### PR TITLE
fix(ci): clear ruff lint + format errors blocking CI

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -10,9 +10,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import structlog
-from fastapi import FastAPI
-
-from fastapi import Depends
+from fastapi import Depends, FastAPI
 
 from hal0 import __version__
 from hal0.api.middleware import error_codes, request_id
@@ -377,6 +375,7 @@ def _mount_dashboard(app: FastAPI) -> None:
     """
     import os
     from pathlib import Path
+
     from fastapi.responses import FileResponse, Response
     from fastapi.staticfiles import StaticFiles
 

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -308,18 +308,12 @@ def create_app() -> FastAPI:
     # Single-purpose protected routers — every endpoint requires a token
     # when HAL0_AUTH_ENABLED=1, no path-aware bypass needed.
     _admin_auth = [Depends(require_token)]
-    app.include_router(
-        slots.router, prefix="/api/slots", tags=["slots"], dependencies=_admin_auth
-    )
+    app.include_router(slots.router, prefix="/api/slots", tags=["slots"], dependencies=_admin_auth)
     app.include_router(
         models.router, prefix="/api/models", tags=["models"], dependencies=_admin_auth
     )
-    app.include_router(
-        hardware.router, prefix="/api", tags=["hardware"], dependencies=_admin_auth
-    )
-    app.include_router(
-        logs.router, prefix="/api/logs", tags=["logs"], dependencies=_admin_auth
-    )
+    app.include_router(hardware.router, prefix="/api", tags=["hardware"], dependencies=_admin_auth)
+    app.include_router(logs.router, prefix="/api/logs", tags=["logs"], dependencies=_admin_auth)
     app.include_router(
         settings.router,
         prefix="/api/settings",

--- a/src/hal0/api/middleware/auth.py
+++ b/src/hal0/api/middleware/auth.py
@@ -307,11 +307,11 @@ async def require_admin(
 
 
 __all__ = [
+    "PUBLIC_PATHS",
     "AuthForbidden",
     "AuthIdentity",
     "AuthInvalid",
     "AuthRequired",
-    "PUBLIC_PATHS",
     "require_admin",
     "require_token",
     "require_token_unless_public",

--- a/src/hal0/api/routes/config.py
+++ b/src/hal0/api/routes/config.py
@@ -88,7 +88,7 @@ async def _openwebui_is_active() -> bool:
         return False
     try:
         rc = await asyncio.wait_for(proc.wait(), timeout=2.0)
-    except asyncio.TimeoutError:
+    except TimeoutError:
         proc.kill()
         return False
     return rc == 0

--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -118,7 +118,6 @@ def _local_live_stats(request: Request) -> dict[str, Any]:
     plus a ``gpu_util`` fraction. Returned values may be ``None`` when a
     counter isn't available on this host (e.g. no AMD/NVIDIA GPU).
     """
-    import asyncio
 
     stats = getattr(request.app.state, "hardware_stats", None)
     if stats is None:

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -20,7 +20,6 @@ from fastapi.responses import StreamingResponse
 from hal0.api.middleware.error_codes import Hal0Error
 from hal0.registry.curated import get_curated
 from hal0.registry.pull import (
-    PullError,
     PullInvalidSource,
     PullJob,
     PullJobNotFound,
@@ -296,7 +295,7 @@ async def pull_stream(model_id: str, request: Request) -> StreamingResponse:
             event = job.progress_event
             try:
                 await asyncio.wait_for(event.wait(), timeout=5.0)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 # Keep-alive — surfaces stuck downloads without closing
                 # the stream.
                 yield f"data: {json.dumps(job.as_dict())}\n\n"

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -170,9 +170,7 @@ async def delete_model(model_id: str, request: Request) -> dict[str, object]:
     return {"id": model_id, "deleted": bool(removed)}
 
 
-def _resolve_pull_source(
-    request: Request, model_id: str
-) -> tuple[str, str]:
+def _resolve_pull_source(request: Request, model_id: str) -> tuple[str, str]:
     """Resolve the (hf_repo, hf_file) tuple for a pull.
 
     Priority:

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -119,8 +119,7 @@ def _synthesize_slots_from_upstreams(request: Request) -> list[dict[str, Any]]:
                 "last_used_model": last_used.get(u.name) or None,
                 "_synthetic": True,
                 "_synthetic_reason": (
-                    "Backed by remote upstream; install a local slot of the "
-                    "same name to take over."
+                    "Backed by remote upstream; install a local slot of the same name to take over."
                 ),
             }
         )

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -184,7 +184,7 @@ async def create_slot(request: Request) -> dict[str, object]:
 def _local_throughput_tps(request: Request, window_s: float = 5.0) -> float:
     """Compute current tokens/sec from the rolling tps_events window.
 
-    Rate is ``tokens / (last_event_ts − first_event_ts_in_window)`` rather
+    Rate is ``tokens / (last_event_ts - first_event_ts_in_window)`` rather
     than ``tokens / window_s`` so short bursts read at their real rate
     instead of being smeared across the full lookback. Decays to 0 once
     all events age out.
@@ -428,7 +428,7 @@ async def slot_logs(name: str, request: Request, lines: int = 200) -> dict[str, 
     )
     try:
         stdout, _ = await _asyncio.wait_for(proc.communicate(), timeout=5.0)
-    except _asyncio.TimeoutError:
+    except TimeoutError:
         with contextlib_suppress():
             proc.kill()
         return {"name": name, "logs": "", "hint": "journalctl timed out"}

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -323,8 +323,7 @@ async def images_generations(request: Request, dispatcher: DispatcherDep) -> Res
     upstream = request.app.state.upstreams.get(call.upstream_name)
     if upstream is None:
         raise NoRouteFound(
-            f"image-gen dispatch landed on upstream {call.upstream_name!r} "
-            "which is not registered",
+            f"image-gen dispatch landed on upstream {call.upstream_name!r} which is not registered",
             details={"upstream": call.upstream_name},
         )
     port = _extract_port_from_upstream_url(upstream.url)

--- a/src/hal0/auth/tokens.py
+++ b/src/hal0/auth/tokens.py
@@ -34,6 +34,7 @@ stays intact if the process dies mid-rename.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import secrets
 import time
@@ -374,13 +375,11 @@ class TokenStore:
             if not verify_password(tok.hash, secret):
                 return None
             tok.last_used_at = _now_iso()
-            try:
+            # Don't let a metadata-write failure 401 a valid token —
+            # the request can still be served; the timestamp is a
+            # convenience, not a security boundary.
+            with contextlib.suppress(TokenStoreError):
                 self._save()
-            except TokenStoreError:
-                # Don't let a metadata-write failure 401 a valid token —
-                # the request can still be served; the timestamp is a
-                # convenience, not a security boundary.
-                pass
             return tok
         return None
 
@@ -415,14 +414,14 @@ def _utcnow_unix() -> float:
 
 
 __all__ = [
+    "SCHEMA_VERSION",
+    "VALID_SCOPES",
     "DuplicateLabel",
     "InvalidScope",
-    "SCHEMA_VERSION",
     "Token",
     "TokenNotFound",
     "TokenStore",
     "TokenStoreError",
-    "VALID_SCOPES",
     "auth_enabled",
     "default_token_store_path",
     "get_or_create_store",

--- a/src/hal0/auth/tokens.py
+++ b/src/hal0/auth/tokens.py
@@ -240,9 +240,7 @@ class TokenStore:
                     hash=str(row["hash"]),
                     scope=str(row.get("scope", "all")),
                     created_at=str(row.get("created_at", "")),
-                    last_used_at=(
-                        str(row["last_used_at"]) if row.get("last_used_at") else None
-                    ),
+                    last_used_at=(str(row["last_used_at"]) if row.get("last_used_at") else None),
                     extra={
                         k: v
                         for k, v in row.items()

--- a/src/hal0/cli/doctor_commands.py
+++ b/src/hal0/cli/doctor_commands.py
@@ -76,8 +76,7 @@ def doctor(
     ports: str | None = typer.Option(
         None,
         "--ports",
-        help="Space-separated TCP ports for the port collision check "
-        "(default: '8080 3001').",
+        help="Space-separated TCP ports for the port collision check (default: '8080 3001').",
     ),
 ) -> None:
     """Re-run pre-flight checks (systemd, python, docker, disk, ports)."""

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -19,7 +19,6 @@ from hal0.cli._shared import (
     _api_unreachable,
     api_delete,
     api_get,
-    api_patch,
     api_post,
     api_put,
     die,

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -246,9 +246,7 @@ def slot_create(
     except CliApiError as exc:
         die(str(exc))
         return
-    console.print(
-        f"Created slot [bold]{name}[/bold] on port {snap.get('port')} (model={model})"
-    )
+    console.print(f"Created slot [bold]{name}[/bold] on port {snap.get('port')} (model={model})")
 
 
 @app.command("edit")

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -70,8 +70,7 @@ def _restart_slots() -> None:
         return
     if proc.returncode != 0:
         console.print(
-            f"[yellow]slot restart returned {proc.returncode}:[/yellow] "
-            f"{proc.stderr.strip()[:300]}"
+            f"[yellow]slot restart returned {proc.returncode}:[/yellow] {proc.stderr.strip()[:300]}"
         )
     else:
         console.print("[green]slot units restarted.[/green]")
@@ -198,7 +197,9 @@ def update(
         return
 
     try:
-        job = api_post("/api/updates/apply", json={"version": target_version} if target_version else {})
+        job = api_post(
+            "/api/updates/apply", json={"version": target_version} if target_version else {}
+        )
     except CliApiError as exc:
         die(str(exc))
         return

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -24,7 +24,6 @@ from typing import Any
 
 import tomli_w
 
-from hal0.errors import Hal0Error
 from hal0.config import paths
 from hal0.config.schema import (
     CURRENT_SCHEMA_VERSION,
@@ -34,6 +33,7 @@ from hal0.config.schema import (
     SlotConfig,
     UpstreamsConfig,
 )
+from hal0.errors import Hal0Error
 
 # ── Typed errors ──────────────────────────────────────────────────────────────
 

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -43,9 +43,9 @@ import httpx
 import structlog
 from fastapi.responses import Response, StreamingResponse
 
-from hal0.errors import Hal0Error
 from hal0.dispatcher.proxy import LegacyResolutionFailed, resolve_slot
 from hal0.dispatcher.single_flight import SingleFlightGroup
+from hal0.errors import Hal0Error
 from hal0.upstreams.registry import Upstream, UpstreamRegistry
 
 if TYPE_CHECKING:

--- a/src/hal0/hardware/probe.py
+++ b/src/hal0/hardware/probe.py
@@ -28,9 +28,9 @@ from pathlib import Path
 
 import structlog
 
-from hal0.errors import Hal0Error
 from hal0.config import paths as _paths
 from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
+from hal0.errors import Hal0Error
 
 log = structlog.get_logger(__name__)
 
@@ -197,7 +197,7 @@ def _dmidecode_host_ram_mb() -> int | None:
                     total_mb += n * mult
     if total_mb <= 0:
         return None
-    return int(round(total_mb))
+    return round(total_mb)
 
 
 def _derive_unified_memory_mb(ram_mb: int, gpu: GPUInfo | None) -> int:

--- a/src/hal0/hardware/recommend.py
+++ b/src/hal0/hardware/recommend.py
@@ -22,7 +22,6 @@ from typing import Any
 
 from hal0.config.schema import HardwareInfo
 
-
 # Curated chat models suitable for the primary slot, ordered from
 # largest-context / most capable down to the smallest. We pick the
 # largest model whose ``vram_gb_min`` fits the detected hardware. All

--- a/src/hal0/hardware/recommend.py
+++ b/src/hal0/hardware/recommend.py
@@ -150,8 +150,7 @@ def recommend_primary_slot(hw: HardwareInfo) -> dict[str, Any]:
         "_meta": {
             "rationale_backend": backend_why,
             "rationale_model": (
-                f"{model_id}: largest curated chat model fitting "
-                f"~{budget_gb:.1f} GB budget"
+                f"{model_id}: largest curated chat model fitting ~{budget_gb:.1f} GB budget"
             ),
             "vram_budget_gb": round(budget_gb, 1),
         },

--- a/src/hal0/installer/template_unit.py
+++ b/src/hal0/installer/template_unit.py
@@ -32,9 +32,7 @@ log = logging.getLogger(__name__)
 # Repo-relative source path for the template unit.  Resolved against the
 # package's ``hal0`` location so a wheel/editable install both work:
 #   <repo>/src/hal0/installer/template_unit.py  →  <repo>/packaging/systemd/...
-_DEFAULT_SRC = (
-    Path(__file__).resolve().parents[3] / "packaging" / "systemd" / "hal0-slot@.service"
-)
+_DEFAULT_SRC = Path(__file__).resolve().parents[3] / "packaging" / "systemd" / "hal0-slot@.service"
 
 #: Production install path for the template unit.
 DEFAULT_DEST = Path("/etc/systemd/system/hal0-slot@.service")

--- a/src/hal0/providers/__init__.py
+++ b/src/hal0/providers/__init__.py
@@ -48,10 +48,7 @@ def get_provider(name: str) -> Provider:
     try:
         return _PROVIDERS[name]
     except KeyError as exc:
-        raise KeyError(
-            f"no provider registered for {name!r}; "
-            f"known: {sorted(_PROVIDERS)}"
-        ) from exc
+        raise KeyError(f"no provider registered for {name!r}; known: {sorted(_PROVIDERS)}") from exc
 
 
 __all__ = [

--- a/src/hal0/providers/base.py
+++ b/src/hal0/providers/base.py
@@ -49,7 +49,7 @@ def _quote_for_systemd(value: str) -> str:
     # double quotes in that case (systemd documents this in `systemd.unit(5)`
     # §"Command lines").
     if _SYSTEMD_VAR_REF.search(value) and quoted.startswith("'"):
-        inner = value.replace('\\', '\\\\').replace('"', '\\"')
+        inner = value.replace("\\", "\\\\").replace('"', '\\"')
         return f'"{inner}"'
     return quoted
 

--- a/src/hal0/providers/comfyui.py
+++ b/src/hal0/providers/comfyui.py
@@ -110,14 +110,8 @@ class ComfyUIProvider(Provider):
         slot_cfg: dict[str, Any],
         model_info: dict[str, Any],
     ) -> dict[str, str]:
-        port = (
-            slot_cfg.get("port") or slot_cfg.get("slot", {}).get("port") or _DEFAULT_PORT
-        )
-        backend = (
-            slot_cfg.get("backend")
-            or slot_cfg.get("slot", {}).get("backend")
-            or "rocm"
-        )
+        port = slot_cfg.get("port") or slot_cfg.get("slot", {}).get("port") or _DEFAULT_PORT
+        backend = slot_cfg.get("backend") or slot_cfg.get("slot", {}).get("backend") or "rocm"
         # model_info["path"] is the on-disk checkpoint path. The actual
         # filename gets picked up by the workflow translator (see
         # comfyui_workflows.build_workflow's ckpt_filename arg). We pass

--- a/src/hal0/providers/llama_server.py
+++ b/src/hal0/providers/llama_server.py
@@ -31,12 +31,10 @@ from typing import Any
 import httpx
 
 from hal0.errors import Hal0Error
+from hal0.providers._gpu import resolve_gpu_group_ids as _resolve_gpu_group_ids
 from hal0.providers.base import ContainerSpec, Provider
 
 log = logging.getLogger(__name__)
-
-
-from hal0.providers._gpu import resolve_gpu_group_ids as _resolve_gpu_group_ids
 
 # ── Toolbox image refs ─────────────────────────────────────────────────────────
 # Per PLAN.md §12 the hal0 toolbox images are published under

--- a/src/hal0/registry/curated.py
+++ b/src/hal0/registry/curated.py
@@ -48,13 +48,13 @@ class CuratedModel(BaseModel):
     )
     license: str = Field(..., description="SPDX-ish license short name, e.g. 'Apache-2.0'.")
     license_url: str = Field(..., description="HTTPS URL to the canonical license text.")
-    hf_repo: str = Field(..., description="HuggingFace repo id, e.g. 'Qwen/Qwen3-4B-Instruct-GGUF'.")
+    hf_repo: str = Field(
+        ..., description="HuggingFace repo id, e.g. 'Qwen/Qwen3-4B-Instruct-GGUF'."
+    )
     hf_file: str = Field(..., description="Filename within the repo (GGUF, safetensors, etc.).")
     context_length: int = Field(
         default=0,
-        description=(
-            "Native context window in tokens. Zero/omitted for image-gen entries."
-        ),
+        description=("Native context window in tokens. Zero/omitted for image-gen entries."),
     )
     recommended_slot: str = Field(
         default="primary",
@@ -169,9 +169,7 @@ CURATED_MODELS: list[CuratedModel] = [
         size_gb=6.5,
         vram_gb_min=8.0,
         license="SAI-NC-Research-Community",
-        license_url=(
-            "https://huggingface.co/stabilityai/sdxl-turbo/blob/main/LICENSE.TXT"
-        ),
+        license_url=("https://huggingface.co/stabilityai/sdxl-turbo/blob/main/LICENSE.TXT"),
         hf_repo="stabilityai/sdxl-turbo",
         hf_file="sd_xl_turbo_1.0_fp16.safetensors",
         context_length=0,
@@ -197,9 +195,7 @@ CURATED_MODELS: list[CuratedModel] = [
         size_gb=4.3,
         vram_gb_min=4.0,
         license="CreativeML-Open-RAIL-M",
-        license_url=(
-            "https://huggingface.co/runwayml/stable-diffusion-v1-5/blob/main/LICENSE"
-        ),
+        license_url=("https://huggingface.co/runwayml/stable-diffusion-v1-5/blob/main/LICENSE"),
         hf_repo="runwayml/stable-diffusion-v1-5",
         hf_file="v1-5-pruned-emaonly.safetensors",
         context_length=0,

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -25,7 +25,6 @@ import logging
 import os
 import re
 import secrets
-import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/src/hal0/registry/store.py
+++ b/src/hal0/registry/store.py
@@ -36,8 +36,8 @@ from typing import Any
 
 import tomli_w
 
-from hal0.errors import Hal0Error
 from hal0.config import paths
+from hal0.errors import Hal0Error
 from hal0.registry.model import Model
 
 log = logging.getLogger(__name__)

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -911,9 +911,7 @@ class SlotManager:
                                 body = {}
                             if isinstance(body, dict) and body.get("model_loaded"):
                                 return
-                            last_error = (
-                                f"/health 200 but model_loaded != true (body={body!r})"
-                            )
+                            last_error = f"/health 200 but model_loaded != true (body={body!r})"
                         else:
                             last_error = f"/health HTTP {resp.status_code}"
                     else:

--- a/src/hal0/slots/unit_template.py
+++ b/src/hal0/slots/unit_template.py
@@ -183,9 +183,7 @@ def _render_from_spec(
     if spec.network_mode:
         argv.append(f"--network {spec.network_mode}")
     for host_path, container_path in spec.mounts:
-        argv.append(
-            f"-v {_quote_for_systemd(host_path)}:{_quote_for_systemd(container_path)}"
-        )
+        argv.append(f"-v {_quote_for_systemd(host_path)}:{_quote_for_systemd(container_path)}")
     for device in spec.devices:
         argv.append(f"--device {_quote_for_systemd(device)}")
     for group in spec.group_add:

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -743,7 +743,9 @@ class Updater:
         latest = ""
         if isinstance(raw, dict):
             latest = str(raw.get("version") or raw.get("latest_version") or "")
-        update_available = bool(latest) and _version_tuple(latest) > _version_tuple(hal0.__version__)
+        update_available = bool(latest) and _version_tuple(latest) > _version_tuple(
+            hal0.__version__
+        )
         return ReleaseInfo(
             current=hal0.__version__,
             latest=latest or None,

--- a/src/hal0/upstreams/registry.py
+++ b/src/hal0/upstreams/registry.py
@@ -32,8 +32,8 @@ from typing import Any
 import httpx
 import structlog
 
-from hal0.errors import Hal0Error
 from hal0.config import paths as _paths
+from hal0.errors import Hal0Error
 
 log = structlog.get_logger(__name__)
 

--- a/tests/api/test_auth_middleware.py
+++ b/tests/api/test_auth_middleware.py
@@ -53,17 +53,20 @@ def test_auth_disabled_protected_route_open(client: TestClient) -> None:
 # ── HAL0_AUTH_ENABLED=1 — public routes still open ────────────────────────────
 
 
-@pytest.mark.parametrize("path", [
-    "/api/status",
-    "/api/health/system",
-    "/api/metrics",
-    "/api/features",
-    "/api/install/state",
-    "/api/config/urls",
-    "/api/auth/status",
-    "/api/auth/login",
-    "/v1/models",
-])
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/status",
+        "/api/health/system",
+        "/api/metrics",
+        "/api/features",
+        "/api/install/state",
+        "/api/config/urls",
+        "/api/auth/status",
+        "/api/auth/login",
+        "/v1/models",
+    ],
+)
 def test_public_routes_bypass_auth(auth_app: TestClient, path: str) -> None:
     response = auth_app.get(path)
     # All public routes return 2xx (or 4xx for content reasons), never 401.
@@ -75,15 +78,18 @@ def test_public_routes_bypass_auth(auth_app: TestClient, path: str) -> None:
 # ── HAL0_AUTH_ENABLED=1 — protected routes require credentials ────────────────
 
 
-@pytest.mark.parametrize("path", [
-    "/api/slots",
-    "/api/models",
-    "/api/hardware",
-    "/api/logs",
-    "/api/settings",
-    "/api/providers",
-    "/api/install/curated-models",  # mixed router; this is protected
-])
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/slots",
+        "/api/models",
+        "/api/hardware",
+        "/api/logs",
+        "/api/settings",
+        "/api/providers",
+        "/api/install/curated-models",  # mixed router; this is protected
+    ],
+)
 def test_protected_routes_require_auth(auth_app: TestClient, path: str) -> None:
     response = auth_app.get(path)
     assert response.status_code == 401, (
@@ -203,15 +209,11 @@ def test_revoked_token_returns_401(auth_app: TestClient) -> None:
     store: TokenStore = auth_app.app.state.token_store
     tok, raw = store.create(label="bridge", scope="all")
     # First call: works.
-    assert auth_app.get(
-        "/api/slots", headers={"Authorization": f"Bearer {raw}"}
-    ).status_code == 200
+    assert auth_app.get("/api/slots", headers={"Authorization": f"Bearer {raw}"}).status_code == 200
     # Revoke.
     store.revoke(tok.id)
     # Second call: 401 invalid.
-    response = auth_app.get(
-        "/api/slots", headers={"Authorization": f"Bearer {raw}"}
-    )
+    response = auth_app.get("/api/slots", headers={"Authorization": f"Bearer {raw}"})
     assert response.status_code == 401
     assert response.json()["error"]["code"] == "auth.invalid"
 

--- a/tests/api/test_auth_routes.py
+++ b/tests/api/test_auth_routes.py
@@ -54,9 +54,7 @@ def test_create_token_returns_raw_value_once(
     raw = body["token"]
 
     # The raw token works for auth on the next call.
-    me = auth_app.get(
-        "/api/auth/me", headers={"Authorization": f"Bearer {raw}"}
-    )
+    me = auth_app.get("/api/auth/me", headers={"Authorization": f"Bearer {raw}"})
     assert me.status_code == 200
     assert me.json()["identity"] == "openwebui-bridge"
 
@@ -151,9 +149,7 @@ def test_list_tokens_returns_metadata_only(
 # ── DELETE /api/auth/tokens/{id} ─────────────────────────────────────────────
 
 
-def test_revoke_token(
-    auth_app: TestClient, admin_headers: dict[str, str]
-) -> None:
+def test_revoke_token(auth_app: TestClient, admin_headers: dict[str, str]) -> None:
     create = auth_app.post(
         "/api/auth/tokens",
         json={"label": "victim", "scope": "all"},
@@ -162,26 +158,18 @@ def test_revoke_token(
     token_id = create.json()["id"]
     raw = create.json()["token"]
 
-    response = auth_app.delete(
-        f"/api/auth/tokens/{token_id}", headers=admin_headers
-    )
+    response = auth_app.delete(f"/api/auth/tokens/{token_id}", headers=admin_headers)
     assert response.status_code == 200
     assert response.json()["revoked"] == token_id
 
     # Re-using the raw token now 401s.
-    me = auth_app.get(
-        "/api/auth/me", headers={"Authorization": f"Bearer {raw}"}
-    )
+    me = auth_app.get("/api/auth/me", headers={"Authorization": f"Bearer {raw}"})
     assert me.status_code == 401
     assert me.json()["error"]["code"] == "auth.invalid"
 
 
-def test_revoke_unknown_id_404(
-    auth_app: TestClient, admin_headers: dict[str, str]
-) -> None:
-    response = auth_app.delete(
-        "/api/auth/tokens/notarealid", headers=admin_headers
-    )
+def test_revoke_unknown_id_404(auth_app: TestClient, admin_headers: dict[str, str]) -> None:
+    response = auth_app.delete("/api/auth/tokens/notarealid", headers=admin_headers)
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "auth.token_not_found"
 

--- a/tests/api/test_pull_routes.py
+++ b/tests/api/test_pull_routes.py
@@ -202,9 +202,7 @@ def test_pick_default_defaults_slot_to_primary(
     fake_run_pull: list[dict[str, Any]],
 ) -> None:
     """Body without ``slot`` falls back to ``primary``."""
-    r = client_isolated.post(
-        "/api/install/pick-default", json={"model_id": "qwen3-4b"}
-    )
+    r = client_isolated.post("/api/install/pick-default", json={"model_id": "qwen3-4b"})
     assert r.status_code == 200, r.text
     assert r.json()["slot"] == "primary"
 
@@ -218,7 +216,7 @@ def test_pick_default_preserves_existing_slot_port_and_backend(
     slot_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
     slot_dir.mkdir(parents=True, exist_ok=True)
     (slot_dir / "primary.toml").write_text(
-        "name = \"primary\"\nport = 9999\nbackend = \"rocm\"\nprovider = \"llama-server\"\n",
+        'name = "primary"\nport = 9999\nbackend = "rocm"\nprovider = "llama-server"\n',
         encoding="utf-8",
     )
 

--- a/tests/api/test_pull_routes.py
+++ b/tests/api/test_pull_routes.py
@@ -8,7 +8,6 @@ write, not the HTTP streaming itself (that's tested separately in
 
 from __future__ import annotations
 
-import asyncio
 import time
 import tomllib
 from collections.abc import Iterator
@@ -22,7 +21,6 @@ from fastapi.testclient import TestClient
 from hal0.api import create_app
 from hal0.registry import pull as pull_module
 from hal0.registry.pull import PullJob
-
 
 # ── shared fixtures ─────────────────────────────────────────────────────────
 

--- a/tests/api/test_settings_routes.py
+++ b/tests/api/test_settings_routes.py
@@ -95,9 +95,7 @@ def test_put_settings_non_json_body_returns_envelope(isolated_client: TestClient
     assert "error" in r.json()
 
 
-def test_reload_settings_re_reads_disk(
-    isolated_client: TestClient, tmp_hal0_home: str
-) -> None:
+def test_reload_settings_re_reads_disk(isolated_client: TestClient, tmp_hal0_home: str) -> None:
     """POST /api/settings/reload re-reads hal0.toml from disk."""
     # Hand-write a TOML to disk, then ask the route to reload.
     cfg_dir = Path(tmp_hal0_home) / "etc" / "hal0"

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -379,6 +379,7 @@ async def test_state_stream_emits_transition_event(
         class _ReqShim:
             class _AppShim:
                 state = isolated_app.state
+
             app = _AppShim()
 
         response = await slot_state_stream("primary", _ReqShim())  # type: ignore[arg-type]
@@ -387,7 +388,7 @@ async def test_state_stream_emits_transition_event(
         first = await asyncio.wait_for(agen.__anext__(), timeout=1.0)
         if isinstance(first, bytes):
             first = first.decode("utf-8")
-        assert 'data: ' in first, f"missing data line in initial frame: {first!r}"
+        assert "data: " in first, f"missing data line in initial frame: {first!r}"
 
         # Kick off the next __anext__ — this enters the `async for rec in
         # sm.state_stream()` loop, registers the subscriber queue, and
@@ -409,9 +410,7 @@ async def test_state_stream_emits_transition_event(
         await agen.aclose()
 
         assert next_frame.startswith("event: state\n"), f"bad SSE prefix: {next_frame!r}"
-        data_line = next(
-            line for line in next_frame.splitlines() if line.startswith("data: ")
-        )
+        data_line = next(line for line in next_frame.splitlines() if line.startswith("data: "))
         payload = json.loads(data_line[len("data: ") :])
         assert payload["name"] == "primary"
         # Unload runs READY → UNLOADING → OFFLINE; either intermediate
@@ -445,6 +444,7 @@ async def test_state_stream_subscriber_cleaned_up_on_close(
         class _ReqShim:
             class _AppShim:
                 state = isolated_app.state
+
             app = _AppShim()
 
         before = len(sm._subscribers)
@@ -513,9 +513,7 @@ async def test_state_stream_emits_sse_event_shape(
             first = first.decode("utf-8")
         assert first.startswith("event: state\n"), f"unexpected SSE prefix: {first!r}"
         # Extract the data: line and JSON-parse it.
-        data_line = next(
-            line for line in first.splitlines() if line.startswith("data: ")
-        )
+        data_line = next(line for line in first.splitlines() if line.startswith("data: "))
         payload = json.loads(data_line[len("data: ") :])
         assert payload["name"] == "primary"
         assert payload["state"] == "ready"

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -19,6 +19,7 @@ need a live systemd to exercise the lifecycle.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 from collections.abc import Iterator
 from pathlib import Path
@@ -465,10 +466,8 @@ async def test_state_stream_subscriber_cleaned_up_on_close(
         # Cancel the pending __anext__ so closing the generator doesn't
         # raise from a still-awaiting queue.get().
         next_task.cancel()
-        try:
+        with contextlib.suppress(asyncio.CancelledError, StopAsyncIteration):
             await next_task
-        except (asyncio.CancelledError, StopAsyncIteration):
-            pass
         await agen.aclose()
         assert len(sm._subscribers) == before, (
             f"subscriber leaked: {len(sm._subscribers)} (was {before})"

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -168,9 +168,7 @@ def test_channel_get_returns_stable_default(isolated_client: TestClient) -> None
     assert r.json() == {"channel": "stable"}
 
 
-def test_channel_put_persists_to_hal0_toml(
-    isolated_client: TestClient, tmp_hal0_home: str
-) -> None:
+def test_channel_put_persists_to_hal0_toml(isolated_client: TestClient, tmp_hal0_home: str) -> None:
     """PUT /api/updates/channel writes telemetry.channel into hal0.toml."""
     r = isolated_client.put("/api/updates/channel", json={"channel": "nightly"})
     assert r.status_code == 200, r.text

--- a/tests/auth/test_tokens.py
+++ b/tests/auth/test_tokens.py
@@ -18,9 +18,9 @@ from pathlib import Path
 import pytest
 
 from hal0.auth.tokens import (
+    SCHEMA_VERSION,
     DuplicateLabel,
     InvalidScope,
-    SCHEMA_VERSION,
     TokenNotFound,
     TokenStore,
     TokenStoreError,
@@ -87,7 +87,7 @@ def test_verify_round_trip(store: TokenStore) -> None:
 
 
 def test_verify_wrong_secret(store: TokenStore) -> None:
-    tok, raw = store.create(label="bridge", scope="all")
+    _tok, raw = store.create(label="bridge", scope="all")
     # Tamper with the secret half but keep the id half so we hit the
     # right hash slot before failing argon2 verify.
     prefix, _, _secret = raw.rpartition(".")

--- a/tests/auth/test_tokens.py
+++ b/tests/auth/test_tokens.py
@@ -38,20 +38,21 @@ def test_auth_enabled_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
     assert auth_enabled() is False
 
 
-@pytest.mark.parametrize("val,expected", [
-    ("1", True),
-    ("true", True),
-    ("True", True),
-    ("yes", True),
-    ("on", True),
-    ("0", False),
-    ("false", False),
-    ("", False),
-    ("nope", False),
-])
-def test_auth_enabled_env_parse(
-    monkeypatch: pytest.MonkeyPatch, val: str, expected: bool
-) -> None:
+@pytest.mark.parametrize(
+    "val,expected",
+    [
+        ("1", True),
+        ("true", True),
+        ("True", True),
+        ("yes", True),
+        ("on", True),
+        ("0", False),
+        ("false", False),
+        ("", False),
+        ("nope", False),
+    ],
+)
+def test_auth_enabled_env_parse(monkeypatch: pytest.MonkeyPatch, val: str, expected: bool) -> None:
     monkeypatch.setenv("HAL0_AUTH_ENABLED", val)
     assert auth_enabled() is expected
 
@@ -101,15 +102,18 @@ def test_verify_unknown_id(store: TokenStore) -> None:
     assert store.verify("hal0_deadbeef.somesecret") is None
 
 
-@pytest.mark.parametrize("malformed", [
-    "",
-    "no-prefix",
-    "Bearer hal0_abc.def",  # the strip happens in the middleware, not here
-    "hal0_",
-    "hal0_abc",
-    "hal0_abcde123",  # no '.'
-    "hal0_short.x",  # id too short
-])
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        "",
+        "no-prefix",
+        "Bearer hal0_abc.def",  # the strip happens in the middleware, not here
+        "hal0_",
+        "hal0_abc",
+        "hal0_abcde123",  # no '.'
+        "hal0_short.x",  # id too short
+    ],
+)
 def test_verify_malformed(store: TokenStore, malformed: str) -> None:
     store.create(label="bridge", scope="all")
     assert store.verify(malformed) is None
@@ -167,14 +171,14 @@ def test_reload_picks_up_external_edits(store: TokenStore) -> None:
     store.create(label="initial", scope="all")
     # Simulate an out-of-band write that adds a row.
     contents = store.path.read_text(encoding="utf-8")
-    extra = '''
+    extra = """
 [[tokens]]
 id = "deadbeef"
 label = "external"
 hash = "$argon2id$v=19$m=65536,t=3,p=4$AAAA$BBBB"
 scope = "v1-only"
 created_at = "2026-05-15T10:00:00Z"
-'''
+"""
     store.path.write_text(contents + extra, encoding="utf-8")
 
     # Without reload, the in-memory cache is stale.

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -21,9 +21,7 @@ import typer
 
 from hal0.cli.doctor_commands import _locate_preflight, doctor
 
-pytestmark = pytest.mark.skipif(
-    sys.platform != "linux", reason="preflight.sh is Linux-only"
-)
+pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="preflight.sh is Linux-only")
 
 
 def _make_stub(tmp_path: Path, body: str) -> Path:
@@ -64,9 +62,7 @@ def test_doctor_failure_propagates_exit_code(
     capfd: pytest.CaptureFixture[str],
 ) -> None:
     """A failing preflight script (rc=1) surfaces as a non-zero hal0 doctor exit."""
-    stub = _make_stub(
-        tmp_path, "printf 'disk: only 7 GB free\\n'\nexit 1\n"
-    )
+    stub = _make_stub(tmp_path, "printf 'disk: only 7 GB free\\n'\nexit 1\n")
     monkeypatch.setenv("HAL0_PREFLIGHT_SH", str(stub))
 
     with pytest.raises(typer.Exit) as exc:

--- a/tests/openwebui/test_env_writer.py
+++ b/tests/openwebui/test_env_writer.py
@@ -149,9 +149,7 @@ def test_auth_falsy_values_keep_defaults(
     assert env["WEBUI_AUTH"] == "False"
 
 
-def test_overrides_still_win_under_auth(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_overrides_still_win_under_auth(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Explicit overrides survive the auth-driven defaults."""
     monkeypatch.setenv("HAL0_AUTH_ENABLED", "1")
     target = tmp_path / "openwebui.env"

--- a/tests/providers/test_comfyui.py
+++ b/tests/providers/test_comfyui.py
@@ -302,7 +302,9 @@ async def test_infer_surfaces_workflow_error(provider: ComfyUIProvider) -> None:
             "status": {
                 "status_str": "error",
                 "completed": False,
-                "messages": [["execution_error", {"node_id": "4", "exception_message": "ckpt missing"}]],
+                "messages": [
+                    ["execution_error", {"node_id": "4", "exception_message": "ckpt missing"}]
+                ],
             },
             "outputs": {},
         }

--- a/tests/providers/test_llama_server.py
+++ b/tests/providers/test_llama_server.py
@@ -183,7 +183,9 @@ def test_image_ref_env_var_override(
     provider: LlamaServerProvider, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """HAL0_TOOLBOX_IMAGE_<BACKEND> env var overrides the default map."""
-    monkeypatch.setenv("HAL0_TOOLBOX_IMAGE_VULKAN", "ghcr.io/example/hal0-toolbox-vulkan@sha256:abc")
+    monkeypatch.setenv(
+        "HAL0_TOOLBOX_IMAGE_VULKAN", "ghcr.io/example/hal0-toolbox-vulkan@sha256:abc"
+    )
     ref = provider.image_ref({"backend": "vulkan"})
     assert ref == "ghcr.io/example/hal0-toolbox-vulkan@sha256:abc"
 

--- a/tests/registry/test_curated.py
+++ b/tests/registry/test_curated.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from hal0.registry.curated import (
     CURATED_BY_ID,
@@ -41,7 +42,7 @@ def test_get_curated_hit_and_miss() -> None:
 
 def test_curated_model_validates_required_fields() -> None:
     """The Pydantic model rejects missing required fields."""
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         CuratedModel(id="test")  # type: ignore[call-arg]
 
 

--- a/tests/registry/test_curated_image_models.py
+++ b/tests/registry/test_curated_image_models.py
@@ -43,9 +43,7 @@ def test_curated_image_entries_have_workflow_metadata() -> None:
             continue
         assert m.capability == "image", f"{m.id}: capability must be 'image'"
         assert m.model_class, f"{m.id}: model_class is required for image entries"
-        assert m.comfyui_subdir, (
-            f"{m.id}: comfyui_subdir is required (drives pull-path routing)"
-        )
+        assert m.comfyui_subdir, f"{m.id}: comfyui_subdir is required (drives pull-path routing)"
         assert m.hf_file.endswith(".safetensors"), (
             f"{m.id}: image entries currently ship as safetensors"
         )
@@ -93,9 +91,7 @@ def test_final_path_routes_to_comfyui_subdir(tmp_hal0_home: str) -> None:
 def test_final_path_falls_back_to_default_layout(tmp_hal0_home: str) -> None:
     """Without comfyui_subdir, the legacy /var/lib/hal0/models layout wins."""
     p = _final_path_for_entry("qwen3-4b", "qwen3-4b.gguf", comfyui_subdir=None)
-    expected = (
-        Path(tmp_hal0_home) / "var-lib" / "hal0" / "models" / "qwen3-4b" / "qwen3-4b.gguf"
-    )
+    expected = Path(tmp_hal0_home) / "var-lib" / "hal0" / "models" / "qwen3-4b" / "qwen3-4b.gguf"
     assert p == expected
 
 

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -7,7 +7,6 @@ redirect handling, and partial downloads / cancellation.
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import os
 from pathlib import Path
@@ -16,16 +15,12 @@ import httpx
 import pytest
 
 from hal0.registry.pull import (
-    PullError,
-    PullInvalidSource,
-    PullJob,
     _sanitise_id,
     hf_download_url,
     make_job,
     run_pull,
 )
 from hal0.registry.store import ModelRegistry
-
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -292,14 +292,7 @@ async def test_status_rehydrates_backend_from_toml_when_state_extra_missing(
     # Hand-write a state.json that mimics the legacy shape — no
     # ``extra.backend`` carried.  slot_root fixture already put
     # primary.toml on disk with ``backend = "vulkan"``.
-    state_path = (
-        Path(tmp_hal0_home)
-        / "var-lib"
-        / "hal0"
-        / "slots"
-        / "primary"
-        / "state.json"
-    )
+    state_path = Path(tmp_hal0_home) / "var-lib" / "hal0" / "slots" / "primary" / "state.json"
     write_state_atomic(
         state_path,
         SlotStateRecord(name="primary", state=_S.OFFLINE, port=8081, extra={}),

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -165,9 +165,7 @@ def test_releases_url_appends_channel_for_http_override(
     """An http(s) override is rewritten with ?channel= for non-stable channels."""
     monkeypatch.setenv("HAL0_RELEASES_URL", "https://example.test/releases.json")
     assert releases_url("stable") == "https://example.test/releases.json"
-    assert (
-        releases_url("nightly") == "https://example.test/releases.json?channel=nightly"
-    )
+    assert releases_url("nightly") == "https://example.test/releases.json?channel=nightly"
 
 
 # ── manifest schema validation ─────────────────────────────────────────────────
@@ -501,9 +499,7 @@ def test_check_uses_per_channel_url(
     sig = artifacts / "hal0-0.0.1.tar.gz.sig"
     sig.write_bytes(b"sig")
     manifest_path = artifacts / "latest.json"
-    _write_release_manifest(
-        manifest_path=manifest_path, tarball=tarball, sig=sig, version="0.0.1"
-    )
+    _write_release_manifest(manifest_path=manifest_path, tarball=tarball, sig=sig, version="0.0.1")
     monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest_path))
 
     info_stable = asyncio.run(Updater(channel="stable").check())


### PR DESCRIPTION
## Summary
- Clears 32 ruff `check` errors (auto-fixed 25, manually fixed 7: U+2212→hyphen, try/except/pass→contextlib.suppress, etc.)
- Reformats 31 pre-existing format-drifted files via `ruff format src tests`
- Unblocks the CI Lint job (red on the last 4 main pushes)

## Test plan
- [ ] CI Lint green
- [ ] `ruff check src tests` clean
- [ ] `ruff format --check src tests` clean
- [ ] `pytest` green (locally 592 pass / 6 skip / 1 pre-existing comfyui fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)