### PR TITLE
test(openwebui): add CI smoke test proving prewire end-to-end

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,7 @@ on:
     paths:
       - "src/hal0/**"
       - "tests/slots/**"
+      - "tests/openwebui/**"
       - "packaging/**"
       - "installer/**"
       - ".github/workflows/integration.yml"
@@ -156,4 +157,72 @@ jobs:
           path: |
             journal-api.log
             journal-slot.log
+          if-no-files-found: ignore
+
+  openwebui-prewire-smoke:
+    # Proves the bundled OpenWebUI install actually talks to hal0:
+    # writes /etc/hal0/openwebui.env via env_writer, boots
+    # ghcr.io/open-webui/open-webui:main against a real hal0-api
+    # subprocess, polls /api/models until OpenWebUI advertises the
+    # hal0-served model.  See tests/openwebui/test_prewire_smoke.py.
+    name: OpenWebUI prewire smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Independent of slot-integration — they don't share state and the
+    # OpenWebUI image pull dominates wall-clock, so running them in
+    # parallel cuts critical path.
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install hal0 (editable + dev extras)
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Verify Docker on runner
+        run: |
+          docker version
+          docker info --format '{{.ServerVersion}}'
+
+      - name: Pre-pull OpenWebUI image
+        # Cache the heavy layer step outside the pytest timeout so a
+        # slow registry pull doesn't get billed against the test.
+        run: docker pull ghcr.io/open-webui/open-webui:main
+
+      - name: Run OpenWebUI prewire smoke test
+        run: |
+          . .venv/bin/activate
+          pytest tests/openwebui/test_prewire_smoke.py -v -m integration
+
+      - name: Capture container logs on failure
+        if: failure()
+        run: |
+          # Catch any lingering openwebui smoke container — the fixture
+          # tears them down on success but a hard pytest fail (timeout,
+          # SIGKILL) can leak one.
+          docker ps -a --filter "name=hal0-openwebui-smoke-" --format '{{.ID}} {{.Names}}' \
+              | tee leaked-containers.txt || true
+          for cid in $(docker ps -aq --filter "name=hal0-openwebui-smoke-"); do
+              docker logs --tail 500 "$cid" > "openwebui-$cid.log" 2>&1 || true
+              docker rm -f "$cid" || true
+          done
+
+      - name: Upload OpenWebUI logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openwebui-smoke-logs
+          path: |
+            openwebui-*.log
+            leaked-containers.txt
           if-no-files-found: ignore

--- a/tests/openwebui/conftest.py
+++ b/tests/openwebui/conftest.py
@@ -1,0 +1,19 @@
+"""Pytest marker registration for the openwebui subtree.
+
+The ``integration`` marker is shared with tests/slots — both subtrees use
+``-m integration`` to opt into CI-only end-to-end tests.  Each subtree
+registers the marker locally so ``--strict-markers`` stays clean even if
+only one subtree's tests are collected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "integration: end-to-end tests requiring docker + network "
+        "(skipped on the dev VM unless docker is reachable)",
+    )

--- a/tests/openwebui/test_prewire_smoke.py
+++ b/tests/openwebui/test_prewire_smoke.py
@@ -1,0 +1,521 @@
+"""End-to-end CI smoke test: the prewired OpenWebUI container talks to hal0.
+
+This test proves the v1 install bundle's *prewire* actually works:
+
+    1. ``write_openwebui_env`` produces ``/etc/hal0/openwebui.env``
+       with ``OPENAI_API_BASE_URLS`` pointing at the hal0 API.
+    2. A real OpenWebUI container reads that env file, refuses to
+       launch its own login screen (``WEBUI_AUTH=False``), and queries
+       the hal0 API for its model catalogue.
+    3. hal0 aggregates models from its configured upstreams and serves
+       them on ``/v1/models`` in the OpenAI shape.
+
+Why a stub upstream rather than a real one?
+    A live llama-server would dominate the test budget (model download,
+    GPU init, warm-up).  We only need to prove the *wiring* — that the
+    env file points OpenWebUI at hal0, and that hal0's ``/v1/models``
+    response shape is the one OpenWebUI expects.  A 50-line Python
+    stub HTTP server returning ``{"object": "list", "data": [...]}``
+    is sufficient and runs in <2 s.
+
+Why ``--add-host host.docker.internal:host-gateway``?
+    OpenWebUI runs inside a container; ``127.0.0.1`` is the container
+    itself.  The env writer's default ``OPENAI_API_BASE_URLS`` already
+    points at ``host.docker.internal``; we pass the ``--add-host`` flag
+    so Docker on Linux resolves that name to the host gateway (Docker
+    Desktop on Mac/Windows resolves it automatically).
+
+Run only this file's smoke case:
+    pytest tests/openwebui/test_prewire_smoke.py -v -m integration
+
+Skip it (default for local ``make test``):
+    pytest tests/openwebui/ -m "not integration"
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+
+import httpx
+import pytest
+
+from hal0.openwebui.env_writer import write_openwebui_env
+
+pytestmark = pytest.mark.integration
+
+
+# ── Preflight helpers ────────────────────────────────────────────────────────
+
+
+def _docker_available() -> bool:
+    """Return True iff `docker info` succeeds within 5 s.
+
+    `docker` may be installed but the daemon down (common on CI runners
+    that haven't started the service yet); we need both.
+    """
+    if shutil.which("docker") is None:
+        return False
+    try:
+        proc = subprocess.run(
+            ["docker", "info", "--format", "{{.ServerVersion}}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return False
+    return proc.returncode == 0 and bool(proc.stdout.strip())
+
+
+_DOCKER_OK = _docker_available()
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _DOCKER_OK,
+        reason=(
+            "docker daemon not reachable — OpenWebUI prewire smoke test "
+            "needs `docker run` on the host.  Intended for CI only."
+        ),
+    ),
+]
+
+
+# ── Stub upstream ────────────────────────────────────────────────────────────
+
+STUB_MODEL_ID = "ci-smoke-llama-0.1b"
+
+
+def _free_port() -> int:
+    """Bind a TCP socket to port 0 to ask the kernel for a free port.
+
+    There's a small TOCTOU window between close() and re-bind() but
+    pytest-runs are sequential within a job and the surface area is
+    tiny on a CI runner.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _StubModelsHandler(BaseHTTPRequestHandler):
+    """Tiny stub responding to `GET /v1/models` with an OpenAI-shaped list."""
+
+    # Silence the default per-request stderr access log — pytest captures
+    # it but we don't want to clutter test output when --capture is off.
+    def log_message(self, fmt: str, *args: object) -> None:
+        return
+
+    def do_GET(self) -> None:  # BaseHTTPRequestHandler API spelling
+        if self.path.rstrip("/") in ("/v1/models", "/models"):
+            payload = {
+                "object": "list",
+                "data": [
+                    {
+                        "id": STUB_MODEL_ID,
+                        "object": "model",
+                        "created": int(time.time()),
+                        "owned_by": "hal0-smoke-stub",
+                    }
+                ],
+            }
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_response(404)
+        self.end_headers()
+
+
+@pytest.fixture
+def stub_upstream() -> Iterator[tuple[str, int]]:
+    """Start a threaded HTTP server serving a fake `/v1/models`.
+
+    Yields ``(base_url, port)`` where ``base_url`` is the upstream URL
+    to write into ``upstreams.toml`` (ends in ``/v1`` per hal0
+    convention).  The hal0 API will pull `/v1/models` from this stub
+    when OpenWebUI asks for the catalogue.
+
+    We bind to ``0.0.0.0`` so the OpenWebUI container can reach the
+    server via the host gateway — same plumbing as hal0-api below.
+    """
+    port = _free_port()
+    server = ThreadingHTTPServer(("0.0.0.0", port), _StubModelsHandler)
+    server.daemon_threads = True
+    thread = Thread(target=server.serve_forever, name="stub-upstream", daemon=True)
+    thread.start()
+    try:
+        yield (f"http://127.0.0.1:{port}/v1", port)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+# ── hal0-api fixture ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def hal0_api(
+    tmp_path: Path,
+    stub_upstream: tuple[str, int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[tuple[str, int]]:
+    """Run a real `uvicorn hal0.api:app` against a temp HAL0_HOME.
+
+    Writes an ``upstreams.toml`` pointing at the stub server, then
+    launches uvicorn as a subprocess on a free port, bound to
+    ``0.0.0.0`` so the OpenWebUI container (running on the host's
+    Docker bridge) can hit it via ``host.docker.internal``.
+
+    Polls ``/v1/models`` until the catalogue includes the stub model
+    id before yielding — guarantees the API is fully wired up before
+    we hand control to the OpenWebUI fixture.
+
+    Yields ``(host_addr, host_port)``.  ``host_addr`` is always
+    ``host.docker.internal`` (what OpenWebUI sees), ``host_port`` is
+    the port uvicorn bound on the host.
+    """
+    hal0_home = tmp_path / "hal0-home"
+    (hal0_home / "etc" / "hal0").mkdir(parents=True)
+
+    # Tell hal0's path resolver to live entirely under tmp_path so we
+    # don't touch /etc, /var/lib, etc.
+    monkeypatch.setenv("HAL0_HOME", str(hal0_home))
+    # Skip the hardware probe on startup — it shells out and can take
+    # several seconds on bare-metal CI runners.
+    monkeypatch.setenv("HAL0_NO_PROBE", "1")
+    # Force auth off — the OpenWebUI container won't be sending
+    # bearer tokens against /v1/models.
+    monkeypatch.delenv("HAL0_AUTH_ENABLED", raising=False)
+
+    stub_url, _ = stub_upstream
+    upstreams_toml = hal0_home / "etc" / "hal0" / "upstreams.toml"
+    upstreams_toml.write_text(
+        # Inline TOML — no need to import tomli_w just for this.
+        f'[[upstream]]\n'
+        f'name = "ci-smoke"\n'
+        f'kind = "remote"\n'
+        f'url = "{stub_url}"\n'
+        f'auth_style = "none"\n'
+        f'advertise_models = true\n'
+    )
+
+    port = _free_port()
+    log_path = tmp_path / "hal0-api.log"
+    log_fh = log_path.open("wb")
+
+    env = dict(os.environ)
+    env["HAL0_HOME"] = str(hal0_home)
+    env["HAL0_NO_PROBE"] = "1"
+    env.pop("HAL0_AUTH_ENABLED", None)
+    # `hal0 serve --host 0.0.0.0 --port <p>` would route through Typer,
+    # adding ~400 ms of import overhead and a process-tree layer that
+    # complicates teardown.  Invoke uvicorn directly.
+    cmd = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "hal0.api:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(port),
+        "--log-level",
+        "warning",
+    ]
+    proc = subprocess.Popen(cmd, stdout=log_fh, stderr=subprocess.STDOUT, env=env)
+
+    try:
+        # Wait until /v1/models reports the stub model.  Generous
+        # timeout — fastapi imports a lot, and CI runners can be slow.
+        deadline = time.monotonic() + 30.0
+        last_err: str | None = None
+        seen_model = False
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                log_fh.flush()
+                raise RuntimeError(
+                    f"hal0-api exited early with rc={proc.returncode}; "
+                    f"log tail: {log_path.read_text()[-1000:]}"
+                )
+            try:
+                resp = httpx.get(f"http://127.0.0.1:{port}/v1/models", timeout=2.0)
+                if resp.status_code == 200:
+                    ids = [m.get("id") for m in resp.json().get("data", [])]
+                    if STUB_MODEL_ID in ids:
+                        seen_model = True
+                        break
+                    last_err = f"models endpoint returned {ids!r}"
+                else:
+                    last_err = f"models endpoint returned status={resp.status_code}"
+            except (httpx.HTTPError, OSError) as exc:
+                last_err = f"connect: {exc}"
+            time.sleep(0.5)
+
+        if not seen_model:
+            raise RuntimeError(
+                f"hal0-api did not advertise stub model within 30 s "
+                f"(last error: {last_err})"
+            )
+
+        yield ("host.docker.internal", port)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+        log_fh.close()
+
+
+# ── OpenWebUI container fixture ──────────────────────────────────────────────
+
+OPENWEBUI_IMAGE = "ghcr.io/open-webui/open-webui:main"
+
+
+def _docker_pull(image: str) -> None:
+    """`docker pull` with a generous timeout — first run on a clean CI
+    runner needs to fetch ~2 GB."""
+    subprocess.run(
+        ["docker", "pull", image],
+        check=True,
+        timeout=600,
+    )
+
+
+@pytest.fixture
+def openwebui_container(
+    tmp_path: Path,
+    hal0_api: tuple[str, int],
+) -> Iterator[tuple[str, int]]:
+    """Launch `ghcr.io/open-webui/open-webui:main` against the prewired env.
+
+    Generates ``openwebui.env`` via the production writer (overriding
+    only ``OPENAI_API_BASE_URLS`` to target the test's hal0 port),
+    mounts it via ``--env-file``, and exposes the container's :8080
+    on a free host port.
+
+    Yields ``(host, host_port)`` once the container responds to
+    ``/health``.  Tears down with ``docker stop`` + ``docker rm`` so a
+    crashed test doesn't leak.
+    """
+    host_addr, hal0_port = hal0_api
+
+    # 1) Write the env file the same way the installer does.  Override
+    #    only the base URL — everything else (WEBUI_AUTH=False, etc.)
+    #    stays as the writer's prewired default so this test exercises
+    #    the real production path.
+    env_path = tmp_path / "openwebui.env"
+    write_openwebui_env(
+        env_path,
+        overrides={"OPENAI_API_BASE_URLS": f"http://{host_addr}:{hal0_port}/v1"},
+    )
+
+    # 2) Pull the image up front so the `docker run` step doesn't time
+    #    out on a cold runner.
+    _docker_pull(OPENWEBUI_IMAGE)
+
+    ow_port = _free_port()
+    container_name = f"hal0-openwebui-smoke-{uuid.uuid4().hex[:8]}"
+    cmd = [
+        "docker",
+        "run",
+        "-d",
+        "--rm",
+        "--name",
+        container_name,
+        "--env-file",
+        str(env_path),
+        "--add-host",
+        "host.docker.internal:host-gateway",
+        "-p",
+        f"{ow_port}:8080",
+        OPENWEBUI_IMAGE,
+    ]
+    out = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    container_id = out.stdout.strip()
+    assert container_id, "docker run returned no container id"
+
+    try:
+        # Wait for /health (returns 200 once the FastAPI app is up).
+        # OpenWebUI's first boot does a sqlite migration so we budget
+        # 90 s on a cold runner.
+        deadline = time.monotonic() + 90.0
+        ok = False
+        while time.monotonic() < deadline:
+            try:
+                resp = httpx.get(f"http://127.0.0.1:{ow_port}/health", timeout=2.0)
+                if resp.status_code == 200:
+                    ok = True
+                    break
+            except (httpx.HTTPError, OSError):
+                pass
+            time.sleep(1.0)
+
+        if not ok:
+            # Capture logs for the failure report before tearing down.
+            logs = subprocess.run(
+                ["docker", "logs", "--tail", "200", container_name],
+                capture_output=True,
+                text=True,
+            )
+            raise RuntimeError(
+                "OpenWebUI container failed to become healthy in 90 s.\n"
+                f"--- docker logs ---\n{logs.stdout}\n{logs.stderr}"
+            )
+
+        yield ("127.0.0.1", ow_port)
+    finally:
+        # `docker stop` triggers `--rm` cleanup.  Use `kill` on the way
+        # out if stop hangs (rare, but a hung healthcheck has been known
+        # to wedge open-webui's shutdown).
+        subprocess.run(
+            ["docker", "stop", "--time", "5", container_name],
+            capture_output=True,
+            timeout=15,
+        )
+        subprocess.run(
+            ["docker", "rm", "-f", container_name],
+            capture_output=True,
+            timeout=10,
+        )
+
+
+# ── The test ─────────────────────────────────────────────────────────────────
+
+
+def _openwebui_bootstrap_token(base_url: str) -> str:
+    """Sign up the first OpenWebUI user and return its Bearer token.
+
+    Even with ``WEBUI_AUTH=False`` the model-listing API endpoints still
+    require a Bearer token — OpenWebUI's "no auth" mode means *no login
+    page*, not "no token".  When the install is in the onboarding state
+    (zero users, fresh DB), ``POST /api/v1/auths/signup`` accepts any
+    payload and returns a JWT for the auto-promoted admin.  We do this
+    once and use the token for the catalogue check.
+
+    Polls signup for up to 30 s — the container's first boot does a
+    SQLite migration so the auth router takes a few seconds to come up
+    after ``/health`` already returns 200.
+    """
+    deadline = time.monotonic() + 30.0
+    last_err: str | None = None
+    while time.monotonic() < deadline:
+        try:
+            resp = httpx.post(
+                f"{base_url}/api/v1/auths/signup",
+                json={
+                    "name": "hal0-smoke",
+                    "email": "smoke@hal0.test",
+                    "password": "hal0-smoke-pw",
+                },
+                timeout=5.0,
+            )
+        except (httpx.HTTPError, OSError) as exc:
+            last_err = f"connect: {exc}"
+            time.sleep(1.0)
+            continue
+        if resp.status_code == 200:
+            token = resp.json().get("token", "")
+            if token:
+                return token
+            last_err = f"signup returned no token: {resp.text[:200]}"
+        else:
+            last_err = f"signup -> {resp.status_code}: {resp.text[:200]}"
+        time.sleep(1.0)
+    raise RuntimeError(f"OpenWebUI signup did not return a token: {last_err}")
+
+
+def test_openwebui_reads_prewired_env_and_lists_hal0_models(
+    openwebui_container: tuple[str, int],
+) -> None:
+    """OpenWebUI's `/api/models` advertises the model the hal0 API serves.
+
+    OpenWebUI proxies the OpenAI-compatible endpoint at ``OPENAI_API_BASE_URLS``
+    through its own ``/openai/models`` and surfaces the result on
+    ``/api/models``.  The first request after boot triggers the upstream
+    fetch, so we poll for up to 60 s in case the proxy initialisation
+    races with the test.
+    """
+    host, port = openwebui_container
+    base_url = f"http://{host}:{port}"
+
+    # /api/config is the only unauthenticated catalogue surface and it
+    # gives us a quick proof-of-life that the WEBUI_AUTH=False prewire
+    # took effect — if this asserts, the env file never reached the
+    # container or got clobbered by an inline -e flag.
+    cfg = httpx.get(f"{base_url}/api/config", timeout=5.0).json()
+    assert cfg.get("features", {}).get("auth") is False, (
+        f"expected WEBUI_AUTH=False to propagate to /api/config, got {cfg!r}"
+    )
+
+    token = _openwebui_bootstrap_token(base_url)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    deadline = time.monotonic() + 60.0
+    last_err: str | None = None
+    last_ids: list[str] = []
+
+    while time.monotonic() < deadline:
+        # /openai/models is the direct passthrough to OPENAI_API_BASE_URLS;
+        # /api/models is the merged view (openai + ollama + builtin
+        # arena).  We check the merged view because that's what the
+        # browser sees in the model picker.
+        try:
+            resp = httpx.get(f"{base_url}/api/models", headers=headers, timeout=5.0)
+        except (httpx.HTTPError, OSError) as exc:
+            last_err = f"GET /api/models: {exc}"
+            time.sleep(2.0)
+            continue
+        if resp.status_code != 200:
+            last_err = f"GET /api/models -> {resp.status_code}: {resp.text[:200]}"
+            time.sleep(2.0)
+            continue
+
+        try:
+            body = resp.json()
+        except ValueError as exc:
+            last_err = f"GET /api/models: non-JSON body ({exc})"
+            time.sleep(2.0)
+            continue
+
+        # Body shape varies across OpenWebUI versions:
+        #   {"data": [{"id": ..., ...}, ...]}
+        #   [{"id": ..., ...}, ...]
+        if isinstance(body, dict):
+            entries = body.get("data") or body.get("models") or []
+        elif isinstance(body, list):
+            entries = body
+        else:
+            entries = []
+        last_ids = [
+            (e.get("id") or e.get("name") or "")
+            for e in entries
+            if isinstance(e, dict)
+        ]
+        if STUB_MODEL_ID in last_ids:
+            return  # 🎉 prewire works end-to-end
+
+        last_err = f"models listed: {last_ids!r} (missing {STUB_MODEL_ID!r})"
+        time.sleep(2.0)
+
+    pytest.fail(
+        f"OpenWebUI never advertised the hal0 model {STUB_MODEL_ID!r}. "
+        f"Last seen: {last_ids!r}. Last error: {last_err!r}."
+    )


### PR DESCRIPTION
## Summary
- Adds `tests/openwebui/test_prewire_smoke.py` — real `docker run` of open-webui against uvicorn-hosted hal0-api with stub upstream
- Polls `/api/models` (after bootstrap-admin signup) until stub model appears — proves env file → container env → upstream proxy → response is intact
- Wires `openwebui-prewire-smoke` job into `.github/workflows/integration.yml` alongside slot-integration
- Gated behind `@pytest.mark.integration` + `docker info` preflight

## Verified locally
- 1 passed in 27.33s
- Full `tests/openwebui/` suite: 15/15 in 26.99s

## Test plan
- [ ] CI Integration (β) job green on first push
- [ ] OpenWebUI image pre-pull doesn't blow the timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)