### PR TITLE
fix(updater): gate HAL0_UPDATE_SKIP_COSIGN to pre-release builds only

### DIFF
--- a/docs/release-manifest.md
+++ b/docs/release-manifest.md
@@ -79,14 +79,20 @@ If `cosign` is not on `PATH` the updater raises a typed error
 (`system.update_cosign_missing`) with install hints. It does **not**
 fall back to unsigned acceptance.
 
-### Documented gap: `HAL0_UPDATE_SKIP_COSIGN`
+### Pre-release escape hatch: `HAL0_UPDATE_SKIP_COSIGN`
 
 For the Phase-2 prototype + LXC smoke (PLAN §17 risk #2 — "prototype in
 phase 2 against a throwaway release, not phase 5"), setting
 `HAL0_UPDATE_SKIP_COSIGN=1` bypasses the verify step with a loud WARN
-log. This gap **must close before v1 ships** — the production install
-path on `hal0.dev` must produce a real GH-Actions-signed artifact, and
-the env var must be removed (or hard-fail) in `release/v1.0.0`.
+log.
+
+The env var is **gated to dev (`0.x`) and pre-release builds** (any
+version containing a `-` such as `1.0.0-rc1`, `1.0.0-dev`). On stable
+v1+ tags it is silently ignored — the updater logs
+`updater.cosign_skip_ignored_on_stable` and proceeds with mandatory
+verification. There is no operator override on stable: if you need to
+bypass cosign on a stable build, you have to either downgrade the
+binary to a pre-release build or fix your cosign install.
 
 ## Filesystem effects of `apply()`
 

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -92,10 +92,10 @@ class UpdateCosignMissing(UpdateError):
     """The ``cosign`` binary is not installed on this host.
 
     Surfaced as a typed error with install hints — the updater does NOT
-    fall back to unsigned acceptance. To prototype an end-to-end install
-    on a host without cosign, set ``HAL0_UPDATE_SKIP_COSIGN=1``; this is
-    a documented gap that must close before v1 ships (see
-    ``docs/release-manifest.md``).
+    fall back to unsigned acceptance. On dev (0.x) and pre-release
+    builds, ``HAL0_UPDATE_SKIP_COSIGN=1`` bypasses verification for
+    end-to-end smoke against unsigned tarballs; on stable v1+ tags the
+    env var is silently ignored (see ``docs/release-manifest.md``).
     """
 
     code = "system.update_cosign_missing"
@@ -428,14 +428,34 @@ def _sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
-def _cosign_skip() -> bool:
-    """Return True if ``HAL0_UPDATE_SKIP_COSIGN=1`` is set.
+def _is_pre_release(version: str) -> bool:
+    """True for dev placeholder (0.x) or any pre-release tag (contains a hyphen).
 
-    Documented gap (PLAN §17 risk #2): for the LXC smoke we may not have a
-    real GH-actions signed artifact. The skip flag is loud — it logs WARN
-    every time and must close before v1 ships.
+    Stable releases (e.g. ``1.0.0``, ``1.2.3``, ``2.0.0``) return False —
+    on those, the cosign skip hatch is hard-disabled.
     """
-    return os.environ.get("HAL0_UPDATE_SKIP_COSIGN", "").strip() == "1"
+    return version.startswith("0.") or "-" in version
+
+
+def _cosign_skip() -> bool:
+    """Return True if ``HAL0_UPDATE_SKIP_COSIGN=1`` is honored on this build.
+
+    The env var is only respected on dev (0.x) and pre-release builds
+    (anything with a ``-rc``/``-dev`` suffix). On stable v1+ tags the env
+    var is silently ignored — verified releases are mandatory.
+    """
+    if os.environ.get("HAL0_UPDATE_SKIP_COSIGN", "").strip() != "1":
+        return False
+    from hal0 import __version__
+
+    if not _is_pre_release(__version__):
+        log.warning(
+            "updater.cosign_skip_ignored_on_stable",
+            version=__version__,
+            reason="HAL0_UPDATE_SKIP_COSIGN is not honored on stable releases",
+        )
+        return False
+    return True
 
 
 def _verify_cosign(
@@ -466,13 +486,23 @@ def _verify_cosign(
 
     cosign = shutil.which("cosign")
     if not cosign:
+        from hal0 import __version__
+
+        skip_hint = (
+            "or set HAL0_UPDATE_SKIP_COSIGN=1 to bypass (pre-release builds only; ignored on stable)"
+            if _is_pre_release(__version__)
+            else "skip env-var is not honored on this stable build"
+        )
         raise UpdateCosignMissing(
-            "cosign is not installed; install from https://docs.sigstore.dev/cosign/installation/ "
-            "or set HAL0_UPDATE_SKIP_COSIGN=1 to bypass (NOT RECOMMENDED for production)",
+            f"cosign is not installed; install from https://docs.sigstore.dev/cosign/installation/ {skip_hint}",
             details={
                 "install_hint_arch": "pacman -S cosign  # or: paru -S cosign-bin",
                 "install_hint_deb": "see https://docs.sigstore.dev/cosign/installation/",
-                "skip_env": "HAL0_UPDATE_SKIP_COSIGN=1",
+                "skip_env": (
+                    "HAL0_UPDATE_SKIP_COSIGN=1"
+                    if _is_pre_release(__version__)
+                    else None
+                ),
             },
         )
 

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -36,7 +36,9 @@ from hal0.updater import (
 )
 from hal0.updater.updater import (
     _atomic_symlink_swap,
+    _cosign_skip,
     _current_symlink,
+    _is_pre_release,
     _parse_manifest,
     _previous_record,
     _versioned_install_dir,
@@ -510,3 +512,46 @@ def test_check_uses_per_channel_url(
     info_nightly = asyncio.run(Updater(channel="nightly").check())
     assert info_stable.channel == "stable"
     assert info_nightly.channel == "nightly"
+
+
+# ── HAL0_UPDATE_SKIP_COSIGN gate (pre-release only) ──────────────────────────
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("0.0.0", True),
+        ("0.1.0", True),
+        ("0.99.0", True),
+        ("1.0.0-rc1", True),
+        ("1.0.0-dev", True),
+        ("2.3.4-rc.5", True),
+        ("1.0.0", False),
+        ("1.2.3", False),
+        ("2.0.0", False),
+    ],
+)
+def test_is_pre_release(version: str, expected: bool) -> None:
+    """0.x and any version with a hyphen are pre-release; bare 1+ is stable."""
+    assert _is_pre_release(version) is expected
+
+
+def test_cosign_skip_honored_on_pre_release(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On a pre-release build, HAL0_UPDATE_SKIP_COSIGN=1 disables verification."""
+    monkeypatch.setattr("hal0.__version__", "1.0.0-rc1")
+    monkeypatch.setenv("HAL0_UPDATE_SKIP_COSIGN", "1")
+    assert _cosign_skip() is True
+
+
+def test_cosign_skip_ignored_on_stable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On stable v1+, HAL0_UPDATE_SKIP_COSIGN=1 is silently dropped."""
+    monkeypatch.setattr("hal0.__version__", "1.0.0")
+    monkeypatch.setenv("HAL0_UPDATE_SKIP_COSIGN", "1")
+    assert _cosign_skip() is False
+
+
+def test_cosign_skip_false_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No env, no skip — regardless of build channel."""
+    monkeypatch.setattr("hal0.__version__", "1.0.0-rc1")
+    monkeypatch.delenv("HAL0_UPDATE_SKIP_COSIGN", raising=False)
+    assert _cosign_skip() is False


### PR DESCRIPTION
## Summary
- Closes the documented gap in `docs/release-manifest.md` (PLAN §17 risk #2)
- `_cosign_skip()` now consults `hal0.__version__`: any `0.x` or hyphenated pre-release version honors the env; clean v1.0.0+ tags silently drop it and emit `updater.cosign_skip_ignored_on_stable`
- Closes task #16

## Why gradual instead of remove-now
LXC smoke loop needs to keep working through v1.0.0-rc* tags. A clean v1.0.0 tag will hard-disable the hatch.

## Test plan
- [ ] Updater unit tests green (4 new + 29 existing = 33 pass)
- [ ] Verify on hal0-test that `HAL0_UPDATE_SKIP_COSIGN=1` still works on the dev `0.0.0` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)