### PR TITLE
fix(ui): replace undefined pullProgress with jobFor in Models.vue

### DIFF
--- a/ui/src/views/Models.vue
+++ b/ui/src/views/Models.vue
@@ -498,8 +498,8 @@ const QUANTS = ['Q4_K_M', 'Q5_K_M', 'Q8_0', 'F16', 'BF16']
                     :disabled="pulling"
                     @click="pullCurated(preset)"
                   >
-                    <span v-if="pullProgress[preset.id]" class="spinner" aria-hidden="true" />
-                    {{ pullProgress[preset.id] ? 'Pulling…' : 'Pull' }}
+                    <span v-if="jobFor(preset.id)?.inFlight.value" class="spinner" aria-hidden="true" />
+                    {{ jobFor(preset.id)?.inFlight.value ? 'Pulling…' : 'Pull' }}
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- `Models.vue:501-502` referenced `pullProgress[preset.id]` — undefined in script setup (which defines `pullJobs`)
- Pull-model modal threw `Cannot read properties of undefined` and never mounted
- Blocks the FirstRun curated-pull flow (DoD bullet #1)
- Fix: swap to `jobFor(preset.id)?.inFlight.value` (matches existing row-progress pattern at line 366)
- Closes task #13

## Test plan
- [ ] Manually open the curated-pull modal in the dashboard
- [ ] γ-3 progresses past modal-open (full green requires PR #17 spec rewrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)