### PR TITLE
feat(auth): hot-reload tokens.toml on (mtime, size, inode) change

### DIFF
--- a/src/hal0/auth/tokens.py
+++ b/src/hal0/auth/tokens.py
@@ -176,11 +176,17 @@ def _make_wire_token() -> tuple[str, str, str]:
 class TokenStore:
     """Read/write wrapper around tokens.toml.
 
-    Loads lazily on first access; reload() forces a re-read after an
-    out-of-band edit. All mutations atomically rewrite the whole file —
-    tokens.toml is small (a handful of rows) so we don't bother with
-    delta writes, and the atomic-rename invariant is the same one the
-    rest of hal0 relies on for slot env files.
+    Loads lazily on first access. Subsequent accesses stat the file and
+    re-read it only if (mtime_ns, size, inode) changed — that way a
+    ``hal0 auth token add`` from the CLI (or any out-of-band editor)
+    takes effect on the very next request without an API restart or an
+    explicit reload endpoint. ``reload()`` is retained for tests and as
+    a manual escape hatch.
+
+    All mutations atomically rewrite the whole file — tokens.toml is
+    small (a handful of rows) so we don't bother with delta writes, and
+    the atomic-rename invariant is the same one the rest of hal0 relies
+    on for slot env files.
     """
 
     def __init__(self, path: Path | None = None) -> None:
@@ -190,6 +196,11 @@ class TokenStore:
         # fresh install where the file genuinely doesn't exist.
         self._loaded = False
         self._tokens: list[Token] = []
+        # File-identity tuple recorded after each load/save. We compare on
+        # every access to detect out-of-band writes (e.g. ``hal0 auth
+        # token add`` mutating tokens.toml in a separate process). None
+        # means "no snapshot recorded yet" — the next access will load.
+        self._fingerprint: tuple[int, int, int] | None = None
 
     @property
     def path(self) -> Path:
@@ -198,18 +209,42 @@ class TokenStore:
     # ── load / save ──────────────────────────────────────────────────────
 
     def reload(self) -> None:
-        """Force a re-read from disk. Called from POST /api/auth/tokens/reload
-        and from tests after writing tokens.toml directly.
+        """Force a re-read from disk regardless of the cached fingerprint.
+
+        Kept for tests that want a deterministic re-read and as a manual
+        escape hatch — the normal hot-reload path is the fingerprint
+        check inside :meth:`_ensure_loaded`, which fires on every access.
         """
         self._loaded = False
         self._tokens = []
+        self._fingerprint = None
         self._ensure_loaded()
 
+    def _current_fingerprint(self) -> tuple[int, int, int] | None:
+        """Return (mtime_ns, size, inode) for the on-disk file, or None.
+
+        None means the file is missing or unstattable — treated as a
+        distinct fingerprint from any present file so the
+        appear/disappear transitions force a reload.
+        """
+        try:
+            st = self._path.stat()
+        except (FileNotFoundError, OSError):
+            return None
+        return (st.st_mtime_ns, st.st_size, st.st_ino)
+
     def _ensure_loaded(self) -> None:
-        if self._loaded:
+        # Hot-reload: if the file's fingerprint has shifted since we last
+        # touched it, an out-of-band write (CLI `token add`, manual
+        # edit) happened and our in-memory list is stale. Drop the cache
+        # and re-read. Cheap — one stat per request, no parse unless
+        # something actually changed.
+        current = self._current_fingerprint()
+        if self._loaded and current == self._fingerprint:
             return
         self._loaded = True
         self._tokens = []
+        self._fingerprint = current
         if not self._path.exists():
             return
         try:
@@ -289,6 +324,11 @@ class TokenStore:
                 f"failed to write tokens.toml at {self._path}: {exc}",
                 details={"path": str(self._path), "reason": str(exc)},
             ) from exc
+        # Refresh the fingerprint so the next _ensure_loaded() sees the
+        # file we just wrote as "current" — without this, every save
+        # would invalidate our own cache and force a reparse on the
+        # following request.
+        self._fingerprint = self._current_fingerprint()
 
     # ── CRUD ─────────────────────────────────────────────────────────────
 

--- a/tests/auth/test_tokens.py
+++ b/tests/auth/test_tokens.py
@@ -177,8 +177,10 @@ created_at = "2026-05-15T10:00:00Z"
 '''
     store.path.write_text(contents + extra, encoding="utf-8")
 
-    # Without reload, the in-memory cache is stale.
-    assert any(t.label == "external" for t in store.list()) is False
+    # The fingerprint check in _ensure_loaded() picks the change up on
+    # the next access — no explicit reload() needed. (task #12)
+    assert any(t.label == "external" for t in store.list()) is True
+    # The explicit reload() escape hatch still works and is idempotent.
     store.reload()
     assert any(t.label == "external" for t in store.list()) is True
 
@@ -209,6 +211,42 @@ def test_last_used_at_persists(store: TokenStore) -> None:
     fresh = TokenStore(store.path)
     rows = fresh.list()
     assert rows[0].last_used_at is not None
+
+
+def test_external_token_add_takes_effect_without_restart(tmp_path: Path) -> None:
+    """A token minted into tokens.toml by another process (the CLI's
+    ``hal0 auth token add`` is the motivating case) must validate on the
+    very next request without anyone calling ``store.reload()`` —
+    otherwise operators have to bounce ``hal0-api.service`` every time
+    they issue a credential. See task #12.
+    """
+    path = tmp_path / "tokens.toml"
+
+    # Process A: long-lived API. Mints an initial token and serves a
+    # request with it — same instance is reused for the second request,
+    # mirroring the FastAPI app.state singleton.
+    api_store = TokenStore(path)
+    _, raw_initial = api_store.create(label="initial", scope="all")
+    assert api_store.verify(raw_initial) is not None, (
+        "initial token must validate before the external write"
+    )
+
+    # Process B: CLI in another shell. Opens its own TokenStore against
+    # the same file, mints a token, drops out. The atomic rename in
+    # _save() guarantees the on-disk file has a fresh inode + mtime.
+    cli_store = TokenStore(path)
+    _, raw_added = cli_store.create(label="added-by-cli", scope="all")
+
+    # Process A again: NO reload() call, NO restart. The next verify()
+    # must pick the new token up via the fingerprint check.
+    matched = api_store.verify(raw_added)
+    assert matched is not None, (
+        "newly-added token failed to validate without an API restart — "
+        "fingerprint-driven reload is broken"
+    )
+    assert matched.label == "added-by-cli"
+    # And the original token still works — reload must merge, not replace.
+    assert api_store.verify(raw_initial) is not None
 
 
 def test_corrupt_toml_raises_typed_error(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- TokenStore now stats `tokens.toml` on every access and re-reads when the file fingerprint shifts
- `hal0 auth token add` (separate process) takes effect on the next API request — no `systemctl restart`, no /reload endpoint, no inotify watcher
- Fingerprint refreshed after our own `_save()` so we don't reparse on every request when the API mutates the file
- Closes task #12

## Test plan
- [ ] `tests/auth/test_tokens.py` green (40/40 pass locally)
- [ ] Manual: mint token via CLI, verify next request honors it without API restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)