### PR TITLE
test(comfyui): accept digest-pinned image_ref form

### DIFF
--- a/tests/providers/test_comfyui.py
+++ b/tests/providers/test_comfyui.py
@@ -78,8 +78,12 @@ def test_start_cmd_emits_required_flags(
 
 
 def test_image_ref_is_hal0ai_comfyui(provider: ComfyUIProvider) -> None:
-    assert provider.image_ref({}) == _HAL0_COMFYUI_IMAGE
+    ref = provider.image_ref({})
+    assert ref.startswith("ghcr.io/hal0ai/hal0-toolbox-comfyui")
     assert _HAL0_COMFYUI_IMAGE.startswith("ghcr.io/hal0ai/hal0-toolbox-comfyui")
+    assert ref == _HAL0_COMFYUI_IMAGE or ref.startswith(
+        f"{_HAL0_COMFYUI_IMAGE.split(':', 1)[0]}@sha256:"
+    )
 
 
 def test_image_ref_slot_cfg_override_wins(provider: ComfyUIProvider) -> None:


### PR DESCRIPTION
## Summary
Pre-existing test failure on main (flagged by Team A). `test_image_ref_is_hal0ai_comfyui` asserted `== _HAL0_COMFYUI_IMAGE` (tag form) but the manifest now pins comfyui to a sha256 digest (commit 3449b2c), so `image_ref` returns the digest form.

Update assertion to accept either tag or digest form — test's intent is "image is from hal0ai/hal0-toolbox-comfyui", not "uses the tag form."

## Why this needs to land first
Every other open PR (#2-#13) is red on python tests because of this single failure. Merging this unblocks CI green for all of them.

## Test plan
- [x] `pytest tests/providers/test_comfyui.py` — 14 pass (was 13/1)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)