### PR TITLE
feat(harness): durable end-to-end test harness for installer/CLI/runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,10 @@ yarn-error.log*
 /usr-local/
 hal0-home/
 
+# Test harness runtime artifacts
+.harness/
+tests/harness/reports/
+
 # Secrets
 .env
 .env.local

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: help install dev test test-unit test-integration release-test release-test-report \
+        harness harness-report harness-clean \
         lint fmt typecheck ui-install ui-dev ui-build clean
 
 # ── hal0-test LXC connection knobs (release-gate) ───────────────────────────
@@ -28,6 +29,11 @@ help:
 	@echo "    make ui-build             Production UI build"
 	@echo "    make clean                Remove caches"
 	@echo ""
+	@echo "  Local harness (full install -> CLI -> slot -> uninstall)"
+	@echo "    make harness              Drive every public surface on this host"
+	@echo "    make harness-report       Pretty-print last harness run"
+	@echo "    make harness-clean        Drop tests/harness/reports/"
+	@echo ""
 	@echo "  Release-gate (tier γ, hal0-test LXC at $(HAL0_TEST_HOST))"
 	@echo "    make release-test         Run full NPU + ROCm + Vulkan matrix over SSH"
 	@echo "    make release-test-report  Pretty-print $(HAL0_TEST_REPORT)"
@@ -56,6 +62,19 @@ test-integration:
 	    exit 1; \
 	fi
 	pytest tests/slots/test_integration.py -v -m integration
+
+harness:
+	bash scripts/harness.sh
+
+harness-report:
+	@if [ ! -f tests/harness/reports/harness.json ]; then \
+	    echo "!  tests/harness/reports/harness.json not found. Run 'make harness' first."; \
+	    exit 1; \
+	fi
+	@python3 scripts/harness-report.py tests/harness/reports/harness.json
+
+harness-clean:
+	rm -rf tests/harness/reports/
 
 release-test:
 	HAL0_TEST_HOST="$(HAL0_TEST_HOST)" \

--- a/scripts/harness-report.py
+++ b/scripts/harness-report.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Pretty-print a hal0 multi-tier harness report.
+
+Usage:
+    scripts/harness-report.py tests/harness/reports/harness.json
+
+Exit codes:
+    0 — every row is pass/skip/deferred
+    1 — any row is fail
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def _colours(stream: object) -> dict[str, str]:
+    if not getattr(stream, "isatty", lambda: False)():
+        return dict.fromkeys(
+            ("red", "yellow", "green", "blue", "bold", "dim", "rst"), ""
+        )
+    return {
+        "red":    "\033[0;31m",
+        "yellow": "\033[1;33m",
+        "green":  "\033[0;32m",
+        "blue":   "\033[0;36m",
+        "bold":   "\033[1m",
+        "dim":    "\033[2m",
+        "rst":    "\033[0m",
+    }
+
+
+_STATUS_COLOUR = {
+    "pass": "green",
+    "fail": "red",
+    "skip": "yellow",
+    "deferred": "blue",
+}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} <report.json>", file=sys.stderr)
+        return 2
+
+    path = Path(argv[1])
+    if not path.exists():
+        print(f"!  report not found: {path}", file=sys.stderr)
+        return 2
+
+    report = json.loads(path.read_text())
+    c = _colours(sys.stdout)
+
+    generated = datetime.fromtimestamp(report.get("generated", 0)).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+    summary = report.get("summary", {})
+    tiers   = report.get("tiers", [])
+    rows    = report.get("rows", [])
+
+    print(f"\n{c['bold']}hal0 harness report{c['rst']}")
+    print(f"  generated : {generated}")
+    print(
+        f"  summary   : {c['green']}{summary.get('pass', 0)} pass{c['rst']}  "
+        f"{c['red']}{summary.get('fail', 0)} fail{c['rst']}  "
+        f"{c['yellow']}{summary.get('skip', 0)} skip{c['rst']}  "
+        f"{c['blue']}{summary.get('deferred', 0)} deferred{c['rst']}  "
+        f"({summary.get('total', 0)} total)"
+    )
+    print()
+
+    # Per-tier headers.
+    if tiers:
+        print(f"  {c['bold']}tiers:{c['rst']}")
+        for t in tiers:
+            s = t.get("summary", {})
+            line = (
+                f"    {t['name']:<14}  "
+                f"{c['green']}{s.get('pass', 0):>3} pass{c['rst']}  "
+                f"{c['red']}{s.get('fail', 0):>3} fail{c['rst']}  "
+                f"{c['yellow']}{s.get('skip', 0):>3} skip{c['rst']}  "
+                f"{c['blue']}{s.get('deferred', 0):>3} deferred{c['rst']}"
+            )
+            print(line)
+        print()
+
+    # Row table.
+    fmt = "  {tier:<10}  {name:<32}  {status:<10}  {dur:>7}  {detail}"
+    print(c["dim"] + fmt.format(
+        tier="tier", name="row", status="status", dur="ms", detail="detail"
+    ) + c["rst"])
+    print(c["dim"] + "  " + "─" * 110 + c["rst"])
+    for row in rows:
+        colour = c.get(_STATUS_COLOUR.get(row["status"], "rst"), "")
+        detail = row.get("detail", "")
+        if len(detail) > 80:
+            detail = detail[:77] + "..."
+        print(fmt.format(
+            tier=row.get("tier", "?"),
+            name=row["name"],
+            status=f"{colour}{row['status']}{c['rst']}",
+            dur=row["duration_ms"],
+            detail=detail,
+        ))
+    print()
+
+    return 1 if summary.get("fail", 0) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/harness.sh
+++ b/scripts/harness.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# scripts/harness.sh
+#
+# hal0 end-to-end test harness orchestrator.
+#
+# Runs the four tiers in order and merges per-tier JSON reports into
+# one tests/harness/reports/harness.json:
+#
+#   1. installer-test.sh    # --dev install + assert filesystem + serve
+#   2. cli-test.sh          # every CLI subcommand against the live API
+#   3. runtime-test.sh      # one real slot + chat round-trip
+#   4. harness-cleanup.sh   # tear down dev install, opt-in prod uninstall
+#
+# Env knobs (passed straight to children):
+#   HAL0_HARNESS_PROD=1     enable prod-mode rows (sudo + real /etc paths)
+#   HAL0_HARNESS_AUTH=1     enable --auth=basic install (needs PROD=1)
+#   HAL0_HARNESS_SKIP_LXC=1 skip the optional release-test SSH leg
+#
+# Exit 0 if no FAIL rows in any tier (skip/deferred ok), 1 otherwise.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HARNESS_DIR="${REPO_ROOT}/tests/harness"
+REPORTS_DIR="${HARNESS_DIR}/reports"
+
+# Colours.
+if [[ -t 1 ]]; then
+    BOLD=$'\033[1m'; GRN=$'\033[0;32m'; RED=$'\033[0;31m'; RST=$'\033[0m'
+else
+    BOLD=; GRN=; RED=; RST=
+fi
+
+mkdir -p "${REPORTS_DIR}"
+# Fresh report area.
+rm -f "${REPORTS_DIR}"/*.json "${REPORTS_DIR}"/*.log "${REPORTS_DIR}/.api-handoff" 2>/dev/null || true
+
+run_tier() {
+    local name="$1" script="$2"
+    printf '\n%s═════════════════════════════════════════════════════%s\n' "${BOLD}" "${RST}"
+    printf '%s  Tier: %s%s\n' "${BOLD}" "${name}" "${RST}"
+    printf '%s═════════════════════════════════════════════════════%s\n' "${BOLD}" "${RST}"
+    if ! bash "${script}"; then
+        return 1
+    fi
+}
+
+# Always run installer + cli + runtime + cleanup. We tolerate FAIL rows
+# inside a tier (they go in the JSON); only abort the pipeline if a
+# tier script itself can't complete.
+INSTALLER_RC=0; CLI_RC=0; RUNTIME_RC=0; CLEANUP_RC=0
+run_tier "installer" "${HARNESS_DIR}/installer-test.sh"    || INSTALLER_RC=$?
+run_tier "cli"       "${HARNESS_DIR}/cli-test.sh"          || CLI_RC=$?
+run_tier "runtime"   "${HARNESS_DIR}/runtime-test.sh"      || RUNTIME_RC=$?
+run_tier "cleanup"   "${HARNESS_DIR}/harness-cleanup.sh"   || CLEANUP_RC=$?
+
+# Optional remote leg: scripts/release-test.sh produces its own JSON
+# (tests/release-gate-report.json) with the same row shape. We merge
+# it into the aggregate report under tier="release-gate".
+RELEASE_GATE_JSON="${REPO_ROOT}/tests/release-gate-report.json"
+
+# ── merge into one report ───────────────────────────────────────────────────
+AGGREGATE="${REPORTS_DIR}/harness.json"
+
+python3 - "${AGGREGATE}" "${REPORTS_DIR}" "${RELEASE_GATE_JSON}" <<'PY'
+import json, sys, time
+from pathlib import Path
+
+agg_path     = Path(sys.argv[1])
+reports_dir  = Path(sys.argv[2])
+release_path = Path(sys.argv[3])
+
+tiers = []
+all_rows = []
+
+# Per-tier JSON files written by each tier script.
+for tier_name in ("installer", "cli", "runtime", "cleanup"):
+    p = reports_dir / f"{tier_name}.json"
+    if not p.exists():
+        tiers.append({"name": tier_name, "status": "missing", "summary": {}, "report": None})
+        continue
+    d = json.loads(p.read_text())
+    tiers.append({
+        "name":    tier_name,
+        "status":  "ok",
+        "summary": d.get("summary", {}),
+        "report":  str(p.relative_to(reports_dir.parent.parent)),
+    })
+    for r in d.get("rows", []):
+        r2 = dict(r); r2["tier"] = tier_name
+        all_rows.append(r2)
+
+# Optional release-gate leg.
+if release_path.exists():
+    d = json.loads(release_path.read_text())
+    # Only merge if it has non-baseline content.
+    if d.get("generated", 0) > 0:
+        tiers.append({
+            "name":    "release-gate",
+            "status":  "ok",
+            "summary": d.get("summary", {}),
+            "report":  str(release_path.relative_to(reports_dir.parent.parent.parent)),
+        })
+        for r in d.get("rows", []):
+            r2 = dict(r); r2["tier"] = "release-gate"
+            all_rows.append(r2)
+
+report = {
+    "_schema":   "hal0.harness-report.v1",
+    "generated": int(time.time()),
+    "tiers":     tiers,
+    "summary": {
+        "total":    len(all_rows),
+        "pass":     sum(1 for r in all_rows if r["status"] == "pass"),
+        "fail":     sum(1 for r in all_rows if r["status"] == "fail"),
+        "skip":     sum(1 for r in all_rows if r["status"] == "skip"),
+        "deferred": sum(1 for r in all_rows if r["status"] == "deferred"),
+    },
+    "rows": all_rows,
+}
+agg_path.write_text(json.dumps(report, indent=2) + "\n")
+print(f"wrote {agg_path}")
+PY
+
+# Pretty-print.
+python3 "${SCRIPT_DIR}/harness-report.py" "${AGGREGATE}" || true
+
+# Exit code: any FAIL row → 1.
+FAILS="$(python3 -c "
+import json
+d = json.load(open('${AGGREGATE}'))
+print(d['summary'].get('fail', 0))
+")"
+
+if [[ "${FAILS}" -gt 0 ]]; then
+    printf '\n%s%sharness FAILED%s — %d row(s) failed.\n' "${RED}" "${BOLD}" "${RST}" "${FAILS}" >&2
+    exit 1
+fi
+printf '\n%s%sharness OK%s\n' "${GRN}" "${BOLD}" "${RST}"
+exit 0

--- a/tests/harness/FINDINGS.md
+++ b/tests/harness/FINDINGS.md
@@ -1,0 +1,263 @@
+# hal0 test-harness — first-pass findings
+
+Generated 2026-05-15 from a single `bash scripts/harness.sh` run on
+hal0-dev (10.0.1.141, RTX 4080, CachyOS). The harness drove every
+public surface a developer touches on a fresh install — installer
+script, every CLI subcommand, slot lifecycle, settings, uninstall —
+and emitted one structured row per scenario into
+`tests/harness/reports/harness.json`.
+
+This document is the human-readable companion. Each entry cites a
+file:line so a fix can land directly. Severity is **bug** (production
+defect), **gap** (missing capability), or **env** (host-side issue,
+not a hal0 defect).
+
+Summary of the run: **24 pass, 2 fail, 10 skip, 5 deferred** out of
+41 rows.
+
+---
+
+## 1. `hal0 config validate` crashes with ImportError — **bug**
+
+Both `installer` and `cli` tiers caught the same root cause; one
+fix kills two rows.
+
+- **Where:** `src/hal0/cli/config_commands.py:76`
+- **What:**
+
+  ```python
+  from hal0.config.loader import load_hal0_config, load_providers, load_upstreams
+  ```
+
+  The names `load_providers` / `load_upstreams` do not exist. The
+  loader module (`src/hal0/config/loader.py:315,342`) exports them
+  with a `_config` suffix:
+
+  ```python
+  def load_providers_config(path: Path | None = None) -> ProvidersConfig:
+  def load_upstreams_config(path: Path | None = None) -> UpstreamsConfig:
+  ```
+
+- **Symptom:** Every `hal0 config validate` invocation raises
+  `ImportError: cannot import name 'load_providers' from
+  'hal0.config.loader'` *before* the validator can run.
+- **Fix:** rename the imports in `config_commands.py:76, 84, 88` to
+  `load_providers_config` / `load_upstreams_config` (or add aliases
+  at the bottom of `loader.py`).
+- **Impact:** Anyone following the install guide and running
+  `hal0 config validate` after first install gets a traceback.
+
+---
+
+## 2. `hal0 slot create` conflates provider and backend — **bug**
+
+The CLI exposes a `--backend` flag whose value is actually the
+**provider** (`llama-server`, `flm`, `moonshine`, `kokoro`,
+`comfyui`). The slot's **hardware backend** (`vulkan`, `rocm`,
+`cpu`, …) is hardcoded.
+
+- **Where:** `src/hal0/cli/slot_commands.py:204–229`
+- **What:**
+
+  ```python
+  backend: SlotBackend = typer.Option("llama-server", "--backend", "-b", ...)
+  ...
+  body: dict[str, Any] = {
+      ...
+      "backend": "vulkan",        # hardcoded
+      "provider": str(backend),   # the CLI flag is really the provider
+      ...
+  }
+  ```
+
+- **Symptom:** A user trying to create a ROCm slot via the CLI has
+  no way to. The flag they'd reach for (`--backend rocm`) is
+  rejected by the SlotBackend enum, which lists provider names not
+  hardware targets.
+- **Fix options:**
+  1. Rename the CLI flag to `--provider` and add a separate
+     `--hardware` (default auto-detected from `hardware.json`).
+  2. Keep `--backend` but make it accept hardware values, derive
+     provider from a separate `--provider` flag.
+
+  Either way, drop the hardcoded `"backend": "vulkan"` on line 228.
+- **Impact:** Inability to drive non-Vulkan slots through the CLI;
+  workflows that should be one command require hand-editing
+  `/etc/hal0/slots/<name>.toml`.
+
+---
+
+## 3. `installer/uninstall.sh` has no `--dev` mode — **gap**
+
+The uninstaller hardcodes FHS paths. If a developer runs it from a
+shell where they previously did `bash installer/install.sh --dev`,
+it will happily wipe `/etc/hal0`, `/var/lib/hal0`, `/usr/lib/hal0`,
+and the systemd units on the actual host.
+
+- **Where:**
+  - `installer/uninstall.sh:95-107` (units in `/etc/systemd/system`)
+  - `installer/uninstall.sh:113-120` (`/usr/lib/hal0`)
+  - `installer/uninstall.sh:153-160` (`/etc/hal0`, `/var/lib/hal0`)
+- **What's missing:** a `--dev` (or `HAL0_PREFIX=…`) path that
+  mirrors `install.sh:89–100`'s dev-mode layout so the uninstaller
+  only touches the prefix.
+- **Workaround the harness uses:** `harness-cleanup.sh:dev-manual-cleanup`
+  does the rm-rf by hand, never invoking `uninstall.sh` in dev mode.
+- **Fix:** add `--dev` to `uninstall.sh`. Compute `PREFIX`, `ETC_DIR`,
+  `VAR_DIR`, `UNIT_DIR` exactly like `install.sh:89–100` and use
+  those in the rm loops.
+- **Impact:** dev-mode round-trip incomplete; can hurt operators
+  who copy/paste guide snippets.
+
+---
+
+## 4. `installer/uninstall.sh` doesn't remove `hal0-caddy.service` — **bug**
+
+- **Where:** `installer/uninstall.sh:96–99`
+
+  ```bash
+  for UNIT_FILE in \
+      "${UNIT_DIR}/hal0-api.service" \
+      "${UNIT_DIR}/hal0-openwebui.service" \
+      "${UNIT_DIR}/hal0-slot@.service"
+  do
+  ```
+
+  The fourth unit installed by `--auth=basic` (`hal0-caddy.service`,
+  written by `install.sh:439`) is missing from the loop.
+- **Symptom:** After `install.sh --auth=basic` + `uninstall.sh`,
+  `systemctl status hal0-caddy` still shows an enabled unit (failed
+  to start, since the binary it points at is gone). The next
+  `systemctl daemon-reload` warns about the orphan.
+- **Fix:** add `"${UNIT_DIR}/hal0-caddy.service"` to the list.
+
+---
+
+## 5. `installer/systemd/` is dead code — **gap**
+
+- **Files shipped but unused:**
+  - `installer/systemd/hal0-api.service`
+  - `installer/systemd/hal0-slot@.service`
+- **Evidence:**
+  - `installer/install.sh:488` writes the API unit *inline* with `cat >`
+  - `installer/install.sh:512` reads the slot template from
+    `${REPO_ROOT}/packaging/systemd/hal0-slot@.service`, not from
+    `installer/systemd/`.
+- **Risk:** if someone edits `installer/systemd/hal0-slot@.service`
+  intending to ship a fix, nothing changes — the installer reads
+  the file in `packaging/systemd/` instead.
+- **Fix options:**
+  1. Delete `installer/systemd/`.
+  2. Move both template units there and rewire `install.sh:512` and
+     the inline cat at 488 to copy from this directory.
+
+---
+
+## 6. Slots created under `--dev` can't actually start — **gap**
+
+- **Where:**
+  - `installer/install.sh:530-533` skips `systemctl daemon-reload` in
+    `--dev` mode.
+  - The units are written to `${PREFIX}/etc/systemd/system/` but the
+    host's `systemctl` only consults `/etc/systemd/system` and
+    `/usr/lib/systemd/system`.
+- **Symptom:** `hal0 slot create … && hal0 slot load …` succeeds
+  through slot create, but `slot load` fails with "Unit
+  hal0-slot@<name>.service not found." The harness's `runtime-slot-load`
+  row would surface this as `fail` if a toolbox image were available.
+- **Fix options (rank from least invasive to most):**
+  1. Document the limitation in `installer/README.md` and have
+     `--dev` print a warning.
+  2. Use `systemctl --user` units instead of system units in `--dev`
+     mode (changes the entire deployment story for dev installs).
+  3. Provide a parallel non-systemd launcher (`hal0 slot launch` is
+     already a binary at `installer/bin/hal0-slot-launch`) that
+     `--dev` mode wires up.
+- **Impact:** The "polished one-line install for home users" goal
+  is fine, but the dev-loop story has a sharp edge that the v1
+  contributor docs need to call out.
+
+---
+
+## 7. `releases.hal0.dev` is not reachable — **env / gap**
+
+- **Where:** `hal0 update --check` calls
+  `GET /api/updates/check`, which fetches `https://releases.hal0.dev/stable.json`.
+- **Observation:** the host can't resolve `releases.hal0.dev`
+  (`[Errno -5] No address associated with hostname`). The API
+  returns HTTP 500 correctly; the CLI surfaces the upstream error.
+- **Fix path:** stand up `releases.hal0.dev` as part of the v1
+  release ritual, OR ship the URL as configurable so home installs
+  can point at a self-hosted manifest.
+- **Note:** the harness marks this as `deferred`, not `fail`, since
+  the CLI behaviour is correct given the missing infra.
+
+---
+
+## 8. `ghcr.io/hal0ai/*` toolbox images return `unauthorized` — **env / gap**
+
+- **Observation:** `docker pull ghcr.io/hal0ai/hal0-toolbox-vulkan:v1`
+  (and pulling by digest from `manifest.json`) returns
+  `Error response from daemon: error from registry: unauthorized`.
+- **Memory says:** "all images are published" (per the user note).
+- **Reality on hal0-dev:** can't pull without auth. Either:
+  - The packages are private and `docker login ghcr.io -u <user> -t <PAT>`
+    is needed (and that should be a documented installer prerequisite),
+    OR
+  - The image refs in `manifest.json` are wrong (mismatched org or
+    tag), OR
+  - The org's package visibility setting hasn't been flipped to
+    public yet.
+- **Impact:** every `runtime-*` row in the harness skipped on the
+  dev box; release-gate γ on hal0-test LXC may also fail to pull on
+  a clean reinstall.
+- **Action:** verify visibility on ghcr.io/hal0ai/* packages, or
+  document the login requirement in `installer/README.md` (and have
+  `install.sh` warn if a docker config token isn't present).
+
+---
+
+## 9. host `/` filesystem at 96% on hal0-dev — **env**
+
+`hal0 doctor` correctly fails because `/var/lib` lives on the same
+74 GB root partition that's now at 3.6 GB free.
+
+This is not a hal0 defect — it's a heads-up for the operator. The
+harness's `cli-doctor` row reports it as `deferred` so it doesn't
+hide a real regression.
+
+Recommended host fix: bind-mount `/var/lib/hal0` (or set
+`HAL0_PREFIX` to a path on the larger `/devpool` / `/mnt/...`
+volumes) before next install.
+
+---
+
+## What the harness *didn't* try (and why)
+
+| Path | Reason | How to enable |
+|---|---|---|
+| `install.sh` prod install (touches `/etc`, `/var/lib`, `/usr/lib`) | mutates the real host | `HAL0_HARNESS_PROD=1 bash scripts/harness.sh` |
+| `--auth=basic` Caddy install | needs prod mode + caddy installable | `HAL0_HARNESS_AUTH=1 HAL0_HARNESS_PROD=1 …` |
+| ROCm / FLM-NPU / Moonshine / Kokoro real-model rounds | `hal0-test` LXC owns these | `make release-test` (existing γ tier) |
+| Settings GET/PUT round-trip | route exists but not driven; planned next harness iteration | extend `cli-test.sh` |
+| First-run wizard endpoints | currently mostly stub (PLAN §7) | wait for Team-B model-pull integration |
+| Update --apply / --rollback | needs working releases.hal0.dev | unblock #7 above |
+
+---
+
+## How to re-run
+
+```
+# full harness (no prod, no auth):
+bash scripts/harness.sh
+
+# include sudo /opt/hal0 install + uninstall:
+HAL0_HARNESS_PROD=1 bash scripts/harness.sh
+
+# include --auth=basic install path too:
+HAL0_HARNESS_AUTH=1 HAL0_HARNESS_PROD=1 bash scripts/harness.sh
+```
+
+The aggregate JSON lands at `tests/harness/reports/harness.json` and
+the pretty-printed table is dumped to stdout at the end of every
+run.

--- a/tests/harness/cli-test.sh
+++ b/tests/harness/cli-test.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# tests/harness/cli-test.sh
+#
+# Drives the hal0 CLI surface against a live API. Honors the handoff
+# file written by installer-test.sh (reports/.api-handoff) so the
+# installer harness's --dev install + serve can be re-used; falls back
+# to spinning a fresh one if the handoff is stale.
+#
+# Each subcommand → one row in reports/cli.json, schema
+# hal0.harness-report.v1.
+#
+# Rows (in execution order):
+#   cli-version             hal0 --version
+#   cli-help                hal0 --help (no API)
+#   cli-doctor              hal0 doctor --plain
+#   cli-config-show         hal0 config show
+#   cli-config-validate     hal0 config validate
+#   cli-config-hardware     hal0 config hardware
+#   cli-config-reload       hal0 config reload
+#   cli-status              hal0 status
+#   cli-probe               hal0 probe
+#   cli-slot-list           hal0 slot list
+#   cli-model-list          hal0 model list
+#   cli-model-register      hal0 model register <id> --path <local-gguf>
+#   cli-model-show          hal0 model show <id>
+#   cli-update-check        hal0 update --check
+#   cli-slot-show-primary   hal0 slot show primary (expected: 404-equivalent before create)
+#   cli-slot-create-test    hal0 slot create <test-slot> --provider llama-server --backend vulkan --model <id>
+#   cli-model-assign        hal0 model assign <id> --slot <test-slot>
+#   cli-slot-show-after     hal0 slot show <test-slot>
+#   cli-slot-delete         hal0 slot delete <test-slot> --force
+#   cli-model-rm            hal0 model rm <id> --force
+#
+# Env knobs:
+#   HAL0_API_URL    base URL (default http://127.0.0.1:18080)
+#   HAL0_HOME       prefix root (default /tmp/hal0-h)
+#   HAL0_BIN        binary path (default ${HAL0_HOME}/.venv/bin/hal0)
+
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=lib/common.sh
+source "${SCRIPT_DIR}/lib/common.sh"
+
+REPORT="${SCRIPT_DIR}/reports/cli.json"
+harness_init "cli" "${REPORT}"
+
+# Pick up handoff or use defaults.
+HANDOFF="${SCRIPT_DIR}/reports/.api-handoff"
+if [[ -r "${HANDOFF}" ]]; then
+    # shellcheck disable=SC1090
+    source "${HANDOFF}"
+fi
+: "${HAL0_API_URL:=http://127.0.0.1:18080}"
+: "${HAL0_HOME:=/tmp/hal0-h}"
+: "${HAL0_BIN:=${HAL0_HOME}/.venv/bin/hal0}"
+
+export HAL0_API_URL HAL0_HOME
+
+log_step "CLI harness — bin=${HAL0_BIN}  api=${HAL0_API_URL}  home=${HAL0_HOME}"
+
+# Pre-flight: hal0 binary must exist.
+if [[ ! -x "${HAL0_BIN}" ]]; then
+    log_err "hal0 binary missing at ${HAL0_BIN} — run installer-test.sh first or set HAL0_BIN"
+    add_row "preflight-binary" "fail" "0" "hal0 binary not found at ${HAL0_BIN}"
+    harness_write_report || true
+    exit 1
+fi
+
+# Pre-flight: API must respond.
+if ! curl -fsS -m 2 "${HAL0_API_URL}/api/status" >/dev/null 2>&1; then
+    log_err "API unreachable at ${HAL0_API_URL}/api/status"
+    add_row "preflight-api" "fail" "0" "GET ${HAL0_API_URL}/api/status timed out or 4xx — installer-test.sh's serve might be down"
+    harness_write_report || true
+    exit 1
+fi
+
+# Helper: run a CLI command, capture stdout/stderr/exit, emit one row.
+# Usage: run_row <row_name> <expected_exit:0|nonzero> <detail_on_pass> -- <cmd...>
+run_row() {
+    local name="$1" expect="$2" pass_detail="$3"; shift 3
+    [[ "$1" == "--" ]] && shift
+    local log="${SCRIPT_DIR}/reports/cli-${name}.log"
+    local start; start=$(start_ms)
+    set +e
+    "$@" >"${log}" 2>&1
+    local rc=$?
+    set -e
+    case "${expect}" in
+        0)
+            if [[ "${rc}" -eq 0 ]]; then
+                add_row "${name}" "pass" "$(since_ms "${start}")" "${pass_detail}"
+            else
+                local tail; tail="$(tail -n1 "${log}" 2>/dev/null | tr -d '\n')"
+                add_row "${name}" "fail" "$(since_ms "${start}")" "exit=${rc}: ${tail:-(no stderr)}"
+            fi ;;
+        nonzero)
+            if [[ "${rc}" -ne 0 ]]; then
+                add_row "${name}" "pass" "$(since_ms "${start}")" "${pass_detail} (exit=${rc} as expected)"
+            else
+                add_row "${name}" "fail" "$(since_ms "${start}")" "expected non-zero exit, got 0"
+            fi ;;
+    esac
+}
+
+# ── read-only rows ──────────────────────────────────────────────────────────
+log_step "Read-only CLI rows"
+
+run_row "cli-version" 0 "hal0 --version" -- "${HAL0_BIN}" --version
+run_row "cli-help"    0 "hal0 --help"    -- "${HAL0_BIN}" --help
+# hal0 doctor exits 1 if /var/lib < 20GB free (preflight_disk). That's
+# an environment issue, not a project bug — wrap to surface as deferred
+# rather than fail when the host is just low on disk.
+run_doctor_row() {
+    local log="${SCRIPT_DIR}/reports/cli-cli-doctor.log"
+    local start; start=$(start_ms)
+    set +e
+    "${HAL0_BIN}" doctor --plain >"${log}" 2>&1
+    local rc=$?
+    set -e
+    if [[ "${rc}" -eq 0 ]]; then
+        add_row "cli-doctor" "pass" "$(since_ms "${start}")" "all preflight checks ok"
+    elif grep -q "only .* GB free on /var/lib" "${log}"; then
+        add_row "cli-doctor" "deferred" "$(since_ms "${start}")" \
+            "preflight_disk failed: $(grep -oE 'only .* GB free on /var/lib; need at least .* GB' "${log}" | head -n1) — host env, not hal0"
+    else
+        add_row "cli-doctor" "fail" "$(since_ms "${start}")" "exit=${rc}: $(tail -n1 "${log}" 2>/dev/null | tr -d '\n')"
+    fi
+}
+run_doctor_row
+run_row "cli-config-show" 0 "hal0 config show" -- "${HAL0_BIN}" config show
+run_row "cli-config-validate" 0 "hal0 config validate" -- "${HAL0_BIN}" config validate
+run_row "cli-config-hardware" 0 "hal0 config hardware (cached)" -- "${HAL0_BIN}" config hardware
+run_row "cli-config-reload"   0 "hal0 config reload"   -- "${HAL0_BIN}" config reload
+run_row "cli-status"  0 "hal0 status" -- "${HAL0_BIN}" status
+run_row "cli-probe"   0 "hal0 probe"  -- "${HAL0_BIN}" probe
+run_row "cli-slot-list"   0 "hal0 slot list"   -- "${HAL0_BIN}" slot list
+run_row "cli-model-list"  0 "hal0 model list"  -- "${HAL0_BIN}" model list
+# hal0 update --check needs releases.hal0.dev DNS-resolvable; on a
+# dev box without that the API correctly 500s. Treat DNS failure as
+# deferred so we still notice when the CLI surface itself breaks.
+run_update_check_row() {
+    local log="${SCRIPT_DIR}/reports/cli-cli-update-check.log"
+    local start; start=$(start_ms)
+    set +e
+    "${HAL0_BIN}" update --check >"${log}" 2>&1
+    local rc=$?
+    set -e
+    if [[ "${rc}" -eq 0 ]]; then
+        add_row "cli-update-check" "pass" "$(since_ms "${start}")" "update check completed"
+    elif grep -q "No address associated with hostname\|release manifest fetch failed" "${log}"; then
+        add_row "cli-update-check" "deferred" "$(since_ms "${start}")" \
+            "releases.hal0.dev unreachable from this host; update-check API correctly returns 500. Wire when release infra lives."
+    else
+        add_row "cli-update-check" "fail" "$(since_ms "${start}")" "exit=${rc}: $(tail -n1 "${log}" 2>/dev/null | tr -d '\n')"
+    fi
+}
+run_update_check_row
+
+# ── write rows: register + show + assign + delete ───────────────────────────
+log_step "Mutating CLI rows"
+
+TEST_MODEL_ID="harness-qwen3-0p8b"
+TEST_SLOT_NAME="harness-primary"
+TEST_MODEL_PATH=""
+
+# Pick a tiny GGUF — preferred is the unsloth Qwen3.5-0.8B on /mnt/ai-models.
+for cand in \
+    "/mnt/ai-models/huggingface/hub/models--unsloth--Qwen3.5-0.8B-GGUF/snapshots/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-UD-Q4_K_XL.gguf"; do
+    if [[ -r "${cand}" ]]; then
+        TEST_MODEL_PATH="${cand}"
+        break
+    fi
+done
+
+if [[ -z "${TEST_MODEL_PATH}" ]]; then
+    add_row "cli-model-register" "skip" "0" "no tiny GGUF found on host; skipping register/assign/delete chain"
+    add_row "cli-model-show"     "skip" "0" "depends on cli-model-register"
+    add_row "cli-slot-create"    "skip" "0" "depends on cli-model-register"
+    add_row "cli-model-assign"   "skip" "0" "depends on cli-slot-create"
+    add_row "cli-slot-show-after" "skip" "0" "depends on cli-slot-create"
+    add_row "cli-slot-delete"    "skip" "0" "depends on cli-slot-create"
+    add_row "cli-model-rm"       "skip" "0" "depends on cli-model-register"
+else
+    log_info "using test model: ${TEST_MODEL_PATH}"
+
+    run_row "cli-model-register" 0 "register on-disk gguf" -- \
+        "${HAL0_BIN}" model register "${TEST_MODEL_ID}" \
+        --path "${TEST_MODEL_PATH}" --license apache-2.0 --name "Qwen3.5 0.8B (harness)"
+
+    run_row "cli-model-show" 0 "model show ${TEST_MODEL_ID}" -- \
+        "${HAL0_BIN}" model show "${TEST_MODEL_ID}"
+
+    # slot show on a name that doesn't exist yet — should fail with non-zero
+    run_row "cli-slot-show-missing" nonzero "slot show on absent name returns non-zero" -- \
+        "${HAL0_BIN}" slot show "${TEST_SLOT_NAME}"
+
+    # `hal0 slot create --backend` is actually the *provider* knob
+    # (slot_commands.py:204-229 passes --backend as provider and
+    # hardcodes SlotConfig.backend = "vulkan" at line 228). Port 8093
+    # is in valid range (schema.py:40-41).
+    run_row "cli-slot-create" 0 "slot create ${TEST_SLOT_NAME}" -- \
+        "${HAL0_BIN}" slot create "${TEST_SLOT_NAME}" \
+        --backend llama-server --port 8093 \
+        --model "${TEST_MODEL_ID}"
+
+    run_row "cli-model-assign" 0 "assign model to slot" -- \
+        "${HAL0_BIN}" model assign "${TEST_MODEL_ID}" --slot "${TEST_SLOT_NAME}"
+
+    run_row "cli-slot-show-after" 0 "slot show after create" -- \
+        "${HAL0_BIN}" slot show "${TEST_SLOT_NAME}"
+
+    # Delete + cleanup. Use --force so no stdin prompt blocks the harness.
+    run_row "cli-slot-delete" 0 "slot delete --force" -- \
+        "${HAL0_BIN}" slot delete "${TEST_SLOT_NAME}" --force
+
+    run_row "cli-model-rm" 0 "model rm --force" -- \
+        "${HAL0_BIN}" model rm "${TEST_MODEL_ID}" --force
+fi
+
+# ── write + exit ────────────────────────────────────────────────────────────
+log_step "Write report"
+harness_write_report || true
+log_info "report: ${REPORT}"
+exit 0

--- a/tests/harness/harness-cleanup.sh
+++ b/tests/harness/harness-cleanup.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# tests/harness/harness-cleanup.sh
+#
+# Tears down whatever installer-test.sh set up. Runs last in the
+# harness pipeline so cli-test.sh, runtime-test.sh, etc. can use the
+# live install before it goes away.
+#
+# Rows:
+#   stop-api               kill the hal0 serve PID from the handoff
+#   dev-manual-cleanup     rm -rf the dev prefix (the dev-mode equivalent of uninstall.sh)
+#   prod-uninstall         sudo installer/uninstall.sh --keep-data   (opt-in via HAL0_HARNESS_PROD=1)
+#   no-residue             assert nothing left under /tmp/hal0-h-* or PREFIX
+
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=lib/common.sh
+source "${SCRIPT_DIR}/lib/common.sh"
+
+REPORT="${SCRIPT_DIR}/reports/cleanup.json"
+harness_init "cleanup" "${REPORT}"
+
+HANDOFF="${SCRIPT_DIR}/reports/.api-handoff"
+if [[ -r "${HANDOFF}" ]]; then
+    # shellcheck disable=SC1090
+    source "${HANDOFF}"
+fi
+
+PREFIX="${HAL0_HOME:-}"
+
+log_step "Cleanup harness — prefix=${PREFIX:-<none>}  api=${HAL0_API_URL:-<none>}"
+
+# ── ROW: stop-api ───────────────────────────────────────────────────────────
+log_step "Row: stop-api"
+start=$(start_ms)
+KILLED=()
+if [[ -n "${HAL0_SERVE_PID:-}" ]] && kill -0 "${HAL0_SERVE_PID}" 2>/dev/null; then
+    kill "${HAL0_SERVE_PID}" 2>/dev/null || true
+    sleep 0.5
+    kill -0 "${HAL0_SERVE_PID}" 2>/dev/null && kill -9 "${HAL0_SERVE_PID}" 2>/dev/null || true
+    KILLED+=("${HAL0_SERVE_PID}")
+fi
+# Sweep for orphans owning a port we know about.
+if [[ -n "${HAL0_API_URL:-}" ]]; then
+    port="${HAL0_API_URL##*:}"
+    pids=$(ss -ltnp 2>/dev/null | awk -v p=":${port}" '$4 ~ p {print $NF}' \
+        | grep -oE 'pid=[0-9]+' | cut -d= -f2 | sort -u || true)
+    for pid in ${pids:-}; do
+        kill "${pid}" 2>/dev/null || true
+        KILLED+=("${pid}")
+    done
+fi
+if [[ ${#KILLED[@]} -gt 0 ]]; then
+    add_row "stop-api" "pass" "$(since_ms "${start}")" "killed pids: ${KILLED[*]}"
+else
+    add_row "stop-api" "pass" "$(since_ms "${start}")" "no serve process found (already stopped)"
+fi
+
+# ── ROW: dev-manual-cleanup ─────────────────────────────────────────────────
+log_step "Row: dev-manual-cleanup"
+start=$(start_ms)
+if [[ -z "${PREFIX}" ]]; then
+    add_row "dev-manual-cleanup" "skip" "$(since_ms "${start}")" "no PREFIX in handoff"
+elif [[ "${PREFIX}" == "/" || "${PREFIX}" == "/etc" || "${PREFIX}" == "/var" ]]; then
+    add_row "dev-manual-cleanup" "fail" "$(since_ms "${start}")" "refusing to remove dangerous PREFIX=${PREFIX}"
+elif [[ ! -d "${PREFIX}" ]]; then
+    add_row "dev-manual-cleanup" "skip" "$(since_ms "${start}")" "prefix ${PREFIX} not present"
+else
+    HAD=()
+    [[ -d "${PREFIX}/.venv" ]]               && HAD+=(".venv")
+    [[ -d "${PREFIX}/etc/hal0" ]]            && HAD+=("etc/hal0")
+    [[ -d "${PREFIX}/var/lib/hal0" ]]        && HAD+=("var/lib/hal0")
+    [[ -d "${PREFIX}/etc/systemd/system" ]]  && HAD+=("etc/systemd/system")
+    rm -rf "${PREFIX}/.venv" "${PREFIX}/etc" "${PREFIX}/var"
+    if [[ ! -d "${PREFIX}/.venv" && ! -d "${PREFIX}/etc" && ! -d "${PREFIX}/var" ]]; then
+        add_row "dev-manual-cleanup" "pass" "$(since_ms "${start}")" "removed: ${HAD[*]:-(none)}"
+        # Also remove the empty prefix dir if it's under .harness/.
+        if [[ "${PREFIX}" == "${REPO_ROOT}"/.harness/install-* ]]; then
+            rmdir "${PREFIX}" 2>/dev/null || true
+        fi
+    else
+        add_row "dev-manual-cleanup" "fail" "$(since_ms "${start}")" "manual rm left residue under ${PREFIX}"
+    fi
+fi
+
+# Remove the handoff so the next run starts clean.
+rm -f "${HANDOFF}" || true
+
+# ── ROW: prod-uninstall (opt-in) ────────────────────────────────────────────
+log_step "Row: prod-uninstall"
+start=$(start_ms)
+if [[ "${HAL0_HARNESS_PROD:-0}" != "1" ]]; then
+    add_row "prod-uninstall" "skip" "$(since_ms "${start}")" "skipped — HAL0_HARNESS_PROD=1 required (mutates real /etc, /var/lib, /usr/lib)"
+elif ! sudo -n true 2>/dev/null; then
+    add_row "prod-uninstall" "skip" "$(since_ms "${start}")" "sudo -n not available"
+else
+    LOG_U="${SCRIPT_DIR}/reports/prod-uninstall.log"
+    if HAL0_FORCE=1 sudo -E bash "${REPO_ROOT}/installer/uninstall.sh" --keep-data >"${LOG_U}" 2>&1; then
+        if [[ ! -f /etc/systemd/system/hal0-api.service ]] && [[ -d /etc/hal0 ]]; then
+            add_row "prod-uninstall" "pass" "$(since_ms "${start}")" "--keep-data: units removed, /etc/hal0 preserved"
+        else
+            add_row "prod-uninstall" "fail" "$(since_ms "${start}")" \
+                "post-uninstall state wrong: api unit present=$( [[ -f /etc/systemd/system/hal0-api.service ]] && echo yes || echo no ); /etc/hal0 present=$( [[ -d /etc/hal0 ]] && echo yes || echo no )"
+        fi
+    else
+        rc=$?
+        add_row "prod-uninstall" "fail" "$(since_ms "${start}")" "exit=${rc}; tail: $(tail -n1 "${LOG_U}")"
+    fi
+fi
+
+log_step "Write report"
+harness_write_report || true
+log_info "report: ${REPORT}"
+exit 0

--- a/tests/harness/installer-test.sh
+++ b/tests/harness/installer-test.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# tests/harness/installer-test.sh
+#
+# Drives the installer surface as a series of black-box scenarios. Each
+# scenario lands one row in tests/harness/reports/installer.json using
+# the shared hal0.harness-report.v1 schema.
+#
+# Scenarios:
+#   dev-install        bash installer/install.sh --dev   (under tmp prefix)
+#   dev-idempotent     re-run --dev install on same prefix; expect no-op
+#   dev-files          assert filesystem layout
+#   dev-units          assert systemd unit files were rendered (under prefix)
+#   dev-api-up         start hal0 serve manually, hit /api/status
+#   dev-uninstall-keep bash installer/uninstall.sh --keep-data (forced)
+#   dev-uninstall-purge bash installer/uninstall.sh           (forced, full)
+#   prod-no-start      sudo bash installer/install.sh --no-start
+#                      (only if HAL0_HARNESS_PROD=1 — opt-in, mutates /etc)
+#   auth-basic         --auth=basic + admin/password env, --no-start
+#                      (only if HAL0_HARNESS_AUTH=1 — needs caddy installable)
+#
+# Env knobs:
+#   HAL0_HARNESS_PREFIX    tmp prefix root (default $REPO_ROOT/.harness/install-$$)
+#   HAL0_HARNESS_PROD      1 to run prod-level (sudo) scenarios
+#   HAL0_HARNESS_AUTH      1 to run --auth=basic scenario
+#   HAL0_HARNESS_KEEP      1 to keep the tmp prefix after run (for debugging)
+#
+# Exit:
+#   0   no FAIL rows (skip / deferred ok)
+#   N   N FAIL rows
+
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=lib/common.sh
+source "${SCRIPT_DIR}/lib/common.sh"
+
+REPORT="${SCRIPT_DIR}/reports/installer.json"
+harness_init "installer" "${REPORT}"
+
+PREFIX="${HAL0_HARNESS_PREFIX:-${REPO_ROOT}/.harness/install-$$}"
+KEEP="${HAL0_HARNESS_KEEP:-0}"
+
+cleanup() {
+    # NEVER kill the serve we started, NEVER remove the prefix in
+    # default mode. The orchestrator (scripts/harness.sh) calls
+    # harness-cleanup.sh as a final stage; downstream tiers
+    # (cli-test.sh, runtime-test.sh) need the API + venv to stay up.
+    # Honour HAL0_HARNESS_AUTOCLEAN=1 for standalone runs only.
+    if [[ "${HAL0_HARNESS_AUTOCLEAN:-0}" -eq 1 ]]; then
+        if [[ -n "${HAL0_SERVE_PID:-}" ]] && kill -0 "${HAL0_SERVE_PID}" 2>/dev/null; then
+            kill "${HAL0_SERVE_PID}" 2>/dev/null || true
+            wait "${HAL0_SERVE_PID}" 2>/dev/null || true
+        fi
+        if [[ "${KEEP}" -ne 1 && -d "${PREFIX}" ]]; then
+            rm -rf "${PREFIX}"
+        fi
+    fi
+}
+trap cleanup EXIT
+
+mkdir -p "${PREFIX}"
+log_step "Installer harness — prefix=${PREFIX}"
+
+# ── ROW: dev-install ─────────────────────────────────────────────────────────
+log_step "Row: dev-install"
+start=$(start_ms)
+LOG="${PREFIX}/install-1.log"
+# Run --dev install. Force HAL0_PREFIX so we get a clean dir under our
+# tmp; suppress the hardware probe so this is hardware-independent.
+if HAL0_PREFIX="${PREFIX}" HAL0_NO_PROBE=1 HAL0_PLAIN=1 HAL0_NO_HELLO=1 HAL0_NO_QR=1 \
+    bash "${REPO_ROOT}/installer/install.sh" --dev >"${LOG}" 2>&1; then
+    add_row "dev-install" "pass" "$(since_ms "${start}")" "installer/install.sh --dev exited 0 (log: ${LOG})"
+else
+    rc=$?
+    add_row "dev-install" "fail" "$(since_ms "${start}")" "exit=${rc}; tail: $(tail -n1 "${LOG}" 2>/dev/null | tr -d '\n')"
+fi
+
+# ── ROW: dev-files ───────────────────────────────────────────────────────────
+log_step "Row: dev-files"
+start=$(start_ms)
+MISSING=()
+for p in \
+    ".venv/bin/hal0" \
+    "etc/hal0/hal0.toml" \
+    "etc/hal0/api.env" \
+    "etc/hal0/upstreams.toml" \
+    "etc/hal0/openwebui.env" \
+    "var/lib/hal0/models" \
+    "var/lib/hal0/registry" \
+    "var/lib/hal0/slots" \
+    "var/lib/hal0/openwebui" \
+    "etc/systemd/system/hal0-api.service" \
+    "etc/systemd/system/hal0-slot@.service" \
+    "etc/systemd/system/hal0-openwebui.service"; do
+    if [[ ! -e "${PREFIX}/${p}" ]]; then
+        MISSING+=("${p}")
+    fi
+done
+if [[ ${#MISSING[@]} -eq 0 ]]; then
+    add_row "dev-files" "pass" "$(since_ms "${start}")" "all expected paths present under ${PREFIX}"
+else
+    add_row "dev-files" "fail" "$(since_ms "${start}")" "missing: ${MISSING[*]}"
+fi
+
+# ── ROW: dev-units ───────────────────────────────────────────────────────────
+log_step "Row: dev-units"
+start=$(start_ms)
+API_UNIT="${PREFIX}/etc/systemd/system/hal0-api.service"
+SLOT_UNIT="${PREFIX}/etc/systemd/system/hal0-slot@.service"
+if [[ -f "${API_UNIT}" ]] \
+    && grep -q "ExecStart" "${API_UNIT}" \
+    && grep -q "${PREFIX}" "${API_UNIT}"; then
+    if [[ -f "${SLOT_UNIT}" ]] && grep -q "ExecStart" "${SLOT_UNIT}"; then
+        add_row "dev-units" "pass" "$(since_ms "${start}")" "api + slot template render with prefix-relative paths"
+    else
+        add_row "dev-units" "fail" "$(since_ms "${start}")" "slot template missing or empty ExecStart"
+    fi
+else
+    add_row "dev-units" "fail" "$(since_ms "${start}")" "api unit missing or doesn't reference prefix ${PREFIX}"
+fi
+
+# ── ROW: dev-config-validate ────────────────────────────────────────────────
+log_step "Row: dev-config-validate"
+start=$(start_ms)
+HAL0_BIN="${PREFIX}/.venv/bin/hal0"
+if [[ -x "${HAL0_BIN}" ]]; then
+    VAL_LOG="${PREFIX}/config-validate.log"
+    if HAL0_HOME="${PREFIX}" "${HAL0_BIN}" config validate >"${VAL_LOG}" 2>&1; then
+        add_row "dev-config-validate" "pass" "$(since_ms "${start}")" "config validate against rendered /etc/hal0 returned 0"
+    else
+        rc=$?
+        # Surface the ImportError / traceback summary so the report has root-cause text.
+        DETAIL="$(grep -oE 'ImportError: [^"]+' "${VAL_LOG}" | head -n1 || true)"
+        if [[ -z "${DETAIL}" ]]; then
+            DETAIL="$(tail -n1 "${VAL_LOG}" 2>/dev/null | tr -d '\n')"
+        fi
+        add_row "dev-config-validate" "fail" "$(since_ms "${start}")" "exit=${rc}: ${DETAIL}"
+    fi
+else
+    add_row "dev-config-validate" "skip" "$(since_ms "${start}")" "hal0 binary not built at ${HAL0_BIN}"
+fi
+
+# ── ROW: dev-idempotent ─────────────────────────────────────────────────────
+log_step "Row: dev-idempotent"
+start=$(start_ms)
+# Snapshot mtimes of config files we expect to be left alone.
+declare -A MTIMES_BEFORE
+for f in etc/hal0/hal0.toml etc/hal0/api.env etc/hal0/upstreams.toml; do
+    if [[ -f "${PREFIX}/${f}" ]]; then
+        MTIMES_BEFORE["${f}"]="$(stat -c %Y "${PREFIX}/${f}")"
+    fi
+done
+LOG2="${PREFIX}/install-2.log"
+if HAL0_PREFIX="${PREFIX}" HAL0_NO_PROBE=1 HAL0_PLAIN=1 HAL0_NO_HELLO=1 HAL0_NO_QR=1 \
+    bash "${REPO_ROOT}/installer/install.sh" --dev >"${LOG2}" 2>&1; then
+    # Walk mtimes; any change to existing config = idempotency miss.
+    CHANGED=()
+    for f in "${!MTIMES_BEFORE[@]}"; do
+        new="$(stat -c %Y "${PREFIX}/${f}" 2>/dev/null || echo 0)"
+        if [[ "${MTIMES_BEFORE[$f]}" != "${new}" ]]; then
+            CHANGED+=("${f}")
+        fi
+    done
+    if [[ ${#CHANGED[@]} -eq 0 ]]; then
+        add_row "dev-idempotent" "pass" "$(since_ms "${start}")" "re-run preserved config mtimes"
+    else
+        add_row "dev-idempotent" "fail" "$(since_ms "${start}")" "config mtimes changed on re-run: ${CHANGED[*]}"
+    fi
+else
+    rc=$?
+    add_row "dev-idempotent" "fail" "$(since_ms "${start}")" "second --dev run exit=${rc}; tail: $(tail -n1 "${LOG2}" 2>/dev/null | tr -d '\n')"
+fi
+
+# ── ROW: dev-api-up ─────────────────────────────────────────────────────────
+log_step "Row: dev-api-up"
+start=$(start_ms)
+if [[ -x "${HAL0_BIN}" ]]; then
+    # Pick a free port (default 8080 may be in use on dev box).
+    API_PORT="${HAL0_HARNESS_API_PORT:-18080}"
+    SERVE_LOG="${PREFIX}/serve.log"
+    HAL0_HOME="${PREFIX}" "${HAL0_BIN}" serve --host 127.0.0.1 --port "${API_PORT}" \
+        >"${SERVE_LOG}" 2>&1 &
+    HAL0_SERVE_PID=$!
+    # Poll for up to 15s.
+    UP=0
+    for _ in $(seq 1 30); do
+        if curl -fsS -m 1 "http://127.0.0.1:${API_PORT}/api/status" >/dev/null 2>&1; then
+            UP=1; break
+        fi
+        sleep 0.5
+    done
+    if [[ "${UP}" -eq 1 ]]; then
+        add_row "dev-api-up" "pass" "$(since_ms "${start}")" "hal0 serve --port ${API_PORT} responded /api/status"
+        # Persist the port + pid for cli-test.sh to pick up.
+        printf 'HAL0_API_URL=http://127.0.0.1:%s\nHAL0_HOME=%s\nHAL0_SERVE_PID=%s\n' \
+            "${API_PORT}" "${PREFIX}" "${HAL0_SERVE_PID}" > "${SCRIPT_DIR}/reports/.api-handoff"
+        # Leave the server running for later tiers; trap kills on exit.
+    else
+        add_row "dev-api-up" "fail" "$(since_ms "${start}")" "API never became healthy on :${API_PORT}; tail: $(tail -n3 "${SERVE_LOG}" 2>/dev/null | tr '\n' ' ')"
+    fi
+else
+    add_row "dev-api-up" "skip" "$(since_ms "${start}")" "hal0 binary missing — earlier row failed"
+fi
+
+# ── ROW: prod-no-start (opt-in) ──────────────────────────────────────────────
+log_step "Row: prod-no-start"
+start=$(start_ms)
+if [[ "${HAL0_HARNESS_PROD:-0}" != "1" ]]; then
+    add_row "prod-no-start" "skip" "$(since_ms "${start}")" "skipped — set HAL0_HARNESS_PROD=1 to exercise sudo /opt/hal0 install (mutates /etc and /var/lib)"
+else
+    LOG3="${PREFIX}/install-prod.log"
+    if sudo -n true 2>/dev/null; then
+        if HAL0_NO_PROBE=1 HAL0_PLAIN=1 HAL0_NO_HELLO=1 HAL0_NO_QR=1 \
+            sudo -E bash "${REPO_ROOT}/installer/install.sh" --no-start >"${LOG3}" 2>&1; then
+            # Assert: units exist, not active.
+            if systemctl list-unit-files hal0-api.service --no-legend | grep -q hal0-api \
+                && ! systemctl is-active --quiet hal0-api; then
+                add_row "prod-no-start" "pass" "$(since_ms "${start}")" "units installed, not started"
+            else
+                add_row "prod-no-start" "fail" "$(since_ms "${start}")" "units missing or already-active despite --no-start"
+            fi
+        else
+            rc=$?
+            add_row "prod-no-start" "fail" "$(since_ms "${start}")" "sudo install --no-start exit=${rc}; tail: $(tail -n1 "${LOG3}")"
+        fi
+    else
+        add_row "prod-no-start" "skip" "$(since_ms "${start}")" "sudo -n not available (passwordless sudo required)"
+    fi
+fi
+
+# ── ROW: auth-basic (opt-in) ────────────────────────────────────────────────
+log_step "Row: auth-basic"
+start=$(start_ms)
+if [[ "${HAL0_HARNESS_AUTH:-0}" != "1" ]]; then
+    add_row "auth-basic" "skip" "$(since_ms "${start}")" "skipped — set HAL0_HARNESS_AUTH=1 (and HAL0_HARNESS_PROD=1) to install caddy + render Caddyfile"
+elif [[ "${HAL0_HARNESS_PROD:-0}" != "1" ]]; then
+    add_row "auth-basic" "skip" "$(since_ms "${start}")" "auth=basic is a prod-mode path; HAL0_HARNESS_PROD=1 also required"
+else
+    LOG4="${PREFIX}/install-auth.log"
+    if HAL0_ADMIN_USER=admin HAL0_ADMIN_PASSWORD='hal0-harness-test' \
+       HAL0_HOSTNAME=hal0-harness.local HAL0_TLS_EMAIL=harness@hal0.test \
+       HAL0_NO_PROBE=1 HAL0_PLAIN=1 \
+        sudo -E bash "${REPO_ROOT}/installer/install.sh" --auth=basic --no-start >"${LOG4}" 2>&1; then
+        if [[ -f /etc/hal0/Caddyfile ]] && grep -q basicauth /etc/hal0/Caddyfile \
+            && grep -q HAL0_AUTH_ENABLED=1 /etc/hal0/api.env; then
+            add_row "auth-basic" "pass" "$(since_ms "${start}")" "Caddyfile + api.env auth wiring rendered"
+        else
+            add_row "auth-basic" "fail" "$(since_ms "${start}")" "Caddyfile or api.env auth flag missing post-install"
+        fi
+    else
+        rc=$?
+        add_row "auth-basic" "fail" "$(since_ms "${start}")" "auth install exit=${rc}; tail: $(tail -n1 "${LOG4}")"
+    fi
+fi
+
+# ── ROW: uninstall-dev-gap ──────────────────────────────────────────────────
+# installer/uninstall.sh has no --dev flag and always hardcodes /etc,
+# /usr/lib, /var/lib paths (uninstall.sh:95,113,153). Calling it from
+# a dev-mode harness would clobber the actual host's hal0 install. We
+# record the gap and verify the manual cleanup path instead.
+log_step "Row: uninstall-dev-gap"
+start=$(start_ms)
+add_row "uninstall-dev-gap" "deferred" "$(since_ms "${start}")" \
+    "installer/uninstall.sh:95,113,153 hardcodes /etc/systemd/system, /usr/lib/hal0, /etc/hal0, /var/lib/hal0 — no --dev mode. Calling it on a dev install would touch the real host. Needs a --dev flag mirroring install.sh."
+
+# NOTE: dev-manual-cleanup and prod-uninstall rows live in
+# tests/harness/harness-cleanup.sh so cli-test.sh and runtime-test.sh
+# can use the install before it's torn down.
+
+# ── ROW: uninstall-caddy-gap ────────────────────────────────────────────────
+# uninstall.sh:99 hardcodes only 3 units (api, openwebui, slot@) — the
+# hal0-caddy.service installed by --auth=basic is left behind. Test
+# documents the gap; no destructive verification.
+log_step "Row: uninstall-caddy-gap"
+start=$(start_ms)
+if grep -q 'hal0-caddy' "${REPO_ROOT}/installer/uninstall.sh"; then
+    add_row "uninstall-caddy-gap" "pass" "$(since_ms "${start}")" "uninstall.sh now references hal0-caddy.service"
+else
+    add_row "uninstall-caddy-gap" "deferred" "$(since_ms "${start}")" "installer/uninstall.sh:96-99 does not remove hal0-caddy.service; --auth=basic installs leave caddy unit behind. Add to UNIT_FILE loop."
+fi
+
+# ── ROW: dev-installer-systemd-dir-unused ───────────────────────────────────
+# installer/systemd/ contains hal0-api.service + hal0-slot@.service but
+# install.sh writes the api unit inline (install.sh:488 cat>) and reads
+# the slot template from packaging/systemd/ (install.sh:512). The
+# installer/systemd/ dir is shipped but never read by the installer.
+log_step "Row: dev-installer-systemd-dir-unused"
+start=$(start_ms)
+if grep -q "installer/systemd" "${REPO_ROOT}/installer/install.sh"; then
+    add_row "dev-installer-systemd-dir-unused" "pass" "$(since_ms "${start}")" "install.sh references installer/systemd"
+else
+    add_row "dev-installer-systemd-dir-unused" "deferred" "$(since_ms "${start}")" "installer/systemd/ shipped but never read; install.sh:488 writes api unit inline, install.sh:512 reads slot template from packaging/systemd. Either remove installer/systemd or rewire install.sh."
+fi
+
+# ── write + exit ────────────────────────────────────────────────────────────
+log_step "Write report"
+harness_write_report || true
+log_info "report: ${REPORT}"
+exit 0

--- a/tests/harness/lib/common.sh
+++ b/tests/harness/lib/common.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# tests/harness/lib/common.sh
+#
+# Shared helpers for the hal0 test harness. Sourced by every tier
+# (installer-test.sh, cli-test.sh, runtime-test.sh) so every row in
+# every report uses the same JSON shape that scripts/release-test.sh
+# already emits — i.e. tests/release-gate-report.json schema.
+#
+# Public API (after sourcing):
+#   harness_init <tier_name> <report_path>
+#       Resets ROWS_JSON, captures meta. Tier name is "installer", "cli",
+#       or "runtime"; report_path is where harness_write_report dumps the
+#       final JSON file. Call once at the top of a tier script.
+#
+#   add_row <name> <status:pass|fail|skip|deferred> <duration_ms> <detail>
+#       Appends a structured row to the in-memory accumulator and prints
+#       a colourised one-liner. Mirrors release-test.sh:117–132.
+#
+#   start_ms / since_ms <start>
+#       Wall-clock helpers. start_ms returns ns; since_ms returns int ms.
+#
+#   log_step / log_info / log_warn / log_err
+#       Tee-friendly status prints.
+#
+#   harness_write_report
+#       Serialises {schema, generated, tier, host, summary, rows} to the
+#       path passed to harness_init. Returns 1 if any row is "fail".
+#
+# Design notes:
+#   - Bash 5+ associative-array safe; tested under set -euo pipefail.
+#   - JSON assembly delegated to python3 to keep quoting safe.
+#   - Each tier writes its own report file; scripts/harness.sh merges.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# ── colours ──────────────────────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+    H_RED=$'\033[0;31m'; H_YEL=$'\033[1;33m'; H_GRN=$'\033[0;32m'
+    H_BLU=$'\033[0;36m'; H_BOLD=$'\033[1m';   H_DIM=$'\033[2m'; H_RST=$'\033[0m'
+else
+    H_RED=; H_YEL=; H_GRN=; H_BLU=; H_BOLD=; H_DIM=; H_RST=
+fi
+log_info() { printf "${H_GRN}✔${H_RST}  %s\n" "$*"; }
+log_warn() { printf "${H_YEL}!${H_RST}  %s\n" "$*" >&2; }
+log_err()  { printf "${H_RED}✗${H_RST}  %s\n" "$*" >&2; }
+log_step() { printf "\n${H_BOLD}── %s${H_RST}\n" "$*"; }
+
+# ── timing ───────────────────────────────────────────────────────────────────
+start_ms() { date +%s%N; }
+since_ms() {
+    local start="$1" end
+    end=$(date +%s%N)
+    echo $(( (end - start) / 1000000 ))
+}
+
+# ── row accumulator ──────────────────────────────────────────────────────────
+ROWS_JSON=()
+HARNESS_TIER=""
+HARNESS_REPORT_PATH=""
+HARNESS_HOST="$(hostname -f 2>/dev/null || hostname)"
+
+harness_init() {
+    HARNESS_TIER="${1:?tier name required}"
+    HARNESS_REPORT_PATH="${2:?report path required}"
+    ROWS_JSON=()
+    mkdir -p "$(dirname "${HARNESS_REPORT_PATH}")"
+}
+
+add_row() {
+    local name="$1" status="$2" dur="$3" detail="$4"
+    ROWS_JSON+=("$(python3 - "$name" "$status" "$dur" "$detail" <<'PY'
+import json, sys
+print(json.dumps({
+    "name": sys.argv[1],
+    "status": sys.argv[2],
+    "duration_ms": int(sys.argv[3]),
+    "detail": sys.argv[4],
+}))
+PY
+    )")
+    case "${status}" in
+        pass)     log_info "[${name}] pass (${dur}ms) — ${detail}" ;;
+        fail)     log_err  "[${name}] FAIL (${dur}ms) — ${detail}" ;;
+        skip)     log_warn "[${name}] skip — ${detail}" ;;
+        deferred) log_warn "[${name}] deferred — ${detail}" ;;
+        *)        log_err  "[${name}] BAD STATUS '${status}'" ;;
+    esac
+}
+
+harness_write_report() {
+    if [[ -z "${HARNESS_REPORT_PATH}" ]]; then
+        log_err "harness_init never called"
+        return 2
+    fi
+
+    python3 - "${HARNESS_REPORT_PATH}" "${HARNESS_TIER}" "${HARNESS_HOST}" "${ROWS_JSON[@]}" <<'PY'
+import json, sys, time
+from pathlib import Path
+
+out_path = Path(sys.argv[1])
+tier     = sys.argv[2]
+host     = sys.argv[3]
+rows     = [json.loads(r) for r in sys.argv[4:]]
+
+report = {
+    "_schema":   "hal0.harness-report.v1",
+    "generated": int(time.time()),
+    "tier":      tier,
+    "host":      host,
+    "summary": {
+        "total":    len(rows),
+        "pass":     sum(1 for r in rows if r["status"] == "pass"),
+        "fail":     sum(1 for r in rows if r["status"] == "fail"),
+        "skip":     sum(1 for r in rows if r["status"] == "skip"),
+        "deferred": sum(1 for r in rows if r["status"] == "deferred"),
+    },
+    "rows": rows,
+}
+out_path.write_text(json.dumps(report, indent=2) + "\n")
+print(f"wrote {out_path}")
+PY
+
+    local fails=0
+    for row in "${ROWS_JSON[@]}"; do
+        if grep -q '"status": "fail"' <<<"${row}"; then
+            fails=$(( fails + 1 ))
+        fi
+    done
+    return "${fails}"
+}

--- a/tests/harness/runtime-test.sh
+++ b/tests/harness/runtime-test.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# tests/harness/runtime-test.sh
+#
+# Drives one real slot lifecycle round-trip per provider that can run
+# on the local host. The point isn't matrix coverage (release-test.sh
+# already owns that for the hal0-test LXC) — it's to prove that on a
+# fresh --dev install on the developer's box, the dispatcher can
+# actually route a /v1/chat/completions request to a llama-server
+# container backed by a local tiny GGUF.
+#
+# Rows (current, llama-server only — see comment block at bottom for
+# moonshine/kokoro/comfyui/flm next steps):
+#
+#   runtime-image-check          docker image present (vulkan)
+#   runtime-slot-create          create harness-rt slot
+#   runtime-slot-load            POST /api/slots/<n>/load and poll to READY
+#   runtime-chat-roundtrip       POST /v1/chat/completions returns non-empty content
+#   runtime-slot-unload          POST /api/slots/<n>/unload
+#   runtime-slot-delete          DELETE /api/slots/<n>
+#
+# Each row is structured so a fail can be traced back to a specific
+# transition or HTTP call.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=lib/common.sh
+source "${SCRIPT_DIR}/lib/common.sh"
+
+REPORT="${SCRIPT_DIR}/reports/runtime.json"
+harness_init "runtime" "${REPORT}"
+
+HANDOFF="${SCRIPT_DIR}/reports/.api-handoff"
+if [[ -r "${HANDOFF}" ]]; then
+    # shellcheck disable=SC1090
+    source "${HANDOFF}"
+fi
+: "${HAL0_API_URL:=http://127.0.0.1:18080}"
+: "${HAL0_HOME:=}"
+: "${HAL0_BIN:=${HAL0_HOME:+${HAL0_HOME}/.venv/bin/hal0}}"
+
+export HAL0_API_URL HAL0_HOME
+
+log_step "Runtime harness — bin=${HAL0_BIN:-<unset>}  api=${HAL0_API_URL}"
+
+# Pre-flight: API + binary.
+if ! curl -fsS -m 2 "${HAL0_API_URL}/api/status" >/dev/null 2>&1; then
+    add_row "preflight" "fail" 0 "GET ${HAL0_API_URL}/api/status failed"
+    harness_write_report || true
+    exit 1
+fi
+if [[ -z "${HAL0_BIN:-}" || ! -x "${HAL0_BIN}" ]]; then
+    add_row "preflight" "fail" 0 "hal0 binary missing"
+    harness_write_report || true
+    exit 1
+fi
+
+TEST_SLOT="harness-rt"
+TEST_MODEL_ID="harness-rt-qwen"
+TEST_MODEL_PATH="/mnt/ai-models/huggingface/hub/models--unsloth--Qwen3.5-0.8B-GGUF/snapshots/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-UD-Q4_K_XL.gguf"
+
+# Best-effort cleanup of any prior runs.
+"${HAL0_BIN}" slot delete "${TEST_SLOT}" --force >/dev/null 2>&1 || true
+"${HAL0_BIN}" model rm    "${TEST_MODEL_ID}" --force >/dev/null 2>&1 || true
+
+cleanup_runtime() {
+    "${HAL0_BIN}" slot unload "${TEST_SLOT}" >/dev/null 2>&1 || true
+    "${HAL0_BIN}" slot delete "${TEST_SLOT}" --force >/dev/null 2>&1 || true
+    "${HAL0_BIN}" model rm    "${TEST_MODEL_ID}" --force >/dev/null 2>&1 || true
+}
+trap cleanup_runtime EXIT
+
+# ── ROW: runtime-image-check ────────────────────────────────────────────────
+log_step "Row: runtime-image-check"
+start=$(start_ms)
+IMG="$(python3 -c "
+import json
+m = json.load(open('${REPO_ROOT}/manifest.json'))
+e = m['toolbox_images']['vulkan']
+print(e['tag'])
+" 2>/dev/null || true)"
+if [[ -z "${IMG}" ]]; then
+    add_row "runtime-image-check" "fail" "$(since_ms "${start}")" "manifest.json missing toolbox_images.vulkan.tag"
+elif docker image inspect "${IMG}" >/dev/null 2>&1; then
+    add_row "runtime-image-check" "pass" "$(since_ms "${start}")" "${IMG} present locally"
+else
+    # Try pulling — first run on a fresh box should not fail just because the
+    # image isn't cached yet.
+    if docker pull "${IMG}" >/dev/null 2>&1; then
+        add_row "runtime-image-check" "pass" "$(since_ms "${start}")" "${IMG} pulled"
+    else
+        add_row "runtime-image-check" "skip" "$(since_ms "${start}")" \
+            "vulkan toolbox image not available locally and pull failed — runtime rows will all skip"
+        # Bail early.
+        for r in runtime-model-register runtime-slot-create runtime-slot-load \
+                 runtime-chat-roundtrip runtime-slot-unload runtime-slot-delete; do
+            add_row "${r}" "skip" 0 "no vulkan image"
+        done
+        harness_write_report || true
+        exit 0
+    fi
+fi
+
+# ── ROW: runtime-model-register ─────────────────────────────────────────────
+log_step "Row: runtime-model-register"
+start=$(start_ms)
+if [[ ! -r "${TEST_MODEL_PATH}" ]]; then
+    add_row "runtime-model-register" "skip" "$(since_ms "${start}")" "no tiny GGUF at ${TEST_MODEL_PATH}"
+    for r in runtime-slot-create runtime-slot-load runtime-chat-roundtrip \
+             runtime-slot-unload runtime-slot-delete; do
+        add_row "${r}" "skip" 0 "depends on runtime-model-register"
+    done
+    harness_write_report || true
+    exit 0
+fi
+if "${HAL0_BIN}" model register "${TEST_MODEL_ID}" --path "${TEST_MODEL_PATH}" \
+    --license apache-2.0 --name "Harness Qwen" >/dev/null 2>&1; then
+    add_row "runtime-model-register" "pass" "$(since_ms "${start}")" "${TEST_MODEL_ID} registered"
+else
+    add_row "runtime-model-register" "fail" "$(since_ms "${start}")" "model register exited non-zero"
+fi
+
+# ── ROW: runtime-slot-create ────────────────────────────────────────────────
+log_step "Row: runtime-slot-create"
+start=$(start_ms)
+if "${HAL0_BIN}" slot create "${TEST_SLOT}" \
+    --backend llama-server --port 8093 \
+    --model "${TEST_MODEL_ID}" >/dev/null 2>&1; then
+    add_row "runtime-slot-create" "pass" "$(since_ms "${start}")" "${TEST_SLOT} created (port 8093, llama-server/vulkan)"
+else
+    add_row "runtime-slot-create" "fail" "$(since_ms "${start}")" "slot create non-zero"
+    harness_write_report || true
+    exit 1
+fi
+
+# ── ROW: runtime-slot-load ──────────────────────────────────────────────────
+# Slot template loads in --dev mode? In dev mode install.sh writes the
+# template under PREFIX/etc/systemd/system, but the host's systemctl
+# does not pick it up — so slot load via systemd is expected to fail.
+# We document the gap and skip rather than fail loudly.
+log_step "Row: runtime-slot-load"
+start=$(start_ms)
+LOAD_LOG="${SCRIPT_DIR}/reports/runtime-load.log"
+if "${HAL0_BIN}" slot load "${TEST_SLOT}" >"${LOAD_LOG}" 2>&1; then
+    add_row "runtime-slot-load" "pass" "$(since_ms "${start}")" "${TEST_SLOT} reached ready via systemd"
+    SLOT_LOADED=1
+else
+    rc=$?
+    # Differentiate: did it fail because systemd doesn't know the unit
+    # (dev-mode limitation) vs an actual provider/health failure?
+    if grep -qE "Failed to start|Unit hal0-slot@.*\.service not found|systemctl" "${LOAD_LOG}"; then
+        add_row "runtime-slot-load" "deferred" "$(since_ms "${start}")" \
+            "dev-mode limitation: --dev install writes hal0-slot@.service under PREFIX/etc/systemd/system but host's systemctl ignores it. Slots can't actually run under --dev. install.sh:530-533 — needs --dev to either (a) use systemd --user, (b) document this gap, or (c) wire a per-prefix systemd path."
+        SLOT_LOADED=0
+    else
+        add_row "runtime-slot-load" "fail" "$(since_ms "${start}")" "exit=${rc}; tail: $(tail -n1 "${LOAD_LOG}")"
+        SLOT_LOADED=0
+    fi
+fi
+
+# ── ROW: runtime-chat-roundtrip ─────────────────────────────────────────────
+log_step "Row: runtime-chat-roundtrip"
+start=$(start_ms)
+if [[ "${SLOT_LOADED:-0}" -ne 1 ]]; then
+    add_row "runtime-chat-roundtrip" "skip" "$(since_ms "${start}")" "slot not loaded"
+else
+    if curl -fsS -m 30 "${HAL0_API_URL}/v1/chat/completions" \
+        -H 'content-type: application/json' \
+        -d "{\"model\":\"${TEST_MODEL_ID}\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}],\"max_tokens\":4}" \
+        >/dev/null 2>&1; then
+        add_row "runtime-chat-roundtrip" "pass" "$(since_ms "${start}")" "/v1/chat/completions returned 2xx"
+    else
+        add_row "runtime-chat-roundtrip" "fail" "$(since_ms "${start}")" "/v1/chat/completions did not return 2xx within 30s"
+    fi
+fi
+
+# ── ROW: runtime-slot-unload ────────────────────────────────────────────────
+log_step "Row: runtime-slot-unload"
+start=$(start_ms)
+if [[ "${SLOT_LOADED:-0}" -ne 1 ]]; then
+    add_row "runtime-slot-unload" "skip" "$(since_ms "${start}")" "slot was never loaded"
+else
+    if "${HAL0_BIN}" slot unload "${TEST_SLOT}" >/dev/null 2>&1; then
+        add_row "runtime-slot-unload" "pass" "$(since_ms "${start}")" "unload returned 0"
+    else
+        add_row "runtime-slot-unload" "fail" "$(since_ms "${start}")" "unload non-zero"
+    fi
+fi
+
+# ── ROW: runtime-slot-delete ────────────────────────────────────────────────
+log_step "Row: runtime-slot-delete"
+start=$(start_ms)
+if "${HAL0_BIN}" slot delete "${TEST_SLOT}" --force >/dev/null 2>&1; then
+    add_row "runtime-slot-delete" "pass" "$(since_ms "${start}")" "delete returned 0"
+else
+    add_row "runtime-slot-delete" "fail" "$(since_ms "${start}")" "delete non-zero"
+fi
+
+log_step "Write report"
+harness_write_report || true
+log_info "report: ${REPORT}"
+exit 0
+
+# NOTE for next harness iteration:
+#   - Moonshine / Kokoro can run on CPU on hal0-dev (no GPU needed).
+#     Add a runtime-moonshine and runtime-kokoro tier once dev-mode
+#     can actually start slots (deferred above).
+#   - ComfyUI ROCm + FLM/NPU stay on hal0-test LXC; covered by
+#     scripts/release-test.sh.


### PR DESCRIPTION
## Summary
Durable test harness that drives every public surface a developer touches on a fresh install (install.sh --dev, every CLI subcommand, slot lifecycle, uninstall). Emits structured JSON rows in the same schema as `release-test.sh` so reports are diffable across runs.

- `tests/harness/installer-test.sh` — `install.sh --dev` + filesystem/units assertions, idempotency, opt-in `--auth=basic` + prod rows
- `tests/harness/cli-test.sh` — 20 CLI subcommands, full register → create → assign → delete round-trip
- `tests/harness/runtime-test.sh` — real `/v1/chat/completions` via Vulkan llama-server (blocked on toolbox image pull — see finding #8)
- `tests/harness/harness-cleanup.sh` — teardown + opt-in prod uninstall
- `scripts/harness.sh` orchestrator, `scripts/harness-report.py` pretty-printer
- `make harness` / `harness-report` / `harness-clean` targets

## First-run findings
Catalogued in `tests/harness/FINDINGS.md` — 9 items with file:line cites. **3 real bugs**, 3 gaps, 3 env. First run: **24 pass · 2 fail · 10 skip · 5 deferred** (41 rows).

## Test plan
- [ ] `make harness` runs end-to-end
- [ ] `tests/harness/reports/harness.json` validates against the v1 schema
- [ ] Findings get tracked as separate issues/PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)