### PR TITLE
fix(cli): rename config loader imports to match exports

### DIFF
--- a/src/hal0/cli/config_commands.py
+++ b/src/hal0/cli/config_commands.py
@@ -73,7 +73,11 @@ def config_migrate() -> None:
 @app.command("validate")
 def config_validate() -> None:
     """Validate all config files against the current schema."""
-    from hal0.config.loader import load_hal0_config, load_providers, load_upstreams
+    from hal0.config.loader import (
+        load_hal0_config,
+        load_providers_config,
+        load_upstreams_config,
+    )
 
     problems: list[str] = []
     try:
@@ -81,11 +85,11 @@ def config_validate() -> None:
     except Exception as exc:
         problems.append(f"hal0.toml: {exc}")
     try:
-        load_upstreams()
+        load_upstreams_config()
     except Exception as exc:
         problems.append(f"upstreams.toml: {exc}")
     try:
-        load_providers()
+        load_providers_config()
     except Exception as exc:
         problems.append(f"providers.toml: {exc}")
     if problems:


### PR DESCRIPTION
## Summary
`src/hal0/cli/config_commands.py:76` imported `load_providers` and `load_upstreams` but the loader exports them with `_config` suffix. Every `hal0 config validate` raised ImportError before validation could run.

Fix: rename imports + 3 call sites in config_commands.py.

Closes task #19. Harness FINDINGS.md #1.

## Test plan
- [x] `hal0 config validate` returns "✓ All configs pass schema validation." (exit 0)
- [x] `pytest tests/cli/` — 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)