### PR TITLE
docs(installer): warn --dev users that slot units aren't visible to host systemd

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -114,13 +114,50 @@ sudo systemctl restart hal0-api hal0-openwebui
 
 ## Dev mode (`--dev`)
 
-Runs the full installer logic but lays everything under `$PWD/hal0-home` instead of FHS paths. systemd units are **not** installed or enabled — they are written to `$PWD/hal0-home/etc/systemd/system/` for inspection only.
+Runs the full installer logic but lays everything under `$PWD/.hal0ai/` instead of FHS paths. systemd units are **not** installed or enabled — they are written to `$PWD/.hal0ai/etc/systemd/system/` for inspection only.
 
 ```sh
 bash installer/install.sh --dev
 ```
 
 Use `scripts/dev-bootstrap.sh` to actually start services during development.
+
+### `--dev` mode limitations
+
+`--dev` is a contributor convenience, not a runtime path. The installer writes the same systemd units (`hal0-api.service`, `hal0-slot@.service`, `hal0-openwebui.service`) into the dev tree, but it does **not** register them with the host's systemd. Concretely:
+
+- Units land in `$PWD/.hal0ai/etc/systemd/system/`.
+- The host's `systemctl` only searches `/etc/systemd/system/` and `/usr/lib/systemd/system/`, so it cannot see them.
+- Any flow that ends in `systemctl start hal0-slot@<name>` will fail with:
+
+  ```
+  Failed to start hal0-slot@primary.service: Unit hal0-slot@primary.service not found.
+  ```
+
+  In particular, `hal0 slot create && hal0 slot load` cannot bring a slot up in `--dev`.
+
+Two ways to resolve this, depending on what you're trying to do:
+
+1. **Just do a real install.** This is the supported runtime path:
+
+   ```sh
+   sudo bash installer/install.sh
+   ```
+
+   Real install puts units under `/etc/systemd/system/`, runs `systemctl daemon-reload`, and `hal0 slot load` works end-to-end.
+
+2. **Or link the dev units into the system search path.** Keeps the dev tree as the source of truth, but tells the host systemd where to find the units:
+
+   ```sh
+   sudo systemctl link "$PWD/.hal0ai/etc/systemd/system/hal0-slot@.service"
+   sudo systemctl link "$PWD/.hal0ai/etc/systemd/system/hal0-api.service"
+   sudo systemctl link "$PWD/.hal0ai/etc/systemd/system/hal0-openwebui.service"
+   sudo systemctl daemon-reload
+   ```
+
+   After that, `hal0 slot create && hal0 slot load` works against the dev tree. Edits to the linked unit files take effect after another `systemctl daemon-reload`.
+
+The installer prints the same warning block at the end of every `--dev` run as a reminder. Tracked under harness finding #6 / task #24.
 
 ## Uninstall
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -865,4 +865,30 @@ SUMMARY_LINES+=(
     "$(printf '  %shal0 model list%s     list known models' "${BOLD}" "${RST}")"
     "$(printf '  %shal0 config show%s    inspect %s/hal0.toml' "${BOLD}" "${RST}" "${ETC_DIR}")"
 )
+
+# --dev mode caveat — systemd units were written into the dev tree, not
+# /etc/systemd/system, so the host's systemctl does not see them. The
+# `hal0 slot create && hal0 slot load` flow will fail with "Unit
+# hal0-slot@<name>.service not found" until the operator either runs a
+# real (sudo) install or links the dev units into the system search
+# path. Documented at installer/README.md ("--dev mode limitations").
+# Tracked as harness finding #6 / task #24.
+if [[ "${DEV_MODE}" -eq 1 ]]; then
+    printf '\n'
+    warn "--dev mode: systemd units written to ${UNIT_DIR}"
+    warn "            (not /etc/systemd/system — host systemctl can't see them)"
+    warn ""
+    warn "  Consequence: 'hal0 slot load' will fail with"
+    warn "    'Unit hal0-slot@<name>.service not found'"
+    warn "  because the host's systemctl only consults /etc/systemd/system"
+    warn "  and /usr/lib/systemd/system."
+    warn ""
+    warn "  Workarounds:"
+    warn "    (a) sudo bash installer/install.sh        # real install at /opt/hal0"
+    warn "    (b) sudo systemctl link ${UNIT_DIR}/hal0-slot@.service"
+    warn "        sudo systemctl daemon-reload          # then slot load works"
+    warn ""
+    warn "  See installer/README.md ('--dev mode limitations') for details."
+fi
+
 ui_box "hal0 is ready" "${SUMMARY_LINES[@]}"


### PR DESCRIPTION
## Summary
Surface the existing `--dev` limitation (slot units written under the dev tree, not picked up by host systemctl) rather than silently fail when the user runs `hal0 slot load`.

- `install.sh`: yellow WARN block at end of every `--dev` run with two workarounds (real sudo install, or `systemctl link`)
- `installer/README.md`: new "--dev mode limitations" subsection + stale-path fix (`$PWD/hal0-home` → `$PWD/.hal0ai`)

Wiring `--dev` units into the host's systemd properly is a v1.1+ refactor; the sudo install is v1's documented runtime path.

Closes task #24. Harness FINDINGS.md #6.

## Note
Cherry-picked from Team P's original branch (which was based on pre-#19 main and would have un-deleted `installer/systemd/`). Only the install.sh + installer/README.md additions made it through.

## Test plan
- [x] `bash -n installer/install.sh` syntax OK
- [ ] Next `--dev` install shows the warning block

🤖 Generated with [Claude Code](https://claude.com/claude-code)