### PR TITLE
fix(cli): split slot create --backend into --provider + --hardware

### DIFF
--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -28,13 +28,68 @@ app = typer.Typer(help="Manage inference slots.")
 console = Console()
 
 
-class SlotBackend(StrEnum):
-    """Backends valid for a slot (mirrors PLAN.md §1 provider list)."""
+class SlotProvider(StrEnum):
+    """Providers valid for a slot (mirrors PLAN.md §1 provider list).
+
+    A *provider* is the inference engine binary that serves the slot
+    (e.g. llama-server, flm). This is distinct from a slot's *hardware*
+    backend (vulkan / rocm / cpu) which targets the compute device.
+    """
 
     llama_server = "llama-server"
     flm = "flm"
     moonshine = "moonshine"
     kokoro = "kokoro"
+
+
+# Back-compat alias — older code/docs referenced ``SlotBackend`` for what
+# is semantically the provider. Keep the name importable so external
+# callers don't break; new code should reference ``SlotProvider``.
+SlotBackend = SlotProvider
+
+
+class SlotHardware(StrEnum):
+    """Hardware backends valid for a slot (mirrors SlotConfig.backend).
+
+    See ``hal0.config.schema._VALID_BACKENDS``. ``vulkan`` works on any
+    Vulkan-capable GPU (AMD/NVIDIA/Intel); ``rocm`` requires AMD with
+    ROCm; ``cpu`` is the fallback.
+    """
+
+    vulkan = "vulkan"
+    rocm = "rocm"
+    cpu = "cpu"
+
+
+def _detect_default_hardware() -> str:
+    """Pick a sane default hardware backend from /etc/hal0/hardware.json.
+
+    Falls back to ``"vulkan"`` when the probe file is missing or
+    unreadable — that's the broadest match for AMD/NVIDIA/Intel GPUs and
+    preserves the historical hardcoded default for users without a probe.
+    """
+    try:
+        from hal0.config import paths as _paths
+    except ImportError:
+        return "vulkan"
+    try:
+        raw = _paths.hardware_json().read_text()
+    except OSError:
+        return "vulkan"
+    try:
+        data = jsonlib.loads(raw)
+    except ValueError:
+        return "vulkan"
+    gpus = data.get("gpus") or []
+    if not gpus:
+        return "cpu"
+    g = gpus[0] if isinstance(gpus[0], dict) else {}
+    vendor = (g.get("vendor") or "").lower()
+    if vendor == "amd" and g.get("compute_capable"):
+        return "rocm"
+    if g.get("vulkan_capable") or vendor in ("amd", "nvidia", "intel"):
+        return "vulkan"
+    return "cpu"
 
 
 _STATE_STYLES = {
@@ -200,12 +255,31 @@ def slot_logs(
 @app.command("create")
 def slot_create(
     name: str = typer.Argument(..., help="Slot name (e.g. primary, embed, stt)"),
-    backend: SlotBackend = typer.Option(
+    provider: SlotProvider = typer.Option(
         "llama-server",
+        "--provider",
+        help="Inference provider (engine) for the slot.",
+        case_sensitive=False,
+    ),
+    hardware: SlotHardware | None = typer.Option(
+        None,
+        "--hardware",
+        help=(
+            "Hardware backend: vulkan | rocm | cpu. "
+            "Default: auto-detected from /etc/hal0/hardware.json (vulkan if no probe)."
+        ),
+        case_sensitive=False,
+    ),
+    backend: str | None = typer.Option(
+        None,
         "--backend",
         "-b",
-        help="Provider backend for the slot.",
-        case_sensitive=False,
+        help=(
+            "[DEPRECATED] alias for --provider. "
+            "Note: this flag historically named the provider, NOT the hardware "
+            "backend. Use --provider / --hardware instead."
+        ),
+        hidden=True,
     ),
     model: str = typer.Option(..., "--model", "-m", help="Initial model ref to assign."),
     port: int | None = typer.Option(
@@ -222,10 +296,30 @@ def slot_create(
     url = _api_base()
     if _api_unreachable(url):
         raise typer.Exit(1)
+
+    # Back-compat: --backend was historically the provider name. Translate
+    # with a deprecation warning so existing scripts keep working but the
+    # user is nudged toward the corrected flags.
+    if backend is not None:
+        console.print(
+            "[yellow]warning:[/yellow] --backend is deprecated and was always the "
+            "provider name, not the hardware backend; use --provider instead.",
+            highlight=False,
+        )
+        try:
+            provider = SlotProvider(backend)
+        except ValueError:
+            die(
+                f"--backend {backend!r} is not a valid provider; "
+                f"choose from {[p.value for p in SlotProvider]}"
+            )
+            return
+
+    hw = hardware.value if hardware is not None else _detect_default_hardware()
     body: dict[str, Any] = {
         "name": name,
-        "backend": "vulkan",  # backend in the SlotConfig sense (hardware target)
-        "provider": str(backend),
+        "backend": hw,  # SlotConfig.backend = hardware target (vulkan/rocm/cpu/...)
+        "provider": str(provider),
         "model": {"default": model, "context_size": ctx_size},
     }
     if port is not None:
@@ -255,24 +349,58 @@ def slot_edit(
     model: str | None = typer.Option(None, "--model", "-m"),
     port: int | None = typer.Option(None, "--port", "-p", min=1024, max=65535),
     ctx_size: int | None = typer.Option(None, "--ctx-size", min=128),
-    backend: SlotBackend | None = typer.Option(None, "--backend", "-b", case_sensitive=False),
+    provider: SlotProvider | None = typer.Option(
+        None, "--provider", case_sensitive=False, help="Change the slot's inference provider."
+    ),
+    hardware: SlotHardware | None = typer.Option(
+        None,
+        "--hardware",
+        case_sensitive=False,
+        help="Change the slot's hardware backend (vulkan | rocm | cpu).",
+    ),
+    backend: str | None = typer.Option(
+        None,
+        "--backend",
+        "-b",
+        hidden=True,
+        help="[DEPRECATED] alias for --provider (historic, see `slot create --help`).",
+    ),
 ) -> None:
     """Update one or more slot config fields (PUT /api/slots/{name}/config)."""
     url = _api_base()
     if _api_unreachable(url):
         raise typer.Exit(1)
-    if model is None and port is None and ctx_size is None and backend is None:
+
+    # Back-compat: --backend mapped to provider historically.
+    if backend is not None:
+        console.print(
+            "[yellow]warning:[/yellow] --backend is deprecated and was always the "
+            "provider name, not the hardware backend; use --provider instead.",
+            highlight=False,
+        )
+        try:
+            provider = SlotProvider(backend) if provider is None else provider
+        except ValueError:
+            die(
+                f"--backend {backend!r} is not a valid provider; "
+                f"choose from {[p.value for p in SlotProvider]}"
+            )
+            return
+
+    if model is None and port is None and ctx_size is None and provider is None and hardware is None:
         console.print(
             "[bold yellow]No fields provided.[/bold yellow]  "
-            "Pass at least one of --model, --port, --ctx-size, --backend."
+            "Pass at least one of --model, --port, --ctx-size, --provider, --hardware."
         )
         raise typer.Exit(code=2)
 
     payload: dict[str, Any] = {}
     if port is not None:
         payload["port"] = port
-    if backend is not None:
-        payload["provider"] = str(backend)
+    if provider is not None:
+        payload["provider"] = str(provider)
+    if hardware is not None:
+        payload["backend"] = hardware.value
     if model is not None or ctx_size is not None:
         try:
             cfg = api_get(f"/api/slots/{name}/config")

--- a/tests/cli/test_slot_create_flags.py
+++ b/tests/cli/test_slot_create_flags.py
@@ -1,0 +1,169 @@
+"""Tests for ``hal0 slot create`` flag semantics.
+
+Regression coverage for the hal0 v1 harness finding #2 / task #20:
+``--backend`` historically named the *provider* but the slot's actual
+hardware backend was hardcoded to "vulkan". Fix split the flag into
+``--provider`` (engine) and ``--hardware`` (vulkan / rocm / cpu), with
+``--backend`` kept as a hidden deprecated alias for provider.
+
+These tests poke the Typer command via ``CliRunner`` and monkeypatch
+the API client + hardware-probe defaults so they don't hit network or
+read the host's real ``/etc/hal0/hardware.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import slot_commands
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def captured_post(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Stub the API surface ``slot_create`` touches and capture the POST body."""
+    captured: dict[str, Any] = {}
+
+    def fake_unreachable(_url: str) -> bool:
+        return False
+
+    def fake_get(path: str, **_kw: Any) -> list[dict[str, Any]]:
+        # No existing slots → port auto-assign falls to 8081.
+        return []
+
+    def fake_post(path: str, *, json: dict[str, Any] | None = None, **_kw: Any) -> dict[str, Any]:
+        captured["path"] = path
+        captured["body"] = json or {}
+        return {"port": (json or {}).get("port", 8081)}
+
+    monkeypatch.setattr(slot_commands, "_api_unreachable", fake_unreachable)
+    monkeypatch.setattr(slot_commands, "api_get", fake_get)
+    monkeypatch.setattr(slot_commands, "api_post", fake_post)
+    # Default hardware detection — pin to "vulkan" so tests don't depend on
+    # whatever GPU is on the runner.
+    monkeypatch.setattr(slot_commands, "_detect_default_hardware", lambda: "vulkan")
+    return captured
+
+
+def test_help_lists_new_flags() -> None:
+    """``slot create --help`` mentions --provider and --hardware."""
+    result = runner.invoke(slot_commands.app, ["create", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "--provider" in result.output
+    assert "--hardware" in result.output
+
+
+def test_provider_flag_sets_provider_and_default_hardware(
+    captured_post: dict[str, Any],
+) -> None:
+    """``--provider llama-server`` (no --hardware) uses the auto-detected default."""
+    result = runner.invoke(
+        slot_commands.app,
+        ["create", "primary", "--provider", "llama-server", "--model", "demo"],
+    )
+    assert result.exit_code == 0, result.output
+    body = captured_post["body"]
+    assert body["provider"] == "llama-server"
+    assert body["backend"] == "vulkan"
+
+
+def test_hardware_flag_overrides_default(captured_post: dict[str, Any]) -> None:
+    """``--hardware rocm`` is forwarded as SlotConfig.backend = 'rocm'."""
+    result = runner.invoke(
+        slot_commands.app,
+        [
+            "create",
+            "primary",
+            "--provider",
+            "llama-server",
+            "--hardware",
+            "rocm",
+            "--model",
+            "demo",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured_post["body"]["backend"] == "rocm"
+    assert captured_post["body"]["provider"] == "llama-server"
+
+
+def test_legacy_backend_flag_translates_to_provider(
+    captured_post: dict[str, Any],
+) -> None:
+    """Deprecated ``--backend flm`` is translated to provider=flm + warns."""
+    result = runner.invoke(
+        slot_commands.app,
+        ["create", "primary", "--backend", "flm", "--model", "demo"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured_post["body"]["provider"] == "flm"
+    # The hardware backend must NOT be conflated with the deprecated flag.
+    assert captured_post["body"]["backend"] == "vulkan"
+    assert "deprecated" in result.output.lower()
+
+
+def test_legacy_backend_with_invalid_value_errors(
+    captured_post: dict[str, Any],
+) -> None:
+    """``--backend vulkan`` (hardware-shaped) is rejected as not-a-provider."""
+    result = runner.invoke(
+        slot_commands.app,
+        ["create", "primary", "--backend", "vulkan", "--model", "demo"],
+    )
+    # ``die()`` calls typer.Exit(1) — non-zero is the contract.
+    assert result.exit_code != 0
+    # No API call should have been made.
+    assert "body" not in captured_post
+
+
+def test_default_hardware_reads_probe_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``_detect_default_hardware`` picks rocm for AMD+compute_capable GPUs."""
+    probe = tmp_path / "hardware.json"
+    probe.write_text(
+        json.dumps(
+            {
+                "gpus": [
+                    {
+                        "vendor": "amd",
+                        "name": "Radeon 890M",
+                        "compute_capable": True,
+                        "vulkan_capable": True,
+                    }
+                ]
+            }
+        )
+    )
+    from hal0.config import paths as _paths
+
+    monkeypatch.setattr(_paths, "hardware_json", lambda: probe)
+    assert slot_commands._detect_default_hardware() == "rocm"
+
+
+def test_default_hardware_vulkan_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Missing probe → vulkan (safe default that works on most GPUs)."""
+    from hal0.config import paths as _paths
+
+    monkeypatch.setattr(_paths, "hardware_json", lambda: tmp_path / "missing.json")
+    assert slot_commands._detect_default_hardware() == "vulkan"
+
+
+def test_default_hardware_cpu_when_no_gpu(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Empty gpus[] → cpu."""
+    probe = tmp_path / "hardware.json"
+    probe.write_text(json.dumps({"gpus": []}))
+    from hal0.config import paths as _paths
+
+    monkeypatch.setattr(_paths, "hardware_json", lambda: probe)
+    assert slot_commands._detect_default_hardware() == "cpu"


### PR DESCRIPTION
## Summary
`hal0 slot create --backend` historically named the *provider* (llama-server / flm / etc), but `SlotConfig.backend` is the *hardware target* (vulkan / rocm / cpu). CLI hardcoded `backend: \"vulkan\"` — users couldn't make a ROCm slot via CLI without hand-editing the TOML.

- Add `SlotProvider` + `SlotHardware` enums (old `SlotBackend` alias kept on import surface)
- `slot create` now takes `--provider` + `--hardware` (hardware auto-detects from `/etc/hal0/hardware.json`)
- `slot edit` mirrors the split
- Old `--backend / -b` kept as hidden deprecated alias — warns + translates

Closes task #20. Harness FINDINGS.md #2.

## Cherry-pick note
Lifted only the python changes from Team N's original branch (which was based on pre-#19 main and would have un-deleted `installer/systemd/` + reverted Team P's --dev warning).

## Test plan
- [x] `pytest tests/cli/` — 16/16 pass (new test_slot_create_flags.py adds coverage)
- [ ] Smoke: `hal0 slot create --help` shows new flags + `--backend` flagged deprecated

🤖 Generated with [Claude Code](https://claude.com/claude-code)