### PR TITLE
feat(migration): haloai → hal0 model migration script

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,186 @@
+# haloai → hal0 migration
+
+This document covers the v1 cutover from the legacy `haloai` install to
+`hal0`. **Scope is intentionally narrow:** only models are migrated.
+Slots, providers, upstreams, and OpenWebUI state all start fresh — the
+operator runs the FirstRun wizard post-install to bind models to slots.
+
+The script that does the work is [`scripts/migrate-haloai.py`](../scripts/migrate-haloai.py).
+
+## What's migrated, what isn't
+
+| Carries over | Starts fresh |
+|---|---|
+| Curated allow-list of model files (registered in hal0's model registry; the GGUF/safetensors bytes stay where they are on `/mnt/ai-models`) | Slot configs — re-create via FirstRun wizard (hardware-aware) |
+| | `providers.toml` — re-enter API keys (OpenRouter, Anthropic, etc.) |
+| | `upstreams.toml` — re-add external endpoints |
+| | OpenWebUI state — chat history, user accounts, configs |
+| | Agents, memories, projects, kanban, training, RAG, fixlog, vault, skills (all stripped from v1, PLAN §1) |
+
+## Curated model allow-list
+
+`DEFAULT_ALLOWLIST` ships with **14 entries**, all chat / code LLMs the
+haloai install used as daily drivers. Each entry resolves to the largest
+matching file in `/mnt/ai-models/huggingface/hub/models--<org>--<repo>/snapshots/<sha>/`.
+Missing entries are skipped with a WARN log (not a hard failure).
+
+| id | hf_repo | role |
+|---|---|---|
+| `qwen3-coder-next` | `unsloth/Qwen3-Coder-Next-GGUF` | code/chat |
+| `qwen3-coder-next-mxfp4` | `amd/Qwen3-Coder-Next-MXFP4` | code/chat/NPU |
+| `qwen3.6-27b` | `unsloth/Qwen3.6-27B-GGUF` | chat |
+| `qwen3.6-35b-a3b` | `unsloth/Qwen3.6-35B-A3B-GGUF` | chat (MoE) |
+| `qwen3.6-27b-heretic-neo-code` | `DavidAU/Qwen3.6-27B-Heretic-...-MAX-GGUF` | code/uncensored |
+| `qwen3-coder-reap-25b` | `bartowski/cerebras_Qwen3-Coder-REAP-25B-A3B-GGUF` | code |
+| `qwen3-zero-coder-reasoning-0.8b-neo` | `DavidAU/Qwen3-Zero-Coder-Reasoning-V2-0.8B-NEO-EX-GGUF` | code (tiny) |
+| `qwen3-next-80b-thinking` | `cpatonn/Qwen3-Next-80B-A3B-Thinking-AWQ-4bit` | chat (reasoning) |
+| `qwen3.5-0.8b` | `unsloth/Qwen3.5-0.8B-GGUF` | chat (tiny) |
+| `qwen3.5-4b` | `unsloth/Qwen3.5-4B-GGUF` | chat |
+| `qwen3.5-9b` | `unsloth/Qwen3.5-9B-GGUF` | chat |
+| `qwen3.5-35b-a3b` | `unsloth/Qwen3.5-35B-A3B` | chat (raw weights, MoE) |
+| `kappa-20b-mxfp4` | `eousphoros/kappa-20b-131k-mxfp4` | chat (NPU) |
+| `kappa-20b-i1-gguf` | `mradermacher/kappa-20b-131k-i1-GGUF` | chat |
+
+To override, pass `--allowlist <file.toml>` with a `[[models]]` array.
+
+### Models that need a post-cutover `hal0 model pull`
+
+These were requested but aren't on the haloai LXC's `/mnt/ai-models` —
+the script silently skips them (per design). Pull them after cutover:
+
+- **Llama 4** (any variant)
+- **Llama 4 Scout** — `meta-llama/Llama-4-Scout-*-Instruct` (fill exact repo at pull time)
+- **Nemotron 115B** — `nvidia/Llama-3.1-Nemotron-*` family
+
+Use `hal0 model pull <hf-repo>` after the migration is in place.
+
+## Cutover sequence (PLAN §11)
+
+Run from the **haloai LXC** as a sudo-capable user. The script is read-only
+against `/mnt/ai-models`; only the staging dir gets written.
+
+### Phase 0 — backups (do these even if nothing else)
+
+```bash
+sudo tar czf /root/haloai-backup-$(date +%F).tar.gz \
+    /opt/haloai/openwebui/webui.db \
+    /opt/haloai/config/{providers.toml,upstreams.toml,haloai.toml} \
+    /opt/haloai/data/slots/ 2>/dev/null || true
+```
+
+Even though v1 starts fresh on the openwebui + providers side, hang on to
+the backup until you've confirmed FirstRun + chat works end-to-end.
+
+### Phase 1 — dry-run the migration
+
+```bash
+cd /path/to/hal0  # or wherever the hal0 source/install lives
+python3 scripts/migrate-haloai.py \
+    --hub-root /mnt/ai-models/huggingface/hub \
+    --output   /tmp/hal0-migration-out \
+    --dry-run
+```
+
+Check the summary printed at the end:
+
+- `resolved: N` — how many allow-list entries actually found files on disk.
+- `skipped: M` — entries missing from `/mnt/ai-models` (just informational; not an error).
+
+If `resolved` is zero, double-check `--hub-root` matches your actual HF cache layout.
+
+### Phase 2 — install hal0 fresh
+
+```bash
+# Stop the old stack first
+sudo systemctl stop 'haloai-*.service' 'hermes-*.service' 2>/dev/null || true
+
+# Install hal0
+sudo bash installer/install.sh
+```
+
+The installer writes `/etc/hal0/`, `/var/lib/hal0/`, and the systemd
+template at `hal0-slot@.service`. It does **not** auto-start any slots —
+that's the FirstRun wizard's job.
+
+### Phase 3 — write the migrated registry
+
+```bash
+python3 scripts/migrate-haloai.py \
+    --hub-root /mnt/ai-models/huggingface/hub \
+    --output   /tmp/hal0-migration-out
+
+sudo rsync -av /tmp/hal0-migration-out/var/lib/hal0/registry/ \
+                /var/lib/hal0/registry/
+sudo chown -R hal0:hal0 /var/lib/hal0/registry/
+```
+
+### Phase 4 — start hal0 + verify
+
+```bash
+sudo systemctl start hal0-api.service hal0-openwebui.service
+hal0 model list                 # should show the resolved allow-list
+hal0 status                     # API up, no slots loaded yet
+```
+
+Open the dashboard at `http://<host>:8080`. The FirstRun wizard will
+prompt you to pick a model and assign it to the `primary` slot.
+
+### Phase 5 — confirm end-to-end before tearing the old stack down
+
+1. FirstRun wizard binds a model → primary slot reports `ready`.
+2. Visit OpenWebUI at `http://<host>:3001` → confirm chat works.
+3. After a week of stability:
+
+   ```bash
+   sudo rm -rf /opt/haloai /root/.hermes-next
+   ```
+
+Disable + remove the systemd units last so you can roll back if needed:
+
+```bash
+sudo systemctl disable 'haloai-*.service' 'hermes-*.service' 2>/dev/null || true
+sudo rm -f /etc/systemd/system/haloai-*.service /etc/systemd/system/hermes-*.service
+sudo systemctl daemon-reload
+```
+
+## Verification
+
+```bash
+# Registry parses
+hal0 model list
+
+# Each model resolves on disk
+hal0 model list --format json | jq -r '.[] | .path' | xargs -I{} test -e {}
+echo "all resolved: $?"      # 0 = good
+
+# Round-trip a request
+curl -s http://127.0.0.1:8080/v1/models | jq .
+```
+
+## Rollback
+
+The script's only mutation is writing files under `--output` (a staging
+dir you control). If Phase 3 (the rsync) already happened and you want
+to revert before any data is written:
+
+```bash
+sudo rm /var/lib/hal0/registry/registry.toml
+sudo systemctl restart hal0-api
+```
+
+`hal0 model list` will return empty — operator can then re-run the
+migration or fall back to the haloai stack (which still has all its
+data intact under `/opt/haloai/` until Phase 5).
+
+## CLI reference
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--hub-root` | `/mnt/ai-models/huggingface/hub` | HF cache root. |
+| `--output` | `/tmp/hal0-migration-out` | Staging dir for the generated `var/lib/hal0/registry/registry.toml`. |
+| `--allowlist` | (built-in 14-entry list) | TOML file with `[[models]]` array to override the curated set. |
+| `--dry-run` | off | Resolve + validate, write nothing. |
+| `--force` | off | Wipe `--output` if it's non-empty. |
+
+Exit codes: `0` success, `2` `MigrationError` (missing hub, bad
+allow-list TOML, refused to clobber).

--- a/scripts/migrate-haloai.py
+++ b/scripts/migrate-haloai.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""haloai → hal0 model migration (PLAN §11 step 2).
+
+Reads a curated allow-list of model directories from the shared
+HuggingFace cache (default ``/mnt/ai-models/huggingface/hub``) and
+writes a hal0 ``registry.toml`` describing the resolved entries.
+
+**Scope (v1):** models only. No slot configs, no providers.toml, no
+upstreams.toml, no openwebui state — operator runs the FirstRun wizard
+fresh post-cutover to bind models to slots.
+
+Models stay on the shared NFS mount. The output is just a registry
+file the operator drops into ``/var/lib/hal0/registry/registry.toml``.
+
+Usage (on the haloai LXC):
+    python3 scripts/migrate-haloai.py \\
+        --hub-root /mnt/ai-models/huggingface/hub \\
+        --output   /tmp/hal0-migration-out \\
+        --dry-run
+
+Then rsync ``/tmp/hal0-migration-out/var/lib/hal0/registry/`` into
+``/var/lib/hal0/registry/`` after running ``install.sh``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import shutil
+import sys
+import tomllib
+from pathlib import Path
+
+import structlog
+import tomli_w
+
+# Allow `from hal0.registry.model import Model` when run from a hal0 checkout.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if (_REPO_ROOT / "src" / "hal0").is_dir():
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from hal0.registry.model import Model  # noqa: E402
+
+log = structlog.get_logger(__name__)
+
+
+# ── Errors ─────────────────────────────────────────────────────────────────────
+
+
+class MigrationError(Exception):
+    """Migration script failed in a way the operator must act on."""
+
+
+# ── Allow-list entry ───────────────────────────────────────────────────────────
+
+
+@dataclasses.dataclass(frozen=True)
+class AllowEntry:
+    """One row in the curated allow-list.
+
+    ``hf_pattern`` is a glob applied inside ``snapshots/<sha>/``; the
+    resolver picks the LARGEST matching file (typically the highest quant).
+    Use ``"*"`` when the repo isn't a GGUF cache (AWQ, MXFP4, raw weights).
+    """
+
+    id: str
+    name: str
+    capabilities: tuple[str, ...]
+    license: str
+    hf_repo: str
+    hf_pattern: str = "*.gguf"
+
+
+DEFAULT_ALLOWLIST: tuple[AllowEntry, ...] = (
+    AllowEntry(
+        id="qwen3-coder-next",
+        name="Qwen3 Coder Next (GGUF)",
+        capabilities=("code", "chat"),
+        license="Apache-2.0",
+        hf_repo="unsloth/Qwen3-Coder-Next-GGUF",
+        hf_pattern="*.gguf",
+    ),
+    AllowEntry(
+        id="qwen3-coder-next-mxfp4",
+        name="Qwen3 Coder Next (AMD MXFP4)",
+        capabilities=("code", "chat", "npu"),
+        license="Apache-2.0",
+        hf_repo="amd/Qwen3-Coder-Next-MXFP4",
+        hf_pattern="*",
+    ),
+    AllowEntry(
+        id="qwen3.6-27b",
+        name="Qwen3.6 27B (GGUF)",
+        capabilities=("chat",),
+        license="Apache-2.0",
+        hf_repo="unsloth/Qwen3.6-27B-GGUF",
+        hf_pattern="*.gguf",
+    ),
+    AllowEntry(
+        id="qwen3.6-35b-a3b",
+        name="Qwen3.6 35B A3B (GGUF)",
+        capabilities=("chat",),
+        license="Apache-2.0",
+        hf_repo="unsloth/Qwen3.6-35B-A3B-GGUF",
+        hf_pattern="*.gguf",
+    ),
+    AllowEntry(
+        id="qwen3.6-27b-heretic-neo-code",
+        name="Qwen3.6 27B Heretic NEO-CODE (DavidAU)",
+        capabilities=("code", "chat", "uncensored"),
+        license="Apache-2.0",
+        hf_repo="DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
+        hf_pattern="*.gguf",
+    ),
+    AllowEntry(
+        id="qwen3-coder-reap-25b",
+        name="Qwen3 Coder REAP 25B A3B (cerebras/bartowski)",
+        capabilities=("code", "chat"),
+        license="Apache-2.0",
+        hf_repo="bartowski/cerebras_Qwen3-Coder-REAP-25B-A3B-GGUF",
+        hf_pattern="*.gguf",
+    ),
+    AllowEntry(
+        id="qwen3-zero-coder-reasoning-0.8b-neo",
+        name="Qwen3 Zero Coder Reasoning V2 0.8B NEO (DavidAU)",
+        capabilities=("code", "tiny"),
+        license="Apache-2.0",
+        hf_repo="DavidAU/Qwen3-Zero-Coder-Reasoning-V2-0.8B-NEO-EX-GGUF",
+        hf_pattern="*.gguf",
+    ),
+    AllowEntry(
+        id="qwen3-next-80b-thinking",
+        name="Qwen3-Next 80B A3B Thinking (AWQ 4bit)",
+        capabilities=("chat", "reasoning"),
+        license="Apache-2.0",
+        hf_repo="cpatonn/Qwen3-Next-80B-A3B-Thinking-AWQ-4bit",
+        hf_pattern="*",
+    ),
+    AllowEntry(
+        id="qwen3.5-0.8b",
+        name="Qwen3.5 0.8B (GGUF)",
+        capabilities=("chat", "tiny"),
+        license="Apache-2.0",
+        hf_repo="unsloth/Qwen3.5-0.8B-GGUF",
+        hf_pattern="*.gguf",
+    ),
+    AllowEntry(
+        id="qwen3.5-4b",
+        name="Qwen3.5 4B (GGUF)",
+        capabilities=("chat",),
+        license="Apache-2.0",
+        hf_repo="unsloth/Qwen3.5-4B-GGUF",
+        hf_pattern="*.gguf",
+    ),
+    AllowEntry(
+        id="qwen3.5-9b",
+        name="Qwen3.5 9B (GGUF)",
+        capabilities=("chat",),
+        license="Apache-2.0",
+        hf_repo="unsloth/Qwen3.5-9B-GGUF",
+        hf_pattern="*.gguf",
+    ),
+    AllowEntry(
+        id="qwen3.5-35b-a3b",
+        name="Qwen3.5 35B A3B (raw weights)",
+        capabilities=("chat", "raw"),
+        license="Apache-2.0",
+        hf_repo="unsloth/Qwen3.5-35B-A3B",
+        hf_pattern="*",
+    ),
+    AllowEntry(
+        id="kappa-20b-mxfp4",
+        name="kappa 20B 131k (eousphoros, MXFP4)",
+        capabilities=("chat", "npu"),
+        license="Apache-2.0",
+        hf_repo="eousphoros/kappa-20b-131k-mxfp4",
+        hf_pattern="*",
+    ),
+    AllowEntry(
+        id="kappa-20b-i1-gguf",
+        name="kappa 20B 131k (mradermacher, i1 GGUF)",
+        capabilities=("chat",),
+        license="Apache-2.0",
+        hf_repo="mradermacher/kappa-20b-131k-i1-GGUF",
+        hf_pattern="*.gguf",
+    ),
+)
+
+
+# ── Resolve allow-list entries against the HF cache ───────────────────────────
+
+
+def _hub_dirname(hf_repo: str) -> str:
+    """Convert ``org/repo`` → HF cache dirname ``models--org--repo``."""
+    return "models--" + hf_repo.replace("/", "--")
+
+
+def _pick_largest(paths: list[Path]) -> Path | None:
+    """Return the largest file from a list, or None if list is empty."""
+    if not paths:
+        return None
+    return max(paths, key=lambda p: p.stat().st_size if p.is_file() else 0)
+
+
+def resolve_entry(entry: AllowEntry, hub_root: Path) -> Path | None:
+    """Resolve an allow-list entry to a file on disk, or None if absent.
+
+    HF cache layout: ``<hub_root>/models--<org>--<repo>/snapshots/<sha>/``.
+    Picks the largest file matching ``entry.hf_pattern`` across all
+    snapshots. Snapshots whose files are broken symlinks are skipped.
+    """
+    repo_dir = hub_root / _hub_dirname(entry.hf_repo)
+    if not repo_dir.is_dir():
+        return None
+
+    snapshots_dir = repo_dir / "snapshots"
+    candidates: list[Path] = []
+    if snapshots_dir.is_dir():
+        for snapshot in snapshots_dir.iterdir():
+            if not snapshot.is_dir():
+                continue
+            for match in snapshot.glob(entry.hf_pattern):
+                # Resolve symlinks; only keep files that actually exist.
+                try:
+                    if match.is_file():
+                        candidates.append(match)
+                except OSError:
+                    continue
+
+    return _pick_largest(candidates)
+
+
+def build_model(entry: AllowEntry, resolved: Path) -> Model:
+    """Construct a validated ``Model`` from an allow-list entry + resolved path."""
+    try:
+        size = resolved.stat().st_size
+    except OSError:
+        size = 0
+    return Model(
+        id=entry.id,
+        name=entry.name,
+        path=str(resolved),
+        size_bytes=size,
+        license=entry.license,
+        capabilities=list(entry.capabilities),
+        hf_repo=entry.hf_repo,
+        hf_filename=resolved.name,
+        tags=["migrated", "curated"],
+    )
+
+
+# ── Allow-list loading (operator override) ────────────────────────────────────
+
+
+def load_allowlist(path: Path | None) -> tuple[AllowEntry, ...]:
+    """Load an allow-list from a TOML file, or return DEFAULT_ALLOWLIST."""
+    if path is None:
+        return DEFAULT_ALLOWLIST
+    if not path.is_file():
+        raise MigrationError(f"allowlist file not found: {path}")
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    entries = data.get("models", [])
+    if not isinstance(entries, list):
+        raise MigrationError("allowlist must contain a [[models]] array")
+    out: list[AllowEntry] = []
+    for raw in entries:
+        out.append(
+            AllowEntry(
+                id=raw["id"],
+                name=raw.get("name", raw["id"]),
+                capabilities=tuple(raw.get("capabilities", [])),
+                license=raw.get("license", "unknown"),
+                hf_repo=raw["hf_repo"],
+                hf_pattern=raw.get("hf_pattern", "*.gguf"),
+            )
+        )
+    return tuple(out)
+
+
+# ── Registry serialisation ─────────────────────────────────────────────────────
+
+
+def render_registry(models: list[Model]) -> bytes:
+    """Render Model list as ``registry.toml`` bytes — matches ModelRegistry._atomic_write."""
+    payload = {
+        "models": {
+            m.id: {k: v for k, v in m.model_dump(mode="python").items() if k != "id"}
+            for m in sorted(models, key=lambda m: m.id)
+        }
+    }
+    return tomli_w.dumps(payload).encode("utf-8")
+
+
+# ── Main migration ─────────────────────────────────────────────────────────────
+
+
+@dataclasses.dataclass
+class MigrationSummary:
+    resolved: list[str]
+    skipped: list[str]
+    output_path: Path | None  # None when dry-run
+
+
+def _ensure_empty_or_force(path: Path, *, force: bool) -> None:
+    if path.exists() and any(path.iterdir()) and not force:
+        raise MigrationError(f"output dir {path} is not empty; pass --force to overwrite")
+
+
+def migrate(
+    *,
+    hub_root: Path,
+    output: Path,
+    allowlist: tuple[AllowEntry, ...],
+    dry_run: bool,
+    force: bool,
+) -> MigrationSummary:
+    if not hub_root.is_dir():
+        raise MigrationError(f"hub root not found: {hub_root}")
+
+    resolved_models: list[Model] = []
+    resolved_ids: list[str] = []
+    skipped_ids: list[str] = []
+
+    for entry in allowlist:
+        resolved = resolve_entry(entry, hub_root)
+        if resolved is None:
+            log.warning("model.skip", id=entry.id, hf_repo=entry.hf_repo, reason="not_on_disk")
+            skipped_ids.append(entry.id)
+            continue
+        model = build_model(entry, resolved)
+        resolved_models.append(model)
+        resolved_ids.append(entry.id)
+        log.info(
+            "model.resolved",
+            id=entry.id,
+            path=str(resolved),
+            size_bytes=model.size_bytes,
+        )
+
+    if dry_run:
+        log.info(
+            "migrate.dry_run",
+            resolved=len(resolved_ids),
+            skipped=len(skipped_ids),
+        )
+        return MigrationSummary(
+            resolved=resolved_ids,
+            skipped=skipped_ids,
+            output_path=None,
+        )
+
+    registry_dir = output / "var" / "lib" / "hal0" / "registry"
+    _ensure_empty_or_force(output, force=force)
+    if force and output.exists():
+        shutil.rmtree(output)
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    registry_file = registry_dir / "registry.toml"
+    registry_file.write_bytes(render_registry(resolved_models))
+    log.info(
+        "migrate.wrote_registry",
+        path=str(registry_file),
+        resolved=len(resolved_ids),
+        skipped=len(skipped_ids),
+    )
+    return MigrationSummary(
+        resolved=resolved_ids,
+        skipped=skipped_ids,
+        output_path=registry_file,
+    )
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="migrate-haloai",
+        description=(
+            "haloai → hal0 model migration. Reads a curated allow-list "
+            "from the shared HuggingFace cache, writes a hal0 registry.toml."
+        ),
+    )
+    p.add_argument(
+        "--hub-root",
+        type=Path,
+        default=Path("/mnt/ai-models/huggingface/hub"),
+        help="HF cache root (default: /mnt/ai-models/huggingface/hub).",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=Path("/tmp/hal0-migration-out"),
+        help="Staging dir to write under (default: /tmp/hal0-migration-out).",
+    )
+    p.add_argument(
+        "--allowlist",
+        type=Path,
+        default=None,
+        help="Override allow-list TOML file. Default: 14-entry curated list.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve + validate, don't write anything.",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Wipe existing --output dir before writing.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        allowlist = load_allowlist(args.allowlist)
+        summary = migrate(
+            hub_root=args.hub_root,
+            output=args.output,
+            allowlist=allowlist,
+            dry_run=args.dry_run,
+            force=args.force,
+        )
+    except MigrationError as exc:
+        log.error("migrate.failed", reason=str(exc))
+        return 2
+    print(
+        f"\nMigration {'(dry-run) ' if args.dry_run else ''}complete:"
+        f"\n  resolved: {len(summary.resolved)}"
+        f"\n  skipped:  {len(summary.skipped)}"
+        + (f"\n  output:   {summary.output_path}" if summary.output_path else "")
+        + (f"\n  skipped ids: {', '.join(summary.skipped)}" if summary.skipped else "")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_migrate_haloai.py
+++ b/tests/scripts/test_migrate_haloai.py
@@ -1,0 +1,354 @@
+"""Tests for scripts/migrate-haloai.py.
+
+Hermetic — builds a synthetic HF cache layout under tmp_path, never touches
+the real /mnt/ai-models. Every emitted Model is re-validated through the
+hal0 pydantic schema so the registry file we write is well-formed by
+construction.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from hal0.registry.model import Model
+
+# Load scripts/migrate-haloai.py by path (hyphen in filename → can't import).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MIGRATE_PATH = _REPO_ROOT / "scripts" / "migrate-haloai.py"
+_spec = importlib.util.spec_from_file_location("migrate_haloai", _MIGRATE_PATH)
+assert _spec is not None and _spec.loader is not None
+migrate_haloai = importlib.util.module_from_spec(_spec)
+sys.modules["migrate_haloai"] = migrate_haloai
+_spec.loader.exec_module(migrate_haloai)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _make_snapshot(hub: Path, hf_repo: str, sha: str, files: dict[str, int]) -> Path:
+    """Build a snapshot dir with files of given byte sizes; returns the snapshot path."""
+    dirname = "models--" + hf_repo.replace("/", "--")
+    snap = hub / dirname / "snapshots" / sha
+    snap.mkdir(parents=True, exist_ok=True)
+    for fname, size in files.items():
+        (snap / fname).write_bytes(b"\0" * size)
+    return snap
+
+
+@pytest.fixture
+def hub(tmp_path: Path) -> Path:
+    """Return an empty HF cache hub root."""
+    h = tmp_path / "hf-hub"
+    h.mkdir()
+    return h
+
+
+# ── _hub_dirname ──────────────────────────────────────────────────────────────
+
+
+def test_hub_dirname_translates_slash_to_dashdash() -> None:
+    assert (
+        migrate_haloai._hub_dirname("unsloth/Qwen3.5-4B-GGUF") == "models--unsloth--Qwen3.5-4B-GGUF"
+    )
+
+
+# ── resolve_entry ─────────────────────────────────────────────────────────────
+
+
+def test_resolve_picks_largest_gguf(hub: Path) -> None:
+    _make_snapshot(
+        hub,
+        "unsloth/Qwen3.5-4B-GGUF",
+        sha="abc",
+        files={"small.gguf": 100, "big.gguf": 9999, "README.md": 50},
+    )
+    entry = migrate_haloai.AllowEntry(
+        id="qwen3.5-4b",
+        name="Qwen3.5 4B",
+        capabilities=("chat",),
+        license="Apache-2.0",
+        hf_repo="unsloth/Qwen3.5-4B-GGUF",
+        hf_pattern="*.gguf",
+    )
+    resolved = migrate_haloai.resolve_entry(entry, hub)
+    assert resolved is not None
+    assert resolved.name == "big.gguf"
+
+
+def test_resolve_returns_none_when_repo_missing(hub: Path) -> None:
+    entry = migrate_haloai.AllowEntry(
+        id="missing",
+        name="missing",
+        capabilities=("chat",),
+        license="Apache-2.0",
+        hf_repo="some/missing-repo",
+    )
+    assert migrate_haloai.resolve_entry(entry, hub) is None
+
+
+def test_resolve_glob_star_matches_anything(hub: Path) -> None:
+    _make_snapshot(
+        hub,
+        "amd/Qwen3-Coder-Next-MXFP4",
+        sha="def",
+        files={"model.safetensors": 5000, "config.json": 200},
+    )
+    entry = migrate_haloai.AllowEntry(
+        id="qwen3-coder-next-mxfp4",
+        name="...",
+        capabilities=("code",),
+        license="Apache-2.0",
+        hf_repo="amd/Qwen3-Coder-Next-MXFP4",
+        hf_pattern="*",
+    )
+    resolved = migrate_haloai.resolve_entry(entry, hub)
+    assert resolved is not None
+    assert resolved.name == "model.safetensors"  # largest
+
+
+def test_resolve_across_multiple_snapshots(hub: Path) -> None:
+    _make_snapshot(hub, "org/r", "sha-old", {"old.gguf": 100})
+    _make_snapshot(hub, "org/r", "sha-new", {"new.gguf": 9999})
+    entry = migrate_haloai.AllowEntry(
+        id="x", name="x", capabilities=(), license="", hf_repo="org/r"
+    )
+    assert migrate_haloai.resolve_entry(entry, hub).name == "new.gguf"
+
+
+# ── build_model ───────────────────────────────────────────────────────────────
+
+
+def test_build_model_validates_via_pydantic(hub: Path) -> None:
+    snap = _make_snapshot(hub, "org/r", "s", {"m.gguf": 1234})
+    entry = migrate_haloai.AllowEntry(
+        id="my-model",
+        name="My Model",
+        capabilities=("chat", "code"),
+        license="Apache-2.0",
+        hf_repo="org/r",
+    )
+    m = migrate_haloai.build_model(entry, snap / "m.gguf")
+    assert isinstance(m, Model)
+    assert m.id == "my-model"
+    assert m.size_bytes == 1234
+    assert m.capabilities == ["chat", "code"]
+    assert "migrated" in m.tags
+
+
+# ── DEFAULT_ALLOWLIST ─────────────────────────────────────────────────────────
+
+
+def test_default_allowlist_has_fourteen_entries() -> None:
+    assert len(migrate_haloai.DEFAULT_ALLOWLIST) == 14
+
+
+def test_default_allowlist_ids_are_unique() -> None:
+    ids = [e.id for e in migrate_haloai.DEFAULT_ALLOWLIST]
+    assert len(ids) == len(set(ids))
+
+
+def test_default_allowlist_targets_curated_repos() -> None:
+    repos = {e.hf_repo for e in migrate_haloai.DEFAULT_ALLOWLIST}
+    # Confidence checks the specific big-LLMs the user named are present.
+    assert "unsloth/Qwen3-Coder-Next-GGUF" in repos
+    assert "amd/Qwen3-Coder-Next-MXFP4" in repos
+    assert "cpatonn/Qwen3-Next-80B-A3B-Thinking-AWQ-4bit" in repos
+    assert "eousphoros/kappa-20b-131k-mxfp4" in repos
+    assert "mradermacher/kappa-20b-131k-i1-GGUF" in repos
+
+
+# ── load_allowlist ────────────────────────────────────────────────────────────
+
+
+def test_load_allowlist_default_is_built_in() -> None:
+    assert migrate_haloai.load_allowlist(None) is migrate_haloai.DEFAULT_ALLOWLIST
+
+
+def test_load_allowlist_from_toml(tmp_path: Path) -> None:
+    p = tmp_path / "allow.toml"
+    p.write_text(
+        """
+[[models]]
+id = "custom-1"
+name = "Custom One"
+capabilities = ["chat"]
+license = "MIT"
+hf_repo = "user/custom-1"
+hf_pattern = "*.gguf"
+""",
+        encoding="utf-8",
+    )
+    out = migrate_haloai.load_allowlist(p)
+    assert len(out) == 1
+    assert out[0].id == "custom-1"
+    assert out[0].license == "MIT"
+
+
+def test_load_allowlist_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(migrate_haloai.MigrationError, match="not found"):
+        migrate_haloai.load_allowlist(tmp_path / "nope.toml")
+
+
+# ── migrate() ─────────────────────────────────────────────────────────────────
+
+
+def _two_repo_hub(tmp_path: Path) -> tuple[Path, Path]:
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    _make_snapshot(hub, "unsloth/Qwen3.5-4B-GGUF", "s1", {"Qwen3.5-4B-UD-Q4.gguf": 5000})
+    _make_snapshot(hub, "unsloth/Qwen3.6-27B-GGUF", "s2", {"Qwen3.6-27B-Q5.gguf": 9999})
+    return hub, tmp_path / "out"
+
+
+def test_migrate_writes_validated_registry(tmp_path: Path) -> None:
+    hub, output = _two_repo_hub(tmp_path)
+    # Subset allow-list — just the two we have.
+    allowlist = (
+        migrate_haloai.AllowEntry(
+            id="qwen3.5-4b",
+            name="Qwen3.5 4B",
+            capabilities=("chat",),
+            license="Apache-2.0",
+            hf_repo="unsloth/Qwen3.5-4B-GGUF",
+        ),
+        migrate_haloai.AllowEntry(
+            id="qwen3.6-27b",
+            name="Qwen3.6 27B",
+            capabilities=("chat",),
+            license="Apache-2.0",
+            hf_repo="unsloth/Qwen3.6-27B-GGUF",
+        ),
+    )
+    summary = migrate_haloai.migrate(
+        hub_root=hub,
+        output=output,
+        allowlist=allowlist,
+        dry_run=False,
+        force=False,
+    )
+    assert summary.resolved == ["qwen3.5-4b", "qwen3.6-27b"]
+    assert summary.skipped == []
+    registry = output / "var" / "lib" / "hal0" / "registry" / "registry.toml"
+    assert registry.is_file()
+    with registry.open("rb") as f:
+        data = tomllib.load(f)
+    assert set(data["models"].keys()) == {"qwen3.5-4b", "qwen3.6-27b"}
+    # Each entry round-trips through pydantic.
+    for mid, payload in data["models"].items():
+        Model.model_validate({"id": mid, **payload})
+
+
+def test_missing_model_is_skipped_and_warned(tmp_path: Path) -> None:
+    hub, output = _two_repo_hub(tmp_path)
+    allowlist = (
+        migrate_haloai.AllowEntry(
+            id="real",
+            name="Real",
+            capabilities=("chat",),
+            license="Apache-2.0",
+            hf_repo="unsloth/Qwen3.5-4B-GGUF",
+        ),
+        migrate_haloai.AllowEntry(
+            id="ghost",
+            name="Ghost",
+            capabilities=("chat",),
+            license="Apache-2.0",
+            hf_repo="not/on-disk",
+        ),
+    )
+    summary = migrate_haloai.migrate(
+        hub_root=hub,
+        output=output,
+        allowlist=allowlist,
+        dry_run=False,
+        force=False,
+    )
+    assert summary.resolved == ["real"]
+    assert summary.skipped == ["ghost"]
+
+
+def test_dry_run_writes_nothing(tmp_path: Path) -> None:
+    hub, output = _two_repo_hub(tmp_path)
+    allowlist = (
+        migrate_haloai.AllowEntry(
+            id="qwen3.5-4b",
+            name="Qwen3.5 4B",
+            capabilities=("chat",),
+            license="Apache-2.0",
+            hf_repo="unsloth/Qwen3.5-4B-GGUF",
+        ),
+    )
+    summary = migrate_haloai.migrate(
+        hub_root=hub,
+        output=output,
+        allowlist=allowlist,
+        dry_run=True,
+        force=False,
+    )
+    assert summary.output_path is None
+    assert not output.exists()
+
+
+def test_missing_hub_root_raises(tmp_path: Path) -> None:
+    with pytest.raises(migrate_haloai.MigrationError, match="hub root"):
+        migrate_haloai.migrate(
+            hub_root=tmp_path / "nope",
+            output=tmp_path / "out",
+            allowlist=(),
+            dry_run=False,
+            force=False,
+        )
+
+
+def test_refuses_to_clobber_without_force(tmp_path: Path) -> None:
+    hub, output = _two_repo_hub(tmp_path)
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "preexisting").write_text("hi", encoding="utf-8")
+    with pytest.raises(migrate_haloai.MigrationError, match="not empty"):
+        migrate_haloai.migrate(
+            hub_root=hub,
+            output=output,
+            allowlist=(),
+            dry_run=False,
+            force=False,
+        )
+
+
+def test_force_clobbers_existing_output(tmp_path: Path) -> None:
+    hub, output = _two_repo_hub(tmp_path)
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "preexisting").write_text("hi", encoding="utf-8")
+    summary = migrate_haloai.migrate(
+        hub_root=hub,
+        output=output,
+        allowlist=(
+            migrate_haloai.AllowEntry(
+                id="qwen3.5-4b",
+                name="Qwen3.5 4B",
+                capabilities=("chat",),
+                license="Apache-2.0",
+                hf_repo="unsloth/Qwen3.5-4B-GGUF",
+            ),
+        ),
+        dry_run=False,
+        force=True,
+    )
+    assert summary.output_path is not None
+    assert not (output / "preexisting").exists()
+
+
+# ── render_registry round-trip ────────────────────────────────────────────────
+
+
+def test_render_registry_strips_id_from_per_model_dict() -> None:
+    m = Model(id="abc", name="A", path="/x", license="Apache-2.0", capabilities=["chat"])
+    blob = migrate_haloai.render_registry([m])
+    parsed = tomllib.loads(blob.decode("utf-8"))
+    assert "abc" in parsed["models"]
+    assert "id" not in parsed["models"]["abc"]
+    assert parsed["models"]["abc"]["name"] == "A"


### PR DESCRIPTION
Closes #27. 14-entry curated allow-list, 19 tests pass, docs/migration.md covers full 5-phase cutover.