### PR TITLE
feat(slots): swap model now persists by default (UI + CLI)

### DIFF
--- a/src/hal0/api/routes/installer.py
+++ b/src/hal0/api/routes/installer.py
@@ -428,3 +428,42 @@ async def pick_default(
         "pull_job_id": job.job_id,
         "next": f"poll /api/models/{model_id}/pull/status",
     }
+
+
+@router.put("/slots/{slot}/model")
+async def set_slot_default_model(slot: str, request: Request) -> dict[str, Any]:
+    # Persist-only counterpart to /api/slots/{name}/swap.  Hot-swap changes
+    # the running container; this writes model.default into
+    # /etc/hal0/slots/<slot>.toml so the change survives a restart.  UI
+    # and CLI call both for the common "change and remember" flow.
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise PickDefaultError(
+            f"body must be valid JSON: {exc}",
+            details={"slot": slot, "error": str(exc)},
+        ) from exc
+    if not isinstance(body, dict):
+        raise PickDefaultError("body must be a JSON object", details={"slot": slot})
+    model_id = body.get("model_id")
+    if not isinstance(model_id, str) or not model_id.strip():
+        raise PickDefaultError(
+            "model_id is required (non-empty string)",
+            details={"slot": slot},
+        )
+    model_id = model_id.strip()
+
+    registry = getattr(request.app.state, "model_registry", None)
+    if registry is not None and not registry.has(model_id):
+        raise PickDefaultError(
+            f"model_id {model_id!r} is not in the registry",
+            details={"slot": slot, "model_id": model_id},
+        )
+
+    slot_path = _assign_to_slot(slot, model_id)
+    return {
+        "slot": slot,
+        "model_id": model_id,
+        "slot_path": str(slot_path),
+        "persisted": True,
+    }

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -203,8 +203,23 @@ def slot_restart(
 def slot_swap(
     name: str = typer.Argument(..., help="Slot name to swap"),
     model: str = typer.Option(..., "--model", "-m", help="Model ref to swap in"),
+    no_persist: bool = typer.Option(
+        False,
+        "--no-persist",
+        help="Hot-swap only — don't update /etc/hal0/slots/<slot>.toml.",
+    ),
 ) -> None:
-    """Hot-swap the model in a running slot."""
+    """Swap a slot's model, and (by default) make the change survive a restart.
+
+    Two distinct steps:
+      1. Hot-swap — POST /api/slots/{name}/swap          (runtime)
+      2. Persist  — PUT  /api/install/slots/{name}/model (on-disk default)
+
+    Pass ``--no-persist`` to skip step 2 (try a model briefly without
+    changing the default).  If step 1 succeeds but step 2 fails, the
+    runtime swap is left in place and the failure is surfaced so the
+    operator can retry persist after fixing the cause.
+    """
     url = _api_base()
     if _api_unreachable(url):
         raise typer.Exit(1)
@@ -213,8 +228,27 @@ def slot_swap(
     except CliApiError as exc:
         die(str(exc))
         return
+
+    swapped_id = snap.get("model_id", model)
+    state = _fmt_state(snap.get("state"))
+
+    if no_persist:
+        console.print(
+            f"Swapped [bold]{name}[/bold] → {swapped_id} state={state} "
+            "[dim](runtime only; --no-persist set)[/dim]"
+        )
+        return
+
+    try:
+        api_put(f"/api/install/slots/{name}/model", json={"model_id": model})
+    except CliApiError as exc:
+        console.print(f"Swapped [bold]{name}[/bold] → {swapped_id} state={state}")
+        console.print(f"[yellow]Warning:[/yellow] runtime swap succeeded but persist failed: {exc}")
+        console.print(f"[dim]Change will revert on next restart of hal0-slot@{name}.service.[/dim]")
+        raise typer.Exit(1) from None
+
     console.print(
-        f"Swapped [bold]{name}[/bold] → {snap.get('model_id', model)} state={_fmt_state(snap.get('state'))}"
+        f"Swapped [bold]{name}[/bold] → {swapped_id} state={state} [dim](persisted)[/dim]"
     )
 
 

--- a/tests/api/test_installer_routes.py
+++ b/tests/api/test_installer_routes.py
@@ -118,6 +118,133 @@ def test_install_probe_writes_hardware_json(
     assert info["probed_at"], "probed_at should be a non-empty ISO timestamp"
 
 
+# ── PUT /api/install/slots/{slot}/model ────────────────────────────────────
+
+
+@pytest.fixture
+def isolated_app_client(
+    tmp_hal0_home: str,
+) -> Iterator[tuple[FastAPI, TestClient]]:
+    """Like isolated_client, but also yields the app for state inspection."""
+    app: FastAPI = create_app()
+    with TestClient(app) as c:
+        yield app, c
+
+
+def test_set_slot_default_model_writes_toml_and_returns_path(
+    isolated_app_client: tuple[FastAPI, TestClient], tmp_hal0_home: str
+) -> None:
+    """PUT /api/install/slots/primary/model rewrites the slot TOML."""
+    import tomllib
+
+    from hal0.registry.model import Model
+
+    app, client = isolated_app_client
+    app.state.model_registry.add(
+        Model(
+            id="qwen3.5-4b",
+            name="Qwen 3.5 4B",
+            path="/tmp/qwen3.5-4b.gguf",
+            size_bytes=1,
+            license="Apache-2.0",
+            capabilities=["chat"],
+        )
+    )
+
+    r = client.put(
+        "/api/install/slots/primary/model",
+        json={"model_id": "qwen3.5-4b"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body == {
+        "slot": "primary",
+        "model_id": "qwen3.5-4b",
+        "slot_path": str(Path(tmp_hal0_home) / "etc" / "hal0" / "slots" / "primary.toml"),
+        "persisted": True,
+    }
+
+    cfg = tomllib.loads(Path(body["slot_path"]).read_text())
+    assert cfg["model"]["default"] == "qwen3.5-4b"
+    # Built-in defaults seeded by _assign_to_slot when creating the file.
+    assert cfg["port"] == 8081
+    assert cfg["backend"] == "vulkan"
+
+
+def test_set_slot_default_model_preserves_existing_port_and_backend(
+    isolated_app_client: tuple[FastAPI, TestClient], tmp_hal0_home: str
+) -> None:
+    """Existing port/backend in the TOML survive the model swap."""
+    import tomllib
+
+    import tomli_w
+
+    from hal0.registry.model import Model
+
+    app, client = isolated_app_client
+    app.state.model_registry.add(
+        Model(
+            id="qwen3.5-9b",
+            name="Qwen 3.5 9B",
+            path="/tmp/qwen3.5-9b.gguf",
+            size_bytes=1,
+            license="Apache-2.0",
+            capabilities=["chat"],
+        )
+    )
+    slot_path = Path(tmp_hal0_home) / "etc" / "hal0" / "slots" / "primary.toml"
+    slot_path.parent.mkdir(parents=True, exist_ok=True)
+    slot_path.write_bytes(
+        tomli_w.dumps(
+            {
+                "name": "primary",
+                "port": 9999,
+                "backend": "rocm",
+                "provider": "llama-server",
+                "model": {"default": "phi3-mini"},
+            }
+        ).encode()
+    )
+
+    r = client.put(
+        "/api/install/slots/primary/model",
+        json={"model_id": "qwen3.5-9b"},
+    )
+    assert r.status_code == 200, r.text
+
+    cfg = tomllib.loads(slot_path.read_text())
+    assert cfg["model"]["default"] == "qwen3.5-9b"
+    assert cfg["port"] == 9999  # preserved
+    assert cfg["backend"] == "rocm"  # preserved
+
+
+def test_set_slot_default_model_rejects_unknown_model_id(
+    isolated_app_client: tuple[FastAPI, TestClient],
+) -> None:
+    """An id not in the registry returns 400 install.pick_default_failed."""
+    _, client = isolated_app_client
+    r = client.put(
+        "/api/install/slots/primary/model",
+        json={"model_id": "does-not-exist"},
+    )
+    assert r.status_code == 400
+    body = r.json()
+    assert body["error"]["code"] == "install.pick_default_failed"
+    assert "not in the registry" in body["error"]["message"]
+
+
+def test_set_slot_default_model_requires_non_empty_model_id(
+    isolated_app_client: tuple[FastAPI, TestClient],
+) -> None:
+    _, client = isolated_app_client
+    r = client.put(
+        "/api/install/slots/primary/model",
+        json={"model_id": "   "},
+    )
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "install.pick_default_failed"
+
+
 def test_install_curated_models_returns_catalogue(isolated_client: TestClient) -> None:
     """Curated-models endpoint surfaces the manifest the wizard renders."""
     r = isolated_client.get("/api/install/curated-models")

--- a/ui/src/views/Slots.vue
+++ b/ui/src/views/Slots.vue
@@ -146,13 +146,36 @@ async function doLoad(slot) {
 
 async function doSwap() {
   if (!swapSlot.value || !swapModel.value) return
+  const name = swapSlot.value.name
+  const modelId = swapModel.value
   swapping.value = true
   try {
-    await api(`/api/slots/${swapSlot.value.name}/swap`, {
+    // Step 1: hot-swap the running container (runtime only).  Body shape
+    // is {model_id} — must match src/hal0/api/routes/slots.py::swap_slot.
+    await api(`/api/slots/${name}/swap`, {
       method: 'POST',
-      body: JSON.stringify({ model: swapModel.value }),
+      body: JSON.stringify({ model_id: modelId }),
     })
-    toasts.success(`Swapping model in "${swapSlot.value.name}"`)
+
+    // Step 2: persist to /etc/hal0/slots/<name>.toml so the change
+    // survives a restart.  Treated as a soft failure — runtime swap
+    // already succeeded, so we keep the modal closed and warn instead.
+    let persisted = true
+    try {
+      await api(`/api/install/slots/${name}/model`, {
+        method: 'PUT',
+        body: JSON.stringify({ model_id: modelId }),
+      })
+    } catch (persistErr) {
+      persisted = false
+      toasts.warning(
+        `Swapped "${name}" → ${modelId}, but failed to persist: ${persistErr.message}. ` +
+        `Change will revert on next restart.`
+      )
+    }
+    if (persisted) {
+      toasts.success(`Swapped "${name}" → ${modelId} (persisted)`)
+    }
     swapSlot.value = null
     swapModel.value = ''
     await system.fetchStatus()
@@ -773,7 +796,11 @@ const SLOT_TYPES = ['llama-server', 'flm', 'moonshine', 'kokoro']
                   </option>
                 </select>
               </div>
-              <p class="field-hint">The slot will reload with the new model. In-flight requests will complete first.</p>
+              <p class="field-hint">
+                The slot will reload with the new model — in-flight requests complete first.
+                The change is also written to <code class="mono">/etc/hal0/slots/{{ swapSlot?.name }}.toml</code>
+                so it survives a restart.
+              </p>
             </div>
             <div class="modal-footer">
               <button class="btn-ghost" type="button" @click="swapSlot = null" :disabled="swapping">Cancel</button>


### PR DESCRIPTION
## Summary
- Fixes UI swap modal that was silently broken (sent `{model}` instead of `{model_id}`)
- Makes both UI `Swap model` modal and `hal0 slot swap` persist the change to `/etc/hal0/slots/<slot>.toml` so it survives a restart
- Adds `PUT /api/install/slots/{slot}/model` as a persist-only counterpart to `POST /api/slots/{name}/swap` (keeps the runtime/disk concern split clean)
- CLI: `--no-persist` flag for tinkering (runtime-only swap)

## Why
Until today, swapping a slot's model meant SSH'ing to the host, editing `/etc/hal0/slots/<name>.toml`, and `systemctl restart hal0-slot@<name>.service` — a regression from the "polished home-AI inference platform" promise. The UI swap modal *looked* functional but quietly failed (body-shape mismatch), and even the CLI swap was runtime-only (lost on restart).

## What's verified
- 11/11 tests in `tests/api/test_installer_routes.py` pass (7 existing + 4 new covering: happy path, port/backend preservation, unknown model_id, empty model_id)
- Full `tests/api/` + `tests/cli/` suite: 142 passed, 3 skipped
- `ruff check` clean across the diff
- Format clean on changed files

## Test plan
- [x] API: `PUT /api/install/slots/primary/model` body `{"model_id":"qwen3.5-4b"}` rewrites `/etc/hal0/slots/primary.toml` atomically, preserves port/backend
- [x] API: unknown `model_id` → 400 `install.pick_default_failed`
- [x] API: empty/whitespace `model_id` → 400
- [ ] Manual UI: open Slots → click `Swap model` on a running slot → pick model → confirm runtime swap happens AND the change survives a `systemctl restart hal0-slot@primary.service`
- [ ] Manual CLI: `hal0 slot swap primary --model qwen3.5-4b` reports `(persisted)`; `hal0 slot swap primary --model phi3-mini --no-persist` reports `(runtime only; --no-persist set)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)