### PR TITLE
fix(stt): redact ffmpeg argv on transcode error (closes #33)

### DIFF
--- a/packaging/toolbox/moonshine/moonshine_server.py
+++ b/packaging/toolbox/moonshine/moonshine_server.py
@@ -91,8 +91,51 @@ def _load_model(model_arch: str, model_path: str | None) -> None:
 
 
 # ── Audio helpers ─────────────────────────────────────────────────────────────
+class UnsupportedAudioFormat(Exception):
+    """ffmpeg refused to decode the upload.
+
+    Raised by ``_decode_audio`` instead of letting ``CalledProcessError``
+    propagate — that exception's ``cmd`` attribute carries the full
+    ffmpeg argv including the user-supplied tempfile path, which then
+    leaks into the API response.  The route handler translates this to
+    a 415 with the hal0 envelope shape and no subprocess argv.
+    """
+
+    def __init__(self, returncode: int) -> None:
+        super().__init__(f"ffmpeg decode failed (rc={returncode})")
+        self.returncode = returncode
+
+
+def _redact_ffmpeg_argv(argv: list[str], input_path: str) -> list[str]:
+    """Return a copy of ``argv`` with the user-supplied input path masked.
+
+    Replaces any element equal to ``input_path`` with the placeholder
+    ``<input>`` so the server-side log line carries no temp-file path or
+    user-controlled filename. Everything else (codec flags, sample rate,
+    output path which is derived from the same temp name) is masked the
+    same way if it starts with ``input_path``.
+    """
+    redacted: list[str] = []
+    for arg in argv:
+        if arg == input_path:
+            redacted.append("<input>")
+        elif arg.startswith(input_path):
+            # out_path is `in_path + ".wav"`; keep the suffix visible for debugging.
+            redacted.append("<input>" + arg[len(input_path) :])
+        else:
+            redacted.append(arg)
+    return redacted
+
+
 def _decode_audio(raw: bytes, filename: str | None) -> np.ndarray:
-    """Decode arbitrary audio bytes to mono float32 @ 16kHz via ffmpeg."""
+    """Decode arbitrary audio bytes to mono float32 @ 16kHz via ffmpeg.
+
+    Raises :class:`UnsupportedAudioFormat` when ffmpeg refuses the input,
+    so the route handler can translate to a 415 with the hal0 envelope
+    instead of letting :class:`subprocess.CalledProcessError` propagate —
+    that exception's ``.cmd`` carries the full argv (and therefore the
+    user-supplied temp path) into the API response.
+    """
     # Fast path: if soundfile can read it natively (wav/flac/ogg), no ffmpeg.
     try:
         data, sr = sf.read(io.BytesIO(raw), dtype="float32")
@@ -121,14 +164,32 @@ def _decode_audio(raw: bytes, filename: str | None) -> np.ndarray:
         in_f.write(raw)
         in_path = in_f.name
     out_path = in_path + ".wav"
+    argv = [
+        "ffmpeg", "-y", "-loglevel", "error", "-i", in_path,
+        "-ac", "1", "-ar", str(SAMPLE_RATE), "-f", "wav", out_path,
+    ]
     try:
-        subprocess.run(
-            [
-                "ffmpeg", "-y", "-loglevel", "error", "-i", in_path,
-                "-ac", "1", "-ar", str(SAMPLE_RATE), "-f", "wav", out_path,
-            ],
-            check=True,
-        )
+        try:
+            subprocess.run(argv, check=True, capture_output=True)
+        except subprocess.CalledProcessError as exc:
+            # Log the full failure server-side with the user-supplied
+            # tempfile path masked. stderr from ffmpeg may include the
+            # input path too, so redact it the same way.
+            redacted_argv = _redact_ffmpeg_argv(argv, in_path)
+            stderr_text = ""
+            if exc.stderr:
+                try:
+                    stderr_text = exc.stderr.decode("utf-8", errors="replace")
+                except Exception:
+                    stderr_text = repr(exc.stderr)
+                stderr_text = stderr_text.replace(in_path, "<input>")
+            log.warning(
+                "ffmpeg decode failed rc=%d argv=%r stderr=%s",
+                exc.returncode,
+                redacted_argv,
+                stderr_text[:500],
+            )
+            raise UnsupportedAudioFormat(exc.returncode) from None
         data, _ = sf.read(out_path, dtype="float32")
         if data.ndim > 1:
             data = data.mean(axis=1)
@@ -209,6 +270,31 @@ async def transcriptions(
         raise HTTPException(status_code=400, detail="empty audio upload")
     try:
         pcm = _decode_audio(raw, file.filename)
+    except UnsupportedAudioFormat as exc:
+        # TODO(#32): swap HTTPException for a typed BadRequest subclass
+        # of Hal0Error once #32 lands so the envelope shape comes from
+        # the shared middleware. For now we hand-build the envelope to
+        # match the hal0 main proxy contract.
+        #
+        # Crucially: do NOT include ``exc.cmd`` / ``exc.stdout`` /
+        # ``exc.stderr`` from the underlying CalledProcessError — those
+        # carry the user-supplied tempfile path and stderr text from
+        # the upload, both of which would leak through the proxy.
+        raise HTTPException(
+            status_code=415,
+            detail={
+                "error": {
+                    "code": "audio.unsupported_format",
+                    "message": "Failed to decode audio input",
+                    # Field name is "decoder_returncode" not "ffmpeg_*" so
+                    # the response body contains no reference to the
+                    # underlying tool — issue #33 explicitly forbids the
+                    # substring "ffmpeg" in the response.
+                    "details": {"decoder_returncode": exc.returncode},
+                }
+            },
+        ) from None
+    try:
         text = _transcribe(pcm)
     except Exception as exc:  # noqa: BLE001 — return as 500
         log.exception("transcription failed")

--- a/tests/providers/test_moonshine_server.py
+++ b/tests/providers/test_moonshine_server.py
@@ -1,0 +1,122 @@
+"""Unit tests for the in-container moonshine_server FastAPI app.
+
+The server lives at ``packaging/toolbox/moonshine/moonshine_server.py``
+and is baked into the hal0-toolbox-moonshine image. It's not on the
+``hal0`` import path, so we load it by file path.
+
+Scope of this module: the audio-decode failure mode covered by hal0
+issue #33. The transcription model itself is heavy + ONNX-only and not
+in scope — every test here either skips the decode step entirely or
+swaps the model out before calling.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SERVER_PATH = _REPO_ROOT / "packaging" / "toolbox" / "moonshine" / "moonshine_server.py"
+
+
+def _load_moonshine_server() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("moonshine_server", _SERVER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["moonshine_server"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def server_module() -> types.ModuleType:
+    return _load_moonshine_server()
+
+
+@pytest.fixture
+def client(server_module: types.ModuleType) -> TestClient:
+    # The route short-circuits with 503 unless ``loaded`` is true, so flip
+    # the flag for the bad-input tests. _transcribe is never reached on
+    # these paths (decode fails first) so we don't need a real model.
+    server_module._state["loaded"] = True
+    server_module._state["model_arch"] = "small_streaming"
+    server_module._state["model_id"] = "moonshine-small-streaming-en"
+    return TestClient(server_module.app)
+
+
+# ── Redaction helper ──────────────────────────────────────────────────────────
+
+
+def test_redact_ffmpeg_argv_masks_input_path(server_module: types.ModuleType) -> None:
+    argv = [
+        "ffmpeg", "-y", "-loglevel", "error", "-i", "/tmp/tmp123abc.bin",
+        "-ac", "1", "-ar", "16000", "-f", "wav", "/tmp/tmp123abc.bin.wav",
+    ]
+    redacted = server_module._redact_ffmpeg_argv(argv, "/tmp/tmp123abc.bin")
+    # The standalone input path is fully masked.
+    assert "/tmp/tmp123abc.bin" not in redacted
+    assert "<input>" in redacted
+    # The output path (input + ".wav") keeps its suffix for debugging
+    # but the user-controlled prefix is masked.
+    assert "<input>.wav" in redacted
+    # Codec / format flags are untouched.
+    assert "-ar" in redacted
+    assert "16000" in redacted
+
+
+# ── /v1/audio/transcriptions on bad input ────────────────────────────────────
+
+
+def test_text_payload_returns_415_without_ffmpeg_argv(client: TestClient) -> None:
+    """Posting a text/plain payload (claimed audio/wav) must not leak ffmpeg argv.
+
+    This is the issue #33 acceptance test: send a non-audio body and
+    assert (a) the status is 4xx (415 specifically), (b) the response
+    body does not contain "ffmpeg", and (c) it does not contain any
+    tempfile path under /tmp.
+    """
+    files = {"file": ("hello.wav", b"this is not audio, just plain text", "audio/wav")}
+    resp = client.post("/v1/audio/transcriptions", files=files)
+
+    assert resp.status_code == 415, resp.text
+    body_text = resp.text
+    body_lower = body_text.lower()
+    # Acceptance: response body must not contain the subprocess argv.
+    assert "ffmpeg" not in body_lower, body_text
+    # Acceptance: response body must not contain a tempfile path.
+    assert "/tmp/" not in body_text, body_text
+    # Acceptance: stable hal0 envelope code is set.
+    payload = resp.json()
+    detail = payload.get("detail") or {}
+    error = detail.get("error") or {}
+    assert error.get("code") == "audio.unsupported_format"
+    assert "decode" in (error.get("message") or "").lower()
+    # The decoder returncode is exposed for client diagnostics, but the
+    # argv itself isn't. Note: field name is "decoder_returncode" — the
+    # substring "ffmpeg" must not appear anywhere in the body (issue #33).
+    assert "decoder_returncode" in (error.get("details") or {})
+
+
+def test_single_byte_payload_returns_415(client: TestClient) -> None:
+    """A 1-byte file claiming audio/wav is also rejected without leaks."""
+    files = {"file": ("tiny.wav", b"x", "audio/wav")}
+    resp = client.post("/v1/audio/transcriptions", files=files)
+
+    assert resp.status_code == 415, resp.text
+    assert "ffmpeg" not in resp.text.lower()
+    assert "/tmp/" not in resp.text
+
+
+def test_empty_upload_still_returns_400(client: TestClient) -> None:
+    """The pre-existing empty-upload guard is preserved — it short-circuits
+    before the decode path, so issue #33's 415 only applies to non-empty
+    bad input."""
+    files = {"file": ("empty.wav", b"", "audio/wav")}
+    resp = client.post("/v1/audio/transcriptions", files=files)
+    assert resp.status_code == 400
+    assert "empty" in resp.text.lower()


### PR DESCRIPTION
## Summary

- Catch `CalledProcessError` from the ffmpeg call in `moonshine_server._decode_audio` and re-raise as a small typed `UnsupportedAudioFormat` so the user-supplied tempfile path no longer leaks out through `CalledProcessError.cmd`.
- Translate that to **HTTP 415** with the hal0 envelope `{"error": {"code": "audio.unsupported_format", "message": "Failed to decode audio input", "details": {"decoder_returncode": <int>}}}` — no subprocess argv, no temp paths.
- Log the full ffmpeg failure (argv + stderr) server-side at WARN with the user-supplied input path masked to `<input>`.

Issue #33 explicitly forbids the substring `"ffmpeg"` in the response body, so the diagnostic field is named `decoder_returncode` rather than `ffmpeg_returncode`.

`TODO(#32)`: once typed `BadRequest` lands, replace the hand-built envelope with the shared middleware shape.

## Hard gates respected

- The transcription model wrapper (`_transcribe`) is untouched.
- The upload handling path (multipart parsing, tempfile creation in `_decode_audio`) is untouched — only the ffmpeg error path changes.
- `#32` hasn't merged, so the route raises plain `HTTPException(status_code=415, detail={...envelope...})` with a TODO pointing at the migration.

## Files

- `packaging/toolbox/moonshine/moonshine_server.py:130` — ffmpeg call site, now wrapped in `try/except CalledProcessError` with a redacting log line.
- `packaging/toolbox/moonshine/moonshine_server.py:94` — new `UnsupportedAudioFormat` exception + `_redact_ffmpeg_argv` helper.
- `packaging/toolbox/moonshine/moonshine_server.py:210` — `/v1/audio/transcriptions` route handler, now translates `UnsupportedAudioFormat -> HTTP 415` with the hal0 envelope.
- `tests/providers/test_moonshine_server.py` — new file. Loads the toolbox module by path (it isn't on the `hal0` import path) and exercises the route via `TestClient`.

## Test plan

- [x] `pytest tests/providers/test_moonshine_server.py -v` — 4 tests pass:
  - `_redact_ffmpeg_argv` masks the input path (standalone and as a prefix on the derived output path).
  - `text/plain` body claiming `audio/wav` returns 415 with the envelope, no `ffmpeg` substring in body, no `/tmp/` in body.
  - 1-byte payload returns 415 with the same guarantees.
  - The pre-existing empty-upload 400 guard still fires (not on the new path).
- [x] `pytest tests/providers/` — 101 tests pass, no regressions in the existing `test_moonshine.py` provider tests.

## Acceptance criteria from #33

- [x] POSTing a non-audio body returns 415 (not 500).
- [x] Response body carries the hal0 envelope with code `audio.unsupported_format`, no subprocess argv.
- [x] Unit test asserts status + absence of `"ffmpeg"` in the response body.
- [x] Server logs still capture the subprocess error for debugging (argv redacted).

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)