### PR TITLE
chore: harness port override + error envelope + SSE path docs (closes #38 #39 #40)

### DIFF
--- a/docs/api-errors.md
+++ b/docs/api-errors.md
@@ -1,0 +1,184 @@
+# API error envelopes
+
+hal0 exposes two HTTP surfaces and they return error payloads in
+**two different shapes** by design.  The shape you get depends on
+*who produced the error*, not just the path prefix:
+
+| Producer                                   | Envelope     | When                                             |
+|--------------------------------------------|--------------|--------------------------------------------------|
+| hal0 itself (auth, dispatch, slot, validation, anything internal) | hal0         | Any 4xx/5xx raised inside hal0, on **any** path |
+| Upstream provider (OpenAI, OpenRouter, llama-server, …) | OpenAI-shape | Only on `/v1/*` — when the dispatcher actually reached the upstream and the upstream's HTTP response was non-2xx |
+
+The asymmetry is by-design.  `/v1/*` is the OpenAI-compatibility
+proxy: when the dispatcher *does* reach the upstream, its response
+body is forwarded verbatim (see `Dispatcher._forward_direct` in
+`src/hal0/dispatcher/router.py`) — rewriting the envelope would
+break every OpenAI SDK that pattern-matches on `error.type` and
+`error.code`.  But errors hal0 raises *before* (or instead of)
+forwarding always carry the hal0 envelope.
+
+So in practice:
+
+- All errors on `/api/*` → hal0 envelope.
+- Errors on `/v1/*` that hal0 raised itself (missing auth,
+  unknown model, slot not ready, upstream unreachable, payload
+  validation, …) → hal0 envelope.
+- Errors on `/v1/*` that came back as the upstream's response →
+  OpenAI envelope.
+
+## hal0 envelope
+
+```json
+{
+  "error": {
+    "code": "slot.not_ready",
+    "message": "slot 'primary' is in state STARTING; retry once READY",
+    "details": {"slot": "primary", "state": "STARTING"}
+  }
+}
+```
+
+- `code` — dotted namespace (`auth.*`, `slot.*`, `model.*`, `dispatch.*`, `image.*`, `config.*`, `system.*`).  Stable across releases — safe to pattern-match.
+- `message` — human-readable.  Not stable; do not pattern-match.
+- `details` — open object with structured context (slot name, model id, etc.).  May be `{}`.
+
+Source: `Hal0Error` subclasses raised throughout the codebase,
+serialised by `hal0.api.middleware.error_codes._envelope()`.
+Unhandled `HTTPException`s get auto-wrapped with
+`code = "system.http_<status>"`; uncaught exceptions become
+`code = "system.internal"` at HTTP 500.
+
+## OpenAI envelope
+
+```json
+{
+  "error": {
+    "message": "Invalid value for 'model': 'gpt-5'.",
+    "type": "invalid_request_error",
+    "code": "model_not_found"
+  }
+}
+```
+
+- `message` — upstream provider's string.
+- `type` — coarse OpenAI category (`invalid_request_error`, `authentication_error`, `rate_limit_error`, `api_error`, …).
+- `code` — fine-grained OpenAI code (`model_not_found`, `context_length_exceeded`, …).  May be `null`.
+
+Source: the upstream provider's HTTP response body, byte-for-byte.
+hal0 does not synthesise this shape itself.
+
+## Examples by status
+
+### 400 — bad request
+
+`/api/slots` (hal0 envelope), invalid backend:
+
+```json
+{
+  "error": {
+    "code": "slot.invalid_config",
+    "message": "backend 'cuda' is not supported on this hardware (have: vulkan)",
+    "details": {"requested": "cuda", "available": ["vulkan"]}
+  }
+}
+```
+
+`/v1/chat/completions` (OpenAI envelope), upstream rejected a
+malformed body:
+
+```json
+{
+  "error": {
+    "message": "we could not parse the JSON body of your request",
+    "type": "invalid_request_error",
+    "code": null
+  }
+}
+```
+
+### 401 — unauthorized
+
+`/api/*` and `/v1/*` (hal0 envelope — auth runs before forwarding):
+
+```json
+{
+  "error": {
+    "code": "auth.required",
+    "message": "no bearer token presented",
+    "details": {}
+  }
+}
+```
+
+Same status, hal0 envelope on both surfaces, because the auth
+middleware refuses the request before it can reach an upstream.
+
+### 404 — not found
+
+`/api/slots/nope` (hal0 envelope):
+
+```json
+{
+  "error": {
+    "code": "slot.not_found",
+    "message": "no slot named 'nope'",
+    "details": {"slot": "nope"}
+  }
+}
+```
+
+`/v1/chat/completions` with an unbound model id — dispatch fails
+**before** reaching any upstream, so this is the hal0 envelope on
+a `/v1` path:
+
+```json
+{
+  "error": {
+    "code": "dispatch.no_route",
+    "message": "no upstream serves model 'gpt-5'",
+    "details": {"model": "gpt-5"}
+  }
+}
+```
+
+If the upstream *was* reached and itself returned 404, the response
+would be the OpenAI envelope verbatim.
+
+### 422 — unprocessable entity
+
+`/api/*` — FastAPI pydantic validation, auto-wrapped as
+`system.http_422`:
+
+```json
+{
+  "error": {
+    "code": "system.http_422",
+    "message": "[{'loc': ['body', 'name'], 'msg': 'field required', 'type': 'value_error.missing'}]",
+    "details": {}
+  }
+}
+```
+
+`/v1/images/generations` missing `prompt` — raised as a
+`Hal0Error` subclass inside the route, so this is the hal0
+envelope on a `/v1` URL:
+
+```json
+{
+  "error": {
+    "code": "image.prompt_required",
+    "message": "body.prompt is required",
+    "details": {}
+  }
+}
+```
+
+## Guidance for clients
+
+- **hal0-internal callers** (CLI, dashboard, integration tests): pin
+  to the hal0 envelope and match on `error.code` (stable).
+- **OpenAI-SDK callers**: hit `/v1/*` only.  Be defensive — a
+  pre-upstream failure (auth refused, no route, slot not ready)
+  surfaces the hal0 envelope on a `/v1` URL.  Treat the response as
+  "either OpenAI envelope or hal0 envelope" and fall back to HTTP
+  status code + `error.message` when `error.type` is absent.

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -4,6 +4,14 @@ Phase 1: real SlotManager-backed lifecycle wired alongside synthetic
 upstream-backed entries. Real slots win on name collision; synthetic
 entries persist for remote-upstream visibility in the dashboard until
 every upstream has a corresponding local slot.
+
+SSE endpoints (note: there is no ``/api/slots/{name}/events`` — the
+stream is split by concern):
+
+- ``GET /api/slots/{name}/state/stream`` — state-machine transitions
+  for one slot (``starting → warming → ready → serving → idle …``).
+- ``GET /api/slots/{name}/logs/stream`` — line-by-line journal tail
+  for the slot's systemd unit.
 """
 
 from __future__ import annotations

--- a/tests/harness/README.md
+++ b/tests/harness/README.md
@@ -303,6 +303,7 @@ hand or re-run `installer-test.sh` first.
 | `HAL0_HARNESS_AUTH=1` | Enable `--auth=basic` install (Caddy + bcrypt + bearer tokens). Implies PROD=1. | `installer-test.sh:auth-basic` |
 | `HAL0_HARNESS_KEEP=1` | When running `installer-test.sh` standalone, keep the tmp prefix after exit. No effect through the orchestrator (orchestrator always cleans). | `installer-test.sh` |
 | `HAL0_HARNESS_API_PORT=<n>` | Port `hal0 serve` binds during the install test (default 18080). | `installer-test.sh:dev-api-up` |
+| `HAL0_DOCTOR_PORTS="<p1> <p2>..."` | Space-separated TCP ports `hal0 doctor`'s port-collision check probes. Defaults to `"18080 13001"` inside `cli-test.sh` so the row doesn't trip on a co-resident prod install bound to the canonical `8080 3001`. Override to match your dev install if non-default. | `cli-test.sh:cli-doctor` |
 
 The orchestrator passes the environment through unchanged, so set
 these in front of `bash scripts/harness.sh`.

--- a/tests/harness/cli-test.sh
+++ b/tests/harness/cli-test.sh
@@ -32,9 +32,13 @@
 #   cli-model-rm            hal0 model rm <id> --force
 #
 # Env knobs:
-#   HAL0_API_URL    base URL (default http://127.0.0.1:18080)
-#   HAL0_HOME       prefix root (default /tmp/hal0-h)
-#   HAL0_BIN        binary path (default ${HAL0_HOME}/.venv/bin/hal0)
+#   HAL0_API_URL        base URL (default http://127.0.0.1:18080)
+#   HAL0_HOME           prefix root (default /tmp/hal0-h)
+#   HAL0_BIN            binary path (default ${HAL0_HOME}/.venv/bin/hal0)
+#   HAL0_DOCTOR_PORTS   space-separated TCP ports for `hal0 doctor`
+#                       port-collision check (default "18080 13001" — the
+#                       dev install's ports, so a co-resident prod install
+#                       on 8080/3001 doesn't poison the cli-doctor row).
 
 set -euo pipefail
 IFS=$'\n\t'
@@ -56,8 +60,13 @@ fi
 : "${HAL0_API_URL:=http://127.0.0.1:18080}"
 : "${HAL0_HOME:=/tmp/hal0-h}"
 : "${HAL0_BIN:=${HAL0_HOME}/.venv/bin/hal0}"
+# When a prod hal0 install is co-resident on this host it owns the
+# default doctor port list (8080 + 3001). Probe the dev install's
+# ports instead so cli-doctor doesn't report a false-positive
+# collision. An externally-set HAL0_DOCTOR_PORTS still wins.
+: "${HAL0_DOCTOR_PORTS:=18080 13001}"
 
-export HAL0_API_URL HAL0_HOME
+export HAL0_API_URL HAL0_HOME HAL0_DOCTOR_PORTS
 
 log_step "CLI harness — bin=${HAL0_BIN}  api=${HAL0_API_URL}  home=${HAL0_HOME}"
 


### PR DESCRIPTION
## Summary

Three independent low-risk doc/harness chores in one PR:

- **#38** — `cli-test.sh` now sets `HAL0_DOCTOR_PORTS="${HAL0_DOCTOR_PORTS:-18080 13001}"` so the `cli-doctor` row probes the dev install's ports instead of the prod defaults (8080 + 3001). A co-resident prod install no longer poisons the harness exit code. README §9 documents the knob.
- **#39** — New `docs/api-errors.md` documents the hal0 envelope (`/api/*` + any hal0-raised error) vs the OpenAI envelope (upstream-passthrough on `/v1/*`) side by side with 400/401/404/422 examples. The actual rule is "hal0-produced → hal0 envelope; upstream-passed-through → OpenAI envelope" — not strictly path-based — and the doc spells that out so OpenAI-SDK callers know to fall back when a dispatch-time failure surfaces a hal0 envelope on a `/v1` URL.
- **#40** — Audited `docs/`, `tests/`, and top-level markdown for the stale `/api/slots/{name}/events` reference — no occurrences remained; CONTRIBUTING and the 2026-05-15 handoff already use the canonical `/state/stream` and `/logs/stream`. Added a paragraph to `src/hal0/api/routes/slots.py`'s module docstring enumerating both SSE endpoints so the next grep lands cleanly.

## Test plan

- [ ] Re-run `bash scripts/harness.sh` on a host with a co-resident prod install bound to 8080/3001 and confirm the `cli-doctor` row is `pass` (or `deferred` with a non-collision rationale), not `fail`.
- [ ] Override `HAL0_DOCTOR_PORTS=9999` in front of the harness; confirm the doctor row probes 9999 (override wins).
- [ ] Open `docs/api-errors.md` and confirm the rendered table + examples read correctly on GitHub.
- [ ] `grep -rn "/api/slots/.*/events" --include="*.md" --include="*.py" .` returns empty (current state).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>