### PR TITLE
feat(errors): typed 4xx subclasses + validation envelope handler (closes #32)

### DIFF
--- a/src/hal0/api/middleware/error_codes.py
+++ b/src/hal0/api/middleware/error_codes.py
@@ -4,11 +4,18 @@ All non-2xx responses follow:
 
     {"error": {"code": "<namespace>.<reason>", "message": "...", "details": {...}}}
 
-Error code namespaces: slot.*, model.*, dispatch.*, config.*, system.*
+Error code namespaces: slot.*, model.*, dispatch.*, config.*, system.*,
+auth.*, validation.*, resource.*
 
-This middleware catches uncaught exceptions and unhandled HTTPExceptions
-and reshapes their JSON body. Handlers that raise typed `Hal0Error`
-subclasses get their `code` and `details` propagated as-is.
+This middleware catches uncaught exceptions, unhandled HTTPExceptions, and
+FastAPI's pydantic ``RequestValidationError`` and reshapes their JSON body.
+Handlers that raise typed :class:`Hal0Error` subclasses get their ``code``
+and ``details`` propagated as-is.
+
+The typed 4xx subclasses (``BadRequest``, ``Unauthorized``, ``Forbidden``,
+``NotFound``, ``Conflict``, ``UnprocessableEntity``) live in
+:mod:`hal0.errors` and are re-exported here for the import path most
+routes already use.
 """
 
 from __future__ import annotations
@@ -17,16 +24,48 @@ from typing import Any
 
 import structlog
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from hal0.errors import Hal0Error
+from hal0.errors import (
+    BadRequest,
+    Conflict,
+    Forbidden,
+    Hal0Error,
+    NotFound,
+    Unauthorized,
+    UnprocessableEntity,
+)
 
 log = structlog.get_logger(__name__)
 
 
 def _envelope(code: str, message: str, details: dict[str, Any] | None = None) -> dict[str, Any]:
     return {"error": {"code": code, "message": message, "details": details or {}}}
+
+
+def _shape_validation_errors(exc: RequestValidationError) -> list[dict[str, Any]]:
+    """Reshape pydantic's per-field error dicts into a stable envelope-friendly form.
+
+    Pydantic emits a list of ``{type, loc, msg, input, ctx, url}`` dicts.
+    The envelope contract keeps ``loc`` (so the client knows which field
+    failed), ``msg`` (human-readable), and ``type`` (machine-readable
+    error kind) — and drops the rest to keep the response small and
+    schema-stable. The full pydantic payload remains accessible via
+    structured logs for server-side debugging.
+    """
+    shaped: list[dict[str, Any]] = []
+    for err in exc.errors():
+        loc = err.get("loc", ())
+        shaped.append(
+            {
+                "loc": list(loc),
+                "msg": err.get("msg", ""),
+                "type": err.get("type", ""),
+            }
+        )
+    return shaped
 
 
 def install(app: FastAPI) -> None:
@@ -36,6 +75,31 @@ def install(app: FastAPI) -> None:
         return JSONResponse(
             status_code=exc.status,
             content=_envelope(exc.code, exc.message, exc.details),
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def _validation_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+        # FastAPI's pydantic validator fires for missing/invalid query, path,
+        # and body parameters. Without this handler clients see FastAPI's
+        # default ``{"detail": [...]}`` shape, which doesn't match the hal0
+        # envelope contract. We reshape into the canonical envelope and
+        # downgrade the status from 422 to 400 — these are caller-side input
+        # errors, not "well-formed but semantically rejected" requests
+        # (UnprocessableEntity is reserved for that meaning).
+        errors = _shape_validation_errors(exc)
+        log.info(
+            "hal0.validation_error",
+            path=request.url.path,
+            method=request.method,
+            errors=errors,
+        )
+        return JSONResponse(
+            status_code=400,
+            content=_envelope(
+                "validation.invalid",
+                "request validation failed",
+                {"errors": errors},
+            ),
         )
 
     @app.exception_handler(StarletteHTTPException)
@@ -56,4 +120,13 @@ def install(app: FastAPI) -> None:
         )
 
 
-__all__ = ["Hal0Error", "install"]
+__all__ = [
+    "BadRequest",
+    "Conflict",
+    "Forbidden",
+    "Hal0Error",
+    "NotFound",
+    "Unauthorized",
+    "UnprocessableEntity",
+    "install",
+]

--- a/src/hal0/api/routes/auth.py
+++ b/src/hal0/api/routes/auth.py
@@ -37,7 +37,7 @@ from hal0.auth.tokens import (
     auth_enabled,
     get_or_create_store,
 )
-from hal0.errors import Hal0Error
+from hal0.errors import BadRequest
 
 router = APIRouter()
 
@@ -143,12 +143,13 @@ async def create_token(request: Request) -> dict[str, Any]:
     try:
         body = await request.json()
     except Exception as exc:
-        raise Hal0Error(
+        raise BadRequest(
             "request body must be valid JSON",
             details={"error": str(exc)},
+            code="request.invalid_json",
         ) from exc
     if not isinstance(body, dict):
-        raise Hal0Error("request body must be a JSON object")
+        raise BadRequest("request body must be a JSON object", code="request.not_an_object")
 
     label = str(body.get("label") or "").strip()
     scope = str(body.get("scope") or "all").strip() or "all"

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -15,7 +15,7 @@ from typing import Any
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
-from hal0.api.middleware.error_codes import Hal0Error
+from hal0.api.middleware.error_codes import BadRequest, Hal0Error
 from hal0.slots.manager import Slot, SlotManager
 
 router = APIRouter()
@@ -162,16 +162,20 @@ async def create_slot(request: Request) -> dict[str, object]:
     try:
         body = await request.json()
     except Exception as exc:
-        raise Hal0Error(
+        raise BadRequest(
             "request body must be valid JSON",
             details={"error": str(exc)},
+            code="request.invalid_json",
         ) from exc
     if not isinstance(body, dict):
-        raise Hal0Error("request body must be a JSON object")
+        raise BadRequest("request body must be a JSON object", code="request.not_an_object")
 
     name = body.get("name")
     if not isinstance(name, str) or not name.strip():
-        raise Hal0Error("slot 'name' is required (non-empty string)")
+        raise BadRequest(
+            "slot 'name' is required (non-empty string)",
+            code="slot.name_required",
+        )
 
     snap = await sm.create(name, body)
     return _slot_to_dict(snap, request)

--- a/src/hal0/errors.py
+++ b/src/hal0/errors.py
@@ -4,6 +4,30 @@ Lives here (not in ``hal0.api.middleware.error_codes``) so non-api modules
 — probes, loaders, providers — can raise typed errors without triggering
 the api import chain. The middleware re-exports ``Hal0Error`` for the
 import path everything else has always used.
+
+Typed 4xx subclasses
+====================
+
+For the common HTTP client-error statuses, this module also provides
+ready-to-raise subclasses that set ``status`` correctly. Each one carries
+a sensible default ``code`` in the appropriate namespace, but callers can
+override the code per-raise to keep code strings stable and descriptive.
+
+Example::
+
+    from hal0.errors import BadRequest, NotFound
+
+    if not body.get("name"):
+        raise BadRequest("'name' is required", code="slot.name_missing")
+
+    slot = registry.get(name)
+    if slot is None:
+        raise NotFound(f"slot {name!r} not found", code="slot.not_found")
+
+The api error envelope middleware (:mod:`hal0.api.middleware.error_codes`)
+catches these uniformly with the rest of the ``Hal0Error`` family and
+renders them as the canonical envelope ``{"error": {"code", "message",
+"details"}}`` with the right HTTP status.
 """
 
 from __future__ import annotations
@@ -21,10 +45,141 @@ class Hal0Error(Exception):
     code: str = "system.internal"
     status: int = 500
 
-    def __init__(self, message: str, details: dict[str, Any] | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        details: dict[str, Any] | None = None,
+        *,
+        code: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.message = message
         self.details = details or {}
+        # Per-instance code override — lets callers raise the generic 4xx
+        # subclasses (BadRequest, NotFound, ...) without sub-subclassing
+        # for every distinct error site. Defaults to the class attribute
+        # so existing subclass-driven sites keep working unchanged.
+        if code is not None:
+            self.code = code
 
 
-__all__ = ["Hal0Error"]
+# ── Typed 4xx subclasses ─────────────────────────────────────────────────────
+#
+# These cover the everyday client-error statuses. They're deliberately thin —
+# the api middleware does the envelope rendering. Each subclass sets the
+# correct ``status`` plus a default ``code`` in a sensible namespace.
+#
+# Per the hal0 error envelope contract (see docs/error-envelope.md / #39),
+# every non-2xx ``/api/*`` response carries ``{"error": {"code", "message",
+# "details"}}``. These subclasses are the ergonomic on-ramp for routes that
+# want the right status + envelope shape without inventing a new exception
+# class per call site.
+
+
+class BadRequest(Hal0Error):
+    """400 — the request was syntactically or semantically invalid.
+
+    Use this for client-side validation failures the route itself catches
+    (missing fields, malformed JSON, unparseable values) before any business
+    logic runs.
+
+    Example::
+
+        raise BadRequest("'name' must be a non-empty string")
+        raise BadRequest("unknown backend", code="slot.unknown_backend",
+                         details={"backend": value})
+    """
+
+    code = "validation.invalid"
+    status = 400
+
+
+class Unauthorized(Hal0Error):
+    """401 — no valid credentials presented.
+
+    Use when the caller needs to authenticate but didn't, or presented
+    credentials that didn't validate. For authenticated-but-insufficient,
+    use :class:`Forbidden` instead.
+
+    Example::
+
+        raise Unauthorized("missing bearer token", code="auth.required")
+    """
+
+    code = "auth.required"
+    status = 401
+
+
+class Forbidden(Hal0Error):
+    """403 — authenticated but the credentials lack the required scope.
+
+    Example::
+
+        raise Forbidden("admin scope required", code="auth.forbidden")
+    """
+
+    code = "auth.forbidden"
+    status = 403
+
+
+class NotFound(Hal0Error):
+    """404 — the named resource does not exist.
+
+    Example::
+
+        raise NotFound(f"slot {name!r} not found", code="slot.not_found")
+    """
+
+    code = "resource.not_found"
+    status = 404
+
+
+class Conflict(Hal0Error):
+    """409 — the request conflicts with current resource state.
+
+    Use for duplicate-create attempts, edit-vs-edit races, or operations
+    that aren't valid for the resource's current lifecycle state.
+
+    Example::
+
+        raise Conflict("slot is already running", code="slot.already_running")
+    """
+
+    code = "resource.conflict"
+    status = 409
+
+
+class UnprocessableEntity(Hal0Error):
+    """422 — the request was well-formed but failed business-rule validation.
+
+    Distinct from :class:`BadRequest` (400) which signals structural or
+    syntactic failures. Use 422 when the shape is correct but the values
+    are semantically incompatible (e.g. cross-field constraints).
+
+    Note: FastAPI's automatic pydantic validation also produces 422s — those
+    are caught by ``hal0.api.middleware.error_codes`` and reshaped into the
+    envelope automatically. Raise this class explicitly for hand-written
+    validation in route bodies.
+
+    Example::
+
+        raise UnprocessableEntity(
+            "start_at must be earlier than end_at",
+            code="schedule.invalid_window",
+            details={"start_at": start, "end_at": end},
+        )
+    """
+
+    code = "validation.unprocessable"
+    status = 422
+
+
+__all__ = [
+    "BadRequest",
+    "Conflict",
+    "Forbidden",
+    "Hal0Error",
+    "NotFound",
+    "Unauthorized",
+    "UnprocessableEntity",
+]

--- a/tests/api/test_logs_routes.py
+++ b/tests/api/test_logs_routes.py
@@ -31,16 +31,23 @@ def test_logs_happy_path_returns_lines_and_count(client: TestClient) -> None:
 
 
 def test_logs_validation_error_envelope_for_missing_unit(client: TestClient) -> None:
-    """Missing unit query param yields a 422 (FastAPI's default validation shape)."""
+    """Missing unit query param yields a 400 in the hal0 envelope shape.
+
+    The ``RequestValidationError`` handler (see
+    ``hal0.api.middleware.error_codes``) reshapes FastAPI's default
+    ``{"detail": [...]}`` 422 into the canonical envelope with
+    ``code="validation.invalid"`` and downgrades the status to 400 —
+    pydantic-driven validation failures are caller-side input errors,
+    not "well-formed but semantically rejected".
+    """
     r = client.get("/api/logs")
-    # FastAPI's RequestValidationError handler stays the framework
-    # default (``{"detail": [...]}``) — the structured envelope kicks in
-    # for typed Hal0Error subclasses, not Pydantic-driven query validation.
-    assert r.status_code == 422
+    assert r.status_code == 400
     body = r.json()
-    # Either shape is acceptable; we assert that *some* error structure
-    # is present so a client can render it.
-    assert ("error" in body) or ("detail" in body)
+    assert "error" in body, f"Expected hal0 envelope, got {body}"
+    assert body["error"]["code"] == "validation.invalid"
+    assert "errors" in body["error"]["details"]
+    assert isinstance(body["error"]["details"]["errors"], list)
+    assert body["error"]["details"]["errors"], "expected at least one error entry"
 
 
 def test_logs_invalid_unit_returns_typed_envelope(client: TestClient) -> None:
@@ -62,11 +69,17 @@ def test_logs_invalid_level_returns_typed_envelope(client: TestClient) -> None:
 
 
 def test_logs_n_out_of_range_returns_envelope(client: TestClient) -> None:
-    """?n=0 is below the validator floor and yields a 422 (validation error)."""
+    """?n=0 is below the validator floor and yields the hal0 envelope.
+
+    Pydantic-driven validation is reshaped by the ``RequestValidationError``
+    handler in ``hal0.api.middleware.error_codes`` into the canonical
+    envelope with ``code="validation.invalid"`` and downgraded to 400.
+    """
     r = client.get("/api/logs", params={"unit": "hal0-api", "n": 0})
-    assert r.status_code == 422
+    assert r.status_code == 400
     body = r.json()
-    assert ("error" in body) or ("detail" in body)
+    assert body["error"]["code"] == "validation.invalid"
+    assert "errors" in body["error"]["details"]
 
 
 def test_logs_stream_returns_sse_content_type(client: TestClient) -> None:

--- a/tests/api/test_typed_errors.py
+++ b/tests/api/test_typed_errors.py
@@ -1,0 +1,242 @@
+"""Tests for the typed 4xx ``Hal0Error`` subclasses and the
+``RequestValidationError`` envelope handler.
+
+Each subclass test asserts:
+- The correct HTTP status is set on the response.
+- The response body is the canonical envelope shape
+  ``{"error": {"code", "message", "details"}}``.
+- A per-instance ``code=`` override propagates through the middleware.
+- A ``details=`` dict round-trips.
+
+The pydantic-validation test asserts that a missing query parameter
+no longer returns FastAPI's default 422 ``{"detail": [...]}`` shape;
+instead it returns 400 with ``code="validation.invalid"`` and an
+``errors`` list under ``details``.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Query
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+from hal0.api.middleware.error_codes import install as install_error_codes
+from hal0.errors import (
+    BadRequest,
+    Conflict,
+    Forbidden,
+    Hal0Error,
+    NotFound,
+    Unauthorized,
+    UnprocessableEntity,
+)
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def app() -> FastAPI:
+    """A minimal FastAPI app with only the error-envelope middleware installed.
+
+    Keeps these tests isolated from the full ``create_app()`` lifespan so they
+    exercise the error path and nothing else.
+    """
+    app = FastAPI()
+    install_error_codes(app)
+    return app
+
+
+@pytest.fixture()
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ── Subclass status + envelope round-trip ───────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("exc_cls", "expected_status", "expected_default_code"),
+    [
+        (BadRequest, 400, "validation.invalid"),
+        (Unauthorized, 401, "auth.required"),
+        (Forbidden, 403, "auth.forbidden"),
+        (NotFound, 404, "resource.not_found"),
+        (Conflict, 409, "resource.conflict"),
+        (UnprocessableEntity, 422, "validation.unprocessable"),
+    ],
+)
+def test_typed_4xx_subclass_renders_envelope(
+    app: FastAPI,
+    client: TestClient,
+    exc_cls: type[Hal0Error],
+    expected_status: int,
+    expected_default_code: str,
+) -> None:
+    """Each subclass surfaces with the right status and default code, and
+    the envelope keeps the constructor-supplied message and details."""
+
+    @app.get(f"/test/{exc_cls.__name__.lower()}")
+    async def _raise() -> None:
+        raise exc_cls(
+            f"{exc_cls.__name__} message",
+            details={"k": "v"},
+        )
+
+    r = client.get(f"/test/{exc_cls.__name__.lower()}")
+    assert r.status_code == expected_status
+
+    body = r.json()
+    assert "error" in body, f"missing envelope wrapper: {body}"
+    err = body["error"]
+    assert err["code"] == expected_default_code
+    assert err["message"] == f"{exc_cls.__name__} message"
+    assert err["details"] == {"k": "v"}
+
+
+def test_code_override_propagates(app: FastAPI, client: TestClient) -> None:
+    """Passing ``code=`` to a subclass constructor overrides the class default."""
+
+    @app.get("/test/code-override")
+    async def _raise() -> None:
+        raise BadRequest("bad slot name", code="slot.invalid_name")
+
+    r = client.get("/test/code-override")
+    assert r.status_code == 400
+    body = r.json()
+    assert body["error"]["code"] == "slot.invalid_name"
+    assert body["error"]["message"] == "bad slot name"
+
+
+def test_details_default_empty_dict(app: FastAPI, client: TestClient) -> None:
+    """Omitting details yields ``details: {}`` in the envelope (never null)."""
+
+    @app.get("/test/no-details")
+    async def _raise() -> None:
+        raise NotFound("slot 'primary' not found")
+
+    r = client.get("/test/no-details")
+    body = r.json()
+    assert body["error"]["details"] == {}
+
+
+def test_existing_subclass_pattern_still_works(app: FastAPI, client: TestClient) -> None:
+    """The constructor change must not break the pre-existing pattern of
+    sub-subclassing for stable codes (e.g. ``AuthRequired`` in
+    ``hal0.api.middleware.auth``)."""
+
+    class TeapotError(Hal0Error):
+        code = "test.teapot"
+        status = 418
+
+    @app.get("/test/teapot")
+    async def _raise() -> None:
+        raise TeapotError("teapot")
+
+    r = client.get("/test/teapot")
+    assert r.status_code == 418
+    assert r.json()["error"]["code"] == "test.teapot"
+
+
+# ── FastAPI RequestValidationError handler ──────────────────────────────────
+
+
+class _Color(StrEnum):
+    red = "red"
+    blue = "blue"
+
+
+class _Body(BaseModel):
+    name: str
+    count: int
+
+
+def _register_validation_routes(app: FastAPI) -> None:
+    @app.get("/test/needs-query")
+    async def _needs_query(unit: str = Query(...)) -> dict[str, Any]:
+        return {"unit": unit}
+
+    @app.post("/test/needs-body")
+    async def _needs_body(body: _Body) -> dict[str, Any]:
+        return body.model_dump()
+
+    @app.get("/test/needs-enum")
+    async def _needs_enum(color: _Color = Query(...)) -> dict[str, Any]:
+        return {"color": color.value}
+
+
+def test_missing_query_param_returns_envelope(app: FastAPI, client: TestClient) -> None:
+    """Missing required query param yields 400 + the hal0 envelope.
+
+    FastAPI's default is 422 ``{"detail": [...]}`` — the
+    ``RequestValidationError`` handler downgrades to 400 (caller input
+    error) and reshapes into the canonical envelope.
+    """
+    _register_validation_routes(app)
+
+    r = client.get("/test/needs-query")
+
+    assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+    body = r.json()
+    assert "error" in body, f"expected hal0 envelope, got {body}"
+    assert body["error"]["code"] == "validation.invalid"
+    assert body["error"]["message"] == "request validation failed"
+    errors = body["error"]["details"]["errors"]
+    assert isinstance(errors, list) and len(errors) >= 1
+    err = errors[0]
+    # Shape: {loc: [...], msg: str, type: str}
+    assert set(err.keys()) == {"loc", "msg", "type"}
+    assert "unit" in err["loc"]
+
+
+def test_missing_body_field_returns_envelope(app: FastAPI, client: TestClient) -> None:
+    """A missing required field in a JSON body surfaces in ``details.errors``."""
+    _register_validation_routes(app)
+
+    r = client.post("/test/needs-body", json={"name": "x"})  # missing ``count``
+
+    assert r.status_code == 400
+    body = r.json()
+    assert body["error"]["code"] == "validation.invalid"
+    errors = body["error"]["details"]["errors"]
+    locs = [tuple(e["loc"]) for e in errors]
+    assert any("count" in loc for loc in locs), f"expected 'count' in {locs}"
+
+
+def test_invalid_enum_value_returns_envelope(app: FastAPI, client: TestClient) -> None:
+    """A value outside the enum yields the same shape (not just missing-field)."""
+    _register_validation_routes(app)
+
+    r = client.get("/test/needs-enum", params={"color": "purple"})
+
+    assert r.status_code == 400
+    body = r.json()
+    assert body["error"]["code"] == "validation.invalid"
+    errors = body["error"]["details"]["errors"]
+    assert errors, "expected at least one validation error"
+    # The pydantic ``type`` for invalid enums starts with ``enum``.
+    assert any(e["type"].startswith("enum") for e in errors), errors
+
+
+def test_raised_unprocessable_entity_is_distinct_from_validation_handler(
+    app: FastAPI, client: TestClient
+) -> None:
+    """Manually-raised ``UnprocessableEntity`` keeps its 422 status — only the
+    pydantic-driven validation path is downgraded to 400."""
+
+    @app.post("/test/manual-422")
+    async def _raise() -> None:
+        raise UnprocessableEntity(
+            "start_at must precede end_at",
+            code="schedule.invalid_window",
+            details={"start_at": 10, "end_at": 5},
+        )
+
+    r = client.post("/test/manual-422")
+    assert r.status_code == 422
+    body = r.json()
+    assert body["error"]["code"] == "schedule.invalid_window"
+    assert body["error"]["details"] == {"start_at": 10, "end_at": 5}


### PR DESCRIPTION
## Summary

Closes #32.

- Adds typed `Hal0Error` 4xx subclasses (`BadRequest` 400, `Unauthorized` 401, `Forbidden` 403, `NotFound` 404, `Conflict` 409, `UnprocessableEntity` 422) in `hal0.errors`, each with a sensible default `code` and an optional per-instance `code=` override so routes can pick a stable namespaced code per error site without sub-subclassing.
- Registers a `RequestValidationError` handler in `hal0.api.middleware.error_codes` that reshapes FastAPI's default `{"detail": [...]}` 422 into the canonical envelope `{"error": {"code, message, details: {errors: [...]}}}` with `code="validation.invalid"`, downgrading the status to 400 (caller-side input errors, not "well-formed but semantically rejected" — that meaning is reserved for explicit `UnprocessableEntity` raises).
- Re-exports the new subclasses from `hal0.api.middleware.error_codes` so routes can use the import path most of them already use.

## Scope

This is the **foundation** for the wave-2 cleanup (#34/#35/#36/#37) — those issues should rebase on this branch. The PR only refactors two sanity-test call sites (auth + slots body validation) to prove the round-trip; bulk migration of every existing `Hal0Error("...")` raise is intentionally out of scope here.

The `/v1/*` (OpenAI-shaped) error path is untouched — those routes already use typed `DispatchError` subclasses and share the same middleware envelope today.

## What's new

- `hal0.errors.BadRequest`
- `hal0.errors.Unauthorized`
- `hal0.errors.Forbidden`
- `hal0.errors.NotFound`
- `hal0.errors.Conflict`
- `hal0.errors.UnprocessableEntity`

All re-exported from `hal0.api.middleware.error_codes`.

Handler registration (lives inside `install(app)` in `error_codes.py`):

```python
@app.exception_handler(RequestValidationError)
async def _validation_handler(request, exc): ...
```

## Test plan

- [x] `tests/api/test_typed_errors.py` parametrizes all six subclasses against status + envelope round-trip, plus `code=` override, `details` defaulting, and the legacy sub-subclass pattern.
- [x] Three pydantic-driven validation scenarios covered: missing query param, missing body field, invalid enum value.
- [x] Manually-raised `UnprocessableEntity` keeps its 422 (distinct from the auto-downgraded pydantic path).
- [x] `tests/api/test_logs_routes.py` updated for the new envelope shape on missing/out-of-range params.
- [x] Full test suite: 665 passed, 6 skipped (`pytest tests/ --ignore=tests/harness`).
- [x] `ruff check` + `ruff format --check` clean on touched files.
- [x] `mypy` clean on `hal0/errors.py` + `hal0/api/middleware/error_codes.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)