### PR TITLE
fix(auth): enforce writer scope on admin router mutations (#29)

### DIFF
--- a/src/hal0/api/middleware/auth.py
+++ b/src/hal0/api/middleware/auth.py
@@ -1,12 +1,35 @@
 """Bearer-token + Caddy-edge authentication dependency.
 
-This module exposes two FastAPI dependencies:
+This module exposes four FastAPI dependencies:
 
-  - :func:`require_token` — gates a single route or router.
+  - :func:`require_token` — gates a single route or router. Accepts any
+    valid scope (used as the *reader* gate on admin routers).
   - :func:`require_token_unless_public` — gates a router globally but
     bypasses the auth check for paths in :data:`PUBLIC_PATHS`. This is
     what we attach at ``include_router(...)`` time on routers that mix
     public and protected endpoints (``/v1`` and ``/api/install``).
+  - :func:`require_writer` — gates a single mutating route. Requires an
+    ``admin``- or ``all``-scoped credential; ``read-only`` and
+    ``v1-only`` are rejected with 403 ``auth.forbidden``.
+  - :func:`require_admin` — strictest gate, only ``admin`` scope. Used
+    on the token-CRUD subrouter.
+
+Scope × verb matrix (admin routers: ``/api/slots``, ``/api/models``,
+``/api/settings``, ``/api/hardware``, ``/api/logs``, ``/api/providers``,
+``/api/updates``, ``/api/images``)::
+
+    scope       | GET (reader)       | POST/PUT/PATCH/DELETE (writer)
+    ------------+--------------------+-------------------------------
+    admin       | 200                | 200
+    all         | 200                | 200
+    read-only   | 200                | 403 auth.forbidden
+    v1-only     | 200                | 403 auth.forbidden
+    (no creds)  | 401 auth.required  | 401 auth.required
+    (bad creds) | 401 auth.invalid   | 401 auth.invalid
+
+When ``HAL0_AUTH_ENABLED`` is unset, every dependency is a pass-through
+that returns ``identity="anonymous", scope="all"`` — so the gate
+collapses to "open" on the trusted-LAN install posture.
 
 Public route allowlist
 ----------------------
@@ -87,6 +110,13 @@ _ANONYMOUS_SCOPE = "all"
 # Identity scope returned for an X-Forwarded-Email-only auth path. Caddy
 # basic_auth users are dashboard owners, so they get admin.
 _FORWARDED_SCOPE = "admin"
+
+# Scopes permitted to mutate admin resources. "admin" can do anything
+# (including token CRUD); "all" is the default minted scope for general
+# clients and is treated as a writer for parity with pre-scope behaviour.
+# "read-only" and "v1-only" are explicitly excluded — they get 403 on
+# any mutating route.
+_WRITER_SCOPES: frozenset[str] = frozenset({"admin", "all"})
 
 
 # Routes that bypass auth even when HAL0_AUTH_ENABLED=1. Match exact paths
@@ -306,6 +336,33 @@ async def require_admin(
     return identity
 
 
+async def require_writer(
+    identity: Annotated[AuthIdentity, Depends(require_token)],
+) -> AuthIdentity:
+    """Gate a mutating route — requires ``admin`` or ``all`` scope.
+
+    Attach this to every POST/PUT/PATCH/DELETE handler on the admin
+    routers (slots, models, settings, hardware, providers, updates,
+    images). GETs stay on plain :func:`require_token` so a
+    ``read-only``-scoped token can still observe the system.
+
+    When ``HAL0_AUTH_ENABLED`` is unset, this is a pass-through (same as
+    :func:`require_token` and :func:`require_admin`).
+    """
+    if not auth_enabled():
+        return identity
+    if identity.scope not in _WRITER_SCOPES:
+        raise AuthForbidden(
+            "this endpoint requires a writer-scoped credential (admin or all)",
+            details={
+                "identity": identity.identity,
+                "scope": identity.scope,
+                "required": sorted(_WRITER_SCOPES),
+            },
+        )
+    return identity
+
+
 __all__ = [
     "PUBLIC_PATHS",
     "AuthForbidden",
@@ -315,4 +372,5 @@ __all__ = [
     "require_admin",
     "require_token",
     "require_token_unless_public",
+    "require_writer",
 ]

--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 
+from hal0.api.middleware.auth import require_writer
 from hal0.config import paths
 from hal0.config.loader import load_hardware_info
+
+# See slots.py for the writer-gate rationale.
+_writer = [Depends(require_writer)]
 
 router = APIRouter()
 
@@ -70,7 +74,7 @@ async def get_hardware(request: Request) -> dict[str, Any]:
     return _flatten_for_ui(info)
 
 
-@router.post("/hardware/probe")
+@router.post("/hardware/probe", dependencies=_writer)
 async def reprobe_hardware(request: Request) -> dict[str, Any]:
     """Re-run the hardware probe and persist to /etc/hal0/hardware.json."""
     probe = request.app.state.hardware_probe

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -14,9 +14,10 @@ import os
 import time
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, Request
 from fastapi.responses import StreamingResponse
 
+from hal0.api.middleware.auth import require_writer
 from hal0.api.middleware.error_codes import Hal0Error
 from hal0.registry.curated import get_curated
 from hal0.registry.pull import (
@@ -26,6 +27,9 @@ from hal0.registry.pull import (
     make_job,
     run_pull,
 )
+
+# See slots.py for the writer-gate rationale.
+_writer = [Depends(require_writer)]
 
 router = APIRouter()
 
@@ -98,7 +102,7 @@ async def list_models(request: Request) -> dict[str, Any]:
     return {"models": data, "count": len(data), "filtered_aliases": filtered}
 
 
-@router.post("", status_code=201)
+@router.post("", status_code=201, dependencies=_writer)
 async def create_model(request: Request) -> dict[str, Any]:
     """Register a new model in the local ModelRegistry.
 
@@ -148,7 +152,7 @@ async def get_model(model_id: str, request: Request) -> dict[str, Any]:
     )
 
 
-@router.put("/{model_id}")
+@router.put("/{model_id}", dependencies=_writer)
 async def update_model(model_id: str, request: Request) -> dict[str, Any]:
     """Apply partial updates to a registered model's metadata."""
     registry = request.app.state.model_registry
@@ -162,7 +166,7 @@ async def update_model(model_id: str, request: Request) -> dict[str, Any]:
     return _model_to_dict(model)
 
 
-@router.delete("/{model_id}")
+@router.delete("/{model_id}", dependencies=_writer)
 async def delete_model(model_id: str, request: Request) -> dict[str, object]:
     """Remove a model from the local registry (does not delete files)."""
     registry = request.app.state.model_registry
@@ -201,7 +205,7 @@ def _resolve_pull_source(request: Request, model_id: str) -> tuple[str, str]:
     )
 
 
-@router.post("/{model_id}/pull", status_code=202)
+@router.post("/{model_id}/pull", status_code=202, dependencies=_writer)
 async def pull_model(
     model_id: str,
     request: Request,
@@ -312,7 +316,7 @@ async def pull_stream(model_id: str, request: Request) -> StreamingResponse:
     )
 
 
-@router.post("/{model_id}/pull/cancel")
+@router.post("/{model_id}/pull/cancel", dependencies=_writer)
 async def pull_cancel(model_id: str, request: Request) -> dict[str, object]:
     """Request cancellation of an in-flight pull.
 

--- a/src/hal0/api/routes/providers.py
+++ b/src/hal0/api/routes/providers.py
@@ -17,11 +17,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 
+from hal0.api.middleware.auth import require_writer
 from hal0.api.middleware.error_codes import Hal0Error
 from hal0.upstreams.integrations import get_catalog
 from hal0.upstreams.registry import UpstreamNotFound
+
+# See slots.py for the writer-gate rationale.
+_writer = [Depends(require_writer)]
 
 router = APIRouter()
 
@@ -76,7 +80,7 @@ async def get_upstream(name: str, request: Request) -> dict[str, Any]:
     return _serialize_upstream(u, last_models=model_cache.get(name))
 
 
-@router.post("/upstreams/{name}/test")
+@router.post("/upstreams/{name}/test", dependencies=_writer)
 async def test_upstream(name: str, request: Request) -> dict[str, Any]:
     """Probe ``/v1/models`` on ``name`` and return a reachability report.
 

--- a/src/hal0/api/routes/settings.py
+++ b/src/hal0/api/routes/settings.py
@@ -26,12 +26,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from pydantic import ValidationError
 
+from hal0.api.middleware.auth import require_writer
 from hal0.api.middleware.error_codes import Hal0Error
 from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import Hal0Config
+
+# See slots.py for the writer-gate rationale.
+_writer = [Depends(require_writer)]
 
 router = APIRouter()
 
@@ -88,7 +92,7 @@ async def get_settings(request: Request) -> dict[str, Any]:
     return _config_to_dict(cfg)
 
 
-@router.put("")
+@router.put("", dependencies=_writer)
 async def update_settings(request: Request) -> dict[str, Any]:
     """Apply a partial update to hal0.toml.
 
@@ -134,7 +138,7 @@ async def update_settings(request: Request) -> dict[str, Any]:
     return _config_to_dict(merged)
 
 
-@router.post("/reload")
+@router.post("/reload", dependencies=_writer)
 async def reload_settings(request: Request) -> dict[str, Any]:
     """Re-read hal0.toml from disk into ``app.state.hal0_config``.
 

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -20,11 +20,18 @@ import asyncio
 import json
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
 
+from hal0.api.middleware.auth import require_writer
 from hal0.api.middleware.error_codes import BadRequest, Hal0Error
 from hal0.slots.manager import Slot, SlotManager
+
+# Reusable writer-scope gate applied per-route on every POST/PUT/PATCH/DELETE.
+# The router itself is mounted with require_token at include_router() time
+# (see hal0.api.create_app), which keeps GETs open to read-only tokens
+# while these per-route deps enforce the writer scope on mutations.
+_writer = [Depends(require_writer)]
 
 router = APIRouter()
 
@@ -158,7 +165,7 @@ async def list_slots(request: Request) -> list[dict[str, object]]:
     return merged
 
 
-@router.post("", status_code=201)
+@router.post("", status_code=201, dependencies=_writer)
 async def create_slot(request: Request) -> dict[str, object]:
     """Create a new slot. Body: SlotConfig schema.
 
@@ -274,7 +281,7 @@ async def get_slot(name: str, request: Request) -> dict[str, object]:
         raise
 
 
-@router.delete("/{name}")
+@router.delete("/{name}", dependencies=_writer)
 async def delete_slot(name: str, request: Request) -> dict[str, object]:
     """Delete a slot. If the slot is running, it is stopped first.
 
@@ -295,7 +302,7 @@ async def get_slot_config(name: str, request: Request) -> dict[str, object]:
     return cfg
 
 
-@router.put("/{name}/config")
+@router.put("/{name}/config", dependencies=_writer)
 async def update_slot_config(name: str, request: Request) -> dict[str, object]:
     """Update a slot's config. Body: partial SlotConfig (shallow merge)."""
     sm = _get_slot_manager(request)
@@ -312,7 +319,7 @@ async def update_slot_config(name: str, request: Request) -> dict[str, object]:
     return _slot_to_dict(snap, request)
 
 
-@router.patch("/{name}/defaults")
+@router.patch("/{name}/defaults", dependencies=_writer)
 async def update_slot_defaults(name: str, request: Request) -> dict[str, object]:
     """Update slot defaults (ctx_size, temperature, etc.).
 
@@ -330,7 +337,7 @@ async def update_slot_defaults(name: str, request: Request) -> dict[str, object]
     return _slot_to_dict(snap, request)
 
 
-@router.post("/{name}/backend")
+@router.post("/{name}/backend", dependencies=_writer)
 async def set_slot_backend(name: str, request: Request) -> dict[str, object]:
     """Switch a slot's backend (e.g., vulkan → rocm)."""
     sm = _get_slot_manager(request)
@@ -348,7 +355,7 @@ async def set_slot_backend(name: str, request: Request) -> dict[str, object]:
 # ── lifecycle ──────────────────────────────────────────────────────────────
 
 
-@router.post("/{name}/load")
+@router.post("/{name}/load", dependencies=_writer)
 async def load_slot(name: str, request: Request) -> dict[str, object]:
     """Load a model into a slot. Optional body: {"model_id": "..."}."""
     sm = _get_slot_manager(request)
@@ -363,21 +370,21 @@ async def load_slot(name: str, request: Request) -> dict[str, object]:
     return _slot_to_dict(snap, request)
 
 
-@router.post("/{name}/unload")
+@router.post("/{name}/unload", dependencies=_writer)
 async def unload_slot(name: str, request: Request) -> dict[str, object]:
     sm = _get_slot_manager(request)
     snap = await sm.unload(name)
     return _slot_to_dict(snap, request)
 
 
-@router.post("/{name}/restart")
+@router.post("/{name}/restart", dependencies=_writer)
 async def restart_slot(name: str, request: Request) -> dict[str, object]:
     sm = _get_slot_manager(request)
     snap = await sm.restart(name)
     return _slot_to_dict(snap, request)
 
 
-@router.post("/{name}/swap")
+@router.post("/{name}/swap", dependencies=_writer)
 async def swap_slot(name: str, request: Request) -> dict[str, object]:
     """Hot-swap a slot's model. Body: {"model_id": "..."}."""
     sm = _get_slot_manager(request)

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -31,13 +31,17 @@ import time
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 
 from hal0 import __version__
+from hal0.api.middleware.auth import require_writer
 from hal0.api.middleware.error_codes import Hal0Error
 from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import Hal0Config
 from hal0.updater import Updater, fetch_release_manifest, releases_url
+
+# See slots.py for the writer-gate rationale.
+_writer = [Depends(require_writer)]
 
 router = APIRouter()
 
@@ -187,7 +191,7 @@ async def check_updates(request: Request) -> dict[str, Any]:
 # ── /apply ─────────────────────────────────────────────────────────────────
 
 
-@router.post("/apply")
+@router.post("/apply", dependencies=_writer)
 async def apply_update(request: Request) -> dict[str, Any]:
     """Kick off an update job in the background; return a job id.
 
@@ -251,7 +255,7 @@ async def update_status(job_id: str, request: Request) -> dict[str, Any]:
 # ── /rollback ──────────────────────────────────────────────────────────────
 
 
-@router.post("/rollback")
+@router.post("/rollback", dependencies=_writer)
 async def rollback_update(request: Request) -> dict[str, Any]:
     """Invoke ``Updater.rollback()`` to revert to the retained previous version.
 
@@ -286,7 +290,7 @@ async def get_channel(request: Request) -> dict[str, str]:
     return {"channel": _current_channel(request)}
 
 
-@router.put("/channel")
+@router.put("/channel", dependencies=_writer)
 async def set_channel(request: Request) -> dict[str, str]:
     """Set the update channel.
 

--- a/tests/api/test_auth_writer_scope.py
+++ b/tests/api/test_auth_writer_scope.py
@@ -1,0 +1,196 @@
+"""Scope × verb matrix tests for the ``require_writer`` gate.
+
+Issue #29: admin routers previously accepted any valid token regardless of
+scope. A ``read-only`` or ``v1-only`` token could PUT/POST/DELETE on every
+admin route. This module asserts the corrected contract:
+
+  scope       | GET (reader)       | POST/PUT/PATCH/DELETE (writer)
+  ------------+--------------------+-------------------------------
+  admin       | 200                | 200
+  all         | 200                | 200
+  read-only   | 200                | 403 auth.forbidden
+  v1-only     | 200                | 403 auth.forbidden
+  (no creds)  | 401 auth.required  | 401 auth.required
+
+Tests below mint tokens for each scope, hit a representative GET + a
+representative mutation on each admin router, and assert on the matrix.
+The mutating call payloads are intentionally minimal — we want auth to
+gate *before* business validation, so the test never asserts on 2xx
+shapes (only on the auth status codes 200 / 401 / 403).
+
+For 200 cases, a passing auth check may still surface a 4xx/5xx from the
+handler (e.g. a missing slot). We assert "not 401 and not 403" rather
+than "== 200" to keep the matrix focused on the scope gate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.auth.tokens import TokenStore
+
+
+@pytest.fixture
+def auth_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("HAL0_AUTH_ENABLED", "1")
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    app = create_app()
+    with TestClient(app) as c:
+        c.app.state.token_store = TokenStore(tmp_path / "tokens.toml")
+        yield c
+
+
+def _bearer(auth_app: TestClient, scope: str, label: str | None = None) -> dict[str, str]:
+    """Mint a token at ``scope`` and return its Bearer header dict."""
+    store: TokenStore = auth_app.app.state.token_store
+    _, raw = store.create(label=label or f"test-{scope}", scope=scope)
+    return {"Authorization": f"Bearer {raw}"}
+
+
+# ── representative GETs across the admin routers ─────────────────────────────
+# read-only and v1-only must still be able to observe.
+
+
+READER_ROUTES = [
+    "/api/slots",
+    "/api/models",
+    "/api/hardware",
+    "/api/logs",
+    "/api/settings",
+    "/api/settings/schema",
+    "/api/providers",
+    "/api/upstreams",
+    "/api/updates/check",
+    "/api/updates/channel",
+]
+
+
+@pytest.mark.parametrize("path", READER_ROUTES)
+@pytest.mark.parametrize("scope", ["admin", "all", "read-only", "v1-only"])
+def test_reader_routes_accept_every_scope(
+    auth_app: TestClient, scope: str, path: str
+) -> None:
+    """GETs on admin routers must accept every valid scope.
+
+    We allow any non-401/403 status — the handler may still 5xx on a
+    missing upstream or 404 on an unknown id; the gate is what matters.
+    """
+    response = auth_app.get(path, headers=_bearer(auth_app, scope))
+    assert response.status_code not in (401, 403), (
+        f"reader route {path} rejected scope={scope!r}: "
+        f"status={response.status_code} body={response.text}"
+    )
+
+
+# ── representative writes across the admin routers ───────────────────────────
+# Each tuple: (method, path, json_body). Bodies are minimal because we expect
+# the auth check to fire *before* business validation when the scope is wrong.
+
+
+WRITER_ROUTES: list[tuple[str, str, dict | None]] = [
+    # slots
+    ("POST", "/api/slots", {"name": "test-slot-via-auth"}),
+    ("DELETE", "/api/slots/test-slot-via-auth", None),
+    ("PUT", "/api/slots/primary/config", {}),
+    ("PATCH", "/api/slots/primary/defaults", {}),
+    ("POST", "/api/slots/primary/backend", {"backend": "vulkan"}),
+    ("POST", "/api/slots/primary/load", None),
+    ("POST", "/api/slots/primary/unload", None),
+    ("POST", "/api/slots/primary/restart", None),
+    ("POST", "/api/slots/primary/swap", {"model_id": "x"}),
+    # models
+    ("POST", "/api/models", {"id": "test"}),
+    ("PUT", "/api/models/test", {}),
+    ("DELETE", "/api/models/test", None),
+    ("POST", "/api/models/test/pull", None),
+    ("POST", "/api/models/test/pull/cancel", None),
+    # hardware
+    ("POST", "/api/hardware/probe", None),
+    # settings
+    ("PUT", "/api/settings", {}),
+    ("POST", "/api/settings/reload", None),
+    # providers (upstreams)
+    ("POST", "/api/upstreams/haloai/test", None),
+    # updater
+    ("POST", "/api/updates/apply", None),
+    ("POST", "/api/updates/rollback", None),
+    ("PUT", "/api/updates/channel", {"channel": "stable"}),
+]
+
+
+@pytest.mark.parametrize("scope", ["read-only", "v1-only"])
+@pytest.mark.parametrize("method,path,body", WRITER_ROUTES)
+def test_writer_routes_reject_non_writer_scopes(
+    auth_app: TestClient, scope: str, method: str, path: str, body: dict | None
+) -> None:
+    """Mutating verbs on admin routers must reject read-only / v1-only with 403."""
+    response = auth_app.request(method, path, json=body, headers=_bearer(auth_app, scope))
+    assert response.status_code == 403, (
+        f"{method} {path} did not 403 for scope={scope!r}: "
+        f"status={response.status_code} body={response.text}"
+    )
+    body_json = response.json()
+    assert body_json["error"]["code"] == "auth.forbidden", body_json
+    # The envelope should name the scope so the caller can debug.
+    details = body_json["error"].get("details") or {}
+    assert details.get("scope") == scope
+
+
+@pytest.mark.parametrize("scope", ["admin", "all"])
+@pytest.mark.parametrize("method,path,body", WRITER_ROUTES)
+def test_writer_routes_accept_writer_scopes(
+    auth_app: TestClient, scope: str, method: str, path: str, body: dict | None
+) -> None:
+    """admin / all scopes must pass the writer gate.
+
+    Handler-level failures (404 on a missing slot, 4xx on bad payload, 5xx
+    on a missing background dep) are fine — we only assert that the auth
+    layer does NOT reject the request.
+    """
+    response = auth_app.request(method, path, json=body, headers=_bearer(auth_app, scope))
+    assert response.status_code not in (401, 403), (
+        f"{method} {path} rejected writer scope={scope!r}: "
+        f"status={response.status_code} body={response.text}"
+    )
+
+
+# ── missing credentials still 401 (not 403) on mutating routes ────────────────
+
+
+@pytest.mark.parametrize("method,path,body", WRITER_ROUTES)
+def test_writer_routes_require_auth(
+    auth_app: TestClient, method: str, path: str, body: dict | None
+) -> None:
+    response = auth_app.request(method, path, json=body)
+    assert response.status_code == 401, (
+        f"{method} {path} did not 401 without credentials: "
+        f"status={response.status_code} body={response.text}"
+    )
+    assert response.json()["error"]["code"] == "auth.required"
+
+
+# ── X-Forwarded-Email (Caddy basic_auth) is admin-scoped, so writes work ──────
+
+
+def test_forwarded_email_can_write(auth_app: TestClient) -> None:
+    """Caddy-forwarded identities map to scope=admin → writer access."""
+    response = auth_app.put(
+        "/api/settings",
+        json={},
+        headers={"X-Forwarded-Email": "owner@example.com"},
+    )
+    assert response.status_code not in (401, 403), response.text
+
+
+# ── HAL0_AUTH_ENABLED unset: every route is open ──────────────────────────────
+
+
+def test_writer_routes_open_when_auth_disabled(client: TestClient) -> None:
+    """With auth off, anonymous can hit a write route — preserves trusted-LAN posture."""
+    response = client.put("/api/settings", json={})
+    assert response.status_code not in (401, 403), response.text


### PR DESCRIPTION
## Summary

- Fixes #29 — admin routers previously accepted any valid token (incl. `read-only` / `v1-only`) for mutating verbs, letting any scope swap models, edit settings, change update channels, etc.
- Adds a new `require_writer` FastAPI dep that admits only `admin` and `all` scopes; everything else gets 403 `auth.forbidden`.
- Attaches `Depends(require_writer)` per-route on every POST/PUT/PATCH/DELETE under `/api/slots`, `/api/models`, `/api/hardware`, `/api/settings`, `/api/providers` (and the `/api/upstreams` subset), and `/api/updates`. GETs continue to gate on plain `require_token` so read-only tokens can still observe state. `/api/images` and `/api/logs` have no mutating routes.
- Auth module docstring now documents the scope × verb matrix.
- `tests/api/test_auth_writer_scope.py` covers the full scope × verb matrix (4 scopes × 10 reader paths + 21 writer paths) plus the no-credentials and `HAL0_AUTH_ENABLED=0` fallbacks. 147 new test cases.

## Scope × verb contract

| scope     | GET (reader)       | POST/PUT/PATCH/DELETE (writer) |
|-----------|--------------------|--------------------------------|
| admin     | 200                | 200                            |
| all       | 200                | 200                            |
| read-only | 200                | 403 `auth.forbidden`           |
| v1-only   | 200                | 403 `auth.forbidden`           |
| none      | 401 `auth.required`| 401 `auth.required`            |

`X-Forwarded-Email` (Caddy basic_auth) keeps admin scope → writer-capable.
With `HAL0_AUTH_ENABLED` unset the gate collapses to anonymous=writer, preserving the trusted-LAN default.

## Routes touched

Writer gate added to:
- `POST /api/slots`, `DELETE /api/slots/{name}`, `PUT /api/slots/{name}/config`, `PATCH /api/slots/{name}/defaults`, `POST /api/slots/{name}/backend|load|unload|restart|swap`
- `POST /api/models`, `PUT /api/models/{id}`, `DELETE /api/models/{id}`, `POST /api/models/{id}/pull`, `POST /api/models/{id}/pull/cancel`
- `POST /api/hardware/probe`
- `PUT /api/settings`, `POST /api/settings/reload`
- `POST /api/upstreams/{name}/test`
- `POST /api/updates/apply`, `POST /api/updates/rollback`, `PUT /api/updates/channel`

Out of scope (untouched): `/v1/*` OpenAI surface, Caddy basic_auth layer (#28), token-issuance flow, installer routes.

## Test plan

- [x] `pytest tests/api/test_auth_writer_scope.py` (147 passed)
- [x] `pytest tests/api/ tests/auth/` (309 passed, 3 skipped)
- [x] Full suite `pytest` (799 passed, 6 env-skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)