### PR TITLE
chore(format): ruff format slot_commands + slot_create_flags

### DIFF
--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -387,7 +387,13 @@ def slot_edit(
             )
             return
 
-    if model is None and port is None and ctx_size is None and provider is None and hardware is None:
+    if (
+        model is None
+        and port is None
+        and ctx_size is None
+        and provider is None
+        and hardware is None
+    ):
         console.print(
             "[bold yellow]No fields provided.[/bold yellow]  "
             "Pass at least one of --model, --port, --ctx-size, --provider, --hardware."

--- a/tests/cli/test_slot_create_flags.py
+++ b/tests/cli/test_slot_create_flags.py
@@ -122,9 +122,7 @@ def test_legacy_backend_with_invalid_value_errors(
     assert "body" not in captured_post
 
 
-def test_default_hardware_reads_probe_json(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_default_hardware_reads_probe_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """``_detect_default_hardware`` picks rocm for AMD+compute_capable GPUs."""
     probe = tmp_path / "hardware.json"
     probe.write_text(
@@ -147,9 +145,7 @@ def test_default_hardware_reads_probe_json(
     assert slot_commands._detect_default_hardware() == "rocm"
 
 
-def test_default_hardware_vulkan_fallback(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_default_hardware_vulkan_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Missing probe → vulkan (safe default that works on most GPUs)."""
     from hal0.config import paths as _paths
 
@@ -157,9 +153,7 @@ def test_default_hardware_vulkan_fallback(
     assert slot_commands._detect_default_hardware() == "vulkan"
 
 
-def test_default_hardware_cpu_when_no_gpu(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_default_hardware_cpu_when_no_gpu(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Empty gpus[] → cpu."""
     probe = tmp_path / "hardware.json"
     probe.write_text(json.dumps({"gpus": []}))


### PR DESCRIPTION
Format-only — runs `ruff format` on the two files that drifted in commit 1d26339 (`fix(cli): split slot create --backend into --provider + --hardware`).

The repo's CI runs `ruff format --check src tests` against every PR, so this drift was failing CI on every wave-1 PR (#45/#46/#47/#48/#49/#50) — none of those PRs introduced format issues themselves.

No logic changes; `ruff format` is idempotent.