### PR TITLE
feat(install): collapse Caddy to TLS-only, drop PUBLIC_PATHS, add --no-tls (ADR-0001 Child B — refs #54)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -53,30 +53,44 @@ wait_active() {
 
 DEV_MODE=0
 NO_START=0
-AUTH_MODE="off"   # "off" (default) | "basic" (Caddy + Bearer)
+# TLS posture (per ADR-0001 Child B):
+#   default — install Caddy as a dumb TLS terminator + reverse proxy on
+#             :443 in front of the API on 127.0.0.1:8080. Auth (password
+#             + session cookies + Bearer) lives entirely in FastAPI.
+#   --no-tls — skip Caddy. FastAPI binds 0.0.0.0:8080 directly. Right
+#             for hosts behind an existing reverse proxy (Traefik etc.)
+#             or for trusted-LAN dev boxes that don't need TLS.
+NO_TLS=0
 for arg in "$@"; do
     case "$arg" in
         --dev) DEV_MODE=1 ;;
         --no-start) NO_START=1 ;;
-        --auth=off) AUTH_MODE="off" ;;
-        --auth=basic) AUTH_MODE="basic" ;;
-        --auth=*)
-            warn "unknown --auth value: ${arg} (expected 'off' or 'basic'); using 'off'"
-            ;;
+        --no-tls) NO_TLS=1 ;;
         --help|-h)
             cat <<EOF
-Usage: install.sh [--dev] [--no-start] [--auth=off|basic]
+Usage: install.sh [--dev] [--no-start] [--no-tls]
   --dev          install under \$PWD/.hal0ai/, no systemd setup
   --no-start     set up everything but don't enable/start the API
-  --auth=off     no reverse proxy or auth (default; trusted-LAN posture)
-  --auth=basic   install Caddy with basic_auth + bearer-token enforcement;
-                 the dashboard moves to https://<host>/ on :443
+  --no-tls       skip the Caddy reverse proxy; bind FastAPI on
+                 0.0.0.0:8080 directly. No TLS, no edge proxy. Auth
+                 (password + tokens) still works — set it up in the
+                 first-run wizard or via the dashboard's Settings panel.
 EOF
             exit 0
             ;;
         *) warn "unknown flag: ${arg} (ignored)" ;;
     esac
 done
+
+# --dev implies --no-tls — there's no system Caddy install in a dev tree
+# and the prefix-relative unit paths won't match Caddy's expectations
+# anyway. Warn the operator if they passed --no-tls redundantly.
+if [[ "${DEV_MODE}" -eq 1 ]]; then
+    if [[ "${NO_TLS}" -eq 0 ]]; then
+        info "--dev implies --no-tls (no system Caddy install in dev tree)"
+    fi
+    NO_TLS=1
+fi
 
 # Banner first — before any info/warn so the brand greets the user
 # rather than hiding behind a "Dev mode …" line.
@@ -85,6 +99,20 @@ ui_banner
 HAL0_PORT="${HAL0_PORT:-8080}"
 HAL0_USER="${HAL0_USER:-root}"
 PY="${HAL0_PYTHON:-python3}"
+
+# API bind host:
+#   --no-tls         → 0.0.0.0 (the API is the front door)
+#   default (Caddy)  → 127.0.0.1 (Caddy on :443 is the front door; the
+#                                 API is loopback-only so it can't be
+#                                 reached around the TLS terminator)
+# DEV_MODE forces NO_TLS=1 above, so dev installs bind 0.0.0.0 too —
+# matches the prior behaviour where dev installs were directly reachable
+# on the LAN for testing.
+if [[ "${NO_TLS}" -eq 1 ]]; then
+    API_BIND_HOST="0.0.0.0"
+else
+    API_BIND_HOST="127.0.0.1"
+fi
 
 if [[ "${DEV_MODE}" -eq 1 ]]; then
     PREFIX="${HAL0_PREFIX:-${PWD}/.hal0ai}"
@@ -101,15 +129,12 @@ fi
 VENV_DIR="${PREFIX}/.venv"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Step total — base 8, +1 for the optional Auth setup, +1 for the
-# Auth self-test that runs after Caddy starts. Kept here so editors who
-# add or remove a ui_step bump the visible counter in the same diff.
+# Step total — base 8, +1 for the optional TLS / Caddy setup. Kept
+# here so editors who add or remove a ui_step bump the visible counter
+# in the same diff.
 UI_STEP_TOTAL=8
-if [[ "${AUTH_MODE}" == "basic" && "${DEV_MODE}" -eq 0 ]]; then
-    UI_STEP_TOTAL=$((UI_STEP_TOTAL + 1))           # "Auth (Caddy …)"
-    if [[ "${NO_START}" -eq 0 ]]; then
-        UI_STEP_TOTAL=$((UI_STEP_TOTAL + 1))       # "Auth self-test"
-    fi
+if [[ "${NO_TLS}" -eq 0 ]]; then
+    UI_STEP_TOTAL=$((UI_STEP_TOTAL + 1))           # "TLS (Caddy reverse proxy)"
 fi
 
 trap 'err "install failed at line ${LINENO} during: ${CURRENT_STEP:-pre-init}"
@@ -124,9 +149,9 @@ trap 'err "install failed at line ${LINENO} during: ${CURRENT_STEP:-pre-init}"
             warn "         Retry with HAL0_PYTHON=python3.12 sudo bash install.sh" ;;
         "Service start")
             warn "Recovery: journalctl -u hal0-api -n 60" ;;
-        Auth*)
-            warn "Recovery: rerun with HAL0_ADMIN_USER=... HAL0_ADMIN_PASSWORD=... set,"
-            warn "         or drop --auth=basic to install in the trusted-LAN posture." ;;
+        "TLS (Caddy reverse proxy)")
+            warn "Recovery: install caddy by hand and re-run,"
+            warn "         or rerun with --no-tls to skip the reverse proxy entirely." ;;
         "Hardware probe")
             warn "Recovery: rerun with HAL0_NO_PROBE=1 and file an issue with"
             warn "         /etc/hal0/hardware.json (if present) attached." ;;
@@ -140,8 +165,7 @@ if [[ "${DEV_MODE}" -eq 0 && "$(id -u)" -ne 0 ]]; then
         warn "Re-exec under sudo"
         exec sudo -E HAL0_PORT="${HAL0_PORT}" HAL0_USER="${HAL0_USER}" HAL0_PYTHON="${PY}" \
             HAL0_PREFIX="${HAL0_PREFIX:-}" HAL0_NO_PROBE="${HAL0_NO_PROBE:-}" \
-            HAL0_HOSTNAME="${HAL0_HOSTNAME:-}" HAL0_TLS_EMAIL="${HAL0_TLS_EMAIL:-}" \
-            HAL0_ADMIN_USER="${HAL0_ADMIN_USER:-}" HAL0_ADMIN_PASSWORD="${HAL0_ADMIN_PASSWORD:-}" \
+            HAL0_PUBLIC_HOST="${HAL0_PUBLIC_HOST:-}" HAL0_TLS_EMAIL="${HAL0_TLS_EMAIL:-}" \
             bash "$0" "$@"
     else
         die "must run as root (sudo bash install.sh)"
@@ -303,115 +327,98 @@ EOF
     info "wrote ${UPSTREAMS_TOML}"
 fi
 
-# ── Auth wiring (--auth=basic) ───────────────────────────────────────
-# Done BEFORE the openwebui env writer so the OPENWEBUI_AUTH=True +
-# trusted-header keys are baked in on the first render rather than
-# requiring a second pass.
+# ── TLS / Caddy reverse proxy (default unless --no-tls) ──────────────
+#
+# Per ADR-0001 Child B, Caddy is now a dumb TLS terminator + reverse
+# proxy — no basic_auth at the edge, no PUBLIC_PATHS allowlist, no
+# admin credential prompts. Auth (password + session cookies + Bearer
+# tokens) lives entirely in FastAPI; the wizard owns first-run
+# credential capture.
+#
+# Two paths from here:
+#   NO_TLS=1 — skip this whole block. API binds 0.0.0.0:8080 directly.
+#   default  — install Caddy, render the minimal Caddyfile, write the
+#              systemd unit. Caddy listens on :443, proxies to the API
+#              on 127.0.0.1:8080. Auth (if any) is whatever the
+#              operator sets up via the wizard.
+#
+# Done BEFORE the openwebui env writer so trusted-header keys are baked
+# in on the first render rather than requiring a second pass.
 HAL0_AUTH_ENABLED_FOR_RENDER="0"
-if [[ "${AUTH_MODE}" == "basic" ]]; then
-    if [[ "${DEV_MODE}" -eq 1 ]]; then
-        warn "--auth=basic with --dev is unsupported (no system Caddy install); skipping auth setup"
-        AUTH_MODE="off"
+if [[ "${NO_TLS}" -eq 0 ]]; then
+    ui_step "TLS (Caddy reverse proxy)"
+
+    # Caddy install — Debian/Ubuntu via apt, Arch/CachyOS via pacman.
+    # Anything else falls through with a manual-install hint.
+    if ! command -v caddy >/dev/null; then
+        if command -v apt-get >/dev/null; then
+            info "installing caddy via apt"
+            apt-get update -qq
+            # The official caddy package on Debian needs a third-party
+            # repo; for a polished installer we pin to the cloudsmith
+            # mirror in a v0.3 follow-up. For the POC, surface the
+            # missing-binary path so an operator can apt install caddy
+            # by hand and re-run.
+            APT_ERR="$(mktemp)"
+            if ! apt-get install -y caddy 2>"${APT_ERR}"; then
+                warn "apt failed to install caddy:"
+                sed 's/^/    /' "${APT_ERR}" >&2
+                warn "Install per https://caddyserver.com/docs/install#debian-ubuntu-raspbian and re-run."
+            fi
+            rm -f "${APT_ERR}"
+        elif command -v pacman >/dev/null; then
+            info "installing caddy via pacman"
+            pacman -S --noconfirm caddy
+        else
+            warn "no recognised package manager for caddy; install it from https://caddyserver.com/docs/install and re-run"
+        fi
+    fi
+    if ! command -v caddy >/dev/null; then
+        die "caddy binary not on PATH after install attempt — see warnings above (or rerun with --no-tls)"
+    fi
+    info "caddy: $(caddy version 2>/dev/null | head -n1 || echo unknown)"
+
+    # Public host + TLS posture. HAL0_PUBLIC_HOST defaults to hal0.local
+    # for the mDNS case (Caddy's internal CA mints a self-signed cert).
+    # For a real DNS-resolvable host the operator sets HAL0_PUBLIC_HOST
+    # + HAL0_TLS_EMAIL and Caddy runs ACME against Let's Encrypt.
+    HAL0_PUBLIC_HOST="${HAL0_PUBLIC_HOST:-hal0.local}"
+    HAL0_TLS_EMAIL="${HAL0_TLS_EMAIL:-admin@${HAL0_PUBLIC_HOST}}"
+
+    # Decide the `tls` directive value. ``internal`` triggers Caddy's
+    # private CA path (right for *.local + IP literals); anything else
+    # is treated as an ACME contact email. We auto-detect *.local here
+    # so a fresh ``sudo bash install.sh`` does the right thing without
+    # the operator having to know that ACME-on-.local fails noisily.
+    if [[ "${HAL0_PUBLIC_HOST}" == *.local || "${HAL0_PUBLIC_HOST}" == "localhost" ]]; then
+        HAL0_TLS_DIRECTIVE="internal"
     else
-        ui_step "Auth (Caddy basic_auth + Bearer)"
+        HAL0_TLS_DIRECTIVE="${HAL0_TLS_EMAIL}"
+    fi
 
-        # Caddy install — Debian/Ubuntu via apt, Arch/CachyOS via pacman.
-        # Anything else falls through with a manual-install hint.
-        if ! command -v caddy >/dev/null; then
-            if command -v apt-get >/dev/null; then
-                info "installing caddy via apt"
-                apt-get update -qq
-                # The official caddy package on Debian needs a third-party
-                # repo; for a polished installer we pin to the cloudsmith
-                # mirror in a v0.3 follow-up. For the POC, surface the
-                # missing-binary path so an operator can apt install caddy
-                # by hand and re-run.
-                APT_ERR="$(mktemp)"
-                if ! apt-get install -y caddy 2>"${APT_ERR}"; then
-                    warn "apt failed to install caddy:"
-                    sed 's/^/    /' "${APT_ERR}" >&2
-                    warn "Install per https://caddyserver.com/docs/install#debian-ubuntu-raspbian and re-run."
-                fi
-                rm -f "${APT_ERR}"
-            elif command -v pacman >/dev/null; then
-                info "installing caddy via pacman"
-                pacman -S --noconfirm caddy
-            else
-                warn "no recognised package manager for caddy; install it from https://caddyserver.com/docs/install and re-run"
-            fi
-        fi
-        if ! command -v caddy >/dev/null; then
-            die "caddy binary not on PATH after install attempt — see warnings above"
-        fi
-        info "caddy: $(caddy version 2>/dev/null | head -n1 || echo unknown)"
-
-        # Admin credentials — env-driven for non-interactive installs,
-        # interactive prompts otherwise. Both paths feed into Caddy's
-        # `caddy hash-password` for the bcrypt hash baked into the
-        # Caddyfile.
-        if [[ -z "${HAL0_ADMIN_USER:-}" ]]; then
-            if [[ -t 0 ]]; then
-                read -r -p "Admin username [admin]: " HAL0_ADMIN_USER
-                HAL0_ADMIN_USER="${HAL0_ADMIN_USER:-admin}"
-            else
-                HAL0_ADMIN_USER="admin"
-            fi
-        fi
-        if [[ -z "${HAL0_ADMIN_PASSWORD:-}" ]]; then
-            if [[ -t 0 ]]; then
-                # Read silently; -s isn't POSIX so we fall back if missing.
-                printf "Admin password (will not echo): "
-                read -r -s HAL0_ADMIN_PASSWORD
-                printf "\n"
-                if [[ -z "${HAL0_ADMIN_PASSWORD}" ]]; then
-                    die "admin password must not be empty"
-                fi
-            else
-                die "non-interactive --auth=basic requires HAL0_ADMIN_USER + HAL0_ADMIN_PASSWORD env vars"
-            fi
-        fi
-
-        HAL0_HOSTNAME="${HAL0_HOSTNAME:-hal0.local}"
-        HAL0_TLS_EMAIL="${HAL0_TLS_EMAIL:-admin@${HAL0_HOSTNAME}}"
-
-        # bcrypt hash via caddy's own helper. `--plaintext` reads from
-        # the flag rather than stdin so the password never lands on the
-        # process's argv (the flag itself becomes part of `ps` output —
-        # acceptable on a single-user install host but documented).
-        HAL0_ADMIN_PASSWORD_HASH="$(caddy hash-password --plaintext "${HAL0_ADMIN_PASSWORD}")"
-        if [[ -z "${HAL0_ADMIN_PASSWORD_HASH}" ]]; then
-            die "caddy hash-password returned empty hash"
-        fi
-        info "hashed admin password for ${HAL0_ADMIN_USER}"
-
-        # Render the Caddyfile from the template. envsubst would be
-        # cleaner; use a portable sed pipeline so we don't need to add
-        # a coreutils dep on minimal hosts.
-        CADDY_TEMPLATE="${REPO_ROOT}/packaging/caddy/Caddyfile.template"
-        CADDY_TARGET="${ETC_DIR}/Caddyfile"
-        if [[ ! -f "${CADDY_TEMPLATE}" ]]; then
-            die "Caddyfile template missing at ${CADDY_TEMPLATE}"
-        fi
-        # Use python for the substitution so password hashes containing
-        # '/', '$', '&' don't trip up sed escape rules.
-        HAL0_HOSTNAME="${HAL0_HOSTNAME}" \
-        HAL0_TLS_EMAIL="${HAL0_TLS_EMAIL}" \
-        HAL0_ADMIN_USER="${HAL0_ADMIN_USER}" \
-        HAL0_ADMIN_PASSWORD_HASH="${HAL0_ADMIN_PASSWORD_HASH}" \
-        "${PY}" - "${CADDY_TEMPLATE}" "${CADDY_TARGET}" <<'PY'
-import os, sys, string
+    # Render the Caddyfile from the template. Python so the renderer
+    # doesn't depend on envsubst / coreutils on minimal hosts; the
+    # template only ships {$KEY} / {$KEY:default} placeholders that the
+    # renderer expands at install time.
+    CADDY_TEMPLATE="${REPO_ROOT}/packaging/caddy/Caddyfile.template"
+    CADDY_TARGET="${ETC_DIR}/Caddyfile"
+    if [[ ! -f "${CADDY_TEMPLATE}" ]]; then
+        die "Caddyfile template missing at ${CADDY_TEMPLATE}"
+    fi
+    HAL0_PUBLIC_HOST="${HAL0_PUBLIC_HOST}" \
+    HAL0_TLS_EMAIL="${HAL0_TLS_EMAIL}" \
+    HAL0_TLS_DIRECTIVE="${HAL0_TLS_DIRECTIVE}" \
+    "${PY}" - "${CADDY_TEMPLATE}" "${CADDY_TARGET}" <<'PY'
+import os, sys
 src, dst = sys.argv[1], sys.argv[2]
 text = open(src).read()
 # Caddy's own ${VAR:default} placeholder syntax is what the template
 # uses inside its config — preserve those by only substituting the
 # specific keys we know about. Anything else is passed through verbatim
 # so Caddy's runtime substitution still works.
-keys = ("HAL0_HOSTNAME", "HAL0_TLS_EMAIL", "HAL0_ADMIN_USER", "HAL0_ADMIN_PASSWORD_HASH")
+keys = ("HAL0_PUBLIC_HOST", "HAL0_TLS_EMAIL", "HAL0_TLS_DIRECTIVE")
 for k in keys:
     val = os.environ.get(k, "")
-    # Replace `{$KEY:default}` and `{$KEY}` forms with the resolved
-    # value at install time so the running Caddy config doesn't depend
-    # on systemd-passing the env var.
     text = text.replace("{$" + k + "}", val)
     # Match {$KEY:default} regardless of default value.
     while True:
@@ -425,43 +432,43 @@ for k in keys:
         text = text[:i] + val + text[j+1:]
 open(dst, "w").write(text)
 # 0644 so the unprivileged 'caddy' user can read the rendered file.
-# The bcrypt hash inside is a hash, not a recoverable secret, and the
-# hostname / TLS email are public; nothing here justifies 0640 + chown.
+# Nothing in this template is sensitive post-ADR-0001 (no password
+# hashes, no secrets — just hostname + ACME email).
 os.chmod(dst, 0o644)
 print(f"  rendered {dst}")
 PY
-        info "wrote ${CADDY_TARGET}"
+    info "wrote ${CADDY_TARGET}"
 
-        # systemd unit drop-in.
-        CADDY_UNIT_SRC="${REPO_ROOT}/packaging/systemd/hal0-caddy.service"
-        CADDY_UNIT_DST="${UNIT_DIR}/hal0-caddy.service"
-        if [[ -f "${CADDY_UNIT_SRC}" ]]; then
-            cp "${CADDY_UNIT_SRC}" "${CADDY_UNIT_DST}"
-            info "wrote ${CADDY_UNIT_DST}"
-        else
-            warn "${CADDY_UNIT_SRC} not found — Caddy unit not installed"
-        fi
-
-        # Avahi (best-effort).
-        if command -v avahi-daemon >/dev/null && [[ -d /etc/avahi/services ]]; then
-            cp "${REPO_ROOT}/packaging/avahi/hal0.service" /etc/avahi/services/hal0.service
-            info "wrote /etc/avahi/services/hal0.service (mDNS announcing ${HAL0_HOSTNAME})"
-        else
-            warn "avahi-daemon not present; add an /etc/hosts entry on clients: '<this-host-ip> ${HAL0_HOSTNAME}'"
-        fi
-
-        # Flip the runtime auth flag for hal0-api.
-        if [[ -f "${API_ENV}" ]]; then
-            # Replace any existing line, else append.
-            if grep -q '^HAL0_AUTH_ENABLED=' "${API_ENV}"; then
-                sed -i 's|^HAL0_AUTH_ENABLED=.*|HAL0_AUTH_ENABLED=1|' "${API_ENV}"
-            else
-                echo "HAL0_AUTH_ENABLED=1" >> "${API_ENV}"
-            fi
-            info "set HAL0_AUTH_ENABLED=1 in ${API_ENV}"
-        fi
-        HAL0_AUTH_ENABLED_FOR_RENDER="1"
+    # systemd unit drop-in.
+    CADDY_UNIT_SRC="${REPO_ROOT}/packaging/systemd/hal0-caddy.service"
+    CADDY_UNIT_DST="${UNIT_DIR}/hal0-caddy.service"
+    if [[ -f "${CADDY_UNIT_SRC}" ]]; then
+        cp "${CADDY_UNIT_SRC}" "${CADDY_UNIT_DST}"
+        info "wrote ${CADDY_UNIT_DST}"
+    else
+        warn "${CADDY_UNIT_SRC} not found — Caddy unit not installed"
     fi
+
+    # Avahi (best-effort).
+    if command -v avahi-daemon >/dev/null && [[ -d /etc/avahi/services ]]; then
+        cp "${REPO_ROOT}/packaging/avahi/hal0.service" /etc/avahi/services/hal0.service
+        info "wrote /etc/avahi/services/hal0.service (mDNS announcing ${HAL0_PUBLIC_HOST})"
+    else
+        warn "avahi-daemon not present; add an /etc/hosts entry on clients: '<this-host-ip> ${HAL0_PUBLIC_HOST}'"
+    fi
+
+    # Flip the runtime auth flag for hal0-api. Auth still defaults to
+    # "open" until the wizard sets a password — see
+    # src/hal0/api/routes/auth.py for the first-run claim path.
+    if [[ -f "${API_ENV}" ]]; then
+        if grep -q '^HAL0_AUTH_ENABLED=' "${API_ENV}"; then
+            sed -i 's|^HAL0_AUTH_ENABLED=.*|HAL0_AUTH_ENABLED=1|' "${API_ENV}"
+        else
+            echo "HAL0_AUTH_ENABLED=1" >> "${API_ENV}"
+        fi
+        info "set HAL0_AUTH_ENABLED=1 in ${API_ENV}"
+    fi
+    HAL0_AUTH_ENABLED_FOR_RENDER="1"
 fi
 
 # OpenWebUI prewire env. Rendered via the just-installed venv so the
@@ -497,7 +504,7 @@ Type=simple
 User=${HAL0_USER}
 WorkingDirectory=${PREFIX}
 EnvironmentFile=${API_ENV}
-ExecStart=${HAL0_BIN} serve --host 0.0.0.0 --port \${HAL0_PORT}
+ExecStart=${HAL0_BIN} serve --host ${API_BIND_HOST} --port \${HAL0_PORT}
 Restart=on-failure
 RestartSec=3
 StandardOutput=journal
@@ -608,7 +615,7 @@ ui_step "Service start"
 
 if [[ "${DEV_MODE}" -eq 1 || "${NO_START}" -eq 1 ]]; then
     warn "not starting services automatically (dev / --no-start)."
-    warn "  start manually: ${HAL0_BIN} serve --host 0.0.0.0 --port ${HAL0_PORT}"
+    warn "  start manually: ${HAL0_BIN} serve --host ${API_BIND_HOST} --port ${HAL0_PORT}"
 else
     systemctl enable --now hal0-api
     if wait_active hal0-api 15; then
@@ -629,15 +636,18 @@ else
         fi
     fi
 
-    # If --auth=basic was selected, start Caddy too. Restart hal0-api so
-    # the new HAL0_AUTH_ENABLED=1 takes effect and the ports flip from
-    # the open posture to "Caddy fronts everything".
-    if [[ "${AUTH_MODE}" == "basic" && -f "${UNIT_DIR}/hal0-caddy.service" ]]; then
+    # Default (TLS) install: bring up Caddy in front. Per ADR-0001 Child B
+    # this is a dumb TLS terminator + reverse proxy — no edge auth, no
+    # round-trip self-test against a credential (because there is no
+    # credential at the edge anymore). The wizard captures a password
+    # post-install; until then the server is open on the LAN, matching
+    # the trusted-LAN default documented in the ADR.
+    if [[ "${NO_TLS}" -eq 0 && -f "${UNIT_DIR}/hal0-caddy.service" ]]; then
         systemctl restart hal0-api
         systemctl restart hal0-openwebui || true
         systemctl enable --now hal0-caddy
         if wait_active hal0-caddy 15; then
-            info "hal0-caddy is running (https://${HAL0_HOSTNAME:-hal0.local}/)"
+            info "hal0-caddy is running (https://${HAL0_PUBLIC_HOST:-hal0.local}/)"
         else
             warn "hal0-caddy not yet active; check 'journalctl -u hal0-caddy -n 60'"
         fi
@@ -645,27 +655,6 @@ else
         # (best-effort — failing reload doesn't break anything).
         if command -v systemctl >/dev/null && systemctl is-active --quiet avahi-daemon; then
             systemctl reload avahi-daemon || true
-        fi
-
-        # Round-trip an authenticated request through Caddy so the
-        # installer fails loudly when basic_auth or the bcrypt hash is
-        # wired wrong, instead of leaving the operator to discover it
-        # at first browser load.  -k accepts Caddy's `tls internal`
-        # self-signed cert; we only run this when HAL0_ADMIN_PASSWORD
-        # is still set in scope (it is — the read happens earlier in
-        # this same --auth=basic block and there is no `unset`).
-        ui_step "Auth self-test"
-        if [[ -n "${HAL0_ADMIN_PASSWORD:-}" ]]; then
-            if curl -ksSf --max-time 10 \
-                    -u "${HAL0_ADMIN_USER}:${HAL0_ADMIN_PASSWORD}" \
-                    "https://${HAL0_HOSTNAME}/api/health" >/dev/null 2>&1; then
-                info "basic_auth round-trip OK (https://${HAL0_HOSTNAME}/api/health)"
-            else
-                warn "basic_auth round-trip failed — check 'journalctl -u hal0-caddy -n 60'"
-                warn "  (Caddy may still be provisioning TLS; retry curl in ~10s)"
-            fi
-        else
-            warn "skipping auth self-test — HAL0_ADMIN_PASSWORD not in scope"
         fi
     fi
 fi
@@ -680,8 +669,8 @@ HOST="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
 # Tailscale entry; nothing in this block can fail the installer.
 REACH_LINES=()
 
-if [[ "${AUTH_MODE}" == "basic" ]]; then
-    HOSTNAME_FOR_REACH="${HAL0_HOSTNAME:-hal0.local}"
+if [[ "${NO_TLS}" -eq 0 ]]; then
+    HOSTNAME_FOR_REACH="${HAL0_PUBLIC_HOST:-hal0.local}"
     DASHBOARD_URL="https://${HOSTNAME_FOR_REACH}/"
     REACH_LINES+=("mDNS"$'\t'"https://${HOSTNAME_FOR_REACH}/")
 else
@@ -694,7 +683,7 @@ else
         done
     fi
     if [[ -f /etc/avahi/services/hal0.service ]]; then
-        REACH_LINES+=("mDNS"$'\t'"http://${HAL0_HOSTNAME:-hal0.local}:${HAL0_PORT}/")
+        REACH_LINES+=("mDNS"$'\t'"http://${HAL0_PUBLIC_HOST:-hal0.local}:${HAL0_PORT}/")
     fi
     # Tailscale — show whichever tailnet IPs are present. Never fatal.
     if command -v tailscale >/dev/null 2>&1; then
@@ -826,18 +815,28 @@ SUMMARY_LINES=(
     "$(printf 'Data        %s%s%s' "${BLU}" "${VAR_DIR}" "${RST}")"
 )
 if [[ "${DEV_MODE}" -eq 0 && "${NO_START}" -eq 0 ]]; then
-    if [[ "${AUTH_MODE}" == "basic" ]]; then
-        HOSTNAME_FOR_DISPLAY="${HAL0_HOSTNAME:-hal0.local}"
+    if [[ "${NO_TLS}" -eq 0 ]]; then
+        # TLS-default install: Caddy fronts both services, dashboard
+        # lives on https://<public-host>/. The wizard captures a
+        # password on first visit; until set, the API is reachable
+        # without credentials on the LAN (intentional — see ADR-0001
+        # "First-run posture").
+        HOSTNAME_FOR_DISPLAY="${HAL0_PUBLIC_HOST:-hal0.local}"
         SUMMARY_LINES+=(
             "$(printf 'Dashboard   %shttps://%s/%s' "${BLU}" "${HOSTNAME_FOR_DISPLAY}" "${RST}")"
-            "$(printf 'Chat        %shttps://%s/chat/%s' "${BLU}" "${HOSTNAME_FOR_DISPLAY}" "${RST}")"
-            "$(printf 'Auth        %sbasic_auth (admin: %s) + Bearer at /api/auth/tokens%s' "${DIM}" "${HAL0_ADMIN_USER:-admin}" "${RST}")"
+            "$(printf 'Chat        %shttp://%s:3001%s' "${BLU}" "${HOST}" "${RST}")"
+            "$(printf 'Auth        %sopen — set a password in the wizard or Settings → Authentication%s' "${DIM}" "${RST}")"
             "$(printf 'Logs        %sjournalctl -fu hal0-caddy hal0-api hal0-openwebui%s' "${DIM}" "${RST}")"
         )
     else
+        # --no-tls: API binds 0.0.0.0:8080 directly. No TLS, no edge
+        # proxy. Auth (password + tokens) still works — same as the
+        # TLS path, just over HTTP.
         SUMMARY_LINES+=(
             "$(printf 'Dashboard   %shttp://%s:%s%s' "${BLU}" "${HOST}" "${HAL0_PORT}" "${RST}")"
             "$(printf 'Chat        %shttp://%s:3001%s' "${BLU}" "${HOST}" "${RST}")"
+            "$(printf 'TLS         %soff (--no-tls) — no TLS, no edge proxy%s' "${DIM}" "${RST}")"
+            "$(printf 'Auth        %sopen — set a password in the wizard or Settings → Authentication%s' "${DIM}" "${RST}")"
             "$(printf 'Logs        %sjournalctl -fu hal0-api%s' "${DIM}" "${RST}")"
         )
     fi

--- a/packaging/caddy/Caddyfile.template
+++ b/packaging/caddy/Caddyfile.template
@@ -1,26 +1,29 @@
 # hal0 Caddyfile template — rendered to /etc/hal0/Caddyfile by
-# installer/install.sh when --auth=basic is passed.
+# installer/install.sh on the default (TLS) install path.
 #
-# This file is REGENERATED on every `install.sh --auth=basic` run; for
-# host-specific tweaks (extra vhosts, ACME settings, custom snippets)
-# create /etc/hal0/Caddyfile.local — hal0-caddy.service loads it AFTER
-# this file via Caddy's --watch-config + global import.
+# This file is REGENERATED on every install.sh run; for host-specific
+# tweaks (extra vhosts, ACME settings, custom snippets) create
+# /etc/hal0/Caddyfile.local — hal0-caddy.service loads it AFTER this
+# file via Caddy's --watch-config + global import (the commented-out
+# import at the bottom is the seam).
 #
-# Required env vars (substituted by `envsubst` at install time):
-#   HAL0_HOSTNAME             — public hostname, e.g. hal0.local
-#   HAL0_TLS_EMAIL            — ACME contact email (used for non-.local domains)
-#   HAL0_ADMIN_USER           — basicauth username (default: admin)
-#   HAL0_ADMIN_PASSWORD_HASH  — bcrypt hash from `caddy hash-password`
+# Per ADR-0001 (Collapse edge auth into FastAPI), Caddy is now a dumb
+# TLS terminator + reverse proxy. All auth lives in FastAPI (password +
+# session cookies + Bearer tokens — see src/hal0/api/middleware/auth.py).
+# There is no edge-auth directive, no path allowlist matcher, no per-
+# path handle block — every request passes straight through to the API.
 #
-# TLS:
-#   For ${HAL0_HOSTNAME} ending in .local Caddy mints a self-signed cert
-#   via its internal CA (see ``tls internal`` directive). The CA root
-#   lands in ``~/.local/share/caddy/pki/authorities/local/root.crt`` —
-#   trust it on browser clients, or install via your platform's keychain.
+# Required env vars (substituted at install time by install.sh's Python
+# template renderer; both `{$VAR}` and `{$VAR:default}` forms are
+# replaced):
 #
-#   For real (DNS-resolvable, public) hostnames remove the ``tls
-#   internal`` line and Caddy will run ACME against Let's Encrypt
-#   automatically using HAL0_TLS_EMAIL.
+#   HAL0_PUBLIC_HOST   — public hostname, e.g. hal0.local
+#   HAL0_TLS_DIRECTIVE — the argument to `tls`; either ``internal`` for
+#                        the .local / private-CA path, or an email for
+#                        ACME against Let's Encrypt. install.sh picks
+#                        ``internal`` automatically for *.local hosts.
+#   HAL0_TLS_EMAIL     — ACME contact email written into the global
+#                        block; harmless on .local installs.
 
 {
 	email {$HAL0_TLS_EMAIL:admin@hal0.local}
@@ -28,78 +31,10 @@
 	#              once we don't need it for `caddy reload --address ...`
 }
 
-{$HAL0_HOSTNAME:hal0.local} {
-	tls internal
+{$HAL0_PUBLIC_HOST:hal0.local} {
+	tls {$HAL0_TLS_DIRECTIVE:internal}
 	encode zstd gzip
-
-	# Header hygiene: strip any inbound X-Forwarded-Email/User so a
-	# client can't spoof the SSO identity by sending it themselves.
-	# Caddy re-writes its own copy below for the protected handlers.
-	request_header -X-Forwarded-Email
-	request_header -X-Forwarded-User
-
-	# OpenWebUI under /chat/ — single-sign-on via X-Forwarded-Email.
-	# handle_path strips the /chat prefix before forwarding so OpenWebUI
-	# sees / as its document root. WEBUI_AUTH_TRUSTED_EMAIL_HEADER on
-	# OpenWebUI's side picks up the forwarded identity and skips its own
-	# login page (see src/hal0/openwebui/env_writer.py).
-	handle_path /chat* {
-		basicauth {
-			{$HAL0_ADMIN_USER:admin} {$HAL0_ADMIN_PASSWORD_HASH}
-		}
-		reverse_proxy 127.0.0.1:3001 {
-			header_up X-Forwarded-Email {http.auth.user.id}
-			header_up X-Forwarded-User {http.auth.user.id}
-		}
-	}
-
-	# OpenAI-compatible API — Bearer token auth happens at the hal0-api
-	# layer (Authorization header passes through verbatim). No basicauth
-	# at the edge so programmatic OpenAI clients work without prompting.
-	handle /v1/* {
-		reverse_proxy 127.0.0.1:8080
-	}
-
-	# Public allowlist — paths that MUST be reachable without basic_auth
-	# so the first-run wizard can bootstrap before any credential exists,
-	# and so monitoring tools can scrape liveness without holding creds.
-	#
-	# This list mirrors the PUBLIC_PATHS frozenset in
-	# src/hal0/api/middleware/auth.py — keep them in sync. The `path`
-	# matcher is exact-match (no trailing-slash or prefix expansion), which
-	# matches the `request.url.path in PUBLIC_PATHS` check on the API side.
-	#
-	# This block MUST stay above the default `handle {}` below — Caddy
-	# evaluates `handle` blocks in source order and the first match wins,
-	# so listing `@public` later would let basic_auth swallow the wizard
-	# probes (see issue #28).
-	@public path /api/health/system \
-	             /api/status \
-	             /api/metrics \
-	             /api/features \
-	             /api/install/state \
-	             /api/install/complete \
-	             /api/config/urls \
-	             /api/auth/status \
-	             /api/auth/login \
-	             /api/auth/logout \
-	             /v1/models
-	handle @public {
-		reverse_proxy 127.0.0.1:8080
-	}
-
-	# Dashboard + management API — Caddy basicauth at the edge. Forwards
-	# the identity as X-Forwarded-Email so the hal0 API trusts the user
-	# as admin (see hal0.api.middleware.auth precedence).
-	handle {
-		basicauth {
-			{$HAL0_ADMIN_USER:admin} {$HAL0_ADMIN_PASSWORD_HASH}
-		}
-		reverse_proxy 127.0.0.1:8080 {
-			header_up X-Forwarded-Email {http.auth.user.id}
-			header_up X-Forwarded-User {http.auth.user.id}
-		}
-	}
+	reverse_proxy 127.0.0.1:8080
 }
 
 # Optional: drop overrides here without touching the above block.

--- a/scripts/harness.sh
+++ b/scripts/harness.sh
@@ -13,7 +13,8 @@
 #
 # Env knobs (passed straight to children):
 #   HAL0_HARNESS_PROD=1     enable prod-mode rows (sudo + real /etc paths)
-#   HAL0_HARNESS_AUTH=1     enable --auth=basic install (needs PROD=1)
+#   HAL0_HARNESS_TLS=1      enable the tls-default install row (needs PROD=1
+#                           and installs Caddy via apt/pacman)
 #   HAL0_HARNESS_SKIP_LXC=1 skip the optional release-test SSH leg
 #
 # Exit 0 if no FAIL rows in any tier (skip/deferred ok), 1 otherwise.

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -14,7 +14,7 @@ from fastapi import Depends, FastAPI
 
 from hal0 import __version__
 from hal0.api.middleware import error_codes, request_id
-from hal0.api.middleware.auth import require_token, require_token_unless_public
+from hal0.api.middleware.auth import require_token
 from hal0.api.routes import (
     auth as auth_routes,
 )
@@ -290,29 +290,36 @@ def create_app() -> FastAPI:
     error_codes.install(app)
 
     # ── Auth wiring ──────────────────────────────────────────────────
-    # The /api/auth router is mounted bare — its public endpoints are
-    # listed in PUBLIC_PATHS, and the admin token CRUD subrouter inside
-    # auth_routes.router carries its own require_admin dep.
+    # Per ADR-0001 Child B, the PUBLIC_PATHS frozenset is gone. A route
+    # is public iff its router (or route) does NOT declare an auth
+    # dependency — there is no allowlist to consult, the FastAPI graph
+    # IS the policy.
+    #
+    # The /api/auth router is mounted bare — /status, /login, /logout,
+    # /password (first-run path) are intentionally public; /me declares
+    # require_token at the function level; the /tokens subrouter
+    # declares require_admin at the subrouter level.
     app.include_router(auth_routes.router, prefix="/api/auth", tags=["auth"])
 
-    # /v1 mixes one public endpoint (/v1/models) with protected ones —
-    # use the path-aware variant so /v1/models stays open while
-    # /v1/chat/completions, /v1/embeddings, etc. require a token.
-    _v1_auth = [Depends(require_token_unless_public)]
+    # /v1 is split into a public probe (GET /v1/models + /v1/models/{id})
+    # and a writer surface that requires auth. The split lives in v1.py
+    # via v1.public_router (probes) + v1.router (inference). OpenAI
+    # clients historically GET /v1/models before sending an Authorization
+    # header — keeping that probe auth-free preserves SDK compatibility.
+    app.include_router(v1.public_router, prefix="/v1", tags=["v1"])
+    _v1_auth = [Depends(require_token)]
     app.include_router(v1.router, prefix="/v1", tags=["v1"], dependencies=_v1_auth)
 
-    # /api/install also mixes — first-run state + complete must remain
-    # reachable before any token can exist; the rest is admin-grade.
-    _installer_auth = [Depends(require_token_unless_public)]
-    app.include_router(
-        installer.router,
-        prefix="/api/install",
-        tags=["installer"],
-        dependencies=_installer_auth,
-    )
+    # /api/install drives the first-run wizard, which runs *before* any
+    # credential exists. Mount bare — every wizard endpoint is public.
+    # When the wizard is no longer needed (first_run sentinel written
+    # OR a model is present), the dashboard router-guards stop routing
+    # to it; the endpoints themselves remain reachable for re-entry
+    # (e.g. operator deliberately reopening /firstrun to add a model).
+    app.include_router(installer.router, prefix="/api/install", tags=["installer"])
 
     # Single-purpose protected routers — every endpoint requires a token
-    # when HAL0_AUTH_ENABLED=1, no path-aware bypass needed.
+    # (or session cookie / forwarded email) when HAL0_AUTH_ENABLED=1.
     _admin_auth = [Depends(require_token)]
     app.include_router(slots.router, prefix="/api/slots", tags=["slots"], dependencies=_admin_auth)
     app.include_router(
@@ -337,10 +344,10 @@ def create_app() -> FastAPI:
     )
 
     # Health + config/urls routers carry endpoints that are entirely
-    # public per PUBLIC_PATHS (e.g. /api/status, /api/config/urls). Any
-    # future protected endpoints added to these routers should declare
-    # Depends(require_token) at the function level — keeping the public
-    # bypass to its narrow allowlist.
+    # public (e.g. /api/status, /api/config/urls). Any future protected
+    # endpoints added to these routers should declare
+    # Depends(require_token) at the function level so the publicness of
+    # the rest is declared by absence rather than by allowlist.
     app.include_router(health.router, prefix="/api", tags=["health"])
     app.include_router(config_routes.router, prefix="/api/config", tags=["config"])
 

--- a/src/hal0/api/middleware/auth.py
+++ b/src/hal0/api/middleware/auth.py
@@ -1,13 +1,9 @@
-"""Bearer-token + Caddy-edge authentication dependency.
+"""Bearer-token + cookie-session authentication dependency.
 
-This module exposes four FastAPI dependencies:
+This module exposes three FastAPI dependencies:
 
   - :func:`require_token` — gates a single route or router. Accepts any
     valid scope (used as the *reader* gate on admin routers).
-  - :func:`require_token_unless_public` — gates a router globally but
-    bypasses the auth check for paths in :data:`PUBLIC_PATHS`. This is
-    what we attach at ``include_router(...)`` time on routers that mix
-    public and protected endpoints (``/v1`` and ``/api/install``).
   - :func:`require_writer` — gates a single mutating route. Requires an
     ``admin``- or ``all``-scoped credential; ``read-only`` and
     ``v1-only`` are rejected with 403 ``auth.forbidden``.
@@ -31,28 +27,23 @@ When ``HAL0_AUTH_ENABLED`` is unset, every dependency is a pass-through
 that returns ``identity="anonymous", scope="all"`` — so the gate
 collapses to "open" on the trusted-LAN install posture.
 
-Public route allowlist
-----------------------
+Public routes (no allowlist)
+----------------------------
 
-The following stay public under ``HAL0_AUTH_ENABLED=1``:
-
-  - ``GET  /api/health/system``        — liveness probe
-  - ``GET  /api/status``               — dashboard liveness ping
-  - ``GET  /api/metrics``              — JSON metrics / dashboard scrape
-  - ``GET  /api/features``             — feature-flag inspection
-  - ``GET  /api/install/state``        — first-run gating
-  - ``POST /api/install/complete``     — first-run sentinel write
-  - ``GET  /api/config/urls``          — host-aware URL hints
-  - ``GET  /api/auth/status``          — auth-mode discovery
-  - ``GET  /api/auth/login``           — placeholder (Caddy owns real login)
-  - ``POST /api/auth/logout``          — clears local session hints
-  - ``GET  /v1/models``                — OpenAI clients probe before auth
-
-Everything else under ``/v1/*`` and the admin ``/api/*`` routes is
-gated. Protected single-purpose routers (slots, models, providers,
-hardware, logs, settings, updater) get the dep at router-include time;
-mixed routers (``/v1``, ``/api/install``) get the path-aware variant
-that consults :data:`PUBLIC_PATHS`.
+ADR-0001 (Child B) deleted the ``PUBLIC_PATHS`` frozenset. A route is
+public iff its router / handler does NOT declare an auth dependency —
+that's the entire mechanism. The wizard endpoints
+(``/api/install/state``, ``/api/install/probe``, ``/api/install/complete``,
+``/api/install/curated-models``, ``/api/install/pick-default``), the
+auth surface (``/api/auth/status``, ``/api/auth/login``,
+``/api/auth/logout``, ``/api/auth/password``, ``/api/auth/me`` —
+``me`` IS auth-gated, the rest are public), liveness / metrics
+(``/api/status``, ``/api/health/system``, ``/api/metrics``,
+``/api/features``), config discovery (``/api/config/urls``), and the
+OpenAI pre-auth model probe (``GET /v1/models``) all live on bare /
+auth-free routers. Everything else inherits an auth dep at
+``include_router(...)`` time. See ``hal0.api.create_app`` for the wiring
+table.
 
 Auth precedence
 ---------------
@@ -61,11 +52,16 @@ Auth precedence
    store. Failure ⇒ 401 (``auth.invalid``). Success ⇒ identity = token's
    label, scope = token's scope.
 
-2. ``X-Forwarded-Email`` present (Caddy verified basic_auth at the edge,
-   then forwarded the identity) → trust it. Scope = ``"admin"`` because
-   Caddy's basic_auth users are the dashboard owners.
+2. ``hal0_session`` cookie present (ADR-0001 Child A) → validate signed
+   JWT claims. Failure ⇒ 401 (``auth.invalid``).
 
-3. Else → 401 (``auth.required``).
+3. ``X-Forwarded-Email`` present (a trusted upstream proxy validated the
+   identity and forwarded it) → trust it. Scope = ``"admin"``. This path
+   stays around for users fronting hal0 with their own SSO proxy
+   (Authelia, Authentik, Cloudflare Access, Pangolin etc.) — hal0's own
+   Caddy no longer sets it.
+
+4. Else → 401 (``auth.required``).
 
 When ``HAL0_AUTH_ENABLED`` is unset / falsy, ``require_token`` is a
 no-op pass-through that returns the literal identity ``"anonymous"`` —
@@ -143,43 +139,6 @@ _FORWARDED_SCOPE = "admin"
 # "read-only" and "v1-only" are explicitly excluded — they get 403 on
 # any mutating route.
 _WRITER_SCOPES: frozenset[str] = frozenset({"admin", "all"})
-
-
-# Routes that bypass auth even when HAL0_AUTH_ENABLED=1. Match exact paths
-# (case-sensitive) — all of these are well-known endpoints whose contracts
-# pre-date the auth gate. Adding to this list is a security decision; do
-# it deliberately.
-PUBLIC_PATHS: frozenset[str] = frozenset(
-    {
-        # Liveness / observability — must be reachable for monitoring
-        # tools that pre-date a per-deployment token.
-        #
-        # NOTE (issue #36): /api/metrics/prometheus used to live here but
-        # no Prometheus exposition route ever shipped. Listing a 404 path
-        # as "public" was confusing for scraper operators following the
-        # documented bypass list. Add it back if/when a real exporter
-        # ships — keep this list in lockstep with packaging/caddy's
-        # @public matcher.
-        "/api/health/system",
-        "/api/status",
-        "/api/metrics",
-        "/api/features",
-        # First-run wizard gating — the dashboard hits these before the
-        # user has any chance to mint a token.
-        "/api/install/state",
-        "/api/install/complete",
-        # Host-aware URL hints — used by the FirstRun wizard to render
-        # the OpenWebUI link with the right host.
-        "/api/config/urls",
-        # Auth surface itself — discovery + Caddy-owned login parity.
-        "/api/auth/status",
-        "/api/auth/login",
-        "/api/auth/logout",
-        # OpenAI compat — many clients probe /v1/models before sending
-        # an Authorization header. Models list isn't sensitive.
-        "/v1/models",
-    }
-)
 
 
 # ── Typed errors ──────────────────────────────────────────────────────────────
@@ -393,38 +352,6 @@ async def require_token(request: Request) -> AuthIdentity:
     )
 
 
-async def require_token_unless_public(request: Request) -> AuthIdentity:
-    """Path-aware dependency: bypass for :data:`PUBLIC_PATHS`, else gate.
-
-    Used at ``include_router(...)`` time on routers that mix public and
-    protected endpoints (``/v1``, ``/api/install``). For single-purpose
-    routers where every endpoint is protected, attach plain
-    :func:`require_token` instead — the path lookup is cheap but
-    unnecessary noise.
-
-    Path matching is exact on ``request.url.path``. Sub-path patterns
-    (e.g. ``/v1/models/{id}``) need to match the resolved path, not the
-    template — which means ``/v1/models/foo`` would NOT match
-    ``"/v1/models"`` in the allowlist. That's intentional: the bare
-    ``/v1/models`` listing is OpenAI's pre-auth probe, but
-    ``/v1/models/{id}`` is a model-detail call that warrants the same
-    gate as everything else under ``/v1``. When that turns out to be
-    wrong in practice, add the model-detail path to PUBLIC_PATHS — don't
-    invert the matcher.
-    """
-    if request.url.path in PUBLIC_PATHS:
-        # Mirror the auth-disabled identity so callers that *do* depend
-        # on the dataclass downstream (none today, but the door is open)
-        # see a consistent shape.
-        return AuthIdentity(
-            identity=_ANONYMOUS_IDENTITY,
-            scope=_ANONYMOUS_SCOPE,
-            source="public",
-            token=None,
-        )
-    return await require_token(request)
-
-
 async def require_admin(
     request: Request,
     identity: Annotated[AuthIdentity, Depends(require_token)],
@@ -531,7 +458,6 @@ async def require_writer(
 
 
 __all__ = [
-    "PUBLIC_PATHS",
     "SESSION_COOKIE_NAME",
     "AuthForbidden",
     "AuthIdentity",
@@ -540,6 +466,5 @@ __all__ = [
     "CSRFRequired",
     "require_admin",
     "require_token",
-    "require_token_unless_public",
     "require_writer",
 ]

--- a/src/hal0/api/routes/health.py
+++ b/src/hal0/api/routes/health.py
@@ -8,8 +8,10 @@ Routes mounted under /api:
   PUT  /api/features/{name}   — toggle feature flag
 
 Note (issue #36): a /api/metrics/prometheus route was advertised in this
-docstring and in PUBLIC_PATHS but was never implemented. Both stubs are
-removed until a real prometheus_client-backed exporter ships.
+docstring and in the historical PUBLIC_PATHS allowlist but was never
+implemented. Both stubs are removed until a real prometheus_client-
+backed exporter ships. (PUBLIC_PATHS itself was deleted by ADR-0001
+Child B; routes are now public by virtue of not declaring an auth dep.)
 """
 
 from __future__ import annotations

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -35,7 +35,18 @@ from fastapi.responses import Response, StreamingResponse
 from hal0.api import image_cache
 from hal0.api.deps import DispatcherDep
 
+# Inference router — auth-required. Mounted by hal0.api.create_app() with
+# Depends(require_token) so /v1/chat/completions, /v1/embeddings, the
+# audio + image endpoints, etc. all gate on a valid credential.
 router = APIRouter()
+
+# Public probe router — auth-free. Mounted on the same /v1 prefix.
+# OpenAI clients (OpenWebUI, third-party SDKs) GET /v1/models before
+# they have anywhere to send an Authorization header; gating it would
+# break the "drop in an OpenAI-shaped base_url" UX. Per ADR-0001 Child
+# B, publicness is declared by NOT attaching an auth dep — not by
+# allowlisting the path in a frozenset.
+public_router = APIRouter()
 
 
 def _instrument_streaming_throughput(
@@ -151,7 +162,7 @@ async def _dispatch_and_forward(
     return response
 
 
-@router.get("/models")
+@public_router.get("/models")
 async def list_models(
     request: Request,
     dispatcher: DispatcherDep,
@@ -161,6 +172,10 @@ async def list_models(
     Returns the OpenAI shape: ``{"object": "list", "data": [...]}``.
     Fetches each upstream's catalog on demand (no caching yet — a TTL
     cache lands when the dispatcher gets one).
+
+    PUBLIC — mounted on ``public_router`` so OpenAI SDKs that probe the
+    catalog before sending Authorization headers continue to work after
+    ADR-0001 Child B.
     """
     upstreams = request.app.state.upstreams
     seen: set[str] = set()
@@ -186,12 +201,19 @@ async def list_models(
     return {"object": "list", "data": data}
 
 
-@router.get("/models/{model_id:path}")
+@public_router.get("/models/{model_id:path}")
 async def get_model(
     model_id: str,
     request: Request,
     dispatcher: DispatcherDep,
 ) -> dict[str, object]:
+    """Look up a single model by id from the aggregated catalog.
+
+    PUBLIC — the catalog is non-sensitive (just model ids the upstreams
+    advertise on their own ``/v1/models``). Pairs with ``list_models``
+    so SDKs that resolve a model handle through ``/v1/models/{id}``
+    before chatting don't need credentials to do so.
+    """
     listing = await list_models(request, dispatcher)
     for entry in listing.get("data", []):  # type: ignore[union-attr]
         if isinstance(entry, dict) and entry.get("id") == model_id:

--- a/tests/api/test_auth_middleware.py
+++ b/tests/api/test_auth_middleware.py
@@ -1,6 +1,9 @@
-"""Auth middleware (require_token / require_token_unless_public) tests.
+"""Auth middleware (require_token) tests.
 
-Validates the precedence rules and the public-route bypass.
+Validates the precedence rules and that routes mounted without an auth
+dependency stay public under ``HAL0_AUTH_ENABLED=1``. Per ADR-0001
+Child B, publicness is declared by NOT attaching an auth dep at
+``include_router(...)`` time — not by being on a magic allowlist.
 
 Pattern: each test rebuilds the FastAPI app with HAL0_AUTH_ENABLED=1 set
 before create_app() runs, then swaps the auto-created TokenStore on
@@ -87,7 +90,6 @@ def test_public_routes_bypass_auth(auth_app: TestClient, path: str) -> None:
         "/api/logs",
         "/api/settings",
         "/api/providers",
-        "/api/install/curated-models",  # mixed router; this is protected
     ],
 )
 def test_protected_routes_require_auth(auth_app: TestClient, path: str) -> None:

--- a/tests/api/test_no_public_paths.py
+++ b/tests/api/test_no_public_paths.py
@@ -1,0 +1,157 @@
+"""ADR-0001 Child B — PUBLIC_PATHS deletion regression tests.
+
+Two invariants:
+
+  1. The ``PUBLIC_PATHS`` symbol does NOT exist on
+     ``hal0.api.middleware.auth``. The frozenset's deletion is the
+     architectural point of the ADR; if it comes back, the dual-source
+     drift class of bugs (#28, #51) comes back with it.
+
+  2. Routes that USED to be allowlisted in ``PUBLIC_PATHS`` are still
+     reachable without credentials when ``HAL0_AUTH_ENABLED=1`` — but
+     publicness is now declared by NOT attaching an auth dep, not by
+     consulting a frozenset. The test asserts behaviour: hit each one
+     and assert the response is not a 401.
+
+  3. A writer endpoint (``POST /api/slots/``) still 401s without auth,
+     proving the auth gate is intact on the protected surface.
+
+Pattern mirrors tests/api/test_auth_middleware.py: build a fresh app
+per test with HAL0_AUTH_ENABLED=1 + HAL0_HOME pointed at a tmp dir.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.api.middleware import auth as auth_middleware
+
+
+# ── Invariant 1: the symbol is gone ─────────────────────────────────────────
+
+
+def test_public_paths_symbol_no_longer_exists() -> None:
+    """``hal0.api.middleware.auth`` must not export a PUBLIC_PATHS attribute.
+
+    Deletion is the architectural point of ADR-0001 Child B. A
+    re-introduction would re-open the dual-source-of-truth drift
+    class of bugs (#28 / #36 / #51).
+    """
+    assert not hasattr(auth_middleware, "PUBLIC_PATHS"), (
+        "PUBLIC_PATHS reappeared on hal0.api.middleware.auth — ADR-0001 Child B "
+        "explicitly deletes it; route publicness is now declared by NOT attaching "
+        "an auth dependency, not by allowlisting paths."
+    )
+
+
+def test_require_token_unless_public_no_longer_exists() -> None:
+    """The path-aware dependency went away with the allowlist that backed it."""
+    assert not hasattr(auth_middleware, "require_token_unless_public"), (
+        "require_token_unless_public reappeared — Child B removed it along with "
+        "PUBLIC_PATHS. Use plain require_token at include_router(...) time and "
+        "mount public endpoints on a separate auth-free router."
+    )
+
+
+# ── Invariant 2: previously-public routes still public ──────────────────────
+
+
+@pytest.fixture
+def auth_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """Fresh app with HAL0_AUTH_ENABLED=1; token store rooted at tmp_path."""
+    monkeypatch.setenv("HAL0_AUTH_ENABLED", "1")
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    app = create_app()
+    with TestClient(app) as c:
+        yield c
+
+
+# Every path that used to live in the deleted PUBLIC_PATHS frozenset.
+# The wizard, monitoring tools, and OpenAI clients all depend on these
+# being reachable without credentials when no password is yet set.
+_FORMERLY_PUBLIC_PATHS = [
+    # Liveness / monitoring.
+    "/api/health/system",
+    "/api/status",
+    "/api/metrics",
+    "/api/features",
+    # First-run wizard gating.
+    "/api/install/state",
+    # Host-aware URL hints (wizard uses to render the OpenWebUI link).
+    "/api/config/urls",
+    # Auth surface itself.
+    "/api/auth/status",
+    "/api/auth/login",  # GET legacy hint shim
+    # OpenAI compat — clients probe before sending Authorization.
+    "/v1/models",
+]
+
+
+@pytest.mark.parametrize("path", _FORMERLY_PUBLIC_PATHS)
+def test_formerly_public_paths_stay_open(auth_app: TestClient, path: str) -> None:
+    """Endpoints that were in PUBLIC_PATHS must remain reachable post-deletion.
+
+    A 401 here means the route was implicitly protected after the
+    PUBLIC_PATHS removal — that breaks the first-run wizard's
+    bootstrap, monitoring scrapers, and OpenAI SDKs that pre-flight
+    /v1/models before authenticating.
+    """
+    response = auth_app.get(path)
+    assert response.status_code != 401, (
+        f"route {path} 401'd under HAL0_AUTH_ENABLED=1 — it must remain "
+        f"reachable without credentials (was in the now-deleted "
+        f"PUBLIC_PATHS frozenset). Body: {response.text}"
+    )
+
+
+def test_install_complete_post_stays_open(auth_app: TestClient) -> None:
+    """The wizard's sentinel-write call is a POST — auth-free."""
+    response = auth_app.post("/api/install/complete")
+    assert response.status_code != 401, response.text
+
+
+def test_auth_logout_post_stays_open(auth_app: TestClient) -> None:
+    """POST /api/auth/logout is the cookie-clear path; must be auth-free.
+
+    A logged-out user shouldn't need to authenticate to log out, and the
+    cookie-clear is idempotent — calling it on an already-empty session
+    is a 204 no-op.
+    """
+    response = auth_app.post("/api/auth/logout")
+    assert response.status_code != 401, response.text
+
+
+# ── Invariant 3: writer routes still gated ──────────────────────────────────
+
+
+def test_writer_route_still_requires_auth(auth_app: TestClient) -> None:
+    """POST /api/slots/ (writer-scope) must still 401 without credentials.
+
+    Proves the auth gate is intact on the protected surface — Child B
+    moved publicness into the FastAPI dependency graph, but admin
+    routers still carry ``Depends(require_token)`` at include_router
+    time. A 200 here would mean Child B accidentally opened the writer
+    surface as collateral damage.
+    """
+    response = auth_app.post(
+        "/api/slots",
+        json={"name": "scratch", "port": 8099, "backend": "vulkan", "provider": "llama-server"},
+    )
+    assert response.status_code == 401, (
+        f"writer route POST /api/slots returned {response.status_code} without "
+        f"credentials — auth gate broken. Body: {response.text}"
+    )
+    body = response.json()
+    assert body["error"]["code"] == "auth.required"
+
+
+def test_admin_reader_route_still_requires_auth(auth_app: TestClient) -> None:
+    """GET /api/slots (reader on an admin router) must also still 401."""
+    response = auth_app.get("/api/slots")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "auth.required"

--- a/tests/harness/installer-test.sh
+++ b/tests/harness/installer-test.sh
@@ -15,13 +15,18 @@
 #   dev-uninstall-purge bash installer/uninstall.sh           (forced, full)
 #   prod-no-start      sudo bash installer/install.sh --no-start
 #                      (only if HAL0_HARNESS_PROD=1 — opt-in, mutates /etc)
-#   auth-basic         --auth=basic + admin/password env, --no-start
-#                      (only if HAL0_HARNESS_AUTH=1 — needs caddy installable)
+#   tls-default        default install (no flag) — Caddy installed, the
+#                      rendered Caddyfile is the ADR-0001-Child-B minimal
+#                      form (TLS-only, no basicauth, no @public matcher).
+#                      Opt-in via HAL0_HARNESS_PROD=1 + HAL0_HARNESS_TLS=1.
+#   no-tls             --no-tls install — no Caddy, no Caddyfile, hal0-api
+#                      unit binds 0.0.0.0:8080, /api/auth/status reports
+#                      auth_mode=open. Opt-in via HAL0_HARNESS_PROD=1.
 #
 # Env knobs:
 #   HAL0_HARNESS_PREFIX    tmp prefix root (default $REPO_ROOT/.harness/install-$$)
 #   HAL0_HARNESS_PROD      1 to run prod-level (sudo) scenarios
-#   HAL0_HARNESS_AUTH      1 to run --auth=basic scenario
+#   HAL0_HARNESS_TLS       1 to run the tls-default scenario (also installs caddy)
 #   HAL0_HARNESS_KEEP      1 to keep the tmp prefix after run (for debugging)
 #
 # Exit:
@@ -230,37 +235,118 @@ else
     fi
 fi
 
-# ── ROW: auth-basic (opt-in) ────────────────────────────────────────────────
-log_step "Row: auth-basic"
+# ── ROW: tls-default (opt-in) ───────────────────────────────────────────────
+# Default install path post-ADR-0001-Child-B: Caddy installed as a dumb
+# TLS terminator, rendered Caddyfile is the minimal 10-line form (no
+# basicauth, no @public matcher, no per-path handle block). The grep
+# assertions below are NEGATIVE — they prove the auth-edge surface is
+# gone, not present.
+log_step "Row: tls-default"
 start=$(start_ms)
-if [[ "${HAL0_HARNESS_AUTH:-0}" != "1" ]]; then
-    add_row "auth-basic" "skip" "$(since_ms "${start}")" "skipped — set HAL0_HARNESS_AUTH=1 (and HAL0_HARNESS_PROD=1) to install caddy + render Caddyfile"
+if [[ "${HAL0_HARNESS_TLS:-0}" != "1" ]]; then
+    add_row "tls-default" "skip" "$(since_ms "${start}")" "skipped — set HAL0_HARNESS_TLS=1 (and HAL0_HARNESS_PROD=1) to install caddy + render Caddyfile"
 elif [[ "${HAL0_HARNESS_PROD:-0}" != "1" ]]; then
-    add_row "auth-basic" "skip" "$(since_ms "${start}")" "auth=basic is a prod-mode path; HAL0_HARNESS_PROD=1 also required"
+    add_row "tls-default" "skip" "$(since_ms "${start}")" "tls-default is a prod-mode path; HAL0_HARNESS_PROD=1 also required"
 else
-    LOG4="${PREFIX}/install-auth.log"
-    if HAL0_ADMIN_USER=admin HAL0_ADMIN_PASSWORD='hal0-harness-test' \
-       HAL0_HOSTNAME=hal0-harness.local HAL0_TLS_EMAIL=harness@hal0.test \
+    LOG_TLS="${PREFIX}/install-tls.log"
+    if HAL0_PUBLIC_HOST=hal0-harness.local HAL0_TLS_EMAIL=harness@hal0.test \
        HAL0_NO_PROBE=1 HAL0_PLAIN=1 \
-        sudo -E bash "${REPO_ROOT}/installer/install.sh" --auth=basic --no-start >"${LOG4}" 2>&1; then
-        # Regression for #28: the rendered Caddyfile must carry the
-        # @public matcher + `handle @public` block BEFORE the default
-        # basicauth handler, else the first-run wizard's pre-auth
-        # /api/install/state + /api/config/urls probes 401 and the
-        # SPA can't bootstrap. Asserting both halves (matcher + handle)
-        # so a future edit that drops one without the other is caught.
-        if [[ -f /etc/hal0/Caddyfile ]] && grep -q basicauth /etc/hal0/Caddyfile \
-            && grep -q HAL0_AUTH_ENABLED=1 /etc/hal0/api.env \
-            && grep -q '@public path' /etc/hal0/Caddyfile \
-            && grep -q 'handle @public' /etc/hal0/Caddyfile \
-            && grep -q '/api/install/state' /etc/hal0/Caddyfile; then
-            add_row "auth-basic" "pass" "$(since_ms "${start}")" "Caddyfile + api.env auth wiring rendered (incl. @public allowlist)"
+        sudo -E bash "${REPO_ROOT}/installer/install.sh" --no-start >"${LOG_TLS}" 2>&1; then
+        # Per ADR-0001 the rendered Caddyfile must collapse to the
+        # ~10-line minimal terminator: TLS + reverse_proxy 127.0.0.1:8080
+        # and NOTHING else (no basicauth, no @public matcher). Grep on
+        # actual directive lines (start-of-line with optional leading
+        # whitespace) so a comment mentioning the historical directives
+        # doesn't false-positive.
+        OK=1
+        FAIL_REASON=""
+        if [[ ! -f /etc/hal0/Caddyfile ]]; then
+            OK=0; FAIL_REASON="/etc/hal0/Caddyfile missing"
+        elif ! grep -q 'reverse_proxy 127.0.0.1:8080' /etc/hal0/Caddyfile; then
+            OK=0; FAIL_REASON="reverse_proxy line missing"
+        elif grep -qE '^[[:space:]]*basicauth' /etc/hal0/Caddyfile; then
+            OK=0; FAIL_REASON="basicauth directive still present in Caddyfile (Child B regression)"
+        elif grep -qE '^[[:space:]]*@public' /etc/hal0/Caddyfile; then
+            OK=0; FAIL_REASON="@public matcher still present in Caddyfile (Child B regression)"
+        elif ! grep -q HAL0_AUTH_ENABLED=1 /etc/hal0/api.env; then
+            OK=0; FAIL_REASON="HAL0_AUTH_ENABLED=1 not set in api.env"
+        fi
+        if [[ "${OK}" -eq 1 ]]; then
+            add_row "tls-default" "pass" "$(since_ms "${start}")" "Caddyfile rendered as minimal TLS-only reverse proxy (no edge auth)"
         else
-            add_row "auth-basic" "fail" "$(since_ms "${start}")" "Caddyfile or api.env auth flag missing post-install (check @public allowlist for #28)"
+            add_row "tls-default" "fail" "$(since_ms "${start}")" "${FAIL_REASON}"
         fi
     else
         rc=$?
-        add_row "auth-basic" "fail" "$(since_ms "${start}")" "auth install exit=${rc}; tail: $(tail -n1 "${LOG4}")"
+        add_row "tls-default" "fail" "$(since_ms "${start}")" "tls-default install exit=${rc}; tail: $(tail -n1 "${LOG_TLS}")"
+    fi
+fi
+
+# ── ROW: no-tls (opt-in) ────────────────────────────────────────────────────
+# --no-tls install: Caddy not touched, no Caddyfile, hal0-api unit binds
+# 0.0.0.0:8080 instead of 127.0.0.1:8080, /api/auth/status reports
+# auth_mode=open (no password set, no edge auth — full open posture for
+# hosts behind an existing reverse proxy).
+log_step "Row: no-tls"
+start=$(start_ms)
+if [[ "${HAL0_HARNESS_PROD:-0}" != "1" ]]; then
+    add_row "no-tls" "skip" "$(since_ms "${start}")" "skipped — set HAL0_HARNESS_PROD=1 to exercise sudo /opt/hal0 --no-tls install"
+else
+    LOG_NOTLS="${PREFIX}/install-no-tls.log"
+    if HAL0_NO_PROBE=1 HAL0_PLAIN=1 HAL0_NO_HELLO=1 HAL0_NO_QR=1 \
+        sudo -E bash "${REPO_ROOT}/installer/install.sh" --no-tls --no-start >"${LOG_NOTLS}" 2>&1; then
+        OK=1
+        FAIL_REASON=""
+        # The Caddy unit must NOT be installed (--no-tls skips that block).
+        if [[ -f /etc/systemd/system/hal0-caddy.service ]]; then
+            OK=0; FAIL_REASON="hal0-caddy.service present despite --no-tls"
+        # hal0-api unit must bind 0.0.0.0:8080 (not 127.0.0.1).
+        elif ! grep -q 'serve --host 0.0.0.0' /etc/systemd/system/hal0-api.service; then
+            OK=0; FAIL_REASON="hal0-api ExecStart does not bind 0.0.0.0 under --no-tls"
+        # api.env must NOT carry HAL0_AUTH_ENABLED=1 — --no-tls means
+        # the operator is fronting hal0 with their own proxy and we
+        # don't presume to flip auth on for them.
+        elif grep -q '^HAL0_AUTH_ENABLED=1' /etc/hal0/api.env; then
+            OK=0; FAIL_REASON="HAL0_AUTH_ENABLED=1 set in api.env despite --no-tls"
+        fi
+        if [[ "${OK}" -eq 1 ]]; then
+            # Spin the API up briefly to hit /api/auth/status and verify
+            # the open-mode envelope. Background, poll, kill — same
+            # pattern as dev-api-up above.
+            NOTLS_PORT="${HAL0_HARNESS_NO_TLS_PORT:-18091}"
+            HAL0_HOME="${PREFIX}" HAL0_PORT="${NOTLS_PORT}" \
+                "${PREFIX}/.venv/bin/hal0" serve --host 127.0.0.1 --port "${NOTLS_PORT}" \
+                >"${PREFIX}/serve-no-tls.log" 2>&1 &
+            NOTLS_PID=$!
+            UP=0
+            for _ in $(seq 1 30); do
+                if curl -fsS -m 1 "http://127.0.0.1:${NOTLS_PORT}/api/auth/status" >/dev/null 2>&1; then
+                    UP=1; break
+                fi
+                sleep 0.5
+            done
+            if [[ "${UP}" -eq 1 ]]; then
+                STATUS_JSON="$(curl -fsS "http://127.0.0.1:${NOTLS_PORT}/api/auth/status" 2>/dev/null || echo '{}')"
+                # Tolerate either jq or python for the parse — harness
+                # hosts may not have jq. We grep on the raw JSON to
+                # avoid the dependency.
+                if echo "${STATUS_JSON}" | grep -q '"auth_mode":"open"' \
+                   && echo "${STATUS_JSON}" | grep -q '"password_set":false'; then
+                    add_row "no-tls" "pass" "$(since_ms "${start}")" "Caddy unit absent, hal0-api binds 0.0.0.0, /api/auth/status=open"
+                else
+                    add_row "no-tls" "fail" "$(since_ms "${start}")" "auth/status not in open posture: ${STATUS_JSON}"
+                fi
+            else
+                add_row "no-tls" "fail" "$(since_ms "${start}")" "API never became healthy on :${NOTLS_PORT}; tail: $(tail -n3 "${PREFIX}/serve-no-tls.log" 2>/dev/null | tr '\n' ' ')"
+            fi
+            kill "${NOTLS_PID}" 2>/dev/null || true
+            wait "${NOTLS_PID}" 2>/dev/null || true
+        else
+            add_row "no-tls" "fail" "$(since_ms "${start}")" "${FAIL_REASON}"
+        fi
+    else
+        rc=$?
+        add_row "no-tls" "fail" "$(since_ms "${start}")" "no-tls install exit=${rc}; tail: $(tail -n1 "${LOG_NOTLS}")"
     fi
 fi
 

--- a/ui/src/views/FirstRun.vue
+++ b/ui/src/views/FirstRun.vue
@@ -2,11 +2,15 @@
 /**
  * FirstRun.vue — First-run wizard backed by the model-pull endpoints.
  *
- * 3 steps (plus a "done" coda):
- *   1. Pick a model (curated cards + custom HF form).
- *   2. License confirm (checkbox required).
- *   3. Download + assign (POST /api/install/pick-default; SSE-tail the
+ * 5 steps (plus a "done" coda) post-ADR-0001 Child B:
+ *   1. Set up password (optional, ADR-0001 Child B). Renders only when
+ *      /api/auth/status.password_set === false; auto-skips otherwise.
+ *      Skip button advances without setting a password (open posture).
+ *   2. Pick a model (curated cards + custom HF form).
+ *   3. License confirm (checkbox required).
+ *   4. Download + assign (POST /api/install/pick-default; SSE-tail the
  *      pull stream for live progress; on completion show "Open chat").
+ *   5. Done coda.
  *
  * The router-level guard (router.js) only redirects to /firstrun when
  * /api/install/state.first_run === true; this view does not re-check —
@@ -24,11 +28,23 @@ const router = useRouter()
 const toasts = useToastsStore()
 const system = useSystemStore()
 
-const step = ref(1)              // 1 | 2 | 3 | 4 (done)
+// Step numbers map: 1 = password (optional), 2 = picker, 3 = license,
+// 4 = install, 5 = done. Step 1 self-skips when a password is already
+// set so re-entering the wizard after first install doesn't nag for a
+// password rotation.
+const step = ref(1)              // 1 | 2 | 3 | 4 | 5 (done)
 const curated = ref([])          // /api/install/curated-models result
 const customAllowed = ref(false)
 const loadingCatalogue = ref(true)
 const catalogueError = ref(null)
+
+// Password step state. ``passwordSetServerSide`` reflects the latest
+// /api/auth/status.password_set value; when true on mount we skip step 1.
+const passwordSetServerSide = ref(false)
+const passwordInput = ref('')
+const passwordSubmitting = ref(false)
+const passwordError = ref('')
+const PASSWORD_MIN_LEN = 8  // mirrors hal0.api.routes.auth._MIN_PASSWORD_LEN
 
 // Picker state
 const selectedModel = ref(null)  // curated entry OR { id: 'custom', ... }
@@ -47,8 +63,26 @@ const sse           = ref(null)    // EventSource handle (so onUnmounted closes)
 const downloadStart = ref(0)       // monotonic for ETA
 const chatUrl       = ref(null)
 
-// ── Catalogue fetch on mount ─────────────────────────────────────────────────
+// ── Catalogue + auth-status fetch on mount ───────────────────────────────────
 onMounted(async () => {
+  // Probe auth status first so the password step can auto-skip when a
+  // password is already set (re-running the wizard, or upgrading from
+  // an install where the operator set one through Settings). Failure
+  // here is tolerable — we default to "ask" rather than silently
+  // skipping a security step.
+  try {
+    const s = await api('/api/auth/status')
+    passwordSetServerSide.value = !!s?.password_set
+    if (passwordSetServerSide.value) {
+      step.value = 2
+    }
+  } catch (e) {
+    // Status probe failed — best to leave the password step visible so
+    // the operator can still try to set one. The /password endpoint
+    // will surface a real error if it's broken.
+    console.warn('auth/status probe failed; showing password step anyway', e)
+  }
+
   try {
     const r = await api('/api/install/curated-models')
     curated.value = r?.models ?? []
@@ -102,7 +136,47 @@ function selectCustom() {
   customErr.value = ''
 }
 
-function goStep2() {
+// ── Step 1 — Password (optional, ADR-0001 Child B) ─────────────────────────
+async function submitPassword() {
+  passwordError.value = ''
+  if (passwordInput.value.length < PASSWORD_MIN_LEN) {
+    passwordError.value = `Password must be at least ${PASSWORD_MIN_LEN} characters.`
+    return
+  }
+  passwordSubmitting.value = true
+  try {
+    // First-run claim: /api/auth/password is public when no password is
+    // set, so no Authorization header is needed. The middleware enforces
+    // the writer-scope requirement once a password exists, which is what
+    // makes the second call (rotation) require an authenticated session.
+    await api('/api/auth/password', {
+      method: 'POST',
+      body: JSON.stringify({ password: passwordInput.value }),
+    })
+    passwordSetServerSide.value = true
+    toasts.info('Password set — you can change it later in Settings.')
+    // Clear the input rather than keep a copy in the Vue ref.
+    passwordInput.value = ''
+    step.value = 2
+  } catch (e) {
+    passwordError.value = e?.message || 'Could not set password.'
+    toasts.error(passwordError.value)
+  } finally {
+    passwordSubmitting.value = false
+  }
+}
+
+function skipPassword() {
+  // Skipping leaves the install in the "open" posture — explicit choice
+  // by the operator. The wizard reminds them they can set one later
+  // from Settings → Authentication.
+  passwordInput.value = ''
+  passwordError.value = ''
+  step.value = 2
+}
+
+// ── Step 2 / 3 transitions (picker → license) ──────────────────────────────
+function goStep3() {
   if (showCustom.value) {
     if (!customRepo.value.trim()) {
       customErr.value = 'Repo is required (e.g. org/Model-GGUF)'
@@ -130,21 +204,21 @@ function goStep2() {
     toasts.warning('Please select a model first')
     return
   }
-  step.value = 2
+  step.value = 3
 }
 
 function backToPicker() {
-  step.value = 1
+  step.value = 2
   licenseAccepted.value = false
 }
 
-// ── Step 3 — start the pull ─────────────────────────────────────────────────
+// ── Step 4 — start the pull ─────────────────────────────────────────────────
 async function startDownload() {
   if (!licenseAccepted.value) {
     toasts.warning('Please accept the license first')
     return
   }
-  step.value = 3
+  step.value = 4
   downloadStart.value = performance.now()
   pullJob.value = null
 
@@ -182,7 +256,7 @@ async function startDownload() {
     subscribeToProgress(modelId)
   } catch (e) {
     toasts.error(`Download failed: ${e.message}`)
-    step.value = 2
+    step.value = 3
   }
 }
 
@@ -202,7 +276,7 @@ function subscribeToProgress(modelId) {
         es.close()
         sse.value = null
         toasts.error(`Download ${snapshot.state}: ${snapshot.error || 'unknown error'}`)
-        step.value = 2
+        step.value = 3
       }
     } catch (err) {
       console.error('SSE parse failed', err)
@@ -222,7 +296,7 @@ async function pollAsFallback(modelId) {
     if (s.state === 'completed') { onPullComplete(); return }
     if (s.state === 'failed' || s.state === 'cancelled') {
       toasts.error(`Download ${s.state}: ${s.error || 'unknown error'}`)
-      step.value = 2
+      step.value = 3
       return
     }
     setTimeout(() => pollAsFallback(modelId), 500)
@@ -237,7 +311,7 @@ async function onPullComplete() {
     chatUrl.value = urls?.openwebui ?? null
   } catch { /* tolerable; fallback below */ }
   await system.fetchStatus()
-  step.value = 4
+  step.value = 5
 }
 
 async function openChat() {
@@ -282,7 +356,7 @@ const downloadSpeed = computed(() => {
   return `${fmtSize(pullJob.value.bytes_downloaded / elapsedS)}/s`
 })
 
-const stepLabels = ['Pick model', 'License', 'Install', 'Done']
+const stepLabels = ['Password', 'Pick model', 'License', 'Install', 'Done']
 </script>
 
 <template>
@@ -313,8 +387,52 @@ const stepLabels = ['Pick model', 'License', 'Install', 'Done']
         </div>
       </div>
 
-      <!-- ── Step 1 — Pick model ───────────────────────────────── -->
+      <!-- ── Step 1 — Set up password (optional, ADR-0001 Child B) ── -->
       <div v-if="step === 1" class="wizard-body">
+        <p class="step-desc">
+          Set a password to protect the dashboard and the OpenAI-compatible API.
+          You can skip this and run hal0 open on your trusted LAN, then add a
+          password later from <strong>Settings → Authentication</strong>.
+        </p>
+
+        <label class="field-label" for="firstrun-password">Password</label>
+        <input
+          id="firstrun-password"
+          v-model="passwordInput"
+          class="field-input"
+          type="password"
+          autocomplete="new-password"
+          :placeholder="`at least ${PASSWORD_MIN_LEN} characters`"
+          @keydown.enter.prevent="submitPassword"
+        />
+        <p v-if="passwordError" class="field-err">{{ passwordError }}</p>
+        <p class="field-hint">
+          Recommended: at least 12 characters with a mix of letters and digits.
+          We hash the password with bcrypt (cost 12) before storing it.
+        </p>
+
+        <div class="wizard-footer wizard-footer-2">
+          <button
+            class="btn-ghost"
+            type="button"
+            :disabled="passwordSubmitting"
+            @click="skipPassword"
+          >
+            Skip — leave open
+          </button>
+          <button
+            class="btn-primary"
+            type="button"
+            :disabled="passwordSubmitting || passwordInput.length < PASSWORD_MIN_LEN"
+            @click="submitPassword"
+          >
+            {{ passwordSubmitting ? 'Setting…' : 'Set password' }}
+          </button>
+        </div>
+      </div>
+
+      <!-- ── Step 2 — Pick model ───────────────────────────────── -->
+      <div v-if="step === 2" class="wizard-body">
         <p class="step-desc">Pick a starting model. You can add more from the Models page later.</p>
 
         <div v-if="loadingCatalogue" class="loading-state">Loading models…</div>
@@ -380,15 +498,15 @@ const stepLabels = ['Pick model', 'License', 'Install', 'Done']
             class="btn-primary btn-wide"
             type="button"
             :disabled="!selectedModel && !showCustom"
-            @click="goStep2"
+            @click="goStep3"
           >
             Next: Review license →
           </button>
         </div>
       </div>
 
-      <!-- ── Step 2 — License confirm ─────────────────────────── -->
-      <div v-if="step === 2 && selectedModel" class="wizard-body">
+      <!-- ── Step 3 — License confirm ─────────────────────────── -->
+      <div v-if="step === 3 && selectedModel" class="wizard-body">
         <p class="step-desc">
           You're about to download <strong>{{ selectedModel.display_name }}</strong> under the
           <strong>{{ selectedModel.license }}</strong> license. Confirm the terms below.
@@ -425,8 +543,8 @@ const stepLabels = ['Pick model', 'License', 'Install', 'Done']
         </div>
       </div>
 
-      <!-- ── Step 3 — Download + assign ───────────────────────── -->
-      <div v-if="step === 3" class="wizard-body">
+      <!-- ── Step 4 — Download + assign ───────────────────────── -->
+      <div v-if="step === 4" class="wizard-body">
         <p class="step-desc">
           Downloading <strong>{{ selectedModel?.display_name }}</strong> and assigning to the
           <code class="inline-code">primary</code> slot.
@@ -448,8 +566,8 @@ const stepLabels = ['Pick model', 'License', 'Install', 'Done']
         <p class="step-hint">This typically takes a few minutes depending on your connection. The slot starts automatically when the download completes.</p>
       </div>
 
-      <!-- ── Step 4 — Done ────────────────────────────────────── -->
-      <div v-if="step === 4" class="wizard-body wizard-done">
+      <!-- ── Step 5 — Done ────────────────────────────────────── -->
+      <div v-if="step === 5" class="wizard-body wizard-done">
         <div class="done-icon" aria-hidden="true">✓</div>
         <h2 class="done-title">You're all set!</h2>
         <p class="done-desc">


### PR DESCRIPTION
Wave 2 of ADR-0001 (refs #54, lands the breaking change Child A unblocked).

ADR: [`docs/adr/0001-collapse-edge-auth-into-fastapi.md`](https://github.com/Hal0ai/hal0/blob/main/docs/adr/0001-collapse-edge-auth-into-fastapi.md). Parent issue: #54. Spec: #56.

## Summary

- **Demote Caddy to a dumb TLS terminator + reverse proxy.** All auth (password + session cookies + Bearer tokens) lives in FastAPI, where Child A put it.
- **Delete the `PUBLIC_PATHS` frozenset + `require_token_unless_public` dependency.** Route publicness is now declared by NOT attaching an auth dep at `include_router(...)` time — no allowlist, no two-source drift class of bugs (#28, #51).
- **Drop `--auth=basic` + admin-credential prompts from `installer/install.sh`.** Add `--no-tls` which skips Caddy entirely and binds FastAPI on `0.0.0.0:8080` (right path for hosts behind an existing reverse proxy).
- **Wire the wizard's password step.** Real integration in `ui/src/views/FirstRun.vue` — probes `/api/auth/status` on mount, auto-skips when a password is already set, otherwise renders a "Set up password (optional)" step that POSTs to `/api/auth/password` (Child A's first-run public path).

## Files touched, by concern

| Concern | Files |
|---|---|
| Caddyfile reduction | `packaging/caddy/Caddyfile.template` (-89 / +24, **107 → 42 lines** — the directive block itself is the 10-line ADR §1 form; remainder is doc header + commented-import seam) |
| `PUBLIC_PATHS` deletion + router rewiring | `src/hal0/api/middleware/auth.py`, `src/hal0/api/__init__.py`, `src/hal0/api/routes/v1.py` (split into `public_router` + `router`), `src/hal0/api/routes/health.py` (doc comment) |
| Installer flag surface | `installer/install.sh` (drop `--auth=basic`, add `--no-tls`, rename `HAL0_HOSTNAME` → `HAL0_PUBLIC_HOST`, auto-pick `tls internal` vs ACME based on hostname) |
| Wizard UI hook | `ui/src/views/FirstRun.vue` (new step 1 = password; picker/license/install/done renumber to 2/3/4/5; auto-skip when `password_set`) |
| Harness rows | `tests/harness/installer-test.sh` (drop `auth-basic`; add `tls-default` + `no-tls`), `scripts/harness.sh` (rename `HAL0_HARNESS_AUTH` → `HAL0_HARNESS_TLS`) |
| Tests | `tests/api/test_no_public_paths.py` (new, 15 tests), `tests/api/test_auth_middleware.py` (drop `/api/install/curated-models` from the protected-routes parametrize — wizard endpoint now public by design) |

`git grep PUBLIC_PATHS` returns zero hits in `src/` and `packaging/`. Remaining mentions live in `docs/adr/0001-...`, `tests/harness/FINDINGS.md`, and a couple of historical comments — Child C will sweep those.

## Caddyfile LoC delta

`packaging/caddy/Caddyfile.template`: **107 → 42 lines (-65 net)**. The actual Caddy directives went from `basicauth` + `@public path` matcher + 3 `handle` blocks + `handle_path /chat*` (~70 effective lines) down to:

```caddy
{$HAL0_PUBLIC_HOST:hal0.local} {
    tls {$HAL0_TLS_DIRECTIVE:internal}
    encode zstd gzip
    reverse_proxy 127.0.0.1:8080
}
```

## Wizard UI: real or scaffolded?

**Real integration.** `ui/src/views/FirstRun.vue` got a new step 1 (password) inserted before the picker. It probes `/api/auth/status` on mount; if `password_set` is already true the step auto-skips to the picker. Submit calls the public-on-first-run `POST /api/auth/password`. Skip advances without setting one. Step renumber: picker 1→2, license 2→3, install 3→4, done 4→5. Build verified with `vite build`.

## Test results

```
PYTHONPATH=<worktree>/src uv run --no-sync pytest tests/
869 passed, 3 skipped, 4 deselected in 31.85s
```

15 new tests in `tests/api/test_no_public_paths.py` all green. The auth + installer regression suite (211 tests across `test_auth_*` + `test_password_auth` + `test_installer_routes`) all green.

## Out of scope — Child C lands these

Per the ADR's three-PR plan:

- `installer/README.md`, `PLAN.md`, `tests/harness/FINDINGS.md` doc sweeps
- Closing #43 (credential capture by deletion) and #51 (PUBLIC_PATHS drift)
- Reframing FINDINGS.md #10 (the original #28 entry) as "fixed by architecture removal"

**Do NOT close #54** on merge — Child C still needs to land.

## CI heads-up

Hal0ai org Actions are billing-blocked; PR CI will fail in ~2s with no logs. Verified locally with the `PYTHONPATH=<worktree>/src uv run --no-sync pytest` invocation above. User will admin-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)