### PR TITLE
fix(cli): wire `hal0 uninstall` + escape NOT_IMPLEMENTED sentinel

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -639,7 +639,7 @@ hal0 config show
 hal0 config edit                     # $EDITOR
 hal0 config migrate
 hal0 config validate
-hal0 uninstall [--keep-data]
+hal0 uninstall [--keep-data] [--force] [--dev]
 ```
 
 Implementation: Typer (typed click). Each command hits the local API on

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ The API lives at `http://127.0.0.1:8080`, the dashboard at the Vite dev
 server URL (usually `http://127.0.0.1:5173`).
 
 Run `hal0 doctor` any time to re-check pre-flight (systemd / python /
-docker / disk / ports).
+docker / disk / ports). `hal0 model pull <ref>` streams models from
+Hugging Face into the registry, and `hal0 uninstall [--keep-data]` tears
+down a running install (thin wrapper over `installer/uninstall.sh`).
 
 ### Auth posture
 

--- a/src/hal0/cli/_shared.py
+++ b/src/hal0/cli/_shared.py
@@ -11,7 +11,7 @@ from rich.console import Console
 
 _console = Console(stderr=True)
 
-NOT_IMPLEMENTED = "[not implemented yet — Phase N: see PLAN.md §13]"
+NOT_IMPLEMENTED = "not implemented yet — see PLAN.md §13"
 
 
 def _api_base() -> str:

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -8,6 +8,9 @@ Entry point declared in pyproject.toml:
 from __future__ import annotations
 
 import json as jsonlib
+import os
+import sys
+from pathlib import Path
 
 import typer
 import uvicorn
@@ -18,7 +21,6 @@ from rich.table import Table
 
 import hal0
 from hal0.cli._shared import (
-    NOT_IMPLEMENTED,
     CliApiError,
     _api_base,
     _api_unreachable,
@@ -189,7 +191,53 @@ def uninstall(
         "--keep-data",
         help="Preserve /var/lib/hal0/ (model cache, openwebui state, slot data).",
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Skip the DELETE confirmation prompt (also honours HAL0_FORCE=1).",
+    ),
+    dev: bool = typer.Option(
+        False,
+        "--dev",
+        help="Tear down a dev-mode install rooted at $PWD/.hal0ai (or $HAL0_PREFIX).",
+    ),
 ) -> None:
-    """Uninstall hal0 from this system."""
-    # Phase 5: orchestrate systemctl stop/disable + dir removal
-    console.print(NOT_IMPLEMENTED)
+    """Uninstall hal0 from this system.
+
+    Thin wrapper around ``installer/uninstall.sh`` — the shell script is the
+    source of truth and mirrors install.sh's path layout. We exec it so the
+    script inherits the live TTY for its DELETE confirmation prompt.
+    """
+    import shutil
+
+    # Editable install: src/hal0/__init__.py -> repo root is parents[2].
+    repo_root = Path(hal0.__file__).resolve().parents[2]
+    script = repo_root / "installer" / "uninstall.sh"
+    if not script.is_file():
+        die(
+            f"uninstall.sh not found at {script}. "
+            "This hal0 install looks packaged differently — run the script directly."
+        )
+
+    if not shutil.which("bash"):
+        die("bash is required to run the uninstaller.")
+
+    # The script's DELETE prompt needs an interactive stdin. Refuse early in
+    # non-interactive contexts unless the caller has opted out of the prompt.
+    force_env = os.environ.get("HAL0_FORCE") == "1"
+    if not (keep_data or force or force_env) and not sys.stdin.isatty():
+        die(
+            "Refusing to uninstall non-interactively without --force or "
+            "--keep-data — the shell script's DELETE prompt would hang."
+        )
+
+    argv = ["bash", str(script)]
+    if keep_data:
+        argv.append("--keep-data")
+    if force:
+        argv.append("--force")
+    if dev:
+        argv.append("--dev")
+
+    os.execvp("bash", argv)

--- a/tests/cli/test_uninstall.py
+++ b/tests/cli/test_uninstall.py
@@ -1,0 +1,156 @@
+"""Tests for the ``hal0 uninstall`` CLI subcommand.
+
+The command is a thin wrapper around ``installer/uninstall.sh`` — it
+exec's the script so the script's DELETE prompt inherits the live TTY.
+These tests intercept ``os.execvp`` and assert the argv the wrapper
+constructs, plus the pre-flight refusals that protect non-interactive
+callers from a hung prompt.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from hal0.cli.main import app, uninstall
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def captured_exec(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Intercept os.execvp so we can assert argv without replacing the process."""
+    captured: dict[str, Any] = {}
+
+    def fake_execvp(file: str, argv: list[str]) -> None:
+        captured["file"] = file
+        captured["argv"] = list(argv)
+        # Raise typer.Exit so the command returns control to the test —
+        # the real execvp never returns either, so callers don't expect it to.
+        raise typer.Exit(0)
+
+    monkeypatch.setattr("os.execvp", fake_execvp)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    return captured
+
+
+def test_uninstall_default_args(captured_exec: dict[str, Any]) -> None:
+    """No flags → bash <script> with no extra args.
+
+    Bypasses CliRunner (which swaps stdin for a non-TTY StringIO) and calls
+    the Typer command function directly so the production isatty() check
+    sees the True we monkeypatched."""
+    with pytest.raises(typer.Exit) as exc:
+        uninstall(keep_data=False, force=False, dev=False)
+    assert (exc.value.exit_code or 0) == 0
+    assert captured_exec["file"] == "bash"
+    assert captured_exec["argv"][0] == "bash"
+    assert captured_exec["argv"][1].endswith("/installer/uninstall.sh")
+    assert captured_exec["argv"][2:] == []
+
+
+def test_uninstall_keep_data_flag(captured_exec: dict[str, Any]) -> None:
+    result = runner.invoke(app, ["uninstall", "--keep-data"])
+    assert result.exit_code == 0
+    assert captured_exec["argv"][2:] == ["--keep-data"]
+
+
+def test_uninstall_force_flag(captured_exec: dict[str, Any]) -> None:
+    result = runner.invoke(app, ["uninstall", "--force"])
+    assert result.exit_code == 0
+    assert captured_exec["argv"][2:] == ["--force"]
+
+
+def test_uninstall_short_force_flag(captured_exec: dict[str, Any]) -> None:
+    result = runner.invoke(app, ["uninstall", "-f"])
+    assert result.exit_code == 0
+    assert captured_exec["argv"][2:] == ["--force"]
+
+
+def test_uninstall_dev_flag(captured_exec: dict[str, Any]) -> None:
+    result = runner.invoke(app, ["uninstall", "--dev", "--keep-data"])
+    assert result.exit_code == 0
+    assert captured_exec["argv"][2:] == ["--keep-data", "--dev"]
+
+
+def test_uninstall_refuses_without_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bare `hal0 uninstall` from a non-TTY context must refuse, so the
+    shell script's DELETE prompt doesn't hang silently."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.delenv("HAL0_FORCE", raising=False)
+
+    called: dict[str, Any] = {}
+
+    def fake_execvp(file: str, argv: list[str]) -> None:
+        called["yes"] = True
+
+    monkeypatch.setattr("os.execvp", fake_execvp)
+
+    result = runner.invoke(app, ["uninstall"])
+    assert result.exit_code == 1
+    assert "yes" not in called
+
+
+def test_uninstall_non_tty_with_force_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--force bypasses the prompt — no TTY needed."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.delenv("HAL0_FORCE", raising=False)
+
+    captured: dict[str, Any] = {}
+
+    def fake_execvp(file: str, argv: list[str]) -> None:
+        captured["argv"] = list(argv)
+        raise typer.Exit(0)
+
+    monkeypatch.setattr("os.execvp", fake_execvp)
+
+    result = runner.invoke(app, ["uninstall", "--force"])
+    assert result.exit_code == 0
+    assert "--force" in captured["argv"]
+
+
+def test_uninstall_non_tty_with_hal0_force_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HAL0_FORCE=1 also bypasses the TTY requirement."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setenv("HAL0_FORCE", "1")
+
+    captured: dict[str, Any] = {}
+
+    def fake_execvp(file: str, argv: list[str]) -> None:
+        captured["argv"] = list(argv)
+        raise typer.Exit(0)
+
+    monkeypatch.setattr("os.execvp", fake_execvp)
+
+    result = runner.invoke(app, ["uninstall"])
+    assert result.exit_code == 0
+    assert captured["argv"][1].endswith("/installer/uninstall.sh")
+
+
+def test_uninstall_missing_script_dies(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If uninstall.sh isn't where we expect, fail loudly instead of running."""
+    import hal0
+
+    fake_module = tmp_path / "src" / "hal0" / "__init__.py"
+    fake_module.parent.mkdir(parents=True)
+    fake_module.write_text("")
+    monkeypatch.setattr(hal0, "__file__", str(fake_module))
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    called: dict[str, Any] = {}
+
+    def fake_execvp(file: str, argv: list[str]) -> None:
+        called["yes"] = True
+
+    monkeypatch.setattr("os.execvp", fake_execvp)
+
+    result = runner.invoke(app, ["uninstall"])
+    assert result.exit_code == 1
+    assert "yes" not in called


### PR DESCRIPTION
## Summary

- **Sentinel fix** (`a812e55`): the `NOT_IMPLEMENTED` constant was the string `[not implemented yet — Phase N: see PLAN.md §13]`, which Rich's markup parser treated as a (malformed) tag and silently dropped. Any stub command printing it exited 0 with **zero output** — looking like success while doing nothing. Switched to plain text.
- **`hal0 uninstall` wiring** (`117a55a`): the Typer command was a stub; the shell uninstaller (`installer/uninstall.sh`) has been complete since Phase 2 and is the source of truth. Wired the CLI as a thin wrapper that `os.execvp`s `bash <script>` so the DELETE prompt inherits the live TTY.

## What landed

- New flags `--force/-f` and `--dev` mirror `installer/uninstall.sh`.
- Refuses non-interactively without `--force` / `--keep-data` / `HAL0_FORCE=1` so the script's DELETE prompt can't hang silently.
- Locates the script via the package's editable-install path; fails loudly if missing.
- `tests/cli/test_uninstall.py` covers argv composition (default, `--keep-data`, `--force`, `-f`, `--dev`), TTY refusal, `--force` bypass, `HAL0_FORCE=1` bypass, and missing-script handling — 9 tests, all green.
- `PLAN.md` §13 + `README.md` updated with the new flag surface.

## Test plan

- [x] `pytest tests/cli/` — 25/25 passing (the new 9 + existing 16)
- [x] `pytest tests/api/test_pull_routes.py tests/api/test_stubs_return_envelope.py` — 21/21 passing
- [x] Live exercise on hal0 LXC: `HAL0_PREFIX=/tmp/x /opt/hal0/.venv/bin/hal0 uninstall --dev --keep-data` → CLI exec'd `bash installer/uninstall.sh --keep-data --dev`, script ran end-to-end, exit 0
- [x] `hal0 uninstall </dev/null` → refuses with the expected error (was silently exiting 0 before)
- [x] `hal0 uninstall --help` shows the new `--force/-f` and `--dev` options

🤖 Generated with [Claude Code](https://claude.com/claude-code)