### PR TITLE
chore: ruff clean — fix 19 lint errors + format 27 files

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -19,16 +19,16 @@ from hal0.api.routes import (
     auth as auth_routes,
 )
 from hal0.api.routes import (
-    config as config_routes,
-)
-from hal0.api.routes import (
-    events as events_routes,
-)
-from hal0.api.routes import (
     backends as backends_routes,
 )
 from hal0.api.routes import (
     capabilities as capabilities_routes,
+)
+from hal0.api.routes import (
+    config as config_routes,
+)
+from hal0.api.routes import (
+    events as events_routes,
 )
 from hal0.api.routes import (
     hardware,

--- a/src/hal0/api/deps.py
+++ b/src/hal0/api/deps.py
@@ -60,9 +60,7 @@ def get_hardware(request: Request) -> HardwareProbe:
 def get_capability_orchestrator(request: Request) -> CapabilityOrchestrator:
     obj = _state(request, "capability_orchestrator")
     if obj is None:
-        raise RuntimeError(
-            "capability orchestrator not initialized (lifespan did not run)"
-        )
+        raise RuntimeError("capability orchestrator not initialized (lifespan did not run)")
     return cast("CapabilityOrchestrator", obj)
 
 

--- a/src/hal0/api/routes/backends.py
+++ b/src/hal0/api/routes/backends.py
@@ -16,9 +16,9 @@ from typing import Any
 
 from fastapi import APIRouter, Request
 
-from hal0.api.deps import CapabilityOrchestratorDep, SlotManagerDep
+from hal0.api.deps import SlotManagerDep
 from hal0.capabilities.catalog import available_backends, get_backend
-from hal0.capabilities.orchestrator import _CHILD_TO_SLOT, _SLOT_TO_CHILD
+from hal0.capabilities.orchestrator import _CHILD_TO_SLOT
 from hal0.config.loader import load_hardware_info
 from hal0.errors import NotFound
 
@@ -121,7 +121,7 @@ async def _loaded_children_for_backend(
       1. Walk every (capability slot, child) pair in ``_CHILD_TO_SLOT``
          and surface the ones whose backend matches. These rows carry
          ``source="capability"`` so the UI knows they're managed via the
-         capability picker (no × control).
+         capability picker (no per-row remove control).
 
       2. Walk every other slot (e.g. ``primary``, ad-hoc NPU loads from
          the backend card) and surface the ones whose backend matches.
@@ -226,9 +226,7 @@ async def _build_backend_payload(
 
 
 @router.get("")
-async def list_backends(
-    request: Request, slot_manager: SlotManagerDep
-) -> list[dict[str, Any]]:
+async def list_backends(request: Request, slot_manager: SlotManagerDep) -> list[dict[str, Any]]:
     """Return one row per available backend with live status."""
     out: list[dict[str, Any]] = []
     for backend in available_backends():

--- a/src/hal0/api/routes/config.py
+++ b/src/hal0/api/routes/config.py
@@ -47,6 +47,7 @@ def _validation_error_details(exc: ValidationError) -> dict[str, str]:
         out[loc or "<root>"] = err.get("msg", "invalid")
     return out
 
+
 # Default ports — these match what `hal0-api.service` and
 # `hal0-openwebui.service` bind to.  The API port can be overridden via
 # the HAL0_PORT env var that ``hal0-api.service`` sources from

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -24,8 +24,7 @@ from hal0.api.middleware.error_codes import BadRequest, Hal0Error
 from hal0.config.loader import load_hal0_config
 from hal0.registry.curated import CURATED, CuratedModel, HaloaiModel, get_curated
 from hal0.registry.detect import DetectionResult, detect
-from hal0.registry.discover import is_skippable
-from hal0.registry.discover import scan_and_register
+from hal0.registry.discover import is_skippable, scan_and_register
 from hal0.registry.pull import (
     PullInvalidSource,
     PullJob,
@@ -373,9 +372,7 @@ async def _commit_scan_rows(
             try:
                 defaults_obj = ModelDefaults.model_validate(defaults_payload)
             except Exception as exc:
-                skipped.append(
-                    {"path": str(resolved), "reason": f"invalid_defaults:{exc}"}
-                )
+                skipped.append({"path": str(resolved), "reason": f"invalid_defaults:{exc}"})
                 continue
 
         size_bytes = 0
@@ -542,7 +539,7 @@ async def update_model(model_id: str, request: Request) -> dict[str, Any]:
 
     after = model.model_dump(mode="python")
     changed: list[str] = []
-    for key in body.keys():
+    for key in body:
         if key == "id":
             continue
         if before.get(key) != after.get(key):
@@ -616,11 +613,10 @@ def _clear_slot_default(slot_path: Path, slot_cfg: dict[str, Any]) -> None:
         new_model = dict(model_sect)
         new_model["default"] = ""
         new_cfg["model"] = new_model
-    try:
+    # Cascade continues if the write fails; the dangling reference is
+    # surfaced later.
+    with contextlib.suppress(OSError):
         slot_path.write_bytes(tomli_w.dumps(new_cfg).encode("utf-8"))
-    except OSError:
-        # Cascade continues; the dangling reference is surfaced later.
-        pass
 
 
 async def _unload_slot_if_running(request: Request, slot_name: str) -> None:
@@ -769,9 +765,7 @@ async def _run_pull_with_events(
     signal SSE listens to so the byte counts stay authoritative.
     """
     if event_bus is None:
-        await run_pull(
-            job, hf_repo=hf_repo, hf_file=hf_file, registry=registry, hf_token=hf_token
-        )
+        await run_pull(job, hf_repo=hf_repo, hf_file=hf_file, registry=registry, hf_token=hf_token)
         return
 
     async def _emit_progress() -> None:
@@ -807,9 +801,7 @@ async def _run_pull_with_events(
 
     progress_task = asyncio.create_task(_emit_progress())
     try:
-        await run_pull(
-            job, hf_repo=hf_repo, hf_file=hf_file, registry=registry, hf_token=hf_token
-        )
+        await run_pull(job, hf_repo=hf_repo, hf_file=hf_file, registry=registry, hf_token=hf_token)
     finally:
         progress_task.cancel()
         with contextlib.suppress(asyncio.CancelledError, Exception):

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -259,7 +259,7 @@ async def _systemd_show(unit: str, *props: str) -> dict[str, str]:
             stderr=asyncio.subprocess.DEVNULL,
         )
         out, _ = await asyncio.wait_for(proc.communicate(), timeout=2.0)
-    except (FileNotFoundError, asyncio.TimeoutError, OSError):
+    except (TimeoutError, FileNotFoundError, OSError):
         return {}
     if proc.returncode != 0:
         return {}
@@ -347,7 +347,7 @@ async def _docker_container_mem_bytes(container_name: str) -> int:
             stderr=asyncio.subprocess.DEVNULL,
         )
         out, _ = await asyncio.wait_for(proc.communicate(), timeout=1.5)
-    except (FileNotFoundError, asyncio.TimeoutError, OSError):
+    except (TimeoutError, FileNotFoundError, OSError):
         return 0
     if proc.returncode != 0:
         return 0
@@ -358,7 +358,7 @@ async def _docker_container_mem_bytes(container_name: str) -> int:
     if pid <= 0:
         return 0
     try:
-        with open(f"/proc/{pid}/cgroup", "r", encoding="utf-8") as f:
+        with open(f"/proc/{pid}/cgroup", encoding="utf-8") as f:
             cg_line = f.readline().strip()
     except OSError:
         return 0
@@ -367,7 +367,7 @@ async def _docker_container_mem_bytes(container_name: str) -> int:
         return 0
     cg_rel = cg_line.split("::", 1)[1].lstrip("/")
     try:
-        with open(f"/sys/fs/cgroup/{cg_rel}/memory.current", "r", encoding="utf-8") as f:
+        with open(f"/sys/fs/cgroup/{cg_rel}/memory.current", encoding="utf-8") as f:
             return int(f.read().strip() or 0)
     except (OSError, ValueError):
         return 0
@@ -412,9 +412,7 @@ async def _local_slot_metrics(request: Request) -> dict[str, dict[str, Any]]:
                 "ActiveState",
             )
         )
-        mem_task = asyncio.create_task(
-            _docker_container_mem_bytes(f"hal0-slot-{slot.name}")
-        )
+        mem_task = asyncio.create_task(_docker_container_mem_bytes(f"hal0-slot-{slot.name}"))
         metrics_task = asyncio.create_task(_scrape_llama_metrics(slot.port))
         props, mem_bytes, llm_metrics = await asyncio.gather(
             props_task, mem_task, metrics_task, return_exceptions=False
@@ -640,8 +638,7 @@ async def load_slot(name: str, request: Request) -> dict[str, object]:
             from hal0.registry.store import ModelNotFound
 
             raise ModelNotFound(
-                f"model {model_id!r} is not in the registry "
-                f"(slot {name!r} not touched)",
+                f"model {model_id!r} is not in the registry (slot {name!r} not touched)",
                 details={"model_id": model_id, "slot": name},
             )
     snap = await sm.load(name, model_id=model_id)
@@ -689,8 +686,7 @@ async def swap_slot(name: str, request: Request) -> dict[str, object]:
         from hal0.registry.store import ModelNotFound
 
         raise ModelNotFound(
-            f"model {model_id!r} is not in the registry "
-            f"(slot {name!r} not touched)",
+            f"model {model_id!r} is not in the registry (slot {name!r} not touched)",
             details={"model_id": model_id, "slot": name},
         )
     snap = await sm.swap(name, model_id)

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -27,7 +27,6 @@ from hal0.config.loader import load_hardware_info
 from hal0.registry.curated import CURATED, CuratedModel, HaloaiModel
 from hal0.registry.store import ModelRegistry
 
-
 # ── Capability → child mappings ───────────────────────────────────────────────
 
 # Capability strings that may appear on a Model / CuratedModel mapped to
@@ -296,9 +295,7 @@ def _backend_variants(entry: Any) -> list[str]:
     return out
 
 
-def _provider_for_backend(
-    entry_backend: str, backend_id: str, *, entry: Any = None
-) -> str:
+def _provider_for_backend(entry_backend: str, backend_id: str, *, entry: Any = None) -> str:
     """Pick the provider that pairs with this backend / entry combo.
 
     Resolution order:
@@ -389,10 +386,9 @@ def _is_pullable(entry: Any, *, registry: ModelRegistry | None) -> bool:
     intentionally not pullable.
     """
     repo = (getattr(entry, "hf_repo", "") or "").strip()
-    filename = (
-        (getattr(entry, "hf_file", "") or "").strip()
-        or (getattr(entry, "hf_filename", "") or "").strip()
-    )
+    filename = (getattr(entry, "hf_file", "") or "").strip() or (
+        getattr(entry, "hf_filename", "") or ""
+    ).strip()
     if repo and filename:
         return True
     if registry is None:

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -297,7 +297,6 @@ class CapabilityOrchestrator:
         before_enabled = existing.enabled
         before_model = existing.model
         before_backend = existing.backend
-        before_provider = existing.provider
 
         # Shallow-merge the partial into the existing selection.
         merged_data: dict[str, Any] = existing.model_dump()
@@ -317,9 +316,7 @@ class CapabilityOrchestrator:
         # caller didn't explicitly clear it. We don't fail when the model
         # is empty — that's the "unset" state.
         if merged.model:
-            self._validate_model_in_catalog(
-                slot, child, merged.model, merged.backend
-            )
+            self._validate_model_in_catalog(slot, child, merged.model, merged.backend)
 
         cfg.selections[slot][child] = merged
 
@@ -327,7 +324,9 @@ class CapabilityOrchestrator:
         enabled_changed = merged.enabled != before_enabled
         model_changed = merged.model != before_model
         backend_changed = merged.backend != before_backend
-        provider_changed = merged.provider != before_provider
+        # provider change does not gate any branch today — the slot TOML
+        # rewrite below covers it. Reintroduce if the swap path grows a
+        # provider-aware case.
 
         try:
             # Reconcile the slot TOML against the merged selection whenever
@@ -431,8 +430,7 @@ class CapabilityOrchestrator:
         legal_backends = [b["id"] for b in match.get("backends", [])]
         if backend_id not in legal_backends:
             raise BadRequest(
-                f"backend {backend_id!r} cannot serve model {model_id!r} "
-                f"for {slot}.{child}",
+                f"backend {backend_id!r} cannot serve model {model_id!r} for {slot}.{child}",
                 code="capability.illegal_backend_model_pair",
                 details={
                     "slot": slot,
@@ -443,9 +441,7 @@ class CapabilityOrchestrator:
                 },
             )
 
-    async def _ensure_slot_exists(
-        self, slot_name: str, selection: CapabilitySelection
-    ) -> None:
+    async def _ensure_slot_exists(self, slot_name: str, selection: CapabilitySelection) -> None:
         """Auto-create the slot TOML on first use of a non-builtin child.
 
         ``embed-rerank`` is the canonical example: it isn't a builtin
@@ -539,9 +535,9 @@ class CapabilityOrchestrator:
 
 
 __all__ = [
+    "LEGAL_SLOTS",
     "CapabilityApplyFailed",
     "CapabilityOrchestrator",
-    "LEGAL_SLOTS",
     "child_to_slot",
     "legal_children",
 ]

--- a/src/hal0/cli/capabilities_commands.py
+++ b/src/hal0/cli/capabilities_commands.py
@@ -107,9 +107,7 @@ def migrate(
             capability = _CHILD_TO_CAPABILITY.get((slot, child))
             if capability is None:
                 continue
-            verdict, legal = _classify_pair(
-                capability, sel.model, sel.backend, registry
-            )
+            verdict, legal = _classify_pair(capability, sel.model, sel.backend, registry)
             if verdict in {"empty", "ok"}:
                 continue
             if verdict == "illegal_backend":
@@ -189,6 +187,5 @@ def migrate(
 
     save_capabilities_config(cfg)
     console.print(
-        f"\n[green]migrated[/green] {len(changes)} selection(s) "
-        f"in {capabilities_toml_path()}."
+        f"\n[green]migrated[/green] {len(changes)} selection(s) in {capabilities_toml_path()}."
     )

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -219,10 +219,7 @@ class SlotConfig(BaseModel):
             cleaned = {k: v for k, v in server.items() if v is not None}
             if cleaned:
                 extra = data.get("extra")
-                if not isinstance(extra, dict):
-                    extra = {}
-                else:
-                    extra = dict(extra)
+                extra = dict(extra) if isinstance(extra, dict) else {}
                 extra["server"] = cleaned
                 data["extra"] = extra
         return data
@@ -614,9 +611,7 @@ class ModelsConfig(BaseModel):
             if not s:
                 raise ValueError("models.roots entries must not be empty")
             if not Path(s).is_absolute():
-                raise ValueError(
-                    f"models.roots entry {s!r} must be an absolute path"
-                )
+                raise ValueError(f"models.roots entry {s!r} must be an absolute path")
             out.append(s)
         return out
 

--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -430,17 +430,20 @@ def _probe_flm_catalog() -> list[dict[str, Any]] | None:
 
     image = os.environ.get("HAL0_TOOLBOX_IMAGE_FLM", _DEFAULT_FLM_IMAGE)
     cmd = [
-        "docker", "run", "--rm",
-        "--security-opt", "apparmor=unconfined",
+        "docker",
+        "run",
+        "--rm",
+        "--security-opt",
+        "apparmor=unconfined",
         image,
-        "list", "-j",
+        "list",
+        "-j",
     ]
     try:
         proc = subprocess.run(
             cmd,
             stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             timeout=30.0,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):

--- a/src/hal0/providers/moonshine.py
+++ b/src/hal0/providers/moonshine.py
@@ -81,6 +81,7 @@ def _resolve_model_leaf(model_path: str, variant: str) -> str:
             return str(leaf)
     return model_path
 
+
 # ── Timeouts ───────────────────────────────────────────────────────────────────
 _HEALTH_TIMEOUT = httpx.Timeout(5.0)
 _INFER_TIMEOUT = httpx.Timeout(connect=5.0, read=120.0, write=10.0, pool=10.0)

--- a/src/hal0/registry/curated.py
+++ b/src/hal0/registry/curated.py
@@ -372,7 +372,9 @@ class HaloaiModel(BaseModel):
         default="llamacpp",
         description="Backend runtime: flm | llamacpp | kokoro | moonshine | vibevoice | minimax.",
     )
-    size_bytes: int | None = Field(default=None, description="On-disk size if reported by upstream.")
+    size_bytes: int | None = Field(
+        default=None, description="On-disk size if reported by upstream."
+    )
     params: int | None = Field(default=None, description="Parameter count if reported by upstream.")
     context_size: int | None = Field(default=None, description="Native context window if known.")
 

--- a/src/hal0/registry/detect.py
+++ b/src/hal0/registry/detect.py
@@ -197,7 +197,11 @@ def detect(path: str | Path) -> DetectionResult:
         caps = ["embed"] if is_embed else ["chat"]
 
         name_candidate = header.get("general.name") or header.get("general.basename")
-        suggested_name = str(name_candidate).strip() if isinstance(name_candidate, str) and name_candidate.strip() else None
+        suggested_name = (
+            str(name_candidate).strip()
+            if isinstance(name_candidate, str) and name_candidate.strip()
+            else None
+        )
         if not suggested_name:
             suggested_name = _hf_repo_name_from_path(p)
 

--- a/src/hal0/registry/discover.py
+++ b/src/hal0/registry/discover.py
@@ -313,9 +313,9 @@ def is_skippable(p: Path) -> bool:
 
 
 __all__ = [
-    "is_skippable",
     "CandidateModel",
     "find_candidates",
+    "is_skippable",
     "register_candidate",
     "scan_and_register",
 ]

--- a/src/hal0/registry/model.py
+++ b/src/hal0/registry/model.py
@@ -121,8 +121,7 @@ class Model(BaseModel):
     defaults: ModelDefaults | None = Field(
         default=None,
         description=(
-            "Optional per-model launcher defaults. "
-            "None means the slot config is used as-is."
+            "Optional per-model launcher defaults. None means the slot config is used as-is."
         ),
     )
 

--- a/src/hal0/slots/flag_merge.py
+++ b/src/hal0/slots/flag_merge.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import logging
 import shlex
-from typing import Iterable
+from collections.abc import Iterable
 
 log = logging.getLogger(__name__)
 
@@ -112,9 +112,7 @@ def merge_flags(model_defaults: str | None, slot_extra: str | None) -> str:
         any non-conflicting model defaults.  Empty inputs collapse to
         ``""``.
     """
-    if not (model_defaults and model_defaults.strip()) and not (
-        slot_extra and slot_extra.strip()
-    ):
+    if not (model_defaults and model_defaults.strip()) and not (slot_extra and slot_extra.strip()):
         return ""
 
     if not (slot_extra and slot_extra.strip()):
@@ -171,16 +169,10 @@ def merge_flags(model_defaults: str | None, slot_extra: str | None) -> str:
 
     # Build the dedup set: every flag the slot uses *except* append-list
     # flags.  Empty-string "flags" (stray positionals) are never deduped.
-    slot_flag_names = {
-        flag
-        for flag, _ in slot_pairs
-        if flag and flag not in _APPEND_LIST_FLAGS
-    }
+    slot_flag_names = {flag for flag, _ in slot_pairs if flag and flag not in _APPEND_LIST_FLAGS}
 
     cleaned_model_pairs = [
-        (flag, values)
-        for flag, values in model_pairs
-        if flag not in slot_flag_names
+        (flag, values) for flag, values in model_pairs if flag not in slot_flag_names
     ]
 
     cleaned_model_tokens = _flatten_pairs(cleaned_model_pairs)

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -751,11 +751,7 @@ class SlotManager:
                 adopted = await self._maybe_adopt_running_slot(slot_name, cfg)
                 if adopted is not None:
                     return adopted
-        elif (
-            observed in (SlotState.READY, SlotState.SERVING)
-            and active
-            and not rec.model_id
-        ):
+        elif observed in (SlotState.READY, SlotState.SERVING) and active and not rec.model_id:
             # Migration / self-healing: a stale state.json from before the
             # adoption guard could have READY/SERVING with model_id="".
             # Re-run adoption when the provider actually needs a model so
@@ -1576,11 +1572,7 @@ class SlotManager:
         # with model_id=None.  For providers that need an explicit model
         # we either sniff one from /v1/models or demote to IDLE.
         detected_model: str | None = None
-        if (
-            resolved == SlotState.READY
-            and model_id is None
-            and provider_requires_model(provider)
-        ):
+        if resolved == SlotState.READY and model_id is None and provider_requires_model(provider):
             detected_model = await _fetch_first_concrete_model(port)
             if detected_model:
                 model_id = detected_model

--- a/tests/api/test_events.py
+++ b/tests/api/test_events.py
@@ -331,5 +331,3 @@ async def test_stream_since_skips_backfill() -> None:
         assert collected, "expected at least one event past the cursor"
         assert all(ev["id"] > cursor for ev in collected)
         assert any(ev["message"] == "new" for ev in collected)
-
-

--- a/tests/api/test_models_crud.py
+++ b/tests/api/test_models_crud.py
@@ -230,8 +230,7 @@ def test_create_emits_registered_with_source(
     assert r.status_code == 201, r.text
     events = _events_since(crud_client, pre, "model.registered")
     assert any(
-        ev["data"].get("id") == "hand-1" and ev["data"].get("source") == "manual"
-        for ev in events
+        ev["data"].get("id") == "hand-1" and ev["data"].get("source") == "manual" for ev in events
     ), events
 
 
@@ -245,8 +244,7 @@ def test_create_defaults_source_to_manual(
     crud_client.post("/api/models", json={"id": "h2", "path": str(fpath)})
     events = _events_since(crud_client, pre, "model.registered")
     assert any(
-        ev["data"].get("id") == "h2" and ev["data"].get("source") == "manual"
-        for ev in events
+        ev["data"].get("id") == "h2" and ev["data"].get("source") == "manual" for ev in events
     ), events
 
 
@@ -300,8 +298,7 @@ def test_update_changed_fields_only_lists_actual_changes(
     crud_client.put("/api/models/noop", json={"name": "Same"})
     events = _events_since(crud_client, pre, "model.updated")
     assert any(
-        ev["data"].get("id") == "noop" and ev["data"]["changed_fields"] == []
-        for ev in events
+        ev["data"].get("id") == "noop" and ev["data"]["changed_fields"] == [] for ev in events
     )
 
 
@@ -400,8 +397,7 @@ def test_delete_cascade_clears_slot_default_and_emits_model_deleted_last(
     assert len(deleted) == 1, f"expected exactly one model.deleted, got {new_events}"
     deleted_id = deleted[0]["id"]
     slot_states = [
-        ev for ev in new_events
-        if ev["type"] == "slot.state" and ev["source"] == "slot:primary"
+        ev for ev in new_events if ev["type"] == "slot.state" and ev["source"] == "slot:primary"
     ]
     assert slot_states, "expected slot.state events from the unload cascade"
     for ev in slot_states:
@@ -431,8 +427,7 @@ def test_delete_unreferenced_model_emits_with_empty_affected_slots(
 
     events = _events_since(crud_client, pre, "model.deleted")
     assert any(
-        ev["data"].get("id") == "lonely" and ev["data"]["affected_slots"] == []
-        for ev in events
+        ev["data"].get("id") == "lonely" and ev["data"]["affected_slots"] == [] for ev in events
     )
 
 
@@ -478,6 +473,5 @@ async def test_model_registered_reaches_live_subscriber(
         await asyncio.wait_for(task, timeout=2.0)
 
     assert any(
-        ev["type"] == "model.registered" and ev["data"].get("id") == "sub-1"
-        for ev in received
+        ev["type"] == "model.registered" and ev["data"].get("id") == "sub-1" for ev in received
     )

--- a/tests/capabilities/test_orchestrator_reconciliation.py
+++ b/tests/capabilities/test_orchestrator_reconciliation.py
@@ -65,9 +65,7 @@ class FakeSlotManager:
         self.calls.append(("create", slot_name, {"cfg": cfg}))
         return _StubSlot("offline")
 
-    async def update_config(
-        self, slot_name: str, updates: dict[str, Any]
-    ) -> _StubSlot:
+    async def update_config(self, slot_name: str, updates: dict[str, Any]) -> _StubSlot:
         self.calls.append(("update_config", slot_name, {"updates": updates}))
         return _StubSlot("ready")
 
@@ -218,6 +216,4 @@ async def test_apply_no_rewrite_on_pure_disable(
     await orch.apply("embed", "embed", {"enabled": False})
 
     update_calls = [c for c in fake.calls if c[0] == "update_config"]
-    assert update_calls == [], (
-        f"unexpected update_config on disable transition: {update_calls}"
-    )
+    assert update_calls == [], f"unexpected update_config on disable transition: {update_calls}"

--- a/tests/cli/test_uninstall.py
+++ b/tests/cli/test_uninstall.py
@@ -132,9 +132,7 @@ def test_uninstall_non_tty_with_hal0_force_env(monkeypatch: pytest.MonkeyPatch) 
     assert captured["argv"][1].endswith("/installer/uninstall.sh")
 
 
-def test_uninstall_missing_script_dies(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_uninstall_missing_script_dies(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """If uninstall.sh isn't where we expect, fail loudly instead of running."""
     import hal0
 

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -244,9 +244,7 @@ class TestSlotConfigRoundTrip:
 
     # ── Phase 1 A3: [server].extra_args ──────────────────────────────────
 
-    def test_server_extra_args_missing_defaults_to_none(
-        self, tmp_hal0_home: str
-    ) -> None:
+    def test_server_extra_args_missing_defaults_to_none(self, tmp_hal0_home: str) -> None:
         """A slot TOML without a [server] table loads with server.extra_args = None."""
         paths.slots_config_dir().mkdir(parents=True, exist_ok=True)
         (paths.slots_config_dir() / "primary.toml").write_text(
@@ -282,9 +280,7 @@ class TestSlotConfigRoundTrip:
             data = tomllib.load(f)
         assert data["server"]["extra_args"] == "--rope-freq-base 500000"
 
-    def test_unset_server_extra_args_does_not_write_empty_table(
-        self, tmp_hal0_home: str
-    ) -> None:
+    def test_unset_server_extra_args_does_not_write_empty_table(self, tmp_hal0_home: str) -> None:
         """A default ServerConfig (all None) elides the [server] table on disk."""
         cfg = SlotConfig(name="primary", port=8081)
         save_slot_config(cfg)

--- a/tests/providers/test_flm.py
+++ b/tests/providers/test_flm.py
@@ -145,9 +145,7 @@ def test_container_spec_command_does_not_prefix_binary_path(
         f"first command arg must be an flm subcommand, not an absolute "
         f"path; got {first!r}. Full command: {spec.command!r}"
     )
-    assert first == "serve", (
-        f"expected first arg to be 'serve' subcommand; got {first!r}"
-    )
+    assert first == "serve", f"expected first arg to be 'serve' subcommand; got {first!r}"
 
 
 def test_container_spec_passes_multiplex_flags_in_command(
@@ -178,9 +176,7 @@ def test_container_spec_ld_library_path_includes_xrt(
     """
     spec = provider.container_spec(slot_cfg, model_info)
     ld = spec.env.get("LD_LIBRARY_PATH", "")
-    assert "/opt/xilinx/xrt/lib" in ld, (
-        f"LD_LIBRARY_PATH missing XRT runtime path: {ld!r}"
-    )
+    assert "/opt/xilinx/xrt/lib" in ld, f"LD_LIBRARY_PATH missing XRT runtime path: {ld!r}"
 
 
 # ─── health (TIER1 inference round-trip) ──────────────────────────────────────

--- a/tests/providers/test_llama_server.py
+++ b/tests/providers/test_llama_server.py
@@ -270,9 +270,7 @@ def test_container_spec_returns_frozen_dataclass(
 ) -> None:
     # Pretend /dev/kfd + /dev/dri exist so the host-aware device filter
     # in container_spec keeps them in the rendered spec.
-    monkeypatch.setattr(
-        "hal0.providers.llama_server.Path.exists", lambda self: True
-    )
+    monkeypatch.setattr("hal0.providers.llama_server.Path.exists", lambda self: True)
     spec = provider.container_spec(slot_cfg, model_info)
     assert spec.image == _HAL0_TOOLBOX_IMAGES["vulkan"]
     assert spec.port == 8081
@@ -291,9 +289,7 @@ def test_container_spec_filters_missing_devices(
     model_info: dict[str, Any],
 ) -> None:
     """A CPU-only / virtio-gpu host without /dev/kfd gets an empty devices list."""
-    monkeypatch.setattr(
-        "hal0.providers.llama_server.Path.exists", lambda self: False
-    )
+    monkeypatch.setattr("hal0.providers.llama_server.Path.exists", lambda self: False)
     spec = provider.container_spec(slot_cfg, model_info)
     assert spec.devices == []
 
@@ -342,6 +338,7 @@ def test_render_systemd_override_emits_full_docker_line(
     # Pretend /dev/kfd + /dev/dri exist on the host so the device filter
     # in container_spec keeps them in the rendered docker line.
     import hal0.providers.llama_server as ls_mod
+
     monkeypatch.setattr(ls_mod.Path, "exists", lambda self: True)
     out = provider.render_systemd_override(
         "primary",

--- a/tests/registry/test_discover.py
+++ b/tests/registry/test_discover.py
@@ -158,9 +158,7 @@ def test_scan_and_register_idempotent(model_root: Path, registry: ModelRegistry)
     assert second["added"] == []
 
 
-def test_scan_and_register_missing_root_is_silent(
-    tmp_path: Path, registry: ModelRegistry
-) -> None:
+def test_scan_and_register_missing_root_is_silent(tmp_path: Path, registry: ModelRegistry) -> None:
     cfg = ModelsConfig(roots=[str(tmp_path / "does-not-exist")])
     result = scan_and_register(registry, cfg)
     assert result["added"] == []

--- a/tests/registry/test_gguf_header.py
+++ b/tests/registry/test_gguf_header.py
@@ -161,9 +161,7 @@ class TestMalformed:
 
     def test_truncated_mid_kv_returns_partial(self, tmp_path: Path) -> None:
         """First KV parses, second is truncated."""
-        good_kv = _enc_kv(
-            "general.architecture", _GGUF_TYPE_STRING, _enc_str("llama")
-        )
+        good_kv = _enc_kv("general.architecture", _GGUF_TYPE_STRING, _enc_str("llama"))
         # Start a key but cut off the length bytes mid-stream.
         bad_partial = struct.pack("<Q", 99999)[:4]
         header = (

--- a/tests/registry/test_schema_migration.py
+++ b/tests/registry/test_schema_migration.py
@@ -108,15 +108,15 @@ class TestLegacyMigration:
         rdir.mkdir()
         # Pre-Phase-1 shape: only the fields that already existed.
         (rdir / "registry.toml").write_text(
-            '[models.legacy]\n'
+            "[models.legacy]\n"
             'path = "/m/legacy.gguf"\n'
             'name = "Legacy 7B"\n'
-            'size_bytes = 4000000000\n'
+            "size_bytes = 4000000000\n"
             'license = "Apache-2.0"\n'
             'capabilities = ["chat"]\n'
-            'tags = []\n'
-            '[models.legacy.metadata]\n'
-            'discovered = true\n'
+            "tags = []\n"
+            "[models.legacy.metadata]\n"
+            "discovered = true\n"
         )
         reg = ModelRegistry(registry_dir=rdir)
         m = reg.get("legacy")
@@ -130,10 +130,7 @@ class TestLegacyMigration:
         rdir = tmp_path / "registry"
         rdir.mkdir()
         (rdir / "registry.toml").write_text(
-            '[models.legacy]\n'
-            'path = "/m/legacy.gguf"\n'
-            'name = "Legacy"\n'
-            'capabilities = ["chat"]\n'
+            '[models.legacy]\npath = "/m/legacy.gguf"\nname = "Legacy"\ncapabilities = ["chat"]\n'
         )
         reg = ModelRegistry(registry_dir=rdir)
         updated = reg.update(
@@ -164,19 +161,19 @@ class TestLegacyMigration:
         rdir.mkdir()
         (rdir / "registry.toml").write_text(
             # Legacy entry — no backends/defaults.
-            '[models.old]\n'
+            "[models.old]\n"
             'path = "/m/o.gguf"\n'
             'capabilities = ["chat"]\n'
             # New-style entry — full schema.
-            '[models.new]\n'
+            "[models.new]\n"
             'path = "/m/n.gguf"\n'
             'capabilities = ["embed"]\n'
             'backends = ["vulkan", "rocm"]\n'
-            '[models.new.defaults]\n'
-            'context_size = 4096\n'
-            'n_gpu_layers = -1\n'
-            '[models.new.metadata]\n'
-            'context_length = 4096\n'
+            "[models.new.defaults]\n"
+            "context_size = 4096\n"
+            "n_gpu_layers = -1\n"
+            "[models.new.metadata]\n"
+            "context_length = 4096\n"
         )
         reg = ModelRegistry(registry_dir=rdir)
         old = reg.get("old")

--- a/tests/slots/test_flag_merge.py
+++ b/tests/slots/test_flag_merge.py
@@ -18,7 +18,6 @@ import pytest
 
 from hal0.slots.flag_merge import merge_flags
 
-
 # ─── Empty inputs ─────────────────────────────────────────────────────────────
 
 

--- a/tests/slots/test_transition_guard.py
+++ b/tests/slots/test_transition_guard.py
@@ -32,9 +32,7 @@ async def test_transition_blocks_modelless_ready_for_llama_server(
         extra={"backend": "vulkan", "provider": "llama-server"},
         force=True,
     )
-    state_file = (
-        Path(tmp_hal0_home) / "var-lib" / "hal0" / "slots" / "primary" / "state.json"
-    )
+    state_file = Path(tmp_hal0_home) / "var-lib" / "hal0" / "slots" / "primary" / "state.json"
     record = json.loads(state_file.read_text(encoding="utf-8"))
     assert record["state"] == "idle", (
         f"transition guard must coerce modelless READY to IDLE, got {record['state']}"
@@ -76,9 +74,7 @@ async def test_transition_allows_ready_with_model_id(
         extra={"backend": "vulkan", "provider": "llama-server"},
         force=True,
     )
-    state_file = (
-        Path(tmp_hal0_home) / "var-lib" / "hal0" / "slots" / "primary" / "state.json"
-    )
+    state_file = Path(tmp_hal0_home) / "var-lib" / "hal0" / "slots" / "primary" / "state.json"
     record = json.loads(state_file.read_text(encoding="utf-8"))
     assert record["state"] == "ready"
     assert record["model_id"] == "qwen3-4b-q4_k_m"


### PR DESCRIPTION
## Summary

Closes the chronic red CI on `main` caused by accumulated lint debt. After this PR, `ruff check src tests` and `ruff format --check src tests` are both clean.

## Auto-fixed (13 errors)

- `I001` unsorted imports — 4 files
- `F401` unused imports — `api/__init__.py`, `api/routes/backends.py`
- `RUF022` unsorted `__all__` — `api/__init__.py`, `registry/discover.py`
- `RUF100` unused noqa — 9 sites
- `UP015` redundant open modes — 2
- `UP041` `TimeoutError` aliases — 2
- `UP035` `from typing import Iterable` → `collections.abc`

## Manual (6 errors)

| Rule | Site | Fix |
|---|---|---|
| `RUF002` ambiguous `×` in docstring | `api/routes/backends.py:124` | rephrased as "no per-row remove control" |
| `SIM118` `body.keys()` | `api/routes/models.py:544` | drop `.keys()` |
| `SIM105` `try/except OSError: pass` | `api/routes/models.py:618` | `contextlib.suppress(OSError)` |
| `F841` unused `provider_changed` | `capabilities/orchestrator.py:330` | dropped, plus the now-unused `before_provider` binding. Dead since `39adaf7` made the slot-TOML rewrite unconditional. Inline comment notes where to reintroduce if the swap path grows a provider-aware case. |
| `SIM108` if/else → ternary | `config/schema.py:222` | one-line ternary |
| `UP022` `stdout=PIPE, stderr=PIPE` | `providers/flm.py:439` | `capture_output=True` |

## Format-only (27 files)

Mechanical `ruff format` pass — function signatures collapsing onto single lines where they fit, trailing-comma normalization, etc.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `pytest tests/capabilities/ tests/config/ tests/api/ tests/providers/test_flm.py` — 485 passing, only pre-existing `test_v1_dispatch` failures unchanged
- [x] Full suite (minus pre-broken `tests/slots/test_integration.py`, `tests/openwebui/`, `tests/providers/test_moonshine_server.py`): 998 passing, same 5 pre-existing failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)