### PR TITLE
fix(cli): split --provider vs --hardware on slot create (#2)

### DIFF
--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -333,12 +333,13 @@ def slot_create(
 
     # Back-compat: --backend was historically the provider name. Translate
     # with a deprecation warning so existing scripts keep working but the
-    # user is nudged toward the corrected flags.
+    # user is nudged toward the corrected flags. We emit to stderr via
+    # ``typer.echo(..., err=True)`` so stdout stays parseable for callers
+    # piping the success line into other tools.
     if backend is not None:
-        console.print(
-            "[yellow]warning:[/yellow] --backend is deprecated and was always the "
-            "provider name, not the hardware backend; use --provider instead.",
-            highlight=False,
+        typer.echo(
+            "[deprecated] --backend will be renamed to --provider in v0.2; use --provider",
+            err=True,
         )
         try:
             provider = SlotProvider(backend)
@@ -407,10 +408,9 @@ def slot_edit(
 
     # Back-compat: --backend mapped to provider historically.
     if backend is not None:
-        console.print(
-            "[yellow]warning:[/yellow] --backend is deprecated and was always the "
-            "provider name, not the hardware backend; use --provider instead.",
-            highlight=False,
+        typer.echo(
+            "[deprecated] --backend will be renamed to --provider in v0.2; use --provider",
+            err=True,
         )
         try:
             provider = SlotProvider(backend) if provider is None else provider

--- a/tests/cli/test_slot_create_flags.py
+++ b/tests/cli/test_slot_create_flags.py
@@ -22,6 +22,11 @@ from typer.testing import CliRunner
 
 from hal0.cli import slot_commands
 
+# Click ≥8.2 separates stdout/stderr on the result by default — the
+# deprecation warning (emitted via ``typer.echo(..., err=True)``) lands
+# in ``result.stderr``. We assert against ``result.stderr`` rather than
+# ``result.output`` so a future contributor moving the warning back to
+# stdout fails this regression test loudly.
 runner = CliRunner()
 
 
@@ -96,7 +101,7 @@ def test_hardware_flag_overrides_default(captured_post: dict[str, Any]) -> None:
 def test_legacy_backend_flag_translates_to_provider(
     captured_post: dict[str, Any],
 ) -> None:
-    """Deprecated ``--backend flm`` is translated to provider=flm + warns."""
+    """Deprecated ``--backend flm`` is translated to provider=flm + warns on stderr."""
     result = runner.invoke(
         slot_commands.app,
         ["create", "primary", "--backend", "flm", "--model", "demo"],
@@ -105,7 +110,10 @@ def test_legacy_backend_flag_translates_to_provider(
     assert captured_post["body"]["provider"] == "flm"
     # The hardware backend must NOT be conflated with the deprecated flag.
     assert captured_post["body"]["backend"] == "vulkan"
-    assert "deprecated" in result.output.lower()
+    # Deprecation warning goes to stderr so stdout stays parseable for
+    # scripts piping the success line elsewhere.
+    assert "deprecated" in result.stderr.lower()
+    assert "--provider" in result.stderr
 
 
 def test_legacy_backend_with_invalid_value_errors(
@@ -161,3 +169,94 @@ def test_default_hardware_cpu_when_no_gpu(monkeypatch: pytest.MonkeyPatch, tmp_p
 
     monkeypatch.setattr(_paths, "hardware_json", lambda: probe)
     assert slot_commands._detect_default_hardware() == "cpu"
+
+
+def test_invalid_hardware_value_rejected_by_typer(
+    captured_post: dict[str, Any],
+) -> None:
+    """``--hardware foo`` is rejected at the Typer parsing layer.
+
+    Because ``--hardware`` is a ``SlotHardware`` StrEnum, Typer/Click
+    rejects unknown values before the command body runs — the API
+    client should never be called.
+    """
+    result = runner.invoke(
+        slot_commands.app,
+        [
+            "create",
+            "primary",
+            "--provider",
+            "llama-server",
+            "--hardware",
+            "foo",
+            "--model",
+            "demo",
+        ],
+    )
+    assert result.exit_code != 0
+    # Click's bad-parameter envelope mentions the offending flag.
+    assert "hardware" in (result.stderr + result.output).lower()
+    # No API call should have been made — the command body never ran.
+    assert "body" not in captured_post
+
+
+def test_bare_create_on_strix_halo_resolves_to_vulkan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A bare ``slot create primary`` on a Strix Halo fixture auto-resolves
+    ``--hardware vulkan``.
+
+    Strix Halo presents as an AMD iGPU (vendor=amd) that is Vulkan-capable
+    but typically not flagged compute_capable in the probe output — the
+    iGPU runs llama.cpp via Vulkan, not ROCm. The auto-detect path must
+    pick ``vulkan`` so the user doesn't need to know about hardware flags
+    on the platform that hal0 v1 most cares about.
+    """
+    probe = tmp_path / "hardware.json"
+    probe.write_text(
+        json.dumps(
+            {
+                "gpus": [
+                    {
+                        "vendor": "amd",
+                        "name": "Radeon 890M (Strix Halo)",
+                        "vram_mb": 512,
+                        # iGPU — Vulkan via Mesa, no ROCm.
+                        "compute_capable": False,
+                        "vulkan_capable": True,
+                    }
+                ],
+                "unified_memory_mb": 102400,
+            }
+        )
+    )
+    from hal0.config import paths as _paths
+
+    monkeypatch.setattr(_paths, "hardware_json", lambda: probe)
+
+    captured: dict[str, Any] = {}
+
+    def fake_unreachable(_url: str) -> bool:
+        return False
+
+    def fake_get(path: str, **_kw: Any) -> list[dict[str, Any]]:
+        return []
+
+    def fake_post(path: str, *, json: dict[str, Any] | None = None, **_kw: Any) -> dict[str, Any]:
+        captured["body"] = json or {}
+        return {"port": (json or {}).get("port", 8081)}
+
+    monkeypatch.setattr(slot_commands, "_api_unreachable", fake_unreachable)
+    monkeypatch.setattr(slot_commands, "api_get", fake_get)
+    monkeypatch.setattr(slot_commands, "api_post", fake_post)
+
+    result = runner.invoke(
+        slot_commands.app,
+        ["create", "primary", "--model", "demo"],
+    )
+    assert result.exit_code == 0, result.output
+    # Bare invocation → provider defaults to llama-server, hardware
+    # auto-resolves to vulkan from the Strix Halo fixture.
+    assert captured["body"]["provider"] == "llama-server"
+    assert captured["body"]["backend"] == "vulkan"


### PR DESCRIPTION
Closes finding #2 from tests/harness/FINDINGS.md. The CLI's --backend flag was really the provider; the actual hardware backend was hardcoded to vulkan, blocking ROCm + CPU slot creation from the command line.

## What

Most of the split had already landed (the --provider / --hardware flags exist, the hidden --backend alias is in place, and the _detect_default_hardware probe walks /etc/hal0/hardware.json). This PR finishes the v1 polish:

- Deprecation warning now goes to **stderr** via `typer.echo("[deprecated] --backend will be renamed to --provider in v0.2; use --provider", err=True)`. Previously it was a Rich `console.print` to stdout, which polluted stdout for callers piping the success line into other tools.
- Same stderr-routing applied to `slot edit`'s --backend alias for consistency.
- `--backend` remains a `hidden=True` deprecated alias (per CONTRIBUTING.md style), no full removal.
- Hardcoded `"backend": "vulkan"` is gone from the POST body — already removed in the earlier landing; this PR preserves and tests that.

## Tests

- **New**: bare `hal0 slot create primary` on a Strix Halo fixture (AMD iGPU, vulkan_capable=True, compute_capable=False) auto-resolves `hardware=vulkan` — the platform hal0 v1 most cares about.
- **New**: `--hardware foo` is rejected at the Typer/Click parse layer before the command body runs (no API call made).
- **Updated**: the legacy `--backend` test now asserts the deprecation lands on `result.stderr`, not `result.output`, so re-introducing the old `console.print` path fails this regression test loudly.
- All 10 `test_slot_create_flags.py` tests + the broader 27-test CLI suite are green.

## Schema

`SlotConfig.backend` already accepts `{vulkan, rocm, flm, moonshine, kokoro, cpu}` and `SlotConfig.provider` already accepts `{llama-server, flm, moonshine, kokoro}` — no schema change needed.