### PR TITLE
fix(api): wrap RequestValidationError in hal0 envelope (#20)

### DIFF
--- a/src/hal0/api/middleware/error_codes.py
+++ b/src/hal0/api/middleware/error_codes.py
@@ -51,9 +51,11 @@ def _shape_validation_errors(exc: RequestValidationError) -> list[dict[str, Any]
     Pydantic emits a list of ``{type, loc, msg, input, ctx, url}`` dicts.
     The envelope contract keeps ``loc`` (so the client knows which field
     failed), ``msg`` (human-readable), and ``type`` (machine-readable
-    error kind) — and drops the rest to keep the response small and
-    schema-stable. The full pydantic payload remains accessible via
-    structured logs for server-side debugging.
+    error kind) — and drops the rest. ``input`` in particular is
+    deliberately stripped: it can be verbose, and for body validation
+    failures it often contains the caller-supplied payload, which can
+    leak secrets if echoed back. The full pydantic payload remains
+    accessible via structured logs for server-side debugging.
     """
     shaped: list[dict[str, Any]] = []
     for err in exc.errors():
@@ -83,22 +85,22 @@ def install(app: FastAPI) -> None:
         # and body parameters. Without this handler clients see FastAPI's
         # default ``{"detail": [...]}`` shape, which doesn't match the hal0
         # envelope contract. We reshape into the canonical envelope and
-        # downgrade the status from 422 to 400 — these are caller-side input
-        # errors, not "well-formed but semantically rejected" requests
-        # (UnprocessableEntity is reserved for that meaning).
-        errors = _shape_validation_errors(exc)
+        # keep the FastAPI-default 422 status — OpenAI/FastAPI clients
+        # already expect 422 on request-validation failures, so changing
+        # the status code would break ergonomic detection at the client.
+        fields = _shape_validation_errors(exc)
         log.info(
             "hal0.validation_error",
             path=request.url.path,
             method=request.method,
-            errors=errors,
+            fields=fields,
         )
         return JSONResponse(
-            status_code=400,
+            status_code=422,
             content=_envelope(
                 "validation.invalid",
                 "request validation failed",
-                {"errors": errors},
+                {"fields": fields},
             ),
         )
 

--- a/tests/api/test_logs_routes.py
+++ b/tests/api/test_logs_routes.py
@@ -31,23 +31,23 @@ def test_logs_happy_path_returns_lines_and_count(client: TestClient) -> None:
 
 
 def test_logs_validation_error_envelope_for_missing_unit(client: TestClient) -> None:
-    """Missing unit query param yields a 400 in the hal0 envelope shape.
+    """Missing unit query param yields a 422 in the hal0 envelope shape.
 
     The ``RequestValidationError`` handler (see
     ``hal0.api.middleware.error_codes``) reshapes FastAPI's default
     ``{"detail": [...]}`` 422 into the canonical envelope with
-    ``code="validation.invalid"`` and downgrades the status to 400 —
-    pydantic-driven validation failures are caller-side input errors,
-    not "well-formed but semantically rejected".
+    ``code="validation.invalid"`` while preserving the FastAPI-default
+    422 status — clients already expect 422 on request-validation
+    failures.
     """
     r = client.get("/api/logs")
-    assert r.status_code == 400
+    assert r.status_code == 422
     body = r.json()
     assert "error" in body, f"Expected hal0 envelope, got {body}"
     assert body["error"]["code"] == "validation.invalid"
-    assert "errors" in body["error"]["details"]
-    assert isinstance(body["error"]["details"]["errors"], list)
-    assert body["error"]["details"]["errors"], "expected at least one error entry"
+    assert "fields" in body["error"]["details"]
+    assert isinstance(body["error"]["details"]["fields"], list)
+    assert body["error"]["details"]["fields"], "expected at least one field entry"
 
 
 def test_logs_invalid_unit_returns_typed_envelope(client: TestClient) -> None:
@@ -73,13 +73,14 @@ def test_logs_n_out_of_range_returns_envelope(client: TestClient) -> None:
 
     Pydantic-driven validation is reshaped by the ``RequestValidationError``
     handler in ``hal0.api.middleware.error_codes`` into the canonical
-    envelope with ``code="validation.invalid"`` and downgraded to 400.
+    envelope with ``code="validation.invalid"`` at the FastAPI-default
+    422 status.
     """
     r = client.get("/api/logs", params={"unit": "hal0-api", "n": 0})
-    assert r.status_code == 400
+    assert r.status_code == 422
     body = r.json()
     assert body["error"]["code"] == "validation.invalid"
-    assert "errors" in body["error"]["details"]
+    assert "fields" in body["error"]["details"]
 
 
 def test_logs_stream_returns_sse_content_type(client: TestClient) -> None:

--- a/tests/api/test_typed_errors.py
+++ b/tests/api/test_typed_errors.py
@@ -10,8 +10,8 @@ Each subclass test asserts:
 
 The pydantic-validation test asserts that a missing query parameter
 no longer returns FastAPI's default 422 ``{"detail": [...]}`` shape;
-instead it returns 400 with ``code="validation.invalid"`` and an
-``errors`` list under ``details``.
+instead it returns 422 with ``code="validation.invalid"`` and a
+``fields`` list under ``details``.
 """
 
 from __future__ import annotations
@@ -169,41 +169,67 @@ def _register_validation_routes(app: FastAPI) -> None:
 
 
 def test_missing_query_param_returns_envelope(app: FastAPI, client: TestClient) -> None:
-    """Missing required query param yields 400 + the hal0 envelope.
+    """Missing required query param yields 422 + the hal0 envelope.
 
     FastAPI's default is 422 ``{"detail": [...]}`` — the
-    ``RequestValidationError`` handler downgrades to 400 (caller input
-    error) and reshapes into the canonical envelope.
+    ``RequestValidationError`` handler keeps the 422 status but reshapes
+    the body into the canonical envelope.
     """
     _register_validation_routes(app)
 
     r = client.get("/test/needs-query")
 
-    assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
+    assert r.status_code == 422, f"expected 422, got {r.status_code}: {r.text}"
     body = r.json()
     assert "error" in body, f"expected hal0 envelope, got {body}"
     assert body["error"]["code"] == "validation.invalid"
     assert body["error"]["message"] == "request validation failed"
-    errors = body["error"]["details"]["errors"]
-    assert isinstance(errors, list) and len(errors) >= 1
-    err = errors[0]
-    # Shape: {loc: [...], msg: str, type: str}
-    assert set(err.keys()) == {"loc", "msg", "type"}
-    assert "unit" in err["loc"]
+    fields = body["error"]["details"]["fields"]
+    assert isinstance(fields, list) and len(fields) >= 1
+    field = fields[0]
+    # Shape: {loc: [...], msg: str, type: str} — ``input`` is intentionally
+    # stripped so the envelope can never echo a caller-supplied payload.
+    assert set(field.keys()) == {"loc", "msg", "type"}
+    assert "unit" in field["loc"]
 
 
 def test_missing_body_field_returns_envelope(app: FastAPI, client: TestClient) -> None:
-    """A missing required field in a JSON body surfaces in ``details.errors``."""
+    """A missing required field in a JSON body surfaces in ``details.fields``."""
     _register_validation_routes(app)
 
     r = client.post("/test/needs-body", json={"name": "x"})  # missing ``count``
 
-    assert r.status_code == 400
+    assert r.status_code == 422
     body = r.json()
     assert body["error"]["code"] == "validation.invalid"
-    errors = body["error"]["details"]["errors"]
-    locs = [tuple(e["loc"]) for e in errors]
+    fields = body["error"]["details"]["fields"]
+    locs = [tuple(f["loc"]) for f in fields]
     assert any("count" in loc for loc in locs), f"expected 'count' in {locs}"
+
+
+def test_malformed_json_body_returns_envelope(app: FastAPI, client: TestClient) -> None:
+    """Bytes that aren't valid JSON also land in the hal0 envelope.
+
+    Pydantic raises a ``json_invalid`` error before any field-level
+    validation runs; the handler must reshape that path the same way.
+    """
+    _register_validation_routes(app)
+
+    r = client.post(
+        "/test/needs-body",
+        content=b"{not valid json",
+        headers={"content-type": "application/json"},
+    )
+
+    assert r.status_code == 422, r.text
+    body = r.json()
+    assert body["error"]["code"] == "validation.invalid"
+    fields = body["error"]["details"]["fields"]
+    assert fields, "expected at least one field entry"
+    # The ``input`` key is never propagated — even on JSON-parse failure
+    # where pydantic would otherwise echo the offending bytes.
+    for field in fields:
+        assert "input" not in field, f"input leaked: {field}"
 
 
 def test_invalid_enum_value_returns_envelope(app: FastAPI, client: TestClient) -> None:
@@ -212,20 +238,21 @@ def test_invalid_enum_value_returns_envelope(app: FastAPI, client: TestClient) -
 
     r = client.get("/test/needs-enum", params={"color": "purple"})
 
-    assert r.status_code == 400
+    assert r.status_code == 422
     body = r.json()
     assert body["error"]["code"] == "validation.invalid"
-    errors = body["error"]["details"]["errors"]
-    assert errors, "expected at least one validation error"
+    fields = body["error"]["details"]["fields"]
+    assert fields, "expected at least one validation error"
     # The pydantic ``type`` for invalid enums starts with ``enum``.
-    assert any(e["type"].startswith("enum") for e in errors), errors
+    assert any(f["type"].startswith("enum") for f in fields), fields
 
 
 def test_raised_unprocessable_entity_is_distinct_from_validation_handler(
     app: FastAPI, client: TestClient
 ) -> None:
-    """Manually-raised ``UnprocessableEntity`` keeps its 422 status — only the
-    pydantic-driven validation path is downgraded to 400."""
+    """Manually-raised ``UnprocessableEntity`` keeps its 422 status with its own
+    code/details — the pydantic-driven validation handler shares the status
+    but uses ``code="validation.invalid"``."""
 
     @app.post("/test/manual-422")
     async def _raise() -> None:

--- a/tests/harness/FINDINGS.md
+++ b/tests/harness/FINDINGS.md
@@ -564,7 +564,17 @@ config is bad" gets ambiguous signals.
 - **Fix:** map "no config file AND no in-memory state" →
   `SlotNotFound` upstream in `SlotManager.get_config()`.
 
-## 20. `/api/logs?unit=` missing param returns FastAPI default envelope — **low / envelope inconsistency**
+## 20. `/api/logs?unit=` missing param returns FastAPI default envelope — **low / envelope inconsistency** · ✅ RESOLVED 2026-05-21
+
+> Closed by `fix/validation-envelope-2026-05-21`. A
+> `RequestValidationError` handler now lives in
+> `src/hal0/api/middleware/error_codes.py` and reshapes pydantic-driven
+> failures into `{"error":{"code":"validation.invalid", "details":
+> {"fields":[{"loc","msg","type"}]}}}` at the FastAPI-default 422 status.
+> The `input` field is intentionally stripped from each entry to avoid
+> echoing caller-supplied payloads (potential secret leak on body
+> validation). Original report preserved below.
+
 
 `unit = Query(...)` raises `RequestValidationError`, which is NOT
 in `error_codes.install()`'s handler set


### PR DESCRIPTION
Closes finding #20 from tests/harness/FINDINGS.md. RequestValidationError no longer leaks the FastAPI default envelope; clients see {"error":{"code":"validation.invalid",...}} at 422.

## What

- New app.exception_handler(RequestValidationError) in src/hal0/api/middleware/error_codes.py
- Maps pydantic/fastapi validation errors to the hal0 envelope shape
- Strips the verbose 'input' field per error (also avoids echoing caller-supplied body bytes — potential secret leak)
- Keeps the FastAPI-default 422 status (matches client expectations); manually-raised `BadRequest` is still 400 and manually-raised `UnprocessableEntity` is still 422 with its own code

## Tests

- New test covering missing-required-query-param (GET /api/logs) — now 422 + `details.fields`
- New test covering malformed JSON body (asserts `input` field is stripped)
- Existing Hal0Error envelope tests still pass
- Existing tests pinning the old `details.errors` / status 400 shape updated to `details.fields` / 422