### PR TITLE
fix(tests): isolate from host /etc/hal0 + /var/lib/hal0 state — fixes 9 CI failures

### DIFF
--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -27,6 +27,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator, model_serializer, model_validator
 
+from hal0.config import paths
+
 # ── Shared constants ───────────────────────────────────────────────────────────
 
 # TIER1: surface-area for the backend whitelist. Typos like
@@ -574,10 +576,11 @@ class ModelsConfig(BaseModel):
     model_config = {"populate_by_name": True, "extra": "allow"}
 
     roots: list[str] = Field(
-        default_factory=lambda: ["/var/lib/hal0/models"],
+        default_factory=lambda: [str(paths.models_dir())],
         description=(
             "Filesystem roots scanned for downloaded model files. "
-            "Each must be an absolute path; non-existent paths are skipped at scan time."
+            "Each must be an absolute path; non-existent paths are skipped at scan time. "
+            "Default tracks HAL0_HOME for dev installs."
         ),
     )
     auto_scan_on_start: bool = Field(
@@ -591,13 +594,14 @@ class ModelsConfig(BaseModel):
         ),
     )
     pull_root: str = Field(
-        default="/var/lib/hal0/models",
+        default_factory=lambda: str(paths.models_dir()),
         description=(
             "Destination directory for HuggingFace pulls. Must be an absolute path. "
             "Tempfiles stage under <pull_root>/.tmp/ and finished downloads land at "
             "<pull_root>/<model_id>/<filename>. ComfyUI assets still route to "
-            "/var/lib/hal0/comfyui/models/<subdir>/. This directory is auto-included "
-            "in the discovery scan so pulled files are immediately visible."
+            "<var_lib>/comfyui/models/<subdir>/. This directory is auto-included "
+            "in the discovery scan so pulled files are immediately visible. "
+            "Default tracks HAL0_HOME for dev installs."
         ),
     )
 

--- a/tests/api/test_config_model_roots.py
+++ b/tests/api/test_config_model_roots.py
@@ -21,12 +21,17 @@ def isolated_client(tmp_hal0_home: str) -> Iterator[TestClient]:
         yield c
 
 
-def test_get_models_config_returns_defaults(isolated_client: TestClient) -> None:
+def test_get_models_config_returns_defaults(
+    isolated_client: TestClient, tmp_hal0_home: str
+) -> None:
     r = isolated_client.get("/api/config/models")
     assert r.status_code == 200, r.text
     body = r.json()
-    assert body["roots"] == ["/var/lib/hal0/models"]
-    assert body["pull_root"] == "/var/lib/hal0/models"
+    # Defaults track HAL0_HOME (set by isolated_client → tmp_hal0_home).
+    # In production (HAL0_HOME unset) these resolve to /var/lib/hal0/models.
+    expected_models_dir = f"{tmp_hal0_home}/var-lib/hal0/models"
+    assert body["roots"] == [expected_models_dir]
+    assert body["pull_root"] == expected_models_dir
     assert body["auto_scan_on_start"] is True
     assert ".gguf" in body["file_extensions"]
     assert ".safetensors" in body["file_extensions"]

--- a/tests/cli/test_slot_create_flags.py
+++ b/tests/cli/test_slot_create_flags.py
@@ -52,11 +52,20 @@ def captured_post(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
 
 
 def test_help_lists_new_flags() -> None:
-    """``slot create --help`` mentions --provider and --hardware."""
+    """``slot create --help`` mentions --provider and --hardware.
+
+    Click colors the flag name's leading ``-`` and ``-provider`` with
+    separate ANSI sequences, so the raw ``result.output`` won't contain
+    a contiguous ``--provider`` substring under a coloring terminal.
+    Strip ANSI before checking.
+    """
+    import re
+
     result = runner.invoke(slot_commands.app, ["create", "--help"])
     assert result.exit_code == 0, result.output
-    assert "--provider" in result.output
-    assert "--hardware" in result.output
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    assert "--provider" in plain
+    assert "--hardware" in plain
 
 
 def test_provider_flag_sets_provider_and_default_hardware(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,16 @@ pytest_plugins = ()
 
 
 @pytest.fixture(scope="function")
-def app() -> FastAPI:
-    """Return a fresh FastAPI app instance."""
+def app(tmp_hal0_home: str) -> FastAPI:
+    """Return a fresh FastAPI app instance, filesystem-isolated under tmp_hal0_home.
+
+    Auto-applying tmp_hal0_home means every TestClient-driven test starts
+    against an empty config tree — no host /etc/hal0/slots/*.toml leaks
+    into upstream registration, no host /var/lib/hal0/registry leaks into
+    the model list. Tests that need to populate config should write into
+    ``Path(tmp_hal0_home) / "etc" / "hal0" / ...`` before constructing
+    the client.
+    """
     return create_app()
 
 

--- a/tests/providers/test_moonshine_server.py
+++ b/tests/providers/test_moonshine_server.py
@@ -20,6 +20,12 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+# moonshine_server.py imports numpy at module top — it's a runtime dep
+# of the toolbox container, not of hal0 itself, so it isn't in our dev
+# extras. Skip the whole module when numpy is absent rather than erroring
+# at collection time.
+pytest.importorskip("numpy")
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SERVER_PATH = _REPO_ROOT / "packaging" / "toolbox" / "moonshine" / "moonshine_server.py"
 


### PR DESCRIPTION
## Summary

Closes the remaining red CI test failures by fixing test isolation. After PR #63 made lint green, 9 test failures remained on main — all rooted in the same bug.

## Root cause

`ModelsConfig.roots` and `ModelsConfig.pull_root` had hardcoded `/var/lib/hal0/models` defaults that ignored `HAL0_HOME`. When tests set `HAL0_HOME` via the `tmp_hal0_home` fixture, registry helpers (`_pull_root`, the auto-scan boot path) still wrote into the host FHS layout — failing with `PermissionError` on CI (where `/var/lib/hal0` isn't writable) and host-state leakage on the LXC.

Two related papercuts surfaced once isolation was applied:

1. The global `app` / `client` fixtures didn't compose with `tmp_hal0_home`, so TestClient-driven tests booted against host `/etc/hal0/slots/*.toml` and registered live upstreams — breaking the 4 `test_v1_dispatch` tests that assert an empty upstream catalog.
2. `test_help_lists_new_flags` substring-matched `--provider` in `result.output`, but Click colours the leading dash in a separate ANSI sequence on coloured terminals.

## Changes

- **`src/hal0/config/schema.py`** — `ModelsConfig.roots` and `pull_root` now use `default_factory=lambda: str(paths.models_dir())`. Production behaviour unchanged (resolves to `/var/lib/hal0/models` when `HAL0_HOME` is unset); tests now get a tmp-path default automatically.
- **`tests/conftest.py`** — the `app` fixture takes `tmp_hal0_home`, so every `client` / `app` test is filesystem-isolated by default.
- **`tests/cli/test_slot_create_flags.py::test_help_lists_new_flags`** — strip ANSI before substring assertions.
- **`tests/api/test_config_model_roots.py::test_get_models_config_returns_defaults`** — assertion updated to reflect the new HAL0_HOME-aware defaults (previously inadvertently validating the bug).

## Test plan

- [x] Previously-failing tests all pass — `pytest tests/api/test_v1_dispatch.py tests/registry/test_curated_image_models.py tests/registry/test_pull.py tests/cli/test_slot_create_flags.py` → 35/35
- [x] Full suite (minus `tests/slots/test_integration.py`, `tests/openwebui/`, `tests/providers/test_moonshine_server.py` which need a real environment / numpy) — 1003 passed, 0 failed
- [x] Production behaviour unchanged when `HAL0_HOME` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)