### PR TITLE
fix(ci): override ENTRYPOINT on toolbox smoke-test docker run

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -86,7 +86,10 @@ jobs:
           # The runner has no GPU; the Vulkan binary should still launch
           # against the llvmpipe software rasteriser or fall back to CPU.
           # We accept any non-error exit from --help as proof-of-life.
-          docker run --rm hal0-toolbox-vulkan:ci /bin/bash -c \
+          # --entrypoint override: the image's ENTRYPOINT is llama-server
+          # itself (packaging/toolbox/vulkan.Dockerfile:154), so we have
+          # to swap it for /bin/bash to chain `which` + `--help`.
+          docker run --rm --entrypoint /bin/bash hal0-toolbox-vulkan:ci -c \
             'which llama-server && llama-server --help >/dev/null'
 
       - name: Cache model GGUF


### PR DESCRIPTION
## Summary

The hal0-toolbox-vulkan image's `ENTRYPOINT` is `llama-server` itself (`packaging/toolbox/vulkan.Dockerfile:154`). The Integration (tier β) smoke-test step was running:

```bash
docker run --rm hal0-toolbox-vulkan:ci /bin/bash -c '...'
```

…which passes `/bin/bash` as the first arg to `llama-server`, producing:

```
error: invalid argument: /bin/bash
```

every single run. This has been red on `main` for a while and every Wave 1 polish PR inherits the failure.

## Fix

`--entrypoint /bin/bash` override on the `docker run` line.

## Test plan

- [ ] CI on this branch runs Integration (tier β) green
- [ ] Slot integration (Vulkan-CPU baseline) step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)