### PR TITLE
fix(ci): add numpy + soundfile to dev extras for moonshine_server tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,13 @@ dev = [
   "ruff>=0.8",
   "mypy>=1.13",
   "httpx>=0.28",
+  # Runtime deps of the in-container moonshine_server, loaded via
+  # importlib by tests/providers/test_moonshine_server.py. Not on the
+  # hal0 production path — only the toolbox image needs them at runtime
+  # — but the test suite exercises the redaction logic from harness
+  # finding #14.
+  "numpy>=2.0",
+  "soundfile>=0.12",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

`tests/providers/test_moonshine_server.py` loads the in-container moonshine FastAPI app via `importlib` to exercise the redaction logic from harness finding #14. That module imports `numpy` + `soundfile` at top level, so the four tests in the file ERROR out on CI:

\`\`\`
E   ModuleNotFoundError: No module named 'numpy'
packaging/toolbox/moonshine/moonshine_server.py:34: ModuleNotFoundError
\`\`\`

## Fix

Add `numpy>=2.0` + `soundfile>=0.12` to `[project.optional-dependencies].dev`. Production behaviour unchanged — the toolbox image already installs them via `packaging/toolbox/moonshine/requirements.txt`.

## Test plan

- [ ] CI `python (3.11)` and `python (3.12)` go green on this branch (combined with #67 + #68)

🤖 Generated with [Claude Code](https://claude.com/claude-code)