### PR TITLE
fix(ui/e2e): repair Models view γ-suite specs after refactor (3 flakes)

### DIFF
--- a/ui/tests/e2e/specs/models-slots-refactor.spec.ts
+++ b/ui/tests/e2e/specs/models-slots-refactor.spec.ts
@@ -114,15 +114,27 @@ test('add model: local file scan preview + commit', async ({
   await expect(row).toBeVisible()
   await expect(row.locator('.scan-path')).toContainText('tiny-model.Q4_K_M.gguf')
 
-  // Edit the row's id field to confirm chips/inputs are reachable.
-  const idInput = row.locator('input.scan-input.mono')
-  await expect(idInput).toBeVisible()
+  // Edit the row's name field to confirm chips/inputs are reachable.
+  // The scan-table row now exposes a single editable input (Name) per
+  // row; capabilities + backends are pre-detected and locked at scan
+  // time per the post-360b1c8 design. The Name input drives the
+  // derived id (see Models.vue:1103 "id: …" hint), so reaching it is
+  // the right signal that the row's editable surface renders.
+  const nameInput = row.locator('input.scan-input.scan-name')
+  await expect(nameInput).toBeVisible()
 
-  // Click Commit.
+  // Rows only pre-select when the preview returned `confidence: 'high'`
+  // and `kind: 'llama'` (Models.vue:418); our mock returns a numeric
+  // confidence + no kind, so we tick the include-row checkbox to drive
+  // the commit count.
+  await row.locator('input[type="checkbox"]').check()
+
+  // Click Commit. The button now reads "Register N of M" — the
+  // selected-count-of-total framing is the post-refactor copy.
   const commitReq = page.waitForRequest(
     (r) => r.url().endsWith('/api/models/scan') && r.method() === 'POST',
   )
-  await page.getByRole('button', { name: /^Commit 1 row\(s\)$/ }).click()
+  await page.getByRole('button', { name: /^Register 1 of 1$/ }).click()
   await commitReq
 
   expect(lastScanCommit?.rows?.length).toBe(1)
@@ -370,8 +382,11 @@ test('slotcard inline swap: popover + filter by backend + /swap call', async ({
 
   expect(lastSwap?.model_id).toBe('qwen3-4b')
 
-  // Toast on success.
-  await expect(page.locator('.toast').filter({ hasText: /swapped primary/ })).toBeVisible()
+  // Toast on success. SlotCard fires "swapping <slot> → <label>…" the
+  // instant the swap is dispatched (the eventual "<slot> ready on
+  // <label>" toast lands once the backend health-check resolves; in
+  // mock mode we don't wait that long).
+  await expect(page.locator('.toast').filter({ hasText: /swapping primary/ })).toBeVisible()
   // Popover closes.
   await expect(popover).toHaveCount(0)
 })

--- a/ui/tests/e2e/specs/models.spec.ts
+++ b/ui/tests/e2e/specs/models.spec.ts
@@ -95,7 +95,10 @@ test('pulls a custom HF model, assigns it to primary, deletes it', async ({
   await page.goto('/models')
 
   // ── Open pull modal, switch to HF tab, submit a repo ─────────
-  await page.getByRole('button', { name: /^Pull model$/ }).click()
+  // Page-level trigger is now "Add model" (B3 rename in 360b1c8 — the
+  // page Add button surfaces Curated/HuggingFace/Local tabs; the HF
+  // tab's submit button is still "Pull model").
+  await page.getByRole('button', { name: /^Add model$/ }).click()
   await expect(page.locator('#pull-title')).toBeVisible()
   await page.getByRole('tab', { name: /HuggingFace/ }).click()
   await page.locator('#hf-url').fill(HF_ID)


### PR DESCRIPTION
Three Playwright specs went red on main after the Models view refactor (commits `4a93530`, `bee774a`, `360b1c8`). Selectors no longer match the new DOM.

## What

- `ui/tests/e2e/specs/models-slots-refactor.spec.ts:60` — *add model: local file scan preview + commit*
  - Scan-table row's editable input is now `input.scan-input.scan-name` (the old `.mono` modifier was retired).
  - Commit button copy is `Register N of M`, not `Commit N row(s)`.
  - Rows only pre-select for `confidence === 'high' && kind === 'llama'`; numeric-confidence rows now require an explicit checkbox tick to drive the commit count past zero.
- `ui/tests/e2e/specs/models-slots-refactor.spec.ts:308` — *slotcard inline swap*
  - SlotCard emits `swapping <slot> → <label>…` on dispatch (no longer `swapped`). Toast regex updated.
- `ui/tests/e2e/specs/models.spec.ts:35` — *pulls custom HF model + assigns + deletes*
  - Page-level trigger renamed `Pull model` → `Add model` (B3). The HF-tab submit button is still `Pull model`, so the inner selector stayed.

No production code changes — all stable hooks (ids, role+name, visible text) were already present; no new `data-testid` attrs needed. The fixes are pure spec-selector updates so the tests' behavioural intent (same assertions, same wire shapes) is preserved.

## Test plan

- [x] Three repaired specs pass locally three runs in a row (chromium)
- [x] Full chromium γ-suite (20 specs) goes green — no regression
- [ ] CI γ-suite goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)