### PR TITLE
fix(ci): add python-multipart to dev extras for moonshine_server tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,11 @@ dev = [
   # finding #14.
   "numpy>=2.0",
   "soundfile>=0.12",
+  # FastAPI's File()/UploadFile/Form() construction (used by the
+  # moonshine_server multipart route) requires python-multipart at
+  # import time. Same scope as numpy + soundfile above — toolbox-only
+  # at runtime, but the test suite imports the FastAPI app.
+  "python-multipart>=0.0.9",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

Follow-up to #71. After landing numpy + soundfile dev extras, `tests/providers/test_moonshine_server.py` now loads further into the FastAPI app, which constructs `File()`/`UploadFile`/`Form()` at module import time. Those raise:

\`\`\`
E   RuntimeError: Form data requires "python-multipart" to be installed.
\`\`\`

## Fix

Add \`python-multipart>=0.0.9\` to the dev extras alongside numpy/soundfile (same scope — toolbox-only at runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)