### PR TITLE
fix(ci): install ffmpeg on the CI runner for moonshine redaction tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+      - name: Install system deps
+        # ffmpeg backs the in-container moonshine audio decoder
+        # (packaging/toolbox/moonshine/moonshine_server.py). The redaction
+        # tests in tests/providers/test_moonshine_server.py exercise the
+        # real subprocess path; without ffmpeg they hit FileNotFoundError
+        # instead of the CalledProcessError the code catches.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
       - name: Install
         run: pip install -e ".[dev]"
       - name: Lint


### PR DESCRIPTION
## Summary

After landing #71/#73 (numpy + soundfile + python-multipart dev deps), the moonshine_server tests now load successfully, but two of them fail with:

\`\`\`
FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg'
\`\`\`

The tests exercise the production redaction logic, which catches \`CalledProcessError\` from a real ffmpeg subprocess. Without ffmpeg installed on the runner, they hit \`FileNotFoundError\` instead and never reach the code under test.

## Fix

\`apt-get install ffmpeg\` before \`pip install\` in the CI workflow. The production toolbox image (\`packaging/toolbox/moonshine/Dockerfile\`) already installs it.

## Test plan

- [ ] CI python (3.11) and python (3.12) jobs go fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)