### PR TITLE
fix(manifest): refresh toolbox digests + hal0 doctor toolbox-pull probe (#41)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+      - name: Install system deps
+        # ffmpeg backs the in-container moonshine audio decoder
+        # (packaging/toolbox/moonshine/moonshine_server.py). The redaction
+        # tests in tests/providers/test_moonshine_server.py exercise the
+        # real subprocess path; without ffmpeg they hit FileNotFoundError
+        # instead of the CalledProcessError the code catches.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
       - name: Install
         run: pip install -e ".[dev]"
       - name: Lint

--- a/.github/workflows/toolbox.yml
+++ b/.github/workflows/toolbox.yml
@@ -203,8 +203,15 @@ jobs:
   manifest:
     name: Aggregate manifest.json
     needs: build
-    if: always()
+    # Only fire on push-to-main (or a dispatch with no image filter); on a
+    # partial dispatch we just upload the artefact and skip the PR step,
+    # otherwise we'd open PRs against main with a manifest that only pins a
+    # subset of images.
+    if: always() && github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -217,6 +224,7 @@ jobs:
           merge-multiple: true
 
       - name: Patch manifest.json
+        id: patch
         run: |
           python3 - <<'PY'
           import json
@@ -226,18 +234,28 @@ jobs:
           manifest = json.loads(manifest_path.read_text())
           toolbox_images = manifest.setdefault("toolbox_images", {})
 
+          changed = []
           digests_dir = Path("_digests")
           if digests_dir.is_dir():
               for f in sorted(digests_dir.glob("*.json")):
                   data = json.loads(f.read_text())
                   name = data["name"]
                   entry = toolbox_images.setdefault(name, {})
+                  prev = entry.get("digest")
                   entry["tag"] = data["image"]
                   entry["digest"] = data["digest"]
+                  if prev != data["digest"]:
+                      changed.append(f"{name}: {prev} -> {data['digest']}")
                   print(f"pinned {name}: {data['digest']}")
 
           manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+          Path("_digests/_changed.txt").write_text("\n".join(changed) + "\n")
           PY
+          {
+            echo "changed<<EOF"
+            cat _digests/_changed.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Show manifest
         run: cat manifest.json
@@ -247,3 +265,29 @@ jobs:
         with:
           name: manifest-pinned
           path: manifest.json
+
+      - name: Open PR with refreshed digests
+        if: steps.patch.outputs.changed != ''
+        uses: peter-evans/create-pull-request@v6
+        with:
+          # GITHUB_TOKEN is fine here; PRs opened by this token do NOT
+          # trigger downstream workflows (avoids a build-loop), which is
+          # what we want for a digest-bump PR.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(manifest): refresh toolbox digests after build"
+          title: "chore(manifest): refresh toolbox digests"
+          branch: bot/refresh-toolbox-digests
+          delete-branch: true
+          add-paths: manifest.json
+          body: |
+            Automated refresh of `manifest.json.toolbox_images.*.digest` from
+            the latest `toolbox.yml` build run (commit ${{ github.sha }}).
+
+            Changes:
+            ```
+            ${{ steps.patch.outputs.changed }}
+            ```
+
+            Review and merge to keep installer pins in sync with the
+            published images on ghcr.io. Falls back to `:v1` tag-pull at
+            runtime if a digest is stale or null.

--- a/installer/README.md
+++ b/installer/README.md
@@ -26,6 +26,19 @@ sudo bash installer/install.sh
 
 The installer is **idempotent** — safe to re-run after a partial failure or to update configuration defaults.
 
+### Pulling toolbox images
+
+Toolbox images live under `ghcr.io/hal0ai/hal0-toolbox-*` and are **public**;
+the installer (and `hal0 slot load` at runtime) pull them anonymously. No
+`docker login` is required — even on a hardened LAN box that has never seen
+a GHCR credential.
+
+The pinned image digests are tracked in [`manifest.json`](../manifest.json)
+and refreshed by `.github/workflows/toolbox.yml` after every build. Run
+`hal0 doctor toolbox-pull` to verify each pinned image is reachable from
+this host (anonymous OCI v2 token-exchange + HEAD on the manifest URL —
+no `docker pull` needed).
+
 ## Environment variables
 
 These are the variables `installer/install.sh` actually reads:

--- a/manifest.json
+++ b/manifest.json
@@ -1,38 +1,38 @@
 {
   "_schema": "hal0.manifest.v1",
-  "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release \u2014 the runtime then pulls by tag and emits a warning. The `.github/workflows/toolbox.yml` build job patches this file post-publish with the actual content digests via cosign + buildx. Schema versioned via `_schema`; bump it when the shape changes. See PLAN.md \u00a712 (toolbox images) and \u00a717 (Risks: ghcr.io/hal0ai/ org provisioning may be deferred, so refs use ghcr.io/<owner>/ in the workflow).",
+  "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release \u2014 the runtime then pulls by tag and emits a warning. The `.github/workflows/toolbox.yml` build job patches this file post-publish with the actual content digests via cosign + buildx and opens a PR (or pushes to main, depending on the `manifest` job config) so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See PLAN.md \u00a712 (toolbox images) and \u00a717 (Risks).",
   "version": "0.0.0",
   "channel": "dev",
   "toolbox_images": {
     "vulkan": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1",
-      "digest": "sha256:8257537d32c900014c4fb81249ab8732c72701a9a28fa3053a9d294b5d5ef8e2",
+      "digest": "sha256:eac37fe1b594cf496066fabb050d053692194f3ea8656fc4782b3131cbec7a9c",
       "_notes": "llama.cpp Vulkan backend; default for Strix Halo iGPU"
     },
     "rocm": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-rocm:v1",
-      "digest": "sha256:ea82221a210fd3b7ca6deb1e53b7206c8e53e6dd91fc53595efc0c5c73daea84",
+      "digest": "sha256:3cfa65321cc66d3f7ad389d83e6f134912330ffc4f45ba50360307f97ca42830",
       "_notes": "llama.cpp ROCm backend; multi-arch (gfx1030..gfx1151)"
     },
     "flm": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-flm:v1",
-      "digest": "sha256:6ef99c2f202a0166b3034d474726ba49a36093b16f26e6e472607876a715e690",
+      "digest": "sha256:eadbc8128599fe177a47e536f3a1a638ce9bbe83930910f9594e1f2e8df29ac9",
       "_notes": "FastFlowLM on AMD XDNA2 NPU; requires kernel >= 6.11 + amdxdna driver on the host"
     },
     "moonshine": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-moonshine:v1",
-      "digest": "sha256:b1fbd13db78975c3f29d77d1a4523ba613710fbfd331395e4f2c41913b4faba5",
+      "digest": "sha256:a5bbb78b54ac07620fc28a168d31ef5d8e6523cbf93f76faf189f3bbd8e8ddaa",
       "_notes": "Moonshine STT (CPU/Vulkan); OpenAI-compat /v1/audio/transcriptions + WS"
     },
     "kokoro": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1",
-      "digest": "sha256:2247ed408a2ea556ba257cf3f054cc3d59f8d07b1274a7e44ea9f11b693eb716",
+      "digest": "sha256:0e9e7b06bbda3ba4c81deda71c9d2c3b43697325eb2d514e2fd69afa3cdcb9d1",
       "_notes": "Kokoro-82M TTS (CPU ONNX); OpenAI-compat /v1/audio/speech",
       "_upstream_reference": "https://github.com/thewh1teagle/kokoro-onnx"
     },
     "comfyui": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-comfyui:v1",
-      "digest": "sha256:55d711557f4e6b761c5b09f21601d23736567a3d9a58283da5fe064bd65cd593",
+      "digest": "sha256:f887050f5ae4e648ce2fa7225fbbfed61d45b00941857ec4ec115d3353c99f76",
       "_notes": "ComfyUI image-gen on ROCm; SDXL + SD 1.5 + Flux. Translated from OpenAI /v1/images/generations.",
       "_upstream_reference": "https://github.com/comfyanonymous/ComfyUI"
     }

--- a/src/hal0/cli/doctor_commands.py
+++ b/src/hal0/cli/doctor_commands.py
@@ -1,9 +1,9 @@
 """CLI implementation for ``hal0 doctor``.
 
-Shells out to ``installer/lib/preflight.sh`` (the same script
-``installer/install.sh`` sources for its pre-install checks) so the
-operator can re-run the full preflight battery post-install without
-touching the installer.
+The default ``hal0 doctor`` invocation shells out to
+``installer/lib/preflight.sh`` (the same script ``installer/install.sh``
+sources for its pre-install checks) so the operator can re-run the full
+preflight battery post-install without touching the installer.
 
 Locating the script:
 
@@ -16,6 +16,12 @@ Locating the script:
 
 The command preserves the script's exit code so it composes with other
 shell tooling (``hal0 doctor && hal0 status``).
+
+Sub-commands:
+
+* ``hal0 doctor toolbox-pull`` — assert that every image pinned in
+  ``manifest.json.toolbox_images`` is anonymously reachable on ghcr.io
+  (issue tracker: task #25 / harness FINDINGS §8).
 """
 
 from __future__ import annotations
@@ -25,11 +31,15 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
+import httpx
 import typer
 from rich.console import Console
+from rich.table import Table
 
 import hal0
+from hal0.config.loader import load_manifest
 
 app = typer.Typer(
     name="doctor",
@@ -38,6 +48,21 @@ app = typer.Typer(
 )
 
 console = Console()
+
+
+# OCI manifest media types accepted by ghcr.io. We list the OCI image
+# index + the Docker manifest list first because every toolbox image is
+# multi-arch (amd64 today; arm64 once Strix Halo arm spins up). The
+# single-arch fallbacks are kept so the probe still resolves single-arch
+# tags users may push manually.
+_OCI_MANIFEST_ACCEPT = ",".join(
+    (
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    )
+)
 
 
 def _locate_preflight() -> Path | None:
@@ -68,6 +93,7 @@ def _locate_preflight() -> Path | None:
 
 @app.callback(invoke_without_command=True)
 def doctor(
+    ctx: typer.Context,
     plain: bool = typer.Option(
         False,
         "--plain",
@@ -80,6 +106,12 @@ def doctor(
     ),
 ) -> None:
     """Re-run pre-flight checks (systemd, python, docker, disk, ports)."""
+    # When a sub-command (e.g. ``toolbox-pull``) is invoked, Typer still
+    # calls the callback first. Bail out without running preflight so the
+    # sub-command handles the request on its own — preflight is the
+    # "default" only when no sub-command is given.
+    if ctx.invoked_subcommand is not None:
+        return
     preflight = _locate_preflight()
     if preflight is None:
         console.print(
@@ -115,3 +147,208 @@ def doctor(
     # Preserve the script's exit code verbatim so chained shells see a
     # non-zero on the first failed check.
     raise typer.Exit(result.returncode)
+
+
+# ── hal0 doctor toolbox-pull ──────────────────────────────────────────────────
+
+
+def _parse_image_ref(tag: str) -> tuple[str, str, str] | None:
+    """Split ``ghcr.io/<owner>/<image>:<tag>`` into ``(registry, repo, tag)``.
+
+    Returns ``None`` when the ref doesn't look like a ghcr.io reference —
+    callers surface that as a fail row rather than crashing. We
+    deliberately only support ghcr.io for now; the toolbox contract is
+    "public on ghcr.io/hal0ai/" and reaching other registries would
+    require a different auth flow.
+    """
+    if not tag.startswith("ghcr.io/"):
+        return None
+    body = tag[len("ghcr.io/") :]
+    # Split off the tag suffix (``:v1`` etc.). Digest refs (``@sha256:...``)
+    # aren't valid here — the probe HEAD's the tag because the digest is
+    # exactly what we're trying to discover.
+    if ":" in body:
+        repo, _, ref = body.rpartition(":")
+    else:
+        repo, ref = body, "latest"
+    if not repo or "/" not in repo:
+        return None
+    return ("ghcr.io", repo, ref)
+
+
+def _ghcr_anon_token(repo: str, *, client: httpx.Client) -> str:
+    """Exchange anonymous credentials for a pull-scoped ghcr.io bearer.
+
+    ghcr.io's token endpoint returns ``{"token": "..."}`` for any
+    public package without authentication. We pass ``scope=
+    repository:<repo>:pull`` so the token is narrowed to the one repo
+    we're about to HEAD.
+    """
+    resp = client.get(
+        "https://ghcr.io/token",
+        params={"scope": f"repository:{repo}:pull"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+    token = payload.get("token") or payload.get("access_token")
+    if not isinstance(token, str) or not token:
+        raise RuntimeError(f"ghcr.io token endpoint returned no token for {repo}")
+    return token
+
+
+def _ghcr_manifest_digest(
+    repo: str,
+    ref: str,
+    *,
+    token: str,
+    client: httpx.Client,
+) -> str:
+    """HEAD the manifest URL and return the ``Docker-Content-Digest`` header.
+
+    The header is the canonical content digest for the (possibly
+    multi-arch) manifest the tag points at. We don't fetch the body —
+    HEAD is enough to assert reachability + capture the digest, which is
+    all the probe needs.
+    """
+    resp = client.request(
+        "HEAD",
+        f"https://ghcr.io/v2/{repo}/manifests/{ref}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": _OCI_MANIFEST_ACCEPT,
+        },
+        timeout=10.0,
+    )
+    if resp.status_code >= 400:
+        raise RuntimeError(f"HTTP {resp.status_code} {resp.reason_phrase or ''}".strip())
+    digest = resp.headers.get("docker-content-digest") or resp.headers.get("Docker-Content-Digest")
+    if not digest:
+        raise RuntimeError("manifest HEAD returned no Docker-Content-Digest header")
+    return digest
+
+
+def _probe_one(
+    name: str,
+    entry: dict[str, Any],
+    *,
+    client: httpx.Client,
+) -> dict[str, Any]:
+    """Probe one ``toolbox_images`` entry; never raises — returns a row dict.
+
+    Row shape:
+        {"name", "tag", "ok": bool, "digest": str | None,
+         "pinned_digest": str | None, "matches_pin": bool | None,
+         "error": str | None}
+
+    Digest mismatch is surfaced via ``matches_pin``; it doesn't flip
+    ``ok`` to False because reconciling drift is a separate workflow
+    (the manifest job in toolbox.yml). The probe's job is just
+    "reachable yes/no" + "here's what's actually there".
+    """
+    row: dict[str, Any] = {
+        "name": name,
+        "tag": entry.get("tag") or "",
+        "ok": False,
+        "digest": None,
+        "pinned_digest": entry.get("digest") or None,
+        "matches_pin": None,
+        "error": None,
+    }
+    tag = entry.get("tag")
+    if not isinstance(tag, str) or not tag:
+        row["error"] = "manifest entry missing 'tag'"
+        return row
+    parsed = _parse_image_ref(tag)
+    if parsed is None:
+        row["error"] = f"unsupported registry in tag {tag!r} (only ghcr.io is probed)"
+        return row
+    _, repo, ref = parsed
+    try:
+        token = _ghcr_anon_token(repo, client=client)
+        digest = _ghcr_manifest_digest(repo, ref, token=token, client=client)
+    except (httpx.HTTPError, RuntimeError, ValueError) as exc:
+        row["error"] = f"{type(exc).__name__}: {exc}"
+        return row
+    row["ok"] = True
+    row["digest"] = digest
+    if row["pinned_digest"]:
+        row["matches_pin"] = row["pinned_digest"] == digest
+    return row
+
+
+@app.command("toolbox-pull")
+def toolbox_pull(
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit a JSON list of probe rows instead of the human-readable table.",
+    ),
+    manifest_path: Path | None = typer.Option(
+        None,
+        "--manifest",
+        help="Override manifest.json location (defaults to the loader's FHS-aware resolver).",
+    ),
+) -> None:
+    """Verify each pinned toolbox image is anonymously pullable from ghcr.io.
+
+    Walks ``manifest.json.toolbox_images`` and exercises the anonymous
+    OCI v2 token-exchange + HEAD-manifest flow per image. Reports each
+    image's reachable status and the actual ghcr.io digest seen
+    alongside the pinned digest from the manifest.
+
+    Exit codes:
+      0 — every entry was reachable (digest drift is reported but does
+          NOT fail; that's the manifest job's problem).
+      1 — at least one image could not be reached.
+      2 — manifest.json is empty or has no toolbox_images entries.
+    """
+    import json as jsonlib
+
+    manifest = load_manifest(manifest_path) if manifest_path else load_manifest()
+    images = manifest.get("toolbox_images") or {}
+    if not isinstance(images, dict) or not images:
+        console.print("[yellow]![/yellow]  manifest.json has no toolbox_images entries to probe.")
+        raise typer.Exit(2)
+
+    rows: list[dict[str, Any]] = []
+    with httpx.Client(follow_redirects=True) as client:
+        for name in sorted(images.keys()):
+            entry = images[name]
+            if not isinstance(entry, dict):
+                rows.append(
+                    {
+                        "name": name,
+                        "tag": "",
+                        "ok": False,
+                        "digest": None,
+                        "pinned_digest": None,
+                        "matches_pin": None,
+                        "error": "manifest entry is not a dict",
+                    }
+                )
+                continue
+            rows.append(_probe_one(name, entry, client=client))
+
+    if json_output:
+        console.print_json(jsonlib.dumps(rows))
+    else:
+        table = Table(title="ghcr.io toolbox-image pull probe (anonymous)")
+        table.add_column("Image", style="bold")
+        table.add_column("Status")
+        table.add_column("Digest (actual)")
+        table.add_column("Pin")
+        for row in rows:
+            status = "[green]ok[/green]" if row["ok"] else f"[red]FAIL[/red] {row['error']}"
+            digest = row["digest"] or "—"
+            if row["matches_pin"] is True:
+                pin = "[green]match[/green]"
+            elif row["matches_pin"] is False:
+                pin = "[yellow]drift[/yellow]"
+            else:
+                pin = "[dim]unpinned[/dim]"
+            table.add_row(row["name"], status, digest, pin)
+        console.print(table)
+
+    failures = [r for r in rows if not r["ok"]]
+    raise typer.Exit(1 if failures else 0)

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1,9 +1,13 @@
 """Tests for the ``hal0 doctor`` CLI subcommand.
 
-The command shells out to ``installer/lib/preflight.sh``, so we exercise
-it with the script set to a known shape via the ``HAL0_PREFLIGHT_SH``
-env override. ``capfd`` captures the subprocess's file-descriptor-level
-output (CliRunner's StringIO can't see past subprocess.run).
+The default ``hal0 doctor`` call shells out to ``installer/lib/preflight.sh``,
+so we exercise it with the script set to a known shape via the
+``HAL0_PREFLIGHT_SH`` env override. ``capfd`` captures the subprocess's
+file-descriptor-level output (CliRunner's StringIO can't see past
+subprocess.run).
+
+``hal0 doctor toolbox-pull`` is exercised via an ``httpx.MockTransport``
+that stubs the ghcr.io token-exchange + manifest-HEAD flow.
 
 Skipped on non-Linux platforms — the real preflight script depends on
 ``systemctl`` / ``df`` / ``ss`` which only mean something on Linux.
@@ -11,15 +15,18 @@ Skipped on non-Linux platforms — the real preflight script depends on
 
 from __future__ import annotations
 
+import json as jsonlib
 import os
 import stat
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
+import httpx
 import pytest
 import typer
 
-from hal0.cli.doctor_commands import _locate_preflight, doctor
+from hal0.cli.doctor_commands import _locate_preflight, doctor, toolbox_pull
 
 pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="preflight.sh is Linux-only")
 
@@ -30,6 +37,17 @@ def _make_stub(tmp_path: Path, body: str) -> Path:
     stub.write_text("#!/usr/bin/env bash\n" + body)
     stub.chmod(stub.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     return stub
+
+
+class _FakeCtx:
+    """Minimal stand-in for `typer.Context` — only `invoked_subcommand` matters."""
+
+    invoked_subcommand: str | None = None
+
+
+def _fake_ctx() -> _FakeCtx:
+    """Build a context that represents "no sub-command invoked"."""
+    return _FakeCtx()
 
 
 def _exit_code(exc: pytest.ExceptionInfo[typer.Exit] | typer.Exit) -> int:
@@ -49,7 +67,7 @@ def test_doctor_success_propagates_exit_code(
     monkeypatch.setenv("HAL0_PREFLIGHT_SH", str(stub))
 
     with pytest.raises(typer.Exit) as exc:
-        doctor(plain=False, ports=None)
+        doctor(ctx=_fake_ctx(), plain=False, ports=None)
 
     assert _exit_code(exc) == 0
     captured = capfd.readouterr()
@@ -66,7 +84,7 @@ def test_doctor_failure_propagates_exit_code(
     monkeypatch.setenv("HAL0_PREFLIGHT_SH", str(stub))
 
     with pytest.raises(typer.Exit) as exc:
-        doctor(plain=False, ports=None)
+        doctor(ctx=_fake_ctx(), plain=False, ports=None)
 
     assert _exit_code(exc) == 1
     captured = capfd.readouterr()
@@ -78,7 +96,7 @@ def test_doctor_missing_script_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HAL0_PREFLIGHT_SH", "/definitely/not/a/real/path.sh")
 
     with pytest.raises(typer.Exit) as exc:
-        doctor(plain=False, ports=None)
+        doctor(ctx=_fake_ctx(), plain=False, ports=None)
 
     assert _exit_code(exc) == 2
 
@@ -96,7 +114,7 @@ def test_doctor_forwards_plain_flag(
     monkeypatch.setenv("HAL0_PREFLIGHT_SH", str(stub))
 
     with pytest.raises(typer.Exit) as exc:
-        doctor(plain=True, ports=None)
+        doctor(ctx=_fake_ctx(), plain=True, ports=None)
 
     assert _exit_code(exc) == 0
     captured = capfd.readouterr()
@@ -116,7 +134,7 @@ def test_doctor_forwards_ports_option(
     monkeypatch.setenv("HAL0_PREFLIGHT_SH", str(stub))
 
     with pytest.raises(typer.Exit) as exc:
-        doctor(plain=False, ports="9090 9091")
+        doctor(ctx=_fake_ctx(), plain=False, ports="9090 9091")
 
     assert _exit_code(exc) == 0
     captured = capfd.readouterr()
@@ -152,3 +170,223 @@ def test_locate_preflight_missing_override_returns_none(
     """A bogus HAL0_PREFLIGHT_SH path resolves to None, not a falsy default."""
     monkeypatch.setenv("HAL0_PREFLIGHT_SH", "/no/such/file.sh")
     assert _locate_preflight() is None
+
+
+# ── hal0 doctor toolbox-pull ──────────────────────────────────────────────────
+
+
+def _write_manifest(tmp_path: Path, body: dict) -> Path:
+    """Drop a minimal manifest.json file under tmp_path and return its path."""
+    path = tmp_path / "manifest.json"
+    path.write_text(jsonlib.dumps(body))
+    return path
+
+
+def _install_mock_httpx(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> None:
+    """Replace ``httpx.Client`` in doctor_commands with one backed by ``handler``.
+
+    We patch the symbol the module bound at import time, not the global
+    httpx namespace, so unrelated httpx users in other tests aren't
+    affected.
+    """
+    from hal0.cli import doctor_commands as mod
+
+    transport = httpx.MockTransport(handler)
+    real_client_cls = httpx.Client  # capture before monkeypatch swaps it
+
+    def _client_factory(*_args: object, **kwargs: object) -> httpx.Client:
+        # Drop caller-supplied transport/follow_redirects — we own them.
+        kwargs.pop("transport", None)
+        kwargs.pop("follow_redirects", None)
+        return real_client_cls(transport=transport, follow_redirects=True, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(mod.httpx, "Client", _client_factory)
+
+
+def test_toolbox_pull_reports_ok_when_all_images_reachable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Happy path: every probe HEAD returns the pinned digest → exit 0."""
+    pinned = "sha256:" + "a" * 64
+    manifest_path = _write_manifest(
+        tmp_path,
+        {
+            "_schema": "hal0.manifest.v1",
+            "version": "1.0.0",
+            "toolbox_images": {
+                "vulkan": {
+                    "tag": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1",
+                    "digest": pinned,
+                },
+            },
+        },
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/token":
+            return httpx.Response(200, json={"token": "anon-bearer"})
+        if request.url.path.endswith("/manifests/v1"):
+            assert request.method == "HEAD"
+            assert request.headers["Authorization"] == "Bearer anon-bearer"
+            return httpx.Response(200, headers={"Docker-Content-Digest": pinned})
+        raise AssertionError(f"unexpected URL: {request.url}")
+
+    _install_mock_httpx(monkeypatch, handler)
+
+    with pytest.raises(typer.Exit) as exc:
+        toolbox_pull(json_output=True, manifest_path=manifest_path)
+    assert _exit_code(exc) == 0
+    out = capsys.readouterr().out
+    rows = jsonlib.loads(out)
+    assert rows[0]["ok"] is True
+    assert rows[0]["digest"] == pinned
+    assert rows[0]["matches_pin"] is True
+
+
+def test_toolbox_pull_surfaces_digest_drift_without_failing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Digest drift is reported in ``matches_pin`` but does NOT exit non-zero."""
+    pinned = "sha256:" + "a" * 64
+    actual = "sha256:" + "b" * 64
+    manifest_path = _write_manifest(
+        tmp_path,
+        {
+            "_schema": "hal0.manifest.v1",
+            "toolbox_images": {
+                "vulkan": {
+                    "tag": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1",
+                    "digest": pinned,
+                },
+            },
+        },
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/token":
+            return httpx.Response(200, json={"token": "anon"})
+        return httpx.Response(200, headers={"Docker-Content-Digest": actual})
+
+    _install_mock_httpx(monkeypatch, handler)
+
+    with pytest.raises(typer.Exit) as exc:
+        toolbox_pull(json_output=True, manifest_path=manifest_path)
+    assert _exit_code(exc) == 0, "digest drift must not flip the exit code"
+    rows = jsonlib.loads(capsys.readouterr().out)
+    assert rows[0]["ok"] is True
+    assert rows[0]["digest"] == actual
+    assert rows[0]["matches_pin"] is False
+
+
+def test_toolbox_pull_exits_nonzero_when_image_unreachable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A 404 on the manifest URL surfaces as ok=False and exit code 1."""
+    manifest_path = _write_manifest(
+        tmp_path,
+        {
+            "_schema": "hal0.manifest.v1",
+            "toolbox_images": {
+                "vulkan": {
+                    "tag": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1",
+                    "digest": None,
+                },
+            },
+        },
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/token":
+            return httpx.Response(200, json={"token": "anon"})
+        return httpx.Response(404, text="not found")
+
+    _install_mock_httpx(monkeypatch, handler)
+
+    with pytest.raises(typer.Exit) as exc:
+        toolbox_pull(json_output=True, manifest_path=manifest_path)
+    assert _exit_code(exc) == 1
+    rows = jsonlib.loads(capsys.readouterr().out)
+    assert rows[0]["ok"] is False
+    assert "404" in (rows[0]["error"] or "")
+
+
+def test_toolbox_pull_exits_2_when_manifest_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No toolbox_images block → exit 2 (preserved diagnostic semantics)."""
+    manifest_path = _write_manifest(
+        tmp_path,
+        {"_schema": "hal0.manifest.v1", "toolbox_images": {}},
+    )
+
+    # No network should be touched in this path; install a handler that
+    # blows up loudly if it is.
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("network should not be hit when manifest is empty")
+
+    _install_mock_httpx(monkeypatch, handler)
+
+    with pytest.raises(typer.Exit) as exc:
+        toolbox_pull(json_output=False, manifest_path=manifest_path)
+    assert _exit_code(exc) == 2
+
+
+def test_toolbox_pull_skips_non_ghcr_refs_with_clear_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A non-ghcr.io tag is reported as failed without any network calls."""
+    manifest_path = _write_manifest(
+        tmp_path,
+        {
+            "_schema": "hal0.manifest.v1",
+            "toolbox_images": {
+                "vulkan": {
+                    "tag": "docker.io/hal0ai/hal0-toolbox-vulkan:v1",
+                    "digest": None,
+                },
+            },
+        },
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("non-ghcr tag should not trigger a network call")
+
+    _install_mock_httpx(monkeypatch, handler)
+
+    with pytest.raises(typer.Exit) as exc:
+        toolbox_pull(json_output=True, manifest_path=manifest_path)
+    assert _exit_code(exc) == 1
+    rows = jsonlib.loads(capsys.readouterr().out)
+    assert rows[0]["ok"] is False
+    assert "ghcr.io" in (rows[0]["error"] or "")
+
+
+def test_toolbox_pull_invoked_subcommand_skips_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """When a sub-command is invoked, the callback must NOT exec preflight."""
+    stub = _make_stub(tmp_path, "printf 'should-not-run\\n'\nexit 99\n")
+    monkeypatch.setenv("HAL0_PREFLIGHT_SH", str(stub))
+
+    class _CtxWithSubcommand:
+        invoked_subcommand = "toolbox-pull"
+
+    # Doctor callback should return None silently (no typer.Exit) when a
+    # sub-command is present.
+    result = doctor(ctx=_CtxWithSubcommand(), plain=False, ports=None)  # type: ignore[arg-type]
+    assert result is None
+    assert "should-not-run" not in capfd.readouterr().out


### PR DESCRIPTION
Two related ghcr.io tasks for v1.0:

1. **Closes #41**: documents that `ghcr.io/hal0ai/*` toolbox images are anonymously pullable, with a new `hal0 doctor toolbox-pull` probe that asserts the contract.
2. **Refreshes manifest.json digest pins** — every pinned digest had drifted vs the actual ghcr digest on 2026-05-21. Refreshed all six (vulkan, rocm, flm, moonshine, kokoro, comfyui) to current actuals.

## What

- `installer/README.md`: added a *Pulling toolbox images* section explicitly stating images are public on `ghcr.io/hal0ai/` and that `docker login` is **not** required. Points operators at `hal0 doctor toolbox-pull` to verify reachability.
- `hal0 doctor toolbox-pull`: new sub-command (lives in `src/hal0/cli/doctor_commands.py`). Walks `manifest.json.toolbox_images` and exercises the anonymous OCI v2 token-exchange + HEAD-manifest flow per image. Reports each image's status, the actual ghcr.io digest, and whether it matches the pinned digest. Exits 0 on full reach, 1 on any unreachable image, 2 on an empty manifest. Digest drift is surfaced (`matches_pin: false`) but does **not** flip the exit code — reconciling drift is the manifest workflow's job.
- `manifest.json`: refreshed all six pinned digests against the live ghcr.io content digests captured 2026-05-21; updated the `_comment` to describe the now-PR-driven post-publish patch step and the anonymous-pull contract.
- `.github/workflows/toolbox.yml`: fixed the post-publish digest-patch step. Previously the `manifest` job patched `manifest.json` in the GHA workspace and uploaded it as an artefact but **never committed it back** to the repo — which is why the pins had drifted. The job now opens a PR with the refreshed digests via `peter-evans/create-pull-request@v6`, restricted to push-to-main runs so a partial `workflow_dispatch` (subset of images) doesn't open PRs with half-pinned manifests.

## Verification

Probe ran end-to-end against the live registry on hal0-dev — all six images reachable, all match the refreshed pins:

```
ghcr.io toolbox-image pull probe (anonymous)
  comfyui   ok  sha256:f887050f...  match
  flm       ok  sha256:eadbc812...  match
  kokoro    ok  sha256:0e9e7b06...  match
  moonshine ok  sha256:a5bbb78b...  match
  rocm      ok  sha256:3cfa6532...  match
  vulkan    ok  sha256:eac37fe1...  match
```

## Test plan

- [x] `ruff check src/hal0 tests` + `ruff format --check` clean
- [x] `pytest tests/cli` green (31 tests, 6 new toolbox-pull cases)
- [x] `hal0 doctor toolbox-pull` against live ghcr.io reports all six images as `ok / match` on a host with no docker credentials
- [x] `hal0 doctor toolbox-pull --json` emits parseable JSON rows
- [x] `hal0 doctor` (no sub-command) still runs preflight (callback now gates on `ctx.invoked_subcommand`)
- [ ] Manifest-patch PR opens cleanly after the next toolbox build runs against main (will be observable next push)