### PR TITLE
docs: README + installer/README pre-launch proofread pass for v1.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,10 @@
 # Contributing to hal0
 
-**Pre-alpha.** External contributions aren't being accepted yet. This
-file is a placeholder for the v0.2+ contribution flow.
+hal0 is licensed [Apache 2.0](./LICENSE). The contribution model for
+v1.0 is still being decided (see [`PLAN.md`](./PLAN.md) §16). External
+PRs aren't being merged yet; please open issues for discussion.
 
-When it opens up:
+When the model opens up, the shape will be:
 
 - One PR per feature; small, reviewable diffs
 - Run `make lint test` before pushing
@@ -11,8 +12,6 @@ When it opens up:
 - Slot/dispatcher/provider changes require both unit and integration
   tests (Tier-1 reliability is non-negotiable)
 - UI changes need Playwright coverage for any new critical path
-
-For now, please open issues for discussion only.
 
 ## Test tiers
 
@@ -59,8 +58,9 @@ in `tests/slots/test_integration.py`:
 2. `test_state_transitions_visible_via_stream` — SSE state stream sees `starting → warming → ready`
 3. `test_full_state_machine_round_trip_via_stream` — full round-trip incl. `unloading → offline`
 
-Wall-clock budget: ≤12 minutes per PLAN §10.2. Toolbox image build
-is layer-cached via GHA so cold-cache runs are ~10 min, hot-cache ~4.
+Wall-clock budget: ≤12 minutes (PLAN §10, Integration β). Toolbox
+image build is layer-cached via GHA so cold-cache runs are ~10 min,
+hot-cache ~4.
 
 ### γ — release-gate (`make release-test`)
 
@@ -111,10 +111,11 @@ If any of these fail, fix and re-run before `git tag`.
 ## E2E tests
 
 The `ui/tests/e2e/` Playwright suite covers the seven critical paths
-from PLAN §10.3 (FirstRun wizard, slot lifecycle, model management,
-settings + restart banner, logs SSE tail, hardware probe, update
-banner). All seven run on every PR via `.github/workflows/playwright.yml`
-in <8 minutes against mocked backends.
+from PLAN §10 (E2E γ) — FirstRun wizard, slot lifecycle, model
+management, settings + restart banner, logs SSE tail, hardware probe,
+update banner. All seven run on every PR via
+`.github/workflows/playwright.yml` in <8 minutes against mocked
+backends.
 
 ```bash
 cd ui

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ It manages model slots, exposes an OpenAI-compatible API, and ships with
 a built-in dashboard and a prewired chat UI — all installable in one
 command on any modern Linux box.
 
-> **Status:** pre-alpha. Active development. Not yet a thing you should
-> install. See [`PLAN.md`](./PLAN.md) for the v1 roadmap.
+> **Status:** v1.0 release candidate. The release pipeline (cosign
+> keyless OIDC, signed tarball + `releases.hal0.dev` manifest) is wired
+> end-to-end; the first real tag-push is still pending. See
+> [`PLAN.md`](./PLAN.md) §15 for the milestone state and §18 for the
+> v1.0 definition of done.
 
 ## What hal0 does
 
@@ -27,15 +30,19 @@ command on any modern Linux box.
 - **OpenWebUI bundled** — prewired chat interface at `:3001`, no setup
 - **Image generation** — bundled ComfyUI provider with curated SDXL /
   SD 1.5 / Flux models; OpenAI-compatible `/v1/images/generations`
-- **One-line install** — `curl -fsSL hal0.dev/install | bash`
-  (`--models-dir=PATH` redirects HuggingFace pulls off `/var/lib/hal0`)
+- **One-line install** — `curl -fsSL https://hal0.dev/install | bash`
+  (`--models-dir=PATH` or `HAL0_MODELS_DIR=PATH` redirects HuggingFace
+  pulls off `/var/lib/hal0/models`). Until the `hal0.dev/install`
+  endpoint is wired, the supported entry point is
+  `git clone` + `sudo bash installer/install.sh` — see
+  [`installer/README.md`](./installer/README.md).
 
 ## Backends (v1)
 
 | Backend     | Hardware             | Use case                          |
 |-------------|----------------------|-----------------------------------|
 | llama.cpp   | Vulkan (default) / ROCm | chat, embed, rerank, vision    |
-| FLM         | AMD XDNA NPU (opt-in)| chat + embed (ASR routes through Moonshine for now) |
+| FLM         | AMD XDNA NPU (opt-in)| chat + embed (ASR multiplex available via `defaults.load_asr`; Moonshine is the default STT) |
 | Moonshine   | CPU                  | STT (`/v1/audio/transcriptions`) |
 | Kokoro      | CPU / Vulkan         | TTS                              |
 | ComfyUI     | ROCm                 | image gen (`/v1/images/generations`) |
@@ -54,7 +61,7 @@ hal0/
 ├── ui/               # Vue 3 + Tailwind 4 dashboard
 ├── installer/        # install.sh (systemd unit templates live in packaging/systemd/)
 ├── tests/            # pytest suite
-├── docs/             # architecture, install, slot docs
+├── docs/             # api-errors, release-manifest, migration, ADRs
 └── PLAN.md           # v1 roadmap
 ```
 
@@ -101,6 +108,8 @@ Apache 2.0. See [`LICENSE`](./LICENSE).
 
 ## Contributing
 
-This is pre-alpha. External contributions aren't being accepted yet;
-that opens up around v0.2. See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for
-the eventual flow.
+The contribution model for v1.0 is still being decided
+([`PLAN.md`](./PLAN.md) §16). File issues for discussion; PRs aren't
+being accepted from outside contributors yet. See
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) for the test tiers and the
+eventual flow.

--- a/installer/README.md
+++ b/installer/README.md
@@ -7,11 +7,18 @@ Non-interactive installer for hal0 — the open-source home AI inference platfor
 ```sh
 # From a clone of this repo:
 sudo bash installer/install.sh
+
+# Or point HuggingFace pulls at a larger disk:
+sudo bash installer/install.sh --models-dir=/mnt/ai-models
 ```
 
-> **Phase 1 only.** The one-liner `curl -fsSL https://hal0.dev/install | bash`
-> will ship once the `hal0.dev/install` endpoint is wired; until then,
+> The one-liner `curl -fsSL https://hal0.dev/install | bash` ships
+> with v1.0 once the `hal0.dev/install` endpoint is wired; until then,
 > `git clone` + `sudo bash` is the supported entry point.
+
+The toolbox container images (`ghcr.io/hal0ai/hal0-toolbox-*:v1`) are
+public on GHCR — `docker pull` works without a `docker login`. The
+installer pulls them in the background after the API comes up.
 
 ## What the installer does
 
@@ -36,6 +43,7 @@ These are the variables `installer/install.sh` actually reads:
 | `HAL0_PORT` | `8080` | hal0 API port |
 | `HAL0_USER` | `root` | systemd unit user (see §What the installer does) |
 | `HAL0_PYTHON` | `python3` | Python interpreter used to build the venv |
+| `HAL0_MODELS_DIR` | _(unset)_ | Absolute path where HuggingFace pulls land; same as `--models-dir=PATH`. When unset, models live at `/var/lib/hal0/models` (or `$PWD/.hal0ai/var/lib/hal0/models` under `--dev`). |
 | `HAL0_NO_PROBE` | _(unset)_ | Set to `1` to skip the hardware probe at the end |
 | `HAL0_TOOLBOX_IMAGE_VULKAN` | _(unset)_ | Override the Vulkan toolbox image ref written into `api.env` |
 | `HAL0_TOOLBOX_IMAGE_ROCM` | _(unset)_ | Override the ROCm toolbox image ref written into `api.env` |
@@ -115,12 +123,12 @@ layer your edge already provides.
 
 `--dev` implies `--no-tls`; there is no system Caddy install in a dev tree.
 
-### Upgrade notes (pre-v1)
+### Upgrade notes
 
-hal0 is pre-v1. Existing installs that used the old `--auth=basic` path lose
-**edge auth** on next install upgrade — the Caddyfile no longer carries
-`basicauth`. The dashboard and `/v1/*` are reachable without credentials
-until you do one of:
+Existing installs that used the old `--auth=basic` path lose **edge auth**
+on next install upgrade — the Caddyfile no longer carries `basicauth`. The
+dashboard and `/v1/*` are reachable without credentials until you do one
+of:
 
 - **Set a password in the dashboard wizard.** On first load after upgrade,
   the wizard's password-setup step calls `POST /api/auth/password` and
@@ -241,12 +249,14 @@ Or add your user to the docker group and re-login.
 ✗ pre-flight failed: less than 20GB free in /var/lib
 ```
 
-Free up space, or symlink the models dir to a larger disk before installing:
+Free up space, or redirect HuggingFace pulls to a larger disk:
 
 ```sh
-mkdir -p /mnt/large-disk/hal0-models
-ln -s /mnt/large-disk/hal0-models /var/lib/hal0/models
+sudo bash installer/install.sh --models-dir=/mnt/large-disk/hal0-models
 ```
+
+The installer records this in `/etc/hal0/hal0.toml` under
+`[models].pull_root` so subsequent `hal0 model pull` calls honor it too.
 
 ### Services won't start
 


### PR DESCRIPTION
Walked `README.md`, `installer/README.md`, and `CONTRIBUTING.md` line-by-line for the v1.0 cut. Proofread + sync pass against PLAN.md §1 / §10 / §15-18 and ADR-0001's outcome section. No code touched.

## What changed

**`README.md`**
- Status callout: `pre-alpha` -> `v1.0 release candidate`. The release pipeline (cosign keyless OIDC, signed tarball, `releases.hal0.dev` manifest) is wired end-to-end; first real tag-push is still pending. Cites PLAN.md §15 + §18.
- Install one-liner: spell out the URL with `https://`, document `--models-dir=PATH` AND the matching `HAL0_MODELS_DIR=PATH` env var (the installer accepts both), correct the destination to `/var/lib/hal0/models` (not `/var/lib/hal0`), and link out to `installer/README.md` for the `git clone` fallback while the `hal0.dev/install` endpoint is being wired.
- Backends table FLM row: replace "ASR routes through Moonshine for now" (inaccurate) with the actual posture — FLM ASR multiplex is opt-in via `defaults.load_asr`; Moonshine remains the default STT regardless.
- Project layout comment: replace stale `architecture, install, slot docs` with the docs that actually exist (`api-errors, release-manifest, migration, ADRs`).
- Contributing footer: drop the `v0.2` framing for PLAN.md §16's still-pending decision; keep "issues OK, PRs not yet" posture.

**`installer/README.md`**
- Quick-start: drop the "Phase 1 only" prefix; add a `--models-dir=/mnt/ai-models` example; add a paragraph confirming the `ghcr.io/hal0ai/hal0-toolbox-*:v1` images are public (no `docker login` required — #41 closed).
- Env-var table: add the missing `HAL0_MODELS_DIR` row with the precise default it falls back to.
- Auth section: change `### Upgrade notes (pre-v1)` -> `### Upgrade notes` and drop the now-stale "hal0 is pre-v1" lead-in. Body unchanged (still ADR-0001-accurate).
- Troubleshooting "Not enough disk space": replace the `ln -s` symlink-after-the-fact recipe with the cleaner `--models-dir=PATH` reinstall path (the installer persists `[models].pull_root` into `/etc/hal0/hal0.toml`, so `hal0 model pull` honors it too).

**`CONTRIBUTING.md`**
- Header: replace `**Pre-alpha.** ... placeholder` with the actual v1.0 posture — Apache 2.0 licensed, contribution model gated on PLAN.md §16, issues open / PRs not yet.
- Fix stale `PLAN §10.2` -> `PLAN §10, Integration β` and `PLAN §10.3` -> `PLAN §10 (E2E γ)`. PLAN.md §10 uses named subsections, not numbered ones.

## What stayed

The bulk of `installer/README.md` (auth posture per ADR-0001, TLS modes, `--no-tls`, `--dev` limitations, Bearer + session-cookie composition, the seven-row release-gate matrix in CONTRIBUTING.md) was already accurate for v1 reality and was not touched. CLI command list (`hal0 doctor`, `hal0 model pull`, `hal0 uninstall [--keep-data]`) matches `src/hal0/cli/`.

## Findings (logged, not fixed)

None — no real installer / product bugs surfaced during the proofread. The only drift between docs and code was language drift (status framing, the FLM ASR row, the stale `§10.x` numbering), all addressed in this PR. `tests/harness/FINDINGS.md` untouched.

Link inventory after the pass:
- `./CONTRIBUTING.md`, `./LICENSE`, `./PLAN.md`, `./installer/README.md`, `./docs/adr/0001-collapse-edge-auth-into-fastapi.md` (and the `../` form from `installer/README.md`)

All resolve on disk.

Heads-up to reviewer: the `manifest.json` toolbox image digests are stale per the v1.0 release brief and may be refreshed by a separate PR before tag-push. None of these READMEs hard-code digests, so they'll survive that refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)