### PR TITLE
fix(auth): use constant-time compare for X-CSRF-Token tripwire

### DIFF
--- a/src/hal0/api/middleware/auth.py
+++ b/src/hal0/api/middleware/auth.py
@@ -80,6 +80,7 @@ the request when auth fails is the whole point.
 
 from __future__ import annotations
 
+import hmac
 from dataclasses import dataclass
 from typing import Annotated
 
@@ -410,7 +411,12 @@ def _check_session_csrf(request: Request, identity: AuthIdentity) -> None:
     csrf = headers.get(_CSRF_TOKEN_HEADER, "")
     session_token = identity.session_token or ""
     expected = session_token[:_CSRF_TOKEN_BINDING_LEN]
-    if csrf and expected and csrf == expected:
+    # Constant-time compare so the per-request timing on the X-CSRF-Token
+    # path doesn't leak a byte-by-byte oracle for the bound prefix. The
+    # length-prefilter guards against compare_digest's "compares OK on
+    # empty string" edge case and keeps the short-circuit on the missing-
+    # header branch.
+    if csrf and expected and hmac.compare_digest(csrf, expected):
         return
     raise CSRFRequired(
         "writer routes require a CSRF tripwire when authenticated via cookie",


### PR DESCRIPTION
## Summary

- `_check_session_csrf` compared the X-CSRF-Token header against the bound 16-char session prefix with `==`. Because the prefix is derived deterministically from the cookie, a timing oracle on the compare leaks the prefix one byte at a time across many requests.
- Switch to `hmac.compare_digest`. Keep the existing `csrf and expected` prefilter so `compare_digest` never sees an empty string (it returns True on `compare_digest(\"\", \"\")`, which would mis-pass the missing-session-token branch).
- Refs the v1.0 pre-launch security review, finding §27 in `tests/harness/FINDINGS.md` (PR #82).

## Test plan

- [ ] Run the existing auth test suite — the CSRF tripwire tests should still pass.
- [ ] Manual: cookie-authed POST with the correct prefix in X-CSRF-Token still passes; a wrong prefix still 403s with `auth.csrf_required`.
- [ ] Pyright / ruff pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)