### PR TITLE
fix(auth): gate X-Forwarded-Email trust behind HAL0_TRUST_FORWARDED_EMAIL

### DIFF
--- a/src/hal0/api/middleware/auth.py
+++ b/src/hal0/api/middleware/auth.py
@@ -55,11 +55,14 @@ Auth precedence
 2. ``hal0_session`` cookie present (ADR-0001 Child A) → validate signed
    JWT claims. Failure ⇒ 401 (``auth.invalid``).
 
-3. ``X-Forwarded-Email`` present (a trusted upstream proxy validated the
-   identity and forwarded it) → trust it. Scope = ``"admin"``. This path
-   stays around for users fronting hal0 with their own SSO proxy
-   (Authelia, Authentik, Cloudflare Access, Pangolin etc.) — hal0's own
-   Caddy no longer sets it.
+3. ``X-Forwarded-Email`` present AND ``HAL0_TRUST_FORWARDED_EMAIL=1``
+   in the environment → trust it. Scope = ``"admin"``. The opt-in
+   env-var is mandatory because hal0's own Caddy (post-ADR-0001
+   Child B) no longer sets or strips this header — trusting it on a
+   default install would let any LAN peer spoof admin. Operators
+   fronting hal0 with their own SSO proxy (Authelia, Authentik,
+   Cloudflare Access, Pangolin) flip the env var ON once they've
+   configured their proxy to set + strip the header.
 
 4. Else → 401 (``auth.required``).
 
@@ -81,6 +84,7 @@ the request when auth fails is the whole point.
 from __future__ import annotations
 
 import hmac
+import os
 from dataclasses import dataclass
 from typing import Annotated
 
@@ -99,6 +103,17 @@ from hal0.errors import Hal0Error
 _BEARER_HEADER = "authorization"
 _BEARER_PREFIX = "Bearer "
 _FORWARDED_EMAIL_HEADER = "x-forwarded-email"
+
+# X-Forwarded-Email opt-in env-var. ADR-0001 Child B removed Caddy's
+# basic_auth, so hal0's own bundled Caddy no longer SETS this header —
+# and the bundled Caddyfile.template does NOT strip inbound copies.
+# Trusting the header by default would let any LAN peer authenticate as
+# admin by sending ``X-Forwarded-Email: anyone@example.com``. Operators
+# fronting hal0 with their own SSO proxy (Authelia, Authentik,
+# Cloudflare Access, Pangolin, etc.) opt back in by setting this env
+# var AND configuring their proxy to set + strip the header — see the
+# deployment docs.
+_FORWARDED_EMAIL_TRUST_ENV = "HAL0_TRUST_FORWARDED_EMAIL"
 
 # Session-cookie surface added by ADR-0001 Child A. The cookie name is
 # part of the API contract — the Set-Cookie issued by /api/auth/login,
@@ -252,14 +267,32 @@ def _resolve_session_cookie(request: Request) -> str | None:
     return raw.strip() or None
 
 
-def _resolve_forwarded_email(request: Request) -> str | None:
-    """Extract the trusted email from the Caddy-forwarded header.
+def _forwarded_email_trusted() -> bool:
+    """Return True iff the operator opted into trusting X-Forwarded-Email.
 
-    The header is only trusted because Caddy strips inbound copies before
-    forwarding (see Caddyfile template). On a misconfigured proxy this
-    would let a client spoof identity — the deployment doc spells this
-    out and the installer hard-fails if Caddy isn't fronting the API.
+    Disabled by default after ADR-0001 Child B because the bundled Caddy
+    no longer strips inbound copies of the header — trusting it on a
+    default install lets any LAN peer authenticate as admin. Operators
+    fronting hal0 with their own SSO proxy (Authelia, Authentik,
+    Cloudflare Access, Pangolin) set ``HAL0_TRUST_FORWARDED_EMAIL=1``
+    once they've verified their proxy sets + strips the header.
     """
+    val = os.environ.get(_FORWARDED_EMAIL_TRUST_ENV, "").strip().lower()
+    return val in ("1", "true", "yes", "on")
+
+
+def _resolve_forwarded_email(request: Request) -> str | None:
+    """Extract the trusted email from the upstream SSO-proxy-forwarded header.
+
+    Returns None when the operator has not opted into trusting the header
+    via ``HAL0_TRUST_FORWARDED_EMAIL=1``. On a default install (where
+    Caddy is a dumb TLS terminator + reverse_proxy and does NOT strip
+    inbound copies) the header is attacker-controlled and must not gate
+    auth. Operators with their own SSO proxy configured to set + strip
+    the header opt back in via the env var.
+    """
+    if not _forwarded_email_trusted():
+        return None
     raw = request.headers.get(_FORWARDED_EMAIL_HEADER)
     if not raw:
         return None

--- a/tests/api/test_auth_middleware.py
+++ b/tests/api/test_auth_middleware.py
@@ -44,9 +44,7 @@ def auth_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestCl
 
 
 @pytest.fixture
-def auth_app_trusted_proxy(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> Iterator[TestClient]:
+def auth_app_trusted_proxy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     """auth_app variant that opts in to trusting X-Forwarded-Email.
 
     The default install REJECTS the header (post-§26 fix); operators behind

--- a/tests/api/test_auth_middleware.py
+++ b/tests/api/test_auth_middleware.py
@@ -43,6 +43,26 @@ def auth_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestCl
         yield c
 
 
+@pytest.fixture
+def auth_app_trusted_proxy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[TestClient]:
+    """auth_app variant that opts in to trusting X-Forwarded-Email.
+
+    The default install REJECTS the header (post-§26 fix); operators behind
+    a trusted edge proxy that validates the email themselves set
+    ``HAL0_TRUST_FORWARDED_EMAIL=1`` to re-enable that path.
+    """
+    monkeypatch.setenv("HAL0_AUTH_ENABLED", "1")
+    monkeypatch.setenv("HAL0_TRUST_FORWARDED_EMAIL", "1")
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    app = create_app()
+    with TestClient(app) as c:
+        store = TokenStore(tmp_path / "tokens.toml")
+        c.app.state.token_store = store
+        yield c
+
+
 # ── HAL0_AUTH_ENABLED=0 (default) — pass-through ──────────────────────────────
 
 
@@ -147,21 +167,35 @@ def test_malformed_bearer_falls_through_to_required(auth_app: TestClient) -> Non
     assert response.json()["error"]["code"] == "auth.required"
 
 
-# ── X-Forwarded-Email path (Caddy basic_auth at the edge) ─────────────────────
+# ── X-Forwarded-Email path (post-§26 fix: opt-in only) ────────────────────────
 
 
-def test_forwarded_email_grants_admin_access(auth_app: TestClient) -> None:
-    """When Caddy validates basic_auth and forwards the email, we trust it."""
+def test_forwarded_email_ignored_by_default(auth_app: TestClient) -> None:
+    """Default install (HAL0_TRUST_FORWARDED_EMAIL unset) MUST ignore the header.
+
+    Regression guard for harness finding #26 — the bypass was that any LAN
+    peer could send X-Forwarded-Email and be granted admin scope.
+    """
     response = auth_app.get(
+        "/api/slots",
+        headers={"X-Forwarded-Email": "alex@example.com"},
+    )
+    assert response.status_code == 401, response.text
+    assert response.json()["error"]["code"] == "auth.required"
+
+
+def test_forwarded_email_grants_admin_access(auth_app_trusted_proxy: TestClient) -> None:
+    """When HAL0_TRUST_FORWARDED_EMAIL=1, the edge-validated email is honoured."""
+    response = auth_app_trusted_proxy.get(
         "/api/slots",
         headers={"X-Forwarded-Email": "alex@example.com"},
     )
     assert response.status_code == 200, response.text
 
 
-def test_forwarded_email_grants_admin_scope(auth_app: TestClient) -> None:
-    """The /api/auth/me endpoint should report scope=admin for the forwarded user."""
-    response = auth_app.get(
+def test_forwarded_email_grants_admin_scope(auth_app_trusted_proxy: TestClient) -> None:
+    """With trust env var set, /api/auth/me reports scope=admin for the forwarded user."""
+    response = auth_app_trusted_proxy.get(
         "/api/auth/me",
         headers={"X-Forwarded-Email": "alex@example.com"},
     )
@@ -172,11 +206,13 @@ def test_forwarded_email_grants_admin_scope(auth_app: TestClient) -> None:
     assert body["source"] == "forwarded"
 
 
-def test_bearer_takes_precedence_over_forwarded(auth_app: TestClient) -> None:
-    """Valid Bearer token wins over X-Forwarded-Email; invalid Bearer 401s."""
-    store: TokenStore = auth_app.app.state.token_store
+def test_bearer_takes_precedence_over_forwarded(
+    auth_app_trusted_proxy: TestClient,
+) -> None:
+    """Even when forwarded-email is trusted, a valid Bearer wins; invalid 401s."""
+    store: TokenStore = auth_app_trusted_proxy.app.state.token_store
     _, raw = store.create(label="bridge", scope="v1-only")
-    response = auth_app.get(
+    response = auth_app_trusted_proxy.get(
         "/api/auth/me",
         headers={
             "Authorization": f"Bearer {raw}",
@@ -191,9 +227,11 @@ def test_bearer_takes_precedence_over_forwarded(auth_app: TestClient) -> None:
     assert body["source"] == "token"
 
 
-def test_invalid_bearer_blocks_even_with_forwarded(auth_app: TestClient) -> None:
-    """A bad Bearer + a good X-Forwarded-Email still 401s — Bearer is authoritative."""
-    response = auth_app.get(
+def test_invalid_bearer_blocks_even_with_forwarded(
+    auth_app_trusted_proxy: TestClient,
+) -> None:
+    """Even when forwarded-email is trusted, a bad Bearer + good forwarded still 401s."""
+    response = auth_app_trusted_proxy.get(
         "/api/slots",
         headers={
             "Authorization": "Bearer hal0_deadbeef.bad",

--- a/tests/api/test_auth_writer_scope.py
+++ b/tests/api/test_auth_writer_scope.py
@@ -46,9 +46,7 @@ def auth_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestCl
 
 
 @pytest.fixture
-def auth_app_trusted_proxy(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> Iterator[TestClient]:
+def auth_app_trusted_proxy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     """auth_app variant that opts in to trusting X-Forwarded-Email (§26)."""
     monkeypatch.setenv("HAL0_AUTH_ENABLED", "1")
     monkeypatch.setenv("HAL0_TRUST_FORWARDED_EMAIL", "1")

--- a/tests/api/test_auth_writer_scope.py
+++ b/tests/api/test_auth_writer_scope.py
@@ -45,6 +45,20 @@ def auth_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestCl
         yield c
 
 
+@pytest.fixture
+def auth_app_trusted_proxy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[TestClient]:
+    """auth_app variant that opts in to trusting X-Forwarded-Email (§26)."""
+    monkeypatch.setenv("HAL0_AUTH_ENABLED", "1")
+    monkeypatch.setenv("HAL0_TRUST_FORWARDED_EMAIL", "1")
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    app = create_app()
+    with TestClient(app) as c:
+        c.app.state.token_store = TokenStore(tmp_path / "tokens.toml")
+        yield c
+
+
 def _bearer(auth_app: TestClient, scope: str, label: str | None = None) -> dict[str, str]:
     """Mint a token at ``scope`` and return its Bearer header dict."""
     store: TokenStore = auth_app.app.state.token_store
@@ -172,12 +186,23 @@ def test_writer_routes_require_auth(
     assert response.json()["error"]["code"] == "auth.required"
 
 
-# ── X-Forwarded-Email (Caddy basic_auth) is admin-scoped, so writes work ──────
+# ── X-Forwarded-Email (post-§26 fix: opt-in only) ─────────────────────────────
 
 
-def test_forwarded_email_can_write(auth_app: TestClient) -> None:
-    """Caddy-forwarded identities map to scope=admin → writer access."""
+def test_forwarded_email_writes_blocked_by_default(auth_app: TestClient) -> None:
+    """Default install MUST 401 on X-Forwarded-Email writes (§26 regression guard)."""
     response = auth_app.put(
+        "/api/settings",
+        json={},
+        headers={"X-Forwarded-Email": "owner@example.com"},
+    )
+    assert response.status_code == 401, response.text
+    assert response.json()["error"]["code"] == "auth.required"
+
+
+def test_forwarded_email_can_write(auth_app_trusted_proxy: TestClient) -> None:
+    """With HAL0_TRUST_FORWARDED_EMAIL=1, forwarded identity gets writer access."""
+    response = auth_app_trusted_proxy.put(
         "/api/settings",
         json={},
         headers={"X-Forwarded-Email": "owner@example.com"},


### PR DESCRIPTION
## Summary

- ADR-0001 Child B made Caddy a dumb TLS terminator + reverse_proxy; the bundled `packaging/caddy/Caddyfile.template` does NOT strip inbound copies of `X-Forwarded-Email`. The auth middleware's docstring claimed it did — but greps for `header_up -X-Forwarded-Email` on the template return nothing, so a LAN peer can authenticate as admin by sending the header directly.
- Gate the third precedence step behind an opt-in env var: `HAL0_TRUST_FORWARDED_EMAIL=1`. Default installs leave it unset; the header path now falls through to a 401, closing the bypass.
- Operators fronting hal0 with their own SSO proxy (Authelia, Authentik, Cloudflare Access, Pangolin) flip the env var on once they've configured their proxy to set + strip the header.
- Refs the v1.0 pre-launch security review, finding §26 in `tests/harness/FINDINGS.md` (PR #82).

## Follow-up (not in this PR)

- The bundled `Caddyfile.template` should also explicitly strip the header on the way in (`request_header -X-Forwarded-Email`) as defence-in-depth, even with the new opt-in default — that way an operator who flips `HAL0_TRUST_FORWARDED_EMAIL=1` doesn't lose the strip just because they forgot to add it to their own Caddyfile.
- Deployment doc needs a section on the SSO-proxy integration pattern (header strip + opt-in env var combined).

## Test plan

- [ ] Existing auth tests: rerun — any test that depended on X-Forwarded-Email working without the env var should be updated to set `HAL0_TRUST_FORWARDED_EMAIL=1` in its fixture.
- [ ] New negative test: with `HAL0_AUTH_ENABLED=1` and `HAL0_TRUST_FORWARDED_EMAIL` unset, `curl -H 'X-Forwarded-Email: a@b.com'` against `/api/auth/me` returns 401.
- [ ] Positive test: with the env var set, the same request resolves to `identity=a@b.com, scope=admin, source=forwarded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)