### PR TITLE
fix(api/install): gate /api/install/* + slot-name validate (§29 + §30 — critical)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -386,17 +386,23 @@ def create_app() -> FastAPI:
     _v1_auth = [Depends(require_token)]
     app.include_router(v1.router, prefix="/v1", tags=["v1"], dependencies=_v1_auth)
 
-    # /api/install drives the first-run wizard, which runs *before* any
-    # credential exists. Mount bare — every wizard endpoint is public.
-    # When the wizard is no longer needed (first_run sentinel written
-    # OR a model is present), the dashboard router-guards stop routing
-    # to it; the endpoints themselves remain reachable for re-entry
-    # (e.g. operator deliberately reopening /firstrun to add a model).
-    app.include_router(installer.router, prefix="/api/install", tags=["installer"])
-
     # Single-purpose protected routers — every endpoint requires a token
     # (or session cookie / forwarded email) when HAL0_AUTH_ENABLED=1.
     _admin_auth = [Depends(require_token)]
+
+    # /api/install drives the first-run wizard. When HAL0_AUTH_ENABLED is
+    # unset, the gate is a pure pass-through (require_token short-circuits
+    # to an anonymous identity), so the wizard still works on a fresh
+    # install with no password set — see FINDINGS §29. Once auth is
+    # enabled, every install endpoint requires a valid identity; mutating
+    # endpoints additionally declare Depends(require_writer) at the route
+    # level (matches the #11 admin-router pattern).
+    app.include_router(
+        installer.router,
+        prefix="/api/install",
+        tags=["installer"],
+        dependencies=_admin_auth,
+    )
     app.include_router(slots.router, prefix="/api/slots", tags=["slots"], dependencies=_admin_auth)
     app.include_router(
         models.router, prefix="/api/models", tags=["models"], dependencies=_admin_auth

--- a/src/hal0/api/routes/installer.py
+++ b/src/hal0/api/routes/installer.py
@@ -25,20 +25,60 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import re
 import shutil
 import tempfile
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, Request
 
-from hal0.api.middleware.error_codes import Hal0Error
+from hal0.api.middleware.auth import require_writer
+from hal0.api.middleware.error_codes import BadRequest, Hal0Error
 from hal0.config import paths
 from hal0.hardware.probe import HardwareProbe
 from hal0.registry.curated import CURATED_MODELS, get_curated
 from hal0.registry.model import Model
 from hal0.registry.pull import make_job, run_pull
 from hal0.registry.store import ModelAlreadyExists
+
+# Reusable writer-scope gate, applied per-route on every mutating endpoint
+# (POST /probe, POST /complete, POST /pick-default, PUT /slots/{slot}/model).
+# The router itself is mounted with require_token at include_router() time
+# (see hal0.api.create_app), which keeps GETs open to any valid identity
+# while these per-route deps enforce the writer scope on mutations. Both
+# gates short-circuit to a pass-through when HAL0_AUTH_ENABLED is unset,
+# preserving the fresh-install / first-run wizard UX.
+_writer = [Depends(require_writer)]
+
+# Slot-name policy — mirrors ``SlotConfig.name`` in hal0.config.schema so a
+# slot name accepted by the API installer endpoints is also accepted by the
+# CLI / TOML loader. Reject anything else BEFORE the path is built so a
+# value like ``"../../tmp/pwn"`` can't resolve to an arbitrary on-disk file.
+# See FINDINGS §30.
+_SLOT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
+
+
+def _validate_slot_name(slot: object) -> str:
+    """Return ``slot`` as a string if it matches the slot-name policy.
+
+    Raises :class:`BadRequest` (code ``slot.invalid_name``) on any value
+    that doesn't match the regex — including non-string types, the empty
+    string, path-traversal payloads (``"../foo"``), and absolute paths
+    (``"/etc/passwd"``). The error envelope echoes back the policy so a
+    well-behaved client can correct itself.
+    """
+    if not isinstance(slot, str) or not _SLOT_NAME_RE.match(slot):
+        raise BadRequest(
+            "invalid slot name",
+            details={
+                "slot": slot if isinstance(slot, str) else repr(slot),
+                "policy": _SLOT_NAME_RE.pattern,
+            },
+            code="slot.invalid_name",
+        )
+    return slot
+
 
 router = APIRouter()
 
@@ -145,7 +185,7 @@ async def install_state(request: Request) -> dict[str, Any]:
     }
 
 
-@router.post("/probe")
+@router.post("/probe", dependencies=_writer)
 async def install_probe(request: Request) -> dict[str, Any]:
     """Re-run the hardware probe and rewrite ``/etc/hal0/hardware.json``.
 
@@ -166,7 +206,7 @@ async def install_probe(request: Request) -> dict[str, Any]:
     }
 
 
-@router.post("/complete")
+@router.post("/complete", dependencies=_writer)
 async def install_complete(request: Request) -> dict[str, Any]:
     """Mark the FirstRun wizard as complete by writing the sentinel.
 
@@ -350,7 +390,7 @@ def _assign_to_slot(slot: str, model_id: str) -> Path:
     return slot_path
 
 
-@router.post("/pick-default")
+@router.post("/pick-default", dependencies=_writer)
 async def pick_default(
     request: Request,
     background: BackgroundTasks,
@@ -385,11 +425,10 @@ async def pick_default(
             details={"got": body},
         )
     slot = body.get("slot") or _DEFAULT_SLOT
-    if not isinstance(slot, str) or not slot.strip():
-        raise PickDefaultError(
-            "body.slot must be a non-empty string when provided",
-            details={"got": body},
-        )
+    # Validate the slot name BEFORE any filesystem op — see FINDINGS §30.
+    # A traversal payload (e.g. ``"../../tmp/pwn"``) is rejected here with
+    # a typed 400 rather than escaping the slots config dir on disk.
+    slot = _validate_slot_name(slot)
 
     registry = request.app.state.model_registry
     _ensure_registry_entry(registry, model_id)
@@ -430,12 +469,17 @@ async def pick_default(
     }
 
 
-@router.put("/slots/{slot}/model")
+@router.put("/slots/{slot}/model", dependencies=_writer)
 async def set_slot_default_model(slot: str, request: Request) -> dict[str, Any]:
     # Persist-only counterpart to /api/slots/{name}/swap.  Hot-swap changes
     # the running container; this writes model.default into
     # /etc/hal0/slots/<slot>.toml so the change survives a restart.  UI
     # and CLI call both for the common "change and remember" flow.
+    #
+    # Validate the slot name BEFORE reading the body or touching disk —
+    # see FINDINGS §30. ``slot="../../tmp/pwn"`` would otherwise resolve
+    # under /tmp via the f-string in ``_assign_to_slot``.
+    slot = _validate_slot_name(slot)
     try:
         body = await request.json()
     except Exception as exc:

--- a/tests/api/test_auth_middleware.py
+++ b/tests/api/test_auth_middleware.py
@@ -63,7 +63,12 @@ def test_auth_disabled_protected_route_open(client: TestClient) -> None:
         "/api/health/system",
         "/api/metrics",
         "/api/features",
-        "/api/install/state",
+        # Note: ``/api/install/*`` is no longer public — the entire
+        # installer router is gated by ``require_token`` per FINDINGS §29.
+        # On a fresh install with ``HAL0_AUTH_ENABLED`` unset the gate is
+        # a pass-through (covered by tests/api/test_install_routes.py);
+        # once auth is on, the wizard rides the operator's session
+        # cookie like any other admin surface.
         "/api/config/urls",
         "/api/auth/status",
         "/api/auth/login",

--- a/tests/api/test_install_routes.py
+++ b/tests/api/test_install_routes.py
@@ -1,0 +1,309 @@
+"""Security regression tests for ``/api/install/*`` (FINDINGS §29 + §30).
+
+Two contracts:
+
+  §29 — every mutating installer endpoint requires a writer-scoped
+        credential when ``HAL0_AUTH_ENABLED=1``. When auth is off
+        (fresh-install default), the gate is a pass-through so the
+        FirstRun wizard still works.
+
+  §30 — every installer endpoint that takes a ``slot`` parameter
+        validates it against the slot-name policy BEFORE touching
+        disk. Path-traversal payloads, absolute paths, and other
+        malformed values are rejected with 400 ``slot.invalid_name``.
+
+These are critical pre-launch findings from the v1.0 security audit
+(see ``tests/harness/FINDINGS.md``). The matrix below covers the auth
+gate at three credential levels (none / read-only / writer) plus the
+auth-off pass-through, parametrised across every mutating install
+endpoint. The slot-name matrix runs every malformed payload that came
+up in the audit + one valid value to prove the gate doesn't reject
+legitimate names.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.auth.tokens import TokenStore
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def auth_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """TestClient with HAL0_AUTH_ENABLED=1 and an isolated token store."""
+    monkeypatch.setenv("HAL0_AUTH_ENABLED", "1")
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    monkeypatch.setenv("HAL0_OVERRIDE_DIR", "hal0_home")
+    app: FastAPI = create_app()
+    with TestClient(app) as c:
+        c.app.state.token_store = TokenStore(tmp_path / "tokens.toml")
+        yield c
+
+
+@pytest.fixture
+def open_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """TestClient with HAL0_AUTH_ENABLED unset — the fresh-install posture.
+
+    The FirstRun wizard MUST work in this mode: no password has been set
+    yet, so the require_writer gate has to short-circuit to anonymous.
+    """
+    monkeypatch.delenv("HAL0_AUTH_ENABLED", raising=False)
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    monkeypatch.setenv("HAL0_OVERRIDE_DIR", "hal0_home")
+    app: FastAPI = create_app()
+    with TestClient(app) as c:
+        yield c
+
+
+def _bearer(client: TestClient, scope: str) -> dict[str, str]:
+    store: TokenStore = client.app.state.token_store
+    _, raw = store.create(label=f"test-{scope}", scope=scope)
+    return {"Authorization": f"Bearer {raw}"}
+
+
+# ── §29: mutating install endpoints require_writer ──────────────────────────
+#
+# Each tuple: (method, path, json_body). Bodies are minimal — the auth gate
+# must fire BEFORE any business validation, so the test never asserts on a
+# 2xx shape; it just asserts the gate's status code.
+
+# Bodies use an unknown ``model_id`` for pick-default + slots-model so the
+# auth-disabled pass-through test never fires a real HuggingFace download
+# (the curated catalogue lookup / registry check 404s first). The auth gate
+# fires BEFORE either of those handler-level validations.
+WRITER_ROUTES: list[tuple[str, str, dict | None]] = [
+    ("POST", "/api/install/probe", None),
+    ("POST", "/api/install/complete", None),
+    (
+        "POST",
+        "/api/install/pick-default",
+        {"model_id": "this-id-is-not-curated", "slot": "primary"},
+    ),
+    ("PUT", "/api/install/slots/primary/model", {"model_id": "this-id-is-not-in-registry"}),
+]
+
+
+@pytest.mark.parametrize("method,path,body", WRITER_ROUTES)
+def test_install_writer_routes_401_without_credentials(
+    auth_app: TestClient, method: str, path: str, body: dict | None
+) -> None:
+    """Anonymous calls under HAL0_AUTH_ENABLED=1 must 401.
+
+    Regression for FINDINGS §29: the installer router used to be mounted
+    bare, so an unauthenticated LAN peer could hammer probe / write the
+    sentinel / kick off a multi-GB pull. This test pins the gate.
+    """
+    response = auth_app.request(method, path, json=body)
+    assert response.status_code == 401, (
+        f"{method} {path} did not 401 without credentials: "
+        f"status={response.status_code} body={response.text}"
+    )
+    assert response.json()["error"]["code"] == "auth.required"
+
+
+@pytest.mark.parametrize("method,path,body", WRITER_ROUTES)
+def test_install_writer_routes_403_for_readonly_token(
+    auth_app: TestClient, method: str, path: str, body: dict | None
+) -> None:
+    """A read-only Bearer must 403 — write surface needs writer scope."""
+    response = auth_app.request(method, path, json=body, headers=_bearer(auth_app, "read-only"))
+    assert response.status_code == 403, (
+        f"{method} {path} did not 403 for read-only: "
+        f"status={response.status_code} body={response.text}"
+    )
+    assert response.json()["error"]["code"] == "auth.forbidden"
+
+
+@pytest.mark.parametrize("method,path,body", WRITER_ROUTES)
+def test_install_writer_routes_accept_admin_token(
+    auth_app: TestClient, method: str, path: str, body: dict | None
+) -> None:
+    """An admin Bearer must pass the gate.
+
+    Handler-level failures (e.g. 400 on a missing model_id, 4xx from
+    business validation downstream) are fine — we only assert the auth
+    layer does NOT reject the request.
+    """
+    response = auth_app.request(method, path, json=body, headers=_bearer(auth_app, "admin"))
+    assert response.status_code not in (401, 403), (
+        f"{method} {path} rejected admin scope: status={response.status_code} body={response.text}"
+    )
+
+
+@pytest.mark.parametrize("method,path,body", WRITER_ROUTES)
+def test_install_writer_routes_open_when_auth_disabled(
+    open_app: TestClient, method: str, path: str, body: dict | None
+) -> None:
+    """Fresh-install posture: HAL0_AUTH_ENABLED unset, wizard runs anonymous.
+
+    This is the load-bearing UX contract for §29's fix — gating the
+    installer router would lock first-run users out unless the gates
+    short-circuit when no password / env-flag is set. Asserting "not
+    401 / 403" rather than "== 200" keeps the test agnostic to handler
+    errors (e.g. missing model registry seeds).
+    """
+    response = open_app.request(method, path, json=body)
+    assert response.status_code not in (401, 403), (
+        f"{method} {path} 401/403'd under HAL0_AUTH_ENABLED unset — the "
+        f"first-run wizard relies on anonymous access during fresh "
+        f"install. Body: {response.text}"
+    )
+
+
+# ── §30: slot-name validation rejects path traversal ────────────────────────
+
+
+# Each malformed value the audit highlighted, plus a few representative
+# edge cases. These are the values that MUST be rejected with code
+# ``slot.invalid_name`` regardless of which install endpoint receives
+# them — the path-traversal payload `../../tmp/pwn` is the primary vector
+# called out in FINDINGS §30; the rest fence the policy.
+#
+# The empty string is omitted from this matrix because the pick-default
+# handler treats an empty/missing ``slot`` as a request to use the
+# ``primary`` default. ``set_slot_default_model`` accepts the slot in
+# the URL path, where an empty segment 404s at the router before our
+# validation runs. Either way the empty string is not a valid path
+# traversal vector.
+_BAD_SLOT_NAMES = [
+    "../../tmp/pwn",
+    "/etc/passwd",
+    "..",
+    ".",
+    "a" * 64,  # over 32 chars
+    "WITHCAPS",  # policy is lowercase
+    "with spaces",
+    "with/slash",
+    "with\\backslash",
+    "-leading-hyphen",  # policy requires alphanumeric first
+    "_leading-underscore",
+]
+
+
+@pytest.mark.parametrize("slot", _BAD_SLOT_NAMES)
+def test_pick_default_rejects_bad_slot_names(open_app: TestClient, slot: str) -> None:
+    """POST /api/install/pick-default rejects malformed slots with 400.
+
+    Regression for FINDINGS §30: ``slot="../../tmp/pwn"`` used to resolve
+    to ``/tmp/pwn.toml`` via the f-string in ``_assign_to_slot``. The
+    validation gate fires BEFORE any filesystem op, so the path is never
+    constructed.
+
+    Uses an unknown ``model_id`` so that — in the (regression) case where
+    the slot-name gate fails to fire — we don't accidentally trigger a
+    real HuggingFace download from the curated catalogue.
+    """
+    response = open_app.post(
+        "/api/install/pick-default",
+        json={"model_id": "this-id-is-not-curated", "slot": slot},
+    )
+    assert response.status_code == 400, (
+        f"pick-default did not 400 for slot={slot!r}: "
+        f"status={response.status_code} body={response.text}"
+    )
+    body = response.json()
+    assert body["error"]["code"] == "slot.invalid_name", body
+    assert body["error"]["details"]["slot"] == slot
+
+
+def test_pick_default_accepts_valid_slot_name(open_app: TestClient) -> None:
+    """A policy-compliant slot name passes the validation gate.
+
+    We use an unknown ``model_id`` so the route 404s on the curated
+    catalogue check BEFORE any background pull is queued — the test
+    asserts only that the slot-name gate did not fire, not the
+    handler's downstream behaviour.
+    """
+    response = open_app.post(
+        "/api/install/pick-default",
+        json={"model_id": "this-id-is-not-curated", "slot": "primary"},
+    )
+    # The handler 404s on the curated lookup; the assertion is that the
+    # slot-name gate is not the reason.
+    assert response.status_code != 200, (
+        f"expected the curated lookup to 404, got {response.status_code}: {response.text}"
+    )
+    code = response.json()["error"]["code"]
+    assert code != "slot.invalid_name", response.text
+
+
+@pytest.mark.parametrize("slot", _BAD_SLOT_NAMES)
+def test_set_slot_default_model_rejects_bad_slot_names(open_app: TestClient, slot: str) -> None:
+    """PUT /api/install/slots/{slot}/model rejects malformed slots with 400.
+
+    Same gate as ``pick-default`` but the slot arrives via the URL path,
+    not the body — both ingress points must validate before
+    ``_assign_to_slot`` is called.
+
+    Empty / dot-only / slash-bearing slot values can't be expressed in a
+    URL path segment (they'd hit FastAPI's 404 router first), so we use
+    requests' raw URL form via ``client.request`` and skip values that
+    can't be encoded.
+    """
+    # ``/`` and empty segments can't reach the route at all — the router
+    # 404s before our gate runs. Those cases are exercised by the
+    # pick-default body-param variant above.
+    if not slot or "/" in slot or slot in {".", ".."}:
+        pytest.skip("URL-unreachable slot value; covered by pick-default body matrix")
+    response = open_app.put(
+        f"/api/install/slots/{slot}/model",
+        json={"model_id": "qwen3-4b"},
+    )
+    assert response.status_code == 400, (
+        f"set_slot_default_model did not 400 for slot={slot!r}: "
+        f"status={response.status_code} body={response.text}"
+    )
+    body = response.json()
+    assert body["error"]["code"] == "slot.invalid_name", body
+
+
+def test_set_slot_default_model_accepts_valid_slot_name(open_app: TestClient) -> None:
+    """A policy-compliant slot name passes the validation gate."""
+    response = open_app.put(
+        "/api/install/slots/primary/model",
+        json={"model_id": "does-not-exist"},
+    )
+    # The model_id is unknown, so the handler will 400 on the registry
+    # check — but the slot-name gate must NOT be the reason.
+    if response.status_code == 400:
+        assert response.json()["error"]["code"] != "slot.invalid_name", response.text
+
+
+def test_pick_default_default_slot_passes_validation(open_app: TestClient) -> None:
+    """Omitting ``slot`` falls back to ``primary`` which passes validation.
+
+    Uses an unknown curated id to short-circuit on the catalogue lookup
+    (so no background pull is queued) — the assertion is that the
+    slot-name gate doesn't fire on the default fallback value.
+    """
+    response = open_app.post(
+        "/api/install/pick-default",
+        json={"model_id": "this-id-is-not-curated"},
+    )
+    assert response.status_code != 200
+    assert response.json()["error"]["code"] != "slot.invalid_name", response.text
+
+
+def test_pick_default_rejects_non_string_slot(open_app: TestClient) -> None:
+    """A non-string slot (e.g. a list) is rejected with 400 ``slot.invalid_name``.
+
+    Defensive — the JSON body parser would otherwise let a typed payload
+    bypass the regex check by being not-a-string.
+    """
+    response = open_app.post(
+        "/api/install/pick-default",
+        json={"model_id": "qwen3-4b", "slot": ["primary"]},
+    )
+    assert response.status_code == 400, response.text
+    # Either the slot-name gate fires (preferred) or the body-shape
+    # validator catches the type mismatch first. Both are acceptable
+    # outcomes — neither leaves the path traversal vector open.
+    assert response.json()["error"]["code"] in {"slot.invalid_name", "install.pick_default_failed"}

--- a/tests/api/test_no_public_paths.py
+++ b/tests/api/test_no_public_paths.py
@@ -73,14 +73,19 @@ def auth_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestCl
 # Every path that used to live in the deleted PUBLIC_PATHS frozenset.
 # The wizard, monitoring tools, and OpenAI clients all depend on these
 # being reachable without credentials when no password is yet set.
+#
+# Note: ``/api/install/*`` is intentionally absent from this list as of
+# FINDINGS §29 — the entire installer surface is now gated (require_token
+# at the router level, require_writer per mutating endpoint). On a fresh
+# install with no password set, HAL0_AUTH_ENABLED is unset and both gates
+# pass through, so the wizard still works; once auth is on, the wizard
+# rides the session cookie like any other admin surface.
 _FORMERLY_PUBLIC_PATHS = [
     # Liveness / monitoring.
     "/api/health/system",
     "/api/status",
     "/api/metrics",
     "/api/features",
-    # First-run wizard gating.
-    "/api/install/state",
     # Host-aware URL hints (wizard uses to render the OpenWebUI link).
     "/api/config/urls",
     # Auth surface itself.
@@ -108,10 +113,17 @@ def test_formerly_public_paths_stay_open(auth_app: TestClient, path: str) -> Non
     )
 
 
-def test_install_complete_post_stays_open(auth_app: TestClient) -> None:
-    """The wizard's sentinel-write call is a POST — auth-free."""
+def test_install_complete_post_requires_writer(auth_app: TestClient) -> None:
+    """POST /api/install/complete is a writer endpoint (FINDINGS §29).
+
+    Previously this was anonymously reachable to support the wizard; an
+    unauthenticated LAN peer could write the first-run sentinel and lock
+    the operator out of the password flow. With auth enabled it now
+    requires a writer-scoped credential — anonymous callers 401.
+    """
     response = auth_app.post("/api/install/complete")
-    assert response.status_code != 401, response.text
+    assert response.status_code == 401, response.text
+    assert response.json()["error"]["code"] == "auth.required"
 
 
 def test_auth_logout_post_stays_open(auth_app: TestClient) -> None:


### PR DESCRIPTION
Closes harness FINDINGS §29 + §30 — both critical from the v1.0 pre-launch security review.

## What

- **§29**: every mutating endpoint in `routes/install.py` now requires `require_writer` (matches the #11 admin-router pattern). The router itself is mounted with `require_token` at `include_router` time so all install endpoints (read + write) are gated when auth is on. First-run wizard preserved: when `HAL0_AUTH_ENABLED` is unset, both gates are pass-throughs.
- **§30**: slot name is validated against `^[a-z0-9][a-z0-9_-]{0,31}$` (the same regex `SlotConfig.name` already enforces) at every install route that takes one. Path traversal (`../../tmp/pwn`, `/etc/passwd`, etc) rejected with 400 `slot.invalid_name` BEFORE any filesystem op.

## Files

- `src/hal0/api/__init__.py` — installer router now mounted with `dependencies=_admin_auth`.
- `src/hal0/api/routes/installer.py` — `_writer = [Depends(require_writer)]` on `/probe`, `/complete`, `/pick-default`, `/slots/{slot}/model`; `_validate_slot_name` helper applied at every slot-bearing endpoint.
- `tests/api/test_install_routes.py` — new file. Parametrizes auth (none / read-only / writer / auth-off) x every mutating endpoint, plus slot-name validation matrix (path traversal, absolute paths, dot segments, length, char-class).
- `tests/api/test_auth_middleware.py`, `tests/api/test_no_public_paths.py` — removed `/api/install/state` from the "stays public under HAL0_AUTH_ENABLED=1" lists and updated the install-complete assertion to reflect the new contract (was: stays open under auth; now: 401s without creds).

## Trust posture preserved

Per PLAN.md §1, fresh installs start open on the LAN with no password set. `require_writer` already short-circuits when `auth_enabled()` is False (i.e. when `HAL0_AUTH_ENABLED` is unset), so the FirstRun wizard still runs anonymously. Once the operator sets a password and flips the env flag, the wizard rides the same session cookie as every other admin surface.

## §28 (first-run password race) is a sibling concern

The flag at the top of FINDINGS §28 still stands: even with §29 closed, a LAN attacker can race the legitimate operator to claim ownership via `POST /api/auth/password` during the open window between service start and first login. That's a separate fix (setup token / loopback-only / bind to 127.0.0.1) and is owned by another agent — out of scope here.

## Test plan

- [x] `ruff check src/hal0 tests` — All checks passed.
- [x] `ruff format --check src/hal0 tests` — 191 files already formatted.
- [x] `pytest tests/api/test_install_routes.py` — 37 passed, 5 expected skips (URL-unreachable slot values).
- [x] `pytest tests/api` — 425 passed, 8 skipped (unrelated environment skips).
- [x] `pytest tests/` (full suite) — 1086 passed, 8 skipped, 3 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)