### PR TITLE
feat(ui/firstrun): OTP input field for LAN-browser wizard claim

### DIFF
--- a/ui/src/components/firstrun/useFirstRun.js
+++ b/ui/src/components/firstrun/useFirstRun.js
@@ -89,6 +89,13 @@ export function useFirstRun() {
   const form = reactive({
     // step 1 — password
     password: '',
+    // step 1 — first-run claim OTP (printed by install.sh at the tail of
+    // the summary box; lives in $VAR_DIR/.first-run.lock). The wizard
+    // sends it on POST /api/auth/password so a LAN browser can claim
+    // ownership; on the loopback bypass path the server tolerates an
+    // empty value, so the UI always sends the field even when blank
+    // rather than trying to auto-detect "am I on localhost".
+    firstRunToken: '',
     // step 2 — model dirs (list-of-strings; legacy `modelDir` first entry)
     modelDirs: ['/var/lib/hal0/models'],
     // step 3 — primary chat
@@ -310,12 +317,22 @@ export function useFirstRun() {
   // ── Step 1 — password ─────────────────────────────────────────────
   async function submitPassword() {
     if (!form.password) return
+    // Always include first_run_token, even when empty. The API tolerates
+    // an empty value when the request originates on the loopback
+    // interface (operator running curl on the box itself); for every
+    // other origin the OTP is required. The UI doesn't know the
+    // request's source — sending blindly keeps the loopback path working
+    // without trying to autodetect localhost.
     await api('/api/auth/password', {
       method: 'POST',
-      body: JSON.stringify({ password: form.password }),
+      body: JSON.stringify({
+        password: form.password,
+        first_run_token: form.firstRunToken || '',
+      }),
     })
     passwordAlreadySet.value = true
     form.password = ''
+    form.firstRunToken = ''
   }
 
   // ── Step 2 — model dirs ───────────────────────────────────────────

--- a/ui/src/views/FirstRun.vue
+++ b/ui/src/views/FirstRun.vue
@@ -61,6 +61,12 @@ watch(s.passwordAlreadySet, (set) => { if (set && step.value === 1) step.value =
 // Chat URL for the "Open chat" button on the done coda.
 const chatUrl = ref(null)
 
+// Inline error for the first-run token field. Surfaced when POST
+// /api/auth/password returns 401 with code auth.first_run_otp_required
+// or auth.first_run_otp_invalid (lockfile-OTP gate rejected the value).
+// Cleared on every keystroke so the operator gets immediate feedback.
+const tokenError = ref('')
+
 // Step 4 — rerank is a sub-disclosure inside the embed row, locked off-by-
 // default per the IA-grilling session. The disclosure is closed initially.
 const showRerank = ref(false)
@@ -80,10 +86,21 @@ function removeModelDir(i) {
 async function goNext() {
   if (step.value === 1) {
     if (s.form.password) {
+      tokenError.value = ''
       try {
         await s.submitPassword()
         toasts.info('Password set — you can change it later in Settings.')
       } catch (e) {
+        // 401 with an OTP-flavoured code is a token problem, not a
+        // server fault. Surface it inline next to the OTP field instead
+        // of as a generic toast — the operator's fix is "go grab the
+        // right token", not "open the logs".
+        const code = e?.code || ''
+        if (code === 'auth.first_run_otp_required' || code === 'auth.first_run_otp_invalid') {
+          tokenError.value =
+            'Token rejected — check that you copied it exactly from the installer output.'
+          return
+        }
         toasts.error(e?.message || 'Could not set password.')
         return
       }
@@ -142,6 +159,8 @@ function goBack() {
 
 function skipPassword() {
   s.form.password = ''
+  s.form.firstRunToken = ''
+  tokenError.value = ''
   step.value = 2
 }
 
@@ -267,6 +286,30 @@ const canAdvance = computed(() => {
             Recommended: at least 12 characters with a mix of letters and digits.
             We hash the password with bcrypt (cost 12) before storing it.
           </p>
+
+          <label class="field-label" for="firstrun-token">First-run token</label>
+          <input
+            id="firstrun-token"
+            v-model="s.form.firstRunToken"
+            class="field-input field-input-mono"
+            type="text"
+            autocomplete="off"
+            spellcheck="false"
+            placeholder="32-char hex from install.sh"
+            :aria-invalid="tokenError ? 'true' : 'false'"
+            aria-describedby="firstrun-token-hint"
+            @input="tokenError = ''"
+            @keydown.enter.prevent="goNext"
+          />
+          <p v-if="tokenError" class="field-err">{{ tokenError }}</p>
+          <p id="firstrun-token-hint" class="field-hint">
+            The installer printed this token at the end of <code>install.sh</code>.
+            Find it in your terminal or with
+            <code>journalctl -u hal0-api -n 100 | grep first-run</code>.
+            If you're running this in a browser on the hal0 server itself
+            (localhost), the field is optional.
+          </p>
+
           <div class="wizard-footer wizard-footer-2">
             <button class="btn-ghost" type="button" @click="skipPassword">Skip — leave open</button>
             <button class="btn-primary" type="button" :disabled="!canAdvance" @click="goNext">

--- a/ui/tests/e2e/specs/firstrun.spec.ts
+++ b/ui/tests/e2e/specs/firstrun.spec.ts
@@ -40,6 +40,11 @@ test.beforeEach(async ({ page, mockState }) => {
   // bundle. Provide deterministic empty/closed shapes so the composable
   // settles into "first-run, CPU box, nothing gated".
   await page.route('**/api/auth/status', (route) => json(route, { password_set: false }))
+  // Default password-claim mock — accept whatever the wizard posts.
+  // Token-flow specs below override this with a token-aware variant.
+  await page.route('**/api/auth/password', (route) =>
+    json(route, { ok: true, password_set: true, rotated: false }),
+  )
   await page.route('**/api/capabilities', (route) =>
     json(route, {
       backends: [],
@@ -143,4 +148,119 @@ test('redirects to /firstrun, walks the 8-step wizard, opens chat', async ({ pag
   expect(openCalls[0].url).toBe(mockState.configUrls.openwebui)
   expect(openCalls[0].target).toBe('_blank')
   expect(mockState.installCompleteCount).toBe(1)
+})
+
+/**
+ * First-run OTP field — wired in fix/ui-firstrun-otp-2026-05-21 so a
+ * LAN browser (no loopback bypass) can claim ownership using the token
+ * the installer printed. The wizard always posts `first_run_token` in
+ * the password-claim body; an empty value is tolerated server-side on
+ * the loopback path.
+ */
+test.describe('first-run OTP', () => {
+  test('renders the OTP field on step 1 and posts the token verbatim', async ({
+    page,
+    cleanState: _cleanState,
+  }) => {
+    // Capture the POST body so we can assert the OTP rides along.
+    let capturedBody: { password?: string; first_run_token?: string } | null = null
+    await page.route('**/api/auth/password', (route) => {
+      try {
+        capturedBody = JSON.parse(route.request().postData() || '{}')
+      } catch {
+        capturedBody = null
+      }
+      return json(route, { ok: true, password_set: true, rotated: false })
+    })
+
+    await page.goto('/')
+    await expect(page).toHaveURL(/\/firstrun$/)
+
+    // Field renders + accepts text input.
+    const tokenField = page.locator('#firstrun-token')
+    await expect(tokenField).toBeVisible()
+    await expect(tokenField).toHaveAttribute('type', 'text')
+
+    await page.locator('#firstrun-password').fill('correct horse battery staple')
+    await tokenField.fill('deadbeefcafebabe1234567890abcdef')
+
+    await page.getByRole('button', { name: /Set password/ }).click()
+
+    // Wizard advances to step 2 only after the OTP-bearing POST succeeded.
+    await expect(page.getByText('We probed your hardware')).toBeVisible()
+
+    expect(capturedBody).not.toBeNull()
+    expect(capturedBody!.password).toBe('correct horse battery staple')
+    expect(capturedBody!.first_run_token).toBe('deadbeefcafebabe1234567890abcdef')
+  })
+
+  test('surfaces an inline error on auth.first_run_otp_required', async ({
+    page,
+    cleanState: _cleanState,
+  }) => {
+    // First call rejects with the OTP-required code; UI must show inline
+    // error near the token field, NOT a generic toast, AND must stay on
+    // step 1 so the operator can correct the token.
+    await page.route('**/api/auth/password', (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: {
+            code: 'auth.first_run_otp_required',
+            message: 'first-run OTP is required',
+            details: {},
+          },
+        }),
+      }),
+    )
+
+    await page.goto('/')
+    await expect(page).toHaveURL(/\/firstrun$/)
+
+    await page.locator('#firstrun-password').fill('correct horse battery staple')
+    // Submit with an empty token; the mock 401s regardless.
+    await page.getByRole('button', { name: /Set password/ }).click()
+
+    // Inline error visible next to the token field.
+    await expect(page.locator('#firstrun-token + .field-err, .field-err').first()).toContainText(
+      /Token rejected/i,
+    )
+
+    // Step indicator still on step 1 (we didn't advance).
+    await expect(page.getByText('We probed your hardware')).not.toBeVisible()
+
+    // Editing the field clears the error (immediate feedback).
+    await page.locator('#firstrun-token').fill('a')
+    await expect(page.locator('.field-err')).toHaveCount(0)
+  })
+
+  test('surfaces inline error on auth.first_run_otp_invalid too', async ({
+    page,
+    cleanState: _cleanState,
+  }) => {
+    await page.route('**/api/auth/password', (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: {
+            code: 'auth.first_run_otp_invalid',
+            message: 'first-run OTP did not validate',
+            details: {},
+          },
+        }),
+      }),
+    )
+
+    await page.goto('/')
+    await expect(page).toHaveURL(/\/firstrun$/)
+
+    await page.locator('#firstrun-password').fill('correct horse battery staple')
+    await page.locator('#firstrun-token').fill('wrong-token-value')
+    await page.getByRole('button', { name: /Set password/ }).click()
+
+    await expect(page.locator('.field-err').first()).toContainText(/Token rejected/i)
+    await expect(page.getByText('We probed your hardware')).not.toBeVisible()
+  })
 })


### PR DESCRIPTION
Final piece of the Wave 3 security pass. PR #87's first-run OTP gate left the FirstRun wizard broken for LAN browsers — only host-local curl could mint the owner password. This adds the OTP input to the wizard so any LAN device with the installer-printed token can claim ownership.

## What

- `ui/src/views/FirstRun.vue`: First-run token input on the password-set step, with explanatory hint pointing at `install.sh` output and `journalctl -u hal0-api -n 100 | grep first-run`
- `ui/src/components/firstrun/useFirstRun.js`: `submitPassword()` now posts `first_run_token` alongside `password`; the field is always sent even when empty (API tolerates the empty case on the loopback path)
- Inline error on `auth.first_run_otp_required` / `auth.first_run_otp_invalid` — surfaced next to the token field, not as a generic toast
- 3 new Playwright tests cover: field renders + posts token in body, both OTP error codes display inline + don't advance, error clears on next keystroke
- Existing 8-step happy-path spec still passes (4/4 chromium green)

## Test plan

- [x] Token field renders, accepts text input
- [x] Form submission posts the token in the body (`first_run_token` key)
- [x] 401 `auth.first_run_otp_required` surfaces inline error
- [x] 401 `auth.first_run_otp_invalid` surfaces inline error
- [x] Inline error clears on keystroke
- [x] Happy path: token + password → 200, wizard advances to step 2
- [x] Skip-password path still clears both fields + advances
- [x] `npm run build` clean (no stale-CSS-chunk artefacts)
- [x] `ruff check src/hal0 tests` green (no Python touched, sanity-check)

## Notes

- The API contract field name (`first_run_token`) and error codes (`auth.first_run_otp_required`, `auth.first_run_otp_invalid`) are forward-looking — the server side of the OTP check is not yet wired in `src/hal0/api/routes/auth.py` (PR #87 plants the lockfile but the password POST currently only gates on lockfile presence). When the §28 follow-up wires OTP verification into the route, it must match these names. The UI is ready.
- Token is intentionally NOT cached to localStorage — it's single-use and the wizard runs to completion in one session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)