### PR TITLE
fix(dashboard): NPU pull + chat dropdown capability filter

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -607,6 +607,20 @@ drops the prior host bind-mount entirely. The `FLMProvider` invokes
 namespace (`b90a569`), so the dashboard NPU rollup advertises only
 models FLM can actually serve.
 
+**NPU dashboard pull (2026-05-21):** the dashboard can now pull FLM
+tags end-to-end (PR #89). Two fixes shipped together: the catalog
+probe + the new pull path both bind-mount `HAL0_FLM_MODELS_DIR` to
+`/var/lib/hal0/.config/flm/models` (the toolbox image's non-root
+`hal0` HOME, not `/root`), so `flm list` and `flm pull` see and
+persist into the host-managed model cache. `POST /api/models/{id}/pull`
+detects FLM tags via `is_flm_tag()` and routes them through
+`run_flm_pull()`, which shells out to `flm pull <tag>`, parses the
+`Downloading: …%` progress lines, and writes an HF-shaped registry
+entry on completion. `pullable=True` now propagates to FLM rows in
+the capability catalog. Verified live with `gemma3:1b` (~18 s for
+1.26 GB). FLM-aware pull was the last v0.2 follow-up still listed
+on the public roadmap; closed.
+
 **Moonshine rebuild (2026-05-20):** Republished `hal0-toolbox-moonshine:v1`
 at digest `sha256:a5bbb78b…` after fixing `moonshine_server.py` to pass
 both `models_dir` and `model_name` to `MoonshineOnnxModel` (commit

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -30,6 +30,7 @@ from hal0.registry.pull import (
     PullJob,
     PullJobNotFound,
     make_job,
+    run_flm_pull,
     run_pull,
 )
 
@@ -808,6 +809,17 @@ async def _run_pull_with_events(
         with contextlib.suppress(asyncio.CancelledError, Exception):
             await progress_task
 
+    await _emit_terminal_pull_event(event_bus, job)
+
+
+async def _emit_terminal_pull_event(event_bus: Any, job: PullJob) -> None:
+    """Emit the success/failure/cancellation footer event for a pull.
+
+    Shared between the HF pull wrapper and the FLM pull background task
+    so both surfaces produce the same dashboard footer events.
+    """
+    if event_bus is None:
+        return
     if job.state == "completed":
         await event_bus.emit(
             "pull.completed",
@@ -890,6 +902,15 @@ async def pull_model(
             "resumed": True,
         }
 
+    # FLM/NPU tags route through the toolbox container instead of HF.
+    # The ``model:tag`` shape is the dispatch signal (HF ids never use
+    # colons), validated against the FLM probe so a stray ``foo:bar``
+    # falls through to the HF resolver and gets a clean 422.
+    from hal0.providers.flm import is_flm_tag
+
+    if is_flm_tag(model_id):
+        return await _start_flm_pull(model_id, request, background, jobs)
+
     hf_repo, hf_file = _resolve_pull_source(request, model_id)
     job = make_job(model_id)
     jobs[model_id] = job
@@ -921,6 +942,52 @@ async def pull_model(
         "state": job.state,
         "hf_repo": hf_repo,
         "hf_file": hf_file,
+    }
+
+
+async def _start_flm_pull(
+    model_id: str,
+    request: Request,
+    background: BackgroundTasks,
+    jobs: dict[str, PullJob],
+) -> dict[str, object]:
+    """Spawn a background ``flm pull`` job and return the job handle.
+
+    Shares the PullJob/SSE plumbing with the HF pull path so the
+    dashboard's pull progress UI works unchanged. The HF-specific
+    progress decile + speed/ETA wrapper (:func:`_run_pull_with_events`)
+    isn't reused here because its progress event payload assumes byte
+    deltas from a single HTTP stream — FLM's container emits multiple
+    files with its own progress lines and we don't want to misreport
+    rate. Footer events are emitted directly around the run.
+    """
+    job = make_job(model_id)
+    jobs[model_id] = job
+    registry = request.app.state.model_registry
+    event_bus = getattr(request.app.state, "events", None)
+
+    if event_bus is not None:
+        await event_bus.emit(
+            "pull.queued",
+            "info",
+            f"pull:{model_id}",
+            f"{model_id}: queued (FLM/NPU)",
+            data={"model_id": model_id, "source": "flm"},
+        )
+
+    async def _run_flm_with_events() -> None:
+        try:
+            await run_flm_pull(job, tag=model_id, registry=registry)
+        finally:
+            if event_bus is not None:
+                await _emit_terminal_pull_event(event_bus, job)
+
+    background.add_task(_run_flm_with_events)
+    return {
+        "id": job.job_id,
+        "model_id": model_id,
+        "state": job.state,
+        "source": "flm",
     }
 
 

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -580,13 +580,13 @@ def _flm_rows_for_capability(capability: str) -> list[dict[str, Any]]:
     FLM also serves ``stt`` (whisper-v3, gemma4-it asr=true) but the NPU
     voice path through the slot manager is a later slice.
 
-    ``pullable`` is reported as False even though ``flm pull <tag>``
-    works inside the toolbox: the existing ``POST /api/models/{id}/pull``
-    handler resolves a HuggingFace repo + filename, which FLM tags don't
-    carry. Wiring an FLM-aware pull path is a follow-up; until then,
-    operators run ``flm pull`` manually via the toolbox container and
-    the catalog will flip ``downloaded`` to True on the next probe-cache
-    refresh (process restart).
+    ``pullable`` is True for FLM tags — the pull route (routes/models.py)
+    detects FLM ids via :func:`hal0.providers.flm.is_flm_tag` and dispatches
+    to :func:`hal0.registry.pull.run_flm_pull`, which shells ``flm pull
+    <tag>`` inside the toolbox image with the same bind mount the slot
+    uses. After a successful pull we reset the FLM probe cache so the
+    next ``/api/capabilities`` GET flips ``downloaded`` to True without a
+    process restart.
     """
     if capability not in {"chat", "embed"}:
         return []
@@ -617,7 +617,7 @@ def _flm_rows_for_capability(capability: str) -> list[dict[str, Any]]:
                 "size_gb": size_gb,
                 "capabilities": reported_caps,
                 "downloaded": entry["installed"],
-                "pullable": False,
+                "pullable": True,
             }
         )
     return out

--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -32,6 +32,7 @@ haloai's lib/providers/flm.py.
 from __future__ import annotations
 
 import os
+import re
 from typing import Any
 
 import httpx
@@ -208,9 +209,13 @@ class FLMProvider(Provider):
 
         # Only the model cache is bind-mounted. FLM hardcodes
         # ~/.config/flm/models internally; map our hal0-managed cache
-        # to that path.
+        # to that path. The toolbox image runs as the non-root ``hal0``
+        # user (uid 1000, HOME=/var/lib/hal0), so ~/.config resolves to
+        # /var/lib/hal0/.config — NOT /root/.config. Mounting at the
+        # wrong HOME would silently drop every pulled model into the
+        # container's writable overlay and lose it on exit.
         mounts: list[tuple[str, str]] = [
-            (flm_models, "/root/.config/flm/models"),
+            (flm_models, "/var/lib/hal0/.config/flm/models"),
         ]
 
         # Build the argv passed to the image's ENTRYPOINT. The image runs
@@ -424,17 +429,27 @@ def _probe_flm_catalog() -> list[dict[str, Any]] | None:
     ``flm list`` reads the bundled ``model_list.json`` and never touches
     NPU hardware — keeping the device flag out makes the probe usable on
     dev hosts without XDNA passthrough.
+
+    The hal0-managed FLM models cache is bind-mounted at the same path
+    the slot's container_spec uses (``~/.config/flm/models`` resolved
+    against the toolbox image's non-root ``hal0`` user, HOME=/var/lib/hal0).
+    Without it ``flm list`` runs against an empty overlay and reports
+    every model as not-installed — masking weights the host already has
+    on disk.
     """
     import json
     import subprocess
 
     image = os.environ.get("HAL0_TOOLBOX_IMAGE_FLM", _DEFAULT_FLM_IMAGE)
+    flm_models = os.environ.get("HAL0_FLM_MODELS_DIR") or _DEFAULT_FLM_MODELS_DIR
     cmd = [
         "docker",
         "run",
         "--rm",
         "--security-opt",
         "apparmor=unconfined",
+        "-v",
+        f"{flm_models}:/var/lib/hal0/.config/flm/models",
         image,
         "list",
         "-j",
@@ -522,3 +537,76 @@ def reset_flm_catalog_cache() -> None:
     global _FLM_CATALOG_CACHE, _FLM_PROBE_OK
     _FLM_CATALOG_CACHE = None
     _FLM_PROBE_OK = False
+
+
+def is_flm_tag(model_id: str) -> bool:
+    """True iff ``model_id`` matches an FLM-served tag.
+
+    Routing helper for the pull endpoint: FLM tags are Ollama-style
+    ``family:size`` ids (``qwen3:0.6b``, ``deepseek-r1:8b``, …) and
+    don't carry HF coords, so the generic HF pull path can't pull them.
+    Looks them up against the cached :func:`flm_served_models` so we
+    only treat ids the toolbox actually knows about — a stray ``foo:bar``
+    falls through to the HF resolver and gets a proper 422.
+    """
+    if ":" not in model_id:
+        return False
+    return any(m["tag"] == model_id for m in flm_served_models())
+
+
+def flm_pull_command(tag: str) -> tuple[list[str], str]:
+    """Return ``(argv, host_models_dir)`` for an ``flm pull <tag>`` run.
+
+    Mirrors :func:`_probe_flm_catalog` argv shape (apparmor unconfined,
+    same bind mount target) but invokes ``pull`` instead of ``list``.
+    The host_models_dir is returned so callers can locate the on-disk
+    weights for registry/path bookkeeping after the pull finishes.
+
+    Like the slot's container_spec we do NOT pass ``--device``: ``flm
+    pull`` downloads files; it doesn't touch the NPU. Keeping the
+    device flag out lets the pull run on dev hosts without XDNA
+    passthrough (useful for tests).
+    """
+    image = os.environ.get("HAL0_TOOLBOX_IMAGE_FLM", _DEFAULT_FLM_IMAGE)
+    flm_models = os.environ.get("HAL0_FLM_MODELS_DIR") or _DEFAULT_FLM_MODELS_DIR
+    argv = [
+        "docker",
+        "run",
+        "--rm",
+        "--security-opt",
+        "apparmor=unconfined",
+        "-v",
+        f"{flm_models}:/var/lib/hal0/.config/flm/models",
+        image,
+        "pull",
+        tag,
+    ]
+    return argv, flm_models
+
+
+_FLM_PROGRESS_RE = re.compile(
+    r"Downloading:\s*([0-9.]+)%\s*\(([0-9.]+)\s*([KMG]?)B\s*/\s*([0-9.]+)\s*([KMG]?)B\)"
+)
+
+
+def parse_flm_progress(line: str) -> tuple[int, int] | None:
+    """Extract ``(bytes_downloaded, bytes_total)`` from a ``flm pull`` line.
+
+    FLM emits progress like::
+
+        [FLM]  Downloading: 38.8% (253.0MB / 652.1MB)
+
+    Returns ``None`` on lines that don't match (status, hash check,
+    blank, etc.) so the caller can skip them without branching.
+    """
+    m = _FLM_PROGRESS_RE.search(line)
+    if not m:
+        return None
+    _pct, cur, cur_unit, tot, tot_unit = m.groups()
+    units = {"": 1, "K": 1024, "M": 1024**2, "G": 1024**3}
+    try:
+        bytes_downloaded = int(float(cur) * units[cur_unit])
+        bytes_total = int(float(tot) * units[tot_unit])
+    except (KeyError, ValueError):
+        return None
+    return bytes_downloaded, bytes_total

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -450,6 +450,244 @@ def _register_pulled(
     registry.update(model_id, updates)
 
 
+async def run_flm_pull(
+    job: PullJob,
+    *,
+    tag: str,
+    registry: ModelRegistry,
+) -> None:
+    """Background-task body: shell ``flm pull <tag>`` in the toolbox image.
+
+    Mirrors :func:`run_pull`'s state machine (queued → running →
+    {completed, failed, cancelled}) so the existing SSE / status routes
+    work unchanged. Differs in two ways:
+
+      * Bytes come from parsing FLM's stdout lines (no Content-Length
+        header to lean on) — see :func:`hal0.providers.flm.parse_flm_progress`.
+      * No sha256 is computed here: FLM verifies file hashes internally
+        and refuses to use mismatched weights. Re-hashing would just
+        double-read multi-GB files for the same guarantee.
+
+    Cancellation works via SIGTERM on the docker CLI subprocess — docker
+    propagates that to the container and ``flm pull`` aborts. The partial
+    files are left on disk; FLM's next pull deletes & redownloads them
+    (it checks file sizes against the manifest before reusing).
+
+    On success the FLM probe cache is reset so the next ``/api/capabilities``
+    GET flips this tag's ``downloaded`` flag to True without an api restart.
+    """
+    # Local import to keep providers.flm's docker subprocess out of the
+    # base pull module's import graph (tests pull this module in
+    # environments without docker).
+    from hal0.providers.flm import (
+        flm_pull_command,
+        parse_flm_progress,
+        reset_flm_catalog_cache,
+    )
+
+    job.state = "running"
+    job.started_at = time.time()
+    job._signal()
+
+    argv, host_models_dir = flm_pull_command(tag)
+    proc: asyncio.subprocess.Process | None = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        assert proc.stdout is not None
+        last_emit = time.monotonic()
+        while True:
+            if job.cancel_requested:
+                proc.terminate()
+                with contextlib.suppress(asyncio.TimeoutError):
+                    await asyncio.wait_for(proc.wait(), timeout=10.0)
+                if proc.returncode is None:
+                    proc.kill()
+                    await proc.wait()
+                job.state = "cancelled"
+                job.finished_at = time.time()
+                job._signal()
+                return
+            try:
+                raw = await asyncio.wait_for(proc.stdout.readline(), timeout=1.0)
+            except TimeoutError:
+                # No new line in 1s — loop back so cancellation observes promptly.
+                continue
+            if not raw:
+                break
+            line = raw.decode("utf-8", errors="replace")
+            parsed = parse_flm_progress(line)
+            if parsed is not None:
+                downloaded, total = parsed
+                job.bytes_downloaded = downloaded
+                if total > job.bytes_total:
+                    job.bytes_total = total
+                now = time.monotonic()
+                if (now - last_emit) >= _SSE_MIN_INTERVAL_S:
+                    last_emit = now
+                    job._signal()
+
+        await proc.wait()
+        if proc.returncode != 0:
+            raise PullError(
+                f"flm pull {tag!r} exited with status {proc.returncode}",
+                details={"tag": tag, "exit_code": proc.returncode},
+            )
+
+        # Refresh the catalog so subsequent /api/capabilities picks up
+        # the new installed=true flag without a process restart.
+        reset_flm_catalog_cache()
+
+        # Best-effort path bookkeeping. FLM stores each tag's weights at
+        # ``<host_models_dir>/<HF-repo-name>/`` — we resolve the dir from
+        # the FLM model_list lookup when available, falling back to the
+        # bare host dir so a missing entry doesn't fail the job.
+        final_path = _flm_install_path(host_models_dir, tag) or host_models_dir
+        size_bytes = _dir_size(final_path)
+        if job.bytes_total <= 0 and size_bytes > 0:
+            job.bytes_total = size_bytes
+        if job.bytes_downloaded < size_bytes:
+            job.bytes_downloaded = size_bytes
+        job.path = str(final_path)
+
+        # Register an FLM tag so the registry surfaces it for downstream
+        # consumers (catalog, slot model resolution). hf_repo/filename
+        # stay empty — FLM tags route through the toolbox, not HF directly.
+        _register_flm_pulled(
+            registry,
+            tag=tag,
+            path=str(final_path),
+            size_bytes=size_bytes,
+        )
+
+        job.state = "completed"
+        job.finished_at = time.time()
+        job._signal()
+        log.info(
+            "model.pull_flm_completed",
+            extra={"tag": tag, "path": str(final_path), "bytes": size_bytes},
+        )
+    except asyncio.CancelledError:
+        if proc is not None and proc.returncode is None:
+            proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.wait()
+        job.state = "cancelled"
+        job.finished_at = time.time()
+        job._signal()
+        raise
+    except Hal0Error as exc:
+        job.state = "failed"
+        job.error = exc.message
+        job.error_code = exc.code
+        job.finished_at = time.time()
+        job._signal()
+        log.warning("model.pull_flm_failed", extra={"tag": tag, "error": exc.message})
+    except Exception as exc:
+        job.state = "failed"
+        job.error = f"{type(exc).__name__}: {exc}"
+        job.error_code = "model.pull_failed"
+        job.finished_at = time.time()
+        job._signal()
+        log.exception("model.pull_flm_unexpected_error", extra={"tag": tag})
+
+
+def _flm_install_path(host_models_dir: str, tag: str) -> str | None:
+    """Look up the on-disk subdir FLM uses for ``tag``, or None if unknown.
+
+    Walks the toolbox image's bundled ``model_list.json`` schema (family
+    → variants → name=HF-repo). We probe it via ``flm_served_models``
+    indirectly: the cached entry exposes a ``family`` field but not the
+    HF name, so we read FLM's own JSON by shelling ``flm list -j`` and
+    matching tag → ``name``. The probe is cached, so this lookup is
+    O(1) after the first call.
+    """
+    from hal0.providers.flm import _probe_flm_catalog
+
+    models = _probe_flm_catalog()
+    if not models:
+        return None
+    for entry in models:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("model") == tag or entry.get("name") == tag:
+            # The "name" field on the flat list is the same as model.
+            # The HF repo name lives only in the nested model_list.json
+            # tree; the flat list flattens it into ``files`` + ``url``.
+            # Extract from the ``url`` field, which looks like
+            # ``https://huggingface.co/FastFlowLM/Qwen3-0.6B-NPU2/resolve/...``.
+            url = entry.get("url") or ""
+            parts = url.split("/")
+            try:
+                idx = parts.index("huggingface.co")
+                repo_name = parts[idx + 2]  # owner/<repo>
+                return str(Path(host_models_dir) / repo_name)
+            except (ValueError, IndexError):
+                return None
+    return None
+
+
+def _dir_size(path: str | Path) -> int:
+    """Sum file sizes under ``path``; 0 if path is missing/unreadable."""
+    p = Path(path)
+    if not p.exists():
+        return 0
+    total = 0
+    try:
+        for child in p.rglob("*"):
+            if child.is_file():
+                with contextlib.suppress(OSError):
+                    total += child.stat().st_size
+    except OSError:
+        return total
+    return total
+
+
+def _register_flm_pulled(
+    registry: ModelRegistry,
+    *,
+    tag: str,
+    path: str,
+    size_bytes: int,
+) -> None:
+    """Upsert a registry entry for an FLM-pulled model.
+
+    FLM tags don't carry HF coords from a hal0 perspective (the toolbox
+    image's ``flm pull`` resolves them itself), so ``hf_repo`` and
+    ``hf_filename`` stay empty. ``metadata.runtime = "flm"`` flags the
+    entry so other code (slot pick, model resolution) can route it to
+    the FLM provider without re-deriving from the id.
+    """
+    updates: dict[str, Any] = {
+        "path": path,
+        "size_bytes": size_bytes,
+        "metadata": {"runtime": "flm"},
+    }
+    try:
+        existing = registry.get(tag)
+    except ModelNotFound:
+        registry.add(
+            Model(
+                id=tag,
+                name=tag,
+                path=path,
+                size_bytes=size_bytes,
+                capabilities=["chat"],
+                backends=["npu"],
+                metadata={"runtime": "flm"},
+            )
+        )
+        return
+    merged_meta = dict(existing.metadata)
+    merged_meta["runtime"] = "flm"
+    updates["metadata"] = merged_meta
+    registry.update(tag, updates)
+
+
 __all__ = [
     "PullError",
     "PullInvalidSource",
@@ -459,5 +697,6 @@ __all__ = [
     "get_job",
     "hf_download_url",
     "make_job",
+    "run_flm_pull",
     "run_pull",
 ]

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -146,8 +146,28 @@ const chatOutputEl = ref(null)
 
 async function loadChatModels() {
   try {
-    const r = await api('/v1/models')
-    chatModels.value = (r?.data || []).map((m) => m.id)
+    // The Test chat panel POSTs to /v1/chat/completions, so we must show
+    // only chat-capable upstreams in the dropdown. /v1/models is a flat
+    // aggregation across every slot (embed, rerank, stt, tts included)
+    // with no capability tag — relying on its order put the embed model
+    // at the top of the list as default. We instead derive the set of
+    // chat-capable slots by joining /api/slots (slot → loaded model id)
+    // with /api/capabilities (model id → capabilities) and filter
+    // /v1/models' rows by owned_by ∈ chat-capable slots.
+    const [models, slots, cap] = await Promise.all([
+      api('/v1/models'),
+      api('/api/slots').catch(() => []),
+      api('/api/capabilities').catch(() => ({ catalogs: {} })),
+    ])
+    const chatModelIds = new Set(
+      (cap?.catalogs?.chat?.chat ?? []).map((m) => m.id),
+    )
+    const chatSlots = new Set(
+      (slots || []).filter((s) => chatModelIds.has(s.model_id)).map((s) => s.name),
+    )
+    chatModels.value = (models?.data || [])
+      .filter((m) => chatSlots.has(m.owned_by))
+      .map((m) => m.id)
     if (!chatModel.value && chatModels.value.length) {
       // Prefer a small fast model for the first interaction.
       const preferred = chatModels.value.find((m) =>

--- a/ui/tests/e2e/specs/dashboard.spec.ts
+++ b/ui/tests/e2e/specs/dashboard.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * dashboard.spec.ts — Test chat panel: chat dropdown filters non-chat slots.
+ *
+ * Regression for: pre-fix, the dropdown rendered every model `/v1/models`
+ * returned (embed, rerank, stt, tts included) and defaulted to data[0],
+ * which was the embed slot's model. Post-fix, the dropdown intersects
+ * /v1/models with chat-capable slots derived from /api/slots ×
+ * /api/capabilities.
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+
+test('Test chat dropdown lists only chat-capable upstreams', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  // Three upstreams: an embed slot, a chat slot, an stt slot. Only the
+  // chat one should survive the filter.
+  await page.route('**/v1/models', (route) =>
+    json(route, {
+      object: 'list',
+      data: [
+        { id: 'nomic-embed.gguf', object: 'model', owned_by: 'embed' },
+        { id: 'qwen3-chat.gguf', object: 'model', owned_by: 'primary' },
+        { id: 'moonshine-base', object: 'model', owned_by: 'stt' },
+      ],
+    }),
+  )
+  await page.route('**/api/slots', (route) =>
+    json(route, [
+      { name: 'embed', model_id: 'nomic-embed-text-v1.5-q8_0' },
+      { name: 'primary', model_id: 'qwen3-chat-id' },
+      { name: 'stt', model_id: 'moonshine-base-en' },
+    ]),
+  )
+  await page.route('**/api/capabilities', (route) =>
+    json(route, {
+      backends: [],
+      catalogs: {
+        chat: {
+          chat: [{ id: 'qwen3-chat-id', capabilities: ['chat'] }],
+        },
+      },
+      selections: {},
+    }),
+  )
+
+  await page.goto('/')
+
+  const dropdown = page.locator('select.chat-model')
+  await expect(dropdown).toBeVisible()
+  // Wait for the post-mount fetch to settle and the options to populate.
+  await expect(dropdown.locator('option')).toHaveCount(1, { timeout: 5_000 })
+  await expect(dropdown.locator('option').first()).toHaveText('qwen3-chat.gguf')
+
+  // Selected value mirrors the only chat-capable model.
+  await expect(dropdown).toHaveValue('qwen3-chat.gguf')
+
+  // Negative assertions: embed/stt models must not leak in.
+  await expect(dropdown).not.toContainText('nomic-embed')
+  await expect(dropdown).not.toContainText('moonshine')
+})
+
+test('Test chat dropdown is empty when no chat-capable slot exists', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  // Pre-fix this test would fail because the embed model would leak in
+  // and become the default — sending /v1/chat/completions against an
+  // embedding endpoint.
+  await page.route('**/v1/models', (route) =>
+    json(route, {
+      object: 'list',
+      data: [{ id: 'nomic-embed.gguf', object: 'model', owned_by: 'embed' }],
+    }),
+  )
+  await page.route('**/api/slots', (route) =>
+    json(route, [{ name: 'embed', model_id: 'nomic-embed-text-v1.5-q8_0' }]),
+  )
+  await page.route('**/api/capabilities', (route) =>
+    json(route, {
+      backends: [],
+      catalogs: { chat: { chat: [] } },
+      selections: {},
+    }),
+  )
+
+  await page.goto('/')
+
+  const dropdown = page.locator('select.chat-model')
+  await expect(dropdown).toBeVisible()
+  // "No models" placeholder option is the only entry.
+  await expect(dropdown.locator('option')).toHaveCount(1)
+  await expect(dropdown.locator('option').first()).toHaveText('No models')
+})


### PR DESCRIPTION
## Summary

Two dashboard fixes — NPU model pulls now flow end-to-end through the UI, and the Test chat dropdown stops surfacing non-chat slots.

* **`fix(npu)`** — `flm list` and `flm pull` ran in containers with no model-cache mount, so the toolbox saw an empty overlay and reported every model as not-installed; the pull button was also hardcoded `pullable=False`. Bind-mounts `HAL0_FLM_MODELS_DIR` to `/var/lib/hal0/.config/flm/models` (toolbox HOME), adds FLM-tag routing in `POST /api/models/{id}/pull`, and registers pulled weights as HF-shaped registry entries. Verified live: `gemma3:1b` pull completed in ~18 s and `/api/capabilities` flipped `downloaded=true`.
* **`fix(ui)`** — `loadChatModels` was naively reading `/v1/models` and dropping the embed slot (`nomic-embed-text-v1.5`) into the Test chat dropdown as default. Now does a two-hop join: `/api/capabilities.chat.chat` × `/api/slots` × `/v1/models.owned_by`, so only chat-capable upstreams render.

Adds `ui/tests/e2e/specs/dashboard.spec.ts` (two specs, positive + empty-state) as regression for the dropdown filter.

## Test plan

- [ ] CI green on the new `dashboard.spec.ts` (Playwright Chromium)
- [ ] `npm run lint` + `npm run typecheck` in `ui/`
- [ ] Existing slot-integration tests still pass
- [ ] Manual: open dashboard → Test chat dropdown shows only chat slots (no embed/rerank/stt/tts)
- [ ] Manual: click pull on an FLM model from the dashboard → progress streams, registry entry appears, dropdown flips to ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)