### PR TITLE
fix(npu): blacklist qwen3:0.6b — upstream FLM UTF-8 bug

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -607,6 +607,20 @@ drops the prior host bind-mount entirely. The `FLMProvider` invokes
 namespace (`b90a569`), so the dashboard NPU rollup advertises only
 models FLM can actually serve.
 
+**NPU dashboard pull (2026-05-21):** the dashboard can now pull FLM
+tags end-to-end (PR #89). Two fixes shipped together: the catalog
+probe + the new pull path both bind-mount `HAL0_FLM_MODELS_DIR` to
+`/var/lib/hal0/.config/flm/models` (the toolbox image's non-root
+`hal0` HOME, not `/root`), so `flm list` and `flm pull` see and
+persist into the host-managed model cache. `POST /api/models/{id}/pull`
+detects FLM tags via `is_flm_tag()` and routes them through
+`run_flm_pull()`, which shells out to `flm pull <tag>`, parses the
+`Downloading: …%` progress lines, and writes an HF-shaped registry
+entry on completion. `pullable=True` now propagates to FLM rows in
+the capability catalog. Verified live with `gemma3:1b` (~18 s for
+1.26 GB). FLM-aware pull was the last v0.2 follow-up still listed
+on the public roadmap; closed.
+
 **Moonshine rebuild (2026-05-20):** Republished `hal0-toolbox-moonshine:v1`
 at digest `sha256:a5bbb78b…` after fixing `moonshine_server.py` to pass
 both `models_dir` and `model_name` to `MoonshineOnnxModel` (commit

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -30,6 +30,7 @@ from hal0.registry.pull import (
     PullJob,
     PullJobNotFound,
     make_job,
+    run_flm_pull,
     run_pull,
 )
 
@@ -808,6 +809,17 @@ async def _run_pull_with_events(
         with contextlib.suppress(asyncio.CancelledError, Exception):
             await progress_task
 
+    await _emit_terminal_pull_event(event_bus, job)
+
+
+async def _emit_terminal_pull_event(event_bus: Any, job: PullJob) -> None:
+    """Emit the success/failure/cancellation footer event for a pull.
+
+    Shared between the HF pull wrapper and the FLM pull background task
+    so both surfaces produce the same dashboard footer events.
+    """
+    if event_bus is None:
+        return
     if job.state == "completed":
         await event_bus.emit(
             "pull.completed",
@@ -890,6 +902,15 @@ async def pull_model(
             "resumed": True,
         }
 
+    # FLM/NPU tags route through the toolbox container instead of HF.
+    # The ``model:tag`` shape is the dispatch signal (HF ids never use
+    # colons), validated against the FLM probe so a stray ``foo:bar``
+    # falls through to the HF resolver and gets a clean 422.
+    from hal0.providers.flm import is_flm_tag
+
+    if is_flm_tag(model_id):
+        return await _start_flm_pull(model_id, request, background, jobs)
+
     hf_repo, hf_file = _resolve_pull_source(request, model_id)
     job = make_job(model_id)
     jobs[model_id] = job
@@ -921,6 +942,52 @@ async def pull_model(
         "state": job.state,
         "hf_repo": hf_repo,
         "hf_file": hf_file,
+    }
+
+
+async def _start_flm_pull(
+    model_id: str,
+    request: Request,
+    background: BackgroundTasks,
+    jobs: dict[str, PullJob],
+) -> dict[str, object]:
+    """Spawn a background ``flm pull`` job and return the job handle.
+
+    Shares the PullJob/SSE plumbing with the HF pull path so the
+    dashboard's pull progress UI works unchanged. The HF-specific
+    progress decile + speed/ETA wrapper (:func:`_run_pull_with_events`)
+    isn't reused here because its progress event payload assumes byte
+    deltas from a single HTTP stream — FLM's container emits multiple
+    files with its own progress lines and we don't want to misreport
+    rate. Footer events are emitted directly around the run.
+    """
+    job = make_job(model_id)
+    jobs[model_id] = job
+    registry = request.app.state.model_registry
+    event_bus = getattr(request.app.state, "events", None)
+
+    if event_bus is not None:
+        await event_bus.emit(
+            "pull.queued",
+            "info",
+            f"pull:{model_id}",
+            f"{model_id}: queued (FLM/NPU)",
+            data={"model_id": model_id, "source": "flm"},
+        )
+
+    async def _run_flm_with_events() -> None:
+        try:
+            await run_flm_pull(job, tag=model_id, registry=registry)
+        finally:
+            if event_bus is not None:
+                await _emit_terminal_pull_event(event_bus, job)
+
+    background.add_task(_run_flm_with_events)
+    return {
+        "id": job.job_id,
+        "model_id": model_id,
+        "state": job.state,
+        "source": "flm",
     }
 
 

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -580,13 +580,13 @@ def _flm_rows_for_capability(capability: str) -> list[dict[str, Any]]:
     FLM also serves ``stt`` (whisper-v3, gemma4-it asr=true) but the NPU
     voice path through the slot manager is a later slice.
 
-    ``pullable`` is reported as False even though ``flm pull <tag>``
-    works inside the toolbox: the existing ``POST /api/models/{id}/pull``
-    handler resolves a HuggingFace repo + filename, which FLM tags don't
-    carry. Wiring an FLM-aware pull path is a follow-up; until then,
-    operators run ``flm pull`` manually via the toolbox container and
-    the catalog will flip ``downloaded`` to True on the next probe-cache
-    refresh (process restart).
+    ``pullable`` is True for FLM tags — the pull route (routes/models.py)
+    detects FLM ids via :func:`hal0.providers.flm.is_flm_tag` and dispatches
+    to :func:`hal0.registry.pull.run_flm_pull`, which shells ``flm pull
+    <tag>`` inside the toolbox image with the same bind mount the slot
+    uses. After a successful pull we reset the FLM probe cache so the
+    next ``/api/capabilities`` GET flips ``downloaded`` to True without a
+    process restart.
     """
     if capability not in {"chat", "embed"}:
         return []
@@ -617,7 +617,7 @@ def _flm_rows_for_capability(capability: str) -> list[dict[str, Any]]:
                 "size_gb": size_gb,
                 "capabilities": reported_caps,
                 "downloaded": entry["installed"],
-                "pullable": False,
+                "pullable": True,
             }
         )
     return out

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -75,6 +75,28 @@ _RUNTIME_TO_HOST_BACKENDS: dict[str, tuple[str, ...]] = {
 _FLM_TOOLBOX_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-flm:v1"
 
 
+# FLM tags hidden from the dashboard catalog because of upstream FLM
+# bugs we've reproduced end-to-end on the bundled toolbox image. The
+# slot would still ``state=ready`` for these tags (the health probe
+# passes), but a real ``/v1/chat/completions`` 500s with the recorded
+# error, so surfacing them in the picker is a trap. Revisit after each
+# toolbox-image bump: re-run ``tests/harness`` flm-chat-utf8 and shrink
+# this set if upstream has fixed.
+#
+# Each entry: {tag: short reason}. The reason becomes the next reader's
+# search term when checking whether to remove the entry.
+_FLM_BROKEN_TAGS: dict[str, str] = {
+    # 2026-05-21 (toolbox FLM v0.9.42, model_list.json pin
+    # v0.9.22-faster-q4-1): any prompt that elicits non-ASCII output
+    # returns ``[json.exception.type_error.316] invalid UTF-8 byte at
+    # index 0: 0x..``. nlohmann/json is rejecting a content string that
+    # starts mid-multibyte-UTF-8, so FLM's qwen3 0.6B decoder is emitting
+    # partial token bytes. qwen3:1.7b and qwen3.5:* on the SAME tag
+    # don't repro — bug is model-weight-specific, not tag-wide.
+    "qwen3:0.6b": "FLM v0.9.42 emits invalid UTF-8 on non-ASCII output (see hal0_flm_chat_utf8_error)",
+}
+
+
 def _flm_image_present() -> bool:
     """True iff the FLM toolbox image is already pulled locally.
 
@@ -597,6 +619,8 @@ def _flm_rows_for_capability(capability: str) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     for entry in flm_served_models():
         if capability not in entry["capabilities"]:
+            continue
+        if entry["tag"] in _FLM_BROKEN_TAGS:
             continue
         # Filter capabilities reported to the dashboard down to the
         # in-scope subset; otherwise an "stt" tag would leak through on a

--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -32,6 +32,7 @@ haloai's lib/providers/flm.py.
 from __future__ import annotations
 
 import os
+import re
 from typing import Any
 
 import httpx
@@ -208,9 +209,13 @@ class FLMProvider(Provider):
 
         # Only the model cache is bind-mounted. FLM hardcodes
         # ~/.config/flm/models internally; map our hal0-managed cache
-        # to that path.
+        # to that path. The toolbox image runs as the non-root ``hal0``
+        # user (uid 1000, HOME=/var/lib/hal0), so ~/.config resolves to
+        # /var/lib/hal0/.config — NOT /root/.config. Mounting at the
+        # wrong HOME would silently drop every pulled model into the
+        # container's writable overlay and lose it on exit.
         mounts: list[tuple[str, str]] = [
-            (flm_models, "/root/.config/flm/models"),
+            (flm_models, "/var/lib/hal0/.config/flm/models"),
         ]
 
         # Build the argv passed to the image's ENTRYPOINT. The image runs
@@ -424,17 +429,27 @@ def _probe_flm_catalog() -> list[dict[str, Any]] | None:
     ``flm list`` reads the bundled ``model_list.json`` and never touches
     NPU hardware — keeping the device flag out makes the probe usable on
     dev hosts without XDNA passthrough.
+
+    The hal0-managed FLM models cache is bind-mounted at the same path
+    the slot's container_spec uses (``~/.config/flm/models`` resolved
+    against the toolbox image's non-root ``hal0`` user, HOME=/var/lib/hal0).
+    Without it ``flm list`` runs against an empty overlay and reports
+    every model as not-installed — masking weights the host already has
+    on disk.
     """
     import json
     import subprocess
 
     image = os.environ.get("HAL0_TOOLBOX_IMAGE_FLM", _DEFAULT_FLM_IMAGE)
+    flm_models = os.environ.get("HAL0_FLM_MODELS_DIR") or _DEFAULT_FLM_MODELS_DIR
     cmd = [
         "docker",
         "run",
         "--rm",
         "--security-opt",
         "apparmor=unconfined",
+        "-v",
+        f"{flm_models}:/var/lib/hal0/.config/flm/models",
         image,
         "list",
         "-j",
@@ -522,3 +537,76 @@ def reset_flm_catalog_cache() -> None:
     global _FLM_CATALOG_CACHE, _FLM_PROBE_OK
     _FLM_CATALOG_CACHE = None
     _FLM_PROBE_OK = False
+
+
+def is_flm_tag(model_id: str) -> bool:
+    """True iff ``model_id`` matches an FLM-served tag.
+
+    Routing helper for the pull endpoint: FLM tags are Ollama-style
+    ``family:size`` ids (``qwen3:0.6b``, ``deepseek-r1:8b``, …) and
+    don't carry HF coords, so the generic HF pull path can't pull them.
+    Looks them up against the cached :func:`flm_served_models` so we
+    only treat ids the toolbox actually knows about — a stray ``foo:bar``
+    falls through to the HF resolver and gets a proper 422.
+    """
+    if ":" not in model_id:
+        return False
+    return any(m["tag"] == model_id for m in flm_served_models())
+
+
+def flm_pull_command(tag: str) -> tuple[list[str], str]:
+    """Return ``(argv, host_models_dir)`` for an ``flm pull <tag>`` run.
+
+    Mirrors :func:`_probe_flm_catalog` argv shape (apparmor unconfined,
+    same bind mount target) but invokes ``pull`` instead of ``list``.
+    The host_models_dir is returned so callers can locate the on-disk
+    weights for registry/path bookkeeping after the pull finishes.
+
+    Like the slot's container_spec we do NOT pass ``--device``: ``flm
+    pull`` downloads files; it doesn't touch the NPU. Keeping the
+    device flag out lets the pull run on dev hosts without XDNA
+    passthrough (useful for tests).
+    """
+    image = os.environ.get("HAL0_TOOLBOX_IMAGE_FLM", _DEFAULT_FLM_IMAGE)
+    flm_models = os.environ.get("HAL0_FLM_MODELS_DIR") or _DEFAULT_FLM_MODELS_DIR
+    argv = [
+        "docker",
+        "run",
+        "--rm",
+        "--security-opt",
+        "apparmor=unconfined",
+        "-v",
+        f"{flm_models}:/var/lib/hal0/.config/flm/models",
+        image,
+        "pull",
+        tag,
+    ]
+    return argv, flm_models
+
+
+_FLM_PROGRESS_RE = re.compile(
+    r"Downloading:\s*([0-9.]+)%\s*\(([0-9.]+)\s*([KMG]?)B\s*/\s*([0-9.]+)\s*([KMG]?)B\)"
+)
+
+
+def parse_flm_progress(line: str) -> tuple[int, int] | None:
+    """Extract ``(bytes_downloaded, bytes_total)`` from a ``flm pull`` line.
+
+    FLM emits progress like::
+
+        [FLM]  Downloading: 38.8% (253.0MB / 652.1MB)
+
+    Returns ``None`` on lines that don't match (status, hash check,
+    blank, etc.) so the caller can skip them without branching.
+    """
+    m = _FLM_PROGRESS_RE.search(line)
+    if not m:
+        return None
+    _pct, cur, cur_unit, tot, tot_unit = m.groups()
+    units = {"": 1, "K": 1024, "M": 1024**2, "G": 1024**3}
+    try:
+        bytes_downloaded = int(float(cur) * units[cur_unit])
+        bytes_total = int(float(tot) * units[tot_unit])
+    except (KeyError, ValueError):
+        return None
+    return bytes_downloaded, bytes_total

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -450,6 +450,244 @@ def _register_pulled(
     registry.update(model_id, updates)
 
 
+async def run_flm_pull(
+    job: PullJob,
+    *,
+    tag: str,
+    registry: ModelRegistry,
+) -> None:
+    """Background-task body: shell ``flm pull <tag>`` in the toolbox image.
+
+    Mirrors :func:`run_pull`'s state machine (queued → running →
+    {completed, failed, cancelled}) so the existing SSE / status routes
+    work unchanged. Differs in two ways:
+
+      * Bytes come from parsing FLM's stdout lines (no Content-Length
+        header to lean on) — see :func:`hal0.providers.flm.parse_flm_progress`.
+      * No sha256 is computed here: FLM verifies file hashes internally
+        and refuses to use mismatched weights. Re-hashing would just
+        double-read multi-GB files for the same guarantee.
+
+    Cancellation works via SIGTERM on the docker CLI subprocess — docker
+    propagates that to the container and ``flm pull`` aborts. The partial
+    files are left on disk; FLM's next pull deletes & redownloads them
+    (it checks file sizes against the manifest before reusing).
+
+    On success the FLM probe cache is reset so the next ``/api/capabilities``
+    GET flips this tag's ``downloaded`` flag to True without an api restart.
+    """
+    # Local import to keep providers.flm's docker subprocess out of the
+    # base pull module's import graph (tests pull this module in
+    # environments without docker).
+    from hal0.providers.flm import (
+        flm_pull_command,
+        parse_flm_progress,
+        reset_flm_catalog_cache,
+    )
+
+    job.state = "running"
+    job.started_at = time.time()
+    job._signal()
+
+    argv, host_models_dir = flm_pull_command(tag)
+    proc: asyncio.subprocess.Process | None = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        assert proc.stdout is not None
+        last_emit = time.monotonic()
+        while True:
+            if job.cancel_requested:
+                proc.terminate()
+                with contextlib.suppress(asyncio.TimeoutError):
+                    await asyncio.wait_for(proc.wait(), timeout=10.0)
+                if proc.returncode is None:
+                    proc.kill()
+                    await proc.wait()
+                job.state = "cancelled"
+                job.finished_at = time.time()
+                job._signal()
+                return
+            try:
+                raw = await asyncio.wait_for(proc.stdout.readline(), timeout=1.0)
+            except TimeoutError:
+                # No new line in 1s — loop back so cancellation observes promptly.
+                continue
+            if not raw:
+                break
+            line = raw.decode("utf-8", errors="replace")
+            parsed = parse_flm_progress(line)
+            if parsed is not None:
+                downloaded, total = parsed
+                job.bytes_downloaded = downloaded
+                if total > job.bytes_total:
+                    job.bytes_total = total
+                now = time.monotonic()
+                if (now - last_emit) >= _SSE_MIN_INTERVAL_S:
+                    last_emit = now
+                    job._signal()
+
+        await proc.wait()
+        if proc.returncode != 0:
+            raise PullError(
+                f"flm pull {tag!r} exited with status {proc.returncode}",
+                details={"tag": tag, "exit_code": proc.returncode},
+            )
+
+        # Refresh the catalog so subsequent /api/capabilities picks up
+        # the new installed=true flag without a process restart.
+        reset_flm_catalog_cache()
+
+        # Best-effort path bookkeeping. FLM stores each tag's weights at
+        # ``<host_models_dir>/<HF-repo-name>/`` — we resolve the dir from
+        # the FLM model_list lookup when available, falling back to the
+        # bare host dir so a missing entry doesn't fail the job.
+        final_path = _flm_install_path(host_models_dir, tag) or host_models_dir
+        size_bytes = _dir_size(final_path)
+        if job.bytes_total <= 0 and size_bytes > 0:
+            job.bytes_total = size_bytes
+        if job.bytes_downloaded < size_bytes:
+            job.bytes_downloaded = size_bytes
+        job.path = str(final_path)
+
+        # Register an FLM tag so the registry surfaces it for downstream
+        # consumers (catalog, slot model resolution). hf_repo/filename
+        # stay empty — FLM tags route through the toolbox, not HF directly.
+        _register_flm_pulled(
+            registry,
+            tag=tag,
+            path=str(final_path),
+            size_bytes=size_bytes,
+        )
+
+        job.state = "completed"
+        job.finished_at = time.time()
+        job._signal()
+        log.info(
+            "model.pull_flm_completed",
+            extra={"tag": tag, "path": str(final_path), "bytes": size_bytes},
+        )
+    except asyncio.CancelledError:
+        if proc is not None and proc.returncode is None:
+            proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.wait()
+        job.state = "cancelled"
+        job.finished_at = time.time()
+        job._signal()
+        raise
+    except Hal0Error as exc:
+        job.state = "failed"
+        job.error = exc.message
+        job.error_code = exc.code
+        job.finished_at = time.time()
+        job._signal()
+        log.warning("model.pull_flm_failed", extra={"tag": tag, "error": exc.message})
+    except Exception as exc:
+        job.state = "failed"
+        job.error = f"{type(exc).__name__}: {exc}"
+        job.error_code = "model.pull_failed"
+        job.finished_at = time.time()
+        job._signal()
+        log.exception("model.pull_flm_unexpected_error", extra={"tag": tag})
+
+
+def _flm_install_path(host_models_dir: str, tag: str) -> str | None:
+    """Look up the on-disk subdir FLM uses for ``tag``, or None if unknown.
+
+    Walks the toolbox image's bundled ``model_list.json`` schema (family
+    → variants → name=HF-repo). We probe it via ``flm_served_models``
+    indirectly: the cached entry exposes a ``family`` field but not the
+    HF name, so we read FLM's own JSON by shelling ``flm list -j`` and
+    matching tag → ``name``. The probe is cached, so this lookup is
+    O(1) after the first call.
+    """
+    from hal0.providers.flm import _probe_flm_catalog
+
+    models = _probe_flm_catalog()
+    if not models:
+        return None
+    for entry in models:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("model") == tag or entry.get("name") == tag:
+            # The "name" field on the flat list is the same as model.
+            # The HF repo name lives only in the nested model_list.json
+            # tree; the flat list flattens it into ``files`` + ``url``.
+            # Extract from the ``url`` field, which looks like
+            # ``https://huggingface.co/FastFlowLM/Qwen3-0.6B-NPU2/resolve/...``.
+            url = entry.get("url") or ""
+            parts = url.split("/")
+            try:
+                idx = parts.index("huggingface.co")
+                repo_name = parts[idx + 2]  # owner/<repo>
+                return str(Path(host_models_dir) / repo_name)
+            except (ValueError, IndexError):
+                return None
+    return None
+
+
+def _dir_size(path: str | Path) -> int:
+    """Sum file sizes under ``path``; 0 if path is missing/unreadable."""
+    p = Path(path)
+    if not p.exists():
+        return 0
+    total = 0
+    try:
+        for child in p.rglob("*"):
+            if child.is_file():
+                with contextlib.suppress(OSError):
+                    total += child.stat().st_size
+    except OSError:
+        return total
+    return total
+
+
+def _register_flm_pulled(
+    registry: ModelRegistry,
+    *,
+    tag: str,
+    path: str,
+    size_bytes: int,
+) -> None:
+    """Upsert a registry entry for an FLM-pulled model.
+
+    FLM tags don't carry HF coords from a hal0 perspective (the toolbox
+    image's ``flm pull`` resolves them itself), so ``hf_repo`` and
+    ``hf_filename`` stay empty. ``metadata.runtime = "flm"`` flags the
+    entry so other code (slot pick, model resolution) can route it to
+    the FLM provider without re-deriving from the id.
+    """
+    updates: dict[str, Any] = {
+        "path": path,
+        "size_bytes": size_bytes,
+        "metadata": {"runtime": "flm"},
+    }
+    try:
+        existing = registry.get(tag)
+    except ModelNotFound:
+        registry.add(
+            Model(
+                id=tag,
+                name=tag,
+                path=path,
+                size_bytes=size_bytes,
+                capabilities=["chat"],
+                backends=["npu"],
+                metadata={"runtime": "flm"},
+            )
+        )
+        return
+    merged_meta = dict(existing.metadata)
+    merged_meta["runtime"] = "flm"
+    updates["metadata"] = merged_meta
+    registry.update(tag, updates)
+
+
 __all__ = [
     "PullError",
     "PullInvalidSource",
@@ -459,5 +697,6 @@ __all__ = [
     "get_job",
     "hf_download_url",
     "make_job",
+    "run_flm_pull",
     "run_pull",
 ]

--- a/tests/capabilities/test_catalog_flm_blacklist.py
+++ b/tests/capabilities/test_catalog_flm_blacklist.py
@@ -48,9 +48,7 @@ def flm_entries() -> list[dict[str, Any]]:
 def test_broken_tag_hidden_from_chat_rows(
     monkeypatch: pytest.MonkeyPatch, flm_entries: list[dict[str, Any]]
 ) -> None:
-    monkeypatch.setattr(
-        "hal0.providers.flm.flm_served_models", lambda: flm_entries
-    )
+    monkeypatch.setattr("hal0.providers.flm.flm_served_models", lambda: flm_entries)
     rows = catalog._flm_rows_for_capability("chat")
 
     ids = {row["id"] for row in rows}

--- a/tests/capabilities/test_catalog_flm_blacklist.py
+++ b/tests/capabilities/test_catalog_flm_blacklist.py
@@ -1,0 +1,73 @@
+"""Regression for the FLM broken-tag blacklist.
+
+When the FLM toolbox bundles a model whose chat decoder is known-broken
+upstream (current case: ``qwen3:0.6b`` returning HTTP 500 with
+``invalid UTF-8 byte`` on any non-ASCII output), the dashboard picker
+must not surface it. The slot would otherwise reach ``state=ready`` —
+the health probe with ``max_tokens=1`` doesn't trigger the upstream
+crash — and a real chat would 500, which is a trap for the operator.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hal0.capabilities import catalog
+
+
+@pytest.fixture
+def flm_entries() -> list[dict[str, Any]]:
+    """Three FLM-served rows: a broken tag + a good chat + a good embed."""
+    return [
+        {
+            "tag": "qwen3:0.6b",
+            "size_bytes": 600_000_000,
+            "footprint_gb": 0.66,
+            "capabilities": ["chat"],
+            "installed": True,
+        },
+        {
+            "tag": "gemma3:1b",
+            "size_bytes": 1_000_000_000,
+            "footprint_gb": 1.2,
+            "capabilities": ["chat"],
+            "installed": True,
+        },
+        {
+            "tag": "embed-gemma:300m",
+            "size_bytes": 300_000_000,
+            "footprint_gb": 0.4,
+            "capabilities": ["embed"],
+            "installed": False,
+        },
+    ]
+
+
+def test_broken_tag_hidden_from_chat_rows(
+    monkeypatch: pytest.MonkeyPatch, flm_entries: list[dict[str, Any]]
+) -> None:
+    monkeypatch.setattr(
+        "hal0.providers.flm.flm_served_models", lambda: flm_entries
+    )
+    rows = catalog._flm_rows_for_capability("chat")
+
+    ids = {row["id"] for row in rows}
+    assert "qwen3:0.6b" not in ids, (
+        "blacklist failure: qwen3:0.6b must not surface in the chat picker "
+        "(see _FLM_BROKEN_TAGS in catalog.py)"
+    )
+    assert "gemma3:1b" in ids, "non-broken chat tags must still surface"
+
+
+def test_broken_tag_set_is_documented(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each entry must carry a reason — that's the next reader's recheck cue."""
+    for tag, reason in catalog._FLM_BROKEN_TAGS.items():
+        assert tag and ":" in tag, f"entry {tag!r} is not an FLM tag"
+        assert reason and len(reason) > 10, (
+            f"entry {tag!r} has no reason — the next reader can't tell "
+            f"whether the blacklist still applies after a toolbox bump"
+        )

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -146,8 +146,28 @@ const chatOutputEl = ref(null)
 
 async function loadChatModels() {
   try {
-    const r = await api('/v1/models')
-    chatModels.value = (r?.data || []).map((m) => m.id)
+    // The Test chat panel POSTs to /v1/chat/completions, so we must show
+    // only chat-capable upstreams in the dropdown. /v1/models is a flat
+    // aggregation across every slot (embed, rerank, stt, tts included)
+    // with no capability tag — relying on its order put the embed model
+    // at the top of the list as default. We instead derive the set of
+    // chat-capable slots by joining /api/slots (slot → loaded model id)
+    // with /api/capabilities (model id → capabilities) and filter
+    // /v1/models' rows by owned_by ∈ chat-capable slots.
+    const [models, slots, cap] = await Promise.all([
+      api('/v1/models'),
+      api('/api/slots').catch(() => []),
+      api('/api/capabilities').catch(() => ({ catalogs: {} })),
+    ])
+    const chatModelIds = new Set(
+      (cap?.catalogs?.chat?.chat ?? []).map((m) => m.id),
+    )
+    const chatSlots = new Set(
+      (slots || []).filter((s) => chatModelIds.has(s.model_id)).map((s) => s.name),
+    )
+    chatModels.value = (models?.data || [])
+      .filter((m) => chatSlots.has(m.owned_by))
+      .map((m) => m.id)
     if (!chatModel.value && chatModels.value.length) {
       // Prefer a small fast model for the first interaction.
       const preferred = chatModels.value.find((m) =>

--- a/ui/tests/e2e/specs/dashboard.spec.ts
+++ b/ui/tests/e2e/specs/dashboard.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * dashboard.spec.ts — Test chat panel: chat dropdown filters non-chat slots.
+ *
+ * Regression for: pre-fix, the dropdown rendered every model `/v1/models`
+ * returned (embed, rerank, stt, tts included) and defaulted to data[0],
+ * which was the embed slot's model. Post-fix, the dropdown intersects
+ * /v1/models with chat-capable slots derived from /api/slots ×
+ * /api/capabilities.
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+
+test('Test chat dropdown lists only chat-capable upstreams', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  // Three upstreams: an embed slot, a chat slot, an stt slot. Only the
+  // chat one should survive the filter.
+  await page.route('**/v1/models', (route) =>
+    json(route, {
+      object: 'list',
+      data: [
+        { id: 'nomic-embed.gguf', object: 'model', owned_by: 'embed' },
+        { id: 'qwen3-chat.gguf', object: 'model', owned_by: 'primary' },
+        { id: 'moonshine-base', object: 'model', owned_by: 'stt' },
+      ],
+    }),
+  )
+  await page.route('**/api/slots', (route) =>
+    json(route, [
+      { name: 'embed', model_id: 'nomic-embed-text-v1.5-q8_0' },
+      { name: 'primary', model_id: 'qwen3-chat-id' },
+      { name: 'stt', model_id: 'moonshine-base-en' },
+    ]),
+  )
+  await page.route('**/api/capabilities', (route) =>
+    json(route, {
+      backends: [],
+      catalogs: {
+        chat: {
+          chat: [{ id: 'qwen3-chat-id', capabilities: ['chat'] }],
+        },
+      },
+      selections: {},
+    }),
+  )
+
+  await page.goto('/')
+
+  const dropdown = page.locator('select.chat-model')
+  await expect(dropdown).toBeVisible()
+  // Wait for the post-mount fetch to settle and the options to populate.
+  await expect(dropdown.locator('option')).toHaveCount(1, { timeout: 5_000 })
+  await expect(dropdown.locator('option').first()).toHaveText('qwen3-chat.gguf')
+
+  // Selected value mirrors the only chat-capable model.
+  await expect(dropdown).toHaveValue('qwen3-chat.gguf')
+
+  // Negative assertions: embed/stt models must not leak in.
+  await expect(dropdown).not.toContainText('nomic-embed')
+  await expect(dropdown).not.toContainText('moonshine')
+})
+
+test('Test chat dropdown is empty when no chat-capable slot exists', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  // Pre-fix this test would fail because the embed model would leak in
+  // and become the default — sending /v1/chat/completions against an
+  // embedding endpoint.
+  await page.route('**/v1/models', (route) =>
+    json(route, {
+      object: 'list',
+      data: [{ id: 'nomic-embed.gguf', object: 'model', owned_by: 'embed' }],
+    }),
+  )
+  await page.route('**/api/slots', (route) =>
+    json(route, [{ name: 'embed', model_id: 'nomic-embed-text-v1.5-q8_0' }]),
+  )
+  await page.route('**/api/capabilities', (route) =>
+    json(route, {
+      backends: [],
+      catalogs: { chat: { chat: [] } },
+      selections: {},
+    }),
+  )
+
+  await page.goto('/')
+
+  const dropdown = page.locator('select.chat-model')
+  await expect(dropdown).toBeVisible()
+  // "No models" placeholder option is the only entry.
+  await expect(dropdown.locator('option')).toHaveCount(1)
+  await expect(dropdown.locator('option').first()).toHaveText('No models')
+})


### PR DESCRIPTION
## Summary

Hide `qwen3:0.6b` from the dashboard NPU picker. The FLM toolbox image (FLM v0.9.42) ships a qwen3:0.6b build whose chat decoder emits partial UTF-8 byte sequences whenever the response contains non-ASCII output, and the response builder 500s with `[json.exception.type_error.316] invalid UTF-8 byte at index 0: 0x..`. The slot still reaches `state=ready` (the health probe uses `max_tokens=1` and never elicits the bug), so the operator only finds out on a real chat — that's a trap.

## Stacked on

[Hal0ai/hal0#89](https://github.com/Hal0ai/hal0/pull/89) — uses the new `pullable=True` plumbing that #89 introduces. Will rebase onto `main` when #89 merges.

## Repro (direct against the toolbox, bypassing hal0)

```
docker run … ghcr.io/hal0ai/hal0-toolbox-flm:v1 serve qwen3:0.6b …
curl -X POST .../v1/chat/completions \
  -d '{"model":"qwen3:0.6b","messages":[{"role":"user",
       "content":"Say hello in Chinese"}],"max_tokens":16}'
# → body code:500, invalid UTF-8 byte 0xBC
```

## Matrix (same toolbox image, same prompt)

| Model | Status |
|---|---|
| `qwen3:0.6b` | ❌ invalid UTF-8 byte |
| `qwen3:1.7b` | ✅ emits 你好 cleanly (same `v0.9.22-faster-q4-1` HF tag) |
| `qwen3.5:4b` | ✅ |
| `phi4-mini-it:4b` | ✅ |
| `gemma3:1b` | ✅ |
| `deepseek-r1:8b` | ✅ |

So it's **model-weight-specific** upstream, not tag-wide or toolbox-wide. Only `qwen3:0.6b` is blacklisted.

## Mechanism

* `_FLM_BROKEN_TAGS: dict[str, str]` in `src/hal0/capabilities/catalog.py` — keyed by FLM tag, value is a short recheck-cue reason. The `_flm_rows_for_capability` loop skips tags in the set.
* New test `tests/capabilities/test_catalog_flm_blacklist.py` covers both the skip behaviour and a "every entry has a documented reason" guardrail so the dict doesn't accumulate undocumented entries.

## Recheck protocol

After each `hal0-toolbox-flm` image bump:
1. Spin the toolbox with each blacklisted tag.
2. Run the matrix prompt above.
3. Drop the entry from `_FLM_BROKEN_TAGS` if upstream fixed it.

## Test plan

- [x] `pytest tests/capabilities/test_catalog_flm_blacklist.py` — both pass
- [x] Verified on hal0 LXC: `/api/capabilities` no longer surfaces `qwen3:0.6b`; other FLM tags (gemma3:1b, phi4-mini-it:4b, qwen3:1.7b, qwen3.5:4b, etc.) still surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)