### PR TITLE
fix(ui/slots): read slot.model_id, filter inline picker by backend

### DIFF
--- a/ui/src/views/Slots.vue
+++ b/ui/src/views/Slots.vue
@@ -233,7 +233,7 @@ function openEdit(slot) {
   editingSlot.value = slot
   const initial = {
     backend:        slot.backend ?? 'vulkan',
-    model:          slot.model ?? '',
+    model:          slot.model_id ?? slot.model ?? '',
     ctx_size:       slot.ctx_size ?? 4096,
     auto_start:     slot.auto_start ?? false,
     // Advanced — Model
@@ -653,7 +653,7 @@ const SLOT_TYPES = ['llama-server', 'flm', 'moonshine', 'kokoro']
               <span class="state-dot" :class="stateClass(slot.status)" :title="slot.status" aria-hidden="true" />
               <div class="slot-names">
                 <span class="slot-name">{{ slot.name }}</span>
-                <span class="slot-model" v-if="slot.model">{{ slot.model }}</span>
+                <span class="slot-model" v-if="slot.model_id || slot.model">{{ slot.model_id || slot.model }}</span>
                 <span class="slot-model text-faint" v-else>no model loaded</span>
               </div>
             </div>
@@ -674,7 +674,7 @@ const SLOT_TYPES = ['llama-server', 'flm', 'moonshine', 'kokoro']
             <!-- Right: actions -->
             <div class="slot-actions">
               <!-- Load (when no model loaded) -->
-              <template v-if="!slot.model || slot.status === 'offline'">
+              <template v-if="!(slot.model_id || slot.model) || slot.status === 'offline'">
                 <select
                   class="model-select"
                   :value="slot._selectedModel"
@@ -682,7 +682,7 @@ const SLOT_TYPES = ['llama-server', 'flm', 'moonshine', 'kokoro']
                   :aria-label="`Select model for slot ${slot.name}`"
                 >
                   <option value="">Select model…</option>
-                  <option v-for="m in models" :key="m.id" :value="m.id">
+                  <option v-for="m in filterCompatibleModels(slot.backend)" :key="m.id" :value="m.id">
                     {{ m.name ?? m.id }}{{ m.size_gb ? ` — ${m.size_gb}GB` : '' }} {{ modelFitLabel(m) }}
                   </option>
                 </select>


### PR DESCRIPTION
## Summary

Two compounding bugs in `views/Slots.vue`, both rooted in reading the wrong field from `/api/slots`. Surfaced together because the symptom looks like one issue ("primary slot came unloaded + image models in dropdown") but the root causes are independent.

### Bug 1 — wrong field name (`slot.model` vs `slot.model_id`)

`/api/slots` returns `slot.model_id`; there is no `slot.model` field. But the template referenced `slot.model` in three places:

```vue
<span class="slot-model" v-if="slot.model">{{ slot.model }}</span>
<template v-if="!slot.model || slot.status === 'offline'">    <!-- Load gate -->
model: slot.model ?? '',                                       <!-- edit prefill -->
```

So `!slot.model` was `true` for every slot, including loaded ones. The "Load (when no model loaded)" template branch always rendered the inline model dropdown instead of the running-state branch with Restart + Unload buttons. Visible symptom: a primary slot serving qwen3.6-27b looked "unloaded" in the dashboard.

### Bug 2 — inline Load picker had no model filter

The inline dropdown iterated bare `models` with no backend filter, no capability filter, despite the Create + Edit modals already filtering through `filterCompatibleModels(backend)`. Image models (`backend=comfyui`), NPU FLM tags, and others leaked into a vulkan chat slot's picker.

## Fix

* Read `slot.model_id || slot.model` everywhere (`slot.model` fallback is defensive — `stores/system.js` merges `/api/status` and `/api/slots`, and a future shape change to status could put `model` back on the row).
* Inline picker now uses `filterCompatibleModels(slot.backend)`.

## Known follow-up

A capability leak remains — embed and rerank models also share `backend=vulkan` with chat models, so they will still appear in primary's offline picker. That's the **slot-capability ADR** (step 6 of the 2026-05-21 handoff): an explicit `slot.capabilities = ["chat"]` field is the proper fix. Being scoped separately.

## Test plan

- [x] Verified live on hal0 LXC after rebuild + `systemctl restart hal0-api`: `/api/slots` returns `model_id` for every slot; all six loaded slots (embed, embed-rerank, nano, primary, stt, tts) render Restart + Unload buttons; the inline Load picker (visible only on offline slots) is backend-scoped.
- [ ] CI green on Playwright (the new dashboard.spec.ts in PR #89 covers Test chat dropdown; this PR's surface isn't covered yet — would benefit from a spec but doing so is out of scope for the immediate fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)