### PR TITLE
docs(readme): wordmark banner + hal0.dev links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
-# hal0
+<div align="center">
 
-**Open-source home AI inference platform.**
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./ui/public/brand/logo-halo-dark.svg">
+  <img src="./ui/public/brand/logo-halo-light.svg" alt="hal0" width="220">
+</picture>
+
+### Open-source home AI inference platform
+
+[hal0.dev](https://hal0.dev) · [Install](https://hal0.dev/docs/install/) · [Docs](https://hal0.dev/docs/)
+
+</div>
+
+---
 
 hal0 is a polished, reliable inference platform for running LLMs at home.
 It manages model slots, exposes an OpenAI-compatible API, and ships with


### PR DESCRIPTION
## Summary

- Add hal0 wordmark banner at the top of the README (light/dark variants via `<picture>`).
- Add a quick-link strip pointing to hal0.dev, install docs, and docs root.

## Why

Part of an org-wide cleanup. The org `Hal0ai` now has a profile README and consistent metadata across `hal0`, `hal0-web`, and `amd-strix-halo-toolboxes`; the repo READMEs needed a visible brand element to match.

## Test plan

- [x] Logo files referenced (`ui/public/brand/logo-halo-{light,dark}.svg`) already exist in-repo.
- [ ] Verify GitHub renders the `<picture>` block with dark-mode swap.