### PR TITLE
feat(installer): one-line bootstrap.sh — fetch, verify, hand off

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -72,7 +72,7 @@ home installs, OpenAI-compatible inference, bundled OpenWebUI chat.
   - `WEBUI_AUTH=False` (LAN-only home install)
   - State at `/var/lib/hal0/openwebui/`
 - **One-line installer**
-  - Sensible defaults, non-interactive (`curl -fsSL hal0.dev/install | bash`)
+  - Sensible defaults, non-interactive (`curl -fsSL hal0.dev/install.sh | bash`)
   - Pre-flight checks, hardware probe, lay down `/etc/hal0/slots/{primary,embed,stt,tts}.toml`
   - Pulls toolbox images in background
   - First-run wizard in dashboard for default-model pick
@@ -777,7 +777,7 @@ own decisions before relevant milestones:
 
 ## 18. Definition of done — v1.0
 
-- [ ] Fresh LXC: `curl -fsSL hal0.dev/install | bash` → install completes in <5 min — *unmeasured against a real wipe*
+- [ ] Fresh LXC: `curl -fsSL hal0.dev/install.sh | bash` → install completes in <5 min — *unmeasured against a real wipe*
 - [x] Dashboard at `:8080`, OpenWebUI at `:3001`, both reachable
 - [x] FirstRun wizard downloads a model, assigns to slot, slot reports ready — *UI flow unblocked (PR #7 + #12); pending live model-pull measurement*
 - [ ] Chat works end-to-end (OpenWebUI → hal0 → llama.cpp slot → response) — *stub-proxy CI green (PR #4); real run gated on toolbox image pull (task #25)*

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ command on any modern Linux box.
 - **OpenWebUI bundled** — prewired chat interface at `:3001`, no setup
 - **Image generation** — bundled ComfyUI provider with curated SDXL /
   SD 1.5 / Flux models; OpenAI-compatible `/v1/images/generations`
-- **One-line install** — `curl -fsSL https://hal0.dev/install | bash`
+- **One-line install** — `curl -fsSL https://hal0.dev/install.sh | bash`
   (`--models-dir=PATH` or `HAL0_MODELS_DIR=PATH` redirects HuggingFace
-  pulls off `/var/lib/hal0/models`). Until the `hal0.dev/install`
+  pulls off `/var/lib/hal0/models`). Until the `hal0.dev/install.sh`
   endpoint is wired, the supported entry point is
   `git clone` + `sudo bash installer/install.sh` — see
   [`installer/README.md`](./installer/README.md).

--- a/installer/README.md
+++ b/installer/README.md
@@ -12,8 +12,8 @@ sudo bash installer/install.sh
 sudo bash installer/install.sh --models-dir=/mnt/ai-models
 ```
 
-> The one-liner `curl -fsSL https://hal0.dev/install | bash` ships
-> with v1.0 once the `hal0.dev/install` endpoint is wired; until then,
+> The one-liner `curl -fsSL https://hal0.dev/install.sh | bash` ships
+> with v1.0 once the `hal0.dev/install.sh` endpoint is wired; until then,
 > `git clone` + `sudo bash` is the supported entry point.
 
 The toolbox container images (`ghcr.io/hal0ai/hal0-toolbox-*:v1`) are

--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# ⚠️  This file is MIRRORED between two locations and must stay identical:
+#       - Hal0ai/hal0:installer/bootstrap.sh   (canonical)
+#       - Hal0ai/hal0-web:public/install.sh    (served at https://hal0.dev/install.sh)
+#     When you edit one, sync the other in the same PR.
+#
+# hal0 one-line installer — fetch, verify, unpack, hand off to install.sh.
+#
+# Designed to be piped from curl:
+#
+#   curl -fsSL https://hal0.dev/install.sh | sudo bash
+#   curl -fsSL https://hal0.dev/install.sh | sudo bash -s -- --no-tls --models-dir=/data/models
+#
+# Or downloaded and run directly:
+#
+#   curl -fsSLO https://hal0.dev/install.sh
+#   sudo bash install.sh
+#
+# Env overrides:
+#   HAL0_RELEASES_URL          full URL to a hal0.releases.v1 manifest
+#                              (default: GitHub Releases /latest/download/stable.json)
+#   HAL0_CHANNEL               channel name when using the default URL (default: stable)
+#   HAL0_UPDATE_SKIP_COSIGN=1  skip cosign verify (only honored when cosign
+#                              isn't installed; emits a loud warning)
+#   HAL0_BOOTSTRAP_KEEP_TMP=1  don't delete the work directory on exit
+#                              (debugging the unpacked tree)
+#
+# This script is the trust boundary for the one-line install — it never
+# executes anything from the manifest or the tarball until cosign (or
+# the documented skip) has verified the signature against the workflow
+# OIDC identity in the manifest.
+#
+# Schema reference: docs/release-manifest.md (hal0.releases.v1).
+
+set -euo pipefail
+IFS=$'\n\t'
+
+HAL0_CHANNEL="${HAL0_CHANNEL:-stable}"
+HAL0_RELEASES_URL="${HAL0_RELEASES_URL:-https://github.com/Hal0ai/hal0/releases/latest/download/${HAL0_CHANNEL}.json}"
+
+# ── tiny output helpers ────────────────────────────────────────────────────
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+    _C_DIM=$'\033[2m'; _C_RED=$'\033[31m'; _C_YEL=$'\033[33m'
+    _C_GRN=$'\033[32m'; _C_BLD=$'\033[1m'; _C_RST=$'\033[0m'
+else
+    _C_DIM=""; _C_RED=""; _C_YEL=""; _C_GRN=""; _C_BLD=""; _C_RST=""
+fi
+info() { printf '%s» %s%s\n'   "${_C_DIM}" "$*" "${_C_RST}"; }
+ok()   { printf '%s✓ %s%s\n'   "${_C_GRN}" "$*" "${_C_RST}"; }
+warn() { printf '%s! %s%s\n'   "${_C_YEL}" "$*" "${_C_RST}" >&2; }
+err()  { printf '%s✗ %s%s\n'   "${_C_RED}" "$*" "${_C_RST}" >&2; }
+die()  { err "$*"; exit 1; }
+
+banner() {
+    printf '\n%shal0%s — open-source home AI inference platform\n' "${_C_BLD}" "${_C_RST}"
+    printf '%s%s%s\n\n' "${_C_DIM}" "https://hal0.dev" "${_C_RST}"
+}
+
+# ── preflight ──────────────────────────────────────────────────────────────
+need() {
+    command -v "$1" >/dev/null 2>&1 || die "missing dependency: $1 — install it and re-run"
+}
+
+preflight() {
+    [[ "$(uname -s)" == "Linux" ]] || die "hal0 only supports Linux right now (got $(uname -s))"
+    need curl
+    need tar
+    need sha256sum
+    need python3
+}
+
+# ── manifest fetch + parse ────────────────────────────────────────────────
+fetch_manifest() {
+    local out="$1"
+    info "fetching release manifest"
+    info "  ${_C_DIM}${HAL0_RELEASES_URL}${_C_RST}"
+    if ! curl -fsSL --retry 3 --retry-delay 2 -o "${out}" "${HAL0_RELEASES_URL}"; then
+        die "could not download release manifest from ${HAL0_RELEASES_URL}"
+    fi
+}
+
+parse_manifest_field() {
+    local file="$1" field="$2"
+    python3 -c "
+import json, sys
+try:
+    v = json.load(open('${file}')).get('${field}')
+    if v is None:
+        sys.exit('manifest missing required field: ${field}')
+    print(v)
+except json.JSONDecodeError as e:
+    sys.exit(f'manifest is not valid JSON: {e}')
+"
+}
+
+# ── tarball fetch + sha256 verify ─────────────────────────────────────────
+fetch_and_hash_check() {
+    local url="$1" expected_digest="$2" out="$3"
+    info "downloading tarball"
+    info "  ${_C_DIM}${url}${_C_RST}"
+    curl -fsSL --retry 3 --retry-delay 2 -o "${out}" "${url}" \
+        || die "could not download tarball"
+
+    info "verifying sha256"
+    local actual
+    actual="$(sha256sum "${out}" | awk '{print $1}')"
+    if [[ "${actual}" != "${expected_digest}" ]]; then
+        die "sha256 mismatch — expected ${expected_digest}, got ${actual}"
+    fi
+    ok "sha256 OK (${actual:0:12}…)"
+}
+
+# ── cosign verify (or documented skip) ────────────────────────────────────
+fetch_sig() {
+    local url="$1" out="$2"
+    info "downloading signature"
+    info "  ${_C_DIM}${url}${_C_RST}"
+    curl -fsSL --retry 3 --retry-delay 2 -o "${out}" "${url}" \
+        || die "could not download signature"
+}
+
+cosign_verify() {
+    local tarball="$1" sig="$2" identity="$3" issuer="$4"
+
+    if ! command -v cosign >/dev/null 2>&1; then
+        if [[ "${HAL0_UPDATE_SKIP_COSIGN:-0}" == "1" ]]; then
+            warn "cosign not installed AND HAL0_UPDATE_SKIP_COSIGN=1 — skipping signature verify"
+            warn "this is only safe if you trust the network path to ${HAL0_RELEASES_URL}"
+            return 0
+        fi
+        die "cosign is required to verify the release signature.
+   install it from https://docs.sigstore.dev/cosign/installation/, or
+   re-run with HAL0_UPDATE_SKIP_COSIGN=1 to bypass (NOT recommended)"
+    fi
+
+    info "verifying signature with cosign keyless OIDC"
+    info "  identity-regex: ${_C_DIM}${identity}${_C_RST}"
+    info "  issuer:         ${_C_DIM}${issuer}${_C_RST}"
+    if ! cosign verify-blob \
+            --signature "${sig}" \
+            --certificate-identity-regexp "${identity}" \
+            --certificate-oidc-issuer "${issuer}" \
+            "${tarball}" >/dev/null 2>&1; then
+        die "cosign signature verification FAILED — refusing to install"
+    fi
+    ok "cosign verify OK"
+}
+
+# ── main ──────────────────────────────────────────────────────────────────
+main() {
+    banner
+    preflight
+
+    local work
+    work="$(mktemp -d -t hal0-install-XXXXXX)"
+    if [[ "${HAL0_BOOTSTRAP_KEEP_TMP:-0}" != "1" ]]; then
+        trap 'rm -rf "${work}"' EXIT
+    else
+        warn "HAL0_BOOTSTRAP_KEEP_TMP=1 — leaving work dir ${work}"
+    fi
+
+    local manifest="${work}/manifest.json"
+    fetch_manifest "${manifest}"
+
+    local version url sig_url digest identity issuer
+    version="$(parse_manifest_field "${manifest}" version)"
+    url="$(parse_manifest_field "${manifest}" url)"
+    sig_url="$(parse_manifest_field "${manifest}" sig_url)"
+    digest="$(parse_manifest_field "${manifest}" digest_sha256)"
+    identity="$(parse_manifest_field "${manifest}" signer_identity)"
+    issuer="$(parse_manifest_field "${manifest}" signer_issuer)"
+
+    info "release: ${_C_BLD}hal0 v${version}${_C_RST} (${HAL0_CHANNEL})"
+
+    local tarball="${work}/hal0-${version}.tar.gz"
+    local sig="${tarball}.sig"
+    fetch_and_hash_check "${url}" "${digest}" "${tarball}"
+    fetch_sig "${sig_url}" "${sig}"
+    cosign_verify "${tarball}" "${sig}" "${identity}" "${issuer}"
+
+    info "extracting tarball"
+    tar -xzf "${tarball}" -C "${work}"
+    local unpacked="${work}/hal0-${version}"
+    [[ -x "${unpacked}/installer/install.sh" ]] \
+        || die "extracted tree is missing installer/install.sh — corrupt tarball?"
+
+    ok "ready — handing off to installer"
+    printf '\n'
+
+    # Pass through stdin so install.sh's interactive prompts work when
+    # the user invoked us as `sudo bash install.sh`. When invoked via
+    # curl|bash, stdin is closed and install.sh falls back to defaults.
+    exec bash "${unpacked}/installer/install.sh" "$@"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds the `installer/bootstrap.sh` shell script that backs the advertised one-line install command. Until this PR, `curl -fsSL https://hal0.dev/install | bash` piped an Astro HTML page to bash — the URL was aspirational.

Companion PR with the hal0-web mirror + copy updates: [Hal0ai/hal0-web#7](https://github.com/Hal0ai/hal0-web/pull/7). Both must land before the v0.1.0-alpha tag.

What the bootstrap does (in order):

1. **Preflight** — Linux check, required tools (`curl`, `tar`, `sha256sum`, `python3`).
2. **Fetch manifest** — downloads `hal0.releases.v1` JSON from `HAL0_RELEASES_URL` (defaults to `https://github.com/Hal0ai/hal0/releases/latest/download/stable.json` until `releases.hal0.dev` DNS is up).
3. **Download tarball + sig** — to a `mktemp -d` work dir.
4. **sha256 verify** — first trust gate, against `manifest.digest_sha256`.
5. **cosign verify-blob** — second trust gate, against the workflow OIDC identity in the manifest. Requires cosign; documented `HAL0_UPDATE_SKIP_COSIGN=1` escape hatch only when cosign isn't installed (loud warning).
6. **Extract** — into the work dir.
7. **Hand off** — `exec bash $(unpacked)/installer/install.sh "$@"`. `install.sh` re-execs under sudo if needed and reads from `/dev/tty`.

The script is mirrored at [`Hal0ai/hal0-web:public/install.sh`](https://github.com/Hal0ai/hal0-web/pull/7) — both files carry a sync-warning header comment.

## Why

This was a hard blocker on the v0.1.0-alpha launch: the canonical install command across 11 sites of copy didn't actually execute when piped to bash. Closing the gap before tagging means the alpha actually installs the way the docs say it does.

## Test plan

- [x] `bash -n installer/bootstrap.sh` — syntax check.
- [ ] Run against a real GH Release (smoke-test gated on the companion test tag, see follow-up).
- [ ] `HAL0_UPDATE_SKIP_COSIGN=1` path: confirm loud warning + still proceeds when cosign is absent.
- [ ] Tampered tarball: confirm sha256 mismatch is caught before cosign.
- [ ] Missing manifest fields: confirm `parse_manifest_field` fails with a clear error.