### PR TITLE
fix(release): plumb Fulcio cert through release.yml + updater + bootstrap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 
-      - name: cosign sign-blob (keyless OIDC, legacy raw .sig)
+      - name: cosign sign-blob (keyless OIDC, legacy raw .sig + .crt)
         id: sign
         env:
           # Belt + braces: the keyless flow reads ACTIONS_ID_TOKEN_REQUEST_*
@@ -166,18 +166,25 @@ jobs:
         run: |
           TARBALL="${{ steps.tarball.outputs.path }}"
           SIG="${TARBALL}.sig"
+          CRT="${TARBALL}.crt"
           # cosign 3.x defaults to --new-bundle-format=true and refuses
           # --output-signature. Today's updater (_verify_cosign in
           # src/hal0/updater/updater.py) calls verify-blob with the legacy
-          # --signature flag, so we must opt out of the bundle format
-          # here. When the updater learns to consume Sigstore Bundles
-          # (RELEASE_PIPELINE_NOTES.md → Findings § cosign 3.x), drop the
-          # --new-bundle-format=false and emit a .bundle alongside.
+          # --signature flag, so we opt out of the bundle format here.
+          # cosign 3.x also requires the Fulcio-issued certificate to be
+          # passed via --certificate at verify time (--certificate-identity-
+          # regexp is checked against the cert's SAN), so we --output-certificate
+          # alongside the .sig and publish both as release assets. When the
+          # updater learns to consume Sigstore Bundles (RELEASE_PIPELINE_NOTES.md
+          # → Findings § cosign 3.x), drop --new-bundle-format=false and emit
+          # a .bundle in place of the separate .sig + .crt.
           cosign sign-blob --yes \
               --new-bundle-format=false \
               --output-signature "${SIG}" \
+              --output-certificate "${CRT}" \
               "${TARBALL}"
           echo "sig=${SIG}" >> "$GITHUB_OUTPUT"
+          echo "cert=${CRT}" >> "$GITHUB_OUTPUT"
 
       # ── 4. Self-verify before publishing — never ship a release we can't
       #       verify with our own production code path. ────────────────────────
@@ -185,6 +192,7 @@ jobs:
         run: |
           TARBALL="${{ steps.tarball.outputs.path }}"
           SIG="${{ steps.sign.outputs.sig }}"
+          CRT="${{ steps.sign.outputs.cert }}"
           # The identity regex must match what we'll write into the
           # manifest below — keep these two strings in lock-step.
           # github.repository preserves case (Hal0ai/hal0); use (?i) to
@@ -193,6 +201,7 @@ jobs:
           ISSUER="https://token.actions.githubusercontent.com"
           cosign verify-blob \
               --signature "${SIG}" \
+              --certificate "${CRT}" \
               --certificate-identity-regexp "${IDENT}" \
               --certificate-oidc-issuer    "${ISSUER}" \
               "${TARBALL}"
@@ -227,6 +236,7 @@ jobs:
               "channel":         channel,
               "url":             f"{base}/hal0-{version}.tar.gz",
               "sig_url":         f"{base}/hal0-{version}.tar.gz.sig",
+              "cert_url":        f"{base}/hal0-{version}.tar.gz.crt",
               "digest_sha256":   digest,
               "signer_identity": ident,
               "signer_issuer":   "https://token.actions.githubusercontent.com",
@@ -268,6 +278,7 @@ jobs:
           TAG="${{ steps.ver.outputs.tag }}"
           TARBALL="${{ steps.tarball.outputs.path }}"
           SIG="${{ steps.sign.outputs.sig }}"
+          CRT="${{ steps.sign.outputs.cert }}"
           MANIFEST="${{ steps.manifest.outputs.path }}"
 
           # Create the release if it doesn't already exist (workflow_dispatch
@@ -281,7 +292,7 @@ jobs:
               --prerelease="$([[ "${TAG}" == *-* ]] && echo true || echo false)"
           fi
 
-          gh release upload "${TAG}" "${TARBALL}" "${SIG}" "${MANIFEST}" --clobber
+          gh release upload "${TAG}" "${TARBALL}" "${SIG}" "${CRT}" "${MANIFEST}" --clobber
 
       - name: Summary
         run: |

--- a/docs/release-manifest.md
+++ b/docs/release-manifest.md
@@ -51,6 +51,7 @@ intentional, since there is no real signed artifact behind it yet.
   "channel": "stable",
   "url": "https://github.com/hal0ai/hal0/releases/download/v0.1.1/hal0-0.1.1.tar.gz",
   "sig_url": "https://github.com/hal0ai/hal0/releases/download/v0.1.1/hal0-0.1.1.tar.gz.sig",
+  "cert_url": "https://github.com/hal0ai/hal0/releases/download/v0.1.1/hal0-0.1.1.tar.gz.crt",
   "digest_sha256": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
   "signer_identity": "^(?i)https://github\\.com/hal0ai/hal0/\\.github/workflows/release\\.yml@refs/tags/v0\\.1\\.1$",
   "signer_issuer": "https://token.actions.githubusercontent.com",
@@ -78,6 +79,7 @@ intentional, since there is no real signed artifact behind it yet.
 | `channel` | string | no | `"stable"` (default), `"nightly"`, `"dev"`. |
 | `url` | string | yes | `http(s)` or `file://` URL of the release tarball. |
 | `sig_url` | string | yes | URL of the detached cosign signature (`*.sig`). |
+| `cert_url` | string | yes | URL of the Fulcio-issued certificate (`*.crt`). cosign 3.x requires `--certificate` alongside `--signature` for keyless verify; the cert's SAN is what `--certificate-identity-regexp` checks. |
 | `digest_sha256` | string | yes | Hex sha256 of the tarball bytes (64 chars). `sha256:` prefix tolerated. |
 | `signer_identity` | string | yes | Regex passed to `cosign verify-blob --certificate-identity-regexp`. Must anchor (`^...$`) to the exact GH Actions workflow + ref. Use `(?i)` to absorb GH's case preservation — the `Hal0ai` org slug is canonical capital-H but lowercase `hal0ai` references redirect; `(?i)` matches either. |
 | `signer_issuer` | string | no | OIDC issuer; defaults to GitHub Actions (`token.actions.githubusercontent.com`). |
@@ -99,6 +101,7 @@ The updater shells out to `cosign verify-blob`:
 ```
 cosign verify-blob \
   --signature <sig_url-payload> \
+  --certificate <cert_url-payload> \
   --certificate-identity-regexp <signer_identity> \
   --certificate-oidc-issuer    <signer_issuer> \
   <tarball-path>

--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -112,16 +112,16 @@ fetch_and_hash_check() {
 }
 
 # ── cosign verify (or documented skip) ────────────────────────────────────
-fetch_sig() {
-    local url="$1" out="$2"
-    info "downloading signature"
+fetch_sidecar() {
+    local label="$1" url="$2" out="$3"
+    info "downloading ${label}"
     info "  ${_C_DIM}${url}${_C_RST}"
     curl -fsSL --retry 3 --retry-delay 2 -o "${out}" "${url}" \
-        || die "could not download signature"
+        || die "could not download ${label}"
 }
 
 cosign_verify() {
-    local tarball="$1" sig="$2" identity="$3" issuer="$4"
+    local tarball="$1" sig="$2" cert="$3" identity="$4" issuer="$5"
 
     if ! command -v cosign >/dev/null 2>&1; then
         if [[ "${HAL0_UPDATE_SKIP_COSIGN:-0}" == "1" ]]; then
@@ -137,8 +137,12 @@ cosign_verify() {
     info "verifying signature with cosign keyless OIDC"
     info "  identity-regex: ${_C_DIM}${identity}${_C_RST}"
     info "  issuer:         ${_C_DIM}${issuer}${_C_RST}"
+    # cosign 3.x requires the Fulcio-issued cert via --certificate
+    # alongside the .sig; --certificate-identity-regexp is checked
+    # against the cert's SAN.
     if ! cosign verify-blob \
             --signature "${sig}" \
+            --certificate "${cert}" \
             --certificate-identity-regexp "${identity}" \
             --certificate-oidc-issuer "${issuer}" \
             "${tarball}" >/dev/null 2>&1; then
@@ -163,10 +167,11 @@ main() {
     local manifest="${work}/manifest.json"
     fetch_manifest "${manifest}"
 
-    local version url sig_url digest identity issuer
+    local version url sig_url cert_url digest identity issuer
     version="$(parse_manifest_field "${manifest}" version)"
     url="$(parse_manifest_field "${manifest}" url)"
     sig_url="$(parse_manifest_field "${manifest}" sig_url)"
+    cert_url="$(parse_manifest_field "${manifest}" cert_url)"
     digest="$(parse_manifest_field "${manifest}" digest_sha256)"
     identity="$(parse_manifest_field "${manifest}" signer_identity)"
     issuer="$(parse_manifest_field "${manifest}" signer_issuer)"
@@ -175,9 +180,11 @@ main() {
 
     local tarball="${work}/hal0-${version}.tar.gz"
     local sig="${tarball}.sig"
+    local cert="${tarball}.crt"
     fetch_and_hash_check "${url}" "${digest}" "${tarball}"
-    fetch_sig "${sig_url}" "${sig}"
-    cosign_verify "${tarball}" "${sig}" "${identity}" "${issuer}"
+    fetch_sidecar "signature" "${sig_url}" "${sig}"
+    fetch_sidecar "certificate" "${cert_url}" "${cert}"
+    cosign_verify "${tarball}" "${sig}" "${cert}" "${identity}" "${issuer}"
 
     info "extracting tarball"
     tar -xzf "${tarball}" -C "${work}"

--- a/scripts/release-prototype/verify-roundtrip.sh
+++ b/scripts/release-prototype/verify-roundtrip.sh
@@ -135,6 +135,11 @@ payload = {
     "channel": "dev",
     "url": f"file://{tar}",
     "sig_url": f"file://{sig}",
+    # The prototype signs with --key, so no Fulcio cert exists. Point
+    # cert_url at the sig file itself so the schema is satisfied; the
+    # --key verify path in updater._verify_cosign ignores --certificate
+    # contents (production keyless flow is what actually uses the cert).
+    "cert_url": f"file://{sig}",
     "digest_sha256": digest,
     # In production this is the GH Actions workflow subject (see
     # docs/release-manifest.md). For the local key prototype it is a

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -151,6 +151,14 @@ class ReleaseManifest(BaseModel):
     channel: str = Field(default="stable", description="stable | nightly | dev")
     url: str = Field(..., description="Tarball download URL (https or file).")
     sig_url: str = Field(..., description="Detached cosign signature URL.")
+    cert_url: str = Field(
+        ...,
+        description=(
+            "Fulcio-issued certificate URL (cosign keyless OIDC). "
+            "Required by ``cosign verify-blob --certificate`` in cosign 3.x; "
+            "produced alongside the .sig by ``cosign sign-blob --output-certificate``."
+        ),
+    )
     digest_sha256: str = Field(..., description="Hex sha256 of the tarball bytes.")
     signer_identity: str = Field(
         ...,
@@ -461,6 +469,7 @@ def _cosign_skip() -> bool:
 def _verify_cosign(
     tarball: Path,
     signature: Path,
+    certificate: Path,
     *,
     identity_regexp: str,
     issuer: str,
@@ -471,6 +480,11 @@ def _verify_cosign(
     Raises:
         UpdateCosignMissing: ``cosign`` not on PATH.
         UpdateCosignFailed: signature invalid or identity mismatch.
+
+    cosign 3.x requires the Fulcio-issued certificate (``--certificate``)
+    alongside the signature for keyless verification; ``--certificate-
+    identity-regexp`` is checked against the cert's SAN. The cert is
+    fetched from ``manifest.cert_url`` and stored next to the .sig.
 
     The skip env-var (``HAL0_UPDATE_SKIP_COSIGN=1``) bypasses the entire
     check with a WARN log line — documented gap, must close before v1.
@@ -507,6 +521,8 @@ def _verify_cosign(
         "verify-blob",
         "--signature",
         str(signature),
+        "--certificate",
+        str(certificate),
         "--certificate-identity-regexp",
         identity_regexp,
         "--certificate-oidc-issuer",
@@ -839,11 +855,12 @@ class Updater:
                 manifest=manifest.version,
             )
 
-        # Step 3: download tarball + signature.
+        # Step 3: download tarball + signature + cert.
         cache = _cache_dir(target_version)
         cache.mkdir(parents=True, exist_ok=True)
         tarball_path = cache / f"hal0-{target_version}.tar.gz"
         sig_path = cache / f"hal0-{target_version}.tar.gz.sig"
+        cert_path = cache / f"hal0-{target_version}.tar.gz.crt"
         log.info(
             "updater.download_start",
             job_id=self.job_id,
@@ -852,11 +869,13 @@ class Updater:
         )
         await _download(manifest.url, tarball_path)
         await _download(manifest.sig_url, sig_path)
+        await _download(manifest.cert_url, cert_path)
         log.info(
             "updater.download_ok",
             job_id=self.job_id,
             tarball=str(tarball_path),
             sig=str(sig_path),
+            cert=str(cert_path),
         )
 
         # Step 4: sha256 verify.
@@ -877,6 +896,7 @@ class Updater:
             _verify_cosign,
             tarball_path,
             sig_path,
+            cert_path,
             identity_regexp=manifest.signer_identity,
             issuer=manifest.signer_issuer,
             job_id=self.job_id,

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -84,15 +84,18 @@ def _write_release_manifest(
     tarball: Path,
     sig: Path,
     version: str,
+    cert: Path | None = None,
     overrides: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Write a full hal0.releases.v1 manifest pointing at file:// URLs."""
+    cert_url = f"file://{cert}" if cert is not None else f"file://{sig.with_suffix('.crt')}"
     payload: dict[str, Any] = {
         "_schema": "hal0.releases.v1",
         "version": version,
         "channel": "stable",
         "url": f"file://{tarball}",
         "sig_url": f"file://{sig}",
+        "cert_url": cert_url,
         "digest_sha256": _sha256_of(tarball),
         "signer_identity": "^https://github\\.com/hal0ai/hal0/.*",
         "signer_issuer": "https://token.actions.githubusercontent.com",
@@ -122,14 +125,17 @@ def synthetic_release(
     artifacts.mkdir()
     version = "0.0.1"
     tarball = _build_release_tarball(tmp=artifacts, version=version)
-    # Stub signature file — content doesn't matter when cosign is skipped.
+    # Stub signature + cert files — contents don't matter when cosign is skipped.
     sig = artifacts / f"hal0-{version}.tar.gz.sig"
     sig.write_bytes(b"signature-placeholder\n")
+    cert = artifacts / f"hal0-{version}.tar.gz.crt"
+    cert.write_bytes(b"-----BEGIN CERTIFICATE-----\nplaceholder\n-----END CERTIFICATE-----\n")
     manifest_path = artifacts / "latest.json"
     payload = _write_release_manifest(
         manifest_path=manifest_path,
         tarball=tarball,
         sig=sig,
+        cert=cert,
         version=version,
     )
     monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest_path))
@@ -137,6 +143,7 @@ def synthetic_release(
         "version": version,
         "tarball": tarball,
         "sig": sig,
+        "cert": cert,
         "manifest_path": manifest_path,
         "payload": payload,
     }
@@ -203,6 +210,7 @@ def test_manifest_schema_rejects_malformed_digest() -> None:
         "version": "0.0.1",
         "url": "file:///x",
         "sig_url": "file:///x.sig",
+        "cert_url": "file:///x.crt",
         "digest_sha256": "not-a-real-digest",
         "signer_identity": "^https://github.com/x/.*",
     }
@@ -390,6 +398,7 @@ def test_apply_download_failure_surfaces_typed_error(
         "version": "9.9.9",
         "url": f"file://{tmp_path / 'nope.tar.gz'}",
         "sig_url": f"file://{tmp_path / 'nope.sig'}",
+        "cert_url": f"file://{tmp_path / 'nope.crt'}",
         "digest_sha256": "a" * 64,
         "signer_identity": "^https://github.com/.*",
     }


### PR DESCRIPTION
## Summary

cosign 3.x requires the Fulcio-issued certificate via `--certificate` alongside `--signature` for keyless `verify-blob` (it no longer reconstructs the cert from the rekor entry like 2.x did). The first real release attempt on `v0.0.0-rc1` failed at the self-verify gate with:

> Error: provide a key with --key or --sk, a certificate to verify against with --certificate, or a bundle with --bundle

[Failed run logs](https://github.com/Hal0ai/hal0/actions/runs/26239767111).

Fix: emit and ship the cert as a sidecar `.crt`, advertise its URL in the release manifest, and have every consumer download and pass it to `cosign verify-blob --certificate`.

## Surfaces changed

- **`.github/workflows/release.yml`** — `sign-blob` now passes `--output-certificate`; self-verify and `gh release upload` both include the `.crt`; manifest generation adds `cert_url`.
- **`src/hal0/updater/updater.py`** — `ReleaseManifest` gains a required `cert_url: str` field; the apply() flow downloads cert alongside sig; `_verify_cosign` takes a `certificate: Path` arg and passes `--certificate`.
- **`installer/bootstrap.sh`** — fetches `cert_url` alongside `sig_url`, passes the path to `cosign verify-blob`. `fetch_sig` generalised into `fetch_sidecar`.
- **`docs/release-manifest.md`** — schema table + example payload + verify command all updated.
- **`scripts/release-prototype/verify-roundtrip.sh`** — manifest gains `cert_url` (points at the `.sig` since `--key` verify ignores cert contents).
- **`tests/updater/test_updater.py`** — fixtures + edge-case payloads updated; synthetic-release fixture writes a stub `.crt`.

Companion PR: [Hal0ai/hal0-web#8](https://github.com/Hal0ai/hal0-web/pull/8) mirrors the bootstrap change + adds `cert_url` to the placeholder stable.json.

## Test plan

- [x] `pytest tests/updater/test_updater.py` — 33 passed locally.
- [x] `bash -n installer/bootstrap.sh` — syntax OK.
- [ ] Re-attempt the `v0.0.0-rc1` test tag and confirm release.yml's self-verify step now passes end-to-end.
- [ ] Confirm GH Release publishes the `.crt` asset alongside `.tar.gz` + `.sig` + `stable.json`.