### PR TITLE
fix(release): stage UI bundle at ui/dist/, not ui-dist/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           npm ci
           npm run build
 
-      # ── 2. Stage the release tree (matches updater._extract_tarball expectation) ──
+      # ── 2. Stage the release tree ──
       - name: Stage release tree
         id: stage
         run: |
@@ -123,9 +123,14 @@ jobs:
           cp -a packaging            "${STAGE}/"
           cp -a docs                 "${STAGE}/"
 
-          # UI bundle — the updater extracts this under hal0-<ver>/ui-dist/.
+          # Prebuilt UI bundle — staged at ui/dist/ so install.sh's
+          # "ui/dist already built — left alone" branch fires (the npm
+          # fallback would `cd ui && npm install` which we don't ship)
+          # and so the FastAPI mount_dashboard resolution path
+          # (`<repo>/ui/dist`) finds it without a HAL0_UI_DIST override.
           if [[ -d ui/dist ]]; then
-            cp -a ui/dist            "${STAGE}/ui-dist"
+            mkdir -p                 "${STAGE}/ui"
+            cp -a ui/dist            "${STAGE}/ui/dist"
           else
             echo "::error::ui/dist missing after npm run build"
             exit 1


### PR DESCRIPTION
## Summary

Caught by the v0.0.0-rc1 smoke test on the hal0 LXC: bootstrap.sh fetched + verified the signed tarball end-to-end, but install.sh then died at step 4/8 ("Dashboard UI") trying to `cd ui && npm install` because the release tarball didn't have a `ui/` directory — only `ui-dist/`.

## Why this happened

`install.sh` checks `\${REPO_ROOT}/ui/dist/index.html` and the FastAPI `mount_dashboard` probes `<repo>/ui/dist` as one of its resolution candidates. `release.yml`'s staging step was copying to `ui-dist/` — left over from a misread comment about updater expectations (the updater extracts whatever's in the tarball; it doesn't enforce a layout).

## Fix

Stage the prebuilt UI bundle at `ui/dist/` so `install.sh`'s _"ui/dist already built — left alone"_ branch fires and the runtime API mount finds the bundle without needing `HAL0_UI_DIST`.

## Test plan

- [ ] After merge: re-tag `v0.0.0-rc1` (delete + retag the existing release) and re-run the bootstrap end-to-end on the hal0 LXC. Confirm install.sh proceeds past the UI step.