### PR TITLE
fix(npu+ui): NPU load lifecycle, FLM pull progress, slot-card swap, dashboard sparkline

### DIFF
--- a/src/hal0/api/routes/backends.py
+++ b/src/hal0/api/routes/backends.py
@@ -319,9 +319,7 @@ async def _allocate_npu_port(slot_manager: SlotManagerDep) -> int:
 
 
 @router.post("/npu/load", dependencies=_writer)
-async def load_npu_model(
-    request: Request, slot_manager: SlotManagerDep
-) -> dict[str, Any]:
+async def load_npu_model(request: Request, slot_manager: SlotManagerDep) -> dict[str, Any]:
     """Create + load an FLM slot for one model tag.
 
     Body: ``{"model_id": "lfm2:1.2b"}``. The endpoint is idempotent — a
@@ -343,9 +341,7 @@ async def load_npu_model(
             code="request.invalid_json",
         ) from exc
     if not isinstance(body, dict):
-        raise BadRequest(
-            "request body must be a JSON object", code="request.not_an_object"
-        )
+        raise BadRequest("request body must be a JSON object", code="request.not_an_object")
 
     model_id = body.get("model_id")
     if not isinstance(model_id, str) or not model_id.strip():
@@ -395,9 +391,7 @@ async def load_npu_model(
 
 
 @router.post("/npu/unload", dependencies=_writer)
-async def unload_npu_model(
-    request: Request, slot_manager: SlotManagerDep
-) -> dict[str, Any]:
+async def unload_npu_model(request: Request, slot_manager: SlotManagerDep) -> dict[str, Any]:
     """Unload + delete a dynamically-created NPU slot.
 
     Body: ``{"slot_name": "npu-lfm2-1-2b"}``. Refuses to touch slots
@@ -413,9 +407,7 @@ async def unload_npu_model(
             code="request.invalid_json",
         ) from exc
     if not isinstance(body, dict):
-        raise BadRequest(
-            "request body must be a JSON object", code="request.not_an_object"
-        )
+        raise BadRequest("request body must be a JSON object", code="request.not_an_object")
 
     slot_name = body.get("slot_name")
     if not isinstance(slot_name, str) or not slot_name.strip():

--- a/src/hal0/api/routes/backends.py
+++ b/src/hal0/api/routes/backends.py
@@ -2,8 +2,10 @@
 
 Mounted under ``/api/backends`` (see :mod:`hal0.api.__init__`):
 
-  - ``GET /api/backends``       — list every backend with its live status.
-  - ``GET /api/backends/{id}``  — single-backend detail.
+  - ``GET  /api/backends``           — list every backend with its live status.
+  - ``GET  /api/backends/{id}``      — single-backend detail.
+  - ``POST /api/backends/npu/load``  — bring up an FLM slot for one model tag.
+  - ``POST /api/backends/npu/unload``— tear down a previously loaded NPU slot.
 
 The shape is tuned for the dashboard's Capability-slots footer cards.
 Several fields are placeholders for this round (``totalReqPerSec``
@@ -12,17 +14,55 @@ returns 0 until a stats source lands).
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 
 from hal0.api.deps import SlotManagerDep
+from hal0.api.middleware.auth import require_writer
+from hal0.api.middleware.error_codes import BadRequest
 from hal0.capabilities.catalog import available_backends, get_backend
 from hal0.capabilities.orchestrator import _CHILD_TO_SLOT
 from hal0.config.loader import load_hardware_info
-from hal0.errors import NotFound
+from hal0.errors import Hal0Error, NotFound
 
 router = APIRouter()
+
+# Writer-scope gate for the POST routes (mirrors the slots router pattern).
+_writer = [Depends(require_writer)]
+
+# ── NPU dynamic-slot config ───────────────────────────────────────────────────
+# The NPU backend supports operator-driven slot creation from the dashboard's
+# "+ load NPU model" button. Slots created this way live under the npu- prefix
+# and pick ports from a private range so they don't collide with the built-in
+# slots (8081-8087 reserve primary / nano / embed / stt / etc.).
+_NPU_SLOT_PREFIX = "npu-"
+_NPU_PORT_MIN = 8088
+_NPU_PORT_MAX = 8099
+
+
+class _NoFreeSlotPort(Hal0Error):
+    """No free port available in the NPU dynamic-slot range."""
+
+    code = "backend.no_slot_port"
+    status = 409
+
+
+def _sanitize_slot_suffix(model_id: str) -> str:
+    """Map an FLM tag (e.g. ``qwen3.5:9b``) to a slot-name-safe suffix.
+
+    Slot names land in systemd unit names + on-disk paths, so we lock to
+    ``[a-z0-9-]`` and cap length so the rendered unit stays well under
+    systemd's 256-char limit.
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9-]+", "-", model_id).strip("-").lower()
+    return cleaned[:48] or "model"
+
+
+def _npu_slot_name(model_id: str) -> str:
+    """Slot name used for a given NPU-loaded model tag."""
+    return f"{_NPU_SLOT_PREFIX}{_sanitize_slot_suffix(model_id)}"
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -249,6 +289,167 @@ async def get_backend_details(
             details={"id": backend_id},
         )
     return await _build_backend_payload(backend, slot_manager)
+
+
+# ── NPU dynamic-slot endpoints ────────────────────────────────────────────────
+
+
+async def _allocate_npu_port(slot_manager: SlotManagerDep) -> int:
+    """Return the lowest free port in [_NPU_PORT_MIN, _NPU_PORT_MAX].
+
+    Walks every existing slot's configured port and picks the first
+    unused integer in our range. Raises a typed 409 when the range is
+    exhausted so the dashboard can surface a clean error envelope.
+    """
+    used: set[int] = set()
+    try:
+        all_slots = await slot_manager.list()
+    except Exception:
+        all_slots = []
+    for snap in all_slots:
+        if snap.port:
+            used.add(int(snap.port))
+    for port in range(_NPU_PORT_MIN, _NPU_PORT_MAX + 1):
+        if port not in used:
+            return port
+    raise _NoFreeSlotPort(
+        f"no free NPU slot port in [{_NPU_PORT_MIN},{_NPU_PORT_MAX}]",
+        details={"range": [_NPU_PORT_MIN, _NPU_PORT_MAX]},
+    )
+
+
+@router.post("/npu/load", dependencies=_writer)
+async def load_npu_model(
+    request: Request, slot_manager: SlotManagerDep
+) -> dict[str, Any]:
+    """Create + load an FLM slot for one model tag.
+
+    Body: ``{"model_id": "lfm2:1.2b"}``. The endpoint is idempotent — a
+    second call with the same model_id returns the existing slot's
+    snapshot rather than failing.
+
+    On the wire this is the "+ load NPU model" button's backing call.
+    Until v1.1 the dashboard staged loads in local UI state only; this
+    endpoint promotes that into a real slot lifecycle so the model
+    actually serves traffic and ``/api/backends/npu`` reports it as
+    loaded.
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise BadRequest(
+            "request body must be valid JSON",
+            details={"error": str(exc)},
+            code="request.invalid_json",
+        ) from exc
+    if not isinstance(body, dict):
+        raise BadRequest(
+            "request body must be a JSON object", code="request.not_an_object"
+        )
+
+    model_id = body.get("model_id")
+    if not isinstance(model_id, str) or not model_id.strip():
+        raise BadRequest(
+            "'model_id' is required (non-empty string)",
+            code="backend.model_id_required",
+        )
+    model_id = model_id.strip()
+
+    slot_name = _npu_slot_name(model_id)
+
+    # Reuse an existing slot if one already exists for this tag; create
+    # otherwise. We treat "slot exists" as "config file present" since
+    # SlotManager.status raises for unknown slots.
+    from hal0.slots.state import SlotConfigError  # local import: avoid cycles
+
+    existed = True
+    try:
+        await slot_manager.status(slot_name)
+    except SlotConfigError:
+        existed = False
+    except Exception:
+        existed = False
+
+    if not existed:
+        port = await _allocate_npu_port(slot_manager)
+        cfg = {
+            "name": slot_name,
+            "port": port,
+            "backend": "flm",
+            "provider": "flm",
+            "enabled": True,
+            "model": {"default": model_id},
+        }
+        await slot_manager.create(slot_name, cfg)
+
+    snap = await slot_manager.load(slot_name, model_id=model_id)
+    return {
+        "slot": snap.name,
+        "state": snap.state.value if hasattr(snap.state, "value") else str(snap.state),
+        "port": snap.port,
+        "model_id": snap.model_id,
+        "backend": snap.backend,
+        "provider": (snap.metadata or {}).get("provider", ""),
+        "created": not existed,
+    }
+
+
+@router.post("/npu/unload", dependencies=_writer)
+async def unload_npu_model(
+    request: Request, slot_manager: SlotManagerDep
+) -> dict[str, Any]:
+    """Unload + delete a dynamically-created NPU slot.
+
+    Body: ``{"slot_name": "npu-lfm2-1-2b"}``. Refuses to touch slots
+    outside the ``npu-`` prefix so a misdirected call can't take down
+    primary/embed/etc. by accident.
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise BadRequest(
+            "request body must be valid JSON",
+            details={"error": str(exc)},
+            code="request.invalid_json",
+        ) from exc
+    if not isinstance(body, dict):
+        raise BadRequest(
+            "request body must be a JSON object", code="request.not_an_object"
+        )
+
+    slot_name = body.get("slot_name")
+    if not isinstance(slot_name, str) or not slot_name.strip():
+        raise BadRequest(
+            "'slot_name' is required (non-empty string)",
+            code="backend.slot_name_required",
+        )
+    slot_name = slot_name.strip()
+    if not slot_name.startswith(_NPU_SLOT_PREFIX):
+        raise BadRequest(
+            f"refusing to unload non-NPU slot {slot_name!r}",
+            code="backend.not_npu_slot",
+            details={"slot": slot_name, "prefix": _NPU_SLOT_PREFIX},
+        )
+
+    await slot_manager.unload(slot_name)
+    await slot_manager.delete(slot_name)
+    # Clear systemd's residual "failed" state for the template instance —
+    # the docker-run exit on unload trips systemd's failure detector and
+    # leaves the unit listed in `systemctl --failed` even after delete.
+    # Best-effort; failures here don't affect the unload result.
+    import asyncio as _asyncio
+    import contextlib as _contextlib
+
+    with _contextlib.suppress(Exception):
+        proc = await _asyncio.create_subprocess_exec(
+            "systemctl",
+            "reset-failed",
+            f"hal0-slot@{slot_name}.service",
+            stdout=_asyncio.subprocess.DEVNULL,
+            stderr=_asyncio.subprocess.DEVNULL,
+        )
+        await proc.wait()
+    return {"ok": True, "slot": slot_name}
 
 
 __all__ = ["router"]

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -462,8 +462,13 @@ async def run_flm_pull(
     {completed, failed, cancelled}) so the existing SSE / status routes
     work unchanged. Differs in two ways:
 
-      * Bytes come from parsing FLM's stdout lines (no Content-Length
-        header to lean on) — see :func:`hal0.providers.flm.parse_flm_progress`.
+      * Bytes come from polling the on-disk dir size of the target install
+        path. FLM models contain multiple files (config.json, model.q4nx,
+        tokenizer.json, …) and FLM's stdout emits ``Downloading: X% (cur/tot)``
+        for each file independently — leaning on per-file regex parsing made
+        ``bytes_downloaded`` regress to 0 each time a new file began, which
+        the dashboard rendered as a "hanging" progress bar. Dir-size polling
+        is monotonic by construction and survives FLM stdout-format changes.
       * No sha256 is computed here: FLM verifies file hashes internally
         and refuses to use mismatched weights. Re-hashing would just
         double-read multi-GB files for the same guarantee.
@@ -481,7 +486,7 @@ async def run_flm_pull(
     # environments without docker).
     from hal0.providers.flm import (
         flm_pull_command,
-        parse_flm_progress,
+        flm_served_models,
         reset_flm_catalog_cache,
     )
 
@@ -490,6 +495,22 @@ async def run_flm_pull(
     job._signal()
 
     argv, host_models_dir = flm_pull_command(tag)
+
+    # Resolve the install path + advertised total upfront so progress
+    # reporting is monotonic. _flm_install_path reads the same cached
+    # catalog flm_served_models uses; both fall back gracefully when
+    # the probe failed (host without docker / image not present).
+    target_dir = _flm_install_path(host_models_dir, tag)
+    advertised_total = 0
+    for entry in flm_served_models():
+        if entry["tag"] == tag:
+            advertised_total = int(entry.get("size_bytes") or 0)
+            break
+    baseline_size = _dir_size(target_dir) if target_dir else 0
+    if advertised_total > baseline_size:
+        job.bytes_total = advertised_total
+        job._signal()
+
     proc: asyncio.subprocess.Process | None = None
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -500,6 +521,25 @@ async def run_flm_pull(
         )
         assert proc.stdout is not None
         last_emit = time.monotonic()
+
+        def _tick_progress() -> None:
+            """Refresh bytes_downloaded from on-disk dir size if it grew."""
+            nonlocal last_emit
+            if not target_dir:
+                return
+            now = time.monotonic()
+            if (now - last_emit) < _SSE_MIN_INTERVAL_S:
+                return
+            current = _dir_size(target_dir) - baseline_size
+            if current > job.bytes_downloaded:
+                job.bytes_downloaded = current
+                if current > job.bytes_total:
+                    # FLM's advertised size is approximate; let actual
+                    # bytes stretch bytes_total so the UI stays at ≤100%.
+                    job.bytes_total = current
+                last_emit = now
+                job._signal()
+
         while True:
             if job.cancel_requested:
                 proc.terminate()
@@ -515,21 +555,16 @@ async def run_flm_pull(
             try:
                 raw = await asyncio.wait_for(proc.stdout.readline(), timeout=1.0)
             except TimeoutError:
-                # No new line in 1s — loop back so cancellation observes promptly.
+                # No new line in 1s — loop back so cancellation observes
+                # promptly. Also a good cadence for the dir-size poll.
+                _tick_progress()
                 continue
             if not raw:
                 break
-            line = raw.decode("utf-8", errors="replace")
-            parsed = parse_flm_progress(line)
-            if parsed is not None:
-                downloaded, total = parsed
-                job.bytes_downloaded = downloaded
-                if total > job.bytes_total:
-                    job.bytes_total = total
-                now = time.monotonic()
-                if (now - last_emit) >= _SSE_MIN_INTERVAL_S:
-                    last_emit = now
-                    job._signal()
+            # Reading the line is enough — we don't parse it for byte
+            # accounting any more, but the readline() drains the pipe so
+            # the docker process doesn't block on a full stdout buffer.
+            _tick_progress()
 
         await proc.wait()
         if proc.returncode != 0:

--- a/ui/src/components/SlotCard.vue
+++ b/ui/src/components/SlotCard.vue
@@ -17,16 +17,15 @@ const props = defineProps({
   slot: { type: Object, required: true },
   metrics: { type: Object, default: null },
   sparkData: { type: Object, default: () => ({ tps: [], pps: [] }) },
-  models: { type: Array, default: () => [] },
-  selectedModel: { type: String, default: '' },
   actionLoading: { type: String, default: null },
 })
 
 // `swap` was the interim B2 fallback (parent routed to openEdit). C1 wires
 // the inline popover directly to /api/slots/{name}/swap — emit `swapped` on
 // success so parents that want to refetch can do so without listening to the
-// events ring.
-const emit = defineEmits(['action', 'select-model', 'logs', 'edit', 'delete', 'swapped'])
+// events ring. The bottom-of-card model `<select>` was removed in favour of
+// the inline-trigger popover, so we no longer emit `select-model` either.
+const emit = defineEmits(['action', 'logs', 'edit', 'delete', 'swapped'])
 
 const toasts = useToastsStore()
 
@@ -114,6 +113,23 @@ const hardwareTarget = computed(() => {
   // mix in haloai but show as 'iGPU' for now.
   if (provider === 'kokoro' || provider === 'moonshine') return { id: 'igpu', label: 'iGPU' }
   return { id: 'unknown', label: backend || provider || 'slot' }
+})
+
+// Backend / runtime identifier — the concrete tech driving the slot
+// (vulkan / rocm / cuda / flm / cpu / kokoro / moonshine / …). Surfaced
+// next to the hardware-target chip so the user can tell two iGPU slots
+// apart at a glance ("iGPU via vulkan" vs "iGPU via kokoro").
+const backendTech = computed(() => {
+  const backend = (props.slot.backend || '').toLowerCase()
+  const provider = (props.slot.provider || '').toLowerCase()
+  // Self-managed providers carry their own runtime name in `provider` and
+  // a generic backend (often `cpu` or empty), so prefer provider there.
+  if (provider && provider !== 'llama-server' && provider !== 'llama.cpp') {
+    return { id: provider, label: provider }
+  }
+  if (backend) return { id: backend, label: backend }
+  if (provider) return { id: provider, label: provider }
+  return null
 })
 
 // -----------------------------------------------------------------------------
@@ -374,6 +390,19 @@ onBeforeUnmount(() => {
   if (flashTimer) clearTimeout(flashTimer)
 })
 
+// Start button delegate. When the slot already has a model assigned, just
+// emit `action: 'load'` and let the parent (Slots.vue / doLoad) drive the
+// /api/slots/{name}/load call. When no model is set yet, the bottom <select>
+// used to be the affordance; with that removed we route Start straight into
+// the swap popover so the operator always has a path to pick a model.
+function startSlot() {
+  if (!currentModelId.value && swapAvailable.value) {
+    openSwap()
+    return
+  }
+  emit('action', 'load')
+}
+
 function fmtUptime(s) {
   if (!s || s < 60) return '—'
   const mins = Math.floor(s / 60), hrs = Math.floor(mins / 60), days = Math.floor(hrs / 24)
@@ -446,21 +475,28 @@ const sparkSvg = computed(() => {
       </template>
       <template v-else>
         <!-- Non-FLM slots get an inline swap trigger on the model label.
-             FLM slots multiplex multi-model sets — out of scope for C1, the
-             label stays read-only and the affordance is hidden. -->
+             Styled as a select-like control so the affordance is obvious
+             without hover. FLM slots multiplex multi-model sets — out of
+             scope for C1, the label stays read-only and the chevron hides. -->
         <button
           v-if="swapAvailable"
           ref="swapTriggerRef"
           type="button"
-          class="sc-model sc-model-trigger mono"
-          :title="`Swap model (${modelLabel})`"
+          class="sc-model-trigger mono"
+          :class="{ 'is-empty': !currentModelId, 'is-open': swapOpen }"
+          :title="currentModelId ? `Swap model (${modelLabel})` : 'Pick a model'"
           :aria-haspopup="'listbox'"
           :aria-expanded="swapOpen"
-          :aria-label="`Swap model for ${slot.name}, current ${modelLabel}`"
+          :aria-label="currentModelId
+            ? `Swap model for ${slot.name}, current ${modelLabel}`
+            : `Pick a model for ${slot.name}`"
           @click.stop="openSwap"
         >
-          <span class="sc-model-text">{{ modelLabel }}</span>
-          <svg class="sc-swap-caret" width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+          <svg class="sc-swap-icon" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M7 16V4m0 0L3 8m4-4l4 4M17 8v12m0 0l4-4m-4 4l-4-4"/>
+          </svg>
+          <span class="sc-model-text">{{ currentModelId ? modelLabel : 'select model…' }}</span>
+          <svg class="sc-swap-caret" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6"/>
           </svg>
         </button>
@@ -573,11 +609,6 @@ const sparkSvg = computed(() => {
       </div>
     </Teleport>
 
-    <div class="sc-meta">
-      <span class="sc-chip" :class="`hw-${hardwareTarget.id}`">{{ hardwareTarget.label }}</span>
-      <span v-if="slot.context_size" class="sc-chip dim">ctx {{ (slot.context_size / 1024).toFixed(0) }}K</span>
-    </div>
-
     <!-- Stats row -->
     <div class="sc-stats">
       <div class="sc-stat">
@@ -606,19 +637,22 @@ const sparkSvg = computed(() => {
       <span class="sc-spark-label">tps</span>
     </div>
 
-    <!-- Footer: model picker + actions -->
+    <!-- Footer: hardware + backend chips on the left, lifecycle actions on
+         the right. The model picker used to live here as a redundant
+         <select>; it's been folded into the inline trigger on the model
+         label (which already supports hot-swap + pull-if-missing). In its
+         place we surface the slot's hardware target + concrete backend so
+         two iGPU slots running different runtimes are distinguishable. -->
     <div class="sc-foot">
-      <select
-        class="sc-select mono"
-        :value="selectedModel"
-        :disabled="!models || models.length === 0"
-        @change="$emit('select-model', $event.target.value)"
-      >
-        <option value="">{{ (!models || models.length === 0) ? 'no models' : 'pick model…' }}</option>
-        <option v-for="mdl in models" :key="mdl.id || mdl" :value="mdl.id || mdl">
-          {{ mdl.name || mdl.id || mdl }}
-        </option>
-      </select>
+      <div class="sc-foot-chips" :title="`Hardware: ${hardwareTarget.label}${backendTech ? ' · backend: ' + backendTech.label : ''}`">
+        <span class="sc-chip hw" :class="`hw-${hardwareTarget.id}`">{{ hardwareTarget.label }}</span>
+        <span
+          v-if="backendTech && backendTech.id !== hardwareTarget.id.toLowerCase()"
+          class="sc-chip backend"
+          :class="`be-${backendTech.id}`"
+        >{{ backendTech.label }}</span>
+        <span v-if="slot.context_size" class="sc-chip dim">ctx {{ (slot.context_size / 1024).toFixed(0) }}K</span>
+      </div>
 
       <button class="sc-btn" type="button" @click="$emit('edit')" title="Edit">
         <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.6"><path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
@@ -632,7 +666,14 @@ const sparkSvg = computed(() => {
       <button v-if="running" class="sc-btn danger" type="button" :disabled="busy" @click="$emit('action', 'unload')" title="Stop">
         <svg width="14" height="14" fill="currentColor" viewBox="0 0 24 24"><rect x="6" y="6" width="12" height="12" rx="1"/></svg>
       </button>
-      <button v-else class="sc-btn good" type="button" :disabled="busy" @click="$emit('action', selectedModel ? 'load' : 'load')" title="Start">
+      <button
+        v-else
+        class="sc-btn good"
+        type="button"
+        :disabled="busy"
+        @click="startSlot"
+        :title="currentModelId ? 'Start' : 'Pick a model to start'"
+      >
         <svg width="14" height="14" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5.14v14l11-7-11-7z"/></svg>
       </button>
       <!-- Delete is hidden for built-in slots (primary/embed/stt/tts); the
@@ -726,12 +767,12 @@ const sparkSvg = computed(() => {
 }
 
 .sc-models {
-  padding: 4px 16px;
+  padding: 6px 16px 2px;
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 4px;
-  min-height: 19px;
+  min-height: 28px;
 }
 .sc-model {
   font-size: 11px;
@@ -756,13 +797,6 @@ const sparkSvg = computed(() => {
   background: color-mix(in srgb, var(--hal0-accent) 12%, transparent);
 }
 
-.sc-meta {
-  padding: 6px 16px 0;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
-}
 .sc-chip {
   font-family: var(--font-mono);
   font-size: 9px;
@@ -845,18 +879,51 @@ const sparkSvg = computed(() => {
   align-items: center;
   gap: 6px;
 }
-.sc-select {
+/* Left-side chip cluster replaces the legacy model `<select>`. Flex-grows
+   so the action buttons hug the right edge regardless of how many chips
+   render (cpu-only slots have just the hw chip; iGPU/vulkan slots have
+   two; FLM slots inherit hw=NPU + backend=flm). */
+.sc-foot-chips {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
   flex: 1;
   min-width: 0;
-  background: var(--color-surface-2);
-  color: var(--color-fg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  padding: 5px 8px;
-  font-size: 12px;
 }
-.sc-select:focus { outline: none; border-color: var(--color-accent); }
-.sc-select:disabled { opacity: 0.5; }
+
+/* Backend tech chip — neutral by default so it doesn't compete with the
+   hw-target chip's category colour. Specific runtimes get a recognisable
+   accent (vulkan teal, rocm orange, flm warning-amber). */
+.sc-chip.backend {
+  text-transform: lowercase;
+  letter-spacing: 0.03em;
+}
+.sc-chip.be-vulkan {
+  color: #4fc3f7;
+  border-color: color-mix(in oklch, #4fc3f7, transparent 60%);
+  background: color-mix(in oklch, #4fc3f7, transparent 88%);
+}
+.sc-chip.be-rocm {
+  color: #ff8a65;
+  border-color: color-mix(in oklch, #ff8a65, transparent 60%);
+  background: color-mix(in oklch, #ff8a65, transparent 88%);
+}
+.sc-chip.be-cuda {
+  color: #aed581;
+  border-color: color-mix(in oklch, #aed581, transparent 60%);
+  background: color-mix(in oklch, #aed581, transparent 88%);
+}
+.sc-chip.be-metal {
+  color: #ce93d8;
+  border-color: color-mix(in oklch, #ce93d8, transparent 60%);
+  background: color-mix(in oklch, #ce93d8, transparent 88%);
+}
+.sc-chip.be-flm {
+  color: var(--color-warning);
+  border-color: color-mix(in oklch, var(--color-warning), transparent 60%);
+  background: color-mix(in oklch, var(--color-warning), transparent 90%);
+}
 
 /* Default action button — transparent ghost. Edit / Logs / Delete sit
    here so they don't compete visually with the load-cycle buttons. */
@@ -905,47 +972,77 @@ const sparkSvg = computed(() => {
   border-color: var(--color-danger);
 }
 
-/* Inline swap trigger — looks like the static model label but reveals a
-   caret on hover so the affordance is discoverable. Keeps the same font
-   metrics so layout doesn't shift between FLM (read-only) and non-FLM
-   (clickable) slots. */
+/* Inline swap trigger — styled as a select-like control so the affordance
+   reads as "click me" without depending on hover. A subtle accent-tinted
+   frame distinguishes it from a static label; the left swap-arrows icon
+   reinforces that this is a swap action, and the right caret indicates
+   a dropdown. Empty-state ("select model…") gets a stronger amber accent
+   to draw the eye for newly-created slots. */
 .sc-model-trigger {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   max-width: 100%;
-  background: transparent;
-  border: 0;
-  padding: 0;
+  padding: 3px 8px;
   margin: 0;
   font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--color-fg-muted);
+  font-size: 12px;
+  line-height: 1.2;
+  color: var(--color-fg);
   cursor: pointer;
+  background: color-mix(in oklch, var(--hal0-accent) 5%, var(--color-surface-2));
+  border: 1px solid color-mix(in oklch, var(--hal0-accent) 24%, var(--color-border));
   border-radius: var(--radius-sm);
   text-align: left;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 .sc-model-trigger .sc-model-text {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+.sc-model-trigger .sc-swap-icon {
+  flex-shrink: 0;
+  color: var(--hal0-accent);
+  opacity: 0.75;
 }
 .sc-model-trigger .sc-swap-caret {
   flex-shrink: 0;
-  opacity: 0;
-  transition: opacity 0.15s ease;
+  opacity: 0.7;
+  color: var(--hal0-accent);
+  transition: transform 0.15s ease, opacity 0.15s ease;
 }
 .sc-model-trigger:hover,
 .sc-model-trigger:focus-visible,
-.sc-model-trigger[aria-expanded="true"] {
-  color: var(--color-fg);
+.sc-model-trigger.is-open {
+  background: color-mix(in oklch, var(--hal0-accent) 12%, var(--color-surface-2));
+  border-color: color-mix(in oklch, var(--hal0-accent) 50%, var(--color-border));
 }
+.sc-model-trigger:hover .sc-swap-icon,
+.sc-model-trigger:focus-visible .sc-swap-icon,
+.sc-model-trigger.is-open .sc-swap-icon { opacity: 1; }
 .sc-model-trigger:hover .sc-swap-caret,
-.sc-model-trigger:focus-visible .sc-swap-caret,
-.sc-model-trigger[aria-expanded="true"] .sc-swap-caret {
-  opacity: 0.8;
-}
+.sc-model-trigger:focus-visible .sc-swap-caret { opacity: 1; }
+.sc-model-trigger.is-open .sc-swap-caret { transform: rotate(180deg); opacity: 1; }
 .sc-model-trigger:focus-visible { outline: 1px solid var(--color-accent); outline-offset: 2px; }
+
+/* Empty-state — slot has no model assigned yet. Stronger accent so the
+   operator knows this is the primary CTA to get the slot running. */
+.sc-model-trigger.is-empty {
+  color: var(--hal0-accent);
+  background: color-mix(in oklch, var(--hal0-accent) 10%, var(--color-surface-2));
+  border-color: color-mix(in oklch, var(--hal0-accent) 50%, var(--color-border));
+  border-style: dashed;
+}
+.sc-model-trigger.is-empty:hover,
+.sc-model-trigger.is-empty:focus-visible,
+.sc-model-trigger.is-empty.is-open {
+  background: color-mix(in oklch, var(--hal0-accent) 18%, var(--color-surface-2));
+  border-color: var(--hal0-accent);
+  border-style: solid;
+}
 </style>
 
 <!-- Popover is teleported to <body>. Scoped styles travel with the root

--- a/ui/src/components/capabilities/NPUBackendCard.vue
+++ b/ui/src/components/capabilities/NPUBackendCard.vue
@@ -8,10 +8,10 @@
  *      The "Loaded on NPU" list and memory bar both read from the live
  *      `{ loaded, memUsedMb, memTotalMb, totalReqPerSec }` snapshot.
  *
- *   2. Operator affordance: "+ load NPU model" (preview only). Lets the
- *      operator queue an extra model client-side; v1.1 will wire this to
- *      a backend endpoint. Local `extras` ref stays in this component on
- *      purpose — it's UI scratch state, not capability-store state.
+ *   2. Operator affordance: "+ load NPU model". The button creates a real
+ *      FLM slot via `POST /api/backends/npu/load`; the slot then shows up
+ *      in `/api/backends/npu`'s `loaded` array on the next poll. Removing
+ *      a row tears the slot back down via `POST /api/backends/npu/unload`.
  *
  * Long-term home for this card is the Hardware view (as one of a row of
  * backend cards). Surfaced here next to the capability cards because it
@@ -21,14 +21,15 @@ import { computed, ref } from 'vue'
 import { useCapabilities, useBackend } from '../../composables/useCapabilities.js'
 import { usePullJob, fmtBytes } from '../../composables/usePullJob.js'
 import { useToastsStore } from '../../stores/toasts.js'
+import { api } from '../../composables/useApi.js'
 
 const cap = useCapabilities()
-const { data: npu, error: npuError } = useBackend('npu')
+const { data: npu, error: npuError, refresh: refreshNpu } = useBackend('npu')
 
 const showAdvanced = ref(false)
 const showAdd = ref(false)
 const addPick = ref('')
-const extras = ref([])  // [{ capability, modelId, size_gb }] — preview-only, see header
+const busyUnload = ref('')  // slot name currently being unloaded (for spinner)
 
 // Static fallback while /api/backends/npu hasn't responded yet — keeps
 // the card from flickering empty on first paint.
@@ -74,11 +75,11 @@ const npuModels = computed(() => {
   return out
 })
 
-// IDs already on the live "loaded" list or claimed by a local extra.
+// IDs already on the live "loaded" list — used to filter the add picker
+// so we don't offer to load a model that's already serving.
 const claimedIds = computed(() => {
   const set = new Set()
   for (const item of snap.value.loaded ?? []) set.add(item.modelId)
-  for (const e of extras.value) set.add(e.modelId)
   return set
 })
 
@@ -86,29 +87,21 @@ const addOptions = computed(() =>
   npuModels.value.filter((m) => !claimedIds.value.has(m.id)),
 )
 
-// Combined "serving" list — live backend `loaded` + locally-added extras.
-// `path` is the canonical "{slot}.{child}" tag used to render the
-// capability prefix in the row.
-const serving = computed(() => {
-  const live = (snap.value.loaded ?? []).map((c) => ({
+// Live "serving" list — pulled straight from /api/backends/npu's loaded
+// array. `path` is the canonical "{slot}.{child}" tag used to render the
+// capability prefix in the row, and `slotName` is what the unload route
+// needs.
+const serving = computed(() =>
+  (snap.value.loaded ?? []).map((c) => ({
     path: `${c.slot}.${c.child}`,
+    slotName: c.slotName,
     modelId: c.modelId,
-    source: 'slot',
+    source: c.source ?? 'slot',
     sizeMb: c.sizeMb,
-  }))
-  const extra = extras.value.map((e) => ({
-    path: `npu.${e.capability}`,
-    modelId: e.modelId,
-    source: 'extra',
-    sizeMb: Math.round((e.size_gb || 0) * 1024),
-  }))
-  return [...live, ...extra]
-})
-
-const extraMemMb = computed(() =>
-  extras.value.reduce((n, e) => n + Math.round((e.size_gb || 0) * 1024), 0),
+  })),
 )
-const totalUsedMb = computed(() => (snap.value.memUsedMb || 0) + extraMemMb.value)
+
+const totalUsedMb = computed(() => snap.value.memUsedMb || 0)
 const memPct = computed(() => {
   const tot = snap.value.memTotalMb || 0
   if (!tot) return 0
@@ -126,8 +119,7 @@ async function addExtra() {
   const m = npuModels.value.find((x) => x.id === addPick.value)
   if (!m) return
   // Same pattern as the capability cards: pull first when the file
-  // isn't on disk, then commit the selection (currently UI-only state
-  // for NPU extras — see the header note about v1.1 wiring).
+  // isn't on disk, then promote to a real FLM slot via the backend.
   if (m.downloaded === false) {
     if (m.pullable === false) {
       npuToasts.error(
@@ -144,16 +136,38 @@ async function addExtra() {
       return
     }
   }
-  extras.value.push({
-    capability: m.capability,
-    modelId: m.id,
-    size_gb: m.size_gb,
-  })
+  // Promote into a real slot — the next /api/backends/npu poll will
+  // surface it in `loaded` so the row appears in the serving list.
+  try {
+    await api('/api/backends/npu/load', {
+      method: 'POST',
+      body: JSON.stringify({ model_id: m.id }),
+    })
+  } catch (err) {
+    npuToasts.error(`load "${m.id}" failed: ${err?.message ?? err}`)
+    return
+  }
   addPick.value = ''
   showAdd.value = false
+  // Refresh immediately so the user sees the new row without waiting
+  // for the 5s backend poll tick.
+  refreshNpu()
 }
-function removeExtra(idx) {
-  extras.value.splice(idx, 1)
+
+async function unloadSlot(slotName) {
+  if (!slotName || busyUnload.value) return
+  busyUnload.value = slotName
+  try {
+    await api('/api/backends/npu/unload', {
+      method: 'POST',
+      body: JSON.stringify({ slot_name: slotName }),
+    })
+    refreshNpu()
+  } catch (err) {
+    npuToasts.error(`unload "${slotName}" failed: ${err?.message ?? err}`)
+  } finally {
+    busyUnload.value = ''
+  }
 }
 
 // Group add-options by the upstream capability bucket. The
@@ -205,22 +219,23 @@ const addOptionsGrouped = computed(() => {
         </span>
       </div>
       <ul class="bc-serving-list">
-        <li v-for="(item, i) in serving" :key="item.path + ':' + item.modelId">
+        <li v-for="item in serving" :key="item.slotName + ':' + item.modelId">
           <span class="bc-ch-left">
             <span class="bc-ch-cap">{{ item.path.split('.')[1] }}</span>
             <span class="bc-ch-model mono">{{ item.modelId }}</span>
           </span>
           <span class="bc-ch-right">
             <span class="bc-ch-source" :data-source="item.source">
-              {{ item.source === 'slot' ? item.path.split('.')[0] : 'preview' }}
+              {{ item.path.split('.')[0] }}
             </span>
             <button
-              v-if="item.source === 'extra'"
+              v-if="item.source === 'slot'"
               type="button"
               class="bc-ch-x"
+              :disabled="busyUnload === item.slotName"
               :aria-label="`Unload ${item.modelId}`"
-              @click="removeExtra(i - serving.filter(s => s.source === 'slot').length)"
-            >×</button>
+              @click="unloadSlot(item.slotName)"
+            >{{ busyUnload === item.slotName ? '…' : '×' }}</button>
           </span>
         </li>
         <li v-if="serving.length === 0" class="bc-empty">
@@ -237,9 +252,6 @@ const addOptionsGrouped = computed(() => {
             :disabled="addOptions.length === 0"
             @click="showAdd = true"
           >+ load NPU model</button>
-          <span class="bc-add-hint mono" title="local UI scratch — not yet wired to the backend">
-            preview only
-          </span>
           <span v-if="addOptions.length === 0" class="bc-add-empty mono">no models left</span>
         </template>
         <template v-else>

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -29,7 +29,7 @@ import NPUBackendCard from '../components/capabilities/NPUBackendCard.vue'
 const router = useRouter()
 const system = useSystemStore()
 const { stats } = useStats(2500)
-const { metrics, aggHistory } = useSlotMetrics(2500)
+const { metrics, history, aggHistory } = useSlotMetrics(2500)
 
 const hw = computed(() => stats.value || {})
 
@@ -367,6 +367,7 @@ loadChatModels()
               :key="slot.name"
               :slot="slot"
               :metrics="metrics[slot.name]"
+              :spark-data="history[slot.name] || { tps: [], pps: [] }"
               @action="() => router.push('/slots')"
               @logs="() => router.push('/slots')"
               @edit="() => router.push('/slots')"

--- a/ui/src/views/Slots.vue
+++ b/ui/src/views/Slots.vue
@@ -161,8 +161,20 @@ async function slotAction(slotName, action, body = null) {
 }
 
 async function doLoad(slot) {
-  const model = slotSelections.value[slot.name] || slot._selectedModel
-  if (!model) { toasts.warning('Select a model first'); return }
+  // The card's footer <select> was removed in favour of the inline swap
+  // trigger on the model label, so slotSelections is only populated by
+  // the legacy row layout (kept behind v-if="false"). Fall back to the
+  // slot's persisted model_id so Start on a previously-loaded slot just
+  // reloads its model; if even that is empty the POST body is omitted
+  // and the API uses the slot's TOML default.
+  const model = slotSelections.value[slot.name]
+    || slot._selectedModel
+    || slot.model_id
+    || slot.model
+  if (!model) {
+    await slotAction(slot.name, 'load')
+    return
+  }
   await slotAction(slot.name, 'load', { model })
 }
 
@@ -615,14 +627,10 @@ const SLOT_TYPES = ['llama-server', 'flm', 'moonshine', 'kokoro']
             :slot="slot"
             :metrics="slotMetrics[slot.name]"
             :spark-data="slotHistory[slot.name] || { tps: [], pps: [] }"
-            :models="models"
-            :selected-model="slot._selectedModel"
             :action-loading="actionBusy[slot.name]"
-            @select-model="(v) => { slotSelections[slot.name] = v }"
             @action="(a) => a === 'load' ? doLoad(slot) : slotAction(slot.name, a)"
             @logs="openLogs(slot)"
             @edit="openEdit(slot)"
-            @swap="openEdit(slot)"
             @delete="deletingSlot = slot"
           />
           <!-- NPU backend rides in the same grid as the other slot


### PR DESCRIPTION
## Summary

Four-commit bundle from the npu-fixes branch — all small, all surface-level fixes for what was left rough after the v0.1.0-alpha cut.

- **a9ad9ca** \`fix(registry/flm)\`: poll dir size instead of per-file regex for monotonic pull progress. Multi-file FLM models were rendering as a backwards-jumping progress bar because each new file reset \`bytes_downloaded\` to 0.
- **f52887e** \`feat(npu)\`: wire \"+ load NPU model\" to real FLM slot lifecycle. New \`POST /api/backends/npu/{load,unload}\` endpoints turn the dashboard's preview-only button into a real slot create + load. \`unload\` refuses anything outside the \`npu-\` prefix so misdirected calls can't touch primary/embed/etc.
- **721b4d6** \`ui(slots)\`: drop card-footer model \`<select>\` for inline swap trigger. Two affordances were pointing at the same operation after the inline swap popover landed; this consolidates on the inline path.
- **31ecd0a** \`fix(ui/dashboard)\`: wire SlotCard \`:spark-data\` so throughput sparklines render. The d6f34e1 refactor missed this prop; Slots.vue and the footer SlotsTab were already wiring it.

## Test plan

- [x] FLM pull (llama3.2:1b) shows strictly-monotonic SSE progress end-to-end
- [x] \"+ load NPU model\" creates an \`npu-<model>\` slot, \`/v1/chat/completions\` returns ~39 tps decode
- [x] \"×\" on an NPU row unloads the slot; no console errors; \`systemctl --failed\` stays clean
- [x] SlotCard inline swap reachable from the model label and from the Start button on a modelless slot
- [x] Dashboard sparklines render during streaming chat (verified via a curl-driven chat to nano: \`/api/slots/metrics\` reports \`tokens_per_sec=216.94\` mid-stream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)