### PR TITLE
fix(providers): derive llama-server --embedding from model capabilities

### DIFF
--- a/src/hal0/providers/llama_server.py
+++ b/src/hal0/providers/llama_server.py
@@ -138,8 +138,10 @@ class LlamaServerProvider(Provider):
 
         port = _g(slot_cfg, "port", "slot", "port", 8081)
         model_path = model_info.get("path", "")
-        is_embedding = model_info.get("embedding", False) or _g(
-            slot_cfg, "embedding", "defaults", "embedding", False
+        is_embedding = (
+            model_info.get("embedding", False)
+            or _g(slot_cfg, "embedding", "defaults", "embedding", False)
+            or "embed" in (model_info.get("capabilities") or [])
         )
 
         # Slot backend wins; model preferred_backend is legacy fallback.

--- a/tests/providers/test_llama_server.py
+++ b/tests/providers/test_llama_server.py
@@ -117,6 +117,15 @@ def test_build_env_emits_embedding_flag_when_model_is_embedding(
     assert "--embedding" in env["HAL0_EXTRA_ARGS"]
 
 
+def test_build_env_emits_embedding_flag_when_model_has_embed_capability(
+    provider: LlamaServerProvider, slot_cfg: dict[str, Any], model_info: dict[str, Any]
+) -> None:
+    model_info.pop("embedding", None)
+    model_info["capabilities"] = ["embed"]
+    env = provider.build_env(slot_cfg, model_info)
+    assert "--embedding" in env["HAL0_EXTRA_ARGS"]
+
+
 # ─── A3 flag-merge wiring (model.defaults.extra_args ⊕ slot.server.extra_args)
 #
 # These exercise the launcher's arg-build site that consumes the new


### PR DESCRIPTION
## Summary

\`LlamaServerProvider._is_embedding\` only consulted \`model_info[\"embedding\"]\` and \`slot_cfg.defaults.embedding\` — but the registry's canonical signal for \"this is an embedder\" lives in the \`capabilities\` list (e.g. \`[\"embed\"]\` for nomic-embed, \`[\"rerank\"]\` for bge-reranker-v2-m3). Without an explicit \`embedding=true\` on either the slot or the model row, the provider would launch llama-server without \`--embedding\`, and the slot would 500 on \`/v1/embeddings\` calls.

Add a third branch to the OR: \`\"embed\" in (model_info.get(\"capabilities\") or [])\`. Existing branches still take precedence — operator-set \`embedding\` flags win over capability inference, as they should.

## Test plan

- [x] New test in \`tests/providers/test_llama_server.py\` covers the capability-tag path
- [x] Existing slot.embedding / model.embedding tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)