### PR TITLE
fix(ui/slots): treat 'idle' as an active slot state

### DIFF
--- a/ui/src/composables/useSlotStats.js
+++ b/ui/src/composables/useSlotStats.js
@@ -2,7 +2,12 @@ import { computed } from 'vue'
 import { useSystemStore } from '../stores/system.js'
 
 // Shared running/total/active counts for navbar, sidebar, and dashboard.
-export const ACTIVE_STATES = new Set(['running', 'ready', 'serving'])
+// ``idle`` is included intentionally — a slot whose idle_timeout_s window
+// elapsed without traffic still has its container up, model loaded, and
+// can serve the next request instantly. Excluding it (as the previous
+// revision did) made primary/nano render as "offline" 5 minutes after
+// the last completion, which kept being mis-read as a slot crash.
+export const ACTIVE_STATES = new Set(['running', 'ready', 'serving', 'idle'])
 
 // Providers that serve a single baked-in model without an explicit load —
 // a missing model_id on these is not a misconfiguration.


### PR DESCRIPTION
## Summary

\`ACTIVE_STATES\` in \`useSlotStats.js\` omitted \`idle\`, so once a slot crossed its \`idle_timeout_s\` (default 300s) without traffic, the navbar / sidebar running count dropped it AND SlotCard fell through \`dotState\`'s \`!running.value → 'offline'\` branch — rendering the card with no border and a dim grey dot. Operators kept reading the lifecycle-correct \`ready → idle\` resting transition as a slot crash and restarting primary/nano needlessly.

\`idle\` is a fully-loaded, traffic-ready state per \`src/hal0/slots/state.py::SlotState\` — container up, model resident, can serve the next request without rewarming — and the \`ready ↔ idle ↔ serving\` cycle is explicitly legal per \`SLOT_LEGAL_TRANSITIONS\`. Including it here makes the UI mirror the backend lifecycle.

## Test plan

- [x] Playwright on hal0.thinmint.dev: primary + nano at \`status=\"idle\"\` now render with the standard \`is-running sc-state-idle\` classes
- [x] SLOTS RUNNING reads 6/6 instead of 4/6 after a slot idles out

🤖 Generated with [Claude Code](https://claude.com/claude-code)