### PR TITLE
feat(hardware): surface Proxmox host pressure on the dashboard

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -33,6 +33,9 @@ from hal0.api.routes import (
     events as events_routes,
 )
 from hal0.api.routes import (
+    proxmox as proxmox_routes,
+)
+from hal0.api.routes import (
     hardware,
     health,
     images,
@@ -449,6 +452,15 @@ def create_app() -> FastAPI:
         settings.router,
         prefix="/api/settings",
         tags=["settings"],
+        dependencies=_admin_auth,
+    )
+    # Proxmox integration sub-router (config file at /etc/hal0/proxmox.json).
+    # Mounted as a sibling under /api/settings/proxmox so the dashboard's
+    # Settings panel can read/write it without touching hal0.toml.
+    app.include_router(
+        proxmox_routes.router,
+        prefix="/api/settings/proxmox",
+        tags=["settings", "proxmox"],
         dependencies=_admin_auth,
     )
     app.include_router(

--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -114,13 +114,96 @@ async def _proxy_upstream_endpoint(
     return out
 
 
-def _local_live_stats(request: Request) -> dict[str, Any]:
+async def _npu_status(request: Request) -> dict[str, Any] | None:
+    """Build the ``npu_status`` block the dashboard's memory bar reads.
+
+    Shape matches haloai's ``lib.hardware._npu_status``: ``{ok, model_mb}``.
+
+      - ``ok``        — XDNA driver is loaded (taken from the cached probe;
+                        no subprocess work happens here).
+      - ``model_mb``  — sum of the model file sizes for any slot whose
+                        provider is FLM. Read from the model registry so
+                        we don't shell out per stats poll. Zero when no
+                        FLM slot is loaded — the UI hides the segment.
+
+    Returns ``None`` if no NPU is present so the field stays absent and
+    the UI's NPU pill / segment collapse cleanly.
+    """
+    try:
+        info = load_hardware_info().model_dump(mode="python")
+    except Exception:
+        return None
+    npu = info.get("npu") or {}
+    if not npu.get("present"):
+        return None
+
+    model_mb = 0.0
+    slot_manager = getattr(request.app.state, "slot_manager", None)
+    registry = getattr(request.app.state, "model_registry", None)
+    if slot_manager is not None:
+        # Only states where the model is actually resident on the NPU.
+        # PULLING/STARTING haven't loaded yet; OFFLINE/UNLOADING/ERROR
+        # don't hold weights in GTT.
+        live_states = {"warming", "ready", "serving", "idle"}
+        try:
+            slots = await slot_manager.list()
+        except Exception:
+            slots = []
+        # Build the FLM catalog lookup lazily — only when we actually have
+        # an FLM slot live. flm_served_models() is cached, so repeated
+        # calls are O(1) after the first probe.
+        flm_catalog: dict[str, dict[str, Any]] | None = None
+        for s in slots:
+            state = str(getattr(s, "state", "") or "").lower()
+            if state not in live_states:
+                continue
+            meta = getattr(s, "metadata", None) or {}
+            provider = (meta.get("provider") or "").lower()
+            backend = str(getattr(s, "backend", None) or meta.get("backend") or "").lower()
+            if provider != "flm" and backend not in ("flm", "npu"):
+                continue
+            mid = getattr(s, "model_id", None)
+            if not mid:
+                continue
+            # FLM tags ("name:tag") live in their own namespace — they are
+            # not in the hal0 model registry. Prefer FLM's own footprint
+            # estimate (runtime memory, includes KV cache) over file size.
+            sz_mb = 0.0
+            if flm_catalog is None:
+                try:
+                    from hal0.providers.flm import flm_served_models
+
+                    flm_catalog = {e["tag"]: e for e in flm_served_models()}
+                except Exception:
+                    flm_catalog = {}
+            flm_entry = flm_catalog.get(mid)
+            if flm_entry:
+                footprint_gb = flm_entry.get("footprint_gb") or 0.0
+                if footprint_gb > 0:
+                    sz_mb = footprint_gb * 1024
+                else:
+                    sz_mb = (flm_entry.get("size_bytes") or 0) / (1024 * 1024)
+            elif registry is not None:
+                # Non-FLM-tag model id (rare for npu slots, but possible
+                # if someone wires a llamacpp-shaped GGUF through FLM).
+                try:
+                    m = registry.get(mid)
+                    sz_mb = (getattr(m, "size_bytes", 0) or 0) / (1024 * 1024)
+                except Exception:
+                    sz_mb = 0.0
+            model_mb += sz_mb
+
+    return {"ok": True, "model_mb": round(model_mb, 1)}
+
+
+async def _local_live_stats(request: Request) -> dict[str, Any]:
     """Read live counters from this process's HardwareStats.
 
     Maps the snapshot() fields onto the names the dashboard expects:
     ``ram_used_mb``, ``ram_used_gb``, ``gtt_used_mb``, ``vram_used_mb``,
-    plus a ``gpu_util`` fraction. Returned values may be ``None`` when a
-    counter isn't available on this host (e.g. no AMD/NVIDIA GPU).
+    plus a ``gpu_util`` fraction and an ``npu_status`` block. Returned
+    values may be ``None`` when a counter isn't available on this host
+    (e.g. no AMD/NVIDIA GPU).
     """
 
     stats = getattr(request.app.state, "hardware_stats", None)
@@ -148,7 +231,7 @@ def _local_live_stats(request: Request) -> dict[str, Any]:
         vram_used = _read_sysfs_mb(drm / "mem_info_vram_used")
 
     ram_used_gb = snap.get("ram_used_gb") or 0.0
-    return {
+    out: dict[str, Any] = {
         "ram_used_gb": ram_used_gb,
         "ram_used_mb": int(ram_used_gb * 1024),
         "ram_available_gb": snap.get("ram_available_gb"),
@@ -158,6 +241,10 @@ def _local_live_stats(request: Request) -> dict[str, Any]:
         "gpu_vram_used_mb": snap.get("gpu_vram_used_mb"),
         "gpu_vram_total_mb": snap.get("gpu_vram_total_mb"),
     }
+    npu_status = await _npu_status(request)
+    if npu_status is not None:
+        out["npu_status"] = npu_status
+    return out
 
 
 @router.get("/stats/hardware")
@@ -188,12 +275,47 @@ async def stats_hardware(request: Request) -> dict[str, Any]:
 
     # Live counters from this process — overwrite any zero/missing values
     # in the upstream payload (which often has only the static probe shape).
-    local = _local_live_stats(request)
+    local = await _local_live_stats(request)
     for key, val in local.items():
         if val is None:
             continue
         if primary.get(key) in (None, 0, 0.0):
             primary[key] = val
+
+    # Proxmox host status (when /etc/hal0/proxmox.json is configured).
+    # The merge above already lets an upstream's ``host`` field win if
+    # one was reported; for the common single-LXC deployment we attach
+    # this process's own pve probe. ``configured: false`` keeps the
+    # dashboard quiet on non-Proxmox installs.
+    #
+    # The payload here is the *slim* projection (no tenants[]) because
+    # the dashboard polls /api/stats/hardware every 2.5 s. The Settings
+    # card consumes the full shape via /api/settings/proxmox instead.
+    from hal0.hardware import pve
+
+    if "host" not in primary or not isinstance(primary.get("host"), dict):
+        full = await pve.pve_status()
+        transition = pve.pop_transition(full)
+        if transition is not None:
+            event_bus = getattr(request.app.state, "events", None)
+            if event_bus is not None:
+                if transition == "became_broken":
+                    await event_bus.emit(
+                        "system.proxmox_unreachable",
+                        "warn",
+                        "system",
+                        f"Proxmox host integration unreachable: {full.get('error', 'unknown error')}",
+                        data={"error": full.get("error")},
+                    )
+                else:  # recovered
+                    await event_bus.emit(
+                        "system.proxmox_recovered",
+                        "info",
+                        "system",
+                        f"Proxmox host integration recovered ({full.get('node', '?')})",
+                        data={"node": full.get("node")},
+                    )
+        primary["host"] = pve.project_slim(full)
 
     primary["per_upstream"] = per_upstream
     primary["upstream_names"] = list(per_upstream.keys())

--- a/src/hal0/api/routes/proxmox.py
+++ b/src/hal0/api/routes/proxmox.py
@@ -1,0 +1,230 @@
+"""Proxmox-integration settings endpoints (mounted under /api/settings).
+
+Lets operators configure the optional Proxmox API token used by the
+dashboard's "Proxmox host" memory segment (see hal0.hardware.pve).
+Token is sensitive — it's never echoed back in GET, only ``token_value_set``.
+
+Endpoints:
+    GET    /api/settings/proxmox        — config (redacted) + live status
+    PUT    /api/settings/proxmox        — write new config (atomic)
+    DELETE /api/settings/proxmox        — remove config file
+    POST   /api/settings/proxmox/test   — validate a candidate without saving
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel, Field, ValidationError
+
+from hal0.api.middleware.auth import require_writer
+from hal0.api.middleware.error_codes import Hal0Error
+from hal0.hardware import pve
+
+_writer = [Depends(require_writer)]
+
+router = APIRouter()
+
+
+class ProxmoxConfigBody(BaseModel):
+    """Request shape for PUT /api/settings/proxmox.
+
+    ``token_value`` is optional on edit — if omitted, the existing
+    on-disk value is preserved so the operator can flip ``verify_ssl``
+    or change the host without re-entering the secret.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    host: str = Field(min_length=1)
+    port: int = Field(default=8006, ge=1, le=65535)
+    user: str = Field(min_length=1)
+    token_name: str = Field(min_length=1)
+    token_value: str | None = None
+    verify_ssl: bool = False
+
+
+class ProxmoxTestBody(BaseModel):
+    """Request shape for POST /api/settings/proxmox/test.
+
+    Same as ProxmoxConfigBody but ``token_value`` is required — testing
+    a saved config without editing it goes through the live status that
+    GET already returns.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    host: str = Field(min_length=1)
+    port: int = Field(default=8006, ge=1, le=65535)
+    user: str = Field(min_length=1)
+    token_name: str = Field(min_length=1)
+    token_value: str = Field(min_length=1)
+    verify_ssl: bool = False
+
+
+def _validation_details(exc: ValidationError) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for err in exc.errors():
+        loc = ".".join(str(p) for p in err.get("loc", ()))
+        out[loc or "<root>"] = err.get("msg", "invalid")
+    return out
+
+
+def _load_for_get() -> dict[str, Any]:
+    """Read the raw config (token included) to learn what's persisted.
+
+    Used by GET to surface non-secret fields + a ``token_value_set``
+    flag. The token itself is never returned in the API response.
+    """
+    from hal0.hardware.pve import _load_pve_config
+
+    return _load_pve_config() or {}
+
+
+@router.get("")
+async def get_proxmox_config() -> dict[str, Any]:
+    """Return the current Proxmox integration state.
+
+    Shape:
+        {
+          configured: bool,
+          host, port, user, token_name, verify_ssl,   # blank when unconfigured
+          token_value_set: bool,                       # true iff a token is on disk
+          status: <pve_status() output>,               # live cluster snapshot
+        }
+    """
+    raw = _load_for_get()
+    status = await pve.pve_status()
+    body: dict[str, Any] = {
+        "configured": bool(raw),
+        "host": raw.get("host", ""),
+        "port": raw.get("port", 8006),
+        "user": raw.get("user", ""),
+        "token_name": raw.get("token_name", ""),
+        "verify_ssl": bool(raw.get("verify_ssl", False)),
+        "token_value_set": bool(raw.get("token_value")),
+        "status": status,
+    }
+    return body
+
+
+@router.put("", dependencies=_writer)
+async def put_proxmox_config(request: Request) -> dict[str, Any]:
+    """Write /etc/hal0/proxmox.json from the supplied body.
+
+    If ``token_value`` is omitted and a file already exists, the
+    persisted token is preserved — lets the UI edit other fields
+    without re-prompting for the secret.
+    """
+    try:
+        raw = await request.json()
+    except Exception as exc:
+        raise Hal0Error(
+            "request body must be valid JSON",
+            details={"error": str(exc)},
+            code="request.invalid_json",
+        ) from exc
+    if not isinstance(raw, dict):
+        raise Hal0Error("request body must be a JSON object")
+
+    try:
+        body = ProxmoxConfigBody.model_validate(raw)
+    except ValidationError as exc:
+        raise Hal0Error(
+            "proxmox config failed validation",
+            code="proxmox.config_invalid",
+            details=_validation_details(exc),
+            status=400,
+        ) from exc
+
+    payload = body.model_dump()
+    if not payload.get("token_value"):
+        existing = _load_for_get()
+        if existing.get("token_value"):
+            payload["token_value"] = existing["token_value"]
+        else:
+            raise Hal0Error(
+                "token_value is required when no token is on disk yet",
+                code="proxmox.token_required",
+                details={"field": "token_value"},
+                status=400,
+            )
+
+    try:
+        pve.save_pve_config(payload)
+    except OSError as exc:
+        raise Hal0Error(
+            f"could not persist proxmox config: {exc}",
+            code="proxmox.write_failed",
+            details={"error": str(exc), "errno": getattr(exc, "errno", None)},
+        ) from exc
+
+    event_bus = getattr(request.app.state, "events", None)
+    if event_bus is not None:
+        await event_bus.emit(
+            "system.proxmox_save",
+            "info",
+            "system",
+            "proxmox integration saved",
+            data={"host": payload["host"], "user": payload["user"]},
+        )
+    return await get_proxmox_config()
+
+
+@router.delete("", dependencies=_writer)
+async def delete_proxmox_config(request: Request) -> dict[str, Any]:
+    """Remove the Proxmox config file (returns to 'not configured')."""
+    try:
+        existed = pve.delete_pve_config()
+    except OSError as exc:
+        raise Hal0Error(
+            f"could not delete proxmox config: {exc}",
+            code="proxmox.delete_failed",
+            details={"error": str(exc), "errno": getattr(exc, "errno", None)},
+        ) from exc
+
+    event_bus = getattr(request.app.state, "events", None)
+    if event_bus is not None and existed:
+        await event_bus.emit(
+            "system.proxmox_remove",
+            "info",
+            "system",
+            "proxmox integration removed",
+            data={},
+        )
+    return {"configured": False, "existed": existed}
+
+
+@router.post("/test", dependencies=_writer)
+async def test_proxmox_config(request: Request) -> dict[str, Any]:
+    """Validate a candidate config WITHOUT writing it.
+
+    Used by the Settings UI's 'Test connection' button so operators
+    can verify creds before clicking Save.
+    """
+    try:
+        raw = await request.json()
+    except Exception as exc:
+        raise Hal0Error(
+            "request body must be valid JSON",
+            details={"error": str(exc)},
+            code="request.invalid_json",
+        ) from exc
+    if not isinstance(raw, dict):
+        raise Hal0Error("request body must be a JSON object")
+
+    try:
+        body = ProxmoxTestBody.model_validate(raw)
+    except ValidationError as exc:
+        raise Hal0Error(
+            "proxmox config failed validation",
+            code="proxmox.config_invalid",
+            details=_validation_details(exc),
+            status=400,
+        ) from exc
+
+    return await pve.pve_test(body.model_dump())
+
+
+__all__ = ["router"]

--- a/src/hal0/hardware/pve.py
+++ b/src/hal0/hardware/pve.py
@@ -1,0 +1,362 @@
+"""Proxmox host-pressure probe.
+
+Optional integration: on Strix Halo (and any other AMD-APU /
+single-physical-pool box) deployed as an LXC, the LXC's view of memory
+is just its cgroup share. Other tenants and the host kernel itself draw
+from the same physical DIMMs the GPU's GTT lives in — competing for the
+unified pool with no in-LXC visibility.
+
+When the operator configures ``/etc/hal0/proxmox.json`` with a
+read-only API token, we pull cluster/resources and surface:
+
+  - ``host_mem_total_mb`` / ``host_mem_used_mb`` — physical host RAM
+  - ``tenants`` — every running LXC/VM with its actual + max memory
+
+…so the dashboard's unified-memory bar can show "Proxmox Host" pressure
+honestly instead of pretending only this LXC's bytes exist.
+
+If the config file is missing, every API caller treats it as
+"not configured" and skips the segment — non-Proxmox deployments stay
+out of the way.
+
+Port target: haloai/lib/hardware.py:_pve_status (~2026-04-30).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import ssl
+import tempfile
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from hal0.config import paths
+
+log = structlog.get_logger(__name__)
+
+
+def pve_config_path() -> Path:
+    """Return /etc/hal0/proxmox.json (or HAL0_HOME-rooted equivalent)."""
+    return paths.etc() / "proxmox.json"
+
+
+def _load_pve_config() -> dict[str, Any] | None:
+    """Read /etc/hal0/proxmox.json and return the parsed dict, or None.
+
+    Returns None for: file missing, unreadable, malformed JSON, or
+    missing required keys. Non-Proxmox deployments stay silent.
+    """
+    target = pve_config_path()
+    try:
+        raw = json.loads(target.read_text())
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError) as exc:
+        log.warning("pve.config_unreadable", path=str(target), error=str(exc))
+        return None
+
+    try:
+        proxmox = raw["proxmox"]
+        auth = raw["auth"]
+        cfg = {
+            "host": proxmox["host"],
+            "port": int(proxmox.get("port", 8006)),
+            "verify_ssl": bool(proxmox.get("verify_ssl", False)),
+            "user": auth["user"],
+            "token_name": auth["token_name"],
+            "token_value": auth["token_value"],
+        }
+    except (KeyError, TypeError, ValueError) as exc:
+        log.warning("pve.config_invalid", path=str(target), error=str(exc))
+        return None
+    return cfg
+
+
+def save_pve_config(payload: dict[str, Any]) -> None:
+    """Atomically write /etc/hal0/proxmox.json from a flat payload.
+
+    Accepts the same flat shape we accept from the API
+    ({host, port, user, token_name, token_value, verify_ssl}) and writes
+    the nested {proxmox, auth} structure haloai's _load_pve_config
+    expects, so the two configs stay byte-compatible.
+    """
+    nested = {
+        "proxmox": {
+            "host": str(payload["host"]),
+            "port": int(payload.get("port", 8006)),
+            "verify_ssl": bool(payload.get("verify_ssl", False)),
+            "service": "PVE",
+        },
+        "auth": {
+            "user": str(payload["user"]),
+            "token_name": str(payload["token_name"]),
+            "token_value": str(payload["token_value"]),
+        },
+    }
+    target = pve_config_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+        dir=target.parent,
+    )
+    tmp = Path(tmp_str)
+    try:
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(nested, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise
+        # Token value is sensitive — 0600 keeps it out of the world-read
+        # path even if /etc/hal0 is more permissive.
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, target)
+        tmp = None  # type: ignore[assignment]
+    finally:
+        if tmp is not None:
+            with contextlib.suppress(OSError):
+                tmp.unlink(missing_ok=True)
+    # Drop the cache so the next status call observes the new creds.
+    invalidate_pve_cache()
+
+
+def delete_pve_config() -> bool:
+    """Remove /etc/hal0/proxmox.json. Returns True iff the file existed."""
+    target = pve_config_path()
+    existed = target.exists()
+    if existed:
+        target.unlink()
+    invalidate_pve_cache()
+    return existed
+
+
+# ── HTTP fetch ───────────────────────────────────────────────────────────────
+
+
+def _fetch_pve_resources(cfg: dict[str, Any]) -> list[dict[str, Any]]:
+    """Blocking GET /api2/json/cluster/resources. Run via to_thread."""
+    url = f"https://{cfg['host']}:{cfg['port']}/api2/json/cluster/resources"
+    header = f"PVEAPIToken={cfg['user']}!{cfg['token_name']}={cfg['token_value']}"
+    ctx: ssl.SSLContext | None = None
+    if not cfg["verify_ssl"]:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    req = urllib.request.Request(url, headers={"Authorization": header})
+    with urllib.request.urlopen(req, timeout=3.0, context=ctx) as resp:
+        body = json.loads(resp.read().decode("utf-8"))
+    return body.get("data", []) or []
+
+
+def _summarise(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    """Reduce /cluster/resources entries to the dashboard's flat shape."""
+    node = next((e for e in entries if e.get("type") == "node"), None) or {}
+    tenants: list[dict[str, Any]] = []
+    for e in entries:
+        t = e.get("type")
+        if t not in ("lxc", "qemu"):
+            continue
+        tenants.append(
+            {
+                "type": t,
+                "vmid": e.get("vmid"),
+                "name": e.get("name"),
+                "status": e.get("status"),
+                "maxmem_mb": round((e.get("maxmem") or 0) / (1024 * 1024), 1),
+                "mem_mb": round((e.get("mem") or 0) / (1024 * 1024), 1),
+                "maxcpu": e.get("maxcpu"),
+                "cpu_pct": round((e.get("cpu") or 0) * 100, 1),
+                "node": e.get("node"),
+            }
+        )
+    tenants.sort(key=lambda t: (t["status"] != "running", -t["maxmem_mb"]))
+
+    running = [t for t in tenants if t["status"] == "running"]
+    allocated_mb = sum(t["maxmem_mb"] for t in running)
+    host_max = node.get("maxmem") or 0
+    host_used = node.get("mem") or 0
+    return {
+        "configured": True,
+        "ok": True,
+        "node": node.get("node"),
+        "host_mem_total_mb": round(host_max / (1024 * 1024), 1),
+        "host_mem_used_mb": round(host_used / (1024 * 1024), 1),
+        "host_mem_free_mb": round(max(0, host_max - host_used) / (1024 * 1024), 1),
+        "host_cpu_pct": round((node.get("cpu") or 0) * 100, 1),
+        "host_cpu_count": node.get("maxcpu"),
+        "host_uptime_s": node.get("uptime"),
+        "tenants_running": len(running),
+        "tenants_total": len(tenants),
+        "tenants_allocated_mb": round(allocated_mb, 1),
+        "tenants": tenants,
+    }
+
+
+# ── Slim projection + transition detection ──────────────────────────────────
+
+# Fields the dashboard's /api/stats/hardware doesn't read — keep them in
+# the full shape (returned by /api/settings/proxmox GET) but strip from
+# the slim shape so the 2.5 s-poll payload doesn't grow with cluster size.
+_SLIM_DROP_KEYS = (
+    "tenants",
+    "host_cpu_count",
+    "host_uptime_s",
+    "tenants_allocated_mb",
+)
+
+
+def project_slim(full: dict[str, Any]) -> dict[str, Any]:
+    """Strip per-tenant + unused-scalar fields from a full pve_status dict.
+
+    /api/stats/hardware is polled every 2.5 s; the full tenants[] array
+    grows O(cluster_size). The Settings card still gets the full shape
+    via /api/settings/proxmox where the cadence is on-demand.
+    """
+    if not full.get("configured"):
+        return full  # {"configured": false} — nothing to strip
+    return {k: v for k, v in full.items() if k not in _SLIM_DROP_KEYS}
+
+
+# Tracks the most recent ``ok`` observation so the caller (hardware route)
+# can emit a one-shot event on the ok→broken / broken→ok transitions.
+# None means "never observed" (process start, or configuration was just
+# removed) — the next observation primes the value but emits nothing.
+_prev_ok: bool | None = None
+
+
+def pop_transition(current: dict[str, Any]) -> str | None:
+    """Return ``"became_broken"`` / ``"recovered"`` / ``None``.
+
+    Pass the most recent ``pve_status()`` result. Updates the stored
+    state — call this exactly once per fresh observation. Returns a
+    transition tag only when ``ok`` flipped; otherwise ``None``.
+
+    Unconfigured deployments reset the stored state so a later
+    configure-then-fail doesn't fire a spurious "recovered" event
+    pulled from a much earlier session.
+    """
+    global _prev_ok
+    if not current.get("configured"):
+        _prev_ok = None
+        return None
+    cur_ok = bool(current.get("ok"))
+    prev = _prev_ok
+    _prev_ok = cur_ok
+    if prev is None:
+        return None  # first observation: prime, don't emit
+    if prev and not cur_ok:
+        return "became_broken"
+    if not prev and cur_ok:
+        return "recovered"
+    return None
+
+
+# ── Cached async wrapper ─────────────────────────────────────────────────────
+
+_TTL_S = 30.0
+_cache: dict[str, Any] | None = None
+_cache_at: float = 0.0
+_lock = asyncio.Lock()
+
+
+def invalidate_pve_cache() -> None:
+    """Drop the cached pve_status result so the next call re-fetches."""
+    global _cache, _cache_at
+    _cache = None
+    _cache_at = 0.0
+
+
+async def pve_status() -> dict[str, Any]:
+    """Return the current Proxmox host status. Cached 30 s, single-flight.
+
+    Always returns a dict — never raises — so the API route can merge it
+    unconditionally. Shape:
+
+      - config missing:  ``{"configured": false}``
+      - fetch failed:    ``{"configured": true, "ok": false, "error": ...}``
+      - fetch succeeded: full summary (see _summarise)
+    """
+    global _cache, _cache_at
+    loop = asyncio.get_event_loop()
+    now = loop.time()
+    if _cache is not None and (now - _cache_at) < _TTL_S:
+        return _cache
+
+    async with _lock:
+        now = loop.time()
+        if _cache is not None and (now - _cache_at) < _TTL_S:
+            return _cache
+
+        cfg = _load_pve_config()
+        if cfg is None:
+            result: dict[str, Any] = {"configured": False}
+            _cache = result
+            _cache_at = now
+            return result
+
+        try:
+            entries = await asyncio.to_thread(_fetch_pve_resources, cfg)
+        except Exception as exc:
+            result = {
+                "configured": True,
+                "ok": False,
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+            _cache = result
+            _cache_at = now
+            return result
+
+        result = _summarise(entries)
+        _cache = result
+        _cache_at = now
+        return result
+
+
+async def pve_test(payload: dict[str, Any]) -> dict[str, Any]:
+    """Validate a candidate config WITHOUT writing it or touching the cache.
+
+    Used by ``POST /api/settings/proxmox/test`` so operators can verify
+    credentials in the UI before saving.
+    """
+    cfg = {
+        "host": str(payload.get("host", "")),
+        "port": int(payload.get("port", 8006)),
+        "verify_ssl": bool(payload.get("verify_ssl", False)),
+        "user": str(payload.get("user", "")),
+        "token_name": str(payload.get("token_name", "")),
+        "token_value": str(payload.get("token_value", "")),
+    }
+    missing = [k for k in ("host", "user", "token_name", "token_value") if not cfg[k]]
+    if missing:
+        return {"ok": False, "error": f"missing required fields: {', '.join(missing)}"}
+    try:
+        entries = await asyncio.to_thread(_fetch_pve_resources, cfg)
+    except Exception as exc:
+        return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+    summary = _summarise(entries)
+    return {
+        "ok": True,
+        "node": summary["node"],
+        "host_mem_total_mb": summary["host_mem_total_mb"],
+        "tenants_total": summary["tenants_total"],
+    }
+
+
+__all__ = [
+    "delete_pve_config",
+    "invalidate_pve_cache",
+    "pve_config_path",
+    "pve_status",
+    "pve_test",
+    "save_pve_config",
+]

--- a/tests/hardware/test_pve.py
+++ b/tests/hardware/test_pve.py
@@ -1,0 +1,339 @@
+"""Unit tests for hal0.hardware.pve.
+
+Minimum-scope coverage (per the 2026-05-21 design grill):
+  - _summarise() shape correctness against a /cluster/resources fixture
+  - project_slim() strips the heavy fields and is a no-op when unconfigured
+  - save_pve_config round-trip, 0600 perms, no .tmp residue
+  - delete_pve_config existed-bool semantics
+  - pop_transition state machine (primes silently, fires on flip)
+  - pve_status cache TTL + invalidation
+
+Skipped on purpose (defer to v0.2):
+  - PUT route token-preservation glue (covered by save+load round-trip
+    invariant; the route-level "use existing if blank" rule is glue)
+  - Real Proxmox integration (the canary lives in /api/stats/hardware
+    on a configured deployment — see commit message)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.hardware import pve
+
+# ── /cluster/resources fixture ─────────────────────────────────────────────────
+
+
+# Trimmed sample of what Proxmox 8.x returns from /api2/json/cluster/resources.
+# One node + one running LXC + one stopped LXC + one running VM.
+_CLUSTER_RESOURCES: list[dict[str, Any]] = [
+    {
+        "type": "node",
+        "node": "pve",
+        "status": "online",
+        "maxmem": 128 * 1024 * 1024 * 1024,  # 128 GiB
+        "mem": 72 * 1024 * 1024 * 1024,  # 72 GiB used
+        "maxcpu": 32,
+        "cpu": 0.109,
+        "uptime": 1_089_410,
+    },
+    {
+        "type": "lxc",
+        "vmid": 105,
+        "name": "hal0",
+        "status": "running",
+        "node": "pve",
+        "maxmem": 96 * 1024 * 1024 * 1024,
+        "mem": int(3.78 * 1024 * 1024 * 1024),
+        "maxcpu": 16,
+        "cpu": 0.023,
+    },
+    {
+        "type": "qemu",
+        "vmid": 104,
+        "name": "hal0-dev",
+        "status": "running",
+        "node": "pve",
+        "maxmem": 16 * 1024 * 1024 * 1024,
+        "mem": int(4.2 * 1024 * 1024 * 1024),
+        "maxcpu": 8,
+        "cpu": 0.05,
+    },
+    {
+        "type": "lxc",
+        "vmid": 200,
+        "name": "stopped-lxc",
+        "status": "stopped",
+        "node": "pve",
+        "maxmem": 2 * 1024 * 1024 * 1024,
+        "mem": 0,
+        "maxcpu": 2,
+        "cpu": 0.0,
+    },
+    # Ignored entries — _summarise should skip these.
+    {"type": "storage", "storage": "local-zfs"},
+    {"type": "pool", "pool": "default"},
+]
+
+
+def test_summarise_host_block() -> None:
+    out = pve._summarise(_CLUSTER_RESOURCES)
+    assert out["configured"] is True
+    assert out["ok"] is True
+    assert out["node"] == "pve"
+    assert out["host_mem_total_mb"] == pytest.approx(128 * 1024, rel=0.01)
+    assert out["host_mem_used_mb"] == pytest.approx(72 * 1024, rel=0.01)
+    assert out["host_mem_free_mb"] == pytest.approx(56 * 1024, rel=0.01)
+    assert out["host_cpu_pct"] == pytest.approx(10.9, abs=0.1)
+    assert out["host_cpu_count"] == 32
+    assert out["host_uptime_s"] == 1_089_410
+
+
+def test_summarise_tenants_filtered_and_sorted() -> None:
+    out = pve._summarise(_CLUSTER_RESOURCES)
+    # storage + pool ignored; only lxc + qemu kept.
+    assert out["tenants_total"] == 3
+    assert out["tenants_running"] == 2
+    # Sort: running first (status != 'running' is the primary key, ascending),
+    # then by descending maxmem. So running-96G hal0 first, running-16G hal0-dev
+    # second, stopped 2G last.
+    names = [t["name"] for t in out["tenants"]]
+    assert names == ["hal0", "hal0-dev", "stopped-lxc"]
+    # Allocated = sum of running maxmem only.
+    assert out["tenants_allocated_mb"] == pytest.approx((96 + 16) * 1024, rel=0.01)
+
+
+def test_summarise_empty_cluster() -> None:
+    out = pve._summarise([])
+    assert out["configured"] is True
+    assert out["host_mem_total_mb"] == 0
+    assert out["tenants_total"] == 0
+    assert out["tenants"] == []
+
+
+# ── Slim projection ────────────────────────────────────────────────────────────
+
+
+def test_project_slim_strips_heavy_fields() -> None:
+    full = pve._summarise(_CLUSTER_RESOURCES)
+    slim = pve.project_slim(full)
+    # Heavy / unused fields gone.
+    for k in ("tenants", "host_cpu_count", "host_uptime_s", "tenants_allocated_mb"):
+        assert k not in slim
+    # Dashboard-relevant fields kept.
+    for k in (
+        "configured",
+        "ok",
+        "node",
+        "host_mem_total_mb",
+        "host_mem_used_mb",
+        "host_mem_free_mb",
+        "host_cpu_pct",
+        "tenants_running",
+        "tenants_total",
+    ):
+        assert k in slim
+
+
+def test_project_slim_unconfigured_passthrough() -> None:
+    assert pve.project_slim({"configured": False}) == {"configured": False}
+
+
+def test_project_slim_error_shape_passthrough() -> None:
+    err = {"configured": True, "ok": False, "error": "URLError: timed out"}
+    assert pve.project_slim(err) == err
+
+
+# ── Config file write / read / delete ──────────────────────────────────────────
+
+
+@pytest.fixture
+def isolated_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Redirect pve_config_path() to tmp_path and clear the cache."""
+    target = tmp_path / "proxmox.json"
+    monkeypatch.setattr(pve, "pve_config_path", lambda: target)
+    pve.invalidate_pve_cache()
+    # Reset transition state so tests don't poison each other.
+    monkeypatch.setattr(pve, "_prev_ok", None)
+    return target
+
+
+_PAYLOAD = {
+    "host": "10.0.1.110",
+    "port": 8006,
+    "user": "root@pam",
+    "token_name": "hal0-readonly",
+    "token_value": "00000000-0000-0000-0000-000000000000",
+    "verify_ssl": False,
+}
+
+
+def test_save_pve_config_roundtrip(isolated_config: Path) -> None:
+    pve.save_pve_config(_PAYLOAD)
+    assert isolated_config.exists()
+    # On-disk shape: nested {proxmox, auth} so it's haloai-compatible.
+    raw = json.loads(isolated_config.read_text())
+    assert raw["proxmox"]["host"] == "10.0.1.110"
+    assert raw["proxmox"]["port"] == 8006
+    assert raw["proxmox"]["verify_ssl"] is False
+    assert raw["auth"]["user"] == "root@pam"
+    assert raw["auth"]["token_name"] == "hal0-readonly"
+    assert raw["auth"]["token_value"] == _PAYLOAD["token_value"]
+    # _load_pve_config flattens it back.
+    loaded = pve._load_pve_config()
+    assert loaded is not None
+    assert loaded["host"] == "10.0.1.110"
+    assert loaded["token_value"] == _PAYLOAD["token_value"]
+
+
+def test_save_pve_config_chmod_0600(isolated_config: Path) -> None:
+    """Token is sensitive — file must not be world- or group-readable."""
+    pve.save_pve_config(_PAYLOAD)
+    mode = isolated_config.stat().st_mode & 0o777
+    assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+
+
+def test_save_pve_config_no_tmpfile_residue(isolated_config: Path) -> None:
+    """Atomic write — the .tmp sibling must be cleaned up after replace."""
+    pve.save_pve_config(_PAYLOAD)
+    leftovers = list(isolated_config.parent.glob(f".{isolated_config.name}.*"))
+    assert leftovers == [], f"residue: {leftovers}"
+
+
+def test_delete_pve_config_returns_existed(isolated_config: Path) -> None:
+    # Empty dir → False, no error.
+    assert pve.delete_pve_config() is False
+    # Write then delete → True, file is gone.
+    pve.save_pve_config(_PAYLOAD)
+    assert isolated_config.exists()
+    assert pve.delete_pve_config() is True
+    assert not isolated_config.exists()
+    # Second delete is still False (idempotent).
+    assert pve.delete_pve_config() is False
+
+
+def test_load_pve_config_missing_returns_none(isolated_config: Path) -> None:
+    assert pve._load_pve_config() is None
+
+
+def test_load_pve_config_malformed_returns_none(isolated_config: Path) -> None:
+    isolated_config.write_text("{not json")
+    assert pve._load_pve_config() is None
+
+
+# ── Transition detection ──────────────────────────────────────────────────────
+
+
+def test_pop_transition_primes_silently(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pve, "_prev_ok", None)
+    # First observation just primes — no transition.
+    assert pve.pop_transition({"configured": True, "ok": True}) is None
+    # Second matching observation — still no transition.
+    assert pve.pop_transition({"configured": True, "ok": True}) is None
+
+
+def test_pop_transition_ok_to_broken(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pve, "_prev_ok", None)
+    pve.pop_transition({"configured": True, "ok": True})  # prime
+    assert pve.pop_transition({"configured": True, "ok": False, "error": "x"}) == "became_broken"
+    # Subsequent broken observations don't re-fire.
+    assert pve.pop_transition({"configured": True, "ok": False}) is None
+
+
+def test_pop_transition_broken_to_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pve, "_prev_ok", None)
+    pve.pop_transition({"configured": True, "ok": False})  # prime broken
+    assert pve.pop_transition({"configured": True, "ok": True}) == "recovered"
+    assert pve.pop_transition({"configured": True, "ok": True}) is None
+
+
+def test_pop_transition_unconfigured_resets(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Removing the config wipes the transition memory.
+
+    Otherwise a configure→use→remove→configure cycle could fire a stale
+    'recovered' event pulled from the prior session.
+    """
+    monkeypatch.setattr(pve, "_prev_ok", True)
+    assert pve.pop_transition({"configured": False}) is None
+    # After unconfigure, the next configured+ok observation must prime,
+    # not emit recovery.
+    assert pve.pop_transition({"configured": True, "ok": True}) is None
+
+
+# ── Cache TTL ──────────────────────────────────────────────────────────────────
+
+
+def _make_fetch_counter() -> tuple[list[int], Any]:
+    """Return (counter, fetch_fn) — counter[0] increments on each call."""
+    counter = [0]
+
+    def fake_fetch(_cfg: dict[str, Any]) -> list[dict[str, Any]]:
+        counter[0] += 1
+        return _CLUSTER_RESOURCES
+
+    return counter, fake_fetch
+
+
+def test_pve_status_caches_within_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_config: Path,
+) -> None:
+    pve.save_pve_config(_PAYLOAD)
+    counter, fake_fetch = _make_fetch_counter()
+    monkeypatch.setattr(pve, "_fetch_pve_resources", fake_fetch)
+
+    async def run() -> tuple[dict[str, Any], dict[str, Any]]:
+        a = await pve.pve_status()
+        b = await pve.pve_status()
+        return a, b
+
+    a, b = asyncio.run(run())
+    assert a["ok"] is True
+    assert b is a  # same cached object
+    assert counter[0] == 1, "should have fetched exactly once within TTL"
+
+
+def test_pve_status_refetches_after_invalidate(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_config: Path,
+) -> None:
+    pve.save_pve_config(_PAYLOAD)
+    counter, fake_fetch = _make_fetch_counter()
+    monkeypatch.setattr(pve, "_fetch_pve_resources", fake_fetch)
+
+    async def run() -> int:
+        await pve.pve_status()
+        pve.invalidate_pve_cache()
+        await pve.pve_status()
+        return counter[0]
+
+    fetches = asyncio.run(run())
+    assert fetches == 2
+
+
+def test_pve_status_unconfigured(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(pve, "pve_config_path", lambda: tmp_path / "absent.json")
+    pve.invalidate_pve_cache()
+    out = asyncio.run(pve.pve_status())
+    assert out == {"configured": False}
+
+
+def test_pve_status_fetch_error_recorded(
+    monkeypatch: pytest.MonkeyPatch, isolated_config: Path
+) -> None:
+    pve.save_pve_config(_PAYLOAD)
+
+    def boom(_cfg: dict[str, Any]) -> list[dict[str, Any]]:
+        raise TimeoutError("upstream down")
+
+    monkeypatch.setattr(pve, "_fetch_pve_resources", boom)
+    out = asyncio.run(pve.pve_status())
+    assert out["configured"] is True
+    assert out["ok"] is False
+    assert "TimeoutError" in out["error"]
+    assert "upstream down" in out["error"]

--- a/ui/src/components/footer/FooterBar.vue
+++ b/ui/src/components/footer/FooterBar.vue
@@ -74,6 +74,17 @@ function fmt(used, total) {
 const tally = computed(() => footer.slotTally)
 const slotDot = computed(() => footer.worstSlotDot)
 
+// ── Proxmox integration status ─────────────────────────────────────
+// Persistent indicator: pill renders only when the integration is
+// configured but unreachable. Hidden when ok (transparent) and when
+// unconfigured (bare-metal deployments stay quiet). Clicking opens
+// Settings so the operator can re-test or rotate the token.
+const pveBroken = computed(() => {
+  const h = hw.value.host
+  return !!(h && h.configured && !h.ok)
+})
+const pveError = computed(() => hw.value.host?.error || 'Cluster poll failed')
+
 // ── Active job chips (deduped, max 3 visible, ttl on terminal) ─────
 const visibleChips = ref([])
 
@@ -182,6 +193,19 @@ function onTickerClick(e) {
       <span class="tally-text mono">{{ tally.running }}/{{ tally.total }}</span>
     </button>
 
+    <!-- 4b. Proxmox pill (only when configured && !ok) -->
+    <router-link
+      v-if="pveBroken"
+      to="/settings"
+      class="bar-pve"
+      :title="pveError"
+      :aria-label="`Proxmox integration unreachable: ${pveError}`"
+      @click.stop
+    >
+      <span class="pve-dot" aria-hidden="true"></span>
+      <span class="pve-text mono">PVE</span>
+    </router-link>
+
     <!-- 5. Progress chips -->
     <span class="bar-chips" v-if="visibleChips.length">
       <ProgressChip
@@ -278,6 +302,31 @@ function onTickerClick(e) {
 .tally-text { font-feature-settings: 'zero' 1, 'tnum' 1; }
 
 .bar-chips { display: inline-flex; gap: 4px; flex-shrink: 0; }
+
+.bar-pve {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 7px;
+  height: 18px;
+  background: color-mix(in oklch, var(--color-danger) 14%, transparent);
+  border: 1px solid color-mix(in oklch, var(--color-danger) 35%, var(--color-border));
+  border-radius: 999px;
+  color: var(--color-danger);
+  font-size: 10.5px;
+  text-decoration: none;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+.bar-pve:hover { background: color-mix(in oklch, var(--color-danger) 22%, transparent); }
+.pve-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-danger);
+  box-shadow: 0 0 6px color-mix(in oklch, var(--color-danger) 40%, transparent);
+}
+.pve-text { letter-spacing: 0.05em; font-weight: 600; }
 
 .bar-hint {
   font-size: 10px;

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -55,10 +55,17 @@ const memLabel = computed(() => (hw.value.gtt_total_mb ? 'GTT' : 'VRAM'))
 // ram_total + gtt_total would double-count, which is what produced the
 // "169 GB pool on a 128 GB machine" bug. The probe exposes the true
 // unified_memory_mb (via dmidecode when /proc/meminfo reports an LXC
-// cgroup quota); we trust that. host.host_mem_total_mb is the haloai
-// upstream's equivalent.
+// cgroup quota); we trust that. When a Proxmox API token is configured
+// (see /etc/hal0/proxmox.json) the host's view is more authoritative
+// because it sees the actual physical DIMM total *and* the other
+// tenants competing for it — prefer it when present.
+const hostOk = computed(() => {
+  const h = hw.value.host
+  return !!(h && h.configured && h.ok && h.host_mem_total_mb)
+})
 const unifiedTotalGb = computed(() => {
-  const probed = hw.value.unified_memory_mb || hw.value.host?.host_mem_total_mb
+  if (hostOk.value) return hw.value.host.host_mem_total_mb / 1024
+  const probed = hw.value.unified_memory_mb
   if (probed) return probed / 1024
   // Non-UMA / unknown: RAM + dedicated VRAM is a fair total (no overlap).
   const ramG = (hw.value.ram_total_mb || 0) / 1024
@@ -71,20 +78,39 @@ const unifiedSegments = computed(() => {
   if (totalG === 0) return []
   // Used breakdown:
   //   gtt   = GPU's GTT allocations (live model weights / KV cache on UMA)
-  //   npu   = NPU model resident bytes (also drawn from the unified pool)
-  //   vram  = dedicated VRAM in use (discrete GPUs only — 0 on UMA)
-  //   sys   = system RAM used by everything else (MemTotal - MemAvailable
-  //           minus what's already attributed to the GPU through GTT)
+  //   npu   = NPU model resident bytes (drawn from the same pool as GTT,
+  //           so shown only when an FLM slot is loaded — segment hidden
+  //           at 0 to avoid visually double-counting with GTT).
+  //   vram  = dedicated VRAM in use (discrete GPUs only). On Strix Halo /
+  //           any UMA box the "VRAM" sysfs counter just reports the small
+  //           BIOS-reserved framebuffer slice carved out of the same DIMMs
+  //           the unified pool already covers — we drop it entirely so the
+  //           bar only shows knobs the user can actually manage.
+  //   sys   = system RAM used by everything else (MemTotal - MemAvailable).
+  //           Inside an LXC, /proc/meminfo does NOT account for GPU-pinned
+  //           pages (those live in the host kernel's GTT bookkeeping), so
+  //           ram_used_gb and gtt_used_mb are independent — no subtraction.
+  //   host  = everything else on the Proxmox host competing for the same
+  //           DIMMs — other LXCs/VMs + ZFS ARC + the host kernel. Only
+  //           rendered when /etc/hal0/proxmox.json is configured and the
+  //           cluster/resources poll succeeded; otherwise the bar honestly
+  //           shows "we can't see beyond this LXC" by leaving that mass
+  //           unattributed inside Free.
+  const isUma = !!hw.value.is_uma
   const gtt = (hw.value.gtt_used_mb || 0) / 1024
-  const vram = (hw.value.vram_used_mb || 0) / 1024
-  const npuMb = hw.value.npu_status?.model_mb || 0
-  const npu = npuMb / 1024
-  // ram_used_gb is from /api/stats/hardware (haloai shape) — it's the OS-
-  // visible used total, which already includes pinned GTT bytes on UMA.
-  // Subtract gtt so we don't double-count GTT into both buckets.
-  const ramUsedG = hw.value.ram_used_gb ?? ((hw.value.ram_total_mb || 0) - (hw.value.ram_available_mb || 0)) / 1024
-  const sys = Math.max(0, ramUsedG - gtt)
-  const used = gtt + sys + npu + vram
+  const vram = isUma ? 0 : (hw.value.vram_used_mb || 0) / 1024
+  const npu = (hw.value.npu_status?.model_mb || 0) / 1024
+  const sys = hw.value.ram_used_gb
+    ?? (((hw.value.ram_total_mb || 0) - (hw.value.ram_available_mb || 0)) / 1024)
+  let host = 0
+  if (hostOk.value) {
+    // host_mem_used already includes our LXC's sys RAM + this kernel's
+    // share of GTT (GTT is host-kernel-owned on UMA). Subtract our share
+    // so we don't visually double-count.
+    const hostUsedG = hw.value.host.host_mem_used_mb / 1024
+    host = Math.max(0, hostUsedG - sys - gtt)
+  }
+  const used = gtt + sys + npu + vram + host
   const free = Math.max(0, totalG - used)
   const seg = (label, gb, cls) => ({
     label,
@@ -95,9 +121,14 @@ const unifiedSegments = computed(() => {
   const out = [
     seg('GTT · inference', gtt, 'seg-gtt'),
     seg('System RAM', sys, 'seg-sys'),
-    seg('NPU / FLM', npu, 'seg-npu'),
   ]
-  // Hide the VRAM segment on UMA — it's always 0 and just clutters the legend.
+  // Hide the NPU segment until an FLM slot is loaded — NPU memory comes
+  // out of GTT, so an always-on NPU bucket would visually double-count.
+  if (npu > 0.01) out.push(seg('NPU · FLM', npu, 'seg-npu'))
+  // Proxmox host segment (other tenants + host kernel / ZFS ARC) only when
+  // we have an authoritative cluster snapshot.
+  if (host > 0.01) out.push(seg('Proxmox host', host, 'seg-host'))
+  // VRAM segment only on discrete-GPU (non-UMA) machines.
   if (vram > 0.01) out.push(seg('VRAM', vram, 'seg-vram'))
   out.push(seg('Free', free, 'seg-free'))
   return out
@@ -316,10 +347,29 @@ loadChatModels()
       <!-- ── Unified memory bar (Strix Halo) ─────────────────────── -->
       <Card v-if="unifiedSegments.length" class="um-card">
         <div class="um-head">
-          <div class="um-title">Unified memory · {{ unifiedTotalGb.toFixed(0) }} GB pool</div>
+          <div class="um-title">
+            {{ hostOk ? 'Physical host memory' : 'Unified memory' }} ·
+            {{ unifiedTotalGb.toFixed(0) }} GB pool
+          </div>
           <div class="um-sub">
             {{ unifiedSegments.filter(s => s.cls !== 'seg-free').reduce((a, s) => a + s.gb, 0).toFixed(1) }} GB used
             <span class="dim"> · NPU {{ npuOk ? 'ready' : 'offline' }}</span>
+            <span v-if="hostOk" class="dim">
+              · {{ hw.host.tenants_running }} tenant{{ hw.host.tenants_running === 1 ? '' : 's' }}
+            </span>
+            <!-- Token-rot / network-failure indicator. Memory bar quietly
+                 falls back to the LXC-only view in this state; the pill
+                 is the user-visible signal that the host total is stale.
+                 Click target is the Settings panel where the operator
+                 can re-test or rotate the API token. -->
+            <router-link
+              v-if="hw.host?.configured && !hw.host?.ok"
+              to="/settings"
+              class="pve-warn"
+              :title="hw.host?.error || 'Cluster poll failed — check token / network'"
+            >
+              · Proxmox: unreachable
+            </router-link>
           </div>
         </div>
         <div class="um-bar" role="img" aria-label="Unified memory breakdown">
@@ -474,12 +524,17 @@ loadChatModels()
 .um-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 10px; }
 .um-title { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 500; color: var(--hal0-accent); }
 .um-sub { font-size: 11.5px; color: var(--color-fg-muted); font-family: var(--font-mono); font-feature-settings: 'zero' 1, 'ss02' 1, 'tnum' 1; }
+.um-sub .pve-warn { color: var(--color-danger); text-decoration: none; margin-left: 2px; }
+.um-sub .pve-warn:hover { text-decoration: underline; }
 .um-bar { display: flex; height: 24px; border-radius: 4px; overflow: hidden; background: var(--color-surface-2); border: 1px solid var(--color-border); }
 .useg { height: 100%; transition: width 0.4s ease; }
 .seg-gtt   { background: var(--hal0-accent); }
 .seg-sys   { background: var(--color-success); opacity: 0.85; }
 .seg-npu   { background: var(--color-warning); opacity: 0.9; }
 .seg-vram  { background: color-mix(in oklch, var(--hal0-accent) 50%, var(--color-warning)); }
+/* Muted slate so other-tenant pressure reads as "outside our control"
+   without competing with the amber GTT and green Sys colours. */
+.seg-host  { background: color-mix(in oklch, var(--color-fg-muted) 55%, var(--color-surface-2)); }
 .seg-free  { background: var(--color-surface-2); }
 .um-legend { display: flex; flex-wrap: wrap; gap: 14px 18px; margin-top: 10px; font-size: 11.5px; color: var(--color-fg-muted); font-family: var(--font-mono); font-feature-settings: 'zero' 1, 'ss02' 1, 'tnum' 1; }
 .lg { display: inline-flex; align-items: center; gap: 6px; }

--- a/ui/src/views/Hardware.vue
+++ b/ui/src/views/Hardware.vue
@@ -79,6 +79,15 @@ const hw = computed(() => ({ ...(hardware.value || {}), ...(stats.value || {}) }
 
 const isUma = computed(() => !!hw.value.is_uma)
 
+// Proxmox host memory authority — when /etc/hal0/proxmox.json is configured
+// and the cluster/resources poll succeeded, the host's view trumps the
+// LXC's cgroup view (which is just our slice). Mirrors Dashboard.vue so
+// the two pages can never disagree about totals.
+const hostOk = computed(() => {
+  const h = hw.value.host
+  return !!(h && h.configured && h.ok && h.host_mem_total_mb)
+})
+
 const gpuName    = computed(() => hw.value.gpu_name || '')
 const gpuVendor  = computed(() => hw.value.gpu_vendor || '')
 const gpuUtilPct = computed(() => {
@@ -100,6 +109,7 @@ const vramUsedGb  = computed(() => (hw.value.vram_used_mb || 0) / 1024)
 // the two views can never disagree about totals. Falls back to ram+vram
 // only on non-UMA where the two are independent.
 const unifiedTotalGb = computed(() => {
+  if (hostOk.value) return hw.value.host.host_mem_total_mb / 1024
   const probed = hw.value.unified_memory_mb
   if (probed) return probed / 1024
   const ramG = (hw.value.ram_total_mb || 0) / 1024
@@ -111,14 +121,28 @@ const unifiedSegments = computed(() => {
   const totalG = unifiedTotalGb.value || 0
   if (totalG === 0) return []
   const gtt = gttUsedGb.value
-  const vram = vramUsedGb.value
-  // ram_used_gb is the OS-visible used total. On UMA it *includes* the
-  // pinned GTT bytes, so subtracting GTT keeps the segments additive.
-  const ramUsedG = hw.value.ram_used_gb
+  // On UMA the "VRAM" sysfs counter is the BIOS-reserved framebuffer
+  // slice carved out of the same DIMMs the unified pool covers — drop
+  // it so the bar only shows knobs the user can actually manage.
+  const vram = isUma.value ? 0 : vramUsedGb.value
+  const npu = (hw.value.npu_status?.model_mb || 0) / 1024
+  // ram_used_gb is the OS-visible used total. Inside an LXC, /proc/meminfo
+  // does NOT include GPU-pinned pages (those live in the host kernel's GTT
+  // bookkeeping), so ram_used and gtt_used are independent buckets — no
+  // subtraction needed.
+  const sys = hw.value.ram_used_gb
     ?? ((hw.value.ram_used_mb || 0) / 1024)
     ?? Math.max(0, ((hw.value.ram_total_mb || 0) - (hw.value.ram_available_mb || 0)) / 1024)
-  const sys = Math.max(0, ramUsedG - gtt)
-  const used = gtt + sys + vram
+  // Proxmox-host pressure: everything else on the physical host —
+  // other LXCs/VMs + ZFS ARC + host kernel. Canary confirmed 2026-05-21
+  // that GTT lives in host kernel memory (not the LXC cgroup), so it
+  // shows up inside host_mem_used and must be subtracted out.
+  let host = 0
+  if (hostOk.value) {
+    const hostUsedG = hw.value.host.host_mem_used_mb / 1024
+    host = Math.max(0, hostUsedG - sys - gtt)
+  }
+  const used = gtt + sys + npu + vram + host
   const free = Math.max(0, totalG - used)
   const seg = (label, gb, cls) => ({
     label, gb, pct: Math.max(0, (gb / totalG) * 100), cls,
@@ -127,6 +151,13 @@ const unifiedSegments = computed(() => {
     seg('GTT · inference', gtt, 'seg-gtt'),
     seg('System RAM', sys, 'seg-sys'),
   ]
+  // NPU memory comes out of GTT — only show the segment when an FLM slot
+  // is loaded, otherwise it would visually double-count.
+  if (npu > 0.01) out.push(seg('NPU · FLM', npu, 'seg-npu'))
+  // Proxmox host segment (other tenants + host kernel / ZFS ARC) only
+  // when /etc/hal0/proxmox.json is configured and reachable.
+  if (host > 0.01) out.push(seg('Proxmox host', host, 'seg-host'))
+  // VRAM segment only on discrete-GPU (non-UMA) machines.
   if (vram > 0.01) out.push(seg('Dedicated VRAM', vram, 'seg-vram'))
   out.push(seg('Free', free, 'seg-free'))
   return out
@@ -136,7 +167,15 @@ const unifiedSegments = computed(() => {
 const unifiedUsedPct = computed(() => {
   const total = unifiedTotalGb.value
   if (!total) return 0
-  return Math.min(100, ((gttUsedGb.value + Math.max(0, ((hw.value.ram_used_gb ?? 0) - gttUsedGb.value)) + vramUsedGb.value) / total) * 100)
+  // When we have an authoritative host view, just use it — host_mem_used
+  // already accounts for our LXC + GTT + every other tenant + kernel.
+  if (hostOk.value) {
+    return Math.min(100, (hw.value.host.host_mem_used_mb / 1024 / total) * 100)
+  }
+  const ramUsedG = hw.value.ram_used_gb ?? 0
+  const npu = (hw.value.npu_status?.model_mb || 0) / 1024
+  const vram = isUma.value ? 0 : vramUsedGb.value
+  return Math.min(100, ((gttUsedGb.value + ramUsedG + npu + vram) / total) * 100)
 })
 
 // Non-UMA bars (only render when !is_uma)
@@ -182,11 +221,17 @@ onMounted(loadHardware)
         <h2 id="tiles-heading" class="sr-only">Hardware overview</h2>
         <div class="tiles">
           <div class="tile">
-            <div class="tile-label">{{ isUma ? 'Unified memory' : 'System RAM' }}</div>
+            <div class="tile-label">
+              {{ hostOk ? 'Physical host memory' : (isUma ? 'Unified memory' : 'System RAM') }}
+            </div>
             <div class="tile-value mono">
               {{ unifiedTotalGb.toFixed(0) }}<span class="tile-unit">GB</span>
             </div>
-            <div v-if="isUma" class="tile-sub">{{ unifiedUsedPct.toFixed(0) }}% in use · UMA pool</div>
+            <div v-if="hostOk" class="tile-sub">
+              {{ unifiedUsedPct.toFixed(0) }}% in use ·
+              {{ hw.host.tenants_running }} tenant{{ hw.host.tenants_running === 1 ? '' : 's' }}
+            </div>
+            <div v-else-if="isUma" class="tile-sub">{{ unifiedUsedPct.toFixed(0) }}% in use · UMA pool</div>
             <div v-else class="tile-sub">{{ ramPct.toFixed(0) }}% in use</div>
           </div>
 
@@ -393,6 +438,7 @@ onMounted(loadHardware)
 .bar-seg.seg-gtt  { background: var(--hal0-accent); }
 .bar-seg.seg-sys  { background: color-mix(in oklch, var(--color-fg-muted) 40%, var(--color-surface)); }
 .bar-seg.seg-npu  { background: var(--color-warning); }
+.bar-seg.seg-host { background: color-mix(in oklch, var(--color-fg-muted) 55%, var(--color-surface-2)); }
 .bar-seg.seg-vram { background: var(--color-danger); }
 .bar-seg.seg-free { background: transparent; }
 .bar-total { font-size: 11.5px; color: var(--color-fg-faint); flex-shrink: 0; }
@@ -415,6 +461,7 @@ onMounted(loadHardware)
 .legend-swatch.seg-gtt  { background: var(--hal0-accent); }
 .legend-swatch.seg-sys  { background: color-mix(in oklch, var(--color-fg-muted) 40%, var(--color-surface)); }
 .legend-swatch.seg-npu  { background: var(--color-warning); }
+.legend-swatch.seg-host { background: color-mix(in oklch, var(--color-fg-muted) 55%, var(--color-surface-2)); }
 .legend-swatch.seg-vram { background: var(--color-danger); }
 .legend-swatch.seg-free { background: var(--color-surface-3); border: 1px solid var(--color-border); }
 .legend-label { color: var(--color-fg-muted); }

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -474,10 +474,155 @@ async function saveAndScanModelRoots() {
   }
 }
 
+// ── Proxmox integration ──────────────────────────────────────────────
+// Powers the "Proxmox host" segment on the Dashboard memory bar.
+// Config lives at /etc/hal0/proxmox.json (separate from hal0.toml).
+// Endpoints: GET / PUT / DELETE /api/settings/proxmox, POST .../test.
+const pveLoading = ref(false)
+const pveSaving  = ref(false)
+const pveTesting = ref(false)
+const pveError   = ref(null)
+const pveTestResult = ref(null)
+const pveStatus  = ref(null)
+const pveConfigured = ref(false)
+const pveTokenSet = ref(false)
+const pveForm = reactive({
+  host: '',
+  port: 8006,
+  user: '',
+  token_name: '',
+  token_value: '',
+  verify_ssl: false,
+})
+
+async function loadProxmox() {
+  pveLoading.value = true
+  pveError.value = null
+  try {
+    const data = await api('/api/settings/proxmox')
+    pveConfigured.value = !!data.configured
+    pveTokenSet.value = !!data.token_value_set
+    pveForm.host = data.host || ''
+    pveForm.port = data.port || 8006
+    pveForm.user = data.user || ''
+    pveForm.token_name = data.token_name || ''
+    pveForm.verify_ssl = !!data.verify_ssl
+    // Never echo the secret — keep the field empty on load. Operators
+    // re-enter it only when rotating credentials.
+    pveForm.token_value = ''
+    pveStatus.value = data.status || null
+  } catch (e) {
+    pveError.value = e.message
+  } finally {
+    pveLoading.value = false
+  }
+}
+
+async function testProxmox() {
+  pveTesting.value = true
+  pveError.value = null
+  pveTestResult.value = null
+  try {
+    if (!pveForm.token_value) {
+      pveTestResult.value = { ok: false, error: 'enter the token value to test' }
+      return
+    }
+    const body = JSON.stringify({
+      host: pveForm.host.trim(),
+      port: Number(pveForm.port) || 8006,
+      user: pveForm.user.trim(),
+      token_name: pveForm.token_name.trim(),
+      token_value: pveForm.token_value,
+      verify_ssl: !!pveForm.verify_ssl,
+    })
+    const result = await api('/api/settings/proxmox/test', { method: 'POST', body })
+    pveTestResult.value = result
+    if (result.ok) toasts.success(`Reached ${result.node} — ${result.tenants_total} tenants visible`)
+    else toasts.error(`Test failed: ${result.error}`)
+  } catch (e) {
+    pveTestResult.value = { ok: false, error: e.message }
+    toasts.error(e.message)
+  } finally {
+    pveTesting.value = false
+  }
+}
+
+async function saveProxmox() {
+  pveSaving.value = true
+  pveError.value = null
+  try {
+    const body = {
+      host: pveForm.host.trim(),
+      port: Number(pveForm.port) || 8006,
+      user: pveForm.user.trim(),
+      token_name: pveForm.token_name.trim(),
+      verify_ssl: !!pveForm.verify_ssl,
+    }
+    // Only send token_value when the operator actually entered one —
+    // omission means "keep the existing token on disk."
+    if (pveForm.token_value) body.token_value = pveForm.token_value
+    const data = await api('/api/settings/proxmox', {
+      method: 'PUT',
+      body: JSON.stringify(body),
+    })
+    pveConfigured.value = !!data.configured
+    pveTokenSet.value = !!data.token_value_set
+    pveStatus.value = data.status || null
+    pveForm.token_value = ''
+    pveTestResult.value = null
+    toasts.success('Proxmox integration saved')
+  } catch (e) {
+    if (e.code === 'proxmox.config_invalid' && e.details && typeof e.details === 'object') {
+      const first = Object.entries(e.details)[0]
+      const msg = first ? `${first[0]}: ${first[1]}` : e.message
+      toasts.error(`Invalid: ${msg}`)
+    } else {
+      toasts.error(e.message)
+    }
+  } finally {
+    pveSaving.value = false
+  }
+}
+
+async function removeProxmox() {
+  if (!confirm('Remove Proxmox integration? The dashboard will stop showing host-pressure data.')) return
+  pveSaving.value = true
+  pveError.value = null
+  try {
+    await api('/api/settings/proxmox', { method: 'DELETE' })
+    pveConfigured.value = false
+    pveTokenSet.value = false
+    pveStatus.value = { configured: false }
+    pveForm.host = ''
+    pveForm.port = 8006
+    pveForm.user = ''
+    pveForm.token_name = ''
+    pveForm.token_value = ''
+    pveForm.verify_ssl = false
+    pveTestResult.value = null
+    toasts.success('Proxmox integration removed')
+  } catch (e) {
+    toasts.error(e.message)
+  } finally {
+    pveSaving.value = false
+  }
+}
+
+const pveStatusLine = computed(() => {
+  const s = pveStatus.value
+  if (!s) return null
+  if (s.configured === false) return 'Not configured.'
+  if (s.ok === false) return `Cannot reach Proxmox: ${s.error || 'unknown error'}`
+  const totalGb = (s.host_mem_total_mb / 1024).toFixed(0)
+  const usedGb  = (s.host_mem_used_mb  / 1024).toFixed(1)
+  return `${s.node} · ${usedGb} / ${totalGb} GB used · ${s.tenants_running} of ${s.tenants_total} tenants running`
+})
+
 onMounted(async () => {
   await load()
   await loadAuthState()
   await loadModelsCfg()
+  await loadProxmox()
 })
 </script>
 
@@ -669,6 +814,90 @@ onMounted(async () => {
             >
               <span v-if="modelsCfgSaving" class="spinner" aria-hidden="true" />
               {{ modelsCfgSaving ? 'Scanning…' : 'Save & re-scan' }}
+            </button>
+          </div>
+        </div>
+      </Card>
+
+      <!-- ── Proxmox integration panel ───────────────────────────── -->
+      <Card>
+        <div class="proxmox-header">
+          <h3 class="section-title">Proxmox integration</h3>
+          <span class="auth-badge" :class="pveConfigured ? 'auth-on' : 'auth-off'">
+            {{ pveConfigured ? 'Configured' : 'Off' }}
+          </span>
+        </div>
+        <p class="field-hint">
+          Optional. When hal0 runs as a Proxmox LXC or VM, configure a
+          read-only <code class="mono">PVEAuditor</code> (or root) API token
+          so the dashboard's memory bar can show RAM consumed by other
+          tenants and the host kernel — not just this LXC's slice. Leave
+          off on bare-metal installs.
+          <br />
+          Create the token at
+          <code class="mono">Datacenter → Permissions → API Tokens</code>
+          (uncheck "Privilege Separation" or grant the token
+          <code class="mono">PVEAuditor</code> on <code class="mono">/</code>).
+        </p>
+
+        <div v-if="pveError" class="error-banner" role="alert">{{ pveError }}</div>
+        <div v-else-if="pveLoading" class="loading-row">Loading…</div>
+        <div v-else>
+          <p v-if="pveStatusLine" class="proxmox-status mono" :class="{ 'text-success': pveStatus?.ok, 'text-danger': pveStatus?.configured && !pveStatus?.ok }">
+            {{ pveStatusLine }}
+          </p>
+
+          <div class="proxmox-grid">
+            <div class="field-row proxmox-field">
+              <label for="pve-host" class="field-label">Host</label>
+              <input id="pve-host" v-model="pveForm.host" type="text" class="field-input" placeholder="10.0.1.110" :disabled="pveSaving" />
+            </div>
+            <div class="field-row proxmox-field proxmox-field-narrow">
+              <label for="pve-port" class="field-label">Port</label>
+              <input id="pve-port" v-model.number="pveForm.port" type="number" class="field-input" min="1" max="65535" :disabled="pveSaving" />
+            </div>
+            <div class="field-row proxmox-field">
+              <label for="pve-user" class="field-label">User</label>
+              <input id="pve-user" v-model="pveForm.user" type="text" class="field-input" placeholder="root@pam" :disabled="pveSaving" />
+            </div>
+            <div class="field-row proxmox-field">
+              <label for="pve-token-name" class="field-label">Token name</label>
+              <input id="pve-token-name" v-model="pveForm.token_name" type="text" class="field-input" placeholder="hal0-readonly" :disabled="pveSaving" />
+            </div>
+            <div class="field-row proxmox-field proxmox-field-wide">
+              <label for="pve-token-value" class="field-label">
+                Token value
+                <span v-if="pveTokenSet && !pveForm.token_value" class="restart-badge" title="A token is on disk; leave blank to keep it">on disk</span>
+              </label>
+              <input id="pve-token-value" v-model="pveForm.token_value" type="password" class="field-input mono"
+                     :placeholder="pveTokenSet ? '••••••••  (leave blank to keep existing)' : 'paste the token UUID'"
+                     :disabled="pveSaving" autocomplete="off" />
+            </div>
+            <div class="field-row proxmox-field proxmox-field-toggle">
+              <label class="toggle-label">
+                <input type="checkbox" class="toggle-checkbox" v-model="pveForm.verify_ssl" :disabled="pveSaving" />
+                <span>Verify TLS certificate</span>
+              </label>
+              <p class="field-hint dim">Off by default — most home Proxmox installs use the self-signed cert.</p>
+            </div>
+          </div>
+
+          <p v-if="pveTestResult && !pveTestResult.ok" class="field-err" role="alert">
+            Test failed: {{ pveTestResult.error }}
+          </p>
+
+          <div class="proxmox-actions">
+            <button class="btn-ghost" type="button" @click="testProxmox" :disabled="pveTesting || pveSaving || !pveForm.host || !pveForm.user || !pveForm.token_name">
+              <span v-if="pveTesting" class="spinner" aria-hidden="true" />
+              {{ pveTesting ? 'Testing…' : 'Test connection' }}
+            </button>
+            <button class="btn-primary btn-small" type="button" @click="saveProxmox"
+                    :disabled="pveSaving || !pveForm.host || !pveForm.user || !pveForm.token_name || (!pveTokenSet && !pveForm.token_value)">
+              <span v-if="pveSaving" class="spinner" aria-hidden="true" />
+              {{ pveSaving ? 'Saving…' : 'Save' }}
+            </button>
+            <button v-if="pveConfigured" class="btn-danger btn-small" type="button" @click="removeProxmox" :disabled="pveSaving">
+              Remove
             </button>
           </div>
         </div>
@@ -1112,4 +1341,29 @@ onMounted(async () => {
 .roots-actions { display: flex; align-items: center; gap: 12px; margin-top: 6px; flex-wrap: wrap; }
 .auto-scan-label { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--color-fg-muted); cursor: pointer; }
 .auto-scan-label input[type="checkbox"] { accent-color: var(--hal0-accent); }
+
+/* ── Proxmox integration panel ──────────────────────────────────── */
+.proxmox-header { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }
+.proxmox-status {
+  margin: 8px 0 14px;
+  padding: 8px 12px;
+  border-radius: var(--radius);
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  font-size: 12px;
+}
+.proxmox-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(200px, 1fr));
+  gap: 10px 16px;
+  margin-top: 8px;
+}
+.proxmox-field { display: flex; flex-direction: column; gap: 4px; padding: 0; border-bottom: none; }
+.proxmox-field .field-label { font-size: 11.5px; font-weight: 500; }
+.proxmox-field .field-input { font-family: var(--font-mono); font-size: 12.5px; padding: 6px 10px; }
+.proxmox-field-narrow { max-width: 130px; }
+.proxmox-field-wide { grid-column: 1 / -1; }
+.proxmox-field-toggle { grid-column: 1 / -1; flex-direction: column; align-items: flex-start; gap: 4px; }
+.proxmox-actions { display: flex; gap: 10px; align-items: center; margin-top: 14px; flex-wrap: wrap; }
+.dim { color: var(--color-fg-faint); }
 </style>


### PR DESCRIPTION
## Summary
- Wires an optional read-only Proxmox API token through the dashboard so when hal0 runs as an LXC, the unified-memory bar shows real DIMM pressure (other tenants + ZFS ARC + host kernel) instead of the cgroup-only view.
- New Settings card to manage the token; new dashboard segment + tile-label swap; three signals when the token rots (Dashboard pill, FooterBar pill, one-shot system event on transition).
- /api/stats/hardware ships the slim shape (no tenants[]) so the 2.5s poll stays cheap; /api/settings/proxmox keeps the full shape with tenants[] for the Settings card.

## Design decisions (resolved in the 2026-05-21 grill)
- **Subtraction math** \`host = max(0, hostUsed − sys − gtt)\` — canary against live /api/stats/hardware confirmed GTT lives in host kernel memory, not the LXC cgroup (Vulkan slots had 21.67 GB pinned in GTT while Proxmox reported the hal0 LXC at 3.78 GB).
- **Token-rot signals** — Dashboard pill + FooterBar pill (persistent) + one-shot \`system.proxmox_unreachable\` event on transition (not via ActivityTicker since that overwrites with the next event).
- **Hardware.vue mirrors Dashboard exactly** rather than extracting to a composable — defer the abstraction until a third consumer appears.
- **Token security** — GET redacts to \`token_value_set: bool\`; save event omits secret; atomic 0600 write.

## Test plan
- [x] \`tests/hardware/test_pve.py\` — 20 unit tests (\_summarise fixture, project_slim, save/delete round-trip + 0600 + no .tmp residue, pop_transition state machine, cache TTL + invalidate, error-shape passthrough, malformed-config handling). All passing locally.
- [x] Full \`tests/hardware/\` + \`tests/api/\` — 493 passed, 8 skipped, no regressions.
- [x] \`ruff format\` + \`ruff check\` clean.
- [x] Clean UI rebuild (\`rm -rf node_modules/.vite dist && npm run build\`) — all three new CSS rules (\`pve-warn\`, \`seg-host\`, \`bar-pve\`) present in built bundles.
- [ ] Manual: load https://hal0.thinmint.dev → confirm host segment renders + tile label swaps to 'Physical host memory'.
- [ ] Manual: simulate token rot (edit /etc/hal0/proxmox.json to a bad value) → confirm Dashboard pill + FooterBar pill appear + system event lands in the events log.
- [ ] Manual: bare-metal install (no /etc/hal0/proxmox.json) → confirm Dashboard quiet, no pills, Settings card shows 'Off'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)