### PR TITLE
docs(readme+plan): Proxmox host-pressure integration

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -69,6 +69,14 @@ the box; v1.0 is the eventual stability/perf bar (see §1 "Path to v1.0").
   - Dark mode only; mobile-responsive on read-only paths
   - SSE for slot status + log tail
   - Hardware-aware slot config form (VRAM fit warnings inline)
+  - **Proxmox host-pressure segment** (shipped 2026-05-21 — #103) —
+    optional `/etc/hal0/proxmox.json` PVE API token surfaces the
+    physical host's DIMM total + other-tenant pressure on the unified
+    memory bar when hal0 runs inside an LXC. Token-rot signalled via
+    persistent pills on Dashboard + FooterBar plus a one-shot
+    `system.proxmox_unreachable` event on the ok→broken transition.
+    `/api/stats/hardware` ships a slim projection (no tenants[]) so
+    the 2.5 s poll cadence stays cheap regardless of cluster size.
 - **Bundled prewired OpenWebUI** at `:3001`
   - Installer pre-configures `OPENAI_API_BASE_URLS=http://127.0.0.1:8080/v1`
   - `WEBUI_AUTH=False` (LAN-only home install)

--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ hostnames). Use `--no-tls` to skip Caddy and front hal0 with your own
 reverse proxy. See [`installer/README.md`](./installer/README.md) for
 the full flow.
 
+### Proxmox integration (optional)
+
+If hal0 runs inside a Proxmox LXC, the container only sees its own
+cgroup slice of memory — other tenants, ZFS ARC, and the host kernel
+draw from the same physical DIMMs as GPU GTT but are invisible from
+inside. To surface that, drop a read-only `PVEAuditor` API token into
+the dashboard's Settings → "Proxmox integration" panel. Once saved,
+the unified-memory bar swaps to the physical host's DIMM total and
+adds a muted "Proxmox host" segment for other-tenant + kernel
+pressure. Token is sensitive and stored 0600 at
+`/etc/hal0/proxmox.json`; the API never echoes it back. Bare-metal and
+VM installs leave the panel off and the dashboard stays quiet.
+
 ## License
 
 Apache 2.0. See [`LICENSE`](./LICENSE).


### PR DESCRIPTION
## Summary
- Companion to #103. Both surfaces describe the new optional /etc/hal0/proxmox.json PVE API token that surfaces the physical host's DIMM total + other-tenant pressure on the dashboard's unified-memory bar.
- README.md: new "Proxmox integration (optional)" subsection after the auth posture explanation. Mentions redaction (token_value_set: bool), 0600 storage, and bare-metal "panel stays off" default.
- PLAN.md: bullet under §1 v0.1.0-alpha ships > Dashboard UI with #103 reference + notes the slim /api/stats/hardware projection that keeps the 2.5s poll cheap regardless of cluster size.

## Test plan
- [x] No code changes — README + PLAN only.
- [ ] Manual: skim both files for tone consistency with surrounding sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)