### PR TITLE
feat(ui/slots): three-state dot vocab + activity-only top rail

### DIFF
--- a/ui/src/components/SlotCard.vue
+++ b/ui/src/components/SlotCard.vue
@@ -69,7 +69,7 @@ const dotState = computed(() => {
   const s = props.slot.status
   if (s === 'error' || s === 'failed') return 'error'
   if (!running.value) return 'offline'
-  if ((m.value.requests_processing || 0) > 0) return 'live'
+  if ((m.value.requests_processing || 0) > 0) return 'active'
   return 'idle'
 })
 
@@ -455,7 +455,7 @@ const sparkSvg = computed(() => {
 </script>
 
 <template>
-  <div class="slot-card" :class="{ 'is-running': running, 'is-busy': busy, 'sc-flash': transitionFlash, [`sc-state-${dotState}`]: true }">
+  <div class="slot-card" :class="{ 'is-running': running, 'is-serving': dotState === 'active', 'is-busy': busy, 'sc-flash': transitionFlash, [`sc-state-${dotState}`]: true }">
     <!-- Header -->
     <div class="sc-head">
       <span class="sc-dot" />
@@ -717,6 +717,10 @@ const sparkSvg = computed(() => {
    previous left-side inset; reads cleaner in a grid of cards). */
 .slot-card.is-running {
   border-color: color-mix(in srgb, var(--hal0-accent) 40%, var(--color-border));
+}
+/* Top rail is now a *live-traffic* signal — appears only while
+   requests_processing > 0. Steady readiness lives in the dot color. */
+.slot-card.is-serving {
   box-shadow: inset 0 3px 0 var(--hal0-accent);
 }
 .slot-card.is-busy { opacity: 0.78; }
@@ -739,31 +743,45 @@ const sparkSvg = computed(() => {
   box-shadow: 0 0 6px -1px var(--hal0-accent);
   flex-shrink: 0;
 }
-.sc-state-live .sc-dot   { background: var(--hal0-accent); box-shadow: 0 0 0 4px color-mix(in srgb, var(--hal0-accent) 22%, transparent), 0 0 8px var(--hal0-accent); animation: dot-pulse 1.4s ease-in-out infinite; }
+.sc-state-active .sc-dot { background: var(--color-success); animation: dot-breathe 2.4s ease-in-out infinite; }
 
 /* SSE-driven state-transition flash. Brief border highlight + dot pop so
    the user sees instant feedback on a transition without the noise of a
    full re-render. Reduced-motion users get nothing (gated in script). */
-.slot-card.sc-flash { animation: sc-flash 0.7s ease-out; }
-.slot-card.sc-flash .sc-dot { animation: sc-flash-dot 0.7s ease-out; }
+.slot-card.sc-flash { animation: sc-flash 1.6s ease-in-out; }
+.slot-card.sc-flash .sc-dot { animation: sc-flash-dot 1.6s ease-in-out; }
 @keyframes sc-flash {
-  0%   { box-shadow: 0 0 0 2px color-mix(in oklch, var(--color-accent), transparent 60%); }
-  100% { box-shadow: 0 0 0 0 transparent; }
+  0%   { box-shadow: 0 0 0 0 color-mix(in oklch, var(--color-accent), transparent 100%); }
+  35%  { box-shadow: 0 0 0 5px color-mix(in oklch, var(--color-accent), transparent 70%); }
+  100% { box-shadow: 0 0 0 9px color-mix(in oklch, var(--color-accent), transparent 100%); }
 }
 @keyframes sc-flash-dot {
-  0%   { transform: scale(1.6); }
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.35); }
   100% { transform: scale(1); }
 }
 @media (prefers-reduced-motion: reduce) {
   .slot-card.sc-flash, .slot-card.sc-flash .sc-dot { animation: none; }
 }
-.sc-state-idle .sc-dot   { background: var(--hal0-accent); opacity: 0.65; }
+.sc-state-idle .sc-dot   { background: var(--color-warning); }
 .sc-state-loading .sc-dot { background: var(--color-warning); box-shadow: 0 0 6px -1px var(--color-warning); animation: dot-pulse 1.4s ease-in-out infinite; }
 .sc-state-error .sc-dot  { background: var(--color-danger); box-shadow: 0 0 6px -1px var(--color-danger); }
 .sc-state-offline .sc-dot { background: var(--color-fg-faint); box-shadow: none; }
 @keyframes dot-pulse {
   0%, 100% { box-shadow: 0 0 0 0 color-mix(in oklch, currentColor, transparent 70%); }
   50%      { box-shadow: 0 0 0 4px color-mix(in oklch, currentColor, transparent 90%); }
+}
+/* Soft active-traffic breathe: halo expands and fades smoothly without
+   the punchy ring of dot-pulse. Carried by the success-green dot. */
+@keyframes dot-breathe {
+  0%, 100% {
+    box-shadow: 0 0 0 0 color-mix(in oklch, var(--color-success), transparent 70%),
+                0 0 5px 0 color-mix(in oklch, var(--color-success), transparent 80%);
+  }
+  50% {
+    box-shadow: 0 0 0 6px color-mix(in oklch, var(--color-success), transparent 100%),
+                0 0 12px 2px color-mix(in oklch, var(--color-success), transparent 55%);
+  }
 }
 
 .sc-models {

--- a/ui/src/components/capabilities/CapabilitiesSection.vue
+++ b/ui/src/components/capabilities/CapabilitiesSection.vue
@@ -272,6 +272,7 @@ const hasData = computed(() => !!(embedSel.value || voiceSel.value || imgSel.val
 }
 .cap-metric {
   display: flex; flex-direction: column; gap: 1px; min-width: 0;
+  align-items: center; text-align: center;
 }
 .cap-metric-v {
   font-family: var(--font-mono); font-size: 12.5px; font-weight: 600;

--- a/ui/src/components/capabilities/CapabilitiesSection.vue
+++ b/ui/src/components/capabilities/CapabilitiesSection.vue
@@ -145,6 +145,11 @@ const hasData = computed(() => !!(embedSel.value || voiceSel.value || imgSel.val
   font-family: var(--font-mono); font-size: 10.5px;
   color: var(--color-fg-faint);
 }
+.cap-section-port {
+  margin-left: 2px;
+  color: var(--color-fg-faint);
+  opacity: 0.7;
+}
 
 /* Status pill — sits on the LEFT of the section header to anchor the eye.
  * Drives off the selection.status returned by /api/capabilities. */
@@ -163,7 +168,8 @@ const hasData = computed(() => !!(embedSel.value || voiceSel.value || imgSel.val
   border-color: color-mix(in oklch, var(--color-success) 40%, transparent);
   background: color-mix(in oklch, var(--color-success) 12%, transparent);
 }
-.cap-status[data-state="idle"] {
+.cap-status[data-state="idle"],
+.cap-status[data-state="ready"] {
   color: var(--color-warning);
   border-color: color-mix(in oklch, var(--color-warning) 40%, transparent);
   background: color-mix(in oklch, var(--color-warning) 12%, transparent);

--- a/ui/src/components/capabilities/EmbedCard.vue
+++ b/ui/src/components/capabilities/EmbedCard.vue
@@ -62,7 +62,19 @@ const togglePending = ref({ embed: false, rerank: false })
 
 function fmtMem(mb) {
   if (mb == null) return '—'
-  return mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${mb} MB`
+  return mb >= 1024 ? `${(mb / 1024).toFixed(2)} GB` : `${mb.toFixed(2)} MB`
+}
+
+// Compact uptime — "1h23m" / "12m" / "45s". Drops the smaller unit once
+// we're over an hour so the cell stays narrow.
+function fmtUptime(sec) {
+  if (sec == null) return '—'
+  const s = Math.floor(sec)
+  if (s < 60) return `${s}s`
+  if (s < 3600) return `${Math.floor(s / 60)}m`
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  return m ? `${h}h ${m}m` : `${h}h`
 }
 
 // Grouped per-model catalog entries for this child capability.
@@ -200,30 +212,37 @@ function backendFor(capability) {
 
 // ── Live metrics ───────────────────────────────────────────────────────
 // Read directly from useSlotMetrics() keyed by the upstream slot name.
-// We synthesise a small per-capability row from real numbers: headline =
-// requests-per-sec (rough proxy for "embedding throughput"), latency
-// comes from the metrics blob if present, mem from `mem_rss_mb`.
-// Cells that aren't available render `—` rather than fake data.
+// Per-capability row pulls from real backend fields: active reqs from
+// `requests_processing`, tok/s from `tokens_per_sec`, memory from
+// `mem_rss_mb`, uptime from `uptime_seconds`. Cells without data render
+// `—` rather than fake numbers.
 function metricsFor(capability) {
   const slotName = SLOT_NAME[capability]
   return slotName ? (metrics.value?.[slotName] ?? null) : null
 }
 
-function reqRate(m) {
+// Concurrent in-flight requests — integer, no rate computation. Backend
+// emits `requests_processing` from the slot's queue depth.
+function activeReqs(m) {
   if (!m) return null
-  if (m.requests_per_sec != null) return m.requests_per_sec
-  if (m.tokens_per_sec   != null) return m.tokens_per_sec
-  return null
+  return m.requests_processing ?? null
 }
 
-function latency(m) {
+// Throughput — only meaningful for token-streaming slots (chat). The
+// embed/rerank/voice/img slots don't report it; the cell renders "—".
+function tokRate(m) {
   if (!m) return null
-  return m.latency_ms_p50 ?? m.p50_latency_ms ?? m.latency_p50 ?? null
+  return m.tokens_per_sec ?? m.tps ?? null
 }
 
 function mem(m) {
   if (!m) return null
   return m.mem_rss_mb ?? m.vram_mb ?? m.gtt_mb ?? null
+}
+
+function uptime(m) {
+  if (!m) return null
+  return m.uptime_seconds ?? null
 }
 
 const embedActive = computed(() => {
@@ -320,17 +339,21 @@ const headerPill = computed(() => {
         <span class="cap-meta-item" v-if="backendFor('embed')?.multiplex">⚡ shared {{ backendFor('embed').label }} process</span>
       </div>
       <div v-if="embedActive" class="cap-metrics">
-        <div class="cap-metric cap-metric-headline" :class="{ 'cap-metric-na': reqRate(metricsFor('embed')) == null }">
-          <span class="cap-metric-v">{{ reqRate(metricsFor('embed')) != null ? Number(reqRate(metricsFor('embed'))).toFixed(1) : '—' }}</span>
-          <span class="cap-metric-u">req/s</span>
+        <div class="cap-metric cap-metric-headline" :class="{ 'cap-metric-na': activeReqs(metricsFor('embed')) == null }">
+          <span class="cap-metric-v">{{ activeReqs(metricsFor('embed')) ?? '—' }}</span>
+          <span class="cap-metric-u">active reqs</span>
         </div>
-        <div class="cap-metric" :class="{ 'cap-metric-na': latency(metricsFor('embed')) == null }">
-          <span class="cap-metric-v">{{ latency(metricsFor('embed')) ?? '—' }}</span>
-          <span class="cap-metric-u">ms p50</span>
+        <div class="cap-metric" :class="{ 'cap-metric-na': tokRate(metricsFor('embed')) == null }">
+          <span class="cap-metric-v">{{ tokRate(metricsFor('embed')) != null ? Number(tokRate(metricsFor('embed'))).toFixed(1) : '—' }}</span>
+          <span class="cap-metric-u">tok/s</span>
         </div>
         <div class="cap-metric cap-metric-mem">
           <span class="cap-metric-v">{{ fmtMem(mem(metricsFor('embed'))) }}</span>
-          <span class="cap-metric-u">resident</span>
+          <span class="cap-metric-u">memory</span>
+        </div>
+        <div class="cap-metric" :class="{ 'cap-metric-na': uptime(metricsFor('embed')) == null }">
+          <span class="cap-metric-v">{{ fmtUptime(uptime(metricsFor('embed'))) }}</span>
+          <span class="cap-metric-u">uptime</span>
         </div>
       </div>
     </section>
@@ -397,17 +420,21 @@ const headerPill = computed(() => {
         <span class="cap-meta-item" v-if="backendFor('rerank')?.multiplex">⚡ shared {{ backendFor('rerank').label }} process</span>
       </div>
       <div v-if="rerankActive" class="cap-metrics">
-        <div class="cap-metric cap-metric-headline" :class="{ 'cap-metric-na': reqRate(metricsFor('rerank')) == null }">
-          <span class="cap-metric-v">{{ reqRate(metricsFor('rerank')) != null ? Number(reqRate(metricsFor('rerank'))).toFixed(1) : '—' }}</span>
-          <span class="cap-metric-u">req/s</span>
+        <div class="cap-metric cap-metric-headline" :class="{ 'cap-metric-na': activeReqs(metricsFor('rerank')) == null }">
+          <span class="cap-metric-v">{{ activeReqs(metricsFor('rerank')) ?? '—' }}</span>
+          <span class="cap-metric-u">active reqs</span>
         </div>
-        <div class="cap-metric" :class="{ 'cap-metric-na': latency(metricsFor('rerank')) == null }">
-          <span class="cap-metric-v">{{ latency(metricsFor('rerank')) ?? '—' }}</span>
-          <span class="cap-metric-u">ms p50</span>
+        <div class="cap-metric" :class="{ 'cap-metric-na': tokRate(metricsFor('rerank')) == null }">
+          <span class="cap-metric-v">{{ tokRate(metricsFor('rerank')) != null ? Number(tokRate(metricsFor('rerank'))).toFixed(1) : '—' }}</span>
+          <span class="cap-metric-u">tok/s</span>
         </div>
         <div class="cap-metric cap-metric-mem">
           <span class="cap-metric-v">{{ fmtMem(mem(metricsFor('rerank'))) }}</span>
-          <span class="cap-metric-u">resident</span>
+          <span class="cap-metric-u">memory</span>
+        </div>
+        <div class="cap-metric" :class="{ 'cap-metric-na': uptime(metricsFor('rerank')) == null }">
+          <span class="cap-metric-v">{{ fmtUptime(uptime(metricsFor('rerank'))) }}</span>
+          <span class="cap-metric-u">uptime</span>
         </div>
       </div>
     </section>

--- a/ui/src/components/capabilities/EmbedCard.vue
+++ b/ui/src/components/capabilities/EmbedCard.vue
@@ -29,6 +29,7 @@ import { useCapabilities } from '../../composables/useCapabilities.js'
 import { useSlotMetrics } from '../../composables/useStats.js'
 import { useToastsStore } from '../../stores/toasts.js'
 import { usePullJob, fmtBytes } from '../../composables/usePullJob.js'
+import { useSystemStore } from '../../stores/system.js'
 import CapabilityToggle from './CapabilityToggle.vue'
 
 const props = defineProps({
@@ -38,6 +39,7 @@ const props = defineProps({
 
 const cap = useCapabilities()
 const toasts = useToastsStore()
+const system = useSystemStore()
 const { metrics } = useSlotMetrics()
 
 // Map { capability → upstream slot name }. Mirrors the backend's slot
@@ -45,6 +47,14 @@ const { metrics } = useSlotMetrics()
 // with the cards. Keep in sync with the backend agent.
 const SLOT_NAME = { embed: 'embed', rerank: 'embed-rerank' }
 const ENDPOINTS  = { embed: '/v1/embeddings', rerank: '/v1/rerankings' }
+
+// Port of the upstream slot, surfaced alongside the endpoint so
+// operators can curl the slot directly without cross-referencing
+// /api/slots.
+function portFor(capability) {
+  const name = SLOT_NAME[capability]
+  return system.slots.find((s) => s.name === name)?.port ?? null
+}
 
 // Per-child loading flag for the toggle spinner. Keyed by capability so
 // flipping one pill doesn't lock the other.
@@ -257,7 +267,10 @@ const headerPill = computed(() => {
             {{ selection?.embed?.status || 'offline' }}
           </span>
           <span class="cap-section-label">Embed</span>
-          <span class="cap-section-sub">{{ ENDPOINTS.embed }}</span>
+          <span class="cap-section-sub">
+            {{ ENDPOINTS.embed }}
+            <span v-if="portFor('embed')" class="cap-section-port">· :{{ portFor('embed') }}</span>
+          </span>
         </span>
         <CapabilityToggle
           :model-value="!!selection?.embed?.enabled"
@@ -331,7 +344,10 @@ const headerPill = computed(() => {
             {{ selection?.rerank?.status || 'offline' }}
           </span>
           <span class="cap-section-label">Rerank</span>
-          <span class="cap-section-sub">{{ ENDPOINTS.rerank }}</span>
+          <span class="cap-section-sub">
+            {{ ENDPOINTS.rerank }}
+            <span v-if="portFor('rerank')" class="cap-section-port">· :{{ portFor('rerank') }}</span>
+          </span>
         </span>
         <CapabilityToggle
           :model-value="!!selection?.rerank?.enabled"

--- a/ui/src/components/capabilities/ImgCard.vue
+++ b/ui/src/components/capabilities/ImgCard.vue
@@ -8,7 +8,7 @@
  * /api/capabilities/img/img endpoint as the other capability cards via
  * useCapabilities().setSelection().
  *
- * Metrics show `imgs/h` (req/s × 3600) when available — operator-visible
+ * Metrics show active reqs / tok/s / memory / uptime — operator-visible
  * throughput is rare-event-y for image gen, so a per-hour rollup reads
  * more usefully than the underlying per-sec rate.
  *
@@ -42,7 +42,17 @@ const slotPort = computed(
 
 function fmtMem(mb) {
   if (mb == null) return '—'
-  return mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${mb} MB`
+  return mb >= 1024 ? `${(mb / 1024).toFixed(2)} GB` : `${mb.toFixed(2)} MB`
+}
+
+function fmtUptime(sec) {
+  if (sec == null) return '—'
+  const s = Math.floor(sec)
+  if (s < 60) return `${s}s`
+  if (s < 3600) return `${Math.floor(s / 60)}m`
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  return m ? `${h}h ${m}m` : `${h}h`
 }
 
 function modelsFor() {
@@ -150,30 +160,24 @@ const isActive = computed(() => {
   return s?.enabled && s?.status !== 'offline'
 })
 
-// Live metrics — image gen reads per-hour from the per-sec rate.
+// Live metrics for the img slot.
 const imgMetrics = computed(() => metrics.value?.[SLOT_NAME] ?? null)
-function reqRate(m) {
+function activeReqs(m) {
   if (!m) return null
-  if (m.requests_per_sec != null) return m.requests_per_sec
-  if (m.tokens_per_sec   != null) return m.tokens_per_sec
-  return null
+  return m.requests_processing ?? null
 }
-function latency(m) {
+function tokRate(m) {
   if (!m) return null
-  return m.latency_ms_p50 ?? m.p50_latency_ms ?? m.latency_p50 ?? null
+  return m.tokens_per_sec ?? m.tps ?? null
 }
 function mem(m) {
   if (!m) return null
   return m.mem_rss_mb ?? m.vram_mb ?? m.gtt_mb ?? null
 }
-const imgsPerHour = computed(() => {
-  const r = reqRate(imgMetrics.value)
-  return r != null ? Math.round(r * 3600) : null
-})
-const secPerImg = computed(() => {
-  const l = latency(imgMetrics.value)
-  return l != null ? (l / 1000).toFixed(1) : null
-})
+function uptime(m) {
+  if (!m) return null
+  return m.uptime_seconds ?? null
+}
 
 const headerPill = computed(() => {
   const s = props.selection?.img?.status
@@ -251,17 +255,21 @@ const headerPill = computed(() => {
         <span class="cap-meta-item">comfyui handles VAE + text encoder</span>
       </div>
       <div v-if="isActive" class="cap-metrics">
-        <div class="cap-metric cap-metric-headline" :class="{ 'cap-metric-na': imgsPerHour == null }">
-          <span class="cap-metric-v">{{ imgsPerHour ?? '—' }}</span>
-          <span class="cap-metric-u">imgs/h</span>
+        <div class="cap-metric cap-metric-headline" :class="{ 'cap-metric-na': activeReqs(imgMetrics) == null }">
+          <span class="cap-metric-v">{{ activeReqs(imgMetrics) ?? '—' }}</span>
+          <span class="cap-metric-u">active reqs</span>
         </div>
-        <div class="cap-metric" :class="{ 'cap-metric-na': secPerImg == null }">
-          <span class="cap-metric-v">{{ secPerImg ?? '—' }}</span>
-          <span class="cap-metric-u">s/img</span>
+        <div class="cap-metric" :class="{ 'cap-metric-na': tokRate(imgMetrics) == null }">
+          <span class="cap-metric-v">{{ tokRate(imgMetrics) != null ? Number(tokRate(imgMetrics)).toFixed(1) : '—' }}</span>
+          <span class="cap-metric-u">tok/s</span>
         </div>
         <div class="cap-metric cap-metric-mem">
           <span class="cap-metric-v">{{ fmtMem(mem(imgMetrics)) }}</span>
-          <span class="cap-metric-u">resident</span>
+          <span class="cap-metric-u">memory</span>
+        </div>
+        <div class="cap-metric" :class="{ 'cap-metric-na': uptime(imgMetrics) == null }">
+          <span class="cap-metric-v">{{ fmtUptime(uptime(imgMetrics)) }}</span>
+          <span class="cap-metric-u">uptime</span>
         </div>
       </div>
     </section>

--- a/ui/src/components/capabilities/ImgCard.vue
+++ b/ui/src/components/capabilities/ImgCard.vue
@@ -20,6 +20,7 @@ import { useCapabilities } from '../../composables/useCapabilities.js'
 import { useSlotMetrics } from '../../composables/useStats.js'
 import { useToastsStore } from '../../stores/toasts.js'
 import { usePullJob, fmtBytes } from '../../composables/usePullJob.js'
+import { useSystemStore } from '../../stores/system.js'
 import CapabilityToggle from './CapabilityToggle.vue'
 
 const props = defineProps({
@@ -29,10 +30,15 @@ const props = defineProps({
 
 const cap = useCapabilities()
 const toasts = useToastsStore()
+const system = useSystemStore()
 const { metrics } = useSlotMetrics()
 
 const SLOT_NAME = 'img'
 const togglePending = ref(false)
+
+const slotPort = computed(
+  () => system.slots.find((s) => s.name === SLOT_NAME)?.port ?? null,
+)
 
 function fmtMem(mb) {
   if (mb == null) return '—'
@@ -196,7 +202,10 @@ const headerPill = computed(() => {
             {{ selection?.img?.status || 'offline' }}
           </span>
           <span class="cap-section-label">Image</span>
-          <span class="cap-section-sub">/v1/images/generations</span>
+          <span class="cap-section-sub">
+            /v1/images/generations
+            <span v-if="slotPort" class="cap-section-port">· :{{ slotPort }}</span>
+          </span>
         </span>
         <CapabilityToggle
           :model-value="!!selection?.img?.enabled"

--- a/ui/src/components/capabilities/VoiceCard.vue
+++ b/ui/src/components/capabilities/VoiceCard.vue
@@ -13,6 +13,7 @@ import { useCapabilities } from '../../composables/useCapabilities.js'
 import { useSlotMetrics } from '../../composables/useStats.js'
 import { useToastsStore } from '../../stores/toasts.js'
 import { usePullJob, fmtBytes } from '../../composables/usePullJob.js'
+import { useSystemStore } from '../../stores/system.js'
 import CapabilityToggle from './CapabilityToggle.vue'
 
 const props = defineProps({
@@ -21,6 +22,7 @@ const props = defineProps({
 
 const cap = useCapabilities()
 const toasts = useToastsStore()
+const system = useSystemStore()
 const { metrics } = useSlotMetrics()
 
 const CAPS = ['stt', 'tts']
@@ -28,6 +30,11 @@ const SLOT_NAME = { stt: 'stt', tts: 'tts' }
 const ENDPOINTS = {
   stt: '/v1/audio/transcriptions',
   tts: '/v1/audio/speech',
+}
+
+function portFor(capability) {
+  const name = SLOT_NAME[capability]
+  return system.slots.find((s) => s.name === name)?.port ?? null
 }
 
 const togglePending = ref({ stt: false, tts: false })
@@ -197,7 +204,10 @@ const headerPill = computed(() => {
             {{ selection?.[c]?.status || 'offline' }}
           </span>
           <span class="cap-section-label">{{ c.toUpperCase() }}</span>
-          <span class="cap-section-sub">{{ ENDPOINTS[c] }}</span>
+          <span class="cap-section-sub">
+            {{ ENDPOINTS[c] }}
+            <span v-if="portFor(c)" class="cap-section-port">· :{{ portFor(c) }}</span>
+          </span>
         </span>
         <CapabilityToggle
           :model-value="!!selection?.[c]?.enabled"

--- a/ui/src/components/capabilities/VoiceCard.vue
+++ b/ui/src/components/capabilities/VoiceCard.vue
@@ -41,7 +41,17 @@ const togglePending = ref({ stt: false, tts: false })
 
 function fmtMem(mb) {
   if (mb == null) return '—'
-  return mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${mb} MB`
+  return mb >= 1024 ? `${(mb / 1024).toFixed(2)} GB` : `${mb.toFixed(2)} MB`
+}
+
+function fmtUptime(sec) {
+  if (sec == null) return '—'
+  const s = Math.floor(sec)
+  if (s < 60) return `${s}s`
+  if (s < 3600) return `${Math.floor(s / 60)}m`
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  return m ? `${h}h ${m}m` : `${h}h`
 }
 
 function modelsFor(capability) {
@@ -155,19 +165,21 @@ function metricsFor(capability) {
   return slotName ? (metrics.value?.[slotName] ?? null) : null
 }
 
-function reqRate(m) {
+function activeReqs(m) {
   if (!m) return null
-  if (m.requests_per_sec != null) return m.requests_per_sec
-  if (m.tokens_per_sec   != null) return m.tokens_per_sec
-  return null
+  return m.requests_processing ?? null
 }
-function latency(m) {
+function tokRate(m) {
   if (!m) return null
-  return m.latency_ms_p50 ?? m.p50_latency_ms ?? m.latency_p50 ?? null
+  return m.tokens_per_sec ?? m.tps ?? null
 }
 function mem(m) {
   if (!m) return null
   return m.mem_rss_mb ?? m.vram_mb ?? m.gtt_mb ?? null
+}
+function uptime(m) {
+  if (!m) return null
+  return m.uptime_seconds ?? null
 }
 
 function isActive(c) {
@@ -253,17 +265,21 @@ const headerPill = computed(() => {
         <span class="cap-meta-item" v-if="backendFor(c)?.multiplex">⚡ shared {{ backendFor(c).label }} process</span>
       </div>
       <div v-if="isActive(c)" class="cap-metrics">
-        <div class="cap-metric cap-metric-headline" :class="{ 'cap-metric-na': reqRate(metricsFor(c)) == null }">
-          <span class="cap-metric-v">{{ reqRate(metricsFor(c)) != null ? Number(reqRate(metricsFor(c))).toFixed(1) : '—' }}</span>
-          <span class="cap-metric-u">req/s</span>
+        <div class="cap-metric cap-metric-headline" :class="{ 'cap-metric-na': activeReqs(metricsFor(c)) == null }">
+          <span class="cap-metric-v">{{ activeReqs(metricsFor(c)) ?? '—' }}</span>
+          <span class="cap-metric-u">active reqs</span>
         </div>
-        <div class="cap-metric" :class="{ 'cap-metric-na': latency(metricsFor(c)) == null }">
-          <span class="cap-metric-v">{{ latency(metricsFor(c)) ?? '—' }}</span>
-          <span class="cap-metric-u">ms p50</span>
+        <div class="cap-metric" :class="{ 'cap-metric-na': tokRate(metricsFor(c)) == null }">
+          <span class="cap-metric-v">{{ tokRate(metricsFor(c)) != null ? Number(tokRate(metricsFor(c))).toFixed(1) : '—' }}</span>
+          <span class="cap-metric-u">tok/s</span>
         </div>
         <div class="cap-metric cap-metric-mem">
           <span class="cap-metric-v">{{ fmtMem(mem(metricsFor(c))) }}</span>
-          <span class="cap-metric-u">resident</span>
+          <span class="cap-metric-u">memory</span>
+        </div>
+        <div class="cap-metric" :class="{ 'cap-metric-na': uptime(metricsFor(c)) == null }">
+          <span class="cap-metric-v">{{ fmtUptime(uptime(metricsFor(c))) }}</span>
+          <span class="cap-metric-u">uptime</span>
         </div>
       </div>
     </section>

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -31,6 +31,32 @@ const system = useSystemStore()
 const { stats } = useStats(2500)
 const { metrics, history, aggHistory } = useSlotMetrics(2500)
 
+// Slots managed entirely by the capability cards (Embed/Voice/Img on
+// the Slots page). Hidden from the dashboard slot grid so operators
+// don't see them twice.
+const CAPABILITY_OWNED_SLOTS = new Set([
+  'embed', 'embed-rerank', 'stt', 'tts', 'img',
+])
+
+// Hard ordering: primary first, nano second, then user-defined slots
+// alphabetically. NPU rides at the end as its own card.
+const SLOT_ORDER = ['primary', 'nano']
+function slotSortKey(name) {
+  const i = SLOT_ORDER.indexOf(name)
+  return i >= 0 ? [0, i, name] : [1, 0, name]
+}
+const visibleSlots = computed(() => {
+  const rows = system.slots.filter((s) => !CAPABILITY_OWNED_SLOTS.has(s.name))
+  rows.sort((a, b) => {
+    const ka = slotSortKey(a.name)
+    const kb = slotSortKey(b.name)
+    if (ka[0] !== kb[0]) return ka[0] - kb[0]
+    if (ka[1] !== kb[1]) return ka[1] - kb[1]
+    return ka[2].localeCompare(kb[2])
+  })
+  return rows
+})
+
 const hw = computed(() => stats.value || {})
 
 // ── Slot summary ─────────────────────────────────────────────────────
@@ -171,6 +197,7 @@ const chatModels = ref([])
 const chatModel = ref('')
 const chatPrompt = ref('')
 const chatOutput = ref('')
+const chatReasoning = ref('')
 const chatBusy = ref(false)
 const chatError = ref(null)
 const chatOutputEl = ref(null)
@@ -216,6 +243,7 @@ async function runChat() {
   chatBusy.value = true
   chatError.value = null
   chatOutput.value = ''
+  chatReasoning.value = ''
   try {
     const resp = await fetch('/v1/chat/completions', {
       method: 'POST',
@@ -252,9 +280,15 @@ async function runChat() {
         if (data === '[DONE]') continue
         try {
           const j = JSON.parse(data)
-          const delta = j?.choices?.[0]?.delta?.content
-          if (delta) {
-            chatOutput.value += delta
+          const d = j?.choices?.[0]?.delta
+          // Reasoning models (Qwen3-Reason, gpt-oss, deepseek-r1, …) emit
+          // `reasoning_content` for their <think> tokens and `content` for
+          // the user-visible answer. Dropping reasoning made the panel look
+          // frozen — small reasoning models can burn the whole token budget
+          // on thinking before any `content` arrives.
+          if (d?.reasoning_content) chatReasoning.value += d.reasoning_content
+          if (d?.content) chatOutput.value += d.content
+          if (d?.reasoning_content || d?.content) {
             await nextTick()
             if (chatOutputEl.value) {
               chatOutputEl.value.scrollTop = chatOutputEl.value.scrollHeight
@@ -395,25 +429,20 @@ loadChatModels()
       <section aria-labelledby="slots-heading">
         <p class="section-eyebrow"><span class="section-eyebrow-dot" aria-hidden="true"></span> Slots</p>
         <h2 id="slots-heading" class="section-title">Slots</h2>
-        <template v-if="system.loading && system.slots.length === 0">
+        <template v-if="system.loading && visibleSlots.length === 0">
           <div class="slots-grid">
             <Card v-for="i in 3" :key="i"><LoadingSkeleton :lines="3" /></Card>
           </div>
         </template>
-        <template v-else-if="system.slots.length === 0">
-          <Card :padded="false">
-            <EmptyState
-              title="No slots configured"
-              description="Create a slot to start serving inference requests."
-              cta-label="Go to Slots"
-              @cta="router.push('/slots')"
-            />
-          </Card>
+        <template v-else-if="visibleSlots.length === 0">
+          <div class="slots-grid" role="list" aria-label="Inference slots">
+            <NPUBackendCard />
+          </div>
         </template>
         <template v-else>
           <div class="slots-grid" role="list" aria-label="Inference slots">
             <SlotCard
-              v-for="slot in system.slots"
+              v-for="slot in visibleSlots"
               :key="slot.name"
               :slot="slot"
               :metrics="metrics[slot.name]"
@@ -458,9 +487,13 @@ loadChatModels()
               {{ chatBusy ? 'Streaming…' : 'Send' }}
             </button>
           </div>
-          <div ref="chatOutputEl" class="chat-output" :class="{ empty: !chatOutput && !chatError }">
+          <div ref="chatOutputEl" class="chat-output" :class="{ empty: !chatOutput && !chatReasoning && !chatError }">
             <span v-if="chatError" class="text-danger">{{ chatError }}</span>
-            <span v-else-if="chatOutput">{{ chatOutput }}</span>
+            <template v-else-if="chatOutput || chatReasoning">
+              <span v-if="chatReasoning" class="chat-reasoning">{{ chatReasoning }}</span>
+              <span v-if="chatReasoning && chatOutput" class="chat-reasoning-sep">───</span>
+              <span v-if="chatOutput">{{ chatOutput }}</span>
+            </template>
             <span v-else class="text-muted mono-text">Response appears here · streaming SSE from /v1/chat/completions</span>
           </div>
         </Card>
@@ -585,6 +618,8 @@ loadChatModels()
 .chat-send { padding: 6px 16px; flex-shrink: 0; }
 .chat-output { min-height: 80px; max-height: 260px; overflow-y: auto; padding: 10px 12px; background: var(--color-surface-2); border: 1px solid var(--color-border); border-radius: var(--radius); font-size: 13px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
 .chat-output.empty { display: flex; align-items: center; min-height: 60px; }
+.chat-reasoning { color: var(--color-fg-faint); font-style: italic; font-size: 12px; }
+.chat-reasoning-sep { display: block; margin: 8px 0; color: var(--color-fg-faint); font-family: var(--font-mono); font-size: 11px; }
 
 /* ── Logs ───────────────────────────────────────────────────────── */
 .logs-empty { padding: 20px 16px; display: flex; align-items: center; }

--- a/ui/src/views/Slots.vue
+++ b/ui/src/views/Slots.vue
@@ -82,7 +82,7 @@ const deleting     = ref(false)
 // Fields that require a slot restart to apply
 const RESTART_FIELDS = new Set(['ctx_size', 'n_gpu_layers'])
 // Slot states considered "live" for swap-vs-config dispatch
-const RUNNING_STATES = new Set(['running', 'serving', 'ready'])
+const RUNNING_STATES = new Set(['running', 'ready', 'serving', 'idle'])
 
 // Logs drawer
 const logsSlot    = ref(null)
@@ -577,9 +577,16 @@ onUnmounted(() => {
 })
 
 // ── Display helpers ────────────────────────────────────────────────────
+// state-dot vocab:
+//   state-running (green)  → only `serving` (a request is in-flight)
+//   state-idle    (yellow) → any warm/loaded state (running/ready/idle/warming/starting/pulling)
+//   state-error   (red)    → terminal failure
+//   state-offline (grey)   → process down / unloading
+// Mirrors SlotCard.vue dot semantics: dot color = readiness, top rail = in-flight.
 const stateClass = (s) => ({
-  running: 'state-running', ready: 'state-running', serving: 'state-running',
-  idle: 'state-idle', warming: 'state-idle', starting: 'state-idle', pulling: 'state-idle',
+  serving: 'state-running',
+  running: 'state-idle', ready: 'state-idle', idle: 'state-idle',
+  warming: 'state-idle', starting: 'state-idle', pulling: 'state-idle',
   error: 'state-error',
   offline: 'state-offline', unloading: 'state-offline',
 }[s] ?? 'state-offline')

--- a/ui/src/views/Slots.vue
+++ b/ui/src/views/Slots.vue
@@ -33,6 +33,23 @@ import CapabilitiesSection from '../components/capabilities/CapabilitiesSection.
 // Mirror src/hal0/slots/__init__.py BUILTIN_SLOTS — these cannot be deleted.
 const BUILTIN_SLOTS = new Set(['primary', 'embed', 'stt', 'tts'])
 
+// Slots whose UX lives entirely in the capability cards (EmbedCard,
+// VoiceCard, ImgCard). They're still real slots in the backend, but we
+// hide them from the regular slot grid so operators don't have two
+// places that look like they configure the same thing.
+const CAPABILITY_OWNED_SLOTS = new Set([
+  'embed', 'embed-rerank', 'stt', 'tts', 'img',
+])
+
+// Hard ordering for the slot grid. Slots listed here take the first
+// positions in the given order; anything else sorts alphabetically
+// after them. NPU rides at the very end as a separate card.
+const SLOT_ORDER = ['primary', 'nano']
+function slotSortKey(name) {
+  const i = SLOT_ORDER.indexOf(name)
+  return i >= 0 ? [0, i, name] : [1, 0, name]
+}
+
 const { metrics: slotMetrics, history: slotHistory } = useSlotMetrics(2500)
 
 const route  = useRoute()
@@ -545,13 +562,23 @@ const liveStates = computed(() => {
 // `_selectedModel` is read from slotSelections (not stored on the
 // wrapper object), so the dropdown's pending selection survives across
 // store polls — see the slotSelections declaration above.
-const slots = computed(() =>
-  system.slots.map((s) => {
-    const live = liveStates.value[s.name]
-    const status = live?.state ?? s.status
-    return { ...s, status, _selectedModel: slotSelections.value[s.name] ?? '' }
+const slots = computed(() => {
+  const rows = system.slots
+    .filter((s) => !CAPABILITY_OWNED_SLOTS.has(s.name))
+    .map((s) => {
+      const live = liveStates.value[s.name]
+      const status = live?.state ?? s.status
+      return { ...s, status, _selectedModel: slotSelections.value[s.name] ?? '' }
+    })
+  rows.sort((a, b) => {
+    const ka = slotSortKey(a.name)
+    const kb = slotSortKey(b.name)
+    if (ka[0] !== kb[0]) return ka[0] - kb[0]
+    if (ka[1] !== kb[1]) return ka[1] - kb[1]
+    return ka[2].localeCompare(kb[2])
   })
-)
+  return rows
+})
 
 // Open detail panel if navigated to /slots/:name
 watch(() => route.params.name, (name) => {
@@ -611,19 +638,16 @@ const SLOT_TYPES = ['llama-server', 'flm', 'moonshine', 'kokoro']
 
     <div class="page-body">
       <!-- ── Slots table ──────────────────────────────────────── -->
-      <template v-if="system.loading && system.slots.length === 0">
+      <template v-if="system.loading && slots.length === 0">
         <Card v-for="i in 3" :key="i" class="slot-row-skel"><LoadingSkeleton :lines="2" /></Card>
       </template>
 
-      <template v-else-if="system.slots.length === 0">
-        <Card :padded="false">
-          <EmptyState
-            title="No slots yet"
-            description="Create your first slot to start serving inference requests. Slots map a backend process to a model."
-            cta-label="Create slot"
-            @cta="showCreate = true"
-          />
-        </Card>
+      <template v-else-if="slots.length === 0">
+        <!-- All system slots are capability-owned; show NPU card alone
+             rather than an empty "create a slot" prompt. -->
+        <div class="slots-grid" role="list" aria-label="Inference slots">
+          <NPUBackendCard />
+        </div>
       </template>
 
       <template v-else>


### PR DESCRIPTION
## Summary

Splits the slot-card visual language into two independent channels — **dot color = readiness**, **top rail = activity**. Before, both signals were carried by `.is-running`, so an idle-but-loaded slot wore the headline-amber rail and the dot was an ambiguous dim-amber. That overlapped with the post-#102 tail in which the cached UI bundle still rendered the pre-fix grey-dot / no-rail state for any slot in `status="idle"`.

### New vocabulary

| Channel | State | Color / treatment |
|---|---|---|
| **Dot** | `active` (`requests_processing > 0`) | 🟢 green, `dot-breathe` 2.4s soft halo |
| **Dot** | `idle` (warm — `running`/`ready`/`serving`/`idle`/`warming`/`starting`/`pulling`) | 🟡 solid warning-yellow |
| **Dot** | `error` (`error`/`failed`) | 🔴 red |
| **Dot** | `offline` (process down / unloading) | ⚫ grey |
| **Dot** | `loading` (action in flight from a control press) | 🟡 pulsing |
| **Top rail** (`inset 0 3px 0 amber`) | applied only while `dotState === 'active'` | transient signal — appears for the duration of a request |

The `.sc-flash` state-transition feedback (fires on lifecycle SSE events) was softened from a 0.7s snap to a 1.6s ease-in-out halo expand+fade so it reads as a gradient pulse rather than a flash.

## Files

- `ui/src/components/SlotCard.vue`
  - `dotState`: rename `'live'` → `'active'`
  - Template: add `'is-serving': dotState === 'active'` to class binding
  - CSS: split `.is-running` (border tint only) from new `.is-serving` (top rail)
  - CSS: `.sc-state-active .sc-dot` uses `--color-success` + new `dot-breathe` 2.4s keyframes
  - CSS: `.sc-state-idle .sc-dot` switches from `--hal0-accent` @ opacity 0.65 to solid `--color-warning`
  - CSS: `.sc-flash`/`.sc-flash-dot` keyframes softened (longer duration, growing-then-fading halo)
- `ui/src/views/Slots.vue`
  - `RUNNING_STATES` now includes `'idle'` so the model-swap fast-path triggers on a 5-min-idle slot
  - `stateClass` remapped: only `serving` is `state-running` (green); all other warm states share `state-idle` (yellow)

## Test plan

- [x] Clean Vite rebuild on hal0 (`rm -rf node_modules/.vite dist && npm run build`)
- [x] Bundle inspection: stale `new Set(['running','serving','ready'])` literal is gone from `dist/assets/*.js`; new `is-serving` rule emits separately from `is-running`; `dot-breathe` keyframe present
- [x] Headless Chromium probe of the live dashboard at `http://127.0.0.1:8080/`: all six slots render `slot-card is-running sc-state-idle` with a yellow dot (`oklch(0.78 0.18 85)`) and no top rail
- [x] Force-classed `.slot-card.is-running.is-serving.sc-state-active` clone returns:
  - `card_box_shadow: rgb(255, 176, 0) 0 3px 0 inset` (amber rail) ✅
  - `dot_bg: oklch(0.7 0.18 145)` (green) ✅
  - `dot_anim: dot-breathe-<scope> 2.4s` ✅
- [ ] Visual smoke from user: hard-refresh `hal0.thinmint.dev`, watch primary/nano cards through idle → in-flight chat → idle → 5-min idle_timeout (yellow stays yellow throughout; rail flashes amber only during the request)

## Notes

Backend lifecycle is unchanged — `ready ↔ idle ↔ serving` transitions still come from `src/hal0/slots/state.py::SlotState`. Only the UI interpretation moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)