### PR TITLE
copy: refresh user-visible error + empty strings in homelab voice

### DIFF
--- a/src/hal0/api/middleware/auth.py
+++ b/src/hal0/api/middleware/auth.py
@@ -428,7 +428,7 @@ async def require_token(request: Request) -> AuthIdentity:
         match = store.verify(bearer)
         if match is None:
             raise AuthInvalid(
-                "bearer token did not validate",
+                "bearer token didn't match any active token in the store",
                 details={"reason": "unknown_or_malformed_token"},
             )
         return AuthIdentity(
@@ -443,7 +443,7 @@ async def require_token(request: Request) -> AuthIdentity:
         claims = verify_session_token(cookie)
         if claims is None:
             raise AuthInvalid(
-                "session cookie did not validate",
+                "session cookie is expired or malformed",
                 details={"reason": "expired_or_malformed_session"},
             )
         return AuthIdentity(
@@ -464,11 +464,11 @@ async def require_token(request: Request) -> AuthIdentity:
         )
 
     raise AuthRequired(
-        "this endpoint requires authentication",
+        "this route needs a token or a logged-in session",
         details={
             "hint": (
                 "send Authorization: Bearer <token> for programmatic clients, "
-                "or POST /api/auth/login to obtain a hal0_session cookie"
+                "or POST /api/auth/login to get a hal0_session cookie"
             )
         },
     )
@@ -492,7 +492,7 @@ async def require_admin(
         return identity
     if not identity.is_admin:
         raise AuthForbidden(
-            "this endpoint requires an admin-scoped credential",
+            "this route is admin-only and your credential isn't admin-scoped",
             details={"identity": identity.identity, "scope": identity.scope},
         )
     _check_session_csrf(request, identity)
@@ -573,7 +573,8 @@ async def require_writer(
         return identity
     if identity.scope not in _WRITER_SCOPES:
         raise AuthForbidden(
-            "this endpoint requires a writer-scoped credential (admin or all)",
+            "this route needs a writer-scoped credential (admin or all). "
+            "read-only and v1-only tokens get a 403 here.",
             details={
                 "identity": identity.identity,
                 "scope": identity.scope,

--- a/ui/src/components/capabilities/CapabilitiesSection.vue
+++ b/ui/src/components/capabilities/CapabilitiesSection.vue
@@ -58,7 +58,7 @@ const hasData = computed(() => !!(embedSel.value || voiceSel.value || imgSel.val
          fall through and render the cards normally. -->
     <EmptyState
       v-else-if="cap.error.value && !hasData"
-      title="Couldn't load capabilities"
+      title="Dashboard couldn't reach /api/capabilities"
       :description="cap.error.value"
       cta-label="Retry"
       @cta="cap.refresh()"

--- a/ui/src/views/Models.vue
+++ b/ui/src/views/Models.vue
@@ -711,8 +711,8 @@ const QUANTS = ['Q4_K_M', 'Q5_K_M', 'Q8_0', 'F16', 'BF16']
         <Card :padded="false">
           <EmptyState
             icon="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
-            title="No models in registry"
-            description="Pull from Hugging Face, scan a local directory, or pick from the curated catalogue."
+            title="No models in the registry yet."
+            description="Pull from Hugging Face, scan a directory you already have on disk (NFS mounts are fine), or pick from the curated catalog."
             cta-label="Add a model"
             @cta="showPull = true"
           />

--- a/ui/src/views/Providers.vue
+++ b/ui/src/views/Providers.vue
@@ -234,8 +234,8 @@ onMounted(load)
         <Card :padded="false">
           <EmptyState
             icon="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
-            title="No upstreams configured"
-            description="Add OpenRouter, Anthropic, OpenAI, or a custom OpenAI-compatible upstream to enable external model routing."
+            title="No upstreams configured."
+            description="Wire up OpenRouter, Anthropic, OpenAI, or any OpenAI-compatible endpoint to route requests beyond the slots running locally."
             cta-label="Add upstream"
             @cta="openAddForm"
           />


### PR DESCRIPTION
## Summary

Companion to [Hal0ai/hal0-web#12](https://github.com/Hal0ai/hal0-web/pull/12). The marketing site got a full homelab-voice pass; this PR fixes the product surfaces that those same kinds of strings were quoted as anti-patterns of. *"Couldn't load capabilities"* and *"this endpoint requires authentication"* were literal examples in the brief.

The goal is to make every user-visible error / empty / status string sound like one homelabber writing to another — name the endpoint or path that failed when you can, state the actual reason instead of the abstract verb, drop bureaucratic formulas (*"this endpoint requires…"*), and add a homelab-shaped hint where one fits.

Scope is intentionally narrow: error + empty + status strings on the dashboard surfaces, plus the auth middleware messages. No labels, tooltips, or button copy — those can ride in a follow-up if you want them tightened too.

## Changes

### Dashboard (Vue) EmptyState rewrites

| Component | Before | After |
|---|---|---|
| `CapabilitiesSection.vue` | `Couldn't load capabilities` | `Dashboard couldn't reach /api/capabilities` |
| `Slots.vue` | `No slots yet` / *Create your first slot to start serving inference requests. Slots map a backend process to a model.* | `No slots yet.` / *A slot is one systemd unit running a backend (llama.cpp, FLM, Kokoro, ComfyUI…) bound to one model on its own port. Create one to start serving requests.* |
| `Dashboard.vue` | `No slots configured` / *Create a slot to start serving inference requests.* | `No slots configured.` / *Create one over in Slots. Each slot is a systemd unit on its own port, bound to one model.* |
| `Providers.vue` | `No upstreams configured` / *Add OpenRouter, Anthropic, OpenAI, or a custom OpenAI-compatible upstream to enable external model routing.* | `No upstreams configured.` / *Wire up OpenRouter, Anthropic, OpenAI, or any OpenAI-compatible endpoint to route requests beyond the slots running locally.* |
| `Models.vue` | `No models in registry` / *Pull from Hugging Face, scan a local directory, or pick from the curated catalogue.* | `No models in the registry yet.` / *Pull from Hugging Face, scan a directory you already have on disk (NFS mounts are fine), or pick from the curated catalog.* |

### Auth middleware (`src/hal0/api/middleware/auth.py`) error strings

| Where | Before | After |
|---|---|---|
| `AuthInvalid` (bearer) | `bearer token did not validate` | `bearer token didn't match any active token in the store` |
| `AuthInvalid` (cookie) | `session cookie did not validate` | `session cookie is expired or malformed` |
| `AuthRequired` | `this endpoint requires authentication` | `this route needs a token or a logged-in session` (hint: `obtain` → `get`) |
| `AuthForbidden` (admin) | `this endpoint requires an admin-scoped credential` | `this route is admin-only and your credential isn't admin-scoped` |
| `AuthForbidden` (writer) | `this endpoint requires a writer-scoped credential (admin or all)` | `this route needs a writer-scoped credential (admin or all). read-only and v1-only tokens get a 403 here.` |
| `CSRFRequired` | *unchanged* | *unchanged — "tripwire" is good plain language and the message already explains itself* |

## Test plan

- [x] `pytest tests/api/test_auth_middleware.py tests/api/test_auth_routes.py tests/api/test_auth_writer_scope.py` — 206 passed in 27s. No test asserted on the literal strings I changed.
- [x] `npm run build` in `ui/` — clean in 533ms; bundle sizes unchanged (Dashboard 11.12 kB, Slots 43.72 kB, Models 34.10 kB, Providers 10.70 kB).
- [ ] Sanity-check the dashboard at `https://hal0.thinmint.dev` after merging the toolbox bump (eyeball the EmptyState wording on `/slots`, `/models`, `/providers` once they're empty, and trigger an auth-required curl against `/api/...` to read the new middleware error in the response body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)