### PR TITLE
fix(backends): derive NPU memory total from unified pool, not a flat 16 GB

### DIFF
--- a/src/hal0/api/routes/backends.py
+++ b/src/hal0/api/routes/backends.py
@@ -127,9 +127,17 @@ def _mem_totals_for_backend(backend_id: str) -> tuple[int, int]:
     except Exception:
         return 0, 0
     if backend_id == "npu":
-        # NPU memory isn't exposed by the AMDXDNA driver yet; advertise
-        # 16 GB as the Strix Halo defaults.
-        return 0, 16000
+        # The AMDXDNA driver doesn't expose per-NPU residency yet, so
+        # there's no real per-device cap to report. NPU model weights
+        # live in the same GTT region of the unified-memory pool that
+        # the iGPU pulls from, so advertise the GTT total (or fall back
+        # to the unified-memory total). Once the driver surfaces real
+        # NPU residency, swap this for the live number.
+        if hw.gpus and hw.gpus[0].vram_mb:
+            return 0, hw.gpus[0].vram_mb
+        if hw.unified_memory_mb:
+            return 0, hw.unified_memory_mb
+        return 0, 0
     if backend_id in {"gpu-vulkan", "gpu-rocm"}:
         if hw.gpus and hw.gpus[0].vram_mb:
             return 0, hw.gpus[0].vram_mb


### PR DESCRIPTION
## Summary

The dashboard's NPU backend card has been showing **Memory 0.0 / 15.6 GB** because [\`_mem_totals_for_backend("npu")\`](https://github.com/Hal0ai/hal0/blob/main/src/hal0/api/routes/backends.py#L129-L132) returned a flat \`16000\` MB. That constant predated the FLM toolbox landing and was always a placeholder ("16 GB as the Strix Halo defaults") — it has no relationship to any real per-NPU cap, since:

1. The AMDXDNA driver doesn't expose per-NPU residency yet.
2. NPU model weights live in the same GTT region of the unified memory pool that the iGPU pulls from.

On a 128 GB Strix Halo box this makes the gauge misleading for any FLM model larger than 16 GB. A common workload (\`gpt-oss:20b\` at ~18.6 GB + \`embed-gemma:300m\` at ~0.6 GB) reads as "over capacity" against a cap that doesn't actually exist.

## Change

Mirror the GPU branch's logic in the same function:

```python
if backend_id == "npu":
    if hw.gpus and hw.gpus[0].vram_mb:
        return 0, hw.gpus[0].vram_mb        # GTT total on UMA
    if hw.unified_memory_mb:
        return 0, hw.unified_memory_mb
    return 0, 0
```

On Strix Halo this surfaces the GTT total (~105 GB on a 128 GB box, per the BIOS UMA carveout); on a hypothetical NPU-bearing system without a UMA iGPU it falls back to the unified-memory total. Same pool, same total — the NPU just doesn't have a separate device-local cap to report.

## Trade-off

The NPU memory bar will visually look near-empty most of the time on the dashboard, because the denominator is now ~100 GB instead of 16 GB and per-slot residency isn't wired through yet. That's the accurate state of the world; the previous gauge was tight only because it lied about the cap. Once the AMDXDNA driver surfaces real per-NPU residency (or the FLM provider grows a residency probe), the numerator becomes meaningful and the gauge tightens up honestly.

## Test plan

- [x] \`pytest tests/api/ -k "backend or hardware"\` — 20 passed, no test asserted on the literal \`16000\` constant for NPU.
- [ ] Reload the dashboard on \`https://hal0.thinmint.dev\` after deploy; confirm the NPU card on \`/slots\` shows \`0.0 / ~105 GB\` instead of \`0.0 / 15.6 GB\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)