### PR TITLE
docs(release.yml): replace stale "releases.hal0.dev does not exist yet"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,15 @@ name: Release
 #
 # Triggered by: `git tag vX.Y.Z && git push origin vX.Y.Z`.
 #
+# The manifest is automatically served at https://releases.hal0.dev/<channel>.json
+# (e.g. /stable.json) by the Cloudflare Pages middleware in hal0-web
+# (functions/_middleware.ts). On a successful upload here, the next request
+# to releases.hal0.dev picks it up within ~60s (CF cache TTL) — no hal0-web
+# deploy needed. Updater clients should point at
+# HAL0_RELEASES_URL=https://releases.hal0.dev/stable.json.
+#
 # What this workflow does NOT do (deliberate, see "Blockers" in
 # scripts/release-prototype/RELEASE_PIPELINE_NOTES.md):
-#   - publish the manifest to https://releases.hal0.dev/ — that host
-#     does not exist yet. Until it does, the GH Release page acts as the
-#     canonical source and the updater can be pointed at
-#     HAL0_RELEASES_URL=https://github.com/hal0ai/hal0/releases/latest/download/latest.json
 #   - rebuild + republish toolbox images. That stays in toolbox.yml. The
 #     release manifest mirrors the toolbox digests pinned in
 #     manifest.json at the moment of the tag — the assumption is the


### PR DESCRIPTION
## Summary

The header comment in .github/workflows/release.yml claimed:

> publish the manifest to https://releases.hal0.dev/ — that host does not exist yet. Until it does, the GH Release page acts as the canonical source and the updater can be pointed at \`HAL0_RELEASES_URL=https://github.com/hal0ai/hal0/releases/latest/download/latest.json\`

Both bits are wrong now:

1. **releases.hal0.dev is fully operational.** Hal0ai/hal0-web PRs #10, #14, #15 wired up a Cloudflare Pages middleware proxy (\`functions/_middleware.ts\`) that automatically serves each channel's \`*.json\` asset from the most recent matching GitHub release on this repo. Verified end-to-end: \`curl releases.hal0.dev/stable.json\` returns the live \`v0.1.0-alpha.1\` manifest with all six toolbox image digests, \`x-hal0-source: github-release/v0.1.0-alpha.1\` header set.
2. **The recommended \`HAL0_RELEASES_URL\` pointed at \`latest.json\`**, but the schema we shipped uses \`{stable,nightly,dev}.json\` (per \`docs/release-manifest.md\`). Anyone following that example would 404.

Replaces the obsolete \"does NOT do\" bullet with a positive description: the manifest auto-syncs via the hal0-web proxy, updater clients should point at \`https://releases.hal0.dev/stable.json\`. Keeps the toolbox-image bullet (still accurate).

## What changed

Comment-only edit. No code change, no behavior change.

\`\`\`diff
-# What this workflow does NOT do (deliberate, see \"Blockers\" in
-# scripts/release-prototype/RELEASE_PIPELINE_NOTES.md):
-#   - publish the manifest to https://releases.hal0.dev/ — that host
-#     does not exist yet. Until it does, the GH Release page acts as the
-#     canonical source and the updater can be pointed at
-#     HAL0_RELEASES_URL=https://github.com/hal0ai/hal0/releases/latest/download/latest.json
-#   - rebuild + republish toolbox images. [...]
+# The manifest is automatically served at https://releases.hal0.dev/<channel>.json
+# (e.g. /stable.json) by the Cloudflare Pages middleware in hal0-web
+# (functions/_middleware.ts). On a successful upload here, the next request
+# to releases.hal0.dev picks it up within ~60s (CF cache TTL) — no hal0-web
+# deploy needed. Updater clients should point at
+# HAL0_RELEASES_URL=https://releases.hal0.dev/stable.json.
+#
+# What this workflow does NOT do [...]
+#   - rebuild + republish toolbox images. [...]
\`\`\`

## Test plan

- [x] Workflow file is syntactically valid (comment-only edit).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)