### PR TITLE
fix(firstrun): unblock wizard writer calls + skip-primary + catalog + hardware probe (v0.1.1)

### DIFF
--- a/src/hal0/api/middleware/auth.py
+++ b/src/hal0/api/middleware/auth.py
@@ -88,6 +88,7 @@ from __future__ import annotations
 
 import hmac
 import os
+import re
 from dataclasses import dataclass
 from typing import Annotated
 
@@ -176,6 +177,16 @@ _WRITER_SCOPES: frozenset[str] = frozenset({"admin", "all"})
 # ``Depends(require_writer)`` to those routes: when they do, this
 # helper keeps the first-run claim reachable without rewriting the
 # router wiring.
+#
+# The wizard also calls a handful of writer-gated routes BEFORE the
+# user finishes the password step (or chooses to skip it): persisting
+# the storage dir picks, pulling capability models, and registering
+# each pulled capability with the orchestrator. Those land below as
+# prefix/regex matches because they carry path variables (model id,
+# capability slot/child). The pre-password window is bounded by the
+# lockfile — once /api/auth/password or /api/install/complete consumes
+# it, this helper returns False for everything and the routes revert
+# to their declared writer gate.
 _FIRST_RUN_CLAIM_PATHS: frozenset[str] = frozenset(
     {
         "/api/install/state",
@@ -184,7 +195,29 @@ _FIRST_RUN_CLAIM_PATHS: frozenset[str] = frozenset(
         "/api/install/curated-models",
         "/api/install/pick-default",
         "/api/auth/password",
+        # Wizard step 2 — operator picks the model storage directories.
+        # Gated by require_writer on the live router; admitted here so
+        # the wizard can persist before a credential exists.
+        "/api/config/models",
     }
+)
+
+# Prefix matches for routes whose path carries variables. Each pattern
+# is anchored at the start of the path and used with ``re.fullmatch``,
+# so a stray suffix does NOT slip through (e.g. /api/models/foo/pull
+# matches but /api/models/foo/pull/extra does not).
+_FIRST_RUN_CLAIM_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # POST /api/models/{model_id}/pull — capability pulls launched from
+    # the wizard's install step. The model id segment is anything that
+    # isn't a slash; we deliberately keep it permissive because the
+    # registry's own validation already gates which ids actually exist.
+    re.compile(r"/api/models/[^/]+/pull"),
+    # POST /api/capabilities/{slot}/{child} — orchestrator registration
+    # the wizard fires after each capability pull lands. Slots + child
+    # names are short identifiers (embed/voice/img/...); permissive
+    # regex here is fine because the orchestrator rejects unknown
+    # slot/child combos with its own typed error.
+    re.compile(r"/api/capabilities/[^/]+/[^/]+"),
 )
 
 
@@ -205,11 +238,31 @@ def _password_is_set(request: Request) -> bool:
         return False
 
 
+def _path_is_claim_eligible(path: str) -> bool:
+    """True iff ``path`` is one of the routes the wizard reaches before
+    the operator has a credential.
+
+    Two layers:
+      - :data:`_FIRST_RUN_CLAIM_PATHS` for the fixed routes (cheap set
+        membership).
+      - :data:`_FIRST_RUN_CLAIM_PATTERNS` for the routes that carry a
+        variable segment (model id, capability slot/child) and need a
+        regex full-match.
+
+    Kept as a tiny pure helper so unit tests can exercise the
+    path-matching logic without standing up the full request pipeline.
+    """
+    if path in _FIRST_RUN_CLAIM_PATHS:
+        return True
+    return any(pattern.fullmatch(path) for pattern in _FIRST_RUN_CLAIM_PATTERNS)
+
+
 def _first_run_claim_active(request: Request) -> bool:
     """True iff the first-run claim window is currently open.
 
     Three conditions must hold:
-      1. The route being requested is in :data:`_FIRST_RUN_CLAIM_PATHS`.
+      1. The route being requested matches the claim-eligible set (see
+         :func:`_path_is_claim_eligible`).
       2. The owner password is not yet set.
       3. The installer's ``.first-run.lock`` file exists on disk
          (proof a fresh install just happened on this host).
@@ -220,7 +273,7 @@ def _first_run_claim_active(request: Request) -> bool:
     uninstaller); once it's gone, the only public surface is whatever
     the routers declare via absent-auth-dep.
     """
-    if request.url.path not in _FIRST_RUN_CLAIM_PATHS:
+    if not _path_is_claim_eligible(request.url.path):
         return False
     if _password_is_set(request):
         return False

--- a/src/hal0/api/routes/auth.py
+++ b/src/hal0/api/routes/auth.py
@@ -459,7 +459,7 @@ def _verify_first_run_otp(request: Request, body: dict[str, Any]) -> None:
 
 
 @router.post("/password")
-async def set_password(request: Request) -> Any:
+async def set_password(request: Request, response: Response) -> Any:
     """Set or rotate the owner password.
 
     Body::
@@ -474,10 +474,16 @@ async def set_password(request: Request) -> Any:
           * Non-loopback callers MUST present the OTP minted on
             startup at ``<state>/.first-run.lock`` (printed by the
             installer banner). FINDINGS §28.
+          * On success the response sets a ``hal0_session`` cookie so
+            the wizard's next writer call (PUT /api/config/models, the
+            capability pulls, /api/capabilities/...) authenticates as
+            the new owner. Without this the wizard would 401 on every
+            subsequent mutation — see #fix-firstrun-auth.
       - Rotation (password already set):
           * Requires writer scope (Bearer or cookie). Cookie path
             additionally enforces the CSRF tripwire — same as every
-            other writer-scoped mutation.
+            other writer-scoped mutation. No new cookie is issued; the
+            existing session stays valid.
 
     Always 400s a password shorter than 8 chars (server-side floor;
     the wizard surfaces a stronger UX hint).
@@ -532,6 +538,23 @@ async def set_password(request: Request) -> Any:
     # life-cycle obvious in code review.
     if not has_existing:
         first_run_lock.consume_lockfile()
+        # Mint a session cookie so the wizard's subsequent writer calls
+        # ride a normal cookie session instead of hitting AuthRequired
+        # on every mutation. Mirrors POST /api/auth/login exactly — same
+        # JWT helper, same cookie attributes — because once the password
+        # is set the operator IS the owner and skipping the explicit
+        # /api/auth/login round-trip is just a UX shortcut for the
+        # wizard. Rotation deliberately doesn't re-issue: the caller
+        # already had a session (or a Bearer) to pass require_writer.
+        token = create_session_token(user=_OWNER_USERNAME, scope=_OWNER_SCOPE)
+        response.set_cookie(
+            key=SESSION_COOKIE_NAME,
+            value=token,
+            httponly=True,
+            samesite="lax",
+            secure=_request_is_tls(request),
+            path="/",
+        )
 
     event_bus = getattr(request.app.state, "events", None)
     if event_bus is not None:

--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -35,6 +35,12 @@ def _flatten_for_ui(info: dict[str, Any]) -> dict[str, Any]:
     # only for non-UMA. This stops the dashboard from treating GTT and VRAM
     # as independent buckets.
     is_uma = vendor == "amd" and vram_mb > ram_mb * 0.5
+    platform = info.get("platform", "unknown") or "unknown"
+    # memory_kind tells the UI whether to label the pool "unified" or
+    # "system". Only strix-halo is genuinely unified for our purposes;
+    # everything else (including non-Halo AMD APUs the probe doesn't yet
+    # classify) gets the safer "system" label.
+    memory_kind = "unified" if (platform == "strix-halo" or is_uma) else "system"
     return {
         **info,
         "gpu_name": primary_gpu.get("name", ""),
@@ -51,7 +57,40 @@ def _flatten_for_ui(info: dict[str, Any]) -> dict[str, Any]:
         "cpu_threads": info.get("cpu_threads", 0),
         "npu_present": (info.get("npu") or {}).get("present", False),
         "npu_name": (info.get("npu") or {}).get("name", ""),
+        "platform": platform,
+        "platform_label": _platform_label(platform, primary_gpu),
+        "memory_kind": memory_kind,
     }
+
+
+_PLATFORM_LABELS = {
+    "strix-halo": "Strix Halo (unified memory)",
+    "wsl2": "WSL 2",
+    "proxmox-kvm": "Proxmox VM (KVM)",
+    "kvm": "KVM virtual machine",
+    "lxc": "Linux container (LXC)",
+    "bare-metal-amd-gpu": "Bare metal — AMD GPU",
+    "bare-metal-nvidia-gpu": "Bare metal — NVIDIA GPU",
+    "bare-metal-intel-igpu": "Bare metal — Intel iGPU",
+    "bare-metal-cpu-only": "Bare metal — CPU only",
+    "unknown": "Unknown platform",
+}
+
+
+def _platform_label(platform: str, primary_gpu: dict[str, Any]) -> str:
+    """Pretty label for the probed platform string.
+
+    Promotes the GPU model into the label for bare-metal hosts so the UI
+    can show "Bare metal — NVIDIA GeForce RTX 4080" without re-deriving
+    the brand on the client.
+    """
+    base = _PLATFORM_LABELS.get(platform, _PLATFORM_LABELS["unknown"])
+    name = (primary_gpu or {}).get("name") or ""
+    if platform.startswith("bare-metal-") and name and "GPU" in base:
+        # Drop the generic "GPU" suffix and substitute the actual name.
+        prefix = base.split(" — ")[0]
+        return f"{prefix} — {name}"
+    return base
 
 
 @router.get("/hardware")

--- a/src/hal0/api/routes/installer.py
+++ b/src/hal0/api/routes/installer.py
@@ -33,6 +33,7 @@ from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Request
 
+from hal0.api.auth import first_run as first_run_lock
 from hal0.api.middleware.auth import require_writer
 from hal0.api.middleware.error_codes import BadRequest, Hal0Error
 from hal0.config import paths
@@ -213,6 +214,14 @@ async def install_complete(request: Request) -> dict[str, Any]:
     Atomic: tempfile + os.replace in the parent directory so a partial
     write can't leave a half-written marker. Idempotent — re-calling
     after the sentinel already exists is a no-op.
+
+    Also consumes the ``.first-run.lock`` file. The lockfile already
+    disappears on a successful POST /api/auth/password, but operators
+    who chose "Skip — leave open" never hit that path. Without this
+    cleanup the claim window would stay open indefinitely — the
+    sentinel hides the wizard route in the UI, but the anonymous
+    pass-through on wizard writer routes would survive. Consuming
+    here closes that window the moment the wizard signals completion.
     """
     sentinel = _first_run_sentinel()
     sentinel.parent.mkdir(parents=True, exist_ok=True)
@@ -247,6 +256,9 @@ async def install_complete(request: Request) -> dict[str, Any]:
             with contextlib.suppress(OSError):
                 tmp_path.unlink(missing_ok=True)
 
+    # Idempotent — consume_lockfile() is a no-op if the file is already gone.
+    first_run_lock.consume_lockfile()
+
     return {"first_run": False, "sentinel_path": str(sentinel)}
 
 
@@ -255,7 +267,7 @@ async def install_complete(request: Request) -> dict[str, Any]:
 
 @router.get("/curated-models")
 async def curated_models() -> dict[str, Any]:
-    """Return the curated model catalogue the FirstRun wizard renders.
+    """Return the curated chat-model catalogue the FirstRun wizard renders.
 
     Shape::
 
@@ -264,13 +276,16 @@ async def curated_models() -> dict[str, Any]:
             "custom_allowed": true
         }
 
-    The wizard reads this once on mount and renders one card per entry.
-    Off-catalogue picks go through a separate "Custom Hugging Face URL"
-    form which calls ``POST /api/models`` + ``POST /api/models/{id}/pull``
-    directly.
+    Filtered to ``recommended_slot == "primary"`` — image models and any
+    future non-chat picks live in the same source list but have their own
+    placement in the wizard (step 4 capability pickers). Leaving them in
+    the chat picker would let an operator install Flux as their "chat
+    model", which is meaningless and previously confused users. Sourcing
+    capability picks happens through ``/api/capabilities``.
     """
+    chat_picks = [m for m in CURATED_MODELS if m.recommended_slot == "primary"]
     return {
-        "models": [m.model_dump(mode="json") for m in CURATED_MODELS],
+        "models": [m.model_dump(mode="json") for m in chat_picks],
         "custom_allowed": True,
     }
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -472,6 +472,16 @@ class HardwareInfo(BaseModel):
         default="",
         description="ISO-8601 UTC timestamp of the last probe run.",
     )
+    platform: str = Field(
+        default="unknown",
+        description=(
+            "Detected platform string. One of: 'strix-halo', 'wsl2', "
+            "'proxmox-kvm', 'kvm', 'lxc', 'bare-metal-amd-gpu', "
+            "'bare-metal-nvidia-gpu', 'bare-metal-intel-igpu', "
+            "'bare-metal-cpu-only', or 'unknown'. Used by the UI to label "
+            "memory ('unified' only on strix-halo) and tailor docs links."
+        ),
+    )
     extra: dict[str, Any] = Field(
         default_factory=dict,
         description="Probe-time extras (kernel version, OS release, etc.).",

--- a/src/hal0/hardware/probe.py
+++ b/src/hal0/hardware/probe.py
@@ -109,10 +109,16 @@ def _amd_drm_device() -> Path | None:
 def _parse_cpuinfo() -> tuple[str, int, int]:
     """Return (model_name, physical_cores, logical_threads).
 
-    Reads /proc/cpuinfo. Falls back to os.cpu_count() for threads if parsing fails.
+    Reads /proc/cpuinfo. Falls back to os.cpu_count() for threads if parsing
+    fails. On ARM hosts /proc/cpuinfo has no ``model name`` line — we look
+    at ``Hardware``, ``Model`` and ``CPU implementer`` fields instead so the
+    UI gets a non-empty string instead of a bare "—".
     """
     txt = _read_text(Path("/proc/cpuinfo"))
     model = ""
+    arm_hardware = ""
+    arm_model = ""
+    arm_part = ""
     threads = 0
     physical_ids: set[str] = set()
     cores_per_socket = 0
@@ -125,6 +131,12 @@ def _parse_cpuinfo() -> tuple[str, int, int]:
             v = v.strip()
             if k == "model name" and not model:
                 model = v
+            elif k == "Model" and not arm_model:
+                arm_model = v
+            elif k == "Hardware" and not arm_hardware:
+                arm_hardware = v
+            elif k == "CPU part" and not arm_part:
+                arm_part = v
             elif k == "processor":
                 threads += 1
             elif k == "physical id":
@@ -132,6 +144,20 @@ def _parse_cpuinfo() -> tuple[str, int, int]:
             elif k == "cpu cores":
                 with contextlib.suppress(ValueError):
                     cores_per_socket = max(cores_per_socket, int(v))
+    # ARM fallback: stitch whichever ID-shaped field we found into a name.
+    if not model:
+        model = arm_model or arm_hardware
+        if not model and arm_part:
+            model = f"ARM CPU ({arm_part})"
+    # Last resort: name the architecture so the wizard never shows an empty
+    # CPU row when /proc/cpuinfo exists but lacks any of the above.
+    if not model:
+        with contextlib.suppress(OSError):
+            import platform as _platform
+
+            mach = _platform.machine()
+            if mach:
+                model = f"{mach} CPU"
     if threads == 0:
         threads = os.cpu_count() or 0
     sockets = max(1, len(physical_ids))
@@ -327,12 +353,25 @@ def _detect_vulkan_fallback() -> GPUInfo | None:
 
 
 def _detect_lspci_fallback() -> GPUInfo | None:
-    """Last-resort: parse `lspci -nnk` for a VGA controller."""
-    rc, out, _ = _run(["lspci", "-nnk"])
-    if rc != 0 or not out:
+    """Last-resort: parse ``lspci -nnk`` (or plain ``lspci``) for any
+    VGA / 3D / Display controller. Try the verbose variant first, then
+    degrade to bare ``lspci`` so we still produce a name in containers
+    where pciutils' device-id database is missing.
+    """
+    out = ""
+    for cmd in (["lspci", "-nnk"], ["lspci"]):
+        rc, _out, _ = _run(cmd)
+        if rc == 0 and _out:
+            out = _out
+            break
+    if not out:
         return None
     for line in out.splitlines():
-        if "VGA compatible controller" in line or "3D controller" in line:
+        if (
+            "VGA compatible controller" in line
+            or "3D controller" in line
+            or "Display controller" in line
+        ):
             after = line.split(":", 2)[-1].strip()
             lower = after.lower()
             vendor = "unknown"
@@ -357,6 +396,138 @@ def _detect_gpu() -> GPUInfo:
         if info is not None:
             return info
     return GPUInfo(vendor="unknown")
+
+
+# ── Platform detection ────────────────────────────────────────────────────────
+#
+# Layered probe — first match wins. The string returned drives UI labels
+# (memory "unified" vs "system", docs links, slot recommendation tier) so
+# stability of the values matters more than precision: we'd rather
+# under-classify (return ``"kvm"`` for a Proxmox VM whose DMI strings the
+# kernel hid) than mis-attribute Strix Halo when no NPU is present.
+
+
+_DMI_PATHS = {
+    "product_name": Path("/sys/class/dmi/id/product_name"),
+    "sys_vendor": Path("/sys/class/dmi/id/sys_vendor"),
+    "board_vendor": Path("/sys/class/dmi/id/board_vendor"),
+    "bios_vendor": Path("/sys/class/dmi/id/bios_vendor"),
+}
+
+
+def _read_dmi() -> dict[str, str]:
+    """Read DMI strings used by platform detection. Returns lowercased values."""
+    out: dict[str, str] = {}
+    for key, path in _DMI_PATHS.items():
+        txt = _read_text(path)
+        if txt:
+            out[key] = txt.strip().lower()
+    return out
+
+
+def _is_container() -> bool:
+    """True when /proc/1/cgroup or /proc/self/cgroup hints at lxc/docker."""
+    for p in (Path("/proc/1/cgroup"), Path("/proc/self/cgroup")):
+        txt = _read_text(p)
+        if not txt:
+            continue
+        low = txt.lower()
+        if "lxc" in low or "docker" in low or "kubepods" in low:
+            return True
+    # systemd-nspawn / podman expose /run/.containerenv or /.dockerenv
+    return Path("/.dockerenv").exists() or Path("/run/.containerenv").exists()
+
+
+def _is_lxc() -> bool:
+    """Narrower than _is_container — only matches Proxmox/native LXC."""
+    txt = _read_text(Path("/proc/1/cgroup")) or _read_text(Path("/proc/self/cgroup"))
+    if txt and "lxc" in txt.lower():
+        return True
+    # systemd reports lxc via /proc/1/environ on some kernels
+    env = _read_text(Path("/proc/1/environ"))
+    return bool(env and "container=lxc" in env.lower().replace("\x00", " "))
+
+
+def _is_wsl() -> bool:
+    """True on WSL 1 / WSL 2 (any Microsoft kernel)."""
+    for p in (Path("/proc/version"), Path("/proc/sys/kernel/osrelease")):
+        txt = _read_text(p)
+        if not txt:
+            continue
+        low = txt.lower()
+        if "microsoft" in low or "wsl" in low:
+            return True
+    return False
+
+
+def _detect_platform(gpu: GPUInfo, npu: NPUInfo) -> str:
+    """Return a short platform string. See HardwareInfo.platform for the
+    canonical vocabulary. Detection order is intentional:
+
+      1. Containers first — wsl2 then lxc — because they overlap with KVM
+         when the host is itself a VM.
+      2. KVM detection via DMI ('QEMU' / 'KVM' sys_vendor + product_name).
+      3. Bare metal: classify by GPU vendor + NPU presence.
+    """
+    # 1. WSL — checked before LXC because WSL's /proc/1/cgroup can mention
+    #    other shims; the kernel string is the authoritative signal.
+    if _is_wsl():
+        return "wsl2"
+    if _is_lxc():
+        return "lxc"
+
+    dmi = _read_dmi()
+    product = dmi.get("product_name", "")
+    sysv = dmi.get("sys_vendor", "")
+    bios = dmi.get("bios_vendor", "")
+
+    is_qemu_kvm = (
+        "qemu" in sysv
+        or "qemu" in product
+        or "kvm" in product
+        or "kvm" in sysv
+        or "red hat" in sysv  # virtio devices report Red Hat as vendor
+        or "seabios" in bios
+        or "edk ii" in bios
+        or "ovmf" in bios
+    )
+    if is_qemu_kvm:
+        # Proxmox VMs typically expose "Standard PC (i440FX + PIIX, …)" or
+        # "Standard PC (Q35 + ICH9, …)" as product_name plus a generic QEMU
+        # sys_vendor. There's no DMI field that says "Proxmox" outright, so
+        # we look at the BIOS vendor / SMBIOS oem tags (Proxmox sets
+        # ``Type: 1 Manufacturer: ...`` to QEMU regardless). For the user-
+        # facing label we'd rather say "Proxmox VM (KVM)" when the host is
+        # almost certainly Proxmox; check for the SMBIOS oem string the
+        # PVE installer stamps in newer releases.
+        oem = _read_text(Path("/sys/class/dmi/id/chassis_vendor"))
+        if oem and "proxmox" in oem.lower():
+            return "proxmox-kvm"
+        # Heuristic: a /etc/pve directory is the strongest live signal but
+        # only present on a PVE host, not inside its VMs. For VMs, fall back
+        # to the kernel command line which carries a virtio root marker.
+        cmdline = _read_text(Path("/proc/cmdline")) or ""
+        if "virtio" in cmdline.lower() and "Q35" in (product.upper()):
+            # Q35 + virtio is the Proxmox default; users can override but
+            # 95%+ of homelab deployments hit this code path.
+            return "proxmox-kvm"
+        return "kvm"
+
+    # 3. Bare metal.
+    vendor = (gpu.vendor or "").lower()
+    if npu.present and vendor == "amd":
+        # Strix Halo / Hawk Point: AMD iGPU + XDNA NPU + unified memory.
+        # The drm_path having a GTT counter is what makes "unified" valid,
+        # but at this point we already trusted the GPU detector to report
+        # vram_mb=max(vram,gtt) so this is just the platform label.
+        return "strix-halo"
+    if vendor == "nvidia":
+        return "bare-metal-nvidia-gpu"
+    if vendor == "amd":
+        return "bare-metal-amd-gpu"
+    if vendor == "intel":
+        return "bare-metal-intel-igpu"
+    return "bare-metal-cpu-only"
 
 
 # ── NPU detection ──────────────────────────────────────────────────────────────
@@ -441,6 +612,18 @@ class HardwareProbe:
                 pass
 
             unified_mb = _derive_unified_memory_mb(ram_total_mb, gpu if gpu.vendor else None)
+            platform = "unknown"
+            try:
+                platform = _detect_platform(gpu, npu)
+            except Exception as exc:  # never let platform classification break the probe
+                log.warning("hardware.probe.platform_detect_fail", error=str(exc))
+
+            # We surface a GPU row when EITHER vendor or name is populated;
+            # the old logic dropped vendor="unknown" rows even when lspci
+            # gave us a perfectly good model string (e.g. a virtio GPU in a
+            # Proxmox VM). UI consumers can still gate on gpu.vendor when
+            # they need real compute capability.
+            include_gpu = bool(gpu.vendor and gpu.vendor != "unknown") or bool(gpu.name)
 
             return HardwareInfo(
                 cpu_model=cpu_model,
@@ -449,9 +632,10 @@ class HardwareProbe:
                 ram_mb=ram_total_mb,
                 ram_available_mb=ram_avail_mb,
                 unified_memory_mb=unified_mb,
-                gpus=[gpu] if gpu.vendor else [],
+                gpus=[gpu] if include_gpu else [],
                 npu=npu,
                 disk_free_mb=disk_mb,
+                platform=platform,
                 probed_at=_dt.datetime.now(_dt.UTC).isoformat(timespec="seconds"),
                 extra={"kernel": uname} if uname else {},
             )

--- a/src/hal0/registry/curated.py
+++ b/src/hal0/registry/curated.py
@@ -14,6 +14,51 @@ without touching the curated list.
 # it ships *with* a hal0 release so users can't end up on an outdated
 # pick list. v0.2 may introduce a remote-fetched manifest with signed
 # releases; for v1 a frozen-at-build-time list is plenty.
+
+# TODO(stt/tts curated picks): the FirstRun wizard's STT and TTS
+# dropdowns currently fall back on HaloaiModel seed rows (moonshine,
+# kokoro, vibevoice), which the capability catalog intentionally
+# filters out — they're upstream-routed, not pullable. The blocker for
+# adding real CuratedModel picks is the upstream file shape:
+#
+#   * Moonshine ships its weights as a multi-file ONNX bundle
+#     (``encode_model.ort`` + ``decode_model.ort`` + tokenizer JSON
+#     under ``quantized/<variant>/``). The pull engine (registry/pull.py)
+#     streams a single ``hf_repo/resolve/main/<file>`` URL, and the
+#     curated-model schema validation (tests/registry/test_curated.py)
+#     restricts ``hf_file`` to ``.gguf``/``.safetensors``/``.ckpt``.
+#     ``.ort`` files don't fit either constraint.
+#   * Whisper.cpp GGUF mirrors exist (``oxide-lab/whisper-tiny-GGUF``,
+#     ``xkeyC/whisper-large-v3-turbo-gguf``) but hal0's STT runtime is
+#     the Moonshine toolbox (``_RUNTIME_TO_HOST_BACKENDS["moonshine"]``
+#     in capabilities/catalog.py), which can't load whisper GGUFs.
+#     Surfacing a whisper.cpp pick needs either a whisper-cpp toolbox
+#     image or routing whisper-ggufs through llama-server (which 0.1.x
+#     llama-server doesn't support for transcription).
+#   * Kokoro's only public weight is ``hexgrad/Kokoro-82M/kokoro-v1_0.pth``
+#     — a PyTorch pickle. The ONNX mirror
+#     (``onnx-community/Kokoro-82M-v1.0-ONNX``) ships only ``.onnx`` +
+#     ``voices/*.bin``. Neither fits the allowed suffix list.
+#   * VibeVoice is similarly multi-file safetensors but lives in a
+#     diffusers-style repo (config + multiple shards), not a single
+#     pullable file.
+#
+# Resolutions to unblock (any one is enough):
+#   1. Add a multi-file pull mode to ``registry/pull.py`` that snapshots
+#      a HF repo dir into the model store, and relax the curated
+#      ``hf_file`` validator to allow a directory glob.
+#   2. Ship a whisper-cpp toolbox image and add a ``whisper`` entry to
+#      ``_RUNTIME_TO_HOST_BACKENDS``, then surface whisper.cpp GGUFs
+#      under stt.
+#   3. Keep the HaloaiModel seed rows visible in the wizard but mark
+#      them clearly as "needs upstream routing" — would require
+#      narrowing the ``HaloaiModel`` filter in
+#      ``capabilities/catalog._flat_rows_for_capability`` (NOT the call
+#      this PR makes — that filter is load-bearing).
+#
+# Until one of those lands, the wizard's STT and TTS dropdowns will
+# stay empty on a standalone install and the operator falls back on the
+# "skip this capability" path or the post-install Models view.
 """
 
 from __future__ import annotations
@@ -77,6 +122,17 @@ class CuratedModel(BaseModel):
         description=(
             "Primary capability — 'chat' (default), 'embed', 'asr', 'tts', 'image'. "
             "The pull layer routes 'image' into the ComfyUI models tree."
+        ),
+    )
+    backend: str = Field(
+        default="",
+        description=(
+            "Runtime backend tag the capability catalog fans out from. "
+            "'llamacpp' for GGUF chat/embed/rerank picks (catalog fans "
+            "out to gpu-vulkan/gpu-rocm/cpu); empty for image picks (the "
+            "catalog routes them to ComfyUI via ``comfyui_subdir``). The "
+            "field has no effect on the pull layer — pulls always go "
+            "through hf_repo + hf_file."
         ),
     )
     model_class: str = Field(
@@ -244,6 +300,125 @@ CURATED_MODELS: list[CuratedModel] = [
             "we use that. Smallest validated catalogue entry — good 'just download something' pick."
         ),
     ),
+    # ── Embed picks (llama-server with --embedding) ────────────────────────
+    # The wizard's "Embed" capability dropdown surfaces these. Both are
+    # llama.cpp-compatible GGUFs so they fan out to gpu-vulkan/gpu-rocm/cpu
+    # via _backend_variants. nomic-embed is the canonical light pick
+    # (single-file ~150 MB Q8_0); bge-base-en-v1.5 is the medium pick
+    # (~70 MB Q4_K_M, better English retrieval quality than nomic on MTEB).
+    CuratedModel(
+        id="nomic-embed-text-v1.5-q8_0",
+        display_name="Nomic Embed Text v1.5 (Q8_0)",
+        description=(
+            "Fast, accurate English/multilingual embeddings. Tiny enough "
+            "to ride alongside any chat slot. The default embed pick."
+        ),
+        family="nomic",
+        size_gb=0.15,
+        vram_gb_min=0.5,
+        license="Apache-2.0",
+        license_url="https://www.apache.org/licenses/LICENSE-2.0",
+        hf_repo="nomic-ai/nomic-embed-text-v1.5-GGUF",
+        hf_file="nomic-embed-text-v1.5.Q8_0.gguf",
+        context_length=8192,
+        recommended_slot="embed",
+        tags=["embed", "light"],
+        notes=(
+            "Q8_0 over Q4_K_M because embedding quality is brittle under "
+            "aggressive quantization and the size delta (146 MB vs 84 MB) "
+            "is irrelevant on Strix Halo's 100 GB pool."
+        ),
+        capability="embed",
+        backend="llamacpp",
+    ),
+    CuratedModel(
+        id="bge-base-en-v1.5-q4_k_m",
+        display_name="BGE Base EN v1.5 (Q4_K_M)",
+        description=(
+            "Higher English retrieval quality than nomic. Good when "
+            "RAG accuracy matters more than multilingual coverage."
+        ),
+        family="bge",
+        size_gb=0.07,
+        vram_gb_min=0.5,
+        license="MIT",
+        license_url="https://opensource.org/license/mit",
+        hf_repo="CompendiumLabs/bge-base-en-v1.5-gguf",
+        hf_file="bge-base-en-v1.5-q4_k_m.gguf",
+        context_length=512,
+        recommended_slot="embed",
+        tags=["embed", "medium"],
+        notes=(
+            "BAAI's BGE family leads MTEB English retrieval; Q4_K_M is "
+            "the standard quality/size sweet spot and the CompendiumLabs "
+            "repo is the canonical GGUF mirror."
+        ),
+        capability="embed",
+        backend="llamacpp",
+    ),
+    # ── Rerank picks (llama-server with --reranking) ───────────────────────
+    # Per memory hal0_rerank_slot_wiring, the working recipe is
+    # llama-server on a non-8081 port with --reranking; bge-reranker-v2-m3
+    # Q4_K_M is already running in production on hal0 LXC.
+    CuratedModel(
+        id="bge-reranker-base-q4_k_m",
+        display_name="BGE Reranker Base (Q4_K_M)",
+        description=(
+            "Light cross-encoder reranker for English RAG. ~260 MB on "
+            "disk, runs on CPU comfortably."
+        ),
+        family="bge",
+        size_gb=0.26,
+        vram_gb_min=0.5,
+        license="MIT",
+        license_url="https://opensource.org/license/mit",
+        hf_repo="cstr/bge-reranker-base-GGUF",
+        hf_file="bge-reranker-base-q4_k.gguf",
+        context_length=512,
+        recommended_slot="embed",
+        tags=["rerank", "light"],
+        notes=(
+            "cstr's GGUF mirror includes the classifier-head fix needed "
+            "for llama-server --reranking; the upstream BAAI repo ships "
+            "PyTorch only. Q4_K is the smallest quant that preserves "
+            "rerank ordering on BEIR."
+        ),
+        capability="rerank",
+        backend="llamacpp",
+    ),
+    CuratedModel(
+        id="bge-reranker-v2-m3-q4_k_m",
+        display_name="BGE Reranker v2 M3 (Q4_K_M)",
+        description=(
+            "Multilingual cross-encoder reranker. The production pick on "
+            "the hal0 LXC; ~440 MB, runs on CPU or GPU."
+        ),
+        family="bge",
+        size_gb=0.44,
+        vram_gb_min=1.0,
+        license="Apache-2.0",
+        license_url="https://www.apache.org/licenses/LICENSE-2.0",
+        hf_repo="gpustack/bge-reranker-v2-m3-GGUF",
+        hf_file="bge-reranker-v2-m3-Q4_K_M.gguf",
+        context_length=8192,
+        recommended_slot="embed",
+        tags=["rerank", "medium"],
+        notes=(
+            "v2-m3 covers 100+ languages and beats v1 base on most "
+            "benchmarks. Q4_K_M matches the running config on hal0; "
+            "remember to wire the slot to a non-8081 port and pass "
+            "--reranking (see memory hal0_rerank_slot_wiring)."
+        ),
+        capability="rerank",
+        backend="llamacpp",
+    ),
+    # ── STT / TTS picks ────────────────────────────────────────────────────
+    # Intentionally empty — see the module docstring TODO. The blocker is
+    # the pull layer's single-file shape vs. moonshine/kokoro's multi-file
+    # ONNX/PyTorch bundles. The HaloaiModel seed rows
+    # (moonshine-small-streaming-en, tts-1, kokoro, vibevoice-realtime-0.5b)
+    # remain visible through the /api/models/catalogue surface but are
+    # filtered out of the capability dropdowns by design.
     # ── Image-gen models (recommended_slot="img", routed through ComfyUI) ────
     #
     # Curated picks intentionally span the licensing spectrum:

--- a/tests/api/test_auth_routes.py
+++ b/tests/api/test_auth_routes.py
@@ -320,9 +320,19 @@ def test_set_password_after_first_returns_existing_behaviour(auth_app: TestClien
     The pre-FINDINGS contract was: first-run claim is auth-free, every
     subsequent call requires writer scope. The new §28 lockfile only
     gates the first-run path; the rotation path is unchanged.
+
+    The first-run leg also mints a hal0_session cookie
+    (#fix-firstrun-auth) so the wizard's subsequent writer calls don't
+    401. We explicitly clear that cookie here so the assertion below
+    exercises the genuine "no credentials" branch instead of bouncing
+    off the CSRF tripwire.
     """
     # First-run claim via loopback bypass.
     auth_app.post("/api/auth/password", json={"password": "correcthorse"})
+
+    # Drop the session cookie minted by the first-run leg so the second
+    # call below is truly anonymous.
+    auth_app.cookies.clear()
 
     # Second call without any credential — even from loopback — must
     # still require the writer-scope token. This is the §28 mitigation

--- a/tests/api/test_auth_writer_scope.py
+++ b/tests/api/test_auth_writer_scope.py
@@ -42,8 +42,20 @@ def auth_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestCl
     monkeypatch.delenv("HAL0_AUTH_DISABLED", raising=False)
     monkeypatch.setenv("HAL0_AUTH_ENABLED", "1")
     monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    monkeypatch.setenv("HAL0_OVERRIDE_DIR", "hal0_home")
     app = create_app()
     with TestClient(app) as c:
+        # Lifespan mints ``.first-run.lock`` when no password is set,
+        # which intentionally opens a small claim path-set (the wizard
+        # writer calls — #fix-firstrun-auth). The scope x verb matrix
+        # here pins the POST-CLAIM contract (lockfile already consumed
+        # by the wizard), so we delete the lockfile after lifespan to
+        # exercise the closed-claim writer gate.
+        from hal0.config import paths as _paths
+
+        lock = _paths.first_run_lock()
+        if lock.exists():
+            lock.unlink()
         c.app.state.token_store = TokenStore(tmp_path / "tokens.toml")
         yield c
 
@@ -57,8 +69,17 @@ def auth_app_trusted_proxy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> I
     monkeypatch.setenv("HAL0_AUTH_ENABLED", "1")
     monkeypatch.setenv("HAL0_TRUST_FORWARDED_EMAIL", "1")
     monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    monkeypatch.setenv("HAL0_OVERRIDE_DIR", "hal0_home")
     app = create_app()
     with TestClient(app) as c:
+        # See auth_app: drop the lifespan-minted first-run lockfile so
+        # the writer gate fires normally (the matrix tests are not
+        # interested in the claim window).
+        from hal0.config import paths as _paths
+
+        lock = _paths.first_run_lock()
+        if lock.exists():
+            lock.unlink()
         c.app.state.token_store = TokenStore(tmp_path / "tokens.toml")
         yield c
 

--- a/tests/api/test_firstrun_auth_cookie.py
+++ b/tests/api/test_firstrun_auth_cookie.py
@@ -1,0 +1,419 @@
+"""Tests for the first-run wizard auth fix + "skip chat model" path.
+
+Pins the behavioural contract introduced by commit 913d0ac
+``fix(firstrun): unblock wizard writer calls + allow skipping chat model``:
+
+  1. POST /api/auth/password on the first-run leg sets a hal0_session
+     cookie so subsequent writer mutations from the wizard ride a normal
+     session — without this the wizard 401s on every PUT/POST after the
+     password step.
+  2. The same endpoint on the rotation leg deliberately does NOT
+     re-issue the cookie; the caller already had a session/Bearer to
+     pass require_writer.
+  3. The first-run claim window now reaches a few writer-gated routes
+     the wizard fires before the password step (or while the operator
+     chose "Skip — leave open"): PUT /api/config/models, the per-id
+     pull endpoint, and the per-(slot, child) capability registration.
+  4. The same claim window closes when POST /api/install/complete
+     runs — the lockfile is consumed and follow-up anonymous writes
+     bounce off the writer gate.
+  5. The curated picker filters image models out so an operator can't
+     pick Flux as their chat model.
+  6. The path-matcher helper itself is unit-tested so the regex layer
+     can't regress without a red bar.
+
+The fixtures here mirror tests/api/test_password_auth.py — fresh app per
+test, HAL0_AUTH_ENABLED=1, HAL0_HOME under tmp_path, loopback client-IP
+pin so the OTP gate's loopback bypass exercises during set-password.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.api.auth import first_run as first_run_lock
+from hal0.api.auth.password import verify_session_token
+from hal0.api.middleware.auth import SESSION_COOKIE_NAME
+from hal0.auth.tokens import TokenStore
+
+
+def _install_loopback_client_middleware(app: object) -> None:
+    """Pin ``request.client.host`` to ``127.0.0.1`` for the test app.
+
+    Lifted verbatim from tests/api/test_password_auth.py — Starlette's
+    TestClient hard-codes ``scope['client']`` to ``('testclient',
+    50000)``, but the first-run OTP gate distinguishes loopback from
+    LAN peers. We want set-password's loopback bypass to fire so the
+    test doesn't have to wire the OTP through every call.
+    """
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.requests import Request as StarletteRequest
+
+    class _PinClientMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request: StarletteRequest, call_next):  # type: ignore[override]
+            override = request.headers.get("x-test-client-ip")
+            host = override or "127.0.0.1"
+            request.scope["client"] = (host, 12345)
+            return await call_next(request)
+
+    app.add_middleware(_PinClientMiddleware)  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def auth_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """Fresh app with auth enabled, isolated store + keyring, lockfile kept.
+
+    The lifespan auto-mints ``.first-run.lock`` when no password is set,
+    so by default the first-run claim window is OPEN here. Tests that
+    want the post-claim posture (lockfile consumed) explicitly delete
+    the file themselves.
+    """
+    monkeypatch.delenv("HAL0_AUTH_DISABLED", raising=False)
+    monkeypatch.setenv("HAL0_AUTH_ENABLED", "1")
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    monkeypatch.setenv("HAL0_OVERRIDE_DIR", "hal0_home")
+    app = create_app()
+    _install_loopback_client_middleware(app)
+    with TestClient(app) as c:
+        # Pin the store onto a tmp-rooted path so the password hash
+        # lands under tmp_path/etc/hal0/tokens.toml. Mirrors the
+        # test_password_auth fixture pattern.
+        store = TokenStore(tmp_path / "etc" / "hal0" / "tokens.toml")
+        c.app.state.token_store = store
+        # Reset the rate-limit bucket so a noisy fixture doesn't tip a
+        # later set-password into 429.
+        limiter = getattr(c.app.state, "auth_rate_limiter", None)
+        if limiter is not None:
+            limiter.reset()
+        yield c
+
+
+def _admin_bearer(client: TestClient, label: str = "test-admin") -> dict[str, str]:
+    store: TokenStore = client.app.state.token_store
+    _, raw = store.create(label=label, scope="admin")
+    return {"Authorization": f"Bearer {raw}"}
+
+
+# ── (1) Set-password issues Set-Cookie on the first-run leg ─────────────────
+
+
+def test_first_run_set_password_issues_session_cookie(auth_app: TestClient) -> None:
+    """A fresh-install set-password call returns a HttpOnly hal0_session cookie.
+
+    Without this, the wizard's subsequent PUT /api/config/models / pull
+    / capability calls would 401 because no credential exists yet. The
+    fix mints a session JWT and pins it onto the response so the rest of
+    the wizard rides a normal cookie session.
+    """
+    # Sanity: lockfile was minted by the lifespan and password isn't set.
+    assert first_run_lock.lockfile_path().exists()
+
+    response = auth_app.post("/api/auth/password", json={"password": "correcthorse"})
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["password_set"] is True
+    assert body["rotated"] is False
+
+    # Set-Cookie header must carry the session cookie with HttpOnly +
+    # Path=/. SameSite=lax is part of the cookie contract too — we
+    # don't assert Secure because the TestClient is not HTTPS.
+    set_cookie = response.headers.get("set-cookie", "")
+    assert f"{SESSION_COOKIE_NAME}=" in set_cookie, set_cookie
+    assert "HttpOnly" in set_cookie, set_cookie
+    assert "Path=/" in set_cookie, set_cookie
+
+    # The cookie value must verify as a real session token with the
+    # owner identity + admin scope. The middleware reads sub + scope to
+    # populate AuthIdentity on subsequent requests.
+    cookie_value = auth_app.cookies.get(SESSION_COOKIE_NAME)
+    assert cookie_value, "cookie not stashed in client jar"
+    claims = verify_session_token(cookie_value)
+    assert claims is not None, "session cookie failed to verify"
+    assert claims["sub"] == "owner"
+    assert claims["scope"] == "admin"
+
+
+# ── (2) Rotation does NOT re-issue the cookie ───────────────────────────────
+
+
+def test_set_password_rotation_does_not_reissue_cookie(auth_app: TestClient) -> None:
+    """Rotation under an existing session keeps the existing cookie.
+
+    The rotation leg already has a credential (Bearer or session); the
+    fix only mints on the first-run path. Re-issuing on rotation would
+    be a quiet TTL refresh side-effect — not desired here.
+    """
+    # First-run claim — primes the password + sets the initial cookie.
+    first = auth_app.post("/api/auth/password", json={"password": "correcthorse"})
+    assert first.status_code == 200, first.text
+    initial_cookie = auth_app.cookies.get(SESSION_COOKIE_NAME)
+    assert initial_cookie, "first-run leg should have set the cookie"
+
+    # Rotate via the existing session. The cookie path goes through the
+    # CSRF tripwire, so add X-Requested-With.
+    rotate = auth_app.post(
+        "/api/auth/password",
+        json={"password": "newbatterystaple"},
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
+    assert rotate.status_code == 200, rotate.text
+    body = rotate.json()
+    assert body["rotated"] is True
+
+    # The response must NOT carry a fresh Set-Cookie for hal0_session
+    # — rotation is the "you already had auth, prove it; we don't touch
+    # the session" path. The TestClient cookie jar still holds the
+    # original cookie (httpx doesn't pop on absence).
+    set_cookie = rotate.headers.get("set-cookie", "") or ""
+    assert f"{SESSION_COOKIE_NAME}=" not in set_cookie, (
+        f"rotation must not re-issue the session cookie; got: {set_cookie!r}"
+    )
+
+
+# ── (3) First-run claim covers PUT /api/config/models ───────────────────────
+
+
+def test_first_run_claim_admits_put_config_models(auth_app: TestClient) -> None:
+    """Anonymous PUT /api/config/models lands during the claim window.
+
+    The wizard fires this after the operator picks storage directories.
+    Before the fix added the path to the claim set it bounced with 401
+    auth.required, blocking step 2 entirely.
+    """
+    # Sanity: claim window is open (lockfile present + no password).
+    assert first_run_lock.lockfile_path().exists()
+    response = auth_app.put(
+        "/api/config/models",
+        json={"roots": [], "auto_scan_on_start": False},
+    )
+    # Either the route's business logic accepts the body (200) or it
+    # rejects on a downstream concern — what we must NEVER see is the
+    # 401 auth.required that would mean the claim path-set missed.
+    assert response.status_code != 401, (
+        f"PUT /api/config/models must be reachable during the first-run "
+        f"claim window; got {response.status_code}: {response.text}"
+    )
+    # In practice the route returns 200 on the minimal body — pin that
+    # so a future regression that flips the auth into a different 4xx
+    # gets caught.
+    assert response.status_code == 200, response.text
+
+
+# ── (4) First-run claim covers regex routes ─────────────────────────────────
+
+
+def test_first_run_claim_admits_models_pull(auth_app: TestClient) -> None:
+    """Anonymous POST /api/models/{id}/pull lands during the claim window.
+
+    The handler may reject downstream (unknown model id, missing
+    HF_TOKEN, etc.) — we only assert the request makes it past the
+    auth gate.
+    """
+    assert first_run_lock.lockfile_path().exists()
+    response = auth_app.post("/api/models/this-id-is-not-curated/pull")
+    assert response.status_code != 401, (
+        f"POST /api/models/{{id}}/pull must be reachable during the "
+        f"first-run claim window; got {response.status_code}: {response.text}"
+    )
+
+
+def test_first_run_claim_admits_capability_registration(auth_app: TestClient) -> None:
+    """Anonymous POST /api/capabilities/{slot}/{child} lands during the claim."""
+    assert first_run_lock.lockfile_path().exists()
+    # Use a known-legal slot/child so the orchestrator doesn't 400 on
+    # the slot lookup; the auth layer is what we're pinning anyway.
+    response = auth_app.post(
+        "/api/capabilities/embed/embed",
+        json={"enabled": False},
+    )
+    assert response.status_code != 401, (
+        f"POST /api/capabilities/{{slot}}/{{child}} must be reachable "
+        f"during the first-run claim window; got {response.status_code}: "
+        f"{response.text}"
+    )
+
+
+def test_first_run_claim_rejects_extra_path_segment(auth_app: TestClient) -> None:
+    """An extra trailing segment must NOT slip past the regex.
+
+    ``re.fullmatch`` anchors at both ends, so /api/models/foo/pull/extra
+    is not a claim-eligible path even though the leading segment
+    matches. We assert at the helper level rather than the HTTP layer
+    because FastAPI's router resolves paths before auth deps fire, so a
+    non-existent path 404/405s before reaching ``_first_run_claim_active``
+    — exactly what we want defensively, but it makes the HTTP-level
+    assertion brittle. The unit-level path matrix below covers the
+    fullmatch contract directly.
+    """
+    from hal0.api.middleware.auth import _path_is_claim_eligible
+
+    assert _path_is_claim_eligible("/api/models/foo/pull/extra") is False
+    assert _path_is_claim_eligible("/api/capabilities/embed/embed/extra") is False
+    # And the matching base paths still ARE eligible — proof the regex
+    # is doing the work, not a blanket "no extras" rule that would also
+    # break legitimate routes.
+    assert _path_is_claim_eligible("/api/models/foo/pull") is True
+    assert _path_is_claim_eligible("/api/capabilities/embed/embed") is True
+
+
+# ── (5) /api/install/complete consumes the lockfile ─────────────────────────
+
+
+def test_install_complete_consumes_lockfile_and_closes_claim(
+    auth_app: TestClient,
+) -> None:
+    """POST /api/install/complete unlinks the lockfile and closes the window.
+
+    Before the fix the wizard's "Skip — leave open" branch never
+    reached POST /api/auth/password, so the lockfile (and its
+    anonymous claim window) survived the wizard's completion. The new
+    consume call in /api/install/complete closes the window
+    unconditionally — the moment the wizard signals "done", the claim
+    paths revert to writer-gated.
+    """
+    # Sanity: lockfile present + claim window open. Demonstrate the
+    # anonymous-write path works BEFORE we call /complete.
+    lock = first_run_lock.lockfile_path()
+    assert lock.exists()
+    pre_response = auth_app.put(
+        "/api/config/models",
+        json={"roots": [], "auto_scan_on_start": False},
+    )
+    assert pre_response.status_code == 200, pre_response.text
+
+    # POST /api/install/complete is itself a writer route that the
+    # claim window admits anonymously — same gate, same path-set.
+    complete = auth_app.post("/api/install/complete")
+    assert complete.status_code == 200, complete.text
+
+    # Lockfile must be gone — the install-complete handler calls
+    # ``first_run_lock.consume_lockfile()`` after writing the sentinel.
+    assert not lock.exists(), (
+        f"install/complete must consume the first-run lockfile; "
+        f"still present at {lock}"
+    )
+
+    # Follow-up anonymous PUT now bounces with 401 auth.required —
+    # the claim window is closed, the writer dep is enforced.
+    post_response = auth_app.put(
+        "/api/config/models",
+        json={"roots": [], "auto_scan_on_start": False},
+    )
+    assert post_response.status_code == 401, (
+        f"after /api/install/complete the writer gate must re-enforce; "
+        f"got {post_response.status_code}: {post_response.text}"
+    )
+    assert post_response.json()["error"]["code"] == "auth.required"
+
+
+# ── (6) Curated picker filters image models ─────────────────────────────────
+
+
+def test_curated_models_filters_out_image_slot(auth_app: TestClient) -> None:
+    """GET /api/install/curated-models surfaces only chat picks.
+
+    Pre-fix the curated catalogue included image-gen rows
+    (``recommended_slot="img"``), which let an operator install Flux
+    as their "chat model" — meaningless. The fix filters the response
+    to ``recommended_slot == "primary"`` so the wizard's chat step
+    only shows valid chat candidates.
+
+    We also assert directly against the source catalogue to prove the
+    filter is real (i.e. there ARE img entries upstream — without
+    that, the filter could silently be a no-op).
+    """
+    from hal0.registry.curated import CURATED_MODELS
+
+    # Source catalogue MUST contain at least one img entry — otherwise
+    # the filter doesn't actually filter anything and the test is
+    # vacuous.
+    assert any(m.recommended_slot == "img" for m in CURATED_MODELS), (
+        "catalogue invariant: at least one image-gen entry must exist "
+        "to make the filter meaningful"
+    )
+
+    response = auth_app.get("/api/install/curated-models")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    img_picks = [m for m in body["models"] if m.get("recommended_slot") == "img"]
+    assert img_picks == [], (
+        f"chat-picker must filter out img-slot models; got: "
+        f"{[m['id'] for m in img_picks]}"
+    )
+    # And every surfaced row must positively be a chat pick.
+    for m in body["models"]:
+        assert m.get("recommended_slot") == "primary", (
+            f"curated-models must only surface primary-slot picks; "
+            f"got {m.get('id')!r} with slot {m.get('recommended_slot')!r}"
+        )
+
+
+# ── (7) _path_is_claim_eligible — pure-function path matrix ─────────────────
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        # Fixed paths (exact set membership)
+        ("/api/install/state", True),
+        ("/api/install/probe", True),
+        ("/api/install/complete", True),
+        ("/api/install/curated-models", True),
+        ("/api/install/pick-default", True),
+        ("/api/auth/password", True),
+        ("/api/config/models", True),
+        # Regex matches — /api/models/{id}/pull
+        ("/api/models/qwen3-4b/pull", True),
+        ("/api/models/some-weird_id.v2/pull", True),
+        # Regex matches — /api/capabilities/{slot}/{child}
+        ("/api/capabilities/embed/embed", True),
+        ("/api/capabilities/voice/stt", True),
+        ("/api/capabilities/img/img", True),
+        # Near-misses: extra trailing segments must NOT match (fullmatch
+        # contract). These are the regression cases for §28 / §29.
+        ("/api/models/foo/pull/extra", False),
+        ("/api/capabilities/embed/embed/extra", False),
+        # Near-misses: missing required segments.
+        ("/api/models/pull", False),
+        ("/api/models//pull", False),
+        ("/api/capabilities/embed", False),
+        ("/api/capabilities//child", False),
+        ("/api/capabilities/embed/", False),
+        # Totally unrelated paths — the helper must reject everything
+        # outside the claim surface so the wizard's path-set can't
+        # accidentally leak into the rest of the admin API.
+        ("/api/slots", False),
+        ("/api/slots/primary", False),
+        ("/api/auth/login", False),
+        ("/api/auth/logout", False),
+        ("/api/hardware", False),
+        ("/api/models", False),
+        ("/api/models/foo", False),
+        ("/", False),
+        ("", False),
+        # Case sensitivity — paths are case-sensitive in the helper.
+        ("/API/install/state", False),
+    ],
+)
+def test_path_is_claim_eligible(path: str, expected: bool) -> None:
+    """Walk the full path matrix for the claim-eligible helper.
+
+    Anchors:
+      - Fixed-path hits via :data:`_FIRST_RUN_CLAIM_PATHS` (set
+        membership).
+      - Regex hits via :data:`_FIRST_RUN_CLAIM_PATTERNS` using
+        ``re.fullmatch`` — extra trailing segments must NOT match.
+      - Unrelated paths fall through to False so the admin surface
+        stays gated.
+    """
+    from hal0.api.middleware.auth import _path_is_claim_eligible
+
+    assert _path_is_claim_eligible(path) is expected, (
+        f"claim-eligibility mismatch for path={path!r}: "
+        f"got {not expected}, expected {expected}"
+    )

--- a/tests/api/test_firstrun_auth_cookie.py
+++ b/tests/api/test_firstrun_auth_cookie.py
@@ -294,8 +294,7 @@ def test_install_complete_consumes_lockfile_and_closes_claim(
     # Lockfile must be gone — the install-complete handler calls
     # ``first_run_lock.consume_lockfile()`` after writing the sentinel.
     assert not lock.exists(), (
-        f"install/complete must consume the first-run lockfile; "
-        f"still present at {lock}"
+        f"install/complete must consume the first-run lockfile; still present at {lock}"
     )
 
     # Follow-up anonymous PUT now bounces with 401 auth.required —
@@ -333,8 +332,7 @@ def test_curated_models_filters_out_image_slot(auth_app: TestClient) -> None:
     # the filter doesn't actually filter anything and the test is
     # vacuous.
     assert any(m.recommended_slot == "img" for m in CURATED_MODELS), (
-        "catalogue invariant: at least one image-gen entry must exist "
-        "to make the filter meaningful"
+        "catalogue invariant: at least one image-gen entry must exist to make the filter meaningful"
     )
 
     response = auth_app.get("/api/install/curated-models")
@@ -342,8 +340,7 @@ def test_curated_models_filters_out_image_slot(auth_app: TestClient) -> None:
     body = response.json()
     img_picks = [m for m in body["models"] if m.get("recommended_slot") == "img"]
     assert img_picks == [], (
-        f"chat-picker must filter out img-slot models; got: "
-        f"{[m['id'] for m in img_picks]}"
+        f"chat-picker must filter out img-slot models; got: {[m['id'] for m in img_picks]}"
     )
     # And every surfaced row must positively be a chat pick.
     for m in body["models"]:
@@ -414,6 +411,5 @@ def test_path_is_claim_eligible(path: str, expected: bool) -> None:
     from hal0.api.middleware.auth import _path_is_claim_eligible
 
     assert _path_is_claim_eligible(path) is expected, (
-        f"claim-eligibility mismatch for path={path!r}: "
-        f"got {not expected}, expected {expected}"
+        f"claim-eligibility mismatch for path={path!r}: got {not expected}, expected {expected}"
     )

--- a/tests/api/test_hardware_routes.py
+++ b/tests/api/test_hardware_routes.py
@@ -1,0 +1,93 @@
+"""Unit tests for hal0.api.routes.hardware — flatten + platform pass-through.
+
+The flatten shape is consumed by the Vue Hardware + FirstRun views; we
+freeze its contract here so a future refactor of HardwareInfo doesn't
+silently regress the dashboard.
+"""
+
+from __future__ import annotations
+
+from hal0.api.routes.hardware import _flatten_for_ui, _platform_label
+from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
+
+
+def test_flatten_pass_through_kvm_with_virtio_gpu() -> None:
+    info = HardwareInfo(
+        cpu_model="QEMU Virtual CPU version 2.5+",
+        cpu_cores=4,
+        cpu_threads=4,
+        ram_mb=16384,
+        unified_memory_mb=16384,
+        gpus=[GPUInfo(vendor="unknown", name="Red Hat, Inc. Virtio 1.0 GPU")],
+        npu=NPUInfo(present=False),
+        platform="kvm",
+    ).model_dump(mode="python")
+    flat = _flatten_for_ui(info)
+    assert flat["cpu_name"] == "QEMU Virtual CPU version 2.5+"
+    assert flat["ram_total_mb"] == 16384
+    assert flat["gpu_name"].startswith("Red Hat")
+    assert flat["platform"] == "kvm"
+    assert flat["platform_label"] == "KVM virtual machine"
+    assert flat["memory_kind"] == "system"
+    assert flat["npu_present"] is False
+
+
+def test_flatten_strix_halo_is_unified() -> None:
+    info = HardwareInfo(
+        cpu_model="AMD Ryzen AI Max+ PRO 395",
+        cpu_cores=16,
+        cpu_threads=32,
+        ram_mb=128 * 1024,
+        unified_memory_mb=128 * 1024,
+        gpus=[GPUInfo(vendor="amd", name="Radeon 8060S", vram_mb=96 * 1024)],
+        npu=NPUInfo(present=True, vendor="amd", name="AMD NPU (XDNA)"),
+        platform="strix-halo",
+    ).model_dump(mode="python")
+    flat = _flatten_for_ui(info)
+    assert flat["platform"] == "strix-halo"
+    assert flat["platform_label"] == "Strix Halo (unified memory)"
+    assert flat["memory_kind"] == "unified"
+    assert flat["is_uma"] is True
+
+
+def test_flatten_bare_metal_nvidia_promotes_gpu_into_label() -> None:
+    info = HardwareInfo(
+        cpu_model="Intel i9-13900K",
+        cpu_cores=8,
+        cpu_threads=24,
+        ram_mb=64 * 1024,
+        unified_memory_mb=64 * 1024,
+        gpus=[GPUInfo(vendor="nvidia", name="NVIDIA GeForce RTX 4080", vram_mb=16 * 1024)],
+        npu=NPUInfo(present=False),
+        platform="bare-metal-nvidia-gpu",
+    ).model_dump(mode="python")
+    flat = _flatten_for_ui(info)
+    assert flat["memory_kind"] == "system"
+    assert flat["platform_label"] == "Bare metal — NVIDIA GeForce RTX 4080"
+    assert flat["vram_total_mb"] == 16 * 1024
+    assert flat["gtt_total_mb"] == 0
+
+
+def test_flatten_handles_legacy_payload_without_platform() -> None:
+    """A pre-platform /etc/hal0/hardware.json on disk should still flatten
+    cleanly — we don't want stale caches to crash the dashboard.
+    """
+    info = HardwareInfo(
+        cpu_model="Generic x86_64",
+        ram_mb=8192,
+        gpus=[],
+        npu=NPUInfo(present=False),
+    ).model_dump(mode="python")
+    # Simulate a HardwareInfo missing the platform key altogether
+    info.pop("platform", None)
+    flat = _flatten_for_ui(info)
+    assert flat["platform"] == "unknown"
+    assert flat["platform_label"] == "Unknown platform"
+    assert flat["memory_kind"] == "system"
+
+
+def test_platform_label_for_known_strings() -> None:
+    assert _platform_label("wsl2", {}) == "WSL 2"
+    assert _platform_label("proxmox-kvm", {}) == "Proxmox VM (KVM)"
+    assert _platform_label("lxc", {}) == "Linux container (LXC)"
+    assert _platform_label("nonsense-value", {}) == "Unknown platform"

--- a/tests/api/test_password_auth.py
+++ b/tests/api/test_password_auth.py
@@ -133,10 +133,22 @@ def test_first_run_set_password_no_auth_required(auth_app: TestClient) -> None:
 
 
 def test_second_set_password_without_auth_returns_401(auth_app: TestClient) -> None:
-    """Once a password is set, the endpoint requires writer scope."""
+    """Once a password is set, the endpoint requires writer scope.
+
+    The first-run leg auto-mints a hal0_session cookie (#fix-firstrun-auth)
+    so the wizard's subsequent writer calls ride a session. To exercise
+    the "second call with no creds" contract we clear that cookie first
+    — otherwise the second call rides the session and bounces on the
+    CSRF tripwire (403 ``auth.csrf_required``) instead of the no-creds
+    gate (401 ``auth.required``).
+    """
     # First run claims ownership.
     first = auth_app.post("/api/auth/password", json={"password": "correcthorse"})
     assert first.status_code == 200
+
+    # Drop the session cookie minted by the first-run leg so the
+    # follow-up call is genuinely "no credentials presented".
+    auth_app.cookies.clear()
 
     # Second call with no auth → 401 auth.required.
     second = auth_app.post("/api/auth/password", json={"password": "newbatterystaple"})
@@ -186,6 +198,11 @@ def test_login_happy_path_sets_session_cookie(auth_app: TestClient) -> None:
 
 def test_login_wrong_password_returns_401(auth_app: TestClient) -> None:
     auth_app.post("/api/auth/password", json={"password": "correcthorse"})
+    # First-run set-password mints a cookie (#fix-firstrun-auth). Clear
+    # it so the "no cookie after failed login" assertion below means
+    # "/login didn't issue one" rather than "the jar happens to still
+    # hold the set-password cookie".
+    auth_app.cookies.clear()
     response = auth_app.post(
         "/api/auth/login",
         json={"username": "owner", "password": "wrong"},

--- a/tests/hardware/test_probe.py
+++ b/tests/hardware/test_probe.py
@@ -443,3 +443,192 @@ def test_run_handles_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     rc, _, err = probe_mod._run(["sleep", "60"], timeout=1.0)
     assert rc == -1
     assert "timeout" in err
+
+
+# ── Platform detection ────────────────────────────────────────────────────────
+
+
+def _stub_files(monkeypatch: pytest.MonkeyPatch, table: dict[str, str | None]) -> None:
+    """Make ``probe._read_text(path)`` return canned content for ``table`` keys."""
+
+    def fake(p: Path) -> str | None:
+        return table.get(str(p))
+
+    monkeypatch.setattr(probe_mod, "_read_text", fake)
+
+
+def test_detect_platform_wsl_via_proc_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_files(
+        monkeypatch,
+        {
+            "/proc/version": "Linux version 5.15.146.1-microsoft-standard-WSL2",
+            "/proc/sys/kernel/osrelease": "5.15.146.1-microsoft-standard-WSL2",
+            "/proc/1/cgroup": "0::/init.scope",
+        },
+    )
+    gpu = GPUInfo(vendor="unknown")
+    npu = probe_mod.NPUInfo(present=False)
+    assert probe_mod._detect_platform(gpu, npu) == "wsl2"
+
+
+def test_detect_platform_lxc(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_files(
+        monkeypatch,
+        {
+            "/proc/version": "Linux version 6.6.0",
+            "/proc/1/cgroup": "0::/lxc.payload.105",
+            "/proc/self/cgroup": "0::/lxc.payload.105",
+            "/proc/1/environ": "",
+        },
+    )
+    gpu = GPUInfo(vendor="amd", name="Radeon")
+    npu = probe_mod.NPUInfo(present=True, vendor="amd")
+    # LXC short-circuits before strix-halo classification — but downstream
+    # consumers can still see the NPU + AMD GPU on the HardwareInfo body.
+    assert probe_mod._detect_platform(gpu, npu) == "lxc"
+
+
+def test_detect_platform_kvm_via_dmi(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Stub DMI sysfs by routing _read_text on the DMI paths through a dict.
+    files = {
+        "/proc/version": "Linux version 6.6.0",
+        "/proc/1/cgroup": "0::/init.scope",
+        str(probe_mod._DMI_PATHS["product_name"]): "Standard PC (Q35 + ICH9, 2009)",
+        str(probe_mod._DMI_PATHS["sys_vendor"]): "QEMU",
+        str(probe_mod._DMI_PATHS["bios_vendor"]): "SeaBIOS",
+        str(probe_mod._DMI_PATHS["board_vendor"]): "",
+        "/proc/cmdline": "root=UUID=... ro quiet",  # no virtio hint
+    }
+    _stub_files(monkeypatch, files)
+    monkeypatch.setattr(probe_mod, "_is_wsl", lambda: False)
+    monkeypatch.setattr(probe_mod, "_is_lxc", lambda: False)
+    gpu = GPUInfo(vendor="unknown")
+    npu = probe_mod.NPUInfo(present=False)
+    assert probe_mod._detect_platform(gpu, npu) == "kvm"
+
+
+def test_detect_platform_proxmox_kvm_heuristic(monkeypatch: pytest.MonkeyPatch) -> None:
+    files = {
+        "/proc/version": "Linux version 6.6.0",
+        "/proc/1/cgroup": "0::/init.scope",
+        str(probe_mod._DMI_PATHS["product_name"]): "Standard PC (Q35 + ICH9, 2009)",
+        str(probe_mod._DMI_PATHS["sys_vendor"]): "QEMU",
+        str(probe_mod._DMI_PATHS["bios_vendor"]): "SeaBIOS",
+        str(probe_mod._DMI_PATHS["board_vendor"]): "",
+        "/proc/cmdline": "root=UUID=... ro quiet virtio_blk",
+    }
+    _stub_files(monkeypatch, files)
+    monkeypatch.setattr(probe_mod, "_is_wsl", lambda: False)
+    monkeypatch.setattr(probe_mod, "_is_lxc", lambda: False)
+    gpu = GPUInfo(vendor="unknown")
+    npu = probe_mod.NPUInfo(present=False)
+    assert probe_mod._detect_platform(gpu, npu) == "proxmox-kvm"
+
+
+def test_detect_platform_bare_metal_nvidia(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(probe_mod, "_is_wsl", lambda: False)
+    monkeypatch.setattr(probe_mod, "_is_lxc", lambda: False)
+    monkeypatch.setattr(probe_mod, "_read_dmi", lambda: {})  # bare metal: real OEM
+    gpu = GPUInfo(vendor="nvidia", name="GeForce RTX 4080")
+    npu = probe_mod.NPUInfo(present=False)
+    assert probe_mod._detect_platform(gpu, npu) == "bare-metal-nvidia-gpu"
+
+
+def test_detect_platform_strix_halo(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(probe_mod, "_is_wsl", lambda: False)
+    monkeypatch.setattr(probe_mod, "_is_lxc", lambda: False)
+    monkeypatch.setattr(probe_mod, "_read_dmi", lambda: {})
+    gpu = GPUInfo(vendor="amd", name="Radeon 8060S")
+    npu = probe_mod.NPUInfo(present=True, vendor="amd", name="AMD NPU (XDNA)")
+    assert probe_mod._detect_platform(gpu, npu) == "strix-halo"
+
+
+def test_detect_platform_cpu_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(probe_mod, "_is_wsl", lambda: False)
+    monkeypatch.setattr(probe_mod, "_is_lxc", lambda: False)
+    monkeypatch.setattr(probe_mod, "_read_dmi", lambda: {})
+    gpu = GPUInfo(vendor="unknown")
+    npu = probe_mod.NPUInfo(present=False)
+    assert probe_mod._detect_platform(gpu, npu) == "bare-metal-cpu-only"
+
+
+# ── End-to-end: probe() populates platform + survives a WSL-shaped host ───────
+
+
+def test_probe_populates_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(probe_mod, "_parse_cpuinfo", lambda: ("Intel WSL CPU", 4, 8))
+    monkeypatch.setattr(probe_mod, "_parse_meminfo", lambda: (16384, 12000))
+    monkeypatch.setattr(probe_mod, "_detect_gpu", lambda: GPUInfo(vendor="unknown"))
+    monkeypatch.setattr(probe_mod, "_detect_npu", lambda: probe_mod.NPUInfo(present=False))
+    monkeypatch.setattr(probe_mod, "_disk_free_mb", lambda _: 512000)
+    monkeypatch.setattr(probe_mod, "_read_text", lambda _: None)
+    monkeypatch.setattr(probe_mod, "_detect_platform", lambda *_: "wsl2")
+
+    info = HardwareProbe().probe()
+    # The whole point: CPU + RAM populate even when no GPU vendor matched.
+    assert info.cpu_model == "Intel WSL CPU"
+    assert info.ram_mb == 16384
+    assert info.platform == "wsl2"
+
+
+def test_probe_includes_named_gpu_even_when_vendor_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """lspci returns a model string but vendor matched none of nvidia/amd/intel
+    (e.g. a virtio GPU in a Proxmox VM). The probe should still surface the
+    name so the dashboard shows "Red Hat, Inc. Virtio GPU" instead of "—".
+    """
+    monkeypatch.setattr(probe_mod, "_parse_cpuinfo", lambda: ("x86 CPU", 4, 8))
+    monkeypatch.setattr(probe_mod, "_parse_meminfo", lambda: (4096, 2048))
+    monkeypatch.setattr(
+        probe_mod,
+        "_detect_gpu",
+        lambda: GPUInfo(vendor="unknown", name="Red Hat, Inc. Virtio 1.0 GPU"),
+    )
+    monkeypatch.setattr(probe_mod, "_detect_npu", lambda: probe_mod.NPUInfo(present=False))
+    monkeypatch.setattr(probe_mod, "_disk_free_mb", lambda _: 1024)
+    monkeypatch.setattr(probe_mod, "_read_text", lambda _: None)
+    monkeypatch.setattr(probe_mod, "_detect_platform", lambda *_: "kvm")
+
+    info = HardwareProbe().probe()
+    assert len(info.gpus) == 1
+    assert info.gpus[0].name.startswith("Red Hat")
+
+
+def test_parse_cpuinfo_arm_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ARM /proc/cpuinfo has Hardware/Model fields instead of 'model name'."""
+    arm_sample = (
+        "processor\t: 0\n"
+        "BogoMIPS\t: 108.00\n"
+        "Hardware\t: BCM2835\n"
+        "Model\t: Raspberry Pi 4 Model B Rev 1.5\n"
+    )
+    monkeypatch.setattr(
+        probe_mod, "_read_text", lambda p: arm_sample if str(p) == "/proc/cpuinfo" else None
+    )
+    model, _cores, _threads = probe_mod._parse_cpuinfo()
+    assert "Raspberry Pi" in model or "BCM2835" in model
+
+
+def test_detect_lspci_fallback_handles_display_controller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``lspci -nnk`` failed (rc!=0) but bare ``lspci`` returned a Display
+    controller line — e.g. a WSL2 vGPU. We should still surface a name.
+    """
+    calls = {"n": 0}
+
+    def fake_run(cmd: list[str], timeout: float = 4.0) -> tuple[int, str, str]:
+        calls["n"] += 1
+        if cmd == ["lspci", "-nnk"]:
+            return -1, "", "binary not found: lspci"
+        if cmd == ["lspci"]:
+            return 0, "0000:00:00.0 Display controller: Microsoft Corporation Virtual GPU", ""
+        return -1, "", "not mocked"
+
+    monkeypatch.setattr(probe_mod, "_run", fake_run)
+    info = probe_mod._detect_lspci_fallback()
+    assert info is not None
+    assert "Microsoft" in info.name

--- a/tests/hardware/test_probe.py
+++ b/tests/hardware/test_probe.py
@@ -488,9 +488,7 @@ def test_detect_platform_lxc(monkeypatch: pytest.MonkeyPatch) -> None:
     assert probe_mod._detect_platform(gpu, npu) == "lxc"
 
 
-def test_detect_platform_kvm_via_dmi(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_detect_platform_kvm_via_dmi(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     # Stub DMI sysfs by routing _read_text on the DMI paths through a dict.
     files = {
         "/proc/version": "Linux version 6.6.0",

--- a/ui/src/components/firstrun/useFirstRun.js
+++ b/ui/src/components/firstrun/useFirstRun.js
@@ -523,6 +523,14 @@ export function useFirstRun() {
     pull.done = false
     pull.error = null
     _initPullItems()
+    if (pull.items.length === 0) {
+      // Nothing-to-do install (operator skipped chat + every capability).
+      // _checkAllDone short-circuits to terminal=true on an empty array,
+      // so the wizard flips to step 8 immediately rather than dangling
+      // on a blank progress screen.
+      _checkAllDone()
+      return
+    }
     await Promise.all(pull.items.map((it) => _startOne(it)))
   }
 

--- a/ui/src/components/footer/FooterBar.vue
+++ b/ui/src/components/footer/FooterBar.vue
@@ -35,8 +35,11 @@ const hostname = computed(() => system.status?.hostname || '')
 const hw = computed(() => stats.value || {})
 
 const isUnified = computed(() => {
-  // memory_kind from probe; fall back to is_uma
-  const kind = system.hardware?.memory_kind || (system.hardware?.is_uma ? 'unified' : 'discrete')
+  // memory_kind from the API flatten (preferred; strix-halo and any
+  // explicit UMA host). Fall back to the older is_uma signal so a stale
+  // /etc/hal0/hardware.json doesn't regress to the wrong stat row.
+  const kind = system.hardware?.memory_kind
+    || (system.hardware?.is_uma ? 'unified' : 'system')
   return kind === 'unified'
 })
 

--- a/ui/src/views/FirstRun.vue
+++ b/ui/src/views/FirstRun.vue
@@ -119,10 +119,12 @@ async function goNext() {
     return
   }
   if (step.value === 3) {
-    if (!s.primaryModel.value) {
-      toasts.warning('Please select a chat model first')
-      return
-    }
+    // No-primary is a valid install — a capabilities-only box (embed +
+    // voice + img) is a legitimate shape, and operators who plan to
+    // route chat to a remote provider via Settings → Providers don't
+    // need a local chat model at all. The wizard's enabledList already
+    // omits the primary row when null, so step 7 just kicks the
+    // capability pulls.
     step.value = 4
     return
   }
@@ -137,12 +139,12 @@ async function goNext() {
     return
   }
   if (step.value === 6) {
-    if (!s.form.licenseAccepted) {
-      toasts.warning('Please accept the licenses first')
-      return
-    }
     if (!s.fits.value) {
       toasts.warning('Not enough disk space — free up storage or remove capabilities')
+      return
+    }
+    if (s.enabledList.value.length > 0 && !s.form.licenseAccepted) {
+      toasts.warning('Please accept the licenses first')
       return
     }
     step.value = 7
@@ -162,6 +164,11 @@ function skipPassword() {
   s.form.firstRunToken = ''
   tokenError.value = ''
   step.value = 2
+}
+
+function skipPrimary() {
+  s.form.primaryId = null
+  step.value = 4
 }
 
 // Step 7 → 8 happens implicitly when every pull is terminal. The
@@ -223,10 +230,14 @@ const licenseList = computed(() => s.enabledList.value)
 const canAdvance = computed(() => {
   if (step.value === 1) return s.form.password.length === 0 || s.form.password.length >= 8
   if (step.value === 2) return s.form.modelDirs.some((d) => String(d).trim().length > 0)
-  if (step.value === 3) return !!s.primaryModel.value
+  if (step.value === 3) return true  // primary is optional — operators can run capabilities-only
   if (step.value === 4) return true
   if (step.value === 5) return true  // skip is allowed; empty token is permitted
-  if (step.value === 6) return s.form.licenseAccepted && s.fits.value
+  if (step.value === 6) {
+    // Nothing selected ⇒ nothing to accept; let the operator pass straight through.
+    if (s.enabledList.value.length === 0) return s.fits.value
+    return s.form.licenseAccepted && s.fits.value
+  }
   return false
 })
 </script>
@@ -370,7 +381,10 @@ const canAdvance = computed(() => {
 
         <!-- ── 3. Primary chat ───────────────────────────────────── -->
         <div v-else-if="!s.loading.value && step === 3" key="s3" class="wizard-body">
-          <p class="step-desc">Pick the model that powers chat. You can add more from the Models page later.</p>
+          <p class="step-desc">
+            Pick the model that powers chat. You can add more from the Models page later, or
+            <strong>skip</strong> if you plan to route chat to a remote provider (Settings → Providers).
+          </p>
 
           <div v-if="!s.curated.value.length" class="error-state">
             Curated catalogue is empty — the API may be unavailable.
@@ -411,8 +425,9 @@ const canAdvance = computed(() => {
             </label>
           </div>
 
-          <div class="wizard-footer wizard-footer-2">
+          <div class="wizard-footer wizard-footer-3">
             <button class="btn-ghost" type="button" @click="goBack">← Back</button>
+            <button class="btn-ghost" type="button" @click="skipPrimary">Skip — no chat model</button>
             <button class="btn-primary" type="button" :disabled="!canAdvance" @click="goNext">Next: capabilities →</button>
           </div>
         </div>
@@ -578,50 +593,61 @@ const canAdvance = computed(() => {
 
         <!-- ── 6. License acceptance (aggregated) ────────────────── -->
         <div v-else-if="!s.loading.value && step === 6" key="s6" class="wizard-body">
-          <p class="step-desc">
-            You're about to download these models. Confirm the licenses below.
-            hal0 does not modify or redistribute weights — files come straight
-            from Hugging Face. You're responsible for compliance in your jurisdiction.
-          </p>
+          <template v-if="licenseList.length > 0">
+            <p class="step-desc">
+              You're about to download these models. Confirm the licenses below.
+              hal0 does not modify or redistribute weights — files come straight
+              from Hugging Face. You're responsible for compliance in your jurisdiction.
+            </p>
 
-          <ul class="license-list">
-            <li v-for="row in licenseList" :key="row.kind + ':' + row.modelId" class="license-row">
-              <div class="license-row-l">
-                <span class="license-row-name">{{ row.label }}</span>
-                <span class="license-row-size">{{ fmtGb(row.sizeGb) }}</span>
-              </div>
-              <div class="license-row-r">
-                <span class="meta-chip">{{ row.license || 'see repo' }}</span>
-                <a
-                  v-if="row.license_url"
-                  class="license-link"
-                  :href="row.license_url"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >view ↗</a>
-              </div>
-            </li>
-          </ul>
+            <ul class="license-list">
+              <li v-for="row in licenseList" :key="row.kind + ':' + row.modelId" class="license-row">
+                <div class="license-row-l">
+                  <span class="license-row-name">{{ row.label }}</span>
+                  <span class="license-row-size">{{ fmtGb(row.sizeGb) }}</span>
+                </div>
+                <div class="license-row-r">
+                  <span class="meta-chip">{{ row.license || 'see repo' }}</span>
+                  <a
+                    v-if="row.license_url"
+                    class="license-link"
+                    :href="row.license_url"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >view ↗</a>
+                </div>
+              </li>
+            </ul>
 
-          <div class="totals">
-            <div><span class="totals-l">Total download</span><span class="totals-v">{{ fmtGb(s.totalDownloadGb.value) }}</span></div>
-            <div>
-              <span class="totals-l">Free on storage dir</span>
-              <span class="totals-v" :class="{ 'totals-bad': !s.fits.value }">{{ fmtGb(s.diskFreeGb.value) }}</span>
+            <div class="totals">
+              <div><span class="totals-l">Total download</span><span class="totals-v">{{ fmtGb(s.totalDownloadGb.value) }}</span></div>
+              <div>
+                <span class="totals-l">Free on storage dir</span>
+                <span class="totals-v" :class="{ 'totals-bad': !s.fits.value }">{{ fmtGb(s.diskFreeGb.value) }}</span>
+              </div>
             </div>
-          </div>
-          <p v-if="!s.fits.value" class="field-err">
-            Not enough disk space. Free up some, add a larger storage directory in step 2, or remove capabilities.
-          </p>
+            <p v-if="!s.fits.value" class="field-err">
+              Not enough disk space. Free up some, add a larger storage directory in step 2, or remove capabilities.
+            </p>
 
-          <label class="accept-label">
-            <input type="checkbox" v-model="s.form.licenseAccepted" />
-            I accept the licenses for each model shown above.
-          </label>
+            <label class="accept-label">
+              <input type="checkbox" v-model="s.form.licenseAccepted" />
+              I accept the licenses for each model shown above.
+            </label>
+          </template>
+          <template v-else>
+            <p class="step-desc">
+              Nothing to download — you skipped the chat model and didn't enable any capabilities.
+              You can install hal0 as-is and add models later from <strong>Models</strong> or
+              <strong>Capabilities</strong>, or go back and pick something now.
+            </p>
+          </template>
 
           <div class="wizard-footer wizard-footer-2">
             <button class="btn-ghost" type="button" @click="goBack">← Back</button>
-            <button class="btn-primary" type="button" :disabled="!canAdvance" @click="goNext">Accept &amp; install →</button>
+            <button class="btn-primary" type="button" :disabled="!canAdvance" @click="goNext">
+              {{ licenseList.length > 0 ? 'Accept &amp; install →' : 'Finish setup →' }}
+            </button>
           </div>
         </div>
 
@@ -959,6 +985,8 @@ const canAdvance = computed(() => {
 /* ── Footers + buttons ─────────────────────────────────────────────────── */
 .wizard-footer { padding-top: 4px; }
 .wizard-footer-2 { display: flex; justify-content: space-between; align-items: center; }
+.wizard-footer-3 { display: flex; justify-content: space-between; align-items: center; gap: 8px; flex-wrap: wrap; padding-top: 4px; }
+.wizard-footer-3 .btn-ghost { flex-shrink: 0; }
 
 .btn-primary { display: inline-flex; align-items: center; justify-content: center; gap: 6px; padding: 11px 22px; border-radius: var(--radius); background: var(--hal0-accent); color: #000; font-family: var(--font-mono); font-size: 13px; font-weight: 500; border: none; cursor: pointer; transition: background 0.15s, transform 0.05s; }
 .btn-primary:hover:not(:disabled) { background: var(--hal0-accent-hover); }

--- a/ui/src/views/FirstRun.vue
+++ b/ui/src/views/FirstRun.vue
@@ -334,8 +334,17 @@ const canAdvance = computed(() => {
           <p class="step-desc">We probed your hardware. Confirm where downloaded models live.</p>
 
           <div class="hw-card">
+            <div class="hw-row" v-if="s.hardware.value?.platform_label">
+              <span class="hw-l">Platform</span>
+              <span class="hw-v">{{ s.hardware.value?.platform_label }}</span>
+            </div>
             <div class="hw-row"><span class="hw-l">CPU</span><span class="hw-v">{{ s.hardware.value?.cpu_name || s.hardware.value?.cpu_model || '—' }}</span></div>
-            <div class="hw-row"><span class="hw-l">Memory</span><span class="hw-v">{{ Math.round((s.hardware.value?.unified_memory_mb || s.hardware.value?.ram_total_mb || 0) / 1024) }} GB unified</span></div>
+            <div class="hw-row">
+              <span class="hw-l">Memory</span>
+              <span class="hw-v">
+                {{ Math.round((s.hardware.value?.unified_memory_mb || s.hardware.value?.ram_total_mb || 0) / 1024) }} GB<template v-if="s.hardware.value?.memory_kind === 'unified'"> unified</template>
+              </span>
+            </div>
             <div class="hw-row"><span class="hw-l">GPU</span><span class="hw-v">{{ s.hardware.value?.gpu_name || '—' }}</span></div>
             <div class="hw-row"><span class="hw-l">NPU</span><span class="hw-v">{{ s.hardware.value?.npu_present ? (s.hardware.value?.npu_name || 'detected') : 'none detected' }}</span></div>
           </div>

--- a/ui/src/views/Hardware.vue
+++ b/ui/src/views/Hardware.vue
@@ -78,6 +78,12 @@ async function reProbe() {
 const hw = computed(() => ({ ...(hardware.value || {}), ...(stats.value || {}) }))
 
 const isUma = computed(() => !!hw.value.is_uma)
+const platform = computed(() => hw.value.platform || 'unknown')
+const platformLabel = computed(() => hw.value.platform_label || '')
+// "unified" is only meaningful on Strix Halo (and any future UMA host the
+// probe explicitly classifies). On generic KVM, WSL, or discrete-GPU bare
+// metal, "system" memory is the accurate label.
+const isUnifiedMemory = computed(() => hw.value.memory_kind === 'unified' || isUma.value)
 
 // Proxmox host memory authority — when /etc/hal0/proxmox.json is configured
 // and the cluster/resources poll succeeded, the host's view trumps the
@@ -222,7 +228,7 @@ onMounted(loadHardware)
         <div class="tiles">
           <div class="tile">
             <div class="tile-label">
-              {{ hostOk ? 'Physical host memory' : (isUma ? 'Unified memory' : 'System RAM') }}
+              {{ hostOk ? 'Physical host memory' : (isUnifiedMemory ? 'Unified memory' : 'System RAM') }}
             </div>
             <div class="tile-value mono">
               {{ unifiedTotalGb.toFixed(0) }}<span class="tile-unit">GB</span>
@@ -231,8 +237,14 @@ onMounted(loadHardware)
               {{ unifiedUsedPct.toFixed(0) }}% in use ·
               {{ hw.host.tenants_running }} tenant{{ hw.host.tenants_running === 1 ? '' : 's' }}
             </div>
-            <div v-else-if="isUma" class="tile-sub">{{ unifiedUsedPct.toFixed(0) }}% in use · UMA pool</div>
+            <div v-else-if="isUnifiedMemory" class="tile-sub">{{ unifiedUsedPct.toFixed(0) }}% in use · UMA pool</div>
             <div v-else class="tile-sub">{{ ramPct.toFixed(0) }}% in use</div>
+          </div>
+
+          <div class="tile" v-if="platformLabel">
+            <div class="tile-label">Platform</div>
+            <div class="tile-value tile-small">{{ platformLabel }}</div>
+            <div class="tile-sub mono">{{ platform }}</div>
           </div>
 
           <div class="tile" v-if="gpuName">


### PR DESCRIPTION
## Summary

Unblocks the FirstRun wizard end-to-end on installs where it was previously broken (notably WSL), and bundles the related quality-of-life fixes the user surfaced while reproducing the auth bug. Target: **v0.1.1**.

- **Auth**: `POST /api/auth/password` now issues a `hal0_session` cookie on the first-run leg, so the wizard's next mutation rides a valid session instead of bouncing with 401 `auth.required`. The first-run claim allowlist extends to `PUT /api/config/models`, `POST /api/models/{id}/pull`, and `POST /api/capabilities/{slot}/{child}` so the "Skip — leave open" path also completes. The claim window closes when `POST /api/install/complete` consumes the lockfile (idempotent).
- **Wizard UX**: chat-model selection is now optional. Step 3 has a "Skip — no chat model" button; capabilities-only installs flow through with a zero-item progress screen → done coda. Image models filtered out of the chat picker.
- **Curated catalog**: 3 embed picks (nomic-embed Q8_0, bge-base Q4_K_M, embed-gemma:300m) + 2 rerank picks (bge-reranker-base Q4_K_M, bge-reranker-v2-m3 Q4_K_M) so the wizard's capability dropdowns are no longer empty on a standalone install. STT/TTS left as documented TODO — moonshine + kokoro don't fit the GGUF/safetensors `CuratedModel` shape; needs a pull-layer extension. Inline fix to `CuratedModel.backend` field that was missing and silently dropping non-image rows from the picker fan-out.
- **Hardware probe**: portable CPU (ARM fallback), real GPU model strings even when the vendor doesn't classify (virtio in Proxmox VMs, vGPU in WSL), `Display controller` recognition in `lspci`, and a new `platform` field (`wsl2` / `lxc` / `proxmox-kvm` / `kvm` / `strix-halo` / `bare-metal-{nvidia,amd,intel}-gpu` / `bare-metal-cpu-only` / `unknown`). UI surfaces a platform tile and only labels memory as "unified" when `memory_kind === "unified"`.

Diagnosed from user-reported WSL install: `Could not persist storage dirs: this endpoint requires authentication. Continuing with defaults.` followed by `not enough storage` on the model pull. Root cause was the wizard never getting a session cookie after step 1; downstream cascade was the writer-gated `PUT /api/config/models` silently no-op'ing → default `/var/lib/hal0/models` on a cramped WSL VHDX → pull failed the storage-fits check.

## Commits

- `913d0ac` fix(firstrun): unblock wizard writer calls + allow skipping chat model
- `aa64fc3` test(firstrun): cover session cookie + claim extension + lockfile consume (37 new tests)
- `f563ca4` feat(curated): seed embed/rerank wizard picks; TODO stt/tts blockers
- `5b8c2ee` fix(hardware): portable CPU/RAM/GPU probe + add platform detection

## Test plan

- [x] `uv run pytest -q` — 1187 passed, 8 skipped, 3 xfailed (pre-existing CI-only xfails)
- [x] `npm run build` in `ui/` — clean
- [ ] Smoke install in WSL: bootstrap → wizard → step 2 dir picks persist → step 3 skip → step 4 capability dropdowns populated → installs complete
- [ ] Smoke install on hal0 LXC: full happy path with password set → primary qwen pick → embed/rerank capabilities enabled
- [ ] Manual: dashboard hardware card shows CPU/RAM/GPU + platform pill on this dev VM (`kvm` platform; RTX 4080 visible when dock attached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)