### PR TITLE
release(v0.1.2): skip-auth, capability dropdowns, NPU-gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.1.1"
+version = "0.1.2"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/hal0/api/middleware/auth.py
+++ b/src/hal0/api/middleware/auth.py
@@ -195,6 +195,12 @@ _FIRST_RUN_CLAIM_PATHS: frozenset[str] = frozenset(
         "/api/install/curated-models",
         "/api/install/pick-default",
         "/api/auth/password",
+        # Wizard "Skip — leave open" — writes HAL0_AUTH_DISABLED=1 to
+        # api.env and schedules a service restart so the trusted-LAN
+        # posture is in effect from the next request onward. Gated
+        # internally on no-password + lockfile-present, so the open
+        # claim window can't widen this beyond the wizard.
+        "/api/auth/disable",
         # Wizard step 2 — operator picks the model storage directories.
         # Gated by require_writer on the live router; admitted here so
         # the wizard can persist before a credential exists.

--- a/src/hal0/api/routes/auth.py
+++ b/src/hal0/api/routes/auth.py
@@ -43,6 +43,12 @@ must NOT be touched by edits to this file.
 
 from __future__ import annotations
 
+import contextlib
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
 from typing import Annotated, Any
 
 import structlog
@@ -62,6 +68,7 @@ from hal0.api.auth.rate_limit import (
 )
 from hal0.api.middleware.auth import (
     SESSION_COOKIE_NAME,
+    AuthForbidden,
     AuthIdentity,
     AuthInvalid,
     AuthRequired,
@@ -76,6 +83,7 @@ from hal0.auth.tokens import (
     auth_enabled,
     get_or_create_store,
 )
+from hal0.config import paths
 from hal0.errors import BadRequest, Hal0Error
 
 log = structlog.get_logger(__name__)
@@ -574,6 +582,81 @@ async def set_password(request: Request, response: Response) -> Any:
     }
 
 
+@router.post("/disable")
+async def disable_auth(request: Request) -> dict[str, Any]:
+    """First-run-only: switch the box to trusted-LAN posture.
+
+    Called from the wizard's "Skip — leave open" path. Writes
+    ``HAL0_AUTH_DISABLED=1`` into ``/etc/hal0/api.env`` (atomic
+    tmp-file + replace; the line is added or uncommented as needed),
+    consumes the first-run lockfile so the open-claim window closes,
+    and schedules a deferred ``systemctl restart hal0-api`` so the
+    response can flush before the process turns over. The next
+    request lands on an auth-disabled process where every dependency
+    returns ``identity=anonymous, scope=all`` — the dashboard's
+    Settings panels stop 401'ing and the operator gets the
+    pre-v1 trusted-LAN posture they asked for by clicking Skip.
+
+    Gates:
+      - Only callable while no owner password is set AND the
+        first-run lockfile exists. Once either condition flips, this
+        endpoint returns 403 ``auth.disable_not_available`` — we
+        deliberately do NOT allow flipping auth off from an existing
+        password-secured install via a single anonymous POST.
+      - The endpoint is in :data:`_FIRST_RUN_CLAIM_PATHS` so anonymous
+        callers can reach it during the claim window.
+
+    On hosts without systemd (dev installs, CI), the restart step is
+    a no-op and the env-var write is the only side effect — the next
+    process start (manual or harness-driven) picks it up.
+    """
+    try:
+        check_rate_limit(request, scope=_RATE_SCOPE_PASSWORD)
+    except RateLimitExceeded as exc:
+        return _rate_limited_response(exc)
+
+    store = _store(request)
+    if store.get_password_hash() is not None:
+        raise AuthForbidden(
+            "cannot disable auth after the owner password has been set — "
+            "edit /etc/hal0/api.env and restart hal0-api instead",
+            details={"reason": "password_already_set"},
+        )
+    if first_run_lock.read_lockfile() is None:
+        raise AuthForbidden(
+            "first-run claim window has closed — cannot toggle auth from "
+            "an anonymous request, edit /etc/hal0/api.env directly",
+            details={"reason": "claim_window_closed"},
+        )
+
+    api_env = paths.etc() / "api.env"
+    _set_auth_disabled_in_env(api_env)
+    first_run_lock.consume_lockfile()
+
+    # Best-effort deferred restart so the response flushes before the
+    # process turns over. On dev / CI / containerised installs without
+    # systemd, swallow the FileNotFoundError — the env-var write stuck
+    # to disk and the next process start picks it up.
+    _schedule_service_restart()
+
+    event_bus = getattr(request.app.state, "events", None)
+    if event_bus is not None:
+        await event_bus.emit(
+            "system.auth_changed",
+            "info",
+            "system",
+            "auth disabled — trusted-LAN posture (first-run skip)",
+            data={"auth_disabled": True},
+        )
+
+    return {
+        "ok": True,
+        "auth_disabled": True,
+        "api_env_path": str(api_env),
+        "restart_scheduled": True,
+    }
+
+
 @router.get("/me")
 async def me(
     identity: Annotated[AuthIdentity, Depends(require_token)],
@@ -588,6 +671,106 @@ async def me(
         "scope": identity.scope,
         "source": identity.source,
     }
+
+
+# ── Auth-disable helpers (POST /api/auth/disable) ────────────────────────────
+
+
+_AUTH_DISABLED_LINE = "HAL0_AUTH_DISABLED=1\n"
+
+
+def _set_auth_disabled_in_env(api_env: Path) -> None:
+    """Add or uncomment ``HAL0_AUTH_DISABLED=1`` in ``api.env``.
+
+    Atomic: writes a tmp file in the same directory then ``os.replace``
+    over the target so a crash mid-write leaves the prior file intact.
+    Idempotent: if the line is already present and uncommented, we
+    rewrite the file with the same content (no-op semantically).
+
+    The installer's default ``api.env`` ships the line commented out
+    (``# HAL0_AUTH_DISABLED=1``); we look for the commented form and
+    uncomment it in place to preserve surrounding comments. If neither
+    form is present we append. The file is created with mode 0644 to
+    match what the installer drops — adjust the umask if the deploy
+    posture changes.
+    """
+    api_env.parent.mkdir(parents=True, exist_ok=True)
+    existing = ""
+    try:
+        existing = api_env.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        raise Hal0Error(
+            f"could not read {api_env}: {exc}",
+            details={"path": str(api_env), "error": str(exc)},
+        ) from exc
+
+    lines = existing.splitlines(keepends=True) if existing else []
+    rewritten: list[str] = []
+    replaced = False
+    for line in lines:
+        stripped = line.lstrip()
+        if (
+            stripped.startswith("HAL0_AUTH_DISABLED=")
+            or stripped.startswith("# HAL0_AUTH_DISABLED=")
+            or stripped.startswith("#HAL0_AUTH_DISABLED=")
+        ):
+            if not replaced:
+                rewritten.append(_AUTH_DISABLED_LINE)
+                replaced = True
+            # Drop the original line (whether commented or set to a
+            # different value) — the new line above is authoritative.
+            continue
+        rewritten.append(line)
+    if not replaced:
+        if rewritten and not rewritten[-1].endswith("\n"):
+            rewritten.append("\n")
+        rewritten.append(_AUTH_DISABLED_LINE)
+
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=f".{api_env.name}.",
+        suffix=".tmp",
+        dir=str(api_env.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write("".join(rewritten))
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_str, 0o644)
+        os.replace(tmp_str, api_env)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_str)
+        raise
+
+
+def _schedule_service_restart() -> None:
+    """Best-effort deferred ``systemctl restart hal0-api``.
+
+    Spawns a detached background shell that sleeps 2s and then asks
+    systemd to restart this process. The sleep lets the HTTP response
+    flush before the kill arrives, and the detach (``setsid`` +
+    closed FDs) makes the child outlive its parent.
+
+    Silently no-ops when ``systemctl`` is absent (dev / CI /
+    containerised installs without systemd). The env-var write
+    already landed; the next process start picks it up.
+    """
+    systemctl = shutil.which("systemctl")
+    if not systemctl:
+        return
+    # If we can't even spawn sh, the env-var write still stuck; the
+    # operator's next manual restart picks it up.
+    with contextlib.suppress(OSError, FileNotFoundError):
+        subprocess.Popen(
+            ["sh", "-c", f"sleep 2 && {systemctl} restart hal0-api"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
 
 
 # ── Admin: token CRUD ─────────────────────────────────────────────────────────

--- a/tests/api/test_firstrun_auth_cookie.py
+++ b/tests/api/test_firstrun_auth_cookie.py
@@ -413,3 +413,133 @@ def test_path_is_claim_eligible(path: str, expected: bool) -> None:
     assert _path_is_claim_eligible(path) is expected, (
         f"claim-eligibility mismatch for path={path!r}: got {not expected}, expected {expected}"
     )
+
+
+# ── (8) /api/auth/disable — first-run skip → trusted-LAN posture ────────────
+#
+# The wizard's "Skip — leave open" button writes HAL0_AUTH_DISABLED=1
+# into /etc/hal0/api.env and schedules a service restart so the
+# dashboard's writer routes stop 401'ing on a no-credential install.
+# These tests pin the gates (password-not-set + lockfile-present) and
+# the env-writer's idempotency.
+
+
+@pytest.fixture
+def stub_restart(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the ``_schedule_service_restart`` helper with a no-op.
+
+    Without this the test would try to ``systemctl restart hal0-api``,
+    which is either missing (CI runners) or actually restarts the test
+    process (real systemd). The endpoint's contract is "best-effort
+    deferred restart, never blocks on failure"; the no-op stub keeps
+    the rest of the assertions clean.
+    """
+    from hal0.api.routes import auth as auth_routes
+
+    monkeypatch.setattr(auth_routes, "_schedule_service_restart", lambda: None)
+
+
+def test_disable_auth_writes_env_and_consumes_lockfile(
+    auth_app: TestClient, tmp_path: Path, stub_restart: None
+) -> None:
+    """First-run anonymous POST sticks HAL0_AUTH_DISABLED=1 + closes claim."""
+    lock = first_run_lock.lockfile_path()
+    assert lock.exists()
+
+    api_env = tmp_path / "etc" / "hal0" / "api.env"
+    # Pre-seed an existing api.env with the commented form, the way
+    # installer/install.sh writes it. The handler should uncomment.
+    api_env.parent.mkdir(parents=True, exist_ok=True)
+    api_env.write_text(
+        "HAL0_PORT=8080\nHAL0_LOG_LEVEL=info\n# HAL0_AUTH_DISABLED=1\n",
+        encoding="utf-8",
+    )
+
+    response = auth_app.post("/api/auth/disable")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["auth_disabled"] is True
+    assert body["restart_scheduled"] is True
+
+    written = api_env.read_text(encoding="utf-8")
+    assert "HAL0_AUTH_DISABLED=1" in written
+    # Commented form must be gone — the handler uncomments in place
+    # rather than appending a duplicate.
+    assert "# HAL0_AUTH_DISABLED=1" not in written
+
+    # Lockfile consumed → the claim window closes.
+    assert not lock.exists()
+
+
+def test_disable_auth_rejects_after_password_set(auth_app: TestClient, stub_restart: None) -> None:
+    """403 once an owner password exists — can't toggle auth anonymously."""
+    # Set a password via the normal first-run flow.
+    set_response = auth_app.post(
+        "/api/auth/password",
+        json={"password": "supersecret123"},
+    )
+    assert set_response.status_code == 200, set_response.text
+
+    # Clear the session cookie the set-password response minted —
+    # we want to exercise the anonymous-call gate, not the
+    # authenticated-rotation path.
+    auth_app.cookies.clear()
+
+    response = auth_app.post("/api/auth/disable")
+    assert response.status_code == 403, response.text
+    assert response.json()["error"]["code"] == "auth.forbidden"
+
+
+def test_disable_auth_rejects_after_lockfile_consumed(
+    auth_app: TestClient, stub_restart: None
+) -> None:
+    """403 once the claim window has closed (lockfile gone)."""
+    first_run_lock.consume_lockfile()
+    assert not first_run_lock.lockfile_path().exists()
+
+    response = auth_app.post("/api/auth/disable")
+    assert response.status_code == 403, response.text
+    assert response.json()["error"]["code"] == "auth.forbidden"
+
+
+def test_set_auth_disabled_in_env_idempotency(tmp_path: Path) -> None:
+    """``_set_auth_disabled_in_env`` handles the three input shapes.
+
+    Cases:
+      - File missing → appended.
+      - Commented (``# HAL0_AUTH_DISABLED=1``) → uncommented in place.
+      - Already set with a different value → replaced.
+      - Already set with the canonical value → no-op (still exactly one line).
+    """
+    from hal0.api.routes.auth import _set_auth_disabled_in_env
+
+    target = tmp_path / "api.env"
+
+    # 1. Missing file → handler creates parent + writes the line.
+    _set_auth_disabled_in_env(target)
+    assert target.read_text(encoding="utf-8") == "HAL0_AUTH_DISABLED=1\n"
+
+    # 2. Commented form → uncomment.
+    target.write_text(
+        "HAL0_PORT=8080\n# HAL0_AUTH_DISABLED=1\n",
+        encoding="utf-8",
+    )
+    _set_auth_disabled_in_env(target)
+    contents = target.read_text(encoding="utf-8")
+    assert "HAL0_AUTH_DISABLED=1\n" in contents
+    assert "# HAL0_AUTH_DISABLED=1" not in contents
+    # Exactly one occurrence.
+    assert contents.count("HAL0_AUTH_DISABLED=1") == 1
+
+    # 3. Different value → overwritten.
+    target.write_text(
+        "HAL0_PORT=8080\nHAL0_AUTH_DISABLED=0\n",
+        encoding="utf-8",
+    )
+    _set_auth_disabled_in_env(target)
+    assert target.read_text(encoding="utf-8").count("HAL0_AUTH_DISABLED=1") == 1
+    assert "HAL0_AUTH_DISABLED=0" not in target.read_text(encoding="utf-8")
+
+    # 4. Already canonical → no-op (still exactly one line).
+    _set_auth_disabled_in_env(target)
+    assert target.read_text(encoding="utf-8").count("HAL0_AUTH_DISABLED=1") == 1

--- a/ui/src/components/firstrun/useFirstRun.js
+++ b/ui/src/components/firstrun/useFirstRun.js
@@ -49,7 +49,14 @@ const SMART_DEFAULTS = {
 }
 
 function pickBackendTier(hw) {
-  if (hw?.npu_present) return 'npu'
+  // NPU tier is reserved for Strix Halo specifically. The FLM toolbox
+  // image ships AMD-XDNA-on-Strix-Halo binaries and the curated NPU
+  // tags are validated on that hardware; advertising NPU on any future
+  // XDNA-bearing chip just because npu_present=true would push
+  // operators onto an unsupported runtime. Once we validate a second
+  // XDNA platform, widen this list rather than dropping back to the
+  // bare npu_present check.
+  if (hw?.npu_present && hw?.platform === 'strix-halo') return 'npu'
   const v = hw?.gpu_vendor || ''
   if (v === 'amd' && !hw?.is_uma) return 'rocm'
   if (v === 'nvidia') return 'rocm'  // closest analogue in our catalog; CUDA not in capability matrix
@@ -229,7 +236,42 @@ export function useFirstRun() {
   }
 
   // ── Catalog helpers (for the capability dropdowns) ────────────────
-  const optionsFor = (slot, child) => capsData.catalogs?.[slot]?.[child] || []
+  // `/api/capabilities` returns the GROUPED shape — one row per model
+  // id, with `backends: [{id, provider, downloaded, pullable}, ...]`.
+  // The wizard's dropdown template iterates options expecting the OLD
+  // FLAT shape (`o.backend` as a top-level string + `o.provider`), so
+  // we flatten back to per-(model × backend) rows here. That keeps the
+  // existing setCapModel / sizeFor / pickFirstAvailableModels /
+  // enabledList code paths working without rewriting the template.
+  // When a row lacks a `backends` array (legacy or registry-only
+  // entries), we fall back to the row itself — that preserves any
+  // already-flat shape some path might still produce.
+  function _flattenCatalog(rows) {
+    if (!Array.isArray(rows)) return []
+    const out = []
+    for (const r of rows) {
+      const backends = Array.isArray(r.backends) ? r.backends : null
+      if (backends && backends.length > 0) {
+        for (const b of backends) {
+          out.push({
+            id: r.id,
+            backend: b.id,
+            provider: b.provider,
+            size_gb: r.size_gb,
+            capabilities: r.capabilities,
+            downloaded: b.downloaded,
+            pullable: b.pullable,
+            license: r.license,
+            license_url: r.license_url,
+          })
+        }
+      } else if (r.backend) {
+        out.push(r)
+      }
+    }
+    return out
+  }
+  const optionsFor = (slot, child) => _flattenCatalog(capsData.catalogs?.[slot]?.[child])
 
   function setCapModel(key, slot, child, comboKey) {
     const opts = optionsFor(slot, child)
@@ -333,6 +375,27 @@ export function useFirstRun() {
     passwordAlreadySet.value = true
     form.password = ''
     form.firstRunToken = ''
+  }
+
+  // "Skip — leave open" path. Flips the box to trusted-LAN posture
+  // (HAL0_AUTH_DISABLED=1 in /etc/hal0/api.env + deferred restart) so
+  // Settings → Authentication and every other writer-scoped admin
+  // route stops 401'ing. The endpoint is gated server-side on
+  // no-password + lockfile-present, so this only fires during the
+  // first-run claim window. We swallow individual error codes —
+  // the wizard advances either way, since the user explicitly chose
+  // "skip" and there's nothing else to do on this step.
+  async function disableAuthForSkip() {
+    try {
+      await api('/api/auth/disable', { method: 'POST' })
+    } catch (e) {
+      // Surface for telemetry but don't block the wizard. The most
+      // common failure is "claim window closed" (lockfile already
+      // consumed by an earlier run) — harmless, the box stays in
+      // whatever posture it was already in.
+      // eslint-disable-next-line no-console
+      console.warn('disableAuthForSkip failed:', e?.message || e)
+    }
   }
 
   // ── Step 2 — model dirs ───────────────────────────────────────────
@@ -571,7 +634,7 @@ export function useFirstRun() {
     // helpers
     optionsFor, setCapModel, sizeFor,
     // actions
-    load, submitPassword, persistModelDirs, persistHfToken,
+    load, submitPassword, disableAuthForSkip, persistModelDirs, persistHfToken,
     startAllPulls, retryItem, markComplete, dispose,
   }
   load()

--- a/ui/src/views/FirstRun.vue
+++ b/ui/src/views/FirstRun.vue
@@ -159,10 +159,17 @@ function goBack() {
   step.value = Math.max(1, step.value - 1)
 }
 
-function skipPassword() {
+async function skipPassword() {
   s.form.password = ''
   s.form.firstRunToken = ''
   tokenError.value = ''
+  // Flip the box to trusted-LAN posture (HAL0_AUTH_DISABLED=1 +
+  // deferred restart). Without this the dashboard's Settings panels
+  // 401 on every writer route after the wizard finishes, because the
+  // skip path never establishes a credential. Fire-and-forget — the
+  // composable swallows errors and the wizard advances either way.
+  s.disableAuthForSkip()
+  toasts.info('Dashboard runs open on the trusted LAN. You can set a password later in Settings.')
   step.value = 2
 }
 


### PR DESCRIPTION
## Summary

Three follow-ups to v0.1.1's first-run wizard, all surfaced by users running fresh installs:

1. **\"Skip — leave open\" actually leaves it open.** New `POST /api/auth/disable` endpoint writes `HAL0_AUTH_DISABLED=1` to `/etc/hal0/api.env`, consumes the lockfile, and schedules a deferred service restart. Without this, skip-password installs surface that token error all over Settings.

2. **Capability dropdowns no longer render `undefined / <id>`.** `/api/capabilities` returns the GROUPED shape; the wizard template expects FLAT. Adding a `_flattenCatalog` shim in `useFirstRun.js` so the existing code paths keep working.

3. **NPU slot stops auto-enabling on non-Strix-Halo XDNA hosts.** `pickBackendTier` now requires `platform === 'strix-halo'` in addition to `npu_present`.

## Test plan

- [x] `uv run pytest -q` — 1191 passed, 8 skipped, 3 xfailed (pre-existing CI-only xfails)
- [x] `npm run build` in `ui/` — clean
- [ ] Smoke install on WSL: bootstrap → wizard step 1 click \"Skip — leave open\" → dashboard loads with auth disabled, Settings panels work without 401s
- [ ] Smoke install on WSL: walk to step 4, confirm embed/rerank dropdowns list 3 + 2 models with real backend tags (cpu)
- [ ] Smoke install on bare-metal Strix Halo: NPU still auto-enabled for embed + stt smart defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)