### PR TITLE
release(v0.1.3): wizard reads on claim, NPU gated, config readable

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -376,6 +376,14 @@ TOML
 else
     info "${HAL0_TOML} exists — left alone"
 fi
+# Make the config world-readable. It's not a secret (no tokens, no
+# passwords — those live in tokens.toml + auth.toml which stay 0600),
+# and `hal0 config show` from a non-root shell needs to read it.
+# Same goes for /etc/hal0 itself — without this an install run with
+# a tightened root umask leaves /etc/hal0 at 0700 and every non-root
+# CLI command 500s with PermissionError. Idempotent on re-runs.
+chmod 0755 "${ETC_DIR}" 2>/dev/null || true
+chmod 0644 "${HAL0_TOML}" 2>/dev/null || true
 
 API_ENV="${ETC_DIR}/api.env"
 if [[ ! -f "${API_ENV}" ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.2.0-alpha.1"
+version = "0.2.0-alpha.2"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/hal0/api/middleware/auth.py
+++ b/src/hal0/api/middleware/auth.py
@@ -205,6 +205,15 @@ _FIRST_RUN_CLAIM_PATHS: frozenset[str] = frozenset(
         # Gated by require_writer on the live router; admitted here so
         # the wizard can persist before a credential exists.
         "/api/config/models",
+        # Wizard load — read-only hardware + capability info. Both are
+        # fetched on mount BEFORE the operator has had a chance to set
+        # a password (or click "Skip — leave open"), so without this
+        # admission the disk-free row and the capability dropdowns
+        # render empty on every fresh install. Neither leaks anything
+        # secret — the probe payload is already available through
+        # /api/install/probe (also in this set).
+        "/api/hardware",
+        "/api/capabilities",
     }
 )
 

--- a/src/hal0/cli/config_commands.py
+++ b/src/hal0/cli/config_commands.py
@@ -33,7 +33,22 @@ def config_show() -> None:
     if not path.exists():
         console.print(f"[dim]No config at {path}[/dim]")
         raise typer.Exit(0)
-    body = path.read_text()
+    # Translate PermissionError into a clear hint — pre-v0.1.3 installs
+    # left /etc/hal0 mode 0700 in some umask-tightened environments,
+    # which makes `hal0 config show` from a non-root shell explode with
+    # a raw Python traceback. Re-run under sudo or chmod the config tree
+    # 0755/0644 (the installer does this for fresh installs as of
+    # v0.1.3).
+    try:
+        body = path.read_text()
+    except PermissionError as exc:
+        console.print(f"[red]Permission denied:[/red] {path}")
+        console.print(
+            "[dim]The config is owned by root. Re-run with [bold]sudo[/bold], "
+            "or run [bold]sudo chmod 0755 /etc/hal0 && sudo chmod 0644 "
+            f"{path}[/bold] once and the command will work without sudo.[/dim]"
+        )
+        raise typer.Exit(1) from exc
     console.print(
         Panel(
             Syntax(body, "toml", theme="ansi_dark", background_color="default"),

--- a/tests/api/test_auth_middleware.py
+++ b/tests/api/test_auth_middleware.py
@@ -126,9 +126,22 @@ def test_public_routes_bypass_auth(auth_app: TestClient, path: str) -> None:
         "/api/logs",
         "/api/settings",
         "/api/providers",
+        "/api/capabilities",
     ],
 )
 def test_protected_routes_require_auth(auth_app: TestClient, path: str) -> None:
+    # Drop the first-run lockfile so the claim window is closed for this
+    # assertion. /api/hardware and /api/capabilities are deliberately
+    # admitted while .first-run.lock + no-password — see
+    # _FIRST_RUN_CLAIM_PATHS in src/hal0/api/middleware/auth.py — so
+    # without this the wizard-claim layer would mask the writer gate
+    # and the test would 200 instead of 401. The protected-route
+    # contract this test pins is "auth required once the wizard has
+    # finished", which matches the install-complete posture.
+    from hal0.api.auth import first_run as first_run_lock
+
+    first_run_lock.consume_lockfile()
+
     response = auth_app.get(path)
     assert response.status_code == 401, (
         f"protected route {path} did not 401: status={response.status_code} body={response.text}"

--- a/tests/api/test_firstrun_auth_cookie.py
+++ b/tests/api/test_firstrun_auth_cookie.py
@@ -363,7 +363,13 @@ def test_curated_models_filters_out_image_slot(auth_app: TestClient) -> None:
         ("/api/install/curated-models", True),
         ("/api/install/pick-default", True),
         ("/api/auth/password", True),
+        ("/api/auth/disable", True),
         ("/api/config/models", True),
+        # The wizard's load() reads these on mount, before the operator
+        # has had a chance to set a password — admit them so the disk
+        # row and capability dropdowns render on a fresh install.
+        ("/api/hardware", True),
+        ("/api/capabilities", True),
         # Regex matches — /api/models/{id}/pull
         ("/api/models/qwen3-4b/pull", True),
         ("/api/models/some-weird_id.v2/pull", True),
@@ -388,7 +394,6 @@ def test_curated_models_filters_out_image_slot(auth_app: TestClient) -> None:
         ("/api/slots/primary", False),
         ("/api/auth/login", False),
         ("/api/auth/logout", False),
-        ("/api/hardware", False),
         ("/api/models", False),
         ("/api/models/foo", False),
         ("/", False),

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -166,6 +166,15 @@ const unifiedSegments = computed(() => {
 // proxy from — still lights up when amdxdna + /dev/accel are present.
 const npuOk = computed(() => hw.value.npu_status?.ok ?? !!hw.value.npu_present)
 
+// Only render the NPU backend card on Strix Halo. Even when npu_present
+// is true on a future XDNA-bearing chip, the FLM toolbox image is
+// validated on Strix Halo only — surfacing the card on every NPU host
+// would put operators in front of a broken backend they can't use yet.
+// Widen this list when a second NPU platform is validated.
+const showNpuCard = computed(
+  () => !!hw.value.npu_present && hw.value.platform === 'strix-halo',
+)
+
 // ── Throughput ────────────────────────────────────────────────────────
 const totalTps = computed(() =>
   Object.values(metrics.value).reduce((a, m) => a + (m?.tokens_per_sec ?? m?.tps ?? 0), 0),
@@ -436,7 +445,8 @@ loadChatModels()
         </template>
         <template v-else-if="visibleSlots.length === 0">
           <div class="slots-grid" role="list" aria-label="Inference slots">
-            <NPUBackendCard />
+            <NPUBackendCard v-if="showNpuCard" />
+            <p v-else class="empty-slots">No slots configured yet — head to <a href="/slots">Slots</a> to create one.</p>
           </div>
         </template>
         <template v-else>
@@ -455,8 +465,9 @@ loadChatModels()
             />
             <!-- NPU backend lives in the slots grid: it can serve a
                  chat-shaped model the same way a llama.cpp slot does,
-                 so colocating it here is honest. -->
-            <NPUBackendCard />
+                 so colocating it here is honest. Strix-Halo-only —
+                 see showNpuCard above. -->
+            <NPUBackendCard v-if="showNpuCard" />
           </div>
         </template>
       </section>
@@ -608,6 +619,18 @@ loadChatModels()
   grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
   gap: 14px;
 }
+.empty-slots {
+  grid-column: 1 / -1;
+  padding: 24px;
+  text-align: center;
+  color: var(--color-fg-muted);
+  font-size: 13px;
+  background: var(--color-surface);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-lg);
+}
+.empty-slots a { color: var(--hal0-accent); text-decoration: none; }
+.empty-slots a:hover { text-decoration: underline; }
 
 /* ── Chat panel ─────────────────────────────────────────────────── */
 .chat-card { padding: 14px 16px; display: flex; flex-direction: column; gap: 10px; }

--- a/ui/src/views/Slots.vue
+++ b/ui/src/views/Slots.vue
@@ -148,6 +148,14 @@ const availMemMb = computed(() => {
   return hardware.value.gtt_total_mb ?? hardware.value.vram_total_mb ?? null
 })
 
+// Strix-Halo-only NPU card visibility. The FLM toolbox image only
+// runs on Strix Halo today; surfacing the card on any other XDNA host
+// (or, worse, on a virtio "NPU" in a misconfigured probe) leads
+// operators to a backend they can't use.
+const showNpuCard = computed(
+  () => !!hardware.value?.npu_present && hardware.value?.platform === 'strix-halo',
+)
+
 function modelFit(model) {
   if (availMemMb.value === null) return null
   const reqMb = (model.size_gb ?? 0) * 1024 * 1.1  // 10% overhead
@@ -647,9 +655,15 @@ const SLOT_TYPES = ['llama-server', 'flm', 'moonshine', 'kokoro']
 
       <template v-else-if="slots.length === 0">
         <!-- All system slots are capability-owned; show NPU card alone
-             rather than an empty "create a slot" prompt. -->
+             rather than an empty "create a slot" prompt. Strix-Halo-only;
+             elsewhere we render an explicit empty state. -->
         <div class="slots-grid" role="list" aria-label="Inference slots">
-          <NPUBackendCard />
+          <NPUBackendCard v-if="showNpuCard" />
+          <p v-else class="empty-slots-msg">
+            No slots configured. The Capabilities section above creates
+            them automatically; create a custom slot with the form below
+            once you've pulled a model.
+          </p>
         </div>
       </template>
 
@@ -686,8 +700,9 @@ const SLOT_TYPES = ['llama-server', 'flm', 'moonshine', 'kokoro']
           </div>
           <!-- NPU backend rides in the same grid as the other slot
                cards now — it serves chat-shaped models the same way a
-               local llama.cpp slot does. -->
-          <NPUBackendCard />
+               local llama.cpp slot does. Strix-Halo-only; see
+               showNpuCard above. -->
+          <NPUBackendCard v-if="showNpuCard" />
         </div>
       </template>
 


### PR DESCRIPTION
## Summary

Four bugs from a fresh WSL install of v0.1.2:

1. **Wizard reads 401'd before the user could disable auth.** GET /api/hardware + GET /api/capabilities now admitted by the first-run claim while .first-run.lock + no-password. Closes once /api/install/complete consumes the lockfile.
2. **NPUBackendCard rendered on every host.** Gated on `npu_present && platform === 'strix-halo'` in Dashboard + Slots; plain "no slots configured" message elsewhere.
3. **`hal0 config show` 500'd with raw PermissionError.** Installer now chmods /etc/hal0 → 0755 and hal0.toml → 0644 explicitly. CLI catches PermissionError and prints a clear sudo hint.
4. **Capability dropdowns and disk-free row were therefore empty.** Resolved by #1.

## Test plan

- [x] `uv run pytest -q` — 1194 passed, 8 skipped, 3 xfailed
- [x] `npm run build` — clean
- [ ] Fresh WSL install: wizard step 2 shows disk-free; step 4 shows nomic + bge-base + 2 rerankers in dropdowns; dashboard has no NPU card
- [ ] `hal0 config show` from non-root shell prints config (post-fresh-install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)