### PR TITLE
fix(install): version reads from metadata; copy source to PREFIX

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -254,6 +254,36 @@ mkdir -p \
     "${UNIT_DIR}"
 info "directories under ${PREFIX}, ${ETC_DIR}, ${VAR_DIR} (pulls → ${MODELS_DIR})"
 
+# Production install ships the source tree into ${PREFIX} so `pip install
+# --editable` ends up pointing at a persistent location, not the temp dir
+# the bootstrap unpacks into (which gets cleaned on exit — and on a
+# tmpfs /tmp, doesn't survive a reboot). Dev installs skip this: their
+# REPO_ROOT is the operator's git checkout and we want pip's editable
+# link aimed there so source edits flow without a reinstall.
+if [[ "${DEV_MODE}" -eq 0 && "${REPO_ROOT}" != "${PREFIX}" ]]; then
+    if command -v rsync >/dev/null 2>&1; then
+        ui_spinner_run "Copying source to ${PREFIX}" \
+            rsync -a --delete \
+                --exclude='.venv/' \
+                --exclude='.git/' \
+                --exclude='__pycache__/' \
+                --exclude='*.pyc' \
+                --exclude='node_modules/' \
+                --exclude='.pytest_cache/' \
+                --exclude='.ruff_cache/' \
+                "${REPO_ROOT}/" "${PREFIX}/"
+    else
+        # rsync isn't strictly a prereq; tar-pipe falls back cleanly.
+        (cd "${REPO_ROOT}" && tar --exclude='.venv' --exclude='.git' \
+            --exclude='__pycache__' --exclude='*.pyc' \
+            --exclude='node_modules' --exclude='.pytest_cache' \
+            --exclude='.ruff_cache' -cf - .) \
+            | (cd "${PREFIX}" && tar -xf -)
+        info "copied source → ${PREFIX} (tar fallback)"
+    fi
+    REPO_ROOT="${PREFIX}"
+fi
+
 # Seed hal0.toml's [models].pull_root when the operator picked a non-default
 # directory, so the API and CLI both read the same value from the
 # canonical config without an extra dashboard step. Idempotent: a

--- a/src/hal0/__init__.py
+++ b/src/hal0/__init__.py
@@ -1,6 +1,7 @@
 """hal0 — open-source home AI inference platform."""
 
-from importlib.metadata import PackageNotFoundError, version as _pkg_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 try:
     __version__ = _pkg_version("hal0")

--- a/src/hal0/__init__.py
+++ b/src/hal0/__init__.py
@@ -1,3 +1,11 @@
 """hal0 — open-source home AI inference platform."""
 
-__version__ = "0.2.0-alpha.1"
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("hal0")
+except PackageNotFoundError:
+    # Importing the source tree without `pip install`-ing it (e.g. a
+    # `python -c "import hal0"` from a repo clone) bypasses metadata.
+    # Surface a clear sentinel rather than a confusing crash.
+    __version__ = "0.0.0+source"


### PR DESCRIPTION
## Summary

Two related install-correctness bugs found via the v0.2.0-alpha.2 fresh-LXC E2E on stage 231 (10.0.1.231).

1. **\`__version__\` drift.** PR #114's squash bumped \`pyproject.toml\` to 0.2.0-alpha.2 but missed \`src/hal0/__init__.py\`, which still hardcoded \`0.2.0-alpha.1\`. Every consumer of \`hal0.__version__\` (CLI, \`/api/status\`, updater, audit log) reported the wrong version on every alpha.2 install.

   **Fix**: read version via \`importlib.metadata\` so \`pyproject.toml\` is the single source of truth. Source-tree import without pip-install falls back to a clear \`0.0.0+source\` sentinel.

2. **\`pip install --editable\` aimed at the bootstrap's tempdir.** \`installer/install.sh\` ran \`pip install -e \"\${REPO_ROOT}\"\` where REPO_ROOT under the bootstrap flow is \`/tmp/hal0-install-XXX/hal0-<version>/\`. That dir gets cleaned on bootstrap exit (and won't survive a tmpfs \`/tmp\` reboot), leaving the venv with a dangling editable link and hal0-api crashing on next import. Confirmed on stage: \`/opt/hal0/src/\` didn't exist post-install; \`pip show hal0\` reported \`Editable project location: /tmp/hal0-install-fXompE/hal0-0.2.0-alpha.2\`.

   **Fix**: in production mode (\`DEV_MODE != 1\`), rsync source from REPO_ROOT → PREFIX (\`/opt/hal0\`) before the venv step, then reassign REPO_ROOT to PREFIX so all subsequent operations read from the persistent location. Dev mode untouched. \`_mount_dashboard\` already walks up from \`__file__\` looking for \`ui/dist\` so the UI mount works transparently.

Both warrant cutting v0.2.0-alpha.3 immediately — alpha.2 ships with the wrong version string visible to every user and is one tmpfs reboot away from a dead service.

## Test plan

- [x] \`bash -n installer/install.sh\` — syntax OK
- [x] \`python3 -c \"import hal0; print(hal0.__version__)\"\` from a source-only checkout → \`0.0.0+source\` sentinel
- [ ] Fresh LXC reinstall: \`/api/status\` reports \`0.2.0-alpha.3\`, \`/opt/hal0/src/hal0/__init__.py\` exists, \`pip show hal0\` editable-location is \`/opt/hal0\`
- [ ] Reboot the LXC, verify hal0-api comes back up clean (no \`/tmp\` dangle)
- [ ] Cosign verify chain on the new release artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)