### PR TITLE
feat(phase-8): MCP tool annotations on admin + memory servers (G1 + D1)

### DIFF
--- a/docs/internal/adr/0004-agents.md
+++ b/docs/internal/adr/0004-agents.md
@@ -25,6 +25,8 @@ Bundle third-party agent apps. Each install from official upstream, byte for byt
 
 No first-party agent runtime. No hal0-authored prompts. No hal0-authored tool dispatch. The shim only do install + wire.
 
+**SDK divergence (D1).** hal0's MCP servers are built on the upstream Python SDK (`mcp.server.fastmcp.FastMCP`), not the TypeScript SDK the `mcp-builder` skill recommends for new servers. Justification: the orchestrator + every other hal0 surface is Python, FastMCP is the upstream Python SDK, and we have no MCPB distribution target. Divergence accepted; see [audit 2026-05-22 §D1](../audit-2026-05-22-phase8-skill-review.md#d1--python-fastmcp-over-typescript-mcp-sdk).
+
 ### 2. Picker + lifecycle
 
 - Picker live in two places: first-run wizard step, plus `hal0 agent install <name>` CLI subcommand for after the fact.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -81,6 +81,7 @@ import structlog
 # server module itself (the orchestrator decides whether to mount).
 try:
     from mcp.server.fastmcp import FastMCP  # type: ignore[import-not-found]
+    from mcp.types import ToolAnnotations  # type: ignore[import-not-found]
 except ImportError as _import_exc:  # pragma: no cover — exercised at install time
     raise ImportError(
         "hal0.mcp.admin requires the 'mcp' Python SDK. "
@@ -436,6 +437,96 @@ async def _execute_tool(
     )
 
 
+# ── Tool annotations (mcp-builder Phase 2.3) ─────────────────────────────────
+#
+# Per the MCP spec, every tool advertises four behavioural hints so the
+# client can pick the right warning UX before invocation:
+#
+#   readOnlyHint     — call doesn't mutate hal0 state.
+#   destructiveHint  — meaningful only when readOnly=False; true if the
+#                      call removes data or deletes a resource.
+#   idempotentHint   — repeated calls with the same args leave the same
+#                      end state (true for "set X to Y" semantics).
+#   openWorldHint    — call reaches outside hal0's own surface (e.g.
+#                      pulling weights from HuggingFace).
+#
+# These are advisory — server-side gating in :func:`is_gated` is still
+# the authoritative policy. The annotations exist so MCP clients render
+# the right approval-prompt language without having to read ADR-0004.
+
+_ANNOTATIONS: dict[str, ToolAnnotations] = {
+    # Autonomous read — pure reads against the local REST surface.
+    "slot_list": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "slot_status": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "model_list": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "hardware_probe": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "logs_tail": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "capability_list": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "provider_list": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "version_info": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    # Read-shaped memory tools — surface a Cognee query, no writes.
+    "memory_search": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "memory_list": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    # Mutating, reversible, idempotent end-state writes.
+    "model_swap": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "capability_set": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "config_write": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "provider_credential_write": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    # Mutating, reversible, non-idempotent (each call has additional effect).
+    "memory_add": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+    ),
+    "slot_create": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+    ),
+    "slot_restart": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+    ),
+    # Reaches outside hal0 (HuggingFace / upstream registries).
+    "model_pull": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=True
+    ),
+    # Destructive — re-delete is a no-op so idempotentHint stays true.
+    "model_delete": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
+    ),
+    "slot_delete": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
+    ),
+    "memory_delete": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
+    ),
+}
+
+
 # ── FastMCP server builder ───────────────────────────────────────────────────
 
 
@@ -487,7 +578,8 @@ def build_server(
 
         _tool.__name__ = tool_name
         _tool.__doc__ = description
-        server.tool(name=tool_name, description=description)(_tool)
+        annotations = _ANNOTATIONS.get(tool_name)
+        server.tool(name=tool_name, description=description, annotations=annotations)(_tool)
 
     # Autonomous read
     _register("slot_list", "List every slot known to hal0 (local + remote).")
@@ -527,6 +619,7 @@ __all__ = [
     "AUTONOMOUS_READ_TOOLS",
     "AUTONOMOUS_WRITE_TOOLS",
     "GATED_TOOLS",
+    "_ANNOTATIONS",
     "build_server",
     "dispatch",
     "is_gated",

--- a/src/hal0/mcp/memory.py
+++ b/src/hal0/mcp/memory.py
@@ -68,6 +68,7 @@ import structlog
 
 try:
     from mcp.server.fastmcp import FastMCP  # type: ignore[import-not-found]
+    from mcp.types import ToolAnnotations  # type: ignore[import-not-found]
 except ImportError as _import_exc:  # pragma: no cover — exercised at install time
     raise ImportError(
         "hal0.mcp.memory requires the 'mcp' Python SDK. "
@@ -381,6 +382,30 @@ def make_dispatcher(
     return _dispatch
 
 
+# ── Tool annotations (mcp-builder Phase 2.3) ─────────────────────────────────
+#
+# Matches the standalone-server view of memory tools. Hints stay
+# consistent with :mod:`hal0.mcp.admin`'s table — the destructive bit
+# on memory_delete is intrinsic to the operation; admin-layer approval
+# gating for bulk deletes is a separate enforcement layer that doesn't
+# change the annotation.
+
+_ANNOTATIONS: dict[str, ToolAnnotations] = {
+    "memory_add": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+    ),
+    "memory_search": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "memory_list": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "memory_delete": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
+    ),
+}
+
+
 # ── Standalone server (used when the memory MCP is mounted on its own) ───────
 
 
@@ -416,7 +441,8 @@ def build_server(
 
         _tool.__name__ = tool
         _tool.__doc__ = description
-        server.tool(name=tool, description=description)(_tool)
+        annotations = _ANNOTATIONS.get(tool)
+        server.tool(name=tool, description=description, annotations=annotations)(_tool)
 
     _register("memory_add", "Add an item to long-term memory.")
     _register("memory_search", "Search long-term memory.")
@@ -430,6 +456,7 @@ def build_server(
 
 
 __all__ = [
+    "_ANNOTATIONS",
     "MemorySchemaError",
     "build_server",
     "make_dispatcher",

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -129,6 +129,52 @@ async def test_build_server_registers_full_catalog(queue: ApprovalQueue) -> None
     assert expected.issubset(registered)
 
 
+def test_every_tool_has_annotations() -> None:
+    """Every tool registered with FastMCP must carry the four MCP hints
+    (readOnly / destructive / idempotent / openWorld). New tools added
+    to the catalog without an annotation row trip this guard."""
+    catalog = admin.AUTONOMOUS_READ_TOOLS | admin.AUTONOMOUS_WRITE_TOOLS | admin.GATED_TOOLS
+    missing = catalog - admin._ANNOTATIONS.keys()
+    assert not missing, f"tools missing MCP annotations: {sorted(missing)}"
+    for name, ann in admin._ANNOTATIONS.items():
+        assert ann.readOnlyHint is not None, f"{name}: readOnlyHint unset"
+        assert ann.destructiveHint is not None, f"{name}: destructiveHint unset"
+        assert ann.idempotentHint is not None, f"{name}: idempotentHint unset"
+        assert ann.openWorldHint is not None, f"{name}: openWorldHint unset"
+
+
+def test_destructive_tools_match_gated_destructive_set() -> None:
+    """ADR-0004 §4's "destructive" classification must match the
+    destructiveHint annotations exactly. The annotation is the
+    client-facing surface; ADR-0004 is the policy. They cannot drift."""
+    destructive_per_adr = {"model_delete", "slot_delete", "memory_delete"}
+    destructive_per_annotation = {
+        name for name, ann in admin._ANNOTATIONS.items() if ann.destructiveHint
+    }
+    assert destructive_per_annotation == destructive_per_adr
+
+
+def test_open_world_tool_is_model_pull_only() -> None:
+    """model_pull is the only tool that reaches outside hal0's own
+    surface (HuggingFace + upstream registries). Anything else with
+    openWorldHint=True needs a deliberate ADR update."""
+    open_world = {name for name, ann in admin._ANNOTATIONS.items() if ann.openWorldHint}
+    assert open_world == {"model_pull"}
+
+
+@pytest.mark.asyncio
+async def test_registered_tools_carry_their_annotations(queue: ApprovalQueue) -> None:
+    """The annotation table must actually reach FastMCP's tool list —
+    not just sit in a dict no one looks at."""
+    server = admin.build_server(approval_queue=queue, base_url="http://t")
+    tools = await server.list_tools()
+    by_name = {t.name: t for t in tools}
+    sample = "model_delete"  # destructive — easiest to spot a regression on
+    assert by_name[sample].annotations is not None
+    assert by_name[sample].annotations.destructiveHint is True
+    assert by_name[sample].annotations.readOnlyHint is False
+
+
 @pytest.mark.asyncio
 async def test_autonomous_read_dispatches_get_with_bearer(
     queue: ApprovalQueue, mock_transport: dict[str, Any]

--- a/tests/mcp/test_memory.py
+++ b/tests/mcp/test_memory.py
@@ -210,3 +210,24 @@ async def test_private_without_client_id_errors(wrapper: _FakeWrapper) -> None:
     out = await disp("memory_add", {"text": "x"})
     assert out["status"] == "error"
     assert out["error"]["code"] == "mcp.memory_schema"
+
+
+@pytest.mark.asyncio
+async def test_standalone_server_tools_carry_annotations(wrapper: _FakeWrapper) -> None:
+    """The standalone /mcp/memory server must surface MCP hints —
+    matching what the admin server reports for the same tool names."""
+    server = memory.build_server(wrapper=wrapper)
+    tools = await server.list_tools()
+    by_name = {t.name: t for t in tools}
+    for tool_name in ("memory_add", "memory_search", "memory_list", "memory_delete"):
+        ann = by_name[tool_name].annotations
+        assert ann is not None, f"{tool_name}: annotations missing"
+        assert ann.readOnlyHint is not None
+        assert ann.destructiveHint is not None
+        assert ann.idempotentHint is not None
+        assert ann.openWorldHint is not None
+    # memory_delete is the destructive one.
+    assert by_name["memory_delete"].annotations.destructiveHint is True
+    # memory_search + memory_list are reads.
+    assert by_name["memory_search"].annotations.readOnlyHint is True
+    assert by_name["memory_list"].annotations.readOnlyHint is True


### PR DESCRIPTION
## Summary

Closes #115. Adds the four MCP behavioural hints (`readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`) to every tool registered with FastMCP on both the admin server and the standalone memory server, so MCP clients can render the right warning UX without having to read ADR-0004 to know which tools are destructive.

Annotations are wired through a `_ANNOTATIONS: dict[str, ToolAnnotations]` table next to each `_register()` helper. New tests guard the table:

- `test_every_tool_has_annotations` — every catalog tool has a row with all four hints set; new tools added without an annotation row fail loudly.
- `test_destructive_tools_match_gated_destructive_set` — pins the destructive set against ADR-0004 §4's classification so the annotation can't drift away from policy.
- `test_open_world_tool_is_model_pull_only` — `model_pull` is the only tool that reaches outside hal0's own surface.
- `test_registered_tools_carry_their_annotations` / `test_standalone_server_tools_carry_annotations` — assert FastMCP actually surfaces the annotations on `list_tools` output (catches the dict-with-no-readers regression class).

Also lands the **D1 documented divergence** in ADR-0004 §1 — the SDK-language note: Python (FastMCP) chosen over the `mcp-builder` skill's TypeScript recommendation, with reasoning + link to the audit doc.

## Annotation table

Derived from ADR-0004 §4 + the audit doc:

| Category | Tools | RO | Dest | Idem | OW |
|---|---|---|---|---|---|
| Read | `slot_list`, `slot_status`, `model_list`, `hardware_probe`, `logs_tail`, `capability_list`, `provider_list`, `version_info`, `memory_search`, `memory_list` | T | F | T | F |
| Mutate, reversible, idempotent | `model_swap`, `capability_set`, `config_write`, `provider_credential_write` | F | F | T | F |
| Mutate, reversible, non-idempotent | `slot_create`, `slot_restart`, `memory_add` | F | F | F | F |
| Mutate, fetches externally | `model_pull` | F | F | T | T |
| Destructive | `model_delete`, `slot_delete`, `memory_delete` | F | T | T | F |

Mechanical change; no behaviour change. Server-side `is_gated` policy is still the authoritative approval gate — annotations are advisory hints for the client UX layer.

## Test plan

- [x] `tests/mcp/test_admin.py` + `tests/mcp/test_memory.py` — 32 tests pass on hal0 LXC
- [x] `ruff check` + `ruff format` clean on touched files
- [x] D1 doc-link to audit (PR #117, now on main) resolves
- [ ] Manual MCP-Inspector verification on running `/mcp/admin` (post-merge — wave with #116 wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)