### PR TITLE
feat(toolbox): bump vulkan to v2 (b9279) + synthesise KV-cache % from /slots

### DIFF
--- a/packaging/toolbox/vulkan.Dockerfile
+++ b/packaging/toolbox/vulkan.Dockerfile
@@ -1,6 +1,10 @@
 # hal0-toolbox-vulkan — llama.cpp Vulkan backend for AMD iGPU (Strix Halo)
 #
-# Target image:    ghcr.io/hal0-dev/hal0-toolbox-vulkan:v1  (Phase 5 publish)
+# Target image:    ghcr.io/hal0ai/hal0-toolbox-vulkan:v2
+#                  (v2 pins LLAMA_CPP_REF=b9279 so /slots emits
+#                  ``n_prompt_tokens`` and the dashboard can synthesise
+#                  a KV-cache % gauge — see
+#                  src/hal0/api/routes/slots.py:_scrape_llama_metrics.)
 # Local dev tag:   hal0-toolbox-vulkan:dev
 #
 # Provider contract (src/hal0/providers/llama_server.py):
@@ -29,8 +33,11 @@ FROM ubuntu:24.04 AS builder
 
 # llama.cpp git ref. Override at build time, e.g.:
 #   docker build --build-arg LLAMA_CPP_REF=b4404 ...
-# For :dev we track master; :v1 will pin to a signed release tag.
-ARG LLAMA_CPP_REF=master
+# For :dev we track master; :v2 pins to b9279 (2026-05-22) — the
+# first ref that reinstates per-slot ``n_prompt_tokens`` in /slots
+# after the server.cpp restructure, which the dashboard's KV-cache %
+# gauge depends on. Bump the default when bumping the published tag.
+ARG LLAMA_CPP_REF=b9279
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Build deps: compiler toolchain, cmake, Vulkan SDK headers, glslang

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -305,8 +305,16 @@ async def _systemd_show(unit: str, *props: str) -> dict[str, str]:
 
 
 async def _scrape_llama_metrics(port: int) -> dict[str, Any]:
-    """Scrape llama.cpp's /metrics endpoint on loopback and parse the
-    Prometheus text into a small whitelist of slot-card-relevant fields.
+    """Scrape llama.cpp's /metrics + /slots endpoints on loopback.
+
+    /metrics is parsed for ``requests_processing`` / ``requests_deferred``
+    (still emitted by current llama-server master). The KV-cache ratio
+    gauge upstream used to emit (``llamacpp:kv_cache_usage_ratio``) was
+    removed in the post-refactor server, so we synthesise it from
+    /slots: ``max(n_prompt_tokens) / n_ctx`` across the slot's parallel
+    sub-slots. This matches what the gauge used to represent — the
+    fullest cache slot — and is provider-agnostic (any llama-server
+    with a busy parallel slot reports n_prompt_tokens).
 
     Returns an empty dict on any failure (slot not running, port
     unbound, llama-server built without ``--metrics``, parse error) so
@@ -316,17 +324,24 @@ async def _scrape_llama_metrics(port: int) -> dict[str, Any]:
         return {}
     import httpx
 
-    url = f"http://127.0.0.1:{port}/metrics"
-    try:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(0.5)) as client:
-            resp = await client.get(url)
-    except (httpx.HTTPError, OSError):
-        return {}
-    if resp.status_code != 200:
-        return {}
+    metrics_url = f"http://127.0.0.1:{port}/metrics"
+    slots_url = f"http://127.0.0.1:{port}/slots"
+    timeout = httpx.Timeout(0.5)
+    out: dict[str, Any] = {}
 
-    # Same whitelist haloai used in lib/providers/llama_server.py — keep
-    # output keys in sync with the SlotCard's expected field names.
+    # Fan the two scrapes out in parallel; either may 404 (older builds,
+    # --no-slots, --no-metrics) and we degrade silently per-endpoint.
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        try:
+            metrics_resp, slots_resp = await asyncio.gather(
+                client.get(metrics_url),
+                client.get(slots_url),
+                return_exceptions=True,
+            )
+        except (httpx.HTTPError, OSError):
+            return out
+
+    # --- /metrics: still the source of truth for queue depth gauges. ---
     #
     # We intentionally DO NOT scrape `llamacpp:predicted_tokens_seconds`
     # here. That gauge is the lifetime average since llama-server start,
@@ -337,24 +352,82 @@ async def _scrape_llama_metrics(port: int) -> dict[str, Any]:
     wanted: dict[str, tuple[str, type]] = {
         "llamacpp:requests_processing": ("requests_processing", int),
         "llamacpp:requests_deferred": ("requests_deferred", int),
+        # Kept for completeness in case a future llama.cpp reintroduces it;
+        # current master (b9279) does not emit this gauge.
         "llamacpp:kv_cache_usage_ratio": ("kv_cache_usage", float),
     }
-    out: dict[str, Any] = {}
-    for line in resp.text.splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        parts = line.split()
-        if len(parts) < 2:
-            continue
-        entry = wanted.get(parts[0])
-        if entry is None:
-            continue
-        key, caster = entry
+    # Duck-typed: any object with a status_code + text attr (real httpx
+    # Response or a test stub) passes; exceptions returned by gather()
+    # fall through to the synthesis branch below.
+    if (
+        not isinstance(metrics_resp, BaseException)
+        and getattr(metrics_resp, "status_code", 0) == 200
+    ):
+        for line in metrics_resp.text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            entry = wanted.get(parts[0])
+            if entry is None:
+                continue
+            key, caster = entry
+            try:
+                out[key] = int(float(parts[1])) if caster is int else float(parts[1])
+            except (ValueError, TypeError):
+                continue
+
+    # --- /slots: KV-cache % via max(n_prompt_tokens)/n_ctx. -------------
+    #
+    # Newer llama-server (post-server.cpp refactor, b9000-ish onward)
+    # exposes ``n_prompt_tokens`` per parallel sub-slot when busy, plus
+    # ``n_ctx`` always. Older builds only return id/n_ctx/is_processing,
+    # in which case the max is 0 and we skip the synthesised gauge so
+    # the UI renders '—' rather than a misleading 0%.
+    if (
+        "kv_cache_usage" not in out
+        and not isinstance(slots_resp, BaseException)
+        and getattr(slots_resp, "status_code", 0) == 200
+    ):
         try:
-            out[key] = int(float(parts[1])) if caster is int else float(parts[1])
+            payload = slots_resp.json()
         except (ValueError, TypeError):
-            continue
+            payload = None
+        if isinstance(payload, list) and payload:
+            max_used = 0
+            n_ctx = 0
+            for slot in payload:
+                if not isinstance(slot, dict):
+                    continue
+                try:
+                    ctx = int(slot.get("n_ctx", 0) or 0)
+                except (ValueError, TypeError):
+                    ctx = 0
+                if ctx > n_ctx:
+                    n_ctx = ctx
+                # Prefer n_prompt_tokens (current prompt+cache occupancy)
+                # if it's there; cache_tokens / n_past are legacy fallbacks
+                # used by even-older builds.
+                used = 0
+                for key in ("n_prompt_tokens", "cache_tokens", "n_past"):
+                    v = slot.get(key)
+                    if v is None:
+                        continue
+                    try:
+                        iv = int(v)
+                    except (ValueError, TypeError):
+                        continue
+                    if iv > used:
+                        used = iv
+                if used > max_used:
+                    max_used = used
+            if n_ctx > 0 and max_used > 0:
+                ratio = max_used / float(n_ctx)
+                # Clamp — n_prompt_tokens can briefly exceed n_ctx during
+                # shift; surfacing >1.0 would look broken in the UI.
+                out["kv_cache_usage"] = min(max(ratio, 0.0), 1.0)
     return out
 
 

--- a/src/hal0/providers/llama_server.py
+++ b/src/hal0/providers/llama_server.py
@@ -45,7 +45,13 @@ log = logging.getLogger(__name__)
 # org provisioning"). Names are fixed now so the rest of the system can
 # wire against them; Phase 5 publishes digests into manifest.json.
 _HAL0_TOOLBOX_IMAGES = {
-    "vulkan": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1",
+    # v2 (b9279) reinstates per-slot ``n_prompt_tokens`` in /slots so the
+    # dashboard can surface a KV-cache % gauge (the legacy
+    # ``llamacpp:kv_cache_usage_ratio`` Prometheus metric never came back
+    # after the server.cpp refactor; we synthesise it from /slots in
+    # api/routes/slots.py:_scrape_llama_metrics). ROCm stays on :v1 until
+    # the matching rebuild lands.
+    "vulkan": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v2",
     "rocm": "ghcr.io/hal0ai/hal0-toolbox-rocm:v1",
 }
 
@@ -105,7 +111,7 @@ class LlamaServerProvider(Provider):
     """Provider for llama.cpp (llama-server) backends.
 
     Toolbox images (PLAN.md §12):
-      Vulkan: ghcr.io/hal0ai/hal0-toolbox-vulkan:v1
+      Vulkan: ghcr.io/hal0ai/hal0-toolbox-vulkan:v2
       ROCm:   ghcr.io/hal0ai/hal0-toolbox-rocm:v1
 
     Backend is selected by slot_cfg["backend"]: "vulkan" | "rocm" | "cpu".
@@ -326,7 +332,8 @@ class LlamaServerProvider(Provider):
              ``HAL0_TOOLBOX_IMAGE_VULKAN=ghcr.io/hal0ai/...@sha256:abc``
              materialised by the installer at first-run.
           3. ``_HAL0_TOOLBOX_IMAGES[backend]`` — the schema default
-             (``ghcr.io/hal0ai/hal0-toolbox-<backend>:v1``).
+             (``ghcr.io/hal0ai/hal0-toolbox-<backend>:v{1,2}`` — see
+             ``_HAL0_TOOLBOX_IMAGES`` for the current per-backend tags).
 
         Backends: "vulkan" | "rocm" | "cpu" (cpu falls through to vulkan
         since the vulkan image runs on cpu when no GPU is exposed).

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -565,3 +565,164 @@ async def test_state_stream_emits_sse_event_shape(
         assert payload["port"] == 8081
         # Close the generator so the SlotManager removes its subscriber.
         await agen.aclose()
+
+
+# ── _scrape_llama_metrics — Prometheus + /slots synthesis ────────────────────
+
+
+class _StubResponse:
+    """Minimal httpx.Response stand-in for the scrape tests.
+
+    Implements just the surface ``_scrape_llama_metrics`` reaches into:
+    ``status_code``, ``text``, ``json()``. Using a hand-rolled stub keeps
+    these tests free of network shims and lets us swap the httpx client
+    out with a one-line monkeypatch.
+    """
+
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        text: str = "",
+        json_data: Any = None,
+    ) -> None:
+        self.status_code = status_code
+        self.text = text
+        self._json = json_data
+
+    def json(self) -> Any:
+        if isinstance(self._json, Exception):
+            raise self._json
+        return self._json
+
+
+def _patch_httpx(monkeypatch: pytest.MonkeyPatch, metrics: _StubResponse, slots: _StubResponse):
+    """Patch httpx.AsyncClient used inside slots._scrape_llama_metrics.
+
+    Routes the two URLs the scrape hits to the supplied stubs and leaves
+    every other call short-circuited so an accidentally widened scrape
+    fails loudly in the test.
+    """
+
+    class _Client:
+        def __init__(self, *_a: Any, **_kw: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_Client":
+            return self
+
+        async def __aexit__(self, *_exc: Any) -> None:
+            return None
+
+        async def get(self, url: str) -> _StubResponse:
+            if url.endswith("/metrics"):
+                return metrics
+            if url.endswith("/slots"):
+                return slots
+            raise AssertionError(f"unexpected scrape URL: {url}")
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+
+
+@pytest.mark.asyncio
+async def test_scrape_llama_metrics_synthesises_kv_from_slots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Newer llama-server (b9279+) drops kv_cache_usage_ratio from
+    /metrics but still exposes per-slot n_prompt_tokens + n_ctx in
+    /slots; the scrape should synthesise ``kv_cache_usage`` as
+    max(n_prompt_tokens) / n_ctx."""
+    from hal0.api.routes.slots import _scrape_llama_metrics
+
+    metrics_text = (
+        "# HELP llamacpp:requests_processing gauge\n"
+        "# TYPE llamacpp:requests_processing gauge\n"
+        "llamacpp:requests_processing 1\n"
+        "llamacpp:requests_deferred 0\n"
+    )
+    slots_json = [
+        {"id": 0, "n_ctx": 4096, "is_processing": False},
+        {"id": 1, "n_ctx": 4096, "is_processing": True, "n_prompt_tokens": 2048},
+    ]
+    _patch_httpx(
+        monkeypatch,
+        _StubResponse(text=metrics_text),
+        _StubResponse(json_data=slots_json),
+    )
+
+    out = await _scrape_llama_metrics(8081)
+    assert out["requests_processing"] == 1
+    assert out["requests_deferred"] == 0
+    # 2048 / 4096 = 0.5
+    assert out["kv_cache_usage"] == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_scrape_llama_metrics_prefers_native_ratio_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If a future llama.cpp reintroduces ``llamacpp:kv_cache_usage_ratio``
+    we use the native gauge as-is and skip the /slots synthesis."""
+    from hal0.api.routes.slots import _scrape_llama_metrics
+
+    metrics_text = (
+        "llamacpp:requests_processing 0\n"
+        "llamacpp:requests_deferred 0\n"
+        "llamacpp:kv_cache_usage_ratio 0.73\n"
+    )
+    # /slots would otherwise synthesise 0.25; the native gauge should win.
+    slots_json = [{"id": 0, "n_ctx": 4096, "n_prompt_tokens": 1024}]
+    _patch_httpx(
+        monkeypatch,
+        _StubResponse(text=metrics_text),
+        _StubResponse(json_data=slots_json),
+    )
+
+    out = await _scrape_llama_metrics(8081)
+    assert out["kv_cache_usage"] == pytest.approx(0.73)
+
+
+@pytest.mark.asyncio
+async def test_scrape_llama_metrics_omits_kv_when_slots_idle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Idle /slots payload (no n_prompt_tokens on any sub-slot) leaves
+    ``kv_cache_usage`` absent so the UI renders '—' rather than 0%."""
+    from hal0.api.routes.slots import _scrape_llama_metrics
+
+    metrics_text = "llamacpp:requests_processing 0\nllamacpp:requests_deferred 0\n"
+    slots_json = [
+        {"id": 0, "n_ctx": 4096, "is_processing": False},
+        {"id": 1, "n_ctx": 4096, "is_processing": False},
+    ]
+    _patch_httpx(
+        monkeypatch,
+        _StubResponse(text=metrics_text),
+        _StubResponse(json_data=slots_json),
+    )
+
+    out = await _scrape_llama_metrics(8081)
+    assert out.get("requests_processing") == 0
+    assert "kv_cache_usage" not in out
+
+
+@pytest.mark.asyncio
+async def test_scrape_llama_metrics_clamps_overrun(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """n_prompt_tokens can briefly exceed n_ctx during shift; clamp the
+    synthesised ratio at 1.0 instead of surfacing >100%."""
+    from hal0.api.routes.slots import _scrape_llama_metrics
+
+    metrics_text = "llamacpp:requests_processing 1\n"
+    slots_json = [{"id": 0, "n_ctx": 4096, "n_prompt_tokens": 5000}]
+    _patch_httpx(
+        monkeypatch,
+        _StubResponse(text=metrics_text),
+        _StubResponse(json_data=slots_json),
+    )
+
+    out = await _scrape_llama_metrics(8081)
+    assert out["kv_cache_usage"] == pytest.approx(1.0)

--- a/tests/providers/test_llama_server.py
+++ b/tests/providers/test_llama_server.py
@@ -373,7 +373,7 @@ def test_render_systemd_override_emits_full_docker_line(
     # bind-mount for the model file
     assert "/var/lib/hal0/models:/var/lib/hal0/models" in out
     # image + ENTRYPOINT args (llama-server flags)
-    assert "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1" in out
+    assert "ghcr.io/hal0ai/hal0-toolbox-vulkan:v2" in out
     assert "--model" in out
     assert "--port 8081" in out or "--port" in out
     assert "-ngl" in out


### PR DESCRIPTION
## Summary

The dashboard's KV-cache % tile (added in #109/feat/dashboard-ttft-kv) stayed `—` because:

1. The bundled `ghcr.io/hal0ai/hal0-toolbox-vulkan:v1` runs llama.cpp commit `59778f0` (pre-server.cpp refactor) — no `n_prompt_tokens` field in `/slots`.
2. Even on current llama.cpp `master`, the legacy `llamacpp:kv_cache_usage_ratio` Prometheus gauge was **removed** and never reinstated — confirmed by inspecting `tools/server/server-context.cpp` on master today.

This PR ships **Path B** from the brief:

- **Toolbox v2** — `packaging/toolbox/vulkan.Dockerfile` now pins `LLAMA_CPP_REF=b9279` (latest stable tag at time of PR — 2026-05-22). Built image is `ghcr.io/hal0ai/hal0-toolbox-vulkan:v2` (585 MB; 4 MB smaller than v1).
- **Scrape synthesis** — `_scrape_llama_metrics` now fans `/metrics` + `/slots` out in parallel and synthesises `kv_cache_usage = max(n_prompt_tokens) / n_ctx` when the native gauge is absent. Result is clamped to `[0, 1]` (n_prompt_tokens briefly exceeds n_ctx during shift). If a future llama.cpp reintroduces the native gauge, it wins.
- **Provider ref bump** — `_HAL0_TOOLBOX_IMAGES["vulkan"]` → `:v2`. ROCm stays on `:v1` until its rebuild lands separately.
- **Tests** — four new unit tests in `tests/api/test_slots_routes.py` cover the synthesis path, native-gauge preference, idle omission, and overrun clamp. The existing `tests/providers/test_llama_server.py` image-ref assertion bumped to `:v2`.

## End-to-end verification

Built v2 locally on hal0-dev, transferred to the hal0 LXC via `docker save | ssh hal0 docker load`, swapped the `primary` slot to v2, and fired a streaming chat request:

**Before** (primary on v1 image, with the new scrape code already deployed):
```
{
  "name": "primary",
  "mem_rss_mb": 2748.21,
  "uptime_seconds": 58260,
  "requests_processing": 0,
  "requests_deferred": 0
}
```

**After** (primary on v2, mid-stream 1500-token completion against a 4096-ctx slot):
```
{
  "name": "primary",
  "mem_rss_mb": 609.62,
  "uptime_seconds": 41,
  "requests_processing": 1,
  "requests_deferred": 0,
  "kv_cache_usage": 0.083251953125
}
```

**After completion**:
```
{
  "name": "primary",
  ...
  "requests_processing": 0,
  "kv_cache_usage": 0.37158203125
}
```

(Other slots still on `:v1` toolboxes correctly omit `kv_cache_usage` and the UI will render `—` until they're rebuilt too.)

## Test plan

- [x] `pytest tests/api/test_slots_routes.py tests/providers/test_llama_server.py` — 53 pass
- [x] Verify `kv_cache_usage` appears in `/api/slots/metrics` for primary slot during/after a streaming request (see capture above)
- [x] Confirm v2 image is running: `docker inspect hal0-slot-primary --format '{{.Config.Image}}'` → `ghcr.io/hal0ai/hal0-toolbox-vulkan:v2`
- [x] Confirm new llama-server version: `docker exec hal0-slot-primary /opt/llama-vulkan/llama-server --version` → `version: 1 (47c0eda)` (b9279 tag)
- [ ] **NEEDED**: `docker push ghcr.io/hal0ai/hal0-toolbox-vulkan:v2` — local push failed for auth reasons on both hal0-dev and the LXC (no GHCR token configured). The image is sitting on the LXC ready to go; CI (`.github/workflows/toolbox.yml`) will publish it on next workflow run, or push manually once auth is set up.
- [ ] Once published, confirm a fresh pull on a clean host resolves the same digest.

## Judgement calls

- **Pinned to `b9279`** (latest tag at PR open, 2026-05-22). It was 1 hour old at time of pick. The Dockerfile's default `ARG LLAMA_CPP_REF` was also bumped from `master` to `b9279` so reproducible builds without --build-arg get the same content.
- **Scrape parallelism** — chose to add the second HTTP call (vs. local tracker / Path C) because it's stateless, provider-agnostic, and the existing 500ms timeout still covers both round-trips comfortably on loopback.
- **ROCm toolbox left on `:v1`** — same fix needs the same rebuild for the ROCm image, but that's out of scope per the brief (and the build matrix uses a different base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)