### PR TITLE
fix(toolbox-vulkan): install curl in runtime so HEALTHCHECK works

### DIFF
--- a/packaging/toolbox/vulkan.Dockerfile
+++ b/packaging/toolbox/vulkan.Dockerfile
@@ -102,6 +102,11 @@ ARG DEBIAN_FRONTEND=noninteractive
 #                         explicitly so the runtime contract is obvious)
 # - libgomp1            : OpenMP runtime — llama.cpp threads
 # - libcurl4            : runtime side of LLAMA_CURL=ON
+# - curl                : the CLI binary — needed by HEALTHCHECK below.
+#                         libcurl4 alone gives us the library; without
+#                         this the container reports `unhealthy` forever
+#                         ("/bin/sh: 1: curl: not found") even when the
+#                         server is serving fine.
 # - libc++ / libstdc++  : C++ runtime (already in ubuntu:24.04 base, but
 #                         libstdc++6 listed defensively)
 # - ca-certificates     : HTTPS for curl-backed model fetch
@@ -111,6 +116,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libvulkan1 \
         libgomp1 \
         libcurl4 \
+        curl \
         libstdc++6 \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*


### PR DESCRIPTION
## Summary

- Add `curl` to the runtime stage of `packaging/toolbox/vulkan.Dockerfile`.
- The existing `HEALTHCHECK` directive runs `curl -fsS http://127.0.0.1:\$PORT/v1/models`, but the runtime image only installed `libcurl4` (the library), not the CLI binary.
- Result before this fix: every container reports `unhealthy` forever with `/bin/sh: 1: curl: not found` while `llama-server` itself is serving fine. Caught while bringing the b9279 rebuild up on the primary slot post-#124.

Pre-existing Dockerfile bug — not introduced by #124, just newly visible.

## Test plan

- [x] `apt-cache show curl` confirms ~1MB image-size impact, no other deps.
- [ ] CI's `toolbox.yml` rebuilds + publishes vulkan with the fix (same chain as #124).
- [ ] Once published, on the primary slot host: `docker inspect hal0-slot-primary --format '{{.State.Health.Status}}'` reports `healthy` after one healthcheck interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)