### PR TITLE
fix(dispatcher): refresh model_cache when slots transition to ready

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -6,7 +6,9 @@ For tests and alternate entrypoints, call `create_app()`.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 
 import structlog
@@ -120,6 +122,44 @@ async def _autoregister_slot_upstreams(
 # routes ``model: "embed-gemma"`` to nowhere. Seed the cache explicitly.
 _FLM_EMBED_TAG = "embed-gemma"
 _FLM_ASR_TAG = "whisper-v3:turbo"
+
+
+async def _refresh_model_cache_on_ready(
+    event_bus: EventBus,
+    upstreams: UpstreamRegistry,
+    fetch_and_cache: Callable[[Upstream], Awaitable[list[str]]],
+) -> None:
+    """Re-fetch ``model_cache[slot]`` whenever a slot transitions to ready.
+
+    The cache backs ``Dispatcher.dispatch`` Step 2 passthrough. When a slot's
+    loaded GGUF changes (model swap, restart with a new config), the cache
+    must follow — otherwise the dispatcher matches by stale ids and routes
+    ``/v1/chat/completions`` to whichever slot last advertised that filename.
+    SlotManager already emits ``slot.state`` events; subscribing here keeps
+    the cache aligned without coupling the manager to app state.
+    """
+    async with event_bus.subscribe() as q:
+        while True:
+            event = await q.get()
+            if event.get("type") != "slot.state":
+                continue
+            data = event.get("data") or {}
+            if data.get("to") != "ready":
+                continue
+            slot_name = data.get("slot")
+            if not isinstance(slot_name, str) or not slot_name:
+                continue
+            upstream = upstreams.get(slot_name)
+            if upstream is None:
+                continue
+            try:
+                await fetch_and_cache(upstream)
+            except Exception as exc:  # pragma: no cover — defensive
+                log.warning(
+                    "model_cache.refresh_failed",
+                    slot=slot_name,
+                    error=str(exc),
+                )
 
 
 async def _seed_multiplex_models(
@@ -395,10 +435,20 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     managers = getattr(app.state, "mcp_session_managers", []) or []
 
+    refresh_task = asyncio.create_task(
+        _refresh_model_cache_on_ready(event_bus, upstreams, _fetch_and_cache)
+    )
+
+    async def _stop_refresh_task() -> None:
+        refresh_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await refresh_task
+
     try:
         async with AsyncExitStack() as stack:
             for mgr in managers:
                 await stack.enter_async_context(mgr.run())
+            stack.push_async_callback(_stop_refresh_task)
             yield
     finally:
         await slot_manager.stop_idle_monitor()

--- a/tests/api/test_model_cache_refresh.py
+++ b/tests/api/test_model_cache_refresh.py
@@ -1,0 +1,197 @@
+"""Regression test for the stale-model_cache slot-routing bug.
+
+A slot's GGUF can change between process start and the next request
+(model swap, restart with a new config). The dispatcher's Step 2
+passthrough match is keyed on ``app.state.model_cache[slot_name]``;
+if that cache isn't refreshed when the slot's loaded model changes,
+``POST /v1/chat/completions {"model": <new gguf>}`` matches against
+whichever stale slot still advertises that filename and lands on the
+wrong upstream.
+
+The bug observed on the live box:
+
+    slot=nano       model_cache=["Qwen3.5-0.8B-UD-Q4_K_XL.gguf"]  ← primary's CURRENT gguf
+    slot=primary    model_cache=["NousResearch_Hermes-4-14B-Q5_K_M.gguf"]  ← stale
+
+    POST /v1/chat/completions {"model": "Qwen3.5-0.8B-UD-Q4_K_XL.gguf"}
+    → response.model = "Qwen3-Zro-Cdr-Reason-V2-…F16.gguf"  ← served by nano
+
+This test pins the fix: ``_refresh_model_cache_on_ready`` subscribes
+to ``slot.state`` events and re-fetches /v1/models for any slot that
+transitions to ``ready``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hal0.api import _refresh_model_cache_on_ready
+from hal0.events import EventBus
+from hal0.upstreams.registry import Upstream, UpstreamRegistry
+
+
+class FakeUpstreamRegistry(UpstreamRegistry):
+    def __init__(self, upstreams: list[Upstream]) -> None:
+        super().__init__()
+        self._store = {u.name: u for u in upstreams}
+
+    def list(self) -> list[Upstream]:  # type: ignore[override]
+        return list(self._store.values())
+
+    def get(self, name: str) -> Upstream | None:  # type: ignore[override]
+        return self._store.get(name)
+
+
+def _make_slot(name: str) -> Upstream:
+    return Upstream(name=name, kind="slot", url=f"http://127.0.0.1:8000/{name}/v1", slot_name=name)
+
+
+@pytest.mark.asyncio
+async def test_ready_event_refreshes_stale_cache_for_that_slot() -> None:
+    """slot.state ready → ``fetch_and_cache`` runs against that slot's upstream."""
+    bus = EventBus()
+    primary = _make_slot("primary")
+    nano = _make_slot("nano")
+    upstreams = FakeUpstreamRegistry([primary, nano])
+
+    # Cache starts cross-wired (the pathological state from the live box).
+    cache: dict[str, list[str]] = {
+        "primary": ["stale-primary.gguf"],
+        "nano": ["wrong-but-matches-primary.gguf"],
+    }
+    # New advertised set after the slots actually start.
+    advertised: dict[str, list[str]] = {
+        "primary": ["primary-current.gguf"],
+        "nano": ["nano-current.gguf"],
+    }
+
+    async def fetch_and_cache(u: Upstream) -> list[str]:
+        cache[u.name] = list(advertised[u.name])
+        return cache[u.name]
+
+    task = asyncio.create_task(_refresh_model_cache_on_ready(bus, upstreams, fetch_and_cache))
+    try:
+        # Wait for the subscriber to register before emitting.
+        await asyncio.sleep(0)
+        await bus.emit(
+            "slot.state", "info", "slot:primary", "primary: starting → ready",
+            data={"slot": "primary", "from": "starting", "to": "ready"},
+        )
+        # Yield the loop until the refresher has processed the event.
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            if cache["primary"] == ["primary-current.gguf"]:
+                break
+        assert cache["primary"] == ["primary-current.gguf"]
+        # nano wasn't transitioned, its (still wrong) cache must not move.
+        assert cache["nano"] == ["wrong-but-matches-primary.gguf"]
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_non_ready_transitions_do_not_refresh() -> None:
+    """Only the ready edge should trigger a re-fetch — starting/idle/error must not."""
+    bus = EventBus()
+    primary = _make_slot("primary")
+    upstreams = FakeUpstreamRegistry([primary])
+
+    cache: dict[str, list[str]] = {"primary": ["stale.gguf"]}
+    fetch_calls: list[str] = []
+
+    async def fetch_and_cache(u: Upstream) -> list[str]:
+        fetch_calls.append(u.name)
+        return cache[u.name]
+
+    task = asyncio.create_task(_refresh_model_cache_on_ready(bus, upstreams, fetch_and_cache))
+    try:
+        await asyncio.sleep(0)
+        for to_state in ("starting", "idle", "error", "offline"):
+            await bus.emit(
+                "slot.state", "info", "slot:primary", f"primary: ready → {to_state}",
+                data={"slot": "primary", "from": "ready", "to": to_state},
+            )
+        for _ in range(5):
+            await asyncio.sleep(0.01)
+        assert fetch_calls == []
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_event_for_unregistered_slot_is_ignored() -> None:
+    """A slot.state for a slot with no upstream entry must not crash the task."""
+    bus = EventBus()
+    upstreams = FakeUpstreamRegistry([])
+
+    fetch_calls: list[str] = []
+
+    async def fetch_and_cache(u: Upstream) -> list[str]:
+        fetch_calls.append(u.name)
+        return []
+
+    task = asyncio.create_task(_refresh_model_cache_on_ready(bus, upstreams, fetch_and_cache))
+    try:
+        await asyncio.sleep(0)
+        await bus.emit(
+            "slot.state", "info", "slot:ghost", "ghost: starting → ready",
+            data={"slot": "ghost", "from": "starting", "to": "ready"},
+        )
+        for _ in range(5):
+            await asyncio.sleep(0.01)
+        assert fetch_calls == []
+        assert not task.done()
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_exception_does_not_kill_refresher() -> None:
+    """A transient /v1/models fetch failure must not stop future refreshes."""
+    bus = EventBus()
+    primary = _make_slot("primary")
+    upstreams = FakeUpstreamRegistry([primary])
+
+    cache: dict[str, list[str]] = {"primary": ["stale.gguf"]}
+    fetch_calls: list[str] = []
+
+    async def fetch_and_cache(u: Upstream) -> list[str]:
+        fetch_calls.append(u.name)
+        if len(fetch_calls) == 1:
+            raise RuntimeError("simulated transient network failure")
+        cache[u.name] = ["primary-current.gguf"]
+        return cache[u.name]
+
+    task = asyncio.create_task(_refresh_model_cache_on_ready(bus, upstreams, fetch_and_cache))
+    try:
+        await asyncio.sleep(0)
+        ev_data = {"slot": "primary", "from": "starting", "to": "ready"}
+        await bus.emit("slot.state", "info", "slot:primary", "1st", data=ev_data)
+        await bus.emit("slot.state", "info", "slot:primary", "2nd", data=ev_data)
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            if cache["primary"] == ["primary-current.gguf"]:
+                break
+        assert fetch_calls == ["primary", "primary"]
+        assert cache["primary"] == ["primary-current.gguf"]
+        assert not task.done()
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass

--- a/tests/api/test_model_cache_refresh.py
+++ b/tests/api/test_model_cache_refresh.py
@@ -24,6 +24,7 @@ transitions to ``ready``.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 
 import pytest
 
@@ -76,7 +77,10 @@ async def test_ready_event_refreshes_stale_cache_for_that_slot() -> None:
         # Wait for the subscriber to register before emitting.
         await asyncio.sleep(0)
         await bus.emit(
-            "slot.state", "info", "slot:primary", "primary: starting → ready",
+            "slot.state",
+            "info",
+            "slot:primary",
+            "primary: starting → ready",
             data={"slot": "primary", "from": "starting", "to": "ready"},
         )
         # Yield the loop until the refresher has processed the event.
@@ -89,10 +93,8 @@ async def test_ready_event_refreshes_stale_cache_for_that_slot() -> None:
         assert cache["nano"] == ["wrong-but-matches-primary.gguf"]
     finally:
         task.cancel()
-        try:
+        with contextlib.suppress(asyncio.CancelledError):
             await task
-        except asyncio.CancelledError:
-            pass
 
 
 @pytest.mark.asyncio
@@ -114,7 +116,10 @@ async def test_non_ready_transitions_do_not_refresh() -> None:
         await asyncio.sleep(0)
         for to_state in ("starting", "idle", "error", "offline"):
             await bus.emit(
-                "slot.state", "info", "slot:primary", f"primary: ready → {to_state}",
+                "slot.state",
+                "info",
+                "slot:primary",
+                f"primary: ready → {to_state}",
                 data={"slot": "primary", "from": "ready", "to": to_state},
             )
         for _ in range(5):
@@ -122,10 +127,8 @@ async def test_non_ready_transitions_do_not_refresh() -> None:
         assert fetch_calls == []
     finally:
         task.cancel()
-        try:
+        with contextlib.suppress(asyncio.CancelledError):
             await task
-        except asyncio.CancelledError:
-            pass
 
 
 @pytest.mark.asyncio
@@ -144,7 +147,10 @@ async def test_event_for_unregistered_slot_is_ignored() -> None:
     try:
         await asyncio.sleep(0)
         await bus.emit(
-            "slot.state", "info", "slot:ghost", "ghost: starting → ready",
+            "slot.state",
+            "info",
+            "slot:ghost",
+            "ghost: starting → ready",
             data={"slot": "ghost", "from": "starting", "to": "ready"},
         )
         for _ in range(5):
@@ -153,10 +159,8 @@ async def test_event_for_unregistered_slot_is_ignored() -> None:
         assert not task.done()
     finally:
         task.cancel()
-        try:
+        with contextlib.suppress(asyncio.CancelledError):
             await task
-        except asyncio.CancelledError:
-            pass
 
 
 @pytest.mark.asyncio
@@ -191,7 +195,5 @@ async def test_fetch_exception_does_not_kill_refresher() -> None:
         assert not task.done()
     finally:
         task.cancel()
-        try:
+        with contextlib.suppress(asyncio.CancelledError):
             await task
-        except asyncio.CancelledError:
-            pass


### PR DESCRIPTION
## Summary

Fixes the test-chat slot-routing bug observed on the live box: requesting **primary**'s loaded GGUF served back from **nano** (and vice versa).

`Dispatcher.dispatch` Step 2 passthrough matches against `app.state.model_cache[slot_name]`, but the cache was only populated by FLM multiplex seeding and the cold-prefetch path (gated to `kind=remote`). Local slots therefore never refreshed their cache after a model swap or post-restart adoption, so `POST /v1/chat/completions {"model": "<gguf>"}` matched whichever stale slot still advertised that filename.

`/v1/models` (live fetch) and `/api/slots` (cache view) diverged silently, so the dropdown looked correct while routing was inverted.

### Diagnosis snapshot (live state before fix)

| slot | actual loaded gguf | `model_cache[slot]` (dispatcher) |
|---|---|---|
| primary | `Qwen3.5-0.8B-UD-Q4_K_XL.gguf` | `NousResearch_Hermes-4-14B-Q5_K_M.gguf` |
| nano | `Qwen3-Zro-Cdr-Reason-V2-…F16.gguf` | `Qwen3.5-0.8B-UD-Q4_K_XL.gguf` ← primary's CURRENT |

Repro:
```
POST /v1/chat/completions {"model":"Qwen3.5-0.8B-UD-Q4_K_XL.gguf"}
→ response.model = "Qwen3-Zro-Cdr-Reason-V2-…F16.gguf"   # served by nano
```

### Fix

Subscribe a background task to the SlotManager event bus and re-fetch `/v1/models` for any slot transitioning to `ready`. The task lives inside the lifespan `AsyncExitStack` so it cancels cleanly on shutdown.

After fix:
```
POST … {"model":"Qwen3.5-0.8B-UD-Q4_K_XL.gguf"} → served by primary  ✓
POST … {"model":"Qwen3-Zro-Cdr-Reason-V2-…F16.gguf"} → served by nano ✓
```

## Test plan

- [x] New unit tests in `tests/api/test_model_cache_refresh.py`:
  - ready event refreshes that slot's cache
  - non-ready transitions (starting/idle/error/offline) do not trigger refresh
  - event for an unregistered slot is ignored (no crash)
  - transient fetch failures don't kill the refresher task
- [x] `pytest tests/dispatcher tests/api/test_smoke.py tests/api/test_v1_dispatch.py tests/api/test_slots_routes.py tests/api/test_model_cache_refresh.py` — 69 pass + 1 pre-existing failure (`test_decision_logging_runs_on_every_resolution`, unrelated to this change)
- [x] Manual end-to-end repro on hal0 LXC: both directions now route correctly post-restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)