### PR TITLE
feat(agents): hal0-hermes wrapper replaces upstream --hal0-config probe

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -35,8 +35,10 @@ The picker lives in **two places**:
 
 Step 7 of the first-run wizard offers `pi-coder`, `Hermes-Agent`, or
 "no agent". The pick fires `POST /api/agents/install` with the chosen
-name. The Hermes option is disabled (with a tooltip) when the host's
-Hermes upstream does not yet ship hal0-awareness.
+name. The Hermes option is disabled (with a tooltip) when upstream
+`hermes` is not on PATH — the hal0-owned wrapper requires the upstream
+binary to be installed first (`pip install --user hermes-agent` or
+`pipx install hermes-agent`).
 
 `install.sh` itself stays **non-interactive**. There is no `--agent`
 flag on the installer — the wizard is the only first-run entry point
@@ -118,20 +120,37 @@ cross-agent, cross-app.
 upstream (`badlogic/pi-mono`, since renamed to `earendil-works/pi`).
 We do not hold write access on the upstream, and owning the integration
 surface keeps the rebase tax predictable and symmetric with the
-upstream-owned Hermes-Agent path. The fork tracks latest with no patches
+hal0-owned Hermes wrapper path. The fork tracks latest with no patches
 applied yet; re-sync with `bash scripts/fork-pi-mono.sh`. Nightly smoke
 test (see below) catches upstream breakage.
 
-### Hermes-Agent — upstream-owned integration
+### Hermes-Agent — hal0-owned wrapper (`hal0-hermes`)
 
-The Hermes integration grows **upstream**. Hermes is user-owned;
-hal0-awareness lands in Hermes itself, not in a hal0-owned shim.
-hal0's `installer/agents/hermes-agent.sh` is a one-liner calling
-Hermes's own install command and pointing it at the local hal0 admin
-MCP endpoint. Hermes runs as `hal0-agent-hermes.service`.
+The Hermes integration is **a hal0-owned wrapper**, not an upstream
+change. The user cannot PR upstream NousResearch/hermes-agent, so
+hal0 ships `hal0-hermes` — a thin POSIX-shell wrapper installed by
+`hal0 agent install hermes` that sources `/etc/hal0/agents/hermes.env`
+(populating `HAL0_API_URL`, `HAL0_MCP_*_URL`, `HAL0_BEARER_TOKEN`)
+and then `exec`s the upstream `hermes` binary with the same argv.
+No upstream changes are required.
+
+- `installer/wrappers/hal0-hermes` — the wrapper itself (also responds
+  to `--hal0-ready` so the installer + driver can verify it's
+  functional without spawning upstream Hermes).
+- `installer/agents/hermes-agent.sh` — installs the wrapper to
+  `/usr/local/bin` (root) or `~/.local/bin` (user), then writes the
+  uninstall companion. Requires upstream `hermes` to already be on
+  PATH (`pip install --user hermes-agent` or `pipx install hermes-agent`).
+- `hal0.agents.hermes.HermesDriver` — Python driver. Probes the
+  wrapper before shelling out; raises `HermesUpstreamMissingError`
+  with an actionable hint if the wrapper isn't installed.
+
+Hermes runs as `hal0-agent-hermes.service`.
 
 Shape rule for future bundled agents: shim-first, promote to upstream
-integration when the upstream maintainer cooperates.
+integration when the upstream maintainer cooperates. Hermes is the
+worked example of "upstream won't cooperate" — wrapper is the
+fallback.
 
 ## Track-latest policy
 

--- a/docs/internal/adr/0004-agents.md
+++ b/docs/internal/adr/0004-agents.md
@@ -103,8 +103,11 @@ Server-side store the pending queue. Agent's MCP loop decide whether to wait syn
 ### 6. Ownership (asymmetric)
 
 - **pi-coder shim**: hal0 owns `installer/agents/pi-coder.sh`. Script install `pi-mono` upstream, install `pi-mcp-adapter` (a proxy-tool MCP routing layer — ~200 tokens per dispatch instead of dumping the full tool catalog into context), and leave `pi-memory-md` extension in place (project-scoped markdown memory, distinct from hal0's cross-app memory MCP per ADR-0005). Both memory layers coexist; they target different scopes.
-- **Hermes-Agent**: native hal0-awareness grow upstream. User own Hermes — the integration get done in Hermes itself, not in a shim. hal0's Hermes shim is a one-liner calling Hermes's own install command and pointing it at the local hal0 admin MCP endpoint.
-- **Default for future bundled agents**: shim-first. Promote to upstream integration when the upstream maintainer cooperate. Shim is the always-available fallback; native integration is the goal where reachable.
+- **Hermes-Agent**: hal0 owns a thin wrapper (`hal0-hermes`) that env-file-injects HAL0_* into upstream `hermes` on every invocation. The user CAN'T PR upstream NousResearch/hermes-agent, so the previous "native hal0-awareness grows upstream" plan is unreachable; the wrapper is hal0's integration seam instead. Wrapper files:
+    - `installer/wrappers/hal0-hermes` — POSIX shell, sources `$HAL0_ENV_FILE` (default `/etc/hal0/agents/hermes.env`) then `exec hermes "$@"`. Carries a `--hal0-ready` sentinel for installer smoke-test and driver probe.
+    - `installer/agents/hermes-agent.sh` — copies the wrapper to `/usr/local/bin` (root) or `~/.local/bin` (user), chmod 0755, smoke-tests `--hal0-ready`, drops an uninstall companion.
+    - `src/hal0/agents/hermes.py` — driver probes `shutil.which("hal0-hermes")` + `--hal0-ready` rc==0 before shelling out, then writes the canonical env file. No `--hal0-config` probe anymore.
+- **Default for future bundled agents**: shim-first. Promote to upstream integration when the upstream maintainer cooperate. Shim is the always-available fallback; native integration is the goal where reachable. Hermes is the worked example of "upstream maintainer won't cooperate" — wrapper is the answer.
 
 ### 7. Server-side hardening
 

--- a/installer/agents/hermes-agent.sh
+++ b/installer/agents/hermes-agent.sh
@@ -1,62 +1,115 @@
 #!/bin/sh
 # hal0 — Hermes-Agent bundled-agent installer (Phase 8, ADR-0004 §6).
 #
-# POSIX shell, dash-safe. One-liner that calls Hermes's own install
-# command — Hermes is user-owned upstream, hal0-awareness grows there
-# (ADR-0004 §6). This script is the shell mirror of the Python
-# driver's hal0-awareness gate.
+# POSIX shell, dash-safe. Installs the hal0-owned `hal0-hermes` wrapper
+# around upstream `hermes`. The wrapper is the env-file injector that
+# lets hal0 prewire HAL0_* into Hermes's process env WITHOUT requiring
+# any upstream changes — user can't PR upstream NousResearch/hermes-agent,
+# so the wrapper is hal0's integration seam.
 #
-# Inputs:
+# Flow:
+#   1. Verify upstream `hermes` is on PATH (else die with install hint).
+#   2. Pick install dir: /usr/local/bin if root, else ~/.local/bin.
+#   3. Copy installer/wrappers/hal0-hermes → <install_dir>/hal0-hermes (0755).
+#   4. Smoke-test: `hal0-hermes --hal0-ready` returns 0.
+#   5. Drop an uninstall companion under $HAL0_AGENT_DATA_DIR.
+#
+# The env file itself (/etc/hal0/agents/hermes.env) is written by the
+# Python driver (hal0.agents.hermes._write_env_file) AFTER this script
+# exits, so the call shape stays declarative here.
+#
+# Inputs (set by the Python driver; safe to override for manual runs):
 #   HAL0_AGENT_DATA_DIR  per-agent data dir (default:
 #                         /var/lib/hal0/agents/hermes)
 #   HAL0_API_URL         hal0 API base URL (default: http://127.0.0.1:8080)
 #   HAL0_BEARER_TOKEN    Bearer token (default: pulled from
 #                         /etc/hal0/tokens.toml, like pi-coder.sh)
-#
-# Side effects:
-#   - Verifies the local Hermes binary advertises hal0-awareness
-#     (--hal0-config flag OR HERMES_HAL0_READY=1) before doing anything.
-#   - Runs `hermes-agent install --hal0-config /etc/hal0/agents/hermes.env`.
-#     The env file itself is written by the Python driver after this
-#     script exits, so the call shape stays declarative here.
 
 set -eu
 
+# ── Logging ──────────────────────────────────────────────────────────────────
 info()  { printf '[hermes] %s\n' "$*"; }
 warn()  { printf '[hermes] WARN: %s\n' "$*" >&2; }
 die()   { printf '[hermes] ERROR: %s\n' "$*" >&2; exit 1; }
 
+# ── Defaults ─────────────────────────────────────────────────────────────────
 HAL0_AGENT_DATA_DIR="${HAL0_AGENT_DATA_DIR:-/var/lib/hal0/agents/hermes}"
 HAL0_API_URL="${HAL0_API_URL:-http://127.0.0.1:8080}"
 HAL0_BEARER_TOKEN="${HAL0_BEARER_TOKEN:-}"
 
 mkdir -p "$HAL0_AGENT_DATA_DIR"
 
-# ── hal0-awareness gate (mirrors hal0.agents.hermes._probe_hal0_awareness) ───
+# ── Upstream gate ────────────────────────────────────────────────────────────
 #
-# Both branches OR-ed: if either is satisfied, proceed. Failing here
-# is the *expected* path until Hermes upstream ships hal0-awareness.
+# We do NOT probe for hal0-awareness on the upstream binary anymore —
+# upstream Hermes never ships a `--hal0-config` flag and never will
+# (user can't PR upstream). Instead we just verify `hermes` is on PATH;
+# the wrapper carries the integration.
 
-probe_hermes_hal0_aware() {
-    if [ "${HERMES_HAL0_READY:-}" = "1" ]; then
-        return 0
-    fi
-    if ! command -v hermes-agent >/dev/null 2>&1; then
-        return 1
-    fi
-    # --help exit code may be non-zero on some builds; we only care
-    # about the text. Capture both streams.
-    if hermes-agent --help 2>&1 | grep -q -- '--hal0-config'; then
-        return 0
-    fi
-    return 1
-}
-
-if ! probe_hermes_hal0_aware; then
-    die "Hermes-Agent on this host does not ship hal0-awareness yet. Upgrade Hermes to a build that supports --hal0-config, or export HERMES_HAL0_READY=1 if you're testing an unreleased build. Tracking issue: Phase 8 milestone on https://github.com/Hal0ai/hal0."
+if ! command -v hermes >/dev/null 2>&1; then
+    die "upstream \`hermes\` not found on PATH. Install Hermes first: \
+\`pip install --user hermes-agent\` (or \`pipx install hermes-agent\`), \
+then re-run \`hal0 agent install hermes\`."
 fi
 
-# ── Token discovery (same shape as pi-coder.sh) ──────────────────────────────
+# ── Pick install dir ─────────────────────────────────────────────────────────
+#
+# Root → /usr/local/bin (LSB system binary location). Non-root →
+# ~/.local/bin (XDG user-local). The latter must be on PATH; we warn
+# but don't fail — the user may PATH-prepend it after the fact.
+
+if [ "$(id -u)" = "0" ]; then
+    INSTALL_DIR="/usr/local/bin"
+else
+    INSTALL_DIR="${HOME:-/root}/.local/bin"
+    mkdir -p "$INSTALL_DIR"
+    case ":${PATH:-}:" in
+        *":$INSTALL_DIR:"*) ;;
+        *) warn "$INSTALL_DIR is not on PATH — add it to your shell rc (\
+e.g. export PATH=\"\$HOME/.local/bin:\$PATH\")." ;;
+    esac
+fi
+
+# ── Resolve wrapper source ───────────────────────────────────────────────────
+#
+# This script lives at <repo>/installer/agents/hermes-agent.sh; the
+# wrapper source is its sibling at <repo>/installer/wrappers/hal0-hermes.
+# Resolve relative to $0 so the script works whether called via bash
+# or sourced from a different cwd.
+
+SCRIPT_DIR="$(cd "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)"
+WRAPPER_SRC="$SCRIPT_DIR/../wrappers/hal0-hermes"
+
+if [ ! -r "$WRAPPER_SRC" ]; then
+    die "wrapper source missing at $WRAPPER_SRC. This hal0 install \
+looks packaged without installer/wrappers/ — reinstall hal0 from a \
+release tarball or git clone."
+fi
+
+# ── Install wrapper ──────────────────────────────────────────────────────────
+WRAPPER_DST="$INSTALL_DIR/hal0-hermes"
+info "Installing hal0-hermes wrapper → $WRAPPER_DST"
+cp "$WRAPPER_SRC" "$WRAPPER_DST"
+chmod 0755 "$WRAPPER_DST"
+
+# ── Smoke-test ───────────────────────────────────────────────────────────────
+#
+# `--hal0-ready` short-circuits in the wrapper BEFORE exec'ing upstream
+# `hermes`. A zero rc confirms the wrapper is on PATH (or at least
+# resolvable via INSTALL_DIR), readable, and not corrupted in transit.
+
+info "Smoke-testing $WRAPPER_DST --hal0-ready"
+if ! "$WRAPPER_DST" --hal0-ready >/dev/null 2>&1; then
+    die "hal0-hermes wrapper failed --hal0-ready smoke test. Check \
+permissions on $WRAPPER_DST."
+fi
+
+# ── Token discovery (best-effort, same shape as pi-coder.sh) ─────────────────
+#
+# Surfaced via env file by the Python driver; we keep the discovery
+# here as a no-op for now so future shell-only invocations don't miss
+# the file. No-op in the sense that the driver re-discovers and writes
+# the canonical env file itself.
 if [ -z "$HAL0_BEARER_TOKEN" ] && [ -r /etc/hal0/tokens.toml ]; then
     HAL0_BEARER_TOKEN="$(
         awk '/^wire_token *= */ {gsub(/"/,"",$0); print $3; exit}' \
@@ -64,30 +117,20 @@ if [ -z "$HAL0_BEARER_TOKEN" ] && [ -r /etc/hal0/tokens.toml ]; then
     )"
 fi
 
-# ── Invoke Hermes's own install command ──────────────────────────────────────
+# ── Uninstall companion ──────────────────────────────────────────────────────
 #
-# The env file referenced here is *written by the Python driver*
-# (hal0.agents.hermes._write_env_file) after this script exits cleanly.
-# We pass the path so Hermes can wire its config to consume it on
-# first start.
+# installer/uninstall.sh's uninstall_agents() hook calls this.
+# Removes the wrapper from INSTALL_DIR + the env file from /etc/hal0.
 
-ENV_FILE="/etc/hal0/agents/hermes.env"
-info "Calling hermes-agent install --hal0-config $ENV_FILE"
-hermes-agent install --hal0-config "$ENV_FILE" \
-    || die "hermes-agent install failed — see Hermes-side logs"
-
-# Drop the uninstall companion so installer/uninstall.sh's
-# uninstall_agents() hook can find it.
 {
     printf '#!/bin/sh\n'
     printf '# hal0 — hermes uninstall companion (called from installer/uninstall.sh)\n'
     printf 'set -eu\n'
-    printf 'if command -v hermes-agent >/dev/null 2>&1; then\n'
-    printf '    hermes-agent uninstall 2>/dev/null || true\n'
-    printf 'fi\n'
+    printf 'rm -f %s 2>/dev/null || true\n' "$WRAPPER_DST"
     printf 'rm -f /etc/hal0/agents/hermes.env 2>/dev/null || true\n'
 } > "$HAL0_AGENT_DATA_DIR/uninstall.sh"
 chmod +x "$HAL0_AGENT_DATA_DIR/uninstall.sh"
 
-info "Install complete."
+info "Install complete. Wrapper at $WRAPPER_DST; env file will be \
+written by the hal0 driver at /etc/hal0/agents/hermes.env."
 exit 0

--- a/installer/wrappers/hal0-hermes
+++ b/installer/wrappers/hal0-hermes
@@ -1,0 +1,31 @@
+#!/bin/sh
+# hal0-hermes — env-file injector wrapper around upstream `hermes`.
+#
+# Sourced env-file injection lets hal0 own the hermes integration
+# WITHOUT touching upstream NousResearch/hermes-agent. The wrapper
+# loads HAL0_* + provider config from $HAL0_ENV_FILE (default
+# /etc/hal0/agents/hermes.env), then execs the upstream `hermes`
+# binary with the same argv.
+#
+# The `--hal0-ready` sentinel is consumed by the hal0 installer's
+# post-install smoke test (installer/agents/hermes-agent.sh) so the
+# install script can verify the wrapper is on PATH and functional
+# WITHOUT spawning the heavyweight upstream binary.
+
+set -eu
+
+HAL0_ENV_FILE="${HAL0_ENV_FILE:-/etc/hal0/agents/hermes.env}"
+
+if [ -r "$HAL0_ENV_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    # (path is operator-controlled by design)
+    . "$HAL0_ENV_FILE"
+    set +a
+fi
+
+case "${1:-}" in
+    --hal0-ready) exit 0 ;;
+esac
+
+exec hermes "$@"

--- a/src/hal0/agents/hermes.py
+++ b/src/hal0/agents/hermes.py
@@ -1,23 +1,26 @@
 """Hermes-Agent driver (ADR-0004 §6).
 
-Hermes is user-owned upstream. Native hal0-awareness grows on the
-Hermes side rather than via a hal0-owned shim. This driver is a
-one-liner: detect that upstream Hermes ships hal0-awareness, then
-invoke Hermes's own install command and write
-``/etc/hal0/agents/hermes.env``.
+Hermes is user-owned upstream — and crucially, the user cannot PR
+upstream NousResearch/hermes-agent. So hal0-awareness lives on the
+hal0 side, in a hal0-owned wrapper script (``hal0-hermes``) that
+sources ``/etc/hal0/agents/hermes.env`` and ``exec``s the upstream
+``hermes`` binary.
 
-The "hal0-awareness" probe is intentionally narrow: we look for a
-``--hal0-config`` flag on the Hermes binary (or an
-``HERMES_HAL0_READY=1`` env hint from a marker the upstream installer
-drops). Picking a probe with a concrete shape gives the user an
-actionable error when it fails — vs a vague "Hermes is incompatible"
-that lands them in a Slack thread.
+This driver's responsibilities:
 
-Until Hermes ships that surface, the install path raises
-:class:`HermesNotHal0AwareError` with the upstream issue link to
-follow. The shell script ``installer/agents/hermes-agent.sh`` mirrors
-the same gate at the shell level so a curl|bash invocation also
-short-circuits cleanly.
+1. Probe whether the ``hal0-hermes`` wrapper is installed and
+   functional (``--hal0-ready`` sentinel returns 0).
+2. Shell out to ``installer/agents/hermes-agent.sh`` to install the
+   wrapper if the user invokes this path manually.
+3. Write the canonical env file at ``/etc/hal0/agents/hermes.env``
+   that the wrapper sources on every hermes invocation.
+
+The "hal0-awareness" probe shifted: previously it checked the upstream
+binary for a ``--hal0-config`` flag that was never going to ship.
+Now it checks that the hal0-owned wrapper is on PATH and answers the
+``--hal0-ready`` probe. The shell script
+``installer/agents/hermes-agent.sh`` mirrors this gate at the shell
+level so a curl|bash invocation also short-circuits cleanly.
 """
 
 from __future__ import annotations
@@ -30,40 +33,51 @@ from pathlib import Path
 from hal0.agents.manager import (
     AgentDriver,
     AgentError,
-    HermesNotHal0AwareError,
-    installer_script_path,
+    HermesUpstreamMissingError,
 )
 from hal0.config import paths as _paths
 
-# Concrete probe surface — see module docstring. Both fire OR-ed; the
-# upstream maintainer needs to satisfy only one to flip the gate green.
-_HERMES_BIN_NAME = "hermes-agent"
-_HAL0_AWARE_FLAG = "--hal0-config"
-_HAL0_READY_ENV = "HERMES_HAL0_READY"
+# Hermes's installer script lives at ``installer/agents/hermes-agent.sh``
+# (not ``hermes.sh``) — kept as-is to avoid breaking the curl|bash
+# invocation contract the dashboard uses. We resolve it ourselves
+# rather than via :func:`installer_script_path`, which assumes
+# ``{name}.sh``.
+_INSTALLER_SCRIPT_REL = "installer/agents/hermes-agent.sh"
 
 
-def _probe_hal0_awareness() -> bool:
-    """Return True iff the local Hermes install advertises hal0-awareness.
+def _installer_script_path() -> Path:
+    # parents[0]=agents, [1]=hal0, [2]=src, [3]=repo root — same
+    # resolution shape as :func:`installer_script_path` in the manager.
+    repo_root = Path(__file__).resolve().parents[3]
+    return repo_root / _INSTALLER_SCRIPT_REL
 
-    OR of two cheap checks:
+# The wrapper binary name. Installed by installer/agents/hermes-agent.sh
+# to /usr/local/bin (root) or ~/.local/bin (user). Sourcing the env
+# file + exec'ing upstream `hermes` is the whole job.
+_WRAPPER_BIN_NAME = "hal0-hermes"
+_WRAPPER_READY_FLAG = "--hal0-ready"
 
-    1. ``HERMES_HAL0_READY=1`` env var present (upstream-installer hint).
-    2. ``hermes-agent --help`` mentions :data:`_HAL0_AWARE_FLAG`.
 
-    Both are runtime-only — no network calls. Failing on the host
-    (binary missing, --help non-zero) returns False so the caller raises
-    a clean error rather than the probe itself blowing up.
+def _probe_wrapper_installed() -> bool:
+    """Return True iff the hal0-hermes wrapper is installed and functional.
+
+    Two cheap checks, AND-ed:
+
+    1. ``shutil.which("hal0-hermes")`` resolves (wrapper is on PATH).
+    2. ``hal0-hermes --hal0-ready`` returns rc 0 (wrapper is readable,
+       executable, and not corrupted).
+
+    Both are runtime-only — no network calls. Wrapper missing or
+    smoke-test failing returns False so the caller raises a clean
+    error rather than the probe itself blowing up.
     """
-    if os.environ.get(_HAL0_READY_ENV) == "1":
-        return True
-
-    bin_path = shutil.which(_HERMES_BIN_NAME)
+    bin_path = shutil.which(_WRAPPER_BIN_NAME)
     if bin_path is None:
         return False
 
     try:
         result = subprocess.run(  # nosec B603 — known-safe argv
-            [bin_path, "--help"],
+            [bin_path, _WRAPPER_READY_FLAG],
             check=False,
             capture_output=True,
             timeout=5,
@@ -72,8 +86,7 @@ def _probe_hal0_awareness() -> bool:
     except (OSError, subprocess.SubprocessError):
         return False
 
-    haystack = (result.stdout or "") + (result.stderr or "")
-    return _HAL0_AWARE_FLAG in haystack
+    return result.returncode == 0
 
 
 class HermesDriver(AgentDriver):
@@ -84,24 +97,28 @@ class HermesDriver(AgentDriver):
     def __init__(self, *, runner: object | None = None, prober: object | None = None) -> None:
         # ``runner`` parallels :class:`PiCoderDriver` — tests inject a
         # fake subprocess. ``prober`` lets tests force the
-        # hal0-awareness gate without needing a real Hermes on PATH.
+        # wrapper-installed gate without needing a real hal0-hermes on PATH.
         self._runner = runner if runner is not None else subprocess
-        self._prober = prober if prober is not None else _probe_hal0_awareness
+        self._prober = prober if prober is not None else _probe_wrapper_installed
 
     # ── AgentDriver protocol ────────────────────────────────────────────
 
     def install(self, *, bearer_token: str | None = None) -> None:
+        # Probe FIRST: the wrapper must be installed and functional
+        # before we shell out. The shell installer
+        # (installer/agents/hermes-agent.sh) is the bootstrap path for
+        # the wrapper itself — driver.install() is the "rewire the
+        # env file with a fresh Bearer token" path, and it refuses
+        # to wire an env file the wrapper can't source.
         if not self._prober():
-            raise HermesNotHal0AwareError(
-                "Hermes-Agent on this host does not yet ship hal0-awareness. "
-                "Either upgrade Hermes to a build that supports the "
-                f"{_HAL0_AWARE_FLAG!r} flag, or export "
-                f"{_HAL0_READY_ENV}=1 if you're testing an unreleased build. "
-                "Track upstream progress at "
-                "https://github.com/Hal0ai/hal0/issues (Phase 8 milestone)."
+            raise HermesUpstreamMissingError(
+                "hal0-hermes wrapper not found or not functional. Run "
+                "`installer/agents/hermes-agent.sh` as root or via "
+                "`hal0 agent install hermes`. Requires upstream `hermes` "
+                "on PATH (pip install --user hermes-agent)."
             )
 
-        script = installer_script_path(self.name)
+        script = _installer_script_path()
         if not script.is_file():
             raise AgentError(
                 f"installer script missing at {script}. This hal0 install looks "
@@ -127,9 +144,9 @@ class HermesDriver(AgentDriver):
         except Exception as exc:
             raise AgentError(f"hermes-agent install failed ({type(exc).__name__}: {exc}).") from exc
 
-        # Write the env file Hermes will source on startup. Single
-        # source of truth for the API URL + Bearer the agent uses to
-        # reach hal0.
+        # Write the env file the wrapper sources on every hermes
+        # invocation. Single source of truth for the API URL + Bearer
+        # the agent uses to reach hal0.
         self._write_env_file(bearer_token=bearer_token)
 
     def uninstall(self) -> None:
@@ -148,7 +165,8 @@ class HermesDriver(AgentDriver):
     def _env_file_path(self) -> Path:
         # ADR-0004 §6: "writes /etc/hal0/agents/hermes.env". Lives in
         # /etc so the user/admin can tweak it without disturbing
-        # /var/lib state, same posture as openwebui.env.
+        # /var/lib state, same posture as openwebui.env. The wrapper
+        # sources this file on every hermes invocation.
         return _paths.etc() / "agents" / "hermes.env"
 
     def _write_env_file(self, *, bearer_token: str | None) -> None:

--- a/src/hal0/agents/hermes.py
+++ b/src/hal0/agents/hermes.py
@@ -51,6 +51,7 @@ def _installer_script_path() -> Path:
     repo_root = Path(__file__).resolve().parents[3]
     return repo_root / _INSTALLER_SCRIPT_REL
 
+
 # The wrapper binary name. Installed by installer/agents/hermes-agent.sh
 # to /usr/local/bin (root) or ~/.local/bin (user). Sourcing the env
 # file + exec'ing upstream `hermes` is the whole job.

--- a/src/hal0/agents/manager.py
+++ b/src/hal0/agents/manager.py
@@ -52,11 +52,19 @@ class AgentAlreadyInstalledError(AgentError):
     to atomically swap."""
 
 
-class HermesNotHal0AwareError(AgentError):
-    """Raised by the Hermes driver when the upstream Hermes build does not
-    yet ship hal0-awareness (ADR-0004 §6). Install path refuses with a
-    clean actionable message rather than half-wiring something that will
-    not work."""
+class HermesUpstreamMissingError(AgentError):
+    """Raised by the Hermes driver when the hal0-owned ``hal0-hermes``
+    wrapper is not installed or not functional (ADR-0004 §6). The
+    wrapper is hal0's integration seam against upstream
+    NousResearch/hermes-agent; install path refuses to wire an env file
+    the wrapper can't source rather than half-wiring something that
+    will not work."""
+
+
+# Back-compat alias for the pre-wrapper-pivot error class. Existing
+# callers in ``hal0.api.routes.agents`` (Team CloseOut surface) catch
+# the old name; keep the symbol live until that surface migrates.
+HermesNotHal0AwareError = HermesUpstreamMissingError
 
 
 # ── Bundled catalog ──────────────────────────────────────────────────────────

--- a/tests/agents/test_hermes_wrapper.py
+++ b/tests/agents/test_hermes_wrapper.py
@@ -1,0 +1,238 @@
+"""Unit tests for hal0.agents.hermes.HermesDriver (wrapper pivot).
+
+The driver no longer probes upstream `hermes-agent --help` for a
+`--hal0-config` flag (which was never going to ship — the user cannot
+PR upstream NousResearch/hermes-agent). Instead it probes for the
+hal0-owned `hal0-hermes` wrapper that env-file-injects HAL0_* into
+upstream `hermes` on every invocation.
+
+These tests mirror the shape of ``tests/agents/test_pi_coder_shim.py``:
+fake subprocess + fake prober, so the suite stays hermetic — no real
+upstream binary, no real wrapper-on-PATH dependency.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.agents.hermes import HermesDriver
+from hal0.agents.manager import AgentError, HermesUpstreamMissingError
+
+# ── Fake subprocess ──────────────────────────────────────────────────────────
+
+
+class _FakeCompleted:
+    returncode = 0
+
+
+class _FakeRunner:
+    """Replaces ``subprocess`` for the driver. Records every ``run()``
+    call so tests can assert on argv + env without spawning a real
+    shell."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._fail = fail
+
+    def run(
+        self,
+        argv: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        check: bool = False,
+    ) -> _FakeCompleted:
+        self.calls.append({"argv": list(argv), "env": dict(env or {}), "check": check})
+        if self._fail:
+            raise RuntimeError("fake subprocess failure")
+        return _FakeCompleted()
+
+
+# ── Fake prober ──────────────────────────────────────────────────────────────
+
+
+def _prober_ok() -> bool:
+    """Prober that reports wrapper installed + functional."""
+    return True
+
+
+def _prober_missing() -> bool:
+    """Prober that reports wrapper missing or non-functional."""
+    return False
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def driver(tmp_hal0_home: str) -> HermesDriver:
+    """Driver with default subprocess + a wrapper-installed prober.
+
+    ``tmp_hal0_home`` (autouse'd via the project conftest) routes
+    ``/var/lib/hal0`` and ``/etc/hal0`` under tmp_path so the env file
+    writes don't escape the sandbox.
+
+    Tests that need the wrapper-missing branch override
+    ``driver._prober`` per-test.
+    """
+    return HermesDriver(prober=_prober_ok)
+
+
+# ── install: wrapper-missing short-circuit ───────────────────────────────────
+
+
+def test_install_raises_when_wrapper_missing_before_shelling_out(
+    tmp_hal0_home: str,
+) -> None:
+    """If the hal0-hermes wrapper isn't on PATH (or its --hal0-ready
+    probe fails), driver.install() raises HermesUpstreamMissingError
+    BEFORE invoking the installer script. We assert this by injecting
+    a runner that records calls — it should record zero."""
+    runner = _FakeRunner()
+    drv = HermesDriver(runner=runner, prober=_prober_missing)
+
+    with pytest.raises(HermesUpstreamMissingError, match="hal0-hermes wrapper"):
+        drv.install(bearer_token="hal0_tok_xyz")
+
+    assert runner.calls == [], "installer script must NOT be shelled out when wrapper probe fails"
+
+
+def test_install_error_message_points_to_installer_and_upstream_hermes(
+    tmp_hal0_home: str,
+) -> None:
+    """Error message must tell the operator both how to install the
+    wrapper AND that upstream `hermes` is a prerequisite. Avoids the
+    'Hermes is incompatible' vague-error Slack thread."""
+    drv = HermesDriver(runner=_FakeRunner(), prober=_prober_missing)
+    with pytest.raises(HermesUpstreamMissingError) as exc:
+        drv.install(bearer_token=None)
+    msg = str(exc.value)
+    assert "installer/agents/hermes-agent.sh" in msg
+    assert "hal0 agent install hermes" in msg
+    assert "hermes" in msg  # upstream binary mention
+
+
+# ── install: happy path ──────────────────────────────────────────────────────
+
+
+def test_install_shells_out_to_installer_script_when_wrapper_present(
+    driver: HermesDriver,
+    tmp_hal0_home: str,
+) -> None:
+    runner = _FakeRunner()
+    driver._runner = runner  # type: ignore[assignment]
+
+    driver.install(bearer_token="hal0_tok_xyz")
+
+    assert len(runner.calls) == 1
+    argv = runner.calls[0]["argv"]
+    assert argv[0] == "bash"
+    assert argv[1].endswith("/installer/agents/hermes-agent.sh")
+    env = runner.calls[0]["env"]
+    assert env["HAL0_BEARER_TOKEN"] == "hal0_tok_xyz"
+    assert env["HAL0_AGENT_DATA_DIR"].endswith("/agents/hermes")
+    assert env["HAL0_API_URL"].startswith("http")
+
+
+def test_install_writes_env_file_with_expected_keys(
+    driver: HermesDriver,
+    tmp_hal0_home: str,
+) -> None:
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token="hal0_tok_xyz")
+
+    env_file = Path(tmp_hal0_home) / "etc" / "hal0" / "agents" / "hermes.env"
+    assert env_file.exists()
+    body = env_file.read_text(encoding="utf-8")
+    # The wrapper sources this file via `set -a; . "$HAL0_ENV_FILE"; set +a`,
+    # so the contents must be POSIX env-file shape: KEY=VALUE per line.
+    assert "HAL0_API_URL=http" in body
+    assert "HAL0_MCP_ADMIN_URL=" in body
+    assert "/mcp/admin" in body
+    assert "HAL0_MCP_MEMORY_URL=" in body
+    assert "/mcp/memory" in body
+    assert "HAL0_BEARER_TOKEN=hal0_tok_xyz" in body
+
+
+def test_install_omits_bearer_when_no_token_passed(
+    driver: HermesDriver,
+    tmp_hal0_home: str,
+) -> None:
+    """Auth-disabled dev installs don't surface a token — env file
+    must not include the HAL0_BEARER_TOKEN line in that case."""
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token=None)
+
+    env_file = Path(tmp_hal0_home) / "etc" / "hal0" / "agents" / "hermes.env"
+    body = env_file.read_text(encoding="utf-8")
+    assert "HAL0_BEARER_TOKEN" not in body
+
+
+# ── install: subprocess failure surfaces as AgentError ───────────────────────
+
+
+def test_install_subprocess_failure_raises_agent_error(
+    driver: HermesDriver,
+    tmp_hal0_home: str,
+) -> None:
+    driver._runner = _FakeRunner(fail=True)  # type: ignore[assignment]
+    with pytest.raises(AgentError, match="hermes-agent install failed"):
+        driver.install(bearer_token="tok")
+
+
+# ── install: idempotency ─────────────────────────────────────────────────────
+
+
+def test_install_rerun_overwrites_env_file(
+    driver: HermesDriver,
+    tmp_hal0_home: str,
+) -> None:
+    """Re-running install with a fresh token rewrites the env file
+    atomically; no append/dup behaviour."""
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token="tok-1")
+    env_file = Path(tmp_hal0_home) / "etc" / "hal0" / "agents" / "hermes.env"
+
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token="tok-2")
+    body = env_file.read_text(encoding="utf-8")
+    assert "HAL0_BEARER_TOKEN=tok-2" in body
+    assert "HAL0_BEARER_TOKEN=tok-1" not in body
+
+
+# ── uninstall removes env file ───────────────────────────────────────────────
+
+
+def test_uninstall_removes_env_file(driver: HermesDriver, tmp_hal0_home: str) -> None:
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token="tok")
+    env_file = Path(tmp_hal0_home) / "etc" / "hal0" / "agents" / "hermes.env"
+    assert env_file.exists()
+
+    driver.uninstall()
+    assert not env_file.exists()
+
+
+def test_uninstall_is_idempotent(driver: HermesDriver) -> None:
+    """Calling uninstall when nothing's installed must not raise."""
+    driver.uninstall()  # no env file yet — should be a no-op
+    driver.uninstall()  # twice — still a no-op
+
+
+# ── status reflects env file presence ────────────────────────────────────────
+
+
+def test_status_returns_installed_iff_env_file_exists(
+    driver: HermesDriver,
+    tmp_hal0_home: str,
+) -> None:
+    assert driver.status() == "broken"  # no install yet
+
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token="tok")
+    assert driver.status() == "installed"
+
+    driver.uninstall()
+    assert driver.status() == "broken"


### PR DESCRIPTION
## Summary

- New `installer/wrappers/hal0-hermes` POSIX shell wrapper (31 LOC) — sources `\$HAL0_ENV_FILE` (default `/etc/hal0/agents/hermes.env`), execs upstream \`hermes\`, supports \`--hal0-ready\` probe sentinel
- Rewrote \`installer/agents/hermes-agent.sh\` (136 LOC) — drops \`--hal0-config\` upstream probe; verifies upstream \`hermes\` on PATH; installs wrapper to \`/usr/local/bin\` (root) or \`~/.local/bin\` (user)
- Rewrote \`src/hal0/agents/hermes.py\` (186 LOC) — \`_probe_wrapper_installed\` via \`shutil.which("hal0-hermes")\` + \`subprocess.run([bin, "--hal0-ready"]).returncode == 0\`
- Renamed \`HermesNotHal0AwareError\` → \`HermesUpstreamMissingError\` (with backwards-compat alias in \`manager.py\` so \`api/routes/agents.py\` keeps working)
- New \`tests/agents/test_hermes_wrapper.py\` (238 LOC, 10 tests) — probe-first short-circuit, error msg shape, happy path argv/env, env-file keys, no-token branch, subprocess failure, idempotent rerun, uninstall, idempotent uninstall, status flow
- Updated \`docs/internal/adr/0004-agents.md\` §6 + \`docs/api/agents.md\`

## Why

User does NOT have write access to \`NousResearch/hermes-agent\`. Original Phase 8 design assumed upstream PR could land \`--hal0-config\` flag. Cannot. Pivot: hal0 owns env-file injection in a thin wrapper, exec's unmodified upstream \`hermes\`. Probe becomes "is hal0-hermes on PATH" — zero upstream changes required.

## Test plan

- [x] \`pytest tests/agents/test_hermes_wrapper.py -xvs\` (10 pass)
- [x] \`pytest tests/agents/ -xvs\` (29 pass — no regression in pi-coder/manager tests)
- [x] \`ruff check\` clean
- [x] \`shellcheck\` clean
- [x] Wrapper smoke test: \`hal0-hermes --hal0-ready\` returns rc=0
- [ ] Live LXC install (Stream E)

## Coordination notes

- Sequence: merge AFTER \`feat/pi-mono-fork\` (#TBD) but BEFORE \`feat/phase-8-closeout\` (#TBD)
- After this merges, \`feat/phase-8-closeout\`'s \`tests/agents/test_hermes_driver.py\` will break (it tests old \`_probe_hal0_awareness\` shape) — Team CloseOut's tests will need cleanup. Old shape replaced by tests in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)