### PR TITLE
docs: Lemonade migration strategy — ADRs + spike + runbook + slot definition

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,7 +27,7 @@ The embedded memory engine adopted from v0.2 (Apache 2.0). Defaults: SQLite + La
 
 ## dataset (Cognee)
 
-Cognee's namespace primitive. hal0's namespace rule (v0.2): default `shared` for all clients; per-client `--private` toggle promotes that client's writes to `private:<client_id>`. Multi-user revisits the rule in Phase 9 (ADR-0006 pending). See ADR-0005 §3.
+Cognee's namespace primitive. hal0's namespace rule (v0.2): default `shared` for all clients; per-client `--private` toggle promotes that client's writes to `private:<client_id>`. Multi-user revisits the rule in Phase 9 (future ADR pending — ADR-0006 was reassigned to Lemonade migration). See ADR-0005 §3.
 
 ## MCP server (hal0-exposed)
 
@@ -62,9 +62,22 @@ Overloaded THREE ways. Default to sense (3) in hal0 product context.
 
 (Possible Phase 9+ stretch: agent-side skills in the `cognee-integrations/openclaw-skills` style — `SKILL.md` + YAML frontmatter + self-improving loop. If we ever ship that, it's a separate noun and gets its own gloss entry.)
 
+## device
+
+Per-slot hardware preference in v0.2. Field on `SlotConfig` replacing v0.1.x's overloaded `backend` field (which mixed providers and backends). Enum: `gpu-rocm` | `gpu-vulkan` | `cpu` | `npu`. Default for new installs: `gpu-rocm`. `LemonadeProvider` maps this to Lemonade's recipe:backend pair internally (e.g. `gpu-rocm` → `llamacpp:rocm`, `npu` → `flm:npu`).
+
+Note: spike data showed `gpu-vulkan` is much slower than `gpu-rocm` for Strix Halo through Lemonade — likely user-facing UI should advise `gpu-rocm` as the recommended default and label `gpu-vulkan` as fallback.
+
 ## slot
 
-Existing concept (PLAN.md §2). `hal0-slot@.service` template unit, parameterized by slot name. Runs a model under a provider. NOT a memory or RAG primitive — slots serve inference, memory lives in `/mcp/memory`.
+A named, configured serving target — e.g. `primary`, `embed`, `embed-rerank`, `stt`, `tts`. NOT a memory or RAG primitive — slots serve inference, memory lives in `/mcp/memory`.
+
+Two sub-senses depending on release:
+
+1. **v0.1.x slot (current)** — `hal0-slot@.service` systemd template unit, parameterized by slot name. Owns a process + port + container under a Provider class (PLAN.md §2).
+2. **v0.2 slot (with Lemonade)** — a logical mapping from slot name to ONE Lemonade-loaded model. The per-slot systemd template retires; `lemond` is the single shared process. Slot state (`ready`/`idle`/`serving`) is derived from `/v1/health.loaded[]` by model_name lookup. User-facing UX unchanged. See ADR-0006 (pending).
+
+`SlotManager.start(slot)` in v0.2 calls Lemonade load semantics rather than starting a systemd unit. Slot identity persists in `capabilities.toml` and the user-facing surface; the runtime layer is the Lemonade pool.
 
 ## two-tier scope
 

--- a/docs/internal/adr/0006-migrate-inference-to-lemonade.md
+++ b/docs/internal/adr/0006-migrate-inference-to-lemonade.md
@@ -1,0 +1,95 @@
+# ADR 0006 — Migrate inference to Lemonade Server (v0.2)
+
+- **Status:** Draft
+- **Date:** 2026-05-22
+- **Drivers:** /grill-me + /grill-with-docs sessions 2026-05-22; spike findings (`docs/internal/lemonade-spike-findings-2026-05-22.md`); plan doc (`docs/internal/lemonade-migration-plan.md`)
+- **Supersedes:** Per-modality toolbox architecture from PLAN.md §2 (six Dockerfiles + Provider classes)
+
+## Context
+
+- hal0 v0.1.x ships six per-modality toolbox containers (vulkan, rocm, flm, moonshine, kokoro, comfyui), each wrapped by a `Provider` subclass. Maintenance burden, version-skew tracking, and per-modality publish pipelines consume disproportionate time.
+- AMD ships **Lemonade Server** (Apache 2.0, github.com/lemonade-sdk/lemonade) — an officially-supported, embeddable inference server that bundles llama.cpp (ROCm + Vulkan + CPU), FLM (NPU), whisper.cpp, sd-cpp, kokoro under one process with OpenAI/Ollama/Anthropic-compatible APIs.
+- Spike 2026-05-22 validated Lemonade on hal0 LXC 105 (Strix Halo gfx1151). Results: works; perf parity-to-regression depending on model (hermes-14b at parity, qwen3.5-0.8b -18%, qwen3.6-35b -13% on ROCm); Vulkan-in-Lemonade is 3x slower than hal0's Vulkan baseline.
+
+## Options considered
+
+| Option | Reason accepted / rejected |
+|---|---|
+| **Keep status quo** — maintain six toolboxes | Rejected — maintenance burden is a recurring tax; upstream AMD has a better-resourced solution |
+| **Lemonade as one provider among many** | Rejected — leaves maintenance burden untouched; "Lemonade option" is not the goal |
+| **Partial replacement** (Lemonade for LLM only; keep toolboxes for embed/rerank/ASR/TTS/img) | Rejected pre-spike; spike data argues this is now a fallback option if v0.2 PRs hit hard regressions |
+| **Total replacement** with Lemonade for all modalities | ACCEPTED — captures full maintenance gain; supported by Lemonade's actual modality coverage on Linux |
+
+## Decision
+
+### 1. Total provider replacement
+Lemonade is the sole inference backend in v0.2. The six per-modality Provider classes retire. A single `LemonadeProvider` implementing the existing `Provider` ABC drives load/unload/health via Lemonade's HTTP API.
+
+### 2. Slot abstraction preserved at user-facing layer
+Each hal0 slot (`primary`, `embed`, `embed-rerank`, `stt`, `tts`, `img`) remains a named, configured serving target with a chosen model + device. Runtime layer changes: slot = 1 Lemonade-loaded model rather than 1 systemd template instance + 1 container. `SlotManager.start(slot)` calls Lemonade load semantics; slot state derives from `/v1/health.loaded[]` by model_name. `hal0-slot@.service` template retires.
+
+### 3. Drive method: HTTP-first
+hal0 talks to Lemonade via `/v1/load`, `/v1/unload`, `/v1/health`, `/v1/pull`, `/v1/chat/completions`, `/v1/embeddings`, `/v1/reranking`, `/v1/audio/transcriptions`, `/v1/audio/speech`, `/v1/images/generations`. `LemonadeClient` (`src/hal0/lemonade/client.py`) wraps these. CLI subprocess (`lemonade load X`) is a bootstrap fallback in early PRs until `/v1/load` schema is reverse-engineered (research handoff pending).
+
+### 4. Model registration via hal0-customized `server_models.json`
+At install time hal0 generates `server_models.json` from `/var/lib/hal0/registry/registry.toml` and writes it into Lemonade's resources directory. Curated catalog with explicit type metadata per entry (llm/embedding/reranking/transcription/image/tts). Runtime user adds go via `POST /v1/pull` with `user.*` namespace + type. Spike confirmed Lemonade's bundled `server_models.json` does not include hal0's curated picks (e.g. `hermes-4-14b`, `qwen3-coder-next-reap-40b-a3b`).
+
+### 5. Process supervision: containerized lemond in systemd
+`/etc/systemd/system/lemond.service` runs `podman/docker run --device=/dev/dri --device=/dev/accel/accel0` with `Restart=on-failure RestartSec=5s`. Boot-enabled (always-running). hal0-api `Wants=lemond.service` (soft dep). This combines systemd's standard supervision (Restart, journal, watchdog) with container isolation hal0 already uses.
+
+### 6. Container source: hal0-published wrapper image
+`ghcr.io/hal0ai/hal0-lemond:vX.Y.Z`. Base + lemond tarball + `apt install unzip libxrt-npu2` (system deps Lemonade requires) + pre-pulled backends (`llamacpp:rocm`, `flm:npu`, `whispercpp:cpu`, `sdcpp:rocm`, `kokoro:cpu`). CI build + cosign sign. Replaces six per-modality toolbox images with one multi-backend image. (AMD does not currently publish an official docker image suitable for hal0's needs — research handoff confirms.)
+
+### 7. `SlotConfig.backend` → `SlotConfig.device`
+Schema refactor. Old `backend` field mixed providers and backends (`vulkan|rocm|flm|moonshine|kokoro|cpu`). New `device` field is hardware-preference only: `gpu-rocm | gpu-vulkan | cpu | npu`. Default `gpu-rocm`. `LemonadeProvider` maps `device` to Lemonade's `recipe:backend` pair internally. `capabilities.toml` schema_version bumps to 2; auto-migration preserves user choices.
+
+### 8. UI rework deferred to v0.2.1
+v0.2 ships minimal UI patch (retarget API client to new endpoints; preserve all Vue components/views). v0.2.1 ships UI rework informed by `docs/dev/web-ui.md` research (pending handoff at `/tmp/hal0-lemonade-research-handoff.md`). Vue/Pinia/Tailwind stack stays; brand wordmark and Playwright suite preserved.
+
+### 9. Metrics shim via `/v1/stats` polling
+Spike confirmed Lemonade's bundled llama-server returns 501 on `/metrics`. Backend_url scrape strategy (PR #124 path) does not survive the migration. hal0 builds a metrics aggregator (`src/hal0/lemonade/metrics.py`) that polls `/v1/stats` (last-request perf) and `/v1/health` (model state) per slot, exposes Prometheus surface for the dashboard.
+
+### 10. Version pinning + bundling
+`manifest.json` schema v2 adds `lemonade: { image, digest, version }`. Updates gated behind explicit hal0 release. install.sh pulls + cosign-verifies. Lemonade ships breaking changes weekly; pinning is non-negotiable.
+
+### 11. Rollback
+Downgrade-only via existing update mechanism (`hal0 update --version v0.1.x`). v0.2 deletes old Provider code cleanly — no long-term feature-flag plumbing. Schema_version=2 → 1 downgrade preserves a `.v1.bak` of capabilities.toml on upgrade.
+
+### 12. PR sequence: flag-gated incremental + atomic cutover
+Each PR adds capability behind `HAL0_BACKEND=lemonade` env var while v0.1.x code paths stay default. Sequence at `lemonade-migration-plan.md` §PR sequence. Atomic cutover PR flips default + deletes old Provider classes. v0.1.x patch releases stay shippable from main until cutover.
+
+## Consequences
+
+**Wins:**
+- Six toolbox Dockerfiles + publish pipelines retire → one hal0-lemond image
+- Multi-modal coverage in one process (LLM + embed + rerank + ASR + TTS + img + NPU)
+- Newer llama.cpp build via AMD's release train (rather than hal0's pinned b9279)
+- AMD legitimacy for v1.0 positioning
+- Standard systemd supervision replaces fragile per-slot template + adoption logic
+
+**Losses / regressions:**
+- Performance: parity-to-regression vs hal0-Vulkan baseline (-13% to -18% on tested models; hermes-14b at parity)
+- ComfyUI workflows lost — sdpp covers 90% case; power-users directed to external ComfyUI
+- GPU-accelerated Kokoro TTS (Lemonade's kokoro is CPU-only on Linux); pending spike validation
+- Moonshine ASR (lighter on weak CPUs) → whispercpp (more accurate, heavier)
+- New install.sh deps: `unzip`, `libxrt-npu2`
+
+**Operational risks (mitigated separately):**
+- Nuclear evict-all on load failure → see ADR-0007
+- Serialized load queue can deadlock under stuck load → hal0-side `/v1/load` timeout
+- Weekly Lemonade breaking releases → pin discipline (decision §10)
+
+## Open questions deferred to research handoff
+
+- `/v1/load` actual request schema (CLI works; direct curl rejected)
+- Lemonade WS protocol shape (`/logs/stream` + others) for v0.2.1 UI
+- Omni recipe pattern — may inform `capabilities.toml` design
+- Reserved-args extension hooks (server_models.json field set)
+
+Research handoff: `/tmp/hal0-lemonade-research-handoff.md`. Findings land in `docs/internal/lemonade-repo-deep-dive-2026-05-22.md`.
+
+## Related
+
+- ADR-0007 — Nuclear-evict-all mitigation (tactical)
+- ADR-0001 — Auth boundary (hal0 Bearer token survives unchanged; Lemonade has its own `LEMONADE_API_KEY` for internal hal0→lemond traffic only)
+- ADR-0002, ADR-0003 — Capability overlay + slot-capabilities field (preserved; only the provider behind a capability changes)

--- a/docs/internal/adr/0007-nuclear-evict-all-mitigation.md
+++ b/docs/internal/adr/0007-nuclear-evict-all-mitigation.md
@@ -1,0 +1,95 @@
+# ADR 0007 — Nuclear-evict-all mitigation (Lemonade)
+
+- **Status:** Draft
+- **Date:** 2026-05-22
+- **Drivers:** Spike findings 2026-05-22; ADR-0006 §Operational risks
+- **Scope:** v0.2 Lemonade migration only — does not apply to v0.1.x toolbox era
+
+## Context
+
+Lemonade's `Router` ([github.com/lemonade-sdk/lemonade `src/cpp/Multi-Model-Spec.md`](https://github.com/lemonade-sdk/lemonade/blob/main/src/cpp/Multi-Model-Spec.md)) implements an evict-on-failure policy:
+
+> "If a WrappedServer load fails (with exceptions noted below), all WrappedServers of every type are evicted, and the load is re-attempted. This 'nuclear' policy simplifies implementation while remaining effective in practice. **Exception:** Models are not evicted if the load failed because a file was not found on disk."
+
+**Confirmed live in spike 2026-05-22.** Server log verbatim: `"Load failed with non-file-not-found error, evicting all models and retrying..."`. Observed twice during a single spike session.
+
+For hal0 v0.2 this means: any `/v1/load` failure (corrupted GGUF, model file path mismatch, llama.cpp incompatibility, OOM, GPU driver hiccup) blasts every loaded model. In prod, a single bad model selection during the day unloads every warm slot.
+
+## Options considered
+
+| Option | Reason accepted / rejected |
+|---|---|
+| **Accept the behavior** | Rejected — every slot dropping mid-day on a single bad pull is a user-visible failure mode |
+| **Wrap `/v1/load` in retry loop, hope for the best** | Rejected — re-attempt doesn't help if the underlying cause is structural (corrupted file, OOM) |
+| **Patch Lemonade upstream to make the policy configurable** | Deferred — worth proposing upstream but not on v0.2 critical path |
+| **Pre-validate before `/v1/load`** | ACCEPTED — steer failures into the file-not-found branch (the one Lemonade explicitly exempts from evict-all) |
+
+## Decision
+
+### 1. Pre-validation guards before every `/v1/load`
+
+Implemented in `src/hal0/lemonade/preload.py`:
+
+```python
+def preload_validate(slot_cfg, model_entry) -> None:
+    """Raises PreloadError BEFORE we POST /v1/load. Better the slot stays
+    offline than the whole pool blasted."""
+    # 1. File exists at registry path
+    if not Path(model_entry.path).is_file():
+        raise PreloadError.FILE_NOT_FOUND(model_entry.path)
+
+    # 2. sha256 matches registry (catches partial downloads, corruption)
+    if sha256_file(model_entry.path) != model_entry.sha256:
+        raise PreloadError.CHECKSUM_MISMATCH(model_entry.path)
+
+    # 3. Size matches registry
+    if Path(model_entry.path).stat().st_size != model_entry.size_bytes:
+        raise PreloadError.SIZE_MISMATCH(model_entry.path)
+
+    # 4. GGUF magic byte sanity check
+    if not is_valid_gguf(model_entry.path):
+        raise PreloadError.NOT_A_GGUF(model_entry.path)
+```
+
+### 2. SlotManager surfaces `PreloadError` as slot state `error`, NOT a `/v1/load` attempt
+
+When `preload_validate` raises, SlotManager:
+- Sets slot state to `error` with explicit error class
+- Does NOT call `lemonade_client.load()`
+- Dashboard surfaces `error: checksum_mismatch` etc.
+- Other slots remain loaded — blast radius = this slot only
+
+### 3. Race exception explicitly documented
+
+If validation passes at T0 and the file disappears between T0 and `/v1/load` arriving at lemond, we hit evict-all anyway. Accept the small race window; pre-validation reduces blast radius from "any bad load" to "file deleted in the millisecond between validate and load". Worst case is bounded by the actual file delete pattern (rare in prod).
+
+### 4. NO retry loop wrapping `/v1/load`
+
+If Lemonade returns 500 on `/v1/load`, SlotManager records error and stops. Retry doesn't help if the cause is structural, and retrying GUARANTEES another evict-all if cause was non-file-not-found.
+
+### 5. Hard timeout on `/v1/load`
+
+Lemonade documents serialized loading + indefinite pending-load queue. SlotManager wraps `lemonade_client.load()` with a hard timeout (default 120s, configurable). Timeout → record `PreloadError.LOAD_TIMEOUT`, do NOT retry, surface in dashboard.
+
+## Consequences
+
+**Wins:**
+- Blast radius reduced from "any non-file-not-found failure" to "raced file delete" (rare)
+- Slot errors surface with explicit, actionable messages
+- Dashboard can show pre-validation status BEFORE attempting Lemonade load
+- Mitigation lives in hal0 code — no upstream PR dependency
+
+**Losses:**
+- Pre-validation adds latency to slot start (sha256 + GGUF check ~100ms for 14B Q5)
+- hal0 carries explicit knowledge of model integrity that Lemonade arguably should own
+- Hardcoded assumption that file-not-found is the only safe failure mode — if Lemonade changes the exemption list, mitigation needs revisit
+
+**Maintenance:**
+- Watch Lemonade CHANGELOG for changes to evict-on-failure policy
+- If AMD makes the policy configurable upstream, swap mitigation for a config flag
+
+## Related
+
+- ADR-0006 — Lemonade migration (parent decision)
+- Operational hazard observed in spike: `docs/internal/lemonade-spike-findings-2026-05-22.md` §Negative findings/risks/Operational
+- Memory: `hal0_lemonade_gotchas` (item 1 — nuclear evict-all)

--- a/docs/internal/lemonade-migration-plan.md
+++ b/docs/internal/lemonade-migration-plan.md
@@ -1,0 +1,155 @@
+# hal0 → Lemonade Server Migration Plan
+
+**Status:** Post-spike, post-impl-grilling 2026-05-22. Architectural + impl decisions locked. Web-UI rework pending research handoff (`/tmp/hal0-lemonade-research-handoff.md`). v0.2 PR sequence ready to start.
+
+**Vehicle:** hal0 v0.2 (Lemonade + Agents per parallel session). UI rework deferred to v0.2.1.
+
+**Source artifacts:**
+- Spike findings: `lemonade-spike-findings-2026-05-22.md`
+- Spike runbook: `lemonade-spike-runbook.md`
+- Research handoff (pending): `/tmp/hal0-lemonade-research-handoff.md`
+- Memories: `hal0_lemonade_migration_v0.2`, `hal0_lemonade_gotchas`
+
+---
+
+## Drivers (post-spike reassessment)
+
+1. ✓ Eliminate per-modality toolbox maintenance burden — still wins
+2. ⚠ NPU + iGPU utilization — NPU path broken at spike time (FLM silent fail; libxrt absent), needs install.sh prereq handling
+3. ✓ Stop chasing llama.cpp churn — still wins (AMD pins llamacpp-rocm builds per channel)
+4. ✓ Strategic AMD legitimacy — still wins
+5. ✗ Performance — **evaporated**. Spike: hermes-14b at parity, qwen3.5-0.8b -18%, qwen3.6-35b MoE -13% on ROCm. Vulkan-in-Lemonade is 3x slower than hal0-Vulkan baseline.
+
+Migration still net-positive on the surviving drivers, but the perf narrative needs honest framing in release notes.
+
+---
+
+## Strategic decisions
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | Replacement scope | Total — `lemond` is the only backend |
+| 2 | Spike host (executed) | LXC 105 alongside live hal0 |
+| 3 | NPU strategy | `lemonade backends install flm` at install + install.sh handles libxrt-npu2 prereq |
+| 4 | vLLM-ROCm | Out of scope this cycle — re-evaluate post-v0.2 |
+| 5 | Release vehicle | v0.2 (combined with Agents per parallel session work) |
+| 6 | UI rework | Punt to v0.2.1 pending web-ui.md research |
+| 7 | Bundling + pin | manifest.json schema v2 adds `lemonade: { image, digest, version }` |
+| 8 | Rollback | Downgrade-only via existing update mechanism; v0.2 deletes old Provider code cleanly |
+| 9 | ComfyUI loss | Accepted — sdpp covers 90%; release-notes documented |
+
+## Implementation decisions
+
+| # | Decision | Choice |
+|---|---|---|
+| 10 | Slot abstraction | Preserve. Each hal0 slot = 1 Lemonade-loaded model. SlotManager retargets to Lemonade load/unload. Per-slot `hal0-slot@.service` retires. |
+| 11 | Drive method | HTTP-first /v1/load with reverse-engineered schema (research lands it). `lemonade` CLI subprocess as bootstrap fallback. |
+| 12 | Model registration | Generate hal0-customized `server_models.json` from `registry.toml` at install. Runtime user adds via /v1/pull `user.*` namespace. |
+| 13 | Process supervision | Containerized lemond in systemd. `/etc/systemd/system/lemond.service` wraps `podman/docker run` with `--device` passthrough. Boot-enabled. |
+| 14 | Container source | `ghcr.io/hal0ai/hal0-lemond:vX.Y.Z` — hal0-published wrapper. Base + lemond tarball + `unzip` + `libxrt-npu2` + pre-pulled backends. CI builds + cosign-signs. |
+| 15 | `SlotConfig.backend` | Refactor → `SlotConfig.device` (enum `gpu-rocm \| gpu-vulkan \| cpu \| npu`). Default `gpu-rocm`. Schema_version bump + migration. |
+| 16 | Metrics shim | `/v1/stats` polling (backend_url /metrics returned 501 in spike). hal0-side metrics aggregator polls `/v1/stats` + `/v1/health` per slot. |
+| 17 | Idle-eviction driver | hal0-owned external. SlotManager polls `/v1/health.loaded[].last_use`, calls `POST /v1/unload` when stale per existing 300s policy. |
+| 18 | Nuclear-evict-all mitigation | Pre-validate file existence + sha256 BEFORE `/v1/load`. Steers failures into file-not-found path (the one exempt from evict-all). |
+| 19 | PR sequencing | Flag-gated incremental (`HAL0_BACKEND=lemonade`); main always shippable; atomic cutover PR. |
+
+---
+
+## ADRs (planned)
+
+- **ADR-0006** Migrate inference to Lemonade Server (strategic): covers decisions 1-15. The big arc.
+- **ADR-0007** Nuclear-evict-all mitigation (tactical): covers decision 18, the operational hazard observed live in spike.
+
+ADRs 0007+ for multi-user Cognee, prior plan, are renumbered to 0008+ as needed.
+
+---
+
+## Retirements in v0.2
+
+**Code:**
+- `src/hal0/providers/llama_server.py`, `flm.py`, `moonshine.py`, `kokoro.py`, `comfyui.py`
+- Hardcoded port + metric-name logic in `src/hal0/api/routes/slots.py` `_scrape_llama_metrics()`
+- `hal0-slot@.service` systemd template
+
+**Toolbox infrastructure:**
+- `hal0-toolbox-{vulkan,rocm,flm,moonshine,kokoro,comfyui}` Dockerfiles
+- `.github/workflows/toolbox.yml` publish pipelines
+
+**Host state:**
+- `/opt/hal0/flm-ubuntu` (if exists — spike found it absent)
+- `/var/lib/hal0/flm-models` (replaced by Lemonade model store)
+
+---
+
+## Additions in v0.2
+
+**New code:**
+- `src/hal0/providers/lemonade.py` — single Provider class
+- `src/hal0/lemonade/client.py` — HTTP client (with CLI bootstrap fallback)
+- `src/hal0/lemonade/server_models_gen.py` — registry.toml → server_models.json converter
+- `src/hal0/lemonade/metrics.py` — /v1/stats poller exposing Prometheus surface
+- `src/hal0/lemonade/idle.py` — idle-unload driver
+- Pre-validation logic in load path (sha256 + file-exists checks)
+
+**New config:**
+- `manifest.json` schema v2 with `lemonade: { image, digest, version }`
+- `/var/lib/hal0/lemonade/config.json` template emitted by hal0
+- `capabilities.toml` schema_version = 2 (preserve v1 backup for downgrade)
+- `SlotConfig.device` field (replaces `backend`)
+
+**install.sh changes:**
+- `apt install -y unzip libxrt-npu2` (system deps Lemonade requires)
+- Pull `ghcr.io/hal0ai/hal0-lemond:vX.Y.Z` image
+- Write `/etc/systemd/system/lemond.service`
+- `systemctl enable --now lemond`
+- Generate + install `server_models.json` from registry
+- Stop installing per-modality docker images
+
+**New CI:**
+- `hal0-lemond` image build workflow (replaces six toolbox workflows)
+- Cosign signing per release
+
+---
+
+## PR sequence (preliminary; refined as research lands)
+
+1. **ADR-0006 + ADR-0007 drafts** — written from this session's decisions; tightened post-research
+2. **`LemonadeClient` skeleton** — HTTP client with CLI fallback, type stubs only
+3. **manifest.json schema v2** — `lemonade: {...}` field, validation, `HAL0_BACKEND=lemonade` flag plumbing
+4. **`hal0-lemond` image** — Dockerfile + GH workflow + cosign + publish to ghcr.io
+5. **`lemond.service`** — install.sh writes systemd unit + container-run command + device passthrough
+6. **`server_models_gen.py`** — registry.toml → server_models.json converter + install hook
+7. **`SlotConfig.device`** — schema refactor + capabilities.toml schema_version=2 migration
+8. **`LemonadeProvider`** — concrete provider implementing Provider ABC, drives `LemonadeClient`
+9. **Pre-load validation** — sha256 + file-exists guards before /v1/load (ADR-0007 mitigation)
+10. **`/v1/stats` metrics poller** — Prometheus surface from Lemonade stats
+11. **Idle-unload driver** — SlotManager poll loop calling /v1/unload
+12. **install.sh changes** — apt deps, image pull, service enable, server_models.json install
+13. **Capability orchestrator** — switch `apply()` to drive new SlotManager flow
+14. **`hal0 capabilities migrate-to-lemonade`** — schema migration command (also auto-run on hal0-api upgrade)
+15. **Cutover PR** — flip default backend to Lemonade + delete old Provider code + retire `hal0-slot@.service` template
+16. **Toolbox cleanup** — delete six Dockerfiles, six workflows, hal0-toolbox repos archived
+
+Each PR shippable as v0.1.x patch until #15. UI work skipped; lives in v0.2.1.
+
+---
+
+## Open items deferred to research handoff
+
+- `/v1/load` actual request schema (CLI works; direct curl rejected docs body)
+- Lemonade WS protocol (used by v0.2.1 UI rework)
+- Omni recipe pattern (collection.omni — may inform capability mapping)
+- Whether AMD publishes an official docker image for lemonade (informs container source decision)
+- Reserved-args extension hook (some args may be configurable via server_models.json, not yet known)
+- Pre-load validation hooks (does Lemonade itself expose pre-load validation? Or must hal0 wrap?)
+
+## Operational risks (verbatim from spike)
+
+- **Nuclear evict-all on load failure** — confirmed live. ADR-0007 mitigation.
+- **Serialized load queue** — Lemonade loads one model at a time, pending loads queue indefinitely. Hard timeout at hal0 level.
+- **Weekly upstream breaking changes** — pin discipline non-negotiable.
+- **`unzip` system dep** — install.sh prereq.
+- **libxrt-npu2 absent** in current LXC; install.sh prereq for NPU path.
+- **/metrics returns 501** on bundled llama-server — fallback to /v1/stats poll confirmed needed.
+- **Default backend pick = Vulkan** (slow). Every load must specify `--llamacpp rocm` or equivalent config.
+- **/v1/load API field shape** undocumented; CLI works.

--- a/docs/internal/lemonade-spike-findings-2026-05-22.md
+++ b/docs/internal/lemonade-spike-findings-2026-05-22.md
@@ -1,0 +1,83 @@
+# Lemonade Spike Findings — hal0 LXC 105 — 2026-05-22
+
+## Verdict (qualitative)
+
+Lemonade works on Strix Halo. Native gfx1151 ROCm binary present. But **perf and operational story is weaker than expected**, AND **modality coverage off-the-shelf is rougher than docs suggested**. Migration is feasible but value/cost ratio shifted. Worth re-grilling.
+
+## Perf table (vs 2026-05-22 baseline)
+
+| Model | Baseline (hal0 Vulkan) tok/s | Lemonade ROCm tok/s | Lemonade Vulkan tok/s | Delta vs baseline |
+|---|---|---|---|---|
+| qwen3.5-0.8b nano | 205 | 168 (warm) | 47-69 (variable) | ROCm -18% |
+| qwen3.6-35b-a3b MoE | 53 | 46 (warm) | not tested | ROCm -13% |
+| hermes-4-14b-q5_k_m (current primary) | 20 | 20.4 (warm) | not tested | **parity (+2%)** |
+| qwen3-coder-next-reap-40b | not benched | not benched | not benched | — |
+
+TTFT warm @ ROCm: 17-92ms across models. Load times 21s for qwen3.6-35b. GTT matches baseline (21.45 GiB for qwen3.6-35b, 11.09 GiB for hermes-14b).
+
+**Vulkan-in-Lemonade is much slower than hal0 Vulkan baseline.** Cause unknown — different llama.cpp version (b9253 vs b1274), `--no-mmap` default, different compile flags. ROCm path is the only viable backend.
+
+## Positive findings
+- Lemonade v10.6.0 installs and runs on LXC 105
+- gfx1151 native ROCm nightly build (b1274) installs cleanly (435 MB)
+- NPU hardware detected by Lemonade auto-discovery
+- Apache 2.0, OpenAI-compatible API, /v1/health includes backend_url per loaded model
+- hermes-4-14b PARITY on ROCm — current primary user-experience preserved
+- Strix Halo (gfx1151) first-class in nightly channel
+
+## Negative findings / risks
+
+### Operational
+- **/metrics returns 501** on bundled llama-server (b9253). hal0 metric scrape strategy via backend_url is BROKEN. Must use /v1/stats fallback (Task #5 fallback path wins).
+- **Nuclear evict-all CONFIRMED LIVE** — observed twice in this spike. Server log says verbatim: `"Load failed with non-file-not-found error, evicting all models and retrying..."`. Task #10 hazard is real.
+- **Default backend pick is Vulkan**, which is 3x slower than ROCm in Lemonade. Migration config must force `--llamacpp rocm` per-model.
+- **/v1/load API field shape undocumented** — direct curl returns `"type must be string, but is null"` with the documented body. CLI works. hal0 will need to reverse-engineer the CLI request shape, OR drive via shell CLI from Python.
+
+### Install/deps
+- **`unzip` is an undocumented system dep.** First backend install attempt failed silently. Required prereq for install.sh.
+- **FLM install silently fails.** `lemonade backends install flm:npu` returns "Backend installation failed (no details from server)". Server log shows "Installing backend: flm:npu" then silence. libxrt-npu2 NOT installed on LXC; that is the likely prereq but Lemonade does not handle it. Memory `hal0_flm_models_mount_path.md` referenced `/opt/hal0/flm-ubuntu` which does NOT exist on this LXC — that memory was stale or describing the container-internal path.
+
+### Model discovery + typing
+- **`extra_models_dir` discovers GGUFs but matches them against server_models.json by HF repo coords.** hal0 GGUFs in /mnt/ai-models/local/ that are NOT in Lemonade's registry are discovered as type=LLM only with label "custom". Rerank/embed models discovered this way lack `--reranking`/`--embedding` flag in child llama-server → 501.
+- **Reserved args** — `--reranking`, `--embedding`, `--ctx-size`, `--device`, `--gpu-layers`, `--mmproj*`, `-ngl`, `-m`, etc. are managed by Lemonade and CANNOT be user-overridden. Type classification at registration is mandatory.
+- **HF cache resolution buggy** — for at least one model (pqnet/bge-reranker-v2-m3-Q8_0-GGUF) Lemonade pointed llama-server at the snapshot DIR not the .gguf file → llama_model_load failure → nuclear evict.
+
+### Modality smokes
+| Modality | Status |
+|---|---|
+| LLM chat (qwen3.5-0.8b, hermes-4-14b, qwen3.6-35b) | works on ROCm |
+| Embedding (nomic-embed-text-v1-GGUF) | FAILED to load (HF resolution / model file issue) |
+| Reranking (bge-reranker-v2-m3) | FAILED: registered server_models entry has broken HF cache; custom-discovered file loads as LLM without --reranking |
+| ASR (whispercpp) | not tested |
+| TTS (kokoro) | not tested |
+| Image (sd-cpp) | not tested |
+| NPU LLM (FLM) | install silently failed |
+
+## Reserved-args list (verbatim from server log)
+
+`--ctx-size, --device, --embedding, --embeddings, --gpu-layers, --jinja, --mmproj, --mmproj-auto, --mmproj-offload, --mmproj-url, --model, --n-gpu-layers, --no-jinja, --no-mmproj, --no-mmproj-auto, --no-mmproj-offload, --port, --rerank, --reranking, -c, -dev, -m, -mm, -mmu, -ngl`
+
+## Backends matrix (Linux/Strix Halo) — from `lemonade backends`
+
+| Recipe | Backend | State |
+|---|---|---|
+| llamacpp | rocm | installable + INSTALLED |
+| llamacpp | vulkan | installable + auto-installed-as-sibling |
+| llamacpp | cpu | installable |
+| flm | npu | installable but install SILENTLY FAILS |
+| ryzenai-llm | npu | **unsupported: Requires Windows** |
+| whispercpp | cpu/vulkan | installable |
+| whispercpp | npu | **unsupported: Requires Windows** |
+| sd-cpp | cpu/rocm | installable |
+| vllm | rocm | installable (out-of-scope per plan) |
+| kokoro | cpu | installable (**no GPU variant** — confirms GPU-Kokoro loss) |
+
+## What changed in understanding
+
+Pre-spike: "Lemonade replaces six toolboxes with one binary, perf upside likely from newer llama.cpp + ROCm 7.13."
+
+Post-spike: "Lemonade replaces SOME of the six toolboxes (LLM + img path), but each non-LLM modality (embed/rerank/ASR/TTS) requires explicit type-aware registration. NPU path is broken-to-install. Perf is parity-to-regression depending on model, not upside. The newer llama.cpp build (b9253) is actually SLOWER on Vulkan than hal0's b1274. The unified-binary value remains; the perf value evaporates."
+
+## Recommendation
+
+Re-grill the user on migration drivers given the perf data. Specifically question whether "performance" stays a driver. Topology decision: with weakened perf assumption, the spike data argues for a less ambitious v0.2 scope (LLM-only via Lemonade, keep toolboxes for embed/rerank/ASR/TTS/NPU). Total replacement is still doable but requires significantly more glue work than originally costed (per-modality type registration, FLM XRT prereq install, /v1/stats metrics shim, --llamacpp rocm override everywhere).

--- a/docs/internal/lemonade-spike-runbook.md
+++ b/docs/internal/lemonade-spike-runbook.md
@@ -1,0 +1,330 @@
+# Lemonade Server Spike Runbook — hal0 LXC 105
+
+**Goal:** Evaluate Lemonade Server v10.6.0 as a unified replacement for hal0's per-modality toolboxes. Spike lives on LXC 105 (Strix Halo, gfx1151, XDNA NPU, amdxdna ≥7.0).
+
+**Total wall-clock:** ~4–5 h hands-on, plus 1 h idle-probe wait.
+
+**Ground rules:** All commands run as `root` on `ssh hal0` (10.0.1.142). Lemonade installs to `/opt/lemonade-spike`, listens on `:9100`. Bench artifacts land in `/root/lemonade-spike/findings/`.
+
+---
+
+## 1. Pre-flight checks (~10 min)
+
+```bash
+ssh hal0
+mkdir -p /root/lemonade-spike/findings && cd /root/lemonade-spike
+
+uname -r                                                    # verify: ≥ 7.0
+lsmod | grep amdxdna                                        # verify: amdxdna loaded
+ls /dev/accel/accel0                                        # verify: NPU char dev present
+# NOTE: rocminfo not on LXC host — Lemonade ships its own ROCm runtime. Skip.
+df -h /mnt/ai-models /opt /root                             # verify: ≥50 GB free on each
+mount | grep /mnt/ai-models                                 # verify: rw
+curl -sI https://github.com | head -1                       # verify: HTTP/2 200
+systemctl list-units 'hal0-slot@*.service' --state=active --no-legend --plain \
+  | awk '{print $1}' | tee active-slots.txt                 # verify: 5 services (embed, embed-rerank, primary, stt, tts)
+curl -fsS http://127.0.0.1:8080/api/slots | jq 'length'     # verify: integer count of slots
+```
+
+If any fail, **stop**. Note in findings; don't paper over a missing kernel module.
+
+---
+
+## 2. Install Lemonade v10.6.0 (~15 min)
+
+```bash
+cd /opt
+VER=10.6.0
+curl -fL -o lemonade.tgz \
+  "https://github.com/lemonade-sdk/lemonade/releases/download/v${VER}/lemonade-embeddable-${VER}-ubuntu-x64.tar.gz"
+# verify: file ~150–300 MB
+mkdir -p lemonade-spike && tar -xzf lemonade.tgz -C lemonade-spike --strip-components=1
+ls /opt/lemonade-spike/{lemond,lemonade,LICENSE,resources}  # verify: 4 entries
+
+cat > /opt/lemonade-spike/config.json <<'EOF'
+{
+  "port": 9100,
+  "max_loaded_models": 6,
+  "extra_models_dir": "/mnt/ai-models/local",
+  "rocm_channel": "nightly",
+  "global_timeout": 900,
+  "log_level": "info"
+}
+EOF
+# verify: jq . /opt/lemonade-spike/config.json parses
+
+export LEMONADE_API_KEY="spike-$(openssl rand -hex 8)"
+echo "$LEMONADE_API_KEY" > /root/lemonade-spike/api-key.txt
+# verify: ls -l /root/lemonade-spike/api-key.txt
+
+/opt/lemonade-spike/lemonade backends install llamacpp:rocm 2>&1 \
+  | tee /root/lemonade-spike/findings/install-llamacpp-rocm.log
+# verify: tail shows "installed" + ROCm 7.13+ version line
+
+systemctl stop 'hal0-slot@*'
+# verify: systemctl list-units 'hal0-slot@*' --state=active shows none
+
+tmux new -d -s lemond \
+  "LEMONADE_API_KEY=$LEMONADE_API_KEY /opt/lemonade-spike/lemond /opt/lemonade-spike --port 9100 \
+    2>&1 | tee /root/lemonade-spike/findings/lemond.log"
+sleep 5
+curl -fsS -H "Authorization: Bearer $LEMONADE_API_KEY" http://127.0.0.1:9100/v1/health | jq .
+# verify: JSON with backend_url, max_models, loaded:[]
+curl -fsS -H "Authorization: Bearer $LEMONADE_API_KEY" http://127.0.0.1:9100/v1/system-info | jq .gpu
+# verify: gfx1151 + ROCm version
+```
+
+---
+
+## 3. Bench harness adaptation (~15 min)
+
+```bash
+cp /root/llm-eval/bench.sh /root/lemonade-spike/bench-lemon.sh
+sed -i \
+  -e 's|http://127.0.0.1:8081|http://127.0.0.1:9100|g' \
+  -e "s|^AUTH_HEADER=.*|AUTH_HEADER=\"Authorization: Bearer $LEMONADE_API_KEY\"|" \
+  /root/lemonade-spike/bench-lemon.sh
+grep -nE 'localhost|9100|Bearer' /root/lemonade-spike/bench-lemon.sh
+# verify: every endpoint hits :9100 and carries the bearer header
+
+# Resolve registry paths once
+for m in hermes-4-14b-q5_k_m qwen3.5-0.8b qwen3.6-35b-a3b-q4_k_xl qwen3-coder-next-reap-40b-a3b-q4_k_xl; do
+  python3 -c "import tomllib,sys; r=tomllib.load(open('/var/lib/hal0/registry/registry.toml','rb')); print('$m', r['models']['$m']['path'])"
+done > /root/lemonade-spike/model-paths.txt
+# verify: 4 lines, each pointing under /mnt/ai-models/local
+
+# Smoke a warm model
+MODEL=hermes-4-14b-q5_k_m
+curl -fsS -H "Authorization: Bearer $LEMONADE_API_KEY" -H 'Content-Type: application/json' \
+  -X POST http://127.0.0.1:9100/v1/load -d "{\"model\":\"$MODEL\",\"backend\":\"llamacpp:rocm\"}"
+sleep 5
+/root/lemonade-spike/bench-lemon.sh "$MODEL" 1 | tee /tmp/smoke.txt
+# verify: tok/s within ±20% of 20 tok/s baseline
+```
+
+---
+
+## 4. LLM bench protocol (~75 min)
+
+For each model `$M` in the four targets:
+
+```bash
+M=hermes-4-14b-q5_k_m   # repeat for qwen3.5-0.8b, qwen3.6-35b-a3b-q4_k_xl, qwen3-coder-next-reap-40b-a3b-q4_k_xl
+OUT=/root/lemonade-spike/findings/bench-$M.txt
+
+# COLD: unload, drop caches, single run
+curl -sS -H "Authorization: Bearer $LEMONADE_API_KEY" -X POST http://127.0.0.1:9100/v1/unload -d '{}'
+sync && echo 3 > /proc/sys/vm/drop_caches
+/root/lemonade-spike/bench-lemon.sh "$M" 1 cold | tee -a "$OUT"
+# verify: $OUT has a "cold" row with TTFT + tok/s
+
+# WARM: 3 runs, model stays loaded
+for i in 1 2 3; do
+  /root/lemonade-spike/bench-lemon.sh "$M" 1 "warm-$i" | tee -a "$OUT"
+done
+curl -sS -H "Authorization: Bearer $LEMONADE_API_KEY" http://127.0.0.1:9100/v1/stats | jq . >> "$OUT"
+# verify: 3 warm rows + stats blob
+```
+
+Tabulate in findings template (§10) against `primary-model-eval-2026-05-22.md` baseline. Success bar is **qualitative** — gather data, judge holistically post-spike. Treat large deltas (>15 % on hermes-4-14b, TTFT >2× baseline, GTT >+25 %) as yellow flags worth interrogating, not auto-kills.
+
+---
+
+## 5. Concurrency test (~20 min)
+
+```bash
+KEY="Authorization: Bearer $LEMONADE_API_KEY"
+# Parallel loads (3 models, max_loaded_models=6 so all should fit)
+for M in hermes-4-14b-q5_k_m qwen3.5-0.8b qwen3.6-35b-a3b-q4_k_xl; do
+  curl -sS -H "$KEY" -H 'Content-Type: application/json' \
+    -X POST http://127.0.0.1:9100/v1/load -d "{\"model\":\"$M\"}" &
+done; wait
+curl -sS -H "$KEY" http://127.0.0.1:9100/v1/health | jq '.loaded'
+# verify: serialized — load timestamps should be staggered, not overlapping
+
+# Concurrent mixed-modality (after embed/rerank loaded in §8)
+( /root/lemonade-spike/bench-lemon.sh hermes-4-14b-q5_k_m 1 conc-chat &
+  curl -sS -H "$KEY" -X POST http://127.0.0.1:9100/v1/embeddings \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"bge-small-en","input":"hello world"}' &
+  curl -sS -H "$KEY" -X POST http://127.0.0.1:9100/v1/reranking \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"bge-reranker-v2-m3","query":"q","documents":["a","b"]}' &
+  wait ) | tee /root/lemonade-spike/findings/conc-mixed.log
+# verify: all 3 return non-error; record GTT deltas vs solo
+```
+
+Note any pending-load timeouts; Lemonade queues loads indefinitely so a stuck one blocks everything.
+
+### Metrics shim viability check
+
+```bash
+KEY="Authorization: Bearer $LEMONADE_API_KEY"
+# Discover backend_url per loaded model and probe its /metrics
+curl -sS -H "$KEY" http://127.0.0.1:9100/v1/health \
+  | jq -r '.loaded[] | "\(.model) \(.backend_url)"' > /root/lemonade-spike/findings/backend-urls.txt
+while read M URL; do
+  echo "=== $M ==="
+  curl -sfI "$URL/metrics" 2>&1 | head -1
+  curl -sf "$URL/metrics" 2>/dev/null | head -20
+done < /root/lemonade-spike/findings/backend-urls.txt | tee /root/lemonade-spike/findings/backend-metrics.log
+# verify: at least one llamacpp child returns text/plain Prometheus metrics (llamacpp:requests_processing etc.)
+# If empty: metrics shim falls back to /v1/stats polling (Task #5 fallback path)
+```
+
+---
+
+## 6. Idle-behavior probe (~60 min wallclock, ~2 min hands-on)
+
+```bash
+KEY="Authorization: Bearer $LEMONADE_API_KEY"
+curl -sS -H "$KEY" -X POST http://127.0.0.1:9100/v1/load \
+  -H 'Content-Type: application/json' -d '{"model":"qwen3.5-0.8b"}'
+date +%s > /root/lemonade-spike/findings/idle-start.txt
+sleep 3600
+curl -sS -H "$KEY" http://127.0.0.1:9100/v1/health | jq '.loaded[] | select(.model=="qwen3.5-0.8b")'
+# verify: model still resident; confirms no idle TTL (LRU-only eviction)
+```
+
+Run in parallel with §7/§8 if tight on time.
+
+---
+
+## 7. NPU smoke via FLM (~30 min)
+
+```bash
+/opt/lemonade-spike/lemonade backends install flm 2>&1 \
+  | tee /root/lemonade-spike/findings/install-flm.log
+# verify: log contains "flm installed" and libxrt-npu2 detected
+
+# Pick smallest tag from FLM model list
+jq -r '.models[] | select(.size_gb<1) | .name' /share/flm/model_list.json | head -3
+FLM_MODEL=$(jq -r '.models[] | select(.size_gb<1) | .name' /share/flm/model_list.json | head -1)
+
+KEY="Authorization: Bearer $LEMONADE_API_KEY"
+curl -fsS -H "$KEY" -H 'Content-Type: application/json' \
+  -X POST http://127.0.0.1:9100/v1/pull -d "{\"model\":\"$FLM_MODEL\",\"backend\":\"flm\"}" \
+  | tee /root/lemonade-spike/findings/flm-pull.json
+curl -fsS -H "$KEY" -X POST http://127.0.0.1:9100/v1/load \
+  -H 'Content-Type: application/json' -d "{\"model\":\"$FLM_MODEL\"}"
+curl -fsS -H "$KEY" -X POST http://127.0.0.1:9100/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d "{\"model\":\"$FLM_MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hi in 5 words.\"}]}" \
+  | tee /root/lemonade-spike/findings/flm-completion.json
+curl -sS -H "$KEY" http://127.0.0.1:9100/v1/stats | jq . \
+  > /root/lemonade-spike/findings/flm-stats.json
+# verify: completion has non-empty choices[0].message.content; stats has tokens_per_second
+```
+
+If FLM install fails on amdxdna mismatch, capture full stderr and stop — that's a known sharp edge (see `hal0_flm_models_mount_path.md`).
+
+---
+
+## 8. Modality smoke tests (~20 min)
+
+```bash
+KEY="Authorization: Bearer $LEMONADE_API_KEY"
+F=/root/lemonade-spike/findings
+
+# Embeddings
+curl -fsS -H "$KEY" -X POST http://127.0.0.1:9100/v1/embeddings \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"bge-small-en","input":"hal0 spike"}' | tee $F/smoke-embed.json
+# verify: data[0].embedding is a float array of length ~384
+
+# Rerank
+curl -fsS -H "$KEY" -X POST http://127.0.0.1:9100/v1/reranking \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"bge-reranker-v2-m3","query":"home AI","documents":["cars","hal0 is a home AI platform"]}' \
+  | tee $F/smoke-rerank.json
+# verify: results[*].relevance_score, second doc ranked higher
+
+# ASR
+curl -fsS -H "$KEY" -F model=whisper-tiny \
+  -F file=@/usr/share/sounds/alsa/Front_Center.wav \
+  http://127.0.0.1:9100/v1/audio/transcriptions | tee $F/smoke-asr.json
+# verify: text contains "front" or "center"
+
+# TTS
+curl -fsS -H "$KEY" -H 'Content-Type: application/json' \
+  -X POST http://127.0.0.1:9100/v1/audio/speech \
+  -d '{"model":"kokoro","input":"hello","voice":"af"}' --output $F/smoke-tts.wav
+file $F/smoke-tts.wav   # verify: RIFF WAVE audio
+
+# Image
+curl -fsS -H "$KEY" -H 'Content-Type: application/json' \
+  -X POST http://127.0.0.1:9100/v1/images/generations \
+  -d '{"model":"sd-tiny","prompt":"a lemon","size":"256x256","n":1}' | tee $F/smoke-img.json
+# verify: data[0].b64_json or url present
+```
+
+Each failure is interesting, not fatal — note it. Skip cleanly if model isn't in registry.
+
+---
+
+## 9. Cleanup & restore (~5 min)
+
+```bash
+tmux send-keys -t lemond C-c && sleep 2 && tmux kill-session -t lemond
+# verify: pgrep lemond -> empty
+while read u; do systemctl start "$u"; done < /root/lemonade-spike/active-slots.txt
+sleep 10
+curl -fsS http://127.0.0.1:8080/api/slots | jq 'length'
+# verify: "ok" + all original slots back to active
+
+cp /root/lemonade-spike/findings/lemond.log /root/lemonade-spike/findings/lemond.log.final
+tar -czf /root/lemonade-spike/findings-$(date +%Y%m%d).tar.gz -C /root/lemonade-spike findings
+# verify: tarball exists and is non-empty
+```
+
+Leave `/opt/lemonade-spike` in place for a possible second pass; nuke when done with `rm -rf /opt/lemonade-spike /opt/lemonade.tgz`.
+
+---
+
+## 10. Findings template
+
+Save as `/root/lemonade-spike/findings/SUMMARY.md`:
+
+```markdown
+# Lemonade Spike — Findings ($(date +%F))
+
+## Topology recommendation
+[ ] Replace toolboxes wholesale
+[ ] Adopt for LLM only, keep toolboxes for ASR/TTS/img
+[ ] Keep current; revisit at Lemonade vX
+Why:
+
+## Perf table (vs 2026-05-22 baseline)
+| Model | Baseline tok/s | Lemonade warm tok/s | TTFT (ms) | Cold load (s) | Delta |
+|---|---|---|---|---|---|
+| hermes-4-14b-q5_k_m | 20 |  |  |  |  |
+| qwen3.5-0.8b |  |  |  |  |  |
+| qwen3.6-35b-a3b-q4_k_xl |  |  |  |  |  |
+| qwen3-coder-next-reap-40b-a3b-q4_k_xl |  |  |  |  |  |
+
+## NPU (FLM)
+Install: [ok / failed — reason]
+Model:               TTFT:        tok/s:
+
+## Modality smokes
+embed [ ] rerank [ ] asr [ ] tts [ ] img [ ]
+
+## Surprises / sharp edges
+-
+
+## Yellow flags surfaced (qualitative — not auto-kills)
+[ ] >15% regression on hermes-4-14b
+[ ] TTFT >2× baseline
+[ ] GTT footprint >+25%
+[ ] FLM install fails on current kernel
+[ ] Concurrent load deadlock
+[ ] Missing modality endpoint
+[ ] Metrics shim path broken (backend_url /metrics unreachable)
+
+## Verdict (qualitative judgment over the data above)
+
+```
+
+---
+
+**Total est:** §1 10m + §2 15m + §3 15m + §4 75m + §5 20m + §6 60m idle (overlap) + §7 30m + §8 20m + §9 5m ≈ **3h 10m hands-on**, allow 4–5 h with surprises.


### PR DESCRIPTION
Lands the strategy work that came out of today's grilling sessions and the on-LXC Lemonade spike. Pure docs / CONTEXT update — no code, no api/ changes.

## Files

- **ADR-0006** — Migrate inference to Lemonade Server (v0.2). Drafts the six-toolboxes → one Lemonade server pivot; v0.2 retargeted from Phase 8 Agents.
- **ADR-0007** — Nuclear-evict-all mitigation (Lemonade). Documents the spike-confirmed hazard (\"Load failed with non-file-not-found error, evicting all models and retrying...\") and the mitigations hal0 needs to wrap around it.
- `docs/internal/lemonade-migration-plan.md` (132L) — topology + work breakdown.
- `docs/internal/lemonade-spike-findings-2026-05-22.md` (83L) — verdict (\"feasible but value/cost ratio shifted; worth re-grilling\"), perf table, operational risks, modality smokes.
- `docs/internal/lemonade-spike-runbook.md` (330L) — reproducible spike walkthrough for the LXC.
- `CONTEXT.md` — \`slot\` definition splits into v0.1.x (systemd template) vs v0.2 (Lemonade-mapped) sub-senses; updates the canonical vocabulary alongside the ADRs.

## Coordination

- Pure docs PR — file paths don't overlap with any in-flight agents PR (#131 / #132 / #133) or toolbox PR (#126 / #127). Safe to land at any time.
- ADR-0006 references the v0.3 retarget of Phase 8 Agents; doesn't depend on those PRs being merged first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)