### PR TITLE
feat(lemonade): client skeleton — control-plane HTTP wrapper (ADR-0006 PR-2/16)

### DIFF
--- a/src/hal0/lemonade/__init__.py
+++ b/src/hal0/lemonade/__init__.py
@@ -1,0 +1,40 @@
+"""hal0 ↔ Lemonade Server integration (v0.2).
+
+Lemonade Server is AMD's unified inference daemon. hal0 v0.2 replaces
+the six per-modality toolbox containers with a single Lemonade
+instance, driven over HTTP by ``LemonadeClient`` below.
+
+ADRs:
+- 0006 — Migrate inference to Lemonade Server (parent decision).
+- 0007 — Nuclear-evict-all mitigation (operational hazard wrap-around).
+
+The full module set (sequenced in
+``docs/internal/lemonade-migration-plan.md`` §PR sequence):
+
+  ``client.py`` (this PR)  — HTTP wrapper for the lemond control plane.
+  ``errors.py`` (this PR)  — exception hierarchy callers raise/catch.
+  ``preload.py`` (later)   — file/sha256/GGUF guards before ``/v1/load``.
+  ``metrics.py`` (later)   — ``/v1/stats`` + ``/v1/health`` aggregator.
+
+Nothing here is wired into the running stack yet. Activation is gated
+behind ``HAL0_BACKEND=lemonade`` (manifest schema v2); the v0.1.x
+Provider classes remain the default until ADR-0006 §12 cutover.
+"""
+
+from hal0.lemonade.client import LemonadeClient
+from hal0.lemonade.errors import (
+    LemonadeError,
+    LemonadeHTTPError,
+    LemonadeLoadError,
+    LemonadeTimeoutError,
+    LemonadeUnavailableError,
+)
+
+__all__ = [
+    "LemonadeClient",
+    "LemonadeError",
+    "LemonadeHTTPError",
+    "LemonadeLoadError",
+    "LemonadeTimeoutError",
+    "LemonadeUnavailableError",
+]

--- a/src/hal0/lemonade/client.py
+++ b/src/hal0/lemonade/client.py
@@ -1,0 +1,288 @@
+"""HTTP client for the Lemonade Server control plane.
+
+This is the foundational layer for the v0.2 migration (ADR-0006). Every
+later PR — Provider, SlotManager rewire, metrics, preload validation —
+goes through this wrapper. Inference forward endpoints
+(``/v1/chat/completions``, ``/v1/embeddings``, ...) are NOT included
+here; hal0's existing dispatcher already speaks the OpenAI-compatible
+shape unchanged and proxies them directly. This client owns only the
+control-plane surface.
+
+Endpoints covered (per ADR-0006 §3):
+
+  ``GET  /live``         liveness probe; unauthenticated; cheap
+  ``GET  /v1/health``    full health + ``loaded[]`` of model_names
+  ``GET  /v1/stats``     last-request perf snapshot (metrics shim §9)
+  ``POST /v1/load``      load a registered model
+  ``POST /v1/unload``    unload by model_name
+  ``POST /v1/pull``      download a model from upstream
+
+Bearer auth: hal0 ↔ lemond is loopback-only; the token is hal0's own
+``LEMONADE_API_KEY`` (ADR-0006 §Related → ADR-0001), distinct from the
+``HAL0_BEARER_TOKEN`` users hit hal0-api with.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+
+from hal0.lemonade.errors import (
+    LemonadeHTTPError,
+    LemonadeLoadError,
+    LemonadeTimeoutError,
+    LemonadeUnavailableError,
+)
+
+log = logging.getLogger(__name__)
+
+# ADR-0006 §6: lemond binds 127.0.0.1:9100 in the systemd unit.
+DEFAULT_BASE_URL = "http://127.0.0.1:9100"
+
+# ADR-0007 §5: hard timeout on /v1/load specifically. Other control
+# plane calls get a shorter budget — they're either cheap (/live, /v1/health)
+# or background (/v1/pull which returns immediately and streams progress
+# elsewhere — handled by a separate progress polling loop).
+DEFAULT_TIMEOUT_S = 5.0
+DEFAULT_LOAD_TIMEOUT_S = 120.0
+
+
+class LemonadeClient:
+    """Thin async wrapper around lemond's HTTP control plane.
+
+    Design notes:
+    - Stateless aside from the shared ``httpx.AsyncClient`` (matching
+      the pattern in ``dispatcher/router.py``). Construct one per
+      hal0-api process; share across SlotManager + metrics poller +
+      preload validator.
+    - HTTP errors are re-raised as ``LemonadeError`` subclasses so
+      callers never import httpx. Network failures bubble as
+      ``LemonadeUnavailableError``; timeouts as ``LemonadeTimeoutError``;
+      non-2xx as ``LemonadeHTTPError`` (or ``LemonadeLoadError`` for
+      the special /v1/load case).
+    - No automatic retries. ADR-0007 §4 forbids retrying /v1/load
+      (would guarantee another evict-all); the rest of the API is
+      idempotent enough that the caller decides retry policy.
+    """
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        api_key: str | None = None,
+        *,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+        load_timeout_s: float = DEFAULT_LOAD_TIMEOUT_S,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._timeout_s = timeout_s
+        self._load_timeout_s = load_timeout_s
+        # Match dispatcher/router.py: lazy-init so unit tests that
+        # exercise only one method don't open sockets.
+        self._http_client: httpx.AsyncClient | None = http_client
+        self._owns_http_client: bool = http_client is None
+
+    # ── lifecycle ──────────────────────────────────────────────────
+
+    def _client(self) -> httpx.AsyncClient:
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                timeout=httpx.Timeout(self._timeout_s),
+                follow_redirects=False,
+            )
+        return self._http_client
+
+    async def aclose(self) -> None:
+        """Close the underlying httpx client if we own it. Idempotent."""
+        if self._http_client is not None and self._owns_http_client:
+            await self._http_client.aclose()
+            self._http_client = None
+
+    # ── headers ────────────────────────────────────────────────────
+
+    def _headers(self) -> dict[str, str]:
+        h: dict[str, str] = {"Accept": "application/json"}
+        if self._api_key:
+            h["Authorization"] = f"Bearer {self._api_key}"
+        return h
+
+    # ── /live ──────────────────────────────────────────────────────
+
+    async def live(self) -> bool:
+        """Returns True if ``GET /live`` returned 2xx, False otherwise.
+
+        Used by hal0's healthcheck path — must NOT raise on a down
+        daemon. ``/live`` is unauthenticated and zero-work; safe to
+        poll on the dashboard's normal cadence.
+        """
+        try:
+            async with self._request("GET", "/live") as resp:
+                return 200 <= resp.status_code < 300
+        except (LemonadeUnavailableError, LemonadeTimeoutError):
+            return False
+        except LemonadeHTTPError:
+            return False
+
+    # ── /v1/health ─────────────────────────────────────────────────
+
+    async def health(self) -> dict[str, Any]:
+        """Returns the parsed JSON body of ``GET /v1/health``.
+
+        Expected shape (per Lemonade docs, may evolve): ``{"loaded":
+        [{"model_name": "...", "backend_url": "...", ...}], "ready":
+        bool, ...}``. Caller treats unknown fields permissively.
+        """
+        async with self._request("GET", "/v1/health") as resp:
+            self._raise_for_status(resp)
+            return resp.json()
+
+    # ── /v1/stats ──────────────────────────────────────────────────
+
+    async def stats(self) -> dict[str, Any]:
+        """Returns the parsed JSON body of ``GET /v1/stats``.
+
+        Lemonade's last-request perf snapshot. ADR-0006 §9 makes this
+        the source of truth for hal0's Prometheus shim, replacing the
+        v0.1.x ``/metrics`` scrape that doesn't survive the migration.
+        """
+        async with self._request("GET", "/v1/stats") as resp:
+            self._raise_for_status(resp)
+            return resp.json()
+
+    # ── /v1/load ───────────────────────────────────────────────────
+
+    async def load(
+        self,
+        model_name: str,
+        *,
+        recipe: str | None = None,
+        ctx_size: int | None = None,
+        llamacpp_backend: str | None = None,
+        llamacpp_args: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Load a model into the Lemonade pool.
+
+        Per ADR-0006 §3 + the v1_load_schema memory, only
+        ``model_name`` is required. Optional kwargs map directly to
+        Lemonade's documented load fields. The reserved-args list
+        (``--reranking``, ``--embedding``, ``--ctx-size``, ``-ngl``,
+        etc.) is hardcoded in lemond's router and is NOT extensible —
+        any reserved arg passed via ``llamacpp_args`` will trigger a
+        4xx. Validate at the caller layer.
+
+        Returns the parsed response body on success. Raises
+        ``LemonadeLoadError`` on 4xx/5xx — critically distinct from
+        the generic HTTP error class because a /v1/load failure has
+        evict-all blast radius (ADR-0007).
+        """
+        body: dict[str, Any] = {"model_name": model_name}
+        if recipe is not None:
+            body["recipe"] = recipe
+        if ctx_size is not None:
+            body["ctx_size"] = ctx_size
+        if llamacpp_backend is not None:
+            body["llamacpp_backend"] = llamacpp_backend
+        if llamacpp_args is not None:
+            body["llamacpp_args"] = llamacpp_args
+        async with self._request(
+            "POST", "/v1/load", json=body, timeout=self._load_timeout_s
+        ) as resp:
+            if not (200 <= resp.status_code < 300):
+                # Specialise the error so SlotManager can distinguish
+                # /v1/load failures (evict-all triggered) from other 4xx/5xx.
+                raise LemonadeLoadError(
+                    resp.status_code,
+                    body=_safe_json(resp),
+                    msg=f"lemonade /v1/load returned HTTP {resp.status_code} for model_name={model_name!r}",
+                )
+            return resp.json()
+
+    # ── /v1/unload ─────────────────────────────────────────────────
+
+    async def unload(self, model_name: str) -> dict[str, Any]:
+        """Unload a model by name. Idempotent.
+
+        Used by the idle-unload driver (later PR) when a slot's
+        last-request age exceeds its configured TTL.
+        """
+        async with self._request("POST", "/v1/unload", json={"model_name": model_name}) as resp:
+            self._raise_for_status(resp)
+            return resp.json()
+
+    # ── /v1/pull ───────────────────────────────────────────────────
+
+    async def pull(self, model_name: str, *, allow_overwrite: bool = False) -> dict[str, Any]:
+        """Request lemond to download ``model_name`` to its model store.
+
+        Returns immediately; pull progress is streamed via lemond's
+        ``/logs/stream`` (handled by a separate polling loop, not here).
+        """
+        body: dict[str, Any] = {"model_name": model_name}
+        if allow_overwrite:
+            body["allow_overwrite"] = True
+        async with self._request("POST", "/v1/pull", json=body) as resp:
+            self._raise_for_status(resp)
+            return resp.json()
+
+    # ── internal: HTTP request envelope ────────────────────────────
+
+    @asynccontextmanager
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> AsyncIterator[httpx.Response]:
+        """Single chokepoint for every outbound HTTP call.
+
+        Converts httpx exceptions to our error hierarchy so callers
+        never see ``httpx.*`` types. ``timeout`` per-call overrides
+        the client default — /v1/load uses the longer load timeout.
+        """
+        client = self._client()
+        kwargs: dict[str, Any] = {"headers": self._headers()}
+        if json is not None:
+            kwargs["json"] = json
+        if timeout is not None:
+            kwargs["timeout"] = httpx.Timeout(timeout)
+        try:
+            resp = await client.request(method, path, **kwargs)
+        except httpx.TimeoutException as exc:
+            raise LemonadeTimeoutError(f"{method} {path} timed out") from exc
+        except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadError) as exc:
+            raise LemonadeUnavailableError(f"{method} {path}: lemond unreachable ({exc})") from exc
+        except httpx.HTTPError as exc:
+            # Catch-all for less common httpx errors (NetworkError,
+            # CloseError, etc.) — surface as unavailable so callers
+            # treat the daemon as offline.
+            raise LemonadeUnavailableError(f"{method} {path}: {exc}") from exc
+        try:
+            yield resp
+        finally:
+            await resp.aclose()
+
+    def _raise_for_status(self, resp: httpx.Response) -> None:
+        """Generic 2xx-or-raise. /v1/load uses its own specialised
+        error class (``LemonadeLoadError``) for blast-radius reasons —
+        do not route /v1/load through here."""
+        if 200 <= resp.status_code < 300:
+            return
+        raise LemonadeHTTPError(resp.status_code, body=_safe_json(resp))
+
+
+def _safe_json(resp: httpx.Response) -> object | None:
+    """Best-effort JSON parse — never raises. Used inside error paths
+    where re-raising a parse failure would mask the original HTTP error.
+    """
+    try:
+        return resp.json()
+    except Exception:
+        return None

--- a/src/hal0/lemonade/errors.py
+++ b/src/hal0/lemonade/errors.py
@@ -1,0 +1,62 @@
+"""Exception types raised by ``LemonadeClient``.
+
+Callers in ``SlotManager`` (later PR) catch the specific subclasses to
+distinguish "lemond unreachable" (retry the whole control plane) from
+"lemond returned 4xx on a /v1/load" (surface to the slot as an error
+state, do NOT retry — see ADR-0007 §4).
+
+The base ``LemonadeError`` is the catch-all. Subclasses carry the
+discriminator. Avoid leaking httpx types into the rest of hal0 — the
+LemonadeClient wraps and re-raises.
+"""
+
+from __future__ import annotations
+
+
+class LemonadeError(Exception):
+    """Base class for every error raised by ``LemonadeClient``."""
+
+
+class LemonadeUnavailableError(LemonadeError):
+    """lemond couldn't be reached at all — connect-refused, DNS fail,
+    socket closed before response. Distinct from HTTP 5xx because the
+    daemon may be down (vs. serving but erroring).
+
+    SlotManager should treat this as "control plane offline" and not
+    use it to mark individual slots errored.
+    """
+
+
+class LemonadeTimeoutError(LemonadeError):
+    """A request exceeded the client's timeout budget. Distinct from
+    ``LemonadeUnavailableError`` because the connection succeeded — the
+    server is either slow or has accepted a request that's blocking on
+    its serialized load queue (see ADR-0006 §Operational risks).
+
+    ADR-0007 §5 mandates a hard timeout on ``/v1/load`` specifically.
+    """
+
+
+class LemonadeHTTPError(LemonadeError):
+    """lemond returned a non-2xx HTTP response. ``status_code`` carries
+    the raw code; ``body`` carries the parsed JSON body (if any) so
+    callers can match on Lemonade's error envelope without re-parsing.
+    """
+
+    def __init__(
+        self, status_code: int, body: object | None = None, msg: str | None = None
+    ) -> None:
+        self.status_code = status_code
+        self.body = body
+        super().__init__(msg or f"lemonade returned HTTP {status_code}")
+
+
+class LemonadeLoadError(LemonadeHTTPError):
+    """Specialisation of ``LemonadeHTTPError`` for ``/v1/load`` failures.
+
+    Worth its own class because the nuclear-evict-all policy (ADR-0007)
+    means a /v1/load 5xx has caller-visible consequences other 5xx
+    don't — every loaded slot on the pool has just been blasted.
+    SlotManager catches this and refreshes its view of /v1/health
+    before reporting state, instead of trusting cached state.
+    """

--- a/tests/lemonade/test_client.py
+++ b/tests/lemonade/test_client.py
@@ -1,0 +1,326 @@
+"""Unit tests for ``hal0.lemonade.client.LemonadeClient``.
+
+Covers the control-plane wrapper's shape — every method routes through
+the same ``_request`` chokepoint, so the test surface is:
+
+  * each method hits the right HTTP verb + path + body shape
+  * 2xx responses parse + return JSON body
+  * non-2xx responses raise the right exception subclass
+    (``LemonadeLoadError`` for /v1/load specifically)
+  * httpx network errors raise ``LemonadeUnavailableError``
+  * httpx timeouts raise ``LemonadeTimeoutError``
+  * Bearer header is set when api_key is present, absent otherwise
+  * ``live()`` swallows errors and returns bool, never raises
+  * ``aclose()`` closes the owned client; double-close is a no-op
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from hal0.lemonade.client import LemonadeClient
+from hal0.lemonade.errors import (
+    LemonadeHTTPError,
+    LemonadeLoadError,
+    LemonadeTimeoutError,
+    LemonadeUnavailableError,
+)
+
+
+def _mock_transport(handler):
+    """httpx MockTransport convenience wrapper — handler signature
+    ``(request) -> httpx.Response``."""
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://test")
+
+
+# ── /live ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_live_returns_true_on_2xx() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(204)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        assert await client.live() is True
+
+
+@pytest.mark.asyncio
+async def test_live_returns_false_on_5xx_without_raising() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"err": "down"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        # /live is the healthcheck path — must not raise so a down
+        # daemon doesn't crash hal0-api's poll loop.
+        assert await client.live() is False
+
+
+@pytest.mark.asyncio
+async def test_live_returns_false_on_connect_error_without_raising() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        assert await client.live() is False
+
+
+# ── /v1/health ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_returns_parsed_body() -> None:
+    payload = {
+        "loaded": [{"model_name": "hermes-4-14b", "backend_url": "http://127.0.0.1:9101"}],
+        "ready": True,
+    }
+
+    def h(req: httpx.Request) -> httpx.Response:
+        assert req.method == "GET"
+        assert req.url.path == "/v1/health"
+        return httpx.Response(200, json=payload)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        assert await client.health() == payload
+
+
+@pytest.mark.asyncio
+async def test_health_raises_lemonade_http_error_on_500() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"detail": "internal"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        with pytest.raises(LemonadeHTTPError) as exc:
+            await client.health()
+        assert exc.value.status_code == 500
+        assert exc.value.body == {"detail": "internal"}
+
+
+# ── /v1/stats ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stats_returns_parsed_body() -> None:
+    payload = {"last_request": {"prompt_t_per_s": 287.3, "decode_t_per_s": 21.4}}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        assert req.url.path == "/v1/stats"
+        return httpx.Response(200, json=payload)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        assert await client.stats() == payload
+
+
+# ── /v1/load ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_load_posts_minimal_body() -> None:
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        assert req.method == "POST"
+        assert req.url.path == "/v1/load"
+        import json as _json
+
+        captured["body"] = _json.loads(req.content.decode())
+        return httpx.Response(200, json={"status": "loaded"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        await client.load("hermes-4-14b")
+        # Only model_name is required (v1_load_schema memory + ADR-0006 §3).
+        assert captured["body"] == {"model_name": "hermes-4-14b"}
+
+
+@pytest.mark.asyncio
+async def test_load_includes_optional_fields_when_provided() -> None:
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        import json as _json
+
+        captured["body"] = _json.loads(req.content.decode())
+        return httpx.Response(200, json={"status": "loaded"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        await client.load(
+            "hermes-4-14b",
+            recipe="llamacpp:rocm",
+            ctx_size=8192,
+            llamacpp_backend="rocm",
+            llamacpp_args=["--parallel", "2"],
+        )
+        assert captured["body"] == {
+            "model_name": "hermes-4-14b",
+            "recipe": "llamacpp:rocm",
+            "ctx_size": 8192,
+            "llamacpp_backend": "rocm",
+            "llamacpp_args": ["--parallel", "2"],
+        }
+
+
+@pytest.mark.asyncio
+async def test_load_raises_lemonade_load_error_not_generic_http_error() -> None:
+    """Critical for ADR-0007: SlotManager must distinguish /v1/load
+    failures (evict-all triggered) from other HTTP errors."""
+
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"detail": "load failed"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        with pytest.raises(LemonadeLoadError) as exc:
+            await client.load("hermes-4-14b")
+        # LemonadeLoadError extends LemonadeHTTPError; carries status + body.
+        assert isinstance(exc.value, LemonadeHTTPError)
+        assert exc.value.status_code == 500
+        assert exc.value.body == {"detail": "load failed"}
+        # And the message mentions the model name for debuggability.
+        assert "hermes-4-14b" in str(exc.value)
+
+
+# ── /v1/unload ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unload_posts_model_name() -> None:
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        import json as _json
+
+        captured["body"] = _json.loads(req.content.decode())
+        assert req.url.path == "/v1/unload"
+        return httpx.Response(200, json={"status": "unloaded"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        await client.unload("hermes-4-14b")
+        assert captured["body"] == {"model_name": "hermes-4-14b"}
+
+
+# ── /v1/pull ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pull_posts_model_name_without_overwrite_by_default() -> None:
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        import json as _json
+
+        captured["body"] = _json.loads(req.content.decode())
+        return httpx.Response(200, json={"job_id": "abc"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        await client.pull("hermes-4-14b")
+        assert captured["body"] == {"model_name": "hermes-4-14b"}
+
+
+@pytest.mark.asyncio
+async def test_pull_includes_allow_overwrite_when_true() -> None:
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        import json as _json
+
+        captured["body"] = _json.loads(req.content.decode())
+        return httpx.Response(200, json={"job_id": "abc"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        await client.pull("hermes-4-14b", allow_overwrite=True)
+        assert captured["body"] == {"model_name": "hermes-4-14b", "allow_overwrite": True}
+
+
+# ── network / timeout error mapping ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_connect_error_maps_to_unavailable() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        with pytest.raises(LemonadeUnavailableError):
+            await client.health()
+
+
+@pytest.mark.asyncio
+async def test_timeout_maps_to_lemonade_timeout() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("read timeout")
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        with pytest.raises(LemonadeTimeoutError):
+            await client.health()
+
+
+# ── auth headers ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bearer_header_set_when_api_key_present() -> None:
+    captured: dict[str, str] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        captured["auth"] = req.headers.get("authorization", "")
+        return httpx.Response(200, json={"ok": True})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport, api_key="hal0-internal-token")
+        await client.health()
+    assert captured["auth"] == "Bearer hal0-internal-token"
+
+
+@pytest.mark.asyncio
+async def test_no_auth_header_when_api_key_absent() -> None:
+    captured: dict[str, str] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        captured["auth"] = req.headers.get("authorization", "")
+        return httpx.Response(200, json={"ok": True})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        await client.health()
+    assert captured["auth"] == ""
+
+
+# ── lifecycle ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_idempotent_when_client_is_owned() -> None:
+    """Double-aclose on an owned client should not raise."""
+
+    client = LemonadeClient(base_url="http://test")  # owns the http_client
+    await client.aclose()
+    await client.aclose()  # noop
+
+
+@pytest.mark.asyncio
+async def test_aclose_does_not_close_borrowed_client() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"ok": True})
+
+    transport = _mock_transport(h)
+    client = LemonadeClient(http_client=transport)  # client is borrowed
+    await client.aclose()
+    # Borrowed client should remain usable
+    assert not transport.is_closed
+    await transport.aclose()


### PR DESCRIPTION
First brick of the v0.2 Lemonade migration — PR #2 of 16 from `docs/internal/lemonade-migration-plan.md` §PR sequence.

## Summary

- `LemonadeClient` covering 6 control-plane endpoints: `/live`, `/v1/health`, `/v1/stats`, `/v1/load`, `/v1/unload`, `/v1/pull`.
- Exception hierarchy with `LemonadeLoadError` specialised so SlotManager can distinguish `/v1/load` failures (evict-all blast radius — ADR-0007) from other 4xx/5xx.
- 18 unit tests using `httpx.MockTransport` — no network — cover shape, error mapping, Bearer auth, lifecycle.

## What this PR does NOT do

- Inference forward endpoints — hal0's dispatcher already proxies those unchanged.
- Wire into any running code. Activation is gated behind `HAL0_BACKEND=lemonade` (manifest schema v2, lands in PR-3 of the migration plan).
- Retry policy. None — ADR-0007 §4 forbids retrying `/v1/load`.

## Conforms to

- ADR-0006 §3 (HTTP-only drive, endpoint list)
- ADR-0007 §4/§5 (no /v1/load retry; configurable hard load timeout default 120s)
- Memory `hal0_lemonade_v1_load_schema` (only `model_name` required for `/v1/load`)
- Memory `hal0_lemonade_gotchas` (hazards documented in module + error class docstrings)

## Test plan

- [x] `ruff check src/hal0/lemonade/ tests/lemonade/` clean
- [x] `pytest tests/lemonade/test_client.py` — 18/18 pass locally
- [ ] CI green

## Next in the sequence

PR #3 — `manifest.json` schema v2 + `HAL0_BACKEND=lemonade` flag plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)