### PR TITLE
fix(cli): approvals list — project tool+target into Summary

### DIFF
--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -9,6 +9,9 @@ ADR-0004 §5 "Pending items").
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from typing import Any
+
 import typer
 from rich.console import Console
 from rich.panel import Panel
@@ -23,6 +26,7 @@ from hal0.cli._shared import (
     api_post,
     die,
 )
+from hal0.mcp.approval_queue import _PRIMARY_TARGET_ARG
 
 app = typer.Typer(help="Manage bundled agents (Phase 8 — pi-coder / Hermes-Agent).")
 console = Console()
@@ -120,6 +124,63 @@ def agent_list() -> None:
 # ── Approvals (MCP-backend owns the route shape; CLI assumes ADR-0004 §5) ────
 
 
+def _fmt_enqueued_at(value: Any) -> str:
+    """Project ``enqueued_at`` (epoch seconds float) to a short ISO string.
+
+    Mirrors the dashboard's ``AgentApprovalRow.vue`` tooltip projection
+    (``new Date(epoch * 1000).toISOString()``) — keep CLI + UI agreeing
+    on a single representation so screenshots and CLI output read the
+    same to operators.
+    """
+    if value in (None, "", "—"):
+        return "—"
+    try:
+        epoch = float(value)
+    except (TypeError, ValueError):
+        # Already a string-ish timestamp — pass through untouched.
+        return str(value)
+    return (
+        datetime.fromtimestamp(epoch, tz=UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _approval_summary(entry: dict[str, Any]) -> str:
+    """Build a one-line Summary from ``tool`` + primary target arg.
+
+    Mirrors ``AgentApprovalRow.vue``'s ``primaryArg`` projection: the
+    arg name comes from :data:`hal0.mcp.approval_queue._PRIMARY_TARGET_ARG`
+    so the CLI and the dashboard agree on which field is the
+    "distinguishing" one. When the tool has no registered primary arg
+    we fall back to the first scalar in ``args`` so the operator still
+    sees something more useful than the bare tool name. Truncated to
+    60 chars to fit a reasonable terminal width without wrapping.
+    """
+    tool = str(entry.get("tool") or "—")
+    args = entry.get("args")
+    if not isinstance(args, dict) or not args:
+        return tool[:60]
+
+    primary_key = _PRIMARY_TARGET_ARG.get(tool)
+    primary_val: Any = None
+    if primary_key is not None:
+        primary_val = args.get(primary_key)
+    if primary_val is None:
+        # No registered primary arg (or it's missing) — fall back to
+        # the first scalar value, matching the Vue row's behaviour.
+        for v in args.values():
+            if isinstance(v, str | int | float | bool) and v != "":
+                primary_val = v
+                break
+
+    if isinstance(primary_val, list | tuple):
+        primary_val = ",".join(str(v) for v in primary_val)
+    summary = tool if primary_val is None or primary_val == "" else f"{tool} {primary_val}"
+    return summary[:60]
+
+
 @approvals_app.command("list")
 def approvals_list() -> None:
     """List pending agent approval requests."""
@@ -142,12 +203,16 @@ def approvals_list() -> None:
     table.add_column("Requested at")
     table.add_column("Summary")
     for it in items:
+        # ApprovalEntry.as_dict() emits ``client_id`` + ``enqueued_at``
+        # + ``args`` — NOT ``agent`` / ``requested_at`` / ``summary``.
+        # Mirror ui/src/components/agent/AgentApprovalRow.vue's
+        # projection so CLI + dashboard show the same row content.
         table.add_row(
             str(it.get("id", "—")),
             str(it.get("tool", "—")),
-            str(it.get("agent", "—")),
-            str(it.get("requested_at", "—")),
-            str(it.get("summary", "—"))[:60],
+            str(it.get("client_id") or "—"),
+            _fmt_enqueued_at(it.get("enqueued_at")),
+            _approval_summary(it),
         )
     console.print(table)
 

--- a/tests/cli/test_agent_approvals_list.py
+++ b/tests/cli/test_agent_approvals_list.py
@@ -1,0 +1,212 @@
+"""Tests for ``hal0 agent approvals list`` table projection.
+
+Regression coverage for the field-name drift between
+``ApprovalEntry.as_dict()`` (``enqueued_at`` / ``client_id`` / ``args``)
+and the original CLI renderer (which read ``requested_at`` / ``agent`` /
+``summary`` — none of those exist). Every operator-visible column on the
+``hal0 agent approvals list`` table used to render as "—".
+
+The fix mirrors ``ui/src/components/agent/AgentApprovalRow.vue``:
+
+* ``enqueued_at`` → "Requested at" as a short ISO timestamp.
+* ``client_id`` → "Agent" with "—" fallback.
+* "Summary" built from ``tool`` + primary target arg from
+  :data:`hal0.mcp.approval_queue._PRIMARY_TARGET_ARG`.
+
+ADR-0004 §5 — the inbox row contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import agent_commands
+
+# Rich auto-shrinks columns to terminal width; CliRunner defaults to
+# 80 cols, which truncates long tool names + arg values with "…"
+# ellipsis chars. We assert against the projection helpers directly
+# (sharp + width-independent) AND through the Typer CLI (catches the
+# wiring + ensures the column order didn't regress). The Typer leg
+# uses a wide console so the strings we assert on don't get clipped.
+runner = CliRunner()
+
+
+@pytest.fixture
+def stub_api(monkeypatch: pytest.MonkeyPatch):
+    """Stub the API layer so the CLI runs offline and we drive its input."""
+
+    def fake_unreachable(_url: str) -> bool:
+        return False
+
+    monkeypatch.setattr(agent_commands, "_api_unreachable", fake_unreachable)
+
+    def _install(payload: dict[str, Any]) -> None:
+        def fake_get(path: str, **_kw: Any) -> dict[str, Any]:
+            assert path == "/api/agent/approvals"
+            return payload
+
+        monkeypatch.setattr(agent_commands, "api_get", fake_get)
+
+    return _install
+
+
+# ── Helper unit tests (width-independent) ────────────────────────────────────
+
+
+def test_summary_uses_primary_target_arg_for_registered_tool() -> None:
+    """``model_delete`` → ``"model_delete <model_id>"`` via _PRIMARY_TARGET_ARG."""
+    entry = {
+        "tool": "model_delete",
+        "args": {"model_id": "qwen3:0.6b"},
+    }
+    assert agent_commands._approval_summary(entry) == "model_delete qwen3:0.6b"
+
+
+def test_summary_falls_back_to_first_scalar_for_unregistered_tool() -> None:
+    """Unknown tools get a best-effort scalar so operators see context."""
+    entry = {
+        "tool": "some_unregistered_tool",
+        "args": {"thing": "value-x"},
+    }
+    summary = agent_commands._approval_summary(entry)
+    assert "some_unregistered_tool" in summary
+    assert "value-x" in summary
+
+
+def test_summary_renders_tool_alone_when_args_empty() -> None:
+    """Empty args → bare tool name (no trailing space, no crash)."""
+    entry = {"tool": "model_pull", "args": {}}
+    assert agent_commands._approval_summary(entry) == "model_pull"
+
+
+def test_summary_truncates_to_60_chars() -> None:
+    """A pathological model id can't blow out the column width."""
+    long_id = "a" * 200
+    entry = {
+        "tool": "model_pull",
+        "args": {"model_id": long_id},
+    }
+    summary = agent_commands._approval_summary(entry)
+    assert len(summary) == 60
+    assert summary.startswith("model_pull a")
+
+
+def test_summary_joins_list_primary_target() -> None:
+    """``memory_delete`` has a list-valued primary arg (ids=[…])."""
+    entry = {
+        "tool": "memory_delete",
+        "args": {"ids": ["m1", "m2", "m3"]},
+    }
+    summary = agent_commands._approval_summary(entry)
+    assert "memory_delete" in summary
+    # All ids appear in the joined form.
+    assert "m1" in summary and "m2" in summary and "m3" in summary
+
+
+def test_fmt_enqueued_at_renders_iso_from_epoch() -> None:
+    """Epoch float → short ISO with ``Z`` suffix (UTC), no microseconds."""
+    out = agent_commands._fmt_enqueued_at(1716400000.0)
+    # 1716400000.0 → 2024-05-22T17:46:40Z
+    assert out == "2024-05-22T17:46:40Z"
+
+
+def test_fmt_enqueued_at_dash_for_missing() -> None:
+    assert agent_commands._fmt_enqueued_at(None) == "—"
+    assert agent_commands._fmt_enqueued_at("") == "—"
+
+
+def test_fmt_enqueued_at_passes_through_non_float_strings() -> None:
+    """If the API ever migrates to a pre-formatted ISO string, don't mangle it."""
+    assert agent_commands._fmt_enqueued_at("2024-05-22T17:46:40Z") == "2024-05-22T17:46:40Z"
+
+
+# ── CLI integration tests (wide console so Rich doesn't truncate) ────────────
+
+
+def test_approvals_list_projects_tool_and_target_into_summary(
+    stub_api, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pending ``model_delete`` row renders the model id in Summary,
+    the agent's ``client_id`` in Agent, and a non-"—" Requested-at.
+    """
+    # Rich reads COLUMNS off the env to size its console; pin a wide
+    # value so the strings we assert on don't get clipped by ellipsis.
+    monkeypatch.setenv("COLUMNS", "200")
+
+    stub_api(
+        {
+            "approvals": [
+                {
+                    "id": "abc123",
+                    "tool": "model_delete",
+                    # Per ApprovalEntry.as_dict() — NOT a flat "summary"
+                    # field. The bug pre-fix was reading `summary`,
+                    # `agent`, and `requested_at` (none of which exist).
+                    "args": {"model_id": "qwen3:0.6b"},
+                    "client_id": "pi-coder",
+                    "enqueued_at": 1716400000.0,
+                    "state": "pending",
+                    "hit_count": 1,
+                }
+            ]
+        }
+    )
+
+    result = runner.invoke(agent_commands.approvals_app, ["list"])
+    assert result.exit_code == 0, result.output
+
+    out = result.output
+    # Summary column: tool + primary target arg, mirroring the Vue row.
+    assert "model_delete" in out
+    assert "qwen3:0.6b" in out
+    # Agent column: client_id, not the literal "—" the bug emitted.
+    assert "pi-coder" in out
+    # Requested at: a real ISO timestamp from epoch 1716400000.0 →
+    # 2024-05-22T17:46:40Z. The presence of "2024-" is enough to prove
+    # we're not falling back to the "—" sentinel.
+    assert "2024-" in out
+    # Em-dash sentinels for Agent / Requested-at MUST NOT appear in
+    # this row (one per missing field — the bug showed three).
+    # The table title + headers don't contain em-dashes, so a strict
+    # count works here.
+    assert out.count("—") == 0
+
+
+def test_approvals_list_falls_back_to_dash_when_client_id_missing(
+    stub_api, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Agent column degrades to "—" when ``client_id`` is absent / empty."""
+    monkeypatch.setenv("COLUMNS", "200")
+    stub_api(
+        {
+            "approvals": [
+                {
+                    "id": "def456",
+                    "tool": "slot_delete",
+                    "args": {"name": "scratch"},
+                    "client_id": "",  # empty string — fall back to —
+                    "enqueued_at": 1716400000.0,
+                    "state": "pending",
+                }
+            ]
+        }
+    )
+
+    result = runner.invoke(agent_commands.approvals_app, ["list"])
+    assert result.exit_code == 0, result.output
+    # Summary still works (tool + primary target).
+    assert "slot_delete" in result.output
+    assert "scratch" in result.output
+    # Empty client_id falls back to the em-dash sentinel.
+    assert "—" in result.output
+
+
+def test_approvals_list_empty_short_circuits(stub_api) -> None:
+    """Empty pending set renders the dim "No pending approvals." line."""
+    stub_api({"approvals": []})
+    result = runner.invoke(agent_commands.approvals_app, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "No pending approvals" in result.output


### PR DESCRIPTION
## Summary

`hal0 agent approvals list` rendered Requested-at, Agent, and Summary
columns as "—" because the Rich-table builder read field names that
don't exist on the payload:

| CLI was reading | What `ApprovalEntry.as_dict()` actually emits |
| --- | --- |
| `summary` | (does not exist — build from `tool` + `args`) |
| `requested_at` | `enqueued_at` (epoch float) |
| `agent` | `client_id` |

The dashboard renders this correctly via
`ui/src/components/agent/AgentApprovalRow.vue` — this PR mirrors that
projection in the CLI so both surfaces show identical row content
(ADR-0004 §5 — inbox row contract).

### What changed

- Map `enqueued_at` → short ISO timestamp (UTC, no microseconds, `Z` suffix).
- Map `client_id` → "Agent" column with `—` fallback when empty.
- Build "Summary" from `tool` + primary target arg via
  `hal0.mcp.approval_queue._PRIMARY_TARGET_ARG` (the same registry
  the queue uses for dedup), with a first-scalar fallback for tools
  not in the registry. Truncated to 60 chars to avoid wrapping.

CLI-only — no API / MCP queue / UI changes.

## Test plan

- [x] New `tests/cli/test_agent_approvals_list.py` — 11 cases covering
  the helper functions (width-independent) and the Typer CLI wiring
  (asserts table contains `model_delete qwen3:0.6b`, `pi-coder`, and
  a non-`—` ISO timestamp for a realistic pending entry).
- [x] `pytest tests/cli/ -q` → 44 passed.
- [x] `pytest tests/api/test_approvals.py -q` → 7 passed (API contract
  still satisfied).
- [x] `ruff check src tests` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)