### PR TITLE
test(e2e): γ-suite coverage for ADR-0004 §5 agent-approval UX

### DIFF
--- a/ui/tests/e2e/fixtures/apiMock.ts
+++ b/ui/tests/e2e/fixtures/apiMock.ts
@@ -111,6 +111,10 @@ export type MockState = {
   installProbeCount: number
   /** Map of slot snapshots keyed by name — used for slot lifecycle. */
   slotSnapshots: Record<string, any>
+  /** Approval entries returned by GET /api/agent/approvals (Phase 8). */
+  agentApprovals: any[]
+  /** Installed bundled agents returned by GET /api/agents (Phase 8). */
+  agentInstalled: any[]
 }
 
 export function makeMockState(): MockState {
@@ -127,6 +131,8 @@ export function makeMockState(): MockState {
     installCompleteCount: 0,
     installProbeCount: 0,
     slotSnapshots: {},
+    agentApprovals: [],
+    agentInstalled: [],
   }
 }
 
@@ -199,6 +205,25 @@ export async function installDefaultMocks(page: Page, state: MockState) {
     }
     return json(route, { models: state.models })
   })
+
+  /* Agent surface (Phase 8). The header bell mounts on every page and
+     hits these two endpoints via ensureBootstrapped(); without explicit
+     routes the calls would fall through to the catch-all and yield
+     [], which is fine but routing here lets specs seed
+     `mockState.agentApprovals` / `agentInstalled` without per-spec
+     boilerplate.
+
+     Note: the EventSource for /api/agent/approvals/events is NOT routed
+     here — specs that drive SSE install the sseHarness which replaces
+     window.EventSource wholesale before navigation. Specs that don't
+     install the harness should add an empty-200 stub for the events URL
+     to keep the real EventSource from hitting the vite proxy. */
+  await page.route('**/api/agents', (route) =>
+    json(route, { agents: state.agentInstalled, count: state.agentInstalled.length }),
+  )
+  await page.route('**/api/agent/approvals', (route) =>
+    json(route, { approvals: state.agentApprovals }),
+  )
 }
 
 /* ── Test fixture wiring ─────────────────────────────────────────── */

--- a/ui/tests/e2e/specs/agent-flow.spec.ts
+++ b/ui/tests/e2e/specs/agent-flow.spec.ts
@@ -208,4 +208,196 @@ test.describe('Phase 8 — agent surface', () => {
     // Row is gone; badge gone.
     await expect(page.locator('.bell .badge')).toHaveCount(0)
   })
+
+  /* ── New γ coverage for ADR-0004 §5 gaps ─────────────────────────── */
+
+  test('@agent-approval deny clears the row + badge', async ({
+    page,
+    cleanState: _cleanState,
+  }) => {
+    await page.goto('/')
+    await waitForSse(page, '/api/agent/approvals/events')
+
+    // Enqueue + verify the badge appears.
+    await emitSse(page, '/api/agent/approvals/events', {
+      kind: 'enqueued',
+      entry: {
+        id: 'a-deny-1',
+        tool: 'model_delete',
+        args: { model_id: 'qwen3:0.6b' },
+        client_id: 'pi-coder',
+        enqueued_at: Date.now() / 1000,
+        state: 'pending',
+        hit_count: 1,
+        decided_at: null,
+        result: null,
+        error: null,
+      },
+    })
+    await expect(page.locator('.bell .badge')).toHaveText('1')
+
+    // Open modal, click Deny, intercept the POST.
+    await page.locator('.bell').click()
+    const modal = page.locator('.modal-card')
+    await expect(modal).toBeVisible()
+    await expect(modal.getByText('model_delete')).toBeVisible()
+
+    const denyReq = page.waitForRequest(
+      (req) =>
+        /\/api\/agent\/approvals\/a-deny-1\/deny$/.test(req.url()) &&
+        req.method() === 'POST',
+    )
+    await modal.getByRole('button', { name: /^Deny$/ }).click()
+    await denyReq
+
+    // Store optimistically clears on deny resolve; badge gone, row gone.
+    await expect(page.locator('.bell .badge')).toHaveCount(0)
+    await expect(modal.getByText('model_delete')).toHaveCount(0)
+  })
+
+  test('@agent-approval badge decrements as multi-pending get approved', async ({
+    page,
+    cleanState: _cleanState,
+  }) => {
+    await page.goto('/')
+    await waitForSse(page, '/api/agent/approvals/events')
+
+    // Drive two enqueueds — badge ticks to 2.
+    const baseEntry = {
+      tool: 'model_pull',
+      args: {},
+      client_id: 'pi-coder',
+      enqueued_at: Date.now() / 1000,
+      state: 'pending',
+      hit_count: 1,
+      decided_at: null,
+      result: null,
+      error: null,
+    }
+    await emitSse(page, '/api/agent/approvals/events', {
+      kind: 'enqueued',
+      entry: { ...baseEntry, id: 'a-multi-1', args: { model_id: 'qwen3:0.6b' } },
+    })
+    await emitSse(page, '/api/agent/approvals/events', {
+      kind: 'enqueued',
+      entry: { ...baseEntry, id: 'a-multi-2', args: { model_id: 'phi3-mini' } },
+    })
+    await expect(page.locator('.bell .badge')).toHaveText('2')
+
+    // Approve #1 — badge ticks down to 1. The store optimistically
+    // drops the row on the approve resolve (per stores/agent.js:182).
+    await page.locator('.bell').click()
+    const modal = page.locator('.modal-card')
+    await expect(modal).toBeVisible()
+    const row1 = modal.locator('.approval-row', { hasText: 'qwen3:0.6b' })
+    await expect(row1).toBeVisible()
+    const approve1 = page.waitForRequest(
+      (req) =>
+        /\/api\/agent\/approvals\/a-multi-1\/approve$/.test(req.url()) &&
+        req.method() === 'POST',
+    )
+    await row1.getByRole('button', { name: /^Approve$/ }).click()
+    await approve1
+    await expect(page.locator('.bell .badge')).toHaveText('1')
+
+    // Approve #2 — badge gone.
+    const row2 = modal.locator('.approval-row', { hasText: 'phi3-mini' })
+    await expect(row2).toBeVisible()
+    const approve2 = page.waitForRequest(
+      (req) =>
+        /\/api\/agent\/approvals\/a-multi-2\/approve$/.test(req.url()) &&
+        req.method() === 'POST',
+    )
+    await row2.getByRole('button', { name: /^Approve$/ }).click()
+    await approve2
+    await expect(page.locator('.bell .badge')).toHaveCount(0)
+  })
+
+  test('@agent-approval badge persists across reload via GET backfill', async ({
+    page,
+    mockState,
+    cleanState: _cleanState,
+  }) => {
+    await page.goto('/')
+    await waitForSse(page, '/api/agent/approvals/events')
+
+    // Step 1: emit the pending via SSE → badge '1'.
+    const entry = {
+      id: 'a-persist-1',
+      tool: 'slot_restart',
+      args: { slot: 'primary' },
+      client_id: 'pi-coder',
+      enqueued_at: Date.now() / 1000,
+      state: 'pending',
+      hit_count: 1,
+      decided_at: null,
+      result: null,
+      error: null,
+    }
+    await emitSse(page, '/api/agent/approvals/events', { kind: 'enqueued', entry })
+    await expect(page.locator('.bell .badge')).toHaveText('1')
+
+    // Step 2: stage the GET-backfill response and reload. After reload
+    // the store calls fetchPending() during ensureBootstrapped, so the
+    // backfill is what populates the badge on the fresh page.
+    mockState.agentApprovals = [entry]
+    await page.reload()
+
+    // SSE re-opens after reload; backfill from GET re-seeds pending.
+    await waitForSse(page, '/api/agent/approvals/events')
+    await expect(page.locator('.bell .badge')).toHaveText('1')
+  })
+
+  test('@agent-approval clear-all denies every pending', async ({
+    page,
+    cleanState: _cleanState,
+  }) => {
+    await page.goto('/')
+    await waitForSse(page, '/api/agent/approvals/events')
+
+    // Emit three enqueueds; badge climbs to '3'.
+    const baseEntry = {
+      tool: 'model_pull',
+      args: {},
+      client_id: 'pi-coder',
+      enqueued_at: Date.now() / 1000,
+      state: 'pending',
+      hit_count: 1,
+      decided_at: null,
+      result: null,
+      error: null,
+    }
+    for (const i of [1, 2, 3]) {
+      await emitSse(page, '/api/agent/approvals/events', {
+        kind: 'enqueued',
+        entry: { ...baseEntry, id: `a-clear-${i}`, args: { model_id: `m-${i}` } },
+      })
+    }
+    await expect(page.locator('.bell .badge')).toHaveText('3')
+
+    // Open modal.
+    await page.locator('.bell').click()
+    const modal = page.locator('.modal-card')
+    await expect(modal).toBeVisible()
+
+    // Track all three deny POSTs. stores/agent.js:clearAll loops the
+    // pending list and calls deny() on each entry; the existing default
+    // route mock for /deny is already in beforeEach.
+    const denyIds = new Set<string>()
+    page.on('request', (req) => {
+      const m = req.url().match(/\/api\/agent\/approvals\/([^/]+)\/deny$/)
+      if (m && req.method() === 'POST') denyIds.add(m[1])
+    })
+
+    // window.confirm is the user-facing gate for Clear-all — auto-accept.
+    page.once('dialog', (d) => d.accept())
+    await modal.getByRole('button', { name: /^Clear all$/ }).click()
+
+    // All three deny POSTs fired; badge cleared.
+    await expect.poll(() => denyIds.size, { timeout: 5000 }).toBe(3)
+    expect(denyIds.has('a-clear-1')).toBe(true)
+    expect(denyIds.has('a-clear-2')).toBe(true)
+    expect(denyIds.has('a-clear-3')).toBe(true)
+    await expect(page.locator('.bell .badge')).toHaveCount(0)
+  })
 })

--- a/ui/tests/e2e/specs/models.spec.ts
+++ b/ui/tests/e2e/specs/models.spec.ts
@@ -157,3 +157,57 @@ test('pulls a custom HF model, assigns it to primary, deletes it', async ({
     mockState.status.slots.find((s) => s.name === 'primary')?.model,
   ).toBeNull()
 })
+
+/**
+ * γ — inline pending-approval chip on Models rows (ADR-0004 §5).
+ *
+ * GET /api/agent/approvals returns one model_delete entry keyed on a
+ * known model id. The row's AgentPendingChip should render and link to
+ * /agent?tab=inbox.
+ */
+test('@agent-approval renders inline pending chip on a model row', async ({
+  page,
+  mockState,
+  cleanState: _cleanState,
+}) => {
+  // Seed the registry so a row exists for the chip to attach to. The
+  // store's pendingForResource('model', target) matches on
+  // args.model_id / args.id / args.name.
+  const MODEL_ID = 'phi3-mini'
+  mockState.models.push({ id: MODEL_ID, name: 'Phi-3 Mini', size_gb: 2.4 })
+
+  // Seed the approvals backfill. apiMock.ts's default route reads from
+  // mockState.agentApprovals so the bell + the row chip share state.
+  mockState.agentApprovals = [
+    {
+      id: 'a-model-1',
+      tool: 'model_delete',
+      args: { model_id: MODEL_ID },
+      client_id: 'pi-coder',
+      enqueued_at: Date.now() / 1000,
+      state: 'pending',
+      hit_count: 1,
+      decided_at: null,
+      result: null,
+      error: null,
+    },
+  ]
+
+  await page.goto('/models')
+
+  // Header bell knows about the one pending — sanity check that the
+  // store's bootstrap fetch ran before we assert on the inline chip.
+  await expect(page.locator('.bell .badge')).toHaveText('1')
+
+  // Row chip is present and labels the gated tool.
+  const row = page.locator('tr', { hasText: 'Phi-3 Mini' })
+  await expect(row).toBeVisible()
+  const chip = row.locator('.pending-chip')
+  await expect(chip).toHaveCount(1)
+  await expect(chip).toContainText('model_delete')
+
+  // Click chip → URL hops to the agent inbox tab. Don't bother fully
+  // rendering /agent — the route navigation itself is the contract.
+  await chip.click()
+  await expect(page).toHaveURL(/\/agent\?tab=inbox$/)
+})

--- a/ui/tests/e2e/specs/slot-lifecycle.spec.ts
+++ b/ui/tests/e2e/specs/slot-lifecycle.spec.ts
@@ -152,3 +152,57 @@ test('creates a slot, walks state transitions, restarts, unloads, deletes', asyn
   })
   await expect(page.locator('.slot-card', { hasText: 'test-vulkan' })).toHaveCount(0)
 })
+
+/**
+ * γ — inline pending-approval chip on Slots cards (ADR-0004 §5).
+ *
+ * Mirrors the Models inline-chip test: GET /api/agent/approvals returns
+ * one slot_delete entry for a known slot, and the slot card should
+ * render an AgentPendingChip pointing at /agent?tab=inbox.
+ */
+test('@agent-approval renders inline pending chip on a slot card', async ({
+  page,
+  mockState,
+  cleanState: _cleanState,
+}) => {
+  // Seed a custom slot so it actually shows in the grid. Built-in
+  // slots are filtered into capability cards, not the slot grid.
+  mockState.status.slots.push({
+    name: 'test-vulkan',
+    backend: 'vulkan',
+    model: null,
+    port: 8081,
+    status: 'offline',
+  })
+
+  // pendingForResource('slot', target) matches on args.slot or args.name.
+  mockState.agentApprovals = [
+    {
+      id: 'a-slot-1',
+      tool: 'slot_delete',
+      args: { slot: 'test-vulkan' },
+      client_id: 'pi-coder',
+      enqueued_at: Date.now() / 1000,
+      state: 'pending',
+      hit_count: 1,
+      decided_at: null,
+      result: null,
+      error: null,
+    },
+  ]
+
+  await page.goto('/slots')
+
+  // Bell badge confirms the bootstrap fetch landed.
+  await expect(page.locator('.bell .badge')).toHaveText('1')
+
+  // Slot card chip — scoped to the .slot-pending sibling next to the
+  // matching SlotCard.
+  const cardCell = page.locator('.slot-card', { hasText: 'test-vulkan' }).locator('..')
+  const chip = cardCell.locator('.pending-chip')
+  await expect(chip).toHaveCount(1)
+  await expect(chip).toContainText('slot_delete')
+
+  await chip.click()
+  await expect(page).toHaveURL(/\/agent\?tab=inbox$/)
+})


### PR DESCRIPTION
## Summary

Six concrete γ-suite gaps closed against the Phase 8 agent-approval UX shipped in #113. All tests pass locally (chromium, mocked mode); verified stable across two repeat-each runs.

Per ADR-0004 §5 — bell is canonical, inline chip is convenience, deny/approve/clear-all are the three terminal user actions. The existing γ spec covered only enqueue + approve (one approval). These six tests round out the contract.

## Tests added

All tagged `@agent-approval` for selective filtering.

In `ui/tests/e2e/specs/agent-flow.spec.ts`:
- `deny clears the row + badge` — enqueue via SSE → click Deny → POST `/api/agent/approvals/{id}/deny` intercepted → row + badge clear.
- `badge decrements as multi-pending get approved` — two SSE enqueueds → badge '2' → approve first → '1' → approve second → gone.
- `badge persists across reload via GET backfill` — emit → reload → backfill from GET `/api/agent/approvals` re-seeds the badge. Confirms SSE + REST unified view.
- `clear-all denies every pending` — 3 enqueueds → modal "Clear all" → 3 deny POSTs fire (confirmed via request-collector) → badge gone. window.confirm auto-accepted.

In `ui/tests/e2e/specs/models.spec.ts`:
- `renders inline pending chip on a model row` — GET `/api/agent/approvals` returns one `model_delete` for a known model id → row renders `AgentPendingChip` with the tool name → click chip → URL goes to `/agent?tab=inbox`.

In `ui/tests/e2e/specs/slot-lifecycle.spec.ts`:
- `renders inline pending chip on a slot card` — same pattern, `slot_delete` on a custom slot card.

## Fixture extension

Added `mockState.agentApprovals` and `mockState.agentInstalled` to `ui/tests/e2e/fixtures/apiMock.ts` plus default route stubs for `GET /api/agents` and `GET /api/agent/approvals`. Specs now seed pending approvals declaratively instead of duplicating per-spec route boilerplate (per the brief's note about avoiding agent-flow's per-test stub pattern in cross-cutting specs).

## Bonus (#7) — skipped

Capabilities-page inline chip skipped to keep this PR focused on the six required gaps. `CapabilitiesSection.vue:37-42` is straightforward to test next iteration; the fixture extension already supports it.

## Test plan

- [x] `npx playwright test tests/e2e/specs/agent-flow.spec.ts tests/e2e/specs/models.spec.ts tests/e2e/specs/slot-lifecycle.spec.ts` — 11 passed (13.9s)
- [x] `npx playwright test --grep "@agent-approval" --repeat-each 2` — 12 passed (15.2s), no flakes
- [ ] CI green on the chromium project

🤖 Generated with [Claude Code](https://claude.com/claude-code)