### PR TITLE
feat(lemonade): server_models.json generator from registry.toml (#141)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -764,6 +764,41 @@ else
     warn "skipping probe (HAL0_NO_PROBE=1)"
 fi
 
+# ── Lemonade server_models.json generation (issue #141) ───────────────────
+# Convert hal0's registry.toml into the curated catalog Lemonade Server
+# loads from ``resources/server_models.json``. Must run BEFORE
+# ``systemctl enable --now lemond`` so the daemon picks up our entries on
+# first start (Lemonade re-reads the file on probe, so a later sync
+# does not strictly require a restart).
+#
+# Guarded by the presence of the Lemonade resources directory: installs
+# that have not yet bundled Lemonade (issue #140 lands the tarball) are
+# skipped silently. Once #140 lands, this block becomes the canonical
+# install-time wiring without further changes here.
+#
+# Idempotent: re-running install.sh overwrites server_models.json via
+# atomic tempfile + rename. See ADR-0006 §4 + ``src/hal0/lemonade/server_models_gen.py``.
+ui_step "Lemonade server_models.json"
+
+LEMONADE_RESOURCES="/opt/lemonade/resources"
+LEMONADE_SERVER_MODELS="${LEMONADE_RESOURCES}/server_models.json"
+REGISTRY_TOML="${VAR_DIR}/registry/registry.toml"
+
+if [[ "${DEV_MODE}" -eq 0 && -d "${LEMONADE_RESOURCES}" ]]; then
+    if [[ ! -f "${REGISTRY_TOML}" ]]; then
+        warn "registry.toml not found at ${REGISTRY_TOML}; writing empty server_models.json"
+    fi
+    if "${VENV_DIR}/bin/python" -m hal0.lemonade.server_models_gen \
+        --registry "${REGISTRY_TOML}" \
+        --output "${LEMONADE_SERVER_MODELS}"; then
+        info "wrote ${LEMONADE_SERVER_MODELS}"
+    else
+        warn "server_models_gen failed; Lemonade will fall back to its bundled catalog"
+    fi
+else
+    info "skipping (Lemonade resources dir ${LEMONADE_RESOURCES} not present yet)"
+fi
+
 ui_step "Service start"
 
 if [[ "${DEV_MODE}" -eq 1 || "${NO_START}" -eq 1 ]]; then

--- a/src/hal0/cli/capabilities_commands.py
+++ b/src/hal0/cli/capabilities_commands.py
@@ -52,6 +52,10 @@ from hal0.capabilities.config import (
 )
 from hal0.capabilities.orchestrator import _CHILD_TO_CAPABILITY
 from hal0.config.loader import write_toml_atomic
+from hal0.lemonade.server_models_gen import (
+    generate_server_models,
+    write_server_models,
+)
 from hal0.registry.store import ModelRegistry
 
 app = typer.Typer(
@@ -370,3 +374,70 @@ def migrate_to_lemonade(
         f"v{before_version} → v{CAPABILITIES_SCHEMA_VERSION_CURRENT} "
         f"(backup at {backup.name})."
     )
+
+
+# ── sync (regenerate server_models.json from registry — issue #141) ──────────
+
+# Default paths for the sync command. Override-able for tests + dev installs.
+_DEFAULT_REGISTRY_PATH = Path("/var/lib/hal0/registry/registry.toml")
+_DEFAULT_SERVER_MODELS_PATH = Path("/opt/lemonade/resources/server_models.json")
+
+
+@app.command()
+def sync(
+    registry: Path = typer.Option(
+        _DEFAULT_REGISTRY_PATH,
+        "--registry",
+        help="Path to hal0 registry.toml.",
+    ),
+    output: Path = typer.Option(
+        _DEFAULT_SERVER_MODELS_PATH,
+        "--output",
+        help="Path to Lemonade's server_models.json.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show entry count and recipe summary without writing the file.",
+    ),
+) -> None:
+    """Regenerate Lemonade's ``server_models.json`` from hal0's registry.
+
+    This is the runtime entry point for issue #141 (the install-time hook
+    runs the same code path via ``python -m hal0.lemonade.server_models_gen``).
+    Lemonade re-scans ``resources/server_models.json`` on its next probe,
+    so a sync does NOT require restarting ``lemond.service`` — the next
+    ``/v1/load`` or ``/v1/models`` call sees the new entries.
+
+    Idempotent: re-running with an unchanged registry produces an identical
+    byte stream. Safe to invoke from cron, post-pull hooks, or operators.
+    """
+    catalog = generate_server_models(registry)
+
+    if not catalog:
+        console.print(
+            f"[yellow]warning[/yellow] — no models in {registry}; would write an empty catalog."
+        )
+
+    # Summary table: model id + recipe + first label (the Lemonade type driver).
+    table = Table(title=f"server_models.json ({len(catalog)} entries)")
+    table.add_column("model_id", style="bold")
+    table.add_column("recipe")
+    table.add_column("labels", overflow="fold")
+    table.add_column("checkpoint", overflow="fold")
+    for mid, entry in catalog.items():
+        labels = entry.get("labels") or []
+        table.add_row(
+            mid,
+            entry.get("recipe", "—"),
+            ", ".join(labels) or "(llm)",
+            entry.get("checkpoint", "—"),
+        )
+    console.print(table)
+
+    if dry_run:
+        console.print(f"\n[yellow]--dry-run[/yellow] — not writing {output}.")
+        raise typer.Exit(0)
+
+    write_server_models(registry, output)
+    console.print(f"\n[green]wrote[/green] {len(catalog)} entries to {output}.")

--- a/src/hal0/lemonade/__init__.py
+++ b/src/hal0/lemonade/__init__.py
@@ -31,6 +31,10 @@ from hal0.lemonade.errors import (
 )
 from hal0.lemonade.idle import IdleDriver
 from hal0.lemonade.preload import PreloadError, preload_validate
+from hal0.lemonade.server_models_gen import (
+    generate_server_models,
+    write_server_models,
+)
 
 __all__ = [
     "IdleDriver",
@@ -41,5 +45,7 @@ __all__ = [
     "LemonadeTimeoutError",
     "LemonadeUnavailableError",
     "PreloadError",
+    "generate_server_models",
     "preload_validate",
+    "write_server_models",
 ]

--- a/src/hal0/lemonade/server_models_gen.py
+++ b/src/hal0/lemonade/server_models_gen.py
@@ -1,0 +1,530 @@
+"""``server_models.json`` generator from hal0's model registry.
+
+Produces a hal0-customized ``server_models.json`` (Lemonade Server's
+curated catalog) by reading ``/var/lib/hal0/registry/registry.toml``
+and emitting one Lemonade entry per registered model with the correct
+``labels`` so Lemonade infers the right model ``type`` at load time.
+
+Why this exists
+---------------
+Lemonade's bundled ``server_models.json`` does not list hal0's curated
+picks (``hermes-4-14b``, ``qwen3.6-35b-a3b``, ``qwen3-coder-next-reap``,
+``bge-reranker-v2-m3``, …). The 2026-05-22 spike found that
+``extra_models_dir`` discovery silently classifies every GGUF as
+``type=llm`` because custom-discovered models get only the
+``["custom"]`` label — so ``--reranking`` and ``--embedding`` never make
+it to the child llama-server and Lemonade serves rerank/embed requests
+as plain LLM completions (or 501s). See:
+
+  * ADR-0006 §4 — Model registration via hal0-customized
+    ``server_models.json``.
+  * ``docs/internal/lemonade-spike-findings-2026-05-22.md`` §"Model
+    discovery + typing" — the smoking-gun failure mode.
+  * ``docs/internal/lemonade-repo-deep-dive-2026-05-22.md`` §3 — type
+    classification is **label-driven**, not field-driven; the
+    ``"type"`` field the brief mentions is conceptual. Lemonade's
+    ``get_model_type_from_labels()`` (``src/cpp/include/lemon/model_types.h``)
+    resolves first-match on labels:
+
+        embeddings/embedding → EMBEDDING
+        reranking            → RERANKING
+        transcription        → TRANSCRIPTION
+        image                → IMAGE
+        tts                  → TTS
+        else                 → LLM
+
+    Chat-indicator labels (``vision``, ``reasoning``, ``tool-calling``,
+    ``tools``, ``chat-transcription``) override the first-match to LLM,
+    so we never set ``embeddings`` on a chat model.
+
+Output schema (subset of Lemonade's ``server_models.json``):
+
+::
+
+    {
+      "<model_id>": {
+        "checkpoint": "<owner>/<repo>:<filename>"  | "/abs/path/to.gguf",
+        "recipe":     "llamacpp" | "whispercpp" | "kokoro" | "sd-cpp" | "flm",
+        "labels":     ["embeddings"|"reranking"|"transcription"|"image"|"tts"|...],
+        "size":       <float, GB; 0.0 if unknown>,
+        "suggested":  false,
+        "max_context_window": <int, optional, llm only>
+      },
+      ...
+    }
+
+The generator is intentionally pure: it reads one file, returns a dict,
+and the writer is a separate atomic-replace step. The install hook + a
+new ``hal0 capabilities sync`` subcommand both call ``write_server_models``.
+
+# NOTE: This module sits next to ``client.py`` but does NOT import it.
+# Generation is a one-shot file → file transform; runtime client traffic
+# stays in ``client.py``. Keeping the import boundary clean means tests
+# can run without the httpx machinery from the client.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import logging
+import os
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# ── Mapping tables ─────────────────────────────────────────────────────────────
+
+# hal0 capability → Lemonade label (the string the C++ classifier matches).
+#
+# hal0 historically uses the singular forms (``embed``, ``rerank``); the issue
+# brief uses the plural English forms (``embedding``, ``reranking``). We
+# accept both on input. Output is always the Lemonade-canonical token from
+# ``get_model_type_from_labels()``.
+_CAPABILITY_TO_LABEL: dict[str, str] = {
+    # Embedding
+    "embed": "embeddings",
+    "embedding": "embeddings",
+    "embeddings": "embeddings",
+    # Reranking
+    "rerank": "reranking",
+    "reranking": "reranking",
+    # ASR / transcription
+    "asr": "transcription",
+    "transcription": "transcription",
+    "stt": "transcription",
+    # TTS
+    "tts": "tts",
+    # Image gen
+    "image": "image",
+    "img": "image",
+    # Vision (chat-indicator: forces LLM in Lemonade's classifier)
+    "vision": "vision",
+    # Chat — no Lemonade label needed; LLM is the default
+    "chat": None,  # type: ignore[dict-item]
+}
+
+# Strength ranking — if a model advertises multiple capabilities, the
+# strongest non-chat one wins. We prefer the most specific/limiting type,
+# which matches Lemonade's "non-LLM modalities need explicit registration"
+# semantics. Strongest first → we iterate this list and pick the first match.
+#
+# Vision is not in this list: a chat+vision model should stay LLM (Lemonade's
+# classifier already treats ``vision`` as a chat-indicator label). We emit
+# ``vision`` as a *secondary* label without using it to drive type.
+_CAPABILITY_STRENGTH: tuple[str, ...] = (
+    "rerank",
+    "reranking",
+    "embed",
+    "embedding",
+    "embeddings",
+    "asr",
+    "transcription",
+    "stt",
+    "tts",
+    "image",
+    "img",
+    "chat",
+)
+
+
+# hal0 backend → Lemonade recipe. Multiple hal0 backends can map to the
+# same Lemonade recipe (vulkan/rocm/cuda/cpu are all ``llamacpp`` recipe;
+# the GPU choice is a load-time argument, not a recipe).
+_BACKEND_TO_RECIPE: dict[str, str] = {
+    "vulkan": "llamacpp",
+    "rocm": "llamacpp",
+    "cuda": "llamacpp",
+    "cpu": "llamacpp",
+    "llamacpp": "llamacpp",
+    "moonshine": "whispercpp",  # hal0 used moonshine for ASR; Lemonade has whispercpp
+    "whispercpp": "whispercpp",
+    "whisper": "whispercpp",
+    "kokoro": "kokoro",
+    "sdcpp": "sd-cpp",
+    "sd-cpp": "sd-cpp",
+    "stable-diffusion": "sd-cpp",
+    "comfyui": "sd-cpp",
+    "flm": "flm",
+    "ryzenai-llm": "ryzenai-llm",
+}
+
+# Per-modality default recipes when the registry doesn't advertise any
+# compatible backend. Falls back to llamacpp for chat/embed/rerank since
+# all hal0 GGUFs work there. ASR → whispercpp (Lemonade dropped moonshine).
+_DEFAULT_RECIPE_BY_LABEL: dict[str, str] = {
+    "embeddings": "llamacpp",
+    "reranking": "llamacpp",
+    "transcription": "whispercpp",
+    "tts": "kokoro",
+    "image": "sd-cpp",
+}
+
+# Default context window for chat models when registry doesn't specify.
+_DEFAULT_LLM_CTX: int = 8192
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _read_registry(registry_path: Path) -> dict[str, dict[str, Any]]:
+    """Parse registry.toml and return ``{model_id: entry_dict}``.
+
+    Returns an empty dict when the file is missing or malformed (log at
+    WARN). This matches ``ModelRegistry._read_locked``'s never-blank-on-
+    parse-error stance: an install hook running against a yet-to-be-
+    populated registry should produce an empty ``server_models.json``,
+    not an error.
+    """
+    try:
+        with open(registry_path, "rb") as f:
+            data = tomllib.load(f)
+    except FileNotFoundError:
+        log.warning("registry not found at %s — emitting empty catalog", registry_path)
+        return {}
+    except (tomllib.TOMLDecodeError, OSError) as exc:
+        log.warning(
+            "registry parse failed at %s: %s — emitting empty catalog",
+            registry_path,
+            exc,
+        )
+        return {}
+
+    raw = data.get("models", {}) if isinstance(data, dict) else {}
+    out: dict[str, dict[str, Any]] = {}
+
+    if isinstance(raw, dict):
+        for mid, entry in raw.items():
+            if isinstance(entry, dict):
+                out[mid] = entry
+    elif isinstance(raw, list):
+        # ModelRegistry accepts list-of-tables for backcompat with haloai;
+        # mirror that here so the generator works against either shape.
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            mid = entry.get("id")
+            if isinstance(mid, str) and mid:
+                out[mid] = entry
+
+    return out
+
+
+def _pick_primary_capability(caps: list[str]) -> str | None:
+    """Return the strongest non-chat capability, or 'chat' if only chat, or None."""
+    seen = {c.lower() for c in caps if isinstance(c, str)}
+    if not seen:
+        return None
+    for candidate in _CAPABILITY_STRENGTH:
+        if candidate in seen:
+            return candidate
+    # Capability present but unknown — fall through to LLM default.
+    return None
+
+
+def _resolve_recipe(backends: list[str], primary_label: str | None) -> str:
+    """Pick a Lemonade recipe from a hal0 backends list.
+
+    ``flm`` wins if present (NPU is exclusive; hal0 only puts ``flm`` in
+    a model's backends list when the GGUF actually has FLM weights).
+    Otherwise the first known mapping wins. Falls back to the
+    label-default (llamacpp/whispercpp/kokoro/sd-cpp) when none of the
+    registry's backends are recognised.
+    """
+    lowered = [b.lower() for b in backends if isinstance(b, str)]
+    if "flm" in lowered:
+        return "flm"
+    for b in lowered:
+        recipe = _BACKEND_TO_RECIPE.get(b)
+        if recipe:
+            return recipe
+    if primary_label and primary_label in _DEFAULT_RECIPE_BY_LABEL:
+        return _DEFAULT_RECIPE_BY_LABEL[primary_label]
+    return "llamacpp"
+
+
+def _resolve_checkpoint(entry: dict[str, Any]) -> str:
+    """Build Lemonade's ``checkpoint`` string from a registry entry.
+
+    Format precedence (matching Lemonade's own server_models.json conventions):
+
+    1. ``hf_repo`` + ``hf_filename`` → ``"<owner>/<repo>:<filename>"``
+    2. ``hf_repo`` alone             → ``"<owner>/<repo>"``
+    3. ``path`` (local-only model)   → absolute path string
+
+    The local-path fallback covers models registered via direct file
+    scan (no HF coords). Lemonade's loader accepts an absolute path
+    where it would normally take an HF repo id; the checkpoint resolver
+    in ``src/cpp/server/checkpoint_resolver.cpp`` short-circuits to file
+    loading when the string starts with ``/``.
+    """
+    repo = entry.get("hf_repo") or ""
+    filename = entry.get("hf_filename") or ""
+    if repo and filename:
+        return f"{repo}:{filename}"
+    if repo:
+        return repo
+    path = entry.get("path") or ""
+    return str(path)
+
+
+def _resolve_size_gb(entry: dict[str, Any]) -> float:
+    """Return model size in GB (1024^3 base) for Lemonade's ``size`` field.
+
+    Lemonade displays this in its UI; if the registry says 0 we just emit
+    0.0 — Lemonade falls back to the on-disk file size at load time.
+    """
+    size_bytes = entry.get("size_bytes")
+    if not isinstance(size_bytes, int | float) or size_bytes <= 0:
+        return 0.0
+    # Round to 4 sig figs to keep diffs stable across pulls.
+    return round(float(size_bytes) / (1024**3), 4)
+
+
+def _resolve_ctx(entry: dict[str, Any], primary_label: str | None) -> int | None:
+    """Return ``max_context_window`` value for the entry, or None.
+
+    Priority order:
+      1. ``defaults.context_size`` — operator-set launcher default
+      2. ``metadata.context_length`` — GGUF arch max (set by detect.py)
+      3. ``_DEFAULT_LLM_CTX`` for chat models with no other signal
+      4. None for non-llm modalities (embeddings/rerank/asr/tts/image)
+    """
+    defaults = entry.get("defaults") or {}
+    if isinstance(defaults, dict):
+        ctx = defaults.get("context_size")
+        if isinstance(ctx, int) and ctx > 0:
+            return ctx
+
+    metadata = entry.get("metadata") or {}
+    if isinstance(metadata, dict):
+        ctx = metadata.get("context_length")
+        if isinstance(ctx, int) and ctx > 0:
+            return ctx
+
+    # Only llm models get a default context. Embeddings/rerank/etc carry
+    # their own context window in the model file; Lemonade picks it up.
+    if primary_label is None:
+        # No capability listed → treat as LLM, return default.
+        return _DEFAULT_LLM_CTX
+    if primary_label == "chat":
+        return _DEFAULT_LLM_CTX
+    return None
+
+
+def _entry_labels(caps: list[str], tags: list[str], primary_label: str | None) -> list[str]:
+    """Build the ``labels`` list for one Lemonade entry.
+
+    Rules:
+      * The primary Lemonade type label (one of ``embeddings`` / ``reranking``
+        / ``transcription`` / ``tts`` / ``image``) goes first when present.
+      * ``vision`` is preserved as a secondary label so Lemonade's
+        chat-indicator classifier keeps a vision-LLM as LLM.
+      * Other hal0 tags get a passthrough copy (deduped, no None values).
+    """
+    out: list[str] = []
+    if primary_label and primary_label != "chat":
+        mapped = _CAPABILITY_TO_LABEL.get(primary_label)
+        if mapped:
+            out.append(mapped)
+
+    # Always preserve vision as a chat-indicator label.
+    if any(isinstance(c, str) and c.lower() == "vision" for c in caps) and "vision" not in out:
+        out.append("vision")
+
+    # Tag passthrough: lowercase, dedupe.
+    for tag in tags or []:
+        if not isinstance(tag, str):
+            continue
+        tl = tag.lower()
+        if tl and tl not in out:
+            out.append(tl)
+
+    return out
+
+
+# ── Public API ─────────────────────────────────────────────────────────────────
+
+
+def generate_server_models(registry_path: Path) -> dict[str, dict[str, Any]]:
+    """Read ``registry.toml`` and return the Lemonade ``server_models.json`` dict.
+
+    The returned dict is sorted by model id (deterministic output) so the
+    file is diff-friendly across runs. The caller serialises with
+    ``json.dumps(..., indent=4)`` to match Lemonade's own formatting.
+
+    Args:
+        registry_path: Absolute path to ``registry.toml``. A missing file
+            yields an empty dict (warning logged); the install hook can
+            still write a valid empty catalog.
+
+    Returns:
+        ``{model_id: {checkpoint, recipe, labels, size, suggested, ...}}``.
+    """
+    registry_path = Path(registry_path)
+    entries = _read_registry(registry_path)
+
+    out: dict[str, dict[str, Any]] = {}
+    for mid in sorted(entries):
+        entry = entries[mid]
+        caps = list(entry.get("capabilities") or [])
+        primary = _pick_primary_capability(caps)
+        primary_label = _CAPABILITY_TO_LABEL.get(primary or "chat")
+        # primary_label is None when capability is 'chat' (no Lemonade label
+        # needed) or unrecognised. Either way recipe-resolve handles it.
+
+        backends = list(entry.get("backends") or [])
+        recipe = _resolve_recipe(backends, primary_label)
+
+        checkpoint = _resolve_checkpoint(entry)
+        size_gb = _resolve_size_gb(entry)
+        labels = _entry_labels(caps, list(entry.get("tags") or []), primary)
+
+        lemon: dict[str, Any] = {
+            "checkpoint": checkpoint,
+            "recipe": recipe,
+            "labels": labels,
+            "size": size_gb,
+            "suggested": False,
+        }
+
+        ctx = _resolve_ctx(entry, primary)
+        # Lemonade reads max_context_window via recipe_options at load time;
+        # we surface it as a sibling key for documentation + hal0 UI use.
+        if ctx is not None and recipe in ("llamacpp", "flm"):
+            lemon["max_context_window"] = ctx
+
+        out[mid] = lemon
+
+    return out
+
+
+def write_server_models(
+    registry_path: Path,
+    output_path: Path,
+) -> None:
+    """Generate + atomically write ``server_models.json``.
+
+    The write goes through a sibling tempfile + ``os.replace``: a partial
+    write never overwrites the live file, so a crash mid-run leaves
+    Lemonade's existing catalog intact. Same pattern as
+    ``ModelRegistry._atomic_write``.
+
+    Idempotent: re-running with an unchanged registry produces the same
+    bytes (sorted keys + stable float rounding). Safe to call from the
+    install.sh hook OR from ``hal0 capabilities sync``.
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    catalog = generate_server_models(registry_path)
+    payload = json.dumps(catalog, indent=4, sort_keys=False) + "\n"
+
+    tmp_path: Path | None = None
+    try:
+        fd, tmp_str = tempfile.mkstemp(
+            prefix=f".{output_path.name}.",
+            suffix=".tmp",
+            dir=output_path.parent,
+        )
+        tmp_path = Path(tmp_str)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(payload)
+                f.flush()
+                os.fsync(f.fileno())
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise
+        os.replace(tmp_path, output_path)
+        tmp_path = None
+    finally:
+        if tmp_path is not None:
+            with contextlib.suppress(OSError):
+                tmp_path.unlink(missing_ok=True)
+
+
+# ── CLI entry point ────────────────────────────────────────────────────────────
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m hal0.lemonade.server_models_gen",
+        description=(
+            "Generate Lemonade Server's server_models.json from hal0's "
+            "registry.toml. Run at install time (before lemond.service "
+            "starts) and on `hal0 capabilities sync`."
+        ),
+    )
+    p.add_argument(
+        "--registry",
+        type=Path,
+        default=Path("/var/lib/hal0/registry/registry.toml"),
+        help="Path to hal0 registry.toml (default: /var/lib/hal0/registry/registry.toml).",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=Path("/opt/lemonade/resources/server_models.json"),
+        help="Output path (default: /opt/lemonade/resources/server_models.json).",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print generated JSON to stdout instead of writing.",
+    )
+    return p
+
+
+def cli_main(argv: list[str] | None = None) -> int:
+    """Entry point for ``python -m hal0.lemonade.server_models_gen``.
+
+    Returns the process exit code (0 on success). Logs go to stderr at
+    INFO so install.sh can quote them in its progress output.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(message)s",
+        stream=sys.stderr,
+    )
+    args = _build_arg_parser().parse_args(argv)
+
+    if args.dry_run:
+        catalog = generate_server_models(args.registry)
+        json.dump(catalog, sys.stdout, indent=4)
+        sys.stdout.write("\n")
+        log.info(
+            "server_models_gen: dry-run — %d entries from %s",
+            len(catalog),
+            args.registry,
+        )
+        return 0
+
+    write_server_models(args.registry, args.output)
+    # Re-read for the count without paying the round-trip cost again.
+    catalog = generate_server_models(args.registry)
+    log.info(
+        "server_models_gen: wrote %d entries to %s (from %s)",
+        len(catalog),
+        args.output,
+        args.registry,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised via test_cli_main
+    sys.exit(cli_main())
+
+
+__all__ = [
+    "cli_main",
+    "generate_server_models",
+    "write_server_models",
+]

--- a/tests/cli/test_capabilities_sync.py
+++ b/tests/cli/test_capabilities_sync.py
@@ -1,0 +1,101 @@
+"""Tests for ``hal0 capabilities sync`` — runtime entry point for #141.
+
+The install hook calls ``python -m hal0.lemonade.server_models_gen``
+directly (tested under tests/lemonade/test_server_models_gen.py); this
+file covers the Typer-mounted equivalent operators reach for after a
+``hal0 model pull`` or registry edit.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import tomli_w
+from typer.testing import CliRunner
+
+from hal0.cli.capabilities_commands import app as capabilities_app
+
+runner = CliRunner()
+
+
+def _write_registry(path: Path, models: dict[str, dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        tomli_w.dump({"models": models}, f)
+
+
+def test_sync_writes_server_models_file(tmp_path: Path) -> None:
+    registry = tmp_path / "registry.toml"
+    output = tmp_path / "server_models.json"
+    _write_registry(
+        registry,
+        {
+            "bge-reranker-v2-m3-q4_k_m": {
+                "path": "/mnt/ai-models/local/bge-reranker-v2-m3-Q4_K_M.gguf",
+                "capabilities": ["rerank"],
+                "backends": ["llamacpp"],
+                "hf_repo": "gpustack/bge-reranker-v2-m3-GGUF",
+                "hf_filename": "bge-reranker-v2-m3-Q4_K_M.gguf",
+            }
+        },
+    )
+
+    result = runner.invoke(
+        capabilities_app,
+        ["sync", "--registry", str(registry), "--output", str(output)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert output.exists()
+
+    with open(output) as f:
+        parsed = json.load(f)
+    assert parsed["bge-reranker-v2-m3-q4_k_m"]["labels"] == ["reranking"]
+
+
+def test_sync_dry_run_does_not_write(tmp_path: Path) -> None:
+    registry = tmp_path / "registry.toml"
+    output = tmp_path / "server_models.json"
+    _write_registry(
+        registry,
+        {
+            "m": {
+                "path": "/x.gguf",
+                "capabilities": ["chat"],
+                "backends": ["vulkan"],
+            }
+        },
+    )
+
+    result = runner.invoke(
+        capabilities_app,
+        [
+            "sync",
+            "--registry",
+            str(registry),
+            "--output",
+            str(output),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert not output.exists()
+    # The summary table is printed even in dry-run.
+    assert "m" in result.output
+
+
+def test_sync_empty_registry_warns(tmp_path: Path) -> None:
+    registry = tmp_path / "registry.toml"
+    output = tmp_path / "server_models.json"
+    # No registry file present at all → empty catalog, warning issued.
+
+    result = runner.invoke(
+        capabilities_app,
+        ["sync", "--registry", str(registry), "--output", str(output), "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    # The warning is emitted regardless of dry-run.
+    assert "no models" in result.output or "warning" in result.output.lower()

--- a/tests/lemonade/test_server_models_gen.py
+++ b/tests/lemonade/test_server_models_gen.py
@@ -1,0 +1,748 @@
+"""Unit tests for ``hal0.lemonade.server_models_gen``.
+
+The generator turns hal0's registry.toml into Lemonade Server's
+``server_models.json`` shape. Tests assert:
+
+  * Each hal0 capability maps to the correct Lemonade label.
+  * The bge-reranker-v2-m3-q4_k_m smoke case (the spike's smoking-gun
+    rerank failure) gets ``labels=["reranking"]``.
+  * Backend → recipe resolution covers chat (llamacpp), asr (whispercpp),
+    tts (kokoro), image (sd-cpp), NPU (flm).
+  * Checkpoint formatting handles HF coords + local-path fallback.
+  * The atomic write doesn't leave half-written files on disk.
+  * The CLI entry point round-trips registry → JSON file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import tomli_w
+
+from hal0.lemonade.server_models_gen import (
+    cli_main,
+    generate_server_models,
+    write_server_models,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _write_registry(path: Path, models: dict[str, dict]) -> None:
+    """Write a minimal registry.toml at ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"models": models}
+    with open(path, "wb") as f:
+        tomli_w.dump(payload, f)
+
+
+@pytest.fixture
+def registry_path(tmp_path: Path) -> Path:
+    return tmp_path / "registry" / "registry.toml"
+
+
+# ── Capability → label mapping ───────────────────────────────────────────────
+
+
+class TestCapabilityMapping:
+    """Each hal0 capability maps to the correct Lemonade label."""
+
+    def test_chat_has_no_special_label(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "hermes-4-14b-q5_k_m": {
+                    "path": "/mnt/ai-models/local/hermes-4-14b-q5_k_m.gguf",
+                    "capabilities": ["chat"],
+                    "backends": ["vulkan", "rocm", "cpu"],
+                    "hf_repo": "NousResearch/Hermes-4-14B-GGUF",
+                    "hf_filename": "hermes-4-14b-q5_k_m.gguf",
+                    "size_bytes": 11_500_000_000,
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        entry = out["hermes-4-14b-q5_k_m"]
+        # No type label needed: Lemonade's classifier defaults to LLM.
+        assert entry["labels"] == []
+        assert entry["recipe"] == "llamacpp"
+        assert entry["max_context_window"] == 8192  # default for llm
+
+    def test_embed_maps_to_embeddings_label(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "nomic-embed-text-v1": {
+                    "path": "/mnt/ai-models/local/nomic-embed-text-v1.gguf",
+                    "capabilities": ["embed"],
+                    "backends": ["vulkan", "cpu"],
+                    "hf_repo": "nomic-ai/nomic-embed-text-v1-GGUF",
+                    "hf_filename": "nomic-embed-text-v1.Q4_K_M.gguf",
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["nomic-embed-text-v1"]["labels"] == ["embeddings"]
+        # Embeddings don't get max_context_window (Lemonade reads it
+        # from the GGUF arch header).
+        assert "max_context_window" not in out["nomic-embed-text-v1"]
+
+    def test_embedding_plural_alias_also_maps(self, registry_path: Path) -> None:
+        """Brief uses the plural English form; hal0 uses singular.
+        Generator accepts both."""
+        _write_registry(
+            registry_path,
+            {
+                "bge-base-embedding": {
+                    "path": "/x.gguf",
+                    "capabilities": ["embedding"],
+                    "backends": ["llamacpp"],
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["bge-base-embedding"]["labels"] == ["embeddings"]
+
+    def test_asr_maps_to_transcription_label(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "whisper-base": {
+                    "path": "/models/whisper-base.bin",
+                    "capabilities": ["asr"],
+                    "backends": ["whispercpp"],
+                    "hf_repo": "ggerganov/whisper.cpp",
+                    "hf_filename": "ggml-base.bin",
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["whisper-base"]["labels"] == ["transcription"]
+        assert out["whisper-base"]["recipe"] == "whispercpp"
+
+    def test_tts_maps_to_tts_label(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "kokoro-v1": {
+                    "path": "/models/kokoro-v1",
+                    "capabilities": ["tts"],
+                    "backends": ["kokoro"],
+                    "hf_repo": "mikkoph/kokoro-onnx",
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["kokoro-v1"]["labels"] == ["tts"]
+        assert out["kokoro-v1"]["recipe"] == "kokoro"
+
+    def test_image_maps_to_image_label(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "sd-turbo": {
+                    "path": "/models/sd-turbo.safetensors",
+                    "capabilities": ["image"],
+                    "backends": ["sd-cpp"],
+                    "hf_repo": "stabilityai/sd-turbo",
+                    "hf_filename": "sd_turbo.safetensors",
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["sd-turbo"]["labels"] == ["image"]
+        assert out["sd-turbo"]["recipe"] == "sd-cpp"
+
+    def test_unknown_capability_falls_back_to_llm(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "weird-model": {
+                    "path": "/x.gguf",
+                    "capabilities": ["bogus-cap"],
+                    "backends": ["vulkan"],
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        # bogus capability ignored, defaults to llm (no labels).
+        assert out["weird-model"]["labels"] == []
+        assert out["weird-model"]["recipe"] == "llamacpp"
+        assert out["weird-model"]["max_context_window"] == 8192
+
+
+# ── Multi-capability resolution ──────────────────────────────────────────────
+
+
+class TestMultiCapability:
+    """When a model advertises multiple capabilities, the strongest wins.
+
+    Rerank > Embed > Chat per the generator's strength ranking.
+    """
+
+    def test_rerank_wins_over_embed(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "dual-rerank-embed": {
+                    "path": "/x.gguf",
+                    "capabilities": ["embed", "rerank"],
+                    "backends": ["llamacpp"],
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["dual-rerank-embed"]["labels"] == ["reranking"]
+
+    def test_embed_wins_over_chat(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "dual-embed-chat": {
+                    "path": "/x.gguf",
+                    "capabilities": ["chat", "embed"],
+                    "backends": ["llamacpp"],
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["dual-embed-chat"]["labels"] == ["embeddings"]
+
+    def test_vision_chat_keeps_llm_with_vision_secondary(self, registry_path: Path) -> None:
+        """Vision is a chat-indicator label in Lemonade; emitting it as a
+        secondary label keeps the model classified as LLM even if the
+        registry adds vision alongside chat."""
+        _write_registry(
+            registry_path,
+            {
+                "qwen2-vl-7b": {
+                    "path": "/x.gguf",
+                    "capabilities": ["chat", "vision"],
+                    "backends": ["vulkan"],
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        labels = out["qwen2-vl-7b"]["labels"]
+        assert "vision" in labels
+        # No embedding/reranking label snuck in.
+        assert "embeddings" not in labels
+        assert "reranking" not in labels
+
+
+# ── Smoking-gun case: bge-reranker-v2-m3-q4_k_m ──────────────────────────────
+
+
+class TestBgeRerankerSmokeCase:
+    """The 2026-05-22 spike's smoking-gun failure was that bge-reranker-v2-m3
+    discovered via extra_models_dir loaded as type=LLM (label ``custom``),
+    so the child llama-server never got ``--reranking`` and `/v1/reranking`
+    returned 501. This test asserts our generator produces an entry that
+    Lemonade's ``get_model_type_from_labels()`` will classify as RERANKING.
+    """
+
+    def test_bge_reranker_v2_m3_q4_k_m_has_reranking_label(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "bge-reranker-v2-m3-q4_k_m": {
+                    "name": "BGE Reranker v2 M3 (Q4_K_M)",
+                    "path": "/mnt/ai-models/local/bge-reranker-v2-m3-Q4_K_M.gguf",
+                    "size_bytes": 440_000_000,
+                    "capabilities": ["rerank"],
+                    "backends": ["llamacpp", "vulkan", "cpu"],
+                    "hf_repo": "gpustack/bge-reranker-v2-m3-GGUF",
+                    "hf_filename": "bge-reranker-v2-m3-Q4_K_M.gguf",
+                    "metadata": {"context_length": 8192},
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+
+        assert "bge-reranker-v2-m3-q4_k_m" in out
+        entry = out["bge-reranker-v2-m3-q4_k_m"]
+
+        # The smoke assertion: Lemonade infers RERANKING type from this label.
+        assert entry["labels"] == ["reranking"]
+        # And we route via llamacpp (which gets --reranking pushed).
+        assert entry["recipe"] == "llamacpp"
+        # HF checkpoint coords intact so Lemonade resolves the GGUF blob.
+        assert (
+            entry["checkpoint"] == "gpustack/bge-reranker-v2-m3-GGUF:bge-reranker-v2-m3-Q4_K_M.gguf"
+        )
+
+
+# ── Backend → recipe resolution ──────────────────────────────────────────────
+
+
+class TestBackendRecipeResolution:
+    def test_vulkan_rocm_cpu_all_map_to_llamacpp(self, registry_path: Path) -> None:
+        for backend in ("vulkan", "rocm", "cuda", "cpu"):
+            _write_registry(
+                registry_path,
+                {
+                    "m": {
+                        "path": "/x.gguf",
+                        "capabilities": ["chat"],
+                        "backends": [backend],
+                    }
+                },
+            )
+            out = generate_server_models(registry_path)
+            assert out["m"]["recipe"] == "llamacpp", f"backend={backend}"
+
+    def test_flm_backend_wins_over_other_backends(self, registry_path: Path) -> None:
+        """NPU is exclusive — flm presence forces flm recipe."""
+        _write_registry(
+            registry_path,
+            {
+                "amd-olmo-1b-hybrid": {
+                    "path": "/x.onnx",
+                    "capabilities": ["chat"],
+                    "backends": ["flm", "vulkan"],  # flm even alongside others
+                    "hf_repo": "amd/AMD-OLMo-1B-SFT-DPO-onnx-ryzenai-1.7-hybrid",
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["amd-olmo-1b-hybrid"]["recipe"] == "flm"
+
+    def test_moonshine_backend_maps_to_whispercpp(self, registry_path: Path) -> None:
+        """Lemonade dropped moonshine; we route hal0 moonshine entries
+        through whispercpp."""
+        _write_registry(
+            registry_path,
+            {
+                "moonshine-small": {
+                    "path": "/models/moonshine-small",
+                    "capabilities": ["asr"],
+                    "backends": ["moonshine"],
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["moonshine-small"]["recipe"] == "whispercpp"
+
+    def test_empty_backends_falls_back_to_label_default(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "stt-only": {
+                    "path": "/x",
+                    "capabilities": ["asr"],
+                    "backends": [],
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        # asr → transcription label → whispercpp default
+        assert out["stt-only"]["recipe"] == "whispercpp"
+
+
+# ── Checkpoint formatting ────────────────────────────────────────────────────
+
+
+class TestCheckpointFormatting:
+    def test_hf_repo_plus_filename(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "m": {
+                    "path": "/x.gguf",
+                    "capabilities": ["chat"],
+                    "backends": ["vulkan"],
+                    "hf_repo": "Qwen/Qwen3-4B-GGUF",
+                    "hf_filename": "qwen3-4b-q4_k_m.gguf",
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["m"]["checkpoint"] == "Qwen/Qwen3-4B-GGUF:qwen3-4b-q4_k_m.gguf"
+
+    def test_hf_repo_only(self, registry_path: Path) -> None:
+        """Multi-file models (ONNX dirs etc.) use repo-only coords."""
+        _write_registry(
+            registry_path,
+            {
+                "amd-onnx-model": {
+                    "path": "/models/amd-onnx",
+                    "capabilities": ["chat"],
+                    "backends": ["flm"],
+                    "hf_repo": "amd/AMD-OLMo-1B-SFT-DPO-onnx-ryzenai-1.7-hybrid",
+                    "hf_filename": "",
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert (
+            out["amd-onnx-model"]["checkpoint"] == "amd/AMD-OLMo-1B-SFT-DPO-onnx-ryzenai-1.7-hybrid"
+        )
+
+    def test_local_path_fallback_when_no_hf(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "local-only": {
+                    "path": "/mnt/ai-models/local/private-finetune.gguf",
+                    "capabilities": ["chat"],
+                    "backends": ["vulkan"],
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["local-only"]["checkpoint"] == "/mnt/ai-models/local/private-finetune.gguf"
+
+
+# ── Size + context window ────────────────────────────────────────────────────
+
+
+class TestSizeAndContext:
+    def test_size_bytes_converted_to_gb(self, registry_path: Path) -> None:
+        # 11.5 GB ≈ 12_348_030_976 bytes
+        _write_registry(
+            registry_path,
+            {
+                "m": {
+                    "path": "/x.gguf",
+                    "capabilities": ["chat"],
+                    "backends": ["vulkan"],
+                    "size_bytes": 12_348_030_976,
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        # 12_348_030_976 / 1024**3 ≈ 11.5
+        assert 11.4 < out["m"]["size"] < 11.6
+
+    def test_size_zero_when_unknown(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "m": {
+                    "path": "/x.gguf",
+                    "capabilities": ["chat"],
+                    "backends": ["vulkan"],
+                    "size_bytes": 0,
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["m"]["size"] == 0.0
+
+    def test_context_size_from_defaults_wins(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "m": {
+                    "path": "/x.gguf",
+                    "capabilities": ["chat"],
+                    "backends": ["vulkan"],
+                    "defaults": {"context_size": 32768},
+                    "metadata": {"context_length": 8192},
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["m"]["max_context_window"] == 32768
+
+    def test_context_length_from_metadata(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "m": {
+                    "path": "/x.gguf",
+                    "capabilities": ["chat"],
+                    "backends": ["vulkan"],
+                    "metadata": {"context_length": 16384},
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["m"]["max_context_window"] == 16384
+
+    def test_context_default_for_llm_with_no_signal(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "m": {
+                    "path": "/x.gguf",
+                    "capabilities": ["chat"],
+                    "backends": ["vulkan"],
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["m"]["max_context_window"] == 8192
+
+
+# ── Snapshot ──────────────────────────────────────────────────────────────────
+
+
+class TestSnapshot:
+    """End-to-end snapshot of a representative multi-modality registry.
+
+    Exercises a primary chat model, the bge-reranker case, an embed model,
+    an ASR model, a TTS model, and an image model in one fixture.
+    """
+
+    def test_full_registry_snapshot(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "hermes-4-14b-q5_k_m": {
+                    "path": "/mnt/ai-models/local/hermes-4-14b-q5_k_m.gguf",
+                    "capabilities": ["chat"],
+                    "backends": ["vulkan", "rocm", "cpu"],
+                    "hf_repo": "NousResearch/Hermes-4-14B-GGUF",
+                    "hf_filename": "hermes-4-14b-q5_k_m.gguf",
+                    "size_bytes": 11_000_000_000,
+                    "metadata": {"context_length": 131072},
+                },
+                "bge-reranker-v2-m3-q4_k_m": {
+                    "path": "/mnt/ai-models/local/bge-reranker-v2-m3-Q4_K_M.gguf",
+                    "capabilities": ["rerank"],
+                    "backends": ["llamacpp", "vulkan", "cpu"],
+                    "hf_repo": "gpustack/bge-reranker-v2-m3-GGUF",
+                    "hf_filename": "bge-reranker-v2-m3-Q4_K_M.gguf",
+                },
+                "nomic-embed-text-v1": {
+                    "path": "/mnt/ai-models/local/nomic-embed.gguf",
+                    "capabilities": ["embed"],
+                    "backends": ["llamacpp"],
+                    "hf_repo": "nomic-ai/nomic-embed-text-v1-GGUF",
+                    "hf_filename": "nomic-embed-text-v1.Q4_K_M.gguf",
+                },
+                "whisper-base": {
+                    "path": "/models/whisper-base.bin",
+                    "capabilities": ["asr"],
+                    "backends": ["whispercpp"],
+                    "hf_repo": "ggerganov/whisper.cpp",
+                    "hf_filename": "ggml-base.bin",
+                },
+                "kokoro-v1": {
+                    "path": "/models/kokoro-v1",
+                    "capabilities": ["tts"],
+                    "backends": ["kokoro"],
+                    "hf_repo": "mikkoph/kokoro-onnx",
+                },
+                "sd-turbo": {
+                    "path": "/models/sd-turbo.safetensors",
+                    "capabilities": ["image"],
+                    "backends": ["sd-cpp"],
+                    "hf_repo": "stabilityai/sd-turbo",
+                    "hf_filename": "sd_turbo.safetensors",
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+
+        # Output is ordered by sorted model id for diff-stability.
+        assert list(out.keys()) == sorted(out.keys())
+
+        # Spot-check the modalities all serialize correctly.
+        assert out["hermes-4-14b-q5_k_m"]["recipe"] == "llamacpp"
+        assert out["hermes-4-14b-q5_k_m"]["labels"] == []
+        assert out["hermes-4-14b-q5_k_m"]["max_context_window"] == 131072
+
+        assert out["bge-reranker-v2-m3-q4_k_m"]["labels"] == ["reranking"]
+        assert out["nomic-embed-text-v1"]["labels"] == ["embeddings"]
+        assert out["whisper-base"]["labels"] == ["transcription"]
+        assert out["kokoro-v1"]["labels"] == ["tts"]
+        assert out["sd-turbo"]["labels"] == ["image"]
+
+    def test_generator_is_deterministic(self, registry_path: Path) -> None:
+        _write_registry(
+            registry_path,
+            {
+                "b-model": {"path": "/b", "capabilities": ["chat"], "backends": ["vulkan"]},
+                "a-model": {"path": "/a", "capabilities": ["chat"], "backends": ["vulkan"]},
+            },
+        )
+        out1 = generate_server_models(registry_path)
+        out2 = generate_server_models(registry_path)
+        assert json.dumps(out1) == json.dumps(out2)
+        # Keys come out sorted.
+        assert list(out1.keys()) == ["a-model", "b-model"]
+
+
+# ── Atomic write ─────────────────────────────────────────────────────────────
+
+
+class TestAtomicWrite:
+    def test_writes_valid_json_file(self, tmp_path: Path) -> None:
+        registry = tmp_path / "registry.toml"
+        output = tmp_path / "out" / "server_models.json"
+        _write_registry(
+            registry,
+            {
+                "m": {
+                    "path": "/x.gguf",
+                    "capabilities": ["embed"],
+                    "backends": ["vulkan"],
+                    "hf_repo": "org/repo",
+                    "hf_filename": "x.gguf",
+                },
+            },
+        )
+
+        write_server_models(registry, output)
+
+        assert output.exists()
+        with open(output) as f:
+            parsed = json.load(f)
+        assert "m" in parsed
+        assert parsed["m"]["labels"] == ["embeddings"]
+
+    def test_creates_parent_directory(self, tmp_path: Path) -> None:
+        """Output's parent doesn't have to exist beforehand."""
+        registry = tmp_path / "registry.toml"
+        output = tmp_path / "deep" / "nested" / "path" / "server_models.json"
+        _write_registry(registry, {})
+        write_server_models(registry, output)
+        assert output.exists()
+
+    def test_overwrite_is_atomic(self, tmp_path: Path) -> None:
+        """The output path swaps in atomically (sentinel exists throughout)."""
+        registry = tmp_path / "registry.toml"
+        output = tmp_path / "server_models.json"
+
+        # Pre-existing content.
+        output.write_text('{"old": true}')
+        original_inode = output.stat().st_ino
+
+        _write_registry(
+            registry,
+            {
+                "m": {
+                    "path": "/x.gguf",
+                    "capabilities": ["chat"],
+                    "backends": ["vulkan"],
+                },
+            },
+        )
+        write_server_models(registry, output)
+
+        # File still exists (no transient missing-file window) and the new
+        # inode replaces the old one — proof of os.replace, not in-place write.
+        assert output.exists()
+        new_inode = output.stat().st_ino
+        assert new_inode != original_inode
+
+        with open(output) as f:
+            parsed = json.load(f)
+        assert "m" in parsed
+        assert "old" not in parsed
+
+    def test_no_tempfile_left_behind_on_success(self, tmp_path: Path) -> None:
+        registry = tmp_path / "registry.toml"
+        output = tmp_path / "server_models.json"
+        _write_registry(
+            registry, {"m": {"path": "/x.gguf", "capabilities": ["chat"], "backends": ["vulkan"]}}
+        )
+        write_server_models(registry, output)
+        # No .server_models.json.*.tmp leftovers.
+        leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(".")]
+        assert leftovers == []
+
+    def test_failure_during_write_leaves_original_intact(self, tmp_path: Path) -> None:
+        """If os.replace raises, the original file is unchanged and no
+        tempfile is left behind."""
+        registry = tmp_path / "registry.toml"
+        output = tmp_path / "server_models.json"
+        _write_registry(
+            registry, {"m": {"path": "/x.gguf", "capabilities": ["chat"], "backends": ["vulkan"]}}
+        )
+
+        output.write_text('{"original": true}')
+        original_bytes = output.read_bytes()
+
+        with (
+            patch(
+                "hal0.lemonade.server_models_gen.os.replace",
+                side_effect=OSError("simulated EXDEV"),
+            ),
+            pytest.raises(OSError, match="simulated EXDEV"),
+        ):
+            write_server_models(registry, output)
+
+        # Original content preserved.
+        assert output.read_bytes() == original_bytes
+        # Tempfile cleaned up.
+        leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(".")]
+        assert leftovers == []
+
+
+# ── Missing registry handling ────────────────────────────────────────────────
+
+
+class TestRegistryMissingOrMalformed:
+    def test_missing_registry_yields_empty_catalog(self, tmp_path: Path) -> None:
+        out = generate_server_models(tmp_path / "does-not-exist.toml")
+        assert out == {}
+
+    def test_malformed_registry_yields_empty_catalog(self, tmp_path: Path) -> None:
+        registry = tmp_path / "registry.toml"
+        registry.write_text("this is not valid toml [[[")
+        out = generate_server_models(registry)
+        assert out == {}
+
+    def test_list_shape_registry_accepted(self, tmp_path: Path) -> None:
+        """Mirror ModelRegistry's haloai backcompat: list-of-tables works."""
+        registry = tmp_path / "registry.toml"
+        registry.write_text(
+            "[[models]]\n"
+            'id = "a"\n'
+            'path = "/a.gguf"\n'
+            'capabilities = ["chat"]\n'
+            'backends = ["vulkan"]\n'
+        )
+        out = generate_server_models(registry)
+        assert "a" in out
+
+
+# ── CLI entry point ──────────────────────────────────────────────────────────
+
+
+class TestCliMain:
+    def test_dry_run_writes_to_stdout_only(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        registry = tmp_path / "registry.toml"
+        output = tmp_path / "out.json"
+        _write_registry(
+            registry, {"m": {"path": "/x.gguf", "capabilities": ["chat"], "backends": ["vulkan"]}}
+        )
+
+        rc = cli_main(["--registry", str(registry), "--output", str(output), "--dry-run"])
+
+        assert rc == 0
+        assert not output.exists()  # dry-run didn't touch the file.
+        cap = capsys.readouterr()
+        parsed = json.loads(cap.out)
+        assert "m" in parsed
+
+    def test_writes_to_output_path(self, tmp_path: Path) -> None:
+        registry = tmp_path / "registry.toml"
+        output = tmp_path / "out.json"
+        _write_registry(
+            registry,
+            {
+                "bge-reranker-v2-m3-q4_k_m": {
+                    "path": "/x.gguf",
+                    "capabilities": ["rerank"],
+                    "backends": ["llamacpp"],
+                    "hf_repo": "gpustack/bge-reranker-v2-m3-GGUF",
+                    "hf_filename": "bge-reranker-v2-m3-Q4_K_M.gguf",
+                }
+            },
+        )
+
+        rc = cli_main(["--registry", str(registry), "--output", str(output)])
+
+        assert rc == 0
+        with open(output) as f:
+            parsed = json.load(f)
+        assert parsed["bge-reranker-v2-m3-q4_k_m"]["labels"] == ["reranking"]


### PR DESCRIPTION
## Summary

Generates Lemonade Server's curated catalog from hal0's `registry.toml` at install time and via `hal0 capabilities sync`, so every modality is classified with the correct `labels` (Lemonade infers `type` from labels — see ADR-0006 §4 and `docs/internal/lemonade-repo-deep-dive-2026-05-22.md` §3).

Without explicit label-driven registration, `extra_models_dir` discovery classifies every GGUF as `type=LLM` with the single `["custom"]` label — which is the spike's smoking-gun failure mode where `--reranking` and `--embedding` never reach the child llama-server (`docs/internal/lemonade-spike-findings-2026-05-22.md` §"Model discovery + typing"). The `bge-reranker-v2-m3-q4_k_m` smoke test asserts the fix.

## Pieces

- `src/hal0/lemonade/server_models_gen.py` — `generate_server_models`, `write_server_models` (atomic tempfile+rename), `cli_main` for `python -m hal0.lemonade.server_models_gen`. Capability strength ranking (`rerank > embed > chat`) keeps multi-capability models in the right bucket; `vision` is preserved as a chat-indicator secondary label so vision-LLMs stay LLM under Lemonade's first-match classifier.
- `hal0 capabilities sync` — runtime entry point. Lemonade re-scans `resources/server_models.json` on its next probe, so no `lemond` restart required; idempotent.
- `installer/install.sh` hook — runs before the existing Service-start phase, guarded by `/opt/lemonade/resources/` existence so it is a no-op on installs that haven't yet provisioned the Lemonade tarball (issue #140's territory). Once #140 lands the directory, the hook activates without further install.sh edits.

## Tests (38 new, full suite green)

- Capability mapping — chat / embed / embedding / asr / tts / image / vision / unknown-fallback.
- Multi-capability strength — rerank > embed > chat; vision-chat stays LLM.
- **`bge-reranker-v2-m3-q4_k_m` smoke** — asserts `labels=["reranking"]` (the spike's smoking-gun fix).
- Backend → recipe resolution — vulkan/rocm/cuda/cpu → llamacpp; flm wins over GPU; moonshine → whispercpp; empty backends fall back to label default.
- Checkpoint formatting — HF repo+filename, HF repo only, local-path fallback.
- Atomic write hazards — failure mid-replace leaves original intact + no tempfile leftovers.
- CLI — `--dry-run` writes nothing; `--output` round-trips registry → JSON file.
- Registry edge cases — missing file, malformed TOML, list-of-tables shape.

## Constraints honoured

- Did NOT touch `src/hal0/lemonade/client.py` or `errors.py` (PR #137).
- Did NOT touch `src/hal0/config/schema.py` (#143).
- Did NOT touch installer's systemd-unit files (#140).
- Did NOT add preload/idle/metrics code (#144, #145).
- `__init__.py` additions limited to `generate_server_models` + `write_server_models`.

## Deviation note

The brief and the issue text reference a `type` field on each Lemonade entry. Lemonade's actual schema (`lemonade-sdk/lemonade/src/cpp/resources/server_models.json` + `get_model_type_from_labels()` in `model_types.h`) has **no `type` field** — type is inferred from `labels`. This generator emits the canonical labels (`embeddings`, `reranking`, `transcription`, `tts`, `image`) so Lemonade's classifier picks the right type. Documented inline in the module docstring.

## Test plan

- [x] `pytest tests/lemonade/test_server_models_gen.py` — 35 passing.
- [x] `pytest tests/cli/test_capabilities_sync.py` — 3 passing.
- [x] Full suite green locally (1364 passed, 8 skipped, 3 xfailed pre-existing).
- [x] `ruff check` + `ruff format --check` clean across new + modified files.
- [x] `bash -n installer/install.sh` clean.
- [ ] CI green on PR.

Closes #141