### PR TITLE
feat(lemonade): preload validation + idle-unload driver (ADR-0007) (#144)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -10,9 +10,13 @@ import asyncio
 import contextlib
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
 
 import structlog
 from fastapi import Depends, FastAPI
+
+if TYPE_CHECKING:
+    from hal0.lemonade.idle import IdleDriver
 
 from hal0 import __version__
 from hal0.api.auth import first_run as first_run_lock
@@ -234,6 +238,47 @@ def _hydrate_upstreams(registry: UpstreamRegistry) -> None:
             )
 
 
+async def _maybe_start_lemonade_idle_driver(app: FastAPI) -> IdleDriver | None:
+    """Start the Lemonade idle-unload driver iff v0.2 backend is active.
+
+    Gated on ``HAL0_BACKEND=lemonade`` (manifest schema v2). Under
+    v0.1.x toolbox mode the existing ``SlotManager`` idle monitor
+    already covers the policy; the driver would be redundant noise.
+
+    Failures here MUST NOT block API startup — a busted Lemonade
+    config shouldn't keep the dashboard from coming up so the user
+    can fix it. The driver itself is also resilient to transient
+    lemond unavailability (see ``lemonade/idle.py`` docstring).
+
+    See ADR-0007 §Related, ADR-0006 §17.
+    """
+    import os
+
+    if os.environ.get("HAL0_BACKEND", "").strip().lower() != "lemonade":
+        return None
+    try:
+        from hal0.lemonade.client import LemonadeClient
+        from hal0.lemonade.idle import IdleDriver
+
+        client = LemonadeClient(
+            api_key=os.environ.get("LEMONADE_API_KEY") or None,
+        )
+        driver = IdleDriver(client)
+        await driver.start()
+        # Stash on app.state so /api/health surfaces + tests can find it.
+        app.state.lemonade_client = client
+        app.state.lemonade_idle_driver = driver
+        log.info("lemonade.idle.driver_attached")
+        return driver
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning(
+            "lemonade.idle.driver_start_failed",
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return None
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     log.info("hal0.api.startup", version=__version__)
@@ -444,6 +489,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         with contextlib.suppress(asyncio.CancelledError):
             await refresh_task
 
+    # Lemonade idle-unload driver (ADR-0007 §Related, ADR-0006 §17). Only
+    # started when HAL0_BACKEND=lemonade is the active backend — under
+    # the v0.1.x per-modality toolbox model, SlotManager's own idle
+    # monitor (started above via start_idle_monitor) is the source of
+    # truth and this driver would be redundant. Stored on app.state so
+    # tests + future shutdown hooks can introspect it.
+    lemonade_idle_driver = await _maybe_start_lemonade_idle_driver(app)
+
     try:
         async with AsyncExitStack() as stack:
             for mgr in managers:
@@ -451,6 +504,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             stack.push_async_callback(_stop_refresh_task)
             yield
     finally:
+        if lemonade_idle_driver is not None:
+            await lemonade_idle_driver.stop()
         await slot_manager.stop_idle_monitor()
         await dispatcher.aclose()
         log.info("hal0.api.shutdown")

--- a/src/hal0/lemonade/__init__.py
+++ b/src/hal0/lemonade/__init__.py
@@ -29,12 +29,17 @@ from hal0.lemonade.errors import (
     LemonadeTimeoutError,
     LemonadeUnavailableError,
 )
+from hal0.lemonade.idle import IdleDriver
+from hal0.lemonade.preload import PreloadError, preload_validate
 
 __all__ = [
+    "IdleDriver",
     "LemonadeClient",
     "LemonadeError",
     "LemonadeHTTPError",
     "LemonadeLoadError",
     "LemonadeTimeoutError",
     "LemonadeUnavailableError",
+    "PreloadError",
+    "preload_validate",
 ]

--- a/src/hal0/lemonade/idle.py
+++ b/src/hal0/lemonade/idle.py
@@ -1,0 +1,280 @@
+"""Idle-unload driver for Lemonade-loaded models (ADR-0007 §Related, ADR-0006 §17).
+
+Lemonade has no built-in idle-eviction TTL. hal0 v0.1.x kept its own
+300s "demote READY→IDLE and unload" policy via ``SlotManager``'s idle
+monitor; v0.2 has to keep that policy alive at the Lemonade layer
+because the slot abstraction is no longer the unit of process
+lifecycle — Lemonade owns the pool.
+
+This driver runs as a background asyncio task started in hal0-api's
+lifespan. Once per tick (30s default — matches the existing hal0
+``_IDLE_MONITOR_INTERVAL_S``) it:
+
+  1. Polls ``GET /v1/health`` for ``all_models_loaded[].last_use``
+  2. For each loaded model with ``now - last_use > idle_timeout_s``,
+     calls ``POST /v1/unload``
+  3. Logs the eviction so dashboards can audit
+
+Resilience contract:
+  * Transient lemond unavailability (``LemonadeUnavailableError`` /
+    ``LemonadeTimeoutError``) is logged at WARNING and the driver
+    continues on the next tick. We never crash the task on a flaky
+    daemon.
+  * Cancellation propagates cleanly: the task awaits the sleep, picks
+    up the CancelledError, and exits without partial state.
+  * Per-model unload failures don't abort the whole sweep; we log and
+    move on to the next candidate.
+
+ADR cross-references:
+  * ADR-0007 §Related — operational gap that motivated this driver
+  * ADR-0006 §17 — "Idle-eviction driver: hal0-owned external"
+  * docs/internal/lemonade-spike-findings-2026-05-22.md — confirms
+    Lemonade has no TTL of its own
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from collections.abc import Iterable
+from typing import Any
+
+from hal0.lemonade.client import LemonadeClient
+from hal0.lemonade.errors import (
+    LemonadeError,
+    LemonadeHTTPError,
+    LemonadeTimeoutError,
+    LemonadeUnavailableError,
+)
+
+log = logging.getLogger(__name__)
+
+
+# Defaults intentionally match hal0 v0.1.x conventions (slots/manager.py
+# ``_IDLE_AFTER_S`` / ``_IDLE_MONITOR_INTERVAL_S``) so the operator
+# behaviour doesn't change across the v0.2 cutover.
+DEFAULT_POLL_INTERVAL_S: float = 30.0
+DEFAULT_IDLE_TIMEOUT_S: float = 300.0
+
+
+class IdleDriver:
+    """Background poller that unloads idle models from Lemonade.
+
+    Lifecycle:
+        driver = IdleDriver(client)
+        await driver.start()
+        ...
+        await driver.stop()
+
+    ``start()`` schedules the poll task on the running event loop and
+    returns immediately. ``stop()`` cancels the task and awaits its
+    exit — it's idempotent and safe to call from a finally block.
+
+    The driver does NOT own the ``LemonadeClient``; the caller passes
+    an open instance and is responsible for closing it after
+    ``IdleDriver.stop()`` returns. This mirrors the dispatcher pattern
+    where the http client is shared between subsystems.
+
+    See ADR-0007 §Related, ADR-0006 §17.
+    """
+
+    def __init__(
+        self,
+        client: LemonadeClient,
+        *,
+        idle_timeout_s: float = DEFAULT_IDLE_TIMEOUT_S,
+        poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+        clock: Any = time.time,
+    ) -> None:
+        if idle_timeout_s <= 0:
+            raise ValueError("idle_timeout_s must be > 0")
+        if poll_interval_s <= 0:
+            raise ValueError("poll_interval_s must be > 0")
+        self._client = client
+        self._idle_timeout_s = idle_timeout_s
+        self._poll_interval_s = poll_interval_s
+        # Injectable clock so tests can fast-forward without
+        # monkeypatching the time module globally.
+        self._clock = clock
+        self._task: asyncio.Task[None] | None = None
+        self._stopping = asyncio.Event()
+
+    # ── lifecycle ──────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Schedule the poll task. No-op if already running."""
+        if self._task is not None and not self._task.done():
+            return
+        self._stopping.clear()
+        self._task = asyncio.create_task(self._run(), name="lemonade-idle-driver")
+        log.info(
+            "lemonade.idle.started",
+            extra={
+                "idle_timeout_s": self._idle_timeout_s,
+                "poll_interval_s": self._poll_interval_s,
+            },
+        )
+
+    async def stop(self) -> None:
+        """Signal the task to exit and await its completion. Idempotent."""
+        if self._task is None:
+            return
+        self._stopping.set()
+        self._task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+        log.info("lemonade.idle.stopped")
+
+    # ── core loop ──────────────────────────────────────────────────
+
+    async def _run(self) -> None:
+        """Poll loop. Survives lemond hiccups; exits on cancellation."""
+        try:
+            while not self._stopping.is_set():
+                try:
+                    await self.tick()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:  # pragma: no cover — defensive
+                    # Nothing inside tick() should escape — but if it
+                    # does, log and continue rather than letting the
+                    # driver die silently.
+                    log.warning(
+                        "lemonade.idle.tick_error",
+                        extra={"error": str(exc), "error_type": type(exc).__name__},
+                    )
+                try:
+                    await asyncio.wait_for(self._stopping.wait(), timeout=self._poll_interval_s)
+                except TimeoutError:
+                    # Normal path — the interval elapsed without a stop signal.
+                    continue
+        except asyncio.CancelledError:
+            # Normal shutdown path. Don't re-raise — the awaiter (stop)
+            # already suppresses CancelledError.
+            return
+
+    async def tick(self) -> int:
+        """Run one eviction sweep. Returns the number of models unloaded.
+
+        Public so tests can drive the loop deterministically without
+        sleeping. Production code should call ``start()`` and let
+        ``_run`` manage cadence.
+
+        Resilience: never raises. Lemond unreachable / 5xx is logged
+        + counted as zero evictions; the next tick retries.
+        """
+        try:
+            health = await self._client.health()
+        except (LemonadeUnavailableError, LemonadeTimeoutError) as exc:
+            # ADR-0006 operational risk: lemond may restart, drop the
+            # connection, or hang. Treat as "no signal this tick" and
+            # come back next round — never crash the driver.
+            log.warning(
+                "lemonade.idle.health_unreachable",
+                extra={"error": str(exc), "error_type": type(exc).__name__},
+            )
+            return 0
+        except LemonadeHTTPError as exc:
+            log.warning(
+                "lemonade.idle.health_http_error",
+                extra={"status_code": exc.status_code, "body": exc.body},
+            )
+            return 0
+        except LemonadeError as exc:  # pragma: no cover — defensive
+            log.warning("lemonade.idle.health_error", extra={"error": str(exc)})
+            return 0
+
+        loaded = _extract_loaded_models(health)
+        if not loaded:
+            return 0
+
+        now = float(self._clock())
+        evicted = 0
+        for entry in loaded:
+            name = entry.get("model_name")
+            if not isinstance(name, str) or not name:
+                continue
+            last_use = _coerce_last_use(entry.get("last_use"))
+            if last_use is None:
+                # No timestamp → can't decide; leave it alone. Better
+                # to skip an eviction than evict a freshly-loaded
+                # model whose stats haven't populated yet.
+                continue
+            age = now - last_use
+            if age <= self._idle_timeout_s:
+                continue
+            ok = await self._unload(name, age=age)
+            if ok:
+                evicted += 1
+        return evicted
+
+    async def _unload(self, model_name: str, *, age: float) -> bool:
+        """Call ``POST /v1/unload``. Returns True on success.
+
+        Per-model failure is logged + swallowed so the sweep moves on
+        to the next candidate. The next tick will retry whatever we
+        missed.
+        """
+        try:
+            await self._client.unload(model_name)
+        except LemonadeError as exc:
+            log.warning(
+                "lemonade.idle.unload_failed",
+                extra={
+                    "model_name": model_name,
+                    "age_s": age,
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                },
+            )
+            return False
+        log.info(
+            "lemonade.idle.unloaded",
+            extra={
+                "model_name": model_name,
+                "age_s": age,
+                "idle_timeout_s": self._idle_timeout_s,
+            },
+        )
+        return True
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+def _extract_loaded_models(health: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    """Pull the loaded-models list out of a ``/v1/health`` payload.
+
+    Lemonade has used two field names across versions:
+      * ``all_models_loaded`` (current docs)
+      * ``loaded`` (older + LemonadeClient docstring)
+
+    Accept either so a Lemonade upgrade that renames the field doesn't
+    silently break the driver. Bad shapes (missing field, wrong type)
+    yield an empty iterable — the caller treats that as "nothing to
+    do this tick".
+    """
+    if not isinstance(health, dict):
+        return []
+    for key in ("all_models_loaded", "loaded"):
+        value = health.get(key)
+        if isinstance(value, list):
+            return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+def _coerce_last_use(value: Any) -> float | None:
+    """Coerce a ``last_use`` payload field into a unix-epoch float.
+
+    Lemonade reports last_use as a unix timestamp (float seconds). We
+    accept int/float; anything else (None, str, missing) yields None
+    which the caller treats as "skip this entry this tick".
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        # bool is an int subclass — exclude explicitly so True/False
+        # don't pass for "0 seconds since epoch".
+        return float(value)
+    return None

--- a/src/hal0/lemonade/preload.py
+++ b/src/hal0/lemonade/preload.py
@@ -1,0 +1,466 @@
+"""Pre-load validation guards before ``POST /v1/load`` (ADR-0007).
+
+Lemonade's ``Router`` implements a "nuclear" evict-on-failure policy:
+when ``/v1/load`` fails for any reason *except* file-not-found, every
+WrappedServer in the pool is evicted and the load is retried. Confirmed
+live in the 2026-05-22 spike — server log verbatim:
+
+    "Load failed with non-file-not-found error, evicting all models
+     and retrying..."
+
+For hal0 v0.2 this means a single bad pull mid-day blasts every warm
+slot. ADR-0007 §1 mitigates by steering failures into the file-not-found
+exemption: validate file existence + integrity + GGUF magic in this
+module BEFORE we call ``LemonadeClient.load()``. When validation fails,
+the slot's load is short-circuited — Lemonade never sees the bad load,
+the other loaded models stay loaded, the dashboard surfaces an explicit
+error class (``checksum_mismatch``, ``not_a_gguf``, ...).
+
+The race window (ADR-0007 §3) — file deleted between ``preload_validate``
+returning OK and ``/v1/load`` arriving at lemond — is explicitly
+accepted. It reduces blast radius from "any bad load" to "raced file
+delete in the millisecond between validate and load", which is a
+pattern we don't see in prod. See ADR-0007 §3 for the full reasoning.
+
+See also:
+    docs/internal/adr/0007-nuclear-evict-all-mitigation.md
+    docs/internal/lemonade-spike-findings-2026-05-22.md
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from hal0.lemonade.errors import LemonadeTimeoutError
+
+if TYPE_CHECKING:
+    from hal0.config.schema import SlotConfig
+    from hal0.lemonade.client import LemonadeClient
+    from hal0.registry.model import Model
+    from hal0.registry.store import ModelRegistry
+
+log = logging.getLogger(__name__)
+
+
+# GGUF magic bytes, little-endian. Every GGUF file starts with these
+# four bytes; this is the canonical sniff per the GGUF spec.
+GGUF_MAGIC: bytes = b"GGUF"
+
+# Streaming sha256 chunk size. 64 KiB matches the brief; small enough
+# that even a 14B Q5 (~10 GiB) only burns a few seconds of wall time
+# and the OS page cache absorbs the rest. ADR-0007 §Consequences: the
+# latency is accepted in exchange for blast-radius reduction.
+_SHA256_CHUNK_BYTES: int = 64 * 1024
+
+# Model "kinds" that ship as GGUF and therefore must pass the magic
+# check. Anything else (kokoro/moonshine/sd-cpp/whispercpp) uses a
+# different on-disk format — sha256 + size still apply, but the GGUF
+# magic check is skipped per the brief.
+#
+# Inference rules (in order):
+#   1. explicit ``Model.metadata['kind']`` if present
+#   2. ``Model.backends`` contains any GGUF-capable backend
+#      (vulkan/rocm/cuda/cpu) → treat as GGUF
+#   3. ``Model.capabilities`` contains chat/embed/rerank → treat as GGUF
+#   4. otherwise non-GGUF (e.g. moonshine/kokoro/comfyui assets)
+_GGUF_BACKENDS: frozenset[str] = frozenset({"vulkan", "rocm", "cuda", "cpu"})
+_NON_GGUF_BACKENDS: frozenset[str] = frozenset(
+    {"moonshine", "kokoro", "sd-cpp", "whispercpp", "comfyui"}
+)
+_GGUF_CAPS: frozenset[str] = frozenset({"chat", "embed", "rerank", "vision"})
+
+
+# ── PreloadError hierarchy ────────────────────────────────────────────
+
+
+class PreloadError(Exception):
+    """Base class for pre-load validation failures (ADR-0007 §1, §2).
+
+    Subclass instances carry the offending model path so the SlotManager
+    can surface it as the slot's ERROR-state message verbatim. Catching
+    ``PreloadError`` at the SlotManager layer is the signal to set
+    ``state = ERROR`` and NOT call ``LemonadeClient.load()`` — the
+    whole point of the mitigation.
+    """
+
+    # Short stable token used in structured logs + dashboard labels.
+    kind: str = "preload_error"
+
+    def __init__(self, path: str | Path, message: str | None = None) -> None:
+        self.path = str(path)
+        super().__init__(message or f"{self.kind}: {self.path}")
+
+
+class FileNotFound(PreloadError):
+    """Model file is missing at the registry-declared path (ADR-0007 §1).
+
+    The ONLY pre-load failure mode Lemonade itself handles safely (its
+    evict-all policy explicitly exempts file-not-found). We still
+    intercept here so the dashboard sees a typed error instead of a
+    naked HTTP 4xx from lemond.
+    """
+
+    kind = "file_not_found"
+
+
+class ChecksumMismatch(PreloadError):
+    """File sha256 doesn't match the registry entry (ADR-0007 §1).
+
+    Catches partial downloads, on-disk corruption, and the case where a
+    /mnt/ai-models drop-in was edited out-of-band. Streaming sha256 so
+    we don't load multi-GB models into memory just to validate them.
+    """
+
+    kind = "checksum_mismatch"
+
+
+class SizeMismatch(PreloadError):
+    """File size on disk doesn't match registry ``size_bytes`` (ADR-0007 §1).
+
+    Cheap precheck before the sha256 walk — a partial download fails
+    here before we burn IO on the full hash. (We still compute the
+    hash for clarity in tests, but in prod this short-circuits the
+    most common corruption pattern.)
+    """
+
+    kind = "size_mismatch"
+
+
+class NotAGGUF(PreloadError):
+    """First four bytes of the file aren't the GGUF magic (ADR-0007 §1).
+
+    Skipped for non-GGUF model kinds (moonshine, kokoro, sd-cpp,
+    whispercpp). See ``_is_gguf_kind`` below.
+    """
+
+    kind = "not_a_gguf"
+
+
+class LoadTimeout(PreloadError):
+    """``/v1/load`` exceeded its hard timeout (ADR-0007 §5).
+
+    Lemonade serializes loads and queues pending loads indefinitely; a
+    stuck queue would otherwise block hal0-api forever. We convert
+    ``LemonadeTimeoutError`` from the client layer into this typed
+    ``PreloadError`` so SlotManager can treat all pre-load failures
+    uniformly (one except clause, one state-machine path).
+
+    Per ADR-0007 §4: do NOT retry on this error. Retry would re-issue
+    /v1/load, potentially triggering the nuclear-evict-all on the
+    retry attempt.
+    """
+
+    kind = "load_timeout"
+
+
+# ── public API ────────────────────────────────────────────────────────
+
+
+def preload_validate(
+    slot_cfg: SlotConfig,
+    model_entry: Model,
+    *,
+    registry: ModelRegistry | None = None,
+) -> None:
+    """Validate a model on disk BEFORE calling ``LemonadeClient.load()``.
+
+    Implements the four pre-load guards from ADR-0007 §1:
+
+      1. File exists at ``model_entry.path`` → ``FileNotFound``
+      2. ``stat().st_size`` matches registry ``size_bytes`` → ``SizeMismatch``
+         (skipped if registry entry has ``size_bytes == 0``, treated as
+         "unknown" per the Model schema)
+      3. sha256 streamed over the file matches registry sha256
+         → ``ChecksumMismatch`` (skipped if registry has no sha256
+         recorded — e.g. user-dropped /mnt/ai-models entries)
+      4. First four bytes equal ``GGUF`` magic → ``NotAGGUF``
+         (skipped for non-GGUF model kinds; see ``_is_gguf_kind``)
+
+    The function is sync (no async I/O) because the SlotManager's lock
+    is already held when this runs and we don't want to release it
+    around an await. The streaming hash on a 14B Q5 takes ~3-5s on a
+    warm page cache — accepted per ADR-0007 §Consequences.
+
+    Race exception (ADR-0007 §3):
+        If validation passes at T0 and the file is deleted before
+        ``/v1/load`` arrives at lemond, we hit evict-all anyway. The
+        race window is bounded by the actual file-delete pattern,
+        which is vanishingly rare in prod. Documented here, accepted,
+        no further mitigation.
+
+    Args:
+        slot_cfg: The slot's parsed TOML config. Currently advisory —
+            held in the signature so future per-slot tunables (e.g.
+            "skip sha256 for dev mode") have a place to land.
+        model_entry: The registry ``Model`` whose ``path``, ``size_bytes``,
+            ``metadata['sha256']``, and capability/backend fields are
+            consulted.
+        registry: Optional ``ModelRegistry`` reference. Unused today
+            but kept in the signature so future implementations (e.g.
+            cross-checking sha256 against a sidecar manifest) don't
+            need a signature break. Pass ``None`` in tests.
+
+    Raises:
+        PreloadError: a subclass of ``PreloadError`` per the rules above.
+
+    See:
+        docs/internal/adr/0007-nuclear-evict-all-mitigation.md §1, §3
+    """
+    del slot_cfg, registry  # reserved for future use; see docstring
+
+    path = Path(model_entry.path)
+
+    # ── 1. file exists ────────────────────────────────────────────────
+    # Use is_file() not exists(): a broken symlink or a directory at
+    # the registry path is just as broken as a missing file.
+    if not path.is_file():
+        log.warning(
+            "lemonade.preload.file_not_found",
+            extra={"model_id": model_entry.id, "path": str(path)},
+        )
+        raise FileNotFound(path)
+
+    # ── 2. size matches registry ──────────────────────────────────────
+    # size_bytes == 0 is the registry's "unknown" sentinel (see
+    # Model.size_bytes default). Skip the check in that case rather
+    # than fail every drop-in.
+    actual_size = path.stat().st_size
+    if model_entry.size_bytes and actual_size != model_entry.size_bytes:
+        log.warning(
+            "lemonade.preload.size_mismatch",
+            extra={
+                "model_id": model_entry.id,
+                "path": str(path),
+                "expected": model_entry.size_bytes,
+                "actual": actual_size,
+            },
+        )
+        raise SizeMismatch(
+            path,
+            message=(
+                f"size_mismatch: {path} — registry says "
+                f"{model_entry.size_bytes} bytes, disk has {actual_size}"
+            ),
+        )
+
+    # ── 3. sha256 matches registry ────────────────────────────────────
+    # Streamed in _SHA256_CHUNK_BYTES chunks — never loads the full
+    # file into memory. sha256 lives in metadata['sha256'] per the
+    # registry/pull.py contract (PR #137-era convention).
+    expected_sha = _registry_sha256(model_entry)
+    if expected_sha:
+        actual_sha = _sha256_file(path)
+        if actual_sha.lower() != expected_sha.lower():
+            log.warning(
+                "lemonade.preload.checksum_mismatch",
+                extra={
+                    "model_id": model_entry.id,
+                    "path": str(path),
+                    "expected": expected_sha,
+                    "actual": actual_sha,
+                },
+            )
+            raise ChecksumMismatch(
+                path,
+                message=(
+                    f"checksum_mismatch: {path} — registry sha256 "
+                    f"{expected_sha[:12]}..., disk sha256 {actual_sha[:12]}..."
+                ),
+            )
+
+    # ── 4. GGUF magic bytes ───────────────────────────────────────────
+    # Only for kinds that actually ship as GGUF. moonshine/kokoro/etc.
+    # use their own formats; their integrity is covered by 1-3 above.
+    if _is_gguf_kind(model_entry):
+        with path.open("rb") as fh:
+            first_four = fh.read(4)
+        if first_four != GGUF_MAGIC:
+            log.warning(
+                "lemonade.preload.not_a_gguf",
+                extra={
+                    "model_id": model_entry.id,
+                    "path": str(path),
+                    "first_four_hex": first_four.hex(),
+                },
+            )
+            raise NotAGGUF(
+                path,
+                message=(
+                    f"not_a_gguf: {path} — first 4 bytes were "
+                    f"{first_four!r}, expected {GGUF_MAGIC!r}"
+                ),
+            )
+
+    log.debug(
+        "lemonade.preload.ok",
+        extra={"model_id": model_entry.id, "path": str(path)},
+    )
+
+
+async def safe_load(
+    client: LemonadeClient,
+    slot_cfg: SlotConfig,
+    model_entry: Model,
+    *,
+    registry: ModelRegistry | None = None,
+    recipe: str | None = None,
+    ctx_size: int | None = None,
+    llamacpp_backend: str | None = None,
+    llamacpp_args: list[str] | None = None,
+) -> dict[str, Any]:
+    """Pre-validate then ``POST /v1/load`` — the ADR-0007-safe load path.
+
+    This is the function callers (today: future ``LemonadeProvider``;
+    tomorrow: anywhere we issue a Lemonade load) MUST use instead of
+    bare ``client.load(...)``. It enforces:
+
+      * ADR-0007 §1 — pre-validation in front of every load
+      * ADR-0007 §4 — NO retry on failure
+      * ADR-0007 §5 — convert ``LemonadeTimeoutError`` to
+        ``LoadTimeout`` so SlotManager handles all pre-load failures
+        through a single ``except PreloadError`` clause
+
+    Race exception (ADR-0007 §3):
+        File-deleted-between-validate-and-load remains possible. This
+        function does not re-validate after the load returns; if
+        lemond's evict-all fires due to a raced delete, the caller's
+        cached "loaded" list is stale on the next health probe and
+        the dashboard surfaces the truth on the next poll.
+
+    Args:
+        client: Open ``LemonadeClient`` to drive.
+        slot_cfg: Slot config (forwarded to ``preload_validate``).
+        model_entry: Registry entry to validate + load. Its ``id`` is
+            passed to lemond as ``model_name``.
+        registry: Optional registry handle for the validator.
+        recipe, ctx_size, llamacpp_backend, llamacpp_args: forwarded
+            to ``LemonadeClient.load`` verbatim.
+
+    Returns:
+        The parsed JSON body of ``POST /v1/load`` on success.
+
+    Raises:
+        PreloadError: validation failed OR /v1/load timed out. Caller
+            (SlotManager) maps this to slot ``state=ERROR`` and does
+            NOT retry. Other ``LemonadeError`` subclasses (HTTP 5xx
+            from lemond, connect-refused) propagate unchanged — they're
+            already typed appropriately.
+
+    See:
+        docs/internal/adr/0007-nuclear-evict-all-mitigation.md §1, §4, §5
+    """
+    # Pre-validate (sync). Raises PreloadError → propagates → caller
+    # short-circuits the load. /v1/load is never touched.
+    preload_validate(slot_cfg, model_entry, registry=registry)
+
+    try:
+        return await client.load(
+            model_entry.id,
+            recipe=recipe,
+            ctx_size=ctx_size,
+            llamacpp_backend=llamacpp_backend,
+            llamacpp_args=llamacpp_args,
+        )
+    except LemonadeTimeoutError as exc:
+        # ADR-0007 §5: surface as PreloadError.LoadTimeout so the
+        # SlotManager's pre-load failure path catches it uniformly.
+        # NO retry — see ADR-0007 §4.
+        log.warning(
+            "lemonade.preload.load_timeout",
+            extra={"model_id": model_entry.id, "path": model_entry.path},
+        )
+        raise LoadTimeout(
+            model_entry.path,
+            message=f"load_timeout: /v1/load timed out for model_name={model_entry.id!r}",
+        ) from exc
+
+
+# ── internals ─────────────────────────────────────────────────────────
+
+
+def _sha256_file(path: Path) -> str:
+    """Stream-hash ``path`` with sha256, returning a hex digest.
+
+    Reads in ``_SHA256_CHUNK_BYTES`` chunks so multi-GB models don't
+    spike RSS. Synchronous on purpose — see ``preload_validate``
+    docstring for the rationale (lock held, no async needed).
+    """
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        while True:
+            chunk = fh.read(_SHA256_CHUNK_BYTES)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _registry_sha256(model_entry: Model) -> str | None:
+    """Pull the recorded sha256 out of a registry ``Model`` entry.
+
+    sha256 lives in ``metadata['sha256']`` per the registry/pull.py
+    convention — the pull engine writes it during the streaming
+    download. Returns None for entries that have no recorded hash
+    (e.g. /mnt/ai-models drop-ins that bypassed the pull path);
+    those skip the checksum check rather than fail.
+    """
+    md = getattr(model_entry, "metadata", None) or {}
+    value = md.get("sha256")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _is_gguf_kind(model_entry: Model) -> bool:
+    """Return True iff ``model_entry`` is a GGUF-format model.
+
+    Used to gate the GGUF magic-byte check (rule 4 in
+    ``preload_validate``). Non-GGUF kinds (moonshine, kokoro,
+    sd-cpp, whispercpp, comfyui assets) skip the magic check —
+    their integrity is covered by size + sha256 alone.
+
+    Detection rules (first match wins):
+      1. ``metadata['kind']`` set explicitly (overrides everything)
+      2. Any backend in ``_NON_GGUF_BACKENDS`` → not GGUF
+      3. Any backend in ``_GGUF_BACKENDS`` → GGUF
+      4. Any capability in ``_GGUF_CAPS`` (chat/embed/rerank/vision)
+         → GGUF
+      5. Filename ends with ``.gguf`` → GGUF
+      6. Fallback: treat as GGUF (conservative — runs the magic check;
+         the file either passes or surfaces a typed ``NotAGGUF`` error
+         instead of slipping through with no integrity gate at all).
+    """
+    md = getattr(model_entry, "metadata", None) or {}
+    kind = md.get("kind")
+    if isinstance(kind, str) and kind.strip():
+        kl = kind.strip().lower()
+        if kl in {"moonshine", "kokoro", "sd-cpp", "whispercpp", "comfyui"}:
+            return False
+        if kl in {"llama", "gguf", "flm"}:
+            return True
+        # Unknown explicit kind — fall through to backend/cap rules.
+
+    backends = {b.lower() for b in getattr(model_entry, "backends", []) or []}
+    if backends & _NON_GGUF_BACKENDS:
+        return False
+    if backends & _GGUF_BACKENDS:
+        return True
+
+    caps = {c.lower() for c in getattr(model_entry, "capabilities", []) or []}
+    # ASR/TTS capabilities → non-GGUF formats today (whisper/kokoro).
+    if {"asr", "tts"} & caps:
+        return False
+    if caps & _GGUF_CAPS:
+        return True
+
+    if str(model_entry.path).lower().endswith(".gguf"):
+        return True
+
+    # Conservative fallback: run the magic check. If a non-GGUF file
+    # slipped through detection it'll surface a typed NotAGGUF error
+    # at the call site, which is preferable to silently loading a
+    # corrupt or wrong-format file into Lemonade.
+    return True

--- a/tests/lemonade/test_idle.py
+++ b/tests/lemonade/test_idle.py
@@ -1,0 +1,295 @@
+"""Unit tests for ``hal0.lemonade.idle.IdleDriver`` (ADR-0007 §Related, ADR-0006 §17).
+
+The idle driver's contract:
+
+  * Stale loaded model → ``POST /v1/unload`` called
+  * Fresh loaded model → left alone
+  * Lemond unreachable / 5xx → log + continue, no crash
+  * Per-model unload failure → log + continue, sweep proceeds
+  * Cancellation propagates cleanly through ``stop()``
+
+We drive the driver via its public ``tick()`` method so tests are
+deterministic and don't sleep on the real poll interval.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from hal0.lemonade.client import LemonadeClient
+from hal0.lemonade.idle import (
+    DEFAULT_IDLE_TIMEOUT_S,
+    DEFAULT_POLL_INTERVAL_S,
+    IdleDriver,
+    _coerce_last_use,
+    _extract_loaded_models,
+)
+
+
+def _mock_transport(handler):
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://test")
+
+
+# ── tick(): stale → unload ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stale_model_gets_unloaded() -> None:
+    """A model whose last_use is older than idle_timeout_s must be unloaded."""
+    now = 10_000.0
+    calls: list[str] = []
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/health":
+            return httpx.Response(
+                200,
+                json={
+                    "all_models_loaded": [
+                        {"model_name": "stale", "last_use": now - 500.0},
+                        {"model_name": "fresh", "last_use": now - 5.0},
+                    ]
+                },
+            )
+        if req.url.path == "/v1/unload":
+            import json as _json
+
+            body = _json.loads(req.content.decode())
+            calls.append(body["model_name"])
+            return httpx.Response(200, json={"status": "unloaded"})
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(
+            client,
+            idle_timeout_s=300.0,
+            poll_interval_s=30.0,
+            clock=lambda: now,
+        )
+        evicted = await driver.tick()
+        assert evicted == 1
+        # Only the stale model was unloaded.
+        assert calls == ["stale"]
+
+
+@pytest.mark.asyncio
+async def test_fresh_model_not_unloaded() -> None:
+    """Right on the boundary stays loaded — we use strict `>`, not `>=`."""
+    now = 10_000.0
+    calls: list[str] = []
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/health":
+            return httpx.Response(
+                200,
+                json={
+                    # last_use exactly idle_timeout_s ago — boundary
+                    # case, must NOT evict.
+                    "all_models_loaded": [
+                        {"model_name": "boundary", "last_use": now - 300.0},
+                    ]
+                },
+            )
+        if req.url.path == "/v1/unload":
+            import json as _json
+
+            calls.append(_json.loads(req.content.decode())["model_name"])
+            return httpx.Response(200, json={"status": "unloaded"})
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(client, idle_timeout_s=300.0, poll_interval_s=30.0, clock=lambda: now)
+        assert await driver.tick() == 0
+        assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_entries_without_last_use_are_skipped() -> None:
+    """No last_use timestamp → can't decide → leave the model alone."""
+    now = 10_000.0
+    calls: list[str] = []
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/health":
+            return httpx.Response(
+                200,
+                json={
+                    "all_models_loaded": [
+                        {"model_name": "no-ts"},  # missing last_use
+                        {"model_name": "bad-ts", "last_use": "yesterday"},
+                    ]
+                },
+            )
+        if req.url.path == "/v1/unload":
+            import json as _json
+
+            calls.append(_json.loads(req.content.decode())["model_name"])
+            return httpx.Response(200)
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(client, idle_timeout_s=300.0, clock=lambda: now)
+        assert await driver.tick() == 0
+        assert calls == []
+
+
+# ── tick(): resilience ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_unreachable_does_not_raise() -> None:
+    """ConnectError on /v1/health → driver returns 0 evictions, no exception."""
+
+    def h(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(client)
+        # tick() must NOT raise — the driver is supposed to survive
+        # transient lemond outages.
+        assert await driver.tick() == 0
+
+
+@pytest.mark.asyncio
+async def test_health_5xx_does_not_raise() -> None:
+    """Lemonade 5xx on /v1/health → log + skip, no exception."""
+
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"detail": "starting"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(client)
+        assert await driver.tick() == 0
+
+
+@pytest.mark.asyncio
+async def test_unload_failure_does_not_abort_sweep() -> None:
+    """If one /v1/unload fails, the next stale model is still attempted."""
+    now = 10_000.0
+    attempts: list[str] = []
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/health":
+            return httpx.Response(
+                200,
+                json={
+                    "all_models_loaded": [
+                        {"model_name": "first", "last_use": now - 1000.0},
+                        {"model_name": "second", "last_use": now - 1000.0},
+                    ]
+                },
+            )
+        if req.url.path == "/v1/unload":
+            import json as _json
+
+            name = _json.loads(req.content.decode())["model_name"]
+            attempts.append(name)
+            if name == "first":
+                return httpx.Response(500, json={"detail": "boom"})
+            return httpx.Response(200, json={"status": "unloaded"})
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(client, idle_timeout_s=300.0, clock=lambda: now)
+        evicted = await driver.tick()
+        # second one succeeded; first one's failure was swallowed.
+        assert evicted == 1
+        # Both were attempted (sweep didn't bail out after the first failure).
+        assert attempts == ["first", "second"]
+
+
+# ── lifecycle: start/stop ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_then_stop_is_clean() -> None:
+    """Driver must shut down without leaking tasks or raising on cancel."""
+
+    def h(_: httpx.Request) -> httpx.Response:
+        # Empty health — nothing to evict, but the loop runs.
+        return httpx.Response(200, json={"all_models_loaded": []})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(client, poll_interval_s=0.05, idle_timeout_s=300.0)
+        await driver.start()
+        # Give the loop one tick.
+        await asyncio.sleep(0.15)
+        await driver.stop()
+        # Idempotent — second stop is a no-op.
+        await driver.stop()
+
+
+@pytest.mark.asyncio
+async def test_double_start_is_noop() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"all_models_loaded": []})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(client, poll_interval_s=10.0)
+        await driver.start()
+        first_task = driver._task
+        await driver.start()  # must not start a second task
+        assert driver._task is first_task
+        await driver.stop()
+
+
+# ── shape helpers ─────────────────────────────────────────────────────
+
+
+def test_extract_loaded_models_accepts_both_field_names() -> None:
+    """Lemonade has used both ``loaded`` and ``all_models_loaded``."""
+    a = list(_extract_loaded_models({"all_models_loaded": [{"model_name": "x"}]}))
+    b = list(_extract_loaded_models({"loaded": [{"model_name": "y"}]}))
+    assert a == [{"model_name": "x"}]
+    assert b == [{"model_name": "y"}]
+
+
+def test_extract_loaded_models_tolerates_bad_shapes() -> None:
+    """Missing / wrong-type fields yield an empty iterable, not a crash."""
+    assert list(_extract_loaded_models({})) == []
+    assert list(_extract_loaded_models({"all_models_loaded": "nope"})) == []
+    # Non-dict entries inside the list are dropped.
+    assert list(_extract_loaded_models({"loaded": [{"ok": 1}, "skip", 42]})) == [{"ok": 1}]
+
+
+def test_coerce_last_use_rules() -> None:
+    assert _coerce_last_use(1234.5) == 1234.5
+    assert _coerce_last_use(1234) == 1234.0
+    assert _coerce_last_use(None) is None
+    assert _coerce_last_use("yesterday") is None
+    # Critical: bool must NOT pass as 0.0 / 1.0.
+    assert _coerce_last_use(True) is None
+    assert _coerce_last_use(False) is None
+
+
+# ── constructor validation ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_constructor_rejects_nonpositive_intervals() -> None:
+    client = LemonadeClient(http_client=_mock_transport(lambda _: httpx.Response(204)))
+    try:
+        with pytest.raises(ValueError):
+            IdleDriver(client, idle_timeout_s=0.0)
+        with pytest.raises(ValueError):
+            IdleDriver(client, poll_interval_s=0.0)
+        with pytest.raises(ValueError):
+            IdleDriver(client, idle_timeout_s=-1.0)
+    finally:
+        await client.aclose()
+
+
+def test_defaults_match_v0_1_x_policy() -> None:
+    """Defaults are documented as matching hal0 v0.1.x (300s / 30s)."""
+    assert DEFAULT_IDLE_TIMEOUT_S == 300.0
+    assert DEFAULT_POLL_INTERVAL_S == 30.0

--- a/tests/lemonade/test_preload.py
+++ b/tests/lemonade/test_preload.py
@@ -1,0 +1,404 @@
+"""Unit tests for ``hal0.lemonade.preload`` (ADR-0007 §1, §3, §4, §5).
+
+The preload module's only job is to guard ``/v1/load`` so the
+nuclear-evict-all policy never trips on a corrupt/missing/wrong-format
+model. Each ``PreloadError`` subclass gets its own test; a happy-path
+test confirms a well-formed GGUF passes all four guards; an
+end-to-end ``safe_load`` test confirms the timeout-to-PreloadError
+conversion required by ADR-0007 §5.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from hal0.lemonade.client import LemonadeClient
+from hal0.lemonade.errors import LemonadeTimeoutError
+from hal0.lemonade.preload import (
+    GGUF_MAGIC,
+    ChecksumMismatch,
+    FileNotFound,
+    LoadTimeout,
+    NotAGGUF,
+    PreloadError,
+    SizeMismatch,
+    _is_gguf_kind,
+    _sha256_file,
+    preload_validate,
+    safe_load,
+)
+from hal0.registry.model import Model
+
+# A SlotConfig stub — preload_validate doesn't read its fields today
+# (they're reserved for future per-slot tunables). Use a sentinel
+# object so the type-check in the signature passes without forcing
+# every test to construct a full SlotConfig with all required fields.
+_SLOT_CFG = object()
+
+
+def _gguf_payload(body: bytes = b"\x00" * 1024) -> bytes:
+    """Build a minimum-viable GGUF file: 4-byte magic + arbitrary body."""
+    return GGUF_MAGIC + body
+
+
+def _write_model_file(tmp_path: Path, payload: bytes, name: str = "test.gguf") -> Path:
+    p = tmp_path / name
+    p.write_bytes(payload)
+    return p
+
+
+def _model_entry(
+    path: Path,
+    payload: bytes,
+    *,
+    model_id: str = "test-model",
+    backends: list[str] | None = None,
+    capabilities: list[str] | None = None,
+    metadata_extra: dict[str, Any] | None = None,
+) -> Model:
+    """Build a registry ``Model`` with sha256 + size populated from payload.
+
+    Mirrors what the pull engine writes: sha256 in metadata, size_bytes
+    on the top-level field.
+    """
+    md: dict[str, Any] = {"sha256": hashlib.sha256(payload).hexdigest()}
+    if metadata_extra:
+        md.update(metadata_extra)
+    return Model(
+        id=model_id,
+        path=str(path),
+        size_bytes=len(payload),
+        backends=backends if backends is not None else ["vulkan"],
+        capabilities=capabilities if capabilities is not None else ["chat"],
+        metadata=md,
+    )
+
+
+# ── happy path ────────────────────────────────────────────────────────
+
+
+def test_preload_validate_passes_on_well_formed_gguf(tmp_path: Path) -> None:
+    payload = _gguf_payload()
+    p = _write_model_file(tmp_path, payload)
+    entry = _model_entry(p, payload)
+    # No exception → all four guards passed.
+    preload_validate(_SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+
+
+# ── 1. file exists ────────────────────────────────────────────────────
+
+
+def test_file_not_found_when_path_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "ghost.gguf"
+    # Build the entry without writing the file.
+    entry = Model(
+        id="ghost",
+        path=str(missing),
+        size_bytes=1024,
+        backends=["vulkan"],
+        capabilities=["chat"],
+        metadata={"sha256": "0" * 64},
+    )
+    with pytest.raises(FileNotFound) as exc_info:
+        preload_validate(_SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+    assert str(missing) in str(exc_info.value)
+    assert exc_info.value.kind == "file_not_found"
+    # PreloadError is the documented catch-all.
+    assert isinstance(exc_info.value, PreloadError)
+
+
+def test_file_not_found_when_path_is_a_directory(tmp_path: Path) -> None:
+    """A directory at the registry path is just as broken as a missing file."""
+    d = tmp_path / "model_dir"
+    d.mkdir()
+    entry = Model(
+        id="dirmodel",
+        path=str(d),
+        size_bytes=0,
+        backends=["vulkan"],
+        capabilities=["chat"],
+        metadata={},
+    )
+    with pytest.raises(FileNotFound):
+        preload_validate(_SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+
+
+# ── 2. size matches ───────────────────────────────────────────────────
+
+
+def test_size_mismatch_when_disk_size_differs_from_registry(tmp_path: Path) -> None:
+    payload = _gguf_payload()
+    p = _write_model_file(tmp_path, payload)
+    entry = _model_entry(p, payload)
+    # Lie about the size — pretend registry says a different number.
+    entry.size_bytes = len(payload) + 1
+    with pytest.raises(SizeMismatch) as exc_info:
+        preload_validate(_SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+    assert exc_info.value.kind == "size_mismatch"
+    assert str(p) in str(exc_info.value)
+
+
+def test_size_zero_in_registry_skips_size_check(tmp_path: Path) -> None:
+    """``size_bytes == 0`` is the registry's 'unknown' sentinel."""
+    payload = _gguf_payload()
+    p = _write_model_file(tmp_path, payload)
+    entry = _model_entry(p, payload)
+    entry.size_bytes = 0
+    # Should not raise — size check skipped, other guards pass.
+    preload_validate(_SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+
+
+# ── 3. sha256 matches ─────────────────────────────────────────────────
+
+
+def test_checksum_mismatch_on_corrupt_sha256(tmp_path: Path) -> None:
+    payload = _gguf_payload()
+    p = _write_model_file(tmp_path, payload)
+    entry = _model_entry(p, payload)
+    # Replace the recorded sha with a wrong one.
+    entry.metadata["sha256"] = "deadbeef" * 8  # 64 hex chars but wrong
+    with pytest.raises(ChecksumMismatch) as exc_info:
+        preload_validate(_SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+    assert exc_info.value.kind == "checksum_mismatch"
+    assert str(p) in exc_info.value.path
+
+
+def test_checksum_check_skipped_when_registry_has_no_sha(tmp_path: Path) -> None:
+    """Drop-ins under /mnt/ai-models often lack a sha256 — must not fail them."""
+    payload = _gguf_payload()
+    p = _write_model_file(tmp_path, payload)
+    entry = _model_entry(p, payload)
+    entry.metadata.pop("sha256", None)
+    preload_validate(_SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+
+
+def test_streaming_sha256_covers_multi_chunk_files(tmp_path: Path) -> None:
+    """The streaming hash must cover a file larger than one chunk.
+
+    ``_SHA256_CHUNK_BYTES`` is 64 KiB — write 200 KiB so the hash
+    loop runs multiple times. This guards against a regression where
+    the loop reads only the first chunk and short-circuits.
+    """
+    # Use the GGUF magic so the magic check passes too — we want
+    # the test to fail ONLY if streaming sha was broken.
+    body = b"A" * (200 * 1024)
+    payload = GGUF_MAGIC + body
+    p = _write_model_file(tmp_path, payload)
+
+    # Sanity: streamed sha matches a one-shot stdlib hash.
+    streamed = _sha256_file(p)
+    expected = hashlib.sha256(payload).hexdigest()
+    assert streamed == expected
+    assert len(payload) > 64 * 1024  # confirm we exceeded one chunk
+
+    # Validation passes when the recorded sha is correct.
+    entry = _model_entry(p, payload)
+    preload_validate(_SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+
+    # And flips with a one-byte tweak (catches multi-chunk corruption).
+    p.write_bytes(GGUF_MAGIC + b"A" * (200 * 1024 - 1) + b"B")
+    with pytest.raises(ChecksumMismatch):
+        preload_validate(_SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+
+
+# ── 4. GGUF magic ─────────────────────────────────────────────────────
+
+
+def test_not_a_gguf_when_magic_missing(tmp_path: Path) -> None:
+    """File starts with the wrong magic — must raise even if size+sha match."""
+    payload = b"NOPE" + b"\x00" * 1024
+    p = _write_model_file(tmp_path, payload)
+    entry = _model_entry(p, payload)
+    with pytest.raises(NotAGGUF) as exc_info:
+        preload_validate(_SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+    assert exc_info.value.kind == "not_a_gguf"
+
+
+def test_gguf_magic_check_skipped_for_moonshine_kind(tmp_path: Path) -> None:
+    """ASR/TTS files don't use GGUF — magic check must skip them."""
+    payload = b"ONNX" + b"\x00" * 1024  # not GGUF magic
+    p = _write_model_file(tmp_path, payload, name="moonshine.bin")
+    entry = _model_entry(
+        p,
+        payload,
+        model_id="moonshine-small-en",
+        backends=["moonshine"],
+        capabilities=["asr"],
+    )
+    # Should pass: size + sha agree; GGUF magic skipped for moonshine kind.
+    preload_validate(_SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+
+
+def test_gguf_magic_check_skipped_for_kokoro_kind(tmp_path: Path) -> None:
+    payload = b"KOKO" + b"\x00" * 1024
+    p = _write_model_file(tmp_path, payload, name="kokoro.bin")
+    entry = _model_entry(
+        p,
+        payload,
+        model_id="kokoro-en",
+        backends=["kokoro"],
+        capabilities=["tts"],
+    )
+    preload_validate(_SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+
+
+def test_explicit_kind_in_metadata_overrides_inference(tmp_path: Path) -> None:
+    """``metadata['kind']`` wins over backend/capability inference."""
+    payload = b"WHAT" + b"\x00" * 1024  # not GGUF
+    p = _write_model_file(tmp_path, payload)
+    entry = _model_entry(
+        p,
+        payload,
+        backends=["vulkan"],  # would imply GGUF
+        capabilities=["chat"],
+        metadata_extra={"kind": "moonshine"},  # but explicit override wins
+    )
+    # No NotAGGUF raised — explicit kind takes precedence.
+    preload_validate(_SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+
+
+# ── _is_gguf_kind table ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "backends,capabilities,metadata,path_ext,expected",
+    [
+        # GGUF backends → True
+        (["vulkan"], [], {}, ".gguf", True),
+        (["rocm"], ["chat"], {}, "", True),
+        (["cuda"], [], {}, "", True),
+        (["cpu"], ["embed"], {}, "", True),
+        # Non-GGUF backends → False
+        (["moonshine"], ["asr"], {}, "", False),
+        (["kokoro"], ["tts"], {}, "", False),
+        (["sd-cpp"], [], {}, "", False),
+        # Caps imply GGUF
+        ([], ["chat"], {}, "", True),
+        ([], ["embed"], {}, "", True),
+        ([], ["rerank"], {}, "", True),
+        # ASR/TTS caps → not GGUF
+        ([], ["asr"], {}, "", False),
+        ([], ["tts"], {}, "", False),
+        # Explicit kind wins
+        (["vulkan"], ["chat"], {"kind": "kokoro"}, "", False),
+        (["moonshine"], ["asr"], {"kind": "gguf"}, "", True),
+        # Filename suffix fallback
+        ([], [], {}, ".gguf", True),
+        # Total unknown → conservative True (will sniff magic at call site)
+        ([], [], {}, "", True),
+    ],
+)
+def test_is_gguf_kind_table(
+    backends: list[str],
+    capabilities: list[str],
+    metadata: dict[str, Any],
+    path_ext: str,
+    expected: bool,
+) -> None:
+    entry = Model(
+        id="t",
+        path=f"/tmp/x{path_ext}",
+        size_bytes=0,
+        backends=backends,
+        capabilities=capabilities,
+        metadata=metadata,
+    )
+    assert _is_gguf_kind(entry) is expected
+
+
+# ── PreloadError shape ────────────────────────────────────────────────
+
+
+def test_all_preload_error_subclasses_carry_path() -> None:
+    """Every variant — including LoadTimeout — must surface the path."""
+    for cls in (FileNotFound, ChecksumMismatch, SizeMismatch, NotAGGUF, LoadTimeout):
+        exc = cls("/var/lib/hal0/models/foo.gguf")
+        assert exc.path == "/var/lib/hal0/models/foo.gguf"
+        assert isinstance(exc, PreloadError)
+        # The class-level ``kind`` is the stable token for structured logs.
+        assert isinstance(cls.kind, str) and cls.kind
+
+
+# ── safe_load: ADR-0007 §5 timeout-to-PreloadError ────────────────────
+
+
+def _mock_lemonade_transport(handler):
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://test")
+
+
+@pytest.mark.asyncio
+async def test_safe_load_calls_v1_load_on_validation_pass(tmp_path: Path) -> None:
+    payload = _gguf_payload()
+    p = _write_model_file(tmp_path, payload)
+    entry = _model_entry(p, payload, model_id="hermes-4-14b")
+
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        assert req.method == "POST"
+        assert req.url.path == "/v1/load"
+        import json as _json
+
+        captured["body"] = _json.loads(req.content.decode())
+        return httpx.Response(200, json={"status": "loaded"})
+
+    async with _mock_lemonade_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        body = await safe_load(client, _SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+        assert body == {"status": "loaded"}
+        assert captured["body"]["model_name"] == "hermes-4-14b"
+
+
+@pytest.mark.asyncio
+async def test_safe_load_skips_v1_load_when_validation_fails(tmp_path: Path) -> None:
+    """The whole point of ADR-0007 — pre-validation MUST short-circuit /v1/load.
+
+    If safe_load lets a corrupt model through to /v1/load, the nuclear-
+    evict-all policy will blast every loaded model on the failure.
+    """
+    payload = _gguf_payload()
+    p = _write_model_file(tmp_path, payload)
+    entry = _model_entry(p, payload)
+    entry.metadata["sha256"] = "bad" * 32  # corrupt
+
+    calls = {"count": 0}
+
+    def h(_: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        return httpx.Response(200, json={"status": "loaded"})
+
+    async with _mock_lemonade_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        with pytest.raises(ChecksumMismatch):
+            await safe_load(client, _SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+        # Critical: /v1/load was NEVER called.
+        assert calls["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_safe_load_converts_timeout_to_preload_load_timeout(tmp_path: Path) -> None:
+    """ADR-0007 §5: /v1/load timeout surfaces as PreloadError.LoadTimeout.
+
+    SlotManager handles all pre-load failures via a single
+    ``except PreloadError`` clause, so the timeout must be wrapped.
+    """
+    payload = _gguf_payload()
+    p = _write_model_file(tmp_path, payload)
+    entry = _model_entry(p, payload)
+
+    def h(_: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("simulated hang")
+
+    async with _mock_lemonade_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        with pytest.raises(LoadTimeout) as exc_info:
+            await safe_load(client, _SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+        # The original LemonadeTimeoutError is chained via __cause__.
+        assert isinstance(exc_info.value.__cause__, LemonadeTimeoutError)
+        # Path is preserved for the dashboard's error message.
+        assert exc_info.value.path == str(p)

--- a/tests/slots/test_manager_lemonade_integration.py
+++ b/tests/slots/test_manager_lemonade_integration.py
@@ -1,0 +1,271 @@
+"""SlotManager ↔ Lemonade integration tests (ADR-0007).
+
+This module tests the integration *contract* between SlotManager and
+the Lemonade pre-load + load-timeout path. The contract is enforced
+today via ``hal0.lemonade.preload.safe_load`` — the function the
+future ``LemonadeProvider`` (separate PR per the migration plan) will
+call instead of bare ``LemonadeClient.load``. This file pins the
+behaviour the provider PR must honour:
+
+  * PreloadError on validation failure → /v1/load is NOT called
+  * Other loaded models stay loaded across a pre-validation failure
+    (blast-radius assertion — the whole point of ADR-0007)
+  * /v1/load timeout converts to ``PreloadError.LoadTimeout`` so
+    SlotManager can route it through the same error path
+  * No retry on timeout (ADR-0007 §4)
+
+When the ``LemonadeProvider`` lands, this file becomes the regression
+fence — any code path inside the provider that bypasses ``safe_load``
+will break these tests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from hal0.lemonade.client import LemonadeClient
+from hal0.lemonade.errors import LemonadeTimeoutError
+from hal0.lemonade.preload import (
+    GGUF_MAGIC,
+    ChecksumMismatch,
+    FileNotFound,
+    LoadTimeout,
+    PreloadError,
+    safe_load,
+)
+from hal0.registry.model import Model
+
+# Placeholder for the SlotConfig argument. ``safe_load`` doesn't read
+# the SlotConfig today (reserved for future tunables), so any sentinel
+# works. The LemonadeProvider PR will pass a real one.
+_SLOT_CFG = object()
+
+
+def _mock_transport(handler):
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://test")
+
+
+def _write_gguf(path: Path, body: bytes = b"\x00" * 1024) -> bytes:
+    """Write a minimal GGUF file and return the payload."""
+    payload = GGUF_MAGIC + body
+    path.write_bytes(payload)
+    return payload
+
+
+def _model(path: Path, payload: bytes, *, model_id: str = "primary") -> Model:
+    return Model(
+        id=model_id,
+        path=str(path),
+        size_bytes=len(payload),
+        backends=["vulkan"],
+        capabilities=["chat"],
+        metadata={"sha256": hashlib.sha256(payload).hexdigest()},
+    )
+
+
+# ── ADR-0007 §1 + §2: pre-validation failure → /v1/load NOT called ────
+
+
+@pytest.mark.asyncio
+async def test_preload_failure_does_not_call_v1_load(tmp_path: Path) -> None:
+    """The core ADR-0007 invariant.
+
+    If safe_load lets a corrupt model through to /v1/load, Lemonade's
+    nuclear-evict-all policy will blast every loaded model on the
+    failure. This test pins the short-circuit.
+    """
+    p = tmp_path / "primary.gguf"
+    payload = _write_gguf(p)
+    entry = _model(p, payload)
+    entry.metadata["sha256"] = "0" * 64  # poison the hash
+
+    v1_load_hits = {"count": 0}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/load":
+            v1_load_hits["count"] += 1
+        return httpx.Response(200, json={"status": "loaded"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        with pytest.raises(PreloadError) as exc_info:
+            await safe_load(client, _SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+        # Critical: /v1/load was never touched. No evict-all triggered.
+        assert v1_load_hits["count"] == 0
+        # Specific subclass surfaces for the dashboard.
+        assert isinstance(exc_info.value, ChecksumMismatch)
+
+
+@pytest.mark.asyncio
+async def test_missing_file_short_circuits_before_load(tmp_path: Path) -> None:
+    """FileNotFound is the only failure mode Lemonade itself handles
+    safely, but we STILL intercept here so the dashboard gets a typed
+    error instead of a naked HTTP 4xx — and so the surface is uniform
+    with the other PreloadError variants."""
+    missing = tmp_path / "ghost.gguf"
+    entry = Model(
+        id="ghost",
+        path=str(missing),
+        size_bytes=1024,
+        backends=["vulkan"],
+        capabilities=["chat"],
+        metadata={"sha256": "0" * 64},
+    )
+
+    v1_load_hits = {"count": 0}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/load":
+            v1_load_hits["count"] += 1
+        return httpx.Response(200, json={"status": "loaded"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        with pytest.raises(FileNotFound):
+            await safe_load(client, _SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+        assert v1_load_hits["count"] == 0
+
+
+# ── ADR-0007: other slots stay loaded across a failure ────────────────
+
+
+@pytest.mark.asyncio
+async def test_other_loaded_models_stay_loaded_when_pre_validation_fails(
+    tmp_path: Path,
+) -> None:
+    """Blast-radius assertion.
+
+    Simulates the prod scenario: slot ``alpha`` is loaded and serving;
+    slot ``beta`` is asked to load a corrupt model. Without ADR-0007,
+    /v1/load on beta would 5xx and evict alpha. With ADR-0007's
+    pre-validation, /v1/load is never called for beta → alpha
+    untouched.
+    """
+    p = tmp_path / "beta.gguf"
+    payload = _write_gguf(p)
+    beta = _model(p, payload, model_id="beta")
+    beta.metadata["sha256"] = "deadbeef" * 8  # corrupt
+
+    # Track lemond pool state. /v1/load is the only call that would
+    # cause alpha to drop out of `all_models_loaded`.
+    pool: dict[str, dict[str, Any]] = {"alpha": {"model_name": "alpha", "last_use": 0}}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json={"all_models_loaded": list(pool.values())})
+        if req.url.path == "/v1/load":
+            # If we ever reach here, simulate the nuclear-evict-all:
+            pool.clear()
+            return httpx.Response(500, json={"detail": "boom"})
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        # Confirm baseline: alpha is loaded.
+        assert any(m["model_name"] == "alpha" for m in (await client.health())["all_models_loaded"])
+
+        with pytest.raises(ChecksumMismatch):
+            await safe_load(client, _SLOT_CFG, beta, registry=None)  # type: ignore[arg-type]
+
+        # ADR-0007 invariant: alpha STILL loaded. No evict-all triggered
+        # because /v1/load was never called on beta.
+        after = await client.health()
+        assert any(m["model_name"] == "alpha" for m in after["all_models_loaded"])
+
+
+# ── ADR-0007 §5: timeout converts to PreloadError.LoadTimeout ─────────
+
+
+@pytest.mark.asyncio
+async def test_load_timeout_surfaces_as_preload_load_timeout(tmp_path: Path) -> None:
+    """ADR-0007 §5 + brief item 4.
+
+    SlotManager's pre-load failure path is a single ``except PreloadError``
+    branch. ``LemonadeTimeoutError`` from ``client.load()`` must be
+    wrapped into ``PreloadError.LoadTimeout`` so SlotManager doesn't
+    have to know about httpx/lemonade timeout types.
+    """
+    p = tmp_path / "primary.gguf"
+    payload = _write_gguf(p)
+    entry = _model(p, payload)
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/load":
+            raise httpx.ReadTimeout("simulated hang")
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        with pytest.raises(LoadTimeout) as exc_info:
+            await safe_load(client, _SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+        # Underlying cause is preserved for debug tooling.
+        assert isinstance(exc_info.value.__cause__, LemonadeTimeoutError)
+
+
+# ── ADR-0007 §4: NO retry on timeout ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_safe_load_does_not_retry_on_timeout(tmp_path: Path) -> None:
+    """Per ADR-0007 §4: retry would risk another evict-all if the cause
+    flips from a timeout to a non-file-not-found failure mid-retry.
+    safe_load must call /v1/load exactly once."""
+    p = tmp_path / "primary.gguf"
+    payload = _write_gguf(p)
+    entry = _model(p, payload)
+
+    attempts = {"count": 0}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/load":
+            attempts["count"] += 1
+            raise httpx.ReadTimeout("simulated hang")
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        with pytest.raises(LoadTimeout):
+            await safe_load(client, _SLOT_CFG, entry, registry=None)  # type: ignore[arg-type]
+        # Single attempt, no retry.
+        assert attempts["count"] == 1
+
+
+# ── happy path: validation passes → /v1/load called once ──────────────
+
+
+@pytest.mark.asyncio
+async def test_safe_load_happy_path_calls_v1_load_once(tmp_path: Path) -> None:
+    p = tmp_path / "primary.gguf"
+    payload = _write_gguf(p)
+    entry = _model(p, payload, model_id="hermes-4-14b")
+
+    bodies: list[dict[str, Any]] = []
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/load":
+            import json as _json
+
+            bodies.append(_json.loads(req.content.decode()))
+            return httpx.Response(200, json={"status": "loaded"})
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        result = await safe_load(
+            client,
+            _SLOT_CFG,  # type: ignore[arg-type]
+            entry,
+            registry=None,
+            llamacpp_backend="rocm",
+            ctx_size=8192,
+        )
+        assert result == {"status": "loaded"}
+        assert len(bodies) == 1
+        assert bodies[0]["model_name"] == "hermes-4-14b"
+        assert bodies[0]["llamacpp_backend"] == "rocm"
+        assert bodies[0]["ctx_size"] == 8192


### PR DESCRIPTION
Implements ADR-0007 (nuclear-evict-all mitigation) and the v0.1.x idle policy at the Lemonade layer. Builds on #137 (LemonadeClient skeleton) without modifying it. Closes #144.

## What lands

**`src/hal0/lemonade/preload.py`**
- `PreloadError` + `FileNotFound` / `ChecksumMismatch` / `SizeMismatch` / `NotAGGUF` / `LoadTimeout` subclasses, each carrying the offending model path.
- `preload_validate(slot_cfg, model_entry, *, registry)` — file exists, size matches (registry `size_bytes == 0` treated as the "unknown" sentinel per Model schema), streaming sha256 in 64 KiB chunks (skipped when registry has no recorded hash), GGUF magic-byte sniff (skipped for moonshine/kokoro/sd-cpp/whispercpp via backend + capability + explicit `metadata.kind` inference).
- `safe_load(client, slot_cfg, model_entry, ...)` — pre-validate then `POST /v1/load`; converts `LemonadeTimeoutError` to `PreloadError.LoadTimeout` per ADR-0007 §5; NO retry (ADR-0007 §4). This is the function the future `LemonadeProvider` will call instead of bare `client.load()`.
- Race exception (file deleted between validate and load) documented inline per ADR-0007 §3.

**`src/hal0/lemonade/idle.py`**
- `IdleDriver` — async polling task; defaults match v0.1.x policy (300s idle / 30s poll). Resilient to lemond unavailability + per-model unload failures. Clean cancel via `stop()`.
- Accepts both `all_models_loaded` and `loaded` health field names so a Lemonade upgrade rename doesn't silently break the driver.
- Public `tick()` so tests drive the loop deterministically.

**`src/hal0/api/__init__.py`**
- Conditional lifespan hook: starts `IdleDriver` iff `HAL0_BACKEND=lemonade`. Stashes the client + driver on `app.state` for future introspection. Stops the driver in the lifespan `finally` block.

**`src/hal0/lemonade/__init__.py`**
- Exports `PreloadError`, `preload_validate`, `IdleDriver` (only these, per the brief).

## Acceptance criteria from #144

- [x] Corrupt GGUF (wrong sha256) → slot enters error without `/v1/load` being called
- [x] Other loaded models stay loaded when one slot fails pre-validation
- [x] Idle test: stale model → `POST /v1/unload`; fresh model untouched
- [x] Load timeout test: simulated hung `/v1/load` → `PreloadError.LoadTimeout`, single attempt (no retry)
- [x] Race condition documented (file deleted between validate and load — ADR-0007 §3)
- [x] Unit tests for each `PreloadError` variant
- [x] Integration test confirms nuclear-evict-all is not triggered on pre-validation failure
- [x] Docstrings reference ADR-0007 at relevant call sites

## Tests

- `tests/lemonade/test_preload.py` (31 tests) — every `PreloadError` variant, multi-chunk streaming sha256 (>64 KiB), non-GGUF kind detection, explicit kind override.
- `tests/lemonade/test_idle.py` (13 tests) — stale unload, fresh skip, lemond unreachable resilience, sweep continuation across per-model failures, clean start/stop lifecycle.
- `tests/slots/test_manager_lemonade_integration.py` (6 tests) — pins the contract the future `LemonadeProvider` PR must honour.

Total: 50 new tests added, all green. Full suite: 1376 passed / 0 regressions.

## Notes on integration scope

SlotManager today doesn't call `LemonadeClient.load()` — the wiring lands in the `LemonadeProvider` PR (step 8 in `docs/internal/lemonade-migration-plan.md` §PR sequence). To avoid stepping on that PR's branch, this PR:

1. Builds `preload_validate` + `safe_load` as the canonical safe-load path.
2. Wires `IdleDriver` lifecycle behind `HAL0_BACKEND=lemonade`.
3. Pins the integration contract via `tests/slots/test_manager_lemonade_integration.py` — the LemonadeProvider PR will route through `safe_load` and inherit ADR-0007 compliance.

## Constraints honoured (per brief)

- `src/hal0/lemonade/client.py` untouched (PR #137 owns it; `load_timeout_s` already wired).
- `src/hal0/config/schema.py` untouched (#143).
- No `server_models_gen.py` (#141).
- No metrics aggregator (#145).

## Test plan

- [ ] CI green on the new branch
- [ ] Manual: on a host with `HAL0_BACKEND=lemonade`, hal0-api logs `lemonade.idle.driver_attached` on startup
- [ ] Manual: with lemond down, idle driver logs `lemonade.idle.health_unreachable` and survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)