### PR TITLE
feat(cli): model layout migration to <recipe>/<capability>/ tree (PR-7)

### DIFF
--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -32,6 +32,7 @@ from hal0.cli.agent_commands import app as agent_app
 from hal0.cli.capabilities_commands import app as capabilities_app
 from hal0.cli.config_commands import app as config_app
 from hal0.cli.doctor_commands import app as doctor_app
+from hal0.cli.migrate_commands import app as migrate_app
 from hal0.cli.model_commands import app as model_app
 from hal0.cli.slot_commands import app as slot_app
 from hal0.cli.update_commands import update as _update_impl
@@ -56,6 +57,7 @@ app.add_typer(config_app, name="config")
 app.add_typer(doctor_app, name="doctor")
 app.add_typer(capabilities_app, name="capabilities")
 app.add_typer(agent_app, name="agent")
+app.add_typer(migrate_app, name="migrate")
 
 
 # ---------------------------------------------------------------------------

--- a/src/hal0/cli/migrate_commands.py
+++ b/src/hal0/cli/migrate_commands.py
@@ -1,0 +1,765 @@
+"""``hal0 migrate`` subcommands — one-shot v0.2 layout reorganisation.
+
+This module hosts disk-layout reshapes that v0.2 needs the operator to
+run once. Today there is exactly one such command: ``model-layout``,
+which reorganises the v0.1.x ad-hoc model store at ``/mnt/ai-models/``
+into the canonical ``<recipe>/<capability>/`` tree rooted at
+``/var/lib/hal0/models/`` (see lemonade-adoption-plan §6.1 + ADR-0008
+§7).
+
+Design contract (from plan §11 PR-7):
+
+* **Default is dry-run.** Mutations only happen on explicit ``--apply``.
+* **Idempotent.** A second ``--apply`` after the first is a no-op.
+* **Classification by registry.** ``registry.toml`` is the source of
+  truth for capability + recipe selection. Models on disk that aren't
+  in the registry are classified by the directory of origin (the v0.1.x
+  layout described in the ``hal0_model_store_layout`` memory) and
+  reported as "imported, classify manually" warnings.
+* **Symlinks only.** Never copies or moves the files themselves — the
+  v0.1.x slots may still be reading them, and the files can be huge.
+  The canonical tree consists entirely of per-leaf symlinks pointing at
+  the real on-disk location.
+* **Atomic.** Each symlink is written through a sibling tempfile +
+  ``os.replace`` so a crash mid-run never leaves a half-built link.
+* **Safe by default.** Refuses to overwrite a canonical symlink that
+  already points somewhere else unless ``--force`` is given. Refuses to
+  run when the canonical root is itself a bind mount or symlink (would
+  reflect the mutation into an unexpected place).
+
+What the script does NOT do:
+
+* It does not touch the v0.1.x layout under ``/mnt/ai-models/`` — that
+  stays exactly where it is. Slots running off it keep working.
+* It does not download, copy, move, or hash any model file.
+* It does not write to ``/mnt/ai-models/`` at all.
+* It does not migrate ``/mnt/ai-models/huggingface/`` (HF cache) —
+  Lemonade reads HF cache directly, and clobbering it would re-trigger
+  multi-GB redownloads.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+import tomllib
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+app = typer.Typer(
+    name="migrate",
+    help="One-shot v0.2 layout migrations (disk reshape, no data move).",
+    no_args_is_help=True,
+)
+
+
+@app.callback()
+def _migrate_callback() -> None:
+    """One-shot v0.2 layout migrations (disk reshape, no data move).
+
+    The callback exists so Typer keeps ``model-layout`` as a named
+    subcommand even though it's currently the only command — otherwise
+    Typer auto-collapses single-command groups and the operator ends up
+    typing ``hal0 migrate`` instead of ``hal0 migrate model-layout``,
+    which would break the moment we add a second migration.
+    """
+
+
+# ── Canonical tree shape ───────────────────────────────────────────────────────
+
+# (recipe, capability) directories the script mkdir -ps under the canonical
+# root. Anything outside this set is rejected at classification time so a typo
+# in the registry can't seed a stray directory.
+CANONICAL_LEAVES: tuple[tuple[str, str], ...] = (
+    ("llamacpp", "chat"),
+    ("llamacpp", "embed"),
+    ("llamacpp", "rerank"),
+    ("flm", "chat"),
+    ("flm", "embed"),
+    ("whispercpp", "stt"),
+    ("whispercpp", "moonshine"),
+    ("kokoro", "tts"),
+    ("sd-cpp", "img"),
+    ("collections", "omni"),
+)
+
+# Default paths. Override via CLI flags in tests + dev installs.
+DEFAULT_REGISTRY_PATH = Path("/var/lib/hal0/registry/registry.toml")
+DEFAULT_MOUNT_ROOT = Path("/mnt/ai-models")
+DEFAULT_CANONICAL_ROOT = Path("/var/lib/hal0/models")
+
+# v0.1.x directories under DEFAULT_MOUNT_ROOT that we glob for non-registry
+# models. Maps to (recipe, capability) for the canonical placement.
+#
+# Source: ``hal0_model_store_layout`` memory + the v0.1 launchers
+# (providers/flm.py, providers/moonshine.py, providers/kokoro.py).
+V01_DIR_TO_LEAF: dict[str, tuple[str, str]] = {
+    "flm-ubuntu": ("flm", "chat"),
+    "moonshine_voice": ("whispercpp", "moonshine"),
+    "voices": ("kokoro", "tts"),
+    "comfyui": ("sd-cpp", "img"),
+}
+
+# Directories under DEFAULT_MOUNT_ROOT that the script must NOT touch.
+# - ``huggingface``: shared HF cache; Lemonade reads it directly.
+# - any leaf already in canonical layout: those are the migration target.
+PROTECTED_DIRS: frozenset[str] = frozenset({"huggingface"})
+
+
+# ── Registry-driven capability + recipe inference ──────────────────────────────
+
+# hal0 capability vocab → canonical capability directory.
+# Mirrors the rules in lemonade-adoption-plan-2026-05-22 §6.1.
+_CAPABILITY_TO_LEAF_CAP: dict[str, str] = {
+    "chat": "chat",
+    "embed": "embed",
+    "embedding": "embed",
+    "embeddings": "embed",
+    "rerank": "rerank",
+    "reranking": "rerank",
+    "asr": "stt",
+    "transcription": "stt",
+    "stt": "stt",
+    "tts": "tts",
+    "image": "img",
+    "img": "img",
+}
+
+# Strength order — strongest non-chat capability wins when a model
+# advertises multiple. Same idea as
+# ``hal0.lemonade.server_models_gen._CAPABILITY_STRENGTH`` but the leaf
+# vocab is different.
+_CAP_STRENGTH: tuple[str, ...] = (
+    "rerank",
+    "reranking",
+    "embed",
+    "embedding",
+    "embeddings",
+    "asr",
+    "transcription",
+    "stt",
+    "tts",
+    "image",
+    "img",
+    "chat",
+)
+
+# hal0 backend name → canonical recipe directory.
+_BACKEND_TO_RECIPE: dict[str, str] = {
+    "vulkan": "llamacpp",
+    "rocm": "llamacpp",
+    "cuda": "llamacpp",
+    "cpu": "llamacpp",
+    "llamacpp": "llamacpp",
+    "moonshine": "whispercpp",
+    "whispercpp": "whispercpp",
+    "whisper": "whispercpp",
+    "kokoro": "kokoro",
+    "sdcpp": "sd-cpp",
+    "sd-cpp": "sd-cpp",
+    "stable-diffusion": "sd-cpp",
+    "comfyui": "sd-cpp",
+    "flm": "flm",
+}
+
+# Fallback recipe per leaf-capability when the registry doesn't advertise any
+# recognised backend. Mirrors ``server_models_gen._DEFAULT_RECIPE_BY_LABEL``
+# but keyed by our leaf-cap vocab.
+_DEFAULT_RECIPE_BY_LEAF_CAP: dict[str, str] = {
+    "chat": "llamacpp",
+    "embed": "llamacpp",
+    "rerank": "llamacpp",
+    "stt": "whispercpp",
+    "tts": "kokoro",
+    "img": "sd-cpp",
+}
+
+
+# ── Plan dataclasses ───────────────────────────────────────────────────────────
+
+
+ActionKind = Literal["create", "skip-exists", "would-overwrite", "overwrite", "unclassified"]
+
+
+@dataclass(frozen=True)
+class SymlinkAction:
+    """One planned symlink (or one skip / one warning)."""
+
+    kind: ActionKind
+    link_path: Path
+    target_path: Path | None
+    source: str  # "registry:<model_id>" | "imported:<dir>"
+    reason: str = ""
+
+
+@dataclass
+class MigrationReport:
+    """Aggregate report returned from ``plan_migration`` + ``execute``."""
+
+    actions: list[SymlinkAction] = field(default_factory=list)
+    unclassified: list[Path] = field(default_factory=list)
+
+    def by_leaf(self) -> dict[tuple[str, str], int]:
+        out: dict[tuple[str, str], int] = {}
+        for a in self.actions:
+            if a.kind in ("create", "overwrite"):
+                # link_path = <root>/<recipe>/<capability>/<name>
+                parts = a.link_path.parts
+                if len(parts) >= 3:
+                    leaf = (parts[-3], parts[-2])
+                    out[leaf] = out.get(leaf, 0) + 1
+        return out
+
+
+# ── Registry reading ───────────────────────────────────────────────────────────
+
+
+def _read_registry(path: Path) -> dict[str, dict[str, Any]]:
+    """Parse registry.toml into ``{model_id: entry}`` or return ``{}``.
+
+    Empty / missing / malformed registry yields ``{}`` so a fresh-install
+    box (registry not yet populated) still runs cleanly — every on-disk
+    model just falls into the "imported, classify manually" bucket.
+    """
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+    except (tomllib.TOMLDecodeError, OSError):
+        return {}
+
+    raw = data.get("models", {}) if isinstance(data, dict) else {}
+    out: dict[str, dict[str, Any]] = {}
+    if isinstance(raw, dict):
+        for mid, entry in raw.items():
+            if isinstance(entry, dict):
+                out[str(mid)] = entry
+    elif isinstance(raw, list):
+        for entry in raw:
+            if isinstance(entry, dict):
+                mid = entry.get("id")
+                if isinstance(mid, str) and mid:
+                    out[mid] = entry
+    return out
+
+
+def _pick_capability(caps: Iterable[Any]) -> str | None:
+    """Pick the strongest registered capability, or ``None`` if none usable."""
+    seen = {str(c).lower() for c in caps if isinstance(c, str)}
+    for candidate in _CAP_STRENGTH:
+        if candidate in seen:
+            return candidate
+    return None
+
+
+def _classify_registry_entry(entry: dict[str, Any]) -> tuple[str, str] | None:
+    """Return ``(recipe, capability)`` for a registry entry, or ``None``.
+
+    Resolution order matches the production path the dispatcher takes:
+
+    1. Pick the strongest capability (rerank > embed > asr > tts > img >
+       chat). ``None`` if no recognised capability.
+    2. Map capability → canonical leaf-capability directory.
+    3. Map the registry's first recognised backend → recipe. ``flm``
+       in the backends list always wins (NPU is exclusive). Otherwise
+       fall back to the per-leaf-capability default recipe.
+    """
+    cap = _pick_capability(list(entry.get("capabilities") or []))
+    if cap is None:
+        return None
+    leaf_cap = _CAPABILITY_TO_LEAF_CAP.get(cap)
+    if leaf_cap is None:
+        return None
+
+    backends = [str(b).lower() for b in (entry.get("backends") or []) if isinstance(b, str)]
+    recipe: str | None = None
+    if "flm" in backends:
+        recipe = "flm"
+    else:
+        for b in backends:
+            r = _BACKEND_TO_RECIPE.get(b)
+            if r:
+                recipe = r
+                break
+    if recipe is None:
+        recipe = _DEFAULT_RECIPE_BY_LEAF_CAP.get(leaf_cap, "llamacpp")
+
+    if (recipe, leaf_cap) not in CANONICAL_LEAVES:
+        # Defensive — registry shouldn't combine these, but if it does the
+        # script should report rather than create stray directories.
+        return None
+    return recipe, leaf_cap
+
+
+def _entry_disk_path(entry: dict[str, Any]) -> Path | None:
+    """Best-effort absolute path to the entry's on-disk file."""
+    p = entry.get("path") or ""
+    if isinstance(p, str) and p:
+        return Path(p)
+    return None
+
+
+# ── On-disk scan (v0.1.x layout) ───────────────────────────────────────────────
+
+
+def _scan_v01_layout(mount_root: Path) -> list[tuple[Path, tuple[str, str] | None]]:
+    """Walk the v0.1.x directories under ``mount_root``.
+
+    Returns ``[(disk_path, (recipe, capability) | None), ...]``. Files
+    under directories we know the layout of get a classification; files
+    under ``local/`` (which historically holds a mix of GGUFs across
+    capabilities) get ``None`` — those need registry coverage or manual
+    classification.
+    """
+    out: list[tuple[Path, tuple[str, str] | None]] = []
+    if not mount_root.exists():
+        return out
+
+    # Known dirs (v0.1.x or already-canonical layout).
+    for child in sorted(mount_root.iterdir()):
+        if not child.is_dir():
+            continue
+        name = child.name
+        if name in PROTECTED_DIRS:
+            continue
+        # Already-canonical: <mount_root>/<recipe>/<capability>/...
+        if (name,) in {(r,) for r, _ in CANONICAL_LEAVES}:
+            for cap_dir in sorted(child.iterdir()):
+                if not cap_dir.is_dir():
+                    continue
+                leaf = (name, cap_dir.name)
+                if leaf not in CANONICAL_LEAVES:
+                    continue
+                for f in sorted(_iter_files(cap_dir)):
+                    out.append((f, leaf))
+            continue
+        # v0.1.x well-known dir.
+        leaf = V01_DIR_TO_LEAF.get(name)
+        if leaf is not None:
+            for f in sorted(_iter_files(child)):
+                out.append((f, leaf))
+            continue
+        # ``local/`` (or anything else) — leave unclassified for registry
+        # lookup or warning.
+        for f in sorted(_iter_files(child)):
+            out.append((f, None))
+    return out
+
+
+def _iter_files(root: Path) -> Iterable[Path]:
+    """Yield every regular file beneath ``root`` (depth-first, deterministic).
+
+    Walks into subdirectories so the script also catches the directory-as-
+    model layouts (FLM model dirs, moonshine model dirs). Each "leaf"
+    becomes one symlink at the canonical layer.
+
+    Heuristic: when a subdirectory contains a ``model.gguf`` /
+    ``config.json`` / ``preprocessor_config.json``, treat the *directory*
+    as one model (yields the directory, not its files). Otherwise yield
+    each regular file.
+    """
+    if not root.exists():
+        return
+    for entry in sorted(root.iterdir()):
+        if entry.is_dir():
+            sentinels = {p.name for p in entry.iterdir() if p.is_file()}
+            if sentinels & {"config.json", "preprocessor_config.json", "model.gguf"}:
+                yield entry
+                continue
+            yield from _iter_files(entry)
+        elif entry.is_file():
+            yield entry
+
+
+# ── Planner ────────────────────────────────────────────────────────────────────
+
+
+def plan_migration(
+    *,
+    registry_path: Path,
+    mount_root: Path,
+    canonical_root: Path,
+    force: bool,
+) -> MigrationReport:
+    """Compute the migration plan without touching the filesystem.
+
+    Returns a ``MigrationReport`` whose ``actions`` list every symlink the
+    apply step would write (or skip, or refuse), plus an ``unclassified``
+    list of disk paths that couldn't be placed.
+    """
+    report = MigrationReport()
+
+    # Index disk files by their absolute resolved path so the registry walk
+    # can dedupe against on-disk reality.
+    disk_by_path: dict[Path, tuple[str, str] | None] = {}
+    for disk_path, leaf in _scan_v01_layout(mount_root):
+        try:
+            resolved = disk_path.resolve()
+        except OSError:
+            resolved = disk_path
+        disk_by_path[resolved] = leaf
+
+    # Track every link we plan to create so we don't double-plan when a
+    # registry entry and an on-disk scan name the same target.
+    planned_links: set[Path] = set()
+
+    # ── Pass 1: registry-driven ──────────────────────────────────────────
+    registry = _read_registry(registry_path)
+    for mid, entry in registry.items():
+        disk = _entry_disk_path(entry)
+        if disk is None:
+            continue
+        leaf = _classify_registry_entry(entry)
+        if leaf is None:
+            report.unclassified.append(disk)
+            report.actions.append(
+                SymlinkAction(
+                    kind="unclassified",
+                    link_path=canonical_root,
+                    target_path=disk,
+                    source=f"registry:{mid}",
+                    reason="no recognised capability in registry entry",
+                )
+            )
+            continue
+        recipe, leaf_cap = leaf
+        link_path = canonical_root / recipe / leaf_cap / disk.name
+        action = _plan_one_link(
+            link_path=link_path,
+            target=disk,
+            source=f"registry:{mid}",
+            force=force,
+        )
+        if action.link_path not in planned_links:
+            report.actions.append(action)
+            planned_links.add(action.link_path)
+
+    # ── Pass 2: on-disk fallback (v0.1.x directories) ────────────────────
+    registry_paths = {p for p in (_entry_disk_path(e) for e in registry.values()) if p is not None}
+    for disk_path, leaf in disk_by_path.items():
+        if disk_path in registry_paths:
+            continue  # already handled in pass 1
+        if leaf is None:
+            # Unknown dir (e.g. ``local/`` mixed bag) — surface for manual
+            # classification.
+            report.unclassified.append(disk_path)
+            report.actions.append(
+                SymlinkAction(
+                    kind="unclassified",
+                    link_path=canonical_root,
+                    target_path=disk_path,
+                    source=f"imported:{_origin_dir(disk_path, mount_root)}",
+                    reason="not in registry; source dir is not a known v0.1.x layout",
+                )
+            )
+            continue
+        recipe, leaf_cap = leaf
+        link_path = canonical_root / recipe / leaf_cap / disk_path.name
+        if link_path in planned_links:
+            continue
+        action = _plan_one_link(
+            link_path=link_path,
+            target=disk_path,
+            source=f"imported:{_origin_dir(disk_path, mount_root)}",
+            force=force,
+        )
+        report.actions.append(action)
+        planned_links.add(link_path)
+
+    return report
+
+
+def _origin_dir(disk_path: Path, mount_root: Path) -> str:
+    """Return the top-level subdirectory under ``mount_root`` for reporting."""
+    try:
+        rel = disk_path.relative_to(mount_root)
+    except ValueError:
+        return str(disk_path)
+    parts = rel.parts
+    return parts[0] if parts else str(disk_path)
+
+
+def _plan_one_link(
+    *,
+    link_path: Path,
+    target: Path,
+    source: str,
+    force: bool,
+) -> SymlinkAction:
+    """Inspect the filesystem and decide what action ``link_path`` needs."""
+    if link_path.is_symlink():
+        try:
+            current = Path(os.readlink(link_path))
+        except OSError as exc:
+            return SymlinkAction(
+                kind="would-overwrite",
+                link_path=link_path,
+                target_path=target,
+                source=source,
+                reason=f"readlink failed: {exc}",
+            )
+        if current == target:
+            return SymlinkAction(
+                kind="skip-exists",
+                link_path=link_path,
+                target_path=target,
+                source=source,
+                reason="symlink already points at the canonical target",
+            )
+        if force:
+            return SymlinkAction(
+                kind="overwrite",
+                link_path=link_path,
+                target_path=target,
+                source=source,
+                reason=f"existing symlink → {current}; --force overwrite",
+            )
+        return SymlinkAction(
+            kind="would-overwrite",
+            link_path=link_path,
+            target_path=target,
+            source=source,
+            reason=f"refusing to overwrite existing symlink → {current}; pass --force",
+        )
+    if link_path.exists():
+        # A real file or directory sits where we'd plant the symlink.
+        # Refuse regardless of --force — that's not a symlink we own.
+        return SymlinkAction(
+            kind="would-overwrite",
+            link_path=link_path,
+            target_path=target,
+            source=source,
+            reason="a non-symlink file/dir already occupies this path; refusing",
+        )
+    return SymlinkAction(
+        kind="create",
+        link_path=link_path,
+        target_path=target,
+        source=source,
+    )
+
+
+# ── Apply step ─────────────────────────────────────────────────────────────────
+
+
+def _safe_canonical_root(canonical_root: Path) -> None:
+    """Refuse to operate on a bind mount / symlinked canonical root.
+
+    Touching a symlinked or bind-mounted target would scatter the
+    migration into an unexpected place. The script is opinionated: the
+    canonical root must be a plain directory (or absent — we'll mkdir).
+    """
+    if canonical_root.is_symlink():
+        raise typer.BadParameter(
+            f"{canonical_root} is a symlink; refusing to migrate. "
+            f"Move or recreate it as a plain directory first.",
+            param_hint="--canonical-root",
+        )
+    if not canonical_root.exists():
+        return
+    # Best-effort bind-mount check: a bind mount has a different st_dev
+    # from its parent. Skip the check on systems where the parent is on
+    # the same mount as us — that's the common case.
+    try:
+        own = canonical_root.stat().st_dev
+        parent = canonical_root.parent.stat().st_dev
+    except OSError:
+        return
+    if own != parent:
+        raise typer.BadParameter(
+            f"{canonical_root} appears to be a bind mount (different st_dev "
+            f"from its parent). Refusing to migrate. Unmount or pick a "
+            f"different canonical root.",
+            param_hint="--canonical-root",
+        )
+
+
+def _ensure_canonical_dirs(canonical_root: Path) -> None:
+    """``mkdir -p`` every canonical leaf so the symlink writes have a target."""
+    for recipe, capability in CANONICAL_LEAVES:
+        (canonical_root / recipe / capability).mkdir(parents=True, exist_ok=True)
+
+
+def _atomic_symlink(link_path: Path, target: Path) -> None:
+    """Write ``link_path → target`` via a tempfile + ``os.replace``.
+
+    Mirrors the atomic-write pattern in
+    ``hal0.lemonade.server_models_gen.write_server_models``: a partial /
+    crashed run never leaves a half-formed symlink at the canonical
+    location.
+    """
+    link_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=f".{link_path.name}.",
+        suffix=".lnk.tmp",
+        dir=link_path.parent,
+    )
+    # We don't need the fd — the tempfile is just for a unique name.
+    os.close(fd)
+    tmp_path = Path(tmp_str)
+    try:
+        # ``mkstemp`` actually created a file at the path; remove it so
+        # ``os.symlink`` can take the name.
+        with contextlib.suppress(FileNotFoundError):
+            tmp_path.unlink()
+        os.symlink(target, tmp_path)
+        os.replace(tmp_path, link_path)
+        tmp_path = None  # type: ignore[assignment]
+    finally:
+        if tmp_path is not None:
+            with contextlib.suppress(OSError):
+                tmp_path.unlink()
+
+
+def execute_plan(report: MigrationReport) -> list[SymlinkAction]:
+    """Realise the planned actions on disk. Returns the applied actions.
+
+    Skips ``skip-exists`` (already correct) and ``would-overwrite`` /
+    ``unclassified`` (the planner already decided not to touch those).
+    """
+    applied: list[SymlinkAction] = []
+    for action in report.actions:
+        if action.kind not in ("create", "overwrite"):
+            continue
+        assert action.target_path is not None, "create/overwrite require a target"
+        _atomic_symlink(action.link_path, action.target_path)
+        applied.append(action)
+    return applied
+
+
+# ── CLI command ────────────────────────────────────────────────────────────────
+
+
+@app.command("model-layout")
+def model_layout(
+    apply: bool = typer.Option(
+        False,
+        "--apply",
+        help="Apply the migration. Without this, the command is a dry-run.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Overwrite canonical symlinks that already point elsewhere.",
+    ),
+    registry_path: Path = typer.Option(
+        DEFAULT_REGISTRY_PATH,
+        "--registry",
+        help="Path to hal0 registry.toml.",
+    ),
+    mount_root: Path = typer.Option(
+        DEFAULT_MOUNT_ROOT,
+        "--mount-root",
+        help="Disk-backed model store root (the v0.1.x layout source).",
+    ),
+    canonical_root: Path = typer.Option(
+        DEFAULT_CANONICAL_ROOT,
+        "--canonical-root",
+        help="Canonical <recipe>/<capability>/ tree root (the symlink target).",
+    ),
+) -> None:
+    """Reorganise the model store into the v0.2 canonical layout.
+
+    Reads the v0.1.x layout under ``--mount-root`` and produces a
+    per-leaf symlink farm under ``--canonical-root`` pointing at it.
+    Classification is driven by ``--registry`` first; on-disk entries
+    not in the registry are placed by source-directory convention (the
+    v0.1.x layout described in the ``hal0_model_store_layout`` memory)
+    and reported as warnings for manual review.
+
+    The actual model files are NEVER moved or copied — v0.1.x slots
+    keep working off the disk paths they already know.
+
+    Default is dry-run: pass ``--apply`` to write. Idempotent on
+    repeat: re-running ``--apply`` after a successful run is a no-op.
+    """
+    _safe_canonical_root(canonical_root)
+
+    report = plan_migration(
+        registry_path=registry_path,
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        force=force,
+    )
+
+    # Summary table.
+    table = Table(title=f"model-layout migration ({'apply' if apply else 'dry-run'})")
+    table.add_column("action", style="bold")
+    table.add_column("link", overflow="fold")
+    table.add_column("target", overflow="fold")
+    table.add_column("source")
+    table.add_column("reason", overflow="fold")
+
+    by_kind: dict[str, int] = {}
+    for action in report.actions:
+        by_kind[action.kind] = by_kind.get(action.kind, 0) + 1
+        table.add_row(
+            action.kind,
+            str(action.link_path),
+            str(action.target_path) if action.target_path else "—",
+            action.source,
+            action.reason,
+        )
+
+    if report.actions:
+        console.print(table)
+    else:
+        console.print(f"[green]nothing to do[/green] — no models found under {mount_root}.")
+
+    # Per-leaf rollup.
+    leaf_counts = report.by_leaf()
+    if leaf_counts:
+        leaf_table = Table(title="planned by leaf")
+        leaf_table.add_column("recipe")
+        leaf_table.add_column("capability")
+        leaf_table.add_column("count", justify="right")
+        for (recipe, cap), count in sorted(leaf_counts.items()):
+            leaf_table.add_row(recipe, cap, str(count))
+        console.print(leaf_table)
+
+    # Refusal handling — if any would-overwrite remained, exit non-zero so
+    # CI / scripts notice. Unclassifieds are warnings, not errors.
+    blocked = by_kind.get("would-overwrite", 0)
+    if blocked:
+        console.print(
+            f"\n[yellow]warning[/yellow]: {blocked} action(s) blocked; "
+            f"pass --force to overwrite differing symlinks (will NOT clobber "
+            f"non-symlink files)."
+        )
+
+    if not apply:
+        creates = by_kind.get("create", 0)
+        console.print(
+            f"\n[yellow]--dry-run[/yellow] — would create {creates} symlink(s); "
+            f"pass --apply to write."
+        )
+        # Dry-run is informational only; do not exit non-zero on blocked.
+        raise typer.Exit(0)
+
+    # ── Apply ────────────────────────────────────────────────────────────
+    _ensure_canonical_dirs(canonical_root)
+    applied = execute_plan(report)
+    console.print(f"\n[green]applied[/green] {len(applied)} symlink(s) under {canonical_root}.")
+
+    if report.unclassified:
+        console.print(
+            f"[yellow]warning[/yellow]: {len(report.unclassified)} on-disk model(s) "
+            f"could not be classified automatically — see the table above for paths. "
+            f"Add them to the registry with [bold]hal0 model import[/bold] or "
+            f"[bold]hal0 registry add[/bold] and re-run."
+        )
+
+    if blocked:
+        # In --apply mode a blocked action is a real problem; surface it.
+        raise typer.Exit(1)

--- a/tests/cli/test_migrate_model_layout.py
+++ b/tests/cli/test_migrate_model_layout.py
@@ -1,0 +1,696 @@
+"""Tests for ``hal0 migrate model-layout`` — PR-7 of v0.2 Lemonade migration.
+
+Covers the behaviour contract from lemonade-adoption-plan §11 PR-7:
+
+* Default is dry-run; ``--apply`` mutates.
+* Idempotent: second ``--apply`` is a no-op.
+* Registry-driven classification; on-disk fallback via v0.1.x dir layout.
+* Refuses to overwrite differing symlinks without ``--force``.
+* HF cache (``huggingface/``) left untouched.
+* Atomic write via tempfile + ``os.replace``.
+
+The fixture simulates ``/mnt/ai-models/`` and ``/var/lib/hal0/models/``
+under ``tmp_path``; the real script never gets to touch a live install.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import tomli_w
+from typer.testing import CliRunner
+
+from hal0.cli.migrate_commands import (
+    CANONICAL_LEAVES,
+    SymlinkAction,
+    _atomic_symlink,
+    _classify_registry_entry,
+    _pick_capability,
+    plan_migration,
+)
+from hal0.cli.migrate_commands import (
+    app as migrate_app,
+)
+
+runner = CliRunner()
+
+
+# ── Fixture helpers ───────────────────────────────────────────────────────────
+
+
+def _make_tree(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Return ``(mount_root, canonical_root, registry_path)`` under ``tmp_path``."""
+    mount_root = tmp_path / "mnt" / "ai-models"
+    canonical_root = tmp_path / "var" / "lib" / "hal0" / "models"
+    registry_path = tmp_path / "var" / "lib" / "hal0" / "registry" / "registry.toml"
+    mount_root.mkdir(parents=True)
+    return mount_root, canonical_root, registry_path
+
+
+def _touch_file(path: Path, *, size: int = 16) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\x00" * size)
+    return path
+
+
+def _write_registry(path: Path, models: dict[str, dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        tomli_w.dump({"models": models}, f)
+
+
+def _invoke(
+    *,
+    mount_root: Path,
+    canonical_root: Path,
+    registry_path: Path,
+    extra_args: list[str] | None = None,
+) -> object:
+    args = [
+        "model-layout",
+        "--mount-root",
+        str(mount_root),
+        "--canonical-root",
+        str(canonical_root),
+        "--registry",
+        str(registry_path),
+    ]
+    if extra_args:
+        args.extend(extra_args)
+    return runner.invoke(migrate_app, args)
+
+
+# ── Pure-function tests (classification + capability picking) ─────────────────
+
+
+def test_pick_capability_prefers_rerank_over_chat() -> None:
+    assert _pick_capability(["chat", "rerank"]) == "rerank"
+
+
+def test_pick_capability_prefers_embed_over_chat() -> None:
+    assert _pick_capability(["chat", "embed"]) == "embed"
+
+
+def test_pick_capability_chat_when_only_chat() -> None:
+    assert _pick_capability(["chat"]) == "chat"
+
+
+def test_pick_capability_none_when_no_known() -> None:
+    assert _pick_capability(["unknown", "weirdcap"]) is None
+    assert _pick_capability([]) is None
+
+
+def test_classify_llamacpp_chat_entry() -> None:
+    entry = {"capabilities": ["chat"], "backends": ["vulkan", "rocm"]}
+    assert _classify_registry_entry(entry) == ("llamacpp", "chat")
+
+
+def test_classify_llamacpp_embed_entry() -> None:
+    entry = {"capabilities": ["embed"], "backends": ["llamacpp"]}
+    assert _classify_registry_entry(entry) == ("llamacpp", "embed")
+
+
+def test_classify_llamacpp_rerank_entry() -> None:
+    entry = {"capabilities": ["rerank"], "backends": ["vulkan"]}
+    assert _classify_registry_entry(entry) == ("llamacpp", "rerank")
+
+
+def test_classify_flm_wins_when_in_backends() -> None:
+    entry = {"capabilities": ["chat"], "backends": ["vulkan", "flm"]}
+    assert _classify_registry_entry(entry) == ("flm", "chat")
+
+
+def test_classify_moonshine_becomes_whispercpp() -> None:
+    entry = {"capabilities": ["asr"], "backends": ["moonshine"]}
+    assert _classify_registry_entry(entry) == ("whispercpp", "stt")
+
+
+def test_classify_kokoro_tts() -> None:
+    entry = {"capabilities": ["tts"], "backends": ["kokoro"]}
+    assert _classify_registry_entry(entry) == ("kokoro", "tts")
+
+
+def test_classify_image_sdcpp() -> None:
+    entry = {"capabilities": ["image"], "backends": ["sdcpp"]}
+    assert _classify_registry_entry(entry) == ("sd-cpp", "img")
+
+
+def test_classify_returns_none_when_no_capability() -> None:
+    entry = {"capabilities": [], "backends": ["vulkan"]}
+    assert _classify_registry_entry(entry) is None
+
+
+def test_classify_falls_back_to_default_recipe_when_backend_unknown() -> None:
+    # No recognised backend; capability=tts → default recipe is kokoro.
+    entry = {"capabilities": ["tts"], "backends": ["mystery"]}
+    assert _classify_registry_entry(entry) == ("kokoro", "tts")
+
+
+# ── plan_migration unit tests ─────────────────────────────────────────────────
+
+
+def test_plan_creates_symlink_for_registered_chat_model(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    gguf = _touch_file(mount_root / "local" / "qwen3-4b-q4_k_m.gguf")
+    _write_registry(
+        registry_path,
+        {
+            "qwen3-4b-q4_k_m": {
+                "path": str(gguf),
+                "capabilities": ["chat"],
+                "backends": ["vulkan"],
+            }
+        },
+    )
+
+    report = plan_migration(
+        registry_path=registry_path,
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        force=False,
+    )
+
+    creates = [a for a in report.actions if a.kind == "create"]
+    assert len(creates) == 1
+    act = creates[0]
+    assert act.link_path == canonical_root / "llamacpp" / "chat" / "qwen3-4b-q4_k_m.gguf"
+    assert act.target_path == gguf
+
+
+def test_plan_classifies_non_registry_files_by_dir(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    # Empty registry — everything falls into source-dir classification.
+    voice = _touch_file(mount_root / "voices" / "af_heart.bin")
+    moonshine = _touch_file(mount_root / "moonshine_voice" / "moonshine-base.bin")
+
+    report = plan_migration(
+        registry_path=registry_path,
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        force=False,
+    )
+
+    creates_by_target = {a.target_path: a for a in report.actions if a.kind == "create"}
+    assert voice in creates_by_target
+    assert creates_by_target[voice].link_path == canonical_root / "kokoro" / "tts" / "af_heart.bin"
+    assert moonshine in creates_by_target
+    assert (
+        creates_by_target[moonshine].link_path
+        == canonical_root / "whispercpp" / "moonshine" / "moonshine-base.bin"
+    )
+
+
+def test_plan_reports_local_dir_as_unclassified_when_no_registry(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    rogue = _touch_file(mount_root / "local" / "mystery.gguf")
+
+    report = plan_migration(
+        registry_path=registry_path,
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        force=False,
+    )
+
+    assert rogue in report.unclassified
+    unclassified_actions = [a for a in report.actions if a.kind == "unclassified"]
+    assert any(a.target_path == rogue for a in unclassified_actions)
+
+
+def test_plan_skips_existing_correct_symlink(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    gguf = _touch_file(mount_root / "local" / "m.gguf")
+    _write_registry(
+        registry_path,
+        {"m": {"path": str(gguf), "capabilities": ["chat"], "backends": ["vulkan"]}},
+    )
+    link = canonical_root / "llamacpp" / "chat" / "m.gguf"
+    link.parent.mkdir(parents=True)
+    os.symlink(gguf, link)
+
+    report = plan_migration(
+        registry_path=registry_path,
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        force=False,
+    )
+
+    skips = [a for a in report.actions if a.kind == "skip-exists"]
+    assert len(skips) == 1
+    assert skips[0].link_path == link
+
+
+def test_plan_refuses_to_overwrite_differing_symlink_without_force(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    gguf = _touch_file(mount_root / "local" / "m.gguf")
+    wrong = _touch_file(tmp_path / "somewhere-else" / "decoy.gguf")
+    _write_registry(
+        registry_path,
+        {"m": {"path": str(gguf), "capabilities": ["chat"], "backends": ["vulkan"]}},
+    )
+    link = canonical_root / "llamacpp" / "chat" / "m.gguf"
+    link.parent.mkdir(parents=True)
+    os.symlink(wrong, link)
+
+    report = plan_migration(
+        registry_path=registry_path,
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        force=False,
+    )
+
+    blocked = [a for a in report.actions if a.kind == "would-overwrite"]
+    assert len(blocked) == 1
+    assert "refusing to overwrite" in blocked[0].reason
+
+
+def test_plan_overwrites_differing_symlink_with_force(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    gguf = _touch_file(mount_root / "local" / "m.gguf")
+    wrong = _touch_file(tmp_path / "somewhere-else" / "decoy.gguf")
+    _write_registry(
+        registry_path,
+        {"m": {"path": str(gguf), "capabilities": ["chat"], "backends": ["vulkan"]}},
+    )
+    link = canonical_root / "llamacpp" / "chat" / "m.gguf"
+    link.parent.mkdir(parents=True)
+    os.symlink(wrong, link)
+
+    report = plan_migration(
+        registry_path=registry_path,
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        force=True,
+    )
+
+    overwrites = [a for a in report.actions if a.kind == "overwrite"]
+    assert len(overwrites) == 1
+    assert overwrites[0].target_path == gguf
+
+
+def test_plan_refuses_when_real_file_occupies_canonical_path(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    gguf = _touch_file(mount_root / "local" / "m.gguf")
+    _write_registry(
+        registry_path,
+        {"m": {"path": str(gguf), "capabilities": ["chat"], "backends": ["vulkan"]}},
+    )
+    # Plant a real file (not a symlink) where the migration wants to write.
+    _touch_file(canonical_root / "llamacpp" / "chat" / "m.gguf")
+
+    # Even with --force, a real file is not overwritten.
+    report = plan_migration(
+        registry_path=registry_path,
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        force=True,
+    )
+
+    blocked = [a for a in report.actions if a.kind == "would-overwrite"]
+    assert len(blocked) == 1
+    assert "non-symlink" in blocked[0].reason
+
+
+def test_plan_leaves_huggingface_cache_alone(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    hf_blob = _touch_file(
+        mount_root
+        / "huggingface"
+        / "hub"
+        / "models--owner--repo"
+        / "snapshots"
+        / "abc"
+        / "config.json"
+    )
+
+    report = plan_migration(
+        registry_path=registry_path,
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        force=False,
+    )
+
+    # HF cache must not produce ANY actions.
+    for action in report.actions:
+        assert action.target_path != hf_blob
+        if action.target_path is not None:
+            assert "huggingface" not in str(action.target_path)
+
+
+def test_plan_handles_already_canonical_layout(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    # Disk already in the v0.2 layout.
+    gguf = _touch_file(mount_root / "llamacpp" / "chat" / "qwen.gguf")
+
+    report = plan_migration(
+        registry_path=registry_path,
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        force=False,
+    )
+
+    creates = [a for a in report.actions if a.kind == "create"]
+    assert len(creates) == 1
+    assert creates[0].link_path == canonical_root / "llamacpp" / "chat" / "qwen.gguf"
+    assert creates[0].target_path == gguf
+
+
+def test_plan_treats_flm_model_dir_as_one_entity(tmp_path: Path) -> None:
+    """FLM models live as directories with a ``config.json`` sentinel."""
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    model_dir = mount_root / "flm-ubuntu" / "gemma3-1b"
+    model_dir.mkdir(parents=True)
+    (model_dir / "config.json").write_text("{}")
+    (model_dir / "weights.bin").write_bytes(b"\x00" * 32)
+
+    report = plan_migration(
+        registry_path=registry_path,
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        force=False,
+    )
+
+    creates = [a for a in report.actions if a.kind == "create"]
+    # Should produce ONE link to the directory, not one per file inside.
+    assert len(creates) == 1
+    assert creates[0].link_path == canonical_root / "flm" / "chat" / "gemma3-1b"
+    assert creates[0].target_path == model_dir
+
+
+def test_plan_dedupes_registry_and_disk_scan(tmp_path: Path) -> None:
+    """A registry entry covers the same file the disk scan would surface."""
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    # File lives under flm-ubuntu (v0.1.x dir) AND is in the registry.
+    gguf = _touch_file(mount_root / "flm-ubuntu" / "model.gguf")
+    _write_registry(
+        registry_path,
+        {"m": {"path": str(gguf), "capabilities": ["chat"], "backends": ["flm"]}},
+    )
+
+    report = plan_migration(
+        registry_path=registry_path,
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        force=False,
+    )
+
+    # Only ONE create action, not two.
+    creates = [a for a in report.actions if a.kind == "create"]
+    assert len(creates) == 1
+    assert creates[0].link_path == canonical_root / "flm" / "chat" / "model.gguf"
+
+
+# ── CLI dry-run / apply / idempotency ────────────────────────────────────────
+
+
+def test_cli_dry_run_does_not_write(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    gguf = _touch_file(mount_root / "local" / "m.gguf")
+    _write_registry(
+        registry_path,
+        {"m": {"path": str(gguf), "capabilities": ["chat"], "backends": ["vulkan"]}},
+    )
+
+    result = _invoke(
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        registry_path=registry_path,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "dry-run" in result.output
+    # Canonical tree wasn't created (mkdir only happens on --apply).
+    assert not canonical_root.exists() or not any(canonical_root.iterdir())
+
+
+def test_cli_apply_creates_symlinks(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    gguf = _touch_file(mount_root / "local" / "m.gguf")
+    _write_registry(
+        registry_path,
+        {"m": {"path": str(gguf), "capabilities": ["chat"], "backends": ["vulkan"]}},
+    )
+
+    result = _invoke(
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        registry_path=registry_path,
+        extra_args=["--apply"],
+    )
+
+    assert result.exit_code == 0, result.output
+    link = canonical_root / "llamacpp" / "chat" / "m.gguf"
+    assert link.is_symlink()
+    assert Path(os.readlink(link)) == gguf
+    # And the canonical tree got mkdir -p'd in full.
+    for recipe, capability in CANONICAL_LEAVES:
+        assert (canonical_root / recipe / capability).is_dir()
+
+
+def test_cli_apply_is_idempotent(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    gguf = _touch_file(mount_root / "local" / "m.gguf")
+    _write_registry(
+        registry_path,
+        {"m": {"path": str(gguf), "capabilities": ["chat"], "backends": ["vulkan"]}},
+    )
+
+    first = _invoke(
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        registry_path=registry_path,
+        extra_args=["--apply"],
+    )
+    assert first.exit_code == 0, first.output
+
+    # Capture state.
+    link = canonical_root / "llamacpp" / "chat" / "m.gguf"
+    before_inode = os.lstat(link).st_ino
+
+    second = _invoke(
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        registry_path=registry_path,
+        extra_args=["--apply"],
+    )
+    assert second.exit_code == 0, second.output
+
+    after_inode = os.lstat(link).st_ino
+    # Symlink wasn't replaced (skip-exists path taken).
+    assert before_inode == after_inode
+    assert "skip-exists" in second.output or "applied 0" in second.output
+
+
+def test_cli_refuses_overwrite_without_force_in_apply(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    gguf = _touch_file(mount_root / "local" / "m.gguf")
+    wrong = _touch_file(tmp_path / "decoy" / "wrong.gguf")
+    _write_registry(
+        registry_path,
+        {"m": {"path": str(gguf), "capabilities": ["chat"], "backends": ["vulkan"]}},
+    )
+    link = canonical_root / "llamacpp" / "chat" / "m.gguf"
+    link.parent.mkdir(parents=True)
+    os.symlink(wrong, link)
+
+    result = _invoke(
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        registry_path=registry_path,
+        extra_args=["--apply"],
+    )
+
+    # --apply with blocked actions exits non-zero so CI catches it.
+    assert result.exit_code == 1, result.output
+    # Original symlink untouched.
+    assert Path(os.readlink(link)) == wrong
+
+
+def test_cli_force_overwrites_differing_symlink_in_apply(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    gguf = _touch_file(mount_root / "local" / "m.gguf")
+    wrong = _touch_file(tmp_path / "decoy" / "wrong.gguf")
+    _write_registry(
+        registry_path,
+        {"m": {"path": str(gguf), "capabilities": ["chat"], "backends": ["vulkan"]}},
+    )
+    link = canonical_root / "llamacpp" / "chat" / "m.gguf"
+    link.parent.mkdir(parents=True)
+    os.symlink(wrong, link)
+
+    result = _invoke(
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        registry_path=registry_path,
+        extra_args=["--apply", "--force"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert Path(os.readlink(link)) == gguf
+
+
+def test_cli_refuses_symlinked_canonical_root(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    # Make canonical_root itself a symlink.
+    real = tmp_path / "real-canonical"
+    real.mkdir(parents=True)
+    canonical_root.parent.mkdir(parents=True, exist_ok=True)
+    os.symlink(real, canonical_root)
+
+    result = _invoke(
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        registry_path=registry_path,
+    )
+
+    assert result.exit_code != 0
+    # Typer BadParameter shows up either in stdout or stderr; the runner
+    # collates both into ``result.output``.
+    assert "symlink" in result.output.lower() or "bad" in result.output.lower()
+
+
+def test_cli_empty_mount_root_is_noop(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    # mount_root exists but empty.
+
+    result = _invoke(
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        registry_path=registry_path,
+        extra_args=["--apply"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "nothing to do" in result.output or "applied 0" in result.output
+
+
+# ── Atomicity ─────────────────────────────────────────────────────────────────
+
+
+def test_atomic_symlink_leaves_no_tempfile_on_success(tmp_path: Path) -> None:
+    target = _touch_file(tmp_path / "target.bin")
+    link = tmp_path / "linkdir" / "link"
+
+    _atomic_symlink(link, target)
+
+    assert link.is_symlink()
+    assert Path(os.readlink(link)) == target
+    # No leftover .tmp files in the link's parent.
+    leftover = list(link.parent.glob(".link.*.lnk.tmp"))
+    assert leftover == []
+
+
+def test_atomic_symlink_cleans_up_on_replace_failure(tmp_path: Path) -> None:
+    target = _touch_file(tmp_path / "target.bin")
+    link = tmp_path / "linkdir" / "link"
+    link.parent.mkdir(parents=True)
+
+    # Force os.replace to fail so we exercise the cleanup branch.
+    with (
+        patch("hal0.cli.migrate_commands.os.replace", side_effect=OSError("boom")),
+        pytest.raises(OSError, match="boom"),
+    ):
+        _atomic_symlink(link, target)
+
+    # No partial state: the tempfile is cleaned up, the final link
+    # wasn't created.
+    leftover = list(link.parent.glob(".link.*.lnk.tmp"))
+    assert leftover == []
+    assert not link.exists() and not link.is_symlink()
+
+
+def test_execute_plan_crash_midway_leaves_no_broken_state(tmp_path: Path) -> None:
+    """Simulate a crash partway through ``execute_plan``: completed
+    symlinks survive, the rest are simply not created, and the canonical
+    tree never contains a half-built tempfile.
+    """
+    from hal0.cli.migrate_commands import execute_plan
+
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    g1 = _touch_file(mount_root / "local" / "a.gguf")
+    g2 = _touch_file(mount_root / "local" / "b.gguf")
+    g3 = _touch_file(mount_root / "local" / "c.gguf")
+    _write_registry(
+        registry_path,
+        {
+            "a": {"path": str(g1), "capabilities": ["chat"], "backends": ["vulkan"]},
+            "b": {"path": str(g2), "capabilities": ["chat"], "backends": ["vulkan"]},
+            "c": {"path": str(g3), "capabilities": ["chat"], "backends": ["vulkan"]},
+        },
+    )
+    # The script's apply path mkdir -ps the canonical tree before
+    # writing symlinks; replicate that here.
+    for recipe, capability in CANONICAL_LEAVES:
+        (canonical_root / recipe / capability).mkdir(parents=True, exist_ok=True)
+
+    report = plan_migration(
+        registry_path=registry_path,
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        force=False,
+    )
+
+    # Make the 3rd os.replace blow up.
+    real_replace = os.replace
+    calls = {"n": 0}
+
+    def flaky_replace(src: object, dst: object) -> None:
+        calls["n"] += 1
+        if calls["n"] == 3:
+            raise OSError("simulated crash")
+        real_replace(src, dst)
+
+    with (
+        patch("hal0.cli.migrate_commands.os.replace", side_effect=flaky_replace),
+        pytest.raises(OSError, match="simulated crash"),
+    ):
+        execute_plan(report)
+
+    # The first two symlinks survived; the third never made it but
+    # also didn't leave a tempfile behind.
+    chat_dir = canonical_root / "llamacpp" / "chat"
+    survivors = sorted(p.name for p in chat_dir.iterdir() if p.is_symlink())
+    assert survivors == ["a.gguf", "b.gguf"]
+    leftover = list(chat_dir.glob(".*.lnk.tmp"))
+    assert leftover == []
+
+
+# ── Reporting + structure sanity ─────────────────────────────────────────────
+
+
+def test_report_by_leaf_counts_creates_only(tmp_path: Path) -> None:
+    mount_root, canonical_root, registry_path = _make_tree(tmp_path)
+    g1 = _touch_file(mount_root / "local" / "a.gguf")
+    g2 = _touch_file(mount_root / "local" / "e.gguf")
+    _write_registry(
+        registry_path,
+        {
+            "a": {"path": str(g1), "capabilities": ["chat"], "backends": ["vulkan"]},
+            "e": {"path": str(g2), "capabilities": ["embed"], "backends": ["vulkan"]},
+        },
+    )
+
+    report = plan_migration(
+        registry_path=registry_path,
+        mount_root=mount_root,
+        canonical_root=canonical_root,
+        force=False,
+    )
+
+    leaves = report.by_leaf()
+    assert leaves[("llamacpp", "chat")] == 1
+    assert leaves[("llamacpp", "embed")] == 1
+
+
+def test_action_dataclass_is_frozen() -> None:
+    action = SymlinkAction(
+        kind="create",
+        link_path=Path("/x"),
+        target_path=Path("/y"),
+        source="registry:m",
+    )
+    # frozen dataclass → FrozenInstanceError (subclass of AttributeError)
+    with pytest.raises(AttributeError):
+        action.kind = "skip-exists"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

PR-7 of the v0.2 Lemonade migration (lemonade-adoption-plan §11). Adds `hal0 migrate model-layout` — a one-shot, dry-run-default, idempotent CLI command that reorganises the v0.1.x model store at `/mnt/ai-models/` into the canonical `<recipe>/<capability>/` tree rooted at `/var/lib/hal0/models/`.

Backs plan §6.1 (canonical layout) + ADR-0008 §7 (no `extra.*` namespace).

### What lands

- `src/hal0/cli/migrate_commands.py` — Typer subapp wired into `hal0` as `hal0 migrate model-layout`.
- `tests/cli/test_migrate_model_layout.py` — 36 tests covering the full behaviour contract.
- Two-line wire-up in `src/hal0/cli/main.py`.

### Behaviour contract

- **Default is dry-run.** `--apply` required to mutate.
- **Idempotent.** Second `--apply` is a no-op (skip-exists path).
- **Registry-driven classification.** `registry.toml` is the source of truth — each entry's `capability` + `backends` → `(recipe, capability)` leaf via the same mapping the `server_models.json` generator already uses.
- **Source-dir fallback.** On-disk files not in the registry are placed by v0.1.x source-dir convention per the `hal0_model_store_layout` memory: `flm-ubuntu` → `flm/chat`, `moonshine_voice` → `whispercpp/moonshine`, `voices` → `kokoro/tts`, `comfyui` → `sd-cpp/img`. Files under `local/` (mixed bag) without registry coverage are reported as "imported, classify manually" warnings.
- **Symlinks only.** Per-leaf symlinks from canonical → real on-disk path. No copy, no move.
- **`huggingface/` cache untouched.** Lemonade reads it directly; clobbering would re-trigger multi-GB redownloads.
- **`--force` overwrites differing symlinks** but never clobbers a real file at the canonical path.
- **Refuses to operate on a symlinked / bind-mounted canonical root** — would scatter mutations into an unexpected place.

## Migration safety

This migration is unusually safe by construction, which is the whole point of the design. A few notes on the reasoning that informed each behaviour:

**Why symlinks, not moves.** The v0.1.x slot launchers (`providers/flm.py`, `providers/moonshine.py`, `providers/kokoro.py`, the llama-server wrappers) all read directly from the disk paths the registry hands them — typically `/mnt/ai-models/local/<name>.gguf`. Moving those files mid-flight would silently break any running slot pointing at the old location, with the failure surfacing only on the next request. Symlinking instead means both layouts coexist: v0.1.x slots keep reading their original paths, while v0.2 code (Lemonade's `extra_models_dir`) reads through the canonical tree. The migration becomes a non-event from the running-system perspective.

**Why dry-run by default.** The operator can't see the canonical tree before the migration runs, so they have no way to predict where each model will land. The dry-run table prints the full plan — every link, every target, every classification source — and the operator confirms before any FS mutation. This also means CI / automation can run `hal0 migrate model-layout` without any flag and treat the exit code as a sanity probe rather than as authorisation.

**Why per-leaf atomicity.** Each symlink is written via tempfile + `os.replace` so a crash midway through the apply step never leaves a half-formed link at the canonical location. Either the symlink exists and points where intended, or it doesn't exist at all. The flaky-replace test (`test_execute_plan_crash_midway_leaves_no_broken_state`) verifies the contract: when `os.replace` blows up on the third of three actions, the first two survive cleanly and the canonical directory has no leftover `.tmp` files.

**Why refuse symlinked canonical root.** If `/var/lib/hal0/models/` is itself a symlink to (say) `/mnt/external/whatever/`, the migration would scatter symlinks into the target of that link rather than the place the operator can see at the canonical name. The check is cheap (`Path.is_symlink()` + a `st_dev` parent-comparison for bind mounts) and the failure mode is loud — the operator sees a `BadParameter` with the offending path and is told to recreate it as a plain directory.

**Why `--force` doesn't clobber real files.** A real file occupying the canonical path is a sign of something the operator did deliberately (a hand-placed override, a manual copy, a forgotten experiment). Auto-clobbering would lose data with no recovery path. The migration reports it as a blocked action and exits non-zero in `--apply` mode; the operator decides what to do.

**Why `local/` falls into the unclassified bucket without registry coverage.** v0.1.x stored a mix of chat / embed / rerank GGUFs under `local/` with no per-dir classification. Without registry data, the migration has no reliable way to assign a leaf. Reporting unclassifieds rather than guessing means the operator gets a list of files needing `hal0 model import` (or `hal0 registry add`) and can re-run the migration after fixing the registry.

## Test plan

- [x] `pytest tests/cli/test_migrate_model_layout.py -q` — 36 passed
- [x] `pytest tests/ -q` — 1479 passed, 8 skipped, 3 xfailed (no regressions)
- [x] `ruff check src/hal0/cli tests/cli` — clean
- [x] `ruff format --check src/hal0/cli tests/cli` — clean
- [x] `hal0 migrate --help` — shows `model-layout` subcommand
- [x] `hal0 migrate model-layout --help` — full option surface

## References

- lemonade-adoption-plan-2026-05-22 §6.1 (canonical layout) + §11 PR-7
- ADR-0008 §7 (no `extra.*` namespace)
- Memory `hal0_model_store_layout` (v0.1.x source layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)