### PR TITLE
feat(providers): LemonadeProvider + capability dispatch via Lemonade (PR-8)

### DIFF
--- a/src/hal0/providers/__init__.py
+++ b/src/hal0/providers/__init__.py
@@ -21,6 +21,7 @@ from hal0.providers.base import ContainerSpec, Provider
 from hal0.providers.comfyui import ComfyUIProvider
 from hal0.providers.flm import FLMProvider
 from hal0.providers.kokoro import KokoroProvider
+from hal0.providers.lemonade import LemonadeProvider
 from hal0.providers.llama_server import LlamaServerProvider
 from hal0.providers.moonshine import MoonshineProvider
 
@@ -28,7 +29,17 @@ from hal0.providers.moonshine import MoonshineProvider
 # ABC contract), so one instance per process is enough.  SlotManager
 # itself stays provider-agnostic; the unit-template renderer (which is
 # logically "provider-systemd glue") is the only caller of get_provider.
+#
+# v0.2 (ADR-0008 §2): Lemonade is the only runtime — slots no longer
+# spawn per-modality toolbox containers. ``LemonadeProvider`` is the
+# operational provider for every slot when ``HAL0_BACKEND=lemonade``;
+# the others survive in this table because PR-9 only retired the
+# Dockerfiles + systemd template, not the Python provider classes (per
+# the anti-scope in PR-8's brief — PR-10 owns their removal). The
+# v0.1.x toolbox path remains intact for any caller still on
+# ``HAL0_BACKEND`` ≠ ``lemonade``.
 _PROVIDERS: dict[str, Provider] = {
+    "lemonade": LemonadeProvider(),
     "llama-server": LlamaServerProvider(),
     "flm": FLMProvider(),
     "moonshine": MoonshineProvider(),
@@ -51,13 +62,27 @@ def get_provider(name: str) -> Provider:
         raise KeyError(f"no provider registered for {name!r}; known: {sorted(_PROVIDERS)}") from exc
 
 
+def lemonade_provider() -> LemonadeProvider:
+    """Return the process-wide ``LemonadeProvider`` singleton.
+
+    Convenience accessor for callers that know they want the Lemonade
+    provider specifically (SlotManager's v0.2 dispatch branch is the
+    canonical caller). Equivalent to ``get_provider("lemonade")``
+    cast to ``LemonadeProvider``; kept as a typed helper so callers
+    don't have to cast.
+    """
+    return _PROVIDERS["lemonade"]  # type: ignore[return-value]
+
+
 __all__ = [
     "ComfyUIProvider",
     "ContainerSpec",
     "FLMProvider",
     "KokoroProvider",
+    "LemonadeProvider",
     "LlamaServerProvider",
     "MoonshineProvider",
     "Provider",
     "get_provider",
+    "lemonade_provider",
 ]

--- a/src/hal0/providers/lemonade.py
+++ b/src/hal0/providers/lemonade.py
@@ -1,0 +1,539 @@
+"""LemonadeProvider — v0.2 unified-runtime Provider (PR-8).
+
+In v0.1.x every backend (llama-server, FLM, Moonshine, Kokoro, …) was a
+separate Provider class that spawned its own toolbox container under a
+systemd template unit. v0.2 (ADR-0008) replaces that with a single
+Lemonade Server daemon (``lemond``) that owns process lifecycle for
+every modality. ``LemonadeProvider`` is the thin adapter between hal0's
+slot abstraction and Lemonade's HTTP control plane.
+
+Where this fits in the abstraction stack:
+
+  - SlotManager keeps its v0.1.x public surface (``load`` / ``unload`` /
+    ``swap`` / ``status`` / …). Per PR-8 contract, no caller signatures
+    change. SlotManager internally gates between the legacy
+    docker/systemd path and the Lemonade path on ``HAL0_BACKEND``.
+  - Under ``HAL0_BACKEND=lemonade``, SlotManager calls
+    :meth:`LemonadeProvider.load` / :meth:`unload` instead of writing an
+    override.conf and running ``systemctl start``. The active Lemonade
+    daemon (``hal0-lemonade.service``, port 13305) owns every child
+    process. There is no per-slot container to render.
+  - Under the legacy backend mode, every other Provider in
+    :mod:`hal0.providers` continues to work unchanged. Phase 3's PR-10
+    will retire those providers and the systemd path; until then they
+    live alongside this class.
+
+ABC compliance notes:
+
+The :class:`hal0.providers.base.Provider` ABC has docker/systemd-shaped
+methods (``build_env``, ``start_cmd``, ``container_spec``,
+``render_systemd_override``) that have no operational meaning for a
+daemon-backed runtime. We implement them either as informational stubs
+(``build_env`` returns a slot-identity env block useful for diagnostics
++ audit) or by raising ``NotImplementedError`` with a pointer back to
+this docstring. The ``Provider.render_systemd_override`` path is only
+reached via :mod:`hal0.slots.unit_template`, which SlotManager skips on
+the Lemonade-active branch — so the raising stubs are unreachable in
+production code, but the ABC contract still needs them defined.
+
+Inference forward (``/v1/chat/completions``, ``/v1/embeddings``, …) is
+NOT this class's responsibility; it goes through the existing
+dispatcher unchanged. LemonadeProvider only owns control plane
+(``/v1/load``, ``/v1/unload``, ``/v1/health``) — same separation as
+``LemonadeClient``.
+
+ADR cross-references:
+
+- ADR-0008 §1 — Lemonade as the v0.2 unified runtime
+- ADR-0008 §2 — Lemonade IS the only provider in v0.2
+- ADR-0008 §3 — no preload validation (removed in #155)
+- ADR-0008 §6 — SlotManager.start becomes Lemonade /v1/load
+- docs/internal/lemonade-adoption-plan-2026-05-22.md §4.1 — device →
+  recipe/backend mapping
+- docs/internal/lemonade-adoption-plan-2026-05-22.md §11 PR-8 — the
+  capability-dispatch wiring this class enables
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from hal0.lemonade.client import LemonadeClient
+from hal0.providers.base import ContainerSpec, Provider
+
+log = logging.getLogger(__name__)
+
+
+# ── device → Lemonade recipe/backend mapping ─────────────────────────────────
+#
+# Plan §4.1 + ADR-0008 §6 locked the four-way mapping. ``gpu-*`` slots
+# load through llama.cpp with an explicit backend flag; ``cpu`` is the
+# same recipe with CPU-only inference; ``npu`` uses Lemonade's FLM
+# recipe and does not take a llamacpp_backend (FLM is its own backend).
+#
+# Returned tuple shape: ``(recipe, llamacpp_backend)``. ``recipe=None``
+# means "let Lemonade pick its default" (currently the llama.cpp recipe
+# for gpu/cpu).  Either value being ``None`` causes
+# :meth:`LemonadeClient.load` to omit the key from the request body —
+# Lemonade then falls through to its internal sentinel logic.
+
+
+def device_to_backend(device: str | None) -> tuple[str | None, str | None]:
+    """Map hal0's ``device`` enum onto Lemonade's recipe+backend pair.
+
+    Args:
+        device: One of ``gpu-rocm`` | ``gpu-vulkan`` | ``cpu`` | ``npu``.
+                Empty / unknown values fall back to ``(None, None)`` so
+                Lemonade picks its own defaults — same semantics as
+                omitting the keys from the load body.
+
+    Returns:
+        ``(recipe, llamacpp_backend)``. Either may be ``None`` to mean
+        "don't send this key in the /v1/load body". The two are
+        mutually exclusive in practice — NPU uses ``recipe="flm"`` with
+        no llamacpp_backend; everything else uses ``recipe=None`` with
+        a concrete llamacpp_backend.
+    """
+    if not device:
+        return (None, None)
+    d = device.strip().lower()
+    if d == "gpu-rocm":
+        return (None, "rocm")
+    if d == "gpu-vulkan":
+        return (None, "vulkan")
+    if d == "cpu":
+        return (None, "cpu")
+    if d == "npu":
+        # FLM recipe; ``llamacpp_backend`` is meaningless here. Lemonade
+        # routes the load to its fastflowlm_server backend.
+        return ("flm", None)
+    log.warning(
+        "lemonade.provider.unknown_device",
+        extra={"device": device},
+    )
+    return (None, None)
+
+
+# ── slot config helpers (provider-side) ──────────────────────────────────────
+#
+# Local versions of the dict-or-pydantic coercion that already lives in
+# ``hal0.slots.manager`` and ``hal0.slots.unit_template``. Duplicated
+# here so this module doesn't pull in slots/manager.py (which would
+# create a circular import — manager.py is going to import this class).
+
+
+def _to_dict(slot_cfg: Any) -> dict[str, Any]:
+    if hasattr(slot_cfg, "model_dump"):
+        return slot_cfg.model_dump()  # type: ignore[no-any-return]
+    if isinstance(slot_cfg, dict):
+        return dict(slot_cfg)
+    raise TypeError(f"slot_cfg must be SlotConfig or dict, got {type(slot_cfg).__name__}")
+
+
+def _slot_device(slot_cfg: dict[str, Any]) -> str:
+    """Pull the v0.2 ``device`` field with v0.1.x ``backend`` fallback."""
+    device = slot_cfg.get("device")
+    if device:
+        return str(device)
+    # SlotConfig._promote_backend_to_device promotes on load, but raw
+    # dicts (test injection, capability orchestrator scratch) may carry
+    # only ``backend`` — map through the same helper used elsewhere.
+    backend = slot_cfg.get("backend")
+    if not backend:
+        return ""
+    from hal0.config.schema import map_backend_to_device
+
+    return map_backend_to_device(str(backend))
+
+
+def _slot_model(slot_cfg: dict[str, Any]) -> str:
+    """Pull ``model.default`` from a slot config. Empty when unset."""
+    model_section = slot_cfg.get("model") or {}
+    if isinstance(model_section, dict):
+        return str(model_section.get("default") or "")
+    return ""
+
+
+def _slot_ctx(slot_cfg: dict[str, Any]) -> int | None:
+    """Pull ``model.context_size`` if set. None when unset (Lemonade default)."""
+    model_section = slot_cfg.get("model") or {}
+    if isinstance(model_section, dict):
+        ctx = model_section.get("context_size")
+        if isinstance(ctx, int) and ctx > 0:
+            return ctx
+    return None
+
+
+def _slot_extra_args(slot_cfg: dict[str, Any]) -> str | None:
+    """Pull ``server.extra_args`` if set. None means Lemonade uses defaults.
+
+    The wire format is a single space-separated string (per the
+    ``hal0_lemonade_v1_load_schema`` memory + LemonadeClient.load
+    docstring). Empty string is rejected as a sentinel ambiguity — we
+    omit the key entirely instead.
+    """
+    server_section = slot_cfg.get("server") or {}
+    if isinstance(server_section, dict):
+        extra = server_section.get("extra_args")
+        if isinstance(extra, str) and extra.strip():
+            return extra.strip()
+    return None
+
+
+# ── env override (test seam) ────────────────────────────────────────────────
+
+
+def _env_backend() -> str:
+    """Read the active backend mode from the environment.
+
+    Centralised so tests can monkeypatch one symbol instead of poking
+    ``os.environ`` directly. The match is case-insensitive + stripped
+    so accidental whitespace in ``hal0-api.service`` env files doesn't
+    silently disable the Lemonade path.
+    """
+    return (os.environ.get("HAL0_BACKEND") or "").strip().lower()
+
+
+def lemonade_active() -> bool:
+    """True when ``HAL0_BACKEND=lemonade`` is in effect.
+
+    Public helper so SlotManager + tests can gate on the same predicate
+    without duplicating the env-var spelling. Matches the gating in
+    :func:`hal0.api._maybe_start_lemonade_idle_driver`.
+    """
+    return _env_backend() == "lemonade"
+
+
+# ── provider ────────────────────────────────────────────────────────────────
+
+
+class LemonadeProvider(Provider):
+    """Provider adapter for the Lemonade Server runtime.
+
+    Lifecycle calls (``load`` / ``unload`` / ``status``) translate
+    SlotConfig fields onto :class:`LemonadeClient` calls. All other
+    Provider ABC methods either return informational stubs or raise —
+    see module docstring. Stateless aside from the held client.
+
+    The held ``LemonadeClient`` is shared with the idle-unload driver
+    (see :mod:`hal0.lemonade.idle`) so both subsystems use one
+    connection pool. Construct one provider per hal0-api process —
+    :func:`hal0.providers.lemonade_provider` is the singleton getter
+    matching the pattern used elsewhere in :mod:`hal0.providers`.
+    """
+
+    name: str = "lemonade"
+
+    def __init__(self, client: LemonadeClient | None = None) -> None:
+        # Lazy client init: the singleton in ``providers/__init__.py``
+        # is constructed at import time; we don't want to open an httpx
+        # client until somebody actually uses it. Tests inject their
+        # own pre-mocked client.
+        self._client = client
+        self._owns_client: bool = client is None
+
+    # ── client accessor ────────────────────────────────────────────────────
+
+    def client(self) -> LemonadeClient:
+        """Return the held LemonadeClient, constructing one on first use.
+
+        Reads ``LEMONADE_API_KEY`` from the environment on first
+        construction (same convention as
+        :func:`hal0.api._maybe_start_lemonade_idle_driver`). Subsequent
+        calls reuse the same instance.
+        """
+        if self._client is None:
+            self._client = LemonadeClient(
+                api_key=os.environ.get("LEMONADE_API_KEY") or None,
+            )
+        return self._client
+
+    async def aclose(self) -> None:
+        """Close the held client if we own it. Idempotent."""
+        if self._client is not None and self._owns_client:
+            await self._client.aclose()
+            self._client = None
+
+    # ── Provider ABC implementations ───────────────────────────────────────
+
+    def build_env(
+        self,
+        slot_cfg: dict[str, Any],
+        model_info: dict[str, Any],
+    ) -> dict[str, str]:
+        """Return an informational env block for the slot.
+
+        Under Lemonade there's no per-slot env file written to disk —
+        ``lemond`` reads its own ``/var/lib/hal0/lemonade/config.json``
+        and we never invoke a docker run line. But callers (tests,
+        audit logs, ``hal0 slot inspect``) still want a stable "what
+        does this slot identify as" view, so we return the same
+        ``HAL0_*`` keys the toolbox providers emit, sourced from the
+        slot config + LemonadeProvider's runtime mapping.
+        """
+        cfg = _to_dict(slot_cfg)
+        device = _slot_device(cfg)
+        recipe, llamacpp_backend = device_to_backend(device)
+        env: dict[str, str] = {
+            "HAL0_SLOT_NAME": str(cfg.get("name") or ""),
+            "HAL0_PORT": str(cfg.get("port") or 0),
+            "HAL0_BIND_HOST": "127.0.0.1",
+            "HAL0_DEVICE": device,
+            "HAL0_PROVIDER": "lemonade",
+            "HAL0_MODEL_ID": _slot_model(cfg),
+            # Diagnostic: what Lemonade is told for this slot.
+            "HAL0_LEMONADE_RECIPE": recipe or "",
+            "HAL0_LEMONADE_LLAMACPP_BACKEND": llamacpp_backend or "",
+        }
+        ctx = _slot_ctx(cfg)
+        if ctx is not None:
+            env["HAL0_CTX"] = str(ctx)
+        # Propagate model_info path when available (audit + UI).
+        path = (model_info or {}).get("path")
+        if path:
+            env["HAL0_MODEL_PATH"] = str(path)
+        return env
+
+    def start_cmd(self, env: dict[str, str]) -> list[str]:
+        """Return the conceptual control-plane invocation.
+
+        Lemonade slots don't spawn a per-slot process — the daemon
+        ``lemond`` is shared. The returned argv is informational only;
+        it points at ``hal0-lemonade.service``'s ExecStart so anybody
+        introspecting the slot can find the responsible unit.
+        """
+        return [
+            "/opt/lemonade/lemond",
+            "/var/lib/hal0/lemonade",
+            # Mirror SlotConfig identity so diagnostics line up.
+            f"--slot-name={env.get('HAL0_SLOT_NAME', '')}",
+        ]
+
+    async def health(self, port: int) -> dict[str, Any]:
+        """Probe Lemonade's daemon health.
+
+        ``port`` is the slot's nominal port (the v0.1.x interface); we
+        ignore it and probe lemond on its actual port. Returns a dict
+        shaped like other providers' ``health()`` output: ``{ok,
+        status, ...}``. Failures are reported via the ``ok=False`` +
+        ``status`` keys instead of raising — matches the LlamaServer /
+        FLM provider pattern.
+        """
+        try:
+            body = await self.client().health()
+        except Exception as exc:
+            return {
+                "ok": False,
+                "status": "unavailable",
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+            }
+        return {"ok": True, "status": "ready", "health": body}
+
+    async def infer(self, port: int, body: dict[str, Any]) -> dict[str, Any]:
+        """Pass-through inference is NOT this provider's responsibility.
+
+        The dispatcher (``hal0.dispatcher.router``) speaks OpenAI to
+        Lemonade directly on port 13305 — there is no per-provider
+        infer indirection in the Lemonade path. Raising here surfaces
+        a clear error if anyone wires inference through the provider
+        layer by mistake.
+        """
+        raise NotImplementedError(
+            "LemonadeProvider does not own request forward; the dispatcher "
+            "speaks OpenAI directly to lemond on port 13305."
+        )
+
+    def container_spec(
+        self,
+        slot_cfg: dict[str, Any],
+        model_info: dict[str, Any],
+    ) -> ContainerSpec:
+        """Lemonade has no per-slot container — this method is unreachable
+        in production. Raises so a stray caller fails loudly instead of
+        silently building a bogus docker line.
+        """
+        raise NotImplementedError(
+            "LemonadeProvider has no container abstraction; lemond owns "
+            "process lifecycle. See ADR-0008 §1 + the module docstring."
+        )
+
+    def image_ref(self, slot_cfg: dict[str, Any]) -> str:
+        """Return a stable lemonade:// identifier for this slot.
+
+        Not a real image ref — this string lands in audit logs + the
+        slot inspector. Encodes the recipe the device maps to so two
+        slots on different devices show distinguishable identifiers.
+        """
+        cfg = _to_dict(slot_cfg)
+        device = _slot_device(cfg)
+        recipe, llamacpp_backend = device_to_backend(device)
+        if recipe:
+            return f"lemonade://recipe/{recipe}"
+        if llamacpp_backend:
+            return f"lemonade://llamacpp/{llamacpp_backend}"
+        return "lemonade://default"
+
+    def render_systemd_override(
+        self,
+        slot_name: str,
+        slot_cfg: dict[str, Any],
+        model_info: dict[str, Any],
+        *,
+        env_file_path: Any,
+        container_runtime: str = "/usr/bin/docker",
+    ) -> str:
+        """No per-slot systemd unit under Lemonade.
+
+        Reachable only via :func:`hal0.slots.unit_template.render_override`,
+        which SlotManager skips on the Lemonade-active branch. Raising
+        ensures we fail loudly if the skip is ever wired wrong.
+        """
+        raise NotImplementedError(
+            "LemonadeProvider has no per-slot systemd unit; lemond owns "
+            "process lifecycle. SlotManager must skip render_override "
+            "when HAL0_BACKEND=lemonade."
+        )
+
+    # ── lifecycle (new methods on top of the ABC) ──────────────────────────
+
+    async def load(
+        self,
+        slot_cfg: dict[str, Any] | Any,
+        model_info: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Tell Lemonade to load the slot's model.
+
+        Translates ``slot_cfg.device`` to ``(recipe, llamacpp_backend)``
+        via :func:`device_to_backend`, then calls
+        :meth:`LemonadeClient.load` with the slot's
+        ``model.default`` / ``model.context_size`` /
+        ``server.extra_args``.
+
+        Returns Lemonade's parsed JSON response body on success.
+        Propagates :class:`LemonadeLoadError` / other
+        ``LemonadeError`` subclasses unchanged — SlotManager catches
+        and re-states the slot to ERROR with the original message.
+
+        Args:
+            slot_cfg: SlotConfig pydantic model or raw dict.
+            model_info: Optional registry metadata; currently unused
+                under Lemonade (the daemon resolves models via its own
+                ``server_models.json``). Accepted for symmetry with the
+                toolbox-provider signatures.
+        """
+        cfg = _to_dict(slot_cfg)
+        model_name = _slot_model(cfg)
+        if not model_name:
+            # Mirror the SlotConfigError surface used elsewhere — bare
+            # ValueError is what SlotManager wraps into a typed error.
+            raise ValueError(
+                f"slot {cfg.get('name')!r} has no model.default set; "
+                "Lemonade /v1/load requires a model_name"
+            )
+        device = _slot_device(cfg)
+        recipe, llamacpp_backend = device_to_backend(device)
+        ctx_size = _slot_ctx(cfg)
+        llamacpp_args = _slot_extra_args(cfg)
+
+        log.info(
+            "lemonade.provider.load",
+            extra={
+                "slot": cfg.get("name"),
+                "model_name": model_name,
+                "device": device,
+                "recipe": recipe,
+                "llamacpp_backend": llamacpp_backend,
+            },
+        )
+        return await self.client().load(
+            model_name,
+            recipe=recipe,
+            ctx_size=ctx_size,
+            llamacpp_backend=llamacpp_backend,
+            llamacpp_args=llamacpp_args,
+        )
+
+    async def unload(
+        self,
+        slot_cfg: dict[str, Any] | Any,
+    ) -> dict[str, Any]:
+        """Tell Lemonade to unload the slot's model. Idempotent.
+
+        Returns Lemonade's parsed JSON response. When the slot has no
+        ``model.default`` (never been loaded), returns ``{"ok": True,
+        "noop": "no model to unload"}`` without hitting the network.
+        """
+        cfg = _to_dict(slot_cfg)
+        model_name = _slot_model(cfg)
+        if not model_name:
+            log.info(
+                "lemonade.provider.unload_noop",
+                extra={"slot": cfg.get("name")},
+            )
+            return {"ok": True, "noop": "no model to unload"}
+        log.info(
+            "lemonade.provider.unload",
+            extra={"slot": cfg.get("name"), "model_name": model_name},
+        )
+        return await self.client().unload(model_name)
+
+    async def status(
+        self,
+        slot_cfg: dict[str, Any] | Any,
+    ) -> dict[str, Any]:
+        """Derive a per-slot status snapshot from Lemonade's /v1/health.
+
+        Filters ``loaded[]`` for the slot's model_name and returns:
+
+          - ``{"loaded": True, "model_name": ..., "backend_url": ...,
+             "last_use": ..., "raw": <entry>}`` when found
+          - ``{"loaded": False, "model_name": ..., "reason": ...}``
+            when not found / no model assigned / health probe failed
+
+        Never raises — this method is on the dashboard hot path and a
+        lemond hiccup must not surface as a 500.
+        """
+        cfg = _to_dict(slot_cfg)
+        model_name = _slot_model(cfg)
+        if not model_name:
+            return {"loaded": False, "model_name": "", "reason": "no model assigned"}
+        try:
+            health = await self.client().health()
+        except Exception as exc:
+            return {
+                "loaded": False,
+                "model_name": model_name,
+                "reason": "lemonade unavailable",
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+            }
+        for key in ("loaded", "all_models_loaded"):
+            value = health.get(key) if isinstance(health, dict) else None
+            if not isinstance(value, list):
+                continue
+            for entry in value:
+                if not isinstance(entry, dict):
+                    continue
+                if entry.get("model_name") == model_name:
+                    return {
+                        "loaded": True,
+                        "model_name": model_name,
+                        "backend_url": entry.get("backend_url"),
+                        "last_use": entry.get("last_use"),
+                        "raw": entry,
+                    }
+        return {
+            "loaded": False,
+            "model_name": model_name,
+            "reason": "model not in /v1/health.loaded[]",
+        }
+
+
+__all__ = [
+    "LemonadeProvider",
+    "device_to_backend",
+    "lemonade_active",
+]

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -557,8 +557,40 @@ class SlotManager:
         )
 
     async def _is_active(self, name: str) -> bool:
+        # v0.2 (ADR-0008 §6): under Lemonade there is no per-slot systemd
+        # unit; "is-active" maps to "is the slot's model in lemond's
+        # loaded[]". Failures of the lemond probe are treated as
+        # inactive so the status() reconciler doesn't lock a slot into
+        # a stale READY when lemond is down.
+        if _lemonade_active():
+            return await self._lemonade_is_active(name)
         rc, _, _ = await self._systemctl("is-active", self._service_name(name))
         return rc == 0
+
+    async def _lemonade_is_active(self, slot_name: str) -> bool:
+        """Lemonade-mode replacement for systemctl is-active.
+
+        True when the slot's configured model appears in lemond's
+        ``/v1/health.loaded[]``. Probe errors are coerced to False so
+        ``status()``'s drift reconciler runs (re-load on next request).
+        """
+        cfg = await self._maybe_load_config(slot_name)
+        if not cfg:
+            return False
+        model_name = _model_default(cfg)
+        if not model_name:
+            return False
+        try:
+            from hal0.providers import lemonade_provider
+
+            snap = await lemonade_provider().status({"name": slot_name, **cfg})
+        except Exception as exc:
+            log.warning(
+                "slot.lemonade_is_active_probe_failed",
+                extra={"slot": slot_name, "error": str(exc)},
+            )
+            return False
+        return bool(snap.get("loaded", False))
 
     # ── lifecycle ────────────────────────────────────────────────────────────
 
@@ -865,8 +897,24 @@ class SlotManager:
         slot_cfg: SlotConfig | dict[str, Any],
         model_id: str | None,
     ) -> None:
-        """Spawn body — caller already holds the per-slot lock."""
+        """Spawn body — caller already holds the per-slot lock.
+
+        v0.2 (ADR-0008 §6): when ``HAL0_BACKEND=lemonade`` we delegate
+        to :meth:`LemonadeProvider.load` instead of rendering an
+        override.conf + running ``systemctl start``. The per-slot
+        systemd template ``hal0-slot@.service`` no longer exists (PR-9
+        retired it); the lemond daemon owns process lifecycle and
+        ``/v1/load`` is the single control-plane entry point.
+
+        Legacy (v0.1.x) toolbox path is preserved unchanged for any
+        deployment still on the per-modality container model. PR-10
+        retires that path along with the SlotManager simplification.
+        """
         model_info = await self._resolve_model_info(model_id)
+
+        if _lemonade_active():
+            await self._spawn_via_lemonade(slot_name, slot_cfg, model_id, model_info)
+            return
 
         # TIER1: atomic env write — write_slot_env() delegates to
         # write_env_atomic (tmpfile + os.replace).  haloai's
@@ -902,13 +950,75 @@ class SlotManager:
                 details={"slot": slot_name, "stderr": stderr.strip()},
             )
 
+    async def _spawn_via_lemonade(
+        self,
+        slot_name: str,
+        slot_cfg: SlotConfig | dict[str, Any],
+        model_id: str | None,
+        model_info: dict[str, Any],
+    ) -> None:
+        """Lemonade-mode spawn: POST /v1/load through LemonadeProvider.
+
+        Lemond is shared across every hal0 slot; the slot abstraction
+        survives only as identity + state. ``model_id`` (when set)
+        overrides the slot config's ``model.default`` for swap semantics
+        — :meth:`LemonadeProvider.load` resolves ``model.default`` itself,
+        so we synthesise a transient override on the cfg dict.
+
+        Any :class:`LemonadeError` subclass is wrapped as
+        :class:`SlotSpawnFailed` so the caller's ``except Exception ->
+        ERROR`` branch in :meth:`load` records a stable error envelope
+        with ``slot.spawn_failed`` semantics.
+        """
+        # Re-import locally so the module-level import order stays
+        # clean (providers/__init__.py imports from this subtree's
+        # config/registry modules).
+        from hal0.lemonade.errors import LemonadeError
+        from hal0.providers import lemonade_provider
+
+        cfg = _cfg_to_dict(slot_cfg)
+        if model_id:
+            # Honour the model override the same way the toolbox path
+            # does via ``write_slot_env(..., model_id_override=...)``.
+            existing_model = cfg.get("model")
+            base_model = existing_model if isinstance(existing_model, dict) else {}
+            cfg = {**cfg, "model": {**base_model, "default": model_id}}
+
+        try:
+            await lemonade_provider().load(cfg, model_info)
+        except LemonadeError as exc:
+            raise SlotSpawnFailed(
+                f"lemonade /v1/load for {slot_name!r} failed: {exc}",
+                details={
+                    "slot": slot_name,
+                    "model_id": model_id or _model_default(cfg),
+                    "error_type": type(exc).__name__,
+                },
+            ) from exc
+        except ValueError as exc:
+            # LemonadeProvider raises ValueError for "no model set" —
+            # surface as a typed slot error consistent with the toolbox
+            # path's missing-config behaviour.
+            raise SlotConfigError(
+                f"lemonade load for {slot_name!r} rejected: {exc}",
+                details={"slot": slot_name},
+            ) from exc
+
     async def terminate(self, slot_name: str, *, timeout_s: float = 30.0) -> None:
-        """Low-level: issue systemctl stop and wait for the unit to exit.
+        """Low-level: issue stop and wait for the slot to be unloaded.
 
         Public because the dispatcher's idle-monitor calls it directly to
         release VRAM without going through unload()'s state-machine
         ceremony.  TIER1: bubbles stderr on failure.
+
+        v0.2 (ADR-0008): under Lemonade we POST /v1/unload via
+        :meth:`LemonadeProvider.unload` instead of calling
+        ``systemctl stop``. Mirrors the spawn branch above.
         """
+        if _lemonade_active():
+            await self._terminate_via_lemonade(slot_name, timeout_s=timeout_s)
+            return
+
         rc, _, stderr = await self._systemctl("stop", self._service_name(slot_name))
         if rc != 0:
             raise SlotSpawnFailed(
@@ -925,6 +1035,53 @@ class SlotManager:
         raise SlotSpawnFailed(
             f"slot {slot_name!r} still active {timeout_s}s after systemctl stop",
             details={"slot": slot_name},
+        )
+
+    async def _terminate_via_lemonade(self, slot_name: str, *, timeout_s: float) -> None:
+        """Lemonade-mode terminate: POST /v1/unload through LemonadeProvider.
+
+        Idempotent — LemonadeProvider.unload returns a noop dict when no
+        model is assigned, and Lemonade itself treats unload of an
+        unloaded model as a no-op. We still poll ``_is_active`` to
+        match the toolbox path's "stop returns before exit" contract;
+        in practice /v1/unload is synchronous so the first check
+        succeeds.
+        """
+        from hal0.lemonade.errors import LemonadeError
+        from hal0.providers import lemonade_provider
+
+        cfg = await self._maybe_load_config(slot_name)
+        # Resilient to the slot config being missing — terminate should
+        # never fail just because someone deleted the TOML between load
+        # and unload. Synthesise an empty cfg so the provider's
+        # no-model-to-unload branch fires.
+        if cfg is None:
+            cfg = {"name": slot_name}
+
+        try:
+            await lemonade_provider().unload(cfg)
+        except LemonadeError as exc:
+            raise SlotSpawnFailed(
+                f"lemonade /v1/unload for {slot_name!r} failed: {exc}",
+                details={"slot": slot_name, "error_type": type(exc).__name__},
+            ) from exc
+
+        # Confirm with a single is-active probe before returning so the
+        # surrounding state transitions see a consistent view. We don't
+        # busy-loop the full timeout_s budget for Lemonade because the
+        # unload call is synchronous — but we keep the parameter in
+        # the signature so callers don't have to special-case backends.
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            if not await self._is_active(slot_name):
+                return
+            await asyncio.sleep(0.5)
+        # Fallthrough: log + return cleanly. Failure here would mean
+        # lemond reports the model as still loaded after /v1/unload
+        # returned 2xx — that's a lemond bug, not a slot-state issue.
+        log.warning(
+            "slot.lemonade_unload_still_active",
+            extra={"slot": slot_name, "timeout_s": timeout_s},
         )
 
     # ── slot CRUD ────────────────────────────────────────────────────────────
@@ -1393,7 +1550,17 @@ class SlotManager:
         grace window expires.  This lets dashboards distinguish
         "container running with no model" from "container failing to
         start".
+
+        v0.2 (ADR-0008 §3 + §6): under Lemonade the load is synchronous —
+        ``POST /v1/load`` blocks until the model is paged into the
+        backend (or returns a documented error). When ``_spawn_locked``
+        returned 2xx via :meth:`LemonadeProvider.load`, the model is by
+        construction ready to serve. Short-circuit to READY rather than
+        opening an HTTP probe against a slot port that doesn't host a
+        per-slot process under Lemonade.
         """
+        if _lemonade_active():
+            return await self._lemonade_await_ready(slot_name, provider)
         deadline = time.monotonic() + _HEALTH_GRACE_TOTAL_S
         # Once the upstream returns ANY structured response (even one
         # indicating no model), we know it's alive.  After ``_IDLE_STABILISE_S``
@@ -1536,6 +1703,50 @@ class SlotManager:
             f"slot {slot_name!r} did not become healthy within {_HEALTH_GRACE_TOTAL_S}s",
             details={"slot": slot_name, "last_error": last_error},
         )
+
+    async def _lemonade_await_ready(self, slot_name: str, provider: str) -> SlotState:
+        """Lemonade-mode readiness resolution.
+
+        ``_spawn_locked``'s Lemonade branch calls /v1/load which blocks
+        until lemond has the model loaded; any failure raises before we
+        get here. So the only question this method answers is "did the
+        model actually end up in lemond's loaded[]?". A confirming
+        :meth:`LemonadeProvider.status` call separates the
+        "loaded — go READY" path from the "modelless slot — go IDLE"
+        path that the toolbox provider's _await_ready handles for
+        --model "" launches.
+
+        The probe is best-effort: if lemond is briefly unreachable
+        (transient daemon hiccup) we still resolve READY because /v1/load
+        already returned 2xx. Demotion to ERROR happens via the fail
+        watcher's next tick if the model genuinely isn't loaded.
+        """
+        cfg = await self._maybe_load_config(slot_name)
+        if not cfg:
+            return SlotState.READY  # nothing more to verify
+        model_name = _model_default(cfg)
+        if not model_name:
+            return SlotState.IDLE  # modelless slot; mirrors toolbox path
+        try:
+            from hal0.providers import lemonade_provider
+
+            snap = await lemonade_provider().status({"name": slot_name, **cfg})
+        except Exception as exc:
+            log.warning(
+                "slot.lemonade_await_ready_probe_failed",
+                extra={"slot": slot_name, "error": str(exc)},
+            )
+            return SlotState.READY
+        if snap.get("loaded"):
+            return SlotState.READY
+        # Loaded == False after a successful /v1/load is unusual — the
+        # safest landing state is IDLE so the dashboard surfaces the
+        # discrepancy without erroring the slot outright.
+        log.warning(
+            "slot.lemonade_loaded_check_failed",
+            extra={"slot": slot_name, "model_name": model_name, "snapshot": snap},
+        )
+        return SlotState.IDLE
 
     # ── adoption / drift reconcile (ISSUE #30) ───────────────────────────────
 
@@ -1735,6 +1946,20 @@ def _model_default(cfg: SlotConfig | dict[str, Any]) -> str:
     if isinstance(model, dict):
         return str(model.get("default") or "")
     return ""
+
+
+def _lemonade_active() -> bool:
+    """Return True when SlotManager should dispatch through Lemonade.
+
+    Thin re-export of :func:`hal0.providers.lemonade.lemonade_active`
+    so manager-internal call sites don't have to reach into the
+    providers subtree. Re-import on each call keeps the gating
+    monkey-patchable in tests without touching this module's
+    namespace.
+    """
+    from hal0.providers.lemonade import lemonade_active
+
+    return lemonade_active()
 
 
 def _provider_health_strategy(provider: str) -> str:

--- a/tests/providers/test_lemonade.py
+++ b/tests/providers/test_lemonade.py
@@ -1,0 +1,414 @@
+"""Unit tests for ``hal0.providers.lemonade.LemonadeProvider``.
+
+PR-8 capability dispatch wiring. Covers:
+
+  * ``device_to_backend`` mapping (plan §4.1 + ADR-0008 §6)
+  * ``LemonadeProvider.load`` body construction → ``LemonadeClient.load``
+  * ``LemonadeProvider.unload`` idempotence + noop on modelless slot
+  * ``LemonadeProvider.status`` derivation from ``/v1/health.loaded[]``
+  * ``LemonadeProvider.health`` envelope shape (ok=True/False)
+  * ABC stub behaviour (``container_spec`` /
+    ``render_systemd_override`` raise; ``build_env`` /
+    ``image_ref`` / ``start_cmd`` return informational data)
+  * ``lemonade_active`` env-var gating
+
+Mocks ``LemonadeClient`` via ``httpx.MockTransport`` — same pattern as
+``tests/lemonade/test_client.py``. We exercise the full request path
+(serialisation + parsing) so a bug in either layer surfaces here too.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from typing import Any
+
+import httpx
+import pytest
+
+from hal0.lemonade.client import LemonadeClient
+from hal0.lemonade.errors import LemonadeHTTPError, LemonadeLoadError
+from hal0.providers.lemonade import (
+    LemonadeProvider,
+    device_to_backend,
+    lemonade_active,
+)
+
+
+def _mock_client(handler) -> LemonadeClient:
+    """Build a LemonadeClient backed by an httpx MockTransport."""
+    transport = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://test",
+    )
+    return LemonadeClient(http_client=transport)
+
+
+def _slot_cfg(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "primary",
+        "port": 8081,
+        "device": "gpu-rocm",
+        "provider": "lemonade",
+        "model": {"default": "hermes-4-14b", "context_size": 8192},
+    }
+    base.update(overrides)
+    return base
+
+
+# ── device_to_backend ────────────────────────────────────────────────
+
+
+def test_device_to_backend_rocm() -> None:
+    assert device_to_backend("gpu-rocm") == (None, "rocm")
+
+
+def test_device_to_backend_vulkan() -> None:
+    assert device_to_backend("gpu-vulkan") == (None, "vulkan")
+
+
+def test_device_to_backend_cpu() -> None:
+    assert device_to_backend("cpu") == (None, "cpu")
+
+
+def test_device_to_backend_npu() -> None:
+    # NPU uses the FLM recipe; no llamacpp_backend.
+    assert device_to_backend("npu") == ("flm", None)
+
+
+def test_device_to_backend_empty_returns_double_none() -> None:
+    assert device_to_backend("") == (None, None)
+    assert device_to_backend(None) == (None, None)
+
+
+def test_device_to_backend_unknown_falls_back_to_double_none() -> None:
+    # Unknown devices return ``(None, None)`` so Lemonade picks its
+    # defaults rather than us trying to invent a backend tag.
+    assert device_to_backend("rocm-xtreme-edition") == (None, None)
+
+
+def test_device_to_backend_is_case_insensitive() -> None:
+    assert device_to_backend("GPU-ROCM") == (None, "rocm")
+    assert device_to_backend("  npu  ") == ("flm", None)
+
+
+# ── lemonade_active ──────────────────────────────────────────────────
+
+
+def test_lemonade_active_true_when_env_matches(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_BACKEND", "lemonade")
+    assert lemonade_active() is True
+
+
+def test_lemonade_active_false_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HAL0_BACKEND", raising=False)
+    assert lemonade_active() is False
+
+
+def test_lemonade_active_tolerates_whitespace_and_case(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HAL0_BACKEND", "  Lemonade ")
+    assert lemonade_active() is True
+
+
+# ── load() — request body construction ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_load_posts_model_name_with_rocm_backend() -> None:
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        assert req.method == "POST"
+        assert req.url.path == "/v1/load"
+        captured["body"] = _json.loads(req.content.decode())
+        return httpx.Response(200, json={"status": "loaded"})
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    result = await provider.load(_slot_cfg(device="gpu-rocm"))
+    assert result == {"status": "loaded"}
+    assert captured["body"] == {
+        "model_name": "hermes-4-14b",
+        "ctx_size": 8192,
+        "llamacpp_backend": "rocm",
+    }
+
+
+@pytest.mark.asyncio
+async def test_load_uses_flm_recipe_for_npu_and_omits_llamacpp_backend() -> None:
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        captured["body"] = _json.loads(req.content.decode())
+        return httpx.Response(200, json={"status": "loaded"})
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    await provider.load(
+        _slot_cfg(
+            device="npu",
+            model={"default": "gemma3:1b", "context_size": 4096},
+        )
+    )
+    # NPU → recipe="flm", no llamacpp_backend in body.
+    assert captured["body"]["recipe"] == "flm"
+    assert "llamacpp_backend" not in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_load_omits_ctx_size_when_unset() -> None:
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        captured["body"] = _json.loads(req.content.decode())
+        return httpx.Response(200, json={"status": "loaded"})
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    await provider.load(_slot_cfg(model={"default": "hermes-4-14b"}))
+    assert "ctx_size" not in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_load_serialises_server_extra_args_as_string() -> None:
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        captured["body"] = _json.loads(req.content.decode())
+        return httpx.Response(200, json={"status": "loaded"})
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    cfg = _slot_cfg(server={"extra_args": "--parallel 1 --threads 8"})
+    await provider.load(cfg)
+    # Wire format is a single space-separated string (memory
+    # ``hal0_lemonade_v1_load_schema`` — nlohmann::json raises on lists).
+    assert captured["body"]["llamacpp_args"] == "--parallel 1 --threads 8"
+
+
+@pytest.mark.asyncio
+async def test_load_raises_value_error_when_no_model_default() -> None:
+    def h(_: httpx.Request) -> httpx.Response:  # pragma: no cover — not hit
+        raise AssertionError("client.load should never be called")
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    with pytest.raises(ValueError) as exc:
+        await provider.load(_slot_cfg(model={"default": ""}))
+    assert "model_name" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_load_propagates_lemonade_load_error() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"detail": "evict-all triggered"})
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    with pytest.raises(LemonadeLoadError) as exc:
+        await provider.load(_slot_cfg())
+    assert exc.value.status_code == 500
+
+
+# ── unload() ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unload_posts_model_name_to_v1_unload() -> None:
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        assert req.url.path == "/v1/unload"
+        captured["body"] = _json.loads(req.content.decode())
+        return httpx.Response(200, json={"status": "unloaded"})
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    result = await provider.unload(_slot_cfg())
+    assert result == {"status": "unloaded"}
+    assert captured["body"] == {"model_name": "hermes-4-14b"}
+
+
+@pytest.mark.asyncio
+async def test_unload_is_noop_when_no_model_default() -> None:
+    def h(_: httpx.Request) -> httpx.Response:  # pragma: no cover — not hit
+        raise AssertionError("client.unload should never be called")
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    result = await provider.unload(_slot_cfg(model={"default": ""}))
+    assert result == {"ok": True, "noop": "no model to unload"}
+
+
+# ── status() ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_status_returns_loaded_true_when_model_in_health_loaded_list() -> None:
+    def h(req: httpx.Request) -> httpx.Response:
+        assert req.url.path == "/v1/health"
+        return httpx.Response(
+            200,
+            json={
+                "loaded": [
+                    {
+                        "model_name": "hermes-4-14b",
+                        "backend_url": "http://127.0.0.1:14000",
+                        "last_use": 1715000000.0,
+                    },
+                    {"model_name": "other-model", "backend_url": "http://127.0.0.1:14001"},
+                ]
+            },
+        )
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    snap = await provider.status(_slot_cfg())
+    assert snap["loaded"] is True
+    assert snap["model_name"] == "hermes-4-14b"
+    assert snap["backend_url"] == "http://127.0.0.1:14000"
+    assert snap["last_use"] == 1715000000.0
+
+
+@pytest.mark.asyncio
+async def test_status_accepts_all_models_loaded_field_name() -> None:
+    """Lemonade has used two field names across versions; accept both."""
+
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "all_models_loaded": [
+                    {"model_name": "hermes-4-14b", "backend_url": "http://127.0.0.1:14000"}
+                ]
+            },
+        )
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    snap = await provider.status(_slot_cfg())
+    assert snap["loaded"] is True
+
+
+@pytest.mark.asyncio
+async def test_status_returns_loaded_false_when_model_missing() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"loaded": []})
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    snap = await provider.status(_slot_cfg())
+    assert snap["loaded"] is False
+    assert snap["reason"] == "model not in /v1/health.loaded[]"
+
+
+@pytest.mark.asyncio
+async def test_status_returns_loaded_false_when_no_model_assigned() -> None:
+    def h(_: httpx.Request) -> httpx.Response:  # pragma: no cover — not hit
+        raise AssertionError("client.health should never be called")
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    snap = await provider.status(_slot_cfg(model={"default": ""}))
+    assert snap["loaded"] is False
+    assert snap["reason"] == "no model assigned"
+
+
+@pytest.mark.asyncio
+async def test_status_never_raises_on_lemond_unavailable() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    snap = await provider.status(_slot_cfg())
+    # Must not raise — dashboard hot path.
+    assert snap["loaded"] is False
+    assert snap["reason"] == "lemonade unavailable"
+    assert "error" in snap
+
+
+# ── health() (Provider ABC implementation) ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_returns_ok_true_on_2xx() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"ready": True})
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    result = await provider.health(port=8081)
+    assert result["ok"] is True
+    assert result["health"] == {"ready": True}
+
+
+@pytest.mark.asyncio
+async def test_health_returns_ok_false_on_http_error() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"detail": "down"})
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    result = await provider.health(port=8081)
+    assert result["ok"] is False
+    assert result["status"] == "unavailable"
+    assert result["error_type"] == LemonadeHTTPError.__name__
+
+
+# ── ABC stubs (docker / systemd shape) ───────────────────────────────
+
+
+def test_build_env_returns_informational_block() -> None:
+    provider = LemonadeProvider(client=_mock_client(lambda _: httpx.Response(200)))
+    env = provider.build_env(_slot_cfg(), {"path": "/var/lib/hal0/models/x.gguf"})
+    assert env["HAL0_PROVIDER"] == "lemonade"
+    assert env["HAL0_DEVICE"] == "gpu-rocm"
+    assert env["HAL0_LEMONADE_LLAMACPP_BACKEND"] == "rocm"
+    assert env["HAL0_MODEL_PATH"] == "/var/lib/hal0/models/x.gguf"
+
+
+def test_image_ref_encodes_recipe_for_npu() -> None:
+    provider = LemonadeProvider(client=_mock_client(lambda _: httpx.Response(200)))
+    assert provider.image_ref(_slot_cfg(device="npu")) == "lemonade://recipe/flm"
+
+
+def test_image_ref_encodes_llamacpp_backend_for_gpu() -> None:
+    provider = LemonadeProvider(client=_mock_client(lambda _: httpx.Response(200)))
+    assert provider.image_ref(_slot_cfg(device="gpu-vulkan")) == "lemonade://llamacpp/vulkan"
+
+
+def test_container_spec_raises() -> None:
+    """No per-slot container under Lemonade — caller fails loudly."""
+    provider = LemonadeProvider(client=_mock_client(lambda _: httpx.Response(200)))
+    with pytest.raises(NotImplementedError):
+        provider.container_spec(_slot_cfg(), {})
+
+
+def test_render_systemd_override_raises() -> None:
+    """No per-slot systemd unit under Lemonade."""
+    provider = LemonadeProvider(client=_mock_client(lambda _: httpx.Response(200)))
+    with pytest.raises(NotImplementedError):
+        provider.render_systemd_override(
+            "primary",
+            _slot_cfg(),
+            {},
+            env_file_path="/tmp/env",
+        )
+
+
+@pytest.mark.asyncio
+async def test_infer_raises_not_implemented() -> None:
+    provider = LemonadeProvider(client=_mock_client(lambda _: httpx.Response(200)))
+    with pytest.raises(NotImplementedError):
+        await provider.infer(port=8081, body={})
+
+
+# ── provider registry integration ────────────────────────────────────
+
+
+def test_get_provider_returns_lemonade_singleton() -> None:
+    from hal0.providers import get_provider, lemonade_provider
+
+    a = get_provider("lemonade")
+    b = lemonade_provider()
+    assert a is b
+    assert isinstance(a, LemonadeProvider)
+
+
+def test_legacy_providers_still_registered() -> None:
+    """Anti-scope: PR-8 must NOT remove the v0.1.x provider singletons.
+    PR-10 owns their retirement.
+    """
+    from hal0.providers import get_provider
+
+    for name in ("llama-server", "flm", "moonshine", "kokoro", "comfyui"):
+        provider = get_provider(name)
+        assert provider is not None
+        assert provider.__class__.__name__.lower().startswith(name.split("-")[0].lower())

--- a/tests/slots/test_manager_lemonade_bridge.py
+++ b/tests/slots/test_manager_lemonade_bridge.py
@@ -1,0 +1,221 @@
+"""SlotManager → LemonadeProvider bridge tests (PR-8).
+
+Validates that when ``HAL0_BACKEND=lemonade`` is in effect, the slot
+lifecycle methods on :class:`SlotManager` route through
+:class:`LemonadeProvider` instead of writing override.conf +
+systemctl-driving a per-slot toolbox container.
+
+Caller-surface guarantee: the public method signatures on SlotManager
+must NOT change in PR-8 (PR-10 owns those). These tests exercise the
+same method names + arg shapes as the v0.1.x toolbox path — only the
+backend changes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from hal0.lemonade.client import LemonadeClient
+from hal0.providers.lemonade import LemonadeProvider
+from hal0.slots.manager import SlotManager
+from hal0.slots.state import SlotSpawnFailed, SlotState
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _mock_provider(handler) -> LemonadeProvider:
+    """Build a LemonadeProvider with an httpx-mocked client."""
+    transport = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://test",
+    )
+    return LemonadeProvider(client=LemonadeClient(http_client=transport))
+
+
+@pytest.fixture
+def lemonade_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Activate the Lemonade-dispatch branch of SlotManager."""
+    monkeypatch.setenv("HAL0_BACKEND", "lemonade")
+
+
+@pytest.fixture
+def stub_provider_in_registry(monkeypatch: pytest.MonkeyPatch):
+    """Replace the singleton ``LemonadeProvider`` with a mock-backed one.
+
+    Returns a factory: tests pass the handler they want to drive
+    Lemonade's HTTP responses with. The factory installs the mock
+    provider into ``hal0.providers._PROVIDERS`` so SlotManager's
+    ``lemonade_provider()`` lookup finds it.
+    """
+    import hal0.providers as providers_mod
+
+    original = providers_mod._PROVIDERS["lemonade"]
+
+    def _install(handler) -> LemonadeProvider:
+        provider = _mock_provider(handler)
+        providers_mod._PROVIDERS["lemonade"] = provider
+        return provider
+
+    yield _install
+
+    # Restore so subsequent tests get the real singleton back.
+    providers_mod._PROVIDERS["lemonade"] = original
+
+
+# ── spawn (load) bridge ──────────────────────────────────────────────
+
+
+async def test_load_dispatches_via_lemonade_v1_load(
+    slot_root: Path,
+    lemonade_env: None,
+    stub_provider_in_registry,
+) -> None:
+    """SlotManager.load should POST /v1/load with the slot's model + device."""
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/load":
+            import json as _json
+
+            captured["body"] = _json.loads(req.content.decode())
+            return httpx.Response(200, json={"status": "loaded"})
+        if req.url.path == "/v1/health":
+            return httpx.Response(
+                200,
+                json={"loaded": [{"model_name": "qwen3-4b-q4_k_m"}]},
+            )
+        return httpx.Response(404)
+
+    stub_provider_in_registry(h)
+
+    mgr = SlotManager()
+    snap = await mgr.load("primary")
+    assert snap.state == SlotState.READY
+    # The slot_root fixture writes ``backend = "vulkan"`` → device =
+    # gpu-vulkan via the SlotConfig promotion.
+    assert captured["body"]["model_name"] == "qwen3-4b-q4_k_m"
+    assert captured["body"]["llamacpp_backend"] == "vulkan"
+
+
+async def test_load_propagates_lemonade_load_error_as_slot_error(
+    slot_root: Path,
+    lemonade_env: None,
+    stub_provider_in_registry,
+) -> None:
+    """A 5xx from /v1/load should land the slot in ERROR via SlotSpawnFailed."""
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/load":
+            return httpx.Response(500, json={"detail": "evict-all triggered"})
+        return httpx.Response(200, json={"loaded": []})
+
+    stub_provider_in_registry(h)
+
+    mgr = SlotManager()
+    with pytest.raises(SlotSpawnFailed):
+        await mgr.load("primary")
+    snap = await mgr.status("primary")
+    assert snap.state == SlotState.ERROR
+
+
+async def test_unload_dispatches_via_lemonade_v1_unload(
+    slot_root: Path,
+    lemonade_env: None,
+    stub_provider_in_registry,
+) -> None:
+    """SlotManager.unload should POST /v1/unload via the provider."""
+    unload_calls: list[dict[str, Any]] = []
+    # Mutable state so the same handler advertises "loaded" then "empty"
+    # after the unload landing.
+    loaded_state = {"models": [{"model_name": "qwen3-4b-q4_k_m"}]}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/load":
+            return httpx.Response(200, json={"status": "loaded"})
+        if req.url.path == "/v1/unload":
+            import json as _json
+
+            unload_calls.append(_json.loads(req.content.decode()))
+            loaded_state["models"] = []
+            return httpx.Response(200, json={"status": "unloaded"})
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json={"loaded": loaded_state["models"]})
+        return httpx.Response(404)
+
+    stub_provider_in_registry(h)
+
+    mgr = SlotManager()
+    await mgr.load("primary")
+    snap = await mgr.unload("primary")
+    assert snap.state == SlotState.OFFLINE
+    assert unload_calls == [{"model_name": "qwen3-4b-q4_k_m"}]
+
+
+async def test_swap_under_lemonade_loads_new_model_name(
+    slot_root: Path,
+    lemonade_env: None,
+    stub_provider_in_registry,
+) -> None:
+    """SlotManager.swap should unload then load with the override model."""
+    captured_loads: list[dict[str, Any]] = []
+    loaded_state = {"models": [{"model_name": "qwen3-4b-q4_k_m"}]}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        import json as _json
+
+        if req.url.path == "/v1/load":
+            body = _json.loads(req.content.decode())
+            captured_loads.append(body)
+            loaded_state["models"] = [{"model_name": body["model_name"]}]
+            return httpx.Response(200, json={"status": "loaded"})
+        if req.url.path == "/v1/unload":
+            loaded_state["models"] = []
+            return httpx.Response(200, json={"status": "unloaded"})
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json={"loaded": loaded_state["models"]})
+        return httpx.Response(404)
+
+    stub_provider_in_registry(h)
+
+    mgr = SlotManager()
+    await mgr.load("primary")
+    await mgr.swap("primary", "hermes-2-pro-llama-3-8b")
+    # Two /v1/load calls: initial + swap override.
+    assert len(captured_loads) == 2
+    assert captured_loads[-1]["model_name"] == "hermes-2-pro-llama-3-8b"
+
+
+# ── status() reconcile under Lemonade ────────────────────────────────
+
+
+async def test_is_active_resolves_via_health_loaded_list(
+    slot_root: Path,
+    lemonade_env: None,
+    stub_provider_in_registry,
+) -> None:
+    """_is_active reads /v1/health.loaded[] under Lemonade.
+
+    Drives the status() reconciler: a slot whose model appears in
+    /v1/health is treated as active, regardless of systemctl.
+    """
+    loaded_state = {"models": [{"model_name": "qwen3-4b-q4_k_m"}]}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json={"loaded": loaded_state["models"]})
+        if req.url.path == "/v1/load":
+            return httpx.Response(200, json={"status": "loaded"})
+        return httpx.Response(404)
+
+    stub_provider_in_registry(h)
+    mgr = SlotManager()
+
+    # Active branch
+    assert await mgr._is_active("primary") is True
+    # Inactive branch
+    loaded_state["models"] = []
+    assert await mgr._is_active("primary") is False


### PR DESCRIPTION
## Summary

PR-8 of the v0.2 Lemonade migration: wire hal0's capability layer to Lemonade Server end-to-end (chat.primary, embed, rerank, stt, tts, img) without breaking any existing caller of SlotManager. This is the facade landing — `SlotManager`'s v0.1.x method signatures stay STABLE so the seven+ caller files outside `src/hal0/slots/` keep working untouched. PR-10 (later) will simplify the SlotManager surface and migrate callers.

Re-sequenced ahead of PR-10 per the locked plan: PR-10's brief originally rewrote SlotManager, which would break 7+ callers. PR-8 lands first to ship the Lemonade dispatch path under stable signatures.

Tracks plan §11 PR-8 and ADR-0008 §1 / §2 / §6.

## LemonadeProvider design

The existing `hal0.providers.base.Provider` ABC is shaped around docker+systemd: `build_env`, `start_cmd`, `container_spec`, `image_ref`, `render_systemd_override`. None of those abstractions map to a daemon-backed runtime where `lemond` owns process lifecycle and there is no per-slot container to render. `LemonadeProvider` implements the ABC to satisfy the contract, but the docker/systemd-shaped methods are operationally vestigial:

- `build_env` returns a slot-identity env block (`HAL0_SLOT_NAME`, `HAL0_PORT`, `HAL0_DEVICE`, `HAL0_PROVIDER=lemonade`, `HAL0_LEMONADE_RECIPE`, …) — useful for diagnostics, audit logs, and \`hal0 slot inspect\`, never written to a file.
- `start_cmd` returns the conceptual control-plane invocation (`/opt/lemonade/lemond /var/lib/hal0/lemonade --slot-name=…`) so anyone tracing a slot back to its process can find the responsible unit.
- `image_ref` returns a stable `lemonade://recipe/<recipe>` or `lemonade://llamacpp/<backend>` identifier so audit logs and the slot inspector can distinguish two slots on different devices.
- `container_spec` and `render_systemd_override` raise `NotImplementedError` with pointers to the module docstring. These methods are only reached via `hal0.slots.unit_template.render_override`, which SlotManager skips on the Lemonade-active branch — so the raising stubs are unreachable in production code but the ABC still has them defined.

On top of the ABC, three new lifecycle methods do the real work:

- `LemonadeProvider.load(slot_cfg, model_info=None)` translates `slot_cfg.device` to `(recipe, llamacpp_backend)` via `device_to_backend`, pulls `model.default` / `model.context_size` / `server.extra_args` off the slot config, and calls `LemonadeClient.load(...)`. Returns the parsed body. Propagates `LemonadeLoadError` / other `LemonadeError` subclasses unchanged.
- `LemonadeProvider.unload(slot_cfg)` calls `LemonadeClient.unload(model.default)`. When the slot has no model assigned, returns `{ok: True, noop: "no model to unload"}` without hitting the network.
- `LemonadeProvider.status(slot_cfg)` filters `LemonadeClient.health().loaded[]` (also accepts `all_models_loaded[]` — Lemonade has used both field names across versions) for the slot's model. Never raises — this method is on the dashboard hot path.

The `device_to_backend` mapping is locked per plan §4.1 + ADR-0008 §6:

| device | recipe | llamacpp_backend |
|---|---|---|
| `gpu-rocm` | None | `rocm` |
| `gpu-vulkan` | None | `vulkan` |
| `cpu` | None | `cpu` |
| `npu` | `flm` | None |
| unknown / empty | None | None |

\"None\" causes the corresponding key to be omitted from the `/v1/load` body so Lemonade picks its own defaults.

## Bridging strategy

The bridge between `SlotManager`'s public surface and `LemonadeProvider` lives entirely inside `SlotManager` private methods. No public signatures change.

Gating: `_lemonade_active()` reads `HAL0_BACKEND` (same env var that gates the existing idle-unload driver in `api/__init__.py`). When set to `lemonade`, four private methods route through Lemonade:

- `_spawn_locked` skips the toolbox path (`write_slot_env` + `render_override` + `systemctl start hal0-slot@…`) and calls `LemonadeProvider.load`. Critically: `hal0-slot@.service` no longer exists post-PR-9, so the legacy path can't run on a real v0.2 install regardless — but the existing test suite mocks `_systemctl` and would keep passing either way. This gate makes the runtime correct, not just the tests.
- `terminate` skips `systemctl stop` and calls `LemonadeProvider.unload`. Lemonade's `/v1/unload` is synchronous; we keep the `timeout_s` poll loop intact for signature compatibility but it normally exits immediately.
- `_await_ready` short-circuits — `LemonadeClient.load` blocks until the model is paged in, so if `_spawn_locked` returned cleanly the slot is by construction ready. A confirming `LemonadeProvider.status` probe separates the rare "loaded but missing from /v1/health" case (lands in IDLE) from the normal "loaded" case (lands in READY), matching the toolbox provider's --model "" handling for symmetry.
- `_is_active` reads `LemonadeClient.health().loaded[]` instead of `systemctl is-active`. Drives the status() drift reconciler correctly under Lemonade.

Errors are wrapped: `LemonadeError` subclasses raised by `LemonadeProvider.load` are caught in a new `_spawn_via_lemonade` helper and re-raised as `SlotSpawnFailed`, so `SlotManager.load`'s existing `except Exception → ERROR` branch keeps producing stable `slot.spawn_failed` error envelopes. The toolbox path is unchanged.

## Caller surface preserved

All v0.1.x SlotManager methods keep their signatures + return shapes (mapped by PR-10's stopped agent — not re-derived):

- `src/hal0/api/__init__.py` → `iter_configs` / `start_idle_monitor` / `stop_idle_monitor`
- `src/hal0/api/routes/slots.py` → `list` / `create` / `status` / `delete` / `get_config` / `update_config` / `load` / `unload` / `restart` / `swap` / `state_stream`
- `src/hal0/api/routes/backends.py` → `status` / `list` / `create` / `load` / `unload` / `delete`
- `src/hal0/api/routes/models.py` → `status` / `unload`
- `src/hal0/api/routes/hardware.py` → `list`
- `src/hal0/api/routes/health.py` → `list`
- `src/hal0/dispatcher/router.py:539` → `serving()` context manager
- `src/hal0/capabilities/orchestrator.py` → `status` / `load` / `unload` / `swap` / `create` / `update_config`

None of these required source changes. Verified by running the full test suite (1479 baseline → 1517 with new tests; 0 regressions).

## Anti-scope respected

- DID NOT change SlotManager public signatures (PR-10).
- DID NOT add `SEEDED_SLOTS` / `route_for_request` / `default_slot_for` / `add_slot` / `remove_slot` (PR-10).
- DID NOT rewire `src/hal0/api/routes/*.py`.
- DID NOT delete `src/hal0/providers/{llama_server,flm,moonshine,kokoro,comfyui}.py` — they survive as registered singletons until PR-10.
- DID NOT introduce `extra.*` namespace usage (ADR-0008 §7).
- DID NOT reintroduce preload validation (ADR-0008 §3, removed in #155).

## Files touched

| File | Rationale |
|---|---|
| `src/hal0/providers/lemonade.py` (new, 539 lines) | LemonadeProvider class + device_to_backend + lemonade_active helper. |
| `src/hal0/providers/__init__.py` (+25 lines) | Register \"lemonade\" in _PROVIDERS, add typed `lemonade_provider()` helper. |
| `src/hal0/slots/manager.py` (+227 / -2) | Gate `_spawn_locked` / `terminate` / `_await_ready` / `_is_active` on `_lemonade_active()`; add `_spawn_via_lemonade` / `_terminate_via_lemonade` / `_lemonade_await_ready` / `_lemonade_is_active` helpers. |
| `tests/providers/test_lemonade.py` (new, 414 lines, 33 tests) | Unit coverage for LemonadeProvider + device mapping + active-env gating. |
| `tests/slots/test_manager_lemonade_bridge.py` (new, 221 lines, 5 tests) | Integration coverage for SlotManager → LemonadeProvider dispatch. |

LOC delta: +1428 / -2.

## Test plan

- [x] Full suite passes: 1517 passed, 8 skipped (1479 baseline + 33 lemonade + 5 bridge)
- [x] No existing test required modification
- [x] `ruff check src tests` clean
- [x] `ruff format --check src tests` clean
- [ ] CI green (will populate after push)
- [ ] Manual smoke on hal0 LXC under `HAL0_BACKEND=lemonade` — out of scope for PR-8; PR-11 (dashboard wiring) is the first PR that requires a live lemond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)