### PR TITLE
feat(dashboard): slot state from /v1/health + NPU exclusivity + nuclear-evict banner (PR-11)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -58,6 +58,9 @@ from hal0.api.routes import (
     v1,
 )
 from hal0.api.routes import (
+    lemonade_logs as lemonade_logs_routes,
+)
+from hal0.api.routes import (
     proxmox as proxmox_routes,
 )
 from hal0.capabilities.orchestrator import CapabilityOrchestrator
@@ -574,6 +577,16 @@ def create_app() -> FastAPI:
     )
     app.include_router(hardware.router, prefix="/api", tags=["hardware"], dependencies=_admin_auth)
     app.include_router(logs.router, prefix="/api/logs", tags=["logs"], dependencies=_admin_auth)
+    # PR-11: Lemonade log proxy — surfaces the /logs/stream WS as SSE
+    # streams the dashboard consumes for the journal panel (PR-14) and
+    # the nuclear-evict toast banner. Same admin auth as the rest of
+    # the slot surface.
+    app.include_router(
+        lemonade_logs_routes.router,
+        prefix="/api/lemonade",
+        tags=["lemonade", "logs"],
+        dependencies=_admin_auth,
+    )
     app.include_router(
         settings.router,
         prefix="/api/settings",

--- a/src/hal0/api/routes/lemonade_logs.py
+++ b/src/hal0/api/routes/lemonade_logs.py
@@ -1,0 +1,183 @@
+"""Lemonade log proxy endpoints (mounted under /api/lemonade).
+
+PR-11 (plan §11 + ADR-0008 §3): proxies the Lemonade ``/logs/stream``
+WebSocket to a hal0-api SSE endpoint the dashboard subscribes to. Two
+streams are surfaced:
+
+- ``GET /api/lemonade/logs/stream`` — every parsed log entry from
+  lemond, forwarded as JSON SSE frames. Consumed by PR-14's journal
+  panel (out of scope here; this endpoint just exposes the surface).
+
+- ``GET /api/lemonade/events/stream`` — structured event stream
+  emitted from filtered log lines. The first event surface is
+  ``nuclear_evict``: when lemond emits the trigger line
+  (per :data:`hal0.api.routes.slots.NUCLEAR_EVICT_TRIGGER`), the
+  dashboard's banner subscriber sees a JSON payload it can render as
+  a transient toast.
+
+Both streams degrade gracefully when lemond is down — clients receive
+no events and reconnect on their own cadence. No keep-alive frames are
+sent; the underlying ``LemonadeClient.stream_logs`` iterator simply
+yields nothing when the daemon is unreachable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import time
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import StreamingResponse
+
+# Reuse the trigger constant from slots.py so the contract stays in one
+# place. A future filter (e.g. evict-warning, pull-progress) joins this
+# same module without dragging slots.py in.
+from hal0.api.routes.slots import NUCLEAR_EVICT_TRIGGER
+
+router = APIRouter()
+
+
+def _extract_message(entry: dict[str, Any]) -> str:
+    """Pick the human-readable log line out of a lemond log frame.
+
+    lemond's protocol (per the ``hal0_lemonade_ws_protocol`` memory):
+
+      ``{"op": "logs.entry", "entry": {"message": "...", "level": ...}}``
+      ``{"op": "logs.snapshot", "entries": [{...}, ...]}``
+
+    Both forms route through this helper after the SSE proxy splits
+    snapshot batches into individual entries.
+    """
+    msg = entry.get("message")
+    if isinstance(msg, str):
+        return msg
+    # Some lemond builds nest the line under "text" or "msg"; tolerate
+    # any of them so a protocol shift doesn't silently swallow the
+    # nuclear-evict trigger.
+    for alt in ("text", "msg", "line"):
+        v = entry.get(alt)
+        if isinstance(v, str):
+            return v
+    return ""
+
+
+def _iter_entries(frame: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten a lemond log frame into individual entry dicts.
+
+    ``logs.snapshot`` carries a list under ``entries``; ``logs.entry``
+    carries a single dict under ``entry``. Returns the entries verbatim
+    so callers preserve any provider-specific metadata (level, ts).
+    """
+    op = frame.get("op")
+    if op == "logs.snapshot":
+        entries = frame.get("entries")
+        if isinstance(entries, list):
+            return [e for e in entries if isinstance(e, dict)]
+        return []
+    if op == "logs.entry":
+        entry = frame.get("entry")
+        if isinstance(entry, dict):
+            return [entry]
+        return []
+    # Unknown ops are surfaced as-is so a protocol bump doesn't drop
+    # entries on the floor — the consumer can still inspect ``raw``.
+    return [frame]
+
+
+async def _lemonade_log_entries(request: Request) -> Any:
+    """Async iterator yielding flattened log entries from lemond.
+
+    Wraps ``LemonadeClient.stream_logs`` and re-shapes batched
+    snapshot frames into per-entry yields. Stops when the WebSocket
+    closes; the caller (the SSE proxy) returns an empty event stream
+    in that case.
+    """
+    from hal0.providers import lemonade_provider
+
+    client = lemonade_provider().client()
+    async for frame in client.stream_logs():
+        for entry in _iter_entries(frame):
+            yield entry
+
+
+@router.get("/logs/stream")
+async def lemonade_logs_stream(request: Request) -> StreamingResponse:
+    """SSE proxy of lemond's ``/logs/stream`` WebSocket.
+
+    Each parsed log entry is re-emitted as a ``data: <json>`` SSE
+    frame. Consumed by PR-14's journal panel (out of scope here). The
+    JSON shape is whatever lemond emits — typically
+    ``{"message": "...", "level": "info", "ts": "..."}``.
+    """
+
+    async def event_source() -> Any:
+        try:
+            async for entry in _lemonade_log_entries(request):
+                yield f"data: {json.dumps(entry)}\n\n"
+        except asyncio.CancelledError:
+            raise
+
+    return StreamingResponse(
+        event_source(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.get("/events/stream")
+async def lemonade_events_stream(request: Request) -> StreamingResponse:
+    """SSE stream of structured events derived from lemond logs.
+
+    Right now the only event surface is ``nuclear_evict`` — when a
+    lemond log entry contains :data:`NUCLEAR_EVICT_TRIGGER`, a frame
+    is emitted::
+
+        event: nuclear_evict
+        data: {"type": "nuclear_evict", "message": "...", "ts": "..."}
+
+    The dashboard subscribes to this stream and renders a toast banner
+    on each frame. Other event types (eviction warnings, pull
+    failures) attach here in later PRs.
+
+    Per ADR-0008 §3 nuclear-evict is rare-but-visible — surfacing it
+    inline rather than burying in the journal panel matters more than
+    the bytes saved by combining the two streams.
+    """
+
+    async def event_source() -> Any:
+        with contextlib.suppress(asyncio.CancelledError):
+            async for entry in _lemonade_log_entries(request):
+                msg = _extract_message(entry)
+                if not msg:
+                    continue
+                if NUCLEAR_EVICT_TRIGGER not in msg:
+                    continue
+                payload = {
+                    "type": "nuclear_evict",
+                    "message": msg,
+                    "ts": entry.get("ts") or time.time(),
+                }
+                yield f"event: nuclear_evict\ndata: {json.dumps(payload)}\n\n"
+
+    return StreamingResponse(
+        event_source(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+__all__ = [
+    "NUCLEAR_EVICT_TRIGGER",
+    "_extract_message",
+    "_iter_entries",
+    "router",
+]

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -12,6 +12,15 @@ stream is split by concern):
   for one slot (``starting → warming → ready → serving → idle …``).
 - ``GET /api/slots/{name}/logs/stream`` — line-by-line journal tail
   for the slot's systemd unit.
+
+PR-11 (plan §11 + ADR-0008 §5): list responses are enriched with
+Lemonade-derived state — each entry carries ``lemonade_state``
+(``loaded`` | ``idle`` | ``disabled`` | ``error``), an optional
+``backend_url`` lifted from ``/v1/health.loaded[]``, and a
+``coresident_group`` ID grouping slots that back the same FLM process
+(the NPU trio: ``agent`` + ``stt-npu`` + ``embed-npu``). This is
+backward-compatible — every legacy field is preserved; new keys are
+purely additive.
 """
 
 from __future__ import annotations
@@ -96,6 +105,122 @@ def _slot_to_dict(slot: Slot, request: Request | None = None) -> dict[str, Any]:
     return base
 
 
+#: Slot names that form the NPU FLM trio — chat (agent) + ASR (stt-npu)
+#: + embed (embed-npu) coresident in one FLM process (ADR-0008 §5,
+#: ADR-0009, plan §5.2). All three back the same FLM child process when
+#: the NPU LLM slot is loaded with ``--asr 1 --embed 1``. The dashboard
+#: surfaces them with a shared ``coresident_group`` so the UI can render
+#: them as a trio rather than three independent slots.
+_FLM_TRIO_SLOTS: frozenset[str] = frozenset({"agent", "stt-npu", "embed-npu"})
+
+#: Trigger substring for the nuclear-evict log line. lemond emits this
+#: on the lone ``/v1/load`` path where the error isn't a "not found"
+#: variant — the evict-all blast radius fires. Per ADR-0008 §3 we
+#: surface this verbatim to operators via the dashboard banner.
+NUCLEAR_EVICT_TRIGGER: str = (
+    "Load failed with non-file-not-found error, evicting all models and retrying"
+)
+
+
+async def _lemonade_state_enrichment(request: Request) -> dict[str, dict[str, Any]]:
+    """Build per-slot Lemonade-derived state for list_slots.
+
+    Calls ``/v1/health`` once, then walks the slot configs to build a
+    ``{slot_name: {lemonade_state, backend_url?, coresident_group?}}``
+    map. Never raises — a down lemond returns an empty enrichment so
+    the dashboard degrades to the on-disk view rather than 500ing.
+
+    Coresident grouping (ADR-0008 §5, plan §5.2):
+      A slot of type=llm + device=npu serving as the chat anchor and
+      any sibling ``stt-npu`` / ``embed-npu`` slots that are enabled
+      share a ``coresident_group=npu-flm-trio`` marker. The dashboard
+      uses this to render a "trio" badge linking the three cards.
+    """
+    sm = getattr(request.app.state, "slot_manager", None)
+    if sm is None:
+        return {}
+    try:
+        configs = await sm.iter_configs()
+    except Exception:
+        return {}
+
+    # Single /v1/health probe shared across every slot — calling once
+    # per slot would 5x lemond load for a 5-slot dashboard refresh.
+    from hal0.lemonade.errors import LemonadeError
+    from hal0.providers import lemonade_provider
+
+    health: dict[str, Any] = {}
+    try:
+        health = await lemonade_provider().client().health()
+    except LemonadeError:
+        health = {}
+    except Exception:
+        # Defensive: any error reading health degrades to "no enrichment"
+        # rather than tunnelling up as a 500 — the dashboard is the
+        # primary consumer and would render a broken card.
+        health = {}
+
+    loaded_by_model: dict[str, dict[str, Any]] = {}
+    if isinstance(health, dict):
+        for key in ("loaded", "all_models_loaded"):
+            entries = health.get(key)
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                name = entry.get("model_name")
+                if isinstance(name, str) and name:
+                    loaded_by_model[name] = entry
+
+    # First pass — pick out the NPU LLM slot(s) so we can decide if
+    # the trio is "active" (i.e. there IS an npu-llm slot enabled).
+    npu_llm_enabled: list[str] = [
+        str(cfg.get("name", ""))
+        for cfg in configs
+        if cfg.get("device") == "npu"
+        and cfg.get("type") == "llm"
+        and cfg.get("enabled") is not False
+    ]
+    trio_active = bool(npu_llm_enabled)
+
+    out: dict[str, dict[str, Any]] = {}
+    for cfg in configs:
+        name = str(cfg.get("name", ""))
+        if not name:
+            continue
+        enabled = cfg.get("enabled") is not False
+        model_default = ""
+        model_section = cfg.get("model")
+        if isinstance(model_section, dict):
+            model_default = str(model_section.get("default") or "")
+        entry: dict[str, Any] = {}
+        loaded_entry = loaded_by_model.get(model_default) if model_default else None
+        if not enabled:
+            entry["lemonade_state"] = "disabled"
+        elif loaded_entry is not None:
+            entry["lemonade_state"] = "loaded"
+            backend_url = loaded_entry.get("backend_url")
+            if isinstance(backend_url, str) and backend_url:
+                entry["backend_url"] = backend_url
+        else:
+            # Enabled but not in loaded[]: idle by default. Drift into
+            # error is surfaced via the regular slot state (see
+            # SlotManager.status reconciliation); the dashboard uses
+            # ``status`` for the dot, ``lemonade_state`` for the chip.
+            entry["lemonade_state"] = "idle"
+
+        # Coresident grouping — the FLM trio is hardcoded. A trio slot
+        # only gets the group marker when (a) the NPU LLM anchor is
+        # enabled and (b) THIS slot is enabled too — disabled siblings
+        # don't claim trio membership.
+        if name in _FLM_TRIO_SLOTS and trio_active and enabled:
+            entry["coresident_group"] = "npu-flm-trio"
+
+        out[name] = entry
+    return out
+
+
 def _synthesize_slots_from_upstreams(request: Request) -> list[dict[str, Any]]:
     """Build virtual slot entries from configured upstreams.
 
@@ -153,11 +278,23 @@ async def list_slots(request: Request) -> list[dict[str, object]]:
     Merges real SlotManager-backed entries with synthetic upstream-backed
     ones. Real slots win on name collision so the dashboard sees a single
     authoritative row per slot name once a local slot is installed.
+
+    PR-11: each real entry is enriched in-place with Lemonade-derived
+    fields (``lemonade_state``, optional ``backend_url`` +
+    ``coresident_group``). Synthetic upstream entries are untouched —
+    they aren't managed by lemond and have no health row to lift.
     """
     sm = _get_slot_manager(request)
     real_slots = await sm.list()
     real_entries: list[dict[str, Any]] = [_slot_to_dict(s, request) for s in real_slots]
     real_names = {entry["name"] for entry in real_entries}
+
+    enrichment = await _lemonade_state_enrichment(request)
+    for entry in real_entries:
+        extra = enrichment.get(str(entry["name"]))
+        if extra:
+            for k, v in extra.items():
+                entry.setdefault(k, v)
 
     synthetic = _synthesize_slots_from_upstreams(request)
     merged: list[dict[str, Any]] = list(real_entries)
@@ -639,11 +776,21 @@ async def get_slot(name: str, request: Request) -> dict[str, object]:
     Real slots come from the SlotManager; if the name isn't a configured
     local slot, fall through to the synthetic upstream-backed entry.
     SlotNotFound surfaces as the typed slot.not_found envelope.
+
+    PR-11: real-slot snapshots are enriched with Lemonade-derived state
+    so the dashboard's per-card refresh stays consistent with the list
+    endpoint.
     """
     sm = _get_slot_manager(request)
     try:
         snap = await sm.status(name)
-        return _slot_to_dict(snap, request)
+        out = _slot_to_dict(snap, request)
+        enrichment = await _lemonade_state_enrichment(request)
+        extra = enrichment.get(name)
+        if extra:
+            for k, v in extra.items():
+                out.setdefault(k, v)
+        return out
     except Exception:
         # Fall through to synthetic lookup before re-raising — a remote
         # upstream named ``haloai`` should be observable via this endpoint

--- a/src/hal0/lemonade/client.py
+++ b/src/hal0/lemonade/client.py
@@ -19,6 +19,7 @@ Endpoints covered (per ADR-0008 §1 + plan §2.2):
   ``GET  /internal/config``       full runtime config snapshot
   ``POST /internal/set``          atomic config setter
   ``POST /internal/cleanup-cache``  HF cache hygiene (weekly cron)
+  ``WS   /logs/stream``           server log entries (logs.subscribe / .entry)
 
 Bearer auth: hal0 ↔ lemond is loopback-only; the token is hal0's own
 ``LEMONADE_API_KEY`` (ADR-0008 §1 + ADR-0001), distinct from the
@@ -29,6 +30,7 @@ in addition to the Bearer check.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -316,6 +318,82 @@ class LemonadeClient:
         async with self._request("POST", "/internal/cleanup-cache") as resp:
             self._raise_for_status(resp)
             return resp.json()
+
+    # ── /logs/stream (WebSocket) ───────────────────────────────────
+
+    async def stream_logs(self) -> AsyncIterator[dict[str, Any]]:
+        """Async iterator yielding parsed JSON log entries from ``/logs/stream``.
+
+        Lemonade exposes server logs as a WebSocket frame stream (per the
+        ``hal0_lemonade_ws_protocol`` reference): the client subscribes
+        once with ``{"op": "logs.subscribe"}``, then receives
+        ``logs.snapshot`` (the in-memory ring buffer) followed by
+        ``logs.entry`` frames for each new line. This method yields the
+        parsed JSON message dicts as they arrive; the caller decides
+        how to filter / fan out.
+
+        Used by ``/api/lemonade/logs/stream`` (PR-11) which fans the
+        stream out to the dashboard and looks for the nuclear-evict
+        trigger line ("Load failed with non-file-not-found error,
+        evicting all models and retrying...") to emit a structured
+        ``nuclear_evict`` event. Per ADR-0008 §3 this is hal0's only
+        observability hook for the evict-all blast radius.
+
+        On any failure (lemond down, websockets lib missing, connection
+        drop) the iterator simply stops — callers treat that as "no
+        events for now" and reconnect on their own cadence.
+        """
+        # Lazy import: ``websockets`` ships transitively via
+        # ``uvicorn[standard]`` but isn't a hal0 direct dep, so keep
+        # the import scoped to this method.
+        try:
+            import websockets  # type: ignore[import-untyped]
+            from websockets.exceptions import (  # type: ignore[import-untyped]
+                ConnectionClosed,
+                InvalidHandshake,
+            )
+        except ImportError:
+            return
+
+        import json as _json
+
+        ws_url = self._base_url.replace("http://", "ws://").replace("https://", "wss://")
+        ws_url = f"{ws_url}/logs/stream"
+        headers: dict[str, str] = {}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+
+        try:
+            # ``additional_headers`` was renamed from ``extra_headers`` in
+            # websockets 13.x; try the new name first, fall back for
+            # older lib versions so this works across the supported range.
+            try:
+                ws = await websockets.connect(  # type: ignore[attr-defined]
+                    ws_url, additional_headers=headers, open_timeout=self._timeout_s
+                )
+            except TypeError:
+                ws = await websockets.connect(  # type: ignore[attr-defined]
+                    ws_url, extra_headers=headers, open_timeout=self._timeout_s
+                )
+        except (OSError, InvalidHandshake, TimeoutError):
+            return
+
+        try:
+            await ws.send(_json.dumps({"op": "logs.subscribe"}))
+            async for raw in ws:
+                if isinstance(raw, bytes):
+                    raw = raw.decode("utf-8", errors="replace")
+                try:
+                    msg = _json.loads(raw)
+                except ValueError:
+                    continue
+                if isinstance(msg, dict):
+                    yield msg
+        except (ConnectionClosed, OSError):
+            return
+        finally:
+            with contextlib.suppress(OSError, ConnectionClosed):
+                await ws.close()
 
     # ── internal: HTTP request envelope ────────────────────────────
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -45,6 +45,7 @@ from typing import TYPE_CHECKING, Any
 from hal0.config import paths
 from hal0.slots.state import (
     IllegalSlotTransition,
+    NpuExclusivityViolation,
     SlotConfigError,
     SlotNotFound,
     SlotSpawnFailed,
@@ -1136,6 +1137,11 @@ class SlotManager:
         rendered — lemond owns process lifecycle. The TOML is the only
         on-disk artefact.
 
+        PR-11 (plan §5.3 + ADR-0008 §5): rejects a second ``device=npu,
+        type=llm, enabled=true`` slot — the AMDXDNA hardware context
+        admits exactly one NPU LLM at a time. Disabled NPU LLM slots
+        coexist; only the live anchor count is bounded.
+
         TOML serialisation depends on ``tomli_w`` (declared in
         pyproject.toml); kept inline so this module doesn't pull in
         ``config/loader.py``.
@@ -1148,6 +1154,7 @@ class SlotManager:
             ) from exc
 
         cfg_dict = _cfg_to_dict(slot_cfg)
+        await self._check_npu_exclusivity(slot_name, cfg_dict)
         cfg_path = self._config_file(slot_name)
         cfg_path.parent.mkdir(parents=True, exist_ok=True)
         try:
@@ -1221,6 +1228,12 @@ class SlotManager:
         # build the sub-dict on their side first.
         cfg_dict.update(updates)
 
+        # PR-11: re-run the NPU exclusivity guard whenever the merged
+        # config could land a second device=npu, type=llm anchor (plan
+        # §5.3). Cheap when no NPU LLM is involved — the helper short-
+        # circuits on the merged cfg's own device/type.
+        await self._check_npu_exclusivity(slot_name, cfg_dict)
+
         cfg_path = self._config_file(slot_name)
         try:
             cfg_path.write_bytes(tomli_w.dumps(cfg_dict).encode("utf-8"))
@@ -1230,6 +1243,72 @@ class SlotManager:
             ) from exc
 
         return await self.status(slot_name)
+
+    async def _check_npu_exclusivity(
+        self,
+        slot_name: str,
+        cfg_dict: dict[str, Any],
+    ) -> None:
+        """Reject a write that would land a second NPU LLM anchor.
+
+        Plan §5.3 + ADR-0008 §5: the AMDXDNA hardware context admits
+        ONE ``device=npu, type=llm`` slot at a time. Disabled NPU LLM
+        slots may coexist with another disabled (or enabled) one, but
+        two enabled anchors cannot be configured. This guard runs on
+        every ``create()`` and ``update_config()`` so the constraint
+        holds before any TOML hits disk.
+
+        Cheap fast paths:
+          - the slot being written is not ``device=npu, type=llm`` →
+            no possible violation, return.
+          - the slot being written is not ``enabled`` → at most one
+            enabled NPU LLM can survive (the OTHER one, if any),
+            return.
+
+        On the slow path we walk the other configured slots to see
+        whether any pre-existing NPU LLM is already enabled. Reading
+        the writer's own slot from disk is skipped — the in-memory
+        ``cfg_dict`` IS the authoritative new state.
+        """
+        device = cfg_dict.get("device")
+        type_ = cfg_dict.get("type")
+        if device != "npu" or type_ != "llm":
+            return
+        # The merged write is for an NPU LLM slot. If it isn't being
+        # enabled, no collision is possible — at most one OTHER slot
+        # could still be enabled, and that's the legal state we want.
+        if cfg_dict.get("enabled") is False:
+            return
+        # Walk peers. Use _all_configured_slot_names() so we see slots
+        # whose TOML exists but whose in-memory state hasn't been hit
+        # yet (e.g. installer-seeded slots before first poll).
+        peer_names = [n for n in self._all_configured_slot_names() if n != slot_name]
+        offenders: list[str] = []
+        for name in peer_names:
+            try:
+                peer = await self._load_slot_config(name)
+            except SlotConfigError:
+                # Malformed TOML doesn't block the user's legitimate
+                # write — surface the malformed-slot warning via the
+                # usual path instead of conflating it here.
+                continue
+            except SlotNotFound:
+                continue
+            if peer.get("device") != "npu" or peer.get("type") != "llm":
+                continue
+            if peer.get("enabled") is False:
+                continue
+            offenders.append(name)
+        if offenders:
+            raise NpuExclusivityViolation(
+                "only one NPU LLM slot may be enabled at a time "
+                f"(slot {slot_name!r} would conflict with {offenders[0]!r})",
+                details={
+                    "slot": slot_name,
+                    "conflicting_slots": sorted(offenders),
+                    "hint": "disable the existing NPU LLM slot before enabling another",
+                },
+            )
 
     # ── idle / wake-on-request ───────────────────────────────────────────────
 

--- a/src/hal0/slots/state.py
+++ b/src/hal0/slots/state.py
@@ -186,6 +186,19 @@ class SlotConfigError(SlotError):
     status = 400
 
 
+class NpuExclusivityViolation(SlotError):
+    """Two ``device=npu, type=llm, enabled=true`` slots cannot coexist.
+
+    The AMDXDNA hardware context admits exactly one NPU LLM at a time
+    (plan §5.3, ADR-0008 §5). Surfaced as 409 so the dashboard can
+    distinguish "you already have one — disable it first" from a 400
+    schema error.
+    """
+
+    code = "slot.npu_exclusivity_violation"
+    status = 409
+
+
 # ── Persistence ──────────────────────────────────────────────────────────────
 
 
@@ -313,6 +326,7 @@ __all__ = [
     "LEGAL_TRANSITIONS",
     "SELF_MANAGED_PROVIDERS",
     "IllegalSlotTransition",
+    "NpuExclusivityViolation",
     "SlotConfigError",
     "SlotError",
     "SlotHealthFailed",

--- a/tests/api/test_lemonade_logs_routes.py
+++ b/tests/api/test_lemonade_logs_routes.py
@@ -1,0 +1,127 @@
+"""Tests for the Lemonade log-proxy routes (PR-11, plan §11 + ADR-0008 §3).
+
+Two surfaces:
+  - ``/api/lemonade/logs/stream``: pass-through SSE of every parsed
+    lemond log entry (consumed by PR-14's journal panel).
+  - ``/api/lemonade/events/stream``: structured events derived from
+    filtered log lines; today only ``nuclear_evict`` is emitted.
+
+The unit tests below exercise the message-extraction + frame-flatten
+helpers directly (where the bulk of the logic lives). The end-to-end
+SSE behaviour is exercised by the gamma-suite Playwright spec.
+"""
+
+from __future__ import annotations
+
+from hal0.api.routes.lemonade_logs import (
+    NUCLEAR_EVICT_TRIGGER,
+    _extract_message,
+    _iter_entries,
+)
+
+# ── trigger constant ────────────────────────────────────────────────────────
+
+
+def test_nuclear_evict_trigger_matches_documented_lemond_line() -> None:
+    """The trigger substring must match lemond's actual error log.
+
+    Source: ``hal0_lemonade_gotchas`` memory + ADR-0008 §3. If lemond
+    upstream ever changes the wording, this constant updates and the
+    dashboard banner keeps firing — but the test keeps the contract
+    legible.
+    """
+    assert "Load failed" in NUCLEAR_EVICT_TRIGGER
+    assert "evicting all models" in NUCLEAR_EVICT_TRIGGER
+    assert "non-file-not-found error" in NUCLEAR_EVICT_TRIGGER
+
+
+# ── _extract_message ────────────────────────────────────────────────────────
+
+
+def test_extract_message_picks_canonical_message_key() -> None:
+    assert _extract_message({"message": "hello"}) == "hello"
+
+
+def test_extract_message_tolerates_msg_text_line_fallbacks() -> None:
+    # lemond builds have varied — keep all three legacy keys working.
+    assert _extract_message({"text": "from-text"}) == "from-text"
+    assert _extract_message({"msg": "from-msg"}) == "from-msg"
+    assert _extract_message({"line": "from-line"}) == "from-line"
+
+
+def test_extract_message_returns_empty_string_when_absent() -> None:
+    assert _extract_message({}) == ""
+    assert _extract_message({"level": "info"}) == ""
+
+
+def test_extract_message_skips_non_string_values() -> None:
+    # A protocol bump that ships ``message: {...}`` must NOT crash the
+    # filter — it should fall through to the next candidate key, then
+    # to the empty-string sentinel.
+    assert _extract_message({"message": None}) == ""
+    assert _extract_message({"message": 42}) == ""
+    assert _extract_message({"message": [], "text": "fallback"}) == "fallback"
+
+
+# ── _iter_entries ───────────────────────────────────────────────────────────
+
+
+def test_iter_entries_handles_logs_entry_frame() -> None:
+    frame = {"op": "logs.entry", "entry": {"message": "hi", "level": "info"}}
+    assert _iter_entries(frame) == [{"message": "hi", "level": "info"}]
+
+
+def test_iter_entries_flattens_logs_snapshot_batch() -> None:
+    frame = {
+        "op": "logs.snapshot",
+        "entries": [
+            {"message": "first"},
+            {"message": "second"},
+            "not-a-dict",  # mixed in by buggy upstream — filter out
+        ],
+    }
+    out = _iter_entries(frame)
+    assert out == [{"message": "first"}, {"message": "second"}]
+
+
+def test_iter_entries_handles_unknown_op_as_raw_passthrough() -> None:
+    """Unknown frame ops (future protocol) pass through unfiltered.
+
+    The dashboard's journal panel can render whatever shape it sees;
+    the nuclear-evict filter routes through ``_extract_message`` which
+    safely returns '' for shape mismatches.
+    """
+    frame = {"op": "logs.future_op", "some_field": 1}
+    assert _iter_entries(frame) == [frame]
+
+
+def test_iter_entries_drops_missing_payloads() -> None:
+    # entry: None
+    assert _iter_entries({"op": "logs.entry", "entry": None}) == []
+    # entries: None
+    assert _iter_entries({"op": "logs.snapshot", "entries": None}) == []
+    # entry: wrong type
+    assert _iter_entries({"op": "logs.entry", "entry": "string-not-dict"}) == []
+
+
+# ── route integration ──────────────────────────────────────────────────────
+
+
+def test_routes_mounted_under_api_lemonade_prefix() -> None:
+    """The router is wired under /api/lemonade so the dashboard URLs match.
+
+    Smoke test rather than functional — full SSE timing is covered by
+    the gamma-suite Playwright spec which can drive the stream against
+    mocked EventSource.
+    """
+    from fastapi.testclient import TestClient
+
+    from hal0.api import create_app
+
+    app = create_app()
+    with TestClient(app) as client:
+        # No auth → 401, but the path resolves (404 would mean unmounted).
+        r = client.get("/api/lemonade/logs/stream")
+        # Either 401 (auth required) or 200 (auth disabled in tests) —
+        # NEVER 404, which would mean the route isn't registered.
+        assert r.status_code != 404, "lemonade log routes not mounted"

--- a/tests/api/test_slots_lemonade_state.py
+++ b/tests/api/test_slots_lemonade_state.py
@@ -1,0 +1,417 @@
+"""Tests for the Lemonade-derived state enrichment on /api/slots (PR-11).
+
+The list endpoint enriches each real slot entry with three optional
+fields lifted from Lemonade's ``/v1/health.loaded[]``:
+
+  - ``lemonade_state``: ``loaded`` | ``idle`` | ``disabled`` | ``error``
+  - ``backend_url``: per-model child server URL (only for loaded models)
+  - ``coresident_group``: shared ID for the NPU FLM trio (chat + ASR + embed)
+
+All three are additive — legacy fields stay untouched so v0.1.x clients
+keep rendering.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import hal0.providers as providers_mod
+from hal0.api import create_app
+from hal0.lemonade.client import LemonadeClient
+from hal0.providers.lemonade import LemonadeProvider
+
+
+@pytest.fixture
+def lemonade_health_state() -> dict[str, Any]:
+    """Mutable handle for the lemond stub's /v1/health response.
+
+    Tests mutate ``state["loaded"]`` to drive different enrichment
+    scenarios without re-installing the provider.
+    """
+    return {"loaded": []}
+
+
+@pytest.fixture
+def installed_lemonade_stub(
+    lemonade_health_state: dict[str, Any],
+) -> Iterator[dict[str, Any]]:
+    """Install a Lemonade stub whose /v1/health echoes lemonade_health_state.
+
+    Other lemonade endpoints (/v1/load, /v1/unload) return innocuous
+    success responses so adjacent fixture setup doesn't 4xx.
+    """
+    state = lemonade_health_state
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json={"loaded": state["loaded"]})
+        if req.url.path in ("/v1/load", "/v1/unload"):
+            return httpx.Response(200, json={"status": "ok"})
+        return httpx.Response(404, json={"detail": f"unmocked {req.url.path}"})
+
+    transport = httpx.AsyncClient(
+        transport=httpx.MockTransport(h),
+        base_url="http://test",
+    )
+    provider = LemonadeProvider(client=LemonadeClient(http_client=transport))
+    original = providers_mod._PROVIDERS["lemonade"]
+    providers_mod._PROVIDERS["lemonade"] = provider
+    try:
+        yield state
+    finally:
+        providers_mod._PROVIDERS["lemonade"] = original
+
+
+def _seed_slot_toml(home: str, name: str, lines: list[str]) -> Path:
+    root = Path(home) / "etc" / "hal0" / "slots"
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / f"{name}.toml"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def npu_trio_slot_root(tmp_hal0_home: str) -> Path:
+    """Lay down the NPU FLM trio (agent + stt-npu + embed-npu) on disk."""
+    root = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    root.mkdir(parents=True, exist_ok=True)
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "agent",
+        [
+            'name = "agent"',
+            "port = 8082",
+            'device = "npu"',
+            'type = "llm"',
+            "enabled = true",
+            "[model]",
+            'default = "gemma3-1b"',
+        ],
+    )
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "stt-npu",
+        [
+            'name = "stt-npu"',
+            "port = 8084",
+            'device = "npu"',
+            'type = "transcription"',
+            "enabled = true",
+            "[model]",
+            'default = "whisper-v3"',
+        ],
+    )
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "embed-npu",
+        [
+            'name = "embed-npu"',
+            "port = 8085",
+            'device = "npu"',
+            'type = "embedding"',
+            "enabled = true",
+            "[model]",
+            'default = "embed-gemma"',
+        ],
+    )
+    return root
+
+
+@pytest.fixture
+def isolated_app(tmp_hal0_home: str) -> FastAPI:
+    return create_app()
+
+
+@pytest.fixture
+def isolated_client(isolated_app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(isolated_app) as c:
+        yield c
+
+
+# ── lemonade_state field ───────────────────────────────────────────────────
+
+
+def test_list_slots_emits_idle_for_enabled_slot_with_no_loaded_model(
+    npu_trio_slot_root: Path,
+    installed_lemonade_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """Enabled slot, /v1/health.loaded[] empty → lemonade_state=idle."""
+    installed_lemonade_stub["loaded"] = []
+    r = isolated_client.get("/api/slots")
+    assert r.status_code == 200, r.text
+    by_name = {e["name"]: e for e in r.json()}
+    assert by_name["agent"]["lemonade_state"] == "idle"
+    assert "backend_url" not in by_name["agent"]
+
+
+def test_list_slots_emits_loaded_with_backend_url(
+    npu_trio_slot_root: Path,
+    installed_lemonade_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """Model present in /v1/health.loaded[] → lemonade_state=loaded + backend_url lifted."""
+    installed_lemonade_stub["loaded"] = [
+        {"model_name": "gemma3-1b", "backend_url": "http://127.0.0.1:14002/v1"},
+    ]
+    r = isolated_client.get("/api/slots")
+    assert r.status_code == 200
+    by_name = {e["name"]: e for e in r.json()}
+    agent = by_name["agent"]
+    assert agent["lemonade_state"] == "loaded"
+    assert agent["backend_url"] == "http://127.0.0.1:14002/v1"
+
+
+def test_list_slots_emits_disabled_for_enabled_false_slot(
+    tmp_hal0_home: str,
+    installed_lemonade_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """enabled=false slots surface as lemonade_state=disabled regardless of /v1/health."""
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "agent",
+        [
+            'name = "agent"',
+            "port = 8082",
+            'device = "npu"',
+            'type = "llm"',
+            "enabled = false",
+            "[model]",
+            'default = "gemma3-1b"',
+        ],
+    )
+    # Even if lemond claims it's loaded, the disabled flag wins.
+    installed_lemonade_stub["loaded"] = [{"model_name": "gemma3-1b"}]
+    r = isolated_client.get("/api/slots")
+    by_name = {e["name"]: e for e in r.json()}
+    assert by_name["agent"]["lemonade_state"] == "disabled"
+
+
+# ── coresident_group field ─────────────────────────────────────────────────
+
+
+def test_list_slots_emits_coresident_group_for_npu_trio(
+    npu_trio_slot_root: Path,
+    installed_lemonade_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """When NPU LLM anchor is enabled, all three trio slots get coresident_group."""
+    installed_lemonade_stub["loaded"] = [{"model_name": "gemma3-1b"}]
+    r = isolated_client.get("/api/slots")
+    by_name = {e["name"]: e for e in r.json()}
+    for slot_name in ("agent", "stt-npu", "embed-npu"):
+        assert by_name[slot_name].get("coresident_group") == "npu-flm-trio", (
+            f"slot {slot_name} missing coresident_group: {by_name[slot_name]}"
+        )
+
+
+def test_list_slots_no_coresident_group_when_npu_anchor_disabled(
+    tmp_hal0_home: str,
+    installed_lemonade_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """Disabled NPU LLM anchor → no trio markers on the sibling slots."""
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "agent",
+        [
+            'name = "agent"',
+            "port = 8082",
+            'device = "npu"',
+            'type = "llm"',
+            "enabled = false",
+            "[model]",
+            'default = "gemma3-1b"',
+        ],
+    )
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "stt-npu",
+        [
+            'name = "stt-npu"',
+            "port = 8084",
+            'device = "npu"',
+            'type = "transcription"',
+            "enabled = true",
+            "[model]",
+            'default = "whisper-v3"',
+        ],
+    )
+    r = isolated_client.get("/api/slots")
+    by_name = {e["name"]: e for e in r.json()}
+    assert by_name["stt-npu"].get("coresident_group") is None
+
+
+def test_list_slots_skips_coresident_for_disabled_sibling(
+    tmp_hal0_home: str,
+    installed_lemonade_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """A disabled sibling slot doesn't claim coresident membership."""
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "agent",
+        [
+            'name = "agent"',
+            "port = 8082",
+            'device = "npu"',
+            'type = "llm"',
+            "enabled = true",
+            "[model]",
+            'default = "gemma3-1b"',
+        ],
+    )
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "stt-npu",
+        [
+            'name = "stt-npu"',
+            "port = 8084",
+            'device = "npu"',
+            'type = "transcription"',
+            "enabled = false",
+            "[model]",
+            'default = "whisper-v3"',
+        ],
+    )
+    r = isolated_client.get("/api/slots")
+    by_name = {e["name"]: e for e in r.json()}
+    # Anchor still marked.
+    assert by_name["agent"].get("coresident_group") == "npu-flm-trio"
+    # Disabled sibling is NOT marked.
+    assert by_name["stt-npu"].get("coresident_group") is None
+
+
+# ── Per-slot endpoint enrichment ───────────────────────────────────────────
+
+
+def test_get_slot_includes_lemonade_state(
+    npu_trio_slot_root: Path,
+    installed_lemonade_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """GET /api/slots/{name} is enriched same shape as the list endpoint."""
+    installed_lemonade_stub["loaded"] = [
+        {"model_name": "gemma3-1b", "backend_url": "http://127.0.0.1:14002/v1"},
+    ]
+    r = isolated_client.get("/api/slots/agent")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["lemonade_state"] == "loaded"
+    assert body["backend_url"] == "http://127.0.0.1:14002/v1"
+    assert body["coresident_group"] == "npu-flm-trio"
+
+
+# ── Backwards compatibility ────────────────────────────────────────────────
+
+
+def test_legacy_fields_still_present(
+    npu_trio_slot_root: Path,
+    installed_lemonade_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """v0.1.x clients consuming /api/slots see every legacy key unchanged."""
+    r = isolated_client.get("/api/slots")
+    by_name = {e["name"]: e for e in r.json()}
+    legacy_keys = {"name", "status", "port", "model_id", "backend", "kind"}
+    for slot in ("agent", "stt-npu", "embed-npu"):
+        present = set(by_name[slot].keys())
+        missing = legacy_keys - present
+        assert not missing, f"slot {slot} missing legacy keys: {missing}"
+
+
+def test_list_degrades_when_lemonade_unreachable(
+    npu_trio_slot_root: Path,
+    isolated_client: TestClient,
+) -> None:
+    """A down lemond doesn't break /api/slots — entries omit lemonade_state cleanly.
+
+    No ``installed_lemonade_stub`` fixture: the default LemonadeProvider
+    tries to reach 127.0.0.1:13305 and fails (no daemon under test).
+    The enrichment helper swallows the error.
+    """
+    r = isolated_client.get("/api/slots")
+    assert r.status_code == 200
+    # The legacy entries must still come back; lemonade_state may be
+    # absent (lemond unreachable) or "idle" (which the enrichment
+    # treats as the not-loaded fallback). Either is acceptable; what
+    # matters is that the endpoint doesn't 500.
+    body = r.json()
+    assert isinstance(body, list)
+    assert any(e["name"] == "agent" for e in body)
+
+
+def test_loaded_state_uses_chat_anchor_model(
+    npu_trio_slot_root: Path,
+    installed_lemonade_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """Each slot's lemonade_state keys off ITS OWN model.default, not the chat anchor.
+
+    The NPU trio's siblings carry their own model_name (whisper, embed-gemma).
+    A naive implementation could short-circuit on the chat anchor's model
+    name and over-report 'loaded' for the trio siblings.
+    """
+    # Only the chat model is loaded; siblings should NOT be 'loaded'.
+    installed_lemonade_stub["loaded"] = [{"model_name": "gemma3-1b"}]
+    r = isolated_client.get("/api/slots")
+    by_name = {e["name"]: e for e in r.json()}
+    assert by_name["agent"]["lemonade_state"] == "loaded"
+    assert by_name["stt-npu"]["lemonade_state"] == "idle"
+    assert by_name["embed-npu"]["lemonade_state"] == "idle"
+
+
+def test_list_route_handles_alternate_health_key(
+    npu_trio_slot_root: Path,
+    isolated_client: TestClient,
+) -> None:
+    """/v1/health may emit the ``all_models_loaded`` key alongside ``loaded``.
+
+    LemonadeProvider.status() already accepts both — the enrichment
+    helper inherits that tolerance so a Lemonade build flip doesn't
+    blank the dashboard.
+    """
+    state = {"all_models_loaded": [{"model_name": "gemma3-1b"}]}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json=state)
+        return httpx.Response(404, json={"detail": f"unmocked {req.url.path}"})
+
+    transport = httpx.AsyncClient(
+        transport=httpx.MockTransport(h),
+        base_url="http://test",
+    )
+    provider = LemonadeProvider(client=LemonadeClient(http_client=transport))
+    original = providers_mod._PROVIDERS["lemonade"]
+    providers_mod._PROVIDERS["lemonade"] = provider
+    try:
+        r = isolated_client.get("/api/slots")
+        by_name = {e["name"]: e for e in r.json()}
+        assert by_name["agent"]["lemonade_state"] == "loaded"
+    finally:
+        providers_mod._PROVIDERS["lemonade"] = original
+
+
+def test_json_serialisation_roundtrips(
+    npu_trio_slot_root: Path,
+    installed_lemonade_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """The enriched body must be valid JSON (no exotic types leaked)."""
+    installed_lemonade_stub["loaded"] = [
+        {"model_name": "gemma3-1b", "backend_url": "http://127.0.0.1:14002/v1"},
+    ]
+    r = isolated_client.get("/api/slots")
+    # text + parsing both succeed → no infinite floats or set leaks
+    body = json.loads(r.text)
+    assert isinstance(body, list)

--- a/tests/slots/test_npu_exclusivity.py
+++ b/tests/slots/test_npu_exclusivity.py
@@ -1,0 +1,254 @@
+"""NPU exclusivity validation in SlotManager (PR-11, plan §5.3, ADR-0008 §5).
+
+The AMDXDNA hardware context admits exactly one ``device=npu, type=llm,
+enabled=true`` slot at a time. SlotManager.create() and update_config()
+both gate on the helper :meth:`_check_npu_exclusivity` — these tests
+pin the contract.
+
+Conventions:
+  - Tests don't drive lemond (the validation runs before any HTTP I/O).
+  - ``tmp_hal0_home`` isolates the writer's TOML to a tmp directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.slots.manager import SlotManager
+from hal0.slots.state import NpuExclusivityViolation
+
+
+def _write_slot_toml(home: str, name: str, lines: list[str]) -> Path:
+    """Write a minimal slot TOML under HAL0_HOME without going through SlotManager.
+
+    Tests use this to seed the "peer slot already exists" precondition
+    so the validator under test has something to find.
+    """
+    root = Path(home) / "etc" / "hal0" / "slots"
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / f"{name}.toml"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+# ── Negative paths: NPU LLM is being created/enabled ────────────────────────
+
+
+async def test_create_rejects_second_enabled_npu_llm(tmp_hal0_home: str) -> None:
+    """A second device=npu, type=llm, enabled=true slot must be rejected."""
+    _write_slot_toml(
+        tmp_hal0_home,
+        "agent",
+        [
+            'name = "agent"',
+            "port = 8082",
+            'device = "npu"',
+            'type = "llm"',
+            "enabled = true",
+            "[model]",
+            'default = "gemma3-1b"',
+        ],
+    )
+    sm = SlotManager()
+    with pytest.raises(NpuExclusivityViolation) as exc:
+        await sm.create(
+            "agent-2",
+            {
+                "name": "agent-2",
+                "port": 8083,
+                "device": "npu",
+                "type": "llm",
+                "enabled": True,
+                "model": {"default": "qwen3-1b"},
+            },
+        )
+    assert "agent" in exc.value.details["conflicting_slots"]
+    assert exc.value.status == 409
+    # The new slot must not have been written to disk.
+    assert not (Path(tmp_hal0_home) / "etc" / "hal0" / "slots" / "agent-2.toml").exists()
+
+
+async def test_update_config_rejects_enabling_second_npu_llm(tmp_hal0_home: str) -> None:
+    """Flipping ``enabled=false → true`` on a sibling NPU LLM is blocked."""
+    _write_slot_toml(
+        tmp_hal0_home,
+        "agent",
+        [
+            'name = "agent"',
+            "port = 8082",
+            'device = "npu"',
+            'type = "llm"',
+            "enabled = true",
+            "[model]",
+            'default = "gemma3-1b"',
+        ],
+    )
+    # Seed agent-2 with enabled=false; allowed because it doesn't claim the HW.
+    _write_slot_toml(
+        tmp_hal0_home,
+        "agent-2",
+        [
+            'name = "agent-2"',
+            "port = 8083",
+            'device = "npu"',
+            'type = "llm"',
+            "enabled = false",
+            "[model]",
+            'default = "qwen3-1b"',
+        ],
+    )
+    sm = SlotManager()
+    with pytest.raises(NpuExclusivityViolation):
+        await sm.update_config("agent-2", {"enabled": True})
+
+
+# ── Positive paths: changes that DON'T violate the constraint ───────────────
+
+
+async def test_create_allows_disabled_second_npu_llm(tmp_hal0_home: str) -> None:
+    """A disabled second NPU LLM slot may coexist with an enabled one."""
+    _write_slot_toml(
+        tmp_hal0_home,
+        "agent",
+        [
+            'name = "agent"',
+            "port = 8082",
+            'device = "npu"',
+            'type = "llm"',
+            "enabled = true",
+            "[model]",
+            'default = "gemma3-1b"',
+        ],
+    )
+    sm = SlotManager()
+    snap = await sm.create(
+        "agent-spare",
+        {
+            "name": "agent-spare",
+            "port": 8083,
+            "device": "npu",
+            "type": "llm",
+            "enabled": False,
+            "model": {"default": "qwen3-1b"},
+        },
+    )
+    assert snap is not None
+    assert (Path(tmp_hal0_home) / "etc" / "hal0" / "slots" / "agent-spare.toml").exists()
+
+
+async def test_create_allows_non_npu_slot_alongside_npu_llm(tmp_hal0_home: str) -> None:
+    """device=gpu-rocm slots are unaffected by NPU exclusivity."""
+    _write_slot_toml(
+        tmp_hal0_home,
+        "agent",
+        [
+            'name = "agent"',
+            "port = 8082",
+            'device = "npu"',
+            'type = "llm"',
+            "enabled = true",
+            "[model]",
+            'default = "gemma3-1b"',
+        ],
+    )
+    sm = SlotManager()
+    await sm.create(
+        "primary-2",
+        {
+            "name": "primary-2",
+            "port": 8083,
+            "device": "gpu-rocm",
+            "type": "llm",
+            "enabled": True,
+            "model": {"default": "qwen3-9b"},
+        },
+    )
+
+
+async def test_create_allows_npu_embedding_or_transcription_alongside_npu_llm(
+    tmp_hal0_home: str,
+) -> None:
+    """Only ``type=llm`` slots claim the AMDXDNA chat context.
+
+    The FLM trio (stt-npu + embed-npu) is the canonical example — they
+    DO run on the NPU but coresident with the chat anchor, not as
+    additional anchors.
+    """
+    _write_slot_toml(
+        tmp_hal0_home,
+        "agent",
+        [
+            'name = "agent"',
+            "port = 8082",
+            'device = "npu"',
+            'type = "llm"',
+            "enabled = true",
+            "[model]",
+            'default = "gemma3-1b"',
+        ],
+    )
+    sm = SlotManager()
+    await sm.create(
+        "stt-npu",
+        {
+            "name": "stt-npu",
+            "port": 8084,
+            "device": "npu",
+            "type": "transcription",
+            "enabled": True,
+            "model": {"default": "whisper-v3"},
+        },
+    )
+    await sm.create(
+        "embed-npu",
+        {
+            "name": "embed-npu",
+            "port": 8085,
+            "device": "npu",
+            "type": "embedding",
+            "enabled": True,
+            "model": {"default": "embed-gemma"},
+        },
+    )
+
+
+async def test_update_config_self_idempotent_when_no_conflict(tmp_hal0_home: str) -> None:
+    """Updating the lone NPU LLM slot's own fields does NOT trip the guard.
+
+    The guard skips the writer's own slot — without that, a routine
+    ``swap()`` on the lone NPU LLM would fail every time.
+    """
+    _write_slot_toml(
+        tmp_hal0_home,
+        "agent",
+        [
+            'name = "agent"',
+            "port = 8082",
+            'device = "npu"',
+            'type = "llm"',
+            "enabled = true",
+            "[model]",
+            'default = "gemma3-1b"',
+        ],
+    )
+    sm = SlotManager()
+    await sm.update_config("agent", {"model": {"default": "qwen3-1b"}})
+
+
+async def test_create_allows_first_npu_llm_in_clean_home(tmp_hal0_home: str) -> None:
+    """The very first NPU LLM slot must succeed."""
+    sm = SlotManager()
+    snap = await sm.create(
+        "agent",
+        {
+            "name": "agent",
+            "port": 8082,
+            "device": "npu",
+            "type": "llm",
+            "enabled": True,
+            "model": {"default": "gemma3-1b"},
+        },
+    )
+    assert snap is not None

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useSystemStore } from './stores/system.js'
 import { useFooterStore } from './stores/footer.js'
+import { useNuclearEvictBanner } from './composables/useNuclearEvictBanner.js'
 import Sidebar from './components/Sidebar.vue'
 import TopBar from './components/TopBar.vue'
 import ToastContainer from './components/ToastContainer.vue'
@@ -14,6 +15,10 @@ const system = useSystemStore()
 const footer = useFooterStore()
 const route  = useRoute()
 const router = useRouter()
+
+// PR-11: subscribe once at the app shell so the nuclear-evict toast
+// banner fires on every dashboard route. Disconnect happens on unmount.
+useNuclearEvictBanner()
 
 // ── Responsive sidebar ────────────────────────────────────────────
 // Desktop: sidebarOpen = expanded(true) / collapsed-icon-rail(false)

--- a/ui/src/components/SlotCard.vue
+++ b/ui/src/components/SlotCard.vue
@@ -73,6 +73,28 @@ const dotState = computed(() => {
   return 'idle'
 })
 
+// PR-11: Lemonade /v1/health-derived hints. These come from the backend's
+// per-slot enrichment in `_lemonade_state_enrichment`:
+//   - coresident_group: 'npu-flm-trio' when this slot is one of the FLM
+//     trio (agent/stt-npu/embed-npu) backed by a single FLM process.
+//   - lemonade_state: 'loaded' | 'idle' | 'disabled' | 'error' — a
+//     more precise "is the model in lemond's loaded[]?" signal than the
+//     legacy status dot, which mixes lifecycle + reachability.
+// The badge is a thin visual hint, NOT actionable — clicking it doesn't
+// navigate; it's just there so the operator understands the trio backs
+// one FLM process at a glance.
+const coresidentGroup = computed(() => props.slot.coresident_group || null)
+const coresidentLabel = computed(() => {
+  if (coresidentGroup.value === 'npu-flm-trio') return 'TRIO'
+  return null
+})
+const coresidentTitle = computed(() => {
+  if (coresidentGroup.value === 'npu-flm-trio') {
+    return 'NPU FLM trio — chat, STT, and embed run coresident in one FLM process'
+  }
+  return ''
+})
+
 const modelLabel = computed(() => {
   const raw = props.slot.model_name || props.slot.model || props.slot.model_id || ''
   const s = typeof raw === 'string' ? raw : (raw?.default ?? '')
@@ -487,6 +509,16 @@ const sparkSvg = computed(() => {
     <div class="sc-head">
       <span class="sc-dot" />
       <span class="sc-name">{{ slot.name }}</span>
+      <!-- PR-11: coresident-group badge for the NPU FLM trio. Three slots
+           (agent + stt-npu + embed-npu) all back the same FLM process,
+           so a small static chip makes the relationship discoverable
+           without crowding the layout. Hidden when there's no group. -->
+      <span
+        v-if="coresidentLabel"
+        class="sc-chip coresident"
+        data-testid="coresident-badge"
+        :title="coresidentTitle"
+      >{{ coresidentLabel }}</span>
       <span class="sc-port mono">{{ slot.port ? `:${slot.port}` : '—' }}</span>
     </div>
 
@@ -866,6 +898,18 @@ const sparkSvg = computed(() => {
   letter-spacing: 0.04em;
 }
 .sc-chip.dim { opacity: 0.7; text-transform: lowercase; }
+
+/* PR-11: coresident-group badge. Slim, amber-tinted (matches NPU
+   wordmark hue) so the eye groups trio-slot cards without reading them
+   as warnings. */
+.sc-chip.coresident {
+  margin-left: 6px;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  color: var(--hal0-accent);
+  border-color: color-mix(in srgb, var(--hal0-accent) 50%, transparent);
+  background: color-mix(in srgb, var(--hal0-accent) 12%, transparent);
+}
 
 /* Hardware target chip — colour-coded so the user can see at a glance
    which compute path the slot uses. NPU is amber (distinctive), GPU red,

--- a/ui/src/composables/useNuclearEvictBanner.js
+++ b/ui/src/composables/useNuclearEvictBanner.js
@@ -1,0 +1,59 @@
+/**
+ * useNuclearEvictBanner — subscribe to /api/lemonade/events/stream and
+ * surface every `nuclear_evict` event as a transient toast banner.
+ *
+ * Per ADR-0008 §3, the nuclear-evict escape valve is rare-but-visible:
+ * the dashboard pops a warning toast for each occurrence so the
+ * operator sees the eviction inline, without digging into the journal
+ * panel. The toast auto-dismisses after 8s (longer than the usual 4s
+ * default — operators need time to read the message).
+ *
+ * Mounted once at the App level; child views don't subscribe. The
+ * EventSource auto-reconnects when lemond's log stream drops, so the
+ * banner survives across daemon restarts.
+ */
+import { onMounted, onUnmounted } from 'vue'
+import { useToastsStore } from '../stores/toasts.js'
+
+const EVENTS_URL = '/api/lemonade/events/stream'
+const TOAST_DURATION_MS = 8000
+
+export function useNuclearEvictBanner() {
+  const toasts = useToastsStore()
+  let es = null
+
+  function connect() {
+    if (typeof window === 'undefined' || !window.EventSource) return
+    try {
+      es = new EventSource(EVENTS_URL)
+    } catch (_err) {
+      return
+    }
+    es.addEventListener('nuclear_evict', (evt) => {
+      let payload = {}
+      try {
+        payload = JSON.parse(evt.data)
+      } catch (_err) {
+        payload = { message: String(evt.data) }
+      }
+      const msg = payload.message
+        || 'Lemonade evicted all loaded models after a load failure.'
+      toasts.warning(`Nuclear evict: ${msg}`, TOAST_DURATION_MS)
+    })
+    es.onerror = () => {
+      // EventSource auto-reconnects on its own cadence — no action.
+    }
+  }
+
+  function disconnect() {
+    if (es) {
+      try { es.close() } catch (_err) { /* noop */ }
+      es = null
+    }
+  }
+
+  onMounted(connect)
+  onUnmounted(disconnect)
+
+  return { disconnect }
+}

--- a/ui/src/views/Slots.vue
+++ b/ui/src/views/Slots.vue
@@ -262,7 +262,18 @@ async function submitCreate() {
     createErrors.value = {}
     await system.fetchStatus()
   } catch (e) {
-    toasts.error(e.message)
+    // PR-11: NPU exclusivity violations carry a typed envelope —
+    // surface the conflicting slot name inline so the operator knows
+    // what to disable first.
+    if (e?.code === 'slot.npu_exclusivity_violation') {
+      const conflicting = e?.details?.conflicting_slots?.[0] ?? 'another NPU LLM slot'
+      createErrors.value = {
+        backend: `NPU is already claimed by slot "${conflicting}"; disable it first.`,
+      }
+      toasts.error(e.message)
+    } else {
+      toasts.error(e.message)
+    }
   } finally {
     creating.value = false
   }

--- a/ui/tests/e2e/fixtures/sseHarness.ts
+++ b/ui/tests/e2e/fixtures/sseHarness.ts
@@ -52,6 +52,17 @@ export async function installSseHarness(page: Page) {
             try { self.onmessage && self.onmessage(ev) } catch (e) {}
             self.dispatchEvent(ev)
           },
+          // PR-11: typed-event support. Real SSE streams can declare
+          // ``event: <name>`` for each frame; addEventListener(name, cb)
+          // only fires for that name. The default ``dispatch`` only
+          // emits 'message' events; ``dispatchTyped(type, data)`` fires
+          // a MessageEvent of the requested type so subscribers using
+          // addEventListener still trigger.
+          dispatchTyped: function (type, data) {
+            if (self.readyState !== 1) return
+            const ev = new MessageEvent(type, { data })
+            self.dispatchEvent(ev)
+          },
         }
         if (!streams[this.url]) streams[this.url] = []
         streams[this.url].push(entry)
@@ -94,6 +105,42 @@ export async function emitSse(page: Page, urlSubstring: string, data: any): Prom
       return count
     },
     { sub: urlSubstring, body: payload },
+  )
+}
+
+/**
+ * Push a single TYPED SSE event into the streams whose URL contains
+ * the given substring. Use this for streams that declare
+ * ``event: <type>`` framing — ``addEventListener(type, cb)`` only
+ * fires for the matching type, so the default ``emitSse`` (which
+ * dispatches 'message' events) won't trigger them.
+ *
+ * Returns the number of streams that received the event.
+ */
+export async function emitSseTyped(
+  page: Page,
+  urlSubstring: string,
+  type: string,
+  data: any,
+): Promise<number> {
+  const payload = typeof data === 'string' ? data : JSON.stringify(data)
+  return await page.evaluate(
+    ({ sub, evType, body }) => {
+      const streams = (window).__sseStreams || {}
+      let count = 0
+      for (const url of Object.keys(streams)) {
+        if (url.indexOf(sub) !== -1) {
+          for (const entry of streams[url]) {
+            if (typeof entry.dispatchTyped === 'function') {
+              entry.dispatchTyped(evType, body)
+              count++
+            }
+          }
+        }
+      }
+      return count
+    },
+    { sub: urlSubstring, evType: type, body: payload },
   )
 }
 

--- a/ui/tests/e2e/specs/dashboard-lemonade-state.spec.ts
+++ b/ui/tests/e2e/specs/dashboard-lemonade-state.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * dashboard-lemonade-state.spec.ts — PR-11 dashboard surface.
+ *
+ * Covers (plan §11 PR-11):
+ *   - Slot card renders correct lifecycle state (loaded / idle / offline)
+ *   - Coresident TRIO badge appears when ``slot.coresident_group`` is set
+ *   - Nuclear-evict event from /api/lemonade/events/stream pops a toast
+ *
+ * No live backend — uses ``apiMock`` for HTTP and ``sseHarness`` for SSE.
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+import { emitSseTyped, installSseHarness, waitForSse } from '../fixtures/sseHarness'
+
+const FLM_TRIO_SLOTS = [
+  {
+    name: 'agent',
+    kind: 'local',
+    type: 'llm',
+    device: 'npu',
+    backend: 'flm',
+    provider: 'flm',
+    model_id: 'gemma3-1b',
+    model: 'gemma3-1b',
+    port: 8082,
+    status: 'ready',
+    lemonade_state: 'loaded',
+    backend_url: 'http://127.0.0.1:14002/v1',
+    coresident_group: 'npu-flm-trio',
+  },
+  {
+    name: 'stt-npu',
+    kind: 'local',
+    type: 'transcription',
+    device: 'npu',
+    backend: 'flm',
+    provider: 'flm',
+    model_id: 'whisper-v3',
+    model: 'whisper-v3',
+    port: 8084,
+    status: 'idle',
+    lemonade_state: 'idle',
+    coresident_group: 'npu-flm-trio',
+  },
+  {
+    name: 'embed-npu',
+    kind: 'local',
+    type: 'embedding',
+    device: 'npu',
+    backend: 'flm',
+    provider: 'flm',
+    model_id: 'embed-gemma',
+    model: 'embed-gemma',
+    port: 8085,
+    status: 'idle',
+    lemonade_state: 'idle',
+    coresident_group: 'npu-flm-trio',
+  },
+]
+
+test('coresident TRIO badge appears on all three FLM trio slots', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  await page.route('**/api/slots', (route) => json(route, FLM_TRIO_SLOTS))
+  // Status endpoint also returns the slots — keep the two paths in sync
+  // so the system store doesn't replace the rich /api/slots payload.
+  mockState.status.slots = FLM_TRIO_SLOTS
+
+  await page.goto('/slots')
+
+  // The trio badge has data-testid="coresident-badge". Three slot cards,
+  // three badges — each one carrying the "TRIO" label.
+  const badges = page.getByTestId('coresident-badge')
+  await expect(badges).toHaveCount(3, { timeout: 5_000 })
+  await expect(badges.first()).toHaveText('TRIO')
+})
+
+test('non-trio slot has no coresident badge', async ({ page, mockState, cleanState }) => {
+  const slots = [
+    {
+      name: 'primary',
+      kind: 'local',
+      type: 'llm',
+      device: 'gpu-rocm',
+      backend: 'rocm',
+      provider: 'lemonade',
+      model_id: 'qwen3-4b',
+      model: 'qwen3-4b',
+      port: 8081,
+      status: 'ready',
+      lemonade_state: 'loaded',
+    },
+  ]
+  await page.route('**/api/slots', (route) => json(route, slots))
+  mockState.status.slots = slots
+
+  await page.goto('/slots')
+  // The card renders; no coresident badge is attached.
+  await expect(page.locator('.sc-name', { hasText: 'primary' })).toBeVisible()
+  await expect(page.getByTestId('coresident-badge')).toHaveCount(0)
+})
+
+test('nuclear-evict event from /api/lemonade/events/stream pops a toast', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  // SSE shim must be installed BEFORE the page mounts so the EventSource
+  // construction goes through the fake.
+  await installSseHarness(page)
+
+  // Minimal slot mock so the dashboard doesn't 404 on initial poll.
+  await page.route('**/api/slots', (route) => json(route, []))
+  mockState.status.slots = []
+
+  await page.goto('/slots')
+
+  // useNuclearEvictBanner mounts at the App level and opens the
+  // EventSource on App.onMounted; wait for the stream to appear.
+  await waitForSse(page, '/api/lemonade/events/stream')
+
+  // Drive a typed nuclear_evict event into the open stream. The
+  // composable subscribes via es.addEventListener('nuclear_evict'),
+  // so emitSseTyped — not emitSse — is required.
+  const delivered = await emitSseTyped(page, '/api/lemonade/events/stream', 'nuclear_evict', {
+    type: 'nuclear_evict',
+    message: 'Load failed with non-file-not-found error, evicting all models and retrying...',
+    ts: 1700000000,
+  })
+  expect(delivered).toBeGreaterThan(0)
+
+  // The toast container renders the warning. The text includes
+  // "Nuclear evict:" prefix from the composable.
+  const toast = page.locator('.toast', { hasText: /Nuclear evict/i })
+  await expect(toast).toBeVisible({ timeout: 5_000 })
+})
+
+test('NPU exclusivity violation surfaces a typed error toast', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  // Pre-seed a model so the dropdown isn't empty.
+  mockState.models.push({
+    id: 'qwen3-1b',
+    name: 'Qwen3 1B',
+    size_gb: 0.6,
+  })
+  mockState.status.slots = [
+    {
+      name: 'agent',
+      kind: 'local',
+      type: 'llm',
+      device: 'npu',
+      backend: 'flm',
+      provider: 'flm',
+      model: 'gemma3-1b',
+      port: 8082,
+      status: 'ready',
+      lemonade_state: 'loaded',
+      coresident_group: 'npu-flm-trio',
+    },
+  ]
+
+  await page.route('**/api/slots', (route) => {
+    const req = route.request()
+    if (req.method() === 'POST') {
+      // Mock the backend rejecting the second NPU LLM slot.
+      return route.fulfill({
+        status: 409,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: {
+            code: 'slot.npu_exclusivity_violation',
+            message:
+              "only one NPU LLM slot may be enabled at a time (slot 'agent-2' would conflict with 'agent')",
+            details: {
+              slot: 'agent-2',
+              conflicting_slots: ['agent'],
+            },
+          },
+        }),
+      })
+    }
+    return json(route, mockState.status.slots)
+  })
+
+  await page.goto('/slots')
+
+  // Open create modal + fill in a name. Backend selection details
+  // depend on the actual modal form; we exercise the error path by
+  // posting whatever the form sends.
+  await page.getByRole('button', { name: /New slot/i }).click()
+  await expect(page.locator('#create-slot-title')).toBeVisible()
+  await page.locator('#slot-name').fill('agent-2')
+
+  // Submit. The mock returns 409 with the typed envelope; the toast
+  // must surface the conflicting-slot message. The modal-footer button
+  // toggles label between "Create slot" and "Creating…"; match either.
+  await page.getByRole('button', { name: /^Create slot$/ }).click()
+
+  const toast = page.locator('.toast', { hasText: /NPU LLM slot|conflict/i })
+  await expect(toast).toBeVisible({ timeout: 5_000 })
+})


### PR DESCRIPTION
## Summary

- `/api/slots` (+ per-slot GET) is enriched with Lemonade-derived state lifted from `/v1/health.loaded[]`: `lemonade_state` (loaded / idle / disabled / error), per-model `backend_url`, and a `coresident_group` marker for the FLM trio (`agent` + `stt-npu` + `embed-npu`). Legacy shape preserved.
- `SlotManager.create()` + `update_config()` now refuse a second `device=npu, type=llm, enabled=true` slot via a typed `NpuExclusivityViolation` (409). Disabled siblings coexist; only enabled anchors are bounded.
- New `/api/lemonade/logs/stream` (raw SSE proxy of lemond's `/logs/stream` WebSocket) and `/api/lemonade/events/stream` (filtered structured events; today only `nuclear_evict`). The dashboard mounts `useNuclearEvictBanner` once at App level to pop a warning toast on every evict-all blast.
- SlotCard renders a small amber "TRIO" chip when `coresident_group` is set so the operator sees the three trio cards back one FLM process at a glance. The create flow surfaces NPU-exclusivity violations both as a toast and inline on the form.

Refs: plan §11 PR-11 + §5 (NPU + FLM trio) + §2.2 + §12.6, ADR-0008 §3 + §5, ADR-0009.

## Test plan

- [x] `pytest tests/` — 1546 passed (1517 baseline + 29 new: 7 NPU exclusivity in `tests/slots/test_npu_exclusivity.py`, 12 list-enrichment in `tests/api/test_slots_lemonade_state.py`, 10 log-filter helpers in `tests/api/test_lemonade_logs_routes.py`).
- [x] `ruff check src tests` + `ruff format --check src tests` — clean.
- [x] `npx playwright test` — 38 passed (4 new in `dashboard-lemonade-state.spec.ts` covering trio badge, non-trio absence, nuclear-evict toast, NPU exclusivity toast).
- [x] `npm run build` — clean rebuild after wiping `dist/` + `node_modules/.vite`.

## Anti-scope (per the briefing)

- No FLM trio direct-port routing (PR-19 owns that).
- No metrics shim (PR-12), admin panel (PR-13), or journal panel content (PR-14 — this PR only exposes the SSE proxy endpoint).
- No `extra.*` namespace, no capabilities.toml schema bumps, no SlotManager API surface churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)