### PR TITLE
feat(metrics): Lemonade /v1/stats + FLM-native metrics shim (PR-12)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -17,6 +17,7 @@ from fastapi import Depends, FastAPI
 
 if TYPE_CHECKING:
     from hal0.lemonade.idle import IdleDriver
+    from hal0.lemonade.metrics_shim import MetricsShim
 
 from hal0 import __version__
 from hal0.api.auth import first_run as first_run_lock
@@ -239,6 +240,47 @@ def _hydrate_upstreams(registry: UpstreamRegistry) -> None:
                 error=str(exc),
                 error_type=type(exc).__name__,
             )
+
+
+async def _start_lemonade_metrics_shim(app: FastAPI) -> MetricsShim | None:
+    """Start the Lemonade metrics shim (PR-12, ADR-0008 §3).
+
+    Polls ``GET /v1/stats`` + ``GET /v1/health`` on a 5s cadence and
+    holds the latest snapshot on ``app.state.lemonade_metrics_shim`` so
+    the ``GET /api/metrics/prometheus`` route can read it synchronously
+    without blocking on a fresh upstream call per scrape.
+
+    Reuses the LemonadeClient attached by the idle driver — sharing the
+    client matches the pattern in :mod:`hal0.dispatcher.router` and
+    avoids opening a second connection pool against lemond. If the idle
+    driver failed to start (no client on app.state), the shim is
+    skipped: the shim is purely observability; a busted Lemonade config
+    must not block API startup.
+
+    Failures here never block lifespan progression — log + continue, the
+    /api/metrics/prometheus endpoint will simply return an empty
+    exposition body until the shim attaches successfully on a future
+    restart.
+    """
+    client = getattr(app.state, "lemonade_client", None)
+    if client is None:
+        log.info("lemonade.metrics.skipped_no_client")
+        return None
+    try:
+        from hal0.lemonade.metrics_shim import MetricsShim
+
+        shim = MetricsShim(client)
+        await shim.start()
+        app.state.lemonade_metrics_shim = shim
+        log.info("lemonade.metrics.shim_attached")
+        return shim
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning(
+            "lemonade.metrics.shim_start_failed",
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return None
 
 
 async def _start_lemonade_idle_driver(app: FastAPI) -> IdleDriver | None:
@@ -495,6 +537,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # the prior ``HAL0_BACKEND=lemonade`` gate retired in PR-10. Stored
     # on app.state so tests + future shutdown hooks can introspect it.
     lemonade_idle_driver = await _start_lemonade_idle_driver(app)
+    # Lemonade metrics shim (PR-12, plan §10.1 + §11). Shares the
+    # ``app.state.lemonade_client`` attached by the idle driver so we
+    # don't double up on connection pools against lemond. Provides the
+    # snapshot the /api/metrics/prometheus route reads.
+    lemonade_metrics_shim = await _start_lemonade_metrics_shim(app)
 
     try:
         async with AsyncExitStack() as stack:
@@ -503,6 +550,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             stack.push_async_callback(_stop_refresh_task)
             yield
     finally:
+        if lemonade_metrics_shim is not None:
+            await lemonade_metrics_shim.stop()
         if lemonade_idle_driver is not None:
             await lemonade_idle_driver.stop()
         await slot_manager.stop_idle_monitor()

--- a/src/hal0/api/routes/health.py
+++ b/src/hal0/api/routes/health.py
@@ -1,17 +1,21 @@
 """Health, status, metrics, features.
 
 Routes mounted under /api:
-  GET  /api/status            — overall liveness + summary (dashboard polls this)
-  GET  /api/health/system     — deep health (slots, disk, ram)
-  GET  /api/metrics           — JSON metrics
-  GET  /api/features          — feature flags
-  PUT  /api/features/{name}   — toggle feature flag
+  GET  /api/status              — overall liveness + summary (dashboard polls this)
+  GET  /api/health/system       — deep health (slots, disk, ram)
+  GET  /api/metrics             — JSON metrics
+  GET  /api/metrics/prometheus  — Prometheus exposition (Lemonade /v1/stats + FLM native)
+  GET  /api/features            — feature flags
+  PUT  /api/features/{name}     — toggle feature flag
 
-Note (issue #36): a /api/metrics/prometheus route was advertised in this
-docstring and in the historical PUBLIC_PATHS allowlist but was never
-implemented. Both stubs are removed until a real prometheus_client-
-backed exporter ships. (PUBLIC_PATHS itself was deleted by ADR-0001
-Child B; routes are now public by virtue of not declaring an auth dep.)
+History (issue #36 → PR-12): the v0.1.x ``/api/metrics/prometheus`` stub
+was deleted by ADR-0001 Child B because the underlying scrape (per-slot
+toolbox /metrics) didn't survive the Lemonade migration (plan §12.1).
+PR-12 re-introduces the route on top of :mod:`hal0.lemonade.metrics_shim`
+— the underlying surfaces are ``GET /v1/stats`` + ``GET /v1/health`` +
+FLM-native fields sniffed from ``POST /v1/chat/completions`` response
+bodies. KV% for GPU/llamacpp slots remains ``—`` in v0.2 (accepted gap,
+plan §12.1).
 """
 
 from __future__ import annotations
@@ -19,6 +23,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, Request
+from fastapi.responses import Response
 
 from hal0 import __version__
 
@@ -94,6 +99,33 @@ async def health_system() -> dict[str, object]:
 @router.get("/metrics")
 async def metrics() -> dict[str, object]:
     return {"slots": {}, "hardware": {}, "dispatcher": {}}
+
+
+@router.get("/metrics/prometheus")
+async def metrics_prometheus(request: Request) -> Response:
+    """Prometheus text-exposition surface (PR-12, plan §10.1 + §11).
+
+    Backed by :class:`hal0.lemonade.metrics_shim.MetricsShim` on
+    ``app.state.lemonade_metrics_shim`` (started in the api lifespan).
+    If the shim isn't attached (e.g. tests bypassing lifespan, or
+    Lemonade unreachable since boot), returns an empty exposition body
+    rather than 500 — Prometheus treats that as "no series", which is
+    the correct "no data yet" state.
+
+    Public route by convention (no auth dependency declared). Operators
+    behind a reverse proxy should restrict ``/api/metrics/prometheus``
+    at the edge if they want to limit scraper access; hal0-internal
+    enforcement would block standard Prometheus scrapers that don't
+    speak hal0's bearer-token auth.
+    """
+    from hal0.lemonade.metrics_shim import MetricsShim
+    from hal0.lemonade.prometheus_format import render_prometheus_exposition
+
+    shim: MetricsShim | None = getattr(request.app.state, "lemonade_metrics_shim", None)
+    snapshot = shim.snapshot() if shim is not None else None
+    body = render_prometheus_exposition(snapshot)
+    # Prometheus text format 0.0.4: ``text/plain; version=0.0.4; charset=utf-8``.
+    return Response(content=body, media_type="text/plain; version=0.0.4; charset=utf-8")
 
 
 @router.get("/features")

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -146,6 +146,50 @@ def _record_nonstreaming_throughput(
     events.append((time.monotonic(), int(completion)))
 
 
+def _record_flm_native_metrics(
+    body_bytes: bytes,
+    app_state: Any,
+    slot_name: str | None,
+    model_name: str | None,
+) -> None:
+    """Sniff FLM-native perf fields from a chat-completion response body.
+
+    PR-12 (plan §11 + §12.1 + memory ``hal0_lemonade_flm_npu_install``).
+    FastFlowLM emits ``decoding_speed_tps`` / ``prefill_speed_tps`` /
+    ``prefill_duration_ttft`` / ``kv_token_occupancy_rate_percentage`` /
+    ``decoding_duration`` INSIDE the chat-completion response body —
+    not via ``/v1/stats``. This hook hands those fields to the
+    MetricsShim's in-memory store so the next /api/metrics/prometheus
+    scrape includes them.
+
+    The discriminator is presence of any FLM field in the payload
+    (handled by ``FlmMetrics.from_payload``). Non-FLM upstreams produce
+    no FLM keys → no-op. This keeps the dispatcher path uncoupled from
+    recipe routing — we don't need to ask "is this slot llamacpp or
+    flm?" before recording; the payload shape answers itself.
+
+    Robust by design: any failure (no shim attached, bad slot/model,
+    unparseable JSON) is silently swallowed so a metrics glitch never
+    affects the user-visible chat response.
+    """
+    shim = getattr(app_state, "lemonade_metrics_shim", None)
+    if shim is None or not body_bytes or not slot_name or not model_name:
+        return
+    try:
+        data = json.loads(body_bytes)
+    except (ValueError, TypeError):
+        return
+    if not isinstance(data, dict):
+        return
+    try:
+        shim.record_flm_metrics(slot_name, model_name, data)
+    except Exception:  # pragma: no cover — defensive
+        # The shim's record_flm_metrics is documented as non-raising,
+        # but we wrap defensively so a future contract slip can't take
+        # down the chat path.
+        return
+
+
 async def _read_json_body(request: Request) -> dict[str, Any]:
     """Best-effort JSON parse.  Empty / malformed bodies become ``{}``.
 
@@ -212,6 +256,18 @@ async def _dispatch_and_forward(
         )
     if isinstance(response, Response) and getattr(response, "body", None):
         _record_nonstreaming_throughput(response.body, request.app.state, call.upstream_name)
+        # PR-12: FLM-native metric ingest. The hook is unconditional —
+        # ``record_flm_metrics`` only acts when the payload carries FLM
+        # fields, so non-FLM upstreams pay only a JSON parse. Streaming
+        # FLM responses (where the same fields land in the final SSE
+        # chunk) are deferred to a follow-up; plan §11 PR-12 scope is
+        # the non-streaming hook + the /v1/stats poll surface.
+        _record_flm_native_metrics(
+            response.body,
+            request.app.state,
+            call.upstream_name,
+            call.resolved_model,
+        )
     return response
 
 

--- a/src/hal0/lemonade/metrics_shim.py
+++ b/src/hal0/lemonade/metrics_shim.py
@@ -1,0 +1,450 @@
+"""Lemonade metrics shim — Prometheus-facing aggregator (PR-12, ADR-0008 §3).
+
+v0.1.x's per-slot ``/metrics`` scrape against each llama-server toolbox is
+gone (plan §10.1 retired the toolbox path in PR-9). v0.2 routes every
+inference through Lemonade, which exposes two perf surfaces:
+
+  * ``GET /v1/stats`` — last-request perf snapshot (TTFT, tok/s,
+    prompt + output tokens). Process-wide; NOT keyed by model. hal0 polls
+    on a 5s cadence and treats it as "most recent observation".
+  * ``GET /v1/health`` — currently loaded model list + per-type budgets
+    (``max_models``). Drives the per-model "loaded" gauge so Prometheus
+    can compute pool occupancy without parsing logs.
+
+FLM/NPU slots are the second source: FastFlowLM emits its own perf
+fields INSIDE ``/v1/chat/completions`` response bodies
+(``decoding_speed_tps``, ``prefill_speed_tps``, ``prefill_duration_ttft``,
+``kv_token_occupancy_rate_percentage``, ``decoding_duration``). The
+shim exposes a public ``record_flm_metrics`` method that the
+chat-completion dispatch hook calls when it sniffs those fields. This
+is the only source of KV% in v0.2 — Lemonade's bundled llama-server
+returns ``null`` for ``n_past`` (plan §12.1), so GPU/llamacpp slots
+display ``—`` until a future llama-server bump or local rebuild.
+
+Design contract (mirrors :mod:`hal0.lemonade.idle`):
+
+  * Background task lifecycle: ``start()`` schedules the poll on the
+    running loop, ``stop()`` cancels and awaits the task. Idempotent.
+  * Resilience: lemond unreachable / 5xx → log + zero metrics for that
+    tick; the driver never crashes. FLM-ingest record path is purely
+    in-memory and cannot fail.
+  * Stateless aside from the latest snapshot. The Prometheus exposition
+    surface (:mod:`hal0.api.routes.metrics`) reads ``snapshot()`` and
+    formats text without coupling to the shim's internal storage.
+
+Plan refs: §10.1 (new module), §11 PR-12, §12.1 (KV% accepted missing
+for GPU slots), ADR-0008 §3. Memory ``hal0_lemonade_flm_npu_install``
+documents the FLM-native field names; matched verbatim here so a
+Lemonade-Server-side rename surfaces as a one-line patch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from hal0.lemonade.client import LemonadeClient
+from hal0.lemonade.errors import (
+    LemonadeError,
+    LemonadeHTTPError,
+    LemonadeTimeoutError,
+    LemonadeUnavailableError,
+)
+
+log = logging.getLogger(__name__)
+
+
+# Defaults intentionally short — Prometheus default scrape interval is
+# 15s, so a 5s poll keeps the shim ahead of the scraper without piling
+# up requests on lemond. Plan §11 PR-12 lists 5s explicitly.
+DEFAULT_POLL_INTERVAL_S: float = 5.0
+
+
+# ── snapshot dataclasses ─────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class StatsSnapshot:
+    """Last-request perf snapshot from ``GET /v1/stats``.
+
+    Lemonade's ``/v1/stats`` is process-wide and per-inference, NOT keyed
+    by model_name (plan §5 api.md research). Treated as a single row of
+    gauges labelled by ``source="last_request"``.
+
+    Field names match Lemonade's ``/v1/stats`` response (research-confirmed
+    schema): ``time_to_first_token`` (s), ``tokens_per_second`` (float),
+    ``input_tokens`` (int), ``output_tokens`` (int), ``prompt_tokens`` (int).
+    Any of these may be missing on a fresh process that hasn't served a
+    request yet; in that case the corresponding gauge is absent from
+    exposition rather than reported as 0 (clearer for dashboards).
+    """
+
+    time_to_first_token: float | None = None
+    tokens_per_second: float | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    prompt_tokens: int | None = None
+
+    @classmethod
+    def from_payload(cls, payload: Any) -> StatsSnapshot:
+        """Best-effort parse of ``/v1/stats`` response shape.
+
+        Accepts the v0.2 documented schema (top-level keys) AND falls
+        back to ``{"last_request": {...}}`` — the existing client test
+        used the nested form, and we want a Lemonade upgrade that
+        switches to either shape to keep working. Bad payloads yield
+        an empty snapshot (nothing emitted).
+        """
+        if not isinstance(payload, dict):
+            return cls()
+        # Prefer the documented top-level keys; if absent, look for a
+        # nested ``last_request`` envelope (older Lemonade builds).
+        body = payload
+        if "time_to_first_token" not in body and isinstance(payload.get("last_request"), dict):
+            body = payload["last_request"]
+        return cls(
+            time_to_first_token=_coerce_float(body.get("time_to_first_token")),
+            tokens_per_second=_coerce_float(body.get("tokens_per_second")),
+            input_tokens=_coerce_int(body.get("input_tokens")),
+            output_tokens=_coerce_int(body.get("output_tokens")),
+            prompt_tokens=_coerce_int(body.get("prompt_tokens")),
+        )
+
+
+@dataclass(frozen=True)
+class HealthSnapshot:
+    """Currently-loaded model list + per-type budgets from ``GET /v1/health``.
+
+    ``loaded_models`` is the set of ``model_name`` strings returned in
+    either ``all_models_loaded[]`` (current Lemonade) or ``loaded[]``
+    (older builds — same dual-accept logic as ``idle.py``).
+    ``max_models`` is the per-type budget dict
+    (``{"llm": 1, "embedding": 1, ...}``) used by the dashboard's
+    "1/2 LLM slots" rendering.
+    """
+
+    loaded_models: tuple[str, ...] = ()
+    max_models: dict[str, int] = field(default_factory=dict)
+
+    @classmethod
+    def from_payload(cls, payload: Any) -> HealthSnapshot:
+        if not isinstance(payload, dict):
+            return cls()
+        loaded_raw: Any = None
+        for key in ("all_models_loaded", "loaded"):
+            v = payload.get(key)
+            if isinstance(v, list):
+                loaded_raw = v
+                break
+        names: list[str] = []
+        if isinstance(loaded_raw, list):
+            for entry in loaded_raw:
+                if isinstance(entry, dict):
+                    name = entry.get("model_name")
+                    if isinstance(name, str) and name:
+                        names.append(name)
+        max_raw = payload.get("max_models")
+        budgets: dict[str, int] = {}
+        if isinstance(max_raw, dict):
+            for k, v in max_raw.items():
+                if isinstance(k, str) and isinstance(v, (int, float)) and not isinstance(v, bool):
+                    budgets[k] = int(v)
+        return cls(loaded_models=tuple(names), max_models=budgets)
+
+
+@dataclass(frozen=True)
+class FlmMetrics:
+    """Native perf fields emitted by FastFlowLM inside
+    ``/v1/chat/completions`` response bodies (memory
+    ``hal0_lemonade_flm_npu_install``).
+
+    All five fields are optional per call — partial payloads still
+    update what's present. ``kv_token_occupancy_rate_percentage`` is
+    the ONLY KV% source in v0.2 (plan §12.1 — GPU slots get ``—``).
+    """
+
+    decoding_speed_tps: float | None = None
+    prefill_speed_tps: float | None = None
+    prefill_duration_ttft: float | None = None
+    kv_token_occupancy_rate_percentage: float | None = None
+    decoding_duration: float | None = None
+
+    @classmethod
+    def from_payload(cls, payload: Any) -> FlmMetrics | None:
+        """Sniff FLM-native fields from a chat-completion response body.
+
+        Returns ``None`` if no FLM field is present — the call site uses
+        that as the recipe discriminator (``payload sans FLM fields ==
+        not a FLM response``). This is cleaner than passing a separate
+        recipe argument from the dispatcher, which would require the
+        hook to resolve recipe per upstream first.
+        """
+        if not isinstance(payload, dict):
+            return None
+        present = any(
+            k in payload
+            for k in (
+                "decoding_speed_tps",
+                "prefill_speed_tps",
+                "prefill_duration_ttft",
+                "kv_token_occupancy_rate_percentage",
+                "decoding_duration",
+            )
+        )
+        if not present:
+            return None
+        return cls(
+            decoding_speed_tps=_coerce_float(payload.get("decoding_speed_tps")),
+            prefill_speed_tps=_coerce_float(payload.get("prefill_speed_tps")),
+            prefill_duration_ttft=_coerce_float(payload.get("prefill_duration_ttft")),
+            kv_token_occupancy_rate_percentage=_coerce_float(
+                payload.get("kv_token_occupancy_rate_percentage")
+            ),
+            decoding_duration=_coerce_float(payload.get("decoding_duration")),
+        )
+
+
+# ── MetricsShim ──────────────────────────────────────────────────────────
+
+
+class MetricsShim:
+    """Background-polled aggregator for Lemonade metrics + FLM-native
+    response-body fields.
+
+    Lifecycle:
+        shim = MetricsShim(client)
+        await shim.start()
+        ...
+        await shim.stop()
+
+    The Prometheus exposition surface (:mod:`hal0.api.routes.metrics`)
+    reads :meth:`snapshot` and renders text. FLM-native fields arrive
+    out-of-band via :meth:`record_flm_metrics` from the v1 chat-completion
+    hook.
+
+    Mirrors :class:`hal0.lemonade.idle.IdleDriver` for task lifecycle —
+    same start/stop contract, same cancellation discipline, same
+    resilience to lemond hiccups.
+    """
+
+    def __init__(
+        self,
+        client: LemonadeClient,
+        *,
+        poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+        clock: Any = time.time,
+    ) -> None:
+        if poll_interval_s <= 0:
+            raise ValueError("poll_interval_s must be > 0")
+        self._client = client
+        self._poll_interval_s = poll_interval_s
+        self._clock = clock
+        self._task: asyncio.Task[None] | None = None
+        self._stopping = asyncio.Event()
+
+        # Snapshots are replaced atomically per tick. Readers (the
+        # /metrics route) grab a reference and format synchronously —
+        # no locking needed because Python's GIL makes the dict swap
+        # atomic and the dataclasses themselves are frozen.
+        self._stats: StatsSnapshot = StatsSnapshot()
+        self._health: HealthSnapshot = HealthSnapshot()
+        # FLM metrics keyed by (slot_name, model_name) so the same
+        # model on two slots stays distinct. Tuple key is hashable and
+        # serialises cleanly in tests. Bounded by the number of FLM
+        # slots; cardinality is small (NPU exclusivity = at most one
+        # FLM trio coresident at a time per plan §5).
+        self._flm: dict[tuple[str, str], FlmMetrics] = {}
+        # Wallclock timestamp of the last successful poll, surfaced as
+        # ``hal0_lemonade_metrics_last_scrape_seconds`` so scrapers
+        # can alert on stale data.
+        self._last_poll_ts: float | None = None
+
+    # ── lifecycle ──────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Schedule the poll task. No-op if already running."""
+        if self._task is not None and not self._task.done():
+            return
+        self._stopping.clear()
+        self._task = asyncio.create_task(self._run(), name="lemonade-metrics-shim")
+        log.info(
+            "lemonade.metrics.started",
+            extra={"poll_interval_s": self._poll_interval_s},
+        )
+
+    async def stop(self) -> None:
+        """Signal the task to exit and await its completion. Idempotent."""
+        if self._task is None:
+            return
+        self._stopping.set()
+        self._task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+        log.info("lemonade.metrics.stopped")
+
+    # ── poll loop ──────────────────────────────────────────────────
+
+    async def _run(self) -> None:
+        try:
+            while not self._stopping.is_set():
+                try:
+                    await self.tick()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:  # pragma: no cover — defensive
+                    log.warning(
+                        "lemonade.metrics.tick_error",
+                        extra={"error": str(exc), "error_type": type(exc).__name__},
+                    )
+                try:
+                    await asyncio.wait_for(self._stopping.wait(), timeout=self._poll_interval_s)
+                except TimeoutError:
+                    continue
+        except asyncio.CancelledError:
+            return
+
+    async def tick(self) -> None:
+        """Run one poll cycle: refresh stats + health snapshots.
+
+        Public so tests can drive the loop deterministically. Never
+        raises — lemond down / 5xx leaves the prior snapshot in place
+        but updates the staleness timestamp (or rather, deliberately
+        does NOT update it, so ``last_scrape_seconds`` drifts and
+        alerts can fire).
+        """
+        stats_ok = await self._refresh_stats()
+        health_ok = await self._refresh_health()
+        if stats_ok or health_ok:
+            self._last_poll_ts = float(self._clock())
+
+    async def _refresh_stats(self) -> bool:
+        try:
+            payload = await self._client.stats()
+        except (LemonadeUnavailableError, LemonadeTimeoutError) as exc:
+            log.debug(
+                "lemonade.metrics.stats_unreachable",
+                extra={"error": str(exc), "error_type": type(exc).__name__},
+            )
+            return False
+        except LemonadeHTTPError as exc:
+            log.warning(
+                "lemonade.metrics.stats_http_error",
+                extra={"status_code": exc.status_code},
+            )
+            return False
+        except LemonadeError as exc:  # pragma: no cover — defensive
+            log.warning("lemonade.metrics.stats_error", extra={"error": str(exc)})
+            return False
+        self._stats = StatsSnapshot.from_payload(payload)
+        return True
+
+    async def _refresh_health(self) -> bool:
+        try:
+            payload = await self._client.health()
+        except (LemonadeUnavailableError, LemonadeTimeoutError) as exc:
+            log.debug(
+                "lemonade.metrics.health_unreachable",
+                extra={"error": str(exc), "error_type": type(exc).__name__},
+            )
+            return False
+        except LemonadeHTTPError as exc:
+            log.warning(
+                "lemonade.metrics.health_http_error",
+                extra={"status_code": exc.status_code},
+            )
+            return False
+        except LemonadeError as exc:  # pragma: no cover — defensive
+            log.warning("lemonade.metrics.health_error", extra={"error": str(exc)})
+            return False
+        self._health = HealthSnapshot.from_payload(payload)
+        return True
+
+    # ── FLM ingest (called from chat-completion dispatch hook) ─────
+
+    def record_flm_metrics(
+        self,
+        slot_name: str,
+        model_name: str,
+        payload: Any,
+    ) -> bool:
+        """Sniff FLM-native fields from a chat-completion response body.
+
+        Returns True if FLM fields were detected and stored, False
+        otherwise. Callers can ignore the return value — the hook is
+        wired unconditionally on every chat completion and only does
+        work when the payload looks like a FLM response.
+
+        Robustness contract: NEVER raises. Bad slot_name / model_name /
+        payload yields a False return; the hook stays a no-op so the
+        chat path is unaffected by metric-collection glitches.
+        """
+        if not isinstance(slot_name, str) or not slot_name:
+            return False
+        if not isinstance(model_name, str) or not model_name:
+            return False
+        metrics = FlmMetrics.from_payload(payload)
+        if metrics is None:
+            return False
+        self._flm[(slot_name, model_name)] = metrics
+        return True
+
+    # ── snapshot accessor ──────────────────────────────────────────
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a serialisable snapshot for the Prometheus exposition
+        route. Frozen dataclasses are converted to plain dicts so the
+        renderer doesn't need to import shim internals.
+        """
+        return {
+            "stats": {
+                "time_to_first_token": self._stats.time_to_first_token,
+                "tokens_per_second": self._stats.tokens_per_second,
+                "input_tokens": self._stats.input_tokens,
+                "output_tokens": self._stats.output_tokens,
+                "prompt_tokens": self._stats.prompt_tokens,
+            },
+            "health": {
+                "loaded_models": list(self._health.loaded_models),
+                "max_models": dict(self._health.max_models),
+            },
+            "flm": {
+                f"{slot}::{model}": {
+                    "decoding_speed_tps": m.decoding_speed_tps,
+                    "prefill_speed_tps": m.prefill_speed_tps,
+                    "prefill_duration_ttft": m.prefill_duration_ttft,
+                    "kv_token_occupancy_rate_percentage": m.kv_token_occupancy_rate_percentage,
+                    "decoding_duration": m.decoding_duration,
+                }
+                for (slot, model), m in self._flm.items()
+            },
+            "last_poll_ts": self._last_poll_ts,
+        }
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+def _coerce_float(value: Any) -> float | None:
+    """Best-effort numeric coerce. ``None`` / ``bool`` / non-numeric → None.
+
+    bool is an int subclass — exclude explicitly so True/False can't
+    masquerade as 1.0/0.0 in a stats payload.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    return None

--- a/src/hal0/lemonade/prometheus_format.py
+++ b/src/hal0/lemonade/prometheus_format.py
@@ -1,0 +1,301 @@
+"""Prometheus text-exposition renderer for :mod:`hal0.lemonade.metrics_shim`.
+
+Kept separate from the shim itself so:
+  * MetricsShim stays focused on aggregation + lifecycle and is easy
+    to unit-test without coupling to text-format quirks.
+  * Adding new gauge families is a one-line append here, not a churn
+    through the snapshot-storage layer.
+  * Future swap to ``prometheus_client`` (currently NOT a hal0
+    dependency — see plan §10.1 minimalism) only touches this module.
+
+Format reference: Prometheus exposition format 0.0.4
+(https://prometheus.io/docs/instrumenting/exposition_formats/). We emit
+only ``# HELP`` / ``# TYPE`` headers and ``gauge`` samples — counters
+are deferred to a later PR (architect.md research note proposed
+``lemonade.load.attempts_total`` + ``lemonade.evict.nuclear_total``,
+not in PR-12 scope).
+
+Metric naming follows the ``hal0_lemonade_<noun>_<unit>`` convention so
+all PR-12 series share a single prefix. Labels use the standard
+``key="value"`` quoting; values are escaped per Prometheus spec
+(backslash, double-quote, newline).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Order matters for human-readable output: HELP/TYPE precede their
+# samples, and we group related families together (stats then health
+# then FLM). The Prometheus parser doesn't care about order, but
+# diffing two scrapes visually is easier when families don't interleave.
+
+
+def render_prometheus_exposition(snapshot: dict[str, Any] | None) -> str:
+    """Render a :meth:`MetricsShim.snapshot` dict as Prometheus text format.
+
+    ``None`` snapshot (shim not yet attached) → empty body. Empty body is
+    a valid Prometheus exposition; scrapers treat it as "no series",
+    which is the correct "no data yet" state on a fresh process before
+    the first poll tick.
+
+    The shim's snapshot may contain ``None`` field values when Lemonade
+    hasn't served a request yet (``/v1/stats`` reports zeros / nulls).
+    We skip ``None`` rows entirely rather than emit ``NaN`` so the
+    dashboard's "—" placeholder is unambiguous (absence ≠ explicit NaN).
+    """
+    if snapshot is None:
+        return ""
+
+    lines: list[str] = []
+    _emit_stats(lines, snapshot.get("stats") or {})
+    _emit_health(lines, snapshot.get("health") or {})
+    _emit_flm(lines, snapshot.get("flm") or {})
+    _emit_last_poll(lines, snapshot.get("last_poll_ts"))
+
+    # Prometheus convention: trailing newline so concatenating
+    # exposition bodies (federation) doesn't accidentally fuse rows.
+    if lines and not lines[-1].endswith("\n"):
+        lines.append("")
+    return "\n".join(lines)
+
+
+# ── /v1/stats family ─────────────────────────────────────────────────
+
+
+def _emit_stats(lines: list[str], stats: dict[str, Any]) -> None:
+    """Emit ``hal0_lemonade_*`` gauges sourced from ``GET /v1/stats``.
+
+    ``/v1/stats`` is process-wide and reports last-request perf; we tag
+    every sample with ``source="last_request"`` so future per-model
+    aggregations (when Lemonade adds per-model stats) can sit alongside
+    without colliding on the unlabelled series.
+    """
+    ttft = stats.get("time_to_first_token")
+    if ttft is not None:
+        _emit_gauge(
+            lines,
+            name="hal0_lemonade_ttft_seconds",
+            help_text="Time to first token from /v1/stats (last request, process-wide).",
+            samples=[({"source": "last_request"}, float(ttft))],
+        )
+
+    tps = stats.get("tokens_per_second")
+    if tps is not None:
+        _emit_gauge(
+            lines,
+            name="hal0_lemonade_decode_tokens_per_second",
+            help_text="Decode tokens-per-second from /v1/stats (last request, process-wide).",
+            samples=[({"source": "last_request"}, float(tps))],
+        )
+
+    prompt_tokens = stats.get("prompt_tokens")
+    if prompt_tokens is not None:
+        _emit_gauge(
+            lines,
+            name="hal0_lemonade_prompt_tokens",
+            help_text="Prompt-token count from /v1/stats (last request, process-wide).",
+            samples=[({"source": "last_request"}, float(prompt_tokens))],
+        )
+
+    output_tokens = stats.get("output_tokens")
+    if output_tokens is not None:
+        # Plan §10.1 calls this ``hal0_lemonade_decode_tokens``; Lemonade
+        # exposes the same number under ``output_tokens`` (research §5).
+        # We follow the plan naming to match the rest of the prefix.
+        _emit_gauge(
+            lines,
+            name="hal0_lemonade_decode_tokens",
+            help_text="Decoded-token count from /v1/stats (last request, process-wide).",
+            samples=[({"source": "last_request"}, float(output_tokens))],
+        )
+
+    input_tokens = stats.get("input_tokens")
+    if input_tokens is not None:
+        _emit_gauge(
+            lines,
+            name="hal0_lemonade_input_tokens",
+            help_text="Input-token count from /v1/stats (last request, process-wide).",
+            samples=[({"source": "last_request"}, float(input_tokens))],
+        )
+
+
+# ── /v1/health family ────────────────────────────────────────────────
+
+
+def _emit_health(lines: list[str], health: dict[str, Any]) -> None:
+    """Emit ``hal0_lemonade_models_loaded`` + ``hal0_lemonade_max_models``."""
+    loaded = health.get("loaded_models") or []
+    if isinstance(loaded, list) and loaded:
+        samples: list[tuple[dict[str, str], float]] = []
+        for name in loaded:
+            if isinstance(name, str) and name:
+                samples.append(({"model_name": name}, 1.0))
+        if samples:
+            _emit_gauge(
+                lines,
+                name="hal0_lemonade_models_loaded",
+                help_text="Set membership: 1 if the model is currently loaded in Lemonade's pool.",
+                samples=samples,
+            )
+
+    max_models = health.get("max_models") or {}
+    if isinstance(max_models, dict) and max_models:
+        samples = []
+        for type_name, budget in sorted(max_models.items()):
+            if not isinstance(type_name, str) or not type_name:
+                continue
+            if isinstance(budget, bool) or not isinstance(budget, (int, float)):
+                continue
+            samples.append(({"type": type_name}, float(budget)))
+        if samples:
+            _emit_gauge(
+                lines,
+                name="hal0_lemonade_max_models",
+                help_text="Per-type concurrent-load budget from /v1/health.max_models.",
+                samples=samples,
+            )
+
+
+# ── FLM native family ────────────────────────────────────────────────
+
+
+def _emit_flm(lines: list[str], flm: dict[str, Any]) -> None:
+    """Emit per-(slot, model) FLM-native gauges.
+
+    Field set matches memory ``hal0_lemonade_flm_npu_install``:
+    ``decoding_speed_tps``, ``prefill_speed_tps``,
+    ``prefill_duration_ttft``, ``kv_token_occupancy_rate_percentage``,
+    ``decoding_duration``.
+    """
+    if not isinstance(flm, dict) or not flm:
+        return
+
+    # Build per-metric sample lists so each metric family emits its
+    # HELP/TYPE header once and groups all label combinations together.
+    by_metric: dict[str, list[tuple[dict[str, str], float]]] = {
+        "decoding_speed_tps": [],
+        "prefill_speed_tps": [],
+        "prefill_duration_ttft": [],
+        "kv_token_occupancy_rate_percentage": [],
+        "decoding_duration": [],
+    }
+
+    for key, payload in flm.items():
+        if not isinstance(key, str) or "::" not in key:
+            continue
+        slot_name, model_name = key.split("::", 1)
+        if not slot_name or not model_name or not isinstance(payload, dict):
+            continue
+        labels = {"slot_name": slot_name, "model_name": model_name}
+        for metric_name, samples in by_metric.items():
+            value = payload.get(metric_name)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                samples.append((labels, float(value)))
+
+    # Metric naming mirrors the /v1/stats family where possible so a
+    # dashboard query for "TTFT" can union both series.
+    families: list[tuple[str, str, str]] = [
+        (
+            "decoding_speed_tps",
+            "hal0_lemonade_flm_decode_tokens_per_second",
+            "FLM native decode tok/s from chat-completion response body.",
+        ),
+        (
+            "prefill_speed_tps",
+            "hal0_lemonade_flm_prefill_tokens_per_second",
+            "FLM native prefill tok/s from chat-completion response body.",
+        ),
+        (
+            "prefill_duration_ttft",
+            "hal0_lemonade_flm_ttft_seconds",
+            "FLM native time to first token from chat-completion response body.",
+        ),
+        (
+            "kv_token_occupancy_rate_percentage",
+            "hal0_lemonade_kv_occupancy_ratio",
+            (
+                "FLM native KV cache occupancy ratio (0-100). "
+                "GPU/llamacpp slots have no KV% in v0.2 (plan §12.1)."
+            ),
+        ),
+        (
+            "decoding_duration",
+            "hal0_lemonade_flm_decode_duration_seconds",
+            "FLM native total decode duration from chat-completion response body.",
+        ),
+    ]
+    for field_key, metric_name, help_text in families:
+        samples = by_metric[field_key]
+        if samples:
+            _emit_gauge(lines, name=metric_name, help_text=help_text, samples=samples)
+
+
+# ── meta family ──────────────────────────────────────────────────────
+
+
+def _emit_last_poll(lines: list[str], last_poll_ts: float | None) -> None:
+    """Emit ``hal0_lemonade_metrics_last_scrape_seconds`` for staleness alerts."""
+    if last_poll_ts is None:
+        return
+    _emit_gauge(
+        lines,
+        name="hal0_lemonade_metrics_last_scrape_seconds",
+        help_text="Wallclock timestamp of the last successful MetricsShim poll.",
+        samples=[({}, float(last_poll_ts))],
+    )
+
+
+# ── low-level text formatting ────────────────────────────────────────
+
+
+def _emit_gauge(
+    lines: list[str],
+    *,
+    name: str,
+    help_text: str,
+    samples: list[tuple[dict[str, str], float]],
+) -> None:
+    """Emit one gauge family — HELP, TYPE, then each sample line.
+
+    Per spec: ``# HELP`` value spans to end-of-line; backslash and
+    newline must be escaped. ``# TYPE`` is one of counter/gauge/etc.
+    Sample format: ``<name>{<label>="<value>",...} <number>``.
+    """
+    lines.append(f"# HELP {name} {_escape_help(help_text)}")
+    lines.append(f"# TYPE {name} gauge")
+    for labels, value in samples:
+        lines.append(f"{name}{_format_labels(labels)} {_format_value(value)}")
+
+
+def _format_labels(labels: dict[str, str]) -> str:
+    """Render a label dict as ``{k="v",...}``. Empty dict → empty string."""
+    if not labels:
+        return ""
+    parts = [f'{k}="{_escape_label_value(v)}"' for k, v in sorted(labels.items())]
+    return "{" + ",".join(parts) + "}"
+
+
+def _escape_help(text: str) -> str:
+    """Escape ``\\`` and newline for HELP lines per the exposition spec."""
+    return text.replace("\\", "\\\\").replace("\n", "\\n")
+
+
+def _escape_label_value(value: str) -> str:
+    """Escape ``\\``, ``"``, and newline for label values per spec."""
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _format_value(value: float) -> str:
+    """Format a numeric sample. Integers stay integer-formatted to match
+    Prometheus convention; floats use repr to preserve precision.
+    """
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, int):
+        return str(value)
+    if value.is_integer():
+        # Match the integer-output convention for whole-number gauges
+        # (token counts, max_models) — easier to eyeball in raw scrapes.
+        return str(int(value))
+    return repr(value)

--- a/tests/api/test_metrics_prometheus_route.py
+++ b/tests/api/test_metrics_prometheus_route.py
@@ -1,0 +1,90 @@
+"""Tests for ``GET /api/metrics/prometheus`` (PR-12).
+
+Validates the integration between the route, the lifespan-attached
+metrics shim, and the text-exposition renderer. The shim itself is
+unit-tested in ``tests/lemonade/test_metrics_shim.py`` — these tests
+focus on the surface contract:
+
+  * The route returns ``text/plain; version=0.0.4`` per Prometheus spec.
+  * A missing shim (lifespan never attached one, e.g. Lemonade
+    unreachable at boot) returns 200 with an empty body — scrapers
+    treat that as "no series".
+  * Synthetic snapshot data round-trips through the route exactly.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from hal0.lemonade.client import LemonadeClient
+from hal0.lemonade.metrics_shim import MetricsShim
+
+
+def test_route_returns_prometheus_content_type(client: TestClient) -> None:
+    """text/plain with the version qualifier is the Prometheus contract.
+
+    Scrapers look for ``version=0.0.4`` to pick the parser; without it
+    some older collectors fall back to a chunked-binary format and
+    silently drop the body.
+    """
+    resp = client.get("/api/metrics/prometheus")
+    assert resp.status_code == 200
+    content_type = resp.headers["content-type"]
+    assert content_type.startswith("text/plain"), content_type
+    assert "version=0.0.4" in content_type
+
+
+def test_route_with_no_shim_returns_empty_body(client: TestClient) -> None:
+    """Lemonade unreachable at boot → no shim on app.state → 200 with
+    empty body. Empty Prometheus exposition = "no series", which is the
+    correct first-boot signal."""
+    # Force the shim off if the lifespan happened to attach one.
+    if hasattr(client.app.state, "lemonade_metrics_shim"):
+        client.app.state.lemonade_metrics_shim = None
+    resp = client.get("/api/metrics/prometheus")
+    assert resp.status_code == 200
+    assert resp.text == ""
+
+
+def test_route_renders_attached_shim_snapshot(client: TestClient) -> None:
+    """When the lifespan attached a working shim, the route serialises its
+    snapshot. We inject a synthetic shim so the test doesn't depend on
+    a live lemond — the integration boundary is "route reads .snapshot()
+    and renders text", which is exactly what we exercise here.
+    """
+    shim = MetricsShim(LemonadeClient())
+    shim._stats = shim._stats.__class__(  # type: ignore[misc]
+        time_to_first_token=0.2,
+        tokens_per_second=42.0,
+        prompt_tokens=128,
+        output_tokens=32,
+        input_tokens=128,
+    )
+    shim._health = shim._health.__class__(  # type: ignore[misc]
+        loaded_models=("qwen3:4b",),
+        max_models={"llm": 1},
+    )
+    shim.record_flm_metrics("agent", "gemma3:1b", {"kv_token_occupancy_rate_percentage": 50.0})
+
+    client.app.state.lemonade_metrics_shim = shim
+    resp = client.get("/api/metrics/prometheus")
+    assert resp.status_code == 200
+    body = resp.text
+    assert 'hal0_lemonade_ttft_seconds{source="last_request"} 0.2' in body
+    assert 'hal0_lemonade_decode_tokens_per_second{source="last_request"} 42' in body
+    assert 'hal0_lemonade_models_loaded{model_name="qwen3:4b"} 1' in body
+    assert 'hal0_lemonade_max_models{type="llm"} 1' in body
+    assert 'hal0_lemonade_kv_occupancy_ratio{model_name="gemma3:1b",slot_name="agent"} 50' in body
+
+
+def test_route_is_public(client: TestClient) -> None:
+    """Like /api/status + /api/metrics, the Prometheus surface is public.
+
+    Auth-gating would block standard Prometheus scrapers that don't
+    speak hal0's bearer-token auth. Operators harden via a reverse
+    proxy if they want to limit scraper access. Verified by hitting
+    the route without any Authorization header.
+    """
+    resp = client.get("/api/metrics/prometheus")
+    # 200 even without credentials — public route.
+    assert resp.status_code == 200

--- a/tests/api/test_v1_flm_metrics_ingest.py
+++ b/tests/api/test_v1_flm_metrics_ingest.py
@@ -1,0 +1,104 @@
+"""Tests for the FLM-native metric ingest hook on chat-completion responses.
+
+PR-12 (plan §11 + memory ``hal0_lemonade_flm_npu_install``). The hook
+lives in :func:`hal0.api.routes.v1._record_flm_native_metrics` and is
+wired into ``_dispatch_and_forward`` for non-streaming responses. The
+contract:
+
+  * A response body carrying FLM native fields → shim records by
+    (slot, model). The next /api/metrics/prometheus scrape includes them.
+  * A non-FLM response (no FLM keys present) → no-op.
+  * A missing shim on app.state → no-op (graceful early-boot path).
+  * Unparseable body bytes → no-op (no metric collection should ever
+    crash the user-visible chat path).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from hal0.api.routes.v1 import _record_flm_native_metrics
+from hal0.lemonade.client import LemonadeClient
+from hal0.lemonade.metrics_shim import MetricsShim
+
+
+class _FakeAppState:
+    """Minimal stand-in for ``request.app.state`` — the hook only reads
+    ``lemonade_metrics_shim``. A plain object lets the test inject a real
+    or absent shim without spinning up the full FastAPI app."""
+
+    lemonade_metrics_shim: MetricsShim | None
+
+
+def _state(shim: MetricsShim | None) -> Any:
+    s = _FakeAppState()
+    s.lemonade_metrics_shim = shim
+    return s
+
+
+def test_flm_response_body_lands_in_shim() -> None:
+    """A response carrying ``decoding_speed_tps`` + ``kv_token_occupancy_rate_percentage``
+    is sniffed and recorded under (slot, model)."""
+    shim = MetricsShim(LemonadeClient())
+    body = json.dumps(
+        {
+            "id": "chat-xyz",
+            "decoding_speed_tps": 40.7,
+            "prefill_speed_tps": 320.1,
+            "prefill_duration_ttft": 0.09,
+            "kv_token_occupancy_rate_percentage": 12.5,
+            "decoding_duration": 3.4,
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": ""}}],
+        }
+    ).encode()
+    _record_flm_native_metrics(body, _state(shim), "agent", "gemma3:1b")
+    flm = shim.snapshot()["flm"]
+    assert "agent::gemma3:1b" in flm
+    assert flm["agent::gemma3:1b"]["kv_token_occupancy_rate_percentage"] == pytest.approx(12.5)
+
+
+def test_non_flm_response_body_is_noop() -> None:
+    """A standard OpenAI chat-completion body (no FLM keys) records nothing."""
+    shim = MetricsShim(LemonadeClient())
+    body = json.dumps(
+        {
+            "id": "chat-abc",
+            "object": "chat.completion",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}}],
+            "usage": {"completion_tokens": 5, "prompt_tokens": 10, "total_tokens": 15},
+        }
+    ).encode()
+    _record_flm_native_metrics(body, _state(shim), "primary", "qwen3:4b")
+    assert shim.snapshot()["flm"] == {}
+
+
+def test_missing_shim_is_noop() -> None:
+    """Lifespan-detached state (no shim attached) is fine — early-boot path."""
+    body = json.dumps({"decoding_speed_tps": 1.0}).encode()
+    # Must not raise even though there's no shim to record into.
+    _record_flm_native_metrics(body, _state(None), "agent", "gemma3:1b")
+
+
+def test_unparseable_body_is_noop() -> None:
+    """Defensive: a non-JSON body (or a JSON list) is silently dropped so
+    the user-visible chat response is unaffected by metric glitches."""
+    shim = MetricsShim(LemonadeClient())
+    _record_flm_native_metrics(b"not json", _state(shim), "agent", "g")
+    _record_flm_native_metrics(b"[]", _state(shim), "agent", "g")
+    _record_flm_native_metrics(b"", _state(shim), "agent", "g")
+    assert shim.snapshot()["flm"] == {}
+
+
+def test_missing_slot_or_model_is_noop() -> None:
+    """The hook is called from the dispatcher; not every dispatch resolves
+    to a slot+model (e.g. /v1/models passthrough). Empty strings → no-op."""
+    shim = MetricsShim(LemonadeClient())
+    body = json.dumps({"decoding_speed_tps": 1.0}).encode()
+    _record_flm_native_metrics(body, _state(shim), "", "model")
+    _record_flm_native_metrics(body, _state(shim), "slot", "")
+    _record_flm_native_metrics(body, _state(shim), None, "model")
+    _record_flm_native_metrics(body, _state(shim), "slot", None)
+    assert shim.snapshot()["flm"] == {}

--- a/tests/lemonade/test_metrics_shim.py
+++ b/tests/lemonade/test_metrics_shim.py
@@ -1,0 +1,486 @@
+"""Unit tests for ``hal0.lemonade.metrics_shim`` (PR-12, plan §11 + §10.1).
+
+Contract:
+
+  * One poll cycle refreshes both stats + health snapshots independently.
+  * Lemonade unreachable / 5xx leaves the prior snapshot in place and
+    does NOT advance the staleness timestamp.
+  * Snapshot exposes the most recent observation (frozen between polls).
+  * ``record_flm_metrics`` only stores when FLM-native fields are
+    present in the payload; missing fields → no-op.
+  * KV% is recorded ONLY via FLM ingest (plan §12.1: GPU/llamacpp slots
+    get ``—`` in v0.2).
+  * Per-(slot, model) FLM keys stay distinct.
+  * Lifecycle: start/stop is idempotent and cancellation propagates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from hal0.lemonade.client import LemonadeClient
+from hal0.lemonade.metrics_shim import (
+    DEFAULT_POLL_INTERVAL_S,
+    FlmMetrics,
+    HealthSnapshot,
+    MetricsShim,
+    StatsSnapshot,
+)
+
+
+def _mock_transport(handler):
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://test")
+
+
+# ── construction / lifecycle ─────────────────────────────────────────
+
+
+def test_default_poll_interval_is_documented() -> None:
+    """The default cadence is published as a module constant so tests +
+    the lifespan wiring agree on the value without duplicating it."""
+    assert DEFAULT_POLL_INTERVAL_S == 5.0
+
+
+def test_zero_poll_interval_rejected() -> None:
+    """Negative/zero intervals are a programmer error, not a runtime risk."""
+    client = LemonadeClient()
+    with pytest.raises(ValueError, match="poll_interval_s must be > 0"):
+        MetricsShim(client, poll_interval_s=0.0)
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent() -> None:
+    """Calling start twice doesn't spawn a second task."""
+
+    def h(req: httpx.Request) -> httpx.Response:
+        # Drive both endpoints so the tick doesn't log warnings.
+        if req.url.path == "/v1/stats":
+            return httpx.Response(200, json={})
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json={})
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        shim = MetricsShim(client, poll_interval_s=DEFAULT_POLL_INTERVAL_S)
+        await shim.start()
+        first_task = shim._task
+        await shim.start()
+        assert shim._task is first_task
+        await shim.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_without_start_is_noop() -> None:
+    """Defensive shutdown path — finally blocks call stop unconditionally."""
+    shim = MetricsShim(LemonadeClient())
+    await shim.stop()  # must not raise
+
+
+# ── /v1/stats refresh ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tick_refreshes_stats_with_documented_schema() -> None:
+    """Top-level v0.2 schema: time_to_first_token / tokens_per_second / ..."""
+    payload = {
+        "time_to_first_token": 0.213,
+        "tokens_per_second": 42.5,
+        "input_tokens": 1024,
+        "output_tokens": 256,
+        "prompt_tokens": 1024,
+    }
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/stats":
+            return httpx.Response(200, json=payload)
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json={})
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        shim = MetricsShim(client)
+        await shim.tick()
+        snap = shim.snapshot()
+        assert snap["stats"]["time_to_first_token"] == pytest.approx(0.213)
+        assert snap["stats"]["tokens_per_second"] == pytest.approx(42.5)
+        assert snap["stats"]["input_tokens"] == 1024
+        assert snap["stats"]["output_tokens"] == 256
+        assert snap["stats"]["prompt_tokens"] == 1024
+
+
+@pytest.mark.asyncio
+async def test_tick_tolerates_nested_last_request_envelope() -> None:
+    """An older Lemonade returned ``{"last_request": {...}}``; accept both."""
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/stats":
+            return httpx.Response(
+                200,
+                json={
+                    "last_request": {
+                        "time_to_first_token": 0.4,
+                        "tokens_per_second": 30.0,
+                    }
+                },
+            )
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json={})
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        shim = MetricsShim(client)
+        await shim.tick()
+        snap = shim.snapshot()
+        assert snap["stats"]["time_to_first_token"] == pytest.approx(0.4)
+        assert snap["stats"]["tokens_per_second"] == pytest.approx(30.0)
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_stats_fields_that_are_absent() -> None:
+    """Missing fields stay absent (None) rather than zero — clearer for dashboards."""
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/stats":
+            return httpx.Response(200, json={"tokens_per_second": 10.0})
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json={})
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        shim = MetricsShim(client)
+        await shim.tick()
+        snap = shim.snapshot()
+        assert snap["stats"]["tokens_per_second"] == pytest.approx(10.0)
+        assert snap["stats"]["time_to_first_token"] is None
+        assert snap["stats"]["input_tokens"] is None
+
+
+# ── /v1/health refresh ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tick_refreshes_health_loaded_and_max_models() -> None:
+    """all_models_loaded[] + max_models per type are both surfaced."""
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/stats":
+            return httpx.Response(200, json={})
+        if req.url.path == "/v1/health":
+            return httpx.Response(
+                200,
+                json={
+                    "all_models_loaded": [
+                        {"model_name": "qwen3:4b", "backend_url": "http://127.0.0.1:9101"},
+                        {"model_name": "embed-gemma", "backend_url": "http://127.0.0.1:9102"},
+                    ],
+                    "max_models": {"llm": 1, "embedding": 1, "reranking": 1},
+                },
+            )
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        shim = MetricsShim(client)
+        await shim.tick()
+        snap = shim.snapshot()
+        assert snap["health"]["loaded_models"] == ["qwen3:4b", "embed-gemma"]
+        assert snap["health"]["max_models"] == {"llm": 1, "embedding": 1, "reranking": 1}
+
+
+@pytest.mark.asyncio
+async def test_tick_accepts_legacy_loaded_field_name() -> None:
+    """Older Lemonade builds called the list ``loaded`` (matches idle driver)."""
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/stats":
+            return httpx.Response(200, json={})
+        if req.url.path == "/v1/health":
+            return httpx.Response(
+                200,
+                json={"loaded": [{"model_name": "legacy-name"}]},
+            )
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        shim = MetricsShim(client)
+        await shim.tick()
+        snap = shim.snapshot()
+        assert snap["health"]["loaded_models"] == ["legacy-name"]
+
+
+@pytest.mark.asyncio
+async def test_tick_handles_empty_loaded_list() -> None:
+    """Empty pool → no per-model metrics, no exception."""
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/stats":
+            return httpx.Response(200, json={})
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json={"all_models_loaded": [], "max_models": {}})
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        shim = MetricsShim(client)
+        await shim.tick()
+        snap = shim.snapshot()
+        assert snap["health"]["loaded_models"] == []
+        assert snap["health"]["max_models"] == {}
+
+
+# ── unreachable lemond ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tick_swallows_unreachable_lemond() -> None:
+    """Connection refusal does not raise — prior snapshot survives."""
+
+    def h(_req: httpx.Request) -> httpx.Response:
+        # MockTransport raises ConnectError when the handler raises
+        raise httpx.ConnectError("simulated")
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        shim = MetricsShim(client)
+        await shim.tick()  # must not raise
+        snap = shim.snapshot()
+        assert snap["stats"]["tokens_per_second"] is None
+        assert snap["health"]["loaded_models"] == []
+        # last_poll_ts must NOT advance when neither endpoint succeeded
+        # — that's how dashboards detect staleness.
+        assert snap["last_poll_ts"] is None
+
+
+@pytest.mark.asyncio
+async def test_tick_swallows_5xx() -> None:
+    """5xx leaves the snapshot untouched and doesn't crash the driver."""
+
+    def h(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="busy")
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        shim = MetricsShim(client)
+        await shim.tick()
+        snap = shim.snapshot()
+        assert snap["last_poll_ts"] is None
+
+
+# ── snapshot freezing / monotonic timestamp ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_last_poll_ts_advances_only_on_success() -> None:
+    """Timestamp tracks the most recent successful poll for staleness alerts."""
+
+    call_count = {"n": 0}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/stats":
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return httpx.Response(200, json={"tokens_per_second": 1.0})
+            # Second call: simulate lemond crash mid-test.
+            return httpx.Response(503, text="down")
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json={})
+        return httpx.Response(404)
+
+    clock_values = iter([100.0, 200.0, 300.0])
+    clock = lambda: next(clock_values)  # noqa: E731
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        shim = MetricsShim(client, clock=clock)
+        await shim.tick()  # success → ts = 100
+        first_ts = shim.snapshot()["last_poll_ts"]
+        assert first_ts == 100.0
+        await shim.tick()  # stats 5xx + health ok → still updates
+        second_ts = shim.snapshot()["last_poll_ts"]
+        assert second_ts == 200.0
+
+
+# ── FLM ingest ───────────────────────────────────────────────────────
+
+
+def test_record_flm_metrics_stores_when_fields_present() -> None:
+    """All five documented fields end up in the snapshot, keyed by slot+model."""
+    shim = MetricsShim(LemonadeClient())
+    body = {
+        "id": "chat-xyz",
+        "decoding_speed_tps": 40.7,
+        "prefill_speed_tps": 320.1,
+        "prefill_duration_ttft": 0.087,
+        "kv_token_occupancy_rate_percentage": 12.5,
+        "decoding_duration": 3.4,
+        "choices": [],  # ignored
+    }
+    assert shim.record_flm_metrics("agent", "gemma3:1b", body) is True
+    snap = shim.snapshot()
+    flm = snap["flm"]["agent::gemma3:1b"]
+    assert flm["decoding_speed_tps"] == pytest.approx(40.7)
+    assert flm["prefill_speed_tps"] == pytest.approx(320.1)
+    assert flm["prefill_duration_ttft"] == pytest.approx(0.087)
+    assert flm["kv_token_occupancy_rate_percentage"] == pytest.approx(12.5)
+    assert flm["decoding_duration"] == pytest.approx(3.4)
+
+
+def test_record_flm_metrics_partial_payload_is_stored() -> None:
+    """A response missing some FLM fields still records the ones that are present."""
+    shim = MetricsShim(LemonadeClient())
+    body = {"kv_token_occupancy_rate_percentage": 99.0}
+    assert shim.record_flm_metrics("npu-chat", "model", body) is True
+    flm = shim.snapshot()["flm"]["npu-chat::model"]
+    assert flm["kv_token_occupancy_rate_percentage"] == pytest.approx(99.0)
+    # Missing fields stay None — the renderer skips them.
+    assert flm["decoding_speed_tps"] is None
+    assert flm["prefill_speed_tps"] is None
+
+
+def test_record_flm_metrics_skips_non_flm_payloads() -> None:
+    """A llamacpp chat-completion response has none of the FLM fields →
+    no-op. This is the recipe discriminator — the hook is wired
+    unconditionally on every completion."""
+    shim = MetricsShim(LemonadeClient())
+    body = {
+        "id": "chat-abc",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}}],
+        "usage": {"completion_tokens": 5, "prompt_tokens": 10},
+    }
+    assert shim.record_flm_metrics("primary", "qwen3:4b", body) is False
+    assert shim.snapshot()["flm"] == {}
+
+
+def test_record_flm_metrics_rejects_bad_inputs() -> None:
+    """Non-string slot/model + non-dict payload → False, no exception."""
+    shim = MetricsShim(LemonadeClient())
+    assert shim.record_flm_metrics("", "model", {"decoding_speed_tps": 1.0}) is False
+    assert shim.record_flm_metrics("slot", "", {"decoding_speed_tps": 1.0}) is False
+    # type: ignore on the bad-input cases mirrors real-world misuse.
+    assert shim.record_flm_metrics("slot", "model", "not a dict") is False  # type: ignore[arg-type]
+    assert shim.record_flm_metrics("slot", "model", None) is False
+    assert shim.snapshot()["flm"] == {}
+
+
+def test_record_flm_metrics_keeps_slots_distinct() -> None:
+    """Same model on two slots → two distinct entries; no overwrite."""
+    shim = MetricsShim(LemonadeClient())
+    shim.record_flm_metrics("agent", "gemma3:1b", {"decoding_speed_tps": 40.0})
+    shim.record_flm_metrics("stt-npu", "gemma3:1b", {"decoding_speed_tps": 30.0})
+    flm = shim.snapshot()["flm"]
+    assert flm["agent::gemma3:1b"]["decoding_speed_tps"] == pytest.approx(40.0)
+    assert flm["stt-npu::gemma3:1b"]["decoding_speed_tps"] == pytest.approx(30.0)
+
+
+def test_record_flm_metrics_latest_observation_wins() -> None:
+    """Repeated calls for the same (slot, model) overwrite — the snapshot
+    is "most recent FLM response", not a rolling history."""
+    shim = MetricsShim(LemonadeClient())
+    shim.record_flm_metrics("agent", "g", {"decoding_speed_tps": 1.0})
+    shim.record_flm_metrics("agent", "g", {"decoding_speed_tps": 2.0})
+    assert shim.snapshot()["flm"]["agent::g"]["decoding_speed_tps"] == pytest.approx(2.0)
+
+
+# ── KV% behaviour (plan §12.1) ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_kv_occupancy_is_absent_for_llamacpp_slots() -> None:
+    """Plan §12.1: no KV% for GPU/llamacpp slots in v0.2. The /v1/stats
+    payload never carries the FLM field, so the snapshot has no FLM
+    entry for a llamacpp-only flow."""
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/stats":
+            return httpx.Response(
+                200,
+                json={"time_to_first_token": 0.2, "tokens_per_second": 25.0},
+            )
+        if req.url.path == "/v1/health":
+            return httpx.Response(
+                200,
+                json={"all_models_loaded": [{"model_name": "qwen3:4b"}], "max_models": {"llm": 1}},
+            )
+        return httpx.Response(404)
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        shim = MetricsShim(client)
+        await shim.tick()
+        snap = shim.snapshot()
+        # /v1/stats produced TTFT + tok/s.
+        assert snap["stats"]["time_to_first_token"] is not None
+        assert snap["stats"]["tokens_per_second"] is not None
+        # But NO FLM entry exists → no KV% in exposition.
+        assert snap["flm"] == {}
+
+
+# ── dataclass parsing helpers ────────────────────────────────────────
+
+
+def test_stats_snapshot_rejects_non_dict_payload() -> None:
+    """Defensive: list / string / None all yield an empty snapshot."""
+    assert StatsSnapshot.from_payload(None) == StatsSnapshot()
+    assert StatsSnapshot.from_payload([1, 2, 3]) == StatsSnapshot()
+    assert StatsSnapshot.from_payload("oops") == StatsSnapshot()
+
+
+def test_health_snapshot_skips_non_string_model_names() -> None:
+    """An entry without a usable model_name is silently dropped."""
+    payload = {
+        "all_models_loaded": [
+            {"model_name": "good"},
+            {"model_name": 42},  # numeric — dropped
+            {"backend_url": "http://x"},  # missing model_name — dropped
+            "not-a-dict",  # not a dict — dropped
+            {"model_name": ""},  # empty string — dropped
+        ]
+    }
+    snap = HealthSnapshot.from_payload(payload)
+    assert snap.loaded_models == ("good",)
+
+
+def test_health_snapshot_filters_bad_max_models_values() -> None:
+    """max_models with bool / string values is rejected per-entry."""
+    payload = {
+        "max_models": {"llm": 2, "embedding": True, "extra": "not-a-number", "image": 1},
+    }
+    snap = HealthSnapshot.from_payload(payload)
+    assert snap.max_models == {"llm": 2, "image": 1}
+
+
+def test_flm_metrics_returns_none_without_fields() -> None:
+    """The discriminator: no FLM key → no entry."""
+    assert FlmMetrics.from_payload({"id": "x", "choices": []}) is None
+    assert FlmMetrics.from_payload({}) is None
+    assert FlmMetrics.from_payload("not a dict") is None
+
+
+# ── _run() loop cancellation ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_loop_exits_cleanly_on_stop() -> None:
+    """Cancellation must propagate through _run; stop() awaits the task."""
+
+    def h(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        # Short poll so the loop spends most of its time in the
+        # ``wait_for(stopping.wait, ...)`` sleep — cancellation must
+        # come out cleanly from there.
+        shim = MetricsShim(client, poll_interval_s=0.01)
+        await shim.start()
+        await asyncio.sleep(0.05)  # let at least one tick land
+        await shim.stop()
+        assert shim._task is None

--- a/tests/lemonade/test_prometheus_format.py
+++ b/tests/lemonade/test_prometheus_format.py
@@ -1,0 +1,249 @@
+"""Renderer tests for ``hal0.lemonade.prometheus_format`` (PR-12).
+
+Validates the exposition format against the Prometheus 0.0.4 spec:
+  * One HELP + one TYPE per metric family.
+  * Sample order is deterministic (sorted labels).
+  * Absent fields produce no sample line (avoids ``NaN`` confusion).
+  * Label values are escaped for backslash/quote/newline.
+"""
+
+from __future__ import annotations
+
+from hal0.lemonade.prometheus_format import render_prometheus_exposition
+
+
+def _families(text: str) -> dict[str, list[str]]:
+    """Group exposition output by metric family for assertion convenience.
+
+    Returns ``{metric_name: [sample_line, ...]}``. HELP + TYPE headers
+    are stripped (covered by their own assertions).
+    """
+    families: dict[str, list[str]] = {}
+    for line in text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        # sample line: ``<name>{...} <value>`` OR ``<name> <value>``
+        name = line.split("{", 1)[0].split(" ", 1)[0]
+        families.setdefault(name, []).append(line)
+    return families
+
+
+def test_none_snapshot_returns_empty_body() -> None:
+    """A missing shim (lifespan didn't run) → empty body, not 500. Valid
+    Prometheus exposition: empty input = "no series", scrapers tolerate."""
+    assert render_prometheus_exposition(None) == ""
+
+
+def test_empty_snapshot_returns_empty_body() -> None:
+    """Snapshot present but every field is empty/None → no samples emitted."""
+    snap = {
+        "stats": {
+            "time_to_first_token": None,
+            "tokens_per_second": None,
+            "input_tokens": None,
+            "output_tokens": None,
+            "prompt_tokens": None,
+        },
+        "health": {"loaded_models": [], "max_models": {}},
+        "flm": {},
+        "last_poll_ts": None,
+    }
+    assert render_prometheus_exposition(snap) == ""
+
+
+def test_emits_stats_family_with_help_and_type() -> None:
+    snap = {
+        "stats": {
+            "time_to_first_token": 0.213,
+            "tokens_per_second": 42.5,
+            "input_tokens": 1024,
+            "output_tokens": 256,
+            "prompt_tokens": 1024,
+        },
+        "health": {"loaded_models": [], "max_models": {}},
+        "flm": {},
+        "last_poll_ts": None,
+    }
+    text = render_prometheus_exposition(snap)
+    # HELP / TYPE for each gauge family.
+    assert "# HELP hal0_lemonade_ttft_seconds" in text
+    assert "# TYPE hal0_lemonade_ttft_seconds gauge" in text
+    assert "# HELP hal0_lemonade_decode_tokens_per_second" in text
+    assert "# TYPE hal0_lemonade_decode_tokens_per_second gauge" in text
+    # Samples carry the source label.
+    families = _families(text)
+    assert (
+        'hal0_lemonade_ttft_seconds{source="last_request"} 0.213'
+        in families["hal0_lemonade_ttft_seconds"]
+    )
+    assert (
+        'hal0_lemonade_decode_tokens_per_second{source="last_request"} 42.5'
+        in families["hal0_lemonade_decode_tokens_per_second"]
+    )
+    # Integer-valued gauges format without trailing .0.
+    assert (
+        'hal0_lemonade_prompt_tokens{source="last_request"} 1024'
+        in families["hal0_lemonade_prompt_tokens"]
+    )
+
+
+def test_emits_models_loaded_one_sample_per_model() -> None:
+    snap = {
+        "stats": {},
+        "health": {
+            "loaded_models": ["qwen3:4b", "embed-gemma"],
+            "max_models": {"llm": 1, "embedding": 1},
+        },
+        "flm": {},
+        "last_poll_ts": None,
+    }
+    text = render_prometheus_exposition(snap)
+    families = _families(text)
+    loaded = families["hal0_lemonade_models_loaded"]
+    assert 'hal0_lemonade_models_loaded{model_name="qwen3:4b"} 1' in loaded
+    assert 'hal0_lemonade_models_loaded{model_name="embed-gemma"} 1' in loaded
+    assert len(loaded) == 2
+
+
+def test_emits_max_models_one_sample_per_type() -> None:
+    snap = {
+        "stats": {},
+        "health": {
+            "loaded_models": [],
+            "max_models": {"llm": 1, "embedding": 1, "transcription": 1},
+        },
+        "flm": {},
+        "last_poll_ts": None,
+    }
+    text = render_prometheus_exposition(snap)
+    families = _families(text)
+    max_lines = families["hal0_lemonade_max_models"]
+    assert 'hal0_lemonade_max_models{type="embedding"} 1' in max_lines
+    assert 'hal0_lemonade_max_models{type="llm"} 1' in max_lines
+    assert 'hal0_lemonade_max_models{type="transcription"} 1' in max_lines
+    # Sorted output: ``embedding`` before ``llm`` before ``transcription``.
+    indices = [
+        max_lines.index('hal0_lemonade_max_models{type="embedding"} 1'),
+        max_lines.index('hal0_lemonade_max_models{type="llm"} 1'),
+        max_lines.index('hal0_lemonade_max_models{type="transcription"} 1'),
+    ]
+    assert indices == sorted(indices)
+
+
+def test_emits_flm_family_with_slot_and_model_labels() -> None:
+    snap = {
+        "stats": {},
+        "health": {"loaded_models": [], "max_models": {}},
+        "flm": {
+            "agent::gemma3:1b": {
+                "decoding_speed_tps": 40.7,
+                "prefill_speed_tps": 320.1,
+                "prefill_duration_ttft": 0.087,
+                "kv_token_occupancy_rate_percentage": 12.5,
+                "decoding_duration": 3.4,
+            }
+        },
+        "last_poll_ts": None,
+    }
+    text = render_prometheus_exposition(snap)
+    families = _families(text)
+    # Each FLM metric family maps to its own hal0_lemonade_flm_* name.
+    assert (
+        'hal0_lemonade_flm_decode_tokens_per_second{model_name="gemma3:1b",slot_name="agent"} 40.7'
+        in families["hal0_lemonade_flm_decode_tokens_per_second"]
+    )
+    assert (
+        'hal0_lemonade_kv_occupancy_ratio{model_name="gemma3:1b",slot_name="agent"} 12.5'
+        in families["hal0_lemonade_kv_occupancy_ratio"]
+    )
+    assert (
+        'hal0_lemonade_flm_ttft_seconds{model_name="gemma3:1b",slot_name="agent"} 0.087'
+        in families["hal0_lemonade_flm_ttft_seconds"]
+    )
+
+
+def test_flm_skips_missing_fields_in_partial_payload() -> None:
+    """Only the fields actually present emit samples — partial payloads
+    don't pollute the exposition with absent-metric placeholders."""
+    snap = {
+        "stats": {},
+        "health": {"loaded_models": [], "max_models": {}},
+        "flm": {
+            "agent::g": {
+                "decoding_speed_tps": None,
+                "prefill_speed_tps": None,
+                "prefill_duration_ttft": None,
+                "kv_token_occupancy_rate_percentage": 50.0,
+                "decoding_duration": None,
+            }
+        },
+        "last_poll_ts": None,
+    }
+    text = render_prometheus_exposition(snap)
+    # Only the KV% family appears.
+    assert "hal0_lemonade_kv_occupancy_ratio" in text
+    assert "hal0_lemonade_flm_decode_tokens_per_second" not in text
+    assert "hal0_lemonade_flm_prefill_tokens_per_second" not in text
+
+
+def test_emits_last_scrape_timestamp_for_staleness_alerts() -> None:
+    """``hal0_lemonade_metrics_last_scrape_seconds`` is meta — no labels."""
+    snap = {
+        "stats": {},
+        "health": {"loaded_models": [], "max_models": {}},
+        "flm": {},
+        "last_poll_ts": 1_700_000_000.5,
+    }
+    text = render_prometheus_exposition(snap)
+    assert "hal0_lemonade_metrics_last_scrape_seconds" in text
+    # No label set on the meta gauge.
+    assert "\nhal0_lemonade_metrics_last_scrape_seconds 1700000000.5" in text
+
+
+def test_label_values_escape_quote_and_backslash() -> None:
+    """A pathological model name with quotes must round-trip safely."""
+    snap = {
+        "stats": {},
+        "health": {
+            "loaded_models": ['weird"name\\with-special'],
+            "max_models": {},
+        },
+        "flm": {},
+        "last_poll_ts": None,
+    }
+    text = render_prometheus_exposition(snap)
+    # Backslash-escape both the embedded quote and backslash.
+    assert 'hal0_lemonade_models_loaded{model_name="weird\\"name\\\\with-special"} 1' in text
+
+
+def test_help_text_escapes_backslash_and_newline() -> None:
+    """Defensive — none of our HELPs carry these, but the renderer must
+    handle them per the spec so a future maintainer doesn't introduce
+    a parser-breaking string by accident."""
+    # Exercise via a synthetic snapshot that includes a backslash in
+    # a model name (the HELP text itself is hardcoded; this test pins
+    # the escape helper's behaviour through label flow).
+    snap = {
+        "stats": {},
+        "health": {"loaded_models": ["a\nb"], "max_models": {}},
+        "flm": {},
+        "last_poll_ts": None,
+    }
+    text = render_prometheus_exposition(snap)
+    # The label value must NOT contain a raw newline — that would
+    # split the sample line and corrupt the exposition.
+    assert 'model_name="a\\nb"' in text
+    assert 'model_name="a\nb"' not in text
+
+
+def test_renderer_trailing_newline_for_safe_concatenation() -> None:
+    """Federation / aggregation concatenates bodies — a trailing newline
+    on each prevents fusing two distinct rows."""
+    snap = {
+        "stats": {"tokens_per_second": 1.0},
+        "health": {"loaded_models": [], "max_models": {}},
+        "flm": {},
+        "last_poll_ts": None,
+    }
+    text = render_prometheus_exposition(snap)
+    assert text.endswith("\n")


### PR DESCRIPTION
## Summary

Phase 4 PR-12 of the v0.2 Lemonade migration. Re-establishes hal0's
Prometheus surface after PR-9 retired the v0.1.x per-slot toolbox
``/metrics`` scrape. Two sources are aggregated:

- **`/v1/stats` + `/v1/health` polling** (5s cadence) via a new
  ``MetricsShim`` background task — TTFT, decode tok/s, prompt + decode
  token counts; per-loaded-model "loaded" gauge; per-type
  ``max_models`` budget.
- **FLM-native ingest** for NPU slots — ``decoding_speed_tps``,
  ``prefill_speed_tps``, ``prefill_duration_ttft``,
  ``kv_token_occupancy_rate_percentage``, ``decoding_duration`` sniffed
  from non-streaming ``/v1/chat/completions`` response bodies via a
  thin hook in ``_dispatch_and_forward``.

KV% remains ``—`` for GPU/llamacpp slots per plan §12.1 — Lemonade's
bundled llama-server returns ``null`` for ``n_past``. FLM/NPU slots
get KV% from ``kv_token_occupancy_rate_percentage`` natively.

The shim shares ``app.state.lemonade_client`` with the idle driver
(no second connection pool). Lifecycle mirrors ``IdleDriver`` —
resilient to lemond hiccups, cancellation-safe, ``start()/stop()``
idempotent.

Refs: plan §10.1 + §11 PR-12 + §12.1, ADR-0008 §3, memory
``hal0_lemonade_flm_npu_install``.

## Surface

- ``GET /api/metrics/prometheus`` — text/plain Prometheus 0.0.4
  exposition. Public by convention (operators harden via reverse proxy
  if needed; auth-gating would block standard scrapers).

## Metric families

| Name | Labels | Source |
|---|---|---|
| ``hal0_lemonade_ttft_seconds`` | ``source="last_request"`` | ``/v1/stats.time_to_first_token`` |
| ``hal0_lemonade_decode_tokens_per_second`` | ``source="last_request"`` | ``/v1/stats.tokens_per_second`` |
| ``hal0_lemonade_prompt_tokens`` | ``source="last_request"`` | ``/v1/stats.prompt_tokens`` |
| ``hal0_lemonade_decode_tokens`` | ``source="last_request"`` | ``/v1/stats.output_tokens`` |
| ``hal0_lemonade_input_tokens`` | ``source="last_request"`` | ``/v1/stats.input_tokens`` |
| ``hal0_lemonade_models_loaded`` | ``model_name`` | ``/v1/health.all_models_loaded[]`` |
| ``hal0_lemonade_max_models`` | ``type`` | ``/v1/health.max_models`` |
| ``hal0_lemonade_flm_decode_tokens_per_second`` | ``slot_name``, ``model_name`` | chat-completion body (FLM only) |
| ``hal0_lemonade_flm_prefill_tokens_per_second`` | ``slot_name``, ``model_name`` | chat-completion body (FLM only) |
| ``hal0_lemonade_flm_ttft_seconds`` | ``slot_name``, ``model_name`` | chat-completion body (FLM only) |
| ``hal0_lemonade_kv_occupancy_ratio`` | ``slot_name``, ``model_name`` | chat-completion body (FLM only) |
| ``hal0_lemonade_flm_decode_duration_seconds`` | ``slot_name``, ``model_name`` | chat-completion body (FLM only) |
| ``hal0_lemonade_metrics_last_scrape_seconds`` | — | shim staleness gauge |

## Files

- ``src/hal0/lemonade/metrics_shim.py`` (NEW) — ``MetricsShim`` background poller + FLM ingest receiver.
- ``src/hal0/lemonade/prometheus_format.py`` (NEW) — Prometheus 0.0.4 text exposition renderer.
- ``src/hal0/api/__init__.py`` — wire ``_start_lemonade_metrics_shim`` into lifespan after the idle driver; stop on shutdown.
- ``src/hal0/api/routes/health.py`` — new ``GET /api/metrics/prometheus`` route on the existing public health router.
- ``src/hal0/api/routes/v1.py`` — non-streaming FLM-native ingest hook in ``_dispatch_and_forward``.
- ``tests/lemonade/test_metrics_shim.py`` (NEW) — 23 tests covering poll lifecycle, dual-schema parse, KV%-only-from-FLM contract, FLM ingest dedup, cancellation.
- ``tests/lemonade/test_prometheus_format.py`` (NEW) — 10 tests covering exposition spec compliance (HELP/TYPE, label escape, deterministic sort, trailing newline).
- ``tests/api/test_metrics_prometheus_route.py`` (NEW) — 4 tests covering route content-type, no-shim empty-body behaviour, synthetic snapshot round-trip, public reachability.
- ``tests/api/test_v1_flm_metrics_ingest.py`` (NEW) — 5 tests covering the dispatcher hook (FLM record, non-FLM no-op, missing shim/slot/model no-op, unparseable bytes).

## LOC delta

+1828, -11 (heavy on tests + docstrings)

## Test count delta

+42 (1591 → 1633 total tests passing on this branch)

## Anti-scope

- No admin panel (PR-13), journal panel (PR-14), or ``[CPU]`` chip (PR-15).
- No streaming SSE FLM ingest — only non-streaming chat-completion responses sniffed in PR-12. Streaming FLM ingest is a follow-up (the same fields land in the final SSE chunk).
- No KV% computation for GPU/llamacpp slots (plan §12.1 accepted gap).
- No ``prometheus_client`` dependency added — text exposition is rendered manually (6 gauge families, trivial format).
- No ``extra.*`` namespace introduced (ADR-0008 §7).

## Test plan

- [ ] CI: ``ruff check`` + ``ruff format --check`` + ``pytest tests/``
- [ ] Hit ``GET /api/metrics/prometheus`` from a local hal0 install — verify text/plain Prometheus exposition format
- [ ] Confirm dashboard ``—`` placeholder still renders for GPU/llamacpp KV% (no regression vs PR-11)
- [ ] Smoke-test on the LXC: load an FLM model, send a chat completion, verify ``hal0_lemonade_kv_occupancy_ratio`` appears