### PR TITLE
feat(ui): v2 primitives (Modal/Drawer/ConfirmDialog/Banner/Menu/Toast) + 19th banner skip-path (slice #167)

### DIFF
--- a/ui/src/components/primitives/Banner.vue
+++ b/ui/src/components/primitives/Banner.vue
@@ -1,0 +1,169 @@
+<script setup>
+/**
+ * primitives/Banner.vue — reusable warn/err/info banner shell.
+ *
+ * Mirrors the React `Banner` in
+ *   /tmp/hal0-design-v3/dash/primitives.jsx (lines 123–142).
+ *
+ * Anatomy
+ * ───────
+ *   [icon] [eyebrow / heading / body / actions]   [× dismiss]
+ *
+ * Kind drives both the soft-tinted background + border + icon-tile
+ * colour (warn=amber, err=red, info=accent).
+ *
+ * `actions` is an array of `{ label, primary?, onClick? }`. Buttons
+ * render via the global `.btn` style; primary fills with accent,
+ * non-primary uses the ghost variant. When `onClick` is missing the
+ * banner renders the button as a no-op stub — wiring decisions live
+ * in `BannerStack.vue` (which can fall back to a toast).
+ */
+defineProps({
+  kind:        { type: String, default: 'warn' },          // warn | err | info
+  heading:     { type: String, default: '' },
+  eyebrow:     { type: String, default: '' },
+  body:        { type: String, default: '' },
+  actions:     { type: Array, default: () => [] },
+  onDismiss:   { type: Function, default: null },
+  dismissable: { type: Boolean, default: true },
+})
+
+const emit = defineEmits(['action'])
+
+function fireAction(a) {
+  if (a.onClick) { a.onClick(); return }
+  // Banner is NOT store-aware (per slice brief). Emit an event so a
+  // host (BannerStack / consumer view) can toast-or-no-op.
+  emit('action', a)
+}
+</script>
+
+<template>
+  <div :class="['banner', `banner-${kind}`]" :role="kind === 'err' ? 'alert' : 'status'">
+    <div class="banner-ic">
+      <!-- bell for info, warn-triangle for warn/err — matches Icons.bell/Icons.warn -->
+      <svg
+        v-if="kind === 'info'"
+        width="16" height="16" viewBox="0 0 16 16"
+        fill="none" stroke="currentColor" stroke-width="1.5"
+        stroke-linecap="round" stroke-linejoin="round"
+      >
+        <path d="M4 11h8c-1 0-1.5-0.5-1.5-2V6.5a2.5 2.5 0 0 0-5 0V9c0 1.5-0.5 2-1.5 2zM6.5 13a1.5 1.5 0 0 0 3 0"/>
+      </svg>
+      <svg
+        v-else
+        width="16" height="16" viewBox="0 0 16 16"
+        fill="none" stroke="currentColor" stroke-width="1.5"
+        stroke-linecap="round" stroke-linejoin="round"
+      >
+        <path d="M8 2l6 11H2L8 2z"/>
+        <path d="M8 7v3M8 12v0.01"/>
+      </svg>
+    </div>
+    <div class="banner-content">
+      <div v-if="eyebrow" class="banner-eye mono">{{ eyebrow }}</div>
+      <div v-if="heading" class="banner-heading mono">{{ heading }}</div>
+      <div v-if="body" class="banner-body">
+        <slot name="body">{{ body }}</slot>
+      </div>
+      <div v-if="actions && actions.length" class="banner-actions">
+        <button
+          v-for="(a, i) in actions"
+          :key="i"
+          type="button"
+          :class="a.primary ? 'btn sm' : 'btn ghost sm'"
+          @click="fireAction(a)"
+        >{{ a.label }}</button>
+      </div>
+    </div>
+    <button
+      v-if="onDismiss && dismissable"
+      type="button"
+      class="banner-dismiss"
+      aria-label="Dismiss"
+      @click="onDismiss"
+    >
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M4 4l8 8M12 4l-8 8"/>
+      </svg>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.banner {
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  gap: 14px;
+  padding: 12px 14px;
+  border-radius: var(--rad);
+  border: 1px solid;
+  align-items: start;
+  position: relative;
+}
+.banner-warn {
+  background: color-mix(in oklab, var(--warn-soft) 110%, transparent);
+  border-color: var(--warn-line);
+  color: var(--fg);
+}
+.banner-err {
+  background: color-mix(in oklab, var(--err-soft) 130%, transparent);
+  border-color: var(--err-line);
+  color: var(--fg);
+}
+.banner-info {
+  background: var(--accent-soft);
+  border-color: var(--accent-line);
+  color: var(--fg);
+}
+.banner-ic {
+  width: 28px; height: 28px;
+  border-radius: 4px;
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.banner-warn .banner-ic { background: rgba(232, 185, 78, 0.18); color: var(--warn); }
+.banner-err  .banner-ic { background: rgba(239, 107, 107, 0.18); color: var(--err); }
+.banner-info .banner-ic { background: var(--accent-bg); color: var(--accent); }
+
+.banner-content { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.banner-eye {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: currentColor;
+  opacity: 0.7;
+}
+.banner-warn .banner-eye { color: var(--warn); opacity: 1; }
+.banner-err  .banner-eye { color: var(--err);  opacity: 1; }
+.banner-info .banner-eye { color: var(--accent); opacity: 1; }
+.banner-heading {
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--fg);
+  line-height: 1.35;
+  letter-spacing: -0.005em;
+}
+.banner-body {
+  font-size: 12.5px;
+  color: var(--fg-2);
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+.banner-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+  flex-wrap: wrap;
+}
+.banner-dismiss {
+  background: transparent;
+  border: none;
+  color: var(--fg-4);
+  width: 24px; height: 24px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.banner-dismiss:hover { color: var(--fg); background: rgba(255, 255, 255, 0.05); }
+</style>

--- a/ui/src/components/primitives/BannerStack.vue
+++ b/ui/src/components/primitives/BannerStack.vue
@@ -1,0 +1,79 @@
+<script setup>
+/**
+ * primitives/BannerStack.vue — view-scoped banner renderer.
+ *
+ * Reads `useBannerStore.activeByScope(scope)` and renders one
+ * `<Banner>` per match. Mirrors the React `BannerStack` in
+ *   /tmp/hal0-design-v3/dash/primitives.jsx (lines 161–195).
+ *
+ * Includes the "global" scope automatically so a `<BannerStack
+ * scope="dashboard">` shows both global + dashboard banners
+ * (the design source filters `scope === "global" || scope === scope`).
+ *
+ * Action wiring
+ * ─────────────
+ *   - When the catalog entry's action has `onClick`, that's fired.
+ *   - When missing, falls back to `useToastStore.push("<label> — stubbed", "info")`
+ *     (matches the design's `window.__hal0Toast` fallback).
+ *
+ * Dismiss wiring
+ * ──────────────
+ *   - When `dismissable !== false`, the × calls `banner.dismiss(id)`.
+ *   - When `dismissable === false` (e.g. npu-swap), × is hidden.
+ */
+import { computed } from 'vue'
+import Banner from './Banner.vue'
+import { useBannerStore } from '../../stores/banner.js'
+import { useToastStore } from '../../stores/toast.js'
+
+const props = defineProps({
+  scope: { type: String, default: 'global' },
+})
+
+const banners = useBannerStore()
+const toasts  = useToastStore()
+
+const items = computed(() => {
+  // Always include "global" alongside the requested scope, unless
+  // scope IS "global" (avoid duplicates).
+  const all = banners.activeList
+  if (props.scope === 'global') return all.filter((b) => b.scope === 'global')
+  return all.filter((b) => b.scope === props.scope || b.scope === 'global')
+})
+
+function handleAction(entry, action) {
+  if (action.onClick) { action.onClick(); return }
+  toasts.push(`${action.label} — stubbed`, 'info')
+}
+
+function handleDismiss(entry) {
+  banners.dismiss(entry.id)
+}
+</script>
+
+<template>
+  <div v-if="items.length" class="banner-stack" data-testid="banner-stack">
+    <Banner
+      v-for="b in items"
+      :key="b.id"
+      :kind="b.kind"
+      :eyebrow="b.eyebrow"
+      :heading="b.heading"
+      :body="b.body"
+      :actions="b.actions || []"
+      :dismissable="b.dismissable !== false"
+      :on-dismiss="b.dismissable !== false ? () => handleDismiss(b) : null"
+      @action="(a) => handleAction(b, a)"
+      :data-banner-id="b.id"
+    />
+  </div>
+</template>
+
+<style scoped>
+.banner-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+</style>

--- a/ui/src/components/primitives/ConfirmDialog.vue
+++ b/ui/src/components/primitives/ConfirmDialog.vue
@@ -1,0 +1,119 @@
+<script setup>
+/**
+ * primitives/ConfirmDialog.vue — recoverable + destructive confirm modal.
+ *
+ * Mirrors the React `ConfirmDialog` in
+ *   /tmp/hal0-design-v3/dash/primitives.jsx (lines 78–121)
+ *
+ * Wraps `primitives/Modal.vue` (not the v1 `ConfirmDialog.vue` in the
+ * parent components/ dir — that one stays bound to v1 surfaces).
+ *
+ * Variants
+ * ────────
+ *   - Recoverable (default) — neutral btn, footer reads
+ *     "You can undo this later."
+ *   - `destructive=true` — red btn, footer reads
+ *     "This action is permanent." + eyebrow "Destructive · cannot be undone"
+ *   - `typeToConfirm="some text"` — adds a mono input; the confirm
+ *     button is disabled until the input value matches exactly.
+ */
+import { ref, watch } from 'vue'
+import Modal from './Modal.vue'
+
+const props = defineProps({
+  open:          { type: Boolean, default: false },
+  onCancel:      { type: Function, default: () => {} },
+  onConfirm:     { type: Function, default: () => {} },
+  title:         { type: String, required: true },
+  message:       { type: String, default: '' },
+  confirmLabel:  { type: String, default: 'Confirm' },
+  cancelLabel:   { type: String, default: 'Cancel' },
+  destructive:   { type: Boolean, default: false },
+  typeToConfirm: { type: String, default: null },
+})
+
+const typed = ref('')
+
+// Mirror React `useEffect(() => { if (open) setTyped("") }, [open])`.
+watch(() => props.open, (v) => { if (v) typed.value = '' })
+
+const canConfirm = () => !props.typeToConfirm || typed.value === props.typeToConfirm
+
+function handleConfirm() {
+  if (!canConfirm()) return
+  props.onConfirm()
+}
+</script>
+
+<template>
+  <Modal
+    :open="open"
+    :on-close="onCancel"
+    :title="title"
+    :eyebrow="destructive ? 'Destructive · cannot be undone' : ''"
+    :width="520"
+  >
+    <div class="cd-message" :class="{ 'has-input': typeToConfirm }">{{ message }}</div>
+    <div v-if="typeToConfirm">
+      <div class="cd-input-label mono">
+        Type <span class="cd-input-token">{{ typeToConfirm }}</span> to confirm:
+      </div>
+      <input
+        v-model="typed"
+        class="input mono cd-input"
+        type="text"
+        :placeholder="typeToConfirm"
+        autocomplete="off"
+        spellcheck="false"
+      />
+    </div>
+    <template #foot>
+      <span class="cd-foot-note">
+        {{ destructive ? 'This action is permanent.' : 'You can undo this later.' }}
+      </span>
+      <span class="cd-foot-actions">
+        <button type="button" class="btn ghost sm" @click="onCancel">{{ cancelLabel }}</button>
+        <button
+          type="button"
+          :class="['btn', 'sm', { danger: destructive, 'cd-confirm-destructive': destructive }]"
+          :disabled="!canConfirm()"
+          @click="handleConfirm"
+        >{{ confirmLabel }}</button>
+      </span>
+    </template>
+  </Modal>
+</template>
+
+<style scoped>
+.cd-message {
+  font-size: 13px;
+  color: var(--fg-2);
+  line-height: 1.6;
+}
+.cd-message.has-input { margin-bottom: 16px; }
+
+.cd-input-label {
+  font-size: 11px;
+  color: var(--fg-4);
+  margin-bottom: 6px;
+}
+.cd-input-token { color: var(--err); }
+
+.cd-input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.cd-foot-note { color: var(--fg-4); }
+.cd-foot-actions { display: inline-flex; gap: 8px; }
+
+/* Destructive btn override — design uses an inline style with
+ * background/border-color = var(--err) and color #0a0a0a. Class-scoped
+ * here so we don't leak into other `.btn.danger` usages elsewhere. */
+.cd-confirm-destructive {
+  background: var(--err);
+  border-color: var(--err);
+  color: #0a0a0a;
+}
+.cd-confirm-destructive:hover { filter: brightness(1.06); }
+</style>

--- a/ui/src/components/primitives/Drawer.vue
+++ b/ui/src/components/primitives/Drawer.vue
@@ -1,0 +1,194 @@
+<script setup>
+/**
+ * primitives/Drawer.vue — v2 dashboard right-side slide-in drawer.
+ *
+ * Mirrors the React `Drawer` in
+ *   /tmp/hal0-design-v3/dash/primitives.jsx (lines 45–75)
+ * 1:1. Slide-in via `transform: translateX(100%) → 0` driven by the
+ * `.open` class on `.drawer` + `.drawer-backdrop`.
+ *
+ * Behaviour
+ * ─────────
+ *   - Esc closes the drawer.
+ *   - Backdrop click closes the drawer.
+ *   - Body scroll is locked while open.
+ *   - Focus is trapped inside the drawer; previous focus restored on close.
+ *   - `side` defaults to "right"; the design only ships right-side, but
+ *     the prop is exposed for future "left" variants.
+ */
+import { onBeforeUnmount, ref, watch, nextTick } from 'vue'
+
+const props = defineProps({
+  open:    { type: Boolean, default: false },
+  onClose: { type: Function, default: () => {} },
+  title:   { type: String,  default: '' },
+  eyebrow: { type: String,  default: '' },
+  width:   { type: Number,  default: 520 },
+  side:    { type: String,  default: 'right' },
+})
+
+const drawerRef = ref(null)
+
+let _prevFocus = null
+let _prevOverflow = ''
+
+function onKey(e) {
+  if (e.key === 'Escape') {
+    props.onClose()
+    return
+  }
+  if (e.key === 'Tab' && drawerRef.value) {
+    const focusables = drawerRef.value.querySelectorAll(
+      'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    )
+    if (!focusables.length) return
+    const first = focusables[0]
+    const last  = focusables[focusables.length - 1]
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault(); last.focus()
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault(); first.focus()
+    }
+  }
+}
+
+watch(() => props.open, async (isOpen) => {
+  if (isOpen) {
+    _prevFocus = document.activeElement
+    _prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    document.addEventListener('keydown', onKey)
+    await nextTick()
+    if (drawerRef.value) {
+      const f = drawerRef.value.querySelector(
+        'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+      ;(f || drawerRef.value).focus?.()
+    }
+  } else {
+    document.removeEventListener('keydown', onKey)
+    document.body.style.overflow = _prevOverflow
+    if (_prevFocus && typeof _prevFocus.focus === 'function') _prevFocus.focus()
+    _prevFocus = null
+  }
+}, { immediate: true })
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onKey)
+  if (props.open) document.body.style.overflow = _prevOverflow
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div :class="['drawer-backdrop', { open }]" @click="onClose" />
+    <aside
+      ref="drawerRef"
+      :class="['drawer', `drawer-${side}`, { open }]"
+      :style="{ width: width + 'px' }"
+      role="dialog"
+      aria-modal="true"
+      tabindex="-1"
+      :aria-hidden="!open"
+    >
+      <div class="drawer-h">
+        <div v-if="eyebrow" class="modal-h-eye mono">{{ eyebrow }}</div>
+        <h2 v-if="title" class="mono">{{ title }}</h2>
+        <button
+          type="button"
+          class="modal-close"
+          aria-label="Close"
+          @click="onClose"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4 4l8 8M12 4l-8 8"/>
+          </svg>
+        </button>
+      </div>
+      <div class="drawer-body">
+        <slot />
+      </div>
+      <div v-if="$slots.foot" class="drawer-foot mono">
+        <slot name="foot" />
+      </div>
+    </aside>
+  </Teleport>
+</template>
+
+<style scoped>
+.drawer-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.55);
+  z-index: 80;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease;
+}
+.drawer-backdrop.open { opacity: 1; pointer-events: auto; }
+.drawer {
+  position: fixed;
+  top: 0; bottom: 0;
+  background: var(--bg-1);
+  z-index: 90;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+  box-shadow: -24px 0 64px -16px rgba(0,0,0,0.6);
+  outline: none;
+}
+.drawer-right {
+  right: 0;
+  border-left: 1px solid var(--line-strong);
+  transform: translateX(100%);
+}
+.drawer-left {
+  left: 0;
+  border-right: 1px solid var(--line-strong);
+  transform: translateX(-100%);
+}
+.drawer.open { transform: translateX(0); }
+.drawer-h {
+  padding: 18px 22px 14px;
+  border-bottom: 1px solid var(--line-soft);
+  position: relative;
+}
+.drawer-h h2 {
+  font-size: 18px; font-weight: 500; margin: 0; letter-spacing: -0.02em;
+  color: var(--fg);
+}
+.drawer-h .modal-h-eye {
+  font-size: 10px;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 4px;
+}
+.modal-close {
+  position: absolute;
+  top: 14px; right: 16px;
+  width: 28px; height: 28px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: var(--rad-sm);
+  cursor: pointer;
+  color: var(--fg-3);
+}
+.modal-close:hover { color: var(--fg); border-color: var(--line-strong); }
+.drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px 22px;
+  color: var(--fg);
+}
+.drawer-foot {
+  padding: 14px 22px;
+  border-top: 1px solid var(--line-soft);
+  background: var(--bg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--fg-4);
+}
+</style>

--- a/ui/src/components/primitives/Menu.vue
+++ b/ui/src/components/primitives/Menu.vue
@@ -1,0 +1,178 @@
+<script setup>
+/**
+ * primitives/Menu.vue — popover dropdown menu.
+ *
+ * Mirrors the React `Menu` in
+ *   /tmp/hal0-design-v3/dash/primitives.jsx (lines 384–403),
+ * extended with the v2 brief's behaviours:
+ *
+ *   - `open` controls visibility (the React source assumes the parent
+ *     conditionally renders Menu; we keep an `open` prop to match the
+ *     other primitives' API surface for easier mounting from tests).
+ *   - `anchor` is the trigger element. When provided we position the
+ *     menu absolutely below it using getBoundingClientRect().
+ *   - Auto-close on document click outside, Escape, and selection.
+ *   - Item with `onClick`: fire AND return (do NOT also toast).
+ *   - Item without `onClick`: toast "<label> — stubbed" via
+ *     useToastStore (matches the design's window.__hal0Toast fallback).
+ *
+ * Items shape:
+ *   [
+ *     { icon?: VNode, label: string, kbd?: string, danger?: boolean,
+ *       divider?: boolean, onClick?: () => void }
+ *   ]
+ */
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { useToastStore } from '../../stores/toast.js'
+
+const props = defineProps({
+  open:    { type: Boolean, default: false },
+  anchor:  { type: [Object, null], default: null },     // HTMLElement
+  items:   { type: Array, required: true },
+  onClose: { type: Function, default: () => {} },
+  side:    { type: String, default: 'right' },          // 'left' | 'right'
+})
+
+const toasts = useToastStore()
+const menuRef = ref(null)
+
+const position = ref({ top: 0, left: 0, width: 0 })
+
+function reposition() {
+  if (!props.anchor) return
+  const r = props.anchor.getBoundingClientRect()
+  position.value = {
+    top:   r.bottom + 4,
+    left:  r.left,
+    width: r.width,
+  }
+}
+
+const computedStyle = computed(() => {
+  if (!props.anchor) return {}
+  // Right-aligned: anchor's right edge.
+  if (props.side === 'right') {
+    return {
+      position: 'fixed',
+      top:   position.value.top + 'px',
+      // align right edge of menu with right edge of anchor
+      left:  'auto',
+      right: (window.innerWidth - (position.value.left + position.value.width)) + 'px',
+    }
+  }
+  return {
+    position: 'fixed',
+    top:  position.value.top + 'px',
+    left: position.value.left + 'px',
+  }
+})
+
+function onDocClick(e) {
+  if (!props.open) return
+  if (menuRef.value && menuRef.value.contains(e.target)) return
+  if (props.anchor && props.anchor.contains(e.target)) return
+  props.onClose()
+}
+
+function onKey(e) {
+  if (e.key === 'Escape' && props.open) props.onClose()
+}
+
+function selectItem(it) {
+  if (it.divider) return
+  if (it.onClick) {
+    it.onClick()
+  } else {
+    toasts.push(`${it.label} — stubbed`, 'info')
+  }
+  props.onClose()
+}
+
+watch(() => props.open, (v) => {
+  if (v) {
+    reposition()
+    // Defer listener attachment so the click that opened the menu
+    // doesn't immediately close it.
+    setTimeout(() => {
+      document.addEventListener('click', onDocClick)
+    }, 0)
+    document.addEventListener('keydown', onKey)
+    window.addEventListener('resize', reposition)
+    window.addEventListener('scroll', reposition, true)
+  } else {
+    document.removeEventListener('click', onDocClick)
+    document.removeEventListener('keydown', onKey)
+    window.removeEventListener('resize', reposition)
+    window.removeEventListener('scroll', reposition, true)
+  }
+}, { immediate: true })
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onDocClick)
+  document.removeEventListener('keydown', onKey)
+  window.removeEventListener('resize', reposition)
+  window.removeEventListener('scroll', reposition, true)
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      ref="menuRef"
+      :class="['hal0-menu', side]"
+      :style="computedStyle"
+      role="menu"
+      @click.stop
+    >
+      <template v-for="(it, i) in items" :key="i">
+        <div v-if="it.divider" class="hal0-menu-divider" />
+        <div
+          v-else
+          :class="['hal0-menu-item', { danger: it.danger }]"
+          role="menuitem"
+          tabindex="0"
+          @click="selectItem(it)"
+          @keydown.enter.prevent="selectItem(it)"
+          @keydown.space.prevent="selectItem(it)"
+        >
+          <span v-if="it.icon" class="hal0-menu-ic" v-html="it.icon" />
+          <span class="hal0-menu-lbl">{{ it.label }}</span>
+          <span v-if="it.kbd" class="hal0-menu-kbd kbd">{{ it.kbd }}</span>
+        </div>
+      </template>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.hal0-menu {
+  z-index: 60;
+  min-width: 200px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--rad);
+  box-shadow: 0 16px 48px -8px rgba(0, 0, 0, 0.65);
+  padding: 4px;
+  font-family: var(--jbm);
+}
+.hal0-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--fg-2);
+  user-select: none;
+}
+.hal0-menu-item:hover { background: var(--bg-3); color: var(--fg); }
+.hal0-menu-item.danger { color: var(--err); }
+.hal0-menu-item.danger:hover { background: var(--err-soft); }
+.hal0-menu-ic { color: var(--fg-4); display: inline-flex; }
+.hal0-menu-item:hover .hal0-menu-ic { color: var(--fg-2); }
+.hal0-menu-lbl { flex: 1; }
+.hal0-menu-kbd { margin-left: auto; }
+.hal0-menu-divider { height: 1px; background: var(--line-soft); margin: 4px 0; }
+</style>

--- a/ui/src/components/primitives/Modal.vue
+++ b/ui/src/components/primitives/Modal.vue
@@ -1,0 +1,211 @@
+<script setup>
+/**
+ * primitives/Modal.vue — v2 dashboard generic modal shell.
+ *
+ * Mirrors the React `Modal` in
+ *   /tmp/hal0-design-v3/dash/primitives.jsx (lines 8–42)
+ * 1:1 in markup + class names, so it consumes the global `.modal-*`
+ * styles defined inline below (kept on the component to match the
+ * design source which co-locates the CSS in chrome.jsx).
+ *
+ * Behaviour
+ * ─────────
+ *   - `open=false` → renders nothing (no overlay, no body-lock).
+ *   - Esc closes when `dismissable=true` (default).
+ *   - Backdrop mouse-down closes when `dismissable=true`.
+ *   - Body scroll is locked while open (saves/restores `overflow`).
+ *   - Focus is trapped inside `.modal-shell` via Tab/Shift+Tab cycling;
+ *     focus is restored to the previously-focused element on close.
+ *
+ * Slot
+ * ────
+ *   Default slot is the body content. Pass `eyebrow`/`title` for the
+ *   header strip and `foot` (slot or string) for the footer strip.
+ */
+import { onBeforeUnmount, ref, watch, nextTick } from 'vue'
+
+const props = defineProps({
+  open:        { type: Boolean, default: false },
+  onClose:     { type: Function, default: () => {} },
+  title:       { type: String,  default: '' },
+  eyebrow:     { type: String,  default: '' },
+  width:       { type: Number,  default: 640 },
+  dismissable: { type: Boolean, default: true },
+})
+
+const overlayRef = ref(null)
+const shellRef   = ref(null)
+
+let _prevFocus = null
+let _prevOverflow = ''
+
+function onKey(e) {
+  if (e.key === 'Escape' && props.dismissable) {
+    props.onClose()
+    return
+  }
+  if (e.key === 'Tab' && shellRef.value) {
+    // Hand-rolled focus trap.
+    const focusables = shellRef.value.querySelectorAll(
+      'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    )
+    if (!focusables.length) return
+    const first = focusables[0]
+    const last  = focusables[focusables.length - 1]
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault()
+      last.focus()
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault()
+      first.focus()
+    }
+  }
+}
+
+function onBackdropMouseDown(e) {
+  if (props.dismissable && e.target === overlayRef.value) {
+    props.onClose()
+  }
+}
+
+watch(() => props.open, async (isOpen) => {
+  if (isOpen) {
+    _prevFocus = document.activeElement
+    _prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    document.addEventListener('keydown', onKey)
+    await nextTick()
+    // Focus first focusable inside the shell, or the shell itself.
+    if (shellRef.value) {
+      const f = shellRef.value.querySelector(
+        'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+      ;(f || shellRef.value).focus?.()
+    }
+  } else {
+    document.removeEventListener('keydown', onKey)
+    document.body.style.overflow = _prevOverflow
+    if (_prevFocus && typeof _prevFocus.focus === 'function') {
+      _prevFocus.focus()
+    }
+    _prevFocus = null
+  }
+}, { immediate: true })
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onKey)
+  if (props.open) document.body.style.overflow = _prevOverflow
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      ref="overlayRef"
+      class="modal-backdrop"
+      @mousedown="onBackdropMouseDown"
+    >
+      <div
+        ref="shellRef"
+        class="modal-shell"
+        role="dialog"
+        aria-modal="true"
+        tabindex="-1"
+        :style="{ maxWidth: width + 'px' }"
+        @mousedown.stop
+      >
+        <div v-if="title || eyebrow" class="modal-h">
+          <div v-if="eyebrow" class="modal-h-eye mono">{{ eyebrow }}</div>
+          <h2 v-if="title" class="mono">{{ title }}</h2>
+          <button
+            v-if="dismissable"
+            type="button"
+            class="modal-close"
+            aria-label="Close"
+            @click="onClose"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M4 4l8 8M12 4l-8 8"/>
+            </svg>
+          </button>
+        </div>
+        <div class="modal-body">
+          <slot />
+        </div>
+        <div v-if="$slots.foot" class="modal-foot mono">
+          <slot name="foot" />
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.modal-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(2px);
+  z-index: 100;
+  display: flex; align-items: flex-start; justify-content: center;
+  padding: 80px 24px 24px;
+  overflow-y: auto;
+}
+.modal-shell {
+  background: var(--bg-1);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--rad-lg);
+  box-shadow: 0 24px 80px -16px rgba(0, 0, 0, 0.8);
+  max-width: 680px;
+  width: 100%;
+  overflow: hidden;
+  outline: none;
+}
+.modal-h {
+  padding: 20px 22px 16px;
+  border-bottom: 1px solid var(--line-soft);
+  position: relative;
+}
+.modal-h-eye {
+  font-size: 10px;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 4px;
+}
+.modal-h h2 {
+  font-size: 18px;
+  font-weight: 500;
+  margin: 0;
+  letter-spacing: -0.02em;
+  color: var(--fg);
+}
+.modal-close {
+  position: absolute;
+  top: 16px; right: 16px;
+  width: 28px; height: 28px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: var(--rad-sm);
+  cursor: pointer;
+  color: var(--fg-3);
+}
+.modal-close:hover { color: var(--fg); border-color: var(--line-strong); }
+.modal-body {
+  padding: 18px 22px;
+  max-height: 70vh;
+  overflow-y: auto;
+  color: var(--fg);
+}
+.modal-foot {
+  padding: 14px 22px;
+  border-top: 1px solid var(--line-soft);
+  background: var(--bg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--fg-4);
+}
+</style>

--- a/ui/src/components/primitives/Toast.vue
+++ b/ui/src/components/primitives/Toast.vue
@@ -1,0 +1,80 @@
+<script setup>
+/**
+ * primitives/Toast.vue — single toast pill (presentational).
+ *
+ * ToastStack instantiates one of these per queued toast. We keep it
+ * separate so a view can render an ad-hoc toast (rare) without the
+ * store, and so the visual classes are colocated with the markup.
+ *
+ * `kind`: 'info' | 'success' | 'warning' | 'error'.
+ * The amber/red/info tone mapping follows the design's compact toast
+ * style (smaller than the v1 ToastContainer's stack).
+ */
+defineProps({
+  msg:  { type: String, required: true },
+  kind: { type: String, default: 'info' },
+  onDismiss: { type: Function, default: null },
+})
+</script>
+
+<template>
+  <div :class="['hal0-toast', `hal0-toast-${kind}`]" role="status">
+    <span class="hal0-toast-msg">{{ msg }}</span>
+    <button
+      v-if="onDismiss"
+      type="button"
+      class="hal0-toast-x"
+      aria-label="Dismiss"
+      @click="onDismiss"
+    >
+      <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M4 4l8 8M12 4l-8 8"/>
+      </svg>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.hal0-toast {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 12px;
+  border-radius: var(--rad);
+  border: 1px solid;
+  font-family: var(--jbm);
+  font-size: 12px;
+  color: var(--fg);
+  background: var(--bg-1);
+  box-shadow: 0 12px 32px -8px rgba(0, 0, 0, 0.55);
+  pointer-events: auto;
+  max-width: 360px;
+}
+.hal0-toast-info {
+  border-color: var(--accent-line);
+  background: color-mix(in oklab, var(--accent-soft) 110%, var(--bg-1));
+}
+.hal0-toast-success {
+  border-color: rgba(106, 196, 130, 0.45);
+  background: color-mix(in oklab, rgba(106, 196, 130, 0.18) 110%, var(--bg-1));
+}
+.hal0-toast-warning {
+  border-color: var(--warn-line);
+  background: color-mix(in oklab, var(--warn-soft) 110%, var(--bg-1));
+}
+.hal0-toast-error {
+  border-color: var(--err-line);
+  background: color-mix(in oklab, var(--err-soft) 110%, var(--bg-1));
+}
+.hal0-toast-msg { flex: 1; line-height: 1.4; word-wrap: break-word; }
+.hal0-toast-x {
+  background: transparent;
+  border: none;
+  color: var(--fg-4);
+  cursor: pointer;
+  padding: 2px;
+  display: inline-flex;
+  align-items: center;
+}
+.hal0-toast-x:hover { color: var(--fg); }
+</style>

--- a/ui/src/components/primitives/ToastStack.vue
+++ b/ui/src/components/primitives/ToastStack.vue
@@ -1,0 +1,57 @@
+<script setup>
+/**
+ * primitives/ToastStack.vue — top-right toast queue renderer.
+ *
+ * Reads `useToastStore.queue` (the v2 toast store from
+ * `stores/toast.js`) and renders one `<Toast>` per entry. Auto-removal
+ * is handled inside the store via setTimeout — this component is
+ * purely presentational.
+ *
+ * NOTE: this slice (#167) ships the primitive but does NOT mount it
+ * at App root level — that's slice #5 chrome's job. The component is
+ * importable from views/spec routes today (the primitives spec mounts
+ * it to verify queue + auto-removal).
+ */
+import { useToastStore } from '../../stores/toast.js'
+import Toast from './Toast.vue'
+
+const toasts = useToastStore()
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="hal0-toast-stack" data-testid="toast-stack" aria-live="polite">
+      <TransitionGroup name="hal0-toast" tag="div" class="hal0-toast-list">
+        <Toast
+          v-for="t in toasts.queue"
+          :key="t.id"
+          :msg="t.msg"
+          :kind="t.kind"
+          :on-dismiss="() => toasts.dismiss(t.id)"
+          :data-toast-id="t.id"
+        />
+      </TransitionGroup>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.hal0-toast-stack {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 9999;
+  pointer-events: none;
+}
+.hal0-toast-list {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+.hal0-toast-enter-active,
+.hal0-toast-leave-active { transition: opacity 0.18s ease, transform 0.18s ease; }
+.hal0-toast-enter-from   { opacity: 0; transform: translateX(20px); }
+.hal0-toast-leave-to     { opacity: 0; transform: translateX(20px); }
+.hal0-toast-move         { transition: transform 0.18s ease; }
+</style>

--- a/ui/src/components/primitives/_sandbox/PrimitivesSandbox.vue
+++ b/ui/src/components/primitives/_sandbox/PrimitivesSandbox.vue
@@ -1,0 +1,213 @@
+<script setup>
+/**
+ * primitives/_sandbox/PrimitivesSandbox.vue — test-only host.
+ *
+ * Renders one toggle per primitive so the Playwright spec can mount
+ * each in isolation and exercise behaviours (Esc, backdrop, focus
+ * trap, drawer transform, banner stack scope filtering, menu
+ * outside-click close, toast queue auto-removal).
+ *
+ * NOT linked from any chrome — only reachable via the explicit
+ * `/_primitives_test` route. Lives next to the primitives it tests.
+ */
+import { ref } from 'vue'
+import Modal from '../Modal.vue'
+import Drawer from '../Drawer.vue'
+import ConfirmDialog from '../ConfirmDialog.vue'
+import Banner from '../Banner.vue'
+import BannerStack from '../BannerStack.vue'
+import Menu from '../Menu.vue'
+import ToastStack from '../ToastStack.vue'
+import { useBannerStore } from '../../../stores/banner.js'
+import { useToastStore } from '../../../stores/toast.js'
+
+const banners = useBannerStore()
+const toasts  = useToastStore()
+
+// ── Modal ──────────────────────────────────────────────────────────
+const modalOpen = ref(false)
+function openModal()  { modalOpen.value = true }
+function closeModal() { modalOpen.value = false }
+
+// ── Drawer ─────────────────────────────────────────────────────────
+const drawerOpen = ref(false)
+function openDrawer()  { drawerOpen.value = true }
+function closeDrawer() { drawerOpen.value = false }
+
+// ── ConfirmDialog ──────────────────────────────────────────────────
+const cdRecoverableOpen = ref(false)
+const cdDestructiveOpen = ref(false)
+const cdTypeOpen        = ref(false)
+const cdLog             = ref([])
+function logCd(s) { cdLog.value.push(s) }
+
+// ── Banner / BannerStack ───────────────────────────────────────────
+const bannerScope = ref('slots')
+function toggleBanner(id) { banners.toggle(id) }
+function showAllSlots() {
+  for (const b of banners.CATALOG) if (b.scope === 'slots') banners.show(b.id)
+}
+function clearAll() {
+  for (const id of Object.keys(banners.active)) banners.dismiss(id)
+}
+
+// ── Menu ───────────────────────────────────────────────────────────
+const menuOpen   = ref(false)
+const menuAnchor = ref(null)
+const menuActionLog = ref([])
+const menuItems = [
+  { label: 'Wired action', kbd: '⌘E', onClick: () => menuActionLog.value.push('wired-fired') },
+  { divider: true },
+  { label: 'Stubbed action' }, // no onClick → triggers toast
+  { label: 'Destructive', danger: true, onClick: () => menuActionLog.value.push('destructive-fired') },
+]
+function openMenu() {
+  menuOpen.value = true
+}
+function closeMenu() { menuOpen.value = false }
+
+// ── Toast ──────────────────────────────────────────────────────────
+function pushToast(kind = 'info', ttl = 4000) {
+  toasts.push(`Sandbox ${kind} #${toasts.queue.length + 1}`, kind, ttl)
+}
+function pushShortToast() { toasts.push('quick', 'info', 200) }
+</script>
+
+<template>
+  <div class="sandbox">
+    <h1>Primitives sandbox</h1>
+    <p class="sub">Test-only host for slice #167. Not linked from chrome.</p>
+
+    <!-- ─── Modal ─── -->
+    <section data-section="modal">
+      <h2>Modal</h2>
+      <button type="button" class="btn sm" data-testid="open-modal" @click="openModal">Open modal</button>
+      <Modal :open="modalOpen" :on-close="closeModal" title="Sandbox modal" eyebrow="Test · modal">
+        <p data-testid="modal-body">Modal body content.</p>
+        <input type="text" placeholder="focus-1" data-testid="modal-input-1" />
+        <button type="button" data-testid="modal-btn-inner">Inner button</button>
+      </Modal>
+    </section>
+
+    <!-- ─── Drawer ─── -->
+    <section data-section="drawer">
+      <h2>Drawer</h2>
+      <button type="button" class="btn sm" data-testid="open-drawer" @click="openDrawer">Open drawer</button>
+      <Drawer :open="drawerOpen" :on-close="closeDrawer" title="Sandbox drawer" eyebrow="Test · drawer">
+        <p data-testid="drawer-body">Drawer body content.</p>
+        <button type="button" data-testid="drawer-btn-inner">Inner button</button>
+      </Drawer>
+    </section>
+
+    <!-- ─── ConfirmDialog ─── -->
+    <section data-section="confirm">
+      <h2>ConfirmDialog</h2>
+      <button type="button" class="btn sm" data-testid="open-cd-recoverable" @click="cdRecoverableOpen = true">Open recoverable</button>
+      <button type="button" class="btn sm" data-testid="open-cd-destructive" @click="cdDestructiveOpen = true">Open destructive</button>
+      <button type="button" class="btn sm" data-testid="open-cd-type" @click="cdTypeOpen = true">Open type-to-confirm</button>
+      <pre data-testid="cd-log">{{ cdLog.join('\n') }}</pre>
+
+      <ConfirmDialog
+        :open="cdRecoverableOpen"
+        title="Recoverable action"
+        message="You can undo this."
+        :on-cancel="() => { logCd('rec-cancel'); cdRecoverableOpen = false }"
+        :on-confirm="() => { logCd('rec-confirm'); cdRecoverableOpen = false }"
+      />
+      <ConfirmDialog
+        :open="cdDestructiveOpen"
+        title="Destructive action"
+        message="This action is permanent."
+        destructive
+        :on-cancel="() => { logCd('dest-cancel'); cdDestructiveOpen = false }"
+        :on-confirm="() => { logCd('dest-confirm'); cdDestructiveOpen = false }"
+      />
+      <ConfirmDialog
+        :open="cdTypeOpen"
+        title="Type to confirm"
+        message="Type the keyword to enable confirm."
+        destructive
+        type-to-confirm="DELETE"
+        :on-cancel="() => { logCd('type-cancel'); cdTypeOpen = false }"
+        :on-confirm="() => { logCd('type-confirm'); cdTypeOpen = false }"
+      />
+    </section>
+
+    <!-- ─── Banner / BannerStack ─── -->
+    <section data-section="banner">
+      <h2>Banner / BannerStack</h2>
+      <div class="row">
+        <button type="button" class="btn sm" data-testid="ban-toggle-nuclear" @click="toggleBanner('nuclear-evict')">Toggle nuclear-evict</button>
+        <button type="button" class="btn sm" data-testid="ban-toggle-lemond" @click="toggleBanner('lemond-offline')">Toggle lemond-offline</button>
+        <button type="button" class="btn sm" data-testid="ban-toggle-skip" @click="toggleBanner('skip-path')">Toggle skip-path</button>
+        <button type="button" class="btn sm" data-testid="ban-show-slots" @click="showAllSlots">Show all slots</button>
+        <button type="button" class="btn sm" data-testid="ban-clear" @click="clearAll">Clear</button>
+      </div>
+      <p>Scope: <code>{{ bannerScope }}</code></p>
+      <BannerStack :scope="bannerScope" />
+
+      <h3>Standalone Banner</h3>
+      <Banner
+        kind="warn"
+        eyebrow="Standalone"
+        heading="Sandbox standalone banner"
+        body="Renders without the stack/store, for visual diff."
+        :actions="[{ label: 'Primary', primary: true }, { label: 'Secondary' }]"
+        :on-dismiss="() => {}"
+        data-testid="standalone-banner"
+      />
+    </section>
+
+    <!-- ─── Menu ─── -->
+    <section data-section="menu">
+      <h2>Menu</h2>
+      <button
+        ref="menuAnchor"
+        type="button"
+        class="btn sm"
+        data-testid="open-menu"
+        @click="openMenu"
+      >Open menu ▾</button>
+      <Menu :open="menuOpen" :anchor="menuAnchor" :items="menuItems" :on-close="closeMenu" />
+      <pre data-testid="menu-log">{{ menuActionLog.join('\n') }}</pre>
+    </section>
+
+    <!-- ─── Toast / ToastStack ─── -->
+    <section data-section="toast">
+      <h2>Toast / ToastStack</h2>
+      <button type="button" class="btn sm" data-testid="push-toast" @click="pushToast('info')">Push toast</button>
+      <button type="button" class="btn sm" data-testid="push-short-toast" @click="pushShortToast">Push short toast (200ms)</button>
+      <button type="button" class="btn sm" data-testid="push-toast-error" @click="pushToast('error')">Push error toast</button>
+      <span data-testid="toast-count">queue: {{ toasts.queue.length }}</span>
+      <ToastStack />
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.sandbox {
+  padding: 24px;
+  font-family: var(--font-sans, system-ui);
+  color: var(--fg);
+  background: var(--bg);
+  min-height: 100vh;
+}
+.sandbox h1 { font-size: 22px; margin: 0 0 4px; }
+.sandbox h2 { font-size: 14px; margin: 32px 0 8px; color: var(--fg-2); }
+.sandbox h3 { font-size: 12px; margin: 16px 0 6px; color: var(--fg-3); }
+.sub { color: var(--fg-4); font-size: 12px; margin: 0 0 16px; }
+.row { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 12px; }
+section { padding: 12px 0; border-bottom: 1px solid var(--line-soft); }
+section button { margin-right: 6px; margin-bottom: 6px; }
+pre {
+  font-family: var(--jbm);
+  font-size: 11px;
+  color: var(--fg-3);
+  background: var(--bg-1);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--rad-sm);
+  padding: 6px 8px;
+  margin: 8px 0 0;
+  min-height: 18px;
+}
+</style>

--- a/ui/src/router.js
+++ b/ui/src/router.js
@@ -73,6 +73,19 @@ const routes = [
     meta: { title: 'Setup', skipFirstRunGuard: true },
   },
   {
+    // Slice #167 — primitives test sandbox. Mounts each v2 primitive
+    // in isolation so Playwright can exercise their behaviour without
+    // any view-level dependencies. The route is registered in all
+    // builds (saves a Vite env-flag branch) but is invisible from the
+    // sidebar / TopBar. ``skipFirstRunGuard`` keeps the page reachable
+    // even on a fresh install where the FirstRun guard would otherwise
+    // redirect to /firstrun.
+    path: '/_primitives_test',
+    name: 'primitives-sandbox',
+    component: () => import('./components/primitives/_sandbox/PrimitivesSandbox.vue'),
+    meta: { title: 'Primitives sandbox', skipFirstRunGuard: true },
+  },
+  {
     path: '/:catchAll(.*)',
     name: 'not-found',
     component: () => import('./views/NotFound.vue'),

--- a/ui/src/stores/banner.js
+++ b/ui/src/stores/banner.js
@@ -2,10 +2,13 @@
  * stores/banner.js — Pinia store for the v2 dashboard banner catalog.
  *
  * One source of truth for every "banner state" the design calls out.
- * The 18 entries below mirror the BANNER_CATALOG in
- * /tmp/hal0-design/hal0-v2/project/dash/primitives.jsx verbatim, with
+ * The 19 entries below mirror the BANNER_CATALOG in
+ * /tmp/hal0-design-v3/dash/primitives.jsx (v0.3) verbatim, with the
  * JSX ``body`` collapsed to plain strings (Vue components render the
  * monospace + emphasis via their own template).
+ *
+ * Slice #167 added the 19th entry, `skip-path` (slots scope, info kind),
+ * which is the v0.3 fold-in for the FirstRun "skip the picker" surface.
  *
  * Banners are scope-tagged so a view (Dashboard / Slots / Models / …)
  * can ask for ``activeByScope('slots')`` and get only the banners
@@ -25,7 +28,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 
 // ─────────────────────────────────────────────────────────────────────
-// Catalog — 18 entries, exact id + scope + kind + copy from the
+// Catalog — 19 entries, exact id + scope + kind + copy from the
 // design prototype. Body strings drop the JSX wrappers; Vue templates
 // can re-apply mono/strong styling on render.
 // ─────────────────────────────────────────────────────────────────────
@@ -201,6 +204,21 @@ export const BANNER_CATALOG = Object.freeze([
     actions: [
       { label: 'Take the tour', primary: true },
       { label: 'Dismiss' },
+    ],
+  },
+
+  // ── Slots (skip-path) — added in v0.3 fold-in (slice #167) ──────
+  // Mirror of /tmp/hal0-design-v3/dash/primitives.jsx lines 372–380.
+  // Lives under "slots" scope: shown on the Slots route when the user
+  // skipped the FirstRun bundle picker, prompting them to configure
+  // each seeded slot one-by-one or re-run the picker.
+  {
+    id: 'skip-path', scope: 'slots', kind: 'info',
+    eyebrow: 'Slots · skip-path',
+    heading: 'Six seeded slots, none configured',
+    body: 'You skipped the bundle picker. Each seeded slot below has a Configure button that opens the Create-slot modal pre-filled. Or run the bundle picker again from Settings → FirstRun.',
+    actions: [
+      { label: 'Run picker', primary: true },
     ],
   },
 ])

--- a/ui/tests/e2e/specs/primitives.spec.ts
+++ b/ui/tests/e2e/specs/primitives.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * primitives.spec.ts — slice #167 v2 primitives smoke + behaviour.
+ *
+ * Mounts each primitive on the test-only `/_primitives_test` route
+ * (registered in router.js as ``primitives-sandbox``) and exercises:
+ *
+ *   - Modal:  Esc closes, backdrop click closes, focus trap cycles.
+ *   - Drawer: open triggers translateX(0); Esc + backdrop close.
+ *   - ConfirmDialog: destructive type-to-confirm gates the confirm btn.
+ *   - BannerStack: filters by scope, dismiss removes from store.
+ *   - Menu:   auto-closes on outside click + Esc; stubbed item toasts.
+ *   - ToastStack: queues entries; short-ttl entry auto-removes.
+ *
+ * Uses the default apiMock fixture so the FirstRun guard treats the
+ * sandbox load as a "not first-run" navigation and renders the route.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+test.describe('v2 primitives', () => {
+  test.beforeEach(async ({ cleanState, page }) => {
+    void cleanState
+    await page.goto('/_primitives_test')
+    await expect(page.locator('h1', { hasText: 'Primitives sandbox' })).toBeVisible()
+  })
+
+  // ────────────────────────────────────────────────────────────────
+  test('Modal: opens, closes on Esc, closes on backdrop click', async ({ page }) => {
+    const open  = page.getByTestId('open-modal')
+    const body  = page.getByTestId('modal-body')
+
+    // Esc closes
+    await open.click()
+    await expect(body).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(body).toHaveCount(0)
+
+    // Backdrop click closes
+    await open.click()
+    await expect(body).toBeVisible()
+    // Click the backdrop near the corner — outside the .modal-shell.
+    await page.locator('.modal-backdrop').click({ position: { x: 4, y: 4 } })
+    await expect(body).toHaveCount(0)
+  })
+
+  // ────────────────────────────────────────────────────────────────
+  test('Drawer: opens with translateX(0), closes on Esc', async ({ page }) => {
+    const open = page.getByTestId('open-drawer')
+    const drawer = page.locator('.drawer-right')
+
+    // Initially the drawer element exists but is translated 100% off-screen.
+    await expect(drawer).toBeAttached()
+    let opened = await drawer.evaluate((el) => el.classList.contains('open'))
+    expect(opened).toBe(false)
+
+    await open.click()
+    // Wait for transition to complete (0.22s) before reading transform.
+    await page.waitForTimeout(300)
+    opened = await drawer.evaluate((el) => el.classList.contains('open'))
+    expect(opened).toBe(true)
+    // The transform should be the identity / translateX(0).
+    const transform = await drawer.evaluate((el) => getComputedStyle(el).transform)
+    expect(transform === 'none' || transform.includes('matrix(1, 0, 0, 1, 0, 0)')).toBe(true)
+
+    await page.keyboard.press('Escape')
+    await page.waitForTimeout(50)
+    opened = await drawer.evaluate((el) => el.classList.contains('open'))
+    expect(opened).toBe(false)
+  })
+
+  // ────────────────────────────────────────────────────────────────
+  test('ConfirmDialog (destructive + type-to-confirm)', async ({ page }) => {
+    await page.getByTestId('open-cd-type').click()
+    // Find the confirm button — second button in modal foot (cancel is first).
+    const confirmBtn = page.locator('.modal-foot .cd-foot-actions button').nth(1)
+    await expect(confirmBtn).toBeVisible()
+    await expect(confirmBtn).toBeDisabled()
+
+    // Type a non-matching value — still disabled.
+    const input = page.locator('.modal-shell input.input')
+    await input.fill('NOPE')
+    await expect(confirmBtn).toBeDisabled()
+
+    // Type the matching keyword "DELETE" → confirm enables.
+    await input.fill('DELETE')
+    await expect(confirmBtn).toBeEnabled()
+
+    await confirmBtn.click()
+    await expect(page.getByTestId('cd-log')).toContainText('type-confirm')
+  })
+
+  // ────────────────────────────────────────────────────────────────
+  test('ConfirmDialog: recoverable variant is enabled immediately', async ({ page }) => {
+    await page.getByTestId('open-cd-recoverable').click()
+    const confirmBtn = page.locator('.modal-foot .cd-foot-actions button').nth(1)
+    await expect(confirmBtn).toBeEnabled()
+    await confirmBtn.click()
+    await expect(page.getByTestId('cd-log')).toContainText('rec-confirm')
+  })
+
+  // ────────────────────────────────────────────────────────────────
+  test('BannerStack: filters by scope; dismiss removes from store', async ({ page }) => {
+    // Initially no banners.
+    await expect(page.locator('[data-testid="banner-stack"]')).toHaveCount(0)
+
+    // Toggle nuclear-evict (scope=slots) on — should render.
+    await page.getByTestId('ban-toggle-nuclear').click()
+    await expect(page.locator('[data-banner-id="nuclear-evict"]')).toBeVisible()
+
+    // Add lemond-offline (scope=global) — also renders inside the slots
+    // stack because BannerStack auto-includes "global" alongside the
+    // requested scope (matches the design's filter).
+    await page.getByTestId('ban-toggle-lemond').click()
+    await expect(page.locator('[data-banner-id="lemond-offline"]')).toBeVisible()
+
+    // Stack count = 2.
+    await expect(page.locator('[data-testid="banner-stack"] .banner')).toHaveCount(2)
+
+    // Add the 19th banner (slice #167 fold-in).
+    await page.getByTestId('ban-toggle-skip').click()
+    await expect(page.locator('[data-banner-id="skip-path"]')).toBeVisible()
+    await expect(page.locator('[data-testid="banner-stack"] .banner')).toHaveCount(3)
+
+    // Dismiss skip-path via the × button.
+    await page.locator('[data-banner-id="skip-path"] .banner-dismiss').click()
+    await expect(page.locator('[data-banner-id="skip-path"]')).toHaveCount(0)
+    await expect(page.locator('[data-testid="banner-stack"] .banner')).toHaveCount(2)
+  })
+
+  // ────────────────────────────────────────────────────────────────
+  test('Menu: opens, fires wired onClick, closes on outside click + Esc', async ({ page }) => {
+    await page.getByTestId('open-menu').click()
+    const menu = page.locator('.hal0-menu')
+    await expect(menu).toBeVisible()
+
+    // Click the wired action → onClick fires AND menu closes.
+    await menu.locator('.hal0-menu-item').first().click()
+    await expect(menu).toHaveCount(0)
+    await expect(page.getByTestId('menu-log')).toContainText('wired-fired')
+
+    // Re-open + Esc closes.
+    await page.getByTestId('open-menu').click()
+    await expect(menu).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(menu).toHaveCount(0)
+
+    // Re-open + outside click closes.
+    await page.getByTestId('open-menu').click()
+    await expect(menu).toBeVisible()
+    await page.locator('h1').click()
+    await expect(menu).toHaveCount(0)
+  })
+
+  // ────────────────────────────────────────────────────────────────
+  test('Menu: item without onClick fires a toast', async ({ page }) => {
+    await page.getByTestId('open-menu').click()
+    // The "Stubbed action" item is third (after wired + divider).
+    await page.locator('.hal0-menu-item', { hasText: 'Stubbed action' }).click()
+    // ToastStack renders the stubbed-toast.
+    await expect(page.locator('.hal0-toast', { hasText: 'Stubbed action — stubbed' })).toBeVisible()
+  })
+
+  // ────────────────────────────────────────────────────────────────
+  test('ToastStack: queues entries; short-ttl entry auto-removes', async ({ page }) => {
+    await expect(page.getByTestId('toast-count')).toHaveText('queue: 0')
+
+    await page.getByTestId('push-toast').click()
+    await page.getByTestId('push-toast').click()
+    await page.getByTestId('push-toast').click()
+    await expect(page.locator('.hal0-toast')).toHaveCount(3)
+    await expect(page.getByTestId('toast-count')).toHaveText('queue: 3')
+
+    // Push a short-lived toast (200ms ttl) and assert it disappears.
+    await page.getByTestId('push-short-toast').click()
+    await expect(page.locator('.hal0-toast', { hasText: 'quick' })).toBeVisible()
+    await page.waitForTimeout(400)
+    await expect(page.locator('.hal0-toast', { hasText: 'quick' })).toHaveCount(0)
+    // The three long-lived toasts remain.
+    await expect(page.locator('.hal0-toast')).toHaveCount(3)
+  })
+})


### PR DESCRIPTION
## Summary

Cross-cutting Vue 3 primitives for the v2 dashboard, mirroring `/tmp/hal0-design-v3/dash/primitives.jsx` 1:1. Self-contained under `ui/src/components/primitives/`; no existing views or chrome edited.

Closes the primitives half of #167. Slice from PLAN `docs/internal/dashboard-v2-implementation-plan-2026-05-23.md` (Phase 1).

## What ships

| Primitive | API | Notes |
| --- | --- | --- |
| `Modal.vue` | `{open, onClose, title?, eyebrow?, foot?, width=640, dismissable=true}` + default slot | Esc + backdrop close (gated by `dismissable`), body-scroll lock + restore, hand-rolled Tab/Shift+Tab focus trap, focus restore on close, `<Teleport to="body">` |
| `Drawer.vue` | `{open, onClose, title?, eyebrow?, foot?, width=520, side="right"}` | `translateX(100%)`→`0` slide; same lock/trap/restore as Modal |
| `ConfirmDialog.vue` | `{open, onCancel, onConfirm, title, message, confirmLabel, cancelLabel, destructive, typeToConfirm}` | Wraps Modal; destructive = red btn + eyebrow; `typeToConfirm` gates confirm until exact match |
| `Banner.vue` | `{kind, heading, eyebrow?, body, actions, onDismiss?, dismissable=true}` | Reusable shell; emits `@action` so it stays store-agnostic |
| `BannerStack.vue` | `{scope}` | Reads `useBannerStore.activeByScope(scope)` + the global scope; falls back to a toast when an action has no `onClick` |
| `Menu.vue` | `{open, anchor, items[], onClose, side}` | Teleported popover; auto-close on outside-click + Esc + selection; stubbed items toast `"<label> — stubbed"` |
| `Toast.vue` / `ToastStack.vue` | reads `useToastStore` | Presentational pill + top-right `TransitionGroup`; **NOT yet mounted at App root — that's slice #5** |

## 19th banner — skip-path

`BANNER_CATALOG` in `ui/src/stores/banner.js` is now **19 entries** (was 18). The new `skip-path` entry (`scope: 'slots'`, `kind: 'info'`) is the v0.3 fold-in for the FirstRun bundle-picker skip surface — mirrors lines 372–380 of `primitives.jsx`.

## Tests

`ui/tests/e2e/specs/primitives.spec.ts` — **8 specs, all green** alongside the **45 pre-existing specs** (46 total passing; one models-slots-refactor.spec.ts a11y test is a pre-existing flake that passes on isolated re-run).

- Modal: Esc + backdrop close
- Drawer: `translateX(0)` on open + Esc close
- ConfirmDialog destructive + type-to-confirm gate
- ConfirmDialog recoverable enabled immediately
- BannerStack scope filtering + 19th-banner registration + dismiss removes from store
- Menu wired-onClick + Esc + outside-click close
- Menu stubbed item toasts
- ToastStack queue + short-ttl auto-removal

Test mount lives at `/_primitives_test` (sandbox route registered in `router.js` with `skipFirstRunGuard: true`; unreachable from chrome).

## Anti-scope respected

- Zero edits to `ui/src/views/**`
- Existing `ConfirmDialog.vue`, `ToastContainer.vue`, `LoadingSkeleton.vue` untouched (v1 surfaces keep their existing primitives)
- Chrome (TopBar/Sidebar/Footer) untouched — slice #5
- `ToastStack` NOT mounted at App root — slice #5
- No Tailwind/Vite config changes

## Test plan

- [ ] `cd ui && npm run build` clean (Vite + Tailwind compile)
- [ ] `cd ui && npx playwright test` 46 passed
- [ ] Manual: visit `/_primitives_test`, exercise each toggle, eyeball against `/tmp/hal0-design-v3/dash/primitives.jsx` rendered output
- [ ] Pre-existing python ruff errors are NOT from this PR (only `ui/*` files touched; diff stat confirms)