### PR TITLE
feat(admin): Settings → Lemonade admin panel (PR-13)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -59,6 +59,9 @@ from hal0.api.routes import (
     v1,
 )
 from hal0.api.routes import (
+    lemonade_admin as lemonade_admin_routes,
+)
+from hal0.api.routes import (
     lemonade_logs as lemonade_logs_routes,
 )
 from hal0.api.routes import (
@@ -634,6 +637,18 @@ def create_app() -> FastAPI:
         lemonade_logs_routes.router,
         prefix="/api/lemonade",
         tags=["lemonade", "logs"],
+        dependencies=_admin_auth,
+    )
+    # PR-13: Lemonade admin panel — GET /api/lemonade/config + POST
+    # /api/lemonade/config wrap lemond's /internal/config + /internal/set
+    # so the Settings → Lemonade admin panel can read + edit runtime
+    # config without bypassing hal0's auth. Same admin gate as the log
+    # proxy; POST additionally declares require_writer at the route
+    # level so cookie sessions ride the CSRF tripwire.
+    app.include_router(
+        lemonade_admin_routes.router,
+        prefix="/api/lemonade",
+        tags=["lemonade", "admin"],
         dependencies=_admin_auth,
     )
     app.include_router(

--- a/src/hal0/api/routes/lemonade_admin.py
+++ b/src/hal0/api/routes/lemonade_admin.py
@@ -1,0 +1,365 @@
+"""Lemonade admin endpoints (mounted under /api/lemonade).
+
+PR-13 (plan §11 + plan §2.2 + ADR-0008 §1/§7): config read/write surface
+for the Settings → Lemonade admin panel. Two routes:
+
+  ``GET  /api/lemonade/config``   — full runtime config snapshot from
+                                    ``lemond /internal/config``. Returned
+                                    verbatim plus the immediate-vs-deferred
+                                    key-split metadata the UI needs to
+                                    render the "takes effect now" / "next
+                                    load" labels (plan §2.2).
+  ``POST /api/lemonade/config``   — body ``{key: value, ...}``. Forwarded
+                                    to ``lemond /internal/set`` after
+                                    validation. The response ECHOES which
+                                    keys took immediate effect and which
+                                    are deferred until next load — the UI
+                                    surfaces this in the success toast.
+
+Both routes are admin-gated by the parent ``_admin_auth`` dependency
+applied at ``include_router`` time (see :mod:`hal0.api.__init__`), so we
+don't redeclare auth here. Read is GET; the mutating route is also
+gated by ``require_writer`` so a cookie-based session needs CSRF in
+addition to the admin scope — matching the pattern in
+``/api/settings``.
+
+Validation guardrails (plan §11 PR-13 brief + ADR-0008 §3 + §7):
+
+  - Unknown keys (not in either admin list) are refused 400.
+  - ``llamacpp_args`` MUST contain ``--threads N`` with N >= 2 — per the
+    ``hal0_lemonade_threads_deadlock`` memory, omitting --threads or
+    dropping below 2 oversubscribes the LXC's cores and trips a 30s
+    Vulkan deadlock on the first dual-child load.
+  - ``flm_args`` MUST contain BOTH ``--asr 1`` AND ``--embed 1`` — the
+    FLM trio is mandatory in v0.2 (plan §5, ADR-0009 §1). Without these
+    flags the NPU stt/embed slots have no backend.
+  - ``extra_models_dir`` MUST equal ``/var/lib/hal0/models`` — the
+    symlink farm root (plan §3 + §6.1). Other values would silently
+    repurpose lemond's auto-discovery against hal0's curated layout.
+    Refused 400 rather than warned because flipping this in production
+    leaves the dashboard rendering models lemond can't actually load.
+
+Validation failures return the hal0 error envelope with
+``code: "lemonade.config_invalid"`` and per-field ``details``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+
+from hal0.api.middleware.auth import require_writer
+from hal0.errors import BadRequest, Hal0Error
+
+router = APIRouter()
+
+# See settings.py for the writer-gate rationale: GET stays on the parent
+# admin gate (require_token), POST additionally requires writer scope so
+# cookie sessions ride through the CSRF tripwire alongside Bearer tokens.
+_writer = [Depends(require_writer)]
+
+
+# ── key taxonomy (plan §2.2) ──────────────────────────────────────────
+
+# Keys whose value lemond applies immediately on POST /internal/set. The
+# admin UI shows "Immediate" beside these.
+IMMEDIATE_KEYS: frozenset[str] = frozenset(
+    {
+        "port",
+        "host",
+        "log_level",
+        "global_timeout",
+        "no_broadcast",
+        "extra_models_dir",
+    }
+)
+
+# Keys whose value lemond persists but does NOT apply until the next
+# /v1/load. The admin UI shows "Deferred (next load)" beside these so
+# the operator isn't surprised when the value sticks but observed
+# behaviour stays on the prior value until a load lands.
+DEFERRED_KEYS: frozenset[str] = frozenset(
+    {
+        "max_loaded_models",
+        "ctx_size",
+        "llamacpp_backend",
+        "llamacpp_args",
+        "sdcpp_backend",
+        "whispercpp_backend",
+        "steps",
+        "cfg_scale",
+        "width",
+        "height",
+        "flm_args",
+    }
+)
+
+# Union of every admin-editable key — gates "unknown key" rejection.
+ADMIN_KEYS: frozenset[str] = IMMEDIATE_KEYS | DEFERRED_KEYS
+
+# Locked invariant for extra_models_dir per plan §3 + §6.1. The
+# installer writes this path into the seeded config.json and the symlink
+# farm depends on it; flipping it from the admin panel would silently
+# desync the dashboard's model list from what lemond can actually load.
+LOCKED_EXTRA_MODELS_DIR: str = "/var/lib/hal0/models"
+
+
+class LemonadeConfigInvalidError(Hal0Error):
+    """Validation failure on POST /api/lemonade/config — typed so the
+    envelope carries a per-key reason map."""
+
+    code = "lemonade.config_invalid"
+    status = 400
+
+
+# ── llamacpp_args parser ──────────────────────────────────────────────
+
+
+# Match ``--threads N`` (single dash long form). Lemonade serialises
+# llamacpp_args as a single space-separated string per the
+# ``hal0_lemonade_v1_load_schema`` memory; we accept the same form here.
+# The lookahead-anchored boundary keeps ``--threads-extra`` (a
+# hypothetical future flag) from matching.
+_THREADS_RE = re.compile(r"(?:^|\s)--threads(?:\s+|=)(\d+)(?=\s|$)")
+
+
+def _extract_threads(llamacpp_args: str) -> int | None:
+    """Return the parsed ``--threads N`` value, or None if absent.
+
+    Matches both ``--threads 8`` and ``--threads=8`` so the operator
+    isn't forced into one wire form. Returns None when the flag is
+    missing entirely; returns the integer otherwise (caller validates
+    the >=2 bound).
+    """
+    m = _THREADS_RE.search(llamacpp_args)
+    if m is None:
+        return None
+    try:
+        return int(m.group(1))
+    except ValueError:
+        return None
+
+
+# ── per-key validators ────────────────────────────────────────────────
+
+
+def _validate_llamacpp_args(value: object) -> str | None:
+    """Return an error message if ``llamacpp_args`` would break the
+    locked invariant, else None.
+
+    Per ``hal0_lemonade_threads_deadlock``: lemond's default child
+    invocation omits ``--threads``, which on a 12-core LXC starts
+    multiple Vulkan dispatch threads per child and oversubscribes the
+    cores. The recipe is ``--parallel 1 --threads N`` with N computed
+    from cores; we refuse anything that drops or zeroes the flag.
+    """
+    if not isinstance(value, str):
+        return "must be a string"
+    n = _extract_threads(value)
+    if n is None:
+        return (
+            "must include --threads N where N >= 2 "
+            "(per hal0_lemonade_threads_deadlock — omitting --threads "
+            "trips a Vulkan dispatch deadlock under concurrent load)"
+        )
+    if n < 2:
+        return f"--threads {n} is below the required minimum of 2"
+    return None
+
+
+def _validate_flm_args(value: object) -> str | None:
+    """Return an error message if ``flm_args`` would break the FLM-trio
+    mandate, else None.
+
+    Per plan §5 + ADR-0009 §1, the NPU has a single AMDXDNA hardware
+    context per host — a single ``flm serve`` process. The trio flags
+    ``--asr 1 --embed 1`` pack chat + ASR + embed into that one process.
+    Without both flags the NPU stt-npu and embed-npu slots have no
+    backend; the dashboard would render those slots green while requests
+    404 against a non-existent FLM child port.
+    """
+    if not isinstance(value, str):
+        return "must be a string"
+    # Tolerate any whitespace between flag and arg ("--asr 1", "--asr  1",
+    # "--asr\t1"). Reject "--asr 0" — that's the disable form.
+    if not re.search(r"--asr\s+1(?:\s|$)", value):
+        return "must include --asr 1 (FLM trio mandate, plan §5)"
+    if not re.search(r"--embed\s+1(?:\s|$)", value):
+        return "must include --embed 1 (FLM trio mandate, plan §5)"
+    return None
+
+
+def _validate_extra_models_dir(value: object) -> str | None:
+    """Return an error message if ``extra_models_dir`` would diverge
+    from the symlink farm root, else None."""
+    if not isinstance(value, str):
+        return "must be a string"
+    if value != LOCKED_EXTRA_MODELS_DIR:
+        return (
+            f"must equal {LOCKED_EXTRA_MODELS_DIR!r} "
+            "(plan §3 + §6.1 — the symlink farm root is the single "
+            "source of truth for the model catalog)"
+        )
+    return None
+
+
+# Map of key -> validator. Keys not in the map skip per-value validation
+# but still go through the unknown-key gate above.
+_VALIDATORS: dict[str, Any] = {
+    "llamacpp_args": _validate_llamacpp_args,
+    "flm_args": _validate_flm_args,
+    "extra_models_dir": _validate_extra_models_dir,
+}
+
+
+def _validate_patch(body: dict[str, Any]) -> dict[str, str]:
+    """Return a ``{key: reason}`` map of validation errors. Empty when
+    the patch is acceptable.
+
+    Order:
+      1. Unknown key gate (key not in IMMEDIATE_KEYS | DEFERRED_KEYS).
+      2. Per-key validator for the locked-invariant keys.
+
+    Keys without a dedicated validator are passed through — lemond's own
+    typed schema is the second line of defence (an out-of-range
+    ``global_timeout`` will surface as a 4xx from /internal/set), but we
+    don't reject ergonomic values like ``port=13306`` at this layer.
+    """
+    errors: dict[str, str] = {}
+    for key, value in body.items():
+        if key not in ADMIN_KEYS:
+            errors[key] = f"unknown key — admin-editable keys are {sorted(ADMIN_KEYS)}"
+            continue
+        validator = _VALIDATORS.get(key)
+        if validator is None:
+            continue
+        reason = validator(value)
+        if reason is not None:
+            errors[key] = reason
+    return errors
+
+
+# ── effect-classification helper ──────────────────────────────────────
+
+
+def _classify_effects(keys: list[str]) -> dict[str, list[str]]:
+    """Split a list of touched keys into ``{immediate: [...], deferred:
+    [...]}``. Used to echo what the operator's POST actually changed."""
+    immediate = sorted(k for k in keys if k in IMMEDIATE_KEYS)
+    deferred = sorted(k for k in keys if k in DEFERRED_KEYS)
+    return {"immediate": immediate, "deferred": deferred}
+
+
+# ── routes ────────────────────────────────────────────────────────────
+
+
+@router.get("/config")
+async def get_lemonade_config(request: Request) -> dict[str, Any]:
+    """Return the full ``lemond /internal/config`` snapshot.
+
+    Verbatim payload from lemond plus a ``_hal0.effects`` block carrying
+    the immediate-vs-deferred key partition so the UI doesn't have to
+    re-encode the lists locally. The underscore prefix marks it as a
+    hal0-added envelope field rather than something lemond owns.
+
+    On lemond unavailable we surface the Lemonade error as-is rather
+    than masking it as 500 — the admin panel's empty state needs to
+    distinguish "control plane down" from "config save crashed".
+    """
+    from hal0.providers import lemonade_provider
+
+    client = lemonade_provider().client()
+    snapshot = await client.internal_config()
+    return {
+        **snapshot,
+        "_hal0": {
+            "effects": {
+                "immediate": sorted(IMMEDIATE_KEYS),
+                "deferred": sorted(DEFERRED_KEYS),
+            },
+            "locked": {
+                "extra_models_dir": LOCKED_EXTRA_MODELS_DIR,
+            },
+        },
+    }
+
+
+@router.post("/config", dependencies=_writer)
+async def set_lemonade_config(request: Request) -> dict[str, Any]:
+    """Apply a partial config update against ``lemond /internal/set``.
+
+    Body shape: ``{key: value, ...}`` — only the keys being changed. The
+    keys must all be in :data:`ADMIN_KEYS` and pass any locked-invariant
+    validators (see :func:`_validate_patch`). Validation failures return
+    400 ``lemonade.config_invalid`` with a per-key ``details`` map.
+
+    Response shape::
+
+        {
+          "applied": {<the keys lemond echoed back>},
+          "effects": {
+            "immediate": ["log_level", ...],
+            "deferred":  ["llamacpp_args", ...]
+          }
+        }
+
+    The UI uses ``effects`` to render the success toast ("Saved — N
+    immediate, M deferred until next load") and to know whether to
+    surface a "restart a slot to apply" hint.
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise BadRequest(
+            "request body must be valid JSON",
+            details={"error": str(exc)},
+            code="request.invalid_json",
+        ) from exc
+    if not isinstance(body, dict):
+        raise BadRequest(
+            "request body must be a JSON object",
+            code="request.not_an_object",
+        )
+    if not body:
+        # Empty PATCHes are a no-op; surface that explicitly rather
+        # than calling /internal/set with `{}` (lemond's behaviour for
+        # an empty body is unspecified).
+        raise BadRequest(
+            "request body must contain at least one key to set",
+            code="lemonade.config_empty",
+        )
+
+    errors = _validate_patch(body)
+    if errors:
+        raise LemonadeConfigInvalidError(
+            "one or more keys failed validation",
+            details=errors,
+        )
+
+    from hal0.providers import lemonade_provider
+
+    client = lemonade_provider().client()
+    result = await client.internal_set(body)
+
+    # Echo the immediate-vs-deferred split for exactly the keys this
+    # request touched. We classify off the request body rather than the
+    # response's ``applied`` field so the UI can render the toast even
+    # if a future lemond version drops that field.
+    effects = _classify_effects(list(body.keys()))
+
+    return {
+        "applied": result,
+        "effects": effects,
+    }
+
+
+__all__ = [
+    "ADMIN_KEYS",
+    "DEFERRED_KEYS",
+    "IMMEDIATE_KEYS",
+    "LOCKED_EXTRA_MODELS_DIR",
+    "LemonadeConfigInvalidError",
+    "router",
+]

--- a/tests/api/test_lemonade_admin_route.py
+++ b/tests/api/test_lemonade_admin_route.py
@@ -1,0 +1,502 @@
+"""Tests for /api/lemonade/config — admin panel surface (PR-13).
+
+Covers (plan §11 PR-13 + plan §2.2 + ADR-0008 §1/§7):
+
+  - GET returns the lemond /internal/config snapshot verbatim + the
+    immediate-vs-deferred effect partition + the locked-invariant
+    pointers the UI uses for inline validation hints.
+  - POST happy path: known keys forwarded to /internal/set; response
+    echoes the immediate/deferred split for the keys the request
+    touched.
+  - POST validation: unknown key rejected; llamacpp_args without
+    --threads or with --threads below 2 rejected; flm_args missing
+    either trio flag rejected; extra_models_dir diverging from the
+    symlink farm root rejected.
+  - Auth: the routes are mounted under the parent _admin_auth gate so
+    no per-route auth check is needed; this is covered structurally
+    by the include_router wiring in hal0.api.__init__ and exercised
+    end-to-end by tests/api/test_auth_middleware.py.
+
+Lemonade is stubbed via the same MockTransport pattern as
+test_slots_lemonade_state.py — install a fake LemonadeProvider on the
+process-wide singleton, yield, restore on teardown.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import hal0.providers as providers_mod
+from hal0.api import create_app
+from hal0.api.routes.lemonade_admin import (
+    ADMIN_KEYS,
+    DEFERRED_KEYS,
+    IMMEDIATE_KEYS,
+    LOCKED_EXTRA_MODELS_DIR,
+)
+from hal0.lemonade.client import LemonadeClient
+from hal0.providers.lemonade import LemonadeProvider
+
+# ── stub fixture ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def lemonade_state() -> dict[str, Any]:
+    """Mutable handle: ``config`` is what /internal/config returns;
+    ``last_set`` captures the last /internal/set body for assertions."""
+    return {
+        "config": {
+            "host": "127.0.0.1",
+            "port": 13305,
+            "ctx_size": 4096,
+            "max_loaded_models": 4,
+            "extra_models_dir": LOCKED_EXTRA_MODELS_DIR,
+            "global_timeout": 900,
+            "no_broadcast": True,
+            "log_level": "info",
+            "llamacpp": {
+                "args": "--parallel 1 --threads 8",
+                "backend": "rocm",
+            },
+            "flm": {"args": "--asr 1 --embed 1"},
+            "sdcpp": {
+                "backend": "rocm",
+                "steps": 20,
+                "cfg_scale": 7.0,
+                "width": 512,
+                "height": 512,
+            },
+            "whispercpp": {"backend": "vulkan"},
+        },
+        "last_set": None,
+    }
+
+
+@pytest.fixture
+def installed_lemonade_stub(
+    lemonade_state: dict[str, Any],
+) -> Iterator[dict[str, Any]]:
+    """Install a Lemonade stub whose /internal/* surface obeys
+    lemonade_state mutations.
+
+    /internal/config returns the current snapshot; /internal/set merges
+    the body into the snapshot and echoes ``{"applied": [keys]}``. All
+    other paths return 404 so we never accidentally rely on an
+    un-mocked endpoint.
+    """
+    state = lemonade_state
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/internal/config" and req.method == "GET":
+            return httpx.Response(200, json=state["config"])
+        if req.url.path == "/internal/set" and req.method == "POST":
+            import json as _json
+
+            body = _json.loads(req.content.decode() or "{}")
+            state["last_set"] = body
+            # Mirror the merge into the snapshot so a follow-up GET
+            # reflects what was just set — matches lemond's real
+            # atomic-set semantics.
+            state["config"].update(body)
+            return httpx.Response(200, json={"applied": list(body)})
+        return httpx.Response(404, json={"detail": f"unmocked {req.url.path}"})
+
+    transport = httpx.AsyncClient(
+        transport=httpx.MockTransport(h),
+        base_url="http://test",
+    )
+    provider = LemonadeProvider(client=LemonadeClient(http_client=transport))
+    original = providers_mod._PROVIDERS["lemonade"]
+    providers_mod._PROVIDERS["lemonade"] = provider
+    try:
+        yield state
+    finally:
+        providers_mod._PROVIDERS["lemonade"] = original
+
+
+@pytest.fixture
+def isolated_app(tmp_hal0_home: str) -> FastAPI:
+    return create_app()
+
+
+@pytest.fixture
+def isolated_client(isolated_app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(isolated_app) as c:
+        yield c
+
+
+# ── GET /api/lemonade/config ─────────────────────────────────────────
+
+
+def test_get_config_returns_lemond_snapshot_verbatim(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """Every key in lemond's /internal/config response appears in our
+    GET response unchanged. The route adds metadata under ``_hal0`` but
+    must not mutate the upstream payload."""
+    r = isolated_client.get("/api/lemonade/config")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    for key, value in installed_lemonade_stub["config"].items():
+        assert body[key] == value, f"key {key!r} mutated by hal0 route"
+
+
+def test_get_config_attaches_immediate_deferred_partition(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """``_hal0.effects`` carries the sorted immediate + deferred lists
+    the UI uses to render the "takes effect now" / "next load" labels
+    without re-encoding them in the frontend."""
+    r = isolated_client.get("/api/lemonade/config")
+    body = r.json()
+    effects = body["_hal0"]["effects"]
+    assert effects["immediate"] == sorted(IMMEDIATE_KEYS)
+    assert effects["deferred"] == sorted(DEFERRED_KEYS)
+
+
+def test_get_config_attaches_locked_invariants(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """``_hal0.locked`` carries the canonical extra_models_dir pointer
+    so the UI's inline hint stays in sync with the backend validator."""
+    r = isolated_client.get("/api/lemonade/config")
+    body = r.json()
+    assert body["_hal0"]["locked"]["extra_models_dir"] == LOCKED_EXTRA_MODELS_DIR
+
+
+def test_immediate_and_deferred_partitions_are_disjoint() -> None:
+    """No key may be in both halves — a key that's "immediate" can't
+    also be "deferred"; if lemond ever changes this, the constants here
+    need to flip too."""
+    assert not (IMMEDIATE_KEYS & DEFERRED_KEYS)
+    assert ADMIN_KEYS == IMMEDIATE_KEYS | DEFERRED_KEYS
+
+
+# ── POST /api/lemonade/config — happy path ───────────────────────────
+
+
+def test_post_config_forwards_known_keys_to_internal_set(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """A patch with valid keys lands on /internal/set verbatim — no
+    drop, no rename, no enrichment."""
+    patch = {"log_level": "debug", "max_loaded_models": 6}
+    r = isolated_client.post("/api/lemonade/config", json=patch)
+    assert r.status_code == 200, r.text
+    assert installed_lemonade_stub["last_set"] == patch
+
+
+def test_post_config_echoes_immediate_deferred_split(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """The response's ``effects`` block partitions JUST the touched
+    keys (not the global lists) so the UI can render a precise toast."""
+    patch = {
+        "log_level": "debug",  # immediate
+        "max_loaded_models": 6,  # deferred
+        "ctx_size": 8192,  # deferred
+    }
+    r = isolated_client.post("/api/lemonade/config", json=patch)
+    body = r.json()
+    assert body["effects"]["immediate"] == ["log_level"]
+    assert body["effects"]["deferred"] == ["ctx_size", "max_loaded_models"]
+
+
+def test_post_config_immediate_only_patch(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """A patch touching only immediate keys reports no deferred work —
+    the UI uses this to suppress the "next load" hint."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"log_level": "warn", "no_broadcast": False},
+    )
+    body = r.json()
+    assert body["effects"]["deferred"] == []
+    assert set(body["effects"]["immediate"]) == {"log_level", "no_broadcast"}
+
+
+def test_post_config_deferred_only_patch(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """Symmetric to the immediate-only case — touching only deferred
+    keys reports nothing immediate so the UI shows the "next load"
+    notice."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"ctx_size": 2048},
+    )
+    body = r.json()
+    assert body["effects"]["immediate"] == []
+    assert body["effects"]["deferred"] == ["ctx_size"]
+
+
+def test_post_config_applied_field_carries_lemond_echo(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """``applied`` echoes lemond's response so a future protocol bump
+    (e.g. lemond starting to return rejected keys here) surfaces to
+    the UI without a hal0 release."""
+    r = isolated_client.post("/api/lemonade/config", json={"log_level": "info"})
+    body = r.json()
+    assert body["applied"] == {"applied": ["log_level"]}
+
+
+# ── POST /api/lemonade/config — validation ───────────────────────────
+
+
+def test_post_config_rejects_unknown_key(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """A key outside IMMEDIATE | DEFERRED is refused 400 — we don't
+    forward random keys to lemond because the surface might accept
+    them silently with non-obvious effects (ADR-0008 §7)."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"rocm_channel": "nightly"},  # not admin-editable
+    )
+    assert r.status_code == 400, r.text
+    body = r.json()
+    assert body["error"]["code"] == "lemonade.config_invalid"
+    assert "rocm_channel" in body["error"]["details"]
+    # lemond stub should not have been called.
+    assert installed_lemonade_stub["last_set"] is None
+
+
+def test_post_config_rejects_llamacpp_args_without_threads(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """Omitting --threads trips the LXC oversubscribe deadlock — refuse
+    early per hal0_lemonade_threads_deadlock."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"llamacpp_args": "--parallel 1"},
+    )
+    assert r.status_code == 400, r.text
+    details = r.json()["error"]["details"]
+    assert "llamacpp_args" in details
+    assert "--threads" in details["llamacpp_args"]
+    assert installed_lemonade_stub["last_set"] is None
+
+
+def test_post_config_rejects_llamacpp_args_threads_zero(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """--threads 0 is functionally the same as omitting the flag (libc
+    interprets 0 as ``nproc``) — refuse with a clear "below minimum"
+    message so the operator sees the floor, not a generic shape error."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"llamacpp_args": "--parallel 1 --threads 0"},
+    )
+    assert r.status_code == 400, r.text
+    details = r.json()["error"]["details"]
+    assert "below the required minimum" in details["llamacpp_args"]
+
+
+def test_post_config_rejects_llamacpp_args_threads_one(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """--threads 1 is below the documented floor — refuse with the
+    same message as threads=0 because the deadlock risk is identical."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"llamacpp_args": "--parallel 1 --threads 1"},
+    )
+    assert r.status_code == 400, r.text
+
+
+def test_post_config_accepts_llamacpp_args_threads_equals_form(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """``--threads=8`` is the same as ``--threads 8`` — the validator
+    tolerates the equals form so operators copying llama.cpp invocations
+    from upstream docs don't trip the gate."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"llamacpp_args": "--parallel 1 --threads=8"},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_post_config_rejects_flm_args_missing_asr(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """Without --asr 1 the FLM trio collapses to chat-only — the NPU
+    stt-npu slot would 404 against a non-existent backend port."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"flm_args": "--embed 1"},
+    )
+    assert r.status_code == 400, r.text
+    details = r.json()["error"]["details"]
+    assert "--asr 1" in details["flm_args"]
+
+
+def test_post_config_rejects_flm_args_missing_embed(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """Symmetric to missing-asr: without --embed 1 the embed-npu slot
+    has no backend."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"flm_args": "--asr 1"},
+    )
+    assert r.status_code == 400, r.text
+    details = r.json()["error"]["details"]
+    assert "--embed 1" in details["flm_args"]
+
+
+def test_post_config_rejects_flm_args_with_disable_flag(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """``--asr 0`` is the disable form — must NOT pass the trio
+    mandate, even though "--asr" appears in the string."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"flm_args": "--asr 0 --embed 1"},
+    )
+    assert r.status_code == 400, r.text
+
+
+def test_post_config_accepts_canonical_flm_args(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """The recommended ``--asr 1 --embed 1`` value passes — sanity
+    check the positive path so the validator can't drift into rejecting
+    its own canonical form."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"flm_args": "--asr 1 --embed 1"},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_post_config_rejects_extra_models_dir_divergence(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """Flipping extra_models_dir off the symlink farm root would silently
+    desync the dashboard's catalog from what lemond can load (plan §3 +
+    §6.1). Refuse with the canonical path in the error message."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"extra_models_dir": "/mnt/ai-models"},
+    )
+    assert r.status_code == 400, r.text
+    details = r.json()["error"]["details"]
+    assert LOCKED_EXTRA_MODELS_DIR in details["extra_models_dir"]
+
+
+def test_post_config_accepts_canonical_extra_models_dir(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """Setting extra_models_dir to its locked value is a no-op pass —
+    operators rotating the config should not hit a 400 just because
+    they re-sent the canonical value."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"extra_models_dir": LOCKED_EXTRA_MODELS_DIR},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_post_config_aggregates_multiple_validation_errors(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """If three keys fail at once the response carries all three reasons
+    in ``details`` — the UI's per-field inline error rendering depends
+    on this (single 4xx per submit, not three round-trips)."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={
+            "llamacpp_args": "--parallel 1",
+            "flm_args": "--asr 1",
+            "rocm_channel": "nightly",
+        },
+    )
+    assert r.status_code == 400, r.text
+    details = r.json()["error"]["details"]
+    assert set(details.keys()) == {"llamacpp_args", "flm_args", "rocm_channel"}
+
+
+# ── POST /api/lemonade/config — empty + malformed bodies ─────────────
+
+
+def test_post_config_rejects_empty_body(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """An empty patch is a no-op; we surface a typed 400 rather than
+    proxying ``{}`` to lemond (whose behaviour for empty bodies is
+    unspecified)."""
+    r = isolated_client.post("/api/lemonade/config", json={})
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "lemonade.config_empty"
+
+
+def test_post_config_rejects_non_object_body(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """A JSON array (or scalar) at the top level is rejected — lemond's
+    /internal/set expects an object."""
+    r = isolated_client.post("/api/lemonade/config", json=["log_level"])
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "request.not_an_object"
+
+
+def test_post_config_rejects_non_json_body(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """Non-JSON bodies surface as ``request.invalid_json`` rather than
+    crashing with a parser stack trace."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        content=b"not json",
+        headers={"content-type": "application/json"},
+    )
+    assert r.status_code == 400, r.text
+
+
+# ── Round-trip ───────────────────────────────────────────────────────
+
+
+def test_post_then_get_reflects_change(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """After POST applies the patch (against the merging stub), a
+    follow-up GET shows the new value — confirms the stub mirrors
+    lemond's atomic-set semantics + the route doesn't cache GET."""
+    r = isolated_client.post("/api/lemonade/config", json={"log_level": "warn"})
+    assert r.status_code == 200, r.text
+    r2 = isolated_client.get("/api/lemonade/config")
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["log_level"] == "warn"

--- a/ui/src/router.js
+++ b/ui/src/router.js
@@ -58,6 +58,16 @@ const routes = [
     meta: { title: 'Settings' },
   },
   {
+    // PR-13: Lemonade admin panel — config view + edit of lemond's
+    // /internal/config surface. Separate route (not a section on the
+    // main Settings page) so the unsaved-changes-on-leave behaviour
+    // stays isolated to this panel.
+    path: '/settings/lemonade',
+    name: 'settings-lemonade',
+    component: () => import('./views/Settings/LemonadeAdmin.vue'),
+    meta: { title: 'Lemonade admin' },
+  },
+  {
     // Phase 8 bundled-agent surface. The page is one host component
     // with horizontal tabs driven by ?tab=overview|inbox|activity|chat
     // so the URL is shareable + reload-stable.

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -741,6 +741,28 @@ onMounted(async () => {
         </div>
       </Card>
 
+      <!-- ── Lemonade admin link (PR-13) ─────────────────────────── -->
+      <Card>
+        <div class="lemonade-link-row">
+          <div>
+            <h3 class="section-title">Lemonade backend</h3>
+            <p class="field-hint">
+              Runtime config of the bundled <code class="mono">lemond</code> daemon —
+              backends, ctx_size, concurrency budget, FLM NPU args. Edits go through
+              <code class="mono">/internal/set</code>; some take effect immediately,
+              others apply at the next model load.
+            </p>
+          </div>
+          <router-link
+            :to="{ name: 'settings-lemonade' }"
+            class="btn-ghost"
+            data-testid="lemonade-admin-link"
+          >
+            Open Lemonade admin
+          </router-link>
+        </div>
+      </Card>
+
       <!-- ── Model locations panel ───────────────────────────────── -->
       <Card>
         <h3 class="section-title">Model locations</h3>
@@ -1341,6 +1363,19 @@ onMounted(async () => {
 .roots-actions { display: flex; align-items: center; gap: 12px; margin-top: 6px; flex-wrap: wrap; }
 .auto-scan-label { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--color-fg-muted); cursor: pointer; }
 .auto-scan-label input[type="checkbox"] { accent-color: var(--hal0-accent); }
+
+/* ── Lemonade admin link card (PR-13) ──────────────────────────── */
+.lemonade-link-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.lemonade-link-row .btn-ghost {
+  flex-shrink: 0;
+  text-decoration: none;
+}
 
 /* ── Proxmox integration panel ──────────────────────────────────── */
 .proxmox-header { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }

--- a/ui/src/views/Settings/LemonadeAdmin.vue
+++ b/ui/src/views/Settings/LemonadeAdmin.vue
@@ -1,0 +1,605 @@
+<script setup>
+/**
+ * LemonadeAdmin.vue — Settings → Lemonade admin panel (PR-13).
+ *
+ * Backend contract (src/hal0/api/routes/lemonade_admin.py):
+ *   GET  /api/lemonade/config   → snapshot + _hal0.{effects,locked}
+ *   POST /api/lemonade/config   → body {key: value, ...}
+ *                                  resp {applied, effects:{immediate,deferred}}
+ *
+ * Plan §2.2 key partition:
+ *   immediate: port, host, log_level, global_timeout, no_broadcast,
+ *              extra_models_dir
+ *   deferred:  max_loaded_models, ctx_size, llamacpp_backend,
+ *              llamacpp_args, sdcpp_backend, whispercpp_backend, steps,
+ *              cfg_scale, width, height, flm_args
+ *
+ * Lemonade's /internal/config returns nested keys (llamacpp.{args,
+ * backend}, sdcpp.{backend,steps,...}, whispercpp.backend, flm.args)
+ * but /internal/set takes flat key names (llamacpp_args,
+ * llamacpp_backend, sdcpp_backend, ...). We map both directions in
+ * unpackConfig / buildPatch so the form binding stays flat.
+ *
+ * Locked invariants surfaced inline by the backend's _hal0.locked
+ * block + per-validator hints:
+ *   - llamacpp_args must contain --threads N where N >= 2
+ *     (hal0_lemonade_threads_deadlock)
+ *   - flm_args must contain --asr 1 AND --embed 1 (plan §5 trio)
+ *   - extra_models_dir must equal /var/lib/hal0/models (plan §3 + §6.1)
+ *
+ * No new pinia stores; #178's stores landed on feat/dash-v2-rework, not
+ * main. We use the existing toasts.js store for save UX and the api()
+ * composable for fetches.
+ */
+import { ref, reactive, computed, onMounted } from 'vue'
+import { useToastsStore } from '../../stores/toasts.js'
+import { api } from '../../composables/useApi.js'
+import PageHeader from '../../components/PageHeader.vue'
+import Card from '../../components/Card.vue'
+import LoadingSkeleton from '../../components/LoadingSkeleton.vue'
+
+const toasts = useToastsStore()
+
+const loading = ref(true)
+const saving = ref(false)
+const error = ref(null)
+
+// Server-provided metadata (filled on GET):
+//   effects.immediate / effects.deferred — which keys take effect now
+//   vs at next load. Keeps the partition in one place (the backend)
+//   so a future plan §2.2 change doesn't require a frontend release.
+const serverEffects = ref({ immediate: [], deferred: [] })
+const lockedInvariants = ref({ extra_models_dir: '/var/lib/hal0/models' })
+
+// Flat form state. Keys match what /internal/set accepts; we unpack
+// nested lemond config (llamacpp.args → llamacpp_args, etc.) on load
+// and re-build the patch from the flat keys on save.
+const form = reactive({
+  // service
+  host: '',
+  port: 13305,
+  log_level: 'info',
+  global_timeout: 900,
+  no_broadcast: true,
+  // concurrency + serving
+  max_loaded_models: 4,
+  ctx_size: 4096,
+  extra_models_dir: '/var/lib/hal0/models',
+  // llama.cpp
+  llamacpp_backend: 'rocm',
+  llamacpp_args: '--parallel 1 --threads 8',
+  // FLM (NPU)
+  flm_args: '--asr 1 --embed 1',
+  // whisper.cpp
+  whispercpp_backend: 'vulkan',
+  // Stable Diffusion
+  sdcpp_backend: 'rocm',
+  steps: 20,
+  cfg_scale: 7.0,
+  width: 512,
+  height: 512,
+})
+
+// Original snapshot (for diff + revert).
+const orig = ref({})
+
+// Per-key inline validation errors — populated from POST 400 details.
+const fieldErrors = ref({})
+
+// ── form section catalog ─────────────────────────────────────────────
+// Grouped per the brief: Service / Concurrency+serving / llama.cpp /
+// FLM / whisper.cpp / Stable Diffusion. Each field carries the metadata
+// the template needs to render labels, hints, and the locked-invariant
+// inline error text up front (not just after a failed save).
+
+const SECTIONS = [
+  {
+    id: 'service',
+    title: 'Service',
+    hint: 'Where lemond binds and how loud it logs. All immediate-effect.',
+    fields: [
+      { key: 'host', label: 'Host', type: 'text',
+        hint: 'Bind address. 127.0.0.1 = loopback only (default).' },
+      { key: 'port', label: 'Port', type: 'number',
+        hint: 'Default 13305. Changing this requires reconfiguring hal0-api.' },
+      { key: 'log_level', label: 'Log level', type: 'select',
+        options: ['debug', 'info', 'warn', 'error'],
+        hint: 'Verbosity of lemond logs (visible in the journal panel).' },
+      { key: 'global_timeout', label: 'Global timeout (s)', type: 'number',
+        hint: 'Inference request timeout. Default 900 (15 min).' },
+      { key: 'no_broadcast', label: 'Disable LAN broadcast', type: 'checkbox',
+        hint: 'On = lemond does not advertise itself on the LAN. Recommended.' },
+    ],
+  },
+  {
+    id: 'concurrency',
+    title: 'Concurrency + serving',
+    hint: 'Per-type budget + where lemond looks for models.',
+    fields: [
+      { key: 'max_loaded_models', label: 'Max loaded models (per type)', type: 'number',
+        hint: 'LRU budget per model type (llm / embedding / image / ...).' },
+      { key: 'ctx_size', label: 'Default ctx_size (tokens)', type: 'number',
+        hint: 'Used as the default when a slot does not override.' },
+      { key: 'extra_models_dir', label: 'Extra models dir', type: 'text',
+        locked: true,
+        hint: 'Locked to the symlink farm root. Must equal /var/lib/hal0/models.' },
+    ],
+  },
+  {
+    id: 'llamacpp',
+    title: 'llama.cpp',
+    hint: 'GGUF backend used for primary, agent, coder, embed, rerank slots on GPU.',
+    fields: [
+      { key: 'llamacpp_backend', label: 'Backend', type: 'select',
+        options: ['rocm', 'vulkan', 'cpu'],
+        hint: 'rocm = Strix Halo iGPU (recommended). Pin, not nightly.' },
+      { key: 'llamacpp_args', label: 'Extra args', type: 'text',
+        invariantHint: 'Must include --threads N where N >= 2.',
+        hint: 'Default "--parallel 1 --threads N" — required to avoid the LXC oversubscribe deadlock.' },
+    ],
+  },
+  {
+    id: 'flm',
+    title: 'FLM (NPU)',
+    hint: 'AMDXDNA NPU trio — chat + ASR + embed packed into one flm process.',
+    fields: [
+      { key: 'flm_args', label: 'FLM args', type: 'text',
+        invariantHint: 'Must include both --asr 1 AND --embed 1 (FLM trio).',
+        hint: 'The trio flags are mandatory in v0.2 — dropping either leaves the NPU stt-npu or embed-npu slot without a backend.' },
+    ],
+  },
+  {
+    id: 'whisper',
+    title: 'whisper.cpp',
+    hint: 'STT backend for the cpu/gpu stt slot (NPU stt-npu uses FLM instead).',
+    fields: [
+      { key: 'whispercpp_backend', label: 'Backend', type: 'select',
+        options: ['vulkan', 'rocm', 'cpu'],
+        hint: 'vulkan is the default; switch if whisper.cpp builds for vulkan fail on your box.' },
+    ],
+  },
+  {
+    id: 'sdcpp',
+    title: 'Stable Diffusion',
+    hint: 'Image generation defaults — slot overrides win at request time.',
+    fields: [
+      { key: 'sdcpp_backend', label: 'Backend', type: 'select',
+        options: ['rocm', 'vulkan', 'cpu'],
+        hint: 'rocm matches the llama.cpp default on Strix Halo.' },
+      { key: 'steps', label: 'Default steps', type: 'number',
+        hint: 'Sampler iterations. 20 is a reasonable speed/quality default.' },
+      { key: 'cfg_scale', label: 'CFG scale', type: 'number', step: '0.1',
+        hint: 'Classifier-free guidance strength. 7.0 default.' },
+      { key: 'width', label: 'Default width (px)', type: 'number',
+        hint: 'Per-request override at the API layer always wins.' },
+      { key: 'height', label: 'Default height (px)', type: 'number',
+        hint: 'Per-request override at the API layer always wins.' },
+    ],
+  },
+]
+
+// Effect labels keyed off serverEffects so the source-of-truth is the
+// backend's _hal0.effects block, not a frontend constant.
+function effectFor(key) {
+  if (serverEffects.value.immediate?.includes(key)) return 'immediate'
+  if (serverEffects.value.deferred?.includes(key)) return 'deferred'
+  return null
+}
+function effectLabel(key) {
+  const eff = effectFor(key)
+  if (eff === 'immediate') return 'Immediate'
+  if (eff === 'deferred') return 'Deferred (next load)'
+  return ''
+}
+
+// ── unpack / pack helpers ────────────────────────────────────────────
+//
+// lemond's /internal/config returns nested keys (llamacpp.args, ...);
+// /internal/set takes flat keys (llamacpp_args, ...). Flatten on load,
+// stay flat in the form, build a flat patch on save.
+
+function unpackConfig(snapshot) {
+  // Service + concurrency keys live at the top level — copy verbatim.
+  for (const key of [
+    'host', 'port', 'log_level', 'global_timeout', 'no_broadcast',
+    'max_loaded_models', 'ctx_size', 'extra_models_dir',
+  ]) {
+    if (snapshot[key] !== undefined) form[key] = snapshot[key]
+  }
+  // Nested tables — flatten into the form keys lemond accepts on /set.
+  if (snapshot.llamacpp) {
+    if (snapshot.llamacpp.args !== undefined) form.llamacpp_args = snapshot.llamacpp.args
+    if (snapshot.llamacpp.backend !== undefined) form.llamacpp_backend = snapshot.llamacpp.backend
+  }
+  if (snapshot.flm) {
+    if (snapshot.flm.args !== undefined) form.flm_args = snapshot.flm.args
+  }
+  if (snapshot.whispercpp) {
+    if (snapshot.whispercpp.backend !== undefined) form.whispercpp_backend = snapshot.whispercpp.backend
+  }
+  if (snapshot.sdcpp) {
+    if (snapshot.sdcpp.backend !== undefined) form.sdcpp_backend = snapshot.sdcpp.backend
+    if (snapshot.sdcpp.steps !== undefined) form.steps = snapshot.sdcpp.steps
+    if (snapshot.sdcpp.cfg_scale !== undefined) form.cfg_scale = snapshot.sdcpp.cfg_scale
+    if (snapshot.sdcpp.width !== undefined) form.width = snapshot.sdcpp.width
+    if (snapshot.sdcpp.height !== undefined) form.height = snapshot.sdcpp.height
+  }
+}
+
+function snapshotOrig() {
+  orig.value = JSON.parse(JSON.stringify(form))
+}
+
+function valueChanged(key) {
+  return String(form[key] ?? '') !== String(orig.value?.[key] ?? '')
+}
+
+const changedKeys = computed(() => {
+  return Object.keys(form).filter((k) => valueChanged(k))
+})
+
+function buildPatch() {
+  const patch = {}
+  for (const k of changedKeys.value) patch[k] = form[k]
+  return patch
+}
+
+// ── load + save ──────────────────────────────────────────────────────
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    const data = await api('/api/lemonade/config')
+    // Extract _hal0 metadata BEFORE unpacking — unpackConfig only looks
+    // at known keys but keeping the meta block out of the form makes
+    // the round-trip explicit.
+    serverEffects.value = data?._hal0?.effects ?? { immediate: [], deferred: [] }
+    lockedInvariants.value = data?._hal0?.locked ?? { extra_models_dir: '/var/lib/hal0/models' }
+    unpackConfig(data)
+    snapshotOrig()
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+async function save() {
+  if (changedKeys.value.length === 0) return
+  fieldErrors.value = {}
+  saving.value = true
+  try {
+    const body = JSON.stringify(buildPatch())
+    const resp = await api('/api/lemonade/config', { method: 'POST', body })
+    const eff = resp?.effects ?? { immediate: [], deferred: [] }
+    const nI = eff.immediate?.length ?? 0
+    const nD = eff.deferred?.length ?? 0
+    if (nI && nD) {
+      toasts.success(`Saved — ${nI} immediate, ${nD} deferred until next load`)
+    } else if (nI) {
+      toasts.success(`Saved — ${nI} immediate`)
+    } else if (nD) {
+      toasts.success(`Saved — ${nD} deferred until next load`)
+    } else {
+      toasts.success('Saved')
+    }
+    // Refetch so the form reflects what's actually persisted (and any
+    // server-side normalisation lemond applied).
+    await load()
+  } catch (e) {
+    if (e.code === 'lemonade.config_invalid' && e.details && typeof e.details === 'object') {
+      // Backend returns details keyed by the flat lemond key (e.g.
+      // "llamacpp_args"). Render inline.
+      fieldErrors.value = e.details
+      toasts.error('Some settings did not validate — see inline errors')
+    } else {
+      toasts.error(e.message)
+    }
+  } finally {
+    saving.value = false
+  }
+}
+
+function revert() {
+  if (!orig.value) return
+  for (const k of Object.keys(orig.value)) {
+    form[k] = orig.value[k]
+  }
+  fieldErrors.value = {}
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="lemonade-admin-page">
+    <PageHeader
+      eyebrow="Lemonade"
+      title="Lemonade admin"
+      subtitle="lemond runtime config — /internal/config + /internal/set"
+    >
+      <template #actions>
+        <span v-if="changedKeys.length > 0" class="change-count">
+          {{ changedKeys.length }} unsaved change{{ changedKeys.length !== 1 ? 's' : '' }}
+        </span>
+        <button
+          class="btn-ghost"
+          type="button"
+          @click="revert"
+          :disabled="saving || changedKeys.length === 0"
+        >
+          Revert
+        </button>
+        <button
+          class="btn-primary"
+          type="button"
+          @click="save"
+          :disabled="saving || changedKeys.length === 0"
+          data-testid="lemonade-admin-save"
+        >
+          <span v-if="saving" class="spinner" aria-hidden="true" />
+          {{ saving ? 'Saving…' : 'Save changes' }}
+        </button>
+      </template>
+    </PageHeader>
+
+    <div class="page-body">
+      <div v-if="error" class="error-banner" role="alert" data-testid="lemonade-admin-error">
+        {{ error }}
+      </div>
+
+      <div v-if="loading">
+        <LoadingSkeleton />
+      </div>
+
+      <template v-else>
+        <Card v-for="section in SECTIONS" :key="section.id">
+          <div class="section-head">
+            <h3 class="section-title">{{ section.title }}</h3>
+            <p v-if="section.hint" class="section-hint">{{ section.hint }}</p>
+          </div>
+          <div class="field-grid">
+            <div
+              v-for="field in section.fields"
+              :key="field.key"
+              class="field-row"
+              :data-testid="`lemonade-admin-field-${field.key}`"
+            >
+              <div class="field-meta">
+                <label :for="`f-${field.key}`" class="field-label">
+                  {{ field.label }}
+                  <span
+                    v-if="effectFor(field.key)"
+                    class="effect-badge"
+                    :class="`effect-${effectFor(field.key)}`"
+                    :title="effectFor(field.key) === 'immediate'
+                      ? 'Takes effect immediately'
+                      : 'Persisted now; applies at the next model load'"
+                  >
+                    {{ effectLabel(field.key) }}
+                  </span>
+                </label>
+                <p v-if="field.invariantHint" class="field-hint invariant-hint">
+                  {{ field.invariantHint }}
+                </p>
+                <p v-else-if="field.hint" class="field-hint">{{ field.hint }}</p>
+                <p
+                  v-if="fieldErrors[field.key]"
+                  class="field-err"
+                  role="alert"
+                  :data-testid="`lemonade-admin-error-${field.key}`"
+                >
+                  {{ fieldErrors[field.key] }}
+                </p>
+              </div>
+              <div class="field-input-wrap">
+                <template v-if="field.type === 'checkbox'">
+                  <label class="toggle-label">
+                    <input
+                      :id="`f-${field.key}`"
+                      type="checkbox"
+                      v-model="form[field.key]"
+                    />
+                    <span>{{ form[field.key] ? 'Enabled' : 'Disabled' }}</span>
+                  </label>
+                </template>
+                <template v-else-if="field.type === 'select'">
+                  <select
+                    :id="`f-${field.key}`"
+                    v-model="form[field.key]"
+                    class="field-input"
+                    :class="{
+                      'field-changed': valueChanged(field.key),
+                      'field-error': !!fieldErrors[field.key],
+                    }"
+                  >
+                    <option v-for="opt in field.options" :key="opt" :value="opt">
+                      {{ opt }}
+                    </option>
+                  </select>
+                </template>
+                <template v-else>
+                  <input
+                    :id="`f-${field.key}`"
+                    v-model="form[field.key]"
+                    :type="field.type"
+                    :step="field.step"
+                    :readonly="field.locked"
+                    class="field-input"
+                    :class="{
+                      'field-changed': valueChanged(field.key),
+                      'field-error': !!fieldErrors[field.key],
+                      'field-locked': field.locked,
+                    }"
+                  />
+                </template>
+              </div>
+            </div>
+          </div>
+        </Card>
+      </template>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.lemonade-admin-page {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.page-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 24px 24px;
+}
+
+.error-banner {
+  background: color-mix(in srgb, var(--color-danger, #d33) 12%, var(--color-surface));
+  border: 1px solid var(--color-danger, #d33);
+  color: var(--color-fg);
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+}
+
+.section-head {
+  margin-bottom: 12px;
+}
+.section-title {
+  margin: 0 0 4px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-fg);
+}
+.section-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-fg-muted);
+}
+
+.field-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.field-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.field-meta {
+  min-width: 0;
+}
+
+.field-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-fg);
+}
+
+.effect-badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm, 4px);
+  border: 1px solid var(--color-border);
+  color: var(--color-fg-muted);
+  background: var(--color-surface-alt, transparent);
+  font-weight: 500;
+}
+.effect-immediate {
+  color: var(--hal0-accent);
+  border-color: color-mix(in srgb, var(--hal0-accent) 40%, var(--color-border));
+}
+.effect-deferred {
+  color: var(--color-fg-muted);
+}
+
+.field-hint {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: var(--color-fg-muted);
+}
+
+.invariant-hint {
+  color: var(--hal0-accent);
+  font-weight: 500;
+}
+
+.field-err {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: var(--color-danger, #d33);
+}
+
+.field-input-wrap {
+  display: flex;
+  flex-direction: column;
+}
+
+.field-input {
+  background: var(--color-surface-alt, var(--color-surface));
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  padding: 6px 10px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--color-fg);
+  width: 100%;
+}
+
+.field-changed {
+  border-color: var(--hal0-accent);
+}
+
+.field-error {
+  border-color: var(--color-danger, #d33);
+}
+
+.field-locked {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.toggle-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--color-fg);
+}
+
+.change-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--hal0-accent);
+}
+
+.spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: lemonade-admin-spin 0.8s linear infinite;
+  margin-right: 6px;
+  vertical-align: -1px;
+}
+
+@keyframes lemonade-admin-spin {
+  to { transform: rotate(360deg); }
+}
+</style>

--- a/ui/tests/e2e/fixtures/apiMock.ts
+++ b/ui/tests/e2e/fixtures/apiMock.ts
@@ -59,6 +59,53 @@ export const DEFAULT_SETTINGS = {
   dispatcher: { prefetch_timeout_s: 8.0, prefetch_parallel_cap: 4 },
   telemetry: { enabled: false, channel: 'stable' },
 }
+/**
+ * PR-13 Lemonade admin defaults — what GET /api/lemonade/config returns
+ * in the absence of a per-spec override. Shape matches the real lemond
+ * /internal/config snapshot plus the hal0-added ``_hal0`` metadata
+ * block the route appends (see hal0.api.routes.lemonade_admin).
+ */
+export const DEFAULT_LEMONADE_CONFIG = {
+  host: '127.0.0.1',
+  port: 13305,
+  ctx_size: 4096,
+  max_loaded_models: 4,
+  extra_models_dir: '/var/lib/hal0/models',
+  global_timeout: 900,
+  no_broadcast: true,
+  log_level: 'info',
+  llamacpp: { args: '--parallel 1 --threads 8', backend: 'rocm' },
+  flm: { args: '--asr 1 --embed 1' },
+  whispercpp: { backend: 'vulkan' },
+  sdcpp: { backend: 'rocm', steps: 20, cfg_scale: 7.0, width: 512, height: 512 },
+  _hal0: {
+    effects: {
+      immediate: [
+        'extra_models_dir',
+        'global_timeout',
+        'host',
+        'log_level',
+        'no_broadcast',
+        'port',
+      ],
+      deferred: [
+        'cfg_scale',
+        'ctx_size',
+        'flm_args',
+        'height',
+        'llamacpp_args',
+        'llamacpp_backend',
+        'max_loaded_models',
+        'sdcpp_backend',
+        'steps',
+        'whispercpp_backend',
+        'width',
+      ],
+    },
+    locked: { extra_models_dir: '/var/lib/hal0/models' },
+  },
+}
+
 export const DEFAULT_CURATED_MODELS = {
   models: [
     {
@@ -115,6 +162,10 @@ export type MockState = {
   agentApprovals: any[]
   /** Installed bundled agents returned by GET /api/agents (Phase 8). */
   agentInstalled: any[]
+  /** Lemonade /internal/config snapshot returned by GET /api/lemonade/config (PR-13). */
+  lemonadeConfig: any
+  /** Last POST /api/lemonade/config patch body — for assertions. */
+  lemonadeLastPatch: Record<string, any> | null
 }
 
 export function makeMockState(): MockState {
@@ -133,6 +184,8 @@ export function makeMockState(): MockState {
     slotSnapshots: {},
     agentApprovals: [],
     agentInstalled: [],
+    lemonadeConfig: JSON.parse(JSON.stringify(DEFAULT_LEMONADE_CONFIG)),
+    lemonadeLastPatch: null,
   }
 }
 
@@ -189,6 +242,84 @@ export async function installDefaultMocks(page: Page, state: MockState) {
   })
   await page.route('**/api/settings/reload', (route) => json(route, state.settings))
   await page.route('**/api/settings/schema', (route) => json(route, {}))
+
+  /* PR-13: Lemonade admin panel. GET returns the seeded snapshot;
+     POST validates against the same key gates the backend enforces
+     (unknown key → 400, llamacpp_args missing --threads or below 2 →
+     400, flm_args missing either trio flag → 400). The mock mirrors
+     the real route's response envelope so the UI's success-toast +
+     inline-error code paths are exercised end-to-end. */
+  await page.route('**/api/lemonade/config', (route) => {
+    const req: Request = route.request()
+    if (req.method() === 'POST') {
+      const patch = JSON.parse(req.postData() || '{}')
+      state.lemonadeLastPatch = patch
+      const immediate = new Set([
+        'port', 'host', 'log_level', 'global_timeout', 'no_broadcast', 'extra_models_dir',
+      ])
+      const deferred = new Set([
+        'max_loaded_models', 'ctx_size', 'llamacpp_backend', 'llamacpp_args',
+        'sdcpp_backend', 'whispercpp_backend', 'steps', 'cfg_scale', 'width', 'height',
+        'flm_args',
+      ])
+      const known = new Set([...immediate, ...deferred])
+      const errors: Record<string, string> = {}
+      for (const [key, value] of Object.entries(patch)) {
+        if (!known.has(key)) {
+          errors[key] = `unknown key — admin-editable keys are ${[...known].sort()}`
+          continue
+        }
+        if (key === 'llamacpp_args' && typeof value === 'string') {
+          const m = value.match(/(?:^|\s)--threads(?:\s+|=)(\d+)(?=\s|$)/)
+          if (!m) {
+            errors.llamacpp_args = 'must include --threads N where N >= 2'
+          } else if (parseInt(m[1], 10) < 2) {
+            errors.llamacpp_args = `--threads ${m[1]} is below the required minimum of 2`
+          }
+        }
+        if (key === 'flm_args' && typeof value === 'string') {
+          if (!/--asr\s+1(?:\s|$)/.test(value)) errors.flm_args = 'must include --asr 1 (FLM trio mandate, plan §5)'
+          else if (!/--embed\s+1(?:\s|$)/.test(value)) errors.flm_args = 'must include --embed 1 (FLM trio mandate, plan §5)'
+        }
+        if (key === 'extra_models_dir' && value !== '/var/lib/hal0/models') {
+          errors.extra_models_dir = "must equal '/var/lib/hal0/models'"
+        }
+      }
+      if (Object.keys(errors).length > 0) {
+        return route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: {
+              code: 'lemonade.config_invalid',
+              message: 'one or more keys failed validation',
+              details: errors,
+            },
+          }),
+        })
+      }
+      // Merge accepted patch into the snapshot (flat keys → nested for
+      // llamacpp / flm / whispercpp / sdcpp).
+      for (const [k, v] of Object.entries(patch)) {
+        if (k === 'llamacpp_args') state.lemonadeConfig.llamacpp.args = v
+        else if (k === 'llamacpp_backend') state.lemonadeConfig.llamacpp.backend = v
+        else if (k === 'flm_args') state.lemonadeConfig.flm.args = v
+        else if (k === 'whispercpp_backend') state.lemonadeConfig.whispercpp.backend = v
+        else if (k === 'sdcpp_backend') state.lemonadeConfig.sdcpp.backend = v
+        else if (['steps', 'cfg_scale', 'width', 'height'].includes(k)) state.lemonadeConfig.sdcpp[k] = v
+        else state.lemonadeConfig[k] = v
+      }
+      const touched = Object.keys(patch)
+      return json(route, {
+        applied: { applied: touched },
+        effects: {
+          immediate: touched.filter((k) => immediate.has(k)).sort(),
+          deferred: touched.filter((k) => deferred.has(k)).sort(),
+        },
+      })
+    }
+    return json(route, state.lemonadeConfig)
+  })
   await page.route('**/api/models', (route) => {
     const req: Request = route.request()
     if (req.method() === 'POST') {

--- a/ui/tests/e2e/specs/lemonade-admin.spec.ts
+++ b/ui/tests/e2e/specs/lemonade-admin.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * lemonade-admin.spec.ts — Settings → Lemonade admin panel (PR-13).
+ *
+ * Covers (plan §11 PR-13):
+ *   - Renders config from the mocked GET response (each section
+ *     appears; immediate/deferred badges line up with the partition).
+ *   - Save POSTs ONLY the diff (not the whole snapshot); on success
+ *     the panel reflects the new value and surfaces the
+ *     "N immediate, M deferred" toast.
+ *   - Validation error display: a bad llamacpp_args lands as an inline
+ *     error tied to that field.
+ *   - The link card on /settings deep-links into the panel.
+ *
+ * Uses the shared apiMock fixture (which now seeds /api/lemonade/config
+ * with DEFAULT_LEMONADE_CONFIG and validates POST bodies the same way
+ * the backend does).
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+test('renders all admin sections + immediate/deferred badges', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  await page.goto('/settings/lemonade')
+
+  // Each grouped section appears.
+  for (const title of [
+    'Service',
+    'Concurrency + serving',
+    'llama.cpp',
+    'FLM (NPU)',
+    'whisper.cpp',
+    'Stable Diffusion',
+  ]) {
+    await expect(page.locator('.section-title', { hasText: title })).toBeVisible()
+  }
+
+  // Immediate badge attached to a known-immediate key (host).
+  const hostBadge = page.locator(
+    '[data-testid="lemonade-admin-field-host"] .effect-badge',
+  )
+  await expect(hostBadge).toBeVisible()
+  await expect(hostBadge).toHaveText('Immediate')
+
+  // Deferred badge attached to a known-deferred key (llamacpp_args).
+  const llamaBadge = page.locator(
+    '[data-testid="lemonade-admin-field-llamacpp_args"] .effect-badge',
+  )
+  await expect(llamaBadge).toBeVisible()
+  await expect(llamaBadge).toHaveText('Deferred (next load)')
+})
+
+test('save POSTs only the changed key; success toast cites the effect counts', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  await page.goto('/settings/lemonade')
+
+  // Wait for the form to populate from the mocked GET.
+  const logLevel = page.locator('#f-log_level')
+  await expect(logLevel).toHaveValue('info')
+
+  // Change one immediate key.
+  await logLevel.selectOption('debug')
+
+  // Save.
+  await page.locator('[data-testid="lemonade-admin-save"]').click()
+
+  // Mock fixture captures the patch body — assert it carries log_level
+  // ONLY (not the whole snapshot, not unchanged keys).
+  await expect.poll(() => mockState.lemonadeLastPatch).toEqual({ log_level: 'debug' })
+
+  // The success toast carries the effect count copy. Pattern matches
+  // both "Saved — 1 immediate" and "Saved — 1 immediate, M deferred..."
+  // so the test stays resilient to future copy tweaks that add deferred
+  // alongside.
+  const toast = page.locator('.toast, [role="status"]', { hasText: /Saved.*immediate/ })
+  await expect(toast).toBeVisible({ timeout: 5_000 })
+})
+
+test('bad llamacpp_args surfaces an inline field error', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  await page.goto('/settings/lemonade')
+
+  // Wait for the form to populate.
+  const llamaInput = page.locator('#f-llamacpp_args')
+  await expect(llamaInput).toHaveValue('--parallel 1 --threads 8')
+
+  // Replace with something missing --threads (the locked-invariant
+  // killer the backend refuses).
+  await llamaInput.fill('--parallel 1')
+
+  await page.locator('[data-testid="lemonade-admin-save"]').click()
+
+  // Inline error tied to the field via data-testid — the same DOM
+  // hook the backend's per-key details map flows into.
+  const inlineErr = page.locator('[data-testid="lemonade-admin-error-llamacpp_args"]')
+  await expect(inlineErr).toBeVisible({ timeout: 5_000 })
+  await expect(inlineErr).toContainText('--threads')
+
+  // The other fields stay untouched — no global "all changes lost"
+  // wipe.
+  await expect(llamaInput).toHaveValue('--parallel 1')
+})
+
+test('link from /settings deep-links to /settings/lemonade', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  await page.goto('/settings')
+  const link = page.locator('[data-testid="lemonade-admin-link"]')
+  await expect(link).toBeVisible()
+  await link.click()
+  await expect(page).toHaveURL(/\/settings\/lemonade$/)
+  await expect(page.locator('.page-title')).toContainText('Lemonade admin')
+})


### PR DESCRIPTION
## Summary

PR-13 of the v0.2 Lemonade migration (plan §11 + §2.2, ADR-0008 §1 + §7). Adds the **Settings → Lemonade admin** surface — GET/POST `/api/lemonade/config` on the backend plus a new Vue panel at `/settings/lemonade`.

The endpoints wrap `LemonadeClient.internal_config()` + `internal_set()` (PR-3 / #156). No client changes here — this is the UI + API-route surface that consumes them.

- **`GET /api/lemonade/config`** — proxies `lemond /internal/config` verbatim and attaches a `_hal0` block carrying the plan §2.2 immediate-vs-deferred key partition plus the locked-invariant pointers (`extra_models_dir = /var/lib/hal0/models`). The UI sources its effect badges + inline hints from this block so the partition stays in one place.
- **`POST /api/lemonade/config`** — accepts a flat `{key: value, ...}` patch, validates against the admin allowlist + the locked invariants, forwards to `/internal/set`, and echoes `{applied, effects:{immediate,deferred}}` so the toast can cite "N immediate, M deferred until next load" precisely.

Both routes mount under the parent `_admin_auth` gate; POST additionally declares `require_writer` so cookie sessions ride the CSRF tripwire (same pattern as `/api/settings` PUT).

### Validation guardrails (all refuse `400 lemonade.config_invalid`)

| Key | Rule | Source |
|---|---|---|
| any | must be in `IMMEDIATE_KEYS ∪ DEFERRED_KEYS` | plan §2.2 |
| `llamacpp_args` | must contain `--threads N` with `N >= 2` | memory `hal0_lemonade_threads_deadlock` |
| `flm_args` | must contain BOTH `--asr 1` AND `--embed 1` | plan §5 + ADR-0009 §1 |
| `extra_models_dir` | must equal `/var/lib/hal0/models` | plan §3 + §6.1 |

Multiple failed keys aggregate into a single `details` map (one round-trip per submit, not three). `extra_models_dir` is refused outright per ADR-0008 §7 (no `extra.*` repurposing) rather than warned — flipping it leaves the dashboard rendering models lemond can't load.

### Immediate vs deferred — a note on the chosen wire shape

Lemond's `/internal/set` applies different keys with different semantics:

- **Immediate** (`port`, `host`, `log_level`, `global_timeout`, `no_broadcast`, `extra_models_dir`) — lemond updates its in-memory state on POST.
- **Deferred** (`max_loaded_models`, `ctx_size`, `llamacpp_backend`, `llamacpp_args`, `sdcpp_backend`, `whispercpp_backend`, `steps`, `cfg_scale`, `width`, `height`, `flm_args`) — value persists immediately but observed behaviour doesn't change until the next `/v1/load`.

The partition is enforced at the backend (the `_hal0.effects` block in GET, plus the per-request classification echoed by POST) rather than encoded in the frontend. That keeps two surfaces from drifting when plan §2.2 evolves: the operator's UI label and the place where validation rejection messages reference "next-load" semantics will always agree, because they read from the same Python constants.

The split is also classified on the request body's keys (not on lemond's `applied` echo) so a future protocol bump where lemond starts returning rejected keys here doesn't break the UI toast.

### Frontend

`ui/src/views/Settings/LemonadeAdmin.vue` is a new view at `/settings/lemonade`. The main `Settings.vue` picks up a small link card pointing to it (not a section migration — anti-scope).

- Flat-key reactive form bound to all 13 admin keys.
- Six grouped sections (Service / Concurrency+serving / llama.cpp / FLM (NPU) / whisper.cpp / Stable Diffusion).
- Per-field "Immediate" / "Deferred (next load)" badge sourced from the backend's `_hal0.effects`.
- Inline locked-invariant hints rendered up front on `llamacpp_args` + `flm_args` (so the operator sees the rule before typing, not just after submitting).
- `extra_models_dir` is read-only on the form (backend refuses divergence anyway).
- Save sends ONLY the diff; success toast cites the per-request effect split; 400s land as per-key inline `field-err` lines.

### Tests

- `tests/api/test_lemonade_admin_route.py` — 25 tests covering GET pass-through + metadata attachment, POST happy path with all three effect-split shapes, every validator branch (unknown / no-threads / threads=0 / threads=1 / threads=8 equals-form / asr-missing / embed-missing / asr=0 disable / extra_models_dir divergence + canonical), and empty/non-object/non-JSON body cases.
- `ui/tests/e2e/specs/lemonade-admin.spec.ts` — 4 γ-suite tests covering section rendering + badges, save-posts-only-diff with toast assertion, inline validation error on bad llamacpp_args, link from `/settings` deep-link.

### Heads-up on parallel work

The brief mentioned PRs #177 + #178 (design v2 tokens + Pinia stores: `lemonade`, `backends`, `banner`, `toast`, `tweaks`) being on main. Verified at start of work — they're merged onto `feat/dash-v2-rework`, not main. This PR therefore uses the existing `toasts.js` store + `useApi` composable. When `feat/dash-v2-rework` lands, the admin panel migrates onto the new `lemonade` + `toast` stores in a follow-up.

## Test plan

- [x] Backend: `pytest tests/ -q` — 1571 passed, 8 skipped (+25 vs PR-12 baseline).
- [x] Backend: `ruff check src tests` + `ruff format --check src tests` clean.
- [x] Frontend: `npm run build` clean (LemonadeAdmin chunk 9.13kB / 3.62kB gzip).
- [x] Frontend: `npx playwright test` — 42 passed (+4 new).
- [ ] Live verification on hal0 LXC after merge — load Settings → Lemonade admin, edit `log_level`, save, observe the "1 immediate" toast.
- [ ] Live verification on hal0 LXC — edit `llamacpp_args` to drop `--threads`, save, observe the inline 400 (no `lemond /internal/set` call).

## Anti-scope honoured

- [x] No journal panel content (PR-14).
- [x] No `[CPU]` chip (PR-15).
- [x] No changes to `LemonadeClient.internal_set` or `internal_config` (PR-3 territory).
- [x] No `/api/lemonade/shutdown` or `/api/lemonade/cleanup-cache` action buttons.
- [x] No migration of other settings into the admin panel — `Settings.vue` keeps its sections, just gains one link card.
- [x] No `extra.*` namespace (ADR-0008 §7).
- [x] No churn on #177/#178 (verified not on main; uses pre-#178 stores).
- [x] No planning document in `docs/internal/`.

Refs: plan §11 PR-13 + §2.2; ADR-0008 §1 + §7; memories `hal0_lemonade_threads_deadlock`, `hal0_lemonade_v1_load_schema`, `hal0_lemonade_flm_npu_install`.