### PR TITLE
feat(ui): Lemonade /logs/stream journal panel (PR-14)

### DIFF
--- a/ui/src/components/LemonadeJournalPanel.vue
+++ b/ui/src/components/LemonadeJournalPanel.vue
@@ -1,0 +1,345 @@
+<script setup>
+/**
+ * LemonadeJournalPanel.vue — PR-14 journal surface.
+ *
+ * Subscribes to ``/api/lemonade/logs/stream`` (the PR-11 SSE proxy of
+ * lemond's ``/logs/stream`` WebSocket) and renders every parsed entry
+ * the daemon emits. Companion to the nuclear-evict toast banner — the
+ * banner surfaces the rare-but-visible escape valve; this panel is
+ * the firehose operators page through when triaging.
+ *
+ * Backend contract (PR-11, src/hal0/api/routes/lemonade_logs.py):
+ *   GET /api/lemonade/logs/stream
+ *     → SSE; each ``data:`` frame is JSON of one lemond log entry,
+ *       shape ``{line, severity, tag, timestamp, seq}`` per the
+ *       ``hal0_lemonade_ws_protocol`` memory. The proxy already
+ *       flattens ``logs.snapshot`` batches into per-entry yields, so
+ *       the consumer only sees individual frames.
+ *
+ * Severity enum (lemond Trace|Debug|Info|Warning|Error|Fatal) maps to
+ * three colour classes (debug/info/warn/error) so the visual scan
+ * matches what operators see in the systemd journal tab. Unknown
+ * severities fall through to the default ``log-line`` style.
+ *
+ * Buffer caps at 2000 lines to keep long sessions bounded — older
+ * frames drop off the front as new arrive. Filter is a substring
+ * match on ``line`` (case-insensitive). Auto-scroll defers to the
+ * user: if they scroll back to read, new lines stop pinning to the
+ * bottom until they click resume or reach the bottom again.
+ */
+import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue'
+import Card from './Card.vue'
+
+const LEMONADE_LOGS_URL = '/api/lemonade/logs/stream'
+const BUFFER_CAP = 2000
+
+const entries = ref([])
+const connected = ref(false)
+const filterText = ref('')
+const autoScroll = ref(true)
+const logboxEl = ref(null)
+
+let es = null
+
+/**
+ * Map lemond's Severity enum onto the three-tier colour classes the
+ * existing Logs.vue uses for visual consistency. Lowercase + trim so
+ * a future lemond protocol bump (e.g. ``"INFO"`` vs ``"Info"``)
+ * keeps working without an extra round-trip.
+ */
+function severityClass(sev) {
+  const s = String(sev || '').trim().toLowerCase()
+  if (s === 'error' || s === 'fatal') return 'log-line-error'
+  if (s === 'warning' || s === 'warn') return 'log-line-warn'
+  if (s === 'debug' || s === 'trace') return 'log-line-debug'
+  return ''
+}
+
+const filteredEntries = computed(() => {
+  const q = filterText.value.trim().toLowerCase()
+  if (!q) return entries.value
+  return entries.value.filter((e) => {
+    const line = (e.line || e.message || e.text || '').toLowerCase()
+    return line.includes(q)
+  })
+})
+
+function entryText(entry) {
+  // Lemond ships ``line``; older builds use ``message``/``text``.
+  // Match what the backend's _extract_message tolerates so a protocol
+  // shift doesn't blank the viewport.
+  return entry.line || entry.message || entry.text || entry.msg || ''
+}
+
+function entryTag(entry) {
+  const t = entry.tag
+  return typeof t === 'string' && t.length > 0 ? t : ''
+}
+
+async function scrollToBottom() {
+  await nextTick()
+  if (logboxEl.value) {
+    logboxEl.value.scrollTop = logboxEl.value.scrollHeight
+  }
+}
+
+function onScroll() {
+  if (!logboxEl.value) return
+  const { scrollTop, scrollHeight, clientHeight } = logboxEl.value
+  // Within 40px of bottom → resume auto-scroll. Matches the systemd
+  // tab's threshold so both surfaces behave identically.
+  autoScroll.value = scrollHeight - scrollTop - clientHeight < 40
+}
+
+function connect() {
+  disconnect()
+  if (typeof window === 'undefined' || !window.EventSource) return
+  try {
+    es = new EventSource(LEMONADE_LOGS_URL)
+  } catch (_err) {
+    return
+  }
+  es.onopen = () => { connected.value = true }
+  es.onmessage = (ev) => {
+    let entry
+    try {
+      entry = JSON.parse(ev.data)
+    } catch (_err) {
+      // Tolerate non-JSON frames by wrapping them as plain lines —
+      // an upstream protocol regression should still render text.
+      entry = { line: String(ev.data) }
+    }
+    if (!entry || typeof entry !== 'object') return
+    entries.value.push(entry)
+    if (entries.value.length > BUFFER_CAP) {
+      entries.value = entries.value.slice(-BUFFER_CAP)
+    }
+    if (autoScroll.value) scrollToBottom()
+  }
+  es.onerror = () => {
+    connected.value = false
+    // EventSource auto-reconnects on its own cadence; no manual retry.
+  }
+}
+
+function disconnect() {
+  if (es) {
+    try { es.close() } catch (_err) { /* noop */ }
+    es = null
+  }
+  connected.value = false
+}
+
+function clearBuffer() {
+  entries.value = []
+}
+
+onMounted(connect)
+onUnmounted(disconnect)
+
+defineExpose({ connect, disconnect, clearBuffer })
+</script>
+
+<template>
+  <div class="lemonade-journal" data-testid="lemonade-journal">
+    <div class="journal-toolbar">
+      <div class="status-dot-wrap" :title="connected ? 'SSE connected' : 'disconnected'">
+        <span
+          class="dot"
+          :class="connected ? 'dot-live' : 'dot-off'"
+          aria-hidden="true"
+        />
+        <span class="dot-label">{{ connected ? 'live' : 'offline' }}</span>
+      </div>
+
+      <div class="search-wrap">
+        <svg
+          width="12"
+          height="12"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          stroke-width="2"
+          class="search-icon"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 100-15 7.5 7.5 0 000 15z"
+          />
+        </svg>
+        <input
+          v-model="filterText"
+          class="filter-search"
+          placeholder="Filter lemond log…"
+          aria-label="Filter Lemonade journal lines"
+          data-testid="lemonade-journal-filter"
+        />
+      </div>
+
+      <label class="autoscroll-toggle">
+        <input
+          v-model="autoScroll"
+          type="checkbox"
+          data-testid="lemonade-journal-autoscroll"
+        />
+        <span>Auto-scroll</span>
+      </label>
+
+      <button
+        type="button"
+        class="btn-secondary"
+        data-testid="lemonade-journal-clear"
+        @click="clearBuffer"
+      >
+        Clear
+      </button>
+
+      <span class="line-count" data-testid="lemonade-journal-count">
+        {{ filteredEntries.length }} / {{ entries.length }} lines
+      </span>
+    </div>
+
+    <Card :padded="false" class="logbox-card">
+      <div
+        ref="logboxEl"
+        class="logbox"
+        role="log"
+        aria-live="polite"
+        aria-label="Lemonade daemon log"
+        @scroll="onScroll"
+      >
+        <div v-if="entries.length === 0" class="logbox-empty">
+          No log entries yet. Lemonade may be idle or unreachable.
+        </div>
+        <div v-else-if="filteredEntries.length === 0" class="logbox-empty">
+          No lines match the current filter.
+        </div>
+        <div
+          v-for="(entry, i) in filteredEntries"
+          :key="entry.seq != null ? entry.seq : i"
+          class="log-line"
+          :class="severityClass(entry.severity)"
+          data-testid="lemonade-journal-line"
+        >
+          <span v-if="entryTag(entry)" class="log-tag">[{{ entryTag(entry) }}]</span>
+          <span class="log-text">{{ entryText(entry) }}</span>
+        </div>
+      </div>
+    </Card>
+  </div>
+</template>
+
+<style scoped>
+.lemonade-journal { display: flex; flex-direction: column; gap: 10px; min-height: 0; flex: 1; }
+
+.journal-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.status-dot-wrap { display: flex; align-items: center; gap: 6px; }
+.dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+.dot-live { background: var(--hal0-accent); box-shadow: 0 0 8px var(--hal0-accent); }
+.dot-off { background: var(--color-fg-faint); }
+.dot-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-fg-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.search-wrap { position: relative; }
+.search-icon {
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-fg-faint);
+  pointer-events: none;
+}
+.filter-search {
+  padding: 5px 8px 5px 26px;
+  border-radius: var(--radius);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-2);
+  color: var(--color-fg);
+  font-size: 12px;
+  font-family: var(--font-mono);
+  outline: none;
+  width: 200px;
+  transition: border-color 0.1s;
+}
+.filter-search:focus { border-color: var(--color-border-hi); }
+.filter-search::placeholder { color: var(--color-fg-faint); }
+
+.autoscroll-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--color-fg-muted);
+  cursor: pointer;
+}
+.autoscroll-toggle input[type='checkbox'] { cursor: pointer; }
+
+.btn-secondary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 11px;
+  border-radius: var(--radius);
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.btn-secondary:hover {
+  border-color: var(--color-border-hi);
+  color: var(--color-fg);
+}
+
+.line-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-fg-faint);
+  margin-left: auto;
+}
+
+.logbox-card { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+.logbox {
+  flex: 1;
+  overflow-y: auto;
+  background: var(--hal0-bg-sunken);
+  padding: 12px 16px;
+  min-height: 400px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.55;
+  font-feature-settings: 'zero' 1, 'ss02' 1, 'tnum' 1;
+}
+.logbox-empty { color: var(--color-fg-faint); padding: 8px 0; }
+.log-line {
+  color: var(--hal0-fg-dim);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.log-line.log-line-error { color: var(--color-danger); }
+.log-line.log-line-warn { color: var(--color-warning); }
+.log-line.log-line-debug { color: var(--color-fg-faint); opacity: 0.7; }
+
+.log-tag {
+  display: inline-block;
+  margin-right: 6px;
+  color: var(--color-fg-faint);
+  font-weight: 500;
+}
+</style>

--- a/ui/src/views/Logs.vue
+++ b/ui/src/views/Logs.vue
@@ -27,12 +27,29 @@
  * the user in a terminal.
  */
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useSystemStore } from '../stores/system.js'
 import { api } from '../composables/useApi.js'
 import PageHeader from '../components/PageHeader.vue'
 import Card from '../components/Card.vue'
+import LemonadeJournalPanel from '../components/LemonadeJournalPanel.vue'
 
 const system = useSystemStore()
+const route = useRoute()
+const router = useRouter()
+
+// PR-14: two-tab surface — systemd journal (default, prior behaviour)
+// and Lemonade daemon log. Tab state lives in ?tab=… so the URL is
+// shareable + reload-stable, mirroring Agent.vue's pattern.
+const TABS = ['systemd', 'lemonade']
+const activeTab = computed(() => {
+  const t = String(route.query.tab || 'systemd')
+  return TABS.includes(t) ? t : 'systemd'
+})
+function selectTab(tab) {
+  if (tab === activeTab.value) return
+  router.replace({ query: { ...route.query, tab } })
+}
 
 const lines      = ref([])
 const filter     = ref({
@@ -212,7 +229,7 @@ onUnmounted(closeStream)
 <template>
   <div class="logs-page">
     <PageHeader eyebrow="Journal" title="Logs" subtitle="Live systemd journal tail">
-      <template #actions>
+      <template v-if="activeTab === 'systemd'" #actions>
         <div class="status-dot-wrap" :title="connected ? 'SSE connected' : (frozen ? 'frozen' : 'disconnected')" aria-label="SSE connection status">
           <span class="dot" :class="frozen ? 'dot-frozen' : (connected ? 'dot-live' : 'dot-off')" aria-hidden="true" />
           <span class="dot-label">{{ frozen ? 'frozen' : (connected ? 'live' : 'offline') }}</span>
@@ -237,8 +254,24 @@ onUnmounted(closeStream)
       </template>
     </PageHeader>
 
-    <!-- Filters -->
-    <div class="filters-bar">
+    <!-- Tabs: systemd journal (default) | Lemonade daemon log (PR-14). -->
+    <nav class="tabs" role="tablist" aria-label="Log sources">
+      <button
+        v-for="t in TABS"
+        :key="t"
+        type="button"
+        role="tab"
+        :aria-selected="activeTab === t"
+        :class="['tab', { active: activeTab === t }]"
+        :data-testid="`logs-tab-${t}`"
+        @click="selectTab(t)"
+      >
+        <span class="tab-label">{{ t === 'systemd' ? 'systemd' : 'Lemonade' }}</span>
+      </button>
+    </nav>
+
+    <!-- systemd journal pane (existing surface) -->
+    <div v-if="activeTab === 'systemd'" class="filters-bar">
       <label class="sr-only" for="log-unit-filter">Unit</label>
       <select id="log-unit-filter" v-model="filter.unit" class="filter-select">
         <option v-for="o in unitOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
@@ -293,7 +326,7 @@ onUnmounted(closeStream)
     </div>
 
     <!-- Log box -->
-    <div class="page-body">
+    <div v-if="activeTab === 'systemd'" class="page-body">
       <div v-if="error" class="error-banner" role="alert">{{ error }}</div>
 
       <Card :padded="false" class="logbox-card">
@@ -322,12 +355,61 @@ onUnmounted(closeStream)
         </div>
       </Card>
     </div>
+
+    <!-- Lemonade daemon journal pane (PR-14, plan §11 + §2.2). -->
+    <div v-else-if="activeTab === 'lemonade'" class="page-body lemonade-body">
+      <LemonadeJournalPanel />
+    </div>
   </div>
 </template>
 
 <style scoped>
 .logs-page { display: flex; flex-direction: column; height: 100%; min-height: 0; }
 .page-body { padding: 0 24px 20px; flex: 1; min-height: 0; display: flex; flex-direction: column; gap: 10px; }
+.lemonade-body { padding: 16px 24px 20px; }
+
+/* Tab bar mirrors Agent.vue so navigation feels uniform across the app. */
+.tabs {
+  display: flex;
+  gap: 4px;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+.tab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  background: transparent;
+  border: none;
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  cursor: pointer;
+  text-transform: capitalize;
+  transition: color 0.12s;
+}
+.tab:hover { color: var(--color-fg); }
+.tab.active { color: var(--hal0-accent); }
+.tab.active::after {
+  content: '';
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: -1px;
+  height: 2px;
+  background: var(--hal0-accent);
+  border-radius: 2px 2px 0 0;
+  box-shadow: 0 0 12px -2px var(--hal0-accent);
+}
+.tab:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
 
 .filters-bar {
   display: flex;

--- a/ui/tests/e2e/specs/lemonade-journal.spec.ts
+++ b/ui/tests/e2e/specs/lemonade-journal.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * lemonade-journal.spec.ts — PR-14 Lemonade daemon log panel.
+ *
+ * Covers (plan §11 PR-14 + §2.2):
+ *   - Tab switch from systemd → Lemonade renders the journal pane
+ *   - Streamed entries from /api/lemonade/logs/stream appear with the
+ *     correct severity class (info default, warning amber, error red)
+ *   - Filter input narrows visible lines (substring match on ``line``)
+ *   - Auto-scroll toggle is wired
+ *   - Clear-buffer empties the buffer
+ *
+ * Backend contract (PR-11, src/hal0/api/routes/lemonade_logs.py):
+ * each SSE data frame is JSON of one lemond log entry; shape
+ * ``{line, severity, tag, timestamp, seq}`` per the
+ * hal0_lemonade_ws_protocol memory.
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+import { emitSse, installSseHarness, waitForSse } from '../fixtures/sseHarness'
+
+test.beforeEach(async ({ page }) => {
+  await installSseHarness(page)
+})
+
+test('renders streamed Lemonade log entries with severity classes', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  // The Logs view also bootstraps the systemd tab — keep its mocks
+  // happy so we don't get console noise in the harness.
+  await page.route('**/api/logs*', (route) => {
+    if (route.request().url().includes('/api/logs/stream')) {
+      return route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' })
+    }
+    return json(route, { unit: '', lines: [], count: 0 })
+  })
+
+  await page.goto('/logs?tab=lemonade')
+  await expect(page.getByTestId('lemonade-journal')).toBeVisible()
+
+  // The journal panel opens its own EventSource on mount.
+  await waitForSse(page, '/api/lemonade/logs/stream', 4000)
+
+  // Drive a sequence covering all three severity → colour mappings.
+  await emitSse(page, '/api/lemonade/logs/stream', {
+    seq: 1,
+    severity: 'Info',
+    tag: 'Server',
+    line: 'lemond ready on port 13305',
+  })
+  await emitSse(page, '/api/lemonade/logs/stream', {
+    seq: 2,
+    severity: 'Warning',
+    tag: 'Router',
+    line: 'evicting qwen3-1b to free budget',
+  })
+  await emitSse(page, '/api/lemonade/logs/stream', {
+    seq: 3,
+    severity: 'Error',
+    tag: 'Backend',
+    line: 'failed to load model x',
+  })
+
+  const lines = page.getByTestId('lemonade-journal-line')
+  await expect(lines).toHaveCount(3)
+  // First line is INFO → no severity-colour class (default).
+  await expect(lines.nth(0)).toContainText('lemond ready on port 13305')
+  await expect(lines.nth(0)).toContainText('[Server]')
+  // Warning line picks up log-line-warn.
+  await expect(lines.nth(1)).toHaveClass(/log-line-warn/)
+  // Error line picks up log-line-error.
+  await expect(lines.nth(2)).toHaveClass(/log-line-error/)
+})
+
+test('filter input narrows visible lines', async ({ page, mockState, cleanState }) => {
+  await page.route('**/api/logs*', (route) => {
+    if (route.request().url().includes('/api/logs/stream')) {
+      return route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' })
+    }
+    return json(route, { unit: '', lines: [], count: 0 })
+  })
+
+  await page.goto('/logs?tab=lemonade')
+  await waitForSse(page, '/api/lemonade/logs/stream', 4000)
+
+  for (const line of ['alpha bravo', 'bravo charlie', 'charlie delta']) {
+    await emitSse(page, '/api/lemonade/logs/stream', { line, severity: 'Info' })
+  }
+  const lines = page.getByTestId('lemonade-journal-line')
+  await expect(lines).toHaveCount(3)
+
+  // Substring filter on the canonical ``line`` field.
+  await page.getByTestId('lemonade-journal-filter').fill('bravo')
+  await expect(lines).toHaveCount(2)
+  await expect(lines.nth(0)).toContainText('alpha bravo')
+  await expect(lines.nth(1)).toContainText('bravo charlie')
+
+  // Empty filter restores all rows.
+  await page.getByTestId('lemonade-journal-filter').fill('')
+  await expect(lines).toHaveCount(3)
+})
+
+test('clear button empties the journal buffer', async ({ page, mockState, cleanState }) => {
+  await page.route('**/api/logs*', (route) => {
+    if (route.request().url().includes('/api/logs/stream')) {
+      return route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' })
+    }
+    return json(route, { unit: '', lines: [], count: 0 })
+  })
+
+  await page.goto('/logs?tab=lemonade')
+  await waitForSse(page, '/api/lemonade/logs/stream', 4000)
+
+  for (let i = 0; i < 5; i++) {
+    await emitSse(page, '/api/lemonade/logs/stream', {
+      line: `entry-${i}`,
+      severity: 'Info',
+    })
+  }
+  await expect(page.getByTestId('lemonade-journal-line')).toHaveCount(5)
+
+  await page.getByTestId('lemonade-journal-clear').click()
+  await expect(page.getByTestId('lemonade-journal-line')).toHaveCount(0)
+})
+
+test('auto-scroll toggle is wired and reflects checkbox state', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  await page.route('**/api/logs*', (route) => {
+    if (route.request().url().includes('/api/logs/stream')) {
+      return route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' })
+    }
+    return json(route, { unit: '', lines: [], count: 0 })
+  })
+
+  await page.goto('/logs?tab=lemonade')
+  await waitForSse(page, '/api/lemonade/logs/stream', 4000)
+
+  // Default state: auto-scroll on.
+  const toggle = page.getByTestId('lemonade-journal-autoscroll')
+  await expect(toggle).toBeChecked()
+
+  // Operator opt-out — the user can stop the viewport from jumping.
+  await toggle.uncheck()
+  await expect(toggle).not.toBeChecked()
+
+  // Lines still arrive even with auto-scroll disabled — the toggle
+  // only governs scroll-pin, not buffer ingestion.
+  await emitSse(page, '/api/lemonade/logs/stream', {
+    line: 'still ingesting',
+    severity: 'Info',
+  })
+  await expect(page.getByTestId('lemonade-journal-line')).toHaveCount(1)
+})
+
+test('switching tabs from systemd to lemonade reveals the journal pane', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  await page.route('**/api/logs*', (route) => {
+    if (route.request().url().includes('/api/logs/stream')) {
+      return route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' })
+    }
+    return json(route, { unit: '', lines: [], count: 0 })
+  })
+
+  // Default landing on /logs == systemd tab; the journal pane is hidden.
+  await page.goto('/logs')
+  await expect(page.getByTestId('lemonade-journal')).toHaveCount(0)
+  // The existing filters bar (unit selector) is visible.
+  await expect(page.locator('#log-unit-filter')).toBeVisible()
+
+  // Tab into Lemonade — pane appears, filters bar disappears.
+  await page.getByTestId('logs-tab-lemonade').click()
+  await expect(page.getByTestId('lemonade-journal')).toBeVisible()
+  await expect(page.locator('#log-unit-filter')).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary

PR-14 of the v0.2 Lemonade migration. Folds the daemon `/logs/stream` SSE that PR-11 (#163) proxied into a second tab on the Logs view, so operators can triage lemond from the same surface as the systemd journal.

- New `LemonadeJournalPanel.vue` subscribes to `/api/lemonade/logs/stream`, renders entries with severity colour classes (info/warn/error mapping lemond's `Trace|Debug|Info|Warning|Error|Fatal`), shows tag prefix, caps the buffer at 2000 lines.
- `Logs.vue` becomes a two-tab surface (`?tab=systemd|lemonade`, default `systemd`). The existing filters bar + freeze/reload chrome only render on the systemd tab; the journal panel ships its own filter / clear / auto-scroll toolbar.
- Backend stays put: PR-11's proxy already pass-throughs the full unfiltered stream as JSON-per-frame. The nuclear-evict event stream on `/api/lemonade/events/stream` is untouched.

References: plan §11 PR-14 + §2.2 (`docs/internal/lemonade-adoption-plan-2026-05-22.md`); ADR-0008 §3; memory `hal0_lemonade_ws_protocol`.

## Files touched

- `ui/src/components/LemonadeJournalPanel.vue` (new, 345 lines)
- `ui/src/views/Logs.vue` (+86 lines — tab chrome + lemonade pane gating)
- `ui/tests/e2e/specs/lemonade-journal.spec.ts` (new, 180 lines, 5 specs)

## Test plan

- [x] Backend `pytest tests/` → 1616 passed / 8 skipped (no new tests, PR-11's coverage is reused)
- [x] `ruff check src tests` + `ruff format --check src tests` clean
- [x] `ui` build green (`npm run build`)
- [x] Full γ-suite `npx playwright test` → 47 passed (was 42; +5 from `lemonade-journal.spec.ts`)
- [ ] LXC manual smoke: visit `/logs?tab=lemonade`, confirm daemon entries stream in with colour coding

🤖 Generated with [Claude Code](https://claude.com/claude-code)