### PR TITLE
feat(ui): [CPU] chip + tooltip on voice slot card (PR-15)

### DIFF
--- a/ui/src/components/SlotCard.vue
+++ b/ui/src/components/SlotCard.vue
@@ -95,6 +95,18 @@ const coresidentTitle = computed(() => {
   return ''
 })
 
+// PR-15: kokoro:cpu disclosure. Plan §1 #2 + ADR-0008 §2 locked
+// kokoro:cpu as the only v0.2 TTS recipe. There is no GPU-Kokoro on
+// Linux upstream — so we surface a small "[CPU]" chip + tooltip on the
+// voice slot card to make the constraint legible without a banner.
+// Hard-coded to provider === 'kokoro' per plan; no device-detection
+// logic. GPU-accelerated TTS will land in v0.3.
+const isKokoroCpu = computed(() => {
+  const provider = (props.slot.provider || '').toLowerCase()
+  return provider === 'kokoro'
+})
+const cpuOnlyTooltip = 'Kokoro TTS runs on CPU in v0.2. GPU-accelerated TTS is planned for v0.3.'
+
 const modelLabel = computed(() => {
   const raw = props.slot.model_name || props.slot.model || props.slot.model_id || ''
   const s = typeof raw === 'string' ? raw : (raw?.default ?? '')
@@ -519,6 +531,18 @@ const sparkSvg = computed(() => {
         data-testid="coresident-badge"
         :title="coresidentTitle"
       >{{ coresidentLabel }}</span>
+      <!-- PR-15: kokoro:cpu disclosure chip. Voice slot only. Neutral
+           slate hue (info, not warning). Native title= for tooltip is
+           keyboard-accessible by default; aria-label disambiguates the
+           bare "[CPU]" glyph for screen readers. -->
+      <span
+        v-if="isKokoroCpu"
+        class="sc-chip cpu-only"
+        data-testid="cpu-only-chip"
+        :title="cpuOnlyTooltip"
+        :aria-label="`CPU-only backend — ${cpuOnlyTooltip}`"
+        tabindex="0"
+      >CPU</span>
       <span class="sc-port mono">{{ slot.port ? `:${slot.port}` : '—' }}</span>
     </div>
 
@@ -909,6 +933,24 @@ const sparkSvg = computed(() => {
   color: var(--hal0-accent);
   border-color: color-mix(in srgb, var(--hal0-accent) 50%, transparent);
   background: color-mix(in srgb, var(--hal0-accent) 12%, transparent);
+}
+
+/* PR-15: kokoro:cpu disclosure chip on the voice slot card. Slate /
+   neutral palette so it reads as "info" rather than "warning" — the
+   constraint is intentional in v0.2, not an error state. Focusable so
+   keyboard users can see the native title= tooltip. */
+.sc-chip.cpu-only {
+  margin-left: 6px;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  color: var(--color-fg-muted);
+  border-color: var(--color-border-hi);
+  background: var(--color-surface-3);
+  cursor: help;
+}
+.sc-chip.cpu-only:focus-visible {
+  outline: 1px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 /* Hardware target chip — colour-coded so the user can see at a glance

--- a/ui/src/components/capabilities/VoiceCard.vue
+++ b/ui/src/components/capabilities/VoiceCard.vue
@@ -32,6 +32,20 @@ const ENDPOINTS = {
   tts: '/v1/audio/speech',
 }
 
+// PR-15: kokoro:cpu disclosure. Plan §1 #2 + ADR-0008 §2 locked
+// kokoro:cpu as the only v0.2 TTS recipe — no GPU-Kokoro on Linux
+// upstream. The TTS sub-section gets a small "[CPU]" chip + tooltip so
+// the constraint is legible without a banner. Hard-coded to
+// provider === 'kokoro' per plan; no device-detection logic. GPU TTS
+// will land in v0.3.
+const CPU_ONLY_TOOLTIP =
+  'Kokoro TTS runs on CPU in v0.2. GPU-accelerated TTS is planned for v0.3.'
+function isCpuOnly(capability) {
+  if (capability !== 'tts') return false
+  const provider = (props.selection?.[capability]?.provider || '').toLowerCase()
+  return provider === 'kokoro'
+}
+
 function portFor(capability) {
   const name = SLOT_NAME[capability]
   return system.slots.find((s) => s.name === name)?.port ?? null
@@ -216,6 +230,19 @@ const headerPill = computed(() => {
             {{ selection?.[c]?.status || 'offline' }}
           </span>
           <span class="cap-section-label">{{ c.toUpperCase() }}</span>
+          <!-- PR-15: kokoro:cpu disclosure chip on the TTS sub-section.
+               Neutral slate hue (info, not warning); the constraint is
+               intentional in v0.2. Focusable so keyboard users can see
+               the native title= tooltip. aria-label includes the full
+               disclosure copy for screen-reader users. -->
+          <span
+            v-if="isCpuOnly(c)"
+            class="cap-cpu-chip"
+            data-testid="cpu-only-chip"
+            :title="CPU_ONLY_TOOLTIP"
+            :aria-label="`CPU-only backend — ${CPU_ONLY_TOOLTIP}`"
+            tabindex="0"
+          >CPU</span>
           <span class="cap-section-sub">
             {{ ENDPOINTS[c] }}
             <span v-if="portFor(c)" class="cap-section-port">· :{{ portFor(c) }}</span>
@@ -328,4 +355,26 @@ const headerPill = computed(() => {
 
 /* Picker layout lives in the shared non-scoped block in
  * CapabilitiesSection.vue so all three cards stay aligned. */
+
+/* PR-15: kokoro:cpu disclosure chip on the TTS sub-section header.
+ * Slate / neutral palette so it reads as "info" rather than "warning" —
+ * the constraint is intentional in v0.2, not an error state. cursor:
+ * help to advertise the tooltip on hover. */
+.cap-cpu-chip {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+  color: var(--color-fg-muted);
+  border: 1px solid var(--color-border-hi);
+  background: var(--color-surface-3);
+  cursor: help;
+}
+.cap-cpu-chip:focus-visible {
+  outline: 1px solid var(--color-accent);
+  outline-offset: 2px;
+}
 </style>

--- a/ui/tests/e2e/specs/lemonade-voice-chip.spec.ts
+++ b/ui/tests/e2e/specs/lemonade-voice-chip.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * lemonade-voice-chip.spec.ts — PR-15 voice slot [CPU] disclosure chip.
+ *
+ * Covers (plan §11 PR-15 + ADR-0008 §2):
+ *   - Voice slot TTS section with provider=kokoro renders the [CPU]
+ *     chip with the correct aria-label.
+ *   - Voice slot TTS section with a non-kokoro provider (hypothetical
+ *     future GPU TTS) does NOT render the chip.
+ *   - Tooltip text matches the briefed wording verbatim.
+ *
+ * No live backend — uses ``apiMock`` for HTTP. Chip is hard-coded to
+ * provider === 'kokoro' per plan §1 #2 (no device-detection logic).
+ *
+ * The voice "slot card" in v0.2 is the VoiceCard capability card under
+ * the Capabilities section on /slots; the `tts` slot itself is filtered
+ * out of the main slot grid (CAPABILITY_OWNED_SLOTS in Slots.vue) and
+ * its UX lives entirely in VoiceCard.
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+
+const KOKORO_TOOLTIP =
+  'Kokoro TTS runs on CPU in v0.2. GPU-accelerated TTS is planned for v0.3.'
+
+function capabilitiesPayload(ttsProvider: string) {
+  return {
+    backends: [
+      { id: 'kokoro', label: 'Kokoro', short: 'kokoro', provider: 'kokoro' },
+      { id: 'whispercpp', label: 'whisper.cpp', short: 'whisper', provider: 'whispercpp' },
+    ],
+    catalogs: {
+      voice: {
+        stt: [
+          {
+            id: 'whisper-tiny',
+            backends: [{ id: 'whispercpp', provider: 'whispercpp', downloaded: true }],
+          },
+        ],
+        tts: [
+          {
+            id: 'kokoro-v1',
+            backends: [{ id: 'kokoro', provider: ttsProvider, downloaded: true }],
+          },
+        ],
+      },
+    },
+    selections: {
+      voice: {
+        stt: {
+          backend: 'whispercpp',
+          provider: 'whispercpp',
+          model: 'whisper-tiny',
+          enabled: true,
+          slot: 'stt',
+          status: 'serving',
+        },
+        tts: {
+          backend: 'kokoro',
+          provider: ttsProvider,
+          model: 'kokoro-v1',
+          enabled: true,
+          slot: 'tts',
+          status: 'serving',
+        },
+      },
+    },
+  }
+}
+
+test('kokoro TTS sub-section renders [CPU] chip with aria-label', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  await page.route('**/api/capabilities', (route) =>
+    json(route, capabilitiesPayload('kokoro')),
+  )
+  await page.route('**/api/slots', (route) => json(route, []))
+  mockState.status.slots = []
+
+  await page.goto('/slots')
+
+  const chip = page.getByTestId('cpu-only-chip')
+  await expect(chip).toBeVisible({ timeout: 5_000 })
+  await expect(chip).toHaveText('CPU')
+  // aria-label includes the full tooltip text so screen-reader users get
+  // the same disclosure as sighted users hovering the chip.
+  await expect(chip).toHaveAttribute('aria-label', `CPU-only backend — ${KOKORO_TOOLTIP}`)
+})
+
+test('non-kokoro TTS provider has no [CPU] chip', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  // Hypothetical future GPU-TTS provider — same capability, different
+  // provider. PR-15 only marks kokoro:cpu; other providers stay clean.
+  await page.route('**/api/capabilities', (route) =>
+    json(route, capabilitiesPayload('piper-gpu')),
+  )
+  await page.route('**/api/slots', (route) => json(route, []))
+  mockState.status.slots = []
+
+  await page.goto('/slots')
+
+  // VoiceCard rendered — assert its TTS sub-section is on the page.
+  await expect(page.locator('.cap-title', { hasText: 'voice' })).toBeVisible()
+  await expect(page.getByTestId('cpu-only-chip')).toHaveCount(0)
+})
+
+test('[CPU] chip tooltip text matches the brief verbatim', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  await page.route('**/api/capabilities', (route) =>
+    json(route, capabilitiesPayload('kokoro')),
+  )
+  await page.route('**/api/slots', (route) => json(route, []))
+  mockState.status.slots = []
+
+  await page.goto('/slots')
+
+  const chip = page.getByTestId('cpu-only-chip')
+  await expect(chip).toBeVisible({ timeout: 5_000 })
+  // The native title= attribute carries the verbatim disclosure copy.
+  await expect(chip).toHaveAttribute('title', KOKORO_TOOLTIP)
+})


### PR DESCRIPTION
## Summary

PR-15 of the hal0 v0.2 Lemonade migration — last of Phase 4. Surfaces the locked `kokoro:cpu` constraint as a small `[CPU]` chip with tooltip on the voice slot card.

- **VoiceCard.vue** — chip added to the TTS sub-section header. Renders only when `selection.tts.provider === 'kokoro'`.
- **SlotCard.vue** — same chip on any slot whose `provider === 'kokoro'`, so custom kokoro slots operators create outside the capability surface get the same disclosure.
- Hard-coded to `provider === 'kokoro'` per plan §1 #2 — no device-detection logic. GPU-accelerated TTS lands in v0.3.
- Neutral slate palette (info, not warning); the constraint is intentional in v0.2.
- A11y: chip is focusable (`tabindex="0"`) so keyboard users see the native `title=` tooltip; `aria-label` carries the full disclosure for screen-reader users.

Tooltip copy (verbatim): `Kokoro TTS runs on CPU in v0.2. GPU-accelerated TTS is planned for v0.3.`

References: plan §1 #2, §11 PR-15 (`docs/internal/lemonade-adoption-plan-2026-05-22.md`); ADR-0008 §2 (`docs/internal/adr/0008-lemonade-adoption.md`).

## Test plan

- [x] `tests/e2e/specs/lemonade-voice-chip.spec.ts` — 3 cases:
  - kokoro TTS sub-section renders [CPU] chip with correct aria-label
  - non-kokoro provider has no [CPU] chip
  - tooltip text matches the brief verbatim
- [x] Regression: `dashboard-lemonade-state.spec.ts`, `slot-lifecycle.spec.ts`, `dashboard.spec.ts` all green
- [x] Backend baseline: `pytest tests/` — 1616 passed, 8 skipped (no Python touched)
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)