### PR TITLE
feat(ui): v2 Dashboard / view — snapshot + persona + composer + chat (slice #169)

### DIFF
--- a/ui/src/components/dashboard/ChatActive.vue
+++ b/ui/src/components/dashboard/ChatActive.vue
@@ -1,0 +1,288 @@
+<script setup>
+/**
+ * dashboard/ChatActive.vue — slice #169.
+ *
+ * Renders an active conversation. Messages: user / assistant rows.
+ * Assistant rows can contain inline tool-call blocks via native
+ * <details> markup (slice #175 owns full a11y polish — this just
+ * lays down the collapsible scaffold).
+ *
+ * Message shape (from Dashboard):
+ *   {
+ *     id, role: 'user' | 'assistant' | 'system',
+ *     content?: string,
+ *     reasoning?: string,
+ *     tool_calls?: [{ id, name, args, result?, duration_ms? }],
+ *     attachments?: [{ kind: 'image'|'audio'|'text', src?, text? }],
+ *     swap?: { from, to }                       // persona-swap marker
+ *   }
+ *
+ * Auto-scrolls to bottom when new messages arrive.
+ */
+import { ref, watch, nextTick } from 'vue'
+
+const props = defineProps({
+  messages: { type: Array, required: true },
+})
+
+const bodyEl = ref(null)
+
+watch(
+  () => props.messages.length,
+  async () => {
+    await nextTick()
+    if (bodyEl.value) bodyEl.value.scrollTop = bodyEl.value.scrollHeight
+  },
+)
+
+function shortArgs(args) {
+  if (!args) return ''
+  let s = typeof args === 'string' ? args : JSON.stringify(args)
+  if (s.length > 60) s = s.slice(0, 57) + '…'
+  return s
+}
+
+function prettyArgs(args) {
+  if (!args) return ''
+  return typeof args === 'string' ? args : JSON.stringify(args, null, 2)
+}
+</script>
+
+<template>
+  <div ref="bodyEl" class="chat-body" data-testid="chat-active" role="log" aria-live="polite">
+    <template v-for="msg in messages" :key="msg.id">
+      <!-- Persona-swap divider -->
+      <div
+        v-if="msg.swap"
+        class="swap-line"
+        data-testid="chat-swap-line"
+        role="separator"
+      >
+        Persona swap · <b>{{ msg.swap.from }}</b> → <b>{{ msg.swap.to }}</b>
+      </div>
+
+      <!-- User message -->
+      <div v-else-if="msg.role === 'user'" class="msg user" :data-testid="`msg-user-${msg.id}`">
+        <div class="bubble">{{ msg.content }}</div>
+        <div class="meta">you</div>
+      </div>
+
+      <!-- Assistant message -->
+      <div v-else class="msg assistant" :data-testid="`msg-assistant-${msg.id}`">
+        <div v-if="msg.reasoning" class="reasoning">
+          <details>
+            <summary>thinking…</summary>
+            <pre>{{ msg.reasoning }}</pre>
+          </details>
+        </div>
+        <div v-if="msg.content" class="bubble">{{ msg.content }}</div>
+        <div class="meta"><b>{{ msg.persona || 'assistant' }}</b></div>
+
+        <!-- Inline tool calls -->
+        <details
+          v-for="tc in msg.tool_calls || []"
+          :key="tc.id"
+          class="toolblock"
+          :data-testid="`tool-call-${tc.id}`"
+        >
+          <summary class="tb-h">
+            <span>tool call</span>
+            <span class="arr">→</span>
+            <b>{{ tc.name }}</b>
+            <span class="right">{{ shortArgs(tc.args) }}</span>
+          </summary>
+          <div class="tb-body">
+            <div class="kv">
+              <span class="k">args</span>
+              <pre class="v">{{ prettyArgs(tc.args) }}</pre>
+            </div>
+            <div v-if="tc.result != null" class="kv">
+              <span class="k">result</span>
+              <pre class="v">{{ typeof tc.result === 'string' ? tc.result : JSON.stringify(tc.result, null, 2) }}</pre>
+            </div>
+          </div>
+          <div v-if="tc.duration_ms != null" class="tb-foot">
+            <span><b>{{ (tc.duration_ms / 1000).toFixed(2) }}s</b> · {{ tc.bytes || 0 }} bytes</span>
+          </div>
+        </details>
+
+        <!-- Attachments -->
+        <div
+          v-for="(att, i) in msg.attachments || []"
+          :key="i"
+          class="attach"
+          :data-testid="`attach-${msg.id}-${i}`"
+        >
+          <div v-if="att.kind === 'image'" class="img-ph" :title="att.src">image · {{ att.src || 'preview' }}</div>
+          <audio v-else-if="att.kind === 'audio'" controls :src="att.src" />
+          <pre v-else class="att-text">{{ att.text }}</pre>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.chat-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 22px 22px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.msg { display: flex; flex-direction: column; gap: 4px; max-width: 80%; }
+.msg.user { align-self: flex-end; }
+.msg.user .bubble {
+  background: var(--hal0-accent, var(--accent, #feaf00));
+  color: #0a0a0a;
+  border-color: var(--hal0-accent, var(--accent, #feaf00));
+}
+.msg .bubble {
+  padding: 10px 14px;
+  border: 1px solid var(--color-border, var(--line, #2a2a2a));
+  background: var(--color-surface-2, var(--bg-2, #181818));
+  border-radius: 6px;
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--color-fg, var(--fg, #e5e5e5));
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.msg .meta {
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 10px;
+  color: var(--color-fg-faint, var(--fg-4, #777));
+  letter-spacing: 0.04em;
+}
+.msg .meta b { color: var(--hal0-accent, var(--accent, #feaf00)); font-weight: 500; }
+.msg.user .meta { text-align: right; }
+
+.reasoning { font-family: var(--font-mono, var(--jbm, monospace)); font-size: 11px; }
+.reasoning summary { color: var(--color-fg-faint, var(--fg-4, #777)); cursor: pointer; }
+.reasoning pre {
+  background: var(--color-surface, var(--bg, #0a0a0a));
+  border-left: 2px solid var(--color-border, #2a2a2a);
+  padding: 8px 10px;
+  color: var(--color-fg-faint, var(--fg-4, #777));
+  margin: 6px 0 0;
+  white-space: pre-wrap;
+}
+
+.toolblock {
+  align-self: stretch;
+  margin: 0 6%;
+  background: var(--color-surface, var(--bg, #0a0a0a));
+  border: 1px solid var(--color-border, var(--line, #2a2a2a));
+  border-left: 2px solid var(--hal0-accent, var(--accent, #feaf00));
+  border-radius: 6px;
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 11.5px;
+  overflow: hidden;
+}
+.toolblock summary.tb-h {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  color: var(--color-fg-muted, var(--fg-3, #888));
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+.toolblock summary.tb-h::-webkit-details-marker { display: none; }
+.toolblock summary.tb-h::before {
+  content: "▸";
+  font-size: 10px;
+  color: var(--color-fg-faint, var(--fg-5, #555));
+  transition: transform 0.15s;
+}
+.toolblock[open] summary.tb-h::before { transform: rotate(90deg); }
+.toolblock summary.tb-h b { color: var(--hal0-accent, var(--accent, #feaf00)); font-weight: 500; }
+.toolblock summary.tb-h .arr { color: var(--color-fg-faint, var(--fg-5, #555)); }
+.toolblock summary.tb-h .right {
+  margin-left: auto;
+  color: var(--color-fg-faint, var(--fg-4, #777));
+  text-transform: none;
+  letter-spacing: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 50%;
+}
+.toolblock .tb-body { padding: 10px 12px; color: var(--color-fg-muted, var(--fg-2, #bbb)); border-top: 1px solid var(--color-border, var(--line-soft, #1d1d1d)); }
+.toolblock .tb-body .kv { display: grid; grid-template-columns: 80px 1fr; gap: 4px 14px; font-size: 11px; margin-bottom: 8px; }
+.toolblock .tb-body .kv:last-child { margin-bottom: 0; }
+.toolblock .tb-body .kv .k { color: var(--color-fg-faint, var(--fg-4, #777)); }
+.toolblock .tb-body .kv .v {
+  color: var(--color-fg-muted, var(--fg-2, #bbb));
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}
+.toolblock .tb-foot {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--color-border, var(--line-soft, #1d1d1d));
+  color: var(--color-fg-faint, var(--fg-4, #777));
+  font-size: 10px;
+}
+.toolblock .tb-foot b { color: var(--color-success, var(--ok, #22c55e)); font-weight: 500; }
+
+.attach {
+  align-self: stretch;
+  margin: 0 6%;
+  border: 1px solid var(--color-border, var(--line, #2a2a2a));
+  border-radius: 6px;
+  overflow: hidden;
+  max-width: 320px;
+  background: var(--color-surface-2, var(--bg-2, #181818));
+}
+.attach .img-ph {
+  height: 180px;
+  background:
+    repeating-linear-gradient(45deg, rgba(255, 176, 0, 0.06) 0 12px, transparent 12px 24px),
+    linear-gradient(135deg, #1a1610 0%, #0a0a0a 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 10px;
+  color: var(--color-fg-faint, var(--fg-4, #777));
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.attach .att-text {
+  margin: 0;
+  padding: 10px 12px;
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 12px;
+  color: var(--color-fg-muted, var(--fg-2, #bbb));
+  white-space: pre-wrap;
+}
+
+.swap-line {
+  align-self: stretch;
+  margin: 0 6%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 10.5px;
+  color: var(--color-fg-faint, var(--fg-4, #777));
+  letter-spacing: 0.02em;
+}
+.swap-line::before, .swap-line::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--color-border, var(--line-soft, #1d1d1d));
+}
+.swap-line b { color: var(--hal0-accent, var(--accent, #feaf00)); font-weight: 500; }
+</style>

--- a/ui/src/components/dashboard/ChatEmpty.vue
+++ b/ui/src/components/dashboard/ChatEmpty.vue
@@ -1,0 +1,106 @@
+<script setup>
+/**
+ * dashboard/ChatEmpty.vue — slice #169.
+ *
+ * Placeholder shown above the composer when no conversation exists.
+ * Renders a glyph, prompt, and 3 example chips. Picking a chip emits
+ * ``pick`` with the prompt text so the host can seed the composer.
+ */
+const props = defineProps({
+  prompts: {
+    type: Array,
+    default: () => [
+      'Refactor this Python file…',
+      'Summarize the docs in /docs',
+      'Generate an image of a chip',
+    ],
+  },
+})
+
+const emit = defineEmits(['pick'])
+</script>
+
+<template>
+  <div class="empty-chat" data-testid="chat-empty">
+    <div class="glyph" aria-hidden="true">
+      <span>hal<span class="zero">0</span></span>
+    </div>
+    <h3>What do you need from hal0?</h3>
+    <p>Pick a persona below and start a conversation. Tool calls render inline.</p>
+    <div class="prompts">
+      <button
+        v-for="(p, i) in prompts"
+        :key="i"
+        type="button"
+        class="prompt"
+        :data-testid="`empty-prompt-${i}`"
+        @click="emit('pick', p)"
+      >{{ p }}</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.empty-chat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 40px;
+  text-align: center;
+}
+.empty-chat .glyph {
+  width: 64px;
+  height: 64px;
+  border: 1px solid color-mix(in oklab, var(--hal0-accent, #feaf00) 30%, transparent);
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in oklab, var(--hal0-accent, #feaf00) 12%, transparent);
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--hal0-accent, var(--accent, #feaf00));
+}
+.empty-chat .glyph .zero { color: var(--hal0-accent, var(--accent, #feaf00)); }
+.empty-chat h3 {
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 16px;
+  font-weight: 500;
+  margin: 0;
+  letter-spacing: -0.01em;
+  color: var(--color-fg, var(--fg, #e5e5e5));
+}
+.empty-chat p {
+  color: var(--color-fg-muted, var(--fg-3, #888));
+  font-size: 13px;
+  margin: 0;
+  max-width: 360px;
+  line-height: 1.55;
+}
+.empty-chat .prompts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 8px;
+  max-width: 520px;
+}
+.empty-chat .prompt {
+  padding: 6px 12px;
+  border: 1px solid var(--color-border, var(--line, #2a2a2a));
+  border-radius: 999px;
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 11.5px;
+  color: var(--color-fg-muted, var(--fg-2, #bbb));
+  cursor: pointer;
+  background: var(--color-surface, var(--bg, #0a0a0a));
+}
+.empty-chat .prompt:hover {
+  border-color: var(--hal0-accent, var(--accent, #feaf00));
+  color: var(--hal0-accent, var(--accent, #feaf00));
+}
+</style>

--- a/ui/src/components/dashboard/Composer.vue
+++ b/ui/src/components/dashboard/Composer.vue
@@ -1,0 +1,348 @@
+<script setup>
+/**
+ * dashboard/Composer.vue — slice #169.
+ *
+ * Chat composer with 5 states:
+ *   idle       — input + Send (amber) + attach + mic
+ *   sending    — input disabled + spinner
+ *   streaming  — Send replaced with ✕ Stop (red)
+ *   swap       — dimmed input + above-input swap banner
+ *   no-tools   — persona "no tools" chip + attach/mic disabled tooltip
+ *   offline    — dimmed row + above-input offline banner with restart
+ *
+ * Persona placement is host-controlled — `personaPlacement="above"`
+ * renders a slot above the bar, `"inline"` renders inside the bar.
+ *
+ * Emits:
+ *   submit   — { text } when Send pressed (idle only)
+ *   stop     — when Stop pressed (streaming only)
+ *   restart  — when the offline banner's Restart button clicked
+ */
+import { ref, computed, watch, nextTick } from 'vue'
+
+const props = defineProps({
+  state: {
+    type: String,
+    default: 'idle', // 'idle' | 'sending' | 'streaming' | 'swap' | 'no-tools' | 'offline'
+  },
+  swapTarget: { type: String, default: '' },
+  personaPlacement: {
+    type: String,
+    default: 'inline', // 'above' | 'inline'
+  },
+  placeholder: { type: String, default: 'Ask hal0 anything…' },
+})
+
+const emit = defineEmits(['submit', 'stop', 'restart'])
+
+const text = ref('')
+const inputEl = ref(null)
+
+const isOffline   = computed(() => props.state === 'offline')
+const isSwap      = computed(() => props.state === 'swap')
+const isSending   = computed(() => props.state === 'sending')
+const isStreaming = computed(() => props.state === 'streaming')
+const isNoTools   = computed(() => props.state === 'no-tools')
+const isIdle      = computed(() => props.state === 'idle' || isNoTools.value)
+
+const dimmed = computed(() => isOffline.value || isSwap.value)
+const inputDisabled = computed(() => isSending.value || isStreaming.value || dimmed.value)
+const toolsDisabled = computed(() => isNoTools.value || dimmed.value)
+
+function trySubmit() {
+  if (!isIdle.value) return
+  const t = text.value.trim()
+  if (!t) return
+  emit('submit', { text: t })
+  text.value = ''
+  nextTick(() => inputEl.value?.focus())
+}
+
+function onKeydown(e) {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault()
+    trySubmit()
+  }
+}
+
+watch(() => props.state, (s) => {
+  if (s === 'idle') nextTick(() => inputEl.value?.focus())
+})
+
+defineExpose({ text, focus: () => inputEl.value?.focus() })
+</script>
+
+<template>
+  <div
+    class="composer"
+    :class="{ dimmed }"
+    data-testid="composer"
+    :data-state="state"
+  >
+    <!-- Above-input banners (swap / offline) -->
+    <div
+      v-if="isSwap"
+      class="composer-banner warn"
+      data-testid="composer-banner-swap"
+      role="status"
+    >
+      <span>⟳</span>
+      <span>
+        Swapping NPU chat to <b>{{ swapTarget || 'new model' }}</b>.
+        Voice + embed pause ~14s.
+      </span>
+    </div>
+    <div
+      v-if="isOffline"
+      class="composer-banner err"
+      data-testid="composer-banner-offline"
+      role="alert"
+    >
+      <span>⚠</span>
+      <span><b>lemond offline</b> — inference unavailable.</span>
+      <button
+        type="button"
+        class="banner-btn"
+        @click="emit('restart')"
+      >Restart lemond</button>
+    </div>
+
+    <!-- Persona above row (host slots in) -->
+    <div v-if="personaPlacement === 'above'" class="composer-persona-row">
+      <slot name="persona" />
+    </div>
+
+    <div class="composer-bar">
+      <!-- Persona inline (host slots in) -->
+      <slot v-if="personaPlacement === 'inline'" name="persona" />
+
+      <!-- Attach -->
+      <button
+        type="button"
+        class="composer-ic"
+        :class="{ disabled: toolsDisabled }"
+        :disabled="toolsDisabled"
+        :title="isNoTools ? 'This persona has no tool access' : 'Attach a file'"
+        aria-label="Attach file"
+        data-testid="composer-attach"
+      >📎</button>
+
+      <!-- Input -->
+      <div class="composer-input-wrap">
+        <input
+          ref="inputEl"
+          v-model="text"
+          type="text"
+          class="composer-input"
+          :placeholder="placeholder"
+          :disabled="inputDisabled"
+          :aria-busy="isSending || isStreaming"
+          data-testid="composer-input"
+          @keydown="onKeydown"
+        />
+      </div>
+
+      <!-- Mic -->
+      <button
+        type="button"
+        class="composer-ic"
+        :class="{ disabled: toolsDisabled }"
+        :disabled="toolsDisabled"
+        :title="isNoTools ? 'This persona has no tool access' : 'Voice input'"
+        aria-label="Voice input"
+        data-testid="composer-mic"
+      >🎤</button>
+
+      <!-- Send / Stop -->
+      <button
+        v-if="isStreaming"
+        type="button"
+        class="composer-stop"
+        data-testid="composer-stop"
+        aria-label="Stop streaming"
+        @click="emit('stop')"
+      >
+        <span class="stop-sq" aria-hidden="true" />
+        Stop
+      </button>
+      <button
+        v-else
+        type="button"
+        class="composer-send"
+        :disabled="inputDisabled"
+        :aria-label="isSending ? 'Sending' : 'Send'"
+        data-testid="composer-send"
+        @click="trySubmit"
+      >
+        <span v-if="isSending" class="spinner-sm" aria-hidden="true" />
+        <span v-else aria-hidden="true">➤</span>
+      </button>
+    </div>
+
+    <div v-if="isSending" class="composer-meta" data-testid="composer-meta-sending">
+      <span>sending…</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.composer {
+  border-top: 1px solid var(--color-border, var(--line, #2a2a2a));
+  background: var(--color-surface, var(--bg-1, #111));
+}
+.composer.dimmed .composer-bar { opacity: 0.5; pointer-events: none; }
+.composer.dimmed .composer-input { background: var(--color-surface-3, var(--bg-3, #202020)); }
+/* Keep the banner's own Restart button clickable even though the bar is dimmed */
+.composer.dimmed .composer-banner { opacity: 1; pointer-events: auto; }
+
+.composer-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+}
+.composer-persona-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px 4px;
+  border-bottom: 1px dashed var(--color-border, var(--line-soft, #1d1d1d));
+}
+
+.composer-input-wrap {
+  flex: 1;
+  position: relative;
+}
+.composer-input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--color-fg, var(--fg, #e5e5e5));
+  font-family: var(--font-sans, var(--geist, system-ui));
+  font-size: 13.5px;
+  padding: 7px 0;
+  outline: none;
+  min-height: 28px;
+  line-height: 1.45;
+}
+.composer-input::placeholder { color: var(--color-fg-faint, var(--fg-4, #777)); }
+
+.composer-ic {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-fg-muted, var(--fg-3, #888));
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+.composer-ic:hover {
+  color: var(--color-fg, var(--fg, #e5e5e5));
+  background: var(--color-surface-2, var(--bg-2, #181818));
+}
+.composer-ic.disabled, .composer-ic:disabled {
+  opacity: 0.35;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
+.composer-send {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--hal0-accent, var(--accent, #feaf00));
+  color: #0a0a0a;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+  font-size: 14px;
+}
+.composer-send:hover:not(:disabled) { filter: brightness(1.06); }
+.composer-send:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.composer-stop {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 12px;
+  background: color-mix(in oklab, var(--color-danger, #ef6b6b) 18%, transparent);
+  color: var(--color-danger, #ef6b6b);
+  border: 1px solid var(--color-danger, #ef6b6b);
+  border-radius: 4px;
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.composer-stop:hover { background: color-mix(in oklab, var(--color-danger, #ef6b6b) 28%, transparent); }
+.composer-stop .stop-sq {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background: currentColor;
+  border-radius: 1px;
+}
+
+.composer-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--color-border, var(--line-soft, #1d1d1d));
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 12px;
+}
+.composer-banner b { font-weight: 500; }
+.composer-banner.warn {
+  background: color-mix(in oklab, var(--color-warning, #f59e0b) 18%, transparent);
+  color: var(--color-warning, #f59e0b);
+}
+.composer-banner.err {
+  background: color-mix(in oklab, var(--color-danger, #ef6b6b) 18%, transparent);
+  color: var(--color-danger, #ef6b6b);
+}
+.composer-banner.info {
+  background: color-mix(in oklab, var(--hal0-accent, #feaf00) 14%, transparent);
+  color: var(--hal0-accent, #feaf00);
+}
+.composer-banner .banner-btn {
+  margin-left: auto;
+  padding: 4px 10px;
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 11px;
+  background: transparent;
+  color: inherit;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  cursor: pointer;
+}
+.composer-banner .banner-btn:hover { background: color-mix(in oklab, currentColor 12%, transparent); }
+
+.composer-meta {
+  padding: 4px 14px 8px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 10px;
+  color: var(--color-fg-faint, var(--fg-5, #555));
+}
+
+.spinner-sm {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 1.5px solid rgba(10, 10, 10, 0.25);
+  border-top-color: #0a0a0a;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+</style>

--- a/ui/src/components/dashboard/PersonaPicker.vue
+++ b/ui/src/components/dashboard/PersonaPicker.vue
@@ -1,0 +1,249 @@
+<script setup>
+/**
+ * dashboard/PersonaPicker.vue — slice #169.
+ *
+ * Persona chip + dropdown. Lists chat-capable (type=llm) slots from
+ * the system store; selecting one updates the local v-model.
+ *
+ * Session-only persistence — the component's host (Dashboard.vue)
+ * keeps the chosen persona in component-local state. Reload resets
+ * to the system default (first ``is_default`` slot, else first llm).
+ *
+ * "+ Add chat slot" routes to ``/slots?action=create&type=llm&group=chat``
+ * so the Slots view can pre-fill its create modal once that lands.
+ */
+import { computed, ref, onMounted, onBeforeUnmount, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { useSystemStore } from '../../stores/system.js'
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+  noTools:    { type: Boolean, default: false },
+  disabled:   { type: Boolean, default: false },
+})
+const emit = defineEmits(['update:modelValue', 'swap'])
+
+const router = useRouter()
+const system = useSystemStore()
+
+const open = ref(false)
+const rootEl = ref(null)
+
+const llmSlots = computed(() =>
+  (system.slots || []).filter((s) => (s.type || 'llm').toLowerCase() === 'llm'),
+)
+
+const current = computed(() => {
+  const name = props.modelValue
+  if (name) return llmSlots.value.find((s) => s.name === name)
+  const def = llmSlots.value.find((s) => s.is_default)
+  return def || llmSlots.value[0] || null
+})
+
+function pick(slot) {
+  open.value = false
+  if (!slot || slot.name === props.modelValue) return
+  emit('update:modelValue', slot.name)
+  emit('swap', { from: props.modelValue, to: slot.name, slot })
+}
+
+function addSlot() {
+  open.value = false
+  router.push('/slots?action=create&type=llm&group=chat')
+}
+
+function toggle() {
+  if (props.disabled) return
+  open.value = !open.value
+}
+
+function onClickOutside(e) {
+  if (!rootEl.value) return
+  if (!rootEl.value.contains(e.target)) open.value = false
+}
+
+onMounted(() => document.addEventListener('mousedown', onClickOutside))
+onBeforeUnmount(() => document.removeEventListener('mousedown', onClickOutside))
+
+// Seed the v-model on first slot list arrival so the chip always
+// has a name to show.
+watch(
+  current,
+  (c) => {
+    if (c && !props.modelValue) emit('update:modelValue', c.name)
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <div ref="rootEl" class="persona-wrap" data-testid="persona-picker">
+    <button
+      class="persona"
+      :class="{ disabled }"
+      :disabled="disabled"
+      :aria-expanded="open"
+      :aria-haspopup="true"
+      data-testid="persona-trigger"
+      @click="toggle"
+    >
+      <span class="dot" />
+      <span class="nm">
+        <b>{{ current?.name || 'no persona' }}</b>
+        <span v-if="current?.model" class="sub">· {{ current.model }}</span>
+        <span v-if="noTools" class="sub no-tools">· no tools</span>
+      </span>
+      <span class="chev" aria-hidden="true">⌄</span>
+    </button>
+    <div v-if="open" class="persona-menu" role="menu" data-testid="persona-menu">
+      <div class="pm-h">Chat persona</div>
+      <div v-if="llmSlots.length === 0" class="pm-empty">No chat slots configured.</div>
+      <div
+        v-for="slot in llmSlots"
+        :key="slot.name"
+        class="pm-item"
+        :class="{ active: current?.name === slot.name }"
+        :data-testid="`persona-item-${slot.name}`"
+        role="menuitem"
+        tabindex="0"
+        @click="pick(slot)"
+        @keydown.enter="pick(slot)"
+      >
+        <span class="dot" />
+        <span>
+          <div class="name">{{ slot.name }}</div>
+          <div class="sub">{{ slot.model || 'no model' }} · {{ (slot.device || '').toUpperCase() || '—' }}</div>
+          <div v-if="slot.device === 'npu'" class="warn">
+            Swapping NPU chat pauses voice + embed ~14s
+          </div>
+        </span>
+        <span v-if="current?.name === slot.name" class="check" aria-hidden="true">✓</span>
+      </div>
+      <div class="pm-add" data-testid="persona-add" @click="addSlot">
+        <span aria-hidden="true">+</span>
+        <span>Add chat slot</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.persona-wrap { position: relative; display: inline-block; }
+.persona {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 9px 5px 11px;
+  border: 1px solid var(--color-border, var(--line, #2a2a2a));
+  border-radius: 6px;
+  background: var(--color-surface, var(--bg, #0a0a0a));
+  cursor: pointer;
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 11.5px;
+  color: var(--color-fg, var(--fg, #e5e5e5));
+}
+.persona:hover {
+  border-color: var(--hal0-accent, var(--accent, #feaf00));
+}
+.persona.disabled { opacity: 0.5; cursor: not-allowed; }
+.persona .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-success, #22c55e);
+  box-shadow: 0 0 6px var(--color-success, #22c55e);
+}
+.persona .nm b {
+  color: var(--hal0-accent, var(--accent, #feaf00));
+  font-weight: 500;
+}
+.persona .nm .sub {
+  color: var(--color-fg-faint, var(--fg-4, #777));
+  font-size: 10px;
+  margin-left: 4px;
+}
+.persona .nm .no-tools { color: var(--color-warning, var(--warn, #f59e0b)); }
+.persona .chev { color: var(--color-fg-faint, var(--fg-4, #777)); }
+
+.persona-menu {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  width: 300px;
+  background: var(--color-surface-2, var(--bg-2, #181818));
+  border: 1px solid var(--color-border-hi, var(--line-strong, #3a3a3a));
+  border-radius: 6px;
+  box-shadow: 0 16px 48px -8px rgba(0, 0, 0, 0.6);
+  z-index: 50;
+  overflow: hidden;
+}
+.pm-h {
+  padding: 8px 12px;
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 10px;
+  color: var(--color-fg-faint, var(--fg-4, #777));
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  border-bottom: 1px solid var(--color-border, var(--line-soft, #1d1d1d));
+}
+.pm-empty {
+  padding: 12px;
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 11.5px;
+  color: var(--color-fg-faint, var(--fg-4, #777));
+}
+.pm-item {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--color-border, var(--line-soft, #1d1d1d));
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: 14px 1fr auto;
+  gap: 10px;
+  align-items: center;
+  outline: none;
+}
+.pm-item:hover, .pm-item:focus-visible {
+  background: var(--color-surface-3, var(--bg-3, #202020));
+}
+.pm-item.active {
+  background: color-mix(in oklab, var(--hal0-accent, #feaf00) 12%, transparent);
+}
+.pm-item .name {
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 12.5px;
+  color: var(--color-fg, var(--fg, #e5e5e5));
+}
+.pm-item .sub {
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 10.5px;
+  color: var(--color-fg-muted, var(--fg-3, #888));
+  margin-top: 2px;
+}
+.pm-item .warn {
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 10px;
+  color: var(--color-warning, var(--warn, #f59e0b));
+  margin-top: 3px;
+}
+.pm-item .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-success, #22c55e);
+}
+.pm-item .check {
+  color: var(--hal0-accent, var(--accent, #feaf00));
+  font-weight: bold;
+}
+.pm-add {
+  padding: 10px 12px;
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 11px;
+  color: var(--hal0-accent, var(--accent, #feaf00));
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.pm-add:hover { background: var(--color-surface-3, var(--bg-3, #202020)); }
+</style>

--- a/ui/src/components/dashboard/SnapshotStrip.vue
+++ b/ui/src/components/dashboard/SnapshotStrip.vue
@@ -1,0 +1,303 @@
+<script setup>
+/**
+ * dashboard/SnapshotStrip.vue — slice #169.
+ *
+ * Single-line per-slot snapshot row, lifted from the v0.3 design
+ * (`.snap` / `.snap-row` in /tmp/hal0-design-v3/dashboard.css).
+ *
+ * Each row clicks through to ``/slots/:name``. Per-slot metric strip
+ * is type-aware:
+ *
+ *   llm           → tok/s · TTFT · ctx · KV%
+ *   embed         → req/min · p50 · dim
+ *   transcription → req/min · p50 · model
+ *   tts           → req/min · p50 · model
+ *
+ * KV% renders as "—" for GPU llm slots — the bundled llama-vulkan
+ * does not emit `llamacpp:kv_cache_usage_ratio` (memory:
+ * hal0_llama_vulkan_no_kv_cache_metric). Until that scrape lands we
+ * surface the gap honestly.
+ *
+ * Empty / not-configured rows render a "Configure →" affordance
+ * routing to the Slots view.
+ */
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useSystemStore } from '../../stores/system.js'
+
+const router = useRouter()
+const system = useSystemStore()
+
+const SLOT_ORDER = ['primary', 'nano', 'agent', 'embed', 'embed-rerank', 'stt', 'tts', 'img']
+function orderKey(name) {
+  const i = SLOT_ORDER.indexOf(name)
+  return i >= 0 ? [0, i, name] : [1, 0, name]
+}
+
+const rows = computed(() => {
+  const raw = system.slots || []
+  const sorted = [...raw].sort((a, b) => {
+    const ka = orderKey(a.name)
+    const kb = orderKey(b.name)
+    if (ka[0] !== kb[0]) return ka[0] - kb[0]
+    if (ka[1] !== kb[1]) return ka[1] - kb[1]
+    return ka[2].localeCompare(kb[2])
+  })
+  return sorted
+})
+
+function stateClass(slot) {
+  const st = slot.lemonade_state ?? slot.status
+  if (st === 'loaded' || st === 'serving' || st === 'ready') return 'ok'
+  if (st === 'loading' || st === 'idle') return 'idle'
+  if (st === 'error' || st === 'failed') return 'err'
+  return 'off'
+}
+
+function deviceLabel(slot) {
+  const d = (slot.device || '').toLowerCase()
+  if (d === 'npu') return 'NPU'
+  if (d === 'gpu-rocm') return 'ROCm'
+  if (d === 'gpu-vulkan') return 'Vulkan'
+  if (d === 'cpu') return 'CPU'
+  return d || '—'
+}
+
+function metricCells(slot) {
+  const m = slot.metrics || {}
+  const t = (slot.type || 'llm').toLowerCase()
+  if (t === 'llm') {
+    const tps = (m.tokens_per_sec ?? m.tps ?? 0).toFixed(0)
+    const ttft = m.ttft_avg_seconds != null ? `${(m.ttft_avg_seconds * 1000).toFixed(0)} ms` : '—'
+    const ctx = m.ctx_size ? `${m.ctx_size}` : '—'
+    const isGpuLlm = ['gpu-rocm', 'gpu-vulkan'].includes((slot.device || '').toLowerCase())
+    const kv = isGpuLlm
+      ? '—'
+      : (m.kv_cache_usage != null ? `${(m.kv_cache_usage * 100).toFixed(0)}%` : '—')
+    return [
+      { k: 'tok/s', v: tps },
+      { k: 'TTFT',  v: ttft },
+      { k: 'ctx',   v: ctx },
+      { k: 'KV',    v: kv },
+    ]
+  }
+  if (t === 'embed' || t === 'embedding') {
+    return [
+      { k: 'req/m', v: (m.requests_per_min ?? 0).toFixed(0) },
+      { k: 'p50',   v: m.p50_ms != null ? `${m.p50_ms.toFixed(0)} ms` : '—' },
+      { k: 'dim',   v: m.dim ?? '—' },
+    ]
+  }
+  return [
+    { k: 'req/m', v: (m.requests_per_min ?? 0).toFixed(0) },
+    { k: 'p50',   v: m.p50_ms != null ? `${m.p50_ms.toFixed(0)} ms` : '—' },
+  ]
+}
+
+function rowClick(slot) {
+  router.push(`/slots/${slot.name}`)
+}
+
+function configureClick(e, slot) {
+  e.stopPropagation()
+  router.push(`/slots/${slot.name}`)
+}
+</script>
+
+<template>
+  <section class="snap" data-testid="snapshot-strip" aria-labelledby="snap-h">
+    <header class="snap-head">
+      <span id="snap-h">Slot snapshot</span>
+      <span class="ct">· {{ rows.length }}</span>
+      <span class="right" @click="router.push('/slots')">Manage slots →</span>
+    </header>
+    <div v-if="rows.length === 0" class="snap-empty">
+      No slots configured.
+      <a href="#" @click.prevent="router.push('/slots')">Configure slots →</a>
+    </div>
+    <div v-else class="snap-rows" role="list">
+      <div
+        v-for="slot in rows"
+        :key="slot.name"
+        class="snap-row"
+        :class="{ empty: !slot.model }"
+        :data-testid="`snap-row-${slot.name}`"
+        :data-slot-name="slot.name"
+        role="listitem"
+        tabindex="0"
+        @click="rowClick(slot)"
+        @keydown.enter="rowClick(slot)"
+      >
+        <span class="dot" :class="`dot-${stateClass(slot)}`" :title="slot.lemonade_state || slot.status || 'unknown'" />
+        <span class="name">{{ slot.name }}</span>
+        <span class="model">{{ slot.model || 'no model loaded' }}</span>
+        <span class="chips">
+          <span class="chip">{{ deviceLabel(slot) }}</span>
+          <span v-if="slot.is_default" class="chip default" title="Default chat persona">✦</span>
+          <span v-if="slot.coresident_group" class="chip co" title="Coresident with other NPU slots">co</span>
+        </span>
+        <span class="badge metric-strip" :aria-label="`metrics for ${slot.name}`">
+          <span v-for="cell in metricCells(slot)" :key="cell.k" class="metric">
+            <span class="mk">{{ cell.k }}</span>
+            <span class="mv">{{ cell.v }}</span>
+          </span>
+        </span>
+        <span class="cta">
+          <a
+            v-if="!slot.model"
+            href="#"
+            class="configure-link"
+            @click="(e) => configureClick(e, slot)"
+          >Configure →</a>
+          <span v-else class="chev">›</span>
+        </span>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.snap {
+  border: 1px solid var(--color-border, var(--line, #2a2a2a));
+  border-radius: 8px;
+  background: var(--color-surface, var(--bg-1, #111));
+  overflow: hidden;
+}
+.snap-head {
+  display: flex;
+  align-items: center;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--color-border, var(--line-soft, #1d1d1d));
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-fg-muted, var(--fg-3, #888));
+}
+.snap-head .ct { color: var(--color-fg-faint, var(--fg-5, #555)); margin-left: 6px; }
+.snap-head .right {
+  margin-left: auto;
+  text-transform: none;
+  letter-spacing: 0;
+  cursor: pointer;
+  color: var(--hal0-accent, var(--accent, #feaf00));
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 11px;
+}
+.snap-empty {
+  padding: 28px 16px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--color-fg-muted, var(--fg-3, #888));
+  font-family: var(--font-mono, var(--jbm, monospace));
+}
+.snap-empty a { color: var(--hal0-accent, var(--accent, #feaf00)); text-decoration: none; margin-left: 6px; }
+.snap-empty a:hover { text-decoration: underline; }
+
+.snap-rows { display: flex; flex-direction: column; }
+.snap-row {
+  display: grid;
+  grid-template-columns: 14px 100px 1fr auto auto auto;
+  gap: 14px;
+  align-items: center;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--color-border, var(--line-soft, #1d1d1d));
+  font-size: 12.5px;
+  cursor: pointer;
+  outline: none;
+}
+.snap-row:last-child { border-bottom: none; }
+.snap-row:hover, .snap-row:focus-visible {
+  background: var(--color-surface-2, var(--bg-2, #181818));
+}
+.snap-row:focus-visible {
+  box-shadow: inset 2px 0 0 var(--hal0-accent, var(--accent, #feaf00));
+}
+
+.dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--color-fg-faint, #555);
+  box-shadow: 0 0 6px transparent;
+}
+.dot.dot-ok  { background: var(--color-success, #22c55e); box-shadow: 0 0 6px var(--color-success, #22c55e); }
+.dot.dot-idle { background: var(--hal0-accent, var(--accent, #feaf00)); }
+.dot.dot-err { background: var(--color-danger, #ef6b6b); }
+.dot.dot-off { background: var(--color-fg-faint, #555); }
+
+.name {
+  color: var(--color-fg, var(--fg, #e5e5e5));
+  font-weight: 500;
+  font-family: var(--font-mono, var(--jbm, monospace));
+}
+.model {
+  color: var(--color-fg-muted, var(--fg-2, #bbb));
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.snap-row.empty .model {
+  color: var(--color-fg-faint, var(--fg-4, #777));
+  font-style: italic;
+}
+
+.chips { display: flex; gap: 5px; align-items: center; }
+.chip {
+  display: inline-flex;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--color-surface-2, var(--bg-2, #181818));
+  border: 1px solid var(--color-border, var(--line, #2a2a2a));
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 10px;
+  color: var(--color-fg-muted, var(--fg-3, #888));
+}
+.chip.default {
+  color: var(--hal0-accent, var(--accent, #feaf00));
+  border-color: var(--hal0-accent, var(--accent, #feaf00));
+}
+.chip.co {
+  color: var(--color-warning, var(--warn, #f59e0b));
+  border-color: var(--color-warning, var(--warn, #f59e0b));
+}
+
+.metric-strip {
+  display: inline-flex;
+  gap: 12px;
+}
+.metric { display: inline-flex; align-items: baseline; gap: 4px; }
+.mk {
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 10px;
+  color: var(--color-fg-faint, var(--fg-4, #777));
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.mv {
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 12px;
+  color: var(--color-fg, var(--fg, #e5e5e5));
+  font-variant-numeric: tabular-nums;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 92px;
+}
+.configure-link {
+  color: var(--hal0-accent, var(--accent, #feaf00));
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 11.5px;
+  text-decoration: none;
+}
+.configure-link:hover { text-decoration: underline; }
+.chev { color: var(--color-fg-faint, var(--fg-5, #555)); font-size: 18px; line-height: 1; }
+
+@media (max-width: 720px) {
+  .snap-row { grid-template-columns: 14px 1fr auto auto; }
+  .snap-row .model, .snap-row .chips { display: none; }
+}
+</style>

--- a/ui/src/stores/tweaks.js
+++ b/ui/src/stores/tweaks.js
@@ -26,9 +26,12 @@ const DEFAULTS = Object.freeze({
   slotCardVariant: 'a',       // 'a' | 'b' | 'c'
   npuVariant: 'rollup',       // 'rollup' | 'fan-out' | 'compact'
   heroStrip: 'sparkline',     // 'sparkline' | 'metrics' | 'minimal'
-  composerState: 'idle',      // 'idle' | 'typing' | 'error'
+  composerState: 'idle',      // 'idle' | 'sending' | 'streaming' | 'swap' | 'no-tools' | 'offline'
   firstrunLayout: 'tiers',    // 'tiers' | 'wizard'
   personaPlacement: 'topbar', // 'topbar' | 'inline' | 'drawer'
+  // Dashboard / view (slice #169)
+  chatVariant: 'active',      // 'active' | 'empty'
+  heroVariant: 'returning',   // 'returning' | 'post-install' | 'skip-path-empty'
 })
 
 function loadPersisted() {
@@ -61,6 +64,9 @@ export const useTweaksStore = defineStore('tweaks', () => {
   const composerState     = ref(initial.composerState)
   const firstrunLayout    = ref(initial.firstrunLayout)
   const personaPlacement  = ref(initial.personaPlacement)
+  // Slice #169 — dashboard variants (chat surface + hero strip flavour)
+  const chatVariant       = ref(initial.chatVariant)
+  const heroVariant       = ref(initial.heroVariant)
 
   function snapshot() {
     return {
@@ -70,12 +76,14 @@ export const useTweaksStore = defineStore('tweaks', () => {
       composerState: composerState.value,
       firstrunLayout: firstrunLayout.value,
       personaPlacement: personaPlacement.value,
+      chatVariant: chatVariant.value,
+      heroVariant: heroVariant.value,
     }
   }
 
   // Persist on any change — cheap enough for dev-only overlay.
   watch(
-    [slotCardVariant, npuVariant, heroStrip, composerState, firstrunLayout, personaPlacement],
+    [slotCardVariant, npuVariant, heroStrip, composerState, firstrunLayout, personaPlacement, chatVariant, heroVariant],
     () => persist(snapshot()),
   )
 
@@ -86,12 +94,15 @@ export const useTweaksStore = defineStore('tweaks', () => {
     composerState.value    = DEFAULTS.composerState
     firstrunLayout.value   = DEFAULTS.firstrunLayout
     personaPlacement.value = DEFAULTS.personaPlacement
+    chatVariant.value      = DEFAULTS.chatVariant
+    heroVariant.value      = DEFAULTS.heroVariant
   }
 
   return {
     // state
     slotCardVariant, npuVariant, heroStrip, composerState,
     firstrunLayout, personaPlacement,
+    chatVariant, heroVariant,
     // actions
     snapshot, reset,
     // constants

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -1,336 +1,203 @@
 <script setup>
 /**
- * Dashboard.vue — Control Room (hal0).
+ * Dashboard.vue — slice #169 (v2 dashboard / view).
  *
- * Layout (top to bottom):
- *   - Stat rail (API · slots · memory · model storage)
- *   - Unified memory bar (Strix Halo stacked breakdown)
- *   - Mini tiles (RAM · disk · throughput · NPU)
- *   - Active slots
- *   - Chat panel (test inference against any model)
- *   - Recent logs
+ * Chat-first home page. Three stacked regions inside the route:
  *
- * Stats arrive from /api/stats/hardware (proxied from configured upstreams)
- * via useStats; per-slot metrics from /api/slots/metrics via useSlotMetrics.
+ *   1. Hero strip      ~60px   3 variants: returning | post-install
+ *                              | skip-path-empty
+ *   2. SnapshotStrip   ~90px   per-LLM-slot horizontal row
+ *   3. Chat surface    rest    ChatActive | ChatEmpty + Composer
+ *
+ * The chrome (TopBar / Sidebar / Footer / BottomTabs) is owned by
+ * slice #168 (App.vue); this view only paints the route body.
+ *
+ * The composer talks /v1/chat/completions with stream:true. SSE
+ * parsing accumulates `delta.content`, `delta.reasoning_content`,
+ * and `delta.tool_calls` chunks; tool calls render inline as native
+ * <details> blocks in ChatActive.
+ *
+ * State, banners, and composer state-driving are wired through the
+ * shared stores (system / lemonade / banner / tweaks). Skip-path
+ * variant hides the composer entirely per the design.
  */
-import { computed, ref, nextTick } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useSystemStore } from '../stores/system.js'
-import { useStats, useSlotMetrics } from '../composables/useStats.js'
-import { useSlotStats } from '../composables/useSlotStats.js'
-import { api } from '../composables/useApi.js'
-import { useEvents } from '../composables/useEvents.js'
-import PageHeader from '../components/PageHeader.vue'
-import Card from '../components/Card.vue'
-import LoadingSkeleton from '../components/LoadingSkeleton.vue'
-import EmptyState from '../components/EmptyState.vue'
-import SlotCard from '../components/SlotCard.vue'
-import NPUBackendCard from '../components/capabilities/NPUBackendCard.vue'
+import { useLemonadeStore } from '../stores/lemonade.js'
+import { useBannerStore } from '../stores/banner.js'
+import { useTweaksStore } from '../stores/tweaks.js'
+import BannerStack from '../components/primitives/BannerStack.vue'
+import SnapshotStrip from '../components/dashboard/SnapshotStrip.vue'
+import PersonaPicker from '../components/dashboard/PersonaPicker.vue'
+import Composer from '../components/dashboard/Composer.vue'
+import ChatActive from '../components/dashboard/ChatActive.vue'
+import ChatEmpty from '../components/dashboard/ChatEmpty.vue'
 
 const router = useRouter()
 const system = useSystemStore()
-const { stats } = useStats(2500)
-const { metrics, history, aggHistory } = useSlotMetrics(2500)
+const lemonade = useLemonadeStore()
+const banner = useBannerStore()
+const tweaks = useTweaksStore()
 
-// Slots managed entirely by the capability cards (Embed/Voice/Img on
-// the Slots page). Hidden from the dashboard slot grid so operators
-// don't see them twice.
-const CAPABILITY_OWNED_SLOTS = new Set([
-  'embed', 'embed-rerank', 'stt', 'tts', 'img',
-])
+// ── Hero strip ───────────────────────────────────────────────────
+const HERO_DISMISS_KEY = 'hal0:hero:dismissed'
+const heroDismissed = ref(false)
 
-// Hard ordering: primary first, nano second, then user-defined slots
-// alphabetically. NPU rides at the end as its own card.
-const SLOT_ORDER = ['primary', 'nano']
-function slotSortKey(name) {
-  const i = SLOT_ORDER.indexOf(name)
-  return i >= 0 ? [0, i, name] : [1, 0, name]
+function readDismissed() {
+  try { return sessionStorage.getItem(HERO_DISMISS_KEY) === '1' } catch { return false }
 }
-const visibleSlots = computed(() => {
-  const rows = system.slots.filter((s) => !CAPABILITY_OWNED_SLOTS.has(s.name))
-  rows.sort((a, b) => {
-    const ka = slotSortKey(a.name)
-    const kb = slotSortKey(b.name)
-    if (ka[0] !== kb[0]) return ka[0] - kb[0]
-    if (ka[1] !== kb[1]) return ka[1] - kb[1]
-    return ka[2].localeCompare(kb[2])
-  })
-  return rows
-})
+function dismissHero() {
+  heroDismissed.value = true
+  try { sessionStorage.setItem(HERO_DISMISS_KEY, '1') } catch { /* ignore */ }
+}
 
-const hw = computed(() => stats.value || {})
-
-// ── Slot summary ─────────────────────────────────────────────────────
-const { running: slotsRunning, total: slotsTotal } = useSlotStats()
-const slotSummary = computed(() => ({ running: slotsRunning.value, total: slotsTotal.value }))
-
-// ── Memory tiles — prefer GTT (unified) when present, else VRAM ──────
-const memUsedGb = computed(() => {
-  if (hw.value.gtt_used_mb) return (hw.value.gtt_used_mb / 1024).toFixed(1)
-  if (hw.value.vram_used_mb) return (hw.value.vram_used_mb / 1024).toFixed(1)
-  return null
-})
-const memTotalGb = computed(() => {
-  if (hw.value.gtt_total_mb) return (hw.value.gtt_total_mb / 1024).toFixed(0)
-  if (hw.value.vram_total_mb) return (hw.value.vram_total_mb / 1024).toFixed(0)
-  return null
-})
-const memLabel = computed(() => (hw.value.gtt_total_mb ? 'GTT' : 'VRAM'))
-
-// ── Unified memory bar (Strix Halo: one physical pool, multiple consumers) ──
-// On AMD UMA, GTT *is* system RAM — they share the same DIMMs. Summing
-// ram_total + gtt_total would double-count, which is what produced the
-// "169 GB pool on a 128 GB machine" bug. The probe exposes the true
-// unified_memory_mb (via dmidecode when /proc/meminfo reports an LXC
-// cgroup quota); we trust that. When a Proxmox API token is configured
-// (see /etc/hal0/proxmox.json) the host's view is more authoritative
-// because it sees the actual physical DIMM total *and* the other
-// tenants competing for it — prefer it when present.
-const hostOk = computed(() => {
-  const h = hw.value.host
-  return !!(h && h.configured && h.ok && h.host_mem_total_mb)
-})
-const unifiedTotalGb = computed(() => {
-  if (hostOk.value) return hw.value.host.host_mem_total_mb / 1024
-  const probed = hw.value.unified_memory_mb
-  if (probed) return probed / 1024
-  // Non-UMA / unknown: RAM + dedicated VRAM is a fair total (no overlap).
-  const ramG = (hw.value.ram_total_mb || 0) / 1024
-  const vramG = (hw.value.vram_total_mb || 0) / 1024
-  return ramG + vramG
-})
-
-const unifiedSegments = computed(() => {
-  const totalG = unifiedTotalGb.value || 0
-  if (totalG === 0) return []
-  // Used breakdown:
-  //   gtt   = GPU's GTT allocations (live model weights / KV cache on UMA)
-  //   npu   = NPU model resident bytes (drawn from the same pool as GTT,
-  //           so shown only when an FLM slot is loaded — segment hidden
-  //           at 0 to avoid visually double-counting with GTT).
-  //   vram  = dedicated VRAM in use (discrete GPUs only). On Strix Halo /
-  //           any UMA box the "VRAM" sysfs counter just reports the small
-  //           BIOS-reserved framebuffer slice carved out of the same DIMMs
-  //           the unified pool already covers — we drop it entirely so the
-  //           bar only shows knobs the user can actually manage.
-  //   sys   = system RAM used by everything else (MemTotal - MemAvailable).
-  //           Inside an LXC, /proc/meminfo does NOT account for GPU-pinned
-  //           pages (those live in the host kernel's GTT bookkeeping), so
-  //           ram_used_gb and gtt_used_mb are independent — no subtraction.
-  //   host  = everything else on the Proxmox host competing for the same
-  //           DIMMs — other LXCs/VMs + ZFS ARC + the host kernel. Only
-  //           rendered when /etc/hal0/proxmox.json is configured and the
-  //           cluster/resources poll succeeded; otherwise the bar honestly
-  //           shows "we can't see beyond this LXC" by leaving that mass
-  //           unattributed inside Free.
-  const isUma = !!hw.value.is_uma
-  const gtt = (hw.value.gtt_used_mb || 0) / 1024
-  const vram = isUma ? 0 : (hw.value.vram_used_mb || 0) / 1024
-  const npu = (hw.value.npu_status?.model_mb || 0) / 1024
-  const sys = hw.value.ram_used_gb
-    ?? (((hw.value.ram_total_mb || 0) - (hw.value.ram_available_mb || 0)) / 1024)
-  let host = 0
-  if (hostOk.value) {
-    // host_mem_used already includes our LXC's sys RAM + this kernel's
-    // share of GTT (GTT is host-kernel-owned on UMA). Subtract our share
-    // so we don't visually double-count.
-    const hostUsedG = hw.value.host.host_mem_used_mb / 1024
-    host = Math.max(0, hostUsedG - sys - gtt)
+// Variant derivation: tweak override > derived state.
+// Derived rules:
+//   - 0 slots configured → skip-path-empty
+//   - first run within this session (no localStorage flag) → post-install
+//   - else → returning
+const POST_INSTALL_FLAG = 'hal0:post-install:seen'
+const heroVariant = computed(() => {
+  const tweak = tweaks.heroVariant
+  if (tweak && tweak !== 'returning') {
+    // explicit override (post-install / skip-path-empty)
+    return tweak
   }
-  const used = gtt + sys + npu + vram + host
-  const free = Math.max(0, totalG - used)
-  const seg = (label, gb, cls) => ({
-    label,
-    gb,
-    pct: Math.max(0, (gb / totalG) * 100),
-    cls,
-  })
-  const out = [
-    seg('GTT · inference', gtt, 'seg-gtt'),
-    seg('System RAM', sys, 'seg-sys'),
-  ]
-  // Hide the NPU segment until an FLM slot is loaded — NPU memory comes
-  // out of GTT, so an always-on NPU bucket would visually double-count.
-  if (npu > 0.01) out.push(seg('NPU · FLM', npu, 'seg-npu'))
-  // Proxmox host segment (other tenants + host kernel / ZFS ARC) only when
-  // we have an authoritative cluster snapshot.
-  if (host > 0.01) out.push(seg('Proxmox host', host, 'seg-host'))
-  // VRAM segment only on discrete-GPU (non-UMA) machines.
-  if (vram > 0.01) out.push(seg('VRAM', vram, 'seg-vram'))
-  out.push(seg('Free', free, 'seg-free'))
-  return out
-})
-
-// Prefer upstream-reported NPU readiness (haloai proxies it through
-// /api/stats/hardware as npu_status.ok). Falls back to the local probe's
-// npu_present so the single-LXC deployment — which has no upstreams to
-// proxy from — still lights up when amdxdna + /dev/accel are present.
-const npuOk = computed(() => hw.value.npu_status?.ok ?? !!hw.value.npu_present)
-
-// Only render the NPU backend card on Strix Halo. Even when npu_present
-// is true on a future XDNA-bearing chip, the FLM toolbox image is
-// validated on Strix Halo only — surfacing the card on every NPU host
-// would put operators in front of a broken backend they can't use yet.
-// Widen this list when a second NPU platform is validated.
-const showNpuCard = computed(
-  () => !!hw.value.npu_present && hw.value.platform === 'strix-halo',
-)
-
-// ── Throughput ────────────────────────────────────────────────────────
-const totalTps = computed(() =>
-  Object.values(metrics.value).reduce((a, m) => a + (m?.tokens_per_sec ?? m?.tps ?? 0), 0),
-)
-
-// Fleet avg TTFT — mean of per-slot avg TTFT across slots that have a
-// recent sample. Slots without data are excluded (so the avg doesn't
-// drop to zero just because STT/TTS are idle). Matches the rule
-// validated in `scripts/prototype_ttft/`.
-const avgTtftMs = computed(() => {
-  const samples = Object.values(metrics.value)
-    .map((m) => m?.ttft_avg_seconds ?? m?.ttft_seconds)
-    .filter((v) => v != null && Number.isFinite(v))
-  if (!samples.length) return null
-  return (samples.reduce((a, v) => a + v, 0) / samples.length) * 1000
-})
-
-// Fleet avg KV-cache % — mean over slots that report the gauge.
-// Non-llama slots (and llama builds without the metric) are absent
-// from the dict and naturally excluded.
-const avgKvPct = computed(() => {
-  const samples = Object.values(metrics.value)
-    .map((m) => m?.kv_cache_usage)
-    .filter((v) => v != null && Number.isFinite(v))
-  if (!samples.length) return null
-  return (samples.reduce((a, v) => a + v, 0) / samples.length) * 100
-})
-
-function fmtAvgTtft(v) {
-  if (v == null) return '—'
-  return v < 1000 ? `${Math.round(v)}` : `${(v / 1000).toFixed(1)}`
-}
-function fmtAvgTtftUnit(v) {
-  return v == null ? '' : v < 1000 ? 'ms' : 's'
-}
-const tputSparkPath = computed(() => {
-  const series = aggHistory.value.tps
-  if (!series.length) return ''
-  const max = Math.max(1, ...series)
-  const n = series.length
-  const pts = series.map((v, i) => {
-    const x = (i / Math.max(1, n - 1)) * 320
-    const y = 44 - (v / max) * 40 - 2
-    return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`
-  })
-  return pts.join(' ')
-})
-const tputAreaPath = computed(() => {
-  const line = tputSparkPath.value
-  if (!line) return ''
-  return `${line} L320,44 L0,44 Z`
-})
-
-// ── API health ───────────────────────────────────────────────────────
-const apiOk = computed(() => !system.error && system.status !== null)
-
-// ── Recent events ────────────────────────────────────────────────────
-// Reads the shared /api/events ring owned by the footer's SSE
-// connection — no second subscription. The dashboard panel formerly
-// rendered `system.status.recent_logs`, which the API never populated;
-// structured events from the bus (slot.state, pull.progress, system.*)
-// are what we have live and what actually convey "something happened
-// just now" on this box.
-const eventsApi = useEvents()
-const recentEvents = computed(() => {
-  const all = eventsApi.events.value
-  return all.length > 10 ? all.slice(-10) : all
-})
-function eventTs(ts) {
-  if (!ts) return ''
-  const d = typeof ts === 'number' ? new Date(ts * 1000) : new Date(ts)
-  if (Number.isNaN(d.getTime())) return ''
-  return d.toLocaleTimeString(undefined, { hour12: false })
-}
-function eventSevClass(s) {
-  if (s === 'error') return 'sev-error'
-  if (s === 'warn' || s === 'warning') return 'sev-warn'
-  return 'sev-info'
-}
-
-// ── Chat panel ───────────────────────────────────────────────────────
-const chatModels = ref([])
-const chatModel = ref('')
-const chatPrompt = ref('')
-const chatOutput = ref('')
-const chatReasoning = ref('')
-const chatBusy = ref(false)
-const chatError = ref(null)
-const chatOutputEl = ref(null)
-
-async function loadChatModels() {
+  if ((system.slots?.length ?? 0) === 0) return 'skip-path-empty'
   try {
-    // The Test chat panel POSTs to /v1/chat/completions, so we must show
-    // only chat-capable upstreams in the dropdown. /v1/models is a flat
-    // aggregation across every slot (embed, rerank, stt, tts included)
-    // with no capability tag — relying on its order put the embed model
-    // at the top of the list as default. We instead derive the set of
-    // chat-capable slots by joining /api/slots (slot → loaded model id)
-    // with /api/capabilities (model id → capabilities) and filter
-    // /v1/models' rows by owned_by ∈ chat-capable slots.
-    const [models, slots, cap] = await Promise.all([
-      api('/v1/models'),
-      api('/api/slots').catch(() => []),
-      api('/api/capabilities').catch(() => ({ catalogs: {} })),
-    ])
-    const chatModelIds = new Set(
-      (cap?.catalogs?.chat?.chat ?? []).map((m) => m.id),
-    )
-    const chatSlots = new Set(
-      (slots || []).filter((s) => chatModelIds.has(s.model_id)).map((s) => s.name),
-    )
-    chatModels.value = (models?.data || [])
-      .filter((m) => chatSlots.has(m.owned_by))
-      .map((m) => m.id)
-    if (!chatModel.value && chatModels.value.length) {
-      // Prefer a small fast model for the first interaction.
-      const preferred = chatModels.value.find((m) =>
-        ['gemma3:1b', 'qwen3:0.6b', 'llama3.2:1b', 'lfm2:1.2b'].includes(m),
-      )
-      chatModel.value = preferred || chatModels.value[0]
-    }
-  } catch (e) {
-    chatError.value = e?.message ?? String(e)
+    if (sessionStorage.getItem(POST_INSTALL_FLAG) === '1') return 'post-install'
+  } catch { /* ignore */ }
+  return 'returning'
+})
+
+const defaultModelName = computed(() => {
+  const def = (system.slots || []).find((s) => s.is_default && (s.type || 'llm') === 'llm')
+  return def?.model || 'qwen3'
+})
+
+const hostName = computed(() => system.hostname || 'hal0')
+const version = computed(() => system.status?.version || lemonade.version || 'v0.2')
+
+// ── SnapshotStrip ────────────────────────────────────────────────
+// Falls out of useSystemStore.slots — SnapshotStrip reads it directly.
+
+// ── Persona picker ───────────────────────────────────────────────
+const currentPersona = ref('')
+function onSwap(e) {
+  // Persona swap to an NPU slot pauses voice + embed ~14s. Show the
+  // composer's `swap` state briefly so the user sees that latency
+  // before the next chat reply arrives.
+  const isNpu = (e.slot?.device || '').toLowerCase() === 'npu'
+  if (isNpu) {
+    swapTarget.value = e.to
+    transientState.value = 'swap'
+    // Banner — npu-swap from the catalog (scope=slots; we'd see it on
+    // /slots, and dashboard renders the slots+dashboard scope group).
+    try { banner.show('npu-swap', { body: `Swapping NPU chat to ${e.to}. Voice + embed pause ~14s.` }) } catch { /* ignore */ }
+    setTimeout(() => {
+      transientState.value = null
+      try { banner.dismiss('npu-swap') } catch { /* ignore */ }
+    }, 3500)
+  }
+  // Persona-swap marker into the conversation, for the visual record.
+  if (chatVariant.value === 'active' && messages.value.length > 0) {
+    messages.value.push({
+      id: `swap-${Date.now()}`,
+      role: 'system',
+      swap: { from: e.from || 'previous', to: e.to },
+    })
   }
 }
 
-async function runChat() {
-  if (!chatPrompt.value.trim() || !chatModel.value) return
-  chatBusy.value = true
-  chatError.value = null
-  chatOutput.value = ''
-  chatReasoning.value = ''
+// ── Composer state ───────────────────────────────────────────────
+const transientState = ref(null) // 'sending' | 'streaming' | 'swap'
+const swapTarget = ref('')
+
+const composerState = computed(() => {
+  // 1) Tweak override (dev preview)
+  const tweak = tweaks.composerState
+  if (tweak && tweak !== 'idle') return tweak
+  // 2) Lemonade offline beats everything live
+  if (lemonade.health === 'down') return 'offline'
+  // 3) Transient run-state from in-flight chat
+  if (transientState.value) return transientState.value
+  return 'idle'
+})
+
+function restartLemond() {
+  // Best-effort — backend route may 501 on the dev stub. Either way
+  // we just kick the daemon and let /v1/health polling reflect the
+  // result. No client-side optimism on success.
+  fetch('/api/lemonade/restart', { method: 'POST' }).catch(() => { /* noop */ })
+}
+
+// ── Chat surface ─────────────────────────────────────────────────
+// Variant: tweak override > derived (empty when 0 messages).
+const messages = ref([])
+const chatVariant = computed(() => {
+  const tweak = tweaks.chatVariant
+  if (tweak === 'active' || tweak === 'empty') return tweak
+  return messages.value.length === 0 ? 'empty' : 'active'
+})
+
+function seedFromPrompt(p) {
+  // ChatEmpty chip pick — drop it straight into the composer.
+  if (composerRef.value) {
+    composerRef.value.text = p
+    composerRef.value.focus()
+  }
+}
+
+const composerRef = ref(null)
+const abortCtrl = ref(null)
+
+async function onSubmit({ text }) {
+  if (!text) return
+  const userId = `u-${Date.now()}`
+  messages.value.push({ id: userId, role: 'user', content: text })
+
+  const aId = `a-${Date.now()}`
+  const persona = currentPersona.value || defaultModelName.value
+  const assistant = {
+    id: aId,
+    role: 'assistant',
+    persona,
+    content: '',
+    reasoning: '',
+    tool_calls: [],
+  }
+  messages.value.push(assistant)
+
+  transientState.value = 'sending'
+  abortCtrl.value = new AbortController()
+
   try {
     const resp = await fetch('/v1/chat/completions', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
-        model: chatModel.value,
-        messages: [{ role: 'user', content: chatPrompt.value }],
+        model: persona,
+        messages: messages.value
+          .filter((m) => m.role === 'user' || m.role === 'assistant')
+          .map((m) => ({ role: m.role, content: m.content || '' })),
         stream: true,
         max_tokens: 512,
       }),
+      signal: abortCtrl.value.signal,
     })
     if (!resp.ok) {
       const txt = await resp.text()
-      try {
-        const j = JSON.parse(txt)
-        throw new Error(j?.error?.message || `HTTP ${resp.status}`)
-      } catch {
-        throw new Error(`HTTP ${resp.status}: ${txt.slice(0, 200)}`)
-      }
+      assistant.content = `Error: HTTP ${resp.status} — ${txt.slice(0, 160)}`
+      transientState.value = null
+      return
     }
+
+    transientState.value = 'streaming'
     const reader = resp.body.getReader()
     const decoder = new TextDecoder()
     let buffer = ''
+
     while (true) {
       const { value, done } = await reader.read()
       if (done) break
@@ -345,416 +212,297 @@ async function runChat() {
         try {
           const j = JSON.parse(data)
           const d = j?.choices?.[0]?.delta
-          // Reasoning models (Qwen3-Reason, gpt-oss, deepseek-r1, …) emit
-          // `reasoning_content` for their <think> tokens and `content` for
-          // the user-visible answer. Dropping reasoning made the panel look
-          // frozen — small reasoning models can burn the whole token budget
-          // on thinking before any `content` arrives.
-          if (d?.reasoning_content) chatReasoning.value += d.reasoning_content
-          if (d?.content) chatOutput.value += d.content
-          if (d?.reasoning_content || d?.content) {
-            await nextTick()
-            if (chatOutputEl.value) {
-              chatOutputEl.value.scrollTop = chatOutputEl.value.scrollHeight
+          if (!d) continue
+          if (d.reasoning_content) assistant.reasoning += d.reasoning_content
+          if (d.content) assistant.content += d.content
+          if (Array.isArray(d.tool_calls)) {
+            for (const raw of d.tool_calls) {
+              const id = raw.id || `tc-${aId}-${assistant.tool_calls.length}`
+              let tc = assistant.tool_calls.find((t) => t.id === id)
+              if (!tc) {
+                tc = { id, name: raw.function?.name || raw.name || 'tool', args: '', result: null }
+                assistant.tool_calls.push(tc)
+              }
+              if (raw.function?.arguments) tc.args += raw.function.arguments
+              else if (raw.arguments) tc.args += raw.arguments
             }
           }
-        } catch {
-          /* ignore partial JSON */
-        }
+        } catch { /* ignore partial json */ }
       }
     }
   } catch (e) {
-    chatError.value = e?.message ?? String(e)
+    if (e?.name !== 'AbortError') {
+      assistant.content = (assistant.content || '') + `\n\n[stream error: ${e?.message || e}]`
+    }
   } finally {
-    chatBusy.value = false
+    transientState.value = null
+    abortCtrl.value = null
   }
 }
 
-loadChatModels()
+function onStop() {
+  abortCtrl.value?.abort()
+  transientState.value = null
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────
+onMounted(() => {
+  heroDismissed.value = readDismissed()
+  // Make sure the system store has slot data — chrome's footer kicks
+  // the lemonade poller, but the slot list comes from /api/status.
+  if (!system.status) system.fetchStatus()
+  // E2E hook — let Playwright seed a synthetic assistant message
+  // (tool-call collapsibility spec depends on having a tool block in
+  // the DOM without having to stream a stub SSE response). Gated on
+  // dev so prod doesn't expose it. Cypress-style global; Playwright
+  // calls it via page.evaluate.
+  if (import.meta.env.DEV) {
+    if (typeof window !== 'undefined') {
+      window.__hal0DashTest = {
+        pushMessage(m) { messages.value.push(m) },
+        clearMessages() { messages.value = [] },
+        getMessages() { return JSON.parse(JSON.stringify(messages.value)) },
+      }
+    }
+  }
+})
+
+// Mock SSE / live: nothing to do here; useApi handles its own routes.
+
+// Cleanup banners on unmount (best-effort).
+watch(() => router.currentRoute.value.path, () => {
+  try { banner.dismiss('npu-swap') } catch { /* ignore */ }
+})
 </script>
 
 <template>
-  <div class="dashboard-page">
-    <div class="dashboard-hero" aria-hidden="true"></div>
-    <PageHeader eyebrow="Control Room" title="Dashboard" subtitle="Live status of your hal0 box.">
-      <template #actions>
-        <button class="btn-secondary" type="button" @click="system.fetchStatus()">
-          <svg width="13" height="13" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-          </svg>
-          Refresh
-        </button>
-      </template>
-    </PageHeader>
+  <div class="dash-route">
+    <!-- Dashboard-scoped banners (includes global) -->
+    <BannerStack scope="dashboard" />
 
-    <div class="page-body">
-      <!-- ── Stat rail ───────────────────────────────────────────── -->
-      <div class="stat-grid">
-        <Card class="stat-card">
-          <div class="stat-label">API status</div>
-          <div class="stat-value" :class="apiOk ? 'text-success' : 'text-danger'">
-            {{ apiOk ? 'Online' : 'Unreachable' }}
-          </div>
-          <div class="stat-sub">
-            {{ system.loading ? 'Checking…' : (system.status?.version ? `v${system.status.version}` : 'unknown') }}
-          </div>
-        </Card>
-
-        <Card class="stat-card" :highlight="slotSummary.running > 0">
-          <div class="stat-label">Slots running</div>
-          <div class="stat-value">
-            <template v-if="system.loading && system.slots.length === 0">
-              <LoadingSkeleton :lines="1" height="28px" />
-            </template>
-            <template v-else>
-              {{ slotSummary.running }}<span class="stat-denom">/{{ slotSummary.total }}</span>
-            </template>
-          </div>
-          <div class="stat-sub">
-            <button class="stat-link" type="button" @click="router.push('/slots')">Manage slots →</button>
-          </div>
-        </Card>
-
-        <Card class="stat-card">
-          <div class="stat-label">{{ memLabel }} memory</div>
-          <div class="stat-value">
-            <template v-if="memUsedGb && memTotalGb">
-              {{ memUsedGb }}<span class="stat-denom">/{{ memTotalGb }} GB</span>
-            </template>
-            <template v-else>
-              <span class="text-muted">—</span>
-            </template>
-          </div>
-          <div class="stat-sub">
-            <button class="stat-link" type="button" @click="router.push('/hardware')">Hardware details →</button>
-          </div>
-        </Card>
-
-        <Card class="stat-card stat-tput">
-          <div class="stat-label">Throughput</div>
-          <div class="stat-value">
-            {{ totalTps.toFixed(0) }}<span class="stat-denom">tok/s</span>
-          </div>
-          <div class="stat-sub stat-tput-row">
-            <div class="stat-tput-cell" title="Fleet avg TTFT — mean across slots with recent samples">
-              <span class="stat-tput-l">TTFT</span>
-              <span class="stat-tput-v">{{ fmtAvgTtft(avgTtftMs) }}</span>
-              <span class="stat-tput-u">{{ fmtAvgTtftUnit(avgTtftMs) || '—' }}</span>
-            </div>
-            <div class="stat-tput-cell" title="Fleet avg KV-cache fill — mean across slots that report the gauge">
-              <span class="stat-tput-l">KV</span>
-              <span class="stat-tput-v">{{ avgKvPct == null ? '—' : avgKvPct.toFixed(0) }}</span>
-              <span class="stat-tput-u">{{ avgKvPct == null ? '' : '%' }}</span>
-            </div>
-          </div>
-          <svg class="stat-spark" viewBox="0 0 320 36" preserveAspectRatio="none" aria-hidden="true">
-            <path :d="tputAreaPath" fill="currentColor" opacity="0.12" />
-            <path :d="tputSparkPath" fill="none" stroke="currentColor" stroke-width="1.4" />
-          </svg>
-        </Card>
+    <!-- ── Hero strip ─────────────────────────────────────────── -->
+    <div
+      v-if="!heroDismissed"
+      class="hero-strip"
+      :class="`hero-${heroVariant}`"
+      data-testid="dash-hero"
+      :data-variant="heroVariant"
+    >
+      <div v-if="heroVariant === 'returning'" class="greet">
+        Welcome back. <b>{{ hostName }}</b> · <span class="dim">{{ version }}</span>
       </div>
 
-      <!-- ── Unified memory bar (Strix Halo) ─────────────────────── -->
-      <Card v-if="unifiedSegments.length" class="um-card">
-        <div class="um-head">
-          <div class="um-title">
-            {{ hostOk ? 'Physical host memory' : 'Unified memory' }} ·
-            {{ unifiedTotalGb.toFixed(0) }} GB pool
-          </div>
-          <div class="um-sub">
-            {{ unifiedSegments.filter(s => s.cls !== 'seg-free').reduce((a, s) => a + s.gb, 0).toFixed(1) }} GB used
-            <span class="dim"> · NPU {{ npuOk ? 'ready' : 'offline' }}</span>
-            <span v-if="hostOk" class="dim">
-              · {{ hw.host.tenants_running }} tenant{{ hw.host.tenants_running === 1 ? '' : 's' }}
-            </span>
-            <!-- Token-rot / network-failure indicator. Memory bar quietly
-                 falls back to the LXC-only view in this state; the pill
-                 is the user-visible signal that the host total is stale.
-                 Click target is the Settings panel where the operator
-                 can re-test or rotate the API token. -->
-            <router-link
-              v-if="hw.host?.configured && !hw.host?.ok"
-              to="/settings"
-              class="pve-warn"
-              :title="hw.host?.error || 'Cluster poll failed — check token / network'"
-            >
-              · Proxmox: unreachable
-            </router-link>
-          </div>
-        </div>
-        <div class="um-bar" role="img" aria-label="Unified memory breakdown">
-          <div
-            v-for="seg in unifiedSegments"
-            :key="seg.label"
-            class="useg"
-            :class="seg.cls"
-            :style="{ width: seg.pct + '%' }"
-            :title="`${seg.label}: ${seg.gb.toFixed(1)} GB`"
-          ></div>
-        </div>
-        <div class="um-legend">
-          <span v-for="seg in unifiedSegments" :key="seg.label" class="lg">
-            <span class="sw" :class="seg.cls"></span>
-            <span class="lbl">{{ seg.label }}</span>
-            <span class="dim">{{ seg.gb.toFixed(1) }}<small>GB</small></span>
-          </span>
-        </div>
-      </Card>
+      <div v-else-if="heroVariant === 'post-install'" class="greet">
+        Welcome to hal0. <b>hal0-Pro</b> is loaded.
+        Try a message — <b>primary</b> ({{ defaultModelName }}) is your default chat persona.
+      </div>
 
-      <!-- ── Active slots ─────────────────────────────────────────── -->
-      <section aria-labelledby="slots-heading">
-        <p class="section-eyebrow"><span class="section-eyebrow-dot" aria-hidden="true"></span> Slots</p>
-        <h2 id="slots-heading" class="section-title">Slots</h2>
-        <template v-if="system.loading && visibleSlots.length === 0">
-          <div class="slots-grid">
-            <Card v-for="i in 3" :key="i"><LoadingSkeleton :lines="3" /></Card>
-          </div>
-        </template>
-        <template v-else-if="visibleSlots.length === 0">
-          <div class="slots-grid" role="list" aria-label="Inference slots">
-            <NPUBackendCard v-if="showNpuCard" />
-            <p v-else class="empty-slots">No slots configured yet — head to <a href="/slots">Slots</a> to create one.</p>
-          </div>
-        </template>
-        <template v-else>
-          <div class="slots-grid" role="list" aria-label="Inference slots">
-            <SlotCard
-              v-for="slot in visibleSlots"
-              :key="slot.name"
-              :slot="slot"
-              :metrics="metrics[slot.name]"
-              :spark-data="history[slot.name] || { tps: [], pps: [] }"
-              @action="() => router.push('/slots')"
-              @logs="() => router.push('/slots')"
-              @edit="() => router.push('/slots')"
-              @delete="() => router.push('/slots')"
-              @swapped="() => { /* slot store re-polls on its own */ }"
-            />
-            <!-- NPU backend lives in the slots grid: it can serve a
-                 chat-shaped model the same way a llama.cpp slot does,
-                 so colocating it here is honest. Strix-Halo-only —
-                 see showNpuCard above. -->
-            <NPUBackendCard v-if="showNpuCard" />
-          </div>
-        </template>
-      </section>
+      <div v-else class="greet">
+        No models loaded yet.
+      </div>
 
-      <!-- ── Chat panel ───────────────────────────────────────────── -->
-      <section aria-labelledby="chat-heading">
-        <p class="section-eyebrow"><span class="section-eyebrow-dot" aria-hidden="true"></span> /v1/chat</p>
-        <h2 id="chat-heading" class="section-title">Test chat</h2>
-        <Card class="chat-card">
-          <div class="chat-row">
-            <select v-model="chatModel" class="chat-model">
-              <option v-if="!chatModels.length" value="">No models</option>
-              <option v-for="m in chatModels" :key="m" :value="m">{{ m }}</option>
-            </select>
-            <input
-              v-model="chatPrompt"
-              class="chat-input"
-              placeholder="Ask the model anything…"
-              @keydown.enter="runChat"
-              :disabled="chatBusy"
-            />
-            <button
-              class="btn-primary chat-send"
-              type="button"
-              :disabled="chatBusy || !chatPrompt.trim() || !chatModel"
-              @click="runChat"
-            >
-              {{ chatBusy ? 'Streaming…' : 'Send' }}
-            </button>
-          </div>
-          <div ref="chatOutputEl" class="chat-output" :class="{ empty: !chatOutput && !chatReasoning && !chatError }">
-            <span v-if="chatError" class="text-danger">{{ chatError }}</span>
-            <template v-else-if="chatOutput || chatReasoning">
-              <span v-if="chatReasoning" class="chat-reasoning">{{ chatReasoning }}</span>
-              <span v-if="chatReasoning && chatOutput" class="chat-reasoning-sep">───</span>
-              <span v-if="chatOutput">{{ chatOutput }}</span>
-            </template>
-            <span v-else class="text-muted mono-text">Response appears here · streaming SSE from /v1/chat/completions</span>
-          </div>
-        </Card>
-      </section>
+      <div class="spacer" />
 
-      <!-- ── Recent events ────────────────────────────────────────── -->
-      <section aria-labelledby="logs-heading">
-        <p class="section-eyebrow"><span class="section-eyebrow-dot" aria-hidden="true"></span> Journal</p>
-        <h2 id="logs-heading" class="section-title">
-          Recent events
-          <button class="stat-link section-link" type="button" @click="router.push('/logs')">View all →</button>
-        </h2>
-        <Card :padded="false">
-          <div v-if="recentEvents.length === 0" class="logs-empty">
-            <span class="text-muted mono-text">Waiting for events…</span>
-          </div>
-          <div v-else class="logs-list" role="log" aria-live="polite" aria-relevant="additions">
-            <div
-              v-for="e in recentEvents"
-              :key="e.id"
-              class="log-event"
-              :class="eventSevClass(e.severity)"
-            >
-              <span class="log-ts mono-text">{{ eventTs(e.ts) }}</span>
-              <span class="log-type mono-text" :title="e.type">{{ e.type }}</span>
-              <span class="log-msg">{{ e.message }}</span>
-            </div>
-          </div>
-        </Card>
-      </section>
+      <button
+        v-if="heroVariant === 'post-install'"
+        type="button"
+        class="hero-action"
+        data-testid="hero-tour"
+      >Take the tour</button>
+
+      <template v-else-if="heroVariant === 'skip-path-empty'">
+        <button
+          type="button"
+          class="hero-action"
+          data-testid="hero-pick-bundle"
+          @click="router.push('/models')"
+        >Pick a bundle</button>
+        <button
+          type="button"
+          class="hero-action ghost"
+          data-testid="hero-configure-slots"
+          @click="router.push('/slots')"
+        >Configure slots</button>
+      </template>
+
+      <button
+        type="button"
+        class="close"
+        data-testid="hero-dismiss"
+        aria-label="Dismiss hero"
+        @click="dismissHero"
+      >✕</button>
     </div>
+
+    <!-- ── Snapshot strip ─────────────────────────────────────── -->
+    <SnapshotStrip />
+
+    <!-- ── Chat surface ───────────────────────────────────────── -->
+    <section
+      v-if="heroVariant !== 'skip-path-empty'"
+      class="chat"
+      data-testid="dash-chat"
+      :data-variant="chatVariant"
+    >
+      <ChatActive v-if="chatVariant === 'active'" :messages="messages" />
+      <ChatEmpty v-else @pick="seedFromPrompt" />
+
+      <Composer
+        ref="composerRef"
+        :state="composerState"
+        :swap-target="swapTarget"
+        persona-placement="above"
+        @submit="onSubmit"
+        @stop="onStop"
+        @restart="restartLemond"
+      >
+        <template #persona>
+          <PersonaPicker
+            v-model="currentPersona"
+            :no-tools="composerState === 'no-tools'"
+            :disabled="composerState === 'offline'"
+            @swap="onSwap"
+          />
+        </template>
+      </Composer>
+    </section>
+
+    <!-- ── Skip-path-empty (composer hidden by design) ────────── -->
+    <section v-else class="dash-empty" data-testid="dash-empty">
+      <h3>Pick a bundle to get hal0 chatting.</h3>
+      <p>You haven't loaded any models yet. Bundles install a curated
+        stack (chat + embed + voice) wired into the right slots.</p>
+      <div class="dash-empty-actions">
+        <button class="hero-action" @click="router.push('/models')">Pick a bundle</button>
+        <button class="hero-action ghost" @click="router.push('/slots')">Configure slots</button>
+      </div>
+    </section>
   </div>
 </template>
 
 <style scoped>
-.dashboard-page { position: relative; display: flex; flex-direction: column; min-height: 100%; }
-.page-body { padding: 20px 24px; display: flex; flex-direction: column; gap: 20px; position: relative; z-index: 1; }
-
-/* Hero glow — radial amber wash behind the page title, mirroring
-   the HeroSection on hal0-web. Pointer-events none so it never
-   blocks the refresh button. */
-.dashboard-hero {
-  position: absolute;
-  inset: 0 0 auto 0;
-  height: 220px;
-  pointer-events: none;
-  background: radial-gradient(ellipse at top, var(--hal0-accent-glow), transparent 70%);
-  z-index: 0;
+.dash-route {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 20px 24px;
+  max-width: 1440px;
+  margin: 0 auto;
+  width: 100%;
 }
 
-/* ── Stat rail ──────────────────────────────────────────────────── */
-.stat-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
-@media (max-width: 900px) { .stat-grid { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 480px) { .stat-grid { grid-template-columns: 1fr; } }
-
-.stat-card { padding: 16px; }
-.stat-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--hal0-accent); font-family: var(--font-mono); margin-bottom: 8px; font-weight: 500; }
-.stat-value { font-family: var(--font-mono); font-size: 26px; font-weight: 600; color: var(--color-fg); line-height: 1.1; margin-bottom: 6px; letter-spacing: -0.02em; font-feature-settings: 'zero' 1, 'ss02' 1, 'tnum' 1; }
-.stat-denom { font-size: 14px; color: var(--color-fg-muted); font-weight: 400; margin-left: 2px; }
-.stat-sub { font-size: 11.5px; color: var(--color-fg-faint); font-family: var(--font-mono); }
-.stat-link { background: transparent; border: none; color: var(--hal0-accent); font-family: var(--font-mono); font-size: 11px; cursor: pointer; padding: 0; }
-.stat-link:hover { text-decoration: underline; }
-.stat-tput { display: flex; flex-direction: column; }
-.stat-tput .stat-value { margin-bottom: 4px; }
-.stat-tput .stat-denom { margin-left: 4px; font-size: 13px; }
-.stat-tput-row { display: flex; gap: 14px; margin: 2px 0 6px; }
-.stat-tput-cell { display: inline-flex; align-items: baseline; gap: 4px; }
-.stat-tput-l { font-size: 10px; color: var(--color-fg-faint); letter-spacing: 0.5px; text-transform: uppercase; }
-.stat-tput-v { font-size: 13px; color: var(--color-fg); font-variant-numeric: tabular-nums; }
-.stat-tput-u { font-size: 10.5px; color: var(--color-fg-faint); }
-.stat-spark { width: 100%; height: 30px; color: var(--hal0-accent); margin-top: auto; }
-
-/* ── Unified memory bar ─────────────────────────────────────────── */
-.um-card { padding: 16px 18px; }
-.um-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 10px; }
-.um-title { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 500; color: var(--hal0-accent); }
-.um-sub { font-size: 11.5px; color: var(--color-fg-muted); font-family: var(--font-mono); font-feature-settings: 'zero' 1, 'ss02' 1, 'tnum' 1; }
-.um-sub .pve-warn { color: var(--color-danger); text-decoration: none; margin-left: 2px; }
-.um-sub .pve-warn:hover { text-decoration: underline; }
-.um-bar { display: flex; height: 24px; border-radius: 4px; overflow: hidden; background: var(--color-surface-2); border: 1px solid var(--color-border); }
-.useg { height: 100%; transition: width 0.4s ease; }
-.seg-gtt   { background: var(--hal0-accent); }
-.seg-sys   { background: var(--color-success); opacity: 0.85; }
-.seg-npu   { background: var(--color-warning); opacity: 0.9; }
-.seg-vram  { background: color-mix(in oklch, var(--hal0-accent) 50%, var(--color-warning)); }
-/* Muted slate so other-tenant pressure reads as "outside our control"
-   without competing with the amber GTT and green Sys colours. */
-.seg-host  { background: color-mix(in oklch, var(--color-fg-muted) 55%, var(--color-surface-2)); }
-.seg-free  { background: var(--color-surface-2); }
-.um-legend { display: flex; flex-wrap: wrap; gap: 14px 18px; margin-top: 10px; font-size: 11.5px; color: var(--color-fg-muted); font-family: var(--font-mono); font-feature-settings: 'zero' 1, 'ss02' 1, 'tnum' 1; }
-.lg { display: inline-flex; align-items: center; gap: 6px; }
-.sw { display: inline-block; width: 10px; height: 10px; border-radius: 2px; }
-.lbl { color: var(--color-fg-muted); }
-.lg .dim { color: var(--color-fg-faint); }
-.lg small { color: var(--color-fg-faint); margin-left: 1px; }
-
-/* ── Sections ───────────────────────────────────────────────────── */
-.section-eyebrow {
+/* ── Hero strip ─────────────────────────────────────────────────── */
+.hero-strip {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px;
+  border: 1px solid var(--color-border, var(--line, #2a2a2a));
+  border-radius: 8px;
+  background: var(--color-surface, var(--bg-1, #111));
+  position: relative;
+  min-height: 60px;
+}
+.hero-strip.hero-post-install {
+  background:
+    radial-gradient(circle at 0% 50%, color-mix(in oklab, var(--hal0-accent, #feaf00) 12%, transparent), transparent 60%),
+    var(--color-surface, var(--bg-1, #111));
+}
+.hero-strip .greet {
+  font-size: 14px;
+  color: var(--color-fg, var(--fg, #e5e5e5));
+  line-height: 1.4;
+}
+.hero-strip .greet b {
+  color: var(--hal0-accent, var(--accent, #feaf00));
+  font-weight: 500;
+  font-family: var(--font-mono, var(--jbm, monospace));
+}
+.hero-strip .greet .dim {
+  color: var(--color-fg-muted, var(--fg-3, #888));
+  font-family: var(--font-mono, var(--jbm, monospace));
+}
+.hero-strip .spacer { flex: 1; }
+.hero-action {
+  padding: 6px 12px;
+  background: var(--hal0-accent, var(--accent, #feaf00));
+  color: #0a0a0a;
+  border: 1px solid var(--hal0-accent, var(--accent, #feaf00));
+  border-radius: 4px;
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.hero-action:hover { filter: brightness(1.06); }
+.hero-action.ghost {
+  background: transparent;
+  color: var(--color-fg, var(--fg, #e5e5e5));
+  border-color: var(--color-border, var(--line, #2a2a2a));
+}
+.hero-action.ghost:hover { border-color: var(--hal0-accent, var(--accent, #feaf00)); color: var(--hal0-accent, var(--accent, #feaf00)); filter: none; }
+.hero-strip .close {
+  width: 22px;
+  height: 22px;
   display: inline-flex;
   align-items: center;
-  gap: 7px;
-  margin: 0 0 6px;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--hal0-accent);
-  font-weight: 500;
+  justify-content: center;
+  color: var(--color-fg-faint, var(--fg-4, #777));
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 12px;
 }
-.section-eyebrow-dot {
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background: var(--hal0-accent);
-  box-shadow: 0 0 6px var(--hal0-accent);
+.hero-strip .close:hover {
+  color: var(--color-fg, var(--fg, #e5e5e5));
+  background: var(--color-surface-2, var(--bg-2, #181818));
 }
-.section-title { font-size: 16px; font-weight: 600; color: var(--color-fg); letter-spacing: -0.01em; margin: 0 0 12px; display: flex; align-items: center; gap: 12px; }
-.section-link { margin-left: auto; font-size: 11px; }
 
-/* ── Slot grid ──────────────────────────────────────────────────── */
-/* Wider min-column so the SlotCard's roomier internals (taller spark,
-   outlined load-cycle buttons) breathe without wrapping. Matches the
-   Slots page's grid so the two views stay visually aligned. */
-.slots-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
-  gap: 14px;
+/* ── Chat surface ──────────────────────────────────────────────── */
+.chat {
+  border: 1px solid var(--color-border, var(--line, #2a2a2a));
+  border-radius: 8px;
+  background: var(--color-surface, var(--bg-1, #111));
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 480px;
+  overflow: hidden;
+  position: relative;
 }
-.empty-slots {
-  grid-column: 1 / -1;
-  padding: 24px;
+
+/* ── Skip-path empty state ─────────────────────────────────────── */
+.dash-empty {
+  border: 1px solid var(--color-border, var(--line, #2a2a2a));
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 50% 0%, color-mix(in oklab, var(--hal0-accent, #feaf00) 18%, transparent), transparent 60%),
+    var(--color-surface, var(--bg-1, #111));
+  padding: 80px 40px 64px;
   text-align: center;
-  color: var(--color-fg-muted);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+}
+.dash-empty h3 {
+  font-family: var(--font-mono, var(--jbm, monospace));
+  font-size: 18px;
+  font-weight: 500;
+  margin: 0;
+  color: var(--color-fg, var(--fg, #e5e5e5));
+}
+.dash-empty p {
+  margin: 0;
+  max-width: 480px;
+  color: var(--color-fg-muted, var(--fg-3, #888));
   font-size: 13px;
-  background: var(--color-surface);
-  border: 1px dashed var(--color-border);
-  border-radius: var(--radius-lg);
+  line-height: 1.55;
 }
-.empty-slots a { color: var(--hal0-accent); text-decoration: none; }
-.empty-slots a:hover { text-decoration: underline; }
-
-/* ── Chat panel ─────────────────────────────────────────────────── */
-.chat-card { padding: 14px 16px; display: flex; flex-direction: column; gap: 10px; }
-.chat-row { display: flex; gap: 8px; align-items: stretch; }
-.chat-model { padding: 6px 10px; font-size: 12px; font-family: var(--font-mono); background: var(--color-surface-2); border: 1px solid var(--color-border); border-radius: var(--radius); color: var(--color-fg); min-width: 160px; }
-.chat-input { flex: 1; padding: 6px 12px; font-size: 13px; background: var(--color-surface-2); border: 1px solid var(--color-border); border-radius: var(--radius); color: var(--color-fg); }
-.chat-input:focus, .chat-model:focus { outline: 2px solid var(--color-accent); outline-offset: 1px; }
-.chat-send { padding: 6px 16px; flex-shrink: 0; }
-.chat-output { min-height: 80px; max-height: 260px; overflow-y: auto; padding: 10px 12px; background: var(--color-surface-2); border: 1px solid var(--color-border); border-radius: var(--radius); font-size: 13px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
-.chat-output.empty { display: flex; align-items: center; min-height: 60px; }
-.chat-reasoning { color: var(--color-fg-faint); font-style: italic; font-size: 12px; }
-.chat-reasoning-sep { display: block; margin: 8px 0; color: var(--color-fg-faint); font-family: var(--font-mono); font-size: 11px; }
-
-/* ── Logs ───────────────────────────────────────────────────────── */
-.logs-empty { padding: 20px 16px; display: flex; align-items: center; }
-.logs-list { padding: 8px 0; max-height: 200px; overflow-y: auto; background: var(--hal0-bg-sunken); }
-.log-event {
-  display: grid;
-  grid-template-columns: auto auto 1fr;
+.dash-empty-actions {
+  display: flex;
   gap: 10px;
-  align-items: baseline;
-  padding: 4px 16px;
-  font-size: 11.5px;
-  border-bottom: 1px solid var(--color-border);
+  margin-top: 8px;
 }
-.log-event:last-child { border-bottom: none; }
-.log-ts { color: var(--color-fg-faint); font-size: 11px; }
-.log-type { color: var(--hal0-accent); font-size: 11px; opacity: 0.85; }
-.log-msg { color: var(--color-fg); white-space: pre-wrap; word-break: break-word; }
-.log-event.sev-warn .log-msg { color: var(--color-warning); }
-.log-event.sev-error .log-msg { color: var(--color-danger); }
-
-/* ── Utility ────────────────────────────────────────────────────── */
-.dim { color: var(--color-fg-faint); }
-.text-success { color: var(--color-success); }
-.text-danger  { color: var(--color-danger); }
-.text-muted   { color: var(--color-fg-faint); }
-.mono-text    { font-family: var(--font-mono); font-size: 12px; }
-
-.btn-primary { padding: 8px 18px; border-radius: var(--radius); background: var(--hal0-accent); color: #000; font-family: var(--font-mono); font-size: 12px; font-weight: 500; border: none; cursor: pointer; flex-shrink: 0; transition: background 0.15s; }
-.btn-primary:hover:not(:disabled) { background: var(--hal0-accent-hover); }
-.btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
-
-.btn-secondary { display: flex; align-items: center; gap: 6px; padding: 6px 12px; border-radius: var(--radius); border: 1px solid var(--color-border); background: transparent; color: var(--color-fg-muted); font-family: var(--font-mono); font-size: 12px; cursor: pointer; transition: border-color 0.15s, color 0.15s; }
-.btn-secondary:hover { border-color: var(--color-border-hi); color: var(--color-fg); }
 </style>

--- a/ui/tests/e2e/specs/dashboard.spec.ts
+++ b/ui/tests/e2e/specs/dashboard.spec.ts
@@ -1,96 +1,254 @@
 /**
- * dashboard.spec.ts — Test chat panel: chat dropdown filters non-chat slots.
+ * dashboard.spec.ts — v2 Dashboard / view (slice #169).
  *
- * Regression for: pre-fix, the dropdown rendered every model `/v1/models`
- * returned (embed, rerank, stt, tts included) and defaulted to data[0],
- * which was the embed slot's model. Post-fix, the dropdown intersects
- * /v1/models with chat-capable slots derived from /api/slots ×
- * /api/capabilities.
+ * Covers the chat-first dashboard surface added in slice #169:
+ *   - 5 composer states render via the tweaks store (idle / sending /
+ *     streaming / swap / no-tools / offline)
+ *   - SnapshotStrip rows route to /slots/:name on click
+ *   - PersonaPicker swap to an NPU slot raises the npu-swap banner
+ *   - Tool-call <details> block toggles open / closed
+ *   - Hero ✕ dismiss persists across reloads (sessionStorage)
+ *   - skip-path-empty hero variant hides the chat composer entirely
+ *
+ * Mocks ride on the shared apiMock fixture (slice #166). The first
+ * spec also seeds `useSystemStore.slots` via the /api/slots route
+ * so the snapshot strip has rows to click.
  */
 import { test, expect, json } from '../fixtures/apiMock'
+import { installSseHarness } from '../fixtures/sseHarness'
 
-test('Test chat dropdown lists only chat-capable upstreams', async ({
-  page,
-  mockState,
-  cleanState,
-}) => {
-  // Three upstreams: an embed slot, a chat slot, an stt slot. Only the
-  // chat one should survive the filter.
-  await page.route('**/v1/models', (route) =>
+const SLOTS_FIXTURE = [
+  {
+    name: 'primary',
+    kind: 'local',
+    type: 'llm',
+    device: 'gpu-vulkan',
+    backend: 'llamacpp',
+    provider: 'llamacpp',
+    model: 'qwen3-chat.gguf',
+    model_id: 'qwen3-chat',
+    port: 8081,
+    status: 'ready',
+    lemonade_state: 'loaded',
+    is_default: true,
+  },
+  {
+    name: 'agent',
+    kind: 'local',
+    type: 'llm',
+    device: 'npu',
+    backend: 'flm',
+    provider: 'flm',
+    model: 'gemma3:1b',
+    model_id: 'gemma3-1b',
+    port: 8082,
+    status: 'idle',
+    lemonade_state: 'loaded',
+    coresident_group: 'npu-flm-trio',
+  },
+  {
+    name: 'embed',
+    kind: 'local',
+    type: 'embedding',
+    device: 'gpu-rocm',
+    backend: 'llamacpp',
+    provider: 'llamacpp',
+    model: 'nomic-embed.gguf',
+    model_id: 'nomic-embed',
+    port: 8083,
+    status: 'ready',
+    lemonade_state: 'loaded',
+  },
+]
+
+test.beforeEach(async ({ page, mockState, cleanState }) => {
+  void cleanState
+  await page.setViewportSize({ width: 1366, height: 900 })
+  await installSseHarness(page)
+  // Empty SSE events so the bell + footer don't sit on a real EventSource.
+  await page.route('**/api/events?**', (route) =>
+    json(route, { events: [], next_since: 0 }),
+  )
+  await page.route('**/api/events', (route) =>
+    json(route, { events: [], next_since: 0 }),
+  )
+  await page.route('**/api/events/stream*', (route) =>
+    route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' }),
+  )
+  await page.route('**/api/agent/approvals/events*', (route) =>
+    route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' }),
+  )
+  await page.route('**/api/lemonade/events/stream*', (route) =>
+    route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' }),
+  )
+
+  // Healthy lemonade so the composer's `offline` derivation stays off
+  // unless a spec explicitly overrides it.
+  await page.route('**/v1/health', (route) =>
     json(route, {
-      object: 'list',
-      data: [
-        { id: 'nomic-embed.gguf', object: 'model', owned_by: 'embed' },
-        { id: 'qwen3-chat.gguf', object: 'model', owned_by: 'primary' },
-        { id: 'moonshine-base', object: 'model', owned_by: 'stt' },
+      loaded: [
+        { model_name: 'qwen3-chat', backend_url: 'http://127.0.0.1:8081' },
       ],
+      max_loaded: 4,
+      version: 'v10.6.0',
     }),
   )
-  await page.route('**/api/slots', (route) =>
-    json(route, [
-      { name: 'embed', model_id: 'nomic-embed-text-v1.5-q8_0' },
-      { name: 'primary', model_id: 'qwen3-chat-id' },
-      { name: 'stt', model_id: 'moonshine-base-en' },
-    ]),
-  )
-  await page.route('**/api/capabilities', (route) =>
-    json(route, {
-      backends: [],
-      catalogs: {
-        chat: {
-          chat: [{ id: 'qwen3-chat-id', capabilities: ['chat'] }],
-        },
-      },
-      selections: {},
-    }),
-  )
-
-  await page.goto('/')
-
-  const dropdown = page.locator('select.chat-model')
-  await expect(dropdown).toBeVisible()
-  // Wait for the post-mount fetch to settle and the options to populate.
-  await expect(dropdown.locator('option')).toHaveCount(1, { timeout: 5_000 })
-  await expect(dropdown.locator('option').first()).toHaveText('qwen3-chat.gguf')
-
-  // Selected value mirrors the only chat-capable model.
-  await expect(dropdown).toHaveValue('qwen3-chat.gguf')
-
-  // Negative assertions: embed/stt models must not leak in.
-  await expect(dropdown).not.toContainText('nomic-embed')
-  await expect(dropdown).not.toContainText('moonshine')
+  // Seed the system store with 3 slots so SnapshotStrip + PersonaPicker
+  // have rows. Mirrors /api/slots, which wins over /api/status.slots in
+  // useSystemStore.
+  mockState.status = { ...mockState.status, slots: SLOTS_FIXTURE }
+  await page.route('**/api/slots', (route) => json(route, SLOTS_FIXTURE))
 })
 
-test('Test chat dropdown is empty when no chat-capable slot exists', async ({
-  page,
-  mockState,
-  cleanState,
-}) => {
-  // Pre-fix this test would fail because the embed model would leak in
-  // and become the default — sending /v1/chat/completions against an
-  // embedding endpoint.
-  await page.route('**/v1/models', (route) =>
-    json(route, {
-      object: 'list',
-      data: [{ id: 'nomic-embed.gguf', object: 'model', owned_by: 'embed' }],
-    }),
-  )
-  await page.route('**/api/slots', (route) =>
-    json(route, [{ name: 'embed', model_id: 'nomic-embed-text-v1.5-q8_0' }]),
-  )
-  await page.route('**/api/capabilities', (route) =>
-    json(route, {
-      backends: [],
-      catalogs: { chat: { chat: [] } },
-      selections: {},
-    }),
-  )
+/* ── Hero ────────────────────────────────────────────────────────── */
 
+test('Hero ✕ dismiss persists across reload via sessionStorage', async ({ page }) => {
+  await page.goto('/')
+  const hero = page.locator('[data-testid="dash-hero"]')
+  await expect(hero).toBeVisible()
+  await page.locator('[data-testid="hero-dismiss"]').click()
+  await expect(hero).toHaveCount(0)
+
+  await page.reload()
+  await expect(page.locator('[data-testid="dash-hero"]')).toHaveCount(0)
+})
+
+test('Hero variant `post-install` shows tour CTA', async ({ page }) => {
+  // Pre-seed the tweak override so the hero picks the post-install copy
+  // independent of the (mocked) slot count.
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'hal0:tweaks:v2',
+      JSON.stringify({ heroVariant: 'post-install' }),
+    )
+  })
+  await page.goto('/')
+  const hero = page.locator('[data-testid="dash-hero"]')
+  await expect(hero).toHaveAttribute('data-variant', 'post-install')
+  await expect(page.locator('[data-testid="hero-tour"]')).toBeVisible()
+})
+
+/* ── Snapshot strip ─────────────────────────────────────────────── */
+
+test('SnapshotStrip rows route to /slots/:name on click', async ({ page }) => {
+  await page.goto('/')
+  const strip = page.locator('[data-testid="snapshot-strip"]')
+  await expect(strip).toBeVisible()
+  // Wait for the system store to settle the slot list.
+  await expect(page.locator('[data-testid="snap-row-primary"]')).toBeVisible()
+  await page.locator('[data-testid="snap-row-agent"]').click()
+  await expect(page).toHaveURL(/\/slots\/agent$/)
+})
+
+/* ── Composer states (5 of 5) ───────────────────────────────────── */
+
+const COMPOSER_STATES: Array<'idle' | 'sending' | 'streaming' | 'swap' | 'no-tools' | 'offline'> = [
+  'idle', 'sending', 'streaming', 'swap', 'no-tools', 'offline',
+]
+
+for (const state of COMPOSER_STATES) {
+  test(`Composer state ${state} renders via tweak`, async ({ page }) => {
+    await page.addInitScript((s) => {
+      localStorage.setItem('hal0:tweaks:v2', JSON.stringify({ composerState: s }))
+    }, state)
+    await page.goto('/')
+
+    const composer = page.locator('[data-testid="composer"]')
+    await expect(composer).toBeVisible()
+    await expect(composer).toHaveAttribute('data-state', state)
+
+    if (state === 'streaming') {
+      await expect(page.locator('[data-testid="composer-stop"]')).toBeVisible()
+    } else if (state === 'sending') {
+      await expect(page.locator('[data-testid="composer-meta-sending"]')).toBeVisible()
+    } else if (state === 'swap') {
+      await expect(page.locator('[data-testid="composer-banner-swap"]')).toBeVisible()
+    } else if (state === 'offline') {
+      await expect(page.locator('[data-testid="composer-banner-offline"]')).toBeVisible()
+    } else if (state === 'no-tools') {
+      await expect(page.locator('[data-testid="composer-attach"]')).toBeDisabled()
+      await expect(page.locator('[data-testid="composer-mic"]')).toBeDisabled()
+    } else {
+      // idle — Send is interactive
+      await expect(page.locator('[data-testid="composer-send"]')).toBeVisible()
+    }
+  })
+}
+
+/* ── Persona swap → NPU triggers banner ─────────────────────────── */
+
+test('Persona swap to NPU slot raises the composer swap banner', async ({ page }) => {
+  await page.goto('/')
+  // Open the picker.
+  await page.locator('[data-testid="persona-trigger"]').click()
+  await expect(page.locator('[data-testid="persona-menu"]')).toBeVisible()
+  // Pick the NPU agent slot. The composer drops to its `swap` state
+  // for ~3.5s while voice + embed pause — surfaced inline on the
+  // composer (not the catalog-driven BannerStack, which is scoped to
+  // /slots and wouldn't render on /).
+  await page.locator('[data-testid="persona-item-agent"]').click()
+  const composer = page.locator('[data-testid="composer"]')
+  await expect(composer).toHaveAttribute('data-state', 'swap', { timeout: 2_000 })
+  await expect(page.locator('[data-testid="composer-banner-swap"]')).toBeVisible()
+})
+
+/* ── Tool-call <details> collapses + expands ────────────────────── */
+
+test('Tool-call <details> block collapses and expands', async ({ page }) => {
+  // Force the chat surface into `active` and seed a synthetic assistant
+  // message that carries a tool-call. Avoids re-implementing OpenAI SSE
+  // semantics in a mock — slice #169 only owns the inline
+  // tool-call rendering, not stream correctness (which lives in
+  // Composer / Dashboard's submit handler and is exercised elsewhere).
+  await page.addInitScript(() => {
+    localStorage.setItem('hal0:tweaks:v2', JSON.stringify({ chatVariant: 'active' }))
+  })
   await page.goto('/')
 
-  const dropdown = page.locator('select.chat-model')
-  await expect(dropdown).toBeVisible()
-  // "No models" placeholder option is the only entry.
-  await expect(dropdown.locator('option')).toHaveCount(1)
-  await expect(dropdown.locator('option').first()).toHaveText('No models')
+  await page.waitForFunction(() => !!window.__hal0DashTest)
+  await page.evaluate(() => {
+    window.__hal0DashTest.clearMessages()
+    window.__hal0DashTest.pushMessage({
+      id: 'u-1', role: 'user', content: 'read a.py',
+    })
+    window.__hal0DashTest.pushMessage({
+      id: 'a-1',
+      role: 'assistant',
+      persona: 'primary',
+      content: 'Sure, reading a.py.',
+      tool_calls: [
+        {
+          id: 'tc-1',
+          name: 'read_file',
+          args: { path: 'a.py' },
+          result: 'print("hi")\n',
+          duration_ms: 130,
+        },
+      ],
+    })
+  })
+
+  // Tool-call block appears.
+  const tc = page.locator('[data-testid="tool-call-tc-1"]')
+  await expect(tc).toBeVisible({ timeout: 4_000 })
+
+  // <details> starts collapsed (no `open` attr).
+  await expect(tc).not.toHaveAttribute('open', '')
+  await tc.locator('summary').click()
+  await expect(tc).toHaveAttribute('open', '')
+  await tc.locator('summary').click()
+  await expect(tc).not.toHaveAttribute('open', '')
+})
+
+/* ── Skip-path-empty hides composer ────────────────────────────── */
+
+test('Hero `skip-path-empty` hides the composer entirely', async ({ page, mockState }) => {
+  // Empty slot list → derivation picks `skip-path-empty`.
+  mockState.status = { ...mockState.status, slots: [] }
+  await page.route('**/api/slots', (route) => json(route, []))
+
+  await page.goto('/')
+  await expect(page.locator('[data-testid="dash-hero"]')).toHaveAttribute('data-variant', 'skip-path-empty')
+  await expect(page.locator('[data-testid="composer"]')).toHaveCount(0)
+  await expect(page.locator('[data-testid="dash-empty"]')).toBeVisible()
 })


### PR DESCRIPTION
## Summary

Slice #169 — rewrite Dashboard.vue to the v0.3 chat-first design.

Issue: https://github.com/Hal0ai/hal0/issues/169

### Layout (route view, inside slice #168 chrome)

1. **Hero strip** (~60px) — 3 variants (returning / post-install / skip-path-empty) with sessionStorage-backed ✕ dismiss.
2. **SnapshotStrip** (~90px) — per-slot row routing to `/slots/:name`, type-aware metric strip (llm: tok/s · TTFT · ctx · KV%; embed: req/min · p50 · dim). KV% honestly shows "—" for GPU llm slots per the bundled llama-vulkan scrape gap.
3. **Chat surface** (rest) — ChatActive | ChatEmpty + Composer with persona-above placement.

### Components added (`ui/src/components/dashboard/`)

- `SnapshotStrip.vue` — clickable rows, state dot, device chip, default ✦, coresident chip
- `PersonaPicker.vue` — persona chip + dropdown of llm slots, "+ Add chat slot" → `/slots?action=create&type=llm&group=chat`
- `Composer.vue` — 5 states (idle / sending / streaming / swap / no-tools / offline) with persona slot, attach + mic + Send (or red ✕ Stop)
- `ChatActive.vue` — user/assistant bubbles + inline tool-call `<details>` blocks + persona-swap markers + image/audio/text attachments
- `ChatEmpty.vue` — glyph + 3 example prompt chips (emit `pick`)

### Old Dashboard.vue sections replaced

The previous Dashboard.vue rendered stat rail (API · slots · memory · throughput) + unified memory bar + slot grid + test-chat panel + recent-events panel. Slice #169 replaces all of it. Per-slot status moves to the SnapshotStrip; test-chat panel is superseded by the chat-first surface. Stats / memory / events are owned by other surfaces in v2 (Hardware view, Logs view, footer chips).

### Notes

- Composer's `swap` state surfaces **inline** (`composer-banner-swap`) rather than via the catalog `npu-swap` banner, because the latter is scope=`slots` and would not render through this view's scope=`dashboard` BannerStack. Brief disallowed new catalog entries.
- `useTweaksStore` gains `chatVariant` + `heroVariant` knobs for designer preview without altering prod derivation.
- No `/api/*` contracts changed. `/v1/chat/completions` streaming as before.

### Verification

- **Composer states (5 of 5)**: y — `idle`, `sending`, `streaming`, `swap`, `no-tools`, `offline` all render via tweak + assertions on inline banners / Stop button / sending meta.
- **Tool-call `<details>` collapsible**: y — `<summary>` click toggles `open` attr both directions.
- **SnapshotStrip rows route**: y — click on `[data-testid="snap-row-agent"]` navigates to `/slots/agent`.
- **Persona swap → swap state**: y — picking NPU `agent` slot drops composer to `swap` for 3.5s.
- **Hero × dismiss persists**: y — sessionStorage survives reload.
- **Skip-path-empty hides composer**: y — 0 slots → `dash-empty` block, no `composer`.

## Test plan

- [x] `npm run build` clean
- [x] `npm run test:e2e` 69/69 green (12 in dashboard.spec.ts, all other prior specs unaffected)
- [x] No regressions on chrome.spec, dashboard-lemonade-state.spec, agent-flow.spec, slot-lifecycle.spec, etc.
- [x] Main worktree leak: 0
- [x] Base contains f5118fb chrome merge: y

🤖 Generated with [Claude Code](https://claude.com/claude-code)