### PR TITLE
feat(bundles): first-run picker + 5 manifests (hal0-Lite/Default/Pro/Max + LMX) (PR-17)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1233,6 +1233,34 @@ else
     info "skipping (Lemonade resources dir ${LEMONADE_RESOURCES} not present yet)"
 fi
 
+# ── Bundle picker manifests (ADR-0010 / PR-17) ────────────────────────────
+# Ship the five first-run bundle manifests (hal0-Lite / hal0-Default /
+# hal0-Pro / hal0-Max + LMX-Omni-52B-Halo) into the runtime collections
+# directory. The bundle picker UI on first dashboard load reads from
+# /var/lib/hal0/models/collections/omni/ — without this copy, the API
+# falls back to the in-tree dev manifests, which only exist on a source
+# checkout, not in a packaged install.
+#
+# Idempotent: re-running install.sh overwrites each manifest. Manifests
+# are tiny (a few KB) and the copy is fast, so we don't bother with
+# content hashing.
+ui_step "Bundle picker manifests"
+
+BUNDLES_SRC="${REPO_ROOT}/installer/manifests/omni"
+BUNDLES_DST="${VAR_DIR}/models/collections/omni"
+
+if [[ -d "${BUNDLES_SRC}" ]]; then
+    mkdir -p "${BUNDLES_DST}"
+    if cp -f "${BUNDLES_SRC}"/*.json "${BUNDLES_DST}/" 2>/dev/null; then
+        chown -R hal0:hal0 "${VAR_DIR}/models/collections" 2>/dev/null || true
+        info "installed bundle manifests → ${BUNDLES_DST}"
+    else
+        warn "failed to copy bundle manifests from ${BUNDLES_SRC}"
+    fi
+else
+    warn "bundle manifest source ${BUNDLES_SRC} not found; picker will fall back to in-tree defaults"
+fi
+
 ui_step "Service start"
 
 if [[ "${DEV_MODE}" -eq 1 || "${NO_START}" -eq 1 ]]; then

--- a/installer/manifests/omni/LMX-Omni-52B-Halo.json
+++ b/installer/manifests/omni/LMX-Omni-52B-Halo.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": 1,
+  "hal0": {
+    "name": "LMX-Omni-52B-Halo",
+    "min_ram_gb": 100,
+    "primary": {
+      "slot": "chat.primary",
+      "model_name": "Qwen3.6-35B-A3B-MTP",
+      "size_gb": 23.8,
+      "lru": false
+    },
+    "coder": null,
+    "aux": [
+      {
+        "slot": "stt",
+        "model_name": "Whisper-Large-v3-Turbo",
+        "size_gb": 1.6,
+        "lru": false
+      },
+      {
+        "slot": "tts",
+        "model_name": "kokoro-v1",
+        "size_gb": 0.35,
+        "lru": false
+      },
+      {
+        "slot": "img",
+        "model_name": "Flux-2-Klein-9B",
+        "size_gb": 9.0,
+        "lru": false
+      }
+    ],
+    "npu_trio_shown": false,
+    "npu_trio_optin": false,
+    "display_label": "LMX-Omni-52B-Halo",
+    "display_subtitle": "AMD-curated kit — vendor-blessed Strix Halo bundle",
+    "vendor": "amd"
+  },
+  "omni": {
+    "kind": "collection.omni",
+    "name": "LMX-Omni-52B-Halo",
+    "description": "AMD's curated triple-modality kit for Strix Halo.",
+    "members": [
+      { "model_name": "Qwen3.6-35B-A3B-MTP" },
+      { "model_name": "Whisper-Large-v3-Turbo" },
+      { "model_name": "kokoro-v1" },
+      { "model_name": "Flux-2-Klein-9B" }
+    ]
+  }
+}

--- a/installer/manifests/omni/hal0-default.json
+++ b/installer/manifests/omni/hal0-default.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": 1,
+  "hal0": {
+    "name": "hal0-Default",
+    "min_ram_gb": 32,
+    "primary": {
+      "slot": "chat.primary",
+      "model_name": "qwen3.5-9b",
+      "size_gb": 6.9,
+      "lru": false
+    },
+    "coder": null,
+    "aux": [
+      {
+        "slot": "embed",
+        "model_name": "nomic-v1.5",
+        "size_gb": 0.3,
+        "lru": false
+      },
+      {
+        "slot": "stt",
+        "model_name": "whisper-tiny",
+        "size_gb": 0.075,
+        "lru": false
+      },
+      {
+        "slot": "tts",
+        "model_name": "kokoro:cpu",
+        "size_gb": 0.35,
+        "lru": false
+      }
+    ],
+    "npu_trio_shown": false,
+    "npu_trio_optin": false,
+    "display_label": "hal0-Default",
+    "display_subtitle": "Balanced chat + embed + voice for 32 GB+ boxes",
+    "vendor": "hal0"
+  },
+  "omni": {
+    "kind": "collection.omni",
+    "name": "hal0-Default",
+    "description": "Recommended starter bundle: chat, embed, STT, TTS.",
+    "members": [
+      { "model_name": "qwen3.5-9b" },
+      { "model_name": "nomic-v1.5" },
+      { "model_name": "whisper-tiny" },
+      { "model_name": "kokoro:cpu" }
+    ]
+  }
+}

--- a/installer/manifests/omni/hal0-lite.json
+++ b/installer/manifests/omni/hal0-lite.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "hal0": {
+    "name": "hal0-Lite",
+    "min_ram_gb": 16,
+    "primary": {
+      "slot": "chat.primary",
+      "model_name": "qwen3.5-0.8b",
+      "size_gb": 1.0,
+      "lru": false
+    },
+    "coder": null,
+    "aux": [],
+    "npu_trio_shown": false,
+    "npu_trio_optin": false,
+    "display_label": "hal0-Lite",
+    "display_subtitle": "Minimal chat — fits any 16 GB+ box",
+    "vendor": "hal0"
+  },
+  "omni": {
+    "kind": "collection.omni",
+    "name": "hal0-Lite",
+    "description": "Lightweight chat-only bundle for entry-level hardware.",
+    "members": [
+      { "model_name": "qwen3.5-0.8b" }
+    ]
+  }
+}

--- a/installer/manifests/omni/hal0-max.json
+++ b/installer/manifests/omni/hal0-max.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 1,
+  "hal0": {
+    "name": "hal0-Max",
+    "min_ram_gb": 100,
+    "primary": {
+      "slot": "chat.primary",
+      "model_name": "Qwen3.6-35B-A3B-MTP",
+      "size_gb": 23.8,
+      "lru": false
+    },
+    "coder": {
+      "slot": "chat.coder",
+      "model_name": "Qwen3-Coder-Next-80B-A3B",
+      "size_gb": 48.0,
+      "lru": true
+    },
+    "aux": [
+      {
+        "slot": "embed",
+        "model_name": "nomic-v1.5",
+        "size_gb": 0.3,
+        "lru": false
+      },
+      {
+        "slot": "rerank",
+        "model_name": "bge-reranker-v2-m3",
+        "size_gb": 0.45,
+        "lru": false
+      },
+      {
+        "slot": "stt",
+        "model_name": "whisper-large-v3-turbo",
+        "size_gb": 1.6,
+        "lru": false
+      },
+      {
+        "slot": "tts",
+        "model_name": "kokoro:cpu",
+        "size_gb": 0.35,
+        "lru": false
+      },
+      {
+        "slot": "img",
+        "model_name": "flux-2-klein-9b",
+        "size_gb": 9.0,
+        "lru": true
+      }
+    ],
+    "npu_trio_shown": true,
+    "npu_trio_optin": false,
+    "display_label": "hal0-Max",
+    "display_subtitle": "Top-of-line chat + coder + voice + Flux image, 100 GB+ Strix Halo",
+    "vendor": "hal0"
+  },
+  "omni": {
+    "kind": "collection.omni",
+    "name": "hal0-Max",
+    "description": "Max bundle: largest chat + coder (LRU), Whisper Turbo, Flux 2 Klein.",
+    "members": [
+      { "model_name": "Qwen3.6-35B-A3B-MTP" },
+      { "model_name": "Qwen3-Coder-Next-80B-A3B" },
+      { "model_name": "nomic-v1.5" },
+      { "model_name": "bge-reranker-v2-m3" },
+      { "model_name": "whisper-large-v3-turbo" },
+      { "model_name": "kokoro:cpu" },
+      { "model_name": "flux-2-klein-9b" }
+    ]
+  }
+}

--- a/installer/manifests/omni/hal0-pro.json
+++ b/installer/manifests/omni/hal0-pro.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 1,
+  "hal0": {
+    "name": "hal0-Pro",
+    "min_ram_gb": 64,
+    "primary": {
+      "slot": "chat.primary",
+      "model_name": "Qwen3.6-27B-MTP",
+      "size_gb": 18.8,
+      "lru": false
+    },
+    "coder": {
+      "slot": "chat.coder",
+      "model_name": "Qwen3-Coder-30B-A3B",
+      "size_gb": 18.6,
+      "lru": true
+    },
+    "aux": [
+      {
+        "slot": "embed",
+        "model_name": "nomic-v1.5",
+        "size_gb": 0.3,
+        "lru": false
+      },
+      {
+        "slot": "rerank",
+        "model_name": "bge-reranker-v2-m3",
+        "size_gb": 0.45,
+        "lru": false
+      },
+      {
+        "slot": "stt",
+        "model_name": "whisper-base",
+        "size_gb": 0.15,
+        "lru": false
+      },
+      {
+        "slot": "tts",
+        "model_name": "kokoro:cpu",
+        "size_gb": 0.35,
+        "lru": false
+      },
+      {
+        "slot": "img",
+        "model_name": "sd-turbo",
+        "size_gb": 1.4,
+        "lru": true
+      }
+    ],
+    "npu_trio_shown": true,
+    "npu_trio_optin": false,
+    "display_label": "hal0-Pro",
+    "display_subtitle": "Chat + coder + embed/rerank + STT + TTS + image, 64 GB+",
+    "vendor": "hal0"
+  },
+  "omni": {
+    "kind": "collection.omni",
+    "name": "hal0-Pro",
+    "description": "Pro bundle: chat, coder (LRU), embed/rerank, voice, image.",
+    "members": [
+      { "model_name": "Qwen3.6-27B-MTP" },
+      { "model_name": "Qwen3-Coder-30B-A3B" },
+      { "model_name": "nomic-v1.5" },
+      { "model_name": "bge-reranker-v2-m3" },
+      { "model_name": "whisper-base" },
+      { "model_name": "kokoro:cpu" },
+      { "model_name": "sd-turbo" }
+    ]
+  }
+}

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -39,6 +39,9 @@ from hal0.api.routes import (
     backends as backends_routes,
 )
 from hal0.api.routes import (
+    bundles as bundles_routes,
+)
+from hal0.api.routes import (
     capabilities as capabilities_routes,
 )
 from hal0.api.routes import (
@@ -722,6 +725,18 @@ def create_app() -> FastAPI:
         capabilities_routes.router,
         prefix="/api/capabilities",
         tags=["capabilities"],
+        dependencies=_admin_auth,
+    )
+
+    # First-run bundle picker (ADR-0010 / PR-17). Admin-gated for
+    # consistency with the rest of the capability surface; the picker
+    # writes capabilities.toml entries via the orchestrator and drops
+    # a marker file so the dashboard hides the picker on subsequent
+    # loads. Plan §8 + §11 PR-17 own the user-facing UX.
+    app.include_router(
+        bundles_routes.router,
+        prefix="/api/bundles",
+        tags=["bundles"],
         dependencies=_admin_auth,
     )
 

--- a/src/hal0/api/routes/bundles.py
+++ b/src/hal0/api/routes/bundles.py
@@ -1,0 +1,146 @@
+"""HTTP routes for the first-run bundle picker (ADR-0010 / PR-17).
+
+Mounted under ``/api/bundles`` (see :mod:`hal0.api.__init__`):
+
+  - ``GET  /api/bundles``           — picker payload: tiers + eligible
+                                      subset + current marker status.
+  - ``GET  /api/bundles/skip``      — record the "Skip — configure
+                                      manually" branch and unblock the
+                                      dashboard.
+  - ``POST /api/bundles/{name}``    — apply a tier pick; persists the
+                                      marker and forwards capability
+                                      rows through CapabilityOrchestrator.
+
+The routes are admin-gated at ``include_router`` time (see
+``hal0.api.__init__``). No per-route auth helper is needed here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from hal0.api.deps import CapabilityOrchestratorDep
+from hal0.bundles import eligibility
+from hal0.bundles import store as bundle_store
+from hal0.bundles import tiers as bundle_tiers
+from hal0.errors import BadRequest, NotFound
+
+router = APIRouter()
+
+
+def _bundle_payload() -> dict[str, Any]:
+    summaries = bundle_tiers.list_bundle_summaries()
+    eligible = set(eligibility.eligible_tiers())
+    choice = bundle_store.read_choice()
+    return {
+        "host_ram_gb": eligibility.host_ram_gb(),
+        "tiers": [bundle.to_dict() for bundle in summaries],
+        "eligible": [bundle.name for bundle in summaries if bundle.name in eligible],
+        "choice": choice.to_dict() if choice is not None else None,
+        "picker_pending": choice is None,
+    }
+
+
+@router.get("")
+async def get_bundles() -> dict[str, Any]:
+    """Return the picker payload: tier list + eligibility + marker."""
+
+    return _bundle_payload()
+
+
+@router.get("/skip")
+async def skip_bundles() -> dict[str, Any]:
+    """Record the "Skip — configure manually" decision.
+
+    Idempotent — re-hitting the endpoint after the marker is dropped is
+    a no-op (the marker rewrites with a fresh timestamp but the
+    selection state is unchanged).
+    """
+
+    choice = bundle_store.mark_skipped()
+    return {"ok": True, "choice": choice.to_dict()}
+
+
+def _resolve_bundle_name(name: str) -> str:
+    """Map a URL-supplied bundle name (any case) to the canonical entry."""
+
+    if name in bundle_tiers.BUNDLES:
+        return name
+    lower = name.lower()
+    for canonical in bundle_tiers.BUNDLES:
+        if canonical.lower() == lower:
+            return canonical
+    raise NotFound(
+        f"unknown bundle {name!r}",
+        code="bundle.unknown",
+        details={"name": name, "valid": list(bundle_tiers.BUNDLES)},
+    )
+
+
+@router.post("/{name}")
+async def select_bundle(
+    name: str,
+    request: Request,
+    orchestrator: CapabilityOrchestratorDep,
+) -> dict[str, Any]:
+    """Apply a bundle tier.
+
+    Body: ``{"npu_opt_in": bool}`` — optional, only meaningful for
+    tiers whose manifest ships ``npu_trio_shown=True`` (Pro / Max).
+    For other tiers the flag is recorded verbatim but doesn't gate any
+    side effects.
+    """
+
+    canonical = _resolve_bundle_name(name)
+    manifest = bundle_tiers.load_bundle(canonical)
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    if body is None:
+        body = {}
+    if not isinstance(body, dict):
+        raise BadRequest(
+            "request body must be a JSON object",
+            code="request.not_an_object",
+        )
+
+    allowed_keys = {"npu_opt_in"}
+    extras = set(body.keys()) - allowed_keys
+    if extras:
+        raise BadRequest(
+            f"unexpected keys in body: {sorted(extras)}",
+            code="bundle.unknown_fields",
+            details={"allowed": sorted(allowed_keys), "unexpected": sorted(extras)},
+        )
+
+    npu_opt_in = bool(body.get("npu_opt_in", False))
+    if npu_opt_in and not manifest.bundle.npu_trio_shown:
+        # Explicit reject — clicking the NPU box on a tier that doesn't
+        # surface it would be hand-edited body, not a wizard mistake.
+        raise BadRequest(
+            f"bundle {canonical!r} does not expose the NPU trio",
+            code="bundle.npu_not_available",
+            details={"name": canonical},
+        )
+
+    # Forward each capability-mappable row through the orchestrator
+    # first so the marker reflects the actual applied state.
+    apply_results = await bundle_store.apply_bundle_to_capabilities(manifest, orchestrator)
+    assignments = tuple(apply_results)
+    choice = bundle_store.mark_bundle_chosen(
+        canonical, npu_opt_in=npu_opt_in, assignments=assignments
+    )
+
+    return {
+        "ok": True,
+        "choice": choice.to_dict(),
+        "manifest": manifest.bundle.to_dict(),
+        "applied": apply_results,
+    }
+
+
+__all__ = ["router"]

--- a/src/hal0/bundles/__init__.py
+++ b/src/hal0/bundles/__init__.py
@@ -1,0 +1,33 @@
+"""hal0 bundles — first-run picker manifests + tier eligibility.
+
+ADR-0010 (bundle picker, no default model stack) and Lemonade adoption
+plan §8 (First-run UX) define a small, fixed set of hardware-anchored
+tiers and one vendor-blessed kit. Each bundle is a
+``collection.omni``-compatible manifest plus hal0-specific slot
+metadata. The picker lives on the first dashboard load; this package
+is the backend half.
+
+Public surface:
+
+- :data:`BUNDLES` — the five locked bundle names.
+- :class:`Bundle`, :class:`BundleManifest` — typed shapes
+  (:mod:`hal0.bundles.schema`).
+- :func:`load_bundle`, :func:`load_all_bundles` — manifest loaders.
+- :func:`eligible_tiers` — hardware-anchored RAM filter.
+"""
+
+from __future__ import annotations
+
+from hal0.bundles.eligibility import eligible_tiers
+from hal0.bundles.schema import Bundle, BundleManifest, ModelEntry
+from hal0.bundles.tiers import BUNDLES, load_all_bundles, load_bundle
+
+__all__ = [
+    "BUNDLES",
+    "Bundle",
+    "BundleManifest",
+    "ModelEntry",
+    "eligible_tiers",
+    "load_all_bundles",
+    "load_bundle",
+]

--- a/src/hal0/bundles/eligibility.py
+++ b/src/hal0/bundles/eligibility.py
@@ -1,0 +1,101 @@
+"""Hardware-anchored tier eligibility.
+
+Reads ``/proc/meminfo`` once per process and returns the bundle names
+whose ``min_ram_gb`` floor fits the detected unified RAM. The picker
+greys out ineligible tiers but still surfaces them with a tooltip, so
+the operator sees the gap (rather than mysteriously missing options).
+
+The override knob ``HAL0_HOST_RAM_GB`` is a test seam and a documented
+escape hatch — operators on a too-small box who want to install a
+larger bundle anyway can run with the env var set. The picker UI
+respects whatever this function returns; no separate "force install"
+flag exists.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+
+from hal0.bundles.tiers import load_all_bundles
+
+_DEFAULT_MEMINFO = Path("/proc/meminfo")
+
+
+def _read_meminfo_gb(path: Path = _DEFAULT_MEMINFO) -> int:
+    """Parse MemTotal out of /proc/meminfo and return whole GB.
+
+    Returns ``0`` if the file can't be read; the picker treats that as
+    "no eligibility info" and surfaces every tier without greying. The
+    ``HAL0_HOST_RAM_GB`` override short-circuits the parse entirely.
+    """
+
+    override = os.environ.get("HAL0_HOST_RAM_GB", "").strip()
+    if override:
+        try:
+            return max(0, int(override))
+        except ValueError:
+            return 0
+
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return 0
+
+    for line in content.splitlines():
+        # MemTotal entries look like: "MemTotal:       16332620 kB"
+        if not line.startswith("MemTotal:"):
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            return 0
+        try:
+            kb = int(parts[1])
+        except ValueError:
+            return 0
+        # Floor-divide kilobytes to GiB. Strix Halo / NPU boxes always
+        # have round GiB totals so floor-vs-round doesn't change which
+        # tier is eligible in practice.
+        return max(0, kb // (1024 * 1024))
+    return 0
+
+
+@lru_cache(maxsize=1)
+def host_ram_gb() -> int:
+    """Detected unified RAM in whole GB. Process-lifetime cached."""
+
+    return _read_meminfo_gb()
+
+
+@lru_cache(maxsize=1)
+def eligible_tiers() -> list[str]:
+    """Return bundle names whose ``min_ram_gb`` <= host RAM.
+
+    The returned list preserves the canonical bundle order from
+    :data:`hal0.bundles.tiers.BUNDLES`. If the host RAM probe failed
+    (returns ``0``), every tier is treated as eligible — the picker
+    falls back to a no-greying mode rather than locking the operator
+    out entirely.
+    """
+
+    ram = host_ram_gb()
+    if ram <= 0:
+        return [manifest.bundle.name for manifest in load_all_bundles()]
+    return [
+        manifest.bundle.name for manifest in load_all_bundles() if manifest.bundle.min_ram_gb <= ram
+    ]
+
+
+def reset_cache() -> None:
+    """Drop the cached probe + eligibility lists. Test-only."""
+
+    host_ram_gb.cache_clear()
+    eligible_tiers.cache_clear()
+
+
+__all__ = [
+    "eligible_tiers",
+    "host_ram_gb",
+    "reset_cache",
+]

--- a/src/hal0/bundles/schema.py
+++ b/src/hal0/bundles/schema.py
@@ -1,0 +1,227 @@
+"""Typed dataclasses for bundle manifests.
+
+Bundle manifests on disk are JSON files that combine two concerns:
+
+1. A Lemonade-compatible ``collection.omni`` shape — a list of
+   pre-registered ``model_name`` entries that Lemonade can consume as a
+   single user-facing kit (see memory ``hal0_lemonade_omni_pattern``).
+2. hal0-specific tier metadata — minimum RAM, the slot assignment for
+   each model (which slot id receives which model), whether the FLM NPU
+   trio should be shown / opt-in, and human-readable display fields.
+
+Two dataclasses model this:
+
+  - :class:`Bundle` is the in-memory shape consumed by the API + picker.
+    It carries the hal0-specific fields (``name``, ``min_ram_gb``,
+    ``primary``, ``coder``, ``aux``, ``npu_trio_shown``,
+    ``npu_trio_optin``, ``display_*``) along with a reference to the
+    backing :class:`BundleManifest`.
+  - :class:`BundleManifest` is the full on-disk JSON shape. It nests a
+    ``collection.omni`` block under ``omni`` plus a ``hal0`` block with
+    the tier metadata.
+
+The split is deliberate: future v0.3 work may publish bundles through
+Lemonade's native collection endpoints without needing to re-derive the
+hal0 metadata. Until then, both halves of the JSON travel together.
+
+Serialisation is JSON via :func:`bundle_to_dict` / :func:`bundle_from_dict`.
+We don't pull in pydantic for this because the manifests are a small,
+static product surface and the surrounding code already standardises on
+plain dataclasses for typed shapes.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Fixed values from plan §8 / ADR-0010. Bumping these requires a v0.3 PR.
+SCHEMA_VERSION: int = 1
+
+
+@dataclass(frozen=True)
+class ModelEntry:
+    """One model assignment inside a bundle.
+
+    ``slot`` is the hal0 slot id (``chat.primary``, ``chat.coder``,
+    ``embed``, ``rerank``, ``stt``, ``tts``, ``img``, plus the FLM trio
+    slots ``agent`` / ``stt-npu`` / ``embed-npu`` when present).
+    ``model_name`` is the Lemonade registry id, matching what
+    ``server_models.json`` advertises after ``hal0 registry sync``.
+    ``size_gb`` is the on-disk pull size; informational only — the actual
+    download honours whatever Lemonade resolves at pull time.
+    ``lru`` marks a slot as eligible for LRU eviction (Pro/Max secondary
+    models). The default is False for primary/aux entries.
+    """
+
+    slot: str
+    model_name: str
+    size_gb: float
+    lru: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "slot": self.slot,
+            "model_name": self.model_name,
+            "size_gb": self.size_gb,
+            "lru": self.lru,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ModelEntry:
+        return cls(
+            slot=str(data["slot"]),
+            model_name=str(data["model_name"]),
+            size_gb=float(data["size_gb"]),
+            lru=bool(data.get("lru", False)),
+        )
+
+
+@dataclass(frozen=True)
+class Bundle:
+    """The hal0 bundle metadata block.
+
+    Maps 1:1 onto a row of the plan §8.2 table. Fields:
+
+    - ``name`` is the canonical bundle identifier (``hal0-Lite``,
+      ``hal0-Default``, ``hal0-Pro``, ``hal0-Max``, ``LMX-Omni-52B-Halo``).
+      Used as the URL slug (lowercased) and the registry path.
+    - ``min_ram_gb`` is the unified-RAM floor the picker filters on. A
+      tier with ``min_ram_gb > host_ram_gb`` is rendered greyed-out with
+      a tooltip explaining why.
+    - ``primary``, ``coder`` and ``aux`` describe the slot assignments;
+      ``coder`` is None for tiers that don't ship one.
+    - ``npu_trio_shown`` toggles the picker's visibility of the FLM trio
+      checkbox. ``npu_trio_optin`` is the default value of that
+      checkbox when shown — for v0.2 both Pro and Max are
+      ``shown=True / optin=False`` so the user must tick the box.
+    - ``display_label`` is the user-facing card title;
+      ``display_subtitle`` is the short tagline.
+    - ``vendor`` distinguishes the four hal0-curated tiers from the
+      LMX-Omni AMD-curated kit so the UI can group them under separate
+      headings (plan §8.1 ASCII mockup).
+    """
+
+    name: str
+    min_ram_gb: int
+    primary: ModelEntry | None
+    coder: ModelEntry | None
+    aux: tuple[ModelEntry, ...]
+    npu_trio_shown: bool
+    npu_trio_optin: bool
+    display_label: str
+    display_subtitle: str
+    vendor: str  # "hal0" or "amd"
+
+    @property
+    def slug(self) -> str:
+        """URL-safe lowercase identifier used by the REST surface."""
+
+        return self.name.lower()
+
+    @property
+    def total_size_gb(self) -> float:
+        """Sum of declared model sizes for the install-time download estimate."""
+
+        total = 0.0
+        if self.primary is not None:
+            total += self.primary.size_gb
+        if self.coder is not None:
+            total += self.coder.size_gb
+        for entry in self.aux:
+            total += entry.size_gb
+        return total
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "min_ram_gb": self.min_ram_gb,
+            "primary": self.primary.to_dict() if self.primary is not None else None,
+            "coder": self.coder.to_dict() if self.coder is not None else None,
+            "aux": [entry.to_dict() for entry in self.aux],
+            "npu_trio_shown": self.npu_trio_shown,
+            "npu_trio_optin": self.npu_trio_optin,
+            "display_label": self.display_label,
+            "display_subtitle": self.display_subtitle,
+            "vendor": self.vendor,
+            "total_size_gb": self.total_size_gb,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Bundle:
+        primary_raw = data.get("primary")
+        coder_raw = data.get("coder")
+        return cls(
+            name=str(data["name"]),
+            min_ram_gb=int(data["min_ram_gb"]),
+            primary=ModelEntry.from_dict(primary_raw) if primary_raw else None,
+            coder=ModelEntry.from_dict(coder_raw) if coder_raw else None,
+            aux=tuple(ModelEntry.from_dict(entry) for entry in data.get("aux", [])),
+            npu_trio_shown=bool(data.get("npu_trio_shown", False)),
+            npu_trio_optin=bool(data.get("npu_trio_optin", False)),
+            display_label=str(data.get("display_label", data["name"])),
+            display_subtitle=str(data.get("display_subtitle", "")),
+            vendor=str(data.get("vendor", "hal0")),
+        )
+
+
+@dataclass(frozen=True)
+class BundleManifest:
+    """The full on-disk bundle JSON shape.
+
+    The ``omni`` block mirrors the Lemonade ``collection.omni`` manifest
+    (kind + name + members[]), and the ``hal0`` block carries the
+    :class:`Bundle` metadata. ``schema_version`` lets future formats
+    add fields without breaking older installs.
+    """
+
+    schema_version: int
+    bundle: Bundle
+    omni: dict[str, Any]
+    # Free-form additional fields preserved on round-trip (e.g. release
+    # notes, deprecated-by markers in future revisions).
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "hal0": self.bundle.to_dict(),
+            "omni": self.omni,
+        }
+        if self.extra:
+            out["extra"] = dict(self.extra)
+        return out
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BundleManifest:
+        if "hal0" not in data:
+            raise ValueError("bundle manifest missing required 'hal0' block")
+        if "omni" not in data:
+            raise ValueError("bundle manifest missing required 'omni' block")
+        return cls(
+            schema_version=int(data.get("schema_version", SCHEMA_VERSION)),
+            bundle=Bundle.from_dict(data["hal0"]),
+            omni=dict(data["omni"]),
+            extra=dict(data.get("extra", {})),
+        )
+
+    @classmethod
+    def from_json(cls, raw: str) -> BundleManifest:
+        return cls.from_dict(json.loads(raw))
+
+    @classmethod
+    def from_path(cls, path: Path) -> BundleManifest:
+        return cls.from_json(path.read_text(encoding="utf-8"))
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "Bundle",
+    "BundleManifest",
+    "ModelEntry",
+]

--- a/src/hal0/bundles/store.py
+++ b/src/hal0/bundles/store.py
@@ -1,0 +1,230 @@
+"""Bundle selection persistence + applier.
+
+Once the operator clicks a tier in the first-run picker, two side
+effects happen:
+
+1. The :func:`mark_bundle_chosen` write drops a JSON marker at
+   ``/var/lib/hal0/.bundle-chosen`` so the picker doesn't re-appear on
+   next dashboard load.
+2. The :func:`apply_bundle_to_capabilities` call walks the bundle's
+   :class:`~hal0.bundles.schema.ModelEntry` list and forwards each
+   row that maps onto the existing :class:`CapabilityOrchestrator`
+   surface (``embed`` / ``rerank`` / ``stt`` / ``tts`` / ``img``). The
+   ``chat.primary`` / ``chat.coder`` rows are recorded in the marker
+   for PR-18 to pick up; the orchestrator has no chat surface in v0.2.
+
+The applier is best-effort: per-row failures are logged but don't
+abort the bundle pick. The marker is dropped regardless so the picker
+doesn't loop. This matches the plan §8 framing — "Selecting a bundle
+triggers model downloads in background (progress toast)" — the picker
+is the commit point; the actual provisioning surfaces via the regular
+slot lifecycle.
+
+The NPU trio (FLM coresident ``agent`` / ``stt-npu`` / ``embed-npu``)
+is recorded in the marker as ``npu_opt_in`` but not auto-enabled in
+v0.2 even when the operator ticks the box; ADR-0010 / ADR-0004 keep
+that gated behind the bundled-agent install flow.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hal0.bundles.schema import Bundle, BundleManifest, ModelEntry
+from hal0.config import paths
+
+log = logging.getLogger(__name__)
+
+
+# Map a bundle ModelEntry.slot to the capability orchestrator
+# (slot, child) tuple. Slots not in this map are recorded in the marker
+# but not pushed through orchestrator.apply.
+_SLOT_TO_CAPABILITY: dict[str, tuple[str, str]] = {
+    "embed": ("embed", "embed"),
+    "rerank": ("embed", "rerank"),
+    "stt": ("voice", "stt"),
+    "tts": ("voice", "tts"),
+    "img": ("img", "img"),
+}
+
+
+@dataclass(frozen=True)
+class BundleChoice:
+    """The persisted record of a picker decision."""
+
+    name: str
+    npu_opt_in: bool
+    chosen_at: str  # ISO-8601 UTC
+    skipped: bool = False
+    # The slot assignments recorded at pick time. Used by the dashboard
+    # to show "this slot is part of the hal0-Pro bundle" lineage even
+    # after the user customises individual rows.
+    assignments: tuple[dict[str, Any], ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "npu_opt_in": self.npu_opt_in,
+            "chosen_at": self.chosen_at,
+            "skipped": self.skipped,
+            "assignments": list(self.assignments),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BundleChoice:
+        return cls(
+            name=str(data.get("name", "")),
+            npu_opt_in=bool(data.get("npu_opt_in", False)),
+            chosen_at=str(data.get("chosen_at", "")),
+            skipped=bool(data.get("skipped", False)),
+            assignments=tuple(data.get("assignments", ())),
+        )
+
+
+def marker_path() -> Path:
+    """Return the bundle-chosen marker path (test-friendly indirection)."""
+
+    return paths.bundle_chosen_marker()
+
+
+def read_choice() -> BundleChoice | None:
+    """Return the persisted choice, or None if the marker is absent."""
+
+    path = marker_path()
+    if not path.exists():
+        return None
+    try:
+        return BundleChoice.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError, ValueError):
+        # Corrupted marker — treat as missing so the picker reappears
+        # rather than the operator getting stuck on a half-written file.
+        log.warning("bundles.marker_unreadable", extra={"path": str(path)})
+        return None
+
+
+def is_picker_pending() -> bool:
+    """Return True when the bundle picker should still be shown."""
+
+    return read_choice() is None
+
+
+def _utc_iso_now() -> str:
+    return _dt.datetime.now(_dt.UTC).isoformat(timespec="seconds")
+
+
+def _write_marker(choice: BundleChoice) -> None:
+    path = marker_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(choice.to_dict(), indent=2), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def mark_bundle_chosen(
+    name: str,
+    *,
+    npu_opt_in: bool = False,
+    assignments: tuple[dict[str, Any], ...] = (),
+) -> BundleChoice:
+    """Persist a bundle pick. Atomic on a POSIX filesystem."""
+
+    choice = BundleChoice(
+        name=name,
+        npu_opt_in=npu_opt_in,
+        chosen_at=_utc_iso_now(),
+        skipped=False,
+        assignments=assignments,
+    )
+    _write_marker(choice)
+    return choice
+
+
+def mark_skipped() -> BundleChoice:
+    """Persist the "Skip — configure manually" branch."""
+
+    choice = BundleChoice(
+        name="",
+        npu_opt_in=False,
+        chosen_at=_utc_iso_now(),
+        skipped=True,
+        assignments=(),
+    )
+    _write_marker(choice)
+    return choice
+
+
+async def apply_bundle_to_capabilities(
+    manifest: BundleManifest,
+    orchestrator: Any,
+) -> list[dict[str, Any]]:
+    """Forward each bundle ModelEntry to ``orchestrator.apply()`` where
+    a capability mapping exists.
+
+    Returns one record per entry with ``slot``, ``model_name``,
+    ``applied`` (bool) and either ``selection`` (the orchestrator's
+    echo) or ``error`` (the string message). Failures don't abort the
+    walk — best-effort per ADR-0010's "progress toast" framing.
+    """
+
+    bundle: Bundle = manifest.bundle
+    entries: list[ModelEntry] = []
+    if bundle.primary is not None:
+        entries.append(bundle.primary)
+    if bundle.coder is not None:
+        entries.append(bundle.coder)
+    entries.extend(bundle.aux)
+
+    results: list[dict[str, Any]] = []
+    for entry in entries:
+        record: dict[str, Any] = {
+            "slot": entry.slot,
+            "model_name": entry.model_name,
+            "applied": False,
+        }
+        cap = _SLOT_TO_CAPABILITY.get(entry.slot)
+        if cap is None:
+            # chat.primary / chat.coder land here today; PR-18 owns the
+            # chat surface wiring.
+            record["reason"] = "no_capability_mapping"
+            results.append(record)
+            continue
+        slot, child = cap
+        try:
+            selection = await orchestrator.apply(
+                slot,
+                child,
+                {"model": entry.model_name, "enabled": True},
+            )
+        except Exception as exc:
+            record["error"] = str(exc)
+            log.warning(
+                "bundles.apply_row_failed",
+                extra={
+                    "slot": entry.slot,
+                    "model": entry.model_name,
+                    "error": str(exc),
+                },
+            )
+            results.append(record)
+            continue
+        record["applied"] = True
+        record["selection"] = selection
+        results.append(record)
+    return results
+
+
+__all__ = [
+    "BundleChoice",
+    "apply_bundle_to_capabilities",
+    "is_picker_pending",
+    "mark_bundle_chosen",
+    "mark_skipped",
+    "marker_path",
+    "read_choice",
+]

--- a/src/hal0/bundles/tiers.py
+++ b/src/hal0/bundles/tiers.py
@@ -1,0 +1,138 @@
+"""Bundle tier registry — locked list + loader.
+
+The five bundle names are fixed by ADR-0010 (no additional tiers in
+v0.2). Manifests ship under ``installer/manifests/omni/`` and are
+copied by ``install.sh`` to ``/var/lib/hal0/models/collections/omni/``
+at install time; the loader picks them up from the runtime location
+first and falls back to the in-tree source for dev installs (mirrors
+:func:`hal0.config.paths.manifest_json`).
+"""
+
+from __future__ import annotations
+
+import os
+from functools import cache
+from pathlib import Path
+
+from hal0.bundles.schema import Bundle, BundleManifest
+from hal0.config import paths
+
+# Locked bundle list — order matters: this is the picker rendering
+# order (Lite → Default → Pro → Max → LMX kit).
+BUNDLES: tuple[str, ...] = (
+    "hal0-Lite",
+    "hal0-Default",
+    "hal0-Pro",
+    "hal0-Max",
+    "LMX-Omni-52B-Halo",
+)
+
+
+def _runtime_root() -> Path:
+    """Return the production runtime directory for bundle manifests."""
+
+    return paths.var_lib() / "models" / "collections" / "omni"
+
+
+def _intree_root() -> Path:
+    """Return the in-tree manifest directory used as a dev fallback."""
+
+    # tiers.py → src/hal0/bundles/tiers.py → repo root is parents[3].
+    return Path(__file__).resolve().parents[3] / "installer" / "manifests" / "omni"
+
+
+def _candidate_roots() -> tuple[Path, ...]:
+    """Resolution order for bundle manifest lookups.
+
+    ``HAL0_BUNDLES_DIR`` is a test hook — pointing it at a temp dir lets
+    tests load fixture manifests without touching disk. The production
+    runtime dir takes precedence over the in-tree fallback so a freshly
+    pulled hal0 install never accidentally serves stale dev manifests.
+    """
+
+    override = os.environ.get("HAL0_BUNDLES_DIR", "").strip()
+    if override:
+        return (Path(override),)
+    return (_runtime_root(), _intree_root())
+
+
+def _manifest_filename(name: str) -> str:
+    """Resolve a bundle name to its on-disk filename.
+
+    The hal0 tiers use lowercase slugs; the LMX kit keeps its mixed-case
+    name verbatim because it's vendor-branded.
+    """
+
+    if name == "LMX-Omni-52B-Halo":
+        return "LMX-Omni-52B-Halo.json"
+    return f"{name.lower()}.json"
+
+
+def _locate(name: str) -> Path:
+    """Find the manifest path for ``name`` across the candidate roots."""
+
+    filename = _manifest_filename(name)
+    for root in _candidate_roots():
+        candidate = root / filename
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(
+        f"bundle manifest not found for {name!r} "
+        f"(searched: {[str(root) for root in _candidate_roots()]})"
+    )
+
+
+@cache
+def _load_cached(name: str) -> BundleManifest:
+    """Cached manifest load. Keyed on the bundle name only — bumping the
+    on-disk file requires a process restart, which matches install.sh's
+    write-once semantics.
+    """
+
+    return BundleManifest.from_path(_locate(name))
+
+
+def load_bundle(name: str) -> BundleManifest:
+    """Return the manifest for ``name``. Raises FileNotFoundError if
+    the file is missing on every candidate root.
+    """
+
+    if name not in BUNDLES:
+        raise ValueError(f"unknown bundle {name!r}; expected one of {list(BUNDLES)}")
+    return _load_cached(name)
+
+
+def load_all_bundles() -> list[BundleManifest]:
+    """Load every bundle in :data:`BUNDLES` order.
+
+    Tests that need to assert against the full set walk the result; the
+    HTTP layer uses it to render the picker payload.
+    """
+
+    return [load_bundle(name) for name in BUNDLES]
+
+
+def list_bundle_summaries() -> list[Bundle]:
+    """Project the manifests onto the lightweight :class:`Bundle` shape.
+
+    Used by ``GET /api/bundles`` — the picker doesn't need the
+    ``collection.omni`` payload, just the tier metadata.
+    """
+
+    return [manifest.bundle for manifest in load_all_bundles()]
+
+
+def reset_cache() -> None:
+    """Clear the cached manifest loads. Used by tests + the API on a
+    manual reload."""
+
+    _load_cached.cache_clear()
+
+
+__all__ = [
+    "BUNDLES",
+    "list_bundle_summaries",
+    "load_all_bundles",
+    "load_bundle",
+    "reset_cache",
+]

--- a/src/hal0/config/paths.py
+++ b/src/hal0/config/paths.py
@@ -147,6 +147,24 @@ def first_run_lock() -> Path:
     return var_lib() / ".first-run.lock"
 
 
+def bundle_chosen_marker() -> Path:
+    """Return the bundle-picker completion marker path.
+
+    Dropped by ``POST /api/bundles/{name}`` (or
+    ``GET /api/bundles/skip``) once the operator has engaged the first-
+    run bundle picker (ADR-0010). The dashboard reads this to decide
+    whether to render the picker or the regular dashboard on load.
+
+    Location: ``$HAL0_HOME/var-lib/hal0/.bundle-chosen`` (or
+    ``/var/lib/hal0/.bundle-chosen`` in production). Lives alongside
+    ``.first_run_done`` so a single ``rm -rf /var/lib/hal0`` resets
+    both. Contains a JSON blob with the picked tier name + npu opt-in
+    flag + ISO timestamp; treat as advisory not authoritative — the
+    canonical record of selections is ``capabilities.toml``.
+    """
+    return var_lib() / ".bundle-chosen"
+
+
 def manifest_json() -> Path:
     """Return the release manifest path.
 

--- a/tests/api/test_bundles_route.py
+++ b/tests/api/test_bundles_route.py
@@ -1,0 +1,254 @@
+"""Tests for /api/bundles — first-run bundle picker REST surface (PR-17).
+
+Covers:
+
+  - GET /api/bundles — payload shape + tier list + eligibility filter +
+    picker_pending state transitions across mark/skip writes.
+  - GET /api/bundles/skip — marker write + idempotency.
+  - POST /api/bundles/{name} — orchestrator side effects + npu_opt_in
+    handling + body validation (unknown keys, NPU-not-shown rejection,
+    case-insensitive name resolution).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.bundles import eligibility as bundle_eligibility
+from hal0.bundles import store as bundle_store
+from hal0.bundles import tiers as bundle_tiers
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    """Clear the module-level caches between tests so monkeypatched envs
+    propagate."""
+
+    bundle_eligibility.reset_cache()
+    bundle_tiers.reset_cache()
+    yield
+    bundle_eligibility.reset_cache()
+    bundle_tiers.reset_cache()
+
+
+@pytest.fixture
+def isolated_app(tmp_hal0_home: str) -> FastAPI:
+    return create_app()
+
+
+@pytest.fixture
+def isolated_client(isolated_app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(isolated_app) as c:
+        yield c
+
+
+@pytest.fixture
+def force_ram(monkeypatch: pytest.MonkeyPatch):
+    """Helper to pin host RAM via the documented override."""
+
+    def _set(gb: int):
+        monkeypatch.setenv("HAL0_HOST_RAM_GB", str(gb))
+        bundle_eligibility.reset_cache()
+
+    return _set
+
+
+# ── GET /api/bundles ──────────────────────────────────────────────────
+
+
+def test_get_bundles_returns_all_five_tiers(isolated_client: TestClient, force_ram):
+    force_ram(128)
+    r = isolated_client.get("/api/bundles")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert {t["name"] for t in body["tiers"]} == set(bundle_tiers.BUNDLES)
+    assert len(body["tiers"]) == 5
+
+
+def test_get_bundles_filters_eligibility_by_ram(isolated_client: TestClient, force_ram):
+    force_ram(32)
+    body = isolated_client.get("/api/bundles").json()
+    assert body["eligible"] == ["hal0-Lite", "hal0-Default"]
+    assert body["host_ram_gb"] == 32
+
+
+def test_get_bundles_marks_picker_pending_when_marker_absent(
+    isolated_client: TestClient, force_ram
+):
+    force_ram(64)
+    body = isolated_client.get("/api/bundles").json()
+    assert body["picker_pending"] is True
+    assert body["choice"] is None
+
+
+def test_get_bundles_reflects_marker_after_pick(isolated_client: TestClient, force_ram):
+    force_ram(64)
+    # Pre-pick via the helper so we don't depend on POST behaviour.
+    bundle_store.mark_bundle_chosen("hal0-Pro", npu_opt_in=True)
+    body = isolated_client.get("/api/bundles").json()
+    assert body["picker_pending"] is False
+    assert body["choice"]["name"] == "hal0-Pro"
+    assert body["choice"]["npu_opt_in"] is True
+
+
+def test_get_bundles_tier_rows_carry_total_size(isolated_client: TestClient, force_ram):
+    force_ram(128)
+    body = isolated_client.get("/api/bundles").json()
+    pro = next(t for t in body["tiers"] if t["name"] == "hal0-Pro")
+    # Pro total = 18.8 + 18.6 + (aux sums)
+    assert pro["total_size_gb"] > 18.8 + 18.6
+
+
+# ── GET /api/bundles/skip ─────────────────────────────────────────────
+
+
+def test_skip_records_marker(isolated_client: TestClient, force_ram):
+    force_ram(16)
+    r = isolated_client.get("/api/bundles/skip")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["choice"]["skipped"] is True
+    # And the picker is no longer pending.
+    follow = isolated_client.get("/api/bundles").json()
+    assert follow["picker_pending"] is False
+
+
+def test_skip_is_idempotent(isolated_client: TestClient, force_ram):
+    force_ram(16)
+    isolated_client.get("/api/bundles/skip")
+    r = isolated_client.get("/api/bundles/skip")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["choice"]["skipped"] is True
+
+
+# ── POST /api/bundles/{name} ──────────────────────────────────────────
+
+
+def test_select_unknown_bundle_returns_404(isolated_client: TestClient, force_ram):
+    force_ram(128)
+    r = isolated_client.post("/api/bundles/hal0-Gigantic", json={})
+    assert r.status_code == 404
+    body = r.json()
+    assert body["error"]["code"] == "bundle.unknown"
+
+
+def test_select_bundle_case_insensitive_name(isolated_client: TestClient, force_ram):
+    force_ram(128)
+    r = isolated_client.post("/api/bundles/hal0-lite", json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # Marker carries the canonical (mixed-case) name.
+    assert body["choice"]["name"] == "hal0-Lite"
+
+
+def test_select_bundle_writes_marker(isolated_client: TestClient, force_ram):
+    force_ram(32)
+    isolated_client.post("/api/bundles/hal0-Default", json={})
+    body = isolated_client.get("/api/bundles").json()
+    assert body["choice"]["name"] == "hal0-Default"
+    assert body["picker_pending"] is False
+
+
+def test_select_bundle_records_assignments(isolated_client: TestClient, force_ram):
+    force_ram(32)
+    r = isolated_client.post("/api/bundles/hal0-Default", json={})
+    body = r.json()
+    # Default ships chat.primary (no-mapping) + embed/stt/tts (mapped).
+    applied = body["applied"]
+    slots = {row["slot"] for row in applied}
+    assert "chat.primary" in slots
+    assert "embed" in slots
+    assert "stt" in slots
+    assert "tts" in slots
+
+
+def test_select_bundle_rejects_unknown_keys(isolated_client: TestClient, force_ram):
+    force_ram(128)
+    r = isolated_client.post(
+        "/api/bundles/hal0-Pro",
+        json={"npu_opt_in": True, "extra": "no"},
+    )
+    assert r.status_code == 400
+    body = r.json()
+    assert body["error"]["code"] == "bundle.unknown_fields"
+
+
+def test_select_bundle_rejects_npu_optin_on_tier_without_trio(
+    isolated_client: TestClient, force_ram
+):
+    force_ram(64)
+    r = isolated_client.post("/api/bundles/hal0-Default", json={"npu_opt_in": True})
+    assert r.status_code == 400
+    body = r.json()
+    assert body["error"]["code"] == "bundle.npu_not_available"
+
+
+def test_select_pro_with_npu_optin_records_flag(isolated_client: TestClient, force_ram):
+    force_ram(128)
+    r = isolated_client.post("/api/bundles/hal0-Pro", json={"npu_opt_in": True})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["choice"]["npu_opt_in"] is True
+
+
+def test_select_bundle_empty_body_is_accepted(isolated_client: TestClient, force_ram):
+    """An empty body is the common path — picker fires POST with no body
+    for tiers that don't expose NPU opt-in."""
+
+    force_ram(128)
+    r = isolated_client.post("/api/bundles/hal0-Lite")
+    assert r.status_code == 200, r.text
+
+
+def test_select_bundle_calls_capability_orchestrator(
+    isolated_client: TestClient, force_ram, monkeypatch
+):
+    """Wire-level check — the route hands the manifest to the orchestrator
+    and we see embed/voice/img apply calls land."""
+
+    force_ram(32)
+    calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def _fake_apply(slot, child, body):
+        calls.append((slot, child, body))
+        return {
+            "model": body.get("model"),
+            "enabled": body.get("enabled"),
+            "slot": f"{slot}-{child}",
+            "status": "loading",
+        }
+
+    monkeypatch.setattr(
+        isolated_client.app.state.capability_orchestrator,
+        "apply",
+        _fake_apply,
+    )
+
+    r = isolated_client.post("/api/bundles/hal0-Default", json={})
+    assert r.status_code == 200, r.text
+    keys = {(slot, child) for (slot, child, _) in calls}
+    # Default seeds embed + stt + tts (chat.primary has no mapping).
+    assert ("embed", "embed") in keys
+    assert ("voice", "stt") in keys
+    assert ("voice", "tts") in keys
+
+
+def test_marker_persists_choice_after_post(isolated_client: TestClient, force_ram):
+    """The marker is a real on-disk file; a fresh process under the same
+    HAL0_HOME would see the picker as resolved. We assert by direct
+    store read (the second client recycles tmp_hal0_home implicitly)."""
+
+    force_ram(16)
+    isolated_client.post("/api/bundles/hal0-Lite")
+    choice = bundle_store.read_choice()
+    assert choice is not None
+    assert choice.name == "hal0-Lite"
+    assert choice.skipped is False

--- a/tests/bundles/test_eligibility.py
+++ b/tests/bundles/test_eligibility.py
@@ -1,0 +1,128 @@
+"""Tests for hal0.bundles.eligibility — RAM probe + tier filtering."""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.bundles import eligibility
+from hal0.bundles import tiers as bundle_tiers
+
+
+def setup_function(_):
+    eligibility.reset_cache()
+    bundle_tiers.reset_cache()
+
+
+def _write_meminfo(tmp_path, kb: int):
+    """Write a minimal /proc/meminfo-shaped fixture file."""
+
+    path = tmp_path / "meminfo"
+    path.write_text(f"MemTotal:       {kb} kB\nMemFree:        100 kB\n", encoding="utf-8")
+    return path
+
+
+def test_read_meminfo_parses_memtotal(tmp_path):
+    path = _write_meminfo(tmp_path, 16332620)
+    # ~16 GiB
+    assert eligibility._read_meminfo_gb(path) == 15
+
+
+def test_read_meminfo_handles_missing_file(tmp_path):
+    missing = tmp_path / "nope"
+    assert eligibility._read_meminfo_gb(missing) == 0
+
+
+def test_read_meminfo_handles_empty_file(tmp_path):
+    path = tmp_path / "meminfo"
+    path.write_text("", encoding="utf-8")
+    assert eligibility._read_meminfo_gb(path) == 0
+
+
+def test_read_meminfo_handles_garbage(tmp_path):
+    path = tmp_path / "meminfo"
+    path.write_text("MemTotal: notanumber kB\n", encoding="utf-8")
+    assert eligibility._read_meminfo_gb(path) == 0
+
+
+def test_override_env_var_wins(monkeypatch):
+    monkeypatch.setenv("HAL0_HOST_RAM_GB", "128")
+    assert eligibility._read_meminfo_gb() == 128
+
+
+def test_override_env_var_rejects_garbage(monkeypatch):
+    monkeypatch.setenv("HAL0_HOST_RAM_GB", "lots")
+    assert eligibility._read_meminfo_gb() == 0
+
+
+def test_host_ram_gb_caches_probe(monkeypatch):
+    monkeypatch.setenv("HAL0_HOST_RAM_GB", "32")
+    assert eligibility.host_ram_gb() == 32
+    monkeypatch.setenv("HAL0_HOST_RAM_GB", "64")
+    # Without resetting the cache, the second probe is the cached 32.
+    assert eligibility.host_ram_gb() == 32
+    eligibility.reset_cache()
+    assert eligibility.host_ram_gb() == 64
+
+
+def test_eligible_tiers_at_16gb_yields_only_lite(monkeypatch):
+    monkeypatch.setenv("HAL0_HOST_RAM_GB", "16")
+    assert eligibility.eligible_tiers() == ["hal0-Lite"]
+
+
+def test_eligible_tiers_at_32gb_yields_lite_and_default(monkeypatch):
+    monkeypatch.setenv("HAL0_HOST_RAM_GB", "32")
+    assert eligibility.eligible_tiers() == ["hal0-Lite", "hal0-Default"]
+
+
+def test_eligible_tiers_at_64gb_yields_up_to_pro(monkeypatch):
+    monkeypatch.setenv("HAL0_HOST_RAM_GB", "64")
+    assert eligibility.eligible_tiers() == [
+        "hal0-Lite",
+        "hal0-Default",
+        "hal0-Pro",
+    ]
+
+
+def test_eligible_tiers_at_128gb_yields_all_five(monkeypatch):
+    monkeypatch.setenv("HAL0_HOST_RAM_GB", "128")
+    assert eligibility.eligible_tiers() == [
+        "hal0-Lite",
+        "hal0-Default",
+        "hal0-Pro",
+        "hal0-Max",
+        "LMX-Omni-52B-Halo",
+    ]
+
+
+def test_eligible_tiers_unknown_ram_returns_all_tiers(monkeypatch):
+    """When the probe fails (returns 0), the picker shouldn't lock the
+    operator out — every tier surfaces."""
+
+    monkeypatch.setenv("HAL0_HOST_RAM_GB", "0")
+    assert eligibility.eligible_tiers() == list(bundle_tiers.BUNDLES)
+
+
+def test_eligible_tiers_at_8gb_yields_empty_list(monkeypatch):
+    """A box below the Lite floor gets no tiers — the picker still shows
+    them all (UI greys), but the eligibility list is empty."""
+
+    monkeypatch.setenv("HAL0_HOST_RAM_GB", "8")
+    assert eligibility.eligible_tiers() == []
+
+
+@pytest.mark.parametrize(
+    "ram_gb,expected_count",
+    [
+        (15, 0),
+        (16, 1),
+        (31, 1),
+        (32, 2),
+        (63, 2),
+        (64, 3),
+        (99, 3),
+        (100, 5),
+    ],
+)
+def test_eligibility_boundaries(monkeypatch, ram_gb, expected_count):
+    monkeypatch.setenv("HAL0_HOST_RAM_GB", str(ram_gb))
+    assert len(eligibility.eligible_tiers()) == expected_count

--- a/tests/bundles/test_schema.py
+++ b/tests/bundles/test_schema.py
@@ -1,0 +1,157 @@
+"""Tests for hal0.bundles.schema — dataclass round-trip + serializer."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hal0.bundles.schema import (
+    SCHEMA_VERSION,
+    Bundle,
+    BundleManifest,
+    ModelEntry,
+)
+
+
+def _sample_bundle() -> Bundle:
+    return Bundle(
+        name="hal0-Pro",
+        min_ram_gb=64,
+        primary=ModelEntry(
+            slot="chat.primary",
+            model_name="Qwen3.6-27B-MTP",
+            size_gb=18.8,
+        ),
+        coder=ModelEntry(
+            slot="chat.coder",
+            model_name="Qwen3-Coder-30B-A3B",
+            size_gb=18.6,
+            lru=True,
+        ),
+        aux=(
+            ModelEntry(slot="embed", model_name="nomic-v1.5", size_gb=0.3),
+            ModelEntry(slot="rerank", model_name="bge-reranker-v2-m3", size_gb=0.45),
+        ),
+        npu_trio_shown=True,
+        npu_trio_optin=False,
+        display_label="hal0-Pro",
+        display_subtitle="64 GB+",
+        vendor="hal0",
+    )
+
+
+def _sample_manifest() -> BundleManifest:
+    return BundleManifest(
+        schema_version=SCHEMA_VERSION,
+        bundle=_sample_bundle(),
+        omni={
+            "kind": "collection.omni",
+            "name": "hal0-Pro",
+            "members": [{"model_name": "Qwen3.6-27B-MTP"}],
+        },
+        extra={},
+    )
+
+
+def test_model_entry_round_trip():
+    entry = ModelEntry(slot="embed", model_name="nomic-v1.5", size_gb=0.3, lru=False)
+    restored = ModelEntry.from_dict(entry.to_dict())
+    assert restored == entry
+
+
+def test_model_entry_lru_defaults_false():
+    entry = ModelEntry.from_dict({"slot": "embed", "model_name": "x", "size_gb": 1.0})
+    assert entry.lru is False
+
+
+def test_bundle_round_trip():
+    bundle = _sample_bundle()
+    restored = Bundle.from_dict(bundle.to_dict())
+    assert restored == bundle
+
+
+def test_bundle_total_size_sums_all_entries():
+    bundle = _sample_bundle()
+    expected = 18.8 + 18.6 + 0.3 + 0.45
+    assert bundle.total_size_gb == pytest.approx(expected)
+
+
+def test_bundle_total_size_handles_missing_primary_and_coder():
+    bundle = Bundle(
+        name="empty",
+        min_ram_gb=8,
+        primary=None,
+        coder=None,
+        aux=(),
+        npu_trio_shown=False,
+        npu_trio_optin=False,
+        display_label="empty",
+        display_subtitle="",
+        vendor="hal0",
+    )
+    assert bundle.total_size_gb == 0.0
+
+
+def test_bundle_slug_is_lowercase():
+    bundle = _sample_bundle()
+    assert bundle.slug == "hal0-pro"
+
+
+def test_bundle_to_dict_includes_total_size_for_consumer():
+    bundle = _sample_bundle()
+    data = bundle.to_dict()
+    assert "total_size_gb" in data
+    assert data["total_size_gb"] == pytest.approx(bundle.total_size_gb)
+
+
+def test_manifest_round_trip_via_json():
+    manifest = _sample_manifest()
+    restored = BundleManifest.from_json(manifest.to_json())
+    assert restored == manifest
+
+
+def test_manifest_to_dict_exposes_hal0_and_omni_blocks():
+    manifest = _sample_manifest()
+    data = manifest.to_dict()
+    assert data["schema_version"] == SCHEMA_VERSION
+    assert data["hal0"]["name"] == "hal0-Pro"
+    assert data["omni"]["kind"] == "collection.omni"
+
+
+def test_manifest_from_dict_rejects_missing_hal0_block():
+    with pytest.raises(ValueError):
+        BundleManifest.from_dict({"omni": {}})
+
+
+def test_manifest_from_dict_rejects_missing_omni_block():
+    with pytest.raises(ValueError):
+        BundleManifest.from_dict({"hal0": _sample_bundle().to_dict()})
+
+
+def test_manifest_preserves_extra_block():
+    manifest = BundleManifest(
+        schema_version=SCHEMA_VERSION,
+        bundle=_sample_bundle(),
+        omni={"kind": "collection.omni", "name": "x", "members": []},
+        extra={"deprecated_by": "hal0-Pro-v2"},
+    )
+    restored = BundleManifest.from_json(manifest.to_json())
+    assert restored.extra == {"deprecated_by": "hal0-Pro-v2"}
+
+
+def test_manifest_from_path(tmp_path):
+    manifest = _sample_manifest()
+    path = tmp_path / "hal0-Pro.json"
+    path.write_text(manifest.to_json(), encoding="utf-8")
+    restored = BundleManifest.from_path(path)
+    assert restored == manifest
+
+
+def test_manifest_json_is_pretty_by_default():
+    manifest = _sample_manifest()
+    rendered = manifest.to_json()
+    # Pretty-printed output has newlines; flatten compact output doesn't.
+    assert "\n" in rendered
+    # And it parses back cleanly.
+    json.loads(rendered)

--- a/tests/bundles/test_store.py
+++ b/tests/bundles/test_store.py
@@ -1,0 +1,148 @@
+"""Tests for hal0.bundles.store — marker persistence + capability applier."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from hal0.bundles import store as bundle_store
+from hal0.bundles.schema import Bundle, BundleManifest, ModelEntry
+
+
+@pytest.fixture
+def hal0_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    return tmp_path
+
+
+def test_marker_absent_initially(hal0_home):
+    assert bundle_store.read_choice() is None
+    assert bundle_store.is_picker_pending() is True
+
+
+def test_mark_bundle_chosen_writes_marker(hal0_home):
+    choice = bundle_store.mark_bundle_chosen("hal0-Pro", npu_opt_in=True)
+    assert choice.name == "hal0-Pro"
+    assert choice.npu_opt_in is True
+    assert choice.skipped is False
+    # File-backed; re-read returns the same shape.
+    restored = bundle_store.read_choice()
+    assert restored is not None
+    assert restored.name == "hal0-Pro"
+    assert bundle_store.is_picker_pending() is False
+
+
+def test_mark_skipped_writes_marker_with_skip_flag(hal0_home):
+    choice = bundle_store.mark_skipped()
+    assert choice.skipped is True
+    assert choice.name == ""
+    assert bundle_store.read_choice() is not None
+    assert bundle_store.is_picker_pending() is False
+
+
+def test_corrupt_marker_treated_as_missing(hal0_home):
+    marker = bundle_store.marker_path()
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("not json", encoding="utf-8")
+    assert bundle_store.read_choice() is None
+
+
+def test_marker_round_trip_preserves_assignments(hal0_home):
+    assignments = (
+        {"slot": "embed", "model_name": "nomic-v1.5", "applied": True},
+        {"slot": "stt", "model_name": "whisper-tiny", "applied": True},
+    )
+    bundle_store.mark_bundle_chosen("hal0-Default", npu_opt_in=False, assignments=assignments)
+    restored = bundle_store.read_choice()
+    assert restored is not None
+    assert restored.assignments == assignments
+
+
+def _fake_manifest() -> BundleManifest:
+    bundle = Bundle(
+        name="hal0-Default",
+        min_ram_gb=32,
+        primary=ModelEntry(slot="chat.primary", model_name="qwen3.5-9b", size_gb=6.9),
+        coder=None,
+        aux=(
+            ModelEntry(slot="embed", model_name="nomic-v1.5", size_gb=0.3),
+            ModelEntry(slot="stt", model_name="whisper-tiny", size_gb=0.075),
+        ),
+        npu_trio_shown=False,
+        npu_trio_optin=False,
+        display_label="hal0-Default",
+        display_subtitle="",
+        vendor="hal0",
+    )
+    return BundleManifest(
+        schema_version=1,
+        bundle=bundle,
+        omni={"kind": "collection.omni", "name": "hal0-Default", "members": []},
+    )
+
+
+class _FakeOrchestrator:
+    """Records every orchestrator.apply call + lets a test trigger failures."""
+
+    def __init__(self, *, fail_on: set[tuple[str, str]] | None = None):
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self._fail_on = fail_on or set()
+
+    async def apply(self, slot, child, body):
+        self.calls.append((slot, child, body))
+        if (slot, child) in self._fail_on:
+            raise RuntimeError(f"forced failure on {slot}/{child}")
+        return {
+            "model": body.get("model"),
+            "enabled": body.get("enabled", False),
+            "slot": f"{slot}-{child}",
+            "status": "loading",
+        }
+
+
+@pytest.mark.asyncio
+async def test_apply_bundle_routes_aux_models_through_orchestrator():
+    manifest = _fake_manifest()
+    orch = _FakeOrchestrator()
+    results = await bundle_store.apply_bundle_to_capabilities(manifest, orch)
+
+    # 1 primary + 0 coder + 2 aux = 3 rows total.
+    assert len(results) == 3
+    # The primary lands in the no-mapping bucket (chat surface).
+    primary_row = next(r for r in results if r["slot"] == "chat.primary")
+    assert primary_row["applied"] is False
+    assert primary_row.get("reason") == "no_capability_mapping"
+    # The two aux rows were applied.
+    applied_slots = {r["slot"] for r in results if r["applied"]}
+    assert applied_slots == {"embed", "stt"}
+    # The orchestrator was called with the right tuples + model body.
+    apply_keys = {(slot, child) for (slot, child, _body) in orch.calls}
+    assert apply_keys == {("embed", "embed"), ("voice", "stt")}
+
+
+@pytest.mark.asyncio
+async def test_apply_bundle_records_per_row_failure_without_aborting():
+    manifest = _fake_manifest()
+    orch = _FakeOrchestrator(fail_on={("voice", "stt")})
+    results = await bundle_store.apply_bundle_to_capabilities(manifest, orch)
+    stt_row = next(r for r in results if r["slot"] == "stt")
+    assert stt_row["applied"] is False
+    assert "forced failure" in stt_row.get("error", "")
+    # The embed row still went through.
+    embed_row = next(r for r in results if r["slot"] == "embed")
+    assert embed_row["applied"] is True
+
+
+def test_marker_path_respects_hal0_home(hal0_home):
+    expected = hal0_home / "var-lib" / "hal0" / ".bundle-chosen"
+    assert bundle_store.marker_path() == expected
+
+
+def test_choice_to_dict_is_json_serializable(hal0_home):
+    choice = bundle_store.mark_bundle_chosen("hal0-Lite", npu_opt_in=False)
+    raw = json.dumps(choice.to_dict())
+    # Round-trip.
+    restored = bundle_store.BundleChoice.from_dict(json.loads(raw))
+    assert restored.name == "hal0-Lite"

--- a/tests/bundles/test_tiers.py
+++ b/tests/bundles/test_tiers.py
@@ -1,0 +1,139 @@
+"""Tests for hal0.bundles.tiers — locked bundle list + plan §8.2 contents.
+
+The picker is shape-driven by these manifests; drift between the plan
+table and the on-disk JSON would surface as confused operators (clicking
+a tier and getting a different stack). These tests assert the exact
+values from plan §8.2 / ADR-0010 so a future edit to one without the
+other fails fast.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.bundles import tiers as bundle_tiers
+
+
+def setup_function(_):
+    bundle_tiers.reset_cache()
+
+
+def test_bundles_locked_list_order():
+    assert bundle_tiers.BUNDLES == (
+        "hal0-Lite",
+        "hal0-Default",
+        "hal0-Pro",
+        "hal0-Max",
+        "LMX-Omni-52B-Halo",
+    )
+
+
+def test_load_all_bundles_returns_five_manifests():
+    manifests = bundle_tiers.load_all_bundles()
+    assert [m.bundle.name for m in manifests] == list(bundle_tiers.BUNDLES)
+
+
+def test_load_bundle_rejects_unknown_name():
+    with pytest.raises(ValueError):
+        bundle_tiers.load_bundle("hal0-Gigantic")
+
+
+def test_hal0_lite_matches_plan_table():
+    m = bundle_tiers.load_bundle("hal0-Lite").bundle
+    assert m.min_ram_gb == 16
+    assert m.primary is not None
+    assert m.primary.model_name == "qwen3.5-0.8b"
+    assert m.primary.size_gb == pytest.approx(1.0)
+    assert m.coder is None
+    assert m.aux == ()
+    assert m.npu_trio_shown is False
+    assert m.vendor == "hal0"
+
+
+def test_hal0_default_matches_plan_table():
+    m = bundle_tiers.load_bundle("hal0-Default").bundle
+    assert m.min_ram_gb == 32
+    assert m.primary is not None and m.primary.model_name == "qwen3.5-9b"
+    assert m.primary.size_gb == pytest.approx(6.9)
+    assert m.coder is None
+    aux_models = {entry.model_name for entry in m.aux}
+    assert aux_models == {"nomic-v1.5", "whisper-tiny", "kokoro:cpu"}
+    assert m.npu_trio_shown is False
+
+
+def test_hal0_pro_matches_plan_table():
+    m = bundle_tiers.load_bundle("hal0-Pro").bundle
+    assert m.min_ram_gb == 64
+    assert m.primary is not None and m.primary.model_name == "Qwen3.6-27B-MTP"
+    assert m.primary.size_gb == pytest.approx(18.8)
+    assert m.coder is not None and m.coder.model_name == "Qwen3-Coder-30B-A3B"
+    assert m.coder.size_gb == pytest.approx(18.6)
+    assert m.coder.lru is True
+    aux_models = {entry.model_name for entry in m.aux}
+    # +bge-reranker, +whisper-base, +sd-turbo (plus carryover embed +
+    # kokoro:cpu — the "+" notation in plan §8.2 inherits Default's aux).
+    assert "bge-reranker-v2-m3" in aux_models
+    assert "whisper-base" in aux_models
+    assert "sd-turbo" in aux_models
+    assert m.npu_trio_shown is True
+    assert m.npu_trio_optin is False  # opt-in means user must tick the box
+
+
+def test_hal0_max_matches_plan_table():
+    m = bundle_tiers.load_bundle("hal0-Max").bundle
+    assert m.min_ram_gb == 100
+    assert m.primary is not None and m.primary.model_name == "Qwen3.6-35B-A3B-MTP"
+    assert m.primary.size_gb == pytest.approx(23.8)
+    assert m.coder is not None and m.coder.model_name == "Qwen3-Coder-Next-80B-A3B"
+    assert m.coder.size_gb == pytest.approx(48.0)
+    assert m.coder.lru is True
+    aux_models = {entry.model_name for entry in m.aux}
+    assert "whisper-large-v3-turbo" in aux_models
+    assert "flux-2-klein-9b" in aux_models
+    assert m.npu_trio_shown is True
+
+
+def test_lmx_kit_matches_plan_table():
+    m = bundle_tiers.load_bundle("LMX-Omni-52B-Halo").bundle
+    assert m.min_ram_gb == 100
+    assert m.primary is not None and m.primary.model_name == "Qwen3.6-35B-A3B-MTP"
+    assert m.coder is None  # vendor kit doesn't ship a coder
+    aux_models = {entry.model_name for entry in m.aux}
+    assert aux_models == {"Whisper-Large-v3-Turbo", "kokoro-v1", "Flux-2-Klein-9B"}
+    assert m.vendor == "amd"
+    assert m.npu_trio_shown is False  # kit doesn't expose the toggle
+
+
+def test_list_bundle_summaries_matches_load_all_bundles():
+    summaries = bundle_tiers.list_bundle_summaries()
+    full = bundle_tiers.load_all_bundles()
+    assert [s.name for s in summaries] == [m.bundle.name for m in full]
+
+
+def test_intree_fallback_when_runtime_dir_missing(tmp_path, monkeypatch):
+    """The dev install (no /var/lib/hal0/.../omni/) still serves manifests
+    out of the in-tree installer/manifests/omni/ directory."""
+
+    bundle_tiers.reset_cache()
+    monkeypatch.delenv("HAL0_BUNDLES_DIR", raising=False)
+    # Force HAL0_HOME at a fresh empty dir so the runtime path doesn't
+    # exist — this is what triggers the fallback.
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    manifests = bundle_tiers.load_all_bundles()
+    assert len(manifests) == 5
+
+
+def test_override_dir_short_circuits_search(tmp_path, monkeypatch):
+    bundle_tiers.reset_cache()
+    # Write a minimal manifest for one tier in the override dir; we
+    # expect the loader to use it without falling back.
+    monkeypatch.setenv("HAL0_BUNDLES_DIR", str(tmp_path))
+    payload = (
+        '{"schema_version": 1, "hal0": {"name": "hal0-Lite", "min_ram_gb": 16, '
+        '"primary": null, "coder": null, "aux": [], "npu_trio_shown": false, '
+        '"npu_trio_optin": false, "display_label": "L", "display_subtitle": "", '
+        '"vendor": "hal0"}, "omni": {"kind": "collection.omni", "name": "hal0-Lite", "members": []}}'
+    )
+    (tmp_path / "hal0-lite.json").write_text(payload, encoding="utf-8")
+    m = bundle_tiers.load_bundle("hal0-Lite")
+    assert m.bundle.primary is None  # came from the override, not the in-tree manifest

--- a/ui/src/router.js
+++ b/ui/src/router.js
@@ -83,6 +83,21 @@ const routes = [
     meta: { title: 'Setup', skipFirstRunGuard: true },
   },
   {
+    // PR-17 first-run bundle picker (ADR-0010). Sits between the
+    // install wizard's complete-event and the dashboard's first render:
+    // when capabilities.toml is empty + the bundle-chosen marker is
+    // absent, the dashboard guard redirects here so the user picks a
+    // tier (or explicitly clicks Skip) before any model loads.
+    path: '/bundles',
+    name: 'bundle-picker',
+    component: () => import('./views/FirstRun/BundlePicker.vue'),
+    meta: {
+      title: 'Pick a starting bundle',
+      skipFirstRunGuard: true,
+      skipBundlePickerGuard: true,
+    },
+  },
+  {
     path: '/:catchAll(.*)',
     name: 'not-found',
     component: () => import('./views/NotFound.vue'),
@@ -122,15 +137,54 @@ async function _resolveFirstRun() {
   return _firstRunInflight
 }
 
+// ── Bundle picker guard (ADR-0010 / PR-17) ──────────────────────────────────
+// After the install wizard completes, the first dashboard load drops
+// the user into the bundle picker until they either pick a tier or
+// explicitly skip. Decision is cached per-session like the first-run
+// guard above.
+let _bundleDecision = null   // null = unknown, true = picker, false = clear
+let _bundleInflight = null
+
+async function _resolveBundlePicker() {
+  if (_bundleDecision !== null) return _bundleDecision
+  if (_bundleInflight) return _bundleInflight
+  _bundleInflight = (async () => {
+    try {
+      const r = await fetch('/api/bundles')
+      if (!r.ok) return false  // fail open
+      const body = await r.json()
+      _bundleDecision = !!body?.picker_pending
+      return _bundleDecision
+    } catch {
+      return false
+    } finally {
+      _bundleInflight = null
+    }
+  })()
+  return _bundleInflight
+}
+
 router.beforeEach(async (to) => {
-  if (to.meta?.skipFirstRunGuard) return true
+  if (to.meta?.skipFirstRunGuard) {
+    // Even on a skip-guard route we still want to honour the bundle
+    // picker reset path (e.g. navigating directly to /bundles after
+    // skip → re-pick later in v0.3). The bundle guard exits early on
+    // routes that ALSO declare skipBundlePickerGuard.
+    if (to.meta?.skipBundlePickerGuard) return true
+    return true
+  }
   const needsWizard = await _resolveFirstRun()
   if (needsWizard) return { name: 'firstrun' }
+  if (to.meta?.skipBundlePickerGuard) return true
+  const needsBundle = await _resolveBundlePicker()
+  if (needsBundle) return { name: 'bundle-picker' }
   return true
 })
 
-// Expose a reset so FirstRun.vue can clear the cache after POST /install/complete.
+// Expose resets so FirstRun.vue can clear the cache after
+// POST /install/complete, and BundlePicker.vue after pick/skip.
 export function resetFirstRunGuard() { _firstRunDecision = null }
+export function resetBundlePickerGuard() { _bundleDecision = null }
 
 router.afterEach((to) => {
   const base = 'hal0'

--- a/ui/src/views/FirstRun/BundlePicker.vue
+++ b/ui/src/views/FirstRun/BundlePicker.vue
@@ -1,0 +1,538 @@
+<script setup>
+/**
+ * BundlePicker.vue — First-run bundle picker (ADR-0010 / plan §8 / PR-17).
+ *
+ * Shown on first dashboard load when capabilities.toml lands empty and
+ * the bundle-chosen marker is absent. Five locked tiers:
+ *
+ *   hal0-Lite (16 GB+) · hal0-Default (32 GB+) · hal0-Pro (64 GB+) ·
+ *   hal0-Max (100 GB+) · LMX-Omni-52B-Halo (AMD-curated kit)
+ *
+ * Tiers whose min_ram_gb exceeds the host's detected RAM are greyed
+ * with an explanatory tooltip — the operator can still see they exist
+ * (no silent omission) but the card isn't clickable.
+ *
+ * Picking a tier opens a confirmation modal that surfaces:
+ *   - bundle contents (every model with its slot + size)
+ *   - estimated total download size
+ *   - NPU opt-in toggle (Pro/Max only — manifest's npu_trio_shown)
+ *
+ * Confirm → POST /api/bundles/{name} { npu_opt_in } → redirect to /
+ * Skip → GET /api/bundles/skip → redirect to /
+ *
+ * Wired via ui/src/router.js + a beforeEach guard that hits
+ * /api/bundles to decide between /bundles and the regular dashboard
+ * on a fresh load.
+ */
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { api } from '../../composables/useApi.js'
+import { useToastsStore } from '../../stores/toasts.js'
+import { resetBundlePickerGuard } from '../../router.js'
+import Wordmark from '../../components/Wordmark.vue'
+
+const router = useRouter()
+const toasts = useToastsStore()
+
+const loading = ref(true)
+const error = ref('')
+const tiers = ref([])
+const eligible = ref([])
+const hostRamGb = ref(0)
+
+// Modal state
+const showModal = ref(false)
+const selectedTier = ref(null)
+const npuOptIn = ref(false)
+const submitting = ref(false)
+
+const hal0Tiers = computed(() => tiers.value.filter((t) => t.vendor !== 'amd'))
+const vendorKits = computed(() => tiers.value.filter((t) => t.vendor === 'amd'))
+
+function isEligible(tier) {
+  return eligible.value.includes(tier.name)
+}
+
+function ramTooltip(tier) {
+  if (isEligible(tier)) return ''
+  if (hostRamGb.value > 0) {
+    return `Needs ${tier.min_ram_gb} GB; this host has ~${hostRamGb.value} GB.`
+  }
+  return `Needs ${tier.min_ram_gb} GB; host RAM could not be probed.`
+}
+
+function fmtGb(n) {
+  if (!n && n !== 0) return '—'
+  return `${Number(n).toFixed(1)} GB`
+}
+
+async function refresh() {
+  loading.value = true
+  error.value = ''
+  try {
+    const body = await api('/api/bundles')
+    tiers.value = body.tiers || []
+    eligible.value = body.eligible || []
+    hostRamGb.value = body.host_ram_gb || 0
+    // If the marker is already present (browser back, double-load),
+    // skip straight to the dashboard. The router guard would catch
+    // this on the next navigation, but the picker view rendering at
+    // all would be a confusing flash.
+    if (body.picker_pending === false) {
+      router.replace('/')
+    }
+  } catch (e) {
+    error.value = e?.message || 'Could not load bundle catalogue.'
+  } finally {
+    loading.value = false
+  }
+}
+
+function openTier(tier) {
+  if (!isEligible(tier)) return
+  selectedTier.value = tier
+  npuOptIn.value = !!tier.npu_trio_optin
+  showModal.value = true
+}
+
+function closeModal() {
+  if (submitting.value) return
+  showModal.value = false
+  selectedTier.value = null
+}
+
+async function confirmTier() {
+  if (!selectedTier.value) return
+  submitting.value = true
+  try {
+    const body = selectedTier.value.npu_trio_shown
+      ? { npu_opt_in: !!npuOptIn.value }
+      : {}
+    await api(`/api/bundles/${encodeURIComponent(selectedTier.value.name)}`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+    toasts.info(`Installing ${selectedTier.value.display_label || selectedTier.value.name} — pulling models in the background.`)
+    resetBundlePickerGuard()
+    router.replace('/')
+  } catch (e) {
+    toasts.error(e?.message || 'Could not apply bundle.')
+    submitting.value = false
+  }
+}
+
+async function skipPicker() {
+  submitting.value = true
+  try {
+    await api('/api/bundles/skip')
+    toasts.info('Skipped — configure capabilities manually from the dashboard.')
+    resetBundlePickerGuard()
+    router.replace('/')
+  } catch (e) {
+    toasts.error(e?.message || 'Could not record skip.')
+    submitting.value = false
+  }
+}
+
+onMounted(refresh)
+</script>
+
+<template>
+  <div class="picker-page">
+    <div class="picker-card">
+      <div class="picker-head">
+        <div class="picker-glow" aria-hidden="true"></div>
+        <span class="picker-eyebrow">
+          <span class="picker-eyebrow-dot" aria-hidden="true"></span>
+          First run · bundle picker
+        </span>
+        <Wordmark size="text-5xl" class="picker-mark" aria-hidden="true" />
+        <h1 class="picker-title">Welcome to hal0</h1>
+        <p class="picker-sub">
+          Pick a starting configuration. You can customise any slot afterwards.
+          Or skip to configure manually.
+        </p>
+      </div>
+
+      <div v-if="loading" class="picker-body picker-loading">
+        Loading bundle catalogue…
+      </div>
+
+      <div v-else-if="error" class="picker-body picker-error">
+        <p>{{ error }}</p>
+        <button class="btn-ghost" type="button" @click="refresh">Retry</button>
+      </div>
+
+      <div v-else class="picker-body">
+        <section class="tier-section" aria-label="Hardware-anchored tiers">
+          <header class="tier-section-head">
+            <h2 class="tier-section-title">Hardware-anchored tiers</h2>
+            <p v-if="hostRamGb > 0" class="tier-section-sub">
+              Detected host RAM: {{ hostRamGb }} GB
+            </p>
+          </header>
+          <div class="tier-grid" role="list">
+            <button
+              v-for="tier in hal0Tiers"
+              :key="tier.name"
+              type="button"
+              role="listitem"
+              class="tier-card"
+              :class="{ 'tier-card-disabled': !isEligible(tier) }"
+              :disabled="!isEligible(tier)"
+              :title="ramTooltip(tier)"
+              :aria-label="`${tier.display_label || tier.name} — minimum ${tier.min_ram_gb} GB`"
+              :data-tier-name="tier.name"
+              :data-tier-eligible="isEligible(tier) ? 'true' : 'false'"
+              @click="openTier(tier)"
+            >
+              <div class="tier-card-head">
+                <span class="tier-card-name">{{ tier.display_label || tier.name }}</span>
+                <span class="tier-card-ram">{{ tier.min_ram_gb }} GB+</span>
+              </div>
+              <p class="tier-card-sub">{{ tier.display_subtitle }}</p>
+              <div class="tier-card-meta">
+                <span class="tier-card-chip">{{ fmtGb(tier.total_size_gb) }} total</span>
+                <span v-if="tier.npu_trio_shown" class="tier-card-chip tier-card-chip-npu">NPU trio</span>
+                <span v-if="!isEligible(tier)" class="tier-card-chip tier-card-chip-warn">needs more RAM</span>
+              </div>
+            </button>
+          </div>
+        </section>
+
+        <section v-if="vendorKits.length > 0" class="tier-section" aria-label="Pre-built kits">
+          <header class="tier-section-head">
+            <h2 class="tier-section-title">Pre-built kits</h2>
+            <p class="tier-section-sub">Vendor-curated bundles for specific hardware.</p>
+          </header>
+          <div class="tier-grid tier-grid-kits" role="list">
+            <button
+              v-for="tier in vendorKits"
+              :key="tier.name"
+              type="button"
+              role="listitem"
+              class="tier-card tier-card-kit"
+              :class="{ 'tier-card-disabled': !isEligible(tier) }"
+              :disabled="!isEligible(tier)"
+              :title="ramTooltip(tier)"
+              :aria-label="`${tier.display_label || tier.name} — minimum ${tier.min_ram_gb} GB`"
+              :data-tier-name="tier.name"
+              :data-tier-eligible="isEligible(tier) ? 'true' : 'false'"
+              @click="openTier(tier)"
+            >
+              <div class="tier-card-head">
+                <span class="tier-card-name">{{ tier.display_label || tier.name }}</span>
+                <span class="tier-card-chip tier-card-chip-vendor">AMD</span>
+              </div>
+              <p class="tier-card-sub">{{ tier.display_subtitle }}</p>
+              <div class="tier-card-meta">
+                <span class="tier-card-chip">{{ fmtGb(tier.total_size_gb) }} total</span>
+                <span v-if="!isEligible(tier)" class="tier-card-chip tier-card-chip-warn">needs more RAM</span>
+              </div>
+            </button>
+          </div>
+        </section>
+
+        <div class="picker-footer">
+          <button
+            class="btn-ghost"
+            type="button"
+            :disabled="submitting"
+            data-skip-bundle
+            @click="skipPicker"
+          >Skip — configure manually</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Confirmation modal ────────────────────────────────────── -->
+    <transition name="picker-fade">
+      <div
+        v-if="showModal && selectedTier"
+        class="picker-modal-backdrop"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="`Confirm ${selectedTier.name}`"
+        @click.self="closeModal"
+      >
+        <div class="picker-modal">
+          <h3 class="picker-modal-title">{{ selectedTier.display_label || selectedTier.name }}</h3>
+          <p class="picker-modal-sub">{{ selectedTier.display_subtitle }}</p>
+
+          <ul class="picker-modal-list">
+            <li v-if="selectedTier.primary" class="picker-modal-row">
+              <span class="picker-modal-slot">chat.primary</span>
+              <span class="picker-modal-model">{{ selectedTier.primary.model_name }}</span>
+              <span class="picker-modal-size">{{ fmtGb(selectedTier.primary.size_gb) }}</span>
+            </li>
+            <li v-if="selectedTier.coder" class="picker-modal-row">
+              <span class="picker-modal-slot">chat.coder</span>
+              <span class="picker-modal-model">{{ selectedTier.coder.model_name }}<span v-if="selectedTier.coder.lru" class="picker-modal-lru"> · LRU</span></span>
+              <span class="picker-modal-size">{{ fmtGb(selectedTier.coder.size_gb) }}</span>
+            </li>
+            <li v-for="entry in selectedTier.aux" :key="entry.slot + entry.model_name" class="picker-modal-row">
+              <span class="picker-modal-slot">{{ entry.slot }}</span>
+              <span class="picker-modal-model">{{ entry.model_name }}<span v-if="entry.lru" class="picker-modal-lru"> · LRU</span></span>
+              <span class="picker-modal-size">{{ fmtGb(entry.size_gb) }}</span>
+            </li>
+          </ul>
+
+          <div class="picker-modal-total">
+            <span class="picker-modal-total-label">Total download</span>
+            <span class="picker-modal-total-value">{{ fmtGb(selectedTier.total_size_gb) }}</span>
+          </div>
+
+          <label v-if="selectedTier.npu_trio_shown" class="picker-modal-npu">
+            <input
+              type="checkbox"
+              v-model="npuOptIn"
+              data-npu-opt-in
+            />
+            <span>
+              Also configure the NPU trio (FLM agent + STT-NPU + embed-NPU).
+              The slots will be defined; you can enable them later from the Slots page.
+            </span>
+          </label>
+
+          <div class="picker-modal-actions">
+            <button
+              class="btn-ghost"
+              type="button"
+              :disabled="submitting"
+              @click="closeModal"
+            >Cancel</button>
+            <button
+              class="btn-primary"
+              type="button"
+              :disabled="submitting"
+              data-confirm-bundle
+              @click="confirmTier"
+            >{{ submitting ? 'Applying…' : 'Confirm + install' }}</button>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<style scoped>
+.picker-page {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100%;
+  padding: 32px 16px;
+  background: var(--hal0-bg);
+  overflow: hidden;
+}
+.picker-page::before {
+  content: '';
+  position: absolute;
+  inset: -20% -10% auto -10%;
+  height: 60%;
+  pointer-events: none;
+  background: radial-gradient(ellipse at center, var(--hal0-accent-glow), transparent 70%);
+  z-index: 0;
+}
+
+.picker-card {
+  position: relative;
+  z-index: 1;
+  background: var(--hal0-bg-elevated);
+  border: 1px solid var(--hal0-border);
+  border-radius: var(--radius-xl);
+  width: min(820px, 100%);
+  overflow: hidden;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.45);
+}
+
+.picker-head {
+  position: relative;
+  text-align: center;
+  padding: 36px 32px 24px;
+  border-bottom: 1px solid var(--hal0-border);
+}
+.picker-glow {
+  position: absolute;
+  inset: auto 0 -32px 0;
+  height: 64px;
+  pointer-events: none;
+  background: radial-gradient(ellipse at center, var(--hal0-accent-glow), transparent 70%);
+}
+.picker-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 18px;
+  padding: 4px 11px;
+  border-radius: 999px;
+  border: 1px solid var(--hal0-border);
+  background: var(--hal0-bg);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--hal0-fg-muted);
+}
+.picker-eyebrow-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--hal0-accent);
+  box-shadow: 0 0 8px var(--hal0-accent);
+}
+.picker-mark {
+  display: flex; justify-content: center; margin: 0 auto 18px;
+  filter: drop-shadow(0 0 24px color-mix(in srgb, var(--hal0-accent) 30%, transparent));
+}
+.picker-title { font-size: 28px; font-weight: 600; color: var(--hal0-fg); margin: 0 0 8px; letter-spacing: -0.02em; }
+.picker-sub   { font-size: 14px; color: var(--hal0-fg-muted); margin: 0; line-height: 1.5; }
+
+.picker-body { padding: 24px 32px; display: flex; flex-direction: column; gap: 24px; }
+.picker-loading, .picker-error { text-align: center; padding: 32px; color: var(--color-fg-muted); font-size: 13px; }
+.picker-error { color: var(--color-danger); display: flex; flex-direction: column; align-items: center; gap: 12px; }
+
+.tier-section { display: flex; flex-direction: column; gap: 12px; }
+.tier-section-head { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; flex-wrap: wrap; }
+.tier-section-title { font-size: 14px; font-weight: 600; color: var(--color-fg); margin: 0; letter-spacing: 0.02em; }
+.tier-section-sub { font-size: 11.5px; color: var(--color-fg-faint); margin: 0; font-family: var(--font-mono); }
+
+.tier-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+.tier-grid-kits { grid-template-columns: 1fr; }
+@media (min-width: 720px) {
+  .tier-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .tier-grid-kits { grid-template-columns: 1fr; }
+}
+
+.tier-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px 14px;
+  text-align: left;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  cursor: pointer;
+  font-family: inherit;
+  color: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.05s;
+}
+.tier-card:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--hal0-accent) 45%, var(--color-border));
+  box-shadow: inset 3px 0 0 var(--hal0-accent);
+}
+.tier-card:active:not(:disabled) { transform: translateY(1px); }
+.tier-card-disabled { opacity: 0.45; cursor: not-allowed; }
+
+.tier-card-head { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+.tier-card-name { font-family: var(--font-mono); font-weight: 600; color: var(--color-fg); font-size: 13.5px; }
+.tier-card-ram { font-family: var(--font-mono); font-size: 11px; color: var(--hal0-accent); }
+.tier-card-sub { font-size: 12px; color: var(--color-fg-muted); margin: 0; line-height: 1.5; min-height: 2.6em; }
+.tier-card-meta { display: flex; flex-wrap: wrap; gap: 6px; }
+.tier-card-chip {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--color-surface-3);
+  color: var(--color-fg-faint);
+  border: 1px solid var(--color-border);
+}
+.tier-card-chip-npu { color: var(--hal0-accent); border-color: color-mix(in srgb, var(--hal0-accent) 45%, var(--color-border)); }
+.tier-card-chip-warn { color: var(--color-warning, #f5b049); }
+.tier-card-chip-vendor { color: var(--color-fg); }
+.tier-card-kit { background: var(--color-surface-2); }
+
+.picker-footer { display: flex; justify-content: center; padding-top: 8px; }
+
+.picker-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+.picker-modal {
+  background: var(--hal0-bg-elevated);
+  border: 1px solid var(--hal0-border);
+  border-radius: var(--radius-xl);
+  width: min(520px, 100%);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+.picker-modal-title { font-size: 18px; font-weight: 600; color: var(--color-fg); margin: 0; }
+.picker-modal-sub  { font-size: 12.5px; color: var(--color-fg-muted); margin: 0; line-height: 1.5; }
+.picker-modal-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
+.picker-modal-row {
+  display: grid;
+  grid-template-columns: minmax(80px, 1fr) 2fr auto;
+  gap: 8px;
+  align-items: baseline;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: var(--color-surface-2);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+.picker-modal-slot { color: var(--hal0-accent); }
+.picker-modal-model { color: var(--color-fg); overflow: hidden; text-overflow: ellipsis; }
+.picker-modal-lru { color: var(--color-fg-faint); }
+.picker-modal-size { color: var(--color-fg-faint); justify-self: end; }
+.picker-modal-total {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 6px 0;
+  border-top: 1px solid var(--color-border);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+}
+.picker-modal-total-label { color: var(--color-fg-muted); }
+.picker-modal-total-value { color: var(--hal0-accent); }
+.picker-modal-npu {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  font-size: 12px;
+  color: var(--color-fg-muted);
+  line-height: 1.5;
+  padding: 8px 10px;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius);
+}
+.picker-modal-npu input { margin-top: 2px; }
+.picker-modal-actions { display: flex; justify-content: flex-end; gap: 8px; padding-top: 8px; }
+
+.btn-primary {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 9px 18px; border-radius: var(--radius);
+  background: var(--hal0-accent); color: #000;
+  font-family: var(--font-mono); font-size: 12.5px; font-weight: 500;
+  border: none; cursor: pointer;
+  transition: background 0.15s, transform 0.05s;
+}
+.btn-primary:hover:not(:disabled) { background: var(--hal0-accent-hover); }
+.btn-primary:active:not(:disabled) { transform: translateY(1px); }
+.btn-primary:disabled { opacity: 0.45; cursor: not-allowed; }
+.btn-ghost {
+  padding: 8px 16px; border-radius: var(--radius);
+  border: 1px solid var(--color-border); background: transparent;
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono); font-size: 12px; cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.btn-ghost:hover:not(:disabled) { border-color: var(--color-border-hi); color: var(--color-fg); }
+.btn-ghost:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.picker-fade-enter-active, .picker-fade-leave-active { transition: opacity 0.15s ease; }
+.picker-fade-enter-from, .picker-fade-leave-to { opacity: 0; }
+</style>

--- a/ui/tests/e2e/specs/first-run-bundle-picker.spec.ts
+++ b/ui/tests/e2e/specs/first-run-bundle-picker.spec.ts
@@ -1,0 +1,264 @@
+/**
+ * first-run-bundle-picker.spec.ts — γ First-run bundle picker (PR-17).
+ *
+ * Covers the bundle picker UX (ADR-0010 / plan §8):
+ *   - All five tiers render in order (4 hal0 + 1 LMX kit)
+ *   - RAM-ineligible tiers are greyed + carry a `title` tooltip
+ *   - Tier select → modal → confirm fires POST /api/bundles/{name}
+ *   - NPU opt-in checkbox surfaces only on Pro/Max + rides POST body
+ *   - "Skip — configure manually" fires GET /api/bundles/skip + leaves
+ *
+ * The router's bundle guard sees `picker_pending: true` on / and
+ * redirects to /bundles. The install wizard is mocked as completed so
+ * the firstrun guard doesn't fire.
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+
+// Bundle row shapes returned by GET /api/bundles. Matches the
+// schema.py + tiers.py output verbatim so a future shape drift is
+// surfaced as a spec failure.
+const TIERS = [
+  {
+    name: 'hal0-Lite',
+    min_ram_gb: 16,
+    primary: { slot: 'chat.primary', model_name: 'qwen3.5-0.8b', size_gb: 1.0, lru: false },
+    coder: null,
+    aux: [],
+    npu_trio_shown: false,
+    npu_trio_optin: false,
+    display_label: 'hal0-Lite',
+    display_subtitle: 'Minimal chat — fits any 16 GB+ box',
+    vendor: 'hal0',
+    total_size_gb: 1.0,
+  },
+  {
+    name: 'hal0-Default',
+    min_ram_gb: 32,
+    primary: { slot: 'chat.primary', model_name: 'qwen3.5-9b', size_gb: 6.9, lru: false },
+    coder: null,
+    aux: [
+      { slot: 'embed', model_name: 'nomic-v1.5', size_gb: 0.3, lru: false },
+      { slot: 'stt', model_name: 'whisper-tiny', size_gb: 0.075, lru: false },
+      { slot: 'tts', model_name: 'kokoro:cpu', size_gb: 0.35, lru: false },
+    ],
+    npu_trio_shown: false,
+    npu_trio_optin: false,
+    display_label: 'hal0-Default',
+    display_subtitle: 'Balanced chat + embed + voice for 32 GB+ boxes',
+    vendor: 'hal0',
+    total_size_gb: 7.625,
+  },
+  {
+    name: 'hal0-Pro',
+    min_ram_gb: 64,
+    primary: { slot: 'chat.primary', model_name: 'Qwen3.6-27B-MTP', size_gb: 18.8, lru: false },
+    coder: { slot: 'chat.coder', model_name: 'Qwen3-Coder-30B-A3B', size_gb: 18.6, lru: true },
+    aux: [
+      { slot: 'embed', model_name: 'nomic-v1.5', size_gb: 0.3, lru: false },
+      { slot: 'rerank', model_name: 'bge-reranker-v2-m3', size_gb: 0.45, lru: false },
+      { slot: 'stt', model_name: 'whisper-base', size_gb: 0.15, lru: false },
+      { slot: 'tts', model_name: 'kokoro:cpu', size_gb: 0.35, lru: false },
+      { slot: 'img', model_name: 'sd-turbo', size_gb: 1.4, lru: true },
+    ],
+    npu_trio_shown: true,
+    npu_trio_optin: false,
+    display_label: 'hal0-Pro',
+    display_subtitle: 'Chat + coder + embed/rerank + STT + TTS + image, 64 GB+',
+    vendor: 'hal0',
+    total_size_gb: 40.05,
+  },
+  {
+    name: 'hal0-Max',
+    min_ram_gb: 100,
+    primary: { slot: 'chat.primary', model_name: 'Qwen3.6-35B-A3B-MTP', size_gb: 23.8, lru: false },
+    coder: { slot: 'chat.coder', model_name: 'Qwen3-Coder-Next-80B-A3B', size_gb: 48.0, lru: true },
+    aux: [
+      { slot: 'embed', model_name: 'nomic-v1.5', size_gb: 0.3, lru: false },
+      { slot: 'rerank', model_name: 'bge-reranker-v2-m3', size_gb: 0.45, lru: false },
+      { slot: 'stt', model_name: 'whisper-large-v3-turbo', size_gb: 1.6, lru: false },
+      { slot: 'tts', model_name: 'kokoro:cpu', size_gb: 0.35, lru: false },
+      { slot: 'img', model_name: 'flux-2-klein-9b', size_gb: 9.0, lru: true },
+    ],
+    npu_trio_shown: true,
+    npu_trio_optin: false,
+    display_label: 'hal0-Max',
+    display_subtitle: 'Top-of-line chat + coder + voice + Flux image, 100 GB+ Strix Halo',
+    vendor: 'hal0',
+    total_size_gb: 83.5,
+  },
+  {
+    name: 'LMX-Omni-52B-Halo',
+    min_ram_gb: 100,
+    primary: { slot: 'chat.primary', model_name: 'Qwen3.6-35B-A3B-MTP', size_gb: 23.8, lru: false },
+    coder: null,
+    aux: [
+      { slot: 'stt', model_name: 'Whisper-Large-v3-Turbo', size_gb: 1.6, lru: false },
+      { slot: 'tts', model_name: 'kokoro-v1', size_gb: 0.35, lru: false },
+      { slot: 'img', model_name: 'Flux-2-Klein-9B', size_gb: 9.0, lru: false },
+    ],
+    npu_trio_shown: false,
+    npu_trio_optin: false,
+    display_label: 'LMX-Omni-52B-Halo',
+    display_subtitle: 'AMD-curated kit — vendor-blessed Strix Halo bundle',
+    vendor: 'amd',
+    total_size_gb: 34.75,
+  },
+]
+
+function bundlesPayload({ ramGb = 128, picker_pending = true, choice = null } = {}) {
+  const eligible = TIERS.filter((t) => t.min_ram_gb <= ramGb).map((t) => t.name)
+  return {
+    host_ram_gb: ramGb,
+    tiers: TIERS,
+    eligible,
+    choice,
+    picker_pending,
+  }
+}
+
+test.beforeEach(async ({ page, mockState }) => {
+  // Install wizard already complete (so the firstrun guard doesn't
+  // intercept). The bundle picker is what we're exercising.
+  mockState.installState.first_run = false
+})
+
+test('shows all five bundle cards in order', async ({ page, cleanState: _ }) => {
+  await page.route('**/api/bundles', (route) => json(route, bundlesPayload({ ramGb: 128 })))
+
+  await page.goto('/')
+  await expect(page).toHaveURL(/\/bundles$/)
+  await expect(page.getByText('Welcome to hal0')).toBeVisible()
+
+  // 4 hal0-curated cards.
+  for (const name of ['hal0-Lite', 'hal0-Default', 'hal0-Pro', 'hal0-Max']) {
+    await expect(page.locator(`.tier-card[data-tier-name="${name}"]`)).toBeVisible()
+  }
+  // 1 vendor kit card.
+  await expect(page.locator('.tier-card[data-tier-name="LMX-Omni-52B-Halo"]')).toBeVisible()
+  await expect(page.getByText('Pre-built kits')).toBeVisible()
+})
+
+test('greys out RAM-ineligible tiers and renders a tooltip', async ({ page, cleanState: _ }) => {
+  await page.route('**/api/bundles', (route) => json(route, bundlesPayload({ ramGb: 32 })))
+
+  await page.goto('/bundles')
+
+  const lite = page.locator('.tier-card[data-tier-name="hal0-Lite"]')
+  const max = page.locator('.tier-card[data-tier-name="hal0-Max"]')
+
+  // Lite fits 32 GB and stays clickable.
+  await expect(lite).toHaveAttribute('data-tier-eligible', 'true')
+  await expect(lite).toBeEnabled()
+  // Max needs 100 GB and is disabled with an explanatory tooltip.
+  await expect(max).toHaveAttribute('data-tier-eligible', 'false')
+  await expect(max).toBeDisabled()
+  await expect(max).toHaveAttribute(
+    'title',
+    /Needs 100 GB; this host has ~32 GB\./,
+  )
+})
+
+test('tier select → modal → confirm fires POST /api/bundles/{name}', async ({ page, cleanState: _ }) => {
+  // Mutable so the picker-guard flips to "done" after the POST lands,
+  // letting the dashboard redirect resolve cleanly.
+  let pickerPending = true
+  await page.route('**/api/bundles', (route) =>
+    json(route, bundlesPayload({ ramGb: 128, picker_pending: pickerPending })),
+  )
+
+  let postedTo: string | null = null
+  let postedBody: any = null
+  await page.route('**/api/bundles/hal0-Default', (route) => {
+    if (route.request().method() === 'POST') {
+      postedTo = route.request().url()
+      try { postedBody = JSON.parse(route.request().postData() || '{}') } catch { postedBody = null }
+      pickerPending = false
+      return json(route, {
+        ok: true,
+        choice: { name: 'hal0-Default', npu_opt_in: false, skipped: false, chosen_at: '2026-05-23T00:00:00+00:00', assignments: [] },
+        manifest: TIERS[1],
+        applied: [],
+      })
+    }
+    return route.fallback()
+  })
+
+  await page.goto('/bundles')
+  await page.locator('.tier-card[data-tier-name="hal0-Default"]').click()
+
+  // Modal renders with the bundle contents + total size.
+  await expect(page.getByRole('dialog')).toBeVisible()
+  await expect(page.locator('.picker-modal-title')).toContainText('hal0-Default')
+  await expect(page.locator('.picker-modal-row', { hasText: 'qwen3.5-9b' })).toBeVisible()
+  await expect(page.locator('.picker-modal-row', { hasText: 'whisper-tiny' })).toBeVisible()
+
+  await page.locator('[data-confirm-bundle]').click()
+
+  // POST went through with an empty body (no NPU on Default).
+  await expect.poll(() => postedTo).toContain('/api/bundles/hal0-Default')
+  expect(postedBody).toEqual({})
+
+  // Router replaces us back to the dashboard once confirm resolves.
+  await expect(page).not.toHaveURL(/\/bundles$/, { timeout: 5_000 })
+})
+
+test('Skip — configure manually fires GET /api/bundles/skip and redirects', async ({ page, cleanState: _ }) => {
+  let pickerPending = true
+  await page.route('**/api/bundles', (route) =>
+    json(route, bundlesPayload({ ramGb: 16, picker_pending: pickerPending })),
+  )
+
+  let skipped = false
+  await page.route('**/api/bundles/skip', (route) => {
+    skipped = true
+    pickerPending = false
+    return json(route, {
+      ok: true,
+      choice: { name: '', npu_opt_in: false, skipped: true, chosen_at: '2026-05-23T00:00:00+00:00', assignments: [] },
+    })
+  })
+
+  await page.goto('/bundles')
+  await page.locator('[data-skip-bundle]').click()
+
+  await expect.poll(() => skipped).toBe(true)
+  await expect(page).not.toHaveURL(/\/bundles$/, { timeout: 5_000 })
+})
+
+test('NPU opt-in checkbox surfaces only on Pro and rides POST body', async ({ page, cleanState: _ }) => {
+  await page.route('**/api/bundles', (route) => json(route, bundlesPayload({ ramGb: 128 })))
+
+  let postedBody: any = null
+  await page.route('**/api/bundles/hal0-Pro', (route) => {
+    if (route.request().method() === 'POST') {
+      try { postedBody = JSON.parse(route.request().postData() || '{}') } catch { postedBody = null }
+      return json(route, {
+        ok: true,
+        choice: { name: 'hal0-Pro', npu_opt_in: true, skipped: false, chosen_at: '2026-05-23T00:00:00+00:00', assignments: [] },
+        manifest: TIERS[2],
+        applied: [],
+      })
+    }
+    return route.fallback()
+  })
+
+  await page.goto('/bundles')
+  await page.locator('.tier-card[data-tier-name="hal0-Pro"]').click()
+
+  // The NPU checkbox is present on Pro …
+  const npuBox = page.locator('[data-npu-opt-in]')
+  await expect(npuBox).toBeVisible()
+  await npuBox.check()
+  await page.locator('[data-confirm-bundle]').click()
+
+  await expect.poll(() => postedBody).toEqual({ npu_opt_in: true })
+})
+
+test('NPU opt-in checkbox is absent on tiers that do not expose the trio', async ({ page, cleanState: _ }) => {
+  await page.route('**/api/bundles', (route) => json(route, bundlesPayload({ ramGb: 128 })))
+
+  await page.goto('/bundles')
+  await page.locator('.tier-card[data-tier-name="hal0-Default"]').click()
+  await expect(page.getByRole('dialog')).toBeVisible()
+  await expect(page.locator('[data-npu-opt-in]')).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary

PR-17 of the v0.2 Lemonade migration. Implements the first-run bundle picker UX from ADR-0010 and plan §8 / §11 PR-17. Five locked tiers (hal0-Lite / hal0-Default / hal0-Pro / hal0-Max + the AMD-curated LMX-Omni-52B-Halo kit) ship as collection.omni-compatible JSON manifests; the picker greys tiers whose min_ram_gb exceeds detected /proc/meminfo, persists the operator's pick to a marker file, and forwards capability-mappable rows through the existing CapabilityOrchestrator.

- Backend: new `src/hal0/bundles/` package (schema + tiers + eligibility + store) and `src/hal0/api/routes/bundles.py` mounted at `/api/bundles` with `GET` (payload), `GET /skip` (skip marker), `POST /{name}` (apply tier).
- Manifests: 5 JSON files under `installer/manifests/omni/` copied to `/var/lib/hal0/models/collections/omni/` by an install.sh hook adjacent to the server_models.json block.
- Frontend: `ui/src/views/FirstRun/BundlePicker.vue` + a router guard at `/bundles` that redirects on first dashboard load when the marker is absent.
- NPU trio opt-in surfaces on Pro/Max only and rides the marker; ADR-0004 keeps actual trio enable gated.
- `chat.primary` / `chat.coder` rows are recorded for PR-18 to pick up — the orchestrator has no chat surface in v0.2.

## References

- ADR-0010 — bundle picker, no default model stack
- Lemonade adoption plan §8 (first-run UX) + §11 PR-17 + §1 #6 (no default stack)
- Memory `hal0_lemonade_omni_pattern` — collection.omni manifest shape

## Test plan

- [x] 55 backend tests under `tests/bundles/` (schema round-trip, tier table assertions, RAM eligibility boundaries, marker store + applier)
- [x] 17 route tests under `tests/api/test_bundles_route.py` (GET/POST + skip + NPU opt-in handling + validation)
- [x] 6 Playwright e2e tests under `ui/tests/e2e/specs/first-run-bundle-picker.spec.ts` (picker render, RAM grey-out, confirm POST, skip, NPU opt-in on Pro, NPU absent on Default)
- [x] Full backend suite still green (1791 passed)
- [x] Full Playwright suite still green (56 passed)
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)