### PR TITLE
feat(npu): FLM trio direct-port dispatch for stt-npu + embed-npu (PR-19)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -584,6 +584,43 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         )
         app.state.omni_router = None
 
+    # FLM trio router (PR-19, plan §5 + ADR-0008 §5 + ADR-0009). When an
+    # NPU chat slot is loaded with ``flm.args = "--asr 1 --embed 1"``,
+    # Lemonade only registers the chat model — STT + embed run on the
+    # same FLM child but aren't reachable through Lemonade's dispatcher.
+    # This router discovers the FLM child's ``backend_url`` from
+    # ``/v1/health`` and posts directly when v1.py's STT/embed routes
+    # detect an enabled ``stt-npu`` / ``embed-npu`` slot. Falls back
+    # cleanly when the FLM chat isn't loaded (FLMTrioNotAvailable raised
+    # at dispatch time so the user sees a clear envelope).
+    flm_trio_router = None
+    try:
+        from hal0.dispatcher.flm_trio import FLMTrioRouter
+
+        lemonade_client_for_trio = getattr(app.state, "lemonade_client", None)
+        if lemonade_client_for_trio is not None:
+            flm_trio_router = FLMTrioRouter(
+                lemonade_client=lemonade_client_for_trio,
+            )
+            app.state.flm_trio_router = flm_trio_router
+            log.info("flm_trio.attached")
+        else:
+            # No lemonade client → no trio routing. v1.py's gating check
+            # treats a missing router as "trio not available" and falls
+            # through to the normal Lemonade dispatch path, which 404s
+            # for stt-npu/embed-npu requests (since Lemonade has no
+            # such models registered) — that 404 is the expected
+            # behaviour when NPU isn't wired up.
+            app.state.flm_trio_router = None
+            log.info("flm_trio.skipped_no_lemonade_client")
+    except Exception as exc:
+        log.warning(
+            "flm_trio.start_failed",
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        app.state.flm_trio_router = None
+
     try:
         async with AsyncExitStack() as stack:
             for mgr in managers:

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -367,6 +367,129 @@ async def chat_completions(request: Request, dispatcher: DispatcherDep) -> Respo
     return await _dispatch_and_forward(request, dispatcher, body=body)
 
 
+async def _is_npu_trio_request(
+    request: Request,
+    body: dict[str, Any],
+    *,
+    slot_type: str,
+) -> bool:
+    """Detect whether this request should go through the FLM trio router.
+
+    PR-19 (plan §5.2 + ADR-0009). We route to the trio when:
+
+      1. The request body's ``model`` matches an enabled slot whose
+         ``device == "npu"`` AND ``type == slot_type``. We look at both
+         ``slot.model.default`` AND ``slot.name`` so callers that pass
+         either the model id or the slot name (e.g. dashboard cards
+         using ``model="stt-npu"``) hit the same path.
+      2. The :class:`FLMTrioRouter` itself is attached on ``app.state``
+         (lifespan didn't fail to construct it).
+
+    Returning ``False`` means we fall through to the regular dispatcher
+    path — which, in the NPU-not-enabled case, is exactly the right
+    fallback: Lemonade routes to a GPU/CPU embed/stt slot if one exists,
+    else 404s.
+
+    Note: we deliberately DON'T check whether the FLM chat is currently
+    loaded here. That probe lives inside the trio router (it's an
+    extra ``/v1/health`` call we don't want to spend on the gating
+    check). When the chat isn't loaded the dispatch raises
+    :class:`FLMTrioNotAvailable`, which surfaces as a clean 503 with the
+    "load an NPU chat slot first" envelope — better UX than silently
+    falling through to a 404 from the wrong path.
+    """
+    if getattr(request.app.state, "flm_trio_router", None) is None:
+        return False
+    slot_manager = getattr(request.app.state, "slot_manager", None)
+    if slot_manager is None:
+        return False
+    raw_model = body.get("model") if body else None
+    if not isinstance(raw_model, str) or not raw_model.strip():
+        return False
+    requested = raw_model.strip()
+    try:
+        configs = await slot_manager.iter_configs()
+    except Exception:
+        return False
+    for cfg in configs:
+        if cfg.get("type") != slot_type:
+            continue
+        if cfg.get("device") != "npu":
+            continue
+        if cfg.get("enabled") is False:
+            continue
+        # Match by model.default OR by slot name — callers may pass
+        # either through depending on UI affordance.
+        model_section = cfg.get("model") or {}
+        default = ""
+        if isinstance(model_section, dict):
+            raw_default = model_section.get("default", "")
+            if isinstance(raw_default, str):
+                default = raw_default.strip()
+        slot_name = str(cfg.get("name", "")).strip()
+        if requested in (default, slot_name) and (default or slot_name):
+            return True
+    return False
+
+
+async def _dispatch_via_flm_trio(
+    request: Request,
+    *,
+    body: dict[str, Any],
+    kind: str,
+) -> Response | None:
+    """Forward an embed/STT request through the FLM trio router.
+
+    Returns a FastAPI :class:`Response` on success / surfaced FLM error,
+    or ``None`` when the trio router is not present (caller falls
+    through). :class:`FLMTrioNotAvailable` propagates out so the error
+    middleware emits the proper 503 envelope; HTTP errors from the FLM
+    child are mirrored into the response verbatim.
+
+    Only the embed path is routed through here — STT is multipart and
+    handled inside :func:`_forward_multipart` to keep the
+    bytes-buffer-then-forward seam in one place.
+    """
+    if kind != "embed":  # defensive — only one caller today
+        return None
+    router_obj = getattr(request.app.state, "flm_trio_router", None)
+    if router_obj is None:
+        return None
+    upstream_resp = await router_obj.dispatch_embed_npu(body=body)
+    return _wrap_flm_trio_response(upstream_resp)
+
+
+def _wrap_flm_trio_response(upstream: Any) -> Response:
+    """Build a FastAPI :class:`Response` from an httpx response.
+
+    Mirrors what :class:`Dispatcher._forward_direct` does — strips
+    hop-by-hop headers, preserves the upstream status code, and copies
+    the content-type so OpenAI clients see the same shape they would
+    have if Lemonade had handled the call. Streaming responses aren't
+    supported (FLM's transcribe + embed endpoints are non-streaming).
+    """
+    # Drop hop-by-hop / length headers; Starlette recomputes content-length.
+    skip = {
+        "connection",
+        "content-encoding",
+        "content-length",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+    headers = {k: v for k, v in upstream.headers.items() if k.lower() not in skip}
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        headers=headers,
+        media_type=upstream.headers.get("content-type"),
+    )
+
+
 async def _maybe_run_omni_loop(request: Request, body: dict[str, Any]) -> Response | None:
     """Attempt to run the OmniRouter loop for this chat request.
 
@@ -421,7 +544,17 @@ async def completions(request: Request, dispatcher: DispatcherDep) -> Response:
 
 @router.post("/embeddings")
 async def embeddings(request: Request, dispatcher: DispatcherDep) -> Response:
-    return await _dispatch_and_forward(request, dispatcher)
+    # PR-19: FLM trio direct-port dispatch for the ``embed-npu`` slot.
+    # When a request resolves to an enabled NPU embedding slot AND the
+    # FLM chat anchor is loaded, post straight to the FLM child's
+    # ``/v1/embeddings`` instead of Lemonade (which doesn't register
+    # the embed shadow role — only the chat anchor). Plan §5.2.
+    body = await _read_json_body(request)
+    if await _is_npu_trio_request(request, body, slot_type="embedding"):
+        trio_response = await _dispatch_via_flm_trio(request, body=body, kind="embed")
+        if trio_response is not None:
+            return trio_response
+    return await _dispatch_and_forward(request, dispatcher, body=body)
 
 
 @router.post("/rerankings")
@@ -440,6 +573,15 @@ async def audio_transcriptions(request: Request, dispatcher: DispatcherDep) -> R
     # the missing-model case as 400 (request.missing_model) rather than
     # letting it fall through to the dispatcher's default-model + no-route
     # 404, which obscured the real problem (issue #34).
+    #
+    # PR-19: FLM trio direct-port dispatch for the ``stt-npu`` slot.
+    # When the request targets an enabled NPU transcription slot AND the
+    # FLM chat anchor is loaded, post the raw multipart bytes straight
+    # to the FLM child's ``/v1/audio/transcriptions``. We do the gating
+    # inside ``_forward_multipart`` because (a) we need the model field
+    # parsed from the multipart envelope to decide, and (b) the multipart
+    # bytes-buffer-then-forward pattern is the same either way — only
+    # the destination URL differs.
     response = await _forward_multipart(request, dispatcher, require_model=True)
     return _scrub_audio_decoder_leakage(response)
 
@@ -721,6 +863,25 @@ async def _forward_multipart(
             details={"field": "model", "path": request.url.path},
             code="request.missing_model",
         )
+
+    # PR-19: FLM trio direct-port dispatch for the ``stt-npu`` slot.
+    # We do the gating here (rather than in the route handler) because
+    # the model field only becomes available after the multipart parse
+    # above. When the request targets an enabled NPU transcription slot,
+    # forward the raw multipart bytes directly to the FLM child's
+    # ``/v1/audio/transcriptions`` — Lemonade has no transcription
+    # model registered for the FLM chat anchor, so the standard
+    # dispatch path would 404. Plan §5.2.
+    if model_value and request.url.path.endswith("/audio/transcriptions"):
+        synthetic_body = {"model": model_value}
+        if await _is_npu_trio_request(request, synthetic_body, slot_type="transcription"):
+            router_obj = getattr(request.app.state, "flm_trio_router", None)
+            if router_obj is not None:
+                upstream_resp = await router_obj.dispatch_stt_npu(
+                    body=raw_body,
+                    content_type=content_type,
+                )
+                return _wrap_flm_trio_response(upstream_resp)
 
     call = await dispatcher.dispatch(request, body={"model": model_value} if model_value else {})
 

--- a/src/hal0/dispatcher/flm_trio.py
+++ b/src/hal0/dispatcher/flm_trio.py
@@ -1,0 +1,336 @@
+"""FLM trio direct-port dispatch — PR-19.
+
+When a Lemonade NPU chat slot is loaded with ``flm.args = "--asr 1 --embed 1"``
+(plan §5.1), a single ``flm serve`` child process answers three OpenAI-shaped
+endpoints simultaneously: ``/v1/chat/completions``, ``/v1/audio/transcriptions``,
+and ``/v1/embeddings``. Lemonade only registers the **chat** model; it does
+not know the ASR or embed roles exist. The dashboard surfaces three slots
+anyway (``agent``, ``stt-npu``, ``embed-npu``) because the operator manages
+them as a unit (ADR-0008 §5, ADR-0009).
+
+That asymmetry means hal0 must bypass Lemonade's dispatcher for the two
+"shadow" roles:
+
+  - **Chat → Lemonade.** ``/v1/chat/completions`` keeps routing through
+    Lemonade's ``/v1/chat/completions``; Lemonade's router proxies to the
+    FLM child internally, so the existing dispatcher path works unchanged.
+  - **STT → FLM child directly.** ``/v1/audio/transcriptions`` for the
+    ``stt-npu`` slot must POST straight to ``{backend_url}/v1/audio/transcriptions``
+    where ``backend_url`` is whatever port lemond assigned to the FLM
+    child. Lemonade would 404 these because it has no transcription
+    model registered.
+  - **Embed → FLM child directly.** Same story for ``/v1/embeddings``
+    against the ``embed-npu`` slot.
+
+Discovery: ``GET /v1/health`` returns a ``loaded[]`` list of entries each
+carrying ``model_name``, ``backend_url``, ``recipe``, ``type``, … We pick
+the entry whose ``recipe == "flm"`` AND ``type == "llm"`` — that's the
+chat anchor; its ``backend_url`` is the FLM child process we route to.
+
+This module is pure dispatch — slot lifecycle / capabilities orchestration
+lives in :mod:`hal0.capabilities.orchestrator` and :mod:`hal0.slots.manager`.
+We assume the operator has already enabled the trio via capabilities.toml;
+our job is to honour that selection at request time.
+
+Edge cases (plan §5.3, ADR-0009):
+
+  1. **FLM chat not loaded.** Trio dispatch raises :class:`FLMTrioNotAvailable`
+     so the caller can surface a clear "load an NPU chat slot first"
+     message instead of mysteriously 404ing.
+  2. **``/v1/health`` returns no FLM entry.** Same as (1) — there's no
+     backend_url to POST to.
+  3. **Trio model swap mid-request.** The request already in flight uses
+     the stale backend_url it discovered; subsequent requests re-discover
+     the new url on each call. This is the looser-coupling tradeoff the
+     plan accepts in §5.3 — we don't cache backend_url across requests.
+  4. **NPU slot disabled.** Trio router is NEVER called; v1.py's gating
+     check (active stt-npu/embed-npu + device=npu + enabled=true) keeps
+     normal Lemonade routing in charge. The dispatcher then 404s if no
+     fallback slot is configured — expected fallthrough behaviour.
+
+Per the locked plan: no NPU exclusivity validation here (PR-20 owns); no
+caching of backend_url (the swap-mid-request semantics require fresh
+lookup); no LemonadeClient surface changes (we use the existing
+``.health()`` method only).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+
+from hal0.errors import Hal0Error
+from hal0.lemonade.client import LemonadeClient
+from hal0.lemonade.errors import LemonadeError
+
+log = logging.getLogger(__name__)
+
+# Per-request timeout for the trio's HTTP calls. STT can be slow on cold
+# NPU (whisper warm-up); give it a generous read budget. Embed is fast
+# but shares the same budget for simplicity — the request type already
+# bounds the worst case (embed of a single string completes in <1s on
+# Strix Halo per spike #2 in memory ``hal0_lemonade_flm_npu_install``).
+_DEFAULT_TIMEOUT_S = 120.0
+
+
+class FLMTrioNotAvailable(Hal0Error):
+    """The FLM chat anchor isn't loaded, so the trio's shadow roles
+    (``stt-npu`` / ``embed-npu``) have no backend to forward to.
+
+    Surfaced when:
+
+      - ``/v1/health`` doesn't list a ``recipe == "flm"`` AND ``type == "llm"``
+        entry, OR
+      - that entry lacks a non-empty ``backend_url``, OR
+      - lemond itself is unreachable (the health probe raises).
+
+    Plan §5.3 mandates the surface message: "load an NPU chat slot first".
+    The 503 status fits the "service component temporarily unavailable"
+    semantics — operator action required.
+    """
+
+    code = "npu.trio_unavailable"
+    status = 503
+
+
+class FLMTrioRouter:
+    """Discovers the FLM child process and dispatches STT/embed to it.
+
+    Held as a singleton on ``app.state.flm_trio_router`` (constructed in
+    :func:`hal0.api.create_app`'s lifespan), one per process. The held
+    :class:`LemonadeClient` is the same instance the rest of hal0 uses,
+    so :meth:`find_flm_chat_backend_url` shares the httpx connection pool
+    with every other ``/v1/health`` reader.
+
+    The router is **stateless** apart from the injected client + http
+    client — no caching of backend_url across calls, because plan §5.3
+    explicitly accepts that a trio model swap mid-request leaves the
+    in-flight request bound to the stale URL while the next one
+    re-discovers fresh. Caching would invert that semantics and force
+    cache invalidation hooks in every load/swap path.
+
+    Args:
+        lemonade_client: Used for ``/v1/health`` discovery. Required.
+        http_client: Optional shared httpx client for the FLM POSTs.
+            When ``None``, a per-call client is created (zero shared
+            state — fine for tests; in production wire one in via the
+            lifespan so connections pool).
+        timeout_s: Per-call timeout for the FLM POST. Default 120s —
+            long enough for cold-NPU STT warm-up.
+    """
+
+    def __init__(
+        self,
+        lemonade_client: LemonadeClient,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+    ) -> None:
+        self._lemonade = lemonade_client
+        self._http_client = http_client
+        self._timeout_s = timeout_s
+
+    # ── discovery ──────────────────────────────────────────────────
+
+    async def find_flm_chat_backend_url(self) -> str | None:
+        """Return the FLM child's ``backend_url`` if one is loaded.
+
+        Walks ``/v1/health.loaded[]`` (also ``all_models_loaded[]`` for
+        forward-compat with the alternate key Lemonade emits — see
+        ``hal0/lemonade/metrics_shim.py`` comments) and picks the first
+        entry whose:
+
+          - ``recipe == "flm"`` (rules out llama.cpp slots that happen to
+            be loaded on the iGPU)
+          - ``type == "llm"``    (rules out embed / ASR shadow entries
+            should Lemonade ever advertise them; today it does not)
+          - ``backend_url`` is a non-empty string
+
+        Returns ``None`` when no such entry exists, when lemond raises,
+        or when the JSON body is missing the expected list shape. Never
+        raises — caller treats ``None`` as "trio not available".
+
+        The "never raises" contract is deliberate: every consumer wants
+        the same fallback behaviour (raise :class:`FLMTrioNotAvailable`
+        at the dispatch site), and bubbling the LemonadeError up here
+        would force every call site to repeat the same wrapping.
+        """
+        try:
+            health = await self._lemonade.health()
+        except LemonadeError as exc:
+            log.debug(
+                "flm_trio.health_unavailable",
+                extra={"error": str(exc), "error_type": type(exc).__name__},
+            )
+            return None
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning(
+                "flm_trio.health_unexpected_error",
+                extra={"error": str(exc), "error_type": type(exc).__name__},
+            )
+            return None
+
+        if not isinstance(health, dict):
+            return None
+
+        # Lemonade emits the loaded list under either key depending on
+        # version — accept both. ``all_models_loaded`` is the newer name;
+        # ``loaded`` is what the deep-dive doc and the client docstring
+        # currently expect. Walking both keys keeps us pinned-version-
+        # agnostic.
+        for key in ("loaded", "all_models_loaded"):
+            entries = health.get(key)
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                if entry.get("recipe") != "flm":
+                    continue
+                if entry.get("type") != "llm":
+                    continue
+                backend_url = entry.get("backend_url")
+                if isinstance(backend_url, str) and backend_url.strip():
+                    # Strip trailing slashes so ``{backend_url}/v1/...``
+                    # joining never produces ``//v1/...``. lemond's
+                    # backend_url is conventionally bare (no trailing
+                    # slash) but defensiveness is cheap.
+                    return backend_url.rstrip("/")
+
+        return None
+
+    # ── dispatch — STT ─────────────────────────────────────────────
+
+    async def dispatch_stt_npu(
+        self,
+        *,
+        body: bytes,
+        content_type: str,
+        extra_headers: Mapping[str, str] | None = None,
+    ) -> httpx.Response:
+        """Forward an STT request to the FLM child's ``/v1/audio/transcriptions``.
+
+        ``body`` is the raw multipart bytes from the inbound request —
+        forwarded verbatim so the FLM-side multipart parser sees the
+        same wire format the client sent. ``content_type`` MUST carry
+        the multipart boundary; recompute it from the inbound headers
+        before passing it in (the v1.py route already does this via
+        ``request.headers["content-type"]``).
+
+        Returns the raw :class:`httpx.Response`; the caller decides how
+        to wrap it for FastAPI (the v1.py audio route builds a
+        :class:`starlette.responses.Response` from the bytes + status,
+        same as the dispatcher's ``_forward_direct``).
+
+        Raises:
+            FLMTrioNotAvailable: No FLM chat loaded. Message is the
+                exact "load an NPU chat slot first" string from
+                plan §5.3 so the dashboard can pattern-match.
+        """
+        backend_url = await self.find_flm_chat_backend_url()
+        if backend_url is None:
+            raise FLMTrioNotAvailable(
+                "FLM trio not available — load an NPU chat slot first.",
+                details={"endpoint": "/v1/audio/transcriptions"},
+            )
+        return await self._post(
+            f"{backend_url}/v1/audio/transcriptions",
+            content=body,
+            headers=self._merge_headers(extra_headers, content_type=content_type),
+        )
+
+    # ── dispatch — embed ───────────────────────────────────────────
+
+    async def dispatch_embed_npu(
+        self,
+        *,
+        body: dict[str, Any],
+        extra_headers: Mapping[str, str] | None = None,
+    ) -> httpx.Response:
+        """Forward an embeddings request to the FLM child's ``/v1/embeddings``.
+
+        ``body`` is the parsed OpenAI-shape body (``{"model": ..., "input": ...}``);
+        we re-serialise it as JSON and POST it to the FLM child. Param
+        forwarding is verbatim — anything the caller passes through
+        (e.g., ``encoding_format``, ``dimensions``) lands on the FLM
+        process unchanged.
+
+        Returns the raw :class:`httpx.Response`; the v1.py route wraps
+        it into a FastAPI :class:`Response`.
+
+        Raises:
+            FLMTrioNotAvailable: No FLM chat loaded.
+        """
+        backend_url = await self.find_flm_chat_backend_url()
+        if backend_url is None:
+            raise FLMTrioNotAvailable(
+                "FLM trio not available — load an NPU chat slot first.",
+                details={"endpoint": "/v1/embeddings"},
+            )
+        return await self._post(
+            f"{backend_url}/v1/embeddings",
+            json=body,
+            headers=self._merge_headers(extra_headers, content_type="application/json"),
+        )
+
+    # ── helpers ────────────────────────────────────────────────────
+
+    @staticmethod
+    def _merge_headers(
+        extra: Mapping[str, str] | None,
+        *,
+        content_type: str,
+    ) -> dict[str, str]:
+        """Build the outbound header dict.
+
+        We always set ``content-type`` (callers pass it in so the
+        multipart boundary survives for STT); ``extra`` lets the caller
+        forward anything else relevant (today: nothing — the dispatcher
+        normally forwards request headers, but the trio path skips that
+        because hop-by-hop / auth headers from the inbound request
+        shouldn't leak to the FLM child).
+        """
+        out: dict[str, str] = {"content-type": content_type}
+        if extra:
+            for k, v in extra.items():
+                # Don't let extra clobber our content-type — the
+                # multipart boundary is computed on the inbound side and
+                # the caller passes that exact string in via the
+                # ``content_type`` arg.
+                if k.lower() == "content-type":
+                    continue
+                out[k] = v
+        return out
+
+    async def _post(
+        self,
+        url: str,
+        *,
+        content: bytes | None = None,
+        json: dict[str, Any] | None = None,
+        headers: dict[str, str],
+    ) -> httpx.Response:
+        """Single chokepoint for the FLM POST. Uses the shared client when
+        provided, else opens a per-call one.
+        """
+        if self._http_client is not None:
+            return await self._http_client.post(
+                url,
+                content=content,
+                json=json,
+                headers=headers,
+                timeout=self._timeout_s,
+            )
+        # Per-call client — slightly more expensive but keeps the router
+        # usable without a wired-in pool (tests, ad-hoc scripts).
+        async with httpx.AsyncClient(timeout=self._timeout_s) as client:
+            return await client.post(url, content=content, json=json, headers=headers)
+
+
+__all__ = [
+    "FLMTrioNotAvailable",
+    "FLMTrioRouter",
+]

--- a/tests/api/test_v1_npu_trio_routing.py
+++ b/tests/api/test_v1_npu_trio_routing.py
@@ -1,0 +1,563 @@
+"""End-to-end routing tests for the FLM trio dispatch (PR-19, plan §5).
+
+When a request lands on ``/v1/embeddings`` or ``/v1/audio/transcriptions``
+and the active slot is an enabled NPU shadow role (``embed-npu`` /
+``stt-npu``), the request must bypass Lemonade's dispatcher and forward
+directly to the FLM child process port discovered from ``/v1/health``.
+
+These tests drive the live FastAPI app via ``TestClient`` and verify:
+
+  1. Trio-routed embed: request targeting embed-npu + FLM chat loaded
+     → POSTs to ``<flm-backend>/v1/embeddings``, NOT to Lemonade's
+     ``/v1/embeddings``.
+  2. Trio-routed STT: request targeting stt-npu + FLM chat loaded
+     → POSTs multipart to ``<flm-backend>/v1/audio/transcriptions``.
+  3. Trio-routed embed without FLM chat → 503 with the "load an NPU
+     chat slot first" envelope.
+  4. Disabled NPU slot → request flows through the normal dispatcher
+     path (existing fallback). The trio router is never called.
+  5. No NPU slot configured at all → standard dispatcher path.
+  6. The model field correctly drives the trio match (matching by
+     ``model.default`` AND by slot name).
+
+The test surface stays small — the trio router itself has thorough unit
+tests in ``tests/dispatcher/test_flm_trio.py``. The point here is to
+prove the wiring inside ``hal0/api/routes/v1.py`` makes the gating call
+and reaches the right destination.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import hal0.providers as providers_mod
+from hal0.api import create_app
+from hal0.lemonade.client import LemonadeClient
+from hal0.providers.lemonade import LemonadeProvider
+from hal0.upstreams.registry import Upstream
+
+# ── Test fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def lemonade_state() -> dict[str, Any]:
+    """Mutable handle for the lemond stub's /v1/health response.
+
+    Tests override ``state["loaded"]`` to switch between "FLM chat
+    loaded" and "FLM chat absent" scenarios.
+    """
+    return {"loaded": []}
+
+
+@pytest.fixture
+def trio_test_app(
+    lemonade_state: dict[str, Any], tmp_hal0_home: str
+) -> Iterator[tuple[FastAPI, dict[str, Any]]]:
+    """Build a hal0 app whose Lemonade stub serves ``lemonade_state`` for
+    /v1/health, AND whose FLM child stub records every inbound request.
+
+    Returns ``(app, flm_captures)``:
+
+      - ``app``: the FastAPI app, ready for :class:`TestClient`.
+      - ``flm_captures``: a dict that tests inspect after a request to
+        verify which URL/path/body the FLM child saw. Cleared between
+        scenarios by re-running the fixture.
+
+    The FLM child stub listens on ``http://127.0.0.1:14002`` (mirrors
+    what real lemond reports in ``/v1/health.loaded[].backend_url``).
+    """
+    flm_captures: dict[str, Any] = {"calls": []}
+
+    def transport_handler(req: httpx.Request) -> httpx.Response:
+        host = req.url.host
+        path = req.url.path
+        # Lemonade control-plane stub.
+        if host == "test" or path == "/v1/health":
+            if path == "/v1/health":
+                return httpx.Response(200, json={"loaded": lemonade_state["loaded"]})
+            if path in ("/v1/load", "/v1/unload"):
+                return httpx.Response(200, json={"status": "ok"})
+            if path == "/v1/embeddings":
+                # If THIS path is hit on Lemonade we want to fail the
+                # test loudly — trio routing should bypass lemond.
+                flm_captures.setdefault("lemonade_embed_hits", []).append(
+                    {"url": str(req.url), "body": req.content}
+                )
+                return httpx.Response(200, json={"data": [{"embedding": [0.0]}]})
+            return httpx.Response(404, json={"detail": f"unmocked lemonade path {path}"})
+        # FLM child stub — note the host:port matches what /v1/health
+        # advertises as backend_url.
+        if host == "127.0.0.1" and req.url.port == 14002:
+            flm_captures["calls"].append(
+                {
+                    "url": str(req.url),
+                    "path": path,
+                    "method": req.method,
+                    "content_type": req.headers.get("content-type", ""),
+                    "body": req.content,
+                }
+            )
+            if path == "/v1/embeddings":
+                return httpx.Response(
+                    200,
+                    json={"data": [{"embedding": [0.1, 0.2, 0.3]}], "model": "embed-gemma"},
+                )
+            if path == "/v1/audio/transcriptions":
+                return httpx.Response(200, json={"text": "hello from FLM"})
+            return httpx.Response(404, json={"detail": f"unmocked FLM path {path}"})
+        return httpx.Response(404, json={"detail": f"unmocked host {host} path {path}"})
+
+    # Two clients sharing the same MockTransport instance — one is
+    # bound to the Lemonade base URL (so /v1/health works as a
+    # relative path), the other has no base URL so the trio router's
+    # absolute ``http://127.0.0.1:14002/...`` URLs route through the
+    # same transport. Both delegate to ``transport_handler`` which
+    # discriminates on host/port.
+    mock = httpx.MockTransport(transport_handler)
+    lemonade_transport = httpx.AsyncClient(transport=mock, base_url="http://test")
+    trio_transport = httpx.AsyncClient(transport=mock)
+    # Drive the LemonadeProvider singleton at the same stub.
+    provider = LemonadeProvider(client=LemonadeClient(http_client=lemonade_transport))
+    original_provider = providers_mod._PROVIDERS["lemonade"]
+    providers_mod._PROVIDERS["lemonade"] = provider
+    # Stash the trio transport in the captures dict so the trio_client
+    # fixture can wire it into the router (it has to wait for the
+    # lifespan to construct the router first).
+    flm_captures["_trio_transport"] = trio_transport
+
+    app = create_app()
+    try:
+        yield app, flm_captures
+    finally:
+        providers_mod._PROVIDERS["lemonade"] = original_provider
+
+
+def _seed_slot_toml(home: str, name: str, lines: list[str]) -> Path:
+    root = Path(home) / "etc" / "hal0" / "slots"
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / f"{name}.toml"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def seed_npu_trio(tmp_hal0_home: str) -> None:
+    """Lay down the FLM trio slot TOMLs on disk."""
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "agent",
+        [
+            'name = "agent"',
+            "port = 8082",
+            'device = "npu"',
+            'type = "llm"',
+            "enabled = true",
+            "[model]",
+            'default = "gemma3:1b"',
+        ],
+    )
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "stt-npu",
+        [
+            'name = "stt-npu"',
+            "port = 8084",
+            'device = "npu"',
+            'type = "transcription"',
+            "enabled = true",
+            "[model]",
+            'default = "whisper-v3"',
+        ],
+    )
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "embed-npu",
+        [
+            'name = "embed-npu"',
+            "port = 8085",
+            'device = "npu"',
+            'type = "embedding"',
+            "enabled = true",
+            "[model]",
+            'default = "embed-gemma"',
+        ],
+    )
+
+
+@pytest.fixture
+def trio_client(
+    trio_test_app: tuple[FastAPI, dict[str, Any]],
+    seed_npu_trio: None,
+) -> Iterator[tuple[TestClient, dict[str, Any]]]:
+    """TestClient + the FLM capture dict in one tuple."""
+    app, captures = trio_test_app
+    with TestClient(app) as c:
+        # The trio router needs the lemonade_client wired in; lifespan
+        # constructs one via the idle driver but uses os.environ for the
+        # api key — for tests we want it to reuse the stub provider's
+        # client so /v1/health goes through the MockTransport. And we
+        # also need the trio router's outbound httpx client to share
+        # the mock transport so the absolute ``127.0.0.1:14002`` POSTs
+        # land on the FLM stub instead of attempting real DNS.
+        c.app.state.flm_trio_router._lemonade = providers_mod._PROVIDERS[  # type: ignore[attr-defined]
+            "lemonade"
+        ].client()
+        c.app.state.flm_trio_router._http_client = captures["_trio_transport"]  # type: ignore[attr-defined]
+        # Seed a fallback upstream so the dispatcher has somewhere to
+        # land non-trio requests. The trio-routed ones should never
+        # reach it.
+        c.app.state.upstreams.upsert(
+            Upstream(
+                name="primary",
+                kind="slot",
+                url="http://127.0.0.1:8081/v1",
+                slot_name="primary",
+                auth_style="none",
+            )
+        )
+        yield c, captures
+
+
+def _flm_loaded_chat() -> list[dict[str, Any]]:
+    """The /v1/health.loaded[] entry shape that signals "FLM chat live"."""
+    return [
+        {
+            "model_name": "gemma3:1b",
+            "recipe": "flm",
+            "type": "llm",
+            "backend_url": "http://127.0.0.1:14002",
+        }
+    ]
+
+
+# ── /v1/embeddings: trio-routed ──────────────────────────────────────────
+
+
+def test_embed_npu_routes_to_flm_child_when_chat_loaded(
+    trio_client: tuple[TestClient, dict[str, Any]],
+    lemonade_state: dict[str, Any],
+) -> None:
+    """Happy path: embed against embed-npu's model goes directly to the
+    FLM child, not to Lemonade."""
+    client, captures = trio_client
+    lemonade_state["loaded"] = _flm_loaded_chat()
+
+    r = client.post(
+        "/v1/embeddings",
+        json={"model": "embed-gemma", "input": "hello world"},
+    )
+
+    assert r.status_code == 200, r.text
+    assert r.json() == {
+        "data": [{"embedding": [0.1, 0.2, 0.3]}],
+        "model": "embed-gemma",
+    }
+    # The FLM child saw the request — at the expected path.
+    embed_calls = [c for c in captures["calls"] if c["path"] == "/v1/embeddings"]
+    assert len(embed_calls) == 1, captures["calls"]
+    assert embed_calls[0]["url"] == "http://127.0.0.1:14002/v1/embeddings"
+    # Lemonade's /v1/embeddings was NOT called — that's the whole point.
+    assert "lemonade_embed_hits" not in captures
+
+
+def test_embed_npu_preserves_request_body_verbatim(
+    trio_client: tuple[TestClient, dict[str, Any]],
+    lemonade_state: dict[str, Any],
+) -> None:
+    """Param forwarding (encoding_format, dimensions, …) is verbatim."""
+    client, captures = trio_client
+    lemonade_state["loaded"] = _flm_loaded_chat()
+
+    body = {
+        "model": "embed-gemma",
+        "input": ["one", "two", "three"],
+        "encoding_format": "float",
+        "dimensions": 768,
+    }
+    r = client.post("/v1/embeddings", json=body)
+    assert r.status_code == 200, r.text
+
+    import json as _json
+
+    embed_calls = [c for c in captures["calls"] if c["path"] == "/v1/embeddings"]
+    assert len(embed_calls) == 1
+    decoded = _json.loads(embed_calls[0]["body"])
+    assert decoded == body
+
+
+def test_embed_npu_returns_503_when_flm_chat_not_loaded(
+    trio_client: tuple[TestClient, dict[str, Any]],
+    lemonade_state: dict[str, Any],
+) -> None:
+    """No FLM chat in loaded[] → explicit error envelope.
+
+    Plan §5.3: the trio's shadow roles require the chat anchor to be
+    loaded. Without it, surface a clear "load an NPU chat slot first"
+    message rather than mysteriously 404-ing.
+    """
+    client, _ = trio_client
+    lemonade_state["loaded"] = []  # nothing loaded
+
+    r = client.post(
+        "/v1/embeddings",
+        json={"model": "embed-gemma", "input": "hello world"},
+    )
+
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert body["error"]["code"] == "npu.trio_unavailable"
+    assert "load an NPU chat slot first" in body["error"]["message"]
+
+
+def test_embed_npu_skips_trio_when_slot_disabled(
+    trio_test_app: tuple[FastAPI, dict[str, Any]],
+    lemonade_state: dict[str, Any],
+    tmp_hal0_home: str,
+) -> None:
+    """Disabled embed-npu slot → trio router NOT called, request flows
+    through the normal dispatcher path."""
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "embed-npu",
+        [
+            'name = "embed-npu"',
+            "port = 8085",
+            'device = "npu"',
+            'type = "embedding"',
+            "enabled = false",
+            "[model]",
+            'default = "embed-gemma"',
+        ],
+    )
+    # No NPU chat anchor seeded either.
+    lemonade_state["loaded"] = _flm_loaded_chat()  # even with FLM loaded
+    app, captures = trio_test_app
+    with TestClient(app) as client:
+        # Seed a fallback upstream so the dispatcher resolves somewhere.
+        client.app.state.upstreams.upsert(
+            Upstream(
+                name="primary",
+                kind="slot",
+                url="http://127.0.0.1:9100/v1",
+                slot_name="primary",
+                auth_style="none",
+            )
+        )
+        # Dispatcher will try to forward to ``http://127.0.0.1:9100/v1/embeddings``;
+        # the MockTransport handler 404s unmocked hosts, which the test
+        # treats as "dispatcher path attempted" — proving trio was skipped.
+        r = client.post(
+            "/v1/embeddings",
+            json={"model": "embed-gemma", "input": "hello"},
+        )
+        # The dispatcher's forward path returned 404 (mock for the
+        # primary upstream wasn't wired) — the exact status doesn't
+        # matter; what matters is that NO call landed on the FLM child.
+        flm_embed_hits = [c for c in captures["calls"] if c["path"] == "/v1/embeddings"]
+        assert flm_embed_hits == [], (
+            f"trio router was called despite disabled embed-npu slot: {flm_embed_hits}"
+        )
+        # And request never succeeded — fallback dispatcher tried to
+        # reach the (unmocked) primary upstream.
+        assert r.status_code != 200, r.text
+
+
+def test_embed_request_for_non_npu_model_skips_trio(
+    trio_client: tuple[TestClient, dict[str, Any]],
+    lemonade_state: dict[str, Any],
+) -> None:
+    """A request whose ``model`` doesn't match the embed-npu slot's
+    model.default flows through the normal dispatcher path, even with
+    FLM chat loaded."""
+    client, captures = trio_client
+    lemonade_state["loaded"] = _flm_loaded_chat()
+
+    # ``nomic-embed-text-v1.5`` is NOT the embed-npu default (which is
+    # ``embed-gemma``). Trio gating should skip.
+    r = client.post(
+        "/v1/embeddings",
+        json={"model": "nomic-embed-text-v1.5", "input": "hello"},
+    )
+    # The trio router must NOT have been called.
+    flm_embed_hits = [c for c in captures["calls"] if c["path"] == "/v1/embeddings"]
+    assert flm_embed_hits == [], f"trio router was called despite non-NPU model: {flm_embed_hits}"
+    # The dispatcher took it instead; outcome depends on registry binding,
+    # but the FLM child was not touched.
+    _ = r  # status not asserted; the gating decision is the assertion
+
+
+def test_embed_request_matches_trio_by_slot_name(
+    trio_client: tuple[TestClient, dict[str, Any]],
+    lemonade_state: dict[str, Any],
+) -> None:
+    """Callers can pass either the slot's ``model.default`` OR the slot
+    name itself (``embed-npu``) as ``model`` — both route through the
+    trio. UI surfaces that show "embed-npu" as a dropdown option must
+    work without exposing the underlying model id."""
+    client, captures = trio_client
+    lemonade_state["loaded"] = _flm_loaded_chat()
+
+    r = client.post(
+        "/v1/embeddings",
+        json={"model": "embed-npu", "input": "by slot name"},
+    )
+
+    assert r.status_code == 200, r.text
+    flm_embed_hits = [c for c in captures["calls"] if c["path"] == "/v1/embeddings"]
+    assert len(flm_embed_hits) == 1
+
+
+# ── /v1/audio/transcriptions: trio-routed ────────────────────────────────
+
+
+def test_stt_npu_routes_to_flm_child_when_chat_loaded(
+    trio_client: tuple[TestClient, dict[str, Any]],
+    lemonade_state: dict[str, Any],
+) -> None:
+    """Happy path: STT against stt-npu's model goes directly to FLM."""
+    client, captures = trio_client
+    lemonade_state["loaded"] = _flm_loaded_chat()
+
+    files = {"file": ("clip.wav", b"RIFF\x00\x00\x00\x00WAVEfmt ", "audio/wav")}
+    data = {"model": "whisper-v3"}
+    r = client.post("/v1/audio/transcriptions", files=files, data=data)
+
+    assert r.status_code == 200, r.text
+    assert r.json() == {"text": "hello from FLM"}
+    stt_calls = [c for c in captures["calls"] if c["path"] == "/v1/audio/transcriptions"]
+    assert len(stt_calls) == 1, captures["calls"]
+    assert stt_calls[0]["url"] == "http://127.0.0.1:14002/v1/audio/transcriptions"
+    # Multipart boundary preserved — the FLM side needs the boundary in
+    # the content-type header or its parser fails.
+    assert stt_calls[0]["content_type"].startswith("multipart/form-data")
+    assert "boundary=" in stt_calls[0]["content_type"]
+
+
+def test_stt_npu_returns_503_when_flm_chat_not_loaded(
+    trio_client: tuple[TestClient, dict[str, Any]],
+    lemonade_state: dict[str, Any],
+) -> None:
+    client, _ = trio_client
+    lemonade_state["loaded"] = []  # no FLM chat
+
+    files = {"file": ("clip.wav", b"RIFF\x00\x00\x00\x00WAVEfmt ", "audio/wav")}
+    data = {"model": "whisper-v3"}
+    r = client.post("/v1/audio/transcriptions", files=files, data=data)
+
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert body["error"]["code"] == "npu.trio_unavailable"
+    assert "load an NPU chat slot first" in body["error"]["message"]
+
+
+def test_stt_npu_skips_trio_when_slot_disabled(
+    trio_test_app: tuple[FastAPI, dict[str, Any]],
+    lemonade_state: dict[str, Any],
+    tmp_hal0_home: str,
+) -> None:
+    """Disabled stt-npu → trio NOT called even with FLM chat loaded."""
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "stt-npu",
+        [
+            'name = "stt-npu"',
+            "port = 8084",
+            'device = "npu"',
+            'type = "transcription"',
+            "enabled = false",
+            "[model]",
+            'default = "whisper-v3"',
+        ],
+    )
+    lemonade_state["loaded"] = _flm_loaded_chat()
+    app, captures = trio_test_app
+    with TestClient(app) as client:
+        client.app.state.upstreams.upsert(
+            Upstream(
+                name="primary",
+                kind="slot",
+                url="http://127.0.0.1:9100/v1",
+                slot_name="primary",
+                auth_style="none",
+            )
+        )
+        files = {"file": ("clip.wav", b"RIFF\x00\x00", "audio/wav")}
+        data = {"model": "whisper-v3"}
+        client.post("/v1/audio/transcriptions", files=files, data=data)
+        flm_stt_hits = [c for c in captures["calls"] if c["path"] == "/v1/audio/transcriptions"]
+        assert flm_stt_hits == [], (
+            f"trio router was called despite disabled stt-npu slot: {flm_stt_hits}"
+        )
+
+
+def test_stt_request_matches_trio_by_slot_name(
+    trio_client: tuple[TestClient, dict[str, Any]],
+    lemonade_state: dict[str, Any],
+) -> None:
+    """Passing ``model="stt-npu"`` (slot name) also routes through the trio."""
+    client, captures = trio_client
+    lemonade_state["loaded"] = _flm_loaded_chat()
+
+    files = {"file": ("clip.wav", b"RIFF\x00\x00", "audio/wav")}
+    data = {"model": "stt-npu"}
+    r = client.post("/v1/audio/transcriptions", files=files, data=data)
+    assert r.status_code == 200, r.text
+    stt_calls = [c for c in captures["calls"] if c["path"] == "/v1/audio/transcriptions"]
+    assert len(stt_calls) == 1
+
+
+# ── No NPU trio configured at all ────────────────────────────────────────
+
+
+def test_embed_with_no_npu_slots_configured_skips_trio(
+    trio_test_app: tuple[FastAPI, dict[str, Any]],
+    lemonade_state: dict[str, Any],
+) -> None:
+    """A host without ANY NPU slots configured → trio router never gates,
+    request goes through standard dispatch."""
+    # Note: trio_test_app + tmp_hal0_home are wired but NO slot TOMLs
+    # are seeded here.
+    lemonade_state["loaded"] = []  # even if FLM is loaded; matters less
+    app, captures = trio_test_app
+    with TestClient(app) as client:
+        client.app.state.upstreams.upsert(
+            Upstream(
+                name="primary",
+                kind="slot",
+                url="http://127.0.0.1:9100/v1",
+                slot_name="primary",
+                auth_style="none",
+            )
+        )
+        client.post(
+            "/v1/embeddings",
+            json={"model": "embed-gemma", "input": "hello"},
+        )
+        flm_embed_hits = [c for c in captures["calls"] if c["path"] == "/v1/embeddings"]
+        assert flm_embed_hits == [], flm_embed_hits
+
+
+# ── Edge: empty model field ──────────────────────────────────────────────
+
+
+def test_embed_with_missing_model_skips_trio(
+    trio_client: tuple[TestClient, dict[str, Any]],
+    lemonade_state: dict[str, Any],
+) -> None:
+    """Embed request without a ``model`` field → trio match impossible
+    → standard dispatcher path runs (which falls back on the default-
+    embed model id). Trio router must not be called."""
+    client, captures = trio_client
+    lemonade_state["loaded"] = _flm_loaded_chat()
+
+    client.post("/v1/embeddings", json={"input": "no model field"})
+
+    flm_embed_hits = [c for c in captures["calls"] if c["path"] == "/v1/embeddings"]
+    assert flm_embed_hits == [], flm_embed_hits

--- a/tests/dispatcher/test_flm_trio.py
+++ b/tests/dispatcher/test_flm_trio.py
@@ -1,0 +1,605 @@
+"""Unit tests for ``hal0.dispatcher.flm_trio`` — PR-19.
+
+The trio router is purely two methods + one discovery helper, so the
+test surface is:
+
+  * ``find_flm_chat_backend_url`` returns the URL when a ``recipe=flm``
+    AND ``type=llm`` entry is in ``loaded[]``, and only then.
+  * Both keys ``loaded`` and ``all_models_loaded`` are accepted (Lemonade
+    has used both depending on version).
+  * Non-FLM entries (llamacpp/whispercpp) are skipped even if loaded.
+  * Non-LLM FLM entries (defensively — should not happen today) are
+    skipped.
+  * Missing / empty / non-string ``backend_url`` returns ``None``.
+  * Lemonade errors are swallowed (returns ``None``) — never raises out.
+  * ``dispatch_stt_npu`` posts the raw bytes to ``<backend>/v1/audio/transcriptions``.
+  * ``dispatch_embed_npu`` posts the JSON body to ``<backend>/v1/embeddings``.
+  * Both raise :class:`FLMTrioNotAvailable` with the plan §5.3 message
+    when no FLM chat is loaded.
+  * Param forwarding (extra fields in embed body, multipart bytes for
+    STT) preserved verbatim.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from hal0.dispatcher.flm_trio import FLMTrioNotAvailable, FLMTrioRouter
+from hal0.lemonade.client import LemonadeClient
+from hal0.lemonade.errors import (
+    LemonadeHTTPError,
+    LemonadeUnavailableError,
+)
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _mock_transport(handler: Any) -> httpx.AsyncClient:
+    """httpx ``MockTransport`` convenience wrapper."""
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://test")
+
+
+def _lemonade_with_health(payload: dict[str, Any]) -> tuple[LemonadeClient, httpx.AsyncClient]:
+    """Build a LemonadeClient whose ``/v1/health`` returns ``payload``.
+
+    Returns both so the caller can ``aclose()`` the transport.
+    """
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json=payload)
+        return httpx.Response(404, json={"detail": "unexpected path"})
+
+    transport = _mock_transport(h)
+    return LemonadeClient(http_client=transport), transport
+
+
+# ── find_flm_chat_backend_url ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_returns_url_when_flm_chat_loaded() -> None:
+    """The canonical happy path — one FLM LLM entry yields its backend_url."""
+    payload = {
+        "loaded": [
+            {
+                "model_name": "gemma3:1b",
+                "recipe": "flm",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:14002",
+            }
+        ]
+    }
+    client, transport = _lemonade_with_health(payload)
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() == "http://127.0.0.1:14002"
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_returns_none_when_nothing_loaded() -> None:
+    client, transport = _lemonade_with_health({"loaded": []})
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() is None
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_skips_non_flm_entries() -> None:
+    """A llamacpp LLM loaded on the iGPU must NOT be mistaken for an FLM."""
+    payload = {
+        "loaded": [
+            {
+                "model_name": "hermes-4-14b",
+                "recipe": "llamacpp",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:9101",
+            }
+        ]
+    }
+    client, transport = _lemonade_with_health(payload)
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() is None
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_skips_non_llm_flm_entries() -> None:
+    """Defensive — should not happen today but if Lemonade ever advertises
+    an FLM-typed embed entry directly, we must NOT pick it up as the
+    chat anchor (it isn't multiplex-capable on its own)."""
+    payload = {
+        "loaded": [
+            {
+                "model_name": "embed-gemma",
+                "recipe": "flm",
+                "type": "embedding",
+                "backend_url": "http://127.0.0.1:14003",
+            }
+        ]
+    }
+    client, transport = _lemonade_with_health(payload)
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() is None
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_accepts_all_models_loaded_alias() -> None:
+    """Forward-compat — Lemonade has emitted both ``loaded`` and
+    ``all_models_loaded`` depending on version. We accept either."""
+    payload = {
+        "all_models_loaded": [
+            {
+                "model_name": "gemma3:1b",
+                "recipe": "flm",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:14002",
+            }
+        ]
+    }
+    client, transport = _lemonade_with_health(payload)
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() == "http://127.0.0.1:14002"
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_picks_first_match_with_both_keys_present() -> None:
+    """When both keys exist (unlikely but defensible), the canonical
+    ``loaded`` is consulted first."""
+    payload = {
+        "loaded": [
+            {
+                "model_name": "gemma3:1b",
+                "recipe": "flm",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:14002",
+            }
+        ],
+        "all_models_loaded": [
+            {
+                "model_name": "qwen3:0.6b",
+                "recipe": "flm",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:14999",
+            }
+        ],
+    }
+    client, transport = _lemonade_with_health(payload)
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() == "http://127.0.0.1:14002"
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_strips_trailing_slash() -> None:
+    """Defensive — Lemonade typically emits bare URLs but we tolerate
+    trailing slashes so the ``{backend_url}/v1/...`` join never doubles up."""
+    payload = {
+        "loaded": [
+            {
+                "recipe": "flm",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:14002/",
+            }
+        ]
+    }
+    client, transport = _lemonade_with_health(payload)
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() == "http://127.0.0.1:14002"
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_returns_none_when_backend_url_missing() -> None:
+    payload = {
+        "loaded": [{"recipe": "flm", "type": "llm"}],
+    }
+    client, transport = _lemonade_with_health(payload)
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() is None
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_returns_none_when_backend_url_empty_string() -> None:
+    payload = {
+        "loaded": [{"recipe": "flm", "type": "llm", "backend_url": "   "}],
+    }
+    client, transport = _lemonade_with_health(payload)
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() is None
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_returns_none_when_backend_url_not_string() -> None:
+    payload = {
+        "loaded": [{"recipe": "flm", "type": "llm", "backend_url": 14002}],
+    }
+    client, transport = _lemonade_with_health(payload)
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() is None
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_returns_none_when_lemonade_unavailable() -> None:
+    """Health probe raising LemonadeUnavailableError → None (no exception)."""
+
+    def h(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() is None
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_returns_none_when_health_returns_5xx() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"detail": "internal"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        router = FLMTrioRouter(client)
+        # Confirm via direct call that this would raise LemonadeHTTPError —
+        # the router has to swallow it.
+        with pytest.raises(LemonadeHTTPError):
+            await client.health()
+        assert await router.find_flm_chat_backend_url() is None
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_returns_none_when_body_is_not_dict() -> None:
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[1, 2, 3])
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() is None
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_returns_none_when_loaded_is_not_list() -> None:
+    payload = {"loaded": "not-a-list"}
+    client, transport = _lemonade_with_health(payload)
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() is None
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_skips_non_dict_entries_in_loaded() -> None:
+    payload = {
+        "loaded": [
+            "not-a-dict",
+            None,
+            {
+                "recipe": "flm",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:14002",
+            },
+        ]
+    }
+    client, transport = _lemonade_with_health(payload)
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() == "http://127.0.0.1:14002"
+
+
+# ── dispatch_stt_npu ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_stt_posts_multipart_to_flm_child() -> None:
+    """Verify the URL + content-type + body bytes the FLM child sees."""
+    health = {
+        "loaded": [
+            {
+                "recipe": "flm",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:14002",
+            }
+        ]
+    }
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        captured["url"] = str(req.url)
+        captured["method"] = req.method
+        captured["content_type"] = req.headers.get("content-type", "")
+        captured["body"] = req.content
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json=health)
+        return httpx.Response(200, json={"text": "transcribed"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        router = FLMTrioRouter(client, http_client=transport)
+        multipart_body = (
+            b"--boundary\r\n"
+            b'Content-Disposition: form-data; name="model"\r\n\r\n'
+            b"whisper-v3\r\n"
+            b"--boundary\r\n"
+            b'Content-Disposition: form-data; name="file"; filename="x.wav"\r\n'
+            b"Content-Type: audio/wav\r\n\r\n"
+            b"RIFF\x00\x00\x00\x00WAVE\r\n"
+            b"--boundary--\r\n"
+        )
+        resp = await router.dispatch_stt_npu(
+            body=multipart_body,
+            content_type="multipart/form-data; boundary=boundary",
+        )
+
+    assert resp.status_code == 200
+    # The FLM-child URL is what we computed from /v1/health, not Lemonade's
+    # base URL. The path is the OpenAI-shape transcription endpoint.
+    assert captured["url"] == "http://127.0.0.1:14002/v1/audio/transcriptions"
+    assert captured["method"] == "POST"
+    # Multipart boundary preserved — without this, the FLM-side parser
+    # fails and the request 415s.
+    assert captured["content_type"].startswith("multipart/form-data")
+    assert "boundary=boundary" in captured["content_type"]
+    # Body bytes round-trip verbatim — the wav payload must not be
+    # re-encoded along the way.
+    assert captured["body"] == multipart_body
+
+
+@pytest.mark.asyncio
+async def test_dispatch_stt_raises_flm_trio_unavailable_when_no_chat_loaded() -> None:
+    """Plan §5.3 — the surface error has to call out the user action."""
+    client, transport = _lemonade_with_health({"loaded": []})
+    async with transport:
+        router = FLMTrioRouter(client)
+        with pytest.raises(FLMTrioNotAvailable) as exc:
+            await router.dispatch_stt_npu(
+                body=b"--x--\r\n",
+                content_type="multipart/form-data; boundary=x",
+            )
+    assert "load an NPU chat slot first" in str(exc.value)
+    # Carries the route in details so the dashboard can show context.
+    assert exc.value.details.get("endpoint") == "/v1/audio/transcriptions"
+    # Stable code so frontends can pattern-match.
+    assert exc.value.code == "npu.trio_unavailable"
+    assert exc.value.status == 503
+
+
+@pytest.mark.asyncio
+async def test_dispatch_stt_raises_when_only_llamacpp_loaded() -> None:
+    """A non-FLM LLM in loaded[] is NOT the trio chat anchor."""
+    health = {
+        "loaded": [
+            {
+                "recipe": "llamacpp",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:9101",
+            }
+        ]
+    }
+    client, transport = _lemonade_with_health(health)
+    async with transport:
+        router = FLMTrioRouter(client)
+        with pytest.raises(FLMTrioNotAvailable):
+            await router.dispatch_stt_npu(
+                body=b"--x--\r\n",
+                content_type="multipart/form-data; boundary=x",
+            )
+
+
+# ── dispatch_embed_npu ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_embed_posts_json_to_flm_child() -> None:
+    health = {
+        "loaded": [
+            {
+                "recipe": "flm",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:14002",
+            }
+        ]
+    }
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        captured["url"] = str(req.url)
+        captured["method"] = req.method
+        captured["content_type"] = req.headers.get("content-type", "")
+        captured["body"] = req.content
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json=health)
+        return httpx.Response(
+            200,
+            json={"data": [{"embedding": [0.1, 0.2, 0.3]}], "model": "embed-gemma"},
+        )
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        router = FLMTrioRouter(client, http_client=transport)
+        resp = await router.dispatch_embed_npu(
+            body={"model": "embed-gemma", "input": "hello world"},
+        )
+
+    assert resp.status_code == 200
+    # URL points at the FLM child, NOT lemond.
+    assert captured["url"] == "http://127.0.0.1:14002/v1/embeddings"
+    assert captured["method"] == "POST"
+    assert captured["content_type"].startswith("application/json")
+    import json as _json
+
+    decoded = _json.loads(captured["body"])
+    assert decoded == {"model": "embed-gemma", "input": "hello world"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_embed_preserves_extra_params() -> None:
+    """Caller-supplied params (encoding_format, dimensions, ...) round-trip
+    untouched — the router is pure forward, no shape opinions."""
+    health = {
+        "loaded": [
+            {
+                "recipe": "flm",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:14002",
+            }
+        ]
+    }
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json=health)
+        captured["body"] = req.content
+        return httpx.Response(200, json={"data": []})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        router = FLMTrioRouter(client, http_client=transport)
+        body = {
+            "model": "embed-gemma",
+            "input": ["one", "two"],
+            "encoding_format": "float",
+            "dimensions": 768,
+            "user": "test-user-123",
+        }
+        await router.dispatch_embed_npu(body=body)
+
+    import json as _json
+
+    decoded = _json.loads(captured["body"])
+    assert decoded == body
+
+
+@pytest.mark.asyncio
+async def test_dispatch_embed_raises_flm_trio_unavailable() -> None:
+    client, transport = _lemonade_with_health({"loaded": []})
+    async with transport:
+        router = FLMTrioRouter(client)
+        with pytest.raises(FLMTrioNotAvailable) as exc:
+            await router.dispatch_embed_npu(body={"model": "embed-gemma", "input": "x"})
+    assert "load an NPU chat slot first" in str(exc.value)
+    assert exc.value.details.get("endpoint") == "/v1/embeddings"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_embed_propagates_upstream_status_codes() -> None:
+    """An FLM-side 4xx (e.g. validation) reaches the caller verbatim."""
+    health = {
+        "loaded": [
+            {
+                "recipe": "flm",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:14002",
+            }
+        ]
+    }
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json=health)
+        return httpx.Response(422, json={"detail": "empty input"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        router = FLMTrioRouter(client, http_client=transport)
+        resp = await router.dispatch_embed_npu(body={"model": "embed-gemma", "input": ""})
+
+    assert resp.status_code == 422
+    assert resp.json() == {"detail": "empty input"}
+
+
+# ── content-type isolation ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_stt_extra_headers_dont_clobber_content_type() -> None:
+    """If the caller passes an ``extra_headers`` dict that itself contains
+    a content-type, the multipart boundary that the route handler computed
+    MUST win — otherwise the FLM-side multipart parser breaks."""
+    health = {
+        "loaded": [
+            {
+                "recipe": "flm",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:14002",
+            }
+        ]
+    }
+    captured: dict[str, Any] = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json=health)
+        captured["content_type"] = req.headers.get("content-type", "")
+        return httpx.Response(200, json={"text": "ok"})
+
+    async with _mock_transport(h) as transport:
+        client = LemonadeClient(http_client=transport)
+        router = FLMTrioRouter(client, http_client=transport)
+        await router.dispatch_stt_npu(
+            body=b"--x--\r\n",
+            content_type="multipart/form-data; boundary=correct",
+            extra_headers={"Content-Type": "application/json"},  # adversarial
+        )
+
+    assert "boundary=correct" in captured["content_type"]
+
+
+# ── sanity: the router doesn't crash on missing recipe/type fields ──────
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_handles_entries_without_recipe_field() -> None:
+    """Old-snapshot entries that predate the recipe tagging are safely
+    skipped (no AttributeError / KeyError)."""
+    payload = {
+        "loaded": [
+            {"model_name": "legacy", "backend_url": "http://127.0.0.1:99"},
+            {
+                "recipe": "flm",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:14002",
+            },
+        ]
+    }
+    client, transport = _lemonade_with_health(payload)
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() == "http://127.0.0.1:14002"
+
+
+@pytest.mark.asyncio
+async def test_swallows_unexpected_lemonade_error_types() -> None:
+    """Defence-in-depth — a bug in LemonadeClient that raises a non-typed
+    error must NOT escape the router (the contract is "never raises out
+    of find_flm_chat_backend_url"). We simulate by using a client whose
+    .health() raises a generic Exception."""
+
+    class _BrokenClient:
+        async def health(self) -> dict[str, Any]:
+            raise RuntimeError("boom")
+
+    # Type-cheat: FLMTrioRouter accepts the LemonadeClient class but
+    # duck-types .health() at the call site, so a stand-in works.
+    router = FLMTrioRouter(_BrokenClient())  # type: ignore[arg-type]
+    assert await router.find_flm_chat_backend_url() is None
+
+
+@pytest.mark.asyncio
+async def test_known_lemonade_error_subclass_returns_none() -> None:
+    """Smoke check that the typed LemonadeError path also returns None."""
+
+    class _OfflineClient:
+        async def health(self) -> dict[str, Any]:
+            raise LemonadeUnavailableError("daemon down")
+
+    router = FLMTrioRouter(_OfflineClient())  # type: ignore[arg-type]
+    assert await router.find_flm_chat_backend_url() is None


### PR DESCRIPTION
## Summary

PR-19 of the v0.2 Lemonade migration — first of Phase 6 (NPU + close-out).

When an NPU chat slot is loaded with ``flm.args = "--asr 1 --embed 1"`` a
single ``flm serve`` child process multiplexes **chat + ASR + embed** on the
same NPU hardware context (plan §5.1). Lemonade only registers the **chat**
model, though — STT and embed requests against the trio's shadow slots
(``stt-npu`` / ``embed-npu``) have to bypass Lemonade and forward straight
to the FLM child's ``backend_url``, discovered from
``/v1/health.loaded[]``.

## Routing decision tree

```
                        POST /v1/embeddings
                                │
                                ▼
                ┌──────────────────────────────┐
                │ _is_npu_trio_request(...)?   │
                │   - flm_trio_router on app?  │
                │   - body.model matches an    │
                │     enabled embed-npu slot?  │
                └──────────────────────────────┘
                       │              │
                  yes  │              │  no
                       ▼              ▼
        ┌────────────────────┐   ┌────────────────────┐
        │ find_flm_chat_     │   │ standard           │
        │ backend_url()      │   │ dispatcher path    │
        │ via /v1/health     │   │ (Lemonade routes   │
        └────────────────────┘   │  to GPU/CPU slot   │
              │       │          │  or 404s if none)  │
              │       │          └────────────────────┘
         url  │       │  None
              ▼       ▼
   POST <flm>/v1/   raise FLMTrioNotAvailable
     embeddings     ("load an NPU chat slot first.")
                    → 503 npu.trio_unavailable


                POST /v1/audio/transcriptions  (multipart)
                                │
                                ▼
                buffer body + parse model field
                                │
                                ▼
                ┌──────────────────────────────┐
                │ _is_npu_trio_request(...)?   │
                │   - body.model matches an    │
                │     enabled stt-npu slot?    │
                └──────────────────────────────┘
                       │              │
                  yes  │              │  no
                       ▼              ▼
   POST <flm>/v1/audio/transcriptions     standard _forward_multipart →
   (raw multipart bytes preserved,        Lemonade /v1/audio/transcriptions
    boundary intact in content-type)
```

The same gating logic decides both paths; the only difference is *where*
the gate runs (route handler for embed, inside ``_forward_multipart`` for
STT — because we need the model field parsed from the multipart envelope
first).

## Edge cases handled

1. **FLM chat not loaded** → ``FLMTrioNotAvailable`` raised with the
   plan §5.3 surface message, propagated by the error middleware as a
   503 ``npu.trio_unavailable`` envelope.
2. **``backend_url`` missing / empty / non-string in ``/v1/health``** →
   same 503 envelope (the trio router treats those as "no chat anchor").
3. **Trio model swap mid-request** → the request in flight uses the
   stale ``backend_url`` it discovered; subsequent requests re-discover
   fresh. We never cache ``backend_url`` across calls — that's the
   looser-coupling tradeoff plan §5.3 explicitly accepts.
4. **NPU slot disabled** → ``_is_npu_trio_request`` returns ``False``,
   request flows through the normal dispatcher path. When no fallback
   GPU/CPU embed/stt slot is registered the dispatcher 404s — expected
   behaviour when NPU isn't wired up.

## Files

- ``src/hal0/dispatcher/flm_trio.py`` (NEW, +336 LOC) — ``FLMTrioRouter``
  + ``FLMTrioNotAvailable``.
- ``src/hal0/api/__init__.py`` (+37 LOC) — lifespan wiring next to
  OmniRouter; degrades gracefully when no lemonade client.
- ``src/hal0/api/routes/v1.py`` (+162 LOC) — ``_is_npu_trio_request``
  gating helper, embed-path hook, STT multipart hook,
  ``_wrap_flm_trio_response`` for FastAPI ``Response`` conversion.
- ``tests/dispatcher/test_flm_trio.py`` (NEW, +605 LOC, 26 tests).
- ``tests/api/test_v1_npu_trio_routing.py`` (NEW, +563 LOC, 12 tests).

## References

- Locked plan: ``docs/internal/lemonade-adoption-plan-2026-05-22.md`` §5
  (NPU + FLM trio), §11 PR-19, §3 (service topology).
- ADR-0008 §5 (FLM trio enforcement).
- ADR-0009 (FLM trio NPU packing — entire).
- Memory ``hal0_lemonade_flm_npu_install`` (FLM endpoint shapes).

## Test plan

- [x] ``PYTHONPATH=src .venv/bin/python -m pytest tests/dispatcher/test_flm_trio.py tests/api/test_v1_npu_trio_routing.py -q`` — 38/38 passing locally.
- [x] ``PYTHONPATH=src .venv/bin/python -m pytest tests/ -q`` — 1832 passed / 8 skipped (no new skips; no regressions).
- [x] ``.venv/bin/ruff check src tests`` — clean.
- [x] ``.venv/bin/ruff format --check src tests`` — clean.
- [ ] CI runs the same matrix on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)