### PR TITLE
feat(npu): exclusivity hardening + swap-in-progress UX (PR-20)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -57,6 +57,7 @@ from hal0.api.routes import (
     installer,
     logs,
     models,
+    npu,
     providers,
     settings,
     slots,
@@ -785,6 +786,17 @@ def create_app() -> FastAPI:
         backends_routes.router,
         prefix="/api/backends",
         tags=["backends"],
+        dependencies=_admin_auth,
+    )
+
+    # NPU trio swap-status (PR-20). One read-only endpoint that merges
+    # the configured NPU LLM slot model with lemond's /v1/health.loaded[]
+    # so the dashboard's "Swap incoming" banner has a single source of
+    # truth. Admin-gated alongside the rest of the capability surface.
+    app.include_router(
+        npu.router,
+        prefix="/api/npu",
+        tags=["npu"],
         dependencies=_admin_auth,
     )
 

--- a/src/hal0/api/routes/npu.py
+++ b/src/hal0/api/routes/npu.py
@@ -1,0 +1,78 @@
+"""NPU-specific dashboard endpoints — PR-20.
+
+Mounted under ``/api/npu`` (see :mod:`hal0.api.__init__`):
+
+  - ``GET /api/npu/swap-status`` — returns whether the FLM trio's chat
+    model is currently mid-swap, plus the ``from_model`` / ``to_model``
+    pair when the swap is observable. Polled by the dashboard's NPU
+    block to surface a "Swap incoming" banner + spinner.
+
+Why a dedicated route (not the slot-state SSE stream): the swap-status
+signal needs to merge two unrelated sources (the slot TOML + lemond's
+``/v1/health``). Threading both into the SSE stream would couple the
+slot-state emitter to lemond's HTTP surface; a simple poll endpoint
+keeps the concerns separate and the dashboard's swap banner can re-poll
+every few seconds without holding a long-lived connection open.
+
+The endpoint is read-only and falls back to ``in_progress=false`` on
+every error path (lemond down, no SlotManager, etc.) — the dashboard
+ALREADY surfaces the ``lemond-offline`` banner in the global banner
+stack, so the swap banner re-rendering "no swap" during an outage is
+the correct degrade.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from hal0.dispatcher.npu_swap_status import (
+    NpuSwapStatus,
+    fetch_npu_swap_status,
+)
+
+router = APIRouter()
+
+
+@router.get("/swap-status")
+async def get_swap_status(request: Request) -> dict[str, Any]:
+    """Return the current NPU trio chat-model swap-in-progress snapshot.
+
+    Response shape::
+
+        {
+          "in_progress": bool,
+          "from_model": "gemma3:1b" | null,
+          "to_model":   "llama3.2-3b-npu" | null
+        }
+
+    Always 200. Returns ``in_progress=false`` whenever:
+
+      - No SlotManager / LemonadeClient is wired (test bypass).
+      - No NPU LLM slot is enabled.
+      - Lemonade ``/v1/health`` is unreachable (caught in the helper).
+      - The configured NPU LLM model already matches the loaded one.
+    """
+    sm = getattr(request.app.state, "slot_manager", None)
+    lemonade_client = getattr(request.app.state, "lemonade_client", None)
+
+    if sm is None:
+        # Pre-lifespan / test bypass. Return a stable empty payload so
+        # the dashboard poll never sees a 500 here.
+        return NpuSwapStatus(in_progress=False, from_model=None, to_model=None).to_dict()
+
+    try:
+        slot_configs = await sm.iter_configs()
+    except Exception:
+        # Defensive: a config read error should not propagate to the
+        # status endpoint. iter_configs already swallows individual
+        # malformed TOMLs (see :meth:`SlotManager.iter_configs`); this
+        # catch covers the (unlikely) directory-level failure.
+        slot_configs = []
+
+    status = await fetch_npu_swap_status(slot_configs, lemonade_client)
+    return status.to_dict()
+
+
+__all__ = ["router"]

--- a/src/hal0/dispatcher/npu_swap_status.py
+++ b/src/hal0/dispatcher/npu_swap_status.py
@@ -1,0 +1,237 @@
+"""NPU trio chat-model swap-in-progress detection — PR-20.
+
+When the operator picks a new NPU chat model in the dashboard, the
+underlying FLM trio must:
+
+  1. Persist the new model on the ``device=npu, type=llm`` slot's TOML.
+  2. Issue a ``/v1/load`` against Lemonade with the new model name.
+  3. Lemonade evicts the previous FLM process and spins up a new one.
+  4. The NEW model name appears in ``GET /v1/health.loaded[]``.
+
+Steps (2)→(4) take ~14s on Strix Halo (cold NPU + ASR + embed warm-up
+all together; see plan §5.3, ADR-0009). For the dashboard to render a
+"swap incoming" banner + spinner, hal0 needs a single signal that says
+"this is the swap window".
+
+The signal we publish:
+
+  - capabilities.toml — actually here we read the *slot TOMLs* — has a
+    ``device=npu, type=llm, enabled=true`` slot whose ``model.default``
+    is NOT currently listed in Lemonade's ``loaded[]`` AND there IS at
+    least one other ``recipe=flm`` entry in ``loaded[]`` (i.e., the
+    OLD trio chat is still serving while the new one warms up).
+
+If no FLM is currently loaded at all (``loaded[]`` has no ``recipe=flm``
+entries), this is NOT a swap — it's a fresh first load. The dashboard
+already handles fresh loads via the slot lifecycle dot; we only surface
+the banner when the trio is actually mid-transition.
+
+This module is *pure*: no caching, no side effects. The status endpoint
+calls :func:`compute_npu_swap_status` once per request; the helper reads
+the configured NPU LLM slot list from the SlotManager and the loaded
+list from the LemonadeClient.
+
+Per ADR-0008 §5 + plan §5.3, only one NPU LLM slot may be enabled at a
+time. PR-11's :meth:`hal0.slots.manager.SlotManager._check_npu_exclusivity`
+guards the *write* path; this module observes the *runtime* state.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from hal0.lemonade.errors import LemonadeError
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class NpuSwapStatus:
+    """Snapshot of the NPU trio swap state.
+
+    Attributes:
+        in_progress: True iff the configured NPU LLM model is NOT in
+            Lemonade's ``loaded[]`` AND a different FLM-recipe entry IS
+            loaded (the previous chat model still serving).
+        from_model: The model_name of the currently-loaded FLM chat
+            entry, if any (the "from" side of the swap). ``None`` when
+            no FLM is loaded at all.
+        to_model: The model_name configured on the enabled NPU LLM
+            slot (the "to" side of the swap). ``None`` when no NPU
+            LLM slot is enabled, or when its ``model.default`` is empty.
+    """
+
+    in_progress: bool
+    from_model: str | None
+    to_model: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "in_progress": self.in_progress,
+            "from_model": self.from_model,
+            "to_model": self.to_model,
+        }
+
+
+def _flm_loaded_entries(health: dict[str, Any]) -> list[dict[str, Any]]:
+    """Pull every ``recipe=flm`` entry out of /v1/health.
+
+    Accepts both ``loaded`` and ``all_models_loaded`` keys — same forward-
+    compat dance as :class:`hal0.dispatcher.flm_trio.FLMTrioRouter` —
+    and de-dupes by ``backend_url`` (some Lemonade versions emit the
+    chat under both keys).
+    """
+    seen_urls: set[str] = set()
+    out: list[dict[str, Any]] = []
+    for key in ("loaded", "all_models_loaded"):
+        entries = health.get(key)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("recipe") != "flm":
+                continue
+            url = entry.get("backend_url")
+            url_key = url if isinstance(url, str) else ""
+            if url_key and url_key in seen_urls:
+                continue
+            if url_key:
+                seen_urls.add(url_key)
+            out.append(entry)
+    return out
+
+
+def _enabled_npu_llm_slot(slot_configs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the (at most one) enabled NPU LLM slot config, or None.
+
+    PR-11's exclusivity validation guarantees at most one such slot
+    exists on disk; we walk the list defensively anyway and return the
+    first match. A multi-match would itself be a bug, surfaced upstream
+    by the validator the next time the operator saves.
+    """
+    for cfg in slot_configs:
+        if cfg.get("device") != "npu":
+            continue
+        if cfg.get("type") != "llm":
+            continue
+        if cfg.get("enabled") is False:
+            continue
+        return cfg
+    return None
+
+
+def _slot_model_default(slot_cfg: dict[str, Any]) -> str:
+    """Pull ``model.default`` out of a slot config dict."""
+    model_section = slot_cfg.get("model")
+    if isinstance(model_section, dict):
+        default = model_section.get("default")
+        if isinstance(default, str):
+            return default
+    return ""
+
+
+def compute_npu_swap_status(
+    slot_configs: list[dict[str, Any]],
+    health: dict[str, Any] | None,
+) -> NpuSwapStatus:
+    """Decide whether an NPU chat-model swap is in progress.
+
+    Pure function: every input is an explicit argument so the caller
+    can mock both the slot TOML state and the /v1/health response.
+
+    Args:
+        slot_configs: The list of slot config dicts (as returned by
+            :func:`hal0.api.routes.slots._all_slot_configs` or similar).
+            Only the ``device``, ``type``, ``enabled`` and ``model``
+            keys are read.
+        health: Parsed ``GET /v1/health`` body, or ``None`` when the
+            probe failed. ``None`` is treated as "no FLM loaded" — same
+            as a successful probe that returned an empty ``loaded[]``.
+
+    Returns:
+        :class:`NpuSwapStatus` snapshot. ``in_progress=True`` only when
+        all of:
+
+          - An enabled NPU LLM slot exists.
+          - Its ``model.default`` is set.
+          - At least one ``recipe=flm`` entry is loaded.
+          - That entry's ``model_name`` is *different* from the slot's
+            configured ``model.default``.
+
+        Any other combination (no NPU slot; matching model already
+        loaded; no FLM loaded at all) yields ``in_progress=False``.
+        ``from_model`` / ``to_model`` are populated when known, even
+        when ``in_progress=False`` — the dashboard uses them to render
+        the "current model" string under the chat sub-row.
+    """
+    npu_slot = _enabled_npu_llm_slot(slot_configs)
+    to_model = _slot_model_default(npu_slot) if npu_slot is not None else None
+    if to_model == "":
+        to_model = None
+
+    flm_entries = _flm_loaded_entries(health) if isinstance(health, dict) else []
+    from_model: str | None = None
+    for entry in flm_entries:
+        name = entry.get("model_name")
+        if isinstance(name, str) and name:
+            from_model = name
+            break
+
+    # Not configured, or nothing to swap to → not a swap.
+    if to_model is None:
+        return NpuSwapStatus(in_progress=False, from_model=from_model, to_model=None)
+
+    # Configured + nothing loaded → fresh first load, not a swap.
+    if from_model is None:
+        return NpuSwapStatus(in_progress=False, from_model=None, to_model=to_model)
+
+    # Configured + already loaded the SAME model → steady state.
+    if from_model == to_model:
+        return NpuSwapStatus(in_progress=False, from_model=from_model, to_model=to_model)
+
+    # Configured + an FLM is loaded + that FLM is a DIFFERENT model →
+    # swap window.
+    return NpuSwapStatus(in_progress=True, from_model=from_model, to_model=to_model)
+
+
+async def fetch_npu_swap_status(
+    slot_configs: list[dict[str, Any]],
+    lemonade_client: Any,
+) -> NpuSwapStatus:
+    """Async wrapper that probes ``/v1/health`` and runs the pure helper.
+
+    Catches :class:`hal0.lemonade.errors.LemonadeError` and any other
+    exception from the probe, degrading to ``health=None``. The
+    dashboard NEVER wants a swap-status 503 to cascade — when lemond
+    is unreachable, the global ``lemond-offline`` banner already covers
+    the surface, and the swap banner should fall back to "no swap" so
+    the operator isn't told a swap is in progress while the daemon is
+    down.
+    """
+    health: dict[str, Any] | None = None
+    if lemonade_client is not None:
+        try:
+            probe = await lemonade_client.health()
+            if isinstance(probe, dict):
+                health = probe
+        except LemonadeError as exc:
+            log.debug(
+                "npu_swap.health_unavailable",
+                extra={"error": str(exc), "error_type": type(exc).__name__},
+            )
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning(
+                "npu_swap.health_unexpected_error",
+                extra={"error": str(exc), "error_type": type(exc).__name__},
+            )
+    return compute_npu_swap_status(slot_configs, health)
+
+
+__all__ = [
+    "NpuSwapStatus",
+    "compute_npu_swap_status",
+    "fetch_npu_swap_status",
+]

--- a/tests/dispatcher/test_npu_swap_status.py
+++ b/tests/dispatcher/test_npu_swap_status.py
@@ -1,0 +1,339 @@
+"""NPU trio swap-in-progress detection (PR-20, plan §5.3, ADR-0009).
+
+Tests the pure helper ``compute_npu_swap_status`` and the async
+``fetch_npu_swap_status`` wrapper that probes Lemonade's ``/v1/health``.
+
+The signal we publish: the configured NPU LLM slot's ``model.default``
+is NOT in Lemonade's ``loaded[]`` AND a different ``recipe=flm`` entry
+IS loaded (the old trio chat still serving while the new one warms up).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hal0.dispatcher.npu_swap_status import (
+    NpuSwapStatus,
+    compute_npu_swap_status,
+    fetch_npu_swap_status,
+)
+from hal0.lemonade.errors import LemonadeError
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _flm_loaded(model_name: str, backend_url: str = "http://127.0.0.1:9001") -> dict[str, Any]:
+    return {
+        "model_name": model_name,
+        "backend_url": backend_url,
+        "recipe": "flm",
+        "type": "llm",
+    }
+
+
+def _npu_llm_slot(
+    name: str = "agent",
+    model: str = "llama-3.2-3b-npu",
+    enabled: bool = True,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "device": "npu",
+        "type": "llm",
+        "enabled": enabled,
+        "model": {"default": model},
+    }
+
+
+def _gpu_slot(name: str = "primary", model: str = "phi3") -> dict[str, Any]:
+    return {
+        "name": name,
+        "device": "gpu-vulkan",
+        "type": "llm",
+        "enabled": True,
+        "model": {"default": model},
+    }
+
+
+# ── compute_npu_swap_status — pure helper ──────────────────────────────
+
+
+def test_no_npu_slot_means_no_swap() -> None:
+    """Nothing configured → swap is not in progress."""
+    status = compute_npu_swap_status(
+        slot_configs=[_gpu_slot()],
+        health={"loaded": []},
+    )
+    assert status == NpuSwapStatus(in_progress=False, from_model=None, to_model=None)
+
+
+def test_disabled_npu_slot_ignored() -> None:
+    """A disabled NPU LLM slot doesn't drive a swap."""
+    status = compute_npu_swap_status(
+        slot_configs=[_npu_llm_slot(enabled=False)],
+        health={"loaded": []},
+    )
+    assert status.in_progress is False
+    assert status.to_model is None
+
+
+def test_npu_configured_but_nothing_loaded_is_not_swap() -> None:
+    """Configured + nothing in loaded[] = fresh first load, not a swap."""
+    status = compute_npu_swap_status(
+        slot_configs=[_npu_llm_slot(model="llama-3.2-3b-npu")],
+        health={"loaded": []},
+    )
+    assert status.in_progress is False
+    assert status.to_model == "llama-3.2-3b-npu"
+    assert status.from_model is None
+
+
+def test_npu_same_model_loaded_is_steady_state() -> None:
+    """Configured matches the loaded FLM → steady state."""
+    status = compute_npu_swap_status(
+        slot_configs=[_npu_llm_slot(model="gemma3:1b")],
+        health={"loaded": [_flm_loaded("gemma3:1b")]},
+    )
+    assert status.in_progress is False
+    assert status.from_model == "gemma3:1b"
+    assert status.to_model == "gemma3:1b"
+
+
+def test_npu_different_model_loaded_is_swap() -> None:
+    """Configured != loaded FLM → swap in progress."""
+    status = compute_npu_swap_status(
+        slot_configs=[_npu_llm_slot(model="llama-3.2-3b-npu")],
+        health={"loaded": [_flm_loaded("gemma3:1b")]},
+    )
+    assert status.in_progress is True
+    assert status.from_model == "gemma3:1b"
+    assert status.to_model == "llama-3.2-3b-npu"
+
+
+def test_swap_in_progress_with_gpu_peers_present() -> None:
+    """Non-NPU peer slots don't affect the swap signal."""
+    status = compute_npu_swap_status(
+        slot_configs=[
+            _gpu_slot(name="primary", model="phi3"),
+            _npu_llm_slot(name="agent", model="llama-3.2-3b-npu"),
+            _gpu_slot(name="nano", model="qwen3-1b"),
+        ],
+        health={"loaded": [_flm_loaded("gemma3:1b")]},
+    )
+    assert status.in_progress is True
+    assert status.from_model == "gemma3:1b"
+    assert status.to_model == "llama-3.2-3b-npu"
+
+
+def test_non_flm_loaded_entries_ignored() -> None:
+    """A llama.cpp entry in loaded[] does NOT count as the trio chat."""
+    status = compute_npu_swap_status(
+        slot_configs=[_npu_llm_slot(model="llama-3.2-3b-npu")],
+        health={
+            "loaded": [
+                {
+                    "model_name": "phi3",
+                    "backend_url": "http://127.0.0.1:9002",
+                    "recipe": "llamacpp",
+                    "type": "llm",
+                },
+            ],
+        },
+    )
+    # No FLM loaded → not a swap, just a pending first load.
+    assert status.in_progress is False
+    assert status.from_model is None
+    assert status.to_model == "llama-3.2-3b-npu"
+
+
+def test_alt_health_key_all_models_loaded() -> None:
+    """Forward-compat: ``all_models_loaded`` also recognised."""
+    status = compute_npu_swap_status(
+        slot_configs=[_npu_llm_slot(model="llama-3.2-3b-npu")],
+        health={"all_models_loaded": [_flm_loaded("gemma3:1b")]},
+    )
+    assert status.in_progress is True
+
+
+def test_health_none_means_no_swap() -> None:
+    """Health=None (lemond unreachable) degrades to no-swap."""
+    status = compute_npu_swap_status(
+        slot_configs=[_npu_llm_slot(model="llama-3.2-3b-npu")],
+        health=None,
+    )
+    assert status.in_progress is False
+    assert status.from_model is None
+    assert status.to_model == "llama-3.2-3b-npu"
+
+
+def test_empty_slot_model_default_means_no_swap() -> None:
+    """NPU LLM slot with empty model.default → no to_model, no swap."""
+    cfg = _npu_llm_slot()
+    cfg["model"] = {"default": ""}
+    status = compute_npu_swap_status(
+        slot_configs=[cfg],
+        health={"loaded": [_flm_loaded("gemma3:1b")]},
+    )
+    assert status.in_progress is False
+    assert status.to_model is None
+
+
+def test_missing_model_section_means_no_swap() -> None:
+    """NPU LLM slot missing the [model] section entirely → no to_model."""
+    cfg = {
+        "name": "agent",
+        "device": "npu",
+        "type": "llm",
+        "enabled": True,
+    }
+    status = compute_npu_swap_status(
+        slot_configs=[cfg],
+        health={"loaded": [_flm_loaded("gemma3:1b")]},
+    )
+    assert status.in_progress is False
+    assert status.to_model is None
+
+
+def test_malformed_entries_skipped() -> None:
+    """Non-dict entries in loaded[] don't crash the walker."""
+    status = compute_npu_swap_status(
+        slot_configs=[_npu_llm_slot(model="llama-3.2-3b-npu")],
+        health={"loaded": ["not-a-dict", None, _flm_loaded("gemma3:1b")]},
+    )
+    assert status.in_progress is True
+    assert status.from_model == "gemma3:1b"
+
+
+def test_to_dict_shape() -> None:
+    """NpuSwapStatus.to_dict matches the wire shape."""
+    status = NpuSwapStatus(
+        in_progress=True,
+        from_model="gemma3:1b",
+        to_model="llama-3.2-3b-npu",
+    )
+    assert status.to_dict() == {
+        "in_progress": True,
+        "from_model": "gemma3:1b",
+        "to_model": "llama-3.2-3b-npu",
+    }
+
+
+# ── fetch_npu_swap_status — async wrapper ──────────────────────────────
+
+
+async def test_fetch_swallows_lemonade_error() -> None:
+    """When lemond is unreachable, fetch degrades to no-swap."""
+    client = AsyncMock()
+    client.health = AsyncMock(side_effect=LemonadeError("connection refused"))
+
+    status = await fetch_npu_swap_status(
+        slot_configs=[_npu_llm_slot(model="llama-3.2-3b-npu")],
+        lemonade_client=client,
+    )
+    assert status.in_progress is False
+    assert status.from_model is None
+    assert status.to_model == "llama-3.2-3b-npu"
+
+
+async def test_fetch_with_none_client() -> None:
+    """No lemonade client wired → degrades to no-swap."""
+    status = await fetch_npu_swap_status(
+        slot_configs=[_npu_llm_slot(model="llama-3.2-3b-npu")],
+        lemonade_client=None,
+    )
+    assert status.in_progress is False
+    assert status.to_model == "llama-3.2-3b-npu"
+
+
+async def test_fetch_returns_swap_when_health_reports_old_model() -> None:
+    """Happy path: live /v1/health reports the prior chat, slot points at new."""
+    client = AsyncMock()
+    client.health = AsyncMock(return_value={"loaded": [_flm_loaded("gemma3:1b")]})
+    status = await fetch_npu_swap_status(
+        slot_configs=[_npu_llm_slot(model="llama-3.2-3b-npu")],
+        lemonade_client=client,
+    )
+    assert status.in_progress is True
+    assert status.from_model == "gemma3:1b"
+    assert status.to_model == "llama-3.2-3b-npu"
+
+
+async def test_fetch_swallows_unexpected_error() -> None:
+    """Defensive: any non-LemonadeError from .health() also degrades."""
+    client = AsyncMock()
+    client.health = AsyncMock(side_effect=RuntimeError("nginx hiccup"))
+    status = await fetch_npu_swap_status(
+        slot_configs=[_npu_llm_slot(model="llama-3.2-3b-npu")],
+        lemonade_client=client,
+    )
+    assert status.in_progress is False
+
+
+async def test_fetch_handles_non_dict_health_body() -> None:
+    """If lemond returns a list (malformed), treat as no-swap."""
+    client = AsyncMock()
+    client.health = AsyncMock(return_value=["unexpected", "shape"])
+    status = await fetch_npu_swap_status(
+        slot_configs=[_npu_llm_slot(model="llama-3.2-3b-npu")],
+        lemonade_client=client,
+    )
+    assert status.in_progress is False
+
+
+# ── HTTP route smoke test ──────────────────────────────────────────────
+
+
+def test_swap_status_endpoint_returns_default_shape(client: Any) -> None:
+    """GET /api/npu/swap-status returns the shape even with no NPU configured."""
+    resp = client.get("/api/npu/swap-status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"in_progress", "from_model", "to_model"}
+    assert body["in_progress"] is False
+
+
+def test_swap_status_endpoint_observes_npu_slot(
+    client: Any,
+    tmp_hal0_home: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When an NPU LLM slot is configured and lemond reports a different
+    FLM as loaded, the endpoint surfaces in_progress=True.
+
+    Seeds a slot TOML on disk so SlotManager.iter_configs() picks it up;
+    patches the lifespan-wired LemonadeClient.health() with a fake.
+    """
+    from pathlib import Path
+
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "agent.toml").write_text(
+        'name = "agent"\n'
+        "port = 8092\n"
+        'device = "npu"\n'
+        'type = "llm"\n'
+        "enabled = true\n"
+        'backend = "flm"\n'
+        "[model]\n"
+        'default = "llama-3.2-3b-npu"\n',
+        encoding="utf-8",
+    )
+
+    # Patch app.state.lemonade_client.health for this request only.
+    app = client.app
+    fake_client = AsyncMock()
+    fake_client.health = AsyncMock(return_value={"loaded": [_flm_loaded("gemma3:1b")]})
+    monkeypatch.setattr(app.state, "lemonade_client", fake_client)
+
+    resp = client.get("/api/npu/swap-status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["in_progress"] is True
+    assert body["from_model"] == "gemma3:1b"
+    assert body["to_model"] == "llama-3.2-3b-npu"
+
+
+__all__ = []

--- a/ui/src/components/slots/EditSlotDrawer.vue
+++ b/ui/src/components/slots/EditSlotDrawer.vue
@@ -17,6 +17,7 @@
  */
 import { computed, ref, watch } from 'vue'
 import Drawer from '../primitives/Drawer.vue'
+import ConfirmDialog from '../ConfirmDialog.vue'
 import { api } from '../../composables/useApi.js'
 import { useToastsStore } from '../../stores/toasts.js'
 
@@ -82,6 +83,32 @@ const changedFields = computed(() => {
 
 const isLive = computed(() => !!(props.slot && RUNNING_STATES.has(props.slot.status)))
 
+// PR-20: NPU chat-model swap is destructive — the FLM trio tears down
+// the current process and rewarms for ~14s, pausing voice + embed
+// passengers in the same window. Detect that combination so save()
+// can route through a confirmation modal before kicking off the swap.
+const isNpuLlmSlot = computed(() => {
+  const s = props.slot
+  if (!s) return false
+  const device = String(s.device || '').toLowerCase()
+  const backend = String(s.backend || '').toLowerCase()
+  const isNpu = device === 'npu' || backend === 'flm' || backend === 'npu'
+  const type = String(s.type || s.kind || '').toLowerCase()
+  const isLlm = ['llm', 'llama-server', 'flm'].includes(type)
+  return isNpu && isLlm
+})
+
+const isNpuChatSwap = computed(() => {
+  if (!isNpuLlmSlot.value) return false
+  const ch = changedFields.value
+  // The trio swap penalty fires whenever the chat model changes; we
+  // surface the modal even if the user also tweaked secondary fields
+  // in the same save, since the trio still reboots.
+  return ch.has('model') && !!form.value.model
+})
+
+const confirmOpen = ref(false)
+
 // Effective flags preview — fully read-only, mirrors slot-modals.jsx's strip.
 const effectiveFlags = computed(() => {
   const baseline = '--parallel 1 --threads 8'
@@ -93,6 +120,28 @@ const effectiveFlags = computed(() => {
 })
 
 async function save() {
+  if (!props.slot) return
+  const ch = changedFields.value
+  if (ch.size === 0) {
+    emit('close')
+    return
+  }
+  // PR-20: NPU chat-model swap is destructive — pop the confirmation
+  // modal before letting the POST land. The modal's Confirm button
+  // calls doSave() directly.
+  if (isNpuChatSwap.value) {
+    confirmOpen.value = true
+    return
+  }
+  await doSave()
+}
+
+async function confirmNpuSwap() {
+  confirmOpen.value = false
+  await doSave()
+}
+
+async function doSave() {
   if (!props.slot) return
   saving.value = true
   try {
@@ -282,6 +331,22 @@ const canDelete = computed(() => props.slot && !BUILTIN_SLOTS.has(props.slot.nam
       </span>
     </template>
   </Drawer>
+
+  <!-- PR-20: NPU chat-model swap confirmation. The trio's ASR + embed
+       passengers go offline for ~14s while FLM rewarms, so we ask
+       before kicking the swap. -->
+  <ConfirmDialog
+    :open="confirmOpen"
+    title="Swap NPU chat model?"
+    :message="`Swapping the NPU chat model unloads the current FLM process. ASR (transcription) and embed slots backed by the same trio will briefly be unavailable while FLM rewarms (~14s).`"
+    confirm-label="Swap now"
+    :danger="false"
+    :loading="saving"
+    data-testid="npu-swap-confirm"
+    @update:open="(v) => (confirmOpen = v)"
+    @confirm="confirmNpuSwap"
+    @cancel="confirmOpen = false"
+  />
 </template>
 
 <style scoped>

--- a/ui/src/components/slots/NpuBlock.vue
+++ b/ui/src/components/slots/NpuBlock.vue
@@ -17,9 +17,22 @@ import { computed } from 'vue'
 const props = defineProps({
   /** All NPU-backed slots, in trio order: chat (llm) first, then passengers. */
   slots: { type: Array, required: true },
+  /**
+   * Optional NPU swap-in-progress signal from /api/npu/swap-status.
+   * Shape: `{ in_progress, from_model, to_model }`. When `in_progress`
+   * is true, the chat sub-row swaps its static label for a spinner +
+   * "Loading <to_model>..." line. PR-20 / plan §5.3 / ADR-0009.
+   */
+  swapStatus: {
+    type: Object,
+    default: () => ({ in_progress: false, from_model: null, to_model: null }),
+  },
 })
 
 const emit = defineEmits(['swap-chat'])
+
+const swapInProgress = computed(() => !!props.swapStatus?.in_progress)
+const swapTargetModel = computed(() => props.swapStatus?.to_model || '')
 
 const chat = computed(() => props.slots.find((s) => deviceOf(s) === 'npu' && typeOf(s) === 'llm'))
 const stt  = computed(() => props.slots.find((s) => deviceOf(s) === 'npu' && typeOf(s) === 'transcription'))
@@ -68,25 +81,33 @@ const headerSub = computed(() => {
 
     <div class="npu-body">
       <!-- Chat (lead) -->
-      <div v-if="chat" class="npu-subrow lead">
-        <span class="dot ready" />
+      <div v-if="chat" class="npu-subrow lead" :class="{ 'npu-subrow-swapping': swapInProgress }" data-testid="npu-chat-row">
+        <span class="dot" :class="swapInProgress ? 'loading' : 'ready'" />
         <div class="role mono">
           {{ chat.name }}
           <span class="sub">llm · default</span>
         </div>
         <div class="model mono">
-          <span class="m-text">{{ modelOf(chat) || 'no model' }}</span>
-          <button class="chev-btn" type="button" @click="emit('swap-chat', chat)" title="Swap chat model">
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6"/>
-            </svg>
-          </button>
+          <template v-if="swapInProgress">
+            <span class="spinner" aria-hidden="true" />
+            <span class="m-text" data-testid="npu-swap-progress">Loading {{ swapTargetModel || 'new model' }}…</span>
+          </template>
+          <template v-else>
+            <span class="m-text">{{ modelOf(chat) || 'no model' }}</span>
+            <button class="chev-btn" type="button" @click="emit('swap-chat', chat)" title="Swap chat model">
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6"/>
+              </svg>
+            </button>
+          </template>
         </div>
         <div class="met mono">
-          <span><b>{{ (metricsOf(chat).toks ?? metricsOf(chat).tokens_per_sec ?? 0).toFixed?.(0) ?? '0' }}</b> tok/s · TTFT <b>{{ metricsOf(chat).ttft ?? '—' }}</b>ms · KV <b>{{ metricsOf(chat).kv ?? '—' }}</b>%</span>
+          <span v-if="swapInProgress" class="dim">awaiting trio reload</span>
+          <span v-else><b>{{ (metricsOf(chat).toks ?? metricsOf(chat).tokens_per_sec ?? 0).toFixed?.(0) ?? '0' }}</b> tok/s · TTFT <b>{{ metricsOf(chat).ttft ?? '—' }}</b>ms · KV <b>{{ metricsOf(chat).kv ?? '—' }}</b>%</span>
         </div>
         <div class="st">
-          <span class="chip chip-ok">ready · default</span>
+          <span v-if="swapInProgress" class="chip chip-warn">swapping</span>
+          <span v-else class="chip chip-ok">ready · default</span>
         </div>
       </div>
 
@@ -268,4 +289,29 @@ const headerSub = computed(() => {
   border-color: rgba(200, 150, 255, 0.30);
   background: rgba(200, 150, 255, 0.06);
 }
+.chip.chip-warn {
+  color: var(--color-warn, #f4b942);
+  border-color: color-mix(in oklch, var(--color-warn, #f4b942), transparent 60%);
+  background: color-mix(in oklch, var(--color-warn, #f4b942), transparent 88%);
+}
+.dot.loading {
+  background: var(--color-warn, #f4b942);
+  box-shadow: 0 0 6px var(--color-warn, #f4b942);
+  animation: npu-pulse 1.4s ease-in-out infinite;
+}
+@keyframes npu-pulse {
+  0%, 100% { opacity: 0.5; }
+  50%      { opacity: 1.0; }
+}
+.npu-subrow-swapping { background: color-mix(in oklch, var(--color-warn, #f4b942), transparent 95%); }
+.npu-subrow .model .spinner {
+  width: 11px; height: 11px;
+  border: 2px solid color-mix(in oklch, var(--color-warn, #f4b942), transparent 60%);
+  border-top-color: var(--color-warn, #f4b942);
+  border-radius: 50%;
+  animation: npu-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+@keyframes npu-spin { to { transform: rotate(360deg); } }
+.dim { color: var(--color-fg-faint); }
 </style>

--- a/ui/src/components/slots/NpuReactor.vue
+++ b/ui/src/components/slots/NpuReactor.vue
@@ -12,9 +12,20 @@ const props = defineProps({
   slots: { type: Array, required: true },
   flmVersion: { type: String, default: 'v0.9.42' },
   flmArgs: { type: String, default: '--asr 1 --embed 1' },
+  /**
+   * Optional NPU swap-in-progress signal — see NpuBlock.vue for the
+   * full contract. PR-20 / plan §5.3.
+   */
+  swapStatus: {
+    type: Object,
+    default: () => ({ in_progress: false, from_model: null, to_model: null }),
+  },
 })
 
 const emit = defineEmits(['swap-chat'])
+
+const swapInProgress = computed(() => !!props.swapStatus?.in_progress)
+const swapTargetModel = computed(() => props.swapStatus?.to_model || '')
 
 function deviceOf(s) { return s?.device || 'npu' }
 function typeOf(s) {
@@ -62,16 +73,25 @@ const dormant = computed(() => !chat.value || !modelOf(chat.value))
       </div>
 
       <div class="reactor-roles">
-        <div v-if="chat" class="reactor-role lead">
-          <span class="dot ready" />
+        <div v-if="chat" class="reactor-role lead" :class="{ 'reactor-role-swapping': swapInProgress }" data-testid="npu-chat-row">
+          <span class="dot" :class="swapInProgress ? 'loading' : 'ready'" />
           <div class="lbl">
             {{ chat.name }}
             <span class="sub">chat · llm · default</span>
           </div>
-          <div class="md">{{ modelOf(chat) || 'no model' }}</div>
+          <div v-if="swapInProgress" class="md md-swap">
+            <span class="spinner" aria-hidden="true" />
+            <span data-testid="npu-swap-progress">Loading {{ swapTargetModel || 'new model' }}…</span>
+          </div>
+          <div v-else class="md">{{ modelOf(chat) || 'no model' }}</div>
           <div class="met">
-            <div><b>{{ (metricsOf(chat).toks ?? metricsOf(chat).tokens_per_sec ?? 0).toFixed?.(0) ?? '0' }}</b> tok/s</div>
-            <div class="dim">KV {{ metricsOf(chat).kv ?? '—' }}%</div>
+            <template v-if="swapInProgress">
+              <div class="dim">awaiting trio reload</div>
+            </template>
+            <template v-else>
+              <div><b>{{ (metricsOf(chat).toks ?? metricsOf(chat).tokens_per_sec ?? 0).toFixed?.(0) ?? '0' }}</b> tok/s</div>
+              <div class="dim">KV {{ metricsOf(chat).kv ?? '—' }}%</div>
+            </template>
           </div>
         </div>
 
@@ -261,4 +281,26 @@ const dormant = computed(() => !chat.value || !modelOf(chat.value))
   width: 5px; height: 5px; border-radius: 50%;
   background: currentColor; box-shadow: 0 0 4px currentColor;
 }
+.dot.loading {
+  background: var(--color-warn, #f4b942);
+  box-shadow: 0 0 6px var(--color-warn, #f4b942);
+  animation: reactor-pulse 1.4s ease-in-out infinite;
+}
+@keyframes reactor-pulse {
+  0%, 100% { opacity: 0.5; }
+  50%      { opacity: 1.0; }
+}
+.reactor-role.reactor-role-swapping {
+  border-color: color-mix(in oklch, var(--color-warn, #f4b942), transparent 60%);
+}
+.md.md-swap { display: flex; align-items: center; gap: 7px; color: var(--color-fg-muted); }
+.reactor-role .spinner {
+  width: 11px; height: 11px;
+  border: 2px solid color-mix(in oklch, var(--color-warn, #f4b942), transparent 60%);
+  border-top-color: var(--color-warn, #f4b942);
+  border-radius: 50%;
+  animation: reactor-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+@keyframes reactor-spin { to { transform: rotate(360deg); } }
 </style>

--- a/ui/src/composables/useNpuSwapStatus.js
+++ b/ui/src/composables/useNpuSwapStatus.js
@@ -1,0 +1,87 @@
+/**
+ * useNpuSwapStatus — poll /api/npu/swap-status and reflect into the
+ * slots-scoped banner store.
+ *
+ * Background — PR-20 / plan §5.3 / ADR-0009:
+ *   When the operator picks a new NPU chat model the FLM trio must
+ *   tear down the current process and warm a new one. Lemonade's
+ *   /v1/health returns the prior model in ``loaded[]`` for ~14s while
+ *   the new model loads. This composable polls a hal0-side merge of
+ *   the slot TOML state + lemond health snapshot so the dashboard can
+ *   surface a single "Swap incoming" banner during that window.
+ *
+ * Polling cadence — 2s. Trades off latency (banner appears within 2s
+ * of swap start) against load on lemond /v1/health (single GET per
+ * tick, identical to the other dashboard pollers). The banner uses
+ * the `npu-swap` catalog entry; copy is overridden per poll to carry
+ * the live ``from_model`` → ``to_model`` strings.
+ *
+ * Caller contract — call once from Slots.vue's onMounted. Returns a
+ * reactive ``status`` ref + the disconnect handle for unmount cleanup.
+ * The composable owns the banner show/dismiss lifecycle; the caller
+ * does not need to wire anything else.
+ */
+import { onUnmounted, ref } from 'vue'
+import { api } from './useApi.js'
+import { useBannerStore } from '../stores/banner.js'
+
+const POLL_INTERVAL_MS = 2000
+const BANNER_ID = 'npu-swap'
+
+export function useNpuSwapStatus({ intervalMs = POLL_INTERVAL_MS } = {}) {
+  const banners = useBannerStore()
+  const status = ref({ in_progress: false, from_model: null, to_model: null })
+  let timer = null
+  let stopped = false
+
+  async function poll() {
+    try {
+      const body = await api('/api/npu/swap-status')
+      // Defensive: every miss degrades to "no swap" so the banner never
+      // sticks on a transient error.
+      const next = {
+        in_progress: !!body?.in_progress,
+        from_model: body?.from_model ?? null,
+        to_model: body?.to_model ?? null,
+      }
+      status.value = next
+      if (next.in_progress) {
+        banners.show(BANNER_ID, {
+          heading: `Swapping NPU chat: ${next.from_model || '—'} → ${next.to_model || '—'}`,
+          body: 'Voice + embed paused while FLM restarts. Coresident slots will resume automatically.',
+        })
+      } else if (banners.isActive(BANNER_ID)) {
+        banners.dismiss(BANNER_ID)
+      }
+    } catch (_err) {
+      // Network blip / 5xx — treat as "no swap" but DON'T flap the
+      // banner away on a single failed poll if it was already up. The
+      // next successful poll will reconcile.
+      status.value = { in_progress: false, from_model: null, to_model: null }
+    }
+  }
+
+  async function start() {
+    if (timer != null) return
+    await poll()
+    timer = setInterval(() => {
+      if (stopped) return
+      void poll()
+    }, intervalMs)
+  }
+
+  function stop() {
+    stopped = true
+    if (timer != null) {
+      clearInterval(timer)
+      timer = null
+    }
+    // Clean up our banner on unmount so a stale "swap incoming" doesn't
+    // linger when the view changes.
+    if (banners.isActive(BANNER_ID)) banners.dismiss(BANNER_ID)
+  }
+
+  onUnmounted(stop)
+
+  return { status, start, stop, poll }
+}

--- a/ui/src/views/Slots.vue
+++ b/ui/src/views/Slots.vue
@@ -30,6 +30,7 @@ import { useTweaksStore } from '../stores/tweaks.js'
 import { useBannerStore } from '../stores/banner.js'
 import { useSlotMetrics } from '../composables/useStats.js'
 import { useEvents } from '../composables/useEvents.js'
+import { useNpuSwapStatus } from '../composables/useNpuSwapStatus.js'
 import { api } from '../composables/useApi.js'
 import BannerStack from '../components/primitives/BannerStack.vue'
 import SlotCard from '../components/SlotCard.vue'
@@ -180,6 +181,11 @@ function openCreateForSeed(seed) {
 // ── NPU variant from tweaks ───────────────────────────────────────────
 const npuVariant = computed(() => tweaks.npuVariant)
 
+// ── NPU trio swap-in-progress (PR-20) ─────────────────────────────────
+// Owns the `npu-swap` banner lifecycle + a `status` ref the NPU block
+// reads to render the spinner over the chat sub-row.
+const { status: npuSwapStatus, start: startNpuSwapPoll } = useNpuSwapStatus()
+
 // ── Lifecycle actions ─────────────────────────────────────────────────
 async function slotAction(slotName, action, body = null) {
   actionBusy.value[slotName] = action
@@ -242,6 +248,7 @@ onMounted(() => {
   window.addEventListener('keydown', handleKey)
   Promise.all([loadModels(), loadHardware()])
   if (system.slots.length === 0) system.fetchStatus()
+  startNpuSwapPoll()
 })
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', handleKey)
@@ -447,6 +454,7 @@ function errorFor(slot) {
         <component
           :is="npuVariant === 'reactor' ? NpuReactor : NpuBlock"
           :slots="grouped.npu"
+          :swap-status="npuSwapStatus"
           @swap-chat="(s) => openEdit(s)"
         />
       </section>

--- a/ui/tests/e2e/specs/npu-swap-ux.spec.ts
+++ b/ui/tests/e2e/specs/npu-swap-ux.spec.ts
@@ -1,0 +1,245 @@
+/**
+ * npu-swap-ux.spec.ts — PR-20 / plan §5.3 / ADR-0009.
+ *
+ * Covers the dashboard surface for the NPU trio chat-model swap:
+ *
+ *   1. Banner `npu-swap` appears when /api/npu/swap-status reports
+ *      in_progress=true.
+ *   2. Banner auto-dismisses when the status flips back to in_progress=false.
+ *   3. Spinner + "Loading <to_model>…" line takes over the NPU chat sub-row
+ *      while the swap is in progress.
+ *   4. Editing the NPU LLM slot's model and saving → confirmation modal.
+ *      Cancel keeps the form open; Confirm POSTs to /swap.
+ *   5. Two-enabled NPU LLM refusal (PR-11 case) — covered by the
+ *      backend slot-manager test suite; here we just assert the
+ *      dashboard surfaces a 409 envelope without crashing.
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+
+/** Seed an NPU trio (chat + stt + embed) into mockState. */
+function seedNpuTrio(mockState: any) {
+  mockState.status.slots = [
+    {
+      name: 'agent',
+      kind: 'flm',
+      type: 'llm',
+      backend: 'flm',
+      device: 'npu',
+      model: 'llama-3.2-3b-npu',
+      port: 8092,
+      status: 'ready',
+      coresident_group: 'npu-flm-trio',
+      group: 'npu',
+    },
+    {
+      name: 'stt-npu',
+      kind: 'transcription',
+      backend: 'flm',
+      device: 'npu',
+      model: 'whisper-int8',
+      status: 'ready',
+      coresident_group: 'npu-flm-trio',
+      group: 'npu',
+    },
+    {
+      name: 'embed-npu',
+      kind: 'embedding',
+      backend: 'flm',
+      device: 'npu',
+      model: 'bge-npu',
+      status: 'ready',
+      coresident_group: 'npu-flm-trio',
+      group: 'npu',
+    },
+  ]
+}
+
+test('banner + spinner render when swap-status reports in_progress', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  seedNpuTrio(mockState)
+
+  // Mid-swap: lemond still has gemma3 loaded, slot points at llama-3.2-3b-npu.
+  await page.route('**/api/npu/swap-status', (route) =>
+    json(route, {
+      in_progress: true,
+      from_model: 'gemma3:1b',
+      to_model: 'llama-3.2-3b-npu',
+    }),
+  )
+
+  await page.goto('/slots')
+
+  // Banner surface — matches the `npu-swap` catalog entry.
+  const banner = page.locator('[data-banner-id="npu-swap"]')
+  await expect(banner).toBeVisible()
+  await expect(banner).toContainText('gemma3:1b')
+  await expect(banner).toContainText('llama-3.2-3b-npu')
+
+  // Spinner takes over the NPU chat sub-row.
+  const chatRow = page.getByTestId('npu-chat-row')
+  await expect(chatRow).toBeVisible()
+  const progress = page.getByTestId('npu-swap-progress')
+  await expect(progress).toBeVisible()
+  await expect(progress).toContainText('Loading llama-3.2-3b-npu')
+})
+
+test('banner auto-dismisses when swap-status flips back to false', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  seedNpuTrio(mockState)
+
+  let inProgress = true
+  await page.route('**/api/npu/swap-status', (route) =>
+    json(route, {
+      in_progress: inProgress,
+      from_model: inProgress ? 'gemma3:1b' : null,
+      to_model: 'llama-3.2-3b-npu',
+    }),
+  )
+
+  await page.goto('/slots')
+
+  const banner = page.locator('[data-banner-id="npu-swap"]')
+  await expect(banner).toBeVisible()
+
+  // Flip the mock back to "no swap" and wait for the next poll tick.
+  inProgress = false
+
+  // Poll cadence is 2s — give the next tick 4s headroom for CI jitter.
+  await expect(banner).toHaveCount(0, { timeout: 6000 })
+  // The chat sub-row's spinner should also be gone.
+  await expect(page.getByTestId('npu-swap-progress')).toHaveCount(0)
+})
+
+test('intentional NPU chat-model swap pops the confirmation modal', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  seedNpuTrio(mockState)
+  mockState.models = [
+    { id: 'llama-3.2-3b-npu', name: 'llama-3.2-3b-npu', backends: ['flm'] },
+    { id: 'gemma3:1b',        name: 'gemma3:1b',        backends: ['flm'] },
+  ]
+  // Default: no swap.
+  await page.route('**/api/npu/swap-status', (route) =>
+    json(route, { in_progress: false, from_model: null, to_model: null }),
+  )
+  // Capture the /swap POST so the test can assert it only fires after Confirm.
+  let swapCalls = 0
+  await page.route('**/api/slots/agent/swap', (route) => {
+    swapCalls += 1
+    return json(route, { ok: true })
+  })
+
+  await page.goto('/slots/agent')
+
+  const drawer = page.locator('[aria-labelledby="edit-slot-title"]')
+  await expect(drawer).toBeVisible()
+
+  // Change the model select to the new chat model.
+  await page.locator('#edit-slot-model').selectOption('gemma3:1b')
+
+  // Click Save — should NOT POST yet; should open the confirmation modal.
+  await drawer.getByRole('button', { name: /^Save/ }).click()
+
+  const modal = page.locator('[role="dialog"]', { hasText: /Swap NPU chat model/ })
+  await expect(modal).toBeVisible()
+  expect(swapCalls).toBe(0)
+})
+
+test('cancel on the swap modal leaves the form intact and does not POST', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  seedNpuTrio(mockState)
+  mockState.models = [
+    { id: 'llama-3.2-3b-npu', name: 'llama-3.2-3b-npu', backends: ['flm'] },
+    { id: 'gemma3:1b',        name: 'gemma3:1b',        backends: ['flm'] },
+  ]
+  await page.route('**/api/npu/swap-status', (route) =>
+    json(route, { in_progress: false, from_model: null, to_model: null }),
+  )
+  let swapCalls = 0
+  await page.route('**/api/slots/agent/swap', (route) => {
+    swapCalls += 1
+    return json(route, { ok: true })
+  })
+
+  await page.goto('/slots/agent')
+
+  await page.locator('#edit-slot-model').selectOption('gemma3:1b')
+  await page.locator('[aria-labelledby="edit-slot-title"]')
+    .getByRole('button', { name: /^Save/ }).click()
+
+  const modal = page.locator('[role="dialog"]', { hasText: /Swap NPU chat model/ })
+  await expect(modal).toBeVisible()
+
+  await modal.getByRole('button', { name: /Cancel/ }).click()
+  await expect(modal).toHaveCount(0)
+  expect(swapCalls).toBe(0)
+
+  // Form should still hold the user's pending selection.
+  await expect(page.locator('#edit-slot-model')).toHaveValue('gemma3:1b')
+})
+
+test('two-enabled NPU LLM rejection — 409 envelope surfaces as toast', async ({
+  page,
+  mockState,
+  cleanState,
+}) => {
+  // PR-11 backend test suite covers the actual SlotManager refusal; here
+  // we simulate the envelope coming back through the config-PUT path
+  // and verify the dashboard renders it as a toast instead of crashing.
+  seedNpuTrio(mockState)
+  mockState.models = [
+    { id: 'llama-3.2-3b-npu', name: 'llama-3.2-3b-npu', backends: ['flm'] },
+    { id: 'gemma3:1b',        name: 'gemma3:1b',        backends: ['flm'] },
+  ]
+  await page.route('**/api/npu/swap-status', (route) =>
+    json(route, { in_progress: false, from_model: null, to_model: null }),
+  )
+
+  // Force the swap POST to return the PR-11 envelope.
+  await page.route('**/api/slots/agent/swap', (route) =>
+    route.fulfill({
+      status: 409,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        error: {
+          code: 'slot.npu_exclusivity_violation',
+          message:
+            "only one NPU LLM slot may be enabled at a time " +
+            "(slot 'agent' would conflict with 'agent-2')",
+          details: { slot: 'agent', conflicting_slots: ['agent-2'] },
+        },
+      }),
+    }),
+  )
+
+  await page.goto('/slots/agent')
+
+  // Slot's current model is llama-3.2-3b-npu; pick a different one so the
+  // model field is actually CHANGED and the save path is triggered.
+  await page.locator('#edit-slot-model').selectOption('gemma3:1b')
+  await page.locator('[aria-labelledby="edit-slot-title"]')
+    .getByRole('button', { name: /^Save/ }).click()
+
+  // Confirm the swap — should fire the POST → 409 → toast.
+  const modal = page.locator('[role="dialog"]', { hasText: /Swap NPU chat model/ })
+  await expect(modal).toBeVisible()
+  await modal.getByRole('button', { name: /Swap now/ }).click()
+
+  // The toast surface carries the conflict message — the dashboard
+  // doesn't crash, the drawer closes, and the user can correct.
+  const toast = page.locator('.toast, [role="status"]', {
+    hasText: /NPU LLM slot|conflict|exclus/i,
+  })
+  await expect(toast.first()).toBeVisible({ timeout: 4000 })
+})


### PR DESCRIPTION
## Summary

PR-20 of the v0.2 Lemonade migration — extends PR-11's NPU exclusivity guard with runtime swap-in-progress detection and the corresponding dashboard UX. Builds on PR-19's FLM trio direct-port dispatch (`bd0957e`).

- **Backend** — new `hal0.dispatcher.npu_swap_status` module + `GET /api/npu/swap-status` endpoint. Merges the slot TOML state with lemond's `/v1/health.loaded[]` to publish a single `{in_progress, from_model, to_model}` signal.
- **Frontend (v2 surface, post-#199 cutover)** — `useNpuSwapStatus` composable polls every 2s and drives the existing `npu-swap` banner; `NpuBlock` + `NpuReactor` render a spinner over the chat sub-row during the swap window; `EditSlotDrawer` pops a `ConfirmDialog` on intentional NPU chat-model swaps before kicking off the POST.
- **Tests** — 20 new pytest cases on the helper + endpoint, 5 new γ-suite Playwright cases on the dashboard surface.

PR-11's `SlotManager._check_npu_exclusivity` (two-enabled refusal, 409 `slot.npu_exclusivity_violation`) and PR-16's `route_to_chat` NPU↔NPU refusal were verified intact — no rework needed.

Refs: locked plan §5.3 + §11 PR-20 — `docs/internal/lemonade-adoption-plan-2026-05-22.md`. ADR-0008 §5. ADR-0009.

## Test plan

- [x] `PYTHONPATH=src pytest tests/ -q` → 1852 passed (+20 vs PR-19 baseline 1832).
- [x] `ruff check src tests` + `ruff format --check src tests` → clean.
- [x] `npx playwright test tests/e2e/specs/npu-swap-ux.spec.ts` → 5/5 pass.
- [x] `npx playwright test tests/e2e/specs/slots-v2.spec.ts tests/e2e/specs/slot-lifecycle.spec.ts tests/e2e/specs/models-slots-refactor.spec.ts` → 14 pass / 5 skipped (no regressions).
- [ ] LXC verification deferred to PR-22 release notes prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)