### PR TITLE
feat(installer): v0.1.x detection + hal0 registry import recovery (PR-21)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -92,6 +92,50 @@ EOF
     esac
 done
 
+# ── v0.1.x state detection ─────────────────────────────────────────────────
+# v0.2 is a breaking change: slot architecture, model layout, and runtime have
+# all changed (see lemonade-adoption-plan §9). The installer refuses to run
+# over a v0.1.x state — there is no migration path beyond the registry, and
+# the only safe option is back-up + wipe.
+#
+# Detection criterion (plan §9):
+#   /etc/hal0/slots/*.toml exists  AND  /var/lib/hal0/lemonade/config.json absent.
+#
+# Both conditions matter: the slots dir is the v0.1.x fingerprint, and the
+# absence of the Lemonade config is what tells us this isn't a previously
+# completed v0.2 install with leftover v0.1.x slot files (PR-9 will retire
+# /etc/hal0/slots/ but until then a partial v0.2 box could still have files
+# there).
+#
+# Runs BEFORE the DEV_MODE check on purpose: dev mode does NOT bypass the
+# refusal. Escape hatch is HAL0_SKIP_V01_DETECT=1 (CI + worktree tests).
+# Idempotent — only checks two paths, no side effects.
+if [[ "${HAL0_SKIP_V01_DETECT:-0}" != "1" ]]; then
+    v01_slots_found=0
+    if compgen -G "/etc/hal0/slots/*.toml" >/dev/null 2>&1; then
+        v01_slots_found=1
+    fi
+    if [[ "${v01_slots_found}" -eq 1 && ! -f "/var/lib/hal0/lemonade/config.json" ]]; then
+        cat <<'V01_EOF' >&2
+hal0 v0.1.x detected. v0.2 is a breaking change — slot architecture, model layout,
+and runtime have all changed. The installer will not overwrite a v0.1.x state.
+
+To preserve your configuration:
+  sudo tar czf hal0-v0.1-backup-$(date +%F).tar.gz /etc/hal0 /var/lib/hal0/registry
+
+To wipe v0.1.x and start fresh:
+  sudo systemctl stop 'hal0-slot@*' hal0-api
+  sudo systemctl disable 'hal0-slot@*' hal0-api
+  sudo rm -rf /etc/hal0 /var/lib/hal0 /opt/hal0
+  # then re-run this installer
+
+Or read the v0.2 migration notes: https://hal0.dev/docs/v0.2-upgrade
+V01_EOF
+        exit 1
+    fi
+    unset v01_slots_found
+fi
+
 # --dev implies --no-tls — there's no system Caddy install in a dev tree
 # and the prefix-relative unit paths won't match Caddy's expectations
 # anyway. Warn the operator if they passed --no-tls redundantly.

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -34,6 +34,7 @@ from hal0.cli.config_commands import app as config_app
 from hal0.cli.doctor_commands import app as doctor_app
 from hal0.cli.migrate_commands import app as migrate_app
 from hal0.cli.model_commands import app as model_app
+from hal0.cli.registry_commands import app as registry_app
 from hal0.cli.slot_commands import app as slot_app
 from hal0.cli.update_commands import update as _update_impl
 
@@ -58,6 +59,7 @@ app.add_typer(doctor_app, name="doctor")
 app.add_typer(capabilities_app, name="capabilities")
 app.add_typer(agent_app, name="agent")
 app.add_typer(migrate_app, name="migrate")
+app.add_typer(registry_app, name="registry")
 
 
 # ---------------------------------------------------------------------------

--- a/src/hal0/cli/registry_commands.py
+++ b/src/hal0/cli/registry_commands.py
@@ -1,0 +1,282 @@
+"""``hal0 registry`` subcommands — v0.1.x backup recovery.
+
+This module hosts operator tooling that touches
+``/var/lib/hal0/registry/registry.toml`` directly. Today there is
+exactly one such command — ``import`` — which restores a registry
+extracted from a ``hal0-v0.1-backup-YYYY-MM-DD.tar.gz`` tarball
+produced by following the v0.1.x backup instructions in install.sh
+(see lemonade-adoption-plan §9).
+
+Design contract (from plan §11 PR-21):
+
+* **Registry only.** v0.1.x → v0.2 is a clean break. Slot selections,
+  capabilities, and per-slot TOML files are NOT migrated. The operator
+  redoes slot selection via the bundle picker. Plan §9 is explicit
+  about this: "Slot selections must be redone — alpha social contract".
+* **Refuse to overwrite.** A pre-existing ``registry.toml`` at the
+  canonical path is left alone unless ``--force`` is passed. The
+  freshly-installed registry on a v0.2 box may already have curated
+  picks from the bundle picker; we don't silently clobber them.
+* **Atomic.** The copy goes through a sibling tempfile + ``os.replace``
+  so a crash mid-copy never leaves a half-written ``registry.toml``.
+  Mirrors the pattern in ``hal0.lemonade.server_models_gen``.
+* **Tar safety.** The tarball is extracted into a freshly-created
+  ``tempfile.mkdtemp`` and we refuse any member with an absolute path
+  or a ``..`` component (defence against a hand-crafted backup).
+
+What this script does NOT do:
+
+* It does NOT auto-run ``hal0 capabilities sync`` — the registry import
+  is one step of a larger recovery flow, and the operator may want to
+  inspect the imported file before regenerating Lemonade's catalog.
+  The success message points at the next step explicitly.
+* It does NOT extract ``/etc/hal0/`` from the backup — v0.2's
+  ``capabilities.toml`` schema is incompatible with v0.1.x's
+  per-slot TOML files.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import tarfile
+import tempfile
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+console = Console()
+
+app = typer.Typer(
+    name="registry",
+    help="Inspect + repair the hal0 model registry.",
+    no_args_is_help=True,
+)
+
+
+@app.callback()
+def _registry_callback() -> None:
+    """Inspect + repair the hal0 model registry.
+
+    Currently exposes ``import`` (v0.1.x backup recovery). Future
+    subcommands will live here; the callback keeps Typer from
+    auto-collapsing the single-command group, which would make a
+    second subcommand a breaking change at the CLI surface.
+    """
+
+
+# Default v0.2 canonical path for registry.toml. Override via --dest for
+# tests + dev installs. Source: lemonade-adoption-plan §6.1 + plan §9.
+DEFAULT_REGISTRY_PATH = Path("/var/lib/hal0/registry/registry.toml")
+
+# Relative path inside the v0.1.x backup tarball. The backup instructions
+# in install.sh archive ``/var/lib/hal0/registry``, which extracts as
+# ``var/lib/hal0/registry/registry.toml`` (tar strips the leading slash).
+# We accept either layout to be robust against operators who manually
+# repacked the backup.
+_TARBALL_REGISTRY_CANDIDATES: tuple[str, ...] = (
+    "var/lib/hal0/registry/registry.toml",
+    "registry/registry.toml",
+    "registry.toml",
+)
+
+
+def _is_within(base: Path, target: Path) -> bool:
+    """Return True if ``target`` resolves inside ``base``.
+
+    Used to defend against tar members with absolute paths or ``..``
+    components — a hand-crafted backup could otherwise write anywhere
+    on disk that the running user has permission for.
+    """
+    try:
+        target.resolve().relative_to(base.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _safe_extract(tar: tarfile.TarFile, dest: Path) -> None:
+    """Extract ``tar`` into ``dest`` with path-traversal protection."""
+    for member in tar.getmembers():
+        member_path = dest / member.name
+        if not _is_within(dest, member_path):
+            raise typer.BadParameter(
+                f"refusing to extract {member.name!r}: escapes the tempdir "
+                f"(absolute path or .. component)",
+                param_hint="path",
+            )
+        # Filter out symlinks/hardlinks/devices — only regular files +
+        # directories are expected in a hal0 backup; anything else is
+        # almost certainly hostile.
+        if member.issym() or member.islnk() or member.isdev():
+            raise typer.BadParameter(
+                f"refusing to extract {member.name!r}: link/device member "
+                f"not allowed in hal0 backup",
+                param_hint="path",
+            )
+    # `filter="data"` is the safest standard filter in Python 3.12+; it
+    # strips ownership/mode metadata and rejects unsafe member types.
+    # The pre-loop scan above adds belt-and-braces refusal for absolute
+    # paths so we don't depend solely on tarfile's behaviour matrix.
+    tar.extractall(path=dest, filter="data")
+
+
+def _find_registry_in_dir(root: Path) -> Path | None:
+    """Locate ``registry.toml`` under ``root`` using the candidate list."""
+    for rel in _TARBALL_REGISTRY_CANDIDATES:
+        candidate = root / rel
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _atomic_copy(source: Path, dest: Path) -> None:
+    """Copy ``source`` to ``dest`` via a sibling tempfile + ``os.replace``.
+
+    Mirrors the atomic-write pattern in
+    ``hal0.lemonade.server_models_gen.write_server_models`` so a crash
+    mid-copy never leaves a partial ``registry.toml`` at the canonical
+    path — which would brick ``hal0 capabilities sync`` until the
+    operator manually rolls back.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=f".{dest.name}.",
+        suffix=".tmp",
+        dir=dest.parent,
+    )
+    tmp_path = Path(tmp_str)
+    try:
+        try:
+            with (
+                open(source, "rb") as src,
+                os.fdopen(fd, "wb") as dst,
+            ):
+                shutil.copyfileobj(src, dst)
+                dst.flush()
+                os.fsync(dst.fileno())
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise
+        os.replace(tmp_path, dest)
+        tmp_path = None  # type: ignore[assignment]
+    finally:
+        if tmp_path is not None:
+            with contextlib.suppress(OSError):
+                tmp_path.unlink(missing_ok=True)
+
+
+@app.command("import")
+def import_backup(
+    path: Path = typer.Argument(
+        ...,
+        help="Path to hal0-v0.1-backup-YYYY-MM-DD.tar.gz produced by the "
+        "v0.1.x backup instructions in install.sh.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Overwrite an existing registry.toml at the destination. "
+        "Without this, the command refuses to clobber a registry that "
+        "may already hold v0.2 selections.",
+    ),
+    dest: Path = typer.Option(
+        DEFAULT_REGISTRY_PATH,
+        "--dest",
+        help="Destination registry.toml path. Test/dev escape hatch — "
+        "production always uses /var/lib/hal0/registry/registry.toml.",
+    ),
+) -> None:
+    """Restore ``registry.toml`` from a v0.1.x backup tarball.
+
+    Reads the tarball at ``PATH``, extracts it into a tempdir, locates
+    ``registry.toml`` inside (canonical layout is
+    ``var/lib/hal0/registry/registry.toml``; bare ``registry/`` and
+    flat layouts also accepted for hand-repacked backups), and atomically
+    copies it to ``--dest`` (default: ``/var/lib/hal0/registry/registry.toml``).
+
+    Refuses to overwrite an existing destination unless ``--force`` is
+    passed — a freshly-installed v0.2 box may already have curated picks
+    from the bundle picker.
+
+    Slot selections, ``capabilities.toml``, per-slot TOML files, and all
+    other v0.1.x state are NOT restored. Plan §9 is explicit: v0.1.x →
+    v0.2 is a clean break. After import, redo slot selection via the
+    bundle picker or ``hal0 slot add``.
+    """
+    # ── 1. Validate the source tarball ────────────────────────────────
+    if not path.exists():
+        console.print(f"[red]error[/red]: backup not found: {path}")
+        raise typer.Exit(2)
+    if not path.is_file():
+        console.print(f"[red]error[/red]: not a regular file: {path}")
+        raise typer.Exit(2)
+
+    # ── 2. Refuse to clobber an existing registry unless --force ──────
+    if dest.exists() and not force:
+        console.print(
+            f"[red]error[/red]: destination already exists: {dest}\n"
+            f"        pass [bold]--force[/bold] to overwrite, or move the "
+            f"existing file aside first."
+        )
+        raise typer.Exit(1)
+
+    # ── 3. Extract into a tempdir ─────────────────────────────────────
+    tmpdir = Path(tempfile.mkdtemp(prefix="hal0-registry-import-"))
+    try:
+        try:
+            with tarfile.open(path, "r:*") as tar:
+                _safe_extract(tar, tmpdir)
+        except tarfile.ReadError as exc:
+            console.print(
+                f"[red]error[/red]: cannot read {path} as a tar archive: {exc}\n"
+                f"        is this really a hal0-v0.1-backup-*.tar.gz?"
+            )
+            raise typer.Exit(2) from None
+        except tarfile.TarError as exc:
+            console.print(f"[red]error[/red]: malformed tarball: {exc}")
+            raise typer.Exit(2) from None
+
+        # ── 4. Locate registry.toml ───────────────────────────────────
+        source_registry = _find_registry_in_dir(tmpdir)
+        if source_registry is None:
+            tried = ", ".join(_TARBALL_REGISTRY_CANDIDATES)
+            console.print(
+                f"[red]error[/red]: registry.toml not found in {path}\n"
+                f"        looked under: {tried}\n"
+                f"        is the backup missing /var/lib/hal0/registry/?"
+            )
+            raise typer.Exit(2)
+
+        # ── 5. Atomically copy into place ─────────────────────────────
+        try:
+            _atomic_copy(source_registry, dest)
+        except PermissionError as exc:
+            console.print(
+                f"[red]error[/red]: cannot write {dest}: {exc}\n"
+                f"        re-run with sudo, or pass --dest to a writable path."
+            )
+            raise typer.Exit(1) from None
+        except OSError as exc:
+            console.print(f"[red]error[/red]: copy failed: {exc}")
+            raise typer.Exit(1) from None
+    finally:
+        # Always nuke the tempdir, even on success. Backup tarballs can
+        # be large and we don't want them lingering in /tmp.
+        with contextlib.suppress(OSError):
+            shutil.rmtree(tmpdir)
+
+    # ── 6. Success guidance ───────────────────────────────────────────
+    console.print(
+        f"[green]registry imported[/green] from {path} → {dest}\n"
+        f"\n"
+        f"To regenerate Lemonade's catalog:\n"
+        f"  [bold]hal0 capabilities sync[/bold]\n"
+        f"\n"
+        f"Slot selections from v0.1.x are NOT migrated. Use the bundle\n"
+        f"picker or [bold]hal0 slot add[/bold] to declare slots."
+    )

--- a/tests/cli/test_registry_import.py
+++ b/tests/cli/test_registry_import.py
@@ -378,7 +378,15 @@ def test_registry_command_registered_on_main_app() -> None:
 
 
 def test_registry_import_help_mentions_force_and_dest() -> None:
+    # Strip ANSI escape codes + collapse all whitespace so typer's
+    # rich-renderer line-wrap (CI defaults to narrow terminals and
+    # splits `--force` across lines) does not break the substring
+    # assertions.
+    import re as _re
+
     result = runner.invoke(registry_app, ["import", "--help"])
     assert result.exit_code == 0, result.output
-    assert "--force" in result.output
-    assert "--dest" in result.output
+    plain = _re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    plain = _re.sub(r"\s+", "", plain)
+    assert "--force" in plain
+    assert "--dest" in plain

--- a/tests/cli/test_registry_import.py
+++ b/tests/cli/test_registry_import.py
@@ -1,0 +1,384 @@
+"""Tests for ``hal0 registry import`` — PR-21 of v0.2 Lemonade migration.
+
+Covers the behaviour contract from lemonade-adoption-plan §9 + §11 PR-21:
+
+* Happy path: tarball with ``registry/registry.toml`` → imported, success
+  message printed.
+* Missing tarball → clear error, non-zero exit.
+* Tarball missing ``registry.toml`` → clear error, non-zero exit.
+* Existing destination + no ``--force`` → refused with clear error.
+* Existing destination + ``--force`` → overwritten.
+* Permission errors handled gracefully.
+* Tar path-traversal members rejected.
+* Atomic copy (no partial file left on crash).
+* Tempdir cleanup on success and failure.
+* Bundle-picker recovery path printed on success.
+"""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from hal0.cli.registry_commands import (
+    _TARBALL_REGISTRY_CANDIDATES,
+    _atomic_copy,
+    _find_registry_in_dir,
+    _is_within,
+)
+from hal0.cli.registry_commands import (
+    app as registry_app,
+)
+
+runner = CliRunner()
+
+
+# ── Fixture helpers ───────────────────────────────────────────────────────────
+
+
+REGISTRY_PAYLOAD = b"""# hal0 v0.1.x registry snapshot
+[models.hermes-4-14b]
+path = "/mnt/ai-models/local/hermes-4-14b.gguf"
+backends = ["vulkan"]
+capabilities = ["chat"]
+"""
+
+
+def _make_backup(
+    tmp_path: Path,
+    *,
+    layout: str = "var-lib",
+    include_registry: bool = True,
+    extras: dict[str, bytes] | None = None,
+) -> Path:
+    """Build a synthetic hal0-v0.1-backup tarball under ``tmp_path``.
+
+    ``layout`` picks the relative path under which ``registry.toml``
+    lives inside the tar:
+
+    * ``var-lib``: ``var/lib/hal0/registry/registry.toml`` (canonical;
+      produced by the install.sh backup instructions).
+    * ``short``:   ``registry/registry.toml`` (hand-repacked variant).
+    * ``flat``:    ``registry.toml`` (degenerate, but accepted).
+    """
+    layouts = {
+        "var-lib": "var/lib/hal0/registry/registry.toml",
+        "short": "registry/registry.toml",
+        "flat": "registry.toml",
+    }
+    relpath = layouts[layout]
+
+    staging = tmp_path / f"staging-{layout}"
+    staging.mkdir()
+    if include_registry:
+        target = staging / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(REGISTRY_PAYLOAD)
+
+    # Optional companion files — e.g. /etc/hal0 contents that should be
+    # ignored by the importer.
+    if extras:
+        for name, data in extras.items():
+            extra_path = staging / name
+            extra_path.parent.mkdir(parents=True, exist_ok=True)
+            extra_path.write_bytes(data)
+
+    tar_path = tmp_path / f"hal0-v0.1-backup-{layout}.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        for item in staging.rglob("*"):
+            if item.is_file():
+                tar.add(item, arcname=str(item.relative_to(staging)))
+    return tar_path
+
+
+def _invoke(*, tar_path: Path, dest: Path, force: bool = False) -> object:
+    args = ["import", str(tar_path), "--dest", str(dest)]
+    if force:
+        args.append("--force")
+    return runner.invoke(registry_app, args)
+
+
+# ── Pure-function tests ───────────────────────────────────────────────────────
+
+
+def test_is_within_accepts_nested_path(tmp_path: Path) -> None:
+    base = tmp_path / "root"
+    base.mkdir()
+    assert _is_within(base, base / "a" / "b")
+
+
+def test_is_within_rejects_dotdot_escape(tmp_path: Path) -> None:
+    base = tmp_path / "root"
+    base.mkdir()
+    # Path-traversal — `..` walks out of base.
+    assert not _is_within(base, base / ".." / "other")
+
+
+def test_is_within_rejects_absolute_escape(tmp_path: Path) -> None:
+    base = tmp_path / "root"
+    base.mkdir()
+    assert not _is_within(base, Path("/etc/passwd"))
+
+
+def test_find_registry_prefers_canonical_layout(tmp_path: Path) -> None:
+    # All three layouts present — must pick the canonical one first.
+    for rel in _TARBALL_REGISTRY_CANDIDATES:
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b"x")
+    found = _find_registry_in_dir(tmp_path)
+    assert found is not None
+    assert found.relative_to(tmp_path) == Path(_TARBALL_REGISTRY_CANDIDATES[0])
+
+
+def test_find_registry_returns_none_when_absent(tmp_path: Path) -> None:
+    assert _find_registry_in_dir(tmp_path) is None
+
+
+def test_atomic_copy_writes_destination(tmp_path: Path) -> None:
+    src = tmp_path / "src.toml"
+    src.write_bytes(b"hello")
+    dst = tmp_path / "dst" / "dst.toml"
+    _atomic_copy(src, dst)
+    assert dst.read_bytes() == b"hello"
+
+
+def test_atomic_copy_leaves_no_tempfile(tmp_path: Path) -> None:
+    src = tmp_path / "src.toml"
+    src.write_bytes(b"hello")
+    dst = tmp_path / "dst.toml"
+    _atomic_copy(src, dst)
+    # No sibling tempfile (".dst.toml.XXXX.tmp") survives the copy.
+    siblings = [p for p in tmp_path.iterdir() if p.name.startswith(".dst.toml.")]
+    assert siblings == []
+
+
+# ── CLI: happy paths ─────────────────────────────────────────────────────────
+
+
+def test_import_happy_path_canonical_layout(tmp_path: Path) -> None:
+    tar_path = _make_backup(tmp_path, layout="var-lib")
+    dest = tmp_path / "var" / "lib" / "hal0" / "registry" / "registry.toml"
+
+    result = _invoke(tar_path=tar_path, dest=dest)
+    assert result.exit_code == 0, result.output
+    assert dest.read_bytes() == REGISTRY_PAYLOAD
+    # Success guidance must point operators at the next step.
+    assert "hal0 capabilities sync" in result.output
+    assert "bundle" in result.output.lower() or "slot add" in result.output
+
+
+def test_import_accepts_short_layout(tmp_path: Path) -> None:
+    tar_path = _make_backup(tmp_path, layout="short")
+    dest = tmp_path / "out" / "registry.toml"
+    result = _invoke(tar_path=tar_path, dest=dest)
+    assert result.exit_code == 0, result.output
+    assert dest.read_bytes() == REGISTRY_PAYLOAD
+
+
+def test_import_accepts_flat_layout(tmp_path: Path) -> None:
+    tar_path = _make_backup(tmp_path, layout="flat")
+    dest = tmp_path / "out" / "registry.toml"
+    result = _invoke(tar_path=tar_path, dest=dest)
+    assert result.exit_code == 0, result.output
+    assert dest.read_bytes() == REGISTRY_PAYLOAD
+
+
+def test_import_ignores_extras_in_backup(tmp_path: Path) -> None:
+    # Backup tarballs include /etc/hal0/ — we must extract them into the
+    # tempdir (so the tar walks cleanly) but NOT copy them to disk.
+    tar_path = _make_backup(
+        tmp_path,
+        layout="var-lib",
+        extras={
+            "etc/hal0/capabilities.toml": b"# v0.1.x -- should not be restored\n",
+            "etc/hal0/slots/primary.toml": b"# v0.1.x slot -- must not appear in v0.2\n",
+        },
+    )
+    dest = tmp_path / "out" / "registry.toml"
+    result = _invoke(tar_path=tar_path, dest=dest)
+    assert result.exit_code == 0, result.output
+    # Only the registry made it to the destination.
+    assert dest.read_bytes() == REGISTRY_PAYLOAD
+    # The /etc/hal0 extras did NOT bleed into the destination tree.
+    etc_root = dest.parent.parent / "etc"
+    assert not etc_root.exists()
+
+
+# ── CLI: error paths ─────────────────────────────────────────────────────────
+
+
+def test_import_missing_tarball(tmp_path: Path) -> None:
+    dest = tmp_path / "registry.toml"
+    result = _invoke(tar_path=tmp_path / "does-not-exist.tar.gz", dest=dest)
+    assert result.exit_code != 0
+    assert "not found" in result.output
+    assert not dest.exists()
+
+
+def test_import_not_a_regular_file(tmp_path: Path) -> None:
+    # A directory passed where a tarball is expected.
+    dest = tmp_path / "registry.toml"
+    result = _invoke(tar_path=tmp_path, dest=dest)
+    assert result.exit_code != 0
+    assert "not a regular file" in result.output
+
+
+def test_import_not_a_tar(tmp_path: Path) -> None:
+    not_a_tar = tmp_path / "garbage.tar.gz"
+    not_a_tar.write_bytes(b"not a tar archive")
+    dest = tmp_path / "registry.toml"
+    result = _invoke(tar_path=not_a_tar, dest=dest)
+    assert result.exit_code != 0
+    assert "tar" in result.output.lower()
+    assert not dest.exists()
+
+
+def test_import_tarball_without_registry(tmp_path: Path) -> None:
+    # Backup that DOESN'T contain registry.toml at any known layout.
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    (staging / "etc" / "hal0").mkdir(parents=True)
+    (staging / "etc" / "hal0" / "config.toml").write_bytes(b"# no registry\n")
+    tar_path = tmp_path / "bad-backup.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        tar.add(staging / "etc", arcname="etc")
+
+    dest = tmp_path / "registry.toml"
+    result = _invoke(tar_path=tar_path, dest=dest)
+    assert result.exit_code != 0
+    assert "registry.toml not found" in result.output
+    assert not dest.exists()
+
+
+def test_import_refuses_to_overwrite_without_force(tmp_path: Path) -> None:
+    tar_path = _make_backup(tmp_path, layout="var-lib")
+    dest = tmp_path / "registry.toml"
+    dest.write_bytes(b"# pre-existing v0.2 registry -- do not clobber\n")
+
+    result = _invoke(tar_path=tar_path, dest=dest)
+    assert result.exit_code != 0
+    assert "--force" in result.output
+    # Destination is unchanged.
+    assert dest.read_bytes() == b"# pre-existing v0.2 registry -- do not clobber\n"
+
+
+def test_import_force_overwrites_existing(tmp_path: Path) -> None:
+    tar_path = _make_backup(tmp_path, layout="var-lib")
+    dest = tmp_path / "registry.toml"
+    dest.write_bytes(b"# pre-existing v0.2 registry\n")
+
+    result = _invoke(tar_path=tar_path, dest=dest, force=True)
+    assert result.exit_code == 0, result.output
+    assert dest.read_bytes() == REGISTRY_PAYLOAD
+
+
+def test_import_rejects_path_traversal_member(tmp_path: Path) -> None:
+    # Hand-craft a tar with an absolute member name; the importer must
+    # refuse rather than write outside the tempdir.
+    payload = tmp_path / "payload"
+    payload.write_bytes(b"malicious")
+    tar_path = tmp_path / "evil.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        info = tarfile.TarInfo(name="../../escape/registry.toml")
+        info.size = len(REGISTRY_PAYLOAD)
+        import io
+
+        tar.addfile(info, io.BytesIO(REGISTRY_PAYLOAD))
+
+    dest = tmp_path / "out" / "registry.toml"
+    result = _invoke(tar_path=tar_path, dest=dest)
+    assert result.exit_code != 0
+    # Destination + escape dir are untouched.
+    assert not dest.exists()
+    assert not (tmp_path / "escape").exists()
+
+
+def test_import_handles_permission_error_on_dest(tmp_path: Path) -> None:
+    tar_path = _make_backup(tmp_path, layout="var-lib")
+    dest = tmp_path / "out" / "registry.toml"
+
+    # Force the atomic copy to raise PermissionError.
+    def boom(*_args: object, **_kw: object) -> None:
+        raise PermissionError("simulated permission denied")
+
+    with patch("hal0.cli.registry_commands._atomic_copy", side_effect=boom):
+        result = _invoke(tar_path=tar_path, dest=dest)
+
+    assert result.exit_code != 0
+    # The user must be told what to try next.
+    assert "sudo" in result.output or "writable" in result.output
+
+
+# ── CLI: tempdir cleanup ─────────────────────────────────────────────────────
+
+
+def test_import_cleans_tempdir_on_success(tmp_path: Path) -> None:
+    tar_path = _make_backup(tmp_path, layout="var-lib")
+    dest = tmp_path / "out" / "registry.toml"
+
+    import tempfile as tf_mod
+
+    before = {
+        p.name
+        for p in Path(tf_mod.gettempdir()).iterdir()
+        if p.name.startswith("hal0-registry-import-")
+    }
+    result = _invoke(tar_path=tar_path, dest=dest)
+    assert result.exit_code == 0, result.output
+    after = {
+        p.name
+        for p in Path(tf_mod.gettempdir()).iterdir()
+        if p.name.startswith("hal0-registry-import-")
+    }
+    # No new orphaned tempdirs from this run.
+    assert after - before == set()
+
+
+def test_import_cleans_tempdir_on_failure(tmp_path: Path) -> None:
+    # Bad tarball → cleanup must still happen.
+    not_a_tar = tmp_path / "garbage.tar.gz"
+    not_a_tar.write_bytes(b"nope")
+    dest = tmp_path / "registry.toml"
+
+    import tempfile as tf_mod
+
+    before = {
+        p.name
+        for p in Path(tf_mod.gettempdir()).iterdir()
+        if p.name.startswith("hal0-registry-import-")
+    }
+    result = _invoke(tar_path=not_a_tar, dest=dest)
+    assert result.exit_code != 0
+    after = {
+        p.name
+        for p in Path(tf_mod.gettempdir()).iterdir()
+        if p.name.startswith("hal0-registry-import-")
+    }
+    assert after - before == set()
+
+
+# ── CLI: wiring smoke ─────────────────────────────────────────────────────────
+
+
+def test_registry_command_registered_on_main_app() -> None:
+    """``hal0 registry import`` must be reachable from the top-level app.
+
+    Guards against forgetting the ``app.add_typer(registry_app, ...)``
+    wire-up in ``hal0.cli.main`` after the command was added.
+    """
+    from hal0.cli.main import app as main_app
+
+    result = runner.invoke(main_app, ["registry", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "import" in result.output
+
+
+def test_registry_import_help_mentions_force_and_dest() -> None:
+    result = runner.invoke(registry_app, ["import", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "--force" in result.output
+    assert "--dest" in result.output

--- a/tests/installer/test_v01_detect.sh
+++ b/tests/installer/test_v01_detect.sh
@@ -1,0 +1,138 @@
+#!/bin/sh
+# hal0 — install.sh v0.1.x detection smoke test (PR-21).
+#
+# Verifies the detection clause added at the top of install.sh per
+# lemonade-adoption-plan §9. The test never lets install.sh proceed
+# past the detection block — that would require root, systemd, and a
+# clean machine. Instead it short-circuits each scenario at the
+# detection check.
+#
+# Strategy: extract the detection block via sed, source it in a
+# subshell with mocked v0.1.x paths, and assert behaviour:
+#
+#   1. Both v0.1.x markers present → block exits non-zero + prints the
+#      backup/wipe message.
+#   2. Only /etc/hal0/slots/*.toml (no lemonade config) → SAME refusal.
+#   3. /etc/hal0/slots/*.toml AND /var/lib/hal0/lemonade/config.json
+#      present (partial v0.2 box) → no refusal.
+#   4. No /etc/hal0/slots/*.toml (fresh box) → no refusal.
+#   5. HAL0_SKIP_V01_DETECT=1 → no refusal even with v0.1.x markers
+#      (CI + dev escape hatch).
+#
+# Usage:
+#   sh tests/installer/test_v01_detect.sh
+#
+# Exit 0 on pass, non-zero w/ message on fail.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+INSTALLER="${REPO_ROOT}/installer/install.sh"
+
+log()  { printf '[test_v01_detect] %s\n' "$*"; }
+fail() { printf '[test_v01_detect] FAIL: %s\n' "$*" >&2; exit 1; }
+
+[ -r "${INSTALLER}" ] || fail "missing ${INSTALLER}"
+
+# ── 1. syntax sanity ─────────────────────────────────────────────────
+log "syntax-check install.sh"
+bash -n "${INSTALLER}" || fail "install.sh failed bash -n"
+
+# ── 2. extract the detection block ───────────────────────────────────
+# We grep for the named bounds so a rename of the surrounding sections
+# does not silently start matching the wrong region.
+log "extract detection block from install.sh"
+WORKDIR="$(mktemp -d -t hal0-v01-detect-XXXXXX)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+awk '
+    /^# ── v0\.1\.x state detection ──/ { capturing = 1 }
+    capturing { print }
+    capturing && /^fi$/ {
+        # The second `fi` closes the outer HAL0_SKIP_V01_DETECT guard.
+        fi_count++
+        if (fi_count == 2) { exit }
+    }
+' "${INSTALLER}" > "${WORKDIR}/block.sh"
+
+[ -s "${WORKDIR}/block.sh" ] || fail "detection block not found in install.sh"
+
+# Sanity: block must reference both fingerprint paths.
+grep -q '/etc/hal0/slots' "${WORKDIR}/block.sh" \
+    || fail "detection block missing /etc/hal0/slots/* check"
+grep -q '/var/lib/hal0/lemonade/config.json' "${WORKDIR}/block.sh" \
+    || fail "detection block missing lemonade config.json check"
+grep -q 'HAL0_SKIP_V01_DETECT' "${WORKDIR}/block.sh" \
+    || fail "detection block missing HAL0_SKIP_V01_DETECT escape hatch"
+
+# ── 3. exercise the block with a swapped path prefix ─────────────────
+# The block hard-codes /etc/hal0 + /var/lib/hal0/lemonade. We rewrite
+# them to point into the WORKDIR so we can simulate each scenario
+# without touching the live filesystem.
+sed -e "s|/etc/hal0/slots|${WORKDIR}/etc/hal0/slots|g" \
+    -e "s|/var/lib/hal0/lemonade/config.json|${WORKDIR}/var/lib/hal0/lemonade/config.json|g" \
+    "${WORKDIR}/block.sh" > "${WORKDIR}/block-mocked.sh"
+
+run_block() {
+    # Run in a fresh subshell so HAL0_SKIP_V01_DETECT can be scoped per
+    # scenario, and so we can capture exit + stderr.
+    output_file="$1"
+    skip="$2"
+    (
+        HAL0_SKIP_V01_DETECT="${skip}"
+        export HAL0_SKIP_V01_DETECT
+        bash "${WORKDIR}/block-mocked.sh"
+    ) >"${WORKDIR}/stdout" 2>"${output_file}"
+    return $?
+}
+
+reset_state() {
+    rm -rf "${WORKDIR}/etc" "${WORKDIR}/var"
+}
+
+# Scenario 1: both v0.1.x markers (slot toml present, lemonade absent).
+log "scenario 1: v0.1.x slot present, lemonade absent → refusal"
+reset_state
+mkdir -p "${WORKDIR}/etc/hal0/slots"
+touch "${WORKDIR}/etc/hal0/slots/primary.toml"
+if run_block "${WORKDIR}/stderr1" ""; then
+    fail "scenario 1: expected non-zero exit, got 0"
+fi
+grep -q "hal0 v0.1.x detected" "${WORKDIR}/stderr1" \
+    || fail "scenario 1: refusal message missing 'hal0 v0.1.x detected'"
+grep -q "tar czf hal0-v0.1-backup" "${WORKDIR}/stderr1" \
+    || fail "scenario 1: refusal message missing backup instructions"
+grep -q "rm -rf /etc/hal0 /var/lib/hal0 /opt/hal0" "${WORKDIR}/stderr1" \
+    || fail "scenario 1: refusal message missing wipe instructions"
+
+# Scenario 2: partial v0.2 box (slot toml + lemonade config) → no refusal.
+log "scenario 2: slot present + lemonade present → no refusal"
+reset_state
+mkdir -p "${WORKDIR}/etc/hal0/slots" "${WORKDIR}/var/lib/hal0/lemonade"
+touch "${WORKDIR}/etc/hal0/slots/primary.toml"
+touch "${WORKDIR}/var/lib/hal0/lemonade/config.json"
+if ! run_block "${WORKDIR}/stderr2" ""; then
+    cat "${WORKDIR}/stderr2" >&2
+    fail "scenario 2: expected zero exit (lemonade present overrides), got non-zero"
+fi
+
+# Scenario 3: fresh box (no slot toml) → no refusal.
+log "scenario 3: fresh box → no refusal"
+reset_state
+if ! run_block "${WORKDIR}/stderr3" ""; then
+    cat "${WORKDIR}/stderr3" >&2
+    fail "scenario 3: expected zero exit on fresh box, got non-zero"
+fi
+
+# Scenario 4: escape hatch — HAL0_SKIP_V01_DETECT=1 with v0.1.x markers.
+log "scenario 4: HAL0_SKIP_V01_DETECT=1 bypasses refusal"
+reset_state
+mkdir -p "${WORKDIR}/etc/hal0/slots"
+touch "${WORKDIR}/etc/hal0/slots/primary.toml"
+if ! run_block "${WORKDIR}/stderr4" "1"; then
+    cat "${WORKDIR}/stderr4" >&2
+    fail "scenario 4: HAL0_SKIP_V01_DETECT=1 must skip refusal"
+fi
+
+log "OK — all 4 scenarios passed"


### PR DESCRIPTION
## Summary

PR-21 of the v0.2 Lemonade migration. Implements the v0.1.x clean-break contract from `docs/internal/lemonade-adoption-plan-2026-05-22.md` §9 + §11 PR-21.

- **install.sh**: new detection block at the top (after arg parsing, before DEV_MODE). Refuses to install when `/etc/hal0/slots/*.toml` exists AND `/var/lib/hal0/lemonade/config.json` is absent. Prints the backup + wipe instructions verbatim per plan §9. Escape hatch `HAL0_SKIP_V01_DETECT=1` (CI + dev). Dev mode does NOT bypass the refusal — by design.
- **`hal0 registry import <path>`**: new subcommand in a new `hal0 registry` group. Atomically restores `registry.toml` from a `hal0-v0.1-backup-*.tar.gz`. Refuses to clobber an existing `registry.toml` without `--force`. Tar extraction is path-traversal hardened (rejects absolute + `..` members; uses Python 3.12+ `filter="data"`). Success message points operators at `hal0 capabilities sync` + bundle picker / `hal0 slot add`.
- **Tests**: 23 new Python tests (happy paths × 3 layouts, malformed tar, missing registry, refuse-without-force, force-overwrites, permission errors, path-traversal members, tempdir cleanup, wiring smoke) + 4-scenario shell test (`tests/installer/test_v01_detect.sh`).

## Anti-scope (per brief)
- No auto-migration beyond `registry.toml`. Slot selections must be redone via the bundle picker.
- No upgrade-from-v0.1 path. Refusal is the contract.
- No README/PLAN/release-notes touch (PR-22).
- No LemonadeClient surface change.
- No dashboard touch.

## Test plan
- [x] `bash -n installer/install.sh` clean
- [x] `shellcheck installer/install.sh` clean for new section (only pre-existing warnings in unrelated code)
- [x] `sh tests/installer/test_v01_detect.sh` — all 4 scenarios pass (slot+no-lemonade → refuse, slot+lemonade → pass, fresh box → pass, `HAL0_SKIP_V01_DETECT=1` → pass)
- [x] `pytest tests/cli/test_registry_import.py -q` — 23/23 pass
- [x] `pytest tests/ -q` — **1875 passed**, 8 skipped (baseline 1852 + 23 new)
- [x] `ruff check src tests` — all checks pass
- [x] `ruff format --check src tests` — 291 files already formatted

## Files touched
- `installer/install.sh` (+44 LOC — detection block)
- `src/hal0/cli/main.py` (+2 — wire `registry_app`)
- `src/hal0/cli/registry_commands.py` (new, 282 LOC)
- `tests/cli/test_registry_import.py` (new, 384 LOC)
- `tests/installer/test_v01_detect.sh` (new, 138 LOC, +x)

Plan: `docs/internal/lemonade-adoption-plan-2026-05-22.md` §9 + §11 PR-21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)