### PR TITLE
docs(v0.2): README + PLAN + CHANGELOG + upgrade guide + release notes (PR-22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,220 @@
+# Changelog
+
+All notable changes to hal0 are recorded here. The format loosely
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+the project adheres to semver pre-1.0 caveats: minor releases (v0.1 →
+v0.2) may carry breaking changes; patch releases inside a minor line
+(v0.2.0 → v0.2.1) won't.
+
+Tags older than v0.2.0 ship release notes inside the GitHub release
+page; this CHANGELOG starts at v0.2.0 (the Lemonade migration cut).
+For ADR-level architecture context see `docs/internal/adr/`.
+
+## [v0.2.0] — 2026-05-23
+
+**The Lemonade Server adoption release.** AMD's Lemonade Server
+replaces the six per-modality toolbox containers and the
+`hal0-slot@.service` template as the unified inference runtime; one
+`hal0-lemonade.service` supervises a single `lemond` daemon. Architecture
+recorded in [ADR-0008](docs/internal/adr/0008-lemonade-adoption.md),
+[ADR-0009](docs/internal/adr/0009-flm-trio-npu-packing.md),
+[ADR-0010](docs/internal/adr/0010-bundle-picker-no-default-stack.md);
+locked implementation contract at
+[`docs/internal/lemonade-adoption-plan-2026-05-22.md`](docs/internal/lemonade-adoption-plan-2026-05-22.md).
+
+### Breaking
+
+- **v0.1.x → v0.2 is a clean break — no auto-migration.** `install.sh`
+  detects v0.1.x state (presence of `/etc/hal0/slots/*.toml` AND
+  absence of `/var/lib/hal0/lemonade/config.json`) and refuses to
+  overwrite it, printing explicit backup + wipe instructions and
+  exiting non-zero. See [`docs/v0.2-upgrade.md`](docs/v0.2-upgrade.md)
+  for the user-facing procedure.
+- **Per-modality toolbox containers retired.** `hal0-toolbox-vulkan` /
+  `rocm` / `flm` / `moonshine` / `kokoro` / `comfyui` are no longer
+  built or pulled. Their dispatch responsibilities consolidate into
+  Lemonade's `llamacpp` / `flm:npu` / `whisper.cpp` / `kokoro:cpu` /
+  `sd-cpp` recipes.
+- **`hal0-slot@.service` systemd template retired.** Per-slot units
+  no longer exist. `hal0-lemonade.service` is the new daemon
+  supervisor — one process serving every slot via Lemonade's per-type
+  LRU.
+- **Model layout reorganised** to the canonical
+  `/var/lib/hal0/models/<recipe>/<capability>/` tree. PR-7's
+  migration script reorganises `/mnt/ai-models/{local,flm-ubuntu,moonshine_voice,voices,comfyui}`
+  into the same shape with per-leaf symlinks back to the canonical
+  path. Lemonade's `extra_models_dir` points at the canonical tree.
+- **`/etc/hal0/slots/*.toml` removed** as a persistence surface;
+  `capabilities.toml` is now the single source of truth for slot
+  selections. The slot lifecycle state machine in
+  `src/hal0/slots/state.py` survives; per-slot Provider classes and
+  the slot-systemd-template do not.
+- **Moonshine STT retired** in favour of `whisper.cpp` via Lemonade.
+  More accurate but heavier on weak CPUs; lite-tier users may notice.
+- **ComfyUI workflows lost.** `sd-cpp` covers the 90% case; power
+  users are directed to external ComfyUI installations for advanced
+  workflow graphs.
+- **`HAL0_BACKEND=lemonade` env flag** introduced in PR-8 and removed
+  in PR-10 — Lemonade is now the unconditional runtime.
+
+### Features
+
+- **Lemonade Server unified inference runtime** (PR-3 #156 through
+  PR-22). One `lemond` process per host on `127.0.0.1:13305`, cache
+  + config at `/var/lib/hal0/lemonade/`, supervised by
+  `hal0-lemonade.service`.
+- **`LemonadeProvider`** is the only `Provider` in v0.2's dispatch
+  path. Capability dispatcher reads `/v1/health` for slot state and
+  routes through Lemonade's `/v1/chat/completions` / `/v1/embeddings`
+  / `/v1/rerank` / `/v1/audio/*` / `/v1/images/*` endpoints.
+- **FLM trio NPU packing** (PR-19 #201, PR-20 #202). Lemonade's
+  `flm.args = "--asr 1 --embed 1"` packs chat + transcription +
+  embedding into one `flm serve` process sharing the single AMDXDNA
+  hardware context. hal0 exposes three slots (`agent`, `stt-npu`,
+  `embed-npu`); the capability dispatcher reads
+  `/v1/health.loaded[].backend_url` for the FLM model and routes
+  `stt-npu` / `embed-npu` requests directly to the child's port
+  (Lemonade only knows about the chat role). NPU exclusivity (one
+  `device = "npu", type = "llm"` slot enabled at a time) is enforced
+  in `capabilities.toml` validation; chat-model swap surfaces a
+  "swap incoming, voice + embed paused" UX. See ADR-0009.
+- **OmniRouter client-side tool-calling** (PR-16 #189). 8 tools — 5
+  upstream-mirrored (`generate_image`, `edit_image`,
+  `text_to_speech`, `transcribe_audio`, `analyze_image`) + 3
+  hal0-custom (`embed_text`, `rerank_documents`, `route_to_chat`).
+  Dynamic per-request filtering: a tool is included in the LLM
+  prompt only if at least one enabled slot of its target type exists
+  AND (for label-gated tools) at least one of those slots has a
+  model with the required labels. LLMs without the `tool-calling`
+  label receive no tools. `route_to_chat` is one-shot delegation,
+  blocked at depth=1, blocked across NPU LLM slots.
+- **First-run bundle picker** (PR-17 #196, PR-18 #198).
+  `capabilities.toml` ships empty by design; the dashboard's first
+  load renders four hardware-anchored tiers (`hal0-Lite` ≥16 GB /
+  `Default` ≥32 GB / `Pro` ≥64 GB / `Max` ≥100 GB Strix Halo) plus
+  the AMD-curated `LMX-Omni-52B-Halo` kit, with a "Skip — configure
+  manually" path. Tiers that don't fit detected unified RAM grey out
+  with a tooltip. Bundle manifests live at
+  `/var/lib/hal0/models/collections/omni/`. The NPU trio is opt-in
+  even at Pro and Max tiers. See ADR-0010.
+- **Settings → Lemonade admin panel** (PR-13 #183). Surfaces
+  `/internal/config` snapshot + `/internal/set` atomic writes for a
+  curated subset of keys. Guards against overriding `llamacpp.args`
+  to an unbounded value (would cause the multi-LLM CPU
+  oversubscription deadlock).
+- **Journal panel folded into Logs tab** (PR-14 #184). Lemonade's
+  `/logs/stream` WebSocket streams into the dashboard's event ring,
+  alongside hal0's own structured journal.
+- **Metrics shim** (PR-12 #179). Per-slot TTFT + tok/s +
+  prompt_tokens scraped from `/v1/stats`. FLM-native KV%
+  (`kv_token_occupancy_rate_percentage`) on NPU slots. See known
+  limitations below for the GPU-slot KV% gap.
+- **`[CPU]` chip + tooltip** on the voice slot card (PR-15 #186)
+  disclosing that kokoro is CPU-only in v0.2. GPU TTS deferred to
+  v0.3.
+- **Dashboard reads `/v1/health` for slot state** (PR-11 #163);
+  surfaces NPU exclusivity, FLM trio coresident marker, and the
+  nuclear-evict banner via `/logs/stream` line parsing.
+- **Mandatory `llamacpp.args = "--parallel 1 --threads N"`** in the
+  `lemond` config baseline (PR-5 #159). N is computed at install
+  time as `(cores − 2) / 4`, min 2. Without this, two concurrent
+  child llama-servers oversubscribe the CPU and freeze the Vulkan
+  dispatch — a hard install-time requirement, not a tunable.
+- **Per-type LRU concurrency.** Six independent type budgets
+  (`llm`, `embedding`, `reranking`, `transcription`, `tts`, `image`)
+  reported by `/v1/health.max_models`; default global budget set to
+  4. Nuclear evict-all only fires when a `/v1/load` errors AND the
+  error message does NOT substring-match "not found" / "does not
+  exist" / "No such file" — common failure modes (bad path, missing
+  variant, mistyped name) return graceful errors and leave the
+  loaded pool intact.
+- **Slot model**: bare-name identity + `type` (Lemonade vocab:
+  `llm | embedding | reranking | transcription | tts | image`) +
+  `device` (`gpu-rocm | gpu-vulkan | cpu | npu`) + `model` + `enabled`
+  + optional `default` + `group` for dashboard rollup. User-added
+  slots via `hal0 slot add NAME --type TYPE --model MODEL`. Exactly
+  one `default = true` per type enforced at save / load.
+- **Canonical model namespace.** `registered` (no prefix, from
+  `registry.toml` → Lemonade's `server_models.json`) vs `user.*`
+  (on-demand pulls via `POST /v1/pull`). `extra.*` auto-discovery
+  unused. Dashboard surfaces two badges: `blessed` and `pulled`.
+- **`hal0 registry sync`** (PR-6 #141 → #151) — regenerates
+  `/var/lib/hal0/lemonade/resources/server_models.json` from
+  `registry.toml` and restarts `lemond`. Hourly drift detector
+  surfaces a dashboard banner when `registry.toml` is newer than
+  `server_models.json`.
+- **`hal0 registry import`** (PR-21 #203) — single command, restores
+  `registry.toml` from a v0.1.x backup tarball. Slot selections must
+  be redone via the bundle picker.
+- **`hal0 doctor` extended** to probe `lemond` reachability + FLM
+  `.deb` presence (Linux NPU path).
+
+### Internal
+
+- **22 implementation PRs landed across 6 sub-phases.** Foundation
+  (PR-2 #137, PR-3 #156), install + registry (PR-4 #157, PR-5 #159,
+  PR-6 #141 → #151, PR-7 #158), slot layer rewrite (PR-8 #161, PR-9
+  #160, PR-10 #162), UI + metrics (PR-11 #163, PR-12 #179, PR-13
+  #183, PR-14 #184, PR-15 #186), OmniRouter + bundles (PR-16 #189,
+  PR-17 #196, PR-18 #198), NPU + close-out (PR-19 #201, PR-20 #202,
+  PR-21 #203, PR-22 — this PR).
+- **`SlotManager` simplified** ~358 LOC in PR-10 (#162) — provider
+  ABC dispatch + per-slot systemd adoption logic deleted.
+- **Legacy provider classes preserved as code** (used by image-gen /
+  hardware-probe / catalog non-slot consumers) but no longer in the
+  Lemonade dispatch path.
+- **`SlotConfig.device` refactor + `capabilities.toml`
+  `schema_version=2` migration** (#143 → #153).
+- **Preload validation + idle-unload driver** (#144 → #152) shipped
+  ahead of ADR-0007 supersession; preload validation removed per
+  ADR-0008 §3 in `e660fa3`.
+- **`src/hal0/lemonade/`** — HTTP client + `catalog_sync.py` +
+  `metrics_shim.py` + `log_proxy.py`.
+- **`src/hal0/omni_router/`** — client + tool definitions
+  (checksum-pinned mirror of Lemonade upstream's
+  `toolDefinitions.json`; CI script `scripts/check-tool-definitions.sh`
+  fails on drift).
+- **NPU FLM trio dispatch carve-out** documented in
+  ADR-0009 — narrow exception to ADR-0008's "Lemonade owns
+  inference lifecycle" thesis; scoped to the two endpoint paths
+  (`/v1/audio/transcriptions`, `/v1/embeddings`) that Lemonade
+  doesn't know exist on the FLM child.
+- **v0.2.1 dashboard rewrite** (slice #176, PR #199) cut over on
+  `main` in parallel; PR #197 carries v2 polish work and remains
+  open at v0.2 ship.
+
+### Known limitations
+
+- **KV% for GPU slots reads `—`.** Lemonade's bundled `llama-server`
+  (b9253 Vulkan, b1274 ROCm) returns `null` for `n_past` /
+  `n_prompt_tokens` / `prompt` in `/slots` responses, even during
+  active inference. PR #124's KV%-from-`/slots` strategy did not
+  survive the migration. FLM/NPU slots get KV% native from the
+  `kv_token_occupancy_rate_percentage` field in
+  `/v1/chat/completions` responses. v0.2.x patch path: hal0 builds
+  its own llama-server and swaps via `lemonade config set
+  llamacpp.{rocm_bin,vulkan_bin}` if upstream doesn't populate the
+  fields within ~6 weeks. See ADR-0008 §Costs.
+- **Kokoro TTS is CPU-only in v0.2.** No upstream GPU-Kokoro on
+  Linux at v0.2 ship. UI surfaces a `[CPU]` chip + tooltip on the
+  voice slot card. GPU-accelerated TTS deferred to v0.3.
+- **Performance: parity-to-regression vs the v0.1 hal0-Vulkan
+  baseline** (-13% to -18% on tested models in spike #1;
+  hermes-14b at parity). Accepted in exchange for the
+  six-toolbox-to-one-runtime maintenance collapse.
+- **NPU LLM swap is slow (~14s).** Changing the `agent` slot's
+  chat model tears down the FLM trio (stt + embed go with it) and
+  restarts `flm serve <new-chat-model> --asr 1 --embed 1`. UI
+  surfaces "swap incoming, voice + embed paused".
+- **FLM .deb install is manual on Linux.** Lemonade's `flm:npu`
+  auto-installer is Windows-only as of v0.2. Linux install
+  procedure is PPA `lemonade-team/stable` + libxrt-npu2 + ffmpeg6
+  + boost1.83 + fftw3 + FastFlowLM `.deb`. The hal0 installer
+  handles this end-to-end; users running off-script need the
+  `hal0_lemonade_flm_npu_install` recipe.
+- **Ongoing pin maintenance** for two upstream artifacts (the
+  Lemonade embeddable tarball + the FastFlowLM `.deb`). Each hal0
+  release manually bumps both pins, sha256-verifies, and CI-smokes
+  the install + a triple-concurrency probe before tagging.
+
+[v0.2.0]: https://github.com/Hal0ai/hal0/releases/tag/v0.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing to hal0
 
-hal0 is licensed [Apache 2.0](./LICENSE). hal0 is in **v0.1.0-alpha**;
-the contribution model is still being decided (see
-[`PLAN.md`](./PLAN.md) §16). External PRs aren't being merged yet;
-please open issues for discussion.
+hal0 is licensed [Apache 2.0](./LICENSE). hal0 is at **v0.2.0** — the
+Lemonade Server adoption release. The contribution model is still
+being decided (see [`PLAN.md`](./PLAN.md) §16). External PRs aren't
+being merged yet; please open issues for discussion.
 
 When the model opens up, the shape will be:
 
@@ -23,9 +23,9 @@ is the last gate before a tagged release.
 
 | Tier | What it does | Where it runs | When | Local cmd |
 |---|---|---|---|---|
-| α  Unit | `pytest`, mocked systemd/docker/HTTP | any host, no daemons | every commit / PR | `make test` |
-| β  Integration | Real `hal0-slot@.service` + Vulkan-CPU toolbox + tiny GGUF; load → chat → swap → unload + SSE state stream | GitHub Actions runner (`integration.yml`) **and** any host with systemd + the template installed | every PR; required for merge | `make test-integration` |
-| γ  Release-gate | Full matrix — Vulkan, ROCm, NPU/FLM, STT/TTS smokes, OpenWebUI proxy, updater round-trip | `hal0-test` LXC (10.0.1.230) over SSH | per release candidate, not per-commit | `make release-test` |
+| α  Unit | `pytest`, mocked systemd/HTTP/Lemonade client | any host, no daemons | every commit / PR | `make test` |
+| β  Integration | Real `hal0-lemonade.service` + tiny GGUF; load → chat → swap → unload + slot state via `/v1/health` | GitHub Actions runner (`integration.yml`) **and** any host with systemd + Lemonade installed | every PR; required for merge | `make test-integration` |
+| γ  Release-gate | Full matrix — Lemonade `llamacpp` (Vulkan + ROCm + CPU), `flm:npu` trio, `whisper.cpp`, `kokoro:cpu`, `sd-cpp`, OpenWebUI proxy, updater round-trip | `hal0-test` LXC (10.0.1.230) over SSH | per release candidate, not per-commit | `make release-test` |
 
 ### α — unit (`make test`)
 
@@ -40,33 +40,34 @@ slower than that — integration-flavoured cases must be marked
 
 ### β — integration (`make test-integration`)
 
-Exercises the real systemd template unit and a real container. Needs
-root (the template lands in `/etc/systemd/system/`) and Docker.
+Exercises the real `hal0-lemonade.service` daemon. Needs root (units
+land in `/etc/systemd/system/`) and the Lemonade prerequisites
+(installed by `installer/install.sh`).
 
 Locally:
 
 ```sh
-sudo bash installer/install.sh --no-start    # writes hal0-slot@.service
+sudo bash installer/install.sh --no-start    # writes hal0-lemonade.service + config.json
 make test-integration
 ```
 
 In CI: `.github/workflows/integration.yml` does the install on the
-runner, builds `hal0-toolbox-vulkan` from `packaging/toolbox/vulkan.Dockerfile`,
-caches `Qwen/Qwen2.5-0.5B-Instruct-GGUF`, and runs three gated cases
-in `tests/slots/test_integration.py`:
+runner, caches `Qwen/Qwen2.5-0.5B-Instruct-GGUF`, and runs the gated
+cases in `tests/slots/test_integration.py`:
 
-1. `test_end_to_end_load_serve_unload` — full create → load → unload → delete
-2. `test_state_transitions_visible_via_stream` — SSE state stream sees `starting → warming → ready`
+1. `test_end_to_end_load_serve_unload` — full slot register → load → unload → delete via `/v1/load` + `/v1/unload`
+2. `test_state_transitions_visible_via_stream` — slot state stream sees `starting → warming → ready` (from `/v1/health` polling + Lemonade `/logs/stream` events)
 3. `test_full_state_machine_round_trip_via_stream` — full round-trip incl. `unloading → offline`
 
-Wall-clock budget: ≤12 minutes (PLAN §10, Integration β). Toolbox
-image build is layer-cached via GHA so cold-cache runs are ~10 min,
-hot-cache ~4.
+Wall-clock budget: ≤12 minutes (PLAN §10, Integration β). Lemonade's
+embeddable tarball is layer-cached via GHA so cold-cache runs are
+~10 min, hot-cache ~4.
 
 ### γ — release-gate (`make release-test`)
 
 SSHes into the hal0-test LXC and walks a matrix of seven rows:
-**vulkan, rocm, flm (NPU), moonshine (STT), kokoro (TTS), updater,
+**llamacpp-vulkan, llamacpp-rocm, flm-npu (chat + trio asr/embed),
+whispercpp (STT), kokoro-cpu (TTS), sd-cpp (image), updater,
 openwebui**. Each row produces a structured record; the full report
 lands in `tests/release-gate-report.json`.
 
@@ -84,10 +85,9 @@ make release-test-report
 
 Row status is one of `pass | fail | skip | deferred`:
 
-- **skip** — a required image isn't pinned in `manifest.json` yet
-  (Team A territory). Non-blocking.
-- **deferred** — a cross-team dependency isn't merged yet (e.g.
-  Team D's updater CLI). Non-blocking, but flagged in the report.
+- **skip** — a required dependency isn't pinned in `manifest.json` yet
+  (e.g. a new FastFlowLM `.deb` version waiting on a smoke). Non-blocking.
+- **deferred** — a cross-team dependency isn't merged yet. Non-blocking, but flagged in the report.
 - **fail** — exits the script non-zero; blocks the release.
 
 The hal0-test LXC is shared with other agents; `make release-test`
@@ -102,7 +102,7 @@ tag. It walks the per-release gate:
 
 - backend tests green
 - UI build clean
-- toolbox images present in `manifest.json` with non-empty digests
+- Lemonade embeddable tarball + FastFlowLM `.deb` pinned in `manifest.json` with non-empty sha256s
 - `release-test` last run within 24 h and all-pass
 - git working tree clean, tag doesn't yet exist, `pyproject.toml`
   version matches the proposed tag

--- a/PLAN.md
+++ b/PLAN.md
@@ -7,21 +7,122 @@ one-line install) and re-architected around the things that make hal0
 different from "a wrapper around llama-server": hardware-aware slots,
 clean lifecycle, and a real reliability bar.
 
-**Status (2026-05-22):** shipping as **v0.1.1** — Strix Halo, AMD GPU,
-NVIDIA GPU, and now WSL 2 + Proxmox VM + bare-metal-CPU-only Linux
-home installs. OpenAI-compatible inference, bundled OpenWebUI chat.
-v0.1.0-alpha was the cosign-keyless release-pipeline cut (2026-05-21);
-v0.1.1 (2026-05-22) is the first install that completes end-to-end on
-non-Strix-Halo hosts — the first-run wizard's writer calls authenticate
-cleanly, the chat model is optional (capabilities-only installs are a
-shape), the hardware probe is portable + platform-aware, and the
-capability dropdowns are seeded with real picks. Everything in §1
-"v0.1.1 ships" is in the box; v1.0 is the eventual stability/perf bar
-(see §1 "Path to v1.0").
+**Status (2026-05-23):** shipping as **v0.2.0** — the Lemonade Server
+migration release. AMD's Lemonade Server replaces the six per-modality
+toolbox containers and the `hal0-slot@.service` template as the
+unified inference runtime; `hal0-lemonade.service` supervises one
+`lemond` process per host. v0.2 also brings the OmniRouter client-side
+tool-calling loop (8 tools), the FLM trio NPU packing (chat + ASR +
+embed on one AMDXDNA hardware context), the first-run bundle picker
+(`hal0-Lite` / `Default` / `Pro` / `Max` + `LMX-Omni-52B-Halo`), the
+Lemonade admin panel + Journal panel in the dashboard, and the
+canonical `/var/lib/hal0/models/<recipe>/<capability>/` model layout.
+The 22-PR adoption sequence (PR-2 through PR-22) closes with this cut.
+v0.2 is a **breaking change** from v0.1.x — install.sh refuses to
+overwrite a v0.1.x state, prints the backup/wipe procedure, and ships
+`hal0 registry import` as the only recovery path. See
+[`docs/v0.2-upgrade.md`](docs/v0.2-upgrade.md) for the user-facing
+flow and [`docs/internal/lemonade-adoption-plan-2026-05-22.md`](docs/internal/lemonade-adoption-plan-2026-05-22.md)
+for the locked implementation contract.
+
+The v0.2 architecture decisions are recorded in
+[ADR-0008 (Lemonade adoption)](docs/internal/adr/0008-lemonade-adoption.md),
+[ADR-0009 (FLM trio NPU packing)](docs/internal/adr/0009-flm-trio-npu-packing.md),
+and [ADR-0010 (bundle picker — no default stack)](docs/internal/adr/0010-bundle-picker-no-default-stack.md).
+ADR-0006 / ADR-0007 are superseded.
+
+**Earlier shipping cuts:** v0.1.0-alpha (2026-05-21) was the
+cosign-keyless release-pipeline cut; v0.1.1 (2026-05-22) was the first
+install that completes end-to-end on non-Strix-Halo hosts;
+v0.2.0-alpha.3 (2026-05-22) shipped Phase 8 (Agents v0.2 + MCP +
+Cognee memory).
+
+**Path to v1.0** stays the same as v0.1's framing: stability bar,
+published perf baselines, docs parity. v0.3 is the next milestone —
+GPU TTS, KV% for GPU slots, Phase 8 polish + advanced memory,
+benchmarks/presets UI. See §1 "Path to v1.0" + §15 for the milestones.
 
 ---
 
 ## 1. Scope
+
+### v0.2 ships (current cut)
+
+The Lemonade Server adoption is now end-to-end. See
+[`docs/internal/lemonade-adoption-plan-2026-05-22.md`](docs/internal/lemonade-adoption-plan-2026-05-22.md)
+for the locked implementation contract (do not relitigate); the
+high-level deliverables are:
+
+- **Lemonade Server as the unified inference runtime.** One `lemond`
+  process per host on `127.0.0.1:13305`, supervised by
+  `hal0-lemonade.service`. Cache directory at
+  `/var/lib/hal0/lemonade/`. Six per-modality toolbox containers + the
+  `hal0-slot@.service` template retired.
+- **Capability dispatch via Lemonade.** `LemonadeProvider` is the only
+  `Provider` in v0.2; legacy provider classes are preserved as code
+  (still consumed by image-gen / hardware-probe / catalog non-slot
+  paths) but no longer in the dispatch path. The slot lifecycle state
+  machine in `src/hal0/slots/state.py` survives; per-slot systemd
+  + Provider ABC die.
+- **Slot model.** Bare-name identity + `type` (Lemonade vocab:
+  `llm | embedding | reranking | transcription | tts | image`) +
+  `device` (`gpu-rocm | gpu-vulkan | cpu | npu`) + `model` + `enabled`
+  + optional `default` + `group` for dashboard rollup. Six seeded
+  slots (`primary`, `embed`, `rerank`, `stt`, `tts`, `img`) plus three
+  NPU slots when FLM `.deb` is installed (`agent`, `stt-npu`,
+  `embed-npu`). User-added slots via `hal0 slot add NAME --type TYPE`.
+- **FLM trio NPU packing.** Lemonade's `flm.args = "--asr 1 --embed 1"`
+  packs chat + transcription + embedding into one `flm serve` process
+  on the single AMDXDNA hardware context. hal0's capability dispatcher
+  reads `/v1/health.loaded[].backend_url` for the FLM model and
+  routes `stt-npu` / `embed-npu` requests **directly** to that child's
+  port — Lemonade only knows about the chat role. NPU exclusivity (one
+  `device = "npu", type = "llm"` slot enabled at a time) enforced in
+  `capabilities.toml` validation. See ADR-0009.
+- **OmniRouter client-side tool-calling.** hal0 owns the OpenAI
+  tool-calling loop; Lemonade provides the tool endpoints. v0.2 ships
+  8 tools — 5 upstream-mirrored (`generate_image`, `edit_image`,
+  `text_to_speech`, `transcribe_audio`, `analyze_image`) and 3
+  hal0-custom (`embed_text`, `rerank_documents`, `route_to_chat`).
+  Dynamic per-request filtering by enabled-slot + required-label.
+- **Bundle picker on first run.** `capabilities.toml` ships empty;
+  the dashboard's first load renders four hardware-anchored tiers +
+  the AMD-curated `LMX-Omni-52B-Halo` kit + an explicit "Skip"
+  option. No silent defaults. See ADR-0010.
+- **Canonical model layout** at `/var/lib/hal0/models/<recipe>/<capability>/`;
+  Lemonade's `extra_models_dir` points here. Per-leaf symlinks
+  redirect to `/mnt/ai-models/` when a separate storage volume is in
+  use.
+- **Mandatory `llamacpp.args = "--parallel 1 --threads N"`** in the
+  lemond config baseline (N computed at install time as `(cores − 2) / 4`,
+  min 2). Without this, two concurrent child llama-servers deadlock
+  from CPU oversubscription. See memory
+  `hal0_lemonade_threads_deadlock`.
+- **Per-type LRU concurrency.** Six independent type budgets reported
+  by `/v1/health.max_models`; default budget set to 4 globally. Nuclear
+  evict-all only fires on `/v1/load` errors whose message does NOT
+  substring-match "not found" / "does not exist" / "No such file".
+  Active inference protection: a serving slot cannot be evicted out
+  from under a streaming request.
+- **`hal0 registry import`** — single command, restores `registry.toml`
+  from a v0.1.x backup tarball. Slot selections must be redone via
+  the bundle picker (alpha social contract).
+- **Settings → Lemonade admin panel** — `/internal/config` snapshot +
+  `/internal/set` atomic writes for a curated subset of keys.
+- **Journal panel folded into Logs tab** — Lemonade's `/logs/stream`
+  WebSocket streams into the dashboard's event ring.
+- **Metrics shim** — per-slot TTFT + tok/s + prompt_tokens via
+  `/v1/stats`; FLM-native KV% (`kv_token_occupancy_rate_percentage`)
+  on NPU slots. KV% reads `—` for GPU slots — see §12.1 of the
+  adoption plan for the accepted-missing rationale and the v0.2.x
+  patch path.
+- **`[CPU]` chip + tooltip** on the voice slot card disclosing that
+  kokoro is CPU-only in v0.2. GPU TTS deferred to v0.3.
+- **`HAL0_BACKEND=lemonade` env flag** introduced in PR-8 and removed
+  in PR-10 — Lemonade is the unconditional runtime now.
+
+The 22-PR adoption sequence (PR-2 #137 through PR-22) is closed.
+See §15 Phase 9 below for the per-PR map.
 
 ### v0.1.1 ships
 
@@ -146,13 +247,27 @@ sequence), then v0.2 deferred features as separate minor bumps.
 v0.1.1 is the latest patch in the `v0.1.x` line — bug fixes and
 non-Strix-Halo install completeness, no API shifts.
 
-### v0.2 (deferred)
+### v0.3 (next)
 
-- Memory subsystem
-- MCP support
-- Benchmarks UI + Presets UI
-- AUR PKGBUILD + Ubuntu PPA
-- Light mode toggle
+- **GPU-accelerated TTS** — closes the `[CPU]` chip on the voice slot
+  card; kokoro-vulkan or successor
+- **KV% for GPU slots** — Lemonade upstream populates the
+  `n_past`/`n_prompt_tokens`/`prompt` fields in `/slots`, or hal0
+  builds its own llama-server and swaps via `lemonade config set
+  llamacpp.{rocm_bin,vulkan_bin}`. v0.2.x patch path if upstream
+  takes >6 weeks (per ADR-0008 §Costs)
+- **Phase 8 polish + advanced memory** — Cognee graph extraction
+  (Kuzu) gated behind a configurable model + Memify pipeline +
+  additional source connectors. MCP client side of hal0 (bundled
+  agents reach external MCP servers with per-agent allow-list).
+  Memory federation across local + remote sources
+- **Benchmarks UI + Presets UI** — in-dashboard tok/s + latency runs;
+  curated loadout presets
+- **AUR PKGBUILD + Ubuntu PPA** — native distro packages
+- **`hal0.local` mDNS polish** — avahi auto-registration robustness
+- **Light mode toggle**
+- **Lemonade Omni vs hal0 capability-orchestrator interop strategy**
+  — coexist in v0.2; revisit pre-v0.3
 
 ### Strip (gone for good unless re-justified)
 
@@ -793,7 +908,7 @@ Working assumption: 1 person full-time + Claude as pair. Adjust if not.
 - Migrate haloai LXC → hal0 (cutover) — script ready (PR #22, `scripts/migrate-haloai.py` + 14-model curated allow-list); cutover script tested with synthetic fixtures, not yet against live haloai data
 - Public launch — pending §16 decisions (launch story, contribution model)
 
-**Phase 8 — Agents v0.2 (post-v1.0)** — ✅ done 2026-05-22 — combined Agents + MCP + basic memory release; design settled via grilling 2026-05-22, deliverables in `docs/adr/0004-agents.md` + `docs/adr/0005-memory-engine-cognee.md`. Public API docs: [`docs/api/mcp.md`](./docs/api/mcp.md), [`docs/api/agents.md`](./docs/api/agents.md).
+**Phase 8 — Agents v0.2 (initially v0.2; shipped 2026-05-22 ahead of the Lemonade migration)** — ✅ done 2026-05-22 — combined Agents + MCP + basic memory release; design settled via grilling 2026-05-22, deliverables in `docs/adr/0004-agents.md` + `docs/adr/0005-memory-engine-cognee.md`. Public API docs: [`docs/api/mcp.md`](./docs/api/mcp.md), [`docs/api/agents.md`](./docs/api/agents.md).
 
 - **Bundled agent app, single-pick at install.** Supported choices: `pi-coder` (CLI, installed from `Hal0ai/pi-mono` fork via `@earendil-works/pi-coding-agent` on npm) and `Hermes-Agent` (service, installed via the hal0-owned `hal0-hermes` wrapper around upstream `hermes`). User picks one via the first-run wizard or `hal0 agent {install,uninstall,list} <name>`; single-pick enforced; `--switch` flag for atomic swap. install.sh stays non-interactive (no `--agent` flag).
 - **hal0 admin MCP server at `/mcp/admin`.** Tools wrap existing `/api/*` routes only (rule: a tool ships iff it maps to an existing `/api/*` route — no new privileged surface). Bearer-token auth reused from ADR-0001. Two-tier scope: routine ops (slot status / list / `model_swap` / hardware probe / logs) autonomous; capital-D destructives (`model_pull`, `slot_restart/create/delete`, `capability_set`, `config_write`) gated.
@@ -806,7 +921,26 @@ Working assumption: 1 person full-time + Claude as pair. Adjust if not.
   - `topoteretes/cognee-integrations/integrations/claude-code` — Claude Code plugin using six lifecycle hooks + `node_set` tagging (user-context / project-docs / agent-actions). Gives Claude Code users a second path into the same Cognee store, complementary to MCP.
   - `topoteretes/cognee-integrations/integrations/openclaw-skills` — `SKILL.md` + YAML-frontmatter format + Ingest → Execute → Observe → Amendify loop. Reference shape if hal0 ever grows agent-side skills (distinct from the platform "skills" = MCP tools settled here).
 
-**Phase 9 — Advanced memory + MCP client side (post-v0.2)** — unscheduled; deliverables in `docs/adr/0006-advanced-memory.md`.
+**Phase 9 — Lemonade migration (v0.2)** — ✅ done 2026-05-23 — Lemonade Server adopted as the unified inference runtime; six per-modality toolbox containers + the `hal0-slot@.service` template retired. Locked plan: [`docs/internal/lemonade-adoption-plan-2026-05-22.md`](docs/internal/lemonade-adoption-plan-2026-05-22.md). Architecture decisions: [ADR-0008](docs/internal/adr/0008-lemonade-adoption.md) (adoption), [ADR-0009](docs/internal/adr/0009-flm-trio-npu-packing.md) (FLM trio), [ADR-0010](docs/internal/adr/0010-bundle-picker-no-default-stack.md) (bundle picker). ADR-0006 / ADR-0007 superseded.
+
+22 PRs across 6 sub-phases:
+
+| Sub-phase | PRs | Scope |
+|---|---|---|
+| Foundation | PR-2 (#137), PR-3 (#156) | Lemonade HTTP client skeleton + typed `/v1/*` + `/internal/*` endpoints |
+| Install + registry | PR-4 (#157), PR-5 (#159), PR-6 (#141 → #151), PR-7 (#158) | PPA + FLM `.deb` + `hal0-lemonade.service` + `registry sync` + canonical model layout |
+| Slot layer rewrite | PR-8 (#161), PR-9 (#160), PR-10 (#162) | `LemonadeProvider` dispatch + toolbox + slot-template retirement + `SlotManager` simplification (~358 LOC delta) |
+| UI + metrics | PR-11 (#163), PR-12 (#179), PR-13 (#183), PR-14 (#184), PR-15 (#186) | Dashboard from `/v1/health` + metrics shim + Lemonade admin panel + Journal panel + `[CPU]` chip |
+| OmniRouter + bundles | PR-16 (#189), PR-17 (#196), PR-18 (#198) | Client-side OmniRouter (8 tools) + bundle picker + chat surface |
+| NPU + close-out | PR-19 (#201), PR-20 (#202), PR-21 (#203), PR-22 (this PR) | FLM trio dispatch + NPU exclusivity + v0.1.x detect + `hal0 registry import` + docs sync |
+
+Cross-cutting:
+- PR-2 #137 already shipped pre-grill; the adoption plan's PR-1 is implicit ("write the plan").
+- The `HAL0_BACKEND=lemonade` env flag introduced in PR-8 was removed in PR-10 (Lemonade is unconditional now).
+- Legacy provider classes (`hal0/providers/{llama_server,flm,moonshine,kokoro,comfyui}.py`) are preserved as code — still consumed by image-gen / hardware probe / catalog non-slot consumers — but no longer in the dispatch path.
+- v0.2.1 dashboard rewrite (slice #176, PR #199) cut over on `feat/dash-v2-rework` in parallel; PR #197 carries the v2 polish work and remains open at v0.2 ship.
+
+**Phase 10 — Advanced memory + MCP client side (post-v0.2)** — unscheduled; deliverables in `docs/adr/0006-advanced-memory.md` (file path may move; ADR-0006 is currently the Lemonade superseded ADR).
 
 - **Enable Cognee's advanced features** — graph extraction (Kuzu) gated behind a configurable model (small local models are unreliable at structured output; default to OpenRouter or a 70B-class local model for graph builds), Memify pipeline for memory hygiene, additional source connectors.
 - **MCP client side of hal0** — bundled agents can reach external MCP servers (filesystem scoped to `/var/lib/hal0/agents/<name>/workspace`, web search, third-party memory services like Supermemory or Hindsight). Per-agent allow-list in agent config.
@@ -815,7 +949,7 @@ Working assumption: 1 person full-time + Claude as pair. Adjust if not.
 - **Migration importers** — one-shot scripts to pull upstream agent history into the Cognee store: `migrate-pi-memory-md.py`, `migrate-hermes-mem.py`, `migrate-mem0.py` (for users transitioning from existing mem0 installs).
 - **Optional self-improving skills loop** — adopt the openclaw-skills SKILL.md pattern if the bundled agent supports it; stretch goal, not a v0.3 commitment.
 
-**Total: ~10 weeks of focused work through v1.0.** Phase 8 (v0.2) is post-v1.0 and unestimated. Phases 1–6 closed in ~3 weeks of compressed sprint work + a multi-agent sweep on 2026-05-15.
+**Total: ~10 weeks of focused work through v1.0.** Phase 8 (Agents v0.2) shipped 2026-05-22 ahead of the Lemonade migration; Phase 9 (Lemonade) shipped 2026-05-23. Phases 1–6 closed in ~3 weeks of compressed sprint work + a multi-agent sweep on 2026-05-15.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,110 +15,141 @@
 
 hal0 turns a Linux box — ideally a Ryzen AI Max+ 395 with 128 GB of
 unified memory — into a polished, OpenAI-compatible inference appliance.
-Slots, dispatcher, hardware probe, prewired chat UI, signed self-update.
-One command installs the lot.
+A unified runtime, hardware-aware slots, prewired chat UI, signed
+self-update. One command installs the lot.
 
-It is not another llama-server wrapper. Every workload is a real
-systemd-managed slot with a typed lifecycle, the API surface covers
-chat *and* embed *and* rerank *and* STT *and* TTS *and* image gen, and
-the dashboard is for operating the box — not for chatting with it.
+It is not another llama-server wrapper. v0.2 ships **AMD's Lemonade
+Server as the unified inference runtime** behind a thin hal0 capability
+layer. Every workload — chat, embed, rerank, STT, TTS, image gen —
+runs as a real, named slot in `capabilities.toml`; the API surface
+covers the full OpenAI-compatible matrix; the dashboard is for
+operating the box, not chatting with it.
 
 ```sh
 curl -fsSL https://hal0.dev/install.sh | bash
 ```
 
-> **Status:** **v0.1.1**, shipping. v0.1.0-alpha was the
-> cosign-keyless-OIDC release-pipeline cut; v0.1.1 is the first install
-> that completes end-to-end on every supported host (WSL 2, Proxmox VMs,
-> bare-metal Linux), not just Strix Halo. The probe is portable, the
-> wizard's writer calls authenticate cleanly, and chat-model selection
-> is optional for boxes that want a capabilities-only install. Expect
-> rough edges: APIs may shift, slot lifecycle bugs are still being
-> shaken out, and we don't promise upgrade compatibility across `0.1.x`
-> tags. See [`PLAN.md`](./PLAN.md) §1 for what ships now and the path
-> to v1.0.
+> **Status:** **v0.2.0** — first release on the Lemonade runtime.
+> Six per-modality toolbox containers, the `hal0-slot@.service` template,
+> and the legacy Provider stack all retired in favour of one
+> `hal0-lemonade.service` supervising a single `lemond` daemon. v0.1.x
+> installs do **not** auto-upgrade — see
+> [`docs/v0.2-upgrade.md`](./docs/v0.2-upgrade.md) for the back-up + wipe
+> + reinstall procedure and the `hal0 registry import` recovery path.
+> First run lands a **bundle picker** (`hal0-Lite` / `Default` / `Pro` /
+> `Max` + `LMX-Omni-52B-Halo`) — `capabilities.toml` ships empty by
+> design, no silent default. Expect rough edges: APIs may shift, KV%
+> for GPU slots reads `—` in v0.2 (see [ADR-0008
+> §Costs](./docs/internal/adr/0008-lemonade-adoption.md)), and we don't
+> promise upgrade compatibility across `0.2.x` tags. See
+> [`PLAN.md`](./PLAN.md) §1 for what ships now and the path to v1.0.
 
 ## Why hal0
 
 **Strix Halo native, but not Strix-Halo-only.** The probe is UMA-aware
 on Strix Halo and falls back to portable parsers (`/proc/cpuinfo`,
-`/proc/meminfo`, `lspci`) on every other host. As of v0.1.1 the
-`platform` field on `/api/hardware` resolves to one of `strix-halo`,
-`wsl2`, `lxc`, `proxmox-kvm`, `kvm`, `bare-metal-{nvidia,amd,intel}-gpu`,
-or `bare-metal-cpu-only`, and the dashboard only labels memory as
+`/proc/meminfo`, `lspci`) on every other host. The `platform` field on
+`/api/hardware` resolves to one of `strix-halo`, `wsl2`, `lxc`,
+`proxmox-kvm`, `kvm`, `bare-metal-{nvidia,amd,intel}-gpu`, or
+`bare-metal-cpu-only`, and the dashboard only labels memory as
 "unified" when it actually is. The slot-fit warnings size against the
-real unified pool, not a BAR carve-out. The XDNA NPU has a first-class
-provider (FLM) that's only surfaced in the picker when the hardware
-*and* the toolbox image are both present. 128 GB Ryzen AI Max+ 395 is
+real unified pool, not a BAR carve-out. The XDNA NPU is a first-class
+device — opt-in even at Pro/Max tier, packing three model roles into
+one process via the FLM trio (see below). 128 GB Ryzen AI Max+ 395 is
 the reference deployment — not a hopeful port.
 
-**Concurrent chat + embed + voice + image.** Five built-in slot
-classes (`primary`, `embed`, `stt`, `tts`, `img`), each a real
-systemd-managed process on its own port, run at the same time. On
-Strix Halo, primary + embed concurrent measures **~258 tok/s** with
-**<200 ms** dispatch — both slots hot, iGPU at ~9 GB GTT.
+**One inference runtime, six modalities.** Lemonade Server's per-type
+LRU policy lets chat, embed, rerank, STT, TTS, and image generation
+share one process pool. Concurrent chat + embed + image on Strix Halo
+measured at 1.10s wall-clock under spike #2 with zero evictions; chat
++ embed alone sustains the same ~258 tok/s baseline the v0.1 toolbox
+stack hit, with `--parallel 1 --threads N` mandatory in the daemon
+config to keep the Vulkan dispatch from oversubscribing CPU cores
+(memory: `hal0_lemonade_threads_deadlock`).
 
-**Dispatcher with single-flight + structured decisions.**
-Registry-aware routing across local slots *and* external upstreams
-(OpenRouter, Anthropic, OpenAI, custom). Cold-cache prefetch with
-request coalescing — a thundering herd of identical prefetches
-becomes one HTTP call. Every routing decision logged as a structured
-breadcrumb.
+**NPU multi-role via the FLM trio.** On Strix Halo with FastFlowLM
+installed, a single `flm serve` process hosts chat + transcription +
+embedding concurrently on the one AMDXDNA hardware context — ~2 GB
+NPU memory, gemma3:1b at 40 tok/s + Whisper-V3-Turbo + Embedding-Gemma
+all coresident. hal0 exposes this as three slots (`agent`, `stt-npu`,
+`embed-npu`) that all back the same FLM child via direct port dispatch.
+See [ADR-0009](./docs/internal/adr/0009-flm-trio-npu-packing.md) for
+why.
+
+**Dispatcher with single-flight + OmniRouter tool-calling.** Registry-aware
+routing across local slots *and* external upstreams (OpenRouter,
+Anthropic, OpenAI, custom). v0.2 adds a client-side OmniRouter loop:
+8 OpenAI tool-calling tools (image generation/editing, TTS,
+transcription, vision, embed, rerank, route_to_chat) dispatched
+through hal0 from any chat slot whose model carries the `tool-calling`
+label. The set is filtered per request — a tool only appears in the
+prompt if its target slot is enabled and its model carries the
+required labels.
 
 **Reliability bar.** Atomic env file writes. Schema-validated TOML.
 Structured error envelopes (`{"error":{"code":"slot.not_ready",...}}`).
-Adaptive cold-boot health probes that demand a real `/v1/chat/completions`
-round-trip, not just a populated `/v1/models` list. Cosign-verified
-self-update with one-flag rollback. The things you'd otherwise script
-around `llama-server` by hand.
+Cosign-verified self-update with one-flag rollback. Per-type LRU
+concurrency with active-inference protection — a serving slot cannot
+be evicted out from under a streaming request.
 
 ## What's in the box
 
 - **OpenAI-compatible `/v1/*` API** — chat, completions, embeddings,
   rerank, audio transcriptions, audio speech, image generations,
-  models. Drop-in for any OpenAI SDK; point your client at
-  `http://localhost:8080/v1` and go.
-- **Slots** — each inference workload runs in its own systemd-managed
-  container with a known port, a typed lifecycle
-  (`offline → pulling → starting → warming → ready → serving ↔ idle
-  → unloading`), and a real health probe. State is persisted to
-  `state.json` and streamed over SSE so the dashboard reflects reality,
-  not `systemctl is-active` snapshots.
-- **Capability slots overlay** — thin UX layer grouping flat slots
-  into operator-facing cards (Embed / Voice / Image + NPU backend
-  rollup). Selections persist in `/etc/hal0/capabilities.toml`;
-  `CapabilityOrchestrator.apply()` reconciles selections against
-  `slots/*.toml` on every call — no drift between what you picked and
-  what's running.
+  image edits, models. Drop-in for any OpenAI SDK; point your client
+  at `http://localhost:8080/v1` and go.
+- **Slots** — each named target in `capabilities.toml` carries a
+  Lemonade-vocab `type` (`llm | embedding | reranking | transcription
+  | tts | image`), a `device` (`gpu-rocm | gpu-vulkan | cpu | npu`), a
+  `model`, plus `enabled` and optional `default`. Six seeded slots
+  (`primary`, `embed`, `rerank`, `stt`, `tts`, `img`) plus three NPU
+  slots (`agent`, `stt-npu`, `embed-npu`) when FastFlowLM is installed.
+  User-added slots via `hal0 slot add NAME --type TYPE --model MODEL`.
+- **Lemonade as the unified runtime** — one `lemond` process,
+  loopback-only on `:13305`, supervised by `hal0-lemonade.service`.
+  Cache + config at `/var/lib/hal0/lemonade/`. The hal0 capability
+  layer is the only user-facing inference surface; Lemonade is
+  treated as an internal runtime, never exposed off-box.
+- **Bundle picker on first run** — `capabilities.toml` ships empty by
+  design. The dashboard's first load surfaces four hardware-anchored
+  tiers (`hal0-Lite` ≥16 GB / `Default` ≥32 GB / `Pro` ≥64 GB / `Max`
+  ≥100 GB) plus the vendor-blessed `LMX-Omni-52B-Halo` kit. Tiers
+  that don't fit the detected unified RAM grey out with a tooltip.
+  See [ADR-0010](./docs/internal/adr/0010-bundle-picker-no-default-stack.md)
+  for the no-silent-default rationale.
 - **Hardware-aware probe** — detects GPU / NPU / unified memory,
   writes `/etc/hal0/hardware.json`, surfaces VRAM/RAM fit warnings
-  inline in the slot form. Picks the right backend automatically;
-  you don't pin one by hand.
+  inline in the slot form and the bundle picker.
 - **Dispatcher** — registry-aware routing, cold-cache prefetch,
   upstream fallback (OpenRouter, Anthropic, OpenAI, custom OpenAI-shaped
   endpoints). Mix local + remote per-model in one config.
 - **Dashboard** — Vue 3 + Tailwind 4 UI for slot/model management,
   hardware-aware configuration, live logs, and system health. SSE-backed
-  status + log tail. Dark by default.
+  status + log tail. Lemonade `/logs/stream` folded into the Journal
+  panel. Settings → Lemonade admin panel surfaces the daemon's
+  `/internal/config` for inspection. Dark by default.
 - **OpenWebUI prewired** — chat at `:3001`, zero config. The installer
   writes `openwebui.env` pointing at the local hal0 API.
-- **Image generation, day one** — `POST /v1/images/generations`
-  served by a bundled ComfyUI provider on ROCm. Curated SDXL Turbo /
-  SD 1.5 / Flux Schnell with license badges; the `img` slot runs
-  inside the same lifecycle as everything else.
-- **First-run wizard** — 8 linear steps from password through hardware,
-  primary model, capabilities, optional HF token, license aggregation,
-  parallel pulls, done.
+- **OmniRouter (8 tools)** — `generate_image`, `edit_image`,
+  `text_to_speech`, `transcribe_audio`, `analyze_image` (vision),
+  `embed_text`, `rerank_documents`, `route_to_chat`. Dispatched
+  client-side from chat slots; dynamically filtered per request.
+- **Image generation, day one** — `POST /v1/images/generations` via
+  `sd-cpp` (Lemonade-bundled). Bundle manifests pre-pick SDXL Turbo /
+  Flux-2-Klein-9B as fits the tier.
+- **First-run wizard + bundle picker** — password setup → bundle pick
+  (or "Skip — configure manually") → models download in background.
 - **Atomic self-update with rollback** — `hal0 update --channel
   stable|nightly`. Cosign-verified tarballs swap a
-  `/usr/lib/hal0/current` symlink; `--rollback` reverts. Slot units
-  survive API restarts.
+  `/usr/lib/hal0/current` symlink; `--rollback` reverts.
 - **One-line install** — `curl -fsSL https://hal0.dev/install.sh | bash`
-  (`--models-dir=PATH` or `HAL0_MODELS_DIR=PATH` redirects HuggingFace
-  pulls off `/var/lib/hal0/models`). The bootstrap fetches the release
+  (`--models-dir=PATH` or `HAL0_MODELS_DIR=PATH` redirects model pulls
+  off `/var/lib/hal0/models`). The bootstrap fetches the release
   manifest, sha256-verifies the tarball, cosign-verifies the signature
   against the workflow OIDC identity, then hands off to
-  [`installer/install.sh`](./installer/install.sh).
+  [`installer/install.sh`](./installer/install.sh). v0.1.x installs
+  are detected and refused with explicit backup/wipe instructions
+  (see [`docs/v0.2-upgrade.md`](./docs/v0.2-upgrade.md)).
 
 ### Bundled agents (v0.2)
 
@@ -140,19 +171,29 @@ a header bell + inbox modal in the dashboard, with CLI parity via
 
 ## Backends
 
-| Backend     | Hardware                | Use case                           |
-|-------------|-------------------------|------------------------------------|
-| llama.cpp   | Vulkan (default) / ROCm | chat, embed, rerank, vision        |
-| FLM         | AMD XDNA NPU (opt-in)   | chat + embed (ASR multiplex available via `defaults.load_asr`; Moonshine is the default STT) |
-| Moonshine   | CPU                     | STT (`/v1/audio/transcriptions`)   |
-| Kokoro      | CPU / Vulkan            | TTS (`/v1/audio/speech`)           |
-| ComfyUI     | ROCm                    | image gen (`/v1/images/generations`) |
+v0.2 routes every inference workload through Lemonade Server. The
+table below lists the Lemonade recipe each capability uses, plus the
+hardware device it targets.
 
-The NPU/FLM column is populated at runtime from `flm list -j` inside
-the FLM toolbox image — hal0 doesn't pretend a GGUF runs on the NPU,
-and the dashboard's model picker narrows the backend dropdown to the
-backends a given model can actually serve. (`hal0 capabilities migrate`
-cleans up persisted selections that pre-date this check.)
+| Capability    | Lemonade recipe        | Device                  | Notes                                                       |
+|---------------|------------------------|-------------------------|-------------------------------------------------------------|
+| chat + embed + rerank | `llamacpp`     | Vulkan / ROCm / CPU     | `--parallel 1 --threads N` mandatory in `lemond` config     |
+| chat + STT + embed (NPU) | `flm:npu`   | AMD XDNA (opt-in)       | FLM trio: one process, `--asr 1 --embed 1`, ~2 GB NPU mem  |
+| transcription | `whisper.cpp`          | Vulkan / CPU            | Replaces v0.1 Moonshine for the CPU/GPU path                |
+| TTS           | `kokoro:cpu`           | CPU                     | `[CPU]` chip + tooltip in dashboard; GPU TTS deferred to v0.3 |
+| image         | `sd-cpp`               | ROCm / Vulkan           | SD Turbo / Flux-2-Klein-9B selectable per bundle tier       |
+
+The NPU path is opt-in: a FastFlowLM `.deb` install (manual on Linux —
+the Lemonade auto-installer is Windows-only as of v0.2) unlocks the
+three FLM slots. With FLM present, the bundle picker's Pro and Max
+tiers surface the trio as a toggle; the trio only auto-enables when a
+bundled agent is being installed in the same first-run flow.
+
+The hal0 toolbox containers (`hal0-toolbox-vulkan` / `rocm` / `flm` /
+`moonshine` / `kokoro` / `comfyui`) and the `hal0-slot@.service`
+template that supervised them are retired. v0.2's `lemond` daemon
+takes their place. See [ADR-0008](./docs/internal/adr/0008-lemonade-adoption.md)
+for the migration rationale.
 
 ## Hardware
 
@@ -164,21 +205,28 @@ are not in scope for v1.
 |-----------------|---------------------------------------------------------------------------|--------|
 | **First-class** | AMD Ryzen AI Max+ 395 ("Strix Halo") with iGPU + XDNA NPU + 128 GB unified | Reference deployment. All published perf numbers come from this box. |
 | **First-class** | AMD Ryzen AI Max 385 / 390 with 64 GB unified                              | Same path; small + mid tiers fit, 70B Q4 with shorter context. |
-| **Supported**   | NVIDIA RTX 30/40/50 (10–32 GB)                                            | CUDA-backed llama.cpp. Same slot lifecycle, dedicated VRAM instead of UMA. |
-| **Supported**   | AMD Radeon RX 7000 / discrete (16–24 GB)                                  | Vulkan today; ROCm toolbox image on the build list. |
-| **Fallback**    | CPU-only x86_64 / Vulkan-CPU                                              | CI runs Qwen 0.5B here. Usable for tiny models / smoke tests, not the headline experience. |
+| **Supported**   | NVIDIA RTX 30/40/50 (10–32 GB)                                            | CUDA-backed `llamacpp` via Lemonade. Same slot lifecycle, dedicated VRAM instead of UMA. |
+| **Supported**   | AMD Radeon RX 7000 / discrete (16–24 GB)                                  | ROCm via Lemonade's `llamacpp` recipe; Vulkan fallback. |
+| **Fallback**    | CPU-only x86_64                                                            | Lemonade's CPU path. Usable for tiny models / smoke tests, not the headline experience. |
 
 ## Project layout
 
 ```
 hal0/
-├── src/hal0/         # Python package (FastAPI API + slot manager + CLI)
+├── src/hal0/         # Python package (FastAPI API + capability layer + Lemonade client + CLI)
+│   ├── lemonade/     # HTTP client + catalog_sync + metrics_shim + log_proxy
+│   └── omni_router/  # client-side tool-calling loop + tool definitions
 ├── ui/               # Vue 3 + Tailwind 4 dashboard
-├── installer/        # install.sh (systemd unit templates live in packaging/systemd/)
+├── installer/        # install.sh (writes /var/lib/hal0/lemonade/config.json + hal0-lemonade.service)
 ├── tests/            # pytest suite (α unit, β integration, γ release-gate)
 ├── docs/             # user docs (mirror of hal0.dev/docs); dev docs under docs/internal/
-└── PLAN.md           # roadmap (current cut: v0.1.0-alpha; path to v1.0)
+└── PLAN.md           # roadmap (current cut: v0.2; path to v1.0)
 ```
+
+Models live under `/var/lib/hal0/models/<recipe>/<capability>/` — the
+canonical app-visible tree Lemonade's `extra_models_dir` points at.
+Per-leaf symlinks redirect to `/mnt/ai-models/` when a separate
+storage volume is in use. See PLAN.md §6.1 for the layout.
 
 ## Quick start (development)
 
@@ -198,15 +246,15 @@ The API lives at `http://127.0.0.1:8080`, the dashboard at the Vite dev
 server URL (usually `http://127.0.0.1:5173`).
 
 Run `hal0 doctor` any time to re-check pre-flight (systemd / python /
-docker / disk / ports). `hal0 model pull <ref>` streams models from
-Hugging Face into the registry, and `hal0 uninstall [--keep-data]`
-tears down a running install (thin wrapper over
+disk / ports). `hal0 model pull <ref>` streams models from Hugging Face
+into the registry under the `user.*` namespace, and `hal0 uninstall
+[--keep-data]` tears down a running install (thin wrapper over
 `installer/uninstall.sh`).
 
 ### Auth posture
 
 Per [ADR-0001](./docs/internal/adr/0001-collapse-edge-auth-into-fastapi.md), all
-auth lives in FastAPI. As of v0.1.0-alpha, a fresh install **starts locked** —
+auth lives in FastAPI. A fresh install **starts locked** —
 the dashboard, `/v1/*`, and every admin route reject anonymous requests
 with `401 auth.required`. Only the first-run wizard claim paths
 (`/api/install/*` and `POST /api/auth/password`) stay reachable, and
@@ -247,59 +295,48 @@ VM installs leave the panel off and the dashboard stays quiet.
 No dates — items are direction. The closer to the left, the closer to
 running on your box. Full version at [hal0.dev/roadmap](https://hal0.dev/roadmap).
 
-### Shipped (v0.1.1)
+### Shipped (v0.2)
 
-- OpenAI-compatible `/v1/*` API (chat / completions / embeddings /
-  rerank / transcriptions / speech / images / models)
-- Slot lifecycle state machine — atomic transitions, persisted +
-  SSE-streamed
-- Five-provider stack: llama.cpp, FLM (NPU), Moonshine, Kokoro, ComfyUI
-- **Portable hardware probe with platform detection** (v0.1.1) —
-  real CPU/RAM/GPU on WSL 2, Proxmox VMs, bare-metal Linux, plus a
-  `platform` field that drives UI labels ("unified memory" only when
-  it actually is). UMA path for Strix Halo stays the happy path
-- Capability slots overlay + orchestrator drift reconcile
-- **Curated capability picks in the wizard** (v0.1.1) — 3 embed picks
-  (nomic, bge-base, embed-gemma) + 2 rerank picks (bge-reranker-base,
-  bge-reranker-v2-m3) seed the dropdowns on a standalone install
-- Dispatcher with single-flight + cold-cache prefetch + upstream fallback
-- Bundled OpenWebUI on `:3001`, zero config
-- **First-run wizard (v0.1.1)** — 8 linear steps; chat-model selection
-  optional (capabilities-only installs are a legitimate shape);
-  conditional HF-token step; session cookie issued on first password
-  set so subsequent writer calls authenticate cleanly
-- Image generation via ComfyUI — curated SDXL Turbo / SD 1.5 / Flux Schnell
-- FLM NPU provider live with self-contained toolbox image
-- Caddy + basic auth + HTTPS, one flag (`--auth=basic`)
-- Cosign-keyless self-update with rollback, stable + nightly channels
-- Installer overhaul: preflight + hardware cards + `hal0 doctor` +
-  ERR-trap recovery hints + live-hello + QR + reachability finish
-- `--models-dir=PATH` install flag with auto-scan on first boot
-- Per-slot live metrics (`GET /api/slots/metrics`)
-- Optional Proxmox host-pressure integration (read-only `PVEAuditor` token)
+- **Lemonade Server unified inference runtime** — six per-modality
+  toolbox containers + the `hal0-slot@.service` template retire;
+  `hal0-lemonade.service` supervises one `lemond` daemon
+- **FLM trio NPU packing** — chat + ASR + embed coresident on one
+  AMDXDNA hardware context via `--asr 1 --embed 1`
+- **OmniRouter client-side tool-calling** — 8 tools, dynamic
+  per-request filtering, `route_to_chat` cross-slot delegation
+- **First-run bundle picker** — `hal0-Lite` / `Default` / `Pro` /
+  `Max` + `LMX-Omni-52B-Halo`, hardware-anchored, no silent default
+- **Per-type LRU concurrency** — six type budgets (LLM, embedding,
+  reranking, transcription, tts, image), nuclear-evict only on
+  unrecognised load errors
+- **Settings → Lemonade admin panel** — `/internal/config` snapshot +
+  `/internal/set` atomic config writes
+- **Journal panel** — Lemonade `/logs/stream` folded into Logs tab
+- **Metrics shim** — per-slot TTFT + tok/s + prompt_tokens via
+  `/v1/stats`; FLM-native KV% on NPU slots
+- **`hal0 registry import`** — one-shot v0.1.x → v0.2 registry
+  recovery from the backup tarball
+- Carried forward from v0.1.x: OpenAI-compatible `/v1/*`, portable
+  hardware probe, capability slots overlay + orchestrator, dispatcher
+  with single-flight + cold-cache prefetch, bundled OpenWebUI on
+  `:3001`, Caddy + auth + HTTPS, cosign-keyless self-update with
+  rollback, bundled agents (pi-coder / Hermes-Agent) + MCP admin +
+  Cognee memory MCP
 
-### Soon (v0.2)
+### Soon (v0.3)
 
-- **Hugging Face model pulls** — `POST /api/models/{id}/pull` is wired
-  in the picker + first-run wizard for v1.0; FLM tags need an
-  FLM-aware pull path since they don't carry an HF repo + filename
-- **Agent management & integration** — first-class agents stored on
-  hal0 with conversation orchestration and deterministic tool-use
-  loops. The platform for agents to run on, not just chat with
-- **Unified memory system** — persistent, federated memory across
-  local slots and (optionally) external models. Mem0-style API with
-  sources, search, and scoping
-- **MCP support — host and server** — hal0 speaks Model Context
-  Protocol both directions. Compose tools across local slots and
-  external MCP services; discover them from the dashboard
-- **Extensions framework** — third-party apps packaged as hal0
-  extensions: systemd unit + dashboard tile + healthcheck. BYO app,
-  lifecycle-managed
+- **GPU-accelerated TTS** — kokoro-vulkan or successor; closes the
+  `[CPU]` chip on the voice slot card
+- **KV% for GPU slots** — Lemonade upstream or hal0-built llama-server
+  swap-in; v0.2 ships `—`
+- **Phase 8 polish + advanced memory** — Cognee graph + Memify pipeline
+  enabled, MCP client side of hal0 (agents reach external MCP servers),
+  federated memory across local + remote sources
 - **Benchmarks & presets UI** — in-dashboard tok/s + latency runs,
   plus curated loadout presets you can flash onto a fresh install
 - **AUR PKGBUILD & Ubuntu PPA** — native distro packages on top of
   the install script; pacman and apt as first-class install paths
-- `hal0.local` mDNS auto-discovery
+- `hal0.local` mDNS auto-discovery polish
 - Light mode toggle
 
 ### Exploring (v1.x +)
@@ -311,9 +348,8 @@ running on your box. Full version at [hal0.dev/roadmap](https://hal0.dev/roadmap
   warm base model without unloading the underlying weights
 - **Per-model rate limits & budgets** — cost-style accounting for
   local inference — cap a chatty agent without taking the whole box down
-- **Voice mode end-to-end** — Moonshine + agent loop + Kokoro stitched
-  into a hands-free streaming conversation, gated through the slot
-  lifecycle
+- **Voice mode end-to-end** — Lemonade's `/realtime` WebSocket +
+  agent loop stitched into a hands-free streaming conversation
 - **ChatOps adapters** — Slack and Matrix bridges as extensions —
   talk to hal0 from the rooms you already live in
 

--- a/docs/internal/SESSION_HANDOFF_2026-05-22.md
+++ b/docs/internal/SESSION_HANDOFF_2026-05-22.md
@@ -118,3 +118,14 @@ Mirror `docs/internal/lemonade-spike-runbook.md` shape. Validate on hal0 LXC 105
 - 4 specialist plan agents for Lemonade re-grill — read-only analysis, results captured in this doc + chat.
 - Live verify on hal0 LXC: dashboard agent install, MCP admin/memory enumeration.
 - Doc syncs: PLAN.md, README.md (hal0), CONTENT_BRIEF.md (hal0-web).
+
+## v0.2 ship-cut 2026-05-23
+
+The Lemonade migration shipped. ADR-0008 / ADR-0009 / ADR-0010
+landed in #154; the 22-PR adoption sequence (PR-2 #137 through PR-22
+— docs sync) is closed. README + PLAN + CHANGELOG + the v0.2 upgrade
+guide + release notes synced in PR-22. The "one open decision" in the
+section above was settled by the post-grill adoption plan
+(`docs/internal/lemonade-adoption-plan-2026-05-22.md`) — Path 4
+(Lemonade for all iGPU + NPU modalities) chosen, ADR-0006 / ADR-0007
+superseded.

--- a/docs/release-notes/v0.2.0.md
+++ b/docs/release-notes/v0.2.0.md
@@ -1,0 +1,191 @@
+# hal0 v0.2.0 — the Lemonade adoption release
+
+**hal0 v0.2.0** rebuilds hal0's inference layer around AMD's
+[Lemonade Server](https://lemonade-server.ai/). Six per-modality
+toolbox containers (vulkan, rocm, flm, moonshine, kokoro, comfyui)
+and the `hal0-slot@.service` systemd template that supervised them
+retire in favour of one `hal0-lemonade.service` driving a single
+`lemond` daemon. Chat, embed, rerank, STT, TTS, and image generation
+all flow through the same process pool with per-type LRU concurrency,
+nuclear-evict only on the genuinely-unexpected, and OpenAI tool
+calling stitched on top via a new client-side OmniRouter loop.
+
+**This is a breaking change from v0.1.x.** install.sh refuses to
+overwrite a v0.1.x state and prints the backup + wipe + reinstall
+procedure. Recovery for the model registry is a single command
+(`hal0 registry import`); slot selections are re-picked through the
+new bundle picker. See the [upgrade guide](https://hal0.dev/docs/v0.2-upgrade)
+for the full procedure.
+
+## What's new
+
+- **Lemonade Server as the unified inference runtime.** One `lemond`
+  process per host, loopback-only on `:13305`, supervised by
+  `hal0-lemonade.service`. Cache + config at
+  `/var/lib/hal0/lemonade/`. Newer llama.cpp build via AMD's
+  release train; hal0 no longer carries a pinned llama.cpp branch.
+- **FLM trio NPU packing.** On Strix Halo with FastFlowLM installed,
+  one `flm serve` process hosts chat + transcription + embedding
+  concurrently on the single AMDXDNA hardware context (~2 GB NPU
+  memory, gemma3:1b at 40 tok/s + Whisper-V3-Turbo + Embedding-Gemma
+  all coresident). hal0 exposes this as three slots (`agent`,
+  `stt-npu`, `embed-npu`) backing the same FLM child; the
+  capability dispatcher reads `/v1/health.loaded[].backend_url` and
+  routes `stt-npu` / `embed-npu` requests directly to the child's
+  port. See [ADR-0009](https://github.com/Hal0ai/hal0/blob/main/docs/internal/adr/0009-flm-trio-npu-packing.md).
+- **OmniRouter client-side tool-calling (8 tools).** Chat slots with
+  models carrying the `tool-calling` label get an OpenAI tool catalog
+  dispatched through hal0: `generate_image`, `edit_image`,
+  `text_to_speech`, `transcribe_audio`, `analyze_image`, `embed_text`,
+  `rerank_documents`, `route_to_chat`. Dynamic per-request filtering:
+  a tool only appears in the prompt if at least one enabled slot of
+  its target type exists and (for label-gated tools) its model has
+  the required labels. `route_to_chat` lets one chat slot delegate
+  a single message to another (e.g. `primary` to `coder`).
+- **First-run bundle picker.** `capabilities.toml` ships empty by
+  design — no silent default model stack. The first dashboard load
+  renders four hardware-anchored tiers (`hal0-Lite` ≥16 GB /
+  `Default` ≥32 GB / `Pro` ≥64 GB / `Max` ≥100 GB Strix Halo) plus
+  the AMD-curated `LMX-Omni-52B-Halo` kit. Tiers that don't fit
+  detected unified RAM grey out. An explicit "Skip — configure
+  manually" path leaves slots empty with per-card Configure buttons.
+  See [ADR-0010](https://github.com/Hal0ai/hal0/blob/main/docs/internal/adr/0010-bundle-picker-no-default-stack.md).
+- **Per-type LRU concurrency.** Six independent type budgets (`llm`,
+  `embedding`, `reranking`, `transcription`, `tts`, `image`),
+  default global budget set to 4. Concurrent chat + embed + rerank +
+  image all validated in spike #2. Active-inference protection
+  means a serving slot can't be evicted out from under a streaming
+  request. Nuclear evict-all only fires on `/v1/load` errors whose
+  message does NOT substring-match "not found" / "does not exist" /
+  "No such file" — common failure modes return graceful errors and
+  leave the loaded pool intact.
+- **Lemonade admin panel.** Settings → Lemonade surfaces the
+  daemon's `/internal/config` snapshot with atomic `/internal/set`
+  writes for a curated subset of keys (`max_loaded_models`,
+  `ctx_size`, `log_level`, etc.). Guards against overriding
+  `llamacpp.args` to an unbounded value (would cause the multi-LLM
+  CPU oversubscription deadlock).
+- **Journal panel.** Lemonade's `/logs/stream` WebSocket folds into
+  the Logs tab, alongside hal0's own structured journal. The
+  nuclear-evict banner surfaces via log line parsing.
+- **Metrics shim.** Per-slot TTFT + tok/s + prompt_tokens scraped
+  from `/v1/stats`. FLM-native KV% (`kv_token_occupancy_rate_percentage`)
+  on NPU slots. (GPU slots: see Known limitations.)
+- **`hal0 registry import`** — single command to recover
+  `registry.toml` from a v0.1.x backup tarball. The only sanctioned
+  v0.1 → v0.2 data carry-over path.
+- **Slot model.** Each slot carries a Lemonade-vocab `type`
+  (`llm | embedding | reranking | transcription | tts | image`), a
+  `device` (`gpu-rocm | gpu-vulkan | cpu | npu`), a `model`, plus
+  `enabled` and optional `default`. Six seeded slots + three NPU
+  slots when FastFlowLM is installed. User-added slots via
+  `hal0 slot add NAME --type TYPE --model MODEL`.
+- **Canonical model layout** at `/var/lib/hal0/models/<recipe>/<capability>/`
+  — Lemonade's `extra_models_dir` points here. Per-leaf symlinks
+  back to `/mnt/ai-models/` keep your large-disk overflow path
+  working.
+- **`[CPU]` chip + tooltip** on the voice slot card disclosing
+  kokoro is CPU-only in v0.2 (GPU TTS deferred to v0.3).
+
+## Breaking changes
+
+- **No auto-migration from v0.1.x.** install.sh detects v0.1.x state
+  (presence of `/etc/hal0/slots/*.toml` AND absence of
+  `/var/lib/hal0/lemonade/config.json`) and refuses to install,
+  printing backup + wipe instructions and exiting non-zero.
+- **Toolbox containers retired.** `hal0-toolbox-vulkan` / `rocm` /
+  `flm` / `moonshine` / `kokoro` / `comfyui` are no longer built or
+  pulled.
+- **`hal0-slot@.service` template retired.** Per-slot units no
+  longer exist; `hal0-lemonade.service` is the new supervisor.
+- **Model layout reorganised** to `/var/lib/hal0/models/<recipe>/<capability>/`.
+- **`/etc/hal0/slots/*.toml` removed** as a persistence surface;
+  `capabilities.toml` is now the single source of truth for slot
+  selections.
+- **Moonshine STT retired** in favour of `whisper.cpp` via Lemonade.
+- **ComfyUI retired** in favour of `sd-cpp`; power-users are
+  directed to external ComfyUI installations for advanced workflows.
+
+## Upgrading from v0.1.x
+
+See [`docs/v0.2-upgrade.md`](https://github.com/Hal0ai/hal0/blob/main/docs/v0.2-upgrade.md)
+for the step-by-step procedure. Short form:
+
+```sh
+# 1. Back up the registry (skip if not preserving v0.1 model metadata)
+sudo tar czf hal0-v0.1-backup-$(date +%F).tar.gz /etc/hal0 /var/lib/hal0/registry
+
+# 2. Stop + disable v0.1.x services
+sudo systemctl stop 'hal0-slot@*' hal0-api hal0-openwebui
+sudo systemctl disable 'hal0-slot@*' hal0-api hal0-openwebui
+
+# 3. Wipe v0.1.x state
+sudo rm -rf /etc/hal0 /var/lib/hal0 /opt/hal0
+sudo rm -f /etc/systemd/system/hal0-slot@.service \
+           /etc/systemd/system/hal0-api.service \
+           /etc/systemd/system/hal0-openwebui.service
+sudo systemctl daemon-reload
+
+# 4. Install v0.2 fresh
+curl -fsSL https://hal0.dev/install.sh | bash
+
+# 5. Recover the registry
+hal0 registry import hal0-v0.1-backup-$(date +%F).tar.gz
+hal0 registry sync
+
+# 6. Open the dashboard and pick a bundle (Lite / Default / Pro / Max / LMX / Skip)
+```
+
+## Known limitations
+
+- **KV% for GPU slots reads `—`.** Lemonade's bundled `llama-server`
+  (b9253 Vulkan, b1274 ROCm) returns `null` for `n_past` /
+  `n_prompt_tokens` / `prompt` in `/slots` responses. PR #124's
+  KV%-from-`/slots` strategy from v0.1.x didn't survive the
+  migration. FLM/NPU slots are unaffected — they read KV% native
+  from `kv_token_occupancy_rate_percentage`. v0.2.x patch path: hal0
+  builds its own llama-server and swaps via `lemonade config set
+  llamacpp.{rocm_bin,vulkan_bin}` if upstream takes >6 weeks to
+  populate the fields.
+- **Kokoro TTS is CPU-only.** No upstream GPU-Kokoro on Linux at
+  v0.2 ship. The voice slot card surfaces a `[CPU]` chip + tooltip.
+  GPU-accelerated TTS planned for v0.3.
+- **Performance: parity-to-regression** vs the v0.1 hal0-Vulkan
+  baseline on tested models (-13% to -18% in spike #1; hermes-14b
+  at parity). Accepted in exchange for the maintenance collapse
+  from six toolboxes to one runtime.
+- **NPU LLM swap is slow (~14s).** Changing the `agent` slot's
+  chat model tears down the FLM trio (stt-npu + embed-npu go with
+  it) and restarts `flm serve <new-chat-model> --asr 1 --embed 1`.
+  Dashboard surfaces "swap incoming, voice + embed paused".
+- **FLM .deb install is manual on Linux.** Lemonade's `flm:npu`
+  auto-installer is Windows-only as of v0.2. The hal0 installer
+  handles the manual path (PPA `lemonade-team/stable` +
+  libxrt-npu2 + ffmpeg6 + boost1.83 + fftw3 + FastFlowLM `.deb`)
+  end-to-end.
+- **Ongoing pin maintenance** for two upstream artifacts (the
+  Lemonade embeddable tarball + the FastFlowLM `.deb`) — both ship
+  breaking changes on roughly weekly / monthly cadences. Each hal0
+  release manually bumps both pins, sha256-verifies, and CI-smokes
+  the install + a triple-concurrency probe before tagging.
+
+## Architecture context
+
+The full v0.2 implementation contract lives in
+[`docs/internal/lemonade-adoption-plan-2026-05-22.md`](https://github.com/Hal0ai/hal0/blob/main/docs/internal/lemonade-adoption-plan-2026-05-22.md).
+The architectural decisions are recorded in three ADRs:
+
+- [ADR-0008 — Lemonade adoption](https://github.com/Hal0ai/hal0/blob/main/docs/internal/adr/0008-lemonade-adoption.md)
+- [ADR-0009 — FLM trio NPU packing](https://github.com/Hal0ai/hal0/blob/main/docs/internal/adr/0009-flm-trio-npu-packing.md)
+- [ADR-0010 — Bundle picker, no default model stack](https://github.com/Hal0ai/hal0/blob/main/docs/internal/adr/0010-bundle-picker-no-default-stack.md)
+
+The full per-PR changelog is in
+[`CHANGELOG.md`](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md).
+
+## Thanks
+
+v0.2 builds directly on AMD's [Lemonade Server](https://lemonade-server.ai/)
+and [FastFlowLM](https://fastflowlm.ai/). The Lemonade team's
+`Multi-Model-Spec`, OmniRouter manifest design, and `--asr 1 --embed 1`
+flags in particular made the trio architecture possible without
+forking the runtime.

--- a/docs/v0.2-upgrade.md
+++ b/docs/v0.2-upgrade.md
@@ -1,0 +1,298 @@
+# Upgrading from hal0 v0.1.x to v0.2
+
+hal0 v0.2 is a **breaking change** from v0.1.x. There is no
+auto-migration path. This doc tells you what changed, why, and what to
+do.
+
+If you're a fresh install (no v0.1.x state on disk), skip to
+[Installing v0.2 fresh](#installing-v02-fresh).
+
+## tl;dr
+
+1. **Back up** your registry: `sudo tar czf hal0-v0.1-backup-$(date +%F).tar.gz /etc/hal0 /var/lib/hal0/registry`
+2. **Wipe** v0.1.x: stop + disable `hal0-slot@*` and `hal0-api`, then `sudo rm -rf /etc/hal0 /var/lib/hal0 /opt/hal0`
+3. **Reinstall** v0.2: `curl -fsSL https://hal0.dev/install.sh | bash`
+4. **Recover** the registry: `hal0 registry import hal0-v0.1-backup-$(date +%F).tar.gz`
+5. **Re-pick** your slot configuration via the first-run **bundle picker**, or manually via `hal0 slot add`.
+
+`install.sh` will refuse to overwrite a v0.1.x state and will print
+the exact commands above. If you see that error, this doc is the long
+form.
+
+## What changed
+
+v0.2 rebuilds hal0's inference layer around AMD's **Lemonade Server**.
+The six per-modality toolbox containers (vulkan, rocm, flm, moonshine,
+kokoro, comfyui) and the `hal0-slot@.service` systemd template that
+supervised them are retired. One `hal0-lemonade.service` now
+supervises a single `lemond` daemon that serves every modality —
+chat, embed, rerank, STT, TTS, and image gen — via Lemonade's
+`llamacpp` / `flm:npu` / `whisper.cpp` / `kokoro:cpu` / `sd-cpp`
+recipes.
+
+Concrete file-system changes:
+
+| v0.1.x | v0.2 |
+|---|---|
+| `/etc/hal0/slots/*.toml` (one file per slot) | `/etc/hal0/capabilities.toml` (single source of truth) |
+| `hal0-slot@<name>.service` (per-slot systemd) | `hal0-lemonade.service` (one daemon) |
+| Six toolbox container images | One `lemond` process, ports 13305 + 14000+ for child backends |
+| Models scattered across `/mnt/ai-models/{local,flm-ubuntu,moonshine_voice,voices,comfyui}/` | `/var/lib/hal0/models/<recipe>/<capability>/` canonical tree |
+| `Provider` ABC + `llama_server` / `flm` / `moonshine` / `kokoro` / `comfyui` classes | `LemonadeProvider` (legacy classes preserved as code but not in the dispatch path) |
+| `hal0-toolbox-*` images pulled from `ghcr.io/hal0ai/` | No toolbox pulls; Lemonade ships its own binaries |
+
+See [ADR-0008](internal/adr/0008-lemonade-adoption.md) for the
+architectural rationale, [ADR-0009](internal/adr/0009-flm-trio-npu-packing.md)
+for the FLM trio NPU packing, and [ADR-0010](internal/adr/0010-bundle-picker-no-default-stack.md)
+for the no-silent-default bundle picker.
+
+## Why no auto-migration?
+
+Three reasons:
+
+1. **The shape changed too much.** Slot config went from per-file
+   `slots/*.toml` to a single `capabilities.toml` with a new schema
+   (type / device / model / enabled / default / group). The runtime
+   went from per-slot systemd template + Provider ABC to a single
+   `lemond` daemon with per-type LRU. Translating one to the other
+   would have to make decisions about NPU exclusivity, bundle tiers,
+   model namespaces, OmniRouter tool selection — there's no clean
+   bijection.
+2. **The audience is small.** v0.1.x had single-digit alpha users.
+   The migration-script ROI is poor compared to one polished
+   `hal0 registry import` command plus a re-pick through the bundle
+   picker.
+3. **Alpha social contract.** v0.1.x carried no upgrade-compat
+   promise. v0.2 is a clean architectural break; future minor
+   bumps (v0.2 → v0.3) will not be — they'll keep `capabilities.toml`
+   stable.
+
+## Step-by-step
+
+### 1. Back up
+
+```sh
+sudo tar czf hal0-v0.1-backup-$(date +%F).tar.gz /etc/hal0 /var/lib/hal0/registry
+```
+
+This captures:
+
+- `/etc/hal0/hal0.toml`, `slots/*.toml`, `providers.toml`,
+  `upstreams.toml`, `hardware.json`
+- `/var/lib/hal0/registry/registry.toml` (model metadata)
+
+Models themselves (`/var/lib/hal0/models/` or `/mnt/ai-models/`)
+don't need backing up — they're re-downloadable from Hugging Face
+or kept on a separate disk. If your model store is on `/mnt/ai-models/`
+and you want to keep the bytes, just leave that mountpoint alone
+through the wipe.
+
+OpenWebUI state (`/var/lib/hal0/openwebui/`) is also worth backing
+up if you have chat history or uploads you care about — restore it
+after `install.sh` completes by stopping `hal0-openwebui` and copying
+the directory back.
+
+### 2. Stop + disable v0.1.x services
+
+```sh
+sudo systemctl stop 'hal0-slot@*' hal0-api hal0-openwebui
+sudo systemctl disable 'hal0-slot@*' hal0-api hal0-openwebui
+```
+
+### 3. Wipe v0.1.x state
+
+```sh
+sudo rm -rf /etc/hal0 /var/lib/hal0 /opt/hal0
+sudo rm -f /etc/systemd/system/hal0-slot@.service \
+           /etc/systemd/system/hal0-api.service \
+           /etc/systemd/system/hal0-openwebui.service
+sudo systemctl daemon-reload
+```
+
+If you set `HAL0_MODELS_DIR` to a path outside `/var/lib/hal0/`, that
+directory is left intact — v0.2's installer will accept the same
+`--models-dir=PATH` flag and re-bind it.
+
+### 4. Install v0.2
+
+```sh
+curl -fsSL https://hal0.dev/install.sh | bash
+```
+
+The bootstrap fetches the v0.2 release manifest, sha256-verifies the
+tarball, cosign-verifies the signature against the workflow OIDC
+identity, then hands off to `installer/install.sh`. The Lemonade
+daemon, FastFlowLM `.deb` (Linux NPU), system prerequisites, and
+`hal0-lemonade.service` are provisioned automatically.
+
+After install completes, the post-install summary prints:
+
+- The one-time OTP for the first-run password setup
+- The dashboard URL (`https://hal0.local` or `http://localhost:8080`)
+- A reminder that the bundle picker runs on first dashboard load
+
+### 5. Recover the registry
+
+```sh
+hal0 registry import hal0-v0.1-backup-$(date +%F).tar.gz
+```
+
+This is a single-purpose command. It restores `registry.toml` from
+the backup tarball, deduplicating against the seeded
+`server_models.json` entries that ship with v0.2. It does **not**
+restore slot selections — those need to come back through the bundle
+picker or `hal0 slot add`.
+
+After import, run `hal0 registry sync` to regenerate Lemonade's
+`server_models.json` and pick up the imported entries.
+
+### 6. Re-pick your slot configuration
+
+Open the dashboard. The first load detects the empty
+`capabilities.toml` and renders the **bundle picker**:
+
+- **`hal0-Lite`** (≥16 GB RAM) — qwen3.5-0.8b chat only
+- **`hal0-Default`** (≥32 GB) — qwen3.5-9b + nomic embed + whisper-tiny + kokoro:cpu
+- **`hal0-Pro`** (≥64 GB) — Qwen3.6-27B-MTP + Qwen3-Coder-30B-A3B + bge-reranker + whisper-base + sd-turbo, optional NPU trio
+- **`hal0-Max`** (≥100 GB Strix Halo) — Qwen3.6-35B-A3B-MTP + Qwen3-Coder-Next-80B-A3B + whisper-large-v3-turbo + flux-2-klein-9b, optional NPU trio
+- **`LMX-Omni-52B-Halo`** (≥100 GB Strix Halo, AMD-curated kit)
+- **Skip — configure manually** — leaves slots empty; each card shows a "Configure" button
+
+Tiers that don't fit your detected unified RAM grey out with a
+tooltip. Pick one; the selected models download in the background
+(progress shows in a toast). Once download completes, the bundle's
+slots populate `capabilities.toml` and start serving.
+
+If you prefer to recreate your v0.1.x layout one slot at a time:
+
+```sh
+hal0 slot add primary --type llm --model qwen3.6-27b-mtp --device gpu-rocm
+hal0 slot add embed --type embedding --model nomic-embed-text-v1.5 --device cpu
+# ...
+```
+
+Slot identity (`primary`, `embed`, `stt`, `tts`, `img`, `rerank`)
+matches v0.1.x for the six seeded slots. NPU slots (`agent`,
+`stt-npu`, `embed-npu`) appear only when the FLM `.deb` is installed.
+
+## Migration FAQ
+
+### Why no auto-migrate? (the long version)
+
+See [Why no auto-migration?](#why-no-auto-migration) above. Short
+answer: alpha social contract + the schema change is too deep for
+clean translation + we'd rather ship one polished `hal0 registry
+import` than carry brittle migration code into v1.0.
+
+### Will `hal0 registry import` restore my slot selections too?
+
+No. It restores `registry.toml` only (the model metadata: HF coords,
+sha256, labels). Slot selections — which model serves `primary`,
+which serves `embed`, etc. — come back through the bundle picker or
+`hal0 slot add`. The v0.2 slot schema has no clean projection from
+v0.1.x; type / device / group are new fields, and v0.2's NPU exclusivity
+rules need to be applied on a per-host basis.
+
+### What happens to my v0.1.x models on disk?
+
+If they're under `/var/lib/hal0/models/` and you wipe that directory
+in step 3, they're gone — re-download from HF after install. If
+they're on `/mnt/ai-models/` (a separate disk), they survive the
+wipe untouched, and PR-7's layout migration reorganises them into
+the canonical `<recipe>/<capability>/` tree on first start.
+
+For a clean transition, the v0.1.x → v0.2 file path map is roughly:
+
+| v0.1.x | v0.2 |
+|---|---|
+| `/mnt/ai-models/local/*.gguf` (chat) | `/var/lib/hal0/models/llamacpp/chat/` |
+| `/mnt/ai-models/local/*-embed-*.gguf` | `/var/lib/hal0/models/llamacpp/embed/` |
+| `/mnt/ai-models/local/*-rerank-*.gguf` | `/var/lib/hal0/models/llamacpp/rerank/` |
+| `/mnt/ai-models/moonshine_voice/` | `/var/lib/hal0/models/whispercpp/stt/` (re-download — moonshine retired in favour of whisper.cpp) |
+| `/mnt/ai-models/voices/kokoro*` | `/var/lib/hal0/models/kokoro/tts/` |
+| `/mnt/ai-models/comfyui/` | `/var/lib/hal0/models/sd-cpp/img/` (re-pick — sd-cpp replaces ComfyUI) |
+| `/mnt/ai-models/flm-ubuntu/` | `/var/lib/hal0/models/flm/chat/` (NPU host only) |
+
+### Why was Moonshine retired?
+
+Lemonade's `whisper.cpp` recipe is more accurate and supports both
+Vulkan and CPU paths, but it's heavier on weak CPUs (lite-tier
+users may notice). The trade was worth it for one unified
+transcription path across CPU and GPU. NPU users get
+Whisper-V3-Turbo via the FLM trio — see ADR-0009.
+
+### Why was ComfyUI retired?
+
+`sd-cpp` (Lemonade-bundled, ROCm) covers the 90% case for image
+generation: SDXL Turbo, SD 1.5, Flux Schnell, Flux-2-Klein-9B. Power
+users running complex workflow graphs (ControlNet chains, LoRA
+hot-swap pipelines, custom samplers) should install ComfyUI
+externally and point hal0 at it as an external upstream.
+
+### What about my Bearer tokens?
+
+Tokens minted under v0.1.x are not migrated. The auth store moves
+into a fresh sqlite DB at install. Mint new tokens via the
+dashboard's Settings → Authentication panel after first-run
+password setup completes.
+
+### Can I run v0.1.x and v0.2 side by side?
+
+Not on the same host — they collide on ports 8080 / 3001, on
+`/etc/hal0/`, on `/var/lib/hal0/`, and on the systemd unit names.
+For an A/B test, run v0.2 in a fresh LXC and leave v0.1.x in place
+on the original.
+
+### How do I know if `install.sh` detected v0.1.x state?
+
+You'll see an error like:
+
+```
+hal0 v0.1.x detected. v0.2 is a breaking change — slot architecture, model layout,
+and runtime have all changed. The installer will not overwrite a v0.1.x state.
+
+To preserve your configuration:
+  sudo tar czf hal0-v0.1-backup-$(date +%F).tar.gz /etc/hal0 /var/lib/hal0/registry
+
+To wipe v0.1.x and start fresh:
+  sudo systemctl stop 'hal0-slot@*' hal0-api
+  sudo systemctl disable 'hal0-slot@*' hal0-api
+  sudo rm -rf /etc/hal0 /var/lib/hal0 /opt/hal0
+  # then re-run this installer
+
+Or read the v0.2 migration notes: https://hal0.dev/docs/v0.2-upgrade
+```
+
+Detection criterion: `/etc/hal0/slots/*.toml` exists AND
+`/var/lib/hal0/lemonade/config.json` is absent. If both are absent
+(no prior hal0 install), `install.sh` proceeds normally. If both
+are present (a previous failed v0.2 install), `install.sh` is
+idempotent and re-runs the v0.2 setup against the existing
+Lemonade config.
+
+## Installing v0.2 fresh
+
+No prior hal0 install? It's the standard one-liner:
+
+```sh
+curl -fsSL https://hal0.dev/install.sh | bash
+```
+
+After install:
+
+1. Open `https://hal0.local` (or the IP printed in the post-install summary).
+2. Set a password using the one-time OTP from the installer transcript.
+3. Pick a bundle from the first-run bundle picker (or click "Skip" to configure manually).
+4. Wait for background model downloads to finish (toast).
+5. Chat at `http://hal0.local:3001` (OpenWebUI, prewired).
+
+See [`installer/README.md`](../installer/README.md) for the full
+installer reference, `--no-tls` / `--dev` modes, environment
+variable overrides, and troubleshooting.
+
+## Getting help
+
+- File an issue: <https://github.com/Hal0ai/hal0/issues>
+- Discussion: <https://github.com/Hal0ai/hal0/discussions>
+- Architecture context: [ADR-0008](internal/adr/0008-lemonade-adoption.md), [ADR-0009](internal/adr/0009-flm-trio-npu-packing.md), [ADR-0010](internal/adr/0010-bundle-picker-no-default-stack.md)
+- Full v0.2 changelog: [`CHANGELOG.md`](../CHANGELOG.md)

--- a/installer/README.md
+++ b/installer/README.md
@@ -8,7 +8,7 @@ Non-interactive installer for hal0 — the open-source home AI inference platfor
 # From a clone of this repo:
 sudo bash installer/install.sh
 
-# Or point HuggingFace pulls at a larger disk:
+# Or point model pulls at a larger disk:
 sudo bash installer/install.sh --models-dir=/mnt/ai-models
 ```
 
@@ -18,35 +18,54 @@ sudo bash installer/install.sh --models-dir=/mnt/ai-models
 > and hands off to this `install.sh`. `git clone` + `sudo bash` still
 > works for development against a checkout.
 
-The toolbox container images (`ghcr.io/hal0ai/hal0-toolbox-*:v1`) are
-public on GHCR — `docker pull` works without a `docker login`. The
-installer pulls them in the background after the API comes up.
+> **v0.1.x users:** `install.sh` will detect existing v0.1.x state
+> (`/etc/hal0/slots/*.toml` AND no `/var/lib/hal0/lemonade/config.json`)
+> and refuse to overwrite it. See
+> [`docs/v0.2-upgrade.md`](../docs/v0.2-upgrade.md) for the backup +
+> wipe + reinstall procedure and the `hal0 registry import` recovery
+> command.
+
+As of v0.2, hal0 ships **AMD's Lemonade Server** as the unified
+inference runtime. The installer adds the `lemonade-team/stable`
+PPA, installs system prerequisites (libxrt-npu2, ffmpeg6, boost1.83,
+fftw3, FastFlowLM `.deb` on AMDXDNA NPU hosts), writes
+`/var/lib/hal0/lemonade/config.json` with a computed
+`--parallel 1 --threads N` line, and supervises one `lemond` daemon
+via `hal0-lemonade.service`. The six v0.1.x toolbox container images
+are no longer required, built, or pulled.
 
 ## What the installer does
 
-1. **Pre-flight checks** — confirms Python 3.11–3.14 is on `$PATH`, systemd is present (skipped in `--dev`), and probes for Docker (a soft warning if missing; slot launches will fail until it's installed).
-2. **Privilege model** — runs as `root` (re-execs under `sudo` if needed). The slot template runs the toolbox containers as root by design — the container itself is the sandbox boundary, not the host user. Override with `HAL0_USER=...` if you want a different unit user, but the default is intentional.
-3. **Layout** — creates `/opt/hal0/` (code + venv), `/etc/hal0/{,slots}` (config), `/var/lib/hal0/{models,registry,slots,openwebui,cache}` (state). In `--dev` everything lands under `$PWD/.hal0ai/` instead.
-4. **Installs hal0** — creates a venv at `/opt/hal0/.venv/` and `pip install -e`'s the checkout into it. There is no versioned install dir or `current` symlink yet — the venv tracks the checkout in editable mode.
-5. **Builds the dashboard UI** — runs `npm install && npm run build` in `ui/` if `ui/dist/` is missing and `npm` is available. Skipped (with a warning) when `npm` is absent.
-6. **Config defaults** — writes `/etc/hal0/hal0.toml`, `api.env`, `openwebui.env` (rendered by `hal0.openwebui.env_writer`), and slot skeletons for `primary`, `embed`, `stt`, `tts`. Existing files are **never clobbered** on re-run.
-7. **systemd units** — writes `hal0-api.service`, copies `hal0-openwebui.service` and `hal0-slot@.service` from `packaging/systemd/` to `/etc/systemd/system/`, reloads the daemon, enables and starts `hal0-api` + `hal0-openwebui` (unless `--no-start`).
-8. **Hardware probe + final summary** — prints detected backends and reachable URLs. Skip the probe with `HAL0_NO_PROBE=1`.
+1. **Pre-flight checks** — confirms Python 3.11–3.14 is on `$PATH`, systemd is present (skipped in `--dev`).
+2. **Privilege model** — runs as `root` (re-execs under `sudo` if needed). The `lemond` daemon runs under the `hal0` system user written into `hal0-lemonade.service`. Override with `HAL0_USER=...` if you want a different unit user, but the default is intentional.
+3. **v0.1.x detection** — refuses to overwrite a v0.1.x install (`/etc/hal0/slots/*.toml` present, `/var/lib/hal0/lemonade/config.json` absent). Prints backup + wipe instructions and exits non-zero. See [`docs/v0.2-upgrade.md`](../docs/v0.2-upgrade.md).
+4. **Layout** — creates `/opt/hal0/` (code + venv), `/etc/hal0/` (config), `/var/lib/hal0/{models,registry,lemonade,openwebui,cache}` (state). In `--dev` everything lands under `$PWD/.hal0ai/` instead.
+5. **Lemonade prerequisites** — installs the `lemonade-team/stable` PPA, the Lemonade embeddable tarball pinned in `manifest.json`, system libs (libxrt-npu2, ffmpeg6, boost1.83, fftw3), and (on AMDXDNA NPU hosts) the pinned FastFlowLM `.deb`.
+6. **Installs hal0** — creates a venv at `/opt/hal0/.venv/` and `pip install -e`'s the checkout into it. There is no versioned install dir or `current` symlink yet — the venv tracks the checkout in editable mode.
+7. **Builds the dashboard UI** — runs `npm install && npm run build` in `ui/` if `ui/dist/` is missing and `npm` is available. Skipped (with a warning) when `npm` is absent.
+8. **Config defaults** — writes `/etc/hal0/hal0.toml`, `api.env`, `openwebui.env`, and `/var/lib/hal0/lemonade/config.json` with computed `llamacpp.args = "--parallel 1 --threads N"` (N = `(cores − 2) / 4`, min 2) plus `flm.args = "--asr 1 --embed 1"`. `capabilities.toml` ships empty by design — the first-run dashboard renders the bundle picker. Existing files are **never clobbered** on re-run.
+9. **systemd units** — writes `hal0-api.service`, copies `hal0-lemonade.service` and `hal0-openwebui.service` from `packaging/systemd/` to `/etc/systemd/system/`, reloads the daemon, enables and starts `hal0-api` + `hal0-lemonade` + `hal0-openwebui` (unless `--no-start`).
+10. **Hardware probe + final summary** — prints detected backends, the FLM `.deb` install state (NPU only), and reachable URLs. Skip the probe with `HAL0_NO_PROBE=1`.
 
 The installer is **idempotent** — safe to re-run after a partial failure or to update configuration defaults.
 
-### Pulling toolbox images
+### Lemonade daemon
 
-Toolbox images live under `ghcr.io/hal0ai/hal0-toolbox-*` and are **public**;
-the installer (and `hal0 slot load` at runtime) pull them anonymously. No
-`docker login` is required — even on a hardened LAN box that has never seen
-a GHCR credential.
+The `lemond` process is the only runtime hal0 supervises in v0.2. It
+listens loopback-only on `127.0.0.1:13305`; the hal0-api service on
+8080 fronts external access. The daemon's cache directory at
+`/var/lib/hal0/lemonade/` holds:
 
-The pinned image digests are tracked in [`manifest.json`](../manifest.json)
-and refreshed by `.github/workflows/toolbox.yml` after every build. Run
-`hal0 doctor toolbox-pull` to verify each pinned image is reachable from
-this host (anonymous OCI v2 token-exchange + HEAD on the manifest URL —
-no `docker pull` needed).
+- `config.json` — the persisted daemon config (read by `lemond` on
+  start, written atomically by hal0's `/internal/set` calls).
+- `resources/server_models.json` — generated by `hal0 registry sync`
+  from `/var/lib/hal0/registry/registry.toml`.
+- `user_models.json` — user-pulled models via `POST /v1/pull`.
+
+The pinned Lemonade and FastFlowLM versions are tracked in
+[`manifest.json`](../manifest.json) and refreshed per release. Run
+`hal0 doctor` to verify daemon reachability and (on NPU hosts) FLM
+install state.
 
 ## Environment variables
 
@@ -58,10 +77,8 @@ These are the variables `installer/install.sh` actually reads:
 | `HAL0_PORT` | `8080` | hal0 API port |
 | `HAL0_USER` | `root` | systemd unit user (see §What the installer does) |
 | `HAL0_PYTHON` | `python3` | Python interpreter used to build the venv |
-| `HAL0_MODELS_DIR` | _(unset)_ | Absolute path where HuggingFace pulls land; same as `--models-dir=PATH`. When unset, models live at `/var/lib/hal0/models` (or `$PWD/.hal0ai/var/lib/hal0/models` under `--dev`). |
+| `HAL0_MODELS_DIR` | _(unset)_ | Absolute path where model pulls land (Lemonade's `extra_models_dir`); same as `--models-dir=PATH`. When unset, models live at `/var/lib/hal0/models` (or `$PWD/.hal0ai/var/lib/hal0/models` under `--dev`). |
 | `HAL0_NO_PROBE` | _(unset)_ | Set to `1` to skip the hardware probe at the end |
-| `HAL0_TOOLBOX_IMAGE_VULKAN` | _(unset)_ | Override the Vulkan toolbox image ref written into `api.env` |
-| `HAL0_TOOLBOX_IMAGE_ROCM` | _(unset)_ | Override the ROCm toolbox image ref written into `api.env` |
 | `HAL0_PUBLIC_HOST` | `hal0.local` | Public hostname rendered into the Caddyfile (TLS default install path) |
 | `HAL0_TLS_EMAIL` | `admin@$HAL0_PUBLIC_HOST` | Contact email for Let's Encrypt (when not `tls internal`) |
 | `HAL0_OPENWEBUI_PORT` † | `3001` | OpenWebUI host port — **dev mode only** |
@@ -190,17 +207,11 @@ Use `scripts/dev-bootstrap.sh` to actually start services during development.
 
 ### `--dev` mode limitations
 
-`--dev` is a contributor convenience, not a runtime path. The installer writes the same systemd units (`hal0-api.service`, `hal0-slot@.service`, `hal0-openwebui.service`) into the dev tree, but it does **not** register them with the host's systemd. Concretely:
+`--dev` is a contributor convenience, not a runtime path. The installer writes the same systemd units (`hal0-api.service`, `hal0-lemonade.service`, `hal0-openwebui.service`) into the dev tree, but it does **not** register them with the host's systemd. Concretely:
 
 - Units land in `$PWD/.hal0ai/etc/systemd/system/`.
 - The host's `systemctl` only searches `/etc/systemd/system/` and `/usr/lib/systemd/system/`, so it cannot see them.
-- Any flow that ends in `systemctl start hal0-slot@<name>` will fail with:
-
-  ```
-  Failed to start hal0-slot@primary.service: Unit hal0-slot@primary.service not found.
-  ```
-
-  In particular, `hal0 slot create && hal0 slot load` cannot bring a slot up in `--dev`.
+- Any flow that ends in `systemctl start hal0-lemonade` will fail with `Unit hal0-lemonade.service not found.` In particular, `hal0 slot add` + `hal0 model pull` requests routed through the capability dispatcher will fail because there is no `lemond` daemon for the dispatcher to call.
 
 Two ways to resolve this, depending on what you're trying to do:
 
@@ -210,20 +221,20 @@ Two ways to resolve this, depending on what you're trying to do:
    sudo bash installer/install.sh
    ```
 
-   Real install puts units under `/etc/systemd/system/`, runs `systemctl daemon-reload`, and `hal0 slot load` works end-to-end.
+   Real install puts units under `/etc/systemd/system/`, runs `systemctl daemon-reload`, and the full Lemonade pipeline works end-to-end.
 
 2. **Or link the dev units into the system search path.** Keeps the dev tree as the source of truth, but tells the host systemd where to find the units:
 
    ```sh
-   sudo systemctl link "$PWD/.hal0ai/etc/systemd/system/hal0-slot@.service"
+   sudo systemctl link "$PWD/.hal0ai/etc/systemd/system/hal0-lemonade.service"
    sudo systemctl link "$PWD/.hal0ai/etc/systemd/system/hal0-api.service"
    sudo systemctl link "$PWD/.hal0ai/etc/systemd/system/hal0-openwebui.service"
    sudo systemctl daemon-reload
    ```
 
-   After that, `hal0 slot create && hal0 slot load` works against the dev tree. Edits to the linked unit files take effect after another `systemctl daemon-reload`.
+   After that, slot operations work against the dev tree. Edits to the linked unit files take effect after another `systemctl daemon-reload`.
 
-The installer prints the same warning block at the end of every `--dev` run as a reminder. Tracked under harness finding #6 / task #24.
+The installer prints the same warning block at the end of every `--dev` run as a reminder.
 
 ## Uninstall
 
@@ -255,28 +266,36 @@ HAL0_PORT=8090 sudo bash installer/install.sh
 
 After changing the port, update `/etc/hal0/api.env` and `/etc/hal0/openwebui.env` to match, then `systemctl restart hal0-api hal0-openwebui`.
 
-### Docker not installed
+### Lemonade daemon not reachable
 
 ```
-✗ pre-flight failed: docker not installed.
+hal0 doctor: lemond unreachable on 127.0.0.1:13305
 ```
 
-Install Docker:
+Check the unit:
 
 ```sh
-curl -fsSL https://get.docker.com | sh
-sudo usermod -aG docker $USER
-newgrp docker
+systemctl status hal0-lemonade
+journalctl -fu hal0-lemonade
 ```
 
-### Docker daemon not accessible
+Common causes: the Lemonade prerequisites failed to install (re-run
+`installer/install.sh`), `llamacpp.args` was hand-edited to an
+unbounded value and the daemon crashed on first multi-LLM load (revert
+to `--parallel 1 --threads N`; see `hal0_lemonade_threads_deadlock`
+memory), or a port conflict on 13305 (override via
+`/var/lib/hal0/lemonade/config.json` `port` key).
+
+### FLM .deb missing (NPU host only)
 
 ```
-✗ pre-flight failed: docker daemon not running or not accessible.
+hal0 doctor: AMDXDNA NPU detected but FastFlowLM not installed
 ```
 
-Start the daemon: `sudo systemctl start docker`  
-Or add your user to the docker group and re-login.
+The Lemonade `flm:npu` recipe needs the FastFlowLM `.deb` package.
+The installer handles this automatically on AMDXDNA hosts, but if you
+installed on a non-NPU host and later added the hardware, re-run
+`installer/install.sh` to pick up the FLM prerequisites.
 
 ### Not enough disk space
 
@@ -299,8 +318,9 @@ Check logs:
 
 ```sh
 journalctl -fu hal0-api
+journalctl -fu hal0-lemonade
 journalctl -fu hal0-openwebui
-systemctl status hal0-api hal0-openwebui
+systemctl status hal0-api hal0-lemonade hal0-openwebui
 ```
 
 ### OpenWebUI can't reach the API


### PR DESCRIPTION
## Summary

PR-22 of the v0.2 Lemonade adoption migration — the **final** PR in the 22-PR sequence locked in `docs/internal/lemonade-adoption-plan-2026-05-22.md` §11. Pure docs sweep; no code changes, no test changes.

- README + PLAN + installer/README + CONTRIBUTING rewritten around Lemonade as the unified runtime, the retired toolbox stack, the FLM trio NPU packing, the OmniRouter client-side tools, the bundle picker, and the canonical `/var/lib/hal0/models/<recipe>/<capability>/` layout
- New `CHANGELOG.md` at root starting at v0.2.0 — Breaking + Features + Internal + Known limitations
- New `docs/v0.2-upgrade.md` (the URL PR-21's install.sh error message points at) with the back-up + wipe + reinstall procedure and `hal0 registry import` recovery flow
- New `docs/release-notes/v0.2.0.md` ready for the GitHub release body

## Files touched

| File | Why |
|---|---|
| `README.md` | Lemonade-aware narrative, retired per-modality toolbox references, roadmap reframed from v0.1.1-shipped/v0.2-deferred to v0.2-shipped/v0.3-next |
| `PLAN.md` | Status block reframed; new §1 "v0.2 ships" section linking to the adoption plan (no restatement); §15 adds Phase 9 (Lemonade migration, done) with per-PR table; "v0.2 deferred" → "v0.3 next" |
| `CHANGELOG.md` | NEW; per plan §11 PR-22 scope |
| `docs/v0.2-upgrade.md` | NEW; user-facing upgrade guide referenced by PR-21's install.sh refusal message |
| `docs/release-notes/v0.2.0.md` | NEW; GitHub release body |
| `installer/README.md` | Toolbox references retired (PR-9 anti-scope deferred to PR-22); installer steps renumbered around Lemonade prereqs; Docker daemon troubleshooting replaced with Lemonade daemon + FLM .deb troubleshooting |
| `CONTRIBUTING.md` | Version bump v0.1.0-alpha → v0.2.0; β integration tier rewritten around `hal0-lemonade.service`; γ matrix updated; pre-tag check updated (Lemonade tarball + FLM .deb pins, not toolbox image digests) |
| `docs/internal/SESSION_HANDOFF_2026-05-22.md` | Appended a "v0.2 ship-cut 2026-05-23" note; existing content preserved |

## Architecture refs (frozen — not touched)

- [ADR-0008 — Lemonade adoption](docs/internal/adr/0008-lemonade-adoption.md)
- [ADR-0009 — FLM trio NPU packing](docs/internal/adr/0009-flm-trio-npu-packing.md)
- [ADR-0010 — Bundle picker, no default model stack](docs/internal/adr/0010-bundle-picker-no-default-stack.md)
- [Lemonade adoption plan (source of truth)](docs/internal/lemonade-adoption-plan-2026-05-22.md)
- Memory: `hal0_v0.2_lemonade_migration_state_2026-05-22`

## Test plan

- [x] `pytest tests/ -q` — 1875 passed, 8 skipped, no regressions (docs PR; test suite untouched)
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — 291 files already formatted
- [x] `bash -n installer/install.sh` — syntax clean (installer not modified)
- [ ] Manual: confirm Vercel docs preview renders the new `docs/v0.2-upgrade.md` page
- [ ] User: after merge, run `gh release create v0.2.0 -F docs/release-notes/v0.2.0.md` to ship the release notes
- [ ] User: cross-check that no `hal0.dev/docs/v0.2-upgrade` redirect / proxy rule needs updating in `hal0-web`

## Notes

- Does NOT bump `pyproject.toml` version (per brief — release tagging is a separate user action; PR-22 just preps the notes).
- Does NOT create the GH release (`gh release create` is the user's call after merge).
- Does NOT touch the locked plan / ADR-0008/0009/0010 / adoption plan — all frozen.
- Parallel session note: the brief flagged that `feat/dash-v2-rework` is open (#197) and that #199 already cut over the v0.2.1 dashboard rewrite on main. Docs reflect "v2 / v0.2.1 dashboard is current"; PLAN.md Phase 9 cross-references #199 + #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)