### PR TITLE
docs(v0.3): Hermes-Agent bootstrap plan + ADR-0011 (agent identity cards)

### DIFF
--- a/docs/internal/adr/0011-agent-identity-cards.md
+++ b/docs/internal/adr/0011-agent-identity-cards.md
@@ -1,0 +1,245 @@
+# ADR 0011 — Agent identity cards (Phase 8, v0.3)
+
+- **Status:** Draft
+- **Date:** 2026-05-23
+- **Drivers:** `/grill-me` session 2026-05-23 against `docs/internal/hermes-bootstrap-plan-2026-05-23.md`; bundled Hermes agent v0.3 needs to publish itself + discover peers
+- **Implementing PRs:** PR-1 (this ADR + new MCP admin tools) per the bootstrap plan §23
+- **Related:** ADR-0004 (Agents v0.2), ADR-0005 (Memory engine = Cognee)
+
+## Context
+
+The bundled Hermes-Agent install in v0.3 makes the agent hal0-aware: it
+probes the host, wires local models, connects to the memory MCP, and
+adopts a "right-hand homelab admin" persona. Once that's done it needs
+to **announce itself** so other agents (Claude Code, pi-coder, future
+agents bundled or installed-out-of-band) can discover that Hermes is
+running here and what it can do.
+
+We have one shared substrate every agent on a hal0 host already
+talks to: the `hal0-memory` MCP (Cognee). The question is whether to:
+
+1. Reuse `hal0-memory` as a service registry by storing
+   "identity card" memory items under a convention.
+2. Build a separate `/api/agents` endpoint with its own JSON store.
+
+Option 2 is structurally cleaner (service registry and episodic memory
+are different concerns). Option 1 is zero new endpoints and rides on
+the substrate every agent already needs to authenticate against.
+
+For v0.3 we go with Option 1, but **carve out a dedicated dataset** so
+the conflation doesn't bleed into episodic recall. The dashboard's
+"Agents" panel (v0.3 follow-up) will read this same surface.
+
+## Decision
+
+### 1. Identity cards live in a dedicated `agents` dataset
+
+- Storage: `hal0-memory` MCP.
+- Dataset: **`agents`** (not `shared`, not `private:*`).
+- Tag: `agent-identity` (additional tag for the agent's name allowed,
+  e.g., `hermes`, `pi-coder`).
+- Written by: the agent itself, during its bootstrap / first-run flow.
+- Discovery: `memory_search({dataset: "agents", tags: ["agent-identity"]})`.
+
+**Why dedicated dataset (not shared):**
+- Service registry and episodic memory are different concerns.
+- The `agents` dataset is small (5-10 cards forever) so embed cost is
+  irrelevant.
+- Search-by-similarity is a free side-benefit ("find an agent that can
+  do X" works naturally if cards have descriptive text).
+- `private:*` is wrong — identity is **public-by-design**; anything
+  that wants to delegate has to discover the agent.
+- `shared` is wrong — that's where episodic facts live; conflating
+  concerns invites schema rot.
+
+### 2. Cards are immutable
+
+- Written once at bootstrap.
+- **Not refreshed per session.** Liveness is not a stored field.
+- Re-bootstrap (`hal0 agent bootstrap <agent> --repair`) and Hermes
+  version upgrade rewrite the card. Those are the only legitimate
+  writes besides install.
+- Cleanup: `hal0 agent uninstall <agent>` calls `memory_delete(ids=[card_id])`.
+
+**Why immutable:**
+- Clean audit trail — every card has one source-of-truth write event.
+- Liveness-as-stored-field is a bug magnet (TTL questions, concurrent
+  writes, "when's it stale"). The dashboard can ping `endpoint.url`
+  for liveness; that stays separate.
+- Stale-card-on-uninstall is solved by the uninstall hook, not by
+  TTL.
+
+### 3. Card payload: summary in `text`, structured fields in `metadata`
+
+The `text` field carries a short human-readable summary that surfaces
+well in `memory_search` ranking. Programmatic readers consume the
+structured payload from `metadata`.
+
+```json
+{
+  "text": "I am Hermes, the hal0 admin agent. I have read/write access to the slot lifecycle and the memory store on this host. I can do generalist chat and code review on the LAN.",
+  "tags": ["agent-identity", "hermes"],
+  "dataset": "agents",
+  "metadata": {
+    "agent_id": "hermes-agent",
+    "display_name": "Hermes (hal0 admin)",
+    "namespace": "private:hermes-agent",
+    "roles": ["homelab-admin", "generalist-chat", "memory-curator"],
+    "endpoint": {
+      "type": "mcp-serve",
+      "url": "http://127.0.0.1:8081/mcp",
+      "transport": "streamable-http"
+    },
+    "delegation": {
+      "accepts_tasks_from": ["claude-code", "pi-coder", "user"],
+      "max_concurrent": 3
+    },
+    "hal0_state": {
+      "registered_at": "2026-05-23T14:00:00Z",
+      "bootstrap_version": 1,
+      "hal0_version": "0.2.0-alpha.3",
+      "hermes_version": "0.14.0"
+    }
+  }
+}
+```
+
+### 4. Minimal schema (required fields)
+
+Card MUST include in `metadata`:
+
+| Field | Type | Description |
+|---|---|---|
+| `agent_id` | `str` | Stable, slug-cased. Globally unique per host. |
+| `display_name` | `str` | Human-facing label. |
+| `namespace` | `str` | Where the agent's *working* memory lives in hal0-memory (e.g., `private:hermes-agent`). |
+| `hal0_state.registered_at` | iso8601 | Bootstrap completion timestamp. |
+| `hal0_state.hal0_version` | `str` | Snapshot of hal0 at bootstrap time. |
+| `hal0_state.bootstrap_version` | `int` | Schema version of the card itself. v0.3 ships `1`. |
+
+Recommended (writer SHOULD include):
+
+| Field | Type | Description |
+|---|---|---|
+| `roles` | `list[str]` | Capability rollup the agent self-asserts. |
+| `endpoint.type` | enum | `mcp-serve`, `http`, `none`. |
+| `endpoint.url` | URL | If reachable. Dashboard pings for liveness. |
+| `endpoint.transport` | enum | Per MCP spec or HTTP method family. |
+| `delegation.accepts_tasks_from` | `list[str]` | Agent IDs allowed to delegate. `["user"]` is the minimum. |
+| `delegation.max_concurrent` | `int` | Concurrency hint. |
+
+Forward-compat: readers MUST ignore unknown keys in `metadata`.
+
+### 5. Reserved card schema versions
+
+| Version | Status | Scope |
+|---|---|---|
+| `1` | v0.3 alpha | Fields documented above. |
+| `2` | future | Will likely add capability assertions for embed/rerank exposure (deferred from v0.3 — see Consequences §3). |
+| `3+` | unallocated | |
+
+### 6. Other agents must follow this convention
+
+The convention is agent-agnostic. When the pi-coder bootstrap lands
+(Phase 8 follow-up after Hermes), it writes its own card under the same
+schema. Same for any future bundled or aftermarket agent.
+
+The hal0 CLI ships a `hal0 agent list` command in v0.3 that
+enumerates identity cards (a thin wrapper over the `memory_search`
+call shown above).
+
+## Consequences
+
+### 1. Dashboard can render an "Agents" panel cheaply
+
+The dashboard's existing `hal0-memory` client only needs to learn the
+`agents` dataset name. No new endpoint, no new schema, no new auth.
+
+### 2. Cards are searchable by content
+
+Because cards embed in Cognee like any other memory item, a user query
+like "find an agent that can do code review" can hit the dedicated
+agents dataset and surface relevant cards by semantic similarity. The
+`roles` list gives precise filtering; the `text` summary gives fuzzy
+matching.
+
+### 3. Embed/rerank exposure deferred to v0.4 (schema v2)
+
+Card schema v1 does not include capability flags for whether the agent
+exposes `embed()` / `rerank()` tools (per the bootstrap plan Q6 — both
+explicitly NOT wired in Hermes v0.3). When that wiring lands in v0.4,
+card schema v2 adds a `tools.{embed,rerank}: {available: bool, dataset_required: bool}`
+block.
+
+### 4. Federation invalidation risk
+
+When hal0-memory federation lands (deferred to ADR-0006-equivalent in
+Phase 9), the `agents` dataset will need a `host_id` qualifier — two
+hal0 hosts in a federation will each have a `hermes-agent` and the
+`agent_id` collision will need scoping. The forward-compat ignore-unknown-keys
+rule on `metadata` means schema v1 cards survive the upgrade unmodified
+once readers learn `metadata.host_id`.
+
+### 5. No external "agent registry" surface in v0.3
+
+We deliberately do NOT expose `GET /api/agents` as a REST endpoint in
+v0.3. Anyone wanting to enumerate agents calls `memory_search` on the
+`agents` dataset with the documented tag filter. If the registry use
+case grows beyond what `memory_search` covers (latency, complex
+filtering, write-validation), v1.0 can promote the surface to a
+dedicated endpoint.
+
+### 6. Cleanup is the bootstrap's responsibility
+
+If an agent crashes mid-bootstrap without writing its card, no card
+exists — that's fine.
+
+If an agent crashes mid-uninstall before deleting its card, a ghost
+card remains. Mitigation: `hal0 agent list --prune` (v0.4) flags cards
+whose `endpoint.url` is unreachable AND whose `hal0_version` no longer
+matches any installed agent. User confirms; entries deleted.
+
+## Alternatives considered
+
+### A. Store cards in the `shared` dataset
+
+Rejected. Conflates service registry with episodic memory. Schema
+hygiene degrades over time.
+
+### B. Dedicated `/api/agents` REST endpoint with its own JSON store
+
+Rejected for v0.3. Cleaner conceptually but doubles the surface every
+agent has to discover and authenticate against. v1.0 can promote if
+warranted.
+
+### C. Refresh cards on every session start
+
+Rejected. Liveness-as-stored-field has known failure modes (TTL
+ambiguity, concurrent writes). Dashboard pings the endpoint for
+liveness; card stays authoritative for "what's installed."
+
+### D. YAML/JSON blob in `text` field, ignore `metadata`
+
+Rejected. Forces every reader to parse a text blob. `metadata` is
+exactly the right surface for structured data.
+
+## Open questions
+
+- Does `memory_search` with `dataset="agents"` work without further
+  changes to the MCPAuthMiddleware namespace logic? Per the
+  `hal0-memory` map, custom dataset names are accepted opaquely when
+  not in private mode. Verify in PR-1 that "opaque" includes a write
+  to a name like `agents` without surprise coercion.
+- Should the `hal0 agent list` CLI live in `src/hal0/cli/agent_list.py`
+  or as a subcommand of an existing module? Convention check during
+  PR-1.
+
+## References
+
+- `docs/internal/hermes-bootstrap-plan-2026-05-23.md` §11 — phase
+  `namespace_register`.
+- `docs/internal/hermes-upstream-map-2026-05-23.md` §4 — upstream
+  memory provider lifecycle (`Hal0MemoryProvider.initialize()` is the
+  natural place to publish the card).
+- ADR-0004 — bundled-agent decision frame.
+- ADR-0005 — Cognee as the memory engine; namespace model.

--- a/docs/internal/hermes-bootstrap-plan-2026-05-23.md
+++ b/docs/internal/hermes-bootstrap-plan-2026-05-23.md
@@ -1,0 +1,1011 @@
+# Hermes-Agent bootstrap plan (hal0 v0.3)
+
+**Status:** Draft 2 — post-grilling, decisions resolved.
+**Date:** 2026-05-23.
+**Companion docs:**
+- `docs/internal/hermes-upstream-map-2026-05-23.md` — upstream surface catalogue.
+- `docs/internal/hermes-env-probe-recipes-2026-05-23.md` — env-detection recipes.
+- `docs/internal/adr/0011-agent-identity-cards.md` — ADR for the identity-card convention (stub).
+
+---
+
+## Draft 2 changelog (2026-05-23, post-grilling)
+
+| Was (Draft 1) | Is (Draft 2) | Source |
+|---|---|---|
+| MCP-server path for memory; promote to plugin in v0.4 | **`Hal0MemoryProvider` plugin from day one** (MCP server kept in parallel for operator overrides) | Q1 |
+| `HERMES_HOME=/var/lib/hal0/agents/hermes/home/` | `HERMES_HOME=/var/lib/hal0/agents/hermes/` (drop `/home/` suffix); bootstrap state files relocated to `/var/lib/hal0/state/agents/hermes/` (outside HERMES_HOME) | Q2 |
+| Bearer token at `/etc/hal0/agents/hermes/secrets.env` | Bearer token at `/var/lib/hal0/secrets/agents/hermes.env` (0600, hal0:hal0), wrapper-sourced; + `hal0 agent rotate-token hermes` CLI stub | Q3 |
+| `model.provider: custom` (upstream profile) | `model.provider: hal0` (**`Hal0Profile` plugin**, hal0-owned) | Q4 |
+| Identity cards in `shared` dataset, YAML in `text` | Identity cards in **dedicated `agents` dataset**, summary in `text` + structured fields in `metadata`, immutable + cleaned on uninstall | Q5 |
+| Embed/rerank possibly wired in v0.4 | **Not wired in v0.3**; fastembed CPU stays for Cognee; both reserved as v0.4 follow-ups in ADR-0011 | Q6 |
+| `pip install --user hermes-agent` into `/var/lib/hal0/agents/hermes/venv/` | hal0-managed venv at **`/var/lib/hal0/venvs/hermes/`** with explicit Python 3.11; **hard pin** in `installer/agents/hermes/requirements.txt`; `--to=<version>` flag for opt-in upgrades; plugins packaged inside hal0 wheel + copied at bootstrap | Q7 |
+| `on_session_start` hook with 5s timeout | Tightened to **2s timeout**, light JSON dump only | Q8c |
+| Module: `src/hal0/agents/hermes_bootstrap.py` | Module renamed to **`src/hal0/agents/hermes_provision.py`** (avoids soft collision with upstream's Windows-UTF8 `hermes_bootstrap.py`); CLI verb stays `hal0 agent bootstrap hermes` | Q8f |
+| 14 open decision points in §21 | Status markers added; all 14 + bonus naming resolved | grilling |
+
+---
+
+## 0. TL;DR
+
+When a hal0 user runs `hal0 agent install hermes`, today we install the
+upstream package and write a 4-line env file. That's it. The agent boots
+into a generic Hermes session with no idea it lives on hal0, no
+knowledge of local models, no memory connection, no homelab context.
+
+This plan replaces that 4-line shim with an **idempotent, checkpointed
+bootstrap state machine** that turns the freshly-installed Hermes into a
+hal0-native homelab admin: it probes its environment, enumerates every
+live model, claims a memory namespace, learns the persona of "right-hand
+admin for this specific box," and registers itself as discoverable to
+peer agents (Claude Code, pi-coder, future agents).
+
+The bootstrap is:
+- one new Python module — `src/hal0/agents/hermes_provision.py` (~400 LOC).
+- two hal0-owned Hermes plugins coupled to upstream ABCs:
+  `Hal0MemoryProvider` (`agent/memory_provider.py` ABC) and `Hal0Profile`
+  (`providers/base.py` ABC). Packaged inside the hal0 wheel, copied
+  into `$HERMES_HOME/plugins/` by bootstrap. ~200 LOC.
+- one new shell stage (`installer/agents/hermes-bootstrap.sh`).
+- one new CLI subcommand (`hal0 agent bootstrap hermes`).
+- a state file at `/var/lib/hal0/state/agents/hermes/provision.json`
+  (outside HERMES_HOME — Hermes owns its own tree).
+
+Total new code: ~700 LOC.
+
+We add zero new MCP transports, **zero forks of upstream**, zero new
+daemons. Every wiring decision uses surfaces that already exist in
+hal0 v0.2 (`hal0-admin` MCP, `hal0-memory` MCP, `/api/models`,
+`/api/capabilities`, `/api/hardware`).
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+
+1. **Idempotent.** Re-runnable. Detects partial state. Repair flag.
+2. **Hardware-aware.** Knows it's on Strix Halo iGPU + XDNA2 NPU + UMA;
+   knows it's in an LXC with apparmor-unconfined; knows it has ~96 GiB
+   unified pool.
+3. **Model-aware.** Every active slot in `/etc/hal0/capabilities.toml`
+   becomes a `model_aliases` entry. Embed/rerank/STT/TTS slots wired
+   into their respective Hermes subsystems.
+4. **Memory-connected.** `hal0-memory` MCP registered as an MCP server.
+   Bootstrap claims `private:hermes-agent` namespace; writes an identity
+   card; reads/queues peer agents.
+5. **Context-aware.** `/etc/hal0/HERMES.md` and `/etc/hal0/agent-skills/`
+   exist; `terminal.cwd = /etc/hal0` so Hermes auto-injects them every
+   session.
+6. **Discoverable.** Other agents (Claude Code, pi-coder) can find
+   Hermes via the memory namespace registry and via
+   `hermes mcp serve` if exposed.
+7. **Re-derivable.** No bootstrap output is "the source of truth." Every
+   line of config.yaml can be regenerated from hal0 state at any time.
+
+### Non-goals (v0.3)
+
+- ❌ Federating hal0-memory across mem0 / Supermemory / etc. (Phase 9 / ADR-0006).
+- ❌ Wiring `hermes-agent-self-evolution` into the loop. (Out of scope;
+  separate repo, opens PRs to upstream — not a bootstrap concern.)
+- ❌ Exposing `embed()` / `rerank()` as agent-callable tools (deferred to v0.4 per ADR-0011).
+- ❌ Switching Cognee's embedder from fastembed CPU → bge-on-iGPU
+  (deferred to v0.4; v0.3 alpha memory volumes don't justify the runtime
+  slot dependency).
+- ❌ Modifying upstream `hermes-agent`. No fork. No patches. Everything
+  ships outside `$HERMES_HOME`'s upstream-owned files — but we DO ship
+  two hal0-owned plugins coupled to stable upstream ABCs.
+- ❌ Multi-user. Single hal0 host owner = single Hermes identity.
+
+---
+
+## 2. Upstream anchors (the don't-fight list)
+
+From the upstream map, these are the surfaces we MUST use as-is. Fighting
+them is what makes our current install fragile.
+
+| Anchor | What we honor |
+|---|---|
+| `HERMES_HOME` is the single root of truth | We pin it to `/var/lib/hal0/agents/hermes/` and propagate it via the wrapper + systemd `Environment=`. |
+| `config.yaml` is the persistent store, NOT `.env` | All non-secret config goes in `config.yaml`. `.env` only for token secrets. |
+| `hermes setup` overwrites `model.*` + `terminal.*` | We **never** call `hermes setup` after our bootstrap. We invoke `_run_first_time_quick_setup()` once at the start (or skip entirely) and own `config.yaml` write order ourselves. |
+| `mcp add` writes to `config.yaml` | MCP registration happens AFTER all `config.yaml` writes. Bootstrap order is strict. |
+| `skills.external_dirs` is read-only | Hal0-managed skills land in `/etc/hal0/agent-skills/`; the agent's own learned skills stay in `$HERMES_HOME/skills/`. |
+| `custom` provider profile is the local-server escape hatch | Use `provider: custom` + `base_url: http://127.0.0.1:8000/api/v1`. We do not need a custom plugin in v0.3. |
+| Context files auto-inject from cwd | Set `terminal.cwd = /etc/hal0`; drop `HERMES.md` there. |
+| `delegate_task` is Hermes's subagent surface | We don't try to make Hermes call Claude Code. We let Hermes use its own delegation primitive when it needs subagents. |
+
+---
+
+## 3. State machine
+
+The bootstrap is a deterministic sequence of named phases. Each phase
+writes a checkpoint into `/var/lib/hal0/state/agents/hermes/provision.json`.
+On re-run, the bootstrap reads the checkpoint and skips any phase already
+marked `ok` (unless `--repair` or the phase's inputs have changed).
+
+```
+preflight → install → env_probe → home_init → config_write
+   → mcp_wire → context_link → namespace_register → model_automap
+   → voice_wire → smoke_tests → self_report
+```
+
+Each phase is a function in `hermes_provision.py`:
+
+```python
+def _phase_preflight(state: BootstrapState) -> PhaseResult: ...
+def _phase_install(state: BootstrapState) -> PhaseResult: ...
+def _phase_env_probe(state: BootstrapState) -> PhaseResult: ...
+...
+PHASES = [
+    ("preflight",         _phase_preflight),
+    ("install",           _phase_install),
+    ("env_probe",         _phase_env_probe),
+    ("home_init",         _phase_home_init),
+    ("config_write",      _phase_config_write),
+    ("mcp_wire",          _phase_mcp_wire),
+    ("context_link",      _phase_context_link),
+    ("namespace_register",_phase_namespace_register),
+    ("model_automap",     _phase_model_automap),
+    ("voice_wire",        _phase_voice_wire),
+    ("smoke_tests",       _phase_smoke_tests),
+    ("self_report",       _phase_self_report),
+]
+```
+
+Phase contract:
+- **Input:** `state` (in-memory dataclass mirroring provision.json).
+- **Output:** `PhaseResult(status=ok|skip|fail|repair_needed, details=...)`.
+- **Side effects:** writes to filesystem + hal0-memory; never to network
+  outside of localhost / 10.0.1.x LAN.
+- **Idempotency:** the phase is responsible for detecting "already done"
+  via content hash, not just a checkpoint flag.
+
+### State file shape
+
+State lives at `/var/lib/hal0/state/agents/hermes/provision.json` —
+**outside** `$HERMES_HOME` so Hermes doesn't trample it.
+
+```json
+{
+  "version": 1,
+  "started_at": "2026-05-23T14:00:00Z",
+  "completed_at": null,
+  "hal0_version": "0.2.0-alpha.3",
+  "hermes_version": "0.14.0",
+  "hermes_home": "/var/lib/hal0/agents/hermes",
+  "venv": "/var/lib/hal0/venvs/hermes",
+  "secrets_file": "/var/lib/hal0/secrets/agents/hermes.env",
+  "phases": {
+    "preflight":          {"status":"ok","at":"...","hash":"abc..."},
+    "install":            {"status":"ok","at":"...","hash":"..."},
+    "env_probe":          {"status":"ok","at":"...","snapshot_path":"env-2026-05-23T14:00:01Z.json"},
+    "home_init":          {"status":"ok","at":"..."},
+    "config_write":       {"status":"ok","at":"...","yaml_hash":"..."},
+    "mcp_wire":           {"status":"ok","at":"...","servers":["hal0-admin","hal0-memory"]},
+    "context_link":       {"status":"ok","at":"...","links":[...]},
+    "namespace_register": {"status":"ok","at":"...","memory_id":"mem_..."},
+    "model_automap":      {"status":"ok","at":"...","aliases_written":["primary","embed","rerank","stt","tts","img"]},
+    "voice_wire":         {"status":"skip","reason":"no stt/tts slot configured"},
+    "smoke_tests":        {"status":"ok","at":"...","results":{...}},
+    "self_report":        {"status":"ok","at":"...","summary_id":"mem_..."}
+  },
+  "errors": []
+}
+```
+
+---
+
+## 4. Phase A: Preflight (`_phase_preflight`)
+
+**What it checks:**
+- Python 3.11+ available (`sys.version_info`).
+- `hal0` daemon reachable at `http://127.0.0.1:8080/api/status` (200 OK).
+- `HAL0_BEARER_TOKEN` available (from systemd creds or `/etc/hal0/auth.env`).
+- `/etc/hal0/` writable by the daemon user.
+- `/var/lib/hal0/agents/` writable.
+- Disk: ≥ 4 GiB free under `/var/lib/hal0/`.
+- Network: can reach `pypi.org` (for `pip install hermes-agent`) — or
+  detect an `--offline` flag with a pre-downloaded wheel cache.
+
+**Failure mode:** hard fail. Surface to the dashboard's first-run wizard
+with a concrete remediation hint per failure (`hal0 daemon not running:
+sudo systemctl start hal0`).
+
+**Why first:** preflight failures are 90% of "install succeeded but
+agent broken" tickets. Detect early.
+
+---
+
+## 5. Phase B: Install (`_phase_install`)
+
+**What it does:**
+1. Detects if a hal0-managed Hermes venv already exists at
+   `/var/lib/hal0/venvs/hermes/` AND `hermes version` matches the pin.
+2. If absent or stale: `python3.11 -m venv /var/lib/hal0/venvs/hermes/`
+   (explicit Python 3.11), then `pip install -r installer/agents/hermes/requirements.txt`
+   (hard-pinned `hermes-agent==<pinned>`).
+3. Symlinks `/var/lib/hal0/venvs/hermes/bin/hermes` to `/usr/local/bin/hermes`.
+4. Copies the existing `installer/wrappers/hal0-hermes` wrapper to
+   `/usr/local/bin/hal0-hermes`. Wrapper sources
+   `/var/lib/hal0/secrets/agents/hermes.env` and exports
+   `HERMES_HOME=/var/lib/hal0/agents/hermes` before exec.
+5. Copies the two hal0-owned plugins from the hal0 wheel's package data
+   into `$HERMES_HOME/plugins/`:
+   - `plugins/memory/hal0-memory/__init__.py` → `Hal0MemoryProvider`
+   - `plugins/model-providers/hal0/__init__.py` → `Hal0Profile`
+6. Drops a systemd service template at
+   `/etc/systemd/system/hal0-hermes.service` (Type=simple, runs
+   `hal0-hermes` headless for `mcp serve` mode — see §11).
+
+**Pinning policy:** hard pin in `installer/agents/hermes/requirements.txt`
+(`hermes-agent==0.14.0` exact). Bumping requires a hal0 release; upgrade
+gate is `hal0 agent upgrade hermes [--to=<version>]`. The `--to` flag
+exists for power users + our own compat testing.
+
+---
+
+## 6. Phase C: Env probe (`_phase_env_probe`)
+
+**Purpose:** capture a snapshot of the hal0 host environment so every
+subsequent phase can reference it.
+
+**Source of truth:** `hal0-admin` MCP, NOT direct probing. We don't
+re-implement env discovery in Hermes-land — we reuse what hal0 already
+exposes.
+
+**Calls made (via `hal0-admin` MCP, autonomous-read tools):**
+- `hardware_probe` → CPU, RAM, GPU, NPU, platform, is_uma.
+- `version_info` → hal0 version, build hash.
+- `capability_list` → which capability slots are configured.
+- `slot_list` → which slots are currently running and on what backend.
+- `provider_list` → upstream providers (if any are wired).
+
+**Additionally probed locally** (recipes from env-probe doc):
+- Container layer via `systemd-detect-virt --container`.
+- `/dev/accel/accel0` presence (NPU device node, the LXC-correct check —
+  `modinfo amdxdna` lies in containers).
+- KFD `gfx_target_version` → confirm `gfx1151` (Strix Halo).
+- Default route + DNS reachability of hal0 services.
+- Docker socket presence (so Hermes knows if it can use `terminal.backend = docker`).
+
+**Output:** writes `/var/lib/hal0/agents/hermes/env-<timestamp>.json` AND
+keeps the latest summary in `provision.json["phases"]["env_probe"]`.
+
+**Why NOT in Hermes:** Hermes shouldn't be the one running `xrt-smi`
+because it might be running outside an LXC with NPU passthrough. The
+authoritative answer is hal0's, captured at hal0's vantage point.
+
+**Reusable hal0-admin MCP tools to add (from env-probe agent's recos):**
+- `gpu_target_version()`
+- `npu_status()`
+- `model_store_probe(path)`
+- `env_report()` — full dataclass dump.
+
+These belong in `src/hal0/mcp/admin.py` so the dashboard, the
+Lemonade onboarding wizard, and Hermes bootstrap all consume one
+implementation.
+
+---
+
+## 7. Phase D: Home init (`_phase_home_init`)
+
+**What it does:**
+1. Creates `/var/lib/hal0/agents/hermes/` if absent (this is
+   `$HERMES_HOME`).
+2. Creates standard subdirs: `memories/`, `skills/`, `plugins/`,
+   `plugins/memory/`, `plugins/model-providers/`, `logs/`,
+   `sessions/`, `profiles/`, `mcp-tokens/`.
+3. Sets ownership/mode (`hal0:hal0`, 0750).
+4. Drops a marker file `.hal0-managed` so we don't accidentally clobber a
+   user's pre-existing `~/.hermes`.
+5. Writes `$HERMES_HOME/SOUL.md` from a hal0-bundled persona template
+   (see §7.1).
+6. Copies plugin sources from the hal0 wheel's package data:
+   - `installer/agents/hermes/plugins/hal0-memory/` →
+     `$HERMES_HOME/plugins/memory/hal0-memory/`
+   - `installer/agents/hermes/plugins/hal0/` →
+     `$HERMES_HOME/plugins/model-providers/hal0/`
+
+### 7.1 SOUL.md template
+
+We ship `installer/agents/hermes/SOUL.md.j2` as a Jinja2 template
+parameterized by env-probe output. Rendered example:
+
+```markdown
+# Identity
+
+You are the hal0 admin agent — the right-hand assistant for this
+specific homelab inference platform. You live on a {{ platform }} host
+({{ hostname }}) with:
+
+- {{ cpu_model }} ({{ cpu_threads }} threads)
+- {{ ram_total_gib }} GiB of {{ memory_topology }} RAM
+{% if npu_present %}- AMD XDNA2 NPU ({{ npu_name }}){% endif %}
+{% if gpu_name %}- {{ gpu_name }} ({{ gpu_arch }}){% endif %}
+- Container layer: {{ container_type }}{% if container_type == "lxc" %} (privileged + apparmor-unconfined){% endif %}
+
+# Operating principles
+
+1. Probe before you change. Use `hal0_admin:slot_status` before
+   touching anything; prefer `--dry-run` when offered.
+2. Cite exact paths, ports, and slot names. "Lemonade primary at
+   127.0.0.1:13305" beats "the chat model."
+3. You have a memory MCP at `hal0_memory`. Use it for durable facts
+   about this host. Don't ask the user the same question twice.
+4. Other agents may share this memory (Claude Code, pi-coder).
+   Respect their namespaces; never overwrite their identity cards.
+5. Default to the smallest model that will work for a task. The utility
+   slot on the NPU exists for cheap work; the primary on the iGPU is
+   for reasoning-heavy turns.
+
+# Boundaries
+
+- Never reach outside the LAN without explicit user instruction.
+- Never edit `/etc/hal0/capabilities.toml` directly; go through
+  `hal0_admin:capability_set` so the orchestrator reconciles.
+- Never run `hermes setup` — it will undo your config.
+```
+
+(Full template parameterized; falls back to upstream `DEFAULT_SOUL_MD`
+on render failure.)
+
+---
+
+## 8. Phase E: Config write (`_phase_config_write`)
+
+**What it does:** atomic write of `$HERMES_HOME/config.yaml` from a
+hal0-rendered template + env-probe data.
+
+**Order is critical** (per upstream gotcha §9): all config keys go in
+ONE write. We never call `hermes config set` for the initial wiring —
+that's slow and racy. We render the whole YAML, write to a tmpfile,
+fsync, rename.
+
+### Rendered config.yaml (rough shape)
+
+```yaml
+# Managed by hal0. Edits MAY be overwritten by `hal0 agent bootstrap hermes`.
+# Manual overrides: drop a hal0-override.yaml beside this; bootstrap merges.
+
+model:
+  default: "{{ primary.model_id }}"          # from /etc/hal0/slots/primary.toml runtime
+  provider: "hal0"                            # the Hal0Profile plugin
+  base_url: "{{ primary.backend_url }}"       # from /v1/health.loaded[0]
+  context_length: {{ primary.context_length }}
+
+providers:
+  hal0:
+    request_timeout_seconds: 300
+    stale_timeout_seconds: 900
+
+model_aliases:
+{% for slot in slots if slot.capability == "chat" %}
+  {{ slot.alias }}:
+    model: "{{ slot.model_id }}"
+    provider: hal0
+    base_url: "{{ slot.backend_url }}"
+{% endfor %}
+
+memory:
+  provider: "hal0-memory"   # Hal0MemoryProvider plugin (Path B — native injection)
+  memory_enabled: true
+  user_profile_enabled: true
+  nudge_interval: 10
+
+mcp_servers:
+  # MCP servers stay registered as a parallel surface for operator
+  # overrides (e.g., the user manually invoking memory_delete). The
+  # agent loop goes through the Hal0MemoryProvider plugin.
+  hal0-admin:
+    url: "http://127.0.0.1:8080/mcp/admin"
+    headers:
+      Authorization: "Bearer ${HAL0_BEARER_TOKEN}"
+    timeout: 60
+  hal0-memory:
+    url: "http://127.0.0.1:8080/mcp/memory"
+    headers:
+      Authorization: "Bearer ${HAL0_BEARER_TOKEN}"
+      X-hal0-Private: "1"           # opt into private:hermes-agent namespace
+    timeout: 30
+
+skills:
+  external_dirs:
+    - "/etc/hal0/agent-skills"
+    - "/var/lib/hal0/skills"
+  creation_nudge_interval: 15
+
+terminal:
+  backend: "local"
+  cwd: "/etc/hal0"                  # auto-injects HERMES.md and AGENTS.md
+
+agent:
+  max_turns: 60
+  reasoning_effort: "medium"
+
+display:
+  bell_on_complete: false
+  show_reasoning: false
+
+# Auxiliary model routing — reuse primary by default
+auxiliary:
+  vision:    { provider: "main", model: "" }
+  web_extract: { provider: "main", model: "" }
+  session_search: { provider: "main", model: "" }
+
+# Voice — only emitted if /etc/hal0/slots/{stt,tts}.toml are enabled
+{% if stt %}
+stt:
+  provider: "openai"
+{% endif %}
+{% if tts %}
+tts:
+  provider: "openai"
+{% endif %}
+
+# Hooks — wire hal0 events into Hermes
+hooks:
+  on_session_start:
+    - command: "/usr/lib/hal0/hermes-hooks/inject-system-state.sh"
+      timeout: 5
+```
+
+`.env` (secrets only):
+
+```
+HAL0_BEARER_TOKEN={{ token }}                 # required for MCP auth
+{% if stt %}STT_OPENAI_BASE_URL={{ stt.backend_url }}
+VOICE_TOOLS_OPENAI_KEY=dummy{% endif %}
+GITHUB_TOKEN=                                  # optional; user-supplied
+```
+
+**Override file:** if `/etc/hal0/agents/hermes/overrides.yaml` exists,
+deep-merge it INTO our rendered config on top. This is the user escape
+hatch — anything they put there survives re-bootstrap.
+
+---
+
+## 9. Phase F: MCP wire (`_phase_mcp_wire`)
+
+**What it does:**
+- Verifies `hal0-admin` and `hal0-memory` MCP servers respond to a
+  `tools/list` call.
+- Verifies `Authorization: Bearer` + (for memory) `X-hal0-Private: 1`
+  produce a `private:hermes-agent` namespace on first write.
+- Records the discovered tool surface (the live list of `memory_*`,
+  `slot_*`, `model_*` tool names) into `provision.json` for the
+  `namespace_register` and `model_automap` phases to consume.
+
+**No `hermes mcp add` call** — we already wrote `mcp_servers` directly
+into `config.yaml`. Calling `add` would just edit YAML we already own.
+
+**Failure mode:** if Hermes can't reach the MCP servers but they ARE up
+(verified via curl from hal0 side), we record the failure and continue.
+Smoke tests will surface it.
+
+---
+
+## 10. Phase G: Context link (`_phase_context_link`)
+
+**What it does:**
+1. Creates `/etc/hal0/agent-skills/` if absent (the shared skills root).
+2. Symlinks every hal0-bundled skill from `/usr/share/hal0/skills/` into
+   `/etc/hal0/agent-skills/`. (Bundled with the hal0 wheel under
+   `package-data`.)
+3. Renders `/etc/hal0/HERMES.md` from `installer/agents/hermes/HERMES.md.j2`
+   — this is the cwd-injected context file (per upstream `prompt_builder.py`
+   auto-injection rules).
+4. Renders `/etc/hal0/AGENTS.md` — a generic agent-context file readable
+   by Claude Code, Cursor, Codex, AND Hermes from the same directory.
+5. Symlinks `/etc/hal0/HERMES.md` into `$HERMES_HOME/memories/HOST.md` so
+   it ALSO appears in Hermes's memory tier (belt + braces).
+
+### HERMES.md content (rendered)
+
+Static enough to live in a template, parameterized by env-probe:
+
+```markdown
+# Where you are
+
+- Host: {{ hostname }} ({{ container_type }})
+- Platform: {{ platform }}
+- hal0 version: {{ hal0_version }}
+- Memory MCP: hal0_memory (auto-loaded; you have full read/write on private:hermes-agent)
+- Admin MCP: hal0_admin (auto-loaded; you have autonomous read on all status tools)
+
+# Active capability slots
+
+{% for slot in slots %}
+- **{{ slot.name }}** ({{ slot.capability }}/{{ slot.kind }}): {{ slot.model_id }} on {{ slot.device }}
+  - {{ slot.backend_url }} → call via `model_aliases.{{ slot.alias }}`
+{% endfor %}
+
+# Peer agents
+
+{{ peer_agents_summary }}    # filled in by namespace_register phase
+
+# Skills
+
+- Hal0-managed skills mirror at `/etc/hal0/agent-skills/`.
+- Your own skills land in `$HERMES_HOME/skills/`.
+
+# Conventions
+
+- The dashboard at https://hal0.thinmint.dev shows live slot state.
+- Never edit slot TOMLs directly — use `hal0_admin:capability_set`.
+- Never run `hermes setup` — it will overwrite your model wiring.
+```
+
+---
+
+## 11. Phase H: Namespace register (`_phase_namespace_register`)
+
+**What it does:**
+1. Calls `memory_add` on `hal0-memory` MCP with the agent identity
+   card, targeting the **dedicated `agents` dataset** (not `shared`,
+   not `private:*`). Tag = `agent-identity`. Card is **immutable** —
+   written once at bootstrap, cleaned by `hal0 agent uninstall hermes`.
+2. Calls `memory_search` to enumerate ANY other agent identity cards
+   already in the `agents` dataset (Claude Code, pi-coder, future).
+3. Builds a peer-agents summary, writes it into `provision.json` AND
+   substitutes it into the `HERMES.md` `{{ peer_agents_summary }}`
+   block (re-render `HERMES.md` post-discovery).
+
+### Agent identity card schema (canonical — see ADR-0011)
+
+Stored in the `agents` dataset, tag `agent-identity`. The `text`
+field is a human-readable summary (surfaces well in `memory_search`
+ranking). The structured payload lives in `metadata` so programmatic
+readers don't have to YAML-parse a text blob.
+
+```json
+{
+  "text": "I am Hermes, the hal0 admin agent. I have read/write access to the slot lifecycle and the memory store on this host. I can do generalist chat and code review on the LAN.",
+  "tags": ["agent-identity", "hermes"],
+  "dataset": "agents",
+  "metadata": {
+    "agent_id": "hermes-agent",
+    "display_name": "Hermes (hal0 admin)",
+    "namespace": "private:hermes-agent",
+    "roles": ["homelab-admin", "generalist-chat", "memory-curator"],
+    "endpoint": {
+      "type": "mcp-serve",
+      "url": "http://127.0.0.1:8081/mcp",
+      "transport": "streamable-http"
+    },
+    "delegation": {
+      "accepts_tasks_from": ["claude-code", "pi-coder", "user"],
+      "max_concurrent": 3
+    },
+    "hal0_state": {
+      "registered_at": "2026-05-23T14:00:00Z",
+      "bootstrap_version": 1,
+      "hal0_version": "0.2.0-alpha.3",
+      "hermes_version": "0.14.0"
+    }
+  }
+}
+```
+
+Discovery:
+
+```json
+memory_search({
+  "query": "agent identity",
+  "tags": ["agent-identity"],
+  "dataset": "agents",
+  "limit": 50
+})
+```
+
+**Why `agents` not `shared` or `private`?** Service registry and
+episodic memory are different concerns. Cognee will embed each card
+but the dataset is small (5-10 cards forever) so the embed cost is
+irrelevant. Search-by-similarity is a free side-benefit ("find an
+agent that does X" works naturally). `private:*` is wrong because
+identity is **public-by-design** — anything that wants to delegate to
+Hermes needs to know it's there. `shared` is also wrong because that's
+where episodic facts live; conflating concerns invites schema rot.
+
+**Why immutable?** Cards are write-once. Liveness ("is the endpoint
+reachable right now?") is **not** a stored field; the dashboard pings
+the endpoint to check. Stale-card-on-uninstall is solved by the
+uninstall CLI: `memory_delete(ids=[card_id])` is a one-line cleanup
+step. Re-bootstrap on Hermes-version upgrade rewrites the card —
+that's the only legitimate write besides install.
+
+---
+
+## 12. Phase I: Model automap (`_phase_model_automap`)
+
+**What it does:** walks the output of `slot_list` + `model_list` and
+writes `model_aliases` entries to `config.yaml`. Already partially done
+in `_phase_config_write`, but this phase handles dynamic post-install
+updates (e.g., user added a new chat slot — bootstrap re-run picks it up
+without clobbering anything else).
+
+### Mapping rule
+
+| hal0 capability slot | Hermes config destination |
+|---|---|
+| `primary` (chat) | `model.default` + `model_aliases.primary` |
+| Additional chat slots | `model_aliases.<slot-name>` |
+| `embed` | **Not wired** — Hermes doesn't call `/v1/embeddings` directly. Memory MCP handles embedding internally via Cognee → fastembed. Recorded but unused. |
+| `embed-rerank` | Same — no direct surface in Hermes. |
+| `stt` | `stt.provider: openai` + `STT_OPENAI_BASE_URL` env. |
+| `tts` | `tts.provider: openai` + analogous env. |
+| `img` | `auxiliary.vision` if the model supports vision; otherwise unwired (image generation is not a Hermes core feature). |
+
+**Why embed/rerank stay unwired:** per upstream map §3.8 — Hermes has no
+top-level embeddings provider abstraction. Embeddings live inside
+specific memory providers. Our memory path is MCP-based (hal0-memory
+does Cognee → fastembed internally), so Hermes never needs to know.
+
+**Decision point for grilling:** is that right, or do we WANT Hermes to
+have a direct embed surface for RAG-style skills? If yes, we'd need to
+ship a custom memory provider plugin and route embeds through it.
+Currently leaning no — keep it simple.
+
+---
+
+## 13. Phase J: Voice wire (`_phase_voice_wire`)
+
+Conditionally emits STT/TTS config IF the respective slots are
+configured AND running:
+
+```yaml
+stt:
+  provider: "openai"
+  openai: { model: "moonshine-base" }   # or whatever the slot reports
+
+tts:
+  provider: "openai"
+  openai: { model: "kokoro-default" }
+```
+
+Writes `STT_OPENAI_BASE_URL` and a placeholder `VOICE_TOOLS_OPENAI_KEY=dummy`
+to `.env`.
+
+Per memory `hal0_moonshine_toolbox_bug`: moonshine requires both
+`models_dir` and `model_name` — but that's Lemonade's problem, not ours.
+Hermes just sees an OpenAI-compatible endpoint.
+
+---
+
+## 14. Phase K: Smoke tests (`_phase_smoke_tests`)
+
+Each test is a single call against a wired surface; failure is
+**non-fatal** but recorded.
+
+1. `hermes status` — process running.
+2. `hermes doctor` — provider reachable, models endpoint returns the
+   pinned model.
+3. One `chat/completions` call against `model.default` ("Reply with the
+   word 'ready'.") — assert "ready" in response.
+4. `memory_add` + `memory_search` roundtrip on `hal0-memory` — assert
+   the just-written doc comes back in search.
+5. MCP `tools/list` against `hal0-admin` — assert ≥ 5 tools.
+6. Read `/etc/hal0/HERMES.md` — assert it contains the active primary
+   model id (proves rendering succeeded).
+
+Failures land in `provision.json["errors"]` with a remediation hint
+(`smoke_3_chat_completions_failed: check 'hal0 status primary'`).
+
+---
+
+## 15. Phase L: Self-report (`_phase_self_report`)
+
+**What it does:** writes a bootstrap-completion summary into
+`hal0-memory` under the `private:hermes-agent` namespace, then pings
+the hal0 dashboard's agent-status endpoint so the UI surfaces "Hermes
+bootstrapped ✓" in real time.
+
+Memory write:
+
+```
+memory_add({
+  "text": "Hermes-Agent bootstrap completed. Pinned to hermes 0.14.0 on hal0 0.2.0-alpha.3. Primary chat slot = Qwen3-30B-A3B-Instruct-2507 on gpu-vulkan (lemonade @ 127.0.0.1:13305). Memory MCP + admin MCP wired. 5 model aliases mapped. 0 smoke failures.",
+  "tags": ["bootstrap", "self-report", "agent-identity"],
+  "metadata": { "bootstrap_version": 1, "phase_results": {...} }
+})
+```
+
+This memory becomes the first thing the agent recalls on next session
+start (via the prefetch hook), giving it durable knowledge of when and
+how it was provisioned.
+
+---
+
+## 16. CLI surface
+
+New subcommands under `hal0 agent`:
+
+```
+hal0 agent bootstrap hermes [--repair] [--dry-run] [--skip-phase NAME] [--offline] [--verbose]
+hal0 agent status hermes
+hal0 agent log hermes [--phase NAME]
+hal0 agent upgrade hermes [--to=<version>]
+hal0 agent rotate-token hermes
+hal0 agent uninstall hermes [--keep-memory]
+```
+
+- `bootstrap hermes` — runs phases A–L. Resumes from last successful
+  phase unless `--repair`.
+- `--dry-run` — renders config.yaml + HERMES.md to /tmp, prints diffs
+  against current state, does not write.
+- `--skip-phase` — runtime override for stuck phases (with warning).
+- `status hermes` — pretty-print `provision.json`.
+- `log hermes --phase env_probe` — dump per-phase logs from
+  `/var/lib/hal0/state/agents/hermes/provision-logs/<phase>.log`.
+- `upgrade hermes` — bumps the Hermes pin in the venv, re-runs bootstrap
+  in `--repair` mode against the new version. `--to=<version>` is the
+  power-user escape hatch (and what we use for compat testing).
+- `rotate-token hermes` — mints a new bearer, writes
+  `/var/lib/hal0/secrets/agents/hermes.env`, restarts the wrapper. The
+  long-lived token policy in v0.3 makes this a manual operation; v1.0
+  hardening will add scheduled rotation.
+- `uninstall hermes` — removes venv, plugins, HERMES_HOME (unless
+  `--keep-memory`), the identity card in the `agents` dataset, the
+  systemd unit, and the bearer token file.
+
+`hal0 agent install hermes` (existing) becomes a **thin wrapper** that
+calls `bootstrap hermes` after the existing install. No behavior split
+between install and bootstrap — bootstrap IS install.
+
+---
+
+## 17. Code map
+
+### New files
+
+| Path | Purpose | LOC |
+|---|---|---|
+| `src/hal0/agents/hermes_provision.py` | Phase orchestrator + each phase impl | ~400 |
+| `src/hal0/agents/hermes_templates/SOUL.md.j2` | Persona template | ~80 |
+| `src/hal0/agents/hermes_templates/HERMES.md.j2` | Cwd-injected context | ~60 |
+| `src/hal0/agents/hermes_templates/AGENTS.md.j2` | Generic agent-context (shared with Claude Code etc.) | ~40 |
+| `src/hal0/agents/hermes_templates/config.yaml.j2` | The full Hermes config render | ~100 |
+| `installer/agents/hermes/requirements.txt` | Hard-pinned `hermes-agent==<v>` for the venv | ~5 |
+| `installer/agents/hermes/plugins/hal0-memory/__init__.py` | `Hal0MemoryProvider(MemoryProvider)` plugin | ~150 |
+| `installer/agents/hermes/plugins/hal0-memory/plugin.yaml` | Plugin manifest | ~10 |
+| `installer/agents/hermes/plugins/hal0/__init__.py` | `Hal0Profile(ProviderProfile)` plugin | ~80 |
+| `installer/agents/hermes/plugins/hal0/plugin.yaml` | Plugin manifest | ~10 |
+| `installer/agents/hermes-bootstrap.sh` | Shell hook for the existing installer to call into Python | ~30 |
+| `installer/agents/hermes/hooks/inject-system-state.sh` | Shell hook fired on session start; calls hal0-admin for fresh state (≤2s) | ~25 |
+| `docs/internal/adr/0011-agent-identity-cards.md` | ADR for the identity card convention | ~120 |
+| `tests/agents/test_hermes_provision.py` | Per-phase unit tests | ~250 |
+| `tests/agents/test_hal0_memory_provider.py` | Plugin tests (ABC contract + HTTP roundtrip) | ~120 |
+| `tests/agents/test_hal0_profile.py` | Provider plugin tests | ~80 |
+| `tests/harness/scenarios/hermes_bootstrap.yaml` | δ-tier harness scenario | ~30 |
+
+**Total new code:** ~1,580 LOC (was ~1,090 in Draft 1; Path B plugin +
+provider plugin + tests added the delta).
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `src/hal0/agents/hermes.py` | Existing `HermesDriver.install()` calls into `hermes_provision.run()` after the venv install. The 4-line env file moves to `/var/lib/hal0/secrets/agents/hermes.env`; non-secret config moves to `config.yaml` rendered by Phase E. |
+| `installer/agents/hermes-agent.sh` | After upstream venv install, exec the new bootstrap shell hook. |
+| `installer/wrappers/hal0-hermes` | Source `/var/lib/hal0/secrets/agents/hermes.env`; export `HERMES_HOME=/var/lib/hal0/agents/hermes`; exec `/var/lib/hal0/venvs/hermes/bin/hermes`. |
+| `src/hal0/mcp/admin.py` | Add reusable tools: `gpu_target_version`, `npu_status`, `model_store_probe`, `env_report` (per env-probe agent's recos). |
+| `src/hal0/api/routes/installer.py` | New `POST /api/agents/hermes/bootstrap` route (so dashboard's first-run wizard can trigger it). |
+| `docs/internal/adr/0004-agents.md` | Append §11 referencing this plan + the two hal0-owned plugin commitments. |
+| `pyproject.toml` (hal0) | Add `installer/agents/hermes/plugins/**` to `package-data` so plugins ship inside the wheel. |
+
+### Deleted/replaced
+
+Nothing yet. The existing wrapper survives. ADR-0004 grows; doesn't get
+rewritten.
+
+---
+
+## 18. Failure modes & recovery
+
+| Failure | Detection | Recovery |
+|---|---|---|
+| `pip install hermes-agent` fails | `subprocess.run` non-zero | Retry with `--no-build-isolation`; surface PyPI outage via `hal0 agent log`. |
+| `HERMES_HOME` already exists with a non-hal0 marker | absence of `.hal0-managed` file | Prompt user (dashboard) to choose: backup-and-overwrite vs use a sub-profile. |
+| MCP servers unreachable | `tools/list` times out | Mark `mcp_wire` as `degraded`, continue. Next phase logs the warning. Smoke tests surface to user. |
+| Lemonade primary slot not loaded | `slot_list` returns no `ready` chat slot | `config_write` falls back to a placeholder; bootstrap completes but `model.default` is unwired. Surface in self-report. |
+| `hermes setup` accidentally re-run by user | Detect via `config.yaml` content hash mismatch | `bootstrap --repair` re-renders and writes; preserves overrides.yaml. |
+| Bootstrap killed mid-phase | Checkpoint file inconsistency | Re-run resumes from last `ok` phase; the killed phase re-runs (must be idempotent). |
+| User uninstalled and reinstalled hal0 | `hal0_version` mismatch in provision.json | Bootstrap detects, re-runs all phases. Memory namespace survives via Cognee's persistence. |
+
+---
+
+## 19. Idempotency rules
+
+For each phase to be safely re-runnable:
+
+1. **`config_write`** — write to tmpfile + atomic rename. Hash the
+   rendered YAML; if hash matches current `config.yaml`, skip the write
+   entirely (still mark phase `ok`).
+2. **`context_link`** — symlinks use `os.symlink(target, link)` only
+   when `os.readlink(link) != target`. Otherwise pass.
+3. **`namespace_register`** — `memory_search` first by `agent_id` tag;
+   if our identity card exists, `memory_delete` + `memory_add` so we
+   refresh metadata instead of accumulating cards.
+4. **`model_automap`** — diff the rendered `model_aliases` against the
+   current; only `hermes config set` (or direct YAML rewrite) on
+   changed entries.
+5. **`smoke_tests`** — always re-run. They're cheap and verify the
+   wiring still works.
+
+---
+
+## 20. Self-improvement loop integration (deferred to v0.4)
+
+`NousResearch/hermes-agent-self-evolution` is a separate repo that uses
+DSPy + GEPA to mutate prompts/skills and open PRs against
+`hermes-agent`. It costs ~$2-10 per run and requires a configured
+optimizer LLM.
+
+**v0.3 stance:** mention it in HERMES.md (as a capability the user can
+opt into), but do not wire automatically. The right time to do this is
+after we ship v0.3 stable, see how the bootstrap holds up across a few
+hundred real installs, and then have evolution target the hal0-specific
+skills directory (`/etc/hal0/agent-skills/`).
+
+**Forward-looking sketch (v0.4):**
+- Fork to `Hal0ai/hermes-agent-self-evolution`.
+- Wire to evolve the `agent-skills` corpus, not upstream skills.
+- Schedule via `hal0 agent evolve hermes --weekly`.
+- Gate evolution proposals on the test harness (`make harness`) before
+  any auto-merge.
+
+---
+
+## 21. Open decision points — RESOLVED 2026-05-23 (post-grilling)
+
+> All 14 + bonus naming question resolved. **See the changelog table at
+> the top of this doc** for the final answers. This section is kept as
+> historical record showing the trade-off space we walked through.
+
+Original list (numbered for `/grill-me` to attack one at a time):
+
+1. **`pipx` vs hal0-managed venv vs system pip.** Plan = venv. Reasoning:
+   isolation + Python-version control. Cost: one more thing to maintain.
+
+2. **MCP path vs MemoryProvider plugin path for memory.** Plan = MCP
+   (Path A). Reasoning: zero new code on Hermes side; promote to a
+   plugin later if MCP-tool-discoverability proves clunky. Risk: the
+   model has to "remember" to call memory tools; a plugin would inject
+   memory into every system prompt automatically.
+
+3. **Use upstream `custom` profile vs ship `Hal0Profile` plugin.** Plan =
+   `custom`. Reasoning: zero new code, works today. Cost: setup wizard
+   won't show "hal0" as a first-class provider option (relevant only if
+   we expect users to re-run `hermes setup`, which we don't).
+
+4. **`hermes setup` — never call, or call with `--quick`?** Plan =
+   never. Reasoning: it overwrites our work. Cost: skip the upstream's
+   "is your provider reachable?" check; we re-implement that in
+   smoke_tests.
+
+5. **Bootstrap as separate CLI (`hal0 agent bootstrap hermes`) vs
+   inside install.** Plan = SAME command; install wraps bootstrap.
+   Reasoning: removes "I installed but didn't bootstrap" footgun.
+   Cost: bootstrap failures fail install.
+
+6. **`HERMES_HOME` location — `/var/lib/hal0/agents/hermes/home/` vs
+   user-scoped (`~/.hermes` of the daemon user).** Plan = system path.
+   Reasoning: survives user changes, single-host single-Hermes is the
+   default model. Cost: doesn't support multi-user hal0 (out of scope).
+
+7. **Identity card storage — `shared` dataset vs dedicated.** Plan =
+   `shared` with `tag=agent-identity`. Reasoning: agent discovery is
+   public-by-design. Cost: clutters the shared dataset; future
+   federation may need a dedicated source.
+
+8. **Hooks — opt-in or default-on?** Plan = `on_session_start` hook
+   default-on (injects fresh state). Cost: every session pays a ~5s
+   shell-script tax.
+
+9. **Embed/rerank wiring — leave unwired, or build a skill that calls
+   them via hal0-admin?** Plan = leave unwired in Hermes; the memory
+   MCP handles embeddings internally. Risk: a skill author might want
+   raw embed access; they'd have to call `/v1/embeddings` themselves via
+   the terminal tool.
+
+10. **Voice on by default, or opt-in?** Plan = conditional — only emit
+    voice config if slots are configured. Reasoning: most users won't
+    have STT/TTS in v0.3.
+
+11. **Self-evolution opt-in path in v0.3, or fully deferred?** Plan =
+    mention in HERMES.md only; no wiring. Cost: nothing.
+
+12. **Should we also auto-bootstrap a Claude Code AGENTS.md at
+    `/etc/hal0/AGENTS.md`?** Plan = yes, Phase G writes both HERMES.md
+    AND AGENTS.md from a shared template. Reasoning: free win; any agent
+    landing in `/etc/hal0/` gets the same context. Cost: ~40 LOC.
+
+13. **Cognee namespace migration when v0.4 federates.** Plan = ignore
+    for now; ADR-0006 (pending) will handle.
+
+14. **Where does the bearer token come from on first install?** Plan =
+    hal0 daemon mints a long-lived bearer for the Hermes agent on first
+    install, stores it in `/etc/hal0/agents/hermes/secrets.env` (mode
+    0600). Lifecycle managed by hal0, not the user.
+
+---
+
+## 22. What grilling will probably attack
+
+Anticipated angles:
+
+- **"What if Lemonade isn't started when bootstrap runs?"** → preflight
+  catches it; phase fails with "start Lemonade first" hint.
+- **"What if the user runs `hermes setup` after our bootstrap?"** → we
+  detect via config.yaml hash diff in `bootstrap --repair`; we don't
+  PREVENT it (would require monkey-patching upstream).
+- **"What if two hal0 hosts share a memory store and Hermes is on
+  both?"** → identity card by `agent_id: hermes-agent` collides. Plan
+  punts; ADR-0006 will need a `host_id` qualifier when federation lands.
+- **"Why not just write a Hermes plugin and skip all this?"** → because
+  Hermes plugins are user-managed at `$HERMES_HOME/plugins/`; we want
+  hal0 to OWN the bootstrap from outside, so upgrading Hermes doesn't
+  blow it away.
+- **"What about pi-coder, when it ships?"** → identity card convention
+  is agent-agnostic. pi-coder gets its own bootstrap; uses the same
+  `agent-identity` memory tag.
+
+---
+
+## 23. Timeline / ordering
+
+If accepted post-grilling, sequence:
+
+1. **PR-1:** ADR-0011 (agent identity cards) + the new MCP admin tools (`gpu_target_version`, `npu_status`, `env_report`, `model_store_probe`)
+   (`gpu_target_version`, `npu_status`, `env_report`, `model_store_probe`).
+2. **PR-2:** `hermes_provision.py` scaffold + provision.json schema +
+   `preflight` + `install` + `home_init` phases.
+3. **PR-3:** `env_probe` + `config_write` + `mcp_wire`.
+4. **PR-4:** `context_link` + `namespace_register` + identity card
+   convention.
+5. **PR-5:** `model_automap` + `voice_wire`.
+6. **PR-6:** `smoke_tests` + `self_report` + CLI subcommands.
+7. **PR-7:** Test harness scenario + δ-tier coverage.
+8. **PR-8:** Dashboard panel for agent status (consumes identity cards
+   from `hal0-memory`).
+
+Each PR ships behind a feature flag (`HAL0_HERMES_BOOTSTRAP_V1=1`) until
+PR-8 lands and we flip the default.
+
+---
+
+## 24. Success criteria
+
+The bootstrap is "done" when:
+
+- ✅ `hal0 agent install hermes` on a fresh LXC produces a working,
+  hal0-aware Hermes session with zero user prompts.
+- ✅ `hermes` (bare CLI, no args) opens chat and the model's first
+  utterance demonstrates knowledge of the host (e.g., "I'm running on
+  your Strix Halo LXC; the primary slot is Qwen3-30B...").
+- ✅ Hermes calls `hal0_admin:slot_status` autonomously when asked
+  "is anything broken?" — and gets a real answer.
+- ✅ `memory_search(tags=["agent-identity"])` returns Hermes's card and
+  every peer agent's card.
+- ✅ Re-running `hal0 agent bootstrap hermes` is a no-op (all phases
+  skip).
+- ✅ `hal0 agent bootstrap hermes --repair` after a manual config edit
+  restores the canonical config.
+- ✅ The harness scenario passes on every CI run.
+
+---
+
+## 25. Companions / follow-ups (not part of v0.3)
+
+- pi-coder bootstrap (parallel design, reuses identity card + env
+  probe).
+- Claude Code agent integration (different — Claude Code doesn't
+  install on the hal0 host typically, but we can drop an `AGENTS.md` at
+  `/etc/hal0/` that travels with mount-bound sessions).
+- Hermes `mcp serve` as a hal0 systemd unit, exposing Hermes itself as
+  a callable MCP server for OTHER agents to delegate to. Currently in
+  the install phase but unwired into anything; Phase 9 will use it.
+
+---
+
+**END DRAFT 1.** Ready for `/grill-me`.

--- a/docs/internal/hermes-env-probe-recipes-2026-05-23.md
+++ b/docs/internal/hermes-env-probe-recipes-2026-05-23.md
@@ -1,0 +1,971 @@
+# Hermes-Agent env-discovery probe recipes (2026-05-23)
+
+Reference material for the first-run bootstrap phase that runs as the
+Hermes-Agent process on a hal0 host. The goal of this phase is to
+build an `EnvironmentReport` dataclass that downstream installer
+decisions can dispatch on (which model store path to use, whether to
+enable NPU backends, whether to expect network egress, etc.).
+
+Validated against the live hal0 LXC (`ssh hal0`, container 105 on
+Proxmox `pve`) on 2026-05-23. Outputs shown are real snapshots from
+that host so future maintainers can sanity-check changes.
+
+All recipes prefer:
+
+1. Reading sysfs/procfs — synchronous, no process spawn, no privilege.
+2. `subprocess.run(["cmd", "--flag"], capture_output=True, text=True,
+   timeout=5)` with `check=False` — never let a missing tool crash the
+   probe.
+3. Returning a dataclass field of the form `Optional[Detected[T]]`
+   with three states: `Detected(value, source)`, `Unavailable(reason)`,
+   `ProbeError(exc)`. Downstream code decides whether each is fatal.
+
+Order matters: virtualization → CPU → RAM → GPU → NPU → network →
+filesystem → tooling → checkpoint. Earlier results gate later probes
+(e.g. NPU probe is skipped on a non-Strix host).
+
+---
+
+## 1. Containerization and virtualization layer
+
+### 1.1 `systemd-detect-virt` is the cheapest oracle
+
+```
+$ systemd-detect-virt --container
+lxc
+$ systemd-detect-virt --vm
+none
+$ systemd-detect-virt
+lxc
+```
+
+On the hal0-dev VM (KVM under Proxmox) the same commands return:
+
+```
+$ systemd-detect-virt --container
+none
+$ systemd-detect-virt --vm
+kvm
+$ systemd-detect-virt
+kvm
+```
+
+Combined logic (Python):
+
+```python
+def detect_virt():
+    container = run(["systemd-detect-virt", "--container"]).strip()
+    vm = run(["systemd-detect-virt", "--vm"]).strip()
+    if container != "none":
+        return ("container", container, vm if vm != "none" else None)
+    if vm != "none":
+        return ("vm", vm, None)
+    return ("bare-metal", None, None)
+```
+
+Expected mapping for hal0 deployments:
+
+| Host                  | --container | --vm  | Resulting tuple                    |
+|-----------------------|-------------|-------|------------------------------------|
+| hal0 LXC (`105`)      | `lxc`       | none  | `("container", "lxc", None)`       |
+| hal0-dev VM (`104`)   | `none`      | `kvm` | `("vm", "kvm", None)`              |
+| Bare metal Strix box  | `none`      | `none`| `("bare-metal", None, None)`       |
+| Docker run            | `docker`    | none  | `("container", "docker", None)`    |
+| toolbx/distrobox      | `podman` /  `wsl` | varies | container=podman with extras  |
+
+**Failure mode.** On a stripped-down image without systemd at all
+(Alpine, scratch) `systemd-detect-virt` is missing — fall through to
+the cgroup probe below.
+
+### 1.2 Cross-check via `/proc/1/environ` and `/proc/1/cgroup`
+
+The kernel-injected `container=` env var on PID 1 is the most reliable
+LXC signal; it persists even on stripped images.
+
+```
+$ cat /proc/1/environ | tr '\0' '\n'
+TERM=linux
+container=lxc
+container_ttys=pts/1 pts/2
+```
+
+Other expected `container=` values: `lxc`, `lxc-libvirt`, `systemd-nspawn`,
+`docker`, `podman`, `oci`, `rkt`. `/run/systemd/container` mirrors this
+when systemd is available (`cat /run/systemd/container` → `lxc`).
+
+```
+$ cat /proc/1/cgroup
+0::/init.scope          # cgroup v2 unified
+```
+
+On older Docker engines you'll see `/docker/<id>` segments; on hal0 the
+unified cgroup hides this, so don't rely on cgroup-path parsing as a
+primary signal.
+
+### 1.3 Docker / Podman / toolbx / distrobox markers
+
+| Container kind     | Sentinel file                  | Detection                       |
+|--------------------|--------------------------------|---------------------------------|
+| Docker             | `/.dockerenv`                  | `Path("/.dockerenv").exists()`  |
+| Podman             | `/run/.containerenv`           | also present in OCI containers  |
+| toolbx             | `/run/.toolboxenv`             | toolbx-specific                 |
+| distrobox          | `/run/.containerenv` + env `CONTAINER_ID` set, `/etc/host` mounts | check env `DISTROBOX_HOST_HOME` |
+| systemd-nspawn     | env `container=systemd-nspawn` on PID 1                          | as above                        |
+
+On hal0 LXC, none of these exist:
+
+```
+$ ls /.dockerenv /run/.containerenv /run/.toolboxenv 2>&1
+ls: cannot access '/.dockerenv': No such file or directory
+ls: cannot access '/run/.containerenv': No such file or directory
+ls: cannot access '/run/.toolboxenv': No such file or directory
+```
+
+### 1.4 Proxmox guest vs bare metal
+
+DMI fields work everywhere systemd-detect-virt does, plus give the
+chassis-level brand name:
+
+```
+$ cat /sys/class/dmi/id/sys_vendor
+Micro Computer (HK) Tech Limited
+$ cat /sys/class/dmi/id/product_name
+MS-S1 MAX
+$ cat /sys/class/dmi/id/bios_vendor      # `American Megatrends` on real iron
+$ cat /sys/class/dmi/id/board_vendor     # vendor of the motherboard
+```
+
+Inside a Proxmox KVM VM you see `QEMU` / `Standard PC (Q35 + ICH9, 2009)`.
+Inside an LXC, the DMI fields **pass through from the host** — hal0 LXC
+reports `MS-S1 MAX` because that's the bare-metal host (`pve`). That's
+the asymmetry to remember: LXC sees host DMI; VM sees QEMU DMI.
+
+So the combined classifier is:
+
+```
+LXC on bare metal  :  --container=lxc, DMI=real chassis
+LXC on KVM         :  --container=lxc, DMI=QEMU      (uncommon)
+KVM VM (Proxmox)   :  --vm=kvm,        DMI=QEMU
+Bare metal Strix   :  --container=none, --vm=none,   DMI=real chassis
+```
+
+### 1.5 LXC privileged vs unprivileged
+
+Read `/proc/self/uid_map`. Privileged LXCs map `0 0 4294967295`
+(identity over the entire range). Unprivileged LXCs map `0 100000 65536`
+or similar offset.
+
+```
+$ cat /proc/self/uid_map
+         0          0 4294967295
+```
+
+That's privileged. As a backup check, `CapEff` in `/proc/self/status`
+will be non-zero for privileged root (`000001fcfdfcffff` on hal0).
+
+Apparmor state:
+
+```
+$ cat /proc/self/attr/current
+unconfined
+```
+
+`unconfined` confirms `lxc.apparmor.profile: unconfined` in the LXC
+config — required for ROCm / XDNA passthrough to work. Other values
+to recognise: `lxc-container-default`, `lxc-container-default-cgns`,
+or a named profile.
+
+Failure modes:
+- `aa-status` requires capability `CAP_MAC_ADMIN` (root + privileged
+  container). Don't rely on it from the probe; just read
+  `/proc/self/attr/current` and `/proc/self/attr/exec`.
+- On a kernel built without apparmor, `/proc/self/attr/current` is
+  empty or missing. Treat that as "no LSM" rather than `unconfined`.
+
+---
+
+## 2. CPU
+
+### 2.1 Strix Halo identification
+
+```
+$ grep -m1 'model name' /proc/cpuinfo
+model name      : AMD RYZEN AI MAX+ 395 w/ Radeon 8060S
+$ grep -m1 'vendor_id' /proc/cpuinfo
+vendor_id       : AuthenticAMD
+```
+
+The exact model string for Strix Halo SKUs in the wild:
+
+| SKU                                 | model name regex                                |
+|-------------------------------------|-------------------------------------------------|
+| Ryzen AI Max+ 395                   | `RYZEN AI MAX\+ 395`                            |
+| Ryzen AI Max 390                    | `RYZEN AI MAX 390`                              |
+| Ryzen AI Max 385                    | `RYZEN AI MAX 385`                              |
+| Older Phoenix (XDNA1)               | `Ryzen 7 7840U` / `Ryzen 7 7840HS`              |
+
+Treat any `RYZEN AI MAX` match as Strix Halo (XDNA2 + gfx1151). Be
+defensive: AMD has renamed mobile chips three times in 18 months;
+the *board* name is the safer pin (see `/sys/class/dmi/id/product_name`).
+
+### 2.2 Core counts
+
+```
+$ nproc                     # logical (online) — 16 on hal0 LXC
+$ lscpu -p=CORE | grep -v '^#' | sort -u | wc -l   # physical cores
+12
+$ lscpu | grep -E 'Socket|Core|Thread|CPU\('
+CPU(s):                                  32
+On-line CPU(s) list:                     0-2,5,7,8,16,17,19-23,25,28,30
+Off-line CPU(s) list:                    3,4,6,9-15,18,24,26,27,29,31
+Thread(s) per core:                      2
+Core(s) per socket:                      16
+Socket(s):                               1
+```
+
+Three different "core counts" to keep separate:
+
+1. **Total topology** — `CPU(s):` (32 on a 16C/32T Strix Halo). This
+   reflects what the kernel *knows about*, not what's usable.
+2. **Online logical** — `nproc` (16 on hal0 LXC). Reflects cgroup
+   `cpuset.cpus.effective` constraints. **Use this for thread-pool
+   sizing.**
+3. **Physical cores** — `lscpu -p=CORE | sort -u`. 12 on hal0 LXC.
+   Useful for `--threads N` flags on llama.cpp that don't benefit
+   from SMT siblings.
+
+The "Off-line CPU(s) list" output on hal0 reflects deliberate
+`cpuset` partitioning at the LXC level. Don't treat it as an error.
+
+### 2.3 ISA extensions for inference
+
+Parse the `flags:` line of `/proc/cpuinfo` once and bake into a set:
+
+```python
+flags = set(open("/proc/cpuinfo").read().split("flags\t\t:", 1)[1]
+            .split("\n", 1)[0].split())
+isa = {
+    "avx2":     "avx2"     in flags,
+    "avx512f":  "avx512f"  in flags,
+    "avx512bw": "avx512bw" in flags,
+    "avx512_vnni":     "avx512_vnni"     in flags,
+    "avx512_bf16":     "avx512_bf16"     in flags,
+    "avx_vnni":        "avx_vnni"        in flags,
+    "amx_tile": "amx_tile" in flags,   # Intel Sapphire Rapids+ only
+    "amx_bf16": "amx_bf16" in flags,
+    "amx_int8": "amx_int8" in flags,
+    "f16c":     "f16c"     in flags,
+    "fma":      "fma"      in flags,
+}
+```
+
+Strix Halo (snapshot from hal0):
+
+```
+avx avx2 avx512_bf16 avx512_bitalg avx512_vbmi2 avx512_vnni
+avx512_vp2intersect avx512_vpopcntdq avx512bw avx512cd avx512dq
+avx512f avx512ifma avx512vbmi avx512vl avx_vnni sse4_1 sse4_2 sse4a
+```
+
+So Strix Halo has the *full* AVX-512 set including VNNI + BF16. AMX is
+Intel-only; absence is expected on AMD.
+
+---
+
+## 3. System RAM
+
+### 3.1 Headline numbers
+
+```
+$ grep -E '^(MemTotal|MemAvailable|MemFree|SwapTotal)' /proc/meminfo
+MemTotal:       98304000 kB
+MemFree:        88978000 kB
+MemAvailable:   93094233 kB
+SwapTotal:       8388604 kB
+```
+
+`MemAvailable` (kernel-computed "what could be allocated without
+swapping") is the right field for sizing decisions. `MemFree` is a
+trap — it excludes reclaimable page cache.
+
+In a Strix Halo system with 96 GiB of unified memory, expect
+`MemTotal` around 98300000 kB (96 GiB minus a small reserved chunk
+for GPU framebuffer). hal0 LXC reads 93 GiB (`free -h` line "Mem:
+93Gi") — the delta from 96 GiB is the VRAM/GTT carve-out plus kernel
+reserves.
+
+### 3.2 cgroup limits inside LXC
+
+Even when MemTotal reports the host's full RAM, the container can be
+cgroup-capped. Check before trusting it:
+
+```
+$ cat /sys/fs/cgroup/memory.max
+max
+$ cat /sys/fs/cgroup/memory.current
+9550794752
+```
+
+`max` = uncapped. Numeric value = byte ceiling — must be respected
+when sizing model loads. Fall back to MemTotal only when memory.max
+is `max` or missing.
+
+### 3.3 Unified memory reporting
+
+On Strix Halo the iGPU and NPU draw from the same physical pool as
+the OS. The probe should:
+
+- Report `ram_total_bytes` and `ram_available_bytes` from
+  `/proc/meminfo`.
+- Mark `memory_topology = "unified"` when:
+  - the CPU model matches Strix Halo (§2.1), or
+  - `/sys/class/drm/card*/device/mem_info_vram_total` returns a value
+    well below the system RAM ceiling (1 GiB on hal0 — that's the
+    UMA VRAM carve-out, not real dedicated VRAM).
+- Otherwise mark `memory_topology = "discrete"`.
+
+This matters because callers should size their model budget against
+RAM, **not** against VRAM, on unified hosts. Discrete-VRAM logic
+(NVIDIA, dGPU) needs the opposite.
+
+---
+
+## 4. iGPU (Radeon 8060S, gfx1151)
+
+### 4.1 PCI enumeration
+
+```
+$ lspci -nn | grep -iE 'vga|display|3d'
+bf:00.0 Display controller [0380]: Advanced Micro Devices, Inc. [AMD/ATI] Device [1002:1586] (rev c1)
+```
+
+PCI ID `1002:1586` is the Strix Halo iGPU (Radeon 8060S). Other AMD
+IDs to recognise:
+
+| PCI ID    | GPU                                | gfx target |
+|-----------|------------------------------------|------------|
+| 1002:1586 | Radeon 8060S (Strix Halo)          | gfx1151    |
+| 1002:15bf | Radeon 780M (Phoenix)              | gfx1103    |
+| 1002:1900 | Radeon 8050S (lesser Strix Halo)   | gfx1151    |
+
+`lspci` can fail with `Unable to load libkmod resources: error -2`
+inside an LXC — that's noise, the data still comes through. Don't
+match on stderr.
+
+### 4.2 amdgpu driver via `/sys/class/drm`
+
+```
+$ ls /sys/class/drm/
+card1  card1-DP-1  ...  renderD128  version
+$ cat /sys/class/drm/card1/device/uevent
+DRIVER=amdgpu
+PCI_CLASS=38000
+PCI_ID=1002:1586
+PCI_SUBSYS_ID=1F4C:B026
+PCI_SLOT_NAME=0000:bf:00.0
+```
+
+The `DRIVER=amdgpu` field confirms the kernel driver loaded. If you
+see `DRIVER=` empty (or no `card*` entry at all), amdgpu didn't bind —
+that's the first failure to surface.
+
+### 4.3 gfx target version (gfx1151 confirmation)
+
+The most reliable gfx target probe reads the KFD topology:
+
+```
+$ cat /sys/class/kfd/kfd/topology/nodes/1/properties | grep -E 'gfx_target_version|device_id|simd_count'
+simd_count 80
+gfx_target_version 110501
+device_id 5510
+```
+
+Decode `gfx_target_version`:
+
+| Value   | gfx string |
+|---------|------------|
+| 110501  | gfx1151    |
+| 110300  | gfx1103    |
+| 110000  | gfx1100    |
+| 90400   | gfx940     |
+| 90a00   | gfx90a     |
+
+Parse: `f"gfx{value // 10000}{(value // 100) % 100:02d}{value % 100:02d}"`
+on hal0 gives `gfx1151`. Use this as the canonical identifier — it's
+what ROCm/HSA queries return and what llama.cpp/Lemonade match on.
+
+If `/sys/class/kfd/kfd/topology/nodes` is missing, AMDKFD didn't load
+(common in stripped containers without `--device=/dev/kfd`).
+
+### 4.4 VRAM budget (the dynamic UMA trap)
+
+```
+$ cat /sys/class/drm/card1/device/mem_info_vram_total
+1073741824                              # 1 GiB — the UMA carve-out
+$ cat /sys/class/drm/card1/device/mem_info_vram_used
+477827072
+$ cat /sys/class/drm/card1/device/mem_info_gtt_total
+112742891520                            # ~105 GiB GTT pool
+```
+
+**Important nuance.** On Strix Halo `mem_info_vram_total` reports
+**only the small dedicated carve-out** (BIOS-allocated UMA reserve).
+The real budget the iGPU can use is `mem_info_gtt_total` plus
+`mem_info_vram_total` — and even that is a soft ceiling pulled from
+system RAM at allocation time.
+
+Recipe for "effective VRAM budget":
+
+```python
+def vram_budget_bytes(card="card1"):
+    vram = read_int(f"/sys/class/drm/{card}/device/mem_info_vram_total")
+    gtt  = read_int(f"/sys/class/drm/{card}/device/mem_info_gtt_total")
+    if vram + gtt > 16 * 1024**3:
+        # UMA host — budget is RAM-bound, not VRAM-bound
+        return ("unified", read_int("/proc/meminfo MemAvailable") * 1024)
+    return ("dedicated", vram)
+```
+
+Surface both numbers in the report — downstream code that hard-codes
+"if vram < model_size: refuse" will be wrong on Strix without that
+distinction.
+
+### 4.5 Vulkan availability
+
+```
+$ which vulkaninfo
+$ vulkaninfo --summary 2>&1 | head
+```
+
+On hal0 LXC `vulkaninfo` is **not installed** (`command not found`).
+That's a hal0-toolbox concern — the inference services bring their
+own Vulkan loader. The host probe should treat missing `vulkaninfo` as
+"can't confirm Vulkan from outside the toolbox; check from inside
+the relevant toolbox image instead" rather than as a fatal flag.
+
+If installed, parse:
+
+```
+GPU0:
+        deviceName  = AMD Radeon Graphics (RADV GFX1151)
+        apiVersion  = 1.3.296
+        driverName  = radv
+        deviceType  = PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
+```
+
+### 4.6 ROCm availability
+
+```
+$ which rocm-smi
+$ rocm-smi --showproductname
+```
+
+Missing on hal0 LXC (`command not found`). Same logic as
+`vulkaninfo`: rocm-smi lives inside the ROCm toolbox image. Don't
+treat absence as failure.
+
+If you do need a CPU-side ROCm probe, check `/opt/rocm-*/bin/rocm-smi`
+glob and `/dev/kfd` presence:
+
+```
+$ ls /dev/kfd
+```
+
+`/dev/kfd` is the ROCm userspace queue device. Present + readable =
+amdkfd loaded = ROCm compute ready.
+
+---
+
+## 5. NPU (AMD XDNA2)
+
+### 5.1 Device node
+
+```
+$ ls -la /dev/accel/
+total 0
+drwxr-xr-x  2 root root       60 May 18 02:56 .
+drwxr-xr-x 10 root root      600 May 18 02:56 ..
+crw-rw----  1 root render 261, 0 May 18 02:56 accel0
+```
+
+Major 261 is the accel chardev class. Presence of `/dev/accel/accel0`
+is necessary and (combined with the driver check below) sufficient
+for "NPU is usable".
+
+For an unprivileged LXC, this is the recipe that *must* succeed:
+the `dev0–dev3` cgroup passthrough and a privileged container with
+apparmor unconfined are prerequisites (see haloai 220 LXC config
+recipe, mirrored on hal0 105). If accel0 is missing, the bootstrap
+should fail fast with a pointer to the LXC config — not silently
+fall back to CPU NPU emulation (there is none).
+
+### 5.2 Kernel driver binding
+
+```
+$ lsmod | grep -i xdna
+amdxdna               159744  3
+amd_pmf               106496  1 amdxdna
+gpu_sched              69632  2 amdxdna,amdgpu
+$ ls /sys/bus/pci/drivers/amdxdna/
+0000:c0:00.1  bind  module  new_id  remove_id  uevent  unbind
+$ cat /sys/bus/pci/drivers/amdxdna/0000:c0:00.1/uevent
+DRIVER=amdxdna
+PCI_CLASS=118000
+PCI_ID=1022:17F0
+PCI_SUBSYS_ID=1022:17F0
+PCI_SLOT_NAME=0000:c0:00.1
+```
+
+PCI ID `1022:17F0` is XDNA2 (Strix Halo). Older XDNA1 (Phoenix) is
+`1022:1502`. Use the PCI ID — not the model — to distinguish XDNA1
+from XDNA2.
+
+### 5.3 XRT tooling (optional)
+
+```
+$ which xrt-smi
+$ xrt-smi examine
+```
+
+`xrt-smi` is not on hal0 LXC by default — the FLM toolbox bundles its
+own XRT runtime. Probe should treat missing `xrt-smi` as "can't
+deep-inspect from outside FLM toolbox" rather than as a failure.
+
+When present, `xrt-smi examine` returns one of:
+
+```
+System Configuration
+  OS Name              : Linux
+  ...
+Devices present
+  [0000:c0:00.1] : NPU Strix          # XDNA2 confirmed
+```
+
+### 5.4 Firmware path
+
+`/lib/firmware/amdnpu/` is **not** present on hal0 LXC (firmware lives
+on the Proxmox host, loaded at kernel boot before the LXC starts).
+Missing path inside the LXC ≠ missing firmware. Don't gate on it.
+
+### 5.5 Driver version
+
+```
+$ modinfo amdxdna 2>&1 | head -5
+modinfo: ERROR: Module amdxdna not found.
+```
+
+`modinfo` fails inside the LXC even when the module is loaded,
+because module files live on the host. Use `lsmod | grep amdxdna`
+(works) as the binary "loaded" check, and read `dmesg | grep -i
+amdxdna` from the *host* (not the container) for version info if
+needed. dmesg inside the LXC is empty for amdxdna lines.
+
+### 5.6 Fail-fast policy
+
+```python
+def npu_status(env):
+    if env.cpu_model_strix_halo is False:
+        return Unavailable("non-Strix CPU; XDNA2 not expected")
+    if not Path("/dev/accel/accel0").exists():
+        if env.virt == ("container", "lxc"):
+            return Fatal(
+                "/dev/accel/accel0 missing inside LXC — add dev0..dev3 "
+                "cgroup passthrough to the LXC config (see hal0 "
+                "passthrough recipe) and reboot the container."
+            )
+        return Fatal("/dev/accel/accel0 missing; amdxdna driver not bound")
+    if "amdxdna" not in run(["lsmod"]):
+        return Fatal("amdxdna kernel module not loaded on host")
+    return Detected({"pci": "1022:17F0", "xdna_gen": 2})
+```
+
+The hal0-installer convention: Fatal blocks the bootstrap on Strix
+hosts (NPU is part of the value prop), Warn-but-continue on non-Strix.
+
+---
+
+## 6. Network reachability
+
+### 6.1 Default route + local subnet
+
+```
+$ ip -j route
+[{"dst":"default","gateway":"10.0.1.1","dev":"eth0",...},
+ {"dst":"10.0.1.0/24","dev":"eth0","prefsrc":"10.0.1.142",...},
+ {"dst":"172.17.0.0/16","dev":"docker0","prefsrc":"172.17.0.1",...}]
+```
+
+`ip -j` returns parseable JSON — always prefer over textual output.
+Pick the route with `dst == "default"` for the gateway; pick the
+non-loopback route whose `prefsrc` matches one of the host's IPv4
+addresses for the local subnet.
+
+### 6.2 Private vs public LAN classification
+
+```python
+import ipaddress
+def is_private(ip):
+    return ipaddress.ip_address(ip).is_private
+```
+
+`10.0.1.142` → True. Mark the host as `network_zone = "private"`. If
+the host's primary IP is *public*, the bootstrap should warn before
+binding services on 0.0.0.0 — the hal0 default assumes a private LAN
+with no auth.
+
+### 6.3 DNS resolvability
+
+```
+$ getent hosts hal0.thinmint.dev
+10.0.1.142      hal0.thinmint.dev hal0
+$ getent hosts releases.hal0.dev
+172.67.213.81   releases.hal0.dev
+104.21.86.5     releases.hal0.dev
+```
+
+`getent hosts` uses NSS — so it respects `/etc/hosts` overrides plus
+mDNS plus DNS. Better than raw `dig` for bootstrap purposes because
+it tells you what the running code will actually see.
+
+Recipe:
+
+```python
+def resolves(name, timeout=2.0):
+    try:
+        return bool(subprocess.run(
+            ["getent", "hosts", name],
+            capture_output=True, timeout=timeout, check=False
+        ).stdout.strip())
+    except subprocess.TimeoutExpired:
+        return False
+```
+
+Treat `hal0.local` resolvability as a soft signal — mDNS works on the
+LAN, may not work inside Docker. Treat `releases.hal0.dev` as the
+internet-egress probe.
+
+### 6.4 Reachability without external libraries
+
+Pure stdlib TCP poke:
+
+```python
+import socket
+def tcp_open(host, port, timeout=2.0):
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except (OSError, socket.timeout):
+        return False
+```
+
+Test order:
+
+| Target                       | Why                                           |
+|------------------------------|-----------------------------------------------|
+| `127.0.0.1:8081`             | hal0 primary slot (llama-server / lemonade)   |
+| `127.0.0.1:8095`             | hal0-admin / haloai MCP gateway               |
+| `10.0.1.220:8095`            | haloai LXC MCP (federated memory)             |
+| `10.0.1.220:9130`            | Hermes router                                 |
+| `releases.hal0.dev:443`      | update channel egress                         |
+
+On hal0 LXC, `127.0.0.1:8095` is `Connection refused` (no local MCP
+yet — that comes with v0.3). Treat refusal as "service not yet
+started" rather than as a network failure.
+
+### 6.5 Don't shell out to `ping`
+
+`ping` requires CAP_NET_RAW in unprivileged contexts and is blocked
+in many container default profiles. Use the TCP poke above instead.
+
+---
+
+## 7. Filesystem
+
+### 7.1 Model store discovery
+
+```
+$ findmnt -nt zfs,ext4,nfs,nfs4,btrfs,xfs -o TARGET,SOURCE,FSTYPE
+/                              /dev/mapper/pve-vm--105--disk--0 ext4
+|-/var/lib/hal0/comfyui/models devpool/ai-models[/comfyui]      zfs
+|-/mnt/ai-models               devpool/ai-models                zfs
+|-/mnt/lab                     devpool/dev/lab                  zfs
+|-/mnt/repos                   devpool/dev/repos                zfs
+|-/mnt/projects                devpool/dev/projects             zfs
+|-/mnt/artifacts               devpool/dev/artifacts            zfs
+|-/mnt/share                   devpool/dev[/share]              zfs
+```
+
+`findmnt -J` (JSON) is the structured form; parse from there. For each
+candidate model-store path (`/mnt/ai-models`, `/mnt/dock-models`,
+`~/.cache/hal0/models`):
+
+```python
+def probe_fs(path):
+    p = Path(path)
+    if not p.exists():
+        return {"path": str(p), "exists": False}
+    st = os.statvfs(p)
+    fstype = run(["stat", "-f", "-c", "%T", str(p)]).strip()
+    return {
+        "path": str(p),
+        "exists": True,
+        "fstype": fstype,                            # zfs, ext4, nfs4, …
+        "writable": os.access(p, os.W_OK),
+        "free_bytes": st.f_bavail * st.f_frsize,
+        "total_bytes": st.f_blocks * st.f_frsize,
+    }
+```
+
+Expected hal0 LXC result for `/mnt/ai-models`:
+
+```
+{"path": "/mnt/ai-models", "exists": True, "fstype": "zfs",
+ "writable": True, "free_bytes": ~511GB, "total_bytes": ~978GB}
+```
+
+(Past confusion: hal0 LXC's `/mnt/ai-models` is **rw ZFS** from devpool,
+not the ro NFS export from `pve`'s `/mnt/ai-models`. See memory
+`hal0_model_store_layout` — don't reintroduce the NFS assumption.)
+
+### 7.2 NFS sniffing
+
+```
+$ findmnt -t nfs,nfs4 -J
+```
+
+Returns empty on hal0 LXC (no NFS mounts; everything is ZFS-direct
+from the host). On the hal0-dev VM you'd see the dock-models NFS
+share from `pve`. Use this to tell the two hosts apart programmatically.
+
+### 7.3 Don't use `df` for programmatic data
+
+`df` output is locale-dependent and column widths vary. Use
+`os.statvfs` for free/total bytes; use `findmnt -J` for mount-tree
+structure. Reserve `df -T` for human-readable debug.
+
+---
+
+## 8. Userland tooling
+
+### 8.1 Existence check via `shutil.which`
+
+```python
+import shutil
+def has(cmd): return shutil.which(cmd) is not None
+```
+
+Don't `subprocess.run([cmd, "--version"])` blindly — some binaries
+(`flm` for instance) hang waiting for stdin if no TTY is attached.
+Always pass `stdin=subprocess.DEVNULL` and `timeout=`.
+
+Snapshot from hal0 LXC:
+
+| Binary               | Present | Notes                                       |
+|----------------------|---------|---------------------------------------------|
+| `docker`             | yes     | Docker 29.1.3, daemon up                    |
+| `podman`             | no      |                                             |
+| `lemonade-server`    | no      | v0.2 migration in-flight, not yet installed |
+| `llama-server`       | no      | inside hal0-toolbox-* images, not on host   |
+| `flm`                | yes     | v0.9.42 — installed via PPA + .deb          |
+| `python3`            | yes     | 3.12.3                                      |
+| `uv`                 | depends |                                             |
+
+### 8.2 Daemon health (Docker, Podman)
+
+```python
+def docker_running():
+    r = subprocess.run(
+        ["docker", "info", "--format", "{{.ServerVersion}}"],
+        capture_output=True, text=True, timeout=5, check=False,
+    )
+    return r.returncode == 0 and r.stdout.strip()
+```
+
+`docker info` returns non-zero if the daemon socket isn't reachable.
+Don't `ps | grep dockerd` — both noisy and racy.
+
+### 8.3 Python provenance
+
+```python
+import sys, sysconfig
+report["python"] = {
+    "version": sys.version.split()[0],     # "3.12.3"
+    "executable": sys.executable,
+    "prefix": sysconfig.get_paths()["data"],
+    "uv": shutil.which("uv"),
+    "pip": shutil.which("pip"),
+}
+```
+
+For Hermes-Agent itself, prefer pinning to `sys.executable` rather
+than `which python3` — the bootstrap should run in its own venv and
+inherit that, not re-resolve.
+
+### 8.4 FLM probe (Strix-specific)
+
+```python
+def flm_probe():
+    if not shutil.which("flm"):
+        return Unavailable("flm not on PATH")
+    r = subprocess.run(
+        ["flm", "list", "-j"],
+        capture_output=True, text=True, timeout=10,
+        stdin=subprocess.DEVNULL, check=False,
+    )
+    if r.returncode != 0:
+        return ProbeError(f"flm list -j: {r.stderr.strip()}")
+    return Detected(json.loads(r.stdout))
+```
+
+The `-j` flag is the only stable JSON contract on `flm`; the text
+output reformats across releases.
+
+---
+
+## 9. First-run safety
+
+### 9.1 Idempotent checkpoint file
+
+The hal0 installer already uses `/var/lib/hal0/.first_run_done` and
+`/var/lib/hal0/.first-run.lock` (confirmed on hal0 LXC). Hermes-Agent
+bootstrap should adopt the same convention:
+
+```
+$XDG_DATA_HOME/hermes-agent/first_run_done           # success marker
+$XDG_DATA_HOME/hermes-agent/first_run.lock           # held during run
+$XDG_DATA_HOME/hermes-agent/env-report-<ISO8601>.json # per-run artefact
+```
+
+Resolution order for the base path:
+
+1. `$HERMES_DATA_HOME` if set (explicit override).
+2. `$XDG_DATA_HOME/hermes-agent` if `$XDG_DATA_HOME` is set.
+3. `/var/lib/hermes-agent` if running as root and writable.
+4. `~/.local/share/hermes-agent` otherwise.
+
+Never write to `/tmp` for persistence — it's wiped on reboot, hiding
+the "previous run failed" signal.
+
+### 9.2 Detecting incomplete previous runs
+
+```python
+def previous_run_state(base: Path):
+    done = base / "first_run_done"
+    lock = base / "first_run.lock"
+    if lock.exists() and not stale(lock):
+        return "in-progress"     # another bootstrap is running NOW
+    if lock.exists() and stale(lock):
+        return "abandoned"       # offer to repair
+    if done.exists():
+        return "complete"
+    return "fresh"
+```
+
+`stale()` rule of thumb: lock file mtime older than 1 hour and no
+process with the PID listed inside it. Write `os.getpid()` into the
+lock file at acquire time so you can check `/proc/<pid>` exists.
+
+### 9.3 Atomic checkpoint write
+
+```python
+def mark_done(base: Path, report: dict):
+    tmp = base / f".first_run_done.{os.getpid()}.tmp"
+    tmp.write_text(json.dumps(report, indent=2))
+    tmp.rename(base / "first_run_done")  # atomic on POSIX
+```
+
+The `done` file should contain the full `EnvironmentReport` JSON so a
+later session can read it without re-probing. On any version bump of
+the schema, write `schema_version` into the file and check it before
+trusting cached data.
+
+### 9.4 Bootstrap log location
+
+Single rotating file at `$base/bootstrap.log`. Rotate on bootstrap
+start (move existing to `bootstrap.log.1`). Don't journald-tee — the
+LXC + bare-metal + Docker cases all have different journald stories,
+and a plain text file works everywhere.
+
+Format: one line per probe, JSON-per-line so it's grep-able and
+machine-parseable:
+
+```
+{"ts":"2026-05-23T12:00:01Z","probe":"virt","result":"container/lxc","ok":true}
+{"ts":"2026-05-23T12:00:01Z","probe":"cpu","result":"strix-halo 16C/32T","ok":true}
+{"ts":"2026-05-23T12:00:02Z","probe":"npu","result":"xdna2 1022:17F0","ok":true}
+```
+
+### 9.5 What to do on partial failure
+
+Three severity levels:
+
+- **Fatal** — block the bootstrap, print actionable error, exit 1.
+  Reserved for: missing CPU model entirely (kernel weirdness), no
+  writable data dir, no model store path resolvable.
+- **Capability-disabled** — write the probe failure into the report,
+  set the corresponding capability to `unavailable`, continue.
+  Default for: NPU missing on non-Strix, ROCm tooling missing, Vulkan
+  loader missing, Docker daemon down.
+- **Warn-and-continue** — log a warning, proceed with reduced
+  confidence. Default for: network egress blocked, mDNS not
+  resolving, optional binaries missing.
+
+The mapping is encoded in the probe table itself, not in ad-hoc
+`if/else` at each call site — so policy changes in one place.
+
+**NPU exception on hal0.** On a *Strix Halo LXC* with `/dev/accel/accel0`
+missing, treat as Fatal — the hal0 product positions NPU as a
+first-class capability, and silently CPU-only-fallback hides the
+deployment misconfiguration. The error should point at the cgroup
+passthrough recipe.
+
+---
+
+## Appendix: minimal probe-runner skeleton
+
+```python
+@dataclass
+class Probe:
+    name: str
+    severity: Literal["fatal", "capability", "warn"]
+    run: Callable[[], ProbeResult]
+
+PROBES = [
+    Probe("virt",       "fatal",      probe_virt),
+    Probe("cpu",        "fatal",      probe_cpu),
+    Probe("ram",        "fatal",      probe_ram),
+    Probe("gpu",        "capability", probe_gpu),
+    Probe("npu",        "capability", probe_npu),   # fatal on Strix
+    Probe("network",    "warn",       probe_network),
+    Probe("filesystem", "fatal",      probe_filesystem),
+    Probe("tooling",    "warn",       probe_tooling),
+]
+
+def bootstrap():
+    base = resolve_data_home()
+    base.mkdir(parents=True, exist_ok=True)
+    with acquire_lock(base):
+        report = {"schema_version": 1, "ts": utcnow_iso()}
+        for probe in PROBES:
+            try:
+                report[probe.name] = probe.run().to_dict()
+            except FatalProbe as e:
+                if probe.severity == "fatal":
+                    raise
+                report[probe.name] = {"error": str(e)}
+        mark_done(base, report)
+        return report
+```
+
+---
+
+## See also
+
+- `/etc/hal0/capabilities.toml` — capability rollup that consumes
+  these probe results in the live hal0 installer.
+- ADR-0006 (Lemonade migration) — defines which capabilities the
+  v0.2 installer must report on.
+- Memory: `strix-halo-lxc-passthrough` — privileged + apparmor
+  unconfined + dev0–dev3 cgroup recipe that makes the NPU probe pass.
+- Memory: `hal0_model_store_layout` — why `/mnt/ai-models` on hal0 LXC
+  is rw ZFS and not the ro NFS export from `pve`.

--- a/docs/internal/hermes-upstream-map-2026-05-23.md
+++ b/docs/internal/hermes-upstream-map-2026-05-23.md
@@ -1,0 +1,1131 @@
+# Hermes-Agent upstream technical map (2026-05-23)
+
+Reference for embedding **NousResearch/hermes-agent** as hal0's bundled
+"right-hand admin agent." Goal: every surface area we need to wire to
+hal0 (model providers, memory, MCP, skills, persona, bootstrap) is
+catalogued with concrete file paths and config keys.
+
+> **Disambiguation.** "Hermes" at NousResearch refers to two distinct
+> things. The **Hermes LLM family** (Hermes 3, Hermes 4 etc.) is a series
+> of fine-tuned open-weight chat models. The **Hermes Agent** is the
+> Python-based "self-improving" agent framework — `pip install hermes-agent`,
+> CLI `hermes`. The agent framework is what this doc maps. It is model-
+> agnostic and does NOT require Nous's own models.
+
+## 0. Canonical sources
+
+| Repo | URL | What's in it | Latest |
+|------|-----|--------------|--------|
+| **`NousResearch/hermes-agent`** | https://github.com/NousResearch/hermes-agent | The agent framework itself (Python 3.11+, MIT). | **v0.14.0 / `v2026.5.16`** released 2026-05-16. Default branch `main`, pushed 2026-05-23. |
+| `NousResearch/hermes-agent-self-evolution` | https://github.com/NousResearch/hermes-agent-self-evolution | DSPy + GEPA prompt/skill evolution pipeline. PRs against the main repo. NOT bundled with `pip install hermes-agent`. | active. |
+| `NousResearch/hermes-example-plugins` | https://github.com/NousResearch/hermes-example-plugins | Example plugin scaffolding (companion to the in-tree `plugins/` dir). | active. |
+| `NousResearch/hermes-paperclip-adapter` | n/a for us | Hermes-as-Paperclip-employee adapter. | irrelevant. |
+
+Working clones for this audit:
+
+- `/tmp/hermes-research/hermes-agent/`
+- `/tmp/hermes-research/hermes-agent-self-evolution/`
+- `/tmp/hermes-research/hermes-example-plugins/`
+
+There is currently **no `Hal0ai/hermes-agent` fork**. The local clone is
+read-only research only.
+
+PyPI install: `pip install hermes-agent` (latest 0.14.0). The repo ships
+`pyproject.toml` with one pinned base dep set + many `[extras]` (anthropic,
+exa, firecrawl, fal, edge-tts, modal, daytona, vercel, voice, mcp, …) plus
+a runtime lazy-installer (`tools/lazy_deps.py`) that pulls extras on first
+use of the corresponding backend.
+
+Entry points (`pyproject.toml` `[project.scripts]`):
+
+- `hermes` → `hermes_cli.main:main`  (the agent CLI; argparse, ~530K lines)
+- `hermes-agent` → `run_agent:main`  (lower-level direct loop runner)
+- `hermes-acp` → `acp_adapter.entry:main`  (Agent Client Protocol bridge)
+
+---
+
+## 1. Config surface
+
+Hermes has **three** layered config locations + **one** persistent home:
+
+| Surface | Path | Format | Scope |
+|--------|------|--------|-------|
+| **Home dir** | `$HERMES_HOME` (default `~/.hermes`) | dir | Everything Hermes owns. Single source of truth. |
+| **`config.yaml`** | `$HERMES_HOME/config.yaml` | YAML | Persistent settings — model, providers, terminal, memory, MCP, skills, hooks, display. |
+| **`.env`** | `$HERMES_HOME/.env` | dotenv | Secrets. API keys, OAuth tokens. Loaded into `os.environ`. |
+| **`SOUL.md`** | `$HERMES_HOME/SOUL.md` | Markdown | Agent persona/identity (free-form prose). |
+| **`MEMORY.md` / `USER.md`** | `$HERMES_HOME/memories/{MEMORY,USER}.md` | Markdown | Built-in curated memory + user profile. |
+| **`skills/`** | `$HERMES_HOME/skills/` | dir of `<name>/SKILL.md` | User skills (read/write, where new skills are saved). |
+| **Bundled `skills/`** | `<install>/skills/` and `<install>/optional-skills/` | dir | Read-only, shipped with the wheel. |
+| **`plugins/`** | `$HERMES_HOME/plugins/<kind>/<name>/` | dir | User-installed plugins (model-providers, memory, platforms, …). |
+
+Sole source-of-truth for path resolution:
+`/tmp/hermes-research/hermes-agent/hermes_constants.py` — `get_hermes_home()`,
+`get_config_path()`, `get_skills_dir()`, `get_bundled_skills_dir()`,
+`get_optional_skills_dir()`. Honors `HERMES_HOME`, `HERMES_BUNDLED_SKILLS`,
+`HERMES_OPTIONAL_SKILLS` env vars.
+
+Repo-internal example files:
+
+- `/tmp/hermes-research/hermes-agent/.env.example`            (470 lines — every env var)
+- `/tmp/hermes-research/hermes-agent/cli-config.yaml.example` (1100 lines — every YAML key)
+
+### 1.1 Subsystem: Model provider
+
+`config.yaml` keys (under `model:`):
+
+| Key | Type | Default | Notes |
+|-----|------|---------|------|
+| `model.default` (alias `model.model`) | string | `"anthropic/claude-opus-4.6"` | Model ID. Provider-prefix optional. |
+| `model.provider` | enum or `"auto"` | `"auto"` | One of: `openrouter`, `nous`, `nous-api`, `anthropic`, `openai-codex`, `copilot`, `gemini`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `huggingface`, `nvidia`, `xiaomi`, `arcee`, `ollama-cloud`, `kilocode`, `ai-gateway`, `azure-foundry`, `lmstudio`, `custom` (aliases: `ollama`, `vllm`, `llamacpp`, `llama.cpp`, `llama-cpp`, `local`). |
+| `model.base_url` | string | provider default | OpenAI-compatible endpoint root. Required for `custom`. |
+| `model.api_key` | string | "" | Inline only; prefer `.env`. |
+| `model.context_length` | int | auto-detected | Total context (input+output). |
+| `model.max_tokens` | int | model default | Output cap. |
+| `model.auth_mode` | string | `"api_key"` | `"entra_id"` for Azure-Foundry keyless. |
+| `model.entra.scope` | string | `"https://ai.azure.com/.default"` | Entra-ID scope. |
+| `providers.<name>.request_timeout_seconds` | int | `1800` | Per-provider override (legacy env: `HERMES_API_TIMEOUT`). |
+| `providers.<name>.stale_timeout_seconds` | int | `300` | Per-provider non-stream stale detector. |
+| `providers.<name>.models.<model>.timeout_seconds` | int | inherits | Per-model timeout. |
+| `provider_routing.sort` | enum | `"price"` | OpenRouter only: `price|throughput|latency`. |
+| `provider_routing.only` / `ignore` / `order` | list[str] | — | OpenRouter routing filters. |
+| `provider_routing.require_parameters` | bool | false | OpenRouter strictness. |
+| `provider_routing.data_collection` | enum | `"allow"` | `allow|deny`. |
+| `openrouter.response_cache` | bool | true | OR edge response cache. |
+| `openrouter.response_cache_ttl` | int (1–86400) | 300 | seconds. |
+| `model_aliases.<alias>.{model,provider,base_url}` | map | — | Short aliases for `/model`. |
+
+Provider env vars (`.env`):
+
+```
+OPENROUTER_API_KEY           # default LLM aggregator
+ANTHROPIC_API_KEY            # native Anthropic
+NOVITA_API_KEY / NOVITA_BASE_URL
+GOOGLE_API_KEY / GEMINI_API_KEY / GEMINI_BASE_URL
+OLLAMA_API_KEY / OLLAMA_BASE_URL          # Ollama Cloud (not local)
+GLM_API_KEY / GLM_BASE_URL                # z.ai
+KIMI_API_KEY / KIMI_BASE_URL / KIMI_CN_API_KEY
+ARCEEAI_API_KEY / ARCEE_BASE_URL
+MINIMAX_API_KEY / MINIMAX_BASE_URL
+MINIMAX_CN_API_KEY / MINIMAX_CN_BASE_URL
+OPENCODE_ZEN_API_KEY / OPENCODE_ZEN_BASE_URL
+OPENCODE_GO_API_KEY / OPENCODE_GO_BASE_URL
+HF_TOKEN                      # Hugging Face Inference Providers
+HERMES_QWEN_BASE_URL          # Qwen OAuth (no api_key)
+XIAOMI_API_KEY / XIAOMI_BASE_URL
+NVIDIA_API_KEY
+KILOCODE_API_KEY
+AI_GATEWAY_API_KEY            # Vercel AI Gateway
+AZURE_FOUNDRY_API_KEY / AZURE_FOUNDRY_BASE_URL
+LM_API_KEY                    # LM Studio (default http://127.0.0.1:1234/v1)
+HERMES_INFERENCE_PROVIDER     # forces provider regardless of model.provider
+HERMES_API_TIMEOUT            # legacy global request timeout (s)
+HERMES_API_CALL_STALE_TIMEOUT # legacy stale-detector timeout (s)
+```
+
+Custom / local-server env (`provider: custom`): no fixed env vars — set
+`model.base_url` in `config.yaml` directly.
+
+### 1.2 Subsystem: Memory
+
+`config.yaml` keys (under `memory:`):
+
+| Key | Type | Default | Notes |
+|-----|------|---------|------|
+| `memory.provider` | string | `""` (built-in only) | One of `honcho`, `openviking`, `mem0`, `hindsight`, `holographic`, `retaindb`, `supermemory`, `byterover` — or empty for built-in MEMORY.md/USER.md only. |
+| `memory.memory_enabled` | bool | true | MEMORY.md (agent notes). |
+| `memory.user_profile_enabled` | bool | true | USER.md (user profile). |
+| `memory.memory_char_limit` | int | 2200 | ~800 tokens. |
+| `memory.user_char_limit` | int | 1375 | ~500 tokens. |
+| `memory.nudge_interval` | int | 10 | Remind agent to save memories every N user turns. |
+| `memory.flush_min_turns` | int | 6 | Min user turns to trigger flush on `/reset`/exit. |
+
+Per-provider config either via env or `$HERMES_HOME/<provider>.json` (see
+`plugins/memory/<provider>/README.md`). Example for mem0:
+
+```
+MEM0_API_KEY
+MEM0_USER_ID                  # default "hermes-user"
+MEM0_AGENT_ID                 # default "hermes"
+```
+
+### 1.3 Subsystem: MCP
+
+`config.yaml` keys (under `mcp_servers:`):
+
+```yaml
+mcp_servers:
+  <name>:
+    # Stdio transport:
+    command: <executable>
+    args: [<...>]
+    env: { KEY: VALUE }
+    # OR HTTP/SSE transport:
+    url: https://mcp.example.com/mcp
+    headers: { Authorization: "Bearer ..." }
+    # Common:
+    timeout: 120              # tool call timeout (s)
+    connect_timeout: 60       # initial connect (s)
+    # Sampling (server-initiated LLM):
+    sampling:
+      enabled: true
+      model: "gemini-3-flash"
+      max_tokens_cap: 4096
+      timeout: 30
+      max_rpm: 10
+      allowed_models: []
+      max_tool_rounds: 5
+      log_level: info
+```
+
+`${VAR}` placeholders in any string get resolved from `os.environ` at
+load time (see `_interpolate_env_vars()` in `tools/mcp_tool.py:2224`).
+
+### 1.4 Subsystem: Skills
+
+| Key | Type | Default |
+|-----|------|---------|
+| `skills.creation_nudge_interval` | int | 15 |
+| `skills.external_dirs` | list[str] | `[]` |
+
+`skills.external_dirs` is the **key extension point for hal0** —
+read-only directories the agent will scan in addition to
+`$HERMES_HOME/skills/`. Expansion supports `~` and `${VAR}`. Local skills
+take precedence on name collision. New skill creation always writes to
+`$HERMES_HOME/skills/`.
+
+### 1.5 Subsystem: Persona
+
+| File | Format |
+|------|--------|
+| `$HERMES_HOME/SOUL.md` | free-form Markdown (the persona) |
+| `hermes_cli/default_soul.py` | `DEFAULT_SOUL_MD` constant — fallback identity when SOUL.md absent |
+
+The "personalities" in `config.yaml` `agent.personalities.<name>` are
+**not** SOUL.md — they're one-line prompts swapped via the `/personality`
+slash command. SOUL.md is the durable identity; personalities are short
+per-session overlays.
+
+### 1.6 Subsystem: Subagents / delegation
+
+| Key | Default | Notes |
+|-----|---------|------|
+| `delegation.max_iterations` | 50 | per child |
+| `delegation.max_concurrent_children` | 3 | per batch; floor 1, no ceiling |
+| `delegation.max_spawn_depth` | 1 | 1=flat, raise to 2 for orchestrator children |
+| `delegation.orchestrator_enabled` | true | kill switch |
+| `delegation.subagent_auto_approve` | false | for cron/batch only |
+| `delegation.inherit_mcp_toolsets` | true | child inherits parent MCP toolsets |
+| `delegation.model` / `delegation.provider` | inherit | per-child model override |
+
+### 1.7 Subsystem: Telemetry / Display
+
+`agent.verbose`, `display.tool_progress`, `display.streaming`, `agent.reasoning_effort`
+(values: `xhigh|high|medium|low|minimal|none`), `agent.max_turns` (default 60),
+`agent.api_max_retries` (default 3), `agent.gateway_timeout` (s), etc. See lines
+560–980 of `cli-config.yaml.example`.
+
+### 1.8 Subsystem: Hooks
+
+Shell-script hooks under `config.yaml hooks:` — events: `pre_tool_call`,
+`post_tool_call`, `pre_llm_call`, `post_llm_call`, `pre_api_request`,
+`post_api_request`, `on_session_start`, `on_session_end`,
+`on_session_finalize`, `on_session_reset`, `subagent_stop`. JSON wire
+protocol over stdin/stdout. Per-`(event, command)` consent file at
+`$HERMES_HOME/shell-hooks-allowlist.json`. Non-interactive runs need
+`--accept-hooks` or `HERMES_ACCEPT_HOOKS=1`. **Useful for hal0** — wire
+hal0 admin actions to `on_session_start`.
+
+### 1.9 Subsystem: Compression
+
+`compression.enabled` (true), `compression.threshold` (0.50 = 50% of
+context window), `compression.target_ratio` (0.20 of threshold preserved
+as recent tail), `compression.protect_last_n` (20 messages), `compression.protect_first_n` (3).
+Auxiliary models for summarization configured under
+`auxiliary.{vision,web_extract,session_search}.{provider,model,timeout,...}`.
+
+### 1.10 Subsystem: Terminal
+
+`terminal.backend`: `local | ssh | docker | singularity | modal | daytona | vercel-sandbox`.
+Plus `terminal.cwd`, `terminal.timeout`, `terminal.docker_image`,
+`terminal.ssh_host` etc., and `sudo_password` (plaintext — interactive
+prompt fallback when omitted). Container resource caps:
+`container_cpu`, `container_memory`, `container_disk`, `container_persistent`.
+
+---
+
+## 2. CLI surface
+
+Top-level subcommands wired in `hermes_cli/main.py::build_top_level_parser()`.
+Confirmed by grepping `subparsers.add_parser(...)` calls:
+
+| Subcommand | What it does | Key file |
+|-----------|--------------|---------|
+| (bare) `hermes` | Interactive chat TUI | `hermes_cli/main.py` |
+| `hermes setup` | Full first-run/setup wizard | `hermes_cli/setup.py::run_setup_wizard` |
+| `hermes postinstall` | Post-install hook (pip users) | `hermes_cli/main.py:11392` |
+| `hermes model` | Switch model + provider | `hermes_cli/model_switch.py` |
+| `hermes config show \| edit \| set <k> <v> \| path \| env-path \| check \| migrate` | YAML config CRUD | `hermes_cli/config.py` |
+| `hermes secrets bw …` | Bitwarden bridge for `.env` secrets | `hermes_cli/secrets_cli.py` |
+| `hermes auth add \| list \| remove \| reset \| status \| logout \| spotify` | Pooled credentials | `hermes_cli/auth.py`, `auth_commands.py` |
+| `hermes login` / `hermes logout` | Nous Portal OAuth | `hermes_cli/main.py:11467` |
+| `hermes gateway run \| start \| stop \| restart \| status \| install \| uninstall \| list \| setup \| migrate-legacy` | Messaging gateway lifecycle (systemd templates included) | `hermes_cli/gateway.py` |
+| `hermes proxy start \| stop \| status` | Local credential proxy | `hermes_cli/proxy/` |
+| `hermes whatsapp` | Baileys-based WhatsApp pairing | `hermes_cli/main.py:11403` |
+| `hermes slack manifest …` | Slack app manifest helper | `hermes_cli/slack_cli.py` |
+| `hermes send …` | One-shot send-to-platform | `hermes_cli/send_cmd.py` |
+| `hermes cron list \| create \| edit \| pause \| resume \| run \| remove \| status \| tick` | Built-in scheduler (croniter) | `hermes_cli/cron.py`, `cron/` |
+| `hermes webhook subscribe \| list \| remove \| test` | GitHub / generic webhook handlers | `hermes_cli/webhook.py` |
+| `hermes kanban …` | Built-in kanban DB + LLM workflows | `hermes_cli/kanban*.py` |
+| `hermes hooks list \| test \| revoke \| accept-all` | Manage shell hooks | `hermes_cli/hooks.py` |
+| `hermes doctor` | Diagnostics (provider health, models endpoint, dep check, …) | `hermes_cli/doctor.py` (88909 bytes) |
+| `hermes dump` | Dump session/state for debugging | `hermes_cli/dump.py` |
+| `hermes debug share \| delete` | Share/delete debug bundle | `hermes_cli/debug.py` |
+| `hermes backup` | Backup `$HERMES_HOME` | `hermes_cli/backup.py` |
+| `hermes checkpoints` | Conversation checkpoint mgmt | `hermes_cli/checkpoints.py` |
+| `hermes import` | Import sessions | `hermes_cli/main.py:12083` |
+| `hermes pairing` | DM-pairing flow for messaging platforms | `hermes_cli/pairing.py` |
+| `hermes skills browse \| search \| install \| inspect \| list \| check \| update \| audit \| uninstall \| reset \| publish \| snapshot \| tap` | Skills Hub | `hermes_cli/skills_hub.py` (61717 bytes) |
+| `hermes bundles` | Curated skill bundles | `hermes_cli/bundles.py` |
+| `hermes plugins install \| update \| <plugin-cli>` | Plugin registry CRUD | `hermes_cli/plugins_cmd.py` |
+| `hermes curator` | Auto-curator background tasks | `hermes_cli/curator.py`, `agent/curator.py` |
+| `hermes memory setup \| status \| off \| reset` | Configure memory provider | `hermes_cli/memory_setup.py` |
+| `hermes tools list \| --summary \| <interactive>` | Per-platform tool config | `hermes_cli/tools_config.py` (137133 bytes) |
+| `hermes computer-use …` | Setup macOS cua-driver MCP | `hermes_cli/main.py:12699` |
+| `hermes mcp serve \| add \| remove \| list \| test \| configure \| login` | MCP server lifecycle (and `mcp serve` = expose Hermes as MCP server) | `hermes_cli/mcp_config.py`, `mcp_serve.py` |
+| `hermes sessions list \| export \| delete \| prune \| stats \| rename \| browse` | Session store CRUD | `hermes_cli/main.py:12849` |
+| `hermes insights [--days N]` | Cross-session insights / usage | `agent/insights.py` |
+| `hermes claw migrate \| cleanup` | OpenClaw migration | `hermes_cli/claw.py` |
+| `hermes version` | Print version | `hermes_cli/main.py:13208` |
+| `hermes update` | Self-update | `hermes_cli/main.py:13214` |
+| `hermes uninstall` | Clean uninstall | `hermes_cli/uninstall.py` |
+| `hermes acp` | Run as Agent Client Protocol server (Zed integration) | `acp_adapter/` |
+| `hermes profile list \| use \| create \| delete \| describe \| show \| alias \| rename \| export \| import \| install \| update \| info` | Multi-profile management (`~/.hermes/profiles/<name>/`) | `hermes_cli/profiles.py` |
+| `hermes completion` | Shell completion | `hermes_cli/completion.py` |
+| `hermes dashboard` | Localhost SPA + API | `hermes_cli/web_server.py` (178133 bytes) |
+| `hermes logs` | Tail / show logs | `hermes_cli/logs.py` |
+| `hermes status` | Compact runtime status | `hermes_cli/status.py` |
+| `hermes fallback show \| add \| remove \| edit` | Fallback model chain | `hermes_cli/fallback_cmd.py` |
+
+First-run / install flow (from `scripts/install.sh` + `hermes_cli/setup.py`):
+
+1. `curl -fsSL .../scripts/install.sh | bash` clones repo, installs `uv`,
+   Python 3.11, deps (`.[all]`).
+2. Symlinks `$HOME/.local/bin/hermes` → repo `hermes` shim.
+3. Optionally runs `hermes setup` (interactive wizard) at the end —
+   `_run_first_time_quick_setup(config, hermes_home, is_existing)` at
+   `hermes_cli/setup.py:3283`. Streamlined flow: provider → model →
+   terminal → messaging.
+4. `hermes postinstall` is the pip-only equivalent: installs optional
+   deps + runs `hermes setup`.
+5. `_offer_openclaw_migration()` (`hermes_cli/setup.py:2916`) detects
+   `~/.openclaw/` and offers `hermes claw migrate` before configuration.
+
+---
+
+## 3. Model provider abstraction
+
+### 3.1 Architecture
+
+`/tmp/hermes-research/hermes-agent/providers/base.py` — declares the
+`ProviderProfile` dataclass. **Every** provider — local or remote — is a
+profile object.
+
+```python
+@dataclass
+class ProviderProfile:
+    # Identity
+    name: str
+    api_mode: str = "chat_completions"   # or "responses", "native_anthropic", "bedrock_converse"
+    aliases: tuple = ()
+    # Human metadata
+    display_name: str = ""
+    description: str = ""
+    signup_url: str = ""
+    # Auth + endpoints
+    env_vars: tuple = ()
+    base_url: str = ""
+    models_url: str = ""                 # default {base_url}/models
+    auth_type: str = "api_key"           # api_key|oauth_device_code|oauth_external|copilot|aws_sdk
+    supports_health_check: bool = True
+    # Catalog
+    fallback_models: tuple = ()
+    hostname: str = ""
+    # Client quirks
+    default_headers: dict = …
+    fixed_temperature: Any = None        # use OMIT_TEMPERATURE sentinel to suppress
+    default_max_tokens: int | None = None
+    default_aux_model: str = ""
+```
+
+Overridable hooks: `get_hostname()`, `prepare_messages()`,
+`build_extra_body()`, `build_api_kwargs_extras()`, `fetch_models()`.
+
+### 3.2 Registry
+
+`/tmp/hermes-research/hermes-agent/providers/__init__.py`:
+
+- `register_provider(profile)` — call at plugin import time.
+- `get_provider_profile(name)` — by name OR alias.
+- `list_providers()` — all registered.
+- Discovery is lazy. Three sources, in order:
+  1. **Bundled plugins**: `plugins/model-providers/<name>/__init__.py`.
+  2. **User plugins**: `$HERMES_HOME/plugins/model-providers/<name>/__init__.py`.
+     User wins on name collision (last-writer-wins).
+  3. **Legacy** `providers/<name>.py` single-file (back-compat).
+
+### 3.3 Bundled providers (28 ship in-tree)
+
+`/tmp/hermes-research/hermes-agent/plugins/model-providers/`:
+
+```
+ai-gateway, alibaba, alibaba-coding-plan, anthropic, arcee,
+azure-foundry, bedrock, copilot, copilot-acp, custom, deepseek,
+gemini, gmi, huggingface, kilocode, kimi-coding, minimax, nous,
+novita, nvidia, ollama-cloud, openai-codex, opencode-zen, openrouter,
+qwen-oauth, stepfun, xai, xiaomi, zai
+```
+
+**There is NO `lmstudio/` or `ollama/` (local) plugin dir** — both are
+collapsed into the `custom` profile. `lmstudio` is documented as a
+first-class provider in `cli-config.yaml.example` but is wired via
+`hermes_cli/runtime_provider.py`, not as a model-providers plugin.
+
+### 3.4 The `custom` profile = what hal0 wants
+
+`/tmp/hermes-research/hermes-agent/plugins/model-providers/custom/__init__.py`:
+
+```python
+custom = CustomProfile(
+    name="custom",
+    aliases=("ollama", "local", "vllm", "llamacpp", "llama.cpp", "llama-cpp"),
+    env_vars=(),
+    base_url="",                          # user-configured
+)
+```
+
+`CustomProfile.fetch_models()` does the standard `GET {base_url}/models`
+Bearer-auth probe when `base_url` is set. `build_api_kwargs_extras()`
+adds `extra_body.options.num_ctx` from `ollama_num_ctx` and
+`extra_body.think = False` when reasoning is disabled.
+
+### 3.5 Smallest viable config for a local OpenAI-compatible server
+
+```yaml
+# config.yaml
+model:
+  default: "Qwen3-30B-A3B-Instruct-2507"   # any name your server reports
+  provider: "custom"                        # alias for ollama/vllm/llamacpp
+  base_url: "http://10.0.1.142:8000/v1"
+```
+
+That's it. No env var needed because `env_vars=()` on the custom profile.
+For Lemonade specifically, Lemonade exposes `/api/v1/...` — set
+`base_url: "http://10.0.1.142:8000/api/v1"` so `{base_url}/models` and
+`{base_url}/chat/completions` resolve correctly.
+
+### 3.6 Most complete reference config (hal0-targeted)
+
+```yaml
+model:
+  default: "Qwen3-30B-A3B-Instruct-2507"
+  provider: "custom"
+  base_url: "http://10.0.1.142:8000/api/v1"
+  context_length: 32768
+  # max_tokens unset — let server decide
+
+providers:
+  custom:
+    request_timeout_seconds: 300      # local cold-start tolerance
+    stale_timeout_seconds: 900
+    models:
+      Qwen3-30B-A3B-Instruct-2507:
+        timeout_seconds: 600
+
+model_aliases:
+  qwen-coder:
+    model: "Qwen3-Coder-30B"
+    provider: custom
+    base_url: "http://10.0.1.142:8000/api/v1"
+  glm-air:
+    model: "GLM-4.6-Air"
+    provider: custom
+    base_url: "http://10.0.1.142:8000/api/v1"
+
+# Auxiliary tasks (vision, web_extract, compression summaries)
+# Point at hal0 too if you have a vision-capable slot:
+auxiliary:
+  vision:
+    provider: "main"               # uses model.base_url + (empty) api_key
+    model: ""                       # or specific multimodal slot
+  web_extract:
+    provider: "main"
+    model: ""
+  session_search:
+    provider: "main"
+    model: ""
+```
+
+### 3.7 Custom provider plugin shape (if hal0 wants its own profile)
+
+Instead of using `custom`, hal0 can ship a private profile that hardcodes
+the hal0 base URL and emits a vendor User-Agent. Drop at
+`$HERMES_HOME/plugins/model-providers/hal0/`:
+
+```python
+# __init__.py
+from providers import register_provider
+from providers.base import ProviderProfile
+
+class Hal0Profile(ProviderProfile):
+    pass
+
+hal0 = Hal0Profile(
+    name="hal0",
+    aliases=("hal0-local",),
+    display_name="hal0 (local)",
+    description="hal0 Lemonade-backed slots on the LAN",
+    signup_url="https://hal0.dev",
+    env_vars=("HAL0_API_KEY", "HAL0_BASE_URL"),
+    base_url="http://10.0.1.142:8000/api/v1",
+    default_aux_model="",
+    default_headers={"User-Agent": "hermes-on-hal0/1.0"},
+)
+register_provider(hal0)
+```
+
+```yaml
+# plugin.yaml
+name: hal0-provider
+kind: model-provider
+version: 1.0.0
+description: hal0 LAN inference platform
+author: hal0
+```
+
+### 3.8 Separate provider per modality?
+
+There is **no separate top-level "embeddings provider" or "reranker
+provider" abstraction** in Hermes. Reranking happens inside specific
+memory providers (mem0 uses Mem0's reranker; honcho/holographic do their
+own). Hermes itself does not call `/v1/embeddings` from the agent loop —
+that's not part of its architecture.
+
+STT/TTS providers DO have their own pluggable provider abstraction:
+
+- **STT**: `agent/transcription_tools.py` (config: `stt.provider` =
+  `local | groq | openai | mistral`, `stt.<provider>.model`, optional
+  `GROQ_BASE_URL` / `STT_OPENAI_BASE_URL`).
+- **TTS**: `tools/tts_tool.py` (`tts.provider` = `edge | elevenlabs | openai | minimax | mistral | neutts | kittentts`).
+- **Vision**: routed through `auxiliary.vision.{provider,model}`. Any
+  OpenAI-compatible vision model on a custom endpoint works.
+
+To wire hal0's voice/STT/TTS slots into Hermes:
+- Set `stt.provider: openai` with `STT_OPENAI_BASE_URL=http://10.0.1.142:9000/v1`
+  pointing at hal0's STT slot.
+- Set `tts.provider: openai` and pin to hal0's TTS slot the same way.
+
+---
+
+## 4. Memory system
+
+### 4.1 Two tiers
+
+**Built-in (always on):** `$HERMES_HOME/memories/MEMORY.md` (agent's notes)
+and `$HERMES_HOME/memories/USER.md` (user profile). Bounded character
+limits (default 2200 / 1375). Injected into every system prompt under
+the "volatile" tier. Managed via the built-in `memory` toolset.
+
+**External provider (one at a time):** Selected via `memory.provider` in
+`config.yaml`. Discovery in
+`/tmp/hermes-research/hermes-agent/plugins/memory/__init__.py`:
+
+- Bundled: `plugins/memory/<name>/`.
+- User: `$HERMES_HOME/plugins/<name>/`. Bundled wins on collision.
+
+Bundled providers shipping in-tree:
+
+```
+byterover, hindsight, holographic, honcho, mem0, openviking,
+retaindb, supermemory
+```
+
+The provider ABC is `/tmp/hermes-research/hermes-agent/agent/memory_provider.py::MemoryProvider`.
+Lifecycle:
+
+```python
+initialize(session_id, hermes_home, platform, agent_context,
+           agent_identity, agent_workspace, parent_session_id, user_id)
+system_prompt_block() -> str
+prefetch(query, session_id=) -> str          # before each turn
+queue_prefetch(query, session_id=)            # after each turn (background)
+sync_turn(user, assistant, session_id=)       # after each turn
+get_tool_schemas() -> list[dict]              # tools the provider adds
+handle_tool_call(name, args, **kwargs) -> str # tool dispatch
+shutdown()
+# Optional:
+on_turn_start, on_session_end, on_session_switch, on_pre_compress,
+on_delegation, on_memory_write
+```
+
+### 4.2 Does Hermes use Cognee?
+
+**No.** No Cognee provider ships in-tree. Cognee is referenced nowhere in
+the canonical repo. The closest "knowledge graph" provider is
+`holographic` (plugins/memory/holographic). hal0's plan to use Cognee
+(noted in MEMORY: "hal0 Agents v0.3 design") would either need a custom
+memory provider plugin OR be exposed via MCP and used as a tool.
+
+### 4.3 Wiring hal0's memory MCP into Hermes
+
+Two integration paths:
+
+**Path A (simplest, recommended for v0.3):** expose hal0-memory as an
+MCP server, register under `mcp_servers.hal0-memory`. Memory tools
+appear in the model's tool list. No new code on Hermes side.
+
+**Path B (deeper):** write a `Hal0MemoryProvider(MemoryProvider)` plugin
+that calls hal0's HTTP API directly. Drop at
+`$HERMES_HOME/plugins/hal0-memory/`. Hermes will inject a
+`system_prompt_block()`, prefetch context before each turn, and sync
+turns automatically. Use this when you want hal0 memory to feel
+"native," not as a tool the model has to remember to call.
+
+### 4.4 Namespace / scoping
+
+Built-in: per-`HERMES_HOME` (profile-scoped via
+`~/.hermes/profiles/<name>/`).
+
+Provider plugins receive in `initialize()` kwargs:
+`user_id` (platform user identifier), `agent_identity` (profile name),
+`agent_workspace` (shared workspace), `session_id`, `parent_session_id`,
+`platform`. Each provider decides how to scope. mem0 scopes
+read-filters to `user_id` only (cross-session recall), write-filters
+to `(user_id, agent_id)` (attribution).
+
+---
+
+## 5. MCP integration
+
+### 5.1 Loading
+
+`tools/mcp_tool.py::_load_mcp_config()` at line 2237:
+
+1. Reads `config.yaml mcp_servers`.
+2. Loads `$HERMES_HOME/.env` into `os.environ`.
+3. Resolves `${VAR}` placeholders in every string value.
+
+`hermes mcp add` (in `hermes_cli/mcp_config.py`) supports interactive
+add, named presets (currently only `codex`), `--url`, `--command`,
+`--args`, `--env KEY=VALUE`, `--auth oauth|header`.
+
+### 5.2 Transports
+
+- **Stdio:** `command` + `args` + `env`. Subprocess sandbox. Hermes adds
+  safe-default env vars on top of what's supplied
+  (`tools/mcp_tool.py::_build_safe_env`).
+- **HTTP / SSE:** `url` + `headers`. Both supported (SSE/streamable HTTP
+  detected from server response).
+
+### 5.3 OAuth
+
+`tools/mcp_oauth.py` + `tools/mcp_oauth_manager.py` — Hermes handles
+PKCE OAuth for HTTP MCP servers. Auth tokens land in
+`$HERMES_HOME/mcp-tokens/<server>.json`. `hermes mcp login <name>`
+forces re-auth.
+
+### 5.4 Per-agent or global?
+
+**Global to the profile.** Every `mcp_servers` entry is loaded for every
+agent run within that `HERMES_HOME`. The agent picks WHICH tools to
+expose via the per-platform toolset config
+(`platform_toolsets.<platform>: [server:tool, ...]`). MCP tools use
+`server:tool` notation in toolset lists.
+
+### 5.5 Hermes as MCP server
+
+`mcp_serve.py` (31690 bytes) — `hermes mcp serve` exposes Hermes
+conversations as an MCP server (stdio). Tools mirror OpenClaw's bridge:
+`conversations_list, conversation_get, messages_read, attachments_fetch,
+events_poll, events_wait, messages_send, permissions_list_open,
+permissions_respond, channels_list`. Use this to wire Hermes INTO
+Claude Code / Cursor / Codex as a sub-agent.
+
+---
+
+## 6. Skills / personas / subagents
+
+### 6.1 Skills filesystem layout
+
+A skill is a directory with a `SKILL.md` (the procedure) and arbitrary
+support files. Discovery via `agent/skill_utils.py::get_all_skills_dirs()`:
+
+1. `$HERMES_HOME/skills/` (read-write; new skills land here).
+2. Every path in `config.yaml skills.external_dirs` (read-only; expanded,
+   resolved, dedup'd; missing dirs silently skipped).
+3. Bundled (`<install>/skills/` + `<install>/optional-skills/`) — these
+   appear in the model's "available skills" listing but are not in
+   `external_dirs`.
+
+`get_all_skills_dirs()` walks each dir for `SKILL.md` files. Excluded
+sub-dirs:
+`{.git, .github, .hub, .archive, .venv, venv, node_modules,
+site-packages, __pycache__, .tox, .nox, .pytest_cache, .mypy_cache,
+.ruff_cache}`.
+
+`SKILL.md` frontmatter (parsed by `extract_skill_conditions`):
+
+```yaml
+---
+name: my-skill
+description: One-line summary.
+metadata:
+  hermes:
+    fallback_for_toolsets: [web]      # activate when this toolset is enabled
+    requires_toolsets: [terminal]      # only if these toolsets enabled
+    fallback_for_tools: []
+    requires_tools: []
+---
+# Skill body (Markdown)
+```
+
+Example bundled skill: `skills/dogfood/` → `SKILL.md`,
+`templates/dogfood-report-template.md`, `references/issue-taxonomy.md`.
+Subdirs `templates/` and `references/` are convention, not enforced —
+the skill body references them by relative path.
+
+### 6.2 Skills Hub
+
+`hermes_cli/skills_hub.py` (61717 bytes) — full GitHub-backed skill
+registry (`agentskills.io`). `hermes skills search/install/tap/publish`
+manage external sources. Installed skills land in
+`$HERMES_HOME/skills/<source>/<skill>/`.
+
+### 6.3 Personas
+
+`SOUL.md` at `$HERMES_HOME/SOUL.md` — free-form persona, loaded as the
+"identity" block at the very top of the system prompt
+(`agent/system_prompt.py:90`). When absent, falls back to
+`hermes_cli/default_soul.py::DEFAULT_SOUL_MD`. Per-profile: each profile
+under `~/.hermes/profiles/<name>/` has its own `SOUL.md`.
+
+`agent.personalities.<name>` in `config.yaml` — short one-line prompts
+swappable at runtime via `/personality <name>`. Not the same as SOUL.md.
+
+### 6.4 Subagents
+
+The `delegate_task` tool (`tools/delegate_tool.py`, 119593 bytes) is
+Hermes's equivalent of Claude Code's Agent tool. Single tasks or batch
+mode (default 3 parallel). Children get isolated context, can spawn
+their own subagents up to `delegation.max_spawn_depth` (default 1).
+Per-child `model`/`provider` overrides supported. Subagent system prompt
+is the parent's stable tier + a slimmed-down memory snapshot.
+
+Two related tools:
+- `mixture_of_agents` (`tools/mixture_of_agents_tool.py`) — OpenRouter-
+  required MoA fan-out, not a true delegation primitive.
+- `execute_code` (`tools/code_execution_tool.py`) — programmatic tool
+  calling via Python+RPC; lets the agent compose tool calls in code
+  without growing the context window.
+
+---
+
+## 7. First-run / bootstrap
+
+### 7.1 Bootstrap sequence
+
+1. `scripts/install.sh` clones repo, installs uv/Python 3.11/`.[all]`,
+   symlinks `~/.local/bin/hermes`, ensures `node`, `ripgrep`, `ffmpeg`
+   (via `--ensure`), installs Playwright/Chromium (unless `--skip-browser`).
+2. Calls `tools/skills_sync.py` to seed/sync bundled skills into
+   `$HERMES_HOME/skills/`.
+3. Runs `hermes setup` interactive wizard (unless `--skip-setup`):
+   `_run_first_time_quick_setup()` at `hermes_cli/setup.py:3283`.
+   Streamlined order: provider → model → terminal backend → messaging.
+4. Detects `~/.openclaw/` and offers `hermes claw migrate` first.
+5. Writes `$HERMES_HOME/{config.yaml, .env, SOUL.md}`, ensures
+   `memories/`, `skills/`, `plugins/`, `logs/`, `sessions/` dirs.
+
+`hermes postinstall` is the pip-only equivalent (`hermes_cli/main.py:11392`,
+`scripts/install.sh:2011`).
+
+### 7.2 Self-improvement loop
+
+**Inside the agent loop (every session, automatic):**
+
+- **Memory nudge** (`memory.nudge_interval`, default 10 user turns) —
+  injected reminder to save memories.
+- **Skill creation nudge** (`skills.creation_nudge_interval`, default 15
+  tool iterations) — reminder to create a skill after a complex task.
+- **Skill self-improvement** — `tools/skill_usage.py` tracks per-skill
+  invocation outcomes; `agent/background_review.py` (29465 bytes) runs
+  post-session reviews proposing edits to skills the agent used.
+- **Curator** (`agent/curator.py`, 74849 bytes) — long-running
+  background process that consolidates memory and prunes stale entries.
+
+**External, opt-in:** `NousResearch/hermes-agent-self-evolution`. DSPy +
+GEPA prompt evolution. Reads session traces, proposes targeted
+mutations, gates by tests + size limits + caching compatibility, opens
+PRs against `hermes-agent`. **Not bundled** with `pip install hermes-agent` —
+separate repo (`pip install -e .[dev]`) that you point at
+`HERMES_AGENT_REPO=~/.hermes/hermes-agent`. ~$2-10 per optimization run.
+
+### 7.3 Environment probing
+
+`hermes doctor` (`hermes_cli/doctor.py`, 88909 bytes) — comprehensive
+diagnostic suite. Hits `/models` on every `auth_type=api_key` provider
+profile, checks the terminal backend, validates skills/plugins/MCP
+configs, surfaces missing deps. Run on first start by the install
+script. `hermes_constants.py` separately detects WSL, Termux, container
+runtime, and applies the Windows UTF-8 bootstrap (`hermes_bootstrap.py`).
+
+### 7.4 Onboarding hints
+
+`agent/onboarding.py` — first-touch contextual hints (busy-input mode,
+tool-progress mode, openclaw residue). Each hint fires once per install,
+tracked in `config.yaml onboarding.seen.<flag>`. **Useful hal0 pattern**
+— mimic this for hal0-specific tips on first agent use.
+
+---
+
+## 8. Extension points (where to hook hal0's bootstrap)
+
+Ordered by ease of integration (low risk → deep wiring):
+
+### A. Env discovery on first run
+
+- **Hook**: `config.yaml hooks.on_session_start: [{ command: "/usr/lib/hal0/hermes-hooks/discover-hal0.sh" }]`.
+- Script reads `/etc/hal0/capabilities.toml`, posts to hal0's discovery
+  endpoint, returns JSON injecting fresh context to the model.
+- **Path**: hal0 ships the hook script + flips the consent file
+  (`$HERMES_HOME/shell-hooks-allowlist.json`) at install time so we
+  don't need `--accept-hooks`.
+
+### B. Auto-register every model on a hal0 instance
+
+- **Hook**: post-install script run from hal0's installer. Two surfaces:
+  1. Write `$HERMES_HOME/config.yaml` with `model.provider: custom`,
+     `model.base_url: http://10.0.1.142:8000/api/v1`, and
+     `model_aliases.<slot>` entries — one per slot in
+     `/etc/hal0/capabilities.toml`. The `custom` profile's
+     `fetch_models()` will then auto-populate `/model` picker via
+     `{base_url}/models`.
+  2. OR ship a bundled `Hal0Profile` plugin under
+     `$HERMES_HOME/plugins/model-providers/hal0/` so users see "hal0"
+     as a first-class provider option in the setup wizard.
+- **Decision**: option 1 is zero-code; option 2 is what we want long
+  term (recognizable in the wizard, distinct hostname → provider
+  detection in `agent/model_metadata.py`).
+
+### C. Auto-wire hal0's memory MCP
+
+- **Quick path**: append `mcp_servers.hal0-memory: { url: "http://10.0.1.142:8095/mcp", headers: { ... } }`
+  to `$HERMES_HOME/config.yaml`. Reload Hermes.
+- **Deep path**: ship `Hal0MemoryProvider` under
+  `$HERMES_HOME/plugins/hal0-memory/__init__.py` extending
+  `agent.memory_provider.MemoryProvider`. Wire `system_prompt_block()`,
+  `prefetch()`, `sync_turn()` to hal0's HTTP memory API. Flip
+  `memory.provider: hal0-memory` in `config.yaml`. Provider becomes the
+  ONE active external memory, gets injected into every system prompt.
+
+### D. Post-install hooks (from hal0's installer)
+
+- hal0 installer should call (after `pip install hermes-agent`):
+  1. `hermes config set model.provider custom`
+  2. `hermes config set model.base_url http://10.0.1.142:8000/api/v1`
+  3. `hermes config set memory.provider hal0-memory`
+  4. `hermes mcp add hal0-admin --url http://10.0.1.142:8095/mcp`
+  5. `hermes skills tap add Hal0ai/hal0-skills` (if we publish skills)
+  6. Symlink hal0 context dir → `skills.external_dirs` entry:
+     `hermes config set skills.external_dirs '["/etc/hal0/agent-skills"]'`
+  7. Drop `SOUL.md` template at `$HERMES_HOME/SOUL.md` (hal0 persona).
+  8. Drop a hal0 hook script at `$HERMES_HOME/hal0-hooks/` + register
+     under `hooks.on_session_start`.
+
+### E. Self-improvement integration
+
+- **Out of scope for v0.3**. `hermes-agent-self-evolution` is a separate
+  repo that opens PRs against `hermes-agent` upstream. For hal0 we'd
+  fork to `Hal0ai/hermes-agent-self-evolution` only if we want to
+  evolve hal0-specific skills.
+
+### F. Per-profile installs
+
+- Use `hermes profile create hal0` to give the bundled hal0 install its
+  own `~/.hermes/profiles/hal0/{config.yaml, .env, SOUL.md, skills/, plugins/, …}`
+  isolated from any user's existing hermes install. Activate with
+  `hermes profile use hal0` or `HERMES_HOME=~/.hermes/profiles/hal0 hermes`.
+
+### G. CLI subcommand injection (plugin CLI)
+
+- `hermes_cli/plugins.py` discovers `cli.py::register_cli(subparser)`
+  inside any plugin under `plugins/<name>/`. Drop hal0-specific
+  subcommands (`hermes hal0 status`, `hermes hal0 slot ...`) via a
+  plugin shipped under `$HERMES_HOME/plugins/hal0/`. The plugin can
+  also `register_hook`, `register_tool`.
+
+### H. Skill context-aware dir
+
+- The MEMORY says "skills/context not symlinked into context-aware dir."
+  The right home is `config.yaml skills.external_dirs: ["/etc/hal0/skills",
+  "/var/lib/hal0/agent-skills"]`. These are read-only; new skills the
+  agent creates land in `$HERMES_HOME/skills/`. If hal0 ships skills via
+  a debian-style FHS, point external_dirs there.
+
+### I. Project context files
+
+- Hermes auto-injects `AGENTS.md`, `CLAUDE.md`, `.cursorrules`,
+  `.cursor/rules/*.mdc`, and `HERMES.md` / `.hermes.md` from the cwd
+  (and `.hermes.md` walks to git root). See `agent/prompt_builder.py`
+  lines 1298–1410. Drop a `HERMES.md` at `/etc/hal0/HERMES.md` and
+  always start hermes with cwd `/etc/hal0/` to seed context every session.
+
+### J. Skill conditions for hal0 toolsets
+
+- If hal0 ships an MCP server, the agent can be made to auto-load
+  hal0-specific skills only when its MCP tools are enabled by adding
+  `metadata.hermes.requires_tools: ["hal0_admin:status"]` to the
+  skill's frontmatter.
+
+---
+
+## 9. Gaps and gotchas
+
+### Brittle bits
+
+- **`HERMES_HOME` fallback warning, not error.** `get_hermes_home()` in
+  `hermes_constants.py` writes a warning to stderr if `HERMES_HOME` is
+  unset while `active_profile` is not "default", then falls back to
+  `~/.hermes`. Subprocess spawners must propagate `HERMES_HOME`
+  explicitly. **Bake into hal0's systemd unit**: `Environment=HERMES_HOME=...`.
+
+- **`config.yaml` is the persistent store, NOT `.env`.** The wizard
+  routinely overwrites `model.default`, `model.provider`, `terminal.*`.
+  Don't expect manual edits to `config.yaml` to survive `hermes setup`
+  unless you skip the wizard.
+
+- **Skills `external_dirs` is read-only.** New skill creation always
+  writes to `$HERMES_HOME/skills/`. Don't expect the agent to push
+  improvements back to a hal0-managed dir.
+
+- **`hermes setup` is interactive-by-default.** Need `--quick`, env-var
+  pre-population, or `--skip-setup` to install non-interactively. The
+  wizard at `setup.py:3063` checks `is_interactive_stdin()` and gates
+  questions on it, so `bash -c 'echo y | hermes setup'` is fragile.
+
+- **mistralai dependency removed 2026-05-12** due to a PyPI worm. Don't
+  reference Mistral STT/TTS provider in hal0 docs until upstream
+  re-adds.
+
+- **No model-load-state notification surface.** Hermes polls
+  `{base_url}/models` for catalog freshness but otherwise treats
+  inference endpoints as fire-and-forget. The Lemonade "evict-all on
+  load failure" behavior (from MEMORY: `hal0_lemonade_gotchas`) will
+  surface to Hermes as 503/timeout on the next `chat/completions` —
+  Hermes will retry per `agent.api_max_retries` (3) and either succeed
+  on warm-up or surface a clear failure.
+
+### Linux vs Windows specifics
+
+- **`hermes_bootstrap.py`** explicitly applies Windows UTF-8 mode +
+  reconfigures stdio. POSIX is untouched. Safe for hal0 (Linux-only).
+- **`pty` extra** uses `ptyprocess` on POSIX, `pywinpty` on Windows.
+- **`matrix` extra (python-olm)** has no Windows native wheel. hal0
+  Linux-only so irrelevant.
+- **`docker_extra_args`** + `docker_run_as_host_user` only sensible on
+  Linux (Docker Desktop on Win/macOS rootless differs).
+- **Termux** has its own dep set (`.[termux]`, `constraints-termux.txt`).
+- **WSL detection** in `hermes_constants.is_wsl()`. Hermes's browser
+  dashboard chat pane uses POSIX PTY — needs WSL on Windows.
+
+### CLI-only vs API-only
+
+- **CLI only**: `hermes setup`, `hermes claw migrate`, `hermes mcp add`
+  (interactive), `hermes tools` (curses UI), `hermes gateway install`
+  (writes systemd units), `hermes doctor`.
+- **API only (no CLI)**: programmatic conversation loop via
+  `from run_agent import AIAgent` (used by `batch_runner.py`,
+  `mini_swe_runner.py`); MCP server mode via `hermes mcp serve` (stdio,
+  no HTTP).
+- **Both**: `hermes mcp list/test/remove`, `hermes config set`,
+  `hermes model`, `hermes cron`.
+- The `hermes dashboard` SPA exposes a localhost HTTP API but is for
+  user-facing interaction, not orchestration — don't try to drive
+  hal0 admin actions through it.
+
+### Gotchas specific to embedding Hermes in hal0
+
+- **`hermes` writes to `~/.hermes/`** by default. hal0's daemon user
+  must have a writable `$HOME` OR we set `HERMES_HOME=/var/lib/hal0/hermes`
+  in the systemd unit.
+- **Hermes pulls Python 3.11 via uv** when not present. hal0's LXC must
+  either ship Python 3.11+ OR allow uv to manage it (`UV_PYTHON_INSTALL_DIR`).
+- **`pip install hermes-agent` ≠ `git clone`** for skills. The pip wheel
+  ships bundled skills via setuptools `package-data`. `get_bundled_skills_dir()`
+  prefers `sysconfig.get_path("data")/skills` for wheel installs;
+  override with `HERMES_BUNDLED_SKILLS=/usr/share/hal0/skills` if hal0
+  installs Hermes via apt/dnf with non-standard data dirs.
+- **MCP server registration writes to `config.yaml`**. The hal0
+  installer must `hermes mcp add` AFTER `hermes setup` and AFTER any
+  config-overwriting step, or the add gets clobbered.
+- **`hermes mcp add` requires `--auth` for HTTP servers behind OAuth.**
+  hal0's MCP at `10.0.1.220:8095/mcp` is auth-free on LAN — use plain
+  `--url` and no `--auth`.
+- **No graphql/REST API for runtime introspection.** If hal0 needs to
+  know "is hermes alive and what's it doing right now?" use
+  `hermes status` (CLI) or read `$HERMES_HOME/sessions/` directly.
+
+---
+
+## 10. Reference: minimal vs reference configs
+
+### Minimal viable `config.yaml` (point Hermes at hal0, nothing else)
+
+```yaml
+model:
+  default: "Qwen3-30B-A3B-Instruct-2507"
+  provider: "custom"
+  base_url: "http://10.0.1.142:8000/api/v1"
+
+terminal:
+  backend: "local"
+
+memory:
+  memory_enabled: true
+  user_profile_enabled: true
+```
+
+That's it. The custom profile's `fetch_models()` populates the model
+picker automatically. SOUL.md will fall back to `DEFAULT_SOUL_MD`.
+
+### Reference `config.yaml` (full hal0 wiring)
+
+```yaml
+model:
+  default: "Qwen3-30B-A3B-Instruct-2507"
+  provider: "custom"
+  base_url: "http://10.0.1.142:8000/api/v1"
+
+providers:
+  custom:
+    request_timeout_seconds: 300
+    stale_timeout_seconds: 900
+
+model_aliases:
+  qwen:
+    model: "Qwen3-30B-A3B-Instruct-2507"
+    provider: custom
+    base_url: "http://10.0.1.142:8000/api/v1"
+  coder:
+    model: "Qwen3-Coder-30B"
+    provider: custom
+    base_url: "http://10.0.1.142:8000/api/v1"
+
+memory:
+  provider: "hal0-memory"           # custom MemoryProvider plugin at $HERMES_HOME/plugins/hal0-memory/
+  memory_enabled: true
+  user_profile_enabled: true
+  nudge_interval: 10
+  flush_min_turns: 6
+
+mcp_servers:
+  hal0-admin:
+    url: "http://10.0.1.142:8095/mcp"
+    timeout: 60
+  hal0-memory:
+    url: "http://10.0.1.220:8095/mcp"
+    timeout: 30
+
+skills:
+  external_dirs:
+    - "/etc/hal0/agent-skills"
+    - "/var/lib/hal0/skills"
+  creation_nudge_interval: 15
+
+terminal:
+  backend: "local"
+  cwd: "/etc/hal0"                 # so AGENTS.md/HERMES.md auto-inject
+
+agent:
+  max_turns: 60
+  reasoning_effort: "medium"
+  personalities:
+    helpful: "You are the hal0 admin agent. Be precise and direct."
+
+auxiliary:
+  vision:
+    provider: "main"               # reuse model.base_url
+    model: ""
+  web_extract:
+    provider: "main"
+    model: ""
+
+hooks:
+  on_session_start:
+    - command: "/usr/lib/hal0/hermes-hooks/inject-system-state.sh"
+      timeout: 10
+  post_tool_call:
+    - matcher: "memory_save|memory_replace"
+      command: "/usr/lib/hal0/hermes-hooks/mirror-to-cognee.sh"
+
+display:
+  skin: default
+  bell_on_complete: false
+  show_reasoning: false
+
+privacy:
+  redact_pii: false
+```
+
+`$HERMES_HOME/.env`:
+
+```
+# No model keys needed — custom provider with no env_vars
+# Optional: GitHub token for skills hub rate limits
+GITHUB_TOKEN=ghp_xxx
+# Optional: voice STT/TTS pointing at hal0 slots
+STT_OPENAI_BASE_URL=http://10.0.1.142:9000/v1
+VOICE_TOOLS_OPENAI_KEY=dummy
+```
+
+`$HERMES_HOME/SOUL.md`:
+
+```markdown
+You are the hal0 admin agent, the right-hand assistant for a self-hosted
+home-AI inference platform. You have direct access to slot lifecycle,
+model registry, capability catalog, and memory MCP servers. You favor
+concrete, verifiable actions: probe before you change, prefer dry-runs,
+quote exact paths and ports. ...
+```
+
+---
+
+## Appendix: file-path cheat sheet
+
+| What | Where |
+|------|------|
+| Provider ABC | `providers/base.py` |
+| Provider registry | `providers/__init__.py` |
+| Bundled providers | `plugins/model-providers/<name>/` |
+| User providers | `$HERMES_HOME/plugins/model-providers/<name>/` |
+| Memory ABC | `agent/memory_provider.py` |
+| Memory plugin discovery | `plugins/memory/__init__.py` |
+| MCP config loader | `tools/mcp_tool.py::_load_mcp_config` (line 2237) |
+| MCP CLI commands | `hermes_cli/mcp_config.py` |
+| MCP server mode (hermes-as-MCP) | `mcp_serve.py` |
+| Skill scanning | `agent/skill_utils.py::get_all_skills_dirs` |
+| System prompt assembly | `agent/system_prompt.py::build_system_prompt_parts` |
+| Context-file injection (AGENTS.md, etc.) | `agent/prompt_builder.py::_load_agents_md, _load_claude_md, _load_cursorrules, _load_hermes_md` |
+| First-run wizard | `hermes_cli/setup.py::_run_first_time_quick_setup` |
+| Install script | `scripts/install.sh` |
+| Postinstall hook | `scripts/install.sh::postinstall_mode` |
+| Doctor | `hermes_cli/doctor.py` |
+| Env vars (env vars docs) | `.env.example` |
+| Config YAML reference | `cli-config.yaml.example` |
+| HERMES_HOME / paths | `hermes_constants.py` |
+| Default SOUL.md | `hermes_cli/default_soul.py::DEFAULT_SOUL_MD` |
+| Delegation (subagent) tool | `tools/delegate_tool.py` |
+| Curator (background memory) | `agent/curator.py` |
+| Background review | `agent/background_review.py` |
+| Self-evolution (separate repo) | `NousResearch/hermes-agent-self-evolution` |
+


### PR DESCRIPTION
## Summary

Plan + supporting research for the v0.3 Hermes-Agent bootstrap rewrite. Replaces today's 4-line env-file shim with a 12-phase idempotent state machine that turns a fresh Hermes install into a hal0-native homelab admin (hardware-aware, model-aware via \`capabilities.toml\`, Cognee-memory-connected via a \`Hal0MemoryProvider\` plugin, discoverable via agent identity cards).

**Pure docs PR.** No code changes. Implementation lands as PR-1 through PR-8 per §23 of the bootstrap plan, behind \`HAL0_HERMES_BOOTSTRAP_V1=1\` until PR-8 flips the default.

## Documents

- **ADR-0011 (Draft)** — agent identity cards convention: dedicated \`agents\` Cognee dataset, immutable per-bootstrap, public-by-design. The discovery substrate other agents (Claude Code, pi-coder, future) will query.
- **\`docs/internal/hermes-bootstrap-plan-2026-05-23.md\`** (Draft 2, post-grilling) — the 12-phase state machine, 8-PR sequence, state-file schema, CLI surface, failure/idempotency rules.
- **\`docs/internal/hermes-upstream-map-2026-05-23.md\`** — upstream Hermes surface catalogue (ABCs, plugin slots, config knobs, MCP transports).
- **\`docs/internal/hermes-env-probe-recipes-2026-05-23.md\`** — env-detection recipes consumed by Phase C: GPU vendor + driver versions, XDNA / NPU presence, UMA pool size, LXC + apparmor signal, model store.

## PR sequence (§23)

| PR | Scope |
|---|---|
| 1 | ADR-0011 + new MCP admin tools (\`gpu_target_version\`, \`npu_status\`, \`env_report\`, \`model_store_probe\`) |
| 2 | \`hermes_provision.py\` scaffold + state schema + Preflight / Install / HomeInit phases |
| 3 | EnvProbe + ConfigWrite + McpWire |
| 4 | ContextLink + NamespaceRegister + identity card convention |
| 5 | ModelAutomap + VoiceWire |
| 6 | SmokeTests + SelfReport + CLI |
| 7 | δ-tier test harness coverage |
| 8 | Dashboard agent-status panel → flips default flag |

## Anchors

- Zero upstream Hermes forks.
- Zero new MCP transports.
- Zero new daemons.
- Every wiring decision uses surfaces that already exist in v0.2 (\`hal0-admin\` MCP, \`hal0-memory\` MCP, \`/api/models\`, \`/api/capabilities\`, \`/api/hardware\`).

## Test plan

- [x] All four files render in GitHub markdown viewer
- [x] Cross-references between bootstrap plan ↔ upstream map ↔ env-probe recipes ↔ ADR-0011 resolve
- [x] ADR-0011 status = "Draft" (not yet "Accepted")
- [ ] CI passes (docs-only PR — typecheck + tests should remain green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)