### PR TITLE
feat(api): /v1/* reverse-proxy to lemonade

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -71,6 +71,9 @@ from hal0.api.routes import (
     lemonade_logs as lemonade_logs_routes,
 )
 from hal0.api.routes import (
+    lemonade_proxy as lemonade_proxy_routes,
+)
+from hal0.api.routes import (
     proxmox as proxmox_routes,
 )
 from hal0.capabilities.orchestrator import CapabilityOrchestrator
@@ -684,6 +687,20 @@ def create_app() -> FastAPI:
     app.include_router(v1.public_router, prefix="/v1", tags=["v1"])
     _v1_auth = [Depends(require_token)]
     app.include_router(v1.router, prefix="/v1", tags=["v1"], dependencies=_v1_auth)
+
+    # Issue #212: Lemonade reverse-proxy catch-all on /v1/{path:path}.
+    # Mounted AFTER the dispatcher-owned v1 routers so every explicit
+    # inference path (chat, completions, embeddings, rerankings, audio,
+    # images, models) keeps its dispatcher handler; only un-covered
+    # paths (/v1/health, /v1/stats, /v1/load, /v1/unload, /v1/system-info,
+    # /v1/params, …) fall through to Lemonade. Same admin auth as the
+    # rest of the writer /v1 surface.
+    app.include_router(
+        lemonade_proxy_routes.router,
+        prefix="/v1",
+        tags=["v1", "lemonade-proxy"],
+        dependencies=_v1_auth,
+    )
 
     # Single-purpose protected routers — every endpoint requires a token
     # (or session cookie / forwarded email) when HAL0_AUTH_ENABLED=1.

--- a/src/hal0/api/routes/lemonade_proxy.py
+++ b/src/hal0/api/routes/lemonade_proxy.py
@@ -1,0 +1,232 @@
+"""Lemonade reverse-proxy for the un-routed /v1/* surface.
+
+Issue #212. hal0-api at port 8080 already serves a curated /v1 surface
+backed by the multi-upstream dispatcher (chat, completions, embeddings,
+rerankings, audio, images, models). That surface is intentional — it
+aggregates across every registered upstream so the dashboard / OpenAI
+clients see one catalogue.
+
+But Lemonade also exposes a SECOND tier of /v1 endpoints that aren't
+inference (``/v1/health``, ``/v1/stats``, ``/v1/load``, ``/v1/unload``,
+``/v1/system-info``, ``/v1/params`` …). The v3 React dashboard polls
+those via the ``useLemonadeHealth`` hook to render the sidebar
+'lemond connected' status block. They have no aggregation semantics —
+there's only one Lemonade, on loopback — so the right move is a
+straight reverse-proxy to ``http://127.0.0.1:13305``.
+
+This module mounts a catch-all GET/POST/DELETE/PUT/PATCH at
+``/v1/{path:path}`` and forwards verbatim. FastAPI matches routes in
+registration order, so we mount this AFTER ``v1.public_router`` +
+``v1.router`` — every dispatcher-owned path keeps its handler, and only
+the un-covered paths fall through to the proxy.
+
+Out of scope (handled elsewhere or deferred):
+  - WebSocket upgrade (lemond exposes /logs/stream + /realtime). The
+    existing ``lemonade_logs`` router already proxies /logs/stream → SSE
+    under ``/api/lemonade/logs/stream``; a generic /v1 WS proxy is
+    deferred to a follow-up issue.
+  - Auth: the catch-all sits behind the same ``require_token`` gate the
+    rest of the /v1 inference surface uses (mounted with ``_v1_auth``
+    dependencies in :mod:`hal0.api`). Lemonade itself binds loopback
+    only — anyone reaching this proxy already crossed hal0-api's gate.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Request
+from fastapi.responses import Response
+
+router = APIRouter()
+
+
+# Headers that MUST NOT round-trip across the proxy.  ``host`` would
+# poison Lemonade's URL parser; the hop-by-hop set (RFC 7230 §6.1) is
+# illegal to forward; ``content-length`` is recomputed by httpx +
+# Starlette from the actual body bytes.
+_REQUEST_HOP_BY_HOP = frozenset(
+    {
+        "host",
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+        "content-length",
+    }
+)
+
+# Response-side hop-by-hop. ``content-encoding`` is dropped because we
+# stream the decoded body (httpx auto-decodes gzip / br); echoing the
+# encoding header would mislead the client into a second decode.
+_RESPONSE_HOP_BY_HOP = frozenset(
+    {
+        "connection",
+        "content-encoding",
+        "content-length",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+
+def _lemonade_base_url() -> str:
+    """Return the Lemonade loopback base URL.
+
+    Env override matches :mod:`hal0.api.__init__` so a single
+    ``LEMONADE_BASE_URL=...`` re-points both the OmniRouter and this
+    proxy in development. The default is ADR-0008 §1's pinned loopback
+    URL.
+    """
+    return os.environ.get("LEMONADE_BASE_URL", "http://127.0.0.1:13305").rstrip("/")
+
+
+def _build_client(timeout: httpx.Timeout) -> httpx.AsyncClient:
+    """Construct the per-request httpx client.
+
+    Lives as a module-level seam so tests can monkeypatch it to inject
+    an ``httpx.MockTransport`` without spinning up a real socket.
+    """
+    return httpx.AsyncClient(timeout=timeout)
+
+
+def _filter_request_headers(headers: Any) -> dict[str, str]:
+    """Strip hop-by-hop + host headers from an incoming Starlette Headers."""
+    return {k: v for k, v in headers.items() if k.lower() not in _REQUEST_HOP_BY_HOP}
+
+
+def _filter_response_headers(headers: Any) -> dict[str, str]:
+    """Strip hop-by-hop + length headers from an httpx response."""
+    return {k: v for k, v in headers.items() if k.lower() not in _RESPONSE_HOP_BY_HOP}
+
+
+async def _proxy(request: Request, path: str) -> Response:
+    """Forward ``request`` to Lemonade and return the response.
+
+    The catch-all targets Lemonade's non-streaming surfaces (health,
+    stats, load, unload, system-info, params, …) — JSON in, JSON out,
+    bodies small enough that buffering is cheaper than the extra
+    streaming machinery. Lemonade's real streaming surfaces (the
+    /logs/stream WS and chat-completion SSE) are handled by dedicated
+    routers and don't fall through here.
+
+    Errors:
+      - When Lemonade is unreachable (connection refused, DNS, timeout)
+        we surface a 503 with a hal0-shaped envelope so the dashboard's
+        ``useLemonadeHealth`` hook treats it as 'lemond down' without
+        crashing.
+      - When Lemonade returns an error status, we propagate it verbatim
+        — the body + status code + content-type. Clients see Lemonade's
+        own envelope, not a hal0-rewrap.
+    """
+    base = _lemonade_base_url()
+    # ``path`` arrives without a leading slash courtesy of FastAPI's
+    # path converter; we anchor it ourselves so the upstream sees the
+    # full /v1/<path>.
+    target_url = f"{base}/v1/{path}"
+    headers = _filter_request_headers(request.headers)
+    body = await request.body()
+    params = list(request.query_params.multi_items())
+
+    # Cap the per-request timeout generously — Lemonade can take tens of
+    # seconds to load a model on /v1/load. Connect timeout is short so a
+    # dead daemon surfaces as 503 quickly instead of hanging the
+    # dashboard poll.
+    timeout = httpx.Timeout(connect=2.0, read=120.0, write=30.0, pool=5.0)
+
+    client = _build_client(timeout)
+    try:
+        try:
+            upstream_resp = await client.request(
+                method=request.method,
+                url=target_url,
+                headers=headers,
+                content=body if body else None,
+                params=params,
+            )
+        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+            envelope = {
+                "error": {
+                    "code": "lemonade.unavailable",
+                    "message": "lemonade is not reachable on loopback",
+                    "details": {"target": target_url, "reason": str(exc)},
+                }
+            }
+            return Response(
+                content=json.dumps(envelope).encode("utf-8"),
+                status_code=503,
+                media_type="application/json",
+            )
+        except httpx.HTTPError as exc:
+            envelope = {
+                "error": {
+                    "code": "lemonade.proxy_error",
+                    "message": "error forwarding request to lemonade",
+                    "details": {"target": target_url, "reason": str(exc)},
+                }
+            }
+            return Response(
+                content=json.dumps(envelope).encode("utf-8"),
+                status_code=502,
+                media_type="application/json",
+            )
+    finally:
+        await client.aclose()
+
+    response_headers = _filter_response_headers(upstream_resp.headers)
+    media_type = upstream_resp.headers.get("content-type")
+
+    return Response(
+        content=upstream_resp.content,
+        status_code=upstream_resp.status_code,
+        headers=response_headers,
+        media_type=media_type,
+    )
+
+
+# Catch-all. We register one handler per HTTP method so OpenAPI sees a
+# usable surface (FastAPI's "match any method" isn't well-supported on
+# path operations). ``path`` carries everything after ``/v1/``.
+#
+# HEAD intentionally omitted — Starlette derives HEAD from GET when the
+# response is streaming, which is the right behaviour here.
+
+
+@router.get("/{path:path}", include_in_schema=False)
+async def proxy_get(request: Request, path: str) -> Response:
+    return await _proxy(request, path)
+
+
+@router.post("/{path:path}", include_in_schema=False)
+async def proxy_post(request: Request, path: str) -> Response:
+    return await _proxy(request, path)
+
+
+@router.put("/{path:path}", include_in_schema=False)
+async def proxy_put(request: Request, path: str) -> Response:
+    return await _proxy(request, path)
+
+
+@router.delete("/{path:path}", include_in_schema=False)
+async def proxy_delete(request: Request, path: str) -> Response:
+    return await _proxy(request, path)
+
+
+@router.patch("/{path:path}", include_in_schema=False)
+async def proxy_patch(request: Request, path: str) -> Response:
+    return await _proxy(request, path)
+
+
+__all__ = ["router"]

--- a/tests/api/test_v1_proxy.py
+++ b/tests/api/test_v1_proxy.py
@@ -1,0 +1,291 @@
+"""Tests for the /v1/* reverse-proxy to Lemonade (issue #212).
+
+The proxy mounts a catch-all under ``/v1/{path:path}`` AFTER the
+dispatcher-owned v1 routers. These tests verify:
+
+  * Un-routed paths (/v1/health, /v1/stats, /v1/system-info) reach
+    Lemonade verbatim and the response body / status code round-trips.
+  * Dispatcher-owned paths (/v1/models, /v1/chat/completions) are NOT
+    swallowed by the catch-all — registration order keeps them on the
+    aggregator.
+  * Connection failure surfaces as a 503 with the
+    ``lemonade.unavailable`` envelope code so the dashboard hook can
+    render 'down' without crashing.
+  * Authorization + content-type headers cross the proxy unchanged.
+  * Query parameters round-trip (Lemonade's /v1/load takes a JSON body
+    but a future endpoint may use query params).
+  * Request method round-trips (POST body forwards verbatim).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from hal0.api.routes import lemonade_proxy
+
+# ── handler factory + monkeypatch seam ──────────────────────────────────────
+
+
+def _install_mock(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Any,
+) -> dict[str, Any]:
+    """Swap the proxy's ``_build_client`` for one wired to MockTransport.
+
+    Returns a state dict the handler can mutate to record what was
+    received — by reference so assertions in the calling test see
+    every recorded request.
+    """
+    state: dict[str, Any] = {"requests": []}
+
+    def _recording_handler(req: httpx.Request) -> httpx.Response:
+        state["requests"].append(
+            {
+                "method": req.method,
+                "url": str(req.url),
+                "path": req.url.path,
+                "headers": dict(req.headers),
+                "content": req.content,
+                "params": dict(req.url.params),
+            }
+        )
+        return handler(req)
+
+    def _fake_build_client(timeout: httpx.Timeout) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(_recording_handler),
+            timeout=timeout,
+        )
+
+    monkeypatch.setattr(lemonade_proxy, "_build_client", _fake_build_client)
+    return state
+
+
+@pytest.fixture
+def lemonade_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[dict[str, Any]]:
+    """Default fixture — Lemonade-up with the canonical /v1/health body."""
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        path = req.url.path
+        if path == "/v1/health":
+            return httpx.Response(
+                200,
+                json={
+                    "status": "ok",
+                    "version": "10.6.0",
+                    "loaded": [],
+                    "max_models": {"llm": 4},
+                },
+            )
+        if path == "/v1/stats":
+            return httpx.Response(200, json={"tokens_per_second": 42.5})
+        if path == "/v1/system-info":
+            return httpx.Response(200, json={"cpu": "ryzen", "gpu": "strix-halo"})
+        if path == "/v1/load":
+            return httpx.Response(200, json={"status": "loaded"})
+        if path == "/v1/echo-headers":
+            # Echo selected request headers back so the test can assert
+            # authorization + content-type round-trip.
+            echoed = {
+                k: req.headers.get(k, "")
+                for k in ("authorization", "content-type", "x-custom-marker")
+            }
+            return httpx.Response(200, json=echoed)
+        return httpx.Response(404, json={"error": f"unmocked {path}"})
+
+    state = _install_mock(monkeypatch, _handler)
+    yield state
+
+
+# ── basic round-trip ────────────────────────────────────────────────────────
+
+
+def test_v1_health_proxies_to_lemonade(client: TestClient, lemonade_state: dict[str, Any]) -> None:
+    """GET /v1/health hits the proxy → Lemonade's body returns verbatim."""
+    r = client.get("/v1/health")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["version"] == "10.6.0"
+    # The recorded request must have targeted Lemonade's loopback URL.
+    assert len(lemonade_state["requests"]) == 1
+    req = lemonade_state["requests"][0]
+    assert req["method"] == "GET"
+    assert req["path"] == "/v1/health"
+
+
+def test_v1_stats_proxies(client: TestClient, lemonade_state: dict[str, Any]) -> None:
+    r = client.get("/v1/stats")
+    assert r.status_code == 200
+    assert r.json() == {"tokens_per_second": 42.5}
+    assert lemonade_state["requests"][0]["path"] == "/v1/stats"
+
+
+def test_v1_system_info_proxies(client: TestClient, lemonade_state: dict[str, Any]) -> None:
+    """Nested-looking path (no nesting actually, just sanity)."""
+    r = client.get("/v1/system-info")
+    assert r.status_code == 200
+    assert r.json()["cpu"] == "ryzen"
+
+
+def test_v1_unknown_path_returns_lemonade_404(
+    client: TestClient, lemonade_state: dict[str, Any]
+) -> None:
+    """When the catch-all forwards an unknown path, Lemonade's 404 wins."""
+    r = client.get("/v1/this-is-not-real")
+    assert r.status_code == 404
+    # We expect Lemonade's envelope ("unmocked …"), not hal0's
+    # dispatch.no_route — the catch-all bypasses dispatcher entirely.
+    body = r.json()
+    assert "unmocked" in body.get("error", "")
+
+
+# ── dispatcher routes are NOT swallowed ─────────────────────────────────────
+
+
+def test_v1_models_still_handled_by_aggregator(
+    client: TestClient, lemonade_state: dict[str, Any]
+) -> None:
+    """GET /v1/models stays on the aggregator, NOT the proxy.
+
+    The aggregator returns ``{"object": "list", "data": []}`` when there
+    are no upstreams; the proxy would have returned Lemonade's
+    ``{"data": [], "object": "list"}`` (which has the SAME shape — but
+    we assert through the request recorder that the proxy was NEVER
+    invoked).
+    """
+    r = client.get("/v1/models")
+    assert r.status_code == 200
+    assert r.json() == {"object": "list", "data": []}
+    # The proxy must NOT have been touched.
+    assert lemonade_state["requests"] == []
+
+
+def test_v1_chat_completions_still_hits_dispatcher(
+    client: TestClient, lemonade_state: dict[str, Any]
+) -> None:
+    """POST /v1/chat/completions stays on the dispatcher path.
+
+    With no upstreams configured the dispatcher returns its own
+    ``dispatch.no_route`` envelope. The proxy must NOT have been
+    consulted.
+    """
+    r = client.post(
+        "/v1/chat/completions",
+        json={"model": "primary", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == "dispatch.no_route"
+    assert lemonade_state["requests"] == []
+
+
+# ── error paths ─────────────────────────────────────────────────────────────
+
+
+def test_v1_lemonade_unavailable_returns_503_envelope(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When Lemonade refuses the connection → 503 + lemonade.unavailable."""
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        # MockTransport doesn't simulate connection refused on its own —
+        # we raise ConnectError manually so the proxy's except branch
+        # fires.
+        raise httpx.ConnectError("Connection refused", request=req)
+
+    _install_mock(monkeypatch, _handler)
+
+    r = client.get("/v1/health")
+    assert r.status_code == 503
+    body = r.json()
+    assert body["error"]["code"] == "lemonade.unavailable"
+    assert "target" in body["error"]["details"]
+
+
+def test_v1_proxy_generic_http_error_returns_502_envelope(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-connect httpx errors surface as 502 with proxy_error code."""
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("upstream stalled", request=req)
+
+    _install_mock(monkeypatch, _handler)
+
+    r = client.get("/v1/stats")
+    assert r.status_code == 502
+    body = r.json()
+    assert body["error"]["code"] == "lemonade.proxy_error"
+
+
+# ── header + body passthrough ───────────────────────────────────────────────
+
+
+def test_v1_authorization_header_round_trips(
+    client: TestClient, lemonade_state: dict[str, Any]
+) -> None:
+    """Authorization + custom headers are forwarded verbatim to Lemonade."""
+    r = client.get(
+        "/v1/echo-headers",
+        headers={
+            "Authorization": "Bearer test-token-xyz",
+            "X-Custom-Marker": "hal0-test",
+        },
+    )
+    assert r.status_code == 200
+    echoed = r.json()
+    assert echoed["authorization"] == "Bearer test-token-xyz"
+    assert echoed["x-custom-marker"] == "hal0-test"
+
+
+def test_v1_host_header_is_stripped(client: TestClient, lemonade_state: dict[str, Any]) -> None:
+    """The inbound Host header must NOT propagate to Lemonade.
+
+    Forwarding the hal0-api Host (``hal0.thinmint.dev``) would confuse
+    Lemonade's URL parser. httpx sets its own Host from the target URL.
+    """
+    client.get("/v1/health")
+    forwarded = lemonade_state["requests"][0]["headers"]
+    # httpx sets host to the loopback target — never the original.
+    assert "127.0.0.1" in forwarded.get("host", "") or "lemonade" not in forwarded.get("host", "")
+
+
+def test_v1_post_body_forwards_verbatim(client: TestClient, lemonade_state: dict[str, Any]) -> None:
+    """POST /v1/load round-trips its JSON body to Lemonade."""
+    payload = {"model_name": "gemma3:1b", "backend": "flm"}
+    r = client.post("/v1/load", json=payload)
+    assert r.status_code == 200
+    req = lemonade_state["requests"][0]
+    assert req["method"] == "POST"
+    assert req["path"] == "/v1/load"
+    assert json.loads(req["content"].decode("utf-8")) == payload
+
+
+def test_v1_query_params_round_trip(client: TestClient, lemonade_state: dict[str, Any]) -> None:
+    """Query string forwards intact across the proxy."""
+    r = client.get("/v1/health?debug=1&verbose=true")
+    assert r.status_code == 200
+    params = lemonade_state["requests"][0]["params"]
+    assert params == {"debug": "1", "verbose": "true"}
+
+
+# ── env override ────────────────────────────────────────────────────────────
+
+
+def test_lemonade_base_url_honours_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The LEMONADE_BASE_URL env var re-points the proxy."""
+    monkeypatch.setenv("LEMONADE_BASE_URL", "http://lemond.local:9999/")
+    assert lemonade_proxy._lemonade_base_url() == "http://lemond.local:9999"
+
+
+def test_lemonade_base_url_defaults_to_loopback_13305(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LEMONADE_BASE_URL", raising=False)
+    assert lemonade_proxy._lemonade_base_url() == "http://127.0.0.1:13305"


### PR DESCRIPTION
Closes #212.

## Summary
- Adds a catch-all under `/v1/{path:path}` (in `src/hal0/api/routes/lemonade_proxy.py`) that forwards un-routed paths to Lemonade on loopback (default `http://127.0.0.1:13305`, overridable via `$LEMONADE_BASE_URL` — same env knob the OmniRouter already honours).
- Mounted AFTER `v1.public_router` + `v1.router` so every existing dispatcher-owned path (chat, completions, embeddings, rerankings, audio, images, models) keeps its handler unchanged. Only un-covered paths — `/v1/health`, `/v1/stats`, `/v1/load`, `/v1/unload`, `/v1/system-info`, `/v1/params`, … — fall through to Lemonade.
- Unblocks the v3 dashboard's `useLemonadeHealth` hook so the sidebar 'Lemonade · up' indicator works end-to-end after deploy.

## Mapping
| caller | → | lemonade |
|---|---|---|
| `GET  /v1/health`        | → | `GET  http://127.0.0.1:13305/v1/health`        |
| `GET  /v1/stats`         | → | `GET  http://127.0.0.1:13305/v1/stats`         |
| `POST /v1/load`          | → | `POST http://127.0.0.1:13305/v1/load`          |
| `POST /v1/unload`        | → | `POST http://127.0.0.1:13305/v1/unload`        |
| `GET  /v1/system-info`   | → | `GET  http://127.0.0.1:13305/v1/system-info`   |
| `GET  /v1/models`        | → | hal0 aggregator (unchanged — dispatcher-owned) |
| `POST /v1/chat/completions` | → | hal0 dispatcher (unchanged) |

Confirmed against live lemonade on hal0 LXC: both bare `/v1/*` and `/api/v1/*` work — we use bare `/v1/*` so the URL math is identity.

## Scope decisions
- **WebSocket out of scope for this PR.** The existing `lemonade_logs` router already proxies lemonade's `/logs/stream` WS as SSE under `/api/lemonade/logs/stream`. A generic `/v1` WS proxy is a follow-up issue if anything else needs it.
- **Auth:** same `_v1_auth = [Depends(require_token)]` gate as the rest of the writer /v1 surface. The dashboard already carries the session cookie.
- **Header hygiene:** Host + hop-by-hop stripped both directions; Authorization + custom headers round-trip verbatim.
- **Error envelopes:** `ConnectError` / `ConnectTimeout` → 503 `lemonade.unavailable`; other `httpx.HTTPError` → 502 `lemonade.proxy_error`; Lemonade's own non-2xx responses pass through unchanged.

## Tests
14 new in `tests/api/test_v1_proxy.py` (via `httpx.MockTransport` + a `_build_client` monkeypatch seam):
- `/v1/health`, `/v1/stats`, `/v1/system-info` round-trip
- `/v1/models` + `/v1/chat/completions` still on dispatcher (not swallowed)
- Connection-refused → 503 envelope; generic httpx error → 502 envelope
- Authorization + custom headers round-trip; Host stripped
- POST body forwards verbatim; query params round-trip
- `LEMONADE_BASE_URL` env override + default

Full `tests/api/` suite: 624 prior + 14 new = 638 passed, 8 skipped (unrelated).

## Test plan
- [ ] Merge to `feat/dash-v3-react`, restart hal0-api on hal0 LXC.
- [ ] `curl http://127.0.0.1:8080/v1/health` (or via session cookie from the dashboard) returns Lemonade's JSON envelope.
- [ ] React dashboard sidebar shows 'Lemonade · up' instead of 'connecting' / 'down'.
- [ ] `curl http://127.0.0.1:8080/v1/models` still returns hal0's aggregated catalogue (dispatcher path).
- [ ] Stop lemond → dashboard sidebar flips to 'down' within 2s.