### PR TITLE
fix(ui-v3): normalize /api/slots — defaults for missing .metrics / .spark / .model (deferred fix from v3 cutover handoff)

### DIFF
--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -50,6 +50,36 @@ export interface Slot {
 const SLOTS_POLL_MS = 5_000
 const SLOT_DETAIL_POLL_MS = 2_500
 
+// Backend /api/slots can omit `metrics` (and other fields) for offline /
+// not-yet-loaded slots. Components dereference `slot.metrics.toks` etc.
+// directly, so guarantee a present object with neutral defaults.
+const DEFAULT_METRICS: SlotMetrics = {
+  toks: 0,
+  ttft: null,
+  ctx: 0,
+  kv: null,
+  mem: 0,
+  rpm: 0,
+  lat: null,
+  dim: 0,
+  xrt: 0,
+  precision: '',
+  maxDocs: 0,
+  secs: 0,
+  voice: '',
+  avg: 0,
+  res: '',
+}
+
+function normalizeSlot(s: any): Slot {
+  return {
+    ...s,
+    metrics: { ...DEFAULT_METRICS, ...(s?.metrics ?? {}) },
+    spark: Array.isArray(s?.spark) ? s.spark : [],
+    model: s?.model ?? s?.model_id ?? s?.model_default ?? '',
+  }
+}
+
 async function fetchSlotsUnion(): Promise<Slot[]> {
   // Race /api/status (which may have stale slot list) + /api/slots
   // (authoritative for real slots). Real wins on conflict.
@@ -71,7 +101,7 @@ async function fetchSlotsUnion(): Promise<Slot[]> {
   const byName = new Map<string, Slot>()
   for (const s of statusSlots) byName.set(s.name, s)
   for (const s of realSlots) byName.set(s.name, s)
-  return [...byName.values()]
+  return [...byName.values()].map(normalizeSlot)
 }
 
 export function useSlots(): UseQueryResult<Slot[]> {
@@ -89,7 +119,7 @@ export function useSlots(): UseQueryResult<Slot[]> {
 export function useSlotDetail(name: string | null | undefined): UseQueryResult<Slot> {
   return useQuery({
     queryKey: ['slots', name],
-    queryFn: () => apiGet<Slot>(ENDPOINTS.slot(name as string)),
+    queryFn: async () => normalizeSlot(await apiGet<any>(ENDPOINTS.slot(name as string))),
     enabled: !!name,
     refetchInterval: SLOT_DETAIL_POLL_MS,
   })


### PR DESCRIPTION
## Summary

After PR #235 landed v3 on main, the slots/hardware/dashboard pages black-screened on real backend payloads because v3 components dereference `slot.metrics.toks`, `slot.metrics.kv`, `slot.spark`, etc. directly, and the backend can omit those fields for offline / not-yet-loaded slots.

This was the deferred fix called out in the v3 cutover handoff:

> Two known React crash points still exist (deferred):
> - `slot.metrics.toks` and friends crash when /api/slots returns slots without a `metrics` field (real backend behavior). Proper fix: add a normalizer in `ui/src/api/hooks/useSlots.ts` that defaults `metrics: { toks: 0, ttft: 0, kv: 0, ... }` when absent.

## Change

`useSlots.ts` gains a `normalizeSlot()` helper applied in both `fetchSlotsUnion` and `useSlotDetail`:

- `metrics` defaults to a full `SlotMetrics` shape (toks 0, ttft null, kv null, …)
- `spark` defaults to `[]` (guards `<Spark data={slot.spark} />` rendering)
- `model` falls back `model → model_id → model_default → ''`

One change covers all 20+ `slot.metrics.*` access sites in `slots.jsx` / `dashboard.jsx` / `slot-modals.jsx`.

## Why hot-patch first, PR after

The LXC at `hal0.thinmint.dev` was hot-patched (same byte content as this commit) and rebuilt before this PR went up, so the dashboard is already rendering. This PR brings `main` in sync.

## Known follow-up not in scope

- #236 — `apiMock` fixture rewrite to match Phase B1 hook shapes (γ-suite still red; that's the test-harness side of the same shape mismatch)

## Test plan

- [ ] CI: python (3.11, 3.12) + ui green
- [ ] γ-suite expected to stay red (pre-existing per #236)
- [ ] Smoke on hal0.thinmint.dev: /, /#slots, /#hardware all render with at least one offline primary slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)