### PR TITLE
fix(ui-v3): normalize slot shape in useSlots hook

### DIFF
--- a/ui/src/api/hooks/useBackends.ts
+++ b/ui/src/api/hooks/useBackends.ts
@@ -28,17 +28,46 @@ export interface LemonadeSelf {
 const POLL_MS = 30_000
 const SNAPSHOT_POLL_MS = 5_000
 
+/**
+ * Normalize a backend row. Defaults `usedBy: []` and `state: 'unavailable'`
+ * so views that iterate `b.usedBy` or branch on state don't crash on
+ * partial backend data.
+ */
+export function normalizeBackend(raw: any): Backend {
+  const src = (raw && typeof raw === 'object') ? raw : {}
+  return {
+    id: typeof src.id === 'string' ? src.id : (typeof src.name === 'string' ? src.name : ''),
+    version: typeof src.version === 'string' ? src.version : (typeof src.ver === 'string' ? src.ver : ''),
+    state: typeof src.state === 'string' ? src.state : 'unavailable',
+    usedBy: Array.isArray(src.usedBy) ? src.usedBy.filter((x: any) => typeof x === 'string') : [],
+    recommended: !!src.recommended,
+    note: typeof src.note === 'string' ? src.note : undefined,
+    kind: typeof src.kind === 'string' ? src.kind : undefined,
+    device: typeof src.device === 'string' ? src.device : undefined,
+  }
+}
+
+function normalizeLemonadeSelf(raw: any): LemonadeSelf | null {
+  if (!raw || typeof raw !== 'object') return null
+  return {
+    version: typeof raw.version === 'string' ? raw.version : null,
+    pinned: typeof raw.pinned === 'boolean' ? raw.pinned : null,
+    sha: typeof raw.sha === 'string' ? raw.sha : null,
+    channel: typeof raw.channel === 'string' ? raw.channel : null,
+  }
+}
+
 export function useBackends() {
   return useQuery({
     queryKey: ['backends'],
     queryFn: async () => {
       const body = await apiGet<any>(ENDPOINTS.backends)
-      if (Array.isArray(body)) {
-        return { backends: body as Backend[], lemonade: null as LemonadeSelf | null }
-      }
+      const arr = Array.isArray(body)
+        ? body
+        : (Array.isArray(body?.backends) ? body.backends : [])
       return {
-        backends: (Array.isArray(body?.backends) ? body.backends : []) as Backend[],
-        lemonade: (body?.lemonade ?? null) as LemonadeSelf | null,
+        backends: arr.map(normalizeBackend),
+        lemonade: normalizeLemonadeSelf(Array.isArray(body) ? null : body?.lemonade),
       }
     },
     refetchInterval: POLL_MS,
@@ -49,9 +78,16 @@ export function useBackends() {
 export function useBackendSnapshot(id: string | null | undefined) {
   return useQuery({
     queryKey: ['backends', id],
-    queryFn: () => apiGet<Backend & { loaded?: Array<{ model_name: string; slot: string }> }>(
-      ENDPOINTS.backend(id as string),
-    ),
+    queryFn: async () => {
+      const raw = await apiGet<any>(ENDPOINTS.backend(id as string))
+      const base = normalizeBackend(raw)
+      const loaded = Array.isArray(raw?.loaded)
+        ? raw.loaded.filter((m: any) => m && typeof m === 'object')
+        : []
+      return { ...base, loaded } as Backend & {
+        loaded: Array<{ model_name: string; slot: string }>
+      }
+    },
     enabled: !!id,
     refetchInterval: SNAPSHOT_POLL_MS,
   })

--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -31,14 +31,42 @@ export interface Model {
 
 const MODELS_POLL_MS = 30_000
 
+/**
+ * Normalize a model row from the wire. Mirrors the HAL0_DATA mock
+ * in ui/src/dash/data.jsx. Critical default: `labels: []` — models.jsx
+ * does `model.labels.map(...)` unguarded.
+ */
+export function normalizeModel(raw: any): Model {
+  const src = (raw && typeof raw === 'object') ? raw : {}
+  return {
+    id: typeof src.id === 'string' ? src.id : '',
+    longName: typeof src.longName === 'string' ? src.longName : (src.id ?? ''),
+    repo: typeof src.repo === 'string' ? src.repo : '',
+    params: typeof src.params === 'string' ? src.params : '',
+    size: typeof src.size === 'string' ? src.size : '',
+    labels: Array.isArray(src.labels) ? src.labels.filter((x: any) => typeof x === 'string') : [],
+    type: typeof src.type === 'string' ? src.type : 'llm',
+    device: typeof src.device === 'string' ? src.device : 'cpu',
+    ns: typeof src.ns === 'string' ? src.ns : 'pulled',
+    installed: !!src.installed,
+    runtime: typeof src.runtime === 'string' ? src.runtime : '',
+  }
+}
+
+function normalizeModels(raw: any): Model[] {
+  if (!Array.isArray(raw)) return []
+  return raw.map(normalizeModel)
+}
+
 export function useModels() {
   return useQuery({
     queryKey: ['models'],
     queryFn: async () => {
       const body = await apiGet<any>(ENDPOINTS.models)
-      if (Array.isArray(body)) return body as Model[]
-      if (Array.isArray(body?.models)) return body.models as Model[]
-      return []
+      const arr = Array.isArray(body)
+        ? body
+        : (Array.isArray(body?.models) ? body.models : [])
+      return normalizeModels(arr)
     },
     refetchInterval: MODELS_POLL_MS,
   })
@@ -47,7 +75,7 @@ export function useModels() {
 export function useModel(id: string | null | undefined) {
   return useQuery({
     queryKey: ['models', id],
-    queryFn: () => apiGet<Model>(ENDPOINTS.model(id as string)),
+    queryFn: async () => normalizeModel(await apiGet<any>(ENDPOINTS.model(id as string))),
     enabled: !!id,
   })
 }

--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -12,21 +12,21 @@ import { apiDelete, apiGet, apiPost } from '../client'
 import { ENDPOINTS } from '../endpoints'
 
 export interface SlotMetrics {
-  toks?: number
-  ttft?: number | null
-  ctx?: number
-  kv?: number | null
-  mem?: number
-  rpm?: number
-  lat?: number | null
-  dim?: number
-  xrt?: number
-  precision?: string
-  maxDocs?: number
-  secs?: number
-  voice?: string
-  avg?: number
-  res?: string
+  toks: number
+  ttft: number | null
+  ctx: number
+  kv: number | null
+  mem: number
+  rpm: number
+  lat: number | null
+  dim: number
+  xrt: number
+  precision: string
+  maxDocs: number
+  secs: number
+  voice: string
+  avg: number
+  res: string
 }
 
 export interface Slot {
@@ -50,11 +50,72 @@ export interface Slot {
 const SLOTS_POLL_MS = 5_000
 const SLOT_DETAIL_POLL_MS = 2_500
 
+/**
+ * Default SlotMetrics. Every numeric field defaults to 0, nullable
+ * lat/kv/ttft default to null (components treat null as "—"), strings
+ * default to "". Components do `.toFixed()`/`.replace()` on these
+ * unguarded, so partial backend data MUST be filled in before render.
+ */
+function defaultMetrics(): SlotMetrics {
+  return {
+    toks: 0,
+    ttft: null,
+    ctx: 0,
+    kv: null,
+    mem: 0,
+    rpm: 0,
+    lat: null,
+    dim: 0,
+    xrt: 0,
+    precision: '',
+    maxDocs: 0,
+    secs: 0,
+    voice: '',
+    avg: 0,
+    res: '',
+  }
+}
+
+/**
+ * Normalize a slot from the wire into a shape every component can
+ * read without crashing. Root cause this guards against: real
+ * `/api/slots` rows arrive WITHOUT a `metrics` field, so e.g.
+ * `s.metrics.toks` throws TypeError and unmounts the React tree.
+ *
+ * Mirrors the HAL0_DATA mock contract in ui/src/dash/data.jsx.
+ */
+export function normalizeSlot(raw: any): Slot {
+  const src = (raw && typeof raw === 'object') ? raw : {}
+  const m = (src.metrics && typeof src.metrics === 'object') ? src.metrics : {}
+  return {
+    name: typeof src.name === 'string' ? src.name : '',
+    type: typeof src.type === 'string' ? src.type : 'llm',
+    device: typeof src.device === 'string' ? src.device : 'cpu',
+    state: typeof src.state === 'string' ? src.state : 'offline',
+    model: typeof src.model === 'string' ? src.model : '',
+    model_id: src.model_id ?? undefined,
+    modelLong: src.modelLong ?? undefined,
+    group: src.group ?? undefined,
+    isDefault: !!src.isDefault,
+    coresident: !!src.coresident,
+    cpuOnly: !!src.cpuOnly,
+    port: typeof src.port === 'number' ? src.port : undefined,
+    pid: typeof src.pid === 'number' ? src.pid : undefined,
+    spark: Array.isArray(src.spark) ? src.spark : undefined,
+    metrics: { ...defaultMetrics(), ...m },
+  }
+}
+
+function normalizeSlots(raw: any): Slot[] {
+  if (!Array.isArray(raw)) return []
+  return raw.map(normalizeSlot)
+}
+
 async function fetchSlotsUnion(): Promise<Slot[]> {
   // Race /api/status (which may have stale slot list) + /api/slots
   // (authoritative for real slots). Real wins on conflict.
-  let statusSlots: Slot[] = []
-  let realSlots: Slot[] = []
+  let statusSlots: any[] = []
+  let realSlots: any[] = []
   try {
     const s = await apiGet<any>(ENDPOINTS.status)
     statusSlots = Array.isArray(s?.slots) ? s.slots : []
@@ -69,8 +130,14 @@ async function fetchSlotsUnion(): Promise<Slot[]> {
     // soft-fail; statusSlots covers
   }
   const byName = new Map<string, Slot>()
-  for (const s of statusSlots) byName.set(s.name, s)
-  for (const s of realSlots) byName.set(s.name, s)
+  for (const s of statusSlots) {
+    const n = normalizeSlot(s)
+    if (n.name) byName.set(n.name, n)
+  }
+  for (const s of realSlots) {
+    const n = normalizeSlot(s)
+    if (n.name) byName.set(n.name, n)
+  }
   return [...byName.values()]
 }
 
@@ -89,7 +156,10 @@ export function useSlots(): UseQueryResult<Slot[]> {
 export function useSlotDetail(name: string | null | undefined): UseQueryResult<Slot> {
   return useQuery({
     queryKey: ['slots', name],
-    queryFn: () => apiGet<Slot>(ENDPOINTS.slot(name as string)),
+    queryFn: async () => {
+      const raw = await apiGet<any>(ENDPOINTS.slot(name as string))
+      return normalizeSlot(raw)
+    },
     enabled: !!name,
     refetchInterval: SLOT_DETAIL_POLL_MS,
   })

--- a/ui/tests/e2e/fixtures/apiMock.ts
+++ b/ui/tests/e2e/fixtures/apiMock.ts
@@ -50,8 +50,22 @@ export async function installDefaultMocks(page: Page, state: MockState) {
 
   // Catch-all FIRST so per-route registrations after this win
   // (Playwright matches routes in reverse-registration order).
-  await page.route('**/api/**', (route) => json(route, {}))
-  await page.route('**/v1/**', (route) => json(route, {}))
+  //
+  // IMPORTANT: glob `**/api/**` matches ANY path containing `/api/` — that
+  // includes Vite-served source modules like `/src/api/hooks/useSlots.ts`,
+  // which then get fulfilled with `{}` (application/json) and refuse to load
+  // as ESM modules ("Expected JavaScript module" MIME error). The React tree
+  // never mounts.
+  //
+  // Scope the catch-all to absolute /api/* + /v1/* on the origin (i.e. paths
+  // that start with /api/ or /v1/) so dev-server module URLs pass through.
+  await page.route(/\/(api|v1)\//, (route) => {
+    const u = new URL(route.request().url())
+    if (u.pathname.startsWith('/api/') || u.pathname.startsWith('/v1/')) {
+      return json(route, {})
+    }
+    return route.continue()
+  })
 
   await page.route('**/api/status', (route) =>
     json(route, {

--- a/ui/tests/e2e/specs/slots-empty-metrics.spec.ts
+++ b/ui/tests/e2e/specs/slots-empty-metrics.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * slots-empty-metrics — regression guard for the flash-then-crash on the
+ * Slots + Dashboard pages. Backend returns slot rows WITHOUT a `metrics`
+ * field; the React tree must not unmount.
+ *
+ * Root cause: `s.metrics.toks` in SnapshotStrip / SlotCard threw
+ * TypeError when `metrics` was undefined. Fixed by `normalizeSlot` in
+ * the useSlots hook (defaults the metrics shape).
+ */
+import { test, expect } from '../fixtures/apiMock'
+import { MOCK_DATA, json } from '../fixtures/apiMock'
+
+// Strip `metrics` + `spark` from every slot so we mimic a real backend
+// that doesn't ship the prototype's mock-only metrics envelope.
+function slotsWithoutMetrics() {
+  return MOCK_DATA.slots.map((s: any) => {
+    const { metrics, spark, ...bare } = s
+    return bare
+  })
+}
+
+test.describe('Slots — empty metrics (defensive normalizer)', () => {
+  test.beforeEach(async ({ page }) => {
+    const bare = slotsWithoutMetrics()
+    // Override the default mocks: same routes, bare slots.
+    await page.route('**/api/status', (route) =>
+      json(route, {
+        version: MOCK_DATA.lemond.version,
+        update_available: false,
+        slots: bare,
+        hardware: MOCK_DATA.host,
+      }),
+    )
+    await page.route('**/api/slots', (route) => json(route, { slots: bare }))
+  })
+
+  test('Dashboard renders without JS errors on metrics-less slots', async ({ page }) => {
+    const errors: string[] = []
+    page.on('pageerror', (err) => errors.push(err.message))
+
+    await page.goto('/')
+    await expect(page.locator('.topbar')).toBeVisible()
+    await expect(page.locator('.main .view')).toBeVisible()
+    await expect(page.locator('.snap')).toBeVisible()
+    // Let React Query settle a couple of refetch cycles.
+    await page.waitForTimeout(500)
+
+    // Filter out the Vite dev-server HMR WebSocket failure (config points
+    // HMR at hal0.thinmint.dev, which is unreachable from CI/headless).
+    // We only care about app-level crashes.
+    const appErrors = errors.filter((m) => !/WebSocket/.test(m))
+    expect(appErrors, appErrors.join('\n')).toHaveLength(0)
+  })
+
+  test('Slots view renders cards without crashing', async ({ page }) => {
+    const errors: string[] = []
+    page.on('pageerror', (err) => errors.push(err.message))
+
+    await page.goto('/#slots')
+    await expect(page.locator('.view .vh h1')).toHaveText('Slots')
+    await expect(page.locator('.view .sec h2').first()).toBeVisible()
+    const cards = page.locator('.slots-grid > *, .slots-list > *')
+    expect(await cards.count()).toBeGreaterThan(0)
+    await page.waitForTimeout(500)
+
+    // Filter out the Vite dev-server HMR WebSocket failure (config points
+    // HMR at hal0.thinmint.dev, which is unreachable from CI/headless).
+    // We only care about app-level crashes.
+    const appErrors = errors.filter((m) => !/WebSocket/.test(m))
+    expect(appErrors, appErrors.join('\n')).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Root cause

Real `/api/slots` returns slot rows **without a `metrics` field**. The v3 React components (SnapshotStrip, SlotCard, PersonaPicker, slot-modals) read `s.metrics.toks` / `metrics.mem.toFixed()` / `metrics.precision` unguarded, throwing TypeError on first paint and unmounting the React tree — the flash-then-crash users hit on Dashboard + Slots after auth was disabled.

Earlier fix (PR #N — sed sweep of per-call defensive guards) corrupted `dashboard.jsx` and was reverted in d67f7ea. This lands the proper fix at the **hook layer**.

## Summary

- **`useSlots`**: adds `normalizeSlot()` adapter applied to list, detail, and status-union responses. Every metric field defaults to a safe value matching the `HAL0_DATA` mock contract in `ui/src/dash/data.jsx` (numbers → 0, nullable → null, strings → "").
- **`useModels`**: adds `normalizeModel()`. Defaults `labels: []` — `models.jsx:174` does `model.labels.map(...)` unguarded.
- **`useBackends`**: adds `normalizeBackend()`. Defaults `usedBy: []` + `state: 'unavailable'`.
- **`useLemonade`**: already defensive (`loaded: []` default); no change needed.
- **apiMock fixture**: the `**/api/**` catch-all glob was matching Vite source modules like `/src/api/hooks/useSlots.ts` and fulfilling them with `{}` (application/json), so the React tree never mounted under e2e. Tightened to absolute `/api/` + `/v1/` pathnames only. Unblocked the entire Phase B2 suite as a side effect.
- **New spec**: `ui/tests/e2e/specs/slots-empty-metrics.spec.ts` boots Dashboard + Slots against a backend that returns slots WITHOUT a `metrics` field; asserts no pageerror fires.

## Anti-scope respected

- Component markup unchanged (fix is at the hook layer)
- HAL0_DATA mock structure unchanged (`VITE_MOCK_LEMONADE=1` path unaffected — normalizers are pass-through on full-shape input)
- No new endpoints
- No other slice work touched

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npx playwright test` → 23 passed / 7 skipped (MCP + agent specs pre-skipped at source)
- [x] New `slots-empty-metrics` spec green: Dashboard + Slots both render with metrics-less slot rows, no JS errors
- [ ] Manual smoke against real backend with `VITE_MOCK_LEMONADE=0` (deferred — backend not on this worktree's host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)