### PR TITLE
fix(ui-v3): footer chips honor backend null (closes #221)

### DIFF
--- a/ui/src/api/hooks/useLemonade.ts
+++ b/ui/src/api/hooks/useLemonade.ts
@@ -22,6 +22,12 @@ export interface LemonadeHealth {
   max_loaded: number | null
   version: string | null
   throughput_mbps: number | null
+  // Lemonade /v1/health does not currently surface a queue depth or a
+  // coresident rollup (see hal0_lemonade_v1_load_schema). The hook
+  // preserves them as `null` so the UI can distinguish "not surfaced"
+  // from "really zero" and hide chips that have no real signal yet.
+  queued: number | null
+  coresident: boolean | null
 }
 
 export interface LemonadeStats {
@@ -47,6 +53,9 @@ export function useLemonadeHealth(): UseQueryResult<LemonadeHealth> {
         version: typeof body?.version === 'string' ? body.version : null,
         throughput_mbps:
           typeof body?.throughput_mbps === 'number' ? body.throughput_mbps : null,
+        // Explicit null (NOT 0) when the field is missing — see #221.
+        queued: typeof body?.queued === 'number' ? body.queued : null,
+        coresident: typeof body?.coresident === 'boolean' ? body.coresident : null,
       }
     },
     refetchInterval: POLL_HEALTH_MS,
@@ -86,8 +95,11 @@ export function useLemondRollup() {
     loaded: h?.loaded.length ?? 0,
     budget: h?.max_loaded ?? 4,
     throughput: h?.throughput_mbps ?? null,
-    queued: 0,
-    coresident: true,
+    // queued + coresident are null until Lemonade exposes them on
+    // /v1/health (#221, follow-up filed). Chips that consume these
+    // guard with `!= null` so they hide instead of lying with 0.
+    queued: h?.queued ?? null,
+    coresident: h?.coresident ?? null,
     lastTtft: stats.data?.time_to_first_token ?? null,
     lastTokPerSec: stats.data?.tokens_per_second ?? null,
   }

--- a/ui/src/api/mock.ts
+++ b/ui/src/api/mock.ts
@@ -37,6 +37,11 @@ function buildHealth() {
     max_loaded: L.budget ?? 4,
     version: L.version ?? 'v10.6.0',
     throughput_mbps: L.throughput ?? null,
+    // #221 — `queued` + `coresident` round-trip via the mock so the demo
+    // chips keep rendering. Lemonade itself does not surface these on
+    // /v1/health today; production hides the chips when they're absent.
+    queued: typeof L.queued === 'number' ? L.queued : null,
+    coresident: typeof L.coresident === 'boolean' ? L.coresident : null,
   }
 }
 

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -178,10 +178,12 @@ function SidebarStatusBlock({ onGo }) {
         <span className="k">loaded</span>
         <span className="v"><b>{L.loaded}</b>/{L.budget}</span>
       </div>
-      <div className="row">
-        <span className="k">npu</span>
-        <span className="v" style={{color: "var(--dev-npu)"}}><span className="dot" />coresident</span>
-      </div>
+      {L.coresident && (
+        <div className="row">
+          <span className="k">npu</span>
+          <span className="v" style={{color: "var(--dev-npu)"}}><span className="dot" />coresident</span>
+        </div>
+      )}
       <div className="nudge" onClick={() => onGo("logs")}>View runtime logs →</div>
     </div>
   );
@@ -270,15 +272,19 @@ function Footer({ updateAvailable = true, expanded = false, onToggle, journal = 
           <span className="k">loaded</span>
           <span className="v num">{L.loaded}/{L.budget}</span>
         </div>
-        <div className="foot-chip" style={{ color: "var(--dev-npu)" }}>
-          <span className="dot" />
-          <span className="k">npu</span>
-          <span className="v">coresident</span>
-        </div>
-        <div className="foot-chip">
-          <span className="k">queued</span>
-          <span className="v num">{L.queued}</span>
-        </div>
+        {L.coresident && (
+          <div className="foot-chip" style={{ color: "var(--dev-npu)" }}>
+            <span className="dot" />
+            <span className="k">npu</span>
+            <span className="v">coresident</span>
+          </div>
+        )}
+        {L.queued != null && (
+          <div className="foot-chip">
+            <span className="k">queued</span>
+            <span className="v num">{L.queued}</span>
+          </div>
+        )}
         {updateAvailable && (
           <div className="foot-chip accent">
             <span className="k">●</span>

--- a/ui/tests/e2e/fixtures/apiMock.ts
+++ b/ui/tests/e2e/fixtures/apiMock.ts
@@ -50,8 +50,12 @@ export async function installDefaultMocks(page: Page, state: MockState) {
 
   // Catch-all FIRST so per-route registrations after this win
   // (Playwright matches routes in reverse-registration order).
-  await page.route('**/api/**', (route) => json(route, {}))
-  await page.route('**/v1/**', (route) => json(route, {}))
+  //
+  // Patterns are anchored on the URL origin so they don't accidentally
+  // intercept Vite module imports under `/src/api/…` (which would be
+  // fulfilled with JSON and break React mount with a MIME error).
+  await page.route(/^https?:\/\/[^/]+\/api\//, (route) => json(route, {}))
+  await page.route(/^https?:\/\/[^/]+\/v1\//, (route) => json(route, {}))
 
   await page.route('**/api/status', (route) =>
     json(route, {

--- a/ui/tests/e2e/specs/footer-chips-v3.spec.ts
+++ b/ui/tests/e2e/specs/footer-chips-v3.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * footer-chips-v3 — issue #221.
+ *
+ * The footer "queued" chip used to render `L.queued` which the hook
+ * hardcoded to 0 (lemond never surfaced the field). The "coresident"
+ * chip in both the footer and the sidebar status block was a literal
+ * string with no backend signal. Both now honor `null` by hiding.
+ *
+ * Spec runs against the MOCK_LEMONADE-forced dev server. `buildHealth`
+ * round-trips HAL0_DATA.lemond.{queued,coresident} so the demo keeps
+ * showing the chips; clearing those fields in `HAL0_DATA` simulates a
+ * lemond build that doesn't surface them yet, and the chips hide.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+test.describe('Footer chips honor backend null (#221)', () => {
+  test('queued + coresident chips appear with default HAL0_DATA', async ({ page }) => {
+    await page.goto('/')
+    const footer = page.locator('.footer')
+    await expect(footer).toBeVisible()
+    // Give the 2s health poll a chance to resolve.
+    await expect(page.locator('.sb-status .row .v', { hasText: /^v\d/ })).toBeVisible({ timeout: 6_000 })
+
+    const queuedChip = footer.locator('.foot-chip', { has: page.locator('.k', { hasText: /^queued$/ }) })
+    await expect(queuedChip).toBeVisible()
+    // HAL0_DATA seeds queued=0 — chip should render the literal "0".
+    await expect(queuedChip.locator('.v')).toHaveText('0')
+
+    const npuChip = footer.locator('.foot-chip', { has: page.locator('.k', { hasText: /^npu$/ }) })
+    await expect(npuChip).toBeVisible()
+    await expect(npuChip.locator('.v')).toHaveText('coresident')
+
+    const sidebarNpu = page.locator('.sb-status .row .k', { hasText: /^npu$/ })
+    await expect(sidebarNpu).toBeVisible()
+  })
+
+  test('queued + coresident chips hidden when fields absent from health', async ({ page }) => {
+    // Clobber HAL0_DATA.lemond.{queued,coresident} BEFORE dash modules
+    // load. The mock harness reads HAL0_DATA lazily on every fetch, so
+    // by the time /v1/health is called the rollup will see undefined →
+    // hook coerces to null → chips hide.
+    await page.addInitScript(() => {
+      const id = setInterval(() => {
+        const d = (window as any).HAL0_DATA
+        if (d && d.lemond) {
+          d.lemond.queued = undefined
+          d.lemond.coresident = undefined
+          clearInterval(id)
+        }
+      }, 5)
+    })
+
+    await page.goto('/')
+    const footer = page.locator('.footer')
+    await expect(footer).toBeVisible()
+    // Wait for sidebar rollup to repaint with hook data.
+    await expect(page.locator('.sb-status .row .v', { hasText: /^v\d/ })).toBeVisible({ timeout: 6_000 })
+    // Extra beat so the second health poll lands.
+    await page.waitForTimeout(2_500)
+
+    const queuedChip = footer.locator('.foot-chip', { has: page.locator('.k', { hasText: /^queued$/ }) })
+    await expect(queuedChip).toHaveCount(0)
+
+    const npuChip = footer.locator('.foot-chip', { has: page.locator('.k', { hasText: /^npu$/ }) })
+    await expect(npuChip).toHaveCount(0)
+
+    const sidebarNpu = page.locator('.sb-status .row .k', { hasText: /^npu$/ })
+    await expect(sidebarNpu).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
Closes #221. Follow-up issue #251 filed for the backend side.

## Summary

Issue #221 flagged two footer chrome regressions in the v3 React dash:

1. The footer **queued** chip read `L.queued` from `useLemondRollup`,
   but the hook hardcoded `queued: 0` because Lemonade does not expose
   a queue depth on `/v1/health` (verified directly against hal0 LXC
   10.6.0).
2. The footer + sidebar **coresident** chips were literal strings — no
   backend signal behind them either.

Result: both chips lied about steady-state.

## Decision: Option A (hide on null), with mock continuity

The issue spec gave Options A (hide) or B (wire to backend). Backend
check confirmed Lemonade ships nothing usable — `/v1/health` returns
`status/version/loaded/max_models/websocket_port`, full stop; `/v1/stats`
is per-request perf. So Option A for now, with the backend follow-up
tracked at #251 (computing the rollup server-side in hal0-api is the
likely route, since Lemonade upstream releases weekly and would need
patching anyway).

## Changes

- **`ui/src/api/hooks/useLemonade.ts`** — `LemonadeHealth` now carries
  explicit `queued: number | null` and `coresident: boolean | null`.
  The hook coerces missing fields to `null` (not `0`/`true`) so callers
  can disambiguate "not surfaced" from "really zero". `useLemondRollup`
  forwards both.
- **`ui/src/dash/chrome.jsx`** — footer queued chip guards on
  `L.queued != null`; footer + sidebar coresident chips guard on
  `L.coresident` being truthy. Hidden when backend doesn't say.
- **`ui/src/api/mock.ts`** — `buildHealth()` round-trips
  `HAL0_DATA.lemond.{queued,coresident}` so the MOCK_LEMONADE-forced
  dev/demo build keeps showing the chips (anti-scope: demo continuity
  preserved without changing HAL0_DATA itself).
- **`ui/tests/e2e/fixtures/apiMock.ts`** — bonus drive-by: the
  `**/api/**` and `**/v1/**` catch-all globs were matching Vite's
  `/src/api/client.ts` module imports during E2E, breaking React mount
  on every spec on this branch. Re-anchored the patterns on the URL
  origin via regex (`/^https?:\/\/[^/]+\/api\//`). Restored 22 specs
  that were red on the base commit.
- **`ui/tests/e2e/specs/footer-chips-v3.spec.ts`** — new spec, 2 tests:
  chips render with default HAL0_DATA values; chips hide when the
  `queued`/`coresident` fields are clobbered to `undefined` via
  `addInitScript`.

## Test plan

- [x] `npm install` clean
- [x] `npm run build` clean (113 modules, 474 KB)
- [x] `npx tsc --noEmit` clean
- [x] `npm run test:e2e` — 23 passed / 0 failed / 7 skipped (was 0
      passed / 23 failed on base due to the fixture glob bug)
- [x] `ruff format --check && ruff check` — clean (no python touched)
- [x] Verified against live Lemonade on hal0 LXC:
      `curl 127.0.0.1:13305/api/v1/health` returns no queue/coresident
      fields; production build hides both chips

## Out of scope

- `mcp-main.jsx` has its own hardcoded "coresident" footer chip backed
  by `HAL0_DATA.lemond` (not the rollup hook). It's a v0.3 mock page,
  not the v3 live footer; left alone per the issue's anti-scope.
- HAL0_DATA mock keeps `queued: 0` + `coresident: true` so demo
  screenshots stay consistent.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>