### PR TITLE
fix(ui-v3): infer slot type/group + normalize /api/hardware so slots/hardware render

### DIFF
--- a/ui/src/api/hooks/useHardware.ts
+++ b/ui/src/api/hooks/useHardware.ts
@@ -18,12 +18,44 @@ export interface Hardware {
   npu?: { present: boolean; columns?: number; ctx?: number }
 }
 
+// Backend /api/hardware returns a flat shape (cpu_model, ram_mb, gpu_name,
+// npu.{present}, …). HardwareView dereferences nested fields like
+// H.ram.total, H.npu.columns directly — passing the raw response makes
+// the page crash with "Cannot read properties of undefined". Normalize
+// into the v3 component shape, falling back to neutral defaults for
+// fields the backend doesn't surface (columns/ctx, hostname, uptime).
+function normalizeHardware(raw: any): Hardware {
+  const ramTotalMb = Number(raw?.ram_mb ?? raw?.ram_total_mb ?? 0)
+  const ramFreeMb = Number(raw?.ram_available_mb ?? 0)
+  const ramUsedMb = Math.max(0, ramTotalMb - ramFreeMb)
+  const mbToGb = (mb: number) => Math.round((mb / 1024) * 10) / 10
+  const cores = Number(raw?.cpu_cores ?? 0)
+  const threads = Number(raw?.cpu_threads ?? cores)
+  return {
+    name: raw?.hostname ?? raw?.name ?? raw?.extra?.hostname ?? '',
+    uptime: raw?.uptime ?? '',
+    cpu: raw?.cpu_model ?? raw?.cpu_name ?? raw?.cpu ?? '',
+    cores: cores ? `${cores}c · ${threads}t` : '',
+    gpu: raw?.gpu_name ?? raw?.gpus?.[0]?.name ?? raw?.gpu ?? '',
+    ram: {
+      total: mbToGb(ramTotalMb),
+      used: mbToGb(ramUsedMb),
+      free: mbToGb(ramFreeMb),
+    },
+    npu: {
+      present: !!(raw?.npu?.present ?? raw?.npu_present),
+      columns: Number(raw?.npu?.columns ?? 0),
+      ctx: Number(raw?.npu?.ctx ?? 0),
+    },
+  }
+}
+
 const POLL_MS = 10_000
 
 export function useHardware() {
   return useQuery({
     queryKey: ['hardware'],
-    queryFn: () => apiGet<Hardware>(ENDPOINTS.hardware),
+    queryFn: async () => normalizeHardware(await apiGet<any>(ENDPOINTS.hardware)),
     refetchInterval: POLL_MS,
   })
 }

--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -71,9 +71,55 @@ const DEFAULT_METRICS: SlotMetrics = {
   res: '',
 }
 
+// Backend /api/slots returns sparse slots without `type`, `device`, or
+// `group` for built-in slots (primary, embed, stt, …). The v3 SlotsView
+// groups via `slots.filter(s => s.group === "chat")` etc., so without
+// inference the page renders just the header — looks blank/black.
+// Infer from BUILTIN_SLOTS conventions (primary→chat/llm, embed→embed/…).
+function inferSlotShape(s: any): { type: string; group: string; device: string } {
+  const name = String(s?.name ?? '').toLowerCase()
+  const provider = String(s?.provider ?? '').toLowerCase()
+  const backend = String(s?.backend ?? s?.metadata?.backend ?? '').toLowerCase()
+
+  let type = s?.type as string | undefined
+  let group = s?.group as string | undefined
+  let device = s?.device as string | undefined
+
+  if (!type || !group) {
+    if (name === 'primary' || name === 'coder' || name === 'agent' || name.includes('chat')) {
+      type ??= 'llm'; group ??= 'chat'
+    } else if (name === 'rerank' || name.includes('rerank')) {
+      type ??= 'reranking'; group ??= 'embed'
+    } else if (name === 'embed' || name.includes('embed')) {
+      type ??= 'embedding'; group ??= 'embed'
+    } else if (name === 'stt' || name.includes('whisper') || name.includes('moonshine')) {
+      type ??= 'transcription'; group ??= 'voice'
+    } else if (name === 'tts' || name.includes('kokoro') || name.includes('vibe')) {
+      type ??= 'tts'; group ??= 'voice'
+    } else if (name === 'img' || name === 'image' || name.includes('image') || name.includes('sd')) {
+      type ??= 'image'; group ??= 'img'
+    } else if (provider.includes('llama') || provider.includes('llm')) {
+      type ??= 'llm'; group ??= 'chat'
+    }
+  }
+
+  if (!device) {
+    if (backend === 'vulkan' || backend === 'rocm') device = 'gpu-' + backend
+    else if (backend === 'flm' || backend === 'npu') device = 'npu'
+    else if (backend === 'cpu' || backend.includes('cpu')) device = 'cpu'
+    else device = 'cpu'
+  }
+
+  return { type: type ?? 'llm', group: group ?? 'chat', device }
+}
+
 function normalizeSlot(s: any): Slot {
+  const shape = inferSlotShape(s)
   return {
     ...s,
+    type: shape.type,
+    group: shape.group,
+    device: shape.device,
     metrics: { ...DEFAULT_METRICS, ...(s?.metrics ?? {}) },
     spark: Array.isArray(s?.spark) ? s.spark : [],
     model: s?.model ?? s?.model_id ?? s?.model_default ?? '',


### PR DESCRIPTION
## Summary

Two follow-up regressions surfaced after the v3 cutover (#235 + #249) once the dashboard was driving real backend data instead of HAL0_DATA mocks:

### /slots looked blank/black

Backend `/api/slots` returns sparse slots without `type`, `device`, or `group` for built-in slots (`primary`, `embed`, `stt`, …). `SlotsView` groups via `slots.filter(s => s.group === "chat")` etc., so without inference the primary slot fell out of every section and only the page header rendered. On the dark theme that looked like a black screen.

**Fix:** extend the `useSlots` `normalizeSlot()` helper with `inferSlotShape()` — derives `type` / `group` / `device` from BUILTIN_SLOTS naming conventions:
- `primary` / `coder` / `agent` → `llm` / `chat`
- `embed` / `rerank` → `embedding` or `reranking` / `embed`
- `stt` / `whisper` / `moonshine` → `transcription` / `voice`
- `tts` / `kokoro` / `vibe` → `tts` / `voice`
- `img` / `sd` → `image` / `img`

Plus provider / backend fallbacks (`provider=llama-server` → `llm/chat`, `backend=vulkan` → `gpu-vulkan`, `backend=flm` → `npu`, …).

### /hardware crashed with `TypeError: Cannot read properties of undefined (reading 'total')`

Backend `/api/hardware` returns a flat shape (`cpu_model`, `ram_mb`, `gpu_name`, `npu.present`, …). `HardwareView` dereferences nested fields (`H.ram.total`, `H.npu.columns`) directly. The pattern `const H = hwQuery.data || HAL0_DATA.host` meant live data overrode the mock and crashed because the shapes don't match.

**Fix:** add `normalizeHardware()` in `useHardware` that maps flat keys into the nested shape components expect, with neutral defaults for fields the backend doesn't surface (columns, ctx, hostname, uptime).

## Hot-patch first

LXC at `hal0.thinmint.dev` was hot-patched (same content as this commit) and rebuilt before this PR went up. Confirmed end-to-end:
- `/slots` renders the primary slot card in a Chat section
- `/hardware` renders all five cards (Host/CPU/GPU/NPU/Memory) without errors
- `/dashboard` continues to render cleanly

## Known follow-ups not in scope

- #236 — `apiMock` fixture rewrite (γ-suite still red — pre-existing)
- #248 — `/v1/*` proxy to lemonade (sidebar still shows lemond "down" until that merges)
- Longer-term: this whole class of frontend shape-bridging should move to the backend so `/api/slots` and `/api/hardware` return the shape v3 expects directly. Tracked separately when we revisit the slot model under the Lemonade migration.

## Test plan

- [ ] CI: python (3.11, 3.12) + ui green
- [ ] γ-suite expected to stay red (#236)
- [ ] Manual smoke: /slots shows the primary slot card under Chat; /hardware shows the 5 hw cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)