### PR TITLE
docs(v0.3): add ADR-0013 + ADR-0014 + cross-links

### DIFF
--- a/docs/internal/adr/0005-memory-engine-cognee.md
+++ b/docs/internal/adr/0005-memory-engine-cognee.md
@@ -77,8 +77,8 @@ Endpoint: `/mcp/memory`. Auth = existing Bearer token (ADR-0001). Client identit
 - hal0 MCP server enriches each call with `client_id` from Bearer token before the write hits Cognee.
 - Mirrored to journald for unified hal0 log inspection.
 
-### 6. Cognee features deferred to Phase 9
-- **Graph extraction** (Kuzu) — requires structured-output-reliable LLM. Gate behind a configurable model. Default in Phase 9 will route graph builds to OpenRouter (or 70B-class local model if available) because small local models (qwen3:8b-class) flake on Cognee's structured-output prompts.
+### 6. Cognee features deferred to Phase 9 (graph-extraction model gate settled in ADR-0014, 2026-05-23)
+- **Graph extraction** (Kuzu) — requires structured-output-reliable LLM. Gate behind a configurable model. Default in Phase 9 will route graph builds to OpenRouter (or 70B-class local model if available) because small local models (qwen3:8b-class) flake on Cognee's structured-output prompts. **See [ADR-0014](0014-cognee-graph-extraction-model-gate.md) for the v0.3 decision** — graph defaults OFF, opt-in via dashboard toggle, route enum `upstream` / `primary` / `agent`, eval suite deferred to v0.4.
 - **Memify pipeline** — periodic memory hygiene (stale node cleanup, association strengthening, fact reweighting).
 - **Source connectors** — 30+ available (Slack, Notion, docs, images, audio). Optional bolt-ons in Phase 9.
 - **RBAC + granular permissions** — Cognee's built-in dataset-scoped permissions surface in dashboard.

--- a/docs/internal/adr/0011-agent-identity-cards.md
+++ b/docs/internal/adr/0011-agent-identity-cards.md
@@ -4,7 +4,7 @@
 - **Date:** 2026-05-23
 - **Drivers:** `/grill-me` session 2026-05-23 against `docs/internal/hermes-bootstrap-plan-2026-05-23.md`; bundled Hermes agent v0.3 needs to publish itself + discover peers
 - **Implementing PRs:** PR-1 (this ADR + new MCP admin tools) per the bootstrap plan §23
-- **Related:** ADR-0004 (Agents v0.2), ADR-0005 (Memory engine = Cognee), **ADR-0012 (Remove auth and Caddy entirely)** — supersedes the bearer-token identity model assumed in Draft 2 of the bootstrap plan; identity now flows from an `X-hal0-Agent` header (no auth).
+- **Related:** ADR-0004 (Agents v0.2), ADR-0005 (Memory engine = Cognee), **ADR-0012 (Remove auth and Caddy entirely)** — supersedes the bearer-token identity model assumed in Draft 2 of the bootstrap plan; identity now flows from an `X-hal0-Agent` header (no auth). ADR-0013 (MCP-client allow-list) defines the per-agent server + tool allow-lists at `/etc/hal0/agents/<name>.toml`; a future card schema (v2+) may surface a derived `allowed_tools` projection from that allow-list (the allow-list is the source of truth, not the card).
 
 ## Identity sourcing update (post-ADR-0012)
 

--- a/docs/internal/adr/0013-mcp-client-allow-list.md
+++ b/docs/internal/adr/0013-mcp-client-allow-list.md
@@ -1,0 +1,237 @@
+# ADR 0013 — MCP-client allow-list for bundled agents (v0.3)
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Drivers:** PLAN.md §1 v0.3 stream #5 "MCP client side of hal0 — bundled agents reach external MCP servers with per-agent allow-list, filesystem scoped to `/var/lib/hal0/agents/<name>/workspace`"; v0.3 ships-when criterion
+- **Related:** ADR-0004 (Agents v0.2 — MCP server side), ADR-0011 (agent identity cards), ADR-0012 (remove auth and Caddy — supersedes ADR-0001; the `auth.kind = "bearer-from-env"` examples in this ADR cover OUTBOUND auth from agents to external MCP servers like GitHub, NOT hal0's inbound auth, which doesn't exist post-ADR-0012)
+
+## Context
+
+v0.2 made hal0 an **MCP server host** — bundled agents (Hermes-Agent
+in v0.3) connect *into* hal0-admin + hal0-memory MCPs. The reverse
+direction is still missing: bundled agents are **MCP clients** in
+their own right and the v0.3 spec wants them to reach external MCP
+servers (file system, github, search, third-party knowledge bases,
+custom user-installed MCPs) under per-agent scoped permissions.
+
+The shape currently missing:
+
+1. **Where the allow-list lives on disk** and what schema it uses.
+2. **What "allow" means** — server-level (which servers are reachable
+   at all), tool-level (which of a server's tools the agent can call),
+   or both.
+3. **Default-deny vs default-allow.** Home-AI single-user trust posture
+   leans permissive; agent-tool-access security leans restrictive.
+4. **Sandbox shape.** PLAN.md §1 names
+   `/var/lib/hal0/agents/<name>/workspace` for filesystem; the
+   network surface is unspecified.
+5. **Approval integration.** ADR-0004's approval queue gates capital-D
+   destructive actions on hal0-admin MCP. Does it extend to external
+   MCPs?
+6. **Bootstrap path.** Hermes bootstrap (ADR-0011 + the bootstrap plan
+   §3 `mcp_wire` phase) writes the initial config. What does it write?
+7. **Dashboard surface.** v3's MCP page (`/agents/mcp`) currently
+   manages MCP *servers* (which to install + which to enable). It
+   needs a parallel "clients" view that shows, per agent, what's
+   allowed.
+
+## Options considered
+
+| Option | Reason rejected (or accepted) |
+|---|---|
+| **Single `/etc/hal0/agents.toml`** with all agents' allow-lists in one file | Rejected. Couples per-agent diffs to a shared file, friction for installer-managed agents vs user-added agents. |
+| **Per-agent file at `/etc/hal0/agents/<name>.toml`** | ACCEPTED. Mirrors slots/upstreams pattern. Each bundled-agent installer drops its own file; user-added agents do likewise. |
+| **Embed allow-list inside `<name>`'s service unit env** | Rejected. Auth/permission data shouldn't live in systemd env files (no comments, no structured nesting, hard to dashboard-edit). |
+| **Allow-list in Cognee `agents` dataset (ADR-0011)** with the identity card | Rejected for v0.3. Identity card is a *projection* of running state, not configuration. Allow-list is configuration. Mixing the two muddies ADR-0011's contract. Could converge in v0.4 if the dashboard surface needs a unified view. |
+| **Server-only allow-list** (allow whole server or nothing) | Rejected. Insufficiently granular for high-value MCPs that mix safe + risky tools (e.g., github-mcp's read tools vs `delete_repo`). |
+| **Server + tool allow-list, default-deny on both** | ACCEPTED. Matches OAuth-scope-style mental model. Mirrors ADR-0004's "autonomous vs gated" tool split. |
+
+## Decision
+
+### 1. Config lives at `/etc/hal0/agents/<name>.toml`
+
+- One file per agent (`hermes.toml`, `pi-coder.toml`, etc.).
+- Owned by the installer for bundled agents; user-managed for
+  user-added agents.
+- Preserved across `hal0 update` (same as everything under `/etc/hal0/`).
+- Schema validated at agent bootstrap time + on dashboard-edit save.
+
+### 2. Schema
+
+```toml
+# /etc/hal0/agents/hermes.toml
+schema_version = 1
+
+[agent]
+name        = "hermes"
+display     = "Hermes-Agent"
+# Filesystem sandbox root. Agent processes are chrooted/bind-mounted
+# to see only this path as their workspace. Outside writes require
+# approval (per ADR-0004 §2 destructive-action gating).
+workspace   = "/var/lib/hal0/agents/hermes/workspace"
+
+# ---------------------------------------------------------------
+# MCP servers the agent is permitted to *connect* to.
+# Default-deny: a server not listed here is unreachable.
+# ---------------------------------------------------------------
+
+[mcp.servers.hal0-admin]
+# Built-in. Always allowed for bundled agents; can't be removed
+# from a bundled agent's config without an explicit override.
+builtin = true
+
+[mcp.servers.hal0-memory]
+builtin = true
+
+[mcp.servers.filesystem]
+# User-added local MCP. Connection only — tool gates below.
+url      = "stdio:///usr/lib/hal0/mcp/filesystem-server"
+enabled  = true
+# Per-tool allow-list. Default-deny.
+tools.allow = [
+    "read_file",
+    "list_directory",
+    "search_files",
+]
+# Tools listed here go through the ADR-0004 approval queue even
+# though they're on `tools.allow`. Use for destructive-but-needed.
+tools.gated = [
+    "write_file",
+]
+
+[mcp.servers.github]
+url      = "https://api.github.com/mcp"
+enabled  = false   # opt-in
+auth.kind = "bearer-from-env"
+auth.env  = "HAL0_AGENT_HERMES_GITHUB_TOKEN"
+tools.allow = [
+    "list_issues",
+    "get_pr",
+    "search_code",
+]
+tools.gated = [
+    "create_pr",
+    "post_issue_comment",
+]
+# Tools listed here are explicitly blocked — installer can pin
+# "never allow" tools even if a user later expands tools.allow.
+tools.blocked = [
+    "delete_repo",
+    "delete_branch",
+]
+```
+
+### 3. Default-deny on both axes
+
+- **Server axis.** An MCP server not listed in `[mcp.servers.*]` is
+  unreachable by the agent. No "discover and connect" fallback.
+- **Tool axis.** Inside an allowed server, only tools in
+  `tools.allow` (or `tools.gated`) are callable. Anything else returns
+  `tool.not_permitted` to the agent.
+
+### 4. Three-tier tool classification
+
+| Tier | Behavior | Goes through approval queue? |
+|---|---|---|
+| `tools.allow`   | Autonomous call | No |
+| `tools.gated`   | Call enqueued, awaits user approval | Yes (ADR-0004 surface) |
+| `tools.blocked` | Hard reject at the client; never reaches the server | N/A |
+
+- **Migration path.** A tool starting `gated` and proving stable can
+  be moved to `allow` by the user via dashboard or by editing the
+  TOML. Migration the other direction is permitted too.
+- **Installer-pinned blocks override user edits.** If the installer
+  put `delete_repo` in `tools.blocked` for a bundled agent, the
+  dashboard can't move it out — only direct TOML edit (loud, traceable
+  in git) can.
+
+### 5. Filesystem sandbox
+
+- Agent processes launched via the agent driver (`src/hal0/agents/*`)
+  get `workspace = /var/lib/hal0/agents/<name>/workspace` as their
+  effective HOME + CWD.
+- Filesystem MCPs (when allowed) get their server-side root pinned
+  to that same path — they cannot access anything outside it. Tool
+  arguments that try (`../`, absolute paths) get rejected client-side
+  before they reach the server.
+- Writing outside the workspace happens only via a hal0-admin MCP
+  tool (e.g., `model_store_write`, `config_write`) that already
+  goes through ADR-0004's approval queue.
+
+### 6. Bootstrap path (Hermes-Agent, v0.3)
+
+- `installer/agents/hermes.sh` installs the agent + drops a default
+  `/etc/hal0/agents/hermes.toml` containing:
+  - `hal0-admin` + `hal0-memory` (builtin).
+  - One external MCP (filesystem, scoped to the workspace) — proof
+    of stream #5's *"at least one MCP-client external source
+    connectable from a bundled agent"* ship criterion.
+- Hermes bootstrap state machine (per `hermes-bootstrap-plan-2026-05-23.md`)
+  reads this file in the `mcp_wire` phase, registers the connections
+  with Hermes's MCP client, and proceeds.
+- A failure to connect to a non-builtin MCP logs + continues — the
+  agent doesn't fail bootstrap on a stale URL or missing token.
+
+### 7. Approval-queue integration
+
+- Calls to `tools.gated` enqueue exactly like ADR-0004's hal0-admin
+  destructive-tool gating: dashboard bell + inline pending indicator
+  + CLI parity via `hal0 agent approvals {list,approve,deny}`.
+- The approval record carries `{agent_name, mcp_server, tool, args,
+  client_id}` — same envelope as hal0-admin approvals so the dashboard
+  doesn't need a parallel UI.
+
+### 8. Dashboard surface (v0.3 follow-up; not blocking ADR)
+
+- v3's `/agents/mcp` page gains a **per-agent view** (sibling to the
+  existing per-server view).
+- Read-only in v0.3 alpha; editable in v0.3 stable.
+- Edit writes back to `/etc/hal0/agents/<name>.toml` atomically (same
+  envelope writer as `/etc/hal0/slots/*.toml`).
+
+## Consequences
+
+### Positive
+
+- Cleanly resolves PLAN.md §1 v0.3 ships-when item without expanding
+  ADR-0011's scope into configuration.
+- Default-deny on both server + tool axis matches the structurally
+  correct security posture without forcing users to think about it
+  unless they want to extend.
+- Per-agent file mirrors the slot/upstream layout users already
+  understand — no new mental model.
+- Installer-pinned blocks survive user edits without locking out
+  expert users (TOML edit always wins, just loudly).
+
+### Negative / costs
+
+- Three classifications (allow/gated/blocked) is one more than a
+  pure two-tier system. Mitigation: the dashboard renders the
+  classification with a clear three-color chip — one decision per
+  tool, one click to migrate.
+- Per-agent files multiply small files in `/etc/hal0/`. Mitigation:
+  the existing slots layout already does this; tooling exists.
+- External MCP availability is bursty — servers can disappear, tokens
+  rot. Mitigation: dashboard surfaces per-server health (green/yellow/
+  red dot), and `hal0 agent doctor <name>` round-trips every allowed
+  server during bootstrap repair.
+- The `auth.kind = "bearer-from-env"` indirection requires care so
+  tokens don't leak into systemd unit dumps. Mitigation: tokens loaded
+  at agent-process startup from systemd-credential or env file with
+  `0600 hal0:hal0` perms — never in the agent's command line.
+
+## Pending items
+
+- `src/hal0/config/schema.py` — `AgentConfig`, `MCPServerConfig`,
+  `ToolPolicy` pydantic models.
+- `src/hal0/agents/mcp_client.py` — the per-agent MCP client surface
+  that reads the config + enforces the three-tier classification.
+- `installer/agents/hermes.sh` — adds the default
+  `/etc/hal0/agents/hermes.toml` writer.
+- Dashboard `/agents/mcp` per-agent view (v0.3 follow-up issue, to be
+  filed).
+- Docs page `docs/agents/mcp-client.md` written before the dashboard
+  surface ships.
+- Cross-link from ADR-0011 (identity cards) to this ADR: the
+  identity card's `allowed_tools` projection is *derived from* the
+  allow-list defined here; it's not the source of truth.

--- a/docs/internal/adr/0014-cognee-graph-extraction-model-gate.md
+++ b/docs/internal/adr/0014-cognee-graph-extraction-model-gate.md
@@ -1,0 +1,167 @@
+# ADR 0014 — Cognee graph extraction model gate (v0.3)
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Drivers:** PLAN.md §1 v0.3 stream #5 "Cognee graph extraction (Kuzu) gated behind a configurable model"; v0.3 ships-when criterion; ADR-0005 §6 explicitly deferred this decision to a follow-up
+- **Supersedes:** ADR-0005 §6 graph-extraction bullet (the "Phase 9" deferral)
+- **Related:** ADR-0005 (memory engine = Cognee), ADR-0008 (Lemonade adoption — what `primary` slot looks like), risk PLAN.md §17 "Cognee structured-output reliability on small local models"
+
+## Context
+
+Cognee's graph build pipeline (Kuzu) extracts entities + relations from
+ingested text using an LLM with structured-output prompts. ADR-0005 §6
+deferred this to "Phase 9" on the explicit grounds that small local
+models (qwen3:8b-class) flake on the structured-output format. v0.3
+promoted the feature into scope but PLAN.md §1 left the model-selection
+mechanism open: *"gated behind a configurable model and at least one
+MCP-client external source connectable from a bundled agent"*.
+
+PLAN.md §17 keeps the same risk row open: *"Cognee structured-output
+reliability on small local models (Phase 9 graph builds)"* with the
+mitigation listed as *"Gate graph extraction behind a configurable
+model; default to OpenRouter or 70B-class local model for graph builds.
+Basic memory (add/search/list/delete) works on any model."*
+
+What's unsettled and needs a decision:
+
+1. **Which slot/route carries graph extraction by default?** Existing
+   options: `primary` slot (whatever the user picked at install), a
+   new dedicated `agent` slot, an upstream route (OpenRouter /
+   Anthropic / OpenAI / custom OpenAI-compatible), or no default
+   (force user choice at enable time).
+2. **What's the default ON/OFF state in v0.3?** Forcing graph builds
+   on by default risks broken/empty graphs for users on small local
+   models.
+3. **Do we ship an eval gate?** Without one, "configurable" is just
+   "your problem" — the failure mode (low-quality graph) is silent.
+4. **Privacy trade-off disclosure.** Routing to upstream means the
+   ingested memory text leaves the box. Single-box home-AI identity
+   (per ADR-0001 / ADR-0005) cuts against silent upstream calls.
+
+## Options considered
+
+| Option | Reason rejected (or accepted) |
+|---|---|
+| **Default ON via `primary` slot** | Quality cliff: most users land on 7B/8B local models at install (per PLAN.md §15 Phase 4 wizard). Structured-output failure rate too high to enable silently. Surfaces as "memory works but graph view is empty." |
+| **Default ON via upstream route** | Cleanest quality story but every memory write becomes an exfil event. Contradicts the single-box trust posture user picked at install. Loud + non-obvious. |
+| **Default OFF; user opts in via dashboard, picks route at enable time** | ACCEPTED. Explicit opt-in matches Cognee's own "graph_enabled = false" default (verified against upstream `cognee/config.py`). Surfaces the trade-off where the user makes it. |
+| **Force route choice with no default** | Same as accepted, but blocks "enable + go" flow. Rejected as friction. |
+| **Ship eval suite first; auto-flip ON when local model passes** | ACCEPTED as v0.4 path. Eval suite (audit gap G2) needed regardless. Too much surface for v0.3 ship. |
+
+## Decision
+
+### 1. Graph extraction defaults OFF in v0.3
+
+- `[memory.graph] enabled = false` in installed `hal0.toml`.
+- `hal0-memory` MCP exposes `memory_search` with vector-only path when
+  `enabled = false` — same behavior as v0.2, no graph build runs on
+  `memory_add`.
+- Cognee's `graph_enabled` config flag tied to ours one-for-one; no
+  background indexing when off.
+
+### 2. When enabled, route picked from a typed enum
+
+```toml
+[memory.graph]
+enabled = true
+# One of: "upstream", "primary", "agent"
+route = "upstream"
+
+[memory.graph.upstream]
+# Required when route = "upstream".
+# Format mirrors upstreams.toml entries.
+provider = "openrouter"        # or "anthropic" | "openai" | "custom"
+model    = "anthropic/claude-3.5-sonnet"
+# api_key resolved from upstreams.toml's [providers.openrouter.api_key]
+```
+
+- `route = "upstream"` — resolved via the existing upstreams
+  (`hal0/upstreams/`) machinery. No new credential path.
+- `route = "primary"` — uses the live `primary` slot. Quality on user's
+  responsibility.
+- `route = "agent"` — uses a dedicated `agent` slot if present
+  (typically a larger model on Strix Halo unified RAM). Per ADR-0008 +
+  ADR-0009 the `agent` slot is the FLM NPU path on Strix Halo;
+  graph-extraction prompts must still be CPU/GPU-validated.
+
+### 3. Default route at enable time = `upstream` (when a provider is configured)
+
+- Dashboard's Memory tab "Enable graph extraction" toggle shows a
+  one-screen disclosure: *"Graph extraction sends ingested memory text
+  to <chosen upstream> for entity + relation extraction. Your raw
+  memory store stays local. Switch to a local slot to keep everything
+  on-box (quality may vary on small models)."*
+- If no upstream provider is configured at toggle time, the toggle
+  goes straight to a route-picker that lists configured local slots.
+- CLI parity: `hal0 memory graph enable [--route=upstream|primary|agent]
+  [--provider=...] [--model=...]`.
+
+### 4. Eval gate is a v0.4 deliverable, not v0.3
+
+- v0.3 ships the gate + config + dashboard surface; the suite that
+  *measures* quality per (route × model) ships in v0.4 (audit gap G2
+  per `audit-2026-05-22-phase8-skill-review.md`).
+- Until then, the "enable" toggle copy includes a soft caveat:
+  *"Graph quality varies by model. We don't currently measure it for
+  you — your results may vary."*
+
+### 5. Privacy posture (explicit)
+
+- `route = "upstream"` is the default suggestion but **NEVER** the
+  default behavior — graph extraction is off until the user toggles.
+- The disclosure copy is part of the contract: changing it requires
+  amending this ADR.
+- `route = "primary"` and `route = "agent"` keep memory text on-box.
+
+### 6. Storage + retrieval contract unchanged
+
+- `memory_add` API surface unchanged. When `graph.enabled = true`, the
+  add call enqueues a background graph build; the foreground call
+  returns the same `{id, timestamp}` shape as today.
+- `memory_search` gains an optional `mode: "vector" | "graph" | "hybrid"`
+  parameter; default stays `"vector"` for backward compat.
+- Failed graph builds log + drop silently — never block ingestion.
+  Surfaced in dashboard Memory tab as a per-build error count.
+
+## Consequences
+
+### Positive
+
+- Cleanly resolves PLAN.md §1 v0.3 ships-when item without enabling
+  a feature that flakes on the median user's hardware.
+- Reuses existing upstream-provider machinery — no new credential
+  path, no new config namespace.
+- Explicit privacy disclosure at toggle time matches ADR-0001's
+  "home-LAN open by default, password opt-in" pattern of putting the
+  decision in front of the user, not in a config file.
+- Future-compatible: when the eval suite ships in v0.4 + a local
+  model proves reliable enough, we can flip the default route or
+  even auto-enable for that model family — additive, no migration.
+
+### Negative / costs
+
+- Three routes to test + document means three failure modes the
+  dashboard has to surface coherently. Mitigation: each route reuses
+  an existing health-check path (upstreams already report status;
+  slots already report state).
+- "Default off" means graph features look broken on first install
+  ("why is the graph view empty?"). Mitigation: dashboard Memory tab
+  shows a clear "Graph extraction is off" state with a one-click
+  enable affordance.
+- Tying graph-build to user-configurable upstream means changing the
+  upstream changes graph quality silently. Mitigation: the per-build
+  error count + a model-fingerprint stamp on each graph node so
+  re-routing is traceable.
+
+## Pending items
+
+- Cognee version + the exact `graph_enabled` config flag verified
+  against the pin in `pyproject.toml`.
+- Dashboard Memory tab — "graph extraction" section (one toggle,
+  one route picker, one disclosure, one error counter). Tracked
+  separately under dashboard-v3 (closes part of #228).
+- `[memory.graph]` TOML schema added to `src/hal0/config/schema.py`.
+- CLI surface: `hal0 memory graph {enable,disable,status}`.
+- Eval-suite scaffolding deferred to v0.4 (audit gap G2 issue, to be
+  filed).
+- Docs page `docs/memory/graph.md` written before the toggle ships.


### PR DESCRIPTION
## Summary

- Add **ADR-0013** (MCP-client allow-list for bundled agents)
- Add **ADR-0014** (Cognee graph extraction model gate)
- Cross-link **ADR-0011** Related header → ADR-0013
- Cross-link **ADR-0005** §6 → ADR-0014

Both ADRs were drafted + accepted on 2026-05-23 while PR #268's cascade was in flight; PR #268 already references both files in PLAN.md (lines 44–47, 341, 348, 1052) but the files themselves only exist locally until this PR lands.

## Why now

Tracker issues #257–#260 (ADR-0014 implementation), #265 (v0.4 eval suite), and #261–#264 (ADR-0013 implementation) all link these ADR files. They're broken links until this PR merges.

## Test plan

- [x] Markdown renders cleanly in GH viewer
- [x] No stale `ADR-0012` references to my old number (renumbered to ADR-0014 after PR #267 took the 0012 slot for the auth-removal ADR)
- [x] ADR-0011 + ADR-0005 cross-links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)