### PR TITLE
feat(dash-v3): wire Models panel end-to-end (inspect + recipe + delete cascade)

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -16,14 +16,17 @@ import time
 from pathlib import Path
 from typing import Any
 
+import httpx
 from fastapi import APIRouter, BackgroundTasks, Request
 from fastapi.responses import StreamingResponse
 
 from hal0.api.middleware.error_codes import BadRequest, NotFound
 from hal0.config.loader import load_hal0_config
+from hal0.errors import Hal0Error
 from hal0.registry.curated import CURATED, CuratedModel, HaloaiModel, get_curated
 from hal0.registry.detect import DetectionResult, detect
 from hal0.registry.discover import is_skippable, scan_and_register
+from hal0.registry.model import _derive_ns
 from hal0.registry.pull import (
     PullInvalidSource,
     PullJob,
@@ -117,6 +120,11 @@ async def list_models(request: Request) -> dict[str, Any]:
                     "owned_by": u.name,
                     "upstream": u.name,
                     "installed": False,
+                    # Upstream-only rows have no local path → "pulled"
+                    # by the path-shape rule (issue #220). The
+                    # blessed bucket is reserved for files actually
+                    # laid out under the blessed recipe tree.
+                    "ns": "pulled",
                 }
             )
     return {"models": data, "count": len(data), "filtered_aliases": filtered}
@@ -484,10 +492,25 @@ async def create_model(request: Request) -> dict[str, Any]:
 
 
 def _model_to_dict(model: Any) -> dict[str, Any]:
-    """Serialise a registry Model to the dashboard's flat shape."""
+    """Serialise a registry Model to the dashboard's flat shape.
+
+    Always attaches the ``ns`` ("blessed" | "pulled") namespace bucket
+    so the dashboard's Models view can group rows without re-deriving
+    it client-side. The rule is path-shape only (see :func:`_derive_ns`
+    + issue #220).
+    """
     if hasattr(model, "model_dump"):
-        return model.model_dump(mode="json")
-    return {**getattr(model, "__dict__", {})}
+        dumped = model.model_dump(mode="json")
+    else:
+        dumped = {**getattr(model, "__dict__", {})}
+    # Only registry-backed Model instances have a ``path``; the upstream
+    # rows assembled in :func:`list_models` already set ``ns`` directly.
+    if "ns" not in dumped and hasattr(model, "path"):
+        try:
+            dumped["ns"] = _derive_ns(model)
+        except Exception:
+            dumped["ns"] = "pulled"
+    return dumped
 
 
 @router.get("/{model_id}")
@@ -1049,6 +1072,263 @@ async def pull_stream(model_id: str, request: Request) -> StreamingResponse:
             "X-Accel-Buffering": "no",
         },
     )
+
+
+# ── HuggingFace inspect (POST /api/models/inspect) ────────────────────────────
+
+
+# In-process TTL cache keyed by normalised HF repo id. Storing the whole
+# response shape (variants + tags + metadata) keeps repeat Inspect clicks
+# on the same modal session free; the 5 minute TTL is short enough that
+# a freshly-uploaded quant lands within one render.
+_INSPECT_TTL_SECONDS = 300
+_INSPECT_TIMEOUT_SECONDS = 8.0
+_INSPECT_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
+_INSPECT_GGUF_SUFFIX = ".gguf"
+
+
+class _HFUpstreamError(Hal0Error):
+    """502 — fetching huggingface.co failed (network, 5xx, or unparseable)."""
+
+    code = "hf.unreachable"
+    status = 502
+
+
+def _normalise_hf_repo(value: str) -> str:
+    """Reduce a HF repo input to ``org/name``.
+
+    Accepts the canonical ``org/name`` slug and a full
+    ``https://huggingface.co/org/name[/...]`` URL — both are surfaced
+    in the dashboard's Add-by-HF modal. Trims trailing slashes and
+    drops the ``/tree/<rev>`` / ``/blob/<rev>/...`` suffixes that the
+    HF UI tends to copy along with the slug.
+    """
+    raw = (value or "").strip()
+    if not raw:
+        return ""
+    # Strip protocol + host so we can normalise URL + slug uniformly.
+    for prefix in ("https://huggingface.co/", "http://huggingface.co/", "huggingface.co/"):
+        if raw.startswith(prefix):
+            raw = raw[len(prefix) :]
+            break
+    raw = raw.strip("/")
+    # Drop /tree/<rev> or /blob/<rev>/<path> if the user pasted a deep link.
+    parts = raw.split("/")
+    repo = f"{parts[0]}/{parts[1]}" if len(parts) >= 2 else raw
+    return repo
+
+
+def _extract_readme_excerpt(card_data: Any, limit: int = 400) -> str:
+    """Pull a short README excerpt from the HF model API payload.
+
+    HF returns the model card body under different shapes depending on
+    the endpoint. ``cardData`` carries YAML frontmatter; the actual
+    README body comes back under ``description`` or ``card``. Use
+    whatever is present and truncate hard so the modal stays light.
+    """
+    candidates: list[str] = []
+    if isinstance(card_data, dict):
+        for key in ("description", "card", "readme"):
+            v = card_data.get(key)
+            if isinstance(v, str) and v.strip():
+                candidates.append(v.strip())
+    if not candidates:
+        return ""
+    text = candidates[0]
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "…"
+
+
+def _format_size(size_bytes: int | None) -> str:
+    """Format bytes as a short human label used in the variant dropdown."""
+    if not isinstance(size_bytes, int) or size_bytes <= 0:
+        return "—"
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    if size_bytes < 1024**2:
+        return f"{size_bytes / 1024:.1f} KB"
+    if size_bytes < 1024**3:
+        return f"{size_bytes / 1024**2:.1f} MB"
+    return f"{size_bytes / 1024**3:.2f} GB"
+
+
+async def _fetch_hf_repo(repo: str) -> dict[str, Any]:
+    """Fetch HF model metadata + tree listing for ``repo``.
+
+    Returns the shape consumed by :func:`inspect_model`. Raises a
+    typed :class:`hal0.errors.Hal0Error` subclass on transport failure
+    or 404 so the route maps it to the dashboard envelope.
+    """
+    headers = {"Accept": "application/json"}
+    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    if hf_token:
+        headers["Authorization"] = f"Bearer {hf_token}"
+
+    meta_url = f"https://huggingface.co/api/models/{repo}"
+    tree_url = f"https://huggingface.co/api/models/{repo}/tree/main"
+    try:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(_INSPECT_TIMEOUT_SECONDS),
+            follow_redirects=True,
+            headers=headers,
+        ) as client:
+            meta_res, tree_res = await asyncio.gather(
+                client.get(meta_url),
+                client.get(tree_url),
+            )
+    except (httpx.TimeoutException, httpx.HTTPError) as exc:
+        raise _HFUpstreamError(
+            f"failed to reach huggingface.co for {repo!r}: {exc.__class__.__name__}",
+            code="hf.unreachable",
+            details={"repo": repo, "error": str(exc)},
+        ) from exc
+
+    if meta_res.status_code == 404:
+        raise NotFound(
+            f"hugging face repo {repo!r} not found",
+            code="hf.repo_not_found",
+            details={"repo": repo},
+        )
+    if meta_res.status_code >= 400:
+        raise _HFUpstreamError(
+            f"hugging face metadata fetch returned {meta_res.status_code}",
+            code="hf.upstream_error",
+            details={"repo": repo, "status": meta_res.status_code},
+        )
+    if tree_res.status_code >= 400:
+        # A missing tree (private repo, gated, etc.) is recoverable —
+        # we still surface tags + metadata, just with no variants.
+        tree_payload: list[Any] = []
+    else:
+        try:
+            tree_payload = tree_res.json() or []
+        except ValueError:
+            tree_payload = []
+
+    try:
+        meta_payload = meta_res.json() or {}
+    except ValueError:
+        meta_payload = {}
+
+    variants: list[dict[str, Any]] = []
+    for entry in tree_payload:
+        if not isinstance(entry, dict):
+            continue
+        rel = entry.get("path") or entry.get("rfilename")
+        if not isinstance(rel, str):
+            continue
+        if not rel.lower().endswith(_INSPECT_GGUF_SUFFIX):
+            continue
+        # HF's tree API reports the *pointer file* size in ``size`` for
+        # LFS objects; the real bytes live under ``lfs.size``. Prefer
+        # the LFS size when present so the modal shows the real
+        # download size, not the 100-byte pointer.
+        size_raw: Any = None
+        lfs = entry.get("lfs")
+        if isinstance(lfs, dict):
+            size_raw = lfs.get("size")
+        if size_raw is None:
+            size_raw = entry.get("size")
+        try:
+            size_bytes = int(size_raw) if size_raw is not None else 0
+        except (TypeError, ValueError):
+            size_bytes = 0
+        # Use the GGUF filename as the canonical variant id — that's
+        # also what the pull endpoint resolves against (hf_filename).
+        variants.append(
+            {
+                "id": rel,
+                "size_bytes": size_bytes,
+                "size": _format_size(size_bytes),
+                "info": _format_size(size_bytes) + " · single file",
+            }
+        )
+    variants.sort(key=lambda v: v.get("size_bytes") or 0)
+
+    tags_raw = meta_payload.get("tags") or []
+    tags = [t for t in tags_raw if isinstance(t, str)]
+
+    license_label = ""
+    card = meta_payload.get("cardData")
+    if isinstance(card, dict):
+        lic = card.get("license")
+        if isinstance(lic, str):
+            license_label = lic
+    if not license_label:
+        # Fallback: HF exposes the top-level "license" sometimes.
+        lic = meta_payload.get("license")
+        if isinstance(lic, str):
+            license_label = lic
+
+    return {
+        "variants": variants,
+        "tags": tags,
+        "metadata": {
+            "license": license_label,
+            "readme_excerpt": _extract_readme_excerpt(card),
+        },
+    }
+
+
+@router.post("/inspect")
+async def inspect_model(request: Request) -> dict[str, Any]:
+    """Inspect a HuggingFace repo and return pullable variants + metadata.
+
+    Body shape (either key accepted, ``hf_url`` is the dashboard's older
+    alias)::
+
+        {"hf_repo": "unsloth/Qwen3-8B-GGUF"}
+        {"hf_url":  "https://huggingface.co/unsloth/Qwen3-8B-GGUF"}
+
+    Response::
+
+        {
+          "repo": "...",
+          "variants": [{"id": "qwen3-8b-q4_k_m.gguf", "size_bytes": ..., "info": "..."}],
+          "tags": ["text-generation", ...],
+          "metadata": {"license": "...", "readme_excerpt": "..."}
+        }
+
+    Cached for ~5 minutes per repo. HF unreachable / 5xx → ``502``
+    with ``hf.unreachable`` / ``hf.upstream_error``. Repo missing →
+    ``404`` with ``hf.repo_not_found``.
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise BadRequest("body must be valid JSON", details={"error": str(exc)}) from exc
+    if not isinstance(body, dict):
+        raise BadRequest("body must be a JSON object")
+
+    repo_input = body.get("hf_repo")
+    if not isinstance(repo_input, str) or not repo_input.strip():
+        repo_input = body.get("hf_url")
+    if not isinstance(repo_input, str) or not repo_input.strip():
+        raise BadRequest(
+            "either 'hf_repo' (org/name) or 'hf_url' is required",
+            code="hf.bad_request",
+        )
+
+    repo = _normalise_hf_repo(repo_input)
+    if "/" not in repo:
+        raise BadRequest(
+            f"'{repo_input}' is not a valid org/name HF repo coordinate",
+            code="hf.bad_request",
+            details={"input": repo_input},
+        )
+
+    now = time.time()
+    cached = _INSPECT_CACHE.get(repo)
+    if cached is not None and now - cached[0] < _INSPECT_TTL_SECONDS:
+        payload = dict(cached[1])
+        payload["repo"] = repo
+        payload["cached"] = True
+        return payload
+
+    result = await _fetch_hf_repo(repo)
+    _INSPECT_CACHE[repo] = (now, result)
+    return {"repo": repo, "cached": False, **result}
 
 
 @router.post("/{model_id}/pull/cancel")

--- a/src/hal0/registry/model.py
+++ b/src/hal0/registry/model.py
@@ -147,3 +147,42 @@ class Model(BaseModel):
         if not v.strip():
             raise ValueError("model path must not be empty")
         return v
+
+
+# ── Namespace derivation ─────────────────────────────────────────────────────
+#
+# The dashboard surfaces a two-bucket split — "blessed" (curated /
+# pre-baked artifacts laid out under
+# ``/var/lib/hal0/models/<recipe>/<capability>/``) vs "pulled" (anything
+# we downloaded into the registry's pull tree or that the operator
+# hand-registered). The rule is path-shape only — see issue #220 for
+# the locked decision — so a single source of truth for the derivation
+# keeps every consumer in sync.
+
+_BLESSED_PREFIX = "/var/lib/hal0/models/"
+
+
+def _derive_ns(model: Model) -> str:
+    """Return ``"blessed"`` if ``model.path`` sits under a recipe/capability
+    directory inside the blessed model root, else ``"pulled"``.
+
+    Rule (issue #220 — do not relitigate): a path is blessed iff it
+    begins with ``/var/lib/hal0/models/<recipe>/<capability>/`` — i.e.
+    after the blessed root there are at least two more directory
+    components before the file. The pull tree layout
+    (``/var/lib/hal0/models/<id>/<file>``) only has one component after
+    the root and is therefore "pulled".
+    """
+    path = (model.path or "").strip()
+    if not path or not path.startswith(_BLESSED_PREFIX):
+        return "pulled"
+    tail = path[len(_BLESSED_PREFIX) :]
+    # Need: <recipe>/<capability>/<rest>. That's 2 separators with
+    # non-empty leading segments.
+    parts = tail.split("/")
+    if len(parts) < 3:
+        return "pulled"
+    recipe, capability = parts[0], parts[1]
+    if not recipe or not capability:
+        return "pulled"
+    return "blessed"

--- a/tests/api/test_models_routes.py
+++ b/tests/api/test_models_routes.py
@@ -1,0 +1,356 @@
+"""Tests for the /api/models surface added in the v3 wireup.
+
+Covers two pieces:
+  * ``_derive_ns`` — the locked path-shape rule for blessed vs pulled
+    (see issue #220 + the v3 brief). Three cases: blessed recipe path,
+    pulled path under the model root, and the empty-path edge.
+  * ``POST /api/models/inspect`` — HuggingFace metadata + tree fetch with
+    httpx mocked. Validates the variant filter (.gguf only, LFS-size
+    preferred), the alias body shape, the 502/404 error envelopes, and
+    the 5 minute in-process cache.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.api.routes import models as models_route
+from hal0.registry.model import Model, _derive_ns
+
+# ── _derive_ns ─────────────────────────────────────────────────────────────
+
+
+def test_derive_ns_blessed_for_recipe_capability_path() -> None:
+    """Path under /var/lib/hal0/models/<recipe>/<capability>/ → blessed."""
+    m = Model(
+        id="qwen3-coder",
+        path="/var/lib/hal0/models/qwen3-coder/chat/qwen3-coder-q4_k_m.gguf",
+    )
+    assert _derive_ns(m) == "blessed"
+
+
+def test_derive_ns_pulled_for_id_only_path() -> None:
+    """Default pull layout /var/lib/hal0/models/<id>/<file> → pulled."""
+    m = Model(
+        id="hand-pulled",
+        path="/var/lib/hal0/models/hand-pulled/hand-pulled-q4_k_m.gguf",
+    )
+    assert _derive_ns(m) == "pulled"
+
+
+def test_derive_ns_empty_path_is_pulled() -> None:
+    """Edge case: a Model with an unset/whitespace path must not raise."""
+    # pydantic forbids an empty path; the helper still has to tolerate
+    # a Model-shaped object whose path was wiped post-construction (the
+    # serialisation path runs after registry mutations and we don't
+    # want a single bad row to crash the whole listing).
+    m = Model(id="ghost", path="/tmp/will-be-cleared")
+    object.__setattr__(m, "path", "")
+    assert _derive_ns(m) == "pulled"
+
+
+def test_derive_ns_blessed_root_with_only_id_segment_is_pulled() -> None:
+    """Only one path segment after the blessed root → not blessed.
+
+    The rule requires <recipe>/<capability>/<file> — anything shorter
+    is the legacy single-segment pull layout.
+    """
+    m = Model(id="x", path="/var/lib/hal0/models/x/file.gguf")
+    assert _derive_ns(m) == "pulled"
+
+
+def test_derive_ns_arbitrary_root_is_pulled() -> None:
+    """A path outside the blessed root is always pulled."""
+    m = Model(id="ext", path="/mnt/ai-models/qwen/qwen3-8b/q4.gguf")
+    assert _derive_ns(m) == "pulled"
+
+
+# ── /api/models response shape ─────────────────────────────────────────────
+
+
+@pytest.fixture
+def inspect_app(tmp_hal0_home: str) -> FastAPI:
+    """Fresh app with the inspect cache cleared so each test sees a cold cache."""
+    models_route._INSPECT_CACHE.clear()
+    return create_app()
+
+
+@pytest.fixture
+def inspect_client(inspect_app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(inspect_app) as c:
+        yield c
+
+
+def test_list_models_attaches_ns_for_registry_entries(
+    inspect_client: TestClient,
+    tmp_hal0_home: str,
+) -> None:
+    """Local registry rows must carry the derived ``ns`` field."""
+    fpath = Path(tmp_hal0_home) / "fixture.gguf"
+    fpath.write_bytes(b"\x00" * 8)
+    # Register two rows: one whose path looks blessed, one whose doesn't.
+    inspect_client.post(
+        "/api/models",
+        json={
+            "id": "blessed-row",
+            "path": "/var/lib/hal0/models/qwen3-coder/chat/qwen3-coder.gguf",
+        },
+    )
+    inspect_client.post(
+        "/api/models",
+        json={"id": "pulled-row", "path": str(fpath)},
+    )
+
+    body = inspect_client.get("/api/models").json()
+    rows = {m["id"]: m for m in body["models"]}
+    assert rows["blessed-row"]["ns"] == "blessed"
+    assert rows["pulled-row"]["ns"] == "pulled"
+
+
+def test_get_model_attaches_ns(inspect_client: TestClient, tmp_hal0_home: str) -> None:
+    """GET /api/models/{id} carries the same ``ns`` derivation."""
+    fpath = Path(tmp_hal0_home) / "x.gguf"
+    fpath.write_bytes(b"\x00")
+    inspect_client.post("/api/models", json={"id": "g1", "path": str(fpath)})
+    row = inspect_client.get("/api/models/g1").json()
+    assert row["ns"] == "pulled"
+
+
+# ── POST /api/models/inspect ───────────────────────────────────────────────
+
+
+def _hf_handler(
+    *,
+    meta_status: int = 200,
+    tree_status: int = 200,
+    meta_body: dict[str, Any] | None = None,
+    tree_body: list[dict[str, Any]] | None = None,
+    fail_with: type[Exception] | None = None,
+):
+    """Build an httpx MockTransport handler for the inspect tests."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if fail_with is not None:
+            raise fail_with("simulated transport failure")
+        path = req.url.path
+        if path.endswith("/tree/main"):
+            return httpx.Response(tree_status, json=tree_body or [])
+        # Meta endpoint
+        return httpx.Response(meta_status, json=meta_body or {})
+
+    return handler
+
+
+def _patch_httpx_transport(monkeypatch: pytest.MonkeyPatch, handler) -> None:
+    """Patch ``httpx.AsyncClient`` so the inspect route uses our mock transport.
+
+    The route constructs its own ``AsyncClient`` for the HF fetch. We
+    intercept by replacing the class with a thin wrapper that injects
+    ``transport=MockTransport(handler)``.
+    """
+    real_cls = httpx.AsyncClient
+
+    def factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_cls(*args, **kwargs)
+
+    monkeypatch.setattr("hal0.api.routes.models.httpx.AsyncClient", factory)
+
+
+def test_inspect_returns_gguf_variants_sorted_by_size(
+    inspect_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The route surfaces .gguf entries with LFS size + sorts ascending."""
+    tree = [
+        {"path": "README.md", "size": 4096},
+        {
+            "path": "qwen3-8b-q4_k_m.gguf",
+            "lfs": {"size": 4_900_000_000},
+            "size": 132,
+        },
+        {
+            "path": "qwen3-8b-q8_0.gguf",
+            "lfs": {"size": 8_500_000_000},
+            "size": 132,
+        },
+        {"path": "tokenizer.json", "size": 1024},
+    ]
+    meta = {
+        "tags": ["text-generation", "gguf"],
+        "cardData": {"license": "apache-2.0", "description": "Hello world."},
+    }
+    _patch_httpx_transport(
+        monkeypatch,
+        _hf_handler(meta_body=meta, tree_body=tree),
+    )
+
+    r = inspect_client.post(
+        "/api/models/inspect",
+        json={"hf_repo": "unsloth/Qwen3-8B-GGUF"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["repo"] == "unsloth/Qwen3-8B-GGUF"
+    ids = [v["id"] for v in body["variants"]]
+    assert ids == ["qwen3-8b-q4_k_m.gguf", "qwen3-8b-q8_0.gguf"]
+    assert body["variants"][0]["size_bytes"] == 4_900_000_000
+    assert "gguf" in body["tags"]
+    assert body["metadata"]["license"] == "apache-2.0"
+    assert "Hello world" in body["metadata"]["readme_excerpt"]
+
+
+def test_inspect_accepts_hf_url_alias(
+    inspect_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``hf_url`` is accepted as an alias for ``hf_repo``."""
+    _patch_httpx_transport(
+        monkeypatch,
+        _hf_handler(meta_body={"tags": []}, tree_body=[]),
+    )
+
+    r = inspect_client.post(
+        "/api/models/inspect",
+        json={"hf_url": "https://huggingface.co/foo/bar"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["repo"] == "foo/bar"
+    assert body["variants"] == []
+
+
+def test_inspect_caches_response_for_repeated_calls(
+    inspect_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 5 minute in-process cache prevents a second HF hit on the
+    second click."""
+    hits = {"count": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        hits["count"] += 1
+        if req.url.path.endswith("/tree/main"):
+            return httpx.Response(200, json=[])
+        return httpx.Response(200, json={"tags": []})
+
+    _patch_httpx_transport(monkeypatch, handler)
+    r1 = inspect_client.post("/api/models/inspect", json={"hf_repo": "org/cached"})
+    r2 = inspect_client.post("/api/models/inspect", json={"hf_repo": "org/cached"})
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r2.json()["cached"] is True
+    # Each fresh fetch issues two requests (meta + tree); a cached call
+    # issues none.
+    assert hits["count"] == 2
+
+
+def test_inspect_returns_502_when_hf_unreachable(
+    inspect_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transport failure surfaces as ``hf.unreachable`` with status 502."""
+    _patch_httpx_transport(
+        monkeypatch,
+        _hf_handler(fail_with=httpx.ConnectError),
+    )
+
+    r = inspect_client.post(
+        "/api/models/inspect",
+        json={"hf_repo": "org/down"},
+    )
+    assert r.status_code == 502, r.text
+    body = r.json()
+    assert body["error"]["code"] == "hf.unreachable"
+    assert body["error"]["details"]["repo"] == "org/down"
+
+
+def test_inspect_returns_404_when_repo_missing(
+    inspect_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 404 from HF surfaces as ``hf.repo_not_found``."""
+    _patch_httpx_transport(
+        monkeypatch,
+        _hf_handler(meta_status=404, meta_body={"error": "not found"}),
+    )
+
+    r = inspect_client.post(
+        "/api/models/inspect",
+        json={"hf_repo": "org/missing"},
+    )
+    assert r.status_code == 404, r.text
+    assert r.json()["error"]["code"] == "hf.repo_not_found"
+
+
+def test_inspect_rejects_missing_repo_input(inspect_client: TestClient) -> None:
+    """Either ``hf_repo`` or ``hf_url`` must be present + non-empty."""
+    r = inspect_client.post("/api/models/inspect", json={})
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "hf.bad_request"
+
+
+def test_inspect_rejects_non_org_name_input(inspect_client: TestClient) -> None:
+    """Single-token inputs like 'qwen' are rejected as not org/name."""
+    r = inspect_client.post("/api/models/inspect", json={"hf_repo": "qwen"})
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "hf.bad_request"
+
+
+def test_inspect_bad_json_returns_400(inspect_client: TestClient) -> None:
+    """Non-JSON bodies are rejected with the validation envelope."""
+    r = inspect_client.post(
+        "/api/models/inspect",
+        content=b"not json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert r.status_code == 400, r.text
+
+
+# ── Negative: inspect must not eat HF's pointer-file sizes ─────────────────
+
+
+def test_inspect_falls_back_to_top_level_size_when_no_lfs(
+    inspect_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """For non-LFS files we fall back to the top-level ``size``."""
+    tree = [
+        {"path": "tiny.gguf", "size": 12_345},
+    ]
+    _patch_httpx_transport(
+        monkeypatch,
+        _hf_handler(meta_body={"tags": []}, tree_body=tree),
+    )
+
+    r = inspect_client.post("/api/models/inspect", json={"hf_repo": "org/tiny"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["variants"][0]["size_bytes"] == 12_345
+
+
+# ── Smoke: ensure JSON content-type is what gets returned ──────────────────
+
+
+def test_inspect_response_is_application_json(
+    inspect_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_httpx_transport(
+        monkeypatch,
+        _hf_handler(meta_body={"tags": []}, tree_body=[]),
+    )
+    r = inspect_client.post("/api/models/inspect", json={"hf_repo": "org/x"})
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("application/json")
+    # And the body is parseable JSON.
+    json.loads(r.content)

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -114,6 +114,10 @@ export const apiPost = <T = unknown>(path: string, body?: ApiOptions['body']) =>
 export const apiPatch = <T = unknown>(path: string, body?: ApiOptions['body']) =>
   api<T>(path, { method: 'PATCH', body })
 
+/** Convenience: typed PUT with JSON body. */
+export const apiPut = <T = unknown>(path: string, body?: ApiOptions['body']) =>
+  api<T>(path, { method: 'PUT', body })
+
 /** Convenience: typed DELETE. */
 export const apiDelete = <T = unknown>(path: string) =>
   api<T>(path, { method: 'DELETE' })

--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -12,7 +12,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { apiDelete, apiGet, apiPost, Hal0Error } from '../client'
+import { apiDelete, apiGet, apiPost, apiPut, Hal0Error } from '../client'
 import { ENDPOINTS } from '../endpoints'
 
 export interface Model {
@@ -52,17 +52,55 @@ export function useModel(id: string | null | undefined) {
   })
 }
 
+export interface ModelInspectVariant {
+  id: string
+  size_bytes: number
+  size: string
+  info: string
+}
+
+export interface ModelInspectResponse {
+  repo: string
+  cached: boolean
+  variants: ModelInspectVariant[]
+  tags: string[]
+  metadata: {
+    license: string
+    readme_excerpt: string
+  }
+}
+
 export function useModelInspect() {
-  // POST a HF coord and get back a curated-model preview.
-  return useMutation({
-    mutationFn: (body: { hf_url: string }) => apiPost(ENDPOINTS.modelInspect, body),
+  // POST a HF coord and get back the repo's pullable GGUF variants
+  // plus tags + license + a short README excerpt. Accepts either an
+  // ``hf_repo`` slug or the older ``hf_url`` alias.
+  return useMutation<ModelInspectResponse, Hal0Error, { hf_repo?: string; hf_url?: string }>({
+    mutationFn: (body) => apiPost<ModelInspectResponse>(ENDPOINTS.modelInspect, body),
   })
+}
+
+export interface ModelDeleteResponse {
+  id: string
+  deleted: boolean
+  affected_slots: string[]
 }
 
 export function useModelDelete() {
   const qc = useQueryClient()
-  return useMutation({
-    mutationFn: (id: string) => apiDelete(ENDPOINTS.model(id)),
+  return useMutation<ModelDeleteResponse, Hal0Error, string>({
+    mutationFn: (id: string) => apiDelete<ModelDeleteResponse>(ENDPOINTS.model(id)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['models'] }),
+  })
+}
+
+export function useModelUpdate() {
+  // Partial update — PUT /api/models/{id} with any subset of
+  // ``name | capabilities | backends | defaults``. The dashboard's
+  // Recipe editor uses this for the per-model defaults section.
+  const qc = useQueryClient()
+  return useMutation<Model, Hal0Error, { id: string; body: Record<string, unknown> }>({
+    mutationFn: ({ id, body }) =>
+      apiPut<Model>(ENDPOINTS.model(id), body),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['models'] }),
   })
 }

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -1,46 +1,97 @@
 // hal0 dashboard — Model interactive surface
-// Add by HF coords modal · Delete model confirm · Downloads error/paused states ·
-// "Used by" slot panel · "On disk" panel for the detail pane
+//
+// Add by HF coords modal · Recipe editor · Delete confirm ·
+// "Used by" slot panel · "On disk" panel · DownloadRow (live SSE).
+//
+// Phase B2 wireup (#220 brief): every modal now drives off real
+// hooks — `useModelInspect` populates the variant list, `usePullJob`
+// owns the pull lifecycle, `useModelUpdate` saves recipe edits, and
+// `useModelDelete` returns the cascade affected_slots straight from
+// the backend. The old HAL0_DATA fallbacks live on only as cosmetic
+// fixtures (host RAM, /var disk hint).
 
-const { useState: useStateMM, useEffect: useEffectMM } = React;
+import { useModelInspect, useModelUpdate, useModelDelete, usePullJob, fmtBytes, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
+import { useSlots } from '@/api/hooks/useSlots'
+
+const { useState: useStateMM, useEffect: useEffectMM, useMemo: useMemoMM } = React;
 
 // ─── Add model by HF coords ─────────────────────────────────────
 function AddByHfModal({ open, onClose }) {
   const [repo, setRepo] = useStateMM("");
-  const [inspected, setInspected] = useStateMM(false);
-  const [inspecting, setInspecting] = useStateMM(false);
   const [variant, setVariant] = useStateMM(null);
   const [name, setName] = useStateMM("");
   const [labels, setLabels] = useStateMM({ chat: true });
   const [mmproj, setMmproj] = useStateMM("");
 
+  const inspect = useModelInspect();
+  const pullJob = usePullJob();
+
   useEffectMM(() => {
     if (open) {
-      setRepo(""); setInspected(false); setInspecting(false);
-      setVariant(null); setName(""); setLabels({ chat: true }); setMmproj("");
+      setRepo(""); setVariant(null); setName(""); setLabels({ chat: true }); setMmproj("");
+      inspect.reset();
+      pullJob.reset();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  const variants = [
-    { id: "Q4_K_M",     size: "4.9 GB", info: "single file" },
-    { id: "UD-Q4_K_XL", size: "5.1 GB", info: "single file · unsloth dynamic" },
-    { id: "Q8_0",       size: "8.5 GB", info: "sharded · 2 files" },
-    { id: "Q4_0",       size: "4.7 GB", info: "single file · legacy" },
-    { id: "F16",        size: "16.2 GB", info: "single file · full precision" },
-  ];
+  const variants = inspect.data?.variants ?? [];
+  // mmproj affordance — HF repos often ship an mmproj-Q8.gguf next to
+  // the main quants. Pick those out of the same variant list so the
+  // dropdown reflects what's actually in the repo.
+  const mmprojChoices = useMemoMM(
+    () => variants.filter(v => /mmproj/i.test(v.id)).map(v => v.id),
+    [variants],
+  );
 
-  const inspect = () => {
+  const onInspect = async () => {
     if (!repo) return;
-    setInspecting(true);
-    setTimeout(() => {
-      setInspecting(false);
-      setInspected(true);
-      setName("user." + (repo.split("/")[1] || "model").replace(/-GGUF$/, ""));
-    }, 600);
+    try {
+      const result = await inspect.mutateAsync({ hf_repo: repo });
+      // Auto-suggest a user.* name from the repo's tail segment.
+      const tail = (result?.repo || repo).split("/")[1] || "model";
+      setName(prev => prev || ("user." + tail.replace(/-GGUF$/i, "")));
+    } catch (e) {
+      // The toast surface already renders the Hal0Error envelope;
+      // surface a hint for offline mock scenarios so the operator
+      // doesn't think the button is wedged.
+      window.__hal0Toast && window.__hal0Toast(
+        `Inspect failed — ${e?.message || "unreachable"}`,
+        "err",
+      );
+    }
   };
 
+  const inspected = inspect.isSuccess && !!inspect.data;
   const sel = variants.find(v => v.id === variant);
-  const canPull = inspected && variant && name;
+  const canPull = inspected && variant && name && !pullJob.inFlight;
+
+  const onPull = async () => {
+    if (!canPull) return;
+    try {
+      // The pull endpoint keys on the registry model id. We use the
+      // operator-chosen ``name`` so the row lands under their preferred
+      // namespace, and pass the HF variant + optional mmproj as the
+      // pull job body — the backend resolves them against the registry
+      // entry's hf_repo/hf_filename it writes during the curated
+      // ``pick-default`` flow.
+      const labelList = Object.entries(labels).filter(([, v]) => v).map(([k]) => k);
+      await pullJob.start(name, {
+        hf_repo: inspect.data?.repo ?? repo,
+        hf_filename: variant,
+        mmproj_filename: mmproj || undefined,
+        labels: labelList,
+      });
+      window.__hal0Toast && window.__hal0Toast(
+        `Pulling ${name} · ${sel?.size ?? ""}`, "info",
+      );
+      onClose();
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(
+        `Pull failed — ${e?.message || "see logs"}`, "err",
+      );
+    }
+  };
 
   return (
     <Modal
@@ -51,10 +102,10 @@ function AddByHfModal({ open, onClose }) {
       width={680}
       foot={
         <>
-          <span>Files land under <span className="mono">/var/lib/hal0/models/user.*</span></span>
+          <span>Files land under <span className="mono">/var/lib/hal0/models/&lt;id&gt;</span></span>
           <span style={{display: "inline-flex", gap: 8}}>
             <button className="btn ghost sm" onClick={onClose}>Cancel</button>
-            <button className="btn sm" disabled={!canPull} onClick={() => { onClose(); window.__hal0Toast && window.__hal0Toast(`Pulling ${name} · ${sel ? sel.size : ""}`, "info"); }}>
+            <button className="btn sm" disabled={!canPull} onClick={onPull}>
               {Icons.download} Pull{sel ? ` (${sel.size})` : ""}
             </button>
           </span>
@@ -70,26 +121,40 @@ function AddByHfModal({ open, onClose }) {
           <input
             className="input mono"
             value={repo}
-            onChange={e => { setRepo(e.target.value); setInspected(false); }}
+            onChange={e => { setRepo(e.target.value); inspect.reset(); }}
             placeholder="unsloth/Qwen3-8B-GGUF"
             style={{flex: 1}}
             autoFocus
           />
-          <button className="btn ghost sm" disabled={!repo || inspecting} onClick={inspect}>
-            {inspecting ? "Inspecting…" : "Inspect"}
+          <button className="btn ghost sm" disabled={!repo || inspect.isPending} onClick={onInspect}>
+            {inspect.isPending ? "Inspecting…" : "Inspect"}
           </button>
         </div>
       </div>
+
+      {inspect.isError && (
+        <div className="err" style={{marginBottom: 10}}>
+          {inspect.error?.code === "hf.repo_not_found"
+            ? `HF repo not found: ${repo}`
+            : `Inspect failed: ${inspect.error?.message || "unreachable"}`}
+        </div>
+      )}
 
       {inspected && (
         <>
           <div className="form-row">
             <div className="form-lbl">
               <span>Variants <span className="req">*</span></span>
-              <span className="sub">{variants.length} available · pick a quant</span>
+              <span className="sub">
+                {variants.length} available · pick a quant
+              </span>
             </div>
             <div className="form-ctl" style={{display: "flex", flexDirection: "column", gap: 6}}>
-              {variants.map(v => (
+              {variants.length === 0 ? (
+                <div className="mono" style={{fontSize: 12, color: "var(--fg-4)", fontStyle: "italic"}}>
+                  No .gguf files found in this repo.
+                </div>
+              ) : variants.filter(v => !/mmproj/i.test(v.id)).map(v => (
                 <div
                   key={v.id}
                   className={"variant-row" + (variant === v.id ? " sel" : "")}
@@ -101,15 +166,8 @@ function AddByHfModal({ open, onClose }) {
                     <span className="sub">{v.info}</span>
                   </span>
                   <span className="sz num">{v.size}</span>
-                  <span className="info">{HAL0_DATA.host.ram.free > parseSizeGB(v.size) ? "✓ fits" : "tight on RAM"}</span>
                 </div>
               ))}
-              <div className="variant-row" onClick={() => setVariant("other")} style={{borderStyle: "dashed"}}>
-                <span className="rad" />
-                <span className="nm">Other…<span className="sub">free-text quant tag</span></span>
-                <span></span>
-                <span></span>
-              </div>
             </div>
           </div>
 
@@ -153,21 +211,29 @@ function AddByHfModal({ open, onClose }) {
               </div>
               <div className="form-ctl">
                 <select className="input mono" value={mmproj} onChange={e => setMmproj(e.target.value)}>
-                  <option value="">— pick from repo files…</option>
-                  <option>mmproj-Q8_0.gguf</option>
-                  <option>mmproj-F16.gguf</option>
+                  <option value="">
+                    {mmprojChoices.length === 0
+                      ? "— no mmproj files in repo —"
+                      : "— pick from repo files… —"}
+                  </option>
+                  {mmprojChoices.map(id => <option key={id} value={id}>{id}</option>)}
                 </select>
               </div>
             </div>
           )}
 
+          {inspect.data?.metadata?.license && (
+            <div className="form-section">License · <span className="mono" style={{color: "var(--fg)"}}>{inspect.data.metadata.license}</span></div>
+          )}
+
           <div className="form-section">Pre-flight</div>
           <div style={{padding: 12, background: "var(--bg)", border: "1px solid var(--line-soft)", borderRadius: "var(--rad-sm)", fontFamily: "var(--jbm)", fontSize: 11.5, lineHeight: 1.7}}>
-            <div>repo · <span style={{color: "var(--fg)"}}>{repo}</span></div>
+            <div>repo · <span style={{color: "var(--fg)"}}>{inspect.data?.repo || repo}</span></div>
             <div>variant · <span style={{color: "var(--fg)"}}>{variant || "—"}</span></div>
             <div>size · <span style={{color: "var(--fg)"}}>{sel ? sel.size : "—"}</span></div>
-            <div>disk · <span style={{color: "var(--ok)"}}>412 GB free on /var ✓</span></div>
-            <div>auth · <span style={{color: "var(--ok)"}}>HF_TOKEN set ✓</span></div>
+            {pullJob.inFlight && (
+              <div>pull · <span style={{color: "var(--accent)"}}>{pullJob.state} {pullJob.pct != null ? `${pullJob.pct}%` : ""}</span></div>
+            )}
           </div>
         </>
       )}
@@ -175,21 +241,140 @@ function AddByHfModal({ open, onClose }) {
   );
 }
 
+// ─── Recipe editor (per-model defaults) ────────────────────────
+function RecipeEditorModal({ open, onClose, model }) {
+  const update = useModelUpdate();
+  const init = model?.defaults || {};
+  const [ctx, setCtx] = useStateMM("");
+  const [ngl, setNgl] = useStateMM("");
+  const [extra, setExtra] = useStateMM("");
+
+  useEffectMM(() => {
+    if (open && model) {
+      setCtx(init.context_size != null ? String(init.context_size) : "");
+      setNgl(init.n_gpu_layers != null ? String(init.n_gpu_layers) : "");
+      setExtra(init.extra_args || "");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, model?.id]);
+
+  if (!model) return null;
+
+  const onSave = async () => {
+    const defaults = {};
+    if (ctx.trim()) {
+      const n = parseInt(ctx, 10);
+      if (Number.isFinite(n)) defaults.context_size = n;
+    }
+    if (ngl.trim()) {
+      const n = parseInt(ngl, 10);
+      if (Number.isFinite(n)) defaults.n_gpu_layers = n;
+    }
+    if (extra.trim()) defaults.extra_args = extra;
+    try {
+      await update.mutateAsync({ id: model.id, body: { defaults } });
+      window.__hal0Toast && window.__hal0Toast(`Updated ${model.longName || model.id}`, "ok");
+      onClose();
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(
+        `Save failed — ${e?.message || "see logs"}`, "err",
+      );
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      eyebrow="Recipe · edit defaults"
+      title={`Edit options · ${model.longName || model.name || model.id}`}
+      width={560}
+      foot={
+        <>
+          <span style={{color: "var(--warn)"}}>⟳ ctx_size + extra_args require slot restart</span>
+          <span style={{display: "inline-flex", gap: 8}}>
+            <button className="btn ghost sm" onClick={onClose}>Cancel</button>
+            <button className="btn sm" onClick={onSave} disabled={update.isPending}>
+              {update.isPending ? "Saving…" : "Save options"}
+            </button>
+          </span>
+        </>
+      }
+    >
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>context_size</span>
+          <span className="sub">tokens · empty = launcher default</span>
+        </div>
+        <div className="form-ctl">
+          <input className="input mono" inputMode="numeric" placeholder="e.g. 8192" value={ctx} onChange={e => setCtx(e.target.value)} />
+        </div>
+      </div>
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>n_gpu_layers</span>
+          <span className="sub">-1 = all on GPU · 0 = CPU only</span>
+        </div>
+        <div className="form-ctl">
+          <input className="input mono" inputMode="numeric" placeholder="e.g. -1" value={ngl} onChange={e => setNgl(e.target.value)} />
+        </div>
+      </div>
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>extra_args</span>
+          <span className="sub">freeform · appended after slot extra_args</span>
+        </div>
+        <div className="form-ctl">
+          <input className="input mono" placeholder="--rope-freq-base 10000" value={extra} onChange={e => setExtra(e.target.value)} />
+        </div>
+      </div>
+      {update.isError && (
+        <div className="err">{update.error?.message || "Save failed"}</div>
+      )}
+    </Modal>
+  );
+}
+
 // ─── Delete model confirm ───────────────────────────────────────
 function DeleteModelDialog({ open, onClose, model }) {
+  const del = useModelDelete();
+  // Live affected_slots — prefer the cascade response when the user
+  // has already attempted a force_cascade=false dry-run (not yet
+  // wired in B2); for the default flow we fall back to the live
+  // slots query so the warning matches what the registry sees.
+  const slotsQuery = useSlots();
   if (!model) return null;
-  // Structured match by model_id (preferred); falls back to id for legacy entries.
-  const slotsUsing = HAL0_DATA.slots.filter(s => s.model_id === model.id);
+  const slots = slotsQuery.data ?? [];
+  const slotsUsing = slots.filter(s => (s.model_id || s.model?.default) === model.id);
   const hasUsers = slotsUsing.length > 0;
+
+  const onConfirm = async () => {
+    try {
+      const res = await del.mutateAsync(model.id);
+      const cascaded = res?.affected_slots?.length || 0;
+      window.__hal0Toast && window.__hal0Toast(
+        cascaded
+          ? `Deleted ${model.longName || model.id} (cascaded ${cascaded} slot${cascaded > 1 ? "s" : ""})`
+          : `Deleted ${model.longName || model.id}`,
+        "ok",
+      );
+      onClose();
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(
+        `Delete failed — ${e?.message || "see logs"}`, "err",
+      );
+    }
+  };
+
   return (
     <ConfirmDialog
       open={open}
       onCancel={onClose}
-      onConfirm={() => { onClose(); window.__hal0Toast && window.__hal0Toast(`Deleted ${model.longName}`, "ok"); }}
-      title={`Delete ${model.longName}?`}
+      onConfirm={onConfirm}
+      title={`Delete ${model.longName || model.name || model.id}?`}
       message={
         <span>
-          This removes <span className="mono" style={{color: "var(--fg)"}}>{model.size}</span> from <span className="mono">/var/lib/hal0/models</span>.{" "}
+          This removes <span className="mono" style={{color: "var(--fg)"}}>{model.size || fmtBytes(model.size_bytes || 0)}</span> from <span className="mono">/var/lib/hal0/models</span>.{" "}
           {hasUsers && (
             <span style={{display: "block", marginTop: 10, padding: "10px 12px", background: "var(--warn-soft)", border: "1px solid var(--warn-line)", borderRadius: "var(--rad-sm)", color: "var(--warn)", fontFamily: "var(--jbm)", fontSize: 12}}>
               ⚠ {slotsUsing.length} slot{slotsUsing.length > 1 ? "s" : ""} reference this model: <b>{slotsUsing.map(s => s.name).join(", ")}</b>. They'll move to <span className="mono">empty</span> state. Re-configure with a different model first if you need them live.
@@ -197,7 +382,7 @@ function DeleteModelDialog({ open, onClose, model }) {
           )}
         </span>
       }
-      confirmLabel="Delete model"
+      confirmLabel={del.isPending ? "Deleting…" : "Delete model"}
       destructive
       typeToConfirm={hasUsers ? model.id : null}
     />
@@ -206,8 +391,10 @@ function DeleteModelDialog({ open, onClose, model }) {
 
 // ─── Used-by panel (Model detail) ───────────────────────────────
 function UsedByPanel({ model }) {
+  const slotsQuery = useSlots();
   if (!model) return null;
-  const using = HAL0_DATA.slots.filter(s => s.model_id === model.id);
+  const slots = slotsQuery.data ?? [];
+  const using = slots.filter(s => (s.model_id || s.model?.default) === model.id);
   return (
     <div className="mdl-detail-recipe">
       <div className="lbl">Used by</div>
@@ -220,11 +407,11 @@ function UsedByPanel({ model }) {
           <div key={s.name} className="ro-row" style={{cursor: "pointer", padding: "7px 0"}}
                onClick={() => { window.location.hash = "#slots/" + s.name; }}>
             <span className="k" style={{display: "flex", alignItems: "center", gap: 6}}>
-              <span className={"dot " + s.state} />
+              <span className={"dot " + (s.state || "empty")} />
               {s.name}
             </span>
             <span className="v" style={{display: "flex", alignItems: "center", gap: 6}}>
-              <span style={{color: "var(--fg-3)"}}>{s.type} · {s.device}</span>
+              <span style={{color: "var(--fg-3)"}}>{s.type || ""} · {s.device || s.backend || ""}</span>
               {s.isDefault && <span className="chip outlined amber">default</span>}
               <span style={{marginLeft: "auto", color: "var(--accent)"}}>→</span>
             </span>
@@ -238,102 +425,118 @@ function UsedByPanel({ model }) {
 // ─── On-disk panel (Model detail) ───────────────────────────────
 function OnDiskPanel({ model }) {
   if (!model || !model.installed) return null;
+  const path = model.path || `/var/lib/hal0/models/${model.id}/`;
   return (
     <div className="mdl-detail-recipe">
       <div className="lbl">On disk</div>
       <div className="ro-row">
         <span className="k">path</span>
-        <span className="v" style={{wordBreak: "break-all", fontSize: 11}}>/var/lib/hal0/models/{model.id}.gguf</span>
+        <span className="v" style={{wordBreak: "break-all", fontSize: 11}}>{path}</span>
       </div>
       <div className="ro-row">
-        <span className="k">sha256</span>
-        <span className="v" style={{fontSize: 11, color: "var(--fg-3)"}}>a3f4…b87c</span>
+        <span className="k">size</span>
+        <span className="v">{model.size || fmtBytes(model.size_bytes || 0)}</span>
       </div>
       <div className="ro-row">
-        <span className="k">verified</span>
-        <span className="v"><span style={{color: "var(--ok)"}}>✓</span> 41 days ago</span>
+        <span className="k">ns</span>
+        <span className="v">{model.ns || "—"}</span>
       </div>
       <div style={{display: "flex", gap: 6, marginTop: 8}}>
-        <button className="btn ghost sm" onClick={() => window.__hal0Toast && window.__hal0Toast("Path copied to clipboard", "ok")}>Copy path</button>
-        <button className="btn ghost sm" onClick={() => window.__hal0Toast && window.__hal0Toast("Verifying sha256…", "info")}>Re-verify</button>
+        <button className="btn ghost sm" onClick={() => {
+          navigator.clipboard?.writeText(path);
+          window.__hal0Toast && window.__hal0Toast("Path copied to clipboard", "ok");
+        }}>Copy path</button>
       </div>
     </div>
   );
 }
 
-// ─── Download row with full state vocabulary ────────────────────
-function DownloadRow({ dl, onPause, onResume, onCancel, onRetry, onRemove }) {
-  const state = dl.state;
+// ─── Download row backed by usePullJob ──────────────────────────
+function DownloadRow({ modelId, onRemove }) {
+  const job = usePullJob();
+  // Reattach on mount so a refresh keeps showing in-flight pulls.
+  useEffectMM(() => {
+    if (modelId) job.reattach(modelId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modelId]);
+
+  const state = job.state;
+  const pct = job.pct ?? 0;
+  const onPause = () => {
+    // Lemonade pull engine doesn't support pause — degrade gracefully
+    // by cancelling the in-flight transfer; the row can be re-pulled
+    // from the catalog.
+    job.cancel();
+  };
+  const onResume = () => { /* see Pause comment */ };
+  const onCancel = () => { job.cancel(); };
+  const onRetry = () => { job.start(modelId); };
+
   return (
     <div style={{padding: "12px 16px", borderBottom: "1px solid var(--line-soft)", position: "relative"}}>
       <div style={{display: "flex", justifyContent: "space-between", fontFamily: "var(--jbm)", fontSize: 11.5, marginBottom: 6, alignItems: "center", gap: 8}}>
         <span style={{
-          color: state === "done" ? "var(--ok)" : state === "cancelled" ? "var(--fg-4)" : state === "error" ? "var(--err)" : "var(--fg)",
+          color: state === "completed" ? "var(--ok)" : state === "cancelled" ? "var(--fg-4)" : state === "failed" ? "var(--err)" : "var(--fg)",
           overflow: "hidden",
           textOverflow: "ellipsis",
           whiteSpace: "nowrap",
           flex: 1,
           textDecoration: state === "cancelled" ? "line-through" : "none",
-        }}>{dl.name}</span>
+        }}>{modelId}</span>
         <span style={{
-          color: state === "done" ? "var(--ok)" : state === "queued" ? "var(--fg-4)" : state === "paused" ? "var(--warn)" : state === "error" ? "var(--err)" : "var(--fg)",
+          color: state === "completed" ? "var(--ok)" : state === "queued" ? "var(--fg-4)" : state === "failed" ? "var(--err)" : "var(--fg)",
           fontSize: 11,
         }}>
-          {state === "done"      && "✓ done"}
+          {state === "completed" && "✓ done"}
           {state === "queued"    && "queued"}
-          {state === "pulling"   && `${dl.pct}%`}
-          {state === "paused"    && `${dl.pct}% paused`}
-          {state === "verifying" && "verifying…"}
+          {state === "running"   && `${pct}%`}
           {state === "cancelled" && "cancelled"}
-          {state === "error"     && "failed"}
+          {state === "failed"    && "failed"}
+          {state === "idle"      && "—"}
         </span>
       </div>
       <div className="dl-bar" style={{height: 4}}>
         <i style={{
-          width: `${dl.pct || 0}%`,
-          background: state === "done" ? "var(--ok)" : state === "error" ? "var(--err)" : state === "paused" || state === "cancelled" ? "var(--fg-4)" : "var(--accent)",
+          width: `${pct}%`,
+          background: state === "completed" ? "var(--ok)" : state === "failed" ? "var(--err)" : state === "cancelled" ? "var(--fg-4)" : "var(--accent)",
         }} />
       </div>
-      {state === "pulling" && (
+      {state === "running" && (
         <div style={{display: "flex", justifyContent: "space-between", fontFamily: "var(--jbm)", fontSize: 10, color: "var(--fg-4)", marginTop: 4}}>
-          <span>{dl.done} / {dl.size}</span>
-          <span>{dl.rate} · {dl.eta}</span>
+          <span>{fmtBytes(job.downloaded)} / {fmtBytes(job.total)}</span>
+          <span>{fmtSpeed(job.speedBps)} · {fmtEta(job.etaS)}</span>
         </div>
       )}
-      {state === "error" && (
+      {state === "failed" && job.error && (
         <div style={{marginTop: 6, padding: "8px 10px", background: "var(--err-soft)", border: "1px solid var(--err-line)", borderRadius: "var(--rad-sm)", fontFamily: "var(--jbm)", fontSize: 11, color: "var(--err)"}}>
-          corrupted shard 2/2 · sha256 mismatch
+          {job.error.message || "pull failed"}
         </div>
       )}
-      {/* Per-row actions */}
       <div style={{display: "flex", gap: 4, marginTop: 6}}>
-        {state === "pulling" && (
+        {state === "running" && (
           <>
-            <button className="btn ghost sm" onClick={() => onPause && onPause(dl)}>Pause</button>
-            <button className="btn ghost sm" onClick={() => onCancel && onCancel(dl)}>Cancel</button>
-          </>
-        )}
-        {state === "paused" && (
-          <>
-            <button className="btn ghost sm" onClick={() => onResume && onResume(dl)}>Resume</button>
-            <button className="btn ghost sm" onClick={() => onCancel && onCancel(dl)}>Cancel</button>
+            <button className="btn ghost sm" onClick={onPause}>Pause</button>
+            <button className="btn ghost sm" onClick={onCancel}>Cancel</button>
           </>
         )}
         {state === "queued" && (
-          <button className="btn ghost sm" onClick={() => onCancel && onCancel(dl)}>Cancel</button>
+          <button className="btn ghost sm" onClick={onCancel}>Cancel</button>
         )}
-        {state === "error" && (
+        {state === "failed" && (
           <>
-            <button className="btn ghost sm" onClick={() => onRetry && onRetry(dl)}>{Icons.restart} Retry</button>
-            <button className="btn ghost sm" onClick={() => onRemove && onRemove(dl)}>Remove</button>
+            <button className="btn ghost sm" onClick={onRetry}>{Icons.restart} Retry</button>
+            <button className="btn ghost sm" onClick={() => onRemove && onRemove(modelId)}>Remove</button>
           </>
         )}
         {state === "cancelled" && (
-          <button className="btn ghost sm" onClick={() => onRemove && onRemove(dl)}>Remove</button>
+          <button className="btn ghost sm" onClick={() => onRemove && onRemove(modelId)}>Remove</button>
+        )}
+        {state === "completed" && (
+          <button className="btn ghost sm" onClick={() => onRemove && onRemove(modelId)}>Dismiss</button>
         )}
       </div>
     </div>
   );
 }
 
-Object.assign(window, { AddByHfModal, DeleteModelDialog, UsedByPanel, OnDiskPanel, DownloadRow });
+Object.assign(window, { AddByHfModal, RecipeEditorModal, DeleteModelDialog, UsedByPanel, OnDiskPanel, DownloadRow });

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -1,24 +1,39 @@
 // hal0 dashboard — Models view (catalog + detail + downloads)
 //
-// Phase B1: catalog drives off `useModels()`. Mock fallback retains the
-// HAL0_DATA.models shape so dev + mock builds render. Downloads pane
-// keeps its local optimistic-state UI; per-row SSE wiring lands when
-// the prototype's DownloadRow swaps to `usePullJob(id)` (Phase B2).
+// Phase B2 wireup (#220 brief): the catalog is driven entirely by
+// useModels(); the HAL0_DATA fallback is gone now the backend always
+// emits ``ns`` on every row. The detail pane's Recipe section reads
+// each model's persisted ``defaults`` and writes them back via PUT
+// /api/models/{id}, and the Downloads pane is a thin shell around
+// per-row usePullJob() instances tracked by model_id.
 
-import { useModels } from '@/api/hooks/useModels'
+import { useModels, usePullJob, fmtBytes } from '@/api/hooks/useModels'
 
-const { useState: useStateM } = React;
+const { useState: useStateM, useMemo: useMemoM, useEffect: useEffectM } = React;
 
 function ModelsView() {
-  const [selId, setSelId] = useStateM("qwen3.6-27b-mtp");
+  const [selId, setSelId] = useStateM(null);
   const [filters, setFilters] = useStateM({ type: null, device: null, ns: null });
   const [addOpen, setAddOpen] = useStateM(false);
+  const [recipeOpen, setRecipeOpen] = useStateM(false);
   const [delModel, setDelModel] = useStateM(null);
+  // Track which model_ids the user has launched a pull for this
+  // session — the Downloads pane renders one DownloadRow per entry
+  // and each row owns its own usePullJob() instance (which reattaches
+  // to an in-flight pull on mount).
+  const [activePulls, setActivePulls] = useStateM([]);
 
   const modelsQuery = useModels();
-  const modelList = (modelsQuery.data && modelsQuery.data.length > 0)
-    ? modelsQuery.data
-    : HAL0_DATA.models;
+  const modelList = modelsQuery.data ?? [];
+
+  // Auto-pick the first installed model on first render so the detail
+  // pane never opens empty.
+  useEffectM(() => {
+    if (!selId && modelList.length) {
+      const first = modelList.find(m => m.installed) || modelList[0];
+      if (first) setSelId(first.id);
+    }
+  }, [modelList, selId]);
 
   const selected = modelList.find(m => m.id === selId) || modelList[0];
 
@@ -30,11 +45,22 @@ function ModelsView() {
   };
   const installed = modelList.filter(m => m.installed && fil(m));
   const blessed = modelList.filter(m => !m.installed && m.ns === "blessed" && fil(m));
-  const userNs = modelList.filter(m => m.ns === "pulled" && fil(m));
+  const userNs = modelList.filter(m => m.ns === "pulled" && !m.installed && fil(m));
 
   const toggle = (k, v) => setFilters(f => ({ ...f, [k]: f[k] === v ? null : v }));
 
-  const recipe = HAL0_DATA.recipe[selId] || HAL0_DATA.recipe["qwen3.6-27b-mtp"];
+  // Listen for any other surface (FirstRun, Add modal) that starts a
+  // pull and surface it in our Downloads pane.
+  useEffectM(() => {
+    const handler = (e) => {
+      const id = e?.detail?.modelId;
+      if (id) setActivePulls(prev => prev.includes(id) ? prev : [...prev, id]);
+    };
+    window.addEventListener("hal0:pull-started", handler);
+    return () => window.removeEventListener("hal0:pull-started", handler);
+  }, []);
+
+  const removeActive = (id) => setActivePulls(prev => prev.filter(x => x !== id));
 
   return (
     <div className="view">
@@ -99,6 +125,15 @@ function ModelsView() {
             <span className="right">sort: <span style={{color: "var(--fg-2)"}}>installed</span> ▾</span>
           </div>
 
+          {modelsQuery.isPending && (
+            <div style={{padding: 16, fontFamily: "var(--jbm)", fontSize: 11, color: "var(--fg-4)"}}>Loading models…</div>
+          )}
+          {modelsQuery.isError && (
+            <div style={{padding: 16, fontFamily: "var(--jbm)", fontSize: 11, color: "var(--err)"}}>
+              {modelsQuery.error?.message || "Failed to load models"}
+            </div>
+          )}
+
           {installed.length > 0 && <div className="mdl-section-label">Installed · {installed.length}</div>}
           {installed.map(m => (
             <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
@@ -117,12 +152,18 @@ function ModelsView() {
 
         {/* ── Detail + Downloads ── */}
         <div style={{display: "flex", flexDirection: "column", gap: 14}}>
-          <ModelDetail model={selected} recipe={recipe} onDelete={() => setDelModel(selected)} />
-          <DownloadsPane />
+          <ModelDetail
+            model={selected}
+            onDelete={() => setDelModel(selected)}
+            onEdit={() => setRecipeOpen(true)}
+            onPullStarted={(id) => setActivePulls(prev => prev.includes(id) ? prev : [...prev, id])}
+          />
+          <DownloadsPane activeIds={activePulls} onRemove={removeActive} />
         </div>
       </div>
 
       <AddByHfModal open={addOpen} onClose={() => setAddOpen(false)} />
+      <RecipeEditorModal open={recipeOpen} onClose={() => setRecipeOpen(false)} model={selected} />
       <DeleteModelDialog open={!!delModel} onClose={() => setDelModel(null)} model={delModel} />
     </div>
   );
@@ -133,11 +174,11 @@ function ModelRow({ model, selected, onSelect }) {
     <div className={"mdl-row" + (selected ? " sel" : "")} onClick={onSelect}>
       <span className={"dot " + (model.installed ? "ready" : "empty")} />
       <span className="nm">
-        {model.longName}
-        <span className="sub">{model.repo}</span>
+        {model.longName || model.name || model.id}
+        <span className="sub">{model.repo || model.hf_repo || ""}</span>
       </span>
-      <span className="sz num">{model.params}</span>
-      <span className="sz num">{model.size}</span>
+      <span className="sz num">{model.params || ""}</span>
+      <span className="sz num">{model.size || (model.size_bytes ? fmtBytes(model.size_bytes) : "")}</span>
       <span className="tg">
         {model.installed
           ? <span className="chip ok">installed</span>
@@ -147,35 +188,73 @@ function ModelRow({ model, selected, onSelect }) {
   );
 }
 
-function ModelDetail({ model, recipe, onDelete }) {
+function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
+  const pull = usePullJob();
+  if (!model) {
+    return (
+      <div className="mdl-detail">
+        <div className="mdl-detail-h" style={{padding: 24, color: "var(--fg-4)"}}>No model selected.</div>
+      </div>
+    );
+  }
+  // Render the persisted defaults — pydantic ModelDefaults shape:
+  // {context_size, n_gpu_layers, rope_freq_base, extra_args}.
+  const defaults = model.defaults || {};
+  const recipeRows = [
+    ["context_size", defaults.context_size],
+    ["n_gpu_layers", defaults.n_gpu_layers],
+    ["rope_freq_base", defaults.rope_freq_base],
+    ["extra_args", defaults.extra_args],
+  ].filter(([, v]) => v !== null && v !== undefined && v !== "");
+
+  const onPull = async () => {
+    try {
+      await pull.start(model.id);
+      onPullStarted && onPullStarted(model.id);
+      window.dispatchEvent(new CustomEvent("hal0:pull-started", { detail: { modelId: model.id } }));
+      window.__hal0Toast && window.__hal0Toast(
+        `Pulling ${model.longName || model.id} · ${model.size || fmtBytes(model.size_bytes || 0)}`,
+        "info",
+      );
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(
+        `Pull failed — ${e?.message || "see logs"}`, "err",
+      );
+    }
+  };
+
   return (
     <div className="mdl-detail">
       <div className="mdl-detail-h">
         <div style={{display: "flex", alignItems: "center", gap: 10, marginBottom: 6}}>
           <div className={"dot " + (model.installed ? "ready" : "empty")} />
-          <div className="nm mono">{model.longName}</div>
+          <div className="nm mono">{model.longName || model.name || model.id}</div>
           <span style={{marginLeft: "auto"}}>
             {model.installed
               ? <span className="chip ok">installed</span>
               : <span className="chip amber">available</span>}
           </span>
         </div>
-        <div className="repo">{model.repo}</div>
+        <div className="repo">{model.repo || model.hf_repo || model.id}</div>
       </div>
       <div className="mdl-detail-meta">
-        <div><div className="k">params</div><div className="v">{model.params}</div></div>
-        <div><div className="k">size</div><div className="v">{model.size}</div></div>
-        <div><div className="k">type</div><div className="v">{model.type}</div></div>
-        <div><div className="k">device</div><div className="v">{model.device}</div></div>
-        <div><div className="k">runtime</div><div className="v">{model.runtime}</div></div>
-        <div><div className="k">namespace</div><div className="v">{model.ns}</div></div>
+        <div><div className="k">params</div><div className="v">{model.params || "—"}</div></div>
+        <div><div className="k">size</div><div className="v">{model.size || (model.size_bytes ? fmtBytes(model.size_bytes) : "—")}</div></div>
+        <div><div className="k">type</div><div className="v">{model.type || (model.capabilities?.[0]) || "—"}</div></div>
+        <div><div className="k">device</div><div className="v">{model.device || (model.backends?.[0]) || "—"}</div></div>
+        <div><div className="k">runtime</div><div className="v">{model.runtime || "—"}</div></div>
+        <div><div className="k">namespace</div><div className="v">{model.ns || "—"}</div></div>
       </div>
       <div className="mdl-detail-labels">
-        {model.labels.map(l => <span key={l} className="chip">{l}</span>)}
+        {(model.labels || model.capabilities || []).map(l => <span key={l} className="chip">{l}</span>)}
       </div>
       <div className="mdl-detail-recipe">
         <div className="lbl">recipe options</div>
-        {Object.entries(recipe).map(([k, v]) => (
+        {recipeRows.length === 0 ? (
+          <div className="mono" style={{fontSize: 12, color: "var(--fg-4)", fontStyle: "italic"}}>
+            No defaults set — launcher will use its own.
+          </div>
+        ) : recipeRows.map(([k, v]) => (
           <div key={k} className="ro-row">
             <span className="k">{k}</span>
             <span className="v">{String(v)}</span>
@@ -183,7 +262,7 @@ function ModelDetail({ model, recipe, onDelete }) {
         ))}
         <div style={{marginTop: 10, fontFamily: "var(--jbm)", fontSize: 11, color: "var(--fg-4)", display: "flex", gap: 6, alignItems: "center"}}>
           <span style={{color: "var(--warn)"}}>⟳</span>
-          <span>ctx_size + llamacpp_backend require slot restart to apply.</span>
+          <span>context_size + extra_args require slot restart to apply.</span>
         </div>
       </div>
       <UsedByPanel model={model} />
@@ -191,14 +270,16 @@ function ModelDetail({ model, recipe, onDelete }) {
       <div className="mdl-detail-actions">
         {model.installed ? (
           <>
-            <button className="btn" onClick={() => window.__hal0Toast && window.__hal0Toast(`Loading ${model.longName}…`, "info")}>Load now</button>
-            <button className="btn ghost sm" onClick={() => window.__hal0Toast && window.__hal0Toast("Recipe editor — coming next batch", "info")}>{Icons.edit} Edit options</button>
+            <button className="btn" onClick={() => window.__hal0Toast && window.__hal0Toast(`Loading ${model.longName || model.id}…`, "info")}>Load now</button>
+            <button className="btn ghost sm" onClick={onEdit}>{Icons.edit} Edit options</button>
             <button className="btn danger sm" onClick={onDelete}>{Icons.unload} Delete</button>
           </>
         ) : (
           <>
-            <button className="btn" onClick={() => window.__hal0Toast && window.__hal0Toast(`Pulling ${model.longName} · ${model.size}`, "info")}>{Icons.download} Pull ({model.size})</button>
-            <button className="btn ghost sm" onClick={() => window.__hal0Toast && window.__hal0Toast(`Opening huggingface.co/${model.repo}`, "info")}>View on HF →</button>
+            <button className="btn" onClick={onPull} disabled={pull.inFlight}>
+              {Icons.download} {pull.inFlight ? `Pulling ${pull.pct ?? 0}%` : `Pull (${model.size || (model.size_bytes ? fmtBytes(model.size_bytes) : "—")})`}
+            </button>
+            <button className="btn ghost sm" onClick={() => window.open(`https://huggingface.co/${model.repo || model.hf_repo || ""}`, "_blank")}>View on HF →</button>
           </>
         )}
       </div>
@@ -206,42 +287,23 @@ function ModelDetail({ model, recipe, onDelete }) {
   );
 }
 
-function DownloadsPane() {
-  const [downloads, setDownloads] = useStateM(HAL0_DATA.downloads);
-  const active = downloads.filter(d => d.state === "pulling" || d.state === "queued" || d.state === "paused" || d.state === "error" || d.state === "cancelled");
-  const update = (dl, patch) => setDownloads(ds => ds.map(d => d === dl ? { ...d, ...patch } : d));
-  const remove = (dl) => setDownloads(ds => ds.filter(d => d !== dl));
+function DownloadsPane({ activeIds, onRemove }) {
   return (
     <div className="mdl-dl">
       <div className="mdl-dl-h">
         <span>Downloads</span>
-        <span className="ct mono">{active.length}</span>
-        {active.length > 0 && (
-          <span style={{marginLeft: "auto", color: "var(--fg-4)", textTransform: "none", letterSpacing: 0, fontFamily: "var(--jbm)", fontSize: 11}}>~12.4 MB/s</span>
-        )}
+        <span className="ct mono">{activeIds.length}</span>
       </div>
-      {active.length === 0 ? (
+      {activeIds.length === 0 ? (
         <div style={{padding: "32px 16px", textAlign: "center", color: "var(--fg-4)", fontFamily: "var(--jbm)", fontSize: 12}}>
           <div style={{marginBottom: 6}}>No active downloads.</div>
           <div style={{fontSize: 11, color: "var(--fg-5)"}}>Add a model from the catalog or via "Add by HF coords".</div>
         </div>
       ) : (
-        active.slice(0, 5).map((d, i) => (
-          <DownloadRow
-            key={i}
-            dl={d}
-            onPause={(dl) => update(dl, { state: "paused" })}
-            onResume={(dl) => update(dl, { state: "pulling" })}
-            onCancel={(dl) => update(dl, { state: "cancelled" })}
-            onRetry={(dl) => update(dl, { state: "pulling", pct: 0 })}
-            onRemove={remove}
-          />
+        activeIds.slice(0, 8).map(id => (
+          <DownloadRow key={id} modelId={id} onRemove={onRemove} />
         ))
       )}
-      <div style={{padding: "10px 16px", display: "flex", gap: 6, borderTop: active.length ? "1px solid var(--line-soft)" : "none"}}>
-        <button className="btn ghost sm" style={{flex: 1, justifyContent: "center"}} disabled={!active.length} onClick={() => setDownloads(ds => ds.map(d => d.state === "pulling" ? { ...d, state: "paused" } : d))}>Pause all</button>
-        <button className="btn ghost sm" style={{flex: 1, justifyContent: "center"}} onClick={() => window.__hal0Toast && window.__hal0Toast("Full downloads view — coming next batch", "info")}>View all</button>
-      </div>
     </div>
   );
 }

--- a/ui/tests/e2e/specs/models-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-v3.spec.ts
@@ -1,6 +1,14 @@
 /**
  * models-v3 — `#models` route renders the 3-pane layout (filters / list
  * / detail) and exposes the "Add by HF coords" trigger.
+ *
+ * Wireup (#220 brief): the catalog drives off `useModels()` and the
+ * AddByHF modal calls `POST /api/models/inspect` →
+ * `usePullJob().start()`. Tests in this file mock the new endpoints
+ * (inspect, PUT defaults, DELETE cascade) via `page.route`; the
+ * listing itself is served by the FORCED VITE_MOCK_LEMONADE path
+ * (HAL0_DATA-backed) so we get a populated catalog without poking the
+ * browser's mock cache.
  */
 import { test, expect } from '../fixtures/apiMock'
 
@@ -25,5 +33,140 @@ test.describe('Models v3 (/models)', () => {
     await expect(llmChip).toBeVisible()
     await llmChip.click()
     await expect(llmChip).toHaveClass(/on/)
+  })
+
+  test('namespace chips render from backend ns field (blessed + pulled)', async ({ page }) => {
+    // HAL0_DATA's fixture catalog carries `ns` on every row (blessed
+    // for the vendor-curated list, pulled for the user.* prefix). The
+    // backend now derives the same field path-shape-style — see
+    // tests/api/test_models_routes.py for the locked rule (#220) — so
+    // this is the front-end half of the same contract.
+    await page.goto('/#models')
+    await expect(
+      page.locator('.mdl-section-label', { hasText: 'blessed' }).first(),
+    ).toBeVisible()
+  })
+
+  test('AddByHF Inspect populates variants from /api/models/inspect', async ({ page }) => {
+    await page.route('**/api/models/inspect', async (route) => {
+      const body = JSON.parse(route.request().postData() || '{}')
+      const repo = body.hf_repo || body.hf_url || 'unknown'
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          repo,
+          cached: false,
+          variants: [
+            {
+              id: 'qwen3-8b-q4_k_m.gguf',
+              size_bytes: 4_900_000_000,
+              size: '4.56 GB',
+              info: '4.56 GB · single file',
+            },
+            {
+              id: 'qwen3-8b-q8_0.gguf',
+              size_bytes: 8_500_000_000,
+              size: '7.91 GB',
+              info: '7.91 GB · single file',
+            },
+          ],
+          tags: ['text-generation', 'gguf'],
+          metadata: { license: 'apache-2.0', readme_excerpt: 'Hello world.' },
+        }),
+      })
+    })
+
+    await page.goto('/#models')
+    await page.locator('.view .vh button:has-text("Add by HF coords")').click()
+    await page.locator('input[placeholder*="unsloth/Qwen3-8B-GGUF"]').fill('unsloth/Qwen3-8B-GGUF')
+    await page.locator('button:has-text("Inspect")').click()
+    // Variant rows render from the mocked response.
+    await expect(page.locator('.variant-row', { hasText: 'qwen3-8b-q4_k_m.gguf' })).toBeVisible()
+    await expect(page.locator('.variant-row', { hasText: 'qwen3-8b-q8_0.gguf' })).toBeVisible()
+    // License surface renders the HF metadata payload.
+    await expect(page.locator('.form-section', { hasText: 'License' })).toBeVisible()
+  })
+
+  test('Inspect surface shows the backend error envelope on 502', async ({ page }) => {
+    await page.route('**/api/models/inspect', (route) =>
+      route.fulfill({
+        status: 502,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: {
+            code: 'hf.unreachable',
+            message: 'failed to reach huggingface.co',
+            details: { repo: 'foo/bar' },
+          },
+        }),
+      }),
+    )
+    await page.goto('/#models')
+    await page.locator('.view .vh button:has-text("Add by HF coords")').click()
+    await page.locator('input[placeholder*="unsloth/Qwen3-8B-GGUF"]').fill('foo/bar')
+    await page.locator('button:has-text("Inspect")').click()
+    await expect(page.locator('.err').first()).toContainText('Inspect failed')
+  })
+
+  test('Recipe editor opens, pre-fills defaults, writes PUT /api/models/{id}', async ({ page }) => {
+    // HAL0_DATA's first installed row is "qwen3.6-27b-mtp" — we PUT
+    // against that id and assert the body carries our edited defaults.
+    let putBody: any = null
+    await page.route('**/api/models/qwen3.6-27b-mtp', async (route) => {
+      if (route.request().method() === 'PUT') {
+        putBody = JSON.parse(route.request().postData() || '{}')
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: 'qwen3.6-27b-mtp',
+            defaults: putBody.defaults,
+          }),
+        })
+      }
+      return route.fallback()
+    })
+
+    await page.goto('/#models')
+    // Open Edit Options on the auto-selected (first installed) row.
+    await page.locator('button:has-text("Edit options")').click()
+    // Fill context_size and save. The modal's input placeholder hints
+    // at "8192" — fill whatever's there and assert the PUT body.
+    const ctx = page.locator('input[placeholder*="8192"]')
+    await ctx.fill('16384')
+    await page.locator('button:has-text("Save options")').click()
+    await expect.poll(() => putBody?.defaults?.context_size).toBe(16384)
+  })
+
+  test('Delete cascade reads affected_slots from DELETE response', async ({ page }) => {
+    let deleted = false
+    await page.route('**/api/models/qwen3.6-27b-mtp', async (route) => {
+      if (route.request().method() === 'DELETE') {
+        deleted = true
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: 'qwen3.6-27b-mtp',
+            deleted: true,
+            affected_slots: ['primary'],
+          }),
+        })
+      }
+      return route.fallback()
+    })
+
+    await page.goto('/#models')
+    // The first installed row is auto-selected; trigger Delete from
+    // its detail pane.
+    await page.locator('button.danger:has-text("Delete")').click()
+    // Confirm dialog renders. ConfirmDialog gates Delete on a
+    // type-to-confirm input when the model has referrers; the HAL0_DATA
+    // fixture's primary slot points at this model so the gate is on.
+    const confirmInput = page.locator('input.input.mono').last()
+    await confirmInput.fill('qwen3.6-27b-mtp')
+    await page.locator('button:has-text("Delete model")').click()
+    await expect.poll(() => deleted).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

Replaces the v3 Models surface's HAL0_DATA fallbacks with live API calls. Implements the brief at the top of this work — see also the Models audit + the issue #220 path-based ns decision.

- Backend: derive `ns` ("blessed" | "pulled") path-shape-style on every `/api/models` row; implement `POST /api/models/inspect` against the HuggingFace API with a 5min in-process cache + structured 502/404 envelopes.
- Frontend (Models view): AddByHF modal swaps hardcoded variants for the inspect response and uses `usePullJob().start()`; Recipe editor is now real (`PUT /api/models/{id}`); Delete reads `affected_slots` from the cascade response.
- Tests: 17 pytest cases (ns derivation + inspect happy/error paths + cache TTL) + 5 new γ specs (ns chips, inspect populate, 502 envelope, recipe PUT, delete cascade).

## What I touched
- `src/hal0/registry/model.py` — `_derive_ns(model)` (path-shape rule, single source of truth).
- `src/hal0/api/routes/models.py` — `_model_to_dict` always emits `ns`; new `POST /api/models/inspect`.
- `tests/api/test_models_routes.py` — new file (17 cases).
- `ui/src/api/client.ts` — `apiPut` helper.
- `ui/src/api/hooks/useModels.ts` — typed `useModelInspect`, `useModelDelete`, new `useModelUpdate`.
- `ui/src/dash/model-modals.jsx` — AddByHF wired to inspect+pullJob, new RecipeEditorModal, DeleteModelDialog uses live slots + DELETE response, DownloadRow rebuilt around `usePullJob`.
- `ui/src/dash/models.jsx` — catalog is `useModels`-only (no `HAL0_DATA.models` fallback), Recipe section reads `model.defaults`, Downloads pane tracks pulls by `model_id`.
- `ui/tests/e2e/specs/models-v3.spec.ts` — 5 new specs.

## Out of scope (per brief)
- Slots / NPU / installer / packaging / ADRs / PLAN / `.github/`.
- The HAL0_DATA.models fallback was intentionally removed from `models.jsx` only; `data.jsx` still ships fixtures other surfaces consume.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `pytest tests/api/ tests/registry/` — 415 passed (3 pre-existing skips)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npx playwright test specs/models-v3.spec.ts` — 8/8 pass
- [x] Full γ-suite — 25 passed, 3 pre-existing failures on `firstrun-v3` + `settings-v3` (verified by re-running against main with my changes stashed; same 3 fail there)

## Locked rules (do not relitigate)
- `ns = blessed` iff `model.path` starts with `/var/lib/hal0/models/<recipe>/<capability>/` (issue #220).
- The default pull tree layout `/var/lib/hal0/models/<id>/<file>` is therefore always `pulled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)