### PR TITLE
fix(lemonade): noop /v1/unload when model is in slot config but not in loaded[]

### DIFF
--- a/src/hal0/providers/lemonade.py
+++ b/src/hal0/providers/lemonade.py
@@ -445,6 +445,15 @@ class LemonadeProvider(Provider):
         Returns Lemonade's parsed JSON response. When the slot has no
         ``model.default`` (never been loaded), returns ``{"ok": True,
         "noop": "no model to unload"}`` without hitting the network.
+
+        Also short-circuits when the slot's model exists in config but
+        isn't currently in Lemonade's ``/v1/health.loaded[]`` — calling
+        ``/v1/unload`` against a not-loaded model name 404s, which the
+        seed-vs-runtime distinction (see memory
+        ``hal0_primary_slot_seed_vs_runtime``) makes a routine
+        occurrence: the dashboard's Unload button on a slot whose
+        seed ``model.default`` has never been loaded would otherwise
+        surface as a 500 error to the user.
         """
         cfg = _to_dict(slot_cfg)
         model_name = _slot_model(cfg)
@@ -454,6 +463,23 @@ class LemonadeProvider(Provider):
                 extra={"slot": cfg.get("name")},
             )
             return {"ok": True, "noop": "no model to unload"}
+        # Probe loaded[] before issuing /v1/unload to avoid 404s on
+        # seed-but-never-loaded slots. status() never raises.
+        snap = await self.status(cfg)
+        if not snap.get("loaded"):
+            log.info(
+                "lemonade.provider.unload_noop_not_loaded",
+                extra={
+                    "slot": cfg.get("name"),
+                    "model_name": model_name,
+                    "reason": snap.get("reason"),
+                },
+            )
+            return {
+                "ok": True,
+                "noop": "model not currently loaded",
+                "model_name": model_name,
+            }
         log.info(
             "lemonade.provider.unload",
             extra={"slot": cfg.get("name"), "model_name": model_name},

--- a/tests/providers/test_lemonade.py
+++ b/tests/providers/test_lemonade.py
@@ -194,6 +194,20 @@ async def test_unload_posts_model_name_to_v1_unload() -> None:
     captured: dict[str, Any] = {}
 
     def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/health":
+            # Model IS loaded — unload should proceed to /v1/unload.
+            return httpx.Response(
+                200,
+                json={
+                    "loaded": [
+                        {
+                            "model_name": "hermes-4-14b",
+                            "backend_url": "http://127.0.0.1:14000",
+                            "last_use": 1715000000.0,
+                        }
+                    ]
+                },
+            )
         assert req.url.path == "/v1/unload"
         captured["body"] = _json.loads(req.content.decode())
         return httpx.Response(200, json={"status": "unloaded"})
@@ -212,6 +226,29 @@ async def test_unload_is_noop_when_no_model_default() -> None:
     provider = LemonadeProvider(client=_mock_client(h))
     result = await provider.unload(_slot_cfg(model={"default": ""}))
     assert result == {"ok": True, "noop": "no model to unload"}
+
+
+@pytest.mark.asyncio
+async def test_unload_is_noop_when_model_not_in_loaded() -> None:
+    """Seed-but-never-loaded slots: avoid the Lemonade 404 by probing
+    /v1/health first. Regression for PR #270 follow-up."""
+    saw_unload = False
+
+    def h(req: httpx.Request) -> httpx.Response:
+        nonlocal saw_unload
+        if req.url.path == "/v1/health":
+            # Empty loaded[] — the slot's model_default has never been loaded.
+            return httpx.Response(200, json={"loaded": []})
+        if req.url.path == "/v1/unload":
+            saw_unload = True
+        raise AssertionError(f"unexpected path: {req.url.path}")
+
+    provider = LemonadeProvider(client=_mock_client(h))
+    result = await provider.unload(_slot_cfg())
+    assert result["ok"] is True
+    assert result["noop"] == "model not currently loaded"
+    assert result["model_name"] == "hermes-4-14b"
+    assert saw_unload is False
 
 
 # ── status() ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Surfaced by user via the v3 dashboard Unload button on a seed primary slot — clicking Unload on a never-loaded slot 404'd because the slot's seed `model.default` isn't a currently-loaded model in Lemonade's view. Patches `LemonadeProvider.unload` to probe `/v1/health.loaded[]` via `self.status()` first and short-circuit with a noop when the model isn't actually loaded.

Tracked as the first finding of the post-merge real-hardware sweep (memory: feedback_test_ui_on_real_hardware).