### PR TITLE
fix(slots): drift to OFFLINE not ERROR when lemond evicts model (#275 bug 6)

### DIFF
--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -722,15 +722,22 @@ class SlotManager:
         # Reconcile with lemond reality.
         observed = rec.state
         if observed in (SlotState.READY, SlotState.SERVING, SlotState.IDLE) and not active:
-            # lemond says the model is not loaded; record reflects
-            # ready — drift, demote to ERROR.
+            # lemond says the model is not loaded; record reflects ready.
+            # This is drift but NOT a slot-config error — Lemonade evicts
+            # models on its own (LRU per-type budget, nuclear evict on a
+            # different model's load failure, idle-unload driver, etc.).
+            # Demoting to ERROR was the old "slot broken" semantics from
+            # the per-slot-systemd model; under Lemonade, an evicted model
+            # is a perfectly recoverable state — the dispatcher reloads on
+            # next request. Surface as OFFLINE so the card chip shows the
+            # neutral "not loaded" state rather than red ERROR.
             await self._transition(
                 slot_name,
-                SlotState.ERROR,
-                message="model not loaded in lemond",
+                SlotState.OFFLINE,
+                message="model evicted from lemond (auto-reloads on next request)",
                 force=True,
             )
-            observed = SlotState.ERROR
+            observed = SlotState.OFFLINE
         elif observed in (SlotState.OFFLINE, SlotState.ERROR) and active:
             # Inverse drift — state.json says we're not running, but
             # lemond holds the model. Adoption picks the slot up.

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -332,13 +332,21 @@ async def test_status_reconciles_drift(
     slot_root: Path,
     lemonade_loaded_stub: dict[str, Any],
 ) -> None:
-    """A persisted READY plus an empty lemond loaded[] must transition to ERROR."""
+    """A persisted READY plus an empty lemond loaded[] transitions to OFFLINE.
+
+    Was ERROR pre-issue-#275 (per-slot-systemd era treated drift as
+    slot-broken). Under Lemonade, eviction is normal (per-type LRU
+    budget + nuclear evict + idle-unload driver all evict without
+    breaking the slot config), so we demote to OFFLINE with a neutral
+    message that the dispatcher reloads on next request.
+    """
     sm = SlotManager()
     await sm.load("primary")
     # Mutate the stub state so lemond no longer reports the model loaded.
     lemonade_loaded_stub["loaded"] = []
     snap = await sm.status("primary")
-    assert snap.state == SlotState.ERROR
+    assert snap.state == SlotState.OFFLINE
+    assert "evicted" in (snap.metadata.get("message") or "").lower()
 
 
 async def test_status_adopts_running_slot_when_lemond_holds_model(


### PR DESCRIPTION
Closes part of #275. Surfaced via real-hardware CRUD sweep on the v3 dashboard: primary slot loaded successfully then flickered to red ERROR seconds later because Lemonade evicted the model (routine LRU/idle/nuclear-evict behavior). The slot config is fine — dispatcher reloads on next request. Demote drift from ERROR → OFFLINE with a neutral message.