### PR TITLE
feat(agents): hermes_provision scaffold + bootstrap CLI (#238)

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1,0 +1,348 @@
+"""Hermes-Agent bootstrap state machine (issue #238 scaffold).
+
+Twelve named phases run in a strict deterministic sequence. Each phase
+writes a checkpoint into ``provision.json``. On re-run the orchestrator
+loads the checkpoint and skips any phase already marked ``ok`` unless
+``--repair`` forces re-execution.
+
+This module is the scaffold — every phase is a no-op stub that returns
+``ok``. Real provisioning lands in #240 (preflight/install/home_init),
+#241 (env_probe/config_write), #242 (mcp_wire), and the remaining
+slices in the v0.3 Hermes stream. The phase order + ``PhaseResult``
+contract is locked here so downstream slices only have to fill in the
+bodies.
+
+State file lives at ``/var/lib/hal0/state/agents/hermes/provision.json``
+— intentionally **outside** ``$HERMES_HOME`` so Hermes can't trample
+hal0's bookkeeping when the user runs ``hermes reset`` or similar
+upstream subcommands.
+
+See ``docs/internal/hermes-bootstrap-plan-2026-05-23.md`` §3 + §16 for
+the full design contract and ``docs/internal/adr/0012-remove-auth-and-caddy.md``
+for the agent-identity model (X-hal0-Agent header, not Bearer).
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import os
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+# Schema version embedded in every provision.json. Bump when the on-disk
+# shape changes in a way that can't be migrated by ignoring unknown
+# keys. Currently v1 — the layout in `BootstrapState.to_dict()`.
+SCHEMA_VERSION = 1
+
+# Canonical state-file location. Lives outside $HERMES_HOME — Hermes
+# owns its own tree, and bootstrap state must survive a `hermes reset`.
+_DEFAULT_STATE_ROOT = Path("/var/lib/hal0/state/agents/hermes")
+_STATE_FILE_NAME = "provision.json"
+
+
+class PhaseStatus(StrEnum):
+    """Per-phase outcome stored in provision.json.
+
+    ``ok``       — phase completed; downstream phases may proceed.
+    ``skip``     — phase didn't run (irrelevant for this env); not an error.
+    ``fail``     — phase ran and failed; downstream may still run unless fatal.
+    ``repair_needed`` — checkpoint hash drifted from current inputs; ``--repair`` re-runs.
+
+    String-valued so JSON round-trips cleanly without a custom encoder.
+    """
+
+    OK = "ok"
+    SKIP = "skip"
+    FAIL = "fail"
+    REPAIR_NEEDED = "repair_needed"
+
+
+@dataclass
+class PhaseResult:
+    """Outcome of one phase invocation.
+
+    ``hash`` is the optional content hash a phase computes so future
+    re-runs can detect when their inputs changed — checkpoint presence
+    alone is insufficient (a phase whose inputs drifted needs re-run
+    even without ``--repair``).
+
+    ``details`` is a free-form dict each phase can stash. The
+    orchestrator never inspects its contents; it just JSON-serialises
+    them into the checkpoint.
+    """
+
+    status: PhaseStatus
+    details: dict[str, Any] = field(default_factory=dict)
+    hash: str | None = None
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"status": self.status.value}
+        if self.hash is not None:
+            out["hash"] = self.hash
+        if self.reason is not None:
+            out["reason"] = self.reason
+        if self.details:
+            out["details"] = self.details
+        return out
+
+
+@dataclass
+class BootstrapState:
+    """In-memory mirror of ``provision.json``.
+
+    Persists across runs via :meth:`load` / :meth:`save`. ``phases`` is
+    keyed by phase name with values built from :meth:`PhaseResult.to_dict`
+    plus an ``at`` timestamp the orchestrator stamps at write time.
+
+    The dataclass shape is the contract; the JSON keys are the same as
+    the field names so a human inspecting the file can match it back to
+    the source code without a schema doc.
+    """
+
+    schema_version: int = SCHEMA_VERSION
+    started_at: str | None = None
+    completed_at: str | None = None
+    hal0_version: str | None = None
+    hermes_version: str | None = None
+    hermes_home: str = "/var/lib/hal0/agents/hermes"
+    venv: str = "/var/lib/hal0/venvs/hermes"
+    agent_id: str = "hermes-agent"
+    phases: dict[str, dict[str, Any]] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BootstrapState:
+        # Ignore unknown keys so forward-compat schema bumps don't crash
+        # an older orchestrator reading a newer file.
+        valid = {f for f in cls.__dataclass_fields__}
+        kwargs = {k: v for k, v in data.items() if k in valid}
+        return cls(**kwargs)
+
+    def phase_done(self, name: str) -> bool:
+        entry = self.phases.get(name)
+        if not entry:
+            return False
+        return entry.get("status") == PhaseStatus.OK.value
+
+    def save(self, root: Path) -> None:
+        root.mkdir(parents=True, exist_ok=True)
+        target = root / _STATE_FILE_NAME
+        tmp = target.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n")
+        os.replace(tmp, target)
+
+    @classmethod
+    def load(cls, root: Path) -> BootstrapState | None:
+        target = root / _STATE_FILE_NAME
+        if not target.exists():
+            return None
+        try:
+            data = json.loads(target.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        return cls.from_dict(data)
+
+
+# ── Phase implementations (no-op stubs in #238 scaffold) ─────────────────────
+#
+# Each phase signature: (state: BootstrapState) -> PhaseResult.
+#
+# Real impls land in subsequent slices:
+#   #240 — preflight, install, home_init
+#   #241 — env_probe, config_write
+#   #242 — mcp_wire
+#   #243 — namespace_register
+#   #244 — context_link
+#   #245 — model_automap, voice_wire
+#   #246 — smoke_tests, self_report
+#
+# Until then every stub returns OK with a "stub" marker so the
+# orchestrator wires through end-to-end and the checkpoint shape stays
+# valid.
+
+
+def _stub(name: str) -> Callable[[BootstrapState], PhaseResult]:
+    def _phase(state: BootstrapState) -> PhaseResult:
+        return PhaseResult(status=PhaseStatus.OK, details={"stub": True})
+
+    _phase.__name__ = f"_phase_{name}"
+    _phase.__doc__ = f"Stub for {name!r} phase — real impl pending in a follow-up slice."
+    return _phase
+
+
+_phase_preflight = _stub("preflight")
+_phase_install = _stub("install")
+_phase_env_probe = _stub("env_probe")
+_phase_home_init = _stub("home_init")
+_phase_config_write = _stub("config_write")
+_phase_mcp_wire = _stub("mcp_wire")
+_phase_context_link = _stub("context_link")
+_phase_namespace_register = _stub("namespace_register")
+_phase_model_automap = _stub("model_automap")
+_phase_voice_wire = _stub("voice_wire")
+_phase_smoke_tests = _stub("smoke_tests")
+_phase_self_report = _stub("self_report")
+
+
+PHASES: list[tuple[str, Callable[[BootstrapState], PhaseResult]]] = [
+    ("preflight", _phase_preflight),
+    ("install", _phase_install),
+    ("env_probe", _phase_env_probe),
+    ("home_init", _phase_home_init),
+    ("config_write", _phase_config_write),
+    ("mcp_wire", _phase_mcp_wire),
+    ("context_link", _phase_context_link),
+    ("namespace_register", _phase_namespace_register),
+    ("model_automap", _phase_model_automap),
+    ("voice_wire", _phase_voice_wire),
+    ("smoke_tests", _phase_smoke_tests),
+    ("self_report", _phase_self_report),
+]
+
+PHASE_NAMES: tuple[str, ...] = tuple(name for name, _ in PHASES)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _utcnow() -> str:
+    return datetime.datetime.now(tz=datetime.UTC).isoformat().replace("+00:00", "Z")
+
+
+def content_hash(*pieces: str | bytes) -> str:
+    """Stable content hash phases use to detect "inputs unchanged".
+
+    Phases that produce on-disk outputs (config.yaml, HERMES.md) hash
+    the rendered content and stash it in ``PhaseResult.hash``. A
+    re-run computes the hash again; mismatch → ``repair_needed``.
+    """
+    h = hashlib.sha256()
+    for piece in pieces:
+        if isinstance(piece, str):
+            piece = piece.encode("utf-8")
+        h.update(piece)
+    return h.hexdigest()
+
+
+# ── Orchestrator ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class RunResult:
+    """Aggregate result of one :func:`run` invocation.
+
+    ``phases`` mirrors ``BootstrapState.phases`` post-run for
+    test-side assertions; ``state`` is the persisted dataclass.
+    """
+
+    state: BootstrapState
+    phases: dict[str, dict[str, Any]]
+    skipped: list[str] = field(default_factory=list)
+    failed: list[str] = field(default_factory=list)
+
+
+def run(
+    *,
+    repair: bool = False,
+    dry_run: bool = False,
+    skip_phases: tuple[str, ...] = (),
+    state_root: Path | None = None,
+    verbose: bool = False,
+) -> RunResult:
+    """Run every phase in order, persisting checkpoints to ``state_root``.
+
+    * ``repair`` — re-run every phase regardless of checkpoint state.
+    * ``dry_run`` — execute each phase but don't persist the state file.
+    * ``skip_phases`` — skip the named phases (logged as ``skip``).
+    * ``state_root`` — overrides the default ``provision.json`` location;
+      tests pass a ``tmp_path``.
+
+    Returns a :class:`RunResult` capturing the post-run state + the
+    per-phase outcomes the CLI surface pretty-prints.
+    """
+    root = state_root if state_root is not None else _DEFAULT_STATE_ROOT
+    state = BootstrapState.load(root) or BootstrapState()
+    if state.started_at is None or repair:
+        state.started_at = _utcnow()
+        state.completed_at = None
+
+    skipped: list[str] = []
+    failed: list[str] = []
+
+    for name, phase in PHASES:
+        if name in skip_phases:
+            entry = {
+                "status": PhaseStatus.SKIP.value,
+                "at": _utcnow(),
+                "reason": "--skip-phase",
+            }
+            state.phases[name] = entry
+            skipped.append(name)
+            if verbose:
+                print(f"[skip] {name} (--skip-phase)")
+            continue
+
+        if not repair and state.phase_done(name):
+            if verbose:
+                print(f"[skip] {name} (already ok)")
+            skipped.append(name)
+            continue
+
+        if verbose:
+            print(f"[run ] {name}")
+
+        result = phase(state)
+        entry = result.to_dict()
+        entry["at"] = _utcnow()
+        state.phases[name] = entry
+
+        if result.status == PhaseStatus.FAIL:
+            failed.append(name)
+            state.errors.append(f"{name}: {result.reason or 'unspecified failure'}")
+
+    if not failed:
+        state.completed_at = _utcnow()
+
+    if not dry_run:
+        state.save(root)
+
+    return RunResult(state=state, phases=dict(state.phases), skipped=skipped, failed=failed)
+
+
+# ── CLI surface ──────────────────────────────────────────────────────────────
+
+
+def bootstrap_cli(
+    *,
+    repair: bool,
+    dry_run: bool,
+    skip_phases: tuple[str, ...],
+    verbose: bool,
+    state_root: Path | None = None,
+) -> int:
+    """CLI entry point. Returns a POSIX exit code (0 = success, 1 = any fail)."""
+    result = run(
+        repair=repair,
+        dry_run=dry_run,
+        skip_phases=skip_phases,
+        verbose=verbose,
+        state_root=state_root,
+    )
+    if verbose:
+        target = (state_root or _DEFAULT_STATE_ROOT) / _STATE_FILE_NAME
+        print(f"state: {target}")
+    if result.failed:
+        print(f"bootstrap failed in phases: {', '.join(result.failed)}")
+        return 1
+    return 0

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -36,6 +36,11 @@ console = Console()
 approvals_app = typer.Typer(help="Manage agent approval requests (gated destructives).")
 app.add_typer(approvals_app, name="approvals")
 
+# Bootstrap sub-sub-app — ``hal0 agent bootstrap hermes`` runs the
+# Hermes provisioning state machine (v0.3 Phase 10 stream).
+bootstrap_app = typer.Typer(help="Run bundled-agent bootstrap pipelines (Phase 10).")
+app.add_typer(bootstrap_app, name="bootstrap")
+
 
 # ── Lifecycle ────────────────────────────────────────────────────────────────
 
@@ -247,3 +252,39 @@ def approvals_deny(
         die(str(exc))
         return
     console.print(f"[bold]Denied[/bold] {approval_id}.")
+
+
+# ── Bootstrap (Hermes provisioning, Phase 10) ────────────────────────────────
+
+
+@bootstrap_app.command("hermes")
+def bootstrap_hermes(
+    repair: bool = typer.Option(
+        False,
+        "--repair",
+        help="Re-run every phase regardless of checkpoint state (forces full rerun).",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Run phases but don't persist provision.json.",
+    ),
+    skip_phase: list[str] = typer.Option(
+        [],
+        "--skip-phase",
+        help="Skip the named phase (may be repeated).",
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose phase log."),
+) -> None:
+    """Run the Hermes-Agent bootstrap state machine."""
+    # Late import keeps the CLI startup snappy on hosts where the
+    # hermes_provision module's downstream slices grow heavier deps.
+    from hal0.agents.hermes_provision import bootstrap_cli
+
+    rc = bootstrap_cli(
+        repair=repair,
+        dry_run=dry_run,
+        skip_phases=tuple(skip_phase),
+        verbose=verbose,
+    )
+    raise typer.Exit(rc)

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1,0 +1,178 @@
+"""Unit tests for :mod:`hal0.agents.hermes_provision` (issue #238).
+
+The scaffold lands with no-op phase stubs; these tests pin the
+state-machine invariants downstream slices rely on:
+
+* Every phase runs in declared order.
+* Successful runs produce a checkpoint with every phase marked ``ok``.
+* Re-runs are no-ops (every phase is skipped because checkpoints exist).
+* ``--repair`` forces re-execution of every phase.
+* ``--skip-phase`` records ``skip`` for the named phase.
+* The state file round-trips through ``BootstrapState.load`` ↔
+  ``BootstrapState.save`` losslessly.
+
+Phase ordering matters because downstream phases consume earlier
+phases' outputs (env_probe → config_write → mcp_wire). A regression
+that re-orders or drops a phase here surfaces before the integration
+slice notices.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.agents import hermes_provision as hp
+
+
+def test_phase_names_in_planned_order() -> None:
+    """The planned 12 phases stay in the documented order.
+
+    Mirrors `docs/internal/hermes-bootstrap-plan-2026-05-23.md` §3 —
+    if a slice re-orders or drops a phase, this guard catches it
+    before the integration scenario notices.
+    """
+    expected = (
+        "preflight",
+        "install",
+        "env_probe",
+        "home_init",
+        "config_write",
+        "mcp_wire",
+        "context_link",
+        "namespace_register",
+        "model_automap",
+        "voice_wire",
+        "smoke_tests",
+        "self_report",
+    )
+    assert expected == hp.PHASE_NAMES
+
+
+def test_run_marks_every_phase_ok_on_fresh(tmp_path: Path) -> None:
+    result = hp.run(state_root=tmp_path)
+    for name in hp.PHASE_NAMES:
+        assert result.phases[name]["status"] == hp.PhaseStatus.OK.value
+    assert result.failed == []
+    # Skipped is empty on a fresh run because no checkpoint exists.
+    assert result.skipped == []
+
+
+def test_state_file_written_and_round_trips(tmp_path: Path) -> None:
+    hp.run(state_root=tmp_path)
+    state_file = tmp_path / "provision.json"
+    assert state_file.exists()
+    loaded = hp.BootstrapState.load(tmp_path)
+    assert loaded is not None
+    assert loaded.schema_version == hp.SCHEMA_VERSION
+    assert set(loaded.phases.keys()) >= set(hp.PHASE_NAMES)
+    assert loaded.completed_at is not None
+
+
+def test_rerun_is_noop_when_all_phases_ok(tmp_path: Path) -> None:
+    hp.run(state_root=tmp_path)
+    second = hp.run(state_root=tmp_path)
+    # All phases skipped because their checkpoint is already ok.
+    assert set(second.skipped) == set(hp.PHASE_NAMES)
+    assert second.failed == []
+
+
+def test_repair_flag_forces_rerun(tmp_path: Path) -> None:
+    hp.run(state_root=tmp_path)
+    second = hp.run(state_root=tmp_path, repair=True)
+    # Repair re-runs everything → nothing was skipped via checkpoint.
+    assert second.skipped == []
+    for name in hp.PHASE_NAMES:
+        assert second.phases[name]["status"] == hp.PhaseStatus.OK.value
+
+
+def test_skip_phase_records_skip_reason(tmp_path: Path) -> None:
+    result = hp.run(state_root=tmp_path, skip_phases=("voice_wire", "smoke_tests"))
+    assert result.phases["voice_wire"]["status"] == hp.PhaseStatus.SKIP.value
+    assert result.phases["voice_wire"]["reason"] == "--skip-phase"
+    assert result.phases["smoke_tests"]["status"] == hp.PhaseStatus.SKIP.value
+    # Other phases run as normal.
+    assert result.phases["preflight"]["status"] == hp.PhaseStatus.OK.value
+
+
+def test_dry_run_skips_state_persistence(tmp_path: Path) -> None:
+    hp.run(state_root=tmp_path, dry_run=True)
+    assert not (tmp_path / "provision.json").exists()
+
+
+def test_load_returns_none_when_state_file_missing(tmp_path: Path) -> None:
+    assert hp.BootstrapState.load(tmp_path) is None
+
+
+def test_load_returns_none_when_state_file_corrupt(tmp_path: Path) -> None:
+    (tmp_path / "provision.json").write_text("not-json")
+    assert hp.BootstrapState.load(tmp_path) is None
+
+
+def test_phase_result_to_dict_includes_optional_fields() -> None:
+    r = hp.PhaseResult(
+        status=hp.PhaseStatus.OK,
+        details={"k": "v"},
+        hash="abc",
+        reason=None,
+    )
+    out = r.to_dict()
+    assert out["status"] == "ok"
+    assert out["hash"] == "abc"
+    assert out["details"] == {"k": "v"}
+    assert "reason" not in out  # None reasons omitted
+
+
+def test_content_hash_is_stable_and_collision_free() -> None:
+    a = hp.content_hash("foo", "bar")
+    b = hp.content_hash("foo", "bar")
+    c = hp.content_hash("foo", "baz")
+    assert a == b
+    assert a != c
+    # Stable across the str/bytes split.
+    d = hp.content_hash(b"foo", "bar")
+    assert d == a
+
+
+def test_failed_phase_surfaces_in_result_and_blocks_completion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _failing(_state: hp.BootstrapState) -> hp.PhaseResult:
+        return hp.PhaseResult(status=hp.PhaseStatus.FAIL, reason="forced")
+
+    # Patch the env_probe stub for this test only.
+    new_phases = [(name, _failing if name == "env_probe" else fn) for name, fn in hp.PHASES]
+    monkeypatch.setattr(hp, "PHASES", new_phases)
+
+    result = hp.run(state_root=tmp_path)
+    assert "env_probe" in result.failed
+    assert result.state.completed_at is None
+    assert any("env_probe" in e for e in result.state.errors)
+
+
+def test_cli_entry_returns_zero_on_success(tmp_path: Path) -> None:
+    rc = hp.bootstrap_cli(
+        repair=False,
+        dry_run=False,
+        skip_phases=(),
+        verbose=False,
+        state_root=tmp_path,
+    )
+    assert rc == 0
+
+
+def test_cli_entry_returns_one_on_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _failing(_state: hp.BootstrapState) -> hp.PhaseResult:
+        return hp.PhaseResult(status=hp.PhaseStatus.FAIL, reason="boom")
+
+    new_phases = [(name, _failing if name == "preflight" else fn) for name, fn in hp.PHASES]
+    monkeypatch.setattr(hp, "PHASES", new_phases)
+    rc = hp.bootstrap_cli(
+        repair=False,
+        dry_run=False,
+        skip_phases=(),
+        verbose=False,
+        state_root=tmp_path,
+    )
+    assert rc == 1


### PR DESCRIPTION
## Summary

- Add `src/hal0/agents/hermes_provision.py` — 12-phase pipeline with `PhaseResult` / `BootstrapState`, atomic JSON checkpoint at `/var/lib/hal0/state/agents/hermes/provision.json`, idempotency on re-run, `--repair` force-rerun, `--skip-phase`, `--dry-run`.
- Register \`hal0 agent bootstrap hermes\` sub-sub-app (Phase 10 namespace).
- Every phase is a no-op `OK` stub here; real bodies land in #240–#246. Phase order is locked so downstream slices only fill function bodies.

State file lives outside HERMES_HOME (Hermes can't trample it). `PhaseStatus` uses StrEnum for clean JSON round-trip. `from_dict` ignores unknown keys for forward-compat.

Closes #238.

## Test plan

- [x] `tests/agents/test_hermes_provision.py` — 14 tests covering phase ordering, state-file round-trip, re-run no-op, `--repair`, `--skip-phase`, dry-run, content hash, failure surfacing, CLI exit codes.
- [x] `pytest tests/agents/ tests/cli/` — 149/149 green.
- [x] `ruff format --check` + `ruff check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)