### PR TITLE
fix(installer): create + chown ${VAR_DIR}/.cache for HF hub (#275 bug 4)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -949,6 +949,17 @@ else
         chown -R hal0:hal0 "${LEMONADE_PREFIX}"
     fi
 
+    # HuggingFace hub cache for /v1/pull downloads (#275 bug 4). The hal0
+    # user's HOME is ${VAR_DIR} (per useradd above), so HF's default
+    # cache lands at ${VAR_DIR}/.cache/huggingface/hub. Without this,
+    # the first POST /v1/pull fails with "Permission denied" because
+    # ${VAR_DIR} is created by this script as root and never reassigned
+    # to hal0. Pre-create the leaf dir + give hal0 ownership of the
+    # cache tree (NOT the whole VAR_DIR — slot state.json + registry
+    # are written by hal0-api which runs as ${HAL0_USER}, default root).
+    mkdir -p "${VAR_DIR}/.cache/huggingface/hub"
+    chown -R hal0:hal0 "${VAR_DIR}/.cache"
+
     # 3. Cache dir + config.json. Atomic write (tempfile in the same
     #    directory + mv) so a crash mid-write doesn't leave lemond
     #    parsing a half-written JSON file on next start. Overwrite on


### PR DESCRIPTION
Closes part of #275. Pre-creates and chowns `${VAR_DIR}/.cache` so lemond (running as hal0) can write HF hub downloads on first `POST /v1/pull` without permission errors. Scoped narrowly — does not change ownership of slot state.json / registry which hal0-api writes as root.