### PR TITLE
fix(installer): raise lemond max_loaded_models 4 → 8 (#275 bug 7 mitigation 1)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -974,7 +974,7 @@ else
   "host": "127.0.0.1",
   "port": 13305,
   "ctx_size": 4096,
-  "max_loaded_models": 4,
+  "max_loaded_models": 8,
   "extra_models_dir": "/var/lib/hal0/models",
   "global_timeout": 900,
   "no_broadcast": true,


### PR DESCRIPTION
Bumps Lemonade config baseline to allow the full 5-capability-slot loadout (+NPU trio + image) to coexist without eviction churn. Closes part of #275 bug 7. See bug-7 deep-dive comment on #275 for the full mitigation tree (mitigations 2 + 3 are follow-ups).