### PR TITLE
feat(agents): preflight + install + home_init phases (#240)

### DIFF
--- a/installer/agents/hermes/plugins/hal0-memory/__init__.py
+++ b/installer/agents/hermes/plugins/hal0-memory/__init__.py
@@ -1,0 +1,10 @@
+"""hal0-memory MemoryProvider plugin — STUB for #240.
+
+Lives at ``$HERMES_HOME/plugins/memory/hal0-memory/`` after bootstrap
+copies the package data. The real :class:`Hal0MemoryProvider`
+(subclass of ``agent.memory_provider.MemoryProvider``) lands in #242;
+this stub exists so the install phase (#240) can copy a non-empty
+file into position.
+"""
+
+# Intentionally empty — see #242.

--- a/installer/agents/hermes/plugins/hal0-memory/plugin.yaml
+++ b/installer/agents/hermes/plugins/hal0-memory/plugin.yaml
@@ -1,0 +1,10 @@
+# hal0-memory MCP-backed Hermes memory provider plugin manifest.
+#
+# Real wiring (memory_provider class registration + Cognee graph-gate
+# config read) lands in #242. v0.3 scaffold (#240) just ships the
+# directory + this manifest so Hermes's plugin loader has a valid
+# target to resolve.
+name: hal0-memory
+kind: memory-provider
+version: 0.1.0
+description: hal0-memory MCP-backed memory provider — talks to hal0's Cognee store.

--- a/installer/agents/hermes/plugins/hal0/__init__.py
+++ b/installer/agents/hermes/plugins/hal0/__init__.py
@@ -1,0 +1,11 @@
+"""hal0 model-provider profile — STUB for #240.
+
+Lives at ``$HERMES_HOME/plugins/model-providers/hal0/`` after bootstrap
+copies the package data. The real :class:`Hal0Profile` implementation
+(subclass of ``providers.base.ProviderProfile``) lands in #241; this
+stub exists so the install phase (#240) can copy a non-empty file into
+position and the directory survives ``pip install``-style packaging
+quirks.
+"""
+
+# Intentionally empty — see #241.

--- a/installer/agents/hermes/plugins/hal0/plugin.yaml
+++ b/installer/agents/hermes/plugins/hal0/plugin.yaml
@@ -1,0 +1,9 @@
+# hal0-owned Hermes provider profile plugin manifest.
+#
+# Real wiring (provider/factory entries) lands in #241. v0.3 scaffold
+# (#240) just ships the directory + this manifest so Hermes's plugin
+# loader has a valid target to resolve.
+name: hal0
+kind: model-provider
+version: 0.1.0
+description: hal0-native provider profile — points Hermes at the live primary slot.

--- a/installer/agents/hermes/requirements.txt
+++ b/installer/agents/hermes/requirements.txt
@@ -1,0 +1,13 @@
+# hal0 — hard-pinned Hermes-Agent runtime requirements (v0.3, issue #240).
+#
+# The hal0 bootstrap creates a managed venv at /var/lib/hal0/venvs/hermes/
+# with explicit Python 3.11 and installs from this file. Bumping the pin
+# requires a hal0 release; the `hal0 agent upgrade hermes [--to=<version>]`
+# CLI exists for power users + compat-testing escape hatches.
+#
+# Why a hard pin: Hermes ships breaking config-schema changes between
+# minor releases. Pinning here means a hal0 upgrade is the single point
+# at which Hermes moves — operators don't get surprised by `hermes setup`
+# rewriting their config.yaml.
+
+hermes-agent==0.14.0

--- a/installer/wrappers/hal0-hermes
+++ b/installer/wrappers/hal0-hermes
@@ -1,26 +1,46 @@
 #!/bin/sh
-# hal0-hermes — env-file injector wrapper around upstream `hermes`.
+# hal0-hermes — env-injecting wrapper around the hal0-managed Hermes venv.
 #
-# Sourced env-file injection lets hal0 own the hermes integration
-# WITHOUT touching upstream NousResearch/hermes-agent. The wrapper
-# loads HAL0_* + provider config from $HAL0_ENV_FILE (default
-# /etc/hal0/agents/hermes.env), then execs the upstream `hermes`
-# binary with the same argv.
+# Post-ADR-0012 (no Bearer auth), the wrapper's sole job is to set:
 #
-# The `--hal0-ready` sentinel is consumed by the hal0 installer's
-# post-install smoke test (installer/agents/hermes-agent.sh) so the
-# install script can verify the wrapper is on PATH and functional
-# WITHOUT spawning the heavyweight upstream binary.
+#   HERMES_HOME    — pins Hermes's state dir under hal0's tree so a
+#                    `hermes reset` or upstream config-rewrite stays
+#                    contained.
+#   HAL0_AGENT_ID  — read by `MCPIdentityMiddleware` (renamed from
+#                    `MCPAuthMiddleware`) via the `X-hal0-Agent`
+#                    header, then echoed back as the `client_id` for
+#                    Cognee's `private:<client_id>` namespace.
+#
+# It then execs the hal0-managed venv's `hermes` binary. The venv
+# lives at /var/lib/hal0/venvs/hermes/ (hard-pinned in
+# installer/agents/hermes/requirements.txt). HAL0_HERMES_BIN overrides
+# when the venv lives elsewhere.
+#
+# `--hal0-ready` is the smoke-test sentinel the installer pings to
+# verify the wrapper is on PATH WITHOUT spawning upstream `hermes`.
+#
+# An optional outbound-credentials env file at
+# /var/lib/hal0/secrets/agents/hermes.env (mode 0600) is sourced when
+# present. Post-ADR-0012 this holds HF token + external MCP tokens
+# only — never a hal0 Bearer.
 
 set -eu
 
-HAL0_ENV_FILE="${HAL0_ENV_FILE:-/etc/hal0/agents/hermes.env}"
+HERMES_HOME="${HERMES_HOME:-/var/lib/hal0/agents/hermes}"
+HAL0_AGENT_ID="${HAL0_AGENT_ID:-hermes-agent}"
+HAL0_HERMES_BIN="${HAL0_HERMES_BIN:-/var/lib/hal0/venvs/hermes/bin/hermes}"
+HAL0_HERMES_SECRETS="${HAL0_HERMES_SECRETS:-/var/lib/hal0/secrets/agents/hermes.env}"
 
-if [ -r "$HAL0_ENV_FILE" ]; then
+export HERMES_HOME
+export HAL0_AGENT_ID
+
+# Source the outbound-credentials file when present (HF / external MCP
+# tokens per ADR-0013). Optional — bootstrap may run without one.
+if [ -r "$HAL0_HERMES_SECRETS" ]; then
     set -a
     # shellcheck disable=SC1090
     # (path is operator-controlled by design)
-    . "$HAL0_ENV_FILE"
+    . "$HAL0_HERMES_SECRETS"
     set +a
 fi
 
@@ -28,4 +48,10 @@ case "${1:-}" in
     --hal0-ready) exit 0 ;;
 esac
 
-exec hermes "$@"
+if [ ! -x "$HAL0_HERMES_BIN" ]; then
+    printf 'hal0-hermes: venv binary missing at %s\n' "$HAL0_HERMES_BIN" >&2
+    printf '  Run `hal0 agent bootstrap hermes` to provision.\n' >&2
+    exit 127
+fi
+
+exec "$HAL0_HERMES_BIN" "$@"

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -28,6 +28,9 @@ import datetime
 import hashlib
 import json
 import os
+import shutil
+import subprocess  # nosec B404 — needed to spawn python -m venv + pip
+import sys
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
@@ -181,10 +184,315 @@ def _stub(name: str) -> Callable[[BootstrapState], PhaseResult]:
     return _phase
 
 
-_phase_preflight = _stub("preflight")
-_phase_install = _stub("install")
+# Pinned constants — keep these in sync with installer/agents/hermes/
+# requirements.txt and the wrapper script. The constants are exposed
+# at module scope so tests can monkey-patch them onto a tmp path.
+PYTHON_MIN = (3, 11)
+MIN_FREE_GIB = 4
+DAEMON_HEALTH_URL = "http://127.0.0.1:8080/api/status"
+WRAPPER_INSTALL_PATH = Path("/usr/local/bin/hal0-hermes")
+REPO_ROOT_FOR_INSTALLER = Path(__file__).resolve().parents[3]
+
+
+# ── Phase A: preflight ──────────────────────────────────────────────────────
+
+
+def _http_get(url: str, *, timeout: float = 3.0) -> int:
+    """Cheap stdlib reachability check — returns HTTP status or 0 on error.
+
+    Used by preflight to confirm the hal0 daemon is up before we start
+    spawning subprocesses. Stdlib-only (no requests / httpx) keeps the
+    bootstrap importable on minimal install paths.
+    """
+    from urllib.error import URLError
+    from urllib.request import Request, urlopen
+
+    try:
+        req = Request(url, headers={"Accept": "application/json"})
+        with urlopen(req, timeout=timeout) as resp:
+            return int(resp.status)
+    except (URLError, OSError, TimeoutError):
+        return 0
+
+
+def _phase_preflight(state: BootstrapState) -> PhaseResult:
+    """Hard-fail when the host can't host Hermes.
+
+    Documented blockers (plan §4):
+
+    * Python ≥ 3.11 available — bootstrap shells out to a venv with
+      explicit Python; we verify the running interpreter qualifies so
+      we can re-use ``sys.executable`` instead of hunting PATH.
+    * ``hal0`` daemon reachable at ``/api/status`` — agents that can't
+      reach hal0 are useless. Catch it now instead of during config_write.
+    * ``/var/lib/hal0/`` writable — we'll be writing the venv + HERMES_HOME
+      there in the next phase.
+    * ≥ 4 GiB free under ``/var/lib/hal0/`` — Hermes deps + a typical
+      memory cache run ~3 GiB; 4 GiB leaves headroom for venv rebuild.
+    """
+    failures: list[str] = []
+    details: dict[str, Any] = {}
+
+    py_version = sys.version_info[:3]
+    details["python_version"] = ".".join(str(p) for p in py_version)
+    if py_version < PYTHON_MIN:
+        failures.append(
+            f"python {'.'.join(str(p) for p in PYTHON_MIN)}+ required, "
+            f"have {details['python_version']} — run `apt install python3.11`",
+        )
+
+    rc = _http_get(DAEMON_HEALTH_URL)
+    details["daemon_http_status"] = rc
+    if rc != 200:
+        failures.append(
+            f"hal0 daemon unreachable at {DAEMON_HEALTH_URL} (status={rc or 'no-response'}) "
+            "— run `systemctl start hal0`",
+        )
+
+    var_lib = Path(state.venv).parent.parent  # /var/lib/hal0/
+    details["var_lib_path"] = str(var_lib)
+    if not var_lib.exists() or not os.access(var_lib, os.W_OK):
+        failures.append(
+            f"{var_lib} not writable — run `sudo install -d -o hal0 -g hal0 -m 0755 {var_lib}`",
+        )
+    else:
+        st = os.statvfs(var_lib)
+        free_gib = st.f_bavail * st.f_frsize / (1024**3)
+        details["free_gib"] = round(free_gib, 2)
+        if free_gib < MIN_FREE_GIB:
+            failures.append(
+                f"{var_lib} has {free_gib:.1f} GiB free; need >= {MIN_FREE_GIB} — clear space",
+            )
+
+    if failures:
+        return PhaseResult(
+            status=PhaseStatus.FAIL,
+            details=details,
+            reason="; ".join(failures),
+        )
+    return PhaseResult(status=PhaseStatus.OK, details=details)
+
+
+# ── Phase B: install ────────────────────────────────────────────────────────
+
+
+def _resolve_python311(prober: Callable[[str], str | None] = shutil.which) -> str | None:
+    """Find a python3.11 interpreter; fall back to the running one when it qualifies.
+
+    Prefers an explicit ``python3.11`` on PATH so the venv pins minor
+    version regardless of what ``sys.executable`` is. Falls back to
+    ``sys.executable`` only when the running interpreter is itself
+    3.11+ — keeps tests usable on Python 3.12+ CI shards.
+    """
+    explicit = prober("python3.11")
+    if explicit:
+        return explicit
+    if sys.version_info[:2] >= PYTHON_MIN:
+        return sys.executable
+    return None
+
+
+def _venv_python(venv: Path) -> Path:
+    return venv / "bin" / "python"
+
+
+def _install_venv(
+    venv: Path,
+    requirements: Path,
+    *,
+    runner: Any = subprocess,
+    python_resolver: Callable[[], str | None] = _resolve_python311,
+) -> None:
+    """Create the venv at ``venv`` and install ``requirements`` into it.
+
+    Two-step: ``python3.11 -m venv`` then ``pip install -r``. We don't
+    use ``uv`` here to keep the dependency footprint zero — the
+    runtime venv is small and pip is universally available.
+    """
+    py = python_resolver()
+    if py is None:
+        raise RuntimeError("no python 3.11 interpreter found on PATH")
+    venv.parent.mkdir(parents=True, exist_ok=True)
+    if not venv.exists():
+        runner.run([py, "-m", "venv", str(venv)], check=True)  # nosec B603
+    pip = _venv_python(venv)
+    runner.run(  # nosec B603 — argv from local config
+        [str(pip), "-m", "pip", "install", "--upgrade", "pip"],
+        check=True,
+    )
+    runner.run(  # nosec B603
+        [str(pip), "-m", "pip", "install", "-r", str(requirements)],
+        check=True,
+    )
+
+
+def _copy_wrapper(wrapper_src: Path, wrapper_dst: Path) -> None:
+    """Copy + chmod the wrapper into ``wrapper_dst``."""
+    wrapper_dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(wrapper_src, wrapper_dst)
+    wrapper_dst.chmod(0o755)
+
+
+def _copy_plugin_tree(src: Path, dst: Path) -> None:
+    """Mirror a plugin directory (idempotent)."""
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst)
+
+
+def _phase_install(state: BootstrapState) -> PhaseResult:
+    """Provision the managed Hermes venv + wrapper + plugin stubs.
+
+    The plugin stubs at ``installer/agents/hermes/plugins/{hal0,hal0-memory}/``
+    are copied verbatim into ``$HERMES_HOME/plugins/{model-providers/hal0,memory/hal0-memory}/``.
+    Real plugin bodies arrive in #241 + #242; this phase just stages
+    the directory layout so re-runs after those slices land are a
+    file-by-file overlay, not a structural change.
+
+    Skips heavy work when the venv binary already exists at the
+    expected version — re-runs of ``hal0 agent bootstrap hermes`` are
+    cheap unless ``--repair`` forces re-install.
+    """
+    details: dict[str, Any] = {}
+    venv = Path(state.venv)
+    requirements = REPO_ROOT_FOR_INSTALLER / "installer" / "agents" / "hermes" / "requirements.txt"
+    wrapper_src = REPO_ROOT_FOR_INSTALLER / "installer" / "wrappers" / "hal0-hermes"
+    plugin_src_root = REPO_ROOT_FOR_INSTALLER / "installer" / "agents" / "hermes" / "plugins"
+
+    if not requirements.is_file():
+        return PhaseResult(
+            status=PhaseStatus.FAIL,
+            reason=f"requirements.txt missing at {requirements}",
+        )
+    if not wrapper_src.is_file():
+        return PhaseResult(
+            status=PhaseStatus.FAIL,
+            reason=f"wrapper source missing at {wrapper_src}",
+        )
+
+    hermes_bin = _venv_python(venv).parent / "hermes"
+    if not hermes_bin.exists():
+        try:
+            _install_venv(venv, requirements)
+        except (subprocess.SubprocessError, RuntimeError, OSError) as exc:
+            return PhaseResult(
+                status=PhaseStatus.FAIL,
+                reason=f"venv install failed: {exc}",
+                details=details,
+            )
+    details["venv"] = str(venv)
+    details["hermes_bin"] = str(hermes_bin)
+
+    try:
+        _copy_wrapper(wrapper_src, WRAPPER_INSTALL_PATH)
+        details["wrapper"] = str(WRAPPER_INSTALL_PATH)
+    except OSError as exc:
+        # Non-root operators land here — surface so the user can sudo.
+        return PhaseResult(
+            status=PhaseStatus.FAIL,
+            reason=f"wrapper install to {WRAPPER_INSTALL_PATH} failed: {exc}",
+            details=details,
+        )
+
+    # Plugin stubs into HERMES_HOME-shaped locations. Real bodies in #241/#242.
+    # Claim HERMES_HOME with the .hal0-managed marker FIRST so home_init's
+    # "is this my tree?" check passes — install populates HERMES_HOME with
+    # plugin dirs, so it has to be the phase that stamps the marker.
+    hermes_home = Path(state.hermes_home)
+    claimed, reason = _claim_hermes_home(hermes_home)
+    if not claimed:
+        return PhaseResult(status=PhaseStatus.FAIL, reason=reason)
+    plugin_targets = {
+        "hal0": hermes_home / "plugins" / "model-providers" / "hal0",
+        "hal0-memory": hermes_home / "plugins" / "memory" / "hal0-memory",
+    }
+    for src_name, dst in plugin_targets.items():
+        src = plugin_src_root / src_name
+        if not src.exists():
+            return PhaseResult(
+                status=PhaseStatus.FAIL,
+                reason=f"plugin source missing at {src}",
+            )
+        try:
+            _copy_plugin_tree(src, dst)
+        except OSError as exc:
+            return PhaseResult(
+                status=PhaseStatus.FAIL,
+                reason=f"plugin copy {src} -> {dst} failed: {exc}",
+            )
+    details["plugins"] = [str(p) for p in plugin_targets.values()]
+    return PhaseResult(status=PhaseStatus.OK, details=details)
+
+
+# ── Phase D: home_init ──────────────────────────────────────────────────────
+
+
+_HAL0_MANAGED_MARKER = ".hal0-managed"
+
+
+def _claim_hermes_home(hermes_home: Path) -> tuple[bool, str | None]:
+    """Stamp the ``.hal0-managed`` marker — or refuse if HERMES_HOME isn't ours.
+
+    Returns ``(claimed, reason)``: ``claimed=True`` on success;
+    ``claimed=False`` with a ``reason`` when the dir is populated and
+    lacks the marker (user's pre-existing ~/.hermes — bail). Used by
+    both install (which has to write plugins into the tree) and
+    home_init (which makes the layout canonical).
+    """
+    marker = hermes_home / _HAL0_MANAGED_MARKER
+    if hermes_home.exists() and not marker.exists() and any(hermes_home.iterdir()):
+        return (
+            False,
+            f"{hermes_home} exists and is not hal0-managed "
+            f"(missing {_HAL0_MANAGED_MARKER}). Move it aside before re-running.",
+        )
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    if not marker.exists():
+        marker.write_text(
+            "hal0 — this HERMES_HOME is managed by hal0 (issue #240). Edits may be overwritten.\n",
+            encoding="utf-8",
+        )
+    return (True, None)
+
+
+def _phase_home_init(state: BootstrapState) -> PhaseResult:
+    """Make the ``$HERMES_HOME`` layout canonical.
+
+    Install (#240's first phase) already claimed the marker; home_init
+    is responsible for the wider directory tree Hermes expects.
+    Re-claiming via :func:`_claim_hermes_home` is harmless when install
+    already did so, and necessary when home_init runs first
+    (``--skip-phase install``).
+    """
+    hermes_home = Path(state.hermes_home)
+    claimed, reason = _claim_hermes_home(hermes_home)
+    if not claimed:
+        return PhaseResult(status=PhaseStatus.FAIL, reason=reason)
+
+    standard_subdirs = (
+        "memories",
+        "skills",
+        "plugins",
+        "plugins/memory",
+        "plugins/model-providers",
+        "logs",
+        "sessions",
+        "profiles",
+        "mcp-tokens",
+    )
+    for sub in standard_subdirs:
+        (hermes_home / sub).mkdir(parents=True, exist_ok=True)
+
+    return PhaseResult(
+        status=PhaseStatus.OK,
+        details={
+            "hermes_home": str(hermes_home),
+            "marker": str(hermes_home / _HAL0_MANAGED_MARKER),
+        },
+    )
+
+
 _phase_env_probe = _stub("env_probe")
-_phase_home_init = _stub("home_init")
 _phase_config_write = _stub("config_write")
 _phase_mcp_wire = _stub("mcp_wire")
 _phase_context_link = _stub("context_link")
@@ -259,6 +567,7 @@ def run(
     skip_phases: tuple[str, ...] = (),
     state_root: Path | None = None,
     verbose: bool = False,
+    initial_state: BootstrapState | None = None,
 ) -> RunResult:
     """Run every phase in order, persisting checkpoints to ``state_root``.
 
@@ -267,12 +576,15 @@ def run(
     * ``skip_phases`` — skip the named phases (logged as ``skip``).
     * ``state_root`` — overrides the default ``provision.json`` location;
       tests pass a ``tmp_path``.
+    * ``initial_state`` — seed state when no checkpoint exists; tests
+      pass one with `hermes_home` + `venv` pointed at `tmp_path` so the
+      real install/home_init phases don't need write access to /var/lib.
 
     Returns a :class:`RunResult` capturing the post-run state + the
     per-phase outcomes the CLI surface pretty-prints.
     """
     root = state_root if state_root is not None else _DEFAULT_STATE_ROOT
-    state = BootstrapState.load(root) or BootstrapState()
+    state = BootstrapState.load(root) or initial_state or BootstrapState()
     if state.started_at is None or repair:
         state.started_at = _utcnow()
         state.completed_at = None

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -20,10 +20,39 @@ slice notices.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from hal0.agents import hermes_provision as hp
+
+
+@pytest.fixture
+def state_with_tmp_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.BootstrapState:
+    """Seed a :class:`BootstrapState` rooted in ``tmp_path`` with externals stubbed.
+
+    The real preflight + install phases reach for ``/var/lib/hal0/*``,
+    spawn ``python -m venv``, and HTTP-poke ``127.0.0.1:8080``. Every
+    pipeline-level test needs these dimmed out so the orchestrator's
+    behaviour is what's under test, not the LXC.
+    """
+    var_lib = tmp_path / "var" / "lib" / "hal0"
+    var_lib.mkdir(parents=True)
+    venv = var_lib / "venvs" / "hermes"
+    hermes_home = var_lib / "agents" / "hermes"
+    monkeypatch.setattr(hp, "_http_get", lambda *_a, **_kw: 200)
+    monkeypatch.setattr(hp, "MIN_FREE_GIB", 0)  # /tmp may be tmpfs with little headroom
+    monkeypatch.setattr(
+        hp, "WRAPPER_INSTALL_PATH", tmp_path / "usr" / "local" / "bin" / "hal0-hermes"
+    )
+
+    def _fake_install(v: Path, _req: Path, **_kwargs: Any) -> None:
+        (v / "bin").mkdir(parents=True, exist_ok=True)
+        (v / "bin" / "hermes").write_text("#!/bin/sh\nexit 0\n")
+        (v / "bin" / "hermes").chmod(0o755)
+
+    monkeypatch.setattr(hp, "_install_venv", _fake_install)
+    return hp.BootstrapState(venv=str(venv), hermes_home=str(hermes_home))
 
 
 def test_phase_names_in_planned_order() -> None:
@@ -50,8 +79,10 @@ def test_phase_names_in_planned_order() -> None:
     assert expected == hp.PHASE_NAMES
 
 
-def test_run_marks_every_phase_ok_on_fresh(tmp_path: Path) -> None:
-    result = hp.run(state_root=tmp_path)
+def test_run_marks_every_phase_ok_on_fresh(
+    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState
+) -> None:
+    result = hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths)
     for name in hp.PHASE_NAMES:
         assert result.phases[name]["status"] == hp.PhaseStatus.OK.value
     assert result.failed == []
@@ -59,8 +90,10 @@ def test_run_marks_every_phase_ok_on_fresh(tmp_path: Path) -> None:
     assert result.skipped == []
 
 
-def test_state_file_written_and_round_trips(tmp_path: Path) -> None:
-    hp.run(state_root=tmp_path)
+def test_state_file_written_and_round_trips(
+    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState
+) -> None:
+    hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths)
     state_file = tmp_path / "provision.json"
     assert state_file.exists()
     loaded = hp.BootstrapState.load(tmp_path)
@@ -70,25 +103,33 @@ def test_state_file_written_and_round_trips(tmp_path: Path) -> None:
     assert loaded.completed_at is not None
 
 
-def test_rerun_is_noop_when_all_phases_ok(tmp_path: Path) -> None:
-    hp.run(state_root=tmp_path)
-    second = hp.run(state_root=tmp_path)
+def test_rerun_is_noop_when_all_phases_ok(
+    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState
+) -> None:
+    hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths)
+    second = hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths)
     # All phases skipped because their checkpoint is already ok.
     assert set(second.skipped) == set(hp.PHASE_NAMES)
     assert second.failed == []
 
 
-def test_repair_flag_forces_rerun(tmp_path: Path) -> None:
-    hp.run(state_root=tmp_path)
-    second = hp.run(state_root=tmp_path, repair=True)
+def test_repair_flag_forces_rerun(tmp_path: Path, state_with_tmp_paths: hp.BootstrapState) -> None:
+    hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths)
+    second = hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths, repair=True)
     # Repair re-runs everything → nothing was skipped via checkpoint.
     assert second.skipped == []
     for name in hp.PHASE_NAMES:
         assert second.phases[name]["status"] == hp.PhaseStatus.OK.value
 
 
-def test_skip_phase_records_skip_reason(tmp_path: Path) -> None:
-    result = hp.run(state_root=tmp_path, skip_phases=("voice_wire", "smoke_tests"))
+def test_skip_phase_records_skip_reason(
+    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState
+) -> None:
+    result = hp.run(
+        state_root=tmp_path,
+        initial_state=state_with_tmp_paths,
+        skip_phases=("voice_wire", "smoke_tests"),
+    )
     assert result.phases["voice_wire"]["status"] == hp.PhaseStatus.SKIP.value
     assert result.phases["voice_wire"]["reason"] == "--skip-phase"
     assert result.phases["smoke_tests"]["status"] == hp.PhaseStatus.SKIP.value
@@ -96,8 +137,10 @@ def test_skip_phase_records_skip_reason(tmp_path: Path) -> None:
     assert result.phases["preflight"]["status"] == hp.PhaseStatus.OK.value
 
 
-def test_dry_run_skips_state_persistence(tmp_path: Path) -> None:
-    hp.run(state_root=tmp_path, dry_run=True)
+def test_dry_run_skips_state_persistence(
+    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState
+) -> None:
+    hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths, dry_run=True)
     assert not (tmp_path / "provision.json").exists()
 
 
@@ -136,22 +179,34 @@ def test_content_hash_is_stable_and_collision_free() -> None:
 
 
 def test_failed_phase_surfaces_in_result_and_blocks_completion(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    state_with_tmp_paths: hp.BootstrapState,
 ) -> None:
     def _failing(_state: hp.BootstrapState) -> hp.PhaseResult:
         return hp.PhaseResult(status=hp.PhaseStatus.FAIL, reason="forced")
 
-    # Patch the env_probe stub for this test only.
     new_phases = [(name, _failing if name == "env_probe" else fn) for name, fn in hp.PHASES]
     monkeypatch.setattr(hp, "PHASES", new_phases)
 
-    result = hp.run(state_root=tmp_path)
+    result = hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths)
     assert "env_probe" in result.failed
     assert result.state.completed_at is None
     assert any("env_probe" in e for e in result.state.errors)
 
 
-def test_cli_entry_returns_zero_on_success(tmp_path: Path) -> None:
+def test_cli_entry_returns_zero_on_success(
+    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # bootstrap_cli doesn't take an initial_state kwarg directly — wrap
+    # `run` so the test still threads the tmp-rooted state through.
+    real_run = hp.run
+
+    def _wrapped(**kwargs: Any) -> hp.RunResult:
+        kwargs.setdefault("initial_state", state_with_tmp_paths)
+        return real_run(**kwargs)
+
+    monkeypatch.setattr(hp, "run", _wrapped)
     rc = hp.bootstrap_cli(
         repair=False,
         dry_run=False,
@@ -162,12 +217,24 @@ def test_cli_entry_returns_zero_on_success(tmp_path: Path) -> None:
     assert rc == 0
 
 
-def test_cli_entry_returns_one_on_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cli_entry_returns_one_on_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    state_with_tmp_paths: hp.BootstrapState,
+) -> None:
     def _failing(_state: hp.BootstrapState) -> hp.PhaseResult:
         return hp.PhaseResult(status=hp.PhaseStatus.FAIL, reason="boom")
 
     new_phases = [(name, _failing if name == "preflight" else fn) for name, fn in hp.PHASES]
     monkeypatch.setattr(hp, "PHASES", new_phases)
+
+    real_run = hp.run
+
+    def _wrapped(**kwargs: Any) -> hp.RunResult:
+        kwargs.setdefault("initial_state", state_with_tmp_paths)
+        return real_run(**kwargs)
+
+    monkeypatch.setattr(hp, "run", _wrapped)
     rc = hp.bootstrap_cli(
         repair=False,
         dry_run=False,
@@ -176,3 +243,136 @@ def test_cli_entry_returns_one_on_failure(tmp_path: Path, monkeypatch: pytest.Mo
         state_root=tmp_path,
     )
     assert rc == 1
+
+
+# ── #240 phase impls — preflight / install / home_init ──────────────────────
+
+
+def test_preflight_passes_when_inputs_meet_minimums(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    var_lib = tmp_path / "var" / "lib" / "hal0"
+    var_lib.mkdir(parents=True)
+    venv = var_lib / "venvs" / "hermes"
+    state = hp.BootstrapState(venv=str(venv))
+    monkeypatch.setattr(hp, "_http_get", lambda *_a, **_kw: 200)
+    monkeypatch.setattr(hp, "MIN_FREE_GIB", 0)
+    out = hp._phase_preflight(state)
+    assert out.status == hp.PhaseStatus.OK
+    assert out.details["python_version"]
+    assert out.details["daemon_http_status"] == 200
+
+
+def test_preflight_fails_on_unreachable_daemon(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    var_lib = tmp_path / "var" / "lib" / "hal0"
+    var_lib.mkdir(parents=True)
+    state = hp.BootstrapState(venv=str(var_lib / "venvs" / "hermes"))
+    monkeypatch.setattr(hp, "_http_get", lambda *_a, **_kw: 0)
+    out = hp._phase_preflight(state)
+    assert out.status == hp.PhaseStatus.FAIL
+    assert "daemon unreachable" in (out.reason or "")
+
+
+def test_preflight_fails_on_var_lib_not_writable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(hp, "_http_get", lambda *_a, **_kw: 200)
+    state = hp.BootstrapState(venv=str(tmp_path / "nope" / "venvs" / "hermes"))
+    out = hp._phase_preflight(state)
+    assert out.status == hp.PhaseStatus.FAIL
+    assert "not writable" in (out.reason or "")
+
+
+def test_home_init_creates_layout_with_marker(tmp_path: Path) -> None:
+    hermes_home = tmp_path / "hermes_home"
+    state = hp.BootstrapState(hermes_home=str(hermes_home))
+    out = hp._phase_home_init(state)
+    assert out.status == hp.PhaseStatus.OK
+    assert hermes_home.is_dir()
+    assert (hermes_home / ".hal0-managed").is_file()
+    for sub in ("memories", "skills", "plugins/memory", "plugins/model-providers", "logs"):
+        assert (hermes_home / sub).is_dir()
+
+
+def test_home_init_idempotent_on_managed_dir(tmp_path: Path) -> None:
+    hermes_home = tmp_path / "hermes_home"
+    state = hp.BootstrapState(hermes_home=str(hermes_home))
+    hp._phase_home_init(state)
+    marker_before = (hermes_home / ".hal0-managed").read_text()
+    out2 = hp._phase_home_init(state)
+    assert out2.status == hp.PhaseStatus.OK
+    assert (hermes_home / ".hal0-managed").read_text() == marker_before
+
+
+def test_home_init_refuses_to_clobber_non_managed_dir(tmp_path: Path) -> None:
+    hermes_home = tmp_path / "user_hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("# user file")
+    state = hp.BootstrapState(hermes_home=str(hermes_home))
+    out = hp._phase_home_init(state)
+    assert out.status == hp.PhaseStatus.FAIL
+    assert "not hal0-managed" in (out.reason or "")
+
+
+def test_install_phase_skips_venv_when_binary_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "hermes").write_text("#!/bin/sh\nexit 0\n")
+    (venv / "bin" / "hermes").chmod(0o755)
+
+    wrapper_dst = tmp_path / "usr" / "local" / "bin" / "hal0-hermes"
+    monkeypatch.setattr(hp, "WRAPPER_INSTALL_PATH", wrapper_dst)
+    hermes_home = tmp_path / "hermes_home"
+    state = hp.BootstrapState(venv=str(venv), hermes_home=str(hermes_home))
+
+    called: list[Any] = []
+
+    def _no_install(*args: Any, **kwargs: Any) -> None:
+        called.append(args)
+
+    monkeypatch.setattr(hp, "_install_venv", _no_install)
+
+    out = hp._phase_install(state)
+    assert out.status == hp.PhaseStatus.OK
+    assert called == []
+    assert wrapper_dst.is_file()
+    assert (hermes_home / "plugins" / "model-providers" / "hal0" / "__init__.py").is_file()
+    assert (hermes_home / "plugins" / "memory" / "hal0-memory" / "__init__.py").is_file()
+
+
+def test_install_phase_runs_venv_install_when_binary_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    venv = tmp_path / "venv"
+    wrapper_dst = tmp_path / "usr" / "local" / "bin" / "hal0-hermes"
+    monkeypatch.setattr(hp, "WRAPPER_INSTALL_PATH", wrapper_dst)
+    hermes_home = tmp_path / "hermes_home"
+    state = hp.BootstrapState(venv=str(venv), hermes_home=str(hermes_home))
+
+    install_calls: list[Path] = []
+
+    def _fake_install(v: Path, _req: Path, **_kwargs: Any) -> None:
+        install_calls.append(v)
+        (v / "bin").mkdir(parents=True, exist_ok=True)
+        (v / "bin" / "hermes").write_text("#!/bin/sh\nexit 0\n")
+        (v / "bin" / "hermes").chmod(0o755)
+
+    monkeypatch.setattr(hp, "_install_venv", _fake_install)
+    out = hp._phase_install(state)
+    assert out.status == hp.PhaseStatus.OK
+    assert install_calls == [venv]
+
+
+def test_resolve_python311_prefers_explicit_when_available() -> None:
+    out = hp._resolve_python311(prober=lambda _name: "/opt/python3.11/bin/python3.11")
+    assert out == "/opt/python3.11/bin/python3.11"
+
+
+def test_resolve_python311_falls_back_to_sys_executable() -> None:
+    out = hp._resolve_python311(prober=lambda _name: None)
+    # CI runs on >= 3.11 (pyproject pin); falls back to sys.executable.
+    assert out is not None


### PR DESCRIPTION
## Summary

Implement the first three Hermes-Agent bootstrap phases on top of #238's scaffold.

- **preflight**: Python ≥ 3.11, hal0 daemon at /api/status, /var/lib/hal0 writable, ≥4 GiB free. Hard-fails per documented blocker.
- **install**: managed venv at /var/lib/hal0/venvs/hermes (pinned hermes-agent==0.14.0), wrapper at /usr/local/bin/hal0-hermes, plugin stub copy. Skips venv install when binary present.
- **home_init**: canonical HERMES_HOME layout. Shared \`_claim_hermes_home\` helper stamps \`.hal0-managed\` marker or refuses to clobber pre-existing ~/.hermes.

Wrapper rewritten post-ADR-0012: exports HERMES_HOME + HAL0_AGENT_ID (no Bearer), execs venv's hermes, optionally sources outbound-creds env file (HF / external MCP tokens per ADR-0013). \`--hal0-ready\` smoke-test sentinel preserved.

Real \`Hal0Profile\` + \`Hal0MemoryProvider\` plugin bodies arrive in #241 + #242 — this PR just stages the directory layout so re-runs after those slices land are file-by-file overlays.

Closes #240.

## Test plan

- [x] \`tests/agents/test_hermes_provision.py\` — 24 tests covering preflight pass/fail branches, home_init idempotence + non-managed-refusal, install venv-skip when binary exists + venv-spawn when missing, python3.11 resolver, full pipeline runs through tmp-rooted state, fixture-driven test isolation.
- [x] \`pytest tests/agents/test_hermes_provision.py\` — 24/24 green.
- [x] \`ruff format --check\` + \`ruff check\` — clean.
- [ ] Real-hardware verify on hal0 LXC: \`hal0 agent bootstrap hermes\` provisions venv + wrapper + HERMES_HOME marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)