### PR TITLE
feat(agents): Hal0Profile plugin + env_probe + config_write phases (#241)

### DIFF
--- a/installer/agents/hermes/plugins/hal0/__init__.py
+++ b/installer/agents/hermes/plugins/hal0/__init__.py
@@ -1,11 +1,49 @@
-"""hal0 model-provider profile — STUB for #240.
+"""hal0 model-provider profile (Hermes plugin, issue #241).
 
-Lives at ``$HERMES_HOME/plugins/model-providers/hal0/`` after bootstrap
-copies the package data. The real :class:`Hal0Profile` implementation
-(subclass of ``providers.base.ProviderProfile``) lands in #241; this
-stub exists so the install phase (#240) can copy a non-empty file into
-position and the directory survives ``pip install``-style packaging
-quirks.
+Hardcodes ``base_url`` at the local hal0 daemon's OpenAI-compatible
+surface and emits a vendor ``User-Agent`` so upstream telemetry +
+``hermes doctor`` can tell hal0-routed traffic apart from generic
+custom-profile traffic.
+
+This file is **copied** into ``$HERMES_HOME/plugins/model-providers/hal0/``
+at bootstrap install time by ``_phase_install`` (see
+``src/hal0/agents/hermes_provision.py`` and #240). It is NOT imported
+by hal0 itself — the imports below resolve against the upstream
+``hermes-agent`` venv where the plugin runs, NOT the hal0 wheel.
+
+Extension reserved for #245 / v0.4: Lemonade keep-alive injection
+(per ``hal0_lemonade_gotchas``) can hook ``prepare_messages`` so the
+serialised-loading evict-all behaviour doesn't drop the slot mid-turn.
 """
 
-# Intentionally empty — see #241.
+from __future__ import annotations
+
+from providers.base import ProviderProfile  # type: ignore[import-not-found]
+
+# Imports resolve in the hermes-agent venv. They will fail at
+# bootstrap-copy-time if Hermes isn't installed, but that's fine —
+# `_phase_install` copies the file verbatim and Hermes loads it lazily
+# when the user picks `provider: hal0`.
+from providers import register_provider  # type: ignore[import-not-found]
+
+
+class Hal0Profile(ProviderProfile):
+    """hal0 LAN-inference provider profile.
+
+    Subclass exists so future overrides (model-list filtering,
+    request-shape tweaks for Lemonade) have a class hook to land on.
+    """
+
+
+hal0 = Hal0Profile(
+    name="hal0",
+    aliases=("hal0-local",),
+    display_name="hal0 (local)",
+    description="hal0 Lemonade-backed slots on the LAN",
+    signup_url="https://hal0.dev",
+    env_vars=(),  # No outbound API key — hal0 daemon trusts LAN clients.
+    base_url="http://127.0.0.1:8000/api/v1",
+    default_aux_model="",
+    default_headers={"User-Agent": "hermes-on-hal0/1.0"},
+)
+register_provider(hal0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,13 @@ dependencies = [
   # MIT-licensed Python SDK; consumed by hal0.mcp.* — required at
   # import time, hence core (not optional).
   "mcp==1.27.0",
+  # v0.3 Hermes-Agent bootstrap (issue #241): config_write phase
+  # renders $HERMES_HOME/config.yaml from a Jinja2 template + deep-merges
+  # /etc/hal0/agents/hermes/overrides.yaml. Both libs were already
+  # transitive via cognee/fastapi; pin them explicitly so the bootstrap
+  # surface stops relying on a sibling package keeping them on disk.
+  "Jinja2>=3.1",
+  "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -492,8 +492,205 @@ def _phase_home_init(state: BootstrapState) -> PhaseResult:
     )
 
 
-_phase_env_probe = _stub("env_probe")
-_phase_config_write = _stub("config_write")
+# ── Phase C: env_probe ──────────────────────────────────────────────────────
+#
+# Walks the hal0-admin MCP probe tools (#237) and stashes a snapshot
+# under ``$HERMES_HOME/`` so config_write + context_link can render
+# from the same point-in-time view. We call the probe functions
+# directly rather than HTTP-roundtripping the local MCP — same data,
+# zero dispatcher hop, easier to test.
+
+
+def _read_env_probe() -> dict[str, Any]:
+    """Compose the env_report snapshot. Late-imports keep the bootstrap
+    importable when the MCP probes module shifts location."""
+    from hal0.mcp import probes  # local import for late binding
+
+    return {
+        "env_report": probes.env_report(),
+        "gpu_target_version": probes.gpu_target_version(),
+        "npu_status": probes.npu_status(),
+        "ai_models": probes.model_store_probe("/mnt/ai-models"),
+    }
+
+
+def _phase_env_probe(state: BootstrapState) -> PhaseResult:
+    """Capture a host-environment snapshot for downstream phases.
+
+    Writes the snapshot to ``$HERMES_HOME/env-<ts>.json`` AND keeps a
+    pointer in ``provision.json``. Snapshot is overwritten on every
+    re-run because it's a point-in-time view, not a checkpoint.
+    """
+    snapshot = _read_env_probe()
+    ts = _utcnow().replace(":", "").replace("-", "")
+    hermes_home = Path(state.hermes_home)
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    snapshot_path = hermes_home / f"env-{ts}.json"
+    snapshot_path.write_text(json.dumps(snapshot, indent=2, sort_keys=True), encoding="utf-8")
+    return PhaseResult(
+        status=PhaseStatus.OK,
+        details={
+            "snapshot_path": str(snapshot_path),
+            "strix_halo": snapshot["env_report"].get("cpu", {}).get("strix_halo"),
+            "gfx": snapshot["gpu_target_version"].get("gfx"),
+            "npu_present": snapshot["npu_status"].get("present"),
+        },
+    )
+
+
+# ── Phase E: config_write ───────────────────────────────────────────────────
+
+
+CONFIG_TEMPLATE_PATH = Path(__file__).resolve().parent / "hermes_templates" / "config.yaml.j2"
+
+
+def _resolve_primary_slot(*, fetcher: Callable[[], dict[str, Any]] | None = None) -> dict[str, Any]:
+    """Pick the live primary chat slot from the local hal0 daemon.
+
+    Returns a dict with the keys the config template needs. Falls back
+    to a safe-but-unwired placeholder when no slot is loaded — the
+    self_report phase surfaces this in the bootstrap summary.
+    """
+    fallback = {
+        "model": "primary",
+        "base_url": "http://127.0.0.1:8000/api/v1",
+        "context_length": 32768,
+    }
+    if fetcher is None:
+
+        def _real() -> dict[str, Any]:
+            from urllib.error import URLError
+            from urllib.request import urlopen
+
+            try:
+                with urlopen("http://127.0.0.1:8080/v1/health", timeout=2.0) as resp:
+                    return json.loads(resp.read().decode("utf-8"))
+            except (URLError, OSError, json.JSONDecodeError):
+                return {}
+
+        fetcher = _real
+    data = fetcher() or {}
+    loaded = data.get("loaded") or data.get("slots") or []
+    if isinstance(loaded, list) and loaded:
+        first = loaded[0] if isinstance(loaded[0], dict) else {}
+        return {
+            "model": first.get("model") or first.get("model_id") or fallback["model"],
+            "base_url": first.get("backend_url") or fallback["base_url"],
+            "context_length": int(first.get("context_length") or fallback["context_length"]),
+        }
+    return fallback
+
+
+def _render_config_yaml(
+    *,
+    primary: dict[str, Any] | None,
+    chat_slots: list[dict[str, Any]] | None = None,
+    stt: dict[str, Any] | None = None,
+    tts: dict[str, Any] | None = None,
+    agent_id: str = "hermes-agent",
+    mcp_admin_url: str = "http://127.0.0.1:8080/mcp/admin",
+    mcp_memory_url: str = "http://127.0.0.1:8080/mcp/memory",
+) -> str:
+    """Render the Hermes config.yaml via Jinja2.
+
+    Variable shape matches the template's docstring (see
+    ``src/hal0/agents/hermes_templates/config.yaml.j2``). Jinja2 is
+    pinned in pyproject so the dep is always present in production
+    bootstraps — no fallback needed.
+    """
+    from jinja2 import Environment, FileSystemLoader
+
+    env = Environment(
+        loader=FileSystemLoader(str(CONFIG_TEMPLATE_PATH.parent)),
+        keep_trailing_newline=True,
+        autoescape=False,  # YAML output — escaping would corrupt literal strings.
+    )
+    tpl = env.get_template(CONFIG_TEMPLATE_PATH.name)
+    return tpl.render(
+        primary=primary,
+        chat_slots=chat_slots or [],
+        stt=stt,
+        tts=tts,
+        agent_id=agent_id,
+        mcp_admin_url=mcp_admin_url,
+        mcp_memory_url=mcp_memory_url,
+    )
+
+
+def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Recursive dict merge — overlay wins; nested dicts merge."""
+    out = dict(base)
+    for k, v in overlay.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = _deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def _apply_overrides(rendered_yaml: str, overrides_path: Path) -> str:
+    """Deep-merge ``overrides_path`` (if present) on top of rendered YAML.
+
+    Re-emits YAML via stdlib (json round-trip is the fallback when
+    PyYAML isn't installed — the resulting JSON is still valid YAML).
+    """
+    if not overrides_path.exists():
+        return rendered_yaml
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError:
+        return rendered_yaml  # PyYAML not installed; ship as-is.
+    base = yaml.safe_load(rendered_yaml) or {}
+    overlay = yaml.safe_load(overrides_path.read_text()) or {}
+    merged = _deep_merge(base, overlay)
+    return yaml.safe_dump(merged, sort_keys=False, default_flow_style=False)
+
+
+OVERRIDES_PATH = Path("/etc/hal0/agents/hermes/overrides.yaml")
+
+
+def _phase_config_write(state: BootstrapState) -> PhaseResult:
+    """Atomically render ``$HERMES_HOME/config.yaml`` from the template.
+
+    Idempotent: hash-equal output skips the write. Overrides at
+    ``/etc/hal0/agents/hermes/overrides.yaml`` deep-merge on top.
+    """
+    hermes_home = Path(state.hermes_home)
+    config_path = hermes_home / "config.yaml"
+    primary_raw = _resolve_primary_slot()
+    # The template names the dict keys ``model_id``/``backend_url``;
+    # _resolve_primary_slot returns ``model``/``base_url`` for less
+    # cognitive load at call sites. Translate at the seam.
+    primary = {
+        "model_id": primary_raw["model"],
+        "backend_url": primary_raw["base_url"],
+        "context_length": primary_raw["context_length"],
+    }
+    rendered = _render_config_yaml(
+        primary=primary,
+        agent_id=state.agent_id,
+    )
+    rendered = _apply_overrides(rendered, OVERRIDES_PATH)
+    new_hash = content_hash(rendered)
+
+    if config_path.exists() and content_hash(config_path.read_text(encoding="utf-8")) == new_hash:
+        return PhaseResult(
+            status=PhaseStatus.OK,
+            hash=new_hash,
+            details={"config_path": str(config_path), "unchanged": True},
+        )
+
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    tmp = config_path.with_suffix(".yaml.tmp")
+    tmp.write_text(rendered, encoding="utf-8")
+    os.replace(tmp, config_path)
+    return PhaseResult(
+        status=PhaseStatus.OK,
+        hash=new_hash,
+        details={"config_path": str(config_path), "primary_model": primary["model_id"]},
+    )
+
+
 _phase_mcp_wire = _stub("mcp_wire")
 _phase_context_link = _stub("context_link")
 _phase_namespace_register = _stub("namespace_register")

--- a/src/hal0/agents/hermes_templates/config.yaml.j2
+++ b/src/hal0/agents/hermes_templates/config.yaml.j2
@@ -1,0 +1,127 @@
+{# Hermes-Agent config.yaml — rendered by hal0's config_write phase (issue #241).
+   See docs/internal/hermes-bootstrap-plan-2026-05-23.md §8 for the contract.
+   The render is hashed and atomically swapped into $HERMES_HOME/config.yaml;
+   overrides.yaml (if present) deep-merges on top per the upstream-edit-friendly
+   escape hatch.
+
+   Variables expected (every key has a sensible default; missing values are
+   tolerated so a partial env_probe doesn't crash the render):
+     primary          — dict or None ({model_id, backend_url, context_length})
+     chat_slots       — list[dict]   ({alias, model_id, backend_url})
+     stt              — dict or None ({provider, backend_url, model})
+     tts              — dict or None ({provider, backend_url, model})
+     agent_id         — str          (default "hermes-agent")
+     mcp_admin_url    — str
+     mcp_memory_url   — str
+#}# Managed by hal0 (issue #241). Edits MAY be overwritten by
+# `hal0 agent bootstrap hermes`. Drop a file at
+# /etc/hal0/agents/hermes/overrides.yaml to merge on top.
+
+model:
+{%- if primary %}
+  default: {{ primary.model_id | tojson }}
+  provider: "hal0"
+  base_url: {{ primary.backend_url | tojson }}
+{%- if primary.context_length %}
+  context_length: {{ primary.context_length }}
+{%- endif %}
+{%- else %}
+  # No chat slot was ready at bootstrap time — operator must wire one
+  # before the agent can serve completions. Re-run bootstrap with
+  # `--repair` once the primary slot is loaded to refresh this section.
+  default: ""
+  provider: "hal0"
+  base_url: "http://127.0.0.1:8000/api/v1"
+{%- endif %}
+
+providers:
+  hal0:
+    request_timeout_seconds: 300
+    stale_timeout_seconds: 900
+
+{%- if chat_slots %}
+
+model_aliases:
+{%- for slot in chat_slots %}
+  {{ slot.alias }}:
+    model: {{ slot.model_id | tojson }}
+    provider: "hal0"
+    base_url: {{ slot.backend_url | tojson }}
+{%- endfor %}
+{%- endif %}
+
+memory:
+  # Hal0MemoryProvider plugin (#242). MCP server stays mounted in parallel
+  # so an operator can call memory_delete by hand without going through
+  # the agent loop.
+  provider: "hal0-memory"
+  memory_enabled: true
+  user_profile_enabled: true
+  nudge_interval: 10
+  # ADR-0014: graph extraction defaults OFF. Honored by Hal0MemoryProvider.
+  graph:
+    enabled: false
+    route: "upstream"
+
+mcp_servers:
+  hal0-admin:
+    url: {{ mcp_admin_url | tojson }}
+    headers:
+      # ADR-0012: no Bearer; agent identity flows via X-hal0-Agent
+      # which MCPIdentityMiddleware (renamed from MCPAuthMiddleware)
+      # treats as the client_id for private:<client_id> namespacing.
+      X-hal0-Agent: {{ agent_id | tojson }}
+    timeout: 60
+  hal0-memory:
+    url: {{ mcp_memory_url | tojson }}
+    headers:
+      X-hal0-Agent: {{ agent_id | tojson }}
+      X-hal0-Private: "1"
+    timeout: 30
+
+skills:
+  external_dirs:
+    - "/etc/hal0/agent-skills"
+    - "/var/lib/hal0/skills"
+  creation_nudge_interval: 15
+
+terminal:
+  backend: "local"
+  cwd: "/etc/hal0"
+
+agent:
+  max_turns: 60
+  reasoning_effort: "medium"
+
+display:
+  bell_on_complete: false
+  show_reasoning: false
+
+auxiliary:
+  vision: { provider: "main", model: "" }
+  web_extract: { provider: "main", model: "" }
+  session_search: { provider: "main", model: "" }
+
+{%- if stt %}
+
+stt:
+  provider: {{ stt.provider | default("openai") | tojson }}
+{%- if stt.model %}
+  openai:
+    model: {{ stt.model | tojson }}
+{%- endif %}
+{%- endif %}
+{%- if tts %}
+
+tts:
+  provider: {{ tts.provider | default("openai") | tojson }}
+{%- if tts.model %}
+  openai:
+    model: {{ tts.model | tojson }}
+{%- endif %}
+{%- endif %}
+
+hooks:
+  on_session_start:
+    - command: "/usr/lib/hal0/hermes-hooks/inject-system-state.sh"
+      timeout: 2

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -376,3 +376,128 @@ def test_resolve_python311_falls_back_to_sys_executable() -> None:
     out = hp._resolve_python311(prober=lambda _name: None)
     # CI runs on >= 3.11 (pyproject pin); falls back to sys.executable.
     assert out is not None
+
+
+# ── #241 phase impls — env_probe / config_write ─────────────────────────────
+
+
+def test_env_probe_writes_snapshot_to_hermes_home(tmp_path: Path) -> None:
+    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
+    out = hp._phase_env_probe(state)
+    assert out.status == hp.PhaseStatus.OK
+    snap = Path(out.details["snapshot_path"])
+    assert snap.exists()
+    import json as _json
+
+    data = _json.loads(snap.read_text())
+    for key in ("env_report", "gpu_target_version", "npu_status", "ai_models"):
+        assert key in data
+
+
+def test_resolve_primary_slot_uses_loaded_entry() -> None:
+    fake = lambda: {  # noqa: E731
+        "loaded": [
+            {"model": "qwen3:8b", "backend_url": "http://127.0.0.1:8001", "context_length": 16384}
+        ]
+    }
+    out = hp._resolve_primary_slot(fetcher=fake)
+    assert out["model"] == "qwen3:8b"
+    assert out["base_url"] == "http://127.0.0.1:8001"
+    assert out["context_length"] == 16384
+
+
+def test_resolve_primary_slot_fallback_when_no_loaded_slots() -> None:
+    out = hp._resolve_primary_slot(fetcher=lambda: {})
+    assert out["model"] == "primary"
+    assert out["context_length"] == 32768
+
+
+def test_render_config_yaml_includes_primary_block() -> None:
+    rendered = hp._render_config_yaml(
+        primary={
+            "model_id": "qwen3:8b",
+            "backend_url": "http://127.0.0.1:8001/v1",
+            "context_length": 16384,
+        },
+        agent_id="hermes-agent",
+    )
+    assert '"qwen3:8b"' in rendered
+    assert '"http://127.0.0.1:8001/v1"' in rendered
+    assert 'X-hal0-Agent: "hermes-agent"' in rendered
+    # ADR-0014: graph extraction defaults OFF.
+    assert "enabled: false" in rendered
+
+
+def test_render_config_yaml_no_primary_emits_safe_placeholder() -> None:
+    rendered = hp._render_config_yaml(primary=None, agent_id="hermes-agent")
+    assert 'default: ""' in rendered
+    assert "127.0.0.1:8000/api/v1" in rendered
+
+
+def test_render_config_yaml_chat_slots_become_aliases() -> None:
+    rendered = hp._render_config_yaml(
+        primary={"model_id": "p", "backend_url": "u", "context_length": 8000},
+        chat_slots=[
+            {"alias": "coder", "model_id": "qwen-coder", "backend_url": "http://x"},
+        ],
+        agent_id="hermes-agent",
+    )
+    assert "model_aliases:" in rendered
+    assert "coder:" in rendered
+    assert '"qwen-coder"' in rendered
+
+
+def test_config_write_phase_writes_yaml_idempotently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
+    monkeypatch.setattr(
+        hp,
+        "_resolve_primary_slot",
+        lambda **_kwargs: {"model": "p", "base_url": "u", "context_length": 8000},
+    )
+    monkeypatch.setattr(hp, "OVERRIDES_PATH", tmp_path / "no-such-overrides.yaml")
+    out1 = hp._phase_config_write(state)
+    assert out1.status == hp.PhaseStatus.OK
+    cfg = Path(out1.details["config_path"])
+    assert cfg.exists()
+    first_hash = out1.hash
+    # Re-run is a no-op (hash equals on-disk).
+    out2 = hp._phase_config_write(state)
+    assert out2.details.get("unchanged") is True
+    assert out2.hash == first_hash
+
+
+def test_config_write_phase_applies_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
+    overrides = tmp_path / "overrides.yaml"
+    overrides.write_text("agent:\n  max_turns: 999\n")
+    monkeypatch.setattr(
+        hp,
+        "_resolve_primary_slot",
+        lambda **_kwargs: {"model": "p", "base_url": "u", "context_length": 8000},
+    )
+    monkeypatch.setattr(hp, "OVERRIDES_PATH", overrides)
+    out = hp._phase_config_write(state)
+    assert out.status == hp.PhaseStatus.OK
+    cfg = Path(out.details["config_path"]).read_text()
+    assert "999" in cfg
+
+
+def test_deep_merge_recurses() -> None:
+    base = {"a": {"b": 1, "c": 2}, "d": 3}
+    overlay = {"a": {"c": 99, "e": 4}}
+    merged = hp._deep_merge(base, overlay)
+    assert merged == {"a": {"b": 1, "c": 99, "e": 4}, "d": 3}
+
+
+def test_hal0_profile_plugin_file_present() -> None:
+    """The plugin source file ships in the wheel + has the required hooks."""
+    repo_root = hp.REPO_ROOT_FOR_INSTALLER
+    src = repo_root / "installer" / "agents" / "hermes" / "plugins" / "hal0" / "__init__.py"
+    body = src.read_text()
+    assert "Hal0Profile" in body
+    assert "register_provider" in body
+    assert "hermes-on-hal0" in body  # User-Agent header marker


### PR DESCRIPTION
## Summary

Three interlocked deliverables on top of #240's install layout:

- **\`Hal0Profile(ProviderProfile)\`** real impl at \`installer/agents/hermes/plugins/hal0/__init__.py\` — base_url at 127.0.0.1:8000/api/v1, vendor User-Agent, subclass hook for future Lemonade keep-alive injection.
- **\`env_probe\`** phase consumes the #237 MCP probe tools in-process (env_report + gpu_target_version + npu_status + model_store_probe). Snapshot lands at \`\$HERMES_HOME/env-<ts>.json\`.
- **\`config_write\`** phase: Jinja2 template at \`src/hal0/agents/hermes_templates/config.yaml.j2\`, atomic rename, hash-equal skip on re-run, deep-merge of \`/etc/hal0/agents/hermes/overrides.yaml\`. Honors ADR-0014 (graph default OFF) + ADR-0012 (\`X-hal0-Agent\` header, no Bearer). Sends \`model.provider: hal0\` (the plugin), not \"custom\".

Jinja2 + PyYAML pinned explicitly in pyproject — both were transitive but the bootstrap shouldn't rely on a sibling package keeping them on disk.

Closes #241.

## Test plan

- [x] \`tests/agents/test_hermes_provision.py\` — 34 tests; new: env_probe snapshot shape, _resolve_primary_slot fallback, render variants (primary present/absent, chat_slots → aliases), config_write idempotence + overrides deep-merge, plugin file shape (Hal0Profile + register_provider present).
- [x] \`pytest tests/agents/ tests/mcp/\` — 99/99 green.
- [x] \`ruff format --check\` + \`ruff check\` — clean.
- [ ] Real-hardware verify on hal0 LXC: after \`hal0 agent bootstrap hermes\`, \`hermes doctor\` shows the hal0 provider reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)