### PR TITLE
feat(cli): hal0 memory graph {status,enable,disable} (#258)

### DIFF
--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -32,6 +32,7 @@ from hal0.cli.agent_commands import app as agent_app
 from hal0.cli.capabilities_commands import app as capabilities_app
 from hal0.cli.config_commands import app as config_app
 from hal0.cli.doctor_commands import app as doctor_app
+from hal0.cli.memory_commands import app as memory_app
 from hal0.cli.migrate_commands import app as migrate_app
 from hal0.cli.model_commands import app as model_app
 from hal0.cli.registry_commands import app as registry_app
@@ -54,6 +55,10 @@ app = typer.Typer(
 # Mount sub-apps
 app.add_typer(slot_app, name="slot")
 app.add_typer(model_app, name="model")
+# Issue #258 — ``hal0 memory graph {status,enable,disable}`` ADR-0014 surface.
+# Mounted between ``model`` and ``config`` so it sits alongside the other
+# user-facing data subcommands rather than buried under operator surfaces.
+app.add_typer(memory_app, name="memory")
 app.add_typer(config_app, name="config")
 app.add_typer(doctor_app, name="doctor")
 app.add_typer(capabilities_app, name="capabilities")

--- a/src/hal0/cli/memory_commands.py
+++ b/src/hal0/cli/memory_commands.py
@@ -1,0 +1,186 @@
+"""hal0 memory subcommands — ADR-0014 graph-extraction gate.
+
+Mirrors the slot / model CLI shape: a thin HTTP client to the local
+hal0 API. The ``graph`` sub-sub-app maps 1:1 to the routes in
+:mod:`hal0.api.routes.memory`:
+
+    hal0 memory graph status                            → GET  /api/memory/graph/status
+    hal0 memory graph enable [--route ...] [--provider …] [--model …]
+                                                        → PUT  /api/memory/graph (enabled=true …)
+    hal0 memory graph disable                           → PUT  /api/memory/graph (enabled=false)
+
+PLAN.md §13 ("CLI is a thin client") — every command hits 127.0.0.1:8080.
+"""
+
+from __future__ import annotations
+
+import json as jsonlib
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from hal0.cli._shared import (
+    CliApiError,
+    _api_base,
+    _api_unreachable,
+    api_get,
+    api_put,
+    die,
+)
+
+app = typer.Typer(help="Manage hal0 memory (Cognee — ADR-0005 + ADR-0014).")
+console = Console()
+
+# ``graph`` sub-sub-app so ``hal0 memory graph --help`` renders cleanly
+# alongside ``hal0 memory --help``. Same pattern as ``hal0 agent approvals``.
+graph_app = typer.Typer(help="Graph-extraction gate (ADR-0014).")
+app.add_typer(graph_app, name="graph")
+
+
+# ── ``hal0 memory graph status`` ──────────────────────────────────────────────
+
+
+@graph_app.command("status")
+def graph_status_cmd(
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit raw JSON instead of the human-readable panel.",
+    ),
+) -> None:
+    """Show the live graph-extraction status (enabled / route / counters)."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        s = api_get("/api/memory/graph/status")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    if not isinstance(s, dict):
+        die(f"unexpected status payload: {s!r}")
+        return
+    if json_out:
+        typer.echo(jsonlib.dumps(s, indent=2, sort_keys=True))
+        return
+
+    enabled = bool(s.get("enabled"))
+    state = "[bold green]ON[/bold green]" if enabled else "[bold]OFF[/bold]"
+    route = s.get("route", "—")
+    upstream = s.get("upstream") or {}
+    upstream_line = (
+        f"{upstream.get('provider', '?')} · {upstream.get('model', '?')}"
+        if upstream
+        else "[dim]not configured[/dim]"
+    )
+
+    t = Table.grid(padding=(0, 2))
+    t.add_column("k", style="dim")
+    t.add_column("v")
+    t.add_row("State", state)
+    t.add_row("Route", str(route))
+    t.add_row("Upstream", upstream_line)
+    t.add_row("Builds OK", str(s.get("builds_ok", 0)))
+    t.add_row("Errors", str(s.get("errors", 0)))
+    t.add_row("In-flight", str(s.get("in_flight", 0)))
+    last = s.get("last_built_at") or "[dim]never[/dim]"
+    t.add_row("Last build", str(last))
+    if s.get("last_error"):
+        t.add_row("Last error", f"[red]{s['last_error']}[/red]")
+    console.print(Panel(t, title="memory · graph", border_style="dim"))
+
+
+# ── ``hal0 memory graph enable`` ──────────────────────────────────────────────
+
+
+@graph_app.command("enable")
+def graph_enable_cmd(
+    route: str = typer.Option(
+        "upstream",
+        "--route",
+        help="Where to dispatch graph extraction: upstream | primary | agent.",
+    ),
+    provider: str | None = typer.Option(
+        None,
+        "--provider",
+        help="Upstream provider id (required when --route=upstream).",
+    ),
+    model: str | None = typer.Option(
+        None,
+        "--model",
+        help="Upstream model id (required when --route=upstream).",
+    ),
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit the raw JSON response instead of a panel."
+    ),
+) -> None:
+    """Turn graph extraction ON.
+
+    ``--route=upstream`` requires ``--provider`` + ``--model``. The
+    server-side validator ALSO enforces this, so the CLI can be skipped
+    in scripts that hit the API directly.
+    """
+    if route not in {"upstream", "primary", "agent"}:
+        die(f"--route must be one of upstream | primary | agent (got {route!r})")
+        return
+    if route == "upstream" and (not provider or not model):
+        die("--route=upstream requires --provider and --model")
+        return
+
+    payload: dict[str, Any] = {"enabled": True, "route": route}
+    if route == "upstream":
+        payload["upstream"] = {"provider": provider, "model": model}
+
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        result = api_put("/api/memory/graph", json=payload)
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    if json_out:
+        typer.echo(jsonlib.dumps(result, indent=2, sort_keys=True))
+        return
+    console.print(
+        Panel(
+            f"[bold green]Graph extraction enabled[/bold green]\n"
+            f"route = [bold]{result.get('route')}[/bold]",
+            border_style="green",
+        )
+    )
+
+
+# ── ``hal0 memory graph disable`` ─────────────────────────────────────────────
+
+
+@graph_app.command("disable")
+def graph_disable_cmd(
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit the raw JSON response instead of a panel."
+    ),
+) -> None:
+    """Turn graph extraction OFF; cancels any in-flight build (ADR §6)."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        result = api_put("/api/memory/graph", json={"enabled": False})
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    if json_out:
+        typer.echo(jsonlib.dumps(result, indent=2, sort_keys=True))
+        return
+    console.print(
+        Panel(
+            "[bold]Graph extraction disabled[/bold]\n[dim]In-flight builds cancelled.[/dim]",
+            border_style="yellow",
+        )
+    )
+
+
+__all__ = ["app", "graph_app"]

--- a/tests/cli/test_memory_graph_commands.py
+++ b/tests/cli/test_memory_graph_commands.py
@@ -1,0 +1,142 @@
+"""Tests for ``hal0 memory graph {status,enable,disable}`` (ADR-0014 / #258).
+
+Mocks the API layer so the CLI runs offline. Pins:
+
+  - ``status`` projects ``enabled / route / counters / upstream`` into
+    the panel + JSON view.
+  - ``enable --route=upstream`` requires --provider + --model client-side.
+  - ``enable --route=primary`` sends the right payload (no upstream block).
+  - ``disable`` sends ``{enabled: false}``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import memory_commands
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def stub_api(monkeypatch: pytest.MonkeyPatch):
+    """Stub the shared API helpers so CLI runs offline."""
+
+    def fake_unreachable(_url: str) -> bool:
+        return False
+
+    monkeypatch.setattr(memory_commands, "_api_unreachable", fake_unreachable)
+
+    calls: dict[str, list[Any]] = {"get": [], "put": []}
+
+    def fake_get(path: str, **_kw: Any) -> dict[str, Any]:
+        calls["get"].append(path)
+        # Default status response — tests can override via monkeypatch.
+        return {
+            "enabled": False,
+            "route": "upstream",
+            "upstream": None,
+            "in_flight": 0,
+            "builds_ok": 0,
+            "errors": 0,
+            "last_built_at": None,
+            "last_error": None,
+        }
+
+    def fake_put(path: str, **kw: Any) -> dict[str, Any]:
+        calls["put"].append((path, kw.get("json")))
+        # Echo back the payload as if the server accepted.
+        body = kw.get("json", {})
+        return {**body, "status": {"enabled": body.get("enabled", False)}}
+
+    monkeypatch.setattr(memory_commands, "api_get", fake_get)
+    monkeypatch.setattr(memory_commands, "api_put", fake_put)
+    return calls
+
+
+def test_status_default_panel(stub_api) -> None:
+    result = runner.invoke(memory_commands.app, ["graph", "status"])
+    assert result.exit_code == 0, result.output
+    # Off-by-default → "OFF" appears (rich may insert ANSI; just match
+    # the substring).
+    assert "OFF" in result.output
+    assert "upstream" in result.output
+
+
+def test_status_json(stub_api) -> None:
+    result = runner.invoke(memory_commands.app, ["graph", "status", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["enabled"] is False
+    assert payload["route"] == "upstream"
+
+
+def test_enable_upstream_requires_provider_and_model(stub_api) -> None:
+    result = runner.invoke(
+        memory_commands.app,
+        ["graph", "enable", "--route", "upstream"],
+    )
+    assert result.exit_code != 0
+    assert "--provider" in result.output
+
+
+def test_enable_primary_sends_no_upstream(stub_api) -> None:
+    result = runner.invoke(
+        memory_commands.app,
+        ["graph", "enable", "--route", "primary"],
+    )
+    assert result.exit_code == 0, result.output
+    assert stub_api["put"], "PUT should have been sent"
+    _, payload = stub_api["put"][-1]
+    assert payload == {"enabled": True, "route": "primary"}
+
+
+def test_enable_upstream_with_provider_and_model(stub_api) -> None:
+    result = runner.invoke(
+        memory_commands.app,
+        [
+            "graph",
+            "enable",
+            "--route",
+            "upstream",
+            "--provider",
+            "openrouter",
+            "--model",
+            "anthropic/claude-3.5-sonnet",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    _, payload = stub_api["put"][-1]
+    assert payload["enabled"] is True
+    assert payload["upstream"] == {
+        "provider": "openrouter",
+        "model": "anthropic/claude-3.5-sonnet",
+    }
+
+
+def test_enable_invalid_route_rejected_client_side(stub_api) -> None:
+    result = runner.invoke(
+        memory_commands.app,
+        ["graph", "enable", "--route", "bogus"],
+    )
+    assert result.exit_code != 0
+    # The CLI rejects before sending — no PUT should land.
+    assert stub_api["put"] == []
+
+
+def test_disable_sends_enabled_false(stub_api) -> None:
+    result = runner.invoke(memory_commands.app, ["graph", "disable"])
+    assert result.exit_code == 0, result.output
+    _, payload = stub_api["put"][-1]
+    assert payload == {"enabled": False}
+
+
+def test_disable_json(stub_api) -> None:
+    result = runner.invoke(memory_commands.app, ["graph", "disable", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["enabled"] is False


### PR DESCRIPTION
ADR-0014 §3 CLI surface — thin HTTP client over the /api/memory/graph routes from #287. Closes #258.

## Summary
- `hal0 memory graph status [--json]` renders enabled/route/upstream/counters/last-build.
- `hal0 memory graph enable --route {upstream|primary|agent} [--provider X --model Y]` with client-side guard for upstream route.
- `hal0 memory graph disable` cancels in-flight cognify per ADR §6.

## Test plan
- [x] `tests/cli/test_memory_graph_commands.py` — 8 cases (panel + JSON + payload shape + client-side validation)
- [x] `hal0 memory --help` renders the graph sub-app
- [x] `ruff format --check` + `ruff check` clean

Depends on #287 (backend) — already merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)