### PR TITLE
feat(agents): namespace_register phase + identity cards + hal0 agent peers (#243)

### DIFF
--- a/docs/internal/adr/0011-agent-identity-cards.md
+++ b/docs/internal/adr/0011-agent-identity-cards.md
@@ -1,6 +1,6 @@
 # ADR 0011 — Agent identity cards (Phase 8, v0.3)
 
-- **Status:** Draft
+- **Status:** Accepted (2026-05-23, post-implementation review for #243)
 - **Date:** 2026-05-23
 - **Drivers:** `/grill-me` session 2026-05-23 against `docs/internal/hermes-bootstrap-plan-2026-05-23.md`; bundled Hermes agent v0.3 needs to publish itself + discover peers
 - **Implementing PRs:** PR-1 (this ADR + new MCP admin tools) per the bootstrap plan §23
@@ -153,9 +153,14 @@ The convention is agent-agnostic. When the pi-coder bootstrap lands
 (Phase 8 follow-up after Hermes), it writes its own card under the same
 schema. Same for any future bundled or aftermarket agent.
 
-The hal0 CLI ships a `hal0 agent list` command in v0.3 that
+The hal0 CLI ships a `hal0 agent peers` command in v0.3 that
 enumerates identity cards (a thin wrapper over the `memory_search`
-call shown above).
+call shown above). The `peers` name avoids collision with the
+pre-existing `hal0 agent list` (which lists locally-installed bundled
+agents per v0.2's `AgentManager.list()` contract). The two surfaces
+are complementary: `list` shows what's bundled on this host;
+`peers` shows what's discoverable in the shared Cognee `agents`
+dataset.
 
 ## Consequences
 

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -836,7 +836,183 @@ def _phase_mcp_wire(state: BootstrapState) -> PhaseResult:
 
 
 _phase_context_link = _stub("context_link")
-_phase_namespace_register = _stub("namespace_register")
+
+
+# ── Phase H: namespace_register ─────────────────────────────────────────────
+#
+# Writes the Hermes-Agent identity card to the `agents` Cognee dataset
+# (ADR-0011). Card is immutable post-write — re-bootstrap deletes the
+# existing card and writes a fresh one to refresh metadata (the only
+# legitimate post-install write). On hal0-memory failure, log + continue
+# (per #243 sharpening + ADR-0013); the card is nice-to-have and
+# bootstrap MUST NOT fail because the peer registry is down.
+
+
+AGENT_IDENTITY_TAG = "agent-identity"
+AGENTS_DATASET = "agents"
+
+
+def _hermes_version_pin() -> str:
+    req = REPO_ROOT_FOR_INSTALLER / "installer" / "agents" / "hermes" / "requirements.txt"
+    try:
+        for line in req.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line.startswith("hermes-agent=="):
+                return line.split("==", 1)[1].split("#", 1)[0].strip()
+    except OSError:
+        pass
+    return "unknown"
+
+
+def _hal0_version_string() -> str:
+    try:
+        from hal0 import __version__
+
+        return __version__
+    except (ImportError, AttributeError):
+        return "unknown"
+
+
+def _build_identity_card(state: BootstrapState) -> dict[str, Any]:
+    """Schema v1 per ADR-0011 §4. Text + structured metadata."""
+    return {
+        "text": (
+            "I am Hermes, the hal0 admin agent. I have read/write access to the slot "
+            "lifecycle and the memory store on this host. I can do generalist chat and "
+            "code review on the LAN."
+        ),
+        "tags": [AGENT_IDENTITY_TAG, "hermes"],
+        "dataset": AGENTS_DATASET,
+        "metadata": {
+            "agent_id": state.agent_id,
+            "display_name": "Hermes (hal0 admin)",
+            "namespace": f"private:{state.agent_id}",
+            "roles": ["homelab-admin", "generalist-chat", "memory-curator"],
+            "endpoint": {
+                "type": "mcp-serve",
+                "url": "http://127.0.0.1:8081/mcp",
+                "transport": "streamable-http",
+            },
+            "delegation": {
+                "accepts_tasks_from": ["claude-code", "pi-coder", "user"],
+                "max_concurrent": 3,
+            },
+            "hal0_state": {
+                "registered_at": _utcnow(),
+                "bootstrap_version": 1,
+                "hal0_version": _hal0_version_string(),
+                "hermes_version": _hermes_version_pin(),
+            },
+        },
+    }
+
+
+def _mcp_memory_call(
+    method: str,
+    params: dict[str, Any],
+    *,
+    agent_id: str,
+    base_url: str = "http://127.0.0.1:8080/mcp/memory",
+    timeout: float = 5.0,
+    private: bool = False,
+) -> dict[str, Any]:
+    """JSON-RPC POST to the hal0-memory MCP server. Stdlib transport."""
+    from urllib.error import URLError
+    from urllib.request import Request, urlopen
+
+    body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": method, "params": params}).encode(
+        "utf-8"
+    )
+    headers = {"Content-Type": "application/json", "X-hal0-Agent": agent_id}
+    if private:
+        headers["X-hal0-Private"] = "1"
+    req = Request(base_url, data=body, headers=headers, method="POST")
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except (URLError, OSError, json.JSONDecodeError, TimeoutError) as exc:
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True, "result": data.get("result")}
+
+
+def _phase_namespace_register(state: BootstrapState) -> PhaseResult:
+    """Write the Hermes identity card to the `agents` Cognee dataset.
+
+    Idempotency: search for an existing card by ``agent_id`` first;
+    if present, delete it before writing the fresh one (cards are
+    immutable per ADR-0011 §2, but bootstrap rewrites refresh the
+    snapshot of hal0_version + hermes_version).
+
+    Failure mode: any MCP transport error logs + returns OK with a
+    warning. Bootstrap MUST NOT block on registry unavailability.
+    """
+    card = _build_identity_card(state)
+    warnings: list[str] = []
+
+    # Look up existing card so re-bootstrap doesn't accumulate duplicates.
+    search = _mcp_memory_call(
+        "tools/call",
+        {
+            "name": "memory_search",
+            "arguments": {
+                "query": state.agent_id,
+                "tags": [AGENT_IDENTITY_TAG],
+                "dataset": AGENTS_DATASET,
+                "limit": 50,
+            },
+        },
+        agent_id=state.agent_id,
+    )
+    existing_ids: list[str] = []
+    if search["ok"] and isinstance(search["result"], dict):
+        items = search["result"].get("items") or []
+        for item in items if isinstance(items, list) else []:
+            if not isinstance(item, dict):
+                continue
+            md = item.get("metadata") or {}
+            if md.get("agent_id") == state.agent_id and item.get("id"):
+                existing_ids.append(item["id"])
+    elif not search["ok"]:
+        warnings.append(f"memory_search: {search['error']}")
+
+    if existing_ids:
+        deleted = _mcp_memory_call(
+            "tools/call",
+            {"name": "memory_delete", "arguments": {"ids": existing_ids}},
+            agent_id=state.agent_id,
+        )
+        if not deleted["ok"]:
+            warnings.append(f"memory_delete: {deleted['error']}")
+
+    add = _mcp_memory_call(
+        "tools/call",
+        {"name": "memory_add", "arguments": card},
+        agent_id=state.agent_id,
+    )
+    if not add["ok"]:
+        # Bootstrap continues — the card is nice-to-have, not a blocker.
+        warnings.append(f"memory_add: {add['error']}")
+        return PhaseResult(
+            status=PhaseStatus.OK,
+            details={"registered": False, "warnings": warnings, "card": card},
+            reason="hal0-memory unreachable; identity card not registered (continuing)",
+        )
+
+    memory_id = None
+    if isinstance(add["result"], dict):
+        memory_id = add["result"].get("id")
+    return PhaseResult(
+        status=PhaseStatus.OK,
+        details={
+            "registered": True,
+            "memory_id": memory_id,
+            "card": card,
+            "warnings": warnings,
+            "refreshed_existing": bool(existing_ids),
+        },
+    )
+
+
 _phase_model_automap = _stub("model_automap")
 _phase_voice_wire = _stub("voice_wire")
 _phase_smoke_tests = _stub("smoke_tests")

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -257,6 +257,83 @@ def approvals_deny(
 # ── Bootstrap (Hermes provisioning, Phase 10) ────────────────────────────────
 
 
+@app.command("peers")
+def agent_peers() -> None:
+    """List discoverable agent identity cards (ADR-0011 §6).
+
+    Thin wrapper over ``memory_search`` against the dedicated
+    ``agents`` Cognee dataset. Sibling of ``hal0 agent list`` (which
+    shows installed bundled agents on this host); ``peers`` shows
+    every card published into the federated registry.
+    """
+    import json as _json
+    import urllib.error
+    import urllib.request
+
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+
+    body = _json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "memory_search",
+                "arguments": {
+                    "query": "agent identity",
+                    "tags": ["agent-identity"],
+                    "dataset": "agents",
+                    "limit": 50,
+                },
+            },
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        f"{url}/mcp/memory",
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-hal0-Agent": "hal0-cli",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5.0) as resp:
+            data = _json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, _json.JSONDecodeError) as exc:
+        die(f"memory MCP unreachable: {exc}")
+        return
+
+    items = []
+    result = data.get("result") if isinstance(data, dict) else None
+    if isinstance(result, dict):
+        items = result.get("items") or []
+    if not items:
+        console.print("[dim]No agent identity cards published yet.[/dim]")
+        return
+
+    table = Table(title=f"Agent peers ({len(items)})")
+    table.add_column("Agent ID", style="bold")
+    table.add_column("Display name")
+    table.add_column("Roles")
+    table.add_column("Endpoint")
+    table.add_column("Registered")
+    for item in items:
+        md = item.get("metadata") or {} if isinstance(item, dict) else {}
+        endpoint = md.get("endpoint") or {}
+        hal0_state = md.get("hal0_state") or {}
+        table.add_row(
+            str(md.get("agent_id") or "—"),
+            str(md.get("display_name") or "—"),
+            ", ".join(md.get("roles") or []) or "—",
+            str(endpoint.get("url") or "—"),
+            str(hal0_state.get("registered_at") or "—"),
+        )
+    console.print(table)
+
+
 @bootstrap_app.command("hermes")
 def bootstrap_hermes(
     repair: bool = typer.Option(

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -579,6 +579,90 @@ def test_mcp_wire_phase_degrades_not_fails_on_unreachable_server(
     assert "connection refused" in out.details["warnings"][0]
 
 
+# ── #243 phase impl — namespace_register + identity card schema ─────────────
+
+
+def test_build_identity_card_matches_schema_v1() -> None:
+    state = hp.BootstrapState(agent_id="hermes-agent")
+    card = hp._build_identity_card(state)
+    assert card["dataset"] == hp.AGENTS_DATASET
+    assert hp.AGENT_IDENTITY_TAG in card["tags"]
+    md = card["metadata"]
+    # Required fields per ADR-0011 §4.
+    for required in ("agent_id", "display_name", "namespace", "hal0_state"):
+        assert required in md, f"required field missing: {required}"
+    assert md["namespace"] == "private:hermes-agent"
+    assert md["hal0_state"]["bootstrap_version"] == 1
+    assert md["hal0_state"]["registered_at"]
+
+
+def test_namespace_register_registers_card_on_happy_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = hp.BootstrapState()
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def _fake_mcp(method: str, params: dict[str, Any], **_kw: Any) -> dict[str, Any]:
+        calls.append((method, params))
+        name = params.get("name")
+        if name == "memory_search":
+            return {"ok": True, "result": {"items": []}}
+        if name == "memory_add":
+            return {"ok": True, "result": {"id": "mem_abc"}}
+        return {"ok": True, "result": {}}
+
+    monkeypatch.setattr(hp, "_mcp_memory_call", _fake_mcp)
+    out = hp._phase_namespace_register(state)
+    assert out.status == hp.PhaseStatus.OK
+    assert out.details["registered"] is True
+    assert out.details["memory_id"] == "mem_abc"
+    # First call is the search; second is the add.
+    assert any(p[1]["name"] == "memory_search" for p in calls)
+    assert any(p[1]["name"] == "memory_add" for p in calls)
+
+
+def test_namespace_register_refreshes_existing_card(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = hp.BootstrapState()
+
+    def _fake_mcp(method: str, params: dict[str, Any], **_kw: Any) -> dict[str, Any]:
+        name = params.get("name")
+        if name == "memory_search":
+            return {
+                "ok": True,
+                "result": {
+                    "items": [{"id": "old_mem_id", "metadata": {"agent_id": "hermes-agent"}}]
+                },
+            }
+        if name == "memory_delete":
+            return {"ok": True, "result": {"deleted": 1}}
+        if name == "memory_add":
+            return {"ok": True, "result": {"id": "new_mem_id"}}
+        return {"ok": True, "result": {}}
+
+    monkeypatch.setattr(hp, "_mcp_memory_call", _fake_mcp)
+    out = hp._phase_namespace_register(state)
+    assert out.status == hp.PhaseStatus.OK
+    assert out.details["refreshed_existing"] is True
+
+
+def test_namespace_register_continues_on_mcp_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ADR-0013: registry failure logs + continues; bootstrap doesn't block."""
+    state = hp.BootstrapState()
+    monkeypatch.setattr(
+        hp,
+        "_mcp_memory_call",
+        lambda *a, **kw: {"ok": False, "error": "connection refused"},
+    )
+    out = hp._phase_namespace_register(state)
+    assert out.status == hp.PhaseStatus.OK
+    assert out.details["registered"] is False
+    assert any("memory_add" in w for w in out.details["warnings"])
+
+
 def test_mcp_wire_phase_skips_server_not_in_allowlist(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Hermes-Agent bootstrap publishes itself into the dedicated \`agents\` Cognee dataset (ADR-0011 schema v1). Re-runs refresh metadata via search-and-replace.
- MCP transport failures log + continue (\`registered=False\` in details); bootstrap MUST NOT block on registry unavailability per #243 sharpening + ADR-0013.
- New \`hal0 agent peers\` CLI lists every published card. Sibling of pre-existing \`hal0 agent list\` (locally-installed bundled agents). Distinct surfaces, distinct concerns per ADR-0011 §6.
- ADR-0011 flipped Draft → Accepted.

Closes #243.

## Test plan

- [x] \`pytest tests/agents/test_hermes_provision.py\` — 44 passed (4 new for namespace_register + card schema)
- [x] \`ruff check\` clean
- [ ] hal0 LXC: verify \`memory_search dataset=agents\` returns hermes card post-bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)