### PR TITLE
feat(agents): ADR-0013 MCP-client allow-list schema + mcp_client.py (#261)

### DIFF
--- a/src/hal0/agents/mcp_client.py
+++ b/src/hal0/agents/mcp_client.py
@@ -1,0 +1,283 @@
+"""ADR-0013 MCP client surface for bundled agents.
+
+Reads ``/etc/hal0/agents/<name>.toml``, loads tokens from
+systemd-credential / env file, and exposes the three-tier tool
+classification (allow / gated / blocked) to the agent driver.
+
+This module is **transport-agnostic**: it doesn't speak MCP over the
+wire itself. ADR-0013 §6 says Hermes's MCP client does the wire work;
+the AgentMCPClient defined here is the *policy* layer that sits in
+front of it. The agent driver wires this in via:
+
+    client = AgentMCPClient.from_config_file("/etc/hal0/agents/hermes.toml")
+    decision = client.classify("filesystem", "write_file")
+    if decision == "blocked":
+        raise ToolNotPermitted(...)
+    elif decision == "gated":
+        await approval_queue.enqueue(...)
+    else:  # allow
+        await wire_client.call(server="filesystem", tool="write_file", args=safe_args)
+
+The wire-call site (Hermes) is owned by the Hermes teammate
+(installer/agents/hermes.sh + the hermes provisioner). This module
+only ships the policy + token-loading surface so the Hermes shim can
+import it and stay schema-aware without re-implementing the rules.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Literal
+
+import structlog
+
+from hal0.config import paths as cfg_paths
+from hal0.config.loader import load_agent_config
+from hal0.config.schema import AgentConfig, MCPServerConfig
+
+log = structlog.get_logger(__name__)
+
+
+# ADR-0013 §4 — three-tier classification verdict.
+ClassificationLiteral = Literal["allow", "gated", "blocked", "unknown_server", "unknown_tool"]
+
+
+class ToolNotPermittedError(Exception):
+    """Raised by :meth:`AgentMCPClient.guard` for hard-blocked tools.
+
+    Maps to the wire-level ``tool.not_permitted`` error code per
+    ADR-0013 §3. Agent drivers should catch + translate into whatever
+    error envelope their LLM wire format expects.
+    """
+
+    def __init__(self, server: str, tool: str, reason: str = "tool blocked by allow-list"):
+        super().__init__(f"{server}.{tool}: {reason}")
+        self.server = server
+        self.tool = tool
+        self.reason = reason
+
+
+class WorkspaceEscapeError(Exception):
+    """Raised when filesystem-style MCP args try to escape the workspace.
+
+    ADR-0013 §5: tool arguments that use ``../`` or pass absolute paths
+    outside the workspace get rejected client-side BEFORE they hit the
+    server. The agent driver translates this to a tool error visible to
+    the LLM so it can retry with a corrected path.
+    """
+
+    def __init__(self, path: str, workspace: str):
+        super().__init__(f"path {path!r} escapes workspace {workspace!r}")
+        self.path = path
+        self.workspace = workspace
+
+
+class AgentMCPClient:
+    """Per-agent policy layer over the MCP wire client.
+
+    One instance per agent process. Holds the loaded AgentConfig +
+    resolved tokens; exposes ``classify``, ``guard``, ``token_for``,
+    and ``rewrite_path`` for the agent driver to consult before each
+    tool call.
+
+    The class is **synchronous** — every method is a pure function
+    over loaded config. Wire IO lives in the agent driver. Tests can
+    construct one directly with a fixture-built AgentConfig.
+    """
+
+    def __init__(self, config: AgentConfig, *, workspace: Path | None = None) -> None:
+        """Build a policy client.
+
+        :param config: Validated AgentConfig (see ADR-0013 §2 schema).
+        :param workspace: Override the workspace root (tests use this
+            with ``tmp_path``). When None, derived from
+            ``config.agent.workspace`` if set, else from
+            :func:`hal0.config.paths.agent_workspace_dir`.
+        """
+        self._config = config
+        if workspace is not None:
+            self._workspace = Path(workspace).resolve()
+        elif config.agent.workspace.strip():
+            self._workspace = Path(config.agent.workspace).resolve()
+        else:
+            self._workspace = cfg_paths.agent_workspace_dir(config.agent.name).resolve()
+
+    # ── factory ────────────────────────────────────────────────────────────
+
+    @classmethod
+    def from_config_file(cls, path: str | Path) -> AgentMCPClient:
+        """Load + validate the on-disk TOML, return a ready client."""
+        p = Path(path)
+        # load_agent_config takes the *name*, not the path; route around it.
+        cfg = load_agent_config(agent_name=p.stem, path=p)
+        return cls(cfg)
+
+    @classmethod
+    def from_agent_name(cls, name: str) -> AgentMCPClient:
+        """Load by canonical agent name (``/etc/hal0/agents/<name>.toml``)."""
+        cfg = load_agent_config(agent_name=name)
+        return cls(cfg)
+
+    # ── introspection ──────────────────────────────────────────────────────
+
+    @property
+    def agent_name(self) -> str:
+        return self._config.agent.name
+
+    @property
+    def workspace(self) -> Path:
+        return self._workspace
+
+    @property
+    def config(self) -> AgentConfig:
+        return self._config
+
+    def enabled_servers(self) -> dict[str, MCPServerConfig]:
+        """Return the servers the agent is allowed to *connect* to.
+
+        ADR-0013 §3 server-axis default-deny: a server not in the
+        config or with ``enabled = false`` is unreachable. Builtins
+        (hal0-admin / hal0-memory) flow through unchanged — they're
+        always-allowed for bundled agents.
+        """
+        return {name: srv for name, srv in self._config.mcp.servers.items() if srv.enabled}
+
+    # ── classification ─────────────────────────────────────────────────────
+
+    def classify(self, server: str, tool: str) -> ClassificationLiteral:
+        """Return the verdict for one (server, tool) pair.
+
+        Verdicts:
+
+        - ``unknown_server`` : server not in config (or disabled). Per
+          ADR-0013 §3 the agent should treat this as ``blocked``, but
+          we return a distinct verdict so callers can audit the cause
+          (typo vs intentional removal).
+        - ``unknown_tool``   : server is reachable, tool isn't on any
+          list. Default-deny per ADR-0013 §3 tool-axis.
+        - ``blocked``        : on ``tools.blocked``. Hard reject.
+        - ``gated``          : on ``tools.gated``. Approval-queue path.
+        - ``allow``          : on ``tools.allow``. Autonomous call.
+
+        Blocked is checked FIRST so installer-pinned blocks beat user
+        edits that placed the same tool on ``allow`` (ADR-0013 §4
+        "installer-pinned blocks override user edits"). The pydantic
+        ``ToolPolicy.lists_are_disjoint`` validator should prevent that
+        overlap from ever reaching here, but defense-in-depth is cheap.
+        """
+        servers = self.enabled_servers()
+        srv = servers.get(server)
+        if srv is None:
+            return "unknown_server"
+        pol = srv.tools
+        if tool in pol.blocked:
+            return "blocked"
+        if tool in pol.gated:
+            return "gated"
+        if tool in pol.allow:
+            return "allow"
+        return "unknown_tool"
+
+    def guard(self, server: str, tool: str) -> ClassificationLiteral:
+        """Same as :meth:`classify` but raise on hard-reject verdicts.
+
+        Used at call-site to fail fast: the agent driver typically
+        calls ``guard`` before serialising the tool call; on
+        ``allow`` / ``gated`` the call proceeds (gated routes through
+        the approval queue), on ``blocked`` / ``unknown_*`` the
+        :class:`ToolNotPermittedError` bubbles up and the driver
+        translates into the LLM's tool-error envelope.
+        """
+        verdict = self.classify(server, tool)
+        if verdict in ("blocked", "unknown_server", "unknown_tool"):
+            raise ToolNotPermittedError(server=server, tool=tool, reason=verdict)
+        return verdict
+
+    # ── token loading ──────────────────────────────────────────────────────
+
+    def token_for(self, server: str) -> str | None:
+        """Return the outbound bearer token for ``server`` or None.
+
+        ADR-0013 §6: tokens load at process startup from env vars (or
+        systemd-credential, which systemd materialises as an env var
+        via ``LoadCredential=``); never live in TOML. This method is
+        the single read site so audit-log scaffolding can wrap a
+        per-token-fetch event around it if/when needed.
+
+        Returns None when ``auth.kind != "bearer-from-env"`` (no token
+        needed) OR when the env var is unset. The agent driver decides
+        whether a missing token should fail bootstrap or skip the
+        server gracefully — ADR-0013 §6 picks "log + continue" for
+        non-builtin connection failures.
+        """
+        srv = self._config.mcp.servers.get(server)
+        if srv is None:
+            return None
+        if srv.auth.kind != "bearer-from-env":
+            return None
+        env_name = srv.auth.env or ""
+        if not env_name:
+            return None
+        token = os.environ.get(env_name)
+        if token is None or not token.strip():
+            log.warning(
+                "hal0.agent.mcp_client.token_missing",
+                agent=self.agent_name,
+                server=server,
+                env=env_name,
+            )
+            return None
+        return token
+
+    # ── path rewriting (filesystem MCP sandboxing) ──────────────────────────
+
+    def rewrite_path(self, raw: str) -> Path:
+        """Resolve ``raw`` against the workspace; raise on escape attempts.
+
+        ADR-0013 §5: filesystem MCPs run with their server-side root
+        pinned to the workspace, but the agent can still pass paths
+        that try to escape (``../``, absolute paths outside the
+        workspace). We resolve here BEFORE the server sees the call so
+        the wire-level check happens in trust-aware code.
+
+        ``raw`` is interpreted relative to the workspace if it's
+        relative. Absolute paths are accepted only if they resolve
+        underneath the workspace root.
+        """
+        ws = self._workspace
+        p = Path(raw)
+        if not p.is_absolute():
+            p = ws / p
+        resolved = p.resolve()
+        # is_relative_to is 3.9+ and pydantic supports our Python pin.
+        try:
+            resolved.relative_to(ws)
+        except ValueError as exc:
+            raise WorkspaceEscapeError(path=raw, workspace=str(ws)) from exc
+        return resolved
+
+
+# ── convenience: classify a batch of tools at once ────────────────────────────
+
+
+def classify_many(
+    client: AgentMCPClient,
+    pairs: Iterable[tuple[str, str]],
+) -> dict[tuple[str, str], ClassificationLiteral]:
+    """Bulk-classify a list of (server, tool) pairs.
+
+    Used by the dashboard's read-only per-agent view to surface every
+    classification at once without N HTTP calls.
+    """
+    return {(srv, tool): client.classify(srv, tool) for srv, tool in pairs}
+
+
+__all__ = [
+    "AgentMCPClient",
+    "ClassificationLiteral",
+    "ToolNotPermittedError",
+    "WorkspaceEscapeError",
+    "classify_many",
+]

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -27,6 +27,7 @@ import tomli_w
 from hal0.config import paths
 from hal0.config.schema import (
     CURRENT_SCHEMA_VERSION,
+    AgentConfig,
     Hal0Config,
     HardwareInfo,
     ProvidersConfig,
@@ -376,6 +377,46 @@ def save_upstreams_config(cfg: UpstreamsConfig, path: Path | None = None) -> Non
     write_toml_atomic(target, cfg.model_dump(mode="python"))
 
 
+# ── agents/<name>.toml (ADR-0013) ─────────────────────────────────────────────
+
+
+def load_agent_config(agent_name: str, path: Path | None = None) -> AgentConfig:
+    """Load and validate ``/etc/hal0/agents/<agent_name>.toml`` (ADR-0013).
+
+    Raises:
+        ConfigNotFound: file missing.
+        ConfigParseError: bad TOML or schema-validation failure.
+    """
+    target = path if path is not None else paths.agents_config_dir() / f"{agent_name}.toml"
+    raw = _read_toml(Path(target))
+    try:
+        return AgentConfig.model_validate(raw)
+    except Exception as exc:
+        raise ConfigParseError(
+            f"failed to validate agent config {agent_name!r} at {target}: {exc}",
+            details={"path": str(target), "agent": agent_name, "reason": str(exc)},
+        ) from exc
+
+
+def save_agent_config(cfg: AgentConfig, path: Path | None = None) -> None:
+    """Atomically write an agent config TOML (ADR-0013).
+
+    ``exclude_none=True`` keeps tomli_w from choking on optional blocks
+    (``auth.env``, ``server.url`` on builtins).
+    """
+    target = path if path is not None else paths.agents_config_dir() / f"{cfg.agent.name}.toml"
+    data = cfg.model_dump(mode="python", exclude_none=True)
+    write_toml_atomic(target, data)
+
+
+def list_agent_configs() -> list[str]:
+    """Return every configured agent name (stem of /etc/hal0/agents/*.toml)."""
+    d = paths.agents_config_dir()
+    if not d.exists():
+        return []
+    return sorted(f.stem for f in d.glob("*.toml") if f.is_file())
+
+
 # ── hardware.json (JSON, not TOML) ────────────────────────────────────────────
 
 
@@ -573,7 +614,9 @@ __all__ = [
     "ConfigError",
     "ConfigNotFound",
     "ConfigParseError",
+    "list_agent_configs",
     "list_slots",
+    "load_agent_config",
     "load_hal0_config",
     "load_hardware_info",
     "load_manifest",
@@ -581,6 +624,7 @@ __all__ = [
     "load_slot_config",
     "load_upstreams_config",
     "manifest_image_ref",
+    "save_agent_config",
     "save_hal0_config",
     "save_hardware_info",
     "save_providers_config",

--- a/src/hal0/config/paths.py
+++ b/src/hal0/config/paths.py
@@ -95,6 +95,28 @@ def registry_dir() -> Path:
     return var_lib() / "registry"
 
 
+def agents_config_dir() -> Path:
+    """Return the per-agent allow-list config directory.
+
+    ADR-0013 §1: each bundled or user-added agent gets one TOML at
+    ``/etc/hal0/agents/<name>.toml`` carrying its workspace path,
+    enabled MCP servers, per-server auth, and the three-tier tool
+    classification (allow / gated / blocked).
+    """
+    return etc() / "agents"
+
+
+def agent_workspace_dir(agent_name: str) -> Path:
+    """Return the filesystem sandbox root for a bundled agent.
+
+    ADR-0013 §5: the agent driver chroots/bind-mounts the agent process
+    to this path; writes outside require ADR-0004 approval. Each agent
+    gets its own subtree so a malicious / buggy agent can't poke at
+    another's workspace.
+    """
+    return var_lib() / "agents" / agent_name / "workspace"
+
+
 def models_dir() -> Path:
     """Return the default model cache directory (/var/lib/hal0/models/)."""
     return var_lib() / "models"

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -852,6 +852,269 @@ class MemoryGraphConfig(BaseModel):
         return self
 
 
+# ── AgentConfig (ADR-0013) ─────────────────────────────────────────────────────
+
+# ADR-0013 §1: schema version pin so a future incompatible change
+# (e.g. nesting tool policies under a `[mcp.servers.<name>.policy]`
+# block) can detect + migrate old agent TOMLs without silent breakage.
+AGENT_CONFIG_SCHEMA_VERSION = 1
+
+# ADR-0013 §6: outbound auth styles. Today only ``bearer-from-env``
+# (token loaded at agent-process startup from an env file or
+# systemd-credential) is implemented. Listed as a frozenset so future
+# additions (mtls, oauth-device-flow, …) extend a single source.
+_VALID_AGENT_AUTH_KINDS = frozenset({"none", "bearer-from-env"})
+
+AgentAuthKindLiteral = Literal["none", "bearer-from-env"]
+
+
+class AgentAuthConfig(BaseModel):
+    """``[mcp.servers.<name>.auth]`` block.
+
+    ADR-0013 §6: indirection via env var keeps tokens out of TOML so
+    the config file remains commit-safe and the dashboard can render
+    it. The actual token is loaded by the agent driver at process
+    startup (from systemd-credential or a 0600 env file) and never
+    appears on the command line.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+    kind: AgentAuthKindLiteral = Field(
+        default="none",
+        description=(
+            "Outbound auth style. 'none' = no auth header. "
+            "'bearer-from-env' = read token from the env var named in `env`."
+        ),
+    )
+    env: str | None = Field(
+        default=None,
+        description=(
+            "Env-var name to read for the bearer token. Required when kind == 'bearer-from-env'."
+        ),
+    )
+
+    @field_validator("kind")
+    @classmethod
+    def kind_valid(cls, v: str) -> str:
+        if v not in _VALID_AGENT_AUTH_KINDS:
+            raise ValueError(
+                f"agent auth kind {v!r} not valid; choose from {sorted(_VALID_AGENT_AUTH_KINDS)}"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def env_required_for_bearer(self) -> AgentAuthConfig:
+        if self.kind == "bearer-from-env" and (not self.env or not self.env.strip()):
+            raise ValueError("auth.env (env-var name) required when auth.kind = 'bearer-from-env'")
+        return self
+
+
+class ToolPolicy(BaseModel):
+    """``[mcp.servers.<name>.tools]`` block — three-tier classification.
+
+    ADR-0013 §4:
+
+    - ``allow``  : autonomous call (no approval queue).
+    - ``gated``  : enqueue via ADR-0004 approval queue, await user pick.
+    - ``blocked``: hard-reject at the client; never reaches the server.
+
+    The lists MUST be disjoint — overlap is operator error and surfaces
+    as a load-time ValidationError with the offending tool name in the
+    message, NOT a silent "which list wins?" decision.
+
+    Default is empty on all three axes. Combined with the default-deny
+    posture in :class:`MCPServerConfig`, that means an MCP server with
+    no ``tools`` block has *zero* callable tools — which is what we
+    want for a fresh registration the user hasn't reviewed yet.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+    allow: list[str] = Field(
+        default_factory=list,
+        description=("Tools the agent may call autonomously. Empty = no autonomous tools."),
+    )
+    gated: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Tools the agent may request; each call enqueues an "
+            "approval (ADR-0004 §5). Empty = no gated tools."
+        ),
+    )
+    blocked: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Tools hard-rejected at the client. Installer-pinned "
+            "blocks (e.g. delete_repo on github-mcp) protect against "
+            "dashboard edits surfacing dangerous tools."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def lists_are_disjoint(self) -> ToolPolicy:
+        """Reject overlap between allow / gated / blocked.
+
+        Operators sometimes paste-edit a TOML and forget to remove a
+        tool from one list when promoting/demoting it; we catch that
+        at load time with a specific error so they don't ship a config
+        whose behavior depends on whichever check happens first at
+        dispatch.
+        """
+        allow_set = set(self.allow)
+        gated_set = set(self.gated)
+        blocked_set = set(self.blocked)
+        overlaps: list[tuple[str, str, set[str]]] = [
+            ("allow", "gated", allow_set & gated_set),
+            ("allow", "blocked", allow_set & blocked_set),
+            ("gated", "blocked", gated_set & blocked_set),
+        ]
+        for a, b, shared in overlaps:
+            if shared:
+                # Sort the offenders so error messages are deterministic
+                # across dict-iteration orderings (matters for tests).
+                names = sorted(shared)
+                raise ValueError(
+                    f"tools.{a} and tools.{b} overlap on {names!r}; "
+                    "each tool must appear in at most one list"
+                )
+        return self
+
+
+class MCPServerConfig(BaseModel):
+    """One ``[mcp.servers.<name>]`` entry in an agent TOML.
+
+    ADR-0013 §3: server-axis default-deny — only servers listed here
+    are reachable. ``builtin = true`` marks hal0-admin / hal0-memory
+    which are always reachable for bundled agents and can't be removed
+    without an explicit override.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+    url: str | None = Field(
+        default=None,
+        description=(
+            "MCP server URL. Empty for builtin servers (hal0 mounts "
+            "those internally at /mcp/admin + /mcp/memory). Required "
+            "for user-added servers — stdio:// for local processes, "
+            "http(s):// for remote."
+        ),
+    )
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "When False, the server registration round-trips through "
+            "config but is not connected at agent startup."
+        ),
+    )
+    builtin: bool = Field(
+        default=False,
+        description=(
+            "ADR-0013 §6: marks hal0-admin / hal0-memory. Bundled-agent "
+            "installers set this; user-added servers leave it False."
+        ),
+    )
+    auth: AgentAuthConfig = Field(default_factory=AgentAuthConfig)
+    tools: ToolPolicy = Field(default_factory=ToolPolicy)
+
+    @model_validator(mode="after")
+    def url_required_for_external(self) -> MCPServerConfig:
+        """External (non-builtin) servers must declare a URL."""
+        if not self.builtin and (self.url is None or not self.url.strip()):
+            raise ValueError("mcp.servers.<name>.url required for non-builtin servers")
+        return self
+
+
+class AgentMetadataConfig(BaseModel):
+    """``[agent]`` block — name + display + filesystem sandbox root."""
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+    name: str = Field(..., description="Agent identifier (e.g. 'hermes').")
+    display: str = Field(
+        default="",
+        description="Human-readable label for the dashboard.",
+    )
+    workspace: str = Field(
+        default="",
+        description=(
+            "Filesystem sandbox root (ADR-0013 §5). Empty falls back "
+            "to the canonical /var/lib/hal0/agents/<name>/workspace at "
+            "load time."
+        ),
+    )
+
+    @field_validator("name")
+    @classmethod
+    def name_valid(cls, v: str) -> str:
+        # Agent names land in filesystem paths + systemd unit names —
+        # keep them strict (lowercase alphanumeric + hyphen, max 32 chars).
+        import re
+
+        if not v or not v.strip():
+            raise ValueError("agent name must not be empty")
+        if not re.match(r"^[a-z0-9][a-z0-9-]{0,31}$", v):
+            raise ValueError(
+                f"agent name {v!r}: use lowercase alphanumeric + hyphens "
+                "(must start with alphanumeric, max 32 chars)"
+            )
+        return v
+
+
+class AgentMCPConfig(BaseModel):
+    """``[mcp]`` block container.
+
+    Holds the ``servers`` map. Lives as its own model so future MCP-
+    wide knobs (default-deny override, connect-timeout, retry-backoff)
+    have an obvious home that round-trips through pydantic.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+    servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
+
+
+class AgentConfig(BaseModel):
+    """Top-level shape of ``/etc/hal0/agents/<name>.toml`` (ADR-0013 §1).
+
+    ADR-0013 §1 spells out one file per agent — installer for bundled,
+    user for user-added. Preserved across ``hal0 update``. Schema
+    validated at agent bootstrap time + on dashboard-edit save.
+
+    The ``mcp.servers`` map is dict-of-:class:`MCPServerConfig`. Pydantic
+    accepts dicts on a ``dict[str, ...]`` field natively, so the TOML
+    shape ``[mcp.servers.filesystem]`` round-trips cleanly without a
+    custom flattener.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+    schema_version: int = Field(
+        default=AGENT_CONFIG_SCHEMA_VERSION,
+        ge=1,
+        description=(
+            "Pin so an incompatible future change (e.g. nested tool "
+            "policies) can detect old files + migrate."
+        ),
+    )
+    agent: AgentMetadataConfig = Field(...)
+    mcp: AgentMCPConfig = Field(default_factory=AgentMCPConfig)
+
+    @field_validator("schema_version")
+    @classmethod
+    def schema_version_known(cls, v: int) -> int:
+        # Reject future versions explicitly so a downgrade doesn't
+        # silently accept a config it can't actually understand.
+        if v > AGENT_CONFIG_SCHEMA_VERSION:
+            raise ValueError(
+                f"agent schema_version {v} is newer than this hal0 "
+                f"understands ({AGENT_CONFIG_SCHEMA_VERSION}); "
+                "upgrade hal0 or pin the agent config to an older version"
+            )
+        return v
+
+
 class MemoryConfig(BaseModel):
     """[memory] section of hal0.toml.
 
@@ -948,11 +1211,17 @@ class Hal0Config(BaseModel):
 
 
 __all__ = [
+    "AGENT_CONFIG_SCHEMA_VERSION",
     "BACKEND_TO_DEVICE",
     "CAPABILITIES_SCHEMA_VERSION_CURRENT",
     "CAPABILITIES_SCHEMA_VERSION_LEGACY",
     "CURRENT_SCHEMA_VERSION",
     "DEFAULT_DEVICE",
+    "AgentAuthConfig",
+    "AgentAuthKindLiteral",
+    "AgentConfig",
+    "AgentMCPConfig",
+    "AgentMetadataConfig",
     "DeviceLiteral",
     "DispatcherConfig",
     "GPUInfo",
@@ -960,6 +1229,7 @@ __all__ = [
     "GraphUpstreamConfig",
     "Hal0Config",
     "HardwareInfo",
+    "MCPServerConfig",
     "MemoryConfig",
     "MemoryGraphConfig",
     "MetaConfig",
@@ -972,6 +1242,7 @@ __all__ = [
     "SlotConfig",
     "SlotsConfig",
     "TelemetryConfig",
+    "ToolPolicy",
     "UpstreamEntry",
     "UpstreamsConfig",
     "map_backend_to_device",

--- a/tests/agents/test_mcp_client.py
+++ b/tests/agents/test_mcp_client.py
@@ -1,0 +1,245 @@
+"""ADR-0013 MCP client tests.
+
+Cover:
+  - schema-validation envelope (overlap, missing fields)
+  - classify() three-tier verdict + unknown_server / unknown_tool
+  - guard() raises ToolNotPermittedError on hard-reject
+  - token_for() loads from env, returns None on missing var
+  - rewrite_path() pins to workspace + rejects ../ escapes
+  - from_config_file round-trip
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import tomli_w
+
+from hal0.agents.mcp_client import (
+    AgentMCPClient,
+    ToolNotPermittedError,
+    WorkspaceEscapeError,
+    classify_many,
+)
+from hal0.config.schema import (
+    AgentAuthConfig,
+    AgentConfig,
+    AgentMCPConfig,
+    AgentMetadataConfig,
+    MCPServerConfig,
+    ToolPolicy,
+)
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    p = tmp_path / "ws"
+    p.mkdir()
+    (p / "ok.txt").write_text("hello")
+    return p
+
+
+@pytest.fixture
+def sample_config(workspace: Path) -> AgentConfig:
+    """Hermes-like config with one builtin + one user-added MCP."""
+    return AgentConfig(
+        agent=AgentMetadataConfig(
+            name="hermes",
+            display="Hermes-Agent",
+            workspace=str(workspace),
+        ),
+        mcp=AgentMCPConfig(
+            servers={
+                "hal0-admin": MCPServerConfig(builtin=True),
+                "filesystem": MCPServerConfig(
+                    url="stdio:///usr/lib/hal0/mcp/fs-server",
+                    enabled=True,
+                    tools=ToolPolicy(
+                        allow=["read_file", "list_directory"],
+                        gated=["write_file"],
+                        blocked=["delete_directory"],
+                    ),
+                ),
+                "github": MCPServerConfig(
+                    url="https://api.github.com/mcp",
+                    enabled=False,  # opt-in; should be skipped
+                    auth=AgentAuthConfig(
+                        kind="bearer-from-env",
+                        env="HAL0_AGENT_HERMES_GH_TOKEN",
+                    ),
+                    tools=ToolPolicy(allow=["list_issues"]),
+                ),
+            }
+        ),
+    )
+
+
+@pytest.fixture
+def client(sample_config: AgentConfig, workspace: Path) -> AgentMCPClient:
+    return AgentMCPClient(sample_config, workspace=workspace)
+
+
+# ── classify ──────────────────────────────────────────────────────────────────
+
+
+class TestClassify:
+    def test_allow_tool(self, client: AgentMCPClient) -> None:
+        assert client.classify("filesystem", "read_file") == "allow"
+
+    def test_gated_tool(self, client: AgentMCPClient) -> None:
+        assert client.classify("filesystem", "write_file") == "gated"
+
+    def test_blocked_tool(self, client: AgentMCPClient) -> None:
+        assert client.classify("filesystem", "delete_directory") == "blocked"
+
+    def test_unknown_tool_default_denies(self, client: AgentMCPClient) -> None:
+        assert client.classify("filesystem", "format_disk") == "unknown_tool"
+
+    def test_unknown_server_default_denies(self, client: AgentMCPClient) -> None:
+        assert client.classify("nonexistent", "tool") == "unknown_server"
+
+    def test_disabled_server_is_unknown(self, client: AgentMCPClient) -> None:
+        """``enabled=false`` removes the server from enabled_servers()."""
+        assert client.classify("github", "list_issues") == "unknown_server"
+
+    def test_builtin_no_tools_yields_unknown_tool(self, client: AgentMCPClient) -> None:
+        # hal0-admin has no tool lists in the sample → default-deny.
+        assert client.classify("hal0-admin", "anything") == "unknown_tool"
+
+
+# ── guard ──────────────────────────────────────────────────────────────────────
+
+
+class TestGuard:
+    def test_allow_passes(self, client: AgentMCPClient) -> None:
+        assert client.guard("filesystem", "read_file") == "allow"
+
+    def test_gated_passes(self, client: AgentMCPClient) -> None:
+        assert client.guard("filesystem", "write_file") == "gated"
+
+    def test_blocked_raises(self, client: AgentMCPClient) -> None:
+        with pytest.raises(ToolNotPermittedError) as ei:
+            client.guard("filesystem", "delete_directory")
+        assert ei.value.server == "filesystem"
+        assert ei.value.tool == "delete_directory"
+
+    def test_unknown_server_raises(self, client: AgentMCPClient) -> None:
+        with pytest.raises(ToolNotPermittedError):
+            client.guard("nonexistent", "any")
+
+    def test_unknown_tool_raises(self, client: AgentMCPClient) -> None:
+        with pytest.raises(ToolNotPermittedError):
+            client.guard("filesystem", "format_disk")
+
+
+# ── token_for ──────────────────────────────────────────────────────────────────
+
+
+class TestTokenFor:
+    def test_no_auth_returns_none(self, client: AgentMCPClient) -> None:
+        # filesystem has default auth (kind="none").
+        assert client.token_for("filesystem") is None
+
+    def test_bearer_loads_from_env(
+        self, sample_config: AgentConfig, workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Re-enable github so it shows up to token_for; we test via a
+        # config copy because enabled=False filters from
+        # enabled_servers() but token_for reads the full config map
+        # directly.
+        monkeypatch.setenv("HAL0_AGENT_HERMES_GH_TOKEN", "ghp_secret123")
+        c = AgentMCPClient(sample_config, workspace=workspace)
+        assert c.token_for("github") == "ghp_secret123"
+
+    def test_bearer_missing_env_returns_none(
+        self,
+        sample_config: AgentConfig,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("HAL0_AGENT_HERMES_GH_TOKEN", raising=False)
+        c = AgentMCPClient(sample_config, workspace=workspace)
+        assert c.token_for("github") is None
+
+    def test_unknown_server_returns_none(self, client: AgentMCPClient) -> None:
+        assert client.token_for("nonexistent") is None
+
+
+# ── rewrite_path ──────────────────────────────────────────────────────────────
+
+
+class TestRewritePath:
+    def test_relative_path_resolves_under_workspace(
+        self, client: AgentMCPClient, workspace: Path
+    ) -> None:
+        out = client.rewrite_path("ok.txt")
+        assert out == (workspace / "ok.txt").resolve()
+
+    def test_absolute_inside_workspace_ok(self, client: AgentMCPClient, workspace: Path) -> None:
+        out = client.rewrite_path(str(workspace / "ok.txt"))
+        assert out == (workspace / "ok.txt").resolve()
+
+    def test_dotdot_escape_rejected(self, client: AgentMCPClient) -> None:
+        with pytest.raises(WorkspaceEscapeError):
+            client.rewrite_path("../etc/passwd")
+
+    def test_absolute_outside_workspace_rejected(self, client: AgentMCPClient) -> None:
+        with pytest.raises(WorkspaceEscapeError):
+            client.rewrite_path("/etc/passwd")
+
+
+# ── from_config_file ─────────────────────────────────────────────────────────
+
+
+def test_from_config_file_round_trip(
+    tmp_path: Path,
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Write a TOML the way installer/agents/hermes.sh would, load it."""
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path / "home"))
+    cfg_path = tmp_path / "hermes.toml"
+    data = {
+        "schema_version": 1,
+        "agent": {
+            "name": "hermes",
+            "display": "Hermes",
+            "workspace": str(workspace),
+        },
+        "mcp": {
+            "servers": {
+                "hal0-admin": {"builtin": True},
+                "filesystem": {
+                    "url": "stdio:///x/y",
+                    "enabled": True,
+                    "tools": {
+                        "allow": ["read_file"],
+                        "gated": ["write_file"],
+                    },
+                },
+            }
+        },
+    }
+    cfg_path.write_text(tomli_w.dumps(data))
+    c = AgentMCPClient.from_config_file(cfg_path)
+    assert c.agent_name == "hermes"
+    assert c.classify("filesystem", "read_file") == "allow"
+    assert c.classify("filesystem", "write_file") == "gated"
+
+
+# ── classify_many ────────────────────────────────────────────────────────────
+
+
+def test_classify_many(client: AgentMCPClient) -> None:
+    pairs = [
+        ("filesystem", "read_file"),
+        ("filesystem", "delete_directory"),
+        ("nonexistent", "x"),
+    ]
+    out = classify_many(client, pairs)
+    assert out[("filesystem", "read_file")] == "allow"
+    assert out[("filesystem", "delete_directory")] == "blocked"
+    assert out[("nonexistent", "x")] == "unknown_server"

--- a/tests/config/test_agent_schema.py
+++ b/tests/config/test_agent_schema.py
@@ -1,0 +1,178 @@
+"""ADR-0013 agent-config schema tests.
+
+Pins:
+
+  - schema_version field exists + rejects future versions.
+  - agent.name is lowercase-alphanumeric+hyphen, max 32 chars.
+  - ToolPolicy.lists_are_disjoint rejects overlap (with the offending names).
+  - AgentAuthConfig requires env when kind=bearer-from-env.
+  - MCPServerConfig: external requires url; builtin does not.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from hal0.config.schema import (
+    AGENT_CONFIG_SCHEMA_VERSION,
+    AgentAuthConfig,
+    AgentConfig,
+    AgentMCPConfig,
+    AgentMetadataConfig,
+    MCPServerConfig,
+    ToolPolicy,
+)
+
+# ── AgentConfig schema version ───────────────────────────────────────────────
+
+
+class TestSchemaVersion:
+    def test_default_matches_constant(self) -> None:
+        cfg = AgentConfig(agent=AgentMetadataConfig(name="hermes"))
+        assert cfg.schema_version == AGENT_CONFIG_SCHEMA_VERSION
+
+    def test_future_version_rejected(self) -> None:
+        with pytest.raises(ValidationError) as ei:
+            AgentConfig(
+                schema_version=AGENT_CONFIG_SCHEMA_VERSION + 99,
+                agent=AgentMetadataConfig(name="hermes"),
+            )
+        assert "newer than this hal0" in str(ei.value)
+
+
+# ── AgentMetadataConfig.name ─────────────────────────────────────────────────
+
+
+class TestAgentName:
+    def test_valid_simple(self) -> None:
+        AgentMetadataConfig(name="hermes")
+
+    def test_valid_with_hyphen_and_digits(self) -> None:
+        AgentMetadataConfig(name="pi-coder-2")
+
+    def test_uppercase_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentMetadataConfig(name="Hermes")
+
+    def test_starts_with_hyphen_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentMetadataConfig(name="-bad")
+
+    def test_empty_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentMetadataConfig(name="")
+
+    def test_too_long_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentMetadataConfig(name="a" * 33)
+
+
+# ── ToolPolicy ───────────────────────────────────────────────────────────────
+
+
+class TestToolPolicy:
+    def test_default_empty_lists(self) -> None:
+        p = ToolPolicy()
+        assert p.allow == []
+        assert p.gated == []
+        assert p.blocked == []
+
+    def test_disjoint_lists_ok(self) -> None:
+        ToolPolicy(allow=["a", "b"], gated=["c"], blocked=["d"])
+
+    def test_allow_gated_overlap_rejected(self) -> None:
+        with pytest.raises(ValidationError) as ei:
+            ToolPolicy(allow=["write_file"], gated=["write_file"])
+        msg = str(ei.value)
+        assert "allow" in msg and "gated" in msg
+        assert "write_file" in msg
+
+    def test_allow_blocked_overlap_rejected(self) -> None:
+        with pytest.raises(ValidationError) as ei:
+            ToolPolicy(allow=["delete"], blocked=["delete"])
+        assert "delete" in str(ei.value)
+
+    def test_gated_blocked_overlap_rejected(self) -> None:
+        with pytest.raises(ValidationError) as ei:
+            ToolPolicy(gated=["x"], blocked=["x"])
+        assert "x" in str(ei.value)
+
+    def test_overlap_error_lists_all_offenders_sorted(self) -> None:
+        with pytest.raises(ValidationError) as ei:
+            ToolPolicy(allow=["b", "a"], gated=["a", "b"])
+        # Sorted for determinism — test that 'a' appears before 'b'.
+        msg = str(ei.value)
+        assert msg.index("'a'") < msg.index("'b'")
+
+
+# ── AgentAuthConfig ──────────────────────────────────────────────────────────
+
+
+class TestAgentAuthConfig:
+    def test_default_none_ok(self) -> None:
+        a = AgentAuthConfig()
+        assert a.kind == "none"
+        assert a.env is None
+
+    def test_bearer_requires_env(self) -> None:
+        with pytest.raises(ValidationError) as ei:
+            AgentAuthConfig(kind="bearer-from-env")
+        assert "auth.env" in str(ei.value)
+
+    def test_bearer_with_env_ok(self) -> None:
+        a = AgentAuthConfig(kind="bearer-from-env", env="HAL0_TOK")
+        assert a.env == "HAL0_TOK"
+
+    def test_invalid_kind_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentAuthConfig(kind="oauth-magic")
+
+
+# ── MCPServerConfig ──────────────────────────────────────────────────────────
+
+
+class TestMCPServerConfig:
+    def test_external_without_url_rejected(self) -> None:
+        with pytest.raises(ValidationError) as ei:
+            MCPServerConfig(builtin=False)
+        assert "url required" in str(ei.value)
+
+    def test_builtin_without_url_ok(self) -> None:
+        srv = MCPServerConfig(builtin=True)
+        assert srv.url is None
+
+    def test_external_with_url_ok(self) -> None:
+        srv = MCPServerConfig(url="stdio:///x")
+        assert srv.url == "stdio:///x"
+
+    def test_round_trip_dump(self) -> None:
+        srv = MCPServerConfig(
+            url="stdio:///x",
+            tools=ToolPolicy(allow=["a"], blocked=["b"]),
+            auth=AgentAuthConfig(kind="bearer-from-env", env="TOK"),
+        )
+        dumped = srv.model_dump()
+        MCPServerConfig.model_validate(dumped)
+
+
+# ── AgentConfig full round trip ──────────────────────────────────────────────
+
+
+def test_full_round_trip() -> None:
+    cfg = AgentConfig(
+        agent=AgentMetadataConfig(name="hermes", display="Hermes"),
+        mcp=AgentMCPConfig(
+            servers={
+                "hal0-admin": MCPServerConfig(builtin=True),
+                "filesystem": MCPServerConfig(
+                    url="stdio:///fs",
+                    tools=ToolPolicy(allow=["read_file"], gated=["write_file"]),
+                ),
+            }
+        ),
+    )
+    dumped = cfg.model_dump()
+    rebuilt = AgentConfig.model_validate(dumped)
+    assert rebuilt.agent.name == "hermes"
+    assert rebuilt.mcp.servers["filesystem"].tools.allow == ["read_file"]


### PR DESCRIPTION
Backend half of [ADR-0013](docs/internal/adr/0013-mcp-client-allow-list.md). Closes #261.

## Summary
- **Schemas** (`src/hal0/config/schema.py`): `AgentConfig` + `AgentMetadataConfig` + `AgentMCPConfig` + `MCPServerConfig` + `ToolPolicy` + `AgentAuthConfig` + `AGENT_CONFIG_SCHEMA_VERSION`. Pydantic enforces three-tier disjointness, builtin/external URL rule, bearer-requires-env, lowercase-alphanumeric agent names, future-schema-version rejection.
- **Loader** (`src/hal0/config/loader.py`): `load_agent_config` / `save_agent_config` / `list_agent_configs`.
- **Paths** (`src/hal0/config/paths.py`): `agents_config_dir()` + `agent_workspace_dir()`.
- **Runtime** (`src/hal0/agents/mcp_client.py`): `AgentMCPClient` — policy-layer (transport-agnostic) with `classify` / `guard` / `token_for` / `rewrite_path`. The Hermes shim wires this into its wire client.

## Test plan
- [x] `tests/config/test_agent_schema.py` — 22 schema cases
- [x] `tests/agents/test_mcp_client.py` — 23 runtime cases (classify, guard, token-load, path-rewrite, round-trip)
- [x] `pytest tests/config/ tests/agents/` → 275 passed
- [x] `ruff format --check` + `ruff check` clean

Unblocks #263 (dashboard per-agent view) and #262 (installer; Hermes teammate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)