### PR TITLE
fix(dash): live slot+model counts in sidebars

### DIFF
--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -8,6 +8,8 @@
 
 import { useLemondRollup } from '@/api/hooks/useLemonade'
 import { useLogsStream } from '@/api/hooks/useLogs'
+import { useSlots } from '@/api/hooks/useSlots'
+import { useModels } from '@/api/hooks/useModels'
 
 const { useState: useStateC, useEffect: useEffectC } = React;
 
@@ -126,10 +128,14 @@ function TopBar({ route, hostUptime = "14d 02:11", onBell, onCmdK, approvals = 0
 
 // ─── Sidebar ───
 function Sidebar({ route, onGo }) {
+  const slotsQuery  = useSlots();
+  const modelsQuery = useModels();
+  const slotCount   = slotsQuery.data?.length  ?? 0;
+  const modelCount  = modelsQuery.data?.length ?? 0;
   const items = [
     { id: "dashboard", label: "Dashboard", icon: Icons.dashboard },
-    { id: "slots",     label: "Slots",     icon: Icons.slots, cnt: HAL0_DATA.slots.length },
-    { id: "models",    label: "Models",    icon: Icons.models, cnt: HAL0_DATA.models.length },
+    { id: "slots",     label: "Slots",     icon: Icons.slots, cnt: slotCount },
+    { id: "models",    label: "Models",    icon: Icons.models, cnt: modelCount },
     { id: "hardware",  label: "Hardware",  icon: Icons.hardware },
     { id: "backends",  label: "Backends",  icon: Icons.backends },
     { id: "logs",      label: "Logs",      icon: Icons.logs },

--- a/ui/src/dash/mcp-main.jsx
+++ b/ui/src/dash/mcp-main.jsx
@@ -1,6 +1,10 @@
 // hal0 v0.3 — MCP page mount
 // Composes the existing dashboard chrome (TopBar/Sidebar/Footer) with the new McpView.
 
+import { useLemondRollup } from '@/api/hooks/useLemonade'
+import { useSlots } from '@/api/hooks/useSlots'
+import { useModels } from '@/api/hooks/useModels'
+
 const { useState: useStateMnt, useEffect: useEffectMnt } = React;
 
 const MCP_TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
@@ -12,10 +16,16 @@ const MCP_TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
 // under the Agents grouping. We use a route value of "mcp" so the existing
 // chrome highlights nothing for routes it doesn't know about.
 function McpSidebar({ active }) {
+  const slotsQuery  = useSlots();
+  const modelsQuery = useModels();
+  const L           = useLemondRollup();
+  const slotCount   = slotsQuery.data?.length  ?? 0;
+  const modelCount  = modelsQuery.data?.length ?? 0;
+  const lemondStatusClass = L.status === 'up' ? 'up' : L.status === 'down' ? 'down' : '';
   const items = [
     { id: "dashboard", label: "Dashboard", icon: Icons.dashboard, href: "hal0 v2 dashboard.html" },
-    { id: "slots",     label: "Slots",     icon: Icons.slots, cnt: HAL0_DATA.slots.length, href: "hal0 v2 dashboard.html#slots" },
-    { id: "models",    label: "Models",    icon: Icons.models, cnt: HAL0_DATA.models.length, href: "hal0 v2 dashboard.html#models" },
+    { id: "slots",     label: "Slots",     icon: Icons.slots, cnt: slotCount, href: "hal0 v2 dashboard.html#slots" },
+    { id: "models",    label: "Models",    icon: Icons.models, cnt: modelCount, href: "hal0 v2 dashboard.html#models" },
     { id: "hardware",  label: "Hardware",  icon: Icons.hardware, href: "hal0 v2 dashboard.html#hardware" },
     { id: "backends",  label: "Backends",  icon: Icons.backends, href: "hal0 v2 dashboard.html#backends" },
     { id: "logs",      label: "Logs",      icon: Icons.logs, href: "hal0 v2 dashboard.html#logs" },
@@ -63,11 +73,11 @@ function McpSidebar({ active }) {
       <div className="sb-status">
         <div className="row">
           <span className="k">lemond</span>
-          <span className="v up"><span className="dot" />{HAL0_DATA.lemond.status}</span>
+          <span className={"v " + lemondStatusClass}><span className="dot" />{L.status}</span>
         </div>
         <div className="row">
           <span className="k">version</span>
-          <span className="v">{HAL0_DATA.lemond.version}</span>
+          <span className="v">{L.version}</span>
         </div>
         <div className="ln" />
         <div className="row">


### PR DESCRIPTION
## Bug

Left-sidebar slot + model counts (Sidebar in chrome.jsx and McpSidebar in mcp-main.jsx) read `HAL0_DATA.slots.length` / `HAL0_DATA.models.length` — a module-level static seed in `ui/src/dash/data.jsx`. The counts therefore never update when `/api/slots` or `/api/models` changes; they're frozen at app boot.

McpSidebar additionally read `HAL0_DATA.lemond.status` / `.version` for its status block. The chrome.jsx Sidebar already migrated lemond to `useLemondRollup` via `SidebarStatusBlock` — McpSidebar didn't.

## Fix

Surgical migration to the existing live React Query hooks (already used in `dash/slots.jsx` and `dash/models.jsx`):

- `chrome.jsx::Sidebar` — `useSlots()` + `useModels()`, default to `0` when `data` is undefined.
- `mcp-main.jsx::McpSidebar` — same `useSlots` / `useModels` migration, plus migrate the lemond status block to `useLemondRollup()` mirroring the `SidebarStatusBlock` pattern in chrome.jsx.

`HAL0_DATA` and other consumers are untouched (intentional fallback for the rest of the prototype).

## Files

- `ui/src/dash/chrome.jsx` (+6 / -2)
- `ui/src/dash/mcp-main.jsx` (+14 / -4)

## Verification ran

On hal0-dev (`/tmp/hal0-sidebar-live/ui`):
- `npm run typecheck` — clean.
- `npm install` + `rm -rf node_modules/.vite dist && npm run build` — clean.

On hal0 LXC (`/opt/hal0/ui`, branch checked out + force-reset to remote tip after rebase onto current main):
- `rm -rf node_modules/.vite dist && npm run build` — clean (115 modules, dist/assets/index-CY9F9Fds.js, 508 kB).
- `npm run typecheck` — clean.
- `grep 'queryKey:\["slots"\]\|queryKey:\["models"\]' dist/assets/index-*.js` → 2 matches (hooks compiled into the bundle).
- `systemctl restart hal0-api` → active.
- `curl http://127.0.0.1:8080/` → 200; served `<script src=".../index-CY9F9Fds.js">` matches freshly-built bundle.
- `/api/slots` reports 5 slots (embed/primary/rerank/stt/tts), `/api/models` reports 0 — both will render live in the sidebar instead of the static seed (which had different counts).
- `POST /api/slots/primary/restart` → 200; count stable at 5, primary state cycled to `ready` — useSlots' 5s polling carries the change.

## Out of scope

Other HAL0_DATA consumers (data.jsx is a shared fallback for many components — intentional), eviction bug, tweaks panel, firstrun, other sidebars.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>