### PR TITLE
fix(lemonade): treat /v1/health last_use as opaque counter

### DIFF
--- a/src/hal0/lemonade/idle.py
+++ b/src/hal0/lemonade/idle.py
@@ -11,9 +11,28 @@ lifespan. Once per tick (30s default — matches the existing hal0
 ``_IDLE_MONITOR_INTERVAL_S``) it:
 
   1. Polls ``GET /v1/health`` for ``all_models_loaded[].last_use``
-  2. For each loaded model with ``now - last_use > idle_timeout_s``,
-     calls ``POST /v1/unload``
-  3. Logs the eviction so dashboards can audit
+  2. Tracks each model's ``last_use`` value across ticks. When the
+     value stays unchanged for more than ``idle_timeout_s`` wall-clock
+     seconds (measured against our own injectable clock — NOT against
+     the ``last_use`` field directly), calls ``POST /v1/unload``.
+  3. Logs the eviction so dashboards can audit.
+
+Why we don't compute ``now - last_use`` directly: Lemonade 10.6 reports
+``last_use`` as an opaque monotonic counter, NOT a unix epoch float.
+Verified on hal0 LXC 2026-05-25:
+
+  * Fresh load: ``last_use = 1420647618``
+  * After one ``/v1/chat/completions``: ``last_use = 1420673741``
+    (+26,123 for ~25s wall — clearly not seconds)
+
+If we treated that as epoch seconds the model would always look ~11
+years stale and get evicted on the first sweep (which is exactly the
+regression that motivated this rewrite — see field-bug report from
+2026-05-25). Lemonade ships ~weekly and field semantics drift; the
+safe contract is "the value changes when the model is used" and
+nothing more. We bump a wall-clock idle clock locally each time the
+counter moves, so this driver is correct regardless of the field's
+units (or even sign).
 
 Resilience contract:
   * Transient lemond unavailability (``LemonadeUnavailableError`` /
@@ -24,6 +43,9 @@ Resilience contract:
     up the CancelledError, and exits without partial state.
   * Per-model unload failures don't abort the whole sweep; we log and
     move on to the next candidate.
+  * Models that disappear from the loaded list have their tracker
+    state dropped, so an unload + reload starts a fresh idle clock
+    (rather than evicting the reloaded model immediately).
 
 ADR cross-references:
   * ADR-0007 §Related — operational gap that motivated this driver
@@ -100,6 +122,13 @@ class IdleDriver:
         self._clock = clock
         self._task: asyncio.Task[None] | None = None
         self._stopping = asyncio.Event()
+        # Per-model idle-clock state:
+        #   model_name -> (last_observed_last_use, first_seen_at_wall_clock)
+        # We bump first_seen_at whenever last_observed_last_use moves,
+        # which is the only signal Lemonade gives us that the model was
+        # used. See the module docstring for why we can't trust the
+        # field's units.
+        self._seen: dict[str, tuple[float, float]] = {}
 
     # ── lifecycle ──────────────────────────────────────────────────
 
@@ -187,7 +216,20 @@ class IdleDriver:
             log.warning("lemonade.idle.health_error", extra={"error": str(exc)})
             return 0
 
-        loaded = _extract_loaded_models(health)
+        loaded = list(_extract_loaded_models(health))
+        # First: drop tracker state for any model that's no longer
+        # loaded. An unload + reload must start a fresh idle clock —
+        # otherwise a reloaded model would inherit its previous
+        # last_use snapshot and look stale immediately.
+        live_names = {
+            entry.get("model_name")
+            for entry in loaded
+            if isinstance(entry.get("model_name"), str) and entry.get("model_name")
+        }
+        stale_state = self._seen.keys() - live_names
+        for gone in stale_state:
+            self._seen.pop(gone, None)
+
         if not loaded:
             return 0
 
@@ -199,15 +241,41 @@ class IdleDriver:
                 continue
             last_use = _coerce_last_use(entry.get("last_use"))
             if last_use is None:
-                # No timestamp → can't decide; leave it alone. Better
+                # No counter → can't decide; leave it alone. Better
                 # to skip an eviction than evict a freshly-loaded
-                # model whose stats haven't populated yet.
+                # model whose stats haven't populated yet. We also
+                # don't seed tracker state in this case — the next
+                # tick with a real counter starts cleanly.
                 continue
-            age = now - last_use
+
+            prev = self._seen.get(name)
+            if prev is None:
+                # First sight of this model. Record its counter and
+                # the wall-clock moment we noticed it; skip eviction
+                # this tick so a freshly-loaded model gets at least
+                # one full idle_timeout_s window before it can be
+                # culled.
+                self._seen[name] = (last_use, now)
+                continue
+
+            prev_last_use, first_seen_at = prev
+            if last_use != prev_last_use:
+                # Counter moved → the model was used since our last
+                # observation. Reset the idle clock and skip eviction.
+                self._seen[name] = (last_use, now)
+                continue
+
+            # Counter unchanged since first_seen_at. Decide on
+            # wall-clock age, NOT on the opaque counter's value.
+            age = now - first_seen_at
             if age <= self._idle_timeout_s:
                 continue
             ok = await self._unload(name, age=age)
             if ok:
+                # Drop tracker state proactively so an immediate
+                # reload (before the next health poll observes the
+                # unload) won't reuse the stale entry.
+                self._seen.pop(name, None)
                 evicted += 1
         return evicted
 
@@ -267,14 +335,21 @@ def _extract_loaded_models(health: dict[str, Any]) -> Iterable[dict[str, Any]]:
 
 
 def _coerce_last_use(value: Any) -> float | None:
-    """Coerce a ``last_use`` payload field into a unix-epoch float.
+    """Coerce a ``last_use`` payload field into a comparable float.
 
-    Lemonade reports last_use as a unix timestamp (float seconds). We
-    accept int/float; anything else (None, str, missing) yields None
-    which the caller treats as "skip this entry this tick".
+    Lemonade 10.6 reports ``last_use`` as an opaque monotonic counter
+    (NOT a unix timestamp — verified on hal0 LXC 2026-05-25, see the
+    module docstring). The driver only uses this value for equality
+    comparison across ticks ("did the counter move?"), so the units
+    don't matter — we just need a value we can stash and compare.
+
+    We accept int/float; anything else (None, str, missing) yields
+    None which the caller treats as "skip this entry this tick" (no
+    tracker state seeded, no eviction).
+
+    bool is an int subclass and is excluded explicitly so True/False
+    don't masquerade as 1.0/0.0 counter values.
     """
     if isinstance(value, (int, float)) and not isinstance(value, bool):
-        # bool is an int subclass — exclude explicitly so True/False
-        # don't pass for "0 seconds since epoch".
         return float(value)
     return None

--- a/tests/lemonade/test_idle.py
+++ b/tests/lemonade/test_idle.py
@@ -1,20 +1,28 @@
 """Unit tests for ``hal0.lemonade.idle.IdleDriver`` (ADR-0007 §Related, ADR-0006 §17).
 
-The idle driver's contract:
+The idle driver's contract (post 2026-05-25 opaque-counter rewrite):
 
-  * Stale loaded model → ``POST /v1/unload`` called
-  * Fresh loaded model → left alone
+  * Fresh model (first sighting) → NEVER evicted on the same tick,
+    regardless of its ``last_use`` value
+  * Counter stays unchanged across enough ticks that wall-clock dwell
+    exceeds ``idle_timeout_s`` → ``POST /v1/unload`` called
+  * Counter changes during the wait window → idle clock resets
+  * Model disappears from the loaded list then reappears (even with
+    the same ``last_use``) → starts a fresh idle clock
   * Lemond unreachable / 5xx → log + continue, no crash
   * Per-model unload failure → log + continue, sweep proceeds
   * Cancellation propagates cleanly through ``stop()``
 
 We drive the driver via its public ``tick()`` method so tests are
-deterministic and don't sleep on the real poll interval.
+deterministic and don't sleep on the real poll interval. The driver
+already takes an injectable ``clock`` callable; we wrap a mutable
+container so each tick advances time without monkeypatching.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json as _json
 
 import httpx
 import pytest
@@ -33,109 +41,205 @@ def _mock_transport(handler):
     return httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://test")
 
 
-# ── tick(): stale → unload ────────────────────────────────────────────
+class _Clock:
+    """Mutable wall-clock for fast-forwarding through ticks."""
+
+    def __init__(self, start: float = 10_000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
 
 
-@pytest.mark.asyncio
-async def test_stale_model_gets_unloaded() -> None:
-    """A model whose last_use is older than idle_timeout_s must be unloaded."""
-    now = 10_000.0
-    calls: list[str] = []
+class _HealthScript:
+    """Replays a series of ``/v1/health`` responses across ticks.
 
-    def h(req: httpx.Request) -> httpx.Response:
+    Each entry is the list to return under ``all_models_loaded`` on
+    the next ``/v1/health`` call. ``/v1/unload`` records the model
+    names it received.
+    """
+
+    def __init__(self, scripts: list[list[dict[str, object]]]) -> None:
+        self._scripts = list(scripts)
+        self.unload_calls: list[str] = []
+
+    def __call__(self, req: httpx.Request) -> httpx.Response:
         if req.url.path == "/v1/health":
-            return httpx.Response(
-                200,
-                json={
-                    "all_models_loaded": [
-                        {"model_name": "stale", "last_use": now - 500.0},
-                        {"model_name": "fresh", "last_use": now - 5.0},
-                    ]
-                },
-            )
+            if not self._scripts:
+                return httpx.Response(200, json={"all_models_loaded": []})
+            entry = self._scripts.pop(0)
+            return httpx.Response(200, json={"all_models_loaded": entry})
         if req.url.path == "/v1/unload":
-            import json as _json
-
-            body = _json.loads(req.content.decode())
-            calls.append(body["model_name"])
+            self.unload_calls.append(_json.loads(req.content.decode())["model_name"])
             return httpx.Response(200, json={"status": "unloaded"})
         return httpx.Response(404)
 
-    async with _mock_transport(h) as transport:
-        client = LemonadeClient(http_client=transport)
-        driver = IdleDriver(
-            client,
-            idle_timeout_s=300.0,
-            poll_interval_s=30.0,
-            clock=lambda: now,
-        )
-        evicted = await driver.tick()
-        assert evicted == 1
-        # Only the stale model was unloaded.
-        assert calls == ["stale"]
+
+# ── tick(): opaque-counter idle semantics ─────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_fresh_model_not_unloaded() -> None:
-    """Right on the boundary stays loaded — we use strict `>`, not `>=`."""
-    now = 10_000.0
-    calls: list[str] = []
+async def test_fresh_model_not_evicted_on_first_tick() -> None:
+    """A model we've never seen before must NEVER be evicted on the same tick.
 
-    def h(req: httpx.Request) -> httpx.Response:
-        if req.url.path == "/v1/health":
-            return httpx.Response(
-                200,
-                json={
-                    # last_use exactly idle_timeout_s ago — boundary
-                    # case, must NOT evict.
-                    "all_models_loaded": [
-                        {"model_name": "boundary", "last_use": now - 300.0},
-                    ]
-                },
-            )
-        if req.url.path == "/v1/unload":
-            import json as _json
-
-            calls.append(_json.loads(req.content.decode())["model_name"])
-            return httpx.Response(200, json={"status": "unloaded"})
-        return httpx.Response(404)
-
-    async with _mock_transport(h) as transport:
+    Regression guard for the 2026-05-25 bug: the old code computed
+    ``age = now - last_use`` against an opaque counter that looked
+    like a 2015-era epoch, so a freshly-loaded model was evicted 10s
+    after its first /v1/health appearance.
+    """
+    clock = _Clock()
+    # Use a wildly-out-of-band counter value — if the driver still
+    # treated this as a unix epoch, age would be ~10000 - 1_420_647_618
+    # < 0 (or vice versa) and behaviour would be wrong either way.
+    script = _HealthScript(
+        [
+            [{"model_name": "fresh", "last_use": 1_420_647_618}],
+        ]
+    )
+    async with _mock_transport(script) as transport:
         client = LemonadeClient(http_client=transport)
-        driver = IdleDriver(client, idle_timeout_s=300.0, poll_interval_s=30.0, clock=lambda: now)
+        driver = IdleDriver(client, idle_timeout_s=300.0, clock=clock)
         assert await driver.tick() == 0
-        assert calls == []
+        assert script.unload_calls == []
+
+
+@pytest.mark.asyncio
+async def test_unchanged_within_window_is_not_evicted() -> None:
+    """Counter stays unchanged across N ticks where N*poll < idle_timeout.
+
+    Wall-clock dwell is below the threshold, so no eviction.
+    """
+    clock = _Clock()
+    # 9 health ticks, all reporting the same last_use counter.
+    script = _HealthScript([[{"model_name": "idle", "last_use": 42}]] * 9)
+    async with _mock_transport(script) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(client, idle_timeout_s=300.0, poll_interval_s=30.0, clock=clock)
+        for _ in range(9):
+            assert await driver.tick() == 0
+            clock.advance(30.0)  # 9 * 30 = 270s < 300s
+        assert script.unload_calls == []
+
+
+@pytest.mark.asyncio
+async def test_unchanged_past_window_is_evicted() -> None:
+    """Counter unchanged long enough that wall-clock dwell exceeds idle_timeout.
+
+    The driver must eventually evict.
+    """
+    clock = _Clock()
+    # 12 ticks at 30s = 330s dwell, with counter never moving.
+    script = _HealthScript([[{"model_name": "idle", "last_use": 42}]] * 12)
+    async with _mock_transport(script) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(client, idle_timeout_s=300.0, poll_interval_s=30.0, clock=clock)
+        unloaded = False
+        for _ in range(12):
+            evicted = await driver.tick()
+            if evicted:
+                unloaded = True
+                break
+            clock.advance(30.0)
+        assert unloaded, "model should have been evicted once wall-clock dwell > idle_timeout"
+        assert script.unload_calls == ["idle"]
+
+
+@pytest.mark.asyncio
+async def test_counter_change_resets_idle_clock() -> None:
+    """A bump in last_use during the wait window resets the idle clock.
+
+    Sequence: model sits idle 270s (under threshold), then gets used
+    (counter bumps), then sits idle another 270s. Total wall-clock
+    dwell is 540s but neither stretch alone exceeds 300s — so no
+    eviction.
+    """
+    clock = _Clock()
+    script = _HealthScript(
+        # 9 ticks at last_use=100 (270s dwell), then 9 ticks at
+        # last_use=200 (counter moved → reset → another 270s).
+        [[{"model_name": "bumpy", "last_use": 100}]] * 9
+        + [[{"model_name": "bumpy", "last_use": 200}]] * 9
+    )
+    async with _mock_transport(script) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(client, idle_timeout_s=300.0, poll_interval_s=30.0, clock=clock)
+        for _ in range(18):
+            assert await driver.tick() == 0
+            clock.advance(30.0)
+        assert script.unload_calls == []
+
+
+@pytest.mark.asyncio
+async def test_disappear_then_reappear_starts_fresh_clock() -> None:
+    """Unload + reload (same last_use even!) must NOT carry stale tracker state.
+
+    The driver should drop tracker entries for models no longer in
+    the loaded list, so a reappearance starts the idle window over.
+    """
+    clock = _Clock()
+    script = _HealthScript(
+        [
+            # Tick 1: model present, first sighting.
+            [{"model_name": "blip", "last_use": 42}],
+            # Ticks 2-10: model present, counter unchanged → would
+            # have dwelt 0..270s on the first run.
+            *([[{"model_name": "blip", "last_use": 42}]] * 9),
+            # Tick 11: model GONE (someone unloaded it externally).
+            [],
+            # Tick 12+: model back with the same last_use. This must
+            # be treated as a fresh sighting — NOT evicted just
+            # because the counter still matches the stale state.
+            *([[{"model_name": "blip", "last_use": 42}]] * 12),
+        ]
+    )
+    async with _mock_transport(script) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(client, idle_timeout_s=300.0, poll_interval_s=30.0, clock=clock)
+
+        # First sighting + 9 idle ticks (270s wall-clock dwell).
+        for _ in range(10):
+            assert await driver.tick() == 0
+            clock.advance(30.0)
+
+        # Model gone — tracker state must be dropped.
+        assert await driver.tick() == 0
+        clock.advance(30.0)
+
+        # Model reappears. The reappearance counts as tick #1 for
+        # a fresh idle clock. The driver must NOT evict on the same
+        # tick — even though if it had kept state, total observed
+        # dwell would be 330s > 300s.
+        assert await driver.tick() == 0
+        clock.advance(30.0)
+
+        # Now run another 9 ticks (still under the fresh 300s window).
+        for _ in range(9):
+            assert await driver.tick() == 0
+            clock.advance(30.0)
+
+        assert script.unload_calls == []
 
 
 @pytest.mark.asyncio
 async def test_entries_without_last_use_are_skipped() -> None:
-    """No last_use timestamp → can't decide → leave the model alone."""
-    now = 10_000.0
-    calls: list[str] = []
-
-    def h(req: httpx.Request) -> httpx.Response:
-        if req.url.path == "/v1/health":
-            return httpx.Response(
-                200,
-                json={
-                    "all_models_loaded": [
-                        {"model_name": "no-ts"},  # missing last_use
-                        {"model_name": "bad-ts", "last_use": "yesterday"},
-                    ]
-                },
-            )
-        if req.url.path == "/v1/unload":
-            import json as _json
-
-            calls.append(_json.loads(req.content.decode())["model_name"])
-            return httpx.Response(200)
-        return httpx.Response(404)
-
-    async with _mock_transport(h) as transport:
+    """No last_use counter → can't decide → leave the model alone."""
+    clock = _Clock()
+    script = _HealthScript(
+        [
+            [
+                {"model_name": "no-ts"},  # missing last_use
+                {"model_name": "bad-ts", "last_use": "yesterday"},
+            ]
+        ]
+    )
+    async with _mock_transport(script) as transport:
         client = LemonadeClient(http_client=transport)
-        driver = IdleDriver(client, idle_timeout_s=300.0, clock=lambda: now)
+        driver = IdleDriver(client, idle_timeout_s=300.0, clock=clock)
         assert await driver.tick() == 0
-        assert calls == []
+        assert script.unload_calls == []
 
 
 # ── tick(): resilience ────────────────────────────────────────────────
@@ -172,7 +276,7 @@ async def test_health_5xx_does_not_raise() -> None:
 @pytest.mark.asyncio
 async def test_unload_failure_does_not_abort_sweep() -> None:
     """If one /v1/unload fails, the next stale model is still attempted."""
-    now = 10_000.0
+    clock = _Clock()
     attempts: list[str] = []
 
     def h(req: httpx.Request) -> httpx.Response:
@@ -181,14 +285,12 @@ async def test_unload_failure_does_not_abort_sweep() -> None:
                 200,
                 json={
                     "all_models_loaded": [
-                        {"model_name": "first", "last_use": now - 1000.0},
-                        {"model_name": "second", "last_use": now - 1000.0},
+                        {"model_name": "first", "last_use": 100},
+                        {"model_name": "second", "last_use": 200},
                     ]
                 },
             )
         if req.url.path == "/v1/unload":
-            import json as _json
-
             name = _json.loads(req.content.decode())["model_name"]
             attempts.append(name)
             if name == "first":
@@ -198,7 +300,11 @@ async def test_unload_failure_does_not_abort_sweep() -> None:
 
     async with _mock_transport(h) as transport:
         client = LemonadeClient(http_client=transport)
-        driver = IdleDriver(client, idle_timeout_s=300.0, clock=lambda: now)
+        driver = IdleDriver(client, idle_timeout_s=300.0, poll_interval_s=30.0, clock=clock)
+        # First tick: seed tracker state for both models, no eviction.
+        assert await driver.tick() == 0
+        # Advance past the idle timeout while both counters stay put.
+        clock.advance(301.0)
         evicted = await driver.tick()
         # second one succeeded; first one's failure was swallowed.
         assert evicted == 1
@@ -270,6 +376,9 @@ def test_coerce_last_use_rules() -> None:
     # Critical: bool must NOT pass as 0.0 / 1.0.
     assert _coerce_last_use(True) is None
     assert _coerce_last_use(False) is None
+    # Opaque-counter regime: huge integers (Lemonade 10.6 ships values
+    # like 1_420_647_618) are valid counter values, not epoch garbage.
+    assert _coerce_last_use(1_420_647_618) == 1_420_647_618.0
 
 
 # ── constructor validation ────────────────────────────────────────────


### PR DESCRIPTION
## Bug

`src/hal0/lemonade/idle.py` evicts freshly-loaded models on its very first 30s sweep. Confirmed live on hal0 LXC (10.0.1.142):

```
12:38:51  POST /api/slots/primary/restart → 200
12:39:01  lemonade.idle.unloaded            ← 10s later
```

This corresponds to bug #7 in #275 ("Lemonade evicts loaded models spontaneously") and is the upstream cause of bug #6 (slot watcher flipping to ERROR because the model disappears from `loaded[]` seconds after a successful load).

## Root cause

The idle driver computed `age = now - last_use` where `last_use` came from `/v1/health.all_models_loaded[].last_use` and was treated as a unix-epoch float. But Lemonade 10.6 returns an **opaque monotonic counter**, verified by hand on hal0:

| state | `last_use` |
| --- | --- |
| fresh load | `1420647618` |
| after one `/v1/chat/completions` (~25s later) | `1420673741` |

If those were epoch seconds, the load timestamp would be Jan 2015 and the next request would have advanced the clock by ~26,123 seconds (≈ 7 hours) for ~25s of wall-clock — clearly nonsense. So `age ≈ 11 years >> 300s idle_timeout_s` and the driver always evicted immediately.

Per `hal0_lemonade_gotchas` memory, Lemonade ships ~weekly breaking releases; the field's semantics shifted under us at some point and the driver hadn't caught up.

## Fix

Treat `last_use` as an opaque counter — we only require that **the value changes when the model is used**. Per-model state:

```
{ model_name: (last_observed_last_use, first_seen_at_wall_clock) }
```

- First sight of a model → record `(current_last_use, now)`, skip eviction this tick (fresh-load grace).
- `current_last_use != stored_last_use` → counter moved, the model was used → reset to `(current_last_use, now)`, skip eviction.
- `current_last_use == stored_last_use` → `age = now - first_seen_at_wall_clock`; evict iff `age > idle_timeout_s`.
- Models that disappear from the loaded list have their tracker entry dropped, so an external unload + reload starts a fresh idle clock.

This survives any future Lemonade redefinition of `last_use` units (or sign — counter could go backwards and the logic still holds).

`DEFAULT_IDLE_TIMEOUT_S = 300.0` is unchanged. `_coerce_last_use` keeps the bool-is-int-subclass guard. The module + `_coerce_last_use` docstrings are rewritten to drop the "unix-epoch float" claim and document the opaque-counter contract + the 2026-05-25 field evidence.

## Test cases added

All driven through the existing `clock` injection point — no sleep-based tests.

- [x] `test_fresh_model_not_evicted_on_first_tick` — regression guard for the original bug; uses a 1.4-billion `last_use` value
- [x] `test_unchanged_within_window_is_not_evicted` — 9 ticks × 30s = 270s wall dwell, counter pinned, no eviction
- [x] `test_unchanged_past_window_is_evicted` — 12 ticks × 30s = 330s wall dwell, counter pinned, eviction fires
- [x] `test_counter_change_resets_idle_clock` — 270s idle, counter bump, another 270s idle; no eviction (540s total)
- [x] `test_disappear_then_reappear_starts_fresh_clock` — model vanishes mid-window then comes back with the same `last_use`; the reappearance counts as tick #1 of a fresh window
- [x] `test_entries_without_last_use_are_skipped` — kept from the original suite; counter-less entries don't seed state
- [x] All existing resilience tests (health unreachable, 5xx, per-model unload failure, lifecycle start/stop, double-start, shape helpers) ported to the new semantics — total 16 tests in `test_idle.py`

## Verification

From `/tmp/hal0-idle-driver`:

- `ruff check src/hal0/lemonade/idle.py tests/lemonade/test_idle.py` → all checks passed
- `ruff format --check src/hal0/lemonade/idle.py tests/lemonade/test_idle.py` → 2 files already formatted
- `python -m pytest tests/lemonade/` → 114 passed in 0.48s (16 new in `test_idle.py`, 98 existing)

## Out of scope

- The hal0-api lemonade-proxy (option 3 from analysis)
- The sidebar bug (separate agent)
- Stale `/opt/lemonade-spike/lemond` processes (separate cleanup)

## Follow-up

ADR-0007 / ADR-0008 may want a short addendum noting that Lemonade's `/v1/health.last_use` is contractually opaque — not edited here, but worth a doc PR once the dust settles on field semantics.