### PR TITLE
feat(dash): slot indicator dot states + warming pulse

### DIFF
--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -145,6 +145,7 @@ class Slot:
         model_id: str | None = None,
         backend: str | None = None,
         metadata: dict[str, Any] | None = None,
+        last_used_at: float | None = None,
     ) -> None:
         self.name = name
         self.state = state
@@ -152,6 +153,15 @@ class Slot:
         self.model_id = model_id
         self.backend = backend
         self.metadata: dict[str, Any] = metadata or {}
+        # Wall-clock epoch (seconds) of the most recent request served by
+        # this slot. ``None`` when the slot hasn't served since hal0-api
+        # started — surfaces on /api/slots so the dashboard can render the
+        # "recently live within 1h" indicator (see ui/src/dash/slots.jsx
+        # ``slotIndicator``). Persistence is intentionally process-local:
+        # on restart the dashboard renders the slot as "loaded but stale"
+        # (yellow) until the first request lands, which matches operator
+        # intuition — we don't actually know if it was hit during downtime.
+        self.last_used_at: float | None = last_used_at
 
     def as_dict(self) -> dict[str, Any]:
         """Serialise to a JSON-safe dict for API responses."""
@@ -162,6 +172,7 @@ class Slot:
             "model_id": self.model_id,
             "backend": self.backend,
             "metadata": self.metadata,
+            "last_used_at": self.last_used_at,
         }
 
 
@@ -768,6 +779,7 @@ class SlotManager:
                 **rec.extra,
                 **({"backend": backend} if backend and "backend" not in rec.extra else {}),
             },
+            last_used_at=self._last_used.get(slot_name),
         )
 
     async def _maybe_load_config(self, slot_name: str) -> dict[str, Any] | None:

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -530,6 +530,33 @@ def test_bump_last_used_records_timestamp() -> None:
     assert ts is not None and ts > 0
 
 
+async def test_status_surfaces_last_used_at(
+    slot_root: Path,
+    lemonade_loaded_stub: dict[str, Any],
+    tmp_hal0_home: str,
+) -> None:
+    """Slot snapshots expose last_used_at so /api/slots can render the
+
+    'recently live within 1h' indicator. None before any request lands;
+    bumps to the current wall clock after a request.
+    """
+    sm = SlotManager()
+    await sm.load("primary")
+    # Cold slot — clear any bumps internal load paths may have produced
+    # so we exercise the "no bumps yet" branch deterministically.
+    sm._last_used.pop("primary", None)
+    snap = await sm.status("primary")
+    assert snap.last_used_at is None
+    assert snap.as_dict()["last_used_at"] is None
+
+    sm.bump_last_used("primary")
+    snap2 = await sm.status("primary")
+    assert snap2.last_used_at is not None
+    assert snap2.last_used_at > 0
+    payload = snap2.as_dict()
+    assert payload["last_used_at"] == snap2.last_used_at
+
+
 # ── HAL0_BACKEND env var is a no-op (PR-10) ─────────────────────────────────
 
 

--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -60,6 +60,12 @@ export interface Slot {
   pid?: number
   metrics: SlotMetrics
   spark?: number[]
+  /** Wall-clock epoch (seconds) of the most recent request served by
+   *  this slot. ``null``/undefined means hal0-api has not seen a request
+   *  for this slot since startup. Used by the slots view to render the
+   *  "recently live within 1h" green indicator vs "loaded but stale"
+   *  yellow indicator. See ui/src/dash/slots.jsx → ``slotIndicator``. */
+  last_used_at?: number | null
 }
 
 const SLOTS_POLL_MS = 5_000

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -15,6 +15,122 @@ import {
 
 const { useState: useStateS } = React;
 
+// ─── Slot indicator dot ────────────────────────────────────────────────
+//
+// Maps a slot snapshot → ({ cls, label, tooltip }) for the status dot
+// rendered in SlotCard / SlotListRow. Single source of truth for the
+// "what colour does this slot deserve" question.
+//
+// Mapping (matches PR feat/slot-state-indicator-dots):
+//   ready + last_used_at within RECENTLY_LIVE_MS → "recent" (green)
+//   ready + older / never used                   → "stale"  (yellow)
+//   warming / starting / pulling / unloading     → "warming" (amber, pulses)
+//   serving                                      → "serving" (cyan, pulses — pre-existing)
+//   idle                                         → "stale"  (yellow — semantically "loaded, not serving")
+//   error                                        → "error"  (red)
+//   offline / anything else                      → "offline" (grey)
+//
+// The "1h recently live" window leans on the backend's in-memory
+// `last_used_at` (bumped by SlotManager.serving on every dispatched
+// request). When hal0-api restarts, `last_used_at` is null for every
+// slot until the first new request lands — we render that as "stale"
+// (yellow), which matches operator intuition: we don't know whether
+// the slot was hit during downtime.
+const RECENTLY_LIVE_MS = 60 * 60 * 1000; // 1h window — kept as a named const
+
+function _formatAgo(deltaMs) {
+  if (deltaMs < 0) return "just now";
+  const s = Math.floor(deltaMs / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m} min ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+function slotIndicator(slot, now = Date.now()) {
+  const state = String(slot?.state || "offline");
+  const lastUsedSec = typeof slot?.last_used_at === "number" ? slot.last_used_at : null;
+  const lastUsedMs = lastUsedSec != null ? lastUsedSec * 1000 : null;
+  const deltaMs = lastUsedMs != null ? now - lastUsedMs : null;
+  const errorMsg = slot?.metadata?.message || slot?.message || "";
+  const model = slot?.model || slot?.model_id || slot?.model_default || "";
+
+  if (state === "error") {
+    return {
+      cls: "error",
+      label: "error",
+      tooltip: errorMsg ? `Error: ${errorMsg}` : "Error",
+    };
+  }
+  if (
+    state === "warming" ||
+    state === "starting" ||
+    state === "pulling" ||
+    state === "unloading"
+  ) {
+    const verb =
+      state === "pulling" ? "Pulling"
+        : state === "unloading" ? "Unloading"
+          : "Warming up";
+    return {
+      cls: "warming",
+      label: state,
+      tooltip: model ? `${verb} ${model}…` : `${verb}…`,
+    };
+  }
+  if (state === "serving") {
+    // Pre-existing serving dot behaviour: cyan + pulse (CSS unchanged).
+    return {
+      cls: "serving",
+      label: "serving",
+      tooltip: model ? `Serving ${model}` : "Serving",
+    };
+  }
+  if (state === "ready") {
+    if (deltaMs != null && deltaMs <= RECENTLY_LIVE_MS) {
+      return {
+        cls: "recent",
+        label: "ready",
+        tooltip: `Loaded, last used ${_formatAgo(deltaMs)}`,
+      };
+    }
+    return {
+      cls: "stale",
+      label: "ready",
+      tooltip: deltaMs != null
+        ? `Loaded, idle (${_formatAgo(deltaMs)})`
+        : "Loaded — no requests since hal0-api started",
+    };
+  }
+  if (state === "idle") {
+    return {
+      cls: "stale",
+      label: "idle",
+      tooltip: deltaMs != null
+        ? `Idle (${_formatAgo(deltaMs)})`
+        : "Idle",
+    };
+  }
+  // offline + anything unknown
+  return {
+    cls: "offline",
+    label: state,
+    tooltip: state === "offline" ? "Offline" : `State: ${state}`,
+  };
+}
+
+function IndicatorDot({ slot }) {
+  const ind = slotIndicator(slot);
+  return <span className={"dot " + ind.cls} title={ind.tooltip} />;
+}
+
+// Expose for window-scope JSX (legacy pattern in this codebase) + tests.
+if (typeof window !== "undefined") {
+  Object.assign(window, { slotIndicator, IndicatorDot, RECENTLY_LIVE_MS });
+}
+
 // ─── Mini sparkline for slot card ───
 function Spark({ data, height = 18 }) {
   if (!data || data.length === 0) return null;
@@ -92,7 +208,7 @@ function SlotCard({
   return (
     <div className={"slot" + (state === "serving" ? " serving" : "")}>
       <div className="slot-h">
-        <span className={"dot " + state} />
+        <IndicatorDot slot={slot} />
         <div className="slot-name">
           <span className="nm">{slot.name}</span>
         </div>
@@ -170,7 +286,7 @@ function SlotListRow({ slot, onEdit }) {
               `${metrics.rpm || 0} r/m`;
   return (
     <div className="slot-list-row" onClick={onEdit}>
-      <span className={"dot " + state} />
+      <IndicatorDot slot={slot} />
       <span className="nm">
         {slot.name}
         {isDefault && <span className="chip outlined amber" style={{fontSize: 9, padding: "1px 4px"}}>def</span>}

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -592,7 +592,16 @@ a { color: inherit; text-decoration: none; }
 .dot.error { background: var(--err); }
 .dot.empty { background: var(--fg-5); }
 .dot.coresident { background: var(--dev-npu); box-shadow: 0 0 8px var(--dev-npu); }
-@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+/* Slot indicator dot states — see ui/src/dash/slots.jsx `slotIndicator`.
+   "recent" = ready AND last served within RECENTLY_LIVE_MS (1h).
+   "stale"  = ready but quiet >1h, OR explicit idle state.
+   "warming" = pulsing amber for warming/starting/pulling/unloading.
+   "offline" = neutral grey for offline/unknown. */
+.dot.recent  { background: var(--ok);   box-shadow: 0 0 8px var(--ok); }
+.dot.stale   { background: var(--warn); box-shadow: 0 0 6px rgba(232, 185, 78, 0.45); }
+.dot.warming { background: var(--warn); box-shadow: 0 0 8px var(--warn); animation: pulse 1.2s ease-in-out infinite; }
+.dot.offline { background: var(--fg-4); }
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
 /* Section title — used inside views */
 .sec {

--- a/ui/tests/e2e/specs/slot-indicator-live-screenshot.spec.ts
+++ b/ui/tests/e2e/specs/slot-indicator-live-screenshot.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * One-off live capture against the hal0 LXC (10.0.1.142:8080). Runs only
+ * when HAL0_LIVE_LXC=1 is set, so CI doesn't fail when the LAN host is
+ * unreachable. Use this to grab a screenshot of the actual dashboard with
+ * real /api/slots data exposing last_used_at.
+ *
+ *   HAL0_LIVE_LXC=1 npx playwright test slot-indicator-live-screenshot --grep @live-lxc
+ */
+import { test as base, expect, chromium } from '@playwright/test'
+
+const LIVE = process.env.HAL0_LIVE_LXC === '1'
+const LXC_URL = process.env.HAL0_LXC_URL || 'http://10.0.1.142:8080'
+
+const test = base.extend({})
+
+test.skip(!LIVE, 'set HAL0_LIVE_LXC=1 + ensure 10.0.1.142 is reachable')
+
+test('@live-lxc dashboard slots view against hal0 LXC', async () => {
+  const browser = await chromium.launch()
+  const ctx = await browser.newContext({ baseURL: LXC_URL, viewport: { width: 1440, height: 900 } })
+  const page = await ctx.newPage()
+  await page.goto('/#slots', { waitUntil: 'networkidle' })
+  await expect(page.locator('.view .vh h1')).toHaveText('Slots')
+  await page.waitForSelector('.slot .dot, .slot-list-row .dot')
+  await page.screenshot({
+    path: 'test-results/slot-indicators-live-lxc.png',
+    fullPage: true,
+  })
+  await browser.close()
+})

--- a/ui/tests/e2e/specs/slot-indicator.spec.ts
+++ b/ui/tests/e2e/specs/slot-indicator.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * slot-indicator — exercises the `slotIndicator` mapping helper exported
+ * from ui/src/dash/slots.jsx onto window. Single source of truth for the
+ * status-dot colour/tooltip; this spec pins the state → dot.cls table
+ * so future tweaks can't silently regress (e.g. flipping idle to green
+ * or dropping the 1h "recently live" threshold).
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+type Indicator = { cls: string; label: string; tooltip: string }
+
+const RECENTLY_LIVE_MS = 60 * 60 * 1000
+
+test.describe('slotIndicator helper', () => {
+  test.beforeEach(async ({ page }) => {
+    // Any page renders the dashboard bundle; #slots ensures slots.jsx
+    // is loaded so window.slotIndicator is defined.
+    await page.goto('/#slots')
+    await page.waitForFunction(() => typeof (window as any).slotIndicator === 'function')
+  })
+
+  test('ready + last_used within 1h → recent (green)', async ({ page }) => {
+    const ind = await page.evaluate<Indicator>(() => {
+      const now = Date.now()
+      const slot = { state: 'ready', last_used_at: (now - 12 * 60 * 1000) / 1000, model: 'foo' }
+      return (window as any).slotIndicator(slot, now)
+    })
+    expect(ind.cls).toBe('recent')
+    expect(ind.label).toBe('ready')
+    expect(ind.tooltip).toMatch(/Loaded, last used 12 min ago/)
+  })
+
+  test('ready + last_used >1h ago → stale (yellow)', async ({ page }) => {
+    const ind = await page.evaluate<Indicator>(() => {
+      const now = Date.now()
+      // 90 minutes ago
+      const slot = { state: 'ready', last_used_at: (now - 90 * 60 * 1000) / 1000 }
+      return (window as any).slotIndicator(slot, now)
+    })
+    expect(ind.cls).toBe('stale')
+    expect(ind.tooltip).toMatch(/Loaded, idle \(1h ago\)/)
+  })
+
+  test('ready + last_used null → stale (yellow), tooltip notes no requests', async ({ page }) => {
+    const ind = await page.evaluate<Indicator>(() => {
+      const slot = { state: 'ready', last_used_at: null }
+      return (window as any).slotIndicator(slot, Date.now())
+    })
+    expect(ind.cls).toBe('stale')
+    expect(ind.tooltip).toMatch(/no requests since hal0-api started/)
+  })
+
+  test('warming → warming (pulsing amber)', async ({ page }) => {
+    const ind = await page.evaluate<Indicator>(() => {
+      return (window as any).slotIndicator({ state: 'warming', model: 'Qwen3.5-0.8B-GGUF' })
+    })
+    expect(ind.cls).toBe('warming')
+    expect(ind.tooltip).toMatch(/Warming up Qwen3.5-0.8B-GGUF/)
+  })
+
+  test('starting + pulling + unloading also map to warming', async ({ page }) => {
+    const out = await page.evaluate(() => {
+      return ['starting', 'pulling', 'unloading'].map((state) =>
+        (window as any).slotIndicator({ state }).cls,
+      )
+    })
+    expect(out).toEqual(['warming', 'warming', 'warming'])
+  })
+
+  test('error → error (red), tooltip surfaces metadata.message', async ({ page }) => {
+    const ind = await page.evaluate<Indicator>(() => {
+      return (window as any).slotIndicator({
+        state: 'error',
+        metadata: { message: 'model file missing' },
+      })
+    })
+    expect(ind.cls).toBe('error')
+    expect(ind.tooltip).toBe('Error: model file missing')
+  })
+
+  test('offline → offline (grey)', async ({ page }) => {
+    const ind = await page.evaluate<Indicator>(() => {
+      return (window as any).slotIndicator({ state: 'offline' })
+    })
+    expect(ind.cls).toBe('offline')
+    expect(ind.tooltip).toBe('Offline')
+  })
+
+  test('idle state maps to stale (yellow)', async ({ page }) => {
+    const ind = await page.evaluate<Indicator>(() => {
+      return (window as any).slotIndicator({ state: 'idle', last_used_at: null })
+    })
+    expect(ind.cls).toBe('stale')
+    expect(ind.label).toBe('idle')
+  })
+
+  test('RECENTLY_LIVE_MS exported and equals 1 hour', async ({ page }) => {
+    const ms = await page.evaluate(() => (window as any).RECENTLY_LIVE_MS)
+    expect(ms).toBe(RECENTLY_LIVE_MS)
+  })
+
+  test('boundary: exactly 1h ago is still recent (≤, not <)', async ({ page }) => {
+    const cls = await page.evaluate(() => {
+      const now = Date.now()
+      const slot = { state: 'ready', last_used_at: (now - 60 * 60 * 1000) / 1000 }
+      return (window as any).slotIndicator(slot, now).cls
+    })
+    expect(cls).toBe('recent')
+  })
+
+  test('boundary: 1h + 1s ago becomes stale', async ({ page }) => {
+    const cls = await page.evaluate(() => {
+      const now = Date.now()
+      const slot = { state: 'ready', last_used_at: (now - 60 * 60 * 1000 - 1000) / 1000 }
+      return (window as any).slotIndicator(slot, now).cls
+    })
+    expect(cls).toBe('stale')
+  })
+})


### PR DESCRIPTION
## Investigation summary

`/api/slots` on hal0 LXC exposes `state` + `metadata.updated_at` (last state-change wall clock) but no `last_used_at` (last-serve wall clock). `SlotManager` already maintains `_last_used: dict[str, float]` in memory, bumped on every dispatched request via the `serving()` async context manager (`manager.py:1421/1440/1443`) — wired through `Dispatcher.forward → _forward_with_serving` for every slot-routed call. So the "recently live within 1h" signal already exists server-side; it just isn't surfaced. Minimum diff: thread `_last_used.get(slot_name)` onto the `Slot` snapshot returned from `SlotManager.status()`, surface it on `as_dict()`, and consume it in the frontend. No persistence — on `hal0-api` restart the field resets to null, which the dashboard treats as "stale" (yellow). That matches operator intuition: we don't actually know if the slot was hit during downtime.

## State → dot.cls mapping

| Slot state | Last-used age | Dot class | Color | Behaviour |
|---|---|---|---|---|
| `ready` | within 1h | `recent` | green (`--ok`) | static |
| `ready` | >1h or null | `stale` | yellow (`--warn`) | static |
| `idle` | — | `stale` | yellow (`--warn`) | static |
| `warming` / `starting` / `pulling` / `unloading` | — | `warming` | amber (`--warn`) | **pulsing** (1.2s ease-in-out) |
| `serving` | — | `serving` | cyan (`--accent`) | pulsing (pre-existing) |
| `error` | — | `error` | red (`--err`) | static |
| `offline` / unknown | — | `offline` | grey (`--fg-4`) | static |

The 1h threshold lives as a single named const (`RECENTLY_LIVE_MS = 60 * 60 * 1000`) in `slots.jsx`. The mapping itself is the single function `slotIndicator(slot)`, exported on `window` for unit testing.

## Backend changes

- **`src/hal0/slots/manager.py`**: `Slot.__init__` + `Slot.as_dict()` gain `last_used_at: float | None`. `SlotManager.status()` populates it from `self._last_used.get(slot_name)`.

That's it. No new endpoint, no schema migration, no new bump-site (the existing `serving()` context already covers every dispatched request). `_last_used` is process-local; `hal0-api` restart resets to null and the UI degrades to yellow, which is honest.

Known limitation observed live (NOT a regression — this PR's scope is the indicator, not the bump path): on a hal0 install with no upstreams.toml configured, chat completions fall through to `lemonade_proxy._proxy` (`api/routes/v1.py:241`), which bypasses `SlotManager.serving()` and therefore doesn't bump `last_used_at`. On a normal install with `primary` registered as a slot upstream, the dispatcher's `_forward_with_serving` path bumps as expected. A follow-up could add the bump to the proxy fallback; flagged in the PR conversation for triage rather than expanded here.

## Frontend changes

- **`ui/src/dash/slots.jsx`**: new `slotIndicator(slot, now?)` helper returning `{cls, label, tooltip}`. New `IndicatorDot` component. `RECENTLY_LIVE_MS` const. Replaces the two `<span className={"dot " + state}/>` sites in `SlotCard` + `SlotListRow`. All three exposed on `window` for tests.
- **`ui/src/dashboard.css`**: adds `.dot.recent`, `.dot.stale`, `.dot.warming`, `.dot.offline`. Reuses existing palette + `pulse` keyframe (now `0.4 ↔ 1.0` opacity as the brief suggested, was `0.35`).
- **`ui/src/api/hooks/useSlots.ts`**: `Slot` interface gains `last_used_at?: number | null` so TS keeps its grip.

`chrome.jsx` (PR #306's territory) is **not touched** — its dots are lemond-status / coresident / follow-tail indicators, not per-slot state dots.

## Tests

- **`tests/slots/test_manager.py`**: new `test_status_surfaces_last_used_at` asserts `Slot.last_used_at` round-trips through `status()` + `as_dict()`, both before and after a `bump_last_used()` call. All 117 existing slot tests still pass.
- **`ui/tests/e2e/specs/slot-indicator.spec.ts`**: 10 new Playwright cases pinning every cell of the mapping table — including the `≤1h is still recent` / `1h + 1s is stale` boundary cases and the `null last_used_at` "no requests since hal0-api started" tooltip.
- **`ui/tests/e2e/specs/slot-indicator-live-screenshot.spec.ts`**: opt-in capture against the LXC, gated by `HAL0_LIVE_LXC=1` (skipped in CI, useful for follow-up visual reviews).

Full local suite: 444 pytest tests pass, 44 Playwright tests pass (9 environmentally skipped).

## Live verification on hal0 LXC (10.0.1.142)

After clean rebuild (`cd /opt/hal0/ui && rm -rf dist node_modules/.vite && npm run build && systemctl restart hal0-api`):

| # | Scenario | Verified? | Observation |
|---|---|---|---|
| 1 | `/api/slots` exposes `last_used_at` | ✅ | `curl /api/slots` returns `"last_used_at": null` for all 5 slots after restart |
| 2 | Ready slots with null `last_used_at` render yellow (stale) | ✅ | Captured screenshot: all 5 cards show `--warn` dot |
| 3 | Bump `last_used_at` → primary turns green (recent) | ⚠️ simulated | Unit test proves the mapping; on this LXC the chat path falls through `lemonade_proxy` (no upstreams registered) and bypasses `serving()`. Documented as known limitation; not introduced by this PR. |
| 4 | Forced stale (`last_used_at > 1h` ago) → yellow | ✅ implicit | The current LXC state IS this scenario (null reads as stale via the same code branch) |
| 5 | Restart → warming class (amber pulsing) | ✅ | `POST /api/slots/primary/restart` → screenshot captures primary's `starting` chip with amber dot, plus 4 other slots simultaneously in `offline` grey during the lemond cascade |
| 6 | Error state → red | ⏭️ unit test only | Not safe to force on the shared LXC; Playwright case `error → error (red), tooltip surfaces metadata.message` covers it |
| 7 | Offline slot → grey | ✅ | Multiple slots showed `.dot.offline` grey during scenario 5's restart cascade |

Commands used:

```bash
# Verify field exposure
ssh hal0 'curl -s http://127.0.0.1:8080/api/slots' | python3 -m json.tool | head

# Capture restart-cascade screenshot
ssh hal0 'curl -s -X POST http://127.0.0.1:8080/api/slots/primary/restart -d "{}" -H "content-type: application/json" >/dev/null &' &
sleep 0.4
HAL0_LIVE_LXC=1 npx playwright test slot-indicator-live-screenshot --grep @live-lxc
```

## Files touched

```
M  src/hal0/slots/manager.py              (+13 -1 — Slot.last_used_at + status() wiring)
M  tests/slots/test_manager.py            (+28 — test_status_surfaces_last_used_at)
M  ui/src/api/hooks/useSlots.ts           (+8 — Slot.last_used_at typing)
M  ui/src/dash/slots.jsx                  (+121 — slotIndicator + IndicatorDot + 2 callsites)
M  ui/src/dashboard.css                   (+11 -2 — 4 new dot classes + tweaked pulse opacity)
A  ui/tests/e2e/specs/slot-indicator.spec.ts                (118 lines — 10 mapping cases)
A  ui/tests/e2e/specs/slot-indicator-live-screenshot.spec.ts (29 lines — opt-in capture)
```

Owned-by-sibling-PR files NOT touched: `chrome.jsx` (#306), `dashboard.jsx` (#308/#309), `chat.jsx` (#309), `main.tsx` (#309), `idle.py` (#307), `models.jsx`/`settings.jsx`, `dispatcher/router.py`.

## Out of scope

- Animating colour transitions between states (warming pulse is the only animation)
- Per-slot health detail panel
- "Within 1h" history graph
- Tunable threshold (1h hard-coded; separate PR if needed)
- Bumping `last_used_at` from the lemonade proxy fallback path (separate PR — see the limitation note above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)