### PR TITLE
feat(dash): show reasoning above answer in chat (collapsible)

### DIFF
--- a/ui/src/api/hooks/useChatCompletions.ts
+++ b/ui/src/api/hooks/useChatCompletions.ts
@@ -11,16 +11,17 @@
 //
 // Streaming semantics:
 //   - Each SSE event is `data: { ... }\n\n`, plus a final `data: [DONE]\n\n`.
-//   - The Qwen3.5 family emits a `reasoning_content` delta BEFORE the final
-//     `content` delta. We surface both into the same buffer (reasoning is
-//     dropped if content arrives — keeps the bubble looking like an answer,
-//     not a thought stream; the dedicated think/answer scaffold owns the
-//     proper split, this is just "don't look broken when the model thinks
-//     out loud").
+//   - Either `delta.content` or `delta.reasoning_content` may be present
+//     on any chunk (Qwen3 chat template emits all reasoning chunks first,
+//     then content chunks — but we don't depend on that order).
+//   - We surface BOTH buffers to the caller, distinct. The UI renders
+//     reasoning above the answer with its own collapse affordance
+//     (see ReasoningBlock in chat.jsx). The folding/“reasoningOnly” behaviour
+//     from #200 was removed: with a real reasoning surface in place, content
+//     and reasoning are first-class siblings.
 //
-// Out of scope for #200: tool calls, function calling, multimodal, abort,
-// retry, draft-model speculative decoding visualisation, persistence across
-// reload. v1 is "send a message, see a real response".
+// Out of scope: tool calls, function calling, multimodal, retry,
+// draft-model speculative decoding visualisation, persistence across reload.
 
 export interface ChatMessage {
   role: 'user' | 'assistant' | 'system'
@@ -41,11 +42,17 @@ export interface ChatRequestOptions {
 }
 
 export interface ChatResponse {
-  /** Full assistant message text (content preferred, reasoning_content as fallback). */
+  /** Final assistant answer (delta.content joined). May be empty if the
+   * model only produced reasoning (a non-finalized "thinking" reply). */
   content: string
+  /** Chain-of-thought / reasoning_content (delta.reasoning_content joined).
+   * Empty string when the model produced none — UI hides the block. */
+  reasoning: string
   /** The model the server actually replied as (may differ from request model). */
   model: string
-  /** True when the response is a fallback to reasoning_content (no real answer). */
+  /** True when the model produced reasoning but no content. The chat surface
+   * still renders the bubble + reasoning so the user can see the thought even
+   * if the answer was truncated/empty. */
   reasoningOnly: boolean
 }
 
@@ -82,8 +89,12 @@ export async function chatCompletion(opts: ChatRequestOptions): Promise<ChatResp
   const choice = json.choices?.[0]?.message ?? {}
   const content = (choice.content ?? '').toString()
   const reasoning = (choice.reasoning_content ?? '').toString()
-  if (content) return { content, model: json.model ?? opts.model, reasoningOnly: false }
-  return { content: reasoning, model: json.model ?? opts.model, reasoningOnly: !!reasoning }
+  return {
+    content,
+    reasoning,
+    model: json.model ?? opts.model,
+    reasoningOnly: !content && !!reasoning,
+  }
 }
 
 /**
@@ -91,12 +102,11 @@ export async function chatCompletion(opts: ChatRequestOptions): Promise<ChatResp
  * calls `onDelta` with the running buffers. Returns the final `ChatResponse`
  * once `[DONE]` arrives (or the stream closes).
  *
- * The stream may interleave `reasoning_content` and `content` deltas. We
- * accumulate both; the final response prefers `content` if non-empty so the
- * UI shows the answer rather than the thought. While streaming, the caller
- * sees both buffers and can choose how to render them (the composer's v1
- * shows reasoning faded while it's the only thing present, then swaps to
- * content once the model starts answering).
+ * The stream may interleave `reasoning_content` and `content` deltas. Both
+ * are accumulated independently and surfaced separately in the result + in
+ * each `onDelta` callback. The chat surface renders reasoning above the
+ * final answer with a collapsible 3-line affordance — there is no folding
+ * step here; this layer just deserialises.
  */
 export async function streamChatCompletion(opts: ChatRequestOptions): Promise<ChatResponse> {
   const res = await fetch(ENDPOINT, {
@@ -142,7 +152,8 @@ export async function streamChatCompletion(opts: ChatRequestOptions): Promise<Ch
       const payload = dataLine.slice(5).trim()
       if (payload === '[DONE]') {
         return {
-          content: content || reasoning,
+          content,
+          reasoning,
           model,
           reasoningOnly: !content && !!reasoning,
         }
@@ -169,7 +180,8 @@ export async function streamChatCompletion(opts: ChatRequestOptions): Promise<Ch
     }
   }
   return {
-    content: content || reasoning,
+    content,
+    reasoning,
     model,
     reasoningOnly: !content && !!reasoning,
   }

--- a/ui/src/dash/chat.jsx
+++ b/ui/src/dash/chat.jsx
@@ -384,7 +384,7 @@ function useChat(slots, persona) {
             ? {
                 ...m,
                 content: final.content,
-                reasoning: final.reasoningOnly ? '' : m.reasoning,
+                reasoning: final.reasoning ?? m.reasoning ?? '',
                 model: final.model,
                 streaming: false,
                 reasoningOnly: final.reasoningOnly,
@@ -436,6 +436,47 @@ function fmtTime(ts) {
   return `${hh}:${mm}:${ss}`
 }
 
+// ─── ReasoningBlock ───
+//
+// Renders the model's chain-of-thought ABOVE the answer in a greyed,
+// 3-line-clamped box with a "thinking ▾ / ▴" toggle.
+//
+// Auto-collapse behaviour (per design brief):
+//   - If reasoning streams in but no answer yet → block is auto-EXPANDED so
+//     the user knows the model is alive.
+//   - Once the answer starts streaming (or finishes) → block auto-COLLAPSES.
+//   - The auto-collapse only fires ONCE per message; if the user toggles
+//     manually after that, their choice sticks even if more deltas land.
+function ReasoningBlock({ text, autoExpand }) {
+  const [expanded, setExpanded] = useStateC(autoExpand)
+  const [userTouched, setUserTouched] = useStateC(false)
+  // Drive auto-collapse from `autoExpand`. While streaming + no answer
+  // yet, `autoExpand` is true → block stays open. When the answer starts
+  // streaming, the parent sets `autoExpand=false` → we auto-collapse,
+  // unless the user already clicked the toggle (their choice wins).
+  useEffectC(() => {
+    if (userTouched) return
+    setExpanded(autoExpand)
+  }, [autoExpand, userTouched])
+  if (!text) return null
+  return (
+    <div className={'bubble-reasoning' + (expanded ? ' open' : '')}>
+      <button
+        type="button"
+        className="toggle mono"
+        aria-expanded={expanded}
+        onClick={() => {
+          setUserTouched(true)
+          setExpanded((v) => !v)
+        }}
+      >
+        thinking {expanded ? '▴' : '▾'}
+      </button>
+      <div className="text">{text}</div>
+    </div>
+  )
+}
+
 function MessageList({ messages }) {
   const scrollRef = useRefC(null)
   useEffectC(() => {
@@ -473,9 +514,16 @@ function MessageList({ messages }) {
             </div>
           )
         }
-        // assistant
-        const showReasoningOnly = !m.content && m.reasoning
-        const bubbleText = m.content || m.reasoning || (m.streaming ? '…' : '')
+        // assistant — reasoning (if any) renders ABOVE the answer, never inline.
+        const hasReasoning = !!(m.reasoning && m.reasoning.length > 0)
+        const hasAnswer = !!(m.content && m.content.length > 0)
+        // Auto-expand reasoning while the model is still thinking (streaming
+        // with no answer yet). Collapse as soon as the answer surface starts
+        // filling, or once the message is no longer streaming.
+        const autoExpand = !!(m.streaming && hasReasoning && !hasAnswer)
+        // Bubble placeholder: dim ellipsis while we wait for any content at
+        // all (no reasoning + no answer yet on a streaming message).
+        const showWaitingDots = m.streaming && !hasAnswer && !hasReasoning
         return (
           <div key={m.ts} className="msg">
             <div className="meta mono">
@@ -485,11 +533,26 @@ function MessageList({ messages }) {
               {m.streaming ? <> · streaming…</> : null}
               {m.aborted ? <> · stopped</> : null}
             </div>
-            <div
-              className="bubble"
-              style={showReasoningOnly ? { opacity: 0.7, fontStyle: 'italic' } : undefined}
-            >
-              {bubbleText}
+            {hasReasoning && (
+              <ReasoningBlock text={m.reasoning} autoExpand={autoExpand} />
+            )}
+            <div className="bubble">
+              {hasAnswer ? (
+                m.content
+              ) : showWaitingDots ? (
+                '…'
+              ) : m.streaming ? (
+                // Streaming + we already have reasoning above but the answer
+                // hasn't started — render a faint blinking caret so the
+                // bubble visibly exists.
+                <span className="bubble-caret" aria-hidden="true">▌</span>
+              ) : m.reasoningOnly ? (
+                <span style={{ color: 'var(--fg-4)', fontStyle: 'italic' }}>
+                  (no final answer — see thinking above)
+                </span>
+              ) : (
+                ''
+              )}
             </div>
           </div>
         )

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -828,6 +828,67 @@ a { color: inherit; text-decoration: none; }
 .msg .meta b { color: var(--accent); font-weight: 500; }
 .msg.user .meta { text-align: right; }
 
+/* ── Reasoning block (thinking pane above the assistant's answer) ─────
+ * Greyed text + 3-line clamp by default. The `.toggle` button flips
+ * `.open` on the wrapper, which removes the clamp. Subtle border-left
+ * accent so it visually demarcates from the answer below without
+ * stealing focus. Color/border tokens are reused, no new palette.
+ */
+.bubble-reasoning {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 12px 9px;
+  margin-bottom: 4px;
+  border-left: 2px solid var(--line-strong);
+  background: rgba(255, 255, 255, 0.015);
+  border-radius: 0 var(--rad-sm) var(--rad-sm) 0;
+  color: var(--fg-4);
+  font-size: 12px;
+  line-height: 1.45;
+}
+.bubble-reasoning .toggle {
+  align-self: flex-start;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-4);
+  cursor: pointer;
+  font-family: var(--jbm);
+}
+.bubble-reasoning .toggle:hover { color: var(--fg-2); }
+.bubble-reasoning .toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+.bubble-reasoning .text {
+  white-space: pre-wrap;
+  color: var(--fg-4);
+  /* 3-line clamp by default; .open removes it. */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.bubble-reasoning.open .text {
+  display: block;
+  -webkit-line-clamp: unset;
+  overflow: visible;
+}
+/* Faint blinking caret for the empty answer bubble while reasoning streams. */
+.bubble-caret {
+  color: var(--fg-4);
+  animation: bubble-caret-blink 1s steps(2, end) infinite;
+}
+@keyframes bubble-caret-blink {
+  to { visibility: hidden; }
+}
+
 /* Tool call block */
 .toolblock {
   align-self: stretch;

--- a/ui/tests/e2e/specs/chat-reasoning.spec.ts
+++ b/ui/tests/e2e/specs/chat-reasoning.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * chat-reasoning — covers the reasoning/answer separation that landed in
+ * feat/chat-thinking-separator.
+ *
+ * Scenarios:
+ *   1. Reasoning block renders when SSE delta.reasoning_content arrives.
+ *   2. Reasoning block does NOT render when the model only emits content.
+ *   3. While reasoning streams but answer is empty, the block is expanded
+ *      (the `.bubble-reasoning.open` class is on). When the answer starts
+ *      streaming, the block auto-collapses back to the 3-line clamp.
+ *   4. The user's manual click on the toggle wins over auto-collapse.
+ *
+ * Each test mounts a stubbed SSE stream for /v1/chat/completions; we don't
+ * exercise lemond directly. The Composer is driven by the existing chat hook
+ * (useChat → streamChatCompletion), so the only thing under test here is
+ * "the right buffers go to the right DOM nodes".
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+// Build an OpenAI-style SSE body from an ordered list of (kind, text) chunks.
+function sseStream(chunks: Array<{ kind: 'content' | 'reasoning'; text: string }>): string {
+  const lines: string[] = []
+  for (const c of chunks) {
+    const delta =
+      c.kind === 'content'
+        ? { content: c.text }
+        : { reasoning_content: c.text }
+    const evt = {
+      id: 'chat-mock',
+      model: 'mock-model',
+      choices: [{ index: 0, delta }],
+    }
+    lines.push(`data: ${JSON.stringify(evt)}\n\n`)
+  }
+  lines.push('data: [DONE]\n\n')
+  return lines.join('')
+}
+
+async function stubChat(page: Parameters<typeof test.extend>[0] extends never ? any : any, body: string) {
+  await page.route('**/v1/chat/completions', async (route: any) => {
+    await route.fulfill({
+      status: 200,
+      headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' },
+      body,
+    })
+  })
+}
+
+// Common: drive the composer with a single user message and wait for the
+// assistant bubble to mount.
+async function sendPrompt(page: any, text: string) {
+  const input = page.locator('.composer-input').first()
+  await expect(input).toBeVisible()
+  await input.fill(text)
+  await input.press('Enter')
+  // Wait for the assistant message row to mount.
+  await expect(page.locator('.msg').filter({ hasText: 'assistant' }).first()).toBeVisible()
+}
+
+test.describe('chat reasoning surface', () => {
+  test('reasoning block renders when reasoning_content arrives', async ({ page }) => {
+    await stubChat(
+      page,
+      sseStream([
+        { kind: 'reasoning', text: 'Step 1: understand the question. ' },
+        { kind: 'reasoning', text: 'Step 2: form the answer.' },
+        { kind: 'content', text: 'The sky is blue because of Rayleigh scattering.' },
+      ]),
+    )
+    await page.goto('/')
+    await sendPrompt(page, 'why is the sky blue?')
+    // Final state: reasoning block is present, contains both reasoning chunks,
+    // and the answer bubble holds the content text.
+    const reasoning = page.locator('.bubble-reasoning')
+    await expect(reasoning).toBeVisible()
+    await expect(reasoning.locator('.text')).toContainText('Step 1')
+    await expect(reasoning.locator('.text')).toContainText('Step 2')
+    // The answer bubble (non-user, non-reasoning) shows the final content.
+    const answerBubble = page
+      .locator('.msg:not(.user) .bubble')
+      .filter({ hasText: 'Rayleigh scattering' })
+    await expect(answerBubble).toBeVisible()
+  })
+
+  test('reasoning block does NOT render when only content arrives', async ({ page }) => {
+    await stubChat(
+      page,
+      sseStream([
+        { kind: 'content', text: 'OK' },
+      ]),
+    )
+    await page.goto('/')
+    await sendPrompt(page, 'reply with the exact word OK')
+    // Answer bubble is present…
+    await expect(
+      page.locator('.msg:not(.user) .bubble').filter({ hasText: 'OK' }),
+    ).toBeVisible()
+    // …but no reasoning block exists for this message.
+    await expect(page.locator('.bubble-reasoning')).toHaveCount(0)
+  })
+
+  test('reasoning collapsed by default after stream completes (3-line clamp on)', async ({
+    page,
+  }) => {
+    // Long reasoning text so the clamp is visible — multiple sentences/lines.
+    const longReasoning =
+      'Line A reasoning. Line B reasoning. Line C reasoning. Line D reasoning. ' +
+      'Line E reasoning. Line F reasoning. Line G reasoning.'
+    await stubChat(
+      page,
+      sseStream([
+        { kind: 'reasoning', text: longReasoning },
+        { kind: 'content', text: 'final answer here' },
+      ]),
+    )
+    await page.goto('/')
+    await sendPrompt(page, 'q')
+    const reasoning = page.locator('.bubble-reasoning')
+    await expect(reasoning).toBeVisible()
+    // After the answer arrived, the block should NOT have the `.open` class
+    // (auto-collapse fired). The toggle should read "thinking ▾".
+    await expect(reasoning).not.toHaveClass(/\bopen\b/)
+    const toggle = reasoning.locator('.toggle')
+    await expect(toggle).toHaveText(/thinking\s+▾/)
+    // CSS-level confirmation: the .text element clamps to 3 lines.
+    await expect(reasoning.locator('.text')).toHaveCSS('-webkit-line-clamp', '3')
+  })
+
+  test('clicking toggle expands the reasoning block (and the choice sticks)', async ({
+    page,
+  }) => {
+    await stubChat(
+      page,
+      sseStream([
+        { kind: 'reasoning', text: 'expand me to see the full thought trace.' },
+        { kind: 'content', text: 'done' },
+      ]),
+    )
+    await page.goto('/')
+    await sendPrompt(page, 'q')
+    const reasoning = page.locator('.bubble-reasoning')
+    await expect(reasoning).toBeVisible()
+    // Starts collapsed (answer already streamed).
+    await expect(reasoning).not.toHaveClass(/\bopen\b/)
+    // Click → expands.
+    await reasoning.locator('.toggle').click()
+    await expect(reasoning).toHaveClass(/\bopen\b/)
+    await expect(reasoning.locator('.toggle')).toHaveText(/thinking\s+▴/)
+    // Click again → collapses.
+    await reasoning.locator('.toggle').click()
+    await expect(reasoning).not.toHaveClass(/\bopen\b/)
+  })
+})


### PR DESCRIPTION
## Summary

Render the model's reasoning (`delta.reasoning_content` from the SSE stream)
as a distinct block **above** the assistant's answer, instead of folding it
into `content` when the answer is empty. Reasoning is greyed (`--fg-4`),
truncated to 3 lines with a `-webkit-line-clamp`, and expandable via a
small `thinking ▾ / ▴` toggle. When the model emits no reasoning, the
block does not render at all.

## Design behaviour (4 scenarios)

1. **Reasoning streams first, answer empty.** The block auto-expands so
   the user knows the model is thinking. Greyed text grows in place.
2. **Answer starts streaming.** The block auto-collapses back to the
   3-line clamp; the answer fills its own bubble in white below.
3. **User clicks the toggle.** Their choice sticks — further auto-collapse
   attempts are ignored for that message.
4. **Model emits no reasoning_content.** No reasoning block renders;
   the answer bubble looks like a normal assistant turn.

## Files touched

- `ui/src/api/hooks/useChatCompletions.ts` — drop the
  `content || reasoning` fold; `ChatResponse` now exposes `content` +
  `reasoning` as separate fields. Streaming `onDelta` already surfaced
  both, but the final response object did not.
- `ui/src/dash/chat.jsx` — new `ReasoningBlock` component (auto-expand
  while streaming + no answer, auto-collapse once answer arrives, user
  click sticks). Wired into `MessageList`; assistant turn renders
  reasoning above the answer bubble.
- `ui/src/dashboard.css` — `.bubble-reasoning` styling (subtle
  `--line-strong` border-left, `--fg-4` greyed text, 3-line clamp by
  default, `.open` removes the clamp). Existing tokens only — no new
  palette.
- `ui/tests/e2e/specs/chat-reasoning.spec.ts` — 4 Playwright specs
  covering each scenario against a stubbed SSE body.

## Live LXC verification

Branch deployed to LXC 105 (10.0.1.142, primary slot `Qwen3.5-0.8B-GGUF`),
then restored to main after capture.

```
ssh hal0 \
  'cd /opt/hal0 && git checkout feat/chat-thinking-separator \
     && cd ui && rm -rf dist node_modules/.vite && npm run build \
     && systemctl restart hal0-api'
```

**Prompt 1 — `Reply with the exact word OK`**

Sent end-to-end against the live primary slot (Qwen3.5 with thinking
enabled). The model produced a ~600-char chain-of-thought followed by
the single word `OK`. Observed:

- Greyed `THINKING ▾` block clamped to 3 lines, showing only the start of
  the thought trace ("Thinking Process: / 1. **Analyze the Request:**…").
- Below: separate white answer bubble containing just `OK`.
- Clicking the toggle flipped to `THINKING ▴` and revealed all four
  numbered steps unbounded.

**Prompt 2 — `Why is the sky blue? Be brief.`**

The longer prompt streams ~30s with substantial reasoning. The collapsed
state captured shows the `sending…` chip + waiting bubble during the
empty-stream phase, as designed (proxy buffers most of the SSE stream so
the deltas land in one burst at the end — this is a backend characteristic,
not a UI issue; the parser handles either pattern).

**Verification commands run**

```
cd /tmp/hal0-chat-thinking/ui
npm run typecheck   # clean
npx playwright test # 53 passed (full suite incl. 4 new specs)
```

**LXC restored to main after verification:**

```
ssh hal0 \
  'cd /opt/hal0 && git checkout main \
     && cd ui && rm -rf dist node_modules/.vite && npm run build \
     && systemctl restart hal0-api'
# systemctl is-active hal0-api → active
```

## Test plan

- [x] Unit/E2E: 4 Playwright specs assert render-when-present,
      no-render-when-absent, 3-line clamp by default, click expands +
      reverts on second click.
- [x] Live LXC end-to-end with the real Qwen3.5 primary slot.
- [x] Full e2e suite green (53 passed / 16 unrelated skipped).
- [x] Typecheck green.
- [x] Clean vite build (no stale CSS chunks).

## Out of scope

- Markdown rendering inside reasoning or answer (deferred).
- Persisting expand state across page reload.
- Per-model `reasoning` enable/disable toggles (backend concern).
- "Copy reasoning" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)