### PR TITLE
fix(models): honor body hf_repo/hf_filename in pull route

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -923,6 +923,89 @@ def _resolve_pull_source(request: Request, model_id: str) -> tuple[str, str]:
     )
 
 
+def _seed_registry_from_body(
+    request: Request,
+    model_id: str,
+    hf_repo: str,
+    hf_file: str,
+    labels: list[str] | None,
+) -> None:
+    """Upsert a registry row for ``model_id`` from body-supplied HF coords.
+
+    The AddByHfModal flow inspects a HF repo, picks a variant, and POSTs
+    the pull with the chosen ``hf_repo`` + ``hf_filename`` in the body
+    against a brand-new id (e.g. ``user.Qwen3.6-27B-MTP``). Seeding the
+    registry here gives ``_resolve_pull_source`` something to look up on
+    retries / reattach, and lets the dashboard's Models view surface the
+    in-flight pull against a real row instead of a phantom id.
+
+    Idempotent: if the row already exists, refresh its HF coordinates
+    so a retry with a different variant against the same id stays
+    intentional (rather than silently re-pulling the old variant).
+    """
+    from hal0.config import paths
+    from hal0.registry.model import Model
+    from hal0.registry.store import ModelAlreadyExists
+
+    registry = request.app.state.model_registry
+    provisional_path = str(paths.models_dir() / model_id / hf_file)
+    caps = [str(c).strip() for c in (labels or []) if str(c).strip()] or ["chat"]
+    try:
+        existing = registry.get(model_id)
+    except Exception:
+        existing = None
+    if existing is not None:
+        # Refresh HF coords so a retry with a different variant lands.
+        with contextlib.suppress(Exception):
+            registry.update(
+                model_id,
+                {"hf_repo": hf_repo, "hf_filename": hf_file},
+            )
+        return
+    entry = Model(
+        id=model_id,
+        name=model_id,
+        path=provisional_path,
+        size_bytes=0,
+        capabilities=caps,
+        hf_repo=hf_repo,
+        hf_filename=hf_file,
+        tags=["user-added"],
+        metadata={"source": "add-by-hf"},
+    )
+    # Race with another caller — the existing row already has coords.
+    with contextlib.suppress(ModelAlreadyExists):
+        registry.add(entry)
+
+
+def _resolve_pull_source_with_body(
+    request: Request,
+    model_id: str,
+    body: dict[str, Any] | None,
+) -> tuple[str, str, bool]:
+    """Resolve (hf_repo, hf_file) with an optional body override.
+
+    Returns ``(repo, file, from_body)`` where ``from_body=True`` means
+    the caller supplied both fields in the request payload — the pull
+    route uses that flag to decide whether to seed a registry row.
+
+    A partial body (only one of the two fields) is ignored to avoid
+    silently mixing a body coord with a stale registry coord; the
+    fallback path raises 422 with the existing message so the caller
+    gets the same hint they would on an empty body.
+    """
+    if isinstance(body, dict):
+        repo_raw = body.get("hf_repo")
+        file_raw = body.get("hf_filename") or body.get("hf_file")
+        if isinstance(repo_raw, str) and isinstance(file_raw, str):
+            repo = repo_raw.strip()
+            file = file_raw.strip()
+            if repo and file:
+                return repo, file, True
+    repo, file = _resolve_pull_source(request, model_id)
+    return repo, file, False
+
+
 async def _run_pull_with_events(
     job: PullJob,
     *,
@@ -1058,6 +1141,22 @@ async def pull_model(
 ) -> dict[str, object]:
     """Start a background HuggingFace pull and return a job handle.
 
+    Body (all fields optional)::
+
+        {
+          "hf_repo": "org/repo",          # add-by-HF-coords override
+          "hf_filename": "model.gguf",    # required iff hf_repo is set
+          "labels": ["chat", "vision"],   # seeded onto the registry row
+        }
+
+    Resolution order:
+      1. Body-supplied ``hf_repo`` + ``hf_filename`` (the Add-by-HF-coords
+         modal path — seeds a registry row for ``model_id`` so the
+         dashboard can show progress against a real entry, then pulls).
+      2. Existing registry row's ``hf_repo`` + ``hf_filename`` (the
+         ``pick-default`` path that ran already).
+      3. The curated catalogue entry for ``model_id``.
+
     Idempotent-ish: if a pull for this model_id is already in
     ``queued``/``running`` state, the existing job's handle is returned
     rather than spawning a duplicate. A completed/failed/cancelled job
@@ -1085,7 +1184,23 @@ async def pull_model(
     if is_flm_tag(model_id):
         return await _start_flm_pull(model_id, request, background, jobs)
 
-    hf_repo, hf_file = _resolve_pull_source(request, model_id)
+    # Body is optional — an empty / non-JSON request is the legacy
+    # "pull by id" path used by the wizard's Pull-against-curated row.
+    body: dict[str, Any] | None = None
+    try:
+        if int(request.headers.get("content-length") or 0) > 0:
+            body = await request.json()
+            if not isinstance(body, dict):
+                body = None
+    except Exception:
+        body = None
+
+    hf_repo, hf_file, from_body = _resolve_pull_source_with_body(request, model_id, body)
+    if from_body:
+        labels = body.get("labels") if isinstance(body, dict) else None
+        if not isinstance(labels, list):
+            labels = None
+        _seed_registry_from_body(request, model_id, hf_repo, hf_file, labels)
     job = make_job(model_id)
     jobs[model_id] = job
 

--- a/tests/api/test_pull_routes.py
+++ b/tests/api/test_pull_routes.py
@@ -98,6 +98,92 @@ def test_pull_unknown_model_returns_invalid_source(
     assert fake_run_pull == []
 
 
+def test_pull_body_hf_coords_used_when_id_not_registered(
+    client_isolated: TestClient,
+    app_isolated: FastAPI,
+    fake_run_pull: list[dict[str, Any]],
+) -> None:
+    """Add-by-HF-coords flow — POST a body with hf_repo + hf_filename and
+    the pull starts even when the id is brand new (not in registry, not
+    curated). A registry row is seeded so the dashboard can show progress
+    against a real entry. Regression for issue: the AddByHfModal sent
+    those fields, the backend ignored them, and a freshly-inspected
+    ``user.<NewName>`` always 422'd.
+    """
+    new_id = "user.Qwen3.6-27B-MTP"
+    r = client_isolated.post(
+        f"/api/models/{new_id}/pull",
+        json={
+            "hf_repo": "unsloth/Qwen3.6-27B-A3B-MTP-GGUF",
+            "hf_filename": "Qwen3.6-27B-A3B-MTP-Q4_K_M.gguf",
+            "labels": ["chat", "tool-calling"],
+        },
+    )
+    assert r.status_code == 202, r.text
+    body = r.json()
+    assert body["model_id"] == new_id
+    assert body["hf_repo"] == "unsloth/Qwen3.6-27B-A3B-MTP-GGUF"
+    assert body["hf_file"] == "Qwen3.6-27B-A3B-MTP-Q4_K_M.gguf"
+    # Registry row seeded so subsequent loads find HF coordinates.
+    entry = app_isolated.state.model_registry.get(new_id)
+    assert entry.hf_repo == "unsloth/Qwen3.6-27B-A3B-MTP-GGUF"
+    assert entry.hf_filename == "Qwen3.6-27B-A3B-MTP-Q4_K_M.gguf"
+    assert "chat" in entry.capabilities
+    # Background task ran with the body-supplied coords.
+    assert len(fake_run_pull) == 1
+    assert fake_run_pull[0]["hf_repo"] == "unsloth/Qwen3.6-27B-A3B-MTP-GGUF"
+
+
+def test_pull_body_hf_coords_override_registry_entry(
+    client_isolated: TestClient,
+    app_isolated: FastAPI,
+    fake_run_pull: list[dict[str, Any]],
+) -> None:
+    """If the body supplies hf_repo + hf_filename, they win over an
+    existing registry row's coords — operator retry of a different
+    variant against the same id stays intentional.
+    """
+    from hal0.registry.model import Model
+
+    app_isolated.state.model_registry.add(
+        Model(
+            id="user.SomeModel",
+            name="user.SomeModel",
+            path="/tmp/stub.gguf",
+            hf_repo="stub/old-repo",
+            hf_filename="old.gguf",
+        )
+    )
+    r = client_isolated.post(
+        "/api/models/user.SomeModel/pull",
+        json={"hf_repo": "stub/new-repo", "hf_filename": "new.gguf"},
+    )
+    assert r.status_code == 202, r.text
+    body = r.json()
+    assert body["hf_repo"] == "stub/new-repo"
+    assert body["hf_file"] == "new.gguf"
+    # Registry row updated to reflect the new pick.
+    entry = app_isolated.state.model_registry.get("user.SomeModel")
+    assert entry.hf_repo == "stub/new-repo"
+    assert entry.hf_filename == "new.gguf"
+
+
+def test_pull_body_partial_hf_coords_falls_back_to_resolver(
+    client_isolated: TestClient, fake_run_pull: list[dict[str, Any]]
+) -> None:
+    """An incomplete body (only hf_repo, no hf_filename) is treated as
+    "no override" and falls back to the registry/curated resolver. A
+    brand-new id still 422s instead of silently using a half-set coord.
+    """
+    r = client_isolated.post(
+        "/api/models/user.Nope/pull",
+        json={"hf_repo": "stub/half-set"},
+    )
+    assert r.status_code == 422
+    assert r.json()["error"]["code"] == "model.invalid_source"
+    assert fake_run_pull == []
+
+
 def test_pull_idempotent_when_already_running(
     client_isolated: TestClient,
     app_isolated: FastAPI,


### PR DESCRIPTION
## Summary

Stops `/api/models/user.<HF-tail>/pull` from 422'ing when the
**Add by HF coords** modal posts a body with `hf_repo` + `hf_filename`.
The route now reads the body, seeds a registry row when both fields
are present, and runs the pull against the body-supplied coords.

User-visible symptom: clicking **Pull** in the Add-by-HF-coords modal
after a successful inspect always failed with
> Pull failed — no hugging face source for model 'user.Qwen3.6-27B-MTP' — set hf_repo + hf_filename on the registry entry or pick a curated model id

…even though the modal *had* sent those fields in the body. The
backend was silently discarding them.

## /diagnose summary

Phase 1–2 (loop + reproduce): `curl -X POST .../pull` against an
empty-body request reproduces the 422 immediately. Live `journalctl -u
hal0-api` showed the failures arriving from a real browser at
`10.0.1.200:*`, paired with a `POST /api/models/inspect 200` from the
same client port seconds earlier — fingerprint of the
**Add-by-HF-coords modal** flow on the Models page.

Phase 3–4 (hypothesise + instrument):

| # | Hypothesis | Test |
|---|---|---|
| 1 | `AddByHfModal` POSTs `{hf_repo, hf_filename, …}` but `pull_model` ignores the body and only checks registry+curated → 422 every time. | `curl -X POST -d '{"hf_repo":"…","hf_filename":"…"}' .../pull` → still 422. Confirmed. |
| 2 | Some background self-call on the API process triggers it (`SlotManager._needs_pull` etc.). | Grepped: `_pull_runner` is never wired in `create_app`. Ruled out. |
| 3 | Static seed in `data.jsx` fabricates `user.X` and a row in the live `/api/models`. | `GET /api/models` returns `{"count": 0}`. Ruled out. |

Trigger: `ui/src/dash/model-modals.jsx:54` — `AddByHfModal.onInspect`
auto-suggests `name = "user." + repoTail.replace(/-GGUF$/i, "")`. On
**Pull** click, `pullJob.start(name, {hf_repo, hf_filename, labels})`
POSTs to `/api/models/<name>/pull` with the body. The backend route
discarded the body entirely.

## The fix

`src/hal0/api/routes/models.py`:

- New `_resolve_pull_source_with_body` — body-supplied
  `hf_repo`+`hf_filename` win; partial bodies (one field only) fall
  back to the existing resolver so we never silently mix a body coord
  with a stale registry row.
- New `_seed_registry_from_body` — upserts a `ns=pulled,
  tags=[user-added], metadata.source=add-by-hf` entry so the Models
  view surfaces the in-flight pull against a real registry row and
  `/status` / reattach work after a refresh.
- `pull_model` parses the body once (best-effort; empty/non-JSON →
  legacy curated path stays untouched), calls the new resolver, and
  seeds the row when `from_body=True`.

Smallest correct fix because:
- the **UI was already correct** (sending the body the modal designer
  intended) — the backend was the gap;
- no UI rebuild needed;
- preserves the legacy `pull_model` shape (empty-body curated-id
  pulls still work identically).

## Verification

Before (live LXC, `/opt/hal0` on `main`):
```
$ curl -sX POST -H 'Content-Type: application/json' \
    -d '{"hf_repo":"unsloth/Qwen3.6-27B-A3B-MTP-GGUF",
         "hf_filename":"Qwen3.6-27B-A3B-MTP-Q4_K_M.gguf",
         "labels":["chat"]}' \
    http://127.0.0.1:8080/api/models/user.Qwen3.6-27B-MTP/pull -w '\n%{http_code}\n'
{"error":{"code":"model.invalid_source", …}}
422
```

After (this branch deployed to LXC):
```
{"id":"ff7858f9a8ee53b8","model_id":"user.Qwen3.6-27B-MTP","state":"queued",
 "hf_repo":"unsloth/Qwen3.6-27B-A3B-MTP-GGUF",
 "hf_file":"Qwen3.6-27B-A3B-MTP-Q4_K_M.gguf"}
202
```

`GET /api/models` afterwards showed the seeded row with the
body-supplied coords intact. The downstream `run_pull` then fails
honestly at the upstream (`401 gated repo, set HF_TOKEN`) — a real
HF-side problem with a real path to recovery, not a fake 422 on our
side.

Regression tests (`tests/api/test_pull_routes.py`):

- `test_pull_body_hf_coords_used_when_id_not_registered` — main repro:
  fresh id + body coords → 202 + seeded registry row.
- `test_pull_body_hf_coords_override_registry_entry` — body wins over
  pre-existing row.
- `test_pull_body_partial_hf_coords_falls_back_to_resolver` — partial
  body still 422s, no silent mix.

Existing 10 pull-route tests + 71-test full models suite + 444-test
`tests/api/ tests/registry/` suite all green. `ruff check` and `ruff
format --check` clean.

Chat against primary unaffected: `Qwen3.5-0.8B-GGUF` slot config
unchanged; the fix only adds a new code path through `pull_model`.

`/opt/hal0` restored to `main`, `hal0-api` restarted, 422 reproducible
again on `main` (confirming the fix lives only on this branch).

## Related triggers noticed but NOT fixed here

These are real, but each is a separate scope:

- **`POST /api/firstrun/install`** returns **405 Method Not Allowed**
  on the live LXC — the FirstRun **Install hal0-Pro** button hits a
  non-existent endpoint. No 422, just a silent fail (UI's
  `installM.mutate` swallows it and advances anyway per the
  `Best-effort backend kick; UI advances regardless` comment). The
  bundle picker today only persists the choice marker via `POST
  /api/bundles/{name}`. Recommend filing a follow-up to either wire
  `/api/firstrun/install` to the bundles surface or remove the
  client-side mutation.

- **`installer/manifests/omni/hal0-pro.json`** and `hal0-max.json`
  still reference placeholder model names (`Qwen3.6-27B-MTP`,
  `Qwen3.6-35B-A3B-MTP`) that don't resolve on HF as-named. The
  bundle apply path today drops `chat.primary` / `chat.coder` rows
  with `reason=no_capability_mapping` (no orchestrator surface) so
  they never become pull requests — harmless until v0.3 wires the
  chat capability. Worth scrubbing or aliasing before that ships.

## Test plan

- [x] `curl -X POST .../pull` with the AddByHfModal body shape → 202
- [x] `curl -X POST .../pull` with empty body → 422 (unchanged behavior)
- [x] `curl -X POST .../pull` with only `hf_repo` → 422 (partial body rejected)
- [x] Registry row seeded with `source=add-by-hf` tag after body-pull
- [x] Cancelled pull cleanly fails; row removable via DELETE
- [x] Existing 444 backend tests still pass
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)