### PR TITLE
feat(models): single [models].store with firstrun + migration

### DIFF
--- a/src/hal0/api/routes/lemonade_admin.py
+++ b/src/hal0/api/routes/lemonade_admin.py
@@ -101,7 +101,34 @@ ADMIN_KEYS: frozenset[str] = IMMEDIATE_KEYS | DEFERRED_KEYS
 # installer writes this path into the seeded config.json and the symlink
 # farm depends on it; flipping it from the admin panel would silently
 # desync the dashboard's model list from what lemond can actually load.
+#
+# v0.3 update: the locked value is now derived from
+# ``[models].store`` (or the legacy ``pull_root`` fallback) via
+# :func:`_locked_extra_models_dir`. The constant below is the
+# installer-default and the test fallback when no hal0.toml exists.
+# Settings → Models is the *one* place to change the store path; the
+# Lemonade admin panel still refuses any divergent value because the
+# whole point of /api/settings/models/store is to keep all consumers in
+# lockstep.
 LOCKED_EXTRA_MODELS_DIR: str = "/var/lib/hal0/models"
+
+
+def _locked_extra_models_dir() -> str:
+    """Return the path Lemonade's ``extra_models_dir`` must equal.
+
+    Resolves from ``[models].effective_store()`` so a user who set the
+    store via Settings → Models is allowed to edit Lemonade's config
+    coherently. Falls back to :data:`LOCKED_EXTRA_MODELS_DIR` when no
+    hal0.toml exists (fresh install / test environment), matching what
+    the installer writes.
+    """
+    try:
+        from hal0.config.loader import load_hal0_config
+
+        cfg = load_hal0_config()
+        return cfg.models.effective_store()
+    except Exception:
+        return LOCKED_EXTRA_MODELS_DIR
 
 
 class LemonadeConfigInvalidError(Hal0Error):
@@ -191,14 +218,22 @@ def _validate_flm_args(value: object) -> str | None:
 
 def _validate_extra_models_dir(value: object) -> str | None:
     """Return an error message if ``extra_models_dir`` would diverge
-    from the symlink farm root, else None."""
+    from the hal0 store root, else None.
+
+    The locked value is derived from ``[models].effective_store()`` —
+    so an operator who set the store via Settings → Models can edit
+    Lemonade's config coherently. To change the store path itself, use
+    POST /api/settings/models/store; that endpoint propagates the new
+    value to Lemonade for you.
+    """
     if not isinstance(value, str):
         return "must be a string"
-    if value != LOCKED_EXTRA_MODELS_DIR:
+    locked = _locked_extra_models_dir()
+    if value != locked:
         return (
-            f"must equal {LOCKED_EXTRA_MODELS_DIR!r} "
-            "(plan §3 + §6.1 — the symlink farm root is the single "
-            "source of truth for the model catalog)"
+            f"must equal {locked!r} "
+            "(the hal0 model store is the single source of truth for the catalog; "
+            "use POST /api/settings/models/store to change the path)"
         )
     return None
 
@@ -278,7 +313,7 @@ async def get_lemonade_config(request: Request) -> dict[str, Any]:
                 "deferred": sorted(DEFERRED_KEYS),
             },
             "locked": {
-                "extra_models_dir": LOCKED_EXTRA_MODELS_DIR,
+                "extra_models_dir": _locked_extra_models_dir(),
             },
         },
     }

--- a/src/hal0/api/routes/settings.py
+++ b/src/hal0/api/routes/settings.py
@@ -24,14 +24,28 @@ Validation failures return the structured error envelope with
 
 from __future__ import annotations
 
+import logging
+import os
+from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Request
 from pydantic import ValidationError
 
-from hal0.api.middleware.error_codes import Hal0Error
+from hal0.api.middleware.error_codes import BadRequest, Hal0Error
 from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import Hal0Config
+from hal0.registry.model_store import (
+    MigrationPlan,
+    build_suggestions,
+    describe_store_state,
+    execute_migration,
+    plan_migration,
+    propagate_lemonade_config,
+    restart_lemonade_service,
+)
+
+log = logging.getLogger(__name__)
 
 # See slots.py for the writer-gate rationale.
 
@@ -175,3 +189,328 @@ async def settings_schema() -> dict[str, Any]:
     ``/api/openapi.json`` advertises but without the FastAPI envelope.
     """
     return Hal0Config.model_json_schema()
+
+
+# ── Model storage (Settings → Models · FirstRun "Storage" step) ────────────
+#
+# ONE setting that all model consumers point at. Replaces PR #313's roots
+# + pull_root with a single ``[models].store`` field; the legacy field is
+# retained for round-trip compat (see ModelsConfig.effective_store).
+#
+# Endpoints:
+#   GET  /api/settings/models/store              — current state + suggestions.
+#   POST /api/settings/models/store              — set + propagate; dry-run by
+#                                                  default when a move is
+#                                                  required. Pass migrate=true
+#                                                  (or hit /migrate) to commit.
+#   POST /api/settings/models/store/migrate      — explicit migrate-then-apply.
+
+
+def _store_state_payload(cfg: Hal0Config) -> dict[str, Any]:
+    """Bundle current store + per-path probe + suggestion chips.
+
+    The UI calls this on mount; firstrun calls it to render its preset
+    chips. Keeping it in one helper means the dry-run POST response
+    embeds the same shape so callers don't fork their render paths.
+    """
+    effective = cfg.models.effective_store()
+    state = describe_store_state(effective)
+    return {
+        "store": cfg.models.store or None,
+        "effective": effective,
+        "fallback_active": not bool(cfg.models.store),
+        "pull_root_legacy": cfg.models.pull_root,
+        "current_state": state.to_dict(),
+        "suggestions": build_suggestions(current=effective),
+    }
+
+
+@router.get("/models/store")
+async def get_model_store(request: Request) -> dict[str, Any]:
+    """Return the model-store setting + suggestions for the UI to render.
+
+    The response carries:
+      * ``store`` — the raw value of ``[models].store`` (``None`` when
+        unset and the legacy ``pull_root`` is being used).
+      * ``effective`` — the path the pull engine + Lemonade actually use.
+      * ``fallback_active`` — True when ``store`` is unset and we're
+        riding the PR-#313 ``pull_root`` for backward compatibility.
+      * ``current_state`` — probe of the effective path (exists / files
+        / size / free).
+      * ``suggestions`` — preset chips for firstrun + settings.
+    """
+    cfg = getattr(request.app.state, "hal0_config", None)
+    if cfg is None:
+        cfg = load_hal0_config()
+        request.app.state.hal0_config = cfg
+    return _store_state_payload(cfg)
+
+
+@router.post("/models/store")
+async def set_model_store(request: Request) -> dict[str, Any]:
+    """Set ``[models].store`` and propagate to every consumer.
+
+    Body::
+
+        {"path": "/mnt/ai-models", "migrate": false}
+
+    Validation:
+      * ``path`` must be a non-empty absolute string. Must exist, be a
+        directory, be readable + writable. Empty string is rejected — to
+        clear the override and fall back to the legacy ``pull_root``,
+        pass the literal ``pull_root`` value.
+      * If the effective store currently has files and they don't yet
+        live at ``path``, a migration is required.
+
+    Behaviour:
+      * **Dry-run** (default, ``migrate=false``): when a move is needed,
+        responds 200 with ``{status: "needs_migration", plan: {...}}``
+        and does NOT touch hal0.toml, Lemonade config, or files. The UI
+        renders a confirmation modal.
+      * **Apply** (``migrate=true`` OR no move needed):
+        1. Move files (if needed) atomically.
+        2. Overwrite ``extra_models_dir`` in Lemonade config.json.
+        3. Restart hal0-lemonade.service if its config changed.
+        4. Persist hal0.toml.
+
+      The order is move-first / persist-last so a failed move leaves
+      the prior config + bytes in place. Lemonade restart is best-
+      effort; failure surfaces in the response but the new value is
+      still persisted (a follow-up ``systemctl restart`` by the
+      operator picks it up).
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise BadRequest("body must be valid JSON", details={"error": str(exc)}) from exc
+    if not isinstance(body, dict):
+        raise BadRequest("body must be a JSON object")
+
+    raw_path = body.get("path")
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise BadRequest(
+            "'path' must be a non-empty absolute path string",
+            code="config.invalid",
+        )
+    path = raw_path.strip()
+    migrate = bool(body.get("migrate", False))
+
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        raise BadRequest(
+            f"store path {path!r} must be absolute",
+            code="config.invalid",
+            details={"path": path},
+        )
+    if not candidate.exists():
+        raise BadRequest(
+            f"store path {path!r} does not exist",
+            code="models.store_missing",
+            details={"path": path},
+        )
+    if not candidate.is_dir():
+        raise BadRequest(
+            f"store path {path!r} is not a directory",
+            code="models.store_not_directory",
+            details={"path": path},
+        )
+    if not os.access(candidate, os.R_OK):
+        raise BadRequest(
+            f"store path {path!r} is not readable",
+            code="models.store_unreadable",
+            details={"path": path},
+        )
+    if not os.access(candidate, os.W_OK):
+        raise BadRequest(
+            f"store path {path!r} is not writable",
+            code="models.store_unwritable",
+            details={"path": path},
+        )
+
+    current = getattr(request.app.state, "hal0_config", None)
+    if current is None:
+        current = load_hal0_config()
+    prev_effective = current.models.effective_store()
+
+    plan = plan_migration(current=prev_effective, target=path)
+
+    # Dry-run: confirm needed-migration before touching anything.
+    if plan.needed and not migrate:
+        return {
+            "status": "needs_migration",
+            "plan": {
+                "source": plan.source,
+                "target": plan.target,
+                "files_count": plan.files_count,
+                "size_bytes": plan.size_bytes,
+                "same_filesystem": plan.same_filesystem,
+            },
+            "state": _store_state_payload(current),
+        }
+
+    return await _apply_store_change(
+        request=request,
+        path=path,
+        current=current,
+        plan=plan,
+    )
+
+
+@router.post("/models/store/migrate")
+async def migrate_model_store(request: Request) -> dict[str, Any]:
+    """Explicit migrate-then-apply endpoint.
+
+    Body::
+
+        {"path": "/new/path"}
+
+    Equivalent to POST ``/models/store`` with ``migrate=true``. Exists
+    as a standalone route so the UI's confirmation modal has a clean
+    URL to fire at after the dry-run round-trip.
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise BadRequest("body must be valid JSON", details={"error": str(exc)}) from exc
+    if not isinstance(body, dict):
+        raise BadRequest("body must be a JSON object")
+    body["migrate"] = True
+    # Replay the body through the regular setter — the JSON parse +
+    # validation surface is single-sourced there.
+    request._json = body  # type: ignore[attr-defined]
+
+    async def _replayed_json() -> Any:
+        return body
+
+    request.json = _replayed_json  # type: ignore[assignment]
+    return await set_model_store(request)
+
+
+async def _apply_store_change(
+    *,
+    request: Request,
+    path: str,
+    current: Hal0Config,
+    plan: MigrationPlan,
+) -> dict[str, Any]:
+    """Move files (if any) → propagate Lemonade config → persist hal0.toml.
+
+    Failure semantics:
+      * Move fails → return 500-style envelope; hal0.toml + Lemonade
+        config untouched.
+      * Lemonade propagate fails → return 500-style envelope; hal0.toml
+        untouched. Files already moved are NOT rolled back — operator
+        can re-run with the new path as both source + target (no-op).
+      * Lemonade restart fails → response surfaces ``restart_failed``
+        but hal0.toml IS persisted (the next manual restart picks up
+        the new value).
+    """
+    migration_result_dict: dict[str, Any] | None = None
+    if plan.needed:
+        try:
+            mig = execute_migration(plan)
+        except OSError as exc:
+            raise Hal0Error(
+                f"migration failed: {exc}",
+                code="models.store_migration_failed",
+                details={
+                    "source": plan.source,
+                    "target": plan.target,
+                    "error": str(exc),
+                },
+            ) from exc
+        if mig.failed and not mig.moved:
+            raise Hal0Error(
+                f"migration moved no files; first failure: {mig.failed[0]}",
+                code="models.store_migration_failed",
+                details={
+                    "source": plan.source,
+                    "target": plan.target,
+                    "failed": mig.failed,
+                },
+            )
+        migration_result_dict = {
+            "source": mig.source,
+            "target": mig.target,
+            "moved": list(mig.moved),
+            "failed": list(mig.failed),
+        }
+
+    # Propagate to Lemonade config.json. A missing file (fresh install
+    # pre-installer) returns ``changed=False, prev=None`` and we skip
+    # the restart — the next install run will seed the right value.
+    try:
+        lemonade_changed, lemonade_prev = propagate_lemonade_config(path)
+    except RuntimeError as exc:
+        raise Hal0Error(
+            f"failed to propagate to Lemonade config: {exc}",
+            code="models.lemonade_propagate_failed",
+            details={"path": path, "error": str(exc)},
+        ) from exc
+    except OSError as exc:
+        raise Hal0Error(
+            f"failed to write Lemonade config: {exc}",
+            code="models.lemonade_propagate_failed",
+            details={"path": path, "error": str(exc)},
+        ) from exc
+
+    # Persist hal0.toml.
+    new_models_raw = dict(current.models.model_dump(mode="python"))
+    new_models_raw["store"] = path
+    try:
+        merged_models = current.models.__class__.model_validate(new_models_raw)
+    except ValidationError as exc:
+        raise ConfigInvalidError(
+            "models config failed schema validation",
+            details=_validation_error_details(exc),
+        ) from exc
+    merged = current.model_copy(update={"models": merged_models})
+    try:
+        save_hal0_config(merged)
+    except OSError as exc:
+        raise Hal0Error(
+            f"could not persist hal0 config: {exc}",
+            details={"error": str(exc), "errno": getattr(exc, "errno", None)},
+        ) from exc
+    request.app.state.hal0_config = merged
+
+    # Restart the lemond unit so it picks up the new extra_models_dir.
+    # Best-effort — surface the outcome in the response.
+    restart_outcome: str = "skipped"
+    if lemonade_changed:
+        rc = await restart_lemonade_service()
+        if rc is True:
+            restart_outcome = "ok"
+        elif rc is False:
+            restart_outcome = "failed"
+        else:
+            restart_outcome = "unavailable"
+
+    event_bus = getattr(request.app.state, "events", None)
+    if event_bus is not None:
+        await event_bus.emit(
+            "system.config_save",
+            "info",
+            "system",
+            f"models.store → {path}",
+            data={
+                "store": path,
+                "lemonade_changed": lemonade_changed,
+                "lemonade_restart": restart_outcome,
+                "migrated_files": len(migration_result_dict["moved"])
+                if migration_result_dict
+                else 0,
+            },
+        )
+
+    return {
+        "status": "ok",
+        "config": _config_to_dict(merged),
+        "state": _store_state_payload(merged),
+        "migration": migration_result_dict,
+        "lemonade": {
+            "changed": lemonade_changed,
+            "previous_extra_models_dir": lemonade_prev,
+            "restart": restart_outcome,
+        },
+    }

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1155,12 +1155,22 @@ class ModelsConfig(BaseModel):
     pull_root: str = Field(
         default_factory=lambda: str(paths.models_dir()),
         description=(
-            "Destination directory for HuggingFace pulls. Must be an absolute path. "
-            "Tempfiles stage under <pull_root>/.tmp/ and finished downloads land at "
-            "<pull_root>/<model_id>/<filename>. ComfyUI assets still route to "
-            "<var_lib>/comfyui/models/<subdir>/. This directory is auto-included "
-            "in the discovery scan so pulled files are immediately visible. "
-            "Default tracks HAL0_HOME for dev installs."
+            "DEPRECATED — superseded by ``[models].store``. Retained so PR #313 "
+            "installs round-trip without a manual edit. When ``store`` is set the "
+            "pull engine and Lemonade ignore this field; clearing ``store`` falls "
+            "back to ``pull_root`` so an operator who hand-edited their TOML pre-store "
+            "still works. Will be removed in a future release."
+        ),
+    )
+    store: str = Field(
+        default="",
+        description=(
+            "Single source of truth for where hal0 reads + writes model files. "
+            "When set (absolute path, e.g. ``/mnt/ai-models``), the pull engine "
+            "writes here AND Lemonade's ``extra_models_dir`` is propagated to "
+            "the same path on save (with a hal0-lemonade.service restart). "
+            "Empty falls back to ``pull_root`` for PR-#313 compatibility, "
+            "which itself defaults to ``paths.models_dir()``."
         ),
     )
 
@@ -1187,6 +1197,31 @@ class ModelsConfig(BaseModel):
         if not Path(s).is_absolute():
             raise ValueError(f"models.pull_root {s!r} must be an absolute path")
         return s
+
+    @field_validator("store")
+    @classmethod
+    def store_is_absolute_when_set(cls, v: str) -> str:
+        """Empty means "use pull_root"; non-empty must be absolute."""
+        s = str(v or "").strip()
+        if not s:
+            return ""
+        if not Path(s).is_absolute():
+            raise ValueError(
+                f"models.store {s!r} must be an absolute path (or empty to use pull_root fallback)"
+            )
+        return s
+
+    def effective_store(self) -> str:
+        """Return the resolved model-store path consumers should point at.
+
+        Precedence: ``store`` (the new single-source-of-truth field) wins
+        when set; otherwise we fall back to the deprecated ``pull_root``
+        so PR-#313 installs keep working without an edit. Both already
+        validate as absolute paths.
+        """
+        if self.store:
+            return self.store
+        return self.pull_root
 
 
 class Hal0Config(BaseModel):

--- a/src/hal0/registry/model_store.py
+++ b/src/hal0/registry/model_store.py
@@ -1,0 +1,435 @@
+"""Single-path model store — propagation + migration + suggestions.
+
+The ``[models].store`` setting in hal0.toml is the one source of truth
+for where hal0 reads and writes model files. This module turns that
+abstract setting into concrete on-disk effects:
+
+* :func:`describe_store_state` — probe one path for existence /
+  writability / contents (file count, byte size, free space). Used by
+  the GET endpoint and the dry-run path of the set endpoint.
+* :func:`build_suggestions` — return a small list of common storage
+  locations the firstrun + settings UIs render as preset chips, each
+  with its current state probe.
+* :func:`plan_migration` — compare the current effective store against
+  a candidate target and return either ``MigrationPlan(needed=False, …)``
+  (no move required) or ``MigrationPlan(needed=True, files_count, …)``.
+* :func:`execute_migration` — move files from old → new with cross-fs
+  fallback. Failure leaves both paths intact (no partial state).
+* :func:`propagate_lemonade_config` — atomically overwrite
+  ``extra_models_dir`` inside ``/var/lib/hal0/lemonade/config.json`` and
+  return whether the value actually changed (caller decides whether to
+  restart the service).
+* :func:`restart_lemonade_service` — best-effort ``systemctl restart
+  hal0-lemonade.service``. Returns True/False/None (None when systemd
+  isn't available, e.g. tests / containers).
+
+All on-disk writes go through :func:`hal0.config.loader.write_toml_atomic`'s
+tempfile + fsync + rename pattern so a crash mid-write never leaves a
+half-written file on disk.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from hal0.config import paths
+
+log = logging.getLogger(__name__)
+
+
+# Lemonade's own config.json file lives under /var/lib/hal0/lemonade
+# and is owned by the ``hal0`` system user (per installer/install.sh).
+# We use the same path resolution so HAL0_HOME-rooted dev installs
+# write under their tree, not /var/lib/hal0.
+def _lemonade_config_path() -> Path:
+    return paths.var_lib() / "lemonade" / "config.json"
+
+
+# ── Probe one path ────────────────────────────────────────────────────────
+
+
+@dataclass
+class StoreStateProbe:
+    """Snapshot of one filesystem path's suitability as a model store."""
+
+    path: str
+    exists: bool
+    is_dir: bool
+    readable: bool
+    writable: bool
+    files_count: int
+    size_bytes: int
+    free_bytes: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "exists": self.exists,
+            "is_dir": self.is_dir,
+            "readable": self.readable,
+            "writable": self.writable,
+            "files_count": self.files_count,
+            "size_bytes": self.size_bytes,
+            "free_bytes": self.free_bytes,
+        }
+
+
+def describe_store_state(path: str | Path) -> StoreStateProbe:
+    """Inspect ``path`` and return a :class:`StoreStateProbe` snapshot.
+
+    Probes are non-throwing — missing paths / unreadable directories
+    return zero counts with the corresponding boolean flag cleared so
+    the UI can render a coherent "this candidate is bad because X" line
+    without the caller fanning out into per-error branches.
+    """
+    p = Path(path)
+    state = StoreStateProbe(
+        path=str(p),
+        exists=False,
+        is_dir=False,
+        readable=False,
+        writable=False,
+        files_count=0,
+        size_bytes=0,
+        free_bytes=0,
+    )
+    try:
+        state.exists = p.exists()
+    except OSError:
+        return state
+    if not state.exists:
+        # Free space still reports against the deepest existing ancestor
+        # so the UI can render "if you create this dir, you'll have N
+        # bytes free here" without a separate call.
+        anc = p
+        while anc != anc.parent and not anc.exists():
+            anc = anc.parent
+        if anc.exists():
+            with contextlib.suppress(OSError):
+                state.free_bytes = shutil.disk_usage(anc).free
+        return state
+    state.is_dir = p.is_dir()
+    state.readable = os.access(p, os.R_OK)
+    state.writable = os.access(p, os.W_OK)
+    if state.is_dir:
+        files, size = _walk_size(p)
+        state.files_count = files
+        state.size_bytes = size
+        with contextlib.suppress(OSError):
+            state.free_bytes = shutil.disk_usage(p).free
+    return state
+
+
+def _walk_size(p: Path) -> tuple[int, int]:
+    """Recursively sum file count + bytes under ``p``."""
+    files = 0
+    size = 0
+    try:
+        for child in p.rglob("*"):
+            try:
+                if child.is_file():
+                    files += 1
+                    size += child.stat().st_size
+            except OSError:
+                continue
+    except OSError:
+        return files, size
+    return files, size
+
+
+# ── Suggestions ──────────────────────────────────────────────────────────
+
+
+def build_suggestions(current: str | None = None) -> list[dict[str, Any]]:
+    """Return a small list of candidate storage paths the UI can chip.
+
+    Each entry is the path itself plus its current probe state so the UI
+    can label chips with "exists · 4 models · 12 GB" or "empty · 412 GB
+    free" without an extra round-trip per chip.
+
+    Order is deliberately curated for the firstrun UX:
+      1. ``/mnt/ai-models`` — the conventional external NFS / fast-disk
+         mount most hal0 deployments target.
+      2. ``paths.models_dir()`` — hal0's FHS default (per-install).
+      3. ``~/.local/share/hal0/models`` — XDG-style per-user fallback
+         when running as a non-root user.
+      4. ``current`` — the currently-active store (if any), so the UI
+         can show it as a "stay where you are" option even if it's not
+         in the above list.
+    Duplicates are dropped while preserving the first occurrence.
+    """
+    raw: list[str] = ["/mnt/ai-models", str(paths.models_dir())]
+    # XDG-style per-user dir is meaningful when HOME exists.
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        raw.append(str(Path(home) / ".local" / "share" / "hal0" / "models"))
+    if current:
+        raw.append(current)
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+    for path in raw:
+        if path in seen:
+            continue
+        seen.add(path)
+        state = describe_store_state(path)
+        out.append(
+            {
+                "path": path,
+                "is_current": current == path,
+                **state.to_dict(),
+            }
+        )
+    return out
+
+
+# ── Migration plan ──────────────────────────────────────────────────────
+
+
+@dataclass
+class MigrationPlan:
+    """Result of comparing the current effective store to a target path.
+
+    When ``needed`` is False, callers can propagate + persist directly.
+    When ``needed`` is True, the caller renders a confirmation surface
+    and resubmits with ``migrate=True`` to actually move the bytes.
+    """
+
+    needed: bool
+    source: str | None
+    target: str
+    files_count: int = 0
+    size_bytes: int = 0
+    same_filesystem: bool = False
+    reason: str = ""
+
+
+def plan_migration(*, current: str | None, target: str) -> MigrationPlan:
+    """Compute whether moving from ``current`` to ``target`` requires data move.
+
+    A migration is **needed** when:
+
+      * ``current`` is set and resolves to a different path than ``target``, AND
+      * ``current`` exists with at least one regular file under it.
+
+    A migration is **not** needed when:
+
+      * ``current`` is None / unset (nothing to move from).
+      * ``current == target`` (no-op).
+      * ``current`` exists but is empty.
+      * ``current`` does not exist.
+    """
+    if not current:
+        return MigrationPlan(needed=False, source=None, target=target, reason="no_prior_store")
+    src = Path(current)
+    dst = Path(target)
+    try:
+        if src.resolve() == dst.resolve():
+            return MigrationPlan(needed=False, source=str(src), target=target, reason="same_path")
+    except OSError:
+        if str(src) == str(dst):
+            return MigrationPlan(needed=False, source=str(src), target=target, reason="same_path")
+    if not src.exists():
+        return MigrationPlan(needed=False, source=str(src), target=target, reason="source_missing")
+    files, size = _walk_size(src)
+    if files == 0:
+        return MigrationPlan(needed=False, source=str(src), target=target, reason="source_empty")
+    same_fs = False
+    with contextlib.suppress(OSError):
+        same_fs = src.stat().st_dev == (
+            dst.stat().st_dev if dst.exists() else dst.parent.stat().st_dev
+        )
+    return MigrationPlan(
+        needed=True,
+        source=str(src),
+        target=target,
+        files_count=files,
+        size_bytes=size,
+        same_filesystem=same_fs,
+        reason="has_data",
+    )
+
+
+# ── Migration apply ──────────────────────────────────────────────────────
+
+
+@dataclass
+class MigrationResult:
+    """Outcome of :func:`execute_migration` — surfaces moved entries +
+    any per-entry failures so the API can render an actionable response."""
+
+    source: str
+    target: str
+    moved: list[str] = field(default_factory=list)
+    failed: list[dict[str, str]] = field(default_factory=list)
+
+
+def execute_migration(plan: MigrationPlan) -> MigrationResult:
+    """Move every top-level child of ``plan.source`` into ``plan.target``.
+
+    On a per-entry failure we record the offender in ``failed`` and
+    continue with the rest — surfacing the whole picture lets the UI
+    decide whether to retry just the bad entries or back out wholesale.
+    Failures DO NOT remove the source entry; the operator can re-run
+    after fixing whatever blocked the move (permissions, disk full).
+
+    Uses :func:`shutil.move` which prefers ``os.rename`` for same-FS
+    moves and falls back to recursive copy + remove for cross-FS. We
+    don't pre-flight free-space because cross-FS moves can fail
+    half-way regardless; we just bail loudly when the copy fails and
+    leave the source intact.
+    """
+    if not plan.needed:
+        return MigrationResult(source=plan.source or "", target=plan.target, moved=[], failed=[])
+
+    src = Path(plan.source or "")
+    dst = Path(plan.target)
+    dst.mkdir(parents=True, exist_ok=True)
+    result = MigrationResult(source=str(src), target=str(dst))
+
+    for entry in sorted(src.iterdir()):
+        # Skip dot-entries — they're hal0 internals (``.tmp`` staging,
+        # registry sqlite WAL, etc.) and never user-visible models.
+        if entry.name.startswith("."):
+            continue
+        dest_path = dst / entry.name
+        if dest_path.exists():
+            result.failed.append(
+                {
+                    "name": entry.name,
+                    "reason": "target_exists",
+                    "target": str(dest_path),
+                }
+            )
+            continue
+        try:
+            shutil.move(str(entry), str(dest_path))
+            result.moved.append(entry.name)
+        except OSError as exc:
+            result.failed.append({"name": entry.name, "reason": str(exc)})
+            log.warning(
+                "model_store.migrate_failed",
+                extra={"name": entry.name, "src": str(entry), "error": str(exc)},
+            )
+
+    return result
+
+
+# ── Lemonade config propagation ──────────────────────────────────────────
+
+
+def propagate_lemonade_config(new_store: str) -> tuple[bool, str | None]:
+    """Atomically rewrite Lemonade's ``extra_models_dir``.
+
+    Returns ``(changed, previous_value)``:
+      * ``changed=True``  — ``extra_models_dir`` was updated on disk and
+        the lemond daemon needs a restart for the new value to take
+        effect at load time.
+      * ``changed=False`` — config either matched already or doesn't
+        exist (fresh install before the lemonade installer ran). The
+        caller should treat both as "no-op" and skip the restart.
+    """
+    config_path = _lemonade_config_path()
+    if not config_path.exists():
+        # The installer hasn't seeded the lemonade config yet (HAL0_HOME
+        # dev install pre-bootstrap, or a fresh container). Nothing to
+        # propagate; the next install run will pick up our new value.
+        return False, None
+    try:
+        with open(config_path, "rb") as f:
+            current = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"could not read lemonade config at {config_path}: {exc}") from exc
+
+    prev = current.get("extra_models_dir")
+    if prev == new_store:
+        return False, prev if isinstance(prev, str) else None
+
+    current["extra_models_dir"] = new_store
+
+    # Atomic write: tempfile in the same directory + fsync + os.replace.
+    # Matches the pattern in hal0.config.loader.write_toml_atomic so the
+    # invariant ("lemond never parses a half-written config.json") is
+    # uniform across hal0.
+    tmp_path: Path | None = None
+    try:
+        fd, tmp_str = tempfile.mkstemp(
+            prefix=f".{config_path.name}.",
+            suffix=".tmp",
+            dir=config_path.parent,
+        )
+        tmp_path = Path(tmp_str)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(current, f, indent=2, sort_keys=True)
+                f.write("\n")
+                f.flush()
+                os.fsync(f.fileno())
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise
+        os.replace(tmp_path, config_path)
+        tmp_path = None
+    finally:
+        if tmp_path is not None:
+            with contextlib.suppress(OSError):
+                tmp_path.unlink(missing_ok=True)
+
+    return True, prev if isinstance(prev, str) else None
+
+
+# ── Lemonade service restart ─────────────────────────────────────────────
+
+
+async def restart_lemonade_service() -> bool | None:
+    """Best-effort ``systemctl restart hal0-lemonade.service``.
+
+    Returns:
+      * True  — systemctl exited 0.
+      * False — systemctl exited non-zero (caller may want to surface
+        the user-visible "restart failed" toast).
+      * None  — systemctl unavailable (HAL0_HOME dev install, container
+        without systemd, CI). The caller treats this as "nothing to
+        restart" rather than a failure.
+    """
+    if os.environ.get("HAL0_HOME"):
+        # Dev install — no real systemd to talk to. Treat as no-op.
+        return None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "systemctl",
+            "restart",
+            "hal0-lemonade.service",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except (FileNotFoundError, PermissionError, OSError):
+        return None
+    try:
+        rc = await asyncio.wait_for(proc.wait(), timeout=15.0)
+    except TimeoutError:
+        proc.kill()
+        return False
+    return rc == 0
+
+
+__all__ = [
+    "MigrationPlan",
+    "MigrationResult",
+    "StoreStateProbe",
+    "build_suggestions",
+    "describe_store_state",
+    "execute_migration",
+    "plan_migration",
+    "propagate_lemonade_config",
+    "restart_lemonade_service",
+]

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -150,16 +150,18 @@ def _sanitise_id(model_id: str) -> str:
 def _pull_root() -> Path:
     """Return the configured pull destination root.
 
-    Reads [models].pull_root from hal0.toml on each call so a Settings
-    save takes effect without an API restart. Falls back to
-    paths.models_dir() (the FHS default) if config load fails — keeps
-    pulls working during bootstrap before the config exists.
+    Reads ``[models].store`` (the v0.3 single-source-of-truth setting)
+    from hal0.toml on each call so a Settings save takes effect without
+    an API restart. Falls back to the legacy ``[models].pull_root`` when
+    ``store`` is empty (PR-#313 compatibility), and to
+    :func:`paths.models_dir` if config load fails — keeps pulls working
+    during bootstrap before the config exists.
     """
     try:
         from hal0.config.loader import load_hal0_config
 
         cfg = load_hal0_config()
-        return Path(cfg.models.pull_root)
+        return Path(cfg.models.effective_store())
     except Exception:
         return paths.models_dir()
 

--- a/tests/api/test_lemonade_admin_route.py
+++ b/tests/api/test_lemonade_admin_route.py
@@ -167,10 +167,20 @@ def test_get_config_attaches_locked_invariants(
     installed_lemonade_stub: dict[str, Any],
 ) -> None:
     """``_hal0.locked`` carries the canonical extra_models_dir pointer
-    so the UI's inline hint stays in sync with the backend validator."""
+    so the UI's inline hint stays in sync with the backend validator.
+
+    v0.3: the locked value is derived from
+    ``[models].effective_store()`` so an operator who sets the store via
+    POST /api/settings/models/store sees the admin panel hint follow.
+    Under tmp_hal0_home the effective value is the HAL0_HOME-rooted
+    models_dir; production installs without ``[models].store`` see the
+    legacy ``/var/lib/hal0/models`` literal.
+    """
+    from hal0.api.routes.lemonade_admin import _locked_extra_models_dir
+
     r = isolated_client.get("/api/lemonade/config")
     body = r.json()
-    assert body["_hal0"]["locked"]["extra_models_dir"] == LOCKED_EXTRA_MODELS_DIR
+    assert body["_hal0"]["locked"]["extra_models_dir"] == _locked_extra_models_dir()
 
 
 def test_immediate_and_deferred_partitions_are_disjoint() -> None:
@@ -399,16 +409,19 @@ def test_post_config_rejects_extra_models_dir_divergence(
     isolated_client: TestClient,
     installed_lemonade_stub: dict[str, Any],
 ) -> None:
-    """Flipping extra_models_dir off the symlink farm root would silently
-    desync the dashboard's catalog from what lemond can load (plan §3 +
-    §6.1). Refuse with the canonical path in the error message."""
+    """Flipping extra_models_dir off the hal0 store root would silently
+    desync the dashboard's catalog from what lemond can load. Refuse with
+    the canonical (currently-effective) path in the error message. To
+    change the path, use POST /api/settings/models/store."""
+    from hal0.api.routes.lemonade_admin import _locked_extra_models_dir
+
     r = isolated_client.post(
         "/api/lemonade/config",
-        json={"extra_models_dir": "/mnt/ai-models"},
+        json={"extra_models_dir": "/some/other/absolute/path"},
     )
     assert r.status_code == 400, r.text
     details = r.json()["error"]["details"]
-    assert LOCKED_EXTRA_MODELS_DIR in details["extra_models_dir"]
+    assert _locked_extra_models_dir() in details["extra_models_dir"]
 
 
 def test_post_config_accepts_canonical_extra_models_dir(
@@ -418,9 +431,11 @@ def test_post_config_accepts_canonical_extra_models_dir(
     """Setting extra_models_dir to its locked value is a no-op pass —
     operators rotating the config should not hit a 400 just because
     they re-sent the canonical value."""
+    from hal0.api.routes.lemonade_admin import _locked_extra_models_dir
+
     r = isolated_client.post(
         "/api/lemonade/config",
-        json={"extra_models_dir": LOCKED_EXTRA_MODELS_DIR},
+        json={"extra_models_dir": _locked_extra_models_dir()},
     )
     assert r.status_code == 200, r.text
 

--- a/tests/api/test_settings_models_store.py
+++ b/tests/api/test_settings_models_store.py
@@ -1,0 +1,269 @@
+"""Tests for /api/settings/models/store (single-source-of-truth field).
+
+Exercises:
+  * GET returns suggestions + current state + effective fallback.
+  * POST happy path with no prior data → sets hal0.toml + lemonade config.
+  * POST dry-run when prior path has data → returns ``needs_migration``.
+  * POST migrate=true → moves files, propagates, persists, surfaces result.
+  * Validation: relative path, missing, file-not-dir, non-writable.
+  * Round-trip: getter reflects effective fallback when only legacy
+    pull_root is set (PR-#313 compat).
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.config import paths as cfg_paths
+
+
+@pytest.fixture
+def isolated_client(tmp_hal0_home: str) -> Iterator[TestClient]:
+    app: FastAPI = create_app()
+    with TestClient(app) as c:
+        yield c
+
+
+def _seed_lemonade_config(tmp_hal0_home: str, value: str) -> Path:
+    cfg = cfg_paths.var_lib() / "lemonade" / "config.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        json.dumps({"extra_models_dir": value, "port": 13305}),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+def test_get_store_returns_suggestions_and_effective_fallback(
+    isolated_client: TestClient, tmp_hal0_home: str
+) -> None:
+    r = isolated_client.get("/api/settings/models/store")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # No store set on a fresh install — fallback to pull_root (the
+    # HAL0_HOME-rooted models_dir for tests).
+    assert body["store"] is None
+    assert body["fallback_active"] is True
+    assert body["effective"] == str(cfg_paths.models_dir())
+    assert isinstance(body["suggestions"], list)
+    assert any(s["path"] == "/mnt/ai-models" for s in body["suggestions"])
+
+
+def test_set_store_happy_path_no_prior_data(
+    isolated_client: TestClient, tmp_hal0_home: str, tmp_path: Path
+) -> None:
+    target = tmp_path / "new-store"
+    target.mkdir()
+    _seed_lemonade_config(tmp_hal0_home, "/var/lib/hal0/models")
+
+    r = isolated_client.post(
+        "/api/settings/models/store",
+        json={"path": str(target)},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["config"]["models"]["store"] == str(target)
+    assert body["state"]["effective"] == str(target)
+    # No migration needed → migration block is None.
+    assert body["migration"] is None
+    # Lemonade config was updated.
+    assert body["lemonade"]["changed"] is True
+    assert body["lemonade"]["previous_extra_models_dir"] == "/var/lib/hal0/models"
+    # In tests HAL0_HOME is set → restart_lemonade_service returns None
+    # → response surfaces "unavailable".
+    assert body["lemonade"]["restart"] == "unavailable"
+
+    # hal0.toml persisted.
+    toml_path = cfg_paths.hal0_toml()
+    parsed = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    assert parsed["models"]["store"] == str(target)
+
+    # Lemonade config.json on disk now points at the new path.
+    lemonade_cfg = json.loads(
+        (cfg_paths.var_lib() / "lemonade" / "config.json").read_text(encoding="utf-8")
+    )
+    assert lemonade_cfg["extra_models_dir"] == str(target)
+
+
+def test_set_store_dry_run_when_prior_path_has_data(
+    isolated_client: TestClient, tmp_hal0_home: str, tmp_path: Path
+) -> None:
+    # Seed the default location with a fake model.
+    default_store = cfg_paths.models_dir()
+    default_store.mkdir(parents=True, exist_ok=True)
+    (default_store / "Model").mkdir()
+    (default_store / "Model" / "x.gguf").write_bytes(b"x" * 1024)
+
+    target = tmp_path / "new-store"
+    target.mkdir()
+
+    r = isolated_client.post(
+        "/api/settings/models/store",
+        json={"path": str(target)},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "needs_migration"
+    assert body["plan"]["files_count"] == 1
+    assert body["plan"]["size_bytes"] == 1024
+    assert body["plan"]["source"] == str(default_store)
+    assert body["plan"]["target"] == str(target)
+
+    # Nothing should have moved or been persisted.
+    assert (default_store / "Model" / "x.gguf").exists()
+    assert not (target / "Model").exists()
+    toml_path = cfg_paths.hal0_toml()
+    if toml_path.exists():
+        parsed = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+        assert parsed.get("models", {}).get("store", "") == ""
+
+
+def test_set_store_migrate_true_moves_files(
+    isolated_client: TestClient, tmp_hal0_home: str, tmp_path: Path
+) -> None:
+    default_store = cfg_paths.models_dir()
+    default_store.mkdir(parents=True, exist_ok=True)
+    (default_store / "Model").mkdir()
+    (default_store / "Model" / "x.gguf").write_bytes(b"x" * 1024)
+    _seed_lemonade_config(tmp_hal0_home, str(default_store))
+
+    target = tmp_path / "new-store"
+    target.mkdir()
+
+    r = isolated_client.post(
+        "/api/settings/models/store",
+        json={"path": str(target), "migrate": True},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["migration"]["moved"] == ["Model"]
+    assert body["migration"]["failed"] == []
+    # File now lives in the new store, gone from the old.
+    assert (target / "Model" / "x.gguf").read_bytes() == b"x" * 1024
+    assert not (default_store / "Model").exists()
+
+
+def test_migrate_endpoint_runs_move(
+    isolated_client: TestClient, tmp_hal0_home: str, tmp_path: Path
+) -> None:
+    default_store = cfg_paths.models_dir()
+    default_store.mkdir(parents=True, exist_ok=True)
+    (default_store / "M").mkdir()
+    (default_store / "M" / "x.gguf").write_bytes(b"x" * 10)
+
+    target = tmp_path / "new"
+    target.mkdir()
+
+    r = isolated_client.post(
+        "/api/settings/models/store/migrate",
+        json={"path": str(target)},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["migration"]["moved"] == ["M"]
+
+
+def test_set_store_rejects_relative_path(isolated_client: TestClient) -> None:
+    r = isolated_client.post(
+        "/api/settings/models/store",
+        json={"path": "relative/path"},
+    )
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "config.invalid"
+
+
+def test_set_store_rejects_missing_path(isolated_client: TestClient) -> None:
+    r = isolated_client.post(
+        "/api/settings/models/store",
+        json={"path": "/definitely/missing/zzz-12345"},
+    )
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "models.store_missing"
+
+
+def test_set_store_rejects_file_not_directory(isolated_client: TestClient, tmp_path: Path) -> None:
+    blob = tmp_path / "blob"
+    blob.write_text("hi")
+    r = isolated_client.post(
+        "/api/settings/models/store",
+        json={"path": str(blob)},
+    )
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "models.store_not_directory"
+
+
+def test_set_store_rejects_non_writable_path(isolated_client: TestClient, tmp_path: Path) -> None:
+    ro = tmp_path / "readonly"
+    ro.mkdir()
+    ro.chmod(0o555)
+    try:
+        r = isolated_client.post(
+            "/api/settings/models/store",
+            json={"path": str(ro)},
+        )
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] in (
+            "models.store_unwritable",
+            "models.store_unreadable",
+        )
+    finally:
+        ro.chmod(0o755)
+
+
+def test_set_store_rejects_empty_path(isolated_client: TestClient) -> None:
+    r = isolated_client.post(
+        "/api/settings/models/store",
+        json={"path": ""},
+    )
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "config.invalid"
+
+
+def test_set_store_idempotent_when_path_unchanged(
+    isolated_client: TestClient, tmp_hal0_home: str, tmp_path: Path
+) -> None:
+    target = tmp_path / "store"
+    target.mkdir()
+    r1 = isolated_client.post(
+        "/api/settings/models/store",
+        json={"path": str(target)},
+    )
+    assert r1.status_code == 200
+    r2 = isolated_client.post(
+        "/api/settings/models/store",
+        json={"path": str(target)},
+    )
+    assert r2.status_code == 200
+    body = r2.json()
+    assert body["status"] == "ok"
+    # No move + lemonade already updated → changed=False on second hit.
+    assert body["migration"] is None
+
+
+def test_lemonade_admin_locked_value_follows_store(
+    isolated_client: TestClient, tmp_hal0_home: str, tmp_path: Path
+) -> None:
+    """The Lemonade admin endpoint's locked value should track effective_store."""
+    from hal0.api.routes.lemonade_admin import _locked_extra_models_dir
+
+    target = tmp_path / "new-store"
+    target.mkdir()
+
+    isolated_client.post(
+        "/api/settings/models/store",
+        json={"path": str(target)},
+    )
+    # The locked value the admin validator now refuses to diverge from
+    # is the new store path.
+    assert _locked_extra_models_dir() == str(target)

--- a/tests/registry/test_model_store.py
+++ b/tests/registry/test_model_store.py
@@ -1,0 +1,258 @@
+"""Unit tests for the model_store service module.
+
+Covers:
+  * describe_store_state — present/missing dirs, files vs dirs, free-bytes
+    against deepest existing ancestor when target is missing.
+  * build_suggestions — order, deduplication, current-path surfacing.
+  * plan_migration — needed when source has data + paths differ; not
+    needed for no-prior / same-path / empty / missing.
+  * execute_migration — moves entries, skips dot-entries, records
+    per-entry failures without aborting the whole migration.
+  * propagate_lemonade_config — atomic write, no-op when value matches,
+    no-op when config.json missing, prior value surfaced.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hal0.config import paths as cfg_paths
+from hal0.registry.model_store import (
+    build_suggestions,
+    describe_store_state,
+    execute_migration,
+    plan_migration,
+    propagate_lemonade_config,
+)
+
+# ── describe_store_state ──────────────────────────────────────────────────
+
+
+def test_describe_state_for_missing_path_surfaces_ancestor_free(tmp_path: Path) -> None:
+    target = tmp_path / "deeply" / "nested" / "missing"
+    state = describe_store_state(target)
+    assert state.exists is False
+    assert state.is_dir is False
+    assert state.writable is False
+    assert state.files_count == 0
+    # Free bytes computed against tmp_path's mount, which always exists.
+    assert state.free_bytes > 0
+
+
+def test_describe_state_for_directory_with_files(tmp_path: Path) -> None:
+    p = tmp_path / "store"
+    p.mkdir()
+    (p / "a.gguf").write_bytes(b"x" * 100)
+    (p / "b.gguf").write_bytes(b"y" * 200)
+    state = describe_store_state(p)
+    assert state.exists is True
+    assert state.is_dir is True
+    assert state.writable is True
+    assert state.files_count == 2
+    assert state.size_bytes == 300
+
+
+def test_describe_state_for_file_not_a_dir(tmp_path: Path) -> None:
+    f = tmp_path / "blob"
+    f.write_text("hi")
+    state = describe_store_state(f)
+    assert state.exists is True
+    assert state.is_dir is False
+    # files_count + size_bytes stay at zero because we only walk dirs.
+    assert state.files_count == 0
+
+
+# ── build_suggestions ────────────────────────────────────────────────────
+
+
+def test_suggestions_includes_canonical_defaults(tmp_hal0_home: str) -> None:
+    sug = build_suggestions()
+    paths = [s["path"] for s in sug]
+    assert "/mnt/ai-models" in paths
+    assert str(cfg_paths.models_dir()) in paths
+
+
+def test_suggestions_marks_current(tmp_hal0_home: str) -> None:
+    current = str(cfg_paths.models_dir())
+    sug = build_suggestions(current=current)
+    matching = [s for s in sug if s["path"] == current]
+    assert matching
+    assert matching[0]["is_current"] is True
+
+
+def test_suggestions_dedupes_when_current_matches_default(tmp_hal0_home: str) -> None:
+    current = str(cfg_paths.models_dir())
+    sug = build_suggestions(current=current)
+    paths = [s["path"] for s in sug]
+    assert paths.count(current) == 1
+
+
+# ── plan_migration ───────────────────────────────────────────────────────
+
+
+def test_plan_no_migration_when_current_unset(tmp_path: Path) -> None:
+    plan = plan_migration(current=None, target=str(tmp_path / "new"))
+    assert plan.needed is False
+    assert plan.reason == "no_prior_store"
+
+
+def test_plan_no_migration_when_paths_match(tmp_path: Path) -> None:
+    target = tmp_path / "shared"
+    target.mkdir()
+    plan = plan_migration(current=str(target), target=str(target))
+    assert plan.needed is False
+    assert plan.reason == "same_path"
+
+
+def test_plan_no_migration_when_source_empty(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    dst = tmp_path / "dst"
+    plan = plan_migration(current=str(src), target=str(dst))
+    assert plan.needed is False
+    assert plan.reason == "source_empty"
+
+
+def test_plan_no_migration_when_source_missing(tmp_path: Path) -> None:
+    plan = plan_migration(
+        current=str(tmp_path / "ghost"),
+        target=str(tmp_path / "dst"),
+    )
+    assert plan.needed is False
+    assert plan.reason == "source_missing"
+
+
+def test_plan_migration_needed_when_source_has_files(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "model.gguf").write_bytes(b"x" * 50)
+    dst = tmp_path / "dst"
+    plan = plan_migration(current=str(src), target=str(dst))
+    assert plan.needed is True
+    assert plan.files_count == 1
+    assert plan.size_bytes == 50
+    assert plan.reason == "has_data"
+
+
+# ── execute_migration ────────────────────────────────────────────────────
+
+
+def test_execute_moves_entries_and_records_them(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "Qwen3-8B").mkdir()
+    (src / "Qwen3-8B" / "weights.gguf").write_bytes(b"x" * 100)
+    (src / "Whisper").mkdir()
+    (src / "Whisper" / "w.gguf").write_bytes(b"y" * 50)
+    dst = tmp_path / "dst"
+
+    plan = plan_migration(current=str(src), target=str(dst))
+    assert plan.needed
+    result = execute_migration(plan)
+
+    assert sorted(result.moved) == ["Qwen3-8B", "Whisper"]
+    assert result.failed == []
+    assert (dst / "Qwen3-8B" / "weights.gguf").read_bytes() == b"x" * 100
+    assert not (src / "Qwen3-8B").exists()
+    assert not (src / "Whisper").exists()
+
+
+def test_execute_skips_dot_entries(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / ".tmp").mkdir()
+    (src / ".tmp" / "stage.part").write_bytes(b"in-flight")
+    (src / "model").mkdir()
+    (src / "model" / "x.gguf").write_bytes(b"x")
+    dst = tmp_path / "dst"
+
+    plan = plan_migration(current=str(src), target=str(dst))
+    result = execute_migration(plan)
+
+    assert "model" in result.moved
+    # .tmp left where it was — never mirrored into the new store.
+    assert (src / ".tmp" / "stage.part").read_bytes() == b"in-flight"
+    assert not (dst / ".tmp").exists()
+
+
+def test_execute_records_failure_when_target_already_exists(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "model").mkdir()
+    (src / "model" / "a.gguf").write_bytes(b"new")
+    (src / "model2").mkdir()
+    (src / "model2" / "b.gguf").write_bytes(b"new")
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    (dst / "model").mkdir()  # collision
+    (dst / "model" / "existing.gguf").write_bytes(b"old")
+
+    plan = plan_migration(current=str(src), target=str(dst))
+    result = execute_migration(plan)
+
+    # model2 moved, model recorded as failed (target_exists).
+    assert "model2" in result.moved
+    assert any(row["name"] == "model" for row in result.failed)
+    # Existing target file untouched.
+    assert (dst / "model" / "existing.gguf").read_bytes() == b"old"
+    # The source for the failed entry stays put — operator can retry.
+    assert (src / "model" / "a.gguf").read_bytes() == b"new"
+
+
+def test_execute_noop_when_plan_says_not_needed(tmp_path: Path) -> None:
+    plan = plan_migration(current=None, target=str(tmp_path / "dst"))
+    result = execute_migration(plan)
+    assert result.moved == []
+    assert result.failed == []
+
+
+# ── propagate_lemonade_config ────────────────────────────────────────────
+
+
+def test_propagate_writes_new_value_and_reports_change(
+    tmp_hal0_home: str,
+) -> None:
+    cfg = cfg_paths.var_lib() / "lemonade" / "config.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        json.dumps({"extra_models_dir": "/var/lib/hal0/models", "port": 13305}),
+        encoding="utf-8",
+    )
+
+    changed, prev = propagate_lemonade_config("/mnt/ai-models")
+    assert changed is True
+    assert prev == "/var/lib/hal0/models"
+    on_disk = json.loads(cfg.read_text(encoding="utf-8"))
+    assert on_disk["extra_models_dir"] == "/mnt/ai-models"
+    # Other keys preserved verbatim.
+    assert on_disk["port"] == 13305
+
+
+def test_propagate_noop_when_value_matches(tmp_hal0_home: str) -> None:
+    cfg = cfg_paths.var_lib() / "lemonade" / "config.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        json.dumps({"extra_models_dir": "/mnt/ai-models"}),
+        encoding="utf-8",
+    )
+
+    changed, prev = propagate_lemonade_config("/mnt/ai-models")
+    assert changed is False
+    assert prev == "/mnt/ai-models"
+
+
+def test_propagate_noop_when_config_missing(tmp_hal0_home: str) -> None:
+    changed, prev = propagate_lemonade_config("/mnt/ai-models")
+    assert changed is False
+    assert prev is None
+
+
+def test_propagate_raises_on_malformed_json(tmp_hal0_home: str) -> None:
+    cfg = cfg_paths.var_lib() / "lemonade" / "config.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text("not json", encoding="utf-8")
+    with pytest.raises(RuntimeError):
+        propagate_lemonade_config("/mnt/ai-models")

--- a/tests/registry/test_pull_store.py
+++ b/tests/registry/test_pull_store.py
@@ -1,0 +1,53 @@
+"""Test that ``_pull_root`` honours [models].store with pull_root fallback."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hal0.config import paths
+from hal0.config.loader import save_hal0_config
+from hal0.config.schema import Hal0Config, ModelsConfig
+
+
+def test_pull_root_defaults_to_pull_root_when_store_unset(
+    tmp_hal0_home: str,
+) -> None:
+    cfg = Hal0Config()
+    save_hal0_config(cfg)
+    from hal0.registry.pull import _pull_root
+
+    assert _pull_root() == Path(cfg.models.pull_root)
+
+
+def test_pull_root_uses_store_when_set(tmp_hal0_home: str, tmp_path: Path) -> None:
+    ext = tmp_path / "mnt-ai"
+    ext.mkdir()
+    cfg = Hal0Config(
+        models=ModelsConfig(
+            roots=[str(paths.models_dir())],
+            pull_root=str(paths.models_dir()),
+            store=str(ext),
+        ),
+    )
+    save_hal0_config(cfg)
+    from hal0.registry.pull import _pull_root
+
+    assert _pull_root() == ext
+
+
+def test_effective_store_picks_pull_root_fallback() -> None:
+    """Backward compat — PR-#313 installs without `store` keep working."""
+    models = ModelsConfig(
+        roots=["/some/root"],
+        pull_root="/legacy/path",
+    )
+    assert models.effective_store() == "/legacy/path"
+
+
+def test_effective_store_prefers_explicit_store() -> None:
+    models = ModelsConfig(
+        roots=["/some/root"],
+        pull_root="/legacy/path",
+        store="/new/store",
+    )
+    assert models.effective_store() == "/new/store"

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -91,6 +91,9 @@ export const ENDPOINTS = {
   settings: '/api/settings',
   settingsReload: '/api/settings/reload',
   settingsSchema: '/api/settings/schema',
+  // Single-source-of-truth model storage (Settings → Models + Firstrun → Storage).
+  settingsModelsStore: '/api/settings/models/store',
+  settingsModelsStoreMigrate: '/api/settings/models/store/migrate',
 
   // ── Settings ─────────────────────────────────────────────────────
   // Updates

--- a/ui/src/api/hooks/useSettings.ts
+++ b/ui/src/api/hooks/useSettings.ts
@@ -61,3 +61,114 @@ export function useSettingsReload() {
     onSuccess: (next) => qc.setQueryData(SETTINGS_KEY, next),
   })
 }
+
+// ── Model storage (single source of truth) ──────────────────────────────
+//
+// `[models].store` (v0.3) replaces #313's roots + pull_root with one
+// path that hal0's pull engine + Lemonade's extra_models_dir both
+// point at. The dedicated endpoints below give the Settings page +
+// Firstrun "Storage" step precise validation, a dry-run probe for
+// "needs migration" detection, and an explicit migrate call so the
+// confirmation modal has a clean URL to fire at.
+
+export interface StoreStateProbe {
+  path: string
+  exists: boolean
+  is_dir: boolean
+  readable: boolean
+  writable: boolean
+  files_count: number
+  size_bytes: number
+  free_bytes: number
+}
+
+export interface StoreSuggestion extends StoreStateProbe {
+  is_current: boolean
+}
+
+export interface ModelStoreState {
+  store: string | null
+  effective: string
+  fallback_active: boolean
+  pull_root_legacy: string
+  current_state: StoreStateProbe
+  suggestions: StoreSuggestion[]
+}
+
+export interface MigrationPlan {
+  source: string | null
+  target: string
+  files_count: number
+  size_bytes: number
+  same_filesystem: boolean
+}
+
+export interface MigrationOutcome {
+  source: string
+  target: string
+  moved: string[]
+  failed: { name: string; reason: string; target?: string }[]
+}
+
+export type SetStoreResponse =
+  | { status: 'needs_migration'; plan: MigrationPlan; state: ModelStoreState }
+  | {
+      status: 'ok'
+      config: Hal0Settings
+      state: ModelStoreState
+      migration: MigrationOutcome | null
+      lemonade: {
+        changed: boolean
+        previous_extra_models_dir: string | null
+        restart: 'ok' | 'failed' | 'skipped' | 'unavailable'
+      }
+    }
+
+const MODEL_STORE_KEY = ['settings', 'models', 'store'] as const
+
+export function useModelStore() {
+  return useQuery({
+    queryKey: MODEL_STORE_KEY,
+    queryFn: () => apiGet<ModelStoreState>(ENDPOINTS.settingsModelsStore),
+    // Suggestions probe the filesystem (file counts + free-bytes) so the
+    // refetch cost is non-trivial; 30s is enough for the firstrun chip
+    // labels to stay fresh without spinning under the user.
+    staleTime: 30_000,
+  })
+}
+
+export function useModelStoreSet() {
+  const qc = useQueryClient()
+  return useMutation<
+    SetStoreResponse,
+    Hal0Error,
+    { path: string; migrate?: boolean }
+  >({
+    mutationFn: (body) =>
+      apiPost<SetStoreResponse>(ENDPOINTS.settingsModelsStore, body),
+    onSuccess: (resp) => {
+      if (resp.status === 'ok') {
+        qc.setQueryData(MODEL_STORE_KEY, resp.state)
+        qc.setQueryData(SETTINGS_KEY, resp.config)
+        qc.invalidateQueries({ queryKey: ['models'] })
+      } else {
+        qc.setQueryData(MODEL_STORE_KEY, resp.state)
+      }
+    },
+  })
+}
+
+export function useModelStoreMigrate() {
+  const qc = useQueryClient()
+  return useMutation<SetStoreResponse, Hal0Error, { path: string }>({
+    mutationFn: (body) =>
+      apiPost<SetStoreResponse>(ENDPOINTS.settingsModelsStoreMigrate, body),
+    onSuccess: (resp) => {
+      if (resp.status === 'ok') {
+        qc.setQueryData(MODEL_STORE_KEY, resp.state)
+        qc.setQueryData(SETTINGS_KEY, resp.config)
+        qc.invalidateQueries({ queryKey: ['models'] })
+      }
+    },
+  })
+}

--- a/ui/src/dash/firstrun.jsx
+++ b/ui/src/dash/firstrun.jsx
@@ -7,8 +7,137 @@
 
 import { useCuratedBundles, useFirstRunInstall, useFirstRunComplete } from '@/api/hooks/useFirstRun'
 import { useHardware } from '@/api/hooks/useHardware'
+import { useModelStore, useModelStoreSet, useModelStoreMigrate } from '@/api/hooks/useSettings'
 
-const { useState: useStateF } = React;
+const { useState: useStateF, useEffect: useEffectF } = React;
+
+function _frFmtBytes(n) {
+  if (!n || n < 0) return "—";
+  if (n < 1024) return n + " B";
+  if (n < 1024 ** 2) return (n / 1024).toFixed(1) + " KB";
+  if (n < 1024 ** 3) return (n / 1024 ** 2).toFixed(1) + " MB";
+  return (n / 1024 ** 3).toFixed(2) + " GB";
+}
+
+// ─── Storage step (state 1.5 — between picker and confirm) ───
+//
+// Lets the operator decide WHERE models live before any pulls start.
+// Mirrors the Settings → Models surface (same hooks, same dry-run
+// migration plumbing) so the FirstRun choice and the Settings page
+// stay in lockstep.
+function FirstRunStorage({ onContinue, onBack }) {
+  const storeQuery = useModelStore();
+  const storeSet = useModelStoreSet();
+  const storeMigrate = useModelStoreMigrate();
+  const storeState = storeQuery.data;
+  const [path, setPath] = useStateF("");
+  const [pendingPlan, setPendingPlan] = useStateF(null);
+
+  useEffectF(() => {
+    if (storeState?.effective != null) setPath(storeState.effective);
+  }, [storeState]);
+
+  const apply = async (target, { migrate = false } = {}) => {
+    try {
+      const resp = await storeSet.mutateAsync({ path: target, migrate });
+      if (resp.status === "needs_migration") {
+        setPendingPlan({ ...resp.plan, path: target });
+        return;
+      }
+      window.__hal0Toast && window.__hal0Toast(`Storage set → ${target}`, "ok");
+      onContinue();
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(`Storage save failed — ${e?.message || "see logs"}`, "err");
+    }
+  };
+
+  const confirmMigrate = async () => {
+    if (!pendingPlan) return;
+    const target = pendingPlan.path;
+    setPendingPlan(null);
+    try {
+      await storeMigrate.mutateAsync({ path: target });
+      window.__hal0Toast && window.__hal0Toast(`Moved + set → ${target}`, "ok");
+      onContinue();
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(`Move failed — ${e?.message || "see logs"}`, "err");
+    }
+  };
+
+  return (
+    <div className="fr-inner">
+      <div className="fr-head">
+        <div className="fr-eyebrow"><span className="blip" />FirstRun · storage</div>
+        <h1 className="fr-title">Where should models live?</h1>
+        <p className="fr-lede">Hal0 reads + writes model files here. Both the pull engine and Lemonade point at the same path — pick once.</p>
+      </div>
+
+      {storeQuery.isPending && <div style={{padding: 20, color: "var(--fg-4)", fontFamily: "var(--jbm)", fontSize: 12}}>Probing storage candidates…</div>}
+
+      {storeState && (
+        <div className="card" style={{padding: 20, marginBottom: 24}}>
+          <div className="mono" style={{fontSize: 10, color: "var(--fg-4)", textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 14}}>Storage path</div>
+          <input
+            className="input mono"
+            value={path}
+            onChange={e => setPath(e.target.value)}
+            placeholder="/mnt/ai-models"
+            style={{width: "100%", padding: "10px 12px", fontSize: 14, marginBottom: 14}}
+          />
+          <div style={{display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 16}}>
+            {storeState.suggestions.map(s => (
+              <button
+                key={s.path}
+                className={"chip" + (s.path === path ? " amber" : "")}
+                style={{cursor: "pointer", fontFamily: "var(--jbm)"}}
+                onClick={() => setPath(s.path)}
+                title={s.exists ? `${s.files_count} files · ${_frFmtBytes(s.size_bytes)} used · ${_frFmtBytes(s.free_bytes)} free` : "does not exist yet"}
+              >
+                {s.path}
+                <span style={{marginLeft: 6, color: "var(--fg-4)", fontSize: 10}}>
+                  {s.exists
+                    ? (s.files_count > 0 ? `${s.files_count} files · ${_frFmtBytes(s.free_bytes)} free` : `empty · ${_frFmtBytes(s.free_bytes)} free`)
+                    : "missing"}
+                </span>
+              </button>
+            ))}
+          </div>
+          <div style={{fontFamily: "var(--jbm)", fontSize: 11.5, color: "var(--fg-3)"}}>
+            {storeState.current_state.exists
+              ? <>Current effective: <span style={{color: "var(--fg)"}}>{storeState.effective}</span> · {storeState.current_state.files_count} files · {_frFmtBytes(storeState.current_state.free_bytes)} free here</>
+              : <>Current effective: <span style={{color: "var(--warn)"}}>{storeState.effective}</span> (missing)</>}
+          </div>
+        </div>
+      )}
+
+      <div className="fr-actions">
+        <button className="btn ghost lg" onClick={onBack}>← back</button>
+        <button
+          className="btn lg"
+          disabled={!path.trim() || storeSet.isPending}
+          onClick={() => apply(path.trim(), { migrate: false })}
+        >
+          {storeSet.isPending ? "Saving…" : "Continue"}
+        </button>
+      </div>
+
+      <ConfirmDialog
+        open={!!pendingPlan}
+        onCancel={() => setPendingPlan(null)}
+        onConfirm={confirmMigrate}
+        title="Move existing models?"
+        message={
+          pendingPlan ? (
+            <span>
+              We found <b>{pendingPlan.files_count} file(s)</b> ({_frFmtBytes(pendingPlan.size_bytes)}) at <span className="mono" style={{color: "var(--fg)"}}>{pendingPlan.source}</span>. Move them to <span className="mono" style={{color: "var(--accent)"}}>{pendingPlan.target}</span> and continue?
+            </span>
+          ) : null
+        }
+        confirmLabel={storeMigrate.isPending ? "Moving…" : "Move + continue"}
+      />
+    </div>
+  );
+}
 
 // ─── Bundle picker (state 1) ───
 function FirstRunPicker({ onPick, onSkip, layout }) {
@@ -330,15 +459,24 @@ function FirstRunView({ frStage, setFrStage, frBundle, setFrBundle, onComplete, 
     <div className="fr">
       {frStage === "pick" && (
         <FirstRunPicker
-          onPick={b => { setFrBundle(b); setFrStage("confirm"); }}
+          // Route through the new "storage" stage before confirming the
+          // bundle — the operator decides WHERE models live before any
+          // pulls start so the bundle's downloads land in the right place.
+          onPick={b => { setFrBundle(b); setFrStage("storage"); }}
           onSkip={() => setSkipOpen(true)}
           layout={layout}
+        />
+      )}
+      {frStage === "storage" && (
+        <FirstRunStorage
+          onBack={() => setFrStage("pick")}
+          onContinue={() => setFrStage("confirm")}
         />
       )}
       {frStage === "confirm" && (
         <FirstRunConfirm
           bundleId={frBundle}
-          onBack={() => setFrStage("pick")}
+          onBack={() => setFrStage("storage")}
           onInstall={() => setFrStage("progress")}
         />
       )}
@@ -354,4 +492,4 @@ function FirstRunView({ frStage, setFrStage, frBundle, setFrBundle, onComplete, 
   );
 }
 
-Object.assign(window, { FirstRunView, FirstRunPicker, FirstRunConfirm, FirstRunProgress, BundleGrid, BundleTable });
+Object.assign(window, { FirstRunView, FirstRunPicker, FirstRunStorage, FirstRunConfirm, FirstRunProgress, BundleGrid, BundleTable });

--- a/ui/src/dash/settings.jsx
+++ b/ui/src/dash/settings.jsx
@@ -9,7 +9,13 @@ import { useSecrets, useSecretSet, useSecretDelete } from '@/api/hooks/useSecret
 import { useUpdateState, useUpdateCheck, useUpdateApply } from '@/api/hooks/useUpdates'
 import { useCapabilities, useCapabilityPatch } from '@/api/hooks/useCapabilities'
 import { useLemondRollup, useLemonadeStats } from '@/api/hooks/useLemonade'
-import { useSettings, useSettingsUpdate } from '@/api/hooks/useSettings'
+import {
+  useSettings,
+  useSettingsUpdate,
+  useModelStore,
+  useModelStoreSet,
+  useModelStoreMigrate,
+} from '@/api/hooks/useSettings'
 
 const { useState: useStateSet, useEffect: useEffectSet } = React;
 
@@ -77,59 +83,99 @@ const SRow = ({ k, sub, v, mono, children, actions }) => (
   </div>
 );
 
-// ─── Models (PR feat/models-scan-and-add-by-path) ───────────────
+// ─── Models (v0.3 single-source-of-truth `[models].store`) ───────────
 //
-// Edits [models].roots + [models].pull_root in hal0.toml so the
-// Scan-directory + Add-by-path flows in Models view default to the
-// operator's preferred location (e.g. /mnt/ai-models). Changes hit
-// /api/settings (deep-merge PUT) so the rest of the config rounds
-// through untouched.
+// Replaces the two-field roots + pull_root surface from PR #313 with
+// ONE Storage location field. Hal0 propagates the chosen path to both
+// the pull engine and Lemonade's extra_models_dir, with a confirmation
+// modal when the prior path has data ("Move N models from A to B?").
+//
+// The remaining toggles (auto_scan_on_start, file_extensions) keep
+// writing through the generic PUT /api/settings since they don't need
+// the propagation / migration plumbing.
+function _fmtBytes(n) {
+  if (!n || n < 0) return "—";
+  if (n < 1024) return n + " B";
+  if (n < 1024 ** 2) return (n / 1024).toFixed(1) + " KB";
+  if (n < 1024 ** 3) return (n / 1024 ** 2).toFixed(1) + " MB";
+  return (n / 1024 ** 3).toFixed(2) + " GB";
+}
+
 function ModelsSection() {
   const settings = useSettings();
   const update = useSettingsUpdate();
+  const storeQuery = useModelStore();
+  const storeSet = useModelStoreSet();
+  const storeMigrate = useModelStoreMigrate();
   const liveModels = settings.data?.models;
-  // Local edit buffers — we only PATCH when the operator clicks Save so
-  // they can revise multiple roots without each keystroke triggering an
-  // atomic write on disk.
-  const [rootsText, setRootsText] = useStateSet("");
-  const [pullRoot, setPullRoot] = useStateSet("");
+  const storeState = storeQuery.data;
+
+  // Single edit buffer for the storage path. Auto-scan is a separate
+  // PATCH so a Save on storage doesn't accidentally toggle it.
+  const [storePath, setStorePath] = useStateSet("");
   const [autoScan, setAutoScan] = useStateSet(true);
-  // Re-seed buffers each time the upstream config changes (after Save
-  // the response payload supersedes our buffer).
+  // Migration confirmation dialog state. ``pendingPlan`` holds the
+  // dry-run response so the modal can render N files / M bytes without
+  // a second round-trip.
+  const [pendingPlan, setPendingPlan] = useStateSet(null);
+
   useEffectSet(() => {
-    if (!liveModels) return;
-    setRootsText((liveModels.roots || []).join("\n"));
-    setPullRoot(liveModels.pull_root || "");
-    setAutoScan(liveModels.auto_scan_on_start !== false);
-  }, [liveModels]);
+    if (storeState?.effective != null) setStorePath(storeState.effective);
+    if (liveModels) setAutoScan(liveModels.auto_scan_on_start !== false);
+  }, [storeState, liveModels]);
 
-  const dirty = !!liveModels && (
-    rootsText !== (liveModels.roots || []).join("\n") ||
-    pullRoot !== (liveModels.pull_root || "") ||
-    autoScan !== (liveModels.auto_scan_on_start !== false)
-  );
+  const storeDirty = !!storeState && storePath.trim() !== storeState.effective;
+  const autoScanDirty = !!liveModels && autoScan !== (liveModels.auto_scan_on_start !== false);
 
-  const onSave = async () => {
-    const roots = rootsText
-      .split("\n")
-      .map(s => s.trim())
-      .filter(Boolean);
+  const submitStore = async (path, { migrate = false } = {}) => {
     try {
-      await update.mutateAsync({
-        models: {
-          roots,
-          pull_root: pullRoot.trim(),
-          auto_scan_on_start: autoScan,
-          // Preserve file_extensions verbatim — the Settings UI doesn't
-          // surface it yet, but we don't want a Save to drop the field.
-          file_extensions: liveModels?.file_extensions || [".gguf", ".safetensors"],
-        },
-      });
-      window.__hal0Toast && window.__hal0Toast("Models settings saved", "ok");
-    } catch (e) {
+      const resp = await storeSet.mutateAsync({ path, migrate });
+      if (resp.status === "needs_migration") {
+        setPendingPlan({ ...resp.plan, path });
+        return;
+      }
+      const moved = resp.migration?.moved?.length || 0;
+      const lem = resp.lemonade?.restart;
+      const lemMsg = lem === "ok"
+        ? "Lemonade restarted"
+        : lem === "failed"
+          ? "Lemonade restart failed — run `systemctl restart hal0-lemonade.service` manually"
+          : lem === "unavailable"
+            ? "Lemonade not running here"
+            : "Lemonade config unchanged";
       window.__hal0Toast && window.__hal0Toast(
-        `Save failed — ${e?.message || "see logs"}`, "err",
+        `Storage set → ${path}${moved ? ` · moved ${moved} model(s)` : ""} · ${lemMsg}`,
+        lem === "failed" ? "warn" : "ok",
       );
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(`Save failed — ${e?.message || "see logs"}`, "err");
+    }
+  };
+
+  const onSave = () => submitStore(storePath.trim(), { migrate: false });
+
+  const onAutoScanSave = async () => {
+    try {
+      await update.mutateAsync({ models: { auto_scan_on_start: autoScan } });
+      window.__hal0Toast && window.__hal0Toast("Auto-scan setting saved", "ok");
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(`Save failed — ${e?.message || "see logs"}`, "err");
+    }
+  };
+
+  const onConfirmMigrate = async () => {
+    if (!pendingPlan) return;
+    const path = pendingPlan.path;
+    setPendingPlan(null);
+    try {
+      const resp = await storeMigrate.mutateAsync({ path });
+      const moved = resp.status === "ok" ? (resp.migration?.moved?.length || 0) : 0;
+      window.__hal0Toast && window.__hal0Toast(
+        `Moved ${moved} model(s) → ${path}`,
+        "ok",
+      );
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(`Move failed — ${e?.message || "see logs"}`, "err");
     }
   };
 
@@ -137,46 +183,78 @@ function ModelsSection() {
     <div className="s-section">
       <h2>Models</h2>
       <p className="desc">
-        Where hal0 looks for already-downloaded model files (Scan) and where new HuggingFace pulls land. Each entry must be an absolute path readable by <span className="mono" style={{color: "var(--fg)"}}>hal0-api</span>.
+        Where hal0 reads and writes model files. One path drives both <span className="mono" style={{color: "var(--fg)"}}>hal0-api</span> and Lemonade — pick once, applies everywhere.
       </p>
-      {settings.isPending && <div style={{padding: 16, color: "var(--fg-4)", fontFamily: "var(--jbm)", fontSize: 12}}>Loading settings…</div>}
-      {settings.isError && (
-        <div className="err">{settings.error?.message || "Failed to load settings"}</div>
+
+      {storeQuery.isPending && <div style={{padding: 16, color: "var(--fg-4)", fontFamily: "var(--jbm)", fontSize: 12}}>Loading storage state…</div>}
+      {storeQuery.isError && (
+        <div className="err">{storeQuery.error?.message || "Failed to load storage state"}</div>
       )}
-      {liveModels && (
+
+      {storeState && (
         <>
+          {storeState.fallback_active && (
+            <div className="s-panel" style={{marginBottom: 12, padding: 12, fontFamily: "var(--jbm)", fontSize: 11.5, color: "var(--fg-3)", borderLeft: "2px solid var(--accent)"}}>
+              <b style={{color: "var(--accent)"}}>One field now drives storage.</b> We simplified storage settings — your current path is <span className="mono" style={{color: "var(--fg)"}}>{storeState.effective}</span>. Click Save to make it the new single source of truth.
+            </div>
+          )}
+
           <div className="s-panel">
             <SRow
-              k="Model directories (scan roots)"
-              sub="One absolute path per line · used by Scan + auto-scan"
-              v={
-                <textarea
-                  className="input mono"
-                  value={rootsText}
-                  onChange={e => setRootsText(e.target.value)}
-                  rows={Math.max(3, rootsText.split("\n").length)}
-                  placeholder={"/mnt/ai-models\n/var/lib/hal0/models"}
-                  style={{width: "100%", minWidth: 320, resize: "vertical"}}
-                />
-              }
-            />
-            <SRow
-              k="Pull root"
-              sub="Destination for HuggingFace downloads · finished files land at <pull_root>/<model_id>/"
+              k="Storage location"
+              sub="Absolute directory · pull engine + Lemonade both point here"
               mono
               v={
                 <input
                   className="input mono"
-                  value={pullRoot}
-                  onChange={e => setPullRoot(e.target.value)}
+                  value={storePath}
+                  onChange={e => setStorePath(e.target.value)}
                   placeholder="/mnt/ai-models"
                   style={{minWidth: 320, width: "100%"}}
                 />
               }
             />
             <SRow
+              k="Current state"
+              sub="Probe of the effective storage path"
+              mono
+              v={
+                storeState.current_state.exists
+                  ? <>
+                      <b style={{color: "var(--ok)"}}>exists</b>
+                      <span style={{color: "var(--fg-4)"}}> · {storeState.current_state.files_count} files · {_fmtBytes(storeState.current_state.size_bytes)} used · {_fmtBytes(storeState.current_state.free_bytes)} free</span>
+                      {!storeState.current_state.writable && <span style={{color: "var(--warn)", marginLeft: 6}}>· read-only</span>}
+                    </>
+                  : <span style={{color: "var(--warn)"}}>missing · create it before saving</span>
+              }
+            />
+            <SRow
+              k="Suggested locations"
+              sub="Click to fill — labels show current state"
+              v={
+                <div style={{display: "flex", gap: 6, flexWrap: "wrap"}}>
+                  {storeState.suggestions.map(s => (
+                    <button
+                      key={s.path}
+                      className={"chip" + (s.is_current ? " amber" : "")}
+                      style={{cursor: "pointer", fontFamily: "var(--jbm)"}}
+                      onClick={() => setStorePath(s.path)}
+                      title={s.exists ? `${s.files_count} files · ${_fmtBytes(s.size_bytes)} used · ${_fmtBytes(s.free_bytes)} free` : "does not exist yet"}
+                    >
+                      {s.path}
+                      <span style={{marginLeft: 6, color: "var(--fg-4)", fontSize: 10}}>
+                        {s.exists
+                          ? (s.files_count > 0 ? `${s.files_count} files` : "empty")
+                          : "missing"}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              }
+            />
+            <SRow
               k="Auto-scan on start"
-              sub="Walk the scan roots when hal0-api starts; new files get registered automatically"
+              sub="Walk the storage path when hal0-api starts; new files get registered automatically"
               v={
                 <label className="mono" style={{display: "inline-flex", alignItems: "center", gap: 8, cursor: "pointer", color: "var(--fg-2)"}}>
                   <input
@@ -188,42 +266,58 @@ function ModelsSection() {
                   <span>{autoScan ? "enabled" : "disabled"}</span>
                 </label>
               }
+              actions={autoScanDirty ? <button className="btn ghost sm" disabled={update.isPending} onClick={onAutoScanSave}>{update.isPending ? "Saving…" : "Save"}</button> : null}
             />
             <SRow
               k="File extensions"
               sub="Read-only · edit via hal0 config edit"
               mono
-              v={(liveModels.file_extensions || []).join(" · ") || "—"}
+              v={(liveModels?.file_extensions || []).join(" · ") || "—"}
             />
           </div>
+
           <div style={{marginTop: 14, display: "flex", justifyContent: "space-between", alignItems: "center"}}>
             <span className="mono" style={{fontSize: 11, color: "var(--fg-4)"}}>
-              Stored at <span style={{color: "var(--fg-3)"}}>/etc/hal0/hal0.toml</span>
-              {dirty && <span style={{marginLeft: 8, color: "var(--warn)"}}>· unsaved changes</span>}
+              Stored at <span style={{color: "var(--fg-3)"}}>/etc/hal0/hal0.toml</span> · propagates to Lemonade <span style={{color: "var(--fg-3)"}}>config.json</span>
+              {storeDirty && <span style={{marginLeft: 8, color: "var(--warn)"}}>· unsaved changes</span>}
             </span>
             <div style={{display: "inline-flex", gap: 8}}>
               <button
                 className="btn ghost sm"
-                disabled={!dirty || update.isPending}
-                onClick={() => {
-                  if (!liveModels) return;
-                  setRootsText((liveModels.roots || []).join("\n"));
-                  setPullRoot(liveModels.pull_root || "");
-                  setAutoScan(liveModels.auto_scan_on_start !== false);
-                }}
+                disabled={!storeDirty || storeSet.isPending}
+                onClick={() => storeState && setStorePath(storeState.effective)}
               >Reset</button>
               <button
                 className="btn"
-                disabled={!dirty || update.isPending}
+                disabled={!storeDirty || !storePath.trim() || storeSet.isPending}
                 onClick={onSave}
-              >{update.isPending ? "Saving…" : "Save"}</button>
+              >{storeSet.isPending ? "Saving…" : "Save"}</button>
             </div>
           </div>
-          {update.isError && (
+          {storeSet.isError && (
             <div className="err" style={{marginTop: 10}}>
-              {update.error?.message || "Save failed"}
+              {storeSet.error?.message || "Save failed"}
             </div>
           )}
+
+          <ConfirmDialog
+            open={!!pendingPlan}
+            onCancel={() => setPendingPlan(null)}
+            onConfirm={onConfirmMigrate}
+            title="Move existing models?"
+            message={
+              pendingPlan ? (
+                <span>
+                  Hal0 will move <b className="mono">{pendingPlan.files_count} file(s)</b> ({_fmtBytes(pendingPlan.size_bytes)}) from <span className="mono" style={{color: "var(--fg)"}}>{pendingPlan.source}</span> to <span className="mono" style={{color: "var(--accent)"}}>{pendingPlan.target}</span>.
+                  {pendingPlan.same_filesystem
+                    ? <> Same filesystem — should be instant.</>
+                    : <> Cross-filesystem copy — may take a while.</>}
+                  {" "}A failure leaves both paths intact, you can retry safely.
+                </span>
+              ) : null
+            }
+            confirmLabel={storeMigrate.isPending ? "Moving…" : "Move + apply"}
+          />
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary

ONE setting that all model consumers point at. Replaces #313's two-field `roots` + `pull_root` with a single `[models].store` that propagates atomically to both the hal0 pull engine and Lemonade's `extra_models_dir`. Migration helper (LM Studio-style) detects existing data, returns a dry-run plan, and only moves bytes after the operator confirms.

**Lands after:** #316 (Hermes provision regression — unrelated, no overlap).
**Closes the design space discussion from:** the briefed `external_store` symlink/toggle approach, after the user pivoted to a simpler one-field model.

## Investigation

| Consumer | Where the path lives | Read by |
|---|---|---|
| hal0 pull engine | `[models].pull_root` (PR #313) | `src/hal0/registry/pull.py::_pull_root()` |
| Lemonade | `extra_models_dir` in `/var/lib/hal0/lemonade/config.json` | lemond daemon (binary), seeded by `installer/install.sh` |
| Lemonade admin panel | constant `LOCKED_EXTRA_MODELS_DIR = "/var/lib/hal0/models"` | `src/hal0/api/routes/lemonade_admin.py::_validate_extra_models_dir` |

Before this PR these three lived in separate places and only stayed in sync if the operator manually edited each. The locked admin invariant actively prevented coherent edits.

## Schema

```toml
[models]
store = "/mnt/ai-models"        # NEW — single source of truth (v0.3)
pull_root = "/mnt/ai-models"    # legacy PR-#313 field, still accepted as fallback
roots = ["/mnt/ai-models"]      # legacy PR-#313 field, untouched
```

`ModelsConfig.effective_store()` returns `store` when set, else `pull_root`. Every consumer points at the result.

## API surface

```
GET  /api/settings/models/store
        → { store, effective, fallback_active, current_state, suggestions[] }

POST /api/settings/models/store
        body: { path, migrate?: bool }
        when migration needed AND migrate=false:
          → { status: "needs_migration", plan: { source, target, files_count, size_bytes, same_filesystem } }
        when migration not needed OR migrate=true:
          → { status: "ok", config, state, migration, lemonade: { changed, previous, restart } }

POST /api/settings/models/store/migrate
        body: { path }
        equivalent to POST .../store with migrate=true; standalone URL for the
        confirmation modal's after-confirm call.
```

Validation: empty/relative/missing/file-not-dir/non-writable each surface their own typed code (`config.invalid`, `models.store_missing`, `models.store_not_directory`, `models.store_unwritable`).

## Migration UX (LM Studio pattern)

1. **Dry-run first.** Hitting POST with a target that requires moving data returns `needs_migration` and changes nothing on disk.
2. **Confirm + apply.** UI renders modal showing N files / M bytes (+ same-filesystem hint so cross-fs moves get the "may take a while" copy). On confirm, hit the `/migrate` endpoint.
3. **Atomic ordering**: move files → propagate Lemonade config → restart `hal0-lemonade.service` → persist `hal0.toml`. A failed move leaves both paths intact (no partial state). A failed Lemonade restart still persists hal0.toml; the response surfaces `restart: "failed"` so the UI can prompt the operator.
4. **Per-entry recoverability**: `execute_migration` records each move + each failure; collisions (target already has an entry by that name) don't abort the whole migration — they're reported in `failed[]` and the operator can resolve.

## Frontend

- `useSettings.ts` — adds `useModelStore`, `useModelStoreSet`, `useModelStoreMigrate` typed hooks.
- `settings.jsx` → Models section replaced: single Storage location field + suggestion chips with state probes + current-state line. Confirmation modal on migration. Fallback banner appears when `fallback_active=true` to nudge legacy `pull_root` users to save once and adopt `store`.
- `firstrun.jsx` → new "storage" stage between `pick` and `confirm`. Same Storage field + suggestion chips. Continue → confirm bundle install.

## Tests added (all green locally)

- `tests/registry/test_model_store.py` — 18 unit tests: state probe (missing/dir/file), suggestions (order, dedupe, current), plan_migration (5 reasons), execute_migration (moves, dot-skip, failure recording, noop), propagate_lemonade_config (writes, no-op match, no-op missing, malformed JSON raise).
- `tests/registry/test_pull_store.py` — 4 tests: pull engine honors `store`, falls back to `pull_root`, effective_store precedence.
- `tests/api/test_settings_models_store.py` — 12 endpoint tests: GET state, set happy path, dry-run, migrate=true, dedicated migrate endpoint, validation errors (relative, missing, file, non-writable), idempotency, lemonade admin locked value follows store.
- `tests/api/test_lemonade_admin_route.py` — updated the locked-value tests to use the dynamic `_locked_extra_models_dir()` since the constant is no longer the single answer.

**Full sweep:** `1737 passed, 3 skipped` (`uv run pytest tests/`). `ruff check` + `ruff format --check` both clean across `src` + `tests`.

## LXC verification — live commands + observed output

State before: `/mnt/ai-models` empty save for `.tmp/`, `/var/lib/hal0/models` has `collections/`, hal0.toml `pull_root="/mnt/ai-models"`, Lemonade `extra_models_dir="/var/lib/hal0/models"`.

### 1. GET store — fallback resolution + suggestions

```
$ curl -s http://127.0.0.1:8080/api/settings/models/store
{
  "store": null,
  "effective": "/mnt/ai-models",
  "fallback_active": true,
  "pull_root_legacy": "/mnt/ai-models",
  "current_state": { "exists": true, "writable": true, "files_count": 0, "free_bytes": 112319062016 },
  "suggestions": [
    { "path": "/mnt/ai-models", "is_current": true, "files_count": 0 },
    { "path": "/var/lib/hal0/models", "is_current": false, "files_count": 5 },
    { "path": "/root/.local/share/hal0/models", "is_current": false, "exists": false }
  ]
}
```

### 2. Set store=/mnt/ai-models (no move) — propagates to lemonade + hal0.toml

```
$ curl -s -X POST -d '{"path": "/mnt/ai-models"}' .../api/settings/models/store
{ "status": "ok", "config": { ..., "models": { ..., "store": "/mnt/ai-models" } }, ... }

$ grep -E "store|pull_root" /etc/hal0/hal0.toml
pull_root = "/mnt/ai-models"
store = "/mnt/ai-models"

$ grep extra_models_dir /var/lib/hal0/lemonade/config.json
  "extra_models_dir": "/mnt/ai-models",
```

### 3. Drop a 1 MB file, GET reports it

```
$ mkdir -p /mnt/ai-models/test-model && dd if=/dev/zero of=/mnt/ai-models/test-model/dummy.gguf bs=1M count=1
$ curl -s http://127.0.0.1:8080/api/settings/models/store | jq ".current_state"
{ "files_count": 1, "size_bytes": 1048576 }
```

### 4. Change to /tmp/hal0-store-demo — dry-run, then commit migrate

```
$ curl -s -X POST -d '{"path": "/tmp/hal0-store-demo"}' .../store
{
  "status": "needs_migration",
  "plan": { "source": "/mnt/ai-models", "target": "/tmp/hal0-store-demo", "files_count": 1, "size_bytes": 1048576, "same_filesystem": true }
}

$ curl -s -X POST -d '{"path": "/tmp/hal0-store-demo"}' .../store/migrate
{ "status": "ok", "migration": { "moved": ["test-model"], "failed": [] }, "lemonade": { "changed": true, "restart": "ok" } }

$ ls /mnt/ai-models      # only .tmp/ left
$ ls /tmp/hal0-store-demo/test-model
dummy.gguf
$ grep store /etc/hal0/hal0.toml
store = "/tmp/hal0-store-demo"
$ grep extra_models_dir /var/lib/hal0/lemonade/config.json
  "extra_models_dir": "/tmp/hal0-store-demo",
```

### 5. Restore to /mnt/ai-models + cleanup

```
$ curl -s -X POST -d '{"path": "/mnt/ai-models", "migrate": true}' .../store
{ "status": "ok", "migration": { "moved": ["test-model"] }, "lemonade": { "changed": true, "restart": "ok" } }
$ rm -rf /tmp/hal0-store-demo /mnt/ai-models/test-model
```

Final: hal0.toml `store = "/mnt/ai-models"`, lemonade `extra_models_dir = "/mnt/ai-models"`, all in lockstep.

## Sibling PR coordination

- **#316** (`fix/hermes-bootstrap-lemonade-regression`) — touches `src/hal0/agents/` only. Zero file overlap with this PR. Merge order doesn't matter.
- No collision with `data.jsx` (untouched here).
- `firstrun.jsx` edit is a new top-level `FirstRunStorage` component + one stage routing hunk — no overlap with any in-flight Qwen3.6 phantom-pull work the original brief warned about.

## /opt/hal0 restored to main

```
$ ssh hal0 'cd /opt/hal0 && git checkout main && cd ui && rm -rf dist node_modules/.vite && npm run build && systemctl restart hal0-api'
Switched to branch 'main'
✓ built in 779ms
active

$ git log -1 --oneline
4bd20a9 fix(models): honor body hf_repo/hf_filename in pull route (#318)
```

The hermes stash on the LXC was popped back so the sibling agent's WIP is preserved.

## Test plan

- [ ] Re-run `uv run pytest tests/` on CI (1737 passing locally)
- [ ] `ruff check` + `ruff format --check` (both green locally)
- [ ] Visual Settings → Models check on a fresh install
- [ ] Visual FirstRun → Storage step
- [ ] Verify migration modal confirm/cancel paths in browser
- [ ] Confirm Lemonade restart succeeds on a host with the hal0-lemonade.service unit registered (the verification above exercised it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)