### PR TITLE
fix(slots): repair POST /api/slots ImportError from #281

### DIFF
--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -334,10 +334,10 @@ def _next_free_slot_port(start: int = 8081, end: int = 8099) -> int:
     """
     import tomllib
 
-    from hal0.config.paths import hal0_etc_dir
+    from hal0.config.paths import slots_config_dir
 
     used: set[int] = set()
-    slots_dir = hal0_etc_dir() / "slots"
+    slots_dir = slots_config_dir()
     if slots_dir.is_dir():
         for f in slots_dir.glob("*.toml"):
             try:


### PR DESCRIPTION
## Summary
- PR #281 (`aa03d71`) added `_next_free_slot_port()` in `src/hal0/api/routes/slots.py` that imports `hal0_etc_dir` from `hal0.config.paths` — but no such symbol exists.
- Every `POST /api/slots` from the dashboard 500s with `ImportError: cannot import name 'hal0_etc_dir' from 'hal0.config.paths'`.
- The existing `slots_config_dir()` helper already returns `etc() / "slots"`, exactly what the new code wants. Two-line swap.

## Repro
1. Open dashboard at `https://hal0.thinmint.dev/`
2. Add a new slot via the UI
3. `POST /api/slots` → 500 (ImportError in hal0-api logs)

## Test plan
- [x] `ruff check src/hal0/api/routes/slots.py` clean
- [x] `ruff format --check src/hal0/api/routes/slots.py` clean
- [x] Hot-patched + restarted hal0-api on the LXC. `curl POST /api/slots` returned 201 with correct auto-assigned port 8086 (lowest free in 8081–8099)
- [x] Test slot deleted via `DELETE /api/slots/<name>` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)