### PR TITLE
fix(dash): wire Settings → Updates to real backend (#233)

### DIFF
--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -27,6 +27,8 @@ Endpoints:
 from __future__ import annotations
 
 import asyncio
+import shutil
+import subprocess
 import time
 import uuid
 from typing import Any
@@ -130,6 +132,119 @@ async def _run_apply_job(
         job["state"] = "applied"
     finally:
         job["updated_at"] = time.time()
+
+
+# ── /state ─────────────────────────────────────────────────────────────────
+
+
+_LEMONADE_BIN_CANDIDATES = ("/opt/lemonade/lemonade", "lemonade")
+_FLM_BIN_CANDIDATES = ("flm",)
+
+
+def _probe_version(candidates: tuple[str, ...]) -> str | None:
+    """Run ``<bin> --version`` against the first resolvable candidate.
+
+    Returns the trimmed first line of stdout, or ``None`` if no candidate
+    resolves or the call fails. The 1s timeout is conservative — these
+    are local-process probes that should answer in well under that.
+    """
+    for cand in candidates:
+        binpath = cand if "/" in cand else shutil.which(cand)
+        if not binpath:
+            continue
+        try:
+            out = subprocess.run(
+                [binpath, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=1.0,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        text = (out.stdout or out.stderr or "").strip()
+        if not text:
+            return None
+        return text.splitlines()[0].strip()
+    return None
+
+
+def _parse_lemonade_version(raw: str | None) -> str | None:
+    """``lemonade version 10.6.0`` → ``v10.6.0``."""
+    if not raw:
+        return None
+    # Pull the last whitespace-delimited token; prepend ``v`` if numeric.
+    last = raw.split()[-1] if raw.split() else raw
+    return f"v{last}" if last and last[0].isdigit() else last
+
+
+def _parse_flm_version(raw: str | None) -> str | None:
+    """``FLM v0.9.42`` → ``v0.9.42``."""
+    if not raw:
+        return None
+    parts = raw.split()
+    return parts[-1] if parts else raw
+
+
+@router.get("/state")
+async def update_state(request: Request) -> dict[str, Any]:
+    """Aggregate update state for the Settings → Updates surface.
+
+    Combines the hal0 self-update channel + local probes of bundled
+    components (lemonade, flm) so the dashboard renders real versions
+    instead of hardcoded literals (issue #233).
+
+    Response shape (matches ``ui/src/api/hooks/useUpdates.ts``)::
+
+        {
+            "hal0": {
+                "current": "0.3.0-alpha.1",
+                "available": "0.3.0" | null,
+                "channel": "stable"
+            },
+            "lemonade": {"current": "v10.6.0", "pinned": true, "channel": "stable"},
+            "flm":      {"current": "v0.9.42", "source": "manual-deb"},
+            "autoCheck": true
+        }
+
+    Failures in any single probe degrade gracefully — the corresponding
+    field comes back as ``None`` rather than 5xx'ing the whole response.
+    """
+    channel = _current_channel(request)
+
+    # hal0 self-update: reuse ``check_updates`` semantics but tolerate
+    # a manifest fetch failure (dashboard shouldn't go blank just
+    # because GitHub is rate-limiting).
+    hal0_available: str | None = None
+    try:
+        manifest = await fetch_release_manifest(channel)
+        if isinstance(manifest, dict):
+            latest_raw = manifest.get("version") or manifest.get("latest_version") or ""
+            latest = str(latest_raw)
+            if latest and _version_tuple(latest) > _version_tuple(__version__):
+                hal0_available = latest
+    except (OSError, ValueError):
+        pass
+
+    lemonade_raw = await asyncio.to_thread(_probe_version, _LEMONADE_BIN_CANDIDATES)
+    flm_raw = await asyncio.to_thread(_probe_version, _FLM_BIN_CANDIDATES)
+
+    return {
+        "hal0": {
+            "current": __version__,
+            "available": hal0_available,
+            "channel": channel,
+        },
+        "lemonade": {
+            "current": _parse_lemonade_version(lemonade_raw),
+            "pinned": True,
+            "channel": channel,
+        },
+        "flm": {
+            "current": _parse_flm_version(flm_raw),
+            "source": "manual-deb",
+        },
+        "autoCheck": True,
+    }
 
 
 # ── /check ─────────────────────────────────────────────────────────────────

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -59,6 +59,72 @@ def test_check_returns_well_formed_envelope_with_update_available(
     assert isinstance(body["manifest"], dict)
 
 
+def test_state_returns_shape_expected_by_dashboard(
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET /api/updates/state matches the UpdateState shape in useUpdates.ts.
+
+    Probes are stubbed so the test doesn't depend on lemonade/flm being
+    installed on the test host. Issue #233.
+    """
+    from hal0.api.routes import updater as u_mod
+
+    monkeypatch.setattr(u_mod, "_probe_version", lambda _c: None)
+
+    r = isolated_client.get("/api/updates/state")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # Top-level keys mirror UpdateState in ui/src/api/hooks/useUpdates.ts.
+    assert set(body.keys()) == {"hal0", "lemonade", "flm", "autoCheck"}
+    assert body["hal0"]["current"]  # __version__ is non-empty
+    assert body["hal0"]["available"] == "9.9.9"
+    assert body["hal0"]["channel"] == "stable"
+    # Probes returned None — UI should render '—' rather than fabricated versions.
+    assert body["lemonade"]["current"] is None
+    assert body["flm"]["current"] is None
+    assert body["autoCheck"] is True
+
+
+def test_state_parses_lemonade_and_flm_version_strings(
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Probe output ``lemonade version 10.6.0`` / ``FLM v0.9.42`` parses cleanly."""
+    from hal0.api.routes import updater as u_mod
+
+    def fake_probe(candidates: tuple[str, ...]) -> str | None:
+        # First candidate of the lemonade tuple is /opt/lemonade/lemonade.
+        if "lemonade" in candidates[0]:
+            return "lemonade version 10.6.0"
+        if candidates[0] == "flm":
+            return "FLM v0.9.42"
+        return None
+
+    monkeypatch.setattr(u_mod, "_probe_version", fake_probe)
+
+    r = isolated_client.get("/api/updates/state")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["lemonade"]["current"] == "v10.6.0"
+    assert body["flm"]["current"] == "v0.9.42"
+
+
+def test_state_survives_manifest_fetch_failure(
+    isolated_client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing release-manifest must NOT 5xx /state — degrade hal0.available to None."""
+    missing = tmp_path / "nope.json"
+    monkeypatch.setenv("HAL0_RELEASES_URL", str(missing))
+    from hal0.api.routes import updater as u_mod
+
+    monkeypatch.setattr(u_mod, "_probe_version", lambda _c: None)
+
+    r = isolated_client.get("/api/updates/state")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["hal0"]["available"] is None
+    assert body["hal0"]["current"]  # still reports our version
+
+
 def test_check_no_update_when_versions_match(
     isolated_client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/ui/src/dash/settings.jsx
+++ b/ui/src/dash/settings.jsx
@@ -376,17 +376,13 @@ function SecretsSection() {
 }
 
 function UpdatesSection() {
-  // Phase B1: live state + check + apply mutations. Fallback shows the
-  // design's v0.2.2-available story when no backend.
+  // Phase B1: live state + check + apply mutations. While the query is
+  // in flight or 5xx'd we render an empty envelope and let the SRow
+  // fallbacks show '—' rather than fabricated versions.
   const stateQuery = useUpdateState();
   const checkM = useUpdateCheck();
   const applyM = useUpdateApply();
-  const u = stateQuery.data || {
-    hal0: { current: 'v0.2.1', available: 'v0.2.2', channel: 'stable' },
-    lemonade: { current: 'v10.6.0', pinned: true, channel: 'stable' },
-    flm: { current: 'v0.9.42', source: 'manual-deb' },
-    autoCheck: true,
-  };
+  const u = stateQuery.data || { hal0: {}, lemonade: {}, flm: {}, autoCheck: true };
   return (
     <div className="s-section">
       <h2>Updates</h2>
@@ -414,7 +410,7 @@ function UpdatesSection() {
           k="lemonade"
           sub="Pinned. SHA-256 verified."
           mono
-          v={`${u.lemonade?.current} · channel: ${u.lemonade?.channel || 'stable'}`}
+          v={u.lemonade?.current ? `${u.lemonade.current} · channel: ${u.lemonade.channel || 'stable'}` : '—'}
           actions={<button className="btn ghost sm" onClick={() => checkM.mutate('lemonade')}>Check</button>}
         />
         <SRow


### PR DESCRIPTION
## Summary

- Adds `GET /api/updates/state` that probes hal0 + lemonade + flm versions live and returns the shape `useUpdates.ts` already expects (`UpdateState = {hal0, lemonade, flm, autoCheck}`).
- Drops the hardcoded `v10.6.0` / `v0.9.42` fallback in `settings.jsx` so missing values render as `—` instead of fabricated versions.

First in a series of mock-cleanup PRs against the v3 dashboard (tracker #234). The other carried-over Vue hardcodes (#213 chat chips, #214 hal0-Pro, #215 NPU panel, #216 create-slot enums) need separate fixes — handled in follow-ups.

## Verification

Verified live on hal0 LXC 2026-05-25 — `GET /api/updates/check` already returns hal0 0.2.0a3 → 0.3.0-alpha.1, but the dashboard's `useUpdateState` hook calls `/api/updates/state` (didn't exist before this PR), so the fallback object rendered hardcoded versions.

Backend probes confirmed:
\`\`\`
$ /opt/lemonade/lemonade --version  → lemonade version 10.6.0
$ flm --version                      → FLM v0.9.42
\`\`\`

## Test plan

- [x] `pytest tests/api/test_updater_routes.py` — 14 pass (3 new)
- [x] `ruff check` + `ruff format --check` on touched files
- [ ] Manual: load `/settings` on a fresh hal0 box; confirm hal0/lemonade/flm versions reflect the live install
- [ ] Manual: stop the upstream releases manifest; confirm `hal0.available` degrades to `null` without breaking the surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)