### PR TITLE
fix(dash): hide throughput chip when lemonade does not emit MB/s (#326)

### DIFF
--- a/ui/src/api/mock.ts
+++ b/ui/src/api/mock.ts
@@ -46,6 +46,12 @@ function buildHealth() {
 }
 
 function buildStats() {
+  // /v1/stats fallback (Phase 4, #326). Lemonade's real /v1/stats does
+  // not include `throughput_mbps` — throughput is sourced exclusively
+  // from /v1/health (see useLemondRollup). DO NOT synthesize
+  // `throughput_mbps: 0.0` here as a "completeness" gesture — the
+  // footer chip is gated to hide when null/0 and a synthetic zero
+  // would re-introduce the misleading "0.0 MB/s" the chip is hiding.
   return {
     time_to_first_token: 0.22,
     tokens_per_second: 45.0,

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -275,10 +275,19 @@ function Footer({ updateAvailable = true, expanded = false, onToggle, journal = 
           <span className="k">lemond:</span>
           <span className="v">{L.status}</span>
         </div>
-        <div className="foot-chip">
-          <span className="k">throughput</span>
-          <span className="v num">{L.throughput != null ? `${L.throughput} MB/s` : '—'}</span>
-        </div>
+        {/*
+          Throughput chip (#326): Lemonade does not yet surface
+          throughput_mbps on /v1/health for every backend. The rollup
+          coerces missing → null. Hide the chip entirely instead of
+          rendering "—" or "0.0 MB/s" — a value of 0 from a live system
+          actually serving traffic is just as meaningless as null.
+        */}
+        {L.throughput != null && L.throughput > 0 && (
+          <div className="foot-chip">
+            <span className="k">throughput</span>
+            <span className="v num">{`${L.throughput} MB/s`}</span>
+          </div>
+        )}
         <div className="foot-chip">
           <span className="k">loaded</span>
           <span className="v num">{L.loaded}/{L.budget}</span>

--- a/ui/tests/e2e/specs/footer-throughput-chip-v3.spec.ts
+++ b/ui/tests/e2e/specs/footer-throughput-chip-v3.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * footer-throughput-chip-v3 — issue #326 (epic #322 Phase 4).
+ *
+ * The throughput chip in the footer used to render `${L.throughput} MB/s`
+ * with a `—` fallback when Lemonade did not surface `throughput_mbps`.
+ * That produced misleading "—" output (and would have produced "0.0 MB/s"
+ * if any layer of the fallback chain ever defaulted to 0). The chip now
+ * hides entirely when throughput is null or 0, matching the same null-
+ * honoring discipline as queued + coresident (#221).
+ *
+ * Spec runs against MOCK_LEMONADE-forced dev. `buildHealth` round-trips
+ * HAL0_DATA.lemond.throughput so we can drive the three states by
+ * clobbering HAL0_DATA before the dash modules read it.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+test.describe('Footer throughput chip hides on missing/zero (#326)', () => {
+  test('renders "12.4 MB/s" when health surfaces a positive throughput', async ({ page }) => {
+    await page.goto('/')
+    const footer = page.locator('.footer')
+    await expect(footer).toBeVisible()
+    // Wait for the 2s health poll to land — sidebar version row is a
+    // good proxy for "rollup data has propagated".
+    await expect(page.locator('.sb-status .row .v', { hasText: /^v\d/ })).toBeVisible({ timeout: 6_000 })
+
+    const throughputChip = footer.locator('.foot-chip', { has: page.locator('.k', { hasText: /^throughput$/ }) })
+    await expect(throughputChip).toBeVisible()
+    // HAL0_DATA seeds throughput=12.4.
+    await expect(throughputChip.locator('.v')).toHaveText('12.4 MB/s')
+  })
+
+  test('chip hidden when health omits throughput_mbps', async ({ page }) => {
+    await page.addInitScript(() => {
+      const id = setInterval(() => {
+        const d = (window as any).HAL0_DATA
+        if (d && d.lemond) {
+          d.lemond.throughput = undefined
+          clearInterval(id)
+        }
+      }, 5)
+    })
+
+    await page.goto('/')
+    const footer = page.locator('.footer')
+    await expect(footer).toBeVisible()
+    await expect(page.locator('.sb-status .row .v', { hasText: /^v\d/ })).toBeVisible({ timeout: 6_000 })
+    await page.waitForTimeout(2_500)
+
+    const throughputChip = footer.locator('.foot-chip', { has: page.locator('.k', { hasText: /^throughput$/ }) })
+    await expect(throughputChip).toHaveCount(0)
+  })
+
+  test('chip hidden when health reports throughput_mbps=0', async ({ page }) => {
+    // Zero from a live system that's actually serving traffic is just
+    // as meaningless as null — a "0.0 MB/s" badge in the footer would
+    // look like a metrics bug. Treat 0 as "no signal" and hide.
+    await page.addInitScript(() => {
+      const id = setInterval(() => {
+        const d = (window as any).HAL0_DATA
+        if (d && d.lemond) {
+          d.lemond.throughput = 0
+          clearInterval(id)
+        }
+      }, 5)
+    })
+
+    await page.goto('/')
+    const footer = page.locator('.footer')
+    await expect(footer).toBeVisible()
+    await expect(page.locator('.sb-status .row .v', { hasText: /^v\d/ })).toBeVisible({ timeout: 6_000 })
+    await page.waitForTimeout(2_500)
+
+    const throughputChip = footer.locator('.foot-chip', { has: page.locator('.k', { hasText: /^throughput$/ }) })
+    await expect(throughputChip).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary

The footer throughput chip used to render `${L.throughput} MB/s` with a `—` fallback when Lemonade's `/v1/health` did not surface `throughput_mbps`. This always-on chip looked broken on installs where the metric isn't emitted — and would have shown a misleading "0.0 MB/s" if any layer of the fallback chain ever defaulted to 0. The chip now hides entirely when throughput is null or 0, matching the same null-honoring discipline the queued + coresident chips got in #221. A value of `0` from a live system actually serving traffic is just as meaningless as null, so both states collapse to "hide".

`buildStats()` in the mock harness gets a banner comment explicitly banning future "completeness" defaults of `throughput_mbps: 0.0` — throughput is sourced exclusively from `/v1/health` (via `useLemondRollup`), so synthesizing it on the `/v1/stats` fallback path would re-introduce the misleading chip the gate is designed to hide.

`useLemondRollup` was audited and already coerces correctly (`h?.throughput_mbps ?? null`) — no change needed there.

## Files changed

- `ui/src/dash/chrome.jsx` — gate the throughput chip on `L.throughput != null && L.throughput > 0`
- `ui/src/api/mock.ts` — document `buildStats()` to ban synthetic `throughput_mbps: 0.0` defaults
- `ui/tests/e2e/specs/footer-throughput-chip-v3.spec.ts` — new Playwright spec, 3 cases

## Test plan

- [x] `npm --prefix ui run typecheck` — clean
- [x] `npm --prefix ui run build` — clean (533 KB JS / 84 KB CSS)
- [x] `grep -r "throughput_mbps.*0\.0" ui/dist/` — no match
- [x] `npx playwright test footer-throughput-chip-v3 footer-chips-v3` — 5/5 passed (3 new + 2 existing #221 regression)

Closes #326
Refs #322