### PR TITLE
fix(dash): wire UpdateBanner to useUpdateState (#324)

### DIFF
--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -164,6 +164,11 @@ function App() {
         {!isFirstrun && <Sidebar route={route} onGo={go} />}
         <div className="main">
           <div className="view-banners">
+            {/* Phase 2 of #322: UpdateBanner self-renders when the
+                `useUpdateState()` hook reports a newer hal0 release than
+                the current install. BannerStack continues to drive the
+                Tweaks-panel demo toggles for every other banner state. */}
+            <UpdateBanner />
             <BannerStack scope="global" route={route} />
           </div>
           {renderView()}

--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -1,6 +1,8 @@
 // hal0 dashboard — reusable primitives
 // Modal, Drawer, ConfirmDialog, Banner, BannerStack, Dropdown menu
 
+import { useUpdateState } from '@/api/hooks/useUpdates'
+
 const { useState: useStateP, useEffect: useEffectP, useRef: useRefP, createContext: createContextP, useContext: useContextP } = React;
 
 // ─── Portal-less Modal ────────────────────────────────────────────────────
@@ -380,6 +382,50 @@ const BANNER_CATALOG = [
   },
 ];
 
+// ─── UpdateBanner — live-data wrapper around <Banner> ───────────────────
+// Phase 2 of epic #322: replaces the prototype's hardcoded
+// "hal0 v0.2.2 is available" catalog entry with a live read of
+// `useUpdateState()`. Self-hides when there's no newer release than the
+// current install, and tracks its own dismiss state so the banner stays
+// out until the next session even if the hook continues to report an
+// available upgrade.
+//
+// The catalog entry of the same id is kept around so the Tweaks panel
+// can still preview-toggle a static demo banner, but the source of truth
+// for the real surface is this component.
+function UpdateBanner() {
+  const { data: state } = useUpdateState();
+  const [dismissed, setDismissed] = useStateP(false);
+  const hal0 = state && state.hal0;
+  const current = hal0 && hal0.current;
+  const available = hal0 && hal0.available;
+  const hasUpdate = !!available && available !== current;
+  if (!hasUpdate || dismissed) return null;
+  const channel = (hal0 && hal0.channel) || "stable";
+  return (
+    <Banner
+      kind="info"
+      eyebrow="Update available"
+      heading={`hal0 ${available} available`}
+      body={
+        <span>
+          New release on the <span className="mono">{channel}</span> channel.
+          Update expects a brief outage during lemond + hal0-api restart.
+        </span>
+      }
+      actions={
+        <button
+          className="btn ghost sm"
+          onClick={() =>
+            window.__hal0Toast && window.__hal0Toast(`Opening hal0 ${available} release notes`, "info")
+          }
+        >Read release notes</button>
+      }
+      onDismiss={() => setDismissed(true)}
+    />
+  );
+}
+
 // ─── Dropdown menu ───────────────────────────────────────────────────────
 function Menu({ anchor = "right", items, onClose, style }) {
   return (
@@ -402,4 +448,4 @@ function Menu({ anchor = "right", items, onClose, style }) {
   );
 }
 
-Object.assign(window, { Modal, Drawer, ConfirmDialog, Banner, BannerStack, BannerProvider, useBanners, BANNER_CATALOG, Menu });
+Object.assign(window, { Modal, Drawer, ConfirmDialog, Banner, BannerStack, BannerProvider, useBanners, BANNER_CATALOG, Menu, UpdateBanner });

--- a/ui/tests/e2e/specs/update-banner-v3.spec.ts
+++ b/ui/tests/e2e/specs/update-banner-v3.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * update-banner-v3 — Phase 2 of epic #322.
+ *
+ * The UpdateBanner reads `useUpdateState()` and self-renders into the
+ * global banner slot above the active view. It must:
+ *   1. stay hidden when the hook returns `available: null`
+ *   2. stay hidden when `available` matches `current`
+ *   3. render `"hal0 <available> available"` when there's a newer release
+ *   4. honour its dismiss × button without coming back on re-render
+ *
+ * The dev server runs with VITE_MOCK_LEMONADE=1 so the forced-mock layer
+ * in `src/api/mock.ts` short-circuits `/api/updates/state` without ever
+ * touching the network — `page.route` can't intercept. We override the
+ * mock payload at boot via `window.HAL0_DATA.updateStateOverride` instead,
+ * which `buildUpdateState` checks first.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+async function withUpdateState(
+  page: import('@playwright/test').Page,
+  override: unknown,
+) {
+  await page.addInitScript((payload) => {
+    ;(window as any).__hal0UpdateStateOverride = payload
+  }, override)
+}
+
+test.describe('UpdateBanner (#322 phase 2)', () => {
+  test('renders nothing when available is null', async ({ page }) => {
+    await withUpdateState(page, {
+      hal0: { current: '0.3.0-alpha.1', available: null, channel: 'stable' },
+      lemonade: { current: 'v10.6.0', pinned: true, channel: 'stable' },
+      autoCheck: true,
+    })
+    await page.goto('/#dashboard')
+    await expect(page.locator('.topbar')).toBeVisible()
+    await expect(page.locator('.view-banners')).toBeAttached()
+    await expect(page.locator('.view-banners .banner-info')).toHaveCount(0)
+  })
+
+  test('renders nothing when current === available', async ({ page }) => {
+    await withUpdateState(page, {
+      hal0: { current: '0.3.0-alpha.1', available: '0.3.0-alpha.1', channel: 'stable' },
+      lemonade: { current: 'v10.6.0', pinned: true, channel: 'stable' },
+      autoCheck: true,
+    })
+    await page.goto('/#dashboard')
+    await expect(page.locator('.topbar')).toBeVisible()
+    await expect(page.locator('.view-banners .banner-info')).toHaveCount(0)
+  })
+
+  test('renders "hal0 <version> available" when an update is offered', async ({ page }) => {
+    await withUpdateState(page, {
+      hal0: { current: '0.3.0-alpha.1', available: '0.3.0', channel: 'stable' },
+      lemonade: { current: 'v10.6.0', pinned: true, channel: 'stable' },
+      autoCheck: true,
+    })
+    await page.goto('/#dashboard')
+    const banner = page.locator('.view-banners .banner-info').first()
+    await expect(banner).toBeVisible()
+    await expect(banner).toContainText('hal0 0.3.0 available')
+    // channel from the hook payload should be reflected in the body
+    await expect(banner).toContainText('stable')
+  })
+
+  test('dismiss × hides the banner', async ({ page }) => {
+    await withUpdateState(page, {
+      hal0: { current: '0.3.0-alpha.1', available: '0.3.0', channel: 'stable' },
+      lemonade: { current: 'v10.6.0', pinned: true, channel: 'stable' },
+      autoCheck: true,
+    })
+    await page.goto('/#dashboard')
+    const banner = page.locator('.view-banners .banner-info').first()
+    await expect(banner).toBeVisible()
+    await banner.locator('.banner-dismiss').click()
+    await expect(page.locator('.view-banners .banner-info')).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 2 of epic #322. Replaces the hardcoded `"hal0 v0.2.2 is available"` catalog entry in `primitives.jsx` with a live `<UpdateBanner />` component that reads `/api/updates/state` via the existing `useUpdateState()` hook, self-hides when `hal0.available` is null or equals `hal0.current`, and renders `` `hal0 ${available} available` `` plus a channel chip and the existing dismiss button. The catalog entry stays in place so the Tweaks panel can still preview-toggle the demo banner — the dashboard's source of truth for the real surface is now the hook.

Also adds a `window.__hal0UpdateStateOverride` seam to `buildUpdateState` in the forced-mock layer so the new spec can exercise the "no available release" + "current === available" branches without ripping out the `FORCED` short-circuit in `mockFetch`.

## Files changed

- `ui/src/dash/primitives.jsx` — new `UpdateBanner` component + `useUpdateState` import + window export
- `ui/src/dash/main.jsx` — mount `<UpdateBanner />` in the global banner slot above `<BannerStack />`
- `ui/src/api/mock.ts` — `buildUpdateState` now respects `window.__hal0UpdateStateOverride` (testing seam)
- `ui/tests/e2e/specs/update-banner-v3.spec.ts` — new 4-test spec covering null / equal / newer / dismiss

## Test plan

- [x] Local Playwright run: `npx playwright test specs/update-banner-v3.spec.ts --project=chromium` → 4/4 pass
- [x] Full Playwright suite: `npx playwright test --project=chromium` → 57 passed, 16 skipped, 0 failed
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] CI green (pending PR push)

Closes #324
Refs #322