### PR TITLE
feat(api): /api/journal + /api/journal/stream (#323)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -59,6 +59,9 @@ from hal0.api.routes import (
     v1,
 )
 from hal0.api.routes import (
+    journal as journal_routes,
+)
+from hal0.api.routes import (
     lemonade_admin as lemonade_admin_routes,
 )
 from hal0.api.routes import (
@@ -81,6 +84,7 @@ from hal0.config.loader import ConfigParseError, load_hal0_config, load_upstream
 from hal0.dispatcher.router import Dispatcher
 from hal0.events import EventBus
 from hal0.hardware.probe import HardwareProbe
+from hal0.journal import LemondLogRing, start_lemond_bridge
 from hal0.registry.discover import scan_and_register
 from hal0.registry.store import ModelRegistry
 from hal0.slots.manager import SlotManager
@@ -437,6 +441,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # be wired with the same instance); published on app.state here so
     # request handlers can reach it via ``request.app.state.events``.
     app.state.events = event_bus
+    # Lemond log ring (issue #323 / epic #322 Phase 1). Mirrors the
+    # EventBus ring + fan-out for lemond log lines so the unified
+    # /api/journal endpoints can backfill + live-tail both sources via
+    # one envelope. The background bridge task is started below alongside
+    # the other lemonade-bound lifespan tasks.
+    lemond_log_ring = LemondLogRing()
+    app.state.lemond_log_ring = lemond_log_ring
     await event_bus.emit(
         "system.restart",
         "info",
@@ -517,6 +528,17 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         refresh_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await refresh_task
+
+    # Lemond log bridge (issue #323). Long-running task forwarding
+    # LemonadeClient.stream_logs() into the ring so the journal panel
+    # has backfill across reconnects. The task is resilient to lemond
+    # bouncing — it reconnects with exponential backoff internally.
+    lemond_bridge_task = start_lemond_bridge(lemond_log_ring)
+
+    async def _stop_lemond_bridge() -> None:
+        lemond_bridge_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await lemond_bridge_task
 
     # Lemonade idle-unload driver (ADR-0007 §Related, ADR-0008 §1). v0.2
     # makes Lemonade the sole backend, so this driver always starts —
@@ -604,6 +626,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             for mgr in managers:
                 await stack.enter_async_context(mgr.run())
             stack.push_async_callback(_stop_refresh_task)
+            stack.push_async_callback(_stop_lemond_bridge)
             yield
     finally:
         if lemonade_metrics_shim is not None:
@@ -773,6 +796,16 @@ def create_app() -> FastAPI:
     # reason as /api/status: the footer renders during first-run before
     # any credential exists. No mutating endpoints live on this router.
     app.include_router(events_routes.router, prefix="/api/events", tags=["events"])
+
+    # Unified journal panel (issue #323, epic #322 Phase 1). Merges
+    # /api/events + /api/lemonade/logs/stream into one shape for the
+    # dashboard's journal panel. Read-only; same first-run rationale
+    # as /api/events.
+    app.include_router(
+        journal_routes.router,
+        prefix="/api/journal",
+        tags=["journal"],
+    )
 
     # Image cache — generated PNGs from /v1/images/generations.  Admin
     # auth gate: cached PNGs live at predictable /api/images/cache/<uuid>

--- a/src/hal0/api/routes/journal.py
+++ b/src/hal0/api/routes/journal.py
@@ -1,0 +1,392 @@
+"""Unified journal endpoints — merges hal0 events + lemond logs.
+
+Issue #323 (epic #322 — Phase 1 of the journal panel rework). Surfaces
+two endpoints under ``/api/journal``:
+
+  * ``GET /api/journal`` — HTTP backfill with filter + cursor params.
+  * ``GET /api/journal/stream`` — SSE live tail (with 50-entry replay).
+
+Both endpoints compose two upstream surfaces into one unified shape:
+
+  * **hal0 events** read from :class:`hal0.events.EventBus` via
+    :attr:`app.state.events`.
+  * **lemond logs** read from :class:`hal0.journal.LemondLogRing` via
+    :attr:`app.state.lemond_log_ring` (populated by the lifespan-owned
+    bridge task — see :mod:`hal0.api.__init__`).
+
+The journal route is purposely separate from the existing
+``/api/events`` + ``/api/lemonade/logs/stream`` surfaces: those expose
+the raw single-source shapes for callers that want native fidelity,
+while ``/api/journal`` flattens both into a uniform :class:`JournalEntry`
+the dashboard journal panel can render without per-source branching.
+
+No auth gate — same rationale as ``/api/events`` (post-ADR-0012 hal0-api
+is open on 0.0.0.0:8080; agent identity rides on ``X-hal0-Agent``, not
+Bearer tokens; the journal panel must surface during first-run before
+any agent identity exists).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import Any, Literal
+
+from fastapi import APIRouter, Query, Request
+from pydantic import BaseModel
+from starlette.responses import StreamingResponse
+
+from hal0.events import EventBus
+from hal0.journal import LemondLogRing, now_iso
+
+router = APIRouter()
+
+# Hard ceiling on ``?limit=`` to keep a hostile caller from forcing us
+# to materialise a huge response. Matches the events router's spirit.
+_LIMIT_MAX = 500
+
+# SSE keep-alive cadence. Matches the events route so a single proxy
+# tuning value (>15s idle timeout) covers both streams.
+_KEEPALIVE_S: float = 15.0
+
+# Replay window for the SSE stream — backfill the last N entries
+# synchronously before switching to live tail so a fresh page load
+# always sees some context.
+_STREAM_REPLAY_DEFAULT = 50
+
+
+SourceFilter = Literal["hal0", "lemond", "merged", "all"]
+LevelFilter = Literal["info", "warn", "error"]
+
+
+class JournalEntry(BaseModel):
+    """Unified journal row served by ``/api/journal``.
+
+    Distinct from the raw event shape so the dashboard can render hal0
+    events and lemond log lines through one component without per-source
+    branching. ``data`` is opaque — for hal0 events it carries the raw
+    event ``type`` + ``source`` + ``data`` so callers wanting native
+    fidelity don't have to re-fetch from ``/api/events``; for lemond it
+    carries the raw payload so a future panel-side detail expander has
+    something to show.
+    """
+
+    id: int
+    ts: str
+    source: Literal["hal0", "lemond"]
+    level: LevelFilter
+    msg: str
+    data: dict[str, Any] | None = None
+
+
+# ── Source-specific entry builders ────────────────────────────────────
+
+
+def _hal0_event_to_entry(event: dict[str, Any]) -> JournalEntry:
+    """Project an EventBus event onto the unified ``JournalEntry`` shape.
+
+    Severity passes through as ``level``; the event's structured
+    ``type`` + ``source`` + ``data`` are carried in the entry's
+    ``data`` so consumers wanting native event fidelity don't have to
+    cross-reference ``/api/events``.
+    """
+    severity = event.get("severity") or "info"
+    if severity not in {"info", "warn", "error"}:
+        severity = "info"
+    return JournalEntry(
+        id=int(event["id"]),
+        ts=str(event["ts"]),
+        source="hal0",
+        level=severity,  # type: ignore[arg-type]
+        msg=str(event.get("message") or ""),
+        data={
+            "type": event.get("type"),
+            "source": event.get("source"),
+            **(event.get("data") or {}),
+        },
+    )
+
+
+def _lemond_entry_to_entry(stored: dict[str, Any]) -> JournalEntry:
+    """Project a stored lemond ring entry onto ``JournalEntry``.
+
+    The ring already normalised ``level`` + ``ts`` + ``message`` on
+    append (see :class:`LemondLogRing.append`); we just relabel into
+    the journal envelope here.
+    """
+    level = stored.get("level") or "info"
+    if level not in {"info", "warn", "error"}:
+        level = "info"
+    return JournalEntry(
+        id=int(stored["id"]),
+        ts=str(stored.get("ts") or now_iso()),
+        source="lemond",
+        level=level,  # type: ignore[arg-type]
+        msg=str(stored.get("message") or ""),
+        data=dict(stored.get("raw") or {}) or None,
+    )
+
+
+# ── App-state accessors ───────────────────────────────────────────────
+
+
+def _bus(request: Request) -> EventBus | None:
+    """Return the EventBus on app.state, or ``None`` when absent."""
+    return getattr(request.app.state, "events", None)
+
+
+def _lemond_ring(request: Request) -> LemondLogRing | None:
+    """Return the lemond log ring on app.state, or ``None`` when absent."""
+    return getattr(request.app.state, "lemond_log_ring", None)
+
+
+# ── Filtering ─────────────────────────────────────────────────────────
+
+
+def _passes_filters(
+    entry: JournalEntry,
+    *,
+    level: LevelFilter | None,
+    q: str | None,
+) -> bool:
+    """Apply level (exact) + q (case-insensitive substring on ``msg``).
+
+    Source filtering happens at collection time (we skip the source
+    entirely when ``source != "merged"|"all"``), so it's not handled
+    here.
+    """
+    if level is not None and entry.level != level:
+        return False
+    return not (q and q.lower() not in entry.msg.lower())
+
+
+def _collect(
+    request: Request,
+    *,
+    source: SourceFilter,
+    since: int | None,
+) -> list[JournalEntry]:
+    """Pull raw entries from the selected sources, no filter applied.
+
+    Returns the materialised :class:`JournalEntry` list. ``since``
+    cursors each source independently — the EventBus + lemond ring
+    have disjoint id namespaces, so a single ``since`` value can't
+    cleanly span both. Phase 2 introduces compound cursors; today the
+    cursor applies per-source and the merge runs over the union.
+    """
+    entries: list[JournalEntry] = []
+    if source in {"hal0", "merged", "all"}:
+        bus = _bus(request)
+        if bus is not None:
+            for ev in bus.backfill(since=since, limit=_LIMIT_MAX):
+                entries.append(_hal0_event_to_entry(ev))
+    if source in {"lemond", "merged", "all"}:
+        ring = _lemond_ring(request)
+        if ring is not None:
+            for stored in ring.backfill(since=since, limit=_LIMIT_MAX):
+                entries.append(_lemond_entry_to_entry(stored))
+    return entries
+
+
+def _sort_and_clamp(entries: list[JournalEntry], limit: int) -> list[JournalEntry]:
+    """Sort merged entries by ``ts`` ascending, keep the newest ``limit``."""
+    entries.sort(key=lambda e: e.ts)
+    if len(entries) > limit:
+        entries = entries[-limit:]
+    return entries
+
+
+# ── HTTP backfill ─────────────────────────────────────────────────────
+
+
+@router.get("")
+async def get_journal(
+    request: Request,
+    source: SourceFilter = Query(default="merged"),
+    level: LevelFilter | None = Query(default=None),
+    q: str | None = Query(default=None),
+    since: int | None = Query(default=None, ge=0),
+    limit: int = Query(default=200, ge=1, le=_LIMIT_MAX),
+) -> dict[str, Any]:
+    """Return a page of unified journal entries with a cursor for the next call.
+
+    ``next_since`` is the **largest id seen** in the returned page —
+    callers should pass it back as ``since`` to receive deltas. Because
+    the two sources share a single id namespace from the caller's
+    perspective (the dashboard polls one endpoint), a small ambiguity
+    arises: an id-N hal0 event and an id-N lemond log are both > since-N.
+    Today this means a polling caller might re-see one entry on the
+    next call. Phase 2's compound-cursor work resolves it; the cost
+    of a single duplicate per poll is acceptable.
+    """
+    raw = _collect(request, source=source, since=since)
+    filtered = [e for e in raw if _passes_filters(e, level=level, q=q)]
+    page = _sort_and_clamp(filtered, limit)
+    if page:
+        next_since: int | None = max(e.id for e in page)
+    else:
+        next_since = since
+    return {
+        "entries": [e.model_dump() for e in page],
+        "next_since": next_since,
+    }
+
+
+# ── SSE live tail ─────────────────────────────────────────────────────
+
+
+async def _stream_iter(
+    request: Request,
+    *,
+    source: SourceFilter,
+    level: LevelFilter | None,
+    q: str | None,
+    since: int | None,
+) -> Any:
+    """Async generator producing SSE frames for ``/api/journal/stream``.
+
+    1. Subscribe to both sources up-front so events emitted between
+       backfill snapshot and live tail don't get dropped.
+    2. Yield a synchronous backfill of the last ~50 entries.
+    3. Multiplex live entries off whichever subscriber queue fires next,
+       relabelling into the unified envelope as they arrive.
+    """
+    bus = _bus(request)
+    ring = _lemond_ring(request)
+
+    # Build subscription contexts for whichever sources are selected.
+    # We use AsyncExitStack so cancellation cleans up both queues even
+    # when one source is absent (e.g. lemond bridge not started in a
+    # unit-test fixture).
+    from contextlib import AsyncExitStack
+
+    async with AsyncExitStack() as stack:
+        hal0_q: asyncio.Queue[dict[str, Any]] | None = None
+        lemond_q: asyncio.Queue[dict[str, Any]] | None = None
+
+        if source in {"hal0", "merged", "all"} and bus is not None:
+            hal0_q = await stack.enter_async_context(bus.subscribe())
+        if source in {"lemond", "merged", "all"} and ring is not None:
+            lemond_q = await stack.enter_async_context(ring.subscribe())
+
+        # ── Replay ────────────────────────────────────────────────────
+        replay_limit = _STREAM_REPLAY_DEFAULT
+        raw = _collect(request, source=source, since=since)
+        filtered = [e for e in raw if _passes_filters(e, level=level, q=q)]
+        replay = _sort_and_clamp(filtered, replay_limit)
+        last_hal0_id = since or 0
+        last_lemond_id = since or 0
+        for entry in replay:
+            yield f"data: {json.dumps(entry.model_dump())}\n\n"
+            if entry.source == "hal0":
+                last_hal0_id = max(last_hal0_id, entry.id)
+            else:
+                last_lemond_id = max(last_lemond_id, entry.id)
+
+        # ── Live tail ─────────────────────────────────────────────────
+        # asyncio.wait on the per-source queue.get() coroutines so a
+        # single loop iteration drains whichever surface fired. The
+        # keep-alive timer is folded into the same wait so we don't
+        # need a third coroutine.
+        while True:
+            if await request.is_disconnected():
+                return
+
+            pending: dict[asyncio.Task[Any], str] = {}
+            if hal0_q is not None:
+                t = asyncio.create_task(hal0_q.get())
+                pending[t] = "hal0"
+            if lemond_q is not None:
+                t = asyncio.create_task(lemond_q.get())
+                pending[t] = "lemond"
+
+            if not pending:
+                # No active sources — degrade gracefully by sleeping the
+                # keep-alive interval and emitting a comment frame.
+                await asyncio.sleep(_KEEPALIVE_S)
+                yield ": keepalive\n\n"
+                continue
+
+            done, still_pending = await asyncio.wait(
+                pending.keys(),
+                timeout=_KEEPALIVE_S,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            # Cancel the losers so their queue.get() doesn't leak a
+            # consumer between iterations.
+            for t in still_pending:
+                t.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await t
+
+            if not done:
+                # Timed out → emit keep-alive and loop.
+                yield ": keepalive\n\n"
+                continue
+
+            for task in done:
+                src = pending[task]
+                try:
+                    raw_entry = task.result()
+                except Exception:
+                    continue
+                if src == "hal0":
+                    entry = _hal0_event_to_entry(raw_entry)
+                    if entry.id <= last_hal0_id:
+                        continue
+                    last_hal0_id = entry.id
+                else:
+                    entry = _lemond_entry_to_entry(raw_entry)
+                    if entry.id <= last_lemond_id:
+                        continue
+                    last_lemond_id = entry.id
+                if not _passes_filters(entry, level=level, q=q):
+                    continue
+                yield f"data: {json.dumps(entry.model_dump())}\n\n"
+
+
+@router.get("/stream")
+async def stream_journal(
+    request: Request,
+    source: SourceFilter = Query(default="merged"),
+    level: LevelFilter | None = Query(default=None),
+    q: str | None = Query(default=None),
+    since: int | None = Query(default=None, ge=0),
+) -> StreamingResponse:
+    """SSE live tail of the unified journal.
+
+    Replays the last ~50 filtered entries synchronously, then streams
+    live additions until the client disconnects. Keep-alive comment
+    frames pulse every 15s so proxies don't reap idle connections.
+    """
+
+    async def _safe() -> Any:
+        try:
+            async for chunk in _stream_iter(
+                request,
+                source=source,
+                level=level,
+                q=q,
+                since=since,
+            ):
+                yield chunk
+        except asyncio.CancelledError:
+            raise
+
+    return StreamingResponse(
+        _safe(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )
+
+
+__all__ = [
+    "JournalEntry",
+    "router",
+]

--- a/src/hal0/journal/__init__.py
+++ b/src/hal0/journal/__init__.py
@@ -1,0 +1,288 @@
+"""Lemond log ring + fan-out for the journal panel (issue #323, epic #322).
+
+The journal panel needs a unified view of two log streams:
+
+  * **hal0 events** — already buffered by :class:`hal0.events.EventBus`
+    (500-entry ring + per-subscriber fan-out).
+  * **lemond logs** — surfaced today as a passthrough SSE in
+    :mod:`hal0.api.routes.lemonade_logs`, but with no in-process backfill:
+    a freshly-loaded panel sees only events emitted *after* it subscribes.
+
+This module fills the lemond-side gap. It mirrors :class:`hal0.events.EventBus`'s
+shape (bounded ring + per-subscriber asyncio.Queue with drop-oldest overflow)
+so the journal route can compose both surfaces uniformly. A single background
+task driven from the FastAPI lifespan keeps the ring fed; the task is
+resilient to lemond bouncing — it reconnects with exponential backoff so a
+restart of lemond doesn't permanently silence the journal.
+
+Why not just reuse :class:`EventBus` directly? The two surfaces have
+distinct id namespaces (EventBus events vs lemond lines) and disjoint
+filter semantics (severity glob vs lemond ``level`` strings). Coupling
+them risks accidentally fanning hal0 events into the lemond ring on a
+careless refactor. A small dedicated ring keeps the boundary explicit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import itertools
+from collections import deque
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+
+__all__ = ["LemondLogRing", "now_iso", "start_lemond_bridge"]
+
+log = structlog.get_logger(__name__)
+
+# Match EventBus sizing — 500 entries is roughly a minute of bursty
+# lemond load/unload chatter and keeps memory tiny (~250KB worst case).
+_RING_MAXLEN = 500
+_SUBSCRIBER_MAXSIZE = 256
+
+# Reconnect backoff bounds for the lemond bridge. Start fast so a one-off
+# restart of lemond catches back up within a couple of seconds; cap at
+# 30s so a permanently-down lemond doesn't churn the event loop.
+_RECONNECT_INITIAL_S = 1.0
+_RECONNECT_MAX_S = 30.0
+
+
+def now_iso() -> str:
+    """Return an ISO-8601 UTC timestamp with microsecond precision."""
+    return datetime.now(UTC).isoformat()
+
+
+class LemondLogRing:
+    """Bounded ring + fan-out for lemond log entries.
+
+    Mirrors :class:`hal0.events.EventBus` but keyed on a private id
+    counter so consumers can cursor-paginate independently of the
+    EventBus id space.
+
+    Each stored entry is a dict::
+
+        {
+            "id":      int,                # monotonic, assigned on append
+            "ts":      str,                # ISO-8601 UTC (lemond's if present)
+            "level":   "info"|"warn"|"error",
+            "message": str,
+            "raw":     dict,               # original lemond payload, opaque
+        }
+    """
+
+    def __init__(
+        self,
+        *,
+        ring_maxlen: int = _RING_MAXLEN,
+        subscriber_maxsize: int = _SUBSCRIBER_MAXSIZE,
+    ) -> None:
+        self.ring: deque[dict[str, Any]] = deque(maxlen=ring_maxlen)
+        self.subscribers: set[asyncio.Queue[dict[str, Any]]] = set()
+        self._next_id: itertools.count[int] = itertools.count(1)
+        self._subscriber_maxsize = subscriber_maxsize
+
+    # ── Append ────────────────────────────────────────────────────────
+
+    def append(self, entry: dict[str, Any]) -> dict[str, Any]:
+        """Append a normalised lemond entry to the ring + fan out.
+
+        Accepts the raw lemond payload (``{"message": ..., "level": ...,
+        "ts": ...}`` with the documented ``text|msg|line`` fallbacks) and
+        normalises it into the canonical shape above. Returns the stored
+        dict so callers (and tests) can inspect the assigned id.
+        """
+        message = _pick_message(entry)
+        level = _normalise_level(entry.get("level"))
+        ts_raw = entry.get("ts")
+        ts = ts_raw if isinstance(ts_raw, str) and ts_raw else now_iso()
+        stored = {
+            "id": next(self._next_id),
+            "ts": ts,
+            "level": level,
+            "message": message,
+            "raw": dict(entry),
+        }
+        self.ring.append(stored)
+        for q in list(self.subscribers):
+            self._enqueue(q, stored)
+        return stored
+
+    def _enqueue(self, q: asyncio.Queue[dict[str, Any]], entry: dict[str, Any]) -> None:
+        """Push to a subscriber queue, dropping oldest on overflow."""
+        try:
+            q.put_nowait(entry)
+        except asyncio.QueueFull:
+            with contextlib.suppress(asyncio.QueueEmpty):
+                q.get_nowait()
+            with contextlib.suppress(asyncio.QueueFull):
+                q.put_nowait(entry)
+
+    # ── Subscribe ─────────────────────────────────────────────────────
+
+    @asynccontextmanager
+    async def subscribe(self) -> AsyncIterator[asyncio.Queue[dict[str, Any]]]:
+        """Yield an asyncio.Queue receiving every entry appended after entry.
+
+        Use as ``async with ring.subscribe() as q: ...``. The queue is
+        unregistered on context exit, including exceptions, so disconnected
+        SSE clients don't leak subscriber slots.
+        """
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=self._subscriber_maxsize)
+        self.subscribers.add(q)
+        try:
+            yield q
+        finally:
+            self.subscribers.discard(q)
+
+    # ── Backfill ──────────────────────────────────────────────────────
+
+    def backfill(self, since: int | None = None, limit: int = 200) -> list[dict[str, Any]]:
+        """Return matching ring entries with id > since, ordered ascending.
+
+        ``limit`` clamps to the most-recent matches so a long-disconnected
+        client picks up where the ring still has context rather than seeing
+        a truncated head.
+        """
+        if limit <= 0:
+            return []
+        out: list[dict[str, Any]] = []
+        for entry in self.ring:
+            if since is not None and entry["id"] <= since:
+                continue
+            out.append(entry)
+        if len(out) > limit:
+            out = out[-limit:]
+        return out
+
+
+# ── Lemond payload normalisation ───────────────────────────────────────
+
+
+_LEVEL_ALIASES = {
+    "info": "info",
+    "information": "info",
+    "debug": "info",
+    "trace": "info",
+    "warn": "warn",
+    "warning": "warn",
+    "err": "error",
+    "error": "error",
+    "fatal": "error",
+    "critical": "error",
+}
+
+
+def _pick_message(entry: dict[str, Any]) -> str:
+    """Extract the human-readable log line from a lemond entry.
+
+    Mirrors :func:`hal0.api.routes.lemonade_logs._extract_message` but
+    folded here so the ring module has no cross-route dependency. Same
+    fallback order: ``message`` → ``text`` → ``msg`` → ``line``.
+    """
+    msg = entry.get("message")
+    if isinstance(msg, str):
+        return msg
+    for alt in ("text", "msg", "line"):
+        v = entry.get(alt)
+        if isinstance(v, str):
+            return v
+    return ""
+
+
+def _normalise_level(value: Any) -> str:
+    """Map lemond's varied level strings onto info|warn|error.
+
+    Unknown / missing values default to ``info`` — surfacing them as
+    ``error`` would force the dashboard to colour every untyped line
+    red. ``info`` is the safe default; operators who care can filter
+    by message content.
+    """
+    if not isinstance(value, str):
+        return "info"
+    return _LEVEL_ALIASES.get(value.strip().lower(), "info")
+
+
+# ── Background bridge: lemond WS → ring ────────────────────────────────
+
+
+async def _flatten_frame(frame: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten a lemond log frame into per-entry dicts.
+
+    Inline duplicate of :func:`hal0.api.routes.lemonade_logs._iter_entries`
+    so this module stays import-free of the route layer. Tolerates the
+    same ``logs.snapshot`` / ``logs.entry`` / unknown-op shapes.
+    """
+    op = frame.get("op")
+    if op == "logs.snapshot":
+        entries = frame.get("entries")
+        if isinstance(entries, list):
+            return [e for e in entries if isinstance(e, dict)]
+        return []
+    if op == "logs.entry":
+        entry = frame.get("entry")
+        if isinstance(entry, dict):
+            return [entry]
+        return []
+    return [frame]
+
+
+async def _consume_once(ring: LemondLogRing) -> None:
+    """One pass through lemond's log stream. Returns when the stream ends.
+
+    Imports the provider lazily so unit tests can monkeypatch it on the
+    way in without dragging the full provider singleton into scope.
+    """
+    from hal0.providers import lemonade_provider
+
+    client = lemonade_provider().client()
+    async for frame in client.stream_logs():
+        for entry in await _flatten_frame(frame):
+            ring.append(entry)
+
+
+async def _bridge_loop(ring: LemondLogRing) -> None:
+    """Long-running task that keeps the lemond log ring fed.
+
+    Reconnects with exponential backoff (1s → 30s) on any failure so the
+    journal panel keeps working across lemond restarts. Cancellation
+    (FastAPI shutdown) propagates cleanly via :class:`asyncio.CancelledError`.
+    """
+    backoff = _RECONNECT_INITIAL_S
+    while True:
+        try:
+            await _consume_once(ring)
+            # Stream returned cleanly — reset backoff so the next reconnect
+            # is fast (typically lemond restart, not a permanent outage).
+            backoff = _RECONNECT_INITIAL_S
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning(
+                "journal.lemond_bridge_failed",
+                error=str(exc),
+                error_type=type(exc).__name__,
+                backoff_s=backoff,
+            )
+        # Sleep before reconnecting. A clean stream return still backs off
+        # by the initial 1s — without it, a lemond that immediately closes
+        # the WS would spin the event loop.
+        try:
+            await asyncio.sleep(backoff)
+        except asyncio.CancelledError:
+            raise
+        backoff = min(backoff * 2, _RECONNECT_MAX_S)
+
+
+def start_lemond_bridge(ring: LemondLogRing) -> asyncio.Task[None]:
+    """Spawn the background task that forwards lemond logs into ``ring``.
+
+    Caller (the FastAPI lifespan) is responsible for cancelling the task
+    on shutdown. The returned task survives lemond bouncing thanks to
+    :func:`_bridge_loop`'s reconnect logic; cancellation is the only way
+    it exits.
+    """
+    return asyncio.create_task(_bridge_loop(ring))

--- a/tests/api/test_journal_routes.py
+++ b/tests/api/test_journal_routes.py
@@ -1,0 +1,392 @@
+"""Tests for the unified ``/api/journal`` + ``/api/journal/stream`` routes.
+
+Issue #323 (epic #322 Phase 1). The journal panel flattens two upstream
+surfaces into one shape:
+
+  * hal0 :class:`hal0.events.EventBus` (already in-process).
+  * lemond log lines via the new :class:`hal0.journal.LemondLogRing`
+    fed by a background bridge task started in the lifespan.
+
+These tests cover the HTTP backfill + filters + cursor, plus the SSE
+handshake + live-emit path. The bridge task is stubbed out so the test
+process never tries to open a real WebSocket to lemond.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Iterator
+from contextlib import suppress as _suppress
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.events import EventBus
+from hal0.journal import LemondLogRing
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _stub_lemond_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the lemond log bridge with a no-op forever-sleep task.
+
+    The real bridge opens a WebSocket against the local lemond daemon —
+    not available in CI. Stubbing it keeps the lifespan path identical
+    (a task is spawned, awaited on shutdown) without trying any I/O.
+    """
+
+    async def _noop() -> None:
+        with _suppress(asyncio.CancelledError):
+            while True:
+                await asyncio.sleep(3600)
+
+    def _start(_ring: LemondLogRing) -> asyncio.Task[None]:
+        return asyncio.create_task(_noop())
+
+    monkeypatch.setattr("hal0.api.start_lemond_bridge", _start)
+
+
+@pytest.fixture
+def app(tmp_hal0_home: str) -> FastAPI:
+    return create_app()
+
+
+@pytest.fixture
+def client(app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        yield c
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _clear_bootstrap_events(client: TestClient) -> None:
+    """Drop the lifespan's ``system.restart`` event from the EventBus ring.
+
+    Without this, every "empty" assertion has to special-case the
+    bootstrap line. Tests that want to assert on pristine state call
+    this first.
+    """
+    bus: EventBus = client.app.state.events  # type: ignore[attr-defined]
+    bus.ring.clear()
+
+
+def _ring(client: TestClient) -> LemondLogRing:
+    return client.app.state.lemond_log_ring  # type: ignore[attr-defined,no-any-return]
+
+
+def _bus(client: TestClient) -> EventBus:
+    return client.app.state.events  # type: ignore[attr-defined,no-any-return]
+
+
+def _parse_sse_frames(text: str) -> list[dict[str, Any]]:
+    """Pull JSON payloads out of an SSE response body."""
+    out: list[dict[str, Any]] = []
+    for frame in text.split("\n\n"):
+        for line in frame.splitlines():
+            if line.startswith("data:"):
+                payload = line[len("data:") :].strip()
+                if not payload:
+                    continue
+                with _suppress(ValueError):
+                    out.append(json.loads(payload))
+    return out
+
+
+# ── GET /api/journal ─────────────────────────────────────────────────
+
+
+def test_journal_get_empty_returns_empty_list(client: TestClient) -> None:
+    """No events + no lemond entries → empty list + null cursor."""
+    _clear_bootstrap_events(client)
+    r = client.get("/api/journal?source=merged")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body == {"entries": [], "next_since": None}
+
+
+@pytest.mark.asyncio
+async def test_journal_get_with_hal0_event_returns_it(client: TestClient) -> None:
+    """Emit a slot.state event → GET returns it with source=hal0 + level=info."""
+    _clear_bootstrap_events(client)
+    bus = _bus(client)
+    await bus.emit("slot.state", "info", "slot:primary", "primary: starting → ready")
+
+    r = client.get("/api/journal?source=hal0")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["entries"]) == 1
+    entry = body["entries"][0]
+    # Shape check.
+    assert set(entry.keys()) == {"id", "ts", "source", "level", "msg", "data"}
+    assert entry["source"] == "hal0"
+    assert entry["level"] == "info"
+    assert entry["msg"] == "primary: starting → ready"
+    # The original event's type + source ride along in ``data``.
+    assert entry["data"]["type"] == "slot.state"
+    assert entry["data"]["source"] == "slot:primary"
+    assert body["next_since"] == entry["id"]
+
+
+@pytest.mark.asyncio
+async def test_journal_get_source_filter_hal0_only(client: TestClient) -> None:
+    _clear_bootstrap_events(client)
+    bus = _bus(client)
+    ring = _ring(client)
+    await bus.emit("slot.state", "info", "slot:a", "hal0 event")
+    ring.append({"message": "lemond line", "level": "info"})
+
+    r = client.get("/api/journal?source=hal0")
+    assert r.status_code == 200
+    entries = r.json()["entries"]
+    sources = {e["source"] for e in entries}
+    assert sources == {"hal0"}
+
+
+def test_journal_get_source_filter_lemond_only(client: TestClient) -> None:
+    _clear_bootstrap_events(client)
+    ring = _ring(client)
+    ring.append({"message": "lemond line one", "level": "info"})
+    ring.append({"message": "lemond line two", "level": "warn"})
+
+    r = client.get("/api/journal?source=lemond")
+    assert r.status_code == 200
+    entries = r.json()["entries"]
+    assert len(entries) == 2
+    assert {e["source"] for e in entries} == {"lemond"}
+    assert {e["msg"] for e in entries} == {"lemond line one", "lemond line two"}
+
+
+@pytest.mark.asyncio
+async def test_journal_get_level_filter(client: TestClient) -> None:
+    _clear_bootstrap_events(client)
+    bus = _bus(client)
+    ring = _ring(client)
+    await bus.emit("a", "info", "x", "info-event")
+    await bus.emit("b", "warn", "x", "warn-event")
+    await bus.emit("c", "error", "x", "error-event")
+    ring.append({"message": "lemond-warn", "level": "warning"})
+    ring.append({"message": "lemond-info", "level": "info"})
+
+    r = client.get("/api/journal?source=merged&level=warn")
+    assert r.status_code == 200
+    entries = r.json()["entries"]
+    assert all(e["level"] == "warn" for e in entries)
+    msgs = {e["msg"] for e in entries}
+    assert msgs == {"warn-event", "lemond-warn"}
+
+
+@pytest.mark.asyncio
+async def test_journal_get_q_filter_substring(client: TestClient) -> None:
+    _clear_bootstrap_events(client)
+    bus = _bus(client)
+    ring = _ring(client)
+    await bus.emit("slot.state", "info", "slot:a", "primary: starting → ready")
+    await bus.emit("slot.state", "info", "slot:a", "embed: idle")
+    ring.append({"message": "Loaded primary model from cache", "level": "info"})
+    ring.append({"message": "Warming up worker", "level": "info"})
+
+    # Case-insensitive substring on ``msg``.
+    r = client.get("/api/journal?source=merged&q=PRIMARY")
+    assert r.status_code == 200
+    entries = r.json()["entries"]
+    msgs = [e["msg"] for e in entries]
+    assert all("primary" in m.lower() for m in msgs)
+    assert len(msgs) == 2
+
+
+@pytest.mark.asyncio
+async def test_journal_get_since_cursor_pagination(client: TestClient) -> None:
+    """``since`` advances per source — second page sees only newer ids."""
+    _clear_bootstrap_events(client)
+    bus = _bus(client)
+    for i in range(5):
+        await bus.emit("slot.state", "info", "slot:a", f"event {i}")
+
+    page1 = client.get("/api/journal?source=hal0&limit=2").json()
+    assert len(page1["entries"]) == 2
+    cursor = page1["next_since"]
+    assert cursor is not None
+
+    page2 = client.get(f"/api/journal?source=hal0&since={cursor}&limit=10").json()
+    page2_ids = {e["id"] for e in page2["entries"]}
+    page1_ids = {e["id"] for e in page1["entries"]}
+    # All page-2 entries strictly newer than the cursor.
+    assert all(i > cursor for i in page2_ids)
+    # And disjoint from page 1.
+    assert page1_ids.isdisjoint(page2_ids)
+
+
+# ── GET /api/journal/stream ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_journal_stream_handshake_returns_sse_content_type(app: FastAPI) -> None:
+    """The stream surface advertises the correct content-type + path resolves.
+
+    Driven via the in-process ``stream_journal`` callable so the test
+    doesn't have to drive a real httpx connection (TestClient's sync
+    ``.stream()`` blocks the event loop and never observes
+    ``request.is_disconnected``, hanging the test).
+    """
+    async with app.router.lifespan_context(app):  # type: ignore[attr-defined]
+        from hal0.api.routes.journal import stream_journal
+
+        class _StubRequest:
+            def __init__(self) -> None:
+                self.app = app
+
+            async def is_disconnected(self) -> bool:
+                return True  # Force immediate disconnect on first iter loop.
+
+        resp = await stream_journal(
+            _StubRequest(),  # type: ignore[arg-type]
+            source="merged",
+            level=None,
+            q=None,
+            since=None,
+        )
+        assert resp.status_code == 200
+        ct = resp.headers.get("content-type", "")
+        assert ct.startswith("text/event-stream"), ct
+        # Mirror PR-11's lemonade-logs assertion shape: no-cache + x-accel-buffering
+        # disable proxy buffering so frames flush per-write.
+        assert resp.headers.get("cache-control") == "no-cache"
+        assert resp.headers.get("x-accel-buffering") == "no"
+        # Drain so the generator exits cleanly (it'll observe
+        # is_disconnected=True after the replay flush and return).
+        with _suppress(Exception):
+            async for _ in resp.body_iterator:
+                break
+
+
+@pytest.mark.asyncio
+async def test_journal_stream_yields_event_on_emit(app: FastAPI) -> None:
+    """Subscribe to the SSE stream, emit a hal0 event, expect a frame.
+
+    Drives ``stream_journal`` directly rather than over TestClient — the
+    sync TestClient can't interleave an ``await bus.emit`` between two
+    ``read()`` calls.
+    """
+    async with app.router.lifespan_context(app):  # type: ignore[attr-defined]
+        bus: EventBus = app.state.events
+        bus.ring.clear()
+        # Drop the lifespan's system.restart so the replay-window is empty.
+
+        from hal0.api.routes.journal import stream_journal
+
+        class _StubRequest:
+            def __init__(self) -> None:
+                self.app = app
+
+            async def is_disconnected(self) -> bool:
+                return False
+
+        resp = await stream_journal(
+            _StubRequest(),  # type: ignore[arg-type]
+            source="merged",
+            level=None,
+            q=None,
+            since=None,
+        )
+        gen: AsyncIterator[Any] = resp.body_iterator
+
+        async def _drain_until(predicate: Any, *, timeout: float = 2.0) -> list[dict[str, Any]]:
+            buf = ""
+            collected: list[dict[str, Any]] = []
+            deadline = asyncio.get_event_loop().time() + timeout
+            async for chunk in gen:
+                if isinstance(chunk, bytes):
+                    buf += chunk.decode()
+                else:
+                    buf += str(chunk)
+                collected = _parse_sse_frames(buf)
+                if predicate(collected):
+                    return collected
+                if asyncio.get_event_loop().time() > deadline:
+                    return collected
+            return collected
+
+        # Yield once so the generator's subscribe + replay run before
+        # we emit — otherwise the live tail might miss the emit-as-race.
+        emit_task = asyncio.create_task(bus.emit("slot.state", "info", "slot:a", "live-tail event"))
+        try:
+            seen = await _drain_until(
+                lambda c: any(e.get("msg") == "live-tail event" for e in c),
+                timeout=2.0,
+            )
+        finally:
+            await emit_task
+            with _suppress(Exception):
+                await gen.aclose()
+
+        msgs = [e["msg"] for e in seen]
+        assert "live-tail event" in msgs
+        # And it came through with source=hal0 / level=info.
+        match = next(e for e in seen if e.get("msg") == "live-tail event")
+        assert match["source"] == "hal0"
+        assert match["level"] == "info"
+
+
+@pytest.mark.asyncio
+async def test_journal_stream_replay_includes_lemond_entries(app: FastAPI) -> None:
+    """A lemond entry sitting in the ring is replayed on stream connect."""
+    async with app.router.lifespan_context(app):  # type: ignore[attr-defined]
+        ring: LemondLogRing = app.state.lemond_log_ring
+        ring.append({"message": "stream-replay lemond line", "level": "warn"})
+
+        from hal0.api.routes.journal import stream_journal
+
+        class _StubRequest:
+            def __init__(self) -> None:
+                self.app = app
+                self._calls = 0
+
+            async def is_disconnected(self) -> bool:
+                # First check (after replay) returns False so live tail
+                # arms; second check (after one keep-alive timeout) tears
+                # the generator down — keeps the test bounded.
+                self._calls += 1
+                return self._calls > 1
+
+        resp = await stream_journal(
+            _StubRequest(),  # type: ignore[arg-type]
+            source="lemond",
+            level=None,
+            q=None,
+            since=None,
+        )
+        gen: AsyncIterator[Any] = resp.body_iterator
+
+        buf = ""
+
+        # Replay frames come out synchronously — pull a few chunks until
+        # we see the lemond line, then close.
+        async def _drain() -> str:
+            nonlocal buf
+            async for chunk in gen:
+                if isinstance(chunk, bytes):
+                    buf += chunk.decode()
+                else:
+                    buf += str(chunk)
+                if "stream-replay lemond line" in buf:
+                    return buf
+            return buf
+
+        try:
+            await asyncio.wait_for(_drain(), timeout=2.0)
+        finally:
+            with _suppress(Exception):
+                await gen.aclose()
+
+        frames = _parse_sse_frames(buf)
+        msgs = [f["msg"] for f in frames]
+        assert "stream-replay lemond line" in msgs
+        match = next(f for f in frames if f["msg"] == "stream-replay lemond line")
+        assert match["source"] == "lemond"
+        assert match["level"] == "warn"


### PR DESCRIPTION
## Summary

Phase 1 of the journal panel rework (epic #322 / issue #323). Adds a backend surface that flattens the in-process `EventBus` and a new `LemondLogRing` into one `JournalEntry` shape so the dashboard journal panel can render both sources through a single component. The lemond ring is fed by a lifespan-owned bridge task that wraps `LemonadeClient.stream_logs()` with exponential-backoff reconnect (1s → 30s), so a lemond restart never permanently silences the panel.

## Endpoints

- `GET /api/journal` — backfill with `source` (`hal0` | `lemond` | `merged` | `all`), `level` (`info` | `warn` | `error`), `q` (case-insensitive substring on `msg`), `since`, `limit ≤ 500`. Returns `{ entries: JournalEntry[], next_since }`.
- `GET /api/journal/stream` — SSE: 50-entry replay then live multiplex across both subscriber queues, 15s keep-alive frames, clean disconnect on client close.

Both endpoints are open (no auth) per ADR-0012 — same first-run rationale as `/api/events`.

## Files changed

- `src/hal0/journal/__init__.py` — new `LemondLogRing` (deque(maxlen=500) + per-subscriber `asyncio.Queue` with drop-oldest overflow) + `start_lemond_bridge` background-task helper.
- `src/hal0/api/routes/journal.py` — `JournalEntry` Pydantic model + the two endpoints + the source-specific mappers.
- `src/hal0/api/__init__.py` — wires the router under `/api/journal`, constructs the ring on `app.state.lemond_log_ring`, spawns the bridge task in the lifespan, cancels it cleanly on shutdown.
- `tests/api/test_journal_routes.py` — 10 tests: HTTP empty/shape/source/level/q/since cases + SSE handshake + replay + live-emit. The bridge is stubbed in tests so we never try to open a real WebSocket.

## Test plan

- [x] `pytest tests/api/test_journal_routes.py -x` → 10 passed in 0.9s
- [x] `pytest tests/api/ -x` (full sweep) → 374 passed, 3 pre-existing skipped, no regressions
- [x] `ruff check src/ tests/` → All checks passed
- [x] `ruff format --check src/ tests/` → 298 files already formatted

Closes #323
Refs #322