### PR TITLE
feat(dash): wire footer journal pane + update chip to live data (#325)

### DIFF
--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -82,9 +82,13 @@ export const ENDPOINTS = {
   memoryGraphStatus: '/api/memory/graph/status',
   memoryGraph: '/api/memory/graph',
 
-  // ── Logs (HTTP historical + SSE tail + WS lemond) ────────────────
-  logs: '/api/logs',
-  logsStream: '/api/logs/stream',
+  // ── Journal (HTTP backfill + SSE tail) — unified hal0 + lemond ───
+  // Per #322 Phase 1 (PR #330): the merged ``/api/journal`` surface
+  // supersedes ``/api/logs``. The old constants stay around for the
+  // raw lemond WS channel (used by the LogsView's source=lemond mode);
+  // historical + SSE consumers should prefer the journal endpoints.
+  journal: '/api/journal',
+  journalStream: '/api/journal/stream',
   lemondLogsWs: '/logs/stream',
 
   // ── Settings (hal0.toml read/write) ──────────────────────────────

--- a/ui/src/api/hooks/useLogs.ts
+++ b/ui/src/api/hooks/useLogs.ts
@@ -1,96 +1,224 @@
-// hal0 v3 dashboard — logs hook (Phase B1).
+// hal0 v3 dashboard — journal hook (Phase 3 of epic #322).
 //
-// Three transports per the brief:
-//   - GET /api/logs               — historical snapshot (one-shot)
-//   - SSE /api/logs/stream        — hal0 + lemond merged tail
-//   - WS  /logs/stream            — raw lemond log channel (per
-//                                   hal0_lemonade_ws_protocol memory)
+// Calls the merged ``/api/journal`` surface that landed in PR #330
+// (Phase 1). Two transports:
+//   - GET /api/journal               — historical backfill (one-shot)
+//   - SSE /api/journal/stream        — hal0 + lemond merged live tail
+//   - WS  /logs/stream               — raw lemond log channel, opt-in
+//                                      via includeLemondWs for the Logs
+//                                      page's native-fidelity mode
 //
-// The hook keeps an in-memory ring of `LogEntry`. SSE drives the tail;
-// the historical fetch primes the buffer.
+// The hook keeps an in-memory ring of `JournalEntry`. SSE drives the
+// tail; the historical fetch primes the buffer. SSE reconnects on
+// param change with a short debounce so toggling source/level/q chips
+// doesn't thrash a hot connection.
+//
+// Filter semantics: `source`/`level`/`q` are forwarded to the backend
+// so the wire payload is already small. Callers MAY also filter the
+// returned ring client-side (e.g. the Footer search box) for instant
+// feedback without re-opening the SSE.
 
 import { useEffect, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { apiGet } from '../client'
 import { ENDPOINTS } from '../endpoints'
 
-export interface LogEntry {
+/** Unified journal entry — mirrors ``hal0.api.routes.journal.JournalEntry``. */
+export interface JournalEntry {
+  id: number
   ts: string
-  source: string
-  level: string
-  slot?: string | null
+  source: 'hal0' | 'lemond'
+  level: 'info' | 'warn' | 'error'
   msg: string
+  data?: Record<string, unknown>
+}
+
+/** Back-compat alias — the old LogEntry name is still used by callers. */
+export type LogEntry = JournalEntry & {
+  /** Legacy field carried by the Logs page demo lines, not present on
+   *  JournalEntry. Optional so it doesn't widen the journal contract. */
+  slot?: string | null
+  /** Same story — adjacent-grouping key for the Logs page collapser. */
   group?: string
 }
 
 const RING_MAX = 2000
+/** Debounce SSE reconnect on rapid filter chip toggling. */
+const SSE_RECONNECT_DEBOUNCE_MS = 200
 
-export function useLogsHistorical() {
+export type JournalSource = 'merged' | 'hal0' | 'lemond' | 'all'
+export type JournalLevel = 'info' | 'warn' | 'error'
+
+export interface UseLogsHistoricalOptions {
+  source?: JournalSource
+  level?: JournalLevel | null
+  q?: string | null
+  since?: number | null
+  /** Defaults to 200 (matches backend default + LIMIT_MAX 500). */
+  limit?: number
+  /** When false the query is disabled. */
+  enabled?: boolean
+}
+
+function buildJournalQuery(opts: {
+  source?: JournalSource
+  level?: JournalLevel | null
+  q?: string | null
+  since?: number | null
+  limit?: number
+}): string {
+  const params = new URLSearchParams()
+  if (opts.source && opts.source !== 'merged') params.set('source', opts.source)
+  if (opts.level) params.set('level', opts.level)
+  if (opts.q) params.set('q', opts.q)
+  if (opts.since != null) params.set('since', String(opts.since))
+  if (opts.limit != null) params.set('limit', String(opts.limit))
+  const qs = params.toString()
+  return qs ? `?${qs}` : ''
+}
+
+/**
+ * One-shot historical backfill. Returns the parsed envelope so callers
+ * can advance a cursor (`next_since`) — the LogsView pages through
+ * older entries on scroll.
+ */
+export function useLogsHistorical(opts: UseLogsHistoricalOptions = {}) {
+  const { source = 'merged', level = null, q = null, since = null, limit, enabled = true } = opts
   return useQuery({
-    queryKey: ['logs', 'historical'],
+    queryKey: ['journal', 'historical', source, level, q, since, limit],
+    enabled,
     queryFn: async () => {
-      const body = await apiGet<any>(ENDPOINTS.logs)
-      if (Array.isArray(body)) return body as LogEntry[]
-      if (Array.isArray(body?.entries)) return body.entries as LogEntry[]
-      return [] as LogEntry[]
+      const qs = buildJournalQuery({ source, level, q, since, limit })
+      const body = await apiGet<{ entries: JournalEntry[]; next_since: number | null }>(
+        `${ENDPOINTS.journal}${qs}`,
+      )
+      // Backend always returns `{entries, next_since}`. Guard against an
+      // older / mocked payload that hands back a bare array so a stale
+      // fixture doesn't break the hook signature.
+      if (Array.isArray(body)) return { entries: body as JournalEntry[], next_since: null }
+      return {
+        entries: Array.isArray(body?.entries) ? body.entries : [],
+        next_since: body?.next_since ?? null,
+      }
     },
   })
 }
 
 export interface UseLogsStreamOptions {
-  /** When true, opens an SSE connection to `/api/logs/stream`. */
+  /** When true, opens an SSE connection to `/api/journal/stream`. */
   follow?: boolean
-  /** When set, also opens a WS to `/logs/stream` (lemond raw channel). */
+  /** Forwarded to the journal stream as ?source=. */
+  source?: JournalSource
+  /** Forwarded to the journal stream as ?level=. */
+  level?: JournalLevel | null
+  /** Forwarded to the journal stream as ?q= (server-side substring filter). */
+  q?: string | null
+  /**
+   * When set, also opens a WS to `/logs/stream` (lemond raw channel).
+   * Used by the Logs page when the user wants native lemond log
+   * fidelity over the journal projection.
+   */
   includeLemondWs?: boolean
 }
 
 /**
- * SSE + WS tail. Returns the live ring (newest last) and a
+ * SSE + (optional) WS tail. Returns the live ring (newest last) and a
  * `disconnected` flag so the UI can show "stream paused" banners.
+ *
+ * Reconnects on `source`/`level`/`q`/`follow` change with a 200ms debounce
+ * so a fast cascade of filter-chip clicks coalesces into one new SSE.
  */
 export function useLogsStream(opts: UseLogsStreamOptions = {}) {
-  const { follow = true, includeLemondWs = false } = opts
-  const [ring, setRing] = useState<LogEntry[]>([])
+  const {
+    follow = true,
+    source = 'merged',
+    level = null,
+    q = null,
+    includeLemondWs = false,
+  } = opts
+  const [ring, setRing] = useState<JournalEntry[]>([])
   const [disconnected, setDisconnected] = useState(false)
   const esRef = useRef<EventSource | null>(null)
   const wsRef = useRef<WebSocket | null>(null)
+  /** Increments on every reconnect; used to backoff on repeated errors. */
+  const errorCountRef = useRef(0)
 
-  const push = (entry: LogEntry) => {
+  const push = (entry: JournalEntry) => {
     setRing((prev) => {
-      const next = prev.length >= RING_MAX ? prev.slice(prev.length - RING_MAX + 1) : prev.slice()
+      const next =
+        prev.length >= RING_MAX ? prev.slice(prev.length - RING_MAX + 1) : prev.slice()
       next.push(entry)
       return next
     })
   }
 
   useEffect(() => {
-    if (!follow) return
-    try {
-      esRef.current = new EventSource(ENDPOINTS.logsStream)
-    } catch {
-      setDisconnected(true)
+    if (!follow) {
+      // Close any open stream when follow flips off.
+      if (esRef.current) {
+        esRef.current.close()
+        esRef.current = null
+      }
       return
     }
-    const es = esRef.current
-    es.onmessage = (evt) => {
+
+    // When filter params change we want a fresh connection — but
+    // debounce a touch so rapid chip cycling doesn't open + close
+    // a connection per click.
+    let cancelled = false
+    let backoffTimer: ReturnType<typeof setTimeout> | null = null
+
+    const connect = () => {
+      if (cancelled) return
       try {
-        const entry = JSON.parse(evt.data) as LogEntry
-        if (entry?.ts && entry?.msg) push(entry)
+        const url = `${ENDPOINTS.journalStream}${buildJournalQuery({ source, level, q })}`
+        esRef.current = new EventSource(url)
       } catch {
-        // ignore malformed
+        setDisconnected(true)
+        return
+      }
+      const es = esRef.current
+      if (!es) return
+      es.onmessage = (evt) => {
+        try {
+          const entry = JSON.parse(evt.data) as JournalEntry
+          if (entry?.ts && entry?.msg) push(entry)
+        } catch {
+          // ignore malformed
+        }
+      }
+      es.onerror = () => {
+        setDisconnected(true)
+        errorCountRef.current += 1
+        // Browser EventSource auto-reconnects, but a server-side close
+        // (e.g. backend redeploy) can put us in a loop. Tear down and
+        // schedule our own reconnect with a capped backoff so we don't
+        // hammer the API during an outage.
+        if (esRef.current) {
+          esRef.current.close()
+          esRef.current = null
+        }
+        const delay = Math.min(1000 * 2 ** Math.min(errorCountRef.current - 1, 4), 16_000)
+        backoffTimer = setTimeout(connect, delay)
+      }
+      es.onopen = () => {
+        setDisconnected(false)
+        errorCountRef.current = 0
       }
     }
-    es.onerror = () => {
-      setDisconnected(true)
-    }
-    es.onopen = () => {
-      setDisconnected(false)
-    }
+
+    const debounceTimer = setTimeout(connect, SSE_RECONNECT_DEBOUNCE_MS)
+
     return () => {
-      es.close()
-      esRef.current = null
+      cancelled = true
+      clearTimeout(debounceTimer)
+      if (backoffTimer) clearTimeout(backoffTimer)
+      if (esRef.current) {
+        esRef.current.close()
+        esRef.current = null
+      }
     }
-  }, [follow])
+  }, [follow, source, level, q])
 
   useEffect(() => {
     if (!includeLemondWs) return
@@ -104,9 +232,11 @@ export function useLogsStream(opts: UseLogsStreamOptions = {}) {
     ws.onmessage = (evt) => {
       try {
         const f = JSON.parse(evt.data) as any
-        // Per hal0_lemonade_ws_protocol: logs.entry frames carry `{ts, level, msg}`
+        // Per hal0_lemonade_ws_protocol: logs.entry frames carry `{ts, level, msg}`.
+        // We project onto JournalEntry so the ring stays homogeneous.
         if (f?.type === 'logs.entry' && f.ts && f.msg) {
           push({
+            id: -1, // raw WS entries don't carry a journal id
             ts: f.ts,
             source: 'lemond',
             level: f.level ?? 'info',

--- a/ui/src/api/mock.ts
+++ b/ui/src/api/mock.ts
@@ -112,14 +112,35 @@ function buildHardware() {
   return data().host ?? {}
 }
 
-function buildLogs() {
-  const d = data()
-  return { entries: d.journal ?? [] }
+function buildJournal() {
+  // Phase 3 of #322: HAL0_DATA.journal is gone — the dashboard streams
+  // /api/journal/stream and renders an empty-state placeholder when the
+  // ring is empty. The forced-mock surface returns an empty envelope so
+  // dev runs honour the same "no synthetic copy" rule the live build
+  // does; tests that need to drive specific entries either use
+  // `page.route('/api/journal*')` or push frames via the SSE harness.
+  return { entries: [], next_since: null }
 }
 
 function buildUpdateState() {
+  // Tests (and dev) can override the forced-mock payload by setting
+  // `window.__hal0UpdateStateOverride` before any fetch fires. This is
+  // the seam used by Phase 2's update-banner-v3.spec.ts AND Phase 3's
+  // footer-update-chip-v3.spec.ts to exercise the "no available
+  // release" + "current === available" branches without ripping the
+  // forced-mock short-circuit out of mockFetch. A dedicated window key
+  // is used so that the override survives data.jsx replacing
+  // `window.HAL0_DATA` wholesale at mount.
+  if (typeof window !== 'undefined') {
+    const override = (window as any).__hal0UpdateStateOverride
+    if (override) return override
+  }
+  // Seed: realistic-looking pair so the dev demo's footer chip + banner
+  // render against current-ish release strings. Tests override via the
+  // window seam above; the literals here are only used in dev. Keep the
+  // pair in sync with pyproject.toml's version when bumping major.
   return {
-    hal0: { current: 'v0.2.1', available: 'v0.2.2', channel: 'stable' },
+    hal0: { current: '0.3.0-alpha.1', available: '0.3.0-alpha.2', channel: 'stable' },
     lemonade: { current: 'v10.6.0', pinned: true, channel: 'stable' },
     flm: { current: 'v0.9.42', source: 'manual-deb' },
     autoCheck: true,
@@ -168,7 +189,7 @@ export const MOCK_ALLOWLIST: ReadonlyArray<{ re: RegExp; build: Builder }> = Obj
   { re: /^\/api\/backends$/, build: buildBackends },
   { re: /^\/api\/capabilities$/, build: buildCapabilities },
   { re: /^\/api\/hardware$/, build: buildHardware },
-  { re: /^\/api\/logs$/, build: buildLogs },
+  { re: /^\/api\/journal$/, build: buildJournal },
   { re: /^\/api\/updates\/state$/, build: buildUpdateState },
   { re: /^\/api\/auth\/token$/, build: buildAuthToken },
   { re: /^\/api\/auth\/allowed-origins$/, build: buildAllowedOrigins },

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -10,6 +10,7 @@ import { useLemondRollup } from '@/api/hooks/useLemonade'
 import { useLogsStream } from '@/api/hooks/useLogs'
 import { useSlots } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
+import { useUpdateState } from '@/api/hooks/useUpdates'
 
 const { useState: useStateC, useEffect: useEffectC } = React;
 
@@ -201,28 +202,59 @@ function SidebarStatusBlock({ onGo }) {
 }
 
 // ─── Footer ───
-function Footer({ updateAvailable = true, expanded = false, onToggle, journal = HAL0_DATA.journal }) {
-  // Phase B1: footer chips and journal pane now run off live hooks.
+// Phase 3 of #322: the journal pane reads `useLogsStream` against
+// /api/journal/stream (no more HAL0_DATA.journal fallback) and the
+// update chip reads `useUpdateState` directly (no more `updateAvailable`
+// prop threaded from main.jsx — the chip is self-driven).
+//
+// The `updateAvailable` prop is kept as an OPTIONAL suppression gate
+// so existing callers (BannerStack dismiss state) can still hide the
+// chip without re-architecting. When omitted the chip defaults to
+// "show if there is a real update" — never the prototype's hardcoded
+// "v0.2.2 available" string.
+function Footer({ updateAvailable, expanded = false, onToggle }) {
   // Lemond rollup gives live status / loaded / throughput / queued.
-  // useLogsStream subscribes to /api/logs/stream when the pane is
+  // useLogsStream subscribes to /api/journal/stream when the pane is
   // expanded (saves opening an SSE we don't render).
   const L = useLemondRollup();
-  const live = useLogsStream({ follow: expanded });
   const [paneSrc, setPaneSrc] = useStateC("merged");
   const [paneQ, setPaneQ] = useStateC("");
-  // Phase B1: mux the live SSE ring on top of the static journal.
-  // When the pane is expanded the ring fills in; collapsed it's just
-  // the lookup from props, preserving the design's hero-feel even
-  // before SSE primes.
-  const extended = (live.ring && live.ring.length > 0)
-    ? [...live.ring].sort((a, b) => (a.ts || '').localeCompare(b.ts || ''))
-    : [...journal].sort((a, b) => (a.ts || '').localeCompare(b.ts || ''));
+  // Source filter rides the SSE URL so the backend pre-filters; search
+  // is client-only against `entry.msg` so the user sees instant feedback
+  // while typing (no reconnect per keystroke).
+  const live = useLogsStream({ follow: expanded, source: paneSrc });
 
-  const filtered = extended.filter(e => {
-    if (paneSrc !== "merged" && e.source !== paneSrc) return false;
-    if (paneQ && !e.msg.toLowerCase().includes(paneQ.toLowerCase())) return false;
-    return true;
+  // The ring is the SOLE source of truth — no HAL0_DATA fallback. When
+  // empty (cold load before SSE replays or a genuinely quiet system)
+  // the body renders an empty-state placeholder below.
+  const ringSorted = [...(live.ring || [])].sort((a, b) =>
+    (a.ts || '').localeCompare(b.ts || ''),
+  );
+
+  // Source filter is also applied client-side so entries that arrived
+  // on the previous (broader) SSE stream don't linger after the user
+  // narrows the chip. Server-side filtering on the new SSE prevents
+  // FUTURE entries from arriving; this catches the residual ring.
+  // Search filter is purely client-only (no SSE reconnect per keystroke).
+  const filtered = ringSorted.filter((e) => {
+    if (paneSrc !== 'merged' && e.source !== paneSrc) return false;
+    return !(paneQ && (!e.msg || !e.msg.toLowerCase().includes(paneQ.toLowerCase())));
   });
+
+  // Update chip — self-driven from useUpdateState. The prop can still
+  // suppress (banner-dismiss memory) but never resurrect.
+  const updates = useUpdateState();
+  const updateState = updates.data;
+  const hal0Channel = updateState && updateState.hal0;
+  const hasUpdate = !!(
+    hal0Channel &&
+    hal0Channel.available &&
+    hal0Channel.available !== hal0Channel.current
+  );
+  // Backwards-compat: when caller passes `updateAvailable={false}` the
+  // chip stays hidden even when a real update exists (used to honour
+  // the banner-stack dismiss). Default (undefined) is "no suppression".
+  const showUpdateChip = hasUpdate && updateAvailable !== false;
 
   return (
     <div className={"footer" + (expanded ? " expanded" : "")}>
@@ -230,7 +262,7 @@ function Footer({ updateAvailable = true, expanded = false, onToggle, journal = 
         <div className="foot-pane">
           <div className="foot-pane-h mono">
             <span>Live journal</span>
-            <span className="ct">· {filtered.length} / {extended.length}</span>
+            <span className="ct">· {filtered.length} / {ringSorted.length}</span>
             <div className="foot-pane-filter mono">
               {[["merged", "merged"], ["hal0", "hal0"], ["lemond", "lemond"]].map(([k, l]) => (
                 <button
@@ -247,19 +279,24 @@ function Footer({ updateAvailable = true, expanded = false, onToggle, journal = 
               placeholder="search…"
             />
             <span style={{display: "inline-flex", gap: 10, marginLeft: "auto"}}>
-              <span style={{color: "var(--ok)", display: "inline-flex", alignItems: "center", gap: 5}}>
-                <span className="dot ready" />follow tail
+              <span style={{color: live.disconnected ? "var(--warn)" : "var(--ok)", display: "inline-flex", alignItems: "center", gap: 5}}>
+                <span className={"dot" + (live.disconnected ? "" : " ready")} />
+                {live.disconnected ? "reconnecting…" : "follow tail"}
               </span>
               <a href="#logs" className="foot-pane-link">Open full logs →</a>
             </span>
           </div>
           <div className="foot-pane-body">
-            {filtered.length === 0 ? (
+            {ringSorted.length === 0 ? (
+              <div className="foot-pane-empty" style={{padding: 24, textAlign: "center", color: "var(--fg-4)", fontFamily: "var(--jbm)", fontSize: 11.5}}>
+                No events yet
+              </div>
+            ) : filtered.length === 0 ? (
               <div style={{padding: 24, textAlign: "center", color: "var(--fg-4)", fontFamily: "var(--jbm)", fontSize: 11.5}}>
                 No journal entries match. <span style={{color: "var(--accent)", cursor: "pointer"}} onClick={() => { setPaneSrc("merged"); setPaneQ(""); }}>Clear filters</span>
               </div>
             ) : filtered.map((e, i) => (
-              <div key={i} className={"foot-line " + e.level}>
+              <div key={e.id ?? i} className={"foot-line " + e.level}>
                 <span className="ts">{e.ts}</span>
                 <span className={"sl " + e.source}>[{e.source}]</span>
                 <span className="lvl">{e.level}</span>
@@ -305,10 +342,10 @@ function Footer({ updateAvailable = true, expanded = false, onToggle, journal = 
             <span className="v num">{L.queued}</span>
           </div>
         )}
-        {updateAvailable && (
+        {showUpdateChip && (
           <div className="foot-chip accent">
             <span className="k">●</span>
-            <span className="v">hal0 v0.2.2 available</span>
+            <span className="v">{`hal0 ${hal0Channel.available} available`}</span>
           </div>
         )}
         <button className="foot-toggle" onClick={onToggle} aria-expanded={expanded} aria-label="Toggle journal pane">
@@ -316,17 +353,24 @@ function Footer({ updateAvailable = true, expanded = false, onToggle, journal = 
           <span>journal</span>
         </button>
       </div>
-      <div className="foot-journal mono">
-        {journal.map((e, i) => (
-          <span key={i} className={"ent " + e.level}>
-            <span className="ts">{e.ts}</span>
-            <span className="sl">[{e.source}]</span>
-            <span className="ar">·</span>
-            <span>{e.msg}</span>
-            {i < journal.length - 1 && <span className="sep">  </span>}
-          </span>
-        ))}
-      </div>
+      {/*
+        Always-visible footer journal ribbon: a thin tail of the most
+        recent entries. Pulls from the same SSE ring; renders nothing
+        before the first frame arrives so we never hardcode mock copy.
+      */}
+      {ringSorted.length > 0 && (
+        <div className="foot-journal mono">
+          {ringSorted.slice(-6).map((e, i, arr) => (
+            <span key={e.id ?? i} className={"ent " + e.level}>
+              <span className="ts">{e.ts}</span>
+              <span className="sl">[{e.source}]</span>
+              <span className="ar">·</span>
+              <span>{e.msg}</span>
+              {i < arr.length - 1 && <span className="sep">  </span>}
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/dash/data.jsx
+++ b/ui/src/dash/data.jsx
@@ -273,14 +273,11 @@ const HAL0_DATA = {
     },
   },
 
-  journal: [
-    { ts: "14:02:11.117", source: "lemond", level: "ok",   msg: "loaded model 'qwen3.6-27b-mtp' via llamacpp:rocm" },
-    { ts: "14:02:11.514", source: "hal0",   level: "ok",   msg: "slot:primary state idle → ready" },
-    { ts: "14:02:14.230", source: "hal0",   level: "ok",   msg: "slot:agent coresident with stt-npu, embed-npu" },
-    { ts: "14:02:18.443", source: "lemond", level: "warn", msg: "nuclear evict-all candidate avoided (file-not-found)" },
-    { ts: "14:02:20.117", source: "lemond", level: "ok",   msg: "/v1/chat/completions primary 45 tok/s TTFT 220ms" },
-    { ts: "14:02:22.290", source: "hal0",   level: "ok",   msg: "omnirouter dispatched 'generate_image' → slot img" },
-  ],
+  // ── journal block removed (#322 phase 3) ─────────────────────────
+  // The dashboard now streams /api/journal/stream for the footer pane
+  // and the Logs page; both render an empty state when the SSE has no
+  // entries yet. No more "loaded model 'qwen3.6-27b-mtp'" mock prose
+  // leaking into prod screenshots before SSE primes.
 
   omnirouter: [
     { name: "generate_image",   active: true,  target: "img (sd-turbo)" },

--- a/ui/src/dash/extras.jsx
+++ b/ui/src/dash/extras.jsx
@@ -237,16 +237,28 @@ function LogsView() {
   const [pendingCount, setPendingCount] = useStateX(0);
   const scrollRef = React.useRef(null);
 
-  // Phase B1: historical fetch (one-shot) + SSE tail (live).
-  // includeLemondWs flips on when source=lemond is selected; that
-  // satisfies the design's "raw lemond /logs/stream" requirement
-  // without holding the WS open when not needed.
-  const historical = useLogsHistorical();
-  const live = useLogsStream({ follow: !paused, includeLemondWs: source === 'lemond' });
+  // Phase 3 of #322: historical fetch + SSE tail both hit /api/journal*.
+  // Server-side filter params (source / level / search) round-trip into
+  // the URL so the wire payload is already small; the client filter
+  // pass below stays for slot-name filtering (still client-only — the
+  // backend journal envelope doesn't carry slot yet) and for instant
+  // search feedback while the user types.
+  //
+  // includeLemondWs flips on when source=lemond is selected so the page
+  // can render raw lemond logs.entry frames alongside the projected
+  // journal envelope, satisfying the design's "native fidelity" mode.
+  const historical = useLogsHistorical({ source, level: level || null, q: search || null });
+  const live = useLogsStream({
+    follow: !paused,
+    source,
+    level: level || null,
+    q: search || null,
+    includeLemondWs: source === 'lemond',
+  });
 
-  // Merge static demo lines + live SSE + historical fetch. Static lines
-  // keep the design's grouped-error block (request-id collapsing) visible
-  // when no backend yet ships /api/logs.
+  // Demo lines preserve the design's grouped-error block (request-id
+  // collapsing) so the screenshot suite has something to point at even
+  // when the dev backend has no journal entries yet.
   const demoLines = [
     { ts: "14:01:58.330", source: "lemond", level: "ok",   slot: "primary", msg: "POST /v1/load model=qwen3.6-27b-mtp-q4_k_m backend=llamacpp:rocm" },
     { ts: "14:01:58.341", source: "lemond", level: "info", slot: "primary", msg: "ggml_init_cublas: found 1 ROCm device gfx1151" },
@@ -265,9 +277,12 @@ function LogsView() {
     { ts: "14:02:32.290", source: "hal0",   level: "ok",   slot: "img",     msg: "tool_call generate_image · 4.1s · 2.4 MB" },
     { ts: "14:02:36.117", source: "hal0",   level: "info", slot: "img",     msg: "slot:img state serving → idle" },
   ];
-  const sourceLines = (historical.data && historical.data.length > 0)
-    ? historical.data
-    : [...(HAL0_DATA.journal || []), ...demoLines];
+  // historical now returns `{entries, next_since}`. Fall back to the
+  // demoLines block when there's no journal data yet so the Logs page
+  // still demos the design's grouped-warn collapser before any real
+  // entries land — HAL0_DATA.journal is gone (#322 phase 3).
+  const histEntries = historical.data?.entries ?? [];
+  const sourceLines = histEntries.length > 0 ? histEntries : demoLines;
   const buf = [...sourceLines, ...(live.ring || [])]
     .sort((a, b) => (a.ts || '').localeCompare(b.ts || ''));
 

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -168,8 +168,16 @@ function App() {
           </div>
           {renderView()}
         </div>
+        {/*
+          Phase 3 of #322: Footer is self-driven. The update chip reads
+          `useUpdateState()` directly (no more hardcoded "v0.2.2 available"),
+          and the journal pane streams /api/journal/stream. The legacy
+          `updateAvailable` prop linkage to the BannerStack dismiss state
+          is intentionally dropped — Phase 2's UpdateBanner owns its own
+          dismiss memory and the chip is allowed to keep nagging until
+          a new release is installed.
+        */}
         <Footer
-          updateAvailable={!activeBanners["update-available"]}
           expanded={footerOpen}
           onToggle={() => setFooterOpen(o => !o)}
         />

--- a/ui/tests/e2e/specs/footer-journal-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/footer-journal-pane-v3.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * footer-journal-pane-v3 — issue #325 (epic #322 Phase 3).
+ *
+ * Footer's expand pane now streams /api/journal/stream and renders the
+ * SSE ring directly — no more HAL0_DATA.journal silent fallback. Specs
+ * pin:
+ *
+ *   1. Cold load: pane is closed by default, no SSE is opened, the chips
+ *      still render.
+ *   2. Expanding the pane opens the SSE; entries pushed through the
+ *      sseHarness render in the body.
+ *   3. Clicking `hal0` filter chip rebuilds the EventSource with
+ *      `?source=hal0` and only hal0-source entries pass through.
+ *   4. Typing in the search box filters the in-memory ring client-side
+ *      (no SSE reconnect; matches `entry.msg` case-insensitively).
+ *   5. When the SSE has produced 0 entries the pane shows the empty
+ *      state ("No events yet") — never the old mock copy
+ *      ("loaded model 'qwen3.6-27b-mtp' via llamacpp:rocm").
+ *   6. Production bundle does NOT contain literal "14:02:11.117" — the
+ *      timestamp shape used exclusively by the deleted HAL0_DATA.journal
+ *      block. Other unrelated 14:02 demo timestamps (mcp-modals, agent
+ *      approvals) are explicitly out of #325's scope.
+ */
+import { test, expect } from '../fixtures/apiMock'
+import { installSseHarness, emitSse, waitForSse } from '../fixtures/sseHarness'
+
+const HAL0_ENTRY = {
+  id: 1,
+  ts: '2026-05-25T22:00:00.000000+00:00',
+  source: 'hal0',
+  level: 'info',
+  msg: 'slot:primary state idle → ready',
+}
+const LEMOND_ENTRY = {
+  id: 2,
+  ts: '2026-05-25T22:00:01.000000+00:00',
+  source: 'lemond',
+  level: 'info',
+  msg: 'POST /v1/load model=qwen3.6-27b-mtp backend=llamacpp:rocm',
+}
+const ERROR_ENTRY = {
+  id: 3,
+  ts: '2026-05-25T22:00:02.000000+00:00',
+  source: 'hal0',
+  level: 'error',
+  msg: 'nuclear evict-all triggered: error loading sd-turbo',
+}
+
+test.describe('Footer journal pane (#325)', () => {
+  test.beforeEach(async ({ page }) => {
+    await installSseHarness(page)
+  })
+
+  test('pane is closed on cold load', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.locator('.footer')).toBeVisible()
+    // foot-pane only renders when expanded; should be absent on cold load.
+    await expect(page.locator('.foot-pane')).toHaveCount(0)
+    // Toggle button is the entry point.
+    await expect(page.locator('.foot-toggle')).toBeVisible()
+  })
+
+  test('expanding pane opens SSE and renders pushed events', async ({ page }) => {
+    await page.goto('/')
+    await page.locator('.foot-toggle').click()
+    await expect(page.locator('.foot-pane')).toBeVisible()
+
+    // SSE connects on expansion (debounced ~200ms).
+    await waitForSse(page, '/api/journal/stream', 6_000)
+
+    // Push two entries — they should render in the body.
+    await emitSse(page, '/api/journal/stream', HAL0_ENTRY)
+    await emitSse(page, '/api/journal/stream', LEMOND_ENTRY)
+
+    const body = page.locator('.foot-pane-body')
+    await expect(body.locator('.foot-line .msg', { hasText: HAL0_ENTRY.msg })).toBeVisible()
+    await expect(body.locator('.foot-line .msg', { hasText: LEMOND_ENTRY.msg })).toBeVisible()
+  })
+
+  test('hal0 filter chip narrows source and rebuilds SSE with ?source=hal0', async ({ page }) => {
+    await page.goto('/')
+    await page.locator('.foot-toggle').click()
+    await waitForSse(page, '/api/journal/stream', 6_000)
+    await emitSse(page, '/api/journal/stream', HAL0_ENTRY)
+    await emitSse(page, '/api/journal/stream', LEMOND_ENTRY)
+
+    // Pre-condition: both render.
+    const body = page.locator('.foot-pane-body')
+    await expect(body.locator('.foot-line', { hasText: HAL0_ENTRY.msg })).toBeVisible()
+    await expect(body.locator('.foot-line', { hasText: LEMOND_ENTRY.msg })).toBeVisible()
+
+    // Click the hal0 chip — debounce + reconnect.
+    await page.locator('.foot-pane-chip', { hasText: 'hal0' }).click()
+    await waitForSse(page, '/api/journal/stream?source=hal0', 6_000)
+
+    // Client-side source filter applied on top of the SSE URL filter —
+    // residual lemond entry already in the ring is hidden immediately.
+    await expect(body.locator('.foot-line', { hasText: LEMOND_ENTRY.msg })).toHaveCount(0)
+    // hal0 entry stays.
+    await expect(body.locator('.foot-line', { hasText: HAL0_ENTRY.msg })).toBeVisible()
+
+    // Push another hal0 entry on the new stream — arrives normally.
+    const HAL0_AFTER = { ...HAL0_ENTRY, id: 4, msg: 'slot:agent ready' }
+    await emitSse(page, '/api/journal/stream?source=hal0', HAL0_AFTER)
+    await expect(body.locator('.foot-line .msg', { hasText: 'slot:agent ready' })).toBeVisible()
+
+    // Confirm the URL gained the source param.
+    const seen = await page.evaluate(
+      () => Object.keys((window as any).__sseStreams || {}),
+    )
+    expect(seen.some((u: string) => u.includes('source=hal0'))).toBe(true)
+  })
+
+  test('search input filters the in-memory ring case-insensitively', async ({ page }) => {
+    await page.goto('/')
+    await page.locator('.foot-toggle').click()
+    await waitForSse(page, '/api/journal/stream', 6_000)
+    await emitSse(page, '/api/journal/stream', HAL0_ENTRY)
+    await emitSse(page, '/api/journal/stream', LEMOND_ENTRY)
+    await emitSse(page, '/api/journal/stream', ERROR_ENTRY)
+
+    const body = page.locator('.foot-pane-body')
+    // Pre-condition: all three render.
+    await expect(body.locator('.foot-line')).toHaveCount(3)
+
+    // Type "error" — only ERROR_ENTRY's msg matches.
+    await page.locator('.foot-pane-search').fill('error')
+    await expect(body.locator('.foot-line')).toHaveCount(1)
+    await expect(body.locator('.foot-line', { hasText: ERROR_ENTRY.msg })).toBeVisible()
+
+    // Case-insensitive: "ERROR" lands on the same row.
+    await page.locator('.foot-pane-search').fill('ERROR')
+    await expect(body.locator('.foot-line')).toHaveCount(1)
+
+    // Clearing the search restores the full ring.
+    await page.locator('.foot-pane-search').fill('')
+    await expect(body.locator('.foot-line')).toHaveCount(3)
+  })
+
+  test('empty SSE renders "No events yet", never the old mock prose', async ({ page }) => {
+    await page.goto('/')
+    await page.locator('.foot-toggle').click()
+    await waitForSse(page, '/api/journal/stream', 6_000)
+    // Deliberately push nothing. Give the SSE a moment to settle.
+    await page.waitForTimeout(500)
+
+    const body = page.locator('.foot-pane-body')
+    await expect(body.locator('.foot-pane-empty')).toBeVisible()
+    await expect(body.locator('.foot-pane-empty')).toContainText('No events yet')
+
+    // The old HAL0_DATA.journal lines must never sneak in via a silent
+    // fallback. Pin both the qwen3.6 model load AND the synthetic
+    // 14:02:11.117 timestamp the old block used.
+    await expect(body).not.toContainText("loaded model 'qwen3.6-27b-mtp'")
+    await expect(body).not.toContainText('14:02:11.117')
+  })
+})
+
+test.describe('Footer journal pane — bundle hygiene (#325)', () => {
+  test('production bundle does not contain deleted HAL0_DATA.journal mock copy', async () => {
+    // The old HAL0_DATA.journal block carried unique mock prose
+    // ("loaded model 'qwen3.6-27b-mtp' via llamacpp:rocm", "slot:primary
+    // state idle → ready", etc.) that should be GONE post-delete. The
+    // 14:02:11.117 timestamp itself is shared with mcp-modals.jsx and
+    // intentionally not asserted here — scoping the check to the
+    // journal-specific prose keeps this orthogonal to the MCP page's
+    // demo data which is owned by a different epic.
+    const fs = await import('fs')
+    const path = await import('path')
+    const { fileURLToPath } = await import('url')
+    const here = path.dirname(fileURLToPath(import.meta.url))
+    const root = path.resolve(here, '../../..', 'dist')
+    if (!fs.existsSync(root)) {
+      test.skip(true, 'ui/dist not built — run `npm run build` first')
+      return
+    }
+    const files = fs.readdirSync(path.join(root, 'assets')).filter((f) => f.endsWith('.js'))
+    expect(files.length, 'dist/assets has at least one js chunk').toBeGreaterThan(0)
+    for (const f of files) {
+      const body = fs.readFileSync(path.join(root, 'assets', f), 'utf8')
+      // Copy unique to the deleted journal block:
+      expect(body, `bundle ${f} still ships deleted journal mock copy`).not.toContain(
+        "loaded model 'qwen3.6-27b-mtp' via llamacpp:rocm",
+      )
+      expect(body, `bundle ${f} still ships deleted journal mock copy`).not.toContain(
+        'omnirouter dispatched',
+      )
+      expect(body, `bundle ${f} still ships deleted journal mock copy`).not.toContain(
+        'nuclear evict-all candidate avoided',
+      )
+    }
+  })
+})

--- a/ui/tests/e2e/specs/footer-update-chip-v3.spec.ts
+++ b/ui/tests/e2e/specs/footer-update-chip-v3.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * footer-update-chip-v3 — issue #325 (epic #322 Phase 3 — folded scope).
+ *
+ * Phase 2 (PR #329) wires the TOP banner to `useUpdateState()`. The
+ * Footer chip was still hardcoded to render "hal0 v0.2.2 available"
+ * regardless of real release state — driven only by the global
+ * BannerStack dismiss prop. This spec pins the Footer chip to live
+ * data the same way:
+ *
+ *   1. When `useUpdateState()` returns no available release (or
+ *      current === available), the chip is hidden.
+ *   2. When `useUpdateState()` returns `{current, available}` mismatch,
+ *      the chip renders with the live `${available}` string.
+ *   3. The literal "v0.2.2" no longer appears in chrome.jsx — proven
+ *      by source-grepping the file directly (the bundle itself still
+ *      carries the string from the BANNER_CATALOG prototype entry,
+ *      which Phase 2 owns and is intentionally out of #325's scope).
+ *
+ * The mock seam `window.__hal0UpdateStateOverride` lets us drive
+ * forced-mock dev with arbitrary update-state payloads without ripping
+ * out the mockFetch short-circuit.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+async function withUpdateState(
+  page: import('@playwright/test').Page,
+  override: unknown,
+) {
+  await page.addInitScript((payload) => {
+    ;(window as any).__hal0UpdateStateOverride = payload
+  }, override)
+}
+
+const UPDATE_CHIP = (page: import('@playwright/test').Page) =>
+  page.locator('.footer .foot-chip.accent', { hasText: /hal0 .* available/ })
+
+test.describe('Footer update chip (#325)', () => {
+  test('chip hidden when useUpdateState returns no available release', async ({ page }) => {
+    await withUpdateState(page, {
+      hal0: { current: '0.3.0-alpha.1', available: null, channel: 'stable' },
+      lemonade: { current: 'v10.6.0', pinned: true, channel: 'stable' },
+      autoCheck: true,
+    })
+    await page.goto('/')
+    await expect(page.locator('.footer')).toBeVisible()
+    // Wait for the rollup poll to land — the loaded-chip text proves
+    // useLemondRollup has settled, which means useUpdateState has had
+    // time to run too.
+    await expect(page.locator('.footer .foot-chip', { hasText: 'loaded' })).toBeVisible({
+      timeout: 6_000,
+    })
+    await expect(UPDATE_CHIP(page)).toHaveCount(0)
+  })
+
+  test('chip hidden when current === available', async ({ page }) => {
+    await withUpdateState(page, {
+      hal0: { current: '0.3.0-alpha.1', available: '0.3.0-alpha.1', channel: 'stable' },
+      lemonade: { current: 'v10.6.0', pinned: true, channel: 'stable' },
+      autoCheck: true,
+    })
+    await page.goto('/')
+    await expect(page.locator('.footer')).toBeVisible()
+    await expect(page.locator('.footer .foot-chip', { hasText: 'loaded' })).toBeVisible({
+      timeout: 6_000,
+    })
+    await expect(UPDATE_CHIP(page)).toHaveCount(0)
+  })
+
+  test('chip renders with live available version when an update is offered', async ({ page }) => {
+    await withUpdateState(page, {
+      hal0: { current: '0.3.0-alpha.1', available: '0.3.0', channel: 'stable' },
+      lemonade: { current: 'v10.6.0', pinned: true, channel: 'stable' },
+      autoCheck: true,
+    })
+    await page.goto('/')
+    await expect(page.locator('.footer')).toBeVisible()
+    const chip = UPDATE_CHIP(page)
+    await expect(chip).toBeVisible({ timeout: 6_000 })
+    // The chip text MUST reflect the live `available` string — not the
+    // prototype's hardcoded "v0.2.2".
+    await expect(chip).toContainText('hal0 0.3.0 available')
+    await expect(chip).not.toContainText('v0.2.2')
+  })
+})
+
+test.describe('Footer update chip — source hygiene (#325)', () => {
+  test('chrome.jsx no longer hardcodes "v0.2.2"', async () => {
+    // The Footer used to render `<span className="v">hal0 v0.2.2 available</span>`
+    // as a literal — the chip's bug-of-record. After #325 the chip
+    // composes its text from `useUpdateState()` at render time, so the
+    // string "v0.2.2" should be gone from the file. Note: a single
+    // explanatory comment line in main.jsx still references the old
+    // string and is intentionally allowed (the comment justifies the
+    // change). This spec scopes the assertion to chrome.jsx, which is
+    // the Footer component's own home.
+    const fs = await import('fs')
+    const path = await import('path')
+    const { fileURLToPath } = await import('url')
+    const here = path.dirname(fileURLToPath(import.meta.url))
+    const chromePath = path.resolve(here, '../../..', 'src/dash/chrome.jsx')
+    const body = fs.readFileSync(chromePath, 'utf8')
+    // Allow the explanatory comment in the Footer's docblock that
+    // explicitly cites the old "v0.2.2 available" string as the bug
+    // being fixed. Strip block + line comments and re-check.
+    const codeOnly = body
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '')
+    expect(codeOnly).not.toContain('v0.2.2')
+  })
+})


### PR DESCRIPTION
## Summary

Phase 3 of epic #322 replaces two silent fallbacks in the dashboard footer with live backend wiring, plus folds in the footer update-chip rewire (since Phase 2's #329 only owns the top banner).

### Part A — Journal pane → `/api/journal*` (PR #330)

- `useLogs.ts` rewritten against `/api/journal` + `/api/journal/stream` with `source`/`level`/`q` filter params, debounced (~200ms) SSE reconnect on param change, exponential backoff on `EventSource` error. `JournalEntry` replaces the loose `LogEntry` shape.
- `chrome.jsx` Footer no longer accepts `journal = HAL0_DATA.journal` default; pane reads the SSE ring directly. Source chip rebuilds the SSE URL; search box filters the ring client-side for instant feedback (case-insensitive substring on `entry.msg`). Source filter is also applied client-side so a residual lemond entry doesn't linger after the user narrows to `hal0`.
- Empty SSE ring renders an empty-state placeholder (`No events yet`), never the old mock copy (e.g. `loaded model 'qwen3.6-27b-mtp' via llamacpp:rocm`).
- `HAL0_DATA.journal` block deleted from `data.jsx`. `mock.ts` `buildLogs` replaced with `buildJournal` returning an empty envelope (no synthetic copy).
- `LogsView` in `extras.jsx` updated to consume the new envelope (`{entries, next_since}`) and pass server-side filter params; demoLines block retained so the design's grouped-warn collapser still has something to point at before journal entries arrive.

### Part B — Footer update chip → `useUpdateState()`

- Hardcoded `hal0 v0.2.2 available` literal removed from `chrome.jsx`. Chip composes text from `useUpdateState()` at render time and self-hides when `available == null` or `available === current`.
- The `updateAvailable` prop thread from `main.jsx` is dropped (chip is self-driven now). Phase 2's `UpdateBanner` owns its own dismiss state; the footer chip is allowed to keep nagging until the new release is installed. The dropped coupling is documented inline in `main.jsx`.
- `mock.ts` adds `window.__hal0UpdateStateOverride` seam so the new specs can drive forced-mock update state. This is the same seam Phase 2's PR #329 adds — identical content, will merge trivially.

### Part C — Tests

- `ui/tests/e2e/specs/footer-journal-pane-v3.spec.ts` (6 tests): pane closed on cold load, SSE connects on expand, `hal0` chip narrows source + residue filter, search filters case-insensitively, empty ring shows `No events yet`, deleted journal prose absent from bundle.
- `ui/tests/e2e/specs/footer-update-chip-v3.spec.ts` (4 tests): chip hidden on no-update + on `current === available`, chip renders live `available` version, `chrome.jsx` source no longer contains literal `v0.2.2`.

## Files changed

```
 ui/src/api/endpoints.ts                                |  10 +-
 ui/src/api/hooks/useLogs.ts                            | 220 +++++++++++++++++++++++++++++++++++---------
 ui/src/api/mock.ts                                     |  31 ++++++-
 ui/src/dash/chrome.jsx                                 | 110 +++++++++++++++-------
 ui/src/dash/data.jsx                                   |  13 +--
 ui/src/dash/extras.jsx                                 |  41 ++++++---
 ui/src/dash/main.jsx                                   |  10 +-
 ui/tests/e2e/specs/footer-journal-pane-v3.spec.ts      | 188 ++++++++++++++++++++++++++++++++++++
 ui/tests/e2e/specs/footer-update-chip-v3.spec.ts      | 115 +++++++++++++++++++++++
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vite build` clean
- [x] `npx playwright test` — 66 passed, 16 skipped (live-mode + memory-graph, unchanged from main)
- [x] New specs: 10/10 passing
- [x] Bundle grep `dist/assets/*.js` for `loaded model 'qwen3.6-27b-mtp' via llamacpp:rocm` + `omnirouter dispatched` + `nuclear evict-all candidate avoided` → 0 hits (asserted by spec)

### Bundle-grep caveats

The brief's general grep `grep -r "v0.2.2\|14:02" ui/dist/` will still produce hits, but **none are from the deleted journal mock**:

- Residual `v0.2.2` (1 hit): `primitives.jsx` `BANNER_CATALOG` prototype entry — Phase 2 owns; PR #329 keeps the catalog entry for the Tweaks-panel demo toggle while routing the real surface through `UpdateBanner`.
- Residual `14:02` (≥20 hits): `extras.jsx` demo lines, `mcp-modals.jsx` supervisor logs, `dashboard.jsx` "last message", `mcp-main.jsx` ticker, agent approvals, hermes memory mocks — all out of #325 scope.

The new bundle-hygiene spec scopes its assertion to the **unique-to-journal** prose, which is the actual semantic guarantee we want.

## Coordination

- Phase 2's PR #329 (UpdateBanner top-banner wire) is open at green CI but unmerged. Both branches add the same `window.__hal0UpdateStateOverride` seam to `mock.ts` with identical content — trivial merge.
- Does not touch `primitives.jsx` (Phase 2's `UpdateBanner` component), the throughput chip (#326 / PR #328 — merged), the queued/coresident chips (#221), or any backend Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #325
Refs #322