### PR TITLE
feat(dash): swap-arrow affordance on slot model picker

### DIFF
--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -537,6 +537,7 @@ function InlineSwapPopover({ slot, open, onClose, onPick }) {
             </div>
             <div className="sz num">{m.size}</div>
             <div className={"fit" + (fits ? "" : " no")}>{m.installed ? (fits ? "fits ✓" : "tight") : "will pull"}</div>
+            <span className="swap-arrow" aria-hidden="true">{Icons.chevR}</span>
           </div>
         );
       })}

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -2595,7 +2595,7 @@ a { color: inherit; text-decoration: none; }
 }
 .swap-pop-item {
   display: grid;
-  grid-template-columns: 1fr 60px 70px;
+  grid-template-columns: 1fr 60px 70px 16px;
   gap: 10px;
   padding: 9px 12px;
   border-bottom: 1px solid var(--line-soft);
@@ -2610,6 +2610,9 @@ a { color: inherit; text-decoration: none; }
 .swap-pop-item .sz { color: var(--fg-3); font-size: 11px; }
 .swap-pop-item .fit { color: var(--ok); font-size: 10px; text-align: right; }
 .swap-pop-item .fit.no { color: var(--warn); }
+.swap-pop-item .swap-arrow { display: inline-flex; color: var(--fg-3); transition: color 0.12s ease; }
+.swap-pop-item:hover .swap-arrow { color: var(--ok); }
+.swap-pop-item.cur .swap-arrow { color: var(--ok); }
 
 /* ─── Variant filter chips (HF coords modal) ────────────────────── */
 .variant-row {


### PR DESCRIPTION
## Summary
- Light-grey chevron at the right edge of each row in the inline slot-card swap popover (`InlineSwapPopover`)
- Turns pale green (`--ok`) on row hover — same green as the "fits ✓" text next to it
- Stays green for the currently-loaded model (`.cur` row), reinforcing the running-state read

## Files
- `ui/src/dash/slot-modals.jsx` — one `<span class="swap-arrow">` per row, using `Icons.chevR`
- `ui/src/dashboard.css` — adds a 16px arrow column to the popover grid + three colour rules

## Test plan
- [ ] Open a slot card and click the model text to show the inline swap popover — arrow is visible at right of each row
- [ ] Hover a non-current row — arrow turns pale green; revert to grey on mouse-out
- [ ] Current/running model row — arrow is green and stays green regardless of hover
- [ ] Existing `.swap-pop-item` E2E selector (`tests/e2e/specs/slots-wireup-v3.spec.ts:136`) still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)