### PR TITLE
feat(models): default scan/preview to recursive + UI toggle

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -163,12 +163,19 @@ async def scan_preview(request: Request) -> dict[str, Any]:
 
         {
           "paths":     ["/abs/dir/or/file", ...],   # required
-          "recursive": bool                          # default False
+          "recursive": bool                          # default True
         }
 
     Files matching the configured ``[models].file_extensions`` are
     selected when walking directories. A path that is a file is detected
     directly regardless of extension.
+
+    ``recursive`` defaults to True because the operator-facing flow
+    (dashboard "Scan directory", CLI) almost always points at a model
+    store root (e.g. ``/mnt/ai-models``) whose .gguf files live under
+    per-repo subdirs; a flat ``iterdir()`` returns zero rows there and
+    looks broken. Callers that want a shallow walk pass ``recursive:
+    false`` explicitly.
     """
     try:
         body = await request.json()
@@ -180,7 +187,7 @@ async def scan_preview(request: Request) -> dict[str, Any]:
     raw_paths = body.get("paths") or []
     if not isinstance(raw_paths, list) or not raw_paths:
         raise BadRequest("'paths' must be a non-empty list of absolute paths")
-    recursive = bool(body.get("recursive", False))
+    recursive = bool(body.get("recursive", True))
 
     cfg = load_hal0_config()
     extensions = {e.lower() for e in cfg.models.file_extensions}

--- a/tests/api/test_models_preview.py
+++ b/tests/api/test_models_preview.py
@@ -87,6 +87,30 @@ def test_preview_walks_recursive_when_flag_set(
     assert deep["preview"][0]["path"].endswith("embed-bge-small.gguf")
 
 
+def test_preview_defaults_to_recursive(
+    preview_client: tuple[TestClient, Path],
+) -> None:
+    """Omitting the recursive flag must walk subdirectories.
+
+    The operator-facing flows (dashboard scan modal, CLI) almost always
+    point at a model store root whose .gguf files live under per-repo
+    subdirs; a shallow default produces zero rows and looks broken.
+    """
+    client, root = preview_client
+    nested = root / "huggingface" / "Qwen3.5-4B"
+    nested.mkdir(parents=True)
+    (nested / "Qwen3.5-4B-Q4_K_M.gguf").write_bytes(b"\x00" * 64)
+
+    r = client.post(
+        "/api/models/scan/preview",
+        json={"paths": [str(root)]},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["count"] == 1
+    assert body["preview"][0]["path"].endswith("Qwen3.5-4B-Q4_K_M.gguf")
+
+
 def test_preview_single_file_path(
     preview_client: tuple[TestClient, Path],
 ) -> None:

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -698,6 +698,7 @@ function ScanDirectoryModal({ open, onClose }) {
   const modelsHook = useModels();
 
   const [scanPath, setScanPath] = useStateMM("");
+  const [recursive, setRecursive] = useStateMM(true);
   const [picked, setPicked] = useStateMM(() => new Set());
   const [progress, setProgress] = useStateMM(null); // { done, total } | null
 
@@ -707,6 +708,7 @@ function ScanDirectoryModal({ open, onClose }) {
       add.reset();
       setPicked(new Set());
       setProgress(null);
+      setRecursive(true);
       // Seed the input with the configured scan root so the operator
       // can hit Scan immediately after pinning /mnt/ai-models in Settings.
       const root = settings.data?.models?.roots?.[0] || "";
@@ -725,7 +727,7 @@ function ScanDirectoryModal({ open, onClose }) {
     setPicked(new Set());
     setProgress(null);
     try {
-      await preview.mutateAsync({ paths: [scanPath.trim()], recursive: true });
+      await preview.mutateAsync({ paths: [scanPath.trim()], recursive });
     } catch (e) {
       window.__hal0Toast && window.__hal0Toast(
         `Scan failed — ${e?.message || "see logs"}`, "err",
@@ -816,7 +818,7 @@ function ScanDirectoryModal({ open, onClose }) {
       <div className="form-row">
         <div className="form-lbl">
           <span>Scan path <span className="req">*</span></span>
-          <span className="sub">recursive · absolute path</span>
+          <span className="sub">absolute path</span>
         </div>
         <div className="form-ctl" style={{display: "flex", gap: 8}}>
           <input
@@ -829,6 +831,23 @@ function ScanDirectoryModal({ open, onClose }) {
           <button className="btn ghost sm" disabled={!scanPath.trim() || preview.isPending} onClick={onScan}>
             {preview.isPending ? "Scanning…" : "Scan"}
           </button>
+        </div>
+      </div>
+
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>Walk</span>
+          <span className="sub">off → top-level files only</span>
+        </div>
+        <div className="form-ctl">
+          <label className="checkbox-row">
+            <input
+              type="checkbox"
+              checked={recursive}
+              onChange={e => setRecursive(e.target.checked)}
+            />
+            <span className="mono">Recurse into subdirectories</span>
+          </label>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- Backend `/api/models/scan/preview` defaults `recursive=True`. Operator-facing scans almost always point at a model store root (`/mnt/ai-models`) whose .gguf files live under per-repo subdirs — the previous flat default returned 0 rows and looked broken. Explicit `recursive: false` still opts out.
- Live-verified on LXC: `/mnt/ai-models` → 25 hits default, 0 with `recursive:false`.
- ScanDirectoryModal exposes a "Recurse into subdirectories" checkbox (defaults ON, resets on open). Drops the hardcoded `recursive: true` and the now-redundant "recursive · absolute path" hint.
- `test_preview_defaults_to_recursive` pins the new default; existing preview tests still pass (6/6).

## Test plan

- [x] `uv run pytest tests/api/test_models_preview.py` — 6/6 ✅
- [x] `ruff check` + `ruff format --check` clean
- [x] Live LXC: default recurses (25 hits), `recursive:false` opts out (0 hits)
- [ ] Dashboard smoke: open Scan-directory modal, confirm checkbox renders ON, toggling it off + Scan returns top-level-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)