### PR TITLE
fix(slots): zero-red-dots bundle — 7 slot-card UX fixes

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -411,6 +411,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         slot_manager=slot_manager,
     )
 
+    # One-shot reconciliation: clear pre-fix stuck ERROR on slots whose
+    # only problem was an empty model.default. After fix(slots): empty
+    # default is OFFLINE+CTA, not ERROR; this pass migrates existing
+    # state.json snapshots forward so the dashboard doesn't render red
+    # until the operator clicks each slot.
+    await slot_manager.reconcile_unconfigured_slots()
+
     # Idle monitor — demotes READY → IDLE after the configured timeout
     # so the dashboard distinguishes "warm but quiet" from "warm and
     # actively serving" without operator help.  Defaults to 300s; the

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -518,11 +518,19 @@ class SlotManager:
                 current = self._current_state(slot_name)
                 if current not in _FAIL_WATCH_LIVE_STATES:
                     return
+                # Lemonade routinely evicts loaded models (idle-TTL,
+                # nuclear-evict on a sibling load failure, max_models
+                # pressure). From the slot's perspective this is a clean
+                # unload — the next inference request hot-reloads the
+                # model. Reflect that as OFFLINE (grey dot, "evicted —
+                # auto-reloads on next request") rather than ERROR (red
+                # dot, operator-investigation cue), reserving ERROR for
+                # the real failures: spawn/health/load exceptions.
                 try:
                     await self._transition(
                         slot_name,
-                        SlotState.ERROR,
-                        message="model dropped from lemond unexpectedly",
+                        SlotState.OFFLINE,
+                        message="model evicted from lemond (auto-reloads on next request)",
                         force=True,
                     )
                 except Exception as exc:
@@ -579,6 +587,24 @@ class SlotManager:
                 # Already loaded — return snapshot without restarting.
                 return await self.status(slot_name)
 
+            # Configuration check: a slot with no resolvable model is
+            # NOT an ERROR (which would render red and flag for operator
+            # investigation). It's an unconfigured slot — render grey
+            # with a CTA. Bail before calling lemonade.load(), whose
+            # ValueError would otherwise stamp the slot ERROR every
+            # tick the reconciler runs. The user fixes it by picking a
+            # model in the dashboard dropdown; Fix #1 persists the
+            # choice to TOML so the slot never re-enters this branch.
+            if not resolved_model:
+                await self._transition(
+                    slot_name,
+                    SlotState.OFFLINE,
+                    port=_cfg_port(cfg),
+                    message="no default model — pick one from the dropdown",
+                    force=True,
+                )
+                return await self.status(slot_name)
+
             try:
                 # PULLING — gate the model download behind an explicit
                 # state so dashboards can show "downloading model"
@@ -623,6 +649,25 @@ class SlotManager:
                     model_id=resolved_model,
                     port=_cfg_port(cfg),
                 )
+                # Persist explicit model_id to TOML so reconciliation
+                # after a Lemonade restart doesn't drift back to "no
+                # model.default" ERROR. Only fires when caller passed
+                # model_id (i.e. swap() / explicit /load body), not on
+                # plain reload of the existing default. Best-effort:
+                # a write failure is logged but doesn't fail the load —
+                # the slot is already running with the right model.
+                if model_id and model_id != _model_default(cfg):
+                    try:
+                        await self._persist_model_default(slot_name, model_id)
+                    except Exception as exc:
+                        log.warning(
+                            "slot.persist_model_default_failed",
+                            extra={
+                                "slot": slot_name,
+                                "model_id": model_id,
+                                "error": str(exc),
+                            },
+                        )
             except Exception as exc:
                 # TIER1: never swallow — record ERROR with details, re-raise.
                 await self._transition(
@@ -1262,6 +1307,115 @@ class SlotManager:
             ) from exc
 
         return await self.status(slot_name)
+
+    async def reconcile_unconfigured_slots(self) -> None:
+        """One-shot startup pass: clear stuck ERROR on unconfigured slots.
+
+        Before the empty-default short-circuit in :meth:`load`, slots
+        with no ``model.default`` would get stamped ERROR every time
+        the reconciler called lemonade.load() with an empty model name.
+        Existing state.json snapshots from that era persist the red
+        dot even after this fix lands. This pass rewrites them to
+        OFFLINE with a "pick a model" message so the dashboard
+        re-renders correctly without requiring the operator to click
+        each slot.
+
+        Best-effort — failures are logged and don't block startup.
+
+        Reads in-memory state + state.json directly. Deliberately
+        avoids :meth:`list` (which would trigger Lemonade adoption
+        probes) and :meth:`_maybe_adopt_running_slot` (which would
+        flip slots to READY without calling /v1/load) — this pass is
+        a state-machine cleanup, not a fresh status check.
+        """
+        # Walk slot configs on disk. Hydrate state.json into _states
+        # the same way _current_state does, but without going through
+        # status() (no adoption probes).
+        try:
+            slot_dir = paths.slots_config_dir()
+            cfg_files = sorted(slot_dir.glob("*.toml")) if slot_dir.exists() else []
+        except OSError as exc:
+            log.warning(
+                "slot.reconcile_unconfigured_dir_failed",
+                extra={"error": str(exc)},
+            )
+            return
+        for cfg_path in cfg_files:
+            slot_name = cfg_path.stem
+            try:
+                rec = self._states.get(slot_name) or read_state(self._state_file(slot_name))
+                if rec is None or rec.state != SlotState.ERROR:
+                    continue
+                msg = (rec.message or "").lower()
+                # Cache the hydrated record so _transition compares
+                # against the right baseline.
+                self._states[slot_name] = rec
+                # Pre-fix "no model.default set" ERRORs → OFFLINE+CTA.
+                if "no model.default set" in msg:
+                    cfg = await self._maybe_load_config(slot_name)
+                    if cfg is not None and _model_default(cfg):
+                        # TOML now has a default — leave the ERROR
+                        # alone so the operator sees that something
+                        # else went wrong.
+                        continue
+                    await self._transition(
+                        slot_name,
+                        SlotState.OFFLINE,
+                        message="no default model — pick one from the dropdown",
+                        force=True,
+                    )
+                    continue
+                # Pre-fix "model dropped from lemond unexpectedly"
+                # ERRORs → OFFLINE+evicted. The fail-watcher now
+                # treats eviction as a clean unload (Fix #3); existing
+                # state.json snapshots from before that change
+                # persist the red dot until cleared.
+                if "model dropped from lemond" in msg:
+                    await self._transition(
+                        slot_name,
+                        SlotState.OFFLINE,
+                        message="model evicted from lemond (auto-reloads on next request)",
+                        force=True,
+                    )
+                    continue
+            except Exception as exc:
+                log.warning(
+                    "slot.reconcile_unconfigured_failed",
+                    extra={"slot": slot_name, "error": str(exc)},
+                )
+
+    async def _persist_model_default(self, slot_name: str, model_id: str) -> None:
+        """Write ``[model] default = <model_id>`` into the slot's TOML.
+
+        Preserves every other key — only the ``model.default`` field is
+        rewritten. Used by :meth:`load` after a successful explicit-
+        model load (i.e. swap path) so the next reconciliation pass
+        reads the right default instead of drifting back to the empty
+        seed value that produced the "no model.default set" ERROR.
+
+        Atomic via the same ``write_bytes`` pattern as :meth:`update_config`.
+        Failures bubble up so the caller can log + soft-fail without
+        affecting the live load state.
+        """
+        try:
+            import tomli_w
+        except ImportError as exc:  # pragma: no cover
+            raise SlotConfigError("tomli_w not installed") from exc
+
+        cfg = await self._load_slot_config(slot_name)
+        cfg_dict = _cfg_to_dict(cfg)
+        existing_model = cfg_dict.get("model")
+        base_model = existing_model if isinstance(existing_model, dict) else {}
+        cfg_dict = {**cfg_dict, "model": {**base_model, "default": model_id}}
+
+        cfg_path = self._config_file(slot_name)
+        try:
+            cfg_path.write_bytes(tomli_w.dumps(cfg_dict).encode("utf-8"))
+        except OSError as exc:
+            raise SlotConfigError(
+                f"failed to persist model.default to {cfg_path}: {exc}",
+                details={"slot": slot_name, "model_id": model_id},
+            ) from exc
 
     async def _check_npu_exclusivity(
         self,

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -374,6 +374,24 @@ class SlotManager:
         log.info(
             "slot.transition", extra={"slot": name, "from": current.value, "to": to_state.value}
         )
+        # Structured ERROR audit trail (separate from the info-level
+        # transition log) so operators can `journalctl -u hal0-api |
+        # grep slot.error` to see every red-dot transition with its
+        # cause. Pairs with the event_bus emit below; the bus is
+        # transient SSE, this is durable journald.
+        if to_state == SlotState.ERROR and current != to_state:
+            # NOTE: ``extra=`` MUST NOT use "message" as a key — that's
+            # a reserved LogRecord attribute and stdlib logging raises
+            # KeyError when it collides. Use ``reason`` instead.
+            log.error(
+                "slot.error",
+                extra={
+                    "slot": name,
+                    "from": current.value,
+                    "reason": message or "(no message)",
+                    "model_id": record.model_id or "",
+                },
+            )
         await self._broadcast(record)
         # Footer event bus — best-effort emit. Skip when current == to_state
         # (idempotent refresh, no real transition) so the footer doesn't

--- a/tests/slots/test_fail_watcher.py
+++ b/tests/slots/test_fail_watcher.py
@@ -46,12 +46,20 @@ async def _wait_for_state(
     return rec.state if rec is not None else SlotState.OFFLINE
 
 
-async def test_fail_watcher_pushes_error_when_model_drops_from_lemond(
+async def test_fail_watcher_pushes_offline_when_model_drops_from_lemond(
     slot_root: Any,
     lemonade_loaded_stub: dict[str, Any],
     fast_fail_watch: None,
 ) -> None:
-    """Model leaving lemond's loaded[] while slot is READY must trigger ERROR."""
+    """Model leaving lemond's loaded[] while slot is READY transitions to OFFLINE.
+
+    Lemonade routinely evicts loaded models (idle-TTL, nuclear-evict on
+    a sibling load failure, max_models pressure). From the slot's
+    perspective this is a clean unload — the next inference request
+    hot-reloads the model. Reflected as OFFLINE (grey dot) per the
+    dot-state spec, reserving ERROR (red dot, "investigate") for real
+    spawn/health/load failures.
+    """
     sm = SlotManager()
     snap = await sm.load("primary")
     assert snap.state == SlotState.READY
@@ -63,14 +71,14 @@ async def test_fail_watcher_pushes_error_when_model_drops_from_lemond(
     # No call to status() — the push-driven watcher is what should react.
     lemonade_loaded_stub["loaded"] = []
 
-    observed = await _wait_for_state(sm, "primary", SlotState.ERROR, timeout_s=5.0)
-    assert observed == SlotState.ERROR, (
-        f"watcher failed to push ERROR within 5s; final state={observed}"
+    observed = await _wait_for_state(sm, "primary", SlotState.OFFLINE, timeout_s=5.0)
+    assert observed == SlotState.OFFLINE, (
+        f"watcher failed to push OFFLINE within 5s; final state={observed}"
     )
 
     rec = sm._states["primary"]
-    assert "lemond" in rec.message.lower() or "dropped" in rec.message.lower(), (
-        f"ERROR record should carry an explanatory message (got {rec.message!r})"
+    assert "evict" in rec.message.lower() or "auto-reload" in rec.message.lower(), (
+        f"OFFLINE record should carry an eviction explanation (got {rec.message!r})"
     )
     # Watcher is one-shot — it should have exited after firing.
     watcher = sm._fail_watchers.get("primary")
@@ -82,12 +90,12 @@ async def test_fail_watcher_pushes_error_when_model_drops_from_lemond(
         assert watcher.done()
 
 
-async def test_fail_watcher_emits_sse_frame_for_pushed_error(
+async def test_fail_watcher_emits_sse_frame_for_pushed_eviction(
     slot_root: Any,
     lemonade_loaded_stub: dict[str, Any],
     fast_fail_watch: None,
 ) -> None:
-    """The watcher-triggered ERROR transition must broadcast to SSE subscribers."""
+    """The watcher-triggered OFFLINE transition must broadcast to SSE subscribers."""
     sm = SlotManager()
     await sm.load("primary")
 
@@ -96,17 +104,17 @@ async def test_fail_watcher_emits_sse_frame_for_pushed_error(
     # Trigger failure.
     lemonade_loaded_stub["loaded"] = []
 
-    async def _next_error() -> str:
+    async def _next_offline() -> str:
         async for rec in stream:
-            if rec.state == SlotState.ERROR:
+            if rec.state == SlotState.OFFLINE:
                 return rec.message
         return ""
 
     try:
-        msg = await asyncio.wait_for(_next_error(), timeout=5.0)
+        msg = await asyncio.wait_for(_next_offline(), timeout=5.0)
     except TimeoutError:
-        pytest.fail("watcher did not emit an ERROR SSE frame within 5s")
-    assert "lemond" in msg.lower() or "dropped" in msg.lower()
+        pytest.fail("watcher did not emit an OFFLINE SSE frame within 5s")
+    assert "evict" in msg.lower() or "auto-reload" in msg.lower()
 
 
 async def test_fail_watcher_does_not_fire_when_slot_unloads_cleanly(

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -8,6 +8,7 @@
 // per-row usePullJob() instances tracked by model_id.
 
 import { useModels, usePullJob, fmtBytes } from '@/api/hooks/useModels'
+import { useSlots, useSlotSwap } from '@/api/hooks/useSlots'
 
 const { useState: useStateM, useMemo: useMemoM, useEffect: useEffectM } = React;
 
@@ -196,6 +197,8 @@ function ModelRow({ model, selected, onSelect }) {
 
 function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
   const pull = usePullJob();
+  const slotsQuery = useSlots();
+  const swap = useSlotSwap();
   if (!model) {
     return (
       <div className="mdl-detail">
@@ -276,7 +279,47 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
       <div className="mdl-detail-actions">
         {model.installed ? (
           <>
-            <button className="btn" onClick={() => window.__hal0Toast && window.__hal0Toast(`Loading ${model.longName || model.id}…`, "info")}>Load now</button>
+            <button
+              className="btn"
+              disabled={swap.isPending}
+              onClick={async () => {
+                const slots = slotsQuery.data ?? [];
+                const compatible = slots.filter(s => s.type === model.type);
+                if (compatible.length === 0) {
+                  window.__hal0Toast && window.__hal0Toast(
+                    `No slot accepts type=${model.type || "?"} — create one in Slots`,
+                    "err",
+                  );
+                  return;
+                }
+                // Prefer a slot that already runs this model (re-load),
+                // otherwise the first compatible slot. Multiple compatible
+                // slots without a current owner: user picks via slot card.
+                const owning = compatible.find(
+                  s => (s.model_id || s.model?.default) === model.id,
+                );
+                if (!owning && compatible.length > 1) {
+                  window.__hal0Toast && window.__hal0Toast(
+                    `Multiple compatible slots — use the slot card swap dropdown to pick one`,
+                    "warn",
+                  );
+                  return;
+                }
+                const target = owning || compatible[0];
+                try {
+                  await swap.mutateAsync({ name: target.name, model_id: model.id });
+                  window.__hal0Toast && window.__hal0Toast(
+                    `Loading ${model.longName || model.id} → slot ${target.name}`,
+                    "info",
+                  );
+                } catch (e) {
+                  window.__hal0Toast && window.__hal0Toast(
+                    `Load failed — ${e?.message || "see logs"}`,
+                    "err",
+                  );
+                }
+              }}
+            >{swap.isPending ? "Loading…" : "Load now"}</button>
             <button className="btn ghost sm" onClick={onEdit}>{Icons.edit} Edit options</button>
             <button className="btn danger sm" onClick={onDelete}>{Icons.unload} Delete</button>
           </>

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -530,6 +530,14 @@ function InlineSwapPopover({ slot, open, onClose, onPick }) {
             key={m.id}
             className={"swap-pop-item" + (isCur ? " cur" : "")}
             onClick={() => { onPick(m); onClose(); }}
+            role="button"
+            tabIndex={0}
+            onKeyDown={e => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onPick(m); onClose();
+              }
+            }}
           >
             <div className="nm">
               {m.longName}
@@ -537,7 +545,12 @@ function InlineSwapPopover({ slot, open, onClose, onPick }) {
             </div>
             <div className="sz num">{m.size}</div>
             <div className={"fit" + (fits ? "" : " no")}>{m.installed ? (fits ? "fits ✓" : "tight") : "will pull"}</div>
-            <span className="swap-arrow" aria-hidden="true">{Icons.chevR}</span>
+            <button
+              type="button"
+              className="swap-arrow"
+              aria-label={`Load ${m.longName || m.id}`}
+              onClick={e => { e.stopPropagation(); onPick(m); onClose(); }}
+            >{Icons.chevR}</button>
           </div>
         );
       })}

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -526,18 +526,14 @@ function InlineSwapPopover({ slot, open, onClose, onPick }) {
         const isCur = slot.model_id === m.id;
         const fits = HAL0_DATA.host.ram.free > parseSizeGB(m.size);
         return (
+          // The whole row is a mouse-click target (convenience) but the
+          // nested chevron button is the single keyboard/AT-accessible
+          // affordance — making the row also a role=button creates a
+          // double-announce for screen readers (a11y review 2026-05-27).
           <div
             key={m.id}
             className={"swap-pop-item" + (isCur ? " cur" : "")}
             onClick={() => { onPick(m); onClose(); }}
-            role="button"
-            tabIndex={0}
-            onKeyDown={e => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onPick(m); onClose();
-              }
-            }}
           >
             <div className="nm">
               {m.longName}

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -18,25 +18,26 @@ const { useState: useStateS } = React;
 // ─── Slot indicator dot ────────────────────────────────────────────────
 //
 // Maps a slot snapshot → ({ cls, label, tooltip }) for the status dot
-// rendered in SlotCard / SlotListRow. Single source of truth for the
-// "what colour does this slot deserve" question.
+// and the matching status chip. Single source of truth for the
+// user-visible colour vocabulary (per dot-state spec, 2026-05-27):
 //
-// Mapping (matches PR feat/slot-state-indicator-dots):
-//   ready + last_used_at within RECENTLY_LIVE_MS → "recent" (green)
-//   ready + older / never used                   → "stale"  (yellow)
-//   warming / starting / pulling / unloading     → "warming" (amber, pulses)
-//   serving                                      → "serving" (cyan, pulses — pre-existing)
-//   idle                                         → "stale"  (yellow — semantically "loaded, not serving")
-//   error                                        → "error"  (red)
-//   offline / anything else                      → "offline" (grey)
+//   error                                → "error"   (red)    — load/spawn failure; investigate
+//   !enabled || lemo=disabled            → "offline" (grey)   — operator-disabled
+//   warming / starting / pulling …       → "warming" (amber pulse)
+//   serving + last_used_at fresh         → "serving" (green pulse) — actively processing
+//   serving + last_used_at > 1h          → "stale"   (yellow) — possibly stuck request
+//   loaded in VRAM (lemo=loaded|ready)   → "stale"   (yellow) — ready, awaiting prompt
+//   evicted / idle (lemo=idle|idle)      → "stale"   (yellow) — auto-reloads on next request
+//   offline (clean unload/swap/evict)    → "offline" (grey)
 //
-// The "1h recently live" window leans on the backend's in-memory
-// `last_used_at` (bumped by SlotManager.serving on every dispatched
-// request). When hal0-api restarts, `last_used_at` is null for every
-// slot until the first new request lands — we render that as "stale"
-// (yellow), which matches operator intuition: we don't know whether
-// the slot was hit during downtime.
-const RECENTLY_LIVE_MS = 60 * 60 * 1000; // 1h window — kept as a named const
+// GREEN fires ONLY during an active in-flight request. Yellow covers
+// the entire "loaded and waiting" surface — in-VRAM and evicted both —
+// because operators don't need a colour to tell those apart (the
+// tooltip does). After a serving context manager exits, the slot
+// transitions back to READY (yellow); 1h later the idle monitor demotes
+// to IDLE (also yellow). The 1h timer in this file catches stuck-in-
+// SERVING slots where a request never finished.
+const RECENTLY_LIVE_MS = 60 * 60 * 1000; // 1h hung-request threshold for serving slots
 
 function _formatAgo(deltaMs) {
   if (deltaMs < 0) return "just now";
@@ -51,6 +52,8 @@ function _formatAgo(deltaMs) {
 
 function slotIndicator(slot, now = Date.now()) {
   const state = String(slot?.state || "offline");
+  const lemo = String(slot?.lemonade_state || "");
+  const enabled = slot?.enabled !== false;
   const lastUsedSec = typeof slot?.last_used_at === "number" ? slot.last_used_at : null;
   const lastUsedMs = lastUsedSec != null ? lastUsedSec * 1000 : null;
   const deltaMs = lastUsedMs != null ? now - lastUsedMs : null;
@@ -62,6 +65,13 @@ function slotIndicator(slot, now = Date.now()) {
       cls: "error",
       label: "error",
       tooltip: errorMsg ? `Error: ${errorMsg}` : "Error",
+    };
+  }
+  if (!enabled || lemo === "disabled") {
+    return {
+      cls: "offline",
+      label: "off",
+      tooltip: "Disabled",
     };
   }
   if (
@@ -81,39 +91,49 @@ function slotIndicator(slot, now = Date.now()) {
     };
   }
   if (state === "serving") {
-    // Pre-existing serving dot behaviour: cyan + pulse (CSS unchanged).
+    // Hung-request guard: if a slot has been in SERVING for longer
+    // than RECENTLY_LIVE_MS without a fresh last_used_at bump, it's
+    // almost certainly stuck on a request that will never finish.
+    // Revert to yellow with a "possibly stuck" tooltip — keeps green
+    // honest as "actively processing right now", not "lit since
+    // last week".
+    const stuck = deltaMs != null && deltaMs > RECENTLY_LIVE_MS;
+    if (stuck) {
+      return {
+        cls: "stale",
+        label: "stuck?",
+        tooltip: `Serving since ${_formatAgo(deltaMs)} — request may be stuck`,
+      };
+    }
     return {
       cls: "serving",
       label: "serving",
       tooltip: model ? `Serving ${model}` : "Serving",
     };
   }
-  if (state === "ready") {
-    if (deltaMs != null && deltaMs <= RECENTLY_LIVE_MS) {
-      return {
-        cls: "recent",
-        label: "ready",
-        tooltip: `Loaded, last used ${_formatAgo(deltaMs)}`,
-      };
-    }
+  // Slot is loaded and waiting for a prompt — YELLOW per the dot-state
+  // spec ("active + available to receive prompts → yellow; green only
+  // while actively processing"). In-VRAM vs evicted is a tooltip-only
+  // distinction; the colour is the same so operators don't need to
+  // squint to tell "ready" from "idle".
+  if (lemo === "loaded" || state === "ready") {
     return {
       cls: "stale",
       label: "ready",
       tooltip: deltaMs != null
-        ? `Loaded, idle (${_formatAgo(deltaMs)})`
-        : "Loaded — no requests since hal0-api started",
+        ? `Loaded — last used ${_formatAgo(deltaMs)}`
+        : (model ? `Loaded — ${model} in VRAM` : "Loaded — model in VRAM"),
     };
   }
-  if (state === "idle") {
+  // Lemonade-evicted slots arrive here as state=offline lemonade_state=idle:
+  // the model is available but not in VRAM, lemonade hot-reloads on next request.
+  if (lemo === "idle" || state === "idle") {
     return {
       cls: "stale",
       label: "idle",
-      tooltip: deltaMs != null
-        ? `Idle (${_formatAgo(deltaMs)})`
-        : "Idle",
+      tooltip: "Idle — model not in VRAM, will hot-reload on next request",
     };
   }
-  // offline + anything unknown
   return {
     cls: "offline",
     label: state,
@@ -242,9 +262,15 @@ function SlotCard({
         <span className="chip">{type}</span>
         <span className={"chip dev-" + (device || "cpu").replace("gpu-", "")}>{device}</span>
         {cpuOnly && <span className="chip">[CPU]</span>}
-        <span className="chip" style={{color: state === "serving" ? "var(--accent)" : state === "ready" ? "var(--ok)" : state === "idle" ? "var(--fg-3)" : "var(--fg-3)"}}>
-          {state}
-        </span>
+        {(() => {
+          const ind = slotIndicator(slot);
+          const chipColor = ind.cls === "recent" ? "var(--ok)"
+            : ind.cls === "serving" ? "var(--accent)"
+            : ind.cls === "stale" || ind.cls === "warming" ? "var(--warn)"
+            : ind.cls === "error" ? "var(--err)"
+            : "var(--fg-3)";
+          return <span className="chip" style={{color: chipColor}}>{ind.label}</span>;
+        })()}
       </div>
       <div className="slot-metrics">
         {metricsRow.map((m, i) => (

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -586,7 +586,7 @@ a { color: inherit; text-decoration: none; }
   background: var(--fg-4);
 }
 .dot.ready { background: var(--ok); box-shadow: 0 0 8px var(--ok); }
-.dot.serving { background: var(--accent); box-shadow: 0 0 8px var(--accent); animation: pulse 1.5s ease-in-out infinite; }
+.dot.serving { background: var(--ok); box-shadow: 0 0 8px var(--ok); animation: pulse 1.2s ease-in-out infinite; }
 .dot.idle { background: var(--ok); opacity: 0.45; }
 .dot.loading { background: var(--warn); animation: pulse 1.2s ease-in-out infinite; }
 .dot.error { background: var(--err); }
@@ -2610,9 +2610,26 @@ a { color: inherit; text-decoration: none; }
 .swap-pop-item .sz { color: var(--fg-3); font-size: 11px; }
 .swap-pop-item .fit { color: var(--ok); font-size: 10px; text-align: right; }
 .swap-pop-item .fit.no { color: var(--warn); }
-.swap-pop-item .swap-arrow { display: inline-flex; color: var(--fg-3); transition: color 0.12s ease; }
+.swap-pop-item .swap-arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  padding: 2px;
+  margin: -2px;
+  color: var(--fg-3);
+  cursor: pointer;
+  border-radius: 3px;
+  transition: color 0.12s ease, background 0.12s ease;
+}
 .swap-pop-item:hover .swap-arrow { color: var(--ok); }
 .swap-pop-item.cur .swap-arrow { color: var(--ok); }
+.swap-pop-item .swap-arrow:hover { background: var(--ok-soft); color: var(--ok); }
+.swap-pop-item .swap-arrow:focus-visible {
+  outline: 2px solid var(--ok);
+  outline-offset: 1px;
+}
 
 /* ─── Variant filter chips (HF coords modal) ────────────────────── */
 .variant-row {

--- a/ui/tests/e2e/specs/slot-indicator.spec.ts
+++ b/ui/tests/e2e/specs/slot-indicator.spec.ts
@@ -2,8 +2,21 @@
  * slot-indicator — exercises the `slotIndicator` mapping helper exported
  * from ui/src/dash/slots.jsx onto window. Single source of truth for the
  * status-dot colour/tooltip; this spec pins the state → dot.cls table
- * so future tweaks can't silently regress (e.g. flipping idle to green
- * or dropping the 1h "recently live" threshold).
+ * so future tweaks can't silently regress.
+ *
+ * Contract (2026-05-27 user spec):
+ *   error                  → red
+ *   serving + fresh        → green pulse (GREEN ONLY during in-flight)
+ *   serving + last>1h      → yellow (stuck-request guard)
+ *   ready / lemo=loaded    → yellow (loaded, awaiting prompt)
+ *   idle / lemo=idle       → yellow (evicted, hot-reload on next request)
+ *   warming/starting/…     → amber pulse
+ *   !enabled / disabled    → grey "off"
+ *   offline                → grey
+ *
+ * The pre-2026-05-27 "recent (green) vs stale (yellow)" distinction
+ * for READY slots is gone: GREEN now signals only active serving.
+ * RECENTLY_LIVE_MS is repurposed as the hung-SERVING threshold.
  */
 import { test, expect } from '../fixtures/apiMock'
 
@@ -19,15 +32,17 @@ test.describe('slotIndicator helper', () => {
     await page.waitForFunction(() => typeof (window as any).slotIndicator === 'function')
   })
 
-  test('ready + last_used within 1h → recent (green)', async ({ page }) => {
+  test('ready + last_used within 1h → stale (yellow, "ready")', async ({ page }) => {
+    // Per 2026-05-27 spec: READY is "loaded and waiting" → yellow, not
+    // green. Green is reserved for state=serving (in-flight only).
     const ind = await page.evaluate<Indicator>(() => {
       const now = Date.now()
       const slot = { state: 'ready', last_used_at: (now - 12 * 60 * 1000) / 1000, model: 'foo' }
       return (window as any).slotIndicator(slot, now)
     })
-    expect(ind.cls).toBe('recent')
+    expect(ind.cls).toBe('stale')
     expect(ind.label).toBe('ready')
-    expect(ind.tooltip).toMatch(/Loaded, last used 12 min ago/)
+    expect(ind.tooltip).toMatch(/Loaded — last used 12 min ago/)
   })
 
   test('ready + last_used >1h ago → stale (yellow)', async ({ page }) => {
@@ -38,16 +53,16 @@ test.describe('slotIndicator helper', () => {
       return (window as any).slotIndicator(slot, now)
     })
     expect(ind.cls).toBe('stale')
-    expect(ind.tooltip).toMatch(/Loaded, idle \(1h ago\)/)
+    expect(ind.tooltip).toMatch(/Loaded — last used 1h ago/)
   })
 
-  test('ready + last_used null → stale (yellow), tooltip notes no requests', async ({ page }) => {
+  test('ready + last_used null → stale (yellow), tooltip notes model in VRAM', async ({ page }) => {
     const ind = await page.evaluate<Indicator>(() => {
       const slot = { state: 'ready', last_used_at: null }
       return (window as any).slotIndicator(slot, Date.now())
     })
     expect(ind.cls).toBe('stale')
-    expect(ind.tooltip).toMatch(/no requests since hal0-api started/)
+    expect(ind.tooltip).toMatch(/Loaded — model in VRAM/)
   })
 
   test('warming → warming (pulsing amber)', async ({ page }) => {
@@ -99,21 +114,89 @@ test.describe('slotIndicator helper', () => {
     expect(ms).toBe(RECENTLY_LIVE_MS)
   })
 
-  test('boundary: exactly 1h ago is still recent (≤, not <)', async ({ page }) => {
+  // READY → yellow regardless of last_used_at (the 1h threshold no longer
+  // gates a colour transition for READY; it gates the in-flight stuck
+  // guard for SERVING only). Both boundaries below map to 'stale'.
+  test('boundary: exactly 1h ago READY is stale (yellow)', async ({ page }) => {
     const cls = await page.evaluate(() => {
       const now = Date.now()
       const slot = { state: 'ready', last_used_at: (now - 60 * 60 * 1000) / 1000 }
       return (window as any).slotIndicator(slot, now).cls
     })
-    expect(cls).toBe('recent')
+    expect(cls).toBe('stale')
   })
 
-  test('boundary: 1h + 1s ago becomes stale', async ({ page }) => {
+  test('boundary: 1h + 1s ago READY is still stale (yellow)', async ({ page }) => {
     const cls = await page.evaluate(() => {
       const now = Date.now()
       const slot = { state: 'ready', last_used_at: (now - 60 * 60 * 1000 - 1000) / 1000 }
       return (window as any).slotIndicator(slot, now).cls
     })
     expect(cls).toBe('stale')
+  })
+
+  test('serving + fresh last_used → serving (green pulse)', async ({ page }) => {
+    const ind = await page.evaluate<Indicator>(() => {
+      const now = Date.now()
+      const slot = {
+        state: 'serving',
+        last_used_at: (now - 5 * 1000) / 1000,
+        model: 'qwen3.5-4b-q4kxl',
+      }
+      return (window as any).slotIndicator(slot, now)
+    })
+    expect(ind.cls).toBe('serving')
+    expect(ind.label).toBe('serving')
+    expect(ind.tooltip).toMatch(/Serving qwen3.5-4b-q4kxl/)
+  })
+
+  test('serving + last_used >1h ago → stale (stuck-request guard)', async ({ page }) => {
+    const ind = await page.evaluate<Indicator>(() => {
+      const now = Date.now()
+      const slot = {
+        state: 'serving',
+        last_used_at: (now - 90 * 60 * 1000) / 1000,
+        model: 'qwen3.5-4b-q4kxl',
+      }
+      return (window as any).slotIndicator(slot, now)
+    })
+    expect(ind.cls).toBe('stale')
+    expect(ind.label).toBe('stuck?')
+    expect(ind.tooltip).toMatch(/may be stuck/)
+  })
+
+  test('!enabled → offline (grey "off")', async ({ page }) => {
+    const ind = await page.evaluate<Indicator>(() => {
+      return (window as any).slotIndicator({ state: 'ready', enabled: false })
+    })
+    expect(ind.cls).toBe('offline')
+    expect(ind.label).toBe('off')
+  })
+
+  test('lemonade_state=loaded → stale (yellow)', async ({ page }) => {
+    // Lemonade enrichment override: even if slot.state is offline,
+    // lemo=loaded means the model is in VRAM → yellow.
+    const ind = await page.evaluate<Indicator>(() => {
+      return (window as any).slotIndicator({
+        state: 'offline',
+        lemonade_state: 'loaded',
+        model: 'foo',
+      })
+    })
+    expect(ind.cls).toBe('stale')
+    expect(ind.label).toBe('ready')
+  })
+
+  test('lemonade_state=idle → stale (yellow, evicted)', async ({ page }) => {
+    const ind = await page.evaluate<Indicator>(() => {
+      return (window as any).slotIndicator({
+        state: 'offline',
+        lemonade_state: 'idle',
+        model: 'foo',
+      })
+    })
+    expect(ind.cls).toBe('stale')
+    expect(ind.label).toBe('idle')
+    expect(ind.tooltip).toMatch(/hot-reload on next request/)
   })
 })

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "hal0"
-version = "0.2.0a1"
+version = "0.3.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },
@@ -1373,10 +1373,12 @@ dependencies = [
     { name = "fastapi" },
     { name = "fastembed" },
     { name = "httpx" },
+    { name = "jinja2" },
     { name = "mcp" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
+    { name = "pyyaml" },
     { name = "rich" },
     { name = "sse-starlette" },
     { name = "structlog" },
@@ -1407,6 +1409,7 @@ requires-dist = [
     { name = "fastembed", specifier = ">=0.8,<1.0" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
+    { name = "jinja2", specifier = ">=3.1" },
     { name = "mcp", specifier = "==1.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
     { name = "numpy", marker = "extra == 'dev'", specifier = ">=2.0" },
@@ -1417,6 +1420,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "python-multipart", marker = "extra == 'dev'", specifier = ">=0.0.9" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.9" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
     { name = "soundfile", marker = "extra == 'dev'", specifier = ">=0.12" },


### PR DESCRIPTION
## Summary

Bundled fix for the "slot cards show red with no explanation, dropdown picks don't load" pile-on. Three diagnose agents fanned out (backend lifecycle, dropdown UX, dot state machine), three review agents fanned out after (backend correctness, frontend a11y, user-spec compliance). All concurred ship-as-is after one a11y amendment + one logging amendment.

Live on the LXC: **zero red dots**, swap persists across `hal0-api` restart, structured `slot.error` audit log lands in journald on real failures.

## Fix table

| # | What | File |
|---|------|------|
| 1 | Swap persists `model.default` to TOML so reconciliation never drifts back to "no model.default set" ERROR | `slots/manager.py` (new `_persist_model_default`) |
| 2 | `_fail_watch` treats lemond eviction as a clean unload (OFFLINE+grey), reserving ERROR for spawn/health/load exceptions | `slots/manager.py` |
| 3 | `.dot.serving` cyan/amber → green per dot-state spec | `ui/src/dashboard.css` |
| 4 | `load()` short-circuits to OFFLINE+CTA on empty default instead of letting lemonade throw and stamp ERROR every tick; one-shot startup reconciler migrates pre-fix stuck ERROR snapshots | `slots/manager.py` + `api/__init__.py` |
| 5 | InlineSwapPopover chevron is now an independently-clickable `<button>` with own onClick + aria-label + focus-visible | `slot-modals.jsx` + CSS |
| 6 | "Load now" on Models page wired through `useSlotSwap` — was a toast stub | `ui/src/dash/models.jsx` |
| 7 | `slotIndicator()` rewrite: GREEN only while actively SERVING; loaded+waiting + evicted both → YELLOW; 1h hung-request guard demotes a stuck SERVING slot back to YELLOW with "stuck?" label | `ui/src/dash/slots.jsx` |

### Post-review amendments

- **a11y**: dropped row's `role="button"` / `tabIndex` / `onKeyDown` so the chevron `<button>` is the single keyboard/AT-accessible affordance (frontend reviewer caught a double-announce for screen readers). Mouse onClick on the row body still works.
- **audit logging**: `log.error("slot.error", extra={..., "reason": message, ...})` on every ERROR transition. `journalctl -u hal0-api | grep slot.error` now lists every red-dot transition with cause. NOTE: stdlib `LogRecord` reserves `"message"` — using `extra={"message": ...}` raises KeyError; using `reason` instead, documented inline.

## Dot-state contract (per user spec)

```
error                              → red       — spawn/health/load failure; investigate
!enabled / lemo=disabled           → grey      — operator-disabled
warming / starting / pulling / …   → amber pulse — transient
serving + last_used < 1h           → green pulse — actively processing
serving + last_used > 1h           → yellow    — "stuck?" hung-request guard
ready / lemo=loaded                → yellow    — loaded, awaiting prompt
idle / lemo=idle                   → yellow    — evicted, hot-reload on next request
offline (unload/swap/evict)        → grey
```

## Test plan

- [x] `uv run pytest tests/` — 1772 passed, 3 skipped
- [x] `uv run ruff check && uv run ruff format --check` — clean
- [x] Live LXC: `curl POST /api/slots/primary/swap {model_id: qwen3.5-4b-q4kxl}` → state `error → offline → idle`, TOML carries `default = "qwen3.5-4b-q4kxl"` after the swap
- [x] Survives `systemctl restart hal0-api.service` — no drift back to ERROR
- [x] Same flow on `hermes-agent` with `hermes-4-14b-q5km` — persists
- [x] All 6 LXC slots clean (zero red dots) after deploy
- [ ] Dashboard visual: chevron arrows on each model row in the slot-card swap popover
- [ ] Dashboard visual: dot colours match the contract table above
- [ ] Cause an ERROR transition manually (e.g. point a slot at a non-existent model) and verify `journalctl -u hal0-api | grep slot.error` shows the structured row

## Three diagnose + three review reports

Out-of-band per `/diagnose` and `/triage` workflows. Six independent agent runs reached consensus before any code landed — diagnoses cross-checked each other, then reviews cross-checked the implementation. Summarised in the session transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)