### PR TITLE
fix(dash): derive model.type at useModels so Load-now matches slots

### DIFF
--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -14,6 +14,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiDelete, apiGet, apiPost, apiPut, Hal0Error } from '../client'
 import { ENDPOINTS } from '../endpoints'
+import { normalizeApiModel } from '@/lib/normalizeApiModel'
 
 export interface Model {
   id: string
@@ -36,9 +37,8 @@ export function useModels() {
     queryKey: ['models'],
     queryFn: async () => {
       const body = await apiGet<any>(ENDPOINTS.models)
-      if (Array.isArray(body)) return body as Model[]
-      if (Array.isArray(body?.models)) return body.models as Model[]
-      return []
+      const rows = Array.isArray(body) ? body : Array.isArray(body?.models) ? body.models : []
+      return rows.map(normalizeApiModel) as unknown as Model[]
     },
     refetchInterval: MODELS_POLL_MS,
   })

--- a/ui/src/lib/normalizeApiModel.ts
+++ b/ui/src/lib/normalizeApiModel.ts
@@ -1,0 +1,76 @@
+// Shared /api/models row normalizer.
+//
+// The backend registry intentionally stores `capabilities` (chat | embed |
+// rerank | transcription | tts | vision | tool-calling | coding | image)
+// and leaves `type` unset. Slots use the dispatcher vocabulary
+// (llm | embedding | reranking | transcription | tts | image). The UI
+// joins models ↔ slots on `model.type === slot.type`, so we derive `type`
+// once at the consumer boundary instead of in every consumer.
+//
+// Kept in step with src/hal0/slots/manager.py:_VALID_SLOT_TYPES.
+
+export type SlotType =
+  | 'llm'
+  | 'embedding'
+  | 'reranking'
+  | 'transcription'
+  | 'tts'
+  | 'image'
+  | ''
+
+export interface ApiModelRaw {
+  id: string
+  name?: string
+  capabilities?: string[]
+  backends?: string[]
+  size_bytes?: number
+  hf_repo?: string
+  path?: string
+  type?: string | null
+  [k: string]: unknown
+}
+
+export interface NormalizedModel extends ApiModelRaw {
+  type: SlotType
+  device: string
+  longName: string
+  size: string
+  repo: string
+}
+
+function deriveType(caps: string[]): SlotType {
+  if (caps.includes('chat') || caps.includes('coding') || caps.includes('tool-calling') || caps.includes('vision')) return 'llm'
+  if (caps.includes('rerank')) return 'reranking'
+  if (caps.includes('embed') || caps.includes('embeddings')) return 'embedding'
+  if (caps.includes('transcription') || caps.includes('asr')) return 'transcription'
+  if (caps.includes('tts')) return 'tts'
+  if (caps.includes('image')) return 'image'
+  return ''
+}
+
+function deriveDevice(backends: string[]): string {
+  if (backends.includes('rocm')) return 'rocm'
+  if (backends.includes('vulkan')) return 'vulkan'
+  if (backends.includes('cpu')) return 'cpu'
+  return backends[0] || ''
+}
+
+function formatSize(b: number): string {
+  if (!b) return '—'
+  if (b < 1024 ** 2) return `${(b / 1024).toFixed(1)} KB`
+  if (b < 1024 ** 3) return `${(b / 1024 ** 2).toFixed(1)} MB`
+  return `${(b / 1024 ** 3).toFixed(2)} GB`
+}
+
+export function normalizeApiModel(m: ApiModelRaw): NormalizedModel {
+  const caps = Array.isArray(m.capabilities) ? m.capabilities : []
+  const backends = Array.isArray(m.backends) ? m.backends : []
+  return {
+    ...m,
+    type: deriveType(caps),
+    device: deriveDevice(backends),
+    longName: m.name || m.id,
+    size: formatSize(m.size_bytes || 0),
+    repo: m.hf_repo || m.path || '',
+  }
+}


### PR DESCRIPTION
## Summary

Clicking **Load now** on any model in the catalog (whisper-tiny, embed,
chat, rerank, …) currently toasts:

> `No slot accepts type=? — create one in Slots`

even when a compatible slot is running. Reproduces every time on a stock
v0.3 install (live API + local repro).

## Root cause

`/api/models` rows ship `capabilities: ['transcription' | 'chat' | 'embed' | …]`
and leave `type` unset — the registry has no `type` field. Slots carry
the dispatcher vocabulary (`llm | embedding | reranking | transcription
| tts | image`). The join in `ui/src/dash/models.jsx:287`:

```js
const compatible = slots.filter(s => s.type === model.type);
```

…compares `slot.type` against `undefined`, so the filter is always empty
and the error fires regardless of how many compatible slots are running.

The exact mapping already exists, inlined in `ui/src/dash/slot-modals.jsx`
as a local `normalizeApiModel` — but `models.jsx` doesn't use it.

## Fix

- Extract `normalizeApiModel` to `ui/src/lib/normalizeApiModel.ts`
  (typed, with `SlotType` union + capability/backend derivation).
- Apply it once inside `useModels` so every consumer sees `type` /
  `device` / `size` / `longName` / `repo` populated. Centralises the
  capability→slot-type mapping in one place — when a new capability
  lands, the join in `models.jsx` keeps working without touching it.

Kept in step with `src/hal0/slots/manager.py:_VALID_SLOT_TYPES`.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean
- [x] \`npx playwright test\` → 75 passed, 16 skipped, 0 failed
- [x] Manual: \`curl /api/models\` rows confirmed missing \`type\`; slot
  types confirmed \`transcription | llm | embedding | reranking | tts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)