### PR TITLE
agents: hermes uninstall — venv + context_link teardown (#348 #349)

### DIFF
--- a/src/hal0/agents/hermes.py
+++ b/src/hal0/agents/hermes.py
@@ -25,10 +25,12 @@ level so a curl|bash invocation also short-circuits cleanly.
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess  # nosec B404 — required for shim
 from pathlib import Path
+from typing import Any
 
 from hal0.agents.manager import (
     AgentDriver,
@@ -165,6 +167,32 @@ class HermesDriver(AgentDriver):
         self._write_env_file(bearer_token=bearer_token)
 
     def uninstall(self) -> None:
+        # Order matters (#348 + #349): we MUST read provision.json
+        # BEFORE the manager strips the state dir. The manager calls
+        # ``driver.uninstall()`` first specifically so the driver can
+        # consume bookkeeping that is about to be deleted.
+        #
+        # Two driver-specific artifacts live OUTSIDE the manager's
+        # seed + data + state triad and so will leak if we don't
+        # clean them here:
+        #
+        #   * the dedicated Python venv at ``/var/lib/hal0/venvs/<name>/``
+        #     (built by ``hermes_provision._install_venv``) — full
+        #     interpreter + site-packages, ~hundreds of MiB.
+        #   * the operator-facing docs the ``context_link`` phase
+        #     renders into ``/etc/hal0/`` (HERMES.md + AGENTS.md).
+        #
+        # Both gaps are recorded in ``provision.json`` so we don't
+        # hardcode paths — if a future phase adds another file the
+        # inverse stays correct as long as it stamps a ``"path"``
+        # entry. Each removal is idempotent: a missing path is a
+        # no-op, never an error, so a re-run / partial-uninstall is
+        # safe.
+        provision = self._load_provision()
+        if provision is not None:
+            self._remove_context_link_outputs(provision)
+            self._remove_venv(provision)
+
         env_file = self._env_file_path()
         if env_file.exists():
             env_file.unlink()
@@ -183,6 +211,121 @@ class HermesDriver(AgentDriver):
         # /var/lib state, same posture as openwebui.env. The wrapper
         # sources this file on every hermes invocation.
         return _paths.etc() / "agents" / "hermes.env"
+
+    def _provision_state_path(self) -> Path:
+        """Return the path to ``provision.json`` for this agent.
+
+        Mirrors :meth:`AgentManager._state_dir` so test harnesses that
+        route ``$HAL0_HOME`` through ``_paths.var_lib()`` see the same
+        state file the manager would clean up. Production
+        ``hermes_provision`` hardcodes ``/var/lib/hal0/state/agents/hermes``
+        (see ``_DEFAULT_STATE_ROOT``); under HAL0_HOME both resolutions
+        agree because ``_paths.var_lib()`` returns ``/var/lib/hal0``
+        when HAL0_HOME is unset.
+        """
+        return _paths.var_lib() / "state" / "agents" / self.name / "provision.json"
+
+    def _load_provision(self) -> dict[str, Any] | None:
+        """Best-effort load of the bootstrap checkpoint.
+
+        Returns ``None`` on any failure (missing file, unreadable JSON,
+        unexpected shape) — the driver's uninstall remains a no-op
+        rather than failing the whole teardown over bookkeeping we
+        can't parse. The manager will still strip the state dir after
+        we return, so a half-loaded provision.json doesn't strand
+        artifacts indefinitely.
+        """
+        path = self._provision_state_path()
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        return data
+
+    def _remove_context_link_outputs(self, provision: dict[str, Any]) -> None:
+        """Unlink every file the ``context_link`` phase rendered (#349).
+
+        Reads ``phases.context_link.details.rendered.<name>.path`` —
+        currently HERMES.md + AGENTS.md (written to /etc/hal0/) plus
+        SOUL.md (written under HERMES_HOME, which the manager will
+        rmtree anyway, but removing it here first is harmless and
+        keeps the inverse symmetrical to the install).
+
+        Idempotent: a missing path or a non-file (e.g. directory)
+        produces no error, just a skip. Symlinks created in
+        ``details.links`` aren't tracked here — those all live under
+        HERMES_HOME (data_dir) and get cleaned by the manager's
+        ``shutil.rmtree``.
+        """
+        phases = provision.get("phases")
+        if not isinstance(phases, dict):
+            return
+        context_link = phases.get("context_link")
+        if not isinstance(context_link, dict):
+            return
+        details = context_link.get("details")
+        if not isinstance(details, dict):
+            return
+        rendered = details.get("rendered")
+        if not isinstance(rendered, dict):
+            return
+        for entry in rendered.values():
+            if not isinstance(entry, dict):
+                continue
+            raw_path = entry.get("path")
+            if not isinstance(raw_path, str) or not raw_path:
+                continue
+            target = Path(raw_path)
+            try:
+                # ``missing_ok=True`` covers the "already gone" branch
+                # without a separate exists() check. OSError catches
+                # the "exists but is a directory" branch (unlink would
+                # raise IsADirectoryError) — we skip rather than
+                # rmtree because the manager owns directory teardown
+                # and we don't want this driver hook to delete a tree
+                # an operator hand-placed at a recorded path.
+                target.unlink(missing_ok=True)
+            except OSError:
+                continue
+
+    def _remove_venv(self, provision: dict[str, Any]) -> None:
+        """Remove the per-agent Python venv recorded in provision.json (#348).
+
+        Reads top-level ``venv`` from the checkpoint — that field is
+        the canonical record of where ``hermes_provision._install_venv``
+        actually built the venv on this host, including any operator
+        override. Production default is
+        ``/var/lib/hal0/venvs/<name>/``.
+
+        Idempotent: a missing venv directory is a no-op. We require
+        the recorded path to be a directory before recursing — a
+        symlink-to-elsewhere or a stale file at the recorded location
+        is left alone (the operator can investigate; we don't want
+        an aggressive rmtree following an unexpected target).
+        """
+        raw_venv = provision.get("venv")
+        if not isinstance(raw_venv, str) or not raw_venv:
+            return
+        venv = Path(raw_venv)
+        # Resolve through symlinks via ``is_dir()`` which follows
+        # them; if the recorded path is a symlink-to-dir we still
+        # want to rmtree the target tree (it's our venv, just a
+        # weird mount layout). ``shutil.rmtree`` against a non-dir
+        # raises; the explicit guard turns that into the no-op
+        # contract the issue requires.
+        if not venv.is_dir():
+            return
+        try:
+            shutil.rmtree(venv)
+        except OSError:
+            # Best-effort. A permissions failure or a concurrent
+            # writer won't abort the rest of the uninstall — the
+            # manager's seed + data + state cleanup still runs.
+            return
 
     def _write_env_file(self, *, bearer_token: str | None) -> None:
         api_base = os.environ.get("HAL0_API_URL", "http://127.0.0.1:8080").rstrip("/")

--- a/tests/agents/test_hermes_wrapper.py
+++ b/tests/agents/test_hermes_wrapper.py
@@ -20,6 +20,7 @@ upstream binary, no real wrapper-on-PATH dependency.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -242,3 +243,239 @@ def test_status_returns_installed_iff_env_file_exists(
 
     driver.uninstall()
     assert driver.status() == "broken"
+
+
+# ── uninstall: venv + context_link teardown (#348 / #349) ────────────────────
+#
+# The driver reads provision.json to discover BOTH the venv root and
+# the /etc/hal0 doc paths that ``hermes_provision`` writes. These tests
+# stamp a representative provision.json on disk + assert the right
+# inverse happens.
+
+
+def _state_dir(tmp_hal0_home: str) -> Path:
+    """Return the path where hermes_provision would write its checkpoint."""
+    return Path(tmp_hal0_home) / "var-lib" / "hal0" / "state" / "agents" / "hermes"
+
+
+def _stamp_provision(
+    tmp_hal0_home: str,
+    *,
+    venv: Path | None = None,
+    context_paths: list[Path] | None = None,
+) -> Path:
+    """Stamp a minimal provision.json mirroring what ``hermes_provision`` writes.
+
+    Returns the path to the file. Callers can selectively omit the
+    venv or the context_link section to exercise edge cases.
+    """
+    state_dir = _state_dir(tmp_hal0_home)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "agent_id": "hermes-agent",
+        "phases": {},
+    }
+    if venv is not None:
+        payload["venv"] = str(venv)
+    if context_paths is not None:
+        payload["phases"]["context_link"] = {
+            "status": "ok",
+            "details": {
+                "rendered": {p.name: {"path": str(p), "sha256": "deadbeef"} for p in context_paths},
+                "links": [],
+                "warnings": [],
+            },
+        }
+    target = state_dir / "provision.json"
+    target.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return target
+
+
+def test_uninstall_removes_venv_recorded_in_provision_json(
+    driver: HermesDriver,
+    tmp_hal0_home: str,
+) -> None:
+    """#348: /var/lib/hal0/venvs/<name>/ must not survive uninstall.
+
+    The venv path lives outside the manager's seed + data + state
+    triad, so the driver owns this cleanup. The path is read from
+    provision.json so an operator override is honoured.
+    """
+    venv = Path(tmp_hal0_home) / "var-lib" / "hal0" / "venvs" / "hermes"
+    venv.mkdir(parents=True)
+    (venv / "bin").mkdir()
+    (venv / "bin" / "python").write_text("#!/usr/bin/env python\n")
+    (venv / "pyvenv.cfg").write_text("home = /usr/bin\n")
+    _stamp_provision(tmp_hal0_home, venv=venv)
+
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token="tok")  # env file present so uninstall has work
+    assert venv.exists()
+
+    driver.uninstall()
+    assert not venv.exists(), "venv directory must be removed by uninstall (#348)"
+
+
+def test_uninstall_is_idempotent_when_venv_already_gone(
+    driver: HermesDriver,
+    tmp_hal0_home: str,
+) -> None:
+    """#348 acceptance: missing venv must be a no-op, not an error."""
+    venv = Path(tmp_hal0_home) / "var-lib" / "hal0" / "venvs" / "hermes"
+    # Note: we deliberately do NOT create the venv directory; the
+    # provision.json points at a path that isn't on disk.
+    _stamp_provision(tmp_hal0_home, venv=venv)
+
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token="tok")
+
+    # Should not raise.
+    driver.uninstall()
+    assert not venv.exists()
+
+
+def test_uninstall_without_provision_json_only_removes_env_file(
+    driver: HermesDriver,
+    tmp_hal0_home: str,
+) -> None:
+    """No provision.json (e.g. install failed before bootstrap stamped it) —
+    driver still completes uninstall cleanly, just doesn't have a venv
+    path to chase."""
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token="tok")
+    env_file = Path(tmp_hal0_home) / "etc" / "hal0" / "agents" / "hermes.env"
+    assert env_file.exists()
+
+    driver.uninstall()
+    assert not env_file.exists()
+
+
+def test_uninstall_removes_context_link_docs(
+    driver: HermesDriver,
+    tmp_hal0_home: str,
+) -> None:
+    """#349: /etc/hal0/AGENTS.md + HERMES.md must not survive uninstall.
+
+    Both files are rendered by the ``context_link`` provision phase
+    and recorded in ``provision.json:phases.context_link.details.rendered.*``.
+    The driver reads the file list from that record rather than
+    hardcoding — if a future phase adds another doc, the inverse
+    stays correct automatically.
+    """
+    etc_hal0 = Path(tmp_hal0_home) / "etc" / "hal0"
+    etc_hal0.mkdir(parents=True, exist_ok=True)
+    agents_md = etc_hal0 / "AGENTS.md"
+    hermes_md = etc_hal0 / "HERMES.md"
+    agents_md.write_text("# Agents\n", encoding="utf-8")
+    hermes_md.write_text("# Hermes\n", encoding="utf-8")
+    _stamp_provision(tmp_hal0_home, context_paths=[agents_md, hermes_md])
+
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token="tok")
+    assert agents_md.exists() and hermes_md.exists()
+
+    driver.uninstall()
+    assert not agents_md.exists(), "/etc/hal0/AGENTS.md must be removed by uninstall (#349)"
+    assert not hermes_md.exists(), "/etc/hal0/HERMES.md must be removed by uninstall (#349)"
+
+
+def test_uninstall_context_link_is_idempotent_when_docs_already_gone(
+    driver: HermesDriver,
+    tmp_hal0_home: str,
+) -> None:
+    """#349 acceptance: a missing rendered file is a no-op, not an error."""
+    etc_hal0 = Path(tmp_hal0_home) / "etc" / "hal0"
+    etc_hal0.mkdir(parents=True, exist_ok=True)
+    agents_md = etc_hal0 / "AGENTS.md"
+    hermes_md = etc_hal0 / "HERMES.md"
+    # No files created — the provision.json records paths that aren't on disk.
+    _stamp_provision(tmp_hal0_home, context_paths=[agents_md, hermes_md])
+
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token="tok")
+
+    # Should not raise even though the recorded paths are missing.
+    driver.uninstall()
+
+
+def test_uninstall_skips_context_link_directory_safely(
+    driver: HermesDriver,
+    tmp_hal0_home: str,
+) -> None:
+    """A recorded ``rendered[*].path`` that is unexpectedly a directory
+    (e.g. operator hand-placed a folder where a file used to live)
+    must NOT be rmtree'd by the driver — leave it for the operator
+    to investigate. The rest of the uninstall still runs.
+    """
+    etc_hal0 = Path(tmp_hal0_home) / "etc" / "hal0"
+    etc_hal0.mkdir(parents=True, exist_ok=True)
+    weird_dir = etc_hal0 / "AGENTS.md"
+    weird_dir.mkdir()
+    (weird_dir / "child").write_text("operator-placed\n")
+    hermes_md = etc_hal0 / "HERMES.md"
+    hermes_md.write_text("# Hermes\n", encoding="utf-8")
+    _stamp_provision(tmp_hal0_home, context_paths=[weird_dir, hermes_md])
+
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token="tok")
+
+    driver.uninstall()
+    # Directory survives — driver doesn't rmtree on this path.
+    assert weird_dir.is_dir()
+    assert (weird_dir / "child").exists()
+    # The file-typed entry still gets cleaned.
+    assert not hermes_md.exists()
+
+
+def test_uninstall_handles_corrupt_provision_json(
+    driver: HermesDriver,
+    tmp_hal0_home: str,
+) -> None:
+    """Garbled provision.json must not break uninstall — the env file
+    still gets removed and the driver returns cleanly."""
+    state_dir = _state_dir(tmp_hal0_home)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "provision.json").write_text("{ this is not valid json", encoding="utf-8")
+
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token="tok")
+    env_file = Path(tmp_hal0_home) / "etc" / "hal0" / "agents" / "hermes.env"
+    assert env_file.exists()
+
+    driver.uninstall()
+    assert not env_file.exists()
+
+
+def test_uninstall_full_teardown_via_provision_json(
+    driver: HermesDriver,
+    tmp_hal0_home: str,
+) -> None:
+    """End-to-end driver uninstall: stamp a realistic provision.json
+    with BOTH venv + context_link populated, then assert every
+    recorded artifact is gone post-uninstall."""
+    venv = Path(tmp_hal0_home) / "var-lib" / "hal0" / "venvs" / "hermes"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").write_text("#!/usr/bin/env python\n")
+    etc_hal0 = Path(tmp_hal0_home) / "etc" / "hal0"
+    etc_hal0.mkdir(parents=True, exist_ok=True)
+    agents_md = etc_hal0 / "AGENTS.md"
+    hermes_md = etc_hal0 / "HERMES.md"
+    agents_md.write_text("# Agents\n", encoding="utf-8")
+    hermes_md.write_text("# Hermes\n", encoding="utf-8")
+    _stamp_provision(
+        tmp_hal0_home,
+        venv=venv,
+        context_paths=[agents_md, hermes_md],
+    )
+
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token="tok")
+    env_file = Path(tmp_hal0_home) / "etc" / "hal0" / "agents" / "hermes.env"
+    assert env_file.exists() and venv.exists() and agents_md.exists() and hermes_md.exists()
+
+    driver.uninstall()
+    assert not env_file.exists()
+    assert not venv.exists()
+    assert not agents_md.exists()
+    assert not hermes_md.exists()

--- a/tests/harness/agents-test.sh
+++ b/tests/harness/agents-test.sh
@@ -26,10 +26,21 @@
 #       uninstall every witness is gone (no orphan data_dir,
 #       state dir, or seed left behind).
 #
-# Driver mocking: the manager's _driver_for() is monkey-patched to
+#   agents-hermes-venv-teardown (#348)
+#       Drive HermesDriver.uninstall() directly against a stamped
+#       provision.json that records a venv path → assert the venv
+#       directory is gone.
+#
+#   agents-hermes-context-link-teardown (#349)
+#       Drive HermesDriver.uninstall() against a provision.json whose
+#       context_link phase records HERMES.md + AGENTS.md under
+#       $HAL0_HOME/etc/hal0/ → assert both files are gone.
+#
+# Driver mocking: scenarios #346 patch the manager's _driver_for() to
 # return a stub so we don't need the Hermes upstream installed on the
-# harness host. The unit on test is the manager's cleanup contract +
-# the disk-truth predicate.
+# harness host. The #348 + #349 scenarios DO NOT stub — they instantiate
+# HermesDriver directly because the cleanup paths under test live in
+# that driver, not the manager.
 #
 # Exit: 0 if both rows pass, non-zero (count of fails) otherwise.
 
@@ -83,10 +94,12 @@ log_step "Agent uninstall regression rows (#346) — python=${PY_BIN}"
 # failure (the row's detail captures the diagnostic).
 DRIVER="${SCRIPT_DIR}/reports/agents-driver.py"
 cat >"${DRIVER}" <<'PY'
-"""δ-harness driver for #346. See tests/harness/agents-test.sh."""
+"""δ-harness driver for #346 + #348 + #349. See tests/harness/agents-test.sh."""
 
 from __future__ import annotations
 
+import json
+import os
 import shutil
 import sys
 import tomllib
@@ -223,6 +236,93 @@ def scenario_roundtrip_no_orphans(prefix: Path) -> None:
             )
 
 
+def _stamp_provision_json(
+    state_dir: Path,
+    *,
+    venv: Path | None = None,
+    rendered_paths: list[Path] | None = None,
+) -> None:
+    """Mirror what hermes_provision writes — minimal shape sufficient for the
+    HermesDriver uninstall reader."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "agent_id": "hermes-agent",
+        "phases": {},
+    }
+    if venv is not None:
+        payload["venv"] = str(venv)
+    if rendered_paths is not None:
+        payload["phases"]["context_link"] = {
+            "status": "ok",
+            "details": {
+                "rendered": {
+                    p.name: {"path": str(p), "sha256": "0" * 64} for p in rendered_paths
+                },
+                "links": [],
+                "warnings": [],
+            },
+        }
+    (state_dir / "provision.json").write_text(
+        json.dumps(payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def scenario_hermes_venv_teardown(prefix: Path) -> None:
+    """#348: HermesDriver.uninstall() removes the recorded venv directory."""
+    os.environ["HAL0_HOME"] = str(prefix)
+    # Late import so HAL0_HOME is in effect when paths resolve.
+    from hal0.agents.hermes import HermesDriver
+    from hal0.config import paths as _paths
+
+    venv = _paths.var_lib() / "venvs" / "hermes"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").write_text("#!/usr/bin/env python\n")
+    (venv / "pyvenv.cfg").write_text("home = /usr/bin\n")
+    state_dir = _paths.var_lib() / "state" / "agents" / "hermes"
+    _stamp_provision_json(state_dir, venv=venv)
+
+    if not venv.exists():
+        raise AssertionError(f"pre-condition: venv must exist at {venv}")
+
+    drv = HermesDriver(prober=lambda: True)
+    drv.uninstall()
+
+    if venv.exists():
+        raise AssertionError(
+            f"#348 unmet: venv survived HermesDriver.uninstall() at {venv}"
+        )
+
+
+def scenario_hermes_context_link_teardown(prefix: Path) -> None:
+    """#349: HermesDriver.uninstall() removes /etc/hal0/AGENTS.md + HERMES.md."""
+    os.environ["HAL0_HOME"] = str(prefix)
+    from hal0.agents.hermes import HermesDriver
+    from hal0.config import paths as _paths
+
+    etc_hal0 = _paths.etc()
+    etc_hal0.mkdir(parents=True, exist_ok=True)
+    agents_md = etc_hal0 / "AGENTS.md"
+    hermes_md = etc_hal0 / "HERMES.md"
+    agents_md.write_text("# Agents\n", encoding="utf-8")
+    hermes_md.write_text("# Hermes\n", encoding="utf-8")
+    state_dir = _paths.var_lib() / "state" / "agents" / "hermes"
+    _stamp_provision_json(state_dir, rendered_paths=[agents_md, hermes_md])
+
+    if not (agents_md.exists() and hermes_md.exists()):
+        raise AssertionError("pre-condition: AGENTS.md + HERMES.md must exist")
+
+    drv = HermesDriver(prober=lambda: True)
+    drv.uninstall()
+
+    survivors = [p for p in (agents_md, hermes_md) if p.exists()]
+    if survivors:
+        raise AssertionError(
+            f"#349 unmet: context_link docs survived uninstall: {survivors}"
+        )
+
+
 def main(argv: list[str]) -> int:
     scenario_name = argv[1]
     prefix = Path(argv[2])
@@ -235,6 +335,10 @@ def main(argv: list[str]) -> int:
             scenario_install_corrupt_uninstall(prefix)
         elif scenario_name == "roundtrip-no-orphans":
             scenario_roundtrip_no_orphans(prefix)
+        elif scenario_name == "hermes-venv-teardown":
+            scenario_hermes_venv_teardown(prefix)
+        elif scenario_name == "hermes-context-link-teardown":
+            scenario_hermes_context_link_teardown(prefix)
         else:
             print(f"unknown scenario: {scenario_name}", file=sys.stderr)
             return 2
@@ -267,8 +371,10 @@ run_scenario() {
     fi
 }
 
-run_scenario "agents-install-corrupt-uninstall" "install-corrupt-uninstall"
-run_scenario "agents-roundtrip-no-orphans"      "roundtrip-no-orphans"
+run_scenario "agents-install-corrupt-uninstall"   "install-corrupt-uninstall"
+run_scenario "agents-roundtrip-no-orphans"        "roundtrip-no-orphans"
+run_scenario "agents-hermes-venv-teardown"        "hermes-venv-teardown"
+run_scenario "agents-hermes-context-link-teardown" "hermes-context-link-teardown"
 
 log_step "Write report"
 harness_write_report || true


### PR DESCRIPTION
## What changed

Closes both driver-side teardown gaps that survived the manager-side cleanup in #346:

- **#348 — venv leak**: `HermesDriver.uninstall()` now removes the dedicated Python venv (`/var/lib/hal0/venvs/<name>/`) built by `hermes_provision._install_venv`. The path is read from `provision.json:venv` so an operator override is honoured. Full interpreter + site-packages; a leak per install adds hundreds of MiB.
- **#349 — context_link docs**: `HermesDriver.uninstall()` now removes the operator-facing docs (`/etc/hal0/HERMES.md` + `/etc/hal0/AGENTS.md`) rendered by the `context_link` provision phase. The file list is read from `provision.json:phases.context_link.details.rendered.*.path` rather than hardcoded, so a future phase adding another doc gets the inverse automatically.

Both cleanups read `provision.json` BEFORE the driver returns — the manager's `_state_dir(...)` rmtree (which removes the checkpoint itself) runs after, so neither artifact is stranded. Every removal is idempotent: a missing path / corrupt provision.json / hand-placed directory at a recorded path all fall through to the existing env-file cleanup without raising.

The implementation is HAL0_HOME-aware (`_paths.var_lib()`) so tests under the `tmp_hal0_home` fixture exercise the same code paths as production.

## Test plan

- [x] Unit — `tests/agents/test_hermes_wrapper.py` — 8 new tests:
  - `test_uninstall_removes_venv_recorded_in_provision_json` (#348 happy path)
  - `test_uninstall_is_idempotent_when_venv_already_gone` (#348 no-op contract)
  - `test_uninstall_without_provision_json_only_removes_env_file` (graceful fallback)
  - `test_uninstall_removes_context_link_docs` (#349 happy path)
  - `test_uninstall_context_link_is_idempotent_when_docs_already_gone` (#349 no-op)
  - `test_uninstall_skips_context_link_directory_safely` (operator-placed dir is left alone)
  - `test_uninstall_handles_corrupt_provision_json` (garbled JSON still uninstalls)
  - `test_uninstall_full_teardown_via_provision_json` (end-to-end driver smoke)
- [x] δ-harness — `tests/harness/agents-test.sh` — 2 new scenario rows:
  - `agents-hermes-venv-teardown` (#348)
  - `agents-hermes-context-link-teardown` (#349)
  Both drive `HermesDriver.uninstall()` directly against a stamped `provision.json` fixture (no manager stubbing — the contract under test lives in the driver).
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (298 files formatted)
- [x] `pytest tests/` — 1788 passed, 3 skipped (pre-existing skips, unrelated)

## Context

Base PR for context: #352 (registry-coherent teardown — established `AgentManager._state_dir(name)` + `is_present_on_disk(name)` + the δ-harness scaffolding this slice extends).

Closes #348, Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)