### PR TITLE
agents: hermes uninstall — surface memory teardown failures (#350)

### DIFF
--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -9,8 +9,9 @@ ADR-0004 §5 "Pending items").
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 
 import typer
 from rich.console import Console
@@ -26,6 +27,7 @@ from hal0.cli._shared import (
     api_post,
     die,
 )
+from hal0.cli._shared import _console as _stderr_console
 from hal0.mcp.approval_queue import _PRIMARY_TARGET_ARG
 
 app = typer.Typer(help="Manage bundled agents (Phase 8 — pi-coder / Hermes-Agent).")
@@ -97,7 +99,8 @@ def agent_uninstall(
     # memory call doesn't leave half-state. Skipped on --keep-memory
     # (per #246 + ADR-0011 §6 — re-install reuses the existing card).
     if name == "hermes" and not keep_memory:
-        _uninstall_hermes_memory()
+        outcome = _uninstall_hermes_memory()
+        _warn_memory_outcome(outcome)
 
     try:
         result = api_delete(f"/api/agents/{name}")
@@ -113,12 +116,55 @@ def agent_uninstall(
             console.print("[dim](memory preserved — re-install will reuse it)[/dim]")
 
 
-def _uninstall_hermes_memory() -> None:
+# Outcomes of ``_uninstall_hermes_memory``. See #350 — the bare-swallowed
+# exception used to mask cases where the delete reported OK but the dataset
+# still held leftover rows (observed 2026-05-26: 9 hermes-agent identity
+# cards survived a default uninstall, operator got no signal). The four
+# cases below let the CLI distinguish "all clear" from "memory was down"
+# from "delete lied" without changing the idempotent exit-0 contract.
+MemoryOutcomeStatus = Literal["deleted", "not_found", "unreachable", "leftover"]
+
+
+@dataclass(frozen=True)
+class MemoryUninstallOutcome:
+    """Structured result from ``_uninstall_hermes_memory``.
+
+    Attributes
+    ----------
+    outcome
+        One of ``deleted`` / ``not_found`` / ``unreachable`` / ``leftover``.
+        ``deleted`` = delete request succeeded AND the post-verify search
+        found zero surviving rows. ``not_found`` = the pre-delete search
+        already saw zero matching rows (true no-op). ``unreachable`` =
+        the memory API couldn't be reached on either the search or the
+        delete call. ``leftover`` = delete returned OK but a post-delete
+        verify search still saw matching rows (the bug observed in #350).
+    deleted_count
+        Number of rows the delete call was issued against. Zero for
+        ``not_found`` / ``unreachable`` (we never got to the delete).
+    leftover_count
+        Rows the post-delete verify search saw matching
+        ``agent_id=hermes-agent``. ``None`` when the verify call itself
+        couldn't run (transport error, unparseable response, etc.) —
+        distinct from a confirmed zero.
+    url
+        The hal0 API base we tried (handy in stderr warnings so the
+        operator knows what endpoint to check).
+    """
+
+    outcome: MemoryOutcomeStatus
+    deleted_count: int
+    leftover_count: int | None
+    url: str
+
+
+def _uninstall_hermes_memory() -> MemoryUninstallOutcome:
     """Best-effort: delete the hermes identity card from the `agents` dataset.
 
-    Failure is silent — the agent surface tear-down proceeds regardless
-    (memory unreachable shouldn't strand the operator with a half-uninstalled
-    agent).
+    Failure is tolerated (memory unreachable shouldn't strand the operator
+    with a half-uninstalled agent — same contract as before #350), but
+    surfaces the outcome to the caller so the CLI can warn on unreachable
+    or leftover-row cases. The CLI always exits 0 regardless of outcome.
     """
     import json as _json
     import urllib.error
@@ -129,35 +175,50 @@ def _uninstall_hermes_memory() -> None:
     # semantics: failure is tolerated (memory unreachable shouldn't
     # strand the operator with a half-uninstalled agent).
     url = _api_base()
-    search_body = _json.dumps(
-        {
-            "query": "hermes-agent",
-            "tags": ["agent-identity"],
-            "dataset": "agents",
-            "limit": 50,
-        }
-    ).encode("utf-8")
     headers = {"Content-Type": "application/json", "X-hal0-Agent": "hermes-agent"}
-    req = urllib.request.Request(
-        f"{url}/api/memory/search", data=search_body, headers=headers, method="POST"
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=5.0) as resp:
-            data = _json.loads(resp.read().decode("utf-8"))
-    except (urllib.error.URLError, OSError, _json.JSONDecodeError):
-        return
-    if not isinstance(data, dict):
-        return
-    items = data.get("items") or []
-    ids: list[str] = []
-    for it in items if isinstance(items, list) else []:
-        if not isinstance(it, dict):
-            continue
-        md = it.get("metadata") or {}
-        if md.get("agent_id") == "hermes-agent" and it.get("id"):
-            ids.append(it["id"])
+
+    def _search_ids() -> list[str] | None:
+        """Return matching ids, or ``None`` if the search couldn't run."""
+        search_body = _json.dumps(
+            {
+                "query": "hermes-agent",
+                "tags": ["agent-identity"],
+                "dataset": "agents",
+                "limit": 50,
+            }
+        ).encode("utf-8")
+        req = urllib.request.Request(
+            f"{url}/api/memory/search", data=search_body, headers=headers, method="POST"
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=5.0) as resp:
+                data = _json.loads(resp.read().decode("utf-8"))
+        except (urllib.error.URLError, OSError, _json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        items = data.get("items") or []
+        ids: list[str] = []
+        for it in items if isinstance(items, list) else []:
+            if not isinstance(it, dict):
+                continue
+            md = it.get("metadata") or {}
+            if md.get("agent_id") == "hermes-agent" and it.get("id"):
+                ids.append(it["id"])
+        return ids
+
+    ids = _search_ids()
+    if ids is None:
+        return MemoryUninstallOutcome(
+            outcome="unreachable", deleted_count=0, leftover_count=None, url=url
+        )
     if not ids:
-        return
+        # Pre-delete search saw zero — true no-op. Skip the verify
+        # round-trip since there's nothing to verify.
+        return MemoryUninstallOutcome(
+            outcome="not_found", deleted_count=0, leftover_count=0, url=url
+        )
+
     del_body = _json.dumps({"ids": ids}).encode("utf-8")
     req2 = urllib.request.Request(
         f"{url}/api/memory/delete", data=del_body, headers=headers, method="POST"
@@ -166,7 +227,57 @@ def _uninstall_hermes_memory() -> None:
         with urllib.request.urlopen(req2, timeout=5.0):
             pass
     except (urllib.error.URLError, OSError):
-        return
+        return MemoryUninstallOutcome(
+            outcome="unreachable", deleted_count=len(ids), leftover_count=None, url=url
+        )
+
+    # Post-delete verify: the 2026-05-26 incident logged in #350 had the
+    # delete return 200 but leave 9 rows in place. Re-run the search and
+    # surface the gap if rows survive.
+    verify_ids = _search_ids()
+    if verify_ids is None:
+        # Delete returned OK but verify couldn't run. Don't escalate to
+        # ``leftover`` — we have no evidence either way; treat as silent
+        # success (best-effort contract preserved).
+        return MemoryUninstallOutcome(
+            outcome="deleted", deleted_count=len(ids), leftover_count=None, url=url
+        )
+    if verify_ids:
+        return MemoryUninstallOutcome(
+            outcome="leftover",
+            deleted_count=len(ids),
+            leftover_count=len(verify_ids),
+            url=url,
+        )
+    return MemoryUninstallOutcome(
+        outcome="deleted", deleted_count=len(ids), leftover_count=0, url=url
+    )
+
+
+def _warn_memory_outcome(outcome: MemoryUninstallOutcome) -> None:
+    """Surface the two failure-ish outcomes as yellow stderr warnings.
+
+    ``deleted`` / ``not_found`` stay silent (the happy path); only the
+    two cases that mean "memory teardown didn't complete cleanly" warn.
+    The CLI's exit code is unaffected — operator-facing signal only.
+    """
+    if outcome.outcome == "unreachable":
+        _stderr_console.print(
+            f"[yellow]warning[/yellow]: memory teardown skipped — "
+            f"hal0 memory API unreachable at {outcome.url}. "
+            "Re-run uninstall once the daemon is back, or use "
+            "[bold]hal0 agent uninstall hermes --keep-memory[/bold] "
+            "if this is intentional."
+        )
+    elif outcome.outcome == "leftover":
+        leftover = outcome.leftover_count if outcome.leftover_count is not None else "?"
+        _stderr_console.print(
+            f"[yellow]warning[/yellow]: memory teardown incomplete — "
+            f"{leftover} hermes-agent row(s) still in the [bold]agents[/bold] "
+            "dataset after delete. Inspect with "
+            "[bold]hal0 agent peers[/bold] and clean up by id via "
+            "[bold]/api/memory/delete[/bold]."
+        )
 
 
 @app.command("list")

--- a/tests/cli/test_agent_uninstall_memory.py
+++ b/tests/cli/test_agent_uninstall_memory.py
@@ -1,0 +1,358 @@
+"""Tests for ``_uninstall_hermes_memory`` outcome reporting (#350).
+
+Pre-fix the helper swallowed every failure mode behind a bare ``return``;
+the CLI exited 0 with no signal even when the Cognee ``agents`` dataset
+still held identity-card rows after the delete returned OK (observed
+2026-05-26 on LXC 105: 9 hermes-agent rows survived).
+
+These tests pin the structured-outcome contract:
+
+* ``deleted`` — pre-search hit, delete OK, post-verify empty → silent.
+* ``not_found`` — pre-search empty → silent (true no-op, no delete issued).
+* ``unreachable`` — search OR delete raised a URLError → yellow stderr
+  warning naming the URL, exit 0.
+* ``leftover`` — delete OK but post-verify still has rows → yellow
+  stderr warning naming the dataset + count, exit 0.
+
+The HTTP layer is stubbed by monkey-patching ``urllib.request.urlopen``
+inside the module — same pattern used elsewhere in the agent_commands
+test suite (test_agent_approvals_list.py stubs ``api_get``).
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from collections.abc import Callable, Iterator
+from io import BytesIO
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import agent_commands
+
+runner = CliRunner()
+
+
+# ── HTTP stub plumbing ───────────────────────────────────────────────────────
+
+
+class _FakeResponse:
+    """Minimal stand-in for the object urlopen's context manager yields."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._buf = BytesIO(json.dumps(payload).encode("utf-8"))
+
+    def read(self) -> bytes:
+        return self._buf.read()
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+
+@pytest.fixture
+def fake_urlopen(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
+    """Stub ``urllib.request.urlopen`` inside ``_uninstall_hermes_memory``.
+
+    The helper does ``import urllib.request`` inline (kept that way so
+    CLI startup stays snappy), so we patch the module-level
+    ``urllib.request.urlopen`` and the inline import resolves to the
+    same module object. Returns a setter the test calls to install a
+    sequence of responses, one per request the function issues.
+    """
+    import urllib.request as _urllib
+
+    def _install(responses: list[Any]) -> None:
+        """Each entry is either a dict (JSON body) or an Exception to raise."""
+        iter_responses: Iterator[Any] = iter(responses)
+
+        def _fake_urlopen(req: Any, timeout: float = 5.0) -> _FakeResponse:
+            try:
+                next_value = next(iter_responses)
+            except StopIteration as exc:  # pragma: no cover — test bug
+                raise AssertionError("urlopen called more times than stubbed") from exc
+            if isinstance(next_value, Exception):
+                raise next_value
+            return _FakeResponse(next_value)
+
+        monkeypatch.setattr(_urllib, "urlopen", _fake_urlopen)
+
+    return _install
+
+
+@pytest.fixture
+def stub_api_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the API base so url assertions are deterministic."""
+    monkeypatch.setenv("HAL0_API_URL", "http://127.0.0.1:8080")
+
+
+# ── Outcome dataclass: each branch of the state machine ──────────────────────
+
+
+def test_outcome_not_found_when_search_returns_zero_rows(
+    fake_urlopen: Callable[..., None], stub_api_base: None
+) -> None:
+    """Search returns 0 → no delete issued → outcome=not_found, silent."""
+    fake_urlopen([{"items": []}])
+
+    outcome = agent_commands._uninstall_hermes_memory()
+
+    assert outcome.outcome == "not_found"
+    assert outcome.deleted_count == 0
+    assert outcome.leftover_count == 0
+    assert outcome.url == "http://127.0.0.1:8080"
+
+
+def test_outcome_deleted_when_delete_succeeds_and_verify_empty(
+    fake_urlopen: Callable[..., None], stub_api_base: None
+) -> None:
+    """Pre-search has rows → delete OK → verify-search empty → outcome=deleted."""
+    fake_urlopen(
+        [
+            # Pre-delete search — three matching rows.
+            {
+                "items": [
+                    {"id": "id-1", "metadata": {"agent_id": "hermes-agent"}},
+                    {"id": "id-2", "metadata": {"agent_id": "hermes-agent"}},
+                    {"id": "id-3", "metadata": {"agent_id": "hermes-agent"}},
+                ]
+            },
+            # Delete response — body is ignored by the helper.
+            {"deleted": 3},
+            # Post-delete verify — empty, dataset is clean.
+            {"items": []},
+        ]
+    )
+
+    outcome = agent_commands._uninstall_hermes_memory()
+
+    assert outcome.outcome == "deleted"
+    assert outcome.deleted_count == 3
+    assert outcome.leftover_count == 0
+
+
+def test_outcome_leftover_when_verify_still_finds_rows(
+    fake_urlopen: Callable[..., None], stub_api_base: None
+) -> None:
+    """The 2026-05-26 incident: delete returns OK but rows survive."""
+    fake_urlopen(
+        [
+            # Pre-delete search — two matching rows.
+            {
+                "items": [
+                    {"id": "id-a", "metadata": {"agent_id": "hermes-agent"}},
+                    {"id": "id-b", "metadata": {"agent_id": "hermes-agent"}},
+                ]
+            },
+            # Delete reports success.
+            {"deleted": 2},
+            # But verify still sees rows.
+            {
+                "items": [
+                    {"id": "id-a", "metadata": {"agent_id": "hermes-agent"}},
+                    {"id": "id-b", "metadata": {"agent_id": "hermes-agent"}},
+                    {"id": "id-c", "metadata": {"agent_id": "hermes-agent"}},
+                ]
+            },
+        ]
+    )
+
+    outcome = agent_commands._uninstall_hermes_memory()
+
+    assert outcome.outcome == "leftover"
+    assert outcome.deleted_count == 2
+    assert outcome.leftover_count == 3
+
+
+def test_outcome_unreachable_when_search_raises(
+    fake_urlopen: Callable[..., None], stub_api_base: None
+) -> None:
+    """Search raises URLError → outcome=unreachable, leftover_count=None."""
+    fake_urlopen([urllib.error.URLError("connection refused")])
+
+    outcome = agent_commands._uninstall_hermes_memory()
+
+    assert outcome.outcome == "unreachable"
+    assert outcome.deleted_count == 0
+    assert outcome.leftover_count is None
+
+
+def test_outcome_unreachable_when_delete_raises(
+    fake_urlopen: Callable[..., None], stub_api_base: None
+) -> None:
+    """Search OK but delete raises → outcome=unreachable, deleted_count records intent."""
+    fake_urlopen(
+        [
+            {"items": [{"id": "id-x", "metadata": {"agent_id": "hermes-agent"}}]},
+            urllib.error.URLError("daemon died mid-call"),
+        ]
+    )
+
+    outcome = agent_commands._uninstall_hermes_memory()
+
+    assert outcome.outcome == "unreachable"
+    assert outcome.deleted_count == 1
+    assert outcome.leftover_count is None
+
+
+def test_outcome_deleted_when_verify_call_itself_unreachable(
+    fake_urlopen: Callable[..., None], stub_api_base: None
+) -> None:
+    """Delete OK but verify can't run → best-effort: report deleted, leftover=None.
+
+    Per #350 acceptance criteria: don't escalate to ``leftover`` when we
+    have no evidence rows survived. Operators get a silent pass here —
+    the unreachable warning surface is reserved for cases where the
+    teardown attempt itself failed.
+    """
+    fake_urlopen(
+        [
+            {"items": [{"id": "id-y", "metadata": {"agent_id": "hermes-agent"}}]},
+            {"deleted": 1},
+            urllib.error.URLError("verify call dropped"),
+        ]
+    )
+
+    outcome = agent_commands._uninstall_hermes_memory()
+
+    assert outcome.outcome == "deleted"
+    assert outcome.deleted_count == 1
+    assert outcome.leftover_count is None
+
+
+# ── CLI integration: exit code stays 0; stderr text matches outcome ──────────
+
+
+@pytest.fixture
+def stub_uninstall_api(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
+    """Stub the lifecycle API layer so the CLI runs offline."""
+
+    def _install(*, status: str = "uninstalled") -> None:
+        monkeypatch.setattr(agent_commands, "_api_unreachable", lambda _u: False)
+
+        def fake_delete(path: str, **_kw: Any) -> dict[str, Any]:
+            assert path == "/api/agents/hermes"
+            return {"status": status}
+
+        monkeypatch.setattr(agent_commands, "api_delete", fake_delete)
+
+    return _install
+
+
+def _stub_memory_outcome(
+    monkeypatch: pytest.MonkeyPatch, outcome: agent_commands.MemoryUninstallOutcome
+) -> None:
+    monkeypatch.setattr(agent_commands, "_uninstall_hermes_memory", lambda: outcome)
+
+
+def test_cli_silent_on_deleted_outcome(
+    stub_uninstall_api: Callable[..., None], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stub_uninstall_api()
+    _stub_memory_outcome(
+        monkeypatch,
+        agent_commands.MemoryUninstallOutcome(
+            outcome="deleted",
+            deleted_count=3,
+            leftover_count=0,
+            url="http://127.0.0.1:8080",
+        ),
+    )
+    result = runner.invoke(agent_commands.app, ["uninstall", "hermes"])
+    assert result.exit_code == 0, result.output
+    # No warning markup on stderr.
+    assert "warning" not in (result.stderr or "")
+    # Happy-path success line on stdout.
+    assert "Uninstalled" in result.output
+
+
+def test_cli_silent_on_not_found_outcome(
+    stub_uninstall_api: Callable[..., None], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stub_uninstall_api(status="not_installed")
+    _stub_memory_outcome(
+        monkeypatch,
+        agent_commands.MemoryUninstallOutcome(
+            outcome="not_found",
+            deleted_count=0,
+            leftover_count=0,
+            url="http://127.0.0.1:8080",
+        ),
+    )
+    result = runner.invoke(agent_commands.app, ["uninstall", "hermes"])
+    assert result.exit_code == 0, result.output
+    assert "warning" not in (result.stderr or "")
+
+
+def test_cli_warns_on_unreachable_outcome(
+    stub_uninstall_api: Callable[..., None], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stub_uninstall_api()
+    _stub_memory_outcome(
+        monkeypatch,
+        agent_commands.MemoryUninstallOutcome(
+            outcome="unreachable",
+            deleted_count=0,
+            leftover_count=None,
+            url="http://127.0.0.1:8080",
+        ),
+    )
+    # Pin a wide console so Rich doesn't truncate the URL we assert on.
+    monkeypatch.setenv("COLUMNS", "200")
+
+    result = runner.invoke(agent_commands.app, ["uninstall", "hermes"])
+
+    assert result.exit_code == 0, result.output
+    assert "warning" in result.stderr
+    assert "unreachable" in result.stderr
+    assert "127.0.0.1:8080" in result.stderr
+
+
+def test_cli_warns_on_leftover_outcome(
+    stub_uninstall_api: Callable[..., None], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stub_uninstall_api()
+    _stub_memory_outcome(
+        monkeypatch,
+        agent_commands.MemoryUninstallOutcome(
+            outcome="leftover",
+            deleted_count=2,
+            leftover_count=9,
+            url="http://127.0.0.1:8080",
+        ),
+    )
+    monkeypatch.setenv("COLUMNS", "200")
+
+    result = runner.invoke(agent_commands.app, ["uninstall", "hermes"])
+
+    assert result.exit_code == 0, result.output
+    assert "warning" in result.stderr
+    assert "incomplete" in result.stderr
+    # The leftover count surfaces so operators know the scale of the gap.
+    assert "9" in result.stderr
+    # Dataset name is part of the message so they know where to look.
+    assert "agents" in result.stderr
+
+
+def test_cli_keep_memory_skips_outcome_path(
+    stub_uninstall_api: Callable[..., None], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--keep-memory must not invoke ``_uninstall_hermes_memory`` at all."""
+    stub_uninstall_api()
+    called: dict[str, int] = {"n": 0}
+
+    def _should_not_run() -> agent_commands.MemoryUninstallOutcome:
+        called["n"] += 1
+        raise AssertionError("memory teardown ran with --keep-memory")
+
+    monkeypatch.setattr(agent_commands, "_uninstall_hermes_memory", _should_not_run)
+
+    result = runner.invoke(agent_commands.app, ["uninstall", "hermes", "--keep-memory"])
+    assert result.exit_code == 0, result.output
+    assert called["n"] == 0
+    # Stdout still surfaces the preservation hint.
+    assert "memory preserved" in result.output

--- a/tests/harness/agents-test.sh
+++ b/tests/harness/agents-test.sh
@@ -36,11 +36,25 @@
 #       context_link phase records HERMES.md + AGENTS.md under
 #       $HAL0_HOME/etc/hal0/ → assert both files are gone.
 #
-# Driver mocking: scenarios #346 patch the manager's _driver_for() to
-# return a stub so we don't need the Hermes upstream installed on the
-# harness host. The #348 + #349 scenarios DO NOT stub — they instantiate
-# HermesDriver directly because the cleanup paths under test live in
-# that driver, not the manager.
+#   agents-memory-teardown-clean (#350)
+#       Spins up an in-process HTTP stub that mimics
+#       /api/memory/{search,delete} + the lifecycle DELETE; primes the
+#       search to return one hermes-agent row and the delete to wipe
+#       it; runs the CLI's _uninstall_hermes_memory + verifies the
+#       structured outcome reports ``deleted`` with no stderr warning.
+#
+#   agents-memory-teardown-unreachable (#350)
+#       Points HAL0_API_URL at a closed port → CLI's
+#       _uninstall_hermes_memory returns ``unreachable`` and the
+#       wrapper writes a yellow warning to stderr while the typer
+#       command still exits 0 (idempotent CLI contract).
+#
+# Driver mocking: the #346 scenarios patch the manager's _driver_for()
+# to return a stub so we don't need the Hermes upstream installed on
+# the harness host. The #348 + #349 scenarios DO NOT stub — they
+# instantiate HermesDriver directly because the cleanup paths under
+# test live in that driver, not the manager. The #350 scenarios stub
+# the memory HTTP API in-process and exercise the real CLI helpers.
 #
 # Exit: 0 if both rows pass, non-zero (count of fails) otherwise.
 
@@ -83,6 +97,10 @@ if ! "${PY_BIN}" -c 'import hal0.agents.manager' >/dev/null 2>&1; then
         "hal0 package not importable from ${PY_BIN}; unit tests in tests/agents/test_manager.py cover the same contract"
     add_row "agents-roundtrip-no-orphans" "deferred" "0" \
         "hal0 package not importable from ${PY_BIN}; unit tests cover the same contract"
+    add_row "agents-memory-teardown-clean" "deferred" "0" \
+        "hal0 package not importable from ${PY_BIN}; unit tests in tests/cli/test_agent_uninstall_memory.py cover the same contract"
+    add_row "agents-memory-teardown-unreachable" "deferred" "0" \
+        "hal0 package not importable from ${PY_BIN}; unit tests cover the same contract"
     harness_write_report || true
     exit 0
 fi
@@ -94,7 +112,7 @@ log_step "Agent uninstall regression rows (#346) — python=${PY_BIN}"
 # failure (the row's detail captures the diagnostic).
 DRIVER="${SCRIPT_DIR}/reports/agents-driver.py"
 cat >"${DRIVER}" <<'PY'
-"""δ-harness driver for #346 + #348 + #349. See tests/harness/agents-test.sh."""
+"""δ-harness driver for #346 + #348 + #349 + #350. See tests/harness/agents-test.sh."""
 
 from __future__ import annotations
 
@@ -323,6 +341,165 @@ def scenario_hermes_context_link_teardown(prefix: Path) -> None:
         )
 
 
+def _start_stub_memory_server(state: dict) -> tuple[object, str]:
+    """Spin up an in-process HTTP server stubbing /api/memory/{search,delete}.
+
+    Returns (server, base_url). ``state`` is a mutable dict whose
+    ``items`` list models the dataset. The handler also serves a HEAD
+    on /api/status so _api_unreachable() doesn't bail before the CLI
+    even hits memory.
+    """
+    import json as _json
+    import threading
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    class _Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args):  # noqa: D401 — silence noisy log
+            return
+
+        def do_HEAD(self):  # noqa: N802 — http.server contract
+            if self.path == "/api/status":
+                self.send_response(200)
+                self.end_headers()
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def do_POST(self):  # noqa: N802 — http.server contract
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length) if length else b"{}"
+            try:
+                payload = _json.loads(body.decode("utf-8") or "{}")
+            except _json.JSONDecodeError:
+                payload = {}
+            if self.path == "/api/memory/search":
+                rsp = {"items": list(state["items"])}
+                self._json(200, rsp)
+            elif self.path == "/api/memory/delete":
+                ids = set(payload.get("ids") or [])
+                before = len(state["items"])
+                state["items"] = [
+                    it for it in state["items"] if it.get("id") not in ids
+                ]
+                self._json(200, {"deleted": before - len(state["items"])})
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def do_DELETE(self):  # noqa: N802 — lifecycle DELETE
+            if self.path.startswith("/api/agents/"):
+                self._json(200, {"status": "uninstalled"})
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def _json(self, status: int, body: dict) -> None:
+            data = _json.dumps(body).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[0], server.server_address[1]
+    return server, f"http://{host}:{port}"
+
+
+def scenario_memory_teardown_clean(prefix: Path) -> None:
+    """Stub the memory API with one hermes row → CLI should report deleted, silent."""
+    import os as _os
+
+    state = {
+        "items": [
+            {
+                "id": "card-001",
+                "metadata": {"agent_id": "hermes-agent"},
+            }
+        ]
+    }
+    server, base = _start_stub_memory_server(state)
+    try:
+        _os.environ["HAL0_API_URL"] = base
+        # Late import so the env var is picked up by _api_base().
+        from hal0.cli import agent_commands
+
+        outcome = agent_commands._uninstall_hermes_memory()
+        if outcome.outcome != "deleted":
+            raise AssertionError(
+                f"expected outcome=deleted, got {outcome.outcome!r} "
+                f"(deleted={outcome.deleted_count}, leftover={outcome.leftover_count})"
+            )
+        if state["items"]:
+            raise AssertionError(
+                f"stub dataset still has {len(state['items'])} row(s) "
+                f"matching agent_id=hermes-agent after teardown"
+            )
+        # The wrapper must NOT print a warning for the deleted outcome.
+        import io
+        from contextlib import redirect_stderr
+
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            agent_commands._warn_memory_outcome(outcome)
+        stderr_text = buf.getvalue()
+        if "warning" in stderr_text.lower():
+            raise AssertionError(
+                f"deleted outcome produced an unexpected warning: {stderr_text!r}"
+            )
+    finally:
+        server.shutdown()
+        _os.environ.pop("HAL0_API_URL", None)
+
+
+def scenario_memory_teardown_unreachable(prefix: Path) -> None:
+    """Point at a closed port → outcome=unreachable, warning hits stderr, exit-0 semantics intact."""
+    import os as _os
+    import socket as _socket
+
+    # Pick an ephemeral free port, then close it so the next connect attempt
+    # is guaranteed to fail (refused) without races against other harness rows.
+    sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    closed_port = sock.getsockname()[1]
+    sock.close()
+
+    _os.environ["HAL0_API_URL"] = f"http://127.0.0.1:{closed_port}"
+    try:
+        from hal0.cli import agent_commands
+
+        outcome = agent_commands._uninstall_hermes_memory()
+        if outcome.outcome != "unreachable":
+            raise AssertionError(
+                f"expected outcome=unreachable, got {outcome.outcome!r}"
+            )
+        if outcome.leftover_count is not None:
+            raise AssertionError(
+                f"unreachable outcome must report leftover_count=None, got {outcome.leftover_count!r}"
+            )
+
+        # The wrapper must emit a yellow warning naming the URL.
+        import io
+        from contextlib import redirect_stderr
+
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            agent_commands._warn_memory_outcome(outcome)
+        stderr_text = buf.getvalue()
+        if "warning" not in stderr_text.lower():
+            raise AssertionError(
+                f"unreachable outcome failed to surface a warning to stderr: {stderr_text!r}"
+            )
+        if f"127.0.0.1:{closed_port}" not in stderr_text:
+            raise AssertionError(
+                f"warning text missing target URL ({closed_port}): {stderr_text!r}"
+            )
+    finally:
+        _os.environ.pop("HAL0_API_URL", None)
+
+
 def main(argv: list[str]) -> int:
     scenario_name = argv[1]
     prefix = Path(argv[2])
@@ -339,6 +516,10 @@ def main(argv: list[str]) -> int:
             scenario_hermes_venv_teardown(prefix)
         elif scenario_name == "hermes-context-link-teardown":
             scenario_hermes_context_link_teardown(prefix)
+        elif scenario_name == "memory-teardown-clean":
+            scenario_memory_teardown_clean(prefix)
+        elif scenario_name == "memory-teardown-unreachable":
+            scenario_memory_teardown_unreachable(prefix)
         else:
             print(f"unknown scenario: {scenario_name}", file=sys.stderr)
             return 2
@@ -371,10 +552,12 @@ run_scenario() {
     fi
 }
 
-run_scenario "agents-install-corrupt-uninstall"   "install-corrupt-uninstall"
-run_scenario "agents-roundtrip-no-orphans"        "roundtrip-no-orphans"
-run_scenario "agents-hermes-venv-teardown"        "hermes-venv-teardown"
+run_scenario "agents-install-corrupt-uninstall"    "install-corrupt-uninstall"
+run_scenario "agents-roundtrip-no-orphans"         "roundtrip-no-orphans"
+run_scenario "agents-hermes-venv-teardown"         "hermes-venv-teardown"
 run_scenario "agents-hermes-context-link-teardown" "hermes-context-link-teardown"
+run_scenario "agents-memory-teardown-clean"        "memory-teardown-clean"
+run_scenario "agents-memory-teardown-unreachable"  "memory-teardown-unreachable"
 
 log_step "Write report"
 harness_write_report || true


### PR DESCRIPTION
## Summary

- `_uninstall_hermes_memory()` swallowed every failure mode behind a bare `return`; on LXC 105 (2026-05-26) the Cognee `agents` dataset still had 9 hermes-agent identity-card rows after a default uninstall — operator got no signal.
- Replace the bare swallow with a structured `MemoryUninstallOutcome` (`deleted` / `not_found` / `unreachable` / `leftover`) plus a post-delete verify search.
- `unreachable` and `leftover` now surface as yellow stderr warnings; `deleted` / `not_found` stay silent. CLI exit code stays 0 in all four cases (idempotent contract preserved per docstring).

Closes #350. Sits on top of #352 (`uninstall-wave2-base` == `origin/main` @ 21fd50d). PR #354 is touching `agents/hermes.py` in parallel — no expected conflict (this PR only touches `cli/agent_commands.py`).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `pytest tests/` — 1791 passed, 3 skipped (pre-existing)
- [x] 11 new unit tests in `tests/cli/test_agent_uninstall_memory.py` cover all four outcome branches + CLI integration (`deleted`, `not_found`, `unreachable`, `leftover`, `--keep-memory` short-circuit, verify-call-raises edge case)
- [x] δ-harness: two new rows in `tests/harness/agents-test.sh` (`agents-memory-teardown-clean`, `agents-memory-teardown-unreachable`) — both green locally via in-process HTTP stub
- [ ] CI green
- [ ] LXC 105 smoke: install hermes → write identity card → default uninstall → assert dataset shows 0 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)