### PR TITLE
feat(dash): mirror snapshot/memmap/throughput sidebar onto /slots

### DIFF
--- a/ui/src/dash/dashboard.jsx
+++ b/ui/src/dash/dashboard.jsx
@@ -18,31 +18,45 @@ import { useHardware } from '@/api/hooks/useHardware'
 const { useState: useStateD, useRef: useRefD, useEffect: useEffectD } = React;
 
 // ─── Snapshot strip ───
+// `slotIndicator` is the single source of truth for the dot vocabulary
+// (defined in slots.jsx, published on window). Mirroring it here keeps
+// the snapshot row's dot colour + status label aligned with each
+// SlotCard — so a slot that reads "idle · yellow" on the slots page
+// reads the same way in the sidebar.
 function SnapshotStrip({ slots, onGo }) {
+  const rows = slots.map(s => ({ slot: s, ind: slotIndicator(s) }));
+  const readyCount = rows.filter(r => r.ind.cls === "serving" || r.ind.cls === "stale").length;
   return (
     <div className="snap">
       <div className="snap-head">
         <span>Slot snapshot</span>
-        <span className="ct mono">{slots.filter(s => s.state === "ready" || s.state === "serving" || s.state === "idle").length}/{slots.length} ready</span>
+        <span className="ct mono">{readyCount}/{slots.length} ready</span>
         <span className="right mono" onClick={() => onGo("slots")}>Manage slots →</span>
       </div>
       <div className="snap-rows">
-        {slots.map(s => (
-          <div key={s.name} className="snap-row" onClick={() => onGo("slots/" + s.name)}>
-            <span className={"dot " + s.state} />
-            <span className="name mono">{s.name}</span>
-            <span className="model mono">{s.model}</span>
-            <span className={"chip dev-" + (s.device || "cpu").replace("gpu-", "")}>{s.device}</span>
-            <span className="badge">
-              {s.isDefault && <span className="chip outlined amber">default</span>}
-              {s.coresident && <span className="chip" style={{color: "var(--dev-npu)", borderColor: "rgba(200,150,255,0.30)", background: "rgba(200,150,255,0.06)"}}>coresident</span>}
-              {s.cpuOnly && <span className="chip">[CPU]</span>}
-            </span>
-            <span className="num mono" style={{color: "var(--fg-3)", fontSize: 11, textAlign: "right"}}>
-              {s.state === "serving" ? `${s.metrics.toks} tok/s` : s.state}
-            </span>
-          </div>
-        ))}
+        {rows.map(({ slot: s, ind }) => {
+          const labelColor = ind.cls === "serving" ? "var(--accent)"
+            : ind.cls === "stale" || ind.cls === "warming" ? "var(--warn)"
+            : ind.cls === "error" ? "var(--err)"
+            : "var(--fg-3)";
+          const serving = ind.cls === "serving" && s.metrics?.toks != null;
+          return (
+            <div key={s.name} className="snap-row" onClick={() => onGo("slots/" + s.name)} title={ind.tooltip}>
+              <span className={"dot " + ind.cls} />
+              <span className="name mono">{s.name}</span>
+              <span className="model mono">{s.model}</span>
+              <span className={"chip dev-" + (s.device || "cpu").replace("gpu-", "")}>{s.device}</span>
+              <span className="badge">
+                {s.isDefault && <span className="chip outlined amber">default</span>}
+                {s.coresident && <span className="chip" style={{color: "var(--dev-npu)", borderColor: "rgba(200,150,255,0.30)", background: "rgba(200,150,255,0.06)"}}>coresident</span>}
+                {s.cpuOnly && <span className="chip">[CPU]</span>}
+              </span>
+              <span className="num mono" style={{color: labelColor, fontSize: 11, textAlign: "right"}}>
+                {serving ? `${s.metrics.toks} tok/s` : ind.label}
+              </span>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -137,6 +137,7 @@ function App() {
             slotVariant={tweaks.slotVariant}
             npuVariant={tweaks.npuVariant}
             slotParam={param}
+            onGo={go}
           />
         );
       case "models":   return <ModelsView />;

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -534,7 +534,7 @@ function NpuReactor({ slots }) {
 }
 
 // ─── Slots view ───
-function SlotsView({ slotVariant, npuVariant, slotParam }) {
+function SlotsView({ slotVariant, npuVariant, slotParam, onGo }) {
   const slotsQuery = useSlots();
   // Single source of truth: the hook. The Playwright apiMock fixture
   // fulfils /api/slots so mock-mode coverage is symmetric with live runs;
@@ -657,6 +657,11 @@ function SlotsView({ slotVariant, npuVariant, slotParam }) {
     />
   );
 
+  // `onGo` may be omitted (some legacy call sites); fall through to hash
+  // routing so the snapshot row clicks still navigate. Keeps the sidebar
+  // working in tests/storybook-y harnesses that mount SlotsView directly.
+  const goTo = onGo || ((r) => { window.location.hash = "#" + r; });
+
   // Skip-path layout: render six seeded empty cards under their default groups.
   if (skipPath) {
     const seededByGroup = {
@@ -676,30 +681,39 @@ function SlotsView({ slotVariant, npuVariant, slotParam }) {
           <button className="btn" onClick={() => setCreateOpen(true)}>{Icons.plus} New slot</button>
         </div>
 
-        {["chat", "embed", "voice", "img"].map(g => {
-          const cards = seededByGroup[g];
-          if (!cards.length) return null;
-          return (
-            <section key={g} style={{marginBottom: 24}}>
-              <div className="sec">
-                <h2>{g[0].toUpperCase() + g.slice(1)}<span className="ct mono">{cards.length}</span></h2>
-                <div className="rule" />
-              </div>
-              <div className="slots-grid">
-                {cards.map(c => (
-                  <EmptySlotCard
-                    key={c.name}
-                    name={c.name}
-                    type={c.type}
-                    device={c.device}
-                    group={c.group}
-                    onConfigure={() => openCreatePrefilled({ name: c.name, type: c.type, device: c.device, group: c.group })}
-                  />
-                ))}
-              </div>
-            </section>
-          );
-        })}
+        <div className="dash">
+          <div className="dash-main">
+            {["chat", "embed", "voice", "img"].map(g => {
+              const cards = seededByGroup[g];
+              if (!cards.length) return null;
+              return (
+                <section key={g} style={{marginBottom: 24}}>
+                  <div className="sec">
+                    <h2>{g[0].toUpperCase() + g.slice(1)}<span className="ct mono">{cards.length}</span></h2>
+                    <div className="rule" />
+                  </div>
+                  <div className="slots-grid">
+                    {cards.map(c => (
+                      <EmptySlotCard
+                        key={c.name}
+                        name={c.name}
+                        type={c.type}
+                        device={c.device}
+                        group={c.group}
+                        onConfigure={() => openCreatePrefilled({ name: c.name, type: c.type, device: c.device, group: c.group })}
+                      />
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+          <div className="dash-side">
+            <SnapshotStrip slots={slots} onGo={goTo} />
+            <MemoryMap slots={slots} />
+            <ThroughputCard />
+          </div>
+        </div>
 
         <CreateSlotModal
           open={createOpen}
@@ -769,20 +783,29 @@ function SlotsView({ slotVariant, npuVariant, slotParam }) {
         <button className="btn" onClick={() => setCreateOpen(true)}>{Icons.plus} New slot</button>
       </div>
 
-      {renderGroup("Chat",  groups.chat)}
-      {renderGroup("Embed", groups.embed)}
-      {renderGroup("Voice", groups.voice)}
-      {renderGroup("Image", groups.img)}
+      <div className="dash">
+        <div className="dash-main">
+          {renderGroup("Chat",  groups.chat)}
+          {renderGroup("Embed", groups.embed)}
+          {renderGroup("Voice", groups.voice)}
+          {renderGroup("Image", groups.img)}
 
-      {groups.npu.length > 0 && (
-        <section style={{marginBottom: 24}}>
-          <div className="sec">
-            <h2>NPU<span className="ct mono">trio · 1 process · 3 roles</span></h2>
-            <div className="rule" />
-          </div>
-          {npuVariant === "reactor" ? <NpuReactor slots={slots} /> : <NpuBlock slots={slots} />}
-        </section>
-      )}
+          {groups.npu.length > 0 && (
+            <section style={{marginBottom: 24}}>
+              <div className="sec">
+                <h2>NPU<span className="ct mono">trio · 1 process · 3 roles</span></h2>
+                <div className="rule" />
+              </div>
+              {npuVariant === "reactor" ? <NpuReactor slots={slots} /> : <NpuBlock slots={slots} />}
+            </section>
+          )}
+        </div>
+        <div className="dash-side">
+          <SnapshotStrip slots={slots} onGo={goTo} />
+          <MemoryMap slots={slots} />
+          <ThroughputCard />
+        </div>
+      </div>
 
       <CreateSlotModal
         open={createOpen}


### PR DESCRIPTION
## Summary

- Wraps `SlotsView` in the same `dash > dash-main + dash-side` grid as `DashboardView` so `/slots` carries the right-column sidebar over — slot snapshot, memory map, throughput. Skip-path render gets the same treatment so the sidebar shows even before a slot is configured.
- Fixes `SnapshotStrip` to drive off `slotIndicator(slot)` instead of raw `slot.state`. The strip was rendering `dot ready`/`dot offline`/etc., which fell through the pre-2026-05-27 green-pulse vocabulary and ignored the dot-state spec (loaded-but-idle is yellow; only an in-flight request is green pulse). Now mirrors SlotCard: green pulse during serving, yellow for ready/idle/stale, amber-pulse for warming, red for error, grey for off. Status label tinted to match; tooltip shows the indicator's contextual message ("Loaded — last used 23 min ago" etc.). Ready count counts `cls in {serving, stale}` so Lemonade-evicted slots register as ready (they hot-reload on next request).
- `main.jsx` threads `onGo` into `SlotsView` so snapshot rows navigate; `SlotsView` falls back to hash routing if `onGo` is missing.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (one CSS chunk, one JS chunk, same gzip footprint)
- [x] `npx playwright test specs/slots-v3.spec.ts specs/slot-indicator.spec.ts specs/dashboard-v3.spec.ts` — 21/21 pass
- [ ] Live smoke on hal0 LXC: visit `/#dashboard` then `/#slots` — confirm sidebar is identical, status labels read `serving`/`ready`/`idle`/`warming`/`error`/`off`, dot colours match the slot cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)