### PR TITLE
chore(dash): chat-overhaul follow-up polish

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -187,9 +187,12 @@ See §15 Phase 9 below for the per-PR map.
     (Traefik / nginx / Cloudflare Tunnel / etc.).
   - `hal0.local` reachable on the LAN (mDNS via avahi); HTTPS via
     Caddy's internal CA or Let's Encrypt when a public hostname is set.
-- **Dashboard UI** (Vue 3 + Pinia + Tailwind 4)
-  - 9 views: Dashboard, Slots, Models, Hardware, Logs, Settings,
-    Providers, FirstRun, plus a not-found / error shell
+- **Dashboard UI** (React 18 + Vite + TanStack Query)
+  - Views: Dashboard (system overview + hardware spread), Chat,
+    Slots, Models, Backends, Logs, Agent, MCP, Settings, FirstRun
+  - The standalone `#hardware` page retired in 0.3 — its content
+    now lives on `#dashboard` alongside the slot snapshot, memory
+    map, throughput card, and health card
   - Dark mode only; mobile-responsive on read-only paths
   - SSE for slot status + log tail
   - Hardware-aware slot config form (VRAM fit warnings inline)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Server as the unified inference runtime** behind a thin hal0 capability
 layer. Every workload — chat, embed, rerank, STT, TTS, image gen —
 runs as a real, named slot in `capabilities.toml`; the API surface
 covers the full OpenAI-compatible matrix; the dashboard is for
-operating the box, not chatting with it.
+operating the box, with a built-in chat page for smoke-tests.
 
 ```sh
 curl -fsSL https://hal0.dev/install.sh | bash
@@ -123,11 +123,12 @@ be evicted out from under a streaming request.
 - **Dispatcher** — registry-aware routing, cold-cache prefetch,
   upstream fallback (OpenRouter, Anthropic, OpenAI, custom OpenAI-shaped
   endpoints). Mix local + remote per-model in one config.
-- **Dashboard** — Vue 3 + Tailwind 4 UI for slot/model management,
-  hardware-aware configuration, live logs, and system health. SSE-backed
-  status + log tail. Lemonade `/logs/stream` folded into the Journal
-  panel. Settings → Lemonade admin panel surfaces the daemon's
-  `/internal/config` for inspection. Dark by default.
+- **Dashboard** — React 18 + Vite UI for slot/model management,
+  hardware-aware configuration, live logs, system health, and a
+  built-in chat page (with popout window + reasoning toggle).
+  SSE-backed status + log tail. Lemonade `/logs/stream` folded into
+  the Journal panel. Settings → Lemonade admin panel surfaces the
+  daemon's `/internal/config` for inspection. Dark by default.
 - **OpenWebUI prewired** — chat at `:3001`, zero config. The installer
   writes `openwebui.env` pointing at the local hal0 API.
 - **OmniRouter (8 tools)** — `generate_image`, `edit_image`,

--- a/ui/src/dash/chat.jsx
+++ b/ui/src/dash/chat.jsx
@@ -526,7 +526,9 @@ function MessageList({ messages, showReasoning }) {
                 <span className="bubble-caret" aria-hidden="true">▌</span>
               ) : m.reasoningOnly ? (
                 <span style={{ color: 'var(--fg-4)', fontStyle: 'italic' }}>
-                  (no final answer — see thinking above)
+                  {showReasoning
+                    ? '(no final answer — see thinking above)'
+                    : "(no final answer — enable reasoning to see the model's thinking)"}
                 </span>
               ) : (
                 ''

--- a/ui/src/dash/dashboard.jsx
+++ b/ui/src/dash/dashboard.jsx
@@ -271,12 +271,6 @@ function HardwareSection() {
           </div>
         </HwCard>
 
-        <HwCard title="Storage" eyebrow="model cache" full>
-          <HwRow k="model dir" v="/var/lib/hal0/models" mono />
-          <HwRow k="size" v="46.2 GB · 9 models" />
-          <HwRow k="free on /var" v="412 GB" />
-          <HwRow k="hf cache" v="/root/.cache/huggingface — 8.4 GB" mono />
-        </HwCard>
       </div>
     </div>
   );
@@ -312,15 +306,19 @@ function HwRow({ k, v, mono, sub }) {
 
 // ─── Dashboard view shell ───
 //
-// Chat-page-overhaul: chat surface moved to /chat. The dashboard is now
-// the system-overview page — hardware spread + slot snapshot + memory
-// map + throughput + health. The `chatState === "skip"` branch still
-// stands as the zero-slots empty fallback.
-function DashboardView({ chatState, slots: slotsProp, onGo, showHero, onDismissHero }) {
+// /dashboard is the system-overview page — hardware spread + slot snapshot
+// + memory map + throughput + health. When /api/slots returns an empty
+// list (fresh install, no bundle picked), we render a zero-slots empty
+// state pointing at FirstRun instead.
+function DashboardView({ slots: slotsProp, onGo, showHero, onDismissHero }) {
   const slotsQuery = useSlots();
   const slots = (slotsQuery.data && slotsQuery.data.length > 0) ? slotsQuery.data : slotsProp;
   const lemond = useLemondRollup();
-  if (chatState === "skip") {
+  // Real zero-slots detection: only when /api/slots has resolved to a
+  // confirmed empty array. Still-loading (undefined) keeps showing the
+  // normal dashboard against fixtures.
+  const noSlotsConfigured = Array.isArray(slotsQuery.data) && slotsQuery.data.length === 0;
+  if (noSlotsConfigured) {
     return (
       <div className="view">
         <div className="dash-empty">

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -42,7 +42,6 @@ function App() {
   const [tweaks, setTweak] = useTweaks(TWEAK_DEFAULTS);
   const { active: activeBanners } = useBanners();
   const [{ route, param, query }, setRouteState] = useStateA(parseRoute());
-  const [chatState, setChatState] = useStateA("active");
   const [persona, setPersona] = useStateA("primary");
   const [bellOpen, setBellOpen] = useStateA(false);
   const [frStage, setFrStage] = useStateA("pick");
@@ -116,8 +115,6 @@ function App() {
       case "dashboard":
         return (
           <DashboardView
-            chatState={chatState}
-            setChatState={setChatState}
             slots={HAL0_DATA.slots}
             onGo={go}
             showHero={tweaks.showHero && !heroDismissed}


### PR DESCRIPTION
## Summary

Five small follow-ups that should have ridden with #356:

- **docs**: `PLAN.md` + `README.md` updated to list the actual dashboard views (incl. Chat), note `#hardware` retirement, and correct stale "Vue 3 + Tailwind 4" framing to "React 18 + Vite". Mentions popout window + reasoning toggle.
- **`main.jsx`**: drop dead `chatState`/`setChatState` state + prop passthrough — chat moved to its own route in #356.
- **`dashboard.jsx`**:
  - Drop mocked Storage HwCard (`/var/lib/hal0/models` hardcoded — stale after #319's `[models].store` migration).
  - Replace zero-slots fallback trigger `chatState === "skip"` with a real `Array.isArray(slotsQuery.data) && slotsQuery.data.length === 0`. The old signal stopped existing in #356, so the empty-state branch was effectively dead.
- **`chat.jsx`**: context-aware copy for the "(no final answer)" placeholder — point users at the reasoning toggle when it's currently OFF.

## Test plan

- [x] `git diff` reviewed locally — no Python touched, no behaviour change outside the listed hunks.
- [ ] CI: python (3.11) / python (3.12) / γ-suite (chromium) / ui pass.
- [ ] γ-suite dashboard specs still green against the new empty-state branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)