### PR TITLE
fix(slots): backend update invalidates state.json extra.backend (#359)

### DIFF
--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1324,6 +1324,38 @@ class SlotManager:
                 f"failed to rewrite {cfg_path}: {exc}",
             ) from exc
 
+        # Issue #359: invalidate stale top-level metadata in state.json
+        # whenever the operator's update changes a field that's also
+        # carried in ``extra``. ``_transition()`` shallow-merges extras
+        # (intentional — provider/backend stamped at create-time survive
+        # start→warm→ready), so without an explicit fix here the persisted
+        # ``extra.backend`` survives a ``POST /api/slots/{name}/backend``
+        # forever. ``status()`` short-circuits to this stale value as long
+        # as the model is still in lemond's ``loaded[]`` (the adoption
+        # probe never re-runs once ``rec`` exists).
+        #
+        # Only touch keys the caller actually changed — leave the rest of
+        # ``extra`` (adopted flag, modelless_ready_blocked, etc.) alone.
+        rec = self._states.get(slot_name) or read_state(self._state_file(slot_name))
+        if rec is not None:
+            mirrored = {"backend", "provider"}
+            dirty = mirrored & updates.keys()
+            if dirty:
+                new_extra = dict(rec.extra)
+                for key in dirty:
+                    new_extra[key] = cfg_dict.get(key)
+                refreshed = SlotStateRecord(
+                    name=rec.name,
+                    state=rec.state,
+                    model_id=rec.model_id,
+                    port=rec.port,
+                    updated_at=time.time(),
+                    message=rec.message,
+                    extra=new_extra,
+                )
+                write_state_atomic(self._state_file(slot_name), refreshed)
+                self._states[slot_name] = refreshed
+
         return await self.status(slot_name)
 
     async def reconcile_unconfigured_slots(self) -> None:

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -490,6 +490,60 @@ async def test_update_config_rewrites_toml(slot_root: Path) -> None:
     assert "workers = 4" in cfg_text
 
 
+async def test_update_config_backend_invalidates_state_extras(
+    slot_root: Path,
+    tmp_hal0_home: str,
+    lemonade_loaded_stub: dict[str, Any],
+) -> None:
+    """Issue #359: changing ``backend`` via update_config() must clear
+    the stale ``extra.backend`` mirror in state.json.
+
+    Before the fix, ``status()`` short-circuited to the persisted record
+    while the model was in lemond's ``loaded[]`` and reported the old
+    backend forever. The adoption probe never re-ran because ``rec``
+    already existed.
+    """
+    from hal0.slots.state import SlotStateRecord, read_state, write_state_atomic
+
+    # Seed an adopted-style state.json: primary is READY with
+    # extra.backend=rocm (the boot-time adopted value).
+    state_path = Path(tmp_hal0_home) / "var-lib" / "hal0" / "slots" / "primary" / "state.json"
+    write_state_atomic(
+        state_path,
+        SlotStateRecord(
+            name="primary",
+            state=SlotState.READY,
+            model_id="qwen3-4b-q4_k_m",
+            port=8081,
+            extra={"backend": "rocm", "provider": "lemonade", "adopted": True},
+        ),
+    )
+
+    sm = SlotManager()
+    snap_before = await sm.status("primary")
+    assert snap_before.backend == "rocm"
+
+    snap_after = await sm.update_config("primary", {"backend": "vulkan"})
+    # The snapshot returned from update_config() must reflect the new
+    # backend (this is what the API handler returns to the client).
+    assert snap_after.backend == "vulkan"
+    assert snap_after.metadata.get("backend") == "vulkan"
+
+    # And a fresh status() call (after the in-memory cache) reads the
+    # same value — the persisted state.json was rewritten.
+    snap_via_status = await sm.status("primary")
+    assert snap_via_status.backend == "vulkan"
+
+    # state.json on disk reflects the new backend too.
+    rec = read_state(state_path)
+    assert rec is not None
+    assert rec.extra.get("backend") == "vulkan"
+    # Unrelated extras (adoption marker) are preserved — we only
+    # invalidate the keys the operator actually changed.
+    assert rec.extra.get("adopted") is True
+    assert rec.extra.get("provider") == "lemonade"
+
+
 # ── SSE state stream ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

`POST /api/slots/{name}/backend` rewrites the slot TOML but the persisted state.json's `extra.backend` mirror was never invalidated. `status()` short-circuits to the in-memory record while the model is still in lemond's `loaded[]`, so the dashboard kept reporting the boot-time backend forever even though the running llama-server child had already been respawned with the new binary path.

## Diagnosis

Picked **hypothesis (a)**: `update_config()` is the cleanest place to invalidate.

`_transition()`'s shallow-merge of extras is intentional — it keeps `provider` / `backend` stamped at create time alive through the start->warm->ready chain. Changing that to "fully replace" would regress every callsite that relies on inheritance (the load-path stamps neither `provider` nor `backend` on the `READY` transition). The drift is one-sided: only `update_config()` knows the operator deliberately changed a top-level field. Fixing it there is one mutation per known-mirrored key, surgical, and leaves the rest of the state machine untouched.

Evidence: with the fix reverted, the new regression test asserts `snap_after.backend == "vulkan"` and fails with `'rocm' == 'vulkan'`. With the fix, all three checks pass — return value, fresh `status()` re-read, and on-disk state.json — while `extra.adopted=True` and `extra.provider` survive untouched (only the keys the operator changed get mirrored).

## Changes

- `src/hal0/slots/manager.py` — `update_config()` mirrors `backend`/`provider` updates into the persisted state.json record (and `self._states`) after the TOML rewrite, before the closing `status()` call.
- `tests/slots/test_manager.py` — adds `test_update_config_backend_invalidates_state_extras` exercising the issue's exact repro: seed READY with `extra.backend=rocm`, call `update_config({"backend": "vulkan"})`, assert snapshot + disk + `_states` all flip while unrelated extras survive.

## Test plan

- [x] `ruff check src tests` — all checks passed
- [x] `ruff format --check src tests` — 299 files already formatted
- [x] `pytest tests/slots/` — 118 passed
- [x] Smoke: `pytest tests/api tests/capabilities tests/cli` — 508 passed, 3 pre-existing skips
- [x] New regression test fails on `main` (verified by stashing fix), passes with fix
- [ ] CI green (pending)

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>