### PR TITLE
fix(release): publish pre-v1.0 alpha tags as prerelease=false

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,11 +293,20 @@ jobs:
           # rebuild path) — otherwise just upload the assets, replacing
           # any prior copies with --clobber.
           if ! gh release view "${TAG}" >/dev/null 2>&1; then
+            # NOTE: every pre-v1.0 release is a SemVer prerelease by tag
+            # convention (vX.Y.Z-alpha.N / -beta.N / -rcN), but we
+            # publish them with --prerelease=false on purpose: GitHub's
+            # /releases/latest endpoint and "Latest" badge filter out
+            # prereleases, and the install + update path relies on a
+            # working /latest while we're still pre-stable. Flip back
+            # to a real prerelease check on the v1.0.0 cut. See the
+            # hal0_v0.1.0-alpha-launch + hal0_release_prerelease_flag
+            # memories.
             gh release create "${TAG}" \
               --title "hal0 ${TAG}" \
               --notes "Automated release. See docs/internal/release-manifest.md for the verify path." \
               --draft=false \
-              --prerelease="$([[ "${TAG}" == *-* ]] && echo true || echo false)"
+              --prerelease=false
           fi
 
           gh release upload "${TAG}" "${TARBALL}" "${SIG}" "${CRT}" "${MANIFEST}" --clobber


### PR DESCRIPTION
## Summary

Every pre-v0.3.1 release was published as `prerelease=false` so GitHub's `/releases/latest` endpoint resolves. v0.3.0-alpha.1 was manually flipped by hand post-publish; today's v0.3.1-alpha.1 went out flagged `prerelease=true` and \`/releases/latest\` froze on v0.3.0-alpha.1 until a manual `gh release edit` flip.

`release.yml:300` derived `--prerelease` from the presence of `-` in the tag string, which turned every SemVer alpha/beta/rc into a GitHub prerelease. Hard-coding `--prerelease=false` until v1.0.0 + adding an inline comment so the next operator doesn't "fix" the SemVer purity by re-introducing the heuristic.

## Test plan

- [ ] python (3.11) / python (3.12) / γ-suite / ui green (workflow file change shouldn't touch any of those, but the lint/yaml jobs catch syntax errors).
- After merge: the next `git tag vX.Y.Z-foo && git push origin vX.Y.Z-foo` should produce `prerelease=false` automatically — no manual `gh release edit` follow-up.

## Out of scope

- Re-introducing a `workflow_dispatch` input to allow a real prerelease — we have no use case until v1.0.0.
- Editing the `v0.3.1-alpha.1` release page (already flipped via `gh release edit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)