### PR TITLE
feat(memory): pin embedding model + wire rerank slot into memory_search

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -865,19 +865,30 @@ def create_app() -> FastAPI:
         # ADR-0014: pull [memory.graph] gate + route at boot so a
         # process restart preserves the user's pick. Defaults match
         # the v0.3 ship matrix (enabled=False, route="upstream").
+        # Issue #116: same goes for [memory.embedding].
         try:
             _hal0_cfg = load_hal0_config()
             _graph_cfg = _hal0_cfg.memory.graph
             _graph_enabled = bool(_graph_cfg.enabled)
             _graph_route = str(_graph_cfg.route)
+            _embed_cfg = _hal0_cfg.memory.embedding
+            _embed_model = str(_embed_cfg.model)
+            _rerank_enabled = bool(_embed_cfg.rerank_enabled)
+            _rerank_url = str(_embed_cfg.rerank_url)
         except Exception as exc:  # pragma: no cover — defensive
-            log.warning("hal0.memory.graph_cfg_load_failed", error=str(exc))
+            log.warning("hal0.memory.cfg_load_failed", error=str(exc))
             _graph_enabled = False
             _graph_route = "upstream"
+            _embed_model = "BAAI/bge-small-en-v1.5"
+            _rerank_enabled = False
+            _rerank_url = "http://127.0.0.1:8086"
 
         memory_wrapper = CogneeWrapper(
+            embedding_model=_embed_model,
             graph_enabled=_graph_enabled,
             graph_route=_graph_route,
+            rerank_enabled=_rerank_enabled,
+            rerank_url=_rerank_url,
         )
     except Exception as exc:  # pragma: no cover — defensive
         log.warning("hal0.memory.init_failed", error=str(exc))

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -875,6 +875,10 @@ def create_app() -> FastAPI:
             _embed_model = str(_embed_cfg.model)
             _rerank_enabled = bool(_embed_cfg.rerank_enabled)
             _rerank_url = str(_embed_cfg.rerank_url)
+            _rerank_over_fetch_factor = int(_embed_cfg.rerank_over_fetch_factor)
+            _rerank_max_candidates = int(_embed_cfg.rerank_max_candidates)
+            _rerank_connect_timeout_s = float(_embed_cfg.rerank_connect_timeout_s)
+            _rerank_read_timeout_s = float(_embed_cfg.rerank_read_timeout_s)
         except Exception as exc:  # pragma: no cover — defensive
             log.warning("hal0.memory.cfg_load_failed", error=str(exc))
             _graph_enabled = False
@@ -882,6 +886,10 @@ def create_app() -> FastAPI:
             _embed_model = "BAAI/bge-small-en-v1.5"
             _rerank_enabled = False
             _rerank_url = "http://127.0.0.1:8086"
+            _rerank_over_fetch_factor = 5
+            _rerank_max_candidates = 500
+            _rerank_connect_timeout_s = 1.0
+            _rerank_read_timeout_s = 8.0
 
         memory_wrapper = CogneeWrapper(
             embedding_model=_embed_model,
@@ -889,6 +897,10 @@ def create_app() -> FastAPI:
             graph_route=_graph_route,
             rerank_enabled=_rerank_enabled,
             rerank_url=_rerank_url,
+            rerank_over_fetch_factor=_rerank_over_fetch_factor,
+            rerank_max_candidates=_rerank_max_candidates,
+            rerank_connect_timeout_s=_rerank_connect_timeout_s,
+            rerank_read_timeout_s=_rerank_read_timeout_s,
         )
     except Exception as exc:  # pragma: no cover — defensive
         log.warning("hal0.memory.init_failed", error=str(exc))

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1169,6 +1169,55 @@ class MemoryEmbeddingConfig(BaseModel):
             "protocol. Defaults to hal0's bundled embed-rerank slot."
         ),
     )
+    rerank_over_fetch_factor: int = Field(
+        default=5,
+        ge=1,
+        le=20,
+        description=(
+            "Multiplier on ``limit`` used to determine the vector-search "
+            "candidate count fed into the rerank pass. With the default of "
+            "5, a ``limit=10`` search rerank-scores up to 50 candidates "
+            "before clipping back to the top 10. Bumping this trades "
+            "rerank latency for recall; dropping it toward 1 makes the "
+            "rerank pass increasingly pointless."
+        ),
+    )
+    rerank_max_candidates: int = Field(
+        default=500,
+        ge=10,
+        le=2000,
+        description=(
+            "Absolute cap on candidates per rerank call, applied AFTER "
+            "``rerank_over_fetch_factor`` so memory + latency stay bounded "
+            "regardless of the requested ``limit``. The pre-PR hard-coded "
+            "100 silently collapsed the over-fetch ratio at ``limit >= 20`` "
+            "and made rerank a no-op at ``limit >= 100``."
+        ),
+    )
+    rerank_connect_timeout_s: float = Field(
+        default=1.0,
+        ge=0.05,
+        le=10.0,
+        description=(
+            "TCP connect timeout for the rerank HTTP call. Kept short so "
+            "a wedged rerank slot can't stall memory_search; the read "
+            "budget is the larger of the two knobs."
+        ),
+    )
+    rerank_read_timeout_s: float = Field(
+        default=8.0,
+        ge=0.05,
+        le=60.0,
+        description=(
+            "Read budget for the rerank slot. Default raised from the "
+            "previous shared 2.0s scalar because GPU rerank under "
+            "concurrent load (see auto-memory "
+            "``hal0-lemonade-threads-deadlock``) regularly breaches a "
+            "tight total budget, which silently falls through to vector "
+            "ordering. Failures still fall through — this just stops "
+            "spurious timeouts under healthy-but-loaded conditions."
+        ),
+    )
 
     @field_validator("model")
     @classmethod

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1115,18 +1115,90 @@ class AgentConfig(BaseModel):
         return v
 
 
+class MemoryEmbeddingConfig(BaseModel):
+    """[memory.embedding] section of hal0.toml (issue #116 G3 + G4).
+
+    Pins the embedding model Cognee uses for memory vector retrieval and
+    (optionally) wires a second-pass rerank slot in front of
+    :meth:`hal0.memory.cognee_wrapper.CogneeWrapper.search`.
+
+    Defaults are zero-config preserving:
+
+      - ``model`` keeps Cognee's stock pick (``BAAI/bge-small-en-v1.5``,
+        384-dim) so an upgrade does NOT silently re-embed an existing
+        LanceDB index (dimension mismatch corrupts the store).
+      - ``rerank_enabled`` is OFF by default; when flipped on, the
+        wrapper calls ``rerank_url`` after vector retrieval and reorders
+        candidates by relevance score. Failures fall through to the
+        original vector ordering — never block memory_search.
+      - ``rerank_url`` points at hal0's built-in rerank slot (port 8086
+        per auto-memory ``hal0-rerank-slot-wiring``).
+
+    G3 (pin embedding model) deliberately ships the *existing* default
+    so users who do not flip the toggle see no behavioral change. Future
+    work (audit doc §G3) may bump the default to ``bge-large-en-v1.5``
+    once a migration story for the LanceDB index exists.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+    model: str = Field(
+        default="BAAI/bge-small-en-v1.5",
+        description=(
+            "Embedding model the Cognee wrapper pins (issue #116 G3). "
+            "Defaults to the existing Cognee stock value so the install "
+            "default is byte-identical to v0.3.0 behavior — bumping this "
+            "without a re-embed migration corrupts the LanceDB index."
+        ),
+    )
+    rerank_enabled: bool = Field(
+        default=False,
+        description=(
+            "When True, memory_search posts the vector top-N candidates "
+            "to ``rerank_url`` and reorders by ``relevance_score`` before "
+            "returning the top-K (issue #116 G4). When False (default), "
+            "vector ordering is returned unchanged."
+        ),
+    )
+    rerank_url: str = Field(
+        default="http://127.0.0.1:8086",
+        description=(
+            "Base URL of the llama.cpp rerank endpoint. The wrapper "
+            "POSTs to ``{rerank_url}/rerank`` with "
+            "``{model, query, documents}`` per llama.cpp's reranking "
+            "protocol. Defaults to hal0's bundled embed-rerank slot."
+        ),
+    )
+
+    @field_validator("model")
+    @classmethod
+    def model_nonempty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("memory.embedding.model must not be empty")
+        return v
+
+    @field_validator("rerank_url")
+    @classmethod
+    def rerank_url_nonempty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("memory.embedding.rerank_url must not be empty")
+        return v
+
+
 class MemoryConfig(BaseModel):
     """[memory] section of hal0.toml.
 
-    Container for the per-subsystem memory tunables; today only
-    ``[memory.graph]`` lives here (ADR-0014) but the section exists so
-    future memory features (retention, prune-policy, archival) land
-    under a single namespace rather than scattering top-level tables.
+    Container for the per-subsystem memory tunables. Today carries
+    ``[memory.graph]`` (ADR-0014) and ``[memory.embedding]`` (issue
+    #116). Future memory features (retention, prune-policy, archival)
+    land under a single namespace rather than scattering top-level
+    tables.
     """
 
     model_config = {"populate_by_name": True, "extra": "allow"}
 
     graph: MemoryGraphConfig = Field(default_factory=MemoryGraphConfig)
+    embedding: MemoryEmbeddingConfig = Field(default_factory=MemoryEmbeddingConfig)
 
 
 class ModelsConfig(BaseModel):
@@ -1266,6 +1338,7 @@ __all__ = [
     "HardwareInfo",
     "MCPServerConfig",
     "MemoryConfig",
+    "MemoryEmbeddingConfig",
     "MemoryGraphConfig",
     "MetaConfig",
     "ModelConfig",

--- a/src/hal0/memory/cognee_wrapper.py
+++ b/src/hal0/memory/cognee_wrapper.py
@@ -172,7 +172,10 @@ class CogneeWrapper:
         rerank_enabled: bool = False,
         rerank_url: str = "http://127.0.0.1:8086",
         rerank_model: str = "bge-reranker-v2-m3-q4_k_m",
-        rerank_timeout_s: float = 2.0,
+        rerank_over_fetch_factor: int = 5,
+        rerank_max_candidates: int = 500,
+        rerank_connect_timeout_s: float = 1.0,
+        rerank_read_timeout_s: float = 8.0,
     ) -> None:
         """Configure Cognee + the sidecar SQLite index.
 
@@ -209,9 +212,23 @@ class CogneeWrapper:
         :param rerank_model: Model id sent in the rerank request body.
             llama.cpp's reranker echoes the field but accepts any
             string; the default matches hal0's bundled slot.
-        :param rerank_timeout_s: Per-request timeout for the rerank
-            HTTP call. Failures fall through to vector ordering — a
-            slow rerank slot must NOT block memory_search.
+        :param rerank_over_fetch_factor: Multiplier applied to ``limit``
+            to size the candidate set fed into the rerank pass. Higher
+            values trade rerank latency for recall; the pre-PR hard-
+            coded 5 collapsed at ``limit >= 20`` once the absolute cap
+            kicked in. See :class:`hal0.config.schema.MemoryEmbeddingConfig`.
+        :param rerank_max_candidates: Absolute cap on candidates per
+            rerank call so memory + latency stay bounded regardless of
+            the requested ``limit``. Applied AFTER ``rerank_over_fetch_
+            factor``.
+        :param rerank_connect_timeout_s: TCP connect timeout for the
+            rerank HTTP call. Kept short — a wedged rerank slot must not
+            stall memory_search.
+        :param rerank_read_timeout_s: Read budget for the rerank slot.
+            Default 8.0s; raised from the previous shared 2.0s scalar
+            because GPU rerank under concurrent load regularly breached
+            a tight total budget and silently fell through to vector
+            ordering. Failures still fall through.
         """
         self._cognee_dir = Path(cognee_dir)
         self._cognee_dir.mkdir(parents=True, exist_ok=True)
@@ -262,7 +279,14 @@ class CogneeWrapper:
         # Strip trailing slash so the search path doesn't double up.
         self._rerank_url = str(rerank_url or "").rstrip("/")
         self._rerank_model = str(rerank_model or "")
-        self._rerank_timeout_s = float(rerank_timeout_s)
+        # Over-fetch factor + absolute cap drive candidate_cap on the
+        # search path. The pre-PR ``min(100, max(limit*5, limit))``
+        # hard-coded BOTH knobs and made rerank a no-op at limit >= 100.
+        self._rerank_over_fetch_factor = max(1, int(rerank_over_fetch_factor))
+        self._rerank_max_candidates = max(1, int(rerank_max_candidates))
+        # Split connect vs read budgets — see __init__ docstring.
+        self._rerank_connect_timeout_s = float(rerank_connect_timeout_s)
+        self._rerank_read_timeout_s = float(rerank_read_timeout_s)
 
         # Tail buffer of audit events emitted by this instance. The
         # structlog channel is the production audit-log surface
@@ -742,7 +766,14 @@ class CogneeWrapper:
         # filtered candidate set (up to over-fetched top_k) before
         # reordering, then clip to ``limit``. Pre-rerank slicing would
         # throw away the candidates the reranker is supposed to promote.
-        candidate_cap = min(100, max(limit * 5, limit)) if self._rerank_enabled else limit
+        candidate_cap = (
+            min(
+                self._rerank_max_candidates,
+                max(limit * self._rerank_over_fetch_factor, limit),
+            )
+            if self._rerank_enabled
+            else limit
+        )
         candidates: list[dict[str, Any]] = []
         seen_ids: set[str] = set()
         with self._sidecar_conn() as conn:
@@ -955,8 +986,19 @@ class CogneeWrapper:
             "documents": documents,
         }
         url = f"{self._rerank_url}/rerank"
+        # Split connect vs read budget so a healthy-but-slow GPU rerank
+        # (concurrent load → see auto-memory
+        # ``hal0-lemonade-threads-deadlock``) doesn't burn the connect
+        # phase's share and silently fall through. Connect stays tight
+        # so a wedged port still bails fast.
+        timeout = httpx.Timeout(
+            connect=self._rerank_connect_timeout_s,
+            read=self._rerank_read_timeout_s,
+            write=2.0,
+            pool=None,
+        )
         try:
-            async with httpx.AsyncClient(timeout=self._rerank_timeout_s) as client:
+            async with httpx.AsyncClient(timeout=timeout) as client:
                 resp = await client.post(url, json=payload)
                 resp.raise_for_status()
                 body = resp.json()

--- a/src/hal0/memory/cognee_wrapper.py
+++ b/src/hal0/memory/cognee_wrapper.py
@@ -34,6 +34,7 @@ tag AND-match, date range). Phase 9 will revisit this when Cognee's
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
 import sqlite3
@@ -168,6 +169,10 @@ class CogneeWrapper:
         embedding_dimensions: int = 384,
         graph_enabled: bool = False,
         graph_route: str = "upstream",
+        rerank_enabled: bool = False,
+        rerank_url: str = "http://127.0.0.1:8086",
+        rerank_model: str = "bge-reranker-v2-m3-q4_k_m",
+        rerank_timeout_s: float = 2.0,
     ) -> None:
         """Configure Cognee + the sidecar SQLite index.
 
@@ -194,6 +199,19 @@ class CogneeWrapper:
             "agent". Stored for dashboard/CLI introspection (``status``);
             the LLM-routing implementation itself lands in v0.4 with the
             eval suite. v0.3 ships the gate + the introspection surface.
+        :param rerank_enabled: Issue #116 G4 — when True, ``search``
+            posts the vector top-N candidates to ``rerank_url`` and
+            reorders by ``relevance_score`` before clipping to ``limit``.
+            When False (default), vector ordering is returned unchanged.
+        :param rerank_url: Base URL of the llama.cpp rerank endpoint.
+            The wrapper POSTs to ``{rerank_url}/rerank``. Defaults to
+            hal0's bundled embed-rerank slot (port 8086).
+        :param rerank_model: Model id sent in the rerank request body.
+            llama.cpp's reranker echoes the field but accepts any
+            string; the default matches hal0's bundled slot.
+        :param rerank_timeout_s: Per-request timeout for the rerank
+            HTTP call. Failures fall through to vector ordering — a
+            slow rerank slot must NOT block memory_search.
         """
         self._cognee_dir = Path(cognee_dir)
         self._cognee_dir.mkdir(parents=True, exist_ok=True)
@@ -235,6 +253,16 @@ class CogneeWrapper:
         # (False)`` (ADR-0014 §6 cancel-in-flight) can cooperatively
         # cancel without leaving zombie tasks attached to the loop.
         self._graph_tasks: set[asyncio.Task[Any]] = set()
+
+        # Issue #116 G4 — rerank slot config. The wrapper consults these
+        # only on the search path; ``add`` is unaffected. Stored on the
+        # instance so ``set_rerank_enabled`` can flip them at runtime
+        # without rebuilding Cognee.
+        self._rerank_enabled = bool(rerank_enabled)
+        # Strip trailing slash so the search path doesn't double up.
+        self._rerank_url = str(rerank_url or "").rstrip("/")
+        self._rerank_model = str(rerank_model or "")
+        self._rerank_timeout_s = float(rerank_timeout_s)
 
         # Tail buffer of audit events emitted by this instance. The
         # structlog channel is the production audit-log surface
@@ -710,7 +738,12 @@ class CogneeWrapper:
         # ingest text is the canonical form.
         texts_in_order = [_chunk_text(r) for r in raw]
         scores_in_order = [_chunk_score(r) for r in raw]
-        out: list[dict[str, Any]] = []
+        # Issue #116 G4 — when rerank is on we want to keep the FULL
+        # filtered candidate set (up to over-fetched top_k) before
+        # reordering, then clip to ``limit``. Pre-rerank slicing would
+        # throw away the candidates the reranker is supposed to promote.
+        candidate_cap = min(100, max(limit * 5, limit)) if self._rerank_enabled else limit
+        candidates: list[dict[str, Any]] = []
         seen_ids: set[str] = set()
         with self._sidecar_conn() as conn:
             for text, score in zip(texts_in_order, scores_in_order, strict=True):
@@ -730,18 +763,33 @@ class CogneeWrapper:
                     record = _row_to_record(row, score=score)
                     if not _passes_filters(record, tags, before, after):
                         continue
-                    out.append(record.to_dict())
+                    candidates.append(record.to_dict())
                     seen_ids.add(row["id"])
-                    if len(out) >= limit:
+                    if len(candidates) >= candidate_cap:
                         break
-                if len(out) >= limit:
+                if len(candidates) >= candidate_cap:
                     break
+
+        # Issue #116 G4 — second-pass rerank. Off by default; when on,
+        # post to the rerank slot and re-order candidates by
+        # ``relevance_score``. Failures fall through to the vector
+        # ordering: a flaky or unreachable rerank slot must never block
+        # memory_search.
+        reranked = False
+        if self._rerank_enabled and len(candidates) > 1:
+            reordered = await self._maybe_rerank(query, candidates)
+            if reordered is not None:
+                candidates = reordered
+                reranked = True
+
+        out = candidates[:limit]
 
         self._audit(
             "search",
             ",".join(allowed_datasets),
             query=query,
             results=len(out),
+            reranked=reranked,
         )
         return out
 
@@ -863,6 +911,118 @@ class CogneeWrapper:
             deleted=deleted,
         )
         return {"deleted": deleted}
+
+    # ── Rerank (issue #116 G4) ─────────────────────────────────────────
+
+    def set_rerank_enabled(self, enabled: bool) -> None:
+        """Flip the rerank gate at runtime.
+
+        Companion to the runtime ``set_graph_enabled`` flip. The
+        dashboard's memory pane uses this so the user can A/B the
+        rerank surface without restarting hal0.
+        """
+        self._rerank_enabled = bool(enabled)
+
+    async def _maybe_rerank(
+        self,
+        query: str,
+        candidates: list[dict[str, Any]],
+    ) -> list[dict[str, Any]] | None:
+        """Post candidate texts to the rerank slot and return reordered records.
+
+        Returns ``None`` (signalling fall-through) on ANY failure: the
+        slot is down, the response shape is wrong, the HTTP call times
+        out, etc. ``search`` then keeps the vector ordering and the
+        caller never sees a rerank-induced failure.
+
+        Side effect: each returned record's ``score`` is overwritten
+        with the rerank ``relevance_score`` so callers (and the
+        dashboard) see the post-rerank scoring rather than the original
+        vector cosine. The original vector order is recoverable by
+        flipping ``rerank_enabled = False`` and re-running.
+        """
+        # llama.cpp's /rerank handler accepts ``query`` + ``documents``;
+        # we send the candidate text in document-index order so we can
+        # map results.index back to our list.
+        documents = [c.get("text", "") for c in candidates]
+        # httpx import is local — keeps the wrapper import-cheap for
+        # callers (CLI tooling, tests) that never touch search.
+        import httpx
+
+        payload = {
+            "model": self._rerank_model,
+            "query": query,
+            "documents": documents,
+        }
+        url = f"{self._rerank_url}/rerank"
+        try:
+            async with httpx.AsyncClient(timeout=self._rerank_timeout_s) as client:
+                resp = await client.post(url, json=payload)
+                resp.raise_for_status()
+                body = resp.json()
+        except Exception as exc:
+            _audit_logger().warning(
+                "hal0.memory.rerank.unreachable",
+                client_id=self._client_id,
+                url=url,
+                error=f"{type(exc).__name__}: {exc}"[:200],
+            )
+            return None
+
+        # llama.cpp shape: {"results": [{"index": int,
+        # "relevance_score": float}, ...]}.
+        results = body.get("results") if isinstance(body, dict) else None
+        if not isinstance(results, list) or not results:
+            _audit_logger().warning(
+                "hal0.memory.rerank.bad_response",
+                client_id=self._client_id,
+                url=url,
+            )
+            return None
+
+        # Sort by relevance_score DESC, then map back to our candidate
+        # list. Drop entries whose index is out of range (defensive
+        # against a misconfigured slot).
+        try:
+            ranked = sorted(
+                results,
+                key=lambda r: float(r.get("relevance_score", 0.0)),
+                reverse=True,
+            )
+        except (TypeError, ValueError):
+            _audit_logger().warning(
+                "hal0.memory.rerank.bad_score",
+                client_id=self._client_id,
+                url=url,
+            )
+            return None
+
+        reordered: list[dict[str, Any]] = []
+        seen_idx: set[int] = set()
+        for entry in ranked:
+            idx = entry.get("index")
+            if not isinstance(idx, int) or idx < 0 or idx >= len(candidates):
+                continue
+            if idx in seen_idx:
+                continue
+            seen_idx.add(idx)
+            record = dict(candidates[idx])
+            # Keep the original score if the new one is malformed —
+            # defensive against a slot that returns string-typed scores.
+            with contextlib.suppress(TypeError, ValueError):
+                record["score"] = float(entry.get("relevance_score", 0.0))
+            reordered.append(record)
+
+        # If the rerank response was incomplete (rare; we still got
+        # *some* results), append the un-ranked tail in their original
+        # order so the caller sees the full candidate set.
+        if len(reordered) < len(candidates):
+            for i, record in enumerate(candidates):
+                if i in seen_idx:
+                    continue
+                reordered.append(record)
+
+        return reordered
 
     # ── Internal helpers ───────────────────────────────────────────────
 

--- a/tests/memory/test_rerank.py
+++ b/tests/memory/test_rerank.py
@@ -1,0 +1,388 @@
+"""Issue #116 G4 — rerank slot integration tests.
+
+These tests do NOT run the real Cognee retrieval — that's already
+covered by ``test_cognee_wrapper.py``. Here we monkeypatch
+``cognee.search`` so we can stage a deterministic candidate set and
+assert on the wrapper's rerank wiring:
+
+  - rerank_enabled=False: vector ordering is preserved + no HTTP call
+    fires.
+  - rerank_enabled=True with a live (mock) rerank slot: candidates get
+    reordered by the relevance scores the slot returns.
+  - rerank_enabled=True but slot is unreachable / 5xx / malformed:
+    wrapper falls through silently, vector ordering is preserved, no
+    exception escapes search().
+
+The config schema check is plain pydantic — no Cognee install needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("cognee")
+
+
+# ── Schema defaults (no Cognee needed) ────────────────────────────────────
+
+
+def test_memory_embedding_config_defaults() -> None:
+    """Issue #116 G3 — embedding section must round-trip empty TOML.
+
+    Default behavior must be byte-identical to v0.3.0: rerank off, model
+    pinned to the existing Cognee stock value so an upgrade does NOT
+    silently re-embed an existing LanceDB index.
+    """
+    from hal0.config.schema import MemoryConfig, MemoryEmbeddingConfig
+
+    cfg = MemoryEmbeddingConfig()
+    assert cfg.model == "BAAI/bge-small-en-v1.5"
+    assert cfg.rerank_enabled is False
+    assert cfg.rerank_url == "http://127.0.0.1:8086"
+
+    # Nested under MemoryConfig the field must default-construct.
+    mem = MemoryConfig()
+    assert mem.embedding.rerank_enabled is False
+
+
+def test_memory_embedding_config_rejects_empty_model() -> None:
+    """Empty model is a config error — a blank field would silently let
+    Cognee fall back to its hard-coded default, defeating the pin."""
+    from hal0.config.schema import MemoryEmbeddingConfig
+
+    with pytest.raises(ValueError):
+        MemoryEmbeddingConfig(model="")
+    with pytest.raises(ValueError):
+        MemoryEmbeddingConfig(rerank_url="   ")
+
+
+# ── Wrapper rerank wiring ─────────────────────────────────────────────────
+
+# pyproject's ``asyncio_mode = "auto"`` picks up async test functions
+# without an explicit ``@pytest.mark.asyncio`` decorator — keeping the
+# module mark off avoids warning on the two sync schema tests above.
+
+
+@pytest.fixture
+def stub_cognee_search(monkeypatch: pytest.MonkeyPatch):
+    """Replace ``cognee.search`` with a 3-chunk staged result.
+
+    The wrapper text-matches its sidecar against the chunks' text, so
+    we also need to seed three sidecar rows whose text matches the
+    stub's chunk texts. The fixture returns a helper that takes the
+    wrapper instance and seeds the sidecar rows.
+    """
+    import cognee
+
+    # Three fake chunks. Note: the wrapper expects an attribute-style
+    # ``text`` / ``score`` (see ``_chunk_text`` + ``_chunk_score`` in
+    # cognee_wrapper.py) — MagicMock auto-creates the attrs.
+    chunk_a = MagicMock()
+    chunk_a.text = "alpha document"
+    chunk_a.score = 0.9
+    chunk_b = MagicMock()
+    chunk_b.text = "beta document"
+    chunk_b.score = 0.8
+    chunk_c = MagicMock()
+    chunk_c.text = "gamma document"
+    chunk_c.score = 0.7
+
+    async def fake_search(**kwargs: Any) -> list[Any]:
+        return [chunk_a, chunk_b, chunk_c]
+
+    monkeypatch.setattr(cognee, "search", fake_search)
+
+    def seed(wrapper: Any) -> None:
+        """Drop three rows into the wrapper's sidecar so text-match hits."""
+        import json
+        import uuid
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC).isoformat()
+        with wrapper._sidecar_conn() as conn:
+            for text in ("alpha document", "beta document", "gamma document"):
+                conn.execute(
+                    """
+                    INSERT INTO hal0_memory_items
+                        (id, text, timestamp, dataset, tags, source, metadata,
+                         cognee_data_id, cognee_dataset_id)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        str(uuid.uuid4()),
+                        text,
+                        now,
+                        "shared",
+                        json.dumps([]),
+                        "test",
+                        json.dumps({}),
+                        None,
+                        None,
+                    ),
+                )
+            conn.commit()
+
+    return seed
+
+
+@pytest.fixture
+def wrapper_factory(cognee_dir: Path):
+    from hal0.memory import CogneeWrapper
+
+    def _build(**kwargs: Any) -> Any:
+        return CogneeWrapper(cognee_dir=cognee_dir, **kwargs)
+
+    return _build
+
+
+async def test_rerank_disabled_preserves_vector_order_and_skips_http(
+    wrapper_factory,
+    stub_cognee_search,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default config = rerank off = no HTTP call, vector order preserved."""
+    w = wrapper_factory(rerank_enabled=False)
+    stub_cognee_search(w)
+
+    # Spy on httpx.AsyncClient — if anyone constructs one, the test
+    # explodes. The rerank path is the only consumer in this module,
+    # so an off-default constructing httpx would be a bug.
+    import httpx
+
+    def _explode(*a: Any, **kw: Any) -> Any:
+        raise AssertionError("rerank disabled must not open an httpx client")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _explode)
+
+    out = await w.search(query="anything", limit=3)
+    assert [r["text"] for r in out] == [
+        "alpha document",
+        "beta document",
+        "gamma document",
+    ]
+
+    # Audit tail must record reranked=False so dashboard traces can
+    # distinguish "vector-only" from "rerank applied".
+    search_events = [e for e in w.audit_tail if e["op"] == "search"]
+    assert search_events, w.audit_tail
+    assert search_events[-1]["reranked"] is False
+
+
+async def test_rerank_enabled_reorders_by_relevance_score(
+    wrapper_factory,
+    stub_cognee_search,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """rerank_enabled=True flips alpha (idx 0) → gamma (idx 2) when the
+    rerank slot scores gamma highest. Asserts the score override too —
+    the post-rerank record carries the rerank's relevance_score, not
+    Cognee's cosine."""
+
+    captured: dict[str, Any] = {}
+
+    class _Resp:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            # Index 2 = gamma is the winner; alpha drops to last.
+            return {
+                "results": [
+                    {"index": 2, "relevance_score": 0.95},
+                    {"index": 1, "relevance_score": 0.50},
+                    {"index": 0, "relevance_score": 0.10},
+                ]
+            }
+
+    class _FakeClient:
+        def __init__(self, *a: Any, **kw: Any) -> None:
+            captured["init_kwargs"] = kw
+
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(self, *a: Any) -> None:
+            return None
+
+        async def post(self, url: str, json: dict[str, Any]) -> _Resp:
+            captured["url"] = url
+            captured["payload"] = json
+            return _Resp()
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+
+    w = wrapper_factory(rerank_enabled=True, rerank_url="http://rr.test:9000")
+    stub_cognee_search(w)
+
+    out = await w.search(query="which doc?", limit=3)
+    assert [r["text"] for r in out] == [
+        "gamma document",
+        "beta document",
+        "alpha document",
+    ]
+    # Score on the top hit must be the rerank's relevance_score, not
+    # Cognee's cosine (0.7) — that's the whole point of the second pass.
+    assert out[0]["score"] == pytest.approx(0.95)
+
+    # The wrapper must hit ``{rerank_url}/rerank`` with the documents
+    # in candidate order.
+    assert captured["url"] == "http://rr.test:9000/rerank"
+    assert captured["payload"]["query"] == "which doc?"
+    assert captured["payload"]["documents"] == [
+        "alpha document",
+        "beta document",
+        "gamma document",
+    ]
+
+    # Audit tail flags this search as reranked.
+    search_events = [e for e in w.audit_tail if e["op"] == "search"]
+    assert search_events[-1]["reranked"] is True
+
+
+async def test_rerank_unreachable_falls_through_to_vector(
+    wrapper_factory,
+    stub_cognee_search,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the rerank slot is down (ConnectError), search() returns
+    vector ordering and DOES NOT raise. Audit tail records reranked=False.
+    """
+    import httpx
+
+    class _DownClient:
+        def __init__(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _DownClient:
+            return self
+
+        async def __aexit__(self, *a: Any) -> None:
+            return None
+
+        async def post(self, url: str, json: dict[str, Any]) -> Any:
+            raise httpx.ConnectError("rerank slot offline")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _DownClient)
+
+    w = wrapper_factory(rerank_enabled=True)
+    stub_cognee_search(w)
+
+    out = await w.search(query="anything", limit=3)
+    # Vector order preserved exactly.
+    assert [r["text"] for r in out] == [
+        "alpha document",
+        "beta document",
+        "gamma document",
+    ]
+    search_events = [e for e in w.audit_tail if e["op"] == "search"]
+    assert search_events[-1]["reranked"] is False
+
+
+async def test_rerank_malformed_response_falls_through(
+    wrapper_factory,
+    stub_cognee_search,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the rerank slot returns 200 but with junk, fall through too.
+
+    Defends against a non-llama.cpp deployment behind the same URL
+    (e.g. a misconfigured proxy returning HTML).
+    """
+
+    class _BadResp:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> Any:
+            return {"unexpected": "shape"}
+
+    class _BadClient:
+        def __init__(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _BadClient:
+            return self
+
+        async def __aexit__(self, *a: Any) -> None:
+            return None
+
+        async def post(self, *a: Any, **kw: Any) -> _BadResp:
+            return _BadResp()
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _BadClient)
+
+    w = wrapper_factory(rerank_enabled=True)
+    stub_cognee_search(w)
+
+    out = await w.search(query="anything", limit=3)
+    assert [r["text"] for r in out] == [
+        "alpha document",
+        "beta document",
+        "gamma document",
+    ]
+
+
+async def test_set_rerank_enabled_flips_at_runtime(
+    wrapper_factory,
+    stub_cognee_search,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``set_rerank_enabled`` toggles the gate without rebuilding Cognee."""
+    posted: list[str] = []
+
+    class _Resp:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {
+                "results": [
+                    {"index": 0, "relevance_score": 0.9},
+                    {"index": 1, "relevance_score": 0.5},
+                    {"index": 2, "relevance_score": 0.1},
+                ]
+            }
+
+    class _FakeClient:
+        def __init__(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(self, *a: Any) -> None:
+            return None
+
+        async def post(self, url: str, json: dict[str, Any]) -> _Resp:
+            posted.append(url)
+            return _Resp()
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+
+    w = wrapper_factory(rerank_enabled=False)
+    stub_cognee_search(w)
+
+    # Off — no HTTP.
+    await w.search(query="q", limit=3)
+    assert posted == []
+
+    # Flip on — next search hits the slot.
+    w.set_rerank_enabled(True)
+    await w.search(query="q", limit=3)
+    assert len(posted) == 1

--- a/tests/memory/test_rerank.py
+++ b/tests/memory/test_rerank.py
@@ -386,3 +386,311 @@ async def test_set_rerank_enabled_flips_at_runtime(
     w.set_rerank_enabled(True)
     await w.search(query="q", limit=3)
     assert len(posted) == 1
+
+
+# ── Candidate cap + timeout config (reviewer findings, PR #365) ───────────
+
+
+def test_memory_embedding_config_rerank_tunables_defaults() -> None:
+    """New ``rerank_*`` tunables ship with the documented defaults."""
+    from hal0.config.schema import MemoryEmbeddingConfig
+
+    cfg = MemoryEmbeddingConfig()
+    assert cfg.rerank_over_fetch_factor == 5
+    assert cfg.rerank_max_candidates == 500
+    assert cfg.rerank_connect_timeout_s == pytest.approx(1.0)
+    assert cfg.rerank_read_timeout_s == pytest.approx(8.0)
+
+
+def test_memory_embedding_config_rerank_tunables_bounds() -> None:
+    """Bounds enforced by pydantic ``Field(ge/le)``."""
+    from hal0.config.schema import MemoryEmbeddingConfig
+
+    with pytest.raises(ValueError):
+        MemoryEmbeddingConfig(rerank_over_fetch_factor=0)
+    with pytest.raises(ValueError):
+        MemoryEmbeddingConfig(rerank_over_fetch_factor=21)
+    with pytest.raises(ValueError):
+        MemoryEmbeddingConfig(rerank_max_candidates=5)
+    with pytest.raises(ValueError):
+        MemoryEmbeddingConfig(rerank_max_candidates=5000)
+    with pytest.raises(ValueError):
+        MemoryEmbeddingConfig(rerank_connect_timeout_s=0.0)
+    with pytest.raises(ValueError):
+        MemoryEmbeddingConfig(rerank_read_timeout_s=120.0)
+
+
+# Shared candidate-cap stub. Replaces cognee.search with N synthetic chunks
+# AND seeds matching sidecar rows so the wrapper's text-match path keeps
+# all of them. The wrapper's pre-rerank candidate accumulator is the
+# observable: we assert how many candidates it kept.
+
+
+def _seed_n_candidates(monkeypatch: pytest.MonkeyPatch, wrapper: Any, n: int) -> None:
+    """Stub cognee + sidecar with ``n`` candidates, one per chunk."""
+    import json
+    import uuid
+    from datetime import UTC, datetime
+
+    import cognee
+
+    texts = [f"doc {i}" for i in range(n)]
+    chunks: list[Any] = []
+    for i, text in enumerate(texts):
+        ch = MagicMock()
+        ch.text = text
+        # Strictly descending vector score so the unranked order matches
+        # insertion order.
+        ch.score = 1.0 - (i / max(1, n))
+        chunks.append(ch)
+
+    async def fake_search(**kwargs: Any) -> list[Any]:
+        return chunks
+
+    monkeypatch.setattr(cognee, "search", fake_search)
+
+    now = datetime.now(UTC).isoformat()
+    with wrapper._sidecar_conn() as conn:
+        for text in texts:
+            conn.execute(
+                """
+                INSERT INTO hal0_memory_items
+                    (id, text, timestamp, dataset, tags, source, metadata,
+                     cognee_data_id, cognee_dataset_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(uuid.uuid4()),
+                    text,
+                    now,
+                    "shared",
+                    json.dumps([]),
+                    "test",
+                    json.dumps({}),
+                    None,
+                    None,
+                ),
+            )
+        conn.commit()
+
+
+async def test_candidate_cap_respects_over_fetch_factor(
+    wrapper_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``limit=25`` with default factor=5 → cap=125, well below the 500
+    absolute cap, so the rerank pass should receive 125 candidates (or
+    all available, whichever is smaller).
+
+    We stage 200 cognee chunks and inspect the document list the rerank
+    slot receives — that's the candidate set in candidate order.
+    """
+    captured: dict[str, Any] = {}
+
+    class _Resp:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            # Identity rerank — keep input order.
+            return {
+                "results": [
+                    {"index": i, "relevance_score": 1.0 - (i / 1000)}
+                    for i in range(len(captured.get("payload", {}).get("documents", [])))
+                ]
+            }
+
+    class _FakeClient:
+        def __init__(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(self, *a: Any) -> None:
+            return None
+
+        async def post(self, url: str, json: dict[str, Any]) -> _Resp:
+            captured["url"] = url
+            captured["payload"] = json
+            return _Resp()
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+
+    w = wrapper_factory(rerank_enabled=True)
+    _seed_n_candidates(monkeypatch, w, 200)
+
+    await w.search(query="q", limit=25)
+    # 25 * 5 = 125, < max_candidates (500), and < seeded 200 → exactly 125.
+    assert len(captured["payload"]["documents"]) == 125
+
+
+async def test_candidate_cap_respects_max_candidates(
+    wrapper_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``max_candidates=50`` clamps below ``limit * factor``.
+
+    limit=20, factor=5 → naive cap would be 100; with max=50 the cap is 50.
+    """
+    captured: dict[str, Any] = {}
+
+    class _Resp:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {
+                "results": [
+                    {"index": i, "relevance_score": 1.0 - (i / 1000)}
+                    for i in range(len(captured.get("payload", {}).get("documents", [])))
+                ]
+            }
+
+    class _FakeClient:
+        def __init__(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(self, *a: Any) -> None:
+            return None
+
+        async def post(self, url: str, json: dict[str, Any]) -> _Resp:
+            captured["payload"] = json
+            return _Resp()
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+
+    w = wrapper_factory(rerank_enabled=True, rerank_max_candidates=50)
+    _seed_n_candidates(monkeypatch, w, 200)
+
+    await w.search(query="q", limit=20)
+    assert len(captured["payload"]["documents"]) == 50
+
+
+async def test_rerank_handles_read_timeout(
+    wrapper_factory,
+    stub_cognee_search,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``httpx.ReadTimeout`` raised by the rerank client must fall
+    through silently — vector ordering preserved, no exception escapes,
+    audit tail records reranked=False."""
+    import httpx
+
+    class _SlowClient:
+        def __init__(self, *a: Any, **kw: Any) -> None:
+            # The constructor must accept the split-timeout we now pass.
+            assert isinstance(kw.get("timeout"), httpx.Timeout)
+
+        async def __aenter__(self) -> _SlowClient:
+            return self
+
+        async def __aexit__(self, *a: Any) -> None:
+            return None
+
+        async def post(self, url: str, json: dict[str, Any]) -> Any:
+            raise httpx.ReadTimeout("rerank slot slow")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _SlowClient)
+
+    w = wrapper_factory(rerank_enabled=True)
+    stub_cognee_search(w)
+
+    out = await w.search(query="q", limit=3)
+    assert [r["text"] for r in out] == [
+        "alpha document",
+        "beta document",
+        "gamma document",
+    ]
+    search_events = [e for e in w.audit_tail if e["op"] == "search"]
+    assert search_events[-1]["reranked"] is False
+
+
+async def test_rerank_handles_duplicate_index_in_response(
+    wrapper_factory,
+    stub_cognee_search,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed rerank slot that returns the same index twice must
+    not double-emit the candidate. seen_idx dedup keeps the first hit;
+    later duplicates are skipped."""
+
+    class _Resp:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            # idx=0 listed twice with different scores. After sort DESC
+            # the first entry is the 0.9 one (idx 0). The 0.8 idx=0
+            # entry must be skipped.
+            return {
+                "results": [
+                    {"index": 0, "relevance_score": 0.9},
+                    {"index": 0, "relevance_score": 0.8},
+                    {"index": 1, "relevance_score": 0.7},
+                ]
+            }
+
+    class _FakeClient:
+        def __init__(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(self, *a: Any) -> None:
+            return None
+
+        async def post(self, *a: Any, **kw: Any) -> _Resp:
+            return _Resp()
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+
+    w = wrapper_factory(rerank_enabled=True)
+    stub_cognee_search(w)
+
+    out = await w.search(query="q", limit=3)
+    # No duplicates: alpha (idx 0) appears exactly once.
+    texts = [r["text"] for r in out]
+    assert texts.count("alpha document") == 1
+    # The 3-text candidate set should be fully represented (the unranked
+    # tail re-appends idx=2 after the dedup'd ranked pass).
+    assert set(texts) == {"alpha document", "beta document", "gamma document"}
+
+
+async def test_rerank_skipped_when_single_candidate(
+    wrapper_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``limit=1`` and a single candidate → the rerank pass is skipped
+    entirely (``len(candidates) > 1`` is the guard). No HTTP call,
+    audit tail records reranked=False."""
+    import httpx
+
+    def _explode(*a: Any, **kw: Any) -> Any:
+        raise AssertionError("rerank must be skipped for single-candidate searches")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _explode)
+
+    w = wrapper_factory(rerank_enabled=True)
+    _seed_n_candidates(monkeypatch, w, 1)
+
+    out = await w.search(query="q", limit=1)
+    assert len(out) == 1
+    search_events = [e for e in w.audit_tail if e["op"] == "search"]
+    assert search_events[-1]["reranked"] is False


### PR DESCRIPTION
Closes #116.

## Summary

- Add ``[memory.embedding]`` config section carrying ``model``, ``rerank_enabled``, ``rerank_url``, plus reliability knobs ``rerank_over_fetch_factor`` / ``rerank_max_candidates`` / ``rerank_connect_timeout_s`` / ``rerank_read_timeout_s``. Defaults are zero-change for the existing surface: model stays on the existing Cognee stock value (``BAAI/bge-small-en-v1.5``, 384-dim) and rerank is off.
- Wire ``CogneeWrapper.search`` to optionally POST candidates to ``{rerank_url}/rerank`` and reorder by ``relevance_score``. Failures (unreachable, 5xx, malformed, read-timeout) fall through to vector ordering — never block memory_search.
- ``set_rerank_enabled`` flips the gate at runtime.
- Boot path in ``hal0.api`` reads the new config and threads it into ``CogneeWrapper``.
- Audit events carry ``reranked: bool`` so dashboard traces distinguish vector-only from reranked retrieval.

## Reviewer findings addressed (latest commit)

1. **Hard-coded candidate cap** — ``min(100, max(limit*5, limit))`` collapsed the over-fetch ratio at ``limit >= 20`` and made rerank a no-op at ``limit >= 100``. Replaced with ``rerank_over_fetch_factor`` (default 5, range 1-20) and ``rerank_max_candidates`` (default 500, range 10-2000).
2. **Single rerank timeout shared connect + read budget** — GPU rerank under concurrent load (see auto-memory ``hal0-lemonade-threads-deadlock``) regularly breached the 2.0s total and silently fell through. Split into ``rerank_connect_timeout_s`` (default 1.0) and ``rerank_read_timeout_s`` (default 8.0, raised from 2.0). httpx now receives an explicit ``httpx.Timeout(connect=..., read=..., write=2.0)``.

Both knob sets are wired through the ``CogneeWrapper`` ctor and the ``api/__init__.py`` boot path. Five new tests cover the over-fetch/cap math, ReadTimeout fall-through, duplicate-index dedup, and single-candidate skip path.

## Design notes

G3 (pin embedding model) ships the **existing** default rather than bumping to ``bge-large-en-v1.5``. Reason: the LanceDB index is dimension-pinned; a default flip would silently corrupt existing stores. The config field exists so operators can opt in once a migration story lands (audit doc §G3, separate PR).

G4 (rerank wire-in) is off by default for the same backwards-compat reason — flipping default-on lands once an MCP eval suite exists to confirm the quality lift (audit doc §G2).

llama.cpp's rerank slot is reached via ``{rerank_url}/rerank`` with ``{model, query, documents}`` and parses ``{results: [{index, relevance_score}]}``. Defaults match hal0's bundled embed-rerank slot (port 8086, ``bge-reranker-v2-m3-q4_k_m``).

## Test plan

- [x] ``pytest tests/memory/`` — all green, 14 tests in ``test_rerank.py`` (was 7).
- [x] ``pytest tests/memory/ tests/config/`` — 218 passed (was 211).
- [x] ``ruff check`` + ``ruff format --check`` on changed files — clean. (Pre-existing errors in ``packaging/toolbox/*`` and ``scripts/`` are out of scope and present on ``main``.)
- [ ] Manual smoke on hal0 LXC: load wrapper with ``rerank_enabled=true`` against live rerank slot, confirm reordering on a known-shape query (deferred — does NOT touch the v0.3 default surface, follow-up gated on a memory dashboard pane).

## Out of scope

- Bumping the default embedding model — needs a LanceDB re-embed migration first.
- Default-on rerank — gated on a memory MCP eval suite (audit doc §G2).
- G5 (BM25 + dense hybrid) — ADR-0006 / Phase 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)