### PR TITLE
fix(memory): REST /api/memory/add honors private:* namespace

### DIFF
--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -25,8 +25,59 @@ from pydantic import ValidationError
 from hal0.api.middleware.error_codes import Hal0Error
 from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import GraphUpstreamConfig, MemoryGraphConfig
+from hal0.memory.namespace import (
+    DEFAULT_DATASET,
+    MemoryNamespaceError,
+    resolve_read_datasets,
+    resolve_write_dataset,
+)
 
 router = APIRouter()
+
+
+# ── ADR-0012 identity + ADR-0005 §3 namespace helpers ─────────────────────
+#
+# Post-ADR-0012 hal0-api is open on 0.0.0.0:8080; agent identity flows on
+# the ``X-hal0-Agent`` header (NOT Bearer — auth surface was removed).
+# Private-mode opt-in flows on ``X-hal0-Private`` to match the MCP mount
+# (:mod:`hal0.api.mcp_mount`); the same toggle gates the same namespace
+# promotion rule across both surfaces (issue #317).
+
+
+_AGENT_HEADER = "x-hal0-agent"
+_PRIVATE_HEADER = "x-hal0-private"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+class MemoryNamespaceInvalid(Hal0Error):
+    """The caller's headers + body produced an unresolvable namespace.
+
+    Distinct from a body-shape error so the dashboard can paint a
+    different toast ("you asked for private without an agent identity")
+    vs a generic 400.
+    """
+
+    code = "memory.namespace_invalid"
+    status = 400
+
+
+def _agent_id(request: Request) -> str:
+    """Return the ``X-hal0-Agent`` value, or ``"anonymous"`` if absent.
+
+    Mirrors :func:`hal0.api.mcp_mount.client_id_resolver` for the REST
+    surface — both translate the absence of an identity header into the
+    same sentinel so audit + dataset resolution stay consistent.
+    """
+    raw = request.headers.get(_AGENT_HEADER)
+    if not raw:
+        return "anonymous"
+    return raw.strip() or "anonymous"
+
+
+def _is_private(request: Request) -> bool:
+    """Return whether the caller opted into ``--private`` mode."""
+    raw = request.headers.get(_PRIVATE_HEADER, "")
+    return raw.strip().lower() in _TRUTHY
 
 
 class MemoryGraphConfigInvalid(Hal0Error):
@@ -188,11 +239,22 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
 
 @router.post("/add")
 async def memory_add(request: Request) -> dict[str, Any]:
-    """Add a memory item. Body: ``{text, dataset?, tags?, source?, metadata?}``.
+    """Add a memory item. Body: ``{text, dataset?, tags?, metadata?}``.
 
-    Returns ``{id, timestamp}`` from :meth:`CogneeWrapper.add`. The
-    ``dataset`` defaults to ``"shared"``; tags + metadata are
-    free-form lists / dict respectively.
+    Identity headers (issue #317):
+
+      - ``X-hal0-Agent``: post-ADR-0012 agent identity. Stamped onto
+        the wrapper's ``source`` field — server-injected so callers
+        cannot lie (ADR-0005 §5). Absent header → ``"anonymous"``.
+      - ``X-hal0-Private: 1``: opt into the private namespace.
+        Promotes ``dataset`` to ``private:<agent>`` regardless of the
+        body value (ADR-0005 §3).
+
+    The body's ``source`` field is REJECTED — clients supplying it is
+    treated as an attempt to impersonate, matching the MCP rule. Use
+    the ``X-hal0-Agent`` header to claim identity.
+
+    Returns ``{id, timestamp}`` from :meth:`CogneeWrapper.add`.
     """
     body = await _read_json_body(request)
     text = body.get("text")
@@ -201,12 +263,32 @@ async def memory_add(request: Request) -> dict[str, Any]:
             "memory_add requires 'text' (non-empty string)",
             details={"path": "/api/memory/add"},
         )
+    if "source" in body:
+        # ADR-0005 §5 — source is server-injected from the X-hal0-Agent
+        # header so callers cannot impersonate another agent in the
+        # audit log.
+        raise Hal0Error(
+            "memory_add 'source' is server-injected from X-hal0-Agent and cannot be supplied",
+            details={"path": "/api/memory/add"},
+        )
+
+    agent_id = _agent_id(request)
+    private = _is_private(request)
+    try:
+        dataset = resolve_write_dataset(
+            body.get("dataset"),
+            private=private,
+            client_id=agent_id if agent_id != "anonymous" else None,
+        )
+    except MemoryNamespaceError as exc:
+        raise MemoryNamespaceInvalid(str(exc)) from exc
+
     wrapper = _wrapper(request)
     return await wrapper.add(
         text=text,
-        dataset=body.get("dataset", "shared"),
+        dataset=dataset,
         tags=body.get("tags") or [],
-        source=body.get("source"),
+        source=agent_id,
         metadata=body.get("metadata") or {},
     )
 
@@ -214,6 +296,11 @@ async def memory_add(request: Request) -> dict[str, Any]:
 @router.post("/search")
 async def memory_search(request: Request) -> dict[str, Any]:
     """Search memory. Body: ``{query, limit?, dataset?, tags?, before?, after?}``.
+
+    Identity headers behave like ``/add`` — ``X-hal0-Private: 1``
+    expands a default-empty ``dataset`` to ``[shared, private:<agent>]``
+    per ADR-0005 §3 so a private-mode caller sees both their own scoped
+    items + the shared bucket without per-call opt-in.
 
     Returns ``{items: [MemoryRecord, ...]}`` — wrapped in an envelope so
     we can add ``next_cursor`` / counters later without breaking clients.
@@ -225,11 +312,23 @@ async def memory_search(request: Request) -> dict[str, Any]:
             "memory_search requires 'query' (non-empty string)",
             details={"path": "/api/memory/search"},
         )
+
+    agent_id = _agent_id(request)
+    private = _is_private(request)
+    try:
+        dataset = resolve_read_datasets(
+            body.get("dataset"),
+            private=private,
+            client_id=agent_id if agent_id != "anonymous" else None,
+        )
+    except MemoryNamespaceError as exc:
+        raise MemoryNamespaceInvalid(str(exc)) from exc
+
     wrapper = _wrapper(request)
     items = await wrapper.search(
         query=query,
         limit=int(body.get("limit", 10)),
-        dataset=body.get("dataset", "shared"),
+        dataset=dataset,
         tags=body.get("tags") or [],
         before=body.get("before"),
         after=body.get("after"),
@@ -240,18 +339,41 @@ async def memory_search(request: Request) -> dict[str, Any]:
 @router.get("/list")
 async def memory_list(
     request: Request,
-    dataset: str = "shared",
+    dataset: str | None = None,
     cursor: str | None = None,
     limit: int = 50,
 ) -> dict[str, Any]:
-    """Paginated list. Returns ``{items: [...], next_cursor: str | null}``."""
+    """Paginated list. Returns ``{items: [...], next_cursor: str | null}``.
+
+    Identity rules mirror ``/search``: ``X-hal0-Private: 1`` with no
+    explicit ``?dataset=`` resolves to the caller's own private bucket
+    so the ``hal0 agent memory list`` CLI subcommand can enumerate
+    per-agent items without the operator passing the namespace by hand.
+    """
+    agent_id = _agent_id(request)
+    private = _is_private(request)
+    try:
+        resolved = resolve_write_dataset(
+            dataset,
+            private=private,
+            client_id=agent_id if agent_id != "anonymous" else None,
+        )
+    except MemoryNamespaceError as exc:
+        raise MemoryNamespaceInvalid(str(exc)) from exc
+
     wrapper = _wrapper(request)
-    return await wrapper.list_items(dataset=dataset, cursor=cursor, limit=limit)
+    return await wrapper.list_items(dataset=resolved, cursor=cursor, limit=limit)
 
 
 @router.post("/delete")
 async def memory_delete(request: Request) -> dict[str, int]:
-    """Delete by id. Body: ``{ids: [...]}``. Returns ``{deleted: int}``."""
+    """Delete by id. Body: ``{ids: [...]}``. Returns ``{deleted: int}``.
+
+    Identity headers are not consulted: id-scoped delete bypasses the
+    namespace surface entirely (the wrapper's audit log still stamps
+    the call with the agent identity for forensics — see
+    :meth:`CogneeWrapper._audit`).
+    """
     body = await _read_json_body(request)
     ids = body.get("ids")
     if not isinstance(ids, list) or not ids:
@@ -281,9 +403,11 @@ async def _read_json_body(request: Request) -> dict[str, Any]:
 
 
 __all__ = [
+    "DEFAULT_DATASET",
     "GraphUpstreamConfig",
     "MemoryGraphConfig",
     "MemoryGraphConfigInvalid",
+    "MemoryNamespaceInvalid",
     "MemoryUnavailable",
     "router",
 ]

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -17,6 +17,7 @@ this module is the thin HTTP veneer that:
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from fastapi import APIRouter, Request
@@ -48,6 +49,14 @@ _AGENT_HEADER = "x-hal0-agent"
 _PRIVATE_HEADER = "x-hal0-private"
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
 
+# ADR-0005 §5 security hardening: agent identity feeds the
+# ``private:<agent>`` dataset name AND the audit log's ``source``
+# field. We allow alnum + ``-`` + ``_`` only, up to 64 chars — keeps
+# the resolved namespace path-traversal-free, sql-quotable, and
+# bounded. Matches the convention used by other hal0 identity headers
+# (slot names, capability ids).
+_AGENT_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_\-]{1,64}$")
+
 
 class MemoryNamespaceInvalid(Hal0Error):
     """The caller's headers + body produced an unresolvable namespace.
@@ -61,17 +70,59 @@ class MemoryNamespaceInvalid(Hal0Error):
     status = 400
 
 
+class MemoryAgentIdInvalid(Hal0Error):
+    """The ``X-hal0-Agent`` header value failed the ADR-0005 §5
+    identity-shape check.
+
+    Distinct from :class:`MemoryNamespaceInvalid` so the dashboard
+    can render a focused message ("agent id must be alnum/-/_, ≤64
+    chars, no ``private:`` prefix") rather than a generic namespace
+    error.
+    """
+
+    code = "memory.agent_id_invalid"
+    status = 400
+
+
 def _agent_id(request: Request) -> str:
-    """Return the ``X-hal0-Agent`` value, or ``"anonymous"`` if absent.
+    """Return the validated ``X-hal0-Agent`` value or ``"anonymous"``.
 
     Mirrors :func:`hal0.api.mcp_mount.client_id_resolver` for the REST
     surface — both translate the absence of an identity header into the
     same sentinel so audit + dataset resolution stay consistent.
+
+    Validation (ADR-0005 §5 hardening, surfaced by PR #366 review):
+
+      - Empty / whitespace → ``"anonymous"`` (back-compat with
+        unauthenticated callers).
+      - Values starting with ``private:`` are REJECTED so a caller
+        cannot manufacture ``private:private:bob`` by smuggling the
+        prefix through the header. The ``private`` toggle is the
+        only path to the namespace.
+      - Values must match ``^[a-zA-Z0-9_\\-]{1,64}$`` — agent ids
+        flow into the Cognee dataset name + the audit log's
+        ``source`` field. Path-traversal candidates (``../etc``),
+        control chars, and over-long values are all rejected here.
     """
     raw = request.headers.get(_AGENT_HEADER)
-    if not raw:
+    if raw is None:
         return "anonymous"
-    return raw.strip() or "anonymous"
+    candidate = raw.strip()
+    if not candidate:
+        return "anonymous"
+    if candidate.startswith("private:"):
+        raise MemoryAgentIdInvalid(
+            "X-hal0-Agent must not be prefixed with 'private:' — the "
+            "private namespace is reached via X-hal0-Private: 1, not by "
+            "embedding the prefix in the identity header",
+            details={"header": "X-hal0-Agent"},
+        )
+    if not _AGENT_ID_PATTERN.match(candidate):
+        raise MemoryAgentIdInvalid(
+            "X-hal0-Agent must match [a-zA-Z0-9_-]{1,64}",
+            details={"header": "X-hal0-Agent"},
+        )
+    return candidate
 
 
 def _is_private(request: Request) -> bool:
@@ -405,6 +456,7 @@ async def _read_json_body(request: Request) -> dict[str, Any]:
 __all__ = [
     "DEFAULT_DATASET",
     "GraphUpstreamConfig",
+    "MemoryAgentIdInvalid",
     "MemoryGraphConfig",
     "MemoryGraphConfigInvalid",
     "MemoryNamespaceInvalid",

--- a/src/hal0/mcp/memory.py
+++ b/src/hal0/mcp/memory.py
@@ -66,6 +66,14 @@ from typing import Any
 
 import structlog
 
+from hal0.memory.namespace import (
+    DEFAULT_DATASET as _DEFAULT_DATASET,
+)
+from hal0.memory.namespace import (
+    MemoryNamespaceError,
+    resolve_write_dataset,
+)
+
 try:
     from mcp.server.fastmcp import FastMCP  # type: ignore[import-not-found]
     from mcp.types import ToolAnnotations  # type: ignore[import-not-found]
@@ -126,9 +134,11 @@ def _normalise_tags(value: Any) -> list[str]:
 
 
 # ── Namespace resolution (ADR-0005 §3) ───────────────────────────────────────
-
-
-_DEFAULT_DATASET = "shared"
+#
+# The actual rule lives in :mod:`hal0.memory.namespace` so the REST shims
+# in ``hal0.api.routes.memory`` apply the same logic (issue #317). This
+# wrapper preserves the MCP-side error type so dispatcher-level catches
+# don't have to learn a second exception class.
 
 
 def _resolve_dataset(
@@ -137,20 +147,13 @@ def _resolve_dataset(
     private: bool,
     client_id: str | None,
 ) -> str:
-    """Apply the namespace rule: default ``shared``; ``private`` promotes
-    the caller's writes to ``private:<client_id>``.
-
-    A caller may pass an explicit ``dataset=`` to override the default,
-    but the ``--private`` toggle wins: requesting ``private`` without a
-    client_id is an error (we can't promote without an identity).
-    """
-    if private:
-        if not client_id:
-            raise MemorySchemaError("private namespace requires an authenticated client_id")
-        return f"private:{client_id}"
-    if requested is None or not requested.strip():
-        return _DEFAULT_DATASET
-    return requested
+    """Thin shim around :func:`hal0.memory.namespace.resolve_write_dataset`
+    that re-raises ``MemoryNamespaceError`` as ``MemorySchemaError`` for
+    compatibility with existing MCP dispatcher error envelopes."""
+    try:
+        return resolve_write_dataset(requested, private=private, client_id=client_id)
+    except MemoryNamespaceError as exc:
+        raise MemorySchemaError(str(exc)) from exc
 
 
 def _iso_now() -> str:

--- a/src/hal0/memory/cognee_wrapper.py
+++ b/src/hal0/memory/cognee_wrapper.py
@@ -869,25 +869,33 @@ class CogneeWrapper:
     def _effective_write_dataset(self, requested: str) -> str:
         """Apply the §3 namespace rule to a write.
 
-        ``private_mode`` instances always promote to their own private
-        dataset, regardless of what the caller asks for — clients can't
-        smuggle private data into ``shared`` from a private instance,
-        and can't escape into ``shared`` either (the toggle is a
-        per-client posture, not a per-call switch).
+        Two postures:
 
-        Non-private instances accept ``shared`` (the default) or a
-        passthrough custom dataset; passing ``private:<other>`` from a
-        non-private instance is treated as a typo and quietly folded to
-        ``shared`` rather than letting a client write into another
-        client's namespace.
+          1. ``private_mode=True`` (per-client wrapper, the legacy
+             shape used by `tests/memory/`): the constructor pins the
+             effective dataset to ``private:<client_id>``; ANY
+             ``requested`` value here is promoted to it. Clients can't
+             smuggle private data into ``shared`` from a private
+             instance, and can't escape into ``shared`` either.
+
+          2. ``private_mode=False`` (singleton wrapper, the
+             production shape used by ``app.state.memory_wrapper`` —
+             see issue #367): identity already resolved by the
+             transport layer (REST / MCP) and stamped onto the
+             ``dataset`` string. If the caller passes
+             ``private:<x>``, persist VERBATIM — the REST/MCP layer
+             owns the cross-client guard (regex on agent id +
+             rejection of body ``private:*`` when the private toggle
+             is off). The wrapper used to collapse this to ``shared``,
+             which silently leaked every agent's "private" write into
+             the global bucket. ``shared`` + custom datasets still
+             pass through unchanged.
         """
         if self._private_mode:
             return self._write_dataset
-        if requested.startswith(PRIVATE_PREFIX):
-            # Non-private instance trying to address a private namespace
-            # by name. ADR-0005 §3 doesn't expose that path — collapse
-            # to shared.
-            return SHARED_DATASET
+        # Non-private wrapper: trust the resolved dataset string from
+        # the caller — REST + MCP enforce identity + reject hostile
+        # private:* values before this point (issue #367).
         return requested or SHARED_DATASET
 
     def _allowed_read_datasets(self, requested: str | list[str]) -> list[str]:

--- a/src/hal0/memory/namespace.py
+++ b/src/hal0/memory/namespace.py
@@ -52,6 +52,12 @@ def resolve_write_dataset(
       - ``private=True`` → ``private:<client_id>`` (raises if no
         ``client_id`` is available).
       - ``requested`` is ``None`` / empty → :data:`DEFAULT_DATASET`.
+      - ``requested`` starts with ``private:`` and ``private=False``
+        → ``MemoryNamespaceError``. PR #366 review hardening: a
+        non-private caller must not be able to address the private
+        namespace by passing the prefix in the body — the toggle is
+        the only path in. Surfaces as 400 at the transport layer
+        instead of silently being forwarded to the wrapper.
       - Otherwise the requested string is passed through verbatim.
     """
     if private:
@@ -60,6 +66,11 @@ def resolve_write_dataset(
         return f"{PRIVATE_PREFIX}{client_id}"
     if requested is None or not requested.strip():
         return DEFAULT_DATASET
+    if requested.startswith(PRIVATE_PREFIX):
+        raise MemoryNamespaceError(
+            "non-private callers cannot address the private namespace by name; "
+            "send X-hal0-Private: 1 (REST) or private=true (MCP) instead"
+        )
     return requested
 
 

--- a/src/hal0/memory/namespace.py
+++ b/src/hal0/memory/namespace.py
@@ -1,0 +1,101 @@
+"""ADR-0005 §3 namespace resolution — shared by the MCP + REST surfaces.
+
+The MCP server (:mod:`hal0.mcp.memory`) and the REST shims
+(:mod:`hal0.api.routes.memory`) both translate caller-supplied
+``dataset`` + identity context into the effective Cognee dataset name.
+Keeping that logic in one place ensures the two surfaces can't drift —
+issue #317 surfaced exactly that kind of drift, where the REST handler
+hardcoded ``"shared"`` while the MCP dispatcher correctly honored
+``private:<client_id>`` promotion.
+
+The rule (ADR-0005 §3):
+
+  - Writes default to ``"shared"``.
+  - Callers in "private mode" promote to ``private:<client_id>`` for
+    writes; ``--private`` wins over an explicit body ``dataset`` field
+    so a private-mode client can't smuggle data into ``shared``.
+  - Private-mode reads expand to ``[shared, private:<client_id>]`` so
+    a caller sees their own scoped items alongside the shared bucket
+    without having to opt in per-call.
+  - Requesting ``private`` without an authenticated ``client_id`` is
+    a usage error — the namespace promotion has no identity to scope to.
+
+This module is intentionally tiny: just two pure functions + the
+``MemoryNamespaceError`` sentinel. The wrapper-level enforcement
+(rejecting cross-client writes, intersecting read scopes) still lives
+in :mod:`hal0.memory.cognee_wrapper` — this layer is for transport-side
+resolution only.
+"""
+
+from __future__ import annotations
+
+DEFAULT_DATASET = "shared"
+PRIVATE_PREFIX = "private:"
+
+
+class MemoryNamespaceError(ValueError):
+    """Raised when namespace resolution can't be satisfied (e.g. private
+    requested without an authenticated client_id)."""
+
+
+def resolve_write_dataset(
+    requested: str | None,
+    *,
+    private: bool,
+    client_id: str | None,
+) -> str:
+    """Translate a write request into the effective Cognee dataset name.
+
+    Mirrors :func:`hal0.mcp.memory._resolve_dataset` (which delegates
+    here) — the docstring rule from ADR-0005 §3 applies:
+
+      - ``private=True`` → ``private:<client_id>`` (raises if no
+        ``client_id`` is available).
+      - ``requested`` is ``None`` / empty → :data:`DEFAULT_DATASET`.
+      - Otherwise the requested string is passed through verbatim.
+    """
+    if private:
+        if not client_id:
+            raise MemoryNamespaceError("private namespace requires an authenticated client_id")
+        return f"{PRIVATE_PREFIX}{client_id}"
+    if requested is None or not requested.strip():
+        return DEFAULT_DATASET
+    return requested
+
+
+def resolve_read_datasets(
+    requested: str | list[str] | None,
+    *,
+    private: bool,
+    client_id: str | None,
+) -> str | list[str]:
+    """Translate a read request into the effective dataset filter.
+
+    Mirrors the read branch from :func:`hal0.mcp.memory._memory_search`:
+
+      - ``requested`` already a list → pass through (caller knows what
+        they want; the wrapper still intersects against the read scope).
+      - ``requested`` empty/``None`` + ``private`` + ``client_id`` →
+        expand to ``[shared, private:<client_id>]`` per §3.
+      - ``requested`` empty/``None`` otherwise → :data:`DEFAULT_DATASET`.
+      - ``requested`` non-empty string → resolved via
+        :func:`resolve_write_dataset` (same rule applies; e.g. an explicit
+        ``shared`` from a private-mode client still gets promoted —
+        consistent with the write side).
+    """
+    if isinstance(requested, list):
+        return [str(d) for d in requested]
+    if requested is None or (isinstance(requested, str) and not requested.strip()):
+        if private and client_id:
+            return [DEFAULT_DATASET, f"{PRIVATE_PREFIX}{client_id}"]
+        return DEFAULT_DATASET
+    return resolve_write_dataset(requested, private=private, client_id=client_id)
+
+
+__all__ = [
+    "DEFAULT_DATASET",
+    "PRIVATE_PREFIX",
+    "MemoryNamespaceError",
+    "resolve_read_datasets",
+    "resolve_write_dataset",
+]

--- a/tests/api/test_memory_rest_routes.py
+++ b/tests/api/test_memory_rest_routes.py
@@ -1,0 +1,294 @@
+"""Integration tests for the REST shims under ``/api/memory/{add,search,list,delete}``.
+
+Issue #317: ``/api/memory/add`` used to hardcode ``dataset`` to ``"shared"``
+and to ignore the ``X-hal0-Agent`` + ``X-hal0-Private`` identity headers
+that the dashboard, Hermes bootstrap, and ``hal0 agent`` CLI all send.
+This test module pins the post-fix contract:
+
+  - ``X-hal0-Agent`` is the post-ADR-0012 identity header (no Bearer).
+  - ``X-hal0-Private: 1`` promotes writes to ``private:<agent>`` and
+    expands reads to ``[shared, private:<agent>]`` per ADR-0005 §3.
+  - An explicit ``dataset`` in the body wins over the default but the
+    ``--private`` toggle still wins over both (writes are forced into
+    the caller's private namespace — clients can't smuggle data into
+    ``shared`` while in private mode).
+  - ``source`` on ``add`` is server-injected from the agent header so
+    callers cannot lie about their identity (ADR-0005 §5).
+
+Uses a duck-typed ``StubWrapper`` mirroring :class:`CogneeWrapper`'s
+public surface — same pattern as ``tests/api/test_memory_graph_route``
+and ``tests/mcp/test_memory``. The point here is the *route* behavior,
+not the wrapper; the wrapper has its own coverage under ``tests/memory/``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api.middleware import error_codes
+from hal0.api.routes import memory as memory_routes
+
+
+class StubWrapper:
+    """Duck-typed stand-in for :class:`CogneeWrapper`.
+
+    Captures every ``add`` / ``search`` / ``list_items`` / ``delete``
+    call so tests can assert the route forwarded the resolved dataset
+    + server-injected source without spinning up Cognee.
+    """
+
+    def __init__(self) -> None:
+        self.add_calls: list[dict[str, Any]] = []
+        self.search_calls: list[dict[str, Any]] = []
+        self.list_calls: list[dict[str, Any]] = []
+        self.delete_calls: list[dict[str, Any]] = []
+        self._counter = 0
+
+    async def add(
+        self,
+        *,
+        text: str,
+        dataset: str,
+        tags: list[str],
+        source: str | None,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.add_calls.append(
+            {
+                "text": text,
+                "dataset": dataset,
+                "tags": tags,
+                "source": source,
+                "metadata": metadata,
+            }
+        )
+        self._counter += 1
+        return {"id": f"id-{self._counter}", "timestamp": "2026-05-28T00:00:00Z"}
+
+    async def search(self, **kwargs: Any) -> list[dict[str, Any]]:
+        self.search_calls.append(kwargs)
+        return [{"id": "id-1", "text": "stub", "score": 0.9}]
+
+    async def list_items(self, **kwargs: Any) -> dict[str, Any]:
+        self.list_calls.append(kwargs)
+        return {"items": [{"id": "id-1"}], "next_cursor": None}
+
+    async def delete(self, *, ids: list[str]) -> dict[str, Any]:
+        self.delete_calls.append({"ids": list(ids)})
+        return {"deleted": len(ids)}
+
+
+@pytest.fixture
+def stub_wrapper() -> StubWrapper:
+    return StubWrapper()
+
+
+def _build_app(stub: StubWrapper) -> FastAPI:
+    app = FastAPI()
+    error_codes.install(app)
+    app.include_router(memory_routes.router, prefix="/api/memory", tags=["memory"])
+    app.state.memory_wrapper = stub
+    return app
+
+
+@pytest.fixture
+def client(stub_wrapper: StubWrapper) -> Iterator[TestClient]:
+    app = _build_app(stub_wrapper)
+    with TestClient(app) as c:
+        yield c
+
+
+# ── /api/memory/add ────────────────────────────────────────────────────────
+
+
+def test_add_default_writes_to_shared_no_headers(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """No identity headers → behaves like the old default: shared dataset,
+    anonymous source. Backwards-compatibility guard."""
+    r = client.post("/api/memory/add", json={"text": "hello"})
+    assert r.status_code == 200, r.text
+    call = stub_wrapper.add_calls[0]
+    assert call["dataset"] == "shared"
+    assert call["source"] == "anonymous"
+    assert call["tags"] == []
+    assert call["metadata"] == {}
+
+
+def test_add_private_header_promotes_dataset_to_caller_namespace(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """``X-hal0-Agent: hermes-agent`` + ``X-hal0-Private: 1`` → writes
+    land under ``private:hermes-agent`` (issue #317 main repro)."""
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "probe", "tags": ["probe"]},
+        headers={"X-hal0-Agent": "hermes-agent", "X-hal0-Private": "1"},
+    )
+    assert r.status_code == 200, r.text
+    call = stub_wrapper.add_calls[0]
+    assert call["dataset"] == "private:hermes-agent"
+    # ADR-0005 §5 — source is server-injected from the agent header.
+    assert call["source"] == "hermes-agent"
+
+
+def test_add_explicit_private_dataset_passthrough(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """Explicit ``dataset=private:hermes-agent`` body field is honored
+    when the agent header matches — mirrors the MCP ``dataset`` arg."""
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "probe", "dataset": "private:hermes-agent"},
+        headers={"X-hal0-Agent": "hermes-agent", "X-hal0-Private": "1"},
+    )
+    assert r.status_code == 200, r.text
+    call = stub_wrapper.add_calls[0]
+    assert call["dataset"] == "private:hermes-agent"
+
+
+def test_add_private_mode_wins_over_body_dataset(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """A caller in ``--private`` mode cannot escape into ``shared`` by
+    passing ``dataset="shared"`` in the body — the toggle is a posture,
+    not a per-call switch (ADR-0005 §3, mirrors MCP behavior)."""
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "secret", "dataset": "shared"},
+        headers={"X-hal0-Agent": "hermes-agent", "X-hal0-Private": "1"},
+    )
+    assert r.status_code == 200, r.text
+    call = stub_wrapper.add_calls[0]
+    assert call["dataset"] == "private:hermes-agent"
+
+
+def test_add_custom_dataset_passthrough_no_private(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """Non-private callers can address custom datasets (e.g. the
+    Hermes bootstrap ``agents`` dataset) explicitly."""
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "ident card", "dataset": "agents"},
+        headers={"X-hal0-Agent": "hermes-agent"},
+    )
+    assert r.status_code == 200, r.text
+    call = stub_wrapper.add_calls[0]
+    assert call["dataset"] == "agents"
+    assert call["source"] == "hermes-agent"
+
+
+def test_add_private_without_agent_header_rejected(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """``X-hal0-Private: 1`` without ``X-hal0-Agent`` cannot promote —
+    refuse rather than silently writing to ``private:anonymous``."""
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "probe"},
+        headers={"X-hal0-Private": "1"},
+    )
+    assert r.status_code >= 400
+    assert stub_wrapper.add_calls == []
+
+
+def test_add_caller_supplied_source_rejected(client: TestClient, stub_wrapper: StubWrapper) -> None:
+    """Mirror ADR-0005 §5: ``source`` is server-injected — clients
+    cannot supply it (would otherwise let a compromised agent claim
+    another agent's identity in the audit trail)."""
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "x", "source": "fake-agent"},
+        headers={"X-hal0-Agent": "hermes-agent"},
+    )
+    assert r.status_code >= 400
+    assert stub_wrapper.add_calls == []
+
+
+# ── /api/memory/search ─────────────────────────────────────────────────────
+
+
+def test_search_private_mode_expands_to_both_namespaces(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """Private-mode read sees ``[shared, private:<agent>]`` per
+    ADR-0005 §3 — mirrors :func:`hal0.mcp.memory._memory_search`."""
+    r = client.post(
+        "/api/memory/search",
+        json={"query": "probe"},
+        headers={"X-hal0-Agent": "hermes-agent", "X-hal0-Private": "1"},
+    )
+    assert r.status_code == 200, r.text
+    call = stub_wrapper.search_calls[0]
+    assert call["dataset"] == ["shared", "private:hermes-agent"]
+
+
+def test_search_explicit_private_dataset(client: TestClient, stub_wrapper: StubWrapper) -> None:
+    """Explicit ``dataset=private:hermes-agent`` flows through; the
+    REST handler does not collapse the namespace before passing to the
+    wrapper (the wrapper enforces cross-client read isolation)."""
+    r = client.post(
+        "/api/memory/search",
+        json={"query": "probe", "dataset": "private:hermes-agent"},
+        headers={"X-hal0-Agent": "hermes-agent", "X-hal0-Private": "1"},
+    )
+    assert r.status_code == 200, r.text
+    call = stub_wrapper.search_calls[0]
+    assert call["dataset"] == "private:hermes-agent"
+
+
+def test_search_default_no_headers_is_shared(client: TestClient, stub_wrapper: StubWrapper) -> None:
+    """No identity headers → default to ``shared`` (back-compat)."""
+    r = client.post("/api/memory/search", json={"query": "probe"})
+    assert r.status_code == 200, r.text
+    call = stub_wrapper.search_calls[0]
+    assert call["dataset"] == "shared"
+
+
+# ── /api/memory/list ───────────────────────────────────────────────────────
+
+
+def test_list_private_mode_targets_own_namespace(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """List with ``X-hal0-Private: 1`` resolves to the caller's own
+    private bucket — required for the ``hal0 agent`` CLI ``memory list``
+    subcommand to enumerate per-agent items."""
+    r = client.get(
+        "/api/memory/list",
+        headers={"X-hal0-Agent": "hermes-agent", "X-hal0-Private": "1"},
+    )
+    assert r.status_code == 200, r.text
+    call = stub_wrapper.list_calls[0]
+    assert call["dataset"] == "private:hermes-agent"
+
+
+def test_list_explicit_dataset_query_param(client: TestClient, stub_wrapper: StubWrapper) -> None:
+    """The ``?dataset=`` query param still wins for non-private listers."""
+    r = client.get("/api/memory/list?dataset=agents")
+    assert r.status_code == 200, r.text
+    call = stub_wrapper.list_calls[0]
+    assert call["dataset"] == "agents"
+
+
+# ── /api/memory/delete ─────────────────────────────────────────────────────
+
+
+def test_delete_passes_ids_unchanged(client: TestClient, stub_wrapper: StubWrapper) -> None:
+    """Delete is by id and doesn't touch the namespace surface, but
+    we sanity-pin that the route forwards ids verbatim regardless of
+    identity headers."""
+    r = client.post(
+        "/api/memory/delete",
+        json={"ids": ["a", "b"]},
+        headers={"X-hal0-Agent": "hermes-agent", "X-hal0-Private": "1"},
+    )
+    assert r.status_code == 200, r.text
+    assert stub_wrapper.delete_calls == [{"ids": ["a", "b"]}]
+    assert r.json() == {"deleted": 2}

--- a/tests/api/test_memory_rest_routes.py
+++ b/tests/api/test_memory_rest_routes.py
@@ -292,3 +292,135 @@ def test_delete_passes_ids_unchanged(client: TestClient, stub_wrapper: StubWrapp
     assert r.status_code == 200, r.text
     assert stub_wrapper.delete_calls == [{"ids": ["a", "b"]}]
     assert r.json() == {"deleted": 2}
+
+
+# ── PR #366 review hardening (closes #317 + #367) ──────────────────────────
+#
+# Six new contract pins surfaced by the request-changes review. The
+# first cluster (path traversal, ``private:`` prefix in the agent
+# header) covers the ADR-0005 §5 identity-shape audit findings; the
+# second (body ``dataset="private:other"`` with ``private=False``)
+# covers the namespace-resolver hardening; the third (list endpoint
+# without an agent header) mirrors the existing ``/add`` contract on
+# the read surface.
+
+
+def test_add_agent_header_path_traversal_rejected(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """``X-hal0-Agent: ../etc/passwd`` is rejected at 400 — the agent
+    id feeds the Cognee dataset name + the audit log's ``source`` field,
+    so path-traversal candidates must never reach the wrapper."""
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "x"},
+        headers={"X-hal0-Agent": "../etc/passwd"},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "memory.agent_id_invalid"
+    assert stub_wrapper.add_calls == []
+
+
+def test_add_agent_header_private_prefix_rejected(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """``X-hal0-Agent: private:bob`` is rejected — would otherwise
+    manufacture a ``private:private:bob`` dataset when X-hal0-Private
+    is set. The private namespace is reachable only via the toggle."""
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "x"},
+        headers={"X-hal0-Agent": "private:bob"},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "memory.agent_id_invalid"
+    assert stub_wrapper.add_calls == []
+
+
+def test_add_agent_header_with_colon_variant_rejected(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """Colon in agent id (e.g. ``hermes-agent:1``) is rejected by the
+    ``[a-zA-Z0-9_-]{1,64}`` regex — even non-``private:`` colons cannot
+    flow through because they'd corrupt the dataset string."""
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "x"},
+        headers={"X-hal0-Agent": "hermes-agent:1"},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "memory.agent_id_invalid"
+    assert stub_wrapper.add_calls == []
+
+
+def test_add_body_private_dataset_without_private_header_rejected(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """Body ``dataset=private:other`` with no ``X-hal0-Private`` is
+    rejected — non-private callers cannot address the private namespace
+    by name. The toggle is the only path to ``private:<x>``."""
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "x", "dataset": "private:other"},
+        headers={"X-hal0-Agent": "hermes-agent"},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "memory.namespace_invalid"
+    assert stub_wrapper.add_calls == []
+
+
+def test_list_private_without_agent_header_rejected(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """``X-hal0-Private: 1`` on ``/list`` without an agent header is
+    rejected — mirrors :func:`test_add_private_without_agent_header_rejected`
+    on the read surface so callers get a consistent 400 across CRUD."""
+    r = client.get(
+        "/api/memory/list",
+        headers={"X-hal0-Private": "1"},
+    )
+    assert r.status_code >= 400, r.text
+    assert stub_wrapper.list_calls == []
+
+
+def test_cross_client_private_writes_not_visible_to_other_agents(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """Agent A writes private; Agent B reads without private headers and
+    does NOT see A's private rows.
+
+    Two layers of containment under test:
+      1. The REST handler does not forward A's ``private:A`` dataset to
+         B's default read (B's resolved dataset is ``"shared"``).
+      2. The wrapper search call captured for B contains only ``shared``
+         — no leakage of A's namespace through the route surface.
+
+    The wrapper-level enforcement (own-private intersection) is covered
+    in ``tests/memory/test_cognee_wrapper.py``. This test pins that the
+    REST veneer doesn't undo it.
+    """
+    # Agent A writes private.
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "A's secret"},
+        headers={"X-hal0-Agent": "agent-a", "X-hal0-Private": "1"},
+    )
+    assert r.status_code == 200, r.text
+    assert stub_wrapper.add_calls[0]["dataset"] == "private:agent-a"
+
+    # Agent B searches without the private header.
+    r2 = client.post(
+        "/api/memory/search",
+        json={"query": "secret"},
+        headers={"X-hal0-Agent": "agent-b"},
+    )
+    assert r2.status_code == 200, r2.text
+    # Agent B's resolved read scope is just ``shared`` — the route does
+    # not unilaterally union in any other agent's private namespace.
+    search_call = stub_wrapper.search_calls[-1]
+    assert search_call["dataset"] == "shared"
+    assert "private:agent-a" not in (
+        search_call["dataset"]
+        if isinstance(search_call["dataset"], list)
+        else [search_call["dataset"]]
+    )

--- a/tests/memory/test_namespace_wrapper.py
+++ b/tests/memory/test_namespace_wrapper.py
@@ -1,0 +1,171 @@
+"""Wrapper-level namespace tests — fast, no Cognee init.
+
+PR #366 review found that the singleton ``app.state.memory_wrapper``
+(``client_id="anonymous"``, ``private_mode=False``) collapsed
+``private:<x>`` writes to ``shared`` inside ``_effective_write_dataset``.
+That broke #317's REST fix end-to-end: the route resolved the right
+dataset, the wrapper threw it away.
+
+These tests pin the post-fix contract without standing up Cognee +
+LanceDB + Kuzu — we bypass ``__init__`` so the fixtures stay sub-millisecond
+and live in the default (non-``slow``) suite where CI runs them on every PR.
+
+Issue #367 is the long-form discussion of the fix.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from hal0.memory.cognee_wrapper import (
+    PRIVATE_PREFIX,
+    SHARED_DATASET,
+    CogneeWrapper,
+)
+
+
+def _bare_wrapper(*, client_id: str, private_mode: bool) -> CogneeWrapper:
+    """Return a ``CogneeWrapper`` with only the fields ``_effective_write_dataset``
+    needs — skips ``__init__`` so we don't touch Cognee or the sidecar.
+
+    Tests that exercise the full ``add`` path (with the real Cognee
+    backend) live in ``test_cognee_wrapper.py`` and are gated by
+    ``@pytest.mark.slow``.
+    """
+    w = object.__new__(CogneeWrapper)
+    w._client_id = client_id  # type: ignore[attr-defined]
+    w._private_mode = private_mode  # type: ignore[attr-defined]
+    w._write_dataset = (  # type: ignore[attr-defined]
+        f"{PRIVATE_PREFIX}{client_id}" if private_mode else SHARED_DATASET
+    )
+    return w
+
+
+# ── Non-private singleton wrapper (the production shape, #367) ─────────────
+
+
+def test_effective_write_dataset_passthrough_shared() -> None:
+    """Non-private wrapper, body asks for ``shared`` → ``shared``."""
+    w = _bare_wrapper(client_id="anonymous", private_mode=False)
+    assert w._effective_write_dataset(SHARED_DATASET) == SHARED_DATASET
+
+
+def test_effective_write_dataset_passthrough_custom() -> None:
+    """Non-private wrapper, body asks for a custom dataset (e.g.
+    ``agents``) → unchanged."""
+    w = _bare_wrapper(client_id="anonymous", private_mode=False)
+    assert w._effective_write_dataset("agents") == "agents"
+
+
+def test_effective_write_dataset_persists_private_for_singleton() -> None:
+    """Non-private wrapper, body carries ``private:hermes-agent``
+    (resolved upstream by REST/MCP from headers) → persisted verbatim.
+
+    Pre-#367 this collapsed to ``shared`` and silently leaked every
+    agent's "private" write into the global bucket.
+    """
+    w = _bare_wrapper(client_id="anonymous", private_mode=False)
+    assert w._effective_write_dataset("private:hermes-agent") == "private:hermes-agent"
+
+
+def test_effective_write_dataset_empty_falls_back_to_shared() -> None:
+    """Non-private wrapper, empty requested → ``shared`` default."""
+    w = _bare_wrapper(client_id="anonymous", private_mode=False)
+    assert w._effective_write_dataset("") == SHARED_DATASET
+
+
+# ── Private wrapper (legacy per-client shape — still works) ────────────────
+
+
+def test_effective_write_dataset_private_mode_pins_to_own_namespace() -> None:
+    """``private_mode=True`` wrapper, any body value → caller's own
+    namespace. Smuggling ``shared`` doesn't escape.
+    """
+    w = _bare_wrapper(client_id="alice", private_mode=True)
+    assert w._effective_write_dataset(SHARED_DATASET) == "private:alice"
+    assert w._effective_write_dataset("private:bob") == "private:alice"
+    assert w._effective_write_dataset("agents") == "private:alice"
+
+
+# ── End-to-end add() routes resolved dataset to cognee ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_add_forwards_resolved_private_dataset_to_cognee(tmp_path: Any) -> None:
+    """The full ``add`` path passes ``dataset="private:hermes-agent"``
+    through to ``cognee.add`` instead of folding to ``shared``.
+
+    Patches ``cognee.add`` + the chunk/embed pipeline so we only assert
+    that the wrapper hands the resolved dataset to the engine. Sidecar
+    SQLite write still lands so the same row is queryable via
+    ``list_items`` (covered by the slow suite).
+    """
+    captured: dict[str, Any] = {}
+
+    class _StubAddResult:
+        dataset_id = "stub-ds-id"
+
+    async def _fake_add(*args: Any, **kwargs: Any) -> _StubAddResult:
+        # cognee.add(texts, dataset_name=..., node_set=...)
+        captured["dataset_name"] = kwargs.get("dataset_name")
+        captured["node_set"] = kwargs.get("node_set")
+        return _StubAddResult()
+
+    async def _fake_chunk_and_embed(self: Any, dataset: str) -> None:
+        captured.setdefault("embed_datasets", []).append(dataset)
+
+    async def _fake_latest_data_id(self: Any, dataset_name: str) -> str | None:
+        return None
+
+    # Stub the cognee module before construction so _configure_cognee
+    # doesn't try to wire LanceDB + Kuzu.
+    class _FakeConfig:
+        def system_root_directory(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        def data_root_directory(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        def set_vector_db_provider(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        def set_graph_database_provider(self, *a: Any, **kw: Any) -> None:
+            pass
+
+        def set_embedding_provider(self, *a: Any, **kw: Any) -> None:
+            pass
+
+    class _FakeCognee:
+        config = _FakeConfig()
+
+        @staticmethod
+        async def add(*args: Any, **kwargs: Any) -> _StubAddResult:
+            return await _fake_add(*args, **kwargs)
+
+    with (
+        patch("hal0.memory.cognee_wrapper._cognee", return_value=_FakeCognee),
+        patch("hal0.memory.cognee_wrapper._clear_cognee_caches", return_value=None),
+        patch.object(CogneeWrapper, "_chunk_and_embed", _fake_chunk_and_embed),
+        patch.object(CogneeWrapper, "_latest_cognee_data_id", _fake_latest_data_id),
+    ):
+        w = CogneeWrapper(
+            cognee_dir=tmp_path / "cognee",
+            client_id="anonymous",
+            private_mode=False,
+        )
+        out = await w.add(
+            text="probe",
+            dataset="private:hermes-agent",
+            tags=[],
+            source="hermes-agent",
+            metadata={},
+        )
+
+    assert "id" in out
+    # ✅ The contract: dataset_name reaching cognee.add is the
+    # resolved string, NOT "shared".
+    assert captured["dataset_name"] == "private:hermes-agent"
+    assert captured["embed_datasets"] == ["private:hermes-agent"]


### PR DESCRIPTION
Closes #317, #367.

## Summary

This PR now closes both halves of the private-namespace bug in one merge:

- **#317 (REST contract)** — the REST shims under `/api/memory/{add,search,list}` honor `X-hal0-Agent` + `X-hal0-Private` headers and route through the shared `hal0.memory.namespace` resolver so they cannot drift from the MCP dispatcher again.
- **#367 (wrapper collapse)** — the singleton `CogneeWrapper` (`client_id="anonymous"`, `private_mode=False`) no longer flattens `private:<x>` writes to `shared`. The REST + MCP layers own identity resolution; the wrapper persists the resolved dataset string verbatim. Without this half, merging #317 alone created a regression window where the route promised private and the wrapper silently leaked to the shared bucket.

Folded the review's medium findings (path traversal, `private:` prefix in agent header, body `dataset="private:other"` from non-private callers) into the same change so the security envelope ships atomically.

## Commits

1. `refactor(memory)`: extract `_resolve_dataset` into `hal0.memory.namespace`; rewire MCP dispatcher. Pure refactor.
2. `fix(memory)`: REST handlers consume identity headers + route through the shared resolver; `source` injection rejected.
3. `fix(memory)`: wrapper-level private namespace + identity hardening (this turn). Closes #367 and addresses the medium findings from review.

## Changes by file

- `src/hal0/memory/cognee_wrapper.py` — `_effective_write_dataset` on a non-private wrapper persists `private:<x>` verbatim (was: collapsed to `shared`). Private-mode wrapper unchanged.
- `src/hal0/memory/namespace.py` — `resolve_write_dataset` raises `MemoryNamespaceError` on body `dataset="private:..."` when `private=False`. Non-private callers cannot address the private namespace by name.
- `src/hal0/api/routes/memory.py` — `_agent_id` validates `X-hal0-Agent` against `^[a-zA-Z0-9_-]{1,64}$` and rejects values starting with `private:`. New typed error `MemoryAgentIdInvalid` (code `memory.agent_id_invalid`, 400).

## Test plan

- [x] `tests/api/test_memory_rest_routes.py` — 19 cases (was 13). New: path-traversal in agent header, `private:` prefix in agent header, colon variant in agent header, body `private:other` without `X-hal0-Private`, `/list` private without agent header, cross-client read leakage.
- [x] `tests/memory/test_namespace_wrapper.py` (new) — fast (non-slow) unit + stubbed-cognee coverage of `_effective_write_dataset` across both postures; pins that `cognee.add` receives the resolved dataset string, not `"shared"`.
- [x] `tests/mcp/test_memory.py` still green (16/16) — the MCP `_resolve_dataset` shim re-raises the new `MemoryNamespaceError` as `MemorySchemaError`, no test churn.
- [x] Non-slow `tests/api/ tests/mcp/ tests/memory/` sweep — `478 passed, 3 skipped` locally.
- [x] `ruff check src tests` — clean.
- [x] `ruff format --check src tests` — clean.
- [ ] LXC smoke against a live `/api/memory` once merged — verifies the wrapper-level write path end-to-end (the `hal0 agent bootstrap hermes` `memory_roundtrip` smoke is the acceptance trigger from #317).

## Follow-ups

- An integration test that runs against a real `CogneeWrapper` (not the StubWrapper) would close the LXC-smoke gap in CI; the natural home is the bootstrap-smoke roundtrip and it's worth its own issue when that surface is next touched.