### PR TITLE
feat(dash,mcp): wire /mcp install/uninstall/config + real audit stream (closes #305 #224 #222)

### DIFF
--- a/src/hal0/api/routes/mcp.py
+++ b/src/hal0/api/routes/mcp.py
@@ -1,31 +1,30 @@
-"""MCP introspection routes (mounted under ``/api/mcp``).
+"""MCP introspection + lifecycle routes (mounted under ``/api/mcp``).
 
-Issue #206 — wires the v3 dashboard's ``/agents/mcp`` page to the live
-backend. Surfaces a read-only view of the MCP servers hal0 hosts (the
-two bundled servers built by :mod:`hal0.mcp.admin` + :mod:`hal0.mcp.memory`),
-the clients currently using them (derived from the ``hal0.mcp.audit``
-journald stream), a static catalog of installable MCPs, and a Server-
-Sent-Events tail of tool invocations.
-
-Out of scope (ADR-0013 ``mcp_client.py`` work):
-  - install / uninstall / restart / config-write — these stub with 501
-    so the dashboard can render the toast hint without the routes being
-    absent. The actual lifecycle work owns a separate follow-up PR.
+Issue #206 wired the v3 dashboard's ``/agents/mcp`` page to the live
+backend; issue #305 swaps the 501 stubs for real install / uninstall /
+config-patch handlers backed by :mod:`hal0.mcp.installed` + the
+manifest resolver in :mod:`hal0.mcp.manifest`.
 
 Endpoints
 ---------
 
 ::
 
-    GET  /api/mcp/servers            — list hosted MCP servers
-    GET  /api/mcp/clients            — connected clients (audit-derived)
-    GET  /api/mcp/catalog            — installable MCPs (static)
-    GET  /api/mcp/stream             — SSE of mcp.tool.* events
-    GET  /api/mcp/{id}/logs          — recent audit rows for one server
-    POST /api/mcp/install            — 501 (ADR-0013 follow-up)
-    DELETE /api/mcp/{id}             — 501 (ADR-0013 follow-up)
-    POST /api/mcp/{id}/{action}      — 501 (ADR-0013 follow-up)
-    PATCH /api/mcp/{id}/config       — 501 (ADR-0013 follow-up)
+    GET    /api/mcp/servers            — list hosted MCP servers (bundled + installed)
+    GET    /api/mcp/clients            — connected clients (audit-derived)
+    GET    /api/mcp/catalog            — installable MCPs (static)
+    GET    /api/mcp/resolve            — manifest preview from a URL/spec (#224)
+    GET    /api/mcp/stream             — SSE of mcp.tool.* events
+    GET    /api/mcp/{id}/logs          — recent audit rows for one server
+    POST   /api/mcp/install            — install from a resolved spec/URL (#305)
+    DELETE /api/mcp/{id}               — uninstall a user-installed server (#305)
+    PATCH  /api/mcp/{id}/config        — write env / enabled overrides (#305)
+    POST   /api/mcp/{id}/{action}      — start/stop/restart — stubs 501
+                                          pending the supervisor follow-up.
+
+Bundled servers (``hal0-admin``, ``hal0-memory``) are uninstall-protected;
+the route returns ``409 mcp.bundled`` rather than letting the registry
+file system shadow the in-process FastMCP mount.
 """
 
 from __future__ import annotations
@@ -42,20 +41,23 @@ from fastapi import APIRouter, Query, Request
 from fastapi.responses import StreamingResponse
 
 from hal0 import __version__
-from hal0.errors import Hal0Error
+from hal0.errors import BadRequest, Conflict, Hal0Error
+from hal0.mcp import installed as installed_registry
+from hal0.mcp import manifest as manifest_resolver
 
 router = APIRouter()
 
 
-# ── 501 sentinel ─────────────────────────────────────────────────────────────
+# ── Action-stub sentinel ─────────────────────────────────────────────────────
 
 
 class McpNotImplemented(Hal0Error):
-    """Lifecycle mutations stub here until ADR-0013 lands.
+    """``POST /{id}/{action}`` still stubs here.
 
-    The dashboard surfaces a toast when these endpoints reply 501 — see
-    ``ui/src/api/hooks/useMcp.ts``. The error code is stable so the
-    toast text can branch on it instead of the (more brittle) message.
+    Install / uninstall / config-patch landed in #305; start / stop /
+    restart need the still-pending process-supervisor layer. The
+    dashboard surfaces a distinct toast on this code so operators can
+    tell ``install`` (works) from ``restart`` (not yet) apart.
     """
 
     code = "mcp.not_implemented"
@@ -80,6 +82,7 @@ _CATALOG: list[dict[str, Any]] = [
         "tools": 9,
         "stars": 2840,
         "category": "browser",
+        "spec": "npm:@modelcontextprotocol/server-puppeteer",
     },
     {
         "id": "sqlite",
@@ -90,6 +93,7 @@ _CATALOG: list[dict[str, Any]] = [
         "tools": 4,
         "stars": 1820,
         "category": "data",
+        "spec": "npm:@modelcontextprotocol/server-sqlite",
     },
     {
         "id": "gdrive",
@@ -100,6 +104,7 @@ _CATALOG: list[dict[str, Any]] = [
         "tools": 6,
         "stars": 1410,
         "category": "files",
+        "spec": "npm:@modelcontextprotocol/server-gdrive",
     },
     {
         "id": "slack",
@@ -110,6 +115,7 @@ _CATALOG: list[dict[str, Any]] = [
         "tools": 8,
         "stars": 990,
         "category": "comms",
+        "spec": "npm:@modelcontextprotocol/server-slack",
     },
     {
         "id": "linear",
@@ -120,6 +126,7 @@ _CATALOG: list[dict[str, Any]] = [
         "tools": 14,
         "stars": 720,
         "category": "issues",
+        "spec": "npm:@linear/mcp-server",
     },
     {
         "id": "exa-search",
@@ -130,6 +137,7 @@ _CATALOG: list[dict[str, Any]] = [
         "tools": 3,
         "stars": 540,
         "category": "search",
+        "spec": "npm:exa-mcp-server",
     },
     {
         "id": "homeassistant",
@@ -140,6 +148,7 @@ _CATALOG: list[dict[str, Any]] = [
         "tools": 11,
         "stars": 480,
         "category": "iot",
+        "spec": "npm:homeassistant-mcp",
     },
     {
         "id": "kubernetes",
@@ -150,6 +159,7 @@ _CATALOG: list[dict[str, Any]] = [
         "tools": 16,
         "stars": 920,
         "category": "ops",
+        "spec": "npm:mcp-server-kubernetes",
     },
     {
         "id": "todoist",
@@ -160,6 +170,7 @@ _CATALOG: list[dict[str, Any]] = [
         "tools": 6,
         "stars": 240,
         "category": "productivity",
+        "spec": "npm:todoist-mcp",
     },
 ]
 
@@ -338,6 +349,7 @@ async def list_servers(request: Request) -> dict[str, Any]:
     audit = await _read_audit_events(limit=500)
 
     items: list[dict[str, Any]] = []
+    # ── Bundled servers (live FastMCP introspection) ─────────────────────────
     for sid, server in servers_state.items():
         # SDK contract: ``list_tools/resources/prompts`` are async on
         # FastMCP. Wrap each in a try-block so a misbehaving server
@@ -387,6 +399,48 @@ async def list_servers(request: Request) -> dict[str, Any]:
                 "connected": connected,
                 "description": f"hal0 bundled {sid} MCP server (FastMCP, streamable-http).",
                 "provider": "hal0",
+            }
+        )
+
+    # ── User-installed servers (registry-derived) ────────────────────────────
+    #
+    # No supervisor yet (#305 ships the registry; supervision follows in a
+    # tracked issue). The route reports each installed server as
+    # ``state="stopped"`` so the dashboard renders it in the list +
+    # offers the config / uninstall affordances; the Start button is the
+    # action-stub 501 path that surfaces the "pending supervisor" toast.
+    for record in installed_registry.list_installed():
+        items.append(
+            {
+                "id": record.id,
+                "name": record.name,
+                "bundled": False,
+                # No supervisor yet → installed servers always start stopped;
+                # ``enabled`` is the operator's intent for when the supervisor
+                # arrives, not the current process state.
+                "state": "stopped",
+                "transport": record.transport,
+                "connect_url": _connect_url(request, record.id),
+                "pid": None,
+                "version": "0.0.0",
+                "tools": record.tools,
+                "resources": record.resources,
+                "prompts": record.prompts,
+                "activity": {"rpm": _activity_rpm(audit, record.id)},
+                "connected": sorted(
+                    {
+                        e["client_id"]
+                        for e in audit
+                        if e["client_id"] and e.get("server") == record.id
+                    }
+                ),
+                "description": record.description,
+                "provider": record.author,
+                "spec": record.spec,
+                "source_url": record.source_url,
+                "env": record.env,
+                "enabled": record.enabled,
+                "installed_at": record.installed_at,
             }
         )
 
@@ -584,40 +638,155 @@ async def server_logs(
     return {"server": server_id, "events": events, "count": len(events)}
 
 
-# ── 501 stubs (ADR-0013 follow-up) ──────────────────────────────────────────
+# ── Manifest resolve (#224) ─────────────────────────────────────────────────
 
 
-@router.post("/install")
-async def install_server(body: dict[str, Any]) -> dict[str, Any]:
-    """Stub — install/uninstall lifecycle lives in ADR-0013's mcp_client.py work."""
-    raise McpNotImplemented(
-        "MCP install pending ADR-0013 follow-up (#206)",
-        details={"requested": body},
+@router.get("/resolve")
+async def resolve_manifest(
+    request: Request,
+    url: str = Query(..., min_length=1, max_length=2048),
+) -> dict[str, Any]:
+    """Resolve a paste-box URL/spec to a manifest preview.
+
+    The InstallDrawer calls this once on paste to fill its preview card;
+    if the user clicks Install, the same URL/spec is replayed against
+    ``POST /api/mcp/install`` which re-resolves (so a manifest that
+    changed between paste + install still gets the latest data).
+
+    A test-only fetcher can be injected via
+    ``request.app.state.mcp_manifest_fetcher`` — production leaves that
+    attribute unset and the resolver builds its own httpx client.
+    """
+    fetcher = getattr(request.app.state, "mcp_manifest_fetcher", None)
+    resolved = await manifest_resolver.resolve(url, fetcher=fetcher)
+    return resolved.model_dump(mode="python")
+
+
+# ── Install / uninstall / patch (#305) ──────────────────────────────────────
+
+
+@router.post("/install", status_code=201)
+async def install_server(request: Request, body: dict[str, Any]) -> dict[str, Any]:
+    """Install a user MCP server from a URL / spec.
+
+    Body shape (one of)::
+
+        {"url": "oci://…", ...}      — re-resolve via the manifest layer
+        {"manifest": {...}}          — pre-resolved manifest (round-tripped
+                                       from /api/mcp/resolve)
+
+    Either path produces an :class:`InstalledServer` record on disk;
+    bundled-id collisions return 409 ``mcp.id_reserved``; an already-
+    installed id returns 409 ``mcp.already_installed``.
+
+    The dashboard normally pastes the URL, gets a preview, and on
+    Install posts ``{"url": "<spec>"}``. The ``manifest`` form covers
+    the case where the operator edited the preview before installing.
+    """
+    if not isinstance(body, dict):
+        raise BadRequest("install body must be a JSON object", code="mcp.body_invalid")
+
+    manifest_dict = body.get("manifest")
+    if isinstance(manifest_dict, dict):
+        try:
+            resolved = manifest_resolver.ResolvedManifest.model_validate(manifest_dict)
+        except Exception as exc:
+            raise BadRequest(
+                "invalid manifest body",
+                code="mcp.manifest_invalid",
+                details={"reason": str(exc)},
+            ) from exc
+    else:
+        url = body.get("url") or body.get("spec")
+        if not isinstance(url, str) or not url.strip():
+            raise BadRequest(
+                "install body must include 'url' (or 'manifest')",
+                code="mcp.url_required",
+            )
+        fetcher = getattr(request.app.state, "mcp_manifest_fetcher", None)
+        resolved = await manifest_resolver.resolve(url, fetcher=fetcher)
+
+    record = installed_registry.InstalledServer(
+        id=resolved.id,
+        name=resolved.name,
+        description=resolved.description,
+        spec=resolved.spec,
+        transport=resolved.transport,
+        tools=resolved.tools,
+        resources=resolved.resources,
+        prompts=resolved.prompts,
+        env={k: "" for k in resolved.env_required},
+        enabled=True,
+        source_url=resolved.source_url,
+        author=resolved.author,
+        verified=resolved.verified,
     )
+    stored = installed_registry.install(record)
+    return {"installed": stored.model_dump(mode="python")}
 
 
 @router.delete("/{server_id}")
 async def uninstall_server(server_id: str) -> dict[str, Any]:
-    """Stub — uninstall ships with ADR-0013."""
-    raise McpNotImplemented(
-        "MCP uninstall pending ADR-0013 follow-up (#206)",
-        details={"server_id": server_id},
-    )
+    """Remove a user-installed MCP server. Bundled servers reject 409.
 
-
-@router.post("/{server_id}/{action}")
-async def server_action(server_id: str, action: str) -> dict[str, Any]:
-    """Stub — restart / start / stop ship with ADR-0013."""
-    raise McpNotImplemented(
-        f"MCP {action!r} pending ADR-0013 follow-up (#206)",
-        details={"server_id": server_id, "action": action},
-    )
+    The route validates the id charset before the bundled check so a
+    request with garbage doesn't leak ``mcp.id_reserved`` for inputs
+    that wouldn't have matched anything.
+    """
+    if server_id in installed_registry.BUNDLED_SERVER_IDS:
+        raise Conflict(
+            f"server {server_id!r} is bundled — cannot uninstall",
+            code="mcp.bundled",
+            details={"server_id": server_id},
+        )
+    installed_registry.uninstall(server_id)
+    return {"uninstalled": server_id}
 
 
 @router.patch("/{server_id}/config")
 async def patch_server_config(server_id: str, body: dict[str, Any]) -> dict[str, Any]:
-    """Stub — config write lands with ADR-0013."""
+    """Patch the env / enabled fields of an installed server.
+
+    The InstallDrawer's EditConfigModal posts ``{"env": {...}}`` (full
+    intended env block — the route replaces, not deltas) and optionally
+    ``{"enabled": bool}``. Bundled servers reject 409.
+    """
+    if server_id in installed_registry.BUNDLED_SERVER_IDS:
+        raise Conflict(
+            f"server {server_id!r} is bundled — config is read-only here",
+            code="mcp.bundled",
+            details={"server_id": server_id},
+        )
+    if not isinstance(body, dict):
+        raise BadRequest("patch body must be a JSON object", code="mcp.body_invalid")
+    env_block: dict[str, str] | None = None
+    raw_env = body.get("env")
+    if raw_env is not None:
+        if not isinstance(raw_env, dict):
+            raise BadRequest(
+                "'env' must be an object mapping name → value",
+                code="mcp.env_invalid",
+            )
+        env_block = {str(k): str(v) for k, v in raw_env.items()}
+    enabled = body.get("enabled")
+    if enabled is not None and not isinstance(enabled, bool):
+        raise BadRequest("'enabled' must be a boolean", code="mcp.enabled_invalid")
+    updated = installed_registry.patch_config(server_id, env=env_block, enabled=enabled)
+    return {"server": updated.model_dump(mode="python")}
+
+
+# ── Action stub (start/stop/restart — supervisor follow-up) ─────────────────
+
+
+@router.post("/{server_id}/{action}")
+async def server_action(server_id: str, action: str) -> dict[str, Any]:
+    """Start / stop / restart — stubbed pending the process supervisor.
+
+    The installed-server registry (#305) doesn't yet drive a supervisor;
+    that's a tracked follow-up. The dashboard surfaces a distinct toast
+    for this 501 vs the (now-real) install/uninstall path.
+    """
     raise McpNotImplemented(
-        "MCP config patch pending ADR-0013 follow-up (#206)",
-        details={"server_id": server_id, "patch": body},
+        f"MCP {action!r} pending the process-supervisor follow-up to #305",
+        details={"server_id": server_id, "action": action},
     )

--- a/src/hal0/mcp/installed.py
+++ b/src/hal0/mcp/installed.py
@@ -1,0 +1,273 @@
+"""Registry for hal0-hosted, user-installed MCP servers (issue #305).
+
+Bundled MCP servers (hal0-admin, hal0-memory) are baked into the
+orchestrator at start-up via :mod:`hal0.api.mcp_mount`; this module
+covers the other half — user-installed MCP servers that the dashboard's
+`/agents/mcp` page can install / uninstall / configure at runtime.
+
+Scope (v0.3 alpha)
+------------------
+
+* Persist installed-server records as one TOML file per server under
+  ``/etc/hal0/mcp-servers/<id>.toml`` — mirrors the slot/upstream/agent
+  layout so users get a single mental model.
+* Provide list / add / remove / patch helpers the FastAPI route layer
+  calls through.
+* No process supervision yet — that lives in a follow-up ADR (see
+  ADR-0013 §6 "Bootstrap path"). Installed servers report
+  ``state="stopped"`` in :func:`hal0.api.routes.mcp.list_servers` until
+  the supervisor ships.
+
+The on-disk schema is intentionally small + permissive: the dashboard's
+preview shape (manifest fetch in :mod:`hal0.mcp.manifest`) is the
+source-of-truth for tool counts + descriptions, this file just records
+what the operator chose to install + their per-server env overrides.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import tomllib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import structlog
+from pydantic import BaseModel, Field, ValidationError
+
+from hal0.config import paths as cfg_paths
+from hal0.config.loader import write_toml_atomic
+from hal0.errors import BadRequest, Conflict, NotFound
+
+log = structlog.get_logger(__name__)
+
+
+# Bundled mounts that can't be uninstalled via this registry. The FastAPI
+# route layer guards against deletion + the registry itself never lists
+# them; this set is exposed for the route's bundled-rejection branch.
+BUNDLED_SERVER_IDS = frozenset({"hal0-admin", "hal0-memory"})
+
+
+# ── Schema ──────────────────────────────────────────────────────────────────
+
+
+class InstalledServer(BaseModel):
+    """One user-installed MCP server's on-disk record.
+
+    The shape is intentionally close to the prototype's catalog row so
+    the dashboard can render an installed entry alongside a catalog one
+    without a translation layer.
+    """
+
+    id: str = Field(..., min_length=1, max_length=64)
+    name: str = Field(..., min_length=1, max_length=128)
+    description: str = Field(default="")
+    spec: str = Field(..., min_length=1)
+    """Install spec — ``oci://``, ``npm:``, ``uvx:``, ``git+https://``, or
+    a manifest URL. Stored verbatim so a future re-install / upgrade
+    path can rerun the resolver."""
+    transport: str = Field(default="stdio")
+    """``stdio`` or ``streamable-http``. ``stdio`` covers the most
+    common path (npx/uvx packages) — the supervisor follow-up will
+    actually honour this field."""
+    tools: int = Field(default=0, ge=0, le=4096)
+    resources: int = Field(default=0, ge=0)
+    prompts: int = Field(default=0, ge=0)
+    env: dict[str, str] = Field(default_factory=dict)
+    enabled: bool = Field(default=True)
+    installed_at: str = Field(default="")
+    """ISO-8601 UTC timestamp set on first write."""
+    source_url: str | None = Field(default=None)
+    """The manifest URL the install was resolved against, when applicable."""
+    author: str = Field(default="user")
+    verified: bool = Field(default=False)
+
+    def to_toml_dict(self) -> dict[str, Any]:
+        """Serialise to a tomli_w-compatible dict (drops None values)."""
+        d = self.model_dump(mode="python")
+        return {k: v for k, v in d.items() if v is not None}
+
+
+# ── Registry surface ────────────────────────────────────────────────────────
+
+
+def _registry_dir() -> Path:
+    """Return ``/etc/hal0/mcp-servers/`` (or the HAL0_HOME-rooted equiv).
+
+    Created on first write — list operations tolerate the directory not
+    existing yet, so a fresh install reports zero installed servers
+    without an error.
+    """
+    return cfg_paths.etc() / "mcp-servers"
+
+
+def _registry_path(server_id: str) -> Path:
+    return _registry_dir() / f"{server_id}.toml"
+
+
+_ID_OK = set("abcdefghijklmnopqrstuvwxyz0123456789-_")
+
+
+def _validate_id(server_id: str) -> None:
+    """Enforce a tight id charset.
+
+    The id becomes a filename + a URL path segment; restricting it
+    saves us from quoting both call sites. Bundled-server ids are
+    rejected up-front so an install can't shadow ``hal0-admin``.
+    """
+    if not server_id:
+        raise BadRequest("server id is required", code="mcp.id_required")
+    if len(server_id) > 64:
+        raise BadRequest("server id too long (max 64)", code="mcp.id_too_long")
+    bad = [c for c in server_id if c not in _ID_OK]
+    if bad:
+        raise BadRequest(
+            "server id may contain only [a-z0-9_-]",
+            code="mcp.id_invalid",
+            details={"id": server_id, "bad_chars": sorted(set(bad))},
+        )
+    if server_id in BUNDLED_SERVER_IDS:
+        raise Conflict(
+            f"server id {server_id!r} is reserved for a bundled server",
+            code="mcp.id_reserved",
+        )
+
+
+def list_installed() -> list[InstalledServer]:
+    """Return every installed-server record, sorted by id.
+
+    Missing dir → empty list. A malformed record is logged + skipped
+    rather than crashing the dashboard — operators see the bad row
+    via the journal, the rest of the page keeps working.
+    """
+    root = _registry_dir()
+    if not root.exists():
+        return []
+    rows: list[InstalledServer] = []
+    for p in sorted(root.glob("*.toml")):
+        try:
+            with p.open("rb") as f:
+                raw = tomllib.load(f)
+            rows.append(InstalledServer.model_validate(raw))
+        except (OSError, tomllib.TOMLDecodeError, ValidationError) as exc:
+            log.warning(
+                "hal0.mcp.installed.bad_record",
+                path=str(p),
+                error=str(exc),
+            )
+    return rows
+
+
+def get_installed(server_id: str) -> InstalledServer:
+    """Return one installed-server record. Raises :class:`NotFound`."""
+    _validate_id(server_id)
+    path = _registry_path(server_id)
+    if not path.exists():
+        raise NotFound(
+            f"MCP server {server_id!r} not installed",
+            code="mcp.not_found",
+            details={"server_id": server_id},
+        )
+    try:
+        with path.open("rb") as f:
+            raw = tomllib.load(f)
+        return InstalledServer.model_validate(raw)
+    except (OSError, tomllib.TOMLDecodeError, ValidationError) as exc:
+        raise BadRequest(
+            f"installed-server record at {path} is malformed",
+            code="mcp.record_malformed",
+            details={"server_id": server_id, "reason": str(exc)},
+        ) from exc
+
+
+def install(record: InstalledServer) -> InstalledServer:
+    """Write a new installed-server record. Raises :class:`Conflict` on dup.
+
+    The caller is expected to have populated the record from a
+    manifest fetch (:mod:`hal0.mcp.manifest`) or a hand-rolled spec —
+    we don't re-resolve here, that's a separate route concern.
+    """
+    _validate_id(record.id)
+    path = _registry_path(record.id)
+    if path.exists():
+        raise Conflict(
+            f"MCP server {record.id!r} is already installed",
+            code="mcp.already_installed",
+            details={"server_id": record.id},
+        )
+    # Stamp installed_at if the caller didn't pre-fill it.
+    if not record.installed_at:
+        record = record.model_copy(update={"installed_at": datetime.now(tz=UTC).isoformat()})
+    write_toml_atomic(path, record.to_toml_dict())
+    log.info(
+        "hal0.mcp.installed.added",
+        server_id=record.id,
+        spec=record.spec,
+        transport=record.transport,
+    )
+    return record
+
+
+def uninstall(server_id: str) -> None:
+    """Remove the installed-server record. Raises :class:`NotFound`.
+
+    Bundled servers can't be uninstalled — :func:`_validate_id` rejects
+    those ids before the disk lookup. Tolerates the file disappearing
+    between the existence check and the unlink (race) — the operation
+    is still considered successful.
+    """
+    _validate_id(server_id)
+    path = _registry_path(server_id)
+    if not path.exists():
+        raise NotFound(
+            f"MCP server {server_id!r} not installed",
+            code="mcp.not_found",
+            details={"server_id": server_id},
+        )
+    with contextlib.suppress(FileNotFoundError):
+        path.unlink()
+    log.info("hal0.mcp.installed.removed", server_id=server_id)
+
+
+def patch_config(
+    server_id: str,
+    *,
+    env: dict[str, str] | None = None,
+    enabled: bool | None = None,
+) -> InstalledServer:
+    """Merge env / enabled overrides into a registry record.
+
+    Replaces the record's ``env`` dict wholesale when supplied (a TOML
+    file holds a single per-server env block, so the route layer always
+    sends the full intended set, not a delta). ``enabled`` flips the
+    flag without touching anything else.
+    """
+    record = get_installed(server_id)
+    updates: dict[str, Any] = {}
+    if env is not None:
+        # Coerce values to strings — pydantic validates the type but the
+        # FastAPI body is permissive (numbers, bools, etc).
+        updates["env"] = {k: str(v) for k, v in env.items()}
+    if enabled is not None:
+        updates["enabled"] = bool(enabled)
+    if not updates:
+        return record
+    next_record = record.model_copy(update=updates)
+    write_toml_atomic(_registry_path(server_id), next_record.to_toml_dict())
+    log.info(
+        "hal0.mcp.installed.patched",
+        server_id=server_id,
+        fields=sorted(updates.keys()),
+    )
+    return next_record
+
+
+__all__ = [
+    "BUNDLED_SERVER_IDS",
+    "InstalledServer",
+    "get_installed",
+    "install",
+    "list_installed",
+    "patch_config",
+    "uninstall",
+]

--- a/src/hal0/mcp/installed.py
+++ b/src/hal0/mcp/installed.py
@@ -27,6 +27,7 @@ what the operator chose to install + their per-server env overrides.
 from __future__ import annotations
 
 import contextlib
+import os
 import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
@@ -103,6 +104,31 @@ def _registry_dir() -> Path:
 
 def _registry_path(server_id: str) -> Path:
     return _registry_dir() / f"{server_id}.toml"
+
+
+# Restrictive perms: TOML files contain the per-server ``env`` block, which
+# is the canonical home for API keys for community MCP servers. Default
+# umask (022) would leave them world-readable; we narrow both the directory
+# and individual files explicitly after write.
+_REGISTRY_DIR_MODE = 0o700
+_REGISTRY_FILE_MODE = 0o600
+
+
+def _harden_registry_perms(path: Path) -> None:
+    """Tighten perms on the registry dir + a single record file.
+
+    Called immediately after :func:`write_toml_atomic` so a record's env
+    block (API keys) isn't world-readable even briefly. Uses chmod rather
+    than passing a mode to mkdir because write_toml_atomic also creates
+    the directory under default umask.
+    """
+    parent = path.parent
+    with contextlib.suppress(OSError):
+        parent.mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(OSError):
+        os.chmod(parent, _REGISTRY_DIR_MODE)
+    with contextlib.suppress(OSError):
+        os.chmod(path, _REGISTRY_FILE_MODE)
 
 
 _ID_OK = set("abcdefghijklmnopqrstuvwxyz0123456789-_")
@@ -199,6 +225,7 @@ def install(record: InstalledServer) -> InstalledServer:
     if not record.installed_at:
         record = record.model_copy(update={"installed_at": datetime.now(tz=UTC).isoformat()})
     write_toml_atomic(path, record.to_toml_dict())
+    _harden_registry_perms(path)
     log.info(
         "hal0.mcp.installed.added",
         server_id=record.id,
@@ -253,7 +280,9 @@ def patch_config(
     if not updates:
         return record
     next_record = record.model_copy(update=updates)
-    write_toml_atomic(_registry_path(server_id), next_record.to_toml_dict())
+    target_path = _registry_path(server_id)
+    write_toml_atomic(target_path, next_record.to_toml_dict())
+    _harden_registry_perms(target_path)
     log.info(
         "hal0.mcp.installed.patched",
         server_id=server_id,

--- a/src/hal0/mcp/manifest.py
+++ b/src/hal0/mcp/manifest.py
@@ -33,9 +33,12 @@ render *something* for any plausibly-shaped paste.
 
 from __future__ import annotations
 
+import ipaddress
 import re
+import socket
 from collections.abc import Awaitable, Callable
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
 import structlog
@@ -60,6 +63,105 @@ _HTTP_RE = re.compile(r"^https?://[^\s]+$")
 # unbounded download via a content-length lie.
 _MAX_MANIFEST_BYTES = 256 * 1024
 _FETCH_TIMEOUT = httpx.Timeout(connect=4.0, read=6.0, write=2.0, pool=6.0)
+
+
+# ── SSRF guard ──────────────────────────────────────────────────────────────
+#
+# The manifest fetcher is reachable through ``GET /api/mcp/resolve?url=…``
+# with no auth on the LAN (ADR-0012). Without a guard, an unauthenticated
+# caller can use hal0 as a blind probe against the LAN, IMDS, and loopback.
+# We enforce a deny-list at the URL/IP layer and refuse to follow redirects
+# (a 30x to a private host would otherwise bypass the pre-flight check).
+
+
+class SsrfBlockedError(BadRequest):
+    """The manifest URL resolves to a non-public address — refuse to fetch."""
+
+    code = "mcp.ssrf_blocked"
+    status = 400
+
+
+def _ip_is_safe(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Reject loopback, private, link-local, unspecified, and CGNAT space.
+
+    Mirrors the standard library's ``is_*`` classifiers plus an explicit
+    carrier-grade NAT (100.64.0.0/10) reject — Python's ``is_private``
+    already covers RFC 1918 + ULA + loopback + link-local on both
+    families, but CGNAT only landed in 3.13's ``is_global`` semantics,
+    so we check it explicitly to stay compatible across versions.
+    """
+    if ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_unspecified:
+        return False
+    if ip.is_multicast or ip.is_reserved:
+        return False
+    # Carrier-grade NAT (RFC 6598). is_private in newer Python versions
+    # includes this, but be explicit for portability.
+    return not (
+        isinstance(ip, ipaddress.IPv4Address) and ip in ipaddress.IPv4Network("100.64.0.0/10")
+    )
+
+
+def _is_safe_url(url: str) -> bool:
+    """Return True only when ``url`` resolves entirely to public addresses.
+
+    Steps:
+
+    1. Parse the URL. Reject anything without an http(s) scheme + host.
+    2. Reject ``*.local`` mDNS hostnames before DNS lookup — most
+       resolvers happily answer them from the LAN.
+    3. Resolve the hostname via ``socket.getaddrinfo`` and reject if
+       *any* resolved address is in deny space (avoids DNS-rebinding
+       single-A-record tricks where one of N IPs is private).
+    4. If the host is already a literal IP, classify it directly.
+    """
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return False
+    scheme = (parts.scheme or "").lower()
+    if scheme not in {"http", "https"}:
+        return False
+    host = parts.hostname
+    if not host:
+        return False
+    low = host.lower()
+    # mDNS / multicast DNS hostnames — never let these through.
+    if low == "localhost" or low.endswith(".local"):
+        return False
+
+    # If the host parsed as an IP literal, classify it directly. urlsplit
+    # exposes the unbracketed form for IPv6 via .hostname.
+    try:
+        literal = ipaddress.ip_address(low)
+    except ValueError:
+        literal = None
+    if literal is not None:
+        return _ip_is_safe(literal)
+
+    # DNS lookup. Any resolved address in deny space → reject.
+    try:
+        infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except socket.gaierror:
+        return False
+    for info in infos:
+        sockaddr = info[4]
+        try:
+            ip = ipaddress.ip_address(sockaddr[0])
+        except (ValueError, IndexError):
+            return False
+        if not _ip_is_safe(ip):
+            return False
+    return True
+
+
+def _enforce_safe_url(url: str) -> None:
+    """Raise :class:`SsrfBlockedError` when the URL fails the SSRF guard."""
+    if not _is_safe_url(url):
+        raise SsrfBlockedError(
+            "refusing to fetch a non-public URL",
+            code="mcp.ssrf_blocked",
+            details={"url": url},
+        )
 
 
 # ── Schema ──────────────────────────────────────────────────────────────────
@@ -115,7 +217,9 @@ def _slug(text: str) -> str:
 
 def _resolve_oci(url: str) -> ResolvedManifest:
     m = _OCI_RE.match(url)
-    assert m is not None  # caller has already matched
+    if m is None:  # defensive — caller has already matched, but assert
+        # was stripped under ``python -O`` so we raise a typed error.
+        raise BadRequest(f"invalid oci spec: {url}", code="mcp.spec_unsupported")
     rest = m.group("rest")
     # Take the last path segment, drop the tag for the name.
     last = rest.rsplit("/", 1)[-1]
@@ -133,7 +237,8 @@ def _resolve_oci(url: str) -> ResolvedManifest:
 
 def _resolve_npm(url: str) -> ResolvedManifest:
     m = _NPM_RE.match(url)
-    assert m is not None
+    if m is None:
+        raise BadRequest(f"invalid npm spec: {url}", code="mcp.spec_unsupported")
     pkg = m.group("pkg")
     # Drop the scope (@foo/) for the visible name.
     visible = pkg.split("/", 1)[-1] if pkg.startswith("@") else pkg
@@ -149,7 +254,8 @@ def _resolve_npm(url: str) -> ResolvedManifest:
 
 def _resolve_uvx(url: str) -> ResolvedManifest:
     m = _UV_RE.match(url)
-    assert m is not None
+    if m is None:
+        raise BadRequest(f"invalid uvx spec: {url}", code="mcp.spec_unsupported")
     pkg = m.group("pkg")
     return ResolvedManifest(
         id=_slug(pkg),
@@ -163,7 +269,8 @@ def _resolve_uvx(url: str) -> ResolvedManifest:
 
 def _resolve_git(url: str) -> ResolvedManifest:
     m = _GIT_RE.match(url)
-    assert m is not None
+    if m is None:
+        raise BadRequest(f"invalid git spec: {url}", code="mcp.spec_unsupported")
     repo_url = m.group("url")
     # Last path segment as the visible name.
     last = repo_url.rstrip("/").rsplit("/", 1)[-1]
@@ -255,7 +362,9 @@ def _coerce_int(value: Any) -> int:
         except ValueError:
             return 0
     if isinstance(value, list):
-        return len(value)
+        # Cap at the schema's pydantic upper bound (le=4096) so a manifest
+        # with a runaway tool list doesn't trip a 500 in validation.
+        return min(len(value), 4096)
     return 0
 
 
@@ -263,8 +372,15 @@ def _coerce_int(value: Any) -> int:
 
 
 async def _default_fetcher(url: str) -> Any:
-    """Production fetcher — bounded body size + JSON decode."""
-    async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT, follow_redirects=True) as client:
+    """Production fetcher — SSRF-guarded, bounded body, JSON decoded.
+
+    Redirects are intentionally NOT followed: a 30x to a private host
+    would bypass the pre-flight :func:`_enforce_safe_url` check. If a
+    legitimate manifest sits behind a redirect, the caller can paste the
+    final URL directly.
+    """
+    _enforce_safe_url(url)
+    async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT, follow_redirects=False) as client:
         resp = await client.get(url, headers={"Accept": "application/json"})
         resp.raise_for_status()
         # Bound body size so a misbehaving server can't stuff us.
@@ -310,6 +426,12 @@ async def resolve(url: str, *, fetcher: HttpFetcher | None = None) -> ResolvedMa
     if _GIT_RE.match(url):
         return _resolve_git(url)
     if _HTTP_RE.match(url):
+        # SSRF guard: enforce here as well as inside _default_fetcher so a
+        # test-injected fetcher (or any future caller path) still gets the
+        # pre-flight check. Skipped when the caller injects a fetcher — the
+        # test surface relies on synthesised hosts like example.com.
+        if fetcher is None:
+            _enforce_safe_url(url)
         return await _resolve_http(url, fetcher)
 
     raise BadRequest(
@@ -322,5 +444,6 @@ async def resolve(url: str, *, fetcher: HttpFetcher | None = None) -> ResolvedMa
 __all__ = [
     "HttpFetcher",
     "ResolvedManifest",
+    "SsrfBlockedError",
     "resolve",
 ]

--- a/src/hal0/mcp/manifest.py
+++ b/src/hal0/mcp/manifest.py
@@ -1,0 +1,326 @@
+"""Manifest resolution for MCP install-from-URL (issue #224).
+
+When the dashboard's InstallDrawer paste-box receives a URL or package
+spec, this module produces a :class:`ResolvedManifest` the route layer
+can hand back to the UI for preview + use as the basis for a new
+:class:`hal0.mcp.installed.InstalledServer` record.
+
+Supported spec shapes
+---------------------
+
+``oci://ghcr.io/org/img:tag``
+    OCI container reference — synthesised manifest (no manifest fetch
+    over the wire yet; metadata not in the OCI ref defaults to empty).
+
+``npm:@scope/pkg`` / ``npx:pkg``
+    npm package — synthesised manifest derived from the package name.
+
+``uvx:pkg`` / ``uv:pkg``
+    Python package via uvx — synthesised manifest derived from name.
+
+``git+https://github.com/owner/repo[.git]``
+    Git repository — synthesised manifest derived from repo name.
+
+``https://…/manifest.json`` (or any http(s) URL)
+    Live manifest fetch — JSON with fields ``{name, description, tools,
+    transport, resources, prompts, env}`` (subset).
+
+This file deliberately tolerates partial manifests: every field except
+``id`` + ``name`` falls back to a safe default, because the network
+side of the MCP ecosystem is heterogeneous and the dashboard needs to
+render *something* for any plausibly-shaped paste.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import httpx
+import structlog
+from pydantic import BaseModel, Field
+
+from hal0.errors import BadRequest
+
+# Type alias for a manifest fetcher — async callable taking a URL,
+# returning the parsed JSON (or any payload). Tests inject one.
+HttpFetcher = Callable[[str], Awaitable[Any]]
+
+log = structlog.get_logger(__name__)
+
+
+_OCI_RE = re.compile(r"^oci://(?P<rest>.+)$")
+_NPM_RE = re.compile(r"^(?:npm|npx):(?P<pkg>@?[A-Za-z0-9_/.\-]+)$")
+_UV_RE = re.compile(r"^(?:uvx|uv):(?P<pkg>[A-Za-z0-9_./\-]+)$")
+_GIT_RE = re.compile(r"^git\+(?P<url>https?://[A-Za-z0-9_./\-:%@]+?)(?:\.git)?/?$")
+_HTTP_RE = re.compile(r"^https?://[^\s]+$")
+
+# Maximum response body size we'll accept — protects against an
+# unbounded download via a content-length lie.
+_MAX_MANIFEST_BYTES = 256 * 1024
+_FETCH_TIMEOUT = httpx.Timeout(connect=4.0, read=6.0, write=2.0, pool=6.0)
+
+
+# ── Schema ──────────────────────────────────────────────────────────────────
+
+
+class ResolvedManifest(BaseModel):
+    """Manifest preview surfaced to the InstallDrawer.
+
+    The dashboard reads ``name``, ``description``, ``tools``, plus the
+    truthiness of ``env_required`` to render the install card. The full
+    record is round-tripped to the install POST so the route can build
+    an :class:`hal0.mcp.installed.InstalledServer` without re-resolving.
+    """
+
+    id: str = Field(..., min_length=1, max_length=64)
+    name: str = Field(..., min_length=1)
+    description: str = Field(default="")
+    spec: str = Field(..., min_length=1)
+    transport: str = Field(default="stdio")
+    tools: int = Field(default=0, ge=0, le=4096)
+    resources: int = Field(default=0, ge=0)
+    prompts: int = Field(default=0, ge=0)
+    env_required: list[str] = Field(default_factory=list)
+    source_kind: str = Field(default="url")
+    """One of ``"oci"``, ``"npm"``, ``"uvx"``, ``"git"``, ``"manifest"``,
+    ``"http"`` — drives the preview's "via …" sub-label."""
+    source_url: str | None = Field(default=None)
+    """Original URL when the manifest came from an HTTP fetch."""
+    author: str = Field(default="user")
+    verified: bool = Field(default=False)
+
+
+# ── ID slugging ─────────────────────────────────────────────────────────────
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9_-]+")
+
+
+def _slug(text: str) -> str:
+    """Lowercase + collapse non-id chars to ``-``. Trim to <= 64.
+
+    The InstallDrawer's preview shows the slug so the operator can
+    spot collisions before clicking Install. Empty inputs fall back to
+    ``"mcp"`` so callers always get a non-empty id.
+    """
+    out = _SLUG_RE.sub("-", text.lower()).strip("-")
+    out = re.sub(r"-+", "-", out)
+    return (out or "mcp")[:64]
+
+
+# ── Resolvers ───────────────────────────────────────────────────────────────
+
+
+def _resolve_oci(url: str) -> ResolvedManifest:
+    m = _OCI_RE.match(url)
+    assert m is not None  # caller has already matched
+    rest = m.group("rest")
+    # Take the last path segment, drop the tag for the name.
+    last = rest.rsplit("/", 1)[-1]
+    name = last.split(":", 1)[0] or "mcp"
+    return ResolvedManifest(
+        id=_slug(name),
+        name=name,
+        description=f"OCI image {rest}",
+        spec=url,
+        transport="streamable-http",
+        tools=0,
+        source_kind="oci",
+    )
+
+
+def _resolve_npm(url: str) -> ResolvedManifest:
+    m = _NPM_RE.match(url)
+    assert m is not None
+    pkg = m.group("pkg")
+    # Drop the scope (@foo/) for the visible name.
+    visible = pkg.split("/", 1)[-1] if pkg.startswith("@") else pkg
+    return ResolvedManifest(
+        id=_slug(visible),
+        name=visible,
+        description=f"npm package {pkg}",
+        spec=url,
+        transport="stdio",
+        source_kind="npm",
+    )
+
+
+def _resolve_uvx(url: str) -> ResolvedManifest:
+    m = _UV_RE.match(url)
+    assert m is not None
+    pkg = m.group("pkg")
+    return ResolvedManifest(
+        id=_slug(pkg),
+        name=pkg,
+        description=f"uvx package {pkg}",
+        spec=url,
+        transport="stdio",
+        source_kind="uvx",
+    )
+
+
+def _resolve_git(url: str) -> ResolvedManifest:
+    m = _GIT_RE.match(url)
+    assert m is not None
+    repo_url = m.group("url")
+    # Last path segment as the visible name.
+    last = repo_url.rstrip("/").rsplit("/", 1)[-1]
+    return ResolvedManifest(
+        id=_slug(last),
+        name=last or "mcp",
+        description=f"git repo {repo_url}",
+        spec=url,
+        transport="stdio",
+        source_kind="git",
+    )
+
+
+async def _resolve_http(url: str, fetcher: HttpFetcher | None) -> ResolvedManifest:
+    """Fetch + parse a JSON manifest from an HTTP(s) URL.
+
+    Caller can inject ``fetcher`` for tests; production passes None and
+    we use a default httpx client.
+    """
+    fetch = fetcher or _default_fetcher
+    try:
+        payload = await fetch(url)
+    except httpx.HTTPError as exc:
+        raise BadRequest(
+            f"could not fetch MCP manifest from {url}",
+            code="mcp.manifest_fetch_failed",
+            details={"url": url, "reason": str(exc)},
+        ) from exc
+    if not isinstance(payload, dict):
+        # Not a JSON object — treat the URL as a bare spec.
+        last = url.rstrip("/").rsplit("/", 1)[-1]
+        name = re.sub(r"\.(json|yaml|yml)$", "", last) or "mcp"
+        return ResolvedManifest(
+            id=_slug(name),
+            name=name,
+            description=f"manifest at {url}",
+            spec=url,
+            transport="stdio",
+            source_kind="http",
+            source_url=url,
+        )
+    name = str(payload.get("name") or "").strip() or _slug_from_url(url)
+    description = str(payload.get("description") or "").strip()
+    transport = str(payload.get("transport") or "stdio").strip() or "stdio"
+    tools = _coerce_int(payload.get("tools"))
+    resources = _coerce_int(payload.get("resources"))
+    prompts = _coerce_int(payload.get("prompts"))
+    env_required: list[str] = []
+    env_block = payload.get("env")
+    if isinstance(env_block, dict):
+        env_required = [str(k) for k in env_block]
+    elif isinstance(env_block, list):
+        env_required = [str(x) for x in env_block if isinstance(x, str)]
+    return ResolvedManifest(
+        id=_slug(name),
+        name=name,
+        description=description,
+        spec=url,
+        transport=transport,
+        tools=tools,
+        resources=resources,
+        prompts=prompts,
+        env_required=env_required,
+        source_kind="manifest",
+        source_url=url,
+    )
+
+
+def _slug_from_url(url: str) -> str:
+    last = url.rstrip("/").rsplit("/", 1)[-1]
+    base = re.sub(r"\.(json|yaml|yml)$", "", last) or "mcp"
+    return _slug(base)
+
+
+def _coerce_int(value: Any) -> int:
+    """Best-effort int coercion. Drops non-numeric values to 0.
+
+    Manifests in the wild vary — ``tools`` shows up as ``int``, ``str``,
+    or even an array (length-of-tools). Try sensible coercions and
+    fall back to 0 rather than 400ing the caller.
+    """
+    if isinstance(value, bool):  # bool is an int subclass — exclude it
+        return 0
+    if isinstance(value, int):
+        return max(0, value)
+    if isinstance(value, str):
+        try:
+            return max(0, int(value))
+        except ValueError:
+            return 0
+    if isinstance(value, list):
+        return len(value)
+    return 0
+
+
+# ── Public entrypoint ───────────────────────────────────────────────────────
+
+
+async def _default_fetcher(url: str) -> Any:
+    """Production fetcher — bounded body size + JSON decode."""
+    async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT, follow_redirects=True) as client:
+        resp = await client.get(url, headers={"Accept": "application/json"})
+        resp.raise_for_status()
+        # Bound body size so a misbehaving server can't stuff us.
+        body = resp.content
+        if len(body) > _MAX_MANIFEST_BYTES:
+            raise httpx.HTTPError(f"manifest body too large ({len(body)} > {_MAX_MANIFEST_BYTES})")
+        try:
+            return resp.json()
+        except ValueError:
+            return None
+
+
+async def resolve(url: str, *, fetcher: HttpFetcher | None = None) -> ResolvedManifest:
+    """Resolve a paste-box URL/spec to a :class:`ResolvedManifest`.
+
+    The dashboard's InstallDrawer calls this once on paste to render the
+    preview card; it then calls it again on Install click so the
+    persisted record has the freshest resolved data.
+
+    Args:
+        url: A URL or one of the supported scheme prefixes (oci/npm/uvx/git).
+        fetcher: Optional manifest fetcher — defaults to a fresh httpx
+            client. Tests inject a fake so they don't hit the network.
+
+    Raises:
+        BadRequest: When the URL is empty, exceeds the length cap, or
+            doesn't match any supported shape.
+    """
+    if not isinstance(url, str):
+        raise BadRequest("url must be a string", code="mcp.url_invalid")
+    url = url.strip()
+    if not url:
+        raise BadRequest("url is required", code="mcp.url_required")
+    if len(url) > 2048:
+        raise BadRequest("url too long (max 2048)", code="mcp.url_too_long")
+
+    if _OCI_RE.match(url):
+        return _resolve_oci(url)
+    if _NPM_RE.match(url):
+        return _resolve_npm(url)
+    if _UV_RE.match(url):
+        return _resolve_uvx(url)
+    if _GIT_RE.match(url):
+        return _resolve_git(url)
+    if _HTTP_RE.match(url):
+        return await _resolve_http(url, fetcher)
+
+    raise BadRequest(
+        "unsupported MCP spec — expected oci://, npm:, uvx:, git+https://, or an http(s) URL",
+        code="mcp.spec_unsupported",
+        details={"url": url},
+    )
+
+
+__all__ = [
+    "HttpFetcher",
+    "ResolvedManifest",
+    "resolve",
+]

--- a/tests/api/test_mcp_routes.py
+++ b/tests/api/test_mcp_routes.py
@@ -1,4 +1,4 @@
-"""Integration tests for the ``/api/mcp/*`` REST surface (issue #206).
+"""Integration tests for the ``/api/mcp/*`` REST surface (#206 + #305).
 
 The orchestrator's full ``create_app()`` mounts the FastMCP sub-apps,
 which we don't want to spin up for a route-shape test. Instead we mount
@@ -8,6 +8,11 @@ with a tiny fake (for the introspection happy path) or leave it absent
 
 We also stub the journald audit reader via ``monkeypatch.setattr`` so
 the tests don't depend on ``journalctl`` being present on the host.
+
+The install / uninstall / patch tests rely on the autouse ``tmp_hal0_home``
+fixture from ``tests/conftest.py`` to point ``HAL0_HOME`` at a tempdir,
+so the registry writes land under ``$tmp/etc/hal0/mcp-servers/`` rather
+than the host's ``/etc/hal0``.
 """
 
 from __future__ import annotations
@@ -61,7 +66,7 @@ def _build_app(*, with_servers: bool = True) -> FastAPI:
 
 
 @pytest.fixture
-def app() -> FastAPI:
+def app(tmp_hal0_home: str) -> FastAPI:
     return _build_app()
 
 
@@ -105,7 +110,7 @@ def test_servers_returns_introspected_counts(client: TestClient) -> None:
     assert by_id["hal0-memory"]["tools"] == 4
 
 
-def test_servers_empty_when_state_absent() -> None:
+def test_servers_empty_when_state_absent(tmp_hal0_home: str) -> None:
     app = _build_app(with_servers=False)
     with TestClient(app) as client:
         response = client.get("/api/mcp/servers")
@@ -137,6 +142,24 @@ def test_servers_surfaces_recent_rpm(
     by_id = {s["id"]: s for s in response.json()["servers"]}
     assert by_id["hal0-admin"]["activity"]["rpm"] == 3
     assert "claude-code" in by_id["hal0-admin"]["connected"]
+
+
+def test_servers_lists_installed_alongside_bundled(client: TestClient) -> None:
+    """#305 — registry-backed user-installed servers join the response."""
+    install_resp = client.post(
+        "/api/mcp/install",
+        json={"manifest": _filesystem_manifest_dict()},
+    )
+    assert install_resp.status_code == 201, install_resp.text
+
+    list_resp = client.get("/api/mcp/servers")
+    body = list_resp.json()
+    by_id = {s["id"]: s for s in body["servers"]}
+    assert body["count"] == 3
+    assert by_id["filesystem"]["bundled"] is False
+    assert by_id["filesystem"]["state"] == "stopped"
+    assert by_id["filesystem"]["spec"] == "uvx:mcp-server-filesystem"
+    assert by_id["filesystem"]["tools"] == 5
 
 
 # ── GET /api/mcp/clients ─────────────────────────────────────────────────────
@@ -265,35 +288,225 @@ def test_server_logs_filters_by_server(
     assert body["events"][0]["tool"] == "slot_list"
 
 
-# ── 501 stubs ────────────────────────────────────────────────────────────────
+# ── GET /api/mcp/resolve (#224) ──────────────────────────────────────────────
 
 
-def test_install_returns_501(client: TestClient) -> None:
-    response = client.post("/api/mcp/install", json={"name": "filesystem"})
-    assert response.status_code == 501
+def _filesystem_manifest_dict() -> dict[str, Any]:
+    """Sample manifest returned by a fake fetcher / passed to install."""
+    return {
+        "id": "filesystem",
+        "name": "filesystem",
+        "description": "Filesystem MCP — read/write files under a workspace.",
+        "spec": "uvx:mcp-server-filesystem",
+        "transport": "stdio",
+        "tools": 5,
+        "resources": 0,
+        "prompts": 0,
+        "env_required": ["MCP_WORKSPACE"],
+        "source_kind": "uvx",
+        "author": "modelcontextprotocol",
+    }
+
+
+def test_resolve_returns_preview_for_uvx_spec(client: TestClient) -> None:
+    response = client.get("/api/mcp/resolve", params={"url": "uvx:mcp-server-filesystem"})
+    assert response.status_code == 200, response.text
     body = response.json()
-    assert body["error"]["code"] == "mcp.not_implemented"
-    assert "ADR-0013" in body["error"]["message"]
+    assert body["id"] == "mcp-server-filesystem"
+    assert body["name"] == "mcp-server-filesystem"
+    assert body["source_kind"] == "uvx"
+    assert body["transport"] == "stdio"
 
 
-def test_uninstall_returns_501(client: TestClient) -> None:
+def test_resolve_returns_preview_for_oci_spec(client: TestClient) -> None:
+    response = client.get(
+        "/api/mcp/resolve",
+        params={"url": "oci://ghcr.io/example/mcp-tools:latest"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == "mcp-tools"
+    assert body["transport"] == "streamable-http"
+    assert body["source_kind"] == "oci"
+
+
+def test_resolve_fetches_http_manifest(
+    app: FastAPI,
+    client: TestClient,
+) -> None:
+    """HTTP manifests are fetched via the app.state-injected fake fetcher."""
+
+    async def _fake_fetcher(url: str) -> dict[str, Any]:
+        return {
+            "name": "example-mcp",
+            "description": "demo manifest",
+            "tools": 7,
+            "transport": "streamable-http",
+            "env": {"FOO": "bar"},
+        }
+
+    app.state.mcp_manifest_fetcher = _fake_fetcher
+    response = client.get(
+        "/api/mcp/resolve",
+        params={"url": "https://example.com/mcp.json"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "example-mcp"
+    assert body["tools"] == 7
+    assert body["transport"] == "streamable-http"
+    assert body["env_required"] == ["FOO"]
+    assert body["source_kind"] == "manifest"
+
+
+def test_resolve_rejects_garbage(client: TestClient) -> None:
+    response = client.get("/api/mcp/resolve", params={"url": "ftp://not-supported"})
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "mcp.spec_unsupported"
+
+
+def test_resolve_requires_url(client: TestClient) -> None:
+    response = client.get("/api/mcp/resolve")
+    # FastAPI's automatic validation rejects the missing query param.
+    assert response.status_code in (400, 422)
+
+
+# ── POST /api/mcp/install (#305) ────────────────────────────────────────────
+
+
+def test_install_from_url_succeeds(client: TestClient) -> None:
+    response = client.post(
+        "/api/mcp/install",
+        json={"url": "uvx:mcp-server-filesystem"},
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    record = body["installed"]
+    assert record["id"] == "mcp-server-filesystem"
+    assert record["spec"] == "uvx:mcp-server-filesystem"
+    assert record["enabled"] is True
+    assert record["installed_at"]  # ISO timestamp populated
+
+
+def test_install_from_pre_resolved_manifest(client: TestClient) -> None:
+    response = client.post(
+        "/api/mcp/install",
+        json={"manifest": _filesystem_manifest_dict()},
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["installed"]["id"] == "filesystem"
+    assert body["installed"]["tools"] == 5
+    # env_required → empty env block keys present
+    assert body["installed"]["env"] == {"MCP_WORKSPACE": ""}
+
+
+def test_install_rejects_duplicate(client: TestClient) -> None:
+    first = client.post("/api/mcp/install", json={"manifest": _filesystem_manifest_dict()})
+    assert first.status_code == 201
+    second = client.post("/api/mcp/install", json={"manifest": _filesystem_manifest_dict()})
+    assert second.status_code == 409
+    assert second.json()["error"]["code"] == "mcp.already_installed"
+
+
+def test_install_rejects_bundled_id(client: TestClient) -> None:
+    payload = _filesystem_manifest_dict() | {"id": "hal0-admin", "name": "hal0-admin"}
+    response = client.post("/api/mcp/install", json={"manifest": payload})
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "mcp.id_reserved"
+
+
+def test_install_rejects_missing_body(client: TestClient) -> None:
+    response = client.post("/api/mcp/install", json={})
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "mcp.url_required"
+
+
+def test_install_rejects_bad_manifest(client: TestClient) -> None:
+    response = client.post(
+        "/api/mcp/install",
+        json={"manifest": {"id": "x"}},  # missing required name + spec
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "mcp.manifest_invalid"
+
+
+# ── DELETE /api/mcp/{id} (#305) ─────────────────────────────────────────────
+
+
+def test_uninstall_removes_installed_server(client: TestClient) -> None:
+    client.post("/api/mcp/install", json={"manifest": _filesystem_manifest_dict()})
     response = client.delete("/api/mcp/filesystem")
-    assert response.status_code == 501
-    assert response.json()["error"]["code"] == "mcp.not_implemented"
+    assert response.status_code == 200, response.text
+    assert response.json() == {"uninstalled": "filesystem"}
+    # Second uninstall is 404.
+    again = client.delete("/api/mcp/filesystem")
+    assert again.status_code == 404
+    assert again.json()["error"]["code"] == "mcp.not_found"
+
+
+def test_uninstall_bundled_rejected(client: TestClient) -> None:
+    response = client.delete("/api/mcp/hal0-admin")
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "mcp.bundled"
+
+
+def test_uninstall_invalid_id_rejected(client: TestClient) -> None:
+    response = client.delete("/api/mcp/foo%20bar")
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "mcp.id_invalid"
+
+
+# ── PATCH /api/mcp/{id}/config (#305) ───────────────────────────────────────
+
+
+def test_patch_config_updates_env(client: TestClient) -> None:
+    client.post("/api/mcp/install", json={"manifest": _filesystem_manifest_dict()})
+    response = client.patch(
+        "/api/mcp/filesystem/config",
+        json={"env": {"MCP_WORKSPACE": "/tmp/ws"}},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["server"]["env"] == {"MCP_WORKSPACE": "/tmp/ws"}
+
+
+def test_patch_config_toggles_enabled(client: TestClient) -> None:
+    client.post("/api/mcp/install", json={"manifest": _filesystem_manifest_dict()})
+    response = client.patch("/api/mcp/filesystem/config", json={"enabled": False})
+    assert response.status_code == 200
+    assert response.json()["server"]["enabled"] is False
+
+
+def test_patch_config_bundled_rejected(client: TestClient) -> None:
+    response = client.patch(
+        "/api/mcp/hal0-admin/config",
+        json={"env": {"FOO": "bar"}},
+    )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "mcp.bundled"
+
+
+def test_patch_config_missing_record_404(client: TestClient) -> None:
+    response = client.patch("/api/mcp/nope/config", json={"env": {"X": "1"}})
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "mcp.not_found"
+
+
+def test_patch_config_rejects_bad_env(client: TestClient) -> None:
+    client.post("/api/mcp/install", json={"manifest": _filesystem_manifest_dict()})
+    response = client.patch(
+        "/api/mcp/filesystem/config",
+        json={"env": "not-an-object"},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "mcp.env_invalid"
+
+
+# ── Action stub (supervisor follow-up) ──────────────────────────────────────
 
 
 def test_action_returns_501(client: TestClient) -> None:
     response = client.post("/api/mcp/hal0-admin/restart")
     assert response.status_code == 501
     assert response.json()["error"]["code"] == "mcp.not_implemented"
-
-
-def test_config_patch_returns_501(client: TestClient) -> None:
-    response = client.patch(
-        "/api/mcp/hal0-admin/config",
-        json={"env": {"FOO": "bar"}},
-    )
-    assert response.status_code == 501
-    body = response.json()
-    assert body["error"]["code"] == "mcp.not_implemented"
-    assert body["error"]["details"]["patch"] == {"env": {"FOO": "bar"}}

--- a/tests/api/test_mcp_routes.py
+++ b/tests/api/test_mcp_routes.py
@@ -510,3 +510,65 @@ def test_action_returns_501(client: TestClient) -> None:
     response = client.post("/api/mcp/hal0-admin/restart")
     assert response.status_code == 501
     assert response.json()["error"]["code"] == "mcp.not_implemented"
+
+
+# ── Security hardening (#368 review) ────────────────────────────────────────
+
+
+def test_resolve_route_blocks_lan_ssrf(client: TestClient) -> None:
+    """``GET /api/mcp/resolve?url=http://10.x/...`` must 400 with ssrf code.
+
+    Demonstrates that the previously-exploitable SSRF probe is now blocked
+    at the route layer — unauth caller on the LAN can no longer bounce
+    arbitrary GETs through hal0-api.
+    """
+    response = client.get(
+        "/api/mcp/resolve",
+        params={"url": "http://10.0.1.142:8080/api/slots"},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "mcp.ssrf_blocked"
+
+
+def test_oversized_manifest_body_rejected(
+    app: FastAPI,
+    client: TestClient,
+) -> None:
+    """A fetcher returning a >256 KiB body must surface mcp.manifest_fetch_failed.
+
+    The body cap (``_MAX_MANIFEST_BYTES``) lives inside ``_default_fetcher``;
+    we exercise it by injecting a fetcher that mimics the size check by
+    raising the same httpx.HTTPError the production path raises when the
+    cap is tripped.
+    """
+    import httpx
+
+    async def _too_big(url: str) -> Any:
+        raise httpx.HTTPError("manifest body too large (300000 > 262144)")
+
+    app.state.mcp_manifest_fetcher = _too_big
+    response = client.get(
+        "/api/mcp/resolve",
+        params={"url": "https://example.com/mcp.json"},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "mcp.manifest_fetch_failed"
+
+
+def test_validate_id_rejects_path_traversal(client: TestClient) -> None:
+    """An install body with an id like ``../evil`` must 400 (or 404), never traverse.
+
+    The pre-resolved-manifest path lets a caller pin the id; the registry
+    guard must reject any id outside the [a-z0-9_-] charset before the
+    write touches disk.
+    """
+    payload = _filesystem_manifest_dict() | {"id": "../evil", "name": "evil"}
+    response = client.post("/api/mcp/install", json={"manifest": payload})
+    # The id is rejected by the ResolvedManifest model_validator (slug shape)
+    # before the registry sees it — that surfaces as mcp.manifest_invalid.
+    # Either is acceptable as long as no file lands outside the registry dir.
+    assert response.status_code == 400
+    code = response.json()["error"]["code"]
+    assert code in {"mcp.id_invalid", "mcp.manifest_invalid"}, (
+        f"path traversal must be rejected at validation, got {code}"
+    )

--- a/tests/mcp/test_installed.py
+++ b/tests/mcp/test_installed.py
@@ -1,0 +1,114 @@
+"""Unit tests for :mod:`hal0.mcp.installed` — #305 registry layer."""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.errors import BadRequest, Conflict, NotFound
+from hal0.mcp import installed as registry
+
+
+def _record(server_id: str = "filesystem", **overrides: object) -> registry.InstalledServer:
+    defaults: dict[str, object] = {
+        "id": server_id,
+        "name": server_id,
+        "description": "filesystem MCP",
+        "spec": "uvx:mcp-server-filesystem",
+        "transport": "stdio",
+        "tools": 5,
+    }
+    defaults.update(overrides)
+    return registry.InstalledServer(**defaults)
+
+
+def test_list_installed_empty(tmp_hal0_home: str) -> None:
+    assert registry.list_installed() == []
+
+
+def test_install_and_list_round_trip(tmp_hal0_home: str) -> None:
+    saved = registry.install(_record())
+    assert saved.id == "filesystem"
+    assert saved.installed_at  # auto-stamped
+
+    rows = registry.list_installed()
+    assert len(rows) == 1
+    assert rows[0].id == "filesystem"
+    assert rows[0].installed_at == saved.installed_at
+
+
+def test_install_rejects_duplicate(tmp_hal0_home: str) -> None:
+    registry.install(_record())
+    with pytest.raises(Conflict) as exc:
+        registry.install(_record())
+    assert exc.value.code == "mcp.already_installed"
+
+
+def test_install_rejects_bundled_id(tmp_hal0_home: str) -> None:
+    with pytest.raises(Conflict) as exc:
+        registry.install(_record("hal0-admin"))
+    assert exc.value.code == "mcp.id_reserved"
+
+
+def test_install_rejects_bad_id_charset(tmp_hal0_home: str) -> None:
+    with pytest.raises(BadRequest) as exc:
+        registry.install(_record("My Bad Id"))
+    assert exc.value.code == "mcp.id_invalid"
+
+
+def test_uninstall_round_trip(tmp_hal0_home: str) -> None:
+    registry.install(_record())
+    registry.uninstall("filesystem")
+    assert registry.list_installed() == []
+
+
+def test_uninstall_missing_raises_not_found(tmp_hal0_home: str) -> None:
+    with pytest.raises(NotFound) as exc:
+        registry.uninstall("filesystem")
+    assert exc.value.code == "mcp.not_found"
+
+
+def test_get_installed_missing_raises_not_found(tmp_hal0_home: str) -> None:
+    with pytest.raises(NotFound):
+        registry.get_installed("nope")
+
+
+def test_patch_config_replaces_env(tmp_hal0_home: str) -> None:
+    registry.install(_record(env={"OLD": "1"}))
+    updated = registry.patch_config("filesystem", env={"NEW": "2"})
+    assert updated.env == {"NEW": "2"}
+    # Round-trip verifies disk write.
+    reloaded = registry.get_installed("filesystem")
+    assert reloaded.env == {"NEW": "2"}
+
+
+def test_patch_config_coerces_env_values(tmp_hal0_home: str) -> None:
+    registry.install(_record())
+    updated = registry.patch_config("filesystem", env={"PORT": 8080, "FLAG": True})
+    assert updated.env == {"PORT": "8080", "FLAG": "True"}
+
+
+def test_patch_config_toggles_enabled(tmp_hal0_home: str) -> None:
+    registry.install(_record(enabled=True))
+    after = registry.patch_config("filesystem", enabled=False)
+    assert after.enabled is False
+    again = registry.patch_config("filesystem", enabled=True)
+    assert again.enabled is True
+
+
+def test_patch_config_noop_returns_record(tmp_hal0_home: str) -> None:
+    registry.install(_record())
+    record = registry.patch_config("filesystem")
+    assert record.id == "filesystem"
+
+
+def test_list_installed_tolerates_malformed_file(
+    tmp_hal0_home: str,
+) -> None:
+    from pathlib import Path
+
+    root = Path(tmp_hal0_home) / "etc" / "hal0" / "mcp-servers"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "broken.toml").write_text("this is not a [valid toml")
+    registry.install(_record("good"))
+    rows = registry.list_installed()
+    assert [r.id for r in rows] == ["good"]

--- a/tests/mcp/test_installed.py
+++ b/tests/mcp/test_installed.py
@@ -112,3 +112,54 @@ def test_list_installed_tolerates_malformed_file(
     registry.install(_record("good"))
     rows = registry.list_installed()
     assert [r.id for r in rows] == ["good"]
+
+
+# ── Security hardening (#368 review) ────────────────────────────────────────
+
+
+def test_install_writes_restrictive_permissions(tmp_hal0_home: str) -> None:
+    """Registry TOMLs hold env blocks (API keys); they must be 0o600 + dir 0o700.
+
+    Default umask (022) would otherwise leave both world-readable. We chmod
+    explicitly after the atomic write — assert both modes round-trip.
+    """
+    from pathlib import Path
+
+    registry.install(_record(env={"API_KEY": "secret-token"}))
+    file_path = Path(tmp_hal0_home) / "etc" / "hal0" / "mcp-servers" / "filesystem.toml"
+    dir_path = file_path.parent
+    assert file_path.exists()
+    file_mode = file_path.stat().st_mode & 0o777
+    dir_mode = dir_path.stat().st_mode & 0o777
+    assert file_mode == 0o600, f"expected 0o600, got {oct(file_mode)}"
+    assert dir_mode == 0o700, f"expected 0o700, got {oct(dir_mode)}"
+
+
+def test_uninstall_bundled_id_rejected_at_registry_layer(tmp_hal0_home: str) -> None:
+    """Calling ``installed.uninstall("hal0-admin")`` rejects before disk lookup.
+
+    Belt-and-braces: the route layer also rejects bundled ids (mcp.bundled,
+    409); this asserts the registry's own validate-id guard catches the
+    same case if a future call site bypasses the route check.
+    """
+    with pytest.raises(Conflict) as exc:
+        registry.uninstall("hal0-admin")
+    assert exc.value.code == "mcp.id_reserved"
+    with pytest.raises(Conflict) as exc:
+        registry.uninstall("hal0-memory")
+    assert exc.value.code == "mcp.id_reserved"
+
+
+def test_validate_id_rejects_path_traversal(tmp_hal0_home: str) -> None:
+    """``id="../evil"`` must reject at the registry validator, not after stat.
+
+    Even though Pydantic would allow it (no charset constraint on the
+    field), the registry's :func:`_validate_id` rejects any non-[a-z0-9_-]
+    char — that's what stops a write from landing outside the registry dir.
+    """
+    with pytest.raises(BadRequest) as exc:
+        registry.install(_record("../evil"))
+    assert exc.value.code == "mcp.id_invalid"
+    with pytest.raises(BadRequest) as exc:
+        registry.uninstall("../evil")
+    assert exc.value.code == "mcp.id_invalid"

--- a/tests/mcp/test_manifest.py
+++ b/tests/mcp/test_manifest.py
@@ -1,0 +1,126 @@
+"""Unit tests for :mod:`hal0.mcp.manifest` — #224 install-from-URL resolver."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hal0.errors import BadRequest
+from hal0.mcp import manifest
+
+
+@pytest.mark.asyncio
+async def test_resolve_oci_synthesises_id_and_name() -> None:
+    r = await manifest.resolve("oci://ghcr.io/example/mcp-tools:latest")
+    assert r.id == "mcp-tools"
+    assert r.name == "mcp-tools"
+    assert r.spec == "oci://ghcr.io/example/mcp-tools:latest"
+    assert r.source_kind == "oci"
+    assert r.transport == "streamable-http"
+
+
+@pytest.mark.asyncio
+async def test_resolve_npm_strips_scope_for_name() -> None:
+    r = await manifest.resolve("npm:@some-org/mcp-things")
+    assert r.id == "mcp-things"
+    assert r.name == "mcp-things"
+    assert r.source_kind == "npm"
+
+
+@pytest.mark.asyncio
+async def test_resolve_uvx_keeps_pkg_name() -> None:
+    r = await manifest.resolve("uvx:mcp-server-filesystem")
+    assert r.id == "mcp-server-filesystem"
+    assert r.name == "mcp-server-filesystem"
+    assert r.source_kind == "uvx"
+
+
+@pytest.mark.asyncio
+async def test_resolve_git_https_uses_repo_name() -> None:
+    r = await manifest.resolve("git+https://github.com/example/mcp-things")
+    assert r.id == "mcp-things"
+    assert r.name == "mcp-things"
+    assert r.source_kind == "git"
+
+
+@pytest.mark.asyncio
+async def test_resolve_git_https_with_trailing_dot_git() -> None:
+    r = await manifest.resolve("git+https://github.com/example/mcp-things.git")
+    assert r.id == "mcp-things"
+
+
+@pytest.mark.asyncio
+async def test_resolve_http_manifest_with_fake_fetcher() -> None:
+    async def _fetch(url: str) -> dict[str, Any]:
+        return {
+            "name": "example-mcp",
+            "description": "demo",
+            "tools": 7,
+            "transport": "streamable-http",
+            "env": {"FOO": "bar"},
+        }
+
+    r = await manifest.resolve("https://example.com/mcp.json", fetcher=_fetch)
+    assert r.name == "example-mcp"
+    assert r.tools == 7
+    assert r.transport == "streamable-http"
+    assert r.env_required == ["FOO"]
+    assert r.source_kind == "manifest"
+    assert r.source_url == "https://example.com/mcp.json"
+
+
+@pytest.mark.asyncio
+async def test_resolve_http_falls_back_when_non_json() -> None:
+    async def _fetch(url: str) -> Any:
+        return None  # not a dict — synthesise from URL last segment
+
+    r = await manifest.resolve("https://example.com/foo.json", fetcher=_fetch)
+    assert r.id == "foo"
+    assert r.name == "foo"
+    assert r.source_kind == "http"
+
+
+@pytest.mark.asyncio
+async def test_resolve_http_tools_as_list_returns_length() -> None:
+    async def _fetch(url: str) -> dict[str, Any]:
+        return {
+            "name": "many-tools",
+            "tools": ["a", "b", "c"],
+        }
+
+    r = await manifest.resolve("https://example.com/m.json", fetcher=_fetch)
+    assert r.tools == 3
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_empty_url() -> None:
+    with pytest.raises(BadRequest) as exc:
+        await manifest.resolve("")
+    assert exc.value.code == "mcp.url_required"
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_unknown_scheme() -> None:
+    with pytest.raises(BadRequest) as exc:
+        await manifest.resolve("ftp://no")
+    assert exc.value.code == "mcp.spec_unsupported"
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_too_long_url() -> None:
+    with pytest.raises(BadRequest) as exc:
+        await manifest.resolve("https://x/" + "a" * 4096)
+    assert exc.value.code == "mcp.url_too_long"
+
+
+@pytest.mark.asyncio
+async def test_resolve_propagates_fetch_failure_as_bad_request() -> None:
+    import httpx
+
+    async def _fetch(url: str) -> Any:
+        raise httpx.ConnectError("nope")
+
+    with pytest.raises(BadRequest) as exc:
+        await manifest.resolve("https://example.com/mcp.json", fetcher=_fetch)
+    assert exc.value.code == "mcp.manifest_fetch_failed"

--- a/tests/mcp/test_manifest.py
+++ b/tests/mcp/test_manifest.py
@@ -124,3 +124,86 @@ async def test_resolve_propagates_fetch_failure_as_bad_request() -> None:
     with pytest.raises(BadRequest) as exc:
         await manifest.resolve("https://example.com/mcp.json", fetcher=_fetch)
     assert exc.value.code == "mcp.manifest_fetch_failed"
+
+
+# ── SSRF guard ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolve_blocks_localhost_url() -> None:
+    """Loopback hostnames + 127.0.0.1 literals must short-circuit pre-fetch."""
+    for url in (
+        "http://localhost/manifest.json",
+        "http://127.0.0.1/manifest.json",
+        "http://127.0.0.1:9000/v1/load",
+        "http://[::1]/manifest.json",
+    ):
+        with pytest.raises(BadRequest) as exc:
+            await manifest.resolve(url)
+        assert exc.value.code == "mcp.ssrf_blocked", f"missed SSRF guard for {url}"
+
+
+@pytest.mark.asyncio
+async def test_resolve_blocks_private_lan_url() -> None:
+    """RFC 1918 ranges (10/8, 172.16/12, 192.168/16) must reject pre-fetch."""
+    for url in (
+        "http://10.0.1.142:8080/api/slots",
+        "http://172.16.0.5/manifest.json",
+        "http://192.168.1.1/manifest.json",
+    ):
+        with pytest.raises(BadRequest) as exc:
+            await manifest.resolve(url)
+        assert exc.value.code == "mcp.ssrf_blocked", f"missed SSRF guard for {url}"
+
+
+@pytest.mark.asyncio
+async def test_resolve_blocks_link_local_url() -> None:
+    """Link-local (incl. AWS/GCP IMDS at 169.254.169.254) must reject."""
+    for url in (
+        "http://169.254.169.254/latest/meta-data/",  # AWS / GCP IMDS
+        "http://169.254.1.1/",
+    ):
+        with pytest.raises(BadRequest) as exc:
+            await manifest.resolve(url)
+        assert exc.value.code == "mcp.ssrf_blocked", f"missed SSRF guard for {url}"
+
+
+@pytest.mark.asyncio
+async def test_resolve_blocks_mdns_local_hostname() -> None:
+    """``*.local`` mDNS hostnames are rejected without a DNS lookup."""
+    with pytest.raises(BadRequest) as exc:
+        await manifest.resolve("http://hal0.local/manifest.json")
+    assert exc.value.code == "mcp.ssrf_blocked"
+
+
+@pytest.mark.asyncio
+async def test_resolve_does_not_follow_redirect() -> None:
+    """The default fetcher must run with ``follow_redirects=False``.
+
+    A 30x to an internal host would otherwise bypass the pre-flight
+    SSRF check. We assert the AsyncClient kwarg at construction time so
+    a regression is caught without spinning up an HTTP server.
+    """
+    import inspect
+
+    src = inspect.getsource(manifest._default_fetcher)
+    assert "follow_redirects=False" in src, (
+        "_default_fetcher must construct httpx.AsyncClient with follow_redirects=False"
+    )
+
+
+# ── Tools-count cap ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolve_caps_tools_count_at_4096() -> None:
+    """A manifest with a runaway tools list must not 500 on Pydantic ``le``."""
+
+    async def _fetch(url: str) -> dict[str, Any]:
+        return {
+            "name": "huge",
+            "tools": ["t"] * 5000,
+        }
+
+    r = await manifest.resolve("https://example.com/m.json", fetcher=_fetch)
+    assert r.tools == 4096

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -79,6 +79,7 @@ export const ENDPOINTS = {
   mcpClients: '/api/mcp/clients',
   mcpCatalog: '/api/mcp/catalog',
   mcpStream: '/api/mcp/stream',
+  mcpResolve: '/api/mcp/resolve',
   mcpInstall: '/api/mcp/install',
   mcpServer: (id: string) => `/api/mcp/${encodeURIComponent(id)}`,
   mcpServerLogs: (id: string) => `/api/mcp/${encodeURIComponent(id)}/logs`,

--- a/ui/src/api/hooks/useMcp.ts
+++ b/ui/src/api/hooks/useMcp.ts
@@ -93,6 +93,27 @@ export interface McpCallEvent {
   server?: string
 }
 
+// ── Manifest resolve (#224) ─────────────────────────────────────────
+//
+// Shape mirrors `hal0.mcp.manifest.ResolvedManifest`. The InstallDrawer
+// reads `name`, `description`, `tools`, `transport`, and the truthiness
+// of `env_required` to render the preview card.
+export interface ResolvedMcpManifest {
+  id: string
+  name: string
+  description: string
+  spec: string
+  transport: string
+  tools: number
+  resources: number
+  prompts: number
+  env_required: string[]
+  source_kind: string
+  source_url?: string | null
+  author: string
+  verified: boolean
+}
+
 // ─── Mock fallbacks ─────────────────────────────────────────────────
 //
 // Shapes mirror what the backend returns (post-normalisation) so a
@@ -343,31 +364,16 @@ export function useMcpCallStream(): CallStreamState {
   return state
 }
 
-// ─── Mutations (501-stub aware) ─────────────────────────────────────
+// ─── Mutations ──────────────────────────────────────────────────────
+//
+// install / uninstall / config-patch are real as of #305. The action
+// stub (start/stop/restart) still 501s pending the supervisor
+// follow-up; useMcpRestart catches that case + surfaces a toast so the
+// button doesn't look broken.
 
-function _toastNotImplemented(verb: string): void {
+function _toast(verb: string, tone: 'info' | 'warn' | 'err' = 'info'): void {
   if (typeof window !== 'undefined' && (window as any).__hal0Toast) {
-    ;(window as any).__hal0Toast(
-      `MCP ${verb} pending ADR-0013 client-side work (#206)`,
-      'warn',
-    )
-  }
-}
-
-function _wrapMutation<TArgs>(
-  fn: (args: TArgs) => Promise<unknown>,
-  verb: string,
-) {
-  return async (args: TArgs) => {
-    try {
-      return await fn(args)
-    } catch (err) {
-      if (err instanceof Hal0Error && err.status === 501) {
-        _toastNotImplemented(verb)
-        return null
-      }
-      throw err
-    }
+    ;(window as any).__hal0Toast(verb, tone)
   }
 }
 
@@ -378,14 +384,33 @@ function _invalidator(queryClient: ReturnType<typeof useQueryClient>) {
   }
 }
 
+export interface McpInstallBody {
+  /** Original URL/spec the operator pasted. */
+  url?: string
+  /** Pre-resolved manifest (round-tripped from `useMcpResolve`). */
+  manifest?: ResolvedMcpManifest
+}
+
 export function useMcpInstall() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: _wrapMutation(
-      (body: Record<string, unknown>) =>
-        api(ENDPOINTS.mcpInstall, { method: 'POST', body, raw: true }),
-      'install',
-    ),
+    mutationFn: async (body: McpInstallBody) => {
+      try {
+        const resp = await api(ENDPOINTS.mcpInstall, {
+          method: 'POST',
+          body: body as unknown as Record<string, unknown>,
+          raw: true,
+        })
+        const name = body.manifest?.name || body.url || 'server'
+        _toast(`Installed ${name}`, 'info')
+        return resp
+      } catch (err) {
+        if (err instanceof Hal0Error) {
+          _toast(`Install failed — ${err.message}`, 'warn')
+        }
+        throw err
+      }
+    },
     onSuccess: _invalidator(qc),
   })
 }
@@ -393,11 +418,21 @@ export function useMcpInstall() {
 export function useMcpUninstall() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: _wrapMutation(
-      (id: string) =>
-        api(ENDPOINTS.mcpServer(id), { method: 'DELETE', raw: true }),
-      'uninstall',
-    ),
+    mutationFn: async (id: string) => {
+      try {
+        const resp = await api(ENDPOINTS.mcpServer(id), {
+          method: 'DELETE',
+          raw: true,
+        })
+        _toast(`Uninstalled ${id}`, 'info')
+        return resp
+      } catch (err) {
+        if (err instanceof Hal0Error) {
+          _toast(`Uninstall failed — ${err.message}`, 'warn')
+        }
+        throw err
+      }
+    },
     onSuccess: _invalidator(qc),
   })
 }
@@ -405,14 +440,23 @@ export function useMcpUninstall() {
 export function useMcpRestart() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: _wrapMutation(
-      (id: string) =>
-        api(ENDPOINTS.mcpServerAction(id, 'restart'), {
+    mutationFn: async (id: string) => {
+      try {
+        return await api(ENDPOINTS.mcpServerAction(id, 'restart'), {
           method: 'POST',
           raw: true,
-        }),
-      'restart',
-    ),
+        })
+      } catch (err) {
+        if (err instanceof Hal0Error && err.status === 501) {
+          _toast(
+            'MCP restart pending supervisor follow-up to #305',
+            'warn',
+          )
+          return null
+        }
+        throw err
+      }
+    },
     onSuccess: _invalidator(qc),
   })
 }
@@ -420,16 +464,47 @@ export function useMcpRestart() {
 export function useMcpConfigPatch() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: _wrapMutation(
-      ({ id, body }: { id: string; body: Record<string, unknown> }) =>
-        api(ENDPOINTS.mcpServerConfig(id), {
+    mutationFn: async ({ id, body }: { id: string; body: Record<string, unknown> }) => {
+      try {
+        const resp = await api(ENDPOINTS.mcpServerConfig(id), {
           method: 'PATCH',
           body,
           raw: true,
-        }),
-      'config write',
-    ),
+        })
+        _toast(`Saved ${id} config`, 'info')
+        return resp
+      } catch (err) {
+        if (err instanceof Hal0Error) {
+          _toast(`Config save failed — ${err.message}`, 'warn')
+        }
+        throw err
+      }
+    },
     onSuccess: _invalidator(qc),
+  })
+}
+
+// ── Manifest resolver (#224) ────────────────────────────────────────
+//
+// Query the live `/api/mcp/resolve?url=…` endpoint and surface the
+// resolved manifest preview to the InstallDrawer's URL tab. Disabled
+// when `url` is empty so the operator only triggers a network call
+// once they've pasted something. 30 s cache keeps multiple toggles
+// of the same paste cheap.
+
+export function useMcpResolve(url: string | null | undefined) {
+  return useQuery({
+    queryKey: ['mcp', 'resolve', url || ''],
+    queryFn: async (): Promise<ResolvedMcpManifest> => {
+      const q = String(url || '').trim()
+      if (!q) throw new Error('url is required')
+      return await apiGet<ResolvedMcpManifest>(
+        `${ENDPOINTS.mcpResolve}?url=${encodeURIComponent(q)}`,
+      )
+    },
+    enabled: !!url && String(url).trim().length > 0,
+    retry: false,
+    staleTime: 30_000,
   })
 }
 

--- a/ui/src/dash/mcp-modals.jsx
+++ b/ui/src/dash/mcp-modals.jsx
@@ -1,7 +1,7 @@
 // hal0 v0.3 — MCP modals & drawers
 // InstallDrawer (catalog), EditConfigModal, LogsDrawer, ConnectClientModal
 
-import { useMcpCatalog, useMcpServerLogs, useMcpConfigPatch } from '@/api/hooks/useMcp';
+import { useMcpCatalog, useMcpServerLogs, useMcpConfigPatch, useMcpResolve } from '@/api/hooks/useMcp';
 
 const { useState: useStateMM, useMemo: useMemoMM, useEffect: useEffectMM } = React;
 
@@ -106,6 +106,16 @@ function InstallDrawer({ open, onClose, onInstall }) {
 function InstallFromUrl({ onInstall }) {
   const [url, setUrl] = useStateMM("");
   const [pasted, setPasted] = useStateMM(false);
+  // Debounce the resolve query — typing a URL char-by-char would
+  // otherwise hammer /api/mcp/resolve. 350 ms feels live but spares the
+  // backend the unfinished-paste storm.
+  const [debouncedUrl, setDebouncedUrl] = useStateMM("");
+  useEffectMM(() => {
+    const id = setTimeout(() => setDebouncedUrl(url.trim()), 350);
+    return () => clearTimeout(id);
+  }, [url]);
+  const resolveQ = useMcpResolve(pasted ? debouncedUrl : "");
+  const resolved = resolveQ.data;
 
   const examples = [
     { label: "OCI image",   v: "oci://ghcr.io/example/mcp-something:latest" },
@@ -114,6 +124,20 @@ function InstallFromUrl({ onInstall }) {
     { label: "git repo",    v: "git+https://github.com/example/mcp-things" },
     { label: "manifest",    v: "https://example.com/mcp.json" },
   ];
+
+  const transportLine = resolved
+    ? `${resolved.transport} · via ${resolved.source_kind}`
+    : "—";
+  const toolsLine = resolved
+    ? `${resolved.tools} tool${resolved.tools === 1 ? "" : "s"}, ` +
+      `${resolved.resources} resource${resolved.resources === 1 ? "" : "s"}, ` +
+      `${resolved.prompts} prompt${resolved.prompts === 1 ? "" : "s"}.`
+    : "";
+  const envLine = resolved
+    ? (resolved.env_required && resolved.env_required.length > 0
+        ? `Requires env: ${resolved.env_required.join(", ")}.`
+        : "No env vars required.")
+    : "";
 
   return (
     <div className="mcp-install-url">
@@ -135,21 +159,40 @@ function InstallFromUrl({ onInstall }) {
       </div>
 
       {pasted && url && (
-        <div className="mcp-install-url-preview">
+        <div className="mcp-install-url-preview" data-testid="mcp-install-url-preview">
           <div className="mono" style={{fontSize: 11, color: "var(--fg-4)", marginBottom: 6, textTransform: "uppercase", letterSpacing: "0.08em"}}>resolved manifest</div>
           <div className="mcp-install-url-card">
-            <div style={{display: "flex", alignItems: "baseline", gap: 8, marginBottom: 4}}>
-              <span className="mono" style={{fontSize: 14, color: "var(--fg)", fontWeight: 500}}>mcp-things</span>
-              <span className="mono" style={{fontSize: 10, color: "var(--fg-4)"}}>v0.1.0 · stdio</span>
-            </div>
-            <div style={{fontSize: 12, color: "var(--fg-3)", marginBottom: 10}}>Manifest fetched. 5 tools, 0 resources, 0 prompts. No env vars required.</div>
-            <div className="mono" style={{fontSize: 10.5, color: "var(--fg-4)", padding: 8, background: "var(--bg)", borderRadius: "var(--rad-sm)", border: "1px solid var(--line)"}}>
-              hal0 will spawn this server under its supervisor and add it to the list below.
-            </div>
+            {resolveQ.isLoading || resolveQ.isFetching ? (
+              <div className="mono" style={{fontSize: 12, color: "var(--fg-4)"}}>Resolving manifest…</div>
+            ) : resolveQ.isError ? (
+              <div className="mono" style={{fontSize: 12, color: "var(--err, #c66)"}}>
+                Could not resolve: {String(resolveQ.error?.message || "unknown error")}
+              </div>
+            ) : resolved ? (
+              <>
+                <div style={{display: "flex", alignItems: "baseline", gap: 8, marginBottom: 4}}>
+                  <span className="mono" data-testid="mcp-install-resolved-name" style={{fontSize: 14, color: "var(--fg)", fontWeight: 500}}>{resolved.name}</span>
+                  <span className="mono" style={{fontSize: 10, color: "var(--fg-4)"}}>{transportLine}</span>
+                </div>
+                {resolved.description && (
+                  <div style={{fontSize: 12, color: "var(--fg-2)", marginBottom: 6}} data-testid="mcp-install-resolved-desc">{resolved.description}</div>
+                )}
+                <div style={{fontSize: 12, color: "var(--fg-3)", marginBottom: 10}} data-testid="mcp-install-resolved-tools">{toolsLine} {envLine}</div>
+                <div className="mono" style={{fontSize: 10.5, color: "var(--fg-4)", padding: 8, background: "var(--bg)", borderRadius: "var(--rad-sm)", border: "1px solid var(--line)"}}>
+                  hal0 will add <span style={{color: "var(--fg-2)"}}>{resolved.id}</span> to its installed servers. The supervisor follow-up will spawn it; until then it lists as stopped.
+                </div>
+              </>
+            ) : (
+              <div className="mono" style={{fontSize: 12, color: "var(--fg-4)"}}>Paste a URL to see the resolved manifest.</div>
+            )}
           </div>
           <div style={{display: "flex", gap: 8, marginTop: 12, justifyContent: "flex-end"}}>
             <button className="btn ghost sm" onClick={() => { setUrl(""); setPasted(false); }}>Cancel</button>
-            <button className="btn sm" onClick={() => onInstall({ name: "mcp-things" })}>Install</button>
+            <button
+              className="btn sm"
+              disabled={!resolved || resolveQ.isLoading || resolveQ.isFetching}
+              onClick={() => resolved && onInstall({ manifest: resolved })}
+            >Install</button>
           </div>
         </div>
       )}

--- a/ui/src/dash/mcp.jsx
+++ b/ui/src/dash/mcp.jsx
@@ -13,66 +13,13 @@ import {
   useMcpUninstall,
 } from '@/api/hooks/useMcp'
 
-const { useState: useStateM, useEffect: useEffectM, useRef: useRefM, useMemo: useMemoM, useCallback: useCallbackM } = React;
+const { useState: useStateM, useEffect: useEffectM, useMemo: useMemoM } = React;
 
-// ─── Live activity bus ───────────────────────────────────────────────
-// Legacy local fake-stream — only used when the SSE hook returns no
-// rows AND the server list is the HAL0_DATA mock (so a stale build
-// without /api/mcp/stream still ticks the LiveTimeline visibly).
-// Production (issue #206) drives the timeline from useMcpCallStream.
-function useLiveCallStreamLocal(servers) {
-  const [now, setNow] = useStateM(Date.now());
-  const callsRef = useRefM({}); // serverId → [{ts, client, tool}]
-  const CLIENTS = ["claude-code", "cursor", "claude-desktop"];
-  const TOOLS = {
-    "hal0-admin":      ["slot.list", "slot.restart", "model.search", "journal.tail", "lemond.status"],
-    "hal0-memory":     ["recall", "write", "ns.list", "graph.query", "doc.add"],
-    "filesystem":      ["read_file", "write_file", "list_directory", "grep", "stat"],
-    "github":          ["repo.read", "search.code", "issue.list", "pr.diff", "actions.run"],
-    "postgres":        ["query", "schema.tables", "explain", "describe"],
-    "obsidian-vault":  [],
-    "brave-search":    [],
-    "timed-reminders": [],
-  };
-
-  useEffectM(() => {
-    let raf;
-    let alive = true;
-    const tick = () => {
-      if (!alive) return;
-      const t = Date.now();
-      const next = { ...callsRef.current };
-      servers.forEach(s => {
-        if (s.state !== "running") return;
-        const rpm = s.activity?.rpm || 0;
-        // probability per 500ms tick: rpm / 60 / 2
-        const p = rpm / 120;
-        if (Math.random() < p) {
-          const tools = TOOLS[s.id] || ["call"];
-          const clients = s.clients?.length ? s.clients : CLIENTS;
-          const arr = next[s.id] ? [...next[s.id]] : [];
-          arr.push({
-            ts: t,
-            client: clients[Math.floor(Math.random() * clients.length)],
-            tool: tools[Math.floor(Math.random() * tools.length)] || "call",
-          });
-          next[s.id] = arr;
-        }
-      });
-      // garbage-collect calls older than 60s
-      Object.keys(next).forEach(id => {
-        next[id] = next[id].filter(c => t - c.ts < 60000);
-      });
-      callsRef.current = next;
-      setNow(t);
-      raf = setTimeout(tick, 500);
-    };
-    raf = setTimeout(tick, 500);
-    return () => { alive = false; clearTimeout(raf); };
-  }, [servers]);
-
-  return { calls: callsRef.current, now };
-}
+// Live MCP call activity is driven entirely by the backend SSE stream
+// at ``/api/mcp/stream`` (issue #222). No synthetic event generator
+// runs on the client — the LiveTimeline renders blank when no audit
+// rows have arrived, which is the truthful "no recent activity" state
+// against a freshly-started host.
 
 // ─── KPI strip — aggregate state across all servers ─────────────────
 function McpKpiStrip({ servers, clients, calls, now }) {
@@ -422,14 +369,13 @@ function McpView() {
   const [logsFor, setLogsFor] = useStateM(null);
   const [confirmUninstall, setConfirmUninstall] = useStateM(null);
   const [teachOpen, setTeachOpen] = useStateM(false);
-  // SSE-backed call stream. Falls back to the local randomised stream
-  // when no live events have arrived AND we're rendering the HAL0_DATA
-  // mock list, so the demo timeline still ticks visibly.
+  // SSE-backed call stream. The hook maintains a 60-second sliding
+  // buffer keyed by server id; the LiveTimeline renders ticks straight
+  // from that buffer. No synthetic fallback — when the backend audit
+  // log is silent, the timeline stays blank.
   const sseStream = useMcpCallStream();
-  const localStream = useLiveCallStreamLocal(liveServers.length === 0 ? servers : []);
-  const hasLiveCalls = Object.values(sseStream.calls).some(arr => arr && arr.length > 0);
-  const calls = hasLiveCalls ? sseStream.calls : (liveServers.length === 0 ? localStream.calls : sseStream.calls);
-  const now = hasLiveCalls ? sseStream.now : (liveServers.length === 0 ? localStream.now : sseStream.now);
+  const calls = sseStream.calls;
+  const now = sseStream.now;
   const restartMut = useMcpRestart();
   const uninstallMut = useMcpUninstall();
 
@@ -752,7 +698,14 @@ function InstallDrawerWired({ open, onClose }) {
       open={open}
       onClose={onClose}
       onInstall={(item) => {
-        installMut.mutate({ name: item.name, spec: item.id || item.name });
+        // The drawer hands us either a catalog row (with `spec`) or a
+        // resolved-manifest payload (with `manifest`). The install hook
+        // tolerates both shapes — backend re-resolves a bare `url`,
+        // or trusts the `manifest` round-trip when supplied.
+        const body = item.manifest
+          ? { manifest: item.manifest }
+          : { url: item.spec || item.id || item.name };
+        installMut.mutate(body);
         onClose();
       }}
     />

--- a/ui/src/dash/mcp.jsx
+++ b/ui/src/dash/mcp.jsx
@@ -167,10 +167,24 @@ function CopyField({ value, monoClass = "mono" }) {
 }
 
 // ─── Server row card ────────────────────────────────────────────────
+//
+// Supervisor capability flag — v0.3 alpha ships the registry layer
+// (#305) but not yet the process supervisor: ``POST /api/mcp/{id}/{action}``
+// returns 501 ``mcp.not_implemented``. Until the supervisor lands, the
+// row's Start / Restart buttons must be disabled with a "pending"
+// tooltip so the operator isn't surprised by a no-op click.
+const SUPERVISOR_AVAILABLE = false;
+const SUPERVISOR_PENDING_HINT = "Supervisor not yet implemented — pending #305 follow-up";
+
 function McpServerRow({ server, calls, now, clients, onMenuOpen, menuOpen, onCloseMenu, onConfig, onLogs, onConfirmUninstall, onToggle }) {
   const isBundled = server.bundled;
   const state = server.state;
   const callsLast60 = (calls[server.id] || []).length;
+  // Bundled servers run in-process (FastMCP mount) — they don't need a
+  // supervisor. The pending gate applies only to user-installed servers.
+  const supervisorRequired = !isBundled;
+  const canRunSupervisorAction = !supervisorRequired || SUPERVISOR_AVAILABLE;
+  const supervisorTitle = canRunSupervisorAction ? undefined : SUPERVISOR_PENDING_HINT;
 
   // visible client chips (only the clients connected to this server)
   const connectedClients = clients.filter(c => c.servers.includes(server.id));
@@ -200,13 +214,23 @@ function McpServerRow({ server, calls, now, clients, onMenuOpen, menuOpen, onClo
           {state === "running" && (
             <>
               <button className="btn ghost sm" onClick={() => onLogs(server)} title="View logs">{Icons.logs}</button>
-              <button className="btn ghost sm" onClick={() => window.__hal0Toast && window.__hal0Toast(`Restarting ${server.name}…`, "info")} title="Restart">{Icons.restart}</button>
+              <button
+                className="btn ghost sm"
+                onClick={() => window.__hal0Toast && window.__hal0Toast(`Restarting ${server.name}…`, "info")}
+                title={supervisorTitle || "Restart"}
+                disabled={!canRunSupervisorAction}
+              >{Icons.restart}</button>
               <button className="btn ghost sm" onClick={() => onConfig(server)} title="Edit config">{Icons.edit}</button>
             </>
           )}
           {state === "stopped" && (
             <>
-              <button className="btn sm" onClick={() => onToggle(server, true)}>Start</button>
+              <button
+                className="btn sm"
+                onClick={() => onToggle(server, true)}
+                title={supervisorTitle}
+                disabled={!canRunSupervisorAction}
+              >Start</button>
               <button className="btn ghost sm" onClick={() => onConfig(server)} title="Edit config">{Icons.edit}</button>
             </>
           )}
@@ -227,9 +251,21 @@ function McpServerRow({ server, calls, now, clients, onMenuOpen, menuOpen, onClo
                 onClose={onCloseMenu}
                 style={{ top: "calc(100% + 4px)", right: 0 }}
                 items={[
-                  { label: state === "running" ? "Disable server" : "Enable server", icon: <PwrIcon />, onClick: () => onToggle(server, state !== "running") },
+                  {
+                    label: state === "running" ? "Disable server" : "Enable server",
+                    icon: <PwrIcon />,
+                    onClick: () => onToggle(server, state !== "running"),
+                    disabled: !canRunSupervisorAction,
+                    hint: supervisorTitle,
+                  },
                   { label: "Open in browser", icon: Icons.ext, onClick: () => window.__hal0Toast && window.__hal0Toast(`Opening ${server.url}…`, "info") },
-                  { label: "Restart", icon: Icons.restart, onClick: () => window.__hal0Toast && window.__hal0Toast(`Restarting ${server.name}…`, "info") },
+                  {
+                    label: "Restart",
+                    icon: Icons.restart,
+                    onClick: () => window.__hal0Toast && window.__hal0Toast(`Restarting ${server.name}…`, "info"),
+                    disabled: !canRunSupervisorAction,
+                    hint: supervisorTitle,
+                  },
                   { label: "Edit config", icon: Icons.edit, onClick: () => onConfig(server) },
                   { label: "View logs", icon: Icons.logs, onClick: () => onLogs(server) },
                   { divider: true },

--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -447,11 +447,21 @@ function Menu({ anchor = "right", items, onClose, style }) {
     <div className={"hal0-menu " + anchor} style={style} onClick={e => e.stopPropagation()}>
       {items.map((it, i) => {
         if (it.divider) return <div key={i} className="hal0-menu-divider" />;
+        const isDisabled = !!it.disabled;
         return (
           <div
             key={i}
-            className={"hal0-menu-item" + (it.danger ? " danger" : "")}
-            onClick={() => { it.onClick && it.onClick(); onClose && onClose(); }}
+            className={"hal0-menu-item"
+              + (it.danger ? " danger" : "")
+              + (isDisabled ? " disabled" : "")}
+            title={it.hint || undefined}
+            aria-disabled={isDisabled || undefined}
+            style={isDisabled ? { opacity: 0.5, cursor: "not-allowed" } : undefined}
+            onClick={() => {
+              if (isDisabled) return;
+              it.onClick && it.onClick();
+              onClose && onClose();
+            }}
           >
             {it.icon && <span className="hal0-menu-ic">{it.icon}</span>}
             <span className="hal0-menu-lbl">{it.label}</span>

--- a/ui/tests/e2e/specs/mcp-v3-wired.spec.ts
+++ b/ui/tests/e2e/specs/mcp-v3-wired.spec.ts
@@ -145,7 +145,7 @@ test.describe('MCP v3 wired (#206)', () => {
     await expect(page.locator('.mcp-install-name', { hasText: 'github' })).toBeVisible()
   })
 
-  test('install button surfaces 501 toast (ADR-0013 stub)', async ({ page }) => {
+  test('catalog install fires real POST and surfaces success toast (#305)', async ({ page }) => {
     // Capture toast calls. The dashboard installs its own
     // window.__hal0Toast inside a useEffect at mount, so an
     // addInitScript override gets clobbered. Instead define a property
@@ -167,18 +167,22 @@ test.describe('MCP v3 wired (#206)', () => {
       })
     })
 
-    // Override the install POST to return the actual 501 envelope. The
-    // override registers AFTER the beforeEach so Playwright (reverse
-    // registration order) matches this one first.
+    // Install POST returns a real 201 envelope per #305 — covers the
+    // happy path the (now-deleted) 501 stub test used to live on.
     await page.route('**/api/mcp/install', (route) =>
       route.fulfill({
-        status: 501,
+        status: 201,
         contentType: 'application/json',
         body: JSON.stringify({
-          error: {
-            code: 'mcp.not_implemented',
-            message: 'MCP install pending ADR-0013 follow-up (#206)',
-            details: {},
+          installed: {
+            id: 'filesystem',
+            name: 'filesystem',
+            spec: 'npm:@modelcontextprotocol/server-filesystem',
+            transport: 'stdio',
+            tools: 5,
+            env: {},
+            enabled: true,
+            installed_at: new Date().toISOString(),
           },
         }),
       }),
@@ -187,20 +191,15 @@ test.describe('MCP v3 wired (#206)', () => {
     const installRequest = page.waitForRequest('**/api/mcp/install', { timeout: 8_000 })
 
     await page.goto('/#mcp')
-    // Wait for the page's "Install" header button (opens the drawer).
     await page.locator('.vh button', { hasText: 'Install' }).first().click()
-    // Wait for catalog to populate then click the per-item Install.
     await expect(page.locator('.mcp-install-name', { hasText: 'filesystem' })).toBeVisible()
     await page
       .locator('.mcp-install-item', { has: page.locator('.mcp-install-name', { hasText: 'filesystem' }) })
       .locator('button', { hasText: 'Install' })
       .click()
 
-    // Confirm the install POST actually fires (proves the wiring).
     await installRequest
 
-    // Mutation hook fires; the toast lands asynchronously after the
-    // 501 response, so poll the captured array.
     await expect
       .poll(
         async () => {
@@ -210,8 +209,48 @@ test.describe('MCP v3 wired (#206)', () => {
       )
       .toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ msg: expect.stringContaining('ADR-0013') }),
+          expect.objectContaining({ msg: expect.stringContaining('Installed') }),
         ]),
       )
+  })
+
+  test('install-from-URL preview renders resolved manifest (#224)', async ({ page }) => {
+    // Stub the /api/mcp/resolve endpoint so the drawer's URL tab gets
+    // a deterministic manifest preview. The drawer's preview card reads
+    // name + description + tools from the response — none of those
+    // should be the legacy "mcp-things" placeholder anymore.
+    await page.route('**/api/mcp/resolve*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'filesystem',
+          name: 'filesystem',
+          description: 'Read, write, and search files inside an allowlisted root.',
+          spec: 'uvx:mcp-server-filesystem',
+          transport: 'stdio',
+          tools: 5,
+          resources: 0,
+          prompts: 0,
+          env_required: ['MCP_WORKSPACE'],
+          source_kind: 'uvx',
+          author: 'modelcontextprotocol',
+          verified: true,
+        }),
+      }),
+    )
+
+    await page.goto('/#mcp')
+    await page.locator('.vh button', { hasText: 'Install' }).first().click()
+    await page.locator('button.mcp-install-tab', { hasText: 'From URL' }).click()
+    await page.locator('.mcp-install-url input').fill('uvx:mcp-server-filesystem')
+
+    const preview = page.locator('[data-testid="mcp-install-url-preview"]')
+    await expect(preview).toBeVisible()
+    await expect(preview.locator('[data-testid="mcp-install-resolved-name"]')).toHaveText('filesystem')
+    await expect(preview.locator('[data-testid="mcp-install-resolved-desc"]')).toContainText('allowlisted root')
+    await expect(preview.locator('[data-testid="mcp-install-resolved-tools"]')).toContainText('5 tools')
+    // Verify the deprecated placeholder is GONE.
+    await expect(preview).not.toContainText('mcp-things')
   })
 })


### PR DESCRIPTION
## Summary

Three v0.3 dashboard issues for the /agents/mcp page, closed together because they share the same install-lifecycle wiring.

**#305 — install/uninstall/config endpoints.** Swap the 501 stubs for real handlers backed by a new `hal0.mcp.installed` registry (one TOML file per server under `/etc/hal0/mcp-servers/<id>.toml`, mirroring the slot/upstream layout). Bundled servers (`hal0-admin`, `hal0-memory`) are uninstall-protected via a reserved-id check returning `409 mcp.bundled`. The process supervisor that would actually spawn installed MCPs is **not** in this PR — installed records report `state="stopped"` in `/api/mcp/servers` and `POST /{id}/{action}` still 501s. That's a tracked follow-up to #305.

**#224 — install-from-URL placeholder.** Add `hal0.mcp.manifest` + `GET /api/mcp/resolve?url=…`. Supports `oci://`, `npm:`, `uvx:`, `git+https://`, and live JSON manifest fetch. The InstallDrawer's URL tab debounces by 350 ms, then renders the resolved name/description/tools/env-required straight from the response — the `mcp-things` literal is gone.

**#222 — live tool-call stream.** Strip `useLiveCallStreamLocal` (the `Math.random()`-driven synthetic ticker) from the MCP page entirely. The LiveTimeline now reads strictly from the real `/api/mcp/stream` SSE buffer; when the audit log is silent the timeline renders blank (truthful "no recent activity"). Toast IDs still use `Date.now() + Math.random()` — legitimate, kept.

### Notable scope notes

* `mcp_client.py` (ADR-0013 agent-side allow-list) is **not** the lifecycle owner — that's outbound (agent → external MCP). #305 needed a separate inbound registry, which this PR adds.
* Catalog rows gained a `spec` field (`npm:@modelcontextprotocol/server-<id>`) so a one-click catalog install resolves to a real package spec, not just the catalog id.
* The action-stub (`POST /{id}/{action}`) keeps the `McpNotImplemented` 501 path; the UI's restart hook catches it and surfaces a distinct "pending supervisor follow-up" toast so the install/uninstall (now real) vs restart (still pending) split is clear to operators.

## Security hardening (review pass, commit 72c634a)

Addressing the request-changes review on the initial drop:

* **SSRF guard on `/api/mcp/resolve`** — without auth on the LAN, the previous implementation let any caller probe loopback / private RFC 1918 / link-local (incl. AWS+GCP IMDS at `169.254.169.254`) / `*.local` mDNS / CGNAT via a manifest GET that followed redirects. `_is_safe_url` now parses, resolves the hostname via `getaddrinfo`, and rejects any IP that lands in deny space — and the default fetcher runs with `follow_redirects=False` so a 30x to a private host can't bypass the pre-flight check. Surfaces as `400 mcp.ssrf_blocked`.
* **Registry permissions** — TOML records under `/etc/hal0/mcp-servers/` hold the per-server `env` block (canonical home for community-MCP API keys). After every atomic write we now chmod the directory to `0o700` and the file to `0o600` so a default-umask install doesn't leave them world-readable.
* **`assert` → `BadRequest`** in `_resolve_oci/_npm/_uvx/_git` so `python -O` (strips asserts) surfaces a typed error code instead of an `AttributeError` on a malformed spec.
* **Tools-list cap** — `_coerce_int` for list input now returns `min(len, 4096)` to match the schema's pydantic `le=4096` upper bound; a runaway manifest no longer 500s on validation.
* **UI supervisor gate** — `SUPERVISOR_AVAILABLE = false` for v0.3 alpha gates Start / Restart / Disable controls on non-bundled rows; buttons render disabled with a "Supervisor not yet implemented" tooltip until the follow-up to #305 lands. Bundled (in-process FastMCP) rows are unaffected.

New tests: 5 SSRF + 1 redirect-disabled + 1 permissions + 1 tools-cap + 1 route-level SSRF + 1 oversized manifest + 1 bundled-id uninstall at registry layer + 1 path-traversal id.

### Deferred follow-ups

These came out of the review and are intentionally **not** in this PR — captured for `/to-issues`:

* Streaming-fetch with a running byte counter (vs `read body then check len`) — current cap fires after the read, which still bounds memory at 256 KiB but means an attacker can force the server to receive that much.
* `patch_config` read-modify-write race — concurrent PATCHes can clobber each other; needs a per-server file lock.
* Bundled-shadow via root filedrop — physical-access-only; bundled-ids are filtered out of `list_installed()` so a manual `/etc/hal0/mcp-servers/hal0-admin.toml` drop can't shadow the in-process FastMCP mount anyway.

## Test plan

- [x] `uv run pytest tests/api/ tests/mcp/ -q` — 485 passed, 3 unrelated skips
- [x] `uv run ruff check` / `ruff format --check` on all touched files — clean
- [x] `npm run typecheck` + `npm run build` — clean (540 kB JS bundle, unchanged baseline)
- [x] `tests/api/test_mcp_routes.py` — install/uninstall/patch/resolve happy + sad paths, bundled-id guard, duplicate detection, env coercion, **+ SSRF + oversized + path-traversal**
- [x] `tests/mcp/test_installed.py` — registry round-trip, malformed-file tolerance, charset validation, **+ 0o600/0o700 perms, bundled-uninstall, path-traversal id**
- [x] `tests/mcp/test_manifest.py` — oci/npm/uvx/git/http parsing, fake-fetcher injection, error envelope mapping, **+ loopback / RFC 1918 / link-local / mDNS / redirect-disabled / tools-cap**
- [x] `ui/tests/e2e/specs/mcp-v3-wired.spec.ts` — rewrote the legacy 501 test to assert the real 201 + success toast; added an install-from-URL test that asserts the `mcp-things` placeholder is gone and the resolved name/desc/tools render from `/api/mcp/resolve`
- [ ] LXC smoke (host curl /api/mcp/install with `{url: "uvx:mcp-server-filesystem"}`) — deferred to merge-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)