### PR TITLE
fix(memory): honor per-call client_id on read path + audit (Phase D regression)

### DIFF
--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -341,6 +341,7 @@ async def memory_add(request: Request) -> dict[str, Any]:
         tags=body.get("tags") or [],
         source=agent_id,
         metadata=body.get("metadata") or {},
+        client_id=agent_id if agent_id != "anonymous" else None,
     )
 
 
@@ -383,6 +384,7 @@ async def memory_search(request: Request) -> dict[str, Any]:
         tags=body.get("tags") or [],
         before=body.get("before"),
         after=body.get("after"),
+        client_id=agent_id if agent_id != "anonymous" else None,
     )
     return {"items": items}
 
@@ -413,7 +415,12 @@ async def memory_list(
         raise MemoryNamespaceInvalid(str(exc)) from exc
 
     wrapper = _wrapper(request)
-    return await wrapper.list_items(dataset=resolved, cursor=cursor, limit=limit)
+    return await wrapper.list_items(
+        dataset=resolved,
+        cursor=cursor,
+        limit=limit,
+        client_id=agent_id if agent_id != "anonymous" else None,
+    )
 
 
 @router.post("/delete")
@@ -432,8 +439,12 @@ async def memory_delete(request: Request) -> dict[str, int]:
             "memory_delete requires 'ids' (non-empty list)",
             details={"path": "/api/memory/delete"},
         )
+    agent_id = _agent_id(request)
     wrapper = _wrapper(request)
-    return await wrapper.delete(ids=ids)
+    return await wrapper.delete(
+        ids=ids,
+        client_id=agent_id if agent_id != "anonymous" else None,
+    )
 
 
 async def _read_json_body(request: Request) -> dict[str, Any]:

--- a/src/hal0/mcp/memory.py
+++ b/src/hal0/mcp/memory.py
@@ -213,6 +213,7 @@ async def _memory_add(
         tags=tags,
         source=source,
         metadata=metadata_raw,
+        client_id=client_id,
     )
     return {
         "id": result["id"],
@@ -265,6 +266,7 @@ async def _memory_search(
         tags=tags,
         before=before,
         after=after,
+        client_id=client_id,
     )
     return {"results": list(results)}
 
@@ -285,7 +287,9 @@ async def _memory_list(
     limit_raw = args.get("limit", 50)
     if not isinstance(limit_raw, int) or limit_raw < 1 or limit_raw > 200:
         raise MemorySchemaError("limit must be 1..200")
-    page = await wrapper.list_items(dataset=dataset, cursor=cursor, limit=limit_raw)
+    page = await wrapper.list_items(
+        dataset=dataset, cursor=cursor, limit=limit_raw, client_id=client_id
+    )
     return {
         "items": list(page.get("items", [])),
         "next_cursor": page.get("next_cursor"),
@@ -310,7 +314,7 @@ async def _memory_delete(
     if not isinstance(ids_raw, list) or not ids_raw:
         raise MemorySchemaError("ids must be a non-empty list[str]")
     ids = [str(i) for i in ids_raw]
-    result = await wrapper.delete(ids=ids)
+    result = await wrapper.delete(ids=ids, client_id=client_id)
     deleted_raw = result.get("deleted", len(ids))
     # Accept either a count or the list of deleted ids from the wrapper
     # so we're forgiving of either contract while still returning the

--- a/src/hal0/memory/cognee_wrapper.py
+++ b/src/hal0/memory/cognee_wrapper.py
@@ -446,17 +446,24 @@ class CogneeWrapper:
 
     # ── Audit log ──────────────────────────────────────────────────────
 
-    def _audit(self, op: str, dataset: str, **extra: Any) -> None:
+    def _audit(self, op: str, dataset: str, *, client_id: str | None = None, **extra: Any) -> None:
         """Emit a structured audit event (ADR-0005 §5).
 
         Every call surface logs ``hal0.memory.audit`` with at minimum
         ``client_id, op, dataset, timestamp`` so journald / log
         aggregators can build per-client memory access traces. ``extra``
         carries op-specific context (e.g. ``count`` for delete).
+
+        ``client_id`` lets transport-layer callers (REST + MCP) stamp
+        the resolved per-call identity onto the audit row instead of
+        the singleton wrapper's constructor value (which is
+        ``"anonymous"`` on the production wrapper). Without this
+        override, every audit row on the singleton wrapper looked
+        identical and forensics had to cross-reference HTTP logs.
         """
         event = {
             "event": AUDIT_EVENT,
-            "client_id": self._client_id,
+            "client_id": client_id or self._client_id,
             "op": op,
             "dataset": dataset,
             "timestamp": _now_iso(),
@@ -481,6 +488,7 @@ class CogneeWrapper:
         tags: list[str] | None = None,
         source: str | None = None,
         metadata: dict[str, Any] | None = None,
+        client_id: str | None = None,
     ) -> dict[str, str]:
         """Add a memory item. Returns ``{id, timestamp}``.
 
@@ -490,18 +498,24 @@ class CogneeWrapper:
         cannot escape their own private bucket by passing
         ``dataset="shared"``.
 
-        ``source`` defaults to the constructor's ``client_id``. Callers
-        may pass an override (e.g. a sub-agent identifier) but the
-        ``client_id`` from the Bearer token is what shows up in the
-        audit log either way — clients can annotate but cannot
-        impersonate.
+        ``source`` defaults to ``client_id`` (resolved per-call) or the
+        constructor's value. Callers may pass an override (e.g. a
+        sub-agent identifier) but the resolved identity is what shows
+        up in the audit log either way — clients can annotate but
+        cannot impersonate.
+
+        ``client_id`` lets the REST + MCP transport layers stamp the
+        per-call resolved identity onto audit rows and ``source``.
+        Without it, the singleton wrapper's constructor-pinned
+        ``"anonymous"`` masked every per-agent caller.
         """
         if tags is None:
             tags = []
         if metadata is None:
             metadata = {}
+        effective_client_id = client_id or self._client_id
         effective_dataset = self._effective_write_dataset(dataset)
-        effective_source = source or self._client_id
+        effective_source = source or effective_client_id
         item_id = str(uuid.uuid4())
         timestamp = _now_iso()
 
@@ -543,7 +557,13 @@ class CogneeWrapper:
             )
             conn.commit()
 
-        self._audit("add", effective_dataset, item_id=item_id, tags=list(tags))
+        self._audit(
+            "add",
+            effective_dataset,
+            client_id=effective_client_id,
+            item_id=item_id,
+            tags=list(tags),
+        )
 
         # ADR-0014 §1+§6 — when graph extraction is on, enqueue a
         # background cognify pass after the foreground add returns. The
@@ -665,6 +685,7 @@ class CogneeWrapper:
         before: str | None = None,
         after: str | None = None,
         mode: str = "vector",
+        client_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """Vector + filter search. Returns list of dicts (MemoryRecord shape).
 
@@ -694,15 +715,16 @@ class CogneeWrapper:
             raise ValueError(
                 f"search mode {mode!r} is not valid; choose from 'vector' | 'graph' | 'hybrid'"
             )
+        effective_client_id = client_id or self._client_id
         if mode != "vector" and not self._graph_enabled:
             _audit_logger().info(
                 "hal0.memory.search.mode_fallback",
-                client_id=self._client_id,
+                client_id=effective_client_id,
                 requested_mode=mode,
                 resolved_mode="vector",
                 reason="graph_extraction_disabled",
             )
-        allowed_datasets = self._allowed_read_datasets(dataset)
+        allowed_datasets = self._allowed_read_datasets(dataset, client_id=client_id)
 
         cognee = _cognee()
         # Local import: SearchType is part of Cognee's deep module tree;
@@ -751,7 +773,13 @@ class CogneeWrapper:
                 or "DatabaseNotCreatedError" in exc_str
             )
             if is_first_run:
-                self._audit("search", ",".join(allowed_datasets), query=query, results=0)
+                self._audit(
+                    "search",
+                    ",".join(allowed_datasets),
+                    client_id=effective_client_id,
+                    query=query,
+                    results=0,
+                )
                 return []
             raise
 
@@ -818,6 +846,7 @@ class CogneeWrapper:
         self._audit(
             "search",
             ",".join(allowed_datasets),
+            client_id=effective_client_id,
             query=query,
             results=len(out),
             reranked=reranked,
@@ -829,6 +858,7 @@ class CogneeWrapper:
         dataset: str = SHARED_DATASET,
         cursor: str | None = None,
         limit: int = 50,
+        client_id: str | None = None,
     ) -> dict[str, Any]:
         """Paginated list. Cursor is the last-seen item id.
 
@@ -843,7 +873,8 @@ class CogneeWrapper:
         ``private:bob`` from ``alice`` yields an empty list, not an
         error (ADR-0005 §3 leans toward fail-open-empty for reads).
         """
-        allowed_datasets = self._allowed_read_datasets(dataset)
+        effective_client_id = client_id or self._client_id
+        allowed_datasets = self._allowed_read_datasets(dataset, client_id=client_id)
         with self._sidecar_conn() as conn:
             params: list[Any] = list(allowed_datasets)
             placeholders = ",".join("?" * len(allowed_datasets))
@@ -871,10 +902,15 @@ class CogneeWrapper:
             rows = rows[:limit]
             next_cursor = rows[-1]["id"]
         items = [_row_to_record(r, score=None).to_dict() for r in rows]
-        self._audit("list_items", ",".join(allowed_datasets), count=len(items))
+        self._audit(
+            "list_items",
+            ",".join(allowed_datasets),
+            client_id=effective_client_id,
+            count=len(items),
+        )
         return {"items": items, "next_cursor": next_cursor}
 
-    async def delete(self, ids: list[str]) -> dict[str, int]:
+    async def delete(self, ids: list[str], *, client_id: str | None = None) -> dict[str, int]:
         """Delete by sidecar id. Returns ``{deleted: int}``.
 
         We delete from BOTH the sidecar AND Cognee's own dataset rows
@@ -887,8 +923,15 @@ class CogneeWrapper:
         Empty list is a no-op (``{"deleted": 0}``) — defensive against
         callers handing us ``ids=[]`` rather than guarding upstream.
         """
+        effective_client_id = client_id or self._client_id
         if not ids:
-            self._audit("delete", "-", requested=0, deleted=0)
+            self._audit(
+                "delete",
+                "-",
+                client_id=effective_client_id,
+                requested=0,
+                deleted=0,
+            )
             return {"deleted": 0}
 
         cognee = _cognee()
@@ -910,7 +953,9 @@ class CogneeWrapper:
                 # against a leaked id being used to reach into a different
                 # client's private namespace. (v0.2 single-user => moot
                 # in practice, but the check is cheap + Phase-9-ready.)
-                if row["dataset"] not in self._allowed_read_datasets(SHARED_DATASET):
+                if row["dataset"] not in self._allowed_read_datasets(
+                    SHARED_DATASET, client_id=client_id
+                ):
                     continue
                 if row["cognee_data_id"] and row["cognee_dataset_id"]:
                     try:
@@ -924,7 +969,7 @@ class CogneeWrapper:
                         # the count.
                         _audit_logger().warning(
                             "hal0.memory.delete.cognee_miss",
-                            client_id=self._client_id,
+                            client_id=effective_client_id,
                             item_id=item_id,
                         )
                 conn.execute(
@@ -938,6 +983,7 @@ class CogneeWrapper:
         self._audit(
             "delete",
             ",".join(sorted(wipes_by_dataset)) or "-",
+            client_id=effective_client_id,
             requested=len(ids),
             deleted=deleted,
         )
@@ -1100,7 +1146,9 @@ class CogneeWrapper:
         # private:* values before this point (issue #367).
         return requested or SHARED_DATASET
 
-    def _allowed_read_datasets(self, requested: str | list[str]) -> list[str]:
+    def _allowed_read_datasets(
+        self, requested: str | list[str], *, client_id: str | None = None
+    ) -> list[str]:
         """Intersect requested datasets with the caller's read scope.
 
         Always includes ``shared`` plus the caller's own
@@ -1108,13 +1156,22 @@ class CogneeWrapper:
         different private namespace, it's dropped silently — read
         attempts on another client's private bucket don't error
         (avoid leaking existence) but never return data.
+
+        ``client_id`` lets transport-layer callers pass the resolved
+        per-call identity so reads honor the same ADR-0005 §3 scoping
+        the write path does (PR #366). Without this override, the
+        singleton wrapper's constructor-pinned ``"anonymous"`` drops
+        every per-agent ``private:<id>`` as "another client's private"
+        — agents could write to their private bucket but never search
+        it back.
         """
         if isinstance(requested, str):
             requested_list = [requested]
         else:
             requested_list = list(requested) if requested else [SHARED_DATASET]
         out: list[str] = []
-        own_private = f"{PRIVATE_PREFIX}{self._client_id}"
+        effective_id = client_id or self._client_id
+        own_private = f"{PRIVATE_PREFIX}{effective_id}"
         for ds in requested_list:
             if ds == SHARED_DATASET:
                 out.append(SHARED_DATASET)

--- a/tests/api/test_memory_rest_routes.py
+++ b/tests/api/test_memory_rest_routes.py
@@ -57,6 +57,7 @@ class StubWrapper:
         tags: list[str],
         source: str | None,
         metadata: dict[str, Any],
+        client_id: str | None = None,
     ) -> dict[str, Any]:
         self.add_calls.append(
             {
@@ -65,6 +66,7 @@ class StubWrapper:
                 "tags": tags,
                 "source": source,
                 "metadata": metadata,
+                "client_id": client_id,
             }
         )
         self._counter += 1
@@ -78,8 +80,8 @@ class StubWrapper:
         self.list_calls.append(kwargs)
         return {"items": [{"id": "id-1"}], "next_cursor": None}
 
-    async def delete(self, *, ids: list[str]) -> dict[str, Any]:
-        self.delete_calls.append({"ids": list(ids)})
+    async def delete(self, *, ids: list[str], client_id: str | None = None) -> dict[str, Any]:
+        self.delete_calls.append({"ids": list(ids), "client_id": client_id})
         return {"deleted": len(ids)}
 
 
@@ -290,7 +292,7 @@ def test_delete_passes_ids_unchanged(client: TestClient, stub_wrapper: StubWrapp
         headers={"X-hal0-Agent": "hermes-agent", "X-hal0-Private": "1"},
     )
     assert r.status_code == 200, r.text
-    assert stub_wrapper.delete_calls == [{"ids": ["a", "b"]}]
+    assert stub_wrapper.delete_calls == [{"ids": ["a", "b"], "client_id": "hermes-agent"}]
     assert r.json() == {"deleted": 2}
 
 
@@ -424,3 +426,69 @@ def test_cross_client_private_writes_not_visible_to_other_agents(
         if isinstance(search_call["dataset"], list)
         else [search_call["dataset"]]
     )
+
+
+# ── Read-side namespace plumbing (Phase D regression fix) ──────────────────
+
+
+def test_search_route_passes_resolved_client_id_to_wrapper(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """REST search route must thread X-hal0-Agent through as client_id so
+    the wrapper's _allowed_read_datasets honors per-call identity.
+    Without this, hermes-agent writes to private:hermes-agent but
+    memory_search returns 0 because the singleton wrapper drops
+    private:hermes-agent as "another client's private".
+    """
+    r = client.post(
+        "/api/memory/search",
+        json={"query": "hi"},
+        headers={"X-hal0-Agent": "hermes-agent", "X-hal0-Private": "1"},
+    )
+    assert r.status_code == 200, r.text
+    sc = stub_wrapper.search_calls[-1]
+    assert sc["client_id"] == "hermes-agent"
+
+
+def test_list_route_passes_resolved_client_id_to_wrapper(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """REST list route mirrors search — must thread client_id."""
+    r = client.get(
+        "/api/memory/list",
+        headers={"X-hal0-Agent": "hermes-agent", "X-hal0-Private": "1"},
+    )
+    assert r.status_code == 200, r.text
+    lc = stub_wrapper.list_calls[-1]
+    assert lc["client_id"] == "hermes-agent"
+
+
+def test_add_route_passes_resolved_client_id_to_wrapper(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """REST add route threads client_id so audit log stamps the
+    per-call identity instead of the singleton's "anonymous".
+    """
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "secret"},
+        headers={"X-hal0-Agent": "agent-a", "X-hal0-Private": "1"},
+    )
+    assert r.status_code == 200, r.text
+    ac = stub_wrapper.add_calls[-1]
+    assert ac["client_id"] == "agent-a"
+    assert ac["source"] == "agent-a"
+    assert ac["dataset"] == "private:agent-a"
+
+
+def test_anonymous_call_passes_no_client_id(client: TestClient, stub_wrapper: StubWrapper) -> None:
+    """No X-hal0-Agent header → client_id=None passed to wrapper so the
+    wrapper falls back to its constructor value (legacy behavior).
+    """
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "anon"},
+    )
+    assert r.status_code == 200, r.text
+    ac = stub_wrapper.add_calls[-1]
+    assert ac["client_id"] is None

--- a/tests/mcp/test_memory.py
+++ b/tests/mcp/test_memory.py
@@ -34,6 +34,7 @@ class _FakeWrapper:
         tags: list[str],
         source: str,
         metadata: dict[str, Any],
+        client_id: str | None = None,
     ) -> dict[str, Any]:
         self.add_calls.append(
             {
@@ -42,6 +43,7 @@ class _FakeWrapper:
                 "tags": tags,
                 "source": source,
                 "metadata": metadata,
+                "client_id": client_id,
             }
         )
         self._counter += 1
@@ -55,8 +57,8 @@ class _FakeWrapper:
         self.list_calls.append(kwargs)
         return {"items": [{"id": "id-1"}], "next_cursor": None}
 
-    async def delete(self, *, ids: list[str]) -> dict[str, Any]:
-        self.delete_calls.append({"ids": ids})
+    async def delete(self, *, ids: list[str], client_id: str | None = None) -> dict[str, Any]:
+        self.delete_calls.append({"ids": ids, "client_id": client_id})
         return {"deleted": len(ids)}
 
 

--- a/tests/memory/test_namespace_wrapper.py
+++ b/tests/memory/test_namespace_wrapper.py
@@ -169,3 +169,83 @@ async def test_add_forwards_resolved_private_dataset_to_cognee(tmp_path: Any) ->
     # resolved string, NOT "shared".
     assert captured["dataset_name"] == "private:hermes-agent"
     assert captured["embed_datasets"] == ["private:hermes-agent"]
+
+
+# ── Read-side namespace tests (Phase D regression — read side mirror of #367) ──
+#
+# PR #366 fixed the write path (_effective_write_dataset) but the read path
+# (_allowed_read_datasets) still gated on the SINGLETON wrapper's pinned
+# client_id (= "anonymous"). Agents could write to their private bucket but
+# search returned 0 — hermes_provision memory_roundtrip smoke failed.
+#
+# These tests pin that _allowed_read_datasets + the public search/list_items
+# / delete surfaces honor a per-call client_id when transport-layer callers
+# (REST/MCP) thread their resolved identity through.
+
+
+def test_allowed_read_uses_resolved_client_id_not_singleton() -> None:
+    """Singleton wrapper (client_id=anonymous), per-call client_id="agent-a"
+    → caller sees their own private:agent-a alongside shared, NOT
+    private:anonymous.
+    """
+    w = _bare_wrapper(client_id="anonymous", private_mode=False)
+    allowed = w._allowed_read_datasets(SHARED_DATASET, client_id="agent-a")
+    assert SHARED_DATASET in allowed
+    assert "private:agent-a" in allowed
+    assert "private:anonymous" not in allowed
+
+
+def test_allowed_read_drops_other_agents_private() -> None:
+    """Agent-a explicitly requests agent-b's private namespace → silently
+    dropped (read-attempts on another client's bucket don't error to avoid
+    leaking existence, but they NEVER return data).
+    """
+    w = _bare_wrapper(client_id="anonymous", private_mode=False)
+    allowed = w._allowed_read_datasets("private:agent-b", client_id="agent-a")
+    # agent-b's namespace dropped silently — only own private survives if
+    # requested via shared default; since we asked specifically for b's,
+    # nothing returns.
+    assert "private:agent-b" not in allowed
+
+
+def test_allowed_read_own_private_when_explicit() -> None:
+    """Asking for OWN private namespace by full name keeps it."""
+    w = _bare_wrapper(client_id="anonymous", private_mode=False)
+    allowed = w._allowed_read_datasets("private:agent-a", client_id="agent-a")
+    assert allowed == ["private:agent-a"]
+
+
+def test_allowed_read_falls_back_to_singleton_when_no_call_id() -> None:
+    """Backwards-compat: existing callers that don't pass client_id keep
+    the legacy behavior (intersect against the wrapper's constructor id).
+    """
+    w = _bare_wrapper(client_id="alice", private_mode=False)
+    allowed = w._allowed_read_datasets(SHARED_DATASET)  # no client_id kwarg
+    assert "private:alice" in allowed
+    assert SHARED_DATASET in allowed
+
+
+def test_audit_stamps_resolved_client_id() -> None:
+    """Audit row uses the per-call client_id, not the singleton's
+    "anonymous". Without this, forensic log-driven trace per agent is
+    impossible on the production singleton wrapper.
+    """
+    w = _bare_wrapper(client_id="anonymous", private_mode=False)
+    # Initialise the audit-tail attributes that __init__ would normally set.
+    w.audit_tail = []  # type: ignore[attr-defined]
+    w._audit_tail_max = 1024  # type: ignore[attr-defined]
+    w._audit("add", "private:agent-a", client_id="agent-a", item_id="x")
+    assert len(w.audit_tail) == 1
+    assert w.audit_tail[0]["client_id"] == "agent-a"
+    assert w.audit_tail[0]["dataset"] == "private:agent-a"
+
+
+def test_audit_falls_back_to_singleton_when_no_call_id() -> None:
+    """Backwards-compat: callers that don't pass client_id get the
+    constructor value, same as pre-fix behavior.
+    """
+    w = _bare_wrapper(client_id="alice", private_mode=False)
+    w.audit_tail = []  # type: ignore[attr-defined]
+    w._audit_tail_max = 1024  # type: ignore[attr-defined]
+    w._audit("add", "shared", item_id="x")
+    assert w.audit_tail[0]["client_id"] == "alice"


### PR DESCRIPTION
**Phase D integration smoke caught a regression** in the v0.3 MCP completion push (#364 #365 #366 #368 — all merged to main earlier this session).

## The bug

PR #366 fixed `_effective_write_dataset` (write path) but `_allowed_read_datasets` (read path) still gated on the **singleton wrapper's pinned `client_id`** (= `"anonymous"` on the production wrapper). So:

- ✅ Per-agent **writes** landed in `private:<agent>` correctly (PR #366)
- ❌ Per-agent **reads** filtered against `private:anonymous` instead of `private:<agent>` → agents could write to their private bucket but never search it back
- ❌ Audit log `client_id` was likewise stamped from the constructor — every row read `"anonymous"` regardless of `X-hal0-Agent`

`hermes_provision` `memory_roundtrip` smoke failed across every bootstrap because of this.

## The fix

Thread the resolved per-call `client_id` through the read path + audit stamping, mirroring the write-side fix:

| File | Change |
|---|---|
| `src/hal0/memory/cognee_wrapper.py` | `_audit` + `_allowed_read_datasets` + `search` + `list_items` + `delete` + `add` accept optional `client_id` |
| `src/hal0/api/routes/memory.py` | Routes pass `agent_id` (from `X-hal0-Agent`) to wrapper |
| `src/hal0/mcp/memory.py` | Dispatchers pass MCP `client_id` to wrapper |

**Backwards compatible:** callers that don't pass `client_id` fall back to the constructor value (legacy behavior). Tests pin both the new + legacy paths.

## Tests

- `tests/memory/test_namespace_wrapper.py`: 6 new — `_allowed_read_datasets` honors per-call id; drops other agents' private; falls back when no kwarg; `_audit` stamps resolved id
- `tests/api/test_memory_rest_routes.py`: 4 new — REST search/list/add/delete actually thread `client_id` to wrapper; anonymous call passes `None`
- All 561 pre-existing non-slow tests still green

## Verification
- `ruff check` + `ruff format --check`: clean
- `pytest tests/api/ tests/mcp/ tests/memory/ -m "not slow"`: 561 passed, 3 unrelated skips