### PR TITLE
feat(dash,pve): MemoryMap redesign — GTT-first, Proxmox-aware, sidebar + hardware page

### DIFF
--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -352,7 +352,17 @@ async def stats_hardware(request: Request) -> dict[str, Any]:
                         f"Proxmox host integration recovered ({full.get('node', '?')})",
                         data={"node": full.get("node")},
                     )
-        primary["host"] = pve.project_slim(full)
+        slim = pve.project_slim(full)
+        # When unconfigured, also fold in best-effort detection so the
+        # dashboard can render a "Configure Proxmox →" nudge.
+        if not slim.get("configured"):
+            state = pve.detect_proxmox_host()
+            detected = state == pve.PveDetectionState.DETECTED
+            slim = {"configured": False, "detected": detected}
+            if detected:
+                slim["detection"] = state.value
+                slim["hint"] = "Configure /etc/hal0/proxmox.json to see host pressure."
+        primary["host"] = slim
 
     primary["per_upstream"] = per_upstream
     primary["upstream_names"] = list(per_upstream.keys())

--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -13,6 +13,8 @@ from hal0.config.loader import load_hardware_info
 
 router = APIRouter()
 
+_PVE_CONFIGURE_HINT = "Configure /etc/hal0/proxmox.json to see host pressure."
+
 
 def _flatten_for_ui(info: dict[str, Any]) -> dict[str, Any]:
     """Project HardwareInfo into the fields the Vue Hardware view expects.
@@ -357,12 +359,17 @@ async def stats_hardware(request: Request) -> dict[str, Any]:
         # dashboard can render a "Configure Proxmox →" nudge.
         if not slim.get("configured"):
             state = pve.detect_proxmox_host()
-            detected = state == pve.PveDetectionState.DETECTED
-            slim = {"configured": False, "detected": detected}
-            if detected:
-                slim["detection"] = state.value
-                slim["hint"] = "Configure /etc/hal0/proxmox.json to see host pressure."
-        primary["host"] = slim
+            nudge = state in (
+                pve.PveDetectionState.DETECTED,
+                pve.PveDetectionState.UNCERTAIN,
+            )
+            host_block: dict[str, Any] = {"configured": False, "detected": nudge}
+            if nudge:
+                host_block["detection"] = state.value
+                host_block["hint"] = _PVE_CONFIGURE_HINT
+            primary["host"] = host_block
+        else:
+            primary["host"] = slim
 
     primary["per_upstream"] = per_upstream
     primary["upstream_names"] = list(per_upstream.keys())

--- a/src/hal0/hardware/pve.py
+++ b/src/hal0/hardware/pve.py
@@ -31,6 +31,7 @@ import os
 import ssl
 import tempfile
 import urllib.request
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -200,6 +201,61 @@ def _summarise(entries: list[dict[str, Any]]) -> dict[str, Any]:
         "tenants_allocated_mb": round(allocated_mb, 1),
         "tenants": tenants,
     }
+
+
+# ── Auto-detection (used when no proxmox.json is configured) ───────────────
+
+
+class PveDetectionState(StrEnum):
+    """Confidence that the current host is a Proxmox-managed LXC.
+
+    Used only when /etc/hal0/proxmox.json is missing — the UI surfaces a
+    non-blocking nudge in the DETECTED / UNCERTAIN cases.
+    """
+
+    NOT_DETECTED = "not_detected"
+    UNCERTAIN = "uncertain"
+    DETECTED = "detected"
+
+
+# Module-level Paths so tests can monkeypatch the read sources.
+_PROC_VERSION = Path("/proc/version")
+_PROC_1_CGROUP = Path("/proc/1/cgroup")
+
+
+def _has_pve_kernel() -> bool:
+    try:
+        return "-pve" in _PROC_VERSION.read_text(errors="ignore")
+    except OSError:
+        return False
+
+
+def _is_lxc_init() -> bool:
+    try:
+        text = _PROC_1_CGROUP.read_text(errors="ignore")
+    except OSError:
+        return False
+    # Proxmox LXCs put init under lxc.payload.<vmid>/… or /lxc/<vmid>/…
+    return "lxc.payload" in text or "/lxc/" in text
+
+
+def detect_proxmox_host() -> PveDetectionState:
+    """Best-effort detection of whether hal0 is running inside a Proxmox LXC.
+
+    Signals (each independent, none requires shelling out):
+      - /proc/version contains '-pve'   (strong)
+      - /proc/1/cgroup is lxc-shaped    (medium)
+
+    Two strong signals → DETECTED. One signal → UNCERTAIN. None → NOT_DETECTED.
+    Never raises; unreadable inputs collapse to NOT_DETECTED.
+    """
+    pve_kernel = _has_pve_kernel()
+    lxc_init = _is_lxc_init()
+    if pve_kernel and lxc_init:
+        return PveDetectionState.DETECTED
+    if pve_kernel or lxc_init:
+        return PveDetectionState.UNCERTAIN
+    return PveDetectionState.NOT_DETECTED
 
 
 # ── Slim projection + transition detection ──────────────────────────────────

--- a/src/hal0/hardware/pve.py
+++ b/src/hal0/hardware/pve.py
@@ -246,7 +246,7 @@ def detect_proxmox_host() -> PveDetectionState:
       - /proc/version contains '-pve'   (strong)
       - /proc/1/cgroup is lxc-shaped    (medium)
 
-    Two strong signals → DETECTED. One signal → UNCERTAIN. None → NOT_DETECTED.
+    Both signals present → DETECTED. Either signal alone → UNCERTAIN. Neither → NOT_DETECTED.
     Never raises; unreadable inputs collapse to NOT_DETECTED.
     """
     pve_kernel = _has_pve_kernel()
@@ -409,7 +409,9 @@ async def pve_test(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 __all__ = [
+    "PveDetectionState",
     "delete_pve_config",
+    "detect_proxmox_host",
     "invalidate_pve_cache",
     "pve_config_path",
     "pve_status",

--- a/tests/api/test_hardware_routes.py
+++ b/tests/api/test_hardware_routes.py
@@ -11,7 +11,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 import hal0.hardware.pve as pve_mod
-from hal0.api.routes.hardware import _flatten_for_ui, _platform_label
+from hal0.api.routes.hardware import _PVE_CONFIGURE_HINT, _flatten_for_ui, _platform_label
 from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
 
 
@@ -120,7 +120,7 @@ class TestHostDetectionInStatsHardware:
             "configured": False,
             "detected": True,
             "detection": "detected",
-            "hint": ("Configure /etc/hal0/proxmox.json to see host pressure."),
+            "hint": _PVE_CONFIGURE_HINT,
         }
 
     def test_unconfigured_not_detected_stays_silent(
@@ -193,24 +193,32 @@ class TestHostDetectionInStatsHardware:
         assert resp.status_code == 200
         host = resp.json()["host"]
 
-        # Configured-case path passes through project_slim() (which strips
-        # tenants[], host_cpu_count, host_uptime_s, tenants_allocated_mb).
-        # The remaining keys must all flow through unchanged.
-        assert host["configured"] is True
-        assert host["ok"] is True
-        assert host["node"] == "pve"
-        assert host["host_mem_total_mb"] == 131072.0
-        assert host["host_mem_used_mb"] == 24576.0
-        assert host["host_mem_free_mb"] == 106496.0
-        assert host["host_cpu_pct"] == 5.2
-        assert host["tenants_running"] == 1
-        assert host["tenants_total"] == 1
         # The new detection keys MUST NOT appear when configured=true.
-        assert "detected" not in host
-        assert "detection" not in host
-        assert "hint" not in host
-        # And the slim drop-keys MUST be absent (project_slim strips them).
-        assert "tenants" not in host
-        assert "host_cpu_count" not in host
-        assert "host_uptime_s" not in host
-        assert "tenants_allocated_mb" not in host
+        # The configured-case path is project_slim(full) — assert equality
+        # so an additive regression on the dict shape is caught.
+        from hal0.hardware.pve import project_slim
+
+        assert host == project_slim(configured_full)
+
+    def test_unconfigured_uncertain_also_nudges(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """UNCERTAIN — one weak signal — must still surface the nudge.
+        The pve.py docstring says the UI nudges on both DETECTED and
+        UNCERTAIN. Only the detection field distinguishes them."""
+        monkeypatch.setattr(pve_mod, "_load_pve_config", lambda: None)
+        monkeypatch.setattr(
+            pve_mod,
+            "detect_proxmox_host",
+            lambda: pve_mod.PveDetectionState.UNCERTAIN,
+        )
+        pve_mod.invalidate_pve_cache()
+        resp = client.get("/api/stats/hardware")
+        assert resp.status_code == 200
+        host = resp.json()["host"]
+        assert host == {
+            "configured": False,
+            "detected": True,
+            "detection": "uncertain",
+            "hint": _PVE_CONFIGURE_HINT,
+        }

--- a/tests/api/test_hardware_routes.py
+++ b/tests/api/test_hardware_routes.py
@@ -141,3 +141,76 @@ class TestHostDetectionInStatsHardware:
         # so the UI's shape-discriminator branch (configured vs detected vs
         # off) stays consistent.
         assert host == {"configured": False, "detected": False}
+
+    def test_configured_pass_through_unchanged(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When pve_status() returns configured=true, the detection block
+        must not modify it — the slim projection from project_slim() flows
+        through to the response untouched."""
+        configured_full = {
+            "configured": True,
+            "ok": True,
+            "node": "pve",
+            "host_mem_total_mb": 131072.0,
+            "host_mem_used_mb": 24576.0,
+            "host_mem_free_mb": 106496.0,
+            "host_cpu_pct": 5.2,
+            "host_cpu_count": 32,
+            "host_uptime_s": 1_089_410,
+            "tenants_running": 1,
+            "tenants_total": 1,
+            "tenants_allocated_mb": 8192.0,
+            "tenants": [
+                {
+                    "type": "lxc",
+                    "vmid": 105,
+                    "name": "hal0",
+                    "status": "running",
+                    "maxmem_mb": 98304.0,
+                    "mem_mb": 9216.0,
+                    "maxcpu": 16,
+                    "cpu_pct": 2.3,
+                    "node": "pve",
+                }
+            ],
+        }
+
+        async def fake_pve_status() -> dict[str, object]:
+            return configured_full
+
+        monkeypatch.setattr(pve_mod, "pve_status", fake_pve_status)
+
+        # detect_proxmox_host MUST NOT be consulted in the configured path —
+        # patch it to a sentinel that would fail the assertion if it ran.
+        def _should_not_run() -> pve_mod.PveDetectionState:
+            raise AssertionError("detect_proxmox_host called on configured host")
+
+        monkeypatch.setattr(pve_mod, "detect_proxmox_host", _should_not_run)
+        pve_mod.invalidate_pve_cache()
+
+        resp = client.get("/api/stats/hardware")
+        assert resp.status_code == 200
+        host = resp.json()["host"]
+
+        # Configured-case path passes through project_slim() (which strips
+        # tenants[], host_cpu_count, host_uptime_s, tenants_allocated_mb).
+        # The remaining keys must all flow through unchanged.
+        assert host["configured"] is True
+        assert host["ok"] is True
+        assert host["node"] == "pve"
+        assert host["host_mem_total_mb"] == 131072.0
+        assert host["host_mem_used_mb"] == 24576.0
+        assert host["host_mem_free_mb"] == 106496.0
+        assert host["host_cpu_pct"] == 5.2
+        assert host["tenants_running"] == 1
+        assert host["tenants_total"] == 1
+        # The new detection keys MUST NOT appear when configured=true.
+        assert "detected" not in host
+        assert "detection" not in host
+        assert "hint" not in host
+        # And the slim drop-keys MUST be absent (project_slim strips them).
+        assert "tenants" not in host
+        assert "host_cpu_count" not in host
+        assert "host_uptime_s" not in host
+        assert "tenants_allocated_mb" not in host

--- a/tests/api/test_hardware_routes.py
+++ b/tests/api/test_hardware_routes.py
@@ -7,6 +7,10 @@ silently regress the dashboard.
 
 from __future__ import annotations
 
+import pytest
+from fastapi.testclient import TestClient
+
+import hal0.hardware.pve as pve_mod
 from hal0.api.routes.hardware import _flatten_for_ui, _platform_label
 from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
 
@@ -91,3 +95,49 @@ def test_platform_label_for_known_strings() -> None:
     assert _platform_label("proxmox-kvm", {}) == "Proxmox VM (KVM)"
     assert _platform_label("lxc", {}) == "Linux container (LXC)"
     assert _platform_label("nonsense-value", {}) == "Unknown platform"
+
+
+class TestHostDetectionInStatsHardware:
+    """When proxmox.json is missing, /api/stats/hardware surfaces detection
+    state so the dashboard's MemoryMap can render a Configure → nudge."""
+
+    def test_unconfigured_detected_includes_detection_hint(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No proxmox.json → _load_pve_config returns None.
+        monkeypatch.setattr(pve_mod, "_load_pve_config", lambda: None)
+        monkeypatch.setattr(
+            pve_mod,
+            "detect_proxmox_host",
+            lambda: pve_mod.PveDetectionState.DETECTED,
+        )
+        # Avoid pve_status cache flake across tests.
+        pve_mod.invalidate_pve_cache()
+        resp = client.get("/api/stats/hardware")
+        assert resp.status_code == 200
+        host = resp.json()["host"]
+        assert host == {
+            "configured": False,
+            "detected": True,
+            "detection": "detected",
+            "hint": ("Configure /etc/hal0/proxmox.json to see host pressure."),
+        }
+
+    def test_unconfigured_not_detected_stays_silent(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pve_mod, "_load_pve_config", lambda: None)
+        monkeypatch.setattr(
+            pve_mod,
+            "detect_proxmox_host",
+            lambda: pve_mod.PveDetectionState.NOT_DETECTED,
+        )
+        pve_mod.invalidate_pve_cache()
+        resp = client.get("/api/stats/hardware")
+        assert resp.status_code == 200
+        host = resp.json()["host"]
+        # Bare-metal — keep the legacy single-key shape so older code that
+        # checks `host.configured` still works, but add `detected: false`
+        # so the UI's shape-discriminator branch (configured vs detected vs
+        # off) stays consistent.
+        assert host == {"configured": False, "detected": False}

--- a/tests/hardware/test_pve.py
+++ b/tests/hardware/test_pve.py
@@ -394,3 +394,12 @@ class TestDetectProxmoxHost:
         monkeypatch.setattr(pve, "_PROC_VERSION", bad)
         monkeypatch.setattr(pve, "_PROC_1_CGROUP", bad)
         assert pve.detect_proxmox_host() == pve.PveDetectionState.NOT_DETECTED
+
+    def test_never_raises_on_permission_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Real OSError from read_text() must also collapse to NOT_DETECTED."""
+        from unittest.mock import patch
+
+        # Patch read_text on the Path class so both _PROC_VERSION and
+        # _PROC_1_CGROUP raise when the helpers try to read them.
+        with patch.object(Path, "read_text", side_effect=PermissionError("denied")):
+            assert pve.detect_proxmox_host() == pve.PveDetectionState.NOT_DETECTED

--- a/tests/hardware/test_pve.py
+++ b/tests/hardware/test_pve.py
@@ -337,3 +337,60 @@ def test_pve_status_fetch_error_recorded(
     assert out["ok"] is False
     assert "TimeoutError" in out["error"]
     assert "upstream down" in out["error"]
+
+
+# ── detect_proxmox_host ────────────────────────────────────────────────────
+
+
+class TestDetectProxmoxHost:
+    """detect_proxmox_host() is best-effort, signal-driven, and never raises."""
+
+    def test_returns_detected_when_pve_kernel_and_lxc_cgroup(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        version = tmp_path / "version"
+        version.write_text("Linux version 7.0.0-8-pve (root@…)\n")
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("0::/lxc.payload.105/init.scope\n")
+        monkeypatch.setattr(pve, "_PROC_VERSION", version)
+        monkeypatch.setattr(pve, "_PROC_1_CGROUP", cgroup)
+        assert pve.detect_proxmox_host() == pve.PveDetectionState.DETECTED
+
+    def test_returns_uncertain_when_only_pve_kernel(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        version = tmp_path / "version"
+        version.write_text("Linux version 7.0.0-8-pve\n")
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("0::/\n")  # not lxc-shaped
+        monkeypatch.setattr(pve, "_PROC_VERSION", version)
+        monkeypatch.setattr(pve, "_PROC_1_CGROUP", cgroup)
+        assert pve.detect_proxmox_host() == pve.PveDetectionState.UNCERTAIN
+
+    def test_returns_not_detected_on_bare_metal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        version = tmp_path / "version"
+        version.write_text("Linux version 6.10.5-arch1-1\n")
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("0::/\n")
+        monkeypatch.setattr(pve, "_PROC_VERSION", version)
+        monkeypatch.setattr(pve, "_PROC_1_CGROUP", cgroup)
+        assert pve.detect_proxmox_host() == pve.PveDetectionState.NOT_DETECTED
+
+    def test_missing_files_return_not_detected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pve, "_PROC_VERSION", tmp_path / "missing-1")
+        monkeypatch.setattr(pve, "_PROC_1_CGROUP", tmp_path / "missing-2")
+        assert pve.detect_proxmox_host() == pve.PveDetectionState.NOT_DETECTED
+
+    def test_never_raises_on_unreadable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # PermissionError, EncodingError, etc. all collapse to NOT_DETECTED.
+        bad = tmp_path / "bad"
+        bad.write_bytes(b"\xff\xfe\x00invalid")
+        monkeypatch.setattr(pve, "_PROC_VERSION", bad)
+        monkeypatch.setattr(pve, "_PROC_1_CGROUP", bad)
+        assert pve.detect_proxmox_host() == pve.PveDetectionState.NOT_DETECTED

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -109,6 +109,9 @@ export const ENDPOINTS = {
   // Single-source-of-truth model storage (Settings → Models + Firstrun → Storage).
   settingsModelsStore: '/api/settings/models/store',
   settingsModelsStoreMigrate: '/api/settings/models/store/migrate',
+  // Full-shape Proxmox status — includes tenants[] stripped by the
+  // /api/stats/hardware slim projection (see pve.py:_SLIM_DROP_KEYS).
+  proxmoxSettings: '/api/settings/proxmox',
 
   // ── Settings ─────────────────────────────────────────────────────
   // Updates

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -55,6 +55,7 @@ export const ENDPOINTS = {
 
   // ── Hardware ─────────────────────────────────────────────────────
   hardware: '/api/hardware',
+  statsHardware: '/api/stats/hardware',
 
   // ── Agents — list + dashboard catalogues ─────────────────────────
   // ``agents`` is the installed-bundled list (#207). ``agentSkills`` +

--- a/ui/src/api/hooks/useProxmoxSettings.ts
+++ b/ui/src/api/hooks/useProxmoxSettings.ts
@@ -1,0 +1,65 @@
+// hal0 v3 dashboard — /api/settings/proxmox.
+//
+// The full-shape sibling of /api/stats/hardware's slim host block.
+// The stats endpoint runs through pve.project_slim() and strips
+// tenants[] + a few aggregate fields. The expanded MemoryMap variant
+// needs the full shape to show per-tenant memory rows.
+//
+// Lower cadence (10s) because the data is the same on every poll
+// unless someone is rebooting tenants — the dashboard's 2.5s stats
+// hook handles the actively-changing numbers (host_mem_used_mb,
+// gtt_used_mb, etc.).
+
+import { useQuery } from '@tanstack/react-query'
+import { apiGet } from '../client'
+import { ENDPOINTS } from '../endpoints'
+
+export interface ProxmoxTenant {
+  vmid: number
+  name: string
+  type: 'lxc' | 'qemu'
+  status: string
+  mem_mb: number
+  maxmem_mb: number
+  maxcpu?: number
+  cpu_pct?: number
+  node?: string
+}
+
+export interface ProxmoxFullStatus {
+  configured: boolean
+  ok?: boolean
+  node?: string
+  host_mem_total_mb?: number
+  host_mem_used_mb?: number
+  host_mem_free_mb?: number
+  host_cpu_pct?: number
+  host_cpu_count?: number
+  host_uptime_s?: number
+  tenants_running?: number
+  tenants_total?: number
+  tenants_allocated_mb?: number
+  tenants?: ProxmoxTenant[]
+  error?: string
+}
+
+export interface ProxmoxSettings {
+  configured: boolean
+  host: string
+  port: number
+  user: string
+  token_name: string
+  verify_ssl: boolean
+  token_value_set: boolean
+  status: ProxmoxFullStatus
+}
+
+const POLL_MS = 10_000
+
+export function useProxmoxSettings() {
+  return useQuery<ProxmoxSettings>({
+    queryKey: ['settings', 'proxmox'],
+    queryFn: () => apiGet<ProxmoxSettings>(ENDPOINTS.proxmoxSettings),
+    refetchInterval: POLL_MS,
+  })
+}

--- a/ui/src/api/hooks/useStatsHardware.ts
+++ b/ui/src/api/hooks/useStatsHardware.ts
@@ -9,6 +9,12 @@ import { useQuery } from '@tanstack/react-query'
 import { apiGet } from '../client'
 import { ENDPOINTS } from '../endpoints'
 
+/**
+ * Per-tenant shape — emitted by GET /api/settings/proxmox (full shape).
+ * NOT present on GET /api/stats/hardware (project_slim strips it; see
+ * src/hal0/hardware/pve.py:_SLIM_DROP_KEYS). Exported here for reuse
+ * by the future settings-shape hook.
+ */
 export interface StatsHardwareTenant {
   vmid: number
   name: string
@@ -30,7 +36,6 @@ export interface StatsHardwareHost {
   host_mem_free_mb?: number
   tenants_running?: number
   tenants_total?: number
-  tenants?: StatsHardwareTenant[]
 }
 
 export interface StatsHardware {
@@ -44,13 +49,15 @@ export interface StatsHardware {
   gpu_vram_total_mb?: number | null
   npu_status?: { ok: boolean; model_mb: number }
   host?: StatsHardwareHost
+  per_upstream?: Record<string, unknown>
+  upstream_names?: string[]
 }
 
 const POLL_MS = 2_500
 
 export function useStatsHardware() {
   return useQuery<StatsHardware>({
-    queryKey: ['stats-hardware'],
+    queryKey: ['stats', 'hardware'],
     queryFn: () => apiGet<StatsHardware>(ENDPOINTS.statsHardware),
     refetchInterval: POLL_MS,
   })

--- a/ui/src/api/hooks/useStatsHardware.ts
+++ b/ui/src/api/hooks/useStatsHardware.ts
@@ -9,20 +9,6 @@ import { useQuery } from '@tanstack/react-query'
 import { apiGet } from '../client'
 import { ENDPOINTS } from '../endpoints'
 
-/**
- * Per-tenant shape — emitted by GET /api/settings/proxmox (full shape).
- * NOT present on GET /api/stats/hardware (project_slim strips it; see
- * src/hal0/hardware/pve.py:_SLIM_DROP_KEYS). Exported here for reuse
- * by the future settings-shape hook.
- */
-export interface StatsHardwareTenant {
-  vmid: number
-  name: string
-  type: 'lxc' | 'qemu'
-  status: string
-  mem_mb: number
-  maxmem_mb: number
-}
 
 export interface StatsHardwareHost {
   configured: boolean
@@ -39,6 +25,7 @@ export interface StatsHardwareHost {
 }
 
 export interface StatsHardware {
+  ram_total_mb?: number
   ram_used_mb?: number
   ram_used_gb?: number
   ram_available_gb?: number

--- a/ui/src/api/hooks/useStatsHardware.ts
+++ b/ui/src/api/hooks/useStatsHardware.ts
@@ -1,0 +1,57 @@
+// hal0 v3 dashboard — /api/stats/hardware (live counters).
+//
+// Distinct from useHardware (static probe): this hook polls the live
+// counters (gtt_used_mb, ram_used_mb, npu_status.model_mb, host.*) at
+// 2.5s — same cadence the backend was designed for. Used by the
+// MemoryMap component (sidebar + expanded variants).
+
+import { useQuery } from '@tanstack/react-query'
+import { apiGet } from '../client'
+import { ENDPOINTS } from '../endpoints'
+
+export interface StatsHardwareTenant {
+  vmid: number
+  name: string
+  type: 'lxc' | 'qemu'
+  status: string
+  mem_mb: number
+  maxmem_mb: number
+}
+
+export interface StatsHardwareHost {
+  configured: boolean
+  detected?: boolean
+  detection?: 'detected' | 'uncertain' | 'not_detected'
+  hint?: string
+  ok?: boolean
+  node?: string
+  host_mem_total_mb?: number
+  host_mem_used_mb?: number
+  host_mem_free_mb?: number
+  tenants_running?: number
+  tenants_total?: number
+  tenants?: StatsHardwareTenant[]
+}
+
+export interface StatsHardware {
+  ram_used_mb?: number
+  ram_used_gb?: number
+  ram_available_gb?: number
+  gtt_used_mb?: number | null
+  vram_used_mb?: number | null
+  gpu_util?: number | null
+  gpu_vram_used_mb?: number | null
+  gpu_vram_total_mb?: number | null
+  npu_status?: { ok: boolean; model_mb: number }
+  host?: StatsHardwareHost
+}
+
+const POLL_MS = 2_500
+
+export function useStatsHardware() {
+  return useQuery<StatsHardware>({
+    queryKey: ['stats-hardware'],
+    queryFn: () => apiGet<StatsHardware>(ENDPOINTS.statsHardware),
+    refetchInterval: POLL_MS,
+  })
+}

--- a/ui/src/dash/dashboard.jsx
+++ b/ui/src/dash/dashboard.jsx
@@ -221,6 +221,14 @@ function HardwareSection() {
   );
 }
 
+function HardwareMemorySection() {
+  return (
+    <section className="hardware-mem">
+      <MemoryMap variant="expanded" />
+    </section>
+  );
+}
+
 function HwCard({ title, eyebrow, children, full, purple }) {
   return (
     <div className="card" style={{
@@ -305,6 +313,7 @@ function DashboardView({ slots: slotsProp, onGo, showHero, onDismissHero }) {
       <div className="dash">
         <div className="dash-main">
           <HardwareSection />
+          <HardwareMemorySection />
         </div>
         <div className="dash-side">
           <SnapshotStrip slots={slots} onGo={onGo} />
@@ -317,4 +326,4 @@ function DashboardView({ slots: slotsProp, onGo, showHero, onDismissHero }) {
   );
 }
 
-Object.assign(window, { DashboardView, SnapshotStrip, HealthCard, ThroughputCard, HardwareSection });
+Object.assign(window, { DashboardView, SnapshotStrip, HealthCard, ThroughputCard, HardwareSection, HardwareMemorySection });

--- a/ui/src/dash/dashboard.jsx
+++ b/ui/src/dash/dashboard.jsx
@@ -12,6 +12,7 @@
 import { useSlots } from '@/api/hooks/useSlots'
 import { useLemondRollup } from '@/api/hooks/useLemonade'
 import { useHardware } from '@/api/hooks/useHardware'
+import { MemoryMap } from './memory-map'
 
 const { useState: useStateD, useRef: useRefD, useEffect: useEffectD } = React;
 
@@ -62,76 +63,6 @@ function SnapshotStrip({ slots, onGo }) {
 
 
 // ─── Memory / health side cards ───
-function MemoryMap({ slots }) {
-  // Live OS-level memory from /api/hardware (used / total). Per-slot
-  // segments stay informational — they sum the bookkeeping each slot
-  // reports in `metrics.mem`. The bar then splits into:
-  //   [per-slot segments] + [other used] + [free]
-  // so "used" tracks reality (e.g. shows the few GB the OS itself eats
-  // when zero slots are loaded) rather than the static 128 GB the
-  // HAL0_DATA fixture used to render.
-  const hw = useHardware();
-  const ram = hw.data?.ram;
-  const fallbackTotal = HAL0_DATA.host.ram.total;
-  const total = ram && ram.total > 0 ? ram.total : fallbackTotal;
-  const loaded = slots.filter(s => s.state === "ready" || s.state === "serving" || s.state === "idle");
-  const segs = loaded.map(s => ({ name: s.name, sz: s.metrics.mem || 0, color: s.device }));
-  const slotsUsed = segs.reduce((a, s) => a + s.sz, 0);
-  // Prefer the OS reading; fall back to the slot sum until /api/hardware
-  // has resolved.
-  const used = ram ? ram.used : slotsUsed;
-  const free = Math.max(0, total - used);
-  const otherUsed = Math.max(0, used - slotsUsed);
-  const pct = n => total > 0 ? `${(n / total) * 100}%` : '0%';
-  const colorFor = d => d === "npu" ? "var(--dev-npu)" : d === "cpu" ? "var(--dev-cpu)" : d === "gpu-vulkan" ? "var(--dev-vulkan)" : "var(--dev-rocm)";
-  return (
-    <div className="side-card">
-      <div className="side-card-h">
-        <span>Memory map</span>
-        <span className="right mono">{used.toFixed(1)} / {total.toFixed(0)} GB</span>
-      </div>
-      <div className="side-card-b">
-        <div className="memmap">
-          <div className="memmap-h mono">
-            <span>unified ram</span>
-            <span><b>{free.toFixed(1)} GB</b> free</span>
-          </div>
-          <div className="memmap-bar">
-            {segs.map((s, i) => (
-              <i key={i} style={{ width: pct(s.sz), background: colorFor(s.color) }} />
-            ))}
-            {otherUsed > 0 && (
-              <i style={{ width: pct(otherUsed), background: "var(--fg-5)" }} />
-            )}
-            <i style={{ width: pct(free), background: "var(--bg-4)" }} />
-          </div>
-          <div className="memmap-legend">
-            {segs.map((s, i) => (
-              <div key={i} className="ln mono">
-                <span className="sw" style={{background: colorFor(s.color)}} />
-                <span className="name">{s.name}</span>
-                <span className="sz">{s.sz < 1 ? `${(s.sz * 1024).toFixed(0)} MB` : `${s.sz.toFixed(1)} GB`}</span>
-              </div>
-            ))}
-            {otherUsed > 0 && (
-              <div className="ln mono">
-                <span className="sw" style={{background: "var(--fg-5)"}} />
-                <span className="name">other</span>
-                <span className="sz">{otherUsed.toFixed(1)} GB</span>
-              </div>
-            )}
-            <div className="ln mono">
-              <span className="sw" style={{background: "var(--bg-4)"}} />
-              <span className="name">free</span>
-              <span className="sz">{free.toFixed(1)} GB</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function HealthCard() {
   return (
     <div className="side-card">
@@ -377,7 +308,7 @@ function DashboardView({ slots: slotsProp, onGo, showHero, onDismissHero }) {
         </div>
         <div className="dash-side">
           <SnapshotStrip slots={slots} onGo={onGo} />
-          <MemoryMap slots={slots} />
+          <MemoryMap variant="sidebar" />
           <ThroughputCard />
           <HealthCard />
         </div>
@@ -386,4 +317,4 @@ function DashboardView({ slots: slotsProp, onGo, showHero, onDismissHero }) {
   );
 }
 
-Object.assign(window, { DashboardView, SnapshotStrip, MemoryMap, HealthCard, ThroughputCard, HardwareSection });
+Object.assign(window, { DashboardView, SnapshotStrip, HealthCard, ThroughputCard, HardwareSection });

--- a/ui/src/dash/memory-map.jsx
+++ b/ui/src/dash/memory-map.jsx
@@ -1,0 +1,165 @@
+// hal0 dashboard — Memory map (sidebar + expanded variants).
+//
+// Spec: docs/superpowers/specs/2026-05-28-memory-map-redesign-design.md
+//
+// All attribution math lives in useMemoryMapModel(); the MemoryMap
+// component is a pure renderer (added in Task 6). The same component
+// drives the compact sidebar widget and the full-width hardware-page
+// section via the `variant` prop.
+
+import { useSlots } from '@/api/hooks/useSlots'
+import { useHardware } from '@/api/hooks/useHardware'
+import { useStatsHardware } from '@/api/hooks/useStatsHardware'
+import { useProxmoxSettings } from '@/api/hooks/useProxmoxSettings'
+
+const LIVE_STATES = new Set(['ready', 'serving', 'idle', 'warming'])
+const SAFETY_MARGIN_GB = 2
+const MB_PER_GB = 1024
+
+const round1 = (n) => Math.round(n * 10) / 10
+
+function mbToGb(mb) {
+  if (mb == null || Number.isNaN(mb)) return 0
+  return round1(mb / MB_PER_GB)
+}
+
+function deviceFor(slot) {
+  const d = (slot.device || '').toLowerCase()
+  if (d === 'npu') return 'npu'
+  if (d === 'cpu') return 'cpu'
+  if (d === 'gpu-vulkan' || d === 'vulkan') return 'vulkan'
+  if (d === 'gpu-rocm' || d === 'rocm' || d.startsWith('gpu')) return 'rocm'
+  return 'cpu'
+}
+
+function attributeSlotShares({ liveSlots, gttUsedGb, npuModelGb }) {
+  const npuLive = liveSlots.filter((s) => deviceFor(s) === 'npu')
+  const gpuLive = liveSlots.filter((s) => {
+    const d = deviceFor(s)
+    return d === 'rocm' || d === 'vulkan'
+  })
+
+  const gpuTotalWeight = gpuLive.reduce(
+    (acc, s) => acc + (s.metrics?.mem || 1),
+    0,
+  ) || gpuLive.length || 1
+
+  return liveSlots.map((s) => {
+    const device = deviceFor(s)
+    if (device === 'npu') {
+      const share = npuLive.length > 0 ? npuModelGb / npuLive.length : 0
+      return { slot: s, device, bytesGb: round1(share), approx: npuLive.length > 1 }
+    }
+    if (device === 'rocm' || device === 'vulkan') {
+      const weight = s.metrics?.mem || 1
+      const share = gpuTotalWeight > 0 ? gttUsedGb * (weight / gpuTotalWeight) : 0
+      return { slot: s, device, bytesGb: round1(share), approx: gpuLive.length > 1 }
+    }
+    // cpu
+    return { slot: s, device, bytesGb: round1(s.metrics?.mem || 0), approx: false }
+  })
+}
+
+export function useMemoryMapModel() {
+  const hw = useHardware()
+  const stats = useStatsHardware()
+  const slotsQ = useSlots()
+  const pveSettings = useProxmoxSettings()
+  const slots = slotsQ.data || []
+
+  // Pool total from the static probe — unified_memory_mb when the platform
+  // advertises it (Strix Halo), else ram_mb. Fall back to live ram_used_mb
+  // only as a last resort.
+  const rawHw = hw.data || {}
+  const ramTotalGb = mbToGb(rawHw.ram?.total ? rawHw.ram.total * MB_PER_GB : null)
+  const unifiedFromProbe = mbToGb(rawHw.unified_memory_mb || 0)
+  const unifiedGb = unifiedFromProbe || ramTotalGb || mbToGb(stats.data?.ram_used_mb || 0)
+  const platformLabel = rawHw.platform_label || rawHw.platform || ''
+  const memoryKind = rawHw.memory_kind === 'unified' ? 'unified' : 'system'
+
+  const ramUsedGb = mbToGb(stats.data?.ram_used_mb || 0)
+  const gttUsedGb = mbToGb(
+    stats.data?.gtt_used_mb ?? stats.data?.vram_used_mb ?? 0,
+  )
+  const npuModelGb = mbToGb(stats.data?.npu_status?.model_mb || 0)
+
+  const liveSlots = slots.filter((s) => LIVE_STATES.has((s.state || '').toLowerCase()))
+  const attributed = attributeSlotShares({ liveSlots, gttUsedGb, npuModelGb })
+
+  const cpuUsedGb = attributed
+    .filter((a) => a.device === 'cpu')
+    .reduce((acc, a) => acc + a.bytesGb, 0)
+  const otherRamGb = Math.max(0, round1(ramUsedGb - cpuUsedGb))
+  const selfShareGb = round1(ramUsedGb + gttUsedGb + npuModelGb)
+
+  // ── Host block ──
+  // Stats endpoint host: { configured, [detected], [hint], ok?, host_mem_*, ... }
+  // Settings endpoint full: { status: { tenants[], host_cpu_count, ... } }
+  const statsHost = stats.data?.host || { configured: false }
+  const settingsStatus = pveSettings.data?.status
+  let host
+  if (statsHost.configured && statsHost.ok !== false) {
+    const hostTotalGb = mbToGb(statsHost.host_mem_total_mb || 0)
+    const hostUsedGb = mbToGb(statsHost.host_mem_used_mb || 0)
+    const hostFreeGb = mbToGb(statsHost.host_mem_free_mb || 0)
+    const othersGb = Math.max(0, round1(hostUsedGb - selfShareGb))
+    // Tenants come from the FULL-shape /api/settings/proxmox response,
+    // not the slim stats response (project_slim strips tenants[]).
+    const tenants = (settingsStatus?.tenants || []).map((t) => ({
+      vmid: t.vmid,
+      name: t.name,
+      type: t.type,
+      memGb: mbToGb(t.mem_mb || 0),
+      maxGb: mbToGb(t.maxmem_mb || 0),
+    }))
+    host = {
+      mode: 'configured',
+      totalGb: hostTotalGb,
+      usedGb: hostUsedGb,
+      freeGb: hostFreeGb,
+      selfShareGb,
+      othersGb,
+      tenants,
+    }
+  } else if (statsHost.detected) {
+    host = {
+      mode: 'detected_unconfigured',
+      hint: statsHost.hint || 'Configure Proxmox to see host pressure.',
+    }
+  } else {
+    host = { mode: 'off' }
+  }
+
+  // ── Headroom ──
+  const poolHeadroom = unifiedGb - (gttUsedGb + ramUsedGb + npuModelGb)
+  let limitedBy = 'pool'
+  let candidate = poolHeadroom
+  if (host.mode === 'configured' && host.freeGb < candidate) {
+    candidate = host.freeGb
+    limitedBy = 'host'
+  }
+  // cgroup branch: best-effort, defer to follow-up issue. limitedBy stays
+  // pool/host today.
+  const availableGb = Math.max(0, round1(candidate - SAFETY_MARGIN_GB))
+
+  return {
+    pool: { totalGb: unifiedGb, kind: memoryKind, platformLabel },
+    host,
+    self: {
+      ramUsedGb,
+      gttUsedGb,
+      npuModelGb,
+      otherRamGb,
+      selfShareGb,
+      slots: attributed.map((a) => ({
+        name: a.slot.name,
+        device: a.device,
+        bytesGb: a.bytesGb,
+        modelId: a.slot.model || '',
+        approx: a.approx,
+      })),
+    },
+    headroom: { availableGb, limitedBy },
+    loading: hw.isLoading || stats.isLoading || slotsQ.isLoading,
+  }
+}

--- a/ui/src/dash/memory-map.jsx
+++ b/ui/src/dash/memory-map.jsx
@@ -170,3 +170,256 @@ export function useMemoryMapModel() {
     loading: hw.isLoading || stats.isLoading || slotsQ.isLoading || pveSettings.isLoading,
   }
 }
+
+// ── Render helpers ─────────────────────────────────────────────────────
+
+function colorForDevice(device) {
+  if (device === 'npu') return 'var(--dev-npu)'
+  if (device === 'cpu') return 'var(--dev-cpu)'
+  if (device === 'vulkan') return 'var(--dev-vulkan)'
+  return 'var(--dev-rocm)'
+}
+
+function fmtGb(n) {
+  if (n == null) return '—'
+  if (n < 1) return `${(n * 1024).toFixed(0)} MB`
+  return `${n.toFixed(1)} GB`
+}
+
+function PctSeg({ widthPct, color, title }) {
+  if (widthPct <= 0) return null
+  return <i style={{ width: `${widthPct}%`, background: color }} title={title} />
+}
+
+function HeadroomLabel({ availableGb, limitedBy }) {
+  return (
+    <div className="memmap-headroom mono">
+      Headroom for new models:&nbsp;
+      <b>{fmtGb(availableGb)}</b>
+      <span className="dim">&nbsp;— limited by {limitedBy}</span>
+    </div>
+  )
+}
+
+function PveNudge({ hint, onConfigure }) {
+  return (
+    <div
+      className="memmap-pve-nudge mono"
+      role="status"
+      style={{
+        color: 'var(--warn)',
+        borderTop: '1px solid rgba(255,180,60,0.22)',
+        padding: '6px 8px',
+        marginTop: 6,
+        fontSize: 11,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}
+    >
+      <span>⚠ Hosted on Proxmox — host pressure unknown.</span>
+      <a
+        href="#settings/proxmox"
+        onClick={(e) => {
+          if (onConfigure) {
+            e.preventDefault()
+            onConfigure()
+          }
+        }}
+      >
+        Configure →
+      </a>
+    </div>
+  )
+}
+
+function SidebarBar({ model }) {
+  const { pool, self } = model
+  const total = pool.totalGb || 1
+  const pct = (gb) => (gb / total) * 100
+  const segs = self.slots.filter((s) => s.bytesGb > 0)
+  return (
+    <div className="memmap-bar">
+      {segs.map((s) => (
+        <PctSeg
+          key={s.name}
+          widthPct={pct(s.bytesGb)}
+          color={colorForDevice(s.device)}
+          title={`${s.name} · ${fmtGb(s.bytesGb)}`}
+        />
+      ))}
+      {self.otherRamGb > 0 && (
+        <PctSeg
+          widthPct={pct(self.otherRamGb)}
+          color="var(--fg-5)"
+          title={`other RAM · ${fmtGb(self.otherRamGb)}`}
+        />
+      )}
+      <PctSeg
+        widthPct={Math.max(
+          0,
+          100 - pct(self.gttUsedGb + self.ramUsedGb + self.npuModelGb),
+        )}
+        color="var(--bg-4)"
+        title="free"
+      />
+    </div>
+  )
+}
+
+function HostBar({ model }) {
+  const { host, self } = model
+  if (host.mode !== 'configured') return null
+  const total = host.totalGb || 1
+  const pct = (gb) => (gb / total) * 100
+  return (
+    <div className="memmap-bar memmap-bar-host">
+      <PctSeg
+        widthPct={pct(self.selfShareGb)}
+        color="var(--accent)"
+        title={`this hal0 LXC · ${fmtGb(self.selfShareGb)}`}
+      />
+      <PctSeg
+        widthPct={pct(host.othersGb)}
+        color="var(--mem-tenant-1, var(--fg-5))"
+        title={`other tenants · ${fmtGb(host.othersGb)}`}
+      />
+      <PctSeg
+        widthPct={Math.max(0, 100 - pct(self.selfShareGb + host.othersGb))}
+        color="var(--bg-4)"
+        title="host free"
+      />
+    </div>
+  )
+}
+
+function LegendRow({ swatch, name, sub, sz }) {
+  return (
+    <div className="ln mono">
+      <span className="sw" style={{ background: swatch }} />
+      <span className="name">{name}</span>
+      {sub && <span className="dim" style={{ marginLeft: 6 }}>{sub}</span>}
+      <span className="sz">{fmtGb(sz)}</span>
+    </div>
+  )
+}
+
+export function MemoryMap({ variant = 'sidebar', onConfigure }) {
+  const model = useMemoryMapModel()
+  const { pool, host, self, headroom, loading } = model
+  const total = pool.totalGb
+  const usedSelf = round1(self.ramUsedGb + self.gttUsedGb + self.npuModelGb)
+  const free = Math.max(0, round1(total - usedSelf))
+
+  if (variant === 'expanded') {
+    return (
+      <div className="card memmap-expanded" data-loading={loading || undefined}>
+        <div className="vh">
+          <h2>Memory map</h2>
+          <span className="mono dim">
+            {pool.kind} {fmtGb(total)} · {pool.platformLabel}
+            {host.mode === 'configured' && host.totalGb && ` · host ${fmtGb(host.totalGb)}`}
+          </span>
+        </div>
+
+        {host.mode === 'configured' && (
+          <>
+            <div className="memmap-h mono">
+              <span>host pool</span>
+              <span><b>{fmtGb(host.freeGb)}</b> free on host</span>
+            </div>
+            <HostBar model={model} />
+          </>
+        )}
+
+        <div className="memmap-h mono">
+          <span>inside this hal0</span>
+          <span><b>{fmtGb(free)}</b> free in pool</span>
+        </div>
+        <SidebarBar model={model} />
+
+        <div className="memmap-legend memmap-legend-expanded">
+          {self.slots.map((s) => (
+            <LegendRow
+              key={s.name}
+              swatch={colorForDevice(s.device)}
+              name={s.name}
+              sub={`${s.device}${s.approx ? ' · ≈' : ''}${s.modelId ? ' · ' + s.modelId : ''}`}
+              sz={s.bytesGb}
+            />
+          ))}
+          {self.otherRamGb > 0 && (
+            <LegendRow swatch="var(--fg-5)" name="other RAM" sz={self.otherRamGb} />
+          )}
+          <LegendRow swatch="var(--bg-4)" name="free" sz={free} />
+          {host.mode === 'configured' &&
+            (host.tenants || []).map((t) => (
+              <LegendRow
+                key={`t-${t.vmid}`}
+                swatch="var(--mem-tenant-1, var(--fg-5))"
+                name={`${t.name} (${t.type})`}
+                sub={`vmid ${t.vmid}`}
+                sz={t.memGb}
+              />
+            ))}
+        </div>
+
+        <HeadroomLabel availableGb={headroom.availableGb} limitedBy={headroom.limitedBy} />
+        {host.mode === 'detected_unconfigured' && (
+          <PveNudge hint={host.hint} onConfigure={onConfigure} />
+        )}
+      </div>
+    )
+  }
+
+  // ── sidebar variant ──
+  return (
+    <div className="side-card memmap-sidebar">
+      <div className="side-card-h">
+        <span>Memory map</span>
+        <span className="right mono">
+          {fmtGb(usedSelf)} / {fmtGb(total)}
+        </span>
+      </div>
+      <div className="side-card-b">
+        <div className="memmap">
+          {host.mode === 'configured' && (
+            <div className="memmap-h mono">
+              <span>host {host.tenants?.length ?? 0} tenants</span>
+              <span><b>{fmtGb(host.freeGb)}</b> host free</span>
+            </div>
+          )}
+          <div className="memmap-h mono">
+            <span>{pool.kind} ram</span>
+            <span><b>{fmtGb(free)}</b> free</span>
+          </div>
+          <SidebarBar model={model} />
+          <div className="memmap-legend">
+            {self.slots.map((s) => (
+              <LegendRow
+                key={s.name}
+                swatch={colorForDevice(s.device)}
+                name={s.name}
+                sz={s.bytesGb}
+              />
+            ))}
+            {self.otherRamGb > 0 && (
+              <LegendRow swatch="var(--fg-5)" name="other" sz={self.otherRamGb} />
+            )}
+            <LegendRow swatch="var(--bg-4)" name="free" sz={free} />
+          </div>
+          <HeadroomLabel
+            availableGb={headroom.availableGb}
+            limitedBy={headroom.limitedBy}
+          />
+          {host.mode === 'detected_unconfigured' && (
+            <PveNudge hint={host.hint} onConfigure={onConfigure} />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Window export keeps parity with dashboard.jsx's debug exports.
+Object.assign(window, { MemoryMap, useMemoryMapModel })

--- a/ui/src/dash/memory-map.jsx
+++ b/ui/src/dash/memory-map.jsx
@@ -71,9 +71,12 @@ export function useMemoryMapModel() {
   // advertises it (Strix Halo), else ram_mb. Fall back to live ram_used_mb
   // only as a last resort.
   const rawHw = hw.data || {}
-  const ramTotalGb = mbToGb(rawHw.ram?.total ? rawHw.ram.total * MB_PER_GB : null)
+  const ramTotalGb = rawHw.ram?.total ?? 0
   const unifiedFromProbe = mbToGb(rawHw.unified_memory_mb || 0)
-  const unifiedGb = unifiedFromProbe || ramTotalGb || mbToGb(stats.data?.ram_used_mb || 0)
+  const unifiedGb =
+    unifiedFromProbe ||
+    ramTotalGb ||
+    mbToGb(stats.data?.ram_total_mb || 0)
   const platformLabel = rawHw.platform_label || rawHw.platform || ''
   const memoryKind = rawHw.memory_kind === 'unified' ? 'unified' : 'system'
 
@@ -95,6 +98,10 @@ export function useMemoryMapModel() {
   // ── Host block ──
   // Stats endpoint host: { configured, [detected], [hint], ok?, host_mem_*, ... }
   // Settings endpoint full: { status: { tenants[], host_cpu_count, ... } }
+  // Cadence note: stats refresh at 2.5s, settings at 10s. selfShareGb
+  // (from stats) and tenants[] (from settings) can be briefly out of
+  // sync (<7.5s window) — accepted because tenant allocations change
+  // slowly. Don't unify the cadences; the slim/full split is by design.
   const statsHost = stats.data?.host || { configured: false }
   const settingsStatus = pveSettings.data?.status
   let host
@@ -160,6 +167,6 @@ export function useMemoryMapModel() {
       })),
     },
     headroom: { availableGb, limitedBy },
-    loading: hw.isLoading || stats.isLoading || slotsQ.isLoading,
+    loading: hw.isLoading || stats.isLoading || slotsQ.isLoading || pveSettings.isLoading,
   }
 }

--- a/ui/src/dash/memory-map.jsx
+++ b/ui/src/dash/memory-map.jsx
@@ -112,13 +112,19 @@ export function useMemoryMapModel() {
     const othersGb = Math.max(0, round1(hostUsedGb - selfShareGb))
     // Tenants come from the FULL-shape /api/settings/proxmox response,
     // not the slim stats response (project_slim strips tenants[]).
-    const tenants = (settingsStatus?.tenants || []).map((t) => ({
-      vmid: t.vmid,
-      name: t.name,
-      type: t.type,
-      memGb: mbToGb(t.mem_mb || 0),
-      maxGb: mbToGb(t.maxmem_mb || 0),
-    }))
+    // Filter out the LXC running hal0 itself — it's already represented
+    // as 'this hal0 LXC' via selfShareGb. The static probe exposes our
+    // hostname; tenants whose `name` matches are dropped.
+    const selfHostname = (rawHw.name || '').toLowerCase().trim()
+    const tenants = (settingsStatus?.tenants || [])
+      .filter((t) => !selfHostname || (t.name || '').toLowerCase().trim() !== selfHostname)
+      .map((t) => ({
+        vmid: t.vmid,
+        name: t.name,
+        type: t.type,
+        memGb: mbToGb(t.mem_mb || 0),
+        maxGb: mbToGb(t.maxmem_mb || 0),
+      }))
     host = {
       mode: 'configured',
       totalGb: hostTotalGb,
@@ -203,23 +209,10 @@ function HeadroomLabel({ availableGb, limitedBy }) {
 
 function PveNudge({ hint, onConfigure }) {
   return (
-    <div
-      className="memmap-pve-nudge mono"
-      role="status"
-      style={{
-        color: 'var(--warn)',
-        borderTop: '1px solid rgba(255,180,60,0.22)',
-        padding: '6px 8px',
-        marginTop: 6,
-        fontSize: 11,
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-      }}
-    >
+    <div className="memmap-pve-nudge mono" role="status">
       <span>⚠ Hosted on Proxmox — host pressure unknown.</span>
       <a
-        href="#settings/proxmox"
+        href="#settings"
         onClick={(e) => {
           if (onConfigure) {
             e.preventDefault()
@@ -298,7 +291,7 @@ function LegendRow({ swatch, name, sub, sz }) {
     <div className="ln mono">
       <span className="sw" style={{ background: swatch }} />
       <span className="name">{name}</span>
-      {sub && <span className="dim" style={{ marginLeft: 6 }}>{sub}</span>}
+      {sub && <span className="dim memmap-legend-sub">{sub}</span>}
       <span className="sz">{fmtGb(sz)}</span>
     </div>
   )
@@ -374,7 +367,7 @@ export function MemoryMap({ variant = 'sidebar', onConfigure }) {
 
   // ── sidebar variant ──
   return (
-    <div className="side-card memmap-sidebar">
+    <div className="side-card memmap-sidebar" data-loading={loading || undefined}>
       <div className="side-card-h">
         <span>Memory map</span>
         <span className="right mono">

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -12,6 +12,7 @@ import {
   useSlotUnload,
   useSlotSwap,
 } from '@/api/hooks/useSlots'
+import { MemoryMap } from './memory-map'
 
 const { useState: useStateS } = React;
 
@@ -710,7 +711,7 @@ function SlotsView({ slotVariant, npuVariant, slotParam, onGo }) {
           </div>
           <div className="dash-side">
             <SnapshotStrip slots={slots} onGo={goTo} />
-            <MemoryMap slots={slots} />
+            <MemoryMap variant="sidebar" />
             <ThroughputCard />
           </div>
         </div>
@@ -802,7 +803,7 @@ function SlotsView({ slotVariant, npuVariant, slotParam, onGo }) {
         </div>
         <div className="dash-side">
           <SnapshotStrip slots={slots} onGo={goTo} />
-          <MemoryMap slots={slots} />
+          <MemoryMap variant="sidebar" />
           <ThroughputCard />
         </div>
       </div>

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -54,6 +54,12 @@
   --dev-cpu:      #9c9c95;
   --dev-npu:      #c896ff;
 
+  /* Memory-map tenant colours — rotated for distinguishability vs the
+     device colours used in slot segments. Amber-on-grey palette. */
+  --mem-tenant-1: #b89060;
+  --mem-tenant-2: #8a7848;
+  --mem-tenant-3: #695830;
+
   /* Type */
   --geist: "Geist", "Geist Variable", system-ui, -apple-system, "Segoe UI", sans-serif;
   --jbm:   "JetBrains Mono", "JetBrains Mono Variable", ui-monospace, "SF Mono", Menlo, monospace;
@@ -1240,6 +1246,34 @@ a { color: inherit; text-decoration: none; }
 .memmap-legend .sw { width: 8px; height: 8px; border-radius: 2px; }
 .memmap-legend .name { color: var(--fg-2); flex: 1; }
 .memmap-legend .sz { color: var(--fg-4); }
+
+/* PVE-detected-unconfigured nudge band — Memory map sidebar + expanded.
+   Lives below the bar with an amber border-top. */
+.memmap-pve-nudge {
+  color: var(--warn);
+  border-top: 1px solid rgba(255, 180, 60, 0.22);
+  padding: 6px 8px;
+  margin-top: 6px;
+  font-size: 11px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.memmap-pve-nudge a {
+  color: var(--warn);
+}
+
+/* Subtle text — memory-map secondary labels, headroom rationale, etc.
+   Scoped to .memmap to avoid surprising other consumers that use the
+   bare `.dim` class compound (e.g., .sb-row.dim, .foot-chip .v.dim). */
+.memmap .dim,
+.memmap-expanded .dim {
+  color: var(--fg-4);
+}
+
+.memmap-legend-sub {
+  margin-left: 6px;
+}
 
 /* health */
 .health-row {

--- a/ui/tests/e2e/specs/memory-map-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-map-v3.spec.ts
@@ -41,7 +41,7 @@ function mockProxmoxSettings(page: Page, status: object) {
   )
 }
 
-test.describe('Memory map — sidebar (skipped until Tasks 9-11 wire-up)', () => {
+test.describe('Memory map — sidebar', () => {
   test('off — single-tier bar, no PVE band', async ({ page }) => {
     await mockStatsHardware(page, { configured: false, detected: false })
     await page.goto('/#dashboard')
@@ -131,7 +131,7 @@ test.describe('Memory map — sidebar (skipped until Tasks 9-11 wire-up)', () =>
   })
 })
 
-test.describe('Memory map — expanded (skipped until Task 11 wires HardwareMemorySection)', () => {
+test.describe('Memory map — expanded', () => {
   test('expanded variant renders host pool + inside-LXC + legend', async ({ page }) => {
     await mockStatsHardware(page, {
       configured: true,

--- a/ui/tests/e2e/specs/memory-map-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-map-v3.spec.ts
@@ -41,7 +41,7 @@ function mockProxmoxSettings(page: Page, status: object) {
   )
 }
 
-test.describe.skip('Memory map — sidebar (skipped until Tasks 9-11 wire-up)', () => {
+test.describe('Memory map — sidebar (skipped until Tasks 9-11 wire-up)', () => {
   test('off — single-tier bar, no PVE band', async ({ page }) => {
     await mockStatsHardware(page, { configured: false, detected: false })
     await page.goto('/#dashboard')
@@ -101,7 +101,8 @@ test.describe.skip('Memory map — sidebar (skipped until Tasks 9-11 wire-up)', 
   test('headroom labelled "pool" on bare-metal', async ({ page }) => {
     await mockStatsHardware(page, { configured: false, detected: false })
     await page.goto('/#dashboard')
-    await expect(page.locator('.memmap-headroom')).toContainText('limited by pool')
+    // Scope to sidebar — expanded variant also renders .memmap-headroom
+    await expect(page.locator('.memmap-sidebar .memmap-headroom')).toContainText('limited by pool')
   })
 
   test('headroom labelled "host" when host free is the binding constraint', async ({ page }) => {
@@ -125,11 +126,12 @@ test.describe.skip('Memory map — sidebar (skipped until Tasks 9-11 wire-up)', 
       tenants: [],
     })
     await page.goto('/#dashboard')
-    await expect(page.locator('.memmap-headroom')).toContainText('limited by host')
+    // Scope to sidebar — expanded variant also renders .memmap-headroom
+    await expect(page.locator('.memmap-sidebar .memmap-headroom')).toContainText('limited by host')
   })
 })
 
-test.describe.skip('Memory map — expanded (skipped until Task 11 wires HardwareMemorySection)', () => {
+test.describe('Memory map — expanded (skipped until Task 11 wires HardwareMemorySection)', () => {
   test('expanded variant renders host pool + inside-LXC + legend', async ({ page }) => {
     await mockStatsHardware(page, {
       configured: true,

--- a/ui/tests/e2e/specs/memory-map-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-map-v3.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * memory-map-v3 — MemoryMap sidebar widget across the three host modes
+ * (off / detected_unconfigured / configured) + the attribution edge case.
+ *
+ * The sidebar mounts on /dashboard and /slots. Specs target /dashboard.
+ *
+ * NOTE: This spec is .skip until Tasks 9-11 wire the MemoryMap
+ * component into the dashboard routes. The mocks below are correct;
+ * unskip the `describe` blocks when the consumer wire-ups land.
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+import type { Page } from '@playwright/test'
+
+function mockStatsHardware(page: Page, host: object, overrides: object = {}) {
+  return page.route('**/api/stats/hardware', (route) =>
+    json(route, {
+      ram_total_mb: 96000,
+      ram_used_mb: 1863,
+      ram_available_mb: 94577,
+      gtt_used_mb: 6200,
+      vram_used_mb: 0,
+      npu_status: { ok: true, model_mb: 1100 },
+      host,
+      ...overrides,
+    }),
+  )
+}
+
+function mockProxmoxSettings(page: Page, status: object) {
+  return page.route('**/api/settings/proxmox', (route) =>
+    json(route, {
+      configured: true,
+      host: '10.0.1.110',
+      port: 8006,
+      user: 'hal0@pve',
+      token_name: 'dashboard',
+      verify_ssl: false,
+      token_value_set: true,
+      status,
+    }),
+  )
+}
+
+test.describe.skip('Memory map — sidebar (skipped until Tasks 9-11 wire-up)', () => {
+  test('off — single-tier bar, no PVE band', async ({ page }) => {
+    await mockStatsHardware(page, { configured: false, detected: false })
+    await page.goto('/#dashboard')
+    const card = page.locator('.memmap-sidebar')
+    await expect(card).toBeVisible()
+    await expect(card).not.toContainText('Hosted on Proxmox')
+    await expect(card).not.toContainText('host free')
+  })
+
+  test('detected_unconfigured — amber band with Configure link', async ({ page }) => {
+    await mockStatsHardware(page, {
+      configured: false,
+      detected: true,
+      detection: 'detected',
+      hint: 'Configure /etc/hal0/proxmox.json to see host pressure.',
+    })
+    await page.goto('/#dashboard')
+    const card = page.locator('.memmap-sidebar')
+    await expect(card).toContainText('Hosted on Proxmox')
+    await expect(card.locator('a', { hasText: 'Configure' })).toBeVisible()
+  })
+
+  test('configured — host teaser line above the bar', async ({ page }) => {
+    await mockStatsHardware(page, {
+      configured: true,
+      ok: true,
+      node: 'pve',
+      host_mem_total_mb: 131072,
+      host_mem_used_mb: 24576,
+      host_mem_free_mb: 106496,
+      tenants_running: 3,
+      tenants_total: 5,
+    })
+    await mockProxmoxSettings(page, {
+      configured: true,
+      ok: true,
+      node: 'pve',
+      host_mem_total_mb: 131072,
+      host_mem_used_mb: 24576,
+      host_mem_free_mb: 106496,
+      tenants_running: 3,
+      tenants_total: 5,
+      tenants: [
+        { vmid: 105, name: 'hal0', type: 'lxc', status: 'running', mem_mb: 9216, maxmem_mb: 98304 },
+        { vmid: 159, name: 'halodev', type: 'lxc', status: 'running', mem_mb: 3072, maxmem_mb: 8192 },
+        { vmid: 200, name: 'backup', type: 'qemu', status: 'running', mem_mb: 2150, maxmem_mb: 4096 },
+      ],
+    })
+    await page.goto('/#dashboard')
+    const card = page.locator('.memmap-sidebar')
+    await expect(card).toContainText('host')
+    await expect(card).toContainText('tenants')
+    await expect(card).toContainText('host free')
+    await expect(card).not.toContainText('Hosted on Proxmox')
+  })
+
+  test('headroom labelled "pool" on bare-metal', async ({ page }) => {
+    await mockStatsHardware(page, { configured: false, detected: false })
+    await page.goto('/#dashboard')
+    await expect(page.locator('.memmap-headroom')).toContainText('limited by pool')
+  })
+
+  test('headroom labelled "host" when host free is the binding constraint', async ({ page }) => {
+    await mockStatsHardware(page, {
+      configured: true,
+      ok: true,
+      host_mem_total_mb: 131072,
+      host_mem_used_mb: 125000,
+      host_mem_free_mb: 6072,
+      tenants_running: 0,
+      tenants_total: 0,
+    })
+    await mockProxmoxSettings(page, {
+      configured: true,
+      ok: true,
+      host_mem_total_mb: 131072,
+      host_mem_used_mb: 125000,
+      host_mem_free_mb: 6072,
+      tenants_running: 0,
+      tenants_total: 0,
+      tenants: [],
+    })
+    await page.goto('/#dashboard')
+    await expect(page.locator('.memmap-headroom')).toContainText('limited by host')
+  })
+})
+
+test.describe.skip('Memory map — expanded (skipped until Task 11 wires HardwareMemorySection)', () => {
+  test('expanded variant renders host pool + inside-LXC + legend', async ({ page }) => {
+    await mockStatsHardware(page, {
+      configured: true,
+      ok: true,
+      node: 'pve',
+      host_mem_total_mb: 131072,
+      host_mem_used_mb: 24576,
+      host_mem_free_mb: 106496,
+      tenants_running: 1,
+      tenants_total: 1,
+    })
+    await mockProxmoxSettings(page, {
+      configured: true,
+      ok: true,
+      node: 'pve',
+      host_mem_total_mb: 131072,
+      host_mem_used_mb: 24576,
+      host_mem_free_mb: 106496,
+      tenants_running: 1,
+      tenants_total: 1,
+      tenants: [
+        { vmid: 159, name: 'halodev', type: 'lxc', status: 'running', mem_mb: 3072, maxmem_mb: 8192 },
+      ],
+    })
+    await page.goto('/#dashboard')
+    const card = page.locator('.memmap-expanded')
+    await expect(card).toBeVisible()
+    await expect(card).toContainText('host pool')
+    await expect(card).toContainText('inside this hal0')
+    await expect(card).toContainText('halodev')
+  })
+})


### PR DESCRIPTION
## Summary

Rewrite of the dashboard's Memory map so it works correctly on Strix Halo UMA and surfaces Proxmox host pressure.

**Before:** read only `/api/hardware` (RAM total/used) + summed each slot's self-reported `metrics.mem`. On UMA the model bytes live in **GTT**, not RAM — a 6 GB ROCm slot moved the bar by ~0 GB. Silent on Proxmox host pressure.

**After:** single `<MemoryMap variant="sidebar|expanded" />` driven by `useMemoryMapModel`. GTT-first attribution. Proxmox auto-detected when `/etc/hal0/proxmox.json` is missing. Two-tier host bar + tenants legend on the hardware page when configured.

## What changed

**Backend (pve / api):**
- `pve.detect_proxmox_host()` — best-effort LXC-on-PVE detection from `/proc/version` + `/proc/1/cgroup`. Never raises.
- `/api/stats/hardware` `host` block now carries `{detected, detection, hint}` when unconfigured-but-detected. Configured path unchanged.

**Frontend (UI):**
- New hooks: `useStatsHardware()` (2.5s, live counters incl. `gtt_used_mb`, `npu_status.model_mb`, `host.*`) and `useProxmoxSettings()` (10s, full tenants[] for the expanded legend that the slim stats endpoint strips).
- New component `ui/src/dash/memory-map.jsx` — `useMemoryMapModel` (all attribution math) + `MemoryMap` renderer (sidebar + expanded variants).
- Replaces inline MemoryMap in `dashboard.jsx`, swaps both call-sites in `slots.jsx`, adds `HardwareMemorySection` between `HardwareSection` and the side cards.

**Design choices (settled in spec):**
- Per-slot attribution: NPU evenly split from `npu_status.model_mb`; GPU shares from `gtt_used_mb` weighted by `metrics.mem`; CPU self-reported. ≈ marker only when sharing a pool.
- 2 GB safety margin baked into headroom.
- Self-LXC filtered from tenants legend by hostname match against `Hardware.name` — avoids double-counting against `selfShareGb`.
- Backend `_PVE_CONFIGURE_HINT` constant is single source of truth — tests import it.

Full spec: `docs/superpowers/specs/2026-05-28-memory-map-redesign-design.md`
Plan:      `docs/superpowers/plans/2026-05-28-memory-map-redesign.md`

## Test plan

- [x] `uv run pytest tests/hardware tests/api -v` — 488 passed, 3 skipped (pre-existing).
- [x] `npx playwright test --reporter=line` — 81 passed, 16 skipped (16 pre-existing skips unrelated).
- [x] `npx playwright test memory-map-v3` — **6/6 new specs PASS** covering off / detected_unconfigured / configured / pool-limited / host-limited / expanded variant.
- [x] **Live smoke on hal0 LXC** (10.0.1.142) — branch checked out, `pip install -e .` + `systemctl restart hal0-api`. `/api/stats/hardware` returns `host: {configured:false, detected:true, detection:"uncertain", hint:"..."}`; dashboard renders, sidebar Memory map visible.
- [ ] **Live smoke with proxmox.json configured** — pending real PVE token; the configured-mode rendering hasn't been exercised against a live cluster yet. Mock-driven Playwright spec covers it.

## Notes / follow-ups (not blocking)

- Detection on this LXC fires UNCERTAIN, not DETECTED, because `/proc/1/cgroup` in cgroup-v2 unified mode shows `/init.scope` rather than `/lxc/<vmid>/...`. UI behaviour is correct (UNCERTAIN nudges identically to DETECTED). Broaden the cgroup signal to recognise `/init.scope` + `-pve` kernel as DETECTED — file as follow-up.
- `cgroup memory.max` as a third headroom-binding-constraint candidate (after pool and host). Rare on Strix Halo; deferred.
- Per-slot memory history sparkline — needs a time-series store; out of scope.
- Formal `--mem-tenant-{1,2,3}` palette polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)