### PR TITLE
fix(dispatch): gate slot forwards during swap window with structured 503

### DIFF
--- a/src/hal0/api/middleware/error_codes.py
+++ b/src/hal0/api/middleware/error_codes.py
@@ -74,9 +74,17 @@ def install(app: FastAPI) -> None:
     @app.exception_handler(Hal0Error)
     async def _hal0_handler(_: Request, exc: Hal0Error) -> JSONResponse:
         log.warning("hal0.error", code=exc.code, message=exc.message, **exc.details)
+        # Honor a ``retry_after_s`` hint in details by promoting it to the
+        # ``Retry-After`` HTTP header so OpenAI-compatible SDKs back off
+        # correctly.  Only applied on 503 responses (RFC 7231 §7.1.3).
+        headers: dict[str, str] | None = None
+        retry_after = exc.details.get("retry_after_s") if exc.status == 503 else None
+        if isinstance(retry_after, (int, float)) and retry_after > 0:
+            headers = {"Retry-After": str(int(retry_after))}
         return JSONResponse(
             status_code=exc.status,
             content=_envelope(exc.code, exc.message, exc.details),
+            headers=headers,
         )
 
     @app.exception_handler(RequestValidationError)

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -136,6 +136,25 @@ class UpstreamUnavailable(DispatchError):
     status = 502
 
 
+class SlotLoading(DispatchError):
+    """The target slot is mid-swap — model is starting/loading/unloading.
+
+    Raised by ``Dispatcher.forward`` before attempting the HTTP forward
+    when the slot is in any non-ready state.  Without this gate, requests
+    in the swap window either ConnectError (port not bound) → 502, or the
+    inner llama-server returns its own raw 503 ("still loading the
+    model"), leaving clients with a 5xx and no Retry-After hint.
+
+    The envelope carries a ``progress`` block under ``details`` so the
+    dashboard can render a "model loading…" chip instead of a generic
+    error, and ``retry_after_s`` so OpenAI-compatible SDKs back off
+    correctly (the error middleware promotes it to a real HTTP header).
+    """
+
+    code = "slot.loading"
+    status = 503
+
+
 # ── UpstreamCall ──────────────────────────────────────────────────────────────
 
 
@@ -518,8 +537,61 @@ class Dispatcher:
         ``_forward_streaming`` (PLAN.md §3).
         """
         if call.slot_name and self._slot_manager is not None:
+            # Swap-window gate: refuse to forward if the slot is loading.
+            # Without this, requests hit a dead port (502) or a still-
+            # loading llama-server (raw 503 with no Retry-After).
+            self._check_slot_ready_for_dispatch(call)
             return await self._forward_with_serving(call)
         return await self._forward_plain(call)
+
+    def _check_slot_ready_for_dispatch(self, call: UpstreamCall) -> None:
+        """Raise :class:`SlotLoading` if the target slot isn't ready to serve.
+
+        Ready set: ``READY``, ``SERVING``, ``IDLE``.  Any other state means
+        the slot is mid-lifecycle (``OFFLINE``, ``PULLING``, ``STARTING``,
+        ``WARMING``, ``UNLOADING``, ``ERROR``) and forwarding would either
+        ConnectError or get a raw 503 from llama-server's "still loading"
+        gate.  We raise a typed error here so the middleware can emit a
+        structured envelope plus a ``Retry-After`` header.
+        """
+        from hal0.slots.state import SlotState
+
+        assert self._slot_manager is not None  # narrowed by caller
+        current = self._slot_manager._current_state(call.slot_name)
+        if current in (SlotState.READY, SlotState.SERVING, SlotState.IDLE):
+            return
+
+        raise SlotLoading(
+            f"slot {call.slot_name!r} is {current.value} — not ready to serve",
+            details=self._build_loading_response(call, current),
+        )
+
+    def _build_loading_response(
+        self,
+        call: UpstreamCall,
+        state: Any,  # SlotState; typed loosely to avoid an import cycle
+    ) -> dict[str, Any]:
+        """Shape the ``details`` block on the :class:`SlotLoading` envelope.
+
+        Option B (UX-aware): the response includes a ``progress`` block so
+        the dashboard renders a "model loading…" chip with the slot + the
+        model the user asked for, while still being a clean 503 that
+        OpenAI-style SDKs treat as retryable via ``Retry-After``.
+
+        Retry cadence: Strix Halo iGPU loads typically take 15-60s
+        depending on model size.  We hint 15s — enough to avoid hammering
+        the API, short enough that an active user doesn't give up.
+        """
+        return {
+            "slot": call.slot_name,
+            "state": state.value,
+            "retry_after_s": 15,
+            "progress": {
+                "phase": state.value,
+                "requested_model": call.requested_model,
+                "upstream": call.upstream_name,
+            },
+        }
 
     async def _forward_plain(self, call: UpstreamCall) -> Response:
         client = self._get_http_client()

--- a/tests/api/test_v1_audio.py
+++ b/tests/api/test_v1_audio.py
@@ -28,6 +28,31 @@ from hal0.upstreams.registry import Upstream
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
+def _pin_slot_ready(client: TestClient, slot_name: str = "primary") -> None:
+    """Force ``slot_name`` to READY in the SlotManager state map.
+
+    The dispatcher's swap-window gate (PR-379) refuses to forward when the
+    slot is in any non-ready state.  Audio tests stub the HTTP transport
+    rather than starting a real slot, so the slot is OFFLINE on disk and
+    the gate would 503 every request.  Pinning the in-memory state to
+    READY bypasses the gate for the duration of the test.
+    """
+    import time as _time
+
+    from hal0.slots.state import SlotState, SlotStateRecord
+
+    sm = client.app.state.dispatcher._slot_manager
+    sm._states[slot_name] = SlotStateRecord(
+        name=slot_name,
+        state=SlotState.READY,
+        model_id="test-model",
+        port=0,
+        updated_at=_time.time(),
+        message="pinned by test fixture",
+        extra={},
+    )
+
+
 def _seed_stt_upstream(client: TestClient, port: int = 8089) -> None:
     """Register a fake STT slot the dispatcher's legacy fallback will land on.
 
@@ -46,6 +71,7 @@ def _seed_stt_upstream(client: TestClient, port: int = 8089) -> None:
             auth_style="none",
         )
     )
+    _pin_slot_ready(client)
 
 
 def _seed_tts_upstream(client: TestClient, port: int = 8090) -> None:
@@ -63,6 +89,7 @@ def _seed_tts_upstream(client: TestClient, port: int = 8090) -> None:
             auth_style="none",
         )
     )
+    _pin_slot_ready(client)
 
 
 def _install_mock_transport(client: TestClient, handler: httpx.MockTransport | object) -> None:
@@ -285,6 +312,7 @@ def test_scrubber_does_not_touch_non_audio_routes(
             auth_style="none",
         )
     )
+    _pin_slot_ready(client)
 
     leaky_body = b'{"detail":"trace mentions ffmpeg somewhere"}'
 

--- a/tests/dispatcher/test_serving_integration.py
+++ b/tests/dispatcher/test_serving_integration.py
@@ -21,7 +21,8 @@ from typing import Any
 import httpx
 import pytest
 
-from hal0.dispatcher.router import Dispatcher, UpstreamCall, UpstreamUnavailable
+from hal0.dispatcher.router import Dispatcher, SlotLoading, UpstreamCall, UpstreamUnavailable
+from hal0.slots.state import SlotState
 
 # ── tiny SlotManager stand-in ────────────────────────────────────────────────
 
@@ -33,15 +34,23 @@ class _RecordingSlotManager:
     up a real SlotManager (which would need a slot TOML + systemctl stubs).
     """
 
-    def __init__(self) -> None:
+    def __init__(self, state: SlotState = SlotState.READY) -> None:
         self.events: list[tuple[str, str]] = []  # (op, slot_name)
         self._counts: dict[str, int] = {}
+        self._state = state
 
     def serving(self, slot_name: str) -> _RecordingCtx:
         return _RecordingCtx(self, slot_name)
 
     def in_flight_count(self, slot_name: str) -> int:
         return self._counts.get(slot_name, 0)
+
+    def _current_state(self, _slot_name: str) -> SlotState:
+        # Mirrors SlotManager._current_state — Dispatcher's swap-window
+        # gate calls this before forwarding.  Default READY so the
+        # existing serving-integration tests pass; tests for the gate
+        # construct the mock with the state they want to assert against.
+        return self._state
 
 
 class _RecordingCtx:
@@ -210,3 +219,92 @@ async def test_single_flight_prefetch_does_not_enter_serving() -> None:
     await dispatcher.aclose()
 
     assert sm.events == [], "prefetch must never enter serving()"
+
+
+# ── swap-window gate (SlotLoading) ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        SlotState.OFFLINE,
+        SlotState.PULLING,
+        SlotState.STARTING,
+        SlotState.WARMING,
+        SlotState.UNLOADING,
+        SlotState.ERROR,
+    ],
+)
+@pytest.mark.asyncio
+async def test_forward_gates_slot_in_loading_state(state: SlotState) -> None:
+    """Every non-ready slot state must raise SlotLoading before the HTTP forward.
+
+    Without the gate, requests in the swap window hit a dead port (502)
+    or a still-loading llama-server (raw 503).  The gate raises a
+    structured envelope with retry_after_s instead, which the error
+    middleware promotes to a Retry-After header.
+    """
+    sm = _RecordingSlotManager(state=state)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise AssertionError("forward must not reach upstream when slot is loading")
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm=sm)
+    try:
+        with pytest.raises(SlotLoading) as ei:
+            await dispatcher.forward(_slot_call())
+        exc = ei.value
+        assert exc.code == "slot.loading"
+        assert exc.status == 503
+        assert exc.details["slot"] == "primary"
+        assert exc.details["state"] == state.value
+        assert exc.details["retry_after_s"] == 15
+        progress = exc.details["progress"]
+        assert progress["phase"] == state.value
+        assert progress["upstream"] == "primary"
+        # No serving counter movement — the gate fires before _forward_with_serving.
+        assert sm.events == []
+        assert sm.in_flight_count("primary") == 0
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.parametrize(
+    "state",
+    [SlotState.READY, SlotState.SERVING, SlotState.IDLE],
+)
+@pytest.mark.asyncio
+async def test_forward_passes_through_ready_states(state: SlotState) -> None:
+    """READY / SERVING / IDLE must all be treated as 'ready to serve'."""
+    sm = _RecordingSlotManager(state=state)
+    dispatcher = _make_dispatcher(
+        httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True})),
+        sm=sm,
+    )
+    try:
+        resp = await dispatcher.forward(_slot_call())
+        assert resp.status_code == 200
+        assert sm.events == [("enter", "primary"), ("exit", "primary")]
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_remote_upstream_skips_gate_even_when_slot_state_lookup_would_fail() -> None:
+    """Remote upstreams have no slot_name — the gate must not fire.
+
+    Defends against a regression where the gate is moved before the
+    slot_name + slot_manager check, which would crash on remote calls
+    that don't carry a slot identity.
+    """
+    sm = _RecordingSlotManager(state=SlotState.OFFLINE)  # would trip the gate
+    dispatcher = _make_dispatcher(
+        httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True})),
+        sm=sm,
+    )
+    try:
+        resp = await dispatcher.forward(_remote_call())
+        assert resp.status_code == 200
+        assert sm.events == []
+    finally:
+        await dispatcher.aclose()


### PR DESCRIPTION
## Summary

Chat completions hitting a slot mid-swap (`STARTING` / `WARMING`) used
to return a raw **502** (port not yet bound) or **503** from
llama-server's still-loading gate — no `Retry-After`, no progress
context for the dashboard.

This PR adds a swap-window gate inside `Dispatcher.forward`: if the
target slot isn't in `{READY, SERVING, IDLE}`, raise a typed
`SlotLoading` error instead of forwarding to a port that may not be
bound or a model that may not be loaded. The error carries
`retry_after_s` plus a `progress` block (`phase`, `requested_model`,
`upstream`), and the error middleware now promotes `retry_after_s` to
a real `Retry-After` HTTP header on any 503 envelope so OpenAI-style
SDKs back off cleanly.

**Production trace that prompted this** (2026-05-28, primary swap):

```
02:50:26  POST /v1/chat/completions  502  dispatch.upstream_unavailable  (port 8001 dead)
02:51:24  POST /v1/chat/completions  503  (raw llama-server "still loading")
02:51:31  POST /v1/chat/completions  503  (same)
02:51:35  primary llama-server: listening on :8001
02:54:27  POST /v1/chat/completions  200  (back to normal)
```

After this PR, the 502/503 window returns:

```http
HTTP/1.1 503 Service Unavailable
retry-after: 15
content-type: application/json

{"error":{"code":"slot.loading",
          "message":"slot 'primary' is starting — not ready to serve",
          "details":{"slot":"primary","state":"starting","retry_after_s":15,
                     "progress":{"phase":"starting",
                                 "requested_model":"qwen3-coder-...",
                                 "upstream":"primary"}}}}
```

## Why this works for both audiences

- **OpenAI SDKs** see a textbook `503 + Retry-After: 15` and exponential-back-off-retry without help.
- **The hal0 dashboard** can render a "model loading…" chip from `details.progress` instead of a generic error toast.
- **All `/v1/*` routes** that go through the dispatcher (audio, embeddings, rerank, chat) get the gate for free — it lives at `Dispatcher.forward`, not in a route handler.

## Files

- `src/hal0/dispatcher/router.py` — new `SlotLoading(DispatchError)` + `Dispatcher._check_slot_ready_for_dispatch` + `_build_loading_response`
- `src/hal0/api/middleware/error_codes.py` — promote `details.retry_after_s` to `Retry-After` header on 503 envelopes
- `tests/dispatcher/test_serving_integration.py` — 6 parametrized non-ready states + 3 ready states + remote-skip case
- `tests/api/test_v1_audio.py` — pin in-memory slot state to `READY` in the seed helpers (audio tests stub HTTP transport rather than starting a real slot)

## Verification

- **Unit tests:** 1928/1928 pass, 3 skipped (pre-existing).
- **LXC smoke (live):**
  - OFFLINE slot + chat call → 503 `slot.loading` + `Retry-After: 15` ✅
  - Mid-swap (`state=starting`) chat call → same envelope, `phase=starting` ✅
  - Post-swap chat call → 200 OK unchanged ✅
- **CI gates:** `ruff check` clean, `ruff format --check` clean.

## Related

- #377 — chat dispatcher always routes to legacy `primary` slot regardless of body `model` field. Orthogonal architectural issue, deferred. The swap-window gate doesn't touch routing — it only refuses to forward when the target slot is loading.

## Test plan

- [x] `pytest tests/dispatcher/ tests/api/`
- [x] `ruff check` + `ruff format --check`
- [x] LXC smoke: trigger primary swap, fire chat during load window, assert 503 + Retry-After + structured body
- [x] LXC smoke: post-swap chat returns 200 unchanged