### PR TITLE
docs(plan,changelog): record updater fix + async-job polling contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,28 @@ servers and the dashboard v3 surfaces that consume them. Landed
   Registry files at `/etc/hal0/mcp-servers/<id>.toml` written
   0o600 inside a 0o700 directory.
 
+### Fixed
+
+- **Settings → Updates: Install update silently no-op'd** (#386).
+  The dashboard's Install button hit `POST /api/updates/apply`,
+  received 202 with a `job_id`, toasted "Update started", and never
+  polled the job — so when the background apply hit
+  `UpdateExtractError` from a leftover `/usr/lib/hal0/hal0-<v>/`
+  the user saw nothing. Three fixes:
+  - UI: `useUpdateApply` signature corrected (`version?`, not
+    misnamed `channel`); `useUpdateCheck` GETs `/api/updates/check`
+    (was POSTing to a GET-only route → silent 405); new
+    `useUpdateJob(jobId)` poller surfaces `running` / `applied` /
+    `failed` to inline progress + toasts.
+  - Backend: `Updater._extract_tarball` now quarantines a prior
+    hal0 extraction at the same path to `<dest>.stale-<unix-ts>`
+    instead of refusing, so a retry after a half-failed apply
+    isn't permanently wedged. Foreign non-empty dirs are still
+    refused — heuristic recognises hal0 installs by `VERSION`
+    file or `pyproject.toml` `name="hal0"`.
+  - Deduped the non-empty check in `Updater.apply()`; the extract
+    step is the single source of truth.
+
 ### Deferred
 
 - MCP-installed-server supervisor: start / stop / restart still

--- a/PLAN.md
+++ b/PLAN.md
@@ -737,14 +737,31 @@ hal0 update [--channel=stable|nightly] [--check] [--rollback]
 - If `version > current`:
   - Download tarball + sig to `/var/lib/hal0/cache/`
   - Verify cosign signature against `hal0ai/hal0` GitHub OIDC identity
-  - Extract to `/usr/lib/hal0-<new>/`
+  - Extract to `/usr/lib/hal0-<new>/`. If a prior hal0 extraction is
+    already at that path (e.g. a half-failed earlier apply), it is
+    quarantined to `<dest>.stale-<unix-ts>` rather than blocking the
+    retry. Foreign non-empty dirs are still refused — the heuristic
+    recognises hal0 installs by `VERSION` file or `pyproject.toml`
+    `name="hal0"`.
   - Run any pending config migrations (`hal0 config migrate` if `schema_version` advanced)
   - Atomic-swap `/usr/lib/hal0/current` symlink
   - `systemctl restart hal0-api` (slots untouched unless `--restart-slots`)
   - Old version retained at `/usr/lib/hal0-<old>/` for rollback
 - Rollback: swap symlink back, restart API
-- Dashboard polls `/api/updates/check` on a 24h interval, shows
-  `RestartBanner.vue` when an update is available
+- Dashboard polls `/api/updates/check` on a 24h interval, shows the
+  **Updates** section in Settings when an update is available
+
+### Async-job API contract
+
+`POST /api/updates/apply` returns **202 Accepted** with a job snapshot
+`{id, state: "queued", channel, version, error}`. The actual work runs
+in a background task that transitions the entry through
+`queued → running → applied | failed`. Clients (the dashboard, CLI,
+anything else) **must** poll `GET /api/updates/status/{id}` until
+terminal state — a 202 ack alone says nothing about success. Transient
+errors during the poll are expected (hal0-api is restarting); the UI
+keeps polling until the entry resolves. Same contract applies to the
+other 202-returning endpoints listed in §4 (e.g. `/api/models/{id}/pull`).
 
 Channels:
 - `stable` — tagged releases, signed, default


### PR DESCRIPTION
## Summary

Follow-up to #386. Records the fix in CHANGELOG (Unreleased → Fixed) and codifies the underlying pattern in PLAN §9.

## Changes

**CHANGELOG.md** — new \`### Fixed\` block under Unreleased explaining the three fixes (UI hook verbs/signatures + job poller, backend extract quarantine, dedupe of duplicate non-empty check).

**PLAN.md §9 (Update mechanism)**:
- Extract step now documents the quarantine-on-retry behavior (recognises hal0 installs by VERSION/pyproject; foreign dirs still refused).
- New **Async-job API contract** subsection. Any 202+job_id endpoint (updater apply, model pull, future jobs) requires the client to poll \`GET /status/{id}\` until terminal state and toast the verdict. The 202 ack alone says nothing about success — this was the entire root cause of #386 and was previously implicit only in route docstrings.

## Test plan

- [x] Markdown renders correctly in GitHub preview
- [x] No code changes; CI green by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)