### PR TITLE
docs(internal): pin v0.3 state, add ADR-0015 + ADR-0017, refresh release-manifest

### DIFF
--- a/docs/internal/adr/0015-mcp-as-host-platform.md
+++ b/docs/internal/adr/0015-mcp-as-host-platform.md
@@ -1,0 +1,331 @@
+# ADR 0015 — hal0 is an MCP host platform (v0.3)
+
+- **Status:** Draft (target: `v0.3.0-alpha.2`)
+- **Date:** 2026-05-27
+- **Drivers:** `hal0_mcp_host_platform` auto-memory note —
+  "`/agents` MCP view should host arbitrary aftermarket MCP servers
+  (catalog + install + supervise), not just bundled hal0-admin /
+  hal0-memory. Treat like capability slots." Issue **#224** —
+  open; the dashboard `/agents/mcp` page's install-from-URL UI is
+  a placeholder.
+- **Related:** ADR-0011 (agent identity cards), ADR-0012 (remove
+  auth and Caddy entirely), ADR-0013 (MCP-client allow-list for
+  bundled agents), ADR-0017 (bell+inbox approval UX).
+
+## Context
+
+hal0 today mounts two MCP servers in-process under the FastAPI app:
+
+- `hal0-admin` at `/mcp/admin` — wraps existing `/api/*` routes
+  (per ADR-0004 §4) so a bundled agent can drive hal0's slot /
+  model / capability surface.
+- `hal0-memory` at `/mcp/memory` — wraps Cognee for episodic
+  memory + agent identity cards (per ADR-0005 + ADR-0011).
+
+Both are built by FastMCP and mounted in
+`src/hal0/api/mcp_mount.py::mount_mcp_servers`. They share one
+identity middleware (`MCPAuthMiddleware`, to be renamed to
+`MCPIdentityMiddleware` per ADR-0012) and one in-process dispatch
+path. ADR-0013 has already locked in the *client side* of this story
+for bundled agents: each agent declares which MCP servers it can
+reach and which tools it can call, in
+`/etc/hal0/agents/<name>.toml`, with default-deny on both axes.
+
+What is **not** yet decided is the **host side** for *external* MCP
+servers. The patterns users want to support:
+
+1. A user finds a useful third-party MCP server upstream (filesystem,
+   github, brave-search, a custom corp knowledge MCP, etc.) and
+   wants to install it on their hal0 host so any of their agents can
+   reach it.
+2. A user wants to write a one-off MCP server (a few tools wrapping
+   their own scripts) and run it under hal0's supervision instead of
+   hand-rolling a systemd unit.
+3. The dashboard `/agents/mcp` page currently lets the user view
+   which MCP servers exist but cannot actually install or manage
+   them. Issue #224 tracks the placeholder install-from-URL UI.
+
+This ADR is the gap-closer: it declares hal0 a **first-class MCP
+host platform**, and it treats third-party MCP servers as
+*structurally equivalent* to the bundled `hal0-admin` and
+`hal0-memory` — same lifecycle states, same dashboard surface, same
+supervision model. The capability-slots system (`hal0_capability_slots_system`
+in auto-memory) is the prior art: bundle catalog +
+`/etc/hal0/` registry + systemd template + dashboard tile.
+
+ADR-0013 is the dual side of this: ADR-0015 says *which MCP servers
+can run on the host at all*, ADR-0013 says *which of those each
+bundled agent is allowed to call*.
+
+## Options considered
+
+| Option | Reason rejected (or accepted) |
+|---|---|
+| **In-process FastAPI mounts only** (today's shape, only for first-party MCPs) | Rejected as the target end state. Works for hal0's two own MCPs but forces every third-party MCP to be Python + importable by `hal0-api`. Excludes stdio MCPs entirely, excludes anything not packaged for in-process import. |
+| **stdio MCP per agent, agent supervises** (each bundled agent spawns its own stdio MCP children) | Rejected. Forces each agent to be a process supervisor. Lifecycle, restart, logging, port assignment all duplicated per agent. Bundle-fatigue. |
+| **External MCP server registry under systemd template `hal0-mcp@<name>.service`** + `[mcp.servers]` registry in `/etc/hal0/` | **ACCEPTED.** Mirrors the slot lifecycle pattern users already understand (`hal0-slot@.service`, `/etc/hal0/slots/*.toml`). One supervision model across slots + MCP servers. Dashboard reuse. |
+| **One monolithic MCP gateway** (route external MCPs through one in-process aggregator) | Rejected for v0.3. The MCP spec already supports per-server routing on the client side (ADR-0013's allow-list); putting an aggregator in front adds latency, complicates auth-passthrough, and conflicts with FastMCP's session semantics. Could be revisited in v1.0 if discovery scaling becomes a problem. |
+| **Container-only MCP hosting** (require Docker for every external MCP) | Rejected for v0.3. Many useful MCPs are 50-line stdio scripts; mandating containerisation kills the on-ramp. Containers remain an option (Docker/Podman launch wrapped by the systemd unit) but not a requirement. |
+
+## Decision
+
+### 1. Two source classes of MCP server
+
+hal0 hosts MCP servers from two sources:
+
+| Class | Examples | Lifecycle owner |
+|---|---|---|
+| **Bundled** | `hal0-admin`, `hal0-memory` | hal0-api (in-process FastMCP mount) |
+| **External** | User-installed third-party MCPs from the curated allow-list or a user-added URL | systemd template `hal0-mcp@<name>.service` |
+
+Bundled MCPs stay mounted in-process for the obvious reasons:
+- They are written against hal0's own dispatcher and Cognee handle.
+- Round-trip latency matters for `memory_*` tools called inside an
+  agent's hot loop.
+- Their lifecycle is `hal0-api`'s lifecycle by definition.
+
+External MCPs run under their own systemd unit so:
+- They can be written in any language (stdio MCPs are mostly
+  Node/Python today).
+- A crash in a third-party MCP doesn't take down `hal0-api`.
+- Restart / log / supervise semantics match what users already know
+  from slots.
+
+### 2. Registry at `/etc/hal0/mcp/servers/<name>.toml`
+
+One file per external MCP server. Mirrors `/etc/hal0/slots/*.toml`
+exactly. Sketch:
+
+```toml
+# /etc/hal0/mcp/servers/filesystem.toml
+schema_version = 1
+
+[server]
+name        = "filesystem"
+display     = "Filesystem MCP"
+source      = "registry:filesystem@1.0.2"   # or "url:https://..." or "git:...#sha"
+transport   = "stdio"                       # "stdio" | "streamable-http" | "sse"
+enabled     = true
+
+[server.runtime]
+# What systemd actually exec's. Validated against the curated allow-list
+# for source=registry; honour-trust-but-warn for user-added sources.
+command     = "npx"
+args        = ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"]
+env.HOME    = "/var/lib/hal0/mcp/filesystem"
+
+[server.health]
+# Polled by hal0-api to update lifecycle state.
+probe       = "tool_list"      # "tool_list" | "ping" | "none"
+interval_s  = 30
+```
+
+A `[mcp.servers.*]` section in an agent's
+`/etc/hal0/agents/<name>.toml` (ADR-0013) references one of these by
+`name`. If the agent allow-list names a server that has no
+`/etc/hal0/mcp/servers/<name>.toml`, the agent gets a
+`mcp.server_not_installed` error at startup and the dashboard surfaces
+the gap (with a one-click "Install" button if the name matches a
+curated catalog entry).
+
+### 3. Lifecycle states match slots
+
+External MCP servers carry the same five lifecycle states as slots:
+
+| State | Meaning |
+|---|---|
+| `CONFIGURED` | TOML exists, unit installed, not yet started. |
+| `WARMING` | `systemctl start` issued; waiting for the first health probe to succeed. |
+| `READY` | Health probe green; agents can dispatch. |
+| `FAILED` | Health probe red AND systemd unit is in `failed` state, OR unit start exit code ≠ 0. |
+| `OFFLINE` | `enabled = false` in TOML OR explicit user stop. |
+
+Transitions:
+- `CONFIGURED → WARMING → READY` — happy path on enable.
+- `READY → OFFLINE` — user disabled or stopped.
+- `* → FAILED` — health probe failure or systemd failure.
+- `FAILED → WARMING` — manual restart via dashboard or
+  `hal0 mcp restart <name>`.
+
+The dashboard's `/agents/mcp` page renders these the same way
+`/slots` renders slot lifecycle today — same chip colours, same
+inline restart button.
+
+### 4. Catalog
+
+Curated allow-list ships in `installer/manifests/mcp-catalog.toml`
+(new file; installer drops a copy to `/var/lib/hal0/mcp/catalog.toml`
+on install, refreshable via `hal0 mcp catalog refresh`). The catalog
+is the trust boundary for one-click install:
+
+- Entries name an upstream `source` (`npm:`, `pypi:`, `git:`,
+  `docker:`) with a version pin.
+- Each entry carries a short description + default `[server.runtime]`
+  block + recommended `[server.health]` block.
+- One-click install in the dashboard reads from this catalog;
+  user-added sources (URL or git ref outside the catalog) get a
+  "user-trusted, not curated" badge in the UI and a confirm prompt.
+
+### 5. CLI surface
+
+```sh
+hal0 mcp catalog list                    # what's in the curated catalog
+hal0 mcp install <name>                  # from catalog
+hal0 mcp install --url <url> <name>      # user-trusted
+hal0 mcp list                            # what's installed locally
+hal0 mcp status <name>                   # lifecycle state + last health probe
+hal0 mcp restart <name>
+hal0 mcp uninstall <name>
+hal0 mcp catalog refresh                 # pull a fresh curated catalog
+```
+
+The `install-from-URL` path is the implementation of issue #224's
+placeholder; this ADR is the design doc for it.
+
+### 6. systemd template
+
+`/etc/systemd/system/hal0-mcp@.service`:
+
+```ini
+[Unit]
+Description=hal0 MCP server (%i)
+After=network.target hal0-api.service
+PartOf=hal0-api.service
+
+[Service]
+Type=simple
+User=hal0
+Group=hal0
+WorkingDirectory=/var/lib/hal0/mcp/%i
+EnvironmentFile=-/etc/hal0/mcp/servers/%i.env
+ExecStart=/usr/lib/hal0/mcp/runner %i      # reads /etc/hal0/mcp/servers/%i.toml, exec()s [server.runtime]
+Restart=on-failure
+RestartSec=2s
+```
+
+The runner shim (one Python script) reads the TOML, applies env,
+exec()s the configured command. Same model as the slot template.
+
+### 7. Approval-gating contract (cross-reference to ADR-0017)
+
+External MCP server tools inherit the same destructive-by-default
+classification as bundled-agent MCP tools. The bell + inbox UI
+shipped via Epic #322 (PRs #321 / #328 / #329 / #330 / #332) gates
+all calls flagged DESTRUCTIVE via the MCP `annotations` block in
+the tool's schema, regardless of which MCP server hosts the tool.
+See ADR-0017 for the classification rule.
+
+This means a third-party MCP that ships a `delete_*` tool **without**
+DESTRUCTIVE annotation still gates by default (unclassified =
+DESTRUCTIVE — see ADR-0017 §3). Catalog-curated entries can override
+in `/etc/hal0/mcp/servers/<name>.toml` if the tool genuinely is
+side-effect-free.
+
+### 8. Auth posture
+
+Per ADR-0012, hal0 has no built-in auth. External MCP servers
+inherit this: the supervised process binds to localhost (or to a
+Unix socket — preferred where the transport supports it) and is
+reachable only to local processes. Operator-grade auth is the
+reverse proxy's job; the MCP server itself does not authenticate.
+
+For external MCPs that need outbound credentials (e.g., a GitHub
+MCP needing a token), the `auth.kind = "bearer-from-env"` pattern
+from ADR-0013 §2 is reused: tokens live in
+`/etc/hal0/mcp/servers/<name>.env` with `0600 hal0:hal0` perms, are
+loaded into the unit's environment by `EnvironmentFile=`, and are
+never surfaced to the agent (the MCP server reads them; the agent
+only sees tool calls + responses).
+
+## Consequences
+
+### Positive
+
+- Closes the gap identified in `hal0_mcp_host_platform` auto-memory
+  with a structurally consistent answer (slots model, applied to
+  MCPs).
+- Closes issue #224 with a concrete design instead of a placeholder.
+- One supervision model across slots, capabilities, MCP servers,
+  and agents — the operator learns one mental model.
+- ADR-0013's per-agent allow-list now has a real "what's available
+  to allow" set (the installed MCP servers list).
+- Third-party MCPs can be written in any language without forcing
+  Python-in-process integration.
+- Dashboard surface `/agents/mcp` becomes coherent: per-server tiles
+  with lifecycle chips, install button, log link, restart button.
+
+### Negative / costs
+
+- One more registry directory to back up (`/etc/hal0/mcp/`).
+  Mitigation: the installer already includes `/etc/hal0/**` in its
+  config-preservation envelope.
+- The curated MCP catalog is an editorial commitment — we own
+  vetting upstream MCPs before listing them. Mitigation: keep the
+  v0.3 catalog small (filesystem, git, brave-search, fetch — a
+  handful of high-confidence MCPs) and grow only on demand.
+- A misbehaving external MCP can hold a port, leak memory, or stall
+  health probes. Mitigation: `Restart=on-failure` + the health
+  probe → `FAILED` state transition surfaces the breakage in the
+  dashboard; operator action.
+- Catalog refresh introduces a network dependency. Mitigation: it's
+  pull-only (`hal0 mcp catalog refresh`), never auto on boot;
+  failed refresh logs WARN and keeps the prior catalog.
+- One-click install + arbitrary URLs are an attack surface. The
+  "user-trusted" confirm gate is the user's contract; we explicitly
+  do *not* claim safety guarantees for URL-installed MCPs.
+
+### Neutral
+
+- Bundled MCPs (`hal0-admin`, `hal0-memory`) stay in-process; this
+  ADR doesn't propose moving them. They are documented in this same
+  surface for symmetry (the dashboard shows them as "bundled,
+  in-process" tiles), but their lifecycle is `hal0-api`'s.
+
+## Pending items
+
+- `installer/manifests/mcp-catalog.toml` — initial catalog file.
+- `src/hal0/mcp/runner.py` (or similar) — the systemd ExecStart shim.
+- `src/hal0/mcp/registry.py` — TOML parser + lifecycle state machine
+  + health probe driver.
+- `src/hal0/api/routes/mcp_servers.py` — `/api/mcp/servers/*` CRUD +
+  lifecycle endpoints feeding the dashboard.
+- `src/hal0/cli/mcp_commands.py` — `hal0 mcp ...` subcommands.
+- Dashboard `/agents/mcp` page — replace the placeholder install
+  UI with the catalog + URL flow; per-server tiles.
+- Documentation page `docs/mcp/host-platform.md` describing the
+  shape for users (PR-3's scope).
+- New GH issue (to be filed during implementation): track the
+  follow-up "v3 dashboard MCP page wired to /api/mcp/servers/*"
+  work and link this ADR.
+
+## Open questions
+
+- Should MCP server health probes share the slot health-probe
+  scheduler or run their own loop? Initial guess: share, because the
+  cadence is the same and one less thread is cheaper.
+- Should the dashboard treat bundled MCPs (`hal0-admin`,
+  `hal0-memory`) as configurable at all, or render them as read-only
+  "always-on" tiles? Leaning read-only — they're tied to
+  `hal0-api`'s lifecycle, so a per-MCP enable toggle would be
+  misleading.
+- How does a future federation story (multi-host hal0) discover
+  external MCPs on peer hosts? Out of scope for v0.3; the
+  `agents` dataset (ADR-0011) is the analogous discovery
+  substrate for agents and a similar pattern could extend to MCPs.
+
+## References
+
+- ADR-0011 — agent identity cards (the `agents` dataset is the
+  prior art for "dedicated dataset for service-registry use").
+- ADR-0012 — auth removal (sets the auth posture inherited here).
+- ADR-0013 — MCP-client allow-list for bundled agents (the dual
+  side of this ADR).
+- ADR-0017 — bell + inbox approval UX for destructive MCP calls
+  (the gating contract that extends to third-party MCP servers).
+- `hal0_mcp_host_platform` auto-memory — the gap-statement this ADR
+  closes.
+- `hal0_capability_slots_system` auto-memory — prior art for the
+  catalog + systemd template + dashboard tile pattern.
+- Issue #224 — dashboard `/agents/mcp` install-from-URL placeholder.
+- `src/hal0/api/mcp_mount.py` — current in-process mount path for
+  bundled MCPs.

--- a/docs/internal/adr/0017-bell-inbox-approval-ux.md
+++ b/docs/internal/adr/0017-bell-inbox-approval-ux.md
@@ -1,0 +1,251 @@
+# ADR 0017 — Bell + inbox approval UX for destructive MCP calls (v0.3)
+
+- **Status:** Accepted (post-implementation; UX shipped in Epic #322
+  via PRs #321 / #328 / #329 / #330 / #332)
+- **Date:** 2026-05-27
+- **Drivers:** ADR-0004 §5 sketched the two-tier approval pattern.
+  Code + `release-manifest.md` carry the contract, but the pattern
+  was never given its own ADR. Epic #322 then shipped the dashboard
+  surface (footer bell + inbox modal) on 2026-05-25. This ADR
+  documents the shipped rule so future contributors (including
+  third-party MCP server authors per ADR-0015) have a single
+  reference for "how do I classify my tool?"
+- **Related:** ADR-0004 (agents — original two-tier sketch), ADR-0013
+  (per-agent MCP-client allow-list — `tools.gated` tier maps onto
+  this), ADR-0015 (MCP as host platform — third-party MCP servers
+  inherit this gating contract).
+
+## Context
+
+ADR-0004 §5 introduced the two-tier scope:
+
+- **Autonomous read / routine write** — agent calls proceed without
+  user intervention.
+- **Gated destructive** — call enqueues, returns `pending_approval`
+  immediately, user must approve via dashboard or CLI before the
+  call executes.
+
+The intent was to gate prompt-injection footguns: untrusted text in
+an agent's context can ask it to call `model_delete`, but only the
+user clicking approve makes that delete happen.
+
+The implementation landed across the v0.2 + v0.3 cycle:
+
+- ADR-0004's destructive list (model_pull, model_delete, slot_*,
+  capability_set, config_write, provider_credential_write, bulk
+  memory_delete) → enforced server-side in
+  `src/hal0/mcp/approval_queue.py` + `src/hal0/mcp/admin.py`.
+- Epic #322 (PRs #321 / #328 / #329 / #330 / #332) shipped the
+  dashboard UX: footer bell with badge count + inbox modal +
+  per-card approve/deny + journal stream.
+- CLI parity (`hal0 agent approvals {list,approve,deny}`) shipped
+  alongside.
+
+What was missing: a single document a tool author can read to
+understand the classification rule. ADR-0004's two-tier list is
+specific to hal0-admin tools; ADR-0013 added `tools.gated` per
+agent; ADR-0015 (this PR) extends MCP hosting to third-party
+servers. Without a unifying ADR the rule is split across three
+places and the **MCP `annotations` block** is the actual carrier in
+the protocol.
+
+This ADR collapses those scattered references into one rule, names
+the protocol carrier, and writes down the default for unclassified
+tools.
+
+## Decision
+
+### 1. Every MCP tool is classified READ-ONLY or DESTRUCTIVE
+
+Two classes, set per tool, exposed in the tool's MCP `annotations`
+block:
+
+```jsonc
+{
+  "name": "memory_search",
+  "description": "Search hal0-memory for relevant items.",
+  "inputSchema": { /* ... */ },
+  "annotations": {
+    "destructive": false,        // READ-ONLY by classification
+    "destructiveReason": null
+  }
+}
+```
+
+```jsonc
+{
+  "name": "model_delete",
+  "description": "Delete a model from the registry + disk.",
+  "inputSchema": { /* ... */ },
+  "annotations": {
+    "destructive": true,         // DESTRUCTIVE
+    "destructiveReason": "Permanently removes the model + GGUF bytes."
+  }
+}
+```
+
+- **READ-ONLY** calls proceed without approval. They are journaled
+  to the per-agent journal (per Epic #322 / `src/hal0/journal/`) so
+  the user can audit afterwards. No bell, no inbox entry.
+- **DESTRUCTIVE** calls enqueue an approval request, return
+  `pending_approval` immediately to the MCP client, increment the
+  bell badge, and add an inbox entry. The server executes the call
+  only after the user approves; deny cancels with a `denied` reason
+  surfaced back to the agent.
+
+### 2. The bell + inbox is the canonical surface
+
+| Surface | What it shows | Source of truth? |
+|---|---|---|
+| **Footer bell** (every dashboard page) | Badge count of pending DESTRUCTIVE requests | Yes |
+| **Inbox modal** (opened from the bell) | List of pending requests with approve/deny | Yes |
+| **Inline pending indicators** on Models / Slots / Capabilities pages | Context-rich nudge ("1 pending: model_delete `qwen3:0.6b`") | No — convenience link to the inbox |
+| **CLI** `hal0 agent approvals {list,approve,deny}` | Same queue | Yes — parity with the bell |
+
+The bell is always visible regardless of which view the user is on.
+Inline indicators are a convenience layer.
+
+### 3. Default for unclassified tools: DESTRUCTIVE
+
+If a tool ships **without** an `annotations.destructive` field, hal0
+treats it as DESTRUCTIVE and gates it. This is the safe default:
+
+- Third-party MCP server authors (per ADR-0015) may not always
+  follow the convention. The cost of misclassifying as DESTRUCTIVE
+  is a click-to-approve; the cost of misclassifying as READ-ONLY is
+  unrecoverable side effects.
+- A curator can override per-tool in
+  `/etc/hal0/mcp/servers/<name>.toml` if a tool genuinely is
+  side-effect-free and the author neglected the annotation.
+- Bundled MCP servers (`hal0-admin`, `hal0-memory`) are
+  fully-classified at code level — no unannotated tools exist in
+  hal0's own MCP surface, by repo policy.
+
+### 4. Pending forever — no auto-expire
+
+Approval requests sit in the queue until the user acts on them. No
+TTL, no auto-deny.
+
+- If the user ignores a request for a week, it remains. The bell
+  badge surfaces the backlog.
+- A "Clear all" action on the inbox flushes the queue (categorised
+  as user-initiated deny of all pending).
+- The agent's MCP loop decides whether to wait synchronously on
+  `pending_approval`, poll for the resolution, or abandon and try
+  again later. That's the agent's policy, not hal0's. (ADR-0004 §5
+  is explicit about this; restated here for completeness.)
+
+### 5. No per-agent trust override
+
+There is **no** "trust this agent fully" toggle that bypasses the
+gating queue. Power users wanting full autonomy must amend the
+DESTRUCTIVE classification for the specific tools they want
+unattended, not flip a global bypass. The toggle would be the
+prompt-injection footgun this whole pattern exists to prevent.
+
+A bundled agent (`/etc/hal0/agents/<name>.toml`, per ADR-0013) can
+list a DESTRUCTIVE tool in its `tools.allow` set — but the tool's
+annotation still drives the gating decision at call time. The
+allow-list governs *whether the agent can reach the tool at all*;
+this ADR governs *whether the call proceeds without a click* once
+reached.
+
+### 6. Third-party MCP servers inherit the contract
+
+Per ADR-0015 §7: external MCP servers run under hal0's supervision
+and route through the same approval queue. A third-party MCP that
+ships a `delete_*` or `write_*` tool **without** DESTRUCTIVE
+annotation still gates by default (per §3 above). Catalog-curated
+entries in `installer/manifests/mcp-catalog.toml` may carry a
+`[overrides.tools.<name>.destructive]` block when the curator has
+audited the tool and confirmed it is side-effect-free; user-added
+servers do not get this convenience and gate everything not
+explicitly annotated.
+
+### 7. Approval record envelope
+
+```jsonc
+{
+  "id": "approval_01HXYZ...",
+  "agent_name": "hermes",
+  "client_id": "hermes-agent",          // from X-hal0-Agent (post-rename)
+  "mcp_server": "hal0-admin",           // or "filesystem", "github", etc.
+  "tool": "model_delete",
+  "args": { "id": "qwen3:0.6b" },
+  "enqueued_at": "2026-05-25T14:23:11Z",
+  "destructive_reason": "Permanently removes the model + GGUF bytes."
+}
+```
+
+Identical envelope across hal0-admin, hal0-memory bulk delete, and
+external MCP servers — the dashboard renders one card type
+regardless of source.
+
+## Consequences
+
+### Positive
+
+- One classification rule across all MCP surfaces (bundled +
+  third-party). Tool authors have a single reference.
+- DESTRUCTIVE-by-default for unclassified tools means a third-party
+  MCP without annotations is *safe by default* — the worst case is
+  user click-fatigue, not data loss.
+- The bell + inbox shipped in v0.3 has a canonical design doc to
+  reference when future contributors ask "why is everything
+  destructive by default?" or "where's the trust toggle?"
+- ADR-0015's host-platform decision can now reference a single
+  contract for inheriting gating into third-party MCPs.
+
+### Negative / costs
+
+- Click-fatigue on DESTRUCTIVE-misclassified READ-ONLY tools. Real;
+  mitigated by per-server override in
+  `/etc/hal0/mcp/servers/<name>.toml` (curator-set) and by `tools.allow`
+  pre-vetting from ADR-0013 (which doesn't bypass the gate, but
+  does scope what the agent can reach).
+- No auto-expire means the queue can grow unboundedly on a system
+  with a chatty agent and an absent user. Mitigated by "Clear all"
+  + the bell badge that surfaces the backlog at all times.
+- DESTRUCTIVE-by-default means well-intentioned third-party MCP
+  authors who shipped genuine read tools without annotations get
+  punished UX-wise on first install. We accept this; the curated
+  catalog's override block is the structural answer for
+  high-traffic curated MCPs.
+
+### Neutral
+
+- The wire-level protocol carrier (MCP `annotations.destructive`) is
+  the standard MCP spec extension shape. We're not inventing a new
+  carrier; we're documenting our use of the existing one and
+  formalising the default-when-absent.
+
+## Pending items
+
+(All complete for v0.3 except per-server-curated-override plumbing,
+which depends on ADR-0015 landing first.)
+
+- The `[overrides.tools.<name>.destructive]` block in
+  `installer/manifests/mcp-catalog.toml` and the runtime read path
+  in `src/hal0/mcp/registry.py` (depends on ADR-0015
+  implementation).
+- A linter pass that warns hal0-bundled MCP tools without an
+  explicit `annotations.destructive` set. Belt-and-suspenders so
+  the safe default isn't quietly inherited inside hal0's own
+  surface.
+
+## References
+
+- ADR-0004 §5 — original two-tier sketch + destructive tool list.
+- ADR-0013 — per-agent allow-list (`tools.gated` tier maps onto
+  this contract).
+- ADR-0015 — MCP as host platform (third-party MCP servers inherit
+  this gating contract).
+- Epic #322 — implementation epic (PRs #321 / #328 / #329 / #330 /
+  #332).
+- `src/hal0/journal/` — per-agent journal stream (READ-ONLY calls
+  log here without bell-gating).
+- `src/hal0/mcp/approval_queue.py` — queue + state machine.
+- `src/hal0/mcp/admin.py` — hal0-admin tool catalog, destructive
+  flags wired per ADR-0004.
+- `hal0_epic_322_footer_journal_shipped` auto-memory — shipped
+  state at 2026-05-25.

--- a/docs/internal/api-errors.md
+++ b/docs/internal/api-errors.md
@@ -98,29 +98,35 @@ malformed body:
 
 ### 401 — unauthorized
 
-`/api/*` and `/v1/*` (hal0 envelope — auth runs before forwarding):
+**Post-ADR-0012 status:** there is **no built-in 401 path** on the
+FastAPI surface. `hal0-api` binds open; auth is the operator's reverse
+proxy. The `auth.required` envelope below is documented for two
+reasons: (a) the upstream cosign-verified release endpoints and
+`/mcp/*` mounts still resolve a `client_id` from request headers
+(`X-hal0-Agent` post-rename — see `v0.3-state.md` §3) and may surface
+identity-related errors using this envelope shape, and (b) any
+reverse-proxy auth layer in front of hal0 will surface its own 401
+through the proxy, not through this envelope.
+
+When an identity-required surface does raise, the shape is:
 
 ```json
 {
   "error": {
     "code": "auth.required",
-    "message": "no bearer token presented",
+    "message": "no agent identity presented",
     "details": {}
   }
 }
 ```
 
-Same status, hal0 envelope on both surfaces, because the auth
-middleware refuses the request before it can reach an upstream.
-
-Per [ADR-0001](./adr/0001-collapse-edge-auth-into-fastapi.md) (PR #58),
-the auth surface is a single FastAPI layer — `POST /api/auth/login`
-issues a `hal0_session` cookie, `POST /api/auth/logout` clears it, and
-`POST /api/auth/password` sets or rotates the owner password (public
-when no password is yet set; writer-scoped otherwise). The middleware
-accepts either the session cookie or a Bearer token against the same
-`require_token` / `require_writer` deps, so 401 envelopes are identical
-across both auth paths.
+History: ADR-0001 (PR #58) introduced a FastAPI-layer auth surface
+(`POST /api/auth/login` cookie, `POST /api/auth/password`, Bearer
+tokens). ADR-0012 (PRs #254 / #255 / #256 / #266 / #267, v0.3.0-alpha.1)
+removed that surface entirely — ~6,000 lines deleted across backend,
+frontend, tests, installer, and packaging. The `auth.*` envelope
+code namespace is retained for any future re-introduced auth and for
+the MCP identity middleware.
 
 ### 404 — not found
 

--- a/docs/internal/release-manifest.md
+++ b/docs/internal/release-manifest.md
@@ -7,17 +7,19 @@ https://releases.hal0.dev/{stable|nightly}.json
 ```
 
 A path-based fallback URL (`https://hal0.dev/releases/{channel}.json`)
-serves the same file — both resolve to `public/releases/*.json` in the
-[hal0ai/hal0-web](https://github.com/hal0ai/hal0-web) repo via a
-Cloudflare Pages `_redirects` rewrite. See that repo's `README.md`
-("Release manifest hosting") for the CF Pages + DNS setup.
+serves the same file. Hosting moved off the original Cloudflare Pages
+target to **Vercel** in the v0.1.0-alpha cycle (see
+`hal0_install_bootstrap` auto-memory); both URLs still resolve and the
+schema below is unchanged. The
+[hal0ai/hal0-web](https://github.com/Hal0ai/hal0-web) repo carries the
+files under `public/releases/`.
 
-`hal0 update --check` (CLI) and `GET /api/updates/check` (API) both fetch
-this file, validate it against the schema below, and compare
+`hal0 update --check` (CLI) and `GET /api/updates/check` (API) both
+fetch this file, validate it against the schema below, and compare
 `version` against `hal0.__version__`. `hal0 update` (no `--check`)
-additionally downloads the tarball + cosign signature, verifies both,
-extracts to `/usr/lib/hal0-<version>/`, and atomically swaps the
-`/usr/lib/hal0/current` symlink.
+additionally downloads the tarball + cosign signature + Fulcio
+certificate, verifies them, extracts to `/usr/lib/hal0-<version>/`,
+and atomically swaps the `/usr/lib/hal0/current` symlink.
 
 The publisher (the `release.yml` GitHub Actions workflow) produces this
 file post-build; the runtime consumer is `hal0.updater.Updater.apply()`.
@@ -28,44 +30,77 @@ file post-build; the runtime consumer is `hal0.updater.Updater.apply()`.
 # Fetch + pretty-print the live stable manifest
 curl -s https://releases.hal0.dev/stable.json | jq .
 
-# Verify cache + CORS headers are wired up by Cloudflare Pages
+# Verify cache + CORS headers
 curl -sI https://releases.hal0.dev/stable.json | grep -iE 'cache-control|access-control'
 
 # Path-based fallback
 curl -s https://hal0.dev/releases/stable.json | jq -r '.version, .channel, .digest_sha256'
 ```
 
-Until `release.yml` ships, the live manifest is a placeholder
-(`_placeholder: true`, version `0.0.0`, all-zeros `digest_sha256`). It
-parses cleanly through `ReleaseManifest.model_validate` so
-`hal0 update --check` succeeds and reports "no update available", but
-any attempt to `apply()` it will fail at the cosign-verify step —
-intentional, since there is no real signed artifact behind it yet.
+> **Current state at v0.3.0-alpha.1 (2026-05-27):** the live manifest at
+> `releases.hal0.dev/stable.json` remains a placeholder
+> (`_placeholder: true`, version `0.0.0`, all-zeros `digest_sha256`).
+> It parses cleanly through `ReleaseManifest.model_validate` so
+> `hal0 update --check` succeeds and reports "no update available", but
+> `apply()` will fail at the cosign-verify step — intentional, since no
+> real signed artifact has been published yet. The `release.yml`
+> workflow is in flight; production wiring will follow.
 
 ## Schema
 
-```json
+```jsonc
 {
   "_schema": "hal0.releases.v1",
-  "version": "0.1.1",
+  "version": "0.3.0-alpha.2",
   "channel": "stable",
-  "url": "https://github.com/hal0ai/hal0/releases/download/v0.1.1/hal0-0.1.1.tar.gz",
-  "sig_url": "https://github.com/hal0ai/hal0/releases/download/v0.1.1/hal0-0.1.1.tar.gz.sig",
-  "cert_url": "https://github.com/hal0ai/hal0/releases/download/v0.1.1/hal0-0.1.1.tar.gz.crt",
+  "url":      "https://github.com/Hal0ai/hal0/releases/download/v0.3.0-alpha.2/hal0-0.3.0-alpha.2.tar.gz",
+  "sig_url":  "https://github.com/Hal0ai/hal0/releases/download/v0.3.0-alpha.2/hal0-0.3.0-alpha.2.tar.gz.sig",
+  "cert_url": "https://github.com/Hal0ai/hal0/releases/download/v0.3.0-alpha.2/hal0-0.3.0-alpha.2.tar.gz.crt",
   "digest_sha256": "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
-  "signer_identity": "^(?i)https://github\\.com/hal0ai/hal0/\\.github/workflows/release\\.yml@refs/tags/v0\\.1\\.1$",
+  "signer_identity": "^(?i)https://github\\.com/hal0ai/hal0/\\.github/workflows/release\\.yml@refs/tags/v0\\.3\\.0-alpha\\.2$",
   "signer_issuer": "https://token.actions.githubusercontent.com",
   "min_data_version": 1,
-  "released_at": "2026-05-15T12:00:00Z",
-  "notes_url": "https://github.com/hal0ai/hal0/releases/tag/v0.1.1",
+  "released_at": "2026-05-27T12:00:00Z",
+  "notes_url":    "https://github.com/Hal0ai/hal0/releases/tag/v0.3.0-alpha.2",
   "manifest_url": "https://releases.hal0.dev/stable.json",
+
+  // OPTIONAL: runtime artefact pins.
+  //
+  // v0.2+ shifted the runtime away from per-modality toolbox container
+  // images and onto a single Lemonade install (Lemonade embeddable
+  // tarball + FastFlowLM .deb on NPU hosts). The runtime artefact
+  // pins below mirror the installer's pinned versions so an update
+  // can refuse to apply if the host's Lemonade install drifts away
+  // from the release's expected baseline.
+  //
+  // Both blocks are OPTIONAL — pre-v0.2 manifests and dev manifests
+  // may omit them.
+  "lemonade": {
+    "version": "v10.6.0",
+    "tarball_url": "https://github.com/lemonade-sdk/lemonade/releases/download/v10.6.0/lemonade-embeddable-10.6.0-ubuntu-x64.tar.gz",
+    "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "flm": {
+    "version": "0.9.42",
+    "deb_url": "https://github.com/FastFlowLM/FastFlowLM/releases/download/v0.9.42/fastflowlm_0.9.42_ubuntu24.04_amd64.deb",
+    "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+
+  // OPTIONAL: historical / out-of-tree consumers.
+  //
+  // The `toolbox_images` block is retained as a historical reference
+  // and for any out-of-tree consumers still reading v0.1.x manifests.
+  // The hal0 runtime itself NO LONGER pulls these images in v0.2+ —
+  // the runtime is Lemonade. The in-tree `manifest.json` continues to
+  // carry the image pins (still under `toolbox_images`) but they are
+  // not on the v0.2/v0.3 install path.
   "toolbox_images": {
-    "vulkan":    { "tag": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v0.1.1",    "digest": "sha256:..." },
-    "rocm":      { "tag": "ghcr.io/hal0ai/hal0-toolbox-rocm:v0.1.1",      "digest": "sha256:..." },
-    "flm":       { "tag": "ghcr.io/hal0ai/hal0-toolbox-flm:v0.1.1",       "digest": "sha256:..." },
-    "moonshine": { "tag": "ghcr.io/hal0ai/hal0-toolbox-moonshine:v0.1.1", "digest": "sha256:..." },
-    "kokoro":    { "tag": "ghcr.io/hal0ai/hal0-toolbox-kokoro:v0.1.1",    "digest": "sha256:..." },
-    "comfyui":   { "tag": "ghcr.io/hal0ai/hal0-toolbox-comfyui:v0.1.1",   "digest": "sha256:..." }
+    "vulkan":    { "tag": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1",    "digest": "sha256:..." },
+    "rocm":      { "tag": "ghcr.io/hal0ai/hal0-toolbox-rocm:v1",      "digest": "sha256:..." },
+    "flm":       { "tag": "ghcr.io/hal0ai/hal0-toolbox-flm:v1",       "digest": "sha256:..." },
+    "moonshine": { "tag": "ghcr.io/hal0ai/hal0-toolbox-moonshine:v1", "digest": "sha256:..." },
+    "kokoro":    { "tag": "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1",    "digest": "sha256:..." },
+    "comfyui":   { "tag": "ghcr.io/hal0ai/hal0-toolbox-comfyui:v1",   "digest": "sha256:..." }
   }
 }
 ```
@@ -79,7 +114,7 @@ intentional, since there is no real signed artifact behind it yet.
 | `channel` | string | no | `"stable"` (default), `"nightly"`, `"dev"`. |
 | `url` | string | yes | `http(s)` or `file://` URL of the release tarball. |
 | `sig_url` | string | yes | URL of the detached cosign signature (`*.sig`). |
-| `cert_url` | string | yes | URL of the Fulcio-issued certificate (`*.crt`). cosign 3.x requires `--certificate` alongside `--signature` for keyless verify; the cert's SAN is what `--certificate-identity-regexp` checks. |
+| `cert_url` | string | yes | URL of the Fulcio-issued certificate (`*.crt`). cosign 3.x requires `--certificate` alongside `--signature` for keyless verify; the cert's SAN is what `--certificate-identity-regexp` checks. See `hal0_cosign_cert_plumbing` auto-memory. |
 | `digest_sha256` | string | yes | Hex sha256 of the tarball bytes (64 chars). `sha256:` prefix tolerated. |
 | `signer_identity` | string | yes | Regex passed to `cosign verify-blob --certificate-identity-regexp`. Must anchor (`^...$`) to the exact GH Actions workflow + ref. Use `(?i)` to absorb GH's case preservation — the `Hal0ai` org slug is canonical capital-H but lowercase `hal0ai` references redirect; `(?i)` matches either. |
 | `signer_issuer` | string | no | OIDC issuer; defaults to GitHub Actions (`token.actions.githubusercontent.com`). |
@@ -87,7 +122,9 @@ intentional, since there is no real signed artifact behind it yet.
 | `released_at` | string | no | ISO-8601 release timestamp; surfaced in the dashboard. |
 | `notes_url` | string | no | Link to release notes. |
 | `manifest_url` | string | no | Self-reference (so a cached copy knows where it came from). |
-| `toolbox_images` | object | no | Mirrors the in-tree `manifest.json` shape: `{name: {tag, digest}}`. The release pins compatible container images. |
+| `lemonade` | object | no | Runtime pin for the Lemonade embeddable tarball. Mirrors the installer's `LEMONADE_VERSION` / `LEMONADE_TARBALL` / `LEMONADE_SHA256` pins. v0.2+ only. |
+| `flm` | object | no | Runtime pin for the FastFlowLM `.deb`. Mirrors the installer's `FLM_DEB_VERSION` / `FLM_DEB_URL` / `FLM_DEB_SHA256` pins. v0.2+ only. NPU hosts only — non-NPU hosts ignore this. |
+| `toolbox_images` | object | no | **Historical.** v0.1.x runtime pulled these images; v0.2+ does not. Retained for out-of-tree consumers. Mirrors the in-tree `manifest.json` shape: `{name: {tag, digest}}`. |
 
 Pydantic enforces shape at fetch time
 (`hal0.updater.updater._parse_manifest`). Malformed manifests reject
@@ -113,8 +150,7 @@ fall back to unsigned acceptance.
 
 ### Pre-release escape hatch: `HAL0_UPDATE_SKIP_COSIGN`
 
-For the Phase-2 prototype + LXC smoke (PLAN §17 risk #2 — "prototype in
-phase 2 against a throwaway release, not phase 5"), setting
+For prototype + LXC smoke workflows, setting
 `HAL0_UPDATE_SKIP_COSIGN=1` bypasses the verify step with a loud WARN
 log.
 
@@ -131,33 +167,41 @@ binary to a pre-release build or fix your cosign install.
 ```
 # Before
 /usr/lib/hal0/
-  current -> /usr/lib/hal0-0.1.0/
-  hal0-0.1.0/
+  current -> /usr/lib/hal0-0.3.0-alpha.1/
+  hal0-0.3.0-alpha.1/
 
 /var/lib/hal0/
   cache/                 (may be absent)
   hal0.previous          (may be absent — first install)
 
-# After hal0 update to 0.1.1
+# After `hal0 update` to 0.3.0-alpha.2
 /usr/lib/hal0/
-  current -> /usr/lib/hal0-0.1.1/   (atomic swap)
-  hal0-0.1.0/                       (retained for rollback)
-  hal0-0.1.1/                       (newly extracted)
+  current -> /usr/lib/hal0-0.3.0-alpha.2/   (atomic swap)
+  hal0-0.3.0-alpha.1/                       (retained for rollback)
+  hal0-0.3.0-alpha.2/                       (newly extracted)
 
 /var/lib/hal0/
-  cache/0.1.1/
-    hal0-0.1.1.tar.gz
-    hal0-0.1.1.tar.gz.sig
-  hal0.previous          (content: "/usr/lib/hal0-0.1.0")
+  cache/0.3.0-alpha.2/
+    hal0-0.3.0-alpha.2.tar.gz
+    hal0-0.3.0-alpha.2.tar.gz.sig
+    hal0-0.3.0-alpha.2.tar.gz.crt
+  hal0.previous          (content: "/usr/lib/hal0-0.3.0-alpha.1")
 ```
 
 `hal0 update --rollback` reads `/var/lib/hal0/hal0.previous`, swaps the
 symlink back, and re-points the previous record at what was just
 current — so a second rollback bounces between the two installs.
 
+Lemonade + FLM pin reconciliation is a separate step (not part of the
+hal0 tarball swap): if `lemonade.version` or `flm.version` in the
+new manifest differs from what's installed, the updater logs the gap
+and surfaces a follow-up `hal0 doctor lemonade` / `hal0 doctor flm`
+suggestion. Forced reconciliation is left to the user; the updater
+does not silently re-pull the embeddable tarball or the `.deb`.
+
 ## What the release pipeline must guarantee
 
-When `hal0.dev` exists and the `release.yml` workflow runs, it must:
+When the `release.yml` workflow runs, it must:
 
 1. Build `hal0-<version>.tar.gz` as a tar archive with a top-level
    `hal0-<version>/` directory (matches the synthetic-prototype shape
@@ -167,56 +211,76 @@ When `hal0.dev` exists and the `release.yml` workflow runs, it must:
 3. Sign with cosign keyless against the workflow's OIDC identity. The
    `signer_identity` in the manifest must anchor exactly to that
    identity (`^https://github.com/<org>/<repo>/.github/workflows/release.yml@refs/tags/v<ver>$`).
-4. Publish `hal0-<version>.tar.gz` + `.sig` as release assets.
+4. Publish `hal0-<version>.tar.gz` + `.sig` + `.crt` as release assets
+   (all three are required by the cosign 3.x verify flow — dropping
+   the cert breaks `apply()`).
 5. POST/commit the new `stable.json` or `nightly.json` to
-   [hal0ai/hal0-web](https://github.com/hal0ai/hal0-web) under
-   `public/releases/{channel}.json` — Cloudflare Pages auto-deploys
-   the change to `releases.hal0.dev` (and the path-based fallback
+   [hal0ai/hal0-web](https://github.com/Hal0ai/hal0-web) under
+   `public/releases/{channel}.json` — Vercel auto-deploys the change
+   to `releases.hal0.dev` (and the path-based fallback
    `hal0.dev/releases/`). Two acceptable mechanisms:
    - **PR flow** (preferred for `stable`): `release.yml` opens a PR
      against `hal0ai/hal0-web` updating only `public/releases/stable.json`,
      gated on a human approve before merge.
    - **Direct push** (acceptable for `nightly`): a deploy key with
      write scope limited to `public/releases/nightly.json` lets the
-     workflow commit straight to `master`, no PR.
+     workflow commit straight to `main`, no PR.
    Either way, the file replaces the prior manifest atomically; the
    updater fetches whatever's there with a `max-age=60` cache window
    set by `public/_headers`.
-6. Patch `toolbox_images.<name>.digest` with the sha256 content digests
-   from the toolbox build (`toolbox.yml` already does this for
-   `manifest.json`; mirror that block into the release manifest so an
-   update pulls the exact image set known-good for that release).
+6. Populate `lemonade.{version,tarball_url,sha256}` from the
+   installer's `LEMONADE_*` constants so a `hal0 update` knows which
+   embeddable tarball the new release expects on disk. Same for
+   `flm.{version,deb_url,sha256}` on NPU-supporting releases. These
+   are advisory pins — see "Filesystem effects" above for why the
+   updater does not auto-reconcile them.
 
-## Currently pinned toolbox images (`manifest.json`)
+## Why no longer toolbox-image-centric
 
-The in-tree `manifest.json` is the source of truth for what
-`toolbox_images.<name>` the release pipeline must mirror into the
-release manifest. As of `2026-05-20` the pinned set is:
+v0.1.x shipped a per-modality toolbox container model:
+`hal0-toolbox-{vulkan,rocm,flm,moonshine,kokoro,comfyui}:v1` images
+pulled from ghcr.io, supervised under `hal0-slot@.service` instances.
 
-| Name        | Tag                                       | Notes |
-|---|---|---|
-| `vulkan`    | `ghcr.io/hal0ai/hal0-toolbox-vulkan:v1`   | llama.cpp Vulkan backend; default for Strix Halo iGPU. |
-| `rocm`      | `ghcr.io/hal0ai/hal0-toolbox-rocm:v1`     | llama.cpp ROCm backend; multi-arch (gfx1030..gfx1151). |
-| `flm`       | `ghcr.io/hal0ai/hal0-toolbox-flm:v1`      | FastFlowLM on AMD XDNA2 NPU. Image is self-contained (FLM ships under `/opt/fastflowlm/` inside the image — no host bind-mount required since commit c998106). Requires host kernel ≥ 6.11 + `amdxdna` driver. |
-| `moonshine` | `ghcr.io/hal0ai/hal0-toolbox-moonshine:v1`| Moonshine STT (CPU ONNX only — upstream wheel has no Vulkan/ROCm EP). **Rebuilt 2026-05-20** to fix the `MoonshineOnnxModel(models_dir=..., model_name=...)` constructor requirement; prior tag would `TypeError` on local-weights load. |
-| `kokoro`    | `ghcr.io/hal0ai/hal0-toolbox-kokoro:v1`   | Kokoro-82M TTS (CPU ONNX); OpenAI-compat `/v1/audio/speech`. |
-| `comfyui`   | `ghcr.io/hal0ai/hal0-toolbox-comfyui:v1`  | ComfyUI image-gen on ROCm; SDXL + SD 1.5 + Flux. Translates OpenAI `/v1/images/generations`. |
+v0.2 replaced that runtime with **Lemonade** (ADR-0008, supersedes
+the invalidated ADR-0006 total-replacement plan). The runtime
+artefact is now:
 
-All six entries carry pinned `sha256` digests today (no remaining
-`null`/placeholder values); the `release.yml` mirror step can publish
-straight from `manifest.json` without a patch pass.
+- The Lemonade embeddable tarball (`lemonade-embeddable-<ver>-ubuntu-x64.tar.gz`)
+  extracted to `/opt/lemonade/`, supervised under
+  `hal0-lemonade.service`.
+- The FastFlowLM `.deb` (`fastflowlm_<ver>_ubuntu24.04_amd64.deb`)
+  on AMD XDNA2 NPU hosts.
+- `lemond` (the Lemonade daemon) talks to backends (llama.cpp Vulkan,
+  ROCm where supported, FLM on NPU, whisper, kokoro) using upstream
+  Lemonade's own packaging — hal0 no longer maintains per-modality
+  container images on the install path.
 
-`available_backends()` only advertises `npu` when the FLM image is
-locally present (`docker image inspect` returns 0). Hosts without
-ghcr credentials therefore see GPU/CPU only rather than spiralling
-into a `docker pull → unauthorized → systemd restart` loop on every
-NPU selection. See
-[models-slots-impl-plan.md → FLM provider live](./models-slots-impl-plan.md#flm-provider-live-npu-srchal0providersflmpy).
+The in-tree `manifest.json` continues to carry the v0.1.x
+`toolbox_images` pin block. That file is retained for two reasons:
+
+1. **Out-of-tree consumers.** Anyone scripting against the older
+   manifest shape continues to read sensible pins.
+2. **Historical reference.** When debugging a v0.1.x install the pins
+   are still the source of truth for which image was current at the
+   v0.1.x cycle's last release.
+
+It is **not** the runtime artefact pin for v0.2+ installs. The
+installer's Lemonade + FLM constants (in `installer/install.sh`) are
+the live truth; the release manifest mirrors them via the new
+`lemonade` + `flm` blocks above.
 
 ## Related
 
 - `PLAN.md` §9 — Update mechanism spec
 - `PLAN.md` §17 risk #2 — cosign edge cases
 - `src/hal0/updater/updater.py` — implementation
-- `src/hal0/api/routes/updater.py` — route layer (Team C)
-- `manifest.json` — toolbox image pin file (Team A)
+- `src/hal0/api/routes/updater.py` — route layer
+- `installer/install.sh` — `LEMONADE_VERSION` / `LEMONADE_URL` /
+  `LEMONADE_SHA256` + `FLM_DEB_VERSION` / `FLM_DEB_URL` /
+  `FLM_DEB_SHA256` constants (the live install-time pins this
+  manifest mirrors)
+- `manifest.json` — in-tree historical toolbox image pin file
+- ADR-0006 — original total-replacement Lemonade plan
+  (**invalidated** — see `hal0_lemonade_adr_0006_invalidated`)
+- ADR-0008 — accepted Lemonade adoption (the decision that landed)
+- `v0.3-state.md` — canonical v0.3 stream + status snapshot

--- a/docs/internal/v0.3-state.md
+++ b/docs/internal/v0.3-state.md
@@ -1,0 +1,337 @@
+# hal0 v0.3 — canonical state snapshot
+
+**Audience:** writers refreshing other docs (README, ARCHITECTURE,
+PLAN, dashboard/operate/agents/mcp/memory docs, hal0-web promo), and
+any agent / future session reasoning about "what is true on `main`
+right now."
+
+**Snapshot taken:** 2026-05-27 against
+`Hal0ai/hal0 main @ 81cc9cf` (with a fast-forward to `a02abb4` during
+the docs PR, which only touches README/PLAN/UI). The post-alpha.1
+window is mid-flight; treat anything below as "as of HEAD on that
+date" and re-validate before assuming it still holds.
+
+This file exists because there is currently no single source of truth
+for v0.3 stream status. The PLAN.md §1 stream list says *what should
+ship*; auto-memory says *what shipped yesterday*; the GitHub issue
+tracker says *what's open*. This doc collapses all three into one
+place so writers don't have to triangulate per word.
+
+> **Don't drift this file.** When state changes materially (a stream
+> finishes, an open issue lands, a follow-up PR merges), update this
+> doc in the same PR. It's cheaper than every other doc going stale.
+
+---
+
+## 1. Repo state
+
+| Surface | Value |
+|---|---|
+| Default branch | `main` |
+| HEAD at snapshot | `81cc9cf` (`feat(dash): mirror snapshot/memmap/throughput sidebar onto /slots (#357)`) |
+| Branch the doc PR forks from | `81cc9cf`; fast-forwarded over `a02abb4` (PLAN/README/UI tweaks) during the doc PR |
+| Latest release | `v0.3.0-alpha.1`, tagged 2026-05-24, marked **Latest** on GitHub |
+| Source-of-truth version | `pyproject.toml::version` (currently `0.3.0-alpha.1`). `hal0.__version__` reads via `importlib.metadata`; do not edit `src/hal0/__init__.py` to bump. |
+| Commits on `main` since `v0.3.0-alpha.1` | 80+ (≈63 by `git rev-list` count at audit time, growing as the doc-refresh PRs land) |
+| Next planned tag | `v0.3.0-alpha.2` (no firm date — gated on the five-stream close-out below) |
+
+### 1.1 What's actually inside `v0.3.0-alpha.1`
+
+The alpha.1 tag was deliberately small. Two things only:
+
+- **v3 React dashboard scaffold** — PR #235. Replaces the v2
+  React surface introduced in v0.2.1 with a Tailwind v4 + React Router
+  rework. Most pages still ship with `HAL0_DATA.*` mock fallbacks at
+  alpha.1 — wiring them to live `/api/*` is stream 2 (below).
+- **Auth + Caddy removal** — PRs #254, #255, #256, #266, #267,
+  per ADR-0012 (supersedes ADR-0001). ~6,000 lines deleted across
+  backend / frontend / tests / installer / packaging. `hal0-api`
+  now binds `0.0.0.0:8080` open; auth is the operator's reverse
+  proxy. See ADR-0012 for the full deletion inventory.
+
+Everything else in the v0.3 stream list below has shipped on `main`
+*after* alpha.1 and is queued for `v0.3.0-alpha.2` (or later) — it is
+**not** in any installable release as of this snapshot.
+
+---
+
+## 2. Per-stream status
+
+The v0.3 milestone has five streams (PLAN.md §1, GitHub issues
+#237–#247 as the tracker set). Sub-status legend:
+
+- **Shipped on `main`** — landed, post-alpha.1, will be in alpha.2.
+- **In flight** — PR open or branch active.
+- **Deferred** — explicitly punted to v0.4 / later.
+
+### Stream 1 — Hermes bootstrap (#240, #243, #246)
+
+**Status:** Substantially done. The bundled Hermes-Agent now
+bootstraps end-to-end against a hal0 host (Lemonade-backed primary,
+hal0-admin + hal0-memory MCP servers, agent identity card per
+ADR-0011).
+
+**Shipped on `main`:**
+- PR #278 — bootstrap state machine skeleton
+- PR #279 — slot resolver phase
+- PR #284 — MCP probe phase
+- PR #286 — `context_link` (memory MCP namespace handshake)
+- PR #289 — chat smoke phase
+- PR #291 — wrapper smoke (`hal0-hermes --hal0-ready`)
+- PR #292 — `hal0 agent doctor hermes` repair flow
+- PR #296 — identity-card publish phase
+- PR #298 — `hal0 agent uninstall hermes` teardown
+- PR #316 — regression repair: fixed four silent fallbacks vs.
+  Lemonade-embed + FastMCP transport (slot resolver, MCP probe,
+  context_link, chat smoke). Smoke score moved from 2/6 → 5/6.
+  See `hal0_hermes_bootstrap_v0.3_regressions` auto-memory.
+- PR #348 / #349 / #354 — uninstall venv + context_link teardown
+- PR #350 / #355 — uninstall: surface memory teardown failures
+
+**In flight / blockers (must close before "stream done"):**
+- Issue **#317** — `/api/memory/add` forces `dataset="shared"`
+  regardless of incoming `private:<agent_id>`. Per-agent private
+  memory is a no-op end-to-end. Blocks Hermes-Agent's actual
+  "remember this for me only" path. See
+  `hal0_memory_dataset_namespace_bug` auto-memory.
+- **MCPAuthMiddleware → MCPIdentityMiddleware rename** (no issue
+  filed yet — should be opened). The middleware in
+  `src/hal0/api/mcp_mount.py` still resolves `client_id` from the
+  `Authorization: Bearer` header. ADR-0012 + ADR-0011 both
+  require swapping this to read `X-hal0-Agent` instead. Agent
+  side already sends the header (`HAL0_AGENT_ID` env →
+  `X-hal0-Agent: <id>` request header — see
+  `src/hal0/agents/hermes_provision.py:786,1269`). Server side
+  has not been swapped.
+- Issue **#262** — open; tracked under stream 1.
+
+### Stream 2 — Dashboard v3 wired (#239)
+
+**Status:** ~70%. The v3 React scaffold from PR #235 is in place;
+most page-level data is now coming from live `/api/*` rather than
+`HAL0_DATA.*` mocks, but the migration isn't complete.
+
+**Shipped on `main` (post-alpha.1):** PRs #270, #271, #297, #299,
+#300, #304, #306, #308, #309, #313, #314, #315, #319, #321, #328,
+#329, #330, #331, #332, #343, #344, #351, #353, #356, #357.
+
+Highlights:
+- PR #357 — sidebar snapshot/memmap/throughput mirrored onto
+  `/slots` (merged as `81cc9cf`, the snapshot HEAD).
+- PR #356 — chat moves to `/chat`; `/dashboard` becomes a system
+  overview.
+- PRs #321 / #328 / #329 / #330 / #332 — Epic #322 footer + bell +
+  approval inbox (the UX ADR-0017 documents).
+- PRs #344 / #353 — model-type derivation + Load-now consistency
+  with slots.
+
+**In flight (mock fallbacks still on `main`):**
+- The **#213–#340 named issue set** tracks the remaining
+  `HAL0_DATA.*` mock fallbacks on individual v3 pages. Each issue
+  names a specific page or panel still reading seed data instead
+  of `/api/*`. Pull `gh issue list --search "HAL0_DATA in:title"`
+  for the current cut.
+- Issue #345 — slot-modals dropdown was still seeded from
+  `HAL0_DATA.*` at audit time; partially addressed via the
+  slot-modals fix on 2026-05-27.
+
+### Stream 3 — Lemonade polish (#241)
+
+**Status:** Substantially done. The v0.2 Lemonade migration shipped
+in v0.2.0-alpha.3 (per `hal0_v0.2.0-alpha.3_launch` auto-memory).
+v0.3's stream-3 work has been the operational polish on top of that
+baseline.
+
+**Shipped on `main`:** PRs #248, #274, #276, #277, #280, #281, #282,
+#283, #307, #320, #341. Mix of dispatcher polish, slot model-load
+hardening, and toolbox/embed surface fixes.
+
+**Deferred (intentionally; not blockers for alpha.2):**
+- **llama-vulkan KV-cache metric.** The bundled
+  `/opt/llama-vulkan/llama-server` doesn't emit
+  `llamacpp:kv_cache_usage_ratio`. Dashboard KV% stays `—` until
+  llama-server is upgraded or we compute it locally. PR #124
+  pinned the toolbox bump but full rollout is parked behind the
+  Lemonade-embed migration. See
+  `hal0_llama_vulkan_no_kv_cache_metric` auto-memory.
+- **whisper RUNPATH workaround.** Lemonade ≤ 10.6.0 ships
+  `whispercpp/vulkan` with `RUNPATH=/home/runner` (CI builder
+  leftover). The workaround `/usr/local/sbin/hal0-patchelf-whisper`
+  re-applied via an `ExecStartPre` drop-in on
+  `hal0-lemonade.service` is in place; the upstream fix is not.
+  See `hal0_lemonade_whisper_runpath_bug` auto-memory.
+- **Lemonade unload GPU-cleanup hang.** Lemonade 10.6.0 deadlocks
+  in `ProcessManager` GPU cleanup after model unload; port stays
+  open, `/api/v1/health` times out. Recovery is
+  `systemctl restart hal0-lemonade`. Distinct from the nuclear
+  evict-all behaviour. See `hal0_lemonade_unload_gpu_cleanup_hang`
+  auto-memory.
+
+### Stream 4 — Admin / auth simplification (#237, #244)
+
+**Status:** Shipped in v0.3.0-alpha.1 (PRs #254 / #255 / #256 / #266
+/ #267) per ADR-0012, supersedes ADR-0001. ~6,000 LOC removed across
+backend / frontend / tests / installer / packaging. `hal0-caddy`
+gone; `MCPAuthMiddleware` kept as a thin identity-stashing shim.
+
+**Trailing (not blocking the stream, but loose ends):**
+- **MCPAuthMiddleware → MCPIdentityMiddleware rename** + server-side
+  `X-hal0-Agent` header read **NOT DONE** as of HEAD. The
+  middleware still resolves `client_id` from the bearer header (see
+  `src/hal0/api/mcp_mount.py:83-105`). Cross-stream blocker for
+  Hermes private-namespace memory (see also stream 1 + #317).
+
+### Stream 5 — Advanced memory + MCP client (#245, #247)
+
+**Status:** Partly shipped. The MCP-client side of Hermes-Agent is
+live (per ADR-0013); advanced memory features land progressively.
+
+**Shipped on `main`:** PRs #287, #290, #293, #294, #295, #297, #300,
+#303. Cognee dataset wiring, memory MCP probe gates, agent
+allow-list enforcement.
+
+**Blocker:**
+- Issue **#317** — same blocker as stream 1: forced
+  `dataset="shared"` makes the per-agent private-memory contract a
+  no-op. Until this lands, the "advanced memory" pitch in PLAN.md
+  §1 is half-true.
+
+---
+
+## 3. Terminology canon
+
+Use these spellings and capitalisations everywhere. The auto-memory
+calls out drift in several places; this section is the place to
+settle the spelling once.
+
+| Term | Canonical form | Notes |
+|---|---|---|
+| Agent identity header | `X-hal0-Agent` | The HTTP request header. Mixed-case, hyphenated. Sent by agents (`HAL0_AGENT_ID` env → header). |
+| Agent identity env var | `HAL0_AGENT_ID` | All-caps SHOUTING. Set in the agent's systemd env file or shell. |
+| Identity middleware | `MCPAuthMiddleware` (today) / `MCPIdentityMiddleware` (target) | Rename pending. Both names refer to `src/hal0/api/mcp_mount.py::MCPAuthMiddleware`. When writing docs that need to be true at HEAD, name the current class. When naming the design, name the target. |
+| Lemonade (umbrella) | `Lemonade` | Capital L. Refers to the upstream project + the runtime as a whole. |
+| Lemonade daemon | `lemond` | Lowercase. The systemd-managed process inside `hal0-lemonade.service`. |
+| Lemonade systemd unit | `hal0-lemonade.service` | hal0-prefixed. Always include the `.service` suffix in docs to disambiguate from the daemon name. |
+| Admin MCP server (hal0's) | `hal0-admin` | Mounted at `/mcp/admin`. Built by `hal0.mcp.admin.build_server`. |
+| Memory MCP server (hal0's) | `hal0-memory` | Mounted at `/mcp/memory`. Built by `hal0.mcp.memory.build_server`. Cognee under the hood. |
+| Hermes-Agent (the upstream agent) | `Hermes-Agent` | The bundled third-party agent app. Capital H, hyphenated. |
+| Hermes wrapper (hal0's shim) | `hal0-hermes` | Lowercase. The POSIX shell wrapper at `/usr/local/bin/hal0-hermes` (or `~/.local/bin/`). |
+| Hermes upstream binary | `hermes` | Lowercase. What `hal0-hermes` `exec`s after sourcing the hal0 env file. |
+| Dashboard | `v3 React dashboard` | The Tailwind v4 + React Router rework introduced in PR #235 / v0.3.0-alpha.1. Replaces v2 (which itself replaced the original Vue dashboard, archived in `vue-dashboard-archive.md`). |
+| Lemonade default port | `13305` | This is the Lemonade-server-on-hal0 port (`/var/lib/hal0/lemonade/config.json::port`). NOT 9000 — that's Lemonade's upstream default which we override. |
+| Lemonade upstream default | `9000` | Reference only. Don't bake `:9000` into hal0 docs. |
+| Model registry path | `/var/lib/hal0/registry/registry.toml` | The hal0-owned registry. Lemonade has its own `server_models.json`; the two are merged via the unified-catalog work (see `hal0_model_catalog_unified_2026-05-26`). |
+| Model store root | `/mnt/ai-models` | Single root on the LXC (rw ZFS). Not `/mnt/dock-models` (that's the desktop VM overflow). |
+
+---
+
+## 4. Stale memory / outdated assumptions
+
+These are things that *used to be true* (and so live in older docs,
+auto-memory, or contributor heads) but are no longer. Flag and
+correct when you encounter them.
+
+- **"hal0 uses bearer tokens"** — false post-ADR-0012. There is no
+  Bearer auth on the FastAPI surface. Anyone reachable on
+  `:8080` calls everything. The reverse proxy is the operator's
+  gate. The `Authorization: Bearer` header is *still* parsed by
+  `MCPAuthMiddleware` for backwards compatibility (the value is
+  treated as a client identifier, not authenticated) — but the
+  `X-hal0-Agent` header should be preferred and the bearer path
+  will be removed when the rename ships.
+- **"hal0 ships toolbox containers"** — false post-v0.2. The v0.1.x
+  per-modality toolbox container images
+  (`hal0-toolbox-{vulkan,rocm,flm,moonshine,kokoro,comfyui}:v1`)
+  are no longer the runtime. Lemonade is. `manifest.json` still
+  carries the toolbox image pins for historical reference and for
+  any out-of-tree consumers (and the manifest's `_legacy_toolboxes`
+  block is older still — that's the pre-2026-05-15 key shape).
+  See `release-manifest.md` for the v0.2/v0.3 schema description.
+- **"`hal0-caddy.service` is the front door"** — false post-ADR-0012.
+  `hal0-caddy.service` is gone from packaging. `installer/uninstall.sh`
+  still tears it down so v0.1.x → v0.3 upgrades clean it up.
+- **"First-run sets a password"** — false post-ADR-0012. There is
+  no first-run lockfile, no OTP, no password prompt. Fresh install
+  is immediately usable by anyone on the network. The first-run
+  wizard now just walks the bundle picker.
+- **"`hal0 update` is wired"** — false at v0.3.0-alpha.1. The
+  release manifest at `releases.hal0.dev/stable.json` is a
+  placeholder (`_placeholder: true`, version `0.0.0`,
+  all-zeros `digest_sha256`). `hal0 update --check` succeeds and
+  reports "no update available"; `apply()` would fail at the
+  cosign step. See `release-manifest.md`.
+- **"Hermes private memory is wired end-to-end"** — false. Server
+  forces `dataset="shared"` regardless of incoming header
+  (issue #317). The agent side sends the right thing; the server
+  silently downgrades it.
+- **"`HAL0_AGENT_ID` works"** — half true. The env var is
+  consumed by `hal0-hermes` and emitted as `X-hal0-Agent`. The
+  server reads it back as `client_id`, but routes it through
+  the legacy bearer path (`bearer or "anonymous"`) — see
+  `MCPAuthMiddleware.dispatch` in `src/hal0/api/mcp_mount.py`.
+  Once the rename + header swap land, this becomes fully true.
+
+---
+
+## 5. Open blockers tracked in GitHub
+
+The minimum set to clear before `v0.3.0-alpha.2` can be cut. None of
+these have a hard date; ordering is rough priority.
+
+| Issue / Item | Stream | Why it blocks |
+|---|---|---|
+| #317 (dataset namespace bug) | 1 + 5 | Per-agent private memory is a no-op. Both the Hermes bootstrap pitch and the "advanced memory" pitch are half-true until this lands. |
+| MCPAuthMiddleware rename + server-side `X-hal0-Agent` read | 1 + 4 | Documented in ADR-0012 + ADR-0011 as a trailing item. No GH issue filed yet — should be opened during this doc PR or the next code PR. |
+| #262 | 1 | Open Hermes-bootstrap item. |
+| #224 (MCP-server install-from-URL UI placeholder) | (cross — touches ADR-0015) | The dashboard `/agents/mcp` page's install-from-URL UI is a placeholder. ADR-0015 cites this as the gap the host-platform decision exists to close. |
+| #213–#340 (dashboard mock-fallback set) | 2 | Long-tail set of individual page/panel issues, each naming a `HAL0_DATA.*` fallback. Not all are blockers for alpha.2, but the unmigrated panels are visible to anyone using the v3 dashboard. Pull the current cut with `gh issue list --search "HAL0_DATA in:title"`. |
+
+Not blockers but worth surfacing:
+- Issues #345 (slot modals dropdown) — partially addressed
+  2026-05-27.
+- Follow-up items from epic #322 (footer/journal): #333–#340.
+  Footer + bell shipped; sub-items are polish.
+
+---
+
+## 6. ADR index
+
+| ADR | Status | Title / scope | Notes |
+|---|---|---|---|
+| 0001 | **Superseded** by 0012 | Collapse edge auth into FastAPI | Original v0.2 auth design. Deleted in v0.3.0-alpha.1. |
+| 0002 | Accepted | Capabilities overlay | embed/voice/img child rollup over slots. |
+| 0003 | Accepted | Slot `capabilities` field | Slot-side counterpart to 0002. |
+| 0004 | Draft (in flight) | Agents (Phase 8 v0.2) | Bundled-agent + admin MCP + approval queue. Two-tier approval pattern from §5 is the basis for ADR-0017. |
+| 0005 | Accepted | Memory engine = Cognee | hal0-memory MCP's backing store. |
+| 0006 | **Invalidated** | Migrate inference to Lemonade (total replacement) | Total-replacement plan invalidated by spike findings; superseded by 0008's narrower scope. See `hal0_lemonade_adr_0006_invalidated`. |
+| 0007 | Accepted | Nuclear evict-all mitigation | Lemonade-specific safety net. |
+| 0008 | Accepted | Lemonade adoption | The actual Lemonade decision that landed (post-spike). |
+| 0009 | Accepted | FLM trio NPU packing | FastFlowLM bundling pattern. |
+| 0010 | Accepted | Bundle picker — no default stack | First-run UX rule. |
+| 0011 | Accepted (2026-05-23) | Agent identity cards (Phase 8, v0.3) | `agents` dataset in hal0-memory; immutable cards; ADR-0017 inherits the gating contract. |
+| 0012 | Accepted (2026-05-23) | Remove auth and Caddy entirely | Shipped in v0.3.0-alpha.1. Supersedes 0001. |
+| 0013 | Accepted (2026-05-23) | MCP-client allow-list for bundled agents | Per-agent `/etc/hal0/agents/<name>.toml`; default-deny on server + tool axes. |
+| 0014 | Accepted | Cognee graph extraction model gate | Backing detail for ADR-0005. |
+| 0015 | **Draft (alpha.2 target)** | MCP as host platform | This PR. Generalises 0013's pattern to third-party MCP *servers*. |
+| 0016 | **Deferred** by project lead | React v3 dashboard | Not in this PR. |
+| 0017 | **Accepted** | Bell + inbox approval UX for destructive MCP calls | This PR. Documents the pattern Epic #322 shipped. |
+
+---
+
+## 7. Cross-references
+
+- PLAN.md §1 — five-stream definition (PR-1 may have updated it
+  during this doc cycle; re-read after pull).
+- `release-manifest.md` — the release manifest schema, updated in
+  this PR to reflect Lemonade reality.
+- `migration.md` — haloai → hal0 cutover.
+- `api-errors.md` — hal0 vs OpenAI envelope split. Note the
+  `auth.required` example is now structurally moot post-ADR-0012;
+  the code path is unreachable from the API surface but the
+  envelope shape contract still holds for any future re-introduced
+  auth and for `/mcp/*` future use.
+- `hermes-bootstrap-plan-2026-05-23.md` — the design doc for
+  stream 1. Historical (2026-05-22-or-later but pre-PR-#316);
+  read alongside the PR set above for the current state.
+- ADR-0011 / ADR-0012 / ADR-0013 — the v0.3 ADRs already accepted.
+- ADR-0015 / ADR-0017 — the v0.3 ADRs added in this PR.


### PR DESCRIPTION
## Summary

Part of the v0.3 docs quad (created 2026-05-28 02:00 UTC, PR opened today).

- Pins v0.3 state snapshot in internal docs
- Adds ADR-0015 and ADR-0017
- Refreshes the release-manifest reference doc

## Notes

- Branch is 13 commits behind main at PR-open time — may need rebase before CI passes.
- Sibling PRs: docs/v0.3-agents-mcp-memory, docs/v0.3-lemonade-dashboard, docs/v0.3-root-refresh.