### PR TITLE
docs(operate,dashboard,installer): Lemonade ref + dashboard v3 walkthrough + installer auth gut

### DIFF
--- a/docs/dashboard/v3.md
+++ b/docs/dashboard/v3.md
@@ -1,0 +1,224 @@
+---
+title: Dashboard v3 — tour
+description: Page-by-page walkthrough of the v3 React dashboard shipped in v0.3.0-alpha.1 — what each route shows, what's wired live, and which panels still fall back to mock data.
+sidebar:
+  order: 1
+---
+
+> This file is the **repo-native canonical** copy. The Starlight-rendered
+> version at <https://hal0.dev/docs/dashboard/v3/> is mirrored from
+> here by the docs-sync workflow. Edit this file; do not hand-edit the
+> `.mdx` mirror in `Hal0ai/hal0-web`.
+
+The **v3 dashboard** is the React app that ships with hal0 v0.3 as
+the operator console. It replaces the v0.1/v0.2 single-page layout
+with a routed multi-page shell: sidebar, main view, footer journal
+pane. This page is the operator's tour — what each route shows, which
+panels read live data, and which still fall back to seed mocks while
+the underlying API endpoints land.
+
+The dashboard is served by `hal0-api` itself; open
+`http://<your-hal0-host>:8080/` and you're there. Source lives in
+`ui/src/dash/`. The shell shipped in **v0.3.0-alpha.1** per PR #235;
+everything below tracks panel-by-panel wiring landed since.
+
+## The shell
+
+Three regions, fixed across every route:
+
+- **Sidebar** (left). Top-level nav: `/dashboard`, `/chat`, `/slots`,
+  `/models`, `/mcp`, `/agents`, `/memory`, `/settings`. Live counts
+  next to each item (loaded slots, registered models, connected MCP
+  servers, peer count) updated via the same SSE stream the rest of
+  the dashboard subscribes to. Counts landed in PR #306.
+- **Main** (centre). The active route's content.
+- **Footer** (bottom). Three chips on the left — host, version,
+  uptime — plus the **journal pane** on the right (Epic #322; see
+  [The footer journal](#the-footer-journal)).
+
+The shell never reloads on navigation; routes mount inside the same
+React tree.
+
+## The Mock badge
+
+Panels that haven't been fully wired yet render with a small **Mock**
+chip in their header and read from a hardcoded `HAL0_DATA.*` seed.
+This is intentional and load-bearing — the v3 shell shipped before
+every backend route, and the seed lets the layout, sizing, and
+interactions be reviewed end-to-end before the data is real.
+
+Panels lose the Mock chip as their backing endpoint lands. The set of
+still-mock panels is tracked under the `dashboard-v3` label in the
+[hal0 issue tracker](https://github.com/Hal0ai/hal0/labels/dashboard-v3).
+Don't enumerate them by hand — the label is authoritative.
+
+## `/dashboard` — System overview
+
+The landing page since PR #356 (which moved chat off the root). System
+overview at a glance:
+
+- Unified-memory bar (LXC slice + Proxmox host pressure if
+  `/etc/hal0/proxmox.json` is present, see `docs/operate/config/`).
+- Loaded-slot grid: per-slot state, model, port, KV% (Vulkan slots
+  derive KV% locally — see [Lemonade caveat #1](/docs/operate/lemonade/#1-llama-vulkan-does-not-emit-a-kv-cache-metric)).
+- Throughput sparkline. Live since PR #308.
+- Memory map (which model is in which device). Live since PR #308.
+- Bundle banner with the real installed bundle name (PR #331).
+
+Used to be the chat surface; chat moved to `/chat` so the landing page
+is genuinely operational without a model loaded.
+
+## `/chat` — Real chat surface
+
+The real chat UI, wired against the primary slot (PR #309). Streams
+responses through the same `/v1/chat/completions` path OpenAI clients
+use. Notable features:
+
+- **Reasoning collapsible** (PR #315) — for models that emit a
+  `<thinking>`-style reasoning block, the dashboard renders it
+  collapsed by default with a one-click expand.
+- **Slot indicator dots** (PR #314) — small per-message dot showing
+  which slot served the response. Useful when the dispatcher
+  swap-fires mid-conversation (e.g. eviction; see
+  [Lemonade slots ↔ models](/docs/operate/lemonade/#slots--lemonade-models)).
+- Slot swap dropdown — reads `/api/models` live (PR #351), no more
+  stale seed.
+
+Composer features landed in the dashboard-v2 wave (#200) and were
+ported into the v3 Composer; see the issue tracker for the per-feature
+list.
+
+## `/slots` — Slot management
+
+Per-slot cards: state chip, model, port, backend, load/unload buttons,
+swap dropdown. The card-level UX got a 7-fix sweep in PR #344
+(consistent state colors, hover affordances, ARIA wiring, etc.).
+
+PR #357 added a **sidebar mirror** here — the same
+snapshot/memmap/throughput strip from `/dashboard` is rendered as a
+right rail so you can keep an eye on system load while editing slot
+config. The mirror is read-only and shares the SSE subscription with
+the main dashboard view.
+
+Slot creation dispatches through `hal0 slot create --type <X>`, which
+derives the Lemonade device flag from the slot type (PR #282) and
+the Lemonade model name + auto-port pair (PR #281).
+
+## `/models` — Model registry
+
+The local model registry, sourced from `/api/models`. Two things you
+can do here:
+
+- **Scan** the filesystem for new GGUFs / safetensors. Landed in PR
+  #313.
+- **Add by path** for a model that lives outside the configured
+  store. Same PR.
+
+The registry now has a single `[models].store` setting (PR #319)
+instead of the v0.2-era split between `pull_root` and
+`extra_models_dir`. The store is the one place pulls land and
+Lemonade scans.
+
+The `useModels` hook derives `model.type` (chat / embed / stt / tts /
+img) at the hook layer (PR #353) so Load-now and slot config both see
+the same type — fixes the class of bug where a slot's Load button
+would offer a model the slot couldn't actually serve.
+
+## `/mcp` — MCP host platform
+
+The MCP page is a real backend (PR #304) — connected MCP servers,
+their advertised tools, prompts, and resources. The v0.3 dashboard
+treats MCP hosting as a first-class surface alongside slots and
+models; aftermarket MCP servers can be installed and supervised here
+the same way capability slots are.
+
+**Per-agent MCP clients** landed in PR #300: each agent has its own
+client view of the MCP host, so an agent's tool list is the
+intersection of installed servers and that agent's allowlist.
+
+Full MCP documentation (server install, tool ACLs, the catalog) lives
+under `docs/mcp/` — this page covers only the dashboard surface.
+
+## `/agents` — Agent inventory
+
+The agent registry. The **Peers tab** (PR #299) lists known peer
+agents — other hal0 hosts, remote LLM endpoints, etc — and their
+reachability.
+
+Full agents documentation (identity, approvals, the peer protocol,
+the agent CLI) lives under `docs/agents/`. This page is a thin
+operator surface; consult `docs/agents/` for the model.
+
+## `/memory` — Memory store
+
+The memory tab includes a **graph panel** (PR #297) — visual layout
+of the federated memory graph (Hermes mem0, HALOnotes, Claude
+auto-memory, RAG sources, anything else the memory router exposes).
+
+Throughput chart on the same page is live (PR #308): adds-per-minute,
+search-rate, current write queue depth.
+
+Full memory documentation lives under `docs/memory/`.
+
+## `/settings` — Settings
+
+Six tabs across the top:
+
+- **Memory** (PR #232) — federated memory router config: which
+  sources are mounted, dataset namespaces, the read-federation
+  toggle.
+- **Updates** (PRs #321 / #329) — auto-update channel selection
+  (`stable` / `prerelease` / `dev`), last-check timestamp, manual
+  `hal0 update` trigger. The install banner now shows the real
+  bundle name (PR #331).
+- **Secrets** — secret store CRUD.
+- **Proxmox** — write the read-only PVE token + endpoint into
+  `/etc/hal0/proxmox.json` for the host-pressure segment of the
+  memory bar.
+- **Hardware probe** — re-run `hal0 probe` and review the resulting
+  `/etc/hal0/hardware.json`. (The dedicated `/hardware` route was
+  retired in PR #356; the panel moved here.)
+- **About** — version, license, build SHA.
+
+**There is no Auth tab.** Auth was removed in v0.3.0-alpha.1 per
+ADR-0012; hal0 binds `0.0.0.0:8080` open and treats edge auth as the
+operator's problem. See `docs/operate/auth/` for the recipe.
+
+## The footer journal
+
+The footer's right half is a **journal pane** (Epic #322, shipped via
+PRs #321 / #328 / #329 / #330 / #332). It tails an append-only event
+stream of operationally-meaningful events: slot state transitions,
+model pulls + scans, MCP server connect/disconnect, update checks,
+bundle changes, config writes.
+
+- Backed by `/api/journal` for the initial fetch and
+  `/api/journal/stream` for live updates (PR #330).
+- Click to expand a row for full event payload + timestamp + source
+  unit.
+- Persistent across page navigations — the pane lives in the shell,
+  not the route.
+- Filterable by source (slot / model / mcp / config / update).
+
+It is not a replacement for `journalctl` (see
+[`docs/operate/logs/`](/docs/operate/logs/)) — it's higher-level,
+event-shaped, focused on "what changed" rather than "what's the
+process saying."
+
+## Routes retired in v3
+
+- `/hardware` — folded into Settings → Hardware probe (PR #356).
+- Single-page `/` chat — moved to `/chat` (PR #356).
+- Auth tab in Settings — removed with ADR-0012 (v0.3.0-alpha.1).
+
+## See also
+
+- [Lemonade runtime](/docs/operate/lemonade/) — the daemon every
+  inference panel scrapes.
+- [Configuration](/docs/operate/config/) — the TOML files behind the
+  Settings tabs.
+- [Logs](/docs/operate/logs/) — `journalctl` and the SSE log tail
+  (the journal pane is the higher-level cousin).
+- The
+  [`dashboard-v3` label](https://github.com/Hal0ai/hal0/labels/dashboard-v3)
+  on the issue tracker for the open mock-fallback work.

--- a/docs/operate/lemonade.md
+++ b/docs/operate/lemonade.md
@@ -1,0 +1,233 @@
+---
+title: Lemonade runtime
+description: The AMD-blessed Lemonade Server is hal0's unified inference runtime — one daemon, all modalities, supervised by hal0-lemonade.service on 127.0.0.1:13305.
+sidebar:
+  order: 6
+---
+
+> This file is the **repo-native canonical** copy. The Starlight-rendered
+> version at <https://hal0.dev/docs/operate/lemonade/> is mirrored from
+> here by the docs-sync workflow. Edit this file; do not hand-edit the
+> `.mdx` mirror in `Hal0ai/hal0-web`.
+
+As of **v0.2** (the Lemonade migration, ADR-0008), hal0 ships a single
+runtime daemon: **AMD's Lemonade Server**. One process supervises every
+modality hal0 exposes — chat, embeddings, rerank, STT, TTS, image
+generation — across every backend the host hardware supports (Vulkan
+llama.cpp, ROCm, CUDA, FastFlowLM on XDNA NPUs, sd.cpp, whisper.cpp).
+The six per-modality toolbox container images from v0.1 are gone.
+
+This page is the operator's reference: what Lemonade is, how hal0 wires
+it up, where its state lives, how slots map onto its model registry,
+and the known caveats you'll hit in production.
+
+## What Lemonade is
+
+[Lemonade Server](https://github.com/lemonade-sdk/lemonade) is AMD's
+vendor-blessed local-inference daemon, purpose-built for Strix Halo
+(Ryzen AI Max+ 395, Radeon 8060S iGPU, XDNA NPU, unified memory). It
+exposes an OpenAI-compatible HTTP surface (`/v1/chat/completions`,
+`/v1/embeddings`, `/v1/audio/transcriptions`, `/v1/images/generations`,
+etc.) plus a small control plane (`/v1/load`, `/v1/unload`,
+`/v1/health`, `/v1/stats`, `/v1/models`, `/v1/pull`) for managing the
+in-memory model set.
+
+hal0 uses Lemonade as the only thing that talks to the GPU/NPU. Slots
+are now thin configuration rows that point at a registered Lemonade
+`model_name`; the dispatcher resolves a request to a slot, the slot
+resolves to a `model_name`, and Lemonade does the work.
+
+## Where it lives
+
+| Component                 | Location                                                       |
+|---------------------------|----------------------------------------------------------------|
+| Systemd unit              | `hal0-lemonade.service`                                        |
+| Process name              | `lemond`                                                       |
+| Listen address            | `127.0.0.1:13305` (loopback only)                              |
+| Cache dir                 | `/var/lib/hal0/lemonade/`                                      |
+| Daemon config             | `/var/lib/hal0/lemonade/config.json`                           |
+| Registered models         | `/var/lib/hal0/lemonade/resources/server_models.json`          |
+| User-pulled models        | `/var/lib/hal0/lemonade/user_models.json`                      |
+| HuggingFace cache         | `${HAL0_VAR_DIR}/.cache/huggingface/` (chowned `hal0:hal0`)    |
+| Models on disk            | `/var/lib/hal0/models/` (or `$HAL0_MODELS_DIR` if set)         |
+| Pinned versions           | `manifest.json` at the repo root                               |
+
+Lemonade binds **loopback only**. External access goes through hal0's
+own FastAPI server on `:8080`, which reverse-proxies the un-routed
+`/v1/*` surface to `127.0.0.1:13305` (see below).
+
+## The `/v1/*` proxy
+
+hal0-api at `:8080` serves two `/v1/*` tiers:
+
+1. **Curated, dispatcher-backed routes.** Chat, completions, embeddings,
+   rerank, audio, images, models. These aggregate across every
+   registered slot so OpenAI clients see one unified catalogue. The
+   dispatcher picks the slot that owns the model and forwards to
+   Lemonade with the slot's tuned arguments. Implemented in
+   `src/hal0/api/routes/v1.py`.
+
+2. **Lemonade control plane (catch-all).** Anything *not* matched by
+   the curated routes falls through to a reverse-proxy at
+   `/v1/{path:path}` and is forwarded verbatim to Lemonade. That covers
+   `/v1/health`, `/v1/stats`, `/v1/load`, `/v1/unload`,
+   `/v1/system-info`, `/v1/params`, and anything else Lemonade adds in
+   a future release without hal0 needing a code change. Implemented in
+   `src/hal0/api/routes/lemonade_proxy.py`; mounted last so FastAPI's
+   first-match-wins routing leaves curated handlers intact. Shipped in
+   PR #248 (closes #212), in v0.3.0-alpha.1.
+
+The dispatcher itself also falls through to the Lemonade proxy on
+`NoRouteFound` (PR #277): if a request shape is OpenAI-shaped but no
+slot claims it, hal0 hands it to Lemonade directly rather than 404'ing.
+
+> Lemonade also opens a second HTTP port on `127.0.0.1:9000` for its
+> own embedded OpenAI surface. hal0 does not use it. All hal0 traffic
+> targets `:13305`; `:9000` is incidental and safe to ignore.
+
+## Slots ↔ Lemonade models
+
+A slot is a row in hal0's config (`/etc/hal0/slots/<name>.toml`) that
+binds a slot **name** (e.g. `primary`, `embed`, `stt`) to a registered
+Lemonade `model_name`. Loading the slot is `POST /v1/load` to Lemonade
+with the slot's tuned `args`; unloading is `POST /v1/unload`. The
+slot's lifecycle state machine (OFFLINE → LOADING → READY) is driven
+by polling `/v1/health` and `/v1/stats` for that model_name.
+
+Two registries feed Lemonade's `/v1/models`:
+
+- **`server_models.json`** — generated by `hal0 registry sync` from
+  `/var/lib/hal0/registry/registry.toml` (the canonical hal0 registry,
+  the only place HuggingFace coordinates + SHA256 + curated filenames
+  live). Edit `registry.toml` directly to add or pin a model, then
+  `hal0 registry sync`. Going through the CLI's `register` subcommand
+  loses the HF coordinates by design — use the TOML.
+- **`user_models.json`** — written by `POST /v1/pull` (the dashboard's
+  "add model" flow). Lemonade scans `extra_models_dir` for compatible
+  files; the result is appended here so they survive restart.
+
+Slots created via `hal0 slot create --type <X>` derive the Lemonade
+device flag from the slot type (PR #282). Slot creation also accepts
+the Lemonade-shape model name directly and auto-picks a free port (PR
+#281, with the import fix in PR #320).
+
+## The 8-model cap
+
+Lemonade's `config.json` ships with `max_loaded_models: 8` (set by
+`installer/install.sh:977`, raised from upstream's default of 4 per
+PR #283). When loading a 9th model, Lemonade evicts the
+least-recently-used model **of the same type** (chat-vs-embed-vs-stt
+have separate LRU pools per ADR-0008 §3 — this supersedes the
+nuclear-evict-all behavior described in the obsolete ADR-0007). The
+slot whose model got evicted drifts to **OFFLINE** (not ERROR), and
+the next request that needs it re-loads it on demand. The OFFLINE-on-
+eviction behavior is PR #276.
+
+If you need a larger working set, raise the cap in
+`/var/lib/hal0/lemonade/config.json` and restart `hal0-lemonade`. The
+practical ceiling is unified-memory pressure, not the integer in the
+config.
+
+## Daemon config
+
+`/var/lib/hal0/lemonade/config.json` is the persisted daemon config.
+Lemonade reads it on start; hal0's `/internal/set` writes mutate it
+atomically. Fields hal0 cares about:
+
+| Key                  | What it does                                                                       |
+|----------------------|------------------------------------------------------------------------------------|
+| `port`               | Bind port. Stays `13305` unless you have a conflict.                               |
+| `host`               | Bind address. Stays `127.0.0.1` — external access is hal0-api's job.               |
+| `max_loaded_models`  | LRU cap (see above). Default 8.                                                    |
+| `extra_models_dir`   | Where Lemonade looks for compatible model files. Set to `$HAL0_MODELS_DIR`.        |
+| `llamacpp.args`      | Extra argv for every llama.cpp child. Default `--parallel 1 --threads N` (N = (cores − 2) / 4, min 2). |
+| `llamacpp.backend`   | `vulkan` / `rocm` / `cuda` / `cpu`. The installer probes hardware and writes this. |
+| `flm.args`           | Extra argv for FastFlowLM NPU children. Default `--asr 1 --embed 1`.               |
+
+The `--parallel 1 --threads N` line is **load-bearing**. Lemonade's
+upstream default omits `--threads`, which on a 12-core LXC lets two
+concurrent llama-server children oversubscribe the CPU and starve
+Vulkan dispatch — observable as a ~30-second deadlock the first time
+two slots load at once. Set the `llamacpp.args` line before the first
+multi-slot load.
+
+## Operating it
+
+```sh
+# Daemon status + recent logs
+systemctl status hal0-lemonade
+journalctl -u hal0-lemonade -f
+
+# Health (curated through hal0-api at :8080)
+curl http://127.0.0.1:8080/v1/health
+
+# Currently loaded models + per-model stats
+curl http://127.0.0.1:8080/v1/stats
+
+# Restart (the recovery hammer for most ops issues)
+systemctl restart hal0-lemonade
+
+# Round-trip a chat request against the primary slot
+curl http://127.0.0.1:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "primary", "messages": [{"role": "user", "content": "hi"}]}'
+```
+
+`hal0 doctor` wraps daemon reachability, the FLM `.deb` install state
+(NPU hosts), and HF-cache sanity into one check; run it first when
+something is off.
+
+## Known caveats (v0.3.0-alpha.1)
+
+These are real, in production, deferred to follow-up issues. None of
+them block normal operation — but if you trip one, the symptom is
+recognizable.
+
+### 1. llama-vulkan does not emit a KV-cache metric
+
+The bundled `/opt/llama-vulkan/llama-server` is built without the
+`llamacpp:kv_cache_usage_ratio` Prometheus metric. The scrape silently
+returns nothing for that gauge and the dashboard's KV% chip stays `—`
+on Vulkan slots. PR #124 added a workaround that derives KV% locally
+from `n_prompt_tokens / n_ctx` polled from `/slots`. Fully fixed when
+the toolbox tracks an llama.cpp release that emits the gauge natively;
+in the meantime, the derived value is what shows up on the dashboard.
+
+### 2. Whisper bundle ships a broken `RUNPATH`
+
+Lemonade ≤ 10.6 packages `whispercpp/vulkan` with `RUNPATH=/home/runner`
+(a CI builder leftover). `whisper-server` exits 127 on load, which in
+older Lemonade tripped the nuclear-evict-all path and wiped every other
+slot. hal0 ships `/usr/local/sbin/hal0-patchelf-whisper` and runs it
+via an `ExecStartPre=` drop-in on `hal0-lemonade.service` to re-apply
+`patchelf --set-rpath '$ORIGIN'` on every start. If you swap in a
+hand-built Lemonade tree, the drop-in becomes a no-op as long as the
+binary has a sane `RUNPATH`; no action required.
+
+### 3. Unload can deadlock in GPU cleanup
+
+Lemonade 10.6.0 can deadlock inside `ProcessManager` GPU cleanup after
+a model unload. Symptoms: the port stays open, `/v1/health` returns
+500 / times out, `systemctl show hal0-lemonade` reports `NRestarts=0`
+(the watchdog hasn't tripped because the process is still alive). This
+is distinct from the nuclear-evict-all behavior in (2). Recovery:
+
+```sh
+systemctl restart hal0-lemonade
+```
+
+The slot manager observes the restart, drifts every loaded slot to
+OFFLINE, and re-loads on next request. Tracking issue
+[lemonade-sdk/lemonade#TBD](https://github.com/lemonade-sdk/lemonade).
+
+## See also
+
+- [Dashboard v3 tour](/docs/dashboard/v3/) — visual inspection of every
+  panel that scrapes the Lemonade surface.
+- [Configuration](/docs/operate/config/) — TOML layout for
+  `/etc/hal0/` and the slot files.
+- [Logs](/docs/operate/logs/) — journalctl recipes and the SSE log tail.
+- [Slots](/docs/slots/what-is-a-slot/) — the slot lifecycle state
+  machine and how it talks to Lemonade.
+- ADR-0008 in `docs/internal/adr/` — the canonical decision record for
+  the v0.2 Lemonade migration and the eviction model.

--- a/installer/README.md
+++ b/installer/README.md
@@ -89,100 +89,21 @@ Example:
 HAL0_PORT=9090 sudo bash installer/install.sh
 ```
 
-## Authentication
+## Authentication & TLS
 
-All auth lives in FastAPI. There is no edge-auth layer — the installer
-does not ship a reverse proxy. If you need TLS or edge auth, front
-hal0 with Traefik, nginx, Cloudflare Tunnel, or your own preferred
-upstream (see [TLS](#tls) below).
+As of **v0.3.0-alpha.1** (ADR-0012), authentication is no longer
+hal0's concern. The installer ships no Caddy, no Bearer-token store,
+no first-run OTP, no password claim wizard, no `--no-tls` flag, and
+no `HAL0_AUTH_*` env vars. `hal0-api` binds `0.0.0.0:8080` open; if
+you need a gate, put a reverse proxy (Caddy, Traefik, nginx,
+Cloudflare Tunnel — whatever you already run) in front of it and
+own auth + TLS at the edge. A recipe lives at
+[`docs/operate/auth.mdx`](../docs/operate/auth.mdx).
 
-As of v0.1.0-alpha (security review §36, 2026-05-21), a fresh install **starts
-locked**. The API rejects anonymous requests on every admin route and
-on `/v1/*` with `401 auth.required`. Only the first-run wizard claim
-paths (`/api/install/*`, `POST /api/auth/password`) stay reachable —
-and only while the installer's one-time-OTP lockfile
-(`/var/lib/hal0/.first-run.lock`, mode 0600) is present on disk.
-
-The installer prints the OTP in the post-install summary; the wizard's
-"Set a password" step asks for it before minting the owner password.
-Once the password is set, the wizard's success path deletes the
-lockfile and the claim window closes — from then on every request
-needs a session cookie (browser) or Bearer token (programmatic
-client).
-
-To opt back into the trusted-LAN open posture (single-user dev
-boxes only), uncomment `HAL0_AUTH_DISABLED=1` in `/etc/hal0/api.env`
-and restart `hal0-api`. The dashboard and `/v1/*` will be reachable
-without credentials. **Do not use this on a multi-tenant network.**
-
-Once a password is set:
-
-- Browsers authenticate via `POST /api/auth/login`, which issues a signed
-  `hal0_session` cookie (HttpOnly, SameSite=Lax, Secure-when-TLS).
-  `POST /api/auth/logout` clears it.
-- Programmatic clients keep using Bearer tokens (`Authorization: Bearer hal0_...`)
-  unchanged — the FastAPI middleware accepts both the session cookie and
-  Bearer tokens against the same `require_token` / `require_writer` deps.
-
-Mint a Bearer token via the Settings UI (Authentication panel → Create token)
-or directly:
-
-```sh
-curl -H 'Authorization: Bearer hal0_<admin-token>' \
-  http://hal0.local:8080/api/auth/tokens \
-  -H 'Content-Type: application/json' \
-  -d '{"label": "openwebui-bridge", "scope": "all"}'
-```
-
-The raw token is in the response **once** — copy it immediately. To revoke:
-
-```sh
-curl -H 'Authorization: Bearer hal0_<admin-token>' -X DELETE \
-  http://hal0.local:8080/api/auth/tokens/<token-id>
-```
-
-### TLS
-
-hal0 does not ship an edge proxy or TLS terminator. The API binds
-`0.0.0.0:8080`; put TLS in front with whatever you already run —
-Traefik, nginx, Cloudflare Tunnel, Caddy as a standalone service, an
-LXC's upstream reverse proxy, etc. Two common patterns:
-
-- **Traefik / nginx upstream** — point a router/server at
-  `http://<hal0-host>:8080/` and terminate TLS at the edge. Pass
-  through `/`, `/api/*`, `/v1/*`, `/mcp/*` — hal0 is a single
-  monolithic FastAPI app, no path splits needed.
-- **mDNS-friendly local dev** — run avahi on the host and add a
-  static `<hal0-ip>  hal0.local` entry on each client. The dashboard
-  works fine over plain HTTP on a trusted LAN.
-
-Examples for each upstream live in `docs/operate/tls.md`.
-
-### Upgrade notes
-
-Existing installs that used the old `--auth=basic` path lost **edge
-auth** when ADR-0001 collapsed the Caddyfile in v0.1.0-alpha. As of
-this release the installer no longer ships any edge proxy at all —
-the prior Caddy unit is left untouched on existing hosts but
-`install.sh` neither manages it nor depends on it. To recover:
-
-- **Set a password in the dashboard wizard.** On first load after upgrade,
-  the wizard's password-setup step calls `POST /api/auth/password` and
-  writes the bcrypt hash into the FastAPI auth store. The installer
-  also prints a one-time OTP that the wizard requires for first-run
-  claim; copy it out of the installer transcript or read it directly
-  from `/var/lib/hal0/.first-run.lock`.
-- **Front hal0 with your own reverse proxy** (Traefik, nginx, Caddy you
-  manage outside hal0, Cloudflare Tunnel, etc.) and let the edge own
-  auth. Setting `HAL0_AUTH_DISABLED=1` in `/etc/hal0/api.env` collapses
-  hal0's own gate back to pass-through; do this only when the outer
-  proxy is the trust boundary.
-
-Bearer tokens minted under the prior install continue to work — token storage
-moved with the rest of auth into the FastAPI store (no migration required).
-Legacy `basicauth` credentials from the long-retired `--auth=basic` path
-are not migrated; re-entry via the wizard's password-setup step is the
-supported path.
+Identity at the application layer is the `X-hal0-Agent` request
+header; see [`docs/agents/identity.md`](../docs/agents/identity.md)
+for the agent-identity model and how to set the header from a
+programmatic client.
 
 ## Dev mode (`--dev`)
 


### PR DESCRIPTION
## Summary

Part of the v0.3 docs quad (created 2026-05-28 01:58 UTC, PR opened today).

- New Lemonade operate/reference doc
- Dashboard v3 walkthrough
- Guts the installer's auth section now that ADR-0012 removed auth entirely

## Notes

- Branch is 13 commits behind main at PR-open time — may need rebase before CI passes.
- Sibling PRs: docs/v0.3-agents-mcp-memory, docs/v0.3-internal-adrs, docs/v0.3-root-refresh.