### PR TITLE
docs(root): refresh README/ARCHITECTURE/CONTEXT/CONTRIBUTING for v0.3.0-alpha.1

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,60 +1,114 @@
 # hal0 architecture
 
 This document covers hal0's internal architecture. For the user-facing
-shape (install, ports, filesystem layout), see [`docs/install.md`](./docs/install.md).
-For scope and roadmap, see [`PLAN.md`](./PLAN.md).
+shape (install, ports, filesystem layout), see
+[`docs/install.md`](./docs/install.md). For scope and roadmap, see
+[`PLAN.md`](./PLAN.md). For the v0.3 release notes, see
+[`CHANGELOG.md`](./CHANGELOG.md).
 
 ## Process model
 
-hal0 is a single FastAPI process (`hal0-api.service`) that orchestrates
-N systemd-managed inference containers (`hal0-slot@<name>.service`).
-OpenWebUI runs as its own systemd unit (`hal0-openwebui.service`).
+As of v0.3, hal0 runs as **three** long-lived systemd units on the
+host:
+
+- `hal0-api.service` — the FastAPI app (Uvicorn). Owns slot lifecycle,
+  capability dispatch, the OmniRouter loop, MCP server mounts, and the
+  React dashboard build. Binds `0.0.0.0:8080` open (no built-in auth
+  since [ADR-0012](./docs/internal/adr/0012-remove-auth-and-caddy.md);
+  see "Auth posture" in the README).
+- `hal0-lemonade.service` — one `lemond` daemon. The unified inference
+  runtime ([ADR-0008](./docs/internal/adr/0008-lemonade-adoption.md)).
+  Binds `127.0.0.1:13305` loopback-only — that's the canonical proxy
+  target `hal0-api` points at. `lemond` also opens a separate
+  `127.0.0.1:9000` listener for its own OpenAI-compatible surface, but
+  hal0 never proxies through that port; everything goes via 13305.
+- `hal0-openwebui.service` — OpenWebUI on `:3001`, prewired against
+  the local hal0 API. Optional but installed by default.
 
 ```
                    ┌─────────────────────────┐
    user/clients ─▶ │  hal0-api  (:8080)      │ ◀─ OpenWebUI (:3001)
-                   │  FastAPI + dispatcher   │
+                   │  FastAPI + dispatcher   │       hal0-openwebui.service
+                   │  + /mcp/admin           │
+                   │  + /mcp/memory          │
+                   │  + /v1/* proxy          │
                    └────────────┬────────────┘
-                                │ systemctl + HTTP probes
-                ┌───────────────┼───────────────┐
-                ▼               ▼               ▼
-        hal0-slot@primary  hal0-slot@embed   hal0-slot@stt   ...
-        (llama.cpp)        (llama.cpp)       (Moonshine)
+                                │ HTTP (127.0.0.1:13305)
+                                ▼
+                   ┌─────────────────────────┐
+                   │  lemond  (:13305)       │
+                   │  hal0-lemonade.service  │
+                   │  llamacpp / flm / sd-cpp│
+                   │  whisper.cpp / kokoro   │
+                   └─────────────────────────┘
 ```
 
-Each slot is independent: its own port (8081+), its own model, its own
-lifecycle. The API process only owns slot **lifecycle** (load / unload /
-restart) and **routing** (dispatcher → slot → response). It never holds
-a model in its own memory.
+Slots are no longer one-systemd-unit-per-slot. A slot is a config row
+under `/etc/hal0/slots/<name>.toml` (mirrored into
+`/etc/hal0/capabilities.toml`) that names ONE Lemonade-registered
+model + a `type` + a `device`. `SlotManager.start(slot)` is a
+`POST /v1/load` against `lemond`; the lifecycle state machine
+(`offline → starting → warming → ready ↔ serving / idle → unloading`)
+still holds, but each state is derived from `/v1/health` polling +
+Lemonade `/logs/stream` events rather than `systemctl is-active` on a
+slot-specific unit.
+
+The FLM trio is the one exception worth calling out: on Strix Halo
+with FastFlowLM installed, three NPU slots (`agent`, `stt-npu`,
+`embed-npu`) all back the same `flm serve` child. Lemonade tracks the
+chat role only; hal0's capability dispatcher reads
+`/v1/health.loaded[].backend_url` for the FLM model and routes
+transcription + embedding requests directly to that child's port. See
+[ADR-0009](./docs/internal/adr/0009-flm-trio-npu-packing.md).
 
 ## Module layout
 
 ```
 src/hal0/
 ├── api/             # FastAPI app + routers + middleware
-│   ├── routes/      # one APIRouter per concern (18 modules incl.
-│   │                #   capabilities, backends, images, events, auth)
-│   └── middleware/  # error envelope, request id, cors
-├── slots/           # slot lifecycle (state machine, unit rendering)
-├── dispatcher/      # routing, single-flight, decision logging
-├── providers/       # backend abstraction (llama_server, flm, moonshine,
-│                    #   kokoro, comfyui)
+│   ├── routes/      # ~27 APIRouters: slots, models, capabilities, agents,
+│   │                #   approvals, journal, events, hardware, health,
+│   │                #   bundles, lemonade_admin, lemonade_logs,
+│   │                #   lemonade_proxy (/v1/* reverse-proxy), mcp,
+│   │                #   memory, images, openwebui, installer, ...
+│   ├── middleware/  # error envelope, request id, CORS, identity
+│   ├── mcp_mount.py # mounts /mcp/admin + /mcp/memory (FastMCP
+│   │                #   Streamable-HTTP apps)
+│   └── deps.py      # FastAPI dependency providers
+├── lemonade/        # HTTP client (DEFAULT_BASE_URL = 127.0.0.1:13305),
+│                    #   catalog_sync, metrics_shim, log_proxy
+├── slots/           # slot lifecycle (state machine, status, registry-
+│                    #   driven config)
 ├── capabilities/    # UX overlay grouping flat slots into capability
 │                    #   cards (catalog + config + orchestrator);
 │                    #   persists selections in capabilities.toml and
 │                    #   reconciles slot TOMLs on every apply
+├── dispatcher/      # routing, single-flight, decision logging
+├── omni_router/     # client-side OpenAI tool-calling loop + tool defs
+├── agents/          # bundled-agent install (Hermes-Agent),
+│                    #   hermes_provision orchestrator, identity cards,
+│                    #   approvals queue
+├── mcp/             # bundled MCP servers (hal0-admin, hal0-memory)
+├── memory/          # Cognee adapter (SQLite + LanceDB + Kuzu)
 ├── registry/        # model registry (atomic TOML, mtime cache, GGUF
 │                    #   magic-byte detect, HF-cache repo-name fallback)
 ├── hardware/        # probe + stats (GPU, NPU, RAM, disk)
-├── upstreams/       # external LLM providers (OpenRouter, etc.)
+├── upstreams/       # external LLM providers (OpenRouter, Anthropic, ...)
 ├── config/          # pydantic schemas, TOML loader, migrations
-├── auth/            # password + Bearer token storage (per ADR-0001)
 ├── events/          # in-process pub/sub for SSE streams
+├── journal/         # journal-event store powering the dashboard Journal
+├── bundles/         # first-run bundle picker (hal0-Lite/Default/Pro/Max
+│                    #   + LMX-Omni-52B-Halo)
+├── providers/       # legacy provider ABC + non-slot consumers (image-gen,
+│                    #   hardware probe, catalog). LemonadeProvider is the
+│                    #   only dispatch-path provider in v0.3.
 ├── updater/         # self-update (cosign-verified, atomic swap)
 ├── installer/       # first-run wizard backend, hardware probe writer
-├── voice/           # Moonshine + Kokoro provider glue
+├── voice/           # legacy Moonshine + Kokoro provider glue (still used
+│                    #   by non-Lemonade voice paths)
 ├── openwebui/       # companion service env file writer
-└── cli/             # `hal0` Typer CLI (incl. `capabilities migrate`)
+└── cli/             # `hal0` Typer CLI (incl. agent / approvals / registry
+│                    #   subapps + `capabilities migrate`)
 ```
 
 The capabilities layer is a **thin overlay** on the flat slot layer,
@@ -66,49 +120,47 @@ is no longer valid — primarily for FLM model-tag namespace drift.
 
 ## Key boundaries
 
-- **Slot lifecycle is pure systemd.** The slot manager talks to
-  systemctl + filesystem (env files, unit overrides) + journald. It
-  doesn't import HTTP client code, doesn't know about models other than
-  via the registry, and doesn't make assumptions about backends beyond
-  the provider ABC.
+- **Slot lifecycle talks to Lemonade.** `SlotManager.start(slot)` is a
+  `POST /v1/load` against `lemond`; `.stop(slot)` is `POST /v1/unload`;
+  `.status(slot)` reads `/v1/health.loaded[]`. The slot manager
+  doesn't render systemd units, doesn't import providers, and doesn't
+  parse model files — it asks `lemond` and propagates the answer.
 - **Dispatcher is HTTP-only.** It does not start/stop slots. It reads
   slot status from the slot manager and routes requests. If a slot is
-  offline, it returns a structured error; restarting is a separate API
+  offline, it returns a structured error; loading is a separate API
   call.
-- **Providers are stateless.** Each provider (`LlamaServerProvider`,
-  `FLMProvider`, `MoonshineProvider`, `KokoroProvider`,
-  `ComfyUIProvider`) is a class with `build_env()`, `start_cmd()`,
-  `health()`, `infer()`. They don't hold connection state, don't manage
-  systemd, and don't share globals. One provider per backend type.
-  `FLMProvider` additionally probes `flm list -j` inside the toolbox
-  image to advertise its own model-tag namespace
-  (`share/flm/model_list.json`) — it does **not** run arbitrary GGUFs
-  from the registry.
+- **One inference daemon.** `LemonadeProvider` is the only dispatch-path
+  provider in v0.3. Legacy `Provider` subclasses
+  (`MoonshineProvider`, `KokoroProvider`, `ComfyUIProvider`,
+  `FLMProvider`) remain in the tree to back non-slot paths (image-gen
+  driver, hardware-probe helpers, FLM model-tag namespace probe via
+  `flm list -j`) but no longer manage processes or own ports.
 - **The registry is the only source of truth for "what models exist."**
-  Atomic TOML files under `/var/lib/hal0/registry/`. mtime-cached. Slot
-  configs reference model IDs from the registry; if a model is deleted,
-  any slot referencing it fails to load with a structured error.
+  Atomic TOML files under `/var/lib/hal0/registry/`. mtime-cached.
+  `hal0 registry sync` projects the registry into Lemonade's
+  `server_models.json`; user pulls via `POST /v1/pull` land under the
+  `user.*` namespace and don't require a `lemond` restart.
 
 ## State
 
 Three categories of state, three filesystem locations:
 
-| Kind      | Location              | Examples                                |
-|-----------|-----------------------|------------------------------------------|
-| Code      | `/usr/lib/hal0/current/` | Python package, UI dist, unit templates |
-| Config    | `/etc/hal0/`          | `hal0.toml`, `slots/*.toml`, `providers.toml`, `hardware.json` |
-| Runtime   | `/var/lib/hal0/`      | `models/`, `registry/`, `openwebui/`, `slots/<name>/state.json` |
+| Kind      | Location                 | Examples                                                          |
+|-----------|--------------------------|-------------------------------------------------------------------|
+| Code      | `/usr/lib/hal0/current/` | Python package, UI dist, unit templates                           |
+| Config    | `/etc/hal0/`             | `hal0.toml`, `slots/*.toml`, `capabilities.toml`, `hardware.json` |
+| Runtime   | `/var/lib/hal0/`         | `lemonade/`, `models/`, `registry/`, `openwebui/`, `state/`, `agents/` |
 
 Code is replaceable (every update writes a new versioned dir + flips a
 symlink). Config is preserved across updates. Runtime is preserved
 across updates and survives uninstall when `--keep-data` is passed.
 
-### Slot lifecycle state machine
+## Slot lifecycle state machine
 
 The authoritative enum lives in
-[`hal0.slots.state.SlotState`](./src/hal0/slots/state.py); transitions are
-enforced by `SlotManager._transition()` and persisted atomically to
-`/var/lib/hal0/slots/<name>/state.json`.
+[`hal0.slots.state.SlotState`](./src/hal0/slots/state.py); transitions
+are enforced by `SlotManager._transition()` and persisted atomically
+to `/var/lib/hal0/slots/<name>/state.json`.
 
 ```
 offline → pulling → starting → warming → ready ←──┐
@@ -124,32 +176,36 @@ offline → pulling → starting → warming → ready ←──┐
 
 | State        | Meaning                                                              |
 |--------------|----------------------------------------------------------------------|
-| `offline`    | No systemd unit active.                                              |
-| `pulling`    | Model files downloading / verifying; unit not yet started.           |
-| `starting`   | `systemctl start` issued; container not yet reachable.               |
-| `warming`    | Container reachable; model loading or `/v1/models` populating.       |
+| `offline`    | No model loaded into `lemond` for this slot.                         |
+| `pulling`    | Model files downloading / verifying; load not yet issued.            |
+| `starting`   | `POST /v1/load` issued; Lemonade hasn't acknowledged the load yet.   |
+| `warming`    | Load acknowledged; child reachable but not yet returning `/v1/models`.|
 | `ready`      | Probe converged AND at least one model advertised — safe to route.   |
 | `serving`    | At least one inference request in flight on this slot.               |
-| `idle`       | Container up but cannot fulfil requests right now. Two sub-cases:    |
-|              | (a) `--model ""` / empty `/v1/models` — process-up-no-model;         |
-|              | (b) ready slot quiet for longer than the idle timeout.               |
-| `unloading`  | Graceful `systemctl stop` in progress.                               |
-| `error`      | Failed; details in `state.json.message` and journald.                |
+| `idle`       | Loaded but quiet for longer than the idle timeout (eviction-eligible).|
+| `unloading`  | Graceful `POST /v1/unload` in progress.                              |
+| `error`      | Failed; details in `state.json.message` and `lemond` logs.           |
 
 `SlotManager.status()` runs a bidirectional reconciler against
-`systemctl is-active`:
+`/v1/health.loaded[]`:
 
-- A `ready`/`serving`/`idle` state with a dead unit → transition to
-  `error`.
-- An `offline`/`error` state with a live unit → run a one-shot health
-  probe and adopt the slot into `ready` or `idle` (issue #30).
+- A `ready`/`serving`/`idle` state with the model missing from
+  `loaded[]` → transition to `error` (or back to `offline` if the
+  unload was deliberate).
+- An `offline`/`error` state with the model present in `loaded[]` →
+  adopt the slot into `ready` or `idle`.
 
-Routers MUST treat `idle` distinctly from `ready`: an idle slot has no
-model advertised and will 4xx on inference attempts (issue #31).
+Routers MUST treat `idle` distinctly from `ready`: an idle slot is
+eviction-eligible and may be nuclear-evicted by Lemonade's per-type
+LRU under load.
 
 ## See also
 
-- [`PLAN.md`](./PLAN.md) — v1 scope, modules ported from haloai, milestones
-- [`docs/slots.md`](./docs/slots.md) — slot lifecycle state machine *(TODO)*
-- [`docs/dispatcher.md`](./docs/dispatcher.md) — routing algorithm *(TODO)*
-- [`docs/install.md`](./docs/install.md) — install flow + filesystem layout *(TODO)*
+- [`PLAN.md`](./PLAN.md) — v0.3 scope + path to v1.0
+- [`CHANGELOG.md`](./CHANGELOG.md) — release-level change history
+- [`docs/operate/auth.mdx`](./docs/operate/auth.mdx) — reverse-proxy
+  recipes for hal0 boxes reachable off-LAN
+- [`docs/internal/adr/0008-lemonade-adoption.md`](./docs/internal/adr/0008-lemonade-adoption.md)
+  — why one daemon, why 13305
+- [`docs/internal/adr/0012-remove-auth-and-caddy.md`](./docs/internal/adr/0012-remove-auth-and-caddy.md)
+  — why no built-in auth or TLS in v0.3

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,7 +19,7 @@ When in doubt, ask which sense applies before writing the word.
 
 ## bundled agent
 
-Phase 8 product feature. A third-party agent application installed alongside hal0, prewired to use hal0 as its local AI provider and to consume hal0's MCP servers. v0.2 supports `pi-coder` (CLI shape) and `Hermes-Agent` (service shape). Single-pick at install. See ADR-0004.
+Phase 8 product feature. A third-party agent application installed alongside hal0, prewired to use hal0 as its local AI provider and to consume hal0's MCP servers. v0.2 supported `pi-coder` (CLI shape) and `Hermes-Agent` (service shape). v0.3 narrows the promoted set to `Hermes-Agent` only; `pi-coder` code remains in the repo for v0.3.x reactivation but is dropped from the v0.3 first-run wizard, dashboard, and install promo. Single-pick at install. See ADR-0004 (background) and ADR-0011 (Hermes identity cards).
 
 ## Cognee
 
@@ -29,13 +29,17 @@ The embedded memory engine adopted from v0.2 (Apache 2.0). Defaults: SQLite + La
 
 Cognee's namespace primitive. hal0's namespace rule (v0.2): default `shared` for all clients; per-client `--private` toggle promotes that client's writes to `private:<client_id>`. Multi-user revisits the rule in Phase 9 (future ADR pending — ADR-0006 was reassigned to Lemonade migration). See ADR-0005 §3.
 
+> **🚧 Coming in v0.3.0-alpha.2** — *per-agent private memory namespacing is gated on issue #317: `/api/memory/add` currently forces `dataset = "shared"` regardless of the incoming `private:*` scope, so `--private` is a no-op on the write path today.*
+
+v0.3 also adds a dedicated `agents` dataset (separate from `shared` and `private:*`) for agent-identity cards — see "agents dataset" below.
+
 ## MCP server (hal0-exposed)
 
-hal0 exposes two MCP servers (Phase 8, v0.2):
+hal0 exposes two MCP servers (Phase 8, v0.2; carried forward in v0.3):
 - `/mcp/admin` — wraps existing `/api/*` routes (slot/model/hardware/log admin). Tool catalog rule: ships iff it maps to an existing route. See ADR-0004 §4.
 - `/mcp/memory` — wraps Cognee's Python API. See ADR-0005 §2.
 
-Both reachable by any MCP-speaking client: bundled agents, Claude Code, future RAG services. Auth via existing Bearer token (ADR-0001).
+Both mounted as FastMCP Streamable-HTTP apps and reachable by any MCP-speaking client: the bundled Hermes-Agent, Claude Code, future RAG services. **No Bearer auth** as of v0.3 ([ADR-0012](docs/internal/adr/0012-remove-auth-and-caddy.md) supersedes ADR-0001) — `hal0-api` binds open on `0.0.0.0:8080`; client identity rides on the `X-hal0-Agent` header (target state, see "agent identity" below). Front with an upstream reverse proxy for off-LAN deployments.
 
 ## memory
 
@@ -74,10 +78,10 @@ A named, configured serving target — e.g. `primary`, `embed`, `stt`, `tts`, `i
 
 Two sub-senses depending on release:
 
-1. **v0.1.x slot (current)** — `hal0-slot@.service` systemd template unit, parameterized by slot name. Owns a process + port + container under a Provider class (PLAN.md §2).
-2. **v0.2 slot (with Lemonade)** — a logical mapping from slot name to ONE Lemonade-loaded model. The per-slot systemd template retires; `lemond` is the single shared process. Slot state (`ready`/`idle`/`serving`) is derived from `/v1/health.loaded[]` by model_name lookup. User-facing UX unchanged. See ADR-0006 (pending).
+1. **v0.1.x slot (HISTORICAL — removed in v0.2)** — `hal0-slot@.service` systemd template unit, parameterized by slot name. Owned a process + port + container under a Provider class (PLAN.md §2). Retired in v0.2 alongside the per-modality toolbox containers.
+2. **v0.2 / v0.3 slot (current)** — a logical mapping from slot name to ONE Lemonade-loaded model. `lemond` is the single shared process; the per-slot systemd template is gone. Slot state (`ready`/`idle`/`serving`) is derived from `/v1/health.loaded[]` by model_name lookup. User-facing UX unchanged. See ADR-0008.
 
-`SlotManager.start(slot)` in v0.2 calls Lemonade load semantics rather than starting a systemd unit. Slot identity persists in `capabilities.toml` and the user-facing surface; the runtime layer is the Lemonade pool.
+`SlotManager.start(slot)` in v0.2+ calls Lemonade load semantics rather than starting a systemd unit. Slot identity persists in `capabilities.toml` and the user-facing surface; the runtime layer is the Lemonade pool.
 
 ### slot inventory (v0.2)
 
@@ -279,4 +283,12 @@ Pinned to `/var/lib/hal0/agents/hermes/` for hal0-bundled installs (not `~/.herm
 
 ## v0.3
 
-The active milestone (2026-05-23 →). Five interlocking streams: (1) Hermes-Agent first-run bootstrap, (2) React dashboard v3 wired to live data, (3) Lemonade polish (preload+idle, GPU TTS, KV%, `/v1/*` proxy), (4) Admin/auth simplification (ADR-0001 close-out: FastAPI owns auth, Caddy collapsed to TLS-only or removed), (5) Advanced memory + MCP client side (Cognee graph + Memify + federation + per-agent external MCP allow-list). v0.3 ships when all five close. See PLAN.md §1 v0.3 + §15 Phase 10.
+The active milestone (2026-05-23 →). Five interlocking streams: (1) Hermes-Agent first-run bootstrap, (2) React dashboard v3 wired to live data, (3) Lemonade polish (preload+idle, GPU TTS, KV%, `/v1/*` proxy), (4) Admin/auth simplification — landed as a hard cut in v0.3.0-alpha.1 ([ADR-0012](docs/internal/adr/0012-remove-auth-and-caddy.md) supersedes [ADR-0001](docs/internal/adr/0001-collapse-edge-auth-into-fastapi.md); auth + Caddy both removed entirely, ~6,000 lines deleted), (5) Advanced memory + MCP client side (Cognee graph + Memify + federation + per-agent external MCP allow-list). v0.3 ships when all five close. See PLAN.md §1 v0.3 + §15 Phase 10.
+
+v0.3.0-alpha.1 shipped 2026-05-24 — see [CHANGELOG.md](CHANGELOG.md) for the full change list.
+
+## X-hal0-Agent
+
+The request header bundled agents and the hal0 CLI use to declare their identity to `hal0-api` (replaces the v0.1/v0.2 `Authorization: Bearer` token surface — removed in v0.3 per ADR-0012). Set from the `HAL0_AGENT_ID` env var by `/usr/local/bin/hal0-hermes` and the CLI wrapper.
+
+> **🚧 Coming in v0.3.0-alpha.2** — *client-side wiring shipped in v0.3.0-alpha.1 (CLI, Hermes provisioner, agent templates all emit the header). Server-side read is the post-alpha.1 follow-up: today the FastAPI side still reads `Authorization: Bearer` and falls back to `"anonymous"` for unknown principals (see `MCPAuthMiddleware` in `src/hal0/api/mcp_mount.py`). The `MCPAuthMiddleware → Identity` rename + read switch are tracked under the v0.3 auth-removal close-out.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing to hal0
 
-hal0 is licensed [Apache 2.0](./LICENSE). hal0 is at **v0.2.0** — the
-Lemonade Server adoption release. The contribution model is still
-being decided (see [`PLAN.md`](./PLAN.md) §16). External PRs aren't
-being merged yet; please open issues for discussion.
+hal0 is licensed [Apache 2.0](./LICENSE). hal0 is at **v0.3.0-alpha.1** —
+the auth-removal + dashboard-v3 release. The contribution model is
+still being decided (see [`PLAN.md`](./PLAN.md) §16). External PRs
+aren't being merged yet; please open issues for discussion.
 
 When the model opens up, the shape will be:
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -7,9 +7,22 @@ one-line install) and re-architected around the things that make hal0
 different from "a wrapper around llama-server": hardware-aware slots,
 clean lifecycle, and a real reliability bar.
 
-**Status (2026-05-23):** **v0.2.0 SHIPPED** (Lemonade migration + Agents
-v0.2 + MCP/memory + bundle picker, 22-PR adoption sequence closed).
-**v0.3 is the active milestone** — five interlocking work streams:
+**Status (2026-05-27):** **v0.3.0-alpha.1 SHIPPED** 2026-05-24 — auth
++ Caddy removed entirely ([ADR-0012](docs/internal/adr/0012-remove-auth-and-caddy.md)
+supersedes ADR-0001, ~6,000 lines deleted), React dashboard v3 landed
+on `main` (PR #235), Hermes-Agent first-run bootstrap online
+([ADR-0011](docs/internal/adr/0011-agent-identity-cards.md)). See
+[CHANGELOG.md](CHANGELOG.md) for the full change list. Ship-criteria
+status: streams (1) Hermes bootstrap, (3) Lemonade polish, and (4)
+auth simplification are effectively closed; streams (2) dashboard v3
+wiring (~70%, mock-fallback panels under the `dashboard-v3` label) and
+(5) advanced memory + MCP client side ([ADR-0013](docs/internal/adr/0013-mcp-client-allow-list.md)
++ [ADR-0014](docs/internal/adr/0014-cognee-graph-extraction-model-gate.md))
+roll forward into v0.3.0-alpha.2 and the rest of the v0.3.x line.
+Earlier baseline at 2026-05-23: **v0.2.0 SHIPPED** (Lemonade migration
++ Agents v0.2 + MCP/memory + bundle picker, 22-PR adoption sequence
+closed). **v0.3 is the active milestone** — five interlocking work
+streams:
 
 1. **Hermes-Agent bootstrap** — bundled agent becomes hal0-aware on
    first run: env probe, model auto-wiring, MCP memory connection,

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ unified memory — into a polished, OpenAI-compatible inference appliance.
 A unified runtime, hardware-aware slots, prewired chat UI, signed
 self-update. One command installs the lot.
 
-It is not another llama-server wrapper. v0.2 ships **AMD's Lemonade
+It is not another llama-server wrapper. hal0 ships **AMD's Lemonade
 Server as the unified inference runtime** behind a thin hal0 capability
 layer. Every workload — chat, embed, rerank, STT, TTS, image gen —
 runs as a real, named slot in `capabilities.toml`; the API surface
@@ -29,20 +29,23 @@ operating the box, not chatting with it.
 curl -fsSL https://hal0.dev/install.sh | bash
 ```
 
-> **Status:** **v0.2.0** — first release on the Lemonade runtime.
-> Six per-modality toolbox containers, the `hal0-slot@.service` template,
-> and the legacy Provider stack all retired in favour of one
-> `hal0-lemonade.service` supervising a single `lemond` daemon. v0.1.x
-> installs do **not** auto-upgrade — see
-> [`docs/v0.2-upgrade.md`](./docs/v0.2-upgrade.md) for the back-up + wipe
-> + reinstall procedure and the `hal0 registry import` recovery path.
-> First run lands a **bundle picker** (`hal0-Lite` / `Default` / `Pro` /
-> `Max` + `LMX-Omni-52B-Halo`) — `capabilities.toml` ships empty by
-> design, no silent default. Expect rough edges: APIs may shift, KV%
-> for GPU slots reads `—` in v0.2 (see [ADR-0008
-> §Costs](./docs/internal/adr/0008-lemonade-adoption.md)), and we don't
-> promise upgrade compatibility across `0.2.x` tags. See
-> [`PLAN.md`](./PLAN.md) §1 for what ships now and the path to v1.0.
+> **Status:** **v0.3.0-alpha.1** (2026-05-24) — the auth-removal +
+> dashboard-v3 cut. `hal0-api` now binds `0.0.0.0:8080` open with no
+> built-in auth, no Bearer-token store, no Caddy, no TLS termination
+> ([ADR-0012](./docs/internal/adr/0012-remove-auth-and-caddy.md)
+> supersedes ADR-0001). Front hal0 with an upstream reverse proxy if
+> it's reachable off-LAN — see [`docs/operate/auth.mdx`](./docs/operate/auth.mdx)
+> for Traefik / nginx / Cloudflare Tunnel recipes. The React dashboard
+> v3 lands wired against live data for slots, chat, models, journal,
+> and agents; remaining mock-fallback panels are tracked under the
+> `dashboard-v3` label. First run still lands the v0.2 **bundle picker**
+> (`hal0-Lite` / `Default` / `Pro` / `Max` + `LMX-Omni-52B-Halo`) —
+> `capabilities.toml` ships empty by design, no silent default.
+> Expect rough edges: APIs may still shift, KV% for GPU slots reads
+> `—` (see [ADR-0008 §Costs](./docs/internal/adr/0008-lemonade-adoption.md)),
+> and we don't promise upgrade compatibility across `0.3.x` tags.
+> See [`CHANGELOG.md`](./CHANGELOG.md) for the full v0.3.0-alpha.1
+> change list and [`PLAN.md`](./PLAN.md) §1 for the path to v1.0.
 
 ## Why hal0
 
@@ -105,11 +108,12 @@ be evicted out from under a streaming request.
   (`primary`, `embed`, `rerank`, `stt`, `tts`, `img`) plus three NPU
   slots (`agent`, `stt-npu`, `embed-npu`) when FastFlowLM is installed.
   User-added slots via `hal0 slot add NAME --type TYPE --model MODEL`.
-- **Lemonade as the unified runtime** — one `lemond` process,
-  loopback-only on `:13305`, supervised by `hal0-lemonade.service`.
-  Cache + config at `/var/lib/hal0/lemonade/`. The hal0 capability
-  layer is the only user-facing inference surface; Lemonade is
-  treated as an internal runtime, never exposed off-box.
+- **Lemonade as the unified runtime** — one `lemond` daemon,
+  loopback-only on `127.0.0.1:13305` (the canonical proxy target;
+  `hal0-api` reverse-proxies `/v1/*` to it). Supervised by
+  `hal0-lemonade.service`. Cache + config at `/var/lib/hal0/lemonade/`.
+  The hal0 capability layer is the only user-facing inference surface;
+  Lemonade is treated as an internal runtime, never exposed off-box.
 - **Bundle picker on first run** — `capabilities.toml` ships empty by
   design. The dashboard's first load surfaces four hardware-anchored
   tiers (`hal0-Lite` ≥16 GB / `Default` ≥32 GB / `Pro` ≥64 GB / `Max`
@@ -123,10 +127,11 @@ be evicted out from under a streaming request.
 - **Dispatcher** — registry-aware routing, cold-cache prefetch,
   upstream fallback (OpenRouter, Anthropic, OpenAI, custom OpenAI-shaped
   endpoints). Mix local + remote per-model in one config.
-- **Dashboard** — Vue 3 + Tailwind 4 UI for slot/model management,
-  hardware-aware configuration, live logs, and system health. SSE-backed
-  status + log tail. Lemonade `/logs/stream` folded into the Journal
-  panel. Settings → Lemonade admin panel surfaces the daemon's
+- **Dashboard** — React 18 + TypeScript + Vite + Tailwind 4 UI (v3,
+  landed via PR #235) for slot/model management, hardware-aware
+  configuration, live logs, and system health. SSE-backed status + log
+  tail. Lemonade `/logs/stream` folded into the Journal panel.
+  Settings → Lemonade admin panel surfaces the daemon's
   `/internal/config` for inspection. Dark by default.
 - **OpenWebUI prewired** — chat at `:3001`, zero config. The installer
   writes `openwebui.env` pointing at the local hal0 API.
@@ -148,8 +153,9 @@ be evicted out from under a streaming request.
   manifest, sha256-verifies the tarball, cosign-verifies the signature
   against the workflow OIDC identity, then hands off to
   [`installer/install.sh`](./installer/install.sh). v0.1.x installs
-  are detected and refused with explicit backup/wipe instructions
-  (see [`docs/v0.2-upgrade.md`](./docs/v0.2-upgrade.md)).
+  are detected and refused with explicit backup/wipe instructions;
+  see [`CHANGELOG.md`](./CHANGELOG.md) for the v0.2 + v0.3 upgrade
+  notes and the `hal0 registry import` recovery path.
 - **One-line Proxmox VE install** — on a Proxmox host, `bash -c "$(curl
   -fsSL https://raw.githubusercontent.com/Hal0ai/hal0/main/scripts/proxmox-ve/hal0.sh)"`
   creates an unprivileged Debian 13 LXC and runs the standard bootstrap
@@ -158,27 +164,46 @@ be evicted out from under a streaming request.
   — Strix Halo passthrough still requires the privileged-LXC recipe.
   See [`scripts/proxmox-ve/README.md`](./scripts/proxmox-ve/README.md).
 
-### Bundled agents (v0.2)
+### Bundled agents (v0.3)
 
 hal0 ships **two MCP servers** and **one bundled agent app**. The MCP
 servers (`/mcp/admin` for slot / model / capability / config / hardware
 / log admin and `/mcp/memory` for Cognee-backed long-term memory) are
-reachable by any MCP-speaking client — Claude Code, future RAG
-services, external scripts. The bundled agent is single-pick at install:
-`pi-coder` (CLI shape, installed from `Hal0ai/pi-mono` fork via
-`@earendil-works/pi-coding-agent` on npm) or `Hermes-Agent` (service
-shape, installed via the hal0-owned `hal0-hermes` wrapper around
-upstream `hermes`). Pick one via the first-run wizard or `hal0 agent install
-<name>`; swap atomically with `--switch`. Capital-D destructive MCP
-calls (`model_pull`, `slot_delete`, `config_write`, etc.) gate through
-a header bell + inbox modal in the dashboard, with CLI parity via
-`hal0 agent approvals {list,approve,deny}`. See
+mounted as FastMCP Streamable-HTTP apps at `/mcp/admin` and
+`/mcp/memory`, reachable by any MCP-speaking client — Claude Code,
+future RAG services, external scripts. The bundled agent for v0.3 is
+**Hermes-Agent** (service shape, installed via the hal0-owned
+`hal0-hermes` wrapper around upstream `hermes`). Install via the
+first-run wizard or `hal0 agent install hermes`. Capital-D destructive
+MCP calls (`model_pull`, `slot_delete`, `config_write`, etc.) gate
+through a header bell + inbox modal in the dashboard, with CLI parity
+via `hal0 agent approvals {list,approve,deny}`. See
 [docs/api/mcp.md](./docs/api/mcp.md) and
 [docs/api/agents.md](./docs/api/agents.md).
 
+Clients identify themselves to hal0 via the `X-hal0-Agent` request
+header, sourced from the `HAL0_AGENT_ID` env var in the wrapper
+script. The CLI, the Hermes provisioner, and the bundled agent
+templates all set this header today.
+
+> **🚧 Coming in v0.3.0-alpha.2** — *the FastAPI side still reads
+> legacy `Authorization: Bearer` and falls back to `"anonymous"`;
+> server-side `X-hal0-Agent` adoption + the `MCPAuthMiddleware →
+> Identity` rename land as post-alpha.1 follow-ups, tracked under the
+> auth-removal close-out.*
+
+> **🚧 Coming in v0.3.0-alpha.2** — *Per-agent private memory
+> namespacing is gated on issue #317: `/api/memory/add` currently
+> forces `dataset` to `shared` regardless of the incoming
+> `private:*` scope.*
+
+The `pi-coder` agent path remains in the repository for v0.3.x
+reactivation after the Lemonade UX polish but is not promoted in the
+v0.3 dashboard or first-run wizard.
+
 ## Backends
 
-v0.2 routes every inference workload through Lemonade Server. The
+hal0 routes every inference workload through Lemonade Server. The
 table below lists the Lemonade recipe each capability uses, plus the
 hardware device it targets.
 
@@ -187,20 +212,21 @@ hardware device it targets.
 | chat + embed + rerank | `llamacpp`     | Vulkan / ROCm / CPU     | `--parallel 1 --threads N` mandatory in `lemond` config     |
 | chat + STT + embed (NPU) | `flm:npu`   | AMD XDNA (opt-in)       | FLM trio: one process, `--asr 1 --embed 1`, ~2 GB NPU mem  |
 | transcription | `whisper.cpp`          | Vulkan / CPU            | Replaces v0.1 Moonshine for the CPU/GPU path                |
-| TTS           | `kokoro:cpu`           | CPU                     | `[CPU]` chip + tooltip in dashboard; GPU TTS deferred to v0.3 |
+| TTS           | `kokoro:cpu`           | CPU                     | `[CPU]` chip + tooltip in dashboard; GPU TTS is a v0.3 stream |
 | image         | `sd-cpp`               | ROCm / Vulkan           | SD Turbo / Flux-2-Klein-9B selectable per bundle tier       |
 
 The NPU path is opt-in: a FastFlowLM `.deb` install (manual on Linux —
-the Lemonade auto-installer is Windows-only as of v0.2) unlocks the
-three FLM slots. With FLM present, the bundle picker's Pro and Max
-tiers surface the trio as a toggle; the trio only auto-enables when a
+the Lemonade auto-installer is Windows-only) unlocks the three FLM
+slots. With FLM present, the bundle picker's Pro and Max tiers
+surface the trio as a toggle; the trio only auto-enables when a
 bundled agent is being installed in the same first-run flow.
 
-The hal0 toolbox containers (`hal0-toolbox-vulkan` / `rocm` / `flm` /
-`moonshine` / `kokoro` / `comfyui`) and the `hal0-slot@.service`
-template that supervised them are retired. v0.2's `lemond` daemon
-takes their place. See [ADR-0008](./docs/internal/adr/0008-lemonade-adoption.md)
-for the migration rationale.
+The legacy hal0 toolbox containers (`hal0-toolbox-vulkan` / `rocm` /
+`flm` / `moonshine` / `kokoro` / `comfyui`) and the `hal0-slot@.service`
+template that supervised them were retired in v0.2; v0.3 keeps the
+single `lemond` daemon as the inference floor. See
+[ADR-0008](./docs/internal/adr/0008-lemonade-adoption.md) for the
+migration rationale.
 
 ## Hardware
 
@@ -221,14 +247,16 @@ are not in scope for v1.
 ```
 hal0/
 ├── src/hal0/         # Python package (FastAPI API + capability layer + Lemonade client + CLI)
+│   ├── agents/      # Hermes bootstrap + agent install / approvals / identity
 │   ├── lemonade/     # HTTP client + catalog_sync + metrics_shim + log_proxy
+│   ├── mcp/          # bundled MCP servers (hal0-admin, hal0-memory)
+│   ├── memory/       # Cognee adapter for hal0-memory
 │   └── omni_router/  # client-side tool-calling loop + tool definitions
-├── ui/               # React 18 + TypeScript + Vite + Tailwind 4 dashboard (v3, in flight)
-├── ui-vue.bak/       # v0.2.1 Vue 3 dashboard preserved verbatim for reference
+├── ui/               # React 18 + TypeScript + Vite + Tailwind 4 dashboard (v3)
 ├── installer/        # install.sh (writes /var/lib/hal0/lemonade/config.json + hal0-lemonade.service)
 ├── tests/            # pytest suite (α unit, β integration, γ release-gate)
 ├── docs/             # user docs (mirror of hal0.dev/docs); dev docs under docs/internal/
-└── PLAN.md           # roadmap (current cut: v0.2; path to v1.0)
+└── PLAN.md           # roadmap (current cut: v0.3; path to v1.0)
 ```
 
 Models live under `/var/lib/hal0/models/<recipe>/<capability>/` — the
@@ -291,49 +319,55 @@ VM installs leave the panel off and the dashboard stays quiet.
 No dates — items are direction. The closer to the left, the closer to
 running on your box. Full version at [hal0.dev/roadmap](https://hal0.dev/roadmap).
 
-### Shipped (v0.2)
+### Shipped (v0.3.0-alpha.1, 2026-05-24)
 
-- **Lemonade Server unified inference runtime** — six per-modality
-  toolbox containers + the `hal0-slot@.service` template retire;
-  `hal0-lemonade.service` supervises one `lemond` daemon
-- **FLM trio NPU packing** — chat + ASR + embed coresident on one
-  AMDXDNA hardware context via `--asr 1 --embed 1`
-- **OmniRouter client-side tool-calling** — 8 tools, dynamic
-  per-request filtering, `route_to_chat` cross-slot delegation
-- **First-run bundle picker** — `hal0-Lite` / `Default` / `Pro` /
-  `Max` + `LMX-Omni-52B-Halo`, hardware-anchored, no silent default
-- **Per-type LRU concurrency** — six type budgets (LLM, embedding,
-  reranking, transcription, tts, image), nuclear-evict only on
-  unrecognised load errors
-- **Settings → Lemonade admin panel** — `/internal/config` snapshot +
-  `/internal/set` atomic config writes
-- **Journal panel** — Lemonade `/logs/stream` folded into Logs tab
-- **Metrics shim** — per-slot TTFT + tok/s + prompt_tokens via
-  `/v1/stats`; FLM-native KV% on NPU slots
-- **`hal0 registry import`** — one-shot v0.1.x → v0.2 registry
-  recovery from the backup tarball
-- Carried forward from v0.1.x: OpenAI-compatible `/v1/*`, portable
-  hardware probe, capability slots overlay + orchestrator, dispatcher
-  with single-flight + cold-cache prefetch, bundled OpenWebUI on
-  `:3001`, auth (password + tokens) in FastAPI, cosign-keyless
-  self-update with rollback, bundled agents (pi-coder / Hermes-Agent)
-  + MCP admin + Cognee memory MCP
+- **Auth + Caddy removed** — `hal0-api` binds `0.0.0.0:8080` open;
+  no Bearer-token store, no first-run claim OTP, no bundled TLS.
+  ~6,000 lines deleted across backend, frontend, tests, installer,
+  packaging. Front with an upstream reverse proxy (Traefik / nginx /
+  Cloudflare Tunnel) for non-LAN deployments — see
+  [ADR-0012](./docs/internal/adr/0012-remove-auth-and-caddy.md) and
+  [`docs/operate/auth.mdx`](./docs/operate/auth.mdx).
+- **Dashboard v3** — React 18 + TypeScript + Vite + Tailwind 4
+  (PR #235). `/chat` and `/dashboard` split out; slots overview
+  mirrors snapshot/memmap/throughput sidebars onto `/slots`.
+- **Hermes-Agent first-run bootstrap** — bundled service-shape agent
+  with env probe, model auto-wiring, MCP-memory connection, and
+  identity-card publishing to the dedicated `agents` Cognee dataset
+  ([ADR-0011](./docs/internal/adr/0011-agent-identity-cards.md)).
+  Install via `hal0 agent install hermes`.
+- **Carried forward from v0.2:** Lemonade unified runtime, FLM trio
+  NPU packing, OmniRouter client-side tool-calling, first-run bundle
+  picker, per-type LRU concurrency, Lemonade admin panel, Journal
+  panel, metrics shim, `hal0 registry import`, MCP admin + Cognee
+  memory MCP.
 
-### Soon (v0.3)
+### In flight / soon (v0.3.0-alpha.2 and v0.3.x)
 
+- **Dashboard v3 mock-fallback close-out** — remaining panels still
+  pull from the seed `HAL0_DATA.*` blob (issues #213–#340).
+- **Identity rename + server-side `X-hal0-Agent` read** —
+  `MCPAuthMiddleware → Identity` rename and the FastAPI-side switch
+  away from legacy `Authorization: Bearer`. Today the client wiring
+  ships; the server still falls back to `"anonymous"`.
+- **Per-agent private memory** — `/api/memory/add` currently forces
+  `dataset = "shared"` regardless of incoming `private:*` (issue
+  #317).
 - **GPU-accelerated TTS** — kokoro-vulkan or successor; closes the
-  `[CPU]` chip on the voice slot card
-- **KV% for GPU slots** — Lemonade upstream or hal0-built llama-server
-  swap-in; v0.2 ships `—`
-- **Phase 8 polish + advanced memory** — Cognee graph + Memify pipeline
-  enabled, MCP client side of hal0 (agents reach external MCP servers),
-  federated memory across local + remote sources
+  `[CPU]` chip on the voice slot card.
+- **KV% for GPU slots** — Lemonade upstream or hal0-built
+  llama-server swap-in; v0.3.0-alpha.1 still ships `—`.
+- **Advanced memory + MCP client side** — Cognee graph extraction
+  + Memify pipeline ([ADR-0014](./docs/internal/adr/0014-cognee-graph-extraction-model-gate.md)),
+  per-agent allow-listed external MCP clients
+  ([ADR-0013](./docs/internal/adr/0013-mcp-client-allow-list.md)),
+  federated memory across local + remote sources.
 - **Benchmarks & presets UI** — in-dashboard tok/s + latency runs,
-  plus curated loadout presets you can flash onto a fresh install
+  plus curated loadout presets you can flash onto a fresh install.
 - **AUR PKGBUILD & Ubuntu PPA** — native distro packages on top of
-  the install script; pacman and apt as first-class install paths
-- `hal0.local` mDNS auto-discovery polish
-- Light mode toggle
+  the install script; pacman and apt as first-class install paths.
+- `hal0.local` mDNS auto-discovery polish.
+- Light mode toggle.
 
 ### Exploring (v1.x +)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
   "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release \u2014 the runtime then pulls by tag and emits a warning. The `.github/workflows/toolbox.yml` build job patches this file post-publish with the actual content digests via cosign + buildx and opens a PR (or pushes to main, depending on the `manifest` job config) so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See PLAN.md \u00a712 (toolbox images) and \u00a717 (Risks).",
-  "version": "0.1.0-alpha.1",
+  "version": "0.3.0-alpha.1",
   "channel": "dev",
   "toolbox_images": {
     "vulkan": {


### PR DESCRIPTION
## Summary

Part of the v0.3 docs quad (created 2026-05-28 01:59 UTC, PR opened today).

Refreshes the four root-level docs (README, ARCHITECTURE, CONTEXT, CONTRIBUTING) for the v0.3.0-alpha.1 surface.

## Notes

- Branch is 14 commits behind main at PR-open time — may need rebase before CI passes.
- Sibling PRs: docs/v0.3-agents-mcp-memory, docs/v0.3-internal-adrs, docs/v0.3-lemonade-dashboard.