### PR TITLE
fix(dispatch): recover slot after silent Lemonade eviction

### DIFF
--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -76,6 +76,20 @@ _HOP_BY_HOP_RESPONSE_HEADERS = frozenset(
 # this logger automatically carries {request_id} on every emitted line.
 log = structlog.get_logger("hal0-dispatch")
 
+# Transport-layer errors that indicate the upstream's child process is gone
+# rather than a request-level failure.  These are the recoverable triggers
+# for ``_recover_evicted_slot``:
+#   - ConnectError: TCP connect refused (port closed before the request).
+#   - RemoteProtocolError: peer dropped the connection mid-request (the
+#     classic "lemonade evicted while we were dialing" race).
+#
+# Read/Write timeouts are intentionally excluded — those usually mean the
+# child is alive but overloaded, and re-spawning would lose user work.
+_RECOVERABLE_TRANSPORT_ERRORS = (
+    httpx.ConnectError,
+    httpx.RemoteProtocolError,
+)
+
 # Path defaults used only for routing — never written back into the body.
 # Mirrors haloai lib/dispatcher.py:_DEFAULT_MODEL etc.
 _DEFAULT_MODEL = "primary"
@@ -566,6 +580,50 @@ class Dispatcher:
             details=self._build_loading_response(call, current),
         )
 
+    async def _recover_evicted_slot(self, call: UpstreamCall) -> bool:
+        """Attempt to resync a slot whose upstream port went dead unexpectedly.
+
+        Called from ``_forward_direct`` / ``_forward_streaming`` when an
+        :class:`httpx.ConnectError` lands on a slot upstream.  hal0's
+        in-memory state said the slot was READY/SERVING/IDLE (the gate
+        let us through), but the upstream port was dead — the usual
+        cause is a Lemonade idle/OOM eviction that hal0 didn't observe.
+
+        Delegates to ``SlotManager.recover_evicted_slot`` which forces
+        the slot OFFLINE and re-runs the normal load lifecycle (per-slot
+        lock serializes concurrent requests).
+
+        Returns:
+          ``True``  — slot recovered, caller should retry the forward once.
+          ``False`` — recovery is not applicable (remote upstream, no slot
+            manager wired) or the recover call itself raised.  Caller
+            should surface the original :class:`UpstreamUnavailable`.
+        """
+        if not (call.slot_name and self._slot_manager is not None):
+            return False
+        log.warning(
+            "dispatch.upstream_dead_attempting_recover",
+            upstream=call.upstream_name,
+            slot=call.slot_name,
+            target=call.target_url,
+        )
+        try:
+            await self._slot_manager.recover_evicted_slot(call.slot_name)
+        except Exception as exc:
+            log.warning(
+                "dispatch.recover_evicted_slot_failed",
+                slot=call.slot_name,
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            return False
+        log.info(
+            "dispatch.upstream_recovered",
+            upstream=call.upstream_name,
+            slot=call.slot_name,
+        )
+        return True
+
     def _build_loading_response(
         self,
         call: UpstreamCall,
@@ -654,30 +712,53 @@ class Dispatcher:
         client: httpx.AsyncClient,
         call: UpstreamCall,
     ) -> Response:
-        try:
-            resp = await client.request(
-                call.method,
-                call.target_url,
-                content=call.body or None,
-                headers=call.headers,
-            )
-        except (httpx.HTTPError, OSError) as exc:
-            log.warning(
-                "dispatch.forward_failed",
-                upstream=call.upstream_name,
-                method=call.method,
-                target=call.target_url,
-                error=str(exc),
-                error_type=type(exc).__name__,
-            )
-            raise UpstreamUnavailable(
-                f"upstream {call.upstream_name!r} unreachable: {type(exc).__name__}",
-                details={
-                    "upstream": call.upstream_name,
-                    "target": call.target_url,
-                    "error": str(exc),
-                },
-            ) from exc
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                resp = await client.request(
+                    call.method,
+                    call.target_url,
+                    content=call.body or None,
+                    headers=call.headers,
+                )
+                break
+            except _RECOVERABLE_TRANSPORT_ERRORS as exc:
+                if attempt == 1 and await self._recover_evicted_slot(call):
+                    continue
+                log.warning(
+                    "dispatch.forward_failed",
+                    upstream=call.upstream_name,
+                    method=call.method,
+                    target=call.target_url,
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+                raise UpstreamUnavailable(
+                    f"upstream {call.upstream_name!r} unreachable: {type(exc).__name__}",
+                    details={
+                        "upstream": call.upstream_name,
+                        "target": call.target_url,
+                        "error": str(exc),
+                    },
+                ) from exc
+            except (httpx.HTTPError, OSError) as exc:
+                log.warning(
+                    "dispatch.forward_failed",
+                    upstream=call.upstream_name,
+                    method=call.method,
+                    target=call.target_url,
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+                raise UpstreamUnavailable(
+                    f"upstream {call.upstream_name!r} unreachable: {type(exc).__name__}",
+                    details={
+                        "upstream": call.upstream_name,
+                        "target": call.target_url,
+                        "error": str(exc),
+                    },
+                ) from exc
 
         return Response(
             content=resp.content,
@@ -694,31 +775,54 @@ class Dispatcher:
         # We open the stream eagerly so connect errors surface as
         # UpstreamUnavailable instead of leaking through StreamingResponse
         # as a generator-time exception that confuses the error middleware.
-        try:
-            req = client.build_request(
-                call.method,
-                call.target_url,
-                content=call.body or None,
-                headers=call.headers,
-            )
-            resp = await client.send(req, stream=True)
-        except (httpx.HTTPError, OSError) as exc:
-            log.warning(
-                "dispatch.forward_stream_open_failed",
-                upstream=call.upstream_name,
-                method=call.method,
-                target=call.target_url,
-                error=str(exc),
-                error_type=type(exc).__name__,
-            )
-            raise UpstreamUnavailable(
-                f"upstream {call.upstream_name!r} unreachable: {type(exc).__name__}",
-                details={
-                    "upstream": call.upstream_name,
-                    "target": call.target_url,
-                    "error": str(exc),
-                },
-            ) from exc
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                req = client.build_request(
+                    call.method,
+                    call.target_url,
+                    content=call.body or None,
+                    headers=call.headers,
+                )
+                resp = await client.send(req, stream=True)
+                break
+            except _RECOVERABLE_TRANSPORT_ERRORS as exc:
+                if attempt == 1 and await self._recover_evicted_slot(call):
+                    continue
+                log.warning(
+                    "dispatch.forward_stream_open_failed",
+                    upstream=call.upstream_name,
+                    method=call.method,
+                    target=call.target_url,
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+                raise UpstreamUnavailable(
+                    f"upstream {call.upstream_name!r} unreachable: {type(exc).__name__}",
+                    details={
+                        "upstream": call.upstream_name,
+                        "target": call.target_url,
+                        "error": str(exc),
+                    },
+                ) from exc
+            except (httpx.HTTPError, OSError) as exc:
+                log.warning(
+                    "dispatch.forward_stream_open_failed",
+                    upstream=call.upstream_name,
+                    method=call.method,
+                    target=call.target_url,
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+                raise UpstreamUnavailable(
+                    f"upstream {call.upstream_name!r} unreachable: {type(exc).__name__}",
+                    details={
+                        "upstream": call.upstream_name,
+                        "target": call.target_url,
+                        "error": str(exc),
+                    },
+                ) from exc
 
         async def _iter() -> AsyncIterator[bytes]:
             try:

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -727,6 +727,51 @@ class SlotManager:
         await self.unload(slot_name)
         return await self.load(slot_name)
 
+    async def recover_evicted_slot(self, slot_name: str) -> Slot:
+        """Resync a slot whose child died unexpectedly (Lemonade silent eviction).
+
+        The dispatcher calls this when ``_forward_direct`` hits a
+        ConnectError on a slot upstream — hal0's state.json said the
+        slot was READY but the upstream port is dead.  Two common cases
+        both land here:
+
+          - **Lemonade-initiated eviction** (idle/OOM/auto-evict-all):
+            lemond's ``loaded[]`` table no longer contains the model.
+            A bare ``/v1/load`` actually re-spawns the child.
+          - **Orphan process** (lemond's supervisor missed the death):
+            ``loaded[]`` still claims the model is loaded on a now-dead
+            PID/port.  A bare ``/v1/load`` is a no-op — lemond returns
+            success without re-spawning.  The slot stays dead.
+
+        To cover both, we drive a full unload + load cycle: ``/v1/unload``
+        forces lemond to drop its ``loaded[]`` claim (and is a no-op
+        when the model is genuinely gone, per the LemonadeProvider
+        contract), then ``/v1/load`` actually re-spawns on the slot's
+        configured port.  The slot's per-method locks serialize concurrent
+        recoveries.
+
+        Best-effort: if ``unload()`` itself raises (rare — usually means
+        lemond is hard-down), we still try ``load()`` to give recovery
+        the best shot at succeeding.  A subsequent retry-time
+        ConnectError will surface as ``UpstreamUnavailable`` as before.
+        """
+        self._ensure_known(slot_name)
+        log.info("slot.recover_evicted_dispatched", extra={"slot": slot_name})
+        try:
+            await self.unload(slot_name)
+        except Exception as exc:
+            # Log but don't bail — load() may still succeed if lemond
+            # was just confused about state, not actually broken.
+            log.warning(
+                "slot.recover_unload_failed",
+                extra={
+                    "slot": slot_name,
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                },
+            )
+        return await self.load(slot_name)
+
     async def start(self, slot_name: str) -> Slot:
         """Idempotent start.  Equivalent to load() when slot is offline.
 

--- a/tests/dispatcher/test_serving_integration.py
+++ b/tests/dispatcher/test_serving_integration.py
@@ -34,10 +34,19 @@ class _RecordingSlotManager:
     up a real SlotManager (which would need a slot TOML + systemctl stubs).
     """
 
-    def __init__(self, state: SlotState = SlotState.READY) -> None:
+    def __init__(
+        self,
+        state: SlotState = SlotState.READY,
+        *,
+        recover_raises: BaseException | None = None,
+    ) -> None:
         self.events: list[tuple[str, str]] = []  # (op, slot_name)
         self._counts: dict[str, int] = {}
         self._state = state
+        # Recorded so tests can assert the dispatcher's recovery branch fires
+        # exactly once on ConnectError for a slot upstream.
+        self.recover_calls: list[str] = []
+        self._recover_raises = recover_raises
 
     def serving(self, slot_name: str) -> _RecordingCtx:
         return _RecordingCtx(self, slot_name)
@@ -51,6 +60,14 @@ class _RecordingSlotManager:
         # existing serving-integration tests pass; tests for the gate
         # construct the mock with the state they want to assert against.
         return self._state
+
+    async def recover_evicted_slot(self, slot_name: str) -> None:
+        """Mirrors SlotManager.recover_evicted_slot — dispatcher calls this
+        on ConnectError to resync after a silent Lemonade eviction.
+        """
+        self.recover_calls.append(slot_name)
+        if self._recover_raises is not None:
+            raise self._recover_raises
 
 
 class _RecordingCtx:
@@ -306,5 +323,175 @@ async def test_remote_upstream_skips_gate_even_when_slot_state_lookup_would_fail
         resp = await dispatcher.forward(_remote_call())
         assert resp.status_code == 200
         assert sm.events == []
+    finally:
+        await dispatcher.aclose()
+
+
+# ── silent-eviction recovery (ConnectError on a READY slot) ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_forward_recovers_from_silent_eviction_and_retries() -> None:
+    """ConnectError on a slot upstream triggers recover_evicted_slot + 1 retry.
+
+    Reproduces the v0.3 'lemonade silent eviction' bug: hal0's state.json
+    says the slot is READY but the upstream port is dead because lemond
+    evicted the child llama-server without notifying hal0.  The dispatcher
+    must call SlotManager.recover_evicted_slot() (which drives /v1/load)
+    and then retry the forward once before giving up.
+    """
+    sm = _RecordingSlotManager(state=SlotState.READY)
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ConnectError("connection refused", request=req)
+        return httpx.Response(200, json={"ok": True})
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm=sm)
+    try:
+        resp = await dispatcher.forward(_slot_call())
+        assert resp.status_code == 200
+        assert calls["n"] == 2, "expected exactly one retry after recovery"
+        assert sm.recover_calls == ["primary"]
+        # SERVING enter/exit must still balance after a recovered request.
+        assert sm.in_flight_count("primary") == 0
+        assert sm.events == [("enter", "primary"), ("exit", "primary")]
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_forward_gives_up_when_retry_after_recovery_still_fails() -> None:
+    """If the retry forward also gets ConnectError, surface UpstreamUnavailable.
+
+    Prevents an infinite recover-retry loop when lemond is genuinely down
+    (not just an idle eviction).  recover_evicted_slot is called exactly
+    once; the second ConnectError is fatal.
+    """
+    sm = _RecordingSlotManager(state=SlotState.READY)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("still refused", request=req)
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm=sm)
+    try:
+        with pytest.raises(UpstreamUnavailable):
+            await dispatcher.forward(_slot_call())
+        assert sm.recover_calls == ["primary"], "exactly one recovery attempt"
+        assert sm.in_flight_count("primary") == 0
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_forward_remote_connect_error_does_not_attempt_recovery() -> None:
+    """Remote upstreams (no slot_name) skip the slot-recovery branch.
+
+    Recovery only makes sense for slot upstreams whose port is owned by
+    lemonade.  Remote providers (OpenRouter, Anthropic) have nothing for
+    SlotManager to recover, and calling it would either no-op or crash.
+    """
+    sm = _RecordingSlotManager()
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("nope", request=req)
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm=sm)
+    try:
+        with pytest.raises(UpstreamUnavailable):
+            await dispatcher.forward(_remote_call())
+        assert sm.recover_calls == []
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_forward_streaming_recovers_from_silent_eviction() -> None:
+    """Streaming requests get the same recovery treatment as non-streaming.
+
+    The stream is opened eagerly before the handler returns, so a
+    ConnectError on stream-open is recoverable the same way.
+    """
+    sm = _RecordingSlotManager(state=SlotState.READY)
+    chunks = [b"data: 1\n\n", b"data: [DONE]\n\n"]
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ConnectError("dead port", request=req)
+        return httpx.Response(
+            200,
+            stream=httpx.ByteStream(b"".join(chunks)),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm=sm)
+    try:
+        resp = await dispatcher.forward(_slot_call(streaming=True))
+        collected = b""
+        async for c in resp.body_iterator:
+            collected += c if isinstance(c, bytes) else c.encode()
+        assert collected == b"".join(chunks)
+        assert sm.recover_calls == ["primary"]
+        assert sm.in_flight_count("primary") == 0
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_forward_recovers_from_remote_protocol_error() -> None:
+    """RemoteProtocolError (peer dropped mid-request) also triggers recovery.
+
+    The race window where lemonade evicts the child while hal0 is dialing
+    surfaces as RemoteProtocolError rather than ConnectError — the TCP
+    handshake completed but the peer closed before responding.  Recovery
+    must cover both transport failure modes.
+    """
+    sm = _RecordingSlotManager(state=SlotState.READY)
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.RemoteProtocolError(
+                "Server disconnected without sending a response.",
+                request=req,
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm=sm)
+    try:
+        resp = await dispatcher.forward(_slot_call())
+        assert resp.status_code == 200
+        assert calls["n"] == 2
+        assert sm.recover_calls == ["primary"]
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_forward_gives_up_when_recover_evicted_slot_itself_raises() -> None:
+    """If recover_evicted_slot raises, fall back to the original ConnectError.
+
+    Recovery errors are not retried — surfacing UpstreamUnavailable with
+    the original connection error is more informative than swallowing it
+    behind a recovery-time failure.
+    """
+    sm = _RecordingSlotManager(
+        state=SlotState.READY,
+        recover_raises=RuntimeError("lemonade unreachable"),
+    )
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=req)
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm=sm)
+    try:
+        with pytest.raises(UpstreamUnavailable):
+            await dispatcher.forward(_slot_call())
+        assert sm.recover_calls == ["primary"]
     finally:
         await dispatcher.aclose()


### PR DESCRIPTION
## Summary

Chats returned **502 `dispatch.upstream_unavailable`** when Lemonade
silently evicted a slot's child (idle/OOM) but hal0's in-memory state
still said the slot was READY/SERVING/IDLE.  The swap-window gate from
#385 only catches *known* non-ready states; the state-drift window
bypasses it entirely and lands on a dead port.

User-reported trace:

```
chat-completions 502: {"error":{"code":"dispatch.upstream_unavailable",
  "details":{"upstream":"primary",
             "target":"http://127.0.0.1:8001/v1/chat/completions",
             "error":"ConnectError"}}}
```

## Fix

Two pieces:

- **`src/hal0/slots/manager.py`** — new `SlotManager.recover_evicted_slot()`
  drives a full unload + load cycle.  Unload forces lemond to drop its
  `loaded[]` entry (a bare `/v1/load` returns success without
  re-spawning when `loaded[]` still claims a model on a dead PID); load
  then re-spawns the child.  Unload failure is logged but doesn't bail —
  load may still succeed.

- **`src/hal0/dispatcher/router.py`** — `_forward_direct` and
  `_forward_streaming` retry once after a *recoverable* transport
  error from a slot upstream.  Recoverable set:
    - `httpx.ConnectError` — TCP refused before request
    - `httpx.RemoteProtocolError` — peer dropped mid-request (the
      eviction-race signature)

  Read/write timeouts are intentionally excluded — those usually mean
  overload, not death.  Attempt-1 cap prevents infinite loops; recovery
  itself raising falls back to the original `UpstreamUnavailable`
  envelope so the error trail stays useful.

## Why not change the dispatch target instead?

Routing the data plane through lemond's `/api/v1/chat/completions`
(port 13305) was considered but rejected — both upstream Lemonade and
`hal0/lemonade/client.py:5-6` explicitly call out the control-plane /
data-plane split as a perf design decision.  This fix preserves that
boundary and adds lazy recovery at the existing seam.

## Test coverage

Six new dispatcher tests in `tests/dispatcher/test_serving_integration.py`:

- `test_forward_recovers_from_silent_eviction_and_retries` — happy path
- `test_forward_gives_up_when_retry_after_recovery_still_fails` — no infinite loop
- `test_forward_remote_connect_error_does_not_attempt_recovery` — remote upstreams skip recovery
- `test_forward_streaming_recovers_from_silent_eviction` — streaming gets same treatment
- `test_forward_recovers_from_remote_protocol_error` — peer-dropped variant
- `test_forward_gives_up_when_recover_evicted_slot_itself_raises` — recover failure surfaces original error

215 dispatcher + slots tests pass; ruff check + format clean.

## LXC verification

Recovery branch confirmed end-to-end on hal0 LXC under the
orphan-process trigger:

```
dispatch.upstream_dead_attempting_recover  slot=primary
slot.recover_evicted_dispatched
lemonade.provider.unload
lemonade.provider.load
dispatch.upstream_recovered
```

## Known limitation (out of scope)

If lemond re-spawns the child on a port other than the one hal0's slot
config expects, the retry's `target_url` is stale and still hits the
dead port.  Root cause: `LemonadeProvider.load` doesn't pass a port
hint to `/v1/load`, and hal0 never reads `backend_url` back from
`/v1/health`.  Separate issue; logged for follow-up.

## Related

- #385 — swap-window gate (complementary).  Together they cover the
  full eviction lifecycle: gate catches known-not-ready, this PR
  catches state-drift.
- ADR-0008 — Lemonade integration boundary.

## Test plan

- [x] `pytest tests/dispatcher/ tests/slots/`
- [x] `ruff check` + `ruff format --check`
- [x] LXC smoke: trace recovery branch firing under orphan-process repro
- [ ] Production validation: monitor `dispatch.upstream_dead_attempting_recover` rate over the next week to verify it catches real silent evictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)