### PR TITLE
v0.3: hal0-cognee MemoryProvider (wraps hal0-memory REST; locks #317)

### DIFF
--- a/src/hal0/agents/hermes/__init__.py
+++ b/src/hal0/agents/hermes/__init__.py
@@ -9,3 +9,7 @@ See ``installer/agents/hermes/plugins/`` for the legacy mirror location
 that the bootstrap copies from today. PR-3 (hermes_provision overhaul)
 will switch the copy source to this tree.
 """
+
+from hal0.agents.hermes.driver import HermesDriver
+
+__all__ = ["HermesDriver"]

--- a/src/hal0/agents/hermes/__init__.py
+++ b/src/hal0/agents/hermes/__init__.py
@@ -1,0 +1,11 @@
+"""Hermes agent vendored sources.
+
+Holds Python code that ships INSIDE the Hermes agent's plugin tree at
+provision time. These modules are NOT imported by hal0 itself; they
+target the hermes-agent venv where the upstream ``agent.memory_provider``
+and friends resolve.
+
+See ``installer/agents/hermes/plugins/`` for the legacy mirror location
+that the bootstrap copies from today. PR-3 (hermes_provision overhaul)
+will switch the copy source to this tree.
+"""

--- a/src/hal0/agents/hermes/driver.py
+++ b/src/hal0/agents/hermes/driver.py
@@ -48,9 +48,11 @@ _INSTALLER_SCRIPT_REL = "installer/agents/hermes-agent.sh"
 
 
 def _installer_script_path() -> Path:
-    # parents[0]=agents, [1]=hal0, [2]=src, [3]=repo root — same
-    # resolution shape as :func:`installer_script_path` in the manager.
-    repo_root = Path(__file__).resolve().parents[3]
+    # parents[0]=hermes, [1]=agents, [2]=hal0, [3]=src, [4]=repo root.
+    # Bumped by one when driver.py moved from src/hal0/agents/hermes.py
+    # to src/hal0/agents/hermes/driver.py to make room for the vendored
+    # plugin tree (memory_cognee etc.).
+    repo_root = Path(__file__).resolve().parents[4]
     return repo_root / _INSTALLER_SCRIPT_REL
 
 

--- a/src/hal0/agents/hermes/plugins/__init__.py
+++ b/src/hal0/agents/hermes/plugins/__init__.py
@@ -1,0 +1,6 @@
+"""Hermes plugin sources vendored under hal0's tree.
+
+Each subdirectory mirrors a Hermes plugin layout (``__init__.py`` +
+``plugin.yaml`` + optional ``README.md``). The installer copies the
+directory verbatim into ``$HERMES_HOME/plugins/<category>/<name>/``.
+"""

--- a/src/hal0/agents/hermes/plugins/memory_cognee/README.md
+++ b/src/hal0/agents/hermes/plugins/memory_cognee/README.md
@@ -1,0 +1,86 @@
+# hal0-cognee
+
+`MemoryProvider` plugin for the Hermes agent runtime. Wraps the
+hal0-memory REST surface (`/api/memory/*` on hal0-api) so that Hermes's
+durable memory is backed by hal0's embedded Cognee store.
+
+This plugin lives under hal0's repo (`src/hal0/agents/hermes/plugins/memory_cognee/`)
+and is vendored into the Hermes plugin tree at provision time by
+`hal0.agents.hermes_provision._phase_install`. It is NOT imported by
+hal0 itself — the upstream `agent.memory_provider` ABC resolves inside
+the hermes-agent venv at runtime.
+
+## Contract summary
+
+| Item | Value |
+|---|---|
+| Plugin name | `hal0-cognee` |
+| Kind | `exclusive` (per `MemoryManager` single-provider invariant) |
+| Base URL | `HAL0_MEMORY_BASE` env, defaults `http://127.0.0.1:8080` |
+| Identity | `X-hal0-Agent: $HAL0_AGENT_ID` header (defaults `hermes-agent`) |
+| Dataset field | **NEVER SENT** — server resolves from header (issue #317) |
+| Timeouts | 3s connect / 10s read |
+| Tool schemas | None — memory surfaces via system prompt + prefetch context |
+| Operator CRUD | Via the `hal0-memory` MCP server (loaded separately) |
+
+## Why no `dataset` field
+
+The hal0-memory REST routes call `resolve_write_dataset(requested,
+private, client_id)` (`src/hal0/api/routes/memory.py:291`). When the
+client omits an explicit dataset, the server reads `X-hal0-Agent` and
+routes the write to `private:<agent_id>`. Sending an explicit
+`private:hermes-agent` re-trips the `_AGENT_ID_PATTERN` reject in
+`src/hal0/mcp/memory.py:200` — the same bug the retired
+`hal0-memory` plugin stub caused at
+`installer/agents/hermes/plugins/hal0-memory/__init__.py:117`.
+
+The regression test in
+`tests/agents/hermes_plugins/test_memory_cognee_provider.py` asserts
+that no outbound REST payload carries a `dataset` key, locking the
+fix.
+
+## ABC surface implemented
+
+From `agent/memory_provider.py:42`:
+
+* `name` (property) — returns `"hal0-cognee"`.
+* `is_available()` — `True` unconditionally (config-only check; no
+  network call per ABC docstring).
+* `initialize(session_id, **kwargs)` — opens the async client, honours
+  `agent_context` so cron/flush/subagent loops skip writes (the same
+  guard honcho and supermemory ship).
+* `system_prompt_block()` — short memory-availability preamble.
+* `prefetch(query, *, session_id)` — best-effort `/api/memory/search`
+  with a 5-item budget; transport failures fall back to empty string.
+* `sync_turn(user, assistant, *, session_id)` — fire-and-forget
+  `/api/memory/add`; honours `_SKIP_WRITE_CONTEXTS`.
+* `get_tool_schemas()` — returns `[]`. Memory tools live on the
+  MCP path so they don't double-register against the agent loop.
+* `on_memory_write(action, target, content, metadata=None)` — mirrors
+  the built-in memory tool's writes into hal0-cognee.
+* `shutdown()` — closes the owned `httpx.AsyncClient`.
+
+## Integration wiring (PR-3)
+
+PR-3 (hermes_provision overhaul) will:
+
+1. Copy this directory into `$HERMES_HOME/plugins/memory/hal0-cognee/`
+   at `_phase_install` time.
+2. Set `memory.provider = "hal0-cognee"` in `$HERMES_HOME/config.yaml`.
+3. Drop the retired `installer/agents/hermes/plugins/hal0-memory/`
+   stub.
+
+End-to-end LXC smoke (provider loads, prefetch returns, sync_turn
+writes hit hal0-memory) is deferred to that PR. This PR ships the
+plugin sources + unit tests only.
+
+## Environment variables
+
+| Var | Default | Purpose |
+|---|---|---|
+| `HAL0_MEMORY_BASE` | `http://127.0.0.1:8080` | hal0-api base URL |
+| `HAL0_AGENT_ID` | `hermes-agent` | Identity for `X-hal0-Agent` |
+
+Both are read from the environment at `initialize()` time so per-agent
+unit overrides (PR-5 `hal0-agent@hermes.service`) take effect on
+provider construction without restart.

--- a/src/hal0/agents/hermes/plugins/memory_cognee/__init__.py
+++ b/src/hal0/agents/hermes/plugins/memory_cognee/__init__.py
@@ -1,0 +1,40 @@
+"""hal0-cognee — Hermes ``MemoryProvider`` plugin (issue #240 / PR-2).
+
+This package is COPIED verbatim into
+``$HERMES_HOME/plugins/memory/hal0-cognee/`` at provision time by
+``hal0.agents.hermes_provision._phase_install`` (rework lands in PR-3).
+At runtime it resolves against the hermes-agent venv, where the
+``agent.memory_provider`` ABC lives.
+
+Discovery contract (per upstream ``plugins/memory/__init__.py``):
+
+* Bundled-or-user plugin directory must contain an ``__init__.py`` that
+  either exposes a top-level ``MemoryProvider`` subclass OR a
+  ``register(ctx)`` callable. We ship both so either discovery path
+  works:
+
+  * Re-export ``Hal0CogneeProvider`` so the fallback ``find a subclass``
+    branch at ``plugins/memory/__init__.py:_load_provider_from_dir``
+    picks it up.
+  * Provide ``register(ctx)`` so the preferred path (``_ProviderCollector``)
+    fires ``ctx.register_memory_provider(...)``.
+
+* ``plugin.yaml`` keeps ``kind: exclusive`` per ``MemoryManager``'s
+  single-external-provider invariant.
+"""
+
+from __future__ import annotations
+
+from .provider import Hal0CogneeProvider
+
+__all__ = ["Hal0CogneeProvider", "register"]
+
+
+def register(ctx) -> None:  # type: ignore[no-untyped-def]
+    """Plugin entry point — registers the provider with the loader.
+
+    ``ctx`` is the upstream ``PluginContext`` (or ``_ProviderCollector``
+    test double). It exposes ``register_memory_provider(provider)`` per
+    ``hermes-agent/plugins/memory/__init__.py:_ProviderCollector:288``.
+    """
+    ctx.register_memory_provider(Hal0CogneeProvider())

--- a/src/hal0/agents/hermes/plugins/memory_cognee/_client.py
+++ b/src/hal0/agents/hermes/plugins/memory_cognee/_client.py
@@ -1,0 +1,180 @@
+"""Thin async REST client for the hal0-memory REST surface.
+
+Talks to hal0-api's ``/api/memory/*`` routes, NOT the ``/mcp/memory``
+JSON-RPC transport. Identity is carried via ``X-hal0-Agent`` per
+ADR-0012 + PR #268 — there is no Bearer auth on the hal0 LAN.
+
+#317 contract: this client NEVER sends a ``dataset`` field. The server
+resolves the write target from ``X-hal0-Agent`` (see PR #366
+``resolve_write_dataset``). Sending an explicit ``private:<id>`` here
+re-trips the ``_AGENT_ID_PATTERN`` reject that the old
+``installer/agents/hermes/plugins/hal0-memory/__init__.py:117`` stub
+caused.
+
+The client is intentionally tiny — no retries, no circuit breaker. The
+Hermes agent loop already wraps memory hooks in best-effort try/except;
+re-implementing that here would just double the failure modes.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8080"
+DEFAULT_AGENT_ID = "hermes-agent"
+DEFAULT_CONNECT_TIMEOUT = 3.0
+DEFAULT_READ_TIMEOUT = 10.0
+
+
+class Hal0MemoryClientError(RuntimeError):
+    """Raised when a hal0-memory REST call fails.
+
+    Wraps the upstream status code + response body so callers can either
+    swallow the error (best-effort memory hooks) or surface it via the
+    upstream ``MemoryProviderError`` taxonomy. We intentionally do NOT
+    import ``agent.memory_provider`` here so this module stays
+    importable inside hal0's own venv for unit testing.
+    """
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _resolve_base_url(override: str | None) -> str:
+    if override:
+        return override.rstrip("/")
+    raw = os.environ.get("HAL0_MEMORY_BASE", DEFAULT_BASE_URL)
+    return raw.rstrip("/")
+
+
+def _resolve_agent_id(override: str | None) -> str:
+    if override:
+        return override
+    return os.environ.get("HAL0_AGENT_ID", DEFAULT_AGENT_ID)
+
+
+class Hal0MemoryClient:
+    """Async REST client for hal0-memory.
+
+    Designed to be instantiated once per ``initialize()`` call and reused
+    for the lifetime of the agent session. ``aclose()`` is idempotent.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        agent_id: str | None = None,
+        connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+        read_timeout: float = DEFAULT_READ_TIMEOUT,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._base_url = _resolve_base_url(base_url)
+        self._agent_id = _resolve_agent_id(agent_id)
+        self._owns_client = http_client is None
+        if http_client is None:
+            timeout = httpx.Timeout(read_timeout, connect=connect_timeout)
+            self._client = httpx.AsyncClient(base_url=self._base_url, timeout=timeout)
+        else:
+            self._client = http_client
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    @property
+    def agent_id(self) -> str:
+        return self._agent_id
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "X-hal0-Agent": self._agent_id,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    # ── REST verbs ─────────────────────────────────────────────────────
+
+    async def add(
+        self,
+        text: str,
+        *,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """POST /api/memory/add — record a memory item.
+
+        Omits the ``dataset`` key intentionally; the server resolves it
+        from ``X-hal0-Agent``. See module docstring for the #317 contract.
+        """
+        payload: dict[str, Any] = {"text": text}
+        if tags is not None:
+            payload["tags"] = list(tags)
+        if metadata is not None:
+            payload["metadata"] = dict(metadata)
+        return await self._request("POST", "/api/memory/add", json=payload)
+
+    async def search(self, query: str, *, limit: int = 5) -> dict[str, Any]:
+        """POST /api/memory/search — semantic retrieval.
+
+        Omits ``dataset`` by design (see ``add``).
+        """
+        payload = {"query": query, "limit": int(limit)}
+        return await self._request("POST", "/api/memory/search", json=payload)
+
+    async def list_items(self, *, limit: int = 50) -> dict[str, Any]:
+        """GET /api/memory — page through stored items.
+
+        ``limit`` is forwarded as a query parameter so the server can
+        cap the response; pagination cursors are an upstream concern.
+        """
+        return await self._request("GET", "/api/memory", params={"limit": int(limit)})
+
+    async def delete(self, item_id: str) -> dict[str, Any]:
+        """DELETE /api/memory/{id} — remove a single memory item."""
+        return await self._request("DELETE", f"/api/memory/{item_id}")
+
+    # ── transport core ─────────────────────────────────────────────────
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        try:
+            response = await self._client.request(
+                method,
+                path,
+                headers=self._headers(),
+                json=json,
+                params=params,
+            )
+        except httpx.HTTPError as exc:
+            raise Hal0MemoryClientError(
+                f"hal0-memory transport failure on {method} {path}: {exc}",
+            ) from exc
+
+        if response.status_code >= 400:
+            raise Hal0MemoryClientError(
+                f"hal0-memory {method} {path} returned {response.status_code}: {response.text[:200]}",
+                status_code=response.status_code,
+            )
+
+        try:
+            data = response.json()
+        except ValueError:
+            return {"status": "ok", "raw": response.text}
+        if isinstance(data, dict):
+            return data
+        return {"status": "ok", "raw": data}

--- a/src/hal0/agents/hermes/plugins/memory_cognee/plugin.yaml
+++ b/src/hal0/agents/hermes/plugins/memory_cognee/plugin.yaml
@@ -1,0 +1,17 @@
+# hal0-cognee — Hermes MemoryProvider plugin (PR-2, issue #240/#242).
+#
+# Wraps hal0-memory REST surface (``/api/memory/*``) and slots into
+# Hermes's MemoryManager via the upstream ABC.  Identity flows through
+# ``X-hal0-Agent`` (sourced from ``HAL0_AGENT_ID``); the server resolves
+# the per-agent dataset, the client never sends one — closes issue #317
+# from the client side (server side fixed in PR #366).
+name: hal0-cognee
+kind: exclusive
+version: 0.1.0
+description: >-
+  hal0-cognee — Cognee-backed memory provider via hal0-memory REST.
+  Per-agent namespace resolved server-side from X-hal0-Agent.
+author: hal0 contributors
+provides_hooks:
+  - on_memory_write
+requires_env: []

--- a/src/hal0/agents/hermes/plugins/memory_cognee/provider.py
+++ b/src/hal0/agents/hermes/plugins/memory_cognee/provider.py
@@ -1,0 +1,224 @@
+"""Hermes ``MemoryProvider`` subclass backed by hal0-memory REST.
+
+Subclasses the upstream ``agent.memory_provider.MemoryProvider`` ABC.
+The import resolves inside the Hermes venv at runtime — when the
+plugin is loaded out of ``$HERMES_HOME/plugins/memory/hal0-cognee/``.
+For hal0's own unit tests we import a vendored stub so the suite stays
+runnable without the hermes-agent venv on PYTHONPATH.
+
+Design notes
+------------
+
+* ``hal0-cognee`` is the new plugin name. The retired ``hal0-memory``
+  stub at ``installer/agents/hermes/plugins/hal0-memory/__init__.py``
+  is replaced by this provider in PR-3.
+* The agent loop's memory hooks (``prefetch``/``sync_turn``) are sync,
+  so we wrap async REST calls via ``asyncio.run``. Each call gets its
+  own event loop so we don't fight whatever loop Hermes hosts above us.
+* The provider is best-effort — transport failures fall back to empty
+  context (prefetch) or silent drop (sync_turn) so a missing hal0-api
+  cannot wedge the agent loop. The upstream ``MemoryProviderError``
+  taxonomy is reserved for explicit tool calls.
+* Identity flows via ``X-hal0-Agent`` (sourced from ``HAL0_AGENT_ID``).
+  We NEVER send a ``dataset`` field — the server resolves the namespace
+  from the header (see ``Hal0MemoryClient`` docstring + #317).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any
+
+try:
+    from agent.memory_provider import MemoryProvider  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover — exercised inside Hermes venv only
+    # Fallback stub so hal0's own test suite can import the provider
+    # without the hermes-agent venv on PYTHONPATH. The real ABC ships
+    # with Hermes; this minimal shim mirrors the abstract surface our
+    # provider actually subclasses against.
+    from abc import ABC, abstractmethod
+
+    class MemoryProvider(ABC):  # type: ignore[no-redef]
+        @property
+        @abstractmethod
+        def name(self) -> str: ...
+
+        @abstractmethod
+        def is_available(self) -> bool: ...
+
+        @abstractmethod
+        def initialize(self, session_id: str, **kwargs: Any) -> None: ...
+
+        @abstractmethod
+        def get_tool_schemas(self) -> list[dict[str, Any]]: ...
+
+
+from ._client import Hal0MemoryClient, Hal0MemoryClientError
+
+logger = logging.getLogger(__name__)
+
+# Honour the same context gate honcho + supermemory ship: skip writes
+# from cron / flush / subagent loops so non-primary contexts don't
+# corrupt the user-facing memory namespace.
+_SKIP_WRITE_CONTEXTS = frozenset({"cron", "flush", "subagent"})
+
+
+class Hal0CogneeProvider(MemoryProvider):  # type: ignore[misc]
+    """REST-backed memory provider — wraps hal0-memory.
+
+    Vendored under hal0's tree so the installer can deploy it into the
+    Hermes plugin directory at provision time. Subclasses the upstream
+    ``MemoryProvider`` ABC; see module docstring for the integration
+    contract.
+    """
+
+    def __init__(self, *, client: Hal0MemoryClient | None = None) -> None:
+        self._client_override = client
+        self._client: Hal0MemoryClient | None = None
+        self._session_id: str = ""
+        self._agent_context: str = "primary"
+
+    # ── ABC: identity ──────────────────────────────────────────────────
+
+    @property
+    def name(self) -> str:
+        return "hal0-cognee"
+
+    # ── ABC: lifecycle ─────────────────────────────────────────────────
+
+    def is_available(self) -> bool:
+        """Cheap config check — does NOT make a network call.
+
+        The ABC docstring is explicit: ``is_available`` must only check
+        installed deps + config. The actual reachability check happens
+        lazily on the first REST call.
+        """
+        # httpx is a hard dep of hal0; we ship the client alongside the
+        # provider. No env-var gate — the defaults already point at the
+        # local hal0-api socket on the same host.
+        return True
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        self._session_id = session_id
+        self._agent_context = str(kwargs.get("agent_context") or "primary")
+        if self._client_override is not None:
+            self._client = self._client_override
+            return
+        base_url = os.environ.get("HAL0_MEMORY_BASE")
+        agent_id = os.environ.get("HAL0_AGENT_ID")
+        self._client = Hal0MemoryClient(base_url=base_url, agent_id=agent_id)
+
+    def shutdown(self) -> None:
+        if self._client is None:
+            return
+        try:
+            asyncio.run(self._client.aclose())
+        except RuntimeError:
+            # Already running an event loop (Hermes shutting down inside
+            # its own loop); fire-and-forget close.
+            logger.debug("hal0-cognee shutdown: nested event loop, skipping aclose")
+        finally:
+            self._client = None
+
+    # ── ABC: prompt + recall ───────────────────────────────────────────
+
+    def system_prompt_block(self) -> str:
+        agent_id = self._client.agent_id if self._client else "hermes-agent"
+        return (
+            "You have a durable memory store at hal0-cognee "
+            f"(private:{agent_id} namespace, resolved server-side). "
+            "Use memory_search before asking repeat-questions; "
+            "memory_add to persist facts worth recalling across sessions."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not query or self._client is None:
+            return ""
+        try:
+            result = asyncio.run(self._client.search(query, limit=5))
+        except Hal0MemoryClientError as exc:
+            logger.debug("hal0-cognee prefetch transport failure: %s", exc)
+            return ""
+        except RuntimeError as exc:  # nested loop or other asyncio drift
+            logger.debug("hal0-cognee prefetch asyncio drift: %s", exc)
+            return ""
+
+        items = result.get("items") if isinstance(result, dict) else None
+        if not items:
+            return ""
+        lines = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            text = item.get("text") or item.get("content") or ""
+            if text:
+                lines.append(f"- {text}")
+        if not lines:
+            return ""
+        return "## hal0-cognee memory\n" + "\n".join(lines)
+
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        *,
+        session_id: str = "",
+    ) -> None:
+        if self._client is None:
+            return
+        if self._agent_context in _SKIP_WRITE_CONTEXTS:
+            return
+        if not user_content and not assistant_content:
+            return
+        text = f"User: {user_content}\nAssistant: {assistant_content}"
+        try:
+            asyncio.run(self._client.add(text, tags=["chat", "hermes"]))
+        except Hal0MemoryClientError as exc:
+            logger.debug("hal0-cognee sync_turn transport failure: %s", exc)
+        except RuntimeError as exc:
+            logger.debug("hal0-cognee sync_turn asyncio drift: %s", exc)
+
+    # ── ABC: tools ─────────────────────────────────────────────────────
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        """No model-visible tools.
+
+        Memory surfaces via the system-prompt block + prefetch context.
+        Operator-driven CRUD is exposed via the ``hal0-memory`` MCP
+        server which Hermes loads from ``mcp_servers`` config (PR-3).
+        Keeping the tool list empty avoids schema bloat that competes
+        with the MCP path.
+        """
+        return []
+
+    def handle_tool_call(self, tool_name: str, args: dict[str, Any], **kwargs: Any) -> str:
+        # Defensive: ``get_tool_schemas`` returns []; the loop should
+        # never reach this branch. Match the upstream ABC contract by
+        # returning a JSON-encoded error string.
+        return json.dumps(
+            {"status": "error", "error": f"hal0-cognee exposes no tool '{tool_name}'"}
+        )
+
+    # ── Optional hook: mirror built-in memory writes ───────────────────
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        if action != "add" or self._client is None or not content:
+            return
+        if self._agent_context in _SKIP_WRITE_CONTEXTS:
+            return
+        tags = ["builtin-memory", target] if target else ["builtin-memory"]
+        try:
+            asyncio.run(self._client.add(content, tags=tags, metadata=metadata))
+        except Hal0MemoryClientError as exc:
+            logger.debug("hal0-cognee on_memory_write transport failure: %s", exc)
+        except RuntimeError as exc:
+            logger.debug("hal0-cognee on_memory_write asyncio drift: %s", exc)

--- a/tests/agents/hermes_plugins/test_memory_cognee_provider.py
+++ b/tests/agents/hermes_plugins/test_memory_cognee_provider.py
@@ -1,0 +1,258 @@
+"""Tests for the vendored hal0-cognee Hermes ``MemoryProvider`` plugin.
+
+Locks the PR-2 contract:
+
+* ABC method surface present + callable.
+* Outbound REST payload NEVER carries a ``dataset`` field (issue #317
+  client-side regression lock; server-side fix shipped in PR #366).
+* ``X-hal0-Agent`` header sourced from ``HAL0_AGENT_ID`` env.
+* ``HAL0_MEMORY_BASE`` override is honoured.
+* Server 5xx → ``Hal0MemoryClientError`` from the client, ``prefetch``
+  + ``sync_turn`` swallow it (best-effort hooks) and downgrade to no-op.
+
+The tests stub ``httpx.AsyncClient`` via ``httpx.MockTransport`` — same
+pattern the rest of the hal0 suite uses (see ``tests/lemonade/test_client.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from hal0.agents.hermes.plugins.memory_cognee import Hal0CogneeProvider, register
+from hal0.agents.hermes.plugins.memory_cognee._client import (
+    Hal0MemoryClient,
+    Hal0MemoryClientError,
+)
+from hal0.agents.hermes.plugins.memory_cognee.provider import MemoryProvider
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+class _RequestSpy:
+    """Captures every outbound httpx.Request the client emits."""
+
+    def __init__(self) -> None:
+        self.calls: list[httpx.Request] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.calls.append(request)
+        return httpx.Response(200, json={"items": [], "status": "ok"})
+
+
+def _make_provider(
+    handler,
+    *,
+    base_url: str = "http://test",
+    agent_id: str = "spy-agent",
+) -> Hal0CogneeProvider:
+    """Build a provider wired to an httpx.MockTransport-backed client."""
+    transport = httpx.MockTransport(handler)
+    async_client = httpx.AsyncClient(transport=transport, base_url=base_url)
+    client = Hal0MemoryClient(
+        base_url=base_url,
+        agent_id=agent_id,
+        http_client=async_client,
+    )
+    return Hal0CogneeProvider(client=client)
+
+
+# ── ABC compliance ────────────────────────────────────────────────────
+
+
+def test_provider_subclasses_memory_provider_abc() -> None:
+    provider = Hal0CogneeProvider()
+    assert isinstance(provider, MemoryProvider)
+
+
+def test_provider_implements_all_abstract_methods() -> None:
+    provider = Hal0CogneeProvider()
+    # name (property) + the four ABC-required abstracts
+    assert provider.name == "hal0-cognee"
+    assert provider.is_available() is True
+    assert provider.get_tool_schemas() == []
+    # initialize must accept (session_id, **kwargs)
+    provider.initialize("sess-1", agent_context="primary")
+    provider.shutdown()
+
+
+def test_register_collects_provider_via_ctx() -> None:
+    class FakeCtx:
+        def __init__(self) -> None:
+            self.provider: Any = None
+
+        def register_memory_provider(self, provider: Any) -> None:
+            self.provider = provider
+
+    ctx = FakeCtx()
+    register(ctx)
+    assert isinstance(ctx.provider, Hal0CogneeProvider)
+
+
+# ── identity / headers ────────────────────────────────────────────────
+
+
+def test_x_hal0_agent_header_set_from_provider_agent_id() -> None:
+    spy = _RequestSpy()
+    provider = _make_provider(spy, agent_id="hermes-agent-test")
+    provider.initialize("sess-x")
+
+    # Drive any REST verb — all paths set the identity header.
+    provider.sync_turn("hello", "hi back")
+
+    assert spy.calls, "sync_turn should have emitted at least one request"
+    assert spy.calls[0].headers.get("X-hal0-Agent") == "hermes-agent-test"
+
+
+def test_agent_id_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_AGENT_ID", "from-env")
+    monkeypatch.delenv("HAL0_MEMORY_BASE", raising=False)
+    client = Hal0MemoryClient()
+    try:
+        assert client.agent_id == "from-env"
+    finally:
+        # No live transport; aclose is a no-op against the unused client.
+        pass
+
+
+def test_base_url_honours_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_MEMORY_BASE", "http://hal0.lan:9999/")
+    monkeypatch.setenv("HAL0_AGENT_ID", "x")
+    client = Hal0MemoryClient()
+    # Trailing slash stripped so path joins stay clean.
+    assert client.base_url == "http://hal0.lan:9999"
+
+
+# ── #317 regression lock — payload MUST NOT carry "dataset" ──────────
+
+
+def test_add_payload_omits_dataset_key() -> None:
+    spy = _RequestSpy()
+    provider = _make_provider(spy)
+    provider.initialize("sess-d")
+
+    provider.sync_turn("u", "a")
+
+    assert spy.calls, "sync_turn should have produced a request"
+    request = spy.calls[0]
+    assert request.method == "POST"
+    assert request.url.path == "/api/memory/add"
+    body = _decode_json_body(request)
+    assert "dataset" not in body, (
+        "client must not send a `dataset` field — server resolves the "
+        "private namespace from X-hal0-Agent (issue #317)"
+    )
+    # Sanity: the text payload we DO send shows up intact so this isn't
+    # an accidental no-op route hit.
+    assert "User: u" in body.get("text", "")
+
+
+def test_search_payload_omits_dataset_key() -> None:
+    spy = _RequestSpy()
+    provider = _make_provider(spy)
+    provider.initialize("sess-s")
+
+    provider.prefetch("how do I deploy?")
+
+    assert spy.calls, "prefetch should have produced a request"
+    request = spy.calls[0]
+    assert request.method == "POST"
+    assert request.url.path == "/api/memory/search"
+    body = _decode_json_body(request)
+    assert "dataset" not in body
+    assert body.get("query") == "how do I deploy?"
+
+
+def test_on_memory_write_mirror_omits_dataset_key() -> None:
+    spy = _RequestSpy()
+    provider = _make_provider(spy)
+    provider.initialize("sess-m")
+
+    provider.on_memory_write("add", "user", "user prefers dark mode")
+
+    assert spy.calls, "on_memory_write should mirror to /api/memory/add"
+    body = _decode_json_body(spy.calls[0])
+    assert "dataset" not in body
+    assert body.get("text") == "user prefers dark mode"
+
+
+# ── error mapping ─────────────────────────────────────────────────────
+
+
+def test_client_raises_on_5xx() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "kaboom"})
+
+    transport = httpx.MockTransport(handler)
+    async_client = httpx.AsyncClient(transport=transport, base_url="http://test")
+    client = Hal0MemoryClient(
+        base_url="http://test",
+        agent_id="t",
+        http_client=async_client,
+    )
+
+    import asyncio
+
+    with pytest.raises(Hal0MemoryClientError) as exc_info:
+        asyncio.run(client.add("anything"))
+    assert exc_info.value.status_code == 500
+
+
+def test_prefetch_swallows_transport_failure() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"error": "down"})
+
+    provider = _make_provider(handler)
+    provider.initialize("sess-err")
+
+    # Best-effort hook: a server error must NOT propagate.
+    assert provider.prefetch("ignored") == ""
+
+
+def test_sync_turn_swallows_transport_failure() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    provider = _make_provider(handler)
+    provider.initialize("sess-err")
+
+    # Returns None silently; the assertion is "did not raise".
+    assert provider.sync_turn("u", "a") is None
+
+
+# ── write-context gate ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("ctx", ["cron", "flush", "subagent"])
+def test_sync_turn_skipped_for_non_primary_contexts(ctx: str) -> None:
+    spy = _RequestSpy()
+    provider = _make_provider(spy)
+    provider.initialize("sess-skip", agent_context=ctx)
+
+    provider.sync_turn("u", "a")
+
+    assert spy.calls == [], f"sync_turn must skip writes in {ctx!r} context"
+
+
+def test_sync_turn_runs_for_primary_context() -> None:
+    spy = _RequestSpy()
+    provider = _make_provider(spy)
+    provider.initialize("sess-prim", agent_context="primary")
+
+    provider.sync_turn("u", "a")
+
+    assert len(spy.calls) == 1
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+def _decode_json_body(request: httpx.Request) -> dict[str, Any]:
+    import json
+
+    raw = request.content
+    if not raw:
+        return {}
+    return json.loads(raw.decode("utf-8"))


### PR DESCRIPTION
## Summary
- New Hermes MemoryProvider subclass wrapping hal0-memory REST API
- httpx async REST client; `X-hal0-Agent` header; **no `dataset` field**
- Vendored under `src/hal0/agents/hermes/plugins/memory_cognee/` for installer-time deploy
- Closes the client side of issue #317 (server side fixed in PR #366)

## Test plan
- [x] ABC compliance unit test
- [x] Outbound payload OMITS `dataset` (#317 regression lock — `add`, `search`, `on_memory_write` mirror)
- [x] `X-hal0-Agent` header round-trip from `HAL0_AGENT_ID`
- [x] `HAL0_MEMORY_BASE` env override honoured
- [x] Server-error mapping → `Hal0MemoryClientError` on the client; `prefetch`/`sync_turn` swallow it
- [x] cron/flush/subagent context gate skips writes
- [x] `ruff format --check` / `ruff check` / `mypy src/hal0/agents/hermes/` / `pytest tests/agents/hermes_plugins/`
- [ ] Hermes integration wiring (PR-3, in flight) — `hermes_provision._phase_install` copy + `memory.provider = "hal0-cognee"` in config.yaml + retire `installer/agents/hermes/plugins/hal0-memory/`
- [ ] Live LXC end-to-end (after PR-3 lands)

Refs MASTER-PLAN.md §4 PR-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)