### PR TITLE
v0.3 PR-5: hal0-agent@.service template + hal0-agent CLI shim (Lemonade-deadlock-resistant, event-emitting mode)

### DIFF
--- a/docs/agents/hermes/SERVICE.md
+++ b/docs/agents/hermes/SERVICE.md
@@ -1,0 +1,200 @@
+# `hal0-agent@hermes.service` — operator recipes
+
+The Hermes agent runs as a systemd template instance under the
+**`hal0-agent@.service`** template. This page covers start/stop/status,
+restarts, logs, journals, and the failure modes you'll hit in practice.
+
+For the full Hermes provisioning pipeline (the thing that lays down
+`$HERMES_HOME`, `plugins/`, and `runtime.json`) see
+[`hermes-bootstrap.md`](../hermes-bootstrap.md). For the chat surface
+that consumes the agent's `/api/events` and `/api/pty` streams, see the
+v0.3 architecture notes under `docs/internal/`.
+
+## TL;DR
+
+```bash
+sudo systemctl start  hal0-agent@hermes.service     # boot
+sudo systemctl stop   hal0-agent@hermes.service     # shut down
+sudo systemctl status hal0-agent@hermes.service     # one-screen state
+sudo journalctl -u    hal0-agent@hermes.service -f  # follow logs
+hal0-agent hermes status                            # health-URL probe
+```
+
+The unit is **enabled at install time** by `installer/install.sh` after
+`hal0 agent bootstrap hermes` runs successfully — you should never have
+to enable it by hand.
+
+## What the unit actually runs
+
+`ExecStart=/usr/local/bin/hal0-agent %i serve` where `%i` is the
+instance id (`hermes` for this unit). The `hal0-agent` shim then
+invokes:
+
+```
+/var/lib/hal0/venvs/hermes/bin/hermes dashboard \
+  --host 127.0.0.1 --port 9119 \
+  --tui --no-open --skip-build
+```
+
+The **`dashboard --tui`** subcommand is the only Hermes mode that boots
+`hermes_cli/web_server.py`, which is where the `/api/pty`, `/api/events`,
+and `/api/ws` endpoints live — the ones hal0's chat surface consumes.
+
+**Do not** rewrite the unit to call `hermes mcp serve`. That mode runs
+an MCP query server with no event stream and no PTY; the chat surface
+would render blank with no errors.
+
+## Where things live
+
+| Path | What |
+|---|---|
+| `/etc/systemd/system/hal0-agent@.service` | the template unit |
+| `/etc/systemd/system/hal0-agent@hermes.service.d/override.conf` | hermes-specific env |
+| `/etc/hal0/agents/hermes.env` (optional) | operator overrides (HERMES_HOME, port, …) |
+| `/etc/hal0/agents/hermes.toml` (optional) | shim config (overrides builtin defaults) |
+| `/var/lib/hal0/venvs/hermes/` | the agent's venv — `hermes` binary lives in `bin/` |
+| `/var/lib/hal0/agents/hermes/` | `$HERMES_HOME` (config, personas, plugins) |
+| `/run/hal0/` | sockets, lock files |
+| `/var/log/hal0/` | hal0-side log overflow (most logs go to journald) |
+
+## Lifecycle
+
+### First-boot wiring
+
+`installer/install.sh` (post-bootstrap section) runs:
+
+```
+cp installer/systemd/hal0-agent@.service \
+   /etc/systemd/system/hal0-agent@.service
+mkdir -p /etc/systemd/system/hal0-agent@hermes.service.d
+cp installer/systemd/hal0-agent@hermes.service.d/override.conf \
+   /etc/systemd/system/hal0-agent@hermes.service.d/override.conf
+systemctl daemon-reload
+systemctl enable --now hal0-agent@hermes.service
+```
+
+The `systemctl enable --now` is gated on `hal0 agent bootstrap hermes`
+having completed — if the venv at `/var/lib/hal0/venvs/hermes` isn't
+present yet, the shim's `cmd_serve` will bail with a "run bootstrap
+first" message and systemd will mark the unit failed (correctly — the
+agent has nothing to run).
+
+### Restart / reload
+
+* **Restart** (after editing `override.conf` or upgrading the wheel):
+  `sudo systemctl daemon-reload && sudo systemctl restart hal0-agent@hermes.service`
+* **Persona reload without restart** (Hermes re-reads
+  `overrides.yaml` on `SIGHUP`):
+  `sudo systemctl kill -s HUP hal0-agent@hermes.service`
+* **Re-provision** (re-render configs, replay bootstrap phases):
+  `hal0-agent hermes reprovision` — wraps `hal0 agent bootstrap hermes --repair`.
+
+### Stop
+
+`systemctl stop` sends `SIGTERM`; the shim forwards it to the Hermes
+child and waits up to 15s for clean exit (matches `TimeoutStopSec=`).
+Beyond that systemd `SIGKILL`s the cgroup.
+
+If `systemctl stop` ever hangs, run `hal0-agent hermes stop` directly —
+it scans `/proc` for processes matching the agent's venv binary AND
+`HAL0_AGENT_ID=hermes`, SIGTERMs them, then `SIGKILL`s after 10s.
+
+## Health checks
+
+| What | How |
+|---|---|
+| Is systemd happy? | `systemctl is-active hal0-agent@hermes.service` |
+| Is the HTTP surface up? | `hal0-agent hermes status` (probes `http://127.0.0.1:9119/api/health`) |
+| Last 60 log lines? | `journalctl -u hal0-agent@hermes.service -n 60 --no-pager` |
+| Watchdog trips? | `systemctl show hal0-agent@hermes.service -p NRestarts` |
+
+The unit is `Type=notify` with `WatchdogSec=60`. The shim pings
+`WATCHDOG=1` every 25s as long as the child is alive AND
+`/api/health` responds. A hung Hermes (alive but unresponsive) trips
+the watchdog after 60s and systemd restarts us.
+
+## Failure modes you'll actually hit
+
+### Lemonade unload deadlock (`hal0_lemonade_unload_gpu_cleanup_hang`)
+
+`hal0-lemonade.service` has a known GPU-cleanup-after-unload hang where
+NRestarts stays 0, the port stays open, and `/api/v1/health` times out
+forever. The unit is intentionally wired with `Wants=hal0-lemonade.service`
+(NOT `Requires=` or `BindsTo=`) so this failure mode doesn't pin the
+agent in a permanently-broken "active (running)" state.
+
+When you see chat failing but `systemctl status hal0-agent@hermes`
+green, check lemonade first:
+
+```bash
+ss -tlnp | grep 13305          # port still listening?
+curl -fsS http://127.0.0.1:13305/api/v1/health  # times out?
+systemctl restart hal0-lemonade  # instant fix
+```
+
+### `hermes binary not found`
+
+The shim refused to start because `/var/lib/hal0/venvs/hermes/bin/hermes`
+doesn't exist. Bootstrap was either skipped or failed:
+
+```bash
+hal0 agent bootstrap hermes --repair
+sudo systemctl restart hal0-agent@hermes.service
+```
+
+### Port 9119 already in use
+
+Another hermes (perhaps a manual `hermes dashboard` you forgot about) is
+holding the port. Find it:
+
+```bash
+ss -tlnp | grep 9119
+hal0-agent hermes stop   # SIGTERMs by venv + agent id; ignores other dashboards
+```
+
+### `:13305` lemonade not reachable from the agent
+
+The agent's `HAL0_LEMONADE_BASE` env is wrong (overridden in
+`/etc/hal0/agents/hermes.env`) or lemonade is bound to a different port.
+The default (`127.0.0.1:13305`) matches `installer/install.sh`'s
+lemonade bind — only override if you know why.
+
+## Customising the unit
+
+**Don't edit `hal0-agent@.service` directly** — `hal0 update` will
+overwrite it. Drop overrides in either of:
+
+| File | Scope |
+|---|---|
+| `/etc/systemd/system/hal0-agent@hermes.service.d/local.conf` | this instance only |
+| `/etc/systemd/system/hal0-agent@.service.d/local.conf` | all instances |
+
+Example: bump `WatchdogSec` to 120s for a slow box:
+
+```ini
+# /etc/systemd/system/hal0-agent@hermes.service.d/local.conf
+[Service]
+WatchdogSec=120
+```
+
+Then `systemctl daemon-reload && systemctl restart hal0-agent@hermes.service`.
+
+## Adding a new agent instance (v0.4 preview)
+
+The unit is a template — the same file backs `hal0-agent@piccoder.service`
+or whatever ships next. Wiring a second instance is just:
+
+1. `hal0 agent install <name>` — provisions venv + `$HERMES_HOME`.
+2. (Optional) drop `/etc/hal0/agents/<name>.toml` to override defaults.
+3. `systemctl enable --now hal0-agent@<name>.service`.
+
+The shim resolves the agent type from `[type]` in the toml; builtin ids
+(`hermes` today) work without a toml.
+
+## See also
+
+* [`hermes-bootstrap.md`](../hermes-bootstrap.md) — provisioning state machine
+* [`identity.md`](../identity.md) — `X-hal0-Agent` header and auth model
+* [`mcp-client.md`](../mcp-client.md) — how Hermes talks to hal0-memory + hal0-admin
+* `installer/systemd/hal0-agent@.service` — the unit itself
+* `src/hal0/cli/agent_shim.py` — the shim source

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -515,6 +515,29 @@ else
     warn "${OPENWEBUI_UNIT_SRC} not found — OpenWebUI unit not installed"
 fi
 
+# hal0-agent@ template + hermes drop-in (v0.3 PR-5). The template is the
+# generic per-agent runner; the drop-in pins hermes-specific env.
+# Lay them down whether or not bootstrap has been run — the shim's
+# `cmd_serve` bails cleanly when the venv isn't there yet, and the
+# `systemctl enable --now` for the hermes instance is gated on the
+# venv existing (see "Service start" block below).
+AGENT_UNIT_SRC="${REPO_ROOT}/installer/systemd/hal0-agent@.service"
+AGENT_UNIT_DST="${UNIT_DIR}/hal0-agent@.service"
+if [[ -f "${AGENT_UNIT_SRC}" ]]; then
+    cp "${AGENT_UNIT_SRC}" "${AGENT_UNIT_DST}"
+    info "wrote ${AGENT_UNIT_DST}"
+
+    AGENT_OVERRIDE_SRC="${REPO_ROOT}/installer/systemd/hal0-agent@hermes.service.d/override.conf"
+    AGENT_OVERRIDE_DST_DIR="${UNIT_DIR}/hal0-agent@hermes.service.d"
+    if [[ -f "${AGENT_OVERRIDE_SRC}" ]]; then
+        mkdir -p "${AGENT_OVERRIDE_DST_DIR}"
+        cp "${AGENT_OVERRIDE_SRC}" "${AGENT_OVERRIDE_DST_DIR}/override.conf"
+        info "wrote ${AGENT_OVERRIDE_DST_DIR}/override.conf"
+    fi
+else
+    warn "${AGENT_UNIT_SRC} not found — hal0-agent@ template not installed"
+fi
+
 if [[ "${DEV_MODE}" -eq 0 ]]; then
     systemctl daemon-reload
     info "systemctl daemon-reload"
@@ -1136,6 +1159,23 @@ else
         else
             warn "hal0-openwebui not yet active; check 'journalctl -u hal0-openwebui -n 40'"
         fi
+    fi
+
+    # hal0-agent@hermes — gated on the hermes venv existing. PR-3 owns the
+    # actual `hal0 agent bootstrap hermes` invocation; until that lands,
+    # this branch is a no-op on fresh installs (correct — there's no
+    # agent to run yet). On upgrade installs where the venv is already
+    # present from a previous bootstrap, this enables the unit so the
+    # agent comes back up after the upgrade.
+    if [[ -f "${AGENT_UNIT_DST}" && -x "/var/lib/hal0/venvs/hermes/bin/hermes" ]]; then
+        systemctl enable --now hal0-agent@hermes.service
+        if wait_active hal0-agent@hermes.service 20; then
+            info "hal0-agent@hermes is running (chat at 127.0.0.1:9119, proxied by hal0-api)"
+        else
+            warn "hal0-agent@hermes not yet active; check 'journalctl -u hal0-agent@hermes -n 40'"
+        fi
+    elif [[ -f "${AGENT_UNIT_DST}" ]]; then
+        info "hal0-agent@hermes not enabled — run 'hal0 agent bootstrap hermes' first"
     fi
 
 fi

--- a/installer/systemd/hal0-agent@.service
+++ b/installer/systemd/hal0-agent@.service
@@ -1,0 +1,99 @@
+[Unit]
+# hal0 bundled-agent template — instance `%i` is the agent id
+# (e.g. `systemctl start hal0-agent@hermes.service` → agent id "hermes").
+#
+# v0.4-ready: a future `hal0-agent@piccoder.service` is a drop-in with
+# a per-instance override under hal0-agent@piccoder.service.d/.
+Description=hal0 agent (%i)
+Documentation=https://github.com/Hal0ai/hal0/blob/main/docs/agents/hermes/SERVICE.md
+
+# Soft-link to lemonade — `Wants=` not `Requires=` / `BindsTo=` per
+# DA-sec-ops MUST-FIX #5 in docs/internal/hermes-research-2026-05-28.
+# Lemonade has a known GPU-cleanup-after-unload deadlock (see
+# auto-memory `hal0_lemonade_unload_gpu_cleanup_hang`): NRestarts=0,
+# port stays open, /api/v1/health times out forever.
+#
+# With `BindsTo=` the agent would stay "active (running)" forever even
+# though chat is dead. With `Wants=` we still START with lemonade but
+# survive its later death — and our own `WatchdogSec=` below lets
+# systemd notice when the AGENT process is the one that's hung.
+Wants=hal0-lemonade.service
+After=hal0-lemonade.service network-online.target
+
+# Throttle the restart loop. 5 starts in 120s = a real persistent
+# failure; back off rather than burn cycles.
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
+[Service]
+# Type=notify + WatchdogSec=60 means the shim MUST emit
+# `READY=1` once `/api/health` responds, then `WATCHDOG=1` at least
+# every 60s thereafter. If either drops, systemd restarts us.
+# See `src/hal0/cli/agent_shim.py` `cmd_serve` for the impl.
+Type=notify
+
+# Same posture as hal0-api / hal0-lemonade — run as the hal0 user
+# created by the installer. `User=` is overridable via drop-in for
+# agents that need different privileges (none today).
+User=hal0
+Group=hal0
+
+# `HAL0_AGENT_ID=%i` lets the shim resolve which agent toml to read
+# without parsing argv twice (argv carries it too, but env is what
+# our `_find_child_pids` scan keys off when finding stuck children).
+Environment="HAL0_AGENT_ID=%i"
+# Per-instance env — drop-in scripts may write
+# `/etc/hal0/agents/%i.env` to override HERMES_HOME / model defaults
+# / etc. Leading `-` so a missing file isn't fatal on first boot
+# (the shim has builtin fallbacks).
+EnvironmentFile=-/etc/hal0/agents/%i.env
+
+# ExecStart uses `hal0-agent`, which translates `serve` into
+# `hermes dashboard --tui --skip-build --no-open --host 127.0.0.1`.
+#
+# We DELIBERATELY do NOT call `hermes mcp serve`. That subcommand
+# starts a query-only MCP server with no `/api/events`, `/api/pty`,
+# or `/api/ws` and no JSON-RPC event stream — the hal0 chat surface
+# (PR-9 / PR-10) would render nothing.
+#
+# Rationale + line refs are in `src/hal0/cli/agent_shim.py`
+# `_build_hermes_argv` and DA-sec-ops MUST-FIX #1 in
+# `docs/internal/hermes-research-2026-05-28/plans/da-sec-ops.md`.
+ExecStart=/usr/local/bin/hal0-agent %i serve
+ExecStop=/usr/local/bin/hal0-agent %i stop
+
+# `on-failure` — don't restart on a clean SIGTERM (manual stop),
+# DO restart on a crash or watchdog timeout.
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=120
+TimeoutStopSec=15
+WatchdogSec=60
+
+# Sandboxing. Together these block ~all the privilege-escalation
+# vectors a buggy/compromised agent plugin could try without
+# breaking Hermes's legitimate writes to its HOME, run dir, and log.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+RestrictRealtime=yes
+
+# Carve out the exact paths Hermes + hal0 need to write to under the
+# `ProtectSystem=strict` lockdown. /run/hal0 is for sockets, lock
+# files, and the agent's NOTIFY_SOCKET helpers.
+ReadWritePaths=/var/lib/hal0 /var/log/hal0 /run/hal0
+
+# Stream stdout/stderr into journald with a per-instance identifier
+# so `journalctl -u hal0-agent@hermes` / `-t hal0-agent@hermes` both
+# work and the dashboard footer-journal can filter by tag.
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hal0-agent@%i
+
+[Install]
+WantedBy=multi-user.target

--- a/installer/systemd/hal0-agent@hermes.service.d/override.conf
+++ b/installer/systemd/hal0-agent@hermes.service.d/override.conf
@@ -1,0 +1,33 @@
+# hermes-specific overrides for the hal0-agent@ template.
+#
+# Anything under hal0-agent@<id>.service.d/ applies ONLY to that
+# instance — `hal0-agent@piccoder.service` would NOT inherit these.
+# This keeps the base template generic while letting us pin
+# hermes-shaped env without touching the template every release.
+
+[Unit]
+Documentation=https://github.com/Hal0ai/hal0/blob/main/docs/agents/hermes/SERVICE.md
+
+[Service]
+# HERMES_HOME is what the hermes binary reads to find its config,
+# personas, plugins, and skills. hal0 bootstrap claims a marker file
+# (`.hal0-managed`) inside this dir; if the marker is missing the
+# bootstrap refuses to write here (see
+# `src/hal0/agents/hermes_provision._claim_hermes_home`).
+Environment="HERMES_HOME=/var/lib/hal0/agents/hermes"
+
+# Mirror the `--tui` flag via env so any nested hermes-cli invocation
+# (e.g. hermes shelling out to itself for a one-shot) sees the same
+# dashboard-TUI mode the parent was started in.
+Environment="HERMES_DASHBOARD_TUI=1"
+
+# Pin the dashboard's web dist next to the wheel-installed hermes
+# binary so `--skip-build` finds it without needing npm at runtime.
+# The path is overridable in /etc/hal0/agents/hermes.env if a user
+# wants to point at a hand-built tree.
+Environment="HERMES_WEB_DIST=/var/lib/hal0/venvs/hermes/lib/hermes_cli/web_dist"
+
+# Lemonade endpoint hint — Hermes's `hal0` model-provider plugin
+# reads this to discover the lemond OpenAI-compatible base. Default
+# matches `installer/install.sh`'s lemond bind (127.0.0.1:13305).
+Environment="HAL0_LEMONADE_BASE=http://127.0.0.1:13305"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,14 @@ dev = [
 
 [project.scripts]
 hal0 = "hal0.cli.main:app"
+# hal0-agent is the small subprocess wrapper invoked by the systemd
+# template ``hal0-agent@<id>.service`` (installer/systemd/). Kept as a
+# separate console script (not a ``hal0 agent shim`` subcommand) so the
+# unit's ExecStart points at a stable PATH binary instead of the full
+# typer-loaded ``hal0`` CLI surface. See ``src/hal0/cli/agent_shim.py``
+# for rationale and ``installer/systemd/hal0-agent@.service`` for the
+# unit that drives it.
+hal0-agent = "hal0.cli.agent_shim:main"
 
 [project.urls]
 Homepage = "https://hal0.dev"

--- a/src/hal0/cli/agent_shim.py
+++ b/src/hal0/cli/agent_shim.py
@@ -1,0 +1,503 @@
+"""``hal0-agent`` CLI shim — invoked by ``hal0-agent@<id>.service``.
+
+This is a deliberately tiny entry point that:
+
+1. Resolves the agent type from ``/etc/hal0/agents/<id>.toml`` (or a
+   hardcoded fallback when the id is a known builtin like ``hermes``).
+2. Translates ``serve`` / ``stop`` / ``status`` / ``reprovision`` into
+   the right upstream invocation for that agent type.
+3. Emits ``sd_notify`` (``READY=1`` / ``WATCHDOG=1`` / ``STOPPING=1``)
+   so the systemd template unit's ``Type=notify`` + ``WatchdogSec=``
+   work without pulling ``systemd-python`` into hal0's wheel.
+
+**Why this shim exists vs. running ``hermes`` directly from the unit:**
+
+* Hermes upstream's ``hermes dashboard`` invocation needs hal0-specific
+  env (HAL0_AGENT_ID, HERMES_HOME, dist path) plus a "wait for the
+  /api/events socket to come up THEN sd_notify READY" handshake. The
+  unit can't express that.
+* The agent-id parameterisation (``%i`` in the template) needs to drive
+  the resolution of which upstream binary to run. ``hermes`` today,
+  ``pi-coder`` for v0.4. Keeping that map in the shim lets us add new
+  agent types without editing the template unit.
+* ``mcp serve`` mode in Hermes upstream is a query-only MCP server
+  with NO event stream — picking it kills the chat surface on day 1
+  (see DA-sec-ops MUST-FIX #1 in the v0.3 research bundle, and the
+  ExecStart-mode comment in ``hal0-agent@.service``).
+
+The shim is intentionally pure-stdlib + ``subprocess`` so it stays
+robust against hal0 wheel-build/import drift. It does NOT import
+``hal0.api``, ``fastapi``, or anything that could fail to load when
+``hal0-agent@hermes.service`` starts before ``hal0-api.service``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+import tomllib
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+# ----------------------------------------------------------------------------
+# Configuration discovery
+# ----------------------------------------------------------------------------
+
+# Per-agent TOML — overrides the builtin fallback. Optional.
+# Schema (all keys optional except ``type``):
+#
+#     type   = "hermes"                    # required; selects invocation
+#     home   = "/var/lib/hal0/agents/<id>" # default: derived from id
+#     venv   = "/var/lib/hal0/venvs/<id>"  # default: derived from id
+#     port   = 9119                        # default: hermes upstream's 9119
+#     host   = "127.0.0.1"                 # default: loopback only
+_AGENTS_CONF_DIR = Path(os.environ.get("HAL0_AGENTS_CONF_DIR", "/etc/hal0/agents"))
+
+# Builtin fallback for known agent ids — keyed off the id, NOT the type.
+# Lets ``hal0-agent@hermes.service`` work even before ``/etc/hal0/agents/
+# hermes.toml`` is dropped (first-boot ordering: bootstrap installs the
+# unit + enables it, then ``hermes_provision`` may write the toml).
+_BUILTIN_AGENT_TYPES: dict[str, str] = {
+    "hermes": "hermes",
+}
+
+
+@dataclass(frozen=True)
+class AgentConfig:
+    """Resolved agent invocation parameters."""
+
+    agent_id: str
+    agent_type: str
+    home: Path
+    venv: Path
+    host: str
+    port: int
+
+    @property
+    def hermes_bin(self) -> Path:
+        """Path to the ``hermes`` console script inside the agent's venv."""
+
+        return self.venv / "bin" / "hermes"
+
+    @property
+    def status_url(self) -> str:
+        """URL the shim polls to confirm the agent's HTTP surface is up."""
+
+        # ``/api/health`` is upstream-stable across hermes ≥ 0.10 and is the
+        # cheapest endpoint we can hit to determine "ready". The Hermes
+        # dashboard route doesn't expose ``/healthz`` — verified against
+        # ``~/src/hermes-agent/hermes_cli/web_server.py``.
+        return f"http://{self.host}:{self.port}/api/health"
+
+
+def _load_agent_config(agent_id: str) -> AgentConfig:
+    """Resolve ``agent_id`` to a fully-populated :class:`AgentConfig`.
+
+    Reads ``/etc/hal0/agents/<id>.toml`` if it exists, then falls back
+    to the builtin map. Raises :class:`SystemExit` (via :func:`die`) if
+    the agent id isn't recognised and no TOML exists.
+    """
+
+    conf_path = _AGENTS_CONF_DIR / f"{agent_id}.toml"
+    data: dict[str, object] = {}
+    if conf_path.exists():
+        try:
+            data = tomllib.loads(conf_path.read_text())
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            _die(f"failed to parse {conf_path}: {exc}")
+
+    agent_type = str(data.get("type") or _BUILTIN_AGENT_TYPES.get(agent_id) or "")
+    if not agent_type:
+        _die(
+            f"unknown agent id '{agent_id}' — drop /etc/hal0/agents/{agent_id}.toml "
+            f"with a 'type = ...' field, or use a builtin id "
+            f"({', '.join(sorted(_BUILTIN_AGENT_TYPES))})"
+        )
+
+    home = Path(str(data.get("home") or f"/var/lib/hal0/agents/{agent_id}"))
+    venv = Path(str(data.get("venv") or f"/var/lib/hal0/venvs/{agent_id}"))
+    host = str(data.get("host") or "127.0.0.1")
+    # tomllib parses integers as int already; coerce via str→int to satisfy
+    # mypy's strict object→int handling on the dict.get fallback path.
+    port_raw = data.get("port") or 9119
+    port = int(str(port_raw))
+
+    return AgentConfig(
+        agent_id=agent_id,
+        agent_type=agent_type,
+        home=home,
+        venv=venv,
+        host=host,
+        port=port,
+    )
+
+
+# ----------------------------------------------------------------------------
+# sd_notify (pure-stdlib — no systemd-python dependency)
+# ----------------------------------------------------------------------------
+
+
+def _sd_notify(state: str) -> bool:
+    """Send a single sd_notify state line to ``$NOTIFY_SOCKET``.
+
+    Returns ``True`` on success, ``False`` when the env var is unset
+    (e.g. running the shim outside systemd). Failure to write is
+    swallowed — the shim never crashes for a notify miss.
+    """
+
+    addr = os.environ.get("NOTIFY_SOCKET")
+    if not addr:
+        return False
+    # Abstract-namespace sockets start with '@' which datagram socket
+    # APIs encode as a leading NUL byte. Translate per sd_notify(3).
+    if addr.startswith("@"):
+        addr = "\0" + addr[1:]
+    try:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM | socket.SOCK_CLOEXEC)
+    except OSError:
+        return False
+    try:
+        sock.sendto(state.encode("utf-8"), addr)
+    except OSError:
+        return False
+    finally:
+        sock.close()
+    return True
+
+
+# ----------------------------------------------------------------------------
+# HTTP readiness probe (also pure-stdlib)
+# ----------------------------------------------------------------------------
+
+
+def _is_ready(cfg: AgentConfig, *, timeout: float = 1.0) -> bool:
+    """Cheap GET of the agent's health URL — True iff 2xx."""
+
+    try:
+        with urllib.request.urlopen(cfg.status_url, timeout=timeout) as resp:
+            status: int = resp.status
+            return 200 <= status < 300
+    except (urllib.error.URLError, OSError):
+        return False
+
+
+# ----------------------------------------------------------------------------
+# Hermes invocation
+# ----------------------------------------------------------------------------
+
+
+def _build_hermes_argv(cfg: AgentConfig) -> list[str]:
+    """Build the argv that boots Hermes with ``/api/events`` + ``/api/pty``.
+
+    The chosen subcommand is ``hermes dashboard --tui`` per ``hermes_cli/
+    main.py:14050-14102`` and ``hermes_cli/main.py:10930-10939``:
+
+    * ``cmd_dashboard`` is the ONLY subcommand that imports + calls
+      ``hermes_cli.web_server.start_server``, which is where the
+      ``/api/pty``, ``/api/events``, and ``/api/ws`` routes are mounted
+      (``hermes_cli/web_server.py:3585`` ``/api/pty``,
+      ``hermes_cli/web_server.py:3763`` ``/api/events``,
+      ``hermes_cli/web_server.py:3704`` ``/api/ws``).
+    * ``--tui`` (alias env: ``HERMES_DASHBOARD_TUI=1``) flips on the
+      embedded chat PTY — without it the dashboard runs but the chat
+      tab is hidden and ``/api/pty`` refuses upgrades. hal0's chat
+      surface needs both.
+    * ``--skip-build`` keeps the unit start fast and works without npm
+      on the production box — the wheel ships ``hermes_cli/web_dist/``
+      pre-built.
+    * ``--no-open`` because we're running headless (no browser open).
+    * ``--host 127.0.0.1`` — hal0-api proxies the WS; binding to all
+      interfaces would let any LAN host reach the agent's PTY without
+      the hal0-api Origin/HMAC checks (DA-sec-ops #2).
+    * Explicitly **NOT** ``hermes mcp serve``: that subcommand boots an
+      MCP query server with NO ``message.delta`` / ``tool.start/complete``
+      / ``approval.request`` event stream, so PR-9/PR-10's chat surface
+      would have nothing to render (DA-sec-ops MUST-FIX #1).
+    """
+
+    return [
+        str(cfg.hermes_bin),
+        "dashboard",
+        "--host",
+        cfg.host,
+        "--port",
+        str(cfg.port),
+        "--tui",
+        "--no-open",
+        "--skip-build",
+    ]
+
+
+def _build_hermes_env(cfg: AgentConfig) -> dict[str, str]:
+    """Build the child env for Hermes — inherits parent + adds hal0 keys."""
+
+    env = dict(os.environ)
+    env["HAL0_AGENT_ID"] = cfg.agent_id
+    env["HERMES_HOME"] = str(cfg.home)
+    # Mirror ``--tui`` so any nested hermes-cli invocation (e.g. an
+    # in-process subprocess.run) sees the same flag without parsing argv.
+    env["HERMES_DASHBOARD_TUI"] = "1"
+    # Drop NOTIFY_SOCKET from the child — the shim owns sd_notify,
+    # and a misbehaving Hermes plugin shouldn't be able to send
+    # READY=1 / STOPPING=1 to systemd on our behalf.
+    env.pop("NOTIFY_SOCKET", None)
+    return env
+
+
+# ----------------------------------------------------------------------------
+# Subcommands
+# ----------------------------------------------------------------------------
+
+# How long to wait for the child to become reachable before bailing.
+# Longer than the default 60s WatchdogSec on first boot (lemonade
+# warm-up + provider plugin discovery can dominate), but capped so a
+# truly-wedged hermes doesn't keep the unit in ``activating`` forever.
+_READY_TIMEOUT_S = 90.0
+# Watchdog ping interval — half of the unit's WatchdogSec (60s) so a
+# single miss doesn't trip the watchdog.
+_WATCHDOG_INTERVAL_S = 25.0
+# SIGTERM → SIGKILL escalation window.
+_STOP_GRACE_S = 10.0
+
+
+def cmd_serve(cfg: AgentConfig) -> int:
+    """Launch the agent process, then sd_notify READY once it's reachable.
+
+    Returns the agent process's exit code. Watchdog pings continue for
+    as long as the child is alive AND the health URL responds — a hung
+    agent stops getting pinged and systemd restarts it per the unit's
+    ``Restart=on-failure`` policy.
+    """
+
+    if cfg.agent_type != "hermes":
+        _die(f"agent type '{cfg.agent_type}' not supported by this shim yet")
+    if not cfg.hermes_bin.exists():
+        _die(
+            f"hermes binary not found at {cfg.hermes_bin} — run 'hal0 agent bootstrap hermes' first"
+        )
+
+    argv = _build_hermes_argv(cfg)
+    env = _build_hermes_env(cfg)
+
+    # Don't ``exec`` — we need a parent process to drive sd_notify
+    # READY/WATCHDOG. Forward signals into the child via the SIGTERM
+    # handler below.
+    child = subprocess.Popen(
+        argv,
+        env=env,
+        cwd=str(cfg.home if cfg.home.exists() else Path.cwd()),
+        stdin=subprocess.DEVNULL,
+    )
+
+    def _forward_signal(signum: int, _frame: object) -> None:
+        with contextlib.suppress(ProcessLookupError):
+            child.send_signal(signum)
+
+    signal.signal(signal.SIGTERM, _forward_signal)
+    signal.signal(signal.SIGINT, _forward_signal)
+    # SIGHUP = persona swap / config reload — Hermes upstream re-reads
+    # overrides.yaml on SIGHUP. Pass through unchanged.
+    signal.signal(signal.SIGHUP, _forward_signal)
+
+    # Block until /api/health responds OR the child exits OR we time out.
+    ready = _wait_for_ready(child, cfg, _READY_TIMEOUT_S)
+    if not ready:
+        # Child either crashed or never opened the socket. Don't sd_notify
+        # READY — systemd will mark us failed and trigger Restart.
+        rc = child.wait() if child.poll() is None else (child.returncode or 1)
+        return rc or 1
+
+    _sd_notify("READY=1\nSTATUS=hermes dashboard reachable\n")
+
+    # Heartbeat loop. ``WATCHDOG=1`` while the child is alive AND
+    # reachable; on either failure we let the loop exit and systemd
+    # observe via WatchdogSec.
+    while child.poll() is None:
+        if _is_ready(cfg):
+            _sd_notify("WATCHDOG=1\n")
+        time.sleep(_WATCHDOG_INTERVAL_S)
+
+    _sd_notify("STOPPING=1\n")
+    return child.returncode or 0
+
+
+def _wait_for_ready(
+    child: subprocess.Popen[bytes],
+    cfg: AgentConfig,
+    timeout: float,
+) -> bool:
+    """Poll the agent's health URL until 2xx, child-exit, or timeout."""
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if child.poll() is not None:
+            return False
+        if _is_ready(cfg):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def cmd_stop(cfg: AgentConfig) -> int:
+    """SIGTERM any running ``hermes dashboard`` PTY for this agent id.
+
+    Invoked by ``ExecStop=`` in the template unit AND usable standalone
+    (``hal0-agent hermes stop``). The shim doesn't track PIDs — it
+    scans for the dashboard cmdline + the matching ``HAL0_AGENT_ID``
+    env, mirroring what ``hermes dashboard --stop`` does upstream.
+
+    For Type=notify units, systemd already SIGTERMs the main pid on
+    its own; this command is the manual fallback + the basis for
+    ``status``.
+    """
+
+    needle = str(cfg.hermes_bin)
+    pids = _find_child_pids(needle, cfg.agent_id)
+    if not pids:
+        # Already stopped — exit 0 so retries are idempotent.
+        return 0
+
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            continue
+
+    # Give the child up to _STOP_GRACE_S to exit cleanly, then SIGKILL.
+    deadline = time.monotonic() + _STOP_GRACE_S
+    while time.monotonic() < deadline:
+        pids = _find_child_pids(needle, cfg.agent_id)
+        if not pids:
+            return 0
+        time.sleep(0.25)
+
+    # Escalate.
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            continue
+    return 0
+
+
+def _find_child_pids(needle: str, agent_id: str) -> list[int]:
+    """Scan /proc for processes matching ``needle`` AND ``agent_id``.
+
+    Pure-stdlib so we don't drag psutil into the shim's blast radius.
+    Returns an empty list when running on a non-Linux host (no /proc).
+    """
+
+    proc_root = Path("/proc")
+    if not proc_root.is_dir():
+        return []
+
+    matches: list[int] = []
+    for entry in proc_root.iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            cmdline = (
+                (entry / "cmdline")
+                .read_bytes()
+                .replace(b"\0", b" ")
+                .decode("utf-8", errors="replace")
+            )
+        except OSError:
+            continue
+        if needle not in cmdline:
+            continue
+        try:
+            environ = (entry / "environ").read_bytes()
+        except OSError:
+            continue
+        if f"HAL0_AGENT_ID={agent_id}\0".encode() not in environ + b"\0":
+            continue
+        matches.append(int(entry.name))
+    return matches
+
+
+def cmd_status(cfg: AgentConfig) -> int:
+    """Print short status — exit 0 iff health URL responds."""
+
+    if _is_ready(cfg):
+        print(f"{cfg.agent_id}: reachable at {cfg.status_url}")
+        return 0
+    print(
+        f"{cfg.agent_id}: NOT reachable at {cfg.status_url}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def cmd_reprovision(cfg: AgentConfig) -> int:
+    """Re-run the hal0 bootstrap pipeline for this agent.
+
+    Today this delegates to ``hal0 agent bootstrap <type> --repair``
+    (the only re-entry point in the current CLI). When PR-3 lands an
+    explicit ``reprovision`` subcommand, swap the argv to point at it.
+    """
+
+    hal0_bin = shutil.which("hal0") or "/usr/local/bin/hal0"
+    argv = [hal0_bin, "agent", "bootstrap", cfg.agent_type, "--repair"]
+    return subprocess.call(argv)
+
+
+# ----------------------------------------------------------------------------
+# Argv parsing
+# ----------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="hal0-agent",
+        description=(
+            "Wrap a bundled hal0 agent process with sd_notify, watchdog, "
+            "and graceful stop. Invoked by hal0-agent@<id>.service."
+        ),
+    )
+    parser.add_argument(
+        "agent_id",
+        help="Agent instance id (e.g. 'hermes'). Matches %%i in the systemd unit.",
+    )
+    parser.add_argument(
+        "subcommand",
+        choices=["serve", "stop", "status", "reprovision"],
+        help="What to do with the agent.",
+    )
+    return parser
+
+
+def _die(msg: str, *, exit_code: int = 1) -> None:
+    """Print ``msg`` to stderr and exit non-zero. Never returns."""
+
+    print(f"hal0-agent: {msg}", file=sys.stderr)
+    raise SystemExit(exit_code)
+
+
+_DISPATCH: dict[str, Callable[[AgentConfig], int]] = {
+    "serve": cmd_serve,
+    "stop": cmd_stop,
+    "status": cmd_status,
+    "reprovision": cmd_reprovision,
+}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    cfg = _load_agent_config(args.agent_id)
+    return _DISPATCH[args.subcommand](cfg)
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via entrypoint
+    raise SystemExit(main())

--- a/tests/cli/test_agent_shim.py
+++ b/tests/cli/test_agent_shim.py
@@ -1,0 +1,387 @@
+"""Tests for ``hal0-agent`` — the systemd-unit shim.
+
+Most coverage is at the unit level: argv parsing, config resolution,
+the Hermes argv builder, and the readiness-poll edges. ``cmd_serve``
+isn't exercised end-to-end (it would block on a real subprocess and
+HTTP poll); instead we test the building blocks it composes from.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from hal0.cli import agent_shim
+
+# ---------------------------------------------------------------------------
+# Argv parsing
+# ---------------------------------------------------------------------------
+
+
+class TestArgvParsing:
+    def test_serve_subcommand(self) -> None:
+        parser = agent_shim._build_parser()
+        ns = parser.parse_args(["hermes", "serve"])
+        assert ns.agent_id == "hermes"
+        assert ns.subcommand == "serve"
+
+    @pytest.mark.parametrize("sub", ["serve", "stop", "status", "reprovision"])
+    def test_all_subcommands_accepted(self, sub: str) -> None:
+        parser = agent_shim._build_parser()
+        ns = parser.parse_args(["hermes", sub])
+        assert ns.subcommand == sub
+
+    def test_unknown_subcommand_rejected(self) -> None:
+        parser = agent_shim._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["hermes", "bogus"])
+
+    def test_missing_args_rejected(self) -> None:
+        parser = agent_shim._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["hermes"])
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+
+class TestAgentConfig:
+    def test_builtin_hermes_no_toml(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Empty conf dir → falls through to _BUILTIN_AGENT_TYPES["hermes"].
+        monkeypatch.setattr(agent_shim, "_AGENTS_CONF_DIR", tmp_path)
+        cfg = agent_shim._load_agent_config("hermes")
+        assert cfg.agent_id == "hermes"
+        assert cfg.agent_type == "hermes"
+        assert cfg.home == Path("/var/lib/hal0/agents/hermes")
+        assert cfg.venv == Path("/var/lib/hal0/venvs/hermes")
+        assert cfg.host == "127.0.0.1"
+        assert cfg.port == 9119
+
+    def test_toml_overrides_defaults(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(agent_shim, "_AGENTS_CONF_DIR", tmp_path)
+        (tmp_path / "hermes.toml").write_text(
+            """
+            type = "hermes"
+            home = "/tmp/custom-home"
+            venv = "/tmp/custom-venv"
+            host = "0.0.0.0"
+            port = 9999
+            """
+        )
+        cfg = agent_shim._load_agent_config("hermes")
+        assert cfg.home == Path("/tmp/custom-home")
+        assert cfg.venv == Path("/tmp/custom-venv")
+        assert cfg.host == "0.0.0.0"
+        assert cfg.port == 9999
+
+    def test_unknown_id_without_toml_dies(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(agent_shim, "_AGENTS_CONF_DIR", tmp_path)
+        with pytest.raises(SystemExit) as exc:
+            agent_shim._load_agent_config("piccoder")
+        assert exc.value.code == 1
+
+    def test_custom_id_with_toml_works(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The whole point of `type=...` in the toml is that the operator
+        # can ship a new instance without code changes.
+        monkeypatch.setattr(agent_shim, "_AGENTS_CONF_DIR", tmp_path)
+        (tmp_path / "piccoder.toml").write_text('type = "hermes"\n')
+        cfg = agent_shim._load_agent_config("piccoder")
+        assert cfg.agent_id == "piccoder"
+        assert cfg.agent_type == "hermes"
+        # Defaults derive from the id, not the type.
+        assert cfg.home == Path("/var/lib/hal0/agents/piccoder")
+        assert cfg.venv == Path("/var/lib/hal0/venvs/piccoder")
+
+    def test_malformed_toml_dies(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(agent_shim, "_AGENTS_CONF_DIR", tmp_path)
+        (tmp_path / "hermes.toml").write_text("not = valid = toml = at all\n")
+        with pytest.raises(SystemExit):
+            agent_shim._load_agent_config("hermes")
+
+    def test_status_url_uses_host_port(self) -> None:
+        cfg = agent_shim.AgentConfig(
+            agent_id="hermes",
+            agent_type="hermes",
+            home=Path("/x"),
+            venv=Path("/y"),
+            host="10.0.0.1",
+            port=4242,
+        )
+        assert cfg.status_url == "http://10.0.0.1:4242/api/health"
+
+    def test_hermes_bin_resolves_under_venv(self) -> None:
+        cfg = agent_shim.AgentConfig(
+            agent_id="hermes",
+            agent_type="hermes",
+            home=Path("/x"),
+            venv=Path("/var/lib/hal0/venvs/hermes"),
+            host="127.0.0.1",
+            port=9119,
+        )
+        assert cfg.hermes_bin == Path("/var/lib/hal0/venvs/hermes/bin/hermes")
+
+
+# ---------------------------------------------------------------------------
+# Hermes argv + env builders
+# ---------------------------------------------------------------------------
+
+
+def _cfg(**kw: Any) -> agent_shim.AgentConfig:
+    defaults: dict[str, Any] = dict(
+        agent_id="hermes",
+        agent_type="hermes",
+        home=Path("/var/lib/hal0/agents/hermes"),
+        venv=Path("/var/lib/hal0/venvs/hermes"),
+        host="127.0.0.1",
+        port=9119,
+    )
+    defaults.update(kw)
+    return agent_shim.AgentConfig(**defaults)
+
+
+class TestHermesArgv:
+    def test_chooses_dashboard_subcommand(self) -> None:
+        # This is THE most important assertion in the file.
+        # Picking the wrong subcommand here = dead chat day-1
+        # (DA-sec-ops MUST-FIX #1).
+        argv = agent_shim._build_hermes_argv(_cfg())
+        assert "dashboard" in argv
+        assert "mcp" not in argv
+        assert "serve" not in argv  # `serve` is a subcommand of `mcp`
+
+    def test_includes_tui_flag(self) -> None:
+        # Without --tui the dashboard runs but /api/pty refuses upgrades
+        # and the chat tab is hidden. Verified against
+        # hermes_cli/main.py:14069-14076.
+        argv = agent_shim._build_hermes_argv(_cfg())
+        assert "--tui" in argv
+
+    def test_skip_build_to_avoid_npm_on_runtime_box(self) -> None:
+        argv = agent_shim._build_hermes_argv(_cfg())
+        assert "--skip-build" in argv
+
+    def test_binds_loopback_only(self) -> None:
+        # Default cfg → 127.0.0.1. Binding to 0.0.0.0 would let any LAN
+        # host reach /api/pty without hal0-api's Origin/HMAC checks
+        # (DA-sec-ops #2).
+        argv = agent_shim._build_hermes_argv(_cfg())
+        host_idx = argv.index("--host")
+        assert argv[host_idx + 1] == "127.0.0.1"
+
+    def test_no_open_browser(self) -> None:
+        argv = agent_shim._build_hermes_argv(_cfg())
+        assert "--no-open" in argv
+
+    def test_uses_venv_hermes_binary(self) -> None:
+        argv = agent_shim._build_hermes_argv(_cfg())
+        assert argv[0] == "/var/lib/hal0/venvs/hermes/bin/hermes"
+
+    def test_port_overridable(self) -> None:
+        argv = agent_shim._build_hermes_argv(_cfg(port=9999))
+        port_idx = argv.index("--port")
+        assert argv[port_idx + 1] == "9999"
+
+
+class TestHermesEnv:
+    def test_agent_id_passed_through(self) -> None:
+        env = agent_shim._build_hermes_env(_cfg(agent_id="hermes"))
+        assert env["HAL0_AGENT_ID"] == "hermes"
+
+    def test_custom_agent_id_passed_through(self) -> None:
+        # Future-proofing for v0.4 piccoder.
+        env = agent_shim._build_hermes_env(_cfg(agent_id="piccoder"))
+        assert env["HAL0_AGENT_ID"] == "piccoder"
+
+    def test_hermes_home_passed_through(self) -> None:
+        env = agent_shim._build_hermes_env(_cfg(home=Path("/custom/home")))
+        assert env["HERMES_HOME"] == "/custom/home"
+
+    def test_dashboard_tui_set(self) -> None:
+        # Belt-and-braces with the --tui flag in argv.
+        env = agent_shim._build_hermes_env(_cfg())
+        assert env["HERMES_DASHBOARD_TUI"] == "1"
+
+    def test_notify_socket_stripped(self) -> None:
+        # The shim owns sd_notify; child shouldn't be able to send
+        # READY=1 / STOPPING=1 on our behalf.
+        with patch.dict(os.environ, {"NOTIFY_SOCKET": "/run/systemd/notify"}):
+            env = agent_shim._build_hermes_env(_cfg())
+        assert "NOTIFY_SOCKET" not in env
+
+
+# ---------------------------------------------------------------------------
+# sd_notify
+# ---------------------------------------------------------------------------
+
+
+class TestSdNotify:
+    def test_no_notify_socket_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NOTIFY_SOCKET", raising=False)
+        assert agent_shim._sd_notify("READY=1") is False
+
+    @pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="AF_UNIX datagram + abstract namespace is Linux-only",
+    )
+    def test_sends_to_unix_socket(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        sock_path = tmp_path / "notify.sock"
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        listener.bind(str(sock_path))
+        listener.settimeout(1.0)
+        try:
+            monkeypatch.setenv("NOTIFY_SOCKET", str(sock_path))
+            assert agent_shim._sd_notify("READY=1\n") is True
+            received, _ = listener.recvfrom(64)
+            assert received == b"READY=1\n"
+        finally:
+            listener.close()
+
+
+# ---------------------------------------------------------------------------
+# _find_child_pids — keys on cmdline + HAL0_AGENT_ID env
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not Path("/proc").is_dir(), reason="/proc scan is Linux-only")
+class TestFindChildPids:
+    """Spawn a sleeping subprocess with controlled env + cmdline so we can
+    assert against a known PID. ``monkeypatch.setenv`` doesn't rewrite
+    ``/proc/$pid/environ`` (that's frozen at exec time) so we can't use
+    the test process itself.
+    """
+
+    @pytest.fixture
+    def sleeper(self) -> Any:
+        """Yield a (pid, cmdline_needle) for a long-running child with
+        ``HAL0_AGENT_ID=hermes`` in its env and ``hal0-agent-needle`` in
+        its cmdline.
+        """
+
+        # `sh -c "exec -a <name> sleep 30"` would be cleanest but `exec
+        # -a` is bash-only and CI may run with dash as /bin/sh. Use a
+        # python -c child whose argv contains the needle string directly.
+        needle = "hal0-agent-needle-marker"
+        env = {**os.environ, "HAL0_AGENT_ID": "hermes"}
+        proc = subprocess.Popen(
+            [sys.executable, "-c", f"# {needle}\nimport time; time.sleep(30)"],
+            env=env,
+        )
+        try:
+            # Give the kernel a moment to flush /proc/$pid/cmdline.
+            import time as _t
+
+            _t.sleep(0.1)
+            yield proc.pid, needle
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+    def test_matches_when_needle_AND_agent_id_match(self, sleeper: Any) -> None:
+        pid, needle = sleeper
+        matches = agent_shim._find_child_pids(needle=needle, agent_id="hermes")
+        assert pid in matches
+
+    def test_excludes_when_needle_missing(self, sleeper: Any) -> None:
+        pid, _needle = sleeper
+        # Cmdline-needle doesn't match → no match even with right agent id.
+        matches = agent_shim._find_child_pids(
+            needle="/definitely/not/in/cmdline", agent_id="hermes"
+        )
+        assert pid not in matches
+
+    def test_excludes_when_agent_id_wrong(self, sleeper: Any) -> None:
+        pid, needle = sleeper
+        # Cmdline matches BUT agent id doesn't → no match (proves AND-gate).
+        matches = agent_shim._find_child_pids(needle=needle, agent_id="piccoder")
+        assert pid not in matches
+
+
+# ---------------------------------------------------------------------------
+# cmd_status / cmd_stop / cmd_reprovision integration points
+# ---------------------------------------------------------------------------
+
+
+class TestCmdStatus:
+    def test_returns_0_when_ready(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(agent_shim, "_is_ready", lambda cfg: True)
+        rc = agent_shim.cmd_status(_cfg())
+        assert rc == 0
+
+    def test_returns_nonzero_when_unreachable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(agent_shim, "_is_ready", lambda cfg: False)
+        rc = agent_shim.cmd_status(_cfg())
+        assert rc == 1
+
+
+class TestCmdStop:
+    def test_idempotent_when_no_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(agent_shim, "_find_child_pids", lambda *_a, **_k: [])
+        assert agent_shim.cmd_stop(_cfg()) == 0
+
+
+class TestCmdReprovision:
+    def test_shells_out_to_hal0_agent_bootstrap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        recorded: dict[str, list[str]] = {}
+
+        def fake_call(argv: list[str], *_a: Any, **_kw: Any) -> int:
+            recorded["argv"] = argv
+            return 0
+
+        monkeypatch.setattr(subprocess, "call", fake_call)
+        rc = agent_shim.cmd_reprovision(_cfg())
+        assert rc == 0
+        assert recorded["argv"][-3:] == ["bootstrap", "hermes", "--repair"]
+
+
+# ---------------------------------------------------------------------------
+# main() dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_main_dispatches_to_status(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(agent_shim, "_AGENTS_CONF_DIR", tmp_path)
+        called: dict[str, agent_shim.AgentConfig] = {}
+
+        def fake_status(cfg: agent_shim.AgentConfig) -> int:
+            called["cfg"] = cfg
+            return 7
+
+        monkeypatch.setattr(agent_shim, "_DISPATCH", {"status": fake_status})
+        # Rebuild the parser with only `status` allowed for this test —
+        # but parse_args is what gates the choices, so we patch around it.
+        monkeypatch.setattr(
+            agent_shim,
+            "_build_parser",
+            _make_parser_allowing_only_status,
+        )
+        rc = agent_shim.main(["hermes", "status"])
+        assert rc == 7
+        assert called["cfg"].agent_id == "hermes"
+
+
+def _make_parser_allowing_only_status() -> Any:
+    import argparse
+
+    p = argparse.ArgumentParser(prog="hal0-agent")
+    p.add_argument("agent_id")
+    p.add_argument("subcommand", choices=["status"])
+    return p

--- a/tests/systemd/test_unit_files.py
+++ b/tests/systemd/test_unit_files.py
@@ -1,0 +1,228 @@
+"""Assert the ``hal0-agent@.service`` template ships the directives we need.
+
+These tests parse the unit file as text and assert directive-level
+presence — they don't shell out to ``systemd-analyze`` because:
+
+1. The template uses ``%i`` which the analyzer rejects when the file is
+   parsed in isolation (it expects an instantiated unit name).
+2. CI runs on a wide range of platforms; ``systemd-analyze`` isn't
+   reliably available on macOS or non-systemd Linux dev boxes.
+
+The directives we assert here are the ones that PROTECT a real
+operator outcome (Lemonade-deadlock survival, watchdog-on-hang,
+sandboxing) — drift on any of them should fail loudly.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# Locate the unit files relative to the repo root. Pytest runs from
+# repo root by default; resolve via this file's path to stay robust
+# against ``pytest path/to/tests/`` invocations from anywhere.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TEMPLATE = _REPO_ROOT / "installer" / "systemd" / "hal0-agent@.service"
+_HERMES_OVERRIDE = (
+    _REPO_ROOT / "installer" / "systemd" / "hal0-agent@hermes.service.d" / "override.conf"
+)
+
+
+@pytest.fixture(scope="module")
+def template_text() -> str:
+    assert _TEMPLATE.exists(), f"missing template unit at {_TEMPLATE}"
+    return _TEMPLATE.read_text()
+
+
+@pytest.fixture(scope="module")
+def override_text() -> str:
+    assert _HERMES_OVERRIDE.exists(), f"missing hermes override at {_HERMES_OVERRIDE}"
+    return _HERMES_OVERRIDE.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Dependency wiring
+# ---------------------------------------------------------------------------
+
+
+class TestDependencyWiring:
+    """Lemonade is `Wants=`, not `Requires=` — survives the unload deadlock."""
+
+    def test_wants_lemonade(self, template_text: str) -> None:
+        # `Wants=hal0-lemonade.service` is the single most important line:
+        # `Requires=` or `BindsTo=` would pin the agent in "active" forever
+        # when lemonade hits its GPU-cleanup-after-unload deadlock.
+        # See auto-memory `hal0_lemonade_unload_gpu_cleanup_hang`.
+        assert re.search(r"^Wants=hal0-lemonade\.service\b", template_text, re.MULTILINE), (
+            "Template MUST use `Wants=hal0-lemonade.service` (NOT Requires=/BindsTo=)"
+            " — see DA-sec-ops MUST-FIX #5."
+        )
+
+    def test_after_lemonade_and_network(self, template_text: str) -> None:
+        # `After=` controls start ordering; lemonade must boot first so
+        # the agent's hal0 provider plugin can probe /api/v1/health.
+        assert re.search(r"^After=.*\bhal0-lemonade\.service\b", template_text, re.MULTILINE)
+        assert re.search(r"^After=.*\bnetwork-online\.target\b", template_text, re.MULTILINE)
+
+    def test_no_requires_or_bindsto(self, template_text: str) -> None:
+        # If anyone ever swaps Wants= back to Requires=/BindsTo=, this
+        # catches it before CI green-merges through.
+        assert not re.search(r"^Requires=.*hal0-lemonade", template_text, re.MULTILINE), (
+            "Requires=hal0-lemonade reintroduces the deadlock-pin failure mode"
+        )
+        assert not re.search(r"^BindsTo=.*hal0-lemonade", template_text, re.MULTILINE), (
+            "BindsTo=hal0-lemonade reintroduces the deadlock-pin failure mode"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Service runtime
+# ---------------------------------------------------------------------------
+
+
+class TestServiceRuntime:
+    def test_type_notify(self, template_text: str) -> None:
+        # `Type=notify` is what makes `WatchdogSec=` work. Without it
+        # systemd can't observe hangs.
+        assert re.search(r"^Type=notify\b", template_text, re.MULTILINE)
+
+    def test_watchdog_60s(self, template_text: str) -> None:
+        # `WatchdogSec=60` per DA-sec-ops MUST-FIX #5. The shim pings
+        # at half-interval (25s) so a single miss doesn't trip.
+        m = re.search(r"^WatchdogSec=(\d+)", template_text, re.MULTILINE)
+        assert m is not None, "WatchdogSec= is required (Type=notify alone isn't enough)"
+        assert int(m.group(1)) <= 120, "WatchdogSec should be ≤ 120s for fast hang detection"
+
+    def test_restart_on_failure(self, template_text: str) -> None:
+        # `on-failure` (NOT `always`) — manual SIGTERM via `systemctl stop`
+        # should NOT trigger a restart loop.
+        assert re.search(r"^Restart=on-failure\b", template_text, re.MULTILINE)
+
+    def test_exec_start_uses_hal0_agent_shim(self, template_text: str) -> None:
+        # ExecStart must go through the shim. Without the shim there's
+        # no sd_notify, no watchdog ping, no mode-selection logic.
+        assert re.search(
+            r"^ExecStart=/usr/local/bin/hal0-agent %i serve\b",
+            template_text,
+            re.MULTILINE,
+        )
+
+    def test_exec_start_never_uses_mcp_serve(self, template_text: str) -> None:
+        # DA-sec-ops MUST-FIX #1: `mcp serve` emits no event stream.
+        # If anyone rewrites ExecStart to invoke hermes directly with
+        # `mcp serve`, the chat surface goes dead day-1.
+        # Scoped to `ExecStart=` lines only — the surrounding comments
+        # intentionally mention `mcp serve` to explain why we DON'T use it.
+        exec_lines = [line for line in template_text.splitlines() if line.startswith("ExecStart=")]
+        assert exec_lines, "no ExecStart= directive found"
+        for line in exec_lines:
+            assert "mcp serve" not in line, (
+                "ExecStart must not reference `mcp serve` — that mode emits no "
+                "/api/events. See DA-sec-ops MUST-FIX #1."
+            )
+
+    def test_exec_stop_uses_hal0_agent_shim(self, template_text: str) -> None:
+        assert re.search(
+            r"^ExecStop=/usr/local/bin/hal0-agent %i stop\b",
+            template_text,
+            re.MULTILINE,
+        )
+
+    def test_template_parameterised_by_id(self, template_text: str) -> None:
+        # `%i` (the lowercase instance specifier) is what makes
+        # `hal0-agent@piccoder.service` work without a template edit.
+        assert "%i" in template_text
+
+
+# ---------------------------------------------------------------------------
+# Sandboxing
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxing:
+    """Hardening directives per DA-sec-ops MUST-FIX #5."""
+
+    @pytest.mark.parametrize(
+        "directive",
+        [
+            "NoNewPrivileges=yes",
+            "ProtectSystem=strict",
+            "ProtectHome=yes",
+            "PrivateTmp=yes",
+        ],
+    )
+    def test_hardening_directive_present(self, template_text: str, directive: str) -> None:
+        # Each directive on its own line, exact value.
+        pattern = rf"^{re.escape(directive)}\b"
+        assert re.search(pattern, template_text, re.MULTILINE), (
+            f"Required hardening directive missing: {directive}"
+        )
+
+    def test_readwritepaths_covers_runtime_dirs(self, template_text: str) -> None:
+        # `ProtectSystem=strict` mounts /usr + /etc + /boot read-only;
+        # without ReadWritePaths the agent can't write to its own state
+        # dir. Assert all three required paths are listed.
+        m = re.search(r"^ReadWritePaths=(.+)$", template_text, re.MULTILINE)
+        assert m is not None
+        paths = m.group(1).split()
+        for required in ("/var/lib/hal0", "/var/log/hal0", "/run/hal0"):
+            assert required in paths, (
+                f"ReadWritePaths missing {required} — agent will fail to write state"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Identity
+# ---------------------------------------------------------------------------
+
+
+class TestIdentity:
+    def test_user_and_group_hal0(self, template_text: str) -> None:
+        assert re.search(r"^User=hal0\b", template_text, re.MULTILINE)
+        assert re.search(r"^Group=hal0\b", template_text, re.MULTILINE)
+
+    def test_agent_id_env_set(self, template_text: str) -> None:
+        # The shim's _find_child_pids scan keys off HAL0_AGENT_ID, and
+        # downstream Hermes plugins use it for the X-hal0-Agent header.
+        assert re.search(r'^Environment="HAL0_AGENT_ID=%i"', template_text, re.MULTILINE)
+
+    def test_environment_file_per_instance(self, template_text: str) -> None:
+        # Leading `-` makes a missing file non-fatal — important on
+        # first boot before any operator override exists.
+        assert re.search(
+            r"^EnvironmentFile=-/etc/hal0/agents/%i\.env\b",
+            template_text,
+            re.MULTILINE,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hermes override
+# ---------------------------------------------------------------------------
+
+
+class TestHermesOverride:
+    def test_pins_hermes_home(self, override_text: str) -> None:
+        # The agent's `$HERMES_HOME` is what `_claim_hermes_home` marks
+        # with `.hal0-managed` — if this drifts, bootstrap will refuse
+        # to write a fresh config.
+        assert re.search(
+            r'^Environment="HERMES_HOME=/var/lib/hal0/agents/hermes"',
+            override_text,
+            re.MULTILINE,
+        )
+
+    def test_pins_dashboard_tui(self, override_text: str) -> None:
+        # Belt-and-braces with the shim's `--tui` flag — env wins if
+        # argv is ever stripped (e.g. operator drops a custom ExecStart).
+        assert re.search(r'^Environment="HERMES_DASHBOARD_TUI=1"', override_text, re.MULTILINE)
+
+    def test_lemonade_base_default(self, override_text: str) -> None:
+        # 127.0.0.1:13305 matches `installer/install.sh`'s lemond bind.
+        assert re.search(
+            r'^Environment="HAL0_LEMONADE_BASE=http://127\.0\.0\.1:13305"',
+            override_text,
+            re.MULTILINE,
+        )


### PR DESCRIPTION
## Summary
- New systemd template unit `installer/systemd/hal0-agent@.service` (parameterized by `%i` agent id; v0.4-ready for `hal0-agent@piccoder.service` drop-in)
- New `hal0-agent` CLI shim (`src/hal0/cli/agent_shim.py`) wrapping `hermes dashboard --tui` with sd_notify + watchdog + graceful stop
- `hal0-agent@hermes.service.d/override.conf` pins hermes-specific env (HERMES_HOME, HAL0_LEMONADE_BASE)
- `installer/install.sh` lays down the unit + drop-in, then enables `hal0-agent@hermes.service` when the venv exists (PR-3 lands the venv)
- `docs/agents/hermes/SERVICE.md` — operator recipes (start/stop/restart/journalctl, failure-mode triage, customisation)

## ExecStart mode rationale (DA-sec-ops MUST-FIX #1)

Picking the wrong Hermes subcommand here kills chat day-1. Inspected `~/src/hermes-agent/hermes_cli/` to identify the subcommand that boots `web_server.py` (the one mounting `/api/pty`, `/api/events`, `/api/ws`):

- `hermes_cli/main.py:14050-14102` defines the `dashboard` subparser; `set_defaults(func=cmd_dashboard)` at line 14102
- `hermes_cli/main.py:10861` `cmd_dashboard`, at line **10930** does `from hermes_cli.web_server import start_server` and at line **10933-10939** calls it
- `web_server.py:3585` mounts `/api/pty`, `web_server.py:3763` mounts `/api/events`, `web_server.py:3704` mounts `/api/ws`

**Chosen mode**: **`hermes dashboard --host 127.0.0.1 --port 9119 --tui --no-open --skip-build`**

Flag rationale:
- `--tui` (or env `HERMES_DASHBOARD_TUI=1`, set in the override) — without it the dashboard runs but `/api/pty` refuses upgrades and the chat tab is hidden (`main.py:14069-14076`, `web_server.py:91`)
- `--skip-build` — runtime box may not have npm; wheel ships pre-built `web_dist/`
- `--no-open` — headless
- `--host 127.0.0.1` — hal0-api proxies the WS; binding 0.0.0.0 would skip the Origin/HMAC checks (DA-sec-ops #2)

Test `tests/cli/test_agent_shim.py::TestHermesArgv::test_chooses_dashboard_subcommand` asserts `dashboard` is in argv and neither `mcp` nor `serve` (subcommands of `mcp`) are. Test `tests/systemd/test_unit_files.py::test_exec_start_never_uses_mcp_serve` asserts no `ExecStart=` line in the unit contains `mcp serve`.

## Hardening (DA-sec-ops MUST-FIX #5)

Per `docs/internal/hermes-research-2026-05-28/plans/da-sec-ops.md`:

| Directive | Why |
|---|---|
| `Wants=hal0-lemonade.service` (NOT `Requires=`/`BindsTo=`) | survives Lemonade GPU-cleanup-after-unload deadlock (memory `hal0_lemonade_unload_gpu_cleanup_hang`) |
| `Type=notify` + `WatchdogSec=60` | systemd notices when the agent ITSELF hangs |
| `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome=yes`, `PrivateTmp`, `ProtectKernel*`, `RestrictSUIDSGID`, `RestrictRealtime` | defense-in-depth sandbox |
| `ReadWritePaths=/var/lib/hal0 /var/log/hal0 /run/hal0` | carve-out for legit writes under `ProtectSystem=strict` |

## Shim design notes

- Pure-stdlib + subprocess. No `systemd-python`, no `psutil`, no `fastapi` import — the shim must boot before `hal0-api.service`.
- sd_notify over AF_UNIX datagram (handles abstract namespace `@socket` per sd_notify(3)).
- `cmd_stop` scans `/proc` for processes matching BOTH the venv `hermes` binary path AND the matching `HAL0_AGENT_ID` env — won't kill a manually-launched `hermes dashboard` on the same box.
- `cmd_reprovision` shells to `hal0 agent bootstrap <type> --repair` (current CLI surface).

## Verification

| Check | Result |
|---|---|
| `ruff format --check` (my files) | exit 0 |
| `ruff check` (my files) | exit 0 |
| `mypy src/hal0/cli/agent_shim.py` | exit 0 |
| `pytest tests/cli/test_agent_shim.py tests/systemd/test_unit_files.py` | 57 passed |
| `pytest tests/cli/ tests/systemd/` | 182 passed |
| `systemd-analyze verify hal0-agent@hermes.service` on LXC | only error = missing `/usr/local/bin/hal0-agent` (expected pre-merge) |

5 files would-be-reformatted in `ruff format --check .` are pre-existing on the base branch (confirmed via stash + base check) — none from this PR.

## Test plan
- [x] `pytest tests/cli/test_agent_shim.py` (argv parsing, config resolution, dashboard-mode selection, env propagation, sd_notify wire protocol, /proc PID discovery AND-gate, cmd_status/stop/reprovision)
- [x] `pytest tests/systemd/test_unit_files.py` (directive presence + ExecStart mode safety)
- [x] `systemd-analyze verify` on LXC 105 (real systemd 256)
- [x] `ruff format --check` / `ruff check` / `mypy` on touched files
- [ ] Live LXC start (deferred — needs `hal0-agent` shim on PATH via wheel install; gated by `hal0 agent bootstrap hermes` per install.sh)
- [ ] Full chat round-trip (deferred to PR-9 + PR-10)

Refs `MASTER-PLAN.md §4 PR-5`. Addresses `DA-sec-ops` MUST-FIX #1 + #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)