### PR TITLE
v0.3: /api/agents/{id}/personas endpoints + hot-reload activate

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -23,6 +23,9 @@ if TYPE_CHECKING:
     from hal0.lemonade.metrics_shim import MetricsShim
 
 from hal0 import __version__
+from hal0.api.agents import (
+    personas as agents_personas_routes,
+)
 from hal0.api.middleware import error_codes, request_id
 from hal0.api.routes import (
     agents as agents_routes,
@@ -942,6 +945,16 @@ def create_app() -> FastAPI:
         agents_routes.router,
         prefix="/api/agents",
         tags=["agents"],
+    )
+
+    # Agent personas (v0.3 PR-4). Per-agent persona TOML browse + activate
+    # under the SAME ``/api/agents`` prefix so the dashboard's agent view
+    # nests personas under the agent it belongs to. Routes are
+    # parameterized by agent id; v0.3 only resolves ``"hermes"``.
+    app.include_router(
+        agents_personas_routes.router,
+        prefix="/api/agents",
+        tags=["agents", "personas"],
     )
 
     # Approval inbox (ADR-0004 §5). The dashboard bell, the MCP admin

--- a/src/hal0/api/agents/__init__.py
+++ b/src/hal0/api/agents/__init__.py
@@ -1,0 +1,1 @@
+"""API routes for the agents surface. Submodules are imported by callers."""

--- a/src/hal0/api/agents/personas.py
+++ b/src/hal0/api/agents/personas.py
@@ -1,0 +1,288 @@
+"""Persona endpoints for the bundled agents surface (v0.3 PR-4).
+
+Thin FastAPI wrapper around :mod:`hal0.agents.personas`. The persona TOML
+store + hot-reload nudge live in that module; this file is the HTTP
+shape the dashboard's persona picker (PR-8) + the ``hal0 agent persona``
+CLI (future) consume.
+
+Route shape (master-plan §2 generalization): every endpoint is
+parameterized by ``agent_id`` so v0.4 can unlock pi-coder by adding a
+registry entry without rewriting the route table. v0.3 only resolves
+``"hermes"`` — any other id returns 404 at :func:`_resolve_agent`.
+
+Mounted from :mod:`hal0.api` at prefix ``/api/agents`` so the realized
+routes are:
+
+    GET  /api/agents/{agent_id}/personas
+    GET  /api/agents/{agent_id}/personas/{persona_id}
+    POST /api/agents/{agent_id}/personas/{persona_id}/activate
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import structlog
+from fastapi import APIRouter
+
+from hal0.agents import personas as personas_mod
+from hal0.errors import BadRequest, Hal0Error, NotFound
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+# ── agent registry ──────────────────────────────────────────────────────────
+#
+# v0.3 ships hermes only. Future agents (pi-coder in v0.4) get a row here
+# pointing at their personas root and the existing /personas routes light
+# up unchanged. Keeping this as a module-level dict (vs hard-coding the
+# "hermes" string in every handler) is the v0.3-only place that knows
+# about agent identity — every route below uses :func:`_resolve_agent`.
+
+_AGENT_PERSONAS_ROOTS: dict[str, Path] = {
+    "hermes": personas_mod.PERSONAS_ROOT,
+}
+
+
+def _resolve_agent(agent_id: str) -> Path:
+    """Map an agent id onto its personas store root.
+
+    Raises :class:`NotFound` with a stable code so the dashboard can
+    distinguish "unknown agent" from "unknown persona" (which share the
+    same HTTP status but should render different UX).
+    """
+    root = _AGENT_PERSONAS_ROOTS.get(agent_id)
+    if root is None:
+        raise NotFound(
+            f"unknown agent {agent_id!r}",
+            code="agent.unknown",
+            details={"agent_id": agent_id},
+        )
+    return root
+
+
+# ── serialisers ─────────────────────────────────────────────────────────────
+
+
+def _persona_summary(persona: personas_mod.Persona, active_id: str | None) -> dict[str, Any]:
+    """Compact row shape used by the list endpoint.
+
+    Matches the dashboard persona picker (PR-8) contract — ``id`` plus
+    enough metadata to render a card without a follow-up detail fetch.
+    """
+    return {
+        "id": persona.id,
+        "display_name": persona.display_name,
+        "summary": persona.summary,
+        "active": persona.id == active_id,
+    }
+
+
+def _persona_detail(
+    persona: personas_mod.Persona,
+    *,
+    raw_toml: str,
+    active_id: str | None,
+) -> dict[str, Any]:
+    """Full persona payload — parsed dataclass + raw TOML body.
+
+    The raw body is included so the PR-8 persona editor can let the
+    operator hand-edit the TOML without losing comments or formatting
+    on a round-trip through the dataclass. The parsed fields are there
+    so the picker can render labels + policy chips without re-parsing
+    TOML in the browser.
+    """
+    approval = persona.approval
+    return {
+        "id": persona.id,
+        "display_name": persona.display_name,
+        "summary": persona.summary,
+        "active": persona.id == active_id,
+        "system_prompt": persona.system_prompt,
+        "tools_allowed": list(persona.tools_allowed),
+        "memory_namespace": persona.memory_namespace,
+        "preferred_upstream": persona.preferred_upstream,
+        "preferred_model": persona.preferred_model,
+        "approval": {
+            "default_policy": approval.default_policy,
+            "auto_approve": list(approval.auto_approve),
+            "require_approval": list(approval.require_approval),
+        },
+        "raw_toml": raw_toml,
+    }
+
+
+def _safe_error_message(exc: Exception) -> str:
+    """Strip absolute filesystem paths out of a persona-error message.
+
+    :class:`hal0.agents.personas.PersonaError` includes the offending
+    path so the CLI can point at it; the API surface mustn't leak that
+    to the dashboard (path layout is operator-private). We replace any
+    absolute-looking prefix with ``<persona>``.
+    """
+    msg = str(exc)
+    # PersonaError messages always start with ``<path>: …`` — chop
+    # everything before the first ``: `` if it looks like a filesystem
+    # path. Conservative; only rewrites when the prefix actually starts
+    # with ``/``.
+    if msg.startswith("/"):
+        try:
+            _, rest = msg.split(": ", 1)
+        except ValueError:
+            return msg
+        return f"<persona>: {rest}"
+    return msg
+
+
+# ── GET /{agent_id}/personas ────────────────────────────────────────────────
+
+
+@router.get("/{agent_id}/personas")
+async def list_agent_personas(agent_id: str) -> dict[str, Any]:
+    """List every persona registered for ``agent_id``.
+
+    Returns ``{"agent_id", "active", "personas": [...]}`` so the
+    dashboard can render the picker with one fetch. The ``active`` field
+    at the envelope level mirrors the ``active: bool`` flag on each row
+    — clients can rely on either.
+    """
+    root = _resolve_agent(agent_id)
+    items = personas_mod.list_personas(root=root)
+    active = personas_mod.get_active(root=root)
+    return {
+        "agent_id": agent_id,
+        "active": active,
+        "personas": [_persona_summary(p, active) for p in items],
+    }
+
+
+# ── GET /{agent_id}/personas/{persona_id} ───────────────────────────────────
+
+
+@router.get("/{agent_id}/personas/{persona_id}")
+async def get_agent_persona(agent_id: str, persona_id: str) -> dict[str, Any]:
+    """Return parsed persona + raw TOML body for one persona.
+
+    404 if the agent id is unknown OR the persona file is missing.
+    400 if the file exists but fails to parse — the dashboard surfaces
+    the message verbatim so the operator can fix the offending TOML.
+    """
+    root = _resolve_agent(agent_id)
+    target = root / f"{persona_id}.toml"
+    try:
+        persona = personas_mod.load_persona(persona_id, root=root)
+    except FileNotFoundError as exc:
+        raise NotFound(
+            f"persona {persona_id!r} not found",
+            code="persona.not_found",
+            details={"agent_id": agent_id, "persona_id": persona_id},
+        ) from exc
+    except personas_mod.PersonaError as exc:
+        raise BadRequest(
+            _safe_error_message(exc),
+            code="persona.malformed",
+            details={"agent_id": agent_id, "persona_id": persona_id},
+        ) from exc
+
+    try:
+        raw_toml = target.read_text(encoding="utf-8")
+    except OSError:
+        # Loaded successfully but reading the raw bytes failed — return
+        # an empty body rather than 500ing the whole request. Parsed
+        # content is the authoritative shape; raw_toml is a convenience
+        # for the editor.
+        raw_toml = ""
+
+    active = personas_mod.get_active(root=root)
+    return _persona_detail(persona, raw_toml=raw_toml, active_id=active)
+
+
+# ── POST /{agent_id}/personas/{persona_id}/activate ─────────────────────────
+
+
+@router.post("/{agent_id}/personas/{persona_id}/activate")
+async def activate_agent_persona(
+    agent_id: str,
+    persona_id: str,
+    body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Swap the active persona for ``agent_id`` to ``persona_id``.
+
+    Body shape ``{"reload": bool}``; ``reload`` defaults to ``true`` so
+    the dashboard's persona picker just POSTs an empty body and gets the
+    hot-reload nudge for free. ``reload=false`` writes ``active.txt``
+    but skips the JSON-RPC call — useful for batch tooling that wants
+    to flip the pointer without bothering a running Hermes process.
+
+    Response carries the *previous* active persona id so the dashboard
+    can render an undo affordance. ``reloaded`` reflects the hot-reload
+    helper's success — ``false`` doesn't mean activation failed; it
+    just means the next message will use the new persona instead of
+    the in-flight one.
+    """
+    root = _resolve_agent(agent_id)
+    do_reload = True
+    if isinstance(body, dict) and "reload" in body:
+        do_reload = bool(body["reload"])
+
+    previous = personas_mod.get_active(root=root)
+
+    if do_reload:
+        try:
+            result = personas_mod.activate(persona_id, root=root)
+        except FileNotFoundError as exc:
+            raise NotFound(
+                f"persona {persona_id!r} not found",
+                code="persona.not_found",
+                details={"agent_id": agent_id, "persona_id": persona_id},
+            ) from exc
+        except personas_mod.PersonaError as exc:
+            raise BadRequest(
+                _safe_error_message(exc),
+                code="persona.malformed",
+                details={"agent_id": agent_id, "persona_id": persona_id},
+            ) from exc
+        except Hal0Error:
+            raise
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning(
+                "persona.activate_failed",
+                agent_id=agent_id,
+                persona_id=persona_id,
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            raise Hal0Error(
+                "persona activation failed",
+                code="persona.activate_failed",
+            ) from exc
+
+        hot_reload = result.get("hot_reload") or {}
+        return {
+            "agent_id": agent_id,
+            "active": result.get("persona_id", persona_id),
+            "previous": previous,
+            "reloaded": bool(hot_reload.get("ok")),
+            "reload_error": hot_reload.get("error"),
+        }
+
+    # reload=false branch: write active.txt but DON'T nudge hermes.
+    try:
+        personas_mod.set_active(persona_id, root=root)
+    except FileNotFoundError as exc:
+        raise NotFound(
+            f"persona {persona_id!r} not found",
+            code="persona.not_found",
+            details={"agent_id": agent_id, "persona_id": persona_id},
+        ) from exc
+
+    return {
+        "agent_id": agent_id,
+        "active": persona_id,
+        "previous": previous,
+        "reloaded": False,
+        "reload_error": None,
+    }

--- a/tests/api/test_agents_personas.py
+++ b/tests/api/test_agents_personas.py
@@ -1,0 +1,308 @@
+"""HTTP tests for ``/api/agents/{agent_id}/personas`` (PR-4, v0.3).
+
+Pins the route shape the dashboard persona picker (PR-8) and any future
+CLI/automation consumers depend on. Each test points the personas store
+at a tmp_path via monkeypatching :data:`hal0.agents.personas.PERSONAS_ROOT`
++ the API module's registry so we don't write to ``/var/lib/hal0`` from
+the test runner.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hal0.agents import personas as personas_mod
+from hal0.api.agents import personas as personas_route
+
+
+@pytest.fixture
+def personas_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Path]:
+    """Redirect the personas store to a tmp dir for the whole test.
+
+    Both the module-level :data:`PERSONAS_ROOT` (used by helpers like
+    :func:`hermes_reload`) and the route module's agent registry are
+    rewired so the API handlers resolve agent_id="hermes" against the
+    tmp dir.
+    """
+    root = tmp_path / "personas"
+    root.mkdir()
+    monkeypatch.setattr(personas_mod, "PERSONAS_ROOT", root)
+    monkeypatch.setitem(personas_route._AGENT_PERSONAS_ROOTS, "hermes", root)
+    yield root
+
+
+@pytest.fixture
+def seeded_personas(personas_root: Path) -> Path:
+    """Seed the hermes + coder personas + the active pointer (= hermes)."""
+    personas_mod.seed_default_personas(agent_id="hermes-agent", root=personas_root)
+    return personas_root
+
+
+# ── list ────────────────────────────────────────────────────────────────────
+
+
+def test_list_returns_seeded_personas(client: TestClient, seeded_personas: Path) -> None:
+    r = client.get("/api/agents/hermes/personas")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["agent_id"] == "hermes"
+    assert body["active"] == "hermes"
+    ids = sorted(row["id"] for row in body["personas"])
+    assert ids == ["coder", "hermes"]
+    hermes_row = next(row for row in body["personas"] if row["id"] == "hermes")
+    assert hermes_row["active"] is True
+    assert hermes_row["display_name"] == "Hermes"
+    assert "summary" in hermes_row
+    coder_row = next(row for row in body["personas"] if row["id"] == "coder")
+    assert coder_row["active"] is False
+
+
+def test_list_empty_when_store_empty(client: TestClient, personas_root: Path) -> None:
+    r = client.get("/api/agents/hermes/personas")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["personas"] == []
+    assert body["active"] is None
+
+
+def test_list_unknown_agent_returns_404(client: TestClient, personas_root: Path) -> None:
+    r = client.get("/api/agents/pi-coder/personas")
+    assert r.status_code == 404
+    body = r.json()
+    assert body["error"]["code"] == "agent.unknown"
+
+
+# ── detail ──────────────────────────────────────────────────────────────────
+
+
+def test_detail_returns_parsed_and_raw_toml(client: TestClient, seeded_personas: Path) -> None:
+    r = client.get("/api/agents/hermes/personas/hermes")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["id"] == "hermes"
+    assert body["display_name"] == "Hermes"
+    assert body["active"] is True
+    assert body["system_prompt"].startswith("You are Hermes")
+    assert isinstance(body["tools_allowed"], list)
+    assert body["approval"]["default_policy"] == "ask"
+    assert "memory.read.*" in body["approval"]["auto_approve"]
+    # Raw TOML is the source-of-truth body the editor surface needs.
+    assert "[persona]" in body["raw_toml"]
+    assert 'id = "hermes"' in body["raw_toml"]
+
+
+def test_detail_inactive_persona_reports_active_false(
+    client: TestClient, seeded_personas: Path
+) -> None:
+    r = client.get("/api/agents/hermes/personas/coder")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["id"] == "coder"
+    assert body["active"] is False
+
+
+def test_detail_unknown_persona_returns_404(client: TestClient, seeded_personas: Path) -> None:
+    r = client.get("/api/agents/hermes/personas/ghost")
+    assert r.status_code == 404
+    body = r.json()
+    assert body["error"]["code"] == "persona.not_found"
+
+
+def test_detail_unknown_agent_returns_404(client: TestClient, personas_root: Path) -> None:
+    r = client.get("/api/agents/pi-coder/personas/anything")
+    assert r.status_code == 404
+    body = r.json()
+    assert body["error"]["code"] == "agent.unknown"
+
+
+def test_detail_malformed_toml_returns_400(client: TestClient, personas_root: Path) -> None:
+    (personas_root / "broken.toml").write_text(
+        "[persona]\nid = 'broken'\ndisplay_name = unterminated", encoding="utf-8"
+    )
+    r = client.get("/api/agents/hermes/personas/broken")
+    assert r.status_code == 400
+    body = r.json()
+    assert body["error"]["code"] == "persona.malformed"
+    # The path-leak guard rewrites ``/path: …`` → ``<persona>: …``.
+    msg = body["error"]["message"]
+    assert str(personas_root) not in msg
+
+
+@pytest.mark.parametrize(
+    "toml_body, expected_substring",
+    [
+        # Missing [persona].id
+        (
+            '[persona]\ndisplay_name = "Bad"\n',
+            "id is required",
+        ),
+        # Invalid default_policy
+        (
+            '[persona]\nid = "bad-policy"\ndisplay_name = "Bad"\n'
+            '[persona.approval]\ndefault_policy = "yolo"\n',
+            "default_policy",
+        ),
+    ],
+)
+def test_detail_invalid_persona_returns_400(
+    client: TestClient,
+    personas_root: Path,
+    toml_body: str,
+    expected_substring: str,
+) -> None:
+    # Filename stem must align with [persona].id for the id-mismatch
+    # branch not to fire first; we deliberately exercise the missing-id
+    # + bad-policy errors instead.
+    persona_file = "bad-policy" if "bad-policy" in toml_body else "noid"
+    (personas_root / f"{persona_file}.toml").write_text(toml_body, encoding="utf-8")
+    r = client.get(f"/api/agents/hermes/personas/{persona_file}")
+    assert r.status_code == 400, r.text
+    body = r.json()
+    assert body["error"]["code"] == "persona.malformed"
+    assert expected_substring in body["error"]["message"]
+
+
+# ── activate ────────────────────────────────────────────────────────────────
+
+
+def test_activate_switches_active_and_invokes_hot_reload(
+    client: TestClient,
+    seeded_personas: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default body (no ``reload`` key) triggers the hot-reload helper."""
+    calls: list[dict[str, Any]] = []
+
+    def _fake_reload(**kwargs: Any) -> tuple[bool, str | None]:
+        calls.append(kwargs)
+        return (True, None)
+
+    monkeypatch.setattr(personas_mod, "hermes_reload", _fake_reload)
+
+    r = client.post("/api/agents/hermes/personas/coder/activate", json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["agent_id"] == "hermes"
+    assert body["active"] == "coder"
+    assert body["previous"] == "hermes"
+    assert body["reloaded"] is True
+    assert body["reload_error"] is None
+    # The pointer file actually moved.
+    assert personas_mod.get_active(root=seeded_personas) == "coder"
+    # And the hot-reload nudge actually fired once.
+    assert len(calls) == 1
+
+
+def test_activate_reload_false_skips_hot_reload(
+    client: TestClient,
+    seeded_personas: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``reload=false`` writes active.txt but DOESN'T call hermes_reload."""
+    calls: list[dict[str, Any]] = []
+
+    def _fake_reload(**kwargs: Any) -> tuple[bool, str | None]:
+        calls.append(kwargs)
+        return (True, None)
+
+    monkeypatch.setattr(personas_mod, "hermes_reload", _fake_reload)
+
+    r = client.post(
+        "/api/agents/hermes/personas/coder/activate",
+        json={"reload": False},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["active"] == "coder"
+    assert body["previous"] == "hermes"
+    assert body["reloaded"] is False
+    assert body["reload_error"] is None
+    # Pointer moved …
+    assert personas_mod.get_active(root=seeded_personas) == "coder"
+    # … but hermes_reload was NEVER called.
+    assert calls == []
+
+
+def test_activate_reports_failed_hot_reload(
+    client: TestClient,
+    seeded_personas: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failed hot-reload is non-fatal; response carries ``reloaded=false``."""
+    monkeypatch.setattr(personas_mod, "hermes_reload", lambda **_: (False, "connection refused"))
+
+    r = client.post("/api/agents/hermes/personas/coder/activate", json={})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["active"] == "coder"
+    assert body["reloaded"] is False
+    assert body["reload_error"] == "connection refused"
+    assert personas_mod.get_active(root=seeded_personas) == "coder"
+
+
+def test_activate_unknown_persona_returns_404(
+    client: TestClient,
+    seeded_personas: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(personas_mod, "hermes_reload", lambda **_: (True, None))
+    r = client.post("/api/agents/hermes/personas/ghost/activate", json={})
+    assert r.status_code == 404
+    body = r.json()
+    assert body["error"]["code"] == "persona.not_found"
+    # Active pointer must NOT have moved.
+    assert personas_mod.get_active(root=seeded_personas) == "hermes"
+
+
+def test_activate_unknown_agent_returns_404(
+    client: TestClient,
+    personas_root: Path,
+) -> None:
+    r = client.post("/api/agents/pi-coder/personas/whatever/activate", json={})
+    assert r.status_code == 404
+    body = r.json()
+    assert body["error"]["code"] == "agent.unknown"
+
+
+def test_activate_no_body_defaults_to_reload_true(
+    client: TestClient,
+    seeded_personas: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POSTing with no body still triggers the hot-reload nudge."""
+    calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(
+        personas_mod,
+        "hermes_reload",
+        lambda **kwargs: calls.append(kwargs) or (True, None),
+    )
+
+    r = client.post("/api/agents/hermes/personas/coder/activate")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["reloaded"] is True
+    assert len(calls) == 1
+
+
+def test_activate_reload_false_unknown_persona_404(
+    client: TestClient,
+    seeded_personas: Path,
+) -> None:
+    """The reload=false branch also 404s on missing persona."""
+    r = client.post(
+        "/api/agents/hermes/personas/ghost/activate",
+        json={"reload": False},
+    )
+    assert r.status_code == 404
+    body = r.json()
+    assert body["error"]["code"] == "persona.not_found"
+    assert personas_mod.get_active(root=seeded_personas) == "hermes"


### PR DESCRIPTION
## Summary
- GET list / GET detail / POST activate endpoints for personas
- Uses PR-3's persona TOML store + activation helper (reload.env JSON-RPC)
- Routes parameterized by agent id (v0.3 = hermes only; v0.4 = pi-coder free)

## Test plan
- [x] List returns seeded hermes + coder
- [x] Detail returns parsed + raw TOML
- [x] Activate writes active.txt + invokes hot-reload (mocked)
- [x] reload=false skips hot-reload
- [x] 404 for unknown persona / unknown agent id
- [x] 400 for malformed TOML
- [x] ruff format --check / ruff check / mypy / pytest (17/17)

Refs MASTER-PLAN.md §4 PR-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)