### PR TITLE
v0.3: ADR-0015 upstream Hermes pin + weekly hermes-sdk-diff CI job

### DIFF
--- a/.github/workflows/hermes-sdk-diff.yml
+++ b/.github/workflows/hermes-sdk-diff.yml
@@ -1,0 +1,216 @@
+name: Hermes SDK drift (weekly)
+
+# Weekly diff of the hal0-tracked Hermes-Agent upstream surfaces
+# against the pin recorded in pyproject.toml's
+# [tool.hal0.upstream-hermes] table.
+#
+# Why this exists:
+#   ADR-0015 + MASTER-PLAN §5 ("Upstream upgrade cadence") + DA-arch
+#   must-fix #1 ("Hermes is HOT upstream"). Hermes ships ~40 commits/day
+#   on main; without a process the vendored slice + plugin SDK shim
+#   drift silently. This job is the safety net.
+#
+# Failure handling:
+#   On drift, open (or update) a single tracking issue tagged
+#   `upstream-drift` + `triage`. One issue per drift state — we refuse
+#   to spam a fresh ticket every Monday while the same surface change
+#   is unresolved. Mirrors agent-shim-smoke.yml's `notify` shape.
+
+on:
+  schedule:
+    # Mondays 12:00 UTC — Monday morning in the Americas, Monday lunch
+    # in EU, Monday late-night in Asia. Catches a full week of upstream
+    # churn before the next review.
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: hermes-sdk-diff
+  # Latest weekly run wins. Operators triggering workflow_dispatch
+  # supersede a scheduled run in flight.
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write   # required for the notify job below
+
+jobs:
+  diff:
+    name: Diff tracked Hermes surfaces against pin
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      drift: ${{ steps.diff.outputs.drift }}
+      pinned: ${{ steps.diff.outputs.pinned }}
+      head: ${{ steps.diff.outputs.head }}
+
+    steps:
+      - name: Checkout hal0
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Read upstream pin from pyproject.toml
+        id: pin
+        run: |
+          set -euo pipefail
+          # Sanity check — the script reads pyproject directly, but we
+          # surface the pin in the workflow log too so a glance at the
+          # run page tells you what was compared.
+          python3 - <<'PY'
+          import os, tomllib
+          with open("pyproject.toml", "rb") as fh:
+              data = tomllib.load(fh)
+          pin = data["tool"]["hal0"]["upstream-hermes"]
+          with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+              fh.write(f"repo={pin['repo']}\n")
+              fh.write(f"commit={pin['commit']}\n")
+              fh.write(f"date={pin['date']}\n")
+          PY
+
+      - name: Run hermes-sdk-diff
+        id: diff
+        # The script is the contract. Exit 0 = no drift, exit 1 = drift,
+        # exit 2 = operational error. We treat exit 1 as a successful
+        # run that surfaced drift — the notify job picks it up.
+        run: |
+          set -euo pipefail
+          # Capture stdout (the markdown report) into a file the notify
+          # job can lift into an issue body.
+          set +e
+          bash scripts/hermes-sdk-diff.sh > hermes-sdk-diff.md
+          rc=$?
+          set -e
+          case "$rc" in
+              0)
+                  echo "drift=false" >> "$GITHUB_OUTPUT"
+                  ;;
+              1)
+                  echo "drift=true" >> "$GITHUB_OUTPUT"
+                  ;;
+              *)
+                  echo "::error::hermes-sdk-diff.sh exited with operational error ($rc)"
+                  cat hermes-sdk-diff.md || true
+                  exit "$rc"
+                  ;;
+          esac
+          # Resolve shorts for the title in the notify job.
+          python3 - <<'PY'
+          import os, subprocess, tomllib
+          with open("pyproject.toml", "rb") as fh:
+              data = tomllib.load(fh)
+          pinned = data["tool"]["hal0"]["upstream-hermes"]["commit"]
+          head = subprocess.check_output(
+              ["git", "ls-remote", data["tool"]["hal0"]["upstream-hermes"]["repo"], "HEAD"],
+              text=True,
+          ).split()[0]
+          with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+              fh.write(f"pinned={pinned[:8]}\n")
+              fh.write(f"head={head[:8]}\n")
+          PY
+
+      - name: Upload diff report
+        uses: actions/upload-artifact@v4
+        with:
+          name: hermes-sdk-diff
+          path: hermes-sdk-diff.md
+          if-no-files-found: ignore
+
+  # ── failure-issue handling ───────────────────────────────────────────
+  # Runs only when drift was detected. Opens a fresh issue tagged
+  # `upstream-drift` + `triage` if none is open, or comments on the
+  # existing one with the new run's URL + the new HEAD short sha.
+  # Mirrors agent-shim-smoke.yml's `notify` job shape (ADR-0015 §2).
+  notify:
+    name: Open/update upstream-drift issue
+    needs: diff
+    if: needs.diff.outputs.drift == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Download diff report
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-sdk-diff
+          path: .
+
+      - name: Find or create tracking issue
+        uses: actions/github-script@v7
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PINNED_SHORT: ${{ needs.diff.outputs.pinned }}
+          HEAD_SHORT: ${{ needs.diff.outputs.head }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const labels = ['upstream-drift', 'triage'];
+            const primary = labels[0];
+            const runUrl = process.env.RUN_URL;
+            const pinned = process.env.PINNED_SHORT;
+            const head = process.env.HEAD_SHORT;
+            const today = new Date().toISOString().slice(0, 10);
+
+            let report = '';
+            try {
+              report = fs.readFileSync('hermes-sdk-diff.md', 'utf8');
+            } catch (_) {
+              report = '_(diff report missing from artifact — see run log.)_';
+            }
+
+            // One open tracking issue per drift state. We attach to the
+            // first match and never open duplicates.
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              state: 'open',
+              labels: primary,
+              per_page: 100,
+            });
+
+            const body = [
+              `Upstream Hermes drift detected on ${today}.`,
+              ``,
+              `- Pinned: \`${pinned}\``,
+              `- Upstream HEAD: \`${head}\``,
+              `- Run: ${runUrl}`,
+              ``,
+              `Bump process: see ADR-0015 §4. TL;DR — review the diff`,
+              `below, update any shim adapters in the same PR, then run`,
+              `\`scripts/hermes-sdk-diff.sh --bump <new-sha>\` locally.`,
+              ``,
+              report,
+            ].join('\n');
+
+            if (open.length === 0) {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                title: `chore(hermes): upstream drift detected (${pinned} → ${head})`,
+                body,
+                labels,
+              });
+              core.info(`opened issue #${created.data.number}`);
+            } else {
+              const issue = open[0];
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: issue.number,
+                body: [
+                  `Still drifting on ${today}.`,
+                  ``,
+                  `- Upstream HEAD: \`${head}\``,
+                  `- Run: ${runUrl}`,
+                  ``,
+                  report,
+                ].join('\n'),
+              });
+              core.info(`updated issue #${issue.number}`);
+            }

--- a/docs/internal/adr/0015-upstream-hermes-pin-and-upgrade.md
+++ b/docs/internal/adr/0015-upstream-hermes-pin-and-upgrade.md
@@ -1,0 +1,226 @@
+# ADR 0015 — Upstream Hermes pin + weekly drift detection (v0.3)
+
+- **Status:** Accepted
+- **Date:** 2026-05-28
+- **Drivers:** MASTER-PLAN.md §4 PR-12 + §5 "Upstream upgrade cadence"; DA-arch must-fix #1 ("Hermes is HOT upstream — ~40 commits today alone, `registry.ts` 151 LOC changes monthly")
+- **Related:** ADR-0004 (agents v0.2 — `track-latest` mitigation, mirrored shape for the agent shim smoke job), ADR-0011 (Hermes identity card), ADR-0013 (MCP-client allow-list — the surfaces this pin protects)
+
+## Context
+
+v0.3 vendors a curated slice of Hermes-Agent into hal0 (system prompt
+addendums, the cognee memory provider, persona definitions) and proxies
+the rest through `hal0-api`. The integration depends on a small number
+of upstream surfaces being stable between bumps:
+
+- `web/src/plugins/registry.ts` — the `__HERMES_PLUGIN_SDK__` global
+  the hal0 sidebar block + cognee provider both consume.
+- `web/src/plugins/slots.ts` — plugin slot taxonomy; hal0 shim writes
+  here too.
+- `hermes_cli/web_server.py` — process lifecycle + WS endpoints the
+  hal0-api PTY proxy taps.
+- `agent/memory_provider.py` — the provider contract our vendored
+  `memory_cognee` plugin extends.
+- `tools/registry.py` — tool surface our MCP-client allow-list
+  (ADR-0013) classifies into allow/gated/blocked.
+- The events-bus emitter (taxonomy hal0's `/api/agents/<id>/events` WS
+  bridge re-emits).
+
+Upstream Hermes is **hot**: DA-arch #1 measured ~40 commits/day on
+`main` and ~151 LOC/month churn in `registry.ts` alone. Without a
+process:
+
+1. The vendored slice silently drifts behind upstream API changes.
+2. The `__HERMES_PLUGIN_SDK__` shim breaks when upstream renames or
+   re-shapes a field; first symptom is a blank shadow-root plugin
+   card in production.
+3. The proxy passes through an upstream version that no longer
+   matches the contract `/api/agents/hermes/*` clients depend on.
+
+The current pin (snapshotted by MASTER-PLAN §5 as of 2026-05-28) is
+**`0554ef1aa3a2e5818f292f76a676110239a5d34b`**. There is no
+machine-readable record of this in the hal0 tree, no automated
+detection of upstream drift, and no documented bump process.
+
+## Options considered
+
+| Option | Reason rejected (or accepted) |
+|---|---|
+| **Track upstream `main` (à la `agent-shim-smoke.yml`)** | Rejected. ADR-0004's track-latest worked for pi-coder because the contact surface is a CLI + one MCP handshake. Hermes' contact surface is six files, three of them in fast-moving Hermes plugin internals. Nightly breakage probability too high; the human cost (debugging which of six surfaces moved) is much higher than the cost of a weekly review. |
+| **Pin to upstream tagged releases only** | Rejected for v0.3. Hermes upstream doesn't tag on a predictable cadence; gating on tags would block hotfix adoption. Revisit in v0.4 when cadence is established. |
+| **Pin commit; Renovate/Dependabot for auto-PR on every upstream commit** | Rejected. Spammy at ~40 commits/day; signal-to-noise too low. The interesting events are surface-touching commits, not all commits. |
+| **Pin commit; weekly diff against upstream HEAD; issue on contract drift** | ACCEPTED. Coalesces noise; signal is "did anything hal0 cares about change in the last week?"; issue is the human gate. |
+| **Embed pin in `manifest.json`** | Rejected. `manifest.json` is the toolbox-image registry schema (`hal0.manifest.v1`), keyed by short image name. Repurposing for Python upstream pins muddies its schema + couples manifest-bumping CI to upstream-bumping CI. |
+| **Embed pin in `pyproject.toml` under `[tool.hal0.upstream-hermes]`** | ACCEPTED. Matches DA-arch #1's specific recommendation (`pyproject [tool.hal0.upstream]` lock file). One place, one parser, already in every contributor's tree. Forward-compatible with future `[tool.hal0.upstream-<thing>]` siblings. |
+
+## Decision
+
+### 1. Pin recorded in `pyproject.toml`
+
+A new `[tool.hal0.upstream-hermes]` table holds the pinned commit
+plus the list of upstream files hal0 depends on. Schema:
+
+```toml
+[tool.hal0.upstream-hermes]
+# Hermes-Agent upstream commit hash hal0 v0.3 is vendored/shimmed against.
+# Bump process: ADR-0015 §4. Do not edit by hand outside the bump PR.
+repo   = "https://github.com/earendil-works/hermes-agent"
+commit = "0554ef1aa3a2e5818f292f76a676110239a5d34b"
+date   = "2026-05-28"
+
+# Surfaces hal0 vendors, shims, or proxies. The weekly hermes-sdk-diff
+# job diffs upstream HEAD against `commit` for exactly these paths and
+# opens an issue if any of them changed.
+tracked_files = [
+    "web/src/plugins/registry.ts",
+    "web/src/plugins/slots.ts",
+    "hermes_cli/web_server.py",
+    "agent/memory_provider.py",
+    "tools/registry.py",
+    "agent/events.py",
+]
+```
+
+`scripts/hermes-sdk-diff.sh` and `.github/workflows/hermes-sdk-diff.yml`
+read this table as the single source of truth. `manifest.json` stays
+toolbox-only.
+
+### 2. Weekly upstream drift detection
+
+A new `hermes-sdk-diff` workflow runs **weekly on Mondays at 12:00 UTC**
+(`workflow_dispatch` also enabled for on-demand review). It:
+
+1. Reads `commit` + `tracked_files` from `[tool.hal0.upstream-hermes]`.
+2. Sparse-clones upstream Hermes into a temp dir at HEAD.
+3. For each tracked file, `git diff <pinned-commit>..<upstream-head> --
+   <file>` into a per-file diff section.
+4. If every diff is empty, logs "no drift" and exits 0 — no issue, no
+   noise.
+5. If any diff is non-empty, opens (or comments on) a single tracking
+   issue labeled `upstream-drift` + `triage` with title
+   `chore(hermes): upstream drift detected (<pinned-short> →
+   <head-short>)`. Body carries a per-surface summary + a link to the
+   workflow run. One open issue per drift state — the workflow attaches
+   to the existing issue if it's still open, same shape as
+   `agent-shim-smoke.yml`'s `notify` job.
+
+Concurrency: `cancel-in-progress: true` on the `hermes-sdk-diff`
+group. We never queue back-to-back weekly runs.
+
+Permissions: `contents: read` + `issues: write`.
+
+### 3. Local equivalent
+
+`scripts/hermes-sdk-diff.sh` is the script the workflow calls.
+Operators (and curious contributors) can run it locally with the same
+contract:
+
+```
+scripts/hermes-sdk-diff.sh           # diff + print to stdout; exit 1 on drift
+scripts/hermes-sdk-diff.sh --dry-run # parse the pin, print plan, exit 0
+scripts/hermes-sdk-diff.sh --bump <new-sha>
+                                     # rewrite the pin in pyproject.toml,
+                                     # update `date`, exit 0; intended
+                                     # to be run inside the bump PR.
+```
+
+The script clones upstream into a workdir under `$TMPDIR` (override
+with `HAL0_HERMES_DIFF_WORKDIR`), so it works on an air-gapped LXC
+just like everything else in `scripts/`.
+
+### 4. Bump process
+
+When a `upstream-drift` issue is filed:
+
+1. Reviewer reads the issue, opens the surfaces upstream changed,
+   classifies the change (rename / shape change / new field /
+   refactor-without-contract-change).
+2. If a shim adapter (e.g., `__HERMES_PLUGIN_SDK__` field map) needs
+   updating, that's the same PR.
+3. Run the local script with `--bump <new-sha>` to rewrite the pin and
+   the `date` field in `pyproject.toml`.
+4. Run the δ-harness (`make harness`) + γ-suite locally to confirm the
+   adapter still satisfies the integration contract.
+5. Open a PR titled `chore(hermes): bump upstream pin to <short-sha>`
+   targeting the active v0.x integration branch. PR body links the
+   triage issue + lists the adapter changes (if any).
+6. Closing comment on the `upstream-drift` issue lists the merged PR
+   and a one-line summary of what shifted.
+
+### 5. Freeze window
+
+**No upstream-pin bump is merged within 48h of any `v0.x*` release
+tag** on `Hal0ai/hal0`. Rationale: post-release hours are reserved
+for hotfixes on the released version; introducing a new upstream-pin
+delta at the same time produces ambiguous blame on regressions
+("did the hotfix break it or did the pin?"). The freeze is enforced
+by reviewer discipline rather than a CI gate — the PR template
+includes a checkbox for "I confirm no v0.x tag was pushed in the
+last 48h."
+
+### 6. Out of scope (v0.3)
+
+- **Renovate/Dependabot integration.** Considered; deferred. The
+  weekly-diff-to-issue workflow is the v0.3 contract. Revisit if the
+  drift cadence makes a manual review burdensome.
+- **Tagged-release-only policy.** Revisit in v0.4 once upstream tag
+  cadence is observable.
+- **Auto-rebump on adapter-clean diff.** Tempting but rejected for v0.3
+  — every bump deserves a human eye on at least the diff summary.
+- **Eval suite for upstream-bump regressions.** Same scope/cadence
+  story as ADR-0014's eval gate (v0.4 deliverable, tracked separately).
+
+## Consequences
+
+### Positive
+
+- Closes DA-arch must-fix #1 with a concrete artifact (pin + workflow
+  + script) rather than a process commitment.
+- Pin is machine-readable from `pyproject.toml` — `scripts/`,
+  CI, contributors, and future tooling read from one source.
+- Weekly cadence keeps the human gate cheap (one issue per week, max)
+  while still surfacing breakage at most 7 days after upstream
+  introduces it.
+- One open tracking issue per drift state (same shape as
+  `agent-shim-smoke.yml`) — no PR/issue spam during quiet weeks.
+- The `--bump` subcommand makes the bump PR mechanical:
+  `--bump <sha>` + adapter edit + tests + commit.
+
+### Negative / costs
+
+- 7-day worst-case latency on detecting a surface change is a real
+  trade-off vs nightly runs. Acceptable because the affected
+  components are vendored or shimmed in hal0 — a broken shim doesn't
+  break running installs until hal0 itself bumps the pin.
+- The freeze window is reviewer-disciplined, not CI-enforced. A
+  determined contributor can merge during a freeze window. Mitigation:
+  the PR template checkbox + an explicit ADR §5 paragraph.
+- Two places carry the upstream commit (pyproject + ADR text). The
+  ADR's `currently 0554ef1aa3a...` line is documentary — the
+  machine-readable pin is the source of truth, and the ADR text
+  references it as "see `[tool.hal0.upstream-hermes].commit`". No
+  automation reads the ADR text.
+- Sparse-clone in the workflow assumes upstream stays accessible on
+  GitHub. If upstream moves repos, the workflow needs a config
+  update — caught the same way as any other URL rot.
+
+## Pending items
+
+- `scripts/hermes-sdk-diff.sh` and `.github/workflows/hermes-sdk-diff.yml`
+  ship in this same PR.
+- `[tool.hal0.upstream-hermes]` table added to `pyproject.toml` in
+  this same PR.
+- PR template entry for the 48h freeze checkbox — follow-up issue.
+- First weekly run happens the Monday after merge; the
+  `upstream-drift` GitHub label is created on first issue creation.
+
+## References
+
+- MASTER-PLAN.md §4 PR-12, §5 "Upstream upgrade cadence" (in
+  `hermes-research-2026-05-28/`)
+- DA-arch must-fix #1, R2 vendor/shim findings (in
+  `hermes-research-2026-05-28/plans/da-arch-perf.md`)
+- ADR-0004 §3 ("Mitigation for track-latest churn") — the prior-art
+  shape for "weekly CI + one open issue per drift state"
+- `.github/workflows/agent-shim-smoke.yml` — implementation prior-art
+  for the `notify` job pattern
+- Hermes upstream: `https://github.com/earendil-works/hermes-agent`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,3 +134,27 @@ python_version = "3.11"
 strict = true
 warn_return_any = true
 warn_unused_configs = true
+
+# ADR-0015: machine-readable record of the Hermes-Agent upstream commit
+# hal0 v0.3 is vendored/shimmed against. Single source of truth — the
+# weekly hermes-sdk-diff workflow + scripts/hermes-sdk-diff.sh read this
+# table and nothing else. Bumps go through the process documented in
+# ADR-0015 §4 (review drift issue, edit shim adapter if needed, run
+# `scripts/hermes-sdk-diff.sh --bump <sha>`, δ-harness + γ-suite, open
+# `chore(hermes): bump upstream pin to <short-sha>` PR).
+[tool.hal0.upstream-hermes]
+repo   = "https://github.com/earendil-works/hermes-agent"
+commit = "0554ef1aa3a2e5818f292f76a676110239a5d34b"
+date   = "2026-05-28"
+
+# Surfaces hal0 vendors, shims, or proxies. The diff job only opens an
+# issue when one of these paths changes between the pinned commit and
+# upstream HEAD; commits that don't touch this list are ignored.
+tracked_files = [
+    "web/src/plugins/registry.ts",
+    "web/src/plugins/slots.ts",
+    "hermes_cli/web_server.py",
+    "agent/memory_provider.py",
+    "tools/registry.py",
+    "agent/events.py",
+]

--- a/scripts/hermes-sdk-diff.sh
+++ b/scripts/hermes-sdk-diff.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# hal0 v0.3 — Upstream Hermes drift detector (ADR-0015).
+#
+# Owner: v0.3 integration team.
+# Triggered by: .github/workflows/hermes-sdk-diff.yml (weekly + dispatch),
+#               and operators running locally to preview drift.
+#
+# Reads the pin recorded in pyproject.toml's [tool.hal0.upstream-hermes]
+# table, clones upstream Hermes at HEAD, diffs the tracked surfaces
+# against the pinned commit, and prints a markdown summary suitable for
+# a GitHub issue body.
+#
+# Exit codes:
+#   0 — no drift in tracked files (or --dry-run / --bump --no-fetch path).
+#   1 — drift detected on at least one tracked file.
+#   2 — operational error (missing pin, clone failure, bad arguments).
+#
+# Operator entry points:
+#   scripts/hermes-sdk-diff.sh                # full diff to stdout
+#   scripts/hermes-sdk-diff.sh --dry-run      # parse pin + print plan
+#   scripts/hermes-sdk-diff.sh --bump <sha>   # rewrite pin in-place
+#
+# Environment overrides:
+#   HAL0_HERMES_DIFF_WORKDIR  — clone target (default: mktemp -d).
+#   HAL0_HERMES_DIFF_KEEPDIR  — set non-empty to keep the clone after.
+
+set -euo pipefail
+
+# ── repo root resolution ────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PYPROJECT="${REPO_ROOT}/pyproject.toml"
+
+# ── argument parsing ───────────────────────────────────────────────────
+MODE="diff"
+BUMP_SHA=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            MODE="dry-run"
+            shift
+            ;;
+        --bump)
+            MODE="bump"
+            BUMP_SHA="${2:-}"
+            if [[ -z "${BUMP_SHA}" ]]; then
+                echo "error: --bump requires a commit sha" >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '2,30p' "${BASH_SOURCE[0]}"
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument '$1'" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ── pin parser ─────────────────────────────────────────────────────────
+# Read [tool.hal0.upstream-hermes] via the python tomllib stdlib. Keeps
+# the script free of TOML parsing in bash and matches what the workflow
+# does in its setup step.
+read_pin_field() {
+    local field="$1"
+    python3 - "$PYPROJECT" "$field" <<'PY'
+import sys
+import tomllib
+
+path, field = sys.argv[1], sys.argv[2]
+with open(path, "rb") as fh:
+    data = tomllib.load(fh)
+section = data.get("tool", {}).get("hal0", {}).get("upstream-hermes", {})
+value = section.get(field)
+if value is None:
+    sys.stderr.write(f"error: pyproject.toml is missing [tool.hal0.upstream-hermes].{field}\n")
+    sys.exit(2)
+if isinstance(value, list):
+    print("\n".join(value))
+else:
+    print(value)
+PY
+}
+
+REPO_URL="$(read_pin_field repo)"
+PINNED_COMMIT="$(read_pin_field commit)"
+mapfile -t TRACKED_FILES < <(read_pin_field tracked_files)
+
+# ── mode: dry-run ──────────────────────────────────────────────────────
+if [[ "${MODE}" == "dry-run" ]]; then
+    cat <<EOF
+hermes-sdk-diff plan (dry-run; no clone)
+  repo:    ${REPO_URL}
+  pinned:  ${PINNED_COMMIT}
+  tracked: ${#TRACKED_FILES[@]} file(s)
+EOF
+    for f in "${TRACKED_FILES[@]}"; do
+        echo "    - ${f}"
+    done
+    exit 0
+fi
+
+# ── mode: bump ─────────────────────────────────────────────────────────
+if [[ "${MODE}" == "bump" ]]; then
+    # Rewrite `commit = "..."` and `date = "..."` inside the
+    # [tool.hal0.upstream-hermes] block in-place. Uses python rather
+    # than sed so we never accidentally rewrite a same-shaped line in
+    # an unrelated section.
+    python3 - "$PYPROJECT" "$BUMP_SHA" <<'PY'
+import re
+import sys
+from datetime import date
+
+path, new_sha = sys.argv[1], sys.argv[2]
+with open(path, "r", encoding="utf-8") as fh:
+    text = fh.read()
+
+# Match the [tool.hal0.upstream-hermes] block up to the next top-level
+# section header (line starting with `[`) or EOF. Negative-lookahead is
+# used per-line so `tracked_files = [` arrays inside the block don't
+# terminate the match.
+block_re = re.compile(
+    r"\[tool\.hal0\.upstream-hermes\]\n(?:(?!^\[)[\s\S])*",
+    re.MULTILINE,
+)
+m = block_re.search(text)
+if not m:
+    sys.stderr.write("error: [tool.hal0.upstream-hermes] block not found\n")
+    sys.exit(2)
+block_text = m.group(0)
+
+new_block = re.sub(
+    r'(commit\s*=\s*)"[0-9a-fA-F]+"',
+    f'\\1"{new_sha}"',
+    block_text,
+    count=1,
+)
+new_block = re.sub(
+    r'(date\s*=\s*)"[0-9-]+"',
+    f'\\1"{date.today().isoformat()}"',
+    new_block,
+    count=1,
+)
+if new_block == block_text:
+    sys.stderr.write("error: failed to rewrite commit/date — pin shape changed?\n")
+    sys.exit(2)
+
+with open(path, "w", encoding="utf-8") as fh:
+    fh.write(text[: m.start()] + new_block + text[m.end():])
+print(f"bumped commit -> {new_sha}")
+PY
+    exit 0
+fi
+
+# ── mode: diff (default) ───────────────────────────────────────────────
+if ! command -v git >/dev/null 2>&1; then
+    echo "error: git not on PATH" >&2
+    exit 2
+fi
+
+WORKDIR="${HAL0_HERMES_DIFF_WORKDIR:-$(mktemp -d -t hermes-sdk-diff.XXXXXX)}"
+cleanup() {
+    if [[ -z "${HAL0_HERMES_DIFF_KEEPDIR:-}" && -z "${HAL0_HERMES_DIFF_WORKDIR:-}" ]]; then
+        rm -rf "${WORKDIR}"
+    fi
+}
+trap cleanup EXIT
+
+CLONE_DIR="${WORKDIR}/hermes-upstream"
+if [[ ! -d "${CLONE_DIR}/.git" ]]; then
+    # Sparse + filter clone keeps the workdir small. We need full
+    # history only for the pinned commit; everything else is a single
+    # snapshot at HEAD.
+    git clone --filter=blob:none --no-checkout "${REPO_URL}" "${CLONE_DIR}" >/dev/null 2>&1 || {
+        echo "error: failed to clone ${REPO_URL}" >&2
+        exit 2
+    }
+fi
+
+cd "${CLONE_DIR}"
+git sparse-checkout init --cone >/dev/null 2>&1 || true
+
+# Resolve HEAD + ensure the pinned commit is fetched.
+HEAD_SHA="$(git rev-parse origin/HEAD 2>/dev/null || git rev-parse HEAD)"
+if ! git cat-file -e "${PINNED_COMMIT}^{commit}" 2>/dev/null; then
+    # Pinned commit not in the default fetch — pull it explicitly.
+    git fetch --depth=1 origin "${PINNED_COMMIT}" >/dev/null 2>&1 || {
+        echo "error: failed to fetch pinned commit ${PINNED_COMMIT}" >&2
+        exit 2
+    }
+fi
+
+HEAD_SHORT="${HEAD_SHA:0:8}"
+PINNED_SHORT="${PINNED_COMMIT:0:8}"
+
+# Render markdown summary; track whether any file showed drift.
+drift=0
+{
+    echo "## Hermes upstream drift report"
+    echo
+    echo "- Pinned: \`${PINNED_SHORT}\`"
+    echo "- Upstream HEAD: \`${HEAD_SHORT}\`"
+    echo "- Repo: ${REPO_URL}"
+    echo
+} >&1
+
+for file in "${TRACKED_FILES[@]}"; do
+    diff_out="$(git diff "${PINNED_COMMIT}..${HEAD_SHA}" -- "${file}" 2>/dev/null || true)"
+    if [[ -z "${diff_out}" ]]; then
+        echo "### \`${file}\` — unchanged"
+        echo
+        continue
+    fi
+    drift=1
+    {
+        echo "### \`${file}\` — DRIFT"
+        echo
+        echo '<details><summary>diff</summary>'
+        echo
+        echo '```diff'
+        echo "${diff_out}"
+        echo '```'
+        echo
+        echo '</details>'
+        echo
+    } >&1
+done
+
+if [[ "${drift}" -eq 0 ]]; then
+    echo "_No tracked surfaces changed between ${PINNED_SHORT} and ${HEAD_SHORT}._"
+    exit 0
+fi
+
+exit 1


### PR DESCRIPTION
## Summary
- ADR-0015 codifies upstream Hermes pinning + upgrade policy — closes DA-arch must-fix #1 (Hermes ~40 commits/day, registry.ts churns ~151 LOC/month)
- Pin recorded in `pyproject.toml` under `[tool.hal0.upstream-hermes]` (commit + repo + date + tracked_files list). `manifest.json` left alone — that's the toolbox-image schema, wrong layer for Python upstream pins.
- New `scripts/hermes-sdk-diff.sh` for local + CI use. Exit 0 = no drift, 1 = drift, 2 = operational error. Supports `--dry-run` (parse + plan, no clone) and `--bump <sha>` (rewrite pin in-place).
- New `.github/workflows/hermes-sdk-diff.yml` — weekly (Mondays 12:00 UTC) + `workflow_dispatch`. On drift, opens (or comments on) a single `upstream-drift` / `triage` labeled issue, mirroring `agent-shim-smoke.yml`'s `notify` shape. One open issue per drift state — no spam.
- Bump process documented: review issue → adapter edit → `--bump <sha>` → δ-harness + γ-suite → `chore(hermes): bump upstream pin to <short-sha>` PR.
- 48h freeze window around any `v0.x*` release tag (reviewer-disciplined, PR template checkbox follow-up).

## Notes
- ADR number is **0015**, not 0014 (which is `0014-cognee-graph-extraction-model-gate.md`, shipped 2026-05-23 via PR-3 territory). Brief asked for 0014; verified next free is 0015.
- ADRs live in `docs/internal/adr/` (not `docs/adr/`) — matched the existing tree convention.
- Initial pin recorded as `0554ef1aa3a2e5818f292f76a676110239a5d34b` (2026-05-28) per MASTER-PLAN §5.

## Test plan
- [x] `bash -n scripts/hermes-sdk-diff.sh` — syntax OK
- [x] `shellcheck` — only SC2329 (false positive; `cleanup` is invoked via `trap`)
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on workflow — OK
- [x] `python3 -c "import tomllib; ..."` — pin section parses, 6 tracked files
- [x] `scripts/hermes-sdk-diff.sh --dry-run` — prints repo + pinned + tracked files, exit 0
- [x] `scripts/hermes-sdk-diff.sh --bump <sha>` exercised end-to-end on a temp copy of `pyproject.toml` — commit + date rewritten cleanly, no collateral edits

Refs MASTER-PLAN.md §4 PR-12 + §5 upstream upgrade cadence; DA-arch must-fix #1.

DON'T-touch zones (PR-10 parallel): `ui/src/dash/agents/chat/`, `hermes-chat-tab.jsx` — not touched here.

Generated with [Claude Code](https://claude.com/claude-code)