### PR TITLE
v0.3: HermesChat surface — React composer + transcript + sidecar (NO xterm)

### DIFF
--- a/ui/src/dash/agents/chat/approval-card.jsx
+++ b/ui/src/dash/agents/chat/approval-card.jsx
@@ -1,0 +1,199 @@
+// hal0 v0.3 PR-10 — ApprovalCard.
+//
+// Renders an inline card for an approval / clarify / sudo / secret
+// request emitted by hermes. The four event flavours share an
+// approval-like shape (block on a user response) so we collapse them
+// into a single React component that dispatches to the right respond
+// RPC via window.__hal0HermesSession.
+//
+// Master plan §6 #4: inline card is the PRIMARY surface. The sidebar
+// pip + toast are notification-only — the actual user action happens
+// here.
+//
+// Once resolved (decision sent), the card collapses to a thin
+// confirmation strip so the transcript stays scannable.
+
+function HermesApprovalCard({ row }) {
+  const React = window.React;
+  const { useState, useEffect } = React;
+  if (!row) return null;
+  const flavor = row.kind2 || "approval";
+  const session = window.__hal0HermesSession || {};
+  const [pendingDecision, setPendingDecision] = useState(null);
+  const [draft, setDraft] = useState(""); // for clarify/sudo/secret text
+
+  const payload = row.payload || {};
+  const requestId = row.requestId;
+  const title =
+    flavor === "clarify" ? "Hermes needs clarification" :
+    flavor === "sudo"    ? "Hermes needs sudo"           :
+    flavor === "secret"  ? "Hermes needs a secret"       :
+                           "Approval required";
+  const tone =
+    flavor === "sudo" || flavor === "secret"
+      ? "var(--err)"
+      : "var(--warn)";
+
+  useEffect(() => {
+    // On mount, scroll the card into view if a "Jump to it" toast fires
+    // for this requestId. The use-hermes-session WS layer dispatches
+    // `hal0:hermes:approval` CustomEvents with the requestId.
+    const onJump = (ev) => {
+      if (!ev.detail || ev.detail.requestId !== requestId) return;
+      const el = document.querySelector(`[data-approval-rid="${requestId}"]`);
+      if (el && typeof el.scrollIntoView === "function") {
+        el.scrollIntoView({behavior: "smooth", block: "center"});
+      }
+    };
+    window.addEventListener("hal0:hermes:approval", onJump);
+    return () => window.removeEventListener("hal0:hermes:approval", onJump);
+  }, [requestId]);
+
+  if (row.resolved) {
+    return (
+      <div data-testid="hermes-approval-card" data-resolved="1" className="mono" style={{
+        margin: "4px 0", padding: "6px 10px", fontSize: 11,
+        color: "var(--fg-4)",
+        background: "var(--bg-2)", border: "1px solid var(--line)",
+        borderRadius: 6,
+      }}>
+        ✓ {title} — {pendingDecision || "responded"}
+      </div>
+    );
+  }
+
+  const onApprove = () => {
+    setPendingDecision("approved");
+    if (flavor === "approval") session.respondApproval(requestId, "approve");
+    else if (flavor === "clarify") session.respondClarify(requestId, draft);
+    else if (flavor === "sudo") session.respondSudo(requestId, draft);
+    else if (flavor === "secret") session.respondSecret(requestId, draft);
+  };
+  const onReject = () => {
+    setPendingDecision("rejected");
+    if (flavor === "approval") session.respondApproval(requestId, "reject");
+    else session.respondClarify && session.respondClarify(requestId, "");
+  };
+
+  const needsInput = flavor === "clarify" || flavor === "sudo" || flavor === "secret";
+
+  return (
+    <div
+      data-testid="hermes-approval-card"
+      data-approval-rid={requestId}
+      data-approval-kind={flavor}
+      style={{
+        margin: "6px 0", padding: "10px 12px",
+        background: flavor === "approval" ? "var(--warn-soft)" : "var(--err-soft)",
+        border: `1px solid ${flavor === "approval" ? "var(--warn-line)" : "var(--err-line)"}`,
+        borderRadius: 8,
+        fontFamily: "var(--jbm)",
+      }}
+    >
+      <div style={{
+        display: "flex", alignItems: "center", gap: 8,
+        fontSize: 11.5, color: tone, marginBottom: 8, fontWeight: 500,
+      }}>
+        <span style={{fontSize: 14}}>⚠</span>
+        <span>{title}</span>
+      </div>
+
+      {payload.tool && (
+        <div className="mono" style={{
+          fontSize: 11, color: "var(--fg-2)", marginBottom: 6,
+        }}>
+          <span style={{color: "var(--fg-4)"}}>tool </span>
+          <b style={{color: "var(--fg)"}}>{payload.tool}</b>
+        </div>
+      )}
+      {payload.question && (
+        <div style={{
+          fontSize: 12, color: "var(--fg)", marginBottom: 8, lineHeight: 1.5,
+        }}>
+          {payload.question}
+        </div>
+      )}
+      {payload.prompt && (
+        <div style={{
+          fontSize: 12, color: "var(--fg)", marginBottom: 8, lineHeight: 1.5,
+        }}>
+          {payload.prompt}
+        </div>
+      )}
+      {payload.args && (
+        <pre style={{
+          margin: "0 0 8px", padding: "6px 8px",
+          background: "var(--bg-2)", border: "1px solid var(--line)",
+          borderRadius: 4, fontSize: 11, color: "var(--fg-2)",
+          whiteSpace: "pre-wrap", wordBreak: "break-word",
+          maxHeight: 200, overflow: "auto",
+        }}>
+          {typeof payload.args === "string" ? payload.args : JSON.stringify(payload.args, null, 2)}
+        </pre>
+      )}
+
+      {needsInput && (
+        <input
+          type={flavor === "sudo" || flavor === "secret" ? "password" : "text"}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder={
+            flavor === "clarify" ? "Your answer…" :
+            flavor === "sudo"    ? "sudo password" :
+                                   "secret value"
+          }
+          data-testid="hermes-approval-input"
+          className="mono"
+          style={{
+            width: "100%", padding: "6px 8px", fontSize: 12,
+            background: "var(--bg-1)", border: "1px solid var(--line)",
+            color: "var(--fg)", borderRadius: 4, marginBottom: 8,
+            fontFamily: "var(--jbm)",
+          }}
+        />
+      )}
+
+      {/* Choices come through for clarify.request as `choices: string[]` */}
+      {Array.isArray(payload.choices) && payload.choices.length > 0 && (
+        <div style={{display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 8}}>
+          {payload.choices.map((c, i) => (
+            <button
+              key={i}
+              type="button"
+              className="btn ghost sm"
+              data-testid={`hermes-approval-choice-${i}`}
+              onClick={() => {
+                setPendingDecision(c);
+                session.respondClarify && session.respondClarify(requestId, c);
+              }}
+            >{c}</button>
+          ))}
+        </div>
+      )}
+
+      <div style={{display: "flex", gap: 6, justifyContent: "flex-end"}}>
+        <button
+          type="button"
+          className="btn ghost sm"
+          data-testid="hermes-approval-reject"
+          onClick={onReject}
+        >
+          {flavor === "approval" ? "Reject" : "Cancel"}
+        </button>
+        <button
+          type="button"
+          className="btn sm"
+          data-testid="hermes-approval-approve"
+          onClick={onApprove}
+          disabled={needsInput && !draft.trim()}
+        >
+          {flavor === "approval" ? "Approve" :
+           flavor === "clarify"  ? "Send"    :
+                                   "Submit"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { HermesApprovalCard });

--- a/ui/src/dash/agents/chat/composer.jsx
+++ b/ui/src/dash/agents/chat/composer.jsx
@@ -1,0 +1,108 @@
+// hal0 v0.3 PR-10 — Composer.
+//
+// Textarea + send button. Master plan §6 #2 (user decision):
+//   Enter submits, Shift+Enter inserts a newline. ChatGPT / Claude.ai
+//   pattern.
+//
+// Auto-grows up to a cap (~12 lines) to keep the bottom of the page
+// from disappearing on long drafts. Mobile (<768px) sticks to the
+// viewport bottom — handled in hermes-chat-tab.jsx's grid.
+//
+// Connects to the WS submit channel via window.__hal0HermesSession.
+// Composer is intentionally dumb — it doesn't read transcript state
+// or own its own loading flag; the streaming bubble is sufficient
+// feedback.
+
+function HermesComposer({ connectionState, disabled }) {
+  const React = window.React;
+  const { useState, useRef, useEffect } = React;
+  const [draft, setDraft] = useState("");
+  const taRef = useRef(null);
+  const session = window.__hal0HermesSession || {};
+
+  // Auto-grow textarea. Reset to scrollHeight on every change; cap at
+  // 12 lines (~ 12 * line-height(1.55) * 13px font = ~ 240px).
+  useEffect(() => {
+    const ta = taRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    const next = Math.min(ta.scrollHeight, 240);
+    ta.style.height = `${next}px`;
+  }, [draft]);
+
+  const send = () => {
+    const text = draft.trim();
+    if (!text || disabled) return;
+    const ok = session.submitPrompt && session.submitPrompt(text);
+    if (ok || ok == null) setDraft("");
+  };
+
+  const onKeyDown = (e) => {
+    // Enter submits, Shift+Enter newline (master plan §6 #2).
+    if (e.key === "Enter" && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      e.preventDefault();
+      send();
+    }
+  };
+
+  const isReady = connectionState === "open";
+  const label =
+    connectionState === "connecting"   ? "Connecting…" :
+    connectionState === "reconnecting" ? "Reconnecting…" :
+    connectionState === "closed"       ? "Disconnected" :
+                                         "Message Hermes (Enter to send, Shift+Enter for newline)";
+
+  return (
+    <div
+      data-testid="hermes-composer"
+      data-conn-state={connectionState}
+      style={{
+        display: "flex", alignItems: "flex-end", gap: 8,
+        padding: "10px 14px",
+        background: "var(--bg)",
+        borderTop: "1px solid var(--line)",
+      }}
+    >
+      <div style={{flex: 1, position: "relative"}}>
+        <textarea
+          ref={taRef}
+          data-testid="hermes-composer-input"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={label}
+          rows={1}
+          disabled={disabled}
+          style={{
+            width: "100%", boxSizing: "border-box",
+            padding: "10px 12px",
+            background: "var(--bg-2)",
+            border: "1px solid var(--line)",
+            borderRadius: 8,
+            color: "var(--fg)",
+            fontFamily: "var(--jbm)",
+            fontSize: 13, lineHeight: 1.55,
+            resize: "none",
+            minHeight: 40, maxHeight: 240, overflowY: "auto",
+            outline: "none",
+          }}
+          onFocus={(e) => { e.target.style.borderColor = "var(--accent-line)"; }}
+          onBlur={(e)  => { e.target.style.borderColor = "var(--line)"; }}
+        />
+      </div>
+      <button
+        type="button"
+        data-testid="hermes-composer-send"
+        onClick={send}
+        disabled={!draft.trim() || !isReady || disabled}
+        className="btn"
+        style={{height: 40, padding: "0 16px", fontSize: 12.5}}
+        title="Send (Enter)"
+      >
+        Send
+      </button>
+    </div>
+  );
+}
+
+Object.assign(window, { HermesComposer });

--- a/ui/src/dash/agents/chat/hermes-sidecar.jsx
+++ b/ui/src/dash/agents/chat/hermes-sidecar.jsx
@@ -1,0 +1,240 @@
+// hal0 v0.3 PR-10 — HermesSidecar.
+//
+// Right rail of the chat surface (collapses to a bottom sheet < 768px in
+// hermes-chat-tab.jsx's grid).
+//
+// Composition (master plan §4 PR-10):
+//   - PersonaSwitcher: lists active personas, click → activate
+//   - ModelBadge:      pulled from session.info via the store
+//   - MCPStatusRow:    rolls up hal0-memory + hal0-admin from useMcpStatusPip
+//   - AgentControls:   [Reload] + [Restart] (Restart confirms when streaming)
+//
+// Data flow:
+//   - personas list  → window.__hal0UseAgentPersonas (PR-6 bridge, PR-4 API)
+//   - mcp pip        → window.__hal0UseMcpStatusPip  (PR-6 bridge)
+//   - model + state  → window.useHermesSession (this PR's store)
+//
+// Hot-swap persona: master plan §6 #3 + PR-4 — POST activate, hermes
+// applies on next turn. We just call window.__hal0HermesSession.activatePersona
+// and let TanStack revalidate.
+
+function _PersonaSwitcher({ agentId }) {
+  const React = window.React;
+  const { useState } = React;
+  const usePersonas = window.__hal0UseAgentPersonas;
+  const q = usePersonas ? usePersonas(agentId) : { data: null, isLoading: false };
+  const [open, setOpen] = useState(false);
+  const data = (q && q.data) || { personas: [], active: null };
+  const personas = Array.isArray(data.personas) ? data.personas : [];
+  const activeId = data.active;
+  const activeName =
+    personas.find((p) => p.id === activeId)?.display_name || activeId || "—";
+
+  const onPick = (pid) => {
+    setOpen(false);
+    if (pid === activeId) return;
+    const session = window.__hal0HermesSession;
+    if (session && session.activatePersona) session.activatePersona(agentId, pid);
+  };
+
+  if (personas.length === 0) {
+    return (
+      <div data-testid="hermes-sidecar-persona" className="mono" style={{fontSize: 11, color: "var(--fg-3)"}}>
+        <div style={{color: "var(--fg-4)", fontSize: 9, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 2}}>persona</div>
+        <div>—</div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="hermes-sidecar-persona" className="mono" style={{position: "relative", fontSize: 11.5}}>
+      <div style={{color: "var(--fg-4)", fontSize: 9, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 2}}>persona</div>
+      <button
+        type="button"
+        data-testid="hermes-sidecar-persona-button"
+        onClick={() => setOpen(!open)}
+        className="btn ghost sm"
+        style={{
+          width: "100%", justifyContent: "space-between",
+          display: "flex", alignItems: "center", height: 28,
+          padding: "4px 10px",
+        }}
+      >
+        <span>{activeName}</span>
+        <span style={{color: "var(--fg-3)", fontSize: 10}}>{open ? "▲" : "▼"}</span>
+      </button>
+      {open && (
+        <div data-testid="hermes-sidecar-persona-menu" style={{
+          position: "absolute", top: "100%", left: 0, right: 0,
+          marginTop: 4, padding: 4,
+          background: "var(--bg-1)", border: "1px solid var(--line)",
+          borderRadius: 6, zIndex: 30,
+          boxShadow: "0 6px 24px rgba(0,0,0,0.32)",
+        }}>
+          {personas.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              data-testid={`hermes-sidecar-persona-option-${p.id}`}
+              onClick={() => onPick(p.id)}
+              style={{
+                width: "100%", display: "block",
+                background: p.id === activeId ? "var(--accent-soft)" : "transparent",
+                border: 0, padding: "5px 8px",
+                color: p.id === activeId ? "var(--accent)" : "var(--fg)",
+                fontFamily: "var(--jbm)", fontSize: 11, textAlign: "left",
+                borderRadius: 4, cursor: "pointer",
+              }}
+            >
+              <div style={{fontWeight: 500}}>{p.display_name || p.id}</div>
+              {p.description && (
+                <div style={{color: "var(--fg-4)", fontSize: 10, marginTop: 2}}>{p.description}</div>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function _ModelBadge() {
+  const sess = window.useHermesSession;
+  // Select only the slice we care about so updates to transcript don't
+  // re-render the badge.
+  const { model, provider } = sess ? sess((s) => ({ model: s.model, provider: s.provider })) : { model: null, provider: null };
+  return (
+    <div data-testid="hermes-sidecar-model" className="mono" style={{fontSize: 11.5}}>
+      <div style={{color: "var(--fg-4)", fontSize: 9, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 2}}>model</div>
+      <div style={{color: "var(--fg)", fontWeight: 500}}>
+        {model || "—"}
+      </div>
+      {provider && (
+        <div style={{color: "var(--fg-4)", fontSize: 10, marginTop: 2}}>{provider}</div>
+      )}
+    </div>
+  );
+}
+
+function _MCPStatusRow() {
+  const usePip = window.__hal0UseMcpStatusPip;
+  const q = usePip ? usePip() : { data: { state: "unknown", servers: [] } };
+  const pip = (q && q.data) || { state: "unknown", servers: [] };
+  const color =
+    pip.state === "green" ? "var(--ok)" :
+    pip.state === "yellow" ? "var(--warn)" :
+    pip.state === "red" ? "var(--err)" : "var(--fg-4)";
+  const label =
+    pip.state === "green" ? "ok" :
+    pip.state === "yellow" ? "degraded" :
+    pip.state === "red" ? "down" : "—";
+  return (
+    <div data-testid="hermes-sidecar-mcp" className="mono" style={{fontSize: 11.5}}>
+      <div style={{color: "var(--fg-4)", fontSize: 9, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 2}}>mcp servers</div>
+      <div style={{display: "flex", alignItems: "center", gap: 6, color}}>
+        <span style={{
+          display: "inline-block", width: 6, height: 6,
+          borderRadius: "50%", background: "currentColor",
+          boxShadow: "0 0 6px currentColor",
+        }} />
+        {label}
+      </div>
+      {pip.servers.length > 0 && (
+        <div style={{marginTop: 4, fontSize: 10, color: "var(--fg-3)"}}>
+          {pip.servers.map((s, i) => (
+            <div key={i} style={{display: "flex", justifyContent: "space-between"}}>
+              <span>{s.name}</span>
+              <span style={{color: s.state === "running" ? "var(--ok)" : "var(--err)"}}>{s.state}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function _AgentControls({ agentId }) {
+  const React = window.React;
+  const { useState } = React;
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const sess = window.useHermesSession;
+  const streaming = sess ? sess((s) => !!s.activeAssistantId) : false;
+
+  const onRestart = () => {
+    if (streaming) { setConfirmOpen(true); return; }
+    const s = window.__hal0HermesSession;
+    if (s && s.restartAgent) s.restartAgent(agentId);
+  };
+  const onConfirm = () => {
+    setConfirmOpen(false);
+    const s = window.__hal0HermesSession;
+    if (s && s.restartAgent) s.restartAgent(agentId);
+  };
+
+  return (
+    <div data-testid="hermes-sidecar-controls" style={{
+      display: "flex", flexDirection: "column", gap: 6,
+    }}>
+      <button
+        type="button"
+        data-testid="hermes-sidecar-restart"
+        onClick={onRestart}
+        className="btn ghost sm"
+        style={{justifyContent: "center"}}
+        title={streaming ? "Restart while message in flight — confirm required" : "Restart agent"}
+      >
+        Restart agent
+      </button>
+      {confirmOpen && (
+        <div data-testid="hermes-sidecar-restart-confirm" className="mono" style={{
+          padding: 8,
+          background: "var(--warn-soft)",
+          border: "1px solid var(--warn-line)",
+          borderRadius: 4,
+          fontSize: 10, color: "var(--warn)",
+        }}>
+          A message is streaming. Restart will drop it.
+          <div style={{marginTop: 6, display: "flex", gap: 4, justifyContent: "flex-end"}}>
+            <button
+              type="button"
+              className="btn ghost sm"
+              onClick={() => setConfirmOpen(false)}
+            >Cancel</button>
+            <button
+              type="button"
+              className="btn sm"
+              data-testid="hermes-sidecar-restart-confirm-yes"
+              onClick={onConfirm}
+            >Restart</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HermesSidecar({ agentId }) {
+  return (
+    <aside data-testid="hermes-sidecar" style={{
+      display: "flex", flexDirection: "column", gap: 14,
+      padding: "16px 14px",
+      background: "var(--bg)",
+      borderLeft: "1px solid var(--line)",
+      minWidth: 240,
+    }}>
+      <div className="mono" style={{
+        fontSize: 9, color: "var(--fg-4)",
+        textTransform: "uppercase", letterSpacing: "0.1em",
+      }}>
+        hermes · sidecar
+      </div>
+      <_PersonaSwitcher agentId={agentId} />
+      <_ModelBadge />
+      <_MCPStatusRow />
+      <div style={{flex: 1}} />
+      <_AgentControls agentId={agentId} />
+    </aside>
+  );
+}
+
+Object.assign(window, { HermesSidecar });

--- a/ui/src/dash/agents/chat/index.js
+++ b/ui/src/dash/agents/chat/index.js
@@ -1,0 +1,22 @@
+// hal0 v0.3 PR-10 — HermesChat barrel.
+//
+// Reserved for future symbol re-exports. The chat surface uses the
+// window-globals registration pattern (Object.assign at the bottom of
+// each .jsx / .js file), so this file currently only exists so a single
+// `import './dash/agents/chat'` in main.tsx loads the suite without
+// listing each file. main.tsx today imports the files individually for
+// load-order explicitness; this barrel is the future consolidation
+// point if/when we move to ES modules across dash/*.
+//
+// Window-globals published by this suite (see individual files):
+//   useHermesSession         (use-hermes-session.js — store hook)
+//   __hal0HermesSession      (use-hermes-session.js — connection api)
+//   HermesMarkdown           (markdown.jsx)
+//   HermesMessageBubble      (message-bubble.jsx)
+//   HermesToolCallCard       (tool-call-card.jsx)
+//   HermesApprovalCard       (approval-card.jsx)
+//   HermesThinkingIndicator  (thinking-indicator.jsx)
+//   HermesTranscript         (transcript.jsx)
+//   HermesComposer           (composer.jsx)
+//   HermesSidecar            (hermes-sidecar.jsx)
+//   HermesChatTab            (../hermes-chat-tab.jsx — replaced by PR-10)

--- a/ui/src/dash/agents/chat/markdown.jsx
+++ b/ui/src/dash/agents/chat/markdown.jsx
@@ -1,0 +1,234 @@
+// hal0 v0.3 PR-10 — hal0-native markdown renderer for chat bubbles.
+//
+// Shape-only port of upstream `~/src/hermes-agent/web/src/components/Markdown.tsx`
+// (NOT vendored): same block parser (code fence / heading / hr / list /
+// paragraph) and same inline rules (bold, italic, code, links). Targeted
+// at typical LLM output, NOT a CommonMark conformance suite.
+//
+// Styling uses hal0 dashboard.css tokens (--fg, --bg-2, --accent, --line).
+// No Tailwind v4. Code blocks get a copy button and a language chip when
+// the fence carries a lang tag.
+//
+// Streaming caret (`streaming` prop): inline pulse on the last block so
+// the cursor hugs the final character instead of jumping to a new line.
+
+function _parseBlocks(text) {
+  const lines = String(text || "").split("\n");
+  const blocks = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const fence = line.match(/^```(\w*)/);
+    if (fence) {
+      const lang = fence[1] || "";
+      const buf = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith("```")) {
+        buf.push(lines[i]); i++;
+      }
+      i++; // skip closing ```
+      blocks.push({ type: "code", lang, content: buf.join("\n") });
+      continue;
+    }
+    const heading = line.match(/^(#{1,4})\s+(.+)/);
+    if (heading) {
+      blocks.push({ type: "heading", level: heading[1].length, content: heading[2] });
+      i++; continue;
+    }
+    if (/^[-*_]{3,}\s*$/.test(line)) {
+      blocks.push({ type: "hr" }); i++; continue;
+    }
+    // List
+    const li = line.match(/^\s*([-*]|\d+[.)])\s+(.+)/);
+    if (li) {
+      const ordered = /\d/.test(li[1]);
+      const items = [];
+      while (i < lines.length) {
+        const m = lines[i].match(/^\s*([-*]|\d+[.)])\s+(.+)/);
+        if (!m) break;
+        items.push(m[2]);
+        i++;
+      }
+      blocks.push({ type: "list", ordered, items });
+      continue;
+    }
+    // Paragraph — accumulate until blank line.
+    if (line.trim() === "") { i++; continue; }
+    const para = [line];
+    i++;
+    while (i < lines.length && lines[i].trim() !== "" && !lines[i].match(/^```/) && !lines[i].match(/^#{1,4}\s/)) {
+      para.push(lines[i]); i++;
+    }
+    blocks.push({ type: "paragraph", content: para.join("\n") });
+  }
+  return blocks;
+}
+
+// ── Inline parser ────────────────────────────────────────────────
+// Returns a flat array of React nodes from a string, handling **bold**,
+// *italic*, `code`, [link](url).
+function _renderInline(text) {
+  if (text == null) return null;
+  const out = [];
+  let cursor = 0;
+  const RE = /(\*\*([^*]+)\*\*)|(`([^`]+)`)|(\*([^*]+)\*)|(\[([^\]]+)\]\(([^)]+)\))/g;
+  let m;
+  let key = 0;
+  while ((m = RE.exec(text)) !== null) {
+    if (m.index > cursor) out.push(text.slice(cursor, m.index));
+    if (m[2] !== undefined) {
+      out.push(<strong key={key++} style={{color: "var(--fg)"}}>{m[2]}</strong>);
+    } else if (m[4] !== undefined) {
+      out.push(
+        <code key={key++} style={{
+          background: "var(--bg-2)", padding: "0.5px 5px",
+          borderRadius: 3, fontFamily: "var(--jbm)", fontSize: "0.92em",
+          border: "1px solid var(--line)", color: "var(--accent)",
+        }}>{m[4]}</code>,
+      );
+    } else if (m[6] !== undefined) {
+      out.push(<em key={key++} style={{color: "var(--fg-2)"}}>{m[6]}</em>);
+    } else if (m[8] !== undefined) {
+      out.push(
+        <a key={key++} href={m[9]} target="_blank" rel="noopener noreferrer"
+           style={{color: "var(--accent)", textDecoration: "underline"}}>
+          {m[8]}
+        </a>,
+      );
+    }
+    cursor = RE.lastIndex;
+  }
+  if (cursor < text.length) out.push(text.slice(cursor));
+  return out;
+}
+
+function _StreamingCaret() {
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: "inline-block", width: "0.5em", height: "1em",
+        marginLeft: 2, verticalAlign: "-0.15em",
+        background: "var(--fg-3)", animation: "hermesCaret 1s steps(2) infinite",
+      }}
+    />
+  );
+}
+
+function _CodeBlock({ lang, content }) {
+  const onCopy = () => {
+    try {
+      navigator.clipboard.writeText(content);
+      if (window.__hal0Toast) window.__hal0Toast("Copied", "ok");
+    } catch (_e) {
+      if (window.__hal0Toast) window.__hal0Toast("Copy unavailable", "warn");
+    }
+  };
+  return (
+    <div style={{
+      background: "var(--bg-2)", border: "1px solid var(--line)",
+      borderRadius: 6, margin: "8px 0", overflow: "hidden",
+      fontFamily: "var(--jbm)",
+    }}>
+      <div style={{
+        display: "flex", alignItems: "center", justifyContent: "space-between",
+        padding: "4px 10px",
+        borderBottom: "1px solid var(--line)",
+        background: "var(--bg-3)",
+      }}>
+        <span className="mono" style={{
+          fontSize: 10, color: "var(--fg-3)", textTransform: "uppercase",
+          letterSpacing: "0.08em",
+        }}>{lang || "code"}</span>
+        <button
+          type="button"
+          onClick={onCopy}
+          className="btn ghost sm"
+          style={{height: 22, padding: "2px 8px", fontSize: 10}}
+        >Copy</button>
+      </div>
+      <pre style={{
+        margin: 0, padding: "10px 12px", fontSize: 12.5,
+        color: "var(--fg)", whiteSpace: "pre-wrap", wordBreak: "break-word",
+        overflowX: "auto",
+      }}>{content}</pre>
+    </div>
+  );
+}
+
+function _Block({ block, caret }) {
+  switch (block.type) {
+    case "code":
+      return (
+        <div>
+          <_CodeBlock lang={block.lang} content={block.content} />
+          {caret}
+        </div>
+      );
+    case "heading": {
+      const Tag = `h${Math.min(4, Math.max(1, block.level))}`;
+      const sizes = { 1: 18, 2: 16, 3: 14, 4: 13 };
+      return (
+        <Tag style={{
+          margin: "10px 0 4px", fontWeight: 600,
+          fontSize: sizes[block.level] || 13, color: "var(--fg)",
+          letterSpacing: "-0.01em",
+        }}>
+          {_renderInline(block.content)}
+          {caret}
+        </Tag>
+      );
+    }
+    case "hr":
+      return <hr style={{border: 0, borderTop: "1px solid var(--line)", margin: "10px 0"}} />;
+    case "list": {
+      const ListTag = block.ordered ? "ol" : "ul";
+      return (
+        <ListTag style={{margin: "4px 0", paddingLeft: 22, color: "var(--fg)"}}>
+          {block.items.map((it, i) => (
+            <li key={i} style={{margin: "2px 0", lineHeight: 1.55}}>
+              {_renderInline(it)}
+              {caret && i === block.items.length - 1 ? caret : null}
+            </li>
+          ))}
+        </ListTag>
+      );
+    }
+    case "paragraph":
+    default:
+      return (
+        <p style={{margin: "4px 0", lineHeight: 1.55, color: "var(--fg)"}}>
+          {_renderInline(block.content)}
+          {caret}
+        </p>
+      );
+  }
+}
+
+function Markdown({ content, streaming }) {
+  const React = window.React;
+  const blocks = React.useMemo(() => _parseBlocks(content || ""), [content]);
+  const caret = streaming ? <_StreamingCaret /> : null;
+  return (
+    <div className="mono" style={{fontFamily: "var(--geist), system-ui", fontSize: 13, color: "var(--fg)"}}>
+      {blocks.map((b, i) => (
+        <_Block
+          key={i}
+          block={b}
+          caret={caret && i === blocks.length - 1 ? caret : null}
+        />
+      ))}
+      {blocks.length === 0 && caret}
+    </div>
+  );
+}
+
+// Inject keyframes once for the streaming caret.
+if (typeof document !== "undefined" && !document.getElementById("hal0-hermes-md-css")) {
+  const s = document.createElement("style");
+  s.id = "hal0-hermes-md-css";
+  s.textContent = `@keyframes hermesCaret { 0%, 50% { opacity: 1; } 50.01%, 100% { opacity: 0; } }`;
+  document.head.appendChild(s);
+}
+
+Object.assign(window, { HermesMarkdown: Markdown });

--- a/ui/src/dash/agents/chat/message-bubble.jsx
+++ b/ui/src/dash/agents/chat/message-bubble.jsx
@@ -1,0 +1,103 @@
+// hal0 v0.3 PR-10 — MessageBubble.
+//
+// Renders one transcript row of kind 'user' | 'assistant' | 'system' |
+// 'error'. Assistant bubbles use hal0-native HermesMarkdown for code
+// blocks + inline formatting and show a streaming caret while the
+// message is still in flight.
+//
+// Styling: hal0 tokens only. User bubbles are right-aligned with the
+// amber accent border; assistant bubbles are left-aligned with the
+// default panel surface. Mobile (<768px) bubbles span ~95% width.
+
+function HermesMessageBubble({ row }) {
+  if (!row) return null;
+  const kind = row.kind;
+
+  if (kind === "user") {
+    return (
+      <div data-testid="hermes-msg-user" style={{
+        display: "flex", justifyContent: "flex-end", padding: "4px 0",
+      }}>
+        <div className="mono" style={{
+          maxWidth: "min(75ch, 90%)",
+          background: "var(--accent-soft)",
+          border: "1px solid var(--accent-line)",
+          color: "var(--fg)",
+          padding: "10px 14px",
+          borderRadius: 10, borderBottomRightRadius: 2,
+          fontSize: 13, lineHeight: 1.55,
+          whiteSpace: "pre-wrap", wordBreak: "break-word",
+        }}>
+          {row.text}
+        </div>
+      </div>
+    );
+  }
+
+  if (kind === "assistant") {
+    const Md = window.HermesMarkdown;
+    return (
+      <div data-testid="hermes-msg-assistant" style={{
+        display: "flex", justifyContent: "flex-start", padding: "4px 0",
+      }}>
+        <div style={{
+          maxWidth: "min(75ch, 90%)",
+          background: "var(--bg-2)",
+          border: "1px solid var(--line)",
+          color: "var(--fg)",
+          padding: "10px 14px",
+          borderRadius: 10, borderBottomLeftRadius: 2,
+        }}>
+          {Md
+            ? <Md content={row.text || ""} streaming={!!row.streaming} />
+            : <pre style={{margin: 0, fontFamily: "var(--jbm)", fontSize: 13, color: "var(--fg)"}}>{row.text}</pre>
+          }
+          {row.usage && (
+            <div className="mono" style={{
+              marginTop: 8, paddingTop: 6, borderTop: "1px solid var(--line-soft)",
+              fontSize: 10, color: "var(--fg-4)",
+              display: "flex", gap: 10,
+            }}>
+              {row.usage.input_tokens != null && <span>in {row.usage.input_tokens}</span>}
+              {row.usage.output_tokens != null && <span>out {row.usage.output_tokens}</span>}
+              {row.usage.cost_usd != null && <span>${row.usage.cost_usd.toFixed(4)}</span>}
+            </div>
+          )}
+          {row.warning && (
+            <div className="mono" style={{
+              marginTop: 6, fontSize: 10, color: "var(--warn)",
+            }}>{row.warning}</div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (kind === "error") {
+    return (
+      <div data-testid="hermes-msg-error" className="mono" style={{
+        margin: "6px 0", padding: "8px 12px",
+        background: "var(--err-soft)", border: "1px solid var(--err-line)",
+        color: "var(--err)", borderRadius: 6, fontSize: 12,
+      }}>
+        ⚠ {row.text}
+      </div>
+    );
+  }
+
+  if (kind === "status") {
+    return (
+      <div data-testid="hermes-msg-status" className="mono" style={{
+        margin: "2px 0", textAlign: "center",
+        fontSize: 10, color: "var(--fg-4)",
+        fontStyle: row.ephemeral ? "italic" : "normal",
+      }}>
+        {row.text}
+      </div>
+    );
+  }
+
+  return null;
+}
+
+Object.assign(window, { HermesMessageBubble });

--- a/ui/src/dash/agents/chat/sidecar-hook-bridge.ts
+++ b/ui/src/dash/agents/chat/sidecar-hook-bridge.ts
@@ -1,0 +1,14 @@
+// hal0 dashboard — window-globals bridge for HermesSidecar's TanStack
+// hooks.
+//
+// The sidecar is a .jsx prototype file (no ES imports across the
+// dash/* boundary). This bridge republishes the hooks it consumes onto
+// window before the sidecar evaluates.
+//
+// IMPORTED FROM main.tsx BEFORE ui/src/dash/agents/chat/hermes-sidecar.jsx.
+
+import { useMcpStatusPip } from '@/api/hooks/useAgents'
+
+;(window as unknown as {
+  __hal0UseMcpStatusPip?: typeof useMcpStatusPip
+}).__hal0UseMcpStatusPip = useMcpStatusPip

--- a/ui/src/dash/agents/chat/thinking-indicator.jsx
+++ b/ui/src/dash/agents/chat/thinking-indicator.jsx
@@ -1,0 +1,66 @@
+// hal0 v0.3 PR-10 — ThinkingIndicator.
+//
+// Renders a collapsible "thinking" or "reasoning" panel under an
+// assistant bubble. Aggregates the thinking.delta / reasoning.delta /
+// reasoning.available events the use-hermes-session store collapses
+// into rows of kind 'thinking' | 'reasoning'.
+//
+// Closed by default; click to expand. Pre-formatted, plain text — no
+// markdown — to match upstream's untyped reasoning channel.
+
+function HermesThinkingIndicator({ row }) {
+  const React = window.React;
+  const { useState } = React;
+  if (!row) return null;
+  const [open, setOpen] = useState(false);
+
+  const flavor = row.kind === "reasoning" ? "reasoning" : "thinking";
+  const labels = {
+    thinking:  "thinking",
+    reasoning: "reasoning",
+  };
+  const tone = flavor === "reasoning" ? "var(--dev-vulkan)" : "var(--fg-3)";
+
+  return (
+    <div
+      data-testid={`hermes-${flavor}-indicator`}
+      data-thinking-open={open ? "1" : "0"}
+      style={{
+        margin: "2px 0 6px 12px",
+        fontFamily: "var(--jbm)",
+        fontSize: 11,
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        style={{
+          display: "inline-flex", alignItems: "center", gap: 6,
+          background: "transparent", border: 0, padding: 0,
+          cursor: "pointer", color: tone, fontFamily: "var(--jbm)",
+          fontSize: 10, textTransform: "uppercase", letterSpacing: "0.08em",
+        }}
+      >
+        <span style={{
+          display: "inline-block", width: 8,
+          transform: open ? "rotate(90deg)" : "rotate(0deg)",
+          transition: "transform 120ms ease",
+        }}>▸</span>
+        {labels[flavor]}
+      </button>
+      {open && (
+        <pre style={{
+          marginTop: 4, padding: "6px 8px",
+          background: "var(--bg-2)", border: "1px solid var(--line)",
+          borderRadius: 4, fontSize: 11, color: "var(--fg-2)",
+          whiteSpace: "pre-wrap", wordBreak: "break-word",
+          maxHeight: 220, overflow: "auto",
+        }}>
+          {row.text}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+Object.assign(window, { HermesThinkingIndicator });

--- a/ui/src/dash/agents/chat/tool-call-card.jsx
+++ b/ui/src/dash/agents/chat/tool-call-card.jsx
@@ -1,0 +1,187 @@
+// hal0 v0.3 PR-10 — ToolCallCard.
+//
+// Renders an in-transcript card for a tool.start/tool.complete pair (with
+// any tool.progress in between). Shape-only port of upstream
+// `~/src/hermes-agent/web/src/components/ToolCall.tsx` — same chevron
+// header, same auto-expand-on-error, same elapsed timer — but built
+// against hal0 dashboard.css tokens (no Tailwind v4, no
+// @nous-research/ui).
+
+function _fmtElapsed(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return null;
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(s < 10 ? 1 : 0)}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m${Math.floor(s % 60)}s`;
+}
+
+const TOOL_TICK_MS = 500;
+
+function HermesToolCallCard({ row }) {
+  const React = window.React;
+  const { useState, useEffect } = React;
+  if (!row) return null;
+
+  // userOverride is null → follow default (error open, others closed).
+  const [userOverride, setUserOverride] = useState(null);
+  const open = userOverride ?? (row.status === "error");
+
+  // Tick now while running so elapsed updates live.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (row.status !== "running") return undefined;
+    const id = window.setInterval(() => setNow(Date.now()), TOOL_TICK_MS);
+    return () => window.clearInterval(id);
+  }, [row.status]);
+
+  const hasTimestamps = row.startedAt > 0;
+  const elapsedMs = hasTimestamps
+    ? (row.completedAt ?? now) - row.startedAt
+    : null;
+  const elapsedLabel = elapsedMs != null ? _fmtElapsed(elapsedMs) : null;
+
+  const hasBody = !!(row.context || row.preview || row.summary || row.error || row.inline_diff);
+
+  const bulletColor =
+    row.status === "running" ? "var(--accent)" :
+    row.status === "error"   ? "var(--err)"    :
+                               "var(--ok)";
+  const borderColor =
+    row.status === "running" ? "var(--accent-line)" :
+    row.status === "error"   ? "var(--err-line)"    :
+                               "var(--line)";
+  const bgColor =
+    row.status === "running" ? "var(--accent-soft)" :
+    row.status === "error"   ? "var(--err-soft)"    :
+                               "var(--bg-2)";
+
+  return (
+    <div
+      data-testid="hermes-tool-card"
+      data-tool-status={row.status}
+      data-tool-name={row.name}
+      style={{
+        margin: "6px 0",
+        border: `1px solid ${borderColor}`,
+        background: bgColor,
+        borderRadius: 6,
+        overflow: "hidden",
+        fontFamily: "var(--jbm)",
+      }}
+    >
+      <button
+        type="button"
+        disabled={!hasBody}
+        onClick={() => hasBody && setUserOverride(!open)}
+        aria-expanded={open}
+        data-testid="hermes-tool-card-header"
+        style={{
+          display: "flex", alignItems: "center", gap: 8,
+          width: "100%", padding: "6px 10px",
+          background: "transparent", border: 0,
+          textAlign: "left", cursor: hasBody ? "pointer" : "default",
+          color: "var(--fg)",
+          fontFamily: "var(--jbm)",
+          fontSize: 11.5,
+        }}
+      >
+        {hasBody && (
+          <span style={{
+            color: "var(--fg-3)", width: 10, display: "inline-block",
+            transition: "transform 120ms ease",
+            transform: open ? "rotate(90deg)" : "rotate(0deg)",
+          }}>▸</span>
+        )}
+        <span style={{color: bulletColor, fontSize: 12}}>●</span>
+        <span style={{fontWeight: 500}}>{row.name}</span>
+        {row.context && !open && (
+          <span style={{color: "var(--fg-4)", marginLeft: 4, fontWeight: 400}}>
+            {row.context.length > 60 ? `${row.context.slice(0, 60)}…` : row.context}
+          </span>
+        )}
+        <span style={{flex: 1}} />
+        {elapsedLabel && (
+          <span className="mono" style={{
+            color: row.status === "error" ? "var(--err)" : "var(--fg-4)",
+            fontSize: 10,
+          }}>{elapsedLabel}</span>
+        )}
+        {row.status === "running" && (
+          <span data-testid="hermes-tool-spinner" style={{
+            color: "var(--accent)", fontSize: 10, marginLeft: 6,
+          }}>…</span>
+        )}
+      </button>
+
+      {open && hasBody && (
+        <div data-testid="hermes-tool-card-body" style={{
+          padding: "6px 10px 10px", borderTop: "1px solid var(--line-soft)",
+          fontSize: 11.5, color: "var(--fg-2)",
+        }}>
+          {row.context && (
+            <div style={{marginBottom: 6}}>
+              <div className="mono" style={{
+                fontSize: 9, color: "var(--fg-4)",
+                textTransform: "uppercase", letterSpacing: "0.08em",
+                marginBottom: 2,
+              }}>args</div>
+              <pre style={{margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word"}}>
+                {row.context}
+              </pre>
+            </div>
+          )}
+          {row.preview && row.status === "running" && (
+            <div style={{marginBottom: 6}}>
+              <div className="mono" style={{
+                fontSize: 9, color: "var(--fg-4)",
+                textTransform: "uppercase", letterSpacing: "0.08em",
+                marginBottom: 2,
+              }}>preview</div>
+              <pre style={{margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word", color: "var(--fg-2)"}}>
+                {row.preview}
+              </pre>
+            </div>
+          )}
+          {row.summary && (
+            <div style={{marginBottom: 6}}>
+              <div className="mono" style={{
+                fontSize: 9, color: "var(--fg-4)",
+                textTransform: "uppercase", letterSpacing: "0.08em",
+                marginBottom: 2,
+              }}>result</div>
+              <pre style={{margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word"}}>
+                {row.summary}
+              </pre>
+            </div>
+          )}
+          {row.inline_diff && (
+            <div style={{marginBottom: 6}}>
+              <div className="mono" style={{
+                fontSize: 9, color: "var(--fg-4)",
+                textTransform: "uppercase", letterSpacing: "0.08em",
+                marginBottom: 2,
+              }}>diff</div>
+              <pre style={{
+                margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word",
+                background: "var(--bg-3)", padding: 6, borderRadius: 4,
+                fontSize: 11, color: "var(--fg)",
+              }}>{row.inline_diff}</pre>
+            </div>
+          )}
+          {row.error && (
+            <div className="mono" style={{
+              padding: "6px 8px",
+              background: "var(--err-soft)", border: "1px solid var(--err-line)",
+              color: "var(--err)", borderRadius: 4, fontSize: 11,
+            }}>
+              {row.error}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+Object.assign(window, { HermesToolCallCard });

--- a/ui/src/dash/agents/chat/transcript.jsx
+++ b/ui/src/dash/agents/chat/transcript.jsx
@@ -1,0 +1,100 @@
+// hal0 v0.3 PR-10 — Transcript.
+//
+// Virtualized-ish list. ui/package.json doesn't carry react-window or
+// react-virtuoso, so we ship a hand-rolled windowed renderer that's
+// good enough for a conversation transcript:
+//   - Auto-scroll to bottom when streaming + the user hasn't scrolled
+//     away (sticky-bottom heuristic).
+//   - Render every row (chat transcripts top out at a few hundred rows;
+//     real perf risk is rAF reflows on streaming, NOT row count). If a
+//     real perf problem shows up we drop in react-virtuoso later.
+//
+// Rows dispatch to MessageBubble / ToolCallCard / ApprovalCard /
+// ThinkingIndicator via window-globals lookup.
+
+function HermesTranscript({ rows, status }) {
+  const React = window.React;
+  const { useRef, useEffect, useState, useLayoutEffect } = React;
+  const ref = useRef(null);
+  const [stick, setStick] = useState(true);
+
+  // Sticky-bottom: user scrolling up unsticks; scrolling back to within
+  // 80px of the bottom re-sticks.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return undefined;
+    const onScroll = () => {
+      const dist = el.scrollHeight - el.scrollTop - el.clientHeight;
+      setStick(dist < 80);
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, []);
+
+  // Auto-scroll on new content when sticky.
+  useLayoutEffect(() => {
+    if (!stick) return;
+    const el = ref.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [rows, stick]);
+
+  const Bubble = window.HermesMessageBubble;
+  const ToolCard = window.HermesToolCallCard;
+  const Approval = window.HermesApprovalCard;
+  const Thinking = window.HermesThinkingIndicator;
+
+  return (
+    <div
+      ref={ref}
+      data-testid="hermes-transcript"
+      data-row-count={rows.length}
+      data-conn-state={status}
+      style={{
+        flex: 1, overflowY: "auto", overflowX: "hidden",
+        padding: "16px 18px", display: "flex", flexDirection: "column",
+        background: "var(--bg-1)",
+      }}
+    >
+      {rows.length === 0 && status !== "open" && (
+        <div data-testid="hermes-transcript-empty" className="mono" style={{
+          margin: "auto", padding: "24px",
+          color: "var(--fg-4)", fontSize: 12, textAlign: "center",
+        }}>
+          {status === "connecting" ? "Connecting to Hermes…" :
+           status === "reconnecting" ? "Reconnecting…" :
+           "Waiting for Hermes."}
+        </div>
+      )}
+      {rows.length === 0 && status === "open" && (
+        <div data-testid="hermes-transcript-empty" className="mono" style={{
+          margin: "auto", padding: "24px",
+          color: "var(--fg-4)", fontSize: 12, textAlign: "center", maxWidth: 320, lineHeight: 1.6,
+        }}>
+          Hermes is online. Send the first message to get a welcome
+          with available tools + models.
+        </div>
+      )}
+      {rows.map((row) => {
+        switch (row.kind) {
+          case "user":
+          case "assistant":
+          case "error":
+          case "status":
+            return Bubble ? <Bubble key={row.id} row={row} /> : null;
+          case "tool":
+            return ToolCard ? <ToolCard key={row.id} row={row} /> : null;
+          case "approval":
+            return Approval ? <Approval key={row.id} row={row} /> : null;
+          case "thinking":
+          case "reasoning":
+            return Thinking ? <Thinking key={row.id} row={row} /> : null;
+          default:
+            return null;
+        }
+      })}
+    </div>
+  );
+}
+
+Object.assign(window, { HermesTranscript });

--- a/ui/src/dash/agents/chat/use-hermes-session.js
+++ b/ui/src/dash/agents/chat/use-hermes-session.js
@@ -1,0 +1,713 @@
+// hal0 v0.3 PR-10 — HermesChat session store + WS connection manager.
+//
+// Two WebSocket channels per PR-9's chat_proxy:
+//   /api/agents/hermes/events  — server→browser JSON-RPC event mirror
+//   /api/agents/hermes/submit  — bidi JSON-RPC client→hermes
+//
+// First-connect handshake (PR-9 contract):
+//   GET /api/agents/{id}/session/handshake  → mints the hal0_session
+//   HMAC cookie. We hit this before opening either WS; failure short-
+//   circuits the open so we don't get a quiet 4403 close on the WS.
+//
+// State management (master plan §2):
+//   This file lives in the window-globals .js layer so it can't `import`
+//   zustand directly. We hand-roll a tiny external store + expose a hook
+//   via React.useSyncExternalStore. The store carries the runtime UI
+//   slice (transcript, sessionId, ws status, approvals queue). Persona /
+//   MCP / model badge live behind TanStack Query hooks bridged onto
+//   window by the .ts shim files (matches PR-6/PR-8 pattern).
+//
+// Event routing covers every R1 taxonomy entry (MASTER-PLAN.md §4 PR-10
+// table + notes/r1-upstream-core.md table). See _routeEvent below.
+//
+// Reconnect strategy (browser-side, PR-9 says proxy is stateless):
+//   jittered backoff 250ms → 4s; keep trying. On reconnect, if we have a
+//   sessionId we call session.resume; otherwise session.create w/
+//   first_run=true so the persona welcome (PR-3 prompt addendum) fires.
+//
+// Window-globals shim wiring at file bottom.
+
+;(function () {
+  const React = window.React;
+
+  // ── External store (minimal, subscribable) ───────────────────────
+  function _initialState() {
+    return {
+      // Connection state
+      connectionState: "idle", // idle | connecting | open | reconnecting | closed
+      consecutiveFailures: 0,
+      sessionId: null,
+      firstRun: true,
+
+      // Sidecar/identity
+      model: null,
+      provider: null,
+      caps: null,
+
+      // Transcript: ordered list of items. Item kinds:
+      //   user       { kind:'user',       id, text, ts }
+      //   assistant  { kind:'assistant',  id, text, status, streaming, usage }
+      //   thinking   { kind:'thinking',   id, parentId, text }
+      //   reasoning  { kind:'reasoning',  id, parentId, text }
+      //   tool       { kind:'tool',       id, parentId, tool_id, name, context,
+      //                                   preview, summary, error, status,
+      //                                   startedAt, completedAt }
+      //   approval   { kind:'approval',   id, requestId, payload,
+      //                                   kind2:'approval'|'clarify'|'sudo'|'secret',
+      //                                   resolved }
+      //   status     { kind:'status',     id, level, text, ephemeral? }
+      //   error      { kind:'error',      id, text }
+      transcript: [],
+
+      activeAssistantId: null,
+      pendingApprovals: 0,
+      lastStatus: null,
+      lastSubmitAt: 0,
+    };
+  }
+
+  let _state = _initialState();
+  const _listeners = new Set();
+
+  function getState() { return _state; }
+  function setState(partial) {
+    const next = typeof partial === "function" ? partial(_state) : partial;
+    if (!next) return;
+    _state = Object.assign({}, _state, next);
+    _listeners.forEach((l) => {
+      try { l(); } catch (_e) {}
+    });
+  }
+  function subscribe(listener) {
+    _listeners.add(listener);
+    return () => _listeners.delete(listener);
+  }
+
+  function _reset() { _state = _initialState(); _listeners.forEach((l) => l()); }
+
+  function _now() { return Date.now(); }
+  function _nid() { return `${_now()}-${Math.random().toString(36).slice(2, 8)}`; }
+
+  // ── Mutators ─────────────────────────────────────────────────────
+  const actions = {
+    setConnectionState(s) { setState({ connectionState: s }); },
+    setSession(info) {
+      const p = info || {};
+      setState((st) => ({
+        sessionId: p.session_id || p.sessionId || st.sessionId,
+        model: p.model || st.model,
+        provider: p.provider || st.provider,
+        caps: p.caps || p.toolsets || st.caps,
+        firstRun: p.first_run === true,
+      }));
+    },
+
+    appendUser(text) {
+      const id = _nid();
+      setState((st) => ({
+        transcript: st.transcript.concat({
+          kind: "user", id, text: String(text || ""), ts: _now(),
+        }),
+        lastSubmitAt: _now(),
+      }));
+      return id;
+    },
+
+    startAssistant() {
+      const id = _nid();
+      setState((st) => ({
+        transcript: st.transcript.concat({
+          kind: "assistant", id, text: "",
+          status: "streaming", streaming: true, usage: null,
+          startedAt: _now(),
+        }),
+        activeAssistantId: id,
+      }));
+      return id;
+    },
+
+    appendAssistantDelta(delta) {
+      const text = typeof delta === "string" ? delta : (delta && delta.text) || "";
+      if (!text) return;
+      setState((st) => {
+        const aid = st.activeAssistantId;
+        if (!aid) {
+          // Stream arrived before message.start — open a fresh bubble.
+          const id = _nid();
+          return {
+            transcript: st.transcript.concat({
+              kind: "assistant", id, text,
+              status: "streaming", streaming: true, usage: null,
+              startedAt: _now(),
+            }),
+            activeAssistantId: id,
+          };
+        }
+        const next = st.transcript.slice();
+        for (let i = next.length - 1; i >= 0; i--) {
+          if (next[i].kind === "assistant" && next[i].id === aid) {
+            next[i] = Object.assign({}, next[i], { text: next[i].text + text });
+            break;
+          }
+        }
+        return { transcript: next };
+      });
+    },
+
+    completeAssistant(payload) {
+      const data = payload || {};
+      setState((st) => {
+        const aid = st.activeAssistantId;
+        if (!aid) return null;
+        const next = st.transcript.slice();
+        for (let i = next.length - 1; i >= 0; i--) {
+          if (next[i].kind === "assistant" && next[i].id === aid) {
+            next[i] = Object.assign({}, next[i], {
+              status: data.status || "complete",
+              streaming: false,
+              usage: data.usage || null,
+              warning: data.warning || null,
+              completedAt: _now(),
+              text: data.text != null ? data.text : next[i].text,
+            });
+            break;
+          }
+        }
+        return { transcript: next, activeAssistantId: null };
+      });
+    },
+
+    appendThinking(delta, kind) {
+      const text = typeof delta === "string" ? delta : (delta && delta.text) || "";
+      if (!text) return;
+      const flavor = kind === "reasoning" ? "reasoning" : "thinking";
+      setState((st) => {
+        const aid = st.activeAssistantId;
+        const next = st.transcript.slice();
+        for (let i = next.length - 1; i >= 0; i--) {
+          const row = next[i];
+          if (row.kind === flavor && row.parentId === aid) {
+            next[i] = Object.assign({}, row, { text: row.text + text });
+            return { transcript: next };
+          }
+          if (row.kind === "assistant" || row.kind === "user") break;
+        }
+        next.push({ kind: flavor, id: _nid(), parentId: aid, text, ts: _now() });
+        return { transcript: next };
+      });
+    },
+
+    toolStart(payload) {
+      const data = payload || {};
+      const id = _nid();
+      const toolId = String(data.tool_id || data.name || id);
+      setState((st) => {
+        const row = {
+          kind: "tool", id, tool_id: toolId, parentId: st.activeAssistantId,
+          name: data.name || "tool",
+          context: data.context || data.args_text || null,
+          preview: null, summary: null, error: null,
+          status: "running",
+          startedAt: _now(),
+        };
+        return { transcript: st.transcript.concat(row) };
+      });
+      return id;
+    },
+
+    toolProgress(payload) {
+      const data = payload || {};
+      const toolId = String(data.tool_id || data.name || "");
+      if (!toolId) return;
+      setState((st) => {
+        const next = st.transcript.slice();
+        for (let i = next.length - 1; i >= 0; i--) {
+          const r = next[i];
+          if (r.kind === "tool" && r.tool_id === toolId && r.status === "running") {
+            next[i] = Object.assign({}, r, {
+              preview: data.preview != null ? data.preview : r.preview,
+            });
+            return { transcript: next };
+          }
+        }
+        return null;
+      });
+    },
+
+    toolComplete(payload) {
+      const data = payload || {};
+      const toolId = String(data.tool_id || data.name || "");
+      if (!toolId) return;
+      setState((st) => {
+        const next = st.transcript.slice();
+        for (let i = next.length - 1; i >= 0; i--) {
+          const r = next[i];
+          if (r.kind === "tool" && r.tool_id === toolId && r.status === "running") {
+            const isError = !!data.error || data.status === "error";
+            next[i] = Object.assign({}, r, {
+              status: isError ? "error" : "done",
+              summary: data.summary || data.result_text || null,
+              inline_diff: data.inline_diff || null,
+              error: data.error || null,
+              duration_s: data.duration_s != null ? data.duration_s : null,
+              completedAt: _now(),
+            });
+            return { transcript: next };
+          }
+        }
+        return null;
+      });
+    },
+
+    toolGenerating(payload) {
+      const data = payload || {};
+      setState((st) => ({
+        transcript: st.transcript.concat({
+          kind: "status", id: _nid(),
+          level: "info",
+          text: `(generating tool call: ${data.name || "?"})`,
+          ephemeral: true,
+        }),
+      }));
+    },
+
+    approvalRequest(kind, payload) {
+      const data = payload || {};
+      const requestId = String(data.request_id || data.requestId || _nid());
+      const id = _nid();
+      setState((st) => ({
+        transcript: st.transcript.concat({
+          kind: "approval", id, requestId, kind2: kind, payload: data,
+          resolved: false, ts: _now(),
+        }),
+        pendingApprovals: st.pendingApprovals + 1,
+      }));
+      return { id, requestId };
+    },
+
+    resolveApproval(requestId) {
+      setState((st) => {
+        const next = st.transcript.slice();
+        for (let i = next.length - 1; i >= 0; i--) {
+          const r = next[i];
+          if (r.kind === "approval" && r.requestId === requestId && !r.resolved) {
+            next[i] = Object.assign({}, r, { resolved: true });
+            break;
+          }
+        }
+        return {
+          transcript: next,
+          pendingApprovals: Math.max(0, st.pendingApprovals - 1),
+        };
+      });
+    },
+
+    pushStatus(payload) {
+      const data = payload || {};
+      setState({
+        lastStatus: { level: data.kind || "status", text: data.text || "", ts: _now() },
+      });
+    },
+
+    pushError(payload) {
+      const data = payload || {};
+      const text = data.message || String(data.error || data) || "Unknown error";
+      setState((st) => ({
+        transcript: st.transcript.concat({
+          kind: "error", id: _nid(), text, ts: _now(),
+        }),
+      }));
+    },
+
+    bumpFailure() {
+      setState((st) => ({
+        consecutiveFailures: st.consecutiveFailures + 1,
+        connectionState: "reconnecting",
+      }));
+    },
+    resetFailure() {
+      setState({ consecutiveFailures: 0, connectionState: "open" });
+    },
+  };
+
+  // ── React hook (useSyncExternalStore) ────────────────────────────
+  // We can't pass an object-returning selector straight to
+  // useSyncExternalStore: object identity changes every snapshot and
+  // useSyncExternalStore re-renders on identity mismatch. We cache the
+  // last computed slice and only return a NEW reference when a shallow
+  // equality check fails. This mirrors zustand's shallow selector.
+  function _shallowEq(a, b) {
+    if (Object.is(a, b)) return true;
+    if (typeof a !== "object" || a === null || typeof b !== "object" || b === null) return false;
+    const ak = Object.keys(a);
+    const bk = Object.keys(b);
+    if (ak.length !== bk.length) return false;
+    for (let i = 0; i < ak.length; i++) {
+      const k = ak[i];
+      if (!Object.is(a[k], b[k])) return false;
+    }
+    return true;
+  }
+
+  function useHermesSession(selector) {
+    const cache = React.useRef({ snap: undefined, has: false });
+    const getSnapshot = React.useCallback(() => {
+      const next = selector ? selector(_state) : _state;
+      if (cache.current.has && _shallowEq(cache.current.snap, next)) {
+        return cache.current.snap;
+      }
+      cache.current.snap = next;
+      cache.current.has = true;
+      return next;
+    }, [selector]);
+    return React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  }
+  // Match the zustand-shaped API: useStore.getState() / setState() exposed
+  // on the hook function itself.
+  useHermesSession.getState = getState;
+  useHermesSession.setState = setState;
+  useHermesSession.subscribe = subscribe;
+
+  // ── Event router ─────────────────────────────────────────────────
+  const _warnedEvents = new Set();
+
+  function _routeEvent(envelope) {
+    if (!envelope || envelope.method !== "event") return;
+    const params = envelope.params || {};
+    const type = params.type;
+    const payload = params.payload || {};
+    const sessionId = params.session_id;
+    if (!type) return;
+
+    switch (type) {
+      case "gateway.ready":
+        actions.setConnectionState("open");
+        break;
+      case "session.info":
+        actions.setSession(Object.assign({}, payload, {
+          session_id: sessionId || payload.session_id,
+        }));
+        break;
+      case "message.start":
+        actions.startAssistant();
+        break;
+      case "message.delta":
+        actions.appendAssistantDelta(payload);
+        break;
+      case "message.complete":
+        actions.completeAssistant(payload);
+        break;
+      case "thinking.delta":
+        actions.appendThinking(payload, "thinking");
+        break;
+      case "reasoning.delta":
+      case "reasoning.available":
+        actions.appendThinking(payload, "reasoning");
+        break;
+      case "tool.start":
+        actions.toolStart(payload);
+        break;
+      case "tool.progress":
+        actions.toolProgress(payload);
+        break;
+      case "tool.complete":
+        actions.toolComplete(payload);
+        break;
+      case "tool.generating":
+        actions.toolGenerating(payload);
+        break;
+      case "approval.request":
+        actions.approvalRequest("approval", payload);
+        _fireApprovalToast(payload, "approval");
+        break;
+      case "clarify.request":
+        actions.approvalRequest("clarify", payload);
+        _fireApprovalToast(payload, "clarify");
+        break;
+      case "sudo.request":
+        actions.approvalRequest("sudo", payload);
+        _fireApprovalToast(payload, "sudo");
+        break;
+      case "secret.request":
+        actions.approvalRequest("secret", payload);
+        _fireApprovalToast(payload, "secret");
+        break;
+      case "status.update":
+        actions.pushStatus(payload);
+        break;
+      case "background_review":
+        actions.pushStatus(Object.assign({ kind: "info" }, payload));
+        break;
+      case "error":
+        actions.pushError(payload);
+        if (window.__hal0Toast) {
+          window.__hal0Toast(payload.message || "Hermes error", "warn");
+        }
+        break;
+      case "skin.changed":
+      case "voice.transcript":
+      case "voice.status":
+      case "voice.silent_limit":
+      case "browser.progress":
+        // Master plan §4 PR-10 ignored
+        break;
+      default:
+        if (!_warnedEvents.has(type)) {
+          _warnedEvents.add(type);
+          // eslint-disable-next-line no-console
+          console.warn("hal0.hermes_chat.unknown_event", type);
+        }
+        break;
+    }
+  }
+
+  function _fireApprovalToast(payload, kind) {
+    if (typeof window === "undefined" || !window.__hal0Toast) return;
+    const label =
+      kind === "clarify" ? "Hermes needs clarification" :
+      kind === "sudo"    ? "Hermes needs sudo"           :
+      kind === "secret"  ? "Hermes needs a secret"       :
+                           "Approval requested";
+    window.__hal0Toast(label, "warn");
+    try {
+      window.dispatchEvent(new CustomEvent("hal0:hermes:approval", {
+        detail: { kind, requestId: payload.request_id || payload.requestId },
+      }));
+    } catch (_e) {}
+  }
+
+  // ── WS connection manager ────────────────────────────────────────
+  let _eventsWs = null;
+  let _submitWs = null;
+  let _reconnectTimer = null;
+  let _stopped = false;
+  let _handshakeDone = false;
+  let _agentIdActive = null;
+
+  // Jittered exponential backoff 250ms → 4s capped (PR-9 contract).
+  const RECONNECT_BASE_MS = 250;
+  const RECONNECT_CAP_MS  = 4000;
+  function _nextDelay(failures) {
+    const exp = Math.min(RECONNECT_CAP_MS, RECONNECT_BASE_MS * 2 ** Math.min(failures, 5));
+    return Math.floor(exp * (1 + Math.random() * 0.5));
+  }
+
+  function _wsScheme() {
+    return location.protocol === "https:" ? "wss:" : "ws:";
+  }
+
+  async function _handshake(agentId) {
+    if (_handshakeDone) return true;
+    try {
+      const r = await fetch(`/api/agents/${encodeURIComponent(agentId)}/session/handshake`, {
+        credentials: "include",
+      });
+      if (!r.ok) return false;
+      _handshakeDone = true;
+      return true;
+    } catch (_e) {
+      return false;
+    }
+  }
+
+  function _openEvents(agentId) {
+    if (_eventsWs && _eventsWs.readyState <= 1) return;
+    const url = `${_wsScheme()}//${location.host}/api/agents/${encodeURIComponent(agentId)}/events`;
+    const ws = new WebSocket(url);
+    _eventsWs = ws;
+    ws.onopen = () => {
+      actions.resetFailure();
+    };
+    ws.onmessage = (m) => {
+      const raw = typeof m.data === "string" ? m.data : "";
+      if (!raw) return;
+      try {
+        _routeEvent(JSON.parse(raw));
+      } catch (_e) { /* bad frame — ignored */ }
+    };
+    ws.onclose = () => {
+      if (_stopped) return;
+      actions.bumpFailure();
+      _scheduleReconnect(agentId);
+    };
+    ws.onerror = () => { /* onclose follows */ };
+  }
+
+  function _openSubmit(agentId) {
+    if (_submitWs && _submitWs.readyState <= 1) return;
+    const url = `${_wsScheme()}//${location.host}/api/agents/${encodeURIComponent(agentId)}/submit`;
+    const ws = new WebSocket(url);
+    _submitWs = ws;
+    ws.onopen = () => {
+      // First-run hook (master plan §1 #9): on open, if we have no
+      // sessionId, request a fresh session with first_run=true so the
+      // persona's welcome message (PR-3 system-prompt addendum) fires.
+      // Sent from the SUBMIT socket so the resume/create envelope can't
+      // race ahead of the WS being writable.
+      const st = getState();
+      if (!st.sessionId) {
+        _sendSubmit({
+          jsonrpc: "2.0", id: 1, method: "session.create",
+          params: { first_run: true },
+        });
+      } else {
+        _sendSubmit({
+          jsonrpc: "2.0", id: 1, method: "session.resume",
+          params: { session_id: st.sessionId },
+        });
+      }
+    };
+    ws.onmessage = (m) => {
+      try { _routeEvent(JSON.parse(m.data)); } catch (_e) {}
+    };
+    ws.onclose = () => {
+      if (_stopped) return;
+      _scheduleReconnect(agentId);
+    };
+    ws.onerror = () => {};
+  }
+
+  function _scheduleReconnect(agentId) {
+    if (_reconnectTimer) return;
+    const failures = getState().consecutiveFailures;
+    const delay = _nextDelay(failures);
+    actions.setConnectionState("reconnecting");
+    _reconnectTimer = setTimeout(async () => {
+      _reconnectTimer = null;
+      if (_stopped) return;
+      _handshakeDone = false;
+      const ok = await _handshake(agentId);
+      if (!ok) { actions.bumpFailure(); _scheduleReconnect(agentId); return; }
+      _openEvents(agentId);
+      _openSubmit(agentId);
+    }, delay);
+  }
+
+  function _sendSubmit(envelope) {
+    if (!_submitWs || _submitWs.readyState !== 1) return false;
+    try {
+      _submitWs.send(JSON.stringify(envelope));
+      return true;
+    } catch (_e) {
+      return false;
+    }
+  }
+
+  async function connect(agentId) {
+    _stopped = false;
+    _handshakeDone = false;
+    _agentIdActive = agentId;
+    actions.setConnectionState("connecting");
+    const ok = await _handshake(agentId);
+    if (!ok) {
+      actions.bumpFailure();
+      _scheduleReconnect(agentId);
+      return;
+    }
+    _openEvents(agentId);
+    _openSubmit(agentId);
+  }
+
+  function disconnect() {
+    _stopped = true;
+    if (_reconnectTimer) { clearTimeout(_reconnectTimer); _reconnectTimer = null; }
+    if (_eventsWs) { try { _eventsWs.close(); } catch (_e) {} _eventsWs = null; }
+    if (_submitWs) { try { _submitWs.close(); } catch (_e) {} _submitWs = null; }
+    actions.setConnectionState("closed");
+  }
+
+  function submitPrompt(text) {
+    const st = getState();
+    if (!text || !text.trim()) return false;
+    actions.appendUser(text);
+    return _sendSubmit({
+      jsonrpc: "2.0", id: Date.now(), method: "prompt.submit",
+      params: { session_id: st.sessionId, text },
+    });
+  }
+
+  function respondApproval(requestId, decision, extra) {
+    actions.resolveApproval(requestId);
+    return _sendSubmit({
+      jsonrpc: "2.0", id: Date.now(), method: "approval.respond",
+      params: Object.assign({ request_id: requestId, decision }, extra || {}),
+    });
+  }
+  function respondClarify(requestId, answer) {
+    actions.resolveApproval(requestId);
+    return _sendSubmit({
+      jsonrpc: "2.0", id: Date.now(), method: "clarify.respond",
+      params: { request_id: requestId, answer },
+    });
+  }
+  function respondSudo(requestId, password) {
+    actions.resolveApproval(requestId);
+    return _sendSubmit({
+      jsonrpc: "2.0", id: Date.now(), method: "sudo.respond",
+      params: { request_id: requestId, password },
+    });
+  }
+  function respondSecret(requestId, secret) {
+    actions.resolveApproval(requestId);
+    return _sendSubmit({
+      jsonrpc: "2.0", id: Date.now(), method: "secret.respond",
+      params: { request_id: requestId, secret },
+    });
+  }
+
+  // Restart — POSTs to a hal0-api restart endpoint. Follow-up PR owns the
+  // server side; 404 surfaces as a toast.
+  async function restartAgent(agentId) {
+    try {
+      const r = await fetch(`/api/agents/${encodeURIComponent(agentId)}/restart`, {
+        method: "POST", credentials: "include",
+      });
+      if (!r.ok) {
+        if (window.__hal0Toast) window.__hal0Toast(`Restart not available (${r.status})`, "warn");
+        return false;
+      }
+      if (window.__hal0Toast) window.__hal0Toast("Hermes restarting…", "info");
+      return true;
+    } catch (_e) {
+      if (window.__hal0Toast) window.__hal0Toast("Restart endpoint unreachable", "warn");
+      return false;
+    }
+  }
+
+  async function activatePersona(agentId, personaId) {
+    try {
+      const r = await fetch(
+        `/api/agents/${encodeURIComponent(agentId)}/personas/${encodeURIComponent(personaId)}/activate`,
+        { method: "POST", credentials: "include" },
+      );
+      if (!r.ok) {
+        if (window.__hal0Toast) window.__hal0Toast(`Persona activate failed (${r.status})`, "warn");
+        return false;
+      }
+      if (window.__hal0Toast) {
+        window.__hal0Toast(`Persona ${personaId} activates on next turn`, "ok");
+      }
+      return true;
+    } catch (_e) {
+      if (window.__hal0Toast) window.__hal0Toast("Persona endpoint unreachable", "warn");
+      return false;
+    }
+  }
+
+  // ── Window-globals publish ───────────────────────────────────────
+  Object.assign(window, {
+    useHermesSession,
+    __hal0HermesSession: {
+      useHermesSession,
+      connect, disconnect,
+      submitPrompt,
+      respondApproval, respondClarify, respondSudo, respondSecret,
+      restartAgent, activatePersona,
+      // Test handles
+      _routeEvent,
+      _nextDelay,
+      _reset,
+      _getState: getState,
+    },
+  });
+})();

--- a/ui/src/dash/agents/hermes-chat-tab.jsx
+++ b/ui/src/dash/agents/hermes-chat-tab.jsx
@@ -1,58 +1,192 @@
-// hal0 v0.3 PR-8 — HermesChatTab (placeholder).
+// hal0 v0.3 PR-10 — HermesChatTab.
 //
-// The chat composer + transcript lands in PR-10. PR-8 ships a minimal
-// placeholder so AgentView has a default tab and the nav doesn't dead-end.
+// REPLACES the PR-8 placeholder. Default tab inside AgentView (#agent).
+// Composes the chat surface as a CSS-grid:
 //
-// The link points at the activity log (Logs view filtered for hermes)
-// so operators have somewhere to go in the interim.
+//   ┌───────────────────────────┬──────────────┐
+//   │  Transcript               │  HermesSidecar│
+//   │  (virtualized list)       │  (persona,    │
+//   │                           │   model,      │
+//   │                           │   mcp, ops)   │
+//   ├───────────────────────────┤              │
+//   │  Composer (Enter submits) │              │
+//   └───────────────────────────┴──────────────┘
+//
+// Mobile (<768px): sidecar collapses into a bottom sheet (toggleable
+// via a small tab handle). Composer stays sticky at the viewport
+// bottom (the natural flow inside the grid handles this).
+//
+// State: window.useHermesSession (hook) + window.__hal0HermesSession
+// (connection api) installed by use-hermes-session.js.
+//
+// noAgent: render the install CTA matching PR-8's placeholder shape so
+// existing agent-view-v3 specs that gate on hermes-chat-placeholder
+// continue to pass. We keep the placeholder marker on the noAgent
+// branch ONLY.
 
-function HermesChatTab({ noAgent } = {}) {
+function HermesChatTab({ noAgent, agentId } = {}) {
+  const React = window.React;
+  const { useEffect, useState } = React;
+  const agent = agentId || "hermes";
+  const sess = window.useHermesSession;
+  const session = window.__hal0HermesSession;
+
+  // Read only the slices the shell cares about so streaming-delta
+  // store updates don't re-render the shell.
+  const shellSlice = sess
+    ? sess((s) => ({
+        transcript: s.transcript,
+        connectionState: s.connectionState,
+      }))
+    : { transcript: [], connectionState: "idle" };
+
+  // Mobile-sheet toggle
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  useEffect(() => {
+    if (noAgent || !session || !session.connect) return undefined;
+    session.connect(agent);
+    return () => {
+      // We don't auto-disconnect on unmount because PR-8's tab nav uses
+      // conditional render and a user clicking back into chat would
+      // re-open the WS. Holding the socket open across tab switches
+      // matches the upstream UX too (App.tsx:716 persistent ChatPage).
+    };
+  }, [agent, noAgent, session]);
+
   if (noAgent) {
     return (
-      <div className="card" style={{padding: 40, textAlign: "center", borderStyle: "dashed"}}>
-        <div className="mono" style={{fontSize: 14, color: "var(--fg-3)", marginBottom: 6}}>
+      <div
+        data-testid="hermes-chat-placeholder"
+        className="card"
+        style={{
+          padding: 48, textAlign: "center", borderStyle: "dashed",
+          display: "flex", flexDirection: "column", alignItems: "center", gap: 14,
+        }}
+      >
+        <div className="mono" style={{fontSize: 10, color: "var(--accent)", textTransform: "uppercase", letterSpacing: "0.1em"}}>
+          Hermes · chat
+        </div>
+        <div className="mono" style={{fontSize: 16, color: "var(--fg)", letterSpacing: "-0.01em"}}>
           No bundled agent installed.
         </div>
-        <div className="mono" style={{fontSize: 11, color: "var(--fg-5)"}}>
+        <p className="mono" style={{fontSize: 12, color: "var(--fg-3)", maxWidth: 460, lineHeight: 1.55, margin: 0}}>
           Run <span className="mono" style={{color: "var(--fg)"}}>hal0 agent install hermes</span> to bring the chat surface online.
-        </div>
+        </p>
       </div>
     );
   }
+
+  const Transcript = window.HermesTranscript;
+  const Composer   = window.HermesComposer;
+  const Sidecar    = window.HermesSidecar;
+
   return (
     <div
-      data-testid="hermes-chat-placeholder"
-      className="card"
-      style={{
-        padding: 48,
-        textAlign: "center",
-        borderStyle: "dashed",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        gap: 14,
-      }}
+      data-testid="hermes-chat-surface"
+      data-conn-state={shellSlice.connectionState}
+      className="hermes-chat-grid"
     >
-      <div className="mono" style={{fontSize: 10, color: "var(--accent)", textTransform: "uppercase", letterSpacing: "0.1em"}}>
-        Hermes · chat
+      <div className="hermes-chat-pane">
+        {Transcript && <Transcript rows={shellSlice.transcript} status={shellSlice.connectionState} />}
+        {Composer && (
+          <Composer
+            connectionState={shellSlice.connectionState}
+            disabled={false}
+          />
+        )}
       </div>
-      <div className="mono" style={{fontSize: 16, color: "var(--fg)", letterSpacing: "-0.01em"}}>
-        Chat surface lands in PR-10.
-      </div>
-      <p className="mono" style={{fontSize: 12, color: "var(--fg-3)", maxWidth: 460, lineHeight: 1.55, margin: 0}}>
-        The composer, transcript, persona dropdown, and inline approval
-        cards arrive with the next PR. Hermes is still running — you can
-        see its tool calls land in the activity log below.
-      </p>
-      <a
-        href="#logs"
-        className="btn ghost sm"
-        style={{display: "inline-flex", alignItems: "center", gap: 6}}
+      <div
+        className={"hermes-chat-sidecar" + (sheetOpen ? " open" : "")}
+        data-testid="hermes-chat-sidecar-wrap"
       >
-        {window.Icons && window.Icons.logs} View activity log
-      </a>
+        {Sidecar && <Sidecar agentId={agent} />}
+      </div>
+      {/* Mobile sheet toggle */}
+      <button
+        type="button"
+        data-testid="hermes-chat-sheet-toggle"
+        onClick={() => setSheetOpen(!sheetOpen)}
+        className="hermes-chat-sheet-toggle"
+        aria-label="Toggle agent sidecar"
+      >
+        {sheetOpen ? "Close" : "Agent"}
+      </button>
     </div>
   );
+}
+
+// Scoped CSS for the grid + mobile bottom sheet. Co-located with the
+// component so the layout lives next to the markup.
+const _hermesChatTabCss = `
+.hermes-chat-grid {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 0;
+  height: calc(100vh - var(--topbar-h, 52px) - var(--footer-h, 52px) - 120px);
+  min-height: 480px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--bg-1);
+}
+.hermes-chat-pane {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--bg-1);
+}
+.hermes-chat-sidecar {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  background: var(--bg);
+}
+.hermes-chat-sheet-toggle {
+  display: none;
+  position: absolute;
+  bottom: 76px;
+  right: 12px;
+  z-index: 20;
+  background: var(--accent-soft);
+  color: var(--accent);
+  border: 1px solid var(--accent-line);
+  border-radius: 9999px;
+  padding: 6px 14px;
+  font-family: var(--jbm);
+  font-size: 11px;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.35);
+}
+@media (max-width: 768px) {
+  .hermes-chat-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .hermes-chat-sidecar {
+    position: absolute;
+    bottom: 0; left: 0; right: 0;
+    max-height: 70vh;
+    border-top: 1px solid var(--line);
+    background: var(--bg);
+    transform: translateY(100%);
+    transition: transform 180ms ease;
+    z-index: 15;
+  }
+  .hermes-chat-sidecar.open {
+    transform: translateY(0);
+  }
+  .hermes-chat-sheet-toggle {
+    display: inline-block;
+  }
+}
+`;
+
+if (typeof document !== "undefined" && !document.getElementById("hal0-hermes-chat-tab-css")) {
+  const s = document.createElement("style");
+  s.id = "hal0-hermes-chat-tab-css";
+  s.textContent = _hermesChatTabCss;
+  document.head.appendChild(s);
 }
 
 Object.assign(window, { HermesChatTab });

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -75,6 +75,26 @@ import './dash/extras.jsx'
 // the old monolith is already removed).
 import './dash/agents/personas-tab-hook-bridge'
 import './dash/agents/memory-tab-hook-bridge'
+// v0.3 PR-10: HermesChat surface — composer + transcript + sidecar over
+// the WS proxy from PR-9 (master plan §4 PR-10). The session store
+// + connection manager publishes on window via use-hermes-session.js;
+// markdown/bubble/tool/approval/thinking/transcript/composer/sidecar
+// each register on window via Object.assign at file bottom. Load order
+// matters: session store FIRST so the sidecar can read it, then the
+// leaf components, then transcript (which composes them), then composer
+// + sidecar, then hermes-chat-tab.jsx (which composes the whole grid).
+// Sidecar's TanStack-Query bridge publishes useMcpStatusPip onto window
+// BEFORE the sidecar evaluates.
+import './dash/agents/chat/sidecar-hook-bridge'
+import './dash/agents/chat/use-hermes-session.js'
+import './dash/agents/chat/markdown.jsx'
+import './dash/agents/chat/message-bubble.jsx'
+import './dash/agents/chat/tool-call-card.jsx'
+import './dash/agents/chat/approval-card.jsx'
+import './dash/agents/chat/thinking-indicator.jsx'
+import './dash/agents/chat/transcript.jsx'
+import './dash/agents/chat/composer.jsx'
+import './dash/agents/chat/hermes-sidecar.jsx'
 import './dash/agents/hermes-chat-tab.jsx'
 import './dash/agents/personas-tab.jsx'
 import './dash/agents/skills-tab.jsx'

--- a/ui/tests/e2e/fixtures/wsHarness.ts
+++ b/ui/tests/e2e/fixtures/wsHarness.ts
@@ -1,0 +1,190 @@
+/**
+ * wsHarness — install an in-page WebSocket shim so specs can drive the
+ * Hermes JSON-RPC event stream deterministically. `page.route` can't
+ * intercept WebSocket upgrades, so we replace `window.WebSocket` with
+ * a FakeWebSocket that exposes a registry of open connections to the
+ * spec via `window.__wsStreams`.
+ *
+ * Symmetrically to sseHarness, we expose:
+ *
+ *   - emitWs(page, urlSubstring, frame)  — push one text frame on each
+ *     matching open socket. `frame` may be a string or any JSON-serializable
+ *     value (we stringify it).
+ *   - waitForWs(page, urlSubstring, timeoutMs?) — resolve when at least
+ *     one socket whose URL contains the substring is open.
+ *   - getWsSent(page, urlSubstring) — return the list of frames the page
+ *     has sent on a matching socket (used to assert prompt.submit /
+ *     approval.respond / persona-activate fired the right RPC).
+ *   - closeWs(page, urlSubstring, code?) — drop the socket so the
+ *     component exercises its reconnect path.
+ *
+ * The shim auto-opens (state → 1) on next microtask; specs that need to
+ * defer the open can call `pauseWsOpens(page)` before `goto` and
+ * `resumeWsOpens(page)` once they've installed routes / event listeners.
+ */
+import { Page } from '@playwright/test'
+
+export async function installWsHarness(page: Page) {
+  await page.addInitScript(() => {
+    const w = window as any
+    if (w.__wsStreams) return // already installed
+    const streams: any[] = []
+    w.__wsStreams = streams
+
+    let autoOpen = true
+    w.__wsPause = () => { autoOpen = false }
+    w.__wsResume = () => {
+      autoOpen = true
+      for (const s of streams) if (s.readyState === 0) s._open()
+    }
+
+    class FakeWebSocket extends EventTarget {
+      url: string
+      readyState = 0
+      bufferedAmount = 0
+      protocol = ''
+      extensions = ''
+      binaryType = 'blob'
+      onopen: ((ev: any) => any) | null = null
+      onmessage: ((ev: any) => any) | null = null
+      onclose: ((ev: any) => any) | null = null
+      onerror: ((ev: any) => any) | null = null
+      sentFrames: string[] = []
+      CONNECTING = 0
+      OPEN = 1
+      CLOSING = 2
+      CLOSED = 3
+      static CONNECTING = 0
+      static OPEN = 1
+      static CLOSING = 2
+      static CLOSED = 3
+
+      constructor(url: string, _protocols?: string | string[]) {
+        super()
+        this.url = String(url)
+        streams.push(this)
+        Promise.resolve().then(() => {
+          if (autoOpen) this._open()
+        })
+      }
+
+      _open() {
+        if (this.readyState !== 0) return
+        this.readyState = 1
+        const ev = new Event('open')
+        try { this.onopen && this.onopen(ev) } catch (_e) {}
+        this.dispatchEvent(ev)
+      }
+
+      send(data: any) {
+        if (this.readyState !== 1) return
+        const s = typeof data === 'string' ? data : String(data)
+        this.sentFrames.push(s)
+      }
+
+      close(code?: number, _reason?: string) {
+        if (this.readyState === 3) return
+        this.readyState = 3
+        // CloseEvent ctor is browser-only; on jsdom-light envs fall back
+        // to a plain Event with a code property. Always pass the type
+        // argument so the constructor accepts.
+        let ev: any
+        try {
+          ev = new (window as any).CloseEvent('close', { code: code ?? 1000 })
+        } catch (_e) {
+          ev = Object.assign(new Event('close'), { code: code ?? 1000 })
+        }
+        try { this.onclose && this.onclose(ev) } catch (_e) {}
+        this.dispatchEvent(ev)
+      }
+
+      _push(text: string) {
+        if (this.readyState !== 1) return
+        const ev = new MessageEvent('message', { data: text })
+        try { this.onmessage && this.onmessage(ev) } catch (_e) {}
+        this.dispatchEvent(ev)
+      }
+    }
+    w.WebSocket = FakeWebSocket
+  })
+}
+
+export async function pauseWsOpens(page: Page) {
+  await page.evaluate(() => (window as any).__wsPause && (window as any).__wsPause())
+}
+
+export async function resumeWsOpens(page: Page) {
+  await page.evaluate(() => (window as any).__wsResume && (window as any).__wsResume())
+}
+
+export async function waitForWs(
+  page: Page,
+  urlSubstring: string,
+  timeoutMs = 5000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const ok = await page.evaluate((sub) => {
+      const s = (window as any).__wsStreams || []
+      return s.some((w: any) => w.url && w.url.indexOf(sub) !== -1 && w.readyState === 1)
+    }, urlSubstring)
+    if (ok) return
+    await page.waitForTimeout(40)
+  }
+  throw new Error(`waitForWs: no open WebSocket for "${urlSubstring}" within ${timeoutMs}ms`)
+}
+
+export async function emitWs(
+  page: Page,
+  urlSubstring: string,
+  frame: any,
+): Promise<number> {
+  const payload = typeof frame === 'string' ? frame : JSON.stringify(frame)
+  return await page.evaluate(
+    ({ sub, body }) => {
+      const streams = (window as any).__wsStreams || []
+      let count = 0
+      for (const w of streams) {
+        if (w.url && w.url.indexOf(sub) !== -1 && w.readyState === 1) {
+          w._push(body)
+          count++
+        }
+      }
+      return count
+    },
+    { sub: urlSubstring, body: payload },
+  )
+}
+
+export async function getWsSent(
+  page: Page,
+  urlSubstring: string,
+): Promise<string[]> {
+  return await page.evaluate((sub) => {
+    const streams = (window as any).__wsStreams || []
+    const out: string[] = []
+    for (const w of streams) {
+      if (w.url && w.url.indexOf(sub) !== -1) {
+        for (const f of w.sentFrames) out.push(f)
+      }
+    }
+    return out
+  }, urlSubstring)
+}
+
+export async function closeWs(page: Page, urlSubstring: string, code = 1006): Promise<number> {
+  return await page.evaluate(
+    ({ sub, c }) => {
+      const streams = (window as any).__wsStreams || []
+      let count = 0
+      for (const w of streams) {
+        if (w.url && w.url.indexOf(sub) !== -1 && w.readyState === 1) {
+          w.close(c)
+          count++
+        }
+      }
+      return count
+    },
+    { sub: urlSubstring, c: code },
+  )
+}

--- a/ui/tests/e2e/specs/agent-view-v3.spec.ts
+++ b/ui/tests/e2e/specs/agent-view-v3.spec.ts
@@ -33,12 +33,13 @@ test.describe('AgentView v3 (#agent — PR-8 refactor)', () => {
     )
   })
 
-  test('default tab is chat — placeholder visible, no Inbox or Peers in nav', async ({ page }) => {
+  test('default tab is chat — surface visible, no Inbox or Peers in nav', async ({ page }) => {
     await page.goto('/#agent')
     await expect(page.locator('[data-testid="agent-tab-nav"]')).toBeVisible({ timeout: FIVE_S })
 
-    // Default tab content is the HermesChat placeholder.
-    await expect(page.locator('[data-testid="hermes-chat-placeholder"]')).toBeVisible()
+    // Default tab content is the HermesChat surface (PR-10 replaced
+    // PR-8's placeholder with the composer/transcript/sidecar grid).
+    await expect(page.locator('[data-testid="hermes-chat-surface"]')).toBeVisible()
 
     // Nav contains the new 5-tab set, and ONLY that set.
     for (const id of ['chat', 'personas', 'skills', 'memory', 'plugins']) {
@@ -89,6 +90,6 @@ test.describe('AgentView v3 (#agent — PR-8 refactor)', () => {
 
   test('#agent/chat hash routes to the chat tab', async ({ page }) => {
     await page.goto('/#agent/chat')
-    await expect(page.locator('[data-testid="hermes-chat-placeholder"]')).toBeVisible({ timeout: FIVE_S })
+    await expect(page.locator('[data-testid="hermes-chat-surface"]')).toBeVisible({ timeout: FIVE_S })
   })
 })

--- a/ui/tests/e2e/specs/hermes-chat.spec.ts
+++ b/ui/tests/e2e/specs/hermes-chat.spec.ts
@@ -1,0 +1,314 @@
+/**
+ * hermes-chat — v0.3 PR-10 (master plan §4 PR-10).
+ *
+ * Exercises the HermesChat surface end-to-end against a mocked WS event
+ * stream (wsHarness fixture). Pins the contract for:
+ *
+ *   - Composer submit (Enter submits, Shift+Enter newline)
+ *   - Event routing: message.{start,delta,complete} → assistant bubble
+ *   - Event routing: tool.{start,progress,complete}  → ToolCallCard
+ *   - Event routing: approval.request                → inline ApprovalCard
+ *   - Persona switch via sidecar dropdown
+ *   - MCP status pip rolls up from /api/mcp/servers
+ *   - Reconnect: socket drop kicks the reconnect-scheduler
+ *   - Sidecar restart confirmation while a message is streaming
+ *   - Mobile sheet toggle visible <768px
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+import {
+  installWsHarness,
+  waitForWs,
+  emitWs,
+  getWsSent,
+  closeWs,
+} from '../fixtures/wsHarness'
+
+const FIVE_S = 5_500
+
+const MOCK_AGENTS = {
+  agents: [{ name: 'hermes', installed_at: '2026-05-25T12:00:00Z', status: 'installed' }],
+  count: 1,
+}
+
+const MOCK_PERSONAS = {
+  agent_id: 'hermes',
+  active: 'default',
+  personas: [
+    { id: 'default', display_name: 'Hermes', description: 'Default persona', active: true },
+    { id: 'coder',   display_name: 'Hermes Coder', description: 'Coder persona', active: false },
+  ],
+}
+
+const MOCK_MCP_GREEN = {
+  servers: [
+    { id: 'hal0-admin',  name: 'hal0-admin',  bundled: true, state: 'running' },
+    { id: 'hal0-memory', name: 'hal0-memory', bundled: true, state: 'running' },
+  ],
+  count: 2,
+}
+
+async function seedAndOpen(page: import('@playwright/test').Page) {
+  await page.route('**/api/agents', (route) => json(route, MOCK_AGENTS))
+  await page.route('**/api/agents/hermes/personas', (route) => json(route, MOCK_PERSONAS))
+  await page.route('**/api/mcp/servers', (route) => json(route, MOCK_MCP_GREEN))
+  await page.route('**/api/agent/approvals', (route) => json(route, { approvals: [] }))
+  await page.route('**/api/agents/skills', (route) => json(route, { skills: [], count: 0 }))
+  await page.route('**/api/agents/hermes/memory/stats', (route) => json(route, { writes: 0 }))
+  await page.route('**/api/agents/hermes/session/handshake', (route) =>
+    json(route, { agent_id: 'hermes', ok: true }),
+  )
+  await page.route('**/api/agents/hermes/personas/coder/activate', (route) =>
+    json(route, { ok: true, active: 'coder' }),
+  )
+  await page.route('**/api/agents/hermes/restart', (route) =>
+    json(route, { ok: true }),
+  )
+  await installWsHarness(page)
+  await page.goto('/#agent/chat')
+}
+
+test.describe('HermesChat surface — boot + composer', () => {
+  test('mounts surface + composer + sidecar + connects to events WS', async ({ page }) => {
+    await seedAndOpen(page)
+    await expect(page.locator('[data-testid="hermes-chat-surface"]')).toBeVisible({ timeout: FIVE_S })
+    await expect(page.locator('[data-testid="hermes-composer"]')).toBeVisible()
+    await expect(page.locator('[data-testid="hermes-sidecar"]')).toBeVisible()
+    // Connection manager opens both events + submit WS once handshake
+    // returns 200.
+    await waitForWs(page, '/api/agents/hermes/events', FIVE_S)
+    await waitForWs(page, '/api/agents/hermes/submit', FIVE_S)
+  })
+
+  test('composer Enter submits prompt.submit on the WS', async ({ page }) => {
+    await seedAndOpen(page)
+    await waitForWs(page, '/api/agents/hermes/submit', FIVE_S)
+
+    const input = page.locator('[data-testid="hermes-composer-input"]')
+    await input.fill('hi hermes')
+    await input.press('Enter')
+
+    // The user bubble lands immediately.
+    await expect(page.locator('[data-testid="hermes-msg-user"]')).toContainText('hi hermes', {
+      timeout: FIVE_S,
+    })
+
+    // The WS submit frame includes a JSON-RPC envelope with prompt.submit.
+    const frames = await getWsSent(page, '/api/agents/hermes/submit')
+    expect(frames.some((f) => f.includes('"method":"prompt.submit"'))).toBe(true)
+    expect(frames.some((f) => f.includes('"text":"hi hermes"'))).toBe(true)
+
+    // Textarea cleared.
+    await expect(input).toHaveValue('')
+  })
+
+  test('Shift+Enter inserts a newline (does NOT submit)', async ({ page }) => {
+    await seedAndOpen(page)
+    await waitForWs(page, '/api/agents/hermes/submit', FIVE_S)
+    const input = page.locator('[data-testid="hermes-composer-input"]')
+    await input.fill('line one')
+    await input.press('Shift+Enter')
+    await input.type('line two')
+    // Still has both lines + the message was NOT sent.
+    await expect(input).toHaveValue('line one\nline two')
+    const frames = await getWsSent(page, '/api/agents/hermes/submit')
+    expect(frames.some((f) => f.includes('prompt.submit') && f.includes('line one'))).toBe(false)
+  })
+})
+
+test.describe('HermesChat surface — event routing', () => {
+  test('message.start + message.delta + message.complete renders assistant bubble', async ({ page }) => {
+    await seedAndOpen(page)
+    await waitForWs(page, '/api/agents/hermes/events', FIVE_S)
+
+    await emitWs(page, '/api/agents/hermes/events', {
+      jsonrpc: '2.0', method: 'event',
+      params: { type: 'message.start', session_id: 's1', payload: {} },
+    })
+    await emitWs(page, '/api/agents/hermes/events', {
+      jsonrpc: '2.0', method: 'event',
+      params: { type: 'message.delta', session_id: 's1', payload: { text: 'Hello ' } },
+    })
+    await emitWs(page, '/api/agents/hermes/events', {
+      jsonrpc: '2.0', method: 'event',
+      params: { type: 'message.delta', session_id: 's1', payload: { text: 'world.' } },
+    })
+    await emitWs(page, '/api/agents/hermes/events', {
+      jsonrpc: '2.0', method: 'event',
+      params: { type: 'message.complete', session_id: 's1', payload: { status: 'complete' } },
+    })
+
+    const bubble = page.locator('[data-testid="hermes-msg-assistant"]').first()
+    await expect(bubble).toContainText('Hello world.', { timeout: FIVE_S })
+  })
+
+  test('tool.start + tool.progress + tool.complete renders ToolCallCard', async ({ page }) => {
+    await seedAndOpen(page)
+    await waitForWs(page, '/api/agents/hermes/events', FIVE_S)
+
+    await emitWs(page, '/api/agents/hermes/events', {
+      jsonrpc: '2.0', method: 'event',
+      params: {
+        type: 'tool.start', session_id: 's1',
+        payload: { tool_id: 't1', name: 'read_file', context: 'path=/tmp/x' },
+      },
+    })
+
+    const card = page.locator('[data-testid="hermes-tool-card"]')
+    await expect(card).toBeVisible({ timeout: FIVE_S })
+    await expect(card).toHaveAttribute('data-tool-name', 'read_file')
+    await expect(card).toHaveAttribute('data-tool-status', 'running')
+
+    await emitWs(page, '/api/agents/hermes/events', {
+      jsonrpc: '2.0', method: 'event',
+      params: {
+        type: 'tool.complete', session_id: 's1',
+        payload: { tool_id: 't1', name: 'read_file', summary: '42 bytes', duration_s: 0.2 },
+      },
+    })
+    await expect(card).toHaveAttribute('data-tool-status', 'done')
+  })
+
+  test('approval.request renders inline ApprovalCard + Approve sends approval.respond', async ({ page }) => {
+    await seedAndOpen(page)
+    await waitForWs(page, '/api/agents/hermes/events', FIVE_S)
+    await waitForWs(page, '/api/agents/hermes/submit', FIVE_S)
+
+    await emitWs(page, '/api/agents/hermes/events', {
+      jsonrpc: '2.0', method: 'event',
+      params: {
+        type: 'approval.request', session_id: 's1',
+        payload: { request_id: 'req-42', tool: 'shell_exec', args: { cmd: 'rm -rf /' } },
+      },
+    })
+
+    const card = page.locator('[data-testid="hermes-approval-card"]')
+    await expect(card).toBeVisible({ timeout: FIVE_S })
+    await expect(card).toHaveAttribute('data-approval-rid', 'req-42')
+    await expect(card).toHaveAttribute('data-approval-kind', 'approval')
+
+    await page.locator('[data-testid="hermes-approval-approve"]').click()
+
+    const frames = await getWsSent(page, '/api/agents/hermes/submit')
+    expect(frames.some((f) => f.includes('"method":"approval.respond"') && f.includes('req-42'))).toBe(true)
+    expect(frames.some((f) => f.includes('"decision":"approve"'))).toBe(true)
+  })
+
+  test('status.update + error update sidecar + render error bubble', async ({ page }) => {
+    await seedAndOpen(page)
+    await waitForWs(page, '/api/agents/hermes/events', FIVE_S)
+
+    await emitWs(page, '/api/agents/hermes/events', {
+      jsonrpc: '2.0', method: 'event',
+      params: { type: 'error', session_id: 's1', payload: { message: 'tool died' } },
+    })
+
+    await expect(page.locator('[data-testid="hermes-msg-error"]')).toContainText('tool died', {
+      timeout: FIVE_S,
+    })
+  })
+
+  test('session.info updates model badge', async ({ page }) => {
+    await seedAndOpen(page)
+    await waitForWs(page, '/api/agents/hermes/events', FIVE_S)
+
+    await emitWs(page, '/api/agents/hermes/events', {
+      jsonrpc: '2.0', method: 'event',
+      params: {
+        type: 'session.info', session_id: 's1',
+        payload: { session_id: 's1', model: 'qwen3-coder-30b', provider: 'hal0' },
+      },
+    })
+
+    const badge = page.locator('[data-testid="hermes-sidecar-model"]')
+    await expect(badge).toContainText('qwen3-coder-30b', { timeout: FIVE_S })
+    await expect(badge).toContainText('hal0')
+  })
+})
+
+test.describe('HermesChat sidecar — persona + restart', () => {
+  test('persona dropdown lists personas and activates on click', async ({ page }) => {
+    await seedAndOpen(page)
+    await expect(page.locator('[data-testid="hermes-sidecar-persona"]')).toBeVisible({ timeout: FIVE_S })
+    await page.locator('[data-testid="hermes-sidecar-persona-button"]').click()
+    await expect(page.locator('[data-testid="hermes-sidecar-persona-menu"]')).toBeVisible()
+
+    // Wait for the activate POST to fire when we pick coder.
+    const activateReq = page.waitForRequest(
+      (r) => r.url().includes('/api/agents/hermes/personas/coder/activate') && r.method() === 'POST',
+    )
+    await page.locator('[data-testid="hermes-sidecar-persona-option-coder"]').click()
+    await activateReq
+  })
+
+  test('restart button POSTs /api/agents/hermes/restart when idle', async ({ page }) => {
+    await seedAndOpen(page)
+    await expect(page.locator('[data-testid="hermes-sidecar-restart"]')).toBeVisible({ timeout: FIVE_S })
+
+    const restartReq = page.waitForRequest(
+      (r) => r.url().includes('/api/agents/hermes/restart') && r.method() === 'POST',
+    )
+    await page.locator('[data-testid="hermes-sidecar-restart"]').click()
+    await restartReq
+  })
+
+  test('restart confirms when a message is streaming', async ({ page }) => {
+    await seedAndOpen(page)
+    await waitForWs(page, '/api/agents/hermes/events', FIVE_S)
+    // Begin streaming.
+    await emitWs(page, '/api/agents/hermes/events', {
+      jsonrpc: '2.0', method: 'event',
+      params: { type: 'message.start', session_id: 's1', payload: {} },
+    })
+    await emitWs(page, '/api/agents/hermes/events', {
+      jsonrpc: '2.0', method: 'event',
+      params: { type: 'message.delta', session_id: 's1', payload: { text: 'streaming…' } },
+    })
+
+    await page.locator('[data-testid="hermes-sidecar-restart"]').click()
+    await expect(page.locator('[data-testid="hermes-sidecar-restart-confirm"]')).toBeVisible({
+      timeout: FIVE_S,
+    })
+
+    const restartReq = page.waitForRequest(
+      (r) => r.url().includes('/api/agents/hermes/restart') && r.method() === 'POST',
+    )
+    await page.locator('[data-testid="hermes-sidecar-restart-confirm-yes"]').click()
+    await restartReq
+  })
+})
+
+test.describe('HermesChat — reconnect strategy', () => {
+  test('events WS close kicks the reconnect scheduler', async ({ page }) => {
+    await seedAndOpen(page)
+    await waitForWs(page, '/api/agents/hermes/events', FIVE_S)
+
+    // Drop the events WS.
+    await closeWs(page, '/api/agents/hermes/events', 1006)
+
+    // Reconnect within ~5s (base backoff 250ms, capped 4s; handshake
+    // succeeds against the mock).
+    await waitForWs(page, '/api/agents/hermes/events', FIVE_S)
+  })
+})
+
+test.describe('HermesChat — mobile sheet', () => {
+  test.use({ viewport: { width: 600, height: 900 } })
+
+  test('mobile sheet toggle button is visible <768px', async ({ page }) => {
+    await seedAndOpen(page)
+    await expect(page.locator('[data-testid="hermes-chat-sheet-toggle"]')).toBeVisible({
+      timeout: FIVE_S,
+    })
+  })
+})
+
+test.describe('HermesChat — first-run welcome', () => {
+  test('on initial connect without a sessionId, sends session.create with first_run=true', async ({ page }) => {
+    await seedAndOpen(page)
+    await waitForWs(page, '/api/agents/hermes/submit', FIVE_S)
+    // Give the onopen handler a beat to fire.
+    await page.waitForTimeout(120)
+    const frames = await getWsSent(page, '/api/agents/hermes/submit')
+    expect(frames.some((f) => f.includes('"method":"session.create"') && f.includes('"first_run":true'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Hal0-native React chat surface over PR-9's WS proxy
- Composer (Enter submits, Shift+Enter newline) + Transcript + MessageBubble + Markdown + ToolCallCard + ApprovalCard + ThinkingIndicator
- HermesSidecar: PersonaSwitcher (PR-4 hot-swap), ModelBadge, MCPStatusRow, AgentControls
- WS event routing covers every R1 taxonomy entry
- Approvals: inline card + sidebar pip + toast (no desktop notification)
- First-run welcome via Hermes auto-introduction (PR-3 system prompt addendum)
- Mobile: composer sticky bottom + sidecar bottom sheet < 768px
- State mgmt split per master plan §2: external store + useSyncExternalStore for runtime, TanStack Query for fetch/cache

## Test plan
- [x] Build clean + typecheck
- [x] Playwright \`hermes-chat.spec.ts\` covers: composer submit, message stream, tool card, approval card, persona switch, reconnect
- [x] WS event routing assertions
- [x] Mobile viewport snapshot
- [ ] Live LXC end-to-end (PR-11 delta-harness owns this)

Refs MASTER-PLAN.md §4 PR-10. Addresses §1 pivot #1 (xterm → composer) + §6 user decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)