### PR TITLE
fix(agents): probe /api/status not /api/health for hermes readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ tests/release-gate-report.json
 # OS
 Thumbs.db
 .claude/worktrees/
+
+# Serena MCP project tooling (local index/cache, not source)
+.serena/

--- a/src/hal0/cli/agent_shim.py
+++ b/src/hal0/cli/agent_shim.py
@@ -93,11 +93,17 @@ class AgentConfig:
     def status_url(self) -> str:
         """URL the shim polls to confirm the agent's HTTP surface is up."""
 
-        # ``/api/health`` is upstream-stable across hermes ≥ 0.10 and is the
-        # cheapest endpoint we can hit to determine "ready". The Hermes
-        # dashboard route doesn't expose ``/healthz`` — verified against
-        # ``~/src/hermes-agent/hermes_cli/web_server.py``.
-        return f"http://{self.host}:{self.port}/api/health"
+        # ``/api/status`` is the cheapest endpoint we can hit to determine
+        # "ready", AND — critically — it is one of the few routes hermes
+        # leaves unauthenticated. As of hermes 0.14.0 the dashboard's
+        # ``auth_middleware`` gates every ``/api/`` route behind an ephemeral
+        # per-process session token EXCEPT the ``_PUBLIC_API_PATHS`` allowlist
+        # (``hermes_cli/web_server.py``). ``/api/health`` is NOT on that list,
+        # so probing it returns 401 → the shim never sees 2xx → never emits
+        # READY=1 → systemd start-timeout → restart loop. ``/api/status`` IS
+        # on the allowlist and returns 200 with the version/home/config-state
+        # body, which is exactly the liveness signal we need.
+        return f"http://{self.host}:{self.port}/api/status"
 
 
 def _load_agent_config(agent_id: str) -> AgentConfig:
@@ -309,7 +315,7 @@ def cmd_serve(cfg: AgentConfig) -> int:
     # overrides.yaml on SIGHUP. Pass through unchanged.
     signal.signal(signal.SIGHUP, _forward_signal)
 
-    # Block until /api/health responds OR the child exits OR we time out.
+    # Block until /api/status responds OR the child exits OR we time out.
     ready = _wait_for_ready(child, cfg, _READY_TIMEOUT_S)
     if not ready:
         # Child either crashed or never opened the socket. Don't sd_notify

--- a/tests/cli/test_agent_shim.py
+++ b/tests/cli/test_agent_shim.py
@@ -120,7 +120,7 @@ class TestAgentConfig:
             host="10.0.0.1",
             port=4242,
         )
-        assert cfg.status_url == "http://10.0.0.1:4242/api/health"
+        assert cfg.status_url == "http://10.0.0.1:4242/api/status"
 
     def test_hermes_bin_resolves_under_venv(self) -> None:
         cfg = agent_shim.AgentConfig(


### PR DESCRIPTION
## Problem

Hermes **0.14.0** gates every `/api/*` route behind an ephemeral per-process session token (dashboard `auth_middleware`), except routes on its `_PUBLIC_API_PATHS` allowlist. `/api/health` is **not** on that list, so the agent shim readiness probe received **401**, never saw a 2xx, never emitted `READY=1`, and systemd hit the start-timeout → **hermes agent restart loop**.

## Fix

Probe `/api/status` instead — it **is** on the public allowlist and returns 200 with the version/home/config-state body, which is exactly the liveness signal the shim needs.

- `src/hal0/cli/agent_shim.py`: `status_url` → `/api/status` (+ explanatory comment, + updated wait-for-ready comment)
- `tests/cli/test_agent_shim.py`: assertion updated
- `.gitignore`: ignore `.serena/` (Serena MCP local tooling, not source)

## Verification

- `pytest tests/cli/test_agent_shim.py` → **36 passed**
- `ruff check` + `ruff format --check` clean
- Already running live on LXC 105 (editable install); `hal0-agent@hermes.service` is `active (running)`, `NRestarts=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)