### PR TITLE
fix(mcp): configurable DNS-rebinding allowlist for MCP transport

### DIFF
--- a/docs/operate/config.mdx
+++ b/docs/operate/config.mdx
@@ -123,6 +123,38 @@ file deliberately stays stale. If you edit `default` on a running box
 and nothing changes, this is why. Use `hal0 slot swap <name> --model
 <ref>` (or the dashboard's model picker) to swap.
 
+## Remote MCP access (`HAL0_MCP_ALLOWED_HOSTS`)
+
+The bundled MCP servers (`/mcp/admin`, `/mcp/memory`) ship with the MCP
+SDK's DNS-rebinding protection, which **only accepts a `localhost` Host
+header by default**. On a single box that's invisible — but the moment
+another node, or a reverse-proxy vhost, reaches the mount by IP or domain
+it gets a bare `421 Invalid Host header` with no other hint.
+
+Since hal0 binds `0.0.0.0` on the trusted LAN (network auth was removed in
+[ADR-0012](/internal/adr/0012-remove-auth-and-caddy/)), widen the
+allowlist with two env vars on the `hal0-api` service:
+
+| Env var | Example | Effect |
+| --- | --- | --- |
+| `HAL0_MCP_ALLOWED_HOSTS` | `hal0.lan:8080,hal0.example.com` | Adds these `Host` values to the localhost allowlist. A `host:*` entry matches any port. |
+| `HAL0_MCP_ALLOWED_HOSTS` | `*` | Disables DNS-rebinding protection entirely — the fully-open posture for trusted LAN-only deployments. |
+| `HAL0_MCP_ALLOWED_ORIGINS` | `https://hal0.example.com` | Browser `Origin` allowlist. When unset, `http`+`https` origins are derived from each added host. |
+
+The localhost defaults are always preserved, so local clients keep
+working regardless. CLI clients (e.g. Claude Code) send only a `Host`
+header, so `HAL0_MCP_ALLOWED_HOSTS` is the one that matters for
+node-to-node access; `HAL0_MCP_ALLOWED_ORIGINS` is only for browser-based
+MCP clients.
+
+Apply it with a systemd drop-in, then restart:
+
+```ini
+# /etc/systemd/system/hal0-api.service.d/mcp-hosts.conf
+[Service]
+Environment=HAL0_MCP_ALLOWED_HOSTS=hal0.lan:8080,hal0.example.com
+```
+
 ## Coming soon — outline
 
 - Hot-reload of selected fields (changing an idle timeout without

--- a/src/hal0/api/mcp_mount.py
+++ b/src/hal0/api/mcp_mount.py
@@ -16,6 +16,7 @@ functions accept.
 
 from __future__ import annotations
 
+import os
 from contextvars import ContextVar
 from dataclasses import dataclass
 
@@ -25,6 +26,12 @@ from starlette.requests import Request
 from starlette.types import ASGIApp
 
 log = structlog.get_logger("hal0.api.mcp_mount")
+
+# Localhost values FastMCP itself uses when it auto-enables DNS-rebinding
+# protection for a 127.0.0.1 server. We keep them as the secure floor so
+# the default posture is unchanged even when an operator widens the set.
+_LOCALHOST_HOSTS = ("127.0.0.1:*", "localhost:*", "[::1]:*")
+_LOCALHOST_ORIGINS = ("http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*")
 
 
 def _resolve_bearer(request: Request) -> str | None:
@@ -36,6 +43,61 @@ def _resolve_bearer(request: Request) -> str | None:
     if len(parts) != 2 or parts[0].lower() != "bearer":
         return None
     return parts[1].strip() or None
+
+
+def _mcp_transport_security():
+    """Build the MCP transport's DNS-rebinding allowlist from the env.
+
+    FastMCP auto-enables a *localhost-only* ``TransportSecuritySettings``
+    whenever a server is built with the default ``127.0.0.1`` host (see
+    ``mcp.server.fastmcp.FastMCP.__init__``). That lockdown is invisible
+    until a non-localhost client hits the mount and gets a bare
+    ``421 Invalid Host header`` — exactly what happens the moment another
+    homelab node, or the Traefik vhost, tries to reach ``/mcp/*``.
+
+    hal0 removed network auth entirely (ADR-0012) and binds ``0.0.0.0`` on
+    the trusted LAN, so the mount has to be reachable by its real host
+    name. We keep the secure localhost default but let operators widen it,
+    mirroring the ``HAL0_ALLOWED_ORIGINS`` knob in ``api/agents/_auth``:
+
+    * ``HAL0_MCP_ALLOWED_HOSTS`` — comma-separated ``host`` / ``host:port``
+      / ``host:*`` values added to the localhost allowlist. The single
+      value ``*`` disables DNS-rebinding protection altogether (the
+      fully-open posture some LAN-only deployments want).
+    * ``HAL0_MCP_ALLOWED_ORIGINS`` — comma-separated browser origins.
+      When unset, ``http``+``https`` origins are derived from each added
+      host so the dashboard and Traefik vhost work without a second knob.
+
+    Returns a ``TransportSecuritySettings``. Imported lazily to keep the
+    ``mcp`` dependency out of this module's import path until a mount
+    actually happens.
+    """
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    raw_hosts = os.environ.get("HAL0_MCP_ALLOWED_HOSTS", "").strip()
+    if raw_hosts == "*":
+        return TransportSecuritySettings(enable_dns_rebinding_protection=False)
+
+    extra_hosts = [h.strip() for h in raw_hosts.split(",") if h.strip()]
+    hosts = [*_LOCALHOST_HOSTS, *extra_hosts]
+
+    raw_origins = os.environ.get("HAL0_MCP_ALLOWED_ORIGINS", "").strip()
+    extra_origins = [o.strip() for o in raw_origins.split(",") if o.strip()]
+    if not extra_origins:
+        # Derive http+https origins from each operator host so browser
+        # clients (dashboard, Traefik vhost) work without a second env var.
+        for host in extra_hosts:
+            base = host[:-2] if host.endswith(":*") else host
+            extra_origins.extend((f"http://{base}", f"https://{base}"))
+
+    # dict.fromkeys de-dupes while preserving order.
+    origins = list(dict.fromkeys((*_LOCALHOST_ORIGINS, *extra_origins)))
+
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=hosts,
+        allowed_origins=origins,
+    )
 
 
 @dataclass
@@ -124,12 +186,20 @@ def mount_mcp_servers(
     """
     from hal0.mcp.admin import build_server as build_admin_server
 
+    # DNS-rebinding allowlist for every mounted FastMCP sub-app. Set on
+    # the server's settings *before* ``streamable_http_app()`` builds the
+    # session manager — that's when ``self.settings.transport_security``
+    # is read. Without this each server inherits FastMCP's localhost-only
+    # default and rejects LAN / Traefik clients with a bare 421.
+    transport_security = _mcp_transport_security()
+
     admin_server = build_admin_server(
         approval_queue=approval_queue,
         base_url=base_url,
         memory_dispatcher=memory_dispatcher,
         bearer_resolver=bearer_resolver,
     )
+    admin_server.settings.transport_security = transport_security
     # ``streamable_http_app()`` must be called BEFORE
     # ``session_manager`` is accessible — FastMCP creates the manager
     # lazily on the first app build. The lifespan reads
@@ -156,6 +226,7 @@ def mount_mcp_servers(
             client_id_resolver=client_id_resolver,
             private_resolver=private_resolver,
         )
+        memory_server.settings.transport_security = transport_security
         memory_app: ASGIApp = memory_server.streamable_http_app()
         memory_app.add_middleware(MCPAuthMiddleware)
         app.mount("/mcp/memory", memory_app, name="mcp-memory")
@@ -169,6 +240,8 @@ def mount_mcp_servers(
         "hal0.mcp.mounted",
         admin=True,
         memory=memory_wrapper is not None,
+        dns_rebinding_protection=transport_security.enable_dns_rebinding_protection,
+        allowed_hosts=len(transport_security.allowed_hosts),
     )
 
 

--- a/tests/api/test_mcp_transport_security.py
+++ b/tests/api/test_mcp_transport_security.py
@@ -1,0 +1,134 @@
+"""Unit tests for the MCP transport DNS-rebinding allowlist.
+
+Regression context: FastMCP auto-locks a mount built with the default
+``127.0.0.1`` host to a localhost-only ``TransportSecuritySettings``
+(see ``mcp.server.fastmcp.FastMCP.__init__``). That lockdown is invisible
+until a non-localhost client — another homelab node, or the Traefik vhost
+— hits ``/mcp/*`` and gets a bare ``421 Invalid Host header``. The mount
+now honours ``HAL0_MCP_ALLOWED_HOSTS`` / ``HAL0_MCP_ALLOWED_ORIGINS`` so
+operators can widen the allowlist without losing the secure default.
+"""
+
+from __future__ import annotations
+
+from hal0.api.mcp_mount import _mcp_transport_security
+
+
+def test_default_is_localhost_only(monkeypatch):
+    monkeypatch.delenv("HAL0_MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("HAL0_MCP_ALLOWED_ORIGINS", raising=False)
+
+    sec = _mcp_transport_security()
+
+    assert sec.enable_dns_rebinding_protection is True
+    assert "127.0.0.1:*" in sec.allowed_hosts
+    assert "localhost:*" in sec.allowed_hosts
+    # No operator hosts leaked into the default allowlist.
+    assert "10.0.1.142:8080" not in sec.allowed_hosts
+
+
+def test_extra_hosts_added_and_origins_derived(monkeypatch):
+    # Note the stray whitespace — it must be trimmed.
+    monkeypatch.setenv("HAL0_MCP_ALLOWED_HOSTS", "10.0.1.142:8080, hal0.thinmint.dev")
+    monkeypatch.delenv("HAL0_MCP_ALLOWED_ORIGINS", raising=False)
+
+    sec = _mcp_transport_security()
+
+    assert sec.enable_dns_rebinding_protection is True
+    # Localhost defaults are preserved alongside the operator additions.
+    assert "127.0.0.1:*" in sec.allowed_hosts
+    assert "10.0.1.142:8080" in sec.allowed_hosts
+    assert "hal0.thinmint.dev" in sec.allowed_hosts
+    # http+https origins are derived from each added host for browser clients.
+    assert "http://10.0.1.142:8080" in sec.allowed_origins
+    assert "https://10.0.1.142:8080" in sec.allowed_origins
+    assert "https://hal0.thinmint.dev" in sec.allowed_origins
+
+
+def test_wildcard_disables_protection(monkeypatch):
+    monkeypatch.setenv("HAL0_MCP_ALLOWED_HOSTS", "*")
+    monkeypatch.delenv("HAL0_MCP_ALLOWED_ORIGINS", raising=False)
+
+    sec = _mcp_transport_security()
+
+    # The fully-open posture some auth-removed LAN deployments want.
+    assert sec.enable_dns_rebinding_protection is False
+
+
+def test_explicit_origins_override_derivation(monkeypatch):
+    monkeypatch.setenv("HAL0_MCP_ALLOWED_HOSTS", "10.0.1.142:8080")
+    monkeypatch.setenv("HAL0_MCP_ALLOWED_ORIGINS", "https://app.example.test")
+
+    sec = _mcp_transport_security()
+
+    assert "https://app.example.test" in sec.allowed_origins
+    # When origins are given explicitly, host-derived origins are skipped.
+    assert "http://10.0.1.142:8080" not in sec.allowed_origins
+
+
+def _streamable_client(monkeypatch):
+    """Mount a minimal FastMCP server through the same ``transport_security``
+    wiring ``mount_mcp_servers`` uses, and return a ``TestClient`` for it.
+
+    This exercises the real path: settings are applied *before*
+    ``streamable_http_app()`` builds the session manager, so the SDK's
+    ``TransportSecurityMiddleware`` enforces the allowlist we computed.
+    """
+    from mcp.server.fastmcp import FastMCP
+    from starlette.testclient import TestClient
+
+    server = FastMCP("transport-security-probe")
+    server.settings.transport_security = _mcp_transport_security()
+    return TestClient(server.streamable_http_app())
+
+
+def _initialize_body() -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "probe", "version": "0"},
+        },
+    }
+
+
+def test_allowed_host_is_not_rejected_over_http(monkeypatch):
+    monkeypatch.setenv("HAL0_MCP_ALLOWED_HOSTS", "10.0.1.142:8090")
+    monkeypatch.delenv("HAL0_MCP_ALLOWED_ORIGINS", raising=False)
+
+    with _streamable_client(monkeypatch) as client:
+        resp = client.post(
+            "/mcp",
+            headers={
+                "Host": "10.0.1.142:8090",
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+            },
+            json=_initialize_body(),
+        )
+
+    # The whole point: a configured non-localhost Host clears the
+    # DNS-rebinding gate (it would be a bare 421 without the fix).
+    assert resp.status_code != 421
+
+
+def test_unconfigured_host_still_rejected(monkeypatch):
+    monkeypatch.setenv("HAL0_MCP_ALLOWED_HOSTS", "10.0.1.142:8090")
+    monkeypatch.delenv("HAL0_MCP_ALLOWED_ORIGINS", raising=False)
+
+    with _streamable_client(monkeypatch) as client:
+        resp = client.post(
+            "/mcp",
+            headers={
+                "Host": "attacker.example:8090",
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+            },
+            json=_initialize_body(),
+        )
+
+    # Protection is still live for hosts outside the allowlist.
+    assert resp.status_code == 421


### PR DESCRIPTION
## Problem

The bundled MCP servers (`/mcp/admin`, `/mcp/memory`) are built via `FastMCP(name)` with the default `127.0.0.1` host. FastMCP then **auto-enables a localhost-only** `TransportSecuritySettings` (DNS-rebinding protection). Any non-localhost client — another homelab node, or the Traefik vhost — hits the mount and gets a bare **`421 Invalid Host header`**. It is invisible on a single box and gives no hint in the logs.

This directly contradicts hal0's posture since **ADR-0012** (network auth removed, binds `0.0.0.0` on the trusted LAN): the dashboard, agents, and other nodes are *supposed* to reach the platform by IP/domain, but the MCP mount silently refuses them.

Found while wiring a second Claude Code node to hal0's shared memory MCP — every remote path returned 421.

## Fix

Compute a `TransportSecuritySettings` from the environment in `mcp_mount.py` and apply it to each server **before** `streamable_http_app()` builds the session manager. Mirrors the existing `HAL0_ALLOWED_ORIGINS` knob in `api/agents/_auth.py`.

| Env var | Example | Effect |
| --- | --- | --- |
| `HAL0_MCP_ALLOWED_HOSTS` | `hal0.lan:8080,hal0.example.com` | Added to the localhost allowlist (`host:*` matches any port) |
| `HAL0_MCP_ALLOWED_HOSTS` | `*` | Disables DNS-rebinding protection entirely (open LAN-only deployments) |
| `HAL0_MCP_ALLOWED_ORIGINS` | `https://hal0.example.com` | Browser Origin allowlist; derived from hosts when unset |

- **Secure default preserved** — with no env set, behavior is identical (localhost-only).
- CLI clients (Claude Code) only send `Host`, so `HAL0_MCP_ALLOWED_HOSTS` is the load-bearing knob; origins are for browser MCP clients.
- Mount log line now reports `dns_rebinding_protection` + `allowed_hosts` count so the failure mode is diagnosable.

## Tests

`tests/api/test_mcp_transport_security.py`:
- Helper env-matrix (default localhost-only; extra hosts added + origins derived; `*` disables; explicit origins override derivation).
- **HTTP integration** via Starlette `TestClient` against a real mounted FastMCP app: an allowed Host clears the gate (≠421), an unconfigured Host still returns 421.

`130 passed` across `tests/api/test_mcp_routes.py tests/mcp/` (no regressions); `ruff check` + `ruff format --check` clean.

## Deploy note

Operators set e.g. `HAL0_MCP_ALLOWED_HOSTS=<lan-ip>:8080,<domain>` via a `hal0-api.service.d` drop-in (documented in `docs/operate/config.mdx`) and restart `hal0-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
