### PR TITLE
fix(dispatcher): exempt composite hal0 upstream from slot-readiness gate (#422)

### DIFF
--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -76,6 +76,69 @@ _HOP_BY_HOP_RESPONSE_HEADERS = frozenset(
 # this logger automatically carries {request_id} on every emitted line.
 log = structlog.get_logger("hal0-dispatch")
 
+# ── Composite ``hal0`` upstream ───────────────────────────────────────────────
+#
+# ``_autoregister_slot_upstreams`` (hal0.api.__init__) registers ONE synthetic
+# upstream named ``hal0`` that aggregates every chat-capable slot's model id
+# under a single ``/v1/models`` listing (issue #422 / R4 H2). It is special in
+# two ways that the dispatch path must respect:
+#
+#   1. It is NOT a real slot. ``SlotManager`` has no ``hal0`` entry, so the
+#      readiness gate (``_check_slot_ready_for_dispatch``) and the SERVING wrap
+#      must be skipped for it — otherwise a populated model cache would route a
+#      chat request to the composite and immediately 503 with
+#      ``slot 'hal0' is offline`` (the gate calls ``_current_state('hal0')``
+#      which finds no slot and returns OFFLINE).
+#   2. Its registered ``url`` is hal0-api's OWN ``/v1`` surface
+#      (``127.0.0.1:8080/v1``). That value is deliberate so the ``/v1/models``
+#      aggregator can short-circuit it instead of recursing over HTTP. But it
+#      is the WRONG target to *forward* a chat request to — forwarding to
+#      ``:8080`` would re-enter ``/v1/chat/completions`` and loop forever. The
+#      real inference backend is the Lemonade gateway, so composite forwards
+#      are redirected there.
+_HAL0_COMPOSITE_NAME = "hal0"
+
+# Lemonade's OpenAI-compatible gateway (ADR-0008 §1: lemond binds
+# 127.0.0.1:13305). Overridable via ``LEMONADE_BASE_URL`` to match
+# ``hal0.api.routes.lemonade_proxy._lemonade_base_url``.
+_LEMONADE_DEFAULT_BASE_URL = "http://127.0.0.1:13305"
+
+
+def _is_hal0_composite(upstream: Upstream) -> bool:
+    """True for the synthetic composite ``hal0`` upstream.
+
+    The composite is the single ``kind="slot"`` entry with no backing
+    ``slot_name`` whose name is ``hal0`` (see
+    ``hal0.api._autoregister_slot_upstreams``). Real per-slot upstreams
+    always carry a ``slot_name``; remote providers are ``kind="remote"``.
+    """
+    return (
+        upstream.kind == "slot"
+        and upstream.slot_name is None
+        and upstream.name == _HAL0_COMPOSITE_NAME
+    )
+
+
+def _lemonade_gateway_base() -> str:
+    """Return the Lemonade OpenAI-compat gateway base URL (no trailing slash)."""
+    import os
+
+    return os.environ.get("LEMONADE_BASE_URL", _LEMONADE_DEFAULT_BASE_URL).rstrip("/")
+
+
+def _resolve_target_url(upstream: Upstream, request_path: str) -> str:
+    """Build the forward URL for ``upstream`` given the incoming request path.
+
+    For the composite ``hal0`` upstream the forward must NOT go to the
+    registered ``:8080`` URL (that re-enters hal0-api and loops); it is
+    redirected to the Lemonade gateway. Every other upstream forwards to
+    its own ``url`` via :func:`_join_url`.
+    """
+    if _is_hal0_composite(upstream):
+        return _join_url(_lemonade_gateway_base() + "/v1", request_path)
+    return _join_url(upstream.url, request_path)
+
+
 # Transport-layer errors that indicate the upstream's child process is gone
 # rather than a request-level failure.  These are the recoverable triggers
 # for ``_recover_evicted_slot``:
@@ -412,7 +475,7 @@ class Dispatcher:
                     resolved = actual
                 call = UpstreamCall(
                     upstream_name=upstream.name,
-                    target_url=_join_url(upstream.url, path),
+                    target_url=_resolve_target_url(upstream, path),
                     headers=self._build_headers(request, upstream),
                     body=json.dumps(effective_body).encode("utf-8"),
                     streaming=streaming,
@@ -436,7 +499,7 @@ class Dispatcher:
             if model_id in self._cached_models(upstream.name):
                 call = UpstreamCall(
                     upstream_name=upstream.name,
-                    target_url=_join_url(upstream.url, path),
+                    target_url=_resolve_target_url(upstream, path),
                     headers=self._build_headers(request, upstream),
                     body=_remap_model(body, model_id),
                     streaming=streaming,
@@ -461,7 +524,7 @@ class Dispatcher:
                 if model_id in self._cached_models(upstream.name):
                     call = UpstreamCall(
                         upstream_name=upstream.name,
-                        target_url=_join_url(upstream.url, path),
+                        target_url=_resolve_target_url(upstream, path),
                         headers=self._build_headers(request, upstream),
                         body=_remap_model(body, model_id),
                         streaming=streaming,
@@ -996,8 +1059,18 @@ def _slot_name_of(upstream: Upstream) -> str:
     ``upstream.name`` when ``slot_name`` is unset — autoregistered slots
     use the same value for both, but explicit upstreams.toml entries can
     override.
+
+    The composite ``hal0`` upstream is exempt: it has no backing slot, so
+    returning ``"hal0"`` here would make ``forward()`` run the readiness
+    gate against a non-existent slot (always OFFLINE → spurious 503) and
+    wrap the call in a ``SlotManager.serving("hal0")`` context that can
+    never settle. Returning ``""`` routes it through ``_forward_plain``,
+    which is correct because the actual slot lifecycle is enforced on the
+    Lemonade gateway hop the composite forwards to.
     """
     if upstream.kind != "slot":
+        return ""
+    if _is_hal0_composite(upstream):
         return ""
     return upstream.slot_name or upstream.name
 

--- a/tests/dispatcher/test_composite_dispatch.py
+++ b/tests/dispatcher/test_composite_dispatch.py
@@ -1,0 +1,226 @@
+"""Regression tests for issue #422 — composite ``hal0`` upstream dispatch.
+
+Two distinct bugs are locked down here:
+
+  1. **Empty/ignored composite cache.** When the composite ``hal0`` upstream
+     advertises a chat model, a chat request for that id must resolve via the
+     registry/passthrough path — NOT fall through to the legacy heuristics
+     (which raise :class:`NoRouteFound`, demoting the whole dispatcher layer to
+     a raw Lemonade proxy and killing prompt-cache / instrumentation).
+
+  2. **Readiness-gate masquerade.** ``hal0`` is a synthetic upstream with no
+     backing slot. ``_slot_name_of`` used to fall back to ``upstream.name`` and
+     hand ``forward()`` ``slot_name="hal0"``, so the swap-window gate called
+     ``_current_state("hal0")`` → OFFLINE → a spurious 503. The composite must
+     be exempt from the gate (and the SERVING wrap), and its forward must target
+     the Lemonade gateway rather than hal0-api's own ``:8080`` (which would
+     recurse forever).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from starlette.requests import Request
+
+from hal0.dispatcher.router import (
+    Dispatcher,
+    UpstreamCall,
+    _is_hal0_composite,
+    _resolve_target_url,
+    _slot_name_of,
+)
+from hal0.slots.state import SlotState
+from hal0.upstreams.registry import Upstream, UpstreamRegistry
+
+# ── test doubles ──────────────────────────────────────────────────────────────
+
+
+class _FakeUpstreamRegistry(UpstreamRegistry):
+    def __init__(self, upstreams: list[Upstream]) -> None:
+        super().__init__()
+        self._store: dict[str, Upstream] = {u.name: u for u in upstreams}
+
+    def list(self) -> list[Upstream]:  # type: ignore[override]
+        return list(self._store.values())
+
+    def get(self, name: str) -> Upstream | None:  # type: ignore[override]
+        return self._store.get(name)
+
+
+class _FakeModelRegistry:
+    def __init__(self, routes: dict[str, str] | None = None) -> None:
+        self._routes = routes or {}
+
+    def route_for(self, model_id: str) -> str | None:
+        return self._routes.get(model_id)
+
+
+class _OfflineSlotManager:
+    """SlotManager stand-in whose every slot reports OFFLINE.
+
+    Records ``serving()`` entries so a test can prove the composite path
+    never opens the SERVING context. ``_current_state`` returning OFFLINE
+    would trip the readiness gate for any call carrying a non-empty
+    ``slot_name`` — the composite must carry an empty one.
+    """
+
+    def __init__(self) -> None:
+        self.serving_calls: list[str] = []
+
+    def _current_state(self, _slot_name: str) -> SlotState:
+        return SlotState.OFFLINE
+
+    def serving(self, slot_name: str) -> Any:  # pragma: no cover - guard only
+        self.serving_calls.append(slot_name)
+        raise AssertionError(f"composite forward must not enter serving() (slot={slot_name!r})")
+
+
+def _composite() -> Upstream:
+    """The synthetic composite as ``_autoregister_slot_upstreams`` builds it."""
+    return Upstream(
+        name="hal0",
+        kind="slot",
+        url="http://127.0.0.1:8080/v1",
+        slot_name=None,
+        auth_style="none",
+        warmup_strategy="none",
+        advertise_models=True,
+    )
+
+
+def _make_request(path: str = "/v1/chat/completions") -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [(b"content-type", b"application/json")],
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 12345),
+        "http_version": "1.1",
+        "root_path": "",
+    }
+    return Request(scope)
+
+
+# ── helper-level contracts ────────────────────────────────────────────────────
+
+
+def test_is_hal0_composite_only_matches_the_synthetic_entry() -> None:
+    assert _is_hal0_composite(_composite()) is True
+    # A real per-slot upstream carries a slot_name.
+    assert (
+        _is_hal0_composite(
+            Upstream(name="primary", kind="slot", url="http://x/v1", slot_name="primary")
+        )
+        is False
+    )
+    # A remote provider named "hal0" (operator override) is not the composite.
+    assert _is_hal0_composite(Upstream(name="hal0", kind="remote", url="https://x/v1")) is False
+
+
+def test_slot_name_of_exempts_composite_from_readiness_gate() -> None:
+    """The composite yields an EMPTY slot_name so ``forward()`` skips the
+    readiness gate + SERVING wrap (regression: it used to fall back to the
+    name ``"hal0"`` and 503 against a non-existent slot)."""
+    assert _slot_name_of(_composite()) == ""
+    # Real slot still carries its name through.
+    real = Upstream(name="primary", kind="slot", url="http://x/v1", slot_name="primary")
+    assert _slot_name_of(real) == "primary"
+
+
+def test_composite_forward_target_is_lemonade_gateway_not_self() -> None:
+    """The composite must NOT forward to its own ``:8080`` URL (infinite
+    recursion); it is redirected to the Lemonade gateway."""
+    url = _resolve_target_url(_composite(), "/v1/chat/completions")
+    assert url == "http://127.0.0.1:13305/v1/chat/completions"
+    assert ":8080" not in url
+    # Non-composite upstreams forward to their own url unchanged.
+    real = Upstream(
+        name="primary", kind="slot", url="http://127.0.0.1:8081/v1", slot_name="primary"
+    )
+    assert _resolve_target_url(real, "/v1/chat/completions") == (
+        "http://127.0.0.1:8081/v1/chat/completions"
+    )
+
+
+def test_composite_forward_target_honours_env_override(monkeypatch: Any) -> None:
+    monkeypatch.setenv("LEMONADE_BASE_URL", "http://10.0.0.5:9999")
+    url = _resolve_target_url(_composite(), "/v1/chat/completions")
+    assert url == "http://10.0.0.5:9999/v1/chat/completions"
+
+
+# ── dispatch path ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_advertised_model_resolves_via_passthrough_not_legacy() -> None:
+    """A chat request for a composite-advertised model resolves through the
+    passthrough path (Step 2) — never the legacy fallthrough that demotes the
+    dispatcher to a raw Lemonade proxy."""
+    upstreams = _FakeUpstreamRegistry([_composite()])
+    models = _FakeModelRegistry(routes={})
+    cache = {"hal0": ["hermes-4-14b-q5km", "qwen3-coder-next-reap-40b-a3b-q4kxl"]}
+
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        cached_models=lambda name: cache.get(name, []),
+    )
+
+    call = await dispatcher.dispatch(
+        _make_request(),
+        body={"model": "hermes-4-14b-q5km", "messages": []},
+    )
+
+    assert isinstance(call, UpstreamCall)
+    assert call.upstream_name == "hal0"
+    assert call.resolution_path == "passthrough:hal0"
+    # Readiness-gate exemption: empty slot_name.
+    assert call.slot_name == ""
+    # Forwarded to the Lemonade gateway, not back into hal0-api.
+    assert call.target_url == "http://127.0.0.1:13305/v1/chat/completions"
+
+
+@pytest.mark.asyncio
+async def test_composite_call_skips_readiness_gate_on_forward() -> None:
+    """End-to-end: a composite-resolved call forwards a 200 even though the
+    SlotManager reports every slot OFFLINE — the gate must not fire, and the
+    SERVING context must never open."""
+    upstreams = _FakeUpstreamRegistry([_composite()])
+    cache = {"hal0": ["hermes-4-14b-q5km"]}
+    slot_mgr = _OfflineSlotManager()
+
+    seen: dict[str, str] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["url"] = str(req.url)
+        return httpx.Response(200, json={"id": "chatcmpl-ok", "choices": []})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=_FakeModelRegistry(),
+        cached_models=lambda name: cache.get(name, []),
+        slot_manager=slot_mgr,  # type: ignore[arg-type]
+        http_client=client,
+    )
+    try:
+        call = await dispatcher.dispatch(
+            _make_request(),
+            body={"model": "hermes-4-14b-q5km", "messages": []},
+        )
+        resp = await dispatcher.forward(call)
+        # No spurious 503 from the readiness gate.
+        assert resp.status_code == 200
+        # Forwarded to the gateway, not hal0-api itself.
+        assert seen["url"] == "http://127.0.0.1:13305/v1/chat/completions"
+        # SERVING context never opened (the stub raises if it is).
+        assert slot_mgr.serving_calls == []
+    finally:
+        await dispatcher.aclose()


### PR DESCRIPTION
## Summary

Fixes #422 — the composite `hal0` upstream's `/v1/models` was empty and the dispatcher's registry/passthrough/prompt-cache/instrumentation layer was dead code for chat (every request fell through to the raw Lemonade proxy). This PR makes the composite route correctly through the dispatcher with a **200**, not a 503.

There were two distinct problems behind the issue. Investigation found that **#1 (empty cache) is already fixed on `main`** — the empty live cache is a stale-process artifact, not a code bug. **#2 (readiness-gate masquerade) is real and is what this PR fixes.**

## Root cause

### #1 — empty cache (NOT a code bug on current main)
`_fetch_hal0_composite_models` (`src/hal0/api/__init__.py`) aggregates chat slots correctly. Booting the real lifespan in a `TestClient` against the live `/var/lib/hal0` slot TOMLs yields a populated catalog:

```
GET /v1/models -> 200, 3 models (hermes-4-14b-q5km, qwen3-coder-next-reap-40b-a3b-q4kxl, qwen3-zero-coder-v2-0.8b-f16)
/api/upstreams -> hal0, slot_name=None, models=[...3...]
```

The live `:8080` returning `0` models + `slot_name=""` (vs the on-disk `slot_name=None`) proves the **running process predates the reverted `slot_name None->""` edit**. An API restart clears it. No code change needed for #1.

### #2 — readiness-gate masquerade (fixed here)
`_slot_name_of(upstream)` returned `upstream.slot_name or upstream.name`, yielding `"hal0"` for the composite. So once the cache populated, Step 2 passthrough resolved a chat request to the composite and `forward()` ran `_check_slot_ready_for_dispatch` -> `SlotManager._current_state("hal0")` -> no such slot -> `OFFLINE` -> `SlotLoading` (503). Additionally, the composite's registered URL is hal0-api's own `:8080/v1`, so plain-forwarding it would re-enter `/v1/chat/completions` and loop forever.

## Changes (`src/hal0/dispatcher/router.py`)

- `_is_hal0_composite(upstream)` — predicate for the synthetic composite (`kind=slot`, `slot_name is None`, `name=="hal0"`).
- `_slot_name_of` returns `""` for the composite -> `forward()` skips the readiness gate **and** the SERVING wrap. Slot lifecycle is still enforced on the Lemonade gateway hop.
- `_resolve_target_url(upstream, path)` — composite forwards target the Lemonade gateway (`127.0.0.1:13305`, `LEMONADE_BASE_URL`-overridable, matching `lemonade_proxy`), breaking the `:8080` recursion. All other upstreams forward to their own `url` unchanged.

Real per-slot upstreams (carrying a `slot_name`) and remote providers are untouched.

## Tests

New `tests/dispatcher/test_composite_dispatch.py` (6 tests):
- `_is_hal0_composite` only matches the synthetic entry (not real slots / remote overrides).
- composite is readiness-gate-exempt (`_slot_name_of` -> `""`); real slot keeps its name.
- composite forward targets the gateway, not `:8080`; env override honoured.
- a composite-advertised model resolves via **passthrough** (not legacy fallthrough).
- end-to-end: composite call forwards **200** even when the SlotManager reports every slot OFFLINE, and never opens the SERVING context.

Verification:
- `ruff check` + `ruff format --check` clean on both changed files.
- `130 passed` across `tests/dispatcher/`, `tests/api/test_upstream_dedup.py`, `tests/api/test_slots_routes.py` — no regressions.

## Risks — human review before merge

1. **Live restart required for the full fix.** This branch fixes the 503 path; the *populated cache* only appears after `systemctl restart hal0-api` (the running process is stale). I did **not** restart the live service.
2. **Gateway-redirect behaviour change.** Today, chat works only via the `NoRouteFound` -> raw Lemonade proxy fallback (same `127.0.0.1:13305` target, same verbatim `model`). After this PR a populated cache routes composite chat **through the dispatcher** to the same gateway. Behaviourally equivalent backend target, but now with prompt-cache/instrumentation in the loop — worth a live smoke (chat + streaming) on the LXC.
3. **Model-id == Lemonade-name assumption.** The composite advertises each slot's `model.default`, which equals the lemond model name (no remap), matching the existing proxy fallback. If any slot's `model.default` ever diverged from the lemond-loadable name, that model would 4xx at the gateway — same as the current fallback would.
4. **No idle-eviction recovery on the composite path.** Because `slot_name` is empty, `_recover_evicted_slot` (ConnectError retry) does not fire for composite forwards. This matches the raw-proxy fallback (which also has no recovery), so it is not a regression, but it is a known gap if Lemonade silently evicts mid-request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
