### PR TITLE
fix(lemonade): connect log stream to advertised websocket_port (#421)

### DIFF
--- a/src/hal0/api/routes/lemonade_logs.py
+++ b/src/hal0/api/routes/lemonade_logs.py
@@ -70,8 +70,11 @@ def _iter_entries(frame: dict[str, Any]) -> list[dict[str, Any]]:
     ``logs.snapshot`` carries a list under ``entries``; ``logs.entry``
     carries a single dict under ``entry``. Returns the entries verbatim
     so callers preserve any provider-specific metadata (level, ts).
+
+    lemond keys these frames on ``type``; we read ``type`` first and fall
+    back to ``op`` so a protocol shift doesn't silently drop entries.
     """
-    op = frame.get("op")
+    op = frame.get("type") or frame.get("op")
     if op == "logs.snapshot":
         entries = frame.get("entries")
         if isinstance(entries, list):

--- a/src/hal0/journal/__init__.py
+++ b/src/hal0/journal/__init__.py
@@ -96,8 +96,11 @@ class LemondLogRing:
         dict so callers (and tests) can inspect the assigned id.
         """
         message = _pick_message(entry)
-        level = _normalise_level(entry.get("level"))
-        ts_raw = entry.get("ts")
+        # lemond log entries carry the level under ``severity`` (Info /
+        # Warning / Error / Fatal / …); older/synthetic frames may use
+        # ``level``. Prefer ``severity`` and fall back to ``level``.
+        level = _normalise_level(entry.get("severity") or entry.get("level"))
+        ts_raw = entry.get("ts") or entry.get("timestamp")
         ts = ts_raw if isinstance(ts_raw, str) and ts_raw else now_iso()
         stored = {
             "id": next(self._next_id),
@@ -215,8 +218,12 @@ async def _flatten_frame(frame: dict[str, Any]) -> list[dict[str, Any]]:
     Inline duplicate of :func:`hal0.api.routes.lemonade_logs._iter_entries`
     so this module stays import-free of the route layer. Tolerates the
     same ``logs.snapshot`` / ``logs.entry`` / unknown-op shapes.
+
+    lemond keys frames on ``type`` (``logs.snapshot`` / ``logs.entry``);
+    we read ``type`` first and fall back to ``op`` for resilience to a
+    protocol shift.
     """
-    op = frame.get("op")
+    op = frame.get("type") or frame.get("op")
     if op == "logs.snapshot":
         entries = frame.get("entries")
         if isinstance(entries, list):
@@ -230,34 +237,53 @@ async def _flatten_frame(frame: dict[str, Any]) -> list[dict[str, Any]]:
     return [frame]
 
 
-async def _consume_once(ring: LemondLogRing) -> None:
+async def _consume_once(ring: LemondLogRing) -> bool:
     """One pass through lemond's log stream. Returns when the stream ends.
 
     Imports the provider lazily so unit tests can monkeypatch it on the
     way in without dragging the full provider singleton into scope.
+
+    Returns ``True`` if at least one entry was appended (a genuinely live
+    connection), ``False`` if the stream yielded nothing — e.g. lemond is
+    down or the log-stream WebSocket isn't available. The caller uses this
+    to decide whether to reset the reconnect backoff: an empty pass should
+    keep backing off rather than retry at the floor cadence (issue #421).
     """
     from hal0.providers import lemonade_provider
 
     client = lemonade_provider().client()
+    produced = False
     async for frame in client.stream_logs():
         for entry in await _flatten_frame(frame):
             ring.append(entry)
+            produced = True
+    return produced
 
 
 async def _bridge_loop(ring: LemondLogRing) -> None:
     """Long-running task that keeps the lemond log ring fed.
 
-    Reconnects with exponential backoff (1s → 30s) on any failure so the
-    journal panel keeps working across lemond restarts. Cancellation
-    (FastAPI shutdown) propagates cleanly via :class:`asyncio.CancelledError`.
+    Reconnects with exponential backoff (1s → 30s) so the journal panel
+    keeps working across lemond restarts. Cancellation (FastAPI shutdown)
+    propagates cleanly via :class:`asyncio.CancelledError`.
+
+    The backoff is only reset to the floor after a pass that produced at
+    least one entry (a real, working stream). A pass that returns
+    immediately with nothing — lemond down, or no log-stream WS port
+    advertised — keeps backing off. Without this guard, an instantly
+    empty stream paired with a floor reset would reconnect at ~1 Hz,
+    which is exactly what spammed lemond with ``Error 404: GET
+    /logs/stream`` (issue #421).
     """
     backoff = _RECONNECT_INITIAL_S
     while True:
         try:
-            await _consume_once(ring)
-            # Stream returned cleanly — reset backoff so the next reconnect
-            # is fast (typically lemond restart, not a permanent outage).
-            backoff = _RECONNECT_INITIAL_S
+            produced = await _consume_once(ring)
+            # A working stream that ended (typically a lemond restart) resets
+            # backoff to the floor for a fast reconnect. An empty pass (lemond
+            # down / no WS log stream) keeps backing off so we don't hammer a
+            # dead path at ~1 Hz (issue #421).
+            backoff = _RECONNECT_INITIAL_S if produced else min(backoff * 2, _RECONNECT_MAX_S)
         except asyncio.CancelledError:
             raise
         except Exception as exc:  # pragma: no cover — defensive
@@ -267,14 +293,14 @@ async def _bridge_loop(ring: LemondLogRing) -> None:
                 error_type=type(exc).__name__,
                 backoff_s=backoff,
             )
-        # Sleep before reconnecting. A clean stream return still backs off
-        # by the initial 1s — without it, a lemond that immediately closes
-        # the WS would spin the event loop.
+            backoff = min(backoff * 2, _RECONNECT_MAX_S)
+        # Sleep before reconnecting. Even a successful pass backs off by
+        # the initial 1s so a lemond that immediately closes the WS can't
+        # spin the event loop.
         try:
             await asyncio.sleep(backoff)
         except asyncio.CancelledError:
             raise
-        backoff = min(backoff * 2, _RECONNECT_MAX_S)
 
 
 def start_lemond_bridge(ring: LemondLogRing) -> asyncio.Task[None]:

--- a/src/hal0/lemonade/client.py
+++ b/src/hal0/lemonade/client.py
@@ -35,10 +35,12 @@ import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
 
 from hal0.lemonade.errors import (
+    LemonadeError,
     LemonadeHTTPError,
     LemonadeLoadError,
     LemonadeTimeoutError,
@@ -326,11 +328,22 @@ class LemonadeClient:
 
         Lemonade exposes server logs as a WebSocket frame stream (per the
         ``hal0_lemonade_ws_protocol`` reference): the client subscribes
-        once with ``{"op": "logs.subscribe"}``, then receives
-        ``logs.snapshot`` (the in-memory ring buffer) followed by
+        once with ``{"type": "logs.subscribe", "after_seq": null}``, then
+        receives ``logs.snapshot`` (the in-memory ring buffer) followed by
         ``logs.entry`` frames for each new line. This method yields the
         parsed JSON message dicts as they arrive; the caller decides
         how to filter / fan out.
+
+        The WebSocket server does NOT live on the OpenAI gateway port
+        (``self._base_url``, 13305 on hal0). lemond binds it on a
+        separate, OS-assigned port reported by ``GET /v1/health`` as
+        ``websocket_port``. Connecting to the gateway port returns 404
+        for every upgrade attempt — which, paired with the journal
+        bridge's reconnect loop, produced the ~1 Hz ``Error 404: GET
+        /logs/stream`` storm (issue #421). We resolve the real WS port
+        from ``/v1/health`` before connecting; if the field is absent
+        (no WS server running) we yield nothing rather than hammering a
+        dead path.
 
         Used by ``/api/lemonade/logs/stream`` (PR-11) which fans the
         stream out to the dashboard and looks for the nuclear-evict
@@ -357,8 +370,13 @@ class LemonadeClient:
 
         import json as _json
 
-        ws_url = self._base_url.replace("http://", "ws://").replace("https://", "wss://")
-        ws_url = f"{ws_url}/logs/stream"
+        ws_url = await self._resolve_logs_ws_url()
+        if ws_url is None:
+            # No websocket_port advertised (WS server not running, or
+            # lemond unreachable) — don't connect; a failed handshake
+            # would otherwise spam lemond's log with 404s at the
+            # caller's reconnect cadence (issue #421).
+            return
         headers: dict[str, str] = {}
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"
@@ -379,7 +397,7 @@ class LemonadeClient:
             return
 
         try:
-            await ws.send(_json.dumps({"op": "logs.subscribe"}))
+            await ws.send(_json.dumps({"type": "logs.subscribe", "after_seq": None}))
             async for raw in ws:
                 if isinstance(raw, bytes):
                     raw = raw.decode("utf-8", errors="replace")
@@ -394,6 +412,32 @@ class LemonadeClient:
         finally:
             with contextlib.suppress(OSError, ConnectionClosed):
                 await ws.close()
+
+    async def _resolve_logs_ws_url(self) -> str | None:
+        """Build the ``ws://…/logs/stream`` URL using lemond's real WS port.
+
+        lemond serves the log-stream WebSocket on a port distinct from the
+        OpenAI gateway port (``self._base_url``). It advertises that port
+        via ``GET /v1/health`` → ``websocket_port`` (only present when the
+        WS server is running). We reuse the gateway host but swap in the
+        advertised port. Returns ``None`` when health is unreachable or
+        ``websocket_port`` is missing/invalid, signalling the caller to
+        skip the connection entirely (see issue #421).
+        """
+        try:
+            health = await self.health()
+        except LemonadeError:
+            return None
+        ws_port = health.get("websocket_port") if isinstance(health, dict) else None
+        if not isinstance(ws_port, int) or ws_port <= 0:
+            return None
+
+        base = self._base_url.replace("http://", "ws://").replace("https://", "wss://")
+        parsed = urlsplit(base)
+        host = parsed.hostname or "127.0.0.1"
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        return f"{parsed.scheme}://{host}:{ws_port}/logs/stream"
 
     # ── internal: HTTP request envelope ────────────────────────────
 

--- a/tests/api/test_lemonade_logs_routes.py
+++ b/tests/api/test_lemonade_logs_routes.py
@@ -107,16 +107,33 @@ def test_iter_entries_drops_missing_payloads() -> None:
 # ── route integration ──────────────────────────────────────────────────────
 
 
-def test_routes_mounted_under_api_lemonade_prefix() -> None:
+def test_routes_mounted_under_api_lemonade_prefix(monkeypatch) -> None:
     """The router is wired under /api/lemonade so the dashboard URLs match.
 
     Smoke test rather than functional — full SSE timing is covered by
     the gamma-suite Playwright spec which can drive the stream against
     mocked EventSource.
+
+    ``stream_logs`` is stubbed to an empty async iterator so the SSE
+    body terminates immediately. Without the stub this test makes a real
+    network call: when a lemond daemon is actually reachable (e.g. on the
+    hal0 LXC) the WS log stream is now genuinely connectable and the
+    response would never finish (issue #421 fix), hanging the test. The
+    stub keeps the assertion purely about route registration.
     """
+    from collections.abc import AsyncIterator
+    from typing import Any
+
     from fastapi.testclient import TestClient
 
     from hal0.api import create_app
+    from hal0.lemonade.client import LemonadeClient
+
+    async def _no_logs(self: LemonadeClient) -> AsyncIterator[dict[str, Any]]:
+        return
+        yield  # pragma: no cover — makes this an async generator
+
+    monkeypatch.setattr(LemonadeClient, "stream_logs", _no_logs)
 
     app = create_app()
     with TestClient(app) as client:

--- a/tests/journal/test_bridge.py
+++ b/tests/journal/test_bridge.py
@@ -1,0 +1,149 @@
+"""Unit tests for the lemond → ring journal bridge (issue #421).
+
+Covers the two failure-mode-relevant behaviours that produced (and now
+prevent) the ``Error 404: GET /logs/stream`` 1 Hz log storm:
+
+  * frame flattening keys on lemond's ``type`` field (``logs.snapshot`` /
+    ``logs.entry``), not the legacy ``op`` field;
+  * :func:`hal0.journal._bridge_loop` only resets its reconnect backoff
+    after a pass that produced at least one entry — an empty pass (lemond
+    down / no WS log stream) keeps backing off rather than reconnecting at
+    the 1 s floor.
+
+Also pins :meth:`LemondLogRing.append` to lemond's real entry shape
+(``severity`` / ``timestamp`` / ``line``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from hal0 import journal
+from hal0.journal import LemondLogRing
+
+# ── frame flattening ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_flatten_frame_reads_type_snapshot() -> None:
+    frame = {
+        "type": "logs.snapshot",
+        "entries": [{"line": "a", "seq": 1}, {"line": "b", "seq": 2}],
+    }
+    out = await journal._flatten_frame(frame)
+    assert [e["line"] for e in out] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_flatten_frame_reads_type_entry() -> None:
+    frame = {"type": "logs.entry", "entry": {"line": "c", "seq": 3}}
+    out = await journal._flatten_frame(frame)
+    assert out == [{"line": "c", "seq": 3}]
+
+
+@pytest.mark.asyncio
+async def test_flatten_frame_falls_back_to_op_key() -> None:
+    # Legacy/synthetic frames keyed on ``op`` still parse.
+    frame = {"op": "logs.entry", "entry": {"line": "d"}}
+    out = await journal._flatten_frame(frame)
+    assert out == [{"line": "d"}]
+
+
+# ── entry normalisation ───────────────────────────────────────────────
+
+
+def test_append_reads_severity_and_timestamp_and_line() -> None:
+    ring = LemondLogRing()
+    stored = ring.append(
+        {
+            "line": "2026-06-02 [Error] (Server) boom",
+            "severity": "Error",
+            "timestamp": "2026-06-02 00:31:44.980",
+            "seq": 7,
+        }
+    )
+    assert stored["message"] == "2026-06-02 [Error] (Server) boom"
+    assert stored["level"] == "error"
+    assert stored["ts"] == "2026-06-02 00:31:44.980"
+
+
+def test_append_maps_warning_severity_to_warn() -> None:
+    ring = LemondLogRing()
+    stored = ring.append({"line": "x", "severity": "Warning"})
+    assert stored["level"] == "warn"
+
+
+# ── reconnect backoff guard ───────────────────────────────────────────
+
+
+class _FakeRing:
+    """Records appends; lets a test assert whether a pass produced entries."""
+
+    def __init__(self) -> None:
+        self.appended: list[Any] = []
+
+    def append(self, entry: Any) -> None:
+        self.appended.append(entry)
+
+
+@pytest.mark.asyncio
+async def test_bridge_loop_backs_off_on_empty_passes(monkeypatch) -> None:
+    """An immediately-empty stream (lemond down / no WS port) must NOT
+    reset backoff to the 1 s floor — otherwise the loop reconnects at
+    ~1 Hz and spams lemond with 404s (issue #421)."""
+    sleeps: list[float] = []
+    # Always-empty consume: stand in for stream_logs() returning nothing.
+    monkeypatch.setattr(journal, "_consume_once", _consume_empty)
+
+    async def _fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+        # Stop after a handful of iterations.
+        if len(sleeps) >= 4:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(journal.asyncio, "sleep", _fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await journal._bridge_loop(LemondLogRing())
+
+    # 1 → 2 → 4 → 8: strictly increasing, never pinned at the floor.
+    assert sleeps == [2.0, 4.0, 8.0, 16.0]
+
+
+@pytest.mark.asyncio
+async def test_bridge_loop_resets_backoff_after_productive_pass(monkeypatch) -> None:
+    """A pass that produced entries resets backoff to the floor so a
+    genuine lemond restart reconnects fast."""
+    sleeps: list[float] = []
+    calls = {"n": 0}
+
+    async def _consume(ring: LemondLogRing) -> bool:
+        calls["n"] += 1
+        # First pass: empty (back off). Second pass: productive (reset).
+        # Third pass: empty again — should restart from the floor*2.
+        if calls["n"] == 2:
+            ring.append({"line": "live", "severity": "Info"})
+            return True
+        return False
+
+    monkeypatch.setattr(journal, "_consume_once", _consume)
+
+    async def _fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+        if len(sleeps) >= 3:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(journal.asyncio, "sleep", _fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await journal._bridge_loop(LemondLogRing())
+
+    # pass1 empty -> 2.0 ; pass2 productive -> reset to 1.0 ; pass3 empty -> 2.0
+    assert sleeps == [2.0, 1.0, 2.0]
+
+
+async def _consume_empty(ring: LemondLogRing) -> bool:
+    return False

--- a/tests/lemonade/test_client.py
+++ b/tests/lemonade/test_client.py
@@ -36,6 +36,13 @@ def _mock_transport(handler):
     return httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://test")
 
 
+def _mock_transport_base(handler, base_url: str):
+    """Like :func:`_mock_transport` but pins an explicit ``base_url`` so
+    relative paths resolve against the same host the client was built
+    with (needed by the ``stream_logs`` WS-port-discovery tests)."""
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url=base_url)
+
+
 # ── /live ────────────────────────────────────────────────────────────
 
 
@@ -530,3 +537,137 @@ async def test_internal_endpoints_raise_lemonade_http_error_on_non_2xx() -> None
             with pytest.raises(LemonadeHTTPError) as exc:
                 await coro
             assert exc.value.status_code == 403
+
+
+# ── /logs/stream WebSocket (issue #421) ──────────────────────────────
+
+
+class _FakeWS:
+    """Minimal async websocket double for ``stream_logs`` tests.
+
+    Records messages sent via :meth:`send` and yields the scripted
+    ``frames`` when iterated, then stops (mimicking a closed stream).
+    """
+
+    def __init__(self, frames: list[str]) -> None:
+        self._frames = frames
+        self.sent: list[str] = []
+        self.closed = False
+
+    async def send(self, msg: str) -> None:
+        self.sent.append(msg)
+
+    def __aiter__(self) -> _FakeWS:
+        self._it = iter(self._frames)
+        return self
+
+    async def __anext__(self) -> str:
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _install_fake_websockets(monkeypatch, *, ws, record: dict) -> None:
+    """Inject a fake ``websockets`` module so the lazy import inside
+    ``stream_logs`` resolves to our double. ``record["url"]`` captures the
+    URL ``connect`` was called with; ``ws=None`` makes connect raise so we
+    can exercise the handshake-failure path."""
+    import sys
+    import types
+
+    fake = types.ModuleType("websockets")
+    exc_mod = types.ModuleType("websockets.exceptions")
+
+    class _ConnectionClosed(Exception):
+        pass
+
+    class _InvalidHandshake(Exception):
+        pass
+
+    exc_mod.ConnectionClosed = _ConnectionClosed
+    exc_mod.InvalidHandshake = _InvalidHandshake
+
+    async def _connect(url, **kwargs):
+        record["url"] = url
+        record["kwargs"] = kwargs
+        if ws is None:
+            raise _InvalidHandshake("404")
+        return ws
+
+    fake.connect = _connect
+    fake.exceptions = exc_mod
+    monkeypatch.setitem(sys.modules, "websockets", fake)
+    monkeypatch.setitem(sys.modules, "websockets.exceptions", exc_mod)
+
+
+@pytest.mark.asyncio
+async def test_stream_logs_connects_to_advertised_websocket_port(monkeypatch) -> None:
+    """The WS log stream lives on the port reported by ``/v1/health`` as
+    ``websocket_port`` (9000 on hal0), NOT the OpenAI gateway base port
+    (13305). Connecting to the gateway port 404s once per reconnect and
+    spammed lemond at ~1 Hz (issue #421)."""
+    import json as _json
+
+    frames = [
+        _json.dumps({"type": "logs.snapshot", "entries": [{"line": "boot", "seq": 1}]}),
+        _json.dumps({"type": "logs.entry", "entry": {"line": "loaded", "seq": 2}}),
+    ]
+    ws = _FakeWS(frames)
+    record: dict = {}
+    _install_fake_websockets(monkeypatch, ws=ws, record=record)
+
+    def h(req: httpx.Request) -> httpx.Response:
+        assert req.url.path == "/v1/health"
+        return httpx.Response(200, json={"status": "ok", "websocket_port": 9000})
+
+    async with _mock_transport_base(h, "http://127.0.0.1:13305") as transport:
+        client = LemonadeClient(base_url="http://127.0.0.1:13305", http_client=transport)
+        out = [frame async for frame in client.stream_logs()]
+
+    # Connected to the advertised WS port, not the 13305 gateway port.
+    assert record["url"] == "ws://127.0.0.1:9000/logs/stream"
+    # Subscribed with the documented frame shape (type, not op).
+    assert _json.loads(ws.sent[0]) == {"type": "logs.subscribe", "after_seq": None}
+    assert ws.closed is True
+    assert [f.get("type") for f in out] == ["logs.snapshot", "logs.entry"]
+
+
+@pytest.mark.asyncio
+async def test_stream_logs_yields_nothing_when_websocket_port_absent(monkeypatch) -> None:
+    """When ``/v1/health`` omits ``websocket_port`` (no WS server running)
+    the client must NOT attempt a connection — a 404 handshake at the
+    bridge's reconnect cadence is exactly the spam #421 fixes."""
+    record: dict = {}
+    _install_fake_websockets(monkeypatch, ws=_FakeWS([]), record=record)
+
+    def h(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"status": "ok"})  # no websocket_port
+
+    async with _mock_transport_base(h, "http://127.0.0.1:13305") as transport:
+        client = LemonadeClient(base_url="http://127.0.0.1:13305", http_client=transport)
+        out = [frame async for frame in client.stream_logs()]
+
+    assert out == []
+    assert "url" not in record  # connect() never called
+
+
+@pytest.mark.asyncio
+async def test_stream_logs_yields_nothing_when_health_unreachable(monkeypatch) -> None:
+    """If health itself fails (lemond down), resolving the WS port returns
+    None and the stream yields nothing instead of raising."""
+    record: dict = {}
+    _install_fake_websockets(monkeypatch, ws=_FakeWS([]), record=record)
+
+    def h(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    async with _mock_transport_base(h, "http://127.0.0.1:13305") as transport:
+        client = LemonadeClient(base_url="http://127.0.0.1:13305", http_client=transport)
+        out = [frame async for frame in client.stream_logs()]
+
+    assert out == []
+    assert "url" not in record


### PR DESCRIPTION
## Summary

Fixes the continuous ~1 Hz `[Error] (Server) Error 404: GET /logs/stream` storm in lemond's journal (issue #421).

## Root cause

lemond serves the `/logs/stream` WebSocket on a **separate, OS-assigned port** that it advertises via `GET /v1/health` → `websocket_port` (9000 on hal0), **not** the OpenAI gateway port the `LemonadeClient` is constructed with (13305). `LemonadeClient.stream_logs()` built its `ws://` URL from the gateway `base_url`, so every connection attempt hit `ws://127.0.0.1:13305/logs/stream` — which 404s for any upgrade attempt (verified live: 13305 returns 404 even with a proper `Upgrade: websocket` handshake; 9000 returns `101 Switching Protocols`).

Two things turned a single bad connect into a 1 Hz storm:
1. `stream_logs()` swallows a failed WS handshake and `return`s — indistinguishable from a clean stream end.
2. `journal._bridge_loop` reset its reconnect backoff to the 1 s floor on every clean return, so it reconnected once per second forever.

A live probe also showed the subscribe message was wrong: the client sent `{"op": "logs.subscribe"}`, but lemond keys on `type` and replied with an `error` frame and **no** snapshot/entries — so even on the right port the journal bridge would have received nothing.

## Changes

- **`LemonadeClient.stream_logs`** resolves the real WS port from `/v1/health` (`_resolve_logs_ws_url`) before connecting. If `websocket_port` is missing or health is unreachable, it yields nothing instead of hammering a dead path.
- Subscribe frame corrected to the documented `{"type": "logs.subscribe", "after_seq": null}`.
- **Frame parsing** in `journal._flatten_frame` and `lemonade_logs._iter_entries` now reads the `type` key (`logs.snapshot` / `logs.entry`) with an `op` fallback; `LemondLogRing.append` reads lemond's `severity` / `timestamp` / `line` keys.
- **`_bridge_loop`** only resets backoff after a pass that produced ≥1 entry; an empty pass keeps backing off (1→2→4…→30 s), so a missing WS stream can never re-create the 1 Hz storm.

## Tests

- `tests/lemonade/test_client.py`: WS-port discovery (connects to advertised port, not 13305), correct subscribe shape, and graceful no-port / health-down paths (no connection attempted).
- `tests/journal/test_bridge.py` (new): backoff guard (empty passes keep backing off; productive pass resets to floor), `type`-keyed frame flattening, and `severity`/`timestamp` normalisation.
- The pre-existing route-mount smoke test now stubs `stream_logs` so it terminates when a real lemond is reachable (the fix makes the stream genuinely connectable).

All ruff checks (`check` + `format --check`) clean on changed files; 57 affected tests pass. Live-verified against running lemond: `stream_logs` resolves `ws://127.0.0.1:9000/logs/stream` and receives `logs.snapshot` + live entries.

> Note: the running hal0-api service was **not** restarted, so the 404 spam continues until this lands and the service is redeployed.

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)
