### PR TITLE
docs: brain-redesign planning dossiers (pre-grilling)

### DIFF
--- a/docs/internal/brain-redesign/00-INDEX.md
+++ b/docs/internal/brain-redesign/00-INDEX.md
@@ -1,0 +1,241 @@
+# 00 — Brain Redesign: Index & Executive Summary
+
+**Status:** PLANNING — pre-grilling, not yet decided, not yet implemented.
+**Date:** 2026-06-02.
+**Authors:** a multi-agent research wave (one dossier per agent), synthesized in doc 06.
+
+> This is the **front door** to the brain-redesign dossiers. Read it after a
+> reboot to reload the whole context, then dive into the numbered docs as needed.
+
+---
+
+## TL;DR — what this redesign is
+
+hal0's "brain" is being redesigned as **two durable tiers behind one unchanged
+access plane**:
+
+- **The Engine (Tier E)** — a machine-owned, fast, structured semantic/episodic
+  store. The recommendation is to **replace Cognee with Hindsight** (vectorize.io's
+  biomimetic agent-memory engine: `retain`/`recall`/`reflect` + automatic
+  consolidation of raw facts into evidence-grounded, freshness-tracked
+  *observations*). It captures every turn/fact cheaply, recalls with multi-strategy
+  token-budgeted retrieval, and fixes the staleness gap Cognee-as-used has today.
+- **The Wiki (Tier C)** — a human-legible, curated, cross-linked **compiled-knowledge
+  layer**: the `hal0-wiki` fork of `obsidian-wiki` (Karpathy's "LLM Wiki" pattern over
+  an Obsidian-flavored markdown vault). It holds the knowledge a person reads, edits,
+  audits, and trusts. "Compile, don't retrieve."
+
+The Engine is the hippocampus; the Wiki is the published notebook. They relate
+through a **strictly one-way, gated promotion pipeline** (Engine observation →
+gated promotion → Wiki page → re-embedded back into the Engine as a top-of-hierarchy
+index entry), so there is exactly **one canonical owner per fact-class** and the two
+stores cannot silently disagree. Every consumer — Hermes, external Claude Code,
+pi-coder, OpenWebUI, the dashboard — reaches both tiers through the *unchanged*
+`/mcp/memory` + `/api/memory/*` contract with the `X-hal0-Agent` namespace rule, so
+the brain is felt as **deeper**, not as a new service bolted on. The whole thing runs
+**fully self-hosted on Strix Halo** (CT 105) with no cloud dependency.
+
+---
+
+## Why now — the motivating findings
+
+The audit (doc 03) and landscape brief (doc 05) make the case:
+
+1. **Cognee's graph is dead weight.** hal0 runs a 3-database knowledge-graph engine
+   (SQLite + LanceDB + Kuzu) but graph extraction is **default-OFF**, `cognify` runs
+   only as a fire-and-forget background task whose output is **never read**, and
+   `search` is always pure-vector (`SearchType.CHUNKS`). We pay Cognee's complexity
+   and get RAG.
+2. **The graph is off because it can't run locally.** `.cognify()` needs an LLM to
+   reliably emit structured JSON; sub-32B local models on Strix Halo can't (noisy
+   graphs, 10-min tenacity hangs — independently confirmed in the field). The graph
+   hal0 disabled is the graph hal0 *cannot reliably run locally*.
+3. **pgvector + sidecar reality.** A hand-rolled **SQLite sidecar** is the real
+   source of truth for dataset/tags/source/metadata/timestamp and for *all*
+   filtering, joined to Cognee chunks by **fragile text equality**. In practice hal0
+   is doing the job of `pgvector + a WHERE clause` with three databases behind it.
+4. **Staleness handling gap.** Append-only vector memory accumulates contradictions
+   ("user prefers React" + "user switched to Vue") and surfaces both. hal0 today runs
+   **neither** consolidation (Hindsight observations / Cognee Memify) **nor** an
+   active lint pass. This is where naive vector memory dies.
+5. **Bolt-on risk.** The redesign's explicit non-goal is a second front door. It must
+   attach at seams that already exist (the engine seam, Hermes `prefetch`/`sync_turn`,
+   the embed/rerank slots, `/mcp/memory`, the dashboard Memory tab).
+6. **Issue #317 is NOT a driver.** The known namespace-forcing bug
+   (`/api/memory/add` forcing `dataset="shared"`) is **already FIXED** (PRs #366/#369,
+   shared `hal0.memory.namespace` module). Treat it as closed; the auto-memory entry
+   `hal0_memory_dataset_namespace_bug` is stale and should be marked resolved.
+
+---
+
+## Reading guide
+
+| # | Title | Read this for… | ~Length |
+|---|---|---|---|
+| **00** | Index & Executive Summary | The front door — TL;DR, why-now, the recommendation in one page, open questions, glossary. (this file) | short |
+| **01** | Hindsight Feature Inventory | Exhaustive, accurate feature map of the candidate engine: retain/recall/reflect, observations, memory banks, **bank templates**, documents, ops/admin CLI, webhooks, TEMPR retrieval, fully-local deployment, MCP/Hermes/Claude-Code integrations, hal0 relevance, and a Gaps list (Strix-Halo accel undocumented, webhook registration, etc.). | ~760 lines |
+| **02** | hal0-wiki Research | What the `obsidian-wiki`/`hal0-wiki` fork actually is (a pure-stdlib installer + 38 markdown skill files; **no daemon**), the Karpathy LLM-Wiki pattern, vault structure, the 38 skills, package internals, the AGENTS.md contract, what's "Hal0'd" so far (nothing — byte-identical fork), and hal0 integration relevance (QMD→Engine swap, who maintains the vault, where it lives). | ~510 lines |
+| **03** | Current Memory Audit (as-built) | Ground truth on the existing Cognee subsystem: the one-file `CogneeWrapper` seam, MCP/REST/dispatcher/CLI/Hermes-plugin layers, the data model (Cognee vs sidecar), every known defect (#317 fixed, wrong-route Hermes client bug, fragile text-join, dead Kuzu graph, test gaps), and the swap-seam verdict. | ~540 lines |
+| **04** | Consumer Surface | The complete map of every brain *consumer* (agents, apps, MCP surfaces, slots, dashboard views), with `file:line` citations and a produces/consumes/wiki matrix. The prioritized "where to hook in to feel native" integration map (Tiers A/B/C). | ~485 lines |
+| **05** | Memory Landscape & Tradeoffs | The decision frame: taxonomy of memory paradigms, a scored comparison matrix for hal0's reality, the **two-tier brain thesis** (+ honest counter-cases), where Cognee fits/exits, multi-agent namespacing/trust, self-host constraints on Strix Halo, and 8 open grilling-seed questions. | ~455 lines |
+| **06** | Proposed Architecture | **The synthesis & recommendation.** Thesis + principles, the layered model, the `MemoryProvider` ABC (the linchpin), the Hindsight engine decision + local wiring table, the Wiki layer design, the **promotion model** (critical), per-consumer deep-integration map, bank-templates as a hal0 primitive, keep/change/delete, and 11 risks/open questions. | ~690 lines |
+| **07** | Implementation / phasing roadmap | The staged plan — Phase 0 `MemoryProvider` ABC + conformance suite (no behavior change), Phase 1 Hindsight shadow + **eval hard-gate**, Phase 2 cutover, Phase 3 wiki, Phase 4 promotion pipeline, Phase 5 deep consumer integration, Phase 6 polish. Dependency graph + per-phase rollback + open-question blockers. | ~570 lines |
+| **08** | Grilling decision tree | The dependency-ordered tree of every open decision (S/A/B/C/D/E/F branches), each with options, my recommended answer, and the sharpest counter-challenge. The working doc for the post-reboot `/grill-me` session. | ~380 lines |
+
+> All nine docs (00–08) are present in this directory as of 2026-06-02. Doc 08 (the
+> grilling decision tree) is the working document for the post-reboot session; docs
+> 01–05 are research, 06 is the recommendation, 07 is the build sequence.
+
+---
+
+## Executive summary of the recommendation (faithful to doc 06)
+
+**The layered model.** Three layers:
+
+- **(a) Engine — Hindsight (Tier E):** machine-owned, fast, structured. Owns raw
+  turns/facts and the *observations* derived from them. Verbs: `retain` (LLM extract →
+  4-edge graph → background consolidation), `recall` (TEMPR 4-way → RRF → cross-encoder
+  → token budget), `reflect` (agentic loop with disposition). **Canonical for raw
+  episodic recall.** Banks map 1:1 to hal0 namespaces.
+- **(b) Wiki — hal0-wiki (Tier C):** human-legible, curated, cross-linked markdown with
+  provenance/confidence/lifecycle/typed-relationship frontmatter. **Canonical for
+  curated knowledge** (procedural playbooks, stable semantic facts, architecture notes,
+  agent identity write-ups). No daemon — a directory of markdown plus skill files the
+  agent executes.
+- **(c) Access plane:** the one front door — `/mcp/memory` (4 memory tools + new
+  `wiki_search`/`wiki_get`), `/api/memory/*` (CRUD + graph gate), and a sibling
+  `/api/wiki/*`. The `X-hal0-Agent` → namespace rule (resolved server-side in
+  `hal0.memory.namespace`) is preserved verbatim. **Adding the Wiki adds tools on the
+  same server, not a new service.**
+
+**Engine decision — Hindsight, wired locally.** Replace Cognee with Hindsight, staged
+behind the new ABC, **eval-gated** (run hal0's δ/eval harness on Cognee-as-used vs
+Hindsight vs plain-pgvector first; flip the default only after). Local wiring on CT 105:
+`hindsight-api` as a systemd unit; **embedded `pg0`** (replaces all three Cognee stores);
+**embeddings → the embed capability slot** (TEI/OpenAI-compatible, not a bundled
+embedder); **rerank → the :8086 rerank slot** already wired; **extraction LLM →
+lemond:13305** (Lemonade gateway, not Hindsight's bundled llamacpp). Assume CPU for
+embed/rerank (Strix-Halo/ROCm accel is undocumented — validate). Degrade ladder: full
+retain/recall/reflect → `LLM_PROVIDER=none` recall-only (still better than
+Cognee-as-used) → pgvector/no-op fallback with a "no engine" dashboard state.
+
+**Wiki layer.** Vault at `/var/lib/hal0/wiki` (git-backed), **Hermes-as-librarian**
+(skills installed at provision time, a systemd `daily-update` timer for
+freshness/index/lint). Viewed primarily via a **dashboard render** (markdown +
+`wiki-export` `graph.html`). The single biggest "Hal0'd" change to the fork: **swap QMD
+for the Engine** as the search index (on every vault write, call `register_compiled`;
+on query, semantic pass against the Engine first, Grep fallback). Keep `memory-bridge`
+("what does Hermes know that Claude-Code doesn't") wired to `X-hal0-Agent` identity.
+
+**The recommended promotion model.** Gated, one-way: Engine observation
+(`proof_count ≥ N` *or* `freshness == 'stable'`) → **promotion gate** → Wiki page
+(`provenance: inferred`, `lifecycle: draft`) → `register_compiled()` → Engine
+`kind='wiki'` mental_model (top of the recall hierarchy: wiki → observations → facts).
+Consolidation writes the Engine's own observations **only** — never auto-writes the
+Wiki. Gate by namespace: `private:<agent>` **auto-promotes**; `shared`/`project:<id>`
+are **gated** (librarian agent drafts, human approves via the dashboard inbox, reusing
+the destructive-call approval-queue UX). Wiki → Engine is one-way and derived; the Wiki
+page is canonical, the Engine copy is an index. Main risk: the gate becomes a bottleneck
+or a rubber stamp.
+
+**The `MemoryProvider` seam.** The prerequisite to everything. Today Cognee is contained
+to one file and one construction site but there is **no formal ABC**. The plan promotes
+the implicit five-method contract into an explicit `MemoryProvider` ABC/Protocol
+(`src/hal0/memory/provider.py`) with engine-neutral value types, the core five
+(`add`/`search`/`list_items`/`delete` + runtime-flip helpers `graph_status`/
+`set_graph_enabled`/`set_rerank_enabled`), and **optional** Hindsight-era methods
+(`recall`, `reflect`, `consolidate`, and the promotion seam `register_compiled`) with
+safe defaults so a pgvector fallback still satisfies the contract. `MemoryItem.id`
+becomes the join key (retiring the fragile text-equality sidecar). A **parametrized
+conformance suite** runs against every provider and de-risks the swap. Only the single
+construction site at `api/__init__.py:1108` changes
+(`CogneeWrapper()` → `provider_from_config(cfg)`).
+
+---
+
+## The big open questions
+
+The full decision tree lives in **doc 08** (grilling, authored separately). The headline
+unresolved forks (from doc 05 §7 and doc 06 §10):
+
+1. **Promotion gate** — bottleneck or rubber stamp? Is `private:<agent>`-auto +
+   `shared`-gated the right split on a single-user box where proof-count corroboration
+   may never accrue?
+2. **Eval not yet run** — "Hindsight recalls better than Cognee-as-used" is an
+   architectural judgement, not a benchmark. If the delta is null, do we still pay the
+   migration cost for the consolidation/observations *upgrade path* alone?
+3. **Librarian centralisation** — Hermes-as-librarian is a single failure/trust point;
+   split into a dedicated curator persona, or accept the coupling?
+4. **Strix-Halo accel** — CPU embed/rerank is an *assumption*; bge-on-iGPU may change
+   the embedding model (forcing a re-embed). Unvalidated.
+5. **Local structured-output: invest or route?** Do we ever stand up a
+   grammar-constrained / tool-call 32B+ extraction path, or permanently design for
+   recall-only + hand-curated Wiki?
+6. **Working-memory budget ownership** — recall token budget vs the orchestrator: who
+   arbitrates context space across wiki pages / observations / raw facts?
+7. **External-agent default read** — should an external Claude Code session read the
+   `shared` brain by default? (proposed: read-yes / shared-write-no.)
+8. **Hindsight bundled-daemon port collision** (`:9077`), **webhook per-bank
+   registration** (may be server-wide only), **migration data fidelity** (some
+   text-joined Cognee rows may not cleanly map), and the **YAGNI counter-case** (is the
+   two-tier design over-built for v1 on a single-user box under the ~100k-token wiki
+   ceiling?).
+
+---
+
+## Status & provenance
+
+- These are **PLANNING documents**, produced **2026-06-02** by a multi-agent research
+  wave (one dossier per agent), **pre-grilling**. Nothing here is decided or implemented.
+- The recommendation in doc 06 *supersedes (proposed)* ADR-0005 (Cognee) and ADR-0014
+  (graph gate) and *extends* ADR-0011 (`agents` dataset) and ADR-0012 (`X-hal0-Agent`,
+  no-auth) — but only once decided and shipped.
+- **Source dossiers:** `01-hindsight-research.md`, `02-hal0-wiki-research.md`,
+  `03-current-memory-audit.md`, `04-consumer-surface.md`, `05-memory-landscape.md`,
+  `06-proposed-architecture.md`, `07-integration-roadmap.md`, and
+  `08-grilling-decision-tree.md` — all present in this directory.
+- The **`hindsight-docs` skill is installed locally** at `~/.agents/skills/hindsight-docs/`
+  (SKILL.md + references for architecture, APIs, config, best-practices) and was the
+  primary source for doc 01.
+
+---
+
+## Glossary
+
+- **Engine (Tier E)** — the machine-owned, fast, structured memory store (the candidate
+  is Hindsight). Owns raw episodic turns/facts and the consolidated observations derived
+  from them. Optimised for recall, not human reading.
+- **Wiki layer (Tier C)** — the human-legible, curated, cross-linked markdown corpus
+  (`hal0-wiki` over an Obsidian vault). Canonical for curated knowledge. "Compile, don't
+  retrieve."
+- **retain / recall / reflect** — Hindsight's three core verbs. **retain** = ingest raw
+  content, LLM-extract facts/entities/relations, build a graph, embed, store (then fire
+  background consolidation). **recall** = multi-strategy (semantic + BM25 + graph +
+  temporal) parallel retrieval fused by RRF, reranked by a cross-encoder, truncated to a
+  *token budget* — no LLM. **reflect** = an agentic reasoning loop that gathers evidence
+  and returns a reasoned, cited answer shaped by the bank's disposition.
+- **Observation** — Hindsight's third fact type: a deduplicated, evidence-grounded
+  *belief* synthesized from multiple facts, carrying supporting-source quotes, a
+  **proof count**, and a computed **freshness trend** (stable/strengthening/weakening/
+  new/stale). Refined, not overwritten. This is the staleness fix hal0 lacks today.
+- **Memory bank** — Hindsight's unit of isolation: one isolated store of memories,
+  entities, directives, mental models. Banks share no data. Auto-created on first use.
+  Maps 1:1 to hal0 namespaces.
+- **Bank template** — a declarative JSON manifest (mission, disposition, entity-labels,
+  mental-models, directives) that provisions a fully-configured bank in one `import`
+  call. Proposed as a first-class hal0 primitive bound to personas.
+- **Namespace** — hal0's memory scoping, resolved server-side from `X-hal0-Agent`:
+  **`shared`** (the common brain; curated, write-gated), **`private:<agent_id>`**
+  (per-agent episodic scratch; an agent reads its own + `shared`, never another's
+  private), **`project:<id>`** (task/repo-scoped working sets, formalised from today's
+  pass-through custom datasets), plus **`agents`** (identity cards, ADR-0011).
+- **Promotion** — the gated, one-way movement of a durable Engine observation into a
+  curated Wiki page, then re-embedded back into the Engine as a derived index entry. The
+  seam most likely to recreate hal0's drift bugs if done wrong; hence one-way + tested.
+- **Librarian** — the agent responsible for maintaining the Wiki (drafting promoted
+  pages, running the nightly freshness/index/lint cycle). Proposed default:
+  **Hermes-as-librarian**; open fork whether to split into a dedicated curator agent.
+- **MemoryProvider** — the engine-neutral ABC/Protocol that hides the concrete engine
+  (Cognee, Hindsight, or a pgvector shim) behind one contract. The linchpin: defines the
+  core five methods + optional Hindsight-era methods + the `register_compiled` promotion
+  seam, pinned by a conformance test suite, swapped at a single construction site.

--- a/docs/internal/brain-redesign/01-hindsight-research.md
+++ b/docs/internal/brain-redesign/01-hindsight-research.md
@@ -1,0 +1,764 @@
+# Hindsight Feature Inventory — Research Dossier
+
+**Subject:** Hindsight, the biomimetic agent-memory system by vectorize.io
+**Purpose:** Exhaustive, accurate feature inventory for hal0 platform-integration planning.
+**Author:** AI Memory Systems research pass, 2026-06-02.
+**Primary sources:** the locally-installed `hindsight-docs` skill at
+`~/.agents/skills/hindsight-docs/` (SKILL.md, `references/best-practices.md`,
+`references/faq.md`, `references/openapi.json`, all of `references/developer/**`,
+`references/developer/api/**`, `references/sdks/**`, `references/changelog/**`),
+supplemented by WebFetch of the live docs (`hindsight.vectorize.io`) for the
+`sdks/integrations/{local-mcp,hermes,claude-code}` pages and `/templates`, which
+are NOT shipped in the local skill.
+
+> **Citation convention.** Local skill files are cited by their path under
+> `references/…`. Live-doc-only material is flagged `[web: <url>]`. Where the
+> local skill and live docs diverge or a topic is thin, it is called out
+> explicitly in the relevant section and again in the "Gaps & ambiguities"
+> section at the end.
+
+---
+
+## 0. What Hindsight is, in one paragraph
+
+Hindsight is a self-hostable, biomimetic **memory engine for AI agents** — a
+FastAPI/PostgreSQL service exposing three core verbs (`retain`, `recall`,
+`reflect`) plus an automatic background **observation-consolidation** loop and a
+built-in **MCP server**. It is explicitly positioned *against* stateless RAG: it
+stores structured facts + an entity knowledge graph + temporal grounding rather
+than raw chunks, retrieves with four parallel strategies fused by RRF and a
+cross-encoder, and reasons through a configurable per-bank "personality"
+(missions, directives, disposition traits). Memory is partitioned into isolated
+**memory banks**. It ships Docker / Helm / pip / embedded-Python deployment
+modes and can run **fully local with no cloud dependency** (embedded PostgreSQL +
+local embedder + local reranker + a built-in llama.cpp LLM).
+(`SKILL.md`; `references/developer/index.md`; `references/developer/rag-vs-hindsight.md`)
+
+---
+
+## 1. Core model — "biomimetic memory", and retain / recall / reflect
+
+### 1.1 What "biomimetic" means here
+
+The biomimicry is in the *memory lifecycle*, not the math. Hindsight mimics how
+human memory works:
+
+- **Encoding with meaning, not verbatim storage.** Raw content is never stored as
+  the memory; an LLM extracts facts, entities, relationships, emotions, and
+  causal reasoning at write time. ("Alice joined Google last spring and was
+  thrilled" → core fact + emotion + reasoning, queryable as "Why did Alice join
+  Google?") (`references/developer/retain.md`)
+- **Consolidation into beliefs.** After writes, a background engine deduplicates
+  overlapping facts into **observations** — durable, evidence-grounded beliefs
+  that strengthen, weaken, or get reconciled as new evidence arrives, preserving
+  the *history* of a changing belief rather than overwriting it.
+  (`references/developer/observations.md`)
+- **Two temporal dimensions** like episodic memory: *when it happened*
+  (occurrence time) vs *when you learned it* (mention time).
+  (`references/developer/retain.md`)
+- **Disposition / personality** that colours reasoning, plus pre-computed
+  "mental models" that act like ready recall of frequently-needed knowledge.
+  (`references/developer/reflect.md`, `.../api/mental-models.md`)
+
+### 1.2 The three operations
+
+| Op | Uses LLM? | Uses observations? | Disposition? | Output |
+|----|-----------|--------------------|--------------|--------|
+| **retain** | Yes (extraction) | No | No | Memory IDs |
+| **recall** | No | Yes | No | Ranked facts (+ observations) |
+| **reflect** | Yes (generation) | Yes | Yes | Reasoned answer + citations |
+
+(`references/developer/api/main-methods.md`)
+
+**Retain** — ingests raw content (conversation array preferred, prefixed plain
+text or markdown acceptable; never pre-summarize). Pipeline: chunk → LLM fact
+extraction → entity recognition + resolution (nickname/co-occurrence
+disambiguation) → build a 4-edge knowledge graph (entity, temporal, semantic,
+causal links) → embed → store. Then it *automatically* fires background
+consolidation. Key params: `content`, `context` (high-impact on quality — always
+set it), `document_id` (stable ID = upsert/replace), `timestamp` (enables
+temporal ranking), `tags`, `metadata` (returned but **not filterable**),
+`observation_scopes`, `async_` (default sync). Facts are typed `world` (about
+others), `experience` (the bank's own actions/events), or `observation`
+(consolidated). (`references/developer/retain.md`, `.../api/retain` via
+best-practices, `references/best-practices.md`)
+
+**Recall** — "TEMPR": four strategies run **in parallel** (semantic, keyword/BM25,
+graph traversal, temporal), fused with Reciprocal Rank Fusion, then re-scored by
+a cross-encoder, then three multiplicative boosts (recency, temporal proximity,
+proof-count), then truncated to a **token budget** (`max_tokens`, default 4096)
+rather than top-k. No numeric scores returned — consume in order. Key params:
+`query` (≤500 tokens), `types` (`world`/`experience`/`observation`), `budget`
+(`low`/`mid`/`high`), `max_tokens`, `query_timestamp` (anchors relative time +
+recency), `tags`/`tags_match`, `tag_groups` (recursive and/or/not boolean tree),
+`include.{entities,chunks,source_facts}`, `trace`.
+(`references/developer/retrieval.md`, `references/developer/api/recall.md`)
+
+**Reflect** — an **agentic loop** (≤10 iterations) with tools
+`search_mental_models` → `search_observations` → `recall` → `expand` → `done`,
+applied in that hierarchical priority. Must gather evidence before answering;
+validates that every citation was actually retrieved; auto-verifies *stale*
+observations against current facts. Shaped by the bank's `reflect_mission`,
+`directives` (hard rules), and `disposition` traits. Key params: `query`,
+`context`, `budget` (default `low` in the MCP tool / `mid` elsewhere),
+`max_tokens`, `response_schema` (JSON-Schema → `structured_output`),
+`tags`/`tags_match`, `include.{facts,tool_calls}`. Returns `text`, `based_on`
+(memories/mental_models/directives used), `trace`, `structured_output`, `usage`.
+(`references/developer/reflect.md`, `references/developer/mcp-server.md`)
+
+### 1.3 Observations vs memories (the crux)
+
+- **Memories / facts** = atomic, individually-extracted units (`world` /
+  `experience`). Immutable record of what was said.
+- **Observations** = a *third* fact type: deduplicated, evidence-grounded
+  **beliefs** synthesized from multiple facts. Each tracks supporting source
+  memories (with exact quotes), a **proof count**, and a computed **freshness
+  trend** (`stable` / `strengthening` / `weakening` / `new` / `stale`). They are
+  *refined, not overwritten* — a user who switched React→Vue yields an
+  observation capturing the whole journey. Generated automatically in the
+  background after retain; never part of the retain call itself. Deleting source
+  memories cascades: derived observations are deleted and surviving co-source
+  memories are reset for re-consolidation.
+  (`references/best-practices.md`, `references/developer/observations.md`)
+
+---
+
+## 2. Memory banks
+
+A **memory bank** is the unit of isolation — one isolated store of memories,
+documents, entities, relationships, directives, mental models. Banks share no
+data. Common patterns: one bank per user, or per agent; a shared bank + tags for
+cross-user analysis. **Auto-created on first use**; configure before ingesting to
+steer behavior. (`references/best-practices.md`,
+`references/developer/api/memory-banks.md`)
+
+**Lifecycle / management** (REST + SDK + CLI + MCP):
+`create_bank`, `get_bank`, `get_bank_stats` (node/link counts),
+`update_bank` (name + `config_updates`), `delete_bank` (wipes everything),
+`clear_memories` (optionally by fact type — keeps the bank), plus
+`/stats` for pending-consolidation counters. (`references/developer/mcp-server.md`,
+`references/developer/admin-cli.md`)
+
+**Config knobs** are managed by a **separate config API**
+(`update_bank_config` / `get_bank_config` / `reset_bank_config`) so operational
+settings change independently from identity. `get_bank_config` returns both the
+**resolved** config (server defaults merged with overrides) and the raw
+**overrides**. Knobs (all optional, server-wide defaults via env vars):
+
+- **Extraction:** `retain_mission`, `retain_extraction_mode`
+  (`concise`/`verbose`/`custom`), `retain_custom_instructions`,
+  `retain_chunk_size` (default 3000 chars), `retain_chunk_batch_size`.
+- **Entity classification:** `entity_labels` (controlled vocabulary; see §3),
+  `entities_allow_free_form`.
+- **Observations:** `enable_observations`, `enable_auto_consolidation`,
+  `observations_mission`, `consolidation_llm_batch_size` (default 8),
+  `consolidation_source_facts_max_tokens` (-1 = unlimited),
+  `consolidation_source_facts_max_tokens_per_observation` (default 256).
+- **Reflect personality:** `reflect_mission`, `disposition_skepticism`,
+  `disposition_literalism`, `disposition_empathy` (each 1–5, default 3).
+- **Directives:** hard rules (create/list/update/delete; `is_active`, `priority`,
+  `tags`) injected into reflect prompts and *always* enforced — distinct from
+  soft disposition.
+- **Recall tuning:** `recall_budget_function` (`fixed`/`adaptive`),
+  `recall_budget_fixed_{low,mid,high}` (100/300/1000),
+  `recall_budget_adaptive_{low,mid,high}`, `recall_budget_{min,max}` (20/2000),
+  `recall_include_chunks`, `recall_max_tokens`.
+- **MCP:** `mcp_enabled_tools` (per-bank allowlist of tool names; `null` = all).
+- **LLM safety:** `llm_gemini_safety_settings` (Gemini/Vertex only).
+
+(`references/developer/api/memory-banks.md`, `references/developer/mcp-server.md`)
+
+**Missions** are the single biggest quality lever (best-practices calls
+misconfigured missions "the single biggest cause of low-quality memories"):
+`retain_mission` steers extraction, `observations_mission` steers consolidation,
+`reflect_mission` sets the reasoning persona. **Disposition affects `reflect`
+only**, not `recall`. (`references/best-practices.md`)
+
+---
+
+## 3. Bank templates  *(user priority — detailed)*
+
+A **bank template** is a declarative JSON **manifest** that provisions a fully
+configured bank in a single API call instead of many. Use cases: replication
+(stamp identical banks per user/agent), onboarding (known-good defaults),
+sharing portable setups, shipping a recommended template alongside an
+integration. (`references/developer/api/bank-templates.md`)
+
+### 3.1 Manifest schema (`version: "1"`)
+
+```json
+{
+  "version": "1",
+  "bank": {
+    "reflect_mission": "...",
+    "retain_mission": "...",
+    "retain_extraction_mode": "concise | verbose | custom | chunks",
+    "retain_custom_instructions": "...",
+    "retain_chunk_size": 2048,
+    "disposition_skepticism": 3,
+    "disposition_literalism": 3,
+    "disposition_empathy": 3,
+    "enable_observations": true,
+    "observations_mission": "...",
+    "entity_labels": ["PERSON", "ORGANIZATION"],
+    "entities_allow_free_form": true
+  },
+  "mental_models": [
+    {
+      "id": "unique-lowercase-id",
+      "name": "Human-Readable Name",
+      "source_query": "The query that generates this mental model's content",
+      "tags": ["optional", "tags"],
+      "max_tokens": 2048,
+      "trigger": {
+        "refresh_after_consolidation": false,
+        "fact_types": ["world", "experience", "observation"],
+        "exclude_mental_models": false,
+        "exclude_mental_model_ids": []
+      }
+    }
+  ],
+  "directives": [
+    {
+      "name": "directive-name",
+      "content": "The directive instruction text",
+      "priority": 0,
+      "is_active": true,
+      "tags": ["optional", "tags"]
+    }
+  ]
+}
+```
+
+All three top-level sections (`bank`, `mental_models`, `directives`) are
+**optional** — omit a section to leave that part untouched. Only fields you set
+in `bank` become per-bank overrides; everything else inherits server/tenant
+defaults. (`references/developer/api/bank-templates.md`)
+
+> **Note / minor inconsistency:** the template `bank.entity_labels` example is a
+> flat string array (`["PERSON","ORGANIZATION"]`), whereas the bank-config
+> `entity_labels` schema (§3.4) is a list of richly-typed **label-group objects**.
+> The bank-templates page lists `entity_labels` as `string[]`. Treat the
+> object-form as authoritative for real label groups and verify what the
+> template importer accepts before relying on rich labels in a manifest. Also,
+> the template page lists `retain_extraction_mode` value `chunks`, which does not
+> appear in the bank-config docs (which list only concise/verbose/custom) — flagged.
+
+### 3.2 Import / export / dry-run / round-trip
+
+- **Import:** `POST /v1/default/banks/{bank_id}/import` with the manifest body.
+  Bank auto-created if absent. Mental models matched by `id` (update-or-create);
+  directives matched by `name`. Mental-model content generates **asynchronously**
+  — response carries `operation_ids` + `config_applied` /
+  `mental_models_created` / `directives_created` counts.
+- **Dry run:** add `?dry_run=true` — validates and returns what *would* happen;
+  HTTP 400 with a detailed message on an invalid manifest.
+- **Export:** `GET /v1/default/banks/{bank_id}/export` — returns only the
+  **explicitly-set overrides** (not the resolved config), so the manifest stays
+  portable. Round-trip = export from source bank, import into a new bank.
+- **Schema endpoint:** `GET /v1/bank-template-schema` returns the live JSON
+  Schema (also static at `bank-template-schema.json`).
+- **Versioning:** `version` enables forward-compatible evolution — old manifests
+  auto-upgrade on import; export always emits latest; manifests newer than the
+  server are rejected with a clear error.
+
+(`references/developer/api/bank-templates.md`)
+
+### 3.3 Control-plane authoring + the Templates Hub
+
+The Control Plane's bank-creation dialog has an "Import from template" toggle
+(paste manifest JSON); any bank can be exported via **Actions → Export Template**
+(copies manifest to clipboard). A public **Bank Templates Hub** at
+`/templates` ships ready-to-use examples; custom templates are authored as plain
+JSON manifests and contributed back via PR to the Hindsight repo.
+(`references/developer/api/bank-templates.md`; `[web: hindsight.vectorize.io/templates]`)
+
+The three example templates currently in the Hub `[web: /templates]`:
+
+| Template | Purpose (verbatim summary) |
+|----------|----------------------------|
+| **Conversation** | Chat-based agents/assistants. Tracks user preferences, conversation patterns, builds a profile over time. |
+| **Coding Agent** | Coding assistants. Remembers project architecture, technical decisions, coding patterns, user preferences across sessions. **High literalism** for precise technical recall. |
+| **Personal Assistant** | Always-on personal assistants. Tracks commitments, routines, personal context across daily life. |
+
+> The Hub landing page does not enumerate each template's full field values; to
+> get the exact mission/disposition/mental-model/directive bodies you must open
+> the individual template entry or fetch its JSON. (Flagged in Gaps.)
+
+### 3.4 Entity-labels schema (used by templates and bank config)
+
+A controlled vocabulary of `key:value` classification labels extracted at retain
+time and stored **as entities** (so they auto-link memories in the graph and
+improve semantic + BM25 retrieval). Each entry is a **label group**:
+
+```json
+{
+  "entity_labels": [
+    {
+      "key": "memory_type",
+      "description": "rule vs procedure",
+      "type": "value",            // value | multi-values | text | map
+      "optional": false,
+      "tag": true,                 // also write key:value as a memory tag
+      "values": [
+        { "value": "rule",      "description": "Concise operating rule" },
+        { "value": "procedure", "description": "Step-by-step instruction" }
+      ]
+    }
+  ]
+}
+```
+
+- `type: value` (pick one enum), `multi-values` (pick several), `text` (free-form
+  string), `map` (structured entity with named typed `fields`, stored flat as
+  `key:field:value`, e.g. `person:name:Alice`).
+- `tag: true` makes the extracted label *also* a filterable tag — enabling a hard
+  SQL `WHERE` filter at recall time across all four strategies (e.g. return only
+  `memory_type:rule` memories). This is the recommended way to separate
+  semantically-similar-but-different memories (rules vs runbooks).
+- `entities_allow_free_form: false` disables ordinary named-entity extraction so
+  only label entities are stored.
+
+(`references/developer/api/memory-banks.md`, `references/best-practices.md`,
+`references/developer/retain.md`)
+
+---
+
+## 4. Docs feature (Documents)
+
+"Docs" in Hindsight = **Documents**: containers for retained content that provide
+**source traceability** and bulk lifecycle. A document is created/updated by
+retaining with a `document_id`; re-retaining the same ID **replaces** the prior
+content (delete-old-facts → re-extract). When content is retained it is split
+into **chunks** (raw text segments stored alongside extracted facts);
+`include.chunks` in recall returns those raw segments for verbatim context.
+(`references/developer/api/documents.md`)
+
+Document operations: retain-with-`document_id` (single or `retain_batch`),
+**get** (`original_text`, `content_hash`, `memory_unit_count`,
+`nodes_by_fact_type`, timestamps), **update tags** (mutable `tags` only — no
+re-processing; changing tags invalidates + re-queues derived observations),
+**delete** (removes the doc and *all* its memories — irreversible), **list**
+(filter by `q` substring on ID, by `tags`/`tags_match`, paginate).
+File-upload endpoints exist (`file_convert_retain` operation: PDF/DOCX→text via a
+`HINDSIGHT_API_FILE_PARSER` of `markitdown`/`iris`/`llama_parse`, overridable
+per-request; conversion failures are non-retryable).
+(`references/developer/api/documents.md`, `references/developer/api/operations.md`)
+
+> Hindsight treats "documents" as *provenance + ingestion grouping*, not as a
+> separately-served corpus. There is no separate "docs query" path distinct from
+> recall/reflect — memories extracted from a document are retrieved through the
+> normal pipeline; the document is the audit/back-link handle. The Claude Code
+> integration adds a higher-level "knowledge pages" concept on top
+> (`agent_knowledge_create_page`, page list/get) — that is integration-layer, not
+> core API. (`[web: /sdks/integrations/claude-code]`; flagged in Gaps.)
+
+---
+
+## 5. Operations (admin/ops surface, async lifecycle)
+
+All background work shares one queue (`async_operations` table) and one worker
+pool. Operation **types**: `retain`, `retain_batch` (parent that splits large
+submissions into child `retain` ops; aggregate status), `file_convert_retain`,
+`consolidation` (bank-deduped), `refresh_mental_model`, `graph_maintenance`
+(reconciles links/orphan entities/stale cooccurrences after deletes; bank-deduped),
+`webhook_delivery`. (`references/developer/api/operations.md`)
+
+**Lifecycle states:** `pending` → `processing` → `completed` | `failed` |
+`cancelled`. Worker retries failed ops up to
+`HINDSIGHT_API_WORKER_MAX_RETRIES`; deterministic failures skip retries.
+**REST endpoints** (per bank): list (filter `status`/`type`/`limit`/`offset`/
+`exclude_parents`), get status (optional `include_payload`), cancel (pending
+only — 409 otherwise), retry (failed/cancelled only — resets to pending).
+
+**Worker model.** By default the worker runs **in-process inside the API** (no
+extra process, no external broker — PostgreSQL is the broker). For throughput,
+disable the in-process worker (`HINDSIGHT_API_WORKER_ENABLED=false`) and run
+dedicated `hindsight-worker` processes (same image, different entrypoint; metrics
+port 8889; `/health` + `/metrics`). Per-worker concurrency is
+`HINDSIGHT_API_WORKER_MAX_SLOTS` (default 10) with per-type reservations.
+(`references/developer/services.md`, `references/developer/api/operations.md`)
+
+**Admin CLI (`hindsight-admin`)** — bundled with `hindsight-api`:
+`run-db-migration` (`--schema`; migrations also auto-run on startup unless
+`HINDSIGHT_API_RUN_MIGRATIONS_ON_STARTUP=false`), `backup OUTPUT.zip` /
+`restore INPUT.zip` (REPEATABLE-READ consistent snapshot; restore wipes target
+schema first), `decommission-worker <id>` / `decommission-workers` (release
+stuck/zombie `processing` tasks back to `pending`), `worker-status` (inspect
+running tasks per worker). **Zombie-op gotcha:** an unstable
+`HINDSIGHT_API_WORKER_ID` (defaults to container hostname, which changes on
+Docker restart) strands in-flight tasks — set a stable worker ID in production.
+(`references/developer/admin-cli.md`, `references/developer/installation.md`)
+
+**Audit logging** (off by default): `HINDSIGHT_API_AUDIT_LOG_ENABLED=true`
+captures mutating ops into an `audit_log` table queryable at `/audit-logs`;
+`HINDSIGHT_API_AUDIT_LOG_ACTIONS`, `…_RETENTION_DAYS`.
+(`references/developer/configuration.md`)
+
+---
+
+## 6. Webhooks
+
+Hindsight POSTs HTTP events to a configured URL. Configuration is **server-wide /
+env-var driven** in the shipped skill (no per-bank create-webhook REST endpoint
+is documented locally — the webhooks page says "registered per memory bank and
+fire automatically" but does not show the registration API; flagged in Gaps):
+
+- `HINDSIGHT_API_WEBHOOK_URL` — delivery URL (unset = disabled)
+- `HINDSIGHT_API_WEBHOOK_SECRET` — HMAC signing secret (unset = unsigned)
+- `HINDSIGHT_API_WEBHOOK_EVENT_TYPES` — comma list (default `consolidation.completed`)
+- `HINDSIGHT_API_WEBHOOK_DELIVERY_POLL_INTERVAL_SECONDS` — default 30
+
+(`references/developer/configuration.md`)
+
+**Delivery semantics:** at-least-once (delivery task is committed in the same DB
+transaction as the source op, so it survives a crash — your endpoint may receive
+duplicates; dedupe on `operation_id`). A delivery fails on non-2xx or timeout
+(default 30s); retries with exponential backoff at 5s / 5m / 30m / 2h / 5h, then
+**permanent failure after 6 attempts**. (`references/developer/api/webhooks.md`)
+
+**Event types & payloads** (documented):
+
+1. **`consolidation.completed`** — after observation consolidation finishes for a
+   bank. `data`: `observations_created`, `observations_updated`,
+   `observations_deleted`, `error_message`. `status` ∈ `completed`/`failed`.
+2. **`retain.completed`** — once per document after retain (sync or async); a
+   batch of N fires N events. `data`: `document_id`, `tags`. For async retain the
+   `operation_id` matches the retain API's; for sync it's a trace ID.
+
+Every payload carries `event`, `bank_id`, `operation_id`, `status`, `timestamp`,
+`data`. (`references/developer/api/webhooks.md`)
+
+---
+
+## 7. Retrieval (TEMPR pipeline in depth)
+
+Four strategies run in parallel, then a multi-stage scoring pipeline:
+
+1. **Semantic** — embedding cosine via pgvector HNSW; conceptual/paraphrase
+   matches.
+2. **Keyword (BM25)** — exact names/technical terms. **Five pluggable backends**
+   via `HINDSIGHT_API_TEXT_SEARCH_EXTENSION`: `native` (Postgres tsvector — TF-IDF,
+   Citus-OK), `vchord`, `pg_textsearch` (Timescale), `pgroonga` (CJK/mixed out of
+   the box), `pg_search` (ParadeDB — the only true-BM25 Citus-compatible option,
+   configurable tokenizer incl. jieba/lindera/ngram). BM25 is within-language; the
+   `native` dictionary is set by `…_NATIVE_LANGUAGE` (default `english`).
+3. **Graph traversal** — follows entity/semantic/causal links; score =
+   `tanh(shared_entities×0.5) + kNN_semantic_link + causal_link` ∈ [0,3]
+   (additive — independent evidence channels).
+4. **Temporal** — parses time expressions, filters/ranks by occurrence date.
+
+**Fusion → rank.** RRF with k=60, **all strategies weighted equally** (importance
+from rank position, not source). Then a **cross-encoder** reranks the top
+`HINDSIGHT_API_RERANKER_MAX_CANDIDATES` (default 300) candidates; raw logits are
+sigmoid-normalized to [0,1], calibrated external rerankers pass through.
+Then **three multiplicative boosts**: recency (α0.2, ±10%, linear 365-day decay),
+temporal proximity (α0.2, ±10%, only on time-anchored queries), proof-count
+(α0.1, +5% max, log curve for observations). Net swing ≈ +27% / −23%. Then
+token-budget truncation by `max_tokens` (only `text` counts). Without a
+cross-encoder (`rrf` provider / slim), synthetic [0.1,1.0] scores from RRF rank
+are used so the boosts still work.
+(`references/developer/retrieval.md`, `references/developer/index.md`)
+
+**Budget → pipeline depth.** `low`/`mid`/`high` map (fixed mode) to recall budgets
+100/300/1000, flowing into HNSW over-fetch, BM25 `LIMIT`, graph/temporal node
+expansion. `adaptive` mode scales with `max_tokens`. Reranker pre-filter (300) is
+independent of budget. Typical recall latency 100–600ms (CPU reranker is the
+bottleneck; GPU or external reranker speeds it up).
+(`references/developer/retrieval.md`, `references/developer/performance.md`)
+
+---
+
+## 8. Deployment / runtime — **CRITICAL for hal0: can it run fully local?**
+
+### 8.1 Verdict: YES, fully local / self-hosted, zero cloud dependency
+
+Every external dependency has a local substitute:
+
+| Layer | Cloud option | **Fully-local option** |
+|-------|--------------|------------------------|
+| **Database** | Supabase/Neon/RDS/AlloyDB | **`pg0` embedded PostgreSQL** (default; `~/.hindsight/data/`) or self-hosted Postgres 14+ with a vector extension |
+| **LLM** | OpenAI/Anthropic/Gemini/Groq/… | **built-in `llamacpp`** (auto-downloads Gemma 4 E2B GGUF ~3.5 GB, no API key), **Ollama**, **LM Studio**, llama.cpp, or any OpenAI-compatible local endpoint |
+| **Embeddings** | OpenAI/Cohere/Google/ZeroEntropy | **`local`** SentenceTransformers (default `BAAI/bge-small-en-v1.5`, 384-dim, ~130 MB) or self-hosted **TEI** |
+| **Reranker** | Cohere/ZeroEntropy/… | **`local`** cross-encoder (default `ms-marco-MiniLM-L-6-v2`, ~85 MB), `flashrank`, self-hosted TEI, or `rrf` (no neural rerank) |
+
+So a hal0-style box can run Hindsight with: embedded pg0 + local BGE embedder +
+local MiniLM reranker + a local LLM (llamacpp/Ollama/LM Studio) and **make no
+network calls whatsoever**. (`references/developer/installation.md`,
+`references/developer/models.md`, `references/developer/configuration.md`)
+
+### 8.2 Model requirements & GPU/Strix-Halo constraints
+
+- **LLM (write path, the bottleneck).** Fact extraction is structured, so a small
+  fast model suffices — docs explicitly recommend `gpt-oss-20b`; the built-in
+  llamacpp default is **Gemma 4 E2B**. Caveat: arbitrary models must support
+  **≥65,000 output tokens** for reliable extraction, else set
+  `HINDSIGHT_API_RETAIN_MAX_COMPLETION_TOKENS` lower (must stay >
+  `RETAIN_CHUNK_SIZE`, default 3000). `none` is a valid provider value (recall-only,
+  no LLM). (`references/developer/models.md`, `references/developer/configuration.md`)
+- **Built-in llama.cpp knobs:** `HINDSIGHT_API_LLAMACPP_MODEL_PATH`,
+  `…_GPU_LAYERS` (`-1` = all to GPU, `0` = CPU-only), `…_CONTEXT_SIZE` (8192),
+  `…_CHAT_FORMAT` (auto), `…_NO_GRAMMAR`, `…_EXTRA_ARGS`. Requires the `local-llm`
+  pip extra (`pip install 'hindsight-api-slim[local-llm]'`); the published Docker
+  image does **not** bundle `llama-cpp-python` (use the `docker-compose/local-llm/`
+  recipe). (`references/developer/configuration.md`)
+- **GPU is optional everywhere.** "2 vCPUs on CPU-only is fine for development and
+  basic workloads." The only GPU-sensitive component is the **local reranker
+  (cross-encoder)** on the read path — under production traffic it benefits from a
+  GPU or an external reranker. (`references/developer/installation.md`)
+- **Strix-Halo specifics (hal0): the docs make no mention of AMD ROCm / iGPU /
+  XDNA NPU acceleration.** The local embedder/reranker run on PyTorch/ONNX;
+  llamacpp's `GPU_LAYERS` assumes a llama.cpp build with the right backend.
+  Whether hal0's iGPU/NPU (via the existing Lemonade/ROCm stack) accelerates these
+  is **not addressed by Hindsight docs** — for hal0, the safe default is CPU-only
+  embedder+reranker, and route the heavy LLM extraction to hal0's existing
+  Lemonade-served local model via the **OpenAI-compatible / Ollama / LM Studio
+  provider** (point `HINDSIGHT_API_LLM_BASE_URL` at lemond:13305) rather than
+  Hindsight's bundled llamacpp. (Inference, not Hindsight's responsibility —
+  flagged in Gaps.) There is even a `jina-mlx` reranker for Apple-Silicon local
+  inference, underscoring that hardware-specific accel is opt-in per provider.
+  (`references/developer/models.md`)
+
+### 8.3 Footprint & images
+
+| Variant | RAM (min/rec) | Image size | Notes |
+|---------|---------------|------------|-------|
+| **Full** (`:latest`) | 1.5 / 2 GB | ~9 GB AMD64, ~3.7 GB ARM64 | Bundles local embedder + reranker; works out of the box (only the LLM is external) |
+| **Slim** (`:slim` / `hindsight-api-slim`) | 0.5 / 1 GB | ~500 MB | No local models — requires external embedding + reranker providers (TEI/OpenAI/Cohere) |
+
+(`references/developer/installation.md`)
+
+### 8.4 Deployment modes
+
+- **Docker** (single container, embedded pg0): API on `:8888`, Control Plane UI on
+  `:9999`; persist `~/.hindsight-docker:/home/hindsight/.pg0`. Images Cosign-signed
+  (keyless OIDC). Tags: `hindsight`, `hindsight-api`, `hindsight-control-plane`
+  (+ `-slim`).
+- **Helm/K8s** (`oci://ghcr.io/vectorize-io/charts/hindsight`): built-in or external
+  Postgres; optional dedicated worker StatefulSet (`worker.enabled`,
+  `worker.replicaCount`).
+- **pip** (`hindsight-api` / `hindsight-api-slim`): `hindsight-api` CLI
+  (`--port/--host/--workers/--log-level`); embedded pg0 by default or external
+  `HINDSIGHT_API_DATABASE_URL`.
+- **Embedded-in-Python** (`hindsight-all` / `-slim`): `HindsightServer`
+  (in-process background thread) or `HindsightEmbedded` (managed subprocess daemon,
+  idle-timeout auto-shutdown, shared across processes).
+- **Windows** native (pg0 or external Postgres+pgvector; HF mirror for China).
+- **Hindsight Cloud** (managed SaaS at `api.hindsight.vectorize.io`) — the only
+  thing hal0 should *avoid* if it wants air-gapped operation.
+
+(`references/developer/installation.md`)
+
+### 8.5 The local MCP server (`hindsight-local-mcp`)  *(critical for agent wiring)*
+
+A one-command, fully-local MCP server with embedded Postgres:
+
+```bash
+HINDSIGHT_API_LLM_API_KEY=sk-... uvx --from hindsight-api hindsight-local-mcp
+# Local LLM, no API key:
+HINDSIGHT_API_LLM_PROVIDER=ollama HINDSIGHT_API_LLM_MODEL=llama3.2 uvx --from hindsight-api hindsight-local-mcp
+```
+
+- **HTTP transport** (not stdio), endpoint `http://localhost:8888/mcp/`.
+- Data persists in `~/.pg0/hindsight-mcp/`; first run downloads the ~100 MB
+  embedder + inits the DB.
+- Multi-bank mode (default, `bank_id` per request or `X-Bank-Id` header) or
+  single-bank (`/mcp/<bank-id>/`).
+- Exposes 29 tools (multi-bank) / 26 (single-bank).
+
+The general MCP server is built into the API (enabled by default, mounted at
+`/mcp`, disable with `HINDSIGHT_API_MCP_ENABLED=false`). Per-bank endpoints:
+`/mcp/{bank_id}/`. Bank resolution priority: URL path > `X-Bank-Id` header >
+`HINDSIGHT_MCP_BANK_ID` (default `default`). Auth is **open by default**; enable
+the `ApiKeyTenantExtension` (`HINDSIGHT_API_TENANT_API_KEY`) to require
+`Authorization: Bearer …`. Single-bank mode exposes 27 tools; multi-bank exposes
+~30 incl. `list_banks`/`create_bank`/`get_bank_stats`. Full tool list:
+retain, sync_retain, recall, reflect, mental-model CRUD + refresh + clear,
+directives CRUD, list/get memory, list/get/delete document, list/get/cancel
+operation, list_tags, get/update/delete bank, clear_memories.
+(`references/developer/mcp-server.md`; `[web: /sdks/integrations/local-mcp]`)
+
+---
+
+## 9. Integrations — MCP, Hermes, Claude Code (the three hal0 must support)
+
+### 9.1 MCP (Model Context Protocol)
+
+The canonical wiring surface. Built-in HTTP MCP server (§8.5). Add to Claude
+Code:
+
+```bash
+claude mcp add --transport http hindsight http://localhost:8888/mcp/
+# with auth:
+claude mcp add --transport http hindsight http://localhost:8888/mcp \
+  --header "Authorization: Bearer your-secret-key" --header "X-Bank-Id: my-bank"
+```
+
+Per-bank isolation via URL path or `X-Bank-Id`. Per-bank `mcp_enabled_tools`
+allowlist restricts which tools a connection can call. Custom MCP tools can be
+added without forking via the `MCPExtension`
+(`HINDSIGHT_API_MCP_EXTENSION=pkg.mod:Class`).
+(`references/developer/mcp-server.md`, `references/developer/extensions.md`)
+
+### 9.2 Hermes (Hermes Agent framework)  `[web: /sdks/integrations/hermes]`
+
+Hindsight plugs into Hermes via the `hermes_agent.plugins` entry point.
+Behaviour:
+
+- **Auto-recall** (`pre_llm_call` hook): query memories, inject as ephemeral
+  system-prompt context.
+- **Auto-retain** (`post_llm_call` hook): store the user/assistant exchange.
+- **Three explicit tools:** `hindsight_retain`, `hindsight_recall`,
+  `hindsight_reflect`.
+
+Setup: `hermes memory setup` → choose "hindsight"; verify `hermes memory status`;
+disable Hermes's built-in memory tool (`hermes tools disable memory`) to avoid
+conflicts. Manual config:
+
+```
+hermes config set memory.provider hindsight
+echo "HINDSIGHT_API_KEY=your-key"  >> ~/.hermes/.env
+echo "HINDSIGHT_API_URL=https://api.hindsight.vectorize.io" >> ~/.hermes/.env
+```
+
+Modes: **cloud** (API key) or **local** (embedded server + built-in Postgres,
+needs an LLM key, daemon auto-starts on a configurable port, default **9077**).
+Integration modes: `hybrid` (default, auto + tools), `context` (auto only),
+`tools` (explicit only). Env knobs: `HINDSIGHT_MODE`, `HINDSIGHT_AUTO_RECALL`,
+`HINDSIGHT_AUTO_RETAIN`, `HINDSIGHT_RECALL_BUDGET`. Works with Hermes Gateway
+(Telegram/Discord/Slack) with per-message recall.
+
+> **hal0 note:** hal0's bundled Hermes-Agent would point `HINDSIGHT_MODE=local`
+> (or `HINDSIGHT_API_URL` at a self-hosted Hindsight in CT 105) — *not* the
+> vectorize cloud. The `local` mode's embedded daemon on `:9077` collides
+> conceptually with hal0's existing port map; prefer pointing Hermes at a
+> standalone self-hosted Hindsight API rather than its auto-embedded daemon.
+
+### 9.3 Claude Code  `[web: /sdks/integrations/claude-code]`
+
+Installed as a Claude plugin:
+
+```
+claude plugin marketplace add vectorize-io/hindsight
+claude plugin install hindsight-memory
+```
+
+Connection modes: external API (`hindsightApiUrl` + `hindsightApiToken`), local
+auto-managed daemon (needs `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`/
+`HINDSIGHT_LLM_PROVIDER=claude-code`), or auto-detect an existing
+`hindsight-embed` on **port 9077**. Config in `~/.hindsight/claude-code.json`
+(precedence: defaults → plugin → user config → env).
+
+Behaviour:
+- **Auto-recall** on every prompt → injected as invisible `additionalContext`
+  (`recallBudget` default `mid`, `recallMaxTokens` 1024).
+- **Auto-retain** after responses / every N turns (`retainEveryNTurns` default
+  10; SessionEnd flush).
+- **Knowledge tools** (`enableKnowledgeTools`, default off): `agent_knowledge_*`
+  MCP tools (`agent_knowledge_recall`, `_ingest`, `_create_page`, page list/get).
+- **`/hindsight-memory:create-agent`** skill scaffolds a new agent with isolated
+  memory (understands SDA project layouts).
+- **Bank selection:** static `bankId` default `claude_code`, or **dynamic**
+  (`dynamicBankId: true` + `dynamicBankGranularity` over `agent`/`project`/
+  `session`/`channel`/`user`); explicit directory→bank mapping + Git-worktree
+  support; `{user_id}` template variable for retain tags; recall from additional
+  banks alongside the primary. Tool calls retained as structured JSON.
+
+Env knobs mirror Hermes: `HINDSIGHT_AUTO_RECALL`, `HINDSIGHT_RECALL_BUDGET`,
+`HINDSIGHT_RECALL_MAX_TOKENS`, `HINDSIGHT_AUTO_RETAIN`,
+`HINDSIGHT_ENABLE_KNOWLEDGE_TOOLS`. The Claude-Code integration now **defaults
+recall types to observations** (changelog 0.7.0).
+(`references/changelog/integrations/claude-code.md`; `[web: /sdks/integrations/claude-code]`)
+
+> **Broader integration ecosystem** (changelog lists, not all detailed): AG2,
+> AgentCore, AI SDK, AutoGen, CrewAI, Dify, Flowise, LangGraph, **LiteLLM**,
+> LlamaIndex, n8n, OpenAI Agents, OpenClaw/NemoClaw, OpenCode, Codex, Pydantic-AI,
+> Smolagents, Strands, Pipecat, Vapi, Cloudflare OAuth proxy. LiteLLM is doubly
+> relevant to hal0 (gateway already in the stack at CT 200) — Hindsight both *uses*
+> LiteLLM as an LLM/embedding/reranker provider and *integrates* into a
+> LiteLLM-fronted pipeline. (`references/changelog/integrations/`)
+
+---
+
+## 10. Best practices & anti-patterns (headline guidance)
+
+**Do:**
+- Configure missions before ingesting — be specific about domain + *what to
+  ignore*; vague missions are the #1 cause of noisy memories.
+- Pass the richest representation (conversation JSON > prefixed text >
+  pre-summarized — never pre-summarize).
+- Always set `context`; always set `timestamp` (omitting it disables temporal
+  ranking); use stable `document_id` for upsert.
+- Multi-tenant: tag every user retain with at least `user:<id>` and recall with
+  `any_strict`/`all_strict` (plain `any` leaks across users). Naming conventions:
+  `user:`, `session:`, `team:`, `topic:`, `scope:`.
+- Use `tag:true` entity labels to hard-filter semantically-similar-but-distinct
+  memory shapes (rules vs procedures).
+- One mental model per knowledge dimension (not "everything about the user").
+- Default recall `budget=mid`; reserve `high` for explicit deep flows.
+- Enable `include.facts` in production for audit trails.
+- Retain end-of-turn, recall at start of next turn — never retain+recall in the
+  same turn (writes aren't indexed yet).
+
+**Anti-patterns:** pre-summarizing; random-UUID `document_id` (creates dupes);
+omitting `context`; using `metadata` for filtering (it's not filterable — use
+tags); `tags_match=any` for multi-tenant banks; retain+recall same request; one
+mega mental model; `high` budget for every recall; missing `timestamp`.
+(`references/best-practices.md`)
+
+---
+
+## 11. hal0 relevance — feature-by-feature
+
+| Hindsight feature | How it plugs into hal0 (self-hosted agent platform) |
+|-------------------|------------------------------------------------------|
+| **Fully-local stack (pg0 + local embedder/reranker + local LLM)** | Core fit: run the API in CT 105 with embedded Postgres + local BGE/MiniLM, point the LLM at hal0's Lemonade-served model via the OpenAI-compatible/Ollama provider. No cloud calls. |
+| **retain/recall/reflect** | The three verbs map cleanly onto hal0's memory/agent layer; reflect's structured-output + citations suit the dashboard's audit/inbox surfaces. |
+| **Observations + freshness** | Gives hal0 evolving per-agent beliefs (e.g. "user switched stacks") for free — no app-side consolidation logic. |
+| **Memory banks** | One bank per hal0 agent / per user — natural isolation; auto-create means zero provisioning friction. |
+| **Bank templates** | Ship hal0-curated templates (coding-agent, personal-assistant, support) as JSON manifests; one `import` call provisions an agent's memory persona; export = portable agent personality. |
+| **Documents + chunks** | Source traceability for ingested files/conversations; deep-link memories back to hal0 sources via `metadata`. |
+| **Operations API + admin CLI** | Drives async-job polling already standardized in hal0 (PLAN §9 "poll-to-terminal"); `backup/restore` + `worker-status`/`decommission-*` fit hal0's ops/runbook discipline. |
+| **Webhooks** | `consolidation.completed` / `retain.completed` can drive hal0 dashboard live updates / journal events; HMAC-signable. (But registration API is env-only locally — verify per-bank registration.) |
+| **TEMPR retrieval (esp. pgroonga/pg_search)** | Multilingual/CJK BM25 backends matter if hal0 serves non-English; otherwise `native` + local pipeline is enough. |
+| **Built-in MCP server** | hal0's MCP host platform (the `/agents` view) can register Hindsight's `/mcp/{bank_id}/` as an aftermarket MCP server per agent — exactly hal0's "host arbitrary MCP servers" model. Per-bank `mcp_enabled_tools` = capability gating. |
+| **Hermes integration** | hal0 bundles Hermes-Agent — wire `HINDSIGHT_MODE=local`/self-hosted URL, `hybrid` mode, disable Hermes's built-in memory tool. |
+| **Claude Code integration** | hal0 dev workflows (Claude Code) get persistent project memory via the plugin pointed at the self-hosted API; dynamic per-project banks + Git-worktree mapping fit hal0's worktree-heavy agent dispatch. |
+| **Extensions (Tenant/Http/MCP/Validator)** | hal0 can add its own auth (X-hal0-Agent header → custom TenantExtension), rate limits (OperationValidator), and bespoke MCP tools without forking. |
+| **Monitoring (Prometheus `/metrics` + OTel)** | Drops into hal0's existing Prometheus/Grafana expectations; metric names like `hindsight_recall_duration_seconds`. |
+| **Slim image** | If hal0 wants Hindsight tiny + offloads embed/rerank to existing hal0 capability slots (TEI-style), the 500 MB slim image is the play. |
+
+---
+
+## Gaps & ambiguities (do NOT assume)
+
+1. **Strix-Halo / ROCm / NPU acceleration is undocumented.** Hindsight docs never
+   mention AMD iGPU, ROCm, or XDNA. The local embedder/reranker run on PyTorch/ONNX
+   and llamacpp `GPU_LAYERS` needs an appropriately-built llama.cpp. **Don't assume
+   hal0's iGPU/NPU accelerates Hindsight's local models** — plan CPU embed/rerank
+   and route LLM extraction to hal0's Lemonade-served model via an
+   OpenAI-compatible/Ollama provider. Validate empirically.
+2. **Webhook registration API.** The webhooks page says webhooks are "registered
+   per memory bank" but the shipped skill only documents *server-wide env-var*
+   config and the two event types. A per-bank webhook CRUD REST endpoint, if it
+   exists, was not in the local skill — verify against `openapi.json` / live API
+   before designing per-agent webhook fan-out.
+3. **Bank-template `entity_labels` form mismatch.** Template manifest lists
+   `entity_labels` as `string[]`; bank-config documents rich label-group objects.
+   Also `retain_extraction_mode: chunks` appears only in the template schema.
+   Confirm what the importer accepts.
+4. **Templates Hub field values.** `/templates` names three templates but doesn't
+   publish each one's full mission/disposition/mental-model bodies on the landing
+   page — fetch individual entries for exact contents.
+5. **"Docs feature" = Documents (provenance), not a separate served corpus.** The
+   richer "knowledge pages" concept is **Claude-Code-integration-layer** only, not
+   core API. Don't conflate.
+6. **Hermes/Claude-Code integration details are live-doc-only** (not in the local
+   skill) and are summarized from a single fetched page each; versions move fast
+   (Claude-Code at 0.7.0). Re-verify exact config keys at integration time.
+7. **`hindsight-control-plane`** UI is a separate Next.js process; if hal0 exposes
+   it, note it emits its own routes (treat like any standalone web UI — own
+   port/subdomain).
+8. Local skill **does not ship** `references/cookbook/**` or
+   `references/sdks/integrations/**` (only the changelog stubs exist locally);
+   recipe-level patterns were not available offline.

--- a/docs/internal/brain-redesign/02-hal0-wiki-research.md
+++ b/docs/internal/brain-redesign/02-hal0-wiki-research.md
@@ -1,0 +1,508 @@
+# hal0-wiki Research Dossier
+
+> Research target: **`Hal0ai/hal0-wiki`** — a fork of **`ar9av/obsidian-wiki`**, an
+> implementation of Andrej Karpathy's "LLM Wiki" pattern as a set of agent skill files.
+> Studied via the GitHub API at HEAD commit `ba60beda` ("fix(cli): warn when installed
+> skills are stale after upgrade (#77)"). Written as input to the hal0 brain/memory redesign.
+
+---
+
+## 0. TL;DR
+
+`obsidian-wiki` (the pip package; the fork is `hal0-wiki`) is **not an application or a daemon**.
+It is a **distribution of markdown "skill" files** plus a thin, pure-stdlib Python CLI whose only
+job is to *install* those skills into the skill-discovery directories of a long list of AI coding
+agents (Claude Code, Cursor, Windsurf, Codex, Gemini, **Hermes**, **Pi**, OpenClaw, Kiro, Copilot,
+and more). Once installed, you point an agent at an Obsidian vault and say **"set up my wiki"**, and
+from then on the agent *is* the runtime: it reads source material, distills it into interconnected
+Obsidian-flavored markdown pages, keeps an index/log/manifest current, and answers questions out of
+the compiled pages instead of re-doing retrieval every time.
+
+The pattern, per Karpathy: **the wiki is a compiled, compounding artifact; the LLM is the maintainer;
+Obsidian is the viewer/IDE; the human curates sources and asks questions.** "Compile, don't retrieve."
+
+**Fork status (important):** as of this writing the `Hal0ai/hal0-wiki` fork is **byte-for-byte
+identical to upstream** — `git compare` reports `status: identical, ahead_by: 0, behind_by: 0`, the
+README is identical, and HEAD is the same upstream commit authored by "Arnav". The only "Hal0'd"
+change so far is the GitHub repo *description* ("Hal0'd - Framework for AI agents…") and the repo
+rename. No code or skill divergence exists yet; the fork is a staging point for hal0 integration.
+
+---
+
+## 1. What it actually is
+
+### 1.1 The pip package `obsidian-wiki`
+
+- **Name / entrypoint:** `obsidian-wiki` (PyPI), console script `obsidian-wiki = obsidian_wiki.cli:main`.
+- **Dependencies:** **none.** `pyproject.toml` declares `dependencies = []` — a *pure-stdlib CLI*.
+  "Installing skills needs no third-party runtime dependencies." Python `>=3.9`. License MIT.
+- **Versioning:** CalVer derived from the git tag via `hatch-vcs` (e.g. `v2026.05.2 → 2026.5.2`).
+  Tagging a release *is* the version bump. `__init__.py` reads the version via
+  `importlib.metadata.version("obsidian-wiki")`, falling back to `0.0.0+dev` in a source tree.
+- **What ships in the wheel:** The Python package (`obsidian_wiki/`) is *just the installer*. The
+  actual product — the `.skills/` markdown tree plus the agent bootstrap files (`AGENTS.md`, Cursor
+  rules, Windsurf rules, Kiro steering, Antigravity rules/workflows, Copilot instructions) — is
+  **force-included** into the wheel under `obsidian_wiki/_data/` (`_data/skills/`,
+  `_data/bootstrap/…`). So the installed package is self-contained and can install skills with no
+  cloned repo. Source paths stay at the repo root as the single source of truth.
+
+The Python module docstring states the design plainly: *"The product is the markdown skill content
+under `.skills/` (bundled into this package as data). This module is just the installer CLI."*
+
+### 1.2 The CLI (`setup`, `list`, `info`)
+
+`obsidian_wiki/cli.py` (the Python port of `setup.sh`) exposes three subcommands; with no subcommand
+it defaults to `setup`:
+
+| Command | What it does |
+|---|---|
+| `obsidian-wiki setup` | Writes `~/.obsidian-wiki/config` (vault path + bundled-data root + version stamp) and installs every bundled skill into **every supported agent's** global skills directory under `$HOME`. Flags: `--vault PATH`, `--project [DIR]` (also drop project-local skills + bootstrap/`AGENTS.md` into a repo), `--project-only` (skip the global install), `--copy` (copy instead of symlink). |
+| `obsidian-wiki list` | Prints the bundled skill names (one per line). |
+| `obsidian-wiki info` | Prints version, resolved skills/bootstrap/config paths, vault path, "setup ran" version, bundled skill count, and a **per-agent install status** line (`N/38`) so you can see at a glance whether `setup` has been run for each agent. |
+
+There is **no server, no daemon, no API**. The CLI runs once to wire up skill discovery and exits.
+The only "runtime" is the AI agent reading the markdown.
+
+A staleness guard (`_check_stale()`, added in HEAD commit #77) stamps `OBSIDIAN_WIKI_VERSION` into
+`~/.obsidian-wiki/config` on each `setup`; later CLI invocations warn if the installed version
+drifted from the stamped one, or if `~/.claude/skills/` is missing bundled skills.
+
+### 1.3 How it installs skill files into agents (symlink-vs-copy)
+
+The core install primitive (`install_skills(target_dir, …, mode="symlink"|"copy")`) iterates the
+bundled `.skills/<name>/` folders and, for each, creates `target_dir/<name>`:
+
+- **symlink mode (default):** `target_dir/<name>` → the installed package's skill folder. The payoff:
+  *"Skills are symlinked to the installed package, so `pip install -U obsidian-wiki` upgrades them
+  everywhere — just re-run `obsidian-wiki setup` to pick up new skills."* (The shell `setup.sh`
+  variant emits *relative* `../`-prefixed symlinks for project-local dirs so they match the committed
+  symlink mirrors; the pip CLI uses absolute symlinks since there's no repo.)
+- **copy mode (`--copy`):** `shutil.copytree` the skill folder. For symlink-hostile filesystems.
+- **Safety:** an existing symlink/file at the target is replaced; a *real* directory is replaced only
+  if it contains a `SKILL.md` (i.e. it's a managed skill) — otherwise it's left alone ("not a managed
+  skill, skipping"). Every install is sanity-checked by confirming `…/<name>/SKILL.md` resolves.
+
+**Per-agent global targets** (`GLOBAL_AGENT_DIRS` in the CLI): `~/.claude/skills`, `~/.gemini/skills`,
+`~/.gemini/antigravity/skills`, `~/.codex/skills`, **`~/.hermes/skills`**, `~/.openclaw/skills`,
+`~/.copilot/skills`, `~/.trae/skills`, `~/.trae-cn/skills`, `~/.kiro/skills`, **`~/.pi/agent/skills`**,
+and `~/.agents/skills` (the shared AGENTS.md discovery path for OpenCode/Aider/Droid/generic).
+For Hermes it additionally walks `$HERMES_HOME` and every profile under `~/.hermes/profiles/*/skills/`.
+(The shell `setup.sh` notably installs **only the two portable skills** — `wiki-update`, `wiki-query`
+— into `~/.claude/skills`, whereas the pip CLI installs *all* skills there, since pip users have no
+cloned repo to host project-scoped skills.)
+
+**Agent bootstrap / context files** (one per agent's convention), copied by `install_project()`:
+`AGENTS.md` (Codex, OpenCode, Aider, Droid, Trae, Hermes, OpenClaw, Pi, Kilocode), Cursor
+`.cursor/rules/obsidian-wiki.mdc` (`alwaysApply: true`), Windsurf `.windsurf/rules/…`, Kiro
+`.kiro/steering/…` (`inclusion: always`), Antigravity `.agent/rules/…` + `.agent/workflows/…`,
+GitHub `.github/copilot-instructions.md`. Then **`CLAUDE.md`, `GEMINI.md`, and `.hermes.md` are
+created as symlinks to `AGENTS.md`** (single source of truth; copy fallback on symlink-hostile FS).
+
+So the model is: **write each skill once in `.skills/`, and `setup` fans it out (by symlink) to every
+agent's idiosyncratic discovery path.** Slash commands (`/wiki-ingest`, `/wiki-status`, …) work in
+agents that auto-register skills as commands; elsewhere the user just describes intent and the agent's
+skill-router matches it.
+
+---
+
+## 2. The LLM Wiki pattern (Karpathy)
+
+The bundled `llm-wiki/SKILL.md` is the "theory" skill, and `references/karpathy-pattern.md` distills
+the gist. Karpathy's framing (from the original gist) and how this framework operationalizes it:
+
+### 2.1 Core insight
+
+> *"The wiki is a persistent, compounding artifact. The knowledge is compiled once and then kept
+> current, not re-derived on every query."*
+
+The roles invert relative to a chatbot: **the human curates sources and asks questions; the LLM does
+the bookkeeping** (summarizing, cross-referencing, updating pages when new sources arrive, touching
+10–15 pages per ingest). Karpathy's analogy: **"Obsidian becomes the IDE, the LLM becomes the
+programmer/grunt-worker, and the wiki becomes the codebase."** He grounds it in Vannevar Bush's 1945
+Memex — a private associative knowledge store whose unsolved problem was *who maintains it*; the LLM
+is the answer. The failure mode of human wikis is that *"the maintenance burden grows faster than the
+value"* — LLMs flatten that cost toward zero ("doesn't get bored, doesn't forget to update a
+cross-reference, can touch 15 files in one pass").
+
+### 2.2 Why it beats RAG
+
+Traditional RAG **rediscovers** knowledge on every query (search raw sources → pull chunks →
+synthesize from scratch). The LLM Wiki **compiles** knowledge once into maintained, cross-referenced
+pages, so queries hit pre-synthesized content. Karpathy notes a magnitude threshold: under ~100k
+tokens (~150–200 dense pages), context-based wikis beat RAG on retrieval reliability (no chunking
+artifacts), infrastructure (plain markdown, no vector DB / embedding pipeline), and **global
+reasoning** (the model reasons over the whole synthesis, not stitched snippets). Modern 200k–1M
+context windows push that ceiling up yearly. (This framework adds optional QMD semantic search to
+extend past the threshold — §4.4.)
+
+### 2.3 Three-layer architecture
+
+1. **Layer 1 — Raw Sources (immutable):** the user's original docs, papers, notes, PDFs, conversation
+   logs, bookmarks, **and images** (screenshots/whiteboards/diagrams — first-class, vision-model
+   required). Never modified. The "source code". Configured via `OBSIDIAN_SOURCES_DIR`.
+2. **Layer 2 — The Wiki (LLM-maintained):** interconnected Obsidian markdown organized by category;
+   the *compiled* knowledge — synthesized, cross-referenced, navigable. Lives at `OBSIDIAN_VAULT_PATH`.
+3. **Layer 3 — The Schema (skill + config):** the rules governing structure (categories, conventions,
+   page templates, workflows). Tells the LLM *how* to maintain the wiki. In Karpathy's setup this was
+   `CLAUDE.md`; here it's the skill files + `.env`/global config + the vault's own `AGENTS.md`.
+
+### 2.4 Vault structure & note types
+
+```
+$OBSIDIAN_VAULT_PATH/
+├── index.md          # Master content-catalog by category; rebuilt after every ingest
+├── log.md            # Append-only, parseable chronological op log (INGEST/QUERY/LINT/ARCHIVE…)
+├── hot.md            # ~500-word semantic "hot cache" of recent activity (warm-start next session)
+├── .manifest.json    # Ledger of every ingested source → pages produced (delta backbone)
+├── _meta/            # taxonomy.md (controlled tag vocab) + *.base (Obsidian Bases dashboards)
+├── _insights.md      # Graph analysis output (hubs, bridges, dead ends)
+├── _raw/             # Staging area — drop rough notes; next ingest promotes + deletes them
+├── _staging/         # Review queue when WIKI_STAGED_WRITES=true (invisible in graph until promoted)
+├── _archives/        # Timestamped wiki snapshots (rebuild/restore)
+├── concepts/         # Abstract ideas, patterns, mental models
+├── entities/         # Concrete things — people, tools, libraries, companies
+├── skills/           # How-to knowledge, techniques, procedures
+├── references/       # Factual lookups / per-source summaries
+├── synthesis/        # Cross-cutting analysis connecting multiple concepts
+├── journal/          # Time-bound entries — daily logs, session notes
+└── projects/<name>/  # Per-project knowledge (overview page named <name>.md, not _project.md)
+```
+
+**Two axes of organization:** *categories* (what kind of knowledge) × *projects* (where it came from).
+Project-specific knowledge goes under `projects/<name>/<category>/`; general knowledge goes in the
+global category dirs; both cross-link with `[[wikilinks]]`.
+
+### 2.5 Page template, wikilinks/backlinks, provenance, confidence
+
+Every page carries **required frontmatter**: `title`, `category`, `tags`, `sources`, `created`,
+`updated`. The richer template adds:
+- `summary:` — 1–2 sentences ≤200 chars, written at ingest so queries can preview without opening.
+- `aliases:` and a typed **`relationships:`** block (`extends`, `implements`, `contradicts`,
+  `derived_from`, `uses`, `replaces`, `related_to`) — directional, semantic edges beyond plain links.
+- **`provenance:`** mix (`extracted` / `inferred` / `ambiguous` fractions). Inline claim markers:
+  default = extracted (no marker), `^[inferred]` for LLM synthesis, `^[ambiguous]` for source conflict.
+  *"A wiki that hides its guessing rots silently; one that marks it stays trustworthy."*
+- **`base_confidence`** (0–1, from source count × source-quality buckets: paper 1.0 → llm_generated
+  0.3), **`lifecycle`** (`draft|reviewed|verified|disputed|archived` — only ingest sets `draft`; all
+  other transitions are human-only; `stale` is a *computed overlay*, `updated > 90d`), and **`tier`**
+  (`core|supporting|peripheral`) controlling which pages get touched per ingest and query priority.
+
+**Index notes / MOCs:** `index.md` is the master Map-of-Content, regenerated after each ingest; each
+project gets an overview MOC page that links out to relevant concept/entity/skill pages. Wikilinks
+are bidirectional in Obsidian (backlinks panel + graph view), which is what makes it a knowledge
+*graph* rather than a folder of files. Link format is configurable (`OBSIDIAN_LINK_FORMAT=wikilink`
+default, or `markdown`).
+
+### 2.6 The maintainer/viewer split, in practice
+
+The framework's mantra (from SETUP.md): **"The wiki is the artifact. The agent is the maintainer.
+Obsidian is the viewer."** No scripts, no API keys — *the agent **is** the LLM*. It reads `.env`/config,
+reads `.manifest.json` to know what's done, reads the relevant `SKILL.md`, uses its built-in
+read/write/search tools, and updates the manifest. Output is plain Obsidian-compatible markdown.
+
+### 2.7 The four-stage ingest loop
+
+Every ingest runs: **(1) Ingest** the source directly (md/PDF/JSONL/text/images, no preprocessing) →
+**(2) Pull Information** (concepts, entities, claims, relationships, open questions; drop noise; write
+a `summary:`) → **(3) Merge** against existing pages (update, don't duplicate; note contradictions;
+strengthen cross-refs; track sources) → **(4) Schema** (the schema *emerges* and evolves from sources;
+keep categories consistent, links valid, index accurate). `.manifest.json` enables **delta** ingest:
+on the next run only new/changed sources are processed.
+
+---
+
+## 3. The bundled skills (full enumeration)
+
+Skills live as `.skills/<name>/SKILL.md` (each with YAML frontmatter `name` + `description`, the
+`description` doubling as the trigger/router text). The canonical set is mirrored by `setup` into
+every agent dir. `obsidian-wiki info` at HEAD reports **38** bundled skills. Below is the full set,
+what each does, and its trigger phrases / slash command (drawn from the `AGENTS.md` skill-routing
+table and each skill's own description).
+
+### 3.1 Setup / theory
+
+| Skill | What it does | Triggers |
+|---|---|---|
+| `llm-wiki` | The core pattern + architecture reference (theory skill). Three-layer arch, page templates, project org, config-resolution protocol. | "/llm-wiki", understanding the pattern, structure decisions |
+| `wiki-setup` | Initialize a vault: create dir structure, `index.md`/`log.md`/`hot.md`, `.obsidian/` config, `_raw/`/`_staging/`/`_archives/`, recommend plugins. | "set up my wiki", "initialize", "create a new vault", "get started" |
+| `skill-creator` | Scaffold/refine new skills (ships its own eval harness: analyzer/comparator/grader agents + scripts). | "create a new skill" |
+
+### 3.2 Ingest (sources & history)
+
+| Skill | What it does | Triggers |
+|---|---|---|
+| `wiki-ingest` | Distill documents (md/PDF/text/images) into pages, append or full mode. | "ingest", "add this to the wiki", "process these docs" |
+| `wiki-history-ingest` | Thin **router** for agent-history sources; dispatches to the per-agent skill. | "/wiki-history-ingest \<claude\|codex\|hermes\|openclaw\|copilot\|pi\>" |
+| `claude-history-ingest` | Mine `~/.claude` conversations/memories/sessions. | "import my Claude history", "mine my conversations" |
+| `codex-history-ingest` | Mine `~/.codex` sessions/rollout logs. | "import my Codex history" |
+| `hermes-history-ingest` | Mine `~/.hermes` memories + session JSONL (see §3.6). | "import my Hermes history", "ingest ~/.hermes" |
+| `openclaw-history-ingest` | Mine `~/.openclaw` `MEMORY.md`/daily notes/sessions/dreams. | "import my OpenClaw history", "ingest ~/.openclaw" |
+| `copilot-history-ingest` | Mine `~/.copilot` CLI session history. | "import my Copilot history", "ingest ~/.copilot" |
+| `pi-history-ingest` | Mine `~/.pi/agent/sessions` tree-structured JSONL (see §3.6). | "import my Pi history", "ingest ~/.pi" |
+| `data-ingest` | Ingest any raw text — ChatGPT/Slack/Discord exports, logs, transcripts. | "process this export", "ingest this data" |
+| `ingest-url` | Fetch + ingest a URL directly. | "/ingest-url \<url\>", "add this URL", "save this page" |
+| `obsidian-wiki-ingest` | Project-scoped automation wrapper around wiki-ingest (has an `ingest-wiki.sh` script). | "ingest this obsidian wiki", "ingest the obsidian-wiki project" |
+| `wiki-import` | Import a vault from a prior export (`graph.json` etc.). | "import wiki", "load graph.json", "/wiki-import" |
+| `wiki-quick-chat-capture` | Zero-friction mid-session finding capture to `_raw/` (no subagents/manifest writes; <60s). | "/wiki-quick-chat-capture", "quick capture", "save this gotcha", "drop to raw" |
+| `wiki-capture` | Save the current conversation as a wiki note (base_confidence 0.42). | "save this", "/wiki-capture", "file this conversation" |
+
+### 3.3 Cross-project read/write (the two portable skills)
+
+| Skill | What it does | Triggers |
+|---|---|---|
+| `wiki-update` | From *any* project: scan README/source/git-log/package metadata, distill architecture decisions/patterns/trade-offs (not code dumps), write `projects/<name>.md`, cross-link, delta via `last_commit_synced`. | "update wiki", "sync to wiki", "save this to my wiki" |
+| `wiki-query` | Answer questions from the wiki. **Tiered retrieval:** read titles/tags/`summary:` first, open bodies only when needed; "quick answer"/"just scan" forces index-only. Returns `[[wikilink]]` citations. | "what do I know about X", "find info on Y", any question |
+
+### 3.4 Maintenance / health / graph
+
+| Skill | What it does | Triggers |
+|---|---|---|
+| `wiki-status` | What's ingested/pending/the delta; **insights mode** computes hubs, bridge pages, tag-cluster cohesion, surprising connections, graph delta, suggested questions, token-footprint warning → `_insights.md`. | "what's the status", "show the delta", "wiki insights", "hubs" |
+| `wiki-lint` | Find orphans, broken links, stale content, contradictions, missing frontmatter; recompute provenance mix and flag speculation-heavy pages. | "audit", "lint", "find broken links", "wiki health" |
+| `wiki-dedup` | Find/merge duplicate pages, identity resolution, consolidation. | "dedup my wiki", "find duplicate pages", "consolidate my wiki" |
+| `wiki-rebuild` | Archive (timestamped snapshot) → rebuild from scratch → or restore a prior archive. | "rebuild", "start over", "archive", "restore" |
+| `cross-linker` | Scan vault for unlinked mentions and weave `[[wikilinks]]`/typed relationships in. | "link my pages", "cross-reference", "connect my wiki" |
+| `tag-taxonomy` | Enforce a controlled tag vocabulary (`_meta/taxonomy.md`) across the vault. | "fix my tags", "normalize tags", "tag audit" |
+| `graph-colorize` | Rewrite `<vault>/.obsidian/graph.json` `colorGroups` to tint nodes by tag/category/visibility (backs up first, colorblind-friendly palette). | "color my graph", "color code by tag/category/visibility" |
+| `wiki-export` | Export the wikilink graph to `graph.json`, `graph.graphml` (Gephi/yEd), `cypher.txt` (Neo4j), and self-contained interactive `graph.html`. | "export wiki", "export graph", "graphml", "neo4j" |
+| `wiki-dashboard` | Create dynamic Obsidian **Bases** dashboard views (`_meta/*.base`). | "create a dashboard", "vault dashboard", "show all X as a table" |
+
+### 3.5 Synthesis / digest / validation / automation
+
+| Skill | What it does | Triggers |
+|---|---|---|
+| `wiki-synthesize` | Discover and fill synthesis gaps across concepts (base_confidence = min of inputs). | "synthesize my wiki", "find connections", "what concepts keep coming up together" |
+| `wiki-research` | Autonomous multi-round web research, self-filed into the vault (often base_confidence 0.85+). | "/wiki-research [topic]", "research X", "find everything about Y" |
+| `wiki-digest` | Periodic knowledge summary. | "/wiki-digest", "what did I learn this week", "weekly digest", "monthly review" |
+| `impl-validator` | Validate an implementation against its stated goal. | "/impl-validator", "check this implementation", "is this correct?" |
+| `daily-update` | Daily maintenance cycle (freshness, index, hot cache); can install a cron/launchd job + terminal notification (see `scripts/`). | "/daily-update", "morning sync", "set up the daily cron" |
+| `wiki-switch` | Manage multiple vaults / vault configs. | "/wiki-switch NAME", "switch to my work wiki", "list my wikis" |
+| `wiki-context-pack` | (Pi-tree only) build a context pack. | (Pi-specific) |
+| `wiki-stage-commit` | (Pi-tree) review + promote `_staging/` pages when `WIKI_STAGED_WRITES=true`. | "/wiki-stage-commit" |
+
+### 3.6 Cross-tool memory (the hal0-relevant differentiators)
+
+| Skill | What it does | Triggers |
+|---|---|---|
+| `wiki-agent` | **Query-driven, topic-first** ingest from a *specific* agent's raw history — finds the relevant blobs, distills them, and returns a synthesized answer immediately. | "/wiki-claude [topic]", "/wiki-codex [topic]", "/wiki-hermes [topic]", "/wiki-openclaw [topic]", "/wiki-copilot [topic]", "/wiki-pi [topic]" |
+| `memory-bridge` | Browse/diff wiki knowledge by **which AI tool produced it** (reads `.manifest.json` `source_type` + page `sources:`). Modes: browse / search / **diff** / map. Diff surfaces *blind spots between tools* ("what does hermes know that claude doesn't") — described as "the killer feature". | "/memory-bridge", "what did codex know about X", "compare my AI tool memories", "gaps between tools" |
+
+**Hermes & Pi history ingest specifics** (relevant because hal0 bundles Hermes-Agent and forked Pi):
+- `hermes-history-ingest` reads `~/.hermes/` (`$HERMES_HOME` for non-default profiles): `memories/*.md|json`
+  (highest signal — curated persistent memories), `sessions/**/*.jsonl` (turn-by-turn transcripts),
+  and ignores `.hub/` internals and the `skills/` dir. Source types written to the manifest:
+  `hermes_memory`, `hermes_session`. base_confidence 0.42, lifecycle draft. Hard privacy filter:
+  strip secrets, redact identifiers, summarize — never dump raw transcripts.
+- `pi-history-ingest` reads `~/.pi/agent/sessions/--<cwd>--/<ts>_<uuid>.jsonl` (or
+  `$PI_HISTORY_PATH`/`PI_CODING_AGENT_SESSION_DIR`). Sessions are a **tree** of `id`/`parentId`
+  entries (first line a `session` header). It rebuilds the active branch (walk `parentId` from leaf to
+  root, reverse), extracts `message`/`compaction`/`branch_summary`/`bashExecution`, skips
+  `thinking`/`model_change`/`custom`/`label`. `compaction` and `branch_summary` are treated as
+  pre-distilled gold. Source type `pi_session`.
+
+> **Note on the `info`-reported count vs the tree:** `obsidian-wiki info` reports 38 bundled skills.
+> The repo tree shows a few skills present only under the Pi mirror or `.skills/` and not yet in the
+> generic `.agents/skills` mirror at HEAD (`wiki-context-pack`, `wiki-dedup`, `wiki-stage-commit`,
+> `wiki-import`, `wiki-quick-chat-capture`) — this is mirror drift in the committed symlink trees, not
+> a functional gap, since `setup` regenerates all mirrors from `.skills/` on install. **Ambiguity
+> flagged:** exact installed-skill count may differ slightly from the README's table depending on
+> which mirror an agent reads; trust `.skills/` as the source of truth.
+
+---
+
+## 4. Python package internals
+
+### 4.1 Module layout
+
+`obsidian_wiki/` has three files, all thin:
+- `__init__.py` — exposes `__version__` via `importlib.metadata`.
+- `__main__.py` — `python -m obsidian_wiki` → `cli.main()`.
+- `cli.py` — the whole installer (~360 LOC, stdlib only: `argparse`, `os`, `shutil`, `sys`, `pathlib`).
+
+Key functions: `skills_dir()` / `bootstrap_dir()` (resolve data in both a built wheel `_data/…` and an
+editable source checkout at the repo root), `install_skills()` (the symlink/copy primitive),
+`install_global_skills()` + `_install_hermes_profiles()`, `install_project()` (project-local skills +
+bootstrap files + `AGENTS.md` alias symlinks), `resolve_vault_path()` / `write_config()`,
+`_check_stale()`, and `cmd_setup`/`cmd_list`/`cmd_info`.
+
+### 4.2 Config — `~/.obsidian-wiki/config`
+
+Written by `write_config()`:
+```
+OBSIDIAN_VAULT_PATH="<vault>"
+OBSIDIAN_WIKI_REPO="<bundled-data-root>"   # so skills can find framework assets post-install
+OBSIDIAN_WIKI_VERSION="<version>"          # staleness stamp
+```
+**Config Resolution Protocol** (defined in `llm-wiki/SKILL.md`, obeyed by every skill): walk up from
+CWD looking for a `.env` containing `OBSIDIAN_VAULT_PATH`; else fall back to `~/.obsidian-wiki/config`;
+else prompt the user to run `wiki-setup`. After resolving, **always read
+`$OBSIDIAN_VAULT_PATH/AGENTS.md` if present** — that's the per-vault owner-conventions override.
+Vault-scoped runtime state goes to `~/.obsidian-wiki/state/<md5(vault)[:8]>/`.
+
+### 4.3 `.env.example` variables
+
+Required: `OBSIDIAN_VAULT_PATH`. Optional: `OBSIDIAN_SOURCES_DIR`, `OBSIDIAN_CATEGORIES`
+(default `concepts,entities,skills,references,synthesis,journal`), `OBSIDIAN_MAX_PAGES_PER_INGEST`
+(15), `CLAUDE_HISTORY_PATH`, `CODEX_HISTORY_PATH`, `PI_HISTORY_PATH` (+ `HERMES_HOME`, `OPENCLAW_HOME`,
+`COPILOT_HISTORY_PATH` referenced in skills), `LINT_SCHEDULE` (weekly), `OBSIDIAN_LINK_FORMAT`
+(`wikilink`/`markdown`), `OBSIDIAN_RAW_DIR` (`_raw`), `WIKI_TOKEN_WARN_THRESHOLD` (100000),
+`WIKI_STAGED_WRITES` (false). QMD block: `QMD_WIKI_COLLECTION`, `QMD_PAPERS_COLLECTION`,
+`QMD_TRANSPORT` (`mcp`/`cli`), `QMD_CLI_SEARCH_MODE` (`quality`/`balanced`/`fast`), `QMD_CLI` (binary).
+
+### 4.4 Server/daemon vs pure-CLI
+
+**Pure CLI, no daemon, no network service.** The only optional external moving part is **QMD**
+(`github.com/tobi/qmd`) — a local BM25+vector hybrid search index, addressed either via MCP or the
+local `qmd` CLI. When `QMD_WIKI_COLLECTION` is set, `wiki-query` runs a semantic pass before falling
+back to Grep; when `QMD_PAPERS_COLLECTION` is set, `wiki-ingest` checks sources before writing.
+**Without QMD everything degrades gracefully to Grep/Glob** and remains fully functional. The
+`scripts/` dir ships a macOS launchd plist + `daily-update.sh` + `wiki-notify.sh` for the optional
+daily-maintenance cron — these are the closest thing to a "background" component, and they're opt-in.
+
+---
+
+## 5. The AGENTS.md contract
+
+`AGENTS.md` (root) is the behavioral contract every AGENTS.md-aware agent loads (and `CLAUDE.md`,
+`GEMINI.md`, `.hermes.md` are symlinks to it). It imposes:
+
+1. **Self-description:** "A skill-based framework… No scripts or dependencies — everything is markdown
+   instructions that you execute directly."
+2. **Config resolution** (the protocol above) + "**always read `$VAULT/AGENTS.md` if it exists**" for
+   owner-specific conventions that override framework defaults for the session.
+3. **The vault structure** (§2.4) and **required frontmatter** (`title, category, tags, sources,
+   created, updated`).
+4. **A skill-routing table** mapping natural-language intents → skill name (the same table as the
+   `.hermes.md`/README) — this is how non-slash-command agents pick a skill.
+5. **Cross-project usage** semantics for `wiki-update` (write) and `wiki-query` (read).
+6. **Optional visibility tags** (`visibility/public|internal|pii`) — single-vault, single source of
+   truth; filtered mode is opt-in via query phrasing ("public only", "as a user would see it").
+   PII/internal pages are excluded in filtered mode. These are *system tags* (don't count toward the
+   5-tag limit).
+7. **Core principles:** *Compile, don't retrieve* · *Track everything* (manifest after ingest;
+   index/log/hot after any write) · *Connect with `[[wikilinks]]`* · *Frontmatter is required* ·
+   *Single source of truth* · *Keep context warm* (`hot.md` ≈500-word snapshot every write skill
+   updates, so the next session warm-starts without crawling the vault).
+
+In short, the contract makes the agent a **disciplined, provenance-tracking librarian**: read config →
+resolve owner conventions → route intent to a skill → execute → update the ledgers → never duplicate,
+always cross-link, always mark inferences.
+
+---
+
+## 6. What "Hal0'd" changed vs upstream
+
+**Currently: nothing functional.** Hard evidence from the GitHub API:
+
+- `gh api repos/Hal0ai/hal0-wiki/compare/ar9av:main...Hal0ai:main` → `{"ahead_by":0, "behind_by":0,
+  "total_commits":0, "status":"identical"}`.
+- HEAD commit on both is `ba60beda` ("fix(cli): warn when installed skills are stale…", #77), authored
+  by "Arnav" — i.e. an upstream commit, not a hal0 commit.
+- `README.md` is byte-identical between fork and upstream; both `pushed_at` timestamps match
+  (`2026-05-30T14:28:51Z`).
+- The fork's `pyproject.toml` still names the package `obsidian-wiki`, author `Ar9av`, homepage
+  `github.com/Ar9av/obsidian-wiki`.
+
+The **only** "Hal0'd" delta is metadata: the GitHub repo *name* (`hal0-wiki`) and *description*
+("**Hal0'd** - Framework for AI agents to build and maintain a digital brain…"). So the fork is a
+clean, up-to-date mirror staged for hal0 work — a blank canvas, not a diverged codebase. Any
+hal0-specific changes (Hermes/Pi wiring to the in-repo agents, vault location defaults, package
+rename, MCP exposure) are still **to be made**. This is the right moment to plan that divergence
+deliberately rather than discover drift later.
+
+---
+
+## 7. hal0 integration relevance
+
+This section is the point of the dossier: how `hal0-wiki` could become the **human-legible,
+compiled-knowledge layer** of the hal0 "brain", and how it sits next to a vector/structured memory
+engine.
+
+### 7.1 The fit with hal0's memory story
+
+hal0 already has an MCP memory surface (`hal0-memory`, datasets, `X-hal0-Agent` identity) and bundles
+**Hermes-Agent** plus a forked **Pi** (`Hal0ai/pi-mono`). `obsidian-wiki` is the missing *legible*
+layer: where the existing memory engine answers "what's the nearest vector to this query", the LLM
+Wiki answers "what does the system *understand* about this topic, as prose a human can read, edit, and
+audit". The two are complementary, not competing — see §7.4. Crucially, this framework already has
+**first-class Hermes and Pi ingesters** and a **`memory-bridge` diff** that surfaces cross-tool blind
+spots — exactly the multi-agent topology hal0 runs.
+
+### 7.2 Who maintains the vault (which agent)
+
+Natural owner: **Hermes-Agent on the hal0 LXC (CT 105)**, since (a) it's the bundled long-running
+agent with its own memory store, (b) `hermes-history-ingest` + `~/.hermes/skills/` install is already
+a supported path, and (c) `.hermes.md`→`AGENTS.md` is wired. A `daily-update` cron (the `scripts/`
+launchd plist would become a systemd timer on the LXC) could run the freshness/index/hot-cache cycle
+nightly. `wiki-update`/`wiki-query` (the two portable skills) let *any* hal0 agent push to / read from
+the same vault from any working directory, with the agent-of-origin tracked in `.manifest.json` for
+`memory-bridge` attribution.
+
+### 7.3 Where the vault would live
+
+hal0 runs on the **LXC at CT 105 (`/opt/hal0`, 10.0.1.142)**. The vault is *just a directory of
+markdown* — no service to host — so options:
+- **Canonical store on the LXC** under e.g. `/var/lib/hal0/wiki` (alongside `registry/`,
+  `lemonade/`), set as `OBSIDIAN_VAULT_PATH` in `~/.obsidian-wiki/config` for the agent user. This
+  keeps the brain co-located with the runtime that maintains it. Back it with `Obsidian Git`
+  (the framework recommends it) or a periodic snapshot.
+- **Human viewing:** Obsidian is a desktop app; the LXC is headless. Either (a) sync the vault to the
+  `hal0-dev` desktop VM / a user machine over the existing NFS/`devpool` or a git remote and open it in
+  Obsidian there, or (b) surface the vault read-only through the hal0 dashboard (it already serves a
+  SPA on `:8080` / `hal0.thinmint.dev`) by rendering the markdown + graph. The framework's
+  `wiki-export` → `graph.html`/`graph.json` is a ready-made, server-free way to ship the graph view
+  into the dashboard.
+- Note the **local `obsidian-vault` skill** already present on hal0-dev points at
+  `/mnt/d/Obsidian Vault/AI Research/` (a WSL/Windows path, flat layout, no projects/provenance) — it
+  is a *different, simpler* skill and should not be confused with this framework. If hal0 adopts
+  `hal0-wiki`, decide whether to retire or reconcile that local skill to avoid two competing "Obsidian"
+  conventions.
+
+### 7.4 Relationship to a vector/structured memory engine (e.g. Hindsight)
+
+The clean architecture is **two layers with one source of truth**:
+
+- **Markdown vault = source of truth + human-legible compiled knowledge.** Pages carry provenance,
+  confidence, lifecycle, typed relationships — already a structured graph in frontmatter.
+- **Vector/structured engine = the index over that vault.** This framework's *own* answer is QMD
+  ("the markdown vault is the source of truth; QMD is a search index, not the source of truth";
+  every write skill refreshes QMD after the vault write). **A hal0 integration would swap QMD for the
+  hal0 memory engine / Hindsight**: on every vault write, (re)embed the changed pages into the engine;
+  on query, do a semantic pass against the engine first, then fall back to Grep over the vault. The
+  `wiki-export` Neo4j/GraphML output and the typed `relationships:` block map directly onto a
+  structured/graph memory store if hal0 wants typed-ontology retrieval rather than (or alongside)
+  vectors.
+- **`memory-bridge` ↔ hal0's per-agent datasets:** the framework already attributes every page to the
+  tool that produced it; this lines up with hal0-memory's per-agent dataset namespacing and would let
+  the dashboard show "what each agent contributed" and "blind spots between agents".
+- **Inference policy fit:** the framework needs *no* extra inference daemon — the maintaining agent
+  uses its own LLM access. On hal0 that means the vault is maintained by whichever agent is talking to
+  the Lemonade-served models on the iGPU/NPU; CPU-only embedding for the index can run locally or via
+  the hal0 embed slot. No new always-on service is required beyond the optional nightly cron.
+
+### 7.5 Integration risks / open questions to resolve before adopting
+
+- **Headless Obsidian:** the "viewer" half assumes a desktop. hal0 needs a viewing story (dashboard
+  render or vault sync to a desktop) — decide early.
+- **QMD → Hindsight/hal0-memory swap** is a real code change: the skills hard-reference `qmd`
+  commands. Either keep QMD as the index, or fork the skills to call the hal0 memory API. This is the
+  single biggest "Hal0'd" change to plan.
+- **Vault location & backup** on the LXC (CoW/btrfs snapshot vs Obsidian Git) — pick one.
+- **Package identity:** if hal0 wants `pip install hal0-wiki` and its own version cadence, the
+  `pyproject.toml` name/author/version-source must be changed (currently still upstream's).
+- **Two Obsidian skills:** reconcile or retire the existing local `obsidian-vault` skill.
+- **Skill-mirror drift** (§3.6 note): rely on `.skills/` as source of truth; always re-run
+  `obsidian-wiki setup` after upgrades so each agent dir has the full set.
+
+---
+
+## Appendix — primary sources consulted
+
+- `Hal0ai/hal0-wiki` @ `ba60beda`: `README.md`, `AGENTS.md`, `SETUP.md`, `.hermes.md`, `pyproject.toml`,
+  `setup.sh`, `.env.example`, `obsidian_wiki/{cli,__init__,__main__}.py`, and skill files
+  `.skills/{llm-wiki, llm-wiki/references/karpathy-pattern, wiki-setup, wiki-history-ingest,
+  hermes-history-ingest, pi-history-ingest, memory-bridge, wiki-update}/SKILL.md`; full git tree.
+- Upstream comparison: `gh api …/compare/ar9av:main...Hal0ai:main` (status: identical), upstream
+  `README.md` (identical), repo metadata for both.
+- Karpathy gist: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+- Local context: `~/.claude/skills/obsidian-vault/SKILL.md` (the pre-existing, unrelated local skill).

--- a/docs/internal/brain-redesign/03-current-memory-audit.md
+++ b/docs/internal/brain-redesign/03-current-memory-audit.md
@@ -1,0 +1,538 @@
+# 03 — Current Memory / "Brain" Subsystem Audit (as-built)
+
+**Status:** audit for redesign planning
+**Date:** 2026-06-02
+**Scope:** the memory subsystem as it exists on `main` — `src/hal0/memory/`, the
+`hal0-memory` MCP server, the `/api/memory/*` REST surface, the in-process
+dispatcher, the CLI, and the Hermes `memory_cognee` plugin.
+**Engine:** Cognee `==1.0.7` (embedded SQLite + LanceDB + Kuzu), per
+[ADR-0005](../adr/0005-memory-engine-cognee.md) and
+[ADR-0014](../adr/0014-cognee-graph-extraction-model-gate.md).
+
+Everything below was verified against source. Where a behaviour is documented in
+an ADR but **not** present in code, that is called out explicitly. Citations are
+`path:line`.
+
+---
+
+## 0. TL;DR for the redesign
+
+- Cognee is wrapped behind exactly **one** seam: `CogneeWrapper`
+  (`src/hal0/memory/cognee_wrapper.py`). Every other layer (MCP, REST, dispatcher,
+  CLI, Hermes plugin, stats) calls *that wrapper's five methods* — never `cognee`
+  directly. The wrapper is the engine-swap seam.
+- But the wrapper is **not** an abstract base / Protocol. It is a concrete class.
+  There is no `MemoryProvider` ABC inside hal0 (the only ABC named that way lives
+  in the *Hermes* venv, upstream, and the hal0 plugin subclasses it — that is a
+  different, agent-side abstraction). A swap to e.g. Hindsight means writing a new
+  class with the same five async method signatures and changing the single
+  construction site in `create_app`.
+- The documented **issue #317** namespace-forcing bug ("`/api/memory/add` forces
+  `dataset="shared"`") is **FIXED** in current code (PRs #366/#369). The fix is
+  live and verifiable — see §4.1. The *risk* it represents (two transport surfaces
+  drifting on namespace logic) is now mitigated by a shared
+  `hal0.memory.namespace` module.
+- The data model is **vector-only in practice**. Graph extraction (Kuzu / cognify)
+  exists as a gated, default-OFF, fire-and-forget background task that is never
+  read back — `search` always uses `SearchType.CHUNKS` (pure vector) and falls
+  back to vector for `mode="graph"|"hybrid"`. There is also a **sidecar SQLite
+  index** that is the *real* source of truth for the rich schema (dataset, tags,
+  source, metadata, timestamp) and for all filtering.
+- Two live defects found beyond #317: (a) the Hermes REST client calls **wrong
+  route paths** for `list`/`delete` (§4.2); (b) test coverage exercises the
+  wrapper only against **fakes/stubs** — the real Cognee integration path has no
+  CI coverage outside the `tests/memory/` suite, which needs the heavy Cognee
+  fixture (§4.4).
+
+---
+
+## 1. Architecture as-built
+
+### 1.1 Layer map
+
+```
+                       ┌─────────────────────────────────────────────────────┐
+                       │                    CALLERS                           │
+                       │                                                      │
+   MCP clients ───►  /mcp/memory  (FastMCP sub-app)                          │
+   (agents)            │  hal0.mcp.memory.build_server                        │
+                       │                                                      │
+   MCP admin ──────► hal0.mcp.admin  ──► MemoryDispatcher (in-process)        │
+   (memory_* tools)    │  hal0.dispatcher.memory_dispatcher                   │
+                       │                                                      │
+   HTTP / Hermes ───► /api/memory/{add,search,list,delete}  (REST shims)      │
+   / CLI / dashboard   │  hal0.api.routes.memory                              │
+                       │                                                      │
+   dashboard sidebar ─► /api/agents/{id}/memory/stats                         │
+                       │  hal0.api.agents.memory_stats                        │
+                       └───────────────────────┬──────────────────────────────┘
+                                               │  all paths converge on…
+                            ┌──────────────────▼──────────────────┐
+                            │  hal0.memory.namespace               │
+                            │  resolve_write_dataset / read_datasets│ (pure fns)
+                            └──────────────────┬──────────────────┘
+                                               │
+                            ┌──────────────────▼──────────────────┐
+                            │  CogneeWrapper  (THE SEAM)           │
+                            │  add / search / list_items / delete  │
+                            │  + graph_status / set_graph_enabled  │
+                            │  + set_rerank_enabled                │
+                            └───────┬───────────────────┬─────────┘
+                                    │                   │
+                  ┌─────────────────▼──┐      ┌─────────▼───────────────────┐
+                  │ cognee 1.0.7        │      │ sidecar SQLite              │
+                  │  - LanceDB (vector) │      │  hal0_memory_index.sqlite   │
+                  │  - Kuzu (graph,OFF) │      │  (dataset/tags/source/      │
+                  │  - SQLite (rel/doc) │      │   metadata/timestamp +      │
+                  │  cognee.add/search/ │      │   cognee_data_id link)      │
+                  │  cognify/delete     │      │  → ALL filtering happens here│
+                  └─────────────────────┘      └─────────────────────────────┘
+```
+
+The wiring point is `create_app` in `src/hal0/api/__init__.py:1075-1155`:
+one `CogneeWrapper` singleton is built (`:1108`), stashed on
+`app.state.memory_wrapper` (`:1121`), and handed to both the MCP mount and the
+in-process dispatcher.
+
+### 1.2 The MCP server — `hal0.mcp.memory`
+
+`src/hal0/mcp/memory.py`. `build_server(wrapper, ...)` returns a FastMCP instance
+mounted at `/mcp/memory` by `mount_mcp_servers`
+(`src/hal0/api/mcp_mount.py:151-163`). Four tools are registered
+(`src/hal0/mcp/memory.py:454-460`):
+
+| Tool | Documented schema (ADR-0005 §2) | Handler | Annotations (`:400-413`) |
+|------|----------------------------------|---------|--------------------------|
+| `memory_add(text, dataset="shared", tags=[], metadata={})` → `{id, timestamp}` | `source` is **server-injected**, callers passing it are rejected (`:205-208`) | `_memory_add` `:170` | `readOnly=F destructive=F idempotent=F` |
+| `memory_search(query, limit=10, dataset="shared"\|list, tags=[], before=null, after=null)` → `{results:[…]}` | private-mode reads union `[shared, private:<id>]` (`:254`) | `_memory_search` `:224` | `readOnly=T idempotent=T` |
+| `memory_list(dataset="shared", cursor=null, limit=50)` → `{items, next_cursor}` | resolves a **single** dataset string (`:285`) | `_memory_list` `:274` | `readOnly=T idempotent=T` |
+| `memory_delete(ids: list[str])` → `{deleted: int}` | bulk-delete approval gating lives in `hal0.mcp.admin` (`:299-312` docstring) | `_memory_delete` `:299` | `readOnly=F **destructive=T** idempotent=T` |
+
+Validation is hand-rolled (no pydantic) via `_require` / `_optional` /
+`_normalise_tags` (`:101-133`) so the error envelope matches `admin.py`. Errors
+surface as `{"status":"error","error":{"code":"mcp.memory_schema"|"mcp.memory_failed", ...}}`
+(`:377-387`).
+
+`make_dispatcher(wrapper, client_id_resolver, private_resolver)` (`:339`) builds the
+async closure `_dispatch(tool, args)` that every transport ultimately calls. The
+resolvers are 0-arg callables read **at call time** so the same closure serves both
+the standalone server and the in-process dispatcher.
+
+### 1.3 The in-process dispatcher — `MemoryDispatcher`
+
+`src/hal0/dispatcher/memory_dispatcher.py`. A thin class wrapping
+`make_dispatcher` (`:79`). Its reason for existing (`:1-28` docstring): the admin
+MCP server's `memory_*` tool family must reach Cognee **without** an HTTP
+loop-back through `/mcp/memory`. It is callable (`__call__` `:95`) so
+`hal0.mcp.admin.dispatch(..., memory_dispatcher=…)` can treat it as a plain
+`Callable[[str, dict], Awaitable[dict]]`. Constructed in `create_app`
+(`src/hal0/api/__init__.py:1136`) with the same resolvers
+(`client_id_resolver` / `private_resolver` from `mcp_mount`).
+
+### 1.4 The REST shims — `hal0.api.routes.memory`
+
+`src/hal0/api/routes/memory.py`, mounted at `/api/memory`
+(`src/hal0/api/__init__.py:877-878`). Two route families:
+
+1. **Graph-gate routes** (ADR-0014): `GET /graph/status` (`:174`) and
+   `PUT /graph` (`:213`). These read/flip `[memory.graph]` in `hal0.toml`
+   (`load_hal0_config` / `save_hal0_config`) **and** flip the live wrapper via
+   `wrapper.set_graph_enabled(...)` (`:265`) so no restart is needed.
+
+2. **CRUD shims** added in #302/#303 (`:276-461`):
+   `POST /add` (`:291`), `POST /search` (`:348`), `GET /list` (`:392`),
+   `POST /delete` (`:426`). These exist because the bootstrap + CLI + dashboard
+   were POSTing to `/mcp/memory` as if it were one-shot JSON-RPC, which real
+   FastMCP transport (initialize + session-tagged calls) does not support. The
+   shims are "the cheapest unblock so identity cards actually get written"
+   (`:285-288` docstring). They are a **parallel path** to the MCP transport, not
+   a replacement.
+
+Identity on the REST surface (post-ADR-0012, no auth): the `X-hal0-Agent` header
+(`_agent_id` `:87`, validated against `^[a-zA-Z0-9_\-]{1,64}$`, `private:` prefix
+rejected) and the `X-hal0-Private: 1` toggle (`_is_private` `:128`). Absent agent
+header → `"anonymous"`.
+
+### 1.5 The per-agent stats route — `hal0.api.agents.memory_stats`
+
+`src/hal0/api/agents/memory_stats.py`, mounted under `/api/agents`
+(`src/hal0/api/__init__.py:1004`). `GET /{agent_id}/memory/stats` (`:110`) returns
+`{agent_id, namespace, writes, reads, last_write, available}` for the sidebar chip.
+It reads through the **same in-process wrapper** (`app.state.memory_wrapper`,
+`:141`), scoped to `private:<agent_id>` (`:78-87`). Notable limitations baked into
+the code:
+- `writes` is `len(items)` of a single 500-item page (`:165`, `_LIST_PAGE_LIMIT`),
+  capped — not a true count.
+- `reads` is **hard-coded `0`** (`:217`) because the wrapper exposes no
+  per-namespace read counter.
+- Only `hermes` is a known agent (`_KNOWN_AGENT_IDS` `:68`); anything else → 404.
+
+### 1.6 The CLI — `hal0.cli.memory_commands`
+
+`src/hal0/cli/memory_commands.py`. Despite the package name, the CLI only covers
+the **graph gate**, not CRUD. Three commands, all thin HTTP clients to the local
+API (`:1-13` docstring):
+- `hal0 memory graph status` → `GET /api/memory/graph/status` (`:46`)
+- `hal0 memory graph enable [--route … --provider … --model …]` → `PUT /api/memory/graph` (`:99`)
+- `hal0 memory graph disable` → `PUT /api/memory/graph` (`:160`)
+
+There is **no** `hal0 memory add/search/list/delete` CLI. Operator CRUD over
+memory is not exposed on the command line.
+
+### 1.7 The Hermes plugin — `agents/hermes/plugins/memory_cognee`
+
+`src/hal0/agents/hermes/plugins/memory_cognee/`. This is **copied verbatim** into
+`$HERMES_HOME/plugins/memory/hal0-cognee/` at provision time
+(`__init__.py:1-24`). It is the agent-side consumer:
+
+- `__init__.py` — exposes `register(ctx)` and re-exports `Hal0CogneeProvider` so
+  either Hermes discovery path works.
+- `provider.py` — `Hal0CogneeProvider(MemoryProvider)`. Subclasses the **upstream
+  Hermes ABC** `agent.memory_provider.MemoryProvider` (with a vendored stub
+  fallback for hal0's own tests, `:35-56`). Plugin `name = "hal0-cognee"`. Wraps
+  the async REST client in `asyncio.run` because Hermes' memory hooks are sync
+  (`:16-18` docstring). Best-effort: transport failures fall back to empty context
+  / silent drop (`:18-21`). Hooks:
+  - `system_prompt_block()` (`:128`) — injects a "you have durable memory at
+    `private:<agent>`" block.
+  - `prefetch(query)` (`:137`) — `search(limit=5)`, formats hits as a markdown
+    list. Returns `""` on any failure.
+  - `sync_turn(user, assistant)` (`:163`) — `add(...)` the turn, tagged
+    `["chat","hermes"]`, **unless** `agent_context ∈ {cron, flush, subagent}`
+    (`_SKIP_WRITE_CONTEXTS` `:66`).
+  - `on_memory_write(...)` (`:207`) — mirrors built-in memory writes into hal0.
+  - `get_tool_schemas()` returns `[]` (`:186`) — **no model-visible tools**; recall
+    is implicit via prefetch + system prompt. CRUD is left to the MCP server.
+- `_client.py` — `Hal0MemoryClient`, a tiny async httpx client hitting
+  `/api/memory/*` with `X-hal0-Agent` (sourced from `HAL0_AGENT_ID`,
+  default `hermes-agent`). **Never sends a `dataset` field** — the server resolves
+  the namespace from the header (the #317 contract, `:3-13` docstring).
+
+### 1.8 End-to-end write path (trace)
+
+**Via Hermes (the live agent path):**
+1. Hermes finishes a turn → `Hal0CogneeProvider.sync_turn` (`provider.py:163`).
+2. → `Hal0MemoryClient.add(text, tags=["chat","hermes"])` → `POST /api/memory/add`
+   with `X-hal0-Agent: <HAL0_AGENT_ID>`, **no `dataset`** (`_client.py:106-123`).
+3. → `memory_add` route (`routes/memory.py:291`): rejects body `source`,
+   `_agent_id` validates the header, `_is_private` reads the toggle,
+   `resolve_write_dataset(None, private, client_id)` → `"shared"` (or
+   `private:<agent>` if `X-hal0-Private: 1`).
+4. → `wrapper.add(text, dataset, tags, source=agent_id, metadata, client_id)`
+   (`routes/memory.py:338`).
+5. → `CogneeWrapper.add` (`cognee_wrapper.py:484`):
+   `_effective_write_dataset` (`:1117`) applies the §3 rule, `cognee.add([text],
+   dataset_name=…, node_set=tags)` (`:523`), then `_chunk_and_embed` runs the
+   stripped classify→chunk→embed pipeline (`:412`, **no graph**), then a row is
+   INSERTed into the sidecar (`:538-558`), an audit event is emitted (`:560`), and
+   — only if `graph_enabled` — a background `cognify` task is fired and forgotten
+   (`:575-585`). Returns `{id, timestamp}`.
+
+**Via an MCP client:** identical from step 5 down, but steps 2-4 are replaced by
+`/mcp/memory` → `make_dispatcher._dispatch` → `_memory_add` (`memory.py:170`) →
+`wrapper.add(...)`. The admin MCP `memory_*` tools take the in-process
+`MemoryDispatcher` shortcut to the same `_dispatch`.
+
+### 1.9 End-to-end recall path (trace)
+
+1. `prefetch`/MCP `memory_search`/`POST /api/memory/search` → `wrapper.search`
+   (`cognee_wrapper.py:679`).
+2. `mode` is validated; `graph`/`hybrid` **fall back to vector** with an audit
+   note when graph is disabled (`:719-726`).
+3. `_allowed_read_datasets` (`:1149`) intersects the request with
+   `[shared, private:<client_id>]` (other clients' private buckets silently
+   dropped).
+4. `cognee.search(query_type=SearchType.CHUNKS, datasets=…, top_k=min(100, limit*5))`
+   (`:737-744`) — **pure vector**. A tower of "empty store" exceptions all map to
+   `[]` (`:745-784`).
+5. Returned chunk **texts** are matched back against the **sidecar** to recover the
+   rich schema (`:807-830`); tag AND-match + date range applied by `_passes_filters`
+   (`:1244`).
+6. Optional rerank pass (`_maybe_rerank` `:1003`) posts candidates to the
+   `embed-rerank` slot (`:8086/rerank`) and reorders by `relevance_score`; any
+   failure falls through to vector order.
+7. Clip to `limit`, audit, return `list[dict]`.
+
+---
+
+## 2. Data model
+
+### 2.1 Datasets / namespaces
+
+The namespace rule (ADR-0005 §3) is implemented as two pure functions in
+`src/hal0/memory/namespace.py`, shared by REST and MCP so they cannot drift
+(`:1-28` docstring — this module exists *because* of #317):
+
+- `DEFAULT_DATASET = "shared"`, `PRIVATE_PREFIX = "private:"` (`:32-33`).
+- `resolve_write_dataset(requested, *, private, client_id)` (`:41`):
+  - `private=True` → `private:<client_id>` (raises `MemoryNamespaceError` if no
+    `client_id`).
+  - empty / `None` → `"shared"`.
+  - a body value starting with `private:` while `private=False` → **rejected**
+    (`:69-73`) — the toggle is the only path in (PR #366 hardening).
+  - otherwise pass through verbatim (custom datasets allowed).
+- `resolve_read_datasets(...)` (`:77`): a list passes through; empty + private →
+  `[shared, private:<id>]`; empty otherwise → `"shared"`; non-empty string →
+  delegate to `resolve_write_dataset`.
+
+Wrapper-level enforcement (the actual scoping) lives in `CogneeWrapper`:
+- `_effective_write_dataset` (`:1117`): in `private_mode=True` instances, **any**
+  requested dataset is forced to the constructor's `private:<client_id>`; in
+  `private_mode=False` (the production singleton), the resolved string is persisted
+  **verbatim** — REST/MCP already guarded it (this is the #367/#366 fix; see §4.1).
+- `_allowed_read_datasets` (`:1149`): always unions `shared` + the caller's own
+  `private:<client_id>`; other clients' `private:*` are dropped silently
+  (fail-open-empty, never error — avoids leaking existence).
+
+Custom datasets (anything not `shared`/`private:*`) are opaque to the rule and pass
+through. ADR-0011 reserves an `agents` dataset for identity cards.
+
+### 2.2 What Cognee actually stores vs what the sidecar stores
+
+This is the single most important data-model fact for the redesign:
+
+| Concern | Where it lives | Notes |
+|---------|---------------|-------|
+| Vector embeddings | **Cognee → LanceDB** | 384-dim `fastembed` `BAAI/bge-small-en-v1.5` (`cognee_wrapper.py:167-168`). Embeds chunked at 512 tokens (`:436`). |
+| Graph (entities/relations) | **Cognee → Kuzu** — but **OFF by default** | `cognify` only runs as a fire-and-forget background task when `graph_enabled` (`:575-585`); the result is **never queried** — `search` always uses `SearchType.CHUNKS`. Graph is write-only dead weight today. |
+| Relational / document store | Cognee → SQLite (`<dir>/databases/`) | Cognee's own internal bookkeeping. |
+| **dataset, tags, source, metadata, timestamp** | **Sidecar SQLite** (`hal0_memory_index.sqlite`) | Cognee 1.0.x's chunk payload does **not** carry these at search time, so the wrapper shadows them (`:317-347`, schema at `:331-341`). **All filtering (dataset isolation, tag AND, date range) runs against the sidecar, not Cognee** (`:786-830`). |
+| Cognee back-link | `cognee_data_id` / `cognee_dataset_id` columns | Used only for `delete` (`:960-965`). Recovered post-add via `_latest_cognee_data_id` (`:1198`), a "ask the dataset for its newest item" heuristic that assumes one-item-per-add. |
+
+The search join is **text-equality** between the Cognee chunk text and the sidecar
+`text` column (`:811-818`) — there is no shared id between LanceDB chunks and
+sidecar rows. This is a fragile coupling (see §4.3).
+
+### 2.3 On-disk layout
+
+Default root `DEFAULT_COGNEE_DIR = /var/lib/hal0/memory/cognee`
+(`cognee_wrapper.py:101`). Under it:
+- `data/` — Cognee document data root (`:235`).
+- `databases/` — Cognee relational SQLite + `cognee.kuzu` graph
+  (`:242`, `:394-396`).
+- `databases/` also holds LanceDB tables (via `set_vector_db_provider("lancedb")`).
+- `hal0_memory_index.sqlite` — the sidecar, alongside Cognee's files so
+  `$HAL0_HOME` snapshots cover both (`:307`).
+
+Cognee is configured via env vars + `cognee.config.*` in `_configure_cognee`
+(`:362-408`): `ENABLE_BACKEND_ACCESS_CONTROL=false` (RBAC deferred),
+`COGNEE_SKIP_CONNECTION_TEST=true`, `LLM_API_KEY=sk-hal0-noop-...` (no LLM call
+fires on the v0.2 path), embedding provider/model/dims, and explicit `DB_PATH` /
+`GRAPH_DATABASE_URL`. `_clear_cognee_caches` (`:1288`) is called to bust Cognee's
+`@lru_cache`d config/engine singletons so a second wrapper in the same process
+doesn't inherit the first's dirs.
+
+### 2.4 Audit trail
+
+Every op emits a `hal0.memory.audit` structlog event (`AUDIT_EVENT` `:105`,
+`_audit` `:449`) with `{client_id, op, dataset, timestamp, …}`, mirrored into a
+bounded in-memory `audit_tail` (cap 1024, `:299-300`). This is the ADR-0005 §5
+audit surface; production retention is journald. The `reads` counter the stats
+endpoint wants does **not** exist — audit events are emitted but never aggregated.
+
+---
+
+## 3. Who consumes memory today
+
+| Consumer | Surface used | Status |
+|----------|--------------|--------|
+| **Hermes agent** (bundled) | `/api/memory/{add,search}` via `Hal0CogneeProvider` → `Hal0MemoryClient` | **Live**, the primary writer/reader. `add` on every turn, `search` on prefetch. |
+| **MCP clients / external agents** | `/mcp/memory` FastMCP (`memory_add/search/list/delete`) | Available; mounted only when the wrapper inits. The intended cross-app path. |
+| **MCP admin tools** | `memory_*` via in-process `MemoryDispatcher` | Available; bypasses HTTP. |
+| **Dashboard — Memory tab** | `GET/PUT /api/memory/graph[/status]` only (`ui/src/api/hooks/useMemory.ts`, `ui/src/api/endpoints.ts:120-121`) | **Live but graph-gate ONLY.** The MemoryMap (`ui/src/dash/memory-map.jsx`, PR #370) renders the graph-extraction toggle + counters. There is **no** dataset/item explorer hitting `/api/memory/list` or `/search`. |
+| **Dashboard — sidebar agent block** | `GET /api/agents/hermes/memory/stats` (`endpoints.ts:99`) | Live; renders `writes` / `last_write` chip; `reads` always 0. |
+| **CLI** | `hal0 memory graph {status,enable,disable}` | Live; **no CRUD subcommands**. |
+
+PLAN.md §5 describes a future "Cognee dataset explorer (shared / private /
+`agents`)" for the Memory tab — that explorer is **not built**; only the graph gate
+ships.
+
+---
+
+## 4. Known defects & limitations
+
+### 4.1 Issue #317 — namespace-forcing bug: **FIXED (verify before re-filing)**
+
+The known-context bug ("`/api/memory/add` forces `dataset="shared"` regardless of
+`private:*`") is **no longer present**. Verified:
+
+- `git log` shows the fixes: `9ee21a3 fix(memory): REST /api/memory/add honors
+  private:* namespace (#366)` and `58b582f fix(memory): honor per-call client_id on
+  read path + audit stamping (#369)`.
+- The REST handler now calls
+  `resolve_write_dataset(body.get("dataset"), private=private, client_id=…)`
+  (`src/hal0/api/routes/memory.py:329-333`) — it does **not** hard-code `"shared"`.
+- The wrapper's `_effective_write_dataset` (`cognee_wrapper.py:1142-1147`) persists
+  a resolved `private:<id>` **verbatim** in the non-private singleton instead of
+  collapsing it to `shared`. The collapsing-to-shared behaviour (the actual #317
+  symptom) is explicitly called out as the old bug in the docstring (`:1136-1141`).
+- Shared logic now lives in `hal0.memory.namespace`, consumed by both REST
+  (`routes/memory.py:29-34`) and MCP (`mcp/memory.py:69-75`), so the
+  drift-between-surfaces root cause is structurally addressed.
+
+**Action for redesign:** treat #317 as closed; the auto-memory index entry
+`hal0_memory_dataset_namespace_bug` is stale and should be marked resolved.
+
+### 4.2 Hermes REST client calls **wrong route paths** for list/delete (live latent bug)
+
+`src/hal0/agents/hermes/plugins/memory_cognee/_client.py`:
+- `list_items` calls `GET /api/memory` (`:139`) — but the server route is
+  `GET /api/memory/list` (`routes/memory.py:392`). **No bare `GET /api/memory`
+  route exists.**
+- `delete` calls `DELETE /api/memory/{id}` (`:143`) — but the server route is
+  `POST /api/memory/delete` with an `ids` body (`routes/memory.py:426`). **No
+  `DELETE /api/memory/{id}` route exists.**
+
+`add` (`POST /api/memory/add`) and `search` (`POST /api/memory/search`) are
+correct. Because the provider only ever calls `add` + `search` at runtime
+(`provider.py` never calls `list_items`/`delete`), this is **latent** — it would
+404 the moment anything drives the client's list/delete methods. Worth fixing or
+deleting the dead methods during the redesign.
+
+### 4.3 Sidecar text-equality join is fragile
+
+`search` re-derives the rich schema by matching Cognee's returned chunk **text**
+against the sidecar `text` column (`cognee_wrapper.py:811-818`). Consequences:
+- Two memories with identical text collide and can't be told apart.
+- Any Cognee-side text normalization (whitespace, truncation) silently breaks the
+  join → "no results" rather than an error.
+- `_latest_cognee_data_id` (`:1198`) assumes strictly one item per add and reads
+  "the last element" — concurrent adds to the same dataset could mis-link
+  `cognee_data_id`, corrupting later deletes.
+
+### 4.4 Test coverage gaps
+
+- `tests/mcp/test_memory.py` (235 LOC) and `tests/api/test_memory_rest_routes.py`
+  (494 LOC) exercise the dispatch/route/namespace logic against **`_FakeWrapper` /
+  `StubWrapper`** — **not real Cognee** (`test_memory.py:8`,
+  `test_memory_rest_routes.py:18,38`). They prove the transport + namespace
+  contract, nothing about Cognee integration.
+- The real wrapper-vs-Cognee behaviour (the stripped cognify pipeline, the sidecar
+  join, delete back-linking, first-run empty-store handling) is only in
+  `tests/memory/` (`test_cognee_wrapper.py`, `test_namespace_wrapper.py`,
+  `test_graph_gate.py`, `test_rerank.py`), all marked `slow` and dependent on the
+  heavy Cognee fixture (`tests/memory/conftest.py`). Per the auto-memory note on
+  CI, these `slow`/Cognee suites are not in the default CI gate — meaning the
+  fragile text-join + delete back-link paths (§4.3) can regress without failing CI.
+- No test asserts the Hermes `_client.py` route paths against the real router (which
+  is why §4.2 went unnoticed).
+
+### 4.5 Graph extraction is write-only dead weight
+
+`mode="graph"|"hybrid"` is accepted and validated (`cognee_wrapper.py:714-717`) but
+**always falls back to vector** (`:719`). `cognify` runs only as a fire-and-forget
+background task (`:575-585`, `_build_graph` `:590`) whose output is never read.
+Route resolution (`upstream`/`primary`/`agent`) is stored but unimplemented —
+"lands in v0.4 with the eval suite" (`:597-598`, `:662-665`). So Kuzu accumulates a
+graph nobody queries, and the only observable effect of enabling it is build
+counters in `graph_status()` (`:629`).
+
+### 4.6 Other limitations
+
+- **`reads` counter** is hard-coded `0` (`memory_stats.py:217`) — no per-namespace
+  read aggregation exists.
+- **`writes`** is a capped single-page count, not a real count
+  (`memory_stats.py:165`); the docstring flags a v0.4 `count(dataset=…)` method as
+  the right fix (`:158-163`).
+- **Single-process singleton.** `_configure_cognee` pushes Cognee config as
+  module-level singletons; "last writer wins" if multiple wrappers point at the same
+  dir (`:310-315` comment). v0.2 ships exactly one wrapper per process.
+- **No idle eviction / TTL / hygiene.** Memify is deferred (ADR-0005 §6). Memory
+  grows unbounded.
+- **`/mcp/memory` JSON-RPC is awkward for HTTP callers** — the whole REST-shim
+  family exists because real FastMCP transport needs initialize + session-tagged
+  calls (`routes/memory.py:283-288`). This is the "stopgap" noted in
+  `memory_dispatcher.py:5`.
+- **`memory_list` MCP tool asymmetry.** Unlike `memory_search`, the list tool
+  resolves a **single** dataset string (`mcp/memory.py:285`) and does not union
+  `[shared, private:<id>]` at the tool layer; it relies on the wrapper's
+  `_allowed_read_datasets` to re-add `shared`. The REST `/list` similarly uses
+  `resolve_write_dataset` (`routes/memory.py:409`), so a private-mode list returns
+  only the private bucket from the resolver's perspective. Minor, but a behavioural
+  inconsistency between `search` and `list`.
+
+---
+
+## 5. Coupling — how tightly is Cognee wired in?
+
+**Cognee touchpoints are confined to one file.** A repo-wide grep confirms that
+outside of `src/hal0/memory/cognee_wrapper.py`, nothing imports `cognee`. Every
+other layer imports `CogneeWrapper` (or `MemoryRecord`) from `hal0.memory` and calls
+its five async methods. The package `__init__.py` re-exports only those two names
+(`src/hal0/memory/__init__.py:13-15`) and declares "only the wrapper is public."
+
+**The engine-swap seam is therefore `CogneeWrapper` itself.** To swap to a different
+engine (e.g. Hindsight) you would:
+1. Implement a class with the same async surface:
+   `add(text, dataset, tags, source, metadata, client_id) -> {id, timestamp}`,
+   `search(query, limit, dataset, tags, before, after, mode, client_id) -> list[dict]`,
+   `list_items(dataset, cursor, limit, client_id) -> {items, next_cursor}`,
+   `delete(ids, client_id) -> {deleted}`, plus the runtime-flip helpers
+   `graph_status()`, `set_graph_enabled()`, `set_rerank_enabled()`.
+2. Change the **single construction site** in `create_app`
+   (`src/hal0/api/__init__.py:1108`).
+
+**But there is no formal abstraction.** Caveats that make the swap less clean than
+it looks:
+- **No ABC / Protocol** defines the contract. The wrapper is a concrete class; the
+  contract is implied by call sites + the MCP/REST shims + the test stubs. The
+  `MemoryProvider` ABC referenced anywhere in code is the **Hermes upstream** one
+  (`provider.py:36`), an agent-side abstraction unrelated to the engine seam.
+- **Leaky surface.** Callers depend on Cognee-shaped concepts that a new engine must
+  reproduce: the `dataset` namespace model, the `private:<id>` convention, the
+  `mode` enum, the graph-status/route counters (ADR-0014), and the rerank toggle.
+  The graph-status payload shape is a hard contract — the dashboard depends on every
+  key (`routes/memory.py:178-179`).
+- **The sidecar SQLite is part of the contract too.** Filtering semantics (tag AND,
+  date range, dataset isolation) are implemented in the wrapper against the sidecar,
+  not delegated to the engine. A new engine that natively supports these would make
+  the sidecar redundant — but any migration must preserve the existing sidecar data
+  or re-ingest.
+- **Config coupling.** `[memory.graph]` + `[memory.embedding]` config blocks
+  (`hal0.config.schema`) and the boot-time wiring in `create_app:1083-1118` are
+  Cognee/rerank-flavoured. A swap touches the config schema, not just the class.
+
+**Net:** the seam is real and narrow (one file, one construction site), which is the
+subsystem's biggest strength. But it is a concrete-class seam, not an interface, and
+the contract leaks Cognee-era concepts (datasets, graph route enum, sidecar-backed
+filtering) that a redesign should decide to either keep as the canonical model or
+explicitly shed.
+
+---
+
+## 6. Verdict
+
+### Strengths to keep
+- **Single narrow seam.** Cognee is genuinely contained to `cognee_wrapper.py`;
+  the rest of the stack speaks one five-method contract. This is the redesign's best
+  asset.
+- **Shared namespace module.** `hal0.memory.namespace` killed the #317
+  drift-between-surfaces class of bug by single-sourcing the rule. Keep this pattern.
+- **Defensive transport layer.** Hand-rolled validation, server-injected `source`
+  (anti-impersonation), `private:` prefix rejection, consistent error envelopes,
+  best-effort agent hooks that never wedge the loop. The audit trail is real.
+- **Rerank integration** is a clean optional second pass that fails safe.
+
+### Weaknesses that motivate redesign
+- **Two-store split with a fragile join.** The sidecar SQLite, not Cognee, is the
+  real source of truth for the schema and all filtering; the two are stitched by
+  **text equality** (§4.3). This is the deepest structural smell.
+- **Cognee's graph half is dead weight.** Kuzu + cognify cost ingestion latency and
+  disk but are never read (§4.5). Either commit to the graph or drop the engine that
+  ships it.
+- **No formal engine interface.** The swap seam is a concrete class; an explicit ABC
+  / Protocol (plus a conformance test suite) would de-risk the very swap this audit
+  is preparing (§5).
+- **Real integration path is under-tested.** Transport is well covered against
+  stubs; the Cognee-touching path is `slow`/excluded from the default gate (§4.4).
+- **Missing operability.** No CRUD CLI, no dataset explorer UI (despite PLAN), no
+  real counts, no `reads` metric, no hygiene/TTL/eviction, unbounded growth.
+- **Latent route mismatch** in the Hermes client (§4.2) shows the shim layer drifted
+  from the routes without anything catching it.
+
+**Bottom line:** the *plumbing* (namespace resolution, transport, audit, the single
+seam) is solid and worth carrying forward. The *engine choice and its storage model*
+— Cognee + a shadow SQLite joined by text, with an unused graph — are the parts the
+redesign should put on the table. Whatever replaces Cognee should be hidden behind a
+real interface (not just a concrete class), own its own filtering (retiring the
+sidecar), and either use a graph or not ship one.

--- a/docs/internal/brain-redesign/04-consumer-surface.md
+++ b/docs/internal/brain-redesign/04-consumer-surface.md
@@ -1,0 +1,484 @@
+# Brain Redesign — 04: Consumer Surface
+
+> The complete map of every "consumer of the brain" in hal0: every agent,
+> app, MCP surface, slot/capability, and dashboard view that could **produce**
+> or **consume** memory / wiki / context. Feeds the memory-system redesign
+> (Hindsight engine + Obsidian wiki) whose goal is *deep, non-bolted-on*
+> integration.
+>
+> Scope verified against the repo at `/home/halo/dev/hal0` on 2026-06-02.
+> Citations are `file:line`. Where a thing is aspirational vs shipped it is
+> flagged explicitly.
+
+---
+
+## 0. TL;DR — the brain has exactly one front door today
+
+Everything that touches durable memory in hal0 today funnels through **one
+in-process Cognee store**, reachable via two equivalent transports:
+
+- **MCP**: `hal0-memory` FastMCP server mounted at `/mcp/memory`
+  (`src/hal0/api/mcp_mount.py:161`), tools `memory_add` / `memory_search` /
+  `memory_list` / `memory_delete` (`src/hal0/mcp/memory.py:331-336`).
+- **REST**: `/api/memory/*` (`src/hal0/api/routes/memory.py`, mounted at
+  `prefix="/api/memory"` per `src/hal0/api/__init__.py:878`).
+
+Both resolve the **per-caller namespace server-side** from the `X-hal0-Agent`
+header (REST: `src/hal0/api/routes/memory.py:48`; MCP: Bearer/client-id
+resolver) — clients never send a `dataset` field (issue #317;
+`src/hal0/agents/hermes/plugins/memory_cognee/README.md:21`). Namespaces:
+`shared` (default), `private:<agent_id>` (per-agent), and `agents` (identity
+cards, ADR-0011).
+
+The store itself is `CogneeWrapper` (`src/hal0/memory/cognee_wrapper.py`):
+SQLite + LanceDB (vectors) + Kuzu (graph), all embedded, file-based
+(`cognee_wrapper.py:90-92`). Embeddings default to **fastembed CPU /
+bge-small-en-v1.5 384-dim** (`cognee_wrapper.py:167-169`); graph extraction is
+**default-OFF** behind ADR-0014's model gate (`cognee_wrapper.py:170`,
+`PLAN.md:347-351`). Reranking optionally posts to **hal0's bundled embed-rerank
+slot on port 8086** (`cognee_wrapper.py:209-214`).
+
+**Implication for the redesign:** if the new brain (Hindsight + Obsidian)
+preserves the `/mcp/memory` + `/api/memory/*` contract and the
+`X-hal0-Agent` namespace rule, *every consumer below inherits it for free*.
+The hook points are the wrapper internals and a small number of
+context-injection seams, not the consumer surface.
+
+---
+
+## 1. Agents
+
+`BUNDLED_AGENTS = ("pi-coder", "hermes")` (`src/hal0/agents/manager.py:87`).
+Single-pick at install (`manager.py:223-265`); swap is atomic
+uninstall-then-install. The manager delegates to per-agent driver modules
+looked up by `_driver_for` (`manager.py:142-156`).
+
+### 1.1 Hermes-Agent (`hermes`) — the deep case
+
+Hermes is the service-shape bundled agent, installed via the hal0-owned
+`hal0-hermes` wrapper around upstream `hermes`
+(`src/hal0/agents/hermes/driver.py:1-23`). hal0 cannot PR upstream, so all
+hal0-awareness lives in hal0-owned artifacts: the wrapper, the env file, a
+vendored MemoryProvider plugin, and rendered context files.
+
+**How Hermes gets context today — four distinct channels:**
+
+1. **`MemoryProvider` plugin (`hal0-cognee`)** — the deepest hook. Vendored at
+   `src/hal0/agents/hermes/plugins/memory_cognee/` and copied into
+   `$HERMES_HOME/plugins/memory/hal0-cognee/` at provision time
+   (`hermes_provision.py:_phase_install`). It subclasses upstream
+   `agent.memory_provider.MemoryProvider` (`provider.py:36`) and implements:
+   - `system_prompt_block()` — injects a "you have a durable memory store"
+     preamble naming the `private:<agent_id>` namespace (`provider.py:128-135`).
+   - `prefetch(query)` — **READ**: calls `/api/memory/search` with a 5-item
+     budget on every turn, formats hits as a `## hal0-cognee memory` block
+     prepended to context (`provider.py:137-161`). *This is the live
+     context-injection seam.*
+   - `sync_turn(user, assistant)` — **WRITE**: fire-and-forget
+     `/api/memory/add` of each turn, tagged `["chat","hermes"]`, skipped for
+     `cron`/`flush`/`subagent` contexts (`provider.py:163-182`, `:66`).
+   - `on_memory_write(...)` — mirrors Hermes's *built-in* memory tool writes
+     into hal0-cognee (`provider.py:207-224`).
+   - `get_tool_schemas()` returns `[]` deliberately — memory is surfaced via
+     prompt + prefetch, not model-visible tools, to avoid double-registering
+     against the MCP path (`provider.py:186-195`).
+   - Identity flows via `X-hal0-Agent` from `HAL0_AGENT_ID`
+     (`provider.py:110-112`); never sends `dataset`.
+
+2. **MCP servers** — the wrapper's env file
+   (`src/hal0/agents/hermes/driver.py:332-346`) wires
+   `HAL0_MCP_ADMIN_URL=.../mcp/admin` and `HAL0_MCP_MEMORY_URL=.../mcp/memory`.
+   `hermes_provision._phase_config_write` writes these into Hermes
+   `config.yaml` `mcp_servers` (`hermes_provision.py:646-647`), and
+   `_phase_mcp_wire` verifies they answer `tools/list`
+   (`hermes_provision.py:1022`). So Hermes has **operator-grade CRUD** on
+   memory via `hal0_memory` MCP *in addition to* the implicit provider path.
+
+3. **Rendered context files** — `_phase_context_link`
+   (`hermes_provision.py:1230`) renders three Jinja2 templates from the *live
+   host snapshot* and writes them to disk:
+   - `HERMES.md` → `/etc/hal0/HERMES.md` (`hermes_provision.py:1317-1319`),
+     auto-injected every session because Hermes's terminal cwd is `/etc/hal0`.
+     Advertises Memory MCP, Admin MCP, active capability slots, peer agents,
+     skills (`src/hal0/agents/hermes_templates/HERMES.md.j2`).
+   - `AGENTS.md` → `/etc/hal0/AGENTS.md` (`hermes_provision.py:1331-1333`) —
+     the **tool-agnostic** context file (see 1.2).
+   - `SOUL.md` → under `$HERMES_HOME` (identity/persona prelude).
+   - `$HERMES_HOME/memories/HOST.md` is a symlink to `/etc/hal0/HERMES.md`
+     (`hermes_provision.py:1237`) — folds the host snapshot into Hermes's own
+     memory tier.
+
+4. **Personas** (`src/hal0/agents/personas.py`, `persona.py`) — hal0's
+   user-facing layer over Hermes's `system_prompt_prelude` + tool gating +
+   **memory namespacing** (`personas.py:1-8`). TOML at
+   `/var/lib/hal0/agents/hermes/personas/<id>.toml`; the active persona is read
+   during system-prompt injection. A persona can therefore scope which memory
+   namespace a turn reads/writes.
+
+5. **Identity cards** — `_phase_identity_card` (`hermes_provision.py:1386-1415`)
+   writes a self-describing card (`roles: [..., "memory-curator"]`,
+   `accepts_tasks_from: ["claude-code","pi-coder","user"]`) into the `agents`
+   Cognee dataset via `_mcp_memory_call` (`hermes_provision.py:1415-1434`).
+   This is memory **produced about the agent itself**.
+
+**Where a wiki/memory hook attaches for Hermes:** the `prefetch()` seam in
+`provider.py:137` is the single richest insertion point — today it returns a
+flat list of memory hits; a Hindsight retrieval + an Obsidian-wiki context
+block would slot in here verbatim. Secondary: the `HERMES.md.j2` /
+`AGENTS.md.j2` templates (add a "wiki index" section), and `SOUL.md` for
+durable identity.
+
+### 1.2 Claude Code — support reality: **aspirational, partial scaffolding only**
+
+There is **no `claude-code` driver, install path, or runtime integration** in
+hal0. It is not in `BUNDLED_AGENTS`. What exists:
+
+- **Client *identity detection*** (cosmetic): `/api/mcp/clients` heuristically
+  renders any MCP client whose `client_id` contains `claude-code` as
+  "Claude Code" with role "CLI" (`src/hal0/api/routes/mcp.py:503-504`,
+  `:516-523`). This only labels a client that *already connected on its own*.
+- **The tool-agnostic context file** `AGENTS.md.j2` is explicitly written
+  "Read by any agent that lands in `/etc/hal0/` — Claude Code, Cursor, Codex,
+  Hermes" (`src/hal0/agents/hermes_templates/AGENTS.md.j2:1-3`). So if a user
+  runs Claude Code with cwd `/etc/hal0`, it gets host context — but hal0 does
+  nothing to *make* that happen.
+- **The intended path is MCP**: ADR-0004 §122 states "MCP is the cross-app
+  contract. Claude Code … integrate without hal0-specific glue. The admin MCP
+  server is the public surface; bundled agents are just the first consumers."
+  A user's Claude Code points itself at `/mcp/memory` + `/mcp/admin` and gets
+  the four memory tools (`docs/internal/adr/0005-memory-engine-cognee.md:11`).
+- **A second, planned path**: the Cognee `claude-code` integration — a plugin
+  using six lifecycle hooks (SessionStart, UserPromptSubmit, PostToolUse, Stop,
+  PreCompact, SessionEnd) + `node_set` tagging — "Gives Claude Code users a
+  second path into the same Cognee store, complementary to MCP"
+  (`PLAN.md:1044`, `docs/internal/adr/0005-memory-engine-cognee.md:88`).
+  **Not implemented in this repo.**
+
+**Verdict:** Claude Code support = (a) it can connect as an MCP client today
+and is *recognized* in the dashboard, (b) it can read `AGENTS.md` if pointed at
+`/etc/hal0`, (c) deeper lifecycle-hook ingestion is roadmap-only. For the
+redesign, Claude Code is a **first-class external MCP consumer** — the brain
+should treat "a user's Claude Code / Cursor" as a primary memory client, and
+the Cognee-style six-hook plugin is the obvious "deep" upgrade for the wiki.
+
+### 1.3 pi-coder — present but de-emphasized (NOT removed)
+
+`pi-coder` is still in `BUNDLED_AGENTS` and has a full driver
+(`src/hal0/agents/pi_coder.py`). Status per MEMORY: "narrowed to Hermes-only"
+for v0.2 *promo*, parked in-repo for v0.3 reactivation — the code is live, not
+deleted. How it gets context:
+
+- **MCP via pi-mcp-adapter**: the driver writes
+  `pi-mcp-adapter.json` pointing at `hal0-admin` (`/mcp/admin`) + `hal0-memory`
+  (`/mcp/memory`) with the Bearer token (`pi_coder.py:123-146`). A
+  proxy-tool routing layer (~200 tokens/dispatch vs dumping the full catalog).
+- **`pi-memory-md` left in place** — project-scoped markdown memory, an
+  *upstream* extension. CONTEXT.md is explicit this is a **different scope**
+  from hal0's cross-app memory MCP; they coexist, hal0 does not displace it
+  (`pi_coder.py:10-12`, `PLAN.md:1041-1042`). *This is a notable precedent: a
+  per-project markdown memory living alongside the central store — directly
+  analogous to an Obsidian wiki.*
+
+**Hook point:** same as Hermes — pi-coder consumes memory only through MCP, so
+the wiki tools would appear automatically. The `pi-memory-md` ↔ Obsidian
+analogy is worth mining in the design.
+
+### 1.4 Agent infrastructure (shared)
+
+- `src/hal0/agents/mcp_client.py` — the client side of hal0 reaching *external*
+  MCP servers (v0.3 stream #5, ADR-0013 allow-list; `PLAN.md:353-360`).
+- `src/hal0/agents/budget.py` — per-agent/persona token budgets.
+- `src/hal0/api/agents/` + `src/hal0/api/routes/agents.py` — REST surface
+  (`/api/agents`) for list/install/uninstall/switch + bootstrap/repair.
+
+---
+
+## 2. Apps / integrations advertised in README
+
+Grouped from `README.md`:
+
+**Bundled MCP servers (the cross-app contract):**
+- `hal0-admin` — slot / model / capability / config / hardware / log admin
+  (`README.md:165-168`).
+- `hal0-memory` — Cognee-backed long-term memory (`README.md:165-168`).
+- Both "reachable by any MCP-speaking client — Claude Code, future RAG
+  services, external scripts" (`README.md:166-168`).
+
+**Bundled agent app (single-pick):** `pi-coder` *or* `Hermes-Agent`
+(`README.md:162-178`).
+
+**Chat / UI apps:**
+- **Dashboard** — React 18 + Vite, with built-in chat page
+  (`README.md:126-131`).
+- **OpenWebUI** — prewired at `:3001`, installer writes `openwebui.env`
+  pointing at the local hal0 API (`README.md:132-133`;
+  `src/hal0/openwebui/`).
+
+**Inference / API integrations:**
+- **OpenAI-compatible `/v1/*`** — drop-in for any OpenAI SDK
+  (`README.md:97-100`; `src/hal0/api/routes/v1.py`). This is how *arbitrary
+  external apps* (Continue, Cursor's model backend, scripts) consume hal0.
+- **OmniRouter (8 client-side tools)** — `generate_image`, `edit_image`,
+  `text_to_speech`, `transcribe_audio`, `analyze_image`, `embed_text`,
+  `rerank_documents`, `route_to_chat` (`README.md:134-137`;
+  `src/hal0/omni_router/`). `embed_text` + `rerank_documents` are the
+  memory-adjacent ones — they expose the embed/rerank slots as tools any
+  chat slot can call.
+- **Dispatcher** with upstream fallback: OpenRouter, Anthropic, OpenAI, custom
+  OpenAI-shaped endpoints (`README.md:123-125`; `src/hal0/dispatcher/`,
+  `src/hal0/upstreams/`).
+
+**Roadmap integrations (not shipped):** ChatOps adapters (Slack, Matrix) as
+extensions (`README.md:350-351`); multi-host federation (`README.md:341-344`).
+
+---
+
+## 3. MCP host
+
+### 3.1 Bundled servers (baked in)
+
+Mounted at app start by `mount_mcp_servers` (`src/hal0/api/mcp_mount.py:105`):
+- `/mcp/admin` → `hal0-admin` (`mcp_mount.py:142`; impl `src/hal0/mcp/admin.py`).
+- `/mcp/memory` → `hal0-memory` (`mcp_mount.py:161`; impl `src/hal0/mcp/memory.py`).
+  Skipped silently if Cognee isn't installed (`mcp_mount.py:113-117`).
+
+`BUNDLED_SERVER_IDS = {"hal0-admin","hal0-memory"}` are uninstall-protected
+(`src/hal0/mcp/installed.py:49`); the route returns `409 mcp.bundled`.
+
+**Destructive-call gating:** capital-D MCP calls (`model_pull`, `slot_delete`,
+`config_write`, bulk `memory_delete`, …) route through an approval queue
+(`src/hal0/mcp/approval_queue.py`) surfaced as a header bell + inbox modal,
+with CLI parity (`README.md:174-177`). `memory_delete` carries
+`destructiveHint=True` (`src/hal0/mcp/memory.py:410-412`); bulk deletes gate
+at the admin layer (`memory.py:299-312`).
+
+### 3.2 Aftermarket MCP host platform (v0.3-alpha, partially shipped)
+
+The dashboard's `/agents/mcp` page hosts arbitrary user-installed MCP servers:
+- **`src/hal0/mcp/installed.py`** — registry of installed servers, one TOML per
+  server under `/etc/hal0/mcp-servers/<id>.toml` (`installed.py:1-25`),
+  list/install/uninstall/patch. Perms hardened 0600/0700 because env blocks
+  hold API keys (`installed.py:113-131`).
+- **`src/hal0/mcp/manifest.py`** — resolve-from-URL/spec: `oci://`, `npm:`,
+  `uvx:`, `git+https://`, or a live manifest URL, with an **SSRF guard**
+  (`manifest.py:68-165`) since the resolver is unauthenticated on the LAN.
+- **`src/hal0/mcp/probes.py`** — tool-surface introspection.
+- **`src/hal0/api/routes/mcp.py`** — the route layer. Note: **no process
+  supervision yet** — installed servers report `state="stopped"` until the
+  supervisor lands (`installed.py:16-20`); `POST /{id}/{action}` stubs 501
+  (`mcp.py:54-64`). A static `_CATALOG` of installable servers is hardcoded
+  (`mcp.py:75+`).
+
+### 3.3 What an external agent sees when it connects
+
+A user's Claude Code / Cursor pointed at hal0's MCP gets:
+- From `/mcp/memory`: `memory_add`, `memory_search`, `memory_list`,
+  `memory_delete` (annotated read-only/destructive per
+  `src/hal0/mcp/memory.py:400-413`).
+- From `/mcp/admin`: the full slot/model/capability/hardware/log admin surface,
+  with destructive ops gated through the approval queue.
+- It is **recognized by name** in the dashboard ClientsRibbon
+  (`mcp.py:495-523`) and its activity shows in the MCP audit stream
+  (`/api/mcp/stream`).
+
+Identity it presents (`X-hal0-Agent` or Bearer-derived `client_id`) drives its
+memory namespace. **This is the single most important external consumer for the
+redesign:** the wiki should expose read/search tools here so any IDE agent sees
+the Obsidian vault as first-class MCP resources/tools.
+
+---
+
+## 4. Slots / capabilities — embeddings are already a native slot
+
+"Memory" is **not** itself a capability slot. But the substrate a vector/graph
+memory needs — embeddings + rerank — **is** native:
+
+- Capability → (slot, type) map: `"embed": ("embed","embed")`,
+  `"rerank": ("embed","rerank")` (`src/hal0/capabilities/catalog.py:36-37`).
+  The `embed` capability card rolls up two children: `embed` + `rerank`
+  (`catalog.py:655-669`).
+- Seeded slots include `embed` and `rerank` (`README.md:101-106`). The rerank
+  slot lives on **port 8086**, model `bge-reranker-v2-m3-q4_k_m` (MEMORY
+  `hal0_rerank_slot_wiring`; confirmed `cognee_wrapper.py:209-214`).
+- **The memory store already consumes the rerank slot**: `CogneeWrapper`'s
+  optional rerank pass POSTs vector top-N candidates to the bundled embed-rerank
+  slot at port 8086 and reorders by relevance before clipping
+  (`cognee_wrapper.py:205-225`). Default rerank model matches the slot
+  (`cognee_wrapper.py:212-214`).
+- Cognee's **embedder** is currently fastembed-CPU (bge-small, 384-dim,
+  `cognee_wrapper.py:167-169`); PLAN flags switching to **bge-on-iGPU** as a
+  perf-only follow-up (`PLAN.md:1088`). That is the embed slot.
+- **NPU FLM trio** also fans out an `embed` capability
+  (`catalog.py:243`, `:256`), and exposes `embed-npu` as a slot
+  (`README.md:74-75`).
+
+**Implication:** Hindsight's embedding + rerank needs map onto *existing* hal0
+slots. The redesign should make the brain a **first-class consumer of the embed
+and rerank capabilities** (route Hindsight embeddings through the embed slot,
+reranking through port 8086), rather than bundling its own embedder. Consider
+whether "memory" deserves its own capability card in `capabilities.toml` so the
+dashboard can show its embed/rerank wiring and health.
+
+**Adjacent infra:** `src/hal0/journal/` (lemond log ring + fan-out for the
+Journal panel) and `src/hal0/events/` (in-process EventBus, 500-entry ring,
+footer status). Both are *operational* event streams, not memory — but they are
+candidate **producers** of memory ("what happened on this box") if the brain
+ingests events.
+
+---
+
+## 5. Dashboard surfaces
+
+Hash-routed SPA; routes:
+`["dashboard","chat","firstrun","slots","models","backends","logs","agent","settings","mcp"]`
+(`ui/src/dash/main.jsx:17`). Surfaces that touch memory / context / agents:
+
+| View / file | Touches |
+|---|---|
+| **Agent → Memory tab** (`ui/src/dash/agents/memory-tab.jsx`) | **The Cognee explorer.** GraphExtractionPanel (ADR-0014 route picker), Cognee stats (records/DB), recent records, namespaces side card, and a "Peer memory" subsection reading `/api/memory/search?dataset=agents&tag=agent-identity` (read-only, ADR-0011). Note: stats card currently shows mock numbers (`2,847 records`). |
+| **Agent → Personas tab** (`agents/personas-tab.jsx`, `persona-budget-panel.jsx`) | Persona = prompt + tool gating + **memory namespacing** layer. |
+| **Agent → Plugins tab** (`agents/plugins-tab.jsx`, `plugin-host.jsx`) | Hosts Hermes plugin UIs (incl. the memory plugin) in shadow-DOM via `/api/dashboard/plugins` proxy. |
+| **Agent → Skills tab** (`agents/skills-tab.jsx`) | Static skill catalog (v0.3). |
+| **Agent → Chat tab** (`agents/hermes-chat-tab.jsx`) | Hermes conversation — the live producer of `sync_turn` memory writes. |
+| **Agent view shell** (`agents/agent-view.jsx`, `sidebar-agent-block.jsx`) | Identity cards, reachability, bootstrap/repair/uninstall. |
+| **MCP page** (`mcp.jsx`, `mcp-main.jsx`, `mcp-modals.jsx`, `mcp-data.jsx`) | Lists bundled + installed MCP servers (incl. `hal0-memory`), per-server tool introspection, install drawer, ClientsRibbon (shows connected Claude Code/Cursor), identity-card reader. |
+| **Chat** (`chat.jsx`) | OmniRouter tool chips (incl. `embed_text`/`rerank_documents`), persona dropdown — built-in chat producer/consumer. |
+| **Dashboard / Memory map** (`dashboard.jsx`, `memory-map.jsx`) | **NOT the brain.** This is GTT/RAM *hardware* attribution (unified-memory bar, Proxmox host segment) — distinct from Cognee. Easy to confuse by name. |
+| **Settings** (`settings.jsx`) | Lemonade admin panel, Proxmox token, graph-extraction model route lives logically here / in Memory tab. |
+
+PLAN's v3 dashboard spec for these (`PLAN.md:293-316`): MCP page = list servers
++ tool introspection + identity-card reader; **Memory** = "Cognee dataset
+explorer (shared / private / `agents`); search + delete; per-agent namespace
+surfaced"; Agents = identity cards.
+
+---
+
+## 6. The integration map — where the new brain must hook in to feel native
+
+Prioritized. "Native" = a consumer gets memory/wiki without bespoke glue.
+
+### Tier A — the load-bearing seams (do these or it's bolted-on)
+
+1. **Preserve the dual transport contract.** Keep `/mcp/memory` (4 tools) +
+   `/api/memory/*` with the **`X-hal0-Agent` server-side namespace rule**
+   intact (`mcp/memory.py`, `routes/memory.py:48`, issue #317). Every agent +
+   external client inherits the brain through these. Add wiki read/search as
+   *new tools on the same MCP server* and *new routes under `/api/memory` or a
+   sibling `/api/wiki`* — not a separate service.
+
+2. **Hermes `prefetch()` injection seam** (`provider.py:137-161`). This is the
+   one place that already injects memory into every Hermes turn. Hindsight
+   retrieval + an Obsidian context block must land here. Likewise keep
+   `sync_turn()` (`provider.py:163`) and `on_memory_write()` (`:207`) as the
+   write seams.
+
+3. **Route embeddings + rerank through existing slots.** Make the brain a
+   consumer of the `embed` capability (embed slot; consider bge-on-iGPU,
+   `PLAN.md:1088`) and the `rerank` slot on port 8086 (already wired,
+   `cognee_wrapper.py:205-225`). Do not bundle a second embedder.
+
+4. **CogneeWrapper boundary** (`src/hal0/memory/cognee_wrapper.py`). If
+   Hindsight replaces/augments Cognee, this is the swap point — it already
+   isolates SQLite/LanceDB/Kuzu, graph gate, and the rerank client behind one
+   class. Keep its async `add/search/list/delete/list_items` contract so the
+   MCP + REST shims don't change.
+
+### Tier B — make it visible + operable (native UX)
+
+5. **Dashboard Agent → Memory tab** (`agents/memory-tab.jsx`) — wire the real
+   store stats (today mock `2,847`), add an **Obsidian wiki browser** + graph
+   view alongside the Cognee explorer. The GraphExtractionPanel already exists
+   for ADR-0014 routing.
+
+6. **MCP page ClientsRibbon + Memory MCP card** (`mcp.jsx`, `routes/mcp.py`) —
+   surface that Claude Code / Cursor are *reading the wiki/memory*, and show
+   the wiki tools on the `hal0-memory` server's introspection card.
+
+7. **Consider a `memory` capability card** in `capabilities.toml` /
+   `capabilities/catalog.py` so the brain's embed+rerank wiring + health show
+   up in the same UX language as voice/img/embed cards.
+
+### Tier C — deepen the external + roadmap surfaces
+
+8. **Claude Code / external agents** — ship the Cognee-style six-lifecycle-hook
+   ingestion path (`PLAN.md:1044`) so a user's Claude Code *produces* memory
+   into the wiki, not just reads it via MCP. This is the headline "every agent
+   feeds one brain" story.
+
+9. **Context files** (`HERMES.md.j2`, `AGENTS.md.j2`,
+   `hermes_provision._phase_context_link`) — add a "wiki index / how to query
+   memory" section so *any* agent landing in `/etc/hal0` (Claude Code, Cursor,
+   Codex) learns the brain exists.
+
+10. **Identity cards + `agents` dataset** (`hermes_provision.py:1386-1434`,
+    ADR-0011) — memory the brain holds *about its agents*. The wiki should
+    render these as people/agent notes.
+
+11. **pi-coder `pi-memory-md` precedent** (`pi_coder.py:10-12`) — a per-project
+    markdown memory already coexists with the central store. Mine this as the
+    design analogy for the Obsidian vault, and decide the federation story
+    (PLAN's "memory federation", `PLAN.md:361-364`).
+
+12. **Event/journal producers** (`src/hal0/events/`, `src/hal0/journal/`) —
+    optional: ingest operational events ("model X loaded", "slot evicted") as
+    machine-authored memory so the brain knows the box's history.
+
+---
+
+## 7. Consumers × {produces / consumes memory / consumes wiki}
+
+Legend: ✅ today · ◐ partial/aspirational · ✗ not yet · n/a not applicable.
+"Wiki" = the planned Obsidian vault (does not exist yet) — column shows where it
+*would* attach.
+
+| Consumer | Produces memory? | Consumes memory? | Consumes wiki? (planned) | How / seam |
+|---|---|---|---|---|
+| **Hermes-Agent** | ✅ `sync_turn` + `on_memory_write` → `/api/memory/add` (`provider.py:163,207`) | ✅ `prefetch()` per turn + `hal0_memory` MCP CRUD (`provider.py:137`) | ◐ via `prefetch` seam + HERMES.md | MemoryProvider plugin `hal0-cognee` |
+| **Hermes personas** | ◐ scopes write namespace | ✅ scopes read namespace + prompt | ◐ | `personas.py` |
+| **pi-coder** | ✅ via `hal0-memory` MCP | ✅ via `hal0-memory` MCP | ◐ MCP tools | `pi-mcp-adapter.json` (`pi_coder.py:123`) |
+| **pi-coder `pi-memory-md`** | ✅ project-scoped markdown (upstream, separate store) | ✅ same | n/a (design analogy for Obsidian) | upstream ext, coexists |
+| **Claude Code (external)** | ◐ only if it calls `memory_add`; six-hook plugin ✗ not impl | ✅ as MCP client of `/mcp/memory` | ◐ would see wiki MCP tools | `/mcp/memory` + `AGENTS.md`; recognized in ClientsRibbon |
+| **Cursor / Codex / other IDE agents** | ◐ MCP `memory_add` | ✅ MCP client | ◐ | `/mcp/memory`; `AGENTS.md` |
+| **`hal0-memory` MCP server** | n/a (transport) | n/a | n/a | `mcp/memory.py`, mount `/mcp/memory` |
+| **`hal0-admin` MCP server** | ✗ | ✗ (admin only) | ✗ | `mcp/admin.py` |
+| **Aftermarket MCP servers** | depends on server | depends | ✗ | `mcp/installed.py` registry |
+| **OmniRouter `embed_text` / `rerank_documents`** | ✗ | ✗ (but power memory's embed/rerank) | ✗ | `omni_router/`, slots embed + 8086 |
+| **`/v1/*` OpenAI API consumers (OpenWebUI, scripts, Continue)** | ✗ | ✗ (inference only) | ✗ | `routes/v1.py` |
+| **Dispatcher / upstreams** | ✗ | ✗ | ✗ | inference routing only |
+| **embed slot** | n/a | n/a | n/a | substrate: Cognee embeddings (`cognee_wrapper.py:167`) |
+| **rerank slot (8086)** | n/a | n/a | n/a | substrate: memory rerank pass (`cognee_wrapper.py:209`) |
+| **Identity cards (`agents` dataset)** | ✅ written by Hermes bootstrap | ✅ read by Memory/Agents views | ◐ render as agent notes | `hermes_provision.py:1386` |
+| **Dashboard Agent→Memory tab** | ◐ delete only | ✅ explorer/search | ◐ host wiki browser here | `agents/memory-tab.jsx` |
+| **Dashboard Chat / Agent→Chat** | ✅ drives Hermes `sync_turn` | ✅ shows prefetched context | ◐ | `chat.jsx`, `hermes-chat-tab.jsx` |
+| **Dashboard MCP page** | ✗ | ✅ shows memory server + clients | ◐ show wiki tools | `mcp.jsx` |
+| **Dashboard "Memory map"** | ✗ (hardware GTT, NOT brain) | ✗ | ✗ | `memory-map.jsx` — name collision only |
+| **events / journal** | ◐ candidate event-ingest producer | ✗ | ✗ | `events/`, `journal/` |
+
+---
+
+## 8. Assumptions & caveats (flagged)
+
+- **Cognee may be absent at runtime.** `mount_mcp_servers` skips `/mcp/memory`
+  if `cognee` isn't installed (`mcp_mount.py:113-117`). The whole brain surface
+  is therefore conditionally mounted — the redesign must handle the "no engine"
+  state.
+- **UI is `.jsx` (React-via-globals), not `.tsx`.** Views publish onto
+  `window.*` and read a `HAL0_DATA` seed; several memory numbers in
+  `memory-tab.jsx` are still mock placeholders. Inventory above is from headers
+  + structure, not a deep TS read (as briefed).
+- **pi-coder "parked" is a *promo* decision, not code removal** — the driver +
+  manager entry are live. I did not find a feature flag disabling it at
+  runtime; treat it as installable.
+- **Claude Code lifecycle-hook ingestion is roadmap text only** (`PLAN.md:1044`,
+  ADR-0005) — no code in this repo. The only real Claude Code touchpoint is
+  MCP-client recognition (`mcp.py:503`) + the shared `AGENTS.md`.
+- **`X-hal0-Agent` vs Bearer**: post-ADR-0012 hal0-api is auth-free on
+  `0.0.0.0:8080`; identity flows on `X-hal0-Agent` (REST) /
+  client-id-resolver (MCP). Older pi-coder code still writes a `Bearer` header
+  into the adapter config (`pi_coder.py:135-139`) — a known transitional
+  inconsistency, not a blocker.
+- **Graph + Memify are default-OFF** (ADR-0014). The brain's graph story is a
+  gate + introspection surface in v0.3; real LLM-routed extraction lands v0.4
+  (`cognee_wrapper.py:201-204`, `PLAN.md:347-351`).
+- The **rerank port (8086)** and **embed model** are config-driven defaults;
+  treat them as wiring to verify on a given host, not constants.

--- a/docs/internal/brain-redesign/05-memory-landscape.md
+++ b/docs/internal/brain-redesign/05-memory-landscape.md
@@ -1,0 +1,453 @@
+# 05 — Memory Landscape & Tradeoff Brief
+
+> **Purpose.** Frame the architecture decision for hal0's "brain": how to
+> combine the three memory paradigms (biomimetic vector engine, knowledge-graph
+> memory, human-legible compiled wiki) plus the file-memory + RAG baseline that
+> every coding agent already has, into one coherent system for a fully-local,
+> self-hosted AMD Strix Halo platform.
+>
+> **Status.** Research brief — not a decision. Seeds a grilling session (§7).
+> **Date.** 2026-06-02.
+> **Author.** Memory Systems Architect (research synthesis).
+
+---
+
+## 0. TL;DR
+
+- hal0 *today* runs **Cognee 1.0.7** embedded (SQLite + LanceDB + Kuzu), but
+  **graph extraction and Memify are disabled by default** (ADR-0005 §6,
+  ADR-0014 §1). In practice hal0 currently uses Cognee as a *plain local vector
+  store* with a hand-rolled SQLite sidecar for the dataset/tag/date filters that
+  Cognee 1.0's CHUNKS retriever does not honour. We are paying Cognee's
+  complexity cost and getting RAG.
+- The reason the graph is off is **not** laziness — it is the central
+  constraint of this whole document: **Cognee's `.cognify()` pipeline depends on
+  an LLM reliably emitting structured JSON, and small local models (<~32B) on a
+  CPU/iGPU box cannot do that reliably.** This is independently confirmed by the
+  field (see §6). hal0's own ADR-0005 §6 says exactly this.
+- The strongest emerging recommendation is a **two-tier brain**: a
+  machine-owned structured/semantic engine for fast recall, plus a
+  **human-legible compiled wiki** (Karpathy's "LLM Wiki") as the curated source
+  of truth. They are *not* redundant; they sit at different points on the
+  write-cost / legibility / staleness curve.
+- **Hindsight** (TEMPR + reflect + disposition + observations) is the most
+  complete "biomimetic" engine and is meaningfully better-architected for the
+  agent-memory job than hal0's neutered Cognee — but it is heavier (Postgres +
+  pgvector + cross-encoder + an extraction LLM) and carries the *same*
+  structured-extraction dependency for its richest features.
+
+---
+
+## 1. Taxonomy — sharp definitions
+
+These are the building blocks. Most "memory systems" are a *bundle* of several.
+
+| Term | One-liner | Canonical anchor |
+|---|---|---|
+| **File / wiki memory** | Plain markdown the agent reads *and writes* as full context; no retrieval step below the file granularity. `CLAUDE.md`, `MEMORY.md`, an Obsidian vault. | Karpathy LLM Wiki; CoALA "context". |
+| **Plain RAG** | Embed a query, vector-similarity search a chunk store, stuff top-k chunks into context, generate. Stateless; re-derives knowledge every query. | CoALA semantic-via-retrieval. |
+| **Vector memory** | RAG where the *agent's own past* (turns, facts) is the corpus. Persistent, append-only, similarity-recalled. | Mem0, hal0's current Cognee usage. |
+| **Biomimetic memory** | Vector memory + cognitive-science structure: multi-strategy recall, entity graph, temporal reasoning, **consolidation** of raw facts into evolving *observations/beliefs*, and a reasoning pass with stable *disposition*. | **Hindsight** (TEMPR, reflect, observations). |
+| **Knowledge-graph memory** | Ingestion extracts typed (subject, relation, object) triples into a graph DB *alongside* embeddings; recall does graph traversal + vector hints (multi-hop). | **Cognee** (ECL: Extract–Cognify–Load; Memify). |
+| **Compiled-knowledge wiki** | The LLM incrementally maintains an interlinked markdown wiki: ingest→summary+entity/concept pages, query→answer (filed back), lint→fix contradictions. Knowledge **compounds** instead of being re-derived. | **Karpathy LLM Wiki**. |
+
+### Cognitive-science memory types, mapped to agents (CoALA, arXiv:2309.02427)
+
+| Type | What it stores | hal0 surface today | Natural owner |
+|---|---|---|---|
+| **Working / in-context** | The context window itself — system prompt, recent turns, retrieved chunks. The only memory the model directly reasons over. | The live prompt + prefetch block. | Orchestrator / dispatcher. |
+| **Episodic** | Instance-specific past experiences: *what happened, when, in what order* ("I recommended X to user on date Y"). Single-shot, contextual (who/when/where/why). | `sync_turn` writes to Cognee `shared`/`private:*`. | Vector/biomimetic engine. |
+| **Semantic** | Abstracted, generalized facts & domain knowledge ("user prefers functional style"). | None really — Cognee chunks are episodic-flavoured; no consolidation runs. | Engine *observations* + the wiki. |
+| **Procedural** | Skills, workflows, code, "how we do X here." | `CLAUDE.md` behavioral rules; nothing dynamic. | The wiki (`schema` / playbooks). |
+
+> The ecosystem (Letta/MemGPT, Mem0, MIRIX) has converged on this 3-tier
+> (episodic/semantic/procedural) model over 2025–26, but the Dec-2025 survey
+> *Memory in the Age of AI Agents* (arXiv:2512.13564) explicitly calls it "a
+> starting point, not a final answer" — the **consolidation pathway**
+> (episodic→semantic) and **multi-agent governance** are the open frontiers.
+> Both are exactly hal0's open questions (§3, §5).
+
+---
+
+## 2. Comparison matrix
+
+Scored for hal0's reality: fully local, AMD Strix Halo (iGPU + XDNA NPU via
+Lemonade) for the runtime LLM, CPU elsewhere, no cloud. "Token cost at recall" =
+tokens injected into the agent's context per query.
+
+| Paradigm | Write cost | Recall latency | Human-legible | Structure | Staleness handling | Multi-agent sharing | Local feasibility | Token cost @ recall |
+|---|---|---|---|---|---|---|---|---|
+| **File / wiki (raw)** | Trivial (append) | Zero (it's in context) | **Excellent** | Flat→linked | **Manual** (rots silently) | Filesystem perms / git | **Trivial** | High & fixed (whole file) |
+| **Compiled LLM Wiki** | **High** (LLM rewrites 10–15 pages/ingest) | Low (read index→pages) or zero (small vault in context) | **Excellent** (it's *for* humans) | Interlinked MD + graph | **Active** (lint pass flags contradictions/stale) | Git branches / page namespaces | High (needs a capable LLM to maintain) | Low–med (index + cited pages) |
+| **Plain RAG** | Low (chunk + embed) | Low (1 ANN search) | Poor (chunks) | None | None (no dedup/decay) | Per-collection | **Trivial** (embeddings only) | Med (top-k chunks) |
+| **Vector memory** (hal0/Cognee-as-used) | Low (embed; sidecar row) | Low (ANN + sidecar filter) | Poor | None below chunk | Weak (timestamp recency only) | Dataset namespaces ✓ (hal0 already) | **Trivial** (fastembed bge-small, 384-d) | Med (top-k) |
+| **Biomimetic** (Hindsight) | **Med–High** (LLM fact-extraction at retain; async consolidation) | Med (4 strategies + RRF + cross-encoder) | Med (facts/observations readable, graph less so) | Entity + temporal + causal graph; observations | **Strong** (observations dedup/refine/decay; freshness trend; stale-verify) | Tags + banks; per-bank disposition | **Viable** local; reranker + embed local, but quality of *retain* tracks the local LLM | Med (token-budgeted by design) |
+| **Knowledge-graph** (Cognee, graph ON) | **High** (LLM triple-extraction per chunk; Memify) | Med–High (graph traversal + vector) | Med (graph inspectable) | **Strong** typed graph + ontology | Med (Memify prunes/strengthens) | Per-dataset isolation ✓ | **Fragile local** — `.cognify()` needs reliable structured JSON; <32B local models produce noisy graphs (§6) | Med |
+
+**Sharpest rows for the decision:**
+
+1. **Write cost vs legibility are inversely correlated.** The cheapest writes
+   (RAG/vector) produce the least legible artifact; the most legible artifact
+   (wiki) has the most expensive write. There is no free lunch — you choose
+   where to pay.
+2. **Staleness is where naive vector memory dies.** Append-only vector stores
+   accumulate contradictions ("user prefers React" + "user switched to Vue")
+   and surface both. Only **consolidation** (Hindsight observations, Cognee
+   Memify) or an **active lint pass** (wiki) resolves this. hal0 today has
+   *neither* running.
+3. **Local feasibility forks on one question: does the feature need the LLM to
+   emit reliable structured output?** Embedding + ANN + reranking are all cheap
+   and local-fine. Graph/triple extraction and rich fact-extraction are *not*
+   reliable on a <32B local model. This single fact drives §4 and §6.
+
+---
+
+## 3. The "two-tier brain" thesis
+
+### The claim
+
+A coherent brain has exactly two durable tiers, plus the ephemeral working tier:
+
+- **Tier W — working memory:** the context window. Owned by the orchestrator.
+- **Tier E — the engine (machine-owned, fast, structured):** a
+  vector/biomimetic store. Captures *everything* cheaply (every turn, every
+  fact), recalls by similarity/graph/time, and **consolidates** episodic noise
+  into semantic observations. Optimised for recall latency and recall, not for
+  human reading. This is the agent's *hippocampus + association cortex*.
+- **Tier C — the wiki (human-legible, curated, the source of truth):** an
+  interlinked markdown corpus the LLM maintains and humans read. Optimised for
+  legibility, auditability, and *compounding*. This is the agent's *published
+  notebook* — the cortex's consolidated, write-up form.
+
+### Why two tiers and not one
+
+- **One engine only** → fast but illegible. Humans can't audit, correct, or
+  trust it; staleness is invisible; "what does my agent believe?" has no
+  answer a person can read. hal0's current state.
+- **One wiki only** → legible but (a) write-expensive at every fact, (b)
+  retrieval is page-granular (you read whole pages), and (c) it does not scale:
+  Karpathy himself notes the pure-context approach wins **only below
+  ~50k–100k tokens (~150–200 pages)**; past that you need an index/engine. A
+  pure wiki cannot hold a year of raw conversation turns.
+
+The two tiers are **the consolidation pathway made physical**: Tier E is where
+raw episodic experience lands and gets compressed; Tier C is where the
+compressed, curated semantic/procedural knowledge is published for humans.
+
+### How they should relate (the real design questions)
+
+1. **Which is canonical?** *Proposal:* **the wiki (Tier C) is canonical for
+   curated knowledge; the engine (Tier E) is canonical for raw recall.** A
+   human-readable claim in the wiki overrides a stale fact in the engine. The
+   engine is canonical for "what was literally said on 2026-05-12" because the
+   wiki will never hold that volume.
+2. **Does the wiki get embedded into the engine?** *Proposal:* **yes, one-way.**
+   Wiki pages are ingested into Tier E as high-priority documents so similarity
+   recall can surface them. This mirrors Hindsight's *mental models* (curated
+   summaries checked **first**) and reflect's hierarchy
+   (mental models → observations → raw facts). The wiki literally becomes the
+   top of the recall hierarchy.
+3. **Does `reflect()`/consolidation write *to* the wiki?** *This is the crux.*
+   Two postures:
+   - **Conservative (recommended start):** consolidation writes *observations*
+     inside Tier E only. A separate, **explicitly invoked** "compile" step (the
+     wiki ingest/lint pattern) promotes durable observations into wiki pages,
+     with a human in the loop. Keeps the human source-of-truth human-curated.
+   - **Aggressive:** the agent auto-writes wiki pages on consolidation. Higher
+     compounding, but the wiki stops being trustworthy-by-construction and
+     becomes another thing to lint. Karpathy's pattern *does* file good query
+     answers back as pages — but he is the reviewer in the loop.
+
+### Counter-case (argue the other side honestly)
+
+- **A good biomimetic engine may make the wiki redundant.** Hindsight's
+  observations already *are* consolidated, deduplicated, evidence-cited,
+  freshness-tracked semantic memory — and they're human-readable text. If you
+  add a read-only HTML/Obsidian *view* over observations, you arguably get
+  Tier C's legibility without maintaining a second store. The wiki's unique
+  value then shrinks to: hand-authored procedural knowledge + interlinking +
+  git history.
+- **Two stores = two staleness problems = drift.** hal0 has *already been burned
+  by exactly this*: the `capabilities.toml` ↔ `slots/*.toml` drift bug, the
+  MEMORY.md-vs-reality drift, the `state.json` backend drift. A second
+  source of truth that can disagree with the first is an operational liability
+  unless the promotion direction is strictly one-way and tested.
+- **YAGNI at hal0's scale.** A single-user home box may never exceed Karpathy's
+  100k-token wiki threshold for *curated* knowledge. If so, the wiki *is* the
+  engine, in-context, and Tier E is only needed for raw-turn recall.
+
+**Net:** the two-tier thesis is sound, but its weakest seam is the
+**promotion/consolidation direction** between tiers. Get that wrong and you
+rebuild hal0's drift bugs at the brain layer. (→ §7 Q1, Q2.)
+
+---
+
+## 4. Where Cognee fits or exits
+
+### Where Cognee is *now* in hal0 (grounded in source)
+
+- Embedded: SQLite (relational) + LanceDB (vector) + Kuzu (graph), all
+  file-based under `/var/lib/hal0/memory/cognee` (`cognee_wrapper.py`).
+- **Graph extraction OFF by default** (ADR-0014 §1); **Memify never runs**;
+  the stripped pipeline is `classify → chunk → embed` only (ADR-0005 §6,
+  `_chunk_and_embed`). `LLM_API_KEY` is a noop placeholder.
+- Search is `SearchType.CHUNKS` = **pure vector retrieval, no graph, no LLM**.
+- A **SQLite sidecar** (`hal0_memory_index.sqlite`) shadows dataset/tags/source/
+  metadata/timestamp because *"Cognee 1.0's vector retriever does not natively
+  respect"* dataset isolation, tag AND-match, or date range. hal0 is
+  re-implementing the filtering layer Cognee was supposed to provide.
+- Namespacing (`shared` + `private:<client_id>`), audit log, and rerank are all
+  hal0 code in the wrapper, *not* Cognee features.
+
+**Blunt assessment:** hal0 is running a 3-database knowledge-graph engine to do
+the job of `pgvector + a WHERE clause`, with the graph — Cognee's entire reason
+to exist — switched off because it doesn't work on local models. We carry the
+dependency surface (Cognee version churn, lru_cache singleton fights, the tower
+of "store is empty" exceptions the wrapper catches) for a vector store.
+
+### Why the graph is off — and why that won't change cheaply
+
+Independently confirmed by the field (§6): Cognee's `.cognify()` leans on
+Instructor/BAML **structured JSON output**. Small local models (Qwen3-4B,
+Mistral-7B, even up to ~32B) fail format compliance, retry through long tenacity
+windows (10+ min silent hangs reported), and produce **noisy graphs that
+pollute retrieval**. Cognee's own guidance: clean graphs need **32B+** models;
+the honest community verdict is "great with hundred-billion-param models, failed
+on self-hosted hardware." hal0's primary slot on Strix Halo is in the
+sub-32B-quantized range. **The graph hal0 disabled is the graph hal0 cannot
+reliably run locally.**
+
+### Options
+
+**(a) Keep Cognee, turn the graph on (most "proper" if it worked).**
+- *For:* multi-hop reasoning, ontology grounding, the 92.5%-vs-60% accuracy
+  numbers Cognee markets.
+- *Against:* requires a 32B+ structured-output-reliable LLM hal0 doesn't have
+  locally; reintroduces the cognify hang/instability risk; Memify maintenance
+  cost. Effectively blocked on hardware/model quality, not code.
+
+**(b) Replace Cognee with Hindsight (recommended candidate for Tier E).**
+- *For:* Hindsight is *designed* for the agent-memory job hal0 actually needs —
+  TEMPR (semantic+BM25+graph+temporal+RRF+cross-encoder), **observations
+  consolidation** (the staleness fix hal0 lacks), reflect with disposition, and
+  a **native token-budgeted recall** (agents think in tokens — hal0 currently
+  hard-caps top_k). Local-first: embeddings + reranker run local with no keys;
+  llama.cpp/Ollama/LM Studio supported as the LLM provider. Single Postgres
+  backend (pgvector + tsvector + recursive-CTE graph) — *fewer* moving stores
+  than Cognee's three. Already integrated with **Hermes** upstream
+  (`NousResearch/hermes-agent` ships a Hindsight memory plugin), which is hal0's
+  bundled agent.
+- *Against:* Postgres dependency (vs Cognee's embedded SQLite) — heavier than
+  the current single-file story, though "local embedded" mode + a bundled PG
+  daemon exists. Its richest features (`retain` fact-extraction, the graph,
+  `reflect`) carry the **same** local-LLM-quality dependency as Cognee's
+  cognify — but degrade more gracefully: recall works with **no LLM at all**
+  (semantic+BM25+temporal+rerank are pure-local), so you get a *better vector
+  store than Cognee-as-used* even before any extraction. Migration cost: move
+  the `add/search/list/delete` contract from the Cognee wrapper onto
+  retain/recall; re-home namespacing (Hindsight has *banks* + *tags*); re-point
+  the Hermes plugin (already exists upstream).
+
+**(c) Run both.** Cognee for graph experiments, Hindsight for production recall.
+- *Against:* two engines, two staleness models, double the ops. Only justified
+  if a specific graph/ontology workload demands Cognee that Hindsight's graph
+  strategy can't serve. **Not recommended** for a home box.
+
+**(d) Drop the engine to plain `pgvector` + sidecar.**
+- *For:* honest about what hal0 uses today; minimal deps.
+- *Against:* throws away the *upgrade path* to consolidation/observations that
+  fixes staleness. You'd reinvent Hindsight's observations eventually.
+
+### Verdict
+
+**Replace Cognee with Hindsight as Tier E (option b), staged.** Hindsight is
+strictly more aligned with hal0's needs (consolidation, token-budgeting,
+disposition, Hermes integration) and degrades to "a better local vector store"
+when the local LLM is too weak for extraction — which is precisely hal0's
+constraint. Keep Cognee only if a concrete graph/ontology workload appears that
+Hindsight's graph strategy demonstrably can't serve, and only once a 32B+
+structured-output model is locally viable on Strix Halo.
+
+> **Honesty flag.** This verdict leans on Hindsight's *self-published*
+> architecture docs + the upstream Hermes plugin's existence. The
+> head-to-head recall-quality claim ("better than Cognee-as-used") is an
+> *architectural* judgement, not a benchmark hal0 has run. **Before
+> committing, run hal0's δ/eval harness on both with the actual local primary
+> model and a representative memory corpus.** (→ §7 Q5.)
+
+---
+
+## 5. Multi-agent memory
+
+Actors today: **Hermes** (bundled), **external Claude Code** sessions, future
+**aftermarket MCP agents** (the `/agents` MCP-host platform). hal0 already has
+the right *primitive*: `shared` + `private:<client_id>` datasets, identity from
+`X-hal0-Agent` (Hermes) / Bearer-extracted `client_id`, enforced in
+`namespace.py` + the wrapper.
+
+### Recommended model
+
+- **Three namespace scopes**, not two:
+  1. **`shared`** — the common brain. Both the engine's consolidated
+     observations *and* the wiki live here. All trusted agents read; writes are
+     **moderated** (see trust below).
+  2. **`private:<agent_id>`** — per-agent scratch/episodic. The agent reads its
+     own + `shared`; never another agent's private (already enforced —
+     `_allowed_read_datasets` silently drops foreign `private:*`).
+  3. **`project:<id>` / custom** — task- or repo-scoped working sets that
+     several agents share for the duration of a job, then archive. hal0 already
+     passes custom datasets through verbatim; formalise them.
+- **The wiki gets the same namespacing.** `shared/wiki/`, plus optional
+  per-project wikis. Git is the natural ACL + history layer for Tier C; the
+  engine's dataset filter is the ACL for Tier E.
+
+### Trust / privacy
+
+- **Write trust is the hard part.** A shared brain that any agent can write to
+  is a poisoning vector and a drift vector. *Proposal:* episodic writes to
+  `shared` are cheap and allowed (append-only, attributed via `source` /
+  audit log — hal0 already stamps `client_id` on every op). But **promotion
+  into consolidated observations / the wiki** (the durable, trusted layer) is
+  gated: either human-approved, or only from a designated agent (e.g. Hermes as
+  the "librarian"), or quarantined until corroborated (Hindsight's *proof_count*
+  boost is exactly this signal — observations with more independent evidence
+  rank higher).
+- **Privacy is already mostly right.** Keep the fail-open-empty read posture
+  (foreign private → `[]`, not an error, to avoid leaking existence). Keep the
+  `private:*`-by-name rejection for non-private callers (PR #366 hardening).
+- **External Claude Code** is an *untrusted-ish* peer: give it a `client_id`,
+  let it read `shared` + its own private, but **default it to no
+  shared-observation/wiki write** until explicitly trusted. It's a guest in the
+  house, not a resident.
+
+### Namespacing recommendation (one line)
+
+**`shared` (curated, write-gated) + `private:<agent_id>` (free, attributed) +
+`project:<id>` (scoped, ephemeral)**, with identity from `X-hal0-Agent`/Bearer,
+git ACLs for the wiki, dataset filters for the engine, and **promotion to the
+durable layer always gated** (human or librarian-agent + proof-count
+corroboration).
+
+---
+
+## 6. Self-host constraints
+
+Hardware: Strix Halo iGPU + XDNA NPU + unified memory on LXC 105 (runtime LLM via
+Lemonade); hal0-dev VM and most services are CPU-only; **no cloud, no NVIDIA
+CUDA.** What each paradigm costs here:
+
+| Component | Local cost | Verdict on Strix Halo |
+|---|---|---|
+| **Embeddings** | `bge-small-en-v1.5` (384-d, ~130MB) via fastembed/SentenceTransformers — **CPU-fast**, no GPU needed. Already hal0's default. | ✅ Trivial. |
+| **Vector ANN** | LanceDB (file) today; pgvector HNSW under Hindsight. Both CPU-fine at home-box scale. | ✅ Trivial. |
+| **Reranker (cross-encoder)** | `ms-marco-MiniLM-L-6-v2` (~85MB) CPU, or hal0's bundled GPU rerank slot (port 8086, `bge-reranker-v2-m3`). | ✅ Already wired. |
+| **Fact / triple extraction (LLM)** | Needs the runtime LLM. **This is the bottleneck.** Strix Halo runs sub-32B quantized models; structured-output reliability is the failure mode (§4). | ⚠️ Marginal — the whole reason Cognee's graph is off. |
+| **Storage** | LanceDB/SQLite (Cognee) or Postgres (Hindsight). Postgres is the only *new* daemon a Hindsight move adds. | ✅ Fine; PG can be a bundled local instance. |
+| **The wiki** | Pure markdown on disk + git. **Zero infra.** Maintenance = LLM tokens at ingest/lint time. | ✅ Cheapest store, most expensive writes (LLM time). |
+
+**Viability ranking, fully-local on this hardware:**
+
+1. **File/wiki memory** — fully viable, near-zero infra; cost is LLM *time* to
+   maintain (one capable local model, run at ingest, not per query).
+2. **Plain RAG / vector memory** — fully viable; this is hal0's sweet spot
+   today (CPU embeddings + ANN + optional GPU rerank).
+3. **Biomimetic (Hindsight) — recall path** — fully viable local (no LLM needed
+   for semantic+BM25+temporal+rerank). **Write/consolidation path** degrades
+   with local LLM quality but does not *break* (it extracts fewer/rougher
+   facts).
+4. **Knowledge-graph (Cognee graph / Memify)** — **the only paradigm that is
+   genuinely fragile fully-local**, because triple extraction *requires*
+   reliable structured output that sub-32B models don't deliver. Either route
+   extraction to a larger model (defeats the "no cloud" constraint) or accept
+   noisy graphs.
+
+**Key constraint, restated:** *local embedding/retrieval is free; local
+structured-extraction is the scarce resource.* Architect so the brain is
+**useful with zero LLM extraction** and gets *better*, not *functional*, as the
+local model improves. Hindsight's recall-without-LLM property fits this;
+Cognee's graph-requires-LLM property fights it.
+
+---
+
+## 7. Open architectural questions (grilling seeds)
+
+1. **Promotion direction.** Is the wiki canonical and the engine derived, or the
+   engine canonical and the wiki a published view? One-way promotion
+   (engine→wiki) or bidirectional? Who/what triggers it — a human, a `compile`
+   command, or auto-on-consolidation? *(This is the seam most likely to recreate
+   hal0's drift bugs.)*
+
+2. **Does consolidation write durable memory, or just rank it?** Hindsight
+   observations *evolve beliefs* automatically. Do we trust an unsupervised
+   local-LLM consolidation to mutate the shared brain, or is consolidation
+   advisory (re-ranks recall) until a human/librarian promotes it?
+
+3. **Cognee exit cost vs benefit — measured, not asserted.** Run the δ/eval
+   harness: Cognee-as-used (vector) vs Hindsight recall vs plain pgvector, on
+   the *actual* Strix Halo primary model and a real hal0 memory corpus. Is
+   Hindsight's recall measurably better, or are we trading one dependency for
+   another with no quality delta?
+
+4. **Where does the wiki physically live and who renders it?** `shared/wiki/`
+   in the hal0 data dir served read-only via the dashboard? An actual Obsidian
+   vault on an NFS share? Git repo with PR-style promotion? This decides the
+   human-in-the-loop ergonomics (§3 conservative posture).
+
+5. **Local structured-output: invest or route?** Is it worth standing up a
+   grammar-constrained / `tool_call`-mode extraction path on a 32B+ quantized
+   model on Strix Halo to make graph/fact-extraction reliable — or do we
+   permanently design the brain to *not need* reliable extraction (recall-only
+   engine + hand-curated wiki)? This is the fork that decides whether the graph
+   ever comes back on.
+
+6. **Shared-write trust model.** Append-only-attributed for episodic, gated for
+   durable — but *who* is the gate? Human approval doesn't scale to a chatty
+   multi-agent box; a "librarian agent" centralizes a failure point;
+   proof-count corroboration needs multiple independent witnesses that a
+   single-user box may never get. What's the actual default?
+
+7. **Working-memory budget ownership.** With three durable surfaces (wiki pages,
+   observations, raw facts) all wanting context space, who arbitrates the
+   per-turn token budget — the orchestrator, or a recall-time policy
+   (mental-models→observations→facts hierarchy, hard token cap)? hal0's recall
+   already hard-caps `top_k`; the budget should be *tokens*, agent-style, not
+   result counts.
+
+8. **External agents and the brain.** Should an external Claude Code session
+   read hal0's shared brain at all by default? If yes, via MCP recall tools; if
+   no, what's the opt-in? (Ties to the `/agents` MCP-host trust model.)
+
+---
+
+## Sources
+
+- Hindsight docs (local skill `hindsight-docs`): `index.md`, `rag-vs-hindsight.md`,
+  `retrieval.md` (TEMPR, RRF, cross-encoder, token budgeting), `reflect.md`
+  (agentic loop, disposition, mental-models hierarchy), `retain.md`
+  (fact/entity/causal extraction, consolidation), `storage.md` (Postgres +
+  pgvector + tsvector + recursive-CTE graph; pg0 embedded), `models.md`
+  (embeddings/reranker/LLM providers, local llama.cpp/Ollama).
+- Karpathy, "LLM Wiki" gist — https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+  (three layers: raw sources / wiki / schema; ingest–query–lint; Obsidian as
+  viewer; ~50k–100k-token threshold where context beats RAG).
+- Cognee architecture — https://www.cognee.ai/blog/fundamentals/how-cognee-builds-ai-memory ,
+  https://memgraph.com/blog/from-rag-to-graphs-cognee-ai-memory ,
+  https://www.lancedb.com/blog/case-study-cognee (ECL pipeline, Memify, ontology grounding,
+  graph+vector dual store, datasets).
+- Cognee local-model reliability — https://www.glukhov.org/post/2025/12/selfhosting-cognee-quickstart-llms-comparison/ ,
+  https://github.com/topoteretes/cognee/issues/1812 ,
+  https://github.com/topoteretes/cognee/issues/2119 (structured-output failures on <32B
+  local models; 32B+ recommended; cognify hangs/instability).
+- Hindsight self-host / local — https://hindsight.vectorize.io/blog/2026/03/10/run-hindsight-with-ollama ,
+  https://github.com/vectorize-io/hindsight ,
+  https://github.com/NousResearch/hermes-agent/blob/main/plugins/memory/hindsight/README.md
+  (Hermes integration), https://www.glukhov.org/ai-systems/memory/agent-memory-providers/
+  (provider footprint comparison).
+- Agent memory taxonomy — CoALA, arXiv:2309.02427; *Memory in the Age of AI
+  Agents: A Survey*, arXiv:2512.13564; *Episodic Memory is the Missing Piece*,
+  arXiv:2502.06975; Letta/MemGPT, Mem0 (arXiv:2504.19413), MIRIX.
+- hal0 source (ground truth on current usage): `src/hal0/memory/cognee_wrapper.py`
+  (graph OFF, CHUNKS-only, SQLite sidecar, namespacing, rerank), `namespace.py`
+  (ADR-0005 §3), `src/hal0/agents/hermes/plugins/memory_cognee/README.md`;
+  ADR-0005 (Cognee engine), ADR-0014 (graph-extraction gate).
+```

--- a/docs/internal/brain-redesign/06-proposed-architecture.md
+++ b/docs/internal/brain-redesign/06-proposed-architecture.md
@@ -1,0 +1,688 @@
+# 06 — Proposed Architecture: hal0's Unified Brain
+
+**Status:** Proposed architecture — opinionated, decisive, marks genuine forks for grilling.
+**Date:** 2026-06-02
+**Author:** AI Memory Systems Architect
+**Inputs:** dossiers 01 (Hindsight) · 02 (hal0-wiki) · 03 (current-memory audit) · 04 (consumer surface) · 05 (landscape & tradeoffs).
+**Supersedes (engine):** ADR-0005 (Cognee), ADR-0014 (Cognee graph gate). **Extends:** ADR-0011 (`agents` dataset), ADR-0012 (`X-hal0-Agent`, no-auth).
+
+> This is the synthesis document the five dossiers feed into. It is written to be
+> *grilled*: every load-bearing decision has a recommended default **and** the
+> alternatives it beat, and §10 enumerates the decisions still genuinely open.
+
+---
+
+## 1. Thesis & principles
+
+### Thesis (one paragraph)
+
+hal0's brain is **two durable tiers behind one access plane**: a machine-owned
+**Engine** (Hindsight, replacing the neutered Cognee) that captures every turn
+and fact cheaply, recalls them with multi-strategy + token-budgeted retrieval,
+and *consolidates* episodic noise into evidence-grounded, freshness-tracked
+**observations**; and a human-legible **compiled-knowledge Wiki** (the
+hal0-wiki / Karpathy LLM-Wiki layer on an Obsidian-flavored markdown vault) that
+holds the curated, cross-linked, auditable knowledge a person reads, edits, and
+trusts. The Engine is the hippocampus; the Wiki is the published notebook. They
+relate through a **strictly one-way promotion pipeline** (Engine observation →
+gated promotion → Wiki page → re-embedded back into the Engine as a
+top-of-hierarchy "mental model"), so there is exactly **one canonical owner per
+fact-class** and the two stores cannot silently disagree. Every consumer —
+Hermes, external Claude Code, pi-coder, OpenWebUI, the dashboard — reaches both
+tiers through the *unchanged* `/mcp/memory` + `/api/memory/*` contract with the
+`X-hal0-Agent` namespace rule, so the redesign is felt as a deeper brain, not a
+new service bolted on.
+
+### Design principles (the constitution)
+
+1. **Single source of truth per fact-class.** Raw episodic ("what was literally
+   said on 2026-05-12") is canonical in the Engine. Curated semantic/procedural
+   knowledge ("how we do X here", "the user's stable preferences") is canonical
+   in the Wiki. No fact-class has two owners. This is the principle that kills
+   the drift bugs hal0 has already been burned by (`capabilities.toml`↔slot,
+   `MEMORY.md`↔reality, `state.json` backend drift — dossier 05 §3).
+
+2. **No bolt-on.** The brain attaches at seams that already exist: the engine
+   seam (`CogneeWrapper` → `MemoryProvider` ABC), the Hermes `prefetch()` /
+   `sync_turn()` hooks, the embed + rerank capability slots, the `/mcp/memory`
+   surface, the dashboard Agent→Memory tab. A consumer should get the new brain
+   without bespoke glue. If a feature needs a new front door, the design is wrong.
+
+3. **Local-first, degrade-don't-break.** The brain must be *useful with zero LLM
+   extraction* and get *better* (not merely *functional*) as the local model
+   improves. Embedding + ANN + rerank are free locally; reliable structured
+   extraction is the scarce resource (dossier 05 §6). Architect so recall works
+   with no LLM at all; route the extraction LLM to Lemonade and treat its quality
+   as a tunable, not a prerequisite.
+
+4. **Drift-resistance by construction.** Promotion is one-way and tested. The
+   Wiki never writes back into the Engine as authoritative; it is re-embedded as
+   a *derived index entry*. Consolidation mutates the Engine's own observations
+   only. A conformance test suite pins the contract so a swap can't regress it.
+
+5. **Provenance & gating are first-class.** Every write is attributed
+   (`source`/`client_id`, already stamped). Promotion into the durable curated
+   layer is *gated* (human, librarian agent, or proof-count threshold) — never an
+   unsupervised local-LLM mutation of the shared brain.
+
+---
+
+## 2. Layered model
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  CONSUMERS                                                                     │
+│  Hermes (prefetch/sync_turn)  · external Claude Code (MCP guest)               │
+│  pi-coder · OpenWebUI · dashboard Agent→Memory tab · journal/events            │
+└───────────────┬────────────────────────────────────────────────┬─────────────┘
+                │                                                  │
+                ▼                                                  ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  (c) ACCESS PLANE  — the one front door, unchanged contract                    │
+│                                                                                │
+│    /mcp/memory  (FastMCP)         /api/memory/*  (REST)        /api/wiki/* (REST)│
+│    memory_add/search/list/delete  add/search/list/delete       page render/list │
+│    + wiki_search / wiki_get       + /graph gate (→ engine caps) + graph.json    │
+│                                                                                │
+│    X-hal0-Agent  →  namespace:  shared · private:<agent> · project:<id> · agents│
+│    (resolved server-side in hal0.memory.namespace — clients never send dataset)│
+└───────────────┬────────────────────────────────────────────────┬─────────────┘
+                │  MemoryProvider ABC (the linchpin — §3)          │
+                ▼                                                  ▼
+┌───────────────────────────────────────────┐   ┌────────────────────────────────┐
+│  (a) ENGINE  — Hindsight (Tier E)          │   │  (b) WIKI  — hal0-wiki (Tier C) │
+│  machine-owned · fast · structured         │   │  human-legible · curated · canon│
+│                                            │   │  -ical for curated knowledge    │
+│  retain  → extract → graph → consolidate   │   │                                 │
+│  recall  → TEMPR → RRF → x-encoder → budget│   │  markdown vault @ /var/lib/hal0/│
+│  reflect → agentic loop + disposition      │   │  wiki  (git-backed)             │
+│                                            │   │  index.md/log.md/hot.md/.manifest│
+│  observations = consolidated beliefs       │   │  concepts/entities/skills/...   │
+│  + freshness trend (the staleness fix)     │   │  maintained by the LIBRARIAN    │
+│  banks ↔ shared / private:<id> / project:  │   │  (Hermes-as-librarian, §5)      │
+│                                            │   │                                 │
+│  embeddings → embed slot                   │   │  search index → POINTS AT THE   │
+│  rerank     → rerank slot (:8086)          │◄──┤  ENGINE (not QMD): re-embed     │
+│  extraction → lemond:13305                 │   │  changed pages as mental_models │
+│  storage    → embedded Postgres (pg0)      │   │  one-way: Wiki → Engine index   │
+└───────────────────────────────────────────┘   └────────────────────────────────┘
+        ▲  promotion (gated, one-way) ─────────────────────────────┘
+        │  Engine observation ── promote ──▶ Wiki page ── re-embed ──▶ Engine mental_model
+        └───────────────────────────────────────────────────────────
+```
+
+### Layer definitions (crisp)
+
+- **(a) Engine — Hindsight.** Episodic + semantic recall + consolidation. Owns
+  raw turns/facts and the *observations* derived from them. Optimised for recall
+  latency and recall quality, not human reading. **Canonical for raw episodic
+  recall.** Verbs: `retain` (LLM extract → 4-edge graph → background
+  consolidation), `recall` (TEMPR 4-way → RRF → cross-encoder → token budget),
+  `reflect` (agentic loop with disposition). The staleness fix Cognee-as-used
+  lacks lives here: observations dedup/refine/decay and carry a freshness trend.
+
+- **(b) Compiled-knowledge Wiki — hal0-wiki.** Curated, human-legible,
+  cross-linked markdown. **Canonical for curated knowledge** (procedural
+  playbooks, stable semantic facts, hand-authored architecture notes, agent
+  identity write-ups). No daemon — it is a directory of markdown plus skill files
+  the *agent* executes. Carries provenance/confidence/lifecycle/typed-relationships
+  in frontmatter. Its swappable search index points at the **Engine** (not QMD).
+
+- **(c) Access plane.** The single front door: `/mcp/memory` (4 memory tools +
+  new `wiki_search`/`wiki_get`), `/api/memory/*` (CRUD + graph gate), and a
+  sibling `/api/wiki/*` for page render/list/graph. The `X-hal0-Agent` →
+  namespace contract (resolved server-side in `hal0.memory.namespace`) is
+  preserved verbatim. **Adding the Wiki adds *tools on the same server*, not a
+  new service.**
+
+- **(d) Consumers.** Hermes (deep, via the plugin `prefetch`/`sync_turn` seam),
+  external Claude Code (first-class MCP guest), pi-coder (MCP), OpenWebUI &
+  `/v1/*` (inference only, no memory by default), the dashboard Agent→Memory tab
+  (the real explorer), and journal/events (candidate machine-authored producers).
+
+---
+
+## 3. The `MemoryProvider` interface (the linchpin)
+
+The audit (dossier 03 §5) is unambiguous: Cognee is contained to **one file**
+and **one construction site** (`api/__init__.py:1108`), but there is **no formal
+ABC** — the contract is implied by call sites, MCP/REST shims, and test stubs.
+Before any swap, we promote the implicit five-method contract into an explicit
+`Protocol` + `ABC`, with a conformance test suite that both `CogneeWrapper` and a
+new `HindsightProvider` must pass. **This is the prerequisite to everything
+else.**
+
+`src/hal0/memory/provider.py` (new):
+
+```python
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import Protocol, TypedDict, Literal, Optional, Sequence
+from datetime import datetime
+
+# ── value types (engine-neutral; shed Cognee-era leakage where possible) ──────
+
+class MemoryItem(TypedDict, total=False):
+    id: str                       # engine-stable id (NOT a fragile text-equality join)
+    text: str
+    dataset: str                  # shared | private:<id> | project:<id> | agents | custom
+    tags: list[str]
+    source: str                   # server-injected client_id (anti-impersonation)
+    metadata: dict
+    timestamp: str                # ISO-8601; occurrence time if known
+    kind: Literal["fact", "observation", "wiki"]   # NEW: provenance of the row
+    score: Optional[float]        # engines that expose a score MAY set it; consumers must not require it
+    freshness: Optional[Literal["stable","strengthening","weakening","new","stale"]]  # observations only
+
+class AddResult(TypedDict):
+    id: str
+    timestamp: str
+
+class ListPage(TypedDict):
+    items: list[MemoryItem]
+    next_cursor: Optional[str]
+
+class DeleteResult(TypedDict):
+    deleted: int
+
+class GraphStatus(TypedDict, total=False):
+    enabled: bool
+    route: str                    # upstream | primary | agent (kept for dashboard contract)
+    provider: str
+    model: str
+    nodes: int
+    links: int
+    pending_consolidation: int    # NEW: surfaces Hindsight /stats counters
+
+Mode = Literal["vector", "graph", "hybrid"]   # kept for back-compat; engines map as they can
+
+
+# ── the contract every engine must satisfy ───────────────────────────────────
+
+class MemoryProvider(ABC):
+    """Engine-neutral durable-memory contract. Cognee, Hindsight, and a plain
+    pgvector shim are all implementations. Hidden behind this so the access
+    plane, dispatcher, CLI, and Hermes plugin never import a concrete engine."""
+
+    # ---- core five (the existing implied contract, now formalised) ----
+    @abstractmethod
+    async def add(self, text: str, *, dataset: str, tags: Sequence[str] = (),
+                  source: str, metadata: Optional[dict] = None,
+                  client_id: Optional[str] = None) -> AddResult: ...
+
+    @abstractmethod
+    async def search(self, query: str, *, limit: int = 10,
+                     dataset: str | Sequence[str] = "shared",
+                     tags: Sequence[str] = (),
+                     before: Optional[datetime] = None,
+                     after: Optional[datetime] = None,
+                     mode: Mode = "vector",
+                     client_id: Optional[str] = None) -> list[MemoryItem]: ...
+
+    @abstractmethod
+    async def list_items(self, *, dataset: str = "shared",
+                         cursor: Optional[str] = None, limit: int = 50,
+                         client_id: Optional[str] = None) -> ListPage: ...
+
+    @abstractmethod
+    async def delete(self, ids: Sequence[str], *,
+                     client_id: Optional[str] = None) -> DeleteResult: ...
+
+    # ---- runtime-flip helpers (dashboard graph-gate contract; keep) ----
+    @abstractmethod
+    async def graph_status(self) -> GraphStatus: ...
+    @abstractmethod
+    async def set_graph_enabled(self, enabled: bool, *, route: Optional[str] = None,
+                               provider: Optional[str] = None,
+                               model: Optional[str] = None) -> GraphStatus: ...
+    @abstractmethod
+    async def set_rerank_enabled(self, enabled: bool) -> None: ...
+
+    # ---- NEW capability surface the Hindsight era unlocks (optional-by-default) ----
+    async def recall(self, query: str, *, dataset: str | Sequence[str] = "shared",
+                     max_tokens: int = 1024, types: Sequence[str] = ("observation","world","experience"),
+                     client_id: Optional[str] = None) -> list[MemoryItem]:
+        """Token-budgeted, observation-aware recall. Default impl == search()
+        clipped to a count; Hindsight overrides with true TEMPR token-budgeting."""
+        return await self.search(query, dataset=dataset, client_id=client_id)
+
+    async def reflect(self, query: str, *, dataset: str = "shared",
+                      max_tokens: int = 2048, response_schema: Optional[dict] = None,
+                      client_id: Optional[str] = None) -> dict:
+        """Reasoned answer + citations. NotImplemented on engines without a
+        reasoning loop (pgvector shim raises; consumers feature-detect)."""
+        raise NotImplementedError
+
+    async def consolidate(self, *, dataset: str = "shared") -> dict:
+        """Force consolidation now (else background). No-op on engines without it."""
+        return {"observations_created": 0, "observations_updated": 0}
+
+    # ---- the promotion seam (§6) — the one method the Wiki layer calls ----
+    async def register_compiled(self, *, page_id: str, text: str, dataset: str,
+                               tags: Sequence[str], source: str = "wiki") -> AddResult:
+        """Re-embed a compiled Wiki page into the engine as a top-of-hierarchy
+        index entry (Hindsight: a mental_model / kind='wiki' document). One-way:
+        the Wiki is canonical; this is a derived index, never read back as truth.
+        Default impl == add(..., tags=[*tags, 'wiki']) so even pgvector supports it."""
+        return await self.add(text, dataset=dataset, tags=[*tags, "wiki"],
+                              source=source)
+```
+
+Notes that make this real, not aspirational:
+
+- **The core five stay byte-compatible** with what `CogneeWrapper` exposes today
+  (dossier 03 §5), so the MCP server (`mcp/memory.py`), REST shims
+  (`routes/memory.py`), in-process dispatcher, and the Hermes plugin do **not**
+  change their call sites — only the construction site at `api/__init__.py:1108`
+  swaps `CogneeWrapper()` → `provider_from_config(cfg)`.
+- **`MemoryItem.id` becomes the join key**, retiring Cognee's fragile
+  text-equality sidecar join (dossier 03 §4.3). A Hindsight memory id *is* the
+  stable id; no shadow store needed.
+- **The optional methods** (`recall`, `reflect`, `consolidate`,
+  `register_compiled`) are where the Hindsight upgrade lands. They have safe
+  defaults so a `PgVectorProvider` fallback (dossier 05 §4 option d) still
+  satisfies the ABC.
+- **Conformance suite** (`tests/memory/test_provider_contract.py`, new): a single
+  parametrized suite run against every provider — `CogneeWrapper`,
+  `HindsightProvider`, `PgVectorProvider`, and the test fakes — asserting
+  namespace isolation, tag-AND, date-range, delete semantics, and the
+  fail-open-empty foreign-private read. This is what de-risks the swap (dossier
+  03 §6 "no formal engine interface").
+
+---
+
+## 4. Engine decision — Hindsight, wired locally
+
+**Recommendation: replace Cognee with Hindsight as Tier E (dossier 05 §4 option
+b), staged behind the `MemoryProvider` ABC.** Hindsight is *designed* for the job
+hal0 actually needs (consolidation/observations = the staleness fix, token-
+budgeted recall, disposition, an upstream Hermes plugin) and — critically —
+**degrades to "a better local vector store than Cognee-as-used" with no LLM at
+all** (semantic + BM25 + temporal + rerank are pure-local). That degrade story is
+exactly hal0's local-first constraint (principle 3).
+
+### Local wiring on hal0 (CT 105)
+
+| Concern | Decision | Why |
+|---|---|---|
+| **Service placement** | Run `hindsight-api` (full image, `:8888` API; `:9999` control-plane optional) as a systemd unit on **CT 105** next to lemond, alongside `registry/` and `lemonade/`. Data root `/var/lib/hal0/memory/hindsight/`. | Co-locate the brain with the runtime that maintains it. Single LXC, no new host. |
+| **Postgres** | **Embedded `pg0`** (Hindsight default; `~/.hindsight/data` → bind to `/var/lib/hal0/memory/hindsight/pg0`). NOT a separate Postgres daemon. | pg0 is the only *new* moving part vs Cognee's three embedded stores — and it replaces all three (dossier 05 §4b). `$HAL0_HOME` snapshot covers it. |
+| **Embeddings** | Route to the **embed capability slot** via Hindsight's self-hosted **TEI / OpenAI-compatible embedding provider**, NOT the bundled BGE. Point `HINDSIGHT_API_EMBEDDING_*` at the embed slot (consider bge-on-iGPU, `PLAN.md:1088`). | Dossier 04 §4: embed is a real slot. **Do not bundle a second embedder.** If the embed slot's model ≠ bge-small-384, re-embed on cutover. |
+| **Reranker** | Route to the **rerank slot on :8086** (`bge-reranker-v2-m3`) via Hindsight's external/TEI reranker provider — the same slot `CogneeWrapper` already POSTs to (`cognee_wrapper.py:209`). | Dossier 04 §4 / dossier 03 §1.9 step 6: already wired. Reuse, don't duplicate. Fallback: Hindsight's local MiniLM cross-encoder (CPU) or `rrf` (no neural rerank). |
+| **Extraction LLM** | `HINDSIGHT_API_LLM_PROVIDER=openai`-compatible → **`HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:13305`** (lemond gateway, dossier — Lemonade gateway port 13305). NOT Hindsight's bundled llamacpp/Gemma. | Inference lives in Lemonade on the iGPU/NPU; Hindsight's bundled llamacpp would be a second, CPU-only inference path. Caveat: arbitrary models need ≥65k output-token support or set `RETAIN_MAX_COMPLETION_TOKENS` lower (> `RETAIN_CHUNK_SIZE` 3000). |
+| **Strix-Halo accel** | **Assume CPU** for embed/rerank (Hindsight docs never mention ROCm/XDNA — dossier 01 §8.2 Gap 1). Validate empirically; the rerank slot already gives GPU rerank for free. | Don't assume the iGPU accelerates Hindsight's PyTorch/ONNX models. The only GPU-sensitive read-path component (rerank) is offloaded to the slot. |
+| **MCP** | Hindsight's **built-in MCP server** (`/mcp/{bank_id}/`) is NOT exposed directly. hal0's `/mcp/memory` stays the front door; `HindsightProvider` calls Hindsight over its REST/SDK in-process. | Preserve the access-plane contract (principle 2). Optionally register Hindsight's MCP as an aftermarket server later for power users. |
+
+### Bank ↔ namespace mapping
+
+Hindsight **memory banks** are the unit of isolation; hal0 has **datasets**.
+Map them 1:1 so the `X-hal0-Agent` rule (dossier 03 §2.1) is preserved:
+
+| hal0 namespace | Hindsight bank | Notes |
+|---|---|---|
+| `shared` | bank `shared` | The common brain. Observations + re-embedded Wiki pages live here. |
+| `private:<agent_id>` | bank `private__<agent_id>` (`:` → `__`, Hindsight bank-id-safe) | Per-agent episodic. `_allowed_read_datasets` still unions `shared` + own private. |
+| `project:<id>` | bank `project__<id>` | Formalised from today's pass-through custom datasets (dossier 05 §5). Auto-created on first use. |
+| `agents` | bank `agents` | Identity cards (ADR-0011). |
+
+`HindsightProvider.add(dataset=…)` resolves the bank, `search` recalls from the
+allowed banks. Hindsight tags (`user:`, `session:`, `topic:`) carry hal0's
+`tags`; Hindsight's hard SQL `tag:true` entity-label filter replaces the sidecar
+tag-AND filter — **the engine owns its own filtering** (dossier 03 §6 directive:
+"own its own filtering, retiring the sidecar").
+
+### Degrade / fallback ladder
+
+1. **Hindsight + Lemonade extraction healthy** → full retain/recall/reflect +
+   observations. Best case.
+2. **Lemonade unreachable / extraction model too weak** → set
+   `HINDSIGHT_API_LLM_PROVIDER=none` at runtime; `retain` stores facts without
+   extraction, `recall` is semantic+BM25+temporal+rerank (still better than
+   Cognee-as-used). **Brain stays useful** (principle 3).
+3. **Hindsight unavailable at boot** (dossier 04 §8 — the whole brain surface is
+   conditionally mounted today) → `provider_from_config` falls back to a
+   `PgVectorProvider` or a no-op provider; `/mcp/memory` still mounts, tools
+   return `available:false`. The dashboard renders a "no engine" state.
+
+> **Cutover discipline (dossier 05 §4 honesty flag + §7 Q3):** before flipping
+> the construction site, run hal0's δ/eval harness on **Cognee-as-used vs
+> Hindsight-recall vs plain-pgvector**, on the *actual* Strix-Halo primary model
+> and a representative corpus. The architectural judgement that Hindsight recalls
+> better is not yet a benchmark. Ship the ABC + conformance suite + dual-write
+> migration first; flip the default only after the eval.
+
+---
+
+## 5. Wiki layer design
+
+### Where the vault lives
+
+**`/var/lib/hal0/wiki`** on CT 105, alongside `registry/`, `lemonade/`,
+`memory/hindsight/`. It is *just a directory of markdown* — no service to host
+(dossier 02 §7.3). Backed by **git** (`Obsidian Git` convention → a git repo with
+a periodic commit; btrfs snapshot is belt-and-suspenders). `OBSIDIAN_VAULT_PATH`
+in `~/.obsidian-wiki/config` for the agent user points here.
+
+### Who maintains it
+
+**Hermes-as-librarian** (dossier 02 §7.2, dossier 05 §5 "librarian agent").
+Rationale: Hermes is the bundled long-running agent, `~/.hermes/skills/` install
+is already supported, `.hermes.md`→`AGENTS.md` is wired, and it already holds the
+`memory-curator` role in its identity card (dossier 04 §1.1.5). Concretely:
+
+- `obsidian-wiki setup` installs the wiki skills into `~/.hermes/skills/` at
+  Hermes provision time.
+- A **systemd timer** (the framework's macOS launchd plist → a CT 105 timer) runs
+  `daily-update` nightly: freshness pass, `index.md`/`hot.md` rebuild, lint.
+- The two portable skills `wiki-update` (write) / `wiki-query` (read) let *any*
+  hal0 agent push to / read from the same vault, with agent-of-origin tracked in
+  `.manifest.json` for `memory-bridge` attribution.
+
+> **Open fork (→ §10 Q3):** Hermes-as-librarian centralises a failure point and a
+> trust point. Alternative: a dedicated lightweight "librarian" persona/agent
+> whose *only* job is curation, separable from Hermes's conversational role. Start
+> with Hermes; split if curation contends with conversation.
+
+### How it's viewed
+
+CT 105 is headless; Obsidian is a desktop app. Three viewing paths, ship in order:
+
+1. **Dashboard render (primary).** Surface the vault read-only through the hal0
+   dashboard Agent→Memory tab (the SPA already serves on `:8080`). Render markdown
+   + the `wiki-export` `graph.html`/`graph.json` (a server-free graph view the
+   framework already produces). This is the "feels native" path.
+2. **Git remote → Obsidian on a desktop** (`hal0-dev` VM or a user machine over
+   NFS/devpool). For deep human editing.
+3. **Obsidian-over-RDP** to the desktop VM. Heaviest; only if 1+2 insufficient.
+
+### How the wiki's search index points at the Engine
+
+This is the single biggest "Hal0'd" change to the fork (dossier 02 §7.5). The
+framework's own answer is **QMD** ("the markdown vault is the source of truth;
+QMD is a search index, not the source of truth"; every write skill refreshes QMD
+after the vault write). **We swap QMD for the Engine**, preserving the exact
+semantics:
+
+- On every vault write (`wiki-ingest`, `wiki-update`, lint), the maintaining
+  agent calls **`register_compiled(page_id, text, dataset, tags)`** (§3) — which
+  on Hindsight creates/updates a `kind='wiki'` document / **mental_model** in the
+  `shared` bank. One-way: Wiki → Engine index.
+- On query, `wiki-query` does a **semantic pass against the Engine first**
+  (`recall` with `types=['wiki','observation']`), then falls back to Grep/Glob
+  over the vault (the framework's graceful-degrade path is preserved).
+- The fork edit is mechanical: the skills hard-reference `qmd` commands; replace
+  those call sites with `/api/wiki`-mediated `register_compiled` / `recall` calls.
+  This is the deliberate divergence to plan now while the fork is byte-identical
+  to upstream (dossier 02 §6).
+
+### The role of `memory-bridge`
+
+`memory-bridge` (dossier 02 §3.6, "the killer feature") diffs wiki knowledge by
+**which AI tool produced it** (reads `.manifest.json` `source_type` + page
+`sources:`). This lines up with hal0-memory's per-agent dataset namespacing: the
+dashboard can render **"what does Hermes know that Claude-Code doesn't"** and
+surface cross-agent blind spots. It is the legible, human-facing counterpart to
+the Engine's per-bank isolation — keep it, wire its attribution to the
+`X-hal0-Agent` identity that already stamps every Engine write.
+
+---
+
+## 6. The promotion model (CRITICAL)
+
+This is the seam most likely to recreate hal0's drift bugs (dossier 05 §3 "weakest
+seam", §7 Q1/Q2). We resolve it decisively, with alternatives marked.
+
+### Canonical ownership (the rule that prevents drift)
+
+| Fact-class | Canonical owner | Rationale |
+|---|---|---|
+| Raw episodic ("what was said on date X", turn transcripts) | **Engine** | The Wiki will never hold a year of raw turns (Karpathy ~100k-token ceiling, dossier 05 §3). |
+| Engine-derived **observations** (auto-consolidated beliefs) | **Engine** | They evolve automatically; mutating them by hand defeats consolidation. |
+| Curated semantic facts ("user's stable preferences"), procedural playbooks ("how we do X here"), architecture notes, agent identity write-ups | **Wiki** | Human-legible, audited, git-historied. A human-readable Wiki claim **overrides** a stale Engine fact at recall time. |
+
+### Recommended default: **gated one-way promotion, Engine → Wiki, Wiki → Engine-as-index**
+
+```
+ episodic turn ──retain──▶ Engine fact ──background consolidate──▶ Engine observation
+                                                                        │
+                                              proof_count ≥ N OR freshness=='stable'
+                                                                        │  (PROMOTION CANDIDATE)
+                                                                        ▼
+                                                          ┌─────────────────────────┐
+                                                          │  PROMOTION GATE          │
+                                                          │  (default: librarian     │
+                                                          │   agent reviews; human   │
+                                                          │   approves via dashboard │
+                                                          │   inbox for shared/      │
+                                                          │   project; auto for      │
+                                                          │   private:<agent>)       │
+                                                          └────────────┬────────────┘
+                                                                       │ approved
+                                                                       ▼
+                                                        Wiki page (wiki-ingest writes,
+                                                        provenance=inferred, lifecycle=draft)
+                                                                       │
+                                                       register_compiled() (one-way)
+                                                                       ▼
+                                              Engine mental_model / kind='wiki' (top of
+                                              recall hierarchy: wiki → observations → facts)
+```
+
+- **Consolidation writes to the Engine only** (its own observations). It does
+  **not** auto-write the Wiki. (Dossier 05 §3 "conservative posture", recommended
+  start.)
+- **Promotion into the Wiki is gated.** Default gate by namespace:
+  - `private:<agent>` → **auto-promote** (it's the agent's own scratch; low blast
+    radius).
+  - `shared` / `project:<id>` → **gated**: a promotion candidate (observation with
+    `proof_count ≥ N` *or* `freshness == 'stable'`) is queued; the **librarian
+    agent** drafts the Wiki page (`provenance: inferred`, `lifecycle: draft`); a
+    **human approves** via the dashboard inbox (reusing the existing
+    destructive-call approval-queue UX, dossier 04 §3.1) to flip
+    `lifecycle: reviewed`.
+- **Wiki → Engine is one-way and derived.** `register_compiled` re-embeds the page
+  as a `kind='wiki'` index entry. The Engine never treats it as a mutable
+  truth-source; it's the top of the recall hierarchy (mirroring Hindsight's
+  *mental models checked first*, dossier 01 §1.2 reflect hierarchy). This is the
+  single-source-of-truth-per-fact-class principle made physical: the Wiki page is
+  canonical; the Engine copy is an index.
+
+### Alternatives (honest forks)
+
+- **(Alt-A) Aggressive auto-promotion.** Agent auto-writes Wiki pages on every
+  consolidation. *For:* maximum compounding, zero human latency. *Against:* the
+  Wiki stops being trustworthy-by-construction and becomes another thing to lint;
+  reintroduces a second unsupervised-mutation source of truth (dossier 05 §3). Use
+  only for `private:<agent>` banks, never `shared`.
+- **(Alt-B) Wiki-canonical-for-everything, Engine purely derived.** The Wiki is
+  the sole source of truth; the Engine is a disposable index rebuilt from the
+  vault. *For:* one source of truth, period; YAGNI for a single-user box that may
+  never exceed the 100k-token ceiling (dossier 05 §3 counter-case). *Against:*
+  throws away cheap episodic capture (a year of raw turns can't live in markdown);
+  loses the consolidation upgrade path.
+- **(Alt-C) Proof-count-only auto-gate (no human).** Promote when `proof_count ≥
+  N` with no human review. *For:* scales without a human bottleneck. *Against:* a
+  single-user box may never get N independent witnesses (dossier 05 §7 Q6); N=1
+  degenerates to Alt-A.
+
+### Main risk of the recommended model
+
+**The gate is a bottleneck or a rubber stamp.** If the human never reviews the
+promotion inbox, `shared` knowledge ossifies as draft-only and the Wiki's
+curated layer stays thin — the brain quietly degrades to "Engine + an empty
+notebook". Mitigation: make the librarian agent's draft *good enough to one-click
+approve*, default `private:<agent>` to auto (most volume), and treat an aging
+promotion inbox as a dashboard health signal. This risk is explicitly carried
+into §10 for grilling.
+
+---
+
+## 7. Deep-integration map (per consumer)
+
+The rule (dossier 04 §6): "native" = a consumer gets memory/wiki without bespoke
+glue. Hook at seams that already exist.
+
+| Consumer | Exact hook | What changes |
+|---|---|---|
+| **Hermes — recall** | `Hal0CogneeProvider.prefetch(query)` (`provider.py:137`) — the live per-turn injection seam (dossier 04 §1.1). | `prefetch` calls `recall(types=['wiki','observation','world'], max_tokens=…)` instead of flat `search(limit=5)`. Returns Wiki-block + observation-block, top-of-hierarchy first. Rename plugin `hal0-cognee` → `hal0-memory`. |
+| **Hermes — write** | `sync_turn(user, assistant)` (`provider.py:163`) + `on_memory_write` (`:207`). | Unchanged call path → `retain` (was `add`). Background consolidation now actually runs (it didn't on Cognee). Fix the **latent wrong-route bug** in `_client.py` list/delete (dossier 03 §4.2) while here. |
+| **Hermes — context files** | `HERMES.md.j2` / `AGENTS.md.j2` via `_phase_context_link` (`hermes_provision.py:1230`, dossier 04 §1.1.3). | Add a "Wiki index / how to query the brain" section so any agent landing in `/etc/hal0` learns the brain exists. |
+| **External Claude Code** | `/mcp/memory` MCP guest (dossier 04 §1.2, §3.3) — first-class external consumer. | Add `wiki_search`/`wiki_get` tools on the *same* `hal0-memory` server. Default an external client to **read `shared`+own-private, no shared-write** (dossier 05 §5 trust). Ship the six-lifecycle-hook ingestion plugin (SessionStart/UserPromptSubmit/PostToolUse/Stop/PreCompact/SessionEnd) so it *produces* into the Wiki, not just reads — the headline "every agent feeds one brain" story (dossier 04 §6 Tier C-8). |
+| **pi-coder** | `pi-mcp-adapter.json` → `/mcp/memory` (`pi_coder.py:123`). | Wiki tools appear automatically (MCP). Mine the `pi-memory-md` precedent (per-project markdown coexisting with central store, dossier 04 §1.3) as the `project:<id>` Wiki-namespace analogy. |
+| **OpenWebUI / `/v1/*`** | Inference only; **no memory by default** (dossier 04 §2, §7). | No change. Memory is an agent concern, not a raw-inference one. (Optional later: a memory-augmented chat persona.) |
+| **Dashboard Agent→Memory tab** | `ui/src/dash/agents/memory-tab.jsx` — the real explorer (dossier 04 §5; stats currently **mock** `2,847`). | Wire real stats (Hindsight `get_bank_stats` + `/stats` pending-consolidation). Add an **Obsidian Wiki browser** (render markdown + `graph.html`) and the **promotion inbox** (reuse approval-queue UX). Keep the GraphExtractionPanel as the engine graph-gate. **Do NOT** confuse with the hardware "Memory map" (`memory-map.jsx`) — name collision only. |
+| **embed + rerank slots** | `capabilities/catalog.py` `embed`/`rerank` (dossier 04 §4). | Hindsight embeddings → embed slot; rerank → :8086 slot. Consider a **`memory` capability card** in `capabilities.toml` so the brain's embed/rerank wiring + health render in the same UX as voice/img cards. |
+| **journal / events** | `src/hal0/journal/`, `src/hal0/events/` (dossier 04 §4 adjacent). | **Optional, gated:** a producer that ingests operational events ("model X loaded", "slot evicted") into `shared` as machine-authored memory tagged `["machine","event"]`, so the brain knows the box's history. Off by default (volume/noise). |
+| **Webhooks** | Hindsight `consolidation.completed` / `retain.completed` (dossier 01 §6). | Point `HINDSIGHT_API_WEBHOOK_URL` at a hal0 endpoint that fans `consolidation.completed` into the **EventBus** (footer/journal live update) and **enqueues promotion candidates**. Dedupe on `operation_id` (at-least-once). Verify per-bank registration (dossier 01 Gap 2). |
+
+---
+
+## 8. Bank-templates as a hal0 primitive
+
+The user's interest in templates maps cleanly: hal0 already drives capability and
+slot config from **TOML templates**; Hindsight ships **JSON bank-templates**
+(dossier 01 §3) that provision a fully-configured bank (mission, disposition,
+entity-labels, mental-models, directives) in one `import` call. Treat a
+**"memory bank template" as a first-class hal0 primitive**, one per persona/project:
+
+- **Location:** `/etc/hal0/memory-templates/<id>.json` (echoing
+  `/etc/hal0/mcp-servers/<id>.toml` and `capabilities.toml`). hal0 owns a curated
+  set, contributable like slot templates.
+- **Binding to personas (dossier 04 §1.1.4):** a Hermes persona already scopes a
+  memory namespace; extend it so a persona *names a memory-bank template*. When a
+  persona is selected, hal0 ensures the matching bank exists by importing the
+  template (idempotent — Hindsight matches mental-models by `id`, directives by
+  `name`).
+- **Curated hal0 templates** (seed set, from Hindsight's Hub + hal0 needs):
+  `coding-agent` (high literalism, project-architecture mental-models — for
+  pi-coder / Claude-Code project banks), `conversation` (Hermes default persona),
+  `personal-assistant`, and a hal0-specific `homelab-ops` (entity-labels for
+  hosts/slots/services; directives encoding the inference policy).
+- **Round-trip / portability:** `export` emits only explicit overrides → a
+  persona's memory personality becomes a portable, version-controlled artifact in
+  the repo (`docs/` or `installer/`), `import --dry-run` validates it in CI.
+- **Caveat to verify (dossier 01 Gap 3):** the template `entity_labels` form
+  (flat `string[]`) vs bank-config rich label-group objects, and
+  `retain_extraction_mode: chunks` only in the template schema. Confirm what the
+  importer accepts before shipping rich-label templates.
+
+This gives hal0 the same "stamp a known-good config from a template" ergonomics
+for *memory* that it has for *slots*, and makes per-agent memory personality
+declarative and reviewable.
+
+---
+
+## 9. What we keep / change / delete vs the current Cognee system
+
+### Keep (the plumbing is solid — dossier 03 §6 strengths)
+
+- **The single narrow seam** (one construction site) — *promote* it to a formal
+  `MemoryProvider` ABC (§3) but keep the swap-at-one-site property.
+- **`hal0.memory.namespace`** (the shared resolver that killed #317 drift) —
+  unchanged; it now maps to Hindsight banks (§4).
+- **The dual transport contract** `/mcp/memory` + `/api/memory/*` with the
+  `X-hal0-Agent` server-side namespace rule — verbatim.
+- **Defensive transport layer:** hand-rolled validation, server-injected
+  `source`, `private:` rejection, consistent error envelopes, best-effort agent
+  hooks that never wedge the loop, the audit trail.
+- **Rerank slot integration** (:8086) — reuse from Hindsight.
+- **The graph-status dashboard contract** (`graph_status()` payload shape) — kept
+  in the ABC so the GraphExtractionPanel keeps working.
+
+### Change
+
+- **Engine: Cognee → Hindsight** behind the ABC, staged, eval-gated (§4).
+- **Hermes plugin `hal0-cognee` → `hal0-memory`**; `prefetch` → `recall`,
+  `add` → `retain`; fix the latent wrong-route list/delete bug (dossier 03 §4.2).
+- **Filtering ownership: sidecar SQLite → the engine.** Hindsight owns dataset
+  isolation, tag-AND (via `tag:true` entity labels), and date range natively
+  (dossier 03 §6 directive). The fragile text-equality join (dossier 03 §4.3) dies
+  with it.
+- **hal0-wiki fork: QMD → Engine** as the search index; vault at
+  `/var/lib/hal0/wiki`, Hermes-as-librarian, git-backed (§5). Rename
+  `obsidian-wiki` → `hal0-wiki` in `pyproject.toml` (currently still upstream's,
+  dossier 02 §6/§7.5).
+- **Dashboard Memory tab:** real stats + Wiki browser + promotion inbox (§7).
+- **Personas:** gain a `memory_bank_template` field (§8).
+
+### Delete
+
+- **Cognee** (`cognee==1.0.7`) and `cognee_wrapper.py` once the eval clears and
+  Hindsight is default. Mark **ADR-0005 / ADR-0014 superseded.**
+- **The sidecar `hal0_memory_index.sqlite`** and its text-equality join (dossier
+  03 §2.2, §4.3) — migrate its rows into Hindsight on cutover, then drop.
+- **The write-only Kuzu graph** (dead weight — dossier 03 §4.5): never queried;
+  Hindsight's graph is read in TEMPR, so this is a net upgrade, not a loss.
+- **The pre-existing local `obsidian-vault` skill** on hal0-dev (flat `/mnt/d/...`
+  WSL path, no provenance — dossier 02 §7.3) — retire to avoid two competing
+  Obsidian conventions.
+- **Stale auto-memory entry** `hal0_memory_dataset_namespace_bug` — #317 is fixed
+  (dossier 03 §4.1); mark resolved.
+
+---
+
+## 10. Risks & open questions (grilling seeds)
+
+These are genuinely unresolved or carry real downside; do not paper over them.
+
+1. **Promotion gate = bottleneck or rubber stamp (§6 main risk).** If the human
+   never works the promotion inbox, `shared` curated knowledge ossifies as draft.
+   Is `private:<agent>`-auto + `shared`-gated the right split? What's the actual
+   default trust gate on a single-user box where proof-count corroboration may
+   never accrue (dossier 05 §7 Q6)?
+
+2. **Eval not yet run (dossier 05 §4 honesty flag, §7 Q3).** The "Hindsight recalls
+   better than Cognee-as-used" claim is architectural, not benchmarked. The whole
+   engine swap is conditional on the δ/eval result on the *actual* Strix-Halo
+   primary model. If the delta is null, do we still pay the Postgres/Hindsight
+   migration cost for the consolidation/observations *upgrade path* alone?
+
+3. **Librarian centralisation (§5).** Hermes-as-librarian is a single failure +
+   trust point. Split into a dedicated librarian persona/agent, or accept the
+   coupling? When does curation contend with Hermes's conversational role?
+
+4. **Strix-Halo accel is undocumented (dossier 01 Gap 1).** We *assume* CPU
+   embed/rerank and offload rerank to :8086. Unvalidated. If CPU embed is too slow
+   at ingest volume, is bge-on-iGPU (the embed slot) actually faster, and does it
+   change the embedding model (forcing a re-embed)?
+
+5. **Local structured-output: invest or route (dossier 05 §7 Q5)?** We route
+   extraction to lemond:13305 and design the brain to not *need* reliable
+   extraction. But Hindsight's *richest* features (graph edges in TEMPR, good
+   observations) still track local-LLM quality. Do we ever stand up a
+   grammar-constrained / tool-call extraction path on a 32B+ quantized model, or
+   permanently design for recall-only + hand-curated Wiki?
+
+6. **Working-memory budget ownership (dossier 05 §7 Q7).** Three durable surfaces
+   (Wiki pages, observations, raw facts) compete for context space. Does `recall`'s
+   token budget + the wiki→observations→facts hierarchy arbitrate it, or does the
+   orchestrator? Where does the per-turn cap live?
+
+7. **External-agent default read (dossier 05 §7 Q8).** Should an external Claude
+   Code session read hal0's `shared` brain by default? We propose read-yes /
+   shared-write-no. Is even read-yes too much for an untrusted LAN guest?
+
+8. **Hindsight bundled-daemon port collision (dossier 01 §9.2).** The Hermes
+   *upstream* Hindsight plugin's `local` mode auto-embeds a daemon on `:9077`,
+   which collides conceptually with hal0's port map. We point Hermes at the
+   standalone CT-105 Hindsight API instead — confirm the upstream plugin lets us
+   override the URL without spawning its own daemon.
+
+9. **Webhook per-bank registration (dossier 01 Gap 2).** The promotion-candidate
+   fan-out depends on `consolidation.completed`. The local skill documents only
+   server-wide env-var webhook config; per-bank registration may not exist. If
+   it's server-wide only, promotion-candidate routing must demultiplex by `bank_id`
+   in one handler.
+
+10. **Migration data fidelity.** Cutover must move sidecar rows + Cognee chunks
+    into Hindsight banks without losing the `dataset`/`tags`/`timestamp`/`source`
+    schema (dossier 03 §2.2). Dual-write window, or one-shot backfill + verify? The
+    text-equality join means some Cognee rows may not cleanly map — what's the
+    acceptable loss?
+
+11. **YAGNI counter-case (dossier 05 §3, Alt-B in §6).** A single-user home box
+    may never exceed Karpathy's ~100k-token curated-knowledge ceiling. If so, the
+    Wiki *is* the brain in-context and the Engine is only for raw-turn recall —
+    arguably we don't need the full Hindsight consolidation machinery. Is the
+    two-tier design over-built for v1?
+```

--- a/docs/internal/brain-redesign/07-integration-roadmap.md
+++ b/docs/internal/brain-redesign/07-integration-roadmap.md
@@ -1,0 +1,564 @@
+# 07 — Integration Roadmap: hal0 Unified Brain
+
+**Status:** Sequenced build plan. Derived from doc 06 (authoritative architecture), doc 03 (as-built audit), doc 04 (consumer surface), doc 01/02/05 (engine/wiki/landscape specifics).
+**Date:** 2026-06-02
+**Author:** Technical Planner
+**Reads against:** ADR-0005/0014 (superseded by 06), ADR-0011/0012 (extended). Open design questions tracked in doc 08; this roadmap flags every dependency on them with **[Q#]**.
+
+> **How to read this.** Each phase is a *vertical tracer-bullet slice* that leaves
+> `main` shippable. For each phase: **Goal**, **Work items** (file-level where the
+> audit gives paths), **Exit criteria** (the verification gate), **Rollback**,
+> **"Can ship after this phase"**, and **Risk / blocked-on**. Hard gates are called
+> out in bold. The single most important rule of the whole arc, from doc 06 §4:
+> **do not flip the engine blind — the δ-eval (Phase 1) is a hard gate before the
+> Phase 2 cutover.**
+
+---
+
+## Dependency graph
+
+```
+ Phase 0  Seam & safety net  (MemoryProvider ABC + conformance suite + _client.py 404 fix)
+    │   ← prerequisite to everything (doc 06 §3 "the linchpin")
+    ▼
+ Phase 1  Hindsight behind the seam (SHADOW)  + δ-eval  ──────────┐
+    │   needs: Phase 0 ABC                                         │
+    │   ┌──────────────────────────────────────────────┐          │
+    │   │  ★ HARD GATE: δ-eval Cognee vs Hindsight vs   │          │
+    │   │    pgvector on real Strix model [Q2]          │          │
+    │   └──────────────────────────────────────────────┘          │
+    ▼                                                              │
+ Phase 2  Cutover + namespace/bank mapping                        │
+    │   needs: Phase 1 + δ-eval PASS; Cognee kept as fallback flag │
+    ▼                                                              │
+ Phase 3  Wiki layer (vault + skills + register_compiled index)   │
+    │   needs: Phase 2 (engine is the wiki search index)           │
+    ▼                                                              │
+ Phase 4  Promotion pipeline (webhook → EventBus → gated queue)   │
+    │   needs: Phase 1 (webhooks) + Phase 3 (wiki write target) [Q1][Q9]
+    ▼
+ Phase 5  Deep consumer integration (Hermes recall/retain, CC plugin,
+    │      dashboard Memory tab, name-collision fix, bank-templates)
+    │   needs: Phase 2 (engine), Phase 3 (wiki), Phase 4 (inbox) — partial
+    ▼   [Q3][Q5][Q7][Q8]
+ Phase 6  Polish (per-bank webhooks, observability, docs/promo, ADRs)
+        needs: all prior  [Q1..Q11 closure]
+```
+
+Parallelizable: Phase 3 (wiki skills) can begin in a worktree during Phase 1's
+eval wait, since it only depends on the `register_compiled` ABC method (Phase 0),
+not on the flip. The Hermes `_client.py` 404 fix (Phase 0) and the dashboard
+name-collision rename (Phase 5) are independent and can land any time.
+
+---
+
+## Phase 0 — Seam & safety net
+
+**Goal.** Promote the implicit five-method `CogneeWrapper` contract into an
+explicit `MemoryProvider` ABC + Protocol with a parametrized conformance suite,
+and route the one construction site through a config factory — **with zero
+behaviour change**. Cognee remains the only live engine. Also fix the latent
+Hermes `_client.py` 404 route mismatch found in the audit. This is the
+prerequisite to every later phase (doc 06 §3).
+
+**Work items.**
+- **New `src/hal0/memory/provider.py`** — exactly the ABC/Protocol and value
+  types in doc 06 §3 (`MemoryItem`, `AddResult`, `ListPage`, `DeleteResult`,
+  `GraphStatus`, `Mode`; abstract core five `add/search/list_items/delete` +
+  runtime-flip `graph_status/set_graph_enabled/set_rerank_enabled`; optional
+  `recall/reflect/consolidate/register_compiled` with safe defaults). The core
+  five signatures must be **byte-compatible** with `CogneeWrapper` (audit §5
+  enumerates them) so no call site changes.
+- **`src/hal0/memory/cognee_wrapper.py`** — make `CogneeWrapper(MemoryProvider)`
+  subclass the new ABC. No logic change; just declare conformance. Add the
+  default `recall` (clip `search`), `reflect` (raise `NotImplementedError`),
+  `consolidate` (no-op), `register_compiled` (`add(..., tags=[*tags,'wiki'])`).
+- **New `provider_from_config(cfg)` factory** in `src/hal0/memory/__init__.py`
+  (re-export per the package's "only the wrapper is public" rule, audit §5).
+  Phase 0 returns `CogneeWrapper(...)` always; later phases add the branch.
+- **`src/hal0/api/__init__.py:1108`** — replace `CogneeWrapper(...)` with
+  `provider_from_config(cfg)`. State key `app.state.memory_wrapper` (`:1121`) and
+  the dispatcher hand-off (`:1136`) unchanged. Rename the state key to
+  `app.state.memory_provider` is **deferred to Phase 2** to avoid a wide diff now.
+- **New `src/hal0/memory/pgvector_provider.py` (stub)** — a minimal
+  `PgVectorProvider(MemoryProvider)` that satisfies the ABC (core five over a
+  pgvector table; `reflect` raises). Needed as the conformance-suite third
+  implementation and the Phase 2 fallback. May be skeletal here; fleshed in
+  Phase 1.
+- **New `tests/memory/test_provider_contract.py`** — the single parametrized
+  conformance suite from doc 06 §3, run against `CogneeWrapper`, `PgVectorProvider`,
+  and the existing `_FakeWrapper`/`StubWrapper` test doubles (audit §4.4). Assert:
+  namespace isolation, `private:` write rejection, tag-AND, date-range filter,
+  delete semantics, **fail-open-empty foreign-private read** (audit §2.1), and
+  the `graph_status()` payload-shape contract (every key the dashboard reads,
+  audit §5).
+- **Fix `src/hal0/agents/hermes/plugins/memory_cognee/_client.py`** — the latent
+  404 (audit §4.2): `list_items` hits `GET /api/memory` (no such route → use
+  `GET /api/memory/list`); `delete` hits `DELETE /api/memory/{id}` (no such route
+  → use `POST /api/memory/delete` with `{ids}` body). Add a route-path test
+  asserting the client paths against the real router so this can't silently
+  re-drift. (If the methods are confirmed dead, delete them instead — but the
+  test is the point.)
+- **CI:** wire `test_provider_contract.py` into the **default** gate (not the
+  `slow`/Cognee-fixture exclusion that hid §4.2/§4.4). Run `ruff format --check`
+  too (per the standing CI gotcha).
+
+**Exit criteria.**
+- Conformance suite green for `CogneeWrapper` + `PgVectorProvider` + fakes.
+- `provider_from_config` returns `CogneeWrapper`; full app boots; a manual
+  `add → search → list → delete` round-trip via `/api/memory/*` and `/mcp/memory`
+  is byte-identical to pre-change behaviour.
+- Hermes `_client.py` route-path test green against the real router.
+- No diff to MCP server, REST shims, dispatcher, CLI, or the Hermes provider call
+  sites (only the construction site + the client fix).
+
+**Rollback.** Pure additive + one-line construction swap. Revert the
+`api/__init__.py:1108` line to `CogneeWrapper(...)`; the ABC and tests are inert.
+Zero data implications.
+
+**Can ship after this phase.** Yes — identical runtime behaviour, better-tested,
+plus a real latent-404 bug fixed. Strict improvement.
+
+**Risk / blocked-on.** Low. **No open-question dependency.** Only subtlety:
+getting the ABC signatures byte-compatible so later phases don't have to touch
+call sites — the audit §5 enumeration is the spec; verify against actual
+`cognee_wrapper.py` method headers, not the doc.
+
+---
+
+## Phase 1 — Hindsight behind the seam (shadow) + the δ-eval gate
+
+**Goal.** Stand up Hindsight on CT 105 as a systemd unit, implement
+`HindsightProvider` against the Phase-0 ABC, wire its embeddings/rerank/extraction
+to existing hal0 slots, and **run the δ-eval** (Cognee-as-used vs Hindsight-recall
+vs plain-pgvector) on the *actual* Strix-Halo primary model and a representative
+corpus. Hindsight runs in **shadow** — built and conformance-tested, but
+`provider_from_config` still defaults to Cognee. **No flip in this phase.**
+
+**Work items.**
+- **Deploy Hindsight on CT 105** as a systemd unit beside lemond
+  (`hindsight-api`, full image, API `:8888`, control-plane `:9999` optional).
+  Data root `/var/lib/hal0/memory/hindsight/`; **embedded pg0** bound to
+  `/var/lib/hal0/memory/hindsight/pg0` (NOT a separate Postgres daemon —
+  doc 06 §4, doc 01 §8.4). `HINDSIGHT_API_RUN_MIGRATIONS_ON_STARTUP` handled per
+  doc 01 §5. Build on the hal0-dev VM if a docker build is needed (LXC apparmor
+  build denial is a known constraint), then `docker save | ssh hal0 docker load`.
+- **Wire to slots** (doc 06 §4 table, doc 04 §4):
+  - Embeddings → **embed capability slot** via Hindsight's OpenAI-compatible/TEI
+    embedding provider (`HINDSIGHT_API_EMBEDDING_*`). **Do not bundle BGE.** If the
+    embed slot's model ≠ Cognee's `bge-small-en-v1.5` (384-dim), a **re-embed on
+    cutover** is required — record the slot's actual model now. **[Q4]** (Strix
+    accel undocumented; assume CPU, validate empirically.)
+  - Rerank → **rerank slot `:8086`** (`bge-reranker-v2-m3`) via Hindsight's
+    external/TEI reranker provider — the same slot `cognee_wrapper.py:209` already
+    POSTs to. Fallback: Hindsight's local MiniLM cross-encoder (CPU) or pure RRF.
+  - Extraction LLM → **`HINDSIGHT_API_LLM_PROVIDER=openai` →
+    `HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:13305`** (lemond gateway). Mind
+    `RETAIN_MAX_COMPLETION_TOKENS` vs `RETAIN_CHUNK_SIZE` (3000) per doc 01 §8.2.
+- **New `src/hal0/memory/hindsight_provider.py`** — `HindsightProvider(MemoryProvider)`
+  calling Hindsight over its REST/SDK in-process. Implements core five + overrides
+  `recall` (true TEMPR token-budgeting), `reflect`, `consolidate`,
+  `register_compiled` (creates a `kind='wiki'` mental_model). **Engine owns its own
+  filtering** — map hal0 `tags` to Hindsight `tag:true` entity-label filter,
+  date-range and dataset isolation to Hindsight banks (doc 06 §4, audit §6
+  directive: retire the sidecar). Bank mapping per the Phase-2 table but
+  *implemented here* so the eval uses the real mapping.
+- **Flesh `PgVectorProvider`** into a runnable engine (the eval's third arm and the
+  Phase-2 boot fallback).
+- **`provider_from_config`** gains `engine = "cognee" | "hindsight" | "pgvector"`
+  config (default **cognee**) + a degrade ladder (doc 06 §4): Hindsight unavailable
+  at boot → fall back to pgvector/no-op; tools return `available:false`; dashboard
+  renders "no engine" (doc 04 §8 — surface is already conditionally mounted).
+- **Confirm the Hermes upstream-plugin port question [Q8 doc06 / Gap re :9077]:**
+  verify Hermes' upstream Hindsight plugin `local` mode can be pointed at the
+  standalone CT-105 API URL **without** auto-spawning its own `:9077` daemon. (We
+  do *not* wire Hermes to Hindsight in this phase — just confirm the override
+  exists, for Phase 5.)
+- **★ The δ-eval harness** — extend hal0's δ/eval harness (`tests/harness/`) with a
+  recall-quality eval: a representative hal0 memory corpus + a query set with
+  graded relevance, run identically through `CogneeWrapper`, `HindsightProvider`,
+  and `PgVectorProvider`, **on the actual Strix-Halo primary model** for extraction.
+  Emit recall@k / nDCG / latency / ingest-cost JSON rows. (See the `llm-evaluation`
+  skill for metric scaffolding.)
+
+**Exit criteria — this phase's gate is two-part.**
+1. **Conformance:** `HindsightProvider` and the runnable `PgVectorProvider` both
+   pass `test_provider_contract.py` unmodified. Hindsight boots as a systemd unit;
+   pg0 persists across restart; embed/rerank/extraction routed to the right
+   slots/gateway and health-checked.
+2. **★ HARD GATE — δ-eval result reviewed before Phase 2.** The
+   "Hindsight recalls better than Cognee-as-used" claim is **architectural, not yet
+   benchmarked** (doc 06 §10 Q2, doc 05 §4 honesty flag). The eval must run and be
+   reviewed. Decision rule, explicit per doc 06 §10 Q2 / §11:
+   - **Delta positive** → proceed to Phase 2 cutover.
+   - **Delta null/negative** → escalate the open question: do we still pay the
+     Postgres/Hindsight migration cost for the *consolidation/observations upgrade
+     path* alone, or stay on Cognee (or drop to pgvector, doc 05 option d)? **This
+     decision must be made by a human before any flip.**
+
+**Rollback.** Trivial — nothing is flipped. Stop/disable the `hindsight-api`
+systemd unit; `provider_from_config` is still defaulting to Cognee. Hindsight data
+root is isolated under `/var/lib/hal0/memory/hindsight/`; deleting it touches no
+Cognee data.
+
+**Can ship after this phase.** Yes — Cognee is still the live engine; Hindsight is
+dark. Shipping carries an idle systemd unit (resource cost only), or ship with the
+unit masked.
+
+**Risk / blocked-on.**
+- **★ Blocked-on [Q2]:** the cutover (Phase 2) cannot proceed until the eval is run
+  and reviewed. This is the spine of the whole plan.
+- **[Q4]** Strix accel unknown — if CPU embed is too slow at ingest volume, may need
+  bge-on-iGPU (embed slot), which could change the embedding model and force a
+  re-embed. Surfaces here as a perf measurement in the eval.
+- **[Q5]** Extraction quality tracks local-LLM quality; design for recall-only +
+  degrade ladder so a weak extractor doesn't block the eval.
+- **[Q8]** Upstream Hindsight plugin daemon-port collision — confirm override before
+  relying on it in Phase 5.
+
+---
+
+## Phase 2 — Cutover + namespace/bank mapping
+
+**Goal.** With the δ-eval cleared, flip `provider_from_config` to Hindsight as the
+default engine, map hal0 namespaces to Hindsight banks, migrate existing Cognee +
+sidecar data into banks with a verified fidelity plan, and keep Cognee behind a
+fallback flag for one release.
+
+**Work items.**
+- **Bank ↔ namespace mapping** (doc 06 §4), implemented + tested in
+  `HindsightProvider` and asserted in the conformance suite:
+  | hal0 namespace | Hindsight bank |
+  |---|---|
+  | `shared` | `shared` |
+  | `private:<agent>` | `private__<agent>` (`:`→`__`, bank-id-safe) |
+  | `project:<id>` | `project__<id>` (auto-create on first use — formalises today's pass-through custom datasets, doc 05 §5) |
+  | `agents` | `agents` (identity cards, ADR-0011) |
+  The shared `hal0.memory.namespace` resolver (the #317 fix) is **unchanged**; it
+  now maps to banks.
+- **Migration** (doc 06 §10 Q10 — this is a flagged open question on *method*):
+  move sidecar `hal0_memory_index.sqlite` rows (the real schema: `dataset / tags /
+  source / metadata / timestamp`, audit §2.2) + Cognee chunks into the matching
+  banks, preserving schema. **[Q10 — decide:]** dual-write window vs one-shot
+  backfill+verify. The text-equality join (audit §4.3) means some Cognee rows may
+  not cleanly map — **define and record the acceptable-loss threshold before
+  running.** Build a `hal0 memory migrate` one-shot with a `--dry-run` that reports
+  row counts mapped/unmapped and a post-migration **verify** pass (count + spot
+  recall parity).
+- **Flip the construction site:** `provider_from_config` default → `hindsight`.
+  Rename `app.state.memory_wrapper` → `app.state.memory_provider` across the ~handful
+  of readers (audit §1.1 stash sites) now that the engine is generic.
+- **Fallback flag:** `[memory] engine = "cognee"` in `hal0.toml` reverts to Cognee
+  for one release. Cognee package + `cognee_wrapper.py` stay in-tree (deletion is
+  Phase 6 / doc 06 §9).
+- **Retire the sidecar** as the filtering source of truth (Hindsight owns filtering
+  now). Keep the sidecar file read-only until migration verify passes, then it's
+  dead.
+
+**Exit criteria.**
+- δ-eval **PASS** on record (Phase 1 gate) — re-stated as the precondition.
+- `hal0 memory migrate --dry-run` shows mapped/unmapped within the agreed loss
+  threshold; live migration + verify pass (count + recall-parity spot check).
+- Default boot uses Hindsight; `add/search/list/delete` over both transports green;
+  namespace isolation + `private:` rejection + foreign-private fail-open-empty all
+  pass against the live Hindsight engine.
+- `[memory] engine = "cognee"` cleanly reverts and still serves the migrated-from
+  Cognee store (it was never mutated).
+- Per-agent stats route (`memory_stats.py`) still answers (real counts wired in
+  Phase 5; `available` must be honest now).
+
+**Rollback.** Set `[memory] engine = "cognee"` and restart hal0-api — instant
+revert to the untouched Cognee store. Because migration is *copy-into-Hindsight*
+(Cognee data is read-only during it), rollback loses only memories written to
+Hindsight *after* the flip; mitigate with a short dual-write window **[Q10]** if the
+team chooses that path.
+
+**Can ship after this phase.** Yes — this is the headline release. Hindsight is the
+live brain; Cognee is a one-flag escape hatch. Wiki/promotion not yet present, but
+the engine upgrade (consolidation/observations, token-budgeted recall) ships.
+
+**Risk / blocked-on.**
+- **Blocked-on [Q2]** (must be cleared in Phase 1) and **[Q10]** (migration method +
+  acceptable loss — decide before running).
+- Main risk: silent recall regression on real traffic that the eval corpus didn't
+  cover. Mitigation: the fallback flag + keep Cognee data untouched for one release.
+
+---
+
+## Phase 3 — Wiki layer
+
+**Goal.** Stand up the git-backed Obsidian-flavored vault, install the hal0-wiki
+skills into the agents, and make the wiki's **search index point at the Engine**
+(not QMD) via `register_compiled`, with a librarian maintenance timer. Can begin in
+parallel during Phase 1's eval wait (depends only on the Phase-0 `register_compiled`
+ABC method), but lands after Phase 2 so the index target is the live Hindsight
+engine.
+
+**Work items.**
+- **Vault at `/var/lib/hal0/wiki`** on CT 105 (beside `registry/`, `lemonade/`,
+  `memory/hindsight/`). Just a markdown directory (doc 02 §7.3): `index.md`
+  (content catalog), `log.md` (append-only op log), `hot.md` (warm-start cache),
+  `.manifest.json` (source→pages ledger), and `concepts/entities/skills/...` trees
+  (doc 02). **Git-backed** (periodic commit; btrfs snapshot as belt-and-suspenders).
+- **Fork rename:** `obsidian-wiki` → `hal0-wiki` in the fork's `pyproject.toml`
+  (currently still upstream's — doc 02 §6/§7.5, doc 06 §9). Set
+  `OBSIDIAN_VAULT_PATH` / `~/.obsidian-wiki/config` for the agent user to the vault.
+- **The deliberate fork edit (QMD → Engine)** — doc 06 §5, doc 02 §7.5. In the
+  `wiki-ingest` / `wiki-update` / lint skills, replace the hard-referenced `qmd`
+  call sites with `/api/wiki`-mediated `register_compiled(page_id, text, dataset,
+  tags)` calls (one-way: Wiki → Engine index, `kind='wiki'` mental_model). In
+  `wiki-query`, do a **semantic pass against the Engine first** (`recall` with
+  `types=['wiki','observation']`) then fall back to Grep/Glob over the vault
+  (preserve upstream's graceful-degrade path). Do this now while the fork is
+  byte-identical to upstream.
+- **Skill install:** `obsidian-wiki setup` (renamed `hal0-wiki setup`) installs the
+  two portable skills `wiki-update` (write) / `wiki-query` (read) plus the wiki
+  toolset into `~/.hermes/skills/` at Hermes provision time; also into
+  `~/.claude/skills` and `~/.pi/agent/skills` (doc 02 §1.3 target dirs) so Pi and
+  external Claude Code can read/write the same vault.
+- **New `/api/wiki/*` REST surface** (sibling to `/api/memory/*`, doc 06 §2(c)):
+  page render/list + `graph.json`/`graph.html` (the framework's server-free graph
+  view) + the `register_compiled` mediation. Mounted in `create_app`.
+- **Librarian maintenance timer** (doc 06 §5): a CT 105 **systemd timer** (the
+  framework's launchd plist → a timer) runs `daily-update` nightly — freshness
+  pass, `index.md`/`hot.md` rebuild, lint. **Hermes-as-librarian** for now **[Q3]**.
+- **`.manifest.json` attribution** wired to the `X-hal0-Agent` identity that stamps
+  every Engine write — the basis for `memory-bridge` (doc 06 §5).
+- **Retire** the pre-existing local `obsidian-vault` skill on hal0-dev (flat WSL
+  path, no provenance — doc 06 §9) to avoid two competing conventions.
+
+**Exit criteria.**
+- `hal0-wiki setup` installs skills into Hermes/Claude/Pi skill dirs; `info` shows
+  per-agent install status.
+- A `wiki-ingest` of a sample page writes markdown to `/var/lib/hal0/wiki`, commits
+  to git, and calls `register_compiled` → the page is recallable from the Engine via
+  `recall(types=['wiki'])`.
+- `wiki-query` returns the page via the Engine semantic pass, and still returns it
+  with the Engine down (Grep fallback).
+- `/api/wiki/list` + `graph.json` render; nightly `daily-update` timer fires and
+  rebuilds `index.md`/`hot.md`.
+
+**Rollback.** The wiki is additive — a directory + skills + a sibling REST surface.
+Disable the librarian timer, uninstall the skills (`setup` is reversible / symlinks),
+and unmount `/api/wiki/*`. The engine is unaffected; `kind='wiki'` index entries can
+be left (inert) or filtered out. No memory-engine rollback needed.
+
+**Can ship after this phase.** Yes — the wiki is a read/write knowledge layer that
+degrades to plain markdown. Promotion (Phase 4) not yet automated; humans/agents
+write the wiki by hand via skills. Still a coherent, shippable "engine + notebook".
+
+**Risk / blocked-on.**
+- **[Q3]** Hermes-as-librarian centralisation (single failure + trust point). Start
+  with Hermes; the timer/skill design must not assume Hermes-only so a dedicated
+  librarian persona can be split out later without rework.
+- Fork-divergence discipline: the QMD→Engine edit is the one big "Hal0'd" change;
+  keep it surgical and documented so upstream re-syncs stay tractable (doc 02 §6).
+
+---
+
+## Phase 4 — Promotion pipeline
+
+**Goal.** Wire the **one-way, gated** Engine→Wiki promotion (doc 06 §6): Hindsight's
+`consolidation.completed` webhook fans into the hal0 EventBus and enqueues promotion
+candidates; the librarian drafts a wiki page; a human approves via a dashboard inbox;
+approval writes the page and `register_compiled` re-embeds it. Consolidation writes
+to the Engine **only** — it never auto-writes the Wiki.
+
+**Work items.**
+- **Webhook receiver:** point `HINDSIGHT_API_WEBHOOK_URL` at a new hal0 endpoint
+  (e.g. `/api/memory/webhooks/hindsight`) that verifies the HMAC
+  (`HINDSIGHT_API_WEBHOOK_SECRET`), **dedupes on `operation_id`** (at-least-once
+  delivery, doc 01 §6), and fans `consolidation.completed` into
+  `src/hal0/events/` EventBus (footer/journal live update) (doc 06 §7).
+  **[Q9 — Gap 2:]** the shipped Hindsight webhook config is **server-wide env-var
+  only** (no documented per-bank registration, doc 01 §6). So the handler must
+  **demultiplex by `bank_id`** in one endpoint to route candidates to the right
+  namespace. Verify whether per-bank exists before assuming; if not, single-handler
+  demux is the design.
+- **Promotion-candidate queue:** an observation qualifies when `proof_count ≥ N`
+  **or** `freshness == 'stable'` (doc 06 §6). Gate by namespace:
+  - `private:<agent>` → **auto-promote** (low blast radius).
+  - `shared` / `project:<id>` → **gated**: librarian agent drafts the wiki page
+    (`provenance: inferred`, `lifecycle: draft`); a **human approves** via the
+    dashboard inbox (reusing the existing destructive-call approval-queue UX —
+    `src/hal0/mcp/approval_queue.py`, doc 04 §3.1) to flip `lifecycle: reviewed`.
+- **Approval → write:** on approve, `wiki-ingest` writes the page and
+  `register_compiled` re-embeds it as `kind='wiki'` (top of the recall hierarchy:
+  wiki → observations → facts). One-way; the Engine never reads it back as mutable
+  truth.
+- **Dashboard health signal:** an aging promotion inbox surfaces as a health metric
+  (mitigation for the §6 main risk).
+
+**Exit criteria.**
+- A forced `consolidate()` → `consolidation.completed` webhook → EventBus event +
+  candidate enqueued, deduped on `operation_id` (replayed webhook is idempotent).
+- `private:<agent>` candidate auto-promotes to a draft wiki page + Engine re-embed.
+- `shared` candidate appears in the dashboard promotion inbox; human approve writes
+  the page, flips `lifecycle: reviewed`, and re-embeds.
+- Round-trip recall shows the wiki page ranked above the raw observation it came from.
+
+**Rollback.** Unset `HINDSIGHT_API_WEBHOOK_URL` (promotion stops; consolidation still
+runs internally to the Engine, harming nothing). Disable auto-promote (set all
+namespaces to gated, or disable the queue). Already-promoted wiki pages remain valid
+hand-written pages. No data loss.
+
+**Can ship after this phase.** Yes — the brain now compounds: consolidation feeds a
+gated pipeline into the curated wiki. The remaining work (Phase 5) is depth/UX, not
+correctness.
+
+**Risk / blocked-on.**
+- **★ [Q1] — the headline open question.** Is `private:<agent>`-auto + `shared`-gated
+  the right split? The gate is either a bottleneck or a rubber stamp (doc 06 §6 main
+  risk, §10 Q1). On a single-user box, proof-count corroboration may never accrue
+  **[Q6]** — so `freshness=='stable'` likely carries more weight than `proof_count ≥
+  N`. **Resolve the default trust gate before shipping auto-promotion to `shared`.**
+- **[Q9]** Webhook per-bank registration may not exist → single-handler demux design
+  must be confirmed.
+
+---
+
+## Phase 5 — Deep consumer integration
+
+**Goal.** Make every consumer feel the brain natively (doc 06 §7, doc 04 §6): Hermes
+recall/retain wired to the engine's `recall`/`retain`; external Claude Code as a
+first-class guest with the six-hook ingestion plugin; the dashboard Agent→Memory tab
+with real stats + wiki browser + promotion inbox; the "Memory map" name-collision
+resolved; bank-templates as a persona/project primitive.
+
+**Work items.**
+- **Hermes — recall:** `Hal0CogneeProvider.prefetch(query)` (`provider.py:137`) calls
+  **`recall(types=['wiki','observation','world'], max_tokens=…)`** instead of flat
+  `search(limit=5)`; returns a wiki-block + observation-block, top-of-hierarchy
+  first (doc 06 §7). **Rename the plugin `hal0-cognee` → `hal0-memory`** (dir,
+  `name`, README; copied into `$HERMES_HOME/plugins/memory/hal0-memory/`).
+- **Hermes — write:** `sync_turn` (`provider.py:163`) + `on_memory_write` (`:207`)
+  unchanged call path → now backed by Hindsight `retain`; background consolidation
+  actually runs (it didn't on Cognee). (The `_client.py` 404 was already fixed in
+  Phase 0.)
+- **Hermes — context files:** add a "Wiki index / how to query the brain" section to
+  `HERMES.md.j2` / `AGENTS.md.j2` via `_phase_context_link`
+  (`hermes_provision.py:1230`) so any agent landing in `/etc/hal0` learns the brain
+  exists (doc 04 §6 #9).
+- **External Claude Code:** add `wiki_search` / `wiki_get` tools on the **same**
+  `hal0-memory` MCP server (not a new service, doc 06 §2). Default an external client
+  to **read `shared` + own-private, no shared-write** **[Q7 — confirm read-yes is
+  acceptable for a LAN guest]** (doc 06 §10 Q7). Ship the **six-lifecycle-hook
+  ingestion plugin** (SessionStart / UserPromptSubmit / PostToolUse / Stop /
+  PreCompact / SessionEnd) so Claude Code *produces* into the wiki — the headline
+  "every agent feeds one brain" story (doc 04 §6 Tier C-8, PLAN:1044).
+- **pi-coder:** Wiki tools appear automatically via MCP (`pi-mcp-adapter.json` →
+  `/mcp/memory`). Mine the `pi-memory-md` precedent as the `project:<id>` wiki-
+  namespace analogy (doc 04 §1.3). No code change required beyond MCP tool exposure.
+- **Dashboard Agent→Memory tab** (`ui/src/dash/agents/memory-tab.jsx`): wire **real
+  stats** (Hindsight `get_bank_stats` + `/stats` pending-consolidation — replaces the
+  mock `2,847`); add an **Obsidian wiki browser** (render markdown +
+  `graph.html`/`graph.json`); add the **promotion inbox** (reuse approval-queue UX).
+  Keep `GraphExtractionPanel` as the engine graph-gate. **Wire real `reads`/`writes`
+  counts** (audit §4.6 — `reads` is hard-coded `0`, `writes` is a capped page count).
+- **Resolve the "Memory map" name collision:** `ui/src/dash/memory-map.jsx` is
+  **hardware GTT/RAM attribution, NOT the brain** (doc 04 §5, audit §3). Rename the
+  hardware view (e.g. "Hardware Memory" / "Unified Memory map") so it cannot be
+  confused with the Agent→Memory brain tab. Mechanical but do it before docs/promo.
+- **`memory` capability card** (optional, doc 06 §7 / doc 04 §7): add to
+  `capabilities.toml` / `capabilities/catalog.py` so the brain's embed+rerank wiring
+  + health render in the same UX as voice/img cards.
+- **Bank-templates as a hal0 primitive** (doc 06 §8): JSON templates at
+  `/etc/hal0/memory-templates/<id>.json` (echoing `/etc/hal0/mcp-servers/<id>.toml`).
+  Seed set: `coding-agent`, `conversation`, `personal-assistant`, `homelab-ops`.
+  Extend personas (`personas.py`) with a `memory_bank_template` field; on persona
+  select, idempotently `import` the template to ensure the bank exists. `export`
+  emits overrides → version-controlled artifact; `import --dry-run` in CI.
+  **[Caveat — doc 01 Gap 3:]** confirm the importer accepts the template
+  `entity_labels` form (flat `string[]`) vs bank-config rich label-group objects, and
+  `retain_extraction_mode: chunks`, before shipping rich-label templates.
+- **journal/events producer (optional, off by default, doc 06 §7):** a gated producer
+  that ingests operational events into `shared` tagged `["machine","event"]`. Ship
+  behind a flag; default off (volume/noise).
+
+**Exit criteria.**
+- Hermes prefetch returns wiki + observation blocks (hierarchy-ordered) on a live
+  turn; `sync_turn` write triggers eventual consolidation.
+- A real external Claude Code session reads `shared`, is blocked from shared-write,
+  and the six-hook plugin produces a wiki page from a session.
+- Dashboard Memory tab shows non-mock stats, renders a wiki page + graph, and the
+  promotion inbox approves a candidate end-to-end.
+- "Memory map" hardware view renamed; no UI string confuses it with the brain tab.
+- Selecting a persona with a `memory_bank_template` provisions the bank
+  idempotently; `import --dry-run` passes in CI.
+
+**Rollback.** Per-surface and granular: the plugin rename is reversible; `prefetch`
+can revert to flat `search`; the CC six-hook plugin is opt-in; the dashboard tab can
+fall back to the engine-only explorer; bank-templates default to none; the events
+producer is flagged off. None touch engine data.
+
+**Can ship after this phase.** Yes — this is the "feels native" release. Every
+consumer reaches the unified brain through the unchanged contract.
+
+**Risk / blocked-on.**
+- **[Q3]** librarian split (if Phase 4 surfaced contention).
+- **[Q5]** extraction quality — Hermes recall quality tracks it.
+- **[Q7]** external-agent default read (read-yes / shared-write-no) — confirm before
+  exposing wiki tools to LAN guests.
+- **[Q6]** proof-count on a single-user box informs the bank-template defaults
+  (disposition/promotion thresholds).
+
+---
+
+## Phase 6 — Polish
+
+**Goal.** Close the operational and documentation loop: per-bank webhooks,
+observability/monitoring, docs + promo sync, ADRs, and delete the Cognee corpse.
+
+**Work items.**
+- **Per-bank webhooks** if Hindsight gains/exposes per-bank registration (else keep
+  the Phase-4 single-handler demux) **[Q9 closure]**.
+- **Observability/monitoring:** Hindsight `/stats` counters (pending consolidation,
+  per-bank sizes) surfaced to the dashboard + footer; promotion-inbox-age health
+  signal; audit-trail aggregation to finally back the `reads`/`writes` counts
+  honestly (audit §2.4 / §4.6).
+- **Delete Cognee** once the fallback flag has soaked one release without revert
+  (doc 06 §9): remove `cognee==1.0.7`, `cognee_wrapper.py`, the sidecar
+  `hal0_memory_index.sqlite` + text-equality join, and the write-only Kuzu graph.
+  Drop the `engine = "cognee"` branch.
+- **ADRs:** mark **ADR-0005 / ADR-0014 superseded**; write new ADRs for the
+  `MemoryProvider` ABC + engine choice (Hindsight), the promotion model, and
+  bank-templates-as-primitive. Mark the stale auto-memory entry
+  `hal0_memory_dataset_namespace_bug` resolved (#317 fixed, audit §4.1).
+- **Docs + promo sync** (per the standing reminder): README (bundled `hal0-memory`
+  description, wiki, brain), PLAN (engine pivot, wiki, promotion), hal0-web
+  CONTENT_BRIEF + Astro pages.
+
+**Exit criteria.** Cognee fully removed and CI green without it; ADRs landed; README/
+PLAN/hal0-web reflect the unified brain; observability panels live.
+
+**Rollback.** Cognee deletion is the only irreversible step — do it **only after** the
+fallback flag soaked one release with no revert. Everything else is additive/docs.
+
+**Can ship after this phase.** Yes — terminal, fully-polished state.
+
+**Risk / blocked-on.** **[Q11]** YAGNI counter-case (is the two-tier design over-built
+for a single-user box?) — if the eval/usage data says the Wiki-in-context suffices,
+Phase 6 is where you'd consciously *not* invest further in consolidation machinery
+rather than gold-plate it. **[Q9]** per-bank webhook closure.
+
+---
+
+## Open-question dependency index (maps to doc 08)
+
+| Q# (doc 06 §10) | Blocks | Must resolve before |
+|---|---|---|
+| **Q2 — eval not yet run** | the whole engine flip | **★ Phase 2** (hard gate; run in Phase 1) |
+| Q10 — migration fidelity / method | data cutover | Phase 2 |
+| Q1 — promotion gate split | auto-promote to `shared` | Phase 4 |
+| Q9 — webhook per-bank registration | promotion fan-out routing | Phase 4 (design), Phase 6 (closure) |
+| Q6 — proof-count on single-user box | promotion thresholds, bank-template defaults | Phase 4 / Phase 5 |
+| Q3 — librarian centralisation | librarian agent design | Phase 3 (don't hard-couple), Phase 5 (split if needed) |
+| Q4 — Strix accel undocumented | embed model / re-embed decision | Phase 1 (measure in eval) |
+| Q5 — local structured-output invest-or-route | extraction quality ceiling | Phase 1/5 (design for recall-only) |
+| Q7 — external-agent default read | CC/Cursor wiki tool exposure | Phase 5 |
+| Q8 — Hindsight bundled-daemon port collision | Hermes→Hindsight wiring | Phase 1 (confirm), Phase 5 (use) |
+| Q11 — YAGNI / over-built | depth-of-investment in Phase 6 | Phase 6 |
+
+**The one non-negotiable:** Q2's δ-eval is a **hard gate before Phase 2**. Doc 06 §4
+is explicit — *ship the ABC + conformance suite + dual-write migration first; flip the
+default only after the eval.* Do not flip blind.

--- a/docs/internal/brain-redesign/08-grilling-decision-tree.md
+++ b/docs/internal/brain-redesign/08-grilling-decision-tree.md
@@ -1,0 +1,408 @@
+# 08 — Grilling Decision Tree
+
+> **Purpose.** This is the working document for the post-reboot grilling session
+> (`/grill-me` / `/grill-with-docs`). It collects every genuinely-open design
+> decision surfaced by the research wave (docs 01–07) and arranges them as a
+> **dependency-ordered tree**: resolve the roots first, because their answers
+> prune or reshape the branches below them.
+>
+> Each node carries: **Question · Why it matters · Options · Depends on ·
+> Recommended answer · Grill focus** (the sharpest attack on my own
+> recommendation — start the interrogation there).
+>
+> Status: planning, 2026-06-02. Nothing here is decided. Recommendations are
+> *opening positions to be stress-tested*, not conclusions.
+
+---
+
+## How to read this tree
+
+```
+ROOT  S — Scope & commitment        (decide first; gates everything)
+ ├── A — Engine                     (what powers recall)
+ ├── B — Namespace & multi-agent    (who sees what)
+ ├── C — Wiki layer                 (the human-legible tier)
+ ├── D — Promotion model            (how the two tiers relate) ← the crux
+ ├── E — Integration mechanics      (the wiring)
+ └── F — Process & sequencing
+```
+
+Dependency order for the session: **S → A → B → D → C → E → F.**
+(D before C is deliberate: how the tiers relate determines what the wiki layer
+even needs to be. If D collapses to "engine-only", branch C largely evaporates.)
+
+---
+
+## ROOT — S. Scope & commitment
+
+### S1. Are we replacing the memory engine at all, or hardening what exists?
+- **Why it matters.** Everything downstream assumes a swap. If the answer is
+  "harden Cognee," the entire roadmap collapses to a much smaller refactor.
+- **Options.**
+  1. **Replace** the engine (Hindsight candidate) behind a clean seam.
+  2. **Reduce** — drop Cognee's dead graph layer, keep a thin `pgvector + filters`
+     store, no new dependency.
+  3. **Harden Cognee** in place (turn on graph with a 32B+ extractor).
+- **Recommended answer.** **Option 1 (replace), but gated by the eval in A3** —
+  with Option 2 as the *fallback the seam gives us for free*. Rationale (doc 03/05):
+  hal0 already runs Cognee as "pgvector + a fragile SQLite text-join sidecar"
+  with the graph off; Hindsight's *observations/consolidation* directly fixes the
+  staleness gap nothing in hal0 addresses today, and it degrades to "a better
+  local vector store" even with no extraction LLM.
+- **Grill focus.** "You're adding a Postgres daemon and a whole new engine to fix
+  staleness — but the cheapest staleness fix is a wiki-lint pass you're building
+  anyway in branch C. Why isn't Option 2 + wiki the whole answer?"
+
+### S2. Two-tier brain (engine **+** wiki), or single-tier?
+- **Why it matters.** This is the YAGNI question (architect Q11). Two stores = two
+  staleness sources = drift risk — and hal0 has *already been burned* by drift
+  (capabilities.toml↔slot, MEMORY.md). The wiki only earns its keep if it's
+  doing something the engine genuinely can't.
+- **Options.**
+  1. **Two-tier** — engine for raw recall, wiki for curated human-canonical knowledge.
+  2. **Engine-only** — Hindsight observations *are* the legible layer (they're
+     deduped, cited, freshness-tracked, human-readable).
+  3. **Wiki-only** — Karpathy-pure; markdown is the brain, engine is just its index.
+- **Depends on.** S1.
+- **Recommended answer.** **Two-tier (1), but with a hard "wiki must justify itself"
+  test:** adopt the wiki layer only for content classes the engine serves badly —
+  *narrative/architectural knowledge, onboarding, cross-agent shared canon, and
+  anything a human needs to read/edit directly.* Everything episodic stays
+  engine-only. This keeps the wiki small and high-value instead of a second copy
+  of everything.
+- **Grill focus.** "Name three facts that *must* live in the wiki and could not be
+  a Hindsight observation. If you can't, S2 should be Option 2."
+
+---
+
+## A. Engine
+
+### A1. Hindsight, pgvector-minimal, or keep Cognee — as the recommended target?
+- **Why it matters.** Picks the thing we build a provider for.
+- **Options.** Hindsight · pgvector-minimal · Cognee-hardened.
+- **Depends on.** S1.
+- **Recommended answer.** **Hindsight as the target hypothesis**, validated by A3.
+  Reasons (doc 01/05): TEMPR retrieval + token-budgeted recall, observations =
+  built-in consolidation/staleness, bank-templates map cleanly onto hal0's
+  TOML-template idiom, and *upstream Hermes + Claude-Code plugins already exist*.
+- **Grill focus.** "Hindsight's bundled stack assumes its own BGE + reranker +
+  Gemma. You want to rip all three out and route to hal0 slots + Lemonade. How
+  much of Hindsight's quality story survives that surgery — is it still Hindsight
+  or just their Postgres schema?"
+
+### A2. Structured extraction: invest in it, or design to never need it?
+- **Why it matters.** The single fact that explains why Cognee's graph is off:
+  reliable triple/entity extraction needs ≥32B grammar-constrained models hal0
+  can't reliably run locally (doc 05). This decision sets a *ceiling* on every
+  graph/knowledge-graph feature, in either engine.
+- **Options.**
+  1. **Design to not need it** — semantic + BM25 + temporal + rerank only; graph
+     stays a "someday, when local models are good enough" feature.
+  2. **Invest** — stand up a 32B+ grammar-constrained extractor (where? Strix can
+     hold it but it competes with the primary slot for memory).
+  3. **Route extraction off-box** — but hal0 is no-cloud, so this is a non-starter
+     unless to another LAN host.
+- **Depends on.** A1.
+- **Recommended answer.** **Option 1 now, architected so Option 2 is a later
+  toggle.** The MemoryProvider's `retain()`/`consolidate()` should treat
+  extraction quality as a pluggable knob, not a hard dependency. Don't block the
+  redesign on a capability local models don't reliably have yet.
+- **Grill focus.** "If extraction is off, Hindsight's 'biomimetic graph' is just a
+  vector store with freshness metadata. Did we just pick Hindsight for features
+  we've decided not to turn on?"
+
+### A3. The eval — what exactly gates the cutover, and what's the pass bar?
+- **Why it matters.** Doc 06 §4 and doc 07 P1 both make this a **hard gate: no
+  flip blind.** But "run an eval" is not a decision until we define pass/fail.
+- **Options for the bar.**
+  1. **Quality-primary** — Hindsight must beat Cognee-today on a recall-relevance
+     set by margin X.
+  2. **Parity-is-enough** — match Cognee quality but win on staleness/legibility/ops.
+  3. **Latency-bounded** — must stay under N ms p95 recall on Strix CPU embed.
+- **Depends on.** A1, A2, and **A4 (Strix accel)**.
+- **Recommended answer.** **Parity-or-better on relevance (2) AND a latency ceiling
+  (3),** measured with the δ-harness on the *actual* primary Strix model and a
+  representative hal0 memory corpus. Hindsight wins the tie on staleness + the
+  existing plugins. Cognee-vs-Hindsight-vs-pgvector all three in the bake-off so
+  Option 2 (S1) stays a live fallback.
+- **Grill focus.** "We have no labelled hal0 recall set today. Are we going to
+  hand-build eval data, or is this 'gate' actually just vibes-on-a-demo?"
+
+### A4. Strix-Halo acceleration: validate, or assume CPU?
+- **Why it matters.** Hindsight's docs say *nothing* about ROCm/XDNA (doc 01).
+  Embeddings + rerank on CPU is fine; but the assumption needs a number before A3.
+- **Options.** Assume CPU and move · Spend a day validating iGPU/NPU embed paths first.
+- **Depends on.** —
+- **Recommended answer.** **Assume CPU for embed/rerank** (route through existing
+  embed/:8086 slots which already decide their own backend), **route the extraction
+  LLM to `lemond:13305`** (iGPU), and treat any iGPU embedding win as later upside.
+  Don't let an unvalidated accel assumption sit *inside* the eval.
+- **Grill focus.** "The embed slot's backend choice is hal0's, not Hindsight's — so
+  'CPU embed' might already be false. Did you confirm what the embed slot actually
+  runs on before baking 'assume CPU' into the plan?"
+
+---
+
+## B. Namespace & multi-agent
+
+### B1. Confirm the namespace scheme and bank mapping.
+- **Why it matters.** Determines isolation, sharing, and how banks map.
+- **Options.** `shared` / `private:<agent>` / `project:<id>` (+ `agents` identity
+  set) with **1:1 namespace↔Hindsight-bank** · vs a flatter or richer scheme.
+- **Depends on.** A1.
+- **Recommended answer.** **Keep the existing three-namespace primitive 1:1 with
+  banks.** It already exists in `namespace.py`, the #317 fix made it real, and it
+  maps onto Hindsight banks without translation.
+- **Grill focus.** "1:1 bank-per-namespace — does Hindsight charge per-bank
+  overhead (separate index/worker)? `project:<id>` could spawn hundreds. What's the
+  bank lifecycle/GC story?"
+
+### B2. External agents (Claude Code, Cursor) — default read/write policy.
+- **Why it matters.** hal0's MCP host exposes memory tools to *any* connecting
+  agent. The default trust posture is a security/coherence decision.
+- **Options.**
+  1. **Guest** — read `shared` + own `private:`, **no `shared` write** by default.
+  2. **Trusted** — full read/write like Hermes.
+  3. **Sandboxed** — only own `private:`, no shared read.
+- **Depends on.** B1, and D (promotion gate).
+- **Recommended answer.** **Guest (1).** External agents read the curated canon and
+  their own scratch, but writing to `shared` goes through the same promotion gate
+  as everyone else (branch D). This is the "deeply integrated but not a free-for-all"
+  posture the platform wants.
+- **Grill focus.** "A user's Claude Code that *can't* persist a shared insight will
+  feel second-class — the opposite of 'native'. Is guest-read-only the integration
+  the user asked for, or a hedge?"
+
+---
+
+## D. Promotion model — **the crux**
+
+### D1. Promotion direction between engine and wiki.
+- **Why it matters.** This is the seam doc 05/06 both call the weakest point. Get
+  it wrong and you get drift (two canonical copies) or a dead wiki (nothing flows).
+- **Options.**
+  1. **One-way, engine→wiki, gated** — engine accrues observations; curated ones
+     get promoted *up* into the wiki; wiki→engine is only a derived read-index.
+  2. **Wiki-canonical** — humans/agents write the wiki; engine is purely its index
+     (Karpathy-pure).
+  3. **Bidirectional** — both can be source-of-truth per fact-class.
+- **Depends on.** S2.
+- **Recommended answer.** **One-way gated (1).** The wiki is canonical *for what's
+  in it*; the engine is canonical for raw recall; promotion flows up under a gate;
+  the wiki is embedded into the engine **one-way** as "mental-model" priors checked
+  first, never read back as truth. This gives exactly one source of truth per fact.
+- **Grill focus.** "One-way means a human editing the wiki can't correct the
+  engine — the engine will keep surfacing the stale observation the human just
+  fixed. Doesn't that violate 'single source of truth' the moment a human edits?"
+
+### D2. The gate mechanism for `shared`/`project:` promotion.
+- **Why it matters.** Architect's #1 risk: the gate becomes a bottleneck or a
+  rubber-stamp, and the curated layer stays empty — the failure mode that kills
+  two-tier systems.
+- **Options.**
+  1. **Human-approval inbox** (reuse the MCP approval-queue UI).
+  2. **Librarian-agent auto-promote** with periodic human audit.
+  3. **Proof-count threshold** — Hindsight `proof_count`/corroboration auto-promotes.
+  4. **Hybrid** — librarian drafts → human one-click approve.
+- **Depends on.** D1, C3 (who the librarian is).
+- **Recommended answer.** **Hybrid (4):** librarian agent drafts wiki entries from
+  high-corroboration observations, queued to a lightweight approval inbox; one-click
+  approve writes + re-embeds. Tune toward auto (2/3) once trust is established.
+- **Grill focus.** "Every two-tier knowledge system dies on the approval queue.
+  What's the *concrete* daily volume, and who is the human that clears it — because
+  if it's nobody, the honest design is auto-promote (2/3) from day one."
+
+### D3. Does consolidation **mutate** the shared brain, or only re-rank?
+- **Why it matters.** (landscape Q2) If `reflect()`/consolidation can rewrite or
+  retire shared observations autonomously, that's an agent mutating canon without a
+  gate — in tension with D1/D2.
+- **Options.** Mutate (autonomous belief revision) · Rank-only (never destroys,
+  only re-weights) · Mutate-private-only.
+- **Depends on.** D1, D2.
+- **Recommended answer.** **Rank-only for `shared`; mutate freely within
+  `private:<agent>`.** Belief revision is fine in an agent's own head; revising
+  shared canon is a promotion-gated event, not a background job.
+- **Grill focus.** "Hindsight's whole pitch is autonomous consolidation. If you
+  forbid it on `shared`, are you fighting the engine's design — and does
+  rank-only even fix staleness, or just hide it?"
+
+### D4. Per-namespace promotion policy.
+- **Recommended answer.** `private:<agent>` = auto-promote/auto-mutate (cheap,
+  attributed, the agent's own scratch); `shared`/`project:` = gated per D2.
+  *Mostly a corollary of D1–D3; included so the grilling can confirm it explicitly.*
+
+---
+
+## C. Wiki layer
+
+### C1. Adopt the wiki now, or defer to a later milestone?
+- **Depends on.** S2 (if engine-only wins, C is dead).
+- **Recommended answer.** **Adopt, but after the engine cutover (roadmap P3),** so
+  we're not landing two big changes at once.
+- **Grill focus.** "Deferring the wiki means Phases 1–2 ship a pure engine swap with
+  *no* user-visible win. Is there a thin wiki slice worth pulling forward to make
+  the early phases feel like progress?"
+
+### C2. Where the vault lives and who renders it for humans.
+- **Why it matters.** hal0 runs headless on CT105; Obsidian is a desktop GUI.
+- **Options.** Dashboard-rendered (graph.html / built-in viewer) · git→desktop
+  Obsidian sync · both.
+- **Recommended answer.** **Vault at `/var/lib/hal0/wiki`, git-backed; dashboard
+  render is primary** (lives where the rest of hal0's UI is), **git→Obsidian sync is
+  the power-user secondary.** The Agent→Memory dashboard tab becomes the wiki browser.
+- **Grill focus.** "Building a Markdown+wikilink+graph renderer in the dashboard is
+  real frontend work. Is rebuilding Obsidian-lite in-house justified versus just
+  shipping the git repo and letting users point their own Obsidian at it?"
+
+### C3. Who maintains the wiki — Hermes-as-librarian or a dedicated librarian agent?
+- **Why it matters.** (architect Q3) Centralizing maintenance in one agent is
+  simpler but a single point of failure / bottleneck.
+- **Options.** Hermes wears the librarian hat · a dedicated lightweight librarian
+  persona · any-agent-can-edit-with-lint.
+- **Depends on.** D2.
+- **Recommended answer.** **Dedicated librarian persona** (a Hermes persona/profile,
+  not a separate runtime) that owns the nightly maintenance timer, lint, and
+  promotion drafting. Keeps maintenance accountable to one identity without a new
+  daemon.
+- **Grill focus.** "A 'librarian persona' still runs on the one Hermes instance —
+  same bottleneck, fancier name. What happens to wiki freshness when Hermes is busy
+  serving chat?"
+
+### C4. Fork strategy for hal0-wiki.
+- **Why it matters.** The fork is byte-identical to upstream `ar9av/obsidian-wiki`
+  today (doc 02) — a blank canvas. We can track upstream or harden a hal0 package.
+- **Options.** Track upstream (symlink skills, `pip -U`) · Hard-fork into a hal0 pkg
+  · Vendor the skills into hal0's own skills tree.
+- **Recommended answer.** **Track upstream initially** (skills are markdown; cheap to
+  re-pull), **vendor only the one change we know we need: swap the QMD search index
+  for the engine** via the wiki's pluggable index seam. Hard-fork only if upstream
+  diverges from our needs.
+- **Grill focus.** "Tracking upstream means an `ar9av` skill update could silently
+  change how hal0's brain is maintained. For a *core* platform subsystem, is
+  uncontrolled upstream drift acceptable?"
+
+---
+
+## E. Integration mechanics
+
+### E1. The `MemoryProvider` ABC shape.
+- **Recommended answer.** Confirm doc 06's sketch: byte-compatible core
+  (`add/search/list_items/delete/graph_status/set_graph/set_rerank`) so existing
+  callers don't change, plus optional `recall`/`reflect`/`consolidate`/
+  `register_compiled` (wiki→engine one-way). `MemoryItem.id` becomes the real join
+  key, killing the SQLite text-join. Conformance suite gates any provider.
+- **Grill focus.** "Byte-compatible core preserves the *current* contract — which
+  leaks Cognee concepts (dataset enums, graph-route flags). Are you enshrining
+  Cognee's abstractions in the ABC that's supposed to outlive Cognee?"
+
+### E2. Who owns the working-memory / recall token budget?
+- **Question (architect Q6).** Recall returns a token-budgeted set — does the
+  *provider*, the *consumer* (Hermes prefetch), or a *central policy* set the budget?
+- **Recommended answer.** **Consumer sets the budget, provider enforces it.** Hermes
+  knows its context window and persona; the provider just honors a `max_tokens`.
+- **Grill focus.** "If every consumer picks its own budget, shared recall quality is
+  inconsistent across agents. Should there be a platform default they override,
+  rather than free-for-all?"
+
+### E3. The `:9077` daemon collision (architect Q8).
+- **Question.** Hindsight's Hermes plugin runs a local daemon on `:9077`; does that
+  collide with anything in hal0's port map (lemond 13305, admin 9000, slots 8001+,
+  rerank 8086, serena 9121/9122)?
+- **Recommended answer.** **Verify the port map and pin Hindsight's port explicitly**
+  in config; don't rely on its default. Low-risk but must be checked before P1.
+- **Grill focus.** "Do we even want Hindsight's *own* daemon, or should hal0 embed
+  the engine in-process behind the provider and skip the extra service entirely?"
+
+### E4. Webhook per-bank registration (architect Q9 / landscape).
+- **Question.** The local skill only documents env-level webhook config
+  (`WEBHOOK_URL`/`_SECRET`/`_EVENT_TYPES`) for `consolidation.completed` and
+  `retain.completed`. A *per-bank* registration API was not confirmed.
+- **Recommended answer.** **Verify against the live API/openapi before relying on
+  per-bank webhooks**; design the promotion pipeline (P4) to work with the
+  env-level firehose + an internal router as the fallback, so we're not blocked on
+  an unconfirmed feature.
+- **Grill focus.** "The promotion pipeline's trigger is `consolidation.completed`.
+  If per-bank webhooks don't exist, every bank's consolidation hits one global
+  endpoint — does the router scale, and can it even tell which namespace fired?"
+
+### E5. Dashboard "Memory map" name collision.
+- **Question.** `memory-map.jsx` is hardware GTT/RAM; the real brain explorer is the
+  Agent→Memory tab. Two different "memory" surfaces confuse users.
+- **Recommended answer.** **Rename the hardware view** (e.g. "Memory & GTT" or
+  "Hardware Memory") and reserve "Memory"/"Brain" for the knowledge surface. Cheap,
+  do it during P5.
+- **Grill focus.** "Is 'Brain' the user-facing name we want, or marketing fluff?
+  Pick the vocabulary now so docs/UI/skills don't drift."
+
+### E6. Cognee→Hindsight migration fidelity (architect Q10).
+- **Question.** Existing Cognee data = LanceDB vectors + the SQLite sidecar
+  (filters/tags/dates are *only* in the sidecar). How faithfully must it migrate?
+- **Options.** Full re-ingest (re-embed raw text into Hindsight) · metadata-only
+  bridge · accept lossy / start-fresh with an archive.
+- **Recommended answer.** **Re-ingest from the sidecar's authoritative text+metadata**
+  (the sidecar *is* the real source of truth per doc 03), re-embedding into
+  Hindsight; keep a read-only Cognee archive for one release as rollback.
+- **Grill focus.** "Re-embedding changes vectors — recall results *will* shift.
+  How do you prove the migration didn't silently lose or reorder knowledge users
+  rely on?"
+
+---
+
+## F. Process & sequencing
+
+### F1. ADRs.
+- **Recommended answer.** New ADRs that **supersede ADR-0005/0014** (the Cognee/graph
+  decisions). At minimum: ADR "memory engine = Hindsight behind MemoryProvider",
+  ADR "two-tier brain + promotion model", ADR "wiki layer adoption". ADRs live in
+  `docs/internal/adr/` (note: `docs/adr/` is empty — don't put them there).
+- **Grill focus.** "Which of these is reversible enough to *not* need an ADR yet?
+  Don't ADR-lock decisions the eval (A3) might overturn."
+
+### F2. Milestone & promo sync.
+- **Recommended answer.** Target **v0.4** (current default per auto-memory). After
+  any phase that changes installer/capabilities/agents, sync README + PLAN +
+  hal0-web CONTENT_BRIEF/Astro pages (standing feedback rule).
+- **Grill focus.** "This is a multi-phase epic spanning a Postgres daemon, an engine
+  swap, a wiki subsystem, and dashboard work. Is that one v0.4, or are we
+  over-stuffing a milestone?"
+
+---
+
+## Quick map: open question → source → roadmap blocker
+
+| ID | Question | Source | Blocks roadmap phase |
+|----|----------|--------|----------------------|
+| S1 | Replace vs harden engine | 03,05 | P0/P1 framing |
+| S2 | Two-tier vs single-tier | 05,06 | P3,P4 (whole wiki arc) |
+| A1 | Hindsight vs pgvector vs Cognee | 01,05 | P1 |
+| A2 | Invest in extraction vs not | 05 | P1 (feature ceiling) |
+| A3 | Eval pass bar | 06,07 | **P2 hard gate** |
+| A4 | Strix accel validate vs assume | 01 | P1 (eval input) |
+| B1 | Namespace/bank mapping | 04,06 | P2 |
+| B2 | External-agent default policy | 04,05 | P5 |
+| D1 | Promotion direction | 05,06 | P4 |
+| D2 | Gate mechanism | 06 | **P4** |
+| D3 | Consolidation mutate vs rank | 05 | P4 |
+| C2 | Vault location/render | 02,06 | P3 |
+| C3 | Librarian centralization | 06 | P3,P4 |
+| C4 | Fork strategy | 02 | P3 |
+| E2 | Token-budget owner | 06 | P5 |
+| E3 | :9077 collision | 06 | P1 |
+| E4 | Per-bank webhooks | 01,06 | P4 |
+| E6 | Migration fidelity | 03,06 | P2 |
+| F2 | YAGNI / milestone scope | 06 | P6 |
+
+---
+
+## Suggested grilling order (one pass)
+
+1. **S1, S2** — settle scope. If S2 → engine-only, skip branches C and most of D.
+2. **A2, then A1, A4 → A3** — the engine + the eval gate (the technical spine).
+3. **B1, B2** — isolation/trust.
+4. **D1 → D2 → D3 → D4** — the promotion crux (do this with full attention).
+5. **C1–C4** — wiki specifics (only as deep as S2/D allow).
+6. **E1–E6** — wiring details.
+7. **F1, F2** — ADRs + milestone scoping.
+
+Resolve each node, record the decision inline, and convert the settled tree into
+ADRs (F1) and issues (`/to-issues`) afterward.


### PR DESCRIPTION
## What

Nine cross-linked planning documents in `docs/internal/brain-redesign/` for a unified-memory **"brain"** redesign of the hal0 platform: a **two-tier system** pairing a semantic/episodic **engine** (Hindsight candidate, replacing Cognee) with a human-legible **compiled-knowledge wiki** (`Hal0ai/hal0-wiki` / Karpathy "LLM Wiki" pattern), integrated across every hal0 agent/app/MCP surface and fully self-hosted on Strix Halo.

| Doc | Purpose |
|-----|---------|
| `00-INDEX` | Front door — TL;DR, reading guide, exec summary, glossary |
| `01-hindsight-research` | Exhaustive Hindsight feature inventory (banks, bank-templates, retain/recall/reflect, webhooks, ops, MCP, integrations) |
| `02-hal0-wiki-research` | The Obsidian LLM-Wiki framework (skills, vault model, Hermes/Pi/Claude install) |
| `03-current-memory-audit` | As-built Cognee subsystem with `file:line` citations |
| `04-consumer-surface` | Every brain consumer + the deep-integration hook map |
| `05-memory-landscape` | Paradigm taxonomy, tradeoff matrix, two-tier thesis |
| `06-proposed-architecture` | The recommendation: layers, `MemoryProvider` ABC, promotion model |
| `07-integration-roadmap` | 7 ship-able phases, dependency graph, eval hard-gate |
| `08-grilling-decision-tree` | **Working doc for the grilling session** — dependency-ordered decisions, each with a recommended answer + counter-challenge |

## Why now

- **Cognee's graph layer is dead weight** — off by default because local <32B models can't do reliable triple extraction; hal0 effectively runs "pgvector + a fragile SQLite filter sidecar."
- No **staleness handling** today; Hindsight's consolidation/observations directly addresses it.
- **#317** (private-namespace no-op) is **already fixed** (PR #366/#369) — *not* a driver; flagged so it isn't relitigated.
- **Hindsight runs fully local** (embedded Postgres + BGE + MiniLM rerank + built-in LLM, or route extraction to `lemond:13305`); Strix-Halo accel is undocumented → plan CPU embed/rerank via existing slots.

## Status

**Planning only — nothing decided or implemented.** Recommendations are opening positions to be stress-tested in a `/grill-me` session (start at doc 08). Multi-agent research wave, 2026-06-02. Targets v0.4. Will supersede ADR-0005/0014 once decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)