### PR TITLE
feat(agents+gateway): Hermes role-slot model addressing (#377)

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -667,6 +667,8 @@ def _render_config_yaml(
     mcp_servers: list[dict[str, Any]] | None = None,
     system_prompt: str = "",
     personality_name: str = "",
+    delegation: dict[str, Any] | None = None,
+    auxiliary_tasks: dict[str, dict[str, Any]] | None = None,
 ) -> str:
     """Render the Hermes config.yaml via Jinja2.
 
@@ -686,6 +688,17 @@ def _render_config_yaml(
       personality_name — display name for upstream's CLI personality
                          picker (Phase 8 cosmetic; the system prompt
                          already carries the persona's prelude).
+
+    Role-slot inputs (feat/hermes-role-slots):
+      delegation       — dict {model, base_url, provider} or None. When
+                         set, renders the ``delegation:`` block so
+                         subagents run on the ``agent-hermes`` slot's
+                         model. None → block omitted → subagents inherit
+                         the chat model.
+      auxiliary_tasks  — dict task→{provider, model, base_url} driving the
+                         ``auxiliary:`` block. Defaults (when omitted) to
+                         the all-provider:"main" inventory so callers that
+                         predate role-slots keep the original behavior.
     """
     from jinja2 import Environment, FileSystemLoader
 
@@ -704,7 +717,25 @@ def _render_config_yaml(
         mcp_servers=mcp_servers if mcp_servers is not None else _default_mcp_servers(),
         system_prompt=system_prompt,
         personality_name=personality_name,
+        delegation=delegation,
+        auxiliary_tasks=(
+            auxiliary_tasks if auxiliary_tasks is not None else _default_auxiliary_tasks()
+        ),
     )
+
+
+def _default_auxiliary_tasks() -> dict[str, dict[str, Any]]:
+    """All-``provider:"main"`` auxiliary inventory.
+
+    Used when a caller renders without resolving live slots. Matches the
+    pre-role-slots hard-coded template block (vision / web_extract /
+    session_search) plus the rest of the confirmed task keys so the
+    rendered ``auxiliary:`` block is always fully populated.
+    """
+    tasks: dict[str, dict[str, Any]] = {}
+    for task in (*_MAIN_AUX_TASKS, *_UTILITY_AUX_TASKS):
+        tasks[task] = {"provider": "main", "model": "", "base_url": ""}
+    return tasks
 
 
 def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
@@ -819,6 +850,13 @@ def _phase_config_write(state: BootstrapState) -> PhaseResult:
     # (Phase 9 used to be the only place this worked).
     slots_all = _fetch_slots()
     chat_slots = _collect_chat_slots(slots_all)
+    # feat/hermes-role-slots: resolve per-role models from live slot NAMES.
+    # delegation ← `agent-hermes` slot; auxiliary ← `utility` slot. Both
+    # talk to hal0's /v1 endpoint (same base_url as the main model), so a
+    # missing slot degrades safely (delegation omitted / aux → "main").
+    hal0_v1_base = primary["backend_url"]
+    delegation = _resolve_delegation(slots_all, hal0_base_url=hal0_v1_base)
+    auxiliary_tasks = _resolve_auxiliary_tasks(slots_all, hal0_base_url=hal0_v1_base)
     # PR-3 Phase 6: probe-driven mcp_servers list. For the very first
     # config_write (before mcp_wire runs the live probe) we fall back to
     # the default inventory; mcp_wire then captures the probed shape and
@@ -833,6 +871,8 @@ def _phase_config_write(state: BootstrapState) -> PhaseResult:
         mcp_servers=mcp_servers,
         system_prompt=system_prompt,
         personality_name=personality_name,
+        delegation=delegation,
+        auxiliary_tasks=auxiliary_tasks,
     )
     rendered = _apply_overrides(rendered, OVERRIDES_PATH)
     new_hash = content_hash(rendered)
@@ -863,8 +903,23 @@ def _phase_config_write(state: BootstrapState) -> PhaseResult:
             "chat_slot_count": len(chat_slots),
             "persona": personality_name or None,
             "mcp_server_count": len(mcp_servers) if mcp_servers else 0,
+            "delegation_model": (delegation or {}).get("model"),
+            "auxiliary_utility_model": _utility_aux_model(auxiliary_tasks),
         },
     )
+
+
+def _utility_aux_model(auxiliary_tasks: dict[str, dict[str, Any]] | None) -> str | None:
+    """Surface the utility-slot model used by the aux compaction group.
+
+    Returns the ``compression`` task's model (representative of the whole
+    utility group) for self_report visibility, or ``None`` when the group
+    degraded to provider:"main".
+    """
+    if not auxiliary_tasks:
+        return None
+    comp = auxiliary_tasks.get("compression") or {}
+    return comp.get("model") or None
 
 
 # ── Phase F: mcp_wire ───────────────────────────────────────────────────────
@@ -1667,6 +1722,16 @@ def _collect_chat_slots(slots: list[dict[str, Any]]) -> list[dict[str, Any]]:
     Only slots reporting a live/ready state are advertised so we don't tell
     the agent about a model that isn't actually loaded — matches the
     dashboard chat-filter at ``src/hal0/api/routes/slots.py``.
+
+    Each alias's ``backend_url`` is the STABLE hal0 gateway (`:8080/v1`),
+    NOT the slot's raw ``backend_url``. lemond reassigns the per-slot
+    upstream port (`:8001/:8002/…`) on every model reload, so a baked-in
+    alias port goes stale immediately — and could then point at a port
+    now serving a DIFFERENT co-resident model. The gateway resolves both
+    the alias name and the model_id to the correct co-resident slot, so
+    `model_id` + `:8080/v1` stays correct across reloads (the same source
+    the ``model:`` / ``delegation:`` / ``auxiliary:`` blocks use). This is
+    what lets the in-agent model switcher pick a slot up after a restart.
     """
     out: list[dict[str, Any]] = []
     for s in slots:
@@ -1681,10 +1746,129 @@ def _collect_chat_slots(slots: list[dict[str, Any]]) -> list[dict[str, Any]]:
             {
                 "alias": _slot_alias(s),
                 "model_id": model_id,
-                "backend_url": _slot_backend_url(s),
+                "backend_url": _DEFAULT_PRIMARY_BACKEND_URL,
             }
         )
     return out
+
+
+# ── Role→slot resolution (delegation + auxiliary) ───────────────────────────
+#
+# hermes-agent supports per-ROLE models beyond the main chat block:
+#   * subagents  → the `delegation:` block (delegate_tool.py
+#     `_resolve_delegation_credentials` reads delegation.{model,provider,
+#     base_url}; a `base_url` forces provider → "custom").
+#   * side-tasks → `auxiliary.<task>.{provider,model,base_url}` read by
+#     auxiliary_client.py `_resolve_task_provider_model` (a base_url +
+#     non-"auto" provider routes the task to that direct endpoint).
+#
+# We resolve these from LIVE slot NAMES, not hardcoded model ids, so
+# swapping a slot's model flows through on the next `--repair`:
+#   chat       → slot `primary`      (the existing model: block)
+#   subagents  → slot `agent-hermes` (delegation: block)
+#   side-tasks → slot `utility`      (auxiliary.* compaction/search/title)
+#
+# Vision + web_extract have no dedicated slot — they stay provider:"main".
+
+# The hal0-routed side-tasks (everything that should run on the cheap
+# `utility` slot). vision/web_extract are intentionally excluded — they
+# keep provider:"main" so they inherit the chat model (which may carry a
+# vision label) rather than the tiny utility model.
+_UTILITY_AUX_TASKS: tuple[str, ...] = (
+    "compression",
+    "session_search",
+    "title_generation",
+    "skills_hub",
+    "mcp",
+)
+
+# Tasks that always stay on the main chat provider regardless of slot
+# state. Rendered verbatim so the auxiliary: block is fully parameterized
+# (no hard-coded entries left in the template).
+_MAIN_AUX_TASKS: tuple[str, ...] = ("vision", "web_extract")
+
+# Canonical role→slot names. Kept here (not in the template) so the
+# resolution stays data-driven and a future slot rename is a one-line edit.
+_DELEGATION_SLOT_NAME = "agent-hermes"
+_UTILITY_SLOT_NAME = "utility"
+
+
+def _find_named_ready_slot(slots: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    """Return the ready ``type=='llm'`` slot whose name matches ``name``.
+
+    Degrade-safe: returns ``None`` when the slot is absent OR present but
+    not ready/loaded OR carries no model_id, so callers can fall back
+    gracefully (delegation omitted; aux tasks revert to provider:"main").
+    """
+    for s in slots:
+        if not isinstance(s, dict):
+            continue
+        if _slot_alias(s) != name:
+            continue
+        if (s.get("type") or "").lower() != "llm":
+            continue
+        if not _is_ready(s):
+            continue
+        if not _slot_model_id(s):
+            continue
+        return s
+    return None
+
+
+def _resolve_delegation(
+    slots: list[dict[str, Any]],
+    *,
+    hal0_base_url: str,
+) -> dict[str, Any] | None:
+    """Build the ``delegation`` template dict from the ``agent-hermes`` slot.
+
+    Returns ``{model, base_url, provider}`` when the slot is live, else
+    ``None`` so the template omits the block and subagents inherit the
+    parent (chat) model. ``base_url`` is the hal0 /v1 endpoint already
+    used for the main model — setting it makes upstream auto-resolve the
+    provider to "custom".
+    """
+    slot = _find_named_ready_slot(slots, _DELEGATION_SLOT_NAME)
+    if slot is None:
+        return None
+    return {
+        "model": _slot_model_id(slot),
+        "base_url": hal0_base_url,
+        "provider": "custom",
+    }
+
+
+def _resolve_auxiliary_tasks(
+    slots: list[dict[str, Any]],
+    *,
+    hal0_base_url: str,
+) -> dict[str, dict[str, Any]]:
+    """Build the ``auxiliary_tasks`` template dict (task → {provider, model, base_url}).
+
+    vision/web_extract always render as provider:"main" (no dedicated
+    slot). The compaction/search/title group routes to the ``utility``
+    slot when it's live; if that slot is missing the group degrades to
+    provider:"main" so side-tasks fall back to the chat model rather than
+    breaking. Resolution keys off the slot NAME (``utility``) and sends
+    the slot's model_id — swapping the slot's model flows through on the
+    next ``--repair``.
+    """
+    tasks: dict[str, dict[str, Any]] = {}
+    for task in _MAIN_AUX_TASKS:
+        tasks[task] = {"provider": "main", "model": "", "base_url": ""}
+
+    utility = _find_named_ready_slot(slots, _UTILITY_SLOT_NAME)
+    for task in _UTILITY_AUX_TASKS:
+        if utility is not None:
+            tasks[task] = {
+                "provider": "custom",
+                "model": _slot_model_id(utility),
+                "base_url": hal0_base_url,
+            }
+        else:
+            # Degrade safely: no utility slot → inherit the chat model.
+            tasks[task] = {"provider": "main", "model": "", "base_url": ""}
+    return tasks
 
 
 def _phase_model_automap(state: BootstrapState) -> PhaseResult:
@@ -1720,6 +1904,11 @@ def _phase_model_automap(state: BootstrapState) -> PhaseResult:
     cached_servers = (state.phases.get("mcp_wire") or {}).get("details", {}).get("rendered_servers")
     mcp_servers = cached_servers if isinstance(cached_servers, list) and cached_servers else None
     system_prompt, personality_name = _active_persona_render(state, mcp_servers=mcp_servers)
+    # feat/hermes-role-slots: identical role-slot resolution to config_write
+    # so a no-drift re-render stays byte-identical (#245 idempotency).
+    hal0_v1_base = primary["backend_url"]
+    delegation = _resolve_delegation(slots, hal0_base_url=hal0_v1_base)
+    auxiliary_tasks = _resolve_auxiliary_tasks(slots, hal0_base_url=hal0_v1_base)
 
     try:
         rendered = _render_config_yaml(
@@ -1729,6 +1918,8 @@ def _phase_model_automap(state: BootstrapState) -> PhaseResult:
             mcp_servers=mcp_servers,
             system_prompt=system_prompt,
             personality_name=personality_name,
+            delegation=delegation,
+            auxiliary_tasks=auxiliary_tasks,
         )
         rendered = _apply_overrides(rendered, OVERRIDES_PATH)
     except Exception as exc:
@@ -1898,6 +2089,11 @@ def _phase_voice_wire(state: BootstrapState) -> PhaseResult:
             cached_servers if isinstance(cached_servers, list) and cached_servers else None
         )
         system_prompt, personality_name = _active_persona_render(state, mcp_servers=mcp_servers)
+        # feat/hermes-role-slots: keep role-slot blocks consistent with the
+        # other render call sites so re-render stays idempotent.
+        hal0_v1_base = primary["backend_url"]
+        delegation = _resolve_delegation(slots, hal0_base_url=hal0_v1_base)
+        auxiliary_tasks = _resolve_auxiliary_tasks(slots, hal0_base_url=hal0_v1_base)
         rendered = _render_config_yaml(
             primary=primary,
             chat_slots=_collect_chat_slots(slots),
@@ -1919,6 +2115,8 @@ def _phase_voice_wire(state: BootstrapState) -> PhaseResult:
             mcp_servers=mcp_servers,
             system_prompt=system_prompt,
             personality_name=personality_name,
+            delegation=delegation,
+            auxiliary_tasks=auxiliary_tasks,
         )
         rendered = _apply_overrides(rendered, OVERRIDES_PATH)
     except Exception as exc:

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -669,6 +669,7 @@ def _render_config_yaml(
     personality_name: str = "",
     delegation: dict[str, Any] | None = None,
     auxiliary_tasks: dict[str, dict[str, Any]] | None = None,
+    custom_providers: list[dict[str, Any]] | None = None,
 ) -> str:
     """Render the Hermes config.yaml via Jinja2.
 
@@ -699,6 +700,13 @@ def _render_config_yaml(
                          ``auxiliary:`` block. Defaults (when omitted) to
                          the all-provider:"main" inventory so callers that
                          predate role-slots keep the original behavior.
+      custom_providers — list[dict] ({name, base_url, models}) or None.
+                         Per-model context_length lookup keyed by model_id
+                         under the hal0 base_url. None → block omitted.
+                         NOTE: ``model.context_length`` is intentionally
+                         NOT rendered — hermes treats it as a global
+                         override that bleeds onto cloud models; per-model
+                         context lives here instead.
     """
     from jinja2 import Environment, FileSystemLoader
 
@@ -721,6 +729,7 @@ def _render_config_yaml(
         auxiliary_tasks=(
             auxiliary_tasks if auxiliary_tasks is not None else _default_auxiliary_tasks()
         ),
+        custom_providers=custom_providers,
     )
 
 
@@ -849,7 +858,7 @@ def _phase_config_write(state: BootstrapState) -> PhaseResult:
     # ``model_aliases:`` block lands on the first config_write pass
     # (Phase 9 used to be the only place this worked).
     slots_all = _fetch_slots()
-    chat_slots = _collect_chat_slots(slots_all)
+    chat_slots = _collect_chat_slots(slots_all, contexts=_fetch_model_contexts())
     # feat/hermes-role-slots: resolve per-role models from live slot NAMES.
     # delegation ← `agent-hermes` slot; auxiliary ← `utility` slot. Both
     # talk to hal0's /v1 endpoint (same base_url as the main model), so a
@@ -857,6 +866,9 @@ def _phase_config_write(state: BootstrapState) -> PhaseResult:
     hal0_v1_base = primary["backend_url"]
     delegation = _resolve_delegation(slots_all, hal0_base_url=hal0_v1_base)
     auxiliary_tasks = _resolve_auxiliary_tasks(slots_all, hal0_base_url=hal0_v1_base)
+    # Per-model context_length lives in custom_providers (NOT the global
+    # model.context_length override) so cloud models keep their own ctx.
+    custom_providers = _resolve_custom_providers(chat_slots, hal0_base_url=hal0_v1_base)
     # PR-3 Phase 6: probe-driven mcp_servers list. For the very first
     # config_write (before mcp_wire runs the live probe) we fall back to
     # the default inventory; mcp_wire then captures the probed shape and
@@ -873,6 +885,7 @@ def _phase_config_write(state: BootstrapState) -> PhaseResult:
         personality_name=personality_name,
         delegation=delegation,
         auxiliary_tasks=auxiliary_tasks,
+        custom_providers=custom_providers,
     )
     rendered = _apply_overrides(rendered, OVERRIDES_PATH)
     new_hash = content_hash(rendered)
@@ -1311,7 +1324,7 @@ def _phase_context_link(state: BootstrapState) -> PhaseResult:
     # _fetch_slots is already failure-tolerant (returns [] on transport
     # error). No try/except needed here — it can't raise.
     slots_all = _fetch_slots()
-    chat_slots = _collect_chat_slots(slots_all)
+    chat_slots = _collect_chat_slots(slots_all, contexts=_fetch_model_contexts())
     primary_raw = _resolve_primary_slot()
     primary_for_template: dict[str, Any] | None = None
     primary_alias = "primary"
@@ -1668,6 +1681,33 @@ def _fetch_slots() -> list[dict[str, Any]]:
     return list(data) if isinstance(data, list) else []
 
 
+def _fetch_model_contexts() -> dict[str, int]:
+    """Map gateway model id -> context_length from ``/v1/models``.
+
+    ``/api/slots`` carries no context field, so the slot dict can't supply
+    one. The gateway's ``/v1/models`` is the authoritative source (it
+    resolves ctx_size/context_size + the model-registry ``defaults``), keyed
+    by the slot ALIAS (== the ``/v1/models`` ``id``). Returns ``{}`` when the
+    daemon is unreachable or no chat slot is loaded.
+    """
+    from urllib.error import URLError
+    from urllib.request import Request, urlopen
+
+    req = Request(f"{HAL0_API_URL}/v1/models", headers={"Accept": "application/json"})
+    try:
+        with urlopen(req, timeout=3.0) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except (URLError, OSError, json.JSONDecodeError, TimeoutError):
+        return {}
+    out: dict[str, int] = {}
+    for entry in (data or {}).get("data") or []:
+        mid = entry.get("id")
+        ctx = entry.get("context_length")
+        if mid and isinstance(ctx, int) and ctx > 0:
+            out[str(mid)] = ctx
+    return out
+
+
 def _slot_kind(slot: dict[str, Any]) -> str:
     """Best-effort capability classifier — handles a few schema variants."""
     for key in ("capability", "kind", "type"):
@@ -1710,8 +1750,34 @@ def _is_ready(slot: dict[str, Any]) -> bool:
     return str(state).lower() in {"ready", "running", "loaded", "ok", "online"}
 
 
-def _collect_chat_slots(slots: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _slot_context_length(slot: dict[str, Any]) -> int | None:
+    """Resolve a slot's effective context length (the value /v1/models
+    advertises), or ``None`` when the slot reports none.
+
+    Reads ``context_length`` then ``ctx_size`` — the same precedence
+    :func:`_resolve_primary_slot` uses — so the per-model entry in
+    ``custom_providers`` matches what the gateway serves.
+    """
+    raw = slot.get("context_length") or slot.get("ctx_size")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _collect_chat_slots(
+    slots: list[dict[str, Any]],
+    contexts: dict[str, int] | None = None,
+) -> list[dict[str, Any]]:
     """Filter ``slots`` to chat-capable entries (``type=="llm"``) with a model_id.
+
+    ``contexts`` is an optional ``{alias: context_length}`` map (from
+    :func:`_fetch_model_contexts`); callers pass it so the per-model context
+    comes from the gateway's ``/v1/models`` rather than the context-less
+    ``/api/slots`` state. When omitted (e.g. unit tests) no network call is
+    made and the per-slot fallback (:func:`_slot_context_length`) is used.
 
     The real ``/api/slots`` payload sets ``type=="llm"`` for chat slots and
     ``kind=="local"`` for the deployment shape. The previous ``_slot_kind``
@@ -1733,6 +1799,10 @@ def _collect_chat_slots(slots: list[dict[str, Any]]) -> list[dict[str, Any]]:
     the ``model:`` / ``delegation:`` / ``auxiliary:`` blocks use). This is
     what lets the in-agent model switcher pick a slot up after a restart.
     """
+    # Context lives on the gateway's /v1/models (keyed by alias), NOT on the
+    # /api/slots state dict — callers pass it in; fall back to any context the
+    # slot dict happens to carry.
+    ctx_map = contexts or {}
     out: list[dict[str, Any]] = []
     for s in slots:
         if (s.get("type") or "").lower() != "llm":
@@ -1742,14 +1812,53 @@ def _collect_chat_slots(slots: list[dict[str, Any]]) -> list[dict[str, Any]]:
         model_id = _slot_model_id(s)
         if not model_id:
             continue
+        alias = _slot_alias(s)
         out.append(
             {
-                "alias": _slot_alias(s),
+                "alias": alias,
                 "model_id": model_id,
                 "backend_url": _DEFAULT_PRIMARY_BACKEND_URL,
+                "context_length": ctx_map.get(alias) or _slot_context_length(s),
             }
         )
     return out
+
+
+def _resolve_custom_providers(
+    chat_slots: list[dict[str, Any]],
+    *,
+    hal0_base_url: str,
+) -> list[dict[str, Any]] | None:
+    """Build the ``custom_providers`` block from live chat slots.
+
+    hermes 0.14.0 `agent/model_metadata.py:get_model_context_length`
+    treats the top-level ``model.context_length`` as a GLOBAL override
+    applied to EVERY model — switching to a cloud model (deepseek/
+    openrouter) then wrongly inherits our local value. The supported
+    per-model mechanism is ``custom_providers[].models.<model_id>.
+    context_length``, matched by base_url + model in `hermes_cli/config.py:
+    get_custom_provider_context_length` (used by startup, /model switch and
+    /info) and merged into the picker via `get_compatible_custom_providers`.
+    It does NOT bleed across base_urls/providers.
+
+    Returns a single-element list ``[{name, base_url, models}]`` where the
+    ``models`` KEYS are model_ids (what hermes looks up at runtime), not
+    slot aliases. Degrade-safe: only slots that resolve a context_length
+    contribute an entry; returns ``None`` when none do so the template
+    omits the block entirely.
+    """
+    models: dict[str, dict[str, Any]] = {}
+    for slot in chat_slots:
+        model_id = slot.get("model_id")
+        ctx = slot.get("context_length")
+        if not model_id or not ctx:
+            continue
+        # First writer wins on a model_id collision (declaration order
+        # mirrors _collect_chat_slots / /api/slots ordering).
+        models.setdefault(model_id, {"context_length": int(ctx)})
+    if not models:
+        return None
+    return [{"name": "hal0", "base_url": hal0_base_url, "models": models}]
 
 
 # ── Role→slot resolution (delegation + auxiliary) ───────────────────────────
@@ -1890,7 +1999,7 @@ def _phase_model_automap(state: BootstrapState) -> PhaseResult:
         )
 
     slots = _fetch_slots()
-    chat_slots = _collect_chat_slots(slots)
+    chat_slots = _collect_chat_slots(slots, contexts=_fetch_model_contexts())
     primary_raw = _resolve_primary_slot()
     primary = {
         "model_id": primary_raw["model"],
@@ -1909,6 +2018,7 @@ def _phase_model_automap(state: BootstrapState) -> PhaseResult:
     hal0_v1_base = primary["backend_url"]
     delegation = _resolve_delegation(slots, hal0_base_url=hal0_v1_base)
     auxiliary_tasks = _resolve_auxiliary_tasks(slots, hal0_base_url=hal0_v1_base)
+    custom_providers = _resolve_custom_providers(chat_slots, hal0_base_url=hal0_v1_base)
 
     try:
         rendered = _render_config_yaml(
@@ -1919,6 +2029,7 @@ def _phase_model_automap(state: BootstrapState) -> PhaseResult:
             system_prompt=system_prompt,
             personality_name=personality_name,
             delegation=delegation,
+            custom_providers=custom_providers,
             auxiliary_tasks=auxiliary_tasks,
         )
         rendered = _apply_overrides(rendered, OVERRIDES_PATH)
@@ -2092,11 +2203,13 @@ def _phase_voice_wire(state: BootstrapState) -> PhaseResult:
         # feat/hermes-role-slots: keep role-slot blocks consistent with the
         # other render call sites so re-render stays idempotent.
         hal0_v1_base = primary["backend_url"]
+        chat_slots = _collect_chat_slots(slots, contexts=_fetch_model_contexts())
         delegation = _resolve_delegation(slots, hal0_base_url=hal0_v1_base)
         auxiliary_tasks = _resolve_auxiliary_tasks(slots, hal0_base_url=hal0_v1_base)
+        custom_providers = _resolve_custom_providers(chat_slots, hal0_base_url=hal0_v1_base)
         rendered = _render_config_yaml(
             primary=primary,
-            chat_slots=_collect_chat_slots(slots),
+            chat_slots=chat_slots,
             stt={
                 "provider": "openai",
                 "backend_url": details["stt"]["backend_url"] if details["stt"] else None,
@@ -2117,6 +2230,7 @@ def _phase_voice_wire(state: BootstrapState) -> PhaseResult:
             personality_name=personality_name,
             delegation=delegation,
             auxiliary_tasks=auxiliary_tasks,
+            custom_providers=custom_providers,
         )
         rendered = _apply_overrides(rendered, OVERRIDES_PATH)
     except Exception as exc:

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -634,7 +634,8 @@ def _default_mcp_servers() -> list[dict[str, Any]]:
     return [
         {
             "name": "hal0-admin",
-            "url": "http://127.0.0.1:8080/mcp/admin",
+            "url": "http://127.0.0.1:8080/mcp/admin/mcp",
+            "type": "http",
             "private": False,
             "timeout": 60,
             "usage_hint": (
@@ -644,7 +645,8 @@ def _default_mcp_servers() -> list[dict[str, Any]]:
         },
         {
             "name": "hal0-memory",
-            "url": "http://127.0.0.1:8080/mcp/memory",
+            "url": "http://127.0.0.1:8080/mcp/memory/mcp",
+            "type": "http",
             "private": True,
             "timeout": 30,
             "usage_hint": (
@@ -1299,6 +1301,7 @@ def _phase_context_link(state: BootstrapState) -> PhaseResult:
     for tpl_name, _out_name in (
         ("HERMES.md.j2", "HERMES.md"),
         ("AGENTS.md.j2", "AGENTS.md"),
+        ("MCP-CLIENTS.md.j2", "MCP-CLIENTS.md"),
     ):
         try:
             rendered[_out_name] = _render_template(tpl_name, **vars_)
@@ -1333,6 +1336,15 @@ def _phase_context_link(state: BootstrapState) -> PhaseResult:
             details["rendered"]["AGENTS.md"] = {"path": str(apath), "sha256": h}
         except OSError as exc:
             warnings.append(f"AGENTS.md write to /etc/hal0: {exc}")
+
+    if "MCP-CLIENTS.md" in rendered:
+        try:
+            ETC_HAL0_DIR.mkdir(parents=True, exist_ok=True)
+            mcppath = ETC_HAL0_DIR / "MCP-CLIENTS.md"
+            h = _atomic_write(mcppath, rendered["MCP-CLIENTS.md"])
+            details["rendered"]["MCP-CLIENTS.md"] = {"path": str(mcppath), "sha256": h}
+        except OSError as exc:
+            warnings.append(f"MCP-CLIENTS.md write to /etc/hal0: {exc}")
 
     # Mirror bundled skills last so a failure here doesn't block context files.
     linked, skill_warnings = _mirror_bundled_skills(HAL0_BUNDLED_SKILLS, ETC_HAL0_AGENT_SKILLS)

--- a/src/hal0/agents/hermes_templates/config.yaml.j2
+++ b/src/hal0/agents/hermes_templates/config.yaml.j2
@@ -87,6 +87,7 @@ memory:
 mcp_servers:
 {%- for srv in mcp_servers %}
   {{ srv.name }}:
+    type: {{ srv.type | default("http") | tojson }}
     url: {{ srv.url | tojson }}
     headers:
       X-hal0-Agent: {{ agent_id | tojson }}

--- a/src/hal0/agents/hermes_templates/config.yaml.j2
+++ b/src/hal0/agents/hermes_templates/config.yaml.j2
@@ -36,14 +36,17 @@
    rendered ``base_url`` driving the actual calls. The legacy
    ``Hal0Profile`` plugin was removed in PR-1-bundle (R4 H4) — it
    hardcoded an :8000 base_url that has no listener. #}
+{# NB: `model.context_length` is deliberately NOT emitted. hermes 0.14.0
+   `agent/model_metadata.py:get_model_context_length` treats it as a
+   GLOBAL override applied to EVERY model — so switching to a cloud model
+   (deepseek/openrouter) wrongly inherited our local value. Per-model
+   context now lives in the `custom_providers:` block below, matched by
+   base_url + model_id. #}
 model:
 {%- if primary %}
   default: {{ primary.model_id | tojson }}
   provider: "custom"
   base_url: {{ primary.backend_url | tojson }}
-{%- if primary.context_length %}
-  context_length: {{ primary.context_length }}
-{%- endif %}
 {%- else %}
   # No chat slot was ready at bootstrap time — operator must wire one
   # before the agent can serve completions. Re-run bootstrap with
@@ -70,6 +73,26 @@ model_aliases:
     model: {{ slot.model_id | tojson }}
     provider: "custom"
     base_url: {{ slot.backend_url | tojson }}
+{%- endfor %}
+{%- endif %}
+{%- if custom_providers %}
+
+{# Per-model context_length, keyed by model_id under the hal0 gateway.
+   hermes_cli/config.py:get_custom_provider_context_length matches
+   base_url + model here (trailing-slash-insensitive) at startup, /model
+   switch and /info; get_compatible_custom_providers also merges these
+   into the model picker. Replaces the global model.context_length above:
+   each entry scopes context to its own model_id, so cloud models keep
+   their real context instead of inheriting our local value. #}
+custom_providers:
+{%- for prov in custom_providers %}
+  - name: {{ prov.name | tojson }}
+    base_url: {{ prov.base_url | tojson }}
+    models:
+{%- for model_id, mcfg in prov.models.items() %}
+      {{ model_id | tojson }}:
+        context_length: {{ mcfg.context_length }}
+{%- endfor %}
 {%- endfor %}
 {%- endif %}
 {%- if delegation %}

--- a/src/hal0/agents/hermes_templates/config.yaml.j2
+++ b/src/hal0/agents/hermes_templates/config.yaml.j2
@@ -16,6 +16,13 @@
                         renders the usage_hint into the system prompt.
      system_prompt    — str          (persona-rendered prelude; PR-3 Phase 7)
      personality_name — str          (display name of active persona; PR-3 Phase 8)
+     delegation       — dict or None ({model, base_url, provider}) — subagent
+                        role model from the `agent-hermes` slot. None → block
+                        omitted → subagents inherit the chat model.
+     auxiliary_tasks  — dict          task → {provider, model, base_url}.
+                        Drives the auxiliary: block. utility-slot tasks render
+                        provider:"custom"+base_url; vision/web_extract stay
+                        provider:"main". (feat/hermes-role-slots)
 #}# Managed by hal0 (issue #241). Edits MAY be overwritten by
 # `hal0 agent bootstrap hermes`. Drop a file at
 # /etc/hal0/agents/hermes/overrides.yaml to merge on top.
@@ -64,6 +71,19 @@ model_aliases:
     provider: "custom"
     base_url: {{ slot.backend_url | tojson }}
 {%- endfor %}
+{%- endif %}
+{%- if delegation %}
+
+{# feat/hermes-role-slots: subagents run on a dedicated slot
+   (`agent-hermes`). delegate_tool.py `_resolve_delegation_credentials`
+   reads delegation.{model,provider,base_url}; setting base_url forces
+   provider → "custom" so subagents hit hal0's OpenAI surface. Omitted
+   entirely when the slot isn't live, in which case subagents inherit the
+   parent (chat) model. #}
+delegation:
+  model: {{ delegation.model | tojson }}
+  provider: {{ delegation.provider | default("custom") | tojson }}
+  base_url: {{ delegation.base_url | tojson }}
 {%- endif %}
 
 memory:
@@ -130,10 +150,22 @@ display:
   personality: {{ personality_name | tojson }}
 {%- endif %}
 
+{# feat/hermes-role-slots: per-task side-job routing. Each task is read by
+   auxiliary_client.py `_resolve_task_provider_model` as
+   auxiliary.<task>.{provider,model,base_url}. utility-slot tasks render
+   provider:"custom"+base_url (cheap compaction/search/title model);
+   vision/web_extract stay provider:"main" so they inherit the chat model.
+   A base_url is only emitted when set, so provider:"main" rows stay
+   minimal. #}
 auxiliary:
-  vision: { provider: "main", model: "" }
-  web_extract: { provider: "main", model: "" }
-  session_search: { provider: "main", model: "" }
+{%- for task, cfg in auxiliary_tasks.items() %}
+  {{ task }}:
+    provider: {{ cfg.provider | default("main") | tojson }}
+    model: {{ cfg.model | default("") | tojson }}
+{%- if cfg.base_url %}
+    base_url: {{ cfg.base_url | tojson }}
+{%- endif %}
+{%- endfor %}
 
 {%- if stt %}
 

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -12,7 +12,7 @@ import os
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import structlog
@@ -193,18 +193,289 @@ async def _fetch_hal0_composite_models(
     return models
 
 
+def _slot_model_id(cfg: dict[str, Any]) -> str:
+    """Extract a chat slot's configured model id from a raw config dict.
+
+    Slot TOML conventions vary: real on-disk TOMLs put the model id under
+    nested ``[model] default``; live /api/slots payloads expose it as
+    ``model_default``; test fixtures sometimes pass ``model_id`` directly.
+    Check every shape so callers work regardless of the entry's origin.
+    Mirrors the lookup inlined in :func:`_fetch_hal0_composite_models`.
+    """
+    model_section = cfg.get("model") or {}
+    defaults = cfg.get("defaults") or {}
+    model_id = (
+        cfg.get("model_default")
+        or cfg.get("model_id")
+        or (model_section.get("default") if isinstance(model_section, dict) else None)
+        or defaults.get("model")
+        or ""
+    )
+    return model_id if isinstance(model_id, str) else ""
+
+
+def _coerce_ctx(raw: Any) -> int | None:
+    """Coerce a context-size value to a positive int, or ``None``."""
+    if raw is None:
+        return None
+    try:
+        ctx = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return ctx if ctx > 0 else None
+
+
+def _slot_ctx_size(
+    cfg: dict[str, Any],
+    model_registry: ModelRegistry | None = None,
+    model_id: str = "",
+) -> int | None:
+    """Resolve a slot's context length.
+
+    The on-disk slot TOMLs are inconsistent about the key name:
+    ``agent-hermes.toml`` uses ``[model] ctx_size`` while ``utility.toml``
+    uses ``[model] context_size`` and ``primary.toml`` pins neither. Read
+    BOTH keys (plus a couple of flat shapes seen in live /api/slots
+    payloads), then fall back to the model registry entry's
+    ``defaults.context_size`` so a slot that doesn't pin a ctx still
+    advertises the model's native window. Returns ``None`` only when no
+    source yields a positive value.
+    """
+    model_section = cfg.get("model") or {}
+    defaults = cfg.get("defaults") or {}
+
+    # Probe order: nested [model] ctx_size / context_size, then flat keys,
+    # then a nested defaults table (live payload shape).
+    for source, keys in (
+        (model_section, ("ctx_size", "context_size")),
+        (cfg, ("ctx_size", "context_size")),
+        (defaults, ("ctx_size", "context_size")),
+    ):
+        if not isinstance(source, dict):
+            continue
+        for key in keys:
+            ctx = _coerce_ctx(source.get(key))
+            if ctx is not None:
+                return ctx
+
+    # Registry fallback — the model's declared default context window.
+    if model_registry is not None and model_id:
+        try:
+            entry = model_registry.get(model_id)
+        except Exception:
+            entry = None
+        if entry is not None:
+            entry_defaults = getattr(entry, "defaults", None)
+            ctx = _coerce_ctx(getattr(entry_defaults, "context_size", None))
+            if ctx is not None:
+                return ctx
+    return None
+
+
+async def _loaded_model_ids(slot_manager: SlotManager) -> set[str] | None:
+    """Return the set of model ids lemond currently reports as loaded.
+
+    Probes lemond's ``/v1/health`` once (mirrors
+    ``api.routes.slots._lemonade_state_enrichment``) and collects every
+    ``model_name`` under ``loaded`` / ``all_models_loaded``. Returns
+    ``None`` when the health probe can't be performed at all (no lemonade
+    provider / unexpected error) so callers can decide how to degrade —
+    distinct from an empty set, which means "lemond is up and nothing is
+    loaded".
+    """
+    _ = slot_manager  # signature symmetry with the other slot helpers
+    try:
+        from hal0.lemonade.errors import LemonadeError
+        from hal0.providers import lemonade_provider
+
+        try:
+            health = await lemonade_provider().client().health()
+        except LemonadeError:
+            return None
+    except Exception:  # pragma: no cover — defensive (import/provider wiring)
+        return None
+    if not isinstance(health, dict):
+        return None
+    loaded: set[str] = set()
+    for key in ("loaded", "all_models_loaded"):
+        entries = health.get(key)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, dict):
+                name = entry.get("model_name")
+                if isinstance(name, str) and name:
+                    loaded.add(name)
+    return loaded
+
+
+async def hal0_slot_alias_models(
+    slot_manager: SlotManager,
+    model_registry: ModelRegistry,
+    *,
+    now: int | None = None,
+) -> list[dict[str, Any]]:
+    """Build OpenAI ``model`` objects for every LOADED chat slot, alias-addressed.
+
+    Each enabled chat slot (``type == "llm"``) whose configured model is
+    currently loaded in lemond surfaces as one model object whose ``id``
+    is the slot **alias = slot name** (e.g. ``primary``, ``agent-hermes``,
+    ``utility``). The alias is the stable handle: it does not change when
+    the underlying model is swapped, so callers can pin a co-resident slot
+    without tracking the GGUF filename.
+
+    Fields:
+
+    * ``id`` — slot name (the stable alias).
+    * ``name`` — ``"<slot> · <model display name>"``; the display name is
+      pulled from the model registry when the slot's model id is
+      registered, falling back to the bare model id otherwise.
+    * ``context_length`` — the slot's configured context window (reading
+      either ``ctx_size`` or ``context_size`` from the slot TOML), falling
+      back to the model registry entry's ``defaults.context_size``.
+    * ``owned_by`` — ``"hal0"``.
+
+    Slots that are disabled, lack a configured model, or whose model is
+    not currently loaded in lemond are omitted. If the lemond health probe
+    can't run at all, no alias entries are emitted (we refuse to advertise
+    a slot we can't confirm is serving) — the composite ``hal0`` model
+    list still carries the raw model ids for direct addressing.
+    """
+    created = int(time.time()) if now is None else now
+    try:
+        cfgs = await slot_manager.iter_configs()
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("v1.slot_alias_iter_failed", error=str(exc))
+        return []
+
+    loaded = await _loaded_model_ids(slot_manager)
+    if loaded is None:
+        # Can't confirm what's loaded → emit nothing rather than advertise
+        # slots that may be cold. The composite still lists raw model ids.
+        return []
+
+    out: list[dict[str, Any]] = []
+    for cfg in cfgs:
+        if (cfg.get("type") or "").lower() != "llm":
+            continue
+        if cfg.get("enabled") is False:
+            continue
+        slot_name = str(cfg.get("name") or "").strip()
+        if not slot_name:
+            continue
+        model_id = _slot_model_id(cfg)
+        if not model_id:
+            continue
+        if model_id not in loaded:
+            continue
+
+        display = model_id
+        try:
+            entry = model_registry.get(model_id)
+            registry_name = getattr(entry, "name", "")
+            if isinstance(registry_name, str) and registry_name.strip():
+                display = registry_name.strip()
+        except Exception:
+            # Model not in the registry (pulled via lemond, hand-loaded,
+            # …) — fall back to the bare model id for the display label.
+            display = model_id
+
+        obj: dict[str, Any] = {
+            "id": slot_name,
+            "object": "model",
+            "created": created,
+            "owned_by": "hal0",
+            "name": f"{slot_name} · {display}",
+        }
+        ctx = _slot_ctx_size(cfg, model_registry, model_id)
+        if ctx is not None:
+            obj["context_length"] = ctx
+        out.append(obj)
+    return out
+
+
+async def hal0_chat_slot_alias_map(slot_manager: SlotManager) -> dict[str, str]:
+    """Return ``{slot_alias: model_id}`` for enabled chat slots.
+
+    The slot **alias** is the slot name (``primary`` / ``agent-hermes`` /
+    ``utility``). Used by the ``/v1`` route layer to translate an
+    alias-addressed request into the slot's configured model id before
+    routing, so the request reaches lemond (which serves chat models by
+    name) with the correct distinct model. This is a thin translation map,
+    not a routing target — the chat slots are NOT independently addressable
+    on their TOML ports.
+
+    Best-effort: returns ``{}`` on any failure so the route layer forwards
+    the request untranslated rather than 500ing. Disabled slots and slots
+    with no configured model are skipped.
+    """
+    try:
+        cfgs = await slot_manager.iter_configs()
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("v1.chat_slot_alias_map_iter_failed", error=str(exc))
+        return {}
+    out: dict[str, str] = {}
+    for cfg in cfgs:
+        if (cfg.get("type") or "").lower() != "llm":
+            continue
+        if cfg.get("enabled") is False:
+            continue
+        slot_name = str(cfg.get("name") or "").strip()
+        if not slot_name:
+            continue
+        model_id = _slot_model_id(cfg)
+        if model_id:
+            out.setdefault(slot_name, model_id)
+    return out
+
+
+async def hal0_chat_slot_model_ids(slot_manager: SlotManager) -> set[str]:
+    """Return the configured model ids of every enabled chat slot.
+
+    Used by ``GET /v1/models`` to suppress raw chat model-id rows from the
+    composite ``hal0`` upstream so each chat slot is represented exactly
+    once — by its alias entry (see :func:`hal0_slot_alias_models`). Unlike
+    the alias builder this does NOT filter on loaded state: a chat model
+    that the composite advertises must be deduped regardless of whether
+    it's currently warm, so the catalog never shows both an alias and a
+    bare ``id=<model_id>`` row for the same slot.
+
+    Best-effort: returns an empty set on any failure so the catalog
+    degrades to "no dedup" rather than 500ing.
+    """
+    try:
+        cfgs = await slot_manager.iter_configs()
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("v1.chat_slot_model_ids_iter_failed", error=str(exc))
+        return set()
+    out: set[str] = set()
+    for cfg in cfgs:
+        if (cfg.get("type") or "").lower() != "llm":
+            continue
+        if cfg.get("enabled") is False:
+            continue
+        model_id = _slot_model_id(cfg)
+        if model_id:
+            out.add(model_id)
+    return out
+
+
 async def _autoregister_slot_upstreams(
     registry: UpstreamRegistry,
     slot_manager: SlotManager,
 ) -> None:
     """Register a single composite ``hal0`` upstream.
 
-    Replaces the previous per-slot autoregistration: Lemonade serialises
-    chat loading on a single port (typically 8001), so registering one
-    Upstream per chat slot produced multiple registry entries pointing
-    at the same URL. ``/v1/models`` deduped on id and credited whichever
-    upstream iterated first, leaving the dashboard showing a duplicate
-    provider that looked empty (R4 H2).
+    Lemonade serialises chat loading and serves EVERY chat model by name
+    from one process (``127.0.0.1:13305``) with co-residency
+    (``max_loaded_models``). The chat slots are therefore NOT independently
+    addressable on their TOML ports — registering one ``kind="slot"``
+    upstream per chat slot (pointed at those ports) produces dead targets
+    and collisions (``primary`` + ``agent-hermes`` both pin ``port=8001``).
+    So we register exactly ONE composite ``hal0`` upstream and let the
+    existing lemonade fall-through serve chat models by name; per-slot
+    addressing is handled by an alias → model-id rewrite in the dispatch
+    path (see :meth:`Dispatcher.dispatch`), not by separate upstreams.
 
     The composite upstream:
 
@@ -219,7 +490,8 @@ async def _autoregister_slot_upstreams(
       restarts — see ``/api/slots/{name}/{swap,restart}``.
 
     Skipped if an explicit ``upstreams.toml`` entry already claims the
-    name ``hal0`` so operator overrides win.
+    name ``hal0`` so operator overrides win. Operator-defined real slot
+    upstreams (any other names) are left untouched.
     """
     if registry.get("hal0") is not None:
         log.info("slots.autoregister_skipped", upstream="hal0", reason="already_registered")

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -227,6 +227,57 @@ async def _read_json_body(request: Request) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+async def _rewrite_chat_slot_alias(request: Request, body: dict[str, Any]) -> dict[str, Any]:
+    """Translate a chat-slot ALIAS in ``body["model"]`` to its model id.
+
+    hermes-role-slots: a request may address a co-resident chat slot by
+    its **alias** (slot name: ``primary`` / ``agent-hermes`` / ``utility``)
+    instead of the underlying model id. Lemonade serves chat models by
+    name on lemond, so we rewrite the alias to the slot's configured model
+    id HERE, at the route layer, before either the dispatcher routes it or
+    the lemonade fall-through forwards it. After the rewrite, both
+    ``model==alias`` and ``model==model_id`` carry the correct distinct
+    model name down the existing path and hit the right co-resident model.
+
+    The rewrite is applied to BOTH:
+      * the returned ``body`` dict (handed to ``dispatcher.dispatch``), and
+      * the request's cached body bytes (``request._body``) — so the
+        ``NoRouteFound`` → ``lemonade_proxy._proxy`` fall-through, which
+        re-reads ``request.body()`` verbatim, forwards the rewritten model
+        name rather than the bare alias.
+
+    No-op when: the model isn't a known chat-slot alias, equals its own
+    model id already, the slot manager is absent, or the config read
+    raises (best-effort — never blocks the request).
+    """
+    raw_model = body.get("model")
+    if not isinstance(raw_model, str) or not raw_model:
+        return body
+    slot_manager = getattr(request.app.state, "slot_manager", None)
+    if slot_manager is None:
+        return body
+    from hal0.api import hal0_chat_slot_alias_map
+
+    try:
+        alias_to_model = await hal0_chat_slot_alias_map(slot_manager)
+    except Exception:
+        return body
+    mapped = alias_to_model.get(raw_model)
+    if not mapped or mapped == raw_model:
+        return body
+
+    new_body = {**body, "model": mapped}
+    # Overwrite the cached request body so the lemonade proxy fall-through
+    # (which reads request.body()) forwards the rewritten model name. If we
+    # can't (unexpected request shape), still return the rewritten dict —
+    # the dispatcher path benefits even if the proxy path can't.
+    import contextlib
+
+    with contextlib.suppress(Exception):
+        request._body = json.dumps(new_body).encode("utf-8")  # type: ignore[attr-defined]
+    return new_body
+
+
 async def _dispatch_and_forward(
     request: Request,
     dispatcher: DispatcherDep,
@@ -234,6 +285,10 @@ async def _dispatch_and_forward(
 ) -> Response:
     if body is None:
         body = await _read_json_body(request)
+    # Translate a chat-slot alias (primary/agent-hermes/utility) → model id
+    # before routing so both the dispatcher and the lemonade fall-through
+    # see the real model name.
+    body = await _rewrite_chat_slot_alias(request, body)
     from hal0.dispatcher.router import NoRouteFound
 
     try:
@@ -306,16 +361,65 @@ async def list_models(
     Fetches each upstream's catalog on demand (no caching yet — a TTL
     cache lands when the dispatcher gets one).
 
+    Two classes of entries are emitted:
+
+    * **Per-slot alias entries** (``hermes-role-slots``). Every enabled
+      chat slot (``type == "llm"``) that is currently loaded in lemond
+      surfaces as one model object whose ``id`` is the slot **alias =
+      slot name** (``primary``, ``agent-hermes``, ``utility``), carrying a
+      human ``name`` (``"<slot> · <model display name>"``) and the slot's
+      ``context_length``. Built by :func:`hal0.api.hal0_slot_alias_models`.
+      Unloaded / disabled slots are omitted. The alias is stable across
+      model swaps so callers can pin a co-resident slot.
+    * **Upstream catalog entries** — the raw model ids each
+      ``advertise_models`` upstream reports, so non-chat models (embed /
+      rerank / image / …) keep their direct-addressing entries. The
+      composite ``hal0`` upstream's CHAT model ids are suppressed here so
+      they don't duplicate the alias entries above — a chat slot is
+      represented exactly once, by its alias.
+
     PUBLIC — mounted on ``public_router`` so OpenAI SDKs that probe the
     catalog before sending Authorization headers continue to work after
     ADR-0001 Child B.
     """
+    from hal0.api import hal0_chat_slot_model_ids, hal0_slot_alias_models
+
     upstreams = request.app.state.upstreams
     model_cache: dict[str, list[str]] = getattr(request.app.state, "upstream_models", {}) or {}
     seen: set[str] = set()
     data: list[dict[str, Any]] = []
     now = int(time.time())
+
+    slot_manager = getattr(request.app.state, "slot_manager", None)
+    model_registry = getattr(request.app.state, "model_registry", None)
+
+    # Per-slot alias entries first so a slot alias (e.g. "primary") wins
+    # the id over any same-named raw model id an upstream might advertise.
+    if slot_manager is not None and model_registry is not None:
+        try:
+            alias_entries = await hal0_slot_alias_models(slot_manager, model_registry, now=now)
+        except Exception:
+            alias_entries = []
+        for entry in alias_entries:
+            mid = entry.get("id")
+            if not isinstance(mid, str) or mid in seen:
+                continue
+            seen.add(mid)
+            data.append(entry)
+
+    # Chat-slot model ids are represented by their aliases above; suppress
+    # them from the raw upstream catalog so the composite ``hal0`` upstream
+    # doesn't emit duplicate ``id=<model_id>`` rows for the same chat slots.
+    chat_model_ids: set[str] = set()
+    if slot_manager is not None:
+        try:
+            chat_model_ids = await hal0_chat_slot_model_ids(slot_manager)
+        except Exception:
+            chat_model_ids = set()
+
     for u in upstreams.list():
+        if not getattr(u, "advertise_models", True):
+            continue
         # The composite ``hal0`` upstream's URL is hal0-api itself —
         # going over HTTP here would re-enter this handler and loop. Its
         # model list lives in ``upstream_models["hal0"]``, refreshed by
@@ -330,6 +434,10 @@ async def list_models(
                 advertised = []
         for mid in advertised:
             if mid in seen:
+                continue
+            # A chat slot's raw model id is already covered by its alias
+            # entry — don't list it twice.
+            if mid in chat_model_ids:
                 continue
             seen.add(mid)
             data.append(
@@ -388,6 +496,11 @@ async def chat_completions(request: Request, dispatcher: DispatcherDep) -> Respo
     # client, or the request doesn't match a chat slot we own) we
     # fall back to the standard dispatch path.
     body = await _read_json_body(request)
+    # Translate a chat-slot alias → model id up front so the OmniRouter
+    # caller-slot match (keyed on the model id) and the dispatch path both
+    # see the real model name. Also rewrites the cached request body for
+    # the lemonade fall-through.
+    body = await _rewrite_chat_slot_alias(request, body)
     if body.get("omni") is True:
         looped = await _maybe_run_omni_loop(request, body)
         if looped is not None:

--- a/src/hal0/cli/agent_shim.py
+++ b/src/hal0/cli/agent_shim.py
@@ -93,11 +93,13 @@ class AgentConfig:
     def status_url(self) -> str:
         """URL the shim polls to confirm the agent's HTTP surface is up."""
 
-        # ``/api/health`` is upstream-stable across hermes ≥ 0.10 and is the
-        # cheapest endpoint we can hit to determine "ready". The Hermes
-        # dashboard route doesn't expose ``/healthz`` — verified against
-        # ``~/src/hermes-agent/hermes_cli/web_server.py``.
-        return f"http://{self.host}:{self.port}/api/health"
+        # Use the UNAUTHENTICATED ``/health`` liveness route. The Hermes
+        # dashboard auth-gates every ``/api/*`` endpoint (it exposes API
+        # keys), so ``/api/health`` returns 401 — which the old poll treated
+        # as "not ready", so the Type=notify start never got READY=1 and the
+        # service crash-looped on the 120s start timeout. ``/health`` (and
+        # ``/healthz``) return 200 without auth — verified live (hermes 0.14.0).
+        return f"http://{self.host}:{self.port}/health"
 
 
 def _load_agent_config(agent_id: str) -> AgentConfig:
@@ -181,12 +183,21 @@ def _sd_notify(state: str) -> bool:
 
 
 def _is_ready(cfg: AgentConfig, *, timeout: float = 1.0) -> bool:
-    """Cheap GET of the agent's health URL — True iff 2xx."""
+    """True iff the agent's HTTP surface is up.
+
+    A 2xx from the unauthenticated health route is the happy path. We also
+    treat an auth challenge (401/403) as "up": an HTTP error response proves
+    the socket is open and serving, so the shim should sd_notify READY rather
+    than time out if a future hermes release auth-gates the health route too.
+    """
 
     try:
         with urllib.request.urlopen(cfg.status_url, timeout=timeout) as resp:
             status: int = resp.status
             return 200 <= status < 300
+    except urllib.error.HTTPError as exc:
+        # Server responded (gated/errored) → it IS reachable.
+        return exc.code in (401, 403)
     except (urllib.error.URLError, OSError):
         return False
 

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -433,6 +433,15 @@ class Dispatcher:
 
         # ── Step 2: passthrough on warm caches ───────────────────────────
         for upstream in self._upstreams_in_priority_order():
+            if _is_self_composite(upstream):
+                # The composite ``hal0`` upstream's URL is hal0-api itself,
+                # and its cache lists EVERY chat slot's model id purely for
+                # ``GET /v1/models`` advertisement. Routing a chat request
+                # there would forward back into hal0-api (loop / wrong
+                # co-resident model). Chat models must instead fall through
+                # to the lemonade proxy, which serves them by name on
+                # lemond — so skip the composite in passthrough matching.
+                continue
             if model_id in self._cached_models(upstream.name):
                 call = UpstreamCall(
                     upstream_name=upstream.name,
@@ -458,6 +467,8 @@ class Dispatcher:
         if cold_remotes:
             await self._cold_prefetch(cold_remotes)  # TIER2 + TIER3
             for upstream in self._upstreams_in_priority_order():
+                if _is_self_composite(upstream):
+                    continue
                 if model_id in self._cached_models(upstream.name):
                     call = UpstreamCall(
                         upstream_name=upstream.name,
@@ -986,6 +997,20 @@ def _remap_model(body: dict[str, Any], new_model: str) -> bytes:
     if new_model:
         body = {**body, "model": new_model}
     return json.dumps(body).encode("utf-8")
+
+
+def _is_self_composite(upstream: Upstream) -> bool:
+    """True for the self-referential composite ``hal0`` upstream.
+
+    The composite is a ``kind="slot"`` entry named ``hal0`` with
+    ``slot_name is None`` whose URL points back at hal0-api's own ``/v1``
+    surface. It aggregates every chat slot's model id for
+    ``GET /v1/models`` only — it must NOT be a dispatch target, or a chat
+    request would forward back into hal0-api (loop / wrong co-resident
+    model) instead of falling through to the lemonade proxy that serves
+    chat models by name on lemond. The passthrough steps skip it.
+    """
+    return upstream.kind == "slot" and upstream.slot_name is None and upstream.name == "hal0"
 
 
 def _slot_name_of(upstream: Upstream) -> str:

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -134,6 +134,48 @@ def _redact_log_line(line: str) -> str:
     return _LOG_SECRET_RE.sub(_sub, line)
 
 
+# ── List-shaped REST responses → top-level dict ──────────────────────────────
+#
+# FastMCP derives a structured-output result model from each tool's
+# ``-> dict[str, Any]`` return annotation, and the MCP SDK validates the
+# tool's return value against it. A bare top-level JSON *array* fails
+# that DictModel validation with
+# ``Input should be a valid dictionary [type=dict_type, ...]``.
+#
+# Most admin tools are fine because their REST route already returns an
+# object (``model_list`` → ``/api/models`` → ``{"object": "list",
+# "data": [...]}``). But two read routes return a bare list:
+#
+#   slot_list     → GET /api/slots     → list[dict]
+#   provider_list → GET /api/providers → list[dict]
+#
+# so those two tools raised the DictModel error at the wrapper boundary.
+# We wrap the list in a top-level object here — mirroring model_list's
+# ``{<key>: [...], "count": N}`` style — keeping the per-item dicts the
+# REST layer produced untouched. Maps tool name → the list's container
+# key in the wrapped object.
+_LIST_TOOL_WRAP_KEY: dict[str, str] = {
+    "slot_list": "slots",
+    "provider_list": "providers",
+}
+
+
+def _wrap_list_payload(tool: str, payload: Any) -> Any:
+    """Wrap a bare-list REST response in a top-level dict for ``tool``.
+
+    ``slot_list`` / ``provider_list`` hit REST routes that return a bare
+    JSON array; the MCP result model requires a top-level object. We wrap
+    the list as ``{<key>: [...], "count": len(list)}`` mirroring
+    ``model_list``'s shape. Non-list payloads (e.g. the ``_call_rest``
+    error envelope, which is already a dict) round-trip unchanged so we
+    never mask a transport error.
+    """
+    key = _LIST_TOOL_WRAP_KEY.get(tool)
+    if key is None or not isinstance(payload, list):
+        return payload
+    return {key: payload, "count": len(payload)}
+
+
 def _redact_logs_payload(payload: Any) -> Any:
     """Walk the GET /api/logs response and redact every line in ``lines``.
 
@@ -530,6 +572,10 @@ async def _execute_tool(
     # review MED-1).
     if tool == "logs_tail":
         result = _redact_logs_payload(result)
+    # Wrap bare-list REST responses (slot_list / provider_list) into a
+    # top-level dict so the FastMCP result model validates. No-op for
+    # every other tool and for the already-dict error envelope.
+    result = _wrap_list_payload(tool, result)
     return result
 
 

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -498,6 +498,167 @@ def test_render_config_yaml_chat_slots_become_aliases() -> None:
     assert '"qwen-coder"' in rendered
 
 
+# ── feat/hermes-role-slots: delegation + auxiliary role→slot wiring ──────────
+
+_ROLE_SLOTS = [
+    {
+        "name": "primary",
+        "type": "llm",
+        "state": "ready",
+        "model_id": "qwen3-coder-next-reap-40b-a3b-q4kxl",
+        "backend_url": "http://127.0.0.1:8001/v1",
+        "context_length": 32768,
+    },
+    {
+        "name": "agent-hermes",
+        "type": "llm",
+        "state": "ready",
+        "model_id": "hermes-4-14b-q5km",
+        "backend_url": "http://127.0.0.1:8001/v1",
+    },
+    {
+        "name": "utility",
+        "type": "llm",
+        "state": "ready",
+        "model_id": "qwen3-zero-coder-v2-0.8b-f16",
+        "backend_url": "http://127.0.0.1:8001/v1",
+    },
+]
+_HAL0_V1 = "http://127.0.0.1:8080/v1"
+
+
+def test_resolve_delegation_picks_agent_hermes_slot() -> None:
+    deleg = hp._resolve_delegation(_ROLE_SLOTS, hal0_base_url=_HAL0_V1)
+    assert deleg == {
+        "model": "hermes-4-14b-q5km",
+        "provider": "custom",
+        "base_url": _HAL0_V1,
+    }
+
+
+def test_resolve_delegation_none_when_slot_absent() -> None:
+    # Only primary present → no subagent slot → degrade to inherit-chat.
+    assert hp._resolve_delegation(_ROLE_SLOTS[:1], hal0_base_url=_HAL0_V1) is None
+
+
+def test_resolve_delegation_none_when_slot_not_ready() -> None:
+    slots = [
+        *_ROLE_SLOTS[:1],
+        {"name": "agent-hermes", "type": "llm", "state": "idle", "model_id": "x"},
+    ]
+    assert hp._resolve_delegation(slots, hal0_base_url=_HAL0_V1) is None
+
+
+def test_resolve_auxiliary_tasks_routes_utility_group_to_utility_slot() -> None:
+    aux = hp._resolve_auxiliary_tasks(_ROLE_SLOTS, hal0_base_url=_HAL0_V1)
+    # Utility group → custom provider on the utility slot's model.
+    for task in ("compression", "session_search", "title_generation", "skills_hub", "mcp"):
+        assert aux[task] == {
+            "provider": "custom",
+            "model": "qwen3-zero-coder-v2-0.8b-f16",
+            "base_url": _HAL0_V1,
+        }
+    # vision/web_extract always stay on the main chat provider.
+    for task in ("vision", "web_extract"):
+        assert aux[task] == {"provider": "main", "model": "", "base_url": ""}
+
+
+def test_resolve_auxiliary_tasks_degrades_to_main_without_utility_slot() -> None:
+    aux = hp._resolve_auxiliary_tasks(_ROLE_SLOTS[:1], hal0_base_url=_HAL0_V1)
+    for task in ("compression", "session_search", "title_generation"):
+        assert aux[task]["provider"] == "main"
+        assert aux[task]["model"] == ""
+
+
+def test_render_config_yaml_emits_delegation_and_auxiliary_blocks() -> None:
+    yaml = pytest.importorskip("yaml")
+    deleg = hp._resolve_delegation(_ROLE_SLOTS, hal0_base_url=_HAL0_V1)
+    aux = hp._resolve_auxiliary_tasks(_ROLE_SLOTS, hal0_base_url=_HAL0_V1)
+    rendered = hp._render_config_yaml(
+        primary={
+            "model_id": "qwen3-coder-next-reap-40b-a3b-q4kxl",
+            "backend_url": _HAL0_V1,
+            "context_length": 32768,
+        },
+        chat_slots=hp._collect_chat_slots(_ROLE_SLOTS),
+        agent_id="hermes-agent",
+        delegation=deleg,
+        auxiliary_tasks=aux,
+    )
+    cfg = yaml.safe_load(rendered)
+    # delegation block → agent-hermes model at the hal0 /v1 endpoint.
+    assert cfg["delegation"] == {
+        "model": "hermes-4-14b-q5km",
+        "provider": "custom",
+        "base_url": _HAL0_V1,
+    }
+    # auxiliary compaction/search/title → utility model at hal0 /v1.
+    assert cfg["auxiliary"]["compression"] == {
+        "provider": "custom",
+        "model": "qwen3-zero-coder-v2-0.8b-f16",
+        "base_url": _HAL0_V1,
+    }
+    assert cfg["auxiliary"]["session_search"]["model"] == "qwen3-zero-coder-v2-0.8b-f16"
+    assert cfg["auxiliary"]["title_generation"]["base_url"] == _HAL0_V1
+    assert cfg["auxiliary"]["vision"]["provider"] == "main"
+
+
+def test_render_config_yaml_omits_delegation_when_slot_missing() -> None:
+    yaml = pytest.importorskip("yaml")
+    aux = hp._resolve_auxiliary_tasks(_ROLE_SLOTS[:1], hal0_base_url=_HAL0_V1)
+    rendered = hp._render_config_yaml(
+        primary={"model_id": "p", "backend_url": _HAL0_V1, "context_length": 8000},
+        delegation=None,
+        auxiliary_tasks=aux,
+        agent_id="hermes-agent",
+    )
+    assert "delegation:" not in rendered
+    cfg = yaml.safe_load(rendered)
+    # No utility slot → aux compaction group falls back to provider:"main".
+    assert cfg["auxiliary"]["compression"]["provider"] == "main"
+
+
+def test_render_config_yaml_default_auxiliary_is_all_main() -> None:
+    # Callers that don't pass auxiliary_tasks keep the pre-role-slots shape:
+    # every task on provider:"main", no delegation block.
+    yaml = pytest.importorskip("yaml")
+    rendered = hp._render_config_yaml(primary=None, agent_id="hermes-agent")
+    cfg = yaml.safe_load(rendered)
+    assert "delegation" not in cfg
+    assert {"vision", "web_extract", "compression", "session_search"} <= set(cfg["auxiliary"])
+    for task_cfg in cfg["auxiliary"].values():
+        assert task_cfg["provider"] == "main"
+
+
+def test_config_write_renders_role_slots_from_live_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    yaml = pytest.importorskip("yaml")
+    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
+    monkeypatch.setattr(
+        hp,
+        "_resolve_primary_slot",
+        lambda **_k: {
+            "model": "qwen3-coder-next-reap-40b-a3b-q4kxl",
+            "base_url": _HAL0_V1,
+            "context_length": 32768,
+        },
+    )
+    monkeypatch.setattr(hp, "_fetch_slots", lambda: list(_ROLE_SLOTS))
+    monkeypatch.setattr(hp, "OVERRIDES_PATH", tmp_path / "no-overrides.yaml")
+    from hal0.agents import personas as _personas
+
+    monkeypatch.setattr(_personas, "PERSONAS_ROOT", tmp_path / "personas-empty")
+    out = hp._phase_config_write(state)
+    assert out.status == hp.PhaseStatus.OK
+    assert out.details["delegation_model"] == "hermes-4-14b-q5km"
+    assert out.details["auxiliary_utility_model"] == "qwen3-zero-coder-v2-0.8b-f16"
+    cfg = yaml.safe_load(Path(out.details["config_path"]).read_text())
+    assert cfg["delegation"]["model"] == "hermes-4-14b-q5km"
+    assert cfg["delegation"]["base_url"] == _HAL0_V1
+    assert cfg["auxiliary"]["compression"]["model"] == "qwen3-zero-coder-v2-0.8b-f16"
+
+
 def test_config_write_phase_writes_yaml_idempotently(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -28,6 +28,17 @@ import pytest
 from hal0.agents import hermes_provision as hp
 
 
+@pytest.fixture(autouse=True)
+def _offline_model_contexts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never hit the live daemon's /v1/models during unit tests.
+
+    ``_collect_chat_slots`` callers pass the result of ``_fetch_model_contexts``;
+    left un-stubbed each phase test would block on a real urlopen. Stub to empty
+    so per-model context falls back to each fixture slot's own context_length.
+    """
+    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {})
+
+
 @pytest.fixture
 def state_with_tmp_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.BootstrapState:
     """Seed a :class:`BootstrapState` rooted in ``tmp_path`` with externals stubbed.
@@ -57,6 +68,9 @@ def state_with_tmp_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.
     # _fetch_slots; without a stub each call would block 3s on a real
     # urlopen timeout. Keep the integration tests offline-fast.
     monkeypatch.setattr(hp, "_fetch_slots", lambda: [])
+    # Same for the /v1/models context fetch — stub to empty so per-model
+    # context falls back to each slot's own context_length (set on fixtures).
+    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {})
     monkeypatch.setattr(
         hp,
         "_probe_mcp_server",
@@ -473,6 +487,10 @@ def test_render_config_yaml_includes_primary_block() -> None:
     assert 'X-hal0-Agent: "hermes-agent"' in rendered
     # ADR-0014: graph extraction defaults OFF.
     assert "enabled: false" in rendered
+    # model.context_length must NOT be emitted — hermes treats it as a
+    # GLOBAL override that bleeds onto cloud models. Per-model context
+    # lives in custom_providers instead.
+    assert "context_length" not in rendered.split("providers:")[0]
 
 
 def test_render_config_yaml_no_primary_emits_safe_placeholder() -> None:
@@ -498,6 +516,125 @@ def test_render_config_yaml_chat_slots_become_aliases() -> None:
     assert '"qwen-coder"' in rendered
 
 
+# ── feat/hermes-role-slots: per-model context via custom_providers ───────────
+
+
+def test_collect_chat_slots_carries_context_length() -> None:
+    slots = [
+        {
+            "name": "primary",
+            "type": "llm",
+            "state": "ready",
+            "model_id": "m1",
+            "backend_url": "http://127.0.0.1:8001/v1",
+            "context_length": 65536,
+        },
+        # ctx_size is the alternate key — must still resolve.
+        {
+            "name": "utility",
+            "type": "llm",
+            "state": "ready",
+            "model_id": "m2",
+            "backend_url": "http://127.0.0.1:8002/v1",
+            "ctx_size": 8192,
+        },
+        # No context at all → None (degrade-safe).
+        {
+            "name": "agent-hermes",
+            "type": "llm",
+            "state": "ready",
+            "model_id": "m3",
+            "backend_url": "http://127.0.0.1:8003/v1",
+        },
+    ]
+    collected = hp._collect_chat_slots(slots)
+    by_model = {s["model_id"]: s["context_length"] for s in collected}
+    assert by_model == {"m1": 65536, "m2": 8192, "m3": None}
+
+
+def test_resolve_custom_providers_keys_by_model_id() -> None:
+    chat_slots = [
+        {"alias": "primary", "model_id": "qwen3-coder", "context_length": 65536},
+        {"alias": "agent-hermes", "model_id": "hermes-4-14b", "context_length": 65536},
+        {"alias": "utility", "model_id": "qwen3-zero", "context_length": 32768},
+    ]
+    cp = hp._resolve_custom_providers(chat_slots, hal0_base_url="http://127.0.0.1:8080/v1")
+    assert cp == [
+        {
+            "name": "hal0",
+            "base_url": "http://127.0.0.1:8080/v1",
+            "models": {
+                "qwen3-coder": {"context_length": 65536},
+                "hermes-4-14b": {"context_length": 65536},
+                "qwen3-zero": {"context_length": 32768},
+            },
+        }
+    ]
+
+
+def test_resolve_custom_providers_omits_slots_without_context() -> None:
+    chat_slots = [
+        {"alias": "primary", "model_id": "m1", "context_length": 40000},
+        {"alias": "utility", "model_id": "m2", "context_length": None},
+    ]
+    cp = hp._resolve_custom_providers(chat_slots, hal0_base_url="http://127.0.0.1:8080/v1")
+    assert list(cp[0]["models"]) == ["m1"]
+
+
+def test_resolve_custom_providers_none_when_nothing_resolves() -> None:
+    assert hp._resolve_custom_providers([], hal0_base_url="http://127.0.0.1:8080/v1") is None
+    chat_slots = [{"alias": "primary", "model_id": "m1", "context_length": None}]
+    assert hp._resolve_custom_providers(chat_slots, hal0_base_url="http://x/v1") is None
+
+
+def test_render_config_yaml_emits_custom_providers_block() -> None:
+    yaml = pytest.importorskip("yaml")
+    chat_slots = [
+        {
+            "alias": "primary",
+            "model_id": "qwen3-coder-next-reap-40b-a3b-q4kxl",
+            "backend_url": "http://127.0.0.1:8080/v1",
+            "context_length": 65536,
+        },
+        {
+            "alias": "agent-hermes",
+            "model_id": "hermes-4-14b-q5km",
+            "backend_url": "http://127.0.0.1:8080/v1",
+            "context_length": 65536,
+        },
+    ]
+    cp = hp._resolve_custom_providers(chat_slots, hal0_base_url="http://127.0.0.1:8080/v1")
+    rendered = hp._render_config_yaml(
+        primary={
+            "model_id": "qwen3-coder-next-reap-40b-a3b-q4kxl",
+            "backend_url": "http://127.0.0.1:8080/v1",
+            "context_length": 65536,
+        },
+        chat_slots=chat_slots,
+        agent_id="hermes-agent",
+        custom_providers=cp,
+    )
+    cfg = yaml.safe_load(rendered)
+    # No global model.context_length override.
+    assert "context_length" not in cfg["model"]
+    # Per-model context, keyed by MODEL ID (not alias), under the gateway.
+    assert cfg["custom_providers"] == [
+        {
+            "name": "hal0",
+            "base_url": "http://127.0.0.1:8080/v1",
+            "models": {
+                "qwen3-coder-next-reap-40b-a3b-q4kxl": {"context_length": 65536},
+                "hermes-4-14b-q5km": {"context_length": 65536},
+            },
+        }
+    ]
+
+
+def test_render_config_yaml_omits_custom_providers_when_none() -> None:
+    rendered = hp._render_config_yaml(primary=None, agent_id="hermes-agent")
+    assert "custom_providers:" not in rendered
+
+
 # ── feat/hermes-role-slots: delegation + auxiliary role→slot wiring ──────────
 
 _ROLE_SLOTS = [
@@ -515,6 +652,7 @@ _ROLE_SLOTS = [
         "state": "ready",
         "model_id": "hermes-4-14b-q5km",
         "backend_url": "http://127.0.0.1:8001/v1",
+        "context_length": 65536,
     },
     {
         "name": "utility",
@@ -522,6 +660,7 @@ _ROLE_SLOTS = [
         "state": "ready",
         "model_id": "qwen3-zero-coder-v2-0.8b-f16",
         "backend_url": "http://127.0.0.1:8001/v1",
+        "context_length": 16384,
     },
 ]
 _HAL0_V1 = "http://127.0.0.1:8080/v1"
@@ -657,6 +796,20 @@ def test_config_write_renders_role_slots_from_live_state(
     assert cfg["delegation"]["model"] == "hermes-4-14b-q5km"
     assert cfg["delegation"]["base_url"] == _HAL0_V1
     assert cfg["auxiliary"]["compression"]["model"] == "qwen3-zero-coder-v2-0.8b-f16"
+    # No global model.context_length override; per-model context comes via
+    # custom_providers keyed by model_id under the gateway.
+    assert "context_length" not in cfg["model"]
+    assert cfg["custom_providers"] == [
+        {
+            "name": "hal0",
+            "base_url": _HAL0_V1,
+            "models": {
+                "qwen3-coder-next-reap-40b-a3b-q4kxl": {"context_length": 32768},
+                "hermes-4-14b-q5km": {"context_length": 65536},
+                "qwen3-zero-coder-v2-0.8b-f16": {"context_length": 16384},
+            },
+        }
+    ]
 
 
 def test_config_write_phase_writes_yaml_idempotently(

--- a/tests/agents/test_hermes_provision_collect.py
+++ b/tests/agents/test_hermes_provision_collect.py
@@ -54,6 +54,27 @@ def test_collect_chat_slots_against_real_lxc_payload(
         assert entry["backend_url"], f"{fixture}: empty backend_url in {entry}"
 
 
+def test_collect_chat_slots_aliases_use_stable_gateway_base_url() -> None:
+    """Alias base_url must be the STABLE hal0 gateway, NOT the slot's raw
+    per-slot upstream port.
+
+    lemond reassigns the slot's backend_url port (:8001/:8002/…) on every
+    model reload, so a baked-in alias port goes stale and could point at a
+    port now serving a different co-resident model. The gateway resolves
+    the model_id to the right slot, so model_id + :8080/v1 is stable.
+    """
+    slots = _load("slots_all_ready.json")
+    collected = hp._collect_chat_slots(slots)
+    assert collected, "fixture should yield at least one chat slot"
+    for entry in collected:
+        assert entry["backend_url"] == hp._DEFAULT_PRIMARY_BACKEND_URL
+        assert entry["backend_url"] == "http://127.0.0.1:8080/v1"
+        # Never a raw per-slot upstream port.
+        assert ":8001" not in entry["backend_url"]
+        assert ":8002" not in entry["backend_url"]
+        assert ":8003" not in entry["backend_url"]
+
+
 def test_collect_chat_slots_skips_non_llm_capabilities() -> None:
     """Embed/rerank/stt/tts slots must never appear in chat aliases even
     when ready. Real /api/slots flips ``state=ready`` for every loaded

--- a/tests/agents/test_hermes_provision_idempotency.py
+++ b/tests/agents/test_hermes_provision_idempotency.py
@@ -23,6 +23,12 @@ from hal0.agents import hermes_provision as hp
 from hal0.agents import personas as P
 
 
+@pytest.fixture(autouse=True)
+def _offline_model_contexts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never hit the live daemon's /v1/models during unit tests."""
+    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {})
+
+
 @pytest.fixture
 def hermetic_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.BootstrapState:
     """A BootstrapState rooted entirely in ``tmp_path`` with externals stubbed."""
@@ -95,6 +101,9 @@ def hermetic_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.Bootst
         ]
 
     monkeypatch.setattr(hp, "_fetch_slots", _fake_slots)
+    # /v1/models context fetch → empty so per-model context falls back to each
+    # slot's own context_length (set on the fixture), keeping renders offline.
+    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {})
 
     # MCP probes succeed deterministically with a fixed tool list so the
     # provision.json `mcp_wire.details` hash matches across runs.
@@ -312,6 +321,22 @@ def test_config_yaml_contains_role_slot_blocks(
         assert cfg["auxiliary"][task]["base_url"] == "http://127.0.0.1:8080/v1"
     # vision/web_extract still inherit the chat model.
     assert cfg["auxiliary"]["vision"]["provider"] == "main"
+    # Per-model context_length via custom_providers (keyed by model_id),
+    # NOT a global model.context_length override (the deepseek-bleed bug).
+    assert "context_length" not in cfg["model"]
+    assert cfg["custom_providers"] == [
+        {
+            "name": "hal0",
+            "base_url": "http://127.0.0.1:8080/v1",
+            "models": {
+                "qwen3-test": {"context_length": 32768},
+                "qwen3-coder-test": {"context_length": 16384},
+                "qwen3-utility-test": {"context_length": 8192},
+            },
+        }
+    ]
+    # The embed slot must not leak into custom_providers either.
+    assert "bge-test" not in cfg["custom_providers"][0]["models"]
 
 
 def test_persona_seed_appears_in_phase_order_before_config_write(tmp_path: Path) -> None:

--- a/tests/agents/test_hermes_provision_idempotency.py
+++ b/tests/agents/test_hermes_provision_idempotency.py
@@ -72,6 +72,16 @@ def hermetic_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.Bootst
                 "backend_url": "http://127.0.0.1:8001/v1",
                 "context_length": 16384,
             },
+            {
+                "name": "utility",
+                "type": "llm",
+                "kind": "local",
+                "state": "ready",
+                "status": "ready",
+                "model_id": "qwen3-utility-test",
+                "backend_url": "http://127.0.0.1:8001/v1",
+                "context_length": 8192,
+            },
             # An embed slot that must NEVER appear in chat aliases.
             {
                 "name": "embed",
@@ -246,6 +256,7 @@ def test_config_yaml_contains_chat_slot_aliases(
 ) -> None:
     """Phase 5 contract: chat_slots appear in the first render
     (pre-PR-3 they only appeared after Phase 9)."""
+    yaml = pytest.importorskip("yaml")
     state_root = tmp_path / "state"
     hp.run(state_root=state_root, initial_state=hermetic_state)
     config = (Path(hermetic_state.hermes_home) / "config.yaml").read_text(encoding="utf-8")
@@ -255,6 +266,14 @@ def test_config_yaml_contains_chat_slot_aliases(
     assert "embed:" not in config.split("model_aliases:")[1].split("\n\n")[0], (
         "embed slot leaked into chat aliases"
     )
+    # Every alias routes through the STABLE gateway, NOT the slot's raw
+    # per-slot upstream port (:8001 in the fixture) — lemond reassigns
+    # those on reload, so baked-in ports go stale.
+    cfg = yaml.safe_load(config)
+    for alias, entry in cfg["model_aliases"].items():
+        assert entry["base_url"] == "http://127.0.0.1:8080/v1", (
+            f"alias {alias} base_url should be the gateway, got {entry['base_url']}"
+        )
 
 
 def test_config_yaml_contains_mcp_servers(
@@ -269,6 +288,30 @@ def test_config_yaml_contains_mcp_servers(
     assert "hal0-admin:" in config
     assert "hal0-memory:" in config
     assert '"hermes-agent"' in config  # X-hal0-Agent value
+
+
+def test_config_yaml_contains_role_slot_blocks(
+    tmp_path: Path, hermetic_state: hp.BootstrapState
+) -> None:
+    """feat/hermes-role-slots: an end-to-end bootstrap renders the
+    delegation block from the ``agent-hermes`` slot and routes the
+    auxiliary compaction group to the ``utility`` slot."""
+    yaml = pytest.importorskip("yaml")
+    state_root = tmp_path / "state"
+    hp.run(state_root=state_root, initial_state=hermetic_state)
+    config_text = (Path(hermetic_state.hermes_home) / "config.yaml").read_text(encoding="utf-8")
+    cfg = yaml.safe_load(config_text)
+    # delegation → agent-hermes slot model at the hal0 /v1 endpoint.
+    assert cfg["delegation"]["model"] == "qwen3-coder-test"
+    assert cfg["delegation"]["provider"] == "custom"
+    assert cfg["delegation"]["base_url"] == "http://127.0.0.1:8080/v1"
+    # auxiliary compaction/search/title → utility slot model.
+    for task in ("compression", "session_search", "title_generation"):
+        assert cfg["auxiliary"][task]["model"] == "qwen3-utility-test"
+        assert cfg["auxiliary"][task]["provider"] == "custom"
+        assert cfg["auxiliary"][task]["base_url"] == "http://127.0.0.1:8080/v1"
+    # vision/web_extract still inherit the chat model.
+    assert cfg["auxiliary"]["vision"]["provider"] == "main"
 
 
 def test_persona_seed_appears_in_phase_order_before_config_write(tmp_path: Path) -> None:

--- a/tests/api/test_upstream_dedup.py
+++ b/tests/api/test_upstream_dedup.py
@@ -79,8 +79,15 @@ def _reset_module_cache() -> None:
 @pytest.mark.asyncio
 async def test_autoregister_creates_single_hal0_upstream() -> None:
     """Exactly one upstream named ``hal0`` lands in the registry — no
-    duplicate ``primary`` / ``agent-hermes`` entries pointing at the
-    same Lemonade port."""
+    per-chat-slot upstreams pointed at the (shared / dead) TOML ports.
+
+    hermes-role-slots: Lemonade-managed chat slots are NOT independently
+    addressable on their TOML ports (``primary`` + ``agent-hermes`` both
+    pin ``port=8001``; ``utility`` pins a dead ``:8081``). They are served
+    by name on lemond, so we register only the composite ``hal0`` upstream
+    and translate slot aliases → model ids in the dispatch path. No
+    per-slot routing upstreams are auto-registered.
+    """
     registry = UpstreamRegistry()
     slot_mgr = _FakeSlotManager(_two_chat_slots())
 
@@ -99,6 +106,7 @@ async def test_autoregister_creates_single_hal0_upstream() -> None:
     assert hal0.url == "http://127.0.0.1:8080/v1"
     assert hal0.kind == "slot"
     assert hal0.slot_name is None  # composite — not a single slot
+    assert hal0.advertise_models is True
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_v1_chat_slot_alias.py
+++ b/tests/api/test_v1_chat_slot_alias.py
@@ -1,0 +1,254 @@
+"""Chat-slot alias → model-id translation (hermes-role-slots).
+
+Co-resident chat slots (``primary`` / ``agent-hermes`` / ``utility``) are
+addressable by their ALIAS (= slot name). Lemonade serves chat models by
+name on lemond, so the ``/v1`` route layer rewrites a chat-slot alias to
+that slot's configured model id BEFORE routing, then the request flows
+down the normal path (for these models, the lemonade fall-through). This
+is a thin translation — NOT per-slot upstream routing.
+
+These tests cover the translation map builders + the route-layer rewrite
+(including the cached-body overwrite that the lemonade proxy fall-through
+re-reads), without depending on a live backend.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+import hal0.api as hal0_api
+from hal0.api import hal0_chat_slot_alias_map, hal0_chat_slot_model_ids
+
+
+class _FakeSlotManager:
+    def __init__(self, configs: list[dict[str, Any]]):
+        self._configs = configs
+
+    async def iter_configs(self) -> list[dict[str, Any]]:
+        return list(self._configs)
+
+
+def _three_chat_slots() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "primary",
+            "type": "llm",
+            "enabled": True,
+            "port": 8001,
+            "model": {"default": "qwen3-coder-next-reap-40b-a3b-q4kxl"},
+        },
+        {
+            "name": "agent-hermes",
+            "type": "llm",
+            "enabled": True,
+            "port": 8001,
+            "model": {"default": "hermes-4-14b-q5km", "ctx_size": 65536},
+        },
+        {
+            "name": "utility",
+            "type": "llm",
+            "enabled": True,
+            "port": 8081,
+            "model": {"default": "qwen3-zero-coder-v2-0.8b-f16", "context_size": 32768},
+        },
+        # Non-chat slot — never an alias.
+        {
+            "name": "embed",
+            "type": "embedding",
+            "enabled": True,
+            "port": 0,
+            "model": {"default": "Qwen3-Embedding-0.6B-GGUF"},
+        },
+        # Disabled chat slot — excluded.
+        {
+            "name": "spare",
+            "type": "llm",
+            "enabled": False,
+            "port": 8082,
+            "model": {"default": "some-spare-model"},
+        },
+    ]
+
+
+# ── alias map + model-id set ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_alias_map_covers_enabled_chat_slots_only() -> None:
+    alias = await hal0_chat_slot_alias_map(_FakeSlotManager(_three_chat_slots()))
+    assert alias == {
+        "primary": "qwen3-coder-next-reap-40b-a3b-q4kxl",
+        "agent-hermes": "hermes-4-14b-q5km",
+        "utility": "qwen3-zero-coder-v2-0.8b-f16",
+    }
+    # No embed (non-chat) and no spare (disabled).
+    assert "embed" not in alias
+    assert "spare" not in alias
+
+
+@pytest.mark.asyncio
+async def test_chat_slot_model_ids_for_dedup() -> None:
+    ids = await hal0_chat_slot_model_ids(_FakeSlotManager(_three_chat_slots()))
+    assert ids == {
+        "qwen3-coder-next-reap-40b-a3b-q4kxl",
+        "hermes-4-14b-q5km",
+        "qwen3-zero-coder-v2-0.8b-f16",
+    }
+    assert "Qwen3-Embedding-0.6B-GGUF" not in ids
+
+
+# ── route-layer rewrite ─────────────────────────────────────────────────────
+
+
+class _FakeApp:
+    def __init__(self, slot_manager: Any):
+        self.state = type("S", (), {"slot_manager": slot_manager})()
+
+
+class _FakeRequest:
+    """Minimal stand-in exposing the surface ``_rewrite_chat_slot_alias``
+    touches: ``app.state.slot_manager`` and a settable ``_body``."""
+
+    def __init__(self, slot_manager: Any):
+        self.app = _FakeApp(slot_manager)
+        self._body = b""
+
+
+@pytest.mark.asyncio
+async def test_rewrite_translates_alias_to_model_id_and_body() -> None:
+    from hal0.api.routes.v1 import _rewrite_chat_slot_alias
+
+    req = _FakeRequest(_FakeSlotManager(_three_chat_slots()))
+    body = await _rewrite_chat_slot_alias(req, {"model": "primary", "messages": []})
+
+    # Returned dict carries the model id, not the alias.
+    assert body["model"] == "qwen3-coder-next-reap-40b-a3b-q4kxl"
+    # Cached request body (read verbatim by the lemonade proxy fall-through)
+    # is overwritten with the rewritten model name.
+    assert json.loads(req._body)["model"] == "qwen3-coder-next-reap-40b-a3b-q4kxl"
+
+
+@pytest.mark.asyncio
+async def test_rewrite_each_alias_maps_to_its_distinct_model() -> None:
+    from hal0.api.routes.v1 import _rewrite_chat_slot_alias
+
+    sm = _FakeSlotManager(_three_chat_slots())
+    for alias, expected in (
+        ("primary", "qwen3-coder-next-reap-40b-a3b-q4kxl"),
+        ("agent-hermes", "hermes-4-14b-q5km"),
+        ("utility", "qwen3-zero-coder-v2-0.8b-f16"),
+    ):
+        req = _FakeRequest(sm)
+        body = await _rewrite_chat_slot_alias(req, {"model": alias, "messages": []})
+        assert body["model"] == expected
+
+
+@pytest.mark.asyncio
+async def test_rewrite_is_noop_for_bare_model_id() -> None:
+    """A request already keyed on a model id (not an alias) is untouched —
+    it flows straight through to the lemonade fall-through by name."""
+    from hal0.api.routes.v1 import _rewrite_chat_slot_alias
+
+    req = _FakeRequest(_FakeSlotManager(_three_chat_slots()))
+    body = await _rewrite_chat_slot_alias(req, {"model": "hermes-4-14b-q5km", "messages": []})
+    assert body["model"] == "hermes-4-14b-q5km"
+    assert req._body == b""  # not rewritten
+
+
+@pytest.mark.asyncio
+async def test_rewrite_is_noop_without_slot_manager() -> None:
+    from hal0.api.routes.v1 import _rewrite_chat_slot_alias
+
+    req = _FakeRequest(None)
+    body = await _rewrite_chat_slot_alias(req, {"model": "primary", "messages": []})
+    assert body["model"] == "primary"
+
+
+# ── dispatcher / proxy non-regression ───────────────────────────────────────
+
+
+def test_resolve_slot_primary_still_falls_through_to_lemonade() -> None:
+    """``resolve_slot`` keeps the ``m != "primary"`` carve-out: a chat
+    request that reaches the legacy fallback selects ``primary`` and
+    (absent a real primary slot upstream) raises the typed legacy error,
+    which the dispatcher converts to NoRouteFound → lemonade fall-through.
+    No per-slot chat upstream is matched."""
+    from hal0.dispatcher.proxy import LegacyResolutionFailed, resolve_slot
+    from hal0.upstreams.registry import Upstream, UpstreamRegistry
+
+    reg = UpstreamRegistry()
+    # Only the composite hal0 upstream exists (no per-slot chat upstreams).
+    reg.upsert(
+        Upstream(
+            name="hal0",
+            kind="slot",
+            url="http://127.0.0.1:8080/v1",
+            slot_name=None,
+            auth_style="none",
+        )
+    )
+    with pytest.raises(LegacyResolutionFailed):
+        # model id form — not an alias, not a registered slot name → falls
+        # to the "primary" default which has no slot upstream → legacy error.
+        resolve_slot(
+            "/v1/chat/completions",
+            {"model": "hermes-4-14b-q5km", "messages": []},
+            reg,
+        )
+
+
+def _patch_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake(_sm: Any) -> dict[str, str]:
+        return {
+            "primary": "qwen3-coder-next-reap-40b-a3b-q4kxl",
+            "agent-hermes": "hermes-4-14b-q5km",
+            "utility": "qwen3-zero-coder-v2-0.8b-f16",
+        }
+
+    monkeypatch.setattr(hal0_api, "hal0_chat_slot_alias_map", _fake)
+
+
+def test_chat_alias_reaches_lemonade_with_model_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: POST /v1/chat/completions with model="primary" rewrites
+    to the model id and falls through to the lemonade proxy carrying that
+    model name (not the bare alias). We stub the proxy to capture the body
+    it would forward to lemond."""
+    from fastapi.testclient import TestClient
+
+    from hal0.api import create_app
+    from hal0.api.routes import v1 as v1_module
+
+    _patch_alias(monkeypatch)
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_proxy(request: Any, path: str) -> Any:
+        from fastapi.responses import Response
+
+        body = await request.body()
+        captured["path"] = path
+        captured["body"] = json.loads(body) if body else {}
+        return Response(content=b'{"ok": true}', media_type="application/json")
+
+    # Patch the symbol the handler imports lazily from the proxy module.
+    import hal0.api.routes.lemonade_proxy as lp
+
+    monkeypatch.setattr(lp, "_proxy", _fake_proxy)
+    _ = v1_module  # imported for clarity that the route lives there
+
+    with TestClient(create_app()) as client:
+        r = client.post(
+            "/v1/chat/completions",
+            json={"model": "primary", "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+    assert r.status_code == 200, r.text
+    assert captured["path"] == "chat/completions"
+    # The body forwarded to lemond carries the rewritten model NAME, not
+    # the alias — so lemond serves qwen3-coder, not "primary".
+    assert captured["body"]["model"] == "qwen3-coder-next-reap-40b-a3b-q4kxl"

--- a/tests/api/test_v1_slot_alias_models.py
+++ b/tests/api/test_v1_slot_alias_models.py
@@ -1,0 +1,225 @@
+"""GET /v1/models per-slot alias entries (hermes-role-slots).
+
+Each LOADED, enabled chat slot surfaces as one OpenAI ``model`` object
+addressed by its alias (= slot name), carrying a human display name and
+the slot's context length. Unloaded / disabled slots are hidden.
+
+These tests exercise the :func:`hal0.api.hal0_slot_alias_models` helper
+directly with a faked lemond health probe so they don't depend on a live
+backend.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import hal0.api as hal0_api
+from hal0.api import hal0_slot_alias_models
+
+
+class _FakeSlotManager:
+    def __init__(self, configs: list[dict[str, Any]]):
+        self._configs = configs
+
+    async def iter_configs(self) -> list[dict[str, Any]]:
+        return list(self._configs)
+
+
+class _FakeDefaults:
+    def __init__(self, context_size: int | None):
+        self.context_size = context_size
+
+
+class _FakeModel:
+    def __init__(self, name: str, context_size: int | None = None):
+        self.name = name
+        self.defaults = _FakeDefaults(context_size) if context_size is not None else None
+
+
+class _FakeModelRegistry:
+    def __init__(self, models: dict[str, tuple[str, int | None]]):
+        # model_id -> (display_name, defaults.context_size | None)
+        self._models = models
+
+    def get(self, model_id: str) -> _FakeModel:
+        if model_id not in self._models:
+            raise KeyError(model_id)
+        name, ctx = self._models[model_id]
+        return _FakeModel(name, ctx)
+
+
+def _three_chat_slots() -> list[dict[str, Any]]:
+    """Mirror the live TOML ctx-key inconsistency:
+    primary pins NO ctx (→ registry fallback), agent-hermes uses
+    ``ctx_size``, utility uses ``context_size``.
+    """
+    return [
+        {
+            "name": "primary",
+            "type": "llm",
+            "enabled": True,
+            "port": 8001,
+            "model": {"default": "qwen3-coder-next-reap-40b-a3b-q4kxl"},
+        },
+        {
+            "name": "agent-hermes",
+            "type": "llm",
+            "enabled": True,
+            "port": 8001,
+            "model": {"default": "hermes-4-14b-q5km", "ctx_size": 65536},
+        },
+        {
+            "name": "utility",
+            "type": "llm",
+            "enabled": True,
+            "port": 8081,
+            "model": {"default": "qwen3-zero-coder-v2-0.8b-f16", "context_size": 32768},
+        },
+        # Non-chat slot — never surfaces as a chat alias.
+        {
+            "name": "embed",
+            "type": "embedding",
+            "enabled": True,
+            "port": 0,
+            "model": {"default": "Qwen3-Embedding-0.6B-GGUF"},
+        },
+    ]
+
+
+def _registry() -> _FakeModelRegistry:
+    return _FakeModelRegistry(
+        {
+            # primary's model has a registry defaults.context_size that the
+            # alias builder falls back to (the slot TOML pins no ctx key).
+            "qwen3-coder-next-reap-40b-a3b-q4kxl": ("Qwen3-Coder-Next", 65536),
+            "hermes-4-14b-q5km": ("Hermes 4 14B", None),
+            # utility's model intentionally absent → display falls back to id.
+        }
+    )
+
+
+def _patch_loaded(monkeypatch: pytest.MonkeyPatch, loaded: set[str] | None) -> None:
+    async def _fake(_sm: Any) -> set[str] | None:
+        return loaded
+
+    monkeypatch.setattr(hal0_api, "_loaded_model_ids", _fake)
+
+
+@pytest.mark.asyncio
+async def test_all_loaded_chat_slots_emit_alias_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_loaded(
+        monkeypatch,
+        {
+            "qwen3-coder-next-reap-40b-a3b-q4kxl",
+            "hermes-4-14b-q5km",
+            "qwen3-zero-coder-v2-0.8b-f16",
+        },
+    )
+    entries = await hal0_slot_alias_models(
+        _FakeSlotManager(_three_chat_slots()), _registry(), now=1000
+    )
+    by_id = {e["id"]: e for e in entries}
+
+    # Exactly the three chat slots, addressed by alias; no embed slot.
+    assert set(by_id) == {"primary", "agent-hermes", "utility"}
+
+    # Stable id = slot name; owned_by = hal0; OpenAI object shape.
+    for e in entries:
+        assert e["object"] == "model"
+        assert e["owned_by"] == "hal0"
+        assert e["created"] == 1000
+
+    # Display name = "<slot> · <model display name>" from the registry.
+    assert by_id["primary"]["name"] == "primary · Qwen3-Coder-Next"
+    assert by_id["agent-hermes"]["name"] == "agent-hermes · Hermes 4 14B"
+    # utility's model isn't in the registry → falls back to the model id.
+    assert by_id["utility"]["name"] == "utility · qwen3-zero-coder-v2-0.8b-f16"
+
+    # context_length surfaces for all three: agent-hermes via ``ctx_size``,
+    # utility via ``context_size``, primary via the registry fallback
+    # (defaults.context_size) since its TOML pins no ctx key.
+    assert by_id["agent-hermes"]["context_length"] == 65536
+    assert by_id["utility"]["context_length"] == 32768
+    assert by_id["primary"]["context_length"] == 65536
+
+
+@pytest.mark.asyncio
+async def test_unloaded_slots_are_hidden(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only slots whose model is in lemond's loaded set appear."""
+    _patch_loaded(monkeypatch, {"hermes-4-14b-q5km"})
+    entries = await hal0_slot_alias_models(
+        _FakeSlotManager(_three_chat_slots()), _registry(), now=1000
+    )
+    assert {e["id"] for e in entries} == {"agent-hermes"}
+
+
+@pytest.mark.asyncio
+async def test_disabled_slots_are_hidden(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfgs = _three_chat_slots()
+    cfgs[0]["enabled"] = False  # disable primary
+    _patch_loaded(
+        monkeypatch,
+        {
+            "qwen3-coder-next-reap-40b-a3b-q4kxl",
+            "hermes-4-14b-q5km",
+            "qwen3-zero-coder-v2-0.8b-f16",
+        },
+    )
+    entries = await hal0_slot_alias_models(_FakeSlotManager(cfgs), _registry(), now=1000)
+    assert "primary" not in {e["id"] for e in entries}
+
+
+@pytest.mark.asyncio
+async def test_no_entries_when_health_probe_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If lemond health can't be read at all, no alias entries are emitted
+    rather than advertising slots we can't confirm are serving."""
+    _patch_loaded(monkeypatch, None)
+    entries = await hal0_slot_alias_models(
+        _FakeSlotManager(_three_chat_slots()), _registry(), now=1000
+    )
+    assert entries == []
+
+
+# ── handler integration: GET /v1/models surfaces the alias entries ──────────
+
+
+def test_v1_models_handler_includes_slot_alias_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public ``GET /v1/models`` handler folds the per-slot alias
+    entries into the OpenAI list response."""
+    from fastapi.testclient import TestClient
+
+    from hal0.api import create_app
+
+    async def _fake_alias_models(
+        _slot_manager: Any, _model_registry: Any, *, now: int | None = None
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": "agent-hermes",
+                "object": "model",
+                "created": now or 0,
+                "owned_by": "hal0",
+                "name": "agent-hermes · Hermes 4 14B",
+                "context_length": 65536,
+            }
+        ]
+
+    monkeypatch.setattr(hal0_api, "hal0_slot_alias_models", _fake_alias_models)
+
+    with TestClient(create_app()) as client:
+        r = client.get("/v1/models")
+    assert r.status_code == 200
+    data = r.json()["data"]
+    by_id = {e["id"]: e for e in data}
+    assert "agent-hermes" in by_id
+    assert by_id["agent-hermes"]["owned_by"] == "hal0"
+    assert by_id["agent-hermes"]["name"] == "agent-hermes · Hermes 4 14B"
+    assert by_id["agent-hermes"]["context_length"] == 65536

--- a/tests/cli/test_agent_shim.py
+++ b/tests/cli/test_agent_shim.py
@@ -120,7 +120,9 @@ class TestAgentConfig:
             host="10.0.0.1",
             port=4242,
         )
-        assert cfg.status_url == "http://10.0.0.1:4242/api/health"
+        # Unauthenticated /health liveness route (the /api/* surface is
+        # auth-gated and returns 401, which would stall the notify start).
+        assert cfg.status_url == "http://10.0.0.1:4242/health"
 
     def test_hermes_bin_resolves_under_venv(self) -> None:
         cfg = agent_shim.AgentConfig(
@@ -385,3 +387,47 @@ def _make_parser_allowing_only_status() -> Any:
     p.add_argument("agent_id")
     p.add_argument("subcommand", choices=["status"])
     return p
+
+
+class TestIsReady:
+    """``_is_ready`` accepts 2xx AND auth-challenges (401/403) as 'reachable'.
+
+    The hermes dashboard auth-gates ``/api/*``; an auth response still proves
+    the socket is open, so the shim must sd_notify READY rather than loop.
+    """
+
+    @staticmethod
+    def _cfg() -> agent_shim.AgentConfig:
+        return agent_shim.AgentConfig(
+            agent_id="hermes",
+            agent_type="hermes",
+            home=Path("/x"),
+            venv=Path("/y"),
+            host="127.0.0.1",
+            port=9119,
+        )
+
+    def test_2xx_is_ready(self) -> None:
+        with patch("hal0.cli.agent_shim.urllib.request.urlopen") as m:
+            m.return_value.__enter__.return_value.status = 200
+            assert agent_shim._is_ready(self._cfg()) is True
+
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [(401, True), (403, True), (404, False), (500, False)],
+    )
+    def test_http_error_codes(self, code: int, expected: bool) -> None:
+        import urllib.error
+
+        err = urllib.error.HTTPError("http://x", code, "msg", {}, None)  # type: ignore[arg-type]
+        with patch("hal0.cli.agent_shim.urllib.request.urlopen", side_effect=err):
+            assert agent_shim._is_ready(self._cfg()) is expected
+
+    def test_connection_error_not_ready(self) -> None:
+        import urllib.error
+
+        with patch(
+            "hal0.cli.agent_shim.urllib.request.urlopen",
+            side_effect=urllib.error.URLError("boom"),
+        ):
+            assert agent_shim._is_ready(self._cfg()) is False

--- a/tests/dispatcher/test_composite_passthrough_skip.py
+++ b/tests/dispatcher/test_composite_passthrough_skip.py
@@ -1,0 +1,103 @@
+"""The composite ``hal0`` upstream must not absorb chat passthrough.
+
+hermes-role-slots fix: Lemonade serves chat models by name on lemond, and
+the composite ``hal0`` upstream (URL = hal0-api itself) only exists to
+aggregate chat model ids for ``GET /v1/models``. If the dispatcher matched
+a chat model id against the composite's cache in the passthrough step, the
+request would forward back into hal0-api (loop / wrong co-resident model)
+instead of falling through to the lemonade proxy. These tests lock the
+skip so chat model ids reach the legacy fallback (→ NoRouteFound → lemonade
+proxy) rather than the composite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.dispatcher.router import Dispatcher, NoRouteFound
+from hal0.upstreams.registry import Upstream, UpstreamRegistry
+
+
+def _make_request(path: str = "/v1/chat/completions", method: str = "POST"):
+    from starlette.requests import Request
+
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [(b"content-type", b"application/json")],
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 12345),
+        "http_version": "1.1",
+        "root_path": "",
+    }
+    return Request(scope)
+
+
+def _registry_with_composite() -> UpstreamRegistry:
+    reg = UpstreamRegistry()
+    reg.upsert(
+        Upstream(
+            name="hal0",
+            kind="slot",
+            url="http://127.0.0.1:8080/v1",
+            slot_name=None,
+            auth_style="none",
+            advertise_models=True,
+        )
+    )
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_chat_model_id_skips_composite_and_falls_through() -> None:
+    """A chat model id present in the composite's cache must NOT route to
+    the composite; with no other upstream it raises NoRouteFound (which the
+    v1 layer turns into the lemonade fall-through)."""
+    reg = _registry_with_composite()
+    # The composite cache lists the chat model id (as it would after
+    # _fetch_hal0_composite_models primes it).
+    cache = {"hal0": ["hermes-4-14b-q5km"]}
+    dispatcher = Dispatcher(
+        upstream_registry=reg,
+        model_registry=None,
+        cached_models=lambda name: cache.get(name, []),
+    )
+    with pytest.raises(NoRouteFound):
+        await dispatcher.dispatch(
+            _make_request(),
+            body={"model": "hermes-4-14b-q5km", "messages": []},
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_composite_passthrough_still_works() -> None:
+    """A real (non-composite) upstream still wins passthrough — the skip is
+    scoped to the self-referential composite only."""
+    reg = _registry_with_composite()
+    reg.upsert(
+        Upstream(
+            name="openrouter",
+            kind="remote",
+            url="https://openrouter.ai/api/v1",
+            auth_style="none",
+        )
+    )
+    cache = {
+        "hal0": ["hermes-4-14b-q5km"],
+        "openrouter": ["meta/llama-3.1-405b"],
+    }
+    dispatcher = Dispatcher(
+        upstream_registry=reg,
+        model_registry=None,
+        cached_models=lambda name: cache.get(name, []),
+    )
+    call = await dispatcher.dispatch(
+        _make_request(),
+        body={"model": "meta/llama-3.1-405b"},
+    )
+    assert call.upstream_name == "openrouter"
+    assert call.resolution_path == "passthrough:openrouter"

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -338,3 +338,104 @@ async def test_missing_path_arg_returns_typed_error(queue: ApprovalQueue) -> Non
     )
     assert result["status"] == "error"
     assert result["error"]["code"] == "mcp.missing_arg"
+
+
+@pytest.fixture
+def list_transport(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Patch httpx.AsyncClient so GET returns a bare JSON *list*.
+
+    Mirrors the real /api/slots and /api/providers routes, which return
+    ``list[dict]`` rather than a top-level object. Used to prove the MCP
+    wrapper wraps the list into a dict (the DictModel-validation fix).
+    """
+    captured: dict[str, Any] = {"payload": [{"name": "primary"}, {"name": "embed"}]}
+
+    class _MockResponse:
+        status_code = 200
+
+        def __init__(self, payload: Any) -> None:
+            self._payload = payload
+            self.text = ""
+
+        def json(self) -> Any:
+            return self._payload
+
+    class _MockClient:
+        def __init__(self, *, base_url: str, timeout: float) -> None:
+            pass
+
+        async def __aenter__(self) -> _MockClient:
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+        async def get(self, url: str, params: Any = None, headers: Any = None) -> _MockResponse:
+            return _MockResponse(captured["payload"])
+
+    monkeypatch.setattr(httpx, "AsyncClient", _MockClient)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_slot_list_wraps_bare_list_into_dict(
+    queue: ApprovalQueue, list_transport: dict[str, Any]
+) -> None:
+    """slot_list's REST route returns a bare list; the MCP tool must
+    return a top-level dict (FastMCP's result model rejects lists with
+    'Input should be a valid dictionary')."""
+    result = await admin.dispatch(
+        tool="slot_list",
+        args={},
+        client_id="pi",
+        bearer="t",
+        base_url="http://t",
+        approval_queue=queue,
+    )
+    assert isinstance(result, dict)
+    assert result == {"slots": [{"name": "primary"}, {"name": "embed"}], "count": 2}
+
+
+@pytest.mark.asyncio
+async def test_provider_list_wraps_bare_list_into_dict(
+    queue: ApprovalQueue, list_transport: dict[str, Any]
+) -> None:
+    """provider_list's REST route returns a bare list; same dict-wrap
+    requirement as slot_list."""
+    list_transport["payload"] = [{"name": "openrouter"}]
+    result = await admin.dispatch(
+        tool="provider_list",
+        args={},
+        client_id="pi",
+        bearer="t",
+        base_url="http://t",
+        approval_queue=queue,
+    )
+    assert isinstance(result, dict)
+    assert result == {"providers": [{"name": "openrouter"}], "count": 1}
+
+
+@pytest.mark.asyncio
+async def test_list_wrap_does_not_touch_dict_payloads(
+    queue: ApprovalQueue, list_transport: dict[str, Any]
+) -> None:
+    """A non-list REST payload (e.g. an error envelope) for slot_list
+    round-trips unchanged — the wrapper never masks a dict response."""
+    list_transport["payload"] = {"status": "error", "http_status": 503}
+    result = await admin.dispatch(
+        tool="slot_list",
+        args={},
+        client_id="pi",
+        bearer="t",
+        base_url="http://t",
+        approval_queue=queue,
+    )
+    assert result == {"status": "error", "http_status": 503}
+
+
+def test_wrap_list_payload_noop_for_other_tools() -> None:
+    """Only slot_list / provider_list get wrapped; other tools (e.g.
+    model_list, whose REST route already returns a dict) pass through."""
+    data = [{"id": "x"}]
+    assert admin._wrap_list_payload("model_list", data) is data
+    assert admin._wrap_list_payload("hardware_probe", {"ok": 1}) == {"ok": 1}


### PR DESCRIPTION
## Summary

Lands the **Hermes role-slot model-addressing** feature (branch `feat/hermes-role-slots`). Closes #377 — the chat dispatcher ignored the request body `model` field and always routed to the `primary` slot.

This is a large feature branch (~2,019 lines / 16 files), not just the #377 one-liner. It includes:

- **Role-slot model addressing** (`742e5de`): the route layer translates a slot-alias `model` field → the slot's `model_id`; `/v1/models` lists `id=slot-alias`. (`api/__init__.py`, `api/routes/v1.py`, `dispatcher/router.py`)
- **Hermes notify-shim fix** (`6e27a55`): shim polls the unauthenticated `/health` and treats 401/403 as reachable so `sd_notify READY=1` fires — fixes the agent-shim crash-loop. (`cli/agent_shim.py`)
- **Per-model context** (`1736f95`): per-model `context_length` via `custom_providers[].models`, removing the global override that bled context across models. (`agents/hermes_provision.py`, `config.yaml.j2`)
- hal0-admin MCP `slot_list`/`provider_list` list-payload wrapping fix. (`mcp/admin.py`)
- +6 test files (provision, slot-alias dispatch, admin, shim).

## Verification

- Merged cleanly into the pre-#424 `main`. **Re-checking mergeability vs current `main`** — PR #424 (just merged) also touched `dispatcher/router.py`, so watch this PR's mergeable status / CI.
- Tests were green on touched modules locally per the team that built the branch; full CI runs here.

## Review asks

- ⚠️ Confirm the alias→`model_id` translation also covers a **raw model-name** request, not only registered slot aliases (the exact symptom in #377).
- This branch is the ancestor of `perf/gpu-probe-fixes` and `feat/backend-selection-ui`; landing it first simplifies those.

Closes #377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
