### PR TITLE
fix(dashboard): synthetic composite slot status from lemond, not catalogue

### DIFF
--- a/src/hal0/api/routes/health.py
+++ b/src/hal0/api/routes/health.py
@@ -59,6 +59,7 @@ async def get_status(request: Request) -> dict[str, Any]:
     # picks them up via /api/slots directly.
     from hal0.api.routes.slots import (
         _get_slot_manager,
+        _lemonade_loaded_models,
         _slot_to_dict,
         _synthesize_slots_from_upstreams,
     )
@@ -75,7 +76,8 @@ async def get_status(request: Request) -> dict[str, Any]:
     real_names = {entry["name"] for entry in real_entries}
 
     slot_list: list[dict[str, Any]] = list(real_entries)
-    for entry in _synthesize_slots_from_upstreams(request):
+    loaded_models = await _lemonade_loaded_models(request)
+    for entry in _synthesize_slots_from_upstreams(request, loaded_models=loaded_models):
         if entry["name"] not in real_names:
             slot_list.append(entry)
 

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -264,13 +264,57 @@ async def _lemonade_state_enrichment(request: Request) -> dict[str, dict[str, An
     return out
 
 
-def _synthesize_slots_from_upstreams(request: Request) -> list[dict[str, Any]]:
+async def _lemonade_loaded_models(request: Request) -> set[str]:
+    """Model names lemond currently reports resident (``/v1/health``).
+
+    The truth source for the synthetic composite slot's ``status``: a
+    model is "serving" only when lemond actually holds it, not when the
+    catalogue merely lists it. Never raises — a down/unreachable lemond
+    yields an empty set so the dashboard degrades to "offline" instead
+    of 500ing.
+    """
+    from hal0.lemonade.errors import LemonadeError
+    from hal0.providers import lemonade_provider
+
+    try:
+        health = await lemonade_provider().client().health()
+    except LemonadeError:
+        return set()
+    except Exception:
+        return set()
+    names: set[str] = set()
+    if isinstance(health, dict):
+        for key in ("loaded", "all_models_loaded"):
+            entries = health.get(key)
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if isinstance(entry, dict):
+                    name = entry.get("model_name")
+                    if isinstance(name, str) and name:
+                        names.add(name)
+    return names
+
+
+def _synthesize_slots_from_upstreams(
+    request: Request, loaded_models: set[str] | None = None
+) -> list[dict[str, Any]]:
     """Build virtual slot entries from configured upstreams.
 
     Until every upstream has a corresponding local slot, the dashboard
     still needs to show remote-backed inference targets. Each upstream
-    surfaces as a read-only slot entry: status="serving" when its model
-    cache is populated, "offline" otherwise.
+    surfaces as a read-only slot entry. ``status`` is computed by kind:
+
+      * local composite (``kind="slot"``) — ``serving`` only when one of
+        the upstream's advertised models appears in lemond's live loaded
+        set (``loaded_models``). The catalogue cache lists every configured
+        chat model, so it is NOT a liveness signal; consulting the loaded
+        set is what keeps the dashboard from showing evicted models as
+        resident. Falls back to the catalogue heuristic only when health
+        was unreadable (``loaded_models is None``).
+      * remote (``kind="remote"``) — ``serving`` when its model cache is
+        populated, since that cache is a live ``/v1/models`` probe of the
+        remote. ``offline`` otherwise.
 
     The slot's ``model`` reflects the most recently dispatched model id
     for this upstream (tracked in ``app.state.last_used_model``); falls
@@ -291,12 +335,24 @@ def _synthesize_slots_from_upstreams(request: Request) -> list[dict[str, Any]]:
             or (real_models[0] if real_models else "")
             or (models[0] if models else "")
         )
+        if u.kind == "slot":
+            # Local composite upstream: ``models`` comes from the slot
+            # CATALOGUE (config), so a non-empty list says nothing about
+            # what is resident. Truth comes from lemond's live loaded set.
+            # If health was unreadable (loaded_models is None) fall back to
+            # the catalogue heuristic rather than flapping to offline on a
+            # transient probe error.
+            serving = bool(models) if loaded_models is None else bool(set(models) & loaded_models)
+        else:
+            # Remote upstream: ``models`` is a live /v1/models probe of the
+            # remote, so a populated list is a genuine liveness signal.
+            serving = bool(models)
         out.append(
             {
                 "name": u.name,
                 "kind": u.kind,
                 "model": primary_model,
-                "status": "serving" if models else "offline",
+                "status": "serving" if serving else "offline",
                 "backend": "remote" if u.kind == "remote" else "vulkan",
                 "provider": "remote-upstream" if u.kind == "remote" else "llama-server",
                 "url": u.url,
@@ -354,7 +410,9 @@ async def list_slots(request: Request) -> list[dict[str, object]]:
         row = per_slot_mem.get(str(entry["name"]))
         entry["mem_mb"] = round(float(row.get("mem_mb", 0) or 0), 1) if row else 0
 
-    synthetic = _synthesize_slots_from_upstreams(request)
+    synthetic = _synthesize_slots_from_upstreams(
+        request, loaded_models=await _lemonade_loaded_models(request)
+    )
     merged: list[dict[str, Any]] = list(real_entries)
     for entry in synthetic:
         if entry["name"] not in real_names:

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -743,3 +743,54 @@ async def test_scrape_llama_metrics_clamps_overrun(
 
     out = await _scrape_llama_metrics(8081)
     assert out["kv_cache_usage"] == pytest.approx(1.0)
+
+
+# ── synthetic composite slot: truthful "serving" status ─────────────────────
+
+
+def test_synthetic_composite_slot_offline_when_lemond_empty(
+    slot_root: Path,
+    isolated_client: TestClient,
+    isolated_app: FastAPI,
+    lemonade_stub_state: dict[str, Any],
+) -> None:
+    """The synthetic composite ``hal0`` slot must derive ``status`` from
+    lemond's live loaded set, NOT from catalogue-cache cardinality.
+
+    Regression: the catalogue cache lists every configured chat model, so
+    the old ``"serving" if models else "offline"`` rule reported the
+    composite as serving forever — even when lemond had evicted every
+    model. The dashboard then showed models "loaded" that were not
+    resident. With nothing loaded, the slot must read ``offline``.
+    """
+    # Catalogue still advertises a chat model ...
+    isolated_app.state.model_cache["hal0"] = ["qwen3-4b-q4_k_m"]
+    # ... but lemond has nothing resident.
+    lemonade_stub_state["loaded"] = []
+
+    r = isolated_client.get("/api/slots")
+    assert r.status_code == 200, r.text
+    by_name = {e["name"]: e for e in r.json()}
+    assert "hal0" in by_name, f"composite hal0 slot missing: {sorted(by_name)}"
+    hal0 = by_name["hal0"]
+    assert hal0.get("_synthetic") is True
+    assert hal0["advertised_models"] >= 1, "catalogue should still advertise the model"
+    assert hal0["status"] == "offline"
+
+
+def test_synthetic_composite_slot_serving_when_model_loaded(
+    slot_root: Path,
+    isolated_client: TestClient,
+    isolated_app: FastAPI,
+    lemonade_stub_state: dict[str, Any],
+) -> None:
+    """Counterpart to the offline case: when lemond reports the catalogued
+    model resident, the composite slot reads ``serving``."""
+    isolated_app.state.model_cache["hal0"] = ["qwen3-4b-q4_k_m"]
+    lemonade_stub_state["loaded"] = [{"model_name": "qwen3-4b-q4_k_m"}]
+
+    r = isolated_client.get("/api/slots")
+    assert r.status_code == 200, r.text
+    by_name = {e["name"]: e for e in r.json()}
+    assert "hal0" in by_name, f"composite hal0 slot missing: {sorted(by_name)}"
+    assert by_name["hal0"]["status"] == "serving"


### PR DESCRIPTION
## Problem

The hal0 dashboard showed the composite **`hal0`** target as **`serving`** with
`advertised_models: 3` while **nothing was actually loaded**. Verified against
the live stack:

- lemond `/api/v1/health` → `all_models_loaded: []`, `model_loaded: null`
- no `llama-server` / `whisper` child processes; nothing resident in VRAM
- yet `/api/slots` emitted the synthetic composite slot as `serving`

## Root cause

`_synthesize_slots_from_upstreams` computed status as
`"serving" if models else "offline"`, where `models = app.state.model_cache[name]`.
For the **local composite** `hal0` upstream that cache is the slot **catalogue**
(every configured chat slot's model id), seeded from config at startup and
refreshed only on slot→ready transitions. It is **never tied to runtime load
state**, so the composite read `serving` whenever ≥1 chat slot was *configured* —
independent of what lemond actually held. The dashboard then presented evicted
models as resident.

PR #439 ("dashboard truth") fixed the real slot rows but missed this synthetic
aggregate path.

## Fix

- New `_lemonade_loaded_models()` helper reads lemond's live `/v1/health`
  loaded set (`loaded` / `all_models_loaded`). Never raises — a down/unreachable
  lemond yields an empty set so the slot degrades to `offline`.
- Local composite (`kind="slot"`): `serving` only when one of its advertised
  model ids is actually resident.
- Remote upstreams keep the cache heuristic — there the cache **is** a live
  `/v1/models` probe of the remote.
- Both callers (`/api/slots`, `/api/status`) thread the loaded set in.

## Tests

`tests/api/test_slots_routes.py`:
- `test_synthetic_composite_slot_offline_when_lemond_empty` — RED→GREEN: composite
  reads `offline` when lemond's loaded set is empty even though the catalogue still
  advertises chat models.
- `test_synthetic_composite_slot_serving_when_model_loaded` — composite reads
  `serving` when the catalogued model is resident.

Local run: `tests/api/test_slots_routes.py` 20 passed; `test_model_cache_refresh`,
`test_pulling_serving_idle`, `test_smoke`, `test_middleware` green. `ruff check`
and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
