### PR TITLE
fix(agents): stop gateway_secrets_wire from clobbering real /etc under pytest

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -2194,6 +2194,29 @@ def _phase_gateway_secrets_wire(state: BootstrapState) -> PhaseResult:
     ``systemctl`` both require root, so a non-root provision SKIPs with a
     clear reason rather than failing the whole bootstrap.
     """
+    # Defense-in-depth (regression: 2026-06-04 outage). The euid!=0 guard
+    # below is the only thing that normally keeps the test suite off the
+    # host's real systemd tree — but it is DEFEATED when pytest runs as
+    # root (or, as on hal0-dev, where /etc/systemd is ACL-writable). A
+    # fixture that monkeypatches HERMES_SECRETS_ENV but forgets
+    # GATEWAY_SYSTEMD_DROPIN_FILE then writes the live drop-in with a
+    # pytest-tmp EnvironmentFile path, restart-looping the gateway once the
+    # tmp dir is reaped. So: under pytest, refuse to touch the real /etc
+    # tree. A test that genuinely exercises the write monkeypatches the
+    # drop-in dir to tmp_path, which moves it out from under /etc.
+    if os.environ.get("PYTEST_CURRENT_TEST") and str(GATEWAY_SYSTEMD_DROPIN_DIR).startswith(
+        "/etc/"
+    ):
+        return PhaseResult(
+            status=PhaseStatus.SKIP,
+            reason=(
+                "running under pytest with an un-sandboxed system drop-in path "
+                "— refusing to write the real /etc/systemd tree; monkeypatch "
+                "GATEWAY_SYSTEMD_DROPIN_DIR/FILE to tmp in the test fixture"
+            ),
+            details={"dropin_path": str(GATEWAY_SYSTEMD_DROPIN_FILE)},
+        )
+
     if os.geteuid() != 0:
         return PhaseResult(
             status=PhaseStatus.SKIP,

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1472,6 +1472,36 @@ def test_gateway_secrets_wire_skips_non_root(
     assert fake.calls == []
 
 
+def test_gateway_secrets_wire_refuses_real_etc_dropin_under_pytest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the 2026-06-04 outage: a fixture that monkeypatches
+    HERMES_SECRETS_ENV but FORGETS GATEWAY_SYSTEMD_DROPIN_FILE leaves the
+    drop-in pointing at the real /etc tree. When pytest runs as root (e.g.
+    on an LXC) the euid!=0 guard is defeated, so the phase would write the
+    host's live drop-in with a pytest-tmp EnvironmentFile path → gateway
+    restart-loop once the tmp dir is reaped. The phase must refuse to touch
+    the real /etc/systemd tree under pytest regardless of euid.
+    """
+    # Intentionally do NOT sandbox the drop-in path — it stays at the real
+    # /etc default, exactly as the buggy fixture left it.
+    assert str(hp.GATEWAY_SYSTEMD_DROPIN_DIR).startswith("/etc/")
+    # Defeat the euid!=0 guard the way root-on-an-LXC does.
+    monkeypatch.setattr(hp.os, "geteuid", lambda: 0)
+
+    # If the phase reaches systemctl it has already escaped — fail loudly.
+    def _boom(*_a: Any, **_kw: Any) -> Any:
+        raise AssertionError("phase invoked systemctl against the real bus")
+
+    monkeypatch.setattr(hp.subprocess, "run", _boom)
+
+    out = hp._phase_gateway_secrets_wire(hp.BootstrapState())
+
+    assert out.status == hp.PhaseStatus.SKIP
+    assert out.reason is not None
+    assert "pytest" in out.reason.lower()
+
+
 # ── #437 — canonical home / wrapper consolidation ───────────────────────────
 
 

--- a/tests/agents/test_hermes_provision_idempotency.py
+++ b/tests/agents/test_hermes_provision_idempotency.py
@@ -50,6 +50,30 @@ def hermetic_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.Bootst
     monkeypatch.setattr(hp, "HAL0_BUNDLED_SKILLS", tmp_path / "usr" / "share" / "hal0" / "skills")
     monkeypatch.setattr(hp, "HERMES_SECRETS_ENV", tmp_path / "secrets" / "hermes.env")
     monkeypatch.setattr(hp, "AGENT_ALLOWLIST_PATH", tmp_path / "etc" / "hal0" / "agents.toml")
+    # #437 gateway_secrets_wire: redirect the SYSTEM drop-in dir under
+    # tmp_path so a pipeline run never escapes into the live
+    # /etc/systemd/system — even when the runner is root or /etc/systemd is
+    # ACL-writable (the 2026-06-04 clobber). Patching HERMES_SECRETS_ENV
+    # alone is NOT enough: that only changes the EnvironmentFile *content*,
+    # not the *destination* the phase writes to.
+    _dropin_dir = tmp_path / "etc" / "systemd" / "system" / "hermes-gateway.service.d"
+    monkeypatch.setattr(hp, "GATEWAY_SYSTEMD_DROPIN_DIR", _dropin_dir)
+    monkeypatch.setattr(hp, "GATEWAY_SYSTEMD_DROPIN_FILE", _dropin_dir / "10-hal0-secrets.conf")
+    # Intercept ONLY `systemctl daemon-reload`; everything else passes
+    # through so env_probe / smoke phases behave as before.
+    _real_run = hp.subprocess.run
+
+    class _NoopCompleted:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def _guarded_run(argv: Any, *a: Any, **kw: Any) -> Any:
+        if isinstance(argv, (list, tuple)) and list(argv[:2]) == ["systemctl", "daemon-reload"]:
+            return _NoopCompleted()
+        return _real_run(argv, *a, **kw)
+
+    monkeypatch.setattr(hp.subprocess, "run", _guarded_run)
     # Personas land under $HERMES_HOME/personas via _personas_root_for —
     # the fixture's hermes_home is already in tmp_path so no further
     # monkey-patching is needed for the persona phase.


### PR DESCRIPTION
## What happened

The live Hermes gateway on CT 105 went down on **2026-06-04** (Telegram + Discord dark, restart-looping). Root cause was a **test-isolation bug**, not a runtime bug.

The bootstrap's `gateway_secrets_wire` phase writes a systemd drop-in at `/etc/systemd/system/hermes-gateway.service.d/10-hal0-secrets.conf` whose `EnvironmentFile=` points at the secrets vault. The phase deals with **two** paths:

| Constant | Role |
|---|---|
| `HERMES_SECRETS_ENV` | the `EnvironmentFile=` **content** written into the drop-in |
| `GATEWAY_SYSTEMD_DROPIN_FILE` | the **destination** the phase writes to |

The `hermetic_state` fixture in `test_hermes_provision_idempotency.py` monkeypatched **only the content path**, not the destination. The phase's `euid != 0` SKIP guard normally keeps tests off real systemd — but that guard is **defeated when pytest runs as root** (normal on an LXC) or where `/etc/systemd` is ACL-writable (as on hal0-dev). So a root pytest run wrote the host's **real** drop-in with a pytest-tmp `EnvironmentFile` path. When pytest reaped the tmp dir, the next gateway restart failed:

```
Failed to load environment files: No such file or directory → restart loop → 0 platforms
```

Same blast radius as #437.

## Fix (two independent layers)

1. **Defense-in-depth (`hermes_provision.py`):** the phase now SKIPs when `PYTEST_CURRENT_TEST` is set *and* the drop-in dir is still under `/etc/`. No future un-sandboxed fixture can escape into real systemd, regardless of euid. A test that genuinely exercises the write monkeypatches the dir to `tmp_path`, moving it out from under `/etc`.
2. **Direct fix (`test_hermes_provision_idempotency.py`):** `hermetic_state` now sandboxes `GATEWAY_SYSTEMD_DROPIN_DIR`/`FILE` to `tmp_path` and stubs `systemctl daemon-reload`, mirroring the already-correct `state_with_tmp_paths` fixture.

## Test

`test_gateway_secrets_wire_refuses_real_etc_dropin_under_pytest` reproduces the escape: before the guard it writes real `/etc` and reaches `systemctl` (RED); after the guard it SKIPs cleanly with no filesystem side-effect (GREEN). Existing dedicated phase tests (sandboxed to tmp) are unaffected.

The live box was already recovered out-of-band (drop-in repointed at `/var/lib/hal0/secrets/agents/hermes.env`); this PR stops the recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)