### PR TITLE
fix(dashboard): drop user. prefix from add-by-HF model ids

### DIFF
--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -49,9 +49,9 @@ function AddByHfModal({ open, onClose }) {
     if (!repo) return;
     try {
       const result = await inspect.mutateAsync({ hf_repo: repo });
-      // Auto-suggest a user.* name from the repo's tail segment.
+      // Auto-suggest a name from the repo's tail segment.
       const tail = (result?.repo || repo).split("/")[1] || "model";
-      setName(prev => prev || ("user." + tail.replace(/-GGUF$/i, "")));
+      setName(prev => prev || tail.replace(/-GGUF$/i, ""));
     } catch (e) {
       // The toast surface already renders the Hal0Error envelope;
       // surface a hint for offline mock scenarios so the operator
@@ -175,7 +175,7 @@ function AddByHfModal({ open, onClose }) {
           <div className="form-row">
             <div className="form-lbl">
               <span>Model name (in hal0)</span>
-              <span className="sub">prefixed with <span className="mono">user.</span> by convention</span>
+              <span className="sub">derived from the HF repo name — edit to taste</span>
             </div>
             <div className="form-ctl">
               <input className="input mono" value={name} onChange={e => setName(e.target.value)} />
@@ -634,7 +634,7 @@ function AddByPathModal({ open, onClose }) {
           <span className="sub">empty → derived from filename</span>
         </div>
         <div className="form-ctl">
-          <input className="input mono" value={id} onChange={e => setId(e.target.value)} placeholder="user.my-model" />
+          <input className="input mono" value={id} onChange={e => setId(e.target.value)} placeholder="my-model" />
         </div>
       </div>
 


### PR DESCRIPTION
## Problem
Adding a model via the dashboard's **Add by HF** flow auto-suggested the name as `user.<repo-tail>`, and that name becomes the registry id, display name, **and on-disk path**. Example: `unsloth/gemma-4-12b-it-GGUF` → `user.gemma-4-12b-it` stored at `/mnt/ai-models/user.gemma-4-12b-it/`.

The `user.` text is purely cosmetic — the functional namespace is the separate `ns` field (stays `pulled` regardless) — so it only added noise to ids, titles, and paths.

## Change
- `AddByHfModal`: auto-suggest the clean repo slug (drop the `user.` prefix)
- Update the helper copy under *Model name (in hal0)*
- `AddByPathModal`: placeholder `user.my-model` → `my-model`

No backend change needed — it mirrors `name = model_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)