### PR TITLE
fix(dashboard): evicted/idle slots render grey (cold), not yellow

### DIFF
--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -28,16 +28,20 @@ const { useState: useStateS } = React;
 //   serving + last_used_at fresh         → "serving" (green pulse) — actively processing
 //   serving + last_used_at > 1h          → "stale"   (yellow) — possibly stuck request
 //   loaded in VRAM (lemo=loaded|ready)   → "stale"   (yellow) — ready, awaiting prompt
-//   evicted / idle (lemo=idle|idle)      → "stale"   (yellow) — auto-reloads on next request
+//   evicted / idle (lemo=idle|idle)      → "offline" (grey)   — not in VRAM; loads on demand
 //   offline (clean unload/swap/evict)    → "offline" (grey)
 //
-// GREEN fires ONLY during an active in-flight request. Yellow covers
-// the entire "loaded and waiting" surface — in-VRAM and evicted both —
-// because operators don't need a colour to tell those apart (the
-// tooltip does). After a serving context manager exits, the slot
-// transitions back to READY (yellow); 1h later the idle monitor demotes
-// to IDLE (also yellow). The 1h timer in this file catches stuck-in-
-// SERVING slots where a request never finished.
+// Colour follows VRAM RESIDENCY, not configuration (truthful-display,
+// 2026-06-04, supersedes the 2026-05-27 spec): GREEN = actively
+// processing an in-flight request; YELLOW = model genuinely resident in
+// VRAM (loaded/ready, awaiting a prompt); GREY = nothing loaded —
+// disabled, cleanly offline, or evicted/idle (lemonade hot-reloads on
+// the next request). Evicted vs disabled is a label/tooltip distinction,
+// not a colour one, so the dashboard never paints a not-loaded slot in a
+// "warm" colour. After a serving context manager exits the slot returns
+// to READY (yellow, still in VRAM); it only goes grey once lemonade
+// evicts it. The 1h timer in this file catches stuck-in-SERVING slots
+// where a request never finished.
 const RECENTLY_LIVE_MS = 60 * 60 * 1000; // 1h hung-request threshold for serving slots
 
 function _formatAgo(deltaMs) {
@@ -156,7 +160,7 @@ function slotIndicator(slot, now = Date.now()) {
   // the model is available but not in VRAM, lemonade hot-reloads on next request.
   if (lemo === "idle" || state === "idle") {
     return {
-      cls: "stale",
+      cls: "offline",
       label: "idle",
       tooltip: "Idle — model not in VRAM, will hot-reload on next request",
     };

--- a/ui/tests/e2e/specs/slot-indicator.spec.ts
+++ b/ui/tests/e2e/specs/slot-indicator.spec.ts
@@ -9,7 +9,7 @@
  *   serving + fresh        → green pulse (GREEN ONLY during in-flight)
  *   serving + last>1h      → yellow (stuck-request guard)
  *   ready / lemo=loaded    → yellow (loaded, awaiting prompt)
- *   idle / lemo=idle       → yellow (evicted, hot-reload on next request)
+ *   idle / lemo=idle       → grey (evicted, not in VRAM; hot-reload on next request)
  *   warming/starting/…     → amber pulse
  *   !enabled / disabled    → grey "off"
  *   offline                → grey
@@ -101,11 +101,11 @@ test.describe('slotIndicator helper', () => {
     expect(ind.tooltip).toBe('Offline')
   })
 
-  test('idle state maps to stale (yellow)', async ({ page }) => {
+  test('idle state maps to offline (grey)', async ({ page }) => {
     const ind = await page.evaluate<Indicator>(() => {
       return (window as any).slotIndicator({ state: 'idle', last_used_at: null })
     })
-    expect(ind.cls).toBe('stale')
+    expect(ind.cls).toBe('offline')
     expect(ind.label).toBe('idle')
   })
 
@@ -187,7 +187,7 @@ test.describe('slotIndicator helper', () => {
     expect(ind.label).toBe('ready')
   })
 
-  test('lemonade_state=idle → stale (yellow, evicted)', async ({ page }) => {
+  test('lemonade_state=idle → offline (grey, evicted, not in VRAM)', async ({ page }) => {
     const ind = await page.evaluate<Indicator>(() => {
       return (window as any).slotIndicator({
         state: 'offline',
@@ -195,7 +195,7 @@ test.describe('slotIndicator helper', () => {
         model: 'foo',
       })
     })
-    expect(ind.cls).toBe('stale')
+    expect(ind.cls).toBe('offline')
     expect(ind.label).toBe('idle')
     expect(ind.tooltip).toMatch(/hot-reload on next request/)
   })


### PR DESCRIPTION
## Problem

On the slots view, the status **dot and chip** painted evicted / not-loaded
slots (`lemonade_state=idle`) the **same yellow** as models actually resident
in VRAM (`lemonade_state=loaded`). The 2026-05-27 dot-state spec did this on
purpose ("yellow covers in-VRAM and evicted both; the tooltip disambiguates"),
but at a glance N configured-but-cold slots read as **N loaded models** — the
dashboard overstated what the backend actually holds. (Reported live: 6–7
"idle" slots shown warm while lemond reported `all_models_loaded: []`.)

## Change

Colour now follows **VRAM residency** (truthful-display, 2026-06-04):

| State | Colour |
|---|---|
| actively processing an in-flight request | 🟢 green |
| model resident in VRAM (`loaded`/`ready`) | 🟡 yellow |
| nothing loaded — disabled / offline / **evicted-idle** | ⚪ grey |

Evicted vs disabled stays a **label/tooltip** distinction (the chip still reads
`idle` with the *"not in VRAM, will hot-reload on next request"* tooltip), not a
colour one. `slotIndicator()` is the single source for the dot, the chip, the
snapshot strip, and the **`X/N ready`** count — so that count now reflects only
slots genuinely in VRAM.

Pairs with #442 (composite slot status from lemond, not catalogue). Together the
dashboard no longer claims models are loaded when the backend holds none.

## Tests

`ui/tests/e2e/specs/slot-indicator.spec.ts` — `idle` / `lemonade_state=idle` now
assert `cls: "offline"` (grey). Verified on the LXC:
- slot-indicator spec: **16 passed**
- slots-v3 / slots-wireup-v3 / dashboard-v3: **11 passed**
- `tsc --noEmit` clean; `npm run build` ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)
