### PR TITLE
fix(memory): scope delete guard to row's own dataset (Peer-memory stale-card flood)

### DIFF
--- a/src/hal0/memory/cognee_wrapper.py
+++ b/src/hal0/memory/cognee_wrapper.py
@@ -953,8 +953,17 @@ class CogneeWrapper:
                 # against a leaked id being used to reach into a different
                 # client's private namespace. (v0.2 single-user => moot
                 # in practice, but the check is cheap + Phase-9-ready.)
+                #
+                # Scope the check to the ROW's own dataset — not a
+                # hardcoded ``shared``. Passing ``SHARED_DATASET`` made the
+                # allowed set always ``[shared, private:<client>]``, so an
+                # id in a custom dataset (e.g. ADR-0011 ``agents``) could
+                # never match and was silently skipped — leaking one Hermes
+                # identity card per bootstrap (Peer-memory stale-card flood).
+                # ``_allowed_read_datasets`` still drops *another* client's
+                # ``private:*``, so the cross-client guard is preserved.
                 if row["dataset"] not in self._allowed_read_datasets(
-                    SHARED_DATASET, client_id=client_id
+                    row["dataset"], client_id=client_id
                 ):
                     continue
                 if row["cognee_data_id"] and row["cognee_dataset_id"]:

--- a/tests/memory/test_cognee_wrapper.py
+++ b/tests/memory/test_cognee_wrapper.py
@@ -188,6 +188,46 @@ async def test_delete_single_id_decrements_list(make_wrapper):
     _ = a  # silence linter; the test only needs id references on b
 
 
+async def test_delete_custom_dataset_item_by_owner(make_wrapper):
+    """Deleting an own item in a CUSTOM dataset (e.g. ADR-0011 ``agents``)
+    actually removes it.
+
+    Regression for the Peer-memory stale-card flood: the delete guard
+    hardcoded the allowed-read set to ``shared`` + own-private, so any id
+    whose row lived in a custom dataset (``agents``) was silently skipped,
+    ``deleted`` stayed 0, and Hermes bootstrap's "delete-then-rewrite"
+    dedup leaked one identity card per run.
+    """
+    w = make_wrapper(client_id="hermes-agent")
+    card = await w.add("identity card", dataset="agents", tags=["agent-identity"])
+
+    res = await w.delete(ids=[card["id"]])
+    assert res == {"deleted": 1}
+
+    remaining = await w.search(
+        query="identity card", dataset="agents", tags=["agent-identity"], limit=10
+    )
+    assert remaining == []
+
+
+async def test_delete_does_not_reach_other_clients_private(make_wrapper):
+    """The dataset guard still blocks deleting another client's private item.
+
+    Tightening the guard to honor custom datasets must NOT regress the
+    cross-client private protection it was written for.
+    """
+    alice = make_wrapper(client_id="alice", private_mode=True)
+    secret = await alice.add("alice secret")  # lands in private:alice
+
+    bob = make_wrapper(client_id="bob", private_mode=False)
+    res = await bob.delete(ids=[secret["id"]])
+    assert res == {"deleted": 0}
+
+    # Still there for the owner.
+    still = await alice.search(query="alice secret", limit=10)
+    assert any(h["text"] == "alice secret" for h in still)
+
+
 async def test_list_items_pagination(make_wrapper):
     """Cursor-based pagination walks the dataset in timestamp DESC order."""
     w = make_wrapper()


### PR DESCRIPTION
## Problem

The dashboard **Peer memory** view (ADR-0011 agent identity cards) was flooded with stale cards — 19 immutable `hermes-agent` cards in the `agents` dataset, all distinct ids/timestamps, where exactly **one** should exist.

## Root cause

`CogneeWrapper.delete()` gated each id against `_allowed_read_datasets(SHARED_DATASET, ...)`, hardcoding the allowed set to `[shared, private:<client>]`. Identity cards live in the dedicated `agents` dataset (ADR-0011 §1), so every card failed the membership check and hit `continue` → `deleted` stayed **0**, while the REST shim still returned HTTP 200.

Hermes bootstrap's `_phase_namespace_register` dedup (search priors → delete → rewrite) treated the 200 as success and **added one fresh card per bootstrap/`--repair` run**. 19 cards = 19 provision runs.

Proven live: `POST /api/memory/delete` on a real card id returned `{"deleted":0}` with the count unchanged.

## Fix

Scope the guard to the **row's own dataset** (`row["dataset"]`) instead of a hardcoded `shared`. An owner can delete their own custom-dataset items; `_allowed_read_datasets` still drops *another* client's `private:*`, so the cross-client protection the guard was written for is preserved. Also fixes `hal0 agent uninstall`'s card cleanup (same `wrapper.delete` path via the MCP tool).

## Tests

- `test_delete_custom_dataset_item_by_owner` — own `agents`-dataset item is actually removed (was the failing repro).
- `test_delete_does_not_reach_other_clients_private` — cross-client private delete still a no-op.
- Existing delete/private tests unchanged. 4 passed locally; ruff clean.

## Follow-ups (not in this PR)

- `_phase_namespace_register` should assert `deleted == len(existing_ids)` rather than trusting HTTP 200 (defense-in-depth).
- ADR-0011 §6 `hal0 agent list --prune` (v0.4) for ghost cards still unbuilt.
- The 18 stale live cards will be pruned once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)