### PR TITLE
ci: pre-cache fastembed bge-small-en-v1.5 to kill the cognee flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   python:
     runs-on: ubuntu-latest
+    env:
+      # fastembed (cognee memory tests) honours FASTEMBED_CACHE_PATH
+      # (fastembed/common/utils.py). Pin it to a stable, cacheable dir so the
+      # warm step AND pytest share one location that actions/cache persists.
+      FASTEMBED_CACHE_PATH: ${{ github.workspace }}/.fastembed-cache
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
@@ -27,26 +32,26 @@ jobs:
       - name: Install
         run: pip install -e ".[dev]"
       - name: Cache fastembed embedding model
-        # The cognee memory tests (tests/memory/test_cognee_wrapper.py) embed
-        # via fastembed -> BAAI/bge-small-en-v1.5 (~70 MB ONNX), fetched into
-        # ~/.cache/huggingface on first use. Caching it removes the per-run HF
-        # download that intermittently fails (could-not-load-model from any
-        # source) and gated unrelated PRs (#442, #445). The model id is fixed,
-        # so a static key caches once and restores forever (bump -vN to refresh).
+        # cognee memory tests (tests/memory/test_cognee_wrapper.py) embed via
+        # fastembed, which downloads qdrant/bge-small-en-v1.5-onnx-q (~64 MB)
+        # into FASTEMBED_CACHE_PATH on first use. That per-run download
+        # intermittently slow-fails (could-not-load-model-from-any-source) and
+        # gated unrelated PRs (#442, #445). The model id is fixed, so a static
+        # key caches once and restores forever (bump -vN to refresh).
         uses: actions/cache@v4
         with:
-          path: ~/.cache/huggingface
-          key: fastembed-bge-small-en-v1.5-v1
+          path: ${{ github.workspace }}/.fastembed-cache
+          key: fastembed-bge-small-en-v1.5-v2
       - name: Warm fastembed cache
-        # On a cache miss, download the model now with retries so a transient
-        # HF blip retries here instead of failing the whole test job. On a
-        # cache hit this is a ~2-3s load from disk. Best-effort: if all
-        # attempts fail, let pytest surface the error rather than masking it.
+        # On a cache miss, download the model now. fastembed already retries 3x
+        # internally; we wrap each attempt in `timeout` so a stalled connection
+        # is bounded (~6 min) and retried fresh rather than hanging. Best-effort:
+        # on total failure, let pytest surface the error rather than masking it.
         run: |
           for attempt in 1 2 3; do
-            python -c "from fastembed import TextEmbedding; TextEmbedding('BAAI/bge-small-en-v1.5'); print('fastembed model warmed')" && exit 0
-            echo "::warning::fastembed warm attempt $attempt failed; retrying in 15s"
-            sleep 15
+            timeout 360 python -c "from fastembed import TextEmbedding; TextEmbedding('BAAI/bge-small-en-v1.5'); print('fastembed model warmed')" && exit 0
+            echo "::warning::fastembed warm attempt $attempt failed/timed out; retrying in 10s"
+            sleep 10
           done
           echo "::warning::fastembed warm-up failed after 3 attempts; cognee tests will surface it"
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,29 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
       - name: Install
         run: pip install -e ".[dev]"
+      - name: Cache fastembed embedding model
+        # The cognee memory tests (tests/memory/test_cognee_wrapper.py) embed
+        # via fastembed -> BAAI/bge-small-en-v1.5 (~70 MB ONNX), fetched into
+        # ~/.cache/huggingface on first use. Caching it removes the per-run HF
+        # download that intermittently fails (could-not-load-model from any
+        # source) and gated unrelated PRs (#442, #445). The model id is fixed,
+        # so a static key caches once and restores forever (bump -vN to refresh).
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: fastembed-bge-small-en-v1.5-v1
+      - name: Warm fastembed cache
+        # On a cache miss, download the model now with retries so a transient
+        # HF blip retries here instead of failing the whole test job. On a
+        # cache hit this is a ~2-3s load from disk. Best-effort: if all
+        # attempts fail, let pytest surface the error rather than masking it.
+        run: |
+          for attempt in 1 2 3; do
+            python -c "from fastembed import TextEmbedding; TextEmbedding('BAAI/bge-small-en-v1.5'); print('fastembed model warmed')" && exit 0
+            echo "::warning::fastembed warm attempt $attempt failed; retrying in 15s"
+            sleep 15
+          done
+          echo "::warning::fastembed warm-up failed after 3 attempts; cognee tests will surface it"
       - name: Lint
         run: ruff check src tests
       - name: Format check


### PR DESCRIPTION
## Problem

`tests/memory/test_cognee_wrapper.py` embeds via **fastembed → BAAI/bge-small-en-v1.5**
(~70 MB ONNX), downloaded into `~/.cache/huggingface` on first use. The `python (3.12)`
runner intermittently fails that download —

```
ValueError: Could not load model BAAI/bge-small-en-v1.5 from any source.
```

— hanging ~12 min before failing all 9 cognee tests. This gated **unrelated** PRs
(#442, #445) even though `python (3.11)` passed the identical suite every time. It
took a manual job re-run to clear each time.

## Fix

In the `python` job, before pytest:

- **`actions/cache@v4`** on `~/.cache/huggingface`. The model id is fixed, so a static
  key (`fastembed-bge-small-en-v1.5-v1`) caches once and restores forever (bump `-vN`
  to refresh).
- **A best-effort warm step** that downloads the model with 3 retries + 15s backoff on
  a cache miss, so a transient HF blip retries *here* instead of failing the whole test
  job. On a cache hit it's a ~2–3s disk load.

Best-effort by design: if all 3 attempts fail, pytest still runs and surfaces the real
error rather than masking it.

## Verification

CI on this PR exercises the new steps. Expect: first run downloads + populates the
cache (warm step logs `fastembed model warmed`); subsequent runs restore from cache with
no network fetch. The flaky-download window is removed from the hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
