### PR TITLE
fix(dashboard): live Hardware cards + dedupe memory map

### DIFF
--- a/src/hal0/memory/cognee_wrapper.py
+++ b/src/hal0/memory/cognee_wrapper.py
@@ -953,8 +953,17 @@ class CogneeWrapper:
                 # against a leaked id being used to reach into a different
                 # client's private namespace. (v0.2 single-user => moot
                 # in practice, but the check is cheap + Phase-9-ready.)
+                #
+                # Scope the check to the ROW's own dataset — not a
+                # hardcoded ``shared``. Passing ``SHARED_DATASET`` made the
+                # allowed set always ``[shared, private:<client>]``, so an
+                # id in a custom dataset (e.g. ADR-0011 ``agents``) could
+                # never match and was silently skipped — leaking one Hermes
+                # identity card per bootstrap (Peer-memory stale-card flood).
+                # ``_allowed_read_datasets`` still drops *another* client's
+                # ``private:*``, so the cross-client guard is preserved.
                 if row["dataset"] not in self._allowed_read_datasets(
-                    SHARED_DATASET, client_id=client_id
+                    row["dataset"], client_id=client_id
                 ):
                     continue
                 if row["cognee_data_id"] and row["cognee_dataset_id"]:

--- a/tests/memory/test_cognee_wrapper.py
+++ b/tests/memory/test_cognee_wrapper.py
@@ -188,6 +188,46 @@ async def test_delete_single_id_decrements_list(make_wrapper):
     _ = a  # silence linter; the test only needs id references on b
 
 
+async def test_delete_custom_dataset_item_by_owner(make_wrapper):
+    """Deleting an own item in a CUSTOM dataset (e.g. ADR-0011 ``agents``)
+    actually removes it.
+
+    Regression for the Peer-memory stale-card flood: the delete guard
+    hardcoded the allowed-read set to ``shared`` + own-private, so any id
+    whose row lived in a custom dataset (``agents``) was silently skipped,
+    ``deleted`` stayed 0, and Hermes bootstrap's "delete-then-rewrite"
+    dedup leaked one identity card per run.
+    """
+    w = make_wrapper(client_id="hermes-agent")
+    card = await w.add("identity card", dataset="agents", tags=["agent-identity"])
+
+    res = await w.delete(ids=[card["id"]])
+    assert res == {"deleted": 1}
+
+    remaining = await w.search(
+        query="identity card", dataset="agents", tags=["agent-identity"], limit=10
+    )
+    assert remaining == []
+
+
+async def test_delete_does_not_reach_other_clients_private(make_wrapper):
+    """The dataset guard still blocks deleting another client's private item.
+
+    Tightening the guard to honor custom datasets must NOT regress the
+    cross-client private protection it was written for.
+    """
+    alice = make_wrapper(client_id="alice", private_mode=True)
+    secret = await alice.add("alice secret")  # lands in private:alice
+
+    bob = make_wrapper(client_id="bob", private_mode=False)
+    res = await bob.delete(ids=[secret["id"]])
+    assert res == {"deleted": 0}
+
+    # Still there for the owner.
+    still = await alice.search(query="alice secret", limit=10)
+    assert any(h["text"] == "alice secret" for h in still)
+
+
 async def test_list_items_pagination(make_wrapper):
     """Cursor-based pagination walks the dataset in timestamp DESC order."""
     w = make_wrapper()


### PR DESCRIPTION
## What
The `/dashboard` Hardware section rendered a mix of live and **hardcoded** values. This wires every card to live data and removes the duplicate memory map.

### Before → After
| Field | Was | Now |
|---|---|---|
| hostname / uptime | empty | live from probe |
| kernel | baked `6.17.13-11-pve` | live `kernel` field |
| distro / boot id | baked / fake | live distro / removed |
| GPU stack | baked `ROCm 6.4 ✓` | live `compute_capable`/`vulkan_capable` |
| NPU loaded trio + FLM ver | static | live NPU-slot model ids |
| Memory "3 models loaded" + bar widths | hardcoded | live count + per-slot attribution |
| memory maps | **two** | **one** sidebar + live Memory card |

## Changes
- **Backend:** add `hostname`/`uptime_s`/`kernel`/`distro` to `HardwareProbe` + `HardwareInfo` (flat `/api/hardware` already spreads them). TDD'd.
- **Frontend:** `HardwareSection` reads `/api/hardware` + `/api/stats/hardware` + `useMemoryMapModel`; unsourceable fields render `—`. Removed expanded `HardwareMemorySection`; hero/empty-state use live host. `HAL0_DATA` seed + e2e mock reshaped to the flat shape.
- **Tests:** probe unit tests; `hardware-v3` e2e asserts live wiring + guards old strings; retired dashboard-mounted `Memory map — expanded` suite.

## Verification
- `pytest` hardware/config/hardware-routes → 269 passed
- full `playwright` γ-suite → 92 passed
- ruff clean

## ⚠️ Live deploy deferred
`/opt/hal0` on CT 105 is on `feat/hermes-home-normal-location-system-gateway` with active uncommitted work (another session) — I did not touch its tree. After merge, re-probe (`POST /api/hardware/probe`) — the deployed cache is ~12 days stale (kernel `7.0.0-8-pve`, `cpu_threads` undercounted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)