### PR TITLE
fix(dashboard): live Hardware cards + dedupe memory map

### DIFF
--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -589,6 +589,17 @@ class HardwareInfo(BaseModel):
 
     model_config = {"populate_by_name": True, "extra": "allow"}
 
+    hostname: str = Field(default="", description="Kernel hostname (/proc/sys/kernel/hostname).")
+    uptime_s: int = Field(
+        default=0, ge=0, description="Seconds since boot at probe time (/proc/uptime)."
+    )
+    kernel: str = Field(
+        default="", description="Kernel version string, e.g. 'Linux version 7.0.6-2-pve'."
+    )
+    distro: str = Field(
+        default="",
+        description="OS PRETTY_NAME from /etc/os-release, e.g. 'Debian GNU/Linux 13 (trixie)'.",
+    )
     cpu_model: str = Field(default="", description="CPU model string, e.g. 'AMD Ryzen 9 7950X'.")
     cpu_cores: int = Field(default=0, ge=0, description="Physical core count.")
     cpu_threads: int = Field(default=0, ge=0, description="Logical thread count.")

--- a/src/hal0/hardware/probe.py
+++ b/src/hal0/hardware/probe.py
@@ -182,6 +182,47 @@ def _parse_meminfo() -> tuple[int, int]:
     return total_kb // 1024, avail_kb // 1024
 
 
+def _read_hostname() -> str:
+    """Return the kernel hostname, or "" on failure.
+
+    Reads /proc/sys/kernel/hostname rather than calling socket.gethostname()
+    so the probe stays sysfs-driven and trivially mockable in tests. Inside
+    an LXC this reflects the container's own hostname, which is what the
+    dashboard should display.
+    """
+    txt = _read_text(Path("/proc/sys/kernel/hostname"))
+    return txt.strip() if txt else ""
+
+
+def _read_uptime_s() -> int:
+    """Return whole seconds since boot from /proc/uptime, 0 on failure.
+
+    /proc/uptime is "<uptime_seconds> <idle_seconds>"; we take the first
+    float and floor it. The UI formats this into "Nd HH:MM".
+    """
+    txt = _read_text(Path("/proc/uptime"))
+    if not txt:
+        return 0
+    with contextlib.suppress(IndexError, ValueError):
+        return int(float(txt.split()[0]))
+    return 0
+
+
+def _read_distro() -> str:
+    """Return PRETTY_NAME from /etc/os-release, or "" on failure."""
+    txt = _read_text(Path("/etc/os-release"))
+    if not txt:
+        return ""
+    for line in txt.splitlines():
+        if line.startswith("PRETTY_NAME="):
+            value = line.partition("=")[2].strip()
+            # PRETTY_NAME is shell-quoted: strip a single layer of quotes.
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1]
+            return value
+    return ""
+
+
 _SIZE_UNITS_MB = {"KB": 1 / 1024, "MB": 1, "GB": 1024, "TB": 1024 * 1024}
 
 
@@ -626,6 +667,10 @@ class HardwareProbe:
             include_gpu = bool(gpu.vendor and gpu.vendor != "unknown") or bool(gpu.name)
 
             return HardwareInfo(
+                hostname=_read_hostname(),
+                uptime_s=_read_uptime_s(),
+                kernel=uname,
+                distro=_read_distro(),
                 cpu_model=cpu_model,
                 cpu_cores=cpu_cores,
                 cpu_threads=cpu_threads,
@@ -637,6 +682,8 @@ class HardwareProbe:
                 disk_free_mb=disk_mb,
                 platform=platform,
                 probed_at=_dt.datetime.now(_dt.UTC).isoformat(timespec="seconds"),
+                # kernel is now a first-class field; keep it in extra too for
+                # back-compat with any consumer still reading extra.kernel.
                 extra={"kernel": uname} if uname else {},
             )
         except Exception as exc:

--- a/tests/hardware/test_probe.py
+++ b/tests/hardware/test_probe.py
@@ -84,6 +84,61 @@ def test_parse_meminfo_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     assert probe_mod._parse_meminfo() == (0, 0)
 
 
+# ── host identity (hostname / uptime / kernel / distro) ─────────────────────────
+
+
+def test_read_hostname(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        probe_mod,
+        "_read_text",
+        lambda p: "hal0\n" if str(p) == "/proc/sys/kernel/hostname" else None,
+    )
+    assert probe_mod._read_hostname() == "hal0"
+
+
+def test_read_hostname_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(probe_mod, "_read_text", lambda _: None)
+    assert probe_mod._read_hostname() == ""
+
+
+def test_read_uptime_s(monkeypatch: pytest.MonkeyPatch) -> None:
+    # /proc/uptime: "<uptime_seconds> <idle_seconds>"
+    monkeypatch.setattr(
+        probe_mod,
+        "_read_text",
+        lambda p: "123456.78 987654.32\n" if str(p) == "/proc/uptime" else None,
+    )
+    assert probe_mod._read_uptime_s() == 123456
+
+
+def test_read_uptime_s_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(probe_mod, "_read_text", lambda _: None)
+    assert probe_mod._read_uptime_s() == 0
+
+
+_OS_RELEASE_SAMPLE = """\
+NAME="Debian GNU/Linux"
+VERSION_ID="13"
+VERSION="13 (trixie)"
+PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
+ID=debian
+"""
+
+
+def test_read_distro(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        probe_mod,
+        "_read_text",
+        lambda p: _OS_RELEASE_SAMPLE if str(p) == "/etc/os-release" else None,
+    )
+    assert probe_mod._read_distro() == "Debian GNU/Linux 13 (trixie)"
+
+
+def test_read_distro_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(probe_mod, "_read_text", lambda _: None)
+    assert probe_mod._read_distro() == ""
+
+
 # ── GPU detection ──────────────────────────────────────────────────────────────
 
 
@@ -290,7 +345,20 @@ def test_probe_assembles_hardware_info(monkeypatch: pytest.MonkeyPatch, tmp_path
         lambda: probe_mod.NPUInfo(present=False),
     )
     monkeypatch.setattr(probe_mod, "_disk_free_mb", lambda _: 512000)
-    monkeypatch.setattr(probe_mod, "_read_text", lambda _: None)
+
+    def fake_read_text(path: Path) -> str | None:
+        s = str(path)
+        if s == "/proc/version":
+            return "Linux version 7.0.6-2-pve (build@host) #1 SMP\n"
+        if s == "/proc/sys/kernel/hostname":
+            return "hal0\n"
+        if s == "/proc/uptime":
+            return "4242.0 9000.0\n"
+        if s == "/etc/os-release":
+            return _OS_RELEASE_SAMPLE
+        return None
+
+    monkeypatch.setattr(probe_mod, "_read_text", fake_read_text)
 
     info = HardwareProbe().probe()
     assert isinstance(info, HardwareInfo)
@@ -305,6 +373,11 @@ def test_probe_assembles_hardware_info(monkeypatch: pytest.MonkeyPatch, tmp_path
     assert info.npu.present is False
     assert info.disk_free_mb == 512000
     assert info.probed_at  # ISO-8601 timestamp populated
+    # Host identity (added for the dashboard hardware cards).
+    assert info.hostname == "hal0"
+    assert info.uptime_s == 4242
+    assert info.kernel == "Linux version 7.0.6-2-pve"
+    assert info.distro == "Debian GNU/Linux 13 (trixie)"
 
 
 _DMIDECODE_SAMPLE = """\

--- a/ui/src/api/hooks/useHardware.ts
+++ b/ui/src/api/hooks/useHardware.ts
@@ -11,41 +11,90 @@ import { ENDPOINTS } from '../endpoints'
 export interface Hardware {
   name: string
   uptime: string
+  kernel: string
+  distro: string
+  platformLabel: string
   cpu: string
   cores: string
   gpu: string
+  gpuVendor: string
+  computeCapable: boolean
+  vulkanCapable: boolean
   ram: { total: number; used: number; free: number }
-  npu?: { present: boolean; columns?: number; ctx?: number }
+  unifiedMb: number
+  gttTotalMb: number
+  npu: {
+    present: boolean
+    vendor: string
+    name: string
+    driver: string
+    columns: number
+    ctx: number
+  }
+}
+
+// Format whole seconds-since-boot into "Nd HH:MM" (matching the old
+// display string). Returns '' for 0 / missing so the row renders "—".
+function formatUptime(seconds: number): string {
+  if (!seconds || seconds <= 0) return ''
+  const d = Math.floor(seconds / 86400)
+  const h = Math.floor((seconds % 86400) / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const hh = String(h).padStart(2, '0')
+  const mm = String(m).padStart(2, '0')
+  return d > 0 ? `${d}d ${hh}:${mm}` : `${hh}:${mm}`
+}
+
+// Strip the leading "Linux version " the probe keeps for /proc/version
+// parity, so the card shows just "7.0.6-2-pve".
+function shortKernel(kernel: string): string {
+  return (kernel || '').replace(/^Linux version\s+/i, '').trim()
 }
 
 // Backend /api/hardware returns a flat shape (cpu_model, ram_mb, gpu_name,
-// npu.{present}, …). HardwareView dereferences nested fields like
-// H.ram.total, H.npu.columns directly — passing the raw response makes
-// the page crash with "Cannot read properties of undefined". Normalize
-// into the v3 component shape, falling back to neutral defaults for
-// fields the backend doesn't surface (columns/ctx, hostname, uptime).
+// npu.{present}, hostname, uptime_s, kernel, distro, …). The Hardware view
+// dereferences nested fields like H.ram.total directly — passing the raw
+// response makes the page crash with "Cannot read properties of undefined".
+// Normalize into the v3 component shape, falling back to neutral defaults
+// (and the legacy display-shape keys, for the e2e mock / HAL0_DATA seed)
+// for fields a given backend doesn't surface.
 function normalizeHardware(raw: any): Hardware {
-  const ramTotalMb = Number(raw?.ram_mb ?? raw?.ram_total_mb ?? 0)
+  const ramTotalMb = Number(raw?.ram_total_mb ?? raw?.ram_mb ?? 0)
   const ramFreeMb = Number(raw?.ram_available_mb ?? 0)
   const ramUsedMb = Math.max(0, ramTotalMb - ramFreeMb)
   const mbToGb = (mb: number) => Math.round((mb / 1024) * 10) / 10
   const cores = Number(raw?.cpu_cores ?? 0)
   const threads = Number(raw?.cpu_threads ?? cores)
+  const gpu0 = raw?.gpus?.[0] ?? {}
+  const npu = raw?.npu ?? {}
+  // Legacy display-shape (e2e mock-data + HAL0_DATA seed expose ram:{}).
+  const ram = raw?.ram ?? {}
   return {
     name: raw?.hostname ?? raw?.name ?? raw?.extra?.hostname ?? '',
-    uptime: raw?.uptime ?? '',
+    uptime: raw?.uptime ?? formatUptime(Number(raw?.uptime_s ?? 0)),
+    kernel: shortKernel(raw?.kernel ?? raw?.extra?.kernel ?? ''),
+    distro: raw?.distro ?? '',
+    platformLabel: raw?.platform_label ?? raw?.platform ?? '',
     cpu: raw?.cpu_model ?? raw?.cpu_name ?? raw?.cpu ?? '',
-    cores: cores ? `${cores}c · ${threads}t` : '',
-    gpu: raw?.gpu_name ?? raw?.gpus?.[0]?.name ?? raw?.gpu ?? '',
+    cores: cores ? `${cores}c · ${threads}t` : (raw?.cores ?? ''),
+    gpu: raw?.gpu_name ?? gpu0?.name ?? raw?.gpu ?? '',
+    gpuVendor: raw?.gpu_vendor ?? gpu0?.vendor ?? '',
+    computeCapable: !!gpu0?.compute_capable,
+    vulkanCapable: !!gpu0?.vulkan_capable,
     ram: {
-      total: mbToGb(ramTotalMb),
-      used: mbToGb(ramUsedMb),
-      free: mbToGb(ramFreeMb),
+      total: ramTotalMb ? mbToGb(ramTotalMb) : Number(ram?.total ?? 0),
+      used: ramTotalMb ? mbToGb(ramUsedMb) : Number(ram?.used ?? 0),
+      free: ramTotalMb ? mbToGb(ramFreeMb) : Number(ram?.free ?? 0),
     },
+    unifiedMb: Number(raw?.unified_memory_mb ?? 0),
+    gttTotalMb: Number(raw?.gtt_total_mb ?? 0),
     npu: {
-      present: !!(raw?.npu?.present ?? raw?.npu_present),
-      columns: Number(raw?.npu?.columns ?? 0),
-      ctx: Number(raw?.npu?.ctx ?? 0),
+      present: !!(npu?.present ?? raw?.npu_present),
+      vendor: npu?.vendor ?? '',
+      name: npu?.name ?? raw?.npu_name ?? '',
+      driver: npu?.driver ?? '',
+      columns: Number(npu?.columns ?? 0),
+      ctx: Number(npu?.ctx ?? 0),
     },
   }
 }

--- a/ui/src/dash/dashboard.jsx
+++ b/ui/src/dash/dashboard.jsx
@@ -12,7 +12,8 @@
 import { useSlots } from '@/api/hooks/useSlots'
 import { useLemondRollup } from '@/api/hooks/useLemonade'
 import { useHardware } from '@/api/hooks/useHardware'
-import { MemoryMap } from './memory-map'
+import { useStatsHardware } from '@/api/hooks/useStatsHardware'
+import { MemoryMap, useMemoryMapModel } from './memory-map'
 
 const { useState: useStateD, useRef: useRefD, useEffect: useEffectD } = React;
 
@@ -145,81 +146,168 @@ function ThroughputCard() {
 // Inherited from extras.jsx HardwareView when the standalone #hardware
 // route was retired. The card primitives stay file-local — nothing else
 // in the codebase rendered HwCard / HwRow.
+//
+// All five cards read LIVE data: the static probe (useHardware →
+// /api/hardware) drives host/cpu/gpu/npu identity; the live counters
+// (useStatsHardware → /api/stats/hardware, 2.5s) + per-slot attribution
+// (useMemoryMapModel) drive the Memory card. No hardcoded versions,
+// kernel strings, "currently loaded" trios, or fixed bar widths remain —
+// fields a probe can't source render as "—" rather than a fabricated
+// value.
+
+// Render "—" for empty / missing fields rather than a blank cell, so a
+// gap reads as "not reported" instead of a broken layout.
+function val(v) {
+  if (v == null) return "—";
+  if (typeof v === "string") return v.trim() === "" ? "—" : v;
+  if (typeof v === "number") return v === 0 ? "—" : v;
+  return v;
+}
+
+// Device → segment colour, mirroring memory-map.jsx's file-local map so
+// the Memory card's per-slot bar matches the (sidebar) memory map.
+const DEVICE_COLOR = {
+  npu: "var(--dev-npu)",
+  cpu: "var(--dev-cpu)",
+  vulkan: "var(--dev-vulkan)",
+  rocm: "var(--dev-rocm)",
+};
+function deviceColor(d) {
+  return DEVICE_COLOR[d] || "var(--dev-rocm)";
+}
+
 function HardwareSection() {
   const hwQuery = useHardware();
-  const H = hwQuery.data || HAL0_DATA.host;
+  const H = hwQuery.data;
+  const stats = useStatsHardware();
+  const mem = useMemoryMapModel();
+  const slotsQuery = useSlots();
+  const liveSlots = (slotsQuery.data || []).filter(
+    (s) => ["ready", "serving", "idle", "warming"].includes((s.state || "").toLowerCase()),
+  );
+
+  // Loaded-model count comes from live slots, not a hardcoded "3".
+  const loadedCount = liveSlots.length;
+
+  // NPU "currently loaded" = live model ids on NPU-device slots. Empty
+  // when nothing is loaded (the common idle state) — no static trio.
+  const npuModels = liveSlots
+    .filter((s) => (s.device || "").toLowerCase() === "npu")
+    .map((s) => s.model)
+    .filter(Boolean);
+
+  // Memory: prefer live stats (2.5s) for system RAM; fall back to the
+  // probe snapshot. Pool total + per-slot model attribution come from
+  // the shared memory-map model so this card and the map never disagree.
+  const round1 = (n) => Math.round(n * 10) / 10;
+  const mbToGb = (mb) => round1((mb || 0) / 1024);
+  // Total = system RAM (what the box reports it has), not the GTT pool —
+  // matches the "system RAM" framing of the card. mem.pool is the GPU
+  // GTT ceiling, which is a different (and confusingly larger) number.
+  const ramTotalGb = (H ? H.ram.total : 0) || mem.pool.totalGb;
+  const ramUsedGb = stats.data?.ram_used_mb != null ? mbToGb(stats.data.ram_used_mb) : (H ? H.ram.used : 0);
+  const ramFreeGb = stats.data?.ram_available_mb != null
+    ? mbToGb(stats.data.ram_available_mb)
+    : (H ? H.ram.free : Math.max(0, round1(ramTotalGb - ramUsedGb)));
+  const modelUsedGb = mem.self.modelUsedGb || 0;
+  const memSlots = (mem.self.slots || []).filter((s) => s.bytesGb > 0);
+
+  // GPU vendor-stack chips reflect the PROBE's capability flags, not a
+  // baked-in "ROCm 6.4 ✓". Vulkan is the bundled default backend.
+  const stackChips = H ? (
+    <>
+      <span className={"chip " + (H.computeCapable ? "ok" : "")}>
+        ROCm {H.computeCapable ? "✓" : "—"}
+      </span>{" "}
+      <span className={"chip " + (H.vulkanCapable ? "ok" : "")}>
+        Vulkan {H.vulkanCapable ? "✓" : "—"}
+      </span>
+    </>
+  ) : "—";
+  const gpuRecommend = H && H.vulkanCapable
+    ? <span className="chip ok">llamacpp:vulkan</span>
+    : H && H.computeCapable
+      ? <span className="chip ok">llamacpp:rocm</span>
+      : <span className="chip">llamacpp:cpu</span>;
+
   return (
     <div className="hw-section">
       <div className="vh" style={{marginBottom: 12}}>
         <span className="vh-eye mono">System</span>
         <h2 style={{margin: 0, fontSize: 18, fontWeight: 500, letterSpacing: "-0.02em"}}>Hardware</h2>
         <span className="vh-spacer" />
-        <span className="hint mono">read-only · sourced from /v1/system-info</span>
+        <span className="hint mono">read-only · live from /api/hardware + /api/stats/hardware</span>
       </div>
 
       <div style={{display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16}}>
         <HwCard title="Host" eyebrow="machine">
-          <HwRow k="hostname" v={H.name} />
-          <HwRow k="kernel" v="Linux 6.17.13-11-pve" />
-          <HwRow k="distro" v="Debian 13 (trixie)" />
-          <HwRow k="uptime" v={H.uptime} />
-          <HwRow k="boot id" v="b3f1a9e2-…-4c81" mono />
+          <HwRow k="hostname" v={val(H?.name)} />
+          <HwRow k="platform" v={val(H?.platformLabel)} />
+          <HwRow k="kernel" v={val(H?.kernel)} mono />
+          <HwRow k="distro" v={val(H?.distro)} />
+          <HwRow k="uptime" v={val(H?.uptime)} />
         </HwCard>
 
-        <HwCard title="CPU" eyebrow="x86-64">
-          <HwRow k="model" v={H.cpu} />
-          <HwRow k="cores" v={`${H.cores}`} />
-          <HwRow k="clock" v="3.0 GHz base · 5.1 GHz boost" />
-          <HwRow k="cache" v="L3 · 64 MB" />
-          <HwRow k="recommended" v={<span className="chip ok">llamacpp:cpu</span>} />
+        <HwCard title="CPU" eyebrow="processor">
+          <HwRow k="model" v={val(H?.cpu)} />
+          <HwRow k="cores" v={val(H?.cores)} />
+          <HwRow k="vendor" v={val(H?.gpuVendor ? H.gpuVendor.toUpperCase() : "")} />
         </HwCard>
 
         <HwCard title="GPU" eyebrow="iGPU · unified memory" full>
-          <HwRow k="device" v="AMD Radeon Graphics (gfx1151, Strix Halo)" />
-          <HwRow k="vendor stack" v={<>ROCm <span style={{color: "var(--ok)"}}>6.4 ✓</span> · Vulkan <span style={{color: "var(--ok)"}}>present</span></>} />
-          <HwRow k="vram model" v="unified · shares system RAM (128 GB)" />
-          <HwRow k="recommended" v={<><span className="chip ok">llamacpp:rocm</span> <span className="chip ok">sdcpp:rocm</span></>} />
-          <HwRow k="fallback" v={<span className="chip">llamacpp:vulkan</span>} sub="if ROCm fails to load a model" />
+          <HwRow k="device" v={val(H?.gpu)} />
+          <HwRow k="vendor stack" v={stackChips} />
+          <HwRow
+            k="vram model"
+            v={H?.gttTotalMb ? <>unified · GTT pool {mbToGb(H.gttTotalMb)} GB</> : "unified · shares system RAM"}
+          />
+          <HwRow k="recommended" v={gpuRecommend} />
         </HwCard>
 
-        <HwCard title="NPU" eyebrow="XDNA2 · coresident trio" full purple>
-          <HwRow k="device" v="AMDXDNA2" />
-          <HwRow k="topology" v={`${H.npu.columns} columns · ${H.npu.ctx} hardware context`} />
-          <HwRow k="runtime" v={<><b>FLM v0.9.42</b> · trio mode (--asr 1 --embed 1)</>} />
-          <HwRow k="currently loaded" v="gemma3:1b · whisper-v3-turbo · embed-gemma-300m" mono />
-          <HwRow k="recommended" v={<span className="chip" style={{color: "var(--dev-npu)", borderColor: "rgba(200,150,255,0.30)", background: "rgba(200,150,255,0.06)"}}>flm:npu</span>} />
+        <HwCard title="NPU" eyebrow="XDNA" full purple>
+          <HwRow k="present" v={H ? (H.npu.present ? "yes" : "no") : "—"} />
+          <HwRow k="device" v={val(H?.npu.name)} />
+          <HwRow k="driver" v={val(H?.npu.driver)} mono />
+          {(H?.npu.columns || H?.npu.ctx) ? (
+            <HwRow k="topology" v={`${H.npu.columns} columns · ${H.npu.ctx} hardware context`} />
+          ) : null}
+          <HwRow
+            k="currently loaded"
+            v={npuModels.length ? npuModels.join(" · ") : "none loaded"}
+            mono
+          />
         </HwCard>
 
         <HwCard title="Memory" eyebrow="unified" full>
-          <HwRow k="total" v={<><span className="num">{H.ram.total}</span> GB</>} />
-          <HwRow k="used" v={<><span className="num">{H.ram.used}</span> GB · 3 models loaded</>} />
-          <HwRow k="free" v={<><span className="num" style={{color: "var(--ok)"}}>{H.ram.free}</span> GB</>} />
-          <HwRow k="per-type budget" v="4 loaded models" />
+          <HwRow k="pool total" v={<><span className="num">{val(round1(ramTotalGb))}</span> GB</>} />
+          <HwRow
+            k="system RAM"
+            v={<><span className="num">{round1(ramUsedGb)}</span> GB used · <span className="num" style={{color: "var(--ok)"}}>{round1(ramFreeGb)}</span> GB free</>}
+          />
+          <HwRow
+            k="model memory"
+            v={<><span className="num">{round1(modelUsedGb)}</span> GB · {loadedCount} {loadedCount === 1 ? "model" : "models"} loaded</>}
+          />
           <div style={{padding: "10px 18px", borderTop: "1px solid var(--line-soft)"}}>
             <div style={{display: "flex", height: 6, borderRadius: 1, overflow: "hidden", background: "var(--bg-3)"}}>
-              <div style={{width: `${(18.8 / H.ram.total) * 100}%`, background: "var(--dev-rocm)"}} />
-              <div style={{width: `${(1.0 / H.ram.total) * 100}%`, background: "var(--dev-npu)"}} />
-              <div style={{width: `${(0.35 / H.ram.total) * 100}%`, background: "var(--dev-rocm)", opacity: 0.6}} />
-              <div style={{width: `${(0.4 / H.ram.total) * 100}%`, background: "var(--dev-cpu)"}} />
-              <div style={{width: `${(33.45 / H.ram.total) * 100}%`, background: "var(--bg-4)"}} />
+              {memSlots.map((s) => (
+                <div
+                  key={s.name}
+                  title={`${s.name} · ${round1(s.bytesGb)} GB`}
+                  style={{width: `${(s.bytesGb / (ramTotalGb || 1)) * 100}%`, background: deviceColor(s.device)}}
+                />
+              ))}
+              <div style={{width: `${Math.max(0, 100 - (modelUsedGb / (ramTotalGb || 1)) * 100)}%`, background: "var(--bg-4)"}} />
             </div>
             <div className="mono" style={{display: "flex", justifyContent: "space-between", fontSize: 10, color: "var(--fg-4)", marginTop: 6}}>
-              <span>primary · agent · embed · tts · free</span>
-              <span>{H.ram.used} / {H.ram.total} GB</span>
+              <span>{memSlots.length ? memSlots.map((s) => s.name).join(" · ") + " · free" : "no models loaded"}</span>
+              <span>{round1(modelUsedGb)} / {round1(ramTotalGb)} GB</span>
             </div>
           </div>
         </HwCard>
 
       </div>
     </div>
-  );
-}
-
-function HardwareMemorySection() {
-  return (
-    <section className="hardware-mem">
-      <MemoryMap variant="expanded" />
-    </section>
   );
 }
 
@@ -265,6 +353,9 @@ function DashboardView({ slots: _slotsProp, onGo, showHero, onDismissHero }) {
   // either the real list or a confirmed-empty state.
   const slots = slotsQuery.data || [];
   const lemond = useLemondRollup();
+  const hw = useHardware();
+  // Live host identity for the hero + empty-state (was HAL0_DATA seed).
+  const hostName = hw.data?.name || HAL0_DATA.host.name;
   const slotsLoading = slotsQuery.isLoading && !slotsQuery.data;
   // Real zero-slots detection: only when /api/slots has resolved to a
   // confirmed empty array. Still-loading (undefined) shows the skeleton.
@@ -277,7 +368,6 @@ function DashboardView({ slots: _slotsProp, onGo, showHero, onDismissHero }) {
         <div className="dash">
           <div className="dash-main">
             <HardwareSection />
-            <HardwareMemorySection />
           </div>
           <div className="dash-side">
             <div className="snap" aria-busy="true">
@@ -302,11 +392,10 @@ function DashboardView({ slots: _slotsProp, onGo, showHero, onDismissHero }) {
           <h1 className="mono">No models configured yet</h1>
           <p>hal0 is ready, but no slot has a model loaded. Pick a bundle to get going, or configure slots one at a time.</p>
           <div className="dash-empty-meta mono">
-            <span><span style={{color: "var(--fg-3)"}}>host</span> {HAL0_DATA.host.name}</span>
+            <span><span style={{color: "var(--fg-3)"}}>host</span> {hostName}</span>
             <span style={{color: "var(--fg-5)"}}>·</span>
-            <span><span style={{color: "var(--fg-3)"}}>ram</span> {HAL0_DATA.host.ram.total} GB</span>
-            <span style={{color: "var(--fg-5)"}}>·</span>
-            <span><span style={{color: "var(--fg-3)"}}>npu</span> ready</span>
+            <span><span style={{color: "var(--fg-3)"}}>ram</span> {hw.data?.ram.total || HAL0_DATA.host.ram.total} GB</span>
+            {hw.data?.npu.present && <><span style={{color: "var(--fg-5)"}}>·</span><span><span style={{color: "var(--fg-3)"}}>npu</span> ready</span></>}
           </div>
           <div className="dash-empty-cta">
             <button className="btn lg" onClick={() => window.location.hash = "#firstrun"}>Pick a bundle</button>
@@ -325,7 +414,7 @@ function DashboardView({ slots: _slotsProp, onGo, showHero, onDismissHero }) {
             <span className="dim">Welcome back, </span>
             <b>halo</b>
             <span className="dim">. system steady on </span>
-            <span className="mono" style={{color: "var(--fg-2)"}}>{HAL0_DATA.host.name}</span>
+            <span className="mono" style={{color: "var(--fg-2)"}}>{hostName}</span>
           </div>
           <div className="spacer" />
           <span className="mono" style={{fontSize: 10, color: "var(--fg-4)"}}>steady · {slots.filter(s => s.state !== "empty").length} slots up · lemond {lemond.status}</span>
@@ -336,7 +425,6 @@ function DashboardView({ slots: _slotsProp, onGo, showHero, onDismissHero }) {
       <div className="dash">
         <div className="dash-main">
           <HardwareSection />
-          <HardwareMemorySection />
         </div>
         <div className="dash-side">
           <SnapshotStrip slots={slots} onGo={onGo} />
@@ -349,4 +437,4 @@ function DashboardView({ slots: _slotsProp, onGo, showHero, onDismissHero }) {
   );
 }
 
-Object.assign(window, { DashboardView, SnapshotStrip, HealthCard, ThroughputCard, HardwareSection, HardwareMemorySection });
+Object.assign(window, { DashboardView, SnapshotStrip, HealthCard, ThroughputCard, HardwareSection });

--- a/ui/src/dash/data.jsx
+++ b/ui/src/dash/data.jsx
@@ -2,14 +2,48 @@
 // Sourced from the brief's wireframes + model strings from registry references.
 
 const HAL0_DATA = {
+  // Flat /api/hardware response shape (mirrors hal0.api.routes.hardware
+  // _flatten_for_ui). useHardware.normalizeHardware reads these flat keys;
+  // the legacy display keys (name/uptime/cpu/cores/gpu/ram) are kept so
+  // direct HAL0_DATA.host.* readers (chrome.jsx, mcp-main.jsx, flow-modals,
+  // firstrun) keep working without a hook.
   host: {
-    name: "halo-strix.local",
+    hostname: "hal0",
+    uptime_s: 1_216_771, // → "14d 02:00"
+    kernel: "Linux version 7.0.6-2-pve",
+    distro: "Debian GNU/Linux 13 (trixie)",
+    platform: "lxc",
+    platform_label: "Linux container (LXC)",
+    cpu_model: "AMD Ryzen AI Max+ PRO 395",
+    cpu_cores: 16,
+    cpu_threads: 32,
+    ram_mb: 131072,
+    ram_total_mb: 131072,
+    ram_available_mb: 75776,
+    unified_memory_mb: 131072,
+    gtt_total_mb: 81920,
+    gpu_name: "AMD Radeon 8060S (gfx1151, Strix Halo)",
+    gpu_vendor: "amd",
+    gpus: [
+      {
+        vendor: "amd",
+        name: "AMD Radeon 8060S (gfx1151, Strix Halo)",
+        vram_mb: 81920,
+        driver: "amdgpu",
+        compute_capable: true,
+        vulkan_capable: true,
+      },
+    ],
+    npu: { present: true, vendor: "amd", name: "AMD NPU (XDNA2)", driver: "amdxdna" },
+    npu_present: true,
+    npu_name: "AMD NPU (XDNA2)",
+    // Legacy display-shape keys (direct HAL0_DATA.host.* readers).
+    name: "hal0",
     uptime: "14d 02:11",
     cpu: "AMD Ryzen AI Max+ PRO 395",
     cores: "16c · 32t",
-    gpu: "Radeon Graphics (gfx1151, Strix Halo)",
+    gpu: "AMD Radeon 8060S (gfx1151, Strix Halo)",
     ram: { total: 128, free: 74, used: 54 }, // GB
-    npu: { present: true, columns: 8, ctx: 1 },
   },
 
   lemond: {

--- a/ui/tests/e2e/fixtures/mock-data.ts
+++ b/ui/tests/e2e/fixtures/mock-data.ts
@@ -17,14 +17,43 @@
  */
 
 export const MOCK_DATA = {
+  // Flat /api/hardware response shape (mirrors hal0.api.routes.hardware
+  // _flatten_for_ui). useHardware.normalizeHardware reads these flat keys;
+  // a few legacy display keys (name/ram) are kept as fallbacks for any
+  // consumer still reading the pre-B1 shape.
   host: {
-    name: 'halo-strix.local',
-    uptime: '14d 02:11',
-    cpu: 'AMD Ryzen AI Max+ PRO 395',
-    cores: '16c · 32t',
-    gpu: 'Radeon Graphics (gfx1151, Strix Halo)',
-    ram: { total: 128, free: 74, used: 54 },
-    npu: { present: true, columns: 8, ctx: 1 },
+    hostname: 'hal0',
+    uptime_s: 123_456, // → "1d 10:17"
+    kernel: 'Linux version 7.0.6-2-pve',
+    distro: 'Debian GNU/Linux 13 (trixie)',
+    platform: 'lxc',
+    platform_label: 'Linux container (LXC)',
+    cpu_model: 'AMD RYZEN AI MAX+ 395 w/ Radeon 8060S',
+    cpu_cores: 16,
+    cpu_threads: 16,
+    ram_mb: 96_000,
+    ram_total_mb: 96_000,
+    ram_available_mb: 94_577,
+    unified_memory_mb: 131_072,
+    gtt_total_mb: 107_520,
+    gpu_name: 'AMD Radeon 8060S (Strix Halo)',
+    gpu_vendor: 'amd',
+    gpus: [
+      {
+        vendor: 'amd',
+        name: 'AMD Radeon 8060S (Strix Halo)',
+        vram_mb: 107_520,
+        driver: 'amdgpu',
+        compute_capable: false,
+        vulkan_capable: true,
+      },
+    ],
+    npu: { present: true, vendor: 'amd', name: 'AMD NPU (XDNA)', driver: 'amdxdna' },
+    npu_present: true,
+    npu_name: 'AMD NPU (XDNA)',
+    // Legacy display-shape fallbacks (pre-B1 consumers).
+    name: 'hal0',
+    ram: { total: 93.8, free: 92.4, used: 1.4 },
   },
 
   lemond: {

--- a/ui/tests/e2e/specs/hardware-v3.spec.ts
+++ b/ui/tests/e2e/specs/hardware-v3.spec.ts
@@ -2,6 +2,11 @@
  * hardware-v3 — hardware spread (Host / CPU / GPU / NPU / Memory cards)
  * now lives inside the `#dashboard` view as `HardwareSection`. The
  * standalone `#hardware` route was retired in the chat-page overhaul.
+ *
+ * Every card reads live data (static probe /api/hardware + live counters
+ * /api/stats/hardware). These tests assert the live wiring and guard
+ * against the old hardcoded values (kernel string, "ROCm 6.4 ✓",
+ * "currently loaded" trio, "3 models loaded") creeping back.
  */
 import { test, expect } from '../fixtures/apiMock'
 
@@ -18,5 +23,50 @@ test.describe('Hardware section (on /dashboard)', () => {
     await page.goto('/#dashboard')
     await expect(page.locator('.hw-section .vh .vh-eye')).toHaveText('System')
     await expect(page.locator('.hw-section .vh .hint')).toContainText('read-only')
+  })
+
+  test('Host card shows live hostname / kernel / distro from /api/hardware', async ({ page }) => {
+    await page.goto('/#dashboard')
+    const section = page.locator('.hw-section')
+    await expect(section).toContainText('hal0')
+    await expect(section).toContainText('7.0.6-2-pve')
+    await expect(section).toContainText('Debian GNU/Linux 13 (trixie)')
+    // The leading "Linux version " noise is stripped.
+    await expect(section).not.toContainText('Linux version 7.0.6-2-pve')
+  })
+
+  test('GPU vendor stack reflects probe capability flags, not a baked version', async ({ page }) => {
+    await page.goto('/#dashboard')
+    const section = page.locator('.hw-section')
+    // The old hardcoded "ROCm 6.4 ✓" (a fabricated version) must be gone;
+    // the stack now shows live ✓/— flags from the probe capability bits.
+    await expect(section).not.toContainText('ROCm 6.4')
+    await expect(section).toContainText('Vulkan ✓')
+    await expect(section).toContainText('llamacpp:vulkan')
+  })
+
+  test('NPU card reads live device + slot models, not the static trio string', async ({ page }) => {
+    await page.goto('/#dashboard')
+    const section = page.locator('.hw-section')
+    // Device name comes from the probe; "currently loaded" comes from the
+    // live NPU-device slots (seed has gemma3:1b on the NPU). The old
+    // hardcoded FLM version string must not appear.
+    await expect(section).toContainText('AMD NPU (XDNA2)')
+    await expect(section).toContainText('currently loaded')
+    await expect(section).not.toContainText('FLM v0.9.42')
+  })
+
+  test('Memory card is the reworked live widget (pool/system/model rows), not the old static one', async ({ page }) => {
+    await page.goto('/#dashboard')
+    const memCard = page.locator('.hw-section .card', { hasText: 'pool total' })
+    // New live structure: separate pool total / system RAM / model memory
+    // rows + a dynamic "N models loaded" count derived from live slots.
+    await expect(memCard).toContainText('pool total')
+    await expect(memCard).toContainText('system RAM')
+    await expect(memCard).toContainText('model memory')
+    await expect(memCard).toContainText('models loaded')
+    // The old fabricated rows are gone.
+    await expect(memCard).not.toContainText('per-type budget')
+    await expect(memCard).not.toContainText('4 loaded models')
   })
 })

--- a/ui/tests/e2e/specs/memory-map-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-map-v3.spec.ts
@@ -141,43 +141,9 @@ test.describe('Memory map — sidebar', () => {
   })
 })
 
-test.describe('Memory map — expanded', () => {
-  test('expanded variant renders host pool + inside-LXC + legend', async ({ page }) => {
-    await mockStatsHardware(page, {
-      configured: true,
-      ok: true,
-      node: 'pve',
-      host_mem_total_mb: 131072,
-      host_mem_used_mb: 24576,
-      host_mem_free_mb: 106496,
-      tenants_running: 1,
-      tenants_total: 1,
-    })
-    await mockProxmoxSettings(page, {
-      configured: true,
-      ok: true,
-      node: 'pve',
-      host_mem_total_mb: 131072,
-      host_mem_used_mb: 24576,
-      host_mem_free_mb: 106496,
-      tenants_running: 1,
-      tenants_total: 1,
-      tenants: [
-        { vmid: 159, name: 'halodev', type: 'lxc', status: 'running', mem_mb: 3072, maxmem_mb: 8192 },
-      ],
-    })
-    await page.goto('/#dashboard')
-    const card = page.locator('.memmap-expanded')
-    await expect(card).toBeVisible()
-    // wave-1: expanded variant has TWO sections — primary "model memory"
-    // (vs the unified pool) and a separate ".memmap-host-section" for
-    // host/Proxmox pressure ("host pressure" / "free on host").
-    await expect(card).toContainText('model memory')
-    const hostSection = card.locator('.memmap-host-section')
-    await expect(hostSection).toBeVisible()
-    await expect(hostSection).toContainText('host pressure')
-    await expect(hostSection).toContainText('free on host')
-    // Tenant legend (excluding self) lists halodev.
-    await expect(hostSection).toContainText('halodev')
-  })
-})
+// NOTE: the `Memory map — expanded` variant (with its Proxmox host-pressure
+// + tenant-breakdown section) was removed from the /#dashboard layout — the
+// dashboard now carries a single memory map (the sticky sidebar) plus the
+// live Memory hardware card. The MemoryMap component still supports
+// `variant="expanded"`, but nothing mounts it on the dashboard, so the
+// former dashboard-scoped expanded suite was retired.


### PR DESCRIPTION
> **Recovery of the work that was on #450.** PR #450's branch was force-pushed out from under it by a parallel session and now carries only a duplicate of the already-merged #446 cognee fix. This PR is the original Hardware-cards work (commit recovered intact from the dangling object), re-based cleanly onto current `main`. #450 is being closed as a no-op dup.

## What
The `/dashboard` Hardware section rendered a mix of live and **hardcoded** values. This wires every card to live data and removes the duplicate memory map.

### Before → After
| Field | Was | Now |
|---|---|---|
| hostname / uptime | empty | live from probe |
| kernel | baked `6.17.13-11-pve` | live `kernel` field |
| distro / boot id | baked / fake | live distro / removed |
| GPU stack | baked `ROCm 6.4 ✓` | live `compute_capable`/`vulkan_capable` |
| NPU loaded trio + FLM ver | static | live NPU-slot model ids |
| Memory "3 models loaded" + bar widths | hardcoded | live count + per-slot attribution |
| memory maps | **two** | **one** sidebar + live Memory card |

## Changes
- **Backend:** add `hostname`/`uptime_s`/`kernel`/`distro` to `HardwareProbe` + `HardwareInfo` (flat `/api/hardware` already spreads them). TDD'd.
- **Frontend:** `HardwareSection` reads `/api/hardware` + `/api/stats/hardware` + `useMemoryMapModel`; unsourceable fields render `—`. Removed expanded `HardwareMemorySection`; hero/empty-state use live host. `HAL0_DATA` seed + e2e mock reshaped to the flat shape.
- **Tests:** probe unit tests; `hardware-v3` e2e asserts live wiring + guards old strings; retired the dashboard-mounted `Memory map — expanded` suite.

## Verification
- `pytest` hardware/config/hardware-routes → green (54 + 269 across runs)
- full `playwright` γ-suite → 92 passed
- ruff clean; UI builds clean

## ⚠️ Live deploy + re-probe still pending
After merge, re-probe the live cache (`POST /api/hardware/probe`) — the deployed snapshot is ~12 days stale (kernel `7.0.0-8-pve`, `cpu_threads` undercounted). CT 105 `/opt/hal0` is currently on another session's branch; deploy once it's clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)