### PR TITLE
feat(dashboard): state-aware SlotCard lifecycle buttons (Start/Stop/Restart)

### DIFF
--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -76,6 +76,7 @@ const Icons = {
   download:  <Icon d="M8 2v8M4 7l4 4 4-4M3 14h10"/>,
   restart:   <Icon><path d="M14 8a6 6 0 1 1-2-4.5"/><path d="M14 1v3.5h-3.5"/></Icon>,
   unload:    <Icon d="M3 11h10M5 8l3 3 3-3M8 11V2"/>,
+  start:     <Icon d="M5 3l8 5-8 5V3z"/>,
   edit:      <Icon d="M3 13l3-1 7-7-2-2-7 7-1 3z"/>,
   more:      <Icon><circle cx="3" cy="8" r="1" fill="currentColor" stroke="none"/><circle cx="8" cy="8" r="1" fill="currentColor" stroke="none"/><circle cx="13" cy="8" r="1" fill="currentColor" stroke="none"/></Icon>,
   cpu:       <Icon><rect x="4" y="4" width="8" height="8" rx="0.5"/><path d="M4 6h-1M4 10h-1M13 6h-1M13 10h-1M6 4v-1M10 4v-1M6 13v-1M10 13v-1"/><rect x="6.5" y="6.5" width="3" height="3"/></Icon>,

--- a/ui/src/dash/data.jsx
+++ b/ui/src/dash/data.jsx
@@ -190,6 +190,18 @@ const HAL0_DATA = {
       pid: 28518,
       metrics: { rpm: 2, avg: 4.1, res: "512×512", mem: 1.2 },
     },
+    {
+      name: "warming-demo",
+      type: "llm",
+      device: "gpu-rocm",
+      model: "qwen3-4b",
+      model_id: "qwen3-4b",
+      group: "chat",
+      state: "warming",
+      lemonade_state: "loading",
+      port: 8099,
+      metrics: { toks: 0, ttft: null, ctx: 8192, kv: null, mem: 4.0 },
+    },
   ],
 
   bundles: [

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -10,6 +10,7 @@ import {
   useSlots,
   useSlotRestart,
   useSlotUnload,
+  useSlotLoad,
   useSlotSwap,
 } from '@/api/hooks/useSlots'
 import { MemoryMap } from './memory-map'
@@ -203,6 +204,7 @@ function SlotCard({
   onOverflow,
   onRestart,
   onUnload,
+  onStart,
   onSwapPick,
   onViewLogs,
   onDelete,
@@ -214,6 +216,13 @@ function SlotCard({
   busy,
 }) {
   const { type, device, model, state, isDefault, coresident, cpuOnly, metrics } = slot;
+  // Lifecycle phase drives which action buttons render (design 2026-06-04):
+  // running (loaded/serving) -> Stop+Restart; off (not loaded) -> Start;
+  // transitional (warming/pulling/unloading) -> actions disabled.
+  const lemoState = String(slot?.lemonade_state || "");
+  const slotRunning = lemoState === "loaded" || lemoState === "ready" || state === "serving" || state === "ready";
+  const slotTransitional = state === "warming" || state === "starting" || state === "pulling" || state === "unloading";
+  const phase = slotTransitional ? "transitional" : slotRunning ? "running" : "off";
   const isLlm = type === "llm";
 
   // Only render chips backed by a real slot-payload field. Dead chips
@@ -335,16 +344,26 @@ function SlotCard({
         ))}
       </div>
       <div className="slot-actions">
-        <button
-          className="btn ghost sm"
-          disabled={!!busy}
-          onClick={() => onRestart && onRestart()}
-        >{Icons.restart} Restart</button>
-        <button
-          className="btn ghost sm"
-          disabled={!!busy}
-          onClick={() => onUnload && onUnload()}
-        >{Icons.unload} Unload</button>
+        {phase === "off" ? (
+          <button
+            className="btn ghost sm"
+            disabled={!!busy}
+            onClick={() => onStart && onStart()}
+          >{Icons.start} Start</button>
+        ) : (
+          <>
+            <button
+              className="btn ghost sm"
+              disabled={!!busy || phase === "transitional"}
+              onClick={() => onUnload && onUnload()}
+            >{Icons.unload} Stop</button>
+            <button
+              className="btn ghost sm"
+              disabled={!!busy || phase === "transitional"}
+              onClick={() => onRestart && onRestart()}
+            >{Icons.restart} Restart</button>
+          </>
+        )}
         <button className="btn ghost sm" onClick={onEdit}>{Icons.edit} Edit</button>
         <span className="spacer" />
       </div>
@@ -608,6 +627,7 @@ function SlotsView({ slotVariant, npuVariant, slotParam, onGo }) {
 
   const restartMut = useSlotRestart();
   const unloadMut = useSlotUnload();
+  const loadMut = useSlotLoad();
   const swapMut = useSlotSwap();
 
   const toast = (msg, kind = "info") =>
@@ -699,6 +719,9 @@ function SlotsView({ slotVariant, npuVariant, slotParam, onGo }) {
       }
       onUnload={() =>
         runMutation(s.name, unloadMut, s.name, `Unloaded ${s.name}`)
+      }
+      onStart={() =>
+        runMutation(s.name, loadMut, s.name, `Starting ${s.name}`)
       }
       onSwapPick={(m) =>
         runMutation(

--- a/ui/tests/e2e/specs/slot-lifecycle-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-lifecycle-controls-v3.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * slot-lifecycle-controls-v3 — SlotCard lifecycle buttons reflect state.
+ *
+ * Behaviour under test (design 2026-06-04):
+ *   - running slot (loaded/serving/ready) → Stop + Restart, no Start
+ *   - off slot (idle/unloaded/offline/disabled) → Start, no Stop/Restart
+ *   - transitional slot (warming/pulling/unloading) → no Start, Restart disabled
+ *
+ * Start → POST /load · Stop → POST /unload · Restart → POST /restart.
+ *
+ * The dashboard renders the slot LIST from in-bundle HAL0_DATA
+ * (VITE_MOCK_LEMONADE=1), so we target real seed slots by exact name:
+ *   primary = serving (running) · coder = idle (off) · warming-demo = warming.
+ * Mutations still go through fetch, so per-route stubs capture them.
+ */
+import { test, expect, type Page } from '../fixtures/apiMock'
+
+const cardByName = (page: Page, name: string) =>
+  page
+    .locator('.slot', { has: page.locator('.slot-name .nm', { hasText: new RegExp(`^${name}$`) }) })
+    .first()
+
+test.describe('Slot lifecycle controls (/slots)', () => {
+  test('off slot (coder/idle) shows Start, not Stop/Restart; Start POSTs /load', async ({ page }) => {
+    const loads: string[] = []
+    await page.route('**/api/slots/coder/load', async (route) => {
+      loads.push(route.request().url())
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+
+    await page.goto('/#slots')
+    const card = cardByName(page, 'coder')
+    await expect(card.getByRole("button", { name: "Start", exact: true })).toBeVisible()
+    await expect(card.locator('button:has-text("Stop")')).toHaveCount(0)
+    await expect(card.locator('button:has-text("Restart")')).toHaveCount(0)
+
+    await card.getByRole("button", { name: "Start", exact: true }).click()
+    await expect.poll(() => loads.length).toBeGreaterThan(0)
+  })
+
+  test('running slot (primary/serving) shows Stop + Restart, not Start; Stop POSTs /unload', async ({ page }) => {
+    const unloads: string[] = []
+    await page.route('**/api/slots/primary/unload', async (route) => {
+      unloads.push(route.request().url())
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+
+    await page.goto('/#slots')
+    const card = cardByName(page, 'primary')
+    await expect(card.locator('button:has-text("Stop")')).toBeVisible()
+    await expect(card.locator('button:has-text("Restart")')).toBeVisible()
+    await expect(card.getByRole("button", { name: "Start", exact: true })).toHaveCount(0)
+
+    await card.locator('button:has-text("Stop")').click()
+    await expect.poll(() => unloads.length).toBeGreaterThan(0)
+  })
+
+  test('transitional slot (warming) shows no Start and a disabled Restart', async ({ page }) => {
+    await page.goto('/#slots')
+    const card = cardByName(page, 'warming-demo')
+    await expect(card).toBeVisible()
+    await expect(card.getByRole("button", { name: "Start", exact: true })).toHaveCount(0)
+    await expect(card.locator('button:has-text("Restart")')).toBeDisabled()
+  })
+})

--- a/ui/tests/e2e/specs/slots-wireup-v3.spec.ts
+++ b/ui/tests/e2e/specs/slots-wireup-v3.spec.ts
@@ -176,7 +176,7 @@ test.describe('Slots v3 wire-up (/slots)', () => {
 
     await page.goto('/#slots')
     const card = page.locator('.slot', { hasText: 'primary' }).first()
-    await card.locator('button:has-text("Unload")').click()
+    await card.locator('button:has-text("Stop")').click()
     await expect.poll(() => unloads.length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## What
SlotCard action buttons now reflect the slot's lifecycle phase instead of always showing Restart + Unload:

| Phase | Detection | Buttons |
|---|---|---|
| **running** | loaded / serving / ready | **Stop** · **Restart** |
| **off** | idle / unloaded / offline / disabled | **Start** |
| **transitional** | warming / pulling / unloading | actions disabled |

## How
- `slots.jsx`: compute `phase` from `state` + `lemonade_state`; render buttons conditionally; wire the (previously unused) `useSlotLoad` hook for **Start** → `POST /api/slots/{name}/load`. **Stop** is the existing unload (`/unload`), relabelled.
- `chrome.jsx`: add a play glyph `Icons.start`.
- `data.jsx`: add a `warming-demo` seed slot so the transitional state renders under the forced-mock harness.

Verbs map to existing endpoints — no backend change.

## Tests (TDD)
- New `slot-lifecycle-controls-v3` spec: off→Start (POSTs /load), running→Stop+Restart (Stop POSTs /unload), transitional→no Start + disabled Restart. Written red-first.
- `slots-wireup-v3`: unload assertion updated to the new **Stop** label.
- Full γ-suite: 95 passed, 13 skipped, 0 failed. Clean `vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)