### PR TITLE
fix(agents): namespace_register verifies memory_delete count, not just HTTP ok

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1647,8 +1647,39 @@ def _phase_namespace_register(state: BootstrapState) -> PhaseResult:
             {"name": "memory_delete", "arguments": {"ids": existing_ids}},
             agent_id=state.agent_id,
         )
+        # #448: a delete that returns HTTP 200 but removes fewer ids than
+        # requested (e.g. the custom-dataset skip bug behind #446) looks
+        # identical to a real prune. Re-adding on top of un-deleted priors
+        # floods the Peer view with duplicates. Verify the count, not just
+        # the transport status — on any shortfall, skip the rewrite.
         if not deleted["ok"]:
             warnings.append(f"memory_delete: {deleted['error']}")
+            return PhaseResult(
+                status=PhaseStatus.OK,
+                details={
+                    "registered": False,
+                    "refreshed_existing": False,
+                    "warnings": warnings,
+                    "card": card,
+                },
+                reason="memory_delete failed; not rewriting to avoid duplicate accumulation",
+            )
+        removed = (deleted.get("result") or {}).get("deleted", 0)
+        if removed != len(existing_ids):
+            warnings.append(
+                f"memory_delete: requested {len(existing_ids)}, removed {removed} "
+                "— not rewriting to avoid duplicate accumulation"
+            )
+            return PhaseResult(
+                status=PhaseStatus.OK,
+                details={
+                    "registered": False,
+                    "refreshed_existing": False,
+                    "warnings": warnings,
+                    "card": card,
+                },
+                reason="memory_delete count mismatch; not rewriting to avoid duplicate accumulation",
+            )
 
     add = _mcp_memory_call(
         "tools/call",

--- a/tests/agents/test_hermes_provision_idempotency.py
+++ b/tests/agents/test_hermes_provision_idempotency.py
@@ -363,6 +363,82 @@ def test_config_yaml_contains_role_slot_blocks(
     assert "bge-test" not in cfg["custom_providers"][0]["models"]
 
 
+def test_namespace_register_skips_add_on_delete_count_mismatch(
+    tmp_path: Path, hermetic_state: hp.BootstrapState, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#448: when memory_delete reports fewer removals than requested, the
+    phase must NOT rewrite the card (avoid duplicate accumulation, #446).
+
+    Repro: search finds one prior card id, but the delete reports
+    ``deleted: 0`` (the custom-dataset skip bug). The HTTP call is OK, so
+    the old call site trusted it and re-added — flooding the Peer view.
+    The fixed call site inspects the count, warns, and skips the add.
+    """
+    add_calls: list[dict[str, Any]] = []
+
+    def _mismatch_memory_call(method: str, params: dict[str, Any], **_kw: Any) -> dict[str, Any]:
+        tool = (params or {}).get("name", "")
+        if tool == "memory_search":
+            return {
+                "ok": True,
+                "result": {
+                    "items": [{"id": "prior-1", "metadata": {"agent_id": hermetic_state.agent_id}}]
+                },
+            }
+        if tool == "memory_add":
+            add_calls.append(params)
+            return {"ok": True, "result": {"id": "memid-stable"}}
+        if tool == "memory_delete":
+            # Found one prior, removed none — the delete-0 mismatch.
+            return {"ok": True, "result": {"deleted": 0}}
+        return {"ok": True, "result": {}}
+
+    monkeypatch.setattr(hp, "_mcp_memory_call", _mismatch_memory_call)
+
+    result = hp._phase_namespace_register(hermetic_state)
+
+    assert result.status == hp.PhaseStatus.OK
+    assert result.details["registered"] is False
+    assert result.details["refreshed_existing"] is False
+    assert not add_calls, "card was re-added despite a delete-count mismatch"
+    assert any("memory_delete" in w for w in result.details["warnings"]), (
+        "expected a delete-count-mismatch warning"
+    )
+
+
+def test_namespace_register_rewrites_when_delete_count_matches(
+    tmp_path: Path, hermetic_state: hp.BootstrapState, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#448 counterpart: when the delete count matches the requested ids,
+    the refresh proceeds normally (card re-added, refreshed_existing True)."""
+    add_calls: list[dict[str, Any]] = []
+
+    def _matching_memory_call(method: str, params: dict[str, Any], **_kw: Any) -> dict[str, Any]:
+        tool = (params or {}).get("name", "")
+        if tool == "memory_search":
+            return {
+                "ok": True,
+                "result": {
+                    "items": [{"id": "prior-1", "metadata": {"agent_id": hermetic_state.agent_id}}]
+                },
+            }
+        if tool == "memory_add":
+            add_calls.append(params)
+            return {"ok": True, "result": {"id": "memid-stable"}}
+        if tool == "memory_delete":
+            return {"ok": True, "result": {"deleted": 1}}
+        return {"ok": True, "result": {}}
+
+    monkeypatch.setattr(hp, "_mcp_memory_call", _matching_memory_call)
+
+    result = hp._phase_namespace_register(hermetic_state)
+
+    assert result.status == hp.PhaseStatus.OK
+    assert result.details["registered"] is True
+    assert result.details["refreshed_existing"] is True
+    assert len(add_calls) == 1
+
+
 def test_persona_seed_appears_in_phase_order_before_config_write(tmp_path: Path) -> None:
     """Ordering guard — persona_seed must come BEFORE config_write so the
     first render gets the active persona's system_prompt."""


### PR DESCRIPTION
## What

`_phase_namespace_register` dedups a prior Hermes identity card by deleting the matched ids before re-adding the fresh snapshot. It only checked the delete's HTTP status (`deleted["ok"]`), never how many ids were actually removed.

A delete that found priors but removed none — the custom-dataset skip bug behind #446 — returns HTTP 200 with `deleted=0`, indistinguishable from a real prune. The phase then re-added the card on top of the un-deleted priors, flooding the Peer view with duplicates.

## Why / Fix

Inspect the removed count from the wrapper envelope (`deleted["result"]["deleted"]`). If it differs from the number of requested ids — or the delete failed outright — warn and skip the re-add, returning `PhaseResult` OK with `registered=False` / `refreshed_existing=False`. This is the call-site guard complementing the wrapper-level fix already merged in #446.

Closes #448

## Acceptance
- [x] `_phase_namespace_register` inspects the delete count, not just the HTTP status
- [x] on a count mismatch it warns and skips the duplicate add
- [x] regression test covers "delete reported fewer than requested" (`test_namespace_register_skips_add_on_delete_count_mismatch`), plus a happy-path counterpart asserting the rewrite still proceeds on a matching count

🤖 Generated with [Claude Code](https://claude.com/claude-code)