### PR TITLE
fix(memory): refcount shared Cognee chunk before delete to protect same-text survivors

### DIFF
--- a/src/hal0/memory/cognee_wrapper.py
+++ b/src/hal0/memory/cognee_wrapper.py
@@ -914,9 +914,12 @@ class CogneeWrapper:
         """Delete by sidecar id. Returns ``{deleted: int}``.
 
         We delete from BOTH the sidecar AND Cognee's own dataset rows
-        (via ``cognee.datasets.delete_data``). A failure on the Cognee
-        side does not unwind the sidecar delete — better to leak a
-        Cognee chunk than to falsely report success on a 2-id batch
+        (via ``cognee.datasets.delete_data``) — but only wipe a Cognee
+        chunk once the LAST sidecar row referencing it is gone, since
+        Cognee content-addresses chunks and identical text shares one
+        ``cognee_data_id`` across rows (issue #449). A failure on the
+        Cognee side does not unwind the sidecar delete — better to leak
+        a Cognee chunk than to falsely report success on a 2-id batch
         where one half succeeded. The audit log records the count
         Cognee acknowledged.
 
@@ -967,20 +970,44 @@ class CogneeWrapper:
                 ):
                     continue
                 if row["cognee_data_id"] and row["cognee_dataset_id"]:
-                    try:
-                        await cognee.datasets.delete_data(
-                            dataset_id=uuid.UUID(row["cognee_dataset_id"]),
-                            data_id=uuid.UUID(row["cognee_data_id"]),
-                        )
-                    except Exception:
-                        # Cognee may already have evicted the chunk —
-                        # treat the sidecar as the source of truth for
-                        # the count.
-                        _audit_logger().warning(
-                            "hal0.memory.delete.cognee_miss",
-                            client_id=effective_client_id,
-                            item_id=item_id,
-                        )
+                    # Cognee 1.0 content-addresses chunks by text, so N
+                    # byte-identical adds (e.g. the static Hermes identity
+                    # cards) all resolve to the SAME ``cognee_data_id``.
+                    # Wiping that chunk on the first delete strands every
+                    # surviving sidecar row pointing at it — the rows stay,
+                    # but their vector is gone, so search never returns
+                    # them again (issue #449). Only evict the shared chunk
+                    # when this row is the LAST reference to it.
+                    #
+                    # The count runs against the live connection mid-batch,
+                    # so rows already ``DELETE``d earlier in this loop are
+                    # not seen (same uncommitted transaction). That makes
+                    # the guard correct even when one ``ids`` batch deletes
+                    # several rows sharing a chunk: only the final one wipes.
+                    survivors = conn.execute(
+                        "SELECT COUNT(*) FROM hal0_memory_items "
+                        "WHERE cognee_data_id = ? AND cognee_dataset_id = ? AND id != ?",
+                        (
+                            row["cognee_data_id"],
+                            row["cognee_dataset_id"],
+                            item_id,
+                        ),
+                    ).fetchone()[0]
+                    if survivors == 0:
+                        try:
+                            await cognee.datasets.delete_data(
+                                dataset_id=uuid.UUID(row["cognee_dataset_id"]),
+                                data_id=uuid.UUID(row["cognee_data_id"]),
+                            )
+                        except Exception:
+                            # Cognee may already have evicted the chunk —
+                            # treat the sidecar as the source of truth for
+                            # the count.
+                            _audit_logger().warning(
+                                "hal0.memory.delete.cognee_miss",
+                                client_id=effective_client_id,
+                                item_id=item_id,
+                            )
                 conn.execute(
                     "DELETE FROM hal0_memory_items WHERE id = ?",
                     (item_id,),

--- a/tests/memory/test_cognee_wrapper.py
+++ b/tests/memory/test_cognee_wrapper.py
@@ -188,6 +188,51 @@ async def test_delete_single_id_decrements_list(make_wrapper):
     _ = a  # silence linter; the test only needs id references on b
 
 
+async def test_delete_identical_text_keeps_survivor_searchable(make_wrapper):
+    """Deleting one of two byte-identical items keeps the other searchable.
+
+    Regression for issue #449: Cognee 1.0 content-addresses chunks by
+    text, so two byte-identical adds (e.g. the static Hermes identity
+    cards) resolve to the SAME ``cognee_data_id``. The old delete loop
+    wiped that shared chunk on the first id, stranding the survivor's
+    sidecar row pointing at a gone vector — invisible to search. The
+    refcount guard must only evict the chunk once the last reference is
+    deleted.
+    """
+    w = make_wrapper()
+    first = await w.add("byte identical memory card")
+    second = await w.add("byte identical memory card")
+
+    # Sanity: both land, search can see the (single, shared-chunk) text.
+    before = await w.search(query="byte identical memory card", limit=10)
+    assert any("byte identical memory card" in h["text"] for h in before)
+
+    # Delete the FIRST — the shared Cognee chunk must NOT be wiped while
+    # the second row still references it.
+    res = await w.delete(ids=[first["id"]])
+    assert res == {"deleted": 1}
+
+    # The survivor is still in the sidecar...
+    listed = await w.list_items(limit=50)
+    survivor_ids = {i["id"] for i in listed["items"]}
+    assert second["id"] in survivor_ids
+    assert first["id"] not in survivor_ids
+
+    # ...AND still returned by vector search (the chunk lives on).
+    after = await w.search(query="byte identical memory card", limit=10)
+    assert any(h["id"] == second["id"] for h in after), (
+        f"survivor of identical-text pair vanished from search: {after!r}"
+    )
+
+    # Deleting the survivor too now evicts the chunk; nothing left.
+    res2 = await w.delete(ids=[second["id"]])
+    assert res2 == {"deleted": 1}
+    gone = await w.search(query="byte identical memory card", limit=10)
+    assert not any(h["id"] in {first["id"], second["id"]} for h in gone), (
+        f"expected both identical-text rows gone, got {gone!r}"
+    )
+
+
 async def test_delete_custom_dataset_item_by_owner(make_wrapper):
     """Deleting an own item in a CUSTOM dataset (e.g. ADR-0011 ``agents``)
     actually removes it.


### PR DESCRIPTION
## What

`CogneeWrapper.delete()` now reference-counts the shared Cognee chunk before evicting it. For each sidecar row it counts other rows referencing the same `(cognee_data_id, cognee_dataset_id)` and only calls `cognee.datasets.delete_data` when this row is the last reference.

## Why

Cognee 1.0 content-addresses chunks by text, so byte-identical adds (e.g. the static Hermes identity cards, `hermes_provision.py:1494`) all resolve to the **same** `cognee_data_id` across sidecar rows. The old per-id delete loop wiped that shared chunk on the first id, stranding every surviving sidecar row pointing at a now-gone vector — invisible to `memory_search` (issue #449).

The ref-count query runs against the live SQLite connection mid-batch, so rows already `DELETE`d earlier in the same batch are not counted. That keeps the guard correct even when one `ids` batch deletes several rows sharing a chunk: only the final reference triggers the Cognee wipe.

Closes #449

## Acceptance

- [x] add same-text item x2 in one dataset → delete one → other still returned by search
- [x] deleting the last reference evicts the chunk (no orphan)
- [x] regression test in `tests/memory/test_cognee_wrapper.py` on the real Cognee harness (`test_delete_identical_text_keeps_survivor_searchable`)
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)