### PR TITLE
fix(dashboard): MCP page honest empty-state, drop fake-client fallback

### DIFF
--- a/ui/src/dash/mcp.jsx
+++ b/ui/src/dash/mcp.jsx
@@ -382,22 +382,26 @@ function McpView() {
   // (new per-agent view). Defaults to "servers" so existing nav stays
   // unchanged.
   const [mode, setMode] = useStateM("servers");
-  // Live data via /api/mcp/* (issue #206). When the backend returns no
-  // rows (404 → mock fallback in the hook, or genuinely empty), fall
-  // through to the HAL0_DATA mock so the prototype demo + Playwright
-  // specs keep rendering against the rich fixture set.
+  // Live data via /api/mcp/* (issue #206). Prototype mode is decided as
+  // a whole, NOT per-query (issue #436): only when BOTH live queries
+  // come back empty do we fall through to the rich HAL0_DATA fixtures so
+  // the demo + Playwright specs keep rendering. On a real host with
+  // registered servers, the live client array is used verbatim — even
+  // when it's empty — so a live-but-idle host shows the honest
+  // NoClientsState instead of fake Claude Code / Cursor rows.
   const serversQ = useMcpServers();
   const clientsQ = useMcpClients();
   const liveServers = serversQ.data || [];
   const liveClients = clientsQ.data || [];
-  const servers = liveServers.length > 0 ? liveServers : MCP_SERVERS;
-  const clients = liveClients.length > 0 ? liveClients.map(c => ({
+  const prototype = liveServers.length === 0 && liveClients.length === 0;
+  const servers = prototype ? MCP_SERVERS : liveServers;
+  const clients = prototype ? MCP_CLIENTS : liveClients.map(c => ({
     ...c,
     // The prototype card reads `servers` (legacy alias) + a `since`
     // string; normalise so the existing render path keeps working.
     servers: c.servers || c.connected_to || [],
     since: typeof c.since === 'number' ? new Date(c.since * 1000).toLocaleTimeString() : (c.since || '—'),
-  })) : MCP_CLIENTS;
+  }));
   const [filter, setFilter] = useStateM("all");
   const [menuId, setMenuId] = useStateM(null);
   const [installOpen, setInstallOpen] = useStateM(false);


### PR DESCRIPTION
## What

The MCP servers page decided its prototype/mock fallback **per-query**. A live host with registered servers but zero connected clients kept the real server rows yet swapped the empty client array for three fake prototype clients (Claude Code / Cursor / Claude Desktop). The honest `NoClientsState` was dead code on any live-but-idle host — the page looked like dummy content (the core grievance in #436).

## Why / Fix

Decide prototype mode **as a whole**: fall through to the rich `HAL0_DATA` fixtures only when **both** the servers and clients queries come back empty. On a real host the live client array is now used verbatim — even when empty — so zero clients renders the existing honest empty state (with its connect-a-client affordance), and no fake clients appear anywhere.

The forced-mock / Playwright path (page.route-injected servers+clients in `mcp-v3-wired.spec.ts`) is unchanged, so the γ-suite specs keep rendering the full fixtures.

Closes #436

## Acceptance

- [x] Live host w/ real servers + 0 clients: server rows + tool counts render; honest `NoClientsState` fires; NO fake Claude Code / Cursor / Claude Desktop clients
- [x] KPI 'clients' reads 0; 'last activity' reads '—' / 'no recent calls' (driven by empty `clients`/`calls`)
- [x] Prototype / forced-mock / Playwright path still renders rich `MCP_SERVERS` + `MCP_CLIENTS` fixtures (γ-suite specs unaffected)
- [x] Server list + tool counts + connect affordance already shipped — left as-is (scoped to the fallback bug)

Note: `dexto` surfacing was the optional low-pri 'Consider' item; left out to keep this PR scoped to the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)