### PR TITLE
fix(lemonade): honor per-slot idle_timeout_s in IdleDriver eviction

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -686,12 +686,41 @@ async def _start_lemonade_metrics_shim(app: FastAPI) -> MetricsShim | None:
         return None
 
 
-async def _start_lemonade_idle_driver(app: FastAPI) -> IdleDriver | None:
+def _build_idle_ttl_provider(
+    slot_manager: SlotManager,
+) -> Callable[[], dict[str, float]]:
+    """Build the per-model idle-TTL provider for the IdleDriver (issue #414).
+
+    Returns a callable the driver invokes once per tick to get the
+    current ``lemond model_name`` → ``idle_timeout_s`` map, derived from
+    each slot's ``[model] default`` and its ``idle_timeout_s``. Rebuilt
+    every call so a config change (PUT slot config) is picked up on the
+    next tick without restarting the driver.
+
+    The driver's resolver is synchronous and runs inside the running
+    event loop, so the provider delegates to ``SlotManager``'s
+    synchronous TOML reader rather than awaiting ``iter_configs``. A
+    model with ``idle_timeout_s == 0`` maps to 0, which the driver
+    treats as "never evict". Unconfigured models aren't in the map and
+    fall back to the driver's global default (300s).
+    """
+
+    def _provider() -> dict[str, float]:
+        return slot_manager.idle_timeout_by_model()
+
+    return _provider
+
+
+async def _start_lemonade_idle_driver(app: FastAPI, slot_manager: SlotManager) -> IdleDriver | None:
     """Start the Lemonade idle-unload driver.
 
     v0.2 (ADR-0008 §1): Lemonade is the sole inference backend; this
     driver always starts. PR-10 removed the prior ``HAL0_BACKEND``
     gate — the v0.1.x toolbox path no longer exists.
+
+    The driver consumes a per-model TTL provider (issue #414) so each
+    slot's configured ``idle_timeout_s`` actually drives eviction
+    instead of a single hardcoded 300s global.
 
     Failures here MUST NOT block API startup — a busted Lemonade
     config shouldn't keep the dashboard from coming up so the user
@@ -709,7 +738,10 @@ async def _start_lemonade_idle_driver(app: FastAPI) -> IdleDriver | None:
         client = LemonadeClient(
             api_key=os.environ.get("LEMONADE_API_KEY") or None,
         )
-        driver = IdleDriver(client)
+        driver = IdleDriver(
+            client,
+            ttl_provider=_build_idle_ttl_provider(slot_manager),
+        )
         await driver.start()
         # Stash on app.state so /api/health surfaces + tests can find it.
         app.state.lemonade_client = client
@@ -955,7 +987,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # makes Lemonade the sole backend, so this driver always starts —
     # the prior ``HAL0_BACKEND=lemonade`` gate retired in PR-10. Stored
     # on app.state so tests + future shutdown hooks can introspect it.
-    lemonade_idle_driver = await _start_lemonade_idle_driver(app)
+    lemonade_idle_driver = await _start_lemonade_idle_driver(app, slot_manager)
     # Lemonade metrics shim (PR-12, plan §10.1 + §11). Shares the
     # ``app.state.lemonade_client`` attached by the idle driver so we
     # don't double up on connection pools against lemond. Provides the

--- a/src/hal0/lemonade/idle.py
+++ b/src/hal0/lemonade/idle.py
@@ -60,7 +60,7 @@ import asyncio
 import contextlib
 import logging
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 
 from hal0.lemonade.client import LemonadeClient
@@ -108,6 +108,7 @@ class IdleDriver:
         *,
         idle_timeout_s: float = DEFAULT_IDLE_TIMEOUT_S,
         poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+        ttl_provider: Callable[[], Mapping[str, float]] | None = None,
         clock: Any = time.time,
     ) -> None:
         if idle_timeout_s <= 0:
@@ -115,8 +116,17 @@ class IdleDriver:
         if poll_interval_s <= 0:
             raise ValueError("poll_interval_s must be > 0")
         self._client = client
+        # ``idle_timeout_s`` is the GLOBAL fallback applied to any model
+        # without a per-slot override. Per-model TTLs come from
+        # ``ttl_provider`` (issue #414) — a callable rebuilt-per-tick
+        # map of lemond ``model_name`` → ``idle_timeout_s`` derived from
+        # the loaded ``SlotConfig``s. A per-model TTL of 0 means "never
+        # evict this model" (the schema allows idle_timeout_s=0 = disable);
+        # the global fallback must still be > 0 so an empty/missing map
+        # preserves the v0.1.x 300s policy.
         self._idle_timeout_s = idle_timeout_s
         self._poll_interval_s = poll_interval_s
+        self._ttl_provider = ttl_provider
         # Injectable clock so tests can fast-forward without
         # monkeypatching the time module globally.
         self._clock = clock
@@ -233,6 +243,13 @@ class IdleDriver:
         if not loaded:
             return 0
 
+        # Resolve the per-model TTL map once per tick (issue #414). Built
+        # fresh each sweep so a config change picks up on the next tick
+        # without restarting the driver. A flaky provider must never
+        # crash the sweep — fall back to the global default for all
+        # models if it raises.
+        ttl_map = self._resolve_ttl_map()
+
         now = float(self._clock())
         evicted = 0
         for entry in loaded:
@@ -267,10 +284,18 @@ class IdleDriver:
 
             # Counter unchanged since first_seen_at. Decide on
             # wall-clock age, NOT on the opaque counter's value.
-            age = now - first_seen_at
-            if age <= self._idle_timeout_s:
+            #
+            # Per-model TTL (issue #414): resolve this model's configured
+            # idle_timeout_s, falling back to the global default for
+            # unknown/unconfigured models. A TTL of 0 disables eviction
+            # for that model entirely (keep it loaded indefinitely).
+            ttl = ttl_map.get(name, self._idle_timeout_s)
+            if ttl <= 0:
                 continue
-            ok = await self._unload(name, age=age)
+            age = now - first_seen_at
+            if age <= ttl:
+                continue
+            ok = await self._unload(name, age=age, idle_timeout_s=ttl)
             if ok:
                 # Drop tracker state proactively so an immediate
                 # reload (before the next health poll observes the
@@ -279,12 +304,34 @@ class IdleDriver:
                 evicted += 1
         return evicted
 
-    async def _unload(self, model_name: str, *, age: float) -> bool:
+    def _resolve_ttl_map(self) -> Mapping[str, float]:
+        """Build the per-model TTL map for this tick (issue #414).
+
+        Returns the ``model_name`` → ``idle_timeout_s`` mapping from the
+        injected ``ttl_provider``, or an empty mapping when no provider
+        is wired (the legacy single-global-TTL behaviour). A provider
+        that raises is logged + treated as empty so a busted config
+        never crashes the sweep — every model falls back to the global
+        default that tick.
+        """
+        if self._ttl_provider is None:
+            return {}
+        try:
+            return self._ttl_provider()
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning(
+                "lemonade.idle.ttl_provider_error",
+                extra={"error": str(exc), "error_type": type(exc).__name__},
+            )
+            return {}
+
+    async def _unload(self, model_name: str, *, age: float, idle_timeout_s: float) -> bool:
         """Call ``POST /v1/unload``. Returns True on success.
 
         Per-model failure is logged + swallowed so the sweep moves on
         to the next candidate. The next tick will retry whatever we
-        missed.
+        missed. ``idle_timeout_s`` is the per-model TTL that triggered
+        the eviction (issue #414), logged for audit.
         """
         try:
             await self._client.unload(model_name)
@@ -304,7 +351,7 @@ class IdleDriver:
             extra={
                 "model_name": model_name,
                 "age_s": age,
-                "idle_timeout_s": self._idle_timeout_s,
+                "idle_timeout_s": idle_timeout_s,
             },
         )
         return True

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -955,8 +955,7 @@ class SlotManager:
             except SlotConfigError as exc:
                 log.warning(
                     "slot.config_skipped",
-                    slot=name,
-                    error=str(exc),
+                    extra={"slot": name, "error": str(exc)},
                 )
                 continue
             out.append(cfg)
@@ -993,7 +992,10 @@ class SlotManager:
                 with open(path, "rb") as f:
                     data = tomllib.load(f)
             except (OSError, tomllib.TOMLDecodeError) as exc:
-                log.warning("slot.idle_ttl_skipped", slot=name, error=str(exc))
+                log.warning(
+                    "slot.idle_ttl_skipped",
+                    extra={"slot": name, "error": str(exc)},
+                )
                 continue
             model = data.get("model") or {}
             model_name = ""

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -962,6 +962,50 @@ class SlotManager:
             out.append(cfg)
         return out
 
+    def idle_timeout_by_model(self) -> dict[str, float]:
+        """Map each slot's lemond ``model_name`` → its ``idle_timeout_s``.
+
+        Issue #414: the Lemonade idle-unload driver evicts by lemond
+        ``model_name``, but the per-slot ``idle_timeout_s`` (config
+        source of truth) was never plumbed through, so every model used
+        the driver's hardcoded 300s global. This synchronous reader
+        builds the per-model TTL map the driver consumes once per tick.
+
+        Synchronous on purpose: the driver's resolver runs inside the
+        running event loop and can't await. We read each slot's TOML
+        directly (the same files ``iter_configs`` reads), which is a
+        cheap local-disk op. Slots with an empty ``[model] default`` or
+        an unreadable / malformed config are skipped — the driver falls
+        back to its global default for any model absent from the map.
+
+        A value of ``idle_timeout_s == 0`` is preserved (maps to 0.0);
+        the driver treats it as "never evict this model".
+        """
+        try:
+            import tomllib
+        except ImportError:  # py<3.11
+            import tomli as tomllib  # type: ignore[no-redef]
+
+        out: dict[str, float] = {}
+        for name in self._all_configured_slot_names():
+            path = self._config_file(name)
+            try:
+                with open(path, "rb") as f:
+                    data = tomllib.load(f)
+            except (OSError, tomllib.TOMLDecodeError) as exc:
+                log.warning("slot.idle_ttl_skipped", slot=name, error=str(exc))
+                continue
+            model = data.get("model") or {}
+            model_name = ""
+            if isinstance(model, dict):
+                model_name = str(model.get("default") or "")
+            if not model_name:
+                continue
+            ttl = data.get("idle_timeout_s")
+            if isinstance(ttl, (int, float)) and not isinstance(ttl, bool):
+                out[model_name] = float(ttl)
+        return out
+
     # ── PR-10: seeded slot catalogue + routing helpers ──────────────────────
 
     @staticmethod

--- a/tests/lemonade/test_idle.py
+++ b/tests/lemonade/test_idle.py
@@ -260,6 +260,107 @@ async def test_entries_without_last_use_are_skipped() -> None:
         assert script.unload_calls == []
 
 
+# ── tick(): per-model TTL (issue #414) ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_per_model_ttl_keeps_long_lived_model_loaded() -> None:
+    """Acceptance #1: a model whose mapped TTL is 86400 stays loaded past 300s.
+
+    The driver's global default is 300s, but the per-model TTL provider
+    maps ``long`` → 86400. After well over 300s of unchanged counter the
+    model must NOT be evicted.
+    """
+    clock = _Clock()
+    script = _HealthScript([[{"model_name": "long", "last_use": 7}]] * 20)
+    async with _mock_transport(script) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(
+            client,
+            idle_timeout_s=300.0,
+            poll_interval_s=30.0,
+            ttl_provider=lambda: {"long": 86400.0},
+            clock=clock,
+        )
+        for _ in range(20):  # 20 * 30 = 600s > 300s default, < 86400s
+            assert await driver.tick() == 0
+            clock.advance(30.0)
+        assert script.unload_calls == []
+
+
+@pytest.mark.asyncio
+async def test_per_model_ttl_zero_disables_eviction() -> None:
+    """Acceptance #2: idle_timeout_s == 0 means never evict (no unload, no crash)."""
+    clock = _Clock()
+    script = _HealthScript([[{"model_name": "pinned", "last_use": 7}]] * 20)
+    async with _mock_transport(script) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(
+            client,
+            idle_timeout_s=300.0,
+            poll_interval_s=30.0,
+            ttl_provider=lambda: {"pinned": 0.0},
+            clock=clock,
+        )
+        for _ in range(20):
+            assert await driver.tick() == 0
+            clock.advance(30.0)
+        assert script.unload_calls == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_model_falls_back_to_global_default() -> None:
+    """Acceptance #3: a model not in the TTL map still evicts at the 300s default."""
+    clock = _Clock()
+    # 12 ticks at 30s = 330s dwell; counter never moves.
+    script = _HealthScript([[{"model_name": "other", "last_use": 7}]] * 12)
+    async with _mock_transport(script) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(
+            client,
+            idle_timeout_s=300.0,
+            poll_interval_s=30.0,
+            ttl_provider=lambda: {"long": 86400.0},  # "other" absent → default
+            clock=clock,
+        )
+        unloaded = False
+        for _ in range(12):
+            if await driver.tick():
+                unloaded = True
+                break
+            clock.advance(30.0)
+        assert unloaded
+        assert script.unload_calls == ["other"]
+
+
+@pytest.mark.asyncio
+async def test_ttl_provider_exception_falls_back_to_default() -> None:
+    """A provider that raises must not crash the sweep — falls back to default TTL."""
+    clock = _Clock()
+    script = _HealthScript([[{"model_name": "x", "last_use": 7}]] * 12)
+
+    def _boom() -> dict[str, float]:
+        raise RuntimeError("config read failed")
+
+    async with _mock_transport(script) as transport:
+        client = LemonadeClient(http_client=transport)
+        driver = IdleDriver(
+            client,
+            idle_timeout_s=300.0,
+            poll_interval_s=30.0,
+            ttl_provider=_boom,
+            clock=clock,
+        )
+        unloaded = False
+        for _ in range(12):
+            if await driver.tick():
+                unloaded = True
+                break
+            clock.advance(30.0)
+        assert unloaded
+        assert script.unload_calls == ["x"]
+
+
 # ── tick(): resilience ────────────────────────────────────────────────
 
 

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -176,6 +176,66 @@ async def test_route_for_request_returns_none_when_nothing_matches(
     assert await sm.route_for_request("llm") is None
 
 
+# ── idle_timeout_by_model (issue #414) ──────────────────────────────────────
+
+
+def _write_idle_slot(
+    root: Path,
+    name: str,
+    *,
+    model_default: str,
+    idle_timeout_s: int | None,
+    port: int = 8081,
+) -> None:
+    """Write a minimal slot TOML with an optional flat idle_timeout_s."""
+    lines = [
+        f'name = "{name}"',
+        f"port = {port}",
+        'provider = "lemonade"',
+        "enabled = true",
+    ]
+    if idle_timeout_s is not None:
+        lines.append(f"idle_timeout_s = {idle_timeout_s}")
+    lines.append("[model]")
+    lines.append(f'default = "{model_default}"')
+    (root / f"{name}.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_idle_timeout_by_model_maps_model_name_to_ttl(slot_root: Path) -> None:
+    """Each slot's [model] default maps to its configured idle_timeout_s."""
+    _write_idle_slot(slot_root, "a", model_default="model-a", idle_timeout_s=86400, port=8082)
+    _write_idle_slot(slot_root, "b", model_default="model-b", idle_timeout_s=120, port=8083)
+    sm = SlotManager()
+    m = sm.idle_timeout_by_model()
+    assert m["model-a"] == 86400.0
+    assert m["model-b"] == 120.0
+
+
+def test_idle_timeout_by_model_preserves_zero(slot_root: Path) -> None:
+    """idle_timeout_s == 0 (disable eviction) round-trips as 0.0, not dropped."""
+    _write_idle_slot(slot_root, "keep", model_default="pinned-model", idle_timeout_s=0, port=8082)
+    sm = SlotManager()
+    m = sm.idle_timeout_by_model()
+    assert m["pinned-model"] == 0.0
+
+
+def test_idle_timeout_by_model_skips_slots_without_model_default(slot_root: Path) -> None:
+    """A slot with an empty [model] default contributes no entry."""
+    _write_idle_slot(slot_root, "empty", model_default="", idle_timeout_s=300, port=8082)
+    sm = SlotManager()
+    m = sm.idle_timeout_by_model()
+    assert "" not in m
+
+
+def test_idle_timeout_by_model_tolerates_malformed_toml(slot_root: Path) -> None:
+    """A malformed slot TOML is skipped, not fatal — others still map."""
+    _write_idle_slot(slot_root, "good", model_default="good-model", idle_timeout_s=42, port=8082)
+    (slot_root / "broken.toml").write_text("name = \nport = ", encoding="utf-8")
+    sm = SlotManager()
+    m = sm.idle_timeout_by_model()
+    assert m["good-model"] == 42.0
+
+
 # ── add_slot / remove_slot (PR-10 §4.3) ─────────────────────────────────────
 
 


### PR DESCRIPTION
## What

Plumb each slot's configured `idle_timeout_s` through to the Lemonade idle-unload driver so it actually drives eviction.

## Why

`idle_timeout_s` was accepted + persisted (`config/schema.py`, `config/loader.py`) but the `IdleDriver` that evicts idle models never consumed it — it was constructed with no per-model TTL, so every model used the hardcoded 300s global (`DEFAULT_IDLE_TIMEOUT_S`). A slot configured with a long idle window was culled at 300s anyway, and `idle_timeout_s=0` (disable) was a no-op.

## How

- `IdleDriver` takes an optional `ttl_provider` callable (rebuilt per tick) returning a `model_name -> idle_timeout_s` map. `tick()` resolves each model's TTL, falling back to the global default for unconfigured models; a per-model TTL of `0` disables eviction. A provider that raises is logged and treated as empty so a busted config never crashes the sweep.
- `SlotManager.idle_timeout_by_model()` builds the map synchronously from slot TOMLs (the driver's resolver runs on the event loop and can't await); malformed configs and slots without a `[model] default` are skipped.
- `hal0-api` wires the provider into `_start_lemonade_idle_driver` from the `SlotManager` already on `app.state`.
- The constructor's global `idle_timeout_s` fallback still must be `> 0`; only per-model TTLs may be `0`.

Closes #414

## Acceptance

- [x] (1) slot with `idle_timeout_s=86400` stays loaded past 300s idle — `test_per_model_ttl_keeps_long_lived_model_loaded`
- [x] (2) `idle_timeout_s=0` disables eviction, no unload / no crash — `test_per_model_ttl_zero_disables_eviction`
- [x] (3) unconfigured/unknown model still evicts at 300s default — `test_unknown_model_falls_back_to_global_default`
- [x] (4) `ruff check` + `ruff format --check` pass

Note: the exact 60-90s field figure from the report needs CT105 to confirm a possible second eviction path (lemond nuclear-evict) and is out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)