### PR TITLE
fix(memory): gate graph-enable behind LLM-target validation, fail fast on 401

### DIFF
--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -26,6 +26,7 @@ from pydantic import ValidationError
 from hal0.api.middleware.error_codes import Hal0Error
 from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import GraphUpstreamConfig, MemoryGraphConfig
+from hal0.memory.cognee_wrapper import GraphRouteUnsupportedError
 from hal0.memory.namespace import (
     DEFAULT_DATASET,
     MemoryNamespaceError,
@@ -136,6 +137,20 @@ class MemoryGraphConfigInvalid(Hal0Error):
 
     code = "config.memory_graph_invalid"
     status = 400
+
+
+class MemoryGraphRouteUnsupported(Hal0Error):
+    """Enable rejected: the requested graph route has no usable LLM target.
+
+    Issue #451 — v0.3 has no resolver for ``route=primary`` / ``agent``
+    (lands v0.4 per ADR-0014 §4) and ``route=upstream`` needs a real
+    ``LLM_API_KEY``. Surfaced as 422 (semantically valid request the
+    server can't fulfil yet) so the dashboard + CLI can fail fast without
+    flipping the gate on.
+    """
+
+    code = "config.memory_graph_route_unsupported"
+    status = 422
 
 
 class MemoryUnavailable(Hal0Error):
@@ -249,6 +264,17 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
             details=_validation_error_details(exc),
         ) from exc
 
+    # Flip the live wrapper BEFORE persisting so a rejected enable
+    # (issue #451 — unwired route / placeholder key) never leaves
+    # ``enabled = true`` on disk. ADR-0014 §6: disable cancels in-flight
+    # builds — handled inside set_graph_enabled.
+    try:
+        wrapper.set_graph_enabled(new_cfg.enabled, route=new_cfg.route)
+    except GraphRouteUnsupportedError as exc:
+        raise MemoryGraphRouteUnsupported(str(exc)) from exc
+    except ValueError as exc:
+        raise MemoryGraphConfigInvalid(str(exc)) from exc
+
     cfg.memory.graph = new_cfg
     try:
         save_hal0_config(cfg)
@@ -257,14 +283,6 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
             f"could not persist hal0 config: {exc}",
             details={"error": str(exc), "errno": getattr(exc, "errno", None)},
         ) from exc
-
-    # Flip the live wrapper so the very next memory_add observes the
-    # new gate. ADR-0014 §6: disable cancels in-flight builds —
-    # handled inside set_graph_enabled.
-    try:
-        wrapper.set_graph_enabled(new_cfg.enabled, route=new_cfg.route)
-    except ValueError as exc:
-        raise MemoryGraphConfigInvalid(str(exc)) from exc
 
     out = new_cfg.model_dump(mode="json")
     # Echo the live status so the dashboard's optimistic-update path
@@ -470,6 +488,7 @@ __all__ = [
     "MemoryAgentIdInvalid",
     "MemoryGraphConfig",
     "MemoryGraphConfigInvalid",
+    "MemoryGraphRouteUnsupported",
     "MemoryNamespaceInvalid",
     "MemoryUnavailable",
     "router",

--- a/src/hal0/memory/cognee_wrapper.py
+++ b/src/hal0/memory/cognee_wrapper.py
@@ -104,6 +104,36 @@ DEFAULT_COGNEE_DIR = Path("/var/lib/hal0/memory/cognee")
 # events for the §5 audit-log assertions.
 AUDIT_EVENT = "hal0.memory.audit"
 
+# Placeholder LLM key seeded by ``_configure_cognee`` when the host has no
+# real upstream key. cognify run against it 401s; litellm then retries
+# (default 5x) per memory_add — the issue #451 auth-retry storm. Both the
+# enable guard and the ``_build_graph`` belt refuse to fire builds while
+# ``LLM_API_KEY`` is this value.
+_NOOP_LLM_API_KEY = "sk-hal0-noop-v0.2-no-cognify"
+
+# ADR-0014 §4: the per-route LLM-target resolver (primary / agent slot
+# dispatch) lands in v0.4 with the eval suite. Until then only
+# ``upstream`` — which cognify reaches through the ambient ``LLM_API_KEY``
+# — has a working target.
+_WIRED_GRAPH_ROUTES = frozenset({"upstream"})
+
+
+class GraphRouteUnsupportedError(Exception):
+    """Raised at enable time when the requested graph route has no usable
+    LLM target in v0.3 (issue #451).
+
+    Two cases:
+
+      - ``route`` is ``primary`` / ``agent`` — the per-route resolver is a
+        v0.4 deliverable (ADR-0014 §4), so there is nothing to dispatch to.
+      - ``route == upstream`` but ``LLM_API_KEY`` is the noop placeholder —
+        cognify would 401 + retry-storm on every ``memory_add``.
+
+    The enable path raises this instead of silently flipping the gate on,
+    so a misconfigured enable fails fast (HTTP 422 / CLI nonzero) and the
+    gate stays off.
+    """
+
 
 # ── Public payload shape ──────────────────────────────────────────────────
 
@@ -380,7 +410,7 @@ class CogneeWrapper:
         os.environ.setdefault("ENABLE_BACKEND_ACCESS_CONTROL", "false")
         os.environ.setdefault("CACHING", "false")
         os.environ.setdefault("COGNEE_SKIP_CONNECTION_TEST", "true")
-        os.environ.setdefault("LLM_API_KEY", "sk-hal0-noop-v0.2-no-cognify")
+        os.environ.setdefault("LLM_API_KEY", _NOOP_LLM_API_KEY)
         os.environ["EMBEDDING_PROVIDER"] = self._embedding_provider
         os.environ["EMBEDDING_MODEL"] = self._embedding_model
         os.environ["EMBEDDING_DIMENSIONS"] = str(self._embedding_dimensions)
@@ -596,7 +626,25 @@ class CogneeWrapper:
         ingestion. Route resolution itself (upstream vs primary vs
         agent) lands in v0.4 with the eval suite; v0.3 runs Cognee's
         default cognify against whatever ``LLM_API_KEY`` the env carries.
+
+        Issue #451 belt-and-suspenders: even though ``set_graph_enabled``
+        rejects unbuildable routes at enable time, a hand-edited
+        ``hal0.toml`` can still construct an enabled wrapper. Re-check the
+        route target here and skip (not error) the build so a placeholder
+        key never triggers the litellm 401 retry storm.
         """
+        try:
+            _validate_graph_route_target(self._graph_route)
+        except GraphRouteUnsupportedError as exc:
+            self._graph_last_error = f"{type(exc).__name__}: {exc}"[:200]
+            _audit_logger().warning(
+                "hal0.memory.graph.build_skipped",
+                client_id=self._client_id,
+                dataset=dataset,
+                reason=str(exc)[:200],
+                route=self._graph_route,
+            )
+            return
         cognee = _cognee()
         try:
             await cognee.cognify(datasets=[dataset], run_in_background=False)
@@ -663,11 +711,24 @@ class CogneeWrapper:
         implementation lands in v0.4 with the eval suite; v0.3 stores
         the pick so a process restart preserves user intent + the
         dashboard always reflects current state.
+
+        Issue #451 — enabling fails fast (raises
+        :class:`GraphRouteUnsupportedError`) when the requested route has
+        no usable LLM target: ``primary`` / ``agent`` have no v0.3
+        resolver, and ``upstream`` needs a real ``LLM_API_KEY`` (not the
+        noop placeholder cognify would 401 against). The gate is left OFF
+        on rejection so a misconfigured enable can't trigger the
+        per-``memory_add`` retry storm. Disabling never validates.
         """
         if route is not None and route not in {"upstream", "primary", "agent"}:
             raise ValueError(
                 f"graph route {route!r} is not valid; choose from 'upstream' | 'primary' | 'agent'"
             )
+        effective_route = route if route is not None else self._graph_route
+        if enabled:
+            # Validate BEFORE mutating any state so a rejected enable
+            # leaves the gate (and the stored route) untouched.
+            _validate_graph_route_target(effective_route)
         if route is not None:
             self._graph_route = route
         if not enabled and self._graph_enabled:
@@ -1292,6 +1353,38 @@ def _chunk_score(chunk: Any) -> float | None:
 def _now_iso() -> str:
     """UTC ISO-8601 timestamp matching ADR-0005 §2 (date filter input)."""
     return datetime.now(UTC).isoformat()
+
+
+def _has_usable_llm_key() -> bool:
+    """Return whether a real (non-placeholder) ``LLM_API_KEY`` is present.
+
+    cognify reaches its extraction LLM through the ambient
+    ``LLM_API_KEY``. Empty or the noop placeholder means cognify would
+    401 + retry-storm (issue #451), so callers treat this as "no target".
+    """
+    key = os.environ.get("LLM_API_KEY", "").strip()
+    return bool(key) and key != _NOOP_LLM_API_KEY
+
+
+def _validate_graph_route_target(route: str) -> None:
+    """Raise :class:`GraphRouteUnsupportedError` if ``route`` can't build.
+
+    v0.3 fail-fast (issue #451): ``primary`` / ``agent`` have no route
+    resolver (lands v0.4 per ADR-0014 §4), and ``upstream`` needs a real
+    ``LLM_API_KEY``. Returns ``None`` when the route is buildable.
+    """
+    if route not in _WIRED_GRAPH_ROUTES:
+        raise GraphRouteUnsupportedError(
+            f"graph route {route!r} is not yet supported in v0.3 — the "
+            f"per-route resolver lands in v0.4 (ADR-0014 §4). Use "
+            f"route='upstream' with a configured provider key."
+        )
+    if not _has_usable_llm_key():
+        raise GraphRouteUnsupportedError(
+            "graph route 'upstream' has no usable LLM_API_KEY — cognify "
+            "would 401 on every memory_add. Configure a real upstream "
+            "provider key before enabling graph extraction."
+        )
 
 
 def _clear_cognee_caches() -> None:

--- a/tests/api/test_memory_graph_route.py
+++ b/tests/api/test_memory_graph_route.py
@@ -41,6 +41,15 @@ class StubWrapper:
         }
 
     def set_graph_enabled(self, enabled: bool, route: str | None = None) -> None:
+        # Mirror the real CogneeWrapper #451 guard: enabling an unwired
+        # route (primary/agent — no v0.3 resolver) is rejected and the
+        # gate stays off.
+        from hal0.memory.cognee_wrapper import GraphRouteUnsupportedError
+
+        if enabled and (route or self.route) in {"primary", "agent"}:
+            raise GraphRouteUnsupportedError(
+                f"graph route {route or self.route!r} is not yet supported (lands v0.4)"
+            )
         self.set_calls.append((enabled, route))
         self.enabled = enabled
         if route is not None:
@@ -95,25 +104,33 @@ def test_graph_status_default_returns_off(client: TestClient, stub_wrapper: Stub
     assert body["builds_ok"] == 0
 
 
-def test_put_enable_with_primary_route_persists(
+def test_put_enable_with_primary_route_rejected(
     client: TestClient, stub_wrapper: StubWrapper, hal0_home: Path
 ) -> None:
+    # Issue #451 — v0.3 has no route resolver for primary/agent (lands
+    # v0.4). Enabling either must fail fast (422) and never flip the gate.
     r = client.put(
         "/api/memory/graph",
         json={"enabled": True, "route": "primary"},
     )
-    assert r.status_code == 200, r.text
-    body = r.json()
-    assert body["enabled"] is True
-    assert body["route"] == "primary"
-    # Wrapper got flipped.
-    assert stub_wrapper.set_calls == [(True, "primary")]
-    # Status payload echoed.
-    assert body["status"]["enabled"] is True
-    # Disk persisted — re-read.
-    r2 = client.get("/api/memory/graph/status")
-    # Stub holds enabled=True now; loader reads same toml.
-    assert r2.json()["route"] == "primary"
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "config.memory_graph_route_unsupported"
+    # Wrapper was NOT flipped on.
+    assert stub_wrapper.set_calls == []
+    assert stub_wrapper.enabled is False
+
+
+def test_put_enable_with_agent_route_rejected(
+    client: TestClient, stub_wrapper: StubWrapper, hal0_home: Path
+) -> None:
+    r = client.put(
+        "/api/memory/graph",
+        json={"enabled": True, "route": "agent"},
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "config.memory_graph_route_unsupported"
+    assert stub_wrapper.set_calls == []
+    assert stub_wrapper.enabled is False
 
 
 def test_put_enable_upstream_without_model_rejected(

--- a/tests/memory/test_graph_gate.py
+++ b/tests/memory/test_graph_gate.py
@@ -40,6 +40,11 @@ def patch_cognify(monkeypatch: pytest.MonkeyPatch):
     """
     import cognee
 
+    # A real (non-placeholder) LLM key so the issue #451 enable guard +
+    # _build_graph belt let the (stubbed) cognify fire. Individual tests
+    # override this to the noop placeholder to exercise the reject paths.
+    monkeypatch.setenv("LLM_API_KEY", "sk-test-real-upstream-key")
+
     calls: list[dict[str, Any]] = []
 
     async def fake_cognify(**kwargs):
@@ -128,6 +133,9 @@ class TestBuildFailureCounter:
     ) -> None:
         import cognee
 
+        # Real key so the #451 belt lets the build fire (then fail).
+        monkeypatch.setenv("LLM_API_KEY", "sk-test-real-upstream-key")
+
         async def boom(**kwargs):
             raise RuntimeError("structured-output parse failed")
 
@@ -163,6 +171,9 @@ class TestBuildFailureCounter:
 class TestDisableCancelsInFlight:
     async def test_disable_cancels(self, wrapper_factory, monkeypatch: pytest.MonkeyPatch) -> None:
         import cognee
+
+        # Real key so the #451 belt lets the build fire (then park).
+        monkeypatch.setenv("LLM_API_KEY", "sk-test-real-upstream-key")
 
         long_running = asyncio.Event()
 
@@ -210,17 +221,84 @@ class TestDisableCancelsInFlight:
 
 
 class TestSetGraphEnabled:
-    async def test_route_change_persists(self, wrapper_factory, patch_cognify) -> None:
-        w = wrapper_factory()
-        w.set_graph_enabled(True, route="agent")
-        s = w.graph_status()
-        assert s["enabled"] is True
-        assert s["route"] == "agent"
-
     async def test_invalid_route_raises(self, wrapper_factory, patch_cognify) -> None:
         w = wrapper_factory()
         with pytest.raises(ValueError):
             w.set_graph_enabled(True, route="bogus")
+
+
+class TestEnableGuardrails:
+    """Issue #451 — fail-fast at enable time, never flip on an unwired
+    route or against the placeholder LLM key.
+
+    v0.3 has no route resolver (lands v0.4 per ADR-0014 §4): enabling
+    ``route=primary`` / ``route=agent`` must be rejected, and
+    ``route=upstream`` must be rejected when ``LLM_API_KEY`` is the noop
+    placeholder cognify would 401 against.
+    """
+
+    async def test_enable_primary_route_rejected(self, wrapper_factory, patch_cognify) -> None:
+        from hal0.memory.cognee_wrapper import GraphRouteUnsupportedError
+
+        w = wrapper_factory()
+        with pytest.raises(GraphRouteUnsupportedError):
+            w.set_graph_enabled(True, route="primary")
+        # Gate stays off — no silent enable.
+        assert w.graph_status()["enabled"] is False
+
+    async def test_enable_agent_route_rejected(self, wrapper_factory, patch_cognify) -> None:
+        from hal0.memory.cognee_wrapper import GraphRouteUnsupportedError
+
+        w = wrapper_factory()
+        with pytest.raises(GraphRouteUnsupportedError):
+            w.set_graph_enabled(True, route="agent")
+        assert w.graph_status()["enabled"] is False
+
+    async def test_enable_upstream_with_placeholder_key_rejected(
+        self, wrapper_factory, patch_cognify, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hal0.memory.cognee_wrapper import _NOOP_LLM_API_KEY, GraphRouteUnsupportedError
+
+        monkeypatch.setenv("LLM_API_KEY", _NOOP_LLM_API_KEY)
+        w = wrapper_factory()
+        with pytest.raises(GraphRouteUnsupportedError):
+            w.set_graph_enabled(True, route="upstream")
+        assert w.graph_status()["enabled"] is False
+
+    async def test_enable_upstream_with_real_key_succeeds(
+        self, wrapper_factory, patch_cognify, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LLM_API_KEY", "sk-real-upstream-key")
+        w = wrapper_factory()
+        w.set_graph_enabled(True, route="upstream")
+        s = w.graph_status()
+        assert s["enabled"] is True
+        assert s["route"] == "upstream"
+
+    async def test_disable_never_validates(self, wrapper_factory, patch_cognify) -> None:
+        # Disabling an unwired route must always succeed — the guard only
+        # fires on the transition to enabled.
+        w = wrapper_factory(graph_enabled=True, graph_route="primary")
+        w.set_graph_enabled(False)
+        assert w.graph_status()["enabled"] is False
+
+    async def test_build_graph_skips_on_placeholder_key(
+        self, wrapper_factory, patch_cognify, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Belt-and-suspenders: even if a hand-edited TOML constructs an
+        # enabled wrapper, _build_graph must NOT fire cognify against the
+        # placeholder key (no 401 retry storm).
+        from hal0.memory.cognee_wrapper import _NOOP_LLM_API_KEY
+
+        monkeypatch.setenv("LLM_API_KEY", _NOOP_LLM_API_KEY)
+        w = wrapper_factory(graph_enabled=True, graph_route="upstream")
+        await w.add("hello world")
+        for t in list(w._graph_tasks):
+            await t
+        # cognify was never called — gate refused to fire the build.
+        assert patch_cognify == []
+        s = w.graph_status()
+        assert s["builds_ok"] == 0
 
 
 class TestSearchModeFallback:


### PR DESCRIPTION
## What

Enabling graph extraction (`hal0 memory graph enable`) used to flip the gate unconditionally. Because the v0.3 per-route resolver is unimplemented (lands v0.4 per ADR-0014 §4), cognify then ran against the placeholder `LLM_API_KEY=sk-hal0-noop-...`, producing a litellm 401 + retry storm on **every** subsequent `memory_add`.

This change makes the enable path fail fast and adds a build-time backstop. Scoped to Option 1 (ship-disabled default + refuse unwired enable) + Option 3 (validate the LLM target at enable time). Full `route=agent`→Lemonade wiring (Option 2) is intentionally **out of scope** — that is the v0.4 deliverable per ADR-0014 §4.

## Why

- `route=primary` / `route=agent` have no v0.3 resolver — nothing to dispatch to.
- `route=upstream` against the noop placeholder key 401s and retries on every add, stalling memory + hal0-api health.

## How

- `CogneeWrapper.set_graph_enabled` validates the route **before** mutating state. Unwired routes and a missing/placeholder `LLM_API_KEY` raise `GraphRouteUnsupportedError`; the gate (and stored route) stay untouched on rejection.
- `_build_graph` re-checks the target and *skips* (does not error) the cognify pass, so a hand-edited `hal0.toml` can't re-introduce the storm.
- `PUT /api/memory/graph` flips the live wrapper **before** persisting, so a rejected enable never writes `enabled = true` to disk, and maps the error to **HTTP 422** (`config.memory_graph_route_unsupported`). The CLI surfaces it as a nonzero exit.

## Acceptance

- [x] `hal0 memory graph enable --route=agent` on a host with the placeholder key fails fast with a clear message; `enabled` stays false in `hal0.toml` (wrapper flip precedes persist).
- [x] No `litellm.AuthenticationError` retry storm after enabling — builds are gated at both enable time and build time.
- [x] `memory_add` still succeeds (vector path unaffected; graph just stays off).
- [x] Unit tests: enabling with unwired route / placeholder key raises and the gate is not flipped (`tests/memory/test_graph_gate.py::TestEnableGuardrails`, `tests/api/test_memory_graph_route.py`).

Note: cross-links #448 (cold-Cognee add vs `_mcp_memory_call` 5s timeout) — same enable-path stability area, separate fix.

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)