### PR TITLE
fix(agents): hermes provision writes seed, env file, and runtime.json

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -24,6 +24,7 @@ for the agent-identity model (X-hal0-Agent header, not Bearer).
 
 from __future__ import annotations
 
+import contextlib
 import datetime
 import hashlib
 import json
@@ -209,6 +210,31 @@ WRAPPER_INSTALL_PATH = Path("/usr/local/bin/hal0-hermes")
 # back-compat symlink to this.
 HERMES_CLI_INSTALL_PATH = Path("/usr/local/bin/hermes")
 REPO_ROOT_FOR_INSTALLER = Path(__file__).resolve().parents[3]
+
+# ── Install artifacts (issue #432) ───────────────────────────────────────────
+#
+# ``hal0 agent bootstrap hermes`` is a separate install path from
+# ``AgentManager.install``; the provision pipeline writes data/state but
+# never wrote the three artifacts downstream components key off, each of
+# which falsely assumed "some other step writes it":
+#
+#   * the manager seed at /etc/hal0/agents/hermes.toml — without it
+#     ``AgentManager._read_record`` short-circuits to ``broken`` before it
+#     ever consults driver health;
+#   * the driver env file at /etc/hal0/agents/hermes.env — the path the
+#     Hermes driver sources (NOT the outbound secrets vault at
+#     HERMES_SECRETS_ENV, a different file);
+#   * runtime.json under $HERMES_HOME — the embed token chat_proxy sends as
+#     ``Authorization: Bearer`` on the browser→hermes hop; absent, every
+#     chat request reaches hermes unauthenticated.
+#
+# All three constants live at module scope so tests can monkey-patch them
+# onto a tmp path, same posture as HERMES_SECRETS_ENV / AGENT_ALLOWLIST_PATH.
+# INSTALL_SEED_PATH is the SAME file as AGENT_ALLOWLIST_PATH — the seed
+# write merges, never clobbers, any operator ``[mcp.servers.*]`` blocks.
+INSTALL_SEED_PATH = Path("/etc/hal0/agents/hermes.toml")
+DRIVER_ENV_PATH = Path("/etc/hal0/agents/hermes.env")
+RUNTIME_JSON_NAME = "runtime.json"
 
 
 # ── Phase A: preflight ──────────────────────────────────────────────────────
@@ -2734,11 +2760,203 @@ def _phase_self_report(state: BootstrapState) -> PhaseResult:
     return PhaseResult(status=PhaseStatus.OK, details={"published": True, "summary_id": summary_id})
 
 
+# ── Phase: install_artifacts (issue #432) ────────────────────────────────────
+#
+# Writes the three manager/proxy install artifacts the provision pipeline
+# used to leak (seed TOML, driver env file, runtime.json embed token). Runs
+# right after home_init so $HERMES_HOME exists for runtime.json, and before
+# the phases that read the seed/allowlist (mcp_wire) so a single bootstrap
+# converges. Idempotent: the embed token is generated once and re-used on
+# re-runs (so the secret doesn't rotate under a running proxy); ``--repair``
+# forces a fresh token + rewrites every artifact.
+
+
+def _seed_payload(state: BootstrapState) -> dict[str, Any]:
+    """Build the ``[agent]`` seed block, mirroring AgentManager._write_seed.
+
+    Shape matches ``hal0.agents.manager.AgentManager._write_seed`` so the
+    manager's ``_read_record`` parses an identical layout regardless of which
+    install path wrote the file.
+    """
+    return {
+        "agent": {
+            "name": "hermes",
+            "installed_at": datetime.datetime.now(tz=datetime.UTC).isoformat(),
+            # Track-latest by design (ADR-0004 §3). No version pin.
+            "version_pin": False,
+        },
+        "data_dir": str(Path("/var/lib/hal0/agents/hermes")),
+    }
+
+
+def _write_seed_toml(state: BootstrapState, *, repair: bool) -> tuple[Path, bool]:
+    """Write/merge the manager seed at :data:`INSTALL_SEED_PATH`.
+
+    The seed file doubles as the MCP allow-list (``[mcp.servers.*]``), so we
+    deep-merge: refresh ``[agent]`` + ``data_dir`` while preserving any
+    operator-added server blocks. Returns ``(path, wrote)`` — ``wrote`` is
+    ``False`` when an existing ``[agent]`` block already carried an
+    ``installed_at`` and ``repair`` is off (idempotent no-op on re-run).
+    """
+    import tomllib
+
+    import tomli_w
+
+    path = INSTALL_SEED_PATH
+    existing: dict[str, Any] = {}
+    if path.exists():
+        try:
+            existing = tomllib.loads(path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError):
+            existing = {}
+
+    has_seed = bool((existing.get("agent") or {}).get("installed_at"))
+    if has_seed and not repair:
+        return path, False
+
+    payload = _seed_payload(state)
+    merged = dict(existing)
+    merged["agent"] = payload["agent"]
+    merged["data_dir"] = payload["data_dir"]
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".toml.tmp")
+    tmp.write_bytes(tomli_w.dumps(merged).encode("utf-8"))
+    os.replace(tmp, path)
+    return path, True
+
+
+def _write_driver_env(state: BootstrapState) -> tuple[Path, bool]:
+    """Write the driver env file at :data:`DRIVER_ENV_PATH`.
+
+    Mirrors ``HermesDriver._write_env_file``: the wrapper sources this on
+    every invocation for the hal0 API URL + MCP endpoints. Content is
+    deterministic, so a hash-equal file is left untouched. Returns
+    ``(path, wrote)``.
+    """
+    api_base = HAL0_API_URL.rstrip("/")
+    body = (
+        "# hal0 — Hermes-Agent env (managed by hal0; safe to edit)\n"
+        f"HAL0_API_URL={api_base}\n"
+        f"HAL0_MCP_ADMIN_URL={api_base}/mcp/admin\n"
+        f"HAL0_MCP_MEMORY_URL={api_base}/mcp/memory\n"
+    )
+    path = DRIVER_ENV_PATH
+    if path.exists():
+        try:
+            if path.read_text(encoding="utf-8") == body:
+                return path, False
+        except OSError:
+            pass
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".env.tmp")
+    tmp.write_text(body, encoding="utf-8")
+    os.replace(tmp, path)
+    return path, True
+
+
+def _write_runtime_json(state: BootstrapState, *, repair: bool) -> tuple[Path, bool]:
+    """Write ``runtime.json`` (embed token) under ``$HERMES_HOME`` chmod 0600.
+
+    The embed token is the shared secret chat_proxy sends as
+    ``Authorization: Bearer`` on the browser→hermes hop. Generated once and
+    re-used on re-runs so the secret never rotates under a running proxy;
+    ``repair`` forces a fresh token. Returns ``(path, wrote)``.
+    """
+    import secrets as _secrets
+
+    path = Path(state.hermes_home) / RUNTIME_JSON_NAME
+    token: str | None = None
+    if path.exists() and not repair:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            existing = data.get("token") or data.get("embed_token")
+            if isinstance(existing, str) and existing:
+                token = existing
+        except (OSError, json.JSONDecodeError):
+            token = None
+    if token is not None:
+        # Re-tighten perms; the token is already on disk and unchanged.
+        with contextlib.suppress(OSError):
+            path.chmod(0o600)
+        return path, False
+
+    token = _secrets.token_urlsafe(32)
+    payload = {"token": token, "written_at": _utcnow()}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+    with contextlib.suppress(OSError):
+        path.chmod(0o600)
+    return path, True
+
+
+def _phase_install_artifacts(state: BootstrapState) -> PhaseResult:
+    """Write the seed TOML, driver env file, and runtime.json (issue #432).
+
+    These three artifacts were previously only written by
+    ``AgentManager.install``; the ``hal0 agent bootstrap hermes`` path skipped
+    them entirely, leaving the manager reporting ``broken`` and the chat proxy
+    sending no Bearer. Idempotent + ``--repair``-aware (mirrors persona_seed).
+
+    Sandbox guard (mirrors gateway_secrets_wire): under pytest, refuse to
+    write the seed/env when they still point at the real ``/etc/`` tree.
+    A test that genuinely exercises these writes monkeypatches
+    INSTALL_SEED_PATH / DRIVER_ENV_PATH to tmp_path; the runtime.json write
+    is always tmp-safe because it tracks ``state.hermes_home``.
+    """
+    repair = bool(state.phases.get("_repair_flag"))
+
+    under_pytest = bool(os.environ.get("PYTEST_CURRENT_TEST"))
+    if under_pytest and (
+        str(INSTALL_SEED_PATH).startswith("/etc/") or str(DRIVER_ENV_PATH).startswith("/etc/")
+    ):
+        # Don't strand artifacts entirely — runtime.json is tmp-safe.
+        runtime_path, token_wrote = _write_runtime_json(state, repair=repair)
+        return PhaseResult(
+            status=PhaseStatus.SKIP,
+            reason=(
+                "running under pytest with un-sandboxed /etc seed/env paths "
+                "— refusing to write the real /etc/hal0 tree; monkeypatch "
+                "INSTALL_SEED_PATH/DRIVER_ENV_PATH to tmp in the test fixture"
+            ),
+            details={
+                "seed_path": str(INSTALL_SEED_PATH),
+                "env_path": str(DRIVER_ENV_PATH),
+                "runtime_json_path": str(runtime_path),
+                "token_wrote": token_wrote,
+            },
+        )
+
+    seed_path, seed_wrote = _write_seed_toml(state, repair=repair)
+    env_path, env_wrote = _write_driver_env(state)
+    runtime_path, token_wrote = _write_runtime_json(state, repair=repair)
+
+    return PhaseResult(
+        status=PhaseStatus.OK,
+        details={
+            "seed_path": str(seed_path),
+            "seed_wrote": seed_wrote,
+            "env_path": str(env_path),
+            "env_wrote": env_wrote,
+            "runtime_json_path": str(runtime_path),
+            "token_wrote": token_wrote,
+        },
+    )
+
+
 PHASES: list[tuple[str, Callable[[BootstrapState], PhaseResult]]] = [
     ("preflight", _phase_preflight),
     ("install", _phase_install),
     ("env_probe", _phase_env_probe),
     ("home_init", _phase_home_init),
+    # #432: write the manager seed + driver env + runtime.json embed token
+    # right after $HERMES_HOME exists and before mcp_wire reads the seed's
+    # allow-list, so a single `bootstrap hermes` run leaves the artifacts the
+    # manager + chat_proxy key off (previously only AgentManager.install wrote
+    # them, so the bootstrap path left the agent reporting `broken`).
+    ("install_artifacts", _phase_install_artifacts),
     # PR-3 Phase 8: seed personas BEFORE config_write so the first
     # config render gets the active persona's system_prompt prelude.
     # mcp_wire runs after config_write to probe the live MCP surface;

--- a/src/hal0/agents/manager.py
+++ b/src/hal0/agents/manager.py
@@ -38,6 +38,7 @@ shell out to ``installer/agents/<name>.sh``. Drivers are looked up by
 
 from __future__ import annotations
 
+import contextlib
 import datetime
 import shutil
 from dataclasses import dataclass
@@ -442,12 +443,23 @@ class AgentManager:
 
         if not seed_readable:
             # No seed (or unreadable) but is_present_on_disk says
-            # something else is here — synthesise a broken record so the
-            # dashboard surfaces it.
+            # something else is here. Before synthesising ``broken``,
+            # consult the driver's live health probe (#432): the
+            # ``hal0 agent bootstrap hermes`` path used to leave the
+            # data + state dirs on disk without the /etc seed, so a
+            # *running, reachable* agent reported ``broken`` purely
+            # because the seed write never happened. If the driver says
+            # the agent is reachable, report ``installed`` and recover
+            # the half-state; otherwise fall through to ``broken`` so
+            # the dashboard's repair affordance stays reachable (#346).
+            status = "broken"
+            with contextlib.suppress(Exception):
+                if self.is_present_on_disk(name) and _driver_for(name).status() == "installed":
+                    status = "installed"
             return AgentRecord(
                 name=name,
                 installed_at="",
-                status="broken",
+                status=status,
                 data_dir=str(self._data_dir(name)),
                 config_path=str(toml_path),
             )

--- a/src/hal0/api/agents/chat_proxy.py
+++ b/src/hal0/api/agents/chat_proxy.py
@@ -72,9 +72,10 @@ router = APIRouter()
 DEFAULT_HERMES_HOST: Final[str] = "127.0.0.1"
 DEFAULT_HERMES_PORT: Final[int] = 9119
 
-# runtime.json lives where PR-3's ``hermes_provision`` writes it. The
-# bootstrap chmods it 0600 — we re-tighten on every read to belt-and-
-# braces against permission drift.
+# runtime.json lives where ``hermes_provision``'s install_artifacts phase
+# writes it (issue #432 — previously nothing wrote it). The bootstrap
+# chmods it 0600; we re-tighten on every read to belt-and-braces against
+# permission drift.
 RUNTIME_JSON_DEFAULT: Final[str] = "/var/lib/hal0/.hermes/runtime.json"
 
 # tool.progress coalescing window. 100ms matches the rate at which the
@@ -100,7 +101,7 @@ def _runtime_json_path() -> Path:
     """Return the on-disk runtime.json path.
 
     Honours ``HAL0_HERMES_RUNTIME_JSON`` (tests + alt installs). The
-    default tracks PR-3's writer.
+    default tracks the bootstrap's install_artifacts writer (#432).
     """
     return Path(os.environ.get("HAL0_HERMES_RUNTIME_JSON", RUNTIME_JSON_DEFAULT))
 

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -126,6 +126,10 @@ def test_phase_names_in_planned_order() -> None:
         "install",
         "env_probe",
         "home_init",
+        # #432: install_artifacts writes the manager seed + driver env +
+        # runtime.json right after $HERMES_HOME exists and before mcp_wire
+        # reads the seed allow-list.
+        "install_artifacts",
         # PR-3 (v0.3): persona_seed inserted before config_write so the
         # first render carries the active persona's system_prompt
         # prelude (Phase 7) on the same pass that lands chat_slots.
@@ -154,7 +158,11 @@ def test_run_marks_every_phase_ok_on_fresh(
     # configured (most CI envs); gateway_secrets_wire SKIPs when the test
     # runner is non-root (can't write /etc/systemd/system). Accept both
     # OK and SKIP for those phases.
-    skip_ok = {"voice_wire", "gateway_secrets_wire"}
+    # #432: install_artifacts SKIPs under the pytest sandbox guard when the
+    # /etc seed/env paths aren't monkeypatched (same posture as
+    # gateway_secrets_wire); its write path is covered by
+    # test_hermes_provision_install_artifacts.py.
+    skip_ok = {"voice_wire", "gateway_secrets_wire", "install_artifacts"}
     for name in hp.PHASE_NAMES:
         status = result.phases[name]["status"]
         allowed = {hp.PhaseStatus.OK.value} | (
@@ -196,7 +204,11 @@ def test_repair_flag_forces_rerun(tmp_path: Path, state_with_tmp_paths: hp.Boots
     # gateway_secrets_wire SKIPs when the test runner is non-root (can't
     # write /etc/systemd/system). Accept both OK and SKIP for those phases
     # (same posture as the fresh-run test above).
-    skip_ok = {"voice_wire", "gateway_secrets_wire"}
+    # #432: install_artifacts SKIPs under the pytest sandbox guard when the
+    # /etc seed/env paths aren't monkeypatched (same posture as
+    # gateway_secrets_wire); its write path is covered by
+    # test_hermes_provision_install_artifacts.py.
+    skip_ok = {"voice_wire", "gateway_secrets_wire", "install_artifacts"}
     for name in hp.PHASE_NAMES:
         status = second.phases[name]["status"]
         allowed = {hp.PhaseStatus.OK.value} | (

--- a/tests/agents/test_hermes_provision_install_artifacts.py
+++ b/tests/agents/test_hermes_provision_install_artifacts.py
@@ -1,0 +1,131 @@
+"""Install-artifacts phase contract (issue #432).
+
+``hal0 agent bootstrap hermes`` is a separate install path from
+``AgentManager.install``. The provision pipeline wrote data/state but
+never the three artifacts downstream components key off:
+
+  * the manager seed at ``/etc/hal0/agents/hermes.toml``,
+  * the driver env file at ``/etc/hal0/agents/hermes.env``,
+  * ``runtime.json`` (embed token) under ``$HERMES_HOME``.
+
+These tests pin the new ``install_artifacts`` phase: a fresh run writes
+all three; re-runs are idempotent (the embed token does NOT rotate);
+``--repair`` rewrites a fresh token; and the chat proxy's
+``_load_embed_token`` finds the token the phase wrote.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from hal0.agents import hermes_provision as hp
+from hal0.api.agents import chat_proxy
+
+
+@pytest.fixture
+def artifact_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.BootstrapState:
+    """A BootstrapState + module path constants rooted under ``tmp_path``.
+
+    Redirects the three artifact destinations off the real /etc + /var
+    tree so the phase writes are hermetic.
+    """
+    hermes_home = tmp_path / "var" / "lib" / "hal0" / ".hermes"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setattr(
+        hp, "INSTALL_SEED_PATH", tmp_path / "etc" / "hal0" / "agents" / "hermes.toml"
+    )
+    monkeypatch.setattr(hp, "DRIVER_ENV_PATH", tmp_path / "etc" / "hal0" / "agents" / "hermes.env")
+    return hp.BootstrapState(hermes_home=str(hermes_home), agent_id="hermes-agent")
+
+
+def test_phase_writes_all_three_artifacts(artifact_state: hp.BootstrapState) -> None:
+    """A fresh run leaves seed TOML + driver env + runtime.json on disk."""
+    result = hp._phase_install_artifacts(artifact_state)
+    assert result.status is hp.PhaseStatus.OK
+
+    seed_path = hp.INSTALL_SEED_PATH
+    env_path = hp.DRIVER_ENV_PATH
+    runtime_path = Path(artifact_state.hermes_home) / hp.RUNTIME_JSON_NAME
+
+    assert seed_path.exists()
+    assert env_path.exists()
+    assert runtime_path.exists()
+
+    # Seed parses + carries the manager-shape ``[agent]`` block.
+    seed = tomllib.loads(seed_path.read_text(encoding="utf-8"))
+    assert seed["agent"]["name"] == "hermes"
+    assert seed["agent"]["installed_at"]
+    assert seed["agent"]["version_pin"] is False
+    assert seed["data_dir"]
+
+    # Driver env carries the canonical hal0 API URL the wrapper sources.
+    env_body = env_path.read_text(encoding="utf-8")
+    assert "HAL0_API_URL=" in env_body
+    assert "HAL0_MCP_ADMIN_URL=" in env_body
+    assert "HAL0_MCP_MEMORY_URL=" in env_body
+
+    # runtime.json carries a non-empty token + is 0600.
+    data = json.loads(runtime_path.read_text(encoding="utf-8"))
+    assert isinstance(data["token"], str) and data["token"]
+    assert (runtime_path.stat().st_mode & 0o777) == 0o600
+
+
+def test_token_is_stable_across_reruns(artifact_state: hp.BootstrapState) -> None:
+    """Re-running without --repair must NOT rotate the embed token —
+    otherwise a re-provision would break a running proxy mid-session."""
+    hp._phase_install_artifacts(artifact_state)
+    runtime_path = Path(artifact_state.hermes_home) / hp.RUNTIME_JSON_NAME
+    token_1 = json.loads(runtime_path.read_text(encoding="utf-8"))["token"]
+
+    result_2 = hp._phase_install_artifacts(artifact_state)
+    token_2 = json.loads(runtime_path.read_text(encoding="utf-8"))["token"]
+    assert token_1 == token_2
+    assert result_2.details["token_wrote"] is False
+
+
+def test_repair_rotates_token(artifact_state: hp.BootstrapState) -> None:
+    """``--repair`` explicitly resets to known-good — a fresh token."""
+    hp._phase_install_artifacts(artifact_state)
+    runtime_path = Path(artifact_state.hermes_home) / hp.RUNTIME_JSON_NAME
+    token_1 = json.loads(runtime_path.read_text(encoding="utf-8"))["token"]
+
+    # Simulate the orchestrator's --repair flag (stashed on state.phases).
+    artifact_state.phases["_repair_flag"] = {"status": "stub", "details": {}}
+    hp._phase_install_artifacts(artifact_state)
+    token_2 = json.loads(runtime_path.read_text(encoding="utf-8"))["token"]
+    assert token_1 != token_2
+
+
+def test_seed_write_preserves_operator_mcp_servers(artifact_state: hp.BootstrapState) -> None:
+    """The seed TOML doubles as the MCP allow-list — the write must merge,
+    never clobber, any operator-added ``[mcp.servers.*]`` blocks."""
+    seed_path = hp.INSTALL_SEED_PATH
+    seed_path.parent.mkdir(parents=True, exist_ok=True)
+    seed_path.write_text(
+        '[mcp.servers.custom]\nurl = "http://127.0.0.1:9000/mcp"\n',
+        encoding="utf-8",
+    )
+    hp._phase_install_artifacts(artifact_state)
+
+    seed = tomllib.loads(seed_path.read_text(encoding="utf-8"))
+    assert seed["mcp"]["servers"]["custom"]["url"] == "http://127.0.0.1:9000/mcp"
+    # And the agent block was still written.
+    assert seed["agent"]["name"] == "hermes"
+
+
+def test_chat_proxy_finds_token_after_provision(
+    artifact_state: hp.BootstrapState, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end seam: chat_proxy._load_embed_token() resolves the token
+    the install_artifacts phase wrote (previously always None — runtime.json
+    had zero writers)."""
+    hp._phase_install_artifacts(artifact_state)
+    runtime_path = Path(artifact_state.hermes_home) / hp.RUNTIME_JSON_NAME
+    expected = json.loads(runtime_path.read_text(encoding="utf-8"))["token"]
+
+    monkeypatch.setenv("HAL0_HERMES_RUNTIME_JSON", str(runtime_path))
+    assert chat_proxy._load_embed_token() == expected

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -352,6 +352,50 @@ def test_list_synthesises_broken_record_for_orphan(
     assert listing[0].installed_at == ""
 
 
+def test_read_record_consults_driver_when_seed_missing(
+    manager: AgentManager,
+    stub_drivers: dict[str, _StubDriver],
+) -> None:
+    """#432: a running agent with on-disk artifacts but NO /etc seed must
+    report ``installed``, not ``broken``.
+
+    The ``hal0 agent bootstrap hermes`` path used to leave the data +
+    state dirs on disk without writing the seed TOML, so ``_read_record``
+    short-circuited to ``broken`` before ever consulting driver health —
+    even though the agent was up and reachable. Now the missing-seed
+    branch defers to ``driver.status()``."""
+    # Synthesise the half-state: data dir present, seed absent.
+    manager._data_dir("hermes").mkdir(parents=True)
+    assert not manager._config_path("hermes").exists()
+    # Driver reports the live agent as reachable.
+    stub_drivers["hermes"]._installed = True
+
+    listing = manager.list()
+    assert len(listing) == 1
+    assert listing[0].name == "hermes"
+    assert listing[0].status == "installed", (
+        "missing-seed + running agent reported 'broken' — #432 regression"
+    )
+    # No seed → no recorded install timestamp.
+    assert listing[0].installed_at == ""
+
+
+def test_read_record_stays_broken_when_driver_unreachable(
+    manager: AgentManager,
+    stub_drivers: dict[str, _StubDriver],
+) -> None:
+    """#432: the missing-seed branch only upgrades to ``installed`` when
+    the driver actually reports reachable. A dead agent with orphan
+    artifacts must stay ``broken`` so the repair affordance is reachable
+    (#346)."""
+    manager._state_dir("hermes").mkdir(parents=True)
+    stub_drivers["hermes"]._installed = False
+
+    listing = manager.list()
+    assert len(listing) == 1
+    assert listing[0].status == "broken"
+
+
 def test_is_present_on_disk_predicate(
     manager: AgentManager,
     stub_drivers: dict[str, _StubDriver],


### PR DESCRIPTION
## What

`hal0 agent bootstrap hermes` (the provision pipeline) is a separate install path from `AgentManager.install`. It wrote `provision.json` + state + the outbound secrets vault, but never the three artifacts the manager and chat proxy depend on — each downstream component falsely assumed some other step wrote it:

- **`/etc/hal0/agents/hermes.toml`** — manager seed (doubles as the MCP allow-list). Missing it makes `AgentManager._read_record` short-circuit to `broken` before consulting driver health.
- **`/etc/hal0/agents/hermes.env`** — the env file the Hermes driver sources (distinct from the outbound `HERMES_SECRETS_ENV` vault).
- **`$HERMES_HOME/runtime.json`** — the embed token `chat_proxy` sends as `Authorization: Bearer`; absent, every chat request reaches hermes unauthenticated.

## Why

The bootstrap path left a half-installed agent: manager reported `broken`, the proxy sent no Bearer. This PR adds an `install_artifacts` provision phase (after `home_init`, before `mcp_wire` reads the allow-list) that atomically writes all three, and hardens `_read_record` to consult driver health when the seed is absent.

- Idempotent: the embed token is generated once and re-used; `--repair` forces a fresh token + rewrites all artifacts (mirrors `persona_seed`).
- The seed write **merges** rather than clobbers, so operator `[mcp.servers.*]` blocks survive.
- A pytest sandbox guard mirrors `gateway_secrets_wire` — refuses to touch the real `/etc` tree unless monkeypatched to tmp.

Closes #432

## Acceptance

- [x] Fresh bootstrap run leaves `hermes.toml` + `/etc` `hermes.env` + `runtime.json` on disk (tmp path env overrides)
- [x] `_read_record` returns `installed` for a running agent with a missing seed (and stays `broken` when the driver is unreachable)
- [x] `chat_proxy._load_embed_token()` finds the token after provision
- [x] Paths consistent with `/var/lib/hal0/.hermes` (re: #453)
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)