### PR TITLE
fix(mcp): read auth headers from FastMCP request context, not dropped contextvar

### DIFF
--- a/installer/wrappers/hal0-hermes
+++ b/installer/wrappers/hal0-hermes
@@ -6,10 +6,11 @@
 #   HERMES_HOME    — pins Hermes's state dir under hal0's tree so a
 #                    `hermes reset` or upstream config-rewrite stays
 #                    contained.
-#   HAL0_AGENT_ID  — read by `MCPIdentityMiddleware` (renamed from
-#                    `MCPAuthMiddleware`) via the `X-hal0-Agent`
-#                    header, then echoed back as the `client_id` for
-#                    Cognee's `private:<client_id>` namespace.
+#   HAL0_AGENT_ID  — surfaced on outbound MCP calls and echoed back as
+#                    the `client_id` for Cognee's `private:<client_id>`
+#                    namespace. The hal0 MCP mount resolves the caller's
+#                    identity + `--private` toggle straight off the live
+#                    MCP request headers (see `hal0.api.mcp_mount`).
 #
 # It then execs the hal0-managed venv's `hermes` binary. The venv
 # lives at /var/lib/hal0/venvs/hermes/ (hard-pinned in

--- a/src/hal0/api/mcp_mount.py
+++ b/src/hal0/api/mcp_mount.py
@@ -8,20 +8,29 @@ the FastAPI ``app``, the ``AuthIdentity`` middleware, the lifespan-scoped
 The trick the mount needs to solve: FastMCP runs as a sub-ASGI app
 underneath ``/mcp/admin`` and ``/mcp/memory``, but the MCP tool handlers
 need to know *who* is calling so the audit log + the ``--private``
-namespace promotion can stamp the right ``client_id``. Solution = a
-contextvar populated by a thin Starlette middleware on each mounted
-sub-app, paired with resolver callbacks that the FastMCP ``build_server``
-functions accept.
+namespace promotion can stamp the right ``client_id``. Solution =
+resolver callbacks (wired into each ``build_server``) that read the
+caller headers straight off the MCP SDK's per-handler request context.
+
+Why not a Starlette-middleware contextvar (issue #413)? FastMCP runs
+tool handlers inside a *lifespan-scoped* anyio task group spun up by
+``StreamableHTTPSessionManager.run()`` — not in the per-request task a
+Starlette ``BaseHTTPMiddleware`` writes into. A contextvar ``set()`` in
+request-dispatch therefore never propagates to the handler: it always
+reads the default (``private=False``, ``client_id="anonymous"``), so
+every write silently collapsed to the ``shared`` namespace regardless of
+``X-hal0-Private: 1``. The MCP SDK *does* set its own ``request_ctx``
+contextvar inside the handler's own task (``mcp.server.lowlevel.server``)
+and stashes the originating Starlette ``Request`` on it; we read the
+headers off that request at call time, mirroring the REST surface in
+:mod:`hal0.api.routes.memory` which reads them straight off ``request``.
 """
 
 from __future__ import annotations
 
 import os
-from contextvars import ContextVar
-from dataclasses import dataclass
 
 import structlog
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.types import ASGIApp
 
@@ -100,68 +109,60 @@ def _mcp_transport_security():
     )
 
 
-@dataclass
-class _MCPCallerCtx:
-    """Per-request caller info populated by :class:`MCPAuthMiddleware`."""
+def _current_mcp_request() -> Request | None:
+    """Return the Starlette ``Request`` for the in-flight MCP tool call.
 
-    bearer: str | None
-    client_id: str
-    private: bool
-
-
-_caller: ContextVar[_MCPCallerCtx | None] = ContextVar("hal0_mcp_caller", default=None)
+    The MCP SDK sets its ``request_ctx`` contextvar *inside* the handler's
+    own anyio task (``mcp.server.lowlevel.server``) and stashes the
+    originating Starlette ``Request`` on ``RequestContext.request`` — that
+    request carries the caller's HTTP headers. Returns ``None`` outside an
+    MCP request (e.g. direct dispatcher calls in unit tests), so resolvers
+    fall back to their anonymous defaults.
+    """
+    try:
+        from mcp.server.lowlevel.server import request_ctx
+    except ImportError:  # pragma: no cover — mcp SDK absent (stubbed tests)
+        return None
+    try:
+        ctx = request_ctx.get()
+    except LookupError:
+        return None
+    request = getattr(ctx, "request", None)
+    return request if isinstance(request, Request) else None
 
 
 def bearer_resolver() -> tuple[str | None, str]:
     """Return ``(raw_bearer, client_id)`` for the current MCP request.
 
-    Wired into :func:`hal0.mcp.admin.build_server`. Falls back to
-    ``(None, "anonymous")`` outside of an MCP request — useful for
+    Wired into :func:`hal0.mcp.admin.build_server`. Reads the
+    ``Authorization`` header off the live MCP request context; falls back
+    to ``(None, "anonymous")`` outside of an MCP request — useful for
     direct dispatcher calls in tests.
     """
-    ctx = _caller.get()
-    if ctx is None:
+    request = _current_mcp_request()
+    if request is None:
         return None, "anonymous"
-    return ctx.bearer, ctx.client_id
+    bearer = _resolve_bearer(request)
+    return bearer, bearer or "anonymous"
 
 
 def client_id_resolver() -> str:
     """Return ``client_id`` for the current MCP request. See
     :func:`bearer_resolver`."""
-    ctx = _caller.get()
-    return ctx.client_id if ctx is not None else "anonymous"
+    return bearer_resolver()[1]
 
 
 def private_resolver() -> bool:
     """Return whether the calling client toggled ``--private`` mode.
 
-    Read from a ``X-hal0-Private: 1`` request header by the middleware
-    — namespace promotion per ADR-0005 §3 is opt-in per client.
+    Read from the ``X-hal0-Private: 1`` request header off the live MCP
+    request context — namespace promotion per ADR-0005 §3 is opt-in per
+    client.
     """
-    ctx = _caller.get()
-    return bool(ctx and ctx.private)
-
-
-class MCPAuthMiddleware(BaseHTTPMiddleware):
-    """Stash MCP caller ctx in a contextvar (auth removed in v0.3).
-
-    The middleware no longer enforces bearer auth — that surface was
-    removed alongside the FastAPI auth modules. It still parses any
-    Authorization: Bearer token off the request (so upstream tools that
-    do pass one can be identified for logging / scoping) but does not
-    require one.
-    """
-
-    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
-        bearer = _resolve_bearer(request)
-        client_id = bearer or "anonymous"
-        private = request.headers.get("x-hal0-private", "").lower() in {"1", "true"}
-
-        token = _caller.set(_MCPCallerCtx(bearer=bearer, client_id=client_id, private=private))
-        try:
-            return await call_next(request)
-        finally:
-            _caller.reset(token)
+    request = _current_mcp_request()
+    if request is None:
+        return False
+    return request.headers.get("x-hal0-private", "").strip().lower() in {"1", "true"}
 
 
 def mount_mcp_servers(
@@ -208,7 +209,6 @@ def mount_mcp_servers(
     # without that, mounted requests crash with
     # ``Task group is not initialized``.
     admin_app: ASGIApp = admin_server.streamable_http_app()
-    admin_app.add_middleware(MCPAuthMiddleware)
     app.mount("/mcp/admin", admin_app, name="mcp-admin")
 
     session_managers = [admin_server.session_manager]
@@ -228,7 +228,6 @@ def mount_mcp_servers(
         )
         memory_server.settings.transport_security = transport_security
         memory_app: ASGIApp = memory_server.streamable_http_app()
-        memory_app.add_middleware(MCPAuthMiddleware)
         app.mount("/mcp/memory", memory_app, name="mcp-memory")
         session_managers.append(memory_server.session_manager)
         mcp_servers["hal0-memory"] = memory_server

--- a/tests/mcp/test_mcp_mount_private_header.py
+++ b/tests/mcp/test_mcp_mount_private_header.py
@@ -1,0 +1,149 @@
+"""Regression test for issue #413 — MCP ``--private`` namespace promotion.
+
+The bug: ``hal0.api.mcp_mount`` parsed ``X-hal0-Private: 1`` into a
+contextvar inside a Starlette ``BaseHTTPMiddleware`` (per-request task),
+but FastMCP runs tool handlers in a *lifespan-scoped* anyio task group
+spun up by ``StreamableHTTPSessionManager.run()`` — not the per-request
+task the middleware writes into. The contextvar value never reached the
+handler, so ``private_resolver`` always returned ``False`` and every
+write collapsed to the ``shared`` namespace regardless of the header.
+
+The fix reads the caller headers straight off the MCP SDK's per-handler
+request context (``mcp.server.lowlevel.server.request_ctx``), which the
+SDK sets *inside* the handler's own task and stamps with the originating
+Starlette ``Request`` (headers and all). These tests reproduce the
+in-handler condition directly: we set the SDK ``request_ctx`` to a
+``RequestContext`` carrying a real ``Request`` with (or without) the
+header, then drive the production resolvers + the mounted memory tool.
+
+On ``main`` the resolvers read the dropped ``_caller`` contextvar, so
+``private_resolver()`` returns ``False`` even with the header present —
+``test_private_resolver_reads_header_off_request_ctx`` fails there. After
+the fix both the resolver and the tool path honour the live header.
+
+The conftest stub only kicks in when the real ``mcp`` SDK is absent;
+these tests need the real SDK (the request context only exists in the
+real transport) and skip cleanly when it isn't installed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+# These tests exercise the real MCP request context — skip when the SDK
+# isn't installed (the tests/mcp conftest otherwise installs a stub that
+# has no request context to read).
+pytest.importorskip("mcp.server.fastmcp")
+request_ctx_mod = pytest.importorskip("mcp.server.lowlevel.server")
+
+from starlette.requests import Request  # noqa: E402
+
+from hal0.api import mcp_mount  # noqa: E402
+from hal0.mcp import memory  # noqa: E402
+
+_request_ctx = request_ctx_mod.request_ctx
+
+
+def _make_request(headers: dict[str, str]) -> Request:
+    """Build a minimal Starlette ``Request`` carrying ``headers``."""
+    raw = [(k.lower().encode(), v.encode()) for k, v in headers.items()]
+    return Request({"type": "http", "method": "POST", "path": "/mcp/memory", "headers": raw})
+
+
+class _CtxToken:
+    """Set the SDK ``request_ctx`` to a context whose ``.request`` carries
+    the given headers — mirrors what the streamable-HTTP transport does
+    inside the handler task (``mcp.server.lowlevel.server``)."""
+
+    def __init__(self, headers: dict[str, str]) -> None:
+        self._headers = headers
+        self._token: Any = None
+
+    def __enter__(self) -> None:
+        from mcp.shared.context import RequestContext
+
+        ctx = RequestContext(
+            request_id=1,
+            meta=None,
+            session=None,
+            lifespan_context=None,
+            request=_make_request(self._headers),
+        )
+        self._token = _request_ctx.set(ctx)
+
+    def __exit__(self, *exc: object) -> None:
+        _request_ctx.reset(self._token)
+
+
+class _RecordingWrapper:
+    """Stand-in CogneeWrapper that records the ``dataset`` each call gets."""
+
+    def __init__(self) -> None:
+        self.add_calls: list[dict[str, Any]] = []
+
+    async def add(
+        self,
+        *,
+        text: str,
+        dataset: str,
+        tags: list[str],
+        source: str,
+        metadata: dict[str, Any],
+        client_id: str | None = None,
+    ) -> dict[str, Any]:
+        self.add_calls.append(
+            {"text": text, "dataset": dataset, "source": source, "client_id": client_id}
+        )
+        return {"id": "id-1", "timestamp": "2026-06-04T00:00:00Z"}
+
+
+def test_private_resolver_reads_header_off_request_ctx() -> None:
+    """``private_resolver`` honours X-hal0-Private off the live request.
+
+    Fails on main (reads the dropped ``_caller`` contextvar → False);
+    passes once the resolver reads the SDK request context.
+    """
+    with _CtxToken({"X-hal0-Private": "1"}):
+        assert mcp_mount.private_resolver() is True
+        assert mcp_mount.client_id_resolver() == "anonymous"
+    with _CtxToken({}):
+        assert mcp_mount.private_resolver() is False
+    # Outside any MCP request context the resolver falls back to False.
+    assert mcp_mount.private_resolver() is False
+
+
+def test_bearer_resolver_stamps_client_id_off_request_ctx() -> None:
+    """A Bearer token on the live request becomes the client_id."""
+    with _CtxToken({"Authorization": "Bearer pi-coder-token"}):
+        bearer, client_id = mcp_mount.bearer_resolver()
+        assert bearer == "pi-coder-token"
+        assert client_id == "pi-coder-token"
+
+
+@pytest.mark.asyncio
+async def test_memory_add_promotes_to_private_namespace_via_resolvers() -> None:
+    """End-to-end: the dispatcher wired with the production resolvers
+    promotes a write to ``private:<client_id>`` when the live MCP request
+    carries ``X-hal0-Private: 1`` — and stays ``shared`` without it.
+
+    This is the user-visible symptom from #413: private writes silently
+    landed in ``shared`` because the resolver never saw the header.
+    """
+    wrapper = _RecordingWrapper()
+    dispatcher = memory.make_dispatcher(
+        wrapper,
+        client_id_resolver=mcp_mount.client_id_resolver,
+        private_resolver=mcp_mount.private_resolver,
+    )
+
+    with _CtxToken({"X-hal0-Private": "1"}):
+        out = await dispatcher("memory_add", {"text": "remember me", "dataset": ""})
+    assert out["status"] == "ok", out
+    assert wrapper.add_calls[-1]["dataset"] == "private:anonymous"
+
+    with _CtxToken({}):
+        out = await dispatcher("memory_add", {"text": "shared note", "dataset": ""})
+    assert out["status"] == "ok", out
+    assert wrapper.add_calls[-1]["dataset"] == "shared"


### PR DESCRIPTION
## What

MCP private/client_id resolvers in `hal0.api.mcp_mount` read a `_caller` `ContextVar` set per-request by a Starlette `BaseHTTPMiddleware`. FastMCP, however, runs tool handlers inside the **lifespan-scoped** anyio task group spun up by `StreamableHTTPSessionManager.run()` — not the per-request task the middleware writes into. The contextvar value therefore never reaches the handler.

Result: `private_resolver()` always returned `False` and `client_id_resolver()` always `anonymous`, so every memory write over MCP collapsed to the `shared` namespace regardless of `X-hal0-Private: 1`. Per-agent private memory was a silent no-op on the MCP surface.

## Why this fix

Drop the contextvar bridge (and the now-purposeless `MCPAuthMiddleware`) and read the caller headers straight off the MCP SDK's per-handler request context (`mcp.server.lowlevel.server.request_ctx`). The SDK sets that contextvar **inside the handler's own task** and stamps it with the originating Starlette `Request` (headers included). This mirrors the REST surface in `hal0.api.routes.memory`, which already reads the same headers directly off the request and works.

Sibling of #317 (same symptom class — writes forced to `shared`) but a different surface: that was a REST-side hardcode, this is the MCP contextvar drop.

Closes #413

## Acceptance

- [x] `X-hal0-Private: 1` (no bearer) → write resolves to `private:anonymous`.
- [x] No header → write stays in `shared`.
- [x] A Bearer token stamps `client_id` off the live request (not `anonymous`).
- [x] New regression test `tests/mcp/test_mcp_mount_private_header.py` fails on `main` (3 failing), passes after the fix.
- [x] Full `tests/mcp/` suite green (106 passed); `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)