### PR TITLE
fix(dashboard): relabel memory-map UMA pool as GPU/GTT, not 'unified'

### DIFF
--- a/ui/src/api/hooks/useHardware.ts
+++ b/ui/src/api/hooks/useHardware.ts
@@ -23,6 +23,7 @@ export interface Hardware {
   ram: { total: number; used: number; free: number }
   unifiedMb: number
   gttTotalMb: number
+  memoryKind: string
   npu: {
     present: boolean
     vendor: string
@@ -88,6 +89,12 @@ function normalizeHardware(raw: any): Hardware {
     },
     unifiedMb: Number(raw?.unified_memory_mb ?? 0),
     gttTotalMb: Number(raw?.gtt_total_mb ?? 0),
+    // Authoritative UMA signal is backend memory_kind; fall back to a
+    // populated unified_memory_mb (Strix Halo UMA reports it, discrete
+    // GPUs don't) so the memory-map pool label is right even on older
+    // probes that omit the field.
+    memoryKind:
+      raw?.memory_kind ?? (Number(raw?.unified_memory_mb ?? 0) > 0 ? 'unified' : 'system'),
     npu: {
       present: !!(npu?.present ?? raw?.npu_present),
       vendor: npu?.vendor ?? '',

--- a/ui/src/dash/data.jsx
+++ b/ui/src/dash/data.jsx
@@ -22,6 +22,8 @@ const HAL0_DATA = {
     ram_available_mb: 75776,
     unified_memory_mb: 131072,
     gtt_total_mb: 81920,
+    memory_kind: "unified", // Strix Halo UMA — drives memory-map "GPU pool (GTT)" label
+
     gpu_name: "AMD Radeon 8060S (gfx1151, Strix Halo)",
     gpu_vendor: "amd",
     gpus: [

--- a/ui/src/dash/memory-map.jsx
+++ b/ui/src/dash/memory-map.jsx
@@ -111,6 +111,10 @@ export function useMemoryMapModel() {
     mbToGb(stats.data?.ram_total_mb || 0)
   const platformLabel = rawHw.platform_label || rawHw.platform || ''
   const memoryKind = rawHw.memory_kind === 'unified' ? 'unified' : 'system'
+  // On UMA the pool ceiling is the GTT cap, not the whole unified RAM
+  // (see unifiedGb above). Don't render the raw 'unified' kind — it reads
+  // as "unified 80GB" and misleads. Label it as the GPU/GTT pool instead.
+  const poolLabel = memoryKind === 'unified' ? 'GPU pool (GTT)' : 'system'
 
   const ramUsedGb = mbToGb(stats.data?.ram_used_mb || 0)
   const gttUsedGb = mbToGb(
@@ -205,7 +209,7 @@ export function useMemoryMapModel() {
   const availableGb = Math.max(0, round1(candidate - SAFETY_MARGIN_GB))
 
   return {
-    pool: { totalGb: unifiedGb, kind: memoryKind, platformLabel },
+    pool: { totalGb: unifiedGb, kind: memoryKind, label: poolLabel, platformLabel },
     host,
     self: {
       // Model memory the map renders against the pool. `modelUsedGb` is
@@ -357,7 +361,7 @@ export function MemoryMap({ variant = 'sidebar', onConfigure }) {
         <div className="vh">
           <h2>Memory map</h2>
           <span className="mono dim">
-            {pool.kind} {fmtGb(total)} · {pool.platformLabel}
+            {pool.label} {fmtGb(total)} · {pool.platformLabel}
             {host.mode === 'configured' && host.totalGb && ` · host ${fmtGb(host.totalGb)}`}
           </span>
         </div>
@@ -419,7 +423,7 @@ export function MemoryMap({ variant = 'sidebar', onConfigure }) {
       <div className="side-card-h">
         <span>Memory map</span>
         <span className="right mono">
-          {fmtGb(usedModel)} / {fmtGb(total)}
+          {pool.label} · {fmtGb(usedModel)} / {fmtGb(total)}
         </span>
       </div>
       <div className="side-card-b">

--- a/ui/src/dash/memory-map.jsx
+++ b/ui/src/dash/memory-map.jsx
@@ -110,7 +110,7 @@ export function useMemoryMapModel() {
     ramTotalGb ||
     mbToGb(stats.data?.ram_total_mb || 0)
   const platformLabel = rawHw.platform_label || rawHw.platform || ''
-  const memoryKind = rawHw.memory_kind === 'unified' ? 'unified' : 'system'
+  const memoryKind = rawHw.memoryKind === 'unified' ? 'unified' : 'system'
   // On UMA the pool ceiling is the GTT cap, not the whole unified RAM
   // (see unifiedGb above). Don't render the raw 'unified' kind — it reads
   // as "unified 80GB" and misleads. Label it as the GPU/GTT pool instead.

--- a/ui/tests/e2e/fixtures/mock-data.ts
+++ b/ui/tests/e2e/fixtures/mock-data.ts
@@ -36,6 +36,7 @@ export const MOCK_DATA = {
     ram_available_mb: 94_577,
     unified_memory_mb: 131_072,
     gtt_total_mb: 107_520,
+    memory_kind: 'unified',
     gpu_name: 'AMD Radeon 8060S (Strix Halo)',
     gpu_vendor: 'amd',
     gpus: [

--- a/ui/tests/e2e/specs/memory-map-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-map-v3.spec.ts
@@ -108,6 +108,17 @@ test.describe('Memory map — sidebar', () => {
     await expect(card).not.toContainText('free on host')
   })
 
+  test('UMA pool labelled "GPU pool (GTT)", not "unified"', async ({ page }) => {
+    // The default mock host is a Strix Halo UMA box (memory_kind: 'unified').
+    // On UMA the pool ceiling is the GTT cap, so the header must read as the
+    // GPU/GTT pool — never the misleading raw "unified" kind. See issue #462.
+    await mockStatsHardware(page, { configured: false, detected: false })
+    await page.goto('/#dashboard')
+    const card = page.locator('.memmap-sidebar')
+    await expect(card.locator('.side-card-h .right')).toContainText('GPU pool (GTT)')
+    await expect(card.locator('.side-card-h .right')).not.toContainText('unified')
+  })
+
   test('headroom labelled "pool" on bare-metal', async ({ page }) => {
     await mockStatsHardware(page, { configured: false, detected: false })
     await page.goto('/#dashboard')


### PR DESCRIPTION
## What

On unified-memory (Strix Halo) hosts the memory-map pool ceiling is the GTT cap (`amdgpu.gttsize`), not the full unified RAM. The header rendered the raw `memory_kind` (`unified`) next to the GTT-capped total, so it read as a misleading "unified 80GB".

This derives a friendly `pool.label` in `useMemoryMapModel` that maps `unified` -> `GPU pool (GTT)` (and leaves `system` for non-UMA), then renders it in both the expanded and sidebar memory-map headers. The raw `pool.kind` is retained for back-compat.

## Why

The pool total is already anchored to the GTT cap (#439); only the label was wrong. "unified 80GB" implies models can allocate the whole unified pool, which they cannot.

## Acceptance

- [x] Expanded + sidebar headers read "GPU pool (GTT)", not "unified 80GB"
- [x] `memory-map-v3` e2e spec updated: asserts sidebar header contains "GPU pool (GTT)" and never "unified"

Out of scope: per-slot attribution validation under a live loaded slot (parent #434).

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)