### PR TITLE
fix(agents): converge AgentManager data_dir onto HERMES_HOME (.hermes), guard uninstall

### DIFF
--- a/src/hal0/agents/manager.py
+++ b/src/hal0/agents/manager.py
@@ -89,6 +89,23 @@ BUNDLED_AGENTS: tuple[str, ...] = ("pi-coder", "hermes")
 matching driver module + ``installer/agents/<name>.sh``."""
 
 
+# Marker file the Hermes provisioner stamps into ``$HERMES_HOME`` to
+# claim the tree (``hermes_provision._HAL0_MANAGED_MARKER``). Mirrored
+# here so :meth:`AgentManager.uninstall` can refuse to ``rmtree`` a home
+# that hal0 doesn't own (a user's pre-existing ~/.hermes or a shared
+# tree). Keep in sync with that module — duplicated rather than imported
+# so the manager stays importable without the provisioner's deps (#453).
+_HAL0_MANAGED_MARKER = ".hal0-managed"
+
+# Agents whose runtime data dir is a canonical home OUTSIDE the legacy
+# ``<var_lib>/agents/<name>`` layout. Hermes uses ``HERMES_HOME``
+# (``<var_lib>/.hermes``, set by the provisioner + systemd units); the
+# registry must agree or status/list report a dead path and uninstall
+# rmtree's the wrong tree (#453). Value is the home subpath under
+# ``var_lib()``. Agents not listed here keep the per-name layout.
+_AGENT_HOME_SUBDIR: dict[str, str] = {"hermes": ".hermes"}
+
+
 # ── Records ──────────────────────────────────────────────────────────────────
 
 
@@ -311,7 +328,7 @@ class AgentManager:
             toml_path.unlink()
 
         data_dir = self._data_dir(name)
-        if data_dir.exists():
+        if data_dir.exists() and self._safe_to_remove_data_dir(name, data_dir):
             shutil.rmtree(data_dir)
 
         # State dir last — see #346. Removed atomically with the seed +
@@ -333,7 +350,35 @@ class AgentManager:
         return self._etc_root / f"{name}.toml"
 
     def _data_dir(self, name: str) -> Path:
+        """Return the per-agent runtime data dir.
+
+        For agents in :data:`_AGENT_HOME_SUBDIR` this is the canonical
+        home OUTSIDE the legacy ``<var_root>/<name>`` layout — Hermes
+        resolves to ``HERMES_HOME`` (``<var_lib>/.hermes``) so the
+        registry agrees with the provisioner + systemd units (#453).
+        ``<var_lib>`` is ``self._var_root.parent`` (``_var_root`` is
+        ``var_lib()/agents``), which keeps the injectable-root contract
+        intact for tests.
+        """
+        subdir = _AGENT_HOME_SUBDIR.get(name)
+        if subdir is not None:
+            return self._var_root.parent / subdir
         return self._var_root / name
+
+    def _safe_to_remove_data_dir(self, name: str, data_dir: Path) -> bool:
+        """Gate the uninstall ``rmtree`` of a converged agent home (#453).
+
+        Legacy per-name data dirs (``<var_root>/<name>``) are always
+        hal0's to remove. But a converged home like ``HERMES_HOME`` may
+        be a user's pre-existing ``~/.hermes`` or a shared tree — the
+        provisioner only writes into it after stamping the
+        ``.hal0-managed`` marker (``_claim_hermes_home``). Mirror that
+        contract here: refuse to ``rmtree`` a converged home that lacks
+        the marker rather than nuke data hal0 doesn't own.
+        """
+        if name not in _AGENT_HOME_SUBDIR:
+            return True
+        return (data_dir / _HAL0_MANAGED_MARKER).exists()
 
     def _state_dir(self, name: str) -> Path:
         """Per-agent bootstrap state dir (provision.json + logs).
@@ -391,7 +436,14 @@ class AgentManager:
             ) from exc
 
         self._etc_root.mkdir(parents=True, exist_ok=True)
-        self._data_dir(name).mkdir(parents=True, exist_ok=True)
+        # Legacy per-name data dirs are the manager's to create. Converged
+        # homes (HERMES_HOME, :data:`_AGENT_HOME_SUBDIR`) are owned by the
+        # agent's provisioner, which claims + stamps the ``.hal0-managed``
+        # marker before any write (#453). Don't mkdir an unmarked home
+        # here — uninstall would then refuse to remove it (no marker) and
+        # leave an orphan.
+        if name not in _AGENT_HOME_SUBDIR:
+            self._data_dir(name).mkdir(parents=True, exist_ok=True)
 
         installed_at = datetime.datetime.now(tz=datetime.UTC).isoformat()
         payload: dict[str, object] = {

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -233,6 +233,20 @@ def _seed_state_dir(manager: AgentManager, name: str) -> Path:
     return state_dir
 
 
+def _seed_managed_home(manager: AgentManager, name: str) -> Path:
+    """Helper: simulate the agent provisioner claiming a converged home.
+
+    For agents whose data dir is a canonical home (hermes → HERMES_HOME),
+    the manager itself no longer mkdir's the tree — the provisioner does,
+    stamping the ``.hal0-managed`` marker (#453). The stub driver used in
+    these tests does neither, so tests that need a removable data dir
+    must create the marked home the way the real provisioner would."""
+    home = manager._data_dir(name)
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".hal0-managed").write_text("hal0\n")
+    return home
+
+
 def test_uninstall_removes_state_dir(
     manager: AgentManager,
     stub_drivers: dict[str, _StubDriver],
@@ -241,6 +255,7 @@ def test_uninstall_removes_state_dir(
     ``/var/lib/hal0/state/agents/<name>/`` in addition to the seed TOML
     + data dir."""
     manager.install("hermes")
+    _seed_managed_home(manager, "hermes")
     state_dir = _seed_state_dir(manager, "hermes")
     assert state_dir.exists()
     assert (state_dir / "provision.json").exists()
@@ -263,6 +278,7 @@ def test_uninstall_with_missing_seed_still_reports_uninstalled(
     case); the next uninstall MUST still report
     ``removed=True`` because the data + state dirs were torn down."""
     manager.install("hermes")
+    _seed_managed_home(manager, "hermes")
     _seed_state_dir(manager, "hermes")
 
     # Corrupt the registry: remove the seed TOML out from under us, but
@@ -326,6 +342,7 @@ def test_install_uninstall_install_uninstall_round_trip(
     again, uninstall again. After each uninstall every witness is gone."""
     for _ in range(2):
         manager.install("hermes")
+        _seed_managed_home(manager, "hermes")
         _seed_state_dir(manager, "hermes")
         assert manager.installed_names() == ["hermes"]
 
@@ -411,3 +428,73 @@ def test_switch_failed_install_leaves_no_installed_agent(
     # pi-coder was torn down; hermes never got a seed written.
     assert manager.installed_names() == []
     assert stubs["pi-coder"].uninstalls == 1
+
+
+# ── #453: converge hermes data_dir onto HERMES_HOME (.hermes) ─────────────────
+
+
+def test_hermes_data_dir_is_hermes_home(manager: AgentManager, tmp_path: Path) -> None:
+    """#453: the manager's data_dir for hermes must be the canonical
+    HERMES_HOME (``<var_lib>/.hermes``), NOT the legacy
+    ``<var_lib>/agents/hermes`` tree. The provisioner + systemd units
+    use ``/var/lib/hal0/.hermes``; the registry must agree or
+    status/list/uninstall act on a dead path."""
+    # var_root is tmp_path/"var" → var_lib is tmp_path → home is tmp_path/.hermes.
+    assert manager._data_dir("hermes") == tmp_path / ".hermes"
+    # Non-converged agents keep the legacy per-name layout.
+    assert manager._data_dir("pi-coder") == tmp_path / "var" / "pi-coder"
+
+
+def test_hermes_install_records_hermes_home_as_data_dir(
+    manager: AgentManager,
+    stub_drivers: dict[str, _StubDriver],
+    tmp_path: Path,
+) -> None:
+    """#453: the seed TOML + AgentRecord must carry the converged home so
+    ``hal0 agent status hermes`` reports ``data: <var_lib>/.hermes``."""
+    rec = manager.install("hermes")
+    assert rec.data_dir == str(tmp_path / ".hermes")
+    parsed = tomllib.loads(manager._config_path("hermes").read_text())
+    assert parsed["data_dir"] == str(tmp_path / ".hermes")
+    # Re-seed must NOT recreate the legacy /agents/hermes tree.
+    assert not (tmp_path / "var" / "hermes").exists()
+
+
+def test_hermes_uninstall_removes_managed_home(
+    manager: AgentManager,
+    stub_drivers: dict[str, _StubDriver],
+    tmp_path: Path,
+) -> None:
+    """#453: uninstall removes the live HERMES_HOME when it carries the
+    ``.hal0-managed`` marker."""
+    manager.install("hermes")
+    home = _seed_managed_home(manager, "hermes")
+    (home / "plugins").mkdir()
+    assert home == tmp_path / ".hermes"
+    assert home.exists()
+
+    removed = manager.uninstall("hermes")
+    assert removed is True
+    assert not home.exists()
+
+
+def test_hermes_uninstall_refuses_unmanaged_home(
+    manager: AgentManager,
+    stub_drivers: dict[str, _StubDriver],
+    tmp_path: Path,
+) -> None:
+    """#453 (safety guard): uninstall must NOT rmtree a HERMES_HOME that
+    lacks the ``.hal0-managed`` marker — a user's pre-existing ~/.hermes
+    or a shared tree. Refuse rather than nuke someone else's data."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True)
+    (home / "user-data.txt").write_text("precious\n")  # no marker
+    # Seed exists so the agent counts as installed.
+    manager._etc_root.mkdir(parents=True, exist_ok=True)
+    manager._config_path("hermes").write_text("")
+
+    manager.uninstall("hermes")
+    # Home + its contents survive — only the seed was removed.
+    assert home.exists()
+    assert (home / "user-data.txt").exists()
+    assert not manager._config_path("hermes").exists()


### PR DESCRIPTION
## What

`AgentManager` hardcoded the legacy per-name data dir (`<var_lib>/agents/<name>`) while the Hermes provisioner and systemd units use the canonical `HERMES_HOME` (`<var_lib>/.hermes`). This split-brain meant:

- `hal0 agent status hermes` / `list` reported a dead path.
- `_write_seed` recreated the divergent `/var/lib/hal0/agents/hermes` tree on every re-seed.
- uninstall `rmtree`'d the stale tree while leaving the live home on disk.

## Why

The home-normalization migration (#440 / closes #437) updated the provisioner + units but never touched the manager registry. This converges the registry onto the real home.

## Changes

- `_data_dir("hermes")` resolves to `<var_lib>/.hermes` via an `_AGENT_HOME_SUBDIR` map; other agents keep the legacy per-name layout. Status/list/seed all derive `data_dir` from this helper, so the reported path + re-seed follow automatically — a re-install rewrites the stale `hermes.toml` with the correct path (no separate migration step).
- `_write_seed` no longer mkdir's a converged home — the provisioner owns claiming/creation and stamps the `.hal0-managed` marker.
- uninstall gates the `rmtree` of a converged home behind the `.hal0-managed` marker (`_safe_to_remove_data_dir`): removes a hal0-managed home, refuses to nuke a user's pre-existing or shared `~/.hermes`.

Closes #453

## Acceptance

- [x] `hal0 agent status hermes` reports `data: /var/lib/hal0/.hermes`
- [x] uninstall removes the live managed home, refuses an unmanaged one, never touches the stale `/var/lib/hal0/agents/hermes` path
- [x] re-seed does not recreate `/var/lib/hal0/agents/hermes`
- [x] existing #346 uninstall / state-dir tests remain green (`tests/agents/test_manager.py` 24 passed)
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)