### PR TITLE
fix(dashboard): stop SlotCard clipping the swap-model dropdown

### DIFF
--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -273,7 +273,7 @@ function SlotCard({
   })();
 
   return (
-    <div className={"slot" + (state === "serving" ? " serving" : "")}>
+    <div className={"slot" + (state === "serving" ? " serving" : "") + (swapOpen ? " swap-open" : "")}>
       <div className="slot-h">
         <IndicatorDot slot={slot} />
         <div className="slot-name">

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -1628,6 +1628,9 @@ a { color: inherit; text-decoration: none; }
   transition: border-color 0.12s ease;
 }
 .slot:hover { border-color: var(--line-strong); }
+/* While the inline swap dropdown is open, stop clipping so the
+   absolutely-positioned .swap-pop can extend past the card bottom. */
+.slot.swap-open { overflow: visible; }
 .slot.serving { border-color: var(--accent-line); }
 .slot-h { display: flex; align-items: center; gap: 8px; }
 .slot-name {

--- a/ui/tests/e2e/specs/slot-swap-clip-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-swap-clip-v3.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * slot-swap-clip-v3 — the swap dropdown must not be clipped by the card.
+ *
+ * The .slot card has overflow:hidden (rounded corners), which painted-clips
+ * the absolutely-positioned .swap-pop to the card's bottom edge — hiding the
+ * lower models (e.g. qwen3.6-35b) and their internal scroll. When the
+ * dropdown is open the card must stop clipping.
+ */
+import { test, expect, type Page } from '../fixtures/apiMock'
+
+const cardByName = (page: Page, name: string) =>
+  page
+    .locator('.slot', { has: page.locator('.slot-name .nm', { hasText: new RegExp(`^${name}$`) }) })
+    .first()
+
+test.describe('Slot swap dropdown — not clipped by card', () => {
+  test('card stops clipping (overflow-y visible) while the swap dropdown is open', async ({ page }) => {
+    await page.goto('/#slots')
+    const card = cardByName(page, 'primary')
+
+    // Closed: card clips its content (rounded-corner aesthetic).
+    expect(await card.evaluate((el) => getComputedStyle(el).overflowY)).toBe('hidden')
+
+    await card.locator('.slot-model').click()
+    await expect(page.locator('.swap-pop')).toBeVisible()
+
+    // Open: card must not clip the dropdown.
+    expect(await card.evaluate((el) => getComputedStyle(el).overflowY)).toBe('visible')
+  })
+})


### PR DESCRIPTION
Slot swap dropdown was painted-clipped by the .slot cards overflow:hidden, hiding lower models (e.g. qwen3.6-35b) and the popover scrollbar. Fix: .slot.swap-open { overflow: visible } applied while the dropdown is open; popover keeps max-height:320px + internal scroll. Test slot-swap-clip-v3 asserts overflow-y flips hidden->visible on open. 13/13 slot specs pass.

Generated with Claude Code