### PR TITLE
feat(dashboard): per-slot colors in memory map + drop redundant sidebar headroom

### DIFF
--- a/ui/src/dash/memory-map.jsx
+++ b/ui/src/dash/memory-map.jsx
@@ -16,6 +16,33 @@ const LIVE_STATES = new Set(['ready', 'serving', 'idle', 'warming'])
 const SAFETY_MARGIN_GB = 2
 const MB_PER_GB = 1024
 
+// Categorical per-slot palette (CSS custom props defined in dashboard.css).
+// Each loaded model slot gets its OWN stable colour so co-resident models
+// are distinguishable in the bar + legend — device colour alone collapses
+// several GPU slots into a single hue.
+const SLOT_PALETTE = [
+  'var(--mem-slot-1)',
+  'var(--mem-slot-2)',
+  'var(--mem-slot-3)',
+  'var(--mem-slot-4)',
+  'var(--mem-slot-5)',
+  'var(--mem-slot-6)',
+  'var(--mem-slot-7)',
+  'var(--mem-slot-8)',
+]
+
+// Deterministic, render-stable colour for a slot: sort live slot names and
+// index by position into the palette. A given slot name always maps to the
+// same colour within a render set, and the swatch matches its bar segment.
+function assignSlotColors(slotNames) {
+  const sorted = [...slotNames].sort()
+  const map = new Map()
+  sorted.forEach((name, i) => {
+    map.set(name, SLOT_PALETTE[i % SLOT_PALETTE.length])
+  })
+  return map
+}
+
 const round1 = (n) => Math.round(n * 10) / 10
 
 function mbToGb(mb) {
@@ -220,13 +247,17 @@ export function useMemoryMapModel() {
       ramUsedGb,
       gttUsedGb,
       npuModelGb,
-      slots: attributed.map((a) => ({
-        name: a.slot.name,
-        device: a.device,
-        bytesGb: a.bytesGb,
-        modelId: a.slot.model || '',
-        approx: a.approx,
-      })),
+      slots: (() => {
+        const colorMap = assignSlotColors(attributed.map((a) => a.slot.name))
+        return attributed.map((a) => ({
+          name: a.slot.name,
+          device: a.device,
+          color: colorMap.get(a.slot.name),
+          bytesGb: a.bytesGb,
+          modelId: a.slot.model || '',
+          approx: a.approx,
+        }))
+      })(),
     },
     headroom: { availableGb, limitedBy },
     loading: hw.isLoading || stats.isLoading || slotsQ.isLoading || pveSettings.isLoading,
@@ -234,13 +265,6 @@ export function useMemoryMapModel() {
 }
 
 // ── Render helpers ─────────────────────────────────────────────────────
-
-function colorForDevice(device) {
-  if (device === 'npu') return 'var(--dev-npu)'
-  if (device === 'cpu') return 'var(--dev-cpu)'
-  if (device === 'vulkan') return 'var(--dev-vulkan)'
-  return 'var(--dev-rocm)'
-}
 
 function fmtGb(n) {
   if (n == null) return '—'
@@ -296,7 +320,7 @@ function SidebarBar({ model }) {
         <PctSeg
           key={s.name}
           widthPct={pct(s.bytesGb)}
-          color={colorForDevice(s.device)}
+          color={s.color}
           title={`${s.name} · ${fmtGb(s.bytesGb)}`}
         />
       ))}
@@ -377,7 +401,7 @@ export function MemoryMap({ variant = 'sidebar', onConfigure }) {
           {self.slots.map((s) => (
             <LegendRow
               key={s.name}
-              swatch={colorForDevice(s.device)}
+              swatch={s.color}
               name={s.name}
               sub={`${s.device}${s.approx ? ' · ≈' : ''}${s.modelId ? ' · ' + s.modelId : ''}`}
               sz={s.bytesGb}
@@ -439,17 +463,14 @@ export function MemoryMap({ variant = 'sidebar', onConfigure }) {
             {self.slots.map((s) => (
               <LegendRow
                 key={s.name}
-                swatch={colorForDevice(s.device)}
+                swatch={s.color}
                 name={s.name}
+                sub={s.device}
                 sz={s.bytesGb}
               />
             ))}
             <LegendRow swatch="var(--bg-4)" name="free" sz={free} />
           </div>
-          <HeadroomLabel
-            availableGb={headroom.availableGb}
-            limitedBy={headroom.limitedBy}
-          />
           {host.mode === 'detected_unconfigured' && (
             <PveNudge hint={host.hint} onConfigure={onConfigure} />
           )}

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -60,6 +60,19 @@
   --mem-tenant-2: #8a7848;
   --mem-tenant-3: #695830;
 
+  /* Memory-map per-slot categorical palette — one stable colour per loaded
+     model slot so co-resident models are visually distinguishable in the
+     bar + legend (device colour alone collapses multiple GPU slots into one
+     hue). Colourblind-aware 8-colour set (Okabe-Ito derived). */
+  --mem-slot-1: #5b9bd5; /* blue */
+  --mem-slot-2: #e69f00; /* orange */
+  --mem-slot-3: #009e73; /* bluish green */
+  --mem-slot-4: #cc79a7; /* reddish purple */
+  --mem-slot-5: #f0e442; /* yellow */
+  --mem-slot-6: #d55e00; /* vermillion */
+  --mem-slot-7: #56b4e9; /* sky blue */
+  --mem-slot-8: #b39ddb; /* lavender */
+
   /* Type */
   --geist: "Geist", "Geist Variable", system-ui, -apple-system, "Segoe UI", sans-serif;
   --jbm:   "JetBrains Mono", "JetBrains Mono Variable", ui-monospace, "SF Mono", Menlo, monospace;

--- a/ui/tests/e2e/specs/memory-map-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-map-v3.spec.ts
@@ -119,14 +119,24 @@ test.describe('Memory map — sidebar', () => {
     await expect(card.locator('.side-card-h .right')).not.toContainText('unified')
   })
 
-  test('headroom labelled "pool" on bare-metal', async ({ page }) => {
+  test('sidebar no longer renders the headroom line (pool scenario)', async ({ page }) => {
+    // The oversized "Headroom for new models … limited by pool/host" line was
+    // dropped from the SIDEBAR variant — the "<free> free" value above the bar
+    // is the kept signal. The headroom + limited-by string now lives ONLY in
+    // the expanded variant (see EXPANDED-variant coverage below).
     await mockStatsHardware(page, { configured: false, detected: false })
     await page.goto('/#dashboard')
-    // Scope to sidebar — expanded variant also renders .memmap-headroom
-    await expect(page.locator('.memmap-sidebar .memmap-headroom')).toContainText('limited by pool')
+    const card = page.locator('.memmap-sidebar')
+    await expect(card).toBeVisible()
+    await expect(card.locator('.memmap-headroom')).toHaveCount(0)
+    // The retained free signal is still present in the sidebar header row.
+    await expect(card.locator('.memmap-h')).toContainText('free')
   })
 
-  test('headroom labelled "host" when host free is the binding constraint', async ({ page }) => {
+  test('sidebar drops headroom even when host is the binding constraint', async ({ page }) => {
+    // Host-limited pool: previously the sidebar showed "limited by host". The
+    // limited-by distinction is now expanded-only; the sidebar must show no
+    // headroom line regardless of which constraint binds.
     await mockStatsHardware(page, {
       configured: true,
       ok: true,
@@ -147,8 +157,28 @@ test.describe('Memory map — sidebar', () => {
       tenants: [],
     })
     await page.goto('/#dashboard')
-    // Scope to sidebar — expanded variant also renders .memmap-headroom
-    await expect(page.locator('.memmap-sidebar .memmap-headroom')).toContainText('limited by host')
+    const card = page.locator('.memmap-sidebar')
+    await expect(card).toBeVisible()
+    await expect(card.locator('.memmap-headroom')).toHaveCount(0)
+  })
+
+  test('co-resident slots render distinct legend swatch colours', async ({ page }) => {
+    // Change 1: each loaded model slot gets its OWN stable colour so
+    // co-resident models are visually distinguishable. The default mock has
+    // four live slots with mem_mb > 0 (primary/agent/coder/embed) — three of
+    // them share device=gpu-rocm, which used to collapse to one device hue.
+    // Their legend swatches must now differ.
+    await mockStatsHardware(page, { configured: false, detected: false })
+    await page.goto('/#dashboard')
+    const swatches = page.locator('.memmap-sidebar .memmap-legend .ln .sw')
+    // free row adds one swatch; expect ≥3 (>=2 live slots + free).
+    await expect(swatches.first()).toBeVisible()
+    const count = await swatches.count()
+    expect(count).toBeGreaterThanOrEqual(3)
+    // First two slot swatches (sorted by name) must be distinct colours.
+    const c0 = await swatches.nth(0).evaluate((el) => getComputedStyle(el).backgroundColor)
+    const c1 = await swatches.nth(1).evaluate((el) => getComputedStyle(el).backgroundColor)
+    expect(c0).not.toBe(c1)
   })
 })
 
@@ -158,3 +188,15 @@ test.describe('Memory map — sidebar', () => {
 // live Memory hardware card. The MemoryMap component still supports
 // `variant="expanded"`, but nothing mounts it on the dashboard, so the
 // former dashboard-scoped expanded suite was retired.
+//
+// HEADROOM coverage: the "Headroom for new models … limited by pool/host"
+// line (and the pool-vs-host limited-by distinction) now renders ONLY in the
+// expanded variant — it was dropped from the sidebar (the "<free> free" value
+// above the bar is the kept signal). Because no live route mounts the
+// expanded variant, the limited-by string is not e2e-reachable today; the
+// `limitedBy` logic still lives in useMemoryMapModel() and the expanded
+// <HeadroomLabel> render. The former sidebar "limited by pool"/"limited by
+// host" assertions were converted above to assert the sidebar no longer shows
+// the headroom line (under both pool- and host-constrained mocks). When a
+// route mounts variant="expanded", re-add a `.memmap-expanded .memmap-headroom`
+// limited-by assertion here.


### PR DESCRIPTION
## What & why

**Per-slot unique colors.** Each loaded model slot now gets its own stable, deterministic color so co-resident models are visually distinguishable in the memory map. Previously every GPU slot shared a single device hue (`colorForDevice`), so multiple `gpu-rocm` slots (e.g. `primary` + `coder` + `embed`) collapsed into one indistinguishable color and you couldn't tell which segment was which.

- `useMemoryMapModel` assigns each live slot a `color` field from a curated 8-color colorblind-aware categorical palette (Okabe-Ito derived), added as `--mem-slot-*` CSS custom props in `dashboard.css`.
- Colors are deterministic and render-stable: live slot names are sorted and indexed into the palette (`i % N`), so a given slot name always maps to the same color within a render set.
- Both the **bar segments** (`SidebarBar` / `PctSeg`) and the **legend swatches** (`LegendRow`) read `s.color`, so each swatch matches its segment.
- Device stays visible — passed as the `LegendRow` `sub` label in the sidebar (it was already shown in the expanded legend).
- `colorForDevice` became unused and was removed.

**Drop redundant sidebar headroom.** The oversized "Headroom for new models — limited by …" line is removed from the **sidebar** variant; the "`<free>` free" value above the bar is the kept signal. The headroom line is **retained in the expanded variant**.

## E2E changes (`memory-map-v3.spec.ts`)

- The two sidebar headroom assertions (`limited by pool` / `limited by host`) were converted to assert the sidebar no longer renders `.memmap-headroom`, under both pool- and host-constrained mocks (coverage not deleted). limited-by coverage is documented as expanded-only — no live route currently mounts `variant="expanded"`, so the limited-by string isn't e2e-reachable today; the logic still lives in `useMemoryMapModel` + the expanded `<HeadroomLabel>`, with a NOTE on how to re-add the assertion when expanded is mounted.
- Added a test asserting two co-resident slots render **distinct** legend swatch colors.
- The existing "GPU pool (GTT)" label test is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)