### PR TITLE
feat(hermes): auto-render live STATE.md on restart + model/slot change

### DIFF
--- a/docs/internal/hermes-state-md-auto-render-2026-06-04-plan.md
+++ b/docs/internal/hermes-state-md-auto-render-2026-06-04-plan.md
@@ -186,15 +186,16 @@ def _collect_capability_rollup(slots: list[dict[str, Any]]) -> list[dict[str, An
     return out
 
 
-def _igpu_sclk_mhz() -> int | None:
+def _igpu_sclk_mhz(sysfs_root: Path = Path("/sys/class/drm")) -> int | None:
     """Active iGPU shader clock (MHz) from amdgpu sysfs, or None.
 
     Reads ``pp_dpm_sclk`` and returns the MHz of the active ('*') DPM
     level. Best-effort: any read/parse error returns None so the template
-    simply omits the clock line. Tries card0..card3 (Strix Halo dev nodes).
+    simply omits the clock line. Tries card0..card3 (Strix Halo dev nodes);
+    ``sysfs_root`` is injectable for tests.
     """
     for idx in range(4):
-        path = Path(f"/sys/class/drm/card{idx}/device/pp_dpm_sclk")
+        path = sysfs_root / f"card{idx}" / "device" / "pp_dpm_sclk"
         try:
             text = path.read_text(encoding="utf-8")
         except OSError:
@@ -205,7 +206,7 @@ def _igpu_sclk_mhz() -> int | None:
                 for tok in line.replace("Mhz", " ").replace("MHz", " ").split():
                     if tok.isdigit():
                         return int(tok)
-        return None
+        # no active line on this card — try the next one
     return None
 ```
 

--- a/docs/internal/hermes-state-md-auto-render-2026-06-04-plan.md
+++ b/docs/internal/hermes-state-md-auto-render-2026-06-04-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Hermes always sees current hal0 live state (loaded model, capabilities, GPU/NPU backend) — refreshed on every service restart **and** every runtime model/capability change — without bloating the cacheable persona or stalling Hermes session start.
 
-**Architecture:** A thin `/etc/hal0/STATE.md` snapshot is the buffer. One shared `render_live_context()` function (re)writes it, content-hash gated. Two event writers call it: `ExecStartPre` on restart, and a detached best-effort spawn after `manager.swap()` / `orchestrator.apply()` on runtime change. The (previously-dangling) `on_session_start` hook `cat`s the file into every new Hermes session and background-regens only when stale (>5 min TTL). `SOUL.md` stays byte-stable; live primary/slot lines move out of `HERMES.md` into `STATE.md`.
+**Architecture:** A thin `/var/lib/hal0/STATE.md` snapshot is the buffer. One shared `render_live_context()` function (re)writes it, content-hash gated. Two event writers call it: `ExecStartPre` on restart, and a detached best-effort spawn after `manager.swap()` / `orchestrator.apply()` on runtime change. The (previously-dangling) `on_session_start` hook `cat`s the file into every new Hermes session and background-regens only when stale (>5 min TTL). `SOUL.md` stays byte-stable; live primary/slot lines move out of `HERMES.md` into `STATE.md`.
 
 **Tech Stack:** Python 3.12, Jinja2, pytest, systemd unit drop-ins, POSIX shell (hook + installer). All hal0 code under `src/hal0/`, tests under `tests/`.
 
@@ -523,7 +523,7 @@ Replace it with a pointer to STATE.md:
 # Live state
 
 Current loaded model, capabilities, and GPU/NPU backend are in
-`/etc/hal0/STATE.md` (auto-injected each session; refreshed on restart
+`/var/lib/hal0/STATE.md` (auto-injected each session; refreshed on restart
 and on every model/slot change). Read it for the live picture rather
 than assuming — it carries an `_as_of:` timestamp.
 ```
@@ -587,7 +587,7 @@ def test_render_context_dispatch_calls_render(monkeypatch, tmp_path):
     def fake_render(*, hermes_home):
         called["home"] = hermes_home
         return {"state_written": True, "hermes_written": False,
-                "degraded": False, "state_path": "/etc/hal0/STATE.md"}
+                "degraded": False, "state_path": "/var/lib/hal0/STATE.md"}
 
     monkeypatch.setattr(agent_shim, "_render_live_context", fake_render)
 
@@ -739,13 +739,13 @@ Create `installer/agents/hermes/hooks/inject-system-state.sh` (mode 0755):
 #
 # Wired by hermes_templates/config.yaml.j2 (hooks.on_session_start).
 # Contract: emit context to stdout for the new session; stay inside the
-# 2s hook timeout. We ONLY cat the pre-rendered /etc/hal0/STATE.md (the
+# 2s hook timeout. We ONLY cat the pre-rendered /var/lib/hal0/STATE.md (the
 # expensive probe runs in the writers, not here). If STATE.md is older
 # than the TTL we additionally kick a DETACHED background refresh so the
 # NEXT session is fresh — we never block this session on a probe.
 set -eu
 
-STATE_FILE="/etc/hal0/STATE.md"
+STATE_FILE="/var/lib/hal0/STATE.md"
 TTL_SECONDS=300   # 5 min — defense-in-depth for missed change events.
 
 # Missing file (first boot before any render) => emit nothing, exit clean.
@@ -982,14 +982,14 @@ Then verify each trigger:
 ```bash
 # (a) Restart trigger — ExecStartPre rewrites STATE.md.
 ssh hal0 'sudo systemctl daemon-reload && sudo systemctl restart hal0-agent@hermes'
-ssh hal0 'cat /etc/hal0/STATE.md'   # shows current model + as_of just now
+ssh hal0 'cat /var/lib/hal0/STATE.md'   # shows current model + as_of just now
 ssh hal0 'journalctl -u hal0-agent@hermes -n 20 | grep render-context'  # "render-context ok ..."
 
 # (b) Runtime change trigger — swap a slot, STATE.md as_of bumps.
-ssh hal0 'cat /etc/hal0/STATE.md | grep _as_of'   # note timestamp
+ssh hal0 'cat /var/lib/hal0/STATE.md | grep _as_of'   # note timestamp
 ssh hal0 'hal0 slot swap primary <some-other-model>'  # or capability_set
 sleep 3
-ssh hal0 'cat /etc/hal0/STATE.md | grep _as_of'   # timestamp advanced; model changed
+ssh hal0 'cat /var/lib/hal0/STATE.md | grep _as_of'   # timestamp advanced; model changed
 
 # (c) Hook injection — new session sees STATE.md.
 ssh hal0 'cat /usr/lib/hal0/hermes-hooks/inject-system-state.sh'  # installed

--- a/docs/internal/hermes-state-md-auto-render-2026-06-04-plan.md
+++ b/docs/internal/hermes-state-md-auto-render-2026-06-04-plan.md
@@ -1,0 +1,1026 @@
+# Hermes live-state auto-render (`STATE.md`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hermes always sees current hal0 live state (loaded model, capabilities, GPU/NPU backend) — refreshed on every service restart **and** every runtime model/capability change — without bloating the cacheable persona or stalling Hermes session start.
+
+**Architecture:** A thin `/etc/hal0/STATE.md` snapshot is the buffer. One shared `render_live_context()` function (re)writes it, content-hash gated. Two event writers call it: `ExecStartPre` on restart, and a detached best-effort spawn after `manager.swap()` / `orchestrator.apply()` on runtime change. The (previously-dangling) `on_session_start` hook `cat`s the file into every new Hermes session and background-regens only when stale (>5 min TTL). `SOUL.md` stays byte-stable; live primary/slot lines move out of `HERMES.md` into `STATE.md`.
+
+**Tech Stack:** Python 3.12, Jinja2, pytest, systemd unit drop-ins, POSIX shell (hook + installer). All hal0 code under `src/hal0/`, tests under `tests/`.
+
+**Spec:** `docs/internal/hermes-state-md-auto-render-2026-06-04.md`
+
+**Working dir / branch:** worktree `/home/halo/dev/hal0-state-md`, branch `feat/hermes-state-md-autorender` (off `origin/main`). Run python via the repo venv: `/opt/hal0/.venv/bin/python3` on the LXC, or local `.venv` (`pip install -e . --no-deps`). Locally run **test subsets** — the full suite hangs on this VM (lemond health waits); let CI gate the full run.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `src/hal0/agents/hermes_templates/STATE.md.j2` | **New.** Volatile live-state snapshot template (~12 lines). |
+| `src/hal0/agents/hermes_templates/HERMES.md.j2` | **Modify.** Remove live primary/chat-slot lines (now in STATE.md); keep structural map. |
+| `src/hal0/agents/hermes_provision.py` | **Modify.** Add `_igpu_sclk_mhz()`, `_collect_capability_rollup()`, `_state_body_minus_timestamp()`, `render_live_context()`; delegate HERMES.md + STATE.md rendering from `_phase_context_link`. |
+| `src/hal0/cli/agent_shim.py` | **Modify.** Add `render-context` subcommand + parser choice + dispatch entry. |
+| `src/hal0/slots/manager.py` | **Modify.** Best-effort detached render after `swap()`. |
+| `src/hal0/capabilities/orchestrator.py` | **Modify.** Best-effort detached render after `apply()`. |
+| `installer/systemd/hal0-agent@hermes.service.d/override.conf` | **Modify.** Add `ExecStartPre=-…render-context`. |
+| `installer/agents/hermes/hooks/inject-system-state.sh` | **New.** `on_session_start` hook: cat STATE.md + stale background-regen. |
+| `installer/install.sh` | **Modify.** Install hook to `/usr/lib/hal0/hermes-hooks/`. |
+| `installer/uninstall.sh` | **Modify.** Remove hook dir. |
+| `tests/agents/test_hermes_state_render.py` | **New.** Template render, helpers, content-hash gating, `render_live_context`. |
+| `tests/cli/test_agent_shim.py` | **Modify.** `render-context` dispatch test. |
+
+**Shared-function contract** (used everywhere so there is one code path):
+
+```python
+def render_live_context(
+    *,
+    hermes_home: Path,
+    slots_fetcher: Callable[[], list[dict[str, Any]]] | None = None,
+    now_iso: str | None = None,
+) -> dict[str, Any]:
+    """Re-probe live slot/capability state and (re)write HERMES.md + STATE.md.
+
+    STATE.md is content-hash gated: rewritten (and its ``_as_of`` line
+    bumped) only when the substantive body changes. HERMES.md is written
+    atomically (identical content => identical bytes => prompt-cache safe).
+    Never raises on a daemon-unreachable read — leaves last-good files and
+    reports ``degraded=True``.
+
+    Returns: {"state_written": bool, "hermes_written": bool,
+              "degraded": bool, "state_path": str}.
+    """
+```
+
+---
+
+## Task 1: `STATE.md.j2` template + render helpers (capability rollup, iGPU clock)
+
+**Files:**
+- Create: `src/hal0/agents/hermes_templates/STATE.md.j2`
+- Modify: `src/hal0/agents/hermes_provision.py` (add helpers near the other `_slot_*` helpers, ~line 1841)
+- Test: `tests/agents/test_hermes_state_render.py`
+
+- [ ] **Step 1: Write the failing test for the helpers + template**
+
+Create `tests/agents/test_hermes_state_render.py`:
+
+```python
+"""Unit tests for the live STATE.md render path (Hermes auto-render)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.agents import hermes_provision as hp
+
+
+def _slot(name, type_, model, *, state="ready", backend=None):
+    d = {"name": name, "type": type_, "model_id": model, "status": state}
+    if backend:
+        d["backend"] = backend
+    return d
+
+
+def test_collect_capability_rollup_filters_and_maps_types():
+    slots = [
+        _slot("primary", "llm", "qwen3-25b", backend="vulkan"),   # chat -> excluded here
+        _slot("embed", "embedding", "bge-m3", backend="vulkan"),
+        _slot("stt", "stt", "moonshine", backend="vulkan"),
+        _slot("tts", "tts", "kokoro", backend="vulkan"),
+        _slot("img", "image", "sdxl", backend="rocm"),
+        _slot("rerank", "rerank", "bge-reranker", backend="vulkan"),
+        _slot("cold", "embedding", "unused", state="stopped"),     # not ready -> excluded
+    ]
+    rollup = hp._collect_capability_rollup(slots)
+    caps = {r["capability"]: r for r in rollup}
+    assert set(caps) == {"embed", "voice-stt", "voice-tts", "img", "rerank"}
+    assert caps["img"]["backend"] == "rocm"
+    assert caps["embed"]["model_id"] == "bge-m3"
+    assert "cold" not in {r.get("name") for r in rollup}
+
+
+def test_state_template_renders_full_state():
+    body = hp._render_template(
+        "STATE.md.j2",
+        primary={"alias": "primary", "model_id": "qwen3-25b",
+                 "backend_url": "http://127.0.0.1:8080/v1", "context_length": 32768,
+                 "backend": "vulkan"},
+        capabilities=[{"capability": "embed", "model_id": "bge-m3", "backend": "vulkan"}],
+        npu={"present": True, "model_id": "qwen3-it-4b-FLM"},
+        igpu_sclk_mhz=2900,
+        dashboard_url="https://hal0.thinmint.dev",
+        lemonade_base="http://127.0.0.1:13305",
+        daemon="reachable",
+        as_of="2026-06-04T15:00:00+00:00",
+    )
+    assert "qwen3-25b" in body
+    assert "32768" in body
+    assert "embed" in body and "bge-m3" in body
+    assert "vulkan" in body
+    assert "qwen3-it-4b-FLM" in body
+    assert "2900" in body
+    assert "reachable" in body
+    assert body.rstrip().splitlines()[-1].startswith("_as_of: 2026-06-04T15:00:00")
+
+
+def test_state_template_degraded_no_primary():
+    body = hp._render_template(
+        "STATE.md.j2",
+        primary=None, capabilities=[], npu={"present": False, "model_id": None},
+        igpu_sclk_mhz=None, dashboard_url="https://hal0.thinmint.dev",
+        lemonade_base="http://127.0.0.1:13305", daemon="degraded",
+        as_of="2026-06-04T15:00:00+00:00",
+    )
+    assert "degraded" in body
+    assert "no chat model loaded" in body.lower()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/agents/test_hermes_state_render.py -v`
+Expected: FAIL — `AttributeError: module 'hal0.agents.hermes_provision' has no attribute '_collect_capability_rollup'` and `jinja2.exceptions.TemplateNotFound: STATE.md.j2`.
+
+- [ ] **Step 3: Add the helpers to `hermes_provision.py`**
+
+Insert after `_slot_context_length` (~line 1841), near the other `_slot_*` helpers:
+
+```python
+# capability slot `type` (from /api/slots) -> STATE.md rollup label.
+_CAPABILITY_TYPE_LABELS = {
+    "embedding": "embed",
+    "stt": "voice-stt",
+    "tts": "voice-tts",
+    "image": "img",
+    "img": "img",
+    "rerank": "rerank",
+}
+
+
+def _collect_capability_rollup(slots: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Ready non-chat capability slots, mapped to STATE.md rollup rows.
+
+    Chat (``type=='llm'``) slots are handled by the primary/chat path and
+    excluded here. Only ready slots are advertised so we never tell the
+    agent about a capability that isn't actually loaded.
+    """
+    out: list[dict[str, Any]] = []
+    for s in slots:
+        if not isinstance(s, dict):
+            continue
+        label = _CAPABILITY_TYPE_LABELS.get((s.get("type") or "").lower())
+        if not label:
+            continue
+        if not _is_ready(s):
+            continue
+        out.append(
+            {
+                "capability": label,
+                "model_id": _slot_model_id(s),
+                "backend": s.get("backend"),
+            }
+        )
+    return out
+
+
+def _igpu_sclk_mhz() -> int | None:
+    """Active iGPU shader clock (MHz) from amdgpu sysfs, or None.
+
+    Reads ``pp_dpm_sclk`` and returns the MHz of the active ('*') DPM
+    level. Best-effort: any read/parse error returns None so the template
+    simply omits the clock line. Tries card0..card3 (Strix Halo dev nodes).
+    """
+    for idx in range(4):
+        path = Path(f"/sys/class/drm/card{idx}/device/pp_dpm_sclk")
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            if line.rstrip().endswith("*"):
+                # e.g. "2: 2900Mhz *"
+                for tok in line.replace("Mhz", " ").replace("MHz", " ").split():
+                    if tok.isdigit():
+                        return int(tok)
+        return None
+    return None
+```
+
+- [ ] **Step 4: Create the `STATE.md.j2` template**
+
+Create `src/hal0/agents/hermes_templates/STATE.md.j2`:
+
+```jinja
+{# Volatile live-state snapshot — re-rendered on restart + on model/slot
+   change, injected into every Hermes session by the on_session_start hook.
+   Keep it LEAN: this is fed to the model every session. Stable identity
+   lives in SOUL.md; structural map lives in HERMES.md.
+   Params: primary (dict|None), capabilities (list), npu (dict),
+   igpu_sclk_mhz (int|None), dashboard_url, lemonade_base, daemon, as_of. #}
+# Live system state
+
+{% if primary -%}
+- Chat model: `{{ primary.model_id }}` ({{ primary.context_length | default("?") }} ctx{% if primary.backend %}, {{ primary.backend }}{% endif %}) via `model_aliases.{{ primary.alias | default("primary") }}`
+{%- else -%}
+- Chat model: _no chat model loaded — wire one via `hal0 slot create`._
+{%- endif %}
+{% if capabilities -%}
+- Capabilities: {% for c in capabilities %}{{ c.capability }} (`{{ c.model_id }}`{% if c.backend %}/{{ c.backend }}{% endif %}){% if not loop.last %}, {% endif %}{% endfor %}
+{%- else -%}
+- Capabilities: _none loaded._
+{%- endif %}
+{% if npu.present -%}
+- NPU (XDNA): {% if npu.model_id %}`{{ npu.model_id }}` (FLM){% else %}present, idle{% endif %}
+{%- endif %}
+{% if igpu_sclk_mhz -%}
+- iGPU clock: {{ igpu_sclk_mhz }} MHz
+{%- endif %}
+- Endpoints: dashboard {{ dashboard_url }} · lemond {{ lemonade_base }}
+- Daemon: {{ daemon }}
+
+_as_of: {{ as_of }}_
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/agents/test_hermes_state_render.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hal0/agents/hermes_templates/STATE.md.j2 src/hal0/agents/hermes_provision.py tests/agents/test_hermes_state_render.py
+git commit -m "feat(hermes): STATE.md template + capability/igpu render helpers"
+```
+
+---
+
+## Task 2: `render_live_context()` shared function with content-hash gating
+
+**Files:**
+- Modify: `src/hal0/agents/hermes_provision.py` (add after `_collect_capability_rollup`/`_igpu_sclk_mhz`)
+- Test: `tests/agents/test_hermes_state_render.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/agents/test_hermes_state_render.py`:
+
+```python
+def test_state_body_minus_timestamp_ignores_as_of_line():
+    a = "# Live system state\n- Chat model: x\n\n_as_of: 2026-06-04T10:00:00+00:00_\n"
+    b = "# Live system state\n- Chat model: x\n\n_as_of: 2026-06-04T22:00:00+00:00_\n"
+    assert hp._state_body_minus_timestamp(a) == hp._state_body_minus_timestamp(b)
+
+
+def test_render_live_context_writes_then_skips_when_unchanged(tmp_path, monkeypatch):
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    slots = [
+        {"name": "primary", "type": "llm", "model_id": "qwen3-25b",
+         "status": "ready", "backend": "vulkan"},
+        {"name": "embed", "type": "embedding", "model_id": "bge-m3",
+         "status": "ready", "backend": "vulkan"},
+    ]
+    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {"primary": 32768})
+
+    r1 = hp.render_live_context(
+        hermes_home=home, slots_fetcher=lambda: slots,
+        now_iso="2026-06-04T10:00:00+00:00",
+    )
+    assert r1["state_written"] is True
+    assert r1["degraded"] is False
+    state = (tmp_path / "STATE.md").read_text()
+    assert "qwen3-25b" in state and "bge-m3" in state
+
+    # Same substantive state, different clock-time -> NOT rewritten.
+    r2 = hp.render_live_context(
+        hermes_home=home, slots_fetcher=lambda: slots,
+        now_iso="2026-06-04T22:00:00+00:00",
+    )
+    assert r2["state_written"] is False
+    assert "10:00:00" in (tmp_path / "STATE.md").read_text()  # as_of unchanged
+
+
+def test_render_live_context_degraded_when_daemon_unreachable(tmp_path, monkeypatch):
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    r = hp.render_live_context(
+        hermes_home=home, slots_fetcher=lambda: [],
+        now_iso="2026-06-04T10:00:00+00:00",
+    )
+    assert r["degraded"] is True
+    assert "degraded" in (tmp_path / "STATE.md").read_text()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/agents/test_hermes_state_render.py -k "render_live_context or minus_timestamp" -v`
+Expected: FAIL — `module ... has no attribute '_state_body_minus_timestamp'` / `render_live_context`.
+
+- [ ] **Step 3: Implement the function**
+
+Add to `hermes_provision.py` after the Task 1 helpers. Note `datetime` is needed — add `from datetime import datetime, timezone` to the imports at the top of the file if not present.
+
+```python
+def _state_body_minus_timestamp(text: str) -> str:
+    """STATE.md body with the volatile ``_as_of:`` line removed.
+
+    Used for content-hash gating so a regen that finds nothing
+    substantive changed does not churn the file (and bust prompt-cache).
+    """
+    return "\n".join(
+        line for line in text.splitlines() if not line.startswith("_as_of:")
+    )
+
+
+def render_live_context(
+    *,
+    hermes_home: Path,
+    slots_fetcher: Callable[[], list[dict[str, Any]]] | None = None,
+    now_iso: str | None = None,
+) -> dict[str, Any]:
+    """Re-probe live slot/capability state; (re)write HERMES.md + STATE.md.
+
+    See module docstring / design doc. Never raises on a daemon-unreachable
+    read — leaves last-good files and reports ``degraded=True``.
+    """
+    fetch = slots_fetcher or _fetch_slots
+    slots_all = fetch() or []
+    degraded = not slots_all
+
+    contexts = _fetch_model_contexts()
+    chat_slots = _collect_chat_slots(slots_all, contexts=contexts)
+    primary_raw = _resolve_primary_slot(slots_fetcher=lambda: slots_all)
+
+    primary_slot = next(
+        (s for s in slots_all if isinstance(s, dict) and s.get("name") == "primary"),
+        None,
+    )
+    primary_for_template: dict[str, Any] | None = None
+    if primary_raw["model"] and primary_raw["model"] != "primary":
+        primary_for_template = {
+            "alias": _slot_alias(primary_slot) if primary_slot else "primary",
+            "model_id": primary_raw["model"],
+            "backend_url": primary_raw["base_url"],
+            "context_length": primary_raw["context_length"],
+            "backend": (primary_slot or {}).get("backend"),
+        }
+
+    capabilities = _collect_capability_rollup(slots_all)
+
+    # NPU: present from the cached env snapshot; loaded model from any FLM
+    # backend slot (NPU LLM path is FastFlowLM — see hal0_flm_npu_llm_models).
+    env_report = _latest_env_snapshot(hermes_home).get("env_report", {})
+    npu_model = next(
+        (
+            _slot_model_id(s)
+            for s in slots_all
+            if isinstance(s, dict) and "flm" in str(s.get("backend") or "").lower()
+        ),
+        None,
+    )
+    npu = {"present": bool(env_report.get("npu", {}).get("present")), "model_id": npu_model}
+
+    now = now_iso or datetime.now(timezone.utc).isoformat()
+
+    state_vars = {
+        "primary": primary_for_template,
+        "capabilities": capabilities,
+        "npu": npu,
+        "igpu_sclk_mhz": _igpu_sclk_mhz(),
+        "dashboard_url": "https://hal0.thinmint.dev",
+        "lemonade_base": "http://127.0.0.1:13305",
+        "daemon": "degraded" if degraded else "reachable",
+        "as_of": now,
+    }
+    new_state = _render_template("STATE.md.j2", **state_vars)
+
+    out: dict[str, Any] = {
+        "state_written": False,
+        "hermes_written": False,
+        "degraded": degraded,
+        "state_path": str(ETC_HAL0_DIR / "STATE.md"),
+    }
+
+    # STATE.md — content-hash gated (ignore the as_of line).
+    state_path = ETC_HAL0_DIR / "STATE.md"
+    existing = ""
+    if state_path.exists():
+        existing = state_path.read_text(encoding="utf-8")
+    if _state_body_minus_timestamp(existing) != _state_body_minus_timestamp(new_state):
+        _atomic_write(state_path, new_state)
+        out["state_written"] = True
+
+    # HERMES.md — structural map; atomic write (identical content => identical
+    # bytes => prompt-cache safe). Render failure is non-fatal.
+    try:
+        hermes_md = _render_template(
+            "HERMES.md.j2",
+            env=env_report,
+            hal0_version=_hal0_version_string(),
+            hermes_version=_hermes_version_pin(),
+            primary=primary_for_template,
+            chat_slots=chat_slots,
+            peer_agents=[],
+        )
+        hpath = ETC_HAL0_DIR / "HERMES.md"
+        if not hpath.exists() or hpath.read_text(encoding="utf-8") != hermes_md:
+            _atomic_write(hpath, hermes_md)
+            out["hermes_written"] = True
+    except Exception:  # noqa: BLE001 — best-effort; STATE.md already written
+        pass
+
+    return out
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/agents/test_hermes_state_render.py -v`
+Expected: PASS (all 6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/agents/hermes_provision.py tests/agents/test_hermes_state_render.py
+git commit -m "feat(hermes): render_live_context() with content-hash-gated STATE.md"
+```
+
+---
+
+## Task 3: Trim live lines from `HERMES.md.j2`; render STATE.md in `_phase_context_link`
+
+**Files:**
+- Modify: `src/hal0/agents/hermes_templates/HERMES.md.j2`
+- Modify: `src/hal0/agents/hermes_provision.py` (`_phase_context_link`, ~line 1357)
+- Test: `tests/agents/test_hermes_state_render.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/agents/test_hermes_state_render.py`:
+
+```python
+def test_phase_context_link_writes_state_md(tmp_path, monkeypatch):
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    home = tmp_path / "home"
+    (home / "memories").mkdir(parents=True)
+    # No env snapshot file -> empty env_report (templates use defaults).
+    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {"primary": 32768})
+    monkeypatch.setattr(
+        hp, "_fetch_slots",
+        lambda: [{"name": "primary", "type": "llm", "model_id": "qwen3-25b",
+                  "status": "ready", "backend": "vulkan"}],
+    )
+    monkeypatch.setattr(hp, "HAL0_BUNDLED_SKILLS", tmp_path / "nope")
+
+    state = hp.BootstrapState(hermes_home=str(home))  # other fields default
+    res = hp._phase_context_link(state)
+    assert res.status == hp.PhaseStatus.OK
+    assert (tmp_path / "STATE.md").exists()
+    assert "qwen3-25b" in (tmp_path / "STATE.md").read_text()
+    # HERMES.md no longer carries the live "Active capability slots" body.
+    hermes_md = (tmp_path / "HERMES.md").read_text()
+    assert "Live system state" not in hermes_md  # that lives in STATE.md now
+```
+
+> Note: confirm the `BootstrapState` constructor signature in `hermes_provision.py` (~line 40) and pass whatever required fields it needs; adapt the `hp.BootstrapState(...)` call to match. If construction is heavy, build it via the same helper the existing `test_hermes_provision.py` uses.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/agents/test_hermes_state_render.py::test_phase_context_link_writes_state_md -v`
+Expected: FAIL — `STATE.md` not written by `_phase_context_link` yet.
+
+- [ ] **Step 3: Trim `HERMES.md.j2`**
+
+Edit `src/hal0/agents/hermes_templates/HERMES.md.j2`. Delete the live block (current lines ~15–28):
+
+```jinja
+# Active capability slots
+{% if primary %}
+- **primary** (chat/{{ primary.alias | default("primary") }}): `{{ primary.model_id }}`
+  - Endpoint: {{ primary.backend_url }} (alias `model_aliases.primary`)
+{%- endif %}
+{%- if chat_slots %}
+{%- for slot in chat_slots %}
+- **{{ slot.alias }}** (chat): `{{ slot.model_id }}`
+  - {{ slot.backend_url }} → call via `model_aliases.{{ slot.alias }}`
+{%- endfor %}
+{%- endif %}
+{%- if not primary and not chat_slots %}
+- _no chat slots loaded — wire one via `hal0 slot create` then re-run bootstrap with `--repair`._
+{%- endif %}
+```
+
+Replace it with a pointer to STATE.md:
+
+```jinja
+# Live state
+
+Current loaded model, capabilities, and GPU/NPU backend are in
+`/etc/hal0/STATE.md` (auto-injected each session; refreshed on restart
+and on every model/slot change). Read it for the live picture rather
+than assuming — it carries an `_as_of:` timestamp.
+```
+
+- [ ] **Step 4: Make `_phase_context_link` delegate STATE.md + HERMES.md to `render_live_context`**
+
+In `_phase_context_link` (`hermes_provision.py` ~1357): keep the SOUL.md / AGENTS.md / MCP-CLIENTS.md rendering and writes as-is. Remove the HERMES.md render+write block (lines ~1442–1454) — `render_live_context` now owns HERMES.md and STATE.md. After the SOUL.md write block (after line ~1440) and before the AGENTS.md block, add:
+
+```python
+    # STATE.md + HERMES.md are the live files — one shared code path with
+    # the per-restart / per-swap writers. Best-effort: failure here must
+    # not fail bootstrap (SOUL/AGENTS already written).
+    try:
+        live = render_live_context(hermes_home=hermes_home)
+        details["rendered"]["STATE.md"] = {"path": live["state_path"]}
+        if live["degraded"]:
+            warnings.append("STATE.md rendered with daemon degraded")
+        # Re-establish the HOST.md -> HERMES.md mirror (render_live_context
+        # writes HERMES.md but not the symlink).
+        hpath = ETC_HAL0_DIR / "HERMES.md"
+        if hpath.exists():
+            host_md = hermes_home / "memories" / "HOST.md"
+            if _safe_symlink(hpath, host_md):
+                details["links"].append(str(host_md))
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"render_live_context: {exc}")
+```
+
+Also delete the now-dead `chat_slots` / `primary_for_template` setup at the top of `_phase_context_link` only if nothing else in the function uses it after the HERMES.md removal (the SOUL.md render still needs `env`/`vars_`; keep `vars_` for SOUL/AGENTS/MCP-CLIENTS but drop `primary`/`chat_slots` keys if unused by those three templates — verify by grep: `grep -n "primary\|chat_slots" src/hal0/agents/hermes_templates/{SOUL,AGENTS,MCP-CLIENTS}.md.j2`. If they don't reference them, remove from `vars_`).
+
+- [ ] **Step 5: Run the test + the existing provision tests**
+
+Run: `.venv/bin/python -m pytest tests/agents/test_hermes_state_render.py tests/agents/test_hermes_provision.py tests/agents/test_hermes_provision_collect.py -v`
+Expected: PASS. If a pre-existing provision test asserted HERMES.md's old "Active capability slots" text, update that assertion to the new pointer text (it moved to STATE.md by design).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hal0/agents/hermes_templates/HERMES.md.j2 src/hal0/agents/hermes_provision.py tests/agents/test_hermes_state_render.py
+git commit -m "refactor(hermes): move live slot lines HERMES.md -> STATE.md; render via shared path"
+```
+
+---
+
+## Task 4: `render-context` subcommand in the agent shim
+
+**Files:**
+- Modify: `src/hal0/cli/agent_shim.py` (`cmd_render_context`, parser choice, `_DISPATCH`)
+- Test: `tests/cli/test_agent_shim.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/cli/test_agent_shim.py` (match its existing import style; it imports the shim module — confirm the alias, e.g. `from hal0.cli import agent_shim`):
+
+```python
+def test_render_context_dispatch_calls_render(monkeypatch, tmp_path):
+    from hal0.cli import agent_shim
+
+    called = {}
+
+    def fake_render(*, hermes_home):
+        called["home"] = hermes_home
+        return {"state_written": True, "hermes_written": False,
+                "degraded": False, "state_path": "/etc/hal0/STATE.md"}
+
+    monkeypatch.setattr(agent_shim, "_render_live_context", fake_render)
+
+    cfg = agent_shim.AgentConfig(
+        agent_id="hermes", agent_type="hermes",
+        home=tmp_path, venv=tmp_path / "venv",
+        host="127.0.0.1", port=8133,
+    )
+    rc = agent_shim.cmd_render_context(cfg)
+    assert rc == 0
+    assert called["home"] == tmp_path
+
+
+def test_render_context_in_parser_choices():
+    from hal0.cli import agent_shim
+
+    parser = agent_shim._build_parser()
+    args = parser.parse_args(["hermes", "render-context"])
+    assert args.subcommand == "render-context"
+```
+
+> Confirm `AgentConfig`'s real fields/constructor (~line 76) and adapt the kwargs — use the same construction the existing shim tests use if they have a fixture/factory.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/cli/test_agent_shim.py -k render_context -v`
+Expected: FAIL — `cmd_render_context` / `_render_live_context` missing; `render-context` not a valid choice.
+
+- [ ] **Step 3: Implement the subcommand**
+
+In `src/hal0/cli/agent_shim.py`:
+
+a) Add a thin import-indirection near the top-level imports (kept patchable for tests, and lazy to avoid importing provision at module load):
+
+```python
+def _render_live_context(*, hermes_home: Path) -> dict[str, object]:
+    """Indirection so tests can patch; lazy import keeps shim startup light."""
+    from hal0.agents.hermes_provision import render_live_context
+
+    return render_live_context(hermes_home=hermes_home)
+```
+
+b) Add the command function (near `cmd_reprovision`):
+
+```python
+def cmd_render_context(cfg: AgentConfig) -> int:
+    """Re-probe live hal0 state and (re)write STATE.md + HERMES.md.
+
+    Wired as ``ExecStartPre`` on hal0-agent@hermes.service (non-fatal) and
+    spawned detached after a model/slot change. Render is best-effort:
+    a daemon-unreachable read leaves last-good files and still exits 0 so
+    it never blocks the service from starting.
+    """
+    if cfg.agent_type != "hermes":
+        _die(f"agent type '{cfg.agent_type}' not supported by this shim yet")
+    try:
+        result = _render_live_context(hermes_home=cfg.home)
+    except Exception as exc:  # noqa: BLE001 — never block service start
+        print(f"hal0-agent: render-context failed (non-fatal): {exc}", file=sys.stderr)
+        return 0
+    state = "degraded" if result.get("degraded") else "ok"
+    print(
+        f"hal0-agent: render-context {state} "
+        f"(state_written={result.get('state_written')}, "
+        f"hermes_written={result.get('hermes_written')})"
+    )
+    return 0
+```
+
+c) Add `"render-context"` to the parser `choices` list and to `_DISPATCH`:
+
+```python
+        choices=["serve", "stop", "status", "reprovision", "render-context"],
+```
+```python
+_DISPATCH: dict[str, Callable[[AgentConfig], int]] = {
+    "serve": cmd_serve,
+    "stop": cmd_stop,
+    "status": cmd_status,
+    "reprovision": cmd_reprovision,
+    "render-context": cmd_render_context,
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/cli/test_agent_shim.py -k render_context -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/cli/agent_shim.py tests/cli/test_agent_shim.py
+git commit -m "feat(hermes): hal0-agent render-context subcommand"
+```
+
+---
+
+## Task 5: ExecStartPre wiring on the systemd unit
+
+**Files:**
+- Modify: `installer/systemd/hal0-agent@hermes.service.d/override.conf`
+
+- [ ] **Step 1: Add the ExecStartPre directive**
+
+In `installer/systemd/hal0-agent@hermes.service.d/override.conf`, under the existing `[Service]` section, append:
+
+```ini
+# Refresh STATE.md / HERMES.md from live slot+capability state before the
+# agent boots, so a restart always reflects the current model/backend.
+# Leading `-` => non-fatal: a render failure (daemon not up yet) leaves
+# last-good files and never blocks the service from starting. See
+# docs/internal/hermes-state-md-auto-render-2026-06-04.md.
+ExecStartPre=-/usr/local/bin/hal0-agent %i render-context
+```
+
+- [ ] **Step 2: Verify the unit parses**
+
+Run (locally, syntax-only — `systemd-analyze verify` needs the full unit; instead lint the drop-in for the directive):
+
+```bash
+grep -n "ExecStartPre=-/usr/local/bin/hal0-agent %i render-context" installer/systemd/hal0-agent@hermes.service.d/override.conf
+```
+Expected: the line is present. (Full `systemctl daemon-reload` verification happens on the LXC in Task 8.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add installer/systemd/hal0-agent@hermes.service.d/override.conf
+git commit -m "feat(hermes): ExecStartPre render-context on hal0-agent@hermes"
+```
+
+---
+
+## Task 6: `on_session_start` hook script + installer wiring
+
+**Files:**
+- Create: `installer/agents/hermes/hooks/inject-system-state.sh`
+- Modify: `installer/install.sh`
+- Modify: `installer/uninstall.sh`
+
+- [ ] **Step 1: Write the hook script**
+
+Create `installer/agents/hermes/hooks/inject-system-state.sh` (mode 0755):
+
+```sh
+#!/bin/sh
+# hal0 Hermes on_session_start hook — inject live system state.
+#
+# Wired by hermes_templates/config.yaml.j2 (hooks.on_session_start).
+# Contract: emit context to stdout for the new session; stay inside the
+# 2s hook timeout. We ONLY cat the pre-rendered /etc/hal0/STATE.md (the
+# expensive probe runs in the writers, not here). If STATE.md is older
+# than the TTL we additionally kick a DETACHED background refresh so the
+# NEXT session is fresh — we never block this session on a probe.
+set -eu
+
+STATE_FILE="/etc/hal0/STATE.md"
+TTL_SECONDS=300   # 5 min — defense-in-depth for missed change events.
+
+# Missing file (first boot before any render) => emit nothing, exit clean.
+[ -f "$STATE_FILE" ] || exit 0
+
+# Stale? Kick a detached, output-discarded refresh. setsid+& so it never
+# holds up the session even if the daemon probe is slow.
+now=$(date +%s)
+mtime=$(stat -c %Y "$STATE_FILE" 2>/dev/null || echo "$now")
+age=$(( now - mtime ))
+if [ "$age" -gt "$TTL_SECONDS" ]; then
+    setsid /usr/local/bin/hal0-agent hermes render-context >/dev/null 2>&1 &
+fi
+
+# Inject the current (possibly slightly-stale) snapshot into the session.
+cat "$STATE_FILE"
+```
+
+- [ ] **Step 2: Test the hook behavior with a shell test**
+
+Run these manual assertions (no pytest harness for shell hooks in-repo):
+
+```bash
+# missing file -> no output, exit 0
+sh installer/agents/hermes/hooks/inject-system-state.sh && echo "EXIT_OK"
+# Expected: just "EXIT_OK" (STATE_FILE absent at /etc/hal0 on this VM).
+
+# present file -> contents echoed (use a temp copy of the logic by pointing
+# STATE_FILE via a sed-free check): create a fixture and source-test inline
+tmp=$(mktemp -d); printf '# Live system state\n_as_of: x_\n' > "$tmp/STATE.md"
+STATE_FILE="$tmp/STATE.md" sh -c '
+  set -eu; STATE_FILE="$1"; [ -f "$STATE_FILE" ] || exit 0; cat "$STATE_FILE"
+' _ "$tmp/STATE.md"
+# Expected: prints the two lines.
+```
+Expected: first prints `EXIT_OK`; second prints the fixture contents.
+
+- [ ] **Step 3: Wire the hook into `install.sh`**
+
+Find where `install.sh` defines `LIB_DIR` / installs lib assets (`grep -n "usr/lib/hal0\|LIB_DIR\|hermes" installer/install.sh`). Add a step that copies the hook into place (adapt variable names to the script's existing style):
+
+```sh
+# hal0 Hermes session hooks (on_session_start: inject-system-state.sh).
+install -d "${LIB_DIR}/hermes-hooks"
+install -m 0755 "${SRC_DIR}/agents/hermes/hooks/inject-system-state.sh" \
+    "${LIB_DIR}/hermes-hooks/inject-system-state.sh"
+```
+
+> `LIB_DIR` here must resolve to `/usr/lib/hal0` (matches `config.yaml.j2`'s `/usr/lib/hal0/hermes-hooks/inject-system-state.sh` and `uninstall.sh`'s `LIB_DIR`). Confirm `SRC_DIR` (or equivalent) is the installer's source root used by other `install -m` calls; reuse that exact variable.
+
+- [ ] **Step 4: Wire removal into `uninstall.sh`**
+
+In `installer/uninstall.sh`, near the existing `LIB_DIR` cleanup (~line 70–77), ensure the hooks dir is removed:
+
+```sh
+rm -rf "${LIB_DIR}/hermes-hooks"
+```
+(If `uninstall.sh` already `rm -rf "${LIB_DIR}"` wholesale, no change is needed — verify and skip this step if so.)
+
+- [ ] **Step 5: Verify scripts are shell-lint clean**
+
+Run: `shellcheck installer/agents/hermes/hooks/inject-system-state.sh` (if `shellcheck` is available) and `sh -n installer/agents/hermes/hooks/inject-system-state.sh`
+Expected: no syntax errors. (`sh -n` is always available; shellcheck optional.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add installer/agents/hermes/hooks/inject-system-state.sh installer/install.sh installer/uninstall.sh
+git commit -m "feat(hermes): write the on_session_start inject-system-state hook + installer wiring"
+```
+
+---
+
+## Task 7: Runtime writers — refresh on `swap()` and `apply()`
+
+**Files:**
+- Modify: `src/hal0/slots/manager.py` (`swap()`, ~line 787)
+- Modify: `src/hal0/capabilities/orchestrator.py` (`apply()`, ~line 316)
+- Test: `tests/agents/test_hermes_state_render.py` (append — test the shared spawn helper)
+
+The daemon runs an asyncio event loop; we must NOT block it on the urllib probe. Spawn a **detached, best-effort** `hal0-agent hermes render-context` subprocess. Factor it into one helper so both call sites are identical.
+
+- [ ] **Step 1: Write the failing test for the spawn helper**
+
+Append to `tests/agents/test_hermes_state_render.py`:
+
+```python
+def test_spawn_context_refresh_is_best_effort(monkeypatch):
+    from hal0.agents import hermes_refresh
+
+    calls = {}
+
+    def fake_popen(argv, **kw):
+        calls["argv"] = argv
+        calls["kw"] = kw
+        class _P:  # minimal stand-in
+            pass
+        return _P()
+
+    monkeypatch.setattr(hermes_refresh.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(hermes_refresh.shutil, "which", lambda _n: "/usr/local/bin/hal0-agent")
+
+    hermes_refresh.spawn_context_refresh("hermes")
+    assert calls["argv"] == ["/usr/local/bin/hal0-agent", "hermes", "render-context"]
+
+    # Never raises even if Popen blows up.
+    def boom(*a, **k):
+        raise OSError("no exec")
+    monkeypatch.setattr(hermes_refresh.subprocess, "Popen", boom)
+    hermes_refresh.spawn_context_refresh("hermes")  # must not raise
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/agents/test_hermes_state_render.py::test_spawn_context_refresh_is_best_effort -v`
+Expected: FAIL — `No module named 'hal0.agents.hermes_refresh'`.
+
+- [ ] **Step 3: Create the spawn helper module**
+
+Create `src/hal0/agents/hermes_refresh.py`:
+
+```python
+"""Fire-and-forget trigger to refresh the Hermes live-context files.
+
+Called from the asyncio daemon (slot swap / capability apply) where we
+must not block the event loop on the urllib probe inside
+``render_live_context``. We spawn a detached ``hal0-agent <id>
+render-context`` instead — the subcommand owns the probe + atomic writes.
+Best-effort: any failure is logged and swallowed; a model swap must never
+fail because context refresh couldn't start.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+def spawn_context_refresh(agent_id: str = "hermes") -> None:
+    """Spawn a detached ``hal0-agent <agent_id> render-context``. Never raises."""
+    try:
+        binary = shutil.which("hal0-agent") or "/usr/local/bin/hal0-agent"
+        subprocess.Popen(  # noqa: S603 — fixed argv, no shell
+            [binary, agent_id, "render-context"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.debug("hermes context refresh spawn failed (non-fatal): %s", exc)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/agents/test_hermes_state_render.py::test_spawn_context_refresh_is_best_effort -v`
+Expected: PASS.
+
+- [ ] **Step 5: Call the helper from `manager.swap()`**
+
+In `src/hal0/slots/manager.py`, at the end of `swap()` (~line 787) — after the swap has succeeded and is about to `return slot` — add:
+
+```python
+        # Refresh Hermes's live-context files so a model swap is visible to
+        # the agent on its next session (detached; never blocks the swap).
+        from hal0.agents.hermes_refresh import spawn_context_refresh
+
+        spawn_context_refresh()
+```
+
+Place it just before the `return`. Read the surrounding lines first to match indentation and ensure it's on the success path only (not inside an exception branch).
+
+- [ ] **Step 6: Call the helper from `orchestrator.apply()`**
+
+In `src/hal0/capabilities/orchestrator.py`, at the end of `apply()` (~line 316), on the success path before its return, add the same three lines:
+
+```python
+        from hal0.agents.hermes_refresh import spawn_context_refresh
+
+        spawn_context_refresh()
+```
+
+- [ ] **Step 7: Run the relevant manager/orchestrator tests**
+
+Run: `.venv/bin/python -m pytest tests/ -k "swap or orchestrator or capabilit" -v` (subset — full suite hangs locally)
+Expected: PASS. Tests that exercise `swap`/`apply` should be unaffected (the spawn is patched-out or harmlessly fails when `hal0-agent` isn't on PATH in the test env — confirm no test asserts on subprocess; if one does, monkeypatch `spawn_context_refresh` in that test).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/hal0/agents/hermes_refresh.py src/hal0/slots/manager.py src/hal0/capabilities/orchestrator.py tests/agents/test_hermes_state_render.py
+git commit -m "feat(hermes): refresh STATE.md on slot swap + capability apply"
+```
+
+---
+
+## Task 8: Lint, format, and LXC integration verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Ruff lint + format check (CI gates both)**
+
+Run:
+```bash
+.venv/bin/ruff check src/hal0/agents/hermes_provision.py src/hal0/agents/hermes_refresh.py src/hal0/cli/agent_shim.py
+.venv/bin/ruff format --check src/hal0/agents/hermes_provision.py src/hal0/agents/hermes_refresh.py src/hal0/cli/agent_shim.py
+```
+Expected: both clean. Fix any findings and re-run. (`ruff format --check` is a separate fatal CI step — do not skip it.)
+
+- [ ] **Step 2: Run the full new test file + touched suites**
+
+Run:
+```bash
+.venv/bin/python -m pytest tests/agents/test_hermes_state_render.py tests/cli/test_agent_shim.py tests/agents/test_hermes_provision.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step 3: Deploy to the LXC and verify end-to-end**
+
+The runtime behavior (systemd ExecStartPre, the hook, live probe) can only be verified on `hal0` (CT 105). Sync + install + exercise:
+
+```bash
+# Sync the branch to the LXC working copy (adapt to your deploy flow).
+ssh hal0 'cd /opt/hal0 && git fetch origin && git checkout feat/hermes-state-md-autorender && git pull --ff-only'
+ssh hal0 'cd /opt/hal0 && .venv/bin/pip install -e . --no-deps'
+ssh hal0 'sudo bash installer/install.sh --upgrade'   # or the project's reinstall path; confirm the flag
+```
+
+Then verify each trigger:
+
+```bash
+# (a) Restart trigger — ExecStartPre rewrites STATE.md.
+ssh hal0 'sudo systemctl daemon-reload && sudo systemctl restart hal0-agent@hermes'
+ssh hal0 'cat /etc/hal0/STATE.md'   # shows current model + as_of just now
+ssh hal0 'journalctl -u hal0-agent@hermes -n 20 | grep render-context'  # "render-context ok ..."
+
+# (b) Runtime change trigger — swap a slot, STATE.md as_of bumps.
+ssh hal0 'cat /etc/hal0/STATE.md | grep _as_of'   # note timestamp
+ssh hal0 'hal0 slot swap primary <some-other-model>'  # or capability_set
+sleep 3
+ssh hal0 'cat /etc/hal0/STATE.md | grep _as_of'   # timestamp advanced; model changed
+
+# (c) Hook injection — new session sees STATE.md.
+ssh hal0 'cat /usr/lib/hal0/hermes-hooks/inject-system-state.sh'  # installed
+ssh hal0 'sh /usr/lib/hal0/hermes-hooks/inject-system-state.sh'   # prints STATE.md
+
+# (d) Cache safety — SOUL.md byte-stable across a restart with no slot change.
+ssh hal0 'sha256sum /var/lib/hal0/.hermes/SOUL.md'
+ssh hal0 'sudo systemctl restart hal0-agent@hermes && sha256sum /var/lib/hal0/.hermes/SOUL.md'
+# Expected: identical hashes.
+```
+Expected: (a) STATE.md `_as_of` is fresh + journal logs `render-context ok`; (b) `_as_of` advances and the model line changes after a swap; (c) hook prints STATE.md; (d) SOUL.md hash unchanged.
+
+- [ ] **Step 4: Record findings + push the branch**
+
+Note any deviations in the spec doc's "Testing strategy" section. Then push (Tier-2: verify branch name + remote first):
+
+```bash
+git push -u origin feat/hermes-state-md-autorender
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+gh pr create --title "feat(hermes): auto-render live STATE.md on restart + model/slot change" \
+  --body "Implements docs/internal/hermes-state-md-auto-render-2026-06-04.md (DreamServer mesh parity #2). See plan: docs/internal/hermes-state-md-auto-render-2026-06-04-plan.md."
+```
+
+---
+
+## Self-Review Notes (author)
+
+- **Spec coverage:** STATE.md template (T1) ✓; render_live_context + content-hash + as_of + degraded (T2) ✓; HERMES.md trim + SOUL untouched (T3) ✓; render-context subcommand (T4) ✓; ExecStartPre restart trigger (T5) ✓; on_session_start hook + 5-min TTL non-blocking regen + installer wiring (T6) ✓; swap()/apply() runtime trigger (T7) ✓; cache-stability + LXC verification (T8) ✓. All four chosen fields (loaded model+ctx, capability rollup, GPU/NPU backend, URLs+health) + timestamp covered in T1/T2.
+- **Verified during planning:** `BootstrapState` is a dataclass with all-defaulted fields — `BootstrapState(hermes_home=str(home))` is valid (T3). `AgentConfig` fields are `agent_id, agent_type, home, venv, host, port` (`hermes_bin`/`status_url` are read-only properties, NOT ctor args) — T4 test uses these.
+- **Open verification points flagged inline (must check during impl, not assume):** `install.sh` `LIB_DIR`/`SRC_DIR` variable names (T6); exact success-path return sites in `swap()`/`apply()` (T7); whether `uninstall.sh` already removes `LIB_DIR` wholesale (T6); whether any existing test asserts the old HERMES.md "Active capability slots" text (T3) or subprocess in swap/apply tests (T7).
+- **Non-goals honored:** no new daemon, no timer unit, no SIGHUP path.

--- a/docs/internal/hermes-state-md-auto-render-2026-06-04.md
+++ b/docs/internal/hermes-state-md-auto-render-2026-06-04.md
@@ -1,0 +1,213 @@
+# Hermes live-state auto-render (`STATE.md`) — design
+
+**Date:** 2026-06-04
+**Branch:** `feat/hermes-state-md-autorender`
+**Status:** Approved design — ready for implementation plan
+**Origin:** DreamServer mesh parity item #2 ("auto-render Hermes SOUL from
+live slot/capability state every restart"). hal0 has richer state to
+inject than DreamServer (NPU + iGPU + capability rollup), so this goes
+beyond their `build-installation-context.py`.
+
+## Goal
+
+Hermes always sees the **current** hal0 live state — fresh on every
+service restart **and** on every runtime model/capability change —
+without:
+
+- bloating the cacheable persona prefix (`SOUL.md`), and
+- stalling Hermes session start with a synchronous daemon probe.
+
+## Background — what already exists
+
+- `_phase_context_link` (`src/hal0/agents/hermes_provision.py`) already
+  renders `SOUL.md`, `HERMES.md`, `AGENTS.md`, `MCP-CLIENTS.md` from
+  Jinja2 templates in `hermes_templates/`, pulling live slot state
+  (`/api/slots`), per-model context (`/v1/models`), and a cached
+  hardware env snapshot.
+- **It only runs at `hal0 agent bootstrap hermes` / `--repair`**, and is
+  checkpoint-gated so it won't even re-run unless an input hash drifts.
+- The service path is `hal0-agent@hermes.service` → `hal0-agent hermes
+  serve` (`cmd_serve` in `src/hal0/cli/agent_shim.py`) → spawns `hermes
+  dashboard`. **No render happens at restart.**
+- `config.yaml.j2` (line ~213) already declares an `on_session_start`
+  hook pointing at `/usr/lib/hal0/hermes-hooks/inject-system-state.sh`
+  — **but that script was never written.** It is a dangling reference
+  from the 2026-05-23 bootstrap plan; the hook fires every session and
+  silently no-ops today.
+
+### Key mechanism fact
+
+Hermes reads cwd-context files (`SOUL.md`, `HERMES.md`) at **process /
+session start** — a file rewritten mid-run is not seen until the next
+session. The **only** mechanism that re-evaluates per session without a
+restart is the `on_session_start` hook, which injects its stdout into
+the new session via Hermes's JSON wire protocol (hooks have a per-event
+allowlist at `$HERMES_HOME/shell-hooks-allowlist.json`; non-interactive
+runs need `--accept-hooks` / `HERMES_ACCEPT_HOOKS=1`). The hook here is
+configured with a **2s timeout**.
+
+## Architecture — buffer-file + reader-hook with dual writers
+
+```
+                 ┌── ExecStartPre: `hal0-agent <id> render-context`   (on RESTART)
+   writers ──────┤
+                 └── post-change call in manager.swap() /             (on MODEL/SLOT/
+                     orchestrator.apply()                              CAPABILITY CHANGE)
+                          │
+                          ▼
+                  /etc/hal0/STATE.md   ← thin volatile snapshot (~12 lines)
+                          │
+   reader ────────────────┤
+                  on_session_start hook (inject-system-state.sh)
+                    → cats STATE.md to stdout
+                    → if file older than TTL: also spawns DETACHED render-context
+                          │
+                          ▼
+                  injected into EVERY new Hermes session — even if the
+                  process has run for hours and the model changed under it
+```
+
+The expensive probe runs **only on actual change events** (restart,
+swap, apply), never on the latency-sensitive session-start path. The
+session-start hook just `cat`s a file → instant, never risks the 2s
+timeout.
+
+## Components
+
+### 1. `STATE.md` — volatile live snapshot
+
+- Path: `/etc/hal0/STATE.md` (same dir as `HERMES.md`, which is the
+  Hermes `terminal.cwd`).
+- New template: `src/hal0/agents/hermes_templates/STATE.md.j2`.
+- Target size: ~12 lines. Holds **only** volatile state. Fields:
+  1. **Loaded chat model + ctx window** — the actually-loaded primary
+     model id + its `context_length` (`/api/slots` ∩ `/v1/models`).
+  2. **Active capabilities rollup** — one line each for embed / voice
+     (stt+tts) / img / rerank that are loaded, and on which backend
+     (iGPU vs NPU).
+  3. **GPU/NPU runtime backend** — inference backend (Vulkan vs ROCm),
+     iGPU clock, NPU XDNA presence + loaded model.
+  4. **Live URLs + daemon-health marker** — dashboard URL, lemond base,
+     and a one-word `reachable` / `degraded` marker.
+  5. **`as_of` timestamp** — when the snapshot content was last
+     rendered.
+
+### 2. `render-context` subcommand (`agent_shim.py`)
+
+- New lightweight, render-only entrypoint: `hal0-agent <id>
+  render-context`. Added to the `_DISPATCH` table alongside
+  `serve`/`stop`/`status`/`reprovision`.
+- Re-probes `/api/slots` + `/v1/models` + the cached env snapshot and
+  rewrites `STATE.md` (and re-renders `HERMES.md`, since a swap may
+  add/remove a slot and change the structural map).
+- Reuses the existing render helpers from `hermes_provision`
+  (`_fetch_slots`, `_collect_chat_slots`, `_fetch_model_contexts`,
+  `_resolve_primary_slot`, `_render_template`, `_atomic_write`). Does
+  **not** run the full bootstrap or touch checkpoints.
+- **Content-hash gated:** compute a hash over the substantive fields
+  (excluding `as_of`); only rewrite the file + bump `as_of` when the
+  hash changes. A regen that finds nothing changed does not churn the
+  file.
+- Degraded handling: if the daemon is unreachable, leave the existing
+  `STATE.md` intact and emit a non-zero-but-non-fatal warning; the
+  `degraded` marker is only written when we have a partial-but-current
+  read.
+
+### 3. ExecStartPre on the unit
+
+- Add to `installer/systemd/hal0-agent@hermes.service.d/override.conf`:
+  `ExecStartPre=-/usr/local/bin/hal0-agent %i render-context`.
+- Leading `-` → render failure is **non-fatal**: leaves last-good files
+  and never blocks the service from starting.
+
+### 4. Runtime writer hook (the second trigger)
+
+- After a **successful** `slots/manager.py:swap()` and
+  `capabilities/orchestrator.py:apply()`, fire the same render
+  best-effort (logged, swallowed on error, never blocks the API
+  response or the swap/apply result).
+- Implementation note: factor the render into a small importable
+  function so both the CLI subcommand and these call sites use one code
+  path (no `subprocess` round-trip from inside the daemon).
+
+### 5. `inject-system-state.sh` — finally write the dangling hook
+
+- Path: `/usr/lib/hal0/hermes-hooks/inject-system-state.sh` (shipped by
+  the installer; referenced by `config.yaml.j2` `on_session_start`).
+- Behavior:
+  1. `cat` `/etc/hal0/STATE.md` to stdout in the hook's JSON wire
+     format (inject as session context).
+  2. If `STATE.md` mtime is older than **TTL = 5 minutes**, additionally
+     spawn a **detached** `hal0-agent hermes render-context` (background,
+     `&` / `setsid`, output discarded) so the *next* session is fresh.
+     **Never** block on the probe — the current session always gets the
+     existing (possibly slightly stale) file immediately.
+  3. Stay well inside the 2s hook timeout (pure `cat` + a non-blocking
+     spawn).
+- If `STATE.md` is missing entirely (first boot before any render),
+  emit nothing and exit 0 — never error the session.
+
+### 6. `SOUL.md` and `HERMES.md` boundary cleanup
+
+- **`SOUL.md`**: unchanged in spirit — stable persona (identity +
+  operating principles + boundaries). Stays byte-stable across restarts
+  → keeps the large cacheable prefix warm.
+- **`HERMES.md`**: trimmed to **structural / rarely-changing** content
+  (slot layout intent, peer agents, skills paths, conventions). Its
+  current *live* "primary / chat slot" lines (template lines ~16–28)
+  **move into `STATE.md`** to avoid duplication and to stop the live
+  data from churning the structural file.
+
+## Freshness model (resolved decisions)
+
+- **Primary freshness = the two event writers** (restart, swap/apply).
+  These carry the real load and keep `STATE.md` current almost always.
+- **TTL (5 min) = defense-in-depth** for *missed* events (an unobserved
+  daemon restart, a mutation path not hooked, a writer that failed).
+  Implemented as a **non-blocking background kick** in the hook — serve
+  stale instantly, refresh out of band (stale-while-revalidate).
+- **`as_of` timestamp + `degraded` marker** make staleness *visible* to
+  the agent instead of silent — directly countering the
+  "silent-fallback" failure class that bit the original bootstrap
+  (PR #316).
+
+## Non-goals / boundaries
+
+- No new daemon, no systemd timer unit (TTL lives in the hook).
+- No SIGHUP config-reload path.
+- No change to bootstrap phase ordering or checkpoint logic.
+- Approach 2 (restart-only re-render) and Approach 3 (hook-only live
+  probe, no file) were considered and **rejected** — 2 fails the
+  runtime-change trigger; 3 puts the probe on the session path.
+
+## Testing strategy
+
+- **Unit:** `STATE.md.j2` renders correctly for (a) full live state,
+  (b) no chat slot loaded, (c) daemon degraded. Content-hash gating:
+  identical substantive state → no rewrite / no `as_of` bump; changed
+  field → rewrite + bump.
+- **Unit:** `render-context` subcommand dispatches, writes atomically,
+  and is non-fatal when the daemon is unreachable.
+- **Integration (LXC):** restart `hal0-agent@hermes` → `STATE.md`
+  refreshes (ExecStartPre); `hal0 slot swap` / `capability_set` →
+  `STATE.md` refreshes (runtime writer); start a new Hermes session →
+  hook injects current `STATE.md`; touch `STATE.md` mtime back >5 min →
+  new session still instant + a background regen fires.
+- **Cache check:** confirm `SOUL.md` + `HERMES.md` are byte-identical
+  across a restart that doesn't change slots (only `STATE.md` differs).
+
+## Affected files (anticipated)
+
+- `src/hal0/agents/hermes_templates/STATE.md.j2` (new)
+- `src/hal0/agents/hermes_templates/HERMES.md.j2` (trim live lines)
+- `src/hal0/agents/hermes_provision.py` (extract shared render fn;
+  render `STATE.md` in `_phase_context_link` too)
+- `src/hal0/cli/agent_shim.py` (`render-context` subcommand)
+- `src/hal0/slots/manager.py` (`swap()` post-change render call)
+- `src/hal0/capabilities/orchestrator.py` (`apply()` post-change render call)
+- `installer/systemd/hal0-agent@hermes.service.d/override.conf` (ExecStartPre)
+- `installer/agents/hermes/hooks/inject-system-state.sh` (new) — source
+  asset, installed to `/usr/lib/hal0/hermes-hooks/` (`LIB_DIR` in
+  `install.sh`); add the copy+chmod step to `install.sh` and the matching
+  removal to `uninstall.sh`
+- Tests under `tests/` mirroring the above.

--- a/docs/internal/hermes-state-md-auto-render-2026-06-04.md
+++ b/docs/internal/hermes-state-md-auto-render-2026-06-04.md
@@ -55,7 +55,7 @@ configured with a **2s timeout**.
                      orchestrator.apply()                              CAPABILITY CHANGE)
                           │
                           ▼
-                  /etc/hal0/STATE.md   ← thin volatile snapshot (~12 lines)
+                  /var/lib/hal0/STATE.md   ← thin volatile snapshot (~12 lines)
                           │
    reader ────────────────┤
                   on_session_start hook (inject-system-state.sh)
@@ -76,7 +76,7 @@ timeout.
 
 ### 1. `STATE.md` — volatile live snapshot
 
-- Path: `/etc/hal0/STATE.md` (same dir as `HERMES.md`, which is the
+- Path: `/var/lib/hal0/STATE.md` (same dir as `HERMES.md`, which is the
   Hermes `terminal.cwd`).
 - New template: `src/hal0/agents/hermes_templates/STATE.md.j2`.
 - Target size: ~12 lines. Holds **only** volatile state. Fields:
@@ -135,7 +135,7 @@ timeout.
 - Path: `/usr/lib/hal0/hermes-hooks/inject-system-state.sh` (shipped by
   the installer; referenced by `config.yaml.j2` `on_session_start`).
 - Behavior:
-  1. `cat` `/etc/hal0/STATE.md` to stdout in the hook's JSON wire
+  1. `cat` `/var/lib/hal0/STATE.md` to stdout in the hook's JSON wire
      format (inject as session context).
   2. If `STATE.md` mtime is older than **TTL = 5 minutes**, additionally
      spawn a **detached** `hal0-agent hermes render-context` (background,

--- a/installer/agents/hermes/hooks/inject-system-state.sh
+++ b/installer/agents/hermes/hooks/inject-system-state.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# hal0 Hermes on_session_start hook — inject live system state.
+#
+# Wired by hermes_templates/config.yaml.j2 (hooks.on_session_start).
+# Contract: emit context to stdout for the new session; stay inside the
+# 2s hook timeout. We ONLY cat the pre-rendered /etc/hal0/STATE.md (the
+# expensive probe runs in the writers, not here). If STATE.md is older
+# than the TTL we additionally kick a DETACHED background refresh so the
+# NEXT session is fresh — we never block this session on a probe.
+set -eu
+
+STATE_FILE="/etc/hal0/STATE.md"
+TTL_SECONDS=300   # 5 min — defense-in-depth for missed change events.
+
+# Missing file (first boot before any render) => emit nothing, exit clean.
+[ -f "$STATE_FILE" ] || exit 0
+
+# Stale? Kick a detached, output-discarded refresh. setsid+& so it never
+# holds up the session even if the daemon probe is slow.
+now=$(date +%s)
+mtime=$(stat -c %Y "$STATE_FILE" 2>/dev/null || echo "$now")
+age=$(( now - mtime ))
+if [ "$age" -gt "$TTL_SECONDS" ]; then
+    setsid /usr/local/bin/hal0-agent hermes render-context >/dev/null 2>&1 &
+fi
+
+# Inject the current (possibly slightly-stale) snapshot into the session.
+cat "$STATE_FILE"

--- a/installer/agents/hermes/hooks/inject-system-state.sh
+++ b/installer/agents/hermes/hooks/inject-system-state.sh
@@ -3,13 +3,15 @@
 #
 # Wired by hermes_templates/config.yaml.j2 (hooks.on_session_start).
 # Contract: emit context to stdout for the new session; stay inside the
-# 2s hook timeout. We ONLY cat the pre-rendered /etc/hal0/STATE.md (the
+# 2s hook timeout. We ONLY cat the pre-rendered /var/lib/hal0/STATE.md (the
 # expensive probe runs in the writers, not here). If STATE.md is older
 # than the TTL we additionally kick a DETACHED background refresh so the
 # NEXT session is fresh — we never block this session on a probe.
 set -eu
 
-STATE_FILE="/etc/hal0/STATE.md"
+# Runtime snapshot lives under the hal0-owned /var/lib/hal0 (#473) so the
+# User=hal0 render-context writer can produce it under the hermes sandbox.
+STATE_FILE="/var/lib/hal0/STATE.md"
 TTL_SECONDS=300   # 5 min — defense-in-depth for missed change events.
 
 # Missing file (first boot before any render) => emit nothing, exit clean.

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -534,6 +534,24 @@ if [[ -f "${AGENT_UNIT_SRC}" ]]; then
         cp "${AGENT_OVERRIDE_SRC}" "${AGENT_OVERRIDE_DST_DIR}/override.conf"
         info "wrote ${AGENT_OVERRIDE_DST_DIR}/override.conf"
     fi
+
+    # Session-start hook: inject-system-state.sh cats /etc/hal0/STATE.md into
+    # every new Hermes session (referenced by config.yaml.j2's
+    # hooks.on_session_start). MUST land at the absolute /usr/lib/hal0 path
+    # the config hardcodes (dev mode shadows it under PREFIX).
+    if [[ "${DEV_MODE}" -eq 1 ]]; then
+        LIB_DIR="${PREFIX}/usr/lib/hal0"
+    else
+        LIB_DIR="/usr/lib/hal0"
+    fi
+    HOOK_SRC="${REPO_ROOT}/installer/agents/hermes/hooks/inject-system-state.sh"
+    if [[ -f "${HOOK_SRC}" ]]; then
+        install -d "${LIB_DIR}/hermes-hooks"
+        install -m 0755 "${HOOK_SRC}" "${LIB_DIR}/hermes-hooks/inject-system-state.sh"
+        info "wrote ${LIB_DIR}/hermes-hooks/inject-system-state.sh"
+    else
+        warn "${HOOK_SRC} not found — Hermes session-state hook not installed"
+    fi
 else
     warn "${AGENT_UNIT_SRC} not found — hal0-agent@ template not installed"
 fi

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -535,7 +535,7 @@ if [[ -f "${AGENT_UNIT_SRC}" ]]; then
         info "wrote ${AGENT_OVERRIDE_DST_DIR}/override.conf"
     fi
 
-    # Session-start hook: inject-system-state.sh cats /etc/hal0/STATE.md into
+    # Session-start hook: inject-system-state.sh cats /var/lib/hal0/STATE.md into
     # every new Hermes session (referenced by config.yaml.j2's
     # hooks.on_session_start). MUST land at the absolute /usr/lib/hal0 path
     # the config hardcodes (dev mode shadows it under PREFIX).

--- a/installer/systemd/hal0-agent@hermes.service.d/override.conf
+++ b/installer/systemd/hal0-agent@hermes.service.d/override.conf
@@ -31,3 +31,10 @@ Environment="HERMES_WEB_DIST=/var/lib/hal0/venvs/hermes/lib/python3.12/site-pack
 # reads this to discover the lemond OpenAI-compatible base. Default
 # matches `installer/install.sh`'s lemond bind (127.0.0.1:13305).
 Environment="HAL0_LEMONADE_BASE=http://127.0.0.1:13305"
+
+# Refresh STATE.md / HERMES.md from live slot+capability state before the
+# agent boots, so a restart always reflects the current model/backend.
+# Leading `-` => non-fatal: a render failure (e.g. daemon not up yet)
+# leaves last-good files and never blocks the service from starting. See
+# docs/internal/hermes-state-md-auto-render-2026-06-04.md.
+ExecStartPre=-/usr/local/bin/hal0-agent %i render-context

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1892,15 +1892,16 @@ def _collect_capability_rollup(slots: list[dict[str, Any]]) -> list[dict[str, An
     return out
 
 
-def _igpu_sclk_mhz() -> int | None:
+def _igpu_sclk_mhz(sysfs_root: Path = Path("/sys/class/drm")) -> int | None:
     """Active iGPU shader clock (MHz) from amdgpu sysfs, or None.
 
     Reads ``pp_dpm_sclk`` and returns the MHz of the active ('*') DPM
     level. Best-effort: any read/parse error returns None so the template
-    simply omits the clock line. Tries card0..card3 (Strix Halo dev nodes).
+    simply omits the clock line. Tries card0..card3 (Strix Halo dev nodes);
+    ``sysfs_root`` is injectable for tests.
     """
     for idx in range(4):
-        path = Path(f"/sys/class/drm/card{idx}/device/pp_dpm_sclk")
+        path = sysfs_root / f"card{idx}" / "device" / "pp_dpm_sclk"
         try:
             text = path.read_text(encoding="utf-8")
         except OSError:
@@ -1911,7 +1912,7 @@ def _igpu_sclk_mhz() -> int | None:
                 for tok in line.replace("Mhz", " ").replace("MHz", " ").split():
                     if tok.isdigit():
                         return int(tok)
-        return None
+        # no active line on this card — try the next one
     return None
 
 

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1916,6 +1916,121 @@ def _igpu_sclk_mhz(sysfs_root: Path = Path("/sys/class/drm")) -> int | None:
     return None
 
 
+def _state_body_minus_timestamp(text: str) -> str:
+    """STATE.md body with the volatile ``_as_of:`` line removed.
+
+    Used for content-hash gating so a regen that finds nothing
+    substantive changed does not churn the file (and bust prompt-cache).
+    """
+    return "\n".join(line for line in text.splitlines() if not line.startswith("_as_of:"))
+
+
+def render_live_context(
+    *,
+    hermes_home: Path,
+    slots_fetcher: Callable[[], list[dict[str, Any]]] | None = None,
+    now_iso: str | None = None,
+) -> dict[str, Any]:
+    """Re-probe live slot/capability state; (re)write HERMES.md + STATE.md.
+
+    STATE.md is content-hash gated: rewritten (and its ``_as_of`` line
+    bumped) only when the substantive body changes. HERMES.md is written
+    atomically (identical content => identical bytes => prompt-cache safe).
+    Never raises on a daemon-unreachable read — leaves last-good files and
+    reports ``degraded=True``.
+
+    Returns: {"state_written": bool, "hermes_written": bool,
+              "degraded": bool, "state_path": str}.
+    """
+    fetch = slots_fetcher or _fetch_slots
+    slots_all = fetch() or []
+    degraded = not slots_all
+
+    contexts = _fetch_model_contexts()
+    chat_slots = _collect_chat_slots(slots_all, contexts=contexts)
+    primary_raw = _resolve_primary_slot(slots_fetcher=lambda: slots_all)
+
+    primary_slot = next(
+        (s for s in slots_all if isinstance(s, dict) and s.get("name") == "primary"),
+        None,
+    )
+    primary_for_template: dict[str, Any] | None = None
+    if primary_raw["model"] and primary_raw["model"] != "primary":
+        primary_for_template = {
+            "alias": _slot_alias(primary_slot) if primary_slot else "primary",
+            "model_id": primary_raw["model"],
+            "backend_url": primary_raw["base_url"],
+            "context_length": primary_raw["context_length"],
+            "backend": (primary_slot or {}).get("backend"),
+        }
+
+    capabilities = _collect_capability_rollup(slots_all)
+
+    # NPU: present from the cached env snapshot; loaded model from any FLM
+    # backend slot (NPU LLM path is FastFlowLM).
+    env_report = _latest_env_snapshot(hermes_home).get("env_report", {})
+    npu_model = next(
+        (
+            _slot_model_id(s)
+            for s in slots_all
+            if isinstance(s, dict) and "flm" in str(s.get("backend") or "").lower()
+        ),
+        None,
+    )
+    npu = {"present": bool(env_report.get("npu", {}).get("present")), "model_id": npu_model}
+
+    now = now_iso or datetime.datetime.now(datetime.UTC).isoformat()
+
+    state_vars = {
+        "primary": primary_for_template,
+        "capabilities": capabilities,
+        "npu": npu,
+        "igpu_sclk_mhz": _igpu_sclk_mhz(),
+        "dashboard_url": "https://hal0.thinmint.dev",
+        "lemonade_base": "http://127.0.0.1:13305",
+        "daemon": "degraded" if degraded else "reachable",
+        "as_of": now,
+    }
+    new_state = _render_template("STATE.md.j2", **state_vars)
+
+    out: dict[str, Any] = {
+        "state_written": False,
+        "hermes_written": False,
+        "degraded": degraded,
+        "state_path": str(ETC_HAL0_DIR / "STATE.md"),
+    }
+
+    # STATE.md — content-hash gated (ignore the as_of line).
+    state_path = ETC_HAL0_DIR / "STATE.md"
+    existing = ""
+    if state_path.exists():
+        existing = state_path.read_text(encoding="utf-8")
+    if _state_body_minus_timestamp(existing) != _state_body_minus_timestamp(new_state):
+        _atomic_write(state_path, new_state)
+        out["state_written"] = True
+
+    # HERMES.md — structural map; atomic write (identical content => identical
+    # bytes => prompt-cache safe). Render failure is non-fatal.
+    try:
+        hermes_md = _render_template(
+            "HERMES.md.j2",
+            env=env_report,
+            hal0_version=_hal0_version_string(),
+            hermes_version=_hermes_version_pin(),
+            primary=primary_for_template,
+            chat_slots=chat_slots,
+            peer_agents=[],
+        )
+        hpath = ETC_HAL0_DIR / "HERMES.md"
+        if not hpath.exists() or hpath.read_text(encoding="utf-8") != hermes_md:
+            _atomic_write(hpath, hermes_md)
+            out["hermes_written"] = True
+    except Exception:  # best-effort; STATE.md already written
+        pass
+
+    return out
+
+
 def _collect_chat_slots(
     slots: list[dict[str, Any]],
     contexts: dict[str, int] | None = None,

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1855,6 +1855,66 @@ def _slot_context_length(slot: dict[str, Any]) -> int | None:
         return None
 
 
+# capability slot `type` (from /api/slots) -> STATE.md rollup label.
+_CAPABILITY_TYPE_LABELS = {
+    "embedding": "embed",
+    "stt": "voice-stt",
+    "tts": "voice-tts",
+    "image": "img",
+    "img": "img",
+    "rerank": "rerank",
+}
+
+
+def _collect_capability_rollup(slots: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Ready non-chat capability slots, mapped to STATE.md rollup rows.
+
+    Chat (``type=='llm'``) slots are handled by the primary/chat path and
+    excluded here. Only ready slots are advertised so we never tell the
+    agent about a capability that isn't actually loaded.
+    """
+    out: list[dict[str, Any]] = []
+    for s in slots:
+        if not isinstance(s, dict):
+            continue
+        label = _CAPABILITY_TYPE_LABELS.get((s.get("type") or "").lower())
+        if not label:
+            continue
+        if not _is_ready(s):
+            continue
+        out.append(
+            {
+                "capability": label,
+                "model_id": _slot_model_id(s),
+                "backend": s.get("backend"),
+            }
+        )
+    return out
+
+
+def _igpu_sclk_mhz() -> int | None:
+    """Active iGPU shader clock (MHz) from amdgpu sysfs, or None.
+
+    Reads ``pp_dpm_sclk`` and returns the MHz of the active ('*') DPM
+    level. Best-effort: any read/parse error returns None so the template
+    simply omits the clock line. Tries card0..card3 (Strix Halo dev nodes).
+    """
+    for idx in range(4):
+        path = Path(f"/sys/class/drm/card{idx}/device/pp_dpm_sclk")
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            if line.rstrip().endswith("*"):
+                # e.g. "2: 2900Mhz *"
+                for tok in line.replace("Mhz", " ").replace("MHz", " ").split():
+                    if tok.isdigit():
+                        return int(tok)
+        return None
+    return None
+
+
 def _collect_chat_slots(
     slots: list[dict[str, Any]],
     contexts: dict[str, int] | None = None,

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1921,6 +1921,8 @@ def _state_body_minus_timestamp(text: str) -> str:
 
     Used for content-hash gating so a regen that finds nothing
     substantive changed does not churn the file (and bust prompt-cache).
+    Assumes ``_as_of:`` is not a prefix of any substantive content line
+    (guaranteed by STATE.md.j2, which emits it only as the final footer).
     """
     return "\n".join(line for line in text.splitlines() if not line.startswith("_as_of:"))
 
@@ -2025,8 +2027,9 @@ def render_live_context(
         if not hpath.exists() or hpath.read_text(encoding="utf-8") != hermes_md:
             _atomic_write(hpath, hermes_md)
             out["hermes_written"] = True
-    except Exception:  # best-effort; STATE.md already written
-        pass
+    except Exception as exc:  # best-effort; STATE.md already written
+        log.warning("hermes_provision.render_live_context_hermes_failed", error=str(exc))
+        out["hermes_error"] = str(exc)
 
     return out
 

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1442,8 +1442,15 @@ def _phase_context_link(state: BootstrapState) -> PhaseResult:
     # path used by the per-restart / per-swap writers. Best-effort: failure
     # here must not fail bootstrap (SOUL/AGENTS already written).
     try:
+        # NB: render_live_context re-fetches /api/slots + /v1/models itself
+        # (separate from the vars_ fetch above). Acceptable at bootstrap
+        # frequency; keeps it usable standalone from the restart/swap writers.
         live = render_live_context(hermes_home=hermes_home)
         details["rendered"]["STATE.md"] = {"path": live["state_path"]}
+        details["rendered"]["HERMES.md"] = {
+            "path": str(ETC_HAL0_DIR / "HERMES.md"),
+            "written": live["hermes_written"],
+        }
         if live["degraded"]:
             warnings.append("STATE.md rendered with daemon degraded")
         if live.get("hermes_error"):

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1958,7 +1958,14 @@ def render_live_context(
     """
     fetch = slots_fetcher or _fetch_slots
     slots_all = fetch() or []
-    degraded = not slots_all
+    # Reachability is independent of slot count. A reachable daemon with
+    # zero configured slots is NOT degraded (we render "no chat model
+    # loaded" + reachable). degraded == the daemon couldn't be reached at
+    # all — in which case we must NOT clobber a last-good snapshot. A
+    # non-empty fetch implies the daemon answered, so we only probe health
+    # when the slot list came back empty.
+    reachable = True if slots_all else _http_get(DAEMON_HEALTH_URL) == 200
+    degraded = not reachable
 
     contexts = _fetch_model_contexts()
     chat_slots = _collect_chat_slots(slots_all, contexts=contexts)
@@ -2000,8 +2007,8 @@ def render_live_context(
         "capabilities": capabilities,
         "npu": npu,
         "igpu_sclk_mhz": _igpu_sclk_mhz(),
-        "dashboard_url": "https://hal0.thinmint.dev",
-        "lemonade_base": "http://127.0.0.1:13305",
+        "dashboard_url": os.environ.get("HAL0_DASHBOARD_URL", "https://hal0.thinmint.dev"),
+        "lemonade_base": os.environ.get("HAL0_LEMONADE_BASE", "http://127.0.0.1:13305"),
         "daemon": "degraded" if degraded else "reachable",
         "as_of": now,
     }
@@ -2019,9 +2026,24 @@ def render_live_context(
     existing = ""
     if state_path.exists():
         existing = state_path.read_text(encoding="utf-8")
+
+    # Daemon unreachable but we already have a last-good snapshot: preserve
+    # it (spec — never clobber good state with a degraded one, e.g. when
+    # ExecStartPre fires before hal0-api is up). Leave mtime stale so the
+    # session hook keeps retrying the regen until the daemon returns.
+    if degraded and existing:
+        return out  # state_written=False, hermes_written=False, degraded=True
+
     if _state_body_minus_timestamp(existing) != _state_body_minus_timestamp(new_state):
         _atomic_write(state_path, new_state)
         out["state_written"] = True
+    elif reachable:
+        # Content unchanged, but we just confirmed it current against a
+        # reachable daemon — bump mtime so the on_session_start hook's TTL
+        # staleness check settles instead of firing a background regen every
+        # session forever. mtime is not content, so Hermes's injected text
+        # is byte-identical and the prompt-cache prefix stays warm.
+        os.utime(state_path, None)
 
     # HERMES.md — structural map; atomic write (identical content => identical
     # bytes => prompt-cache safe). Render failure is non-fatal.

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1424,7 +1424,6 @@ def _phase_context_link(state: BootstrapState) -> PhaseResult:
         rendered["SOUL.md"] = fallback_soul
 
     for tpl_name, _out_name in (
-        ("HERMES.md.j2", "HERMES.md"),
         ("AGENTS.md.j2", "AGENTS.md"),
         ("MCP-CLIENTS.md.j2", "MCP-CLIENTS.md"),
     ):
@@ -1439,19 +1438,25 @@ def _phase_context_link(state: BootstrapState) -> PhaseResult:
     h = _atomic_write(soul_path, rendered["SOUL.md"])
     details["rendered"]["SOUL.md"] = {"path": str(soul_path), "sha256": h}
 
-    if "HERMES.md" in rendered:
-        try:
-            ETC_HAL0_DIR.mkdir(parents=True, exist_ok=True)
-            hpath = ETC_HAL0_DIR / "HERMES.md"
-            h = _atomic_write(hpath, rendered["HERMES.md"])
-            details["rendered"]["HERMES.md"] = {"path": str(hpath), "sha256": h}
-            # Mirror into HERMES_HOME/memories/HOST.md so context shows up in
-            # the memory tier as well as cwd auto-injection.
+    # STATE.md + HERMES.md are the live files — render via the one shared
+    # path used by the per-restart / per-swap writers. Best-effort: failure
+    # here must not fail bootstrap (SOUL/AGENTS already written).
+    try:
+        live = render_live_context(hermes_home=hermes_home)
+        details["rendered"]["STATE.md"] = {"path": live["state_path"]}
+        if live["degraded"]:
+            warnings.append("STATE.md rendered with daemon degraded")
+        if live.get("hermes_error"):
+            warnings.append(f"HERMES.md render: {live['hermes_error']}")
+        # render_live_context writes HERMES.md but not the HOST.md mirror;
+        # re-establish the symlink that the memory tier reads.
+        hpath = ETC_HAL0_DIR / "HERMES.md"
+        if hpath.exists():
             host_md = hermes_home / "memories" / "HOST.md"
             if _safe_symlink(hpath, host_md):
                 details["links"].append(str(host_md))
-        except OSError as exc:
-            warnings.append(f"HERMES.md write to /etc/hal0: {exc}")
+    except Exception as exc:  # best-effort
+        warnings.append(f"render_live_context: {exc}")
 
     if "AGENTS.md" in rendered:
         try:

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1276,6 +1276,15 @@ HAL0_BUNDLED_SKILLS = Path("/usr/share/hal0/skills")
 ETC_HAL0_DIR = Path("/etc/hal0")
 ETC_HAL0_AGENT_SKILLS = ETC_HAL0_DIR / "agent-skills"
 
+# STATE.md — the volatile live snapshot rewritten on every restart / model
+# swap — lives under the hal0-owned /var/lib/hal0 rather than the root-owned
+# /etc/hal0 (#473): the hermes unit runs User=hal0 with ProtectSystem=strict,
+# so its ExecStartPre `render-context` can only write to paths in
+# ReadWritePaths — /var/lib/hal0 is already there, /etc/hal0 is not. HERMES.md
+# (structural, cwd-injected from /etc/hal0) and the rest of the config stay
+# under ETC_HAL0_DIR, written at provision time as root.
+RUNTIME_SNAPSHOT_DIR = Path("/var/lib/hal0")
+
 
 def _latest_env_snapshot(hermes_home: Path) -> dict[str, Any]:
     """Load the most recent env-<ts>.json snapshot env_probe wrote.
@@ -2018,11 +2027,14 @@ def render_live_context(
         "state_written": False,
         "hermes_written": False,
         "degraded": degraded,
-        "state_path": str(ETC_HAL0_DIR / "STATE.md"),
+        "state_path": str(RUNTIME_SNAPSHOT_DIR / "STATE.md"),
     }
 
-    # STATE.md — content-hash gated (ignore the as_of line).
-    state_path = ETC_HAL0_DIR / "STATE.md"
+    # STATE.md — content-hash gated (ignore the as_of line). Written under the
+    # hal0-owned RUNTIME_SNAPSHOT_DIR so render-context works under the User=hal0
+    # / ProtectSystem=strict hermes sandbox (#473).
+    RUNTIME_SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    state_path = RUNTIME_SNAPSHOT_DIR / "STATE.md"
     existing = ""
     if state_path.exists():
         existing = state_path.read_text(encoding="utf-8")

--- a/src/hal0/agents/hermes_refresh.py
+++ b/src/hal0/agents/hermes_refresh.py
@@ -1,0 +1,32 @@
+"""Fire-and-forget trigger to refresh the Hermes live-context files.
+
+Called from the asyncio daemon (slot swap / capability apply) where we
+must not block the event loop on the urllib probe inside
+``render_live_context``. We spawn a detached ``hal0-agent <id>
+render-context`` instead — the subcommand owns the probe + atomic writes.
+Best-effort: any failure is logged and swallowed; a model swap must never
+fail because context refresh couldn't start.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+def spawn_context_refresh(agent_id: str = "hermes") -> None:
+    """Spawn a detached ``hal0-agent <agent_id> render-context``. Never raises."""
+    try:
+        binary = shutil.which("hal0-agent") or "/usr/local/bin/hal0-agent"
+        subprocess.Popen(  # fixed argv, no shell
+            [binary, agent_id, "render-context"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception as exc:  # best-effort, never propagate
+        logger.debug("hermes context refresh spawn failed (non-fatal): %s", exc)

--- a/src/hal0/agents/hermes_templates/HERMES.md.j2
+++ b/src/hal0/agents/hermes_templates/HERMES.md.j2
@@ -15,7 +15,7 @@
 # Live state
 
 Current loaded model, capabilities, and GPU/NPU backend are in
-`/etc/hal0/STATE.md` (auto-injected each session; refreshed on restart
+`/var/lib/hal0/STATE.md` (auto-injected each session; refreshed on restart
 and on every model/slot change). Read it for the live picture rather
 than assuming — it carries an `_as_of:` timestamp.
 

--- a/src/hal0/agents/hermes_templates/HERMES.md.j2
+++ b/src/hal0/agents/hermes_templates/HERMES.md.j2
@@ -12,20 +12,12 @@
 - Memory MCP: `hal0_memory` (auto-loaded; you have full read/write on `private:hermes-agent`)
 - Admin MCP: `hal0_admin` (auto-loaded; autonomous read on all status tools, gated on destructive)
 
-# Active capability slots
-{% if primary %}
-- **primary** (chat/{{ primary.alias | default("primary") }}): `{{ primary.model_id }}`
-  - Endpoint: {{ primary.backend_url }} (alias `model_aliases.primary`)
-{%- endif %}
-{%- if chat_slots %}
-{%- for slot in chat_slots %}
-- **{{ slot.alias }}** (chat): `{{ slot.model_id }}`
-  - {{ slot.backend_url }} → call via `model_aliases.{{ slot.alias }}`
-{%- endfor %}
-{%- endif %}
-{%- if not primary and not chat_slots %}
-- _no chat slots loaded — wire one via `hal0 slot create` then re-run bootstrap with `--repair`._
-{%- endif %}
+# Live state
+
+Current loaded model, capabilities, and GPU/NPU backend are in
+`/etc/hal0/STATE.md` (auto-injected each session; refreshed on restart
+and on every model/slot change). Read it for the live picture rather
+than assuming — it carries an `_as_of:` timestamp.
 
 # Peer agents
 {% if peer_agents %}

--- a/src/hal0/agents/hermes_templates/STATE.md.j2
+++ b/src/hal0/agents/hermes_templates/STATE.md.j2
@@ -16,7 +16,7 @@
 {%- else -%}
 - Capabilities: _none loaded._
 {%- endif %}
-{% if npu.present -%}
+{% if npu and npu.present -%}
 - NPU (XDNA): {% if npu.model_id %}`{{ npu.model_id }}` (FLM){% else %}present, idle{% endif %}
 {%- endif %}
 {% if igpu_sclk_mhz -%}

--- a/src/hal0/agents/hermes_templates/STATE.md.j2
+++ b/src/hal0/agents/hermes_templates/STATE.md.j2
@@ -1,0 +1,28 @@
+{# Volatile live-state snapshot — re-rendered on restart + on model/slot
+   change, injected into every Hermes session by the on_session_start hook.
+   Keep it LEAN: this is fed to the model every session. Stable identity
+   lives in SOUL.md; structural map lives in HERMES.md.
+   Params: primary (dict|None), capabilities (list), npu (dict),
+   igpu_sclk_mhz (int|None), dashboard_url, lemonade_base, daemon, as_of. #}
+# Live system state
+
+{% if primary -%}
+- Chat model: `{{ primary.model_id }}` ({{ primary.context_length | default("?") }} ctx{% if primary.backend %}, {{ primary.backend }}{% endif %}) via `model_aliases.{{ primary.alias | default("primary") }}`
+{%- else -%}
+- Chat model: _no chat model loaded — wire one via `hal0 slot create`._
+{%- endif %}
+{% if capabilities -%}
+- Capabilities: {% for c in capabilities %}{{ c.capability }} (`{{ c.model_id }}`{% if c.backend %}/{{ c.backend }}{% endif %}){% if not loop.last %}, {% endif %}{% endfor %}
+{%- else -%}
+- Capabilities: _none loaded._
+{%- endif %}
+{% if npu.present -%}
+- NPU (XDNA): {% if npu.model_id %}`{{ npu.model_id }}` (FLM){% else %}present, idle{% endif %}
+{%- endif %}
+{% if igpu_sclk_mhz -%}
+- iGPU clock: {{ igpu_sclk_mhz }} MHz
+{%- endif %}
+- Endpoints: dashboard {{ dashboard_url }} · lemond {{ lemonade_base }}
+- Daemon: {{ daemon }}
+
+_as_of: {{ as_of }}_

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -433,7 +433,11 @@ class CapabilityOrchestrator:
 
         # A capability change (enable/disable/model/backend) just altered
         # live slot state — refresh Hermes's context files (detached;
-        # best-effort, never blocks the API response).
+        # best-effort, never blocks the API response). NB: the hot-swap
+        # branch above already triggers manager.swap()'s own refresh, so a
+        # model/backend change fires this twice; that's harmless — the
+        # render is idempotent and content-hash gated, and manager.swap()
+        # must keep its spawn for direct /api/slots/<name>/swap callers.
         from hal0.agents.hermes_refresh import spawn_context_refresh
 
         spawn_context_refresh()

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -431,6 +431,13 @@ class CapabilityOrchestrator:
         # call doesn't leave a stale selection on disk.
         self._save(cfg)
 
+        # A capability change (enable/disable/model/backend) just altered
+        # live slot state — refresh Hermes's context files (detached;
+        # best-effort, never blocks the API response).
+        from hal0.agents.hermes_refresh import spawn_context_refresh
+
+        spawn_context_refresh()
+
         status_str = await self._slot_status_string(slot_name)
         return {
             "backend": merged.backend,

--- a/src/hal0/cli/agent_shim.py
+++ b/src/hal0/cli/agent_shim.py
@@ -463,6 +463,37 @@ def cmd_reprovision(cfg: AgentConfig) -> int:
     return subprocess.call(argv)
 
 
+def _render_live_context(*, hermes_home: Path) -> dict[str, object]:
+    """Indirection so tests can patch; lazy import keeps shim startup light."""
+    from hal0.agents.hermes_provision import render_live_context
+
+    return render_live_context(hermes_home=hermes_home)
+
+
+def cmd_render_context(cfg: AgentConfig) -> int:
+    """Re-probe live hal0 state and (re)write STATE.md + HERMES.md.
+
+    Wired as ``ExecStartPre`` on hal0-agent@hermes.service (non-fatal) and
+    spawned detached after a model/slot change. Render is best-effort:
+    a daemon-unreachable read leaves last-good files and still exits 0 so
+    it never blocks the service from starting.
+    """
+    if cfg.agent_type != "hermes":
+        _die(f"agent type '{cfg.agent_type}' not supported by this shim yet")
+    try:
+        result = _render_live_context(hermes_home=cfg.home)
+    except Exception as exc:  # never block service start
+        print(f"hal0-agent: render-context failed (non-fatal): {exc}", file=sys.stderr)
+        return 0
+    state = "degraded" if result.get("degraded") else "ok"
+    print(
+        f"hal0-agent: render-context {state} "
+        f"(state_written={result.get('state_written')}, "
+        f"hermes_written={result.get('hermes_written')})"
+    )
+    return 0
+
+
 # ----------------------------------------------------------------------------
 # Argv parsing
 # ----------------------------------------------------------------------------
@@ -482,7 +513,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "subcommand",
-        choices=["serve", "stop", "status", "reprovision"],
+        choices=["serve", "stop", "status", "reprovision", "render-context"],
         help="What to do with the agent.",
     )
     return parser
@@ -500,6 +531,7 @@ _DISPATCH: dict[str, Callable[[AgentConfig], int]] = {
     "stop": cmd_stop,
     "status": cmd_status,
     "reprovision": cmd_reprovision,
+    "render-context": cmd_render_context,
 }
 
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -790,7 +790,13 @@ class SlotManager:
             raise SlotConfigError("swap requires a non-empty model id")
         self._ensure_known(slot_name)
         await self.unload(slot_name)
-        return await self.load(slot_name, model_id=new_model_id)
+        slot = await self.load(slot_name, model_id=new_model_id)
+        # Refresh Hermes's live-context files so a model swap is visible to
+        # the agent on its next session (detached; never blocks the swap).
+        from hal0.agents.hermes_refresh import spawn_context_refresh
+
+        spawn_context_refresh()
+        return slot
 
     # ── queries ──────────────────────────────────────────────────────────────
 

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1144,6 +1144,10 @@ def test_context_link_renders_all_three_files(
     # non-root without touching the real system.
     etc = tmp_path / "etc" / "hal0"
     monkeypatch.setattr(hp, "ETC_HAL0_DIR", etc)
+    # STATE.md now renders into RUNTIME_SNAPSHOT_DIR (#473); redirect it to
+    # tmp_path too so render_live_context's STATE.md write doesn't hit the real
+    # /var/lib/hal0 (and so its failure can't skip the HERMES.md write below).
+    monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)
     monkeypatch.setattr(hp, "ETC_HAL0_AGENT_SKILLS", etc / "agent-skills")
     monkeypatch.setattr(hp, "HAL0_BUNDLED_SKILLS", tmp_path / "no-such-skills")
     # Context-link consults /api/slots when wiring HERMES.md's primary
@@ -1183,6 +1187,7 @@ def test_context_link_falls_back_when_soul_render_fails(
     hermes_home.mkdir()
     state = hp.BootstrapState(hermes_home=str(hermes_home))
     monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path / "etc" / "hal0")
+    monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)  # STATE.md target (#473)
     monkeypatch.setattr(hp, "ETC_HAL0_AGENT_SKILLS", tmp_path / "etc" / "hal0" / "agent-skills")
     monkeypatch.setattr(hp, "HAL0_BUNDLED_SKILLS", tmp_path / "no-skills")
     monkeypatch.setattr(hp, "_fetch_slots", lambda: [])

--- a/tests/agents/test_hermes_state_render.py
+++ b/tests/agents/test_hermes_state_render.py
@@ -138,6 +138,7 @@ def test_render_live_context_writes_then_skips_when_unchanged(tmp_path, monkeypa
 
 def test_render_live_context_degraded_when_daemon_unreachable(tmp_path, monkeypatch):
     monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    monkeypatch.setattr(hp, "_http_get", lambda *a, **k: 0)  # daemon down
     home = tmp_path / "home"
     home.mkdir()
     r = hp.render_live_context(
@@ -146,7 +147,77 @@ def test_render_live_context_degraded_when_daemon_unreachable(tmp_path, monkeypa
         now_iso="2026-06-04T10:00:00+00:00",
     )
     assert r["degraded"] is True
+    # First boot (no prior STATE.md) -> a degraded placeholder is written.
     assert "degraded" in (tmp_path / "STATE.md").read_text()
+
+
+def test_render_live_context_preserves_good_state_when_unreachable(tmp_path, monkeypatch):
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    good = "# Live system state\n- Chat model: `qwen3-25b` (32768 ctx, vulkan)\n\n_as_of: 2026-06-04T09:00:00+00:00_\n"
+    (tmp_path / "STATE.md").write_text(good)
+    monkeypatch.setattr(hp, "_http_get", lambda *a, **k: 0)  # daemon down
+    r = hp.render_live_context(
+        hermes_home=home,
+        slots_fetcher=lambda: [],
+        now_iso="2026-06-04T10:00:00+00:00",
+    )
+    assert r["degraded"] is True
+    assert r["state_written"] is False
+    # Last-good snapshot left intact — NOT clobbered with a degraded body.
+    assert (tmp_path / "STATE.md").read_text() == good
+
+
+def test_render_live_context_reachable_empty_is_not_degraded(tmp_path, monkeypatch):
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(hp, "_http_get", lambda *a, **k: 200)  # daemon up, no slots
+    r = hp.render_live_context(
+        hermes_home=home,
+        slots_fetcher=lambda: [],
+        now_iso="2026-06-04T10:00:00+00:00",
+    )
+    assert r["degraded"] is False
+    body = (tmp_path / "STATE.md").read_text()
+    assert "reachable" in body
+    assert "no chat model loaded" in body.lower()
+
+
+def test_render_live_context_bumps_mtime_when_unchanged_reachable(tmp_path, monkeypatch):
+    import os as _os
+
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    slots = [
+        {
+            "name": "primary",
+            "type": "llm",
+            "model_id": "qwen3-25b",
+            "status": "ready",
+            "backend": "vulkan",
+        }
+    ]
+    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {"primary": 32768})
+
+    r1 = hp.render_live_context(
+        hermes_home=home, slots_fetcher=lambda: slots, now_iso="2026-06-04T10:00:00+00:00"
+    )
+    assert r1["state_written"] is True
+    state_path = tmp_path / "STATE.md"
+    # Backdate mtime to simulate a stable system past the hook TTL.
+    old = state_path.stat().st_mtime - 10_000
+    _os.utime(state_path, (old, old))
+
+    r2 = hp.render_live_context(
+        hermes_home=home, slots_fetcher=lambda: slots, now_iso="2026-06-04T22:00:00+00:00"
+    )
+    assert r2["state_written"] is False  # content unchanged
+    assert state_path.stat().st_mtime > old  # but mtime bumped -> TTL settles
+    assert "09:00" not in state_path.read_text()  # sanity: content (as_of) NOT rewritten
+    assert "10:00:00" in state_path.read_text()  # as_of still the first render's
 
 
 def test_phase_context_link_writes_state_md(tmp_path, monkeypatch):

--- a/tests/agents/test_hermes_state_render.py
+++ b/tests/agents/test_hermes_state_render.py
@@ -195,3 +195,31 @@ def test_phase_context_link_writes_state_md(tmp_path, monkeypatch):
     hermes_md = (tmp_path / "HERMES.md").read_text()
     assert "Live system state" not in hermes_md  # that H1 now lives in STATE.md
     assert "STATE.md" in hermes_md  # pointer present
+
+
+def test_spawn_context_refresh_is_best_effort(monkeypatch):
+    from hal0.agents import hermes_refresh
+
+    calls = {}
+
+    def fake_popen(argv, **kw):
+        calls["argv"] = argv
+        calls["kw"] = kw
+
+        class _P:  # minimal stand-in
+            pass
+
+        return _P()
+
+    monkeypatch.setattr(hermes_refresh.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(hermes_refresh.shutil, "which", lambda _n: "/usr/local/bin/hal0-agent")
+
+    hermes_refresh.spawn_context_refresh("hermes")
+    assert calls["argv"] == ["/usr/local/bin/hal0-agent", "hermes", "render-context"]
+
+    # Never raises even if Popen blows up.
+    def boom(*a, **k):
+        raise OSError("no exec")
+
+    monkeypatch.setattr(hermes_refresh.subprocess, "Popen", boom)
+    hermes_refresh.spawn_context_refresh("hermes")  # must not raise

--- a/tests/agents/test_hermes_state_render.py
+++ b/tests/agents/test_hermes_state_render.py
@@ -95,6 +95,7 @@ def test_state_body_minus_timestamp_ignores_as_of_line():
 
 def test_render_live_context_writes_then_skips_when_unchanged(tmp_path, monkeypatch):
     monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)
     home = tmp_path / "home"
     home.mkdir()
 
@@ -138,6 +139,7 @@ def test_render_live_context_writes_then_skips_when_unchanged(tmp_path, monkeypa
 
 def test_render_live_context_degraded_when_daemon_unreachable(tmp_path, monkeypatch):
     monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)
     monkeypatch.setattr(hp, "_http_get", lambda *a, **k: 0)  # daemon down
     home = tmp_path / "home"
     home.mkdir()
@@ -153,6 +155,7 @@ def test_render_live_context_degraded_when_daemon_unreachable(tmp_path, monkeypa
 
 def test_render_live_context_preserves_good_state_when_unreachable(tmp_path, monkeypatch):
     monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)
     home = tmp_path / "home"
     home.mkdir()
     good = "# Live system state\n- Chat model: `qwen3-25b` (32768 ctx, vulkan)\n\n_as_of: 2026-06-04T09:00:00+00:00_\n"
@@ -171,6 +174,7 @@ def test_render_live_context_preserves_good_state_when_unreachable(tmp_path, mon
 
 def test_render_live_context_reachable_empty_is_not_degraded(tmp_path, monkeypatch):
     monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setattr(hp, "_http_get", lambda *a, **k: 200)  # daemon up, no slots
@@ -189,6 +193,7 @@ def test_render_live_context_bumps_mtime_when_unchanged_reachable(tmp_path, monk
     import os as _os
 
     monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)
     home = tmp_path / "home"
     home.mkdir()
     slots = [
@@ -224,6 +229,7 @@ def test_phase_context_link_writes_state_md(tmp_path, monkeypatch):
     import json
 
     monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)
     home = tmp_path / "home"
     (home / "memories").mkdir(parents=True)
     # Seed an env snapshot so HERMES.md (env.container/env.cpu) renders, exactly

--- a/tests/agents/test_hermes_state_render.py
+++ b/tests/agents/test_hermes_state_render.py
@@ -1,0 +1,70 @@
+"""Unit tests for the live STATE.md render path (Hermes auto-render)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.agents import hermes_provision as hp
+
+
+def _slot(name, type_, model, *, state="ready", backend=None):
+    d = {"name": name, "type": type_, "model_id": model, "status": state}
+    if backend:
+        d["backend"] = backend
+    return d
+
+
+def test_collect_capability_rollup_filters_and_maps_types():
+    slots = [
+        _slot("primary", "llm", "qwen3-25b", backend="vulkan"),   # chat -> excluded here
+        _slot("embed", "embedding", "bge-m3", backend="vulkan"),
+        _slot("stt", "stt", "moonshine", backend="vulkan"),
+        _slot("tts", "tts", "kokoro", backend="vulkan"),
+        _slot("img", "image", "sdxl", backend="rocm"),
+        _slot("rerank", "rerank", "bge-reranker", backend="vulkan"),
+        _slot("cold", "embedding", "unused", state="stopped"),     # not ready -> excluded
+    ]
+    rollup = hp._collect_capability_rollup(slots)
+    caps = {r["capability"]: r for r in rollup}
+    assert set(caps) == {"embed", "voice-stt", "voice-tts", "img", "rerank"}
+    assert caps["img"]["backend"] == "rocm"
+    assert caps["embed"]["model_id"] == "bge-m3"
+    assert "cold" not in {r.get("name") for r in rollup}
+
+
+def test_state_template_renders_full_state():
+    body = hp._render_template(
+        "STATE.md.j2",
+        primary={"alias": "primary", "model_id": "qwen3-25b",
+                 "backend_url": "http://127.0.0.1:8080/v1", "context_length": 32768,
+                 "backend": "vulkan"},
+        capabilities=[{"capability": "embed", "model_id": "bge-m3", "backend": "vulkan"}],
+        npu={"present": True, "model_id": "qwen3-it-4b-FLM"},
+        igpu_sclk_mhz=2900,
+        dashboard_url="https://hal0.thinmint.dev",
+        lemonade_base="http://127.0.0.1:13305",
+        daemon="reachable",
+        as_of="2026-06-04T15:00:00+00:00",
+    )
+    assert "qwen3-25b" in body
+    assert "32768" in body
+    assert "embed" in body and "bge-m3" in body
+    assert "vulkan" in body
+    assert "qwen3-it-4b-FLM" in body
+    assert "2900" in body
+    assert "reachable" in body
+    assert body.rstrip().splitlines()[-1].startswith("_as_of: 2026-06-04T15:00:00")
+
+
+def test_state_template_degraded_no_primary():
+    body = hp._render_template(
+        "STATE.md.j2",
+        primary=None, capabilities=[], npu={"present": False, "model_id": None},
+        igpu_sclk_mhz=None, dashboard_url="https://hal0.thinmint.dev",
+        lemonade_base="http://127.0.0.1:13305", daemon="degraded",
+        as_of="2026-06-04T15:00:00+00:00",
+    )
+    assert "degraded" in body
+    assert "no chat model loaded" in body.lower()

--- a/tests/agents/test_hermes_state_render.py
+++ b/tests/agents/test_hermes_state_render.py
@@ -85,3 +85,65 @@ def test_igpu_sclk_mhz_parses_active_line_and_scans_cards(tmp_path):
 
 def test_igpu_sclk_mhz_returns_none_when_absent(tmp_path):
     assert hp._igpu_sclk_mhz(sysfs_root=tmp_path) is None
+
+
+def test_state_body_minus_timestamp_ignores_as_of_line():
+    a = "# Live system state\n- Chat model: x\n\n_as_of: 2026-06-04T10:00:00+00:00_\n"
+    b = "# Live system state\n- Chat model: x\n\n_as_of: 2026-06-04T22:00:00+00:00_\n"
+    assert hp._state_body_minus_timestamp(a) == hp._state_body_minus_timestamp(b)
+
+
+def test_render_live_context_writes_then_skips_when_unchanged(tmp_path, monkeypatch):
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    slots = [
+        {
+            "name": "primary",
+            "type": "llm",
+            "model_id": "qwen3-25b",
+            "status": "ready",
+            "backend": "vulkan",
+        },
+        {
+            "name": "embed",
+            "type": "embedding",
+            "model_id": "bge-m3",
+            "status": "ready",
+            "backend": "vulkan",
+        },
+    ]
+    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {"primary": 32768})
+
+    r1 = hp.render_live_context(
+        hermes_home=home,
+        slots_fetcher=lambda: slots,
+        now_iso="2026-06-04T10:00:00+00:00",
+    )
+    assert r1["state_written"] is True
+    assert r1["degraded"] is False
+    state = (tmp_path / "STATE.md").read_text()
+    assert "qwen3-25b" in state and "bge-m3" in state
+
+    # Same substantive state, different clock-time -> NOT rewritten.
+    r2 = hp.render_live_context(
+        hermes_home=home,
+        slots_fetcher=lambda: slots,
+        now_iso="2026-06-04T22:00:00+00:00",
+    )
+    assert r2["state_written"] is False
+    assert "10:00:00" in (tmp_path / "STATE.md").read_text()  # as_of unchanged
+
+
+def test_render_live_context_degraded_when_daemon_unreachable(tmp_path, monkeypatch):
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    r = hp.render_live_context(
+        hermes_home=home,
+        slots_fetcher=lambda: [],
+        now_iso="2026-06-04T10:00:00+00:00",
+    )
+    assert r["degraded"] is True
+    assert "degraded" in (tmp_path / "STATE.md").read_text()

--- a/tests/agents/test_hermes_state_render.py
+++ b/tests/agents/test_hermes_state_render.py
@@ -147,3 +147,51 @@ def test_render_live_context_degraded_when_daemon_unreachable(tmp_path, monkeypa
     )
     assert r["degraded"] is True
     assert "degraded" in (tmp_path / "STATE.md").read_text()
+
+
+def test_phase_context_link_writes_state_md(tmp_path, monkeypatch):
+    import json
+
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    home = tmp_path / "home"
+    (home / "memories").mkdir(parents=True)
+    # Seed an env snapshot so HERMES.md (env.container/env.cpu) renders, exactly
+    # as the env_probe phase would before context_link in the real pipeline.
+    (home / "env-1.json").write_text(
+        json.dumps(
+            {
+                "env_report": {
+                    "container": {"product_name": "hal0-test", "kind": "lxc"},
+                    "cpu": {"model": "AMD Strix Halo", "logical_online": 16},
+                    "npu": {"present": True},
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {"primary": 32768})
+    monkeypatch.setattr(
+        hp,
+        "_fetch_slots",
+        lambda: [
+            {
+                "name": "primary",
+                "type": "llm",
+                "model_id": "qwen3-25b",
+                "status": "ready",
+                "backend": "vulkan",
+            }
+        ],
+    )
+    monkeypatch.setattr(hp, "HAL0_BUNDLED_SKILLS", tmp_path / "nope")
+
+    state = hp.BootstrapState(hermes_home=str(home))
+    res = hp._phase_context_link(state)
+    assert res.status == hp.PhaseStatus.OK
+    # STATE.md written with the live model.
+    assert (tmp_path / "STATE.md").exists()
+    assert "qwen3-25b" in (tmp_path / "STATE.md").read_text()
+    # HERMES.md written, no longer carries the live snapshot heading, and
+    # points at STATE.md.
+    hermes_md = (tmp_path / "HERMES.md").read_text()
+    assert "Live system state" not in hermes_md  # that H1 now lives in STATE.md
+    assert "STATE.md" in hermes_md  # pointer present

--- a/tests/agents/test_hermes_state_render.py
+++ b/tests/agents/test_hermes_state_render.py
@@ -2,10 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-import pytest
-
 from hal0.agents import hermes_provision as hp
 
 
@@ -18,28 +14,32 @@ def _slot(name, type_, model, *, state="ready", backend=None):
 
 def test_collect_capability_rollup_filters_and_maps_types():
     slots = [
-        _slot("primary", "llm", "qwen3-25b", backend="vulkan"),   # chat -> excluded here
+        _slot("primary", "llm", "qwen3-25b", backend="vulkan"),  # chat -> excluded here
         _slot("embed", "embedding", "bge-m3", backend="vulkan"),
         _slot("stt", "stt", "moonshine", backend="vulkan"),
         _slot("tts", "tts", "kokoro", backend="vulkan"),
         _slot("img", "image", "sdxl", backend="rocm"),
         _slot("rerank", "rerank", "bge-reranker", backend="vulkan"),
-        _slot("cold", "embedding", "unused", state="stopped"),     # not ready -> excluded
+        _slot("cold", "embedding", "unused", state="stopped"),  # not ready -> excluded
     ]
     rollup = hp._collect_capability_rollup(slots)
     caps = {r["capability"]: r for r in rollup}
     assert set(caps) == {"embed", "voice-stt", "voice-tts", "img", "rerank"}
     assert caps["img"]["backend"] == "rocm"
     assert caps["embed"]["model_id"] == "bge-m3"
-    assert "cold" not in {r.get("name") for r in rollup}
+    assert "unused" not in {r.get("model_id") for r in rollup}
 
 
 def test_state_template_renders_full_state():
     body = hp._render_template(
         "STATE.md.j2",
-        primary={"alias": "primary", "model_id": "qwen3-25b",
-                 "backend_url": "http://127.0.0.1:8080/v1", "context_length": 32768,
-                 "backend": "vulkan"},
+        primary={
+            "alias": "primary",
+            "model_id": "qwen3-25b",
+            "backend_url": "http://127.0.0.1:8080/v1",
+            "context_length": 32768,
+            "backend": "vulkan",
+        },
         capabilities=[{"capability": "embed", "model_id": "bge-m3", "backend": "vulkan"}],
         npu={"present": True, "model_id": "qwen3-it-4b-FLM"},
         igpu_sclk_mhz=2900,
@@ -61,10 +61,27 @@ def test_state_template_renders_full_state():
 def test_state_template_degraded_no_primary():
     body = hp._render_template(
         "STATE.md.j2",
-        primary=None, capabilities=[], npu={"present": False, "model_id": None},
-        igpu_sclk_mhz=None, dashboard_url="https://hal0.thinmint.dev",
-        lemonade_base="http://127.0.0.1:13305", daemon="degraded",
+        primary=None,
+        capabilities=[],
+        npu={"present": False, "model_id": None},
+        igpu_sclk_mhz=None,
+        dashboard_url="https://hal0.thinmint.dev",
+        lemonade_base="http://127.0.0.1:13305",
+        daemon="degraded",
         as_of="2026-06-04T15:00:00+00:00",
     )
     assert "degraded" in body
     assert "no chat model loaded" in body.lower()
+
+
+def test_igpu_sclk_mhz_parses_active_line_and_scans_cards(tmp_path):
+    # card0 readable but no active line -> must fall through to card1.
+    (tmp_path / "card0" / "device").mkdir(parents=True)
+    (tmp_path / "card0" / "device" / "pp_dpm_sclk").write_text("0: 400Mhz\n1: 800Mhz\n")
+    (tmp_path / "card1" / "device").mkdir(parents=True)
+    (tmp_path / "card1" / "device" / "pp_dpm_sclk").write_text("0: 800Mhz\n2: 2900Mhz *\n")
+    assert hp._igpu_sclk_mhz(sysfs_root=tmp_path) == 2900
+
+
+def test_igpu_sclk_mhz_returns_none_when_absent(tmp_path):
+    assert hp._igpu_sclk_mhz(sysfs_root=tmp_path) is None

--- a/tests/capabilities/test_orchestrator_reconciliation.py
+++ b/tests/capabilities/test_orchestrator_reconciliation.py
@@ -29,6 +29,15 @@ import pytest
 from hal0.capabilities.orchestrator import CapabilityOrchestrator
 
 
+@pytest.fixture(autouse=True)
+def _no_spawn_context_refresh(monkeypatch):
+    # The runtime writers (swap/apply) fire a detached hal0-agent
+    # render-context; stub it so tests never launch real subprocesses.
+    import hal0.agents.hermes_refresh as _hr
+
+    monkeypatch.setattr(_hr, "spawn_context_refresh", lambda *a, **k: None)
+
+
 class _StubSlot:
     """Minimal stand-in for the Slot dataclass that ``status()`` returns."""
 

--- a/tests/cli/test_agent_shim.py
+++ b/tests/cli/test_agent_shim.py
@@ -434,3 +434,43 @@ class TestIsReady:
             side_effect=urllib.error.URLError("boom"),
         ):
             assert agent_shim._is_ready(self._cfg()) is False
+
+
+# ---------------------------------------------------------------------------
+# cmd_render_context
+# ---------------------------------------------------------------------------
+
+
+def test_render_context_dispatch_calls_render(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    called: dict[str, Path] = {}
+
+    def fake_render(*, hermes_home: Path) -> dict[str, object]:
+        called["home"] = hermes_home
+        return {
+            "state_written": True,
+            "hermes_written": False,
+            "degraded": False,
+            "state_path": "/etc/hal0/STATE.md",
+        }
+
+    monkeypatch.setattr(agent_shim, "_render_live_context", fake_render)
+
+    cfg = agent_shim.AgentConfig(
+        agent_id="hermes",
+        agent_type="hermes",
+        home=tmp_path,
+        venv=tmp_path / "venv",
+        host="127.0.0.1",
+        port=8133,
+    )
+    rc = agent_shim.cmd_render_context(cfg)
+    assert rc == 0
+    assert called["home"] == tmp_path
+
+
+def test_render_context_in_parser_choices() -> None:
+    parser = agent_shim._build_parser()
+    args = parser.parse_args(["hermes", "render-context"])
+    assert args.subcommand == "render-context"

--- a/tests/cli/test_agent_shim.py
+++ b/tests/cli/test_agent_shim.py
@@ -32,7 +32,7 @@ class TestArgvParsing:
         assert ns.agent_id == "hermes"
         assert ns.subcommand == "serve"
 
-    @pytest.mark.parametrize("sub", ["serve", "stop", "status", "reprovision"])
+    @pytest.mark.parametrize("sub", ["serve", "stop", "status", "reprovision", "render-context"])
     def test_all_subcommands_accepted(self, sub: str) -> None:
         parser = agent_shim._build_parser()
         ns = parser.parse_args(["hermes", sub])

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -44,6 +44,15 @@ from hal0.slots.state import (
 # and the other slot-suite modules.
 
 
+@pytest.fixture(autouse=True)
+def _no_spawn_context_refresh(monkeypatch):
+    # The runtime writers (swap/apply) fire a detached hal0-agent
+    # render-context; stub it so tests never launch real subprocesses.
+    import hal0.agents.hermes_refresh as _hr
+
+    monkeypatch.setattr(_hr, "spawn_context_refresh", lambda *a, **k: None)
+
+
 # ── SEEDED_SLOTS + NPU_SEEDED_SLOTS (PR-10 §10.2) ───────────────────────────
 
 

--- a/tests/slots/test_manager_lemonade_bridge.py
+++ b/tests/slots/test_manager_lemonade_bridge.py
@@ -35,6 +35,15 @@ def _mock_provider(handler) -> LemonadeProvider:
     return LemonadeProvider(client=LemonadeClient(http_client=transport))
 
 
+@pytest.fixture(autouse=True)
+def _no_spawn_context_refresh(monkeypatch):
+    # The runtime writers (swap/apply) fire a detached hal0-agent
+    # render-context; stub it so tests never launch real subprocesses.
+    import hal0.agents.hermes_refresh as _hr
+
+    monkeypatch.setattr(_hr, "spawn_context_refresh", lambda *a, **k: None)
+
+
 @pytest.fixture
 def lemonade_env() -> None:
     """No-op fixture (PR-10 retired the HAL0_BACKEND gate).


### PR DESCRIPTION
## Summary

Auto-renders Hermes's live system state so the agent always sees the current loaded model, capabilities, and GPU/NPU backend — refreshed on **every service restart** *and* **every runtime model/slot/capability change** — without bloating the cacheable persona or stalling session start. (DreamServer mesh parity item #2, but richer: NPU/iGPU/capability rollup, and freshness on two triggers instead of just restart.)

A thin `/etc/hal0/STATE.md` snapshot is the buffer, written by one shared `render_live_context()`:

- **Restart trigger** — `ExecStartPre=-/usr/local/bin/hal0-agent %i render-context` on `hal0-agent@hermes.service` (non-fatal).
- **Runtime trigger** — detached, best-effort `spawn_context_refresh()` after `SlotManager.swap()` and `CapabilityOrchestrator.apply()`.
- **Per-session surface** — the (previously-dangling) `on_session_start` hook `inject-system-state.sh` cats STATE.md into every new Hermes session and background-regens only when older than a 5-min TTL.

Design choices:
- `SOUL.md` stays byte-stable (prompt-cacheable); live slot lines moved **out** of `HERMES.md` into `STATE.md`.
- STATE.md writes are **content-hash gated** (ignoring the `_as_of:` line) so steady state doesn't churn the prompt cache; a reachable no-change render bumps mtime so the hook TTL settles.
- Daemon **unreachable → last-good STATE.md is preserved** (never clobbered with a degraded snapshot, e.g. when ExecStartPre fires before hal0-api is up); reachable-but-empty is *not* degraded. `_as_of` + daemon-health marker make staleness visible.

Spec: `docs/internal/hermes-state-md-auto-render-2026-06-04.md` · Plan: `docs/internal/hermes-state-md-auto-render-2026-06-04-plan.md`

## Test Plan

- [x] Unit: STATE.md template (full / no-primary / degraded), capability rollup, iGPU sysfs scan, content-hash gating, preserve-on-unreachable, reachable-empty, TTL mtime-settle, render-context dispatch, spawn-helper best-effort (185 passing locally; ruff check + format clean)
- [x] Guard fixtures stop swap/apply suites from spawning real subprocesses
- [ ] **LXC integration (CT 105) — not yet run:** restart `hal0-agent@hermes` refreshes STATE.md (ExecStartPre); `hal0 slot swap` / `capability_set` refreshes STATE.md (runtime writer); new Hermes session injects STATE.md via the hook; `SOUL.md` sha256 unchanged across a no-slot-change restart (cache safety)

🤖 Generated with [Claude Code](https://claude.com/claude-code)