### PR TITLE
fix(api): stop hal0-api storming lemond's control plane (#474)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1081,6 +1081,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 await omni_router_client.aclose()
         await slot_manager.stop_idle_monitor()
         await dispatcher.aclose()
+        with contextlib.suppress(Exception):
+            await lemonade_proxy_routes.aclose_client()
         log.info("hal0.api.shutdown")
 
 

--- a/src/hal0/api/routes/lemonade_proxy.py
+++ b/src/hal0/api/routes/lemonade_proxy.py
@@ -33,8 +33,11 @@ Out of scope (handled elsewhere or deferred):
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import os
+import time
 from typing import Any
 
 import httpx
@@ -42,6 +45,31 @@ from fastapi import APIRouter, Request
 from fastapi.responses import Response
 
 router = APIRouter()
+
+# Per-request timeout. Connect is short so a dead daemon surfaces as 503
+# quickly; read is generous because /v1/load can take tens of seconds.
+_DEFAULT_TIMEOUT = httpx.Timeout(connect=2.0, read=120.0, write=30.0, pool=5.0)
+
+# Issue #474: the dashboard's useLemonadeHealth (2s) + useLemonadeStats (5s)
+# hooks poll through this proxy, once PER open browser tab. lemond is a
+# cpp-httplib server with a hardcoded 8-thread pool + accept backlog of 5, so an
+# unbounded fan-out of fresh TCP connections starves its control plane (FIN-
+# WAIT-2 pile-up, /health timeouts). Two guards:
+#   1. A single shared, pooled client caps concurrent upstream connections.
+#   2. A short TTL + single-flight cache on the read-only /v1/health and
+#      /v1/stats polls collapses N tabs into one upstream call per window.
+_POOL_LIMITS = httpx.Limits(max_connections=4, max_keepalive_connections=2)
+
+# GET paths cheap + safe to coalesce (global pool snapshots, no side effects).
+_CACHEABLE_GET_PATHS = frozenset({"health", "stats"})
+_CACHE_TTL_S = 2.0
+
+# Module-level shared client + cache. The client is built lazily (so importing
+# this module opens no sockets) and lives for the process; closed by the app
+# lifespan via aclose_client(). _reset_state() exists for test isolation.
+_client: httpx.AsyncClient | None = None
+_cache: dict[str, tuple[float, int, bytes, str | None, dict[str, str]]] = {}
+_cache_locks: dict[str, asyncio.Lock] = {}
 
 
 # Headers that MUST NOT round-trip across the proxy.  ``host`` would
@@ -94,12 +122,61 @@ def _lemonade_base_url() -> str:
 
 
 def _build_client(timeout: httpx.Timeout) -> httpx.AsyncClient:
-    """Construct the per-request httpx client.
+    """Construct the shared httpx client.
 
     Lives as a module-level seam so tests can monkeypatch it to inject
-    an ``httpx.MockTransport`` without spinning up a real socket.
+    an ``httpx.MockTransport`` without spinning up a real socket. The pool
+    limits (#474) cap concurrent connections to lemond's control plane.
     """
-    return httpx.AsyncClient(timeout=timeout)
+    return httpx.AsyncClient(timeout=timeout, limits=_POOL_LIMITS)
+
+
+def _get_client() -> httpx.AsyncClient:
+    """Return the process-wide shared proxy client, building it lazily.
+
+    Reused across requests so dashboard polls amortise keep-alive instead of
+    opening a fresh TCP connection per poll (#474). The check-and-set is atomic
+    under asyncio (no await between), so concurrent first-callers can't race in
+    two clients.
+    """
+    global _client
+    if _client is None:
+        _client = _build_client(_DEFAULT_TIMEOUT)
+    return _client
+
+
+async def aclose_client() -> None:
+    """Close the shared client on app shutdown. Idempotent."""
+    global _client
+    if _client is not None:
+        with contextlib.suppress(Exception):
+            await _client.aclose()
+        _client = None
+
+
+def _reset_state() -> None:
+    """Drop the shared client + cache. For test isolation only."""
+    global _client
+    _client = None
+    _cache.clear()
+    _cache_locks.clear()
+
+
+def _cache_get(path: str) -> tuple[float, int, bytes, str | None, dict[str, str]] | None:
+    """Return a live cache entry for ``path`` or None (evicting if expired)."""
+    entry = _cache.get(path)
+    if entry is None:
+        return None
+    if time.monotonic() >= entry[0]:
+        _cache.pop(path, None)
+        return None
+    return entry
+
+
+def _response_from_cache(
+    entry: tuple[float, int, bytes, str | None, dict[str, str]],
+) -> Response:
+    return _make_response(entry[1:])
 
 
 def _filter_request_headers(headers: Any) -> dict[str, str]:
@@ -136,62 +213,96 @@ async def _proxy(request: Request, path: str) -> Response:
     # path converter; we anchor it ourselves so the upstream sees the
     # full /v1/<path>.
     target_url = f"{base}/v1/{path}"
+
+    # Non-cacheable (writes, query-bearing, or non-health/stats GETs) go
+    # straight upstream over the shared pooled client.
+    cacheable = (
+        request.method == "GET" and path in _CACHEABLE_GET_PATHS and not request.query_params
+    )
+    if not cacheable:
+        return _make_response(await _forward(request, target_url))
+
+    # Fast path: serve a fresh cache entry without touching lemond.
+    hit = _cache_get(path)
+    if hit is not None:
+        return _response_from_cache(hit)
+
+    # Single-flight: the first caller fills the cache while concurrent callers
+    # for the same path wait on the lock and then re-check the cache — so N
+    # dashboard tabs collapse into one upstream poll per TTL window (#474).
+    lock = _cache_locks.setdefault(path, asyncio.Lock())
+    async with lock:
+        hit = _cache_get(path)
+        if hit is not None:
+            return _response_from_cache(hit)
+        status, content, media_type, headers = await _forward(request, target_url)
+        if 200 <= status < 300:
+            _cache[path] = (
+                time.monotonic() + _CACHE_TTL_S,
+                status,
+                content,
+                media_type,
+                headers,
+            )
+        return _make_response((status, content, media_type, headers))
+
+
+async def _forward(
+    request: Request, target_url: str
+) -> tuple[int, bytes, str | None, dict[str, str]]:
+    """Forward one request to lemond over the shared client.
+
+    Returns the response parts ``(status, content, media_type, headers)`` —
+    including hal0-shaped 503/502 envelopes when lemond is unreachable or
+    errors — so the caller can both build a Response and (for cacheable GETs)
+    store the parts.
+    """
     headers = _filter_request_headers(request.headers)
     body = await request.body()
     params = list(request.query_params.multi_items())
 
-    # Cap the per-request timeout generously — Lemonade can take tens of
-    # seconds to load a model on /v1/load. Connect timeout is short so a
-    # dead daemon surfaces as 503 quickly instead of hanging the
-    # dashboard poll.
-    timeout = httpx.Timeout(connect=2.0, read=120.0, write=30.0, pool=5.0)
-
-    client = _build_client(timeout)
+    client = _get_client()
     try:
-        try:
-            upstream_resp = await client.request(
-                method=request.method,
-                url=target_url,
-                headers=headers,
-                content=body if body else None,
-                params=params,
-            )
-        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
-            envelope = {
-                "error": {
-                    "code": "lemonade.unavailable",
-                    "message": "lemonade is not reachable on loopback",
-                    "details": {"target": target_url, "reason": str(exc)},
-                }
+        upstream_resp = await client.request(
+            method=request.method,
+            url=target_url,
+            headers=headers,
+            content=body if body else None,
+            params=params,
+        )
+    except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+        envelope = {
+            "error": {
+                "code": "lemonade.unavailable",
+                "message": "lemonade is not reachable on loopback",
+                "details": {"target": target_url, "reason": str(exc)},
             }
-            return Response(
-                content=json.dumps(envelope).encode("utf-8"),
-                status_code=503,
-                media_type="application/json",
-            )
-        except httpx.HTTPError as exc:
-            envelope = {
-                "error": {
-                    "code": "lemonade.proxy_error",
-                    "message": "error forwarding request to lemonade",
-                    "details": {"target": target_url, "reason": str(exc)},
-                }
+        }
+        return 503, json.dumps(envelope).encode("utf-8"), "application/json", {}
+    except httpx.HTTPError as exc:
+        envelope = {
+            "error": {
+                "code": "lemonade.proxy_error",
+                "message": "error forwarding request to lemonade",
+                "details": {"target": target_url, "reason": str(exc)},
             }
-            return Response(
-                content=json.dumps(envelope).encode("utf-8"),
-                status_code=502,
-                media_type="application/json",
-            )
-    finally:
-        await client.aclose()
+        }
+        return 502, json.dumps(envelope).encode("utf-8"), "application/json", {}
 
-    response_headers = _filter_response_headers(upstream_resp.headers)
-    media_type = upstream_resp.headers.get("content-type")
+    return (
+        upstream_resp.status_code,
+        upstream_resp.content,
+        upstream_resp.headers.get("content-type"),
+        _filter_response_headers(upstream_resp.headers),
+    )
 
+
+def _make_response(parts: tuple[int, bytes, str | None, dict[str, str]]) -> Response:
+    status, content, media_type, headers = parts
     return Response(
-        content=upstream_resp.content,
-        status_code=upstream_resp.status_code,
-        headers=response_headers,
+        content=content,
+        status_code=status,
+        headers=dict(headers),
         media_type=media_type,
     )
 

--- a/src/hal0/lemonade/client.py
+++ b/src/hal0/lemonade/client.py
@@ -68,9 +68,16 @@ DEFAULT_LOAD_TIMEOUT_S = 120.0
 # /api/slots refresh (SlotManager.list() fans out _is_active over every
 # slot, each calling health()), plus one more from the route's enrichment
 # pass — ~8 identical round-trips per request on a 7-slot box. The body is
-# a global pool snapshot, so a sub-second coalescing cache collapses the
-# burst to one upstream call without changing observed behaviour.
-_HEALTH_CACHE_TTL_S = 0.5
+# a global pool snapshot, so a short coalescing cache collapses the burst to
+# one upstream call without changing observed behaviour.
+#
+# #474: raised 0.5s -> 2.0s to match the dashboard's fastest poll cadence
+# (useLemonadeHealth at 2s). lemond's control plane (cpp-httplib, 8 threads,
+# accept backlog 5) wedges under poll pressure when a big model is loaded and
+# inference serialises its threads; a 2s window keeps the multiple
+# health-bearing routes (/api/slots, /api/status) to one upstream poll per
+# window. Staleness ceiling stays at 2s, acceptable for a status snapshot.
+_HEALTH_CACHE_TTL_S = 2.0
 
 
 class LemonadeClient:

--- a/tests/api/test_v1_proxy.py
+++ b/tests/api/test_v1_proxy.py
@@ -63,6 +63,9 @@ def _install_mock(
             timeout=timeout,
         )
 
+    # #474: the proxy now keeps a process-wide shared client + a short TTL
+    # cache. Reset both so each test starts clean and picks up this mock.
+    lemonade_proxy._reset_state()
     monkeypatch.setattr(lemonade_proxy, "_build_client", _fake_build_client)
     return state
 
@@ -291,3 +294,84 @@ def test_lemonade_base_url_defaults_to_loopback_13305(
 ) -> None:
     monkeypatch.delenv("LEMONADE_BASE_URL", raising=False)
     assert lemonade_proxy._lemonade_base_url() == "http://127.0.0.1:13305"
+
+
+# ── #474: connection-storm guards (pooled client + TTL/single-flight cache) ──
+
+
+def test_v1_health_cached_within_ttl(client: TestClient, lemonade_state: dict[str, Any]) -> None:
+    """A 2nd GET /v1/health inside the TTL is served from cache — no 2nd poll.
+
+    This is the amplifier killer: N dashboard tabs polling /v1/health every 2s
+    collapse into one upstream call per TTL window instead of one per tab.
+    """
+    r1 = client.get("/v1/health")
+    r2 = client.get("/v1/health")
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert r1.json()["status"] == "ok" and r2.json()["status"] == "ok"
+    assert len(lemonade_state["requests"]) == 1, "2nd health poll should hit the cache"
+
+
+def test_v1_stats_cached_within_ttl(client: TestClient, lemonade_state: dict[str, Any]) -> None:
+    client.get("/v1/stats")
+    client.get("/v1/stats")
+    stats_polls = [r for r in lemonade_state["requests"] if r["path"] == "/v1/stats"]
+    assert len(stats_polls) == 1, "2nd stats poll should hit the cache"
+
+
+def test_v1_health_query_params_bypass_cache(
+    client: TestClient, lemonade_state: dict[str, Any]
+) -> None:
+    """Query-bearing requests are not cacheable — they always reach lemond."""
+    client.get("/v1/health")
+    client.get("/v1/health?debug=1")
+    assert len(lemonade_state["requests"]) == 2
+
+
+def test_v1_load_post_is_not_cached(client: TestClient, lemonade_state: dict[str, Any]) -> None:
+    """Writes (POST /v1/load) must never be cached — each call reaches lemond."""
+    client.post("/v1/load", json={"model_name": "gemma3:1b"})
+    client.post("/v1/load", json={"model_name": "gemma3:1b"})
+    loads = [r for r in lemonade_state["requests"] if r["path"] == "/v1/load"]
+    assert len(loads) == 2
+
+
+def test_v1_health_non_2xx_is_not_cached(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-2xx upstream (e.g. lemond mid-load) is not cached — keep polling."""
+    calls = {"n": 0}
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(503, json={"status": "loading"})
+
+    _install_mock(monkeypatch, _handler)
+    assert client.get("/v1/health").status_code == 503
+    assert client.get("/v1/health").status_code == 503
+    assert calls["n"] == 2, "non-2xx must not be cached"
+
+
+def test_proxy_reuses_a_single_pooled_client(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The proxy builds ONE shared client and reuses it across requests (#474).
+
+    Previously a fresh httpx.AsyncClient (new TCP connection) was built per
+    request, storming lemond's accept queue.
+    """
+    built: list[int] = []
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"cpu": "ryzen"})
+
+    def _counting_build(timeout: httpx.Timeout) -> httpx.AsyncClient:
+        built.append(1)
+        return httpx.AsyncClient(transport=httpx.MockTransport(_handler), timeout=timeout)
+
+    lemonade_proxy._reset_state()
+    monkeypatch.setattr(lemonade_proxy, "_build_client", _counting_build)
+    # /v1/system-info is not cacheable, so each call exercises _get_client().
+    for _ in range(3):
+        assert client.get("/v1/system-info").status_code == 200
+    assert built == [1], "expected exactly one shared client across 3 requests"


### PR DESCRIPTION
Closes #474.

## Problem
The `/v1/*` reverse-proxy (`lemonade_proxy.py`) built a **fresh `httpx.AsyncClient` per request**, and the dashboard's `useLemonadeHealth` (2s) + `useLemonadeStats` (5s) hooks poll through it **once per open browser tab**. lemond is cpp-httplib with a hardcoded 8-thread pool + accept backlog of 5 — the unbounded fan-out of fresh TCP connections starved its control plane (FIN-WAIT-2 corpses, `/health`/`/load`/`/models` timing out) whenever a big model serialized lemond's threads. Previously masked by the Hermes Hindsight leak (#472b).

## Fix
`lemonade_proxy.py`:
- **Single process-wide pooled client** (`limits: max_connections=4, max_keepalive=2`), reused across requests, closed on app shutdown via `aclose_client()` wired into the lifespan.
- **2s TTL + single-flight cache** on read-only `GET /v1/health` and `/v1/stats` — N tabs collapse into one upstream poll per window. Writes, query-bearing requests, and non-2xx are never cached.

`client.py`: raise `_HEALTH_CACHE_TTL_S` 0.5s → 2s so backend self-probes (`/api/slots` + `/api/status` enrichment) share one upstream poll per window.

## Tests
5 new proxy tests (cache hit, query bypass, write not cached, non-2xx not cached, single shared client). `tests/api/test_v1_proxy.py` 20 pass; `tests/lemonade` + providers + slots-state 185 pass. ruff check + format clean.

## Verification (live)
Deploy to CT105, restart hal0-api, watch `ss -tn 'dst 127.0.0.1:13305'` settle (no growing FIN-WAIT-2) and `/api/v1/health` stay responsive under dashboard load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)