### PR TITLE
feat: fold lemond normalization into hal0-api (hal0/* virtual names + thinking suppression)

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -727,6 +727,7 @@ def _render_config_yaml(
     delegation: dict[str, Any] | None = None,
     auxiliary_tasks: dict[str, dict[str, Any]] | None = None,
     custom_providers: list[dict[str, Any]] | None = None,
+    live_resolve_enabled: bool = False,
 ) -> str:
     """Render the Hermes config.yaml via Jinja2.
 
@@ -787,6 +788,7 @@ def _render_config_yaml(
             auxiliary_tasks if auxiliary_tasks is not None else _default_auxiliary_tasks()
         ),
         custom_providers=custom_providers,
+        live_resolve_enabled=live_resolve_enabled,
     )
 
 
@@ -933,6 +935,7 @@ def _phase_config_write(state: BootstrapState) -> PhaseResult:
     cached_servers = (state.phases.get("mcp_wire") or {}).get("details", {}).get("rendered_servers")
     mcp_servers = cached_servers if isinstance(cached_servers, list) and cached_servers else None
     system_prompt, personality_name = _active_persona_render(state, mcp_servers=mcp_servers)
+    live_resolve_enabled = os.environ.get("HAL0_HERMES_LIVE_RESOLVE", "0") == "1"
     rendered = _render_config_yaml(
         primary=primary,
         chat_slots=chat_slots,
@@ -943,6 +946,7 @@ def _phase_config_write(state: BootstrapState) -> PhaseResult:
         delegation=delegation,
         auxiliary_tasks=auxiliary_tasks,
         custom_providers=custom_providers,
+        live_resolve_enabled=live_resolve_enabled,
     )
     rendered = _apply_overrides(rendered, OVERRIDES_PATH)
     new_hash = content_hash(rendered)

--- a/src/hal0/agents/hermes_templates/config.yaml.j2
+++ b/src/hal0/agents/hermes_templates/config.yaml.j2
@@ -23,6 +23,9 @@
                         Drives the auxiliary: block. utility-slot tasks render
                         provider:"custom"+base_url; vision/web_extract stay
                         provider:"main". (feat/hermes-role-slots)
+     live_resolve_enabled — bool      when true, model.default + providers.custom.base_url
+                        render the virtual "hal0/primary" name against the gateway
+                        (http://127.0.0.1:8080/v1) instead of the physical slot model.
 #}# Managed by hal0 (issue #241). Edits MAY be overwritten by
 # `hal0 agent bootstrap hermes`. Drop a file at
 # /etc/hal0/agents/hermes/overrides.yaml to merge on top.
@@ -65,7 +68,7 @@ providers:
   # LAN endpoints; hal0 sits in that bucket.
   custom:
     name: "hal0"
-    base_url: {{ (primary.backend_url if primary else "http://127.0.0.1:8080/v1") | tojson }}
+    base_url: {{ ("http://127.0.0.1:8080/v1" if live_resolve_enabled else (primary.backend_url if primary else "http://127.0.0.1:8080/v1")) | tojson }}
     request_timeout_seconds: 300
     stale_timeout_seconds: 900
 

--- a/src/hal0/agents/hermes_templates/config.yaml.j2
+++ b/src/hal0/agents/hermes_templates/config.yaml.j2
@@ -43,7 +43,11 @@
    context now lives in the `custom_providers:` block below, matched by
    base_url + model_id. #}
 model:
-{%- if primary %}
+{%- if live_resolve_enabled %}
+  default: "hal0/primary"
+  provider: "custom"
+  base_url: "http://127.0.0.1:8080/v1"
+{%- elif primary %}
   default: {{ primary.model_id | tojson }}
   provider: "custom"
   base_url: {{ primary.backend_url | tojson }}

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -429,7 +429,10 @@ async def hal0_chat_slot_alias_map(slot_manager: SlotManager) -> dict[str, str]:
     return out
 
 
-async def hal0_llm_slot_views(slot_manager: SlotManager) -> list[dict[str, Any]]:
+async def hal0_llm_slot_views(
+    slot_manager: SlotManager,
+    model_registry: ModelRegistry | None = None,
+) -> list[dict[str, Any]]:
     """Return one dict per enabled llm slot: {name, role, device, model_id, context_length}.
 
     Source for normalize.LiveSlotResolver's SlotView list. Mirrors
@@ -450,14 +453,13 @@ async def hal0_llm_slot_views(slot_manager: SlotManager) -> list[dict[str, Any]]
         model_id = _slot_model_id(cfg)
         if not name or not model_id:
             continue
-        model_section = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
         out.append(
             {
                 "name": name,
                 "role": cfg.get("role"),
                 "device": (cfg.get("device") or "").strip(),
                 "model_id": model_id,
-                "context_length": int(model_section.get("context_size") or 0),
+                "context_length": int(_slot_ctx_size(cfg, model_registry, model_id) or 0),
             }
         )
     return out

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -429,6 +429,40 @@ async def hal0_chat_slot_alias_map(slot_manager: SlotManager) -> dict[str, str]:
     return out
 
 
+async def hal0_llm_slot_views(slot_manager: SlotManager) -> list[dict[str, Any]]:
+    """Return one dict per enabled llm slot: {name, role, device, model_id, context_length}.
+
+    Source for normalize.LiveSlotResolver's SlotView list. Mirrors
+    hal0_chat_slot_alias_map's iteration but carries role + device + context.
+    """
+    try:
+        cfgs = await slot_manager.iter_configs()
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("v1.llm_slot_views_iter_failed", error=str(exc))
+        return []
+    out: list[dict[str, Any]] = []
+    for cfg in cfgs:
+        if (cfg.get("type") or "").lower() != "llm":
+            continue
+        if cfg.get("enabled") is False:
+            continue
+        name = str(cfg.get("name") or "").strip()
+        model_id = _slot_model_id(cfg)
+        if not name or not model_id:
+            continue
+        model_section = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+        out.append(
+            {
+                "name": name,
+                "role": cfg.get("role"),
+                "device": (cfg.get("device") or "").strip(),
+                "model_id": model_id,
+                "context_length": int(model_section.get("context_size") or 0),
+            }
+        )
+    return out
+
+
 async def hal0_chat_slot_model_ids(slot_manager: SlotManager) -> set[str]:
     """Return the configured model ids of every enabled chat slot.
 

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -607,6 +607,9 @@ async def list_models(
         slot_views_provider=lambda: views,
         loaded_models_provider=lambda: _normalize_loaded_models(request),
     )
+    # All 3 canonical names are advertised whenever they resolve. hal0/npu and
+    # hal0/utility fall back to the primary when no npu/utility slot is loaded —
+    # intentional: the name always routes (see resolve_chain's fallback contract).
     for vname in DEFAULT_CHAINS:  # canonical names only (aliases excluded from the picker)
         if vname in seen:
             continue

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -607,7 +607,7 @@ async def list_models(
         slot_views_provider=lambda: views,
         loaded_models_provider=lambda: _normalize_loaded_models(request),
     )
-    for vname in DEFAULT_CHAINS:   # canonical names only (aliases excluded from the picker)
+    for vname in DEFAULT_CHAINS:  # canonical names only (aliases excluded from the picker)
         if vname in seen:
             continue
         res = await resolver.resolve(vname)
@@ -615,19 +615,21 @@ async def list_models(
             continue
         seen.add(vname)
         device = next((v.device for v in views if v.model_id == res.model_id), "")
-        data.append({
-            "id": vname,
-            "object": "model",
-            "created": now,
-            "owned_by": "hal0",
-            "context_length": res.context_length,
-            "_hal0": {
-                "virtual": True,
-                "kind": "live-resolve",
-                "resolves_to": res.model_id,
-                "device": device,
-            },
-        })
+        data.append(
+            {
+                "id": vname,
+                "object": "model",
+                "created": now,
+                "owned_by": "hal0",
+                "context_length": res.context_length,
+                "_hal0": {
+                    "virtual": True,
+                    "kind": "live-resolve",
+                    "resolves_to": res.model_id,
+                    "device": device,
+                },
+            }
+        )
 
     return {"object": "list", "data": data}
 

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -598,6 +598,37 @@ async def list_models(
                     "owned_by": u.name,
                 }
             )
+    # Advertise live-resolve virtual names so Hermes' /model picker discovers them.
+    # context_length is mandatory: without it Hermes assumes a 256K window.
+    from hal0.normalize.resolver import DEFAULT_CHAINS, LiveSlotResolver
+
+    views = await _normalize_slot_views(request)
+    resolver = LiveSlotResolver(
+        slot_views_provider=lambda: views,
+        loaded_models_provider=lambda: _normalize_loaded_models(request),
+    )
+    for vname in DEFAULT_CHAINS:   # canonical names only (aliases excluded from the picker)
+        if vname in seen:
+            continue
+        res = await resolver.resolve(vname)
+        if res is None or not res.model_id:
+            continue
+        seen.add(vname)
+        device = next((v.device for v in views if v.model_id == res.model_id), "")
+        data.append({
+            "id": vname,
+            "object": "model",
+            "created": now,
+            "owned_by": "hal0",
+            "context_length": res.context_length,
+            "_hal0": {
+                "virtual": True,
+                "kind": "live-resolve",
+                "resolves_to": res.model_id,
+                "device": device,
+            },
+        })
+
     return {"object": "list", "data": data}
 
 

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -301,7 +301,7 @@ async def _normalize_slot_views(request: Request) -> list:
     sm = getattr(request.app.state, "slot_manager", None)
     if sm is None:
         return []
-    rows = await hal0_llm_slot_views(sm)
+    rows = await hal0_llm_slot_views(sm, getattr(request.app.state, "model_registry", None))
     return [
         SlotView(
             name=r["name"],
@@ -707,6 +707,10 @@ async def chat_completions(request: Request, dispatcher: DispatcherDep) -> Respo
     # backends.
     if "omni" in body:
         body = {k: v for k, v in body.items() if k != "omni"}
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            request._body = json.dumps(body).encode("utf-8")  # type: ignore[attr-defined]
     return await _dispatch_and_forward(request, dispatcher, body=body)
 
 

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -281,6 +281,85 @@ async def _rewrite_chat_slot_alias(request: Request, body: dict[str, Any]) -> di
     return new_body
 
 
+def _normalize_loaded_models(request: Request) -> set[str]:
+    """Currently-loaded model ids from the cached health snapshot (NO new lemond poll)."""
+    shim = getattr(request.app.state, "lemonade_metrics_shim", None)
+    if shim is None:
+        return set()
+    try:
+        return set(shim._health.loaded_models)
+    except Exception:  # pragma: no cover — defensive
+        return set()
+
+
+async def _normalize_slot_views(request: Request) -> list:
+    """Build SlotView list from slot config (awaits hal0_llm_slot_views, like the
+    existing per-request alias-map read)."""
+    from hal0.api import hal0_llm_slot_views
+    from hal0.normalize.resolver import SlotView
+
+    sm = getattr(request.app.state, "slot_manager", None)
+    if sm is None:
+        return []
+    rows = await hal0_llm_slot_views(sm)
+    return [
+        SlotView(
+            name=r["name"],
+            role=r.get("role"),
+            device=r.get("device", ""),
+            model_id=r["model_id"],
+            context_length=int(r.get("context_length") or 0),
+        )
+        for r in rows
+    ]
+
+
+def _is_remote_model(request: Request, model_id: str) -> bool:
+    """True if model_id maps to a kind=='remote' upstream (skip thinking injection)."""
+    upstreams = getattr(request.app.state, "upstreams", None)
+    cache = getattr(request.app.state, "upstream_models", {}) or {}
+    if upstreams is None:
+        return False
+    try:
+        for u in upstreams.list():
+            if getattr(u, "kind", "") == "remote" and model_id in set(cache.get(u.name, [])):
+                return True
+    except Exception:  # pragma: no cover — defensive
+        return False
+    return False
+
+
+async def _normalize_chat_body(request: Request, body: dict[str, Any]) -> dict[str, Any]:
+    """Resolve hal0/* virtual model names + inject thinking policy for lemond-bound calls.
+
+    Rewrites request._body so BOTH the dispatcher path and the NoRouteFound proxy
+    fall-through observe the normalized body.
+    """
+    from hal0.normalize.resolver import LiveSlotResolver
+    from hal0.normalize.thinking import apply_thinking_policy
+
+    views = await _normalize_slot_views(request)
+    resolver = LiveSlotResolver(
+        slot_views_provider=lambda: views,
+        loaded_models_provider=lambda: _normalize_loaded_models(request),
+    )
+    raw_model = body.get("model")
+    if isinstance(raw_model, str) and raw_model:
+        res = await resolver.resolve(raw_model)
+        if res is not None and res.model_id:
+            body = {**body, "model": res.model_id}
+
+    model_id = body.get("model")
+    if isinstance(model_id, str) and not _is_remote_model(request, model_id):
+        body = apply_thinking_policy(body)
+
+    import contextlib
+
+    with contextlib.suppress(Exception):
+        request._body = json.dumps(body).encode("utf-8")  # type: ignore[attr-defined]
+    return body
+
+
 async def _ensure_backend_for_model(request: Request, body: dict[str, Any]) -> None:
     """#430: load a slot-backed model under its DECLARED backend before routing.
 
@@ -572,6 +651,17 @@ async def chat_completions(request: Request, dispatcher: DispatcherDep) -> Respo
     # see the real model name. Also rewrites the cached request body for
     # the lemonade fall-through.
     body = await _rewrite_chat_slot_alias(request, body)
+    # SOLE normalization gate (chat only). Resolves hal0/* virtual names +
+    # injects the thinking policy, and rewrites request._body. Placed BEFORE
+    # the omni branch so the OmniRouter posts the normalized body; the
+    # non-omni path then hands the already-normalized body=body into
+    # _dispatch_and_forward (which sees request._body too via the proxy
+    # fall-through). Deliberately NOT in _dispatch_and_forward — that helper
+    # also serves /v1/completions, /v1/embeddings, /v1/rerankings, and the
+    # multipart /v1/audio/transcriptions, none of which are chat and where an
+    # unconditional request._body=json(body) rewrite would corrupt the
+    # multipart upload / inject a meaningless enable_thinking.
+    body = await _normalize_chat_body(request, body)
     if body.get("omni") is True:
         looped = await _maybe_run_omni_loop(request, body)
         if looped is not None:

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -242,6 +242,14 @@ class SlotConfig(BaseModel):
         default=True,
         description="Whether this slot is started on hal0 startup.",
     )
+    role: str | None = Field(
+        default=None,
+        description=(
+            "Optional role hint for normalization chain binding "
+            "(e.g. 'primary', 'utility', 'npu'). When unset, role is derived "
+            "from the slot name. Authoritative over the name when set."
+        ),
+    )
 
     # [model] section (nested)
     model: ModelConfig = Field(default_factory=ModelConfig)

--- a/src/hal0/normalize/__init__.py
+++ b/src/hal0/normalize/__init__.py
@@ -1,11 +1,11 @@
 """Request normalization for lemond-bound chat traffic (model resolution + thinking)."""
 
 from hal0.normalize.resolver import (  # noqa: F401
-    SlotView,
-    Resolution,
     DEFAULT_CHAINS,
     VIRTUAL_ALIASES,
+    LiveSlotResolver,
+    Resolution,
+    SlotView,
     is_npu_or_flm,
     resolve_chain,
-    LiveSlotResolver,
 )

--- a/src/hal0/normalize/__init__.py
+++ b/src/hal0/normalize/__init__.py
@@ -1,0 +1,11 @@
+"""Request normalization for lemond-bound chat traffic (model resolution + thinking)."""
+
+from hal0.normalize.resolver import (  # noqa: F401
+    SlotView,
+    Resolution,
+    DEFAULT_CHAINS,
+    VIRTUAL_ALIASES,
+    is_npu_or_flm,
+    resolve_chain,
+    LiveSlotResolver,
+)

--- a/src/hal0/normalize/__init__.py
+++ b/src/hal0/normalize/__init__.py
@@ -9,3 +9,4 @@ from hal0.normalize.resolver import (  # noqa: F401
     is_npu_or_flm,
     resolve_chain,
 )
+from hal0.normalize.thinking import apply_thinking_policy  # noqa: F401

--- a/src/hal0/normalize/__init__.py
+++ b/src/hal0/normalize/__init__.py
@@ -6,7 +6,6 @@ from hal0.normalize.resolver import (  # noqa: F401
     LiveSlotResolver,
     Resolution,
     SlotView,
-    is_npu_or_flm,
     resolve_chain,
 )
 from hal0.normalize.thinking import apply_thinking_policy  # noqa: F401

--- a/src/hal0/normalize/resolver.py
+++ b/src/hal0/normalize/resolver.py
@@ -42,15 +42,6 @@ class Resolution:
     fallback: bool  # True => nothing in the chain was loaded; caller should ensure-load
 
 
-def is_npu_or_flm(model_name: str) -> bool:
-    """Name suffix/substring heuristic used only for a loaded model with no slot-config match.
-
-    Matches a ``-FLM`` suffix, or the substring ``FLM`` or ``NPU`` anywhere in the name.
-    """
-    upper = model_name.upper()
-    return upper.endswith("-FLM") or "FLM" in upper or "NPU" in upper
-
-
 def _slot_matches_role(slot: SlotView, role: str) -> bool:
     """Authoritative role binding: device for npu, role tag (else name) for primary/utility."""
     if role == "npu":

--- a/src/hal0/normalize/resolver.py
+++ b/src/hal0/normalize/resolver.py
@@ -7,6 +7,7 @@ wrapper reuses ``MetricsShim._health`` (see hal0-api lifespan).
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 # Canonical virtual names -> ordered chain of roles to try against loaded slots.
@@ -97,4 +98,28 @@ def resolve_chain(
     return Resolution("", 0, None, fallback=True)
 
 
-LiveSlotResolver = None  # type: ignore[assignment]  # implemented in a later task
+class LiveSlotResolver:
+    """Async wrapper around ``resolve_chain``.
+
+    ``slot_views_provider`` returns the current list of ``SlotView`` (built from
+    slot config). ``loaded_models_provider`` returns the set of currently-loaded
+    model ids from the cached health snapshot — NO new lemond poll.
+    """
+
+    def __init__(
+        self,
+        slot_views_provider: Callable[[], list[SlotView]],
+        loaded_models_provider: Callable[[], set[str]],
+    ) -> None:
+        self._views = slot_views_provider
+        self._loaded = loaded_models_provider
+
+    async def resolve(self, model_name: str) -> Resolution | None:
+        if model_name not in DEFAULT_CHAINS and model_name not in VIRTUAL_ALIASES:
+            return None
+        try:
+            views = list(self._views() or [])
+            loaded = set(self._loaded() or set())
+        except Exception:
+            views, loaded = [], set()
+        return resolve_chain(model_name, views, loaded)

--- a/src/hal0/normalize/resolver.py
+++ b/src/hal0/normalize/resolver.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-
 # Canonical virtual names -> ordered chain of roles to try against loaded slots.
 DEFAULT_CHAINS: dict[str, tuple[str, ...]] = {
     "hal0/primary": ("primary",),
@@ -29,7 +28,7 @@ class SlotView:
 
     name: str
     role: str | None
-    device: str           # "gpu-vulkan" | "gpu-rocm" | "cpu" | "npu"
+    device: str  # "gpu-vulkan" | "gpu-rocm" | "cpu" | "npu"
     model_id: str
     context_length: int
 
@@ -38,12 +37,15 @@ class SlotView:
 class Resolution:
     model_id: str
     context_length: int
-    matched_role: str | None   # role that matched a loaded slot, or None on fallback
-    fallback: bool             # True => nothing in the chain was loaded; caller should ensure-load
+    matched_role: str | None  # role that matched a loaded slot, or None on fallback
+    fallback: bool  # True => nothing in the chain was loaded; caller should ensure-load
 
 
 def is_npu_or_flm(model_name: str) -> bool:
-    """Name-suffix heuristic used only for a loaded model with no slot-config match."""
+    """Name suffix/substring heuristic used only for a loaded model with no slot-config match.
+
+    Matches a ``-FLM`` suffix, or the substring ``FLM`` or ``NPU`` anywhere in the name.
+    """
     upper = model_name.upper()
     return upper.endswith("-FLM") or "FLM" in upper or "NPU" in upper
 
@@ -60,6 +62,7 @@ def _configured_primary(slots: list[SlotView]) -> SlotView | None:
     for s in slots:
         if _slot_matches_role(s, "primary"):
             return s
+    # last-resort: first enabled llm slot if none is tagged/named primary
     return slots[0] if slots else None
 
 
@@ -81,6 +84,9 @@ def resolve_chain(
 
     for role in chain:
         for slot in slots:
+            # Contract: both sides are the canonical lemond model_id, compared exactly.
+            # The async wrapper passes lemond's loaded model_names verbatim — exact
+            # match is intended, do NOT lowercase.
             if _slot_matches_role(slot, role) and slot.model_id in loaded:
                 return Resolution(slot.model_id, slot.context_length, role, fallback=False)
 

--- a/src/hal0/normalize/resolver.py
+++ b/src/hal0/normalize/resolver.py
@@ -1,0 +1,94 @@
+"""Live-slot model resolution for hal0 virtual model names.
+
+Pure core (``resolve_chain``) + an async wrapper (``LiveSlotResolver``) that reads
+slot config and the cached lemond health snapshot. No new lemond polling — the
+wrapper reuses ``MetricsShim._health`` (see hal0-api lifespan).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+# Canonical virtual names -> ordered chain of roles to try against loaded slots.
+DEFAULT_CHAINS: dict[str, tuple[str, ...]] = {
+    "hal0/primary": ("primary",),
+    "hal0/npu": ("npu", "utility", "primary"),
+    "hal0/utility": ("utility", "npu", "primary"),
+}
+
+# Aliases that resolve to a canonical name before chain lookup.
+VIRTUAL_ALIASES: dict[str, str] = {
+    "hal0/flm": "hal0/npu",
+}
+
+
+@dataclass(frozen=True)
+class SlotView:
+    """Minimal view of one enabled llm slot, drawn from slot config."""
+
+    name: str
+    role: str | None
+    device: str           # "gpu-vulkan" | "gpu-rocm" | "cpu" | "npu"
+    model_id: str
+    context_length: int
+
+
+@dataclass(frozen=True)
+class Resolution:
+    model_id: str
+    context_length: int
+    matched_role: str | None   # role that matched a loaded slot, or None on fallback
+    fallback: bool             # True => nothing in the chain was loaded; caller should ensure-load
+
+
+def is_npu_or_flm(model_name: str) -> bool:
+    """Name-suffix heuristic used only for a loaded model with no slot-config match."""
+    upper = model_name.upper()
+    return upper.endswith("-FLM") or "FLM" in upper or "NPU" in upper
+
+
+def _slot_matches_role(slot: SlotView, role: str) -> bool:
+    """Authoritative role binding: device for npu, role tag (else name) for primary/utility."""
+    if role == "npu":
+        return slot.device == "npu" or (slot.role or "").lower() == "npu"
+    effective = (slot.role or slot.name).lower()
+    return effective == role
+
+
+def _configured_primary(slots: list[SlotView]) -> SlotView | None:
+    for s in slots:
+        if _slot_matches_role(s, "primary"):
+            return s
+    return slots[0] if slots else None
+
+
+def resolve_chain(
+    virtual_name: str,
+    slots: list[SlotView],
+    loaded: set[str],
+) -> Resolution | None:
+    """Resolve a virtual name to a live slot's physical model id.
+
+    Returns ``None`` if ``virtual_name`` is not a known virtual name. Otherwise
+    always returns a ``Resolution`` (falling back to the configured primary,
+    ``fallback=True``, when no chain role is currently loaded).
+    """
+    canonical = VIRTUAL_ALIASES.get(virtual_name, virtual_name)
+    chain = DEFAULT_CHAINS.get(canonical)
+    if chain is None:
+        return None
+
+    for role in chain:
+        for slot in slots:
+            if _slot_matches_role(slot, role) and slot.model_id in loaded:
+                return Resolution(slot.model_id, slot.context_length, role, fallback=False)
+
+    primary = _configured_primary(slots)
+    if primary is not None:
+        return Resolution(primary.model_id, primary.context_length, None, fallback=True)
+    # No slots at all: degrade to a bare model id so the caller can still 503 cleanly.
+    return Resolution("", 0, None, fallback=True)
+
+
+LiveSlotResolver = None  # type: ignore[assignment]  # implemented in a later task

--- a/src/hal0/normalize/thinking.py
+++ b/src/hal0/normalize/thinking.py
@@ -1,0 +1,27 @@
+"""Reasoning-suppression policy for lemond-bound chat requests.
+
+lemond (SHA 1bce071) reads TOP-LEVEL ``enable_thinking``/``thinking`` and does its
+own ``/no_think`` injection (server.cpp:58-114). We inject top-level
+``enable_thinking: false`` unless the caller already expressed a thinking
+preference. Idempotent and non-mutating.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _caller_opted(body: dict[str, Any]) -> bool:
+    if "enable_thinking" in body or "thinking" in body:
+        return True
+    ctk = body.get("chat_template_kwargs")
+    return isinstance(ctk, dict) and "enable_thinking" in ctk
+
+
+def apply_thinking_policy(body: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``body`` with ``enable_thinking: false`` injected unless
+    the caller already set a thinking control field. A ``no_think`` prompt marker
+    is left untouched (passthrough)."""
+    if _caller_opted(body):
+        return body
+    return {**body, "enable_thinking": False}

--- a/tests/agents/test_hermes_live_resolve_render.py
+++ b/tests/agents/test_hermes_live_resolve_render.py
@@ -1,0 +1,32 @@
+from hal0.agents.hermes_provision import _render_config_yaml
+
+
+def _ctx(**over):
+    base = dict(
+        primary={
+            "model_id": "phys-35b",
+            "backend_url": "http://127.0.0.1:8080/v1",
+            "context_length": 65536,
+        },
+        chat_slots=[],
+        agent_id="hermes",
+        mcp_servers=None,
+        system_prompt="x",
+        personality_name="default",
+        delegation=None,
+        auxiliary_tasks=None,
+        custom_providers=None,
+    )
+    base.update(over)
+    return base
+
+
+def test_live_resolve_renders_virtual_default():
+    out = _render_config_yaml(live_resolve_enabled=True, **_ctx())
+    assert 'default: "hal0/primary"' in out
+
+
+def test_disabled_renders_physical_default():
+    out = _render_config_yaml(live_resolve_enabled=False, **_ctx())
+    assert "phys-35b" in out
+    assert "hal0/primary" not in out

--- a/tests/agents/test_hermes_live_resolve_render.py
+++ b/tests/agents/test_hermes_live_resolve_render.py
@@ -24,9 +24,30 @@ def _ctx(**over):
 def test_live_resolve_renders_virtual_default():
     out = _render_config_yaml(live_resolve_enabled=True, **_ctx())
     assert 'default: "hal0/primary"' in out
+    assert 'provider: "custom"' in out
+    assert 'base_url: "http://127.0.0.1:8080/v1"' in out
 
 
 def test_disabled_renders_physical_default():
     out = _render_config_yaml(live_resolve_enabled=False, **_ctx())
     assert "phys-35b" in out
     assert "hal0/primary" not in out
+
+
+def test_live_resolve_forces_gateway_for_nonlocal_primary():
+    """A non-8080 primary backend_url must NOT leak into either base_url
+    under live_resolve — both model.base_url and providers.custom.base_url
+    render the gateway so Hermes's base_url cross-match stays consistent."""
+    primary = {
+        "model_id": "m",
+        "backend_url": "http://127.0.0.1:8001/v1",
+        "context_length": 4096,
+    }
+    out_on = _render_config_yaml(live_resolve_enabled=True, **_ctx(primary=primary))
+    assert "8001" not in out_on
+    # Both base_url lines (model: and providers.custom:) point at the gateway.
+    assert out_on.count('base_url: "http://127.0.0.1:8080/v1"') >= 2
+
+    # Sanity: with the flag OFF the same primary DOES surface its 8001 URL.
+    out_off = _render_config_yaml(live_resolve_enabled=False, **_ctx(primary=primary))
+    assert "8001" in out_off

--- a/tests/api/test_chat_normalization.py
+++ b/tests/api/test_chat_normalization.py
@@ -1,0 +1,221 @@
+from types import SimpleNamespace
+
+import pytest
+
+from hal0.api.routes import v1
+
+
+class _Health:
+    def __init__(self, loaded):
+        self.loaded_models = tuple(loaded)
+
+
+class _Shim:
+    def __init__(self, loaded):
+        self._health = _Health(loaded)
+
+
+class _SlotManager:
+    def __init__(self, cfgs):
+        self._cfgs = cfgs
+
+    async def iter_configs(self):
+        return self._cfgs
+
+
+class _Upstreams:
+    def __init__(self, ups):
+        self._ups = ups
+
+    def list(self):
+        return self._ups
+
+
+def _make_request(*, cfgs=None, loaded=None, upstreams=None, upstream_models=None):
+    state = SimpleNamespace(
+        slot_manager=_SlotManager(cfgs or []),
+        lemonade_metrics_shim=_Shim(loaded or set()),
+        upstreams=_Upstreams(upstreams or []),
+        upstream_models=upstream_models or {},
+    )
+    return SimpleNamespace(app=SimpleNamespace(state=state), _body=b"")
+
+
+_PRIMARY = [
+    {
+        "name": "primary",
+        "type": "llm",
+        "enabled": True,
+        "device": "gpu-vulkan",
+        "role": None,
+        "model": {"default": "big", "context_size": 4096},
+    }
+]
+
+
+@pytest.mark.asyncio
+async def test_virtual_name_resolved_and_thinking_injected():
+    req = _make_request(cfgs=_PRIMARY, loaded={"big"})
+    out = await v1._normalize_chat_body(req, {"model": "hal0/primary", "messages": []})
+    assert out["model"] == "big"
+    assert out["enable_thinking"] is False
+
+
+@pytest.mark.asyncio
+async def test_physical_model_passthrough_still_gets_thinking():
+    req = _make_request(cfgs=_PRIMARY, loaded={"big"})
+    out = await v1._normalize_chat_body(req, {"model": "big", "messages": []})
+    assert out["model"] == "big"  # non-virtual -> not rewritten
+    assert out["enable_thinking"] is False
+
+
+@pytest.mark.asyncio
+async def test_remote_model_not_thinking_injected():
+    req = _make_request(
+        upstreams=[SimpleNamespace(name="or", kind="remote")],
+        upstream_models={"or": ["gpt-x"]},
+    )
+    out = await v1._normalize_chat_body(req, {"model": "gpt-x", "messages": []})
+    assert "enable_thinking" not in out
+
+
+@pytest.mark.asyncio
+async def test_caller_opted_thinking_preserved():
+    req = _make_request(cfgs=_PRIMARY, loaded={"big"})
+    out = await v1._normalize_chat_body(req, {"model": "hal0/primary", "enable_thinking": True})
+    assert out["enable_thinking"] is True
+
+
+@pytest.mark.asyncio
+async def test_request_body_rewritten_for_proxy_fallthrough():
+    import json
+
+    req = _make_request(cfgs=_PRIMARY, loaded={"big"})
+    await v1._normalize_chat_body(req, {"model": "hal0/primary", "messages": []})
+    # the proxy fall-through reads request._body, so it must carry the normalized body
+    assert json.loads(req._body)["model"] == "big"
+    assert json.loads(req._body)["enable_thinking"] is False
+
+
+class _Headers:
+    def get(self, key, default=None):
+        # No content-type → _read_json_body takes the JSON path.
+        return default
+
+
+class _OmniRequest:
+    """Request that flows through chat_completions -> _read_json_body -> omni branch."""
+
+    def __init__(self, raw: bytes):
+        self._raw = raw
+        self.headers = _Headers()
+        state = SimpleNamespace(
+            slot_manager=_SlotManager(_PRIMARY),
+            lemonade_metrics_shim=_Shim({"big"}),
+            upstreams=_Upstreams([]),
+            upstream_models={},
+        )
+        self.app = SimpleNamespace(state=state)
+
+    async def body(self):
+        return self._raw
+
+
+@pytest.mark.asyncio
+async def test_omni_path_receives_normalized_body(monkeypatch):
+    """The omni branch returns before _dispatch_and_forward, so chat_completions
+    must normalize BEFORE the omni gate. Prove the body handed to the OmniRouter
+    has the virtual name resolved + thinking injected."""
+    import json
+
+    from starlette.responses import JSONResponse
+
+    from hal0.normalize.resolver import SlotView
+
+    # Pin the resolver inputs so resolution is deterministic regardless of
+    # alias-map internals: hal0/primary -> "big" (loaded on gpu-vulkan).
+    async def _fake_views(request):
+        return [
+            SlotView(
+                name="primary",
+                role=None,
+                device="gpu-vulkan",
+                model_id="big",
+                context_length=4096,
+            )
+        ]
+
+    monkeypatch.setattr(v1, "_normalize_slot_views", _fake_views)
+    monkeypatch.setattr(v1, "_normalize_loaded_models", lambda request: {"big"})
+
+    seen = {}
+
+    async def _fake_omni(request, body):
+        seen["body"] = body
+        return JSONResponse({"ok": True})
+
+    monkeypatch.setattr(v1, "_maybe_run_omni_loop", _fake_omni)
+
+    raw = json.dumps({"model": "hal0/primary", "omni": True, "messages": []}).encode("utf-8")
+    req = _OmniRequest(raw)
+
+    resp = await v1.chat_completions(req, dispatcher=None)
+
+    assert resp.status_code == 200
+    assert seen["body"]["model"] == "big"
+    assert seen["body"]["enable_thinking"] is False
+
+
+# Single-gate invariant: _normalize_chat_body is called in exactly ONE place
+# (chat_completions, before the omni branch) and NOT in _dispatch_and_forward.
+# _dispatch_and_forward also serves the non-chat endpoints — /v1/completions,
+# /v1/embeddings, /v1/rerankings, and the multipart /v1/audio/transcriptions —
+# where an unconditional request._body = json(body) rewrite would corrupt the
+# multipart upload or inject a meaningless enable_thinking. Normalization is a
+# chat-only concern (virtual hal0/* names + thinking policy), so it must stay
+# out of the shared dispatch helper.
+
+
+class _NonChatRequest:
+    def __init__(self):
+        self.headers = _Headers()
+        self.url = SimpleNamespace(path="/v1/embeddings")
+        state = SimpleNamespace(
+            slot_manager=None,
+            last_used_model={},
+            tps_events=None,
+            ttft_events=None,
+        )
+        self.app = SimpleNamespace(state=state)
+
+    async def body(self):
+        return b""
+
+
+class _FakeDispatcher:
+    async def dispatch(self, request, body=None):
+        return SimpleNamespace(upstream_name="embed", resolved_model="bge")
+
+    async def forward(self, call):
+        from fastapi.responses import Response as _Resp
+
+        return _Resp(content=b"", media_type="application/json")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_and_forward_does_not_normalize_non_chat(monkeypatch):
+    """_dispatch_and_forward must NOT invoke _normalize_chat_body — that would
+    rewrite request._body and break embeddings/rerank/multipart-audio."""
+    called = {"flag": False}
+
+    async def _spy(request, body):
+        called["flag"] = True
+        return body
+
+    monkeypatch.setattr(v1, "_normalize_chat_body", _spy)
+
+    req = _NonChatRequest()
+    body = {"model": "bge", "input": "hello"}
+    await v1._dispatch_and_forward(req, _FakeDispatcher(), body=body)
+
+    assert called["flag"] is False, "_dispatch_and_forward must not normalize non-chat requests"

--- a/tests/api/test_chat_normalization.py
+++ b/tests/api/test_chat_normalization.py
@@ -203,6 +203,32 @@ class _FakeDispatcher:
 
 
 @pytest.mark.asyncio
+async def test_chat_template_kwargs_opt_out_through_seam():
+    req = _make_request(cfgs=_PRIMARY, loaded={"big"})
+    out = await v1._normalize_chat_body(
+        req, {"model": "hal0/primary", "chat_template_kwargs": {"enable_thinking": True}}
+    )
+    assert "enable_thinking" not in out
+    assert out["chat_template_kwargs"] == {"enable_thinking": True}
+
+
+def test_normalize_loaded_models_uses_cache_no_rpc():
+    class _RaisingShim:
+        def __init__(self, loaded):
+            self._health = _Health(loaded)
+
+        async def health(self):  # if this were called, the test would fail
+            raise AssertionError("must not poll lemond")
+
+    from types import SimpleNamespace
+
+    req = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(lemonade_metrics_shim=_RaisingShim({"big"})))
+    )
+    assert v1._normalize_loaded_models(req) == {"big"}
+
+
+@pytest.mark.asyncio
 async def test_dispatch_and_forward_does_not_normalize_non_chat(monkeypatch):
     """_dispatch_and_forward must NOT invoke _normalize_chat_body — that would
     rewrite request._body and break embeddings/rerank/multipart-audio."""

--- a/tests/api/test_llm_slot_views.py
+++ b/tests/api/test_llm_slot_views.py
@@ -1,0 +1,43 @@
+import pytest
+
+from hal0.api import hal0_llm_slot_views
+
+
+class _FakeSlotManager:
+    def __init__(self, cfgs):
+        self._cfgs = cfgs
+
+    async def iter_configs(self):
+        return self._cfgs
+
+
+@pytest.mark.asyncio
+async def test_llm_slot_views_filters_and_projects():
+    cfgs = [
+        {
+            "name": "primary",
+            "type": "llm",
+            "enabled": True,
+            "device": "gpu-vulkan",
+            "role": None,
+            "model": {"default": "big", "context_size": 65536},
+        },
+        {
+            "name": "utility",
+            "type": "llm",
+            "enabled": True,
+            "device": "gpu-vulkan",
+            "role": "utility",
+            "model": {"default": "tiny", "context_size": 8192},
+        },
+        {"name": "embed", "type": "embedding", "enabled": True, "model": {"default": "e5"}},
+        {"name": "off", "type": "llm", "enabled": False, "model": {"default": "x"}},
+        {"name": "nomodel", "type": "llm", "enabled": True, "model": {}},
+    ]
+    views = await hal0_llm_slot_views(_FakeSlotManager(cfgs))
+    by_name = {v["name"]: v for v in views}
+    assert set(by_name) == {"primary", "utility"}
+    assert by_name["primary"]["device"] == "gpu-vulkan"
+    assert by_name["primary"]["context_length"] == 65536
+    assert by_name["utility"]["role"] == "utility"
+    assert by_name["utility"]["context_length"] == 8192

--- a/tests/api/test_llm_slot_views.py
+++ b/tests/api/test_llm_slot_views.py
@@ -30,14 +30,24 @@ async def test_llm_slot_views_filters_and_projects():
             "role": "utility",
             "model": {"default": "tiny", "context_size": 8192},
         },
+        {
+            "name": "agent",
+            "type": "llm",
+            "enabled": True,
+            "device": "npu",
+            "role": None,
+            "model": {"default": "flm", "ctx_size": 32768},
+        },
         {"name": "embed", "type": "embedding", "enabled": True, "model": {"default": "e5"}},
         {"name": "off", "type": "llm", "enabled": False, "model": {"default": "x"}},
         {"name": "nomodel", "type": "llm", "enabled": True, "model": {}},
     ]
     views = await hal0_llm_slot_views(_FakeSlotManager(cfgs))
     by_name = {v["name"]: v for v in views}
-    assert set(by_name) == {"primary", "utility"}
+    assert set(by_name) == {"primary", "utility", "agent"}
     assert by_name["primary"]["device"] == "gpu-vulkan"
     assert by_name["primary"]["context_length"] == 65536
     assert by_name["utility"]["role"] == "utility"
     assert by_name["utility"]["context_length"] == 8192
+    # ctx_size key (not context_size) must also be read correctly
+    assert by_name["agent"]["context_length"] == 32768

--- a/tests/api/test_virtual_models.py
+++ b/tests/api/test_virtual_models.py
@@ -1,0 +1,47 @@
+"""GET /v1/models advertises hal0/* virtual names with context_length.
+
+Verifies that the list_models handler appends rows for each canonical
+virtual name (hal0/primary, hal0/npu, hal0/utility) when a slot is
+loaded, and that each row carries a context_length field (required by
+Hermes' custom provider for correct context-window sizing).
+"""
+
+from __future__ import annotations
+
+from hal0.normalize import resolver as R
+
+
+def _views():
+    return [
+        R.SlotView(
+            name="primary", role=None, device="gpu-vulkan", model_id="big", context_length=65536
+        )
+    ]
+
+
+def test_virtual_names_present_with_context_length(client, monkeypatch):
+    async def fake_views(request):
+        return _views()
+
+    monkeypatch.setattr("hal0.api.routes.v1._normalize_slot_views", fake_views)
+    monkeypatch.setattr("hal0.api.routes.v1._normalize_loaded_models", lambda request: {"big"})
+
+    data = client.get("/v1/models").json()["data"]
+    by_id = {row["id"]: row for row in data}
+    assert "hal0/primary" in by_id
+    row = by_id["hal0/primary"]
+    assert row["context_length"] == 65536  # FIRST key in Hermes' context precedence
+    assert row["_hal0"]["virtual"] is True
+    assert row["_hal0"]["resolves_to"] == "big"
+    assert row["_hal0"]["device"] == "gpu-vulkan"
+
+
+def test_virtual_rows_do_not_duplicate(client, monkeypatch):
+    async def fake_views(request):
+        return _views()
+
+    monkeypatch.setattr("hal0.api.routes.v1._normalize_slot_views", fake_views)
+    monkeypatch.setattr("hal0.api.routes.v1._normalize_loaded_models", lambda request: {"big"})
+
+    ids = [r["id"] for r in client.get("/v1/models").json()["data"]]
+    assert ids.count("hal0/primary") == 1

--- a/tests/api/test_virtual_models.py
+++ b/tests/api/test_virtual_models.py
@@ -45,3 +45,22 @@ def test_virtual_rows_do_not_duplicate(client, monkeypatch):
 
     ids = [r["id"] for r in client.get("/v1/models").json()["data"]]
     assert ids.count("hal0/primary") == 1
+
+
+def test_all_canonical_virtual_names_advertised_with_fallback(client, monkeypatch):
+    async def fake_views(request):
+        return _views()
+
+    monkeypatch.setattr("hal0.api.routes.v1._normalize_slot_views", fake_views)
+    monkeypatch.setattr("hal0.api.routes.v1._normalize_loaded_models", lambda request: {"big"})
+
+    payload = client.get("/v1/models").json()
+    assert payload["object"] == "list"
+    by_id = {r["id"]: r for r in payload["data"]}
+    # all three appear; npu/utility fall back to the primary's model on a primary-only box
+    assert {"hal0/primary", "hal0/npu", "hal0/utility"}.issubset(by_id)
+    assert by_id["hal0/npu"]["_hal0"]["resolves_to"] == "big"
+    assert by_id["hal0/utility"]["_hal0"]["resolves_to"] == "big"
+    # every virtual row carries a context_length (mandatory for Hermes)
+    for vid in ("hal0/primary", "hal0/npu", "hal0/utility"):
+        assert by_id[vid]["context_length"] == 65536

--- a/tests/config/test_slot_role.py
+++ b/tests/config/test_slot_role.py
@@ -1,0 +1,18 @@
+from hal0.config.schema import SlotConfig
+
+
+def _base(**over):
+    data = {"name": "utility", "port": 8081, "model": {"default": "tiny.gguf"}}
+    data.update(over)
+    return data
+
+
+def test_role_defaults_to_none():
+    cfg = SlotConfig.model_validate(_base())
+    assert cfg.role is None
+
+
+def test_role_round_trips():
+    cfg = SlotConfig.model_validate(_base(role="utility"))
+    assert cfg.role == "utility"
+    assert SlotConfig.model_validate(cfg.model_dump()).role == "utility"

--- a/tests/normalize/test_resolver.py
+++ b/tests/normalize/test_resolver.py
@@ -1,8 +1,6 @@
-import pytest
-
 from hal0.normalize.resolver import (
-    SlotView,
     DEFAULT_CHAINS,
+    SlotView,
     is_npu_or_flm,
     resolve_chain,
 )
@@ -10,9 +8,19 @@ from hal0.normalize.resolver import (
 
 def _slots():
     return [
-        SlotView(name="primary", role=None, device="gpu-vulkan", model_id="big-35b", context_length=65536),
-        SlotView(name="utility", role=None, device="gpu-vulkan", model_id="tiny-0.8b", context_length=65536),
-        SlotView(name="agent",   role=None, device="npu",        model_id="qwen3-4b-FLM", context_length=32768),
+        SlotView(
+            name="primary", role=None, device="gpu-vulkan", model_id="big-35b", context_length=65536
+        ),
+        SlotView(
+            name="utility",
+            role=None,
+            device="gpu-vulkan",
+            model_id="tiny-0.8b",
+            context_length=65536,
+        ),
+        SlotView(
+            name="agent", role=None, device="npu", model_id="qwen3-4b-FLM", context_length=32768
+        ),
     ]
 
 
@@ -38,12 +46,21 @@ def test_npu_falls_to_utility_before_primary():
 def test_utility_chain_order():
     r = resolve_chain("hal0/utility", _slots(), loaded={"qwen3-4b-FLM", "big-35b"})
     assert r.model_id == "qwen3-4b-FLM"
+    assert r.matched_role == "npu"
 
 
 def test_role_tag_overrides_name():
     slots = [
-        SlotView(name="coder-mini", role="utility", device="gpu-vulkan", model_id="cm", context_length=8192),
-        SlotView(name="primary", role=None, device="gpu-vulkan", model_id="big", context_length=65536),
+        SlotView(
+            name="coder-mini",
+            role="utility",
+            device="gpu-vulkan",
+            model_id="cm",
+            context_length=8192,
+        ),
+        SlotView(
+            name="primary", role=None, device="gpu-vulkan", model_id="big", context_length=65536
+        ),
     ]
     r = resolve_chain("hal0/utility", slots, loaded={"cm"})
     assert r.model_id == "cm"
@@ -63,6 +80,13 @@ def test_flm_alias_resolves_same_as_npu():
 def test_is_npu_or_flm_name_heuristic():
     assert is_npu_or_flm("qwen3-4b-FLM") is True
     assert is_npu_or_flm("big-35b") is False
+
+
+def test_empty_slots_degrades_to_blank_resolution():
+    r = resolve_chain("hal0/primary", [], loaded=set())
+    assert r is not None
+    assert r.model_id == ""
+    assert r.fallback is True
 
 
 def test_unknown_virtual_name_returns_none():

--- a/tests/normalize/test_resolver.py
+++ b/tests/normalize/test_resolver.py
@@ -3,7 +3,6 @@ import pytest
 from hal0.normalize.resolver import (
     DEFAULT_CHAINS,
     SlotView,
-    is_npu_or_flm,
     resolve_chain,
 )
 
@@ -77,11 +76,6 @@ def test_full_miss_falls_back_to_configured_primary_unloaded():
 def test_flm_alias_resolves_same_as_npu():
     r = resolve_chain("hal0/flm", _slots(), loaded={"qwen3-4b-FLM"})
     assert r.model_id == "qwen3-4b-FLM"
-
-
-def test_is_npu_or_flm_name_heuristic():
-    assert is_npu_or_flm("qwen3-4b-FLM") is True
-    assert is_npu_or_flm("big-35b") is False
 
 
 def test_empty_slots_degrades_to_blank_resolution():

--- a/tests/normalize/test_resolver.py
+++ b/tests/normalize/test_resolver.py
@@ -1,3 +1,5 @@
+import pytest
+
 from hal0.normalize.resolver import (
     DEFAULT_CHAINS,
     SlotView,
@@ -97,3 +99,25 @@ def test_default_chains_shape():
     assert DEFAULT_CHAINS["hal0/primary"] == ("primary",)
     assert DEFAULT_CHAINS["hal0/npu"] == ("npu", "utility", "primary")
     assert DEFAULT_CHAINS["hal0/utility"] == ("utility", "npu", "primary")
+
+
+@pytest.mark.asyncio
+async def test_live_resolver_reads_views_and_health():
+    from hal0.normalize.resolver import LiveSlotResolver, SlotView
+
+    views = [
+        SlotView(
+            name="primary", role=None, device="gpu-vulkan", model_id="big", context_length=65536
+        ),
+        SlotView(
+            name="utility", role=None, device="gpu-vulkan", model_id="tiny", context_length=65536
+        ),
+    ]
+    resolver = LiveSlotResolver(
+        slot_views_provider=lambda: views,
+        loaded_models_provider=lambda: {"tiny", "big"},
+    )
+    res = await resolver.resolve("hal0/utility")
+    assert res.model_id == "tiny"
+    # passthrough: non-virtual names return None so the caller leaves the body alone
+    assert await resolver.resolve("some-physical-model") is None

--- a/tests/normalize/test_resolver.py
+++ b/tests/normalize/test_resolver.py
@@ -1,0 +1,75 @@
+import pytest
+
+from hal0.normalize.resolver import (
+    SlotView,
+    DEFAULT_CHAINS,
+    is_npu_or_flm,
+    resolve_chain,
+)
+
+
+def _slots():
+    return [
+        SlotView(name="primary", role=None, device="gpu-vulkan", model_id="big-35b", context_length=65536),
+        SlotView(name="utility", role=None, device="gpu-vulkan", model_id="tiny-0.8b", context_length=65536),
+        SlotView(name="agent",   role=None, device="npu",        model_id="qwen3-4b-FLM", context_length=32768),
+    ]
+
+
+def test_primary_prefers_igpu_when_loaded():
+    r = resolve_chain("hal0/primary", _slots(), loaded={"big-35b", "qwen3-4b-FLM"})
+    assert r.model_id == "big-35b"
+    assert r.context_length == 65536
+    assert r.fallback is False
+
+
+def test_npu_picks_npu_first_never_commandeers_primary():
+    r = resolve_chain("hal0/npu", _slots(), loaded={"qwen3-4b-FLM", "big-35b"})
+    assert r.model_id == "qwen3-4b-FLM"
+    assert r.matched_role == "npu"
+
+
+def test_npu_falls_to_utility_before_primary():
+    r = resolve_chain("hal0/npu", _slots(), loaded={"tiny-0.8b", "big-35b"})
+    assert r.model_id == "tiny-0.8b"
+    assert r.matched_role == "utility"
+
+
+def test_utility_chain_order():
+    r = resolve_chain("hal0/utility", _slots(), loaded={"qwen3-4b-FLM", "big-35b"})
+    assert r.model_id == "qwen3-4b-FLM"
+
+
+def test_role_tag_overrides_name():
+    slots = [
+        SlotView(name="coder-mini", role="utility", device="gpu-vulkan", model_id="cm", context_length=8192),
+        SlotView(name="primary", role=None, device="gpu-vulkan", model_id="big", context_length=65536),
+    ]
+    r = resolve_chain("hal0/utility", slots, loaded={"cm"})
+    assert r.model_id == "cm"
+
+
+def test_full_miss_falls_back_to_configured_primary_unloaded():
+    r = resolve_chain("hal0/utility", _slots(), loaded=set())
+    assert r.model_id == "big-35b"
+    assert r.fallback is True
+
+
+def test_flm_alias_resolves_same_as_npu():
+    r = resolve_chain("hal0/flm", _slots(), loaded={"qwen3-4b-FLM"})
+    assert r.model_id == "qwen3-4b-FLM"
+
+
+def test_is_npu_or_flm_name_heuristic():
+    assert is_npu_or_flm("qwen3-4b-FLM") is True
+    assert is_npu_or_flm("big-35b") is False
+
+
+def test_unknown_virtual_name_returns_none():
+    assert resolve_chain("hal0/nope", _slots(), loaded={"big-35b"}) is None
+
+
+def test_default_chains_shape():
+    assert DEFAULT_CHAINS["hal0/primary"] == ("primary",)
+    assert DEFAULT_CHAINS["hal0/npu"] == ("npu", "utility", "primary")
+    assert DEFAULT_CHAINS["hal0/utility"] == ("utility", "npu", "primary")

--- a/tests/normalize/test_thinking.py
+++ b/tests/normalize/test_thinking.py
@@ -1,0 +1,44 @@
+from hal0.normalize.thinking import apply_thinking_policy
+
+
+def test_injects_top_level_enable_thinking_false_by_default():
+    out = apply_thinking_policy({"model": "m", "messages": []})
+    assert out["enable_thinking"] is False
+
+
+def test_opt_out_enable_thinking_preserved():
+    out = apply_thinking_policy({"enable_thinking": True})
+    assert out["enable_thinking"] is True
+
+
+def test_opt_out_thinking_field_preserved():
+    out = apply_thinking_policy({"thinking": {"type": "enabled"}})
+    assert "enable_thinking" not in out
+    assert out["thinking"] == {"type": "enabled"}
+
+
+def test_opt_out_chat_template_kwargs_preserved():
+    body = {"chat_template_kwargs": {"enable_thinking": True}}
+    out = apply_thinking_policy(body)
+    assert "enable_thinking" not in out
+    assert out["chat_template_kwargs"] == {"enable_thinking": True}
+
+
+def test_no_think_marker_passthrough_untouched():
+    body = {"messages": [{"role": "user", "content": "/no_think hi"}], "no_think": True}
+    out = apply_thinking_policy(body)
+    assert out["no_think"] is True
+    # we still inject the structured field (lemond honors top-level enable_thinking)
+    assert out["enable_thinking"] is False
+
+
+def test_idempotent():
+    once = apply_thinking_policy({"model": "m"})
+    twice = apply_thinking_policy(once)
+    assert once == twice
+
+
+def test_does_not_mutate_input():
+    src = {"model": "m"}
+    apply_thinking_policy(src)
+    assert "enable_thinking" not in src


### PR DESCRIPTION
## Summary
Implements the lemond-normalization design (spec + plan on `main`) inside hal0-api, so every agent gets, on the chat path:
- **Live-slot model resolution** — `hal0/primary` | `hal0/npu` (alias `hal0/flm`) | `hal0/utility` resolve to whichever LLM slot is loaded, via ordered role chains. Hardware axis from each slot's `device`; primary/utility roles from a new optional `SlotConfig.role` (falls back to slot name). NPU/utility work never commandeers/evicts the iGPU primary. Reads the **cached** `MetricsShim._health` snapshot — **no new lemond poll** (respects #474/#475).
- **Reasoning suppression** — top-level `enable_thinking:false` injected for lemond-bound chat requests unless the caller opted in; skipped for remote/cloud upstreams.
- **`/v1/models` advertisement** — virtual names advertised with `context_length` (mandatory; resolved via `_slot_ctx_size` so `ctx_size`/`context_size` both work) + a `_hal0` annotation, so Hermes' `/model` picker discovers them.
- **Hermes render flag** — `model.default: hal0/primary` only when `HAL0_HERMES_LIVE_RESOLVE=1` (gated cutover); stays `provider: custom` + `base_url: :8080/v1`.

Single-gate invariant: normalization runs exactly once in `chat_completions` (before the omni branch), and **not** on the shared `_dispatch_and_forward` path used by embeddings/rerank/audio-multipart.

Closes #476
Closes #477
Closes #478
Closes #479

(#480 Hermes cutover and #481 retire-Bifrost are HITL/operational follow-ups, not in this PR.)

## Test Plan
- [x] Unit: resolver chain matrix (role+device, fallback, protect-primary), thinking opt-out/idempotency/no_think, `SlotConfig.role`, `hal0_llm_slot_views` (incl. `ctx_size`-only slot)
- [x] Integration: chat-path resolve+thinking, omni-path normalized, non-chat endpoints NOT normalized, `/v1/models` virtual rows, Hermes render both flag states
- [x] 36 feature tests green; repo-wide `ruff check` + `ruff format --check` clean
- [ ] CT105 smoke (curl `/v1/models` + `model: hal0/primary`) — part of #480 rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)