### PR TITLE
fix(normalize): suppress thinking via chat_template_kwargs, not top-level enable_thinking

### DIFF
--- a/src/hal0/normalize/thinking.py
+++ b/src/hal0/normalize/thinking.py
@@ -1,9 +1,19 @@
 """Reasoning-suppression policy for lemond-bound chat requests.
 
-lemond (SHA 1bce071) reads TOP-LEVEL ``enable_thinking``/``thinking`` and does its
-own ``/no_think`` injection (server.cpp:58-114). We inject top-level
-``enable_thinking: false`` unless the caller already expressed a thinking
-preference. Idempotent and non-mutating.
+We inject ``chat_template_kwargs.enable_thinking = false`` unless the caller
+already expressed a thinking preference. This is the Qwen3-family lever the
+jinja chat template honors (llama-server runs with ``--jinja``): the template
+emits an empty ``<think></think>`` so the model skips reasoning entirely.
+
+Why NOT the top-level ``enable_thinking``: lemond translates a top-level
+``enable_thinking: false`` into a ``/no_think`` *prompt* injection
+(server.cpp:58-114). Abliterated / "aggressive" Qwen3 fine-tunes (e.g. the
+qwen3.6-35b-a3b-uncensored primary) ignore that soft marker, emit an unbounded
+reasoning block, and never produce ``content`` (verified live: empty content,
+finish_reason=length). The chat-template kwarg is applied by the template
+itself, so suppression no longer depends on the model obeying an instruction.
+
+Idempotent and non-mutating.
 """
 
 from __future__ import annotations
@@ -19,9 +29,11 @@ def _caller_opted(body: dict[str, Any]) -> bool:
 
 
 def apply_thinking_policy(body: dict[str, Any]) -> dict[str, Any]:
-    """Return a copy of ``body`` with ``enable_thinking: false`` injected unless
-    the caller already set a thinking control field. A ``no_think`` prompt marker
+    """Return a copy of ``body`` with ``chat_template_kwargs.enable_thinking: false``
+    injected unless the caller already set a thinking control field. Any other
+    ``chat_template_kwargs`` entries are preserved. A ``no_think`` prompt marker
     is left untouched (passthrough)."""
     if _caller_opted(body):
         return body
-    return {**body, "enable_thinking": False}
+    ctk = {**(body.get("chat_template_kwargs") or {}), "enable_thinking": False}
+    return {**body, "chat_template_kwargs": ctk}

--- a/tests/api/test_chat_normalization.py
+++ b/tests/api/test_chat_normalization.py
@@ -58,7 +58,7 @@ async def test_virtual_name_resolved_and_thinking_injected():
     req = _make_request(cfgs=_PRIMARY, loaded={"big"})
     out = await v1._normalize_chat_body(req, {"model": "hal0/primary", "messages": []})
     assert out["model"] == "big"
-    assert out["enable_thinking"] is False
+    assert out["chat_template_kwargs"]["enable_thinking"] is False
 
 
 @pytest.mark.asyncio
@@ -66,7 +66,7 @@ async def test_physical_model_passthrough_still_gets_thinking():
     req = _make_request(cfgs=_PRIMARY, loaded={"big"})
     out = await v1._normalize_chat_body(req, {"model": "big", "messages": []})
     assert out["model"] == "big"  # non-virtual -> not rewritten
-    assert out["enable_thinking"] is False
+    assert out["chat_template_kwargs"]["enable_thinking"] is False
 
 
 @pytest.mark.asyncio
@@ -94,7 +94,7 @@ async def test_request_body_rewritten_for_proxy_fallthrough():
     await v1._normalize_chat_body(req, {"model": "hal0/primary", "messages": []})
     # the proxy fall-through reads request._body, so it must carry the normalized body
     assert json.loads(req._body)["model"] == "big"
-    assert json.loads(req._body)["enable_thinking"] is False
+    assert json.loads(req._body)["chat_template_kwargs"]["enable_thinking"] is False
 
 
 class _Headers:
@@ -163,7 +163,7 @@ async def test_omni_path_receives_normalized_body(monkeypatch):
 
     assert resp.status_code == 200
     assert seen["body"]["model"] == "big"
-    assert seen["body"]["enable_thinking"] is False
+    assert seen["body"]["chat_template_kwargs"]["enable_thinking"] is False
 
 
 # Single-gate invariant: _normalize_chat_body is called in exactly ONE place

--- a/tests/normalize/test_thinking.py
+++ b/tests/normalize/test_thinking.py
@@ -1,35 +1,42 @@
 from hal0.normalize.thinking import apply_thinking_policy
 
 
-def test_injects_top_level_enable_thinking_false_by_default():
+def test_injects_chat_template_kwargs_enable_thinking_false_by_default():
     out = apply_thinking_policy({"model": "m", "messages": []})
-    assert out["enable_thinking"] is False
+    assert out["chat_template_kwargs"]["enable_thinking"] is False
+    # never sets the top-level field (lemond would /no_think-inject, ineffective)
+    assert "enable_thinking" not in out
 
 
 def test_opt_out_enable_thinking_preserved():
     out = apply_thinking_policy({"enable_thinking": True})
     assert out["enable_thinking"] is True
+    assert "chat_template_kwargs" not in out
 
 
 def test_opt_out_thinking_field_preserved():
     out = apply_thinking_policy({"thinking": {"type": "enabled"}})
-    assert "enable_thinking" not in out
+    assert "chat_template_kwargs" not in out
     assert out["thinking"] == {"type": "enabled"}
 
 
 def test_opt_out_chat_template_kwargs_preserved():
     body = {"chat_template_kwargs": {"enable_thinking": True}}
     out = apply_thinking_policy(body)
-    assert "enable_thinking" not in out
     assert out["chat_template_kwargs"] == {"enable_thinking": True}
+
+
+def test_preserves_sibling_chat_template_kwargs():
+    out = apply_thinking_policy({"chat_template_kwargs": {"add_generation_prompt": True}})
+    assert out["chat_template_kwargs"]["add_generation_prompt"] is True
+    assert out["chat_template_kwargs"]["enable_thinking"] is False
 
 
 def test_no_think_marker_passthrough_untouched():
     body = {"messages": [{"role": "user", "content": "/no_think hi"}], "no_think": True}
     out = apply_thinking_policy(body)
     assert out["no_think"] is True
-    # we still inject the structured field (lemond honors top-level enable_thinking)
-    assert out["enable_thinking"] is False
+    assert out["chat_template_kwargs"]["enable_thinking"] is False
 
 
 def test_idempotent():
@@ -41,4 +48,4 @@ def test_idempotent():
 def test_does_not_mutate_input():
     src = {"model": "m"}
     apply_thinking_policy(src)
-    assert "enable_thinking" not in src
+    assert "chat_template_kwargs" not in src


### PR DESCRIPTION
## Problem

`normalize/thinking.py` injected a **top-level `enable_thinking: false`**. lemond translates that into a `/no_think` *prompt* injection (`server.cpp:58-114`). Abliterated / "aggressive" Qwen3 fine-tunes — including the live `qwen3.6-35b-a3b-uncensored` primary — **ignore that soft marker**, emit an unbounded reasoning block, and never produce `content`.

Verified live (before fix): `content: ""`, `finish_reason: length`, full reasoning dump. This would break the #480 Hermes local-primary cutover (empty responses / think-timeouts).

## Fix

Inject **`chat_template_kwargs.enable_thinking = false`** instead. llama-server runs with `--jinja`, so the Qwen3 template itself emits an empty `<think></think>` — suppression no longer depends on the model obeying an instruction.

Verified live (after fix), default path (no caller kwargs, exactly what Hermes sends):
- `content: "PONG"`, no `reasoning_content`, `finish_reason: stop`, **0.85s**

Tested variants on the loaded model to confirm root cause:
| Method | Result |
|---|---|
| top-level `enable_thinking:false` (old) | ❌ empty content, runaway reasoning |
| **`chat_template_kwargs.enable_thinking:false` (new)** | ✅ clean `content`, no reasoning |
| both | ❌ worse — `/no_think` pollution + raw `<think>` leak |

## Notes

- Sibling `chat_template_kwargs` entries preserved; all caller opt-outs still short-circuit.
- Tests updated — `tests/normalize/test_thinking.py` + `tests/api/test_chat_normalization.py`, 28 pass. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)