### PR TITLE
feat(api): working enable_thinking — top-level translation + per-slot default

### DIFF
--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -329,6 +329,26 @@ def _is_remote_model(request: Request, model_id: str) -> bool:
     return False
 
 
+async def _slot_thinking_default(request: Request, model_id: str) -> bool:
+    """Per-slot reasoning default: the ``enable_thinking`` flag of the slot whose
+    default model is ``model_id``. Falls back to False (global suppression) when
+    no slot sets it. Always overridable per request."""
+    sm = getattr(request.app.state, "slot_manager", None)
+    if sm is None:
+        return False
+    try:
+        for cfg in await sm.iter_configs():
+            if not isinstance(cfg, dict):
+                continue
+            model = cfg.get("model")
+            default_model = model.get("default") if isinstance(model, dict) else None
+            if default_model == model_id and cfg.get("enable_thinking") is not None:
+                return bool(cfg["enable_thinking"])
+    except Exception:
+        return False
+    return False
+
+
 async def _normalize_chat_body(request: Request, body: dict[str, Any]) -> dict[str, Any]:
     """Resolve hal0/* virtual model names + inject thinking policy for lemond-bound calls.
 
@@ -351,7 +371,8 @@ async def _normalize_chat_body(request: Request, body: dict[str, Any]) -> dict[s
 
     model_id = body.get("model")
     if isinstance(model_id, str) and not _is_remote_model(request, model_id):
-        body = apply_thinking_policy(body)
+        default_thinking = await _slot_thinking_default(request, model_id)
+        body = apply_thinking_policy(body, default_thinking=default_thinking)
 
     import contextlib
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -250,6 +250,15 @@ class SlotConfig(BaseModel):
             "from the slot name. Authoritative over the name when set."
         ),
     )
+    enable_thinking: bool | None = Field(
+        default=None,
+        description=(
+            "Per-slot reasoning default. true → requests routed to this slot "
+            "default to thinking ON; false → OFF; None → global default "
+            "(suppressed). Always overridable per request via top-level "
+            "enable_thinking / chat_template_kwargs. See normalize/thinking.py."
+        ),
+    )
 
     # [model] section (nested)
     model: ModelConfig = Field(default_factory=ModelConfig)

--- a/src/hal0/normalize/thinking.py
+++ b/src/hal0/normalize/thinking.py
@@ -46,14 +46,17 @@ def _caller_intent(body: dict[str, Any]) -> bool | None:
     return None
 
 
-def apply_thinking_policy(body: dict[str, Any]) -> dict[str, Any]:
+def apply_thinking_policy(
+    body: dict[str, Any], *, default_thinking: bool = False
+) -> dict[str, Any]:
     """Return a copy of ``body`` whose reasoning is steered via
     ``chat_template_kwargs.enable_thinking``.
 
     A top-level boolean ``enable_thinking`` / ``thinking`` is translated into the
     chat-template kwarg (Qwen3's working lever) and stripped, so a caller asking
     for ``enable_thinking: false`` actually gets no reasoning. Absent any caller
-    preference, reasoning is suppressed by default."""
+    preference, reasoning defaults to ``default_thinking`` — the per-slot default
+    (slot TOML ``enable_thinking``), falling back to suppression (False)."""
     # Caller used the precise lever already — respect it verbatim.
     if _explicit_kwarg_set(body):
         return body
@@ -63,7 +66,7 @@ def apply_thinking_policy(body: dict[str, Any]) -> dict[str, Any]:
         return body
 
     intent = _caller_intent(body)
-    want = False if intent is None else intent
+    want = default_thinking if intent is None else intent
 
     ctk = {**(body.get("chat_template_kwargs") or {}), "enable_thinking": want}
     # Drop the ineffective top-level booleans; keep everything else.

--- a/src/hal0/normalize/thinking.py
+++ b/src/hal0/normalize/thinking.py
@@ -70,10 +70,6 @@ def apply_thinking_policy(
 
     ctk = {**(body.get("chat_template_kwargs") or {}), "enable_thinking": want}
     # Drop the ineffective top-level booleans; keep everything else.
-    new = {
-        k: v
-        for k, v in body.items()
-        if not (k in _TOP_LEVEL_KEYS and isinstance(v, bool))
-    }
+    new = {k: v for k, v in body.items() if not (k in _TOP_LEVEL_KEYS and isinstance(v, bool))}
     new["chat_template_kwargs"] = ctk
     return new

--- a/src/hal0/normalize/thinking.py
+++ b/src/hal0/normalize/thinking.py
@@ -1,17 +1,26 @@
 """Reasoning-suppression policy for lemond-bound chat requests.
 
-We inject ``chat_template_kwargs.enable_thinking = false`` unless the caller
-already expressed a thinking preference. This is the Qwen3-family lever the
-jinja chat template honors (llama-server runs with ``--jinja``): the template
-emits an empty ``<think></think>`` so the model skips reasoning entirely.
+We steer reasoning with ``chat_template_kwargs.enable_thinking`` — the Qwen3-family
+lever the jinja chat template honors (llama-server runs with ``--jinja``): the
+template emits an empty ``<think></think>`` so the model skips reasoning entirely
+(when false), or a normal reasoning block (when true).
 
 Why NOT the top-level ``enable_thinking``: lemond translates a top-level
-``enable_thinking: false`` into a ``/no_think`` *prompt* injection
-(server.cpp:58-114). Abliterated / "aggressive" Qwen3 fine-tunes (e.g. the
-qwen3.6-35b-a3b-uncensored primary) ignore that soft marker, emit an unbounded
-reasoning block, and never produce ``content`` (verified live: empty content,
-finish_reason=length). The chat-template kwarg is applied by the template
-itself, so suppression no longer depends on the model obeying an instruction.
+``enable_thinking`` into a ``/no_think`` *prompt* injection (server.cpp:58-114).
+Abliterated / "aggressive" Qwen3 fine-tunes (e.g. the qwen3.6-35b-a3b-uncensored
+primary) ignore that soft marker, emit an unbounded reasoning block, and never
+produce ``content`` (verified live: empty content, finish_reason=length). The
+chat-template kwarg is applied by the template itself, so suppression no longer
+depends on the model obeying an instruction.
+
+Policy:
+  - Caller set ``chat_template_kwargs.enable_thinking`` → respected verbatim.
+  - Caller set a non-bool ``thinking`` (e.g. Anthropic ``{"type": "enabled"}``)
+    → explicit opt-in, passed through untouched.
+  - Caller set a top-level boolean ``enable_thinking`` / ``thinking`` → translated
+    into ``chat_template_kwargs.enable_thinking`` (the lever that actually works)
+    and the ineffective top-level field is dropped.
+  - Otherwise → default to suppression (``enable_thinking: false``).
 
 Idempotent and non-mutating.
 """
@@ -20,20 +29,48 @@ from __future__ import annotations
 
 from typing import Any
 
+_TOP_LEVEL_KEYS = ("enable_thinking", "thinking")
 
-def _caller_opted(body: dict[str, Any]) -> bool:
-    if "enable_thinking" in body or "thinking" in body:
-        return True
+
+def _explicit_kwarg_set(body: dict[str, Any]) -> bool:
     ctk = body.get("chat_template_kwargs")
     return isinstance(ctk, dict) and "enable_thinking" in ctk
 
 
+def _caller_intent(body: dict[str, Any]) -> bool | None:
+    """The caller's top-level boolean thinking intent, or None if unset."""
+    for key in _TOP_LEVEL_KEYS:
+        val = body.get(key)
+        if isinstance(val, bool):
+            return val
+    return None
+
+
 def apply_thinking_policy(body: dict[str, Any]) -> dict[str, Any]:
-    """Return a copy of ``body`` with ``chat_template_kwargs.enable_thinking: false``
-    injected unless the caller already set a thinking control field. Any other
-    ``chat_template_kwargs`` entries are preserved. A ``no_think`` prompt marker
-    is left untouched (passthrough)."""
-    if _caller_opted(body):
+    """Return a copy of ``body`` whose reasoning is steered via
+    ``chat_template_kwargs.enable_thinking``.
+
+    A top-level boolean ``enable_thinking`` / ``thinking`` is translated into the
+    chat-template kwarg (Qwen3's working lever) and stripped, so a caller asking
+    for ``enable_thinking: false`` actually gets no reasoning. Absent any caller
+    preference, reasoning is suppressed by default."""
+    # Caller used the precise lever already — respect it verbatim.
+    if _explicit_kwarg_set(body):
         return body
-    ctk = {**(body.get("chat_template_kwargs") or {}), "enable_thinking": False}
-    return {**body, "chat_template_kwargs": ctk}
+    # Non-bool ``thinking`` (e.g. Anthropic {"type": "enabled"}) is an explicit
+    # opt-in we leave untouched.
+    if "thinking" in body and not isinstance(body["thinking"], bool):
+        return body
+
+    intent = _caller_intent(body)
+    want = False if intent is None else intent
+
+    ctk = {**(body.get("chat_template_kwargs") or {}), "enable_thinking": want}
+    # Drop the ineffective top-level booleans; keep everything else.
+    new = {
+        k: v
+        for k, v in body.items()
+        if not (k in _TOP_LEVEL_KEYS and isinstance(v, bool))
+    }
+    new["chat_template_kwargs"] = ctk
+    return new

--- a/tests/api/test_chat_normalization.py
+++ b/tests/api/test_chat_normalization.py
@@ -80,10 +80,41 @@ async def test_remote_model_not_thinking_injected():
 
 
 @pytest.mark.asyncio
-async def test_caller_opted_thinking_preserved():
+async def test_caller_top_level_thinking_translated_to_kwarg():
     req = _make_request(cfgs=_PRIMARY, loaded={"big"})
     out = await v1._normalize_chat_body(req, {"model": "hal0/primary", "enable_thinking": True})
-    assert out["enable_thinking"] is True
+    # #487: top-level enable_thinking is translated to the chat-template lever
+    # (lemond's /no_think is ineffective on abliterated Qwen3), not passed through.
+    assert out["chat_template_kwargs"]["enable_thinking"] is True
+    assert "enable_thinking" not in out
+
+
+_PRIMARY_THINKING = [
+    {
+        "name": "primary",
+        "type": "llm",
+        "enabled": True,
+        "device": "gpu-rocm",
+        "role": None,
+        "enable_thinking": True,
+        "model": {"default": "big", "context_size": 4096},
+    }
+]
+
+
+@pytest.mark.asyncio
+async def test_per_slot_enable_thinking_default_applied():
+    # Slot configured enable_thinking=true → requests to its model default to ON.
+    req = _make_request(cfgs=_PRIMARY_THINKING, loaded={"big"})
+    out = await v1._normalize_chat_body(req, {"model": "big", "messages": []})
+    assert out["chat_template_kwargs"]["enable_thinking"] is True
+
+
+@pytest.mark.asyncio
+async def test_per_slot_default_overridden_by_request():
+    req = _make_request(cfgs=_PRIMARY_THINKING, loaded={"big"})
+    out = await v1._normalize_chat_body(req, {"model": "big", "enable_thinking": False})
+    assert out["chat_template_kwargs"]["enable_thinking"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/normalize/test_thinking.py
+++ b/tests/normalize/test_thinking.py
@@ -68,6 +68,24 @@ def test_idempotent_after_top_level_translation():
     assert once == twice
 
 
+def test_per_slot_default_thinking_true():
+    # Per-slot default (slot TOML enable_thinking=true) makes reasoning the
+    # default for that slot when the caller expresses no preference.
+    out = apply_thinking_policy({"model": "m"}, default_thinking=True)
+    assert out["chat_template_kwargs"]["enable_thinking"] is True
+
+
+def test_per_slot_default_overridden_by_caller():
+    # An explicit per-request preference always wins over the slot default.
+    out = apply_thinking_policy({"enable_thinking": False}, default_thinking=True)
+    assert out["chat_template_kwargs"]["enable_thinking"] is False
+
+
+def test_per_slot_default_false_is_baseline():
+    out = apply_thinking_policy({"model": "m"}, default_thinking=False)
+    assert out["chat_template_kwargs"]["enable_thinking"] is False
+
+
 def test_does_not_mutate_input():
     src = {"model": "m"}
     apply_thinking_policy(src)

--- a/tests/normalize/test_thinking.py
+++ b/tests/normalize/test_thinking.py
@@ -8,13 +8,30 @@ def test_injects_chat_template_kwargs_enable_thinking_false_by_default():
     assert "enable_thinking" not in out
 
 
-def test_opt_out_enable_thinking_preserved():
+def test_top_level_enable_thinking_true_translated_to_kwarg():
+    # Top-level boolean is the common/standard field; we translate it to the
+    # lever Qwen3 honors and drop the ineffective top-level key.
     out = apply_thinking_policy({"enable_thinking": True})
-    assert out["enable_thinking"] is True
-    assert "chat_template_kwargs" not in out
+    assert out["chat_template_kwargs"]["enable_thinking"] is True
+    assert "enable_thinking" not in out
 
 
-def test_opt_out_thinking_field_preserved():
+def test_top_level_enable_thinking_false_translated_to_kwarg():
+    # The bug this fixes: top-level enable_thinking:false used to pass through
+    # to lemond's ineffective /no_think; now it suppresses via the kwarg.
+    out = apply_thinking_policy({"enable_thinking": False})
+    assert out["chat_template_kwargs"]["enable_thinking"] is False
+    assert "enable_thinking" not in out
+
+
+def test_top_level_thinking_bool_translated():
+    out = apply_thinking_policy({"thinking": True})
+    assert out["chat_template_kwargs"]["enable_thinking"] is True
+    assert "thinking" not in out
+
+
+def test_opt_out_thinking_dict_field_preserved():
+    # Anthropic-style extended-thinking object is an explicit opt-in; untouched.
     out = apply_thinking_policy({"thinking": {"type": "enabled"}})
     assert "chat_template_kwargs" not in out
     assert out["thinking"] == {"type": "enabled"}
@@ -45,7 +62,17 @@ def test_idempotent():
     assert once == twice
 
 
+def test_idempotent_after_top_level_translation():
+    once = apply_thinking_policy({"enable_thinking": False})
+    twice = apply_thinking_policy(once)
+    assert once == twice
+
+
 def test_does_not_mutate_input():
     src = {"model": "m"}
     apply_thinking_policy(src)
     assert "chat_template_kwargs" not in src
+
+    src2 = {"enable_thinking": False}
+    apply_thinking_policy(src2)
+    assert src2 == {"enable_thinking": False}


### PR DESCRIPTION
## Two fixes for reasoning control on Qwen3 / ROCmFP4 models

### 1. Translate top-level enable_thinking (the bug)
Top-level `enable_thinking:false` was passed to lemond → ineffective `/no_think` prompt marker that abliterated Qwen3 fine-tunes ignore → unbounded `<think>`, empty content. Now translated to `chat_template_kwargs.enable_thinking` (the lever the jinja template honors); top-level stripped. Makes the standard field a working on/off toggle (API + OpenWebUI). Verified live: false→13 tok no-reasoning, true→reasoning.

### 2. Per-slot enable_thinking default
New optional `SlotConfig.enable_thinking` (slot TOML) sets the reasoning default for requests routed to that slot, via `apply_thinking_policy(default_thinking=...)`. Per-request still overrides. Lets the primary/reasoning slot (and Hermes, which talks to it) default to thinking ON while utility/fast slots stay suppressed. Verified live on gpu-rocmfp4: no-param→reasoning ON (slot default), enable_thinking:false→OFF.

Files: `normalize/thinking.py`, `config/schema.py`, `api/routes/v1.py`, tests (`test_thinking.py`, `test_chat_normalization.py`). All passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)