### PR TITLE
ui(dash): device-tag colours, memory-map/hermes cleanups + models page redesign

### DIFF
--- a/ui/src/dash/agents/agent-view.jsx
+++ b/ui/src/dash/agents/agent-view.jsx
@@ -2,7 +2,7 @@
 //
 // AgentView is the `#agent` route. v0.4 reduced it to the Memory
 // capability only. The web-chat surface (HermesChatTab) was abandoned in
-// favour of the `hal0 chat` TUI, and the Personas / Skills / Plugins tabs
+// favour of the `hermes chat` TUI, and the Personas / Skills / Plugins tabs
 // were removed (they showed fixtures rather than live data). The single-
 // tab nav is kept so the route + deep-link shape stay stable.
 //
@@ -24,7 +24,7 @@ const { useState: useStateAV, useEffect: useEffectAV } = React;
 
 // v0.4: the Agent view is reduced to the Memory capability only. Web
 // chat (HermesChatTab) plus the Personas / Skills / Plugins tabs were
-// removed — web chat is abandoned in favour of the `hal0 chat` TUI, and
+// removed — web chat is abandoned in favour of the `hermes chat` TUI, and
 // the other tabs surfaced fixtures rather than live data. The tab nav is
 // kept (single tab) so the route + deep-link shape stay stable.
 const AGENT_TABS = [
@@ -82,7 +82,7 @@ function AgentView() {
         <span className="vh-eye mono">Tools</span>
         <h1>Agent</h1>
         <span className="vh-spacer" />
-        <span className="hint mono">Chat in terminal: <code>hal0 chat</code></span>
+        <span className="hint mono">Chat in terminal: <code>hermes chat</code></span>
       </div>
 
       <div

--- a/ui/src/dash/agents/sidebar-agent-block.jsx
+++ b/ui/src/dash/agents/sidebar-agent-block.jsx
@@ -9,10 +9,13 @@
 //   - service health dot (green when running, amber when unknown, red
 //     when genuinely broken/down)
 //   - agent name + status label
-//   - active persona/profile name (from /api/agents/<id>/personas)
 //   - [Memory →] → onGo("agent") (the dashboard's agent route, now the
-//     Memory capability) plus an inline `hal0 chat` TUI hint. v0.4 dropped
+//     Memory capability) plus an inline `hermes chat` TUI hint. v0.4 dropped
 //     the web chat surface, so the affordance no longer opens a dead chat.
+//
+// NOTE: the persona/profile row was removed — active.txt's persona is
+// disconnected from the prompt the running Hermes actually uses (SOUL.md),
+// so the value misled more than it informed.
 //   - empty state when no agent installed: "Install Hermes" CTA → docs
 //
 // W9 simplification: the prior version rendered approvals / skills /
@@ -26,8 +29,8 @@
 // Data:
 //   useSidebarAgentRollup() (ui/src/api/hooks/useAgents.ts) — TanStack
 //   Query, 5s refetch + revalidate-on-focus. Fields used: agentStatus
-//   (from /api/agents `status`, truthful post-J1), agentId, personaName
-//   (from /api/agents/<id>/personas). No invented fields.
+//   (from /api/agents `status`, truthful post-J1) and agentId. No invented
+//   fields.
 //
 // Mount point:
 //   chrome.jsx Sidebar() — between `<div className="sb-spacer" />` and
@@ -68,11 +71,11 @@ const STATUS_LABEL = {
 
 // Terminal fallback shown in the Open-chat tooltip when there's no
 // in-app deep link beyond the dashboard's own agent route.
-const TUI_HINT = "Open the agent pane — or run `hal0 chat` in a terminal";
+const TUI_HINT = "Open the agent pane — or run `hermes chat` in a terminal";
 
 function SidebarAgentBlock({ onGo }) {
   const rollup = _useSidebarAgentRollup();
-  const { installed, agentId, agentStatus, personaName, loading } = rollup;
+  const { installed, agentId, agentStatus, loading } = rollup;
 
   // Loading state: keep skeleton minimal — sidebar must NOT layout-shift
   // when the first 5s tick lands. Render the same row stack with em-dashes
@@ -138,18 +141,10 @@ function SidebarAgentBlock({ onGo }) {
           {STATUS_LABEL[agentStatus] ?? "—"}
         </span>
       </div>
-      {personaName && (
-        <div className="row">
-          <span className="k">profile</span>
-          <span
-            className="v"
-            title={`active profile: ${personaName}`}
-            data-testid="sidebar-agent-persona"
-          >
-            {personaName}
-          </span>
-        </div>
-      )}
+      {/* Persona/profile row removed: the value (from active.txt) is
+          disconnected from what the running Hermes actually uses (it runs
+          off SOUL.md, not the persona prompt), so surfacing it here was
+          misleading. Honest minimal surface = health dot + chat affordance. */}
       <div className="ln" />
       <button
         className="nudge sb-status-cta"
@@ -164,7 +159,7 @@ function SidebarAgentBlock({ onGo }) {
         title="Run the agent chat in your terminal"
         data-testid="sidebar-agent-tui-hint"
       >
-        Chat in terminal: <code>hal0 chat</code>
+        Chat in terminal: <code>hermes chat</code>
       </div>
     </div>
   );

--- a/ui/src/dash/dashboard.jsx
+++ b/ui/src/dash/dashboard.jsx
@@ -214,21 +214,25 @@ function HardwareSection() {
 
   // GPU vendor-stack chips reflect the PROBE's capability flags, not a
   // baked-in "ROCm 6.4 ✓". Vulkan is the bundled default backend.
+  // Colour by device identity (--dev-rocm red / --dev-vulkan blue) so these
+  // match the slot-snapshot + memory-map chips everywhere else; the ✓/—
+  // glyph carries the capability signal, so an incapable backend renders
+  // as a plain (uncoloured) chip rather than a green "ok" one.
   const stackChips = H ? (
     <>
-      <span className={"chip " + (H.computeCapable ? "ok" : "")}>
+      <span className={"chip " + (H.computeCapable ? "dev-rocm" : "")}>
         ROCm {H.computeCapable ? "✓" : "—"}
       </span>{" "}
-      <span className={"chip " + (H.vulkanCapable ? "ok" : "")}>
+      <span className={"chip " + (H.vulkanCapable ? "dev-vulkan" : "")}>
         Vulkan {H.vulkanCapable ? "✓" : "—"}
       </span>
     </>
   ) : "—";
   const gpuRecommend = H && H.vulkanCapable
-    ? <span className="chip ok">llamacpp:vulkan</span>
+    ? <span className="chip dev-vulkan">llamacpp:vulkan</span>
     : H && H.computeCapable
-      ? <span className="chip ok">llamacpp:rocm</span>
-      : <span className="chip">llamacpp:cpu</span>;
+      ? <span className="chip dev-rocm">llamacpp:rocm</span>
+      : <span className="chip dev-cpu">llamacpp:cpu</span>;
 
   return (
     <div className="hw-section">

--- a/ui/src/dash/memory-map.jsx
+++ b/ui/src/dash/memory-map.jsx
@@ -471,9 +471,10 @@ export function MemoryMap({ variant = 'sidebar', onConfigure }) {
             ))}
             <LegendRow swatch="var(--bg-4)" name="free" sz={free} />
           </div>
-          {host.mode === 'detected_unconfigured' && (
-            <PveNudge hint={host.hint} onConfigure={onConfigure} />
-          )}
+          {/* Proxmox host-pressure nudge intentionally omitted from the
+              sidebar — it lives only in the expanded (hardware-page)
+              variant where the Configure → affordance has room to land.
+              The compact sidebar stays model-memory only. */}
         </div>
       </div>
     </div>

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -14,7 +14,8 @@ const { useState: useStateM, useMemo: useMemoM, useEffect: useEffectM } = React;
 
 function ModelsView() {
   const [selId, setSelId] = useStateM(null);
-  const [filters, setFilters] = useStateM({ type: null, device: null, ns: null });
+  const [filters, setFilters] = useStateM({ type: null, device: null });
+  const [q, setQ] = useStateM("");
   const [addOpen, setAddOpen] = useStateM(false);
   const [addByPathOpen, setAddByPathOpen] = useStateM(false);
   const [scanOpen, setScanOpen] = useStateM(false);
@@ -42,8 +43,18 @@ function ModelsView() {
 
   const fil = m => {
     if (filters.type && m.type !== filters.type) return false;
-    if (filters.device && m.device !== filters.device) return false;
-    if (filters.ns && m.ns !== filters.ns) return false;
+    if (filters.device) {
+      // Match against the full backend set (a model that resolves to device
+      // "rocm" may still also run on vulkan/cpu), not just the single
+      // best-device the normalizer picked.
+      const bes = Array.isArray(m.backends) ? m.backends : [];
+      if (!bes.includes(filters.device) && m.device !== filters.device) return false;
+    }
+    if (q.trim()) {
+      const needle = q.trim().toLowerCase();
+      const hay = `${m.longName || ""} ${m.name || ""} ${m.id || ""} ${m.repo || ""}`.toLowerCase();
+      if (!hay.includes(needle)) return false;
+    }
     return true;
   };
   const installed = modelList.filter(m => m.installed && fil(m));
@@ -78,56 +89,35 @@ function ModelsView() {
       </div>
 
       <div className="models-layout">
-        {/* ── Filters ── */}
-        <div className="mdl-filters">
-          <div className="mdl-filter-grp">
-            <div className="lbl">type</div>
-            <div className="mdl-filter-chips">
+        {/* ── List (toolbar + rows) ── */}
+        <div className="mdl-list">
+          <div className="mdl-toolbar">
+            <input
+              className="input mono mdl-search"
+              placeholder="search name, repo, id…"
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+            />
+            <div className="mdl-toolbar-grp">
+              <span className="lbl">type</span>
               {["llm", "embedding", "reranking", "transcription", "tts", "image"].map(t => (
                 <button key={t} className={"mdl-chip" + (filters.type === t ? " on" : "")} onClick={() => toggle("type", t)}>{t}</button>
               ))}
             </div>
-          </div>
-          <div className="mdl-filter-grp">
-            <div className="lbl">device</div>
-            <div className="mdl-filter-chips">
-              {["gpu-rocm", "gpu-vulkan", "cpu", "npu"].map(d => (
+            <div className="mdl-toolbar-grp">
+              <span className="lbl">device</span>
+              {["rocm", "vulkan", "cpu", "npu"].map(d => (
                 <button key={d} className={"mdl-chip" + (filters.device === d ? " on" : "")} onClick={() => toggle("device", d)}>{d}</button>
               ))}
             </div>
+            {(filters.type || filters.device || q.trim()) && (
+              <button className="mdl-chip mdl-clear" onClick={() => { setFilters({ type: null, device: null }); setQ(""); }}>clear ✕</button>
+            )}
           </div>
-          <div className="mdl-filter-grp">
-            <div className="lbl">namespace</div>
-            <div className="mdl-filter-chips">
-              {["blessed", "pulled"].map(n => (
-                <button key={n} className={"mdl-chip" + (filters.ns === n ? " on" : "")} onClick={() => toggle("ns", n)}>{n}</button>
-              ))}
-            </div>
-          </div>
-          <div className="mdl-filter-grp">
-            <div className="lbl">labels</div>
-            <div className="mdl-filter-chips">
-              {["chat", "tool-calling", "vision", "embeddings", "reranking", "transcription", "tts", "image", "edit"].map(l => (
-                <button key={l} className="mdl-chip">{l}</button>
-              ))}
-            </div>
-          </div>
-          <div className="mdl-filter-grp">
-            <div className="lbl">search</div>
-            <input className="input mono" placeholder="qwen, embed, …" />
-          </div>
-          <div style={{borderTop: "1px solid var(--line-soft)", paddingTop: 10, fontFamily: "var(--jbm)", fontSize: 10, color: "var(--fg-4)", lineHeight: 1.7}}>
-            <div>{modelList.length} total · {modelList.filter(m => m.installed).length} on disk</div>
-            <div style={{color: "var(--fg-5)"}}>{modelList.filter(m => m.ns === "blessed").length} blessed · {modelList.filter(m => m.ns === "pulled").length} pulled</div>
-          </div>
-        </div>
-
-        {/* ── List ── */}
-        <div className="mdl-list">
           <div className="mdl-list-h">
             <span>Catalog</span>
             <span className="ct">· {installed.length + blessed.length + userNs.length} shown</span>
-            <span className="right">sort: <span style={{color: "var(--fg-2)"}}>installed</span> ▾</span>
+            <span className="right mono">{modelList.length} total · {modelList.filter(m => m.installed).length} on disk · {modelList.filter(m => m.ns === "blessed").length} blessed · {modelList.filter(m => m.ns === "pulled").length} pulled</span>
           </div>
 
           {modelsQuery.isPending && (
@@ -153,6 +143,12 @@ function ModelsView() {
           {userNs.map(m => (
             <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
           ))}
+
+          {!modelsQuery.isPending && !modelsQuery.isError && (installed.length + blessed.length + userNs.length) === 0 && (
+            <div style={{padding: 24, textAlign: "center", fontFamily: "var(--jbm)", fontSize: 12, color: "var(--fg-4)"}}>
+              No models match — {(q.trim() || filters.type || filters.device) ? "adjust the search or filters." : "the catalog is empty."}
+            </div>
+          )}
         </div>
 
         {/* ── Detail + Downloads ── */}
@@ -177,14 +173,23 @@ function ModelsView() {
 }
 
 function ModelRow({ model, selected, onSelect }) {
+  // Backend tags use the unified device palette (.chip.dev-rocm / dev-vulkan /
+  // dev-cpu / dev-npu) so a Vulkan tag here is the same blue as everywhere
+  // else on the dash. `type` is the dispatcher vocab derived in normalizeApiModel.
+  const backends = Array.isArray(model.backends) ? model.backends : [];
   return (
     <div className={"mdl-row" + (selected ? " sel" : "")} onClick={onSelect}>
       <span className={"dot " + (model.installed ? "ready" : "empty")} />
       <span className="nm">
         {model.longName || model.name || model.id}
-        <span className="sub">{model.repo || model.hf_repo || ""}</span>
+        <span className="sub">{model.repo || ""}</span>
       </span>
-      <span className="sz num">{model.params || ""}</span>
+      <span className="mdl-row-tags">
+        {model.type && <span className="chip">{model.type}</span>}
+        {backends.map(b => (
+          <span key={b} className={"chip dev-" + b}>{b}</span>
+        ))}
+      </span>
       <span className="sz num">{model.size || (model.size_bytes ? fmtBytes(model.size_bytes) : "")}</span>
       <span className="tg">
         {model.installed
@@ -328,7 +333,7 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
             <button className="btn" onClick={onPull} disabled={pull.inFlight}>
               {Icons.download} {pull.inFlight ? `Pulling ${pull.pct ?? 0}%` : `Pull (${model.size || (model.size_bytes ? fmtBytes(model.size_bytes) : "—")})`}
             </button>
-            <button className="btn ghost sm" onClick={() => window.open(`https://huggingface.co/${model.repo || model.hf_repo || ""}`, "_blank")}>View on HF →</button>
+            <button className="btn ghost sm" onClick={() => window.open(`https://huggingface.co/${model.hf_repo || model.repo || ""}`, "_blank")}>View on HF →</button>
           </>
         )}
       </div>

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -1903,23 +1903,41 @@ a { color: inherit; text-decoration: none; }
    ════════════════════════════════════════════════════════════════════ */
 .models-layout {
   display: grid;
-  grid-template-columns: 280px 1fr 320px;
+  grid-template-columns: 1fr 340px;
   gap: 14px;
   align-items: start;
 }
-.mdl-filters {
-  background: var(--bg-1);
-  border: 1px solid var(--line);
-  border-radius: var(--rad-lg);
-  padding: 14px;
-  position: sticky;
-  top: 12px;
+/* Toolbar — search + type/device filters, sits above the catalog rows
+   (replaces the old left filter sidebar). */
+.mdl-toolbar {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg);
   display: flex;
-  flex-direction: column;
-  gap: 14px;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 14px;
 }
-.mdl-filter-grp .lbl { font-family: var(--jbm); font-size: 10px; color: var(--fg-4); text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 6px; }
-.mdl-filter-chips { display: flex; flex-wrap: wrap; gap: 4px; }
+.mdl-search {
+  flex: 1 1 200px;
+  min-width: 160px;
+}
+.mdl-toolbar-grp {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+.mdl-toolbar-grp .lbl {
+  font-family: var(--jbm);
+  font-size: 10px;
+  color: var(--fg-4);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-right: 2px;
+}
+.mdl-clear { color: var(--fg-4); border-style: dashed; }
+.mdl-clear:hover { color: var(--err); border-color: var(--err-line); }
 .mdl-chip {
   padding: 3px 8px;
   border: 1px solid var(--line);
@@ -1964,7 +1982,7 @@ a { color: inherit; text-decoration: none; }
 }
 .mdl-row {
   display: grid;
-  grid-template-columns: 14px 1fr 60px 80px auto;
+  grid-template-columns: 14px minmax(0, 1fr) auto 72px 78px;
   gap: 12px;
   align-items: center;
   padding: 10px 16px;
@@ -1977,7 +1995,9 @@ a { color: inherit; text-decoration: none; }
 .mdl-row:hover { background: var(--bg-2); }
 .mdl-row.sel { background: var(--accent-bg); }
 .mdl-row .nm { color: var(--fg); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.mdl-row .nm .sub { color: var(--fg-4); font-weight: 400; font-size: 10.5px; display: block; margin-top: 2px; }
+.mdl-row .nm .sub { color: var(--fg-4); font-weight: 400; font-size: 10.5px; display: block; margin-top: 2px; overflow: hidden; text-overflow: ellipsis; }
+.mdl-row-tags { display: flex; flex-wrap: nowrap; gap: 4px; justify-content: flex-end; overflow: hidden; }
+.mdl-row-tags .chip { text-transform: lowercase; }
 .mdl-row .sz { color: var(--fg-3); text-align: right; font-size: 11px; }
 .mdl-row .tg { color: var(--fg-3); font-size: 10.5px; text-align: right; }
 
@@ -2102,8 +2122,8 @@ a { color: inherit; text-decoration: none; }
   .dash { grid-template-columns: 1fr; }
   .dash-side { position: static; flex-direction: row; flex-wrap: wrap; }
   .dash-side > * { flex: 1; min-width: 260px; }
-  .models-layout { grid-template-columns: 240px 1fr; }
-  .mdl-detail { grid-column: span 2; position: static; }
+  .models-layout { grid-template-columns: 1fr; }
+  .mdl-detail { position: static; }
 }
 @media (max-width: 1080px) {
   :root { --sidebar-w: 56px; }

--- a/ui/src/lib/normalizeApiModel.ts
+++ b/ui/src/lib/normalizeApiModel.ts
@@ -62,6 +62,25 @@ function formatSize(b: number): string {
   return `${(b / 1024 ** 3).toFixed(2)} GB`
 }
 
+// Coordinate shown under a model's name. We standardize on the HuggingFace
+// `<org>/<repo>` style and NEVER surface a raw `/mnt/ai-models/…/x.gguf`
+// filesystem path (which leaked through the old `hf_repo || path` fallback):
+//   1. an explicit `hf_repo` wins;
+//   2. else reconstruct coords from a HF cache path
+//      (`…/models--<org>--<repo>/snapshots/<sha>/…` → `<org>/<repo>`);
+//   3. else it's a genuinely local model → a clean `local/<id>` coordinate.
+function deriveRepo(m: ApiModelRaw): string {
+  if (typeof m.hf_repo === 'string' && m.hf_repo) return m.hf_repo
+  const path = typeof m.path === 'string' ? m.path : ''
+  const cacheMatch = path.match(/models--([^/]+)/)
+  if (cacheMatch) {
+    const parts = cacheMatch[1].split('--')
+    if (parts.length >= 2) return `${parts[0]}/${parts.slice(1).join('--')}`
+  }
+  if (m.id) return `local/${m.id}`
+  return ''
+}
+
 export function normalizeApiModel(m: ApiModelRaw): NormalizedModel {
   const caps = Array.isArray(m.capabilities) ? m.capabilities : []
   const backends = Array.isArray(m.backends) ? m.backends : []
@@ -71,6 +90,6 @@ export function normalizeApiModel(m: ApiModelRaw): NormalizedModel {
     device: deriveDevice(backends),
     longName: m.name || m.id,
     size: formatSize(m.size_bytes || 0),
-    repo: m.hf_repo || m.path || '',
+    repo: deriveRepo(m),
   }
 }

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -58,7 +58,7 @@ import './dash/extras.jsx'
 // AgentView is the `#agent` route shell. v0.4 reduced it to the Memory
 // capability only — the web-chat (HermesChatTab) surface plus the
 // Personas / Skills / Plugins tabs were removed (web chat is abandoned in
-// favour of the `hal0 chat` TUI; the other tabs showed fixtures rather
+// favour of the `hermes chat` TUI; the other tabs showed fixtures rather
 // than live data). The MemoryTab bridge installs its TanStack-Query
 // hooks onto `window.__hal0Use*` BEFORE memory-tab.jsx evaluates, and
 // memory-tab.jsx registers on window BEFORE agent-view.jsx mounts.

--- a/ui/tests/e2e/specs/agent-view-v3.spec.ts
+++ b/ui/tests/e2e/specs/agent-view-v3.spec.ts
@@ -2,7 +2,7 @@
  * agent-view-v3 — v0.4 Memory-only AgentView contract.
  *
  * The `#agent` route was reduced to the Memory capability ONLY. Web chat
- * (HermesChatTab) was abandoned in favour of the `hal0 chat` TUI, and the
+ * (HermesChatTab) was abandoned in favour of the `hermes chat` TUI, and the
  * Personas / Skills / Plugins tabs were removed (they surfaced fixtures,
  * not live data). The single-tab nav is kept so the route + deep-link
  * shape stay stable.
@@ -12,7 +12,7 @@
  *   - the Memory tab content is visible by default
  *   - the removed tabs (chat / personas / skills / plugins / inbox /
  *     peers / overview) are ABSENT from the nav
- *   - the header carries the `hal0 chat` terminal hint
+ *   - the header carries the `hermes chat` terminal hint
  *   - the Memory tab exposes the "Peer memory" subsection
  *   - hash routes `#agent`, `#agent/memory`, and legacy `#peers` all land
  *     on the Memory tab
@@ -61,11 +61,11 @@ test.describe('AgentView v3 (#agent — v0.4 Memory-only)', () => {
     await expect(nav).not.toContainText('Plugins')
   })
 
-  test('header carries the `hal0 chat` terminal hint (web chat replaced by TUI)', async ({
+  test('header carries the `hermes chat` terminal hint (web chat replaced by TUI)', async ({
     page,
   }) => {
     await page.goto('/#agent')
-    await expect(page.locator('.view .vh')).toContainText('hal0 chat', { timeout: FIVE_S })
+    await expect(page.locator('.view .vh')).toContainText('hermes chat', { timeout: FIVE_S })
   })
 
   test('Memory tab shows the "Peer memory" subsection', async ({ page }) => {

--- a/ui/tests/e2e/specs/dashboard-v3.spec.ts
+++ b/ui/tests/e2e/specs/dashboard-v3.spec.ts
@@ -2,7 +2,7 @@
  * dashboard-v3 — root `#dashboard` route renders the topbar, sidebar,
  * hardware section, and snapshot strip. The dashboard is the
  * system-overview page. (v0.4: the standalone web-chat `#chat` route was
- * removed — chat lives in the `hal0 chat` TUI.)
+ * removed — chat lives in the `hermes chat` TUI.)
  */
 import { test, expect } from '../fixtures/apiMock'
 

--- a/ui/tests/e2e/specs/memory-map-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-map-v3.spec.ts
@@ -51,7 +51,11 @@ test.describe('Memory map — sidebar', () => {
     await expect(card).not.toContainText('host free')
   })
 
-  test('detected_unconfigured — amber band with Configure link', async ({ page }) => {
+  test('detected_unconfigured — sidebar no longer shows the Proxmox nudge', async ({ page }) => {
+    // The "⚠ Hosted on Proxmox — host pressure unknown. Configure →" nudge was
+    // removed from the SIDEBAR variant (it now lives only in the expanded
+    // hardware-page variant). Even in the detected-but-unconfigured state the
+    // compact sidebar stays model-memory only.
     await mockStatsHardware(page, {
       configured: false,
       detected: true,
@@ -60,8 +64,11 @@ test.describe('Memory map — sidebar', () => {
     })
     await page.goto('/#dashboard')
     const card = page.locator('.memmap-sidebar')
-    await expect(card).toContainText('Hosted on Proxmox')
-    await expect(card.locator('a', { hasText: 'Configure' })).toBeVisible()
+    await expect(card).toBeVisible()
+    await expect(card).not.toContainText('Hosted on Proxmox')
+    await expect(card.locator('.memmap-pve-nudge')).toHaveCount(0)
+    // Model-memory framing is still the sidebar's content.
+    await expect(card).toContainText('model memory')
   })
 
   test('configured — sidebar shows MODEL memory only, no host section', async ({ page }) => {

--- a/ui/tests/e2e/specs/models-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-v3.spec.ts
@@ -1,6 +1,8 @@
 /**
- * models-v3 — `#models` route renders the 3-pane layout (filters / list
- * / detail) and exposes the "Add by HF coords" trigger.
+ * models-v3 — `#models` route renders the 2-pane layout (list-with-toolbar
+ * / detail) and exposes the "Add by HF coords" trigger. The left filter
+ * sidebar was folded into a toolbar above the catalog rows; search +
+ * type/device filters live there now.
  *
  * Wireup (#220 brief): the catalog drives off `useModels()` and the
  * AddByHF modal calls `POST /api/models/inspect` →
@@ -13,11 +15,12 @@
 import { test, expect } from '../fixtures/apiMock'
 
 test.describe('Models v3 (/models)', () => {
-  test('renders 3-pane catalog layout', async ({ page }) => {
+  test('renders catalog layout (toolbar + list + detail)', async ({ page }) => {
     await page.goto('/#models')
     await expect(page.locator('.view .vh h1')).toHaveText('Models')
     await expect(page.locator('.models-layout')).toBeVisible()
-    await expect(page.locator('.mdl-filters')).toBeVisible()
+    await expect(page.locator('.mdl-toolbar')).toBeVisible()
+    await expect(page.locator('.mdl-search')).toBeVisible()
     await expect(page.locator('.mdl-list')).toBeVisible()
   })
 
@@ -27,12 +30,26 @@ test.describe('Models v3 (/models)', () => {
     await expect(page.locator('.view .vh button:has-text("Search HF")')).toBeVisible()
   })
 
-  test('filter chips for type/device/namespace are clickable', async ({ page }) => {
+  test('type/device filter chips in the toolbar are clickable', async ({ page }) => {
     await page.goto('/#models')
-    const llmChip = page.locator('.mdl-filter-chips button.mdl-chip', { hasText: 'llm' }).first()
+    const llmChip = page.locator('.mdl-toolbar button.mdl-chip', { hasText: 'llm' }).first()
     await expect(llmChip).toBeVisible()
     await llmChip.click()
     await expect(llmChip).toHaveClass(/on/)
+    // Device chip uses the normalized backend vocab (rocm, not gpu-rocm).
+    const rocmChip = page.locator('.mdl-toolbar button.mdl-chip', { hasText: 'rocm' }).first()
+    await expect(rocmChip).toBeVisible()
+  })
+
+  test('search input filters the catalog and shows an empty state on no match', async ({
+    page,
+  }) => {
+    await page.goto('/#models')
+    // Sanity: at least one row before filtering.
+    await expect(page.locator('.mdl-row').first()).toBeVisible()
+    await page.locator('.mdl-search').fill('zzz-no-such-model-zzz')
+    await expect(page.locator('.mdl-row')).toHaveCount(0)
+    await expect(page.locator('.mdl-list')).toContainText('No models match')
   })
 
   test('namespace chips render from backend ns field (blessed + pulled)', async ({ page }) => {

--- a/ui/tests/e2e/specs/sidebar-agent-block.spec.ts
+++ b/ui/tests/e2e/specs/sidebar-agent-block.spec.ts
@@ -11,9 +11,12 @@
  *
  *   - health dot + status label, keyed off /api/agents `status`
  *     (installed→running/up, broken→down, else unknown→warn)
- *   - an OPTIONAL active-profile row, only when a persona name exists
  *   - an "Open chat →" button → onGo("agent")
  *   - empty state when no agent installed → "Install Hermes →" CTA
+ *
+ * The persona/profile row was removed: active.txt's persona is disconnected
+ * from the prompt the running Hermes actually uses (SOUL.md), so it misled.
+ * The persona testid MUST now be absent in every state.
  *
  * Tests below assert the new minimal surface; removed-row testids
  * (sidebar-agent-approvals/skills/memory/mcp) MUST be absent.
@@ -84,11 +87,16 @@ test.describe('SidebarAgentBlock — populated', () => {
     await expect(statusRow.locator('.v .dot')).toBeVisible()
   })
 
-  test('renders active persona display name', async ({ page }) => {
+  test('does NOT render the persona/profile row even when a persona is active', async ({
+    page,
+  }) => {
     await page.goto('/')
-    const persona = page.locator('[data-testid="sidebar-agent-persona"]')
-    await expect(persona).toBeVisible({ timeout: FIVE_S })
-    await expect(persona).toHaveText('Hermes')
+    // Even with an active persona in the payload, the row was removed —
+    // it misrepresented the running agent's actual prompt source (SOUL.md).
+    await expect(page.locator('[data-testid="sidebar-agent-block"]')).toBeVisible({
+      timeout: FIVE_S,
+    })
+    await expect(page.locator('[data-testid="sidebar-agent-persona"]')).toHaveCount(0)
   })
 
   test('does NOT render removed approvals/skills/memory/mcp rows', async ({ page }) => {
@@ -105,13 +113,14 @@ test.describe('SidebarAgentBlock — populated', () => {
 
   test('Memory CTA navigates to #agent + inline TUI hint present', async ({ page }) => {
     // v0.4: web chat is gone — the CTA is now "Memory →" (still onGo("agent"))
-    // and an inline `hal0 chat` terminal hint sits below it.
+    // and an inline `hermes chat` terminal hint sits below it (the real
+    // command — `hal0 chat` does not exist).
     await page.goto('/')
     const cta = page.locator('[data-testid="sidebar-agent-open-memory"]')
     await expect(cta).toBeVisible({ timeout: FIVE_S })
     await expect(cta).toContainText('Memory')
     const hint = page.locator('[data-testid="sidebar-agent-tui-hint"]')
-    await expect(hint).toContainText('hal0 chat')
+    await expect(hint).toContainText('hermes chat')
     await cta.click()
     await expect(page).toHaveURL(/#agent/)
   })
@@ -167,11 +176,10 @@ test.describe('SidebarAgentBlock — status tone mapping', () => {
   })
 })
 
-test.describe('SidebarAgentBlock — profile row is conditional', () => {
-  test('omits the profile row when no active persona', async ({ page }) => {
+test.describe('SidebarAgentBlock — persona row is gone', () => {
+  test('omits the profile row regardless of persona payload', async ({ page }) => {
     await page.route('**/api/agents', (route) => json(route, MOCK_AGENTS_INSTALLED))
-    // active=null and no matching persona → personaName resolves to null,
-    // so the profile row must NOT render.
+    // Whatever the personas endpoint returns, the row is no longer rendered.
     await page.route('**/api/agents/hermes/personas', (route) =>
       json(route, { agent_id: 'hermes', active: null, personas: [] }),
     )


### PR DESCRIPTION
Dashboard UI fixes from a review pass. Two cohesive groups (2 commits).

## Commit 1 — device-tag colours, memory-map + hermes widget
- **Unified device-tag colour scheme.** The Hardware GPU card's vendor-stack chips (ROCm/Vulkan) and the recommended `llamacpp:*` chip were generic green `.chip.ok`; now they use the device-identity palette (`--dev-rocm` red, **`--dev-vulkan` blue**, `--dev-cpu` grey), matching the slot-snapshot + memory-map chips everywhere else. The `✓`/`—` glyph still carries the capability signal.
- **Removed the Proxmox nudge from the memory-map sidebar** (`⚠ Hosted on Proxmox — host pressure unknown. Configure →`). It remains in the expanded hardware-page variant where the Configure affordance has room.
- **Honest Hermes sidebar widget:** dropped the `profile: coder` row (the `active.txt` persona is disconnected from the prompt the running Hermes actually uses — `SOUL.md`), and fixed the terminal hint from the non-existent `hal0 chat` to the real `hermes chat`. Verified on the box; inference path `hal0/primary` → iGPU responds (~51 tok/s).

## Commit 2 — models page redesign + filter/search/path fixes
- **Layout:** dropped the left filter sidebar → compact toolbar (search + type/device filters) above the rows; page is now 2-pane. Rows gained a type tag + backend tags (unified `--dev-*` colours) + size; totals moved to the header.
- **Bug fixes:** search input was inert (no `value`/`onChange`) → now filters name/id/repo. Device filter chips emitted `gpu-rocm`/`gpu-vulkan` but the normalizer produces `rocm`/`vulkan` so nothing matched → chips now use backend vocab and match the full `backends[]`. Removed the dead "labels" filter and the redundant namespace filter; added a "No models match" empty state + clear-filters.
- **Repo coords:** models with no `hf_repo` showed a raw `/mnt/ai-models/…/x.gguf` path. Now: `hf_repo` → reconstruct `<org>/<repo>` from a HF cache path → clean `local/<id>`. No filesystem paths leak. `View on HF` prefers `hf_repo`.

## Verification
- `vite build` ✓ · `tsc --noEmit` ✓
- e2e: `sidebar-agent-block.spec.ts` 8/8, `models-v3.spec.ts` 9/9 (updated for new layout + added search/empty-state coverage)
- `deriveRepo` checked against the real live paths (local model → `local/<id>`, HF cache dir → reconstructed coords)
- Models page screenshot verified (toolbar, 2-pane, clean coords)

🤖 Generated with [Claude Code](https://claude.com/claude-code)