### PR TITLE
feat(ui): wire command palette to live data + real slot/pull actions

### DIFF
--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -235,6 +235,12 @@ export function usePullJob(): PullSnapshot {
     if (typeof payload.state === 'string' && TERMINAL.has(payload.state)) {
       closeStream()
       qc.invalidateQueries({ queryKey: ['models'] })
+      // Broadcast terminal state so route-independent listeners (e.g. the
+      // command palette's "Cancel download" affordance) can stop offering
+      // to cancel a pull that has finished.
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('hal0:pull-ended', { detail: { modelId } }))
+      }
     }
   }
 
@@ -309,6 +315,9 @@ export function usePullJob(): PullSnapshot {
       await apiPost(ENDPOINTS.modelPullCancel(modelId))
       setState('cancelled')
       closeStream()
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('hal0:pull-ended', { detail: { modelId } }))
+      }
     } catch (e) {
       if (e instanceof Hal0Error) {
         setError({ code: e.code, message: e.message, details: e.details })

--- a/ui/src/dash/command-palette.jsx
+++ b/ui/src/dash/command-palette.jsx
@@ -1,28 +1,99 @@
 // hal0 dashboard — CommandPalette (Spotlight-style)
 // Fuzzy filter over routes + slots + models + actions, opened via ⌘K / Ctrl+K.
+//
+// v0.4: the palette was the last dash/*.jsx holdout still reading the
+// static HAL0_DATA fixture for its Slots/Models lists (so it showed
+// phantom seed slots in production). It now reads live data via the
+// typed hooks (useSlots/useModels) — mounted only while the palette is
+// open (CommandPaletteInner) so there's no background polling when it's
+// closed. Slot control verbs (start/stop/restart/logs) are dispatched as
+// `hal0:slot-*` events handled by the always-mounted SlotActionBridge
+// below, so they work from any route without a navigate-then-dispatch
+// race. The old toast-only stub actions (restart-lemond, restart-flm,
+// clear-downloads, replay-tour) were removed — every item now does what
+// it says.
+
+import { useSlots, useSlotRestart, useSlotLoad, useSlotUnload } from '@/api/hooks/useSlots'
+import { useModels, fmtBytes } from '@/api/hooks/useModels'
 
 const { useState: useStateCP, useEffect: useEffectCP, useRef: useRefCP, useMemo: useMemoCP } = React;
 
+// Module-level active-pull tracking. The pull job lives in whichever
+// ModelDetail is mounted (per-row usePullJob), so the palette can't reach
+// it through a hook. Instead we listen for the global lifecycle events:
+// models.jsx fires `hal0:pull-started` on .start(); the usePullJob hook
+// fires `hal0:pull-ended` when the job reaches a terminal state. Tracking
+// it here (not in React state) means an open palette only ever offers
+// "Cancel download" while a pull is genuinely live.
+let __cpActivePull = null;
+if (typeof window !== "undefined") {
+  window.addEventListener("hal0:pull-started", (e) => { __cpActivePull = (e.detail && e.detail.modelId) || null; });
+  window.addEventListener("hal0:pull-ended", () => { __cpActivePull = null; });
+}
+
+const cpCopy = (text, label) => {
+  try {
+    navigator.clipboard.writeText(text);
+    window.__hal0Toast && window.__hal0Toast(label, "ok");
+  } catch {
+    window.__hal0Toast && window.__hal0Toast("Copy failed — clipboard unavailable", "err");
+  }
+};
+
+const cpCurlFor = (slotName) =>
+  `curl ${location.origin}/v1/chat/completions \\\n` +
+  `  -H 'Content-Type: application/json' \\\n` +
+  `  -d '{"model":"${slotName}","messages":[{"role":"user","content":"hello"}]}'`;
+
+// Navigate to /slots (where the SlotLogsDrawer is mounted) then ask
+// SlotsView to open the drawer. The tiny delay covers the case where we
+// were on another route and SlotsView's listener hasn't mounted yet.
+const cpViewLogs = (name) => {
+  window.location.hash = "#slots";
+  setTimeout(() => window.dispatchEvent(new CustomEvent("hal0:slot-logs", { detail: { name } })), 60);
+};
+
+// Outer gate — keeps the data hooks (and their polling) unmounted while
+// the palette is closed. All real work happens in CommandPaletteInner.
 function CommandPalette({ open, onClose }) {
+  if (!open) return null;
+  return <CommandPaletteInner onClose={onClose} />;
+}
+
+function CommandPaletteInner({ onClose }) {
   const [q, setQ] = useStateCP("");
   const [idx, setIdx] = useStateCP(0);
+  const [activePull, setActivePull] = useStateCP(__cpActivePull);
   const inputRef = useRefCP(null);
   const listRef = useRefCP(null);
 
+  const slots = useSlots().data || [];
+  const models = useModels().data || [];
+
   useEffectCP(() => {
-    if (open) {
-      setQ("");
-      setIdx(0);
-      setTimeout(() => inputRef.current && inputRef.current.focus(), 0);
-    }
-  }, [open]);
+    setTimeout(() => inputRef.current && inputRef.current.focus(), 0);
+  }, []);
 
-  // Build the unified item list once per open
-  const items = useMemoCP(() => buildCommandItems(), [open]);
+  // Keep the cancel-download affordance honest while the palette is open.
+  useEffectCP(() => {
+    const onStart = (e) => setActivePull((e.detail && e.detail.modelId) || null);
+    const onEnd = () => setActivePull(null);
+    window.addEventListener("hal0:pull-started", onStart);
+    window.addEventListener("hal0:pull-ended", onEnd);
+    return () => {
+      window.removeEventListener("hal0:pull-started", onStart);
+      window.removeEventListener("hal0:pull-ended", onEnd);
+    };
+  }, []);
 
-  // Fuzzy-filter: characters in order, weighted by exact prefix
+  const items = useMemoCP(() => buildCommandItems(slots, models, activePull), [slots, models, activePull]);
+
+  // Fuzzy-filter: characters in order, weighted by exact prefix. Per-slot
+  // control verbs are hidden from the empty-query view (hideWhenEmpty) so
+  // the default list stays a clean nav surface; typing a verb or slot name
+  // surfaces them.
   const filtered = useMemoCP(() => {
-    if (!q.trim()) return items;
+    if (!q.trim()) return items.filter(it => !it.hideWhenEmpty);
     const needle = q.toLowerCase();
     const scored = items.map(it => {
       const hay = (it.label + " " + (it.sub || "") + " " + (it.keywords || "")).toLowerCase();
@@ -50,8 +121,6 @@ function CommandPalette({ open, onClose }) {
     if (row) row.scrollIntoView({ block: "nearest" });
   }, [idx, filtered]);
 
-  if (!open) return null;
-
   const go = (it) => {
     if (it.route) window.location.hash = "#" + it.route;
     if (it.action) it.action();
@@ -68,7 +137,7 @@ function CommandPalette({ open, onClose }) {
   // Group filtered items by section for visual separation
   const groups = {};
   filtered.forEach(it => { (groups[it.section] = groups[it.section] || []).push(it); });
-  const sectionOrder = ["Routes", "Slots", "Models", "Settings", "Actions"];
+  const sectionOrder = ["Routes", "Slots", "Models", "Settings", "Actions", "Copy", "Slot actions"];
 
   return (
     <div className="cp-backdrop" onMouseDown={(e) => { if (e.target.classList.contains("cp-backdrop")) onClose(); }}>
@@ -145,8 +214,12 @@ function highlightCp(text, q) {
   );
 }
 
-// Build a unified list of palette items.
-function buildCommandItems() {
+// States in which a slot holds a model in memory (so Stop/Restart apply;
+// otherwise we offer Start). Mirrors the loaded-state set used by SlotCard.
+const CP_RUNNING_STATES = new Set(["serving", "ready", "idle", "warming"]);
+
+// Build a unified list of palette items from LIVE slots + models.
+function buildCommandItems(slots, models, activePull) {
   const items = [];
 
   // Routes
@@ -162,33 +235,34 @@ function buildCommandItems() {
   ];
   routes.forEach(r => items.push({ ...r, section: "Routes", hint: "↵ jump" }));
 
-  // Slots
-  (HAL0_DATA.slots || []).forEach(s => {
+  // Slots — live (was HAL0_DATA.slots). Nav item opens the edit drawer.
+  (slots || []).forEach(s => {
+    const isDefault = s.is_default ?? s.default ?? s.isDefault;
     items.push({
       id: "s-" + s.name,
       section: "Slots",
       route: "slots/" + s.name,
       label: s.name,
       icon: <span className={"dot " + s.state} style={{display: "inline-block"}} />,
-      sub: `${s.model} · ${s.type} · ${s.device}${s.isDefault ? " · default" : ""}`,
+      sub: `${s.model || "—"} · ${s.type} · ${s.device}${isDefault ? " · default" : ""}`,
       tag: s.state === "serving" ? <span className="chip amber">{s.state}</span> : null,
-      keywords: `${s.type} ${s.device} ${s.group}`,
+      keywords: `${s.type} ${s.device} ${s.group || ""}`,
       hint: "open edit drawer",
     });
   });
 
-  // Models
-  (HAL0_DATA.models || []).forEach(m => {
+  // Models — live (was HAL0_DATA.models). Nav item routes to /models.
+  (models || []).forEach(m => {
+    const size = m.size || (m.size_bytes ? fmtBytes(m.size_bytes) : "");
     items.push({
       id: "m-" + m.id,
       section: "Models",
       route: "models",
-      action: () => window.__hal0Toast && window.__hal0Toast(`Selected ${m.longName} on /models`, "info"),
-      label: m.longName,
+      label: m.longName || m.name || m.id,
       icon: <span className={"dot " + (m.installed ? "ready" : "empty")} style={{display: "inline-block"}} />,
-      sub: `${m.repo} · ${m.size}`,
+      sub: `${m.repo || m.id}${size ? " · " + size : ""}`,
       tag: m.installed ? <span className="chip ok">installed</span> : <span className="chip">{m.ns}</span>,
-      keywords: `${m.type} ${m.device} ${m.labels && m.labels.join(" ")}`,
+      keywords: `${m.ns || ""} ${(m.labels && m.labels.join(" ")) || ""}`,
     });
   });
 
@@ -203,36 +277,94 @@ function buildCommandItems() {
     { id: "set-memory",    label: "Memory (Cognee)",      sub: "namespace, store, records" },
   ].forEach(s => items.push({ ...s, section: "Settings", icon: Icons.settings, route: "settings" }));
 
-  // Actions
+  // Global actions — every one is wired to a real effect.
   const action = (id, label, sub, fn, icon) => items.push({
     id, section: "Actions", label, sub, icon: icon || Icons.flame, action: fn, hint: "↵ run",
   });
 
   action("a-create-slot", "Create slot…", "name + type + device + model",
     () => window.dispatchEvent(new CustomEvent("hal0:create-slot")));
-  action("a-add-hf", "Add model from HF…", "paste org/repo, inspect variants",
-    () => { window.location.hash = "#models"; window.dispatchEvent(new CustomEvent("hal0:add-hf")); });
-  action("a-restart-lemond", "Restart lemond", "expects ~8–12s outage",
-    () => window.__hal0Toast && window.__hal0Toast("Restarting lemond — brief outage", "warn"));
-  action("a-restart-flm", "Restart FLM (NPU trio)", "swaps the coresident chat model",
-    () => window.__hal0Toast && window.__hal0Toast("Restarting FLM trio", "warn"));
+  action("a-add-hf", "Add model from HF…", "open the catalog on /models",
+    () => { window.location.hash = "#models"; });
   action("a-rotate-token", "Rotate hal0 token", "invalidates the current Bearer immediately",
     () => { window.location.hash = "#settings"; window.__hal0Toast && window.__hal0Toast("Routing to Auth → Rotate", "info"); });
-  action("a-clear-downloads", "Clear completed downloads", "purges finished rows",
-    () => window.__hal0Toast && window.__hal0Toast("Cleared completed downloads", "ok"));
   action("a-open-owui", "Open Chat Pro UI →", "external · OpenWebUI",
-    () => window.__hal0Toast && window.__hal0Toast("Opening hal0-chat.thinmint.dev", "info"));
-  action("a-docs", "Open docs →", "hal0.dev/docs/v0.2-upgrade",
-    () => window.__hal0Toast && window.__hal0Toast("Opening hal0.dev/docs", "info"));
-  action("a-toggle-tour", "Replay onboarding tour", "the 3-step intro",
-    () => window.dispatchEvent(new CustomEvent("hal0:tour-start")));
+    () => window.open("https://hal0-chat.thinmint.dev", "_blank", "noopener"));
+  action("a-docs", "Open docs →", "external · hal0.dev/docs",
+    () => window.open("https://hal0.dev/docs", "_blank", "noopener"));
 
-  // v0.3 PR-8: dropped the "Review N pending approvals" shortcut. The
-  // approvals surface lives in the sidebar pip (PR-6) and inline in the
-  // chat composer (PR-10). The command palette item used the dead
-  // HAL0_DATA.approvals fixture.
+  // Cancel download — only offered while a pull is actually live, so it's
+  // never a dead affordance.
+  if (activePull) {
+    const m = (models || []).find(x => x.id === activePull);
+    action("a-cancel-pull", `Cancel download — ${m ? (m.longName || m.id) : activePull}`, "stops the active model pull",
+      () => {
+        fetch(`/api/models/${encodeURIComponent(activePull)}/pull/cancel`, { method: "POST" })
+          .then(() => window.__hal0Toast && window.__hal0Toast("Download cancelled", "warn"))
+          .catch(() => window.__hal0Toast && window.__hal0Toast("Cancel failed — see logs", "err"));
+      });
+  }
+
+  // Copy — clipboard utilities for hitting the API directly.
+  items.push({
+    id: "cp-base", section: "Copy", label: "Copy API base URL", sub: `${location.origin}/v1`,
+    icon: Icons.flame, hint: "↵ copy",
+    action: () => cpCopy(`${location.origin}/v1`, "Copied API base URL"),
+  });
+
+  // Per-slot control verbs — hidden from the empty-query view; surfaced by
+  // typing a verb ("restart", "logs") or a slot name. The mutating verbs
+  // dispatch hal0:slot-* events handled by SlotActionBridge.
+  const slotAct = (id, label, sub, fn, keywords) => items.push({
+    id, section: "Slot actions", label, sub, icon: Icons.slots, action: fn,
+    hint: "↵ run", hideWhenEmpty: true, keywords,
+  });
+  (slots || []).forEach(s => {
+    const kw = `${s.name} ${s.type} ${s.device}`;
+    if (CP_RUNNING_STATES.has(s.state)) {
+      slotAct(`sa-restart-${s.name}`, `Restart ${s.name}`, "reload the slot",
+        () => window.dispatchEvent(new CustomEvent("hal0:slot-restart", { detail: { name: s.name } })),
+        `restart reload ${kw}`);
+      slotAct(`sa-stop-${s.name}`, `Stop ${s.name}`, "unload from memory",
+        () => window.dispatchEvent(new CustomEvent("hal0:slot-stop", { detail: { name: s.name } })),
+        `stop unload ${kw}`);
+    } else {
+      slotAct(`sa-start-${s.name}`, `Start ${s.name}`, "load into memory",
+        () => window.dispatchEvent(new CustomEvent("hal0:slot-start", { detail: { name: s.name } })),
+        `start load ${kw}`);
+    }
+    slotAct(`sa-logs-${s.name}`, `View logs — ${s.name}`, "open the live log drawer",
+      () => cpViewLogs(s.name), `logs tail ${kw}`);
+    slotAct(`sa-curl-${s.name}`, `Copy curl — ${s.name}`, "chat/completions example",
+      () => cpCopy(cpCurlFor(s.name), `Copied curl for ${s.name}`), `copy curl api ${kw}`);
+  });
 
   return items;
 }
 
-Object.assign(window, { CommandPalette });
+// Headless, always-mounted bridge: runs the real slot mutations in
+// response to hal0:slot-* events fired by the palette (or anywhere). Lives
+// at the root (main.jsx) so slot control works from every route without
+// depending on SlotsView being mounted.
+function SlotActionBridge() {
+  const restart = useSlotRestart();
+  const load = useSlotLoad();
+  const unload = useSlotUnload();
+  React.useEffect(() => {
+    const toast = (m, k) => window.__hal0Toast && window.__hal0Toast(m, k);
+    const onRestart = (e) => { const n = e.detail && e.detail.name; if (n) { toast(`Restarting ${n}`, "info"); restart.mutate(n); } };
+    const onStart = (e) => { const n = e.detail && e.detail.name; if (n) { toast(`Starting ${n}`, "info"); load.mutate(n); } };
+    const onStop = (e) => { const n = e.detail && e.detail.name; if (n) { toast(`Stopping ${n}`, "info"); unload.mutate(n); } };
+    window.addEventListener("hal0:slot-restart", onRestart);
+    window.addEventListener("hal0:slot-start", onStart);
+    window.addEventListener("hal0:slot-stop", onStop);
+    return () => {
+      window.removeEventListener("hal0:slot-restart", onRestart);
+      window.removeEventListener("hal0:slot-start", onStart);
+      window.removeEventListener("hal0:slot-stop", onStop);
+    };
+  }, [restart, load, unload]);
+  return null;
+}
+
+Object.assign(window, { CommandPalette, SlotActionBridge });

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -220,6 +220,7 @@ function App() {
       />
 
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
+      <SlotActionBridge />
 
       {toast && (
         <div className={"hal0-toast " + (toast.kind || "info")} role="status" aria-live="polite">

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -669,6 +669,14 @@ function SlotsView({ slotVariant, npuVariant, slotParam, onGo }) {
     return () => window.removeEventListener("hal0:create-slot", onOpen);
   }, []);
 
+  // Open the live log drawer for a slot — fired by the command palette's
+  // "View logs — <slot>" action (which routes here first).
+  React.useEffect(() => {
+    const onLogs = (e) => { const n = e && e.detail && e.detail.name; if (n) setLogsForSlot(n); };
+    window.addEventListener("hal0:slot-logs", onLogs);
+    return () => window.removeEventListener("hal0:slot-logs", onLogs);
+  }, []);
+
   // Close menus on outside click
   React.useEffect(() => {
     const off = () => { setSwapName(null); setMenuName(null); };


### PR DESCRIPTION
## Why

The ⌘K command palette was the last `dash/*.jsx` holdout still reading the static `HAL0_DATA` fixture for its **Slots/Models** lists — so in production it rendered phantom seed slots that never matched the real inventory (especially wrong after the recent rocmfp4 slots landed). Its **Actions** section had also drifted: ~half the items were toast-only stubs or dispatched events with no listener.

## What

**Live data + cleanup**
- Slots/Models now come from live `useSlots()` / `useModels()`, mounted only while the palette is open (`CommandPaletteInner`) — no background polling when closed.
- Removed 4 dead actions: `restart-lemond`, `restart-flm`, `clear-downloads` (toast-only, no endpoint) and `replay-tour` (`hal0:tour-start` had no listener anywhere).
- Made 3 fakes real: `open-owui` / `docs` now `window.open(...)`; `add-hf` drops its dead `hal0:add-hf` event and just navigates to `/models`.

**New, fully-wired actions** (all real — no new stubs)
- **Per-slot Start/Stop/Restart/View-logs** — state-aware (Stop+Restart for running slots, Start for stopped), hidden from the empty-query view and surfaced by typing a verb or slot name. Mutating verbs dispatch `hal0:slot-*` events handled by a headless `SlotActionBridge` mounted at root, so they work from **any** route (not just `/slots`).
- **Cancel download** — only shown while a pull is genuinely live, via a new `hal0:pull-ended` signal emitted from `usePullJob`'s terminal + cancel paths (so it's never a dead affordance).
- **Copy API base URL** (`<origin>/v1`) + per-slot **Copy curl** against `/v1/chat/completions` (slot name is the `model`, per the dispatcher remap).

## Files
- `ui/src/dash/command-palette.jsx` — rework + `SlotActionBridge`
- `ui/src/dash/slots.jsx` — `hal0:slot-logs` listener → opens the log drawer
- `ui/src/dash/main.jsx` — mount `<SlotActionBridge/>`
- `ui/src/api/hooks/useModels.ts` — emit `hal0:pull-ended` on terminal/cancel

## Verification
- `tsc --noEmit` clean · `vite build` green · `dashboard-v3` palette spec passes
- Rebased clean onto latest main (incl. #488 models redesign); rebuilt green

🤖 Generated with [Claude Code](https://claude.com/claude-code)