### PR TITLE
fix(lemonade): classify the ROCmFP4 fork binary as rocm, not cpu

### DIFF
--- a/src/hal0/providers/lemonade.py
+++ b/src/hal0/providers/lemonade.py
@@ -147,6 +147,11 @@ def device_to_backend(device: str | None) -> tuple[str | None, str | None]:
 _BACKEND_PATH_MARKERS: tuple[tuple[str, str], ...] = (
     ("/vulkan/", "vulkan"),
     ("/rocm-stable/", "rocm"),
+    # Custom ROCmFP4 fork (charlie12345/rocmfp4-llama) wired via lemond
+    # rocm_bin — its install path has no /rocm-stable/ marker, so without
+    # this it falls through to the cpu fallback and the dashboard shows a
+    # bogus declared≠actual mismatch for rocm slots serving FP4 models.
+    ("/rocmfp4-llama/", "rocm"),
 )
 
 

--- a/tests/providers/test_lemonade.py
+++ b/tests/providers/test_lemonade.py
@@ -375,6 +375,18 @@ def test_resolve_actual_backend_rocm(monkeypatch: pytest.MonkeyPatch) -> None:
     assert resolve_actual_backend(entry) == "rocm"
 
 
+def test_resolve_actual_backend_rocmfp4_fork(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The custom ROCmFP4 fork binary has no /rocm-stable/ marker; it must
+    # still classify as rocm rather than fall through to the cpu fallback.
+    _patch_actual_backend_chain(
+        monkeypatch,
+        pid=4245,
+        exe="/opt/rocmfp4-llama/bin/llama-server",
+    )
+    entry = {"model_name": "m", "backend_url": "http://127.0.0.1:8001/v1"}
+    assert resolve_actual_backend(entry) == "rocm"
+
+
 def test_resolve_actual_backend_cpu_when_no_gpu_marker(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
resolve_actual_backend (ADR-0022) only recognised `/vulkan/` and `/rocm-stable/` binary paths as GPU. The custom `charlie12345/rocmfp4-llama` binary at `/opt/rocmfp4-llama/bin/llama-server` (wired via lemond `rocm_bin`) matches neither, so it fell through to the cpu fallback — the dashboard showed a bogus declared(rocm)≠actual(cpu) **mismatch** on every rocm slot serving an FP4 model, despite lemond reporting `device=gpu/backend=rocm`. Adds a `/rocmfp4-llama/` marker + test. Verified live: primary now reports declared=rocm/actual=rocm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)