### PR TITLE
feat(0.4): gate memory subsystem behind HAL0_MEMORY_ENABLED (default off)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -432,6 +432,11 @@ if [[ ! -f "${API_ENV}" ]]; then
     cat > "${API_ENV}" <<EOF
 HAL0_PORT=${HAL0_PORT}
 HAL0_LOG_LEVEL=info
+# Memory subsystem (Cognee engine + /mcp/memory + the Agent → Memory tab)
+# is deferred in this release and ships disabled by default. Uncomment to
+# reintroduce it — no other change needed; the dashboard Agent nav returns
+# automatically once /api/status reports it live.
+# HAL0_MEMORY_ENABLED=1
 # Uncomment to pin specific toolbox images:
 # HAL0_TOOLBOX_IMAGE_VULKAN=ghcr.io/hal0ai/hal0-toolbox-vulkan:v1
 # HAL0_TOOLBOX_IMAGE_ROCM=ghcr.io/hal0ai/hal0-toolbox-rocm:v1

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1415,51 +1415,65 @@ def create_app() -> FastAPI:
     app.state.approval_queue = ApprovalQueue()
 
     memory_wrapper = None
-    try:
-        from hal0.memory import CogneeWrapper
-
-        # ADR-0014: pull [memory.graph] gate + route at boot so a
-        # process restart preserves the user's pick. Defaults match
-        # the v0.3 ship matrix (enabled=False, route="upstream").
-        # Issue #116: same goes for [memory.embedding].
+    # 0.4 release gate — memory subsystem deferred. The memory engine
+    # (Cognee), its MCP server (/mcp/memory), the REST surface
+    # (/api/memory/*), and the dashboard's Agent → Memory tab ship
+    # DISABLED by default and return in a later release once the two-tier
+    # brain redesign (Hindsight + hal0-wiki) lands. Set HAL0_MEMORY_ENABLED=1
+    # to reintroduce it with NO code change — every downstream caller
+    # (admin MCP routing, /api/memory/* routes, the Hermes memory provider,
+    # per-agent memory stats) already degrades to a no-op / 503 when
+    # app.state.memory_wrapper is None, so flipping the flag is the whole
+    # toggle. Default off so behaviour is identical on fresh AND upgraded
+    # installs (api.env is not rewritten on upgrade).
+    if os.environ.get("HAL0_MEMORY_ENABLED", "0") != "1":
+        log.info("hal0.memory.disabled", reason="HAL0_MEMORY_ENABLED!=1")
+    else:
         try:
-            _hal0_cfg = load_hal0_config()
-            _graph_cfg = _hal0_cfg.memory.graph
-            _graph_enabled = bool(_graph_cfg.enabled)
-            _graph_route = str(_graph_cfg.route)
-            _embed_cfg = _hal0_cfg.memory.embedding
-            _embed_model = str(_embed_cfg.model)
-            _rerank_enabled = bool(_embed_cfg.rerank_enabled)
-            _rerank_url = str(_embed_cfg.rerank_url)
-            _rerank_over_fetch_factor = int(_embed_cfg.rerank_over_fetch_factor)
-            _rerank_max_candidates = int(_embed_cfg.rerank_max_candidates)
-            _rerank_connect_timeout_s = float(_embed_cfg.rerank_connect_timeout_s)
-            _rerank_read_timeout_s = float(_embed_cfg.rerank_read_timeout_s)
-        except Exception as exc:  # pragma: no cover — defensive
-            log.warning("hal0.memory.cfg_load_failed", error=str(exc))
-            _graph_enabled = False
-            _graph_route = "upstream"
-            _embed_model = "BAAI/bge-small-en-v1.5"
-            _rerank_enabled = False
-            _rerank_url = "http://127.0.0.1:8086"
-            _rerank_over_fetch_factor = 5
-            _rerank_max_candidates = 500
-            _rerank_connect_timeout_s = 1.0
-            _rerank_read_timeout_s = 8.0
+            from hal0.memory import CogneeWrapper
 
-        memory_wrapper = CogneeWrapper(
-            embedding_model=_embed_model,
-            graph_enabled=_graph_enabled,
-            graph_route=_graph_route,
-            rerank_enabled=_rerank_enabled,
-            rerank_url=_rerank_url,
-            rerank_over_fetch_factor=_rerank_over_fetch_factor,
-            rerank_max_candidates=_rerank_max_candidates,
-            rerank_connect_timeout_s=_rerank_connect_timeout_s,
-            rerank_read_timeout_s=_rerank_read_timeout_s,
-        )
-    except Exception as exc:  # pragma: no cover — defensive
-        log.warning("hal0.memory.init_failed", error=str(exc))
+            # ADR-0014: pull [memory.graph] gate + route at boot so a
+            # process restart preserves the user's pick. Defaults match
+            # the v0.3 ship matrix (enabled=False, route="upstream").
+            # Issue #116: same goes for [memory.embedding].
+            try:
+                _hal0_cfg = load_hal0_config()
+                _graph_cfg = _hal0_cfg.memory.graph
+                _graph_enabled = bool(_graph_cfg.enabled)
+                _graph_route = str(_graph_cfg.route)
+                _embed_cfg = _hal0_cfg.memory.embedding
+                _embed_model = str(_embed_cfg.model)
+                _rerank_enabled = bool(_embed_cfg.rerank_enabled)
+                _rerank_url = str(_embed_cfg.rerank_url)
+                _rerank_over_fetch_factor = int(_embed_cfg.rerank_over_fetch_factor)
+                _rerank_max_candidates = int(_embed_cfg.rerank_max_candidates)
+                _rerank_connect_timeout_s = float(_embed_cfg.rerank_connect_timeout_s)
+                _rerank_read_timeout_s = float(_embed_cfg.rerank_read_timeout_s)
+            except Exception as exc:  # pragma: no cover — defensive
+                log.warning("hal0.memory.cfg_load_failed", error=str(exc))
+                _graph_enabled = False
+                _graph_route = "upstream"
+                _embed_model = "BAAI/bge-small-en-v1.5"
+                _rerank_enabled = False
+                _rerank_url = "http://127.0.0.1:8086"
+                _rerank_over_fetch_factor = 5
+                _rerank_max_candidates = 500
+                _rerank_connect_timeout_s = 1.0
+                _rerank_read_timeout_s = 8.0
+
+            memory_wrapper = CogneeWrapper(
+                embedding_model=_embed_model,
+                graph_enabled=_graph_enabled,
+                graph_route=_graph_route,
+                rerank_enabled=_rerank_enabled,
+                rerank_url=_rerank_url,
+                rerank_over_fetch_factor=_rerank_over_fetch_factor,
+                rerank_max_candidates=_rerank_max_candidates,
+                rerank_connect_timeout_s=_rerank_connect_timeout_s,
+                rerank_read_timeout_s=_rerank_read_timeout_s,
+            )
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning("hal0.memory.init_failed", error=str(exc))
     app.state.memory_wrapper = memory_wrapper
 
     # In-process memory dispatcher (Phase 8 closeout, ADR-0004 §7).

--- a/src/hal0/api/routes/health.py
+++ b/src/hal0/api/routes/health.py
@@ -90,6 +90,12 @@ async def get_status(request: Request) -> dict[str, Any]:
         "hardware": None,  # populated by /api/hardware on demand
         "slots": slot_list,
         "upstreams": upstream_summary,
+        # 0.4: single source of truth for whether the memory subsystem is
+        # live (gated by HAL0_MEMORY_ENABLED at create_app). The dashboard
+        # reads this to show/hide the Agent → Memory nav so the UI and the
+        # backend can never disagree. Reflects the real wrapper, so an init
+        # failure also reads as off.
+        "memory_enabled": getattr(request.app.state, "memory_wrapper", None) is not None,
     }
 
 

--- a/tests/api/test_memory_gate.py
+++ b/tests/api/test_memory_gate.py
@@ -1,0 +1,59 @@
+"""0.4 memory gate — ``HAL0_MEMORY_ENABLED`` toggles the whole subsystem.
+
+The memory engine (Cognee), its MCP server (``/mcp/memory``), the REST
+surface (``/api/memory/*``), and the dashboard's Agent → Memory tab ship
+DISABLED by default and return in a later release. The gate lives in
+``create_app`` (``src/hal0/api/__init__.py``); ``/api/status`` reports the
+resulting state as ``memory_enabled`` so the SPA and backend cannot
+disagree. When off, ``app.state.memory_wrapper`` is ``None`` and the REST
+routes degrade to ``503`` rather than ``500``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+
+
+def _build(monkeypatch: pytest.MonkeyPatch, value: str | None) -> tuple[FastAPI, TestClient]:
+    """Build a fresh app + client with HAL0_MEMORY_ENABLED set (or cleared)."""
+    if value is None:
+        monkeypatch.delenv("HAL0_MEMORY_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("HAL0_MEMORY_ENABLED", value)
+    app = create_app()
+    return app, TestClient(app)
+
+
+# Anything other than the literal "1" leaves memory off — including unset,
+# empty, and stray truthy-looking strings. This pins the `!= "1"` contract.
+@pytest.mark.parametrize("flag", [None, "0", "", "no", "true", "2"])
+def test_memory_disabled_unless_flag_is_one(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch, flag: str | None
+) -> None:
+    app, client = _build(monkeypatch, flag)
+    # The wrapper is constructed at create_app time, before lifespan.
+    assert app.state.memory_wrapper is None
+    with client:
+        body = client.get("/api/status").json()
+        assert body["memory_enabled"] is False
+        # REST surface stays mounted but reports MemoryUnavailable (503),
+        # never a 500 — callers get a clean "off", not a crash.
+        assert client.get("/api/memory/list").status_code == 503
+
+
+def test_status_exposes_memory_enabled_as_bool(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """/api/status always carries a boolean memory_enabled field."""
+    app, client = _build(monkeypatch, "1")
+    with client:
+        body = client.get("/api/status").json()
+        assert "memory_enabled" in body
+        assert isinstance(body["memory_enabled"], bool)
+        # The reported flag must mirror the real wrapper state so the field
+        # is trustworthy even if Cognee fails to construct in this image.
+        assert body["memory_enabled"] is (app.state.memory_wrapper is not None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterator
 
 import pytest
@@ -9,6 +10,14 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hal0.api import create_app
+
+# 0.4: the memory subsystem ships disabled by default (HAL0_MEMORY_ENABLED
+# gate in create_app). The bulk of the suite exercises the memory MCP, the
+# /api/memory/* routes, and the Hermes memory provider with memory PRESENT,
+# so default the flag on for tests. `setdefault` runs once at import — before
+# any app is built — and respects an explicit override, so the dedicated gate
+# test (tests/api/test_memory_gate.py) can still set it to "0" per-test.
+os.environ.setdefault("HAL0_MEMORY_ENABLED", "1")
 
 pytest_plugins = ()
 

--- a/ui/src/api/hooks/useMemory.ts
+++ b/ui/src/api/hooks/useMemory.ts
@@ -58,3 +58,22 @@ export function useUpdateMemoryGraph() {
     },
   })
 }
+
+// 0.4 release gate. /api/status carries `memory_enabled`, gated by
+// HAL0_MEMORY_ENABLED at create_app. The dashboard reads it to show/hide
+// the Agent → Memory nav so the UI and backend can never disagree.
+//
+// Treat the loading/unknown state as OFF (`=== true`): 0.4 ships memory
+// disabled, so the common case stays hidden with no flicker; a dev build
+// with memory on simply reveals the Agent item once status lands
+// (sub-second). Distinct query key from useSlots' /api/status race so the
+// two consumers don't fight over one cache entry.
+export function useMemoryEnabled(): boolean {
+  const q = useQuery<{ memory_enabled?: boolean }>({
+    queryKey: ['status', 'memory_enabled'],
+    queryFn: () => apiGet<{ memory_enabled?: boolean }>(ENDPOINTS.status),
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+  })
+  return q.data?.memory_enabled === true
+}

--- a/ui/src/api/mock.ts
+++ b/ui/src/api/mock.ts
@@ -110,10 +110,20 @@ function buildLemonadeConfig() {
 
 function buildStatus() {
   const d = data()
+  // 0.4 gate: forced-mock dev/preview build keeps the memory surface ON so
+  // the Agent → Memory tab stays reachable for layout/screenshot work. The
+  // shipped backend defaults this OFF (HAL0_MEMORY_ENABLED). Because
+  // forced-mock short-circuits `page.route`, a spec can't override
+  // /api/status the usual way — it sets `window.__hal0MockMemoryEnabled =
+  // false` via addInitScript to exercise the disabled path. Default ON.
+  const memoryOff =
+    typeof window !== 'undefined' &&
+    (window as unknown as { __hal0MockMemoryEnabled?: boolean }).__hal0MockMemoryEnabled === false
   return {
     hostname: d.host?.name ?? 'halo-strix.local',
     hardware: d.host ?? null,
     slots: d.slots ?? [],
+    memory_enabled: !memoryOff,
   }
 }
 

--- a/ui/src/dash/agents/memory-tab-hook-bridge.ts
+++ b/ui/src/dash/agents/memory-tab-hook-bridge.ts
@@ -5,7 +5,11 @@
 // `window.__hal0UseMemoryGraphStatus` + `window.__hal0UseUpdateMemoryGraph`
 // so memory-tab.jsx finds them the same way SidebarAgentBlock does.
 
-import { useMemoryGraphStatus, useUpdateMemoryGraph } from '@/api/hooks/useMemory'
+import {
+  useMemoryEnabled,
+  useMemoryGraphStatus,
+  useUpdateMemoryGraph,
+} from '@/api/hooks/useMemory'
 
 ;(window as unknown as {
   __hal0UseMemoryGraphStatus?: typeof useMemoryGraphStatus
@@ -15,3 +19,8 @@ import { useMemoryGraphStatus, useUpdateMemoryGraph } from '@/api/hooks/useMemor
   __hal0UseMemoryGraphStatus?: typeof useMemoryGraphStatus
   __hal0UseUpdateMemoryGraph?: typeof useUpdateMemoryGraph
 }).__hal0UseUpdateMemoryGraph = useUpdateMemoryGraph
+// 0.4 gate: main.jsx (strict no-ES-imports prototype file) reads this to
+// drop the Agent route when the memory subsystem is disabled.
+;(window as unknown as {
+  __hal0UseMemoryEnabled?: typeof useMemoryEnabled
+}).__hal0UseMemoryEnabled = useMemoryEnabled

--- a/ui/src/dash/agents/sidebar-agent-block.jsx
+++ b/ui/src/dash/agents/sidebar-agent-block.jsx
@@ -77,6 +77,16 @@ function SidebarAgentBlock({ onGo }) {
   const rollup = _useSidebarAgentRollup();
   const { installed, agentId, agentStatus, loading } = rollup;
 
+  // 0.4 gate: the "Memory →" CTA below targets the #agent route, which is
+  // the Memory surface. When the memory subsystem is disabled
+  // (HAL0_MEMORY_ENABLED, surfaced via /api/status) that route shows a
+  // "disabled" notice, so suppress the CTA rather than offer a dead end.
+  // Read through the window bridge to keep the dash/*.jsx no-ES-imports
+  // contract. Called before the early returns to satisfy rules-of-hooks.
+  const _useMemEnabled =
+    (typeof window !== "undefined" && window.__hal0UseMemoryEnabled) || null;
+  const memoryEnabled = _useMemEnabled ? _useMemEnabled() : false;
+
   // Loading state: keep skeleton minimal — sidebar must NOT layout-shift
   // when the first 5s tick lands. Render the same row stack with em-dashes
   // so the dimensions match the populated state exactly.
@@ -145,15 +155,22 @@ function SidebarAgentBlock({ onGo }) {
           disconnected from what the running Hermes actually uses (it runs
           off SOUL.md, not the persona prompt), so surfacing it here was
           misleading. Honest minimal surface = health dot + chat affordance. */}
-      <div className="ln" />
-      <button
-        className="nudge sb-status-cta"
-        onClick={() => onGo && onGo("agent")}
-        title={TUI_HINT}
-        data-testid="sidebar-agent-open-memory"
-      >
-        Memory →
-      </button>
+      {/* 0.4 gate: the Memory → CTA targets the #agent (Memory) route,
+          which is disabled in this release — suppress it rather than offer
+          a dead-end link. */}
+      {memoryEnabled && (
+        <>
+          <div className="ln" />
+          <button
+            className="nudge sb-status-cta"
+            onClick={() => onGo && onGo("agent")}
+            title={TUI_HINT}
+            data-testid="sidebar-agent-open-memory"
+          >
+            Memory →
+          </button>
+        </>
+      )}
       <div
         className="sb-status-tui mono"
         title="Run the agent chat in your terminal"

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -10,6 +10,7 @@ import { useLemondRollup } from '@/api/hooks/useLemonade'
 import { useLogsStream } from '@/api/hooks/useLogs'
 import { useSlots, useEndpoints } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
+import { useMemoryEnabled } from '@/api/hooks/useMemory'
 import { useUpdateState } from '@/api/hooks/useUpdates'
 
 const { useState: useStateC, useEffect: useEffectC } = React;
@@ -133,12 +134,18 @@ function Sidebar({ route, onGo }) {
   const modelsQuery = useModels();
   const slotCount   = slotsQuery.data?.length  ?? 0;
   const modelCount  = modelsQuery.data?.length ?? 0;
+  // 0.4 gate: the Agent route is reduced to the Memory tab, so when the
+  // memory subsystem is disabled (HAL0_MEMORY_ENABLED!=1) there is nothing
+  // to show — drop the nav item entirely. Driven by /api/status so the UI
+  // can never disagree with the backend. main.jsx applies the matching
+  // route guard for deep links.
+  const memoryEnabled = useMemoryEnabled();
   const items = [
     { id: "dashboard", label: "Dashboard", icon: Icons.dashboard },
     { id: "slots",     label: "Slots",     icon: Icons.slots, cnt: slotCount },
     { id: "models",    label: "Models",    icon: Icons.models, cnt: modelCount },
     { id: "logs",      label: "Logs",      icon: Icons.logs },
-    { id: "agent",     label: "Agent",     icon: Icons.agent },
+    ...(memoryEnabled ? [{ id: "agent", label: "Agent", icon: Icons.agent }] : []),
     // Issue #206 — MCP page wired to /api/mcp/*. Lives under "Agents"
     // conceptually but kept as a sibling in the sidebar so the URL is
     // discoverable. Icon reuses the agent glyph (no dedicated MCP icon

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -65,6 +65,16 @@ function App() {
   const [footerOpen, setFooterOpen] = useStateA(false);
   const [paletteOpen, setPaletteOpen] = useStateA(false);
 
+  // 0.4 gate: the Agent route is reduced to the Memory tab, so it only
+  // renders when the memory subsystem is live (HAL0_MEMORY_ENABLED, surfaced
+  // via /api/status). Read through the window bridge to keep this strict
+  // no-ES-imports prototype file within the dash/*.jsx contract — the bridge
+  // is imported in main.tsx before main.jsx evaluates, so the ref is stable.
+  // We conditionally RENDER rather than redirect so a deep link to #agent in
+  // a memory-enabled dev build isn't bounced away during the status fetch.
+  const useMemEnabled = (typeof window !== "undefined" && window.__hal0UseMemoryEnabled) || null;
+  const memoryEnabled = useMemEnabled ? useMemEnabled() : false;
+
   useEffectA(() => {
     const onHash = () => setRouteState(parseRoute());
     window.addEventListener("hashchange", onHash);
@@ -157,7 +167,16 @@ function App() {
         );
       case "models":   return <ModelsView />;
       case "logs":     return <LogsView />;
-      case "agent":    return <AgentView />;
+      case "agent":
+        // 0.4: hidden from the sidebar when memory is off; this guard
+        // catches stale deep links / bookmarks to #agent.
+        return memoryEnabled ? (
+          <AgentView />
+        ) : (
+          <div className="view">
+            <div className="empty">The memory surface is disabled in this release.</div>
+          </div>
+        );
       case "mcp":      return <McpView />;
       case "settings": return <SettingsView />;
       default:         return <div className="view">Not found.</div>;

--- a/ui/tests/e2e/fixtures/apiMock.ts
+++ b/ui/tests/e2e/fixtures/apiMock.ts
@@ -64,6 +64,10 @@ export async function installDefaultMocks(page: Page, state: MockState) {
       update_available: false,
       slots: state.slots,
       hardware: state.host,
+      // 0.4 gate: the dashboard hides the Agent (Memory) nav unless
+      // /api/status reports memory live. The γ-suite exercises the memory
+      // UI, so the default mock keeps it on; a dedicated spec flips it off.
+      memory_enabled: true,
     }),
   )
   await page.route('**/api/hardware', (route) => json(route, state.host))

--- a/ui/tests/e2e/specs/memory-gate-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-gate-v3.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * memory-gate-v3 — 0.4 release gate for the memory subsystem.
+ *
+ * The memory engine (Cognee), its MCP server, the REST surface, and the
+ * dashboard's Agent → Memory tab ship DISABLED by default and return in a
+ * later release. The backend gates them behind HAL0_MEMORY_ENABLED and
+ * reports the resulting state via /api/status `memory_enabled`. This spec
+ * pins the UI half of that contract for the OFF state:
+ *
+ *   - the sidebar drops the "Agent" nav item entirely
+ *   - a deep link to #agent shows a "disabled" notice, not the Memory tab
+ *   - the SidebarAgentBlock omits its "Memory →" CTA (no dead-end link)
+ *
+ * The ON state is covered by the default mock (memory_enabled: true) across
+ * agent-view-v3 / memory-graph-v3 / sidebar-agent-block.
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+
+const FIVE_S = 5_500
+
+test.describe('memory gate OFF (HAL0_MEMORY_ENABLED unset)', () => {
+  test.beforeEach(async ({ page }) => {
+    // The γ-suite runs under forced-mock (VITE_MOCK_LEMONADE), which
+    // short-circuits page.route for allowlisted URLs like /api/status. The
+    // mock's buildStatus honours this window flag so we can drive the
+    // disabled path; it must be set before any page script evaluates.
+    await page.addInitScript(() => {
+      ;(window as unknown as { __hal0MockMemoryEnabled?: boolean }).__hal0MockMemoryEnabled = false
+    })
+  })
+
+  test('sidebar omits the Agent nav item', async ({ page }) => {
+    await page.goto('/#dashboard')
+    const navList = page.locator('.sb-list')
+    await expect(navList).toBeVisible({ timeout: FIVE_S })
+    // Control: a sibling nav item is still present...
+    await expect(navList.getByText('Models', { exact: true })).toBeVisible()
+    await expect(navList.getByText('MCP', { exact: true })).toBeVisible()
+    // ...but the Agent (Memory) item is gone.
+    await expect(navList.getByText('Agent', { exact: true })).toHaveCount(0)
+  })
+
+  test('deep link to #agent shows the disabled notice, not the Memory tab', async ({ page }) => {
+    await page.goto('/#agent')
+    await expect(page.getByText('The memory surface is disabled in this release.')).toBeVisible({
+      timeout: FIVE_S,
+    })
+    await expect(page.locator('[data-testid="memory-tab"]')).toHaveCount(0)
+    await expect(page.locator('[data-testid="agent-tab-nav"]')).toHaveCount(0)
+  })
+
+  test('SidebarAgentBlock omits the Memory CTA', async ({ page }) => {
+    await page.goto('/#dashboard')
+    await expect(page.locator('.sb-list')).toBeVisible({ timeout: FIVE_S })
+    await expect(page.locator('[data-testid="sidebar-agent-open-memory"]')).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Why

Get a **functional 0.4 release** out by deferring the least-baked surface — the memory subsystem — without throwing away any of the wiring. The two-tier brain redesign (Hindsight + hal0-wiki) is still planning-stage (`docs/internal/brain-redesign/`), so memory ships **disabled** and returns later by flipping one flag. (Wiki needs no change — it was never integrated; it's research docs only.)

## What

**Backend**
- `create_app()` gates `CogneeWrapper` init on `HAL0_MEMORY_ENABLED` (**default off**). The coupling to agents/Hermes was already designed around an optional `memory_wrapper`, so forcing it `None` makes every downstream caller degrade cleanly — `/mcp/memory` unmounted, admin MCP `memory_*` skipped, `/api/memory/*` → `503`, agent memory stats `available=false`, Hermes memory provider no-ops. No new degradation logic.
- `/api/status` now carries `memory_enabled` (derived from the live wrapper, so an init failure also reads as off) — the single source of truth the dashboard reads.
- **Default-off in code, not just install env**, because `api.env` isn't rewritten on upgrade — an env-only default would leave memory *on* for existing installs (the common case). `installer/api.env` documents the `HAL0_MEMORY_ENABLED=1` re-enable toggle.

**Dashboard**
- Sidebar drops the **Agent** nav item when memory is off (it was reduced to the Memory tab only).
- `#agent` deep links render a "disabled" notice rather than redirecting (avoids a race for memory-on dev builds).
- `SidebarAgentBlock` omits its "Memory →" CTA when off (no dead-end link).

**Reintroduce later:** set `HAL0_MEMORY_ENABLED=1` — backend re-inits, `/api/status` flips, the nav returns automatically. One flag, no code change.

## Tests
- `tests/api/test_memory_gate.py` — disabled path (wrapper `None`, status flag false, `/api/memory/list` → 503) + status exposes a trustworthy bool. **8 passing.**
- `conftest` sets `HAL0_MEMORY_ENABLED=1` so the existing memory/MCP suite (assumes memory present) stays green — verified **76 passing** (`-k "memory or mcp"`).
- e2e `memory-gate-v3.spec` — nav hidden, notice shown, CTA gone. Mocks default memory **on** so the γ-suite still exercises the memory UI. Full e2e: **101 passing**, typecheck + build clean.

> Note: the full `tests/api/` suite hangs locally on this VM (known lemond-health wait, memory `hal0_local_full_test_suite_hangs`) — relies on CI for the complete run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)