### PR TITLE
fix(installer): pin real LEMONADE_SHA256 (#493)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -843,10 +843,14 @@ LEMONADE_VERSION="v10.6.0"
 LEMONADE_VERSION_BARE="${LEMONADE_VERSION#v}"
 LEMONADE_TARBALL="lemonade-embeddable-${LEMONADE_VERSION_BARE}-ubuntu-x64.tar.gz"
 LEMONADE_URL="https://github.com/lemonade-sdk/lemonade/releases/download/${LEMONADE_VERSION}/${LEMONADE_TARBALL}"
-# SHA-256 of the upstream artefact at v10.6.0. Placeholder pre-pin; gate
-# release on populating with the real checksum. HAL0_SKIP_LEMONADE_SHA=1
-# lets CI / dev installs proceed against the placeholder explicitly.
-LEMONADE_SHA256="0000000000000000000000000000000000000000000000000000000000000000"
+# SHA-256 of the upstream artefact (the ${LEMONADE_TARBALL} asset on the
+# lemonade-sdk/lemonade ${LEMONADE_VERSION} GitHub release). When bumping
+# LEMONADE_VERSION, re-pin this from the release's published digest:
+#   gh api repos/lemonade-sdk/lemonade/releases/tags/${LEMONADE_VERSION} \
+#     --jq '.assets[] | select(.name=="'"${LEMONADE_TARBALL}"'") | .digest'
+# (equivalently: curl -fsSL "${LEMONADE_URL}" | sha256sum). HAL0_SKIP_LEMONADE_SHA=1
+# lets CI / dev installs proceed without a matching checksum explicitly.
+LEMONADE_SHA256="3b50b5cc5a9695f970b85f5cf3023297bde215f2230c993134e670baab2474a1"
 
 LEMONADE_PREFIX="/opt/lemonade"
 LEMONADE_CACHE_DIR="${VAR_DIR}/lemonade"


### PR DESCRIPTION
## What

Replaces the placeholder `LEMONADE_SHA256="0000…"` in `installer/install.sh` with the verified checksum of the pinned `lemonade-embeddable-10.6.0-ubuntu-x64.tar.gz` asset:

`3b50b5cc5a9695f970b85f5cf3023297bde215f2230c993134e670baab2474a1`

## Why

With the placeholder and `HAL0_SKIP_LEMONADE_SHA` unset (the default), the installer **refuses to extract the Lemonade tarball** (`install.sh:971-976`) — so a fresh `curl | bash` install ends with a running dashboard and **no inference daemon**. Highest-value, lowest-effort release blocker from the 2026-06-05 install audit.

## Verification

- `gh api repos/lemonade-sdk/lemonade/releases/tags/v10.6.0` digest for the ubuntu-x64 asset == pinned value
- `curl -fsSL <asset> | sha256sum` == pinned value (matches what `install.sh` computes at line 970)
- `bash -n install.sh` passes
- Placeholder guard (line 971) still intact for the all-zeros case; now falls through to the real comparison which matches.

## Note (out of scope, flagging)

v10.6.0 has documented runtime quirks (unload GPU-cleanup hang; whisper RUNPATH ≤10.6). A version **bump** is a separate decision — this PR only pins the SHA for the currently-pinned version. The bump procedure is now documented inline.

Closes #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)