### PR TITLE
fix(ui): remove slot-card overflow (⋯) menu; inline Logs button

### DIFF
--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -728,40 +728,6 @@ function InlineSwapPopover({ slot, open, onClose, onPick }) {
   );
 }
 
-// ─── Overflow menu (⋯) ──────────────────────────────────────────
-function SlotOverflowMenu({ slot, onClose, onViewLogs, onDelete }) {
-  return (
-    <Menu
-      anchor="right"
-      onClose={onClose}
-      items={[
-        {
-          icon: Icons.logs,
-          label: "View slot logs",
-          onClick: () => onViewLogs && onViewLogs(),
-        },
-        {
-          icon: Icons.flame,
-          label: slot.isDefault ? "Already default" : "Set as default",
-          onClick: () => window.__hal0Toast && window.__hal0Toast(`${slot.name} set as default for ${slot.type}`, "ok"),
-        },
-        {
-          icon: Icons.ext,
-          label: "Copy curl example",
-          onClick: () => window.__hal0Toast && window.__hal0Toast("curl example copied to clipboard", "ok"),
-        },
-        { divider: true },
-        {
-          icon: Icons.unload,
-          label: "Delete slot",
-          danger: true,
-          onClick: () => onDelete && onDelete(),
-        },
-      ]}
-    />
-  );
-}
-
 // ─── Slot logs drawer ────────────────────────────────────────────
 // Minimal SSE-backed log tail. The slot-logs stream endpoint
 // (ENDPOINTS.slotLogsStream) emits one JSON-lines event per log line;
@@ -883,4 +849,4 @@ function ErrorSlotCardBanner({ slot, message }) {
   );
 }
 
-Object.assign(window, { CreateSlotModal, EditSlotDrawer, InlineSwapPopover, SlotOverflowMenu, EmptySlotCard, ErrorSlotCardBanner, SlotLogsDrawer });
+Object.assign(window, { CreateSlotModal, EditSlotDrawer, InlineSwapPopover, EmptySlotCard, ErrorSlotCardBanner, SlotLogsDrawer });

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -201,17 +201,13 @@ function SlotCard({
   slot,
   onSwap,
   onEdit,
-  onOverflow,
   onRestart,
   onUnload,
   onStart,
   onSwapPick,
   onViewLogs,
-  onDelete,
   swapOpen,
   onCloseSwap,
-  menuOpen,
-  onCloseMenu,
   errorMsg,
   busy,
 }) {
@@ -279,18 +275,9 @@ function SlotCard({
         <div className="slot-name">
           <span className="nm">{slot.name}</span>
         </div>
-        <div className="right" style={{position: "relative"}}>
+        <div className="right">
           {isDefault && <div className="default-badge">★ default</div>}
           {coresident && <span className="chip" style={{color: "var(--dev-npu)", borderColor: "rgba(200,150,255,0.30)", background: "rgba(200,150,255,0.06)"}}>coresident</span>}
-          <button className="more" onClick={e => { e.stopPropagation(); onOverflow && onOverflow(); }}>{Icons.more}</button>
-          {menuOpen && (
-            <SlotOverflowMenu
-              slot={slot}
-              onClose={onCloseMenu}
-              onViewLogs={onViewLogs}
-              onDelete={onDelete}
-            />
-          )}
         </div>
       </div>
       <div className="slot-model mono" onClick={onSwap} style={{position: "relative"}}>
@@ -364,6 +351,7 @@ function SlotCard({
             >{Icons.restart} Restart</button>
           </>
         )}
+        <button className="btn ghost sm" onClick={() => onViewLogs && onViewLogs()}>{Icons.logs} Logs</button>
         <button className="btn ghost sm" onClick={onEdit}>{Icons.edit} Edit</button>
         <span className="spacer" />
       </div>
@@ -619,7 +607,6 @@ function SlotsView({ slotVariant, npuVariant, slotParam, onGo }) {
   const [createDefaults, setCreateDefaults] = useStateS({});
   const [editName, setEditName] = useStateS(null);
   const [swapName, setSwapName] = useStateS(null);
-  const [menuName, setMenuName] = useStateS(null);
   const [logsForSlot, setLogsForSlot] = useStateS(null);
   const [busyName, setBusyName] = useStateS(null);
   const { active: activeBanners } = useBanners();
@@ -679,7 +666,7 @@ function SlotsView({ slotVariant, npuVariant, slotParam, onGo }) {
 
   // Close menus on outside click
   React.useEffect(() => {
-    const off = () => { setSwapName(null); setMenuName(null); };
+    const off = () => { setSwapName(null); };
     document.addEventListener("click", off);
     return () => document.removeEventListener("click", off);
   }, []);
@@ -716,11 +703,8 @@ function SlotsView({ slotVariant, npuVariant, slotParam, onGo }) {
       errorMsg={errorMsg}
       busy={busyName === s.name}
       swapOpen={swapName === s.name}
-      onSwap={(e) => { e.stopPropagation(); setSwapName(swapName === s.name ? null : s.name); setMenuName(null); }}
+      onSwap={(e) => { e.stopPropagation(); setSwapName(swapName === s.name ? null : s.name); }}
       onCloseSwap={() => setSwapName(null)}
-      menuOpen={menuName === s.name}
-      onOverflow={() => { setMenuName(menuName === s.name ? null : s.name); setSwapName(null); }}
-      onCloseMenu={() => setMenuName(null)}
       onEdit={() => { window.location.hash = "#slots/" + s.name; }}
       onRestart={() =>
         runMutation(s.name, restartMut, s.name, `Restarting ${s.name}`)
@@ -739,8 +723,7 @@ function SlotsView({ slotVariant, npuVariant, slotParam, onGo }) {
           `Swapping ${s.name} → ${m.longName || m.id}`,
         )
       }
-      onViewLogs={() => { setLogsForSlot(s.name); setMenuName(null); }}
-      onDelete={() => { setEditName(s.name); setMenuName(null); }}
+      onViewLogs={() => { setLogsForSlot(s.name); }}
     />
   );
 

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -1665,12 +1665,6 @@ a { color: inherit; text-decoration: none; }
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
-.slot .more {
-  width: 22px; height: 22px;
-  display: inline-flex; align-items: center; justify-content: center;
-  color: var(--fg-4); cursor: pointer; border-radius: var(--rad-sm);
-}
-.slot .more:hover { color: var(--fg); background: var(--bg-2); }
 
 .slot-model {
   display: flex; align-items: center; gap: 8px;

--- a/ui/tests/e2e/specs/slots-wireup-v3.spec.ts
+++ b/ui/tests/e2e/specs/slots-wireup-v3.spec.ts
@@ -4,7 +4,7 @@
  * Covers the six lifecycle paths the slot panel must drive end-to-end:
  *   1. Create  — `New slot` modal POSTs /api/slots.
  *   2. Edit    — drawer PUTs /config + PATCHes /defaults (ctx_size).
- *   3. Delete  — overflow menu → confirm → DELETE /api/slots/{name}.
+ *   3. Delete  — Edit drawer danger button → confirm → DELETE /api/slots/{name}.
  *   4. Swap    — inline popover POSTs /api/slots/{name}/swap.
  *   5. Restart — card button POSTs /api/slots/{name}/restart.
  *   6. Unload  — card button POSTs /api/slots/{name}/unload.
@@ -94,7 +94,7 @@ test.describe('Slots v3 wire-up (/slots)', () => {
     await expect.poll(() => putBodies.length).toBeGreaterThan(0)
   })
 
-  test('Delete slot — overflow → confirm → DELETE /api/slots/{name}', async ({ page }) => {
+  test('Delete slot — drawer danger button → confirm → DELETE /api/slots/{name}', async ({ page }) => {
     const deletes: string[] = []
     await page.route('**/api/slots/primary', async (route) => {
       if (route.request().method() === 'DELETE') {


### PR DESCRIPTION
## What

The slot-card top-right **`⋯` overflow menu** was an odd, hard-to-use affordance — a white box that turned grey on hover and opened a clumsy banner whose labels wrapped to 3 lines in the narrow column. Of its four actions, two were non-functional theater and one was redundant. Rather than polish a kebab menu carrying a single useful action, this **removes it** and surfaces that action inline.

### Before → After
| Menu action | Verdict | Result |
|---|---|---|
| View slot logs | the one real action | → **`Logs` button** in the bottom action row, beside Edit |
| Copy curl example | never actually copied (toast-only) | removed |
| Set as default | no backend at all — no endpoint, serializer never emits `isDefault`, field only in mock data | removed |
| Delete slot | redundant — only opened the Edit drawer, where the real Delete already lives | removed (delete stays in the drawer) |

The card top-right is now clean (just name + status/badges); the action row reads **Start/Stop · Restart · Logs · Edit**.

## Changes
- `slots.jsx` — remove the `⋯` button + `SlotOverflowMenu` render and all its open/close plumbing (`menuName` state, `onOverflow`/`menuOpen`/`onCloseMenu` props); add the `Logs` button wired to the existing `onViewLogs` → `SlotLogsDrawer` path.
- `slot-modals.jsx` — delete `SlotOverflowMenu` and its window export.
- `dashboard.css` — remove now-dead `.slot .more` styles.
- `slots-wireup-v3.spec.ts` — correct the stale "delete via overflow menu" wording (the test already exercised the drawer's Delete button, which is unchanged and still passes).

## Verification
Live on https://hal0.thinmint.dev (Playwright): the `⋯` button is gone (`0` `.more` elements, no `.hal0-menu` in DOM), every card's action row is `Start · Logs · Edit`, and the `Logs` button opens the slot logs drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
