### PR TITLE
fix(installer): link /usr/local/bin/hal0-agent (#496)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -345,6 +345,10 @@ if [[ ! -d "${VENV_DIR}" ]]; then
 fi
 PIP="${VENV_DIR}/bin/pip"
 HAL0_BIN="${VENV_DIR}/bin/hal0"
+# The `hal0-agent` console script (pyproject [project.scripts]) is the
+# stable entry point the `hal0-agent@.service` unit ExecStart's. pip
+# installs it alongside `hal0` in the venv.
+HAL0_AGENT_BIN="${VENV_DIR}/bin/hal0-agent"
 
 # Refresh pip + install hal0 in editable mode pointing at this checkout.
 # ui_spinner_run drops the >/dev/null — the spinner shows the live tail
@@ -368,6 +372,21 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
         info "linked ${HAL0_PATH_LINK} → ${HAL0_BIN}"
     else
         warn "could not link ${HAL0_PATH_LINK} (check permissions); add ${VENV_DIR}/bin to PATH manually"
+    fi
+    # Also link `hal0-agent` — the `hal0-agent@.service` unit ExecStart's
+    # `/usr/local/bin/hal0-agent`, so without this symlink the agent units
+    # fail with status=203/EXEC the moment an operator runs
+    # `hal0 agent bootstrap hermes`. Derive the link dir from HAL0_PATH_LINK
+    # so a relocated `hal0` keeps `hal0-agent` beside it.
+    HAL0_AGENT_LINK="$(dirname "${HAL0_PATH_LINK}")/hal0-agent"
+    if [[ -x "${HAL0_AGENT_BIN}" ]]; then
+        if ln -sfn "${HAL0_AGENT_BIN}" "${HAL0_AGENT_LINK}" 2>/dev/null; then
+            info "linked ${HAL0_AGENT_LINK} → ${HAL0_AGENT_BIN}"
+        else
+            warn "could not link ${HAL0_AGENT_LINK} (check permissions); agent units need it on PATH"
+        fi
+    else
+        warn "hal0-agent shim not found at ${HAL0_AGENT_BIN} — agent units will fail until it is linked"
     fi
 fi
 

--- a/installer/uninstall.sh
+++ b/installer/uninstall.sh
@@ -212,6 +212,12 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
     else
         info "${HAL0_PATH_LINK} not present"
     fi
+    # hal0-agent shim symlink (created alongside hal0 by install.sh)
+    HAL0_AGENT_LINK="$(dirname "${HAL0_PATH_LINK}")/hal0-agent"
+    if [[ -L "${HAL0_AGENT_LINK}" ]] || [[ -f "${HAL0_AGENT_LINK}" ]]; then
+        rm -f "${HAL0_AGENT_LINK}"
+        info "Removed ${HAL0_AGENT_LINK}"
+    fi
 fi
 
 # ── Data dirs ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What
`install.sh` symlinks `/usr/local/bin/hal0` but not `hal0-agent`, while `hal0-agent@.service` `ExecStart`s `/usr/local/bin/hal0-agent`. So the moment an operator runs `hal0 agent bootstrap hermes`, the unit fails with `status=203/EXEC`.

This links the `hal0-agent` console script (installed by pip alongside `hal0`) into the same directory as the `hal0` link (derived from `HAL0_PATH_LINK` so a relocated CLI keeps them together), and removes it on uninstall. Fail-soft with a clear warning if the shim is missing.

## Verification
- `bash -n` clean on `install.sh` + `uninstall.sh`.
- `shellcheck -S warning` adds no new warnings (the lone pre-existing `SC2034` on `UI_STEP_TOTAL` is untouched).
- PR CI (python/ui/γ) does not execute `install.sh`; end-to-end coverage comes from the CT-200 fresh-install smoke harness (#407) and the nightly `agent-shim-smoke`.

Closes #496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)