### PR TITLE
fix(ui): keep slot-snapshot status label inside the sidebar card

### DIFF
--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -815,8 +815,12 @@ a { color: inherit; text-decoration: none; }
 .snap-rows { display: flex; flex-direction: column; }
 .snap-row {
   display: grid;
-  grid-template-columns: 14px 90px 1fr 80px 80px auto;
-  gap: 14px;
+  /* Sidebar is 380px: keep fixed tracks lean and let model + optional
+     chip columns shrink (minmax/auto) so the trailing status column
+     ("idle" / "N tok/s") stays inside the row's 16px right padding
+     instead of overflowing flush against the card border. */
+  grid-template-columns: 14px 84px minmax(0, 1fr) auto auto auto;
+  gap: 10px;
   align-items: center;
   padding: 10px 16px;
   border-bottom: 1px solid var(--line-soft);


### PR DESCRIPTION
## What

The **Slot snapshot** sidebar status label (`idle` / `N tok/s`) was pushed flush against the card border with no right padding.

## Why

`.snap-row` is a 6-column grid in a 380px sidebar. `1fr` (= `minmax(auto, 1fr)`) wouldn't shrink the model column below its name, and the fixed tracks (`14+90+80+80`) + `5×14px` gaps = 334px left only ~12px of the 346px content box for the trailing status column — so it overflowed past the row's 16px right padding and got clipped flush against the border by `.snap { overflow: hidden }`.

## Fix

- `minmax(0, 1fr)` on the model column so it can shrink (also re-enables its existing ellipsis, which never fired before).
- `auto` for the device-chip and badge tracks so they collapse to content when empty instead of reserving 80px each.
- gap `14px → 10px`.

Status label now sits inside the card with its full 16px right padding.

## Test

Clean rebuild (`rm -rf node_modules/.vite dist && npm run build`) succeeds; new grid present in `dist` CSS and served at https://hal0.thinmint.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)