### PR TITLE
ci: detect drift between bootstrap.sh and live install.sh

### DIFF
--- a/.github/workflows/bootstrap-parity.yml
+++ b/.github/workflows/bootstrap-parity.yml
@@ -1,0 +1,74 @@
+name: Bootstrap parity (daily)
+
+# Detect drift between the in-tree, audited installer/bootstrap.sh and the
+# LIVE one-liner served at https://hal0.dev/install.sh (hal0-web's mirrored
+# public/install.sh — what `curl https://hal0.dev/install.sh | bash` runs).
+#
+# Why this is NOT a required PR check:
+#   The check depends on the live public site. Network flakiness or a known,
+#   not-yet-synced drift would block every unrelated PR. Instead it runs on a
+#   daily schedule and on demand, surfacing drift in the run output so the
+#   installer team can reconcile hal0-web in a follow-up. The header of
+#   bootstrap.sh promises the two stay mirrored; this is the safety net.
+#
+# The script is the contract (scripts/check-bootstrap-parity.sh):
+#   exit 0 — in sync.   exit 1 — drift (unified diff printed).
+#   exit 2 — operational error (fetch failed / empty) — NOT read as drift.
+
+on:
+  schedule:
+    # 06:00 UTC daily — early enough that a fresh drift is visible at the
+    # start of the working day across the Americas/EU.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: bootstrap-parity
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  parity:
+    name: Diff in-tree bootstrap.sh against live install.sh
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout hal0
+        uses: actions/checkout@v4
+
+      - name: Run bootstrap-parity check
+        id: parity
+        # Exit 0 = in sync, 1 = drift, 2 = operational error. We surface the
+        # script's stdout/stderr (the unified diff lives there) into the step
+        # summary so a glance at the run page tells the whole story.
+        run: |
+          set +e
+          bash scripts/check-bootstrap-parity.sh > parity.out 2>&1
+          rc=$?
+          set -e
+
+          {
+            echo "## Bootstrap parity check"
+            echo ""
+            echo '```diff'
+            cat parity.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          cat parity.out
+
+          case "$rc" in
+            0)
+              echo "::notice::installer/bootstrap.sh is in sync with the live install.sh."
+              ;;
+            1)
+              echo "::error::DRIFT — installer/bootstrap.sh differs from the live hal0.dev/install.sh. Sync hal0-web:public/install.sh."
+              ;;
+            *)
+              echo "::warning::Could not fetch the live installer (operational error, exit ${rc}). NOT treated as drift."
+              ;;
+          esac
+          exit "$rc"

--- a/scripts/check-bootstrap-parity.sh
+++ b/scripts/check-bootstrap-parity.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# hal0 — bootstrap.sh ↔ live install.sh parity check (issue #494).
+#
+# Owner: installer team.
+# Triggered by: .github/workflows/bootstrap-parity.yml (daily + dispatch),
+#               and operators running locally to preview drift.
+#
+# The header of installer/bootstrap.sh declares that two files are MIRRORED
+# and must stay byte-identical:
+#       - Hal0ai/hal0:installer/bootstrap.sh   (canonical, audited)
+#       - Hal0ai/hal0-web:public/install.sh    (served at hal0.dev/install.sh)
+# "When you edit one, sync the other in the same PR." — with no enforcement,
+# the live one-liner (what `curl https://hal0.dev/install.sh | bash` actually
+# runs) can drift from the audited in-tree copy and execute un-reviewed code.
+#
+# This script fetches the LIVE served copy and diffs it against the in-tree
+# canonical copy. It is deliberately dependency-light: curl + diff only.
+#
+# Exit codes:
+#   0 — the two are byte-identical (in sync).
+#   1 — drift detected; a unified diff is printed to stdout.
+#   2 — operational error (could not fetch the live copy, missing local file,
+#       bad arguments). A transient site/network outage lands here so it is
+#       never misread as drift.
+#
+# Environment overrides:
+#   HAL0_INSTALL_URL  — URL of the live served installer
+#                       (default: https://hal0.dev/install.sh).
+
+set -euo pipefail
+
+# ── repo root resolution ────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+LOCAL_FILE="${REPO_ROOT}/installer/bootstrap.sh"
+INSTALL_URL="${HAL0_INSTALL_URL:-https://hal0.dev/install.sh}"
+
+# ── exit-code constants ─────────────────────────────────────────────────
+EXIT_OK=0
+EXIT_DRIFT=1
+EXIT_OPERROR=2
+
+err() { printf '%s\n' "$*" >&2; }
+
+# ── preconditions ───────────────────────────────────────────────────────
+if ! command -v curl >/dev/null 2>&1; then
+    err "ERROR: curl is required but not found on PATH."
+    exit "${EXIT_OPERROR}"
+fi
+
+if [[ ! -f "${LOCAL_FILE}" ]]; then
+    err "ERROR: canonical in-tree installer not found at: ${LOCAL_FILE}"
+    exit "${EXIT_OPERROR}"
+fi
+
+# ── fetch the live served copy ──────────────────────────────────────────
+REMOTE_FILE="$(mktemp)"
+cleanup() { rm -f "${REMOTE_FILE}"; }
+trap cleanup EXIT
+
+# -f  → fail (non-zero) on HTTP >= 400 instead of saving an error page.
+# -sS → quiet, but still print transport errors to stderr.
+# -L  → follow redirects (Cloudflare Pages may 30x to a canonical path).
+# Retries smooth over transient blips so a single flap is not read as drift.
+if ! curl -fsSL \
+        --retry 3 --retry-delay 2 --retry-connrefused \
+        --max-time 30 \
+        -o "${REMOTE_FILE}" \
+        "${INSTALL_URL}"; then
+    err "ERROR: failed to fetch live installer from: ${INSTALL_URL}"
+    err "       This is treated as an operational error, NOT drift —"
+    err "       a transient outage should not fail the parity check as a mismatch."
+    exit "${EXIT_OPERROR}"
+fi
+
+if [[ ! -s "${REMOTE_FILE}" ]]; then
+    err "ERROR: fetched an EMPTY response from: ${INSTALL_URL}"
+    err "       Treating as an operational error (NOT drift)."
+    exit "${EXIT_OPERROR}"
+fi
+
+# ── compare ─────────────────────────────────────────────────────────────
+# diff exit status: 0 = identical, 1 = differ, >1 = trouble.
+if diff -u "${LOCAL_FILE}" "${REMOTE_FILE}" \
+        --label "installer/bootstrap.sh (in-tree, canonical)" \
+        --label "${INSTALL_URL} (live, served)"; then
+    echo "OK: in-tree bootstrap.sh matches the live install.sh — no drift."
+    exit "${EXIT_OK}"
+fi
+
+err ""
+err "DRIFT: installer/bootstrap.sh differs from ${INSTALL_URL}."
+err "       The audited in-tree copy and the live one-liner have diverged."
+err "       Sync hal0-web:public/install.sh with hal0:installer/bootstrap.sh."
+exit "${EXIT_DRIFT}"


### PR DESCRIPTION
## What

Detects drift between the in-tree, audited `installer/bootstrap.sh` and the live one-liner served at `https://hal0.dev/install.sh` (hal0-web's mirrored `public/install.sh` — what `curl https://hal0.dev/install.sh | bash` actually runs). The header of `bootstrap.sh` declares the two are MIRRORED and synced by hand in the same PR, with no enforcement; this adds the safety net.

## Changes

- **`scripts/check-bootstrap-parity.sh`** — pure bash (`set -euo pipefail`), dependency-light (curl + diff only):
  - Fetches the live served installer (override via `HAL0_INSTALL_URL`).
  - Diffs it against `installer/bootstrap.sh`.
  - Exit `0` = identical, exit `1` = drift (prints a labelled unified diff), exit `2` = operational error (fetch failed / empty response).
  - A transient site/network outage lands on exit `2`, so it is **never** misread as drift. `curl --retry` smooths over single flaps.
- **`.github/workflows/bootstrap-parity.yml`** — runs the script on a **daily `schedule`** + `workflow_dispatch`. Deliberately **NOT a required PR check**: it depends on the live public site, and network flakiness or known not-yet-synced drift should not block every unrelated PR. The diff is surfaced in the run's step summary.

`.github/workflows/ci.yml` is untouched.

## Current parity status

**Presently IN SYNC.** Ran locally before committing:

```
$ bash scripts/check-bootstrap-parity.sh; echo exit=$?
OK: in-tree bootstrap.sh matches the live install.sh — no drift.
exit=0
```

No follow-up sync is required at this time. If they ever diverge, reconciling `hal0-web:public/install.sh` with `hal0:installer/bootstrap.sh` is the follow-up (this PR does not touch the live site or the hal0-web repo).

## Verification

- `shellcheck -S warning scripts/check-bootstrap-parity.sh` → clean.
- Script run locally → exit 0 (in sync).
- Workflow YAML validated.

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)