### PR TITLE
feat(cli): add --json to slot/model/agent list + show

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -31,7 +31,8 @@ UMA changes, GPU swaps, or RAM upgrades.
 ## Slots
 
 ```sh
-hal0 slot list
+hal0 slot list [--json]
+hal0 slot show <name> [--json]
 hal0 slot load <name> [--model M]
 hal0 slot unload <name>
 hal0 slot restart <name>
@@ -46,10 +47,33 @@ through `unloading → starting → warming → ready`.
 `hal0 slot logs <name> --follow` is the journald tail wrapped over
 SSE; it shows the same stream the dashboard's Logs view tails.
 
+### JSON output for pipes / CI
+
+`slot list`, `slot show`, `model list`, `model show`, and `agent list`
+take a `--json` flag that prints the raw API response and nothing else —
+no Rich table, no panel — so the output is safe to pipe into `grep`,
+`jq`, or a CI script even from a non-TTY:
+
+```sh
+hal0 slot list --json | jq '.[] | select(.provider=="llama-server")'
+hal0 slot show primary --json | jq .config
+```
+
+The JSON shape is exactly what the underlying endpoint returns:
+
+| Command            | Shape                                                        |
+| ------------------ | ----------------------------------------------------------- |
+| `slot list --json` | `GET /api/slots` — a JSON array of slot objects             |
+| `slot show --json` | `{ "status": <GET /api/slots/{name}>, "config": <GET …/config> }` |
+| `model list --json`| `GET /api/models` — typically `{ "models": [...] }`         |
+| `model show --json`| `GET /api/models/{ref}` — a single model object             |
+| `agent list --json`| `GET /api/agents` — typically `{ "agents": [...] }`         |
+
 ## Models
 
 ```sh
-hal0 model list
+hal0 model list [--json]
+hal0 model show <ref> [--json]
 hal0 model pull <ref>                        # HF streaming pull
 hal0 model rm <ref>
 hal0 model assign <ref> --slot S

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -9,6 +9,7 @@ ADR-0004 §5 "Pending items").
 
 from __future__ import annotations
 
+import json as jsonlib
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal
@@ -288,7 +289,13 @@ def _warn_memory_outcome(outcome: MemoryUninstallOutcome) -> None:
 
 
 @app.command("list")
-def agent_list() -> None:
+def agent_list(
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the raw /api/agents JSON for CI/pipe use (no Rich table).",
+    ),
+) -> None:
     """List installed bundled agents."""
     url = _api_base()
     if _api_unreachable(url):
@@ -297,6 +304,9 @@ def agent_list() -> None:
         data = api_get("/api/agents")
     except CliApiError as exc:
         die(str(exc))
+        return
+    if json_out:
+        typer.echo(jsonlib.dumps(data, indent=2))
         return
     agents = data.get("agents", []) if isinstance(data, dict) else data
     if not agents:

--- a/src/hal0/cli/model_commands.py
+++ b/src/hal0/cli/model_commands.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json as jsonlib
+
 import typer
 from rich.console import Console
 from rich.table import Table
@@ -33,7 +35,13 @@ def _fmt_size(b: int | None) -> str:
 
 
 @app.command("list")
-def model_list() -> None:
+def model_list(
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the raw /api/models JSON for CI/pipe use (no Rich table).",
+    ),
+) -> None:
     """List all models in the local registry and from upstreams."""
     url = _api_base()
     if _api_unreachable(url):
@@ -42,6 +50,9 @@ def model_list() -> None:
         data = api_get("/api/models")
     except CliApiError as exc:
         die(str(exc))
+        return
+    if json_out:
+        typer.echo(jsonlib.dumps(data, indent=2))
         return
     models = data.get("models", []) if isinstance(data, dict) else data
     table = Table(title=f"Models ({len(models)})")
@@ -175,6 +186,11 @@ def model_rm(
 @app.command("show")
 def model_show(
     ref: str = typer.Argument(..., help="Model ref to inspect"),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the raw model metadata JSON for CI/pipe use (no Rich table).",
+    ),
 ) -> None:
     """Show a model's metadata."""
     url = _api_base()
@@ -184,6 +200,9 @@ def model_show(
         m = api_get(f"/api/models/{ref}")
     except CliApiError as exc:
         die(str(exc))
+        return
+    if json_out:
+        typer.echo(jsonlib.dumps(m, indent=2))
         return
     table = Table(show_header=False, title=m.get("id", ref))
     for k, v in m.items():

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -131,7 +131,13 @@ def _fmt_state(state: str | None) -> str:
 
 
 @app.command("list")
-def slot_list() -> None:
+def slot_list(
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the raw /api/slots JSON for CI/pipe use (no Rich table).",
+    ),
+) -> None:
     """List all configured slots and their current state."""
     url = _api_base()
     if _api_unreachable(url):
@@ -140,6 +146,9 @@ def slot_list() -> None:
         slots = api_get("/api/slots")
     except CliApiError as exc:
         die(str(exc))
+        return
+    if json_out:
+        typer.echo(jsonlib.dumps(slots, indent=2))
         return
     table = Table(title="hal0 slots")
     table.add_column("Name", style="bold")
@@ -531,6 +540,11 @@ def slot_delete(
 @app.command("show")
 def slot_show(
     name: str = typer.Argument(..., help="Slot name to inspect"),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit raw JSON ({status, config}) for CI/pipe use (no Rich panel).",
+    ),
 ) -> None:
     """Show full slot config + status (GET /api/slots/{name})."""
     url = _api_base()
@@ -546,6 +560,9 @@ def slot_show(
     except CliApiError:
         cfg = None
     body = jsonlib.dumps({"status": status, "config": cfg}, indent=2)
+    if json_out:
+        typer.echo(body)
+        return
     console.print(
         Panel(
             Syntax(body, "json", theme="ansi_dark", background_color="default"),

--- a/tests/cli/test_json_output.py
+++ b/tests/cli/test_json_output.py
@@ -1,0 +1,128 @@
+"""Tests for ``--json`` machine-readable output on the list/show commands (#502).
+
+`slot list`, `model list`, `agent list`, `slot show`, and `model show` each
+grew a ``--json`` flag that emits the raw API response (the same payload the
+command already fetches) as ``json.dumps(..., indent=2)`` and returns,
+bypassing the Rich table/panel. Three hardware docs pipe
+``hal0 slot list --json | grep`` — this is the documented-but-missing feature.
+
+Each test stubs the shared API helpers so the CLI runs offline, then asserts
+``json.loads(result.output)`` round-trips to the stubbed payload.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import agent_commands, model_commands, slot_commands
+
+runner = CliRunner()
+
+
+def _stub_reachable(monkeypatch: pytest.MonkeyPatch, module: Any) -> None:
+    monkeypatch.setattr(module, "_api_unreachable", lambda _url: False)
+
+
+# ── slot list --json ─────────────────────────────────────────────────────────
+
+
+def test_slot_list_json_emits_raw_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = [
+        {"name": "primary", "status": "ready", "model": "qwen3-4b", "port": 8081},
+        {"name": "embed", "status": "offline", "model": "bge-m3", "port": 8086},
+    ]
+    _stub_reachable(monkeypatch, slot_commands)
+    monkeypatch.setattr(slot_commands, "api_get", lambda _p, **_k: payload)
+
+    result = runner.invoke(slot_commands.app, ["list", "--json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed == payload
+
+
+def test_slot_list_json_empty_is_valid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_reachable(monkeypatch, slot_commands)
+    monkeypatch.setattr(slot_commands, "api_get", lambda _p, **_k: [])
+
+    result = runner.invoke(slot_commands.app, ["list", "--json"])
+    assert result.exit_code == 0, result.output
+    # Empty must still be parseable JSON (the "No slots configured" Rich
+    # line would NOT parse), so grep pipelines don't choke.
+    assert json.loads(result.output) == []
+
+
+def test_slot_list_json_no_rich_markup(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = [{"name": "primary", "status": "ready"}]
+    _stub_reachable(monkeypatch, slot_commands)
+    monkeypatch.setattr(slot_commands, "api_get", lambda _p, **_k: payload)
+
+    result = runner.invoke(slot_commands.app, ["list", "--json"])
+    assert result.exit_code == 0, result.output
+    # No Rich table chrome should leak into JSON output.
+    assert "hal0 slots" not in result.output
+    assert "┃" not in result.output
+
+
+# ── model list --json ────────────────────────────────────────────────────────
+
+
+def test_model_list_json_emits_raw_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"models": [{"id": "qwen3-4b", "name": "Qwen3 4B", "size_bytes": 123}]}
+    _stub_reachable(monkeypatch, model_commands)
+    monkeypatch.setattr(model_commands, "api_get", lambda _p, **_k: payload)
+
+    result = runner.invoke(model_commands.app, ["list", "--json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed == payload
+
+
+# ── agent list --json ────────────────────────────────────────────────────────
+
+
+def test_agent_list_json_emits_raw_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"agents": [{"name": "hermes", "status": "running"}]}
+    _stub_reachable(monkeypatch, agent_commands)
+    monkeypatch.setattr(agent_commands, "api_get", lambda _p, **_k: payload)
+
+    result = runner.invoke(agent_commands.app, ["list", "--json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed == payload
+
+
+# ── slot show --json ─────────────────────────────────────────────────────────
+
+
+def test_slot_show_json_emits_status_and_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    status = {"name": "primary", "state": "ready"}
+    cfg = {"model": {"default": "qwen3-4b"}, "port": 8081}
+    _stub_reachable(monkeypatch, slot_commands)
+
+    def fake_get(path: str, **_kw: Any) -> dict[str, Any]:
+        return cfg if path.endswith("/config") else status
+
+    monkeypatch.setattr(slot_commands, "api_get", fake_get)
+
+    result = runner.invoke(slot_commands.app, ["show", "primary", "--json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed == {"status": status, "config": cfg}
+
+
+# ── model show --json ────────────────────────────────────────────────────────
+
+
+def test_model_show_json_emits_raw_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"id": "qwen3-4b", "name": "Qwen3 4B", "path": "/mnt/ai-models/x.gguf"}
+    _stub_reachable(monkeypatch, model_commands)
+    monkeypatch.setattr(model_commands, "api_get", lambda _p, **_k: payload)
+
+    result = runner.invoke(model_commands.app, ["show", "qwen3-4b", "--json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed == payload


### PR DESCRIPTION
## Summary

Adds a `--json` output flag to the CLI list/show commands that lacked one, for CI/pipe use with a stable shape. Closes the gap where three hardware docs already pipe `hal0 slot list --json | grep` but the flag didn't exist.

Commands gaining `--json`:
- `hal0 slot list`
- `hal0 model list`
- `hal0 agent list`
- `hal0 slot show`
- `hal0 model show`

Each prints the raw API response the command already fetches (`json.dumps(..., indent=2)`) and returns, bypassing the Rich table/panel — exactly the established `memory graph` / `doctor toolbox-pull` pattern. Non-TTY callers get clean parseable JSON.

## JSON shapes (= raw endpoint response)

| Command | Shape |
| --- | --- |
| `slot list --json` | `GET /api/slots` (array) |
| `slot show --json` | `{ "status": …, "config": … }` |
| `model list --json` | `GET /api/models` (`{ "models": [...] }`) |
| `model show --json` | `GET /api/models/{ref}` (object) |
| `agent list --json` | `GET /api/agents` (`{ "agents": [...] }`) |

## Acceptance criteria
- [x] `--json` on `slot list`, `model list`, `agent list`, `slot show`, `model show`
- [x] Non-TTY callers get parseable JSON (no Rich); empty results still emit valid JSON
- [x] The hardware-doc `slot list --json | grep` examples now work
- [x] Output shape documented (`docs/reference/cli.mdx`)

## Testing
TDD: added `tests/cli/test_json_output.py` (7 tests, written red-first). Full CLI suite green:

```
PYTHONPATH=src .venv/bin/python -m pytest -q tests/cli/   # 184 passed
```

`ruff check` clean; `ruff format --check src tests` clean.

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)