### PR TITLE
feat(updater): release yank/revoke mechanism (#499)

### DIFF
--- a/docs/internal/release-manifest.md
+++ b/docs/internal/release-manifest.md
@@ -269,6 +269,40 @@ installer's Lemonade + FLM constants (in `installer/install.sh`) are
 the live truth; the release manifest mirrors them via the new
 `lemonade` + `flm` blocks above.
 
+## Yanking a release
+
+If a published release turns out to be bad (broken cosign cert, regression,
+data-loss bug), **yank it** so `hal0 update` stops recommending it instead of
+deleting the GitHub release (which loses history and breaks anyone mid-download).
+
+A release is yanked by setting `revoked: true` on its channel manifest:
+
+```jsonc
+{
+  "version": "0.4.2",
+  "revoked": true,
+  "revoked_reason": "cosign cert mismatch — re-cut as 0.4.3",
+  // …all other fields unchanged…
+}
+```
+
+Effect (implemented in `hal0.updater`):
+
+- `Updater.check()` and `GET /api/updates/check` report `update_available: false`
+  for a revoked latest — the version is still surfaced (`revoked` + `revoked_reason`)
+  so the dashboard can explain why no update is offered, but the operator is never
+  nudged toward it. `updater.latest_revoked` is logged.
+- `GET /api/updates/state` carries `hal0.revoked` + `hal0.revoked_reason`.
+- Older manifests without the field parse as `revoked: false` (backward compatible).
+
+SOP:
+
+1. Re-upload the channel manifest asset with `revoked: true` + a `revoked_reason`
+   (`gh release upload <TAG> <channel>.json --clobber`).
+2. Annotate the GitHub release: `gh release edit <TAG> --notes "YANKED: <reason>"`.
+3. Cut and publish the fixed release; once a newer non-revoked version is the latest,
+   it supersedes the revoked one automatically.
+
 ## Related
 
 - `PLAN.md` §9 — Update mechanism spec

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -215,12 +215,20 @@ async def update_state(request: Request) -> dict[str, Any]:
     # a manifest fetch failure (dashboard shouldn't go blank just
     # because GitHub is rate-limiting).
     hal0_available: str | None = None
+    hal0_revoked = False
+    hal0_revoked_reason = ""
+    hal0_revoked_version: str | None = None
     try:
         manifest = await fetch_release_manifest(channel)
         if isinstance(manifest, dict):
             latest_raw = manifest.get("version") or manifest.get("latest_version") or ""
             latest = str(latest_raw)
-            if latest and _version_tuple(latest) > _version_tuple(__version__):
+            hal0_revoked = bool(manifest.get("revoked", False))
+            hal0_revoked_reason = str(manifest.get("revoked_reason") or "")
+            if hal0_revoked and latest:
+                hal0_revoked_version = latest
+            # A revoked latest is not offered (but its reason is surfaced).
+            if latest and not hal0_revoked and _version_tuple(latest) > _version_tuple(__version__):
                 hal0_available = latest
     except (OSError, ValueError):
         pass
@@ -233,6 +241,9 @@ async def update_state(request: Request) -> dict[str, Any]:
             "current": __version__,
             "available": hal0_available,
             "channel": channel,
+            "revoked": hal0_revoked,
+            "revoked_reason": hal0_revoked_reason,
+            "revoked_version": hal0_revoked_version,
         },
         "lemonade": {
             "current": _parse_lemonade_version(lemonade_raw),
@@ -286,16 +297,25 @@ async def check_updates(request: Request) -> dict[str, Any]:
         ) from exc
 
     latest = ""
+    revoked = False
+    revoked_reason = ""
     if isinstance(manifest, dict):
         latest_raw = manifest.get("version") or manifest.get("latest_version") or ""
         latest = str(latest_raw)
+        revoked = bool(manifest.get("revoked", False))
+        revoked_reason = str(manifest.get("revoked_reason") or "")
 
-    update_available = bool(latest) and _version_tuple(latest) > _version_tuple(__version__)
+    # A revoked (yanked) latest is never offered as an available update.
+    update_available = (
+        bool(latest) and not revoked and _version_tuple(latest) > _version_tuple(__version__)
+    )
     return {
         "current": __version__,
         "latest": latest or None,
         "channel": channel,
         "update_available": update_available,
+        "revoked": revoked,
+        "revoked_reason": revoked_reason,
         "manifest_url": url,
         "manifest": manifest if isinstance(manifest, dict) else {},
     }

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -176,6 +176,19 @@ class ReleaseManifest(BaseModel):
         ge=1,
         description="Minimum config schema version required after this update.",
     )
+    revoked: bool = Field(
+        default=False,
+        description=(
+            "True if this release has been yanked/withdrawn. A revoked latest "
+            "is not recommended by ``hal0 update --check`` (see "
+            "``docs/internal/release-manifest.md`` → 'Yanking a release'). "
+            "Older manifests without this field parse as not-revoked."
+        ),
+    )
+    revoked_reason: str = Field(
+        default="",
+        description="Human-readable explanation shown when ``revoked`` is true.",
+    )
     released_at: str | None = Field(default=None, description="ISO-8601 release timestamp.")
     notes_url: str | None = Field(default=None, description="Release notes URL.")
     manifest_url: str | None = Field(default=None, description="Self-reference URL.")
@@ -212,6 +225,8 @@ class ReleaseInfo:
     signer_identity: str | None
     min_data_version: int | None
     notes_url: str | None = None
+    revoked: bool = False
+    revoked_reason: str = ""
     raw_manifest: dict[str, Any] = dataclasses.field(default_factory=dict)
 
 
@@ -824,11 +839,28 @@ class Updater:
         # with just {"version": "9.9.9"} — surface it without forcing a
         # full schema match. Strict validation happens inside ``apply()``.
         latest = ""
+        revoked = False
+        revoked_reason = ""
         if isinstance(raw, dict):
             latest = str(raw.get("version") or raw.get("latest_version") or "")
-        update_available = bool(latest) and _version_tuple(latest) > _version_tuple(
-            hal0.__version__
+            revoked = bool(raw.get("revoked", False))
+            revoked_reason = str(raw.get("revoked_reason") or "")
+        # A revoked (yanked/withdrawn) latest is never recommended — the
+        # operator should not be nudged toward a release we've pulled. The
+        # version is still surfaced (revoked + reason) so the dashboard can
+        # explain why no update is offered. See docs/internal/release-manifest.md.
+        update_available = (
+            bool(latest)
+            and not revoked
+            and _version_tuple(latest) > _version_tuple(hal0.__version__)
         )
+        if revoked and bool(latest):
+            log.warning(
+                "updater.latest_revoked",
+                version=latest,
+                channel=ch,
+                reason=revoked_reason,
+            )
         return ReleaseInfo(
             current=hal0.__version__,
             latest=latest or None,
@@ -839,6 +871,8 @@ class Updater:
             signer_identity=raw.get("signer_identity") if isinstance(raw, dict) else None,
             min_data_version=raw.get("min_data_version") if isinstance(raw, dict) else None,
             notes_url=raw.get("notes_url") if isinstance(raw, dict) else None,
+            revoked=revoked,
+            revoked_reason=revoked_reason,
             raw_manifest=raw if isinstance(raw, dict) else {},
         )
 

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -144,6 +144,61 @@ def test_check_no_update_when_versions_match(
     assert body["latest"] == __version__
 
 
+def test_check_revoked_latest_not_recommended(
+    isolated_client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A revoked latest must report update_available=False + surface the reason."""
+    manifest = _write_manifest(
+        tmp_path / "revoked.json",
+        {
+            "version": "99.9.9",
+            "url": "https://example.test/hal0-99.9.9.tar.gz",
+            "revoked": True,
+            "revoked_reason": "yanked: corrupt tarball",
+        },
+    )
+    monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest))
+
+    r = isolated_client.get("/api/updates/check")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["latest"] == "99.9.9"
+    assert body["update_available"] is False
+    assert body["revoked"] is True
+    assert body["revoked_reason"] == "yanked: corrupt tarball"
+
+
+def test_state_revoked_latest_surfaced(
+    isolated_client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET /api/updates/state nests revoked info in the hal0 block."""
+    from hal0.api.routes import updater as u_mod
+
+    monkeypatch.setattr(u_mod, "_probe_version", lambda _c: None)
+    manifest = _write_manifest(
+        tmp_path / "revoked.json",
+        {
+            "version": "99.9.9",
+            "url": "https://example.test/hal0-99.9.9.tar.gz",
+            "revoked": True,
+            "revoked_reason": "yanked: corrupt tarball",
+        },
+    )
+    monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest))
+
+    r = isolated_client.get("/api/updates/state")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # Top-level shape unchanged for the dashboard contract.
+    assert set(body.keys()) == {"hal0", "lemonade", "flm", "autoCheck"}
+    # Revoked latest is not advertised as available …
+    assert body["hal0"]["available"] is None
+    # … but the withdrawal is surfaced so the UI can show a note.
+    assert body["hal0"]["revoked"] is True
+    assert body["hal0"]["revoked_reason"] == "yanked: corrupt tarball"
+    assert body["hal0"]["revoked_version"] == "99.9.9"
+
+
 def test_check_bad_manifest_returns_envelope(
     isolated_client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -218,6 +218,39 @@ def test_manifest_schema_rejects_malformed_digest() -> None:
         _parse_manifest(payload)
 
 
+def test_manifest_schema_defaults_revoked_false(tmp_path: Path) -> None:
+    """An older manifest without a ``revoked`` field parses with revoked=False."""
+    tarball = _build_release_tarball(tmp=tmp_path, version="0.0.1")
+    sig = tmp_path / "sig"
+    sig.write_bytes(b"x")
+    payload = _write_release_manifest(
+        manifest_path=tmp_path / "latest.json",
+        tarball=tarball,
+        sig=sig,
+        version="0.0.1",
+    )
+    m = _parse_manifest(payload)
+    assert m.revoked is False
+    assert m.revoked_reason == ""
+
+
+def test_manifest_schema_accepts_revoked(tmp_path: Path) -> None:
+    """A manifest with ``revoked: true`` + reason parses and round-trips."""
+    tarball = _build_release_tarball(tmp=tmp_path, version="0.0.1")
+    sig = tmp_path / "sig"
+    sig.write_bytes(b"x")
+    payload = _write_release_manifest(
+        manifest_path=tmp_path / "latest.json",
+        tarball=tarball,
+        sig=sig,
+        version="0.0.1",
+        overrides={"revoked": True, "revoked_reason": "bad cosign cert"},
+    )
+    m = _parse_manifest(payload)
+    assert m.revoked is True
+    assert m.revoked_reason == "bad cosign cert"
+
+
 # ── check ──────────────────────────────────────────────────────────────────────
 
 
@@ -239,6 +272,64 @@ def test_check_handles_missing_manifest(
     monkeypatch.setenv("HAL0_RELEASES_URL", str(tmp_path / "nope.json"))
     with pytest.raises(UpdateError):
         asyncio.run(Updater().check())
+
+
+def test_check_does_not_recommend_revoked_latest(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A revoked latest manifest is NOT reported as an available update."""
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    version = "99.0.0"  # far ahead of __version__ so it WOULD update if not revoked
+    tarball = _build_release_tarball(tmp=artifacts, version=version)
+    sig = artifacts / f"hal0-{version}.tar.gz.sig"
+    sig.write_bytes(b"sig\n")
+    cert = artifacts / f"hal0-{version}.tar.gz.crt"
+    cert.write_bytes(b"cert\n")
+    manifest_path = artifacts / "latest.json"
+    _write_release_manifest(
+        manifest_path=manifest_path,
+        tarball=tarball,
+        sig=sig,
+        cert=cert,
+        version=version,
+        overrides={"revoked": True, "revoked_reason": "yanked: broken slot load"},
+    )
+    monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest_path))
+
+    info = asyncio.run(Updater().check())
+    assert info.latest == version
+    assert info.update_available is False
+    assert info.revoked is True
+    assert info.revoked_reason == "yanked: broken slot load"
+
+
+def test_check_recommends_non_revoked_newer_latest(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A non-revoked newer manifest IS reported as an available update."""
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    version = "99.0.0"
+    tarball = _build_release_tarball(tmp=artifacts, version=version)
+    sig = artifacts / f"hal0-{version}.tar.gz.sig"
+    sig.write_bytes(b"sig\n")
+    cert = artifacts / f"hal0-{version}.tar.gz.crt"
+    cert.write_bytes(b"cert\n")
+    manifest_path = artifacts / "latest.json"
+    _write_release_manifest(
+        manifest_path=manifest_path,
+        tarball=tarball,
+        sig=sig,
+        cert=cert,
+        version=version,
+    )
+    monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest_path))
+
+    info = asyncio.run(Updater().check())
+    assert info.latest == version
+    assert info.update_available is True
+    assert info.revoked is False
 
 
 # ── atomic symlink swap ────────────────────────────────────────────────────────

--- a/ui/src/api/hooks/useUpdates.ts
+++ b/ui/src/api/hooks/useUpdates.ts
@@ -15,6 +15,12 @@ export interface UpdateChannel {
   channel?: string
   pinned?: boolean
   source?: string
+  // Set when the latest release on this channel was yanked/withdrawn. When
+  // true, `available` is null (a revoked release is never offered) and the
+  // Settings → Updates surface can explain why with `revoked_reason`.
+  revoked?: boolean
+  revoked_reason?: string
+  revoked_version?: string | null
 }
 
 export interface UpdateState {


### PR DESCRIPTION
## What
Adds a yank mechanism so a withdrawn release stops being recommended by `hal0 update`, without deleting the GitHub release (which loses history / breaks in-flight downloads).

- `ReleaseManifest` gains optional `revoked: bool` + `revoked_reason: str` (older manifests parse as `revoked: false` — backward compatible).
- `Updater.check()`, `GET /api/updates/check`, and `GET /api/updates/state` no longer advertise a revoked latest as `update_available` / `available`; they surface `revoked` + `revoked_reason` (+ `revoked_version` on `/state`) so the dashboard can show *why* no update is offered. Logs `updater.latest_revoked`.
- `useUpdates.ts` `UpdateChannel` type carries the new fields (visible banner is a thin follow-up — the data is now plumbed end to end).
- `docs/internal/release-manifest.md` documents the yank SOP (`revoked: true` in the channel manifest + `gh release edit --notes "YANKED: …"`).

## Tests
TDD (the red tests came first): manifest parses revoked + defaults false; `check()` does not recommend a revoked latest; `/check` and `/state` expose the fields. **54 passed** (`tests/updater` + `tests/api/test_updater_routes`). `ruff check` + `ruff format --check src tests` clean.

Closes #499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)