### PR TITLE
feat(recommend): RAM-gated default primary + arch-max ctx (#512, #513)

### DIFF
--- a/src/hal0/hardware/recommend.py
+++ b/src/hal0/hardware/recommend.py
@@ -21,20 +21,35 @@ from __future__ import annotations
 from typing import Any
 
 from hal0.config.schema import HardwareInfo, map_backend_to_device
+from hal0.registry.curated import get_curated
 
 # Curated chat models suitable for the primary slot, ordered from
 # largest-context / most capable down to the smallest. We pick the
 # largest model whose ``vram_gb_min`` fits the detected hardware. All
 # three live in :mod:`hal0.registry.curated`; cross-referenced below.
-_PRIMARY_TIERS: list[tuple[str, float]] = [
-    # (curated_id, vram_gb_min) — must mirror CURATED_MODELS in
-    # src/hal0/registry/curated.py. Keep this sorted descending by
-    # capability, since recommend_primary_slot iterates and takes the
-    # first that fits.
-    ("qwen3-4b", 4.0),
-    ("phi3-mini", 3.0),
-    ("llama32-3b", 3.0),
+_PRIMARY_TIERS: list[tuple[str, float, str]] = [
+    # (curated_id, ram_gb_min, kind) — every id MUST exist in
+    # CURATED_MODELS (src/hal0/registry/curated.py); enforced by
+    # tests/registry/test_curation_drift.py and tests/hardware/test_recommend.py.
+    #
+    # GPU picks are RAM-gated on the *unified/total* host RAM — the same
+    # signal the bundle picker gates tiers on (bundles/eligibility.py),
+    # not a half-of-VRAM budget. Largest-that-fits wins, so keep the GPU
+    # rows sorted descending by ram_gb_min.
+    ("Qwen3.6-35B-A3B-MTP-GGUF", 48.0, "gpu"),  # hybrid MoE, ~45 tok/s, tiny KV
+    ("qwen3.5-9b", 16.0, "gpu"),  # dense 9B, comfortable mid-tier
+    ("qwen3-4b", 0.0, "gpu"),  # smallest GPU pick — always downloadable
+    # CPU/MIT fallbacks for hosts with no usable GPU.
+    ("llama32-3b", 0.0, "cpu"),
+    ("phi3-mini", 0.0, "cpu"),
 ]
+
+# Native context windows are read from the curated model's GGUF arch max.
+# MoE/MTP primaries have a tiny hybrid KV cache, so they default to the
+# full window; dense mid-tier models are capped to keep the KV predictable
+# on smaller boxes.
+_CTX_FALLBACK = 8192
+_DENSE_CTX_CAP = 32768
 
 # Strix Halo (UMA) is detected as an AMD GPU with no separate VRAM
 # carve-out, where the model-loading pool comes from GTT. The unified
@@ -44,14 +59,38 @@ _PRIMARY_TIERS: list[tuple[str, float]] = [
 _UMA_UNIFIED_GB_MIN = 32
 
 
-def _pick_chat_model(available_gb: float) -> str:
-    """Return the curated id of the largest chat model that fits."""
-    for cid, min_gb in _PRIMARY_TIERS:
-        if available_gb + 0.01 >= min_gb:
+def _pick_chat_model(ram_gb: float) -> str:
+    """Return the curated id of the largest GPU chat model that fits ``ram_gb``."""
+    for cid, min_gb, kind in _PRIMARY_TIERS:
+        if kind == "gpu" and ram_gb + 0.01 >= min_gb:
             return cid
-    # Fallback: smallest entry. Better to install something downloadable
-    # than to ship an empty default field.
+    # Fallback: smallest GPU entry. Better to ship something downloadable
+    # than an empty default field.
+    gpu_tiers = [t for t in _PRIMARY_TIERS if t[2] == "gpu"]
+    return gpu_tiers[-1][0]
+
+
+def _pick_cpu_model() -> str:
+    """Return the curated id of the default CPU-only chat model."""
+    for cid, _min_gb, kind in _PRIMARY_TIERS:
+        if kind == "cpu":
+            return cid
     return _PRIMARY_TIERS[-1][0]
+
+
+def _resolve_primary_ctx(model_id: str) -> int:
+    """Resolve the primary slot's context window from the curated arch max.
+
+    MoE/MTP primaries (tiny hybrid KV) get the full window; dense models
+    are capped at ``_DENSE_CTX_CAP``; unknown models fall back to
+    ``_CTX_FALLBACK``. Replaces the old flat hard-coded 8192 (#513).
+    """
+    curated = get_curated(model_id)
+    arch_max = curated.context_length if (curated and curated.context_length) else _CTX_FALLBACK
+    is_moe = bool(curated) and ("mtp" in curated.tags or "a3b" in curated.id.lower())
+    if is_moe:
+        return arch_max
+    return min(arch_max, _DENSE_CTX_CAP)
 
 
 def _backend_for(hw: HardwareInfo) -> tuple[str, str]:
@@ -128,14 +167,22 @@ def recommend_primary_slot(hw: HardwareInfo) -> dict[str, Any]:
           name, port, backend, provider, enabled, [model], [meta]
     """
     backend, backend_why = _backend_for(hw)
-    budget_gb = _vram_budget_gb(hw)
-    model_id = _pick_chat_model(budget_gb)
+    # RAM-gate the GPU pick on total/unified host RAM (the same signal the
+    # bundle picker uses), not a half-of-VRAM budget. CPU-only hosts get a
+    # small MIT-licensed fallback. (#512)
+    ram_gb = (hw.unified_memory_mb or hw.ram_mb) / 1024
+    budget_gb = _vram_budget_gb(hw)  # retained for the rationale only
+    if backend == "cpu":
+        model_id = _pick_cpu_model()
+        model_why = f"{model_id}: CPU-only host — small MIT-licensed fallback"
+    else:
+        model_id = _pick_chat_model(ram_gb)
+        model_why = f"{model_id}: largest curated chat model fitting ~{ram_gb:.0f} GB RAM"
 
-    # Context size: Qwen3 supports 32k natively, Llama 3.2 a wild 128k,
-    # Phi-3 only 4k. Default to 8k for the primary slot — long enough for
-    # most chats, short enough to keep KV cache predictable. Operators
-    # can bump it in the rendered TOML.
-    context_size = 8192
+    # Context window resolved from the curated arch max — MoE/MTP primary
+    # gets the full window (tiny hybrid KV), dense models are capped. No
+    # more flat hard-coded 8192. (#513)
+    context_size = _resolve_primary_ctx(model_id)
 
     # v0.2: emit ``device`` as the canonical hardware-preference field
     # (ADR-0006 §7). ``backend`` is also emitted so a downgrade to
@@ -156,9 +203,9 @@ def recommend_primary_slot(hw: HardwareInfo) -> dict[str, Any]:
         "_meta": {
             "rationale_backend": backend_why,
             "rationale_device": f"{device} (mapped from backend={backend!r})",
-            "rationale_model": (
-                f"{model_id}: largest curated chat model fitting ~{budget_gb:.1f} GB budget"
-            ),
+            "rationale_model": model_why,
+            "rationale_ctx": f"context_size={context_size} (from curated arch max)",
+            "host_ram_gb": round(ram_gb, 1),
             "vram_budget_gb": round(budget_gb, 1),
         },
     }

--- a/tests/hardware/test_recommend.py
+++ b/tests/hardware/test_recommend.py
@@ -1,0 +1,128 @@
+"""RAM-gated primary recommendation + ctx resolution (#512, #513).
+
+Covers:
+  * ``recommend_primary_slot`` selects the largest-that-fits curated chat
+    model by *unified RAM* (35B-A3B ≥48 GB, 9B 16–48 GB, 4B <16 GB), the
+    same RAM signal the bundle picker gates on.
+  * The primary slot ctx is resolved from the curated model's GGUF arch
+    max (capped per tier), not a flat hard-coded 8192. The MoE/MTP
+    primary defaults to a large ctx; small/CPU tiers stay conservative.
+"""
+
+from __future__ import annotations
+
+from hal0.config.schema import GPUInfo, HardwareInfo
+from hal0.hardware.recommend import (
+    _PRIMARY_TIERS,
+    _pick_chat_model,
+    recommend_primary_slot,
+)
+from hal0.registry.curated import CURATED_BY_ID
+
+
+def _amd_uma_host(unified_gb: int) -> HardwareInfo:
+    """A Strix-Halo-class AMD UMA host with ``unified_gb`` of unified RAM."""
+    mb = unified_gb * 1024
+    return HardwareInfo(
+        ram_mb=mb,
+        ram_available_mb=mb,
+        unified_memory_mb=mb,
+        gpus=[
+            GPUInfo(
+                vendor="amd",
+                name="Strix Halo",
+                vram_mb=512,  # UMA: no discrete carve-out
+                vulkan_capable=True,
+            )
+        ],
+    )
+
+
+def _cpu_only_host(ram_gb: int) -> HardwareInfo:
+    mb = ram_gb * 1024
+    return HardwareInfo(ram_mb=mb, ram_available_mb=mb, unified_memory_mb=mb, gpus=[])
+
+
+# ── #512: every tier id is curated (mirrors the drift test) ──────────────────
+
+
+def test_all_primary_tier_ids_are_curated() -> None:
+    missing = [cid for cid, *_ in _PRIMARY_TIERS if cid not in CURATED_BY_ID]
+    assert not missing, f"non-curated tier ids: {missing}"
+
+
+def test_default_tier_set_matches_brief() -> None:
+    ids = [cid for cid, *_ in _PRIMARY_TIERS]
+    # The three RAM-gated GPU picks must be present and canonical.
+    assert "Qwen3.6-35B-A3B-MTP-GGUF" in ids
+    assert "qwen3.5-9b" in ids
+    assert "qwen3-4b" in ids
+    # CPU/MIT fallbacks retained.
+    assert "phi3-mini" in ids
+    assert "llama32-3b" in ids
+
+
+# ── #512: RAM-gated selection ────────────────────────────────────────────────
+
+
+def test_96gb_strix_halo_seeds_35b_a3b() -> None:
+    hw = _amd_uma_host(96)
+    rec = recommend_primary_slot(hw)
+    assert rec["model"]["default"] == "Qwen3.6-35B-A3B-MTP-GGUF"
+
+
+def test_48gb_seeds_35b_a3b() -> None:
+    assert recommend_primary_slot(_amd_uma_host(48))["model"]["default"] == (
+        "Qwen3.6-35B-A3B-MTP-GGUF"
+    )
+
+
+def test_32gb_seeds_9b() -> None:
+    assert recommend_primary_slot(_amd_uma_host(32))["model"]["default"] == "qwen3.5-9b"
+
+
+def test_16gb_seeds_9b() -> None:
+    assert recommend_primary_slot(_amd_uma_host(16))["model"]["default"] == "qwen3.5-9b"
+
+
+def test_8gb_seeds_4b() -> None:
+    assert recommend_primary_slot(_amd_uma_host(8))["model"]["default"] == "qwen3-4b"
+
+
+def test_pick_chat_model_thresholds() -> None:
+    assert _pick_chat_model(48) == "Qwen3.6-35B-A3B-MTP-GGUF"
+    assert _pick_chat_model(47) == "qwen3.5-9b"
+    assert _pick_chat_model(16) == "qwen3.5-9b"
+    assert _pick_chat_model(15) == "qwen3-4b"
+    assert _pick_chat_model(8) == "qwen3-4b"
+
+
+# ── #513: ctx resolved from curated arch max, not hard-coded 8192 ────────────
+
+
+def test_moe_primary_gets_large_ctx() -> None:
+    rec = recommend_primary_slot(_amd_uma_host(96))
+    assert rec["model"]["default"] == "Qwen3.6-35B-A3B-MTP-GGUF"
+    # Hybrid SSM+attn KV is tiny — default to the full 131072 window.
+    assert rec["model"]["context_size"] == 131072
+
+
+def test_9b_primary_gets_capped_ctx() -> None:
+    rec = recommend_primary_slot(_amd_uma_host(32))
+    assert rec["model"]["default"] == "qwen3.5-9b"
+    # Dense 9B: cap below the arch max to keep the KV cache predictable.
+    ctx = rec["model"]["context_size"]
+    assert 0 < ctx <= 131072
+    assert ctx <= 32768  # conservative cap for a dense mid-tier on a small box
+
+
+def test_no_hardcoded_8192_for_moe() -> None:
+    rec = recommend_primary_slot(_amd_uma_host(96))
+    assert rec["model"]["context_size"] != 8192
+
+
+def test_cpu_host_gets_small_conservative_model() -> None:
+    # No GPU → fall back to a small CPU-friendly pick, never the 35B MoE.
+    rec = recommend_primary_slot(_cpu_only_host(64))
+    assert rec["model"]["default"] != "Qwen3.6-35B-A3B-MTP-GGUF"
+    assert rec["backend"] == "cpu"

--- a/tests/hardware/test_recommend.py
+++ b/tests/hardware/test_recommend.py
@@ -2,7 +2,7 @@
 
 Covers:
   * ``recommend_primary_slot`` selects the largest-that-fits curated chat
-    model by *unified RAM* (35B-A3B ≥48 GB, 9B 16–48 GB, 4B <16 GB), the
+    model by *unified RAM* (35B-A3B ≥48 GB, 9B 16-48 GB, 4B <16 GB), the
     same RAM signal the bundle picker gates on.
   * The primary slot ctx is resolved from the curated model's GGUF arch
     max (capped per tier), not a flat hard-coded 8192. The MoE/MTP
@@ -103,7 +103,7 @@ def test_pick_chat_model_thresholds() -> None:
 def test_moe_primary_gets_large_ctx() -> None:
     rec = recommend_primary_slot(_amd_uma_host(96))
     assert rec["model"]["default"] == "Qwen3.6-35B-A3B-MTP-GGUF"
-    # Hybrid SSM+attn KV is tiny — default to the full 131072 window.
+    # Hybrid SSM+attn KV is tiny - default to the full 131072 window.
     assert rec["model"]["context_size"] == 131072
 
 

--- a/tests/lemonade/test_server_models_gen.py
+++ b/tests/lemonade/test_server_models_gen.py
@@ -475,7 +475,25 @@ class TestSizeAndContext:
             },
         )
         out = generate_server_models(registry_path)
+        # No regression: a model with no GGUF ctx signal still gets the
+        # conservative 8192 fallback (#513 — small/unknown tiers stay safe).
         assert out["m"]["max_context_window"] == 8192
+
+    def test_large_arch_ctx_from_metadata_is_preserved(self, registry_path: Path) -> None:
+        """#513: a MoE primary advertising a 131072 arch max keeps it."""
+        _write_registry(
+            registry_path,
+            {
+                "moe-primary": {
+                    "path": "/x.gguf",
+                    "capabilities": ["chat"],
+                    "backends": ["vulkan"],
+                    "metadata": {"context_length": 131072},
+                },
+            },
+        )
+        out = generate_server_models(registry_path)
+        assert out["moe-primary"]["max_context_window"] == 131072
 
 
 # ── Snapshot ──────────────────────────────────────────────────────────────────

--- a/tests/registry/test_curation_drift.py
+++ b/tests/registry/test_curation_drift.py
@@ -47,7 +47,7 @@ def _manifest_model_refs() -> dict[str, list[str]]:
 
 
 def test_primary_tiers_ids_are_curated() -> None:
-    missing = [cid for cid, _ in _PRIMARY_TIERS if cid not in CURATED_BY_ID]
+    missing = [cid for cid, *_ in _PRIMARY_TIERS if cid not in CURATED_BY_ID]
     assert not missing, f"_PRIMARY_TIERS ids not defined in CURATED_MODELS: {missing}"
 
 


### PR DESCRIPTION
## What
Builds on the #500 curation unify.

**#512 — RAM-gated default primary.** `recommend_primary_slot` gated the pick on half-of-VRAM and a stale `[qwen3-4b, phi3-mini, llama32-3b]` tier list, so a 96GB Strix Halo seeded **qwen3-4b**. Now gates on total/unified host RAM (the signal `bundles/eligibility.py` uses) with canonical curated ids:

| RAM | primary |
|---|---|
| ≥48GB | `Qwen3.6-35B-A3B-MTP-GGUF` (~45 tok/s MoE) |
| 16–48GB | `qwen3.5-9b` |
| <16GB | `qwen3-4b` |
| CPU-only | `llama32-3b` / `phi3-mini` (MIT) |

**#513 — arch-max ctx.** The primary slot hard-coded `context_size=8192`. Now resolved from the curated arch max: MoE/MTP primary → full window (131072, tiny hybrid KV), dense → capped 32768, unknown → 8192 fallback. (`server_models_gen` already preserved registry metadata ctx — a regression test documents that; no change needed there.)

## Tests
TDD (the agent's red tests defined the contract): RAM thresholds (96/48/32/16/8GB), `_pick_chat_model` boundaries, MoE-vs-dense ctx, CPU fallback. Every `_PRIMARY_TIERS` id stays curated (drift test updated for the new 3-tuple). **123 passed** across `tests/hardware`, `tests/lemonade/test_server_models_gen`, `tests/registry/test_curation_drift`. `ruff` clean.

Closes #512.
Closes #513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)