### PR TITLE
feat(installer): verify-gate install.sh-from-tarball (#511)

### DIFF
--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -195,6 +195,11 @@ main() {
     ok "ready — handing off to installer"
     printf '\n'
 
+    # Signal install.sh that this tree was sha256 + cosign-verified above,
+    # so its release-verification gate lets us through without an explicit
+    # HAL0_INSTALL_SKIP_VERIFY opt-out.
+    export HAL0_BOOTSTRAP_VERIFIED=1
+
     # Pass through stdin so install.sh's interactive prompts work when
     # the user invoked us as `sudo bash install.sh`. When invoked via
     # curl|bash, stdin is closed and install.sh falls back to defaults.

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -154,6 +154,35 @@ fi
 VENV_DIR="${PREFIX}/.venv"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# ── Release verification gate ──────────────────────────────────────────────
+# Refuse to run as root against an UNVERIFIED release tree. The signed
+# install path (`curl -fsSL https://hal0.dev/install.sh | sudo bash`) runs
+# through bootstrap.sh, which sha256 + cosign-verifies the release tarball
+# and exports HAL0_BOOTSTRAP_VERIFIED=1 before exec'ing us. A git checkout
+# is trusted (you cloned it from your own remote) and --dev installs are
+# local. Any other path — e.g. someone who downloaded a random tarball and
+# ran `sudo bash install.sh` — would execute arbitrary code as root, so it
+# must opt in explicitly with HAL0_INSTALL_SKIP_VERIFY=1.
+if [[ "${DEV_MODE}" -eq 0 \
+      && "${HAL0_BOOTSTRAP_VERIFIED:-0}" != "1" \
+      && ! -d "${REPO_ROOT}/.git" ]]; then
+    if [[ "${HAL0_INSTALL_SKIP_VERIFY:-0}" == "1" ]]; then
+        warn "HAL0_INSTALL_SKIP_VERIFY=1 — installing from an UNVERIFIED source (no cosign check)"
+    else
+        die "Refusing to install from an unverified release tree.
+
+  This tree did NOT come through the signed installer (no cosign
+  verification, and it is not a git checkout). Installing it would run
+  arbitrary code as root.
+
+  Use the signed one-liner instead:
+      curl -fsSL https://hal0.dev/install.sh | sudo bash
+
+  Or, if you trust THIS source and accept the risk:
+      HAL0_INSTALL_SKIP_VERIFY=1 sudo bash installer/install.sh"
+    fi
+fi
+
 # Resolve pull destination: explicit flag / env wins, then an interactive
 # prompt (only when attached to a tty), then the FHS default. Always
 # absolute — relative paths under sudo would land in /root or wherever


### PR DESCRIPTION
## What
`install.sh` performed **no** signature verification — running it from a manually downloaded tarball executed arbitrary code as root (W3 audit §3). Adds a release-verification gate:

- Outside the signed bootstrap handoff, a **git checkout**, or **`--dev`**, `install.sh` refuses unless `HAL0_INSTALL_SKIP_VERIFY=1` is set explicitly.
- `bootstrap.sh` (which already sha256 + cosign-verifies the release) now `export HAL0_BOOTSTRAP_VERIFIED=1` before exec'ing `install.sh`, so the signed `curl … | sudo bash` one-liner passes the gate unchanged.

Landed after #493 (real Lemonade SHA) per the sequencing note — hardening verification before the SHA was pinned would have turned "skips inference with a warning" into "hard-fails the whole install."

## ⚠️ Deploy dependency
`installer/bootstrap.sh` is mirrored to **hal0-web `public/install.sh`** (the live one-liner). The matching `export` must land there **before the next release** is cut, or a fresh `curl|bash` install would hit the gate. The export is backward-compatible (current released `install.sh` ignores it), so the mirror can deploy early. Mirror PR: see hal0-web. The #494 daily parity check will flag drift until synced.

## Verification
- `bash -n` clean on both scripts; `shellcheck -S warning` adds no new warnings (the lone pre-existing `SC2034` on `UI_STEP_TOTAL` is untouched).
- PR CI does not execute `install.sh`; end-to-end coverage is the CT-200 harness (#407).

Closes #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)