### PR TITLE
fix(cli): resolve slot add/remove verb drift + make config migrate honest

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ be evicted out from under a streaming request.
   `model`, plus `enabled` and optional `default`. Six seeded slots
   (`primary`, `embed`, `rerank`, `stt`, `tts`, `img`) plus three NPU
   slots (`agent`, `stt-npu`, `embed-npu`) when FastFlowLM is installed.
-  User-added slots via `hal0 slot add NAME --type TYPE --model MODEL`.
+  User-added slots via `hal0 slot create NAME --type TYPE --model MODEL`.
 - **Lemonade as the unified runtime** — one `lemond` process,
   loopback-only on `:13305`, supervised by `hal0-lemonade.service`.
   Cache + config at `/var/lib/hal0/lemonade/`. The hal0 capability

--- a/docs/operate/config.mdx
+++ b/docs/operate/config.mdx
@@ -52,7 +52,7 @@ Three supported workflows:
   hal0 config edit       # opens $EDITOR
   hal0 config validate   # schema check without writing
   hal0 config show       # print merged view
-  hal0 config migrate    # apply schema migrations to an older config
+  hal0 config migrate    # migrate hal0.toml to the latest schema (no-op when current)
   ```
 - **Direct edit.** Open the file in any editor. On the next
   `hal0-api` restart (or a `hal0 config validate` run), the schema

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -33,12 +33,19 @@ UMA changes, GPU swaps, or RAM upgrades.
 ```sh
 hal0 slot list [--json]
 hal0 slot show <name> [--json]
+hal0 slot create <name> --model M [--type T] # add a new slot
+hal0 slot delete <name> [--force]            # remove a slot
 hal0 slot load <name> [--model M]
 hal0 slot unload <name>
 hal0 slot restart <name>
 hal0 slot swap <name> --model M
 hal0 slot logs <name> [--follow]             # SSE tail of journald
 ```
+
+The canonical verbs are `slot create` / `slot delete`. The older
+`slot add` / `slot remove` names still work as hidden deprecated
+aliases (they print a deprecation notice and delegate to the canonical
+command), but prefer `create` / `delete`.
 
 `hal0 slot swap` is the most-used command in normal operation. It
 changes a slot's model in one call and you watch it transition
@@ -99,12 +106,24 @@ to the browser.
 hal0 config show
 hal0 config edit                             # opens $EDITOR
 hal0 config validate                         # schema check
-hal0 config migrate                          # apply schema migrations
+hal0 config migrate                          # migrate hal0.toml to the latest schema
 ```
 
 `hal0 config validate` is safe to run at any time and doesn't write
 anything. Use it before `hal0 config edit` to confirm your starting
 point is clean.
+
+`hal0 config migrate` runs the registered migration chain in
+`hal0.config.migrations` against `hal0.toml`, stamping
+`meta.schema_version` forward and atomically rewriting the file only
+when the schema actually advances. If the config is already at the
+latest version (the common case today, schema v1) it reports that and
+leaves the file untouched.
+
+The model registry has its own generator: `hal0 capabilities sync`
+regenerates Lemonade's `server_models.json` from `registry.toml`. (An
+earlier `hal0 registry sync` name was never shipped under `registry`;
+use `hal0 capabilities sync`.)
 
 ## Updates
 

--- a/src/hal0/cli/config_commands.py
+++ b/src/hal0/cli/config_commands.py
@@ -78,10 +78,55 @@ def config_edit() -> None:
 
 @app.command("migrate")
 def config_migrate() -> None:
-    """Apply pending schema migrations to /etc/hal0/ (Tier 3, no-op today)."""
+    """Migrate hal0.toml forward to the latest config schema version.
+
+    Reads ``meta.schema_version`` from the on-disk config, runs the
+    registered migration chain in ``hal0.config.migrations`` up to the
+    latest version, and atomically writes the result back only if the
+    version actually advanced. If the config is already current (or
+    absent), nothing is written and that is reported honestly.
+    """
+    import tomllib
+
+    from hal0.config.loader import write_toml_atomic
+    from hal0.config.migrations import MigrationError, latest_version, run_migrations
+
+    path = _hal0_toml_path()
+    if not path.exists():
+        console.print(f"[dim]No config at {path} - nothing to migrate.[/dim]")
+        raise typer.Exit(0)
+
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        die(f"could not read {path}: {exc}")
+        return
+
+    current = int((data.get("meta") or {}).get("schema_version", 1) or 1)
+    target = latest_version()
+
+    if current >= target:
+        console.print(
+            f"[green]OK[/green] Config schema is up to date "
+            f"(v{current}, latest v{target}) - nothing to migrate."
+        )
+        raise typer.Exit(0)
+
+    try:
+        migrated, new_version = run_migrations(data, target_version=target)
+    except MigrationError as exc:
+        die(f"migration failed: {exc}")
+        return
+
+    try:
+        write_toml_atomic(path, migrated)
+    except OSError as exc:
+        die(f"could not write {path}: {exc}")
+        return
+
     console.print(
-        "Config schema is at v1 — no migrations pending. "
-        "Future versions will run idempotent transforms here."
+        f"[green]OK[/green] Migrated config schema v{current} -> v{new_version} ({path})."
     )
 
 

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -537,6 +537,47 @@ def slot_delete(
     console.print(f"Deleted slot [bold]{name}[/bold].")
 
 
+@app.command("add", hidden=True)
+def slot_add(
+    name: str = typer.Argument(..., help="Slot name (e.g. primary, embed, stt)"),
+    type_: SlotType = typer.Option(SlotType.llm, "--type", "-t", case_sensitive=False),
+    provider: SlotProvider = typer.Option("llama-server", "--provider", case_sensitive=False),
+    hardware: SlotHardware | None = typer.Option(None, "--hardware", case_sensitive=False),
+    backend: str | None = typer.Option(None, "--backend", "-b", hidden=True),
+    model: str = typer.Option(..., "--model", "-m"),
+    port: int | None = typer.Option(None, "--port", "-p", min=1024, max=65535),
+    ctx_size: int = typer.Option(4096, "--ctx-size", min=128),
+) -> None:
+    """[DEPRECATED] alias for `slot create`; use `slot create` instead."""
+    typer.echo(
+        "[deprecated] `slot add` is renamed to `slot create`; use `slot create`.",
+        err=True,
+    )
+    slot_create(
+        name=name,
+        type_=type_,
+        provider=provider,
+        hardware=hardware,
+        backend=backend,
+        model=model,
+        port=port,
+        ctx_size=ctx_size,
+    )
+
+
+@app.command("remove", hidden=True)
+def slot_remove(
+    name: str = typer.Argument(..., help="Slot name to delete"),
+    force: bool = typer.Option(False, "--force", "-f"),
+) -> None:
+    """[DEPRECATED] alias for `slot delete`; use `slot delete` instead."""
+    typer.echo(
+        "[deprecated] `slot remove` is renamed to `slot delete`; use `slot delete`.",
+        err=True,
+    )
+    slot_delete(name=name, force=force)
+
+
 @app.command("show")
 def slot_show(
     name: str = typer.Argument(..., help="Slot name to inspect"),

--- a/tests/cli/test_config_migrate.py
+++ b/tests/cli/test_config_migrate.py
@@ -1,0 +1,93 @@
+"""Tests for ``hal0 config migrate`` honesty (#503).
+
+The command used to be a no-op stub that unconditionally printed
+"no migrations pending" as if it had run a real check, while there *is*
+a real migration runner in ``hal0.config.migrations``. These tests pin
+the wired behaviour:
+
+  - with no config on disk it reports there is nothing to migrate
+    (instead of pretending it inspected a schema), and
+  - when the on-disk config is already at the latest schema version it
+    says so honestly without rewriting the file.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import tomli_w
+from typer.testing import CliRunner
+
+from hal0.cli import config_commands
+
+runner = CliRunner()
+
+
+def _set_home(monkeypatch, tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    cfg_dir = home / "etc" / "hal0"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HAL0_HOME", str(home))
+    return cfg_dir / "hal0.toml"
+
+
+def test_migrate_no_config_is_honest(monkeypatch, tmp_path: Path) -> None:
+    """With no hal0.toml present, migrate must not claim a successful check."""
+    home = tmp_path / "home"
+    (home / "etc" / "hal0").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HAL0_HOME", str(home))
+
+    result = runner.invoke(config_commands.app, ["migrate"])
+    assert result.exit_code == 0, result.output
+    out = result.output.lower()
+    # It should reference the missing config, not assert a schema check ran.
+    assert "no config" in out or "not found" in out or "nothing to migrate" in out
+
+
+def test_migrate_already_latest_does_not_rewrite(monkeypatch, tmp_path: Path) -> None:
+    """A config already at the latest schema version is reported honestly."""
+    from hal0.config.migrations import latest_version
+
+    path = _set_home(monkeypatch, tmp_path)
+    payload = {"meta": {"schema_version": latest_version()}, "slots": {"port_range_start": 8081}}
+    with open(path, "wb") as f:
+        tomli_w.dump(payload, f)
+    before = path.read_bytes()
+
+    result = runner.invoke(config_commands.app, ["migrate"])
+    assert result.exit_code == 0, result.output
+    out = result.output.lower()
+    assert "up to date" in out or "already" in out or "latest" in out
+    # No migration was needed → the file must be left byte-for-byte intact.
+    assert path.read_bytes() == before
+
+
+def test_migrate_runs_the_real_runner_when_behind(monkeypatch, tmp_path: Path) -> None:
+    """A config behind the latest schema is migrated forward and stamped.
+
+    Only v1 is registered today, so to exercise the real upgrade path we
+    register a temporary v2 migration. The command must run it, stamp
+    ``meta.schema_version = 2``, and leave valid TOML on disk.
+    """
+    from hal0.config import migrations as mig
+
+    path = _set_home(monkeypatch, tmp_path)
+    with open(path, "wb") as f:
+        tomli_w.dump({"meta": {"schema_version": 1}, "slots": {"port_range_start": 8081}}, f)
+
+    def _v2(data: dict) -> dict:
+        out = dict(data)
+        out["slots"] = {**out.get("slots", {}), "migrated_by_v2": True}
+        return out
+
+    # Register a throwaway v2 migration just for this test, then clean up.
+    monkeypatch.setitem(mig.MIGRATIONS, 2, _v2)
+
+    result = runner.invoke(config_commands.app, ["migrate"])
+    assert result.exit_code == 0, result.output
+
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    assert data["meta"]["schema_version"] == 2
+    assert data["slots"]["migrated_by_v2"] is True

--- a/tests/cli/test_slot_verb_aliases.py
+++ b/tests/cli/test_slot_verb_aliases.py
@@ -1,0 +1,103 @@
+"""Tests for the deprecated ``slot add`` / ``slot remove`` verb aliases (#503).
+
+Docs (and older muscle memory) used ``hal0 slot add`` / ``hal0 slot
+remove`` while the real commands are ``slot create`` / ``slot delete``.
+To resolve the verb drift without a breaking rename we keep the canonical
+verbs and add thin deprecated aliases that:
+
+  1. print a one-line deprecation notice to stderr, and
+  2. delegate to the same underlying implementation (no duplicated logic).
+
+These tests assert both halves: the notice lands on stderr (so stdout
+stays parseable) and the underlying API call is identical to the
+canonical verb's.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import slot_commands
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def captured(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Stub the API surface and capture the method + path + body."""
+    captured: dict[str, Any] = {}
+
+    def fake_unreachable(_url: str) -> bool:
+        return False
+
+    def fake_get(_path: str, **_kw: Any) -> list[dict[str, Any]]:
+        return []
+
+    def fake_post(path: str, *, json: dict[str, Any] | None = None, **_kw: Any) -> dict[str, Any]:
+        captured["method"] = "POST"
+        captured["path"] = path
+        captured["body"] = json or {}
+        return {"port": (json or {}).get("port", 8081)}
+
+    def fake_delete(path: str, **_kw: Any) -> dict[str, Any]:
+        captured["method"] = "DELETE"
+        captured["path"] = path
+        return {}
+
+    monkeypatch.setattr(slot_commands, "_api_unreachable", fake_unreachable)
+    monkeypatch.setattr(slot_commands, "api_get", fake_get)
+    monkeypatch.setattr(slot_commands, "api_post", fake_post)
+    monkeypatch.setattr(slot_commands, "api_delete", fake_delete)
+    monkeypatch.setattr(slot_commands, "_detect_default_hardware", lambda: "vulkan")
+    return captured
+
+
+def test_slot_add_is_registered_as_deprecated_alias() -> None:
+    """``slot add`` exists and its help flags it as deprecated for ``slot create``."""
+    import re
+
+    result = runner.invoke(slot_commands.app, ["add", "--help"])
+    assert result.exit_code == 0, result.output
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output).lower()
+    assert "deprecat" in plain
+    assert "create" in plain
+
+
+def test_slot_remove_is_registered_as_deprecated_alias() -> None:
+    """``slot remove`` exists and its help flags it as deprecated for ``slot delete``."""
+    import re
+
+    result = runner.invoke(slot_commands.app, ["remove", "--help"])
+    assert result.exit_code == 0, result.output
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output).lower()
+    assert "deprecat" in plain
+    assert "delete" in plain
+
+
+def test_slot_add_delegates_to_create(captured: dict[str, Any]) -> None:
+    """``slot add`` posts the same body ``slot create`` would (delegation)."""
+    result = runner.invoke(
+        slot_commands.app,
+        ["add", "primary", "--provider", "llama-server", "--model", "demo"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/api/slots"
+    assert captured["body"]["name"] == "primary"
+    assert captured["body"]["provider"] == "llama-server"
+    # The deprecation notice goes to stderr so stdout stays parseable.
+    assert "deprecat" in result.stderr.lower()
+    assert "slot create" in result.stderr.lower()
+
+
+def test_slot_remove_delegates_to_delete(captured: dict[str, Any]) -> None:
+    """``slot remove`` issues the same DELETE ``slot delete`` would (delegation)."""
+    result = runner.invoke(slot_commands.app, ["remove", "primary", "--force"])
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "DELETE"
+    assert captured["path"] == "/api/slots/primary"
+    assert "deprecat" in result.stderr.lower()
+    assert "slot delete" in result.stderr.lower()


### PR DESCRIPTION
## Summary

Two CLI-hygiene fixes from #503.

### 1. Slot verb drift (`add`/`remove` vs `create`/`delete`)
Docs in several places used `hal0 slot add` / `hal0 slot remove`, but the
real commands are `slot create` / `slot delete`. Rather than a breaking
rename, this adds **hidden deprecated aliases**:

- `slot add` -> prints a one-line deprecation notice to stderr, then
  delegates to `slot_create` (same flags, no duplicated logic).
- `slot remove` -> same pattern, delegates to `slot_delete`.

`registry sync` (referenced in docs) never existed under `registry` -
the real command is `hal0 capabilities sync`. The doc pointer in
`docs/reference/cli.mdx` is corrected; README's `slot add` example is
updated to `slot create`.

### 2. `config migrate` no longer lies
It was a no-op stub that always printed "no migrations pending" as if a
real check had run, while a genuine migration runner already exists in
`hal0.config.migrations`. It's now wired to that runner: reads
`meta.schema_version`, runs the registered chain to the latest version,
and **atomically rewrites `hal0.toml` only when the schema actually
advances**, otherwise reports "up to date" honestly. `--help` and the
docs are updated to match.

## Tests (TDD)
- `tests/cli/test_slot_verb_aliases.py` - aliases registered + flagged
  deprecated, delegate to create/delete with a stderr notice.
- `tests/cli/test_config_migrate.py` - honest output when no config /
  already-latest (no rewrite), and the real runner runs when behind.

All 191 `tests/cli/` pass; `ruff check` + `ruff format` clean.

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)