### PR TITLE
chore(registry): prune dead curated entry flux-schnell (#517)

### DIFF
--- a/docs/api/images-generation.mdx
+++ b/docs/api/images-generation.mdx
@@ -45,22 +45,13 @@ states, controls, and metrics.
 
 ## Curated models
 
-The picker UI surfaces three curated entries spanning the licensing
+The picker UI surfaces two curated entries spanning the licensing
 spectrum (see `src/hal0/registry/curated.py`):
 
 | Id                       | Family            | On-disk  | Min VRAM | License                                       |
 |--------------------------|-------------------|----------|----------|-----------------------------------------------|
 | `sdxl-turbo`             | SDXL distilled    | ~6.5 GB  | 8 GB     | SAI Non-Commercial Research Community         |
 | `sd-1.5-pruned-emaonly`  | SD 1.5            | ~4.3 GB  | 4 GB     | CreativeML Open RAIL-M                        |
-| `flux-schnell`           | FLUX.1 [schnell]  | ~23.8 GB | 24 GB    | Apache-2.0                                    |
-
-<Aside type="note">
-  `flux-schnell` is catalogued for completeness, but the default
-  `sdxl_turbo_simple` workflow won't load its T5 text encoder. A
-  Flux-specific workflow is on the punch list before Flux gets
-  promoted in the picker UI. For now treat it as
-  bring-your-own-workflow.
-</Aside>
 
 ## curl: image generation
 
@@ -154,10 +145,7 @@ to the `img` slot.
   in the repo for ComfyUI on Strix Halo iGPU. Treat the curated
   models' VRAM hints as the only published sizing data until a real
   measurement lands.
-- **Flux workflow.** As above: `flux-schnell` is catalogued but the
-  default workflow can't drive it. A Flux workflow is the gating
-  item before Flux is fully picker-grade.
-- **License spread.** The three curated entries each have a
+- **License spread.** The two curated entries each have a
   different license. The picker UI surfaces the badge so you pick
   consciously; check the bundled `license_url` field before shipping
   output anywhere production-facing.

--- a/docs/api/openai-compat.mdx
+++ b/docs/api/openai-compat.mdx
@@ -137,9 +137,9 @@ curl http://localhost:8080/v1/images/generations \
   }'
 ```
 
-Curated models: `sdxl-turbo` (SAI Non-Commercial Research),
-`sd-1.5-pruned-emaonly` (CreativeML Open RAIL-M), `flux-schnell`
-(Apache-2.0). See [Image generation](/docs/api/images-generation/)
+Curated models: `sdxl-turbo` (SAI Non-Commercial Research) and
+`sd-1.5-pruned-emaonly` (CreativeML Open RAIL-M). See
+[Image generation](/docs/api/images-generation/)
 for the full request shape, response shape, slot configuration, and
 hardware requirements.
 

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -1051,7 +1051,7 @@ async def images_generations(request: Request, dispatcher: DispatcherDep) -> Res
     if curated is None or curated.capability != "image":
         raise _ImageModelNotCurated(
             f"model {requested!r} is not in the curated image-gen catalogue; "
-            "current built-ins: sdxl-turbo, sd-1.5-pruned-emaonly, flux-schnell",
+            "current built-ins: sdxl-turbo, sd-1.5-pruned-emaonly",
             details={"model": requested},
         )
 

--- a/src/hal0/dispatcher/proxy.py
+++ b/src/hal0/dispatcher/proxy.py
@@ -37,7 +37,7 @@ _IMAGE_PATHS = ("/images/generations", "/images/edits", "/images/variations")
 _EMBED_NAME_HINTS = ("embed", "rerank")
 
 # Model id prefixes that pin to the image-gen slot. Curated catalogue uses
-# these prefixes (sdxl-turbo, sd-1.5-..., flux-schnell). Anything matching
+# these prefixes (sdxl-turbo, sd-1.5-..., flux-*). Anything matching
 # these in the bare-model lookup goes to the `img` slot before legacy slot
 # name resolution kicks in.
 _IMAGE_NAME_PREFIXES = ("sdxl", "sd-1.5", "sd15", "flux")

--- a/src/hal0/providers/comfyui_workflows.py
+++ b/src/hal0/providers/comfyui_workflows.py
@@ -60,11 +60,11 @@ MODEL_CLASS_TO_TEMPLATE: dict[str, str] = {
     "sdxl": "sdxl_turbo_simple",
     "sd-1.5": "sd15_simple",
     "sd15": "sd15_simple",
-    # NOTE: flux-schnell would want its own template (different VAE,
-    # T5 text encoder, sampler defaults). Until we ship it, route Flux
-    # callers through SDXL Turbo's graph as a soft fallback so the API
-    # never 404s on a registered curated id.
-    "flux-schnell": "sdxl_turbo_simple",
+    # NOTE: Flux model classes (e.g. flux-klein) want their own template
+    # (different VAE, text encoder, sampler defaults). Until we ship one,
+    # route Flux callers through SDXL Turbo's graph as a soft fallback so
+    # the API never 404s on a registered curated id.
+    "flux-klein": "sdxl_turbo_simple",
 }
 
 # Hardcoded OpenAI-compat default size when caller omits ``size``.

--- a/src/hal0/registry/curated.py
+++ b/src/hal0/registry/curated.py
@@ -138,8 +138,8 @@ class CuratedModel(BaseModel):
     model_class: str = Field(
         default="",
         description=(
-            "Image-gen model class discriminator, e.g. 'sdxl-turbo', 'sd-1.5', "
-            "'flux-schnell'. Selects which ComfyUI workflow template to render. "
+            "Image-gen model class discriminator, e.g. 'sdxl-turbo' or "
+            "'sd-1.5'. Selects which ComfyUI workflow template to render. "
             "Empty for non-image entries."
         ),
     )
@@ -244,7 +244,11 @@ CURATED_MODELS: list[CuratedModel] = [
     CuratedModel(
         id="qwen3.5-0.8b",
         display_name="Qwen3.5 0.8B",
-        description="Tiny first-boot pick. Useful for smoke-testing the install before pulling a real chat model.",
+        description=(
+            "Tiny chat pick with a dual role: it is the primary model the Lite "
+            "omni bundle ships, and it doubles as the install smoke-test model "
+            "before pulling a full-size chat pick."
+        ),
         family="qwen",
         size_gb=0.6,
         vram_gb_min=1.0,
@@ -254,8 +258,8 @@ CURATED_MODELS: list[CuratedModel] = [
         hf_file="Qwen3.5-0.8B-UD-Q4_K_XL.gguf",
         context_length=32768,
         recommended_slot="primary",
-        tags=["chat", "tiny", "smoke-test"],
-        notes="Sub-second cold start. Good for verifying the slot lifecycle before downloading a 20+ GB pick.",
+        tags=["chat", "tiny", "lite-bundle", "smoke-test"],
+        notes="Sub-second cold start. Lite-bundle primary; also verifies the slot lifecycle before downloading a 20+ GB pick.",
     ),
     # ── Kept-in-featured legacy picks (explicit user ask): qwen3-4b for
     # mid-tier Vulkan hosts, phi3-mini for the MIT-licensed pick.  Slot
@@ -434,9 +438,8 @@ CURATED_MODELS: list[CuratedModel] = [
     # ── Image-gen models (recommended_slot="img", routed through ComfyUI) ────
     #
     # Curated picks intentionally span the licensing spectrum:
-    #   - SDXL Turbo  : SAI Non-Commercial Research Community (research only).
-    #   - SD 1.5      : CreativeML Open RAIL-M (research + commercial w/ caveats).
-    #   - Flux Schnell: Apache-2.0 (the OSS unicorn — no usage restrictions).
+    #   - SDXL Turbo : SAI Non-Commercial Research Community (research only).
+    #   - SD 1.5     : CreativeML Open RAIL-M (research + commercial w/ caveats).
     # The picker UI must surface these license badges so users pick consciously.
     CuratedModel(
         id="sdxl-turbo",
@@ -487,34 +490,6 @@ CURATED_MODELS: list[CuratedModel] = [
         ),
         capability="image",
         model_class="sd-1.5",
-        comfyui_subdir="checkpoints",
-    ),
-    CuratedModel(
-        id="flux-schnell",
-        display_name="FLUX.1 [schnell]",
-        description=(
-            "Black Forest Labs' Flux Schnell. State-of-the-art quality, "
-            "Apache-2.0 licensed (rare in this space)."
-        ),
-        family="flux",
-        size_gb=23.8,
-        vram_gb_min=24.0,
-        license="Apache-2.0",
-        license_url="https://www.apache.org/licenses/LICENSE-2.0",
-        hf_repo="black-forest-labs/FLUX.1-schnell",
-        hf_file="flux1-schnell.safetensors",
-        context_length=0,
-        recommended_slot="img",
-        tags=["image", "flux", "apache", "high-vram"],
-        notes=(
-            "23 GB checkpoint — fits Strix Halo's 100 GB unified pool but the "
-            "default sdxl_turbo_simple workflow won't load Flux's T5 text "
-            "encoder. Ship a flux-specific workflow before promoting this in "
-            "the picker UI; for v1 it's catalogued so the curated list is "
-            "complete."
-        ),
-        capability="image",
-        model_class="flux-schnell",
         comfyui_subdir="checkpoints",
     ),
     # ── Bundle-only canonical defs (#500) ────────────────────────────────

--- a/tests/dispatcher/test_image_routing.py
+++ b/tests/dispatcher/test_image_routing.py
@@ -60,7 +60,7 @@ def test_flux_model_prefix_routes_to_img() -> None:
     reg = _registry_with_slots("primary", "img")
     upstream = resolve_slot(
         "/v1/images/generations",
-        {"model": "flux-schnell", "prompt": "x"},
+        {"model": "Flux-2-Klein-9B-GGUF", "prompt": "x"},
         reg,
     )
     assert upstream.name == "img"

--- a/tests/providers/test_comfyui_workflows.py
+++ b/tests/providers/test_comfyui_workflows.py
@@ -41,7 +41,7 @@ def test_template_for_unknown_falls_back_to_sdxl_turbo() -> None:
 
 def test_model_class_table_has_named_entries() -> None:
     """Curated catalogue's image entries map to known templates."""
-    for cls in ("sdxl-turbo", "sd-1.5", "flux-schnell"):
+    for cls in ("sdxl-turbo", "sd-1.5", "flux-klein"):
         assert cls in MODEL_CLASS_TO_TEMPLATE
         assert MODEL_CLASS_TO_TEMPLATE[cls]
 

--- a/tests/registry/test_curated_image_models.py
+++ b/tests/registry/test_curated_image_models.py
@@ -33,7 +33,7 @@ from hal0.registry.store import ModelRegistry
 def test_curated_catalogue_includes_image_entries() -> None:
     """The named v1 image-gen picks must always be present."""
     ids = {m.id for m in CURATED_MODELS}
-    assert {"sdxl-turbo", "sd-1.5-pruned-emaonly", "flux-schnell"}.issubset(ids)
+    assert {"sdxl-turbo", "sd-1.5-pruned-emaonly"}.issubset(ids)
 
 
 def test_curated_image_entries_have_workflow_metadata() -> None:


### PR DESCRIPTION
## What

Prunes the genuinely dead/unreferenced curated entry now that `curated.py` is the canonical model source (#500).

### Removed
- **`flux-schnell`** — in the picker but no working ComfyUI workflow (its own docstring admitted the default `sdxl_turbo_simple` graph can't load Flux's T5 text encoder), and referenced by **no** omni bundle manifest. Removed the `CuratedModel` entry plus every dangling reference: the `/v1/images` not-curated error text, the dispatcher prefix comment, the ComfyUI `MODEL_CLASS_TO_TEMPLATE` mapping, both docs tables/asides, and three tests.

### Kept (deliberately)
- **`qwen3-4b`** — the issue's "qwen3-4b dup" does **not** exist: there is no separate `qwen3-4b-q4_k_m` entry. The only `qwen3-4b` is the small-RAM default primary in `_PRIMARY_TIERS` (#512). Left untouched.
- **`qwen3.5-0.8b`** — referenced by the Lite omni bundle (`hal0-lite.json`) **and** used as the install smoke-test model. Not a removal: kept and **disambiguated** — description + tags (`lite-bundle`) now spell out the dual role.

### Flux routing preserved
The bundle-only `Flux-2-Klein-9B-GGUF` entry (model_class `flux-klein`) is the live flux pick. The soft `sdxl-turbo` template fallback and the `flux` image-routing prefix now key off `flux-klein` instead of the removed `flux-schnell`.

## Tests
- `tests/registry/`, `tests/providers/test_comfyui_workflows.py`, `tests/dispatcher/test_image_routing.py`: **140 passed**.
- Curation drift check (#500) green — every manifest `model_name` + `_PRIMARY_TIERS` id still resolves in `CURATED_BY_ID`.
- `ruff check` + `ruff format` over `src tests`: clean.

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)