### PR TITLE
feat(curation): whisper-large-v3-turbo STT default (#514)

### DIFF
--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -50,6 +50,7 @@ _BACKEND_TO_PROVIDER: dict[str, str] = {
     "llama-server": "llama-server",
     "kokoro": "kokoro",
     "moonshine": "moonshine",
+    "whispercpp": "whispercpp",  # Lemonade's built-in whisper.cpp STT recipe
     "vibevoice": "kokoro",  # closest existing provider; the UI lets the user override
     "comfyui": "comfyui",
 }
@@ -63,6 +64,7 @@ _BACKEND_TO_PROVIDER: dict[str, str] = {
 # matches a host backend wins display order in the dropdown.
 _RUNTIME_TO_HOST_BACKENDS: dict[str, tuple[str, ...]] = {
     "moonshine": ("cpu",),
+    "whispercpp": ("gpu-vulkan", "cpu"),  # Lemonade's whisper.cpp supports Vulkan + CPU
     "kokoro": ("gpu-vulkan", "cpu"),
     "vibevoice": ("gpu-vulkan", "cpu"),
     "comfyui": ("gpu-vulkan",),

--- a/src/hal0/registry/curated.py
+++ b/src/hal0/registry/curated.py
@@ -572,7 +572,7 @@ CURATED_MODELS: list[CuratedModel] = [
         recommended_slot="stt",
         tags=["stt", "transcription"],
         notes="Lemonade-stock key (whispercpp recipe). Loaded from Lemonade's bundled catalogue.",
-        capability="asr",
+        capability="stt",
         backend="whispercpp",
         bundle_only=True,
     ),
@@ -590,7 +590,7 @@ CURATED_MODELS: list[CuratedModel] = [
         recommended_slot="stt",
         tags=["stt", "transcription"],
         notes="Lemonade-stock key (whispercpp recipe).",
-        capability="asr",
+        capability="stt",
         backend="whispercpp",
         bundle_only=True,
     ),
@@ -608,9 +608,12 @@ CURATED_MODELS: list[CuratedModel] = [
         recommended_slot="stt",
         tags=["stt", "transcription"],
         notes="Lemonade-stock key (whispercpp recipe). NPU encoder variant available.",
-        capability="asr",
+        capability="stt",
         backend="whispercpp",
-        bundle_only=True,
+        # Visible STT default (#514): loads via Lemonade's built-in whispercpp
+        # recipe, so no whisper-cpp toolbox image is needed. Tiny/Base stay
+        # bundle_only as lower-tier bundle picks.
+        bundle_only=False,
     ),
     CuratedModel(
         id="kokoro-v1",

--- a/tests/capabilities/test_stt_curation.py
+++ b/tests/capabilities/test_stt_curation.py
@@ -1,0 +1,39 @@
+"""STT curation surfacing (#514).
+
+whisper-large-v3-turbo is a visible STT default that loads via Lemonade's
+built-in whisper.cpp recipe. It must show up in the ``stt`` capability
+dropdown, while the lower-tier Tiny/Base bundle picks stay hidden
+(bundle_only).
+"""
+
+from __future__ import annotations
+
+from hal0.capabilities.catalog import models_for_capability
+from hal0.registry.curated import CURATED_BY_ID
+
+
+def test_whisper_large_v3_turbo_is_a_visible_stt_default() -> None:
+    entry = CURATED_BY_ID["Whisper-Large-v3-Turbo"]
+    assert entry.bundle_only is False
+    assert entry.capability == "stt"
+    assert entry.recommended_slot == "stt"
+
+
+def test_stt_dropdown_surfaces_whisper_turbo_not_lower_tiers() -> None:
+    rows = models_for_capability("stt", registry=None)
+    ids = {row["id"] for row in rows}
+    assert "Whisper-Large-v3-Turbo" in ids
+    # Tiny/Base remain bundle_only — hidden from the standalone dropdown.
+    assert "Whisper-Tiny" not in ids
+    assert "Whisper-Base" not in ids
+
+
+def test_whisper_turbo_offers_a_real_backend() -> None:
+    rows = models_for_capability("stt", registry=None)
+    whisper = [r for r in rows if r["id"] == "Whisper-Large-v3-Turbo"]
+    assert whisper, "whisper-large-v3-turbo not surfaced for stt"
+    backends = {b["id"] for b in whisper[0]["backends"]}
+    providers = {b["provider"] for b in whisper[0]["backends"]}
+    # whispercpp fans out to a real host backend (gpu-vulkan/cpu), not empty.
+    assert backends & {"gpu-vulkan", "cpu"}
+    assert "whispercpp" in providers

--- a/tests/registry/test_curated.py
+++ b/tests/registry/test_curated.py
@@ -32,7 +32,9 @@ def test_catalogue_entries_have_hf_coordinates() -> None:
     legitimately carry .bin / .onnx coordinates. hf_repo/hf_file are still
     required (informational), but the extension allowlist does not apply.
     """
-    allowed_suffixes = (".gguf", ".safetensors", ".ckpt")
+    # .bin covers whisper.cpp ggml weights (#514 — whisper-large-v3-turbo is a
+    # visible STT default loaded via Lemonade's whispercpp recipe).
+    allowed_suffixes = (".gguf", ".safetensors", ".ckpt", ".bin")
     for m in CURATED_MODELS:
         assert m.hf_repo, f"{m.id}: hf_repo is required"
         assert m.hf_file, f"{m.id}: hf_file is required"


### PR DESCRIPTION
## What
The wizard STT dropdown was empty on a standalone install. Post-#500, whisper models load via Lemonade's built-in `whisper.cpp` recipe (no separate toolbox image), so:

- **`Whisper-Large-v3-Turbo`** is now a visible STT default (`bundle_only=False`, `capability="stt"` to match the catalog's dropdown query). Tiny/Base stay `bundle_only` as lower-tier bundle picks.
- The catalog registers the **`whispercpp`** runtime — provider + `gpu-vulkan`/`cpu` host backends — so `_flat_rows_for_capability("stt")` fans it out.
- The curated `hf_file` validator now allows **`.bin`** (whisper ggml weights) — the "relax pull validator" the issue asked for.

## Tests
New `tests/capabilities/test_stt_curation.py` (TDD — these were red first): whisper-turbo is a visible `stt` default, surfaces in the dropdown with a real `whispercpp` backend, and the lower tiers stay hidden. Registry + capabilities suites green; `ruff` clean.

Closes #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)