### PR TITLE
fix(lemonade): stock-catalog fallback when registry is empty (#210)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1263,7 +1263,7 @@ REGISTRY_TOML="${VAR_DIR}/registry/registry.toml"
 
 if [[ "${DEV_MODE}" -eq 0 && -d "${LEMONADE_RESOURCES}" ]]; then
     if [[ ! -f "${REGISTRY_TOML}" ]]; then
-        warn "registry.toml not found at ${REGISTRY_TOML}; writing empty server_models.json"
+        info "registry.toml not found at ${REGISTRY_TOML}; writing curated stock catalog (#210)"
     fi
     if "${VENV_DIR}/bin/python" -m hal0.lemonade.server_models_gen \
         --registry "${REGISTRY_TOML}" \

--- a/src/hal0/lemonade/server_models_gen.py
+++ b/src/hal0/lemonade/server_models_gen.py
@@ -170,6 +170,33 @@ _DEFAULT_RECIPE_BY_LABEL: dict[str, str] = {
 _DEFAULT_LLM_CTX: int = 8192
 
 
+# ── Stock fallback (issue #210) ─────────────────────────────────────────────
+#
+# On a fresh ``curl | bash`` install the hal0 registry is not yet seeded, so
+# ``_read_registry`` yields zero models. install.sh writes our output over
+# Lemonade's bundled ``server_models.json`` (which ships ~180 stock entries),
+# so emitting an empty dict here would blank the catalog and leave the daemon
+# with nothing to load - the user can't chat until they manually pull a model.
+#
+# To keep a fresh box usable we fall back to a small curated STOCK set drawn
+# from ``hal0.registry.curated.CURATED_BY_ID``. These ids are the canonical
+# curated ids (kept stable by #500), so the output is non-empty and the daemon
+# has loadable models out of the box. Picked to cover the core modalities a
+# first-run user reaches for: a sub-second smoke/chat model, a lean default
+# chat model, an embed model, a reranker, an STT model, and a TTS voice.
+#
+# This fallback ONLY applies when the registry yields no usable models. A
+# populated registry is emitted verbatim (unchanged behaviour).
+STOCK_FALLBACK_IDS: tuple[str, ...] = (
+    "qwen3.5-0.8b",  # sub-second smoke + Lite-bundle primary chat
+    "qwen3.5-9b",  # lean default chat
+    "nomic-embed-text-v1.5-q8_0",  # default embed
+    "bge-reranker-v2-m3-q4_k_m",  # default reranker
+    "Whisper-Large-v3-Turbo",  # STT
+    "kokoro-v1",  # TTS voice
+)
+
+
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
 
@@ -352,6 +379,84 @@ def _entry_labels(caps: list[str], tags: list[str], primary_label: str | None) -
 # ── Public API ─────────────────────────────────────────────────────────────────
 
 
+def _lemon_entry_from_registry(entry: dict[str, Any]) -> dict[str, Any]:
+    """Convert one registry entry dict into its Lemonade server-model entry."""
+    caps = list(entry.get("capabilities") or [])
+    primary = _pick_primary_capability(caps)
+    primary_label = _CAPABILITY_TO_LABEL.get(primary or "chat")
+    # primary_label is None when capability is 'chat' (no Lemonade label
+    # needed) or unrecognised. Either way recipe-resolve handles it.
+
+    backends = list(entry.get("backends") or [])
+    recipe = _resolve_recipe(backends, primary_label)
+
+    checkpoint = _resolve_checkpoint(entry)
+    size_gb = _resolve_size_gb(entry)
+    labels = _entry_labels(caps, list(entry.get("tags") or []), primary)
+
+    lemon: dict[str, Any] = {
+        "checkpoint": checkpoint,
+        "recipe": recipe,
+        "labels": labels,
+        "size": size_gb,
+        "suggested": False,
+    }
+
+    ctx = _resolve_ctx(entry, primary)
+    # Lemonade reads max_context_window via recipe_options at load time;
+    # we surface it as a sibling key for documentation + hal0 UI use.
+    if ctx is not None and recipe in ("llamacpp", "flm"):
+        lemon["max_context_window"] = ctx
+
+    return lemon
+
+
+def _curated_to_registry_entry(model: Any) -> dict[str, Any]:
+    """Adapt a ``CuratedModel`` into the registry-entry dict the generator
+    consumes, so a curated pick flows through the same per-entry machinery.
+
+    The curated schema uses singular field names (``hf_file``, ``capability``,
+    ``backend``) where the registry uses plural ones (``hf_filename``,
+    ``capabilities``, ``backends``); this bridges the two.
+    """
+    size_bytes = round(float(model.size_gb) * (1024**3)) if model.size_gb else 0
+    entry: dict[str, Any] = {
+        "capabilities": [model.capability] if model.capability else ["chat"],
+        "backends": [model.backend] if model.backend else [],
+        "hf_repo": model.hf_repo,
+        "hf_filename": model.hf_file,
+        "tags": list(model.tags),
+        "size_bytes": size_bytes,
+    }
+    if getattr(model, "context_length", 0):
+        entry["metadata"] = {"context_length": model.context_length}
+    return entry
+
+
+def _stock_fallback_catalog() -> dict[str, dict[str, Any]]:
+    """Build the non-empty stock catalog used when the registry is empty.
+
+    Draws the canonical curated ids in :data:`STOCK_FALLBACK_IDS` from
+    ``hal0.registry.curated.CURATED_BY_ID`` and shapes each as a Lemonade
+    server-model entry. Imported lazily so the registry package is not pulled
+    in on the common (populated-registry) path.
+    """
+    # Local import to keep the populated-registry path import-light and avoid
+    # a module-level dependency cycle between lemonade and registry.
+    from hal0.registry.curated import CURATED_BY_ID
+
+    out: dict[str, dict[str, Any]] = {}
+    for mid in STOCK_FALLBACK_IDS:
+        model = CURATED_BY_ID.get(mid)
+        if model is None:
+            # Defensive: a curated id was renamed without updating the
+            # fallback list. Skip it rather than emit a broken entry.
+            log.warning("stock fallback id %s not in curated catalog - skipping", mid)
+            continue
+        out[mid] = _lemon_entry_from_registry(_curated_to_registry_entry(model))
+    return out
+
+
 def generate_server_models(registry_path: Path) -> dict[str, dict[str, Any]]:
     """Read ``registry.toml`` and return the Lemonade ``server_models.json`` dict.
 
@@ -359,10 +464,15 @@ def generate_server_models(registry_path: Path) -> dict[str, dict[str, Any]]:
     file is diff-friendly across runs. The caller serialises with
     ``json.dumps(..., indent=4)`` to match Lemonade's own formatting.
 
+    When the registry yields no usable models (missing/malformed file, or a
+    not-yet-seeded fresh install), a curated STOCK set is returned instead of
+    an empty dict - see :data:`STOCK_FALLBACK_IDS` and issue #210. install.sh
+    overwrites Lemonade's bundled catalog with this output, so a blank result
+    would leave the daemon with nothing to load.
+
     Args:
-        registry_path: Absolute path to ``registry.toml``. A missing file
-            yields an empty dict (warning logged); the install hook can
-            still write a valid empty catalog.
+        registry_path: Absolute path to ``registry.toml``. A missing or empty
+            registry yields the stock fallback (warning logged).
 
     Returns:
         ``{model_id: {checkpoint, recipe, labels, size, suggested, ...}}``.
@@ -370,37 +480,16 @@ def generate_server_models(registry_path: Path) -> dict[str, dict[str, Any]]:
     registry_path = Path(registry_path)
     entries = _read_registry(registry_path)
 
+    if not entries:
+        log.warning(
+            "registry yielded no models - emitting %d stock fallback entries (#210)",
+            len(STOCK_FALLBACK_IDS),
+        )
+        return _stock_fallback_catalog()
+
     out: dict[str, dict[str, Any]] = {}
     for mid in sorted(entries):
-        entry = entries[mid]
-        caps = list(entry.get("capabilities") or [])
-        primary = _pick_primary_capability(caps)
-        primary_label = _CAPABILITY_TO_LABEL.get(primary or "chat")
-        # primary_label is None when capability is 'chat' (no Lemonade label
-        # needed) or unrecognised. Either way recipe-resolve handles it.
-
-        backends = list(entry.get("backends") or [])
-        recipe = _resolve_recipe(backends, primary_label)
-
-        checkpoint = _resolve_checkpoint(entry)
-        size_gb = _resolve_size_gb(entry)
-        labels = _entry_labels(caps, list(entry.get("tags") or []), primary)
-
-        lemon: dict[str, Any] = {
-            "checkpoint": checkpoint,
-            "recipe": recipe,
-            "labels": labels,
-            "size": size_gb,
-            "suggested": False,
-        }
-
-        ctx = _resolve_ctx(entry, primary)
-        # Lemonade reads max_context_window via recipe_options at load time;
-        # we surface it as a sibling key for documentation + hal0 UI use.
-        if ctx is not None and recipe in ("llamacpp", "flm"):
-            lemon["max_context_window"] = ctx
-
-        out[mid] = lemon
+        out[mid] = _lemon_entry_from_registry(entries[mid])
 
     return out
 
@@ -524,6 +613,7 @@ if __name__ == "__main__":  # pragma: no cover — exercised via test_cli_main
 
 
 __all__ = [
+    "STOCK_FALLBACK_IDS",
     "cli_main",
     "generate_server_models",
     "write_server_models",

--- a/tests/cli/test_capabilities_sync.py
+++ b/tests/cli/test_capabilities_sync.py
@@ -86,10 +86,12 @@ def test_sync_dry_run_does_not_write(tmp_path: Path) -> None:
     assert "m" in result.output
 
 
-def test_sync_empty_registry_warns(tmp_path: Path) -> None:
+def test_sync_empty_registry_emits_stock_fallback(tmp_path: Path) -> None:
     registry = tmp_path / "registry.toml"
     output = tmp_path / "server_models.json"
-    # No registry file present at all → empty catalog, warning issued.
+    # No registry file present at all -> #210: instead of a blank catalog,
+    # the generator now emits a curated STOCK fallback so a fresh install
+    # still has loadable models. The sync output reflects that non-empty set.
 
     result = runner.invoke(
         capabilities_app,
@@ -97,5 +99,8 @@ def test_sync_empty_registry_warns(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    # The warning is emitted regardless of dry-run.
-    assert "no models" in result.output or "warning" in result.output.lower()
+    # Non-empty stock fallback rendered: a short canonical id appears
+    # untruncated and the summary reports the 6-entry fallback count
+    # (long ids are Rich-table-truncated, so assert on stable substrings).
+    assert "qwen3.5-9b" in result.output
+    assert "6 entries" in result.output

--- a/tests/lemonade/test_server_models_gen.py
+++ b/tests/lemonade/test_server_models_gen.py
@@ -23,10 +23,12 @@ import pytest
 import tomli_w
 
 from hal0.lemonade.server_models_gen import (
+    STOCK_FALLBACK_IDS,
     cli_main,
     generate_server_models,
     write_server_models,
 )
+from hal0.registry.curated import CURATED_BY_ID
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -697,15 +699,23 @@ class TestAtomicWrite:
 
 
 class TestRegistryMissingOrMalformed:
-    def test_missing_registry_yields_empty_catalog(self, tmp_path: Path) -> None:
-        out = generate_server_models(tmp_path / "does-not-exist.toml")
-        assert out == {}
+    def test_missing_registry_yields_stock_fallback(self, tmp_path: Path) -> None:
+        """A fresh install (no registry.toml) must NOT blank the catalog.
 
-    def test_malformed_registry_yields_empty_catalog(self, tmp_path: Path) -> None:
+        Issue #210: install.sh writes this output over Lemonade's bundled
+        ``server_models.json`` (180 stock entries). If we emit ``{}`` the
+        daemon has nothing to load and the user can't chat until they
+        manually pull. Fall back to the canonical curated stock set so a
+        fresh box has loadable models out of the box.
+        """
+        out = generate_server_models(tmp_path / "does-not-exist.toml")
+        assert out, "empty registry must fall back to a non-empty stock catalog"
+
+    def test_malformed_registry_yields_stock_fallback(self, tmp_path: Path) -> None:
         registry = tmp_path / "registry.toml"
         registry.write_text("this is not valid toml [[[")
         out = generate_server_models(registry)
-        assert out == {}
+        assert out, "malformed registry must fall back to a non-empty stock catalog"
 
     def test_list_shape_registry_accepted(self, tmp_path: Path) -> None:
         """Mirror ModelRegistry's haloai backcompat: list-of-tables works."""
@@ -719,6 +729,82 @@ class TestRegistryMissingOrMalformed:
         )
         out = generate_server_models(registry)
         assert "a" in out
+
+    def test_empty_models_table_yields_stock_fallback(self, tmp_path: Path) -> None:
+        """A registry that parses fine but lists zero models still falls back."""
+        registry = tmp_path / "registry.toml"
+        registry.write_text("")
+        out = generate_server_models(registry)
+        assert out, "registry with no models must fall back to stock catalog"
+
+
+# ── Stock fallback on empty registry (issue #210) ────────────────────────────
+
+
+class TestStockFallback:
+    """When the registry yields no usable models, the generator emits a
+    curated STOCK set instead of an empty catalog, so a fresh install has
+    loadable models without manual ``hal0 model pull``."""
+
+    def test_fallback_ids_are_canonical_curated_ids(self, tmp_path: Path) -> None:
+        """Every stock-fallback id resolves in the canonical curated catalog
+        (``CURATED_BY_ID``). Blocked-by #500 guarantees these ids exist and
+        do not drift."""
+        out = generate_server_models(tmp_path / "missing.toml")
+        assert out  # non-empty
+        for mid in out:
+            assert mid in CURATED_BY_ID, f"stock id {mid!r} not a canonical curated id"
+
+    def test_fallback_covers_core_chat_modality(self, tmp_path: Path) -> None:
+        """A fresh box must at least have a loadable chat model so the user
+        can reach a streamed token on first run."""
+        # Type-driving labels Lemonade's classifier resolves to a non-LLM type.
+        type_labels = {"embeddings", "reranking", "transcription", "tts", "image"}
+        out = generate_server_models(tmp_path / "missing.toml")
+        chat_ids = [
+            mid
+            for mid in out
+            if CURATED_BY_ID[mid].capability == "chat"
+            # A chat model carries no type-driving label, so Lemonade
+            # classifies it as LLM (chat).
+            and not (set(out[mid]["labels"]) & type_labels)
+        ]
+        assert chat_ids, "stock fallback must include at least one chat model"
+
+    def test_fallback_entries_have_valid_lemonade_shape(self, tmp_path: Path) -> None:
+        """Each stock entry has the keys Lemonade's loader needs."""
+        out = generate_server_models(tmp_path / "missing.toml")
+        for mid, entry in out.items():
+            assert entry["checkpoint"], f"{mid} missing checkpoint"
+            assert entry["recipe"], f"{mid} missing recipe"
+            assert isinstance(entry["labels"], list)
+            assert entry["suggested"] is False
+
+    def test_fallback_set_matches_declared_ids(self, tmp_path: Path) -> None:
+        """The output ids are exactly the declared STOCK_FALLBACK_IDS."""
+        out = generate_server_models(tmp_path / "missing.toml")
+        assert set(out.keys()) == set(STOCK_FALLBACK_IDS)
+
+    def test_populated_registry_does_not_fall_back(self, tmp_path: Path) -> None:
+        """When the registry IS populated, behaviour is unchanged — no stock
+        ids leak in."""
+        registry = tmp_path / "registry.toml"
+        registry.parent.mkdir(parents=True, exist_ok=True)
+        with open(registry, "wb") as f:
+            tomli_w.dump(
+                {
+                    "models": {
+                        "my-only-model": {
+                            "path": "/x.gguf",
+                            "capabilities": ["chat"],
+                            "backends": ["vulkan"],
+                        }
+                    }
+                },
+                f,
+            )
+        out = generate_server_models(registry)
+        assert set(out.keys()) == {"my-only-model"}
 
 
 # ── CLI entry point ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

On a fresh `curl | bash` install, `/var/lib/hal0/registry/registry.toml` is
never seeded, so `generate_server_models()` emitted an (almost) empty
`server_models.json`. `install.sh` writes that output over Lemonade's bundled
stock catalog (~180 entries) at `/opt/lemonade/resources/server_models.json`,
so `lemond` was left with **no models to load** - the user could not chat
until manually running `hal0 model pull` / `registry import`.

## Fix (approach a - curated stock fallback in the generator)

When `_read_registry` yields no usable models (missing / malformed / empty
registry), `generate_server_models` now returns a curated **STOCK** set
instead of `{}`. The ids come from the canonical curated catalog
(`hal0.registry.curated.CURATED_BY_ID`, kept stable by #500) and cover the
core first-run modalities:

- `qwen3.5-0.8b` - sub-second smoke + Lite-bundle primary chat
- `qwen3.5-9b` - lean default chat
- `nomic-embed-text-v1.5-q8_0` - default embed
- `bge-reranker-v2-m3-q4_k_m` - default reranker
- `Whisper-Large-v3-Turbo` - STT
- `kokoro-v1` - TTS voice

A **populated** registry is emitted verbatim - behaviour is unchanged. The
install.sh consumer is untouched (it already calls the generator and writes
its output); the fresh-install warning text was softened to match the new
non-blank result.

Per-entry building is factored into `_lemon_entry_from_registry` and reused
for both paths via a `CuratedModel` -> registry-entry adapter, so the stock
entries get the same label/recipe/checkpoint/ctx resolution as registry rows.

## Tests (TDD)

Extended `tests/lemonade/test_server_models_gen.py`:
- the two prior `== {}` empty-registry assertions now assert a non-empty
  stock fallback
- new `TestStockFallback` asserts the output is non-empty, every id resolves
  in `CURATED_BY_ID`, the set matches `STOCK_FALLBACK_IDS`, each entry has a
  valid Lemonade shape, a chat model is present, and a populated registry
  does **not** fall back.

`162 passed` across `tests/lemonade/test_server_models_gen.py tests/registry/`.
`ruff check` + `ruff format` clean over `src tests`.

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)