### PR TITLE
fix(hermes): guard wrapper against untraversable cwd (/root/.git EACCES)

### DIFF
--- a/installer/wrappers/hermes
+++ b/installer/wrappers/hermes
@@ -61,4 +61,16 @@ if [ ! -x "$HAL0_HERMES_BIN" ]; then
     exit 127
 fi
 
+# cwd-safety guard: hermes probes for a git/workspace root by walking UP from
+# $PWD. If the invoking cwd is not traversable by the effective user -- e.g.
+# launched as the hal0 service user from root's 0700 /root via `h0 hermes`, or a
+# systemd unit with an unreadable WorkingDirectory -- that probe EACCESes
+# ('[Errno 13] Permission denied: /root/.git'; Python 3.12 Path.exists() re-raises
+# EACCES). Step into a guaranteed-traversable dir first; a no-op when cwd is
+# already fine. The bashrc hermes() fn cds to a workspace itself, so this only
+# covers the other entry paths (h0 hermes, systemd, bare invocations).
+if ! { cwd=$(pwd 2>/dev/null) && [ -n "$cwd" ] && [ -r "$cwd" ] && [ -x "$cwd" ]; }; then
+    cd "${HOME:-/var/lib/hal0}" 2>/dev/null || cd /var/lib/hal0 2>/dev/null || cd /
+fi
+
 exec "$HAL0_HERMES_BIN" "$@"


### PR DESCRIPTION
## Problem

Running the `hermes` wrapper as the **hal0 service user** from a directory that
account can't traverse makes Hermes' cwd-rooted git/workspace probe blow up:

```
[Errno 13] Permission denied: '/root/.git'
```

Reproduced exactly on CT 105 (Python 3.12):

```python
>>> from pathlib import Path; (Path('/root/.git')).exists()
PermissionError: [Errno 13] Permission denied: '/root/.git'
```

Python 3.12's `Path.exists()` **re-raises** `EACCES` (unlike `os.path.exists`,
which swallows it), so any of Hermes' `(repo_dir / ".git").exists()` checks crash
when `repo_dir` resolves to a cwd of `/root` (mode 0700, not traversable by
`hal0`). This happens via `h0 hermes` (`sudo -u hal0 -H bash -lc hermes`, which
keeps cwd=`/root`), systemd units with an unreadable WorkingDirectory, or any
bare invocation from `/root`.

This bug has **regressed repeatedly** because the only fixes ever applied lived
on the live box (a self-guard wrapper, a `/root/.bashrc` function) and got
reverted whenever the wrapper was restored to its canonical form.

## Fix

Add a minimal POSIX **cwd-safety guard** to `installer/wrappers/hermes`: if the
current dir isn't readable + traversable, `cd` into `$HOME` (`/var/lib/hal0`)
before `exec`. No-op when cwd is fine, and it does **not** touch the
`HERMES_HOME` single-source-of-truth design. Unlike the bashrc `hermes()`
function (which already cds), this covers **every** entry path.

## Verification (CT 105)

- `sh -n` clean.
- Guard relocates hal0 cwd `/root` → `/var/lib/hal0`.
- Before: `(Path.cwd()/'.git').exists()` from `/root` raises the exact EACCES.
- After: same probe returns `False`, no raise.
- `hermes version` / `hermes chat` run clean as hal0 from `/root`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
