### PR TITLE
feat(installer): preflight hardening (#497)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -33,6 +33,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/ui.sh"
 # shellcheck source=lib/preflight.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/preflight.sh"
 
+# Non-interactive apt for every apt-get call in this installer (PPA add,
+# software-properties-common, Lemonade prereqs, FLM .deb) — without this a
+# debconf prompt can hang a tty install or fail a CI/non-tty run.
+export DEBIAN_FRONTEND=noninteractive
+
 # Poll `systemctl is-active` for up to `timeout` seconds. Returns 0 the
 # moment the unit reports active, 1 on timeout. Use instead of a flat
 # `sleep N; is-active` so slow first boots (OpenWebUI pulling images,
@@ -245,6 +250,14 @@ fi
 
 info "system: $(uname -srm)"
 
+# Architecture is a hard requirement in every mode — all shipped binaries
+# (Lemonade embeddable, FastFlowLM .deb, toolbox images) are amd64-only.
+preflight_arch || die "hal0 requires an x86_64 host (see the message above)"
+
+# Single up-front connectivity probe (soft) so a network/proxy problem
+# surfaces once with guidance instead of as N download failures later.
+preflight_network
+
 # Systemd is hard-required outside dev mode; preflight_systemd just
 # reports presence, so we wrap it in the dev-mode skip and turn its
 # non-zero return into a die().
@@ -263,6 +276,11 @@ if ! preflight_python; then
     # Version warning already printed; keep going.
 fi
 
+# `python3 -m venv` capability is a hard requirement — the install always
+# creates a venv. Catches the common Debian "python3 present, python3-venv
+# missing" case before it fails with an opaque ensurepip error.
+preflight_venv || die "python venv module missing — install python3-venv (see above)"
+
 # preflight_docker is soft (always returns 0 with a warning when
 # Docker is absent), so we don't need to guard the call.
 preflight_docker
@@ -275,6 +293,8 @@ preflight_docker
 # "Pre-flight checks" recovery hint above.
 if [[ "${DEV_MODE}" -eq 0 ]]; then
     pf_rc=0
+    preflight_writable "${PREFIX}" /usr/lib/hal0 "${ETC_DIR}" "${UNIT_DIR}" \
+        "${VAR_DIR}" /opt/lemonade /usr/local/bin || pf_rc=$?
     preflight_disk 20 "${VAR_DIR}"            || pf_rc=$?
     preflight_ports "${HAL0_PORT}" 3001       || pf_rc=$?
     if (( pf_rc != 0 )); then

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -80,8 +80,75 @@ preflight_python() {
         info "python: ${py} (${ver})"
         return 0
     fi
-    warn "python: ${py} (${ver}) — hal0 is tested on 3.11–3.14"
+    warn "python: ${py} (${ver}) — hal0 is tested on 3.11-3.14"
     return 1
+}
+
+# CPU architecture — hal0 ships x86_64-only binaries (Lemonade embeddable,
+# FastFlowLM .deb, toolbox images). On ARM the install gets deep into apt
+# before failing cryptically, so refuse up front.
+preflight_arch() {
+    local m
+    m="$(uname -m 2>/dev/null || echo unknown)"
+    if [[ "${m}" == "x86_64" || "${m}" == "amd64" ]]; then
+        info "arch: ${m}"
+        return 0
+    fi
+    err "unsupported architecture '${m}' — hal0 requires x86_64 (Lemonade/FLM/toolboxes are amd64-only)"
+    return 1
+}
+
+# `python3 -m venv` needs the `ensurepip` + `venv` stdlib modules, which
+# Debian/Ubuntu split into the `python3-venv` package. Without it the
+# venv step fails with an opaque "ensurepip is not available".
+preflight_venv() {
+    local py="${HAL0_PY:-${HAL0_PYTHON:-python3}}"
+    if "${py}" -c 'import ensurepip, venv' >/dev/null 2>&1; then
+        info "python venv: available"
+        return 0
+    fi
+    err "'${py} -m venv' is unavailable (missing ensurepip/venv)"
+    warn "  install the venv module, e.g. 'apt install python3-venv'"
+    return 1
+}
+
+# The install writes to several system trees; if any is read-only (overlay
+# LXC, SELinux-strict, /usr mounted ro) the install explodes halfway. Probe
+# writability of each parent up front. Pass dirs as args; defaults cover the
+# system-mode layout. Runs after the sudo re-exec, so we expect to be root.
+# shellcheck disable=SC2120  # called with args from install.sh, argless (defaults) from preflight_all
+preflight_writable() {
+    local rc=0 d parent
+    local dirs=("$@")
+    if [[ ${#dirs[@]} -eq 0 ]]; then
+        dirs=(/opt /usr/lib /etc/hal0 /etc/systemd/system /var/lib /usr/local/bin)
+    fi
+    for d in "${dirs[@]}"; do
+        parent="${d}"
+        while [[ -n "${parent}" && ! -e "${parent}" ]]; do parent="$(dirname "${parent}")"; done
+        if [[ -w "${parent}" ]]; then
+            continue
+        fi
+        err "not writable: ${parent} (needed to create ${d})"
+        rc=1
+    done
+    [[ "${rc}" -eq 0 ]] && info "writable paths: ok"
+    return "${rc}"
+}
+
+# Single up-front connectivity probe so a network/proxy problem surfaces
+# once with an actionable message instead of as N separate download
+# failures later. curl honours http(s)_proxy/no_proxy automatically. Soft:
+# warns (returns 0) so offline-from-local-tarball installs aren't blocked.
+preflight_network() {
+    local url="${HAL0_NET_PROBE_URL:-https://github.com}"
+    if curl -fsS -m 8 -I "${url}" >/dev/null 2>&1; then
+        info "network: reachable (${url})"
+    else
+        warn "network: could not reach ${url} — check connectivity/proxy (http_proxy/https_proxy)"
+        warn "  downloads (release, Lemonade, FLM, models, images) will fail if this host is offline"
+    fi
+    return 0
 }
 
 preflight_docker() {
@@ -251,8 +318,12 @@ preflight_ports() {
 # picture, not the first failure.
 preflight_all() {
     local rc=0
+    preflight_arch    || rc=$?
     preflight_systemd || rc=$?
     preflight_python  || rc=$?
+    preflight_venv    || rc=$?
+    preflight_writable || rc=$?
+    preflight_network || rc=$?
     preflight_docker  || rc=$?
     preflight_disk    || rc=$?
     preflight_ports   || rc=$?


### PR DESCRIPTION
## What
Hardens installer preflight against the silent-failure classes from the W1 audit:

- **`preflight_arch`** — refuse non-x86_64 up front (Lemonade embeddable, FLM `.deb`, toolbox images are amd64-only; ARM previously failed deep in apt).
- **`preflight_venv`** — verify `python3 -m venv` works (the Debian "`python3` present, `python3-venv` missing" case → opaque ensurepip error).
- **`preflight_writable`** — probe writability of the system trees the install writes to (`/opt`, `/usr/lib/hal0`, `/etc/systemd/system`, `/var/lib`, …) so a read-only/overlay mount fails early instead of halfway.
- **`preflight_network`** — one soft up-front connectivity probe so a network/proxy issue surfaces once with guidance, not as N separate download failures.
- **`export DEBIAN_FRONTEND=noninteractive`** for every apt-get call (a debconf prompt could hang a tty install or fail CI).

Proxy support: `curl` already honours `http(s)_proxy`/`no_proxy`, so proxied hosts work — the probe respects them too. All checks wired into `preflight_all` + the `install.sh` preflight block.

## Verification
- `bash -n` clean on both scripts; `shellcheck -S warning` adds no new warnings.
- Functional smoke on this host: arch/venv/writable/network checks all behave.
- PR CI doesn't execute `install.sh`; end-to-end coverage is the CT-200 harness (#407).

Closes #497.

🤖 Generated with [Claude Code](https://claude.com/claude-code)