### PR TITLE
feat(updater): restart hal0-api after apply + durable job store; dead-code sweep (#509, #510)

### DIFF
--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -5,15 +5,15 @@ The route layer owns:
     which honours ``HAL0_RELEASES_URL`` for tests + file:// fallback)
   - version comparison against ``hal0.__version__``
   - channel read/write (persisted in ``hal0.toml`` via ``Hal0Config.telemetry.channel``)
-  - apply-job bookkeeping (queued / running / applied / failed) — jobs
-    live on ``app.state.update_jobs`` so the dashboard can poll status
-    without touching the updater module directly.
+  - apply-job bookkeeping (queued / running / applied / failed) - jobs
+    live on ``app.state.update_jobs`` AND are mirrored to disk under
+    ``/var/lib/hal0/update-jobs/<id>.json`` so a daemon restart mid-apply
+    doesn't 404 the CLI's status poll.
 
-The actual symlink swap / cosign verify is Team D's domain inside the
-``Updater`` class; the route layer calls ``Updater.apply()`` /
-``Updater.rollback()`` which currently raise ``NotImplementedError``.
-A failing apply surfaces as a job in the ``failed`` state with the
-NotImplementedError message attached — the route surface is real.
+The actual symlink swap / cosign verify lives in the ``Updater`` class;
+the route layer calls ``Updater.apply()`` / ``Updater.rollback()``. After
+a successful apply the route try-restarts ``hal0-api.service`` fail-soft
+(a restart failure is recorded on the job, never tears down the new tree).
 
 Endpoints:
     GET  /api/updates/check              — release-manifest fetch + diff
@@ -27,19 +27,28 @@ Endpoints:
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import json
+import os
 import shutil
 import subprocess
+import tempfile
 import time
 import uuid
+from pathlib import Path
 from typing import Any
 
+import structlog
 from fastapi import APIRouter, Request
 
 from hal0 import __version__
 from hal0.api.middleware.error_codes import BadRequest, Hal0Error
+from hal0.config import paths
 from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import Hal0Config
 from hal0.updater import Updater, fetch_release_manifest, releases_url
+
+log = structlog.get_logger(__name__)
 
 # See slots.py for the writer-gate rationale.
 
@@ -100,6 +109,96 @@ def _update_jobs(request: Request) -> dict[str, dict[str, Any]]:
     return jobs
 
 
+# ── durable job store (#509) ───────────────────────────────────────────────────
+#
+# The in-memory ``update_jobs`` dict is process-local, so an ``hal0-api``
+# restart mid-apply would 404 the CLI's status poll into a 600s timeout.
+# We mirror each job snapshot to ``/var/lib/hal0/update-jobs/<id>.json``
+# (atomic write) and fall back to disk on status lookup.
+
+
+def _jobs_dir() -> Path:
+    """Return ``/var/lib/hal0/update-jobs`` (HAL0_HOME-aware via paths)."""
+    return paths.var_lib() / "update-jobs"
+
+
+def _job_file(job_id: str) -> Path:
+    return _jobs_dir() / f"{job_id}.json"
+
+
+def _persist_job(job: dict[str, Any]) -> None:
+    """Atomically write a job snapshot to disk (best-effort, fail-soft).
+
+    A failure to persist must never break the apply flow - the in-memory
+    registry remains authoritative for the running process.
+    """
+    job_id = job.get("id")
+    if not job_id:
+        return
+    path = _job_file(str(job_id))
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_str = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+        tmp_path = Path(tmp_str)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(job, f)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, path)
+            tmp_path = None  # type: ignore[assignment]
+        finally:
+            if tmp_path is not None:
+                with contextlib.suppress(OSError):
+                    tmp_path.unlink(missing_ok=True)
+    except OSError as exc:
+        log.warning("updater.job_persist_failed", job_id=job_id, error=str(exc))
+
+
+def _load_persisted_job(job_id: str) -> dict[str, Any] | None:
+    """Read a persisted job snapshot from disk, or None if absent/unreadable."""
+    path = _job_file(job_id)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        loaded = json.loads(raw)
+    except ValueError:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _try_restart_hal0_api() -> tuple[bool, str | None]:
+    """``systemctl try-restart hal0-api.service`` - fail-soft.
+
+    Returns ``(restarted, error)``. No-ops cleanly when ``systemctl`` is
+    absent (tests / dev hosts) and never raises: a restart failure must not
+    tear down the just-installed tree.
+    """
+    systemctl = shutil.which("systemctl")
+    if not systemctl:
+        log.info("updater.restart_skipped", reason="systemctl not found")
+        return (False, "systemctl not found")
+    try:
+        proc = subprocess.run(
+            [systemctl, "try-restart", "hal0-api.service"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        log.warning("updater.restart_errored", error=str(exc))
+        return (False, str(exc))
+    if proc.returncode != 0:
+        err = (proc.stderr or "").strip()[:300] or f"systemctl exited {proc.returncode}"
+        log.warning("updater.restart_nonzero", returncode=proc.returncode, stderr=err)
+        return (False, err)
+    log.info("updater.restart_ok")
+    return (True, None)
+
+
 async def _run_apply_job(
     jobs: dict[str, dict[str, Any]],
     job_id: str,
@@ -108,30 +207,36 @@ async def _run_apply_job(
 ) -> None:
     """Background task that drives ``Updater.apply()`` and records progress.
 
-    The actual update work is Team D's. Until then, ``Updater.apply()``
-    raises ``NotImplementedError`` and we land the job in the ``failed``
-    state with the exception message. That keeps the dashboard's polling
-    flow exercising real states (queued → running → failed) instead of
-    just hitting a 501 wall.
+    Persists each state transition to disk so a daemon restart mid-apply
+    doesn't strand the CLI's status poll. On a successful apply it
+    try-restarts ``hal0-api.service`` fail-soft - a restart failure is
+    recorded on the job (``restarted`` / ``restart_error``) but never
+    re-fails the apply or tears down the new tree.
     """
     job = jobs[job_id]
     job["state"] = "running"
     job["updated_at"] = time.time()
+    _persist_job(job)
     try:
         updater = Updater(channel=channel)
         await updater.apply(version)
-    except NotImplementedError as exc:
-        job["state"] = "failed"
-        job["error"] = str(exc)
-        job["error_code"] = "system.update_pending"
     except Exception as exc:
         job["state"] = "failed"
         job["error"] = str(exc)
         job["error_code"] = type(exc).__name__
     else:
+        # Bounce hal0-api so the new tree is actually serving. Fail-soft:
+        # the swap already succeeded - a restart hiccup is a breadcrumb,
+        # not a rollback trigger. Record the restart outcome BEFORE flipping
+        # the job to its terminal "applied" state so a status poll never
+        # observes "applied" without the restart breadcrumb attached.
+        restarted, restart_error = await asyncio.to_thread(_try_restart_hal0_api)
+        job["restarted"] = restarted
+        job["restart_error"] = restart_error
         job["state"] = "applied"
     finally:
         job["updated_at"] = time.time()
+        _persist_job(job)
 
 
 # ── /state ─────────────────────────────────────────────────────────────────
@@ -349,7 +454,10 @@ async def apply_update(request: Request) -> dict[str, Any]:
     if isinstance(body, dict):
         v = body.get("version")
         if isinstance(v, str) and v.strip():
-            version = v.strip()
+            # Strip a leading "v" so {"version": "v0.1.1"} and "0.1.1"
+            # drive the same target - matches the CLI's --target handling
+            # (#510). lstrip is fine here: versions never start with "v".
+            version = v.strip().lstrip("v") or None
 
     channel = _current_channel(request)
     jobs = _update_jobs(request)
@@ -363,6 +471,9 @@ async def apply_update(request: Request) -> dict[str, Any]:
         "updated_at": time.time(),
         "error": None,
     }
+    # Persist the queued snapshot before returning so a status poll always
+    # resolves, even if the daemon restarts before the background task runs.
+    _persist_job(jobs[job_id])
     # Fire-and-forget; the route returns the queued snapshot. The
     # background task transitions the entry to running → applied | failed.
     # We retain a reference on app.state so the task isn't GC'd while
@@ -379,10 +490,20 @@ async def apply_update(request: Request) -> dict[str, Any]:
 
 @router.get("/status/{job_id}")
 async def update_status(job_id: str, request: Request) -> dict[str, Any]:
-    """Return the current snapshot of an update job by id."""
+    """Return the current snapshot of an update job by id.
+
+    Reads the in-memory registry first, then falls back to the on-disk
+    store (``/var/lib/hal0/update-jobs/<id>.json``) so a status poll still
+    resolves after an ``hal0-api`` restart wiped the process-local dict.
+    """
     jobs = _update_jobs(request)
     job = jobs.get(job_id)
     if job is None:
+        persisted = _load_persisted_job(job_id)
+        if persisted is not None:
+            # Re-seed the in-memory registry so subsequent polls are fast.
+            jobs[job_id] = persisted
+            return dict(persisted)
         raise UpdateJobNotFound(
             f"no update job with id {job_id!r}",
             details={"job_id": job_id},
@@ -397,23 +518,18 @@ async def update_status(job_id: str, request: Request) -> dict[str, Any]:
 async def rollback_update(request: Request) -> dict[str, Any]:
     """Invoke ``Updater.rollback()`` to revert to the retained previous version.
 
-    Until Team D ports the real symlink swap, this surfaces a typed
-    envelope (``code: "system.update_pending"``) carrying the
-    NotImplementedError message — keeps the surface real without
-    pretending the rollback succeeded.
+    ``Updater.rollback()`` raises typed ``Hal0Error`` subclasses
+    (e.g. ``UpdateRollbackUnavailable`` when there's no previous record),
+    which the middleware renders as structured envelopes. Anything else is
+    wrapped as a generic ``system.update_error``.
     """
     channel = _current_channel(request)
     updater = Updater(channel=channel)
     try:
         await updater.rollback()
-    except NotImplementedError as exc:
-        # 5xx: feature not yet implemented on the server side; not a
-        # client validation failure. Leave at the default 500 envelope
-        # until Team D ports the real symlink-swap path.
-        raise Hal0Error(
-            f"rollback not yet implemented: {exc}",
-            details={"channel": channel, "owner": "team-d"},
-        ) from exc
+    except Hal0Error:
+        # Already-typed updater errors surface as their own envelope.
+        raise
     except Exception as exc:
         raise UpdateError(
             f"rollback failed: {exc}",

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -1,10 +1,10 @@
 """CLI implementation for ``hal0 update``.
 
 Thin client over the /api/updates/* surface. The CLI never invokes
-``Updater`` directly — it goes through the daemon so the same code path
+``Updater`` directly - it goes through the daemon so the same code path
 is exercised whether you trigger an update from the dashboard or the
-shell. ``--restart-slots`` reaches around the API to ``systemctl`` after
-a successful apply (see PLAN §9 + Team D brief).
+shell. After a successful apply the daemon try-restarts hal0-api itself
+(see ``routes/updater._run_apply_job``); the CLI does not touch systemd.
 
 Surface:
     hal0 update                 # check + apply if newer
@@ -12,21 +12,21 @@ Surface:
     hal0 update --rollback      # roll back to previous tree
     hal0 update --channel CH    # set channel (persists), then check
     hal0 update --target VER    # pin a specific version
-    hal0 update --restart-slots # also bounce hal0-slot@*.service
 """
 
 from __future__ import annotations
 
-import shutil
-import subprocess
 import time
+import tomllib
 from enum import StrEnum
+from pathlib import Path
 
 import typer
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+import hal0
 from hal0.cli._shared import (
     CliApiError,
     _api_base,
@@ -45,35 +45,64 @@ class UpdateChannel(StrEnum):
     nightly = "nightly"
 
 
-def _restart_slots() -> None:
-    """Bounce every hal0-slot@*.service unit on this host.
+def _editable_source_version() -> str | None:
+    """Return the version in the source-tree pyproject.toml, if this is an
+    editable/source checkout; otherwise None.
 
-    Reaches around the API directly because the dashboard's contract is
-    that slot units are untouched across updates; this is an opt-in
-    operator action (``--restart-slots``) per PLAN §9. Missing systemctl
-    or non-root is reported but not fatal — the swap already succeeded.
+    In an editable install ``importlib.metadata.version("hal0")`` is frozen
+    at ``pip install -e`` time and goes stale after a ``git pull``. We detect
+    the source tree by walking up from ``hal0.__file__`` for a pyproject.toml
+    whose project name is ``hal0`` and reading its declared version.
     """
-    systemctl = shutil.which("systemctl")
-    if not systemctl:
-        console.print("[yellow]systemctl not found; skipping slot restart.[/yellow]")
+    mod_file = getattr(hal0, "__file__", None)
+    if not mod_file:
+        return None
+    for parent in Path(mod_file).resolve().parents:
+        pp = parent / "pyproject.toml"
+        if not pp.is_file():
+            continue
+        try:
+            data = tomllib.loads(pp.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError):
+            return None
+        project = data.get("project", {})
+        if project.get("name") == "hal0":
+            ver = project.get("version")
+            return str(ver) if ver else None
+        # A pyproject that isn't hal0's - stop walking (we left the tree).
+        return None
+    return None
+
+
+def _warn_editable_version_drift() -> None:
+    """Warn if the installed metadata version lags the source pyproject.
+
+    Best-effort and silent on the common case (versions match or no source
+    tree found). Surfaces the post-``git pull`` lie so an operator isn't
+    misled by a stale ``hal0 --version``.
+    """
+    source = _editable_source_version()
+    if not source:
         return
+    installed = hal0.__version__
+    # Compare semantically so PEP 440 normalization (0.3.2-alpha.1 vs
+    # 0.3.2a1) doesn't trip a false positive. Fall back to string equality
+    # if either side is unparseable.
     try:
-        proc = subprocess.run(
-            [systemctl, "restart", "hal0-slot@*.service"],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=60,
-        )
-    except (OSError, subprocess.SubprocessError) as exc:
-        console.print(f"[yellow]slot restart errored: {exc}[/yellow]")
-        return
-    if proc.returncode != 0:
+        from packaging.version import InvalidVersion, Version
+
+        try:
+            drifted = Version(source) != Version(installed)
+        except InvalidVersion:
+            drifted = source != installed
+    except ImportError:
+        drifted = source != installed
+    if drifted:
         console.print(
-            f"[yellow]slot restart returned {proc.returncode}:[/yellow] {proc.stderr.strip()[:300]}"
+            f"[yellow]editable install: package metadata reports "
+            f"{installed} but the source tree is {source}. "
+            f"Re-run `pip install -e .` to refresh the version.[/yellow]"
         )
-    else:
-        console.print("[green]slot units restarted.[/green]")
 
 
 def _print_check(body: dict) -> None:
@@ -144,11 +173,6 @@ def update(
         "--target",
         help="Pin a specific version (e.g. v0.1.1). Overrides the latest manifest version.",
     ),
-    restart_slots: bool = typer.Option(
-        False,
-        "--restart-slots",
-        help="After a successful apply, also systemctl restart hal0-slot@*.service.",
-    ),
 ) -> None:
     """Check for, apply, or roll back a hal0 update.
 
@@ -158,6 +182,8 @@ def update(
     url = _api_base()
     if _api_unreachable(url):
         raise typer.Exit(1)
+
+    _warn_editable_version_drift()
 
     if channel is not None:
         try:
@@ -213,8 +239,10 @@ def update(
     state = final.get("state")
     if state == "applied":
         console.print(Panel("[green]update applied.[/green]", border_style="green"))
-        if restart_slots:
-            _restart_slots()
+        if final.get("restarted") is False and final.get("restart_error"):
+            console.print(
+                f"[yellow]hal0-api restart did not complete:[/yellow] {final['restart_error']}"
+            )
     else:
         err = final.get("error") or "unknown error"
         die(f"update {state}: {err}")

--- a/src/hal0/updater/__init__.py
+++ b/src/hal0/updater/__init__.py
@@ -5,16 +5,16 @@ Implements `hal0 update [--channel=stable|nightly] [--check] [--rollback]`.
 The updater fetches the per-channel release manifest, verifies its cosign
 signature, extracts to a versioned directory, runs any pending config
 migrations, and atomically swaps the /usr/lib/hal0/current symlink.
-Running slots are NOT restarted unless --restart-slots is passed.
+Running slots are NOT restarted; only hal0-api is bounced (by the route
+layer) after a successful apply.
 
-Rollback swaps the symlink back to the retained previous version and
-restarts hal0-api.
+Rollback swaps the symlink back to the retained previous version.
 
 See PLAN.md §9 (update mechanism) and §17 risk #2 (cosign edge cases).
 The schema for release manifests lives at ``docs/internal/release-manifest.md``.
 
 Key exports:
-    Updater — check / apply / pull / rollback methods.
+    Updater — check / apply / rollback methods.
     ReleaseInfo — typed result of Updater.check.
     ReleaseManifest — pydantic schema for the on-disk manifest.
     UpdateError + subclasses — typed errors with system.update_* codes.
@@ -23,7 +23,6 @@ Key exports:
 from __future__ import annotations
 
 from hal0.updater.updater import (
-    DEFAULT_RELEASES_URL,
     ReleaseInfo,
     ReleaseManifest,
     UpdateCosignFailed,
@@ -41,7 +40,6 @@ from hal0.updater.updater import (
 )
 
 __all__ = [
-    "DEFAULT_RELEASES_URL",
     "ReleaseInfo",
     "ReleaseManifest",
     "UpdateCosignFailed",

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -13,8 +13,9 @@ Updater handles the full update lifecycle:
   7. Atomically swap the ``/usr/lib/hal0/current`` symlink using the
      POSIX ``symlink(tmp) + os.replace(tmp, current)`` pattern.
   8. Record the prior symlink target in ``/var/lib/hal0/hal0.previous`` for
-     rollback. Slot units are NOT touched — only ``hal0-api.service`` is
-     restarted (by the CLI / operator, not this function).
+     rollback. Slot units are NOT touched. The ``hal0-api.service`` restart
+     is the route layer's job (``routes/updater._run_apply_job``), not this
+     function - apply() only swaps the tree.
 
 Rollback reads ``/var/lib/hal0/hal0.previous``, atomic-swaps the
 ``current`` symlink back, and warns (without erroring) if the
@@ -51,8 +52,6 @@ from hal0.config import paths
 from hal0.config.loader import load_hal0_config, write_toml_atomic
 from hal0.config.migrations import latest_version, run_migrations
 from hal0.errors import Hal0Error
-
-DEFAULT_RELEASES_URL = "https://releases.hal0.dev/latest.json"
 
 log = structlog.get_logger(__name__)
 
@@ -148,7 +147,7 @@ class ReleaseManifest(BaseModel):
 
     schema_id: str = Field(default="hal0.releases.v1", alias="_schema")
     version: str = Field(..., description="Release version, e.g. '0.1.1'.")
-    channel: str = Field(default="stable", description="stable | nightly | dev")
+    channel: str = Field(default="stable", description="stable | nightly")
     url: str = Field(..., description="Tarball download URL (https or file).")
     sig_url: str = Field(..., description="Detached cosign signature URL.")
     cert_url: str = Field(
@@ -893,8 +892,9 @@ class Updater:
           8. Atomic-swap the ``/usr/lib/hal0/current`` symlink.
           9. Record the prior target in ``/var/lib/hal0/hal0.previous``.
 
-        Slot units are NOT restarted; ``hal0-api.service`` restart is the
-        CLI / operator's responsibility (per PLAN §9).
+        Slot units are NOT restarted; the ``hal0-api.service`` restart is
+        the route layer's responsibility (``routes/updater._run_apply_job``
+        try-restarts it fail-soft after a successful apply).
 
         Returns a breadcrumb dict the route layer can attach to the job
         record (``version``, ``previous``, ``installed_at``,
@@ -1034,10 +1034,6 @@ class Updater:
             "installed_at": time.time(),
         }
 
-    # Backwards-compat alias for the CLI; new callers should prefer apply().
-    async def pull(self, version: str | None = None) -> dict[str, Any]:
-        return await self.apply(version)
-
     # ── rollback ───────────────────────────────────────────────────────────────
 
     async def rollback(self) -> dict[str, Any]:
@@ -1128,7 +1124,6 @@ class Updater:
 
 
 __all__ = [
-    "DEFAULT_RELEASES_URL",
     "ReleaseInfo",
     "ReleaseManifest",
     "UpdateCosignFailed",

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -6,7 +6,6 @@ tests point at a local JSON file written into the pytest tmp dir.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import time
 from collections.abc import Iterator
@@ -246,14 +245,15 @@ def test_status_unknown_job_returns_envelope(isolated_client: TestClient) -> Non
     assert r.json()["error"]["code"] == "system.update_job_not_found"
 
 
-def test_apply_status_eventually_failed_until_team_d_ports(
+def test_apply_status_eventually_failed_on_invalid_manifest(
     isolated_client: TestClient,
 ) -> None:
-    """Apply transitions queued → running → failed because Updater.apply()
-    raises NotImplementedError until Team D ports the symlink swap.
+    """Apply transitions queued -> running -> failed on a bad manifest.
 
-    The route layer is what's under test here — that the background task
-    runs, records its error, and the status endpoint reflects it.
+    The isolated_client manifest is minimal ({"version", "url"}) so it
+    fails schema validation inside ``Updater.apply()``. The route layer is
+    what's under test here - that the background task runs, records its
+    error, and the status endpoint reflects it.
     """
     r = isolated_client.post("/api/updates/apply", json={})
     job_id = r.json()["id"]
@@ -268,22 +268,25 @@ def test_apply_status_eventually_failed_until_team_d_ports(
         if final["state"] in ("failed", "applied"):
             break
         # Give the event loop a chance to run the background task.
-        asyncio.run(asyncio.sleep(0.05))
+        time.sleep(0.05)
     assert final.get("state") == "failed", f"expected failed, got {final}"
     assert final.get("error")
 
 
-def test_rollback_returns_pending_envelope_until_ported(
+def test_rollback_without_previous_returns_envelope(
     isolated_client: TestClient,
 ) -> None:
-    """Rollback surfaces the NotImplementedError as a typed envelope, not a 500."""
+    """Rollback with no previous-version record surfaces the typed envelope.
+
+    ``Updater.rollback()`` raises ``UpdateRollbackUnavailable`` (a typed
+    Hal0Error) which the route now surfaces directly instead of wrapping
+    it - the dashboard keys off the structured code.
+    """
     r = isolated_client.post("/api/updates/rollback")
     assert r.status_code in (400, 500, 501)
     body = r.json()
     assert "error" in body
-    # The message should mention rollback or team-d so the dashboard can
-    # render a clear "rollback pending" hint.
-    assert "rollback" in body["error"]["message"].lower()
+    assert body["error"]["code"] == "system.update_rollback_unavailable"
 
 
 def test_channel_get_returns_stable_default(isolated_client: TestClient) -> None:
@@ -319,3 +322,175 @@ def test_channel_put_invalid_value_returns_envelope(isolated_client: TestClient)
     body = r.json()
     assert "error" in body
     assert "allowed" in body["error"]["details"]
+
+
+def test_channel_put_rejects_dev(isolated_client: TestClient) -> None:
+    """The ``dev`` channel is not a valid update channel (reconciled #510)."""
+    r = isolated_client.put("/api/updates/channel", json={"channel": "dev"})
+    assert r.status_code in (400, 500)
+    body = r.json()
+    assert "error" in body
+    assert "dev" not in body["error"]["details"]["allowed"]
+
+
+# ── #509: durable job store + hal0-api restart on apply ────────────────────────
+
+
+def test_apply_persists_job_to_disk(isolated_client: TestClient, tmp_hal0_home: str) -> None:
+    """A queued apply job is written under /var/lib/hal0/update-jobs/<id>.json."""
+    r = isolated_client.post("/api/updates/apply", json={})
+    assert r.status_code == 202, r.text
+    job_id = r.json()["id"]
+
+    job_file = Path(tmp_hal0_home) / "var-lib" / "hal0" / "update-jobs" / f"{job_id}.json"
+    # The queued snapshot is persisted synchronously before the route returns.
+    assert job_file.exists(), f"expected on-disk job record at {job_file}"
+    on_disk = json.loads(job_file.read_text(encoding="utf-8"))
+    assert on_disk["id"] == job_id
+    assert "state" in on_disk
+    assert "updated_at" in on_disk
+
+
+def test_status_falls_back_to_disk_after_restart(
+    isolated_client: TestClient, tmp_hal0_home: str
+) -> None:
+    """Status poll resolves from disk even when the in-memory dict was wiped.
+
+    Simulates an ``hal0-api`` restart mid-apply: the process-local
+    ``app.state.update_jobs`` dict is cleared, but the durable record on
+    disk lets the CLI's status poll still resolve (no 404 -> 600s timeout).
+    """
+    r = isolated_client.post("/api/updates/apply", json={})
+    job_id = r.json()["id"]
+
+    # Wait for the background task to land a terminal state on disk.
+    job_file = Path(tmp_hal0_home) / "var-lib" / "hal0" / "update-jobs" / f"{job_id}.json"
+    deadline = time.monotonic() + 6.0
+    while time.monotonic() < deadline:
+        if job_file.exists():
+            rec = json.loads(job_file.read_text(encoding="utf-8"))
+            if rec.get("state") in ("applied", "failed"):
+                break
+        time.sleep(0.05)
+
+    # Simulate the restart: blow away the in-memory registry.
+    isolated_client.app.state.update_jobs = {}
+
+    s = isolated_client.get(f"/api/updates/status/{job_id}")
+    assert s.status_code == 200, s.text
+    body = s.json()
+    assert body["id"] == job_id
+    assert body["state"] in ("queued", "running", "applied", "failed")
+
+
+def test_apply_success_tries_restart_hal0_api_fail_soft(
+    isolated_client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A successful apply records a restart breadcrumb and never tears down.
+
+    We stub ``Updater.apply`` to succeed and capture the systemctl call so
+    the test doesn't depend on systemd. A restart failure must be fail-soft
+    (logged + recorded), not fatal to the applied job.
+    """
+    from hal0.api.routes import updater as u_mod
+
+    async def fake_apply(self: object, version: str | None = None) -> dict:
+        return {"version": "0.0.9", "installed_at": time.time()}
+
+    monkeypatch.setattr(u_mod.Updater, "apply", fake_apply)
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], *a: object, **k: object) -> object:
+        calls.append(cmd)
+
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr(u_mod.subprocess, "run", fake_run)
+
+    r = isolated_client.post("/api/updates/apply", json={})
+    job_id = r.json()["id"]
+
+    deadline = time.monotonic() + 6.0
+    final: dict = {}
+    while time.monotonic() < deadline:
+        final = isolated_client.get(f"/api/updates/status/{job_id}").json()
+        if final["state"] in ("applied", "failed"):
+            break
+        time.sleep(0.05)
+
+    assert final.get("state") == "applied", final
+    # systemctl try-restart hal0-api.service was invoked.
+    assert any("try-restart" in c and "hal0-api.service" in c for c in calls), calls
+    assert final.get("restarted") is True
+
+
+def test_apply_success_restart_failure_is_fail_soft(
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the restart raises, the job is still 'applied' with a breadcrumb."""
+    from hal0.api.routes import updater as u_mod
+
+    async def fake_apply(self: object, version: str | None = None) -> dict:
+        return {"version": "0.0.9"}
+
+    monkeypatch.setattr(u_mod.Updater, "apply", fake_apply)
+
+    def boom_run(cmd: list[str], *a: object, **k: object) -> object:
+        raise OSError("systemctl exploded")
+
+    monkeypatch.setattr(u_mod.subprocess, "run", boom_run)
+
+    r = isolated_client.post("/api/updates/apply", json={})
+    job_id = r.json()["id"]
+
+    deadline = time.monotonic() + 6.0
+    final: dict = {}
+    while time.monotonic() < deadline:
+        final = isolated_client.get(f"/api/updates/status/{job_id}").json()
+        if final["state"] in ("applied", "failed"):
+            break
+        time.sleep(0.05)
+
+    # The just-installed tree is NOT torn down: the job stays applied.
+    assert final.get("state") == "applied", final
+    assert final.get("restarted") is False
+    assert final.get("restart_error")
+
+
+def test_apply_target_strips_leading_v(
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POST /api/updates/apply normalizes a leading 'v' on the version.
+
+    ``{"version": "v0.1.1"}`` and ``{"version": "0.1.1"}`` must drive the
+    same target so the CLI and direct API callers behave identically (#510).
+    """
+    from hal0.api.routes import updater as u_mod
+
+    seen: list[str | None] = []
+
+    async def fake_apply(self: object, version: str | None = None) -> dict:
+        seen.append(version)
+        return {"version": version or "latest"}
+
+    monkeypatch.setattr(u_mod.Updater, "apply", fake_apply)
+    monkeypatch.setattr(u_mod.subprocess, "run", lambda *a, **k: type("R", (), {"returncode": 0})())
+
+    r = isolated_client.post("/api/updates/apply", json={"version": "v0.1.1"})
+    job_id = r.json()["id"]
+    deadline = time.monotonic() + 6.0
+    while time.monotonic() < deadline:
+        if isolated_client.get(f"/api/updates/status/{job_id}").json()["state"] in (
+            "applied",
+            "failed",
+        ):
+            break
+        time.sleep(0.05)
+
+    assert seen == ["0.1.1"], seen

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -1,0 +1,116 @@
+"""Tests for the ``hal0 update`` CLI subcommand (#510).
+
+The CLI is a thin client over /api/updates/*; these tests stub the
+``api_*`` helpers (imported into the update_commands namespace) so the
+command logic - target-version normalization, the apply trigger, and the
+absence of the retired ``--restart-slots`` flag - is exercised without a
+running daemon.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import update_commands as uc
+from hal0.cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def stub_api(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Stub the api_* helpers + reachability so update() runs offline.
+
+    Returns a captured-calls dict so assertions can inspect what the CLI
+    sent to /api/updates/apply.
+    """
+    captured: dict = {"apply_json": None, "get_paths": [], "put_json": None}
+
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+
+    def fake_get(path: str, **kwargs: object) -> dict:
+        captured["get_paths"].append(path)
+        # /api/updates/check - advertise an available update so apply runs.
+        return {
+            "current": "0.0.0",
+            "latest": "9.9.9",
+            "channel": "stable",
+            "update_available": True,
+            "manifest": {},
+        }
+
+    def fake_post(path: str, *, json: object = None, **kwargs: object) -> dict:
+        if path == "/api/updates/apply":
+            captured["apply_json"] = json
+            return {"id": "job123", "state": "queued"}
+        return {}
+
+    def fake_put(path: str, *, json: object = None, **kwargs: object) -> dict:
+        captured["put_json"] = json
+        return {"channel": json.get("channel") if isinstance(json, dict) else None}
+
+    def fake_poll(job_id: str, **kwargs: object) -> dict:
+        return {"id": job_id, "state": "applied"}
+
+    monkeypatch.setattr(uc, "api_get", fake_get)
+    monkeypatch.setattr(uc, "api_post", fake_post)
+    monkeypatch.setattr(uc, "api_put", fake_put)
+    monkeypatch.setattr(uc, "_poll_job", fake_poll)
+    return captured
+
+
+def test_restart_slots_flag_removed() -> None:
+    """The retired ``--restart-slots`` flag is gone from the command signature."""
+    sig = inspect.signature(uc.update)
+    assert "restart_slots" not in sig.parameters
+    # And the helper that bounced hal0-slot@*.service is removed too.
+    assert not hasattr(uc, "_restart_slots")
+
+
+def test_target_strips_leading_v(stub_api: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--target v0.1.1`` is normalized to ``0.1.1`` before hitting the API."""
+    monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
+    result = runner.invoke(app, ["update", "--target", "v0.1.1"])
+    assert result.exit_code == 0, result.output
+    assert stub_api["apply_json"] == {"version": "0.1.1"}
+
+
+def test_target_without_v_is_unchanged(stub_api: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--target 0.1.1`` behaves identically to ``--target v0.1.1``."""
+    monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
+    result = runner.invoke(app, ["update", "--target", "0.1.1"])
+    assert result.exit_code == 0, result.output
+    assert stub_api["apply_json"] == {"version": "0.1.1"}
+
+
+def test_editable_drift_warns_when_source_ahead(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When the source pyproject is ahead of the metadata version, warn."""
+    import hal0
+
+    monkeypatch.setattr(hal0, "__version__", "0.3.0")
+    monkeypatch.setattr(uc, "_editable_source_version", lambda: "0.4.0")
+    uc._warn_editable_version_drift()
+    out = capsys.readouterr().out
+    assert "0.3.0" in out
+    assert "0.4.0" in out
+
+
+def test_editable_drift_silent_when_matching(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No warning when metadata and source versions agree (or no source)."""
+    import hal0
+
+    monkeypatch.setattr(hal0, "__version__", "0.4.0")
+    monkeypatch.setattr(uc, "_editable_source_version", lambda: "0.4.0")
+    uc._warn_editable_version_drift()
+    assert capsys.readouterr().out == ""
+
+    monkeypatch.setattr(uc, "_editable_source_version", lambda: None)
+    uc._warn_editable_version_drift()
+    assert capsys.readouterr().out == ""

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -687,3 +687,28 @@ def test_cosign_skip_false_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr("hal0.__version__", "1.0.0-rc1")
     monkeypatch.delenv("HAL0_UPDATE_SKIP_COSIGN", raising=False)
     assert _cosign_skip() is False
+
+
+# ── #510: dead-code sweep ──────────────────────────────────────────────────────
+
+
+def test_default_releases_url_export_removed() -> None:
+    """The stale DEFAULT_RELEASES_URL export (pointed at /latest.json) is gone."""
+    import hal0.updater as pkg
+    import hal0.updater.updater as mod
+
+    assert not hasattr(mod, "DEFAULT_RELEASES_URL")
+    assert not hasattr(pkg, "DEFAULT_RELEASES_URL")
+    assert "DEFAULT_RELEASES_URL" not in mod.__all__
+    assert "DEFAULT_RELEASES_URL" not in pkg.__all__
+
+
+def test_updater_pull_alias_removed() -> None:
+    """Updater.pull (no callers) is removed; apply() is the only entrypoint."""
+    assert not hasattr(Updater, "pull")
+
+
+def test_release_manifest_channel_does_not_advertise_dev() -> None:
+    """The manifest channel description is reconciled to stable | nightly only."""
+    desc = ReleaseManifest.model_fields["channel"].description or ""
+    assert "dev" not in desc


### PR DESCRIPTION
Implements **#509** (updater is write-only) and **#510** (dead-code/consistency sweep) together, since they share the updater files.

## #509 — close the two ways `hal0 update` was write-only
- **Restart hal0-api after apply.** `routes/updater._run_apply_job` now `systemctl try-restart hal0-api.service` on success, **fail-soft**: a restart failure is recorded on the job (`restarted` / `restart_error`) and never tears down the just-installed tree. No-ops cleanly when `systemctl` is absent (tests/dev). The restart outcome is recorded *before* the job flips to its terminal `applied` state so a status poll never sees `applied` without the breadcrumb. The updater docstring already claimed this happened — now it's true (and correctly attributed to the route layer, not `Updater.apply`).
- **Durable job registry.** Each job snapshot is atomically mirrored to `/var/lib/hal0/update-jobs/<id>.json` (via `hal0.config.paths`, so `HAL0_HOME` works in tests). `GET /status/{id}` falls back to disk and re-seeds the in-memory dict, so an `hal0-api` restart mid-apply no longer 404s the CLI's status poll into a 600s timeout.

## #510 — dead-code / consistency sweep
- Removed the stale `NotImplementedError` docstring + the unreachable `except NotImplementedError` branch in `routes/updater.py`. Rollback now surfaces its typed `Hal0Error` (e.g. `system.update_rollback_unavailable`) directly instead of wrapping it.
- Removed `Updater.pull` (no callers) and the wrong/unused `DEFAULT_RELEASES_URL` export (it pointed at `/latest.json`; `releases_url()` is the real per-channel resolver).
- Removed the dead `--restart-slots` CLI flag + `_restart_slots` helper (targeted the retired `hal0-slot@.service` template). #509 now restarts hal0-api automatically.
- **`dev` channel reconciled — dropped from the schema.** Only the `ReleaseManifest.channel` field *description* advertised `dev`; the CLI enum, API `_VALID_CHANNELS`, and the telemetry config validator all reject it. Fixing the description is the smaller change than wiring `dev` end-to-end, so the description now reads `stable | nightly`.
- **Editable-install version-drift warning.** `hal0 update` warns when `importlib.metadata` reports an older version than the source-tree `pyproject.toml` (the post-`git pull` lie). Compared with `packaging.version` so PEP 440 normalization (`0.3.2-alpha.1` vs `0.3.2a1`) doesn't false-positive.
- **`--target` v-strip parity.** The API now strips a leading `v` on the posted version, matching the CLI's `--target` handling, so `v0.1.1` and `0.1.1` behave identically from either surface.

## Tests (TDD — written first)
- `tests/api/test_updater_routes.py`: queued job persisted to disk; status falls back to disk after the in-memory dict is wiped (restart sim); apply try-restarts hal0-api with a recorded breadcrumb; restart failure is fail-soft (`applied` + `restart_error`); `--target` v-strip; `dev` channel rejected.
- `tests/updater/test_updater.py`: `DEFAULT_RELEASES_URL` / `Updater.pull` gone; manifest channel description no longer advertises `dev`.
- `tests/cli/test_update_commands.py` (new): `--restart-slots` removed; `--target` v-strip parity; editable drift warns/stays silent.

Verified green and flake-free (5× repeat) with `tests/updater/ tests/api/ -k "updat or release or apply or channel"` (72 passed) and `tests/cli/ -k updat` (5 passed). `ruff check` + `ruff format --check` clean over `src tests`.

Closes #509
Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)