### PR TITLE
feat(installer): opt-in ROCmFP4 + MTP power pack flag (--rocmfp4)

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -80,6 +80,10 @@ These are the variables `installer/install.sh` actually reads:
 | `HAL0_MODELS_DIR` | _(unset)_ | Absolute path where model pulls land (Lemonade's `extra_models_dir`); same as `--models-dir=PATH`. When unset, models live at `/var/lib/hal0/models` (or `$PWD/.hal0ai/var/lib/hal0/models` under `--dev`). |
 | `HAL0_NO_PROBE` | _(unset)_ | Set to `1` to skip the hardware probe at the end |
 | `HAL0_OPENWEBUI_PORT` † | `3001` | OpenWebUI host port — **dev mode only** |
+| `HAL0_ENABLE_ROCMFP4` | _(unset)_ | Set to `1` to opt into the ROCmFP4 + MTP power pack; same as `--rocmfp4`. See [ROCmFP4 power pack (opt-in)](#rocmfp4-power-pack-opt-in). |
+| `HAL0_ROCMFP4_BIN` | `/opt/hal0/rocmfp4-llama/build/bin/llama-server` | Path to the prebuilt `charlie12345/rocmfp4-llama` fork binary (or its wrapper) wired in as Lemonade's `rocm_bin`. Only read when the power pack is enabled. |
+| `HAL0_ROCMFP4_MODEL` | `Qwen3.6-27B-MTP-GGUF` | Model id seeded into the `gpu-rocmfp4` slot. Power pack only. |
+| `HAL0_ROCMFP4_HSA_OVERRIDE` | `11.5.1` | `HSA_OVERRIDE_GFX_VERSION` tag (gfx1151) referenced in the seeded slot's guard note. Power pack only. |
 
 † `HAL0_OPENWEBUI_PORT` is honored by `scripts/dev-bootstrap.sh` (the dev-mode launcher). The installed `hal0-openwebui.service` hardcodes `:3001`; to change it post-install, edit `/etc/systemd/system/hal0-openwebui.service` and reload.
 
@@ -145,6 +149,88 @@ Two ways to resolve this, depending on what you're trying to do:
    After that, slot operations work against the dev tree. Edits to the linked unit files take effect after another `systemctl daemon-reload`.
 
 The installer prints the same warning block at the end of every `--dev` run as a reminder.
+
+## ROCmFP4 power pack (opt-in)
+
+The **ROCmFP4 + MTP power pack** wires a custom `charlie12345/rocmfp4-llama`
+fork of llama.cpp behind Lemonade so FP4 GGUFs with a baked-in multi-token-
+prediction (MTP) head can self-speculate. Where it applies it is a big win
+(measured: 27B at 12.9 → 22.8 tok/s, ~1.77× with MTP).
+
+It is **off by default and is NOT auto-enabled by the `hal0-max` bundle**
+(locked decision D5). It is deliberately opt-in because it is fragile:
+
+- **gfx1151-only / ROCm-only** — Strix Halo iGPU under AMD ROCm. No effect on
+  Vulkan, CPU, NPU, or any other GPU arch.
+- **out-of-band binary** — the fork ships new ggml quant types
+  (`Q4_0_ROCMFP4*`) that **stock llama.cpp cannot load**, so the fork binary
+  (~7.8 GB with its bundled ROCm libs) is built separately, not by this
+  installer.
+- **HSA override dependency** — it needs `HSA_OVERRIDE_GFX_VERSION` (gfx1151 →
+  `11.5.1`), carried by the fork wrapper binary. A *stale* override after a
+  Lemonade ROCm-bundle upgrade is a known crash mode (see below).
+
+### Prerequisite — build the fork binary out-of-band
+
+The installer only *wires in* an existing binary; build it first:
+
+1. Clone `github.com/charlie12345/rocmfp4-llama` (branch `mtp-rocmfp4-strix`).
+2. Build inside a `rocm/dev-ubuntu-24.04:7.2.1-complete` container. On an LXC
+   host, `docker run --security-opt apparmor=unconfined` (docker *build* is
+   apparmor-blocked in an LXC, but *run* works with that flag).
+3. Install the resulting `llama-server` (plus its ROCm libs) somewhere stable.
+   The installer defaults to `/opt/hal0/rocmfp4-llama/build/bin/llama-server`;
+   point `HAL0_ROCMFP4_BIN` elsewhere if you put it somewhere else. A wrapper
+   that sets `LD_LIBRARY_PATH` + `HSA_OVERRIDE_GFX_VERSION` + execs the real
+   binary is a valid target too.
+
+### Enable it
+
+```sh
+# flag form
+sudo bash installer/install.sh --rocmfp4
+
+# env form (equivalent), with a custom binary path + slot model
+HAL0_ENABLE_ROCMFP4=1 \
+HAL0_ROCMFP4_BIN=/opt/hal0/rocmfp4-llama/build/bin/llama-server \
+HAL0_ROCMFP4_MODEL=Qwen3.6-27B-MTP-GGUF \
+  sudo bash installer/install.sh
+```
+
+When enabled on an eligible host with the binary present, the installer:
+
+1. sets `llamacpp.rocm_bin` in `/var/lib/hal0/lemonade/config.json` to the fork
+   binary (global to the ROCm backend; every other hal0 slot runs Vulkan, so
+   isolation is clean). **Restart `hal0-lemonade` for it to take effect** —
+   `rocm_bin` is not a live `/v1/params` key.
+2. seeds `/etc/hal0/slots/gpu-rocmfp4.toml` (device `gpu-rocm`, the MTP /
+   self-speculative `extra_args`, and the HSA-override guard documented
+   inline). An existing slot file is left untouched.
+
+If the host is **not** gfx1151 / ROCm, or the fork binary is **absent**, the
+installer **warns and skips cleanly** — the rest of the install is unaffected.
+`--rocmfp4` is also a no-op under `--dev`.
+
+### Repair — stale `HSA_OVERRIDE_GFX_VERSION` crash
+
+Lemonade's weekly-breaking-release cadence changes the bundled ROCm/rocBLAS
+layout. A `HSA_OVERRIDE_GFX_VERSION` written for an *older* bundle can become
+actively harmful once the new bundle adds native gfx1151 kernels: rocBLAS then
+looks up the wrong arch and crashes `llama-server` on the **first inference**
+(`Cannot read TensileLibrary.dat ... gfx1100`), surfacing as a chat **502**.
+
+Fix:
+
+```sh
+ls /var/lib/hal0/lemonade/bin/therock/    # look for a gfx1151-* dir
+```
+
+- If `gfx1151-*` exists, the override is no longer needed — disable any stale
+  `/etc/systemd/system/hal0-lemonade.service.d/rocm-gfx-override.conf` (rename
+  to `.disabled-<date>`), then `systemctl daemon-reload && systemctl restart
+  hal0-lemonade`.
+- If still needed but for a different arch tag, set `HSA_OVERRIDE_GFX_VERSION`
+  to match (e.g. `11.5.1` for gfx1151).
 
 ## Uninstall
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -58,6 +58,18 @@ wait_active() {
 
 DEV_MODE=0
 NO_START=0
+# ROCmFP4 + MTP "power pack" (issue #516, locked decision D5). OPT-IN only:
+# never default, never auto-enabled by the hal0-max bundle. Scaffolds the
+# gfx1151-only / ROCm-only fork path (charlie12345/rocmfp4-llama) — a global
+# `rocm_bin` override + a `gpu-rocmfp4` slot + the HSA_OVERRIDE_GFX_VERSION
+# guard. Toggle with `--rocmfp4` or HAL0_ENABLE_ROCMFP4=1. The actual fork
+# binary is built out-of-band (see installer/README.md "ROCmFP4 power pack");
+# this flag only wires an EXISTING binary in, warning + skipping if it or the
+# host eligibility is missing. Default install is byte-for-byte unaffected.
+ENABLE_ROCMFP4=0
+if [[ "${HAL0_ENABLE_ROCMFP4:-0}" == "1" ]]; then
+    ENABLE_ROCMFP4=1
+fi
 # TLS posture: hal0-api binds 0.0.0.0:8080 directly. TLS termination,
 # DNS, and any per-host certs are the responsibility of an upstream
 # reverse proxy (Traefik, nginx, Cloudflare Tunnel) — hal0 does not ship
@@ -71,12 +83,20 @@ for arg in "$@"; do
     case "$arg" in
         --dev) DEV_MODE=1 ;;
         --no-start) NO_START=1 ;;
+        --rocmfp4) ENABLE_ROCMFP4=1 ;;
         --models-dir=*) MODELS_DIR="${arg#--models-dir=}" ;;
         --help|-h)
             cat <<EOF
-Usage: install.sh [--dev] [--no-start] [--models-dir=PATH]
+Usage: install.sh [--dev] [--no-start] [--rocmfp4] [--models-dir=PATH]
   --dev               install under \$PWD/.hal0ai/, no systemd setup
   --no-start          set up everything but don't enable/start the API
+  --rocmfp4           opt-in ROCmFP4 + MTP "power pack": wires a prebuilt
+                      charlie12345/rocmfp4-llama fork binary as Lemonade's
+                      global rocm_bin and seeds a gpu-rocmfp4 slot. gfx1151 +
+                      ROCm only; warns + skips cleanly on ineligible hosts or
+                      if the fork binary is absent. Same as HAL0_ENABLE_ROCMFP4=1.
+                      The fork binary is built out-of-band — see
+                      installer/README.md "ROCmFP4 power pack (opt-in)".
   --models-dir=PATH   absolute path where HuggingFace pulls land
                       (default: /var/lib/hal0/models — or \$PWD/.hal0ai/var/lib/hal0/models
                       under --dev). Can also be set with HAL0_MODELS_DIR=PATH.
@@ -1258,6 +1278,167 @@ DROPIN
             warn "systemctl enable hal0-lemonade failed — check 'systemctl status hal0-lemonade'"
     else
         warn "${LEMONADE_PREFIX}/lemond missing — leaving hal0-lemonade.service disabled"
+    fi
+fi
+
+# ── ROCmFP4 + MTP power pack (issue #516, opt-in) ──────────────────────────
+# Locked decision D5: the ROCmFP4 + MTP fork path (charlie12345/rocmfp4-llama)
+# is NOT default and NOT auto-enabled by the hal0-max bundle. It is gfx1151-only
+# (Strix Halo) + ROCm-only, ~7.8 GB of ROCm libs, and depends on a stale-prone
+# HSA_OVERRIDE_GFX_VERSION — too fragile for out-of-box. When it applies it is a
+# big win (27B 12.9 → 22.8 tok/s, 1.77x MTP, verified) so we ship it as an
+# explicit power pack: `--rocmfp4` or HAL0_ENABLE_ROCMFP4=1.
+#
+# This block ONLY runs when explicitly requested. It:
+#   1. checks host eligibility (gfx1151 / AMD ROCm) — warns + skips otherwise,
+#   2. wires Lemonade's GLOBAL rocm_bin override to a PREBUILT fork binary taken
+#      from HAL0_ROCMFP4_BIN (default /opt/hal0/rocmfp4-llama/build/bin), warning
+#      + skipping with build instructions if the path is absent,
+#   3. seeds a gpu-rocmfp4 slot TOML (with the HSA_OVERRIDE_GFX_VERSION guard
+#      documented inline),
+#   4. leaves a guard/repair note for the known stale-HSA-override crash after a
+#      ROCm bundle upgrade.
+# Every failure mode here is a `warn` + `continue past` — NEVER fatal — so the
+# rest of the install is unaffected. Skipped entirely on --dev (no system
+# Lemonade config to patch).
+if [[ "${ENABLE_ROCMFP4}" -eq 1 && "${DEV_MODE}" -eq 0 ]]; then
+    info "ROCmFP4 power pack requested (--rocmfp4 / HAL0_ENABLE_ROCMFP4=1) — opt-in, not default"
+
+    # Default fork binary location. Built out-of-band (see installer/README.md
+    # "ROCmFP4 power pack (opt-in)"); override with HAL0_ROCMFP4_BIN. May be the
+    # real llama-server or the LD_LIBRARY_PATH + HSA-override wrapper that execs it.
+    ROCMFP4_BIN="${HAL0_ROCMFP4_BIN:-/opt/hal0/rocmfp4-llama/build/bin/llama-server}"
+    # gfx1151 maps to HSA_OVERRIDE_GFX_VERSION=11.5.1. Overridable in case a
+    # future ROCm bundle wants a different tag (see the stale-override note below).
+    ROCMFP4_HSA_OVERRIDE="${HAL0_ROCMFP4_HSA_OVERRIDE:-11.5.1}"
+    ROCMFP4_SLOT_MODEL="${HAL0_ROCMFP4_MODEL:-Qwen3.6-27B-MTP-GGUF}"
+
+    rocmfp4_eligible=1
+    # Eligibility: AMD ROCm + gfx1151 (Strix Halo). Best-effort, never fatal.
+    # rocminfo is the authoritative probe; fall back to the Lemonade ROCm
+    # bundle's per-arch dir (bin/therock/gfx1151-*) which only exists on a
+    # gfx1151 ROCm host. If neither signal is present we warn + skip.
+    rocmfp4_gfx_seen=""
+    if command -v rocminfo >/dev/null 2>&1; then
+        if rocminfo 2>/dev/null | grep -qi "gfx1151"; then
+            rocmfp4_gfx_seen="rocminfo:gfx1151"
+        fi
+    fi
+    if [[ -z "${rocmfp4_gfx_seen}" ]] \
+        && compgen -G "${LEMONADE_PREFIX}/bin/therock/gfx1151-*" >/dev/null 2>&1; then
+        rocmfp4_gfx_seen="lemonade-bundle:gfx1151"
+    fi
+    if [[ -z "${rocmfp4_gfx_seen}" ]]; then
+        rocmfp4_eligible=0
+        warn "ROCmFP4 power pack: host does not look gfx1151 / ROCm-eligible"
+        warn "  (no rocminfo gfx1151 and no ${LEMONADE_PREFIX}/bin/therock/gfx1151-* bundle)"
+        warn "  This pack is Strix Halo (gfx1151) + ROCm only — skipping cleanly."
+    fi
+
+    if [[ "${rocmfp4_eligible}" -eq 1 ]]; then
+        if [[ ! -x "${ROCMFP4_BIN}" ]]; then
+            warn "ROCmFP4 power pack: fork binary not found / not executable at ${ROCMFP4_BIN}"
+            warn "  The charlie12345/rocmfp4-llama fork is built OUT-OF-BAND (it ships new"
+            warn "  ggml quant types stock llama.cpp cannot load). Build it, then re-run with"
+            warn "  --rocmfp4 (or set HAL0_ROCMFP4_BIN=/path/to/llama-server):"
+            warn "    1. clone github.com/charlie12345/rocmfp4-llama (branch mtp-rocmfp4-strix)"
+            warn "    2. build in a rocm/dev-ubuntu-24.04:7.2.1-complete container (docker run"
+            warn "       --security-opt apparmor=unconfined on an LXC host)"
+            warn "    3. install the binary (+ its ROCm libs) under ${ROCMFP4_BIN%/*}"
+            warn "  Skipping the power pack — the rest of the install is unaffected."
+        else
+            info "ROCmFP4 power pack: using fork binary ${ROCMFP4_BIN}"
+
+            # 1. Wire the GLOBAL rocm_bin override into the Lemonade config we
+            #    just wrote. rocm_bin is global to the rocm backend, but every
+            #    OTHER hal0 slot runs Vulkan (backend=vulkan), so isolation is
+            #    clean — only gpu-rocm slots pick up the fork. Patch in place via
+            #    an atomic tempfile + rename so a crash mid-write can't leave
+            #    lemond parsing half-written JSON. Idempotent.
+            if [[ -f "${LEMONADE_CONFIG_JSON}" ]]; then
+                ROCMFP4_CFG_TMP="$(mktemp "${LEMONADE_CONFIG_JSON}.XXXXXX")"
+                if "${PY}" - "${LEMONADE_CONFIG_JSON}" "${ROCMFP4_BIN}" "${ROCMFP4_CFG_TMP}" <<'PYROCMFP4'
+import json, sys
+src, rocm_bin, dst = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(src) as f:
+    cfg = json.load(f)
+lc = cfg.setdefault("llamacpp", {})
+lc["rocm_bin"] = rocm_bin
+with open(dst, "w") as f:
+    json.dump(cfg, f, indent=2)
+    f.write("\n")
+print("set llamacpp.rocm_bin =", rocm_bin)
+PYROCMFP4
+                then
+                    chown hal0:hal0 "${ROCMFP4_CFG_TMP}" 2>/dev/null || true
+                    chmod 0644 "${ROCMFP4_CFG_TMP}"
+                    mv "${ROCMFP4_CFG_TMP}" "${LEMONADE_CONFIG_JSON}"
+                    info "wired llamacpp.rocm_bin → ${ROCMFP4_BIN} in ${LEMONADE_CONFIG_JSON}"
+                    info "  restart hal0-lemonade for it to take effect (not a live /v1/params key)"
+                else
+                    rm -f "${ROCMFP4_CFG_TMP}"
+                    warn "ROCmFP4 power pack: failed to patch rocm_bin into ${LEMONADE_CONFIG_JSON} — skipped"
+                fi
+            else
+                warn "ROCmFP4 power pack: ${LEMONADE_CONFIG_JSON} absent — cannot set rocm_bin, skipped"
+            fi
+
+            # 2. Seed the gpu-rocmfp4 slot. Never overwrite an existing one (an
+            #    operator may have tuned extra_args / picked a different FP4
+            #    model). The slot loads via device=gpu-rocm → llamacpp_backend=rocm,
+            #    so it inherits the global rocm_bin fork. extra_args carries the
+            #    MTP / self-speculative flags; --parallel 1 (mandatory for MTP) and
+            #    -fa on / --no-mmap come from the global llamacpp.args.
+            ROCMFP4_SLOT_TOML="${ETC_DIR}/slots/gpu-rocmfp4.toml"
+            if [[ -f "${ROCMFP4_SLOT_TOML}" ]]; then
+                info "ROCmFP4 power pack: ${ROCMFP4_SLOT_TOML} exists — left alone"
+            else
+                mkdir -p "${ETC_DIR}/slots"
+                cat > "${ROCMFP4_SLOT_TOML}" <<ROCMFP4SLOT
+# hal0 ROCmFP4 + MTP slot — OPT-IN power pack (issue #516, decision D5).
+#
+# Seeded ONLY when install.sh is run with --rocmfp4 / HAL0_ENABLE_ROCMFP4=1 on a
+# gfx1151 + ROCm host with the charlie12345/rocmfp4-llama fork binary present.
+# NOT part of the default install and NOT auto-enabled by the hal0-max bundle.
+#
+# Requires the global rocm_bin override (llamacpp.rocm_bin in
+# /var/lib/hal0/lemonade/config.json → ${ROCMFP4_BIN}) — the stock Lemonade
+# llama-server cannot load these FP4 GGUFs (new ggml quant types).
+#
+# HSA_OVERRIDE_GFX_VERSION guard: this path needs HSA_OVERRIDE_GFX_VERSION set
+# (gfx1151 → ${ROCMFP4_HSA_OVERRIDE}). It is carried by the fork wrapper binary,
+# NOT by this slot. KNOWN CRASH MODE: after a Lemonade ROCm-bundle upgrade that
+# adds native gfx1151 kernels, a STALE override (e.g. an old gfx1100 / 11.0.0
+# drop-in) makes rocBLAS look up the wrong arch and crash llama-server on first
+# inference ("Cannot read TensileLibrary.dat ... gfx1100"), surfacing as a chat
+# 502. REPAIR: ls /var/lib/hal0/lemonade/bin/therock/ — if gfx1151-* exists, the
+# override is no longer needed; disable any stale
+# /etc/systemd/system/hal0-lemonade.service.d/rocm-gfx-override.conf (rename to
+# .disabled-<date>), systemctl daemon-reload, systemctl restart hal0-lemonade.
+# If still needed for a different arch tag, set it to match (e.g. ${ROCMFP4_HSA_OVERRIDE}).
+
+name = "gpu-rocmfp4"
+provider = "lemonade"
+port = 8188
+device = "gpu-rocm"
+backend = "rocm"
+
+[model]
+default = "${ROCMFP4_SLOT_MODEL}"
+context_size = 8192
+
+[server]
+# MTP / self-speculative decoding flags (the NextN head is baked into the GGUF
+# — no separate draft model). Global llamacpp.args already supplies
+# --parallel 1 -fa on --no-mmap --threads N. For a vision FP4 model, append
+# --mmproj /path/to/mmproj (vision runs WITHOUT mtp per the fork author).
+extra_args = "--spec-type draft-mtp -ctk q4_0 -ctv q4_0 -b 512 -ub 512"
+ROCMFP4SLOT
+                chmod 0644 "${ROCMFP4_SLOT_TOML}"
+                info "seeded ROCmFP4 slot → ${ROCMFP4_SLOT_TOML} (model ${ROCMFP4_SLOT_MODEL})"
+                info "  HSA_OVERRIDE_GFX_VERSION guard + stale-override repair documented inline"
+            fi
+        fi
     fi
 fi
 


### PR DESCRIPTION
## What

Packages the ROCmFP4 + MTP fork path (`charlie12345/rocmfp4-llama`) as an explicit, **opt-in** installer "power pack" — never default, never auto-enabled by the `hal0-max` bundle (locked decision **D5**).

Where it applies it is a big win (27B 12.9 → 22.8 tok/s, ~1.77× MTP, verified), but it is gfx1151-only / ROCm-only, needs an out-of-band ~7.8 GB fork binary, and depends on a stale-prone `HSA_OVERRIDE_GFX_VERSION` — too fragile for out-of-box.

## Opt-in design

Enable with `--rocmfp4` or `HAL0_ENABLE_ROCMFP4=1`. When requested on an eligible host with the prebuilt binary present, the installer:

1. **Eligibility gate** — checks `rocminfo` for `gfx1151` (falls back to the Lemonade `bin/therock/gfx1151-*` bundle). On an ineligible host it **warns + skips cleanly**, never failing the install.
2. **`rocm_bin` override** — patches `llamacpp.rocm_bin` in `/var/lib/hal0/lemonade/config.json` to the prebuilt fork binary, taken from `HAL0_ROCMFP4_BIN` (default `/opt/hal0/rocmfp4-llama/build/bin/llama-server`). If the binary is absent it warns with the out-of-band build instructions and skips. Atomic tempfile + rename. `rocm_bin` is global to the ROCm backend, but every other hal0 slot runs Vulkan, so isolation is clean.
3. **`gpu-rocmfp4` slot** — seeds `/etc/hal0/slots/gpu-rocmfp4.toml` (device `gpu-rocm`, MTP / self-speculative `extra_args`) with the `HSA_OVERRIDE_GFX_VERSION` guard documented inline. Existing slot file left untouched.
4. **Stale-override guard** — documents the known crash mode (stale `HSA_OVERRIDE_GFX_VERSION` after a Lemonade ROCm-bundle upgrade → rocBLAS `gfx1100` lookup crash → chat 502) and the repair, both in the seeded slot and in the README.

Every failure mode is `warn` + skip, **never fatal**.

## Safety — default path unaffected

- The entire block is gated on `ENABLE_ROCMFP4 == 1 && DEV_MODE == 0`; absent the flag it is a **no-op**, so the default install is byte-for-byte unchanged. The `ui_step` counter is deliberately not touched (block uses `info`/`warn` directly).
- `installer/manifests/omni/hal0-max.json` is **verified unchanged** (`git diff` empty) — the pack is a separate explicit toggle.
- No-op under `--dev`. Rides along with the existing `uninstall.sh` teardown (`/etc/hal0` slot + Lemonade config removed wholesale).

## Docs

`installer/README.md`: new **ROCmFP4 power pack (opt-in)** section (out-of-band fork-build prerequisite, enable steps, stale-override repair) + env-var rows for `HAL0_ENABLE_ROCMFP4` / `HAL0_ROCMFP4_BIN` / `HAL0_ROCMFP4_MODEL` / `HAL0_ROCMFP4_HSA_OVERRIDE`.

## Verification

- `bash -n installer/install.sh` ✅
- `shellcheck -S warning` adds **zero** new warnings (the lone pre-existing SC2034 on `UI_STEP_TOTAL` is unchanged before/after).
- Shell + docs only — no Python touched, so no pytest / ruff required.

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)