### PR TITLE
feat(capabilities): add first-class vision slot reusing curated multimodal MoE

### DIFF
--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -223,6 +223,13 @@ def _model_capabilities(entry: CuratedModel | HaloaiModel | Any) -> list[str]:
     Curated entries expose a single ``capability`` string; haloai-seeded
     entries do the same. Registry-loaded :class:`~hal0.registry.model.Model`
     rows carry a ``capabilities`` list. Either shape works.
+
+    Vision (#515) is a secondary capability: the curated multimodal MoE
+    primaries keep ``capability="chat"`` (they are still chat models) but
+    advertise ``vision`` via their ``tags`` and ship an mmproj sidecar.
+    Surfacing ``vision`` from the ``tags`` lets the same entry appear in
+    both the chat slot and the dedicated vision capability dropdown
+    without a brand-new model download.
     """
     caps: list[str] = []
     cap = getattr(entry, "capability", None)
@@ -233,6 +240,9 @@ def _model_capabilities(entry: CuratedModel | HaloaiModel | Any) -> list[str]:
         for c in cap_list:
             if isinstance(c, str) and c and c not in caps:
                 caps.append(c)
+    tags = getattr(entry, "tags", None)
+    if isinstance(tags, list) and "vision" in tags and "vision" not in caps:
+        caps.append("vision")
     return caps
 
 
@@ -504,10 +514,19 @@ def _flat_rows_for_capability(
     rows: list[dict[str, Any]] = []
     seen: set[tuple[str, str]] = set()
 
+    # ``bundle_only`` entries are normally hidden from capability
+    # dropdowns (they exist only to give bundle manifests a loadable id).
+    # The ``vision`` capability (#515) is the exception: it deliberately
+    # REUSES the curated multimodal MoE primaries (which are bundle_only
+    # because they double as the chat/primary tier) rather than shipping a
+    # new model. Let bundle_only entries through for vision so the dropdown
+    # surfaces a real, already-curated multimodal pick.
+    allow_bundle_only = capability == "vision"
     curated_only = [
         e
         for e in CURATED
-        if not isinstance(e, HaloaiModel) and not getattr(e, "bundle_only", False)
+        if not isinstance(e, HaloaiModel)
+        and (allow_bundle_only or not getattr(e, "bundle_only", False))
     ]
     candidates: list[Any] = curated_only + _iter_registry_models(registry)
 
@@ -680,6 +699,9 @@ def catalogs_by_slot(
         },
         "img": {
             "img": models_for_capability("image", registry=registry),
+        },
+        "vision": {
+            "vision": models_for_capability("vision", registry=registry),
         },
         "chat": {
             "chat": models_for_capability("chat", registry=registry),

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -51,6 +51,7 @@ _CHILD_TO_SLOT: dict[tuple[str, str], str] = {
     ("voice", "stt"): "stt",
     ("voice", "tts"): "tts",
     ("img", "img"): "img",
+    ("vision", "vision"): "vision",
 }
 
 # Inverse for status surfacing ("which child is this slot serving").
@@ -59,7 +60,7 @@ _SLOT_TO_CHILD: dict[str, tuple[str, str]] = {
 }
 
 # The legal capability/child surface — used by HTTP validation.
-LEGAL_SLOTS: tuple[str, ...] = ("embed", "voice", "img")
+LEGAL_SLOTS: tuple[str, ...] = ("embed", "voice", "img", "vision")
 
 
 def legal_children(slot: str) -> list[str]:
@@ -90,6 +91,7 @@ _CHILD_TO_CAPABILITY: dict[tuple[str, str], str] = {
     ("voice", "stt"): "stt",
     ("voice", "tts"): "tts",
     ("img", "img"): "image",
+    ("vision", "vision"): "vision",
 }
 
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -68,7 +68,7 @@ log = logging.getLogger(__name__)
 #: Slots that exist on every hal0 install regardless of hardware. The
 #: dashboard creates these as empty cards at first run; the bundle
 #: picker (Phase 5) populates their ``model.default`` fields.
-SEEDED_SLOTS: tuple[str, ...] = ("primary", "embed", "rerank", "stt", "tts", "img")
+SEEDED_SLOTS: tuple[str, ...] = ("primary", "embed", "rerank", "stt", "tts", "img", "vision")
 
 #: NPU slots seeded only when the FastFlowLM ``.deb`` is installed
 #: (``shutil.which('flm')`` truthy). These back the AMDXDNA hardware

--- a/tests/capabilities/test_vision_curation.py
+++ b/tests/capabilities/test_vision_curation.py
@@ -1,0 +1,63 @@
+"""Vision capability surfacing (#515).
+
+hal0 gains a first-class ``vision`` capability. Rather than introducing a
+brand-new model download, the vision slot REUSES the curated multimodal
+MoE primaries that PR #500 already reconciled into ``curated.py``:
+``Qwen3.6-35B-A3B-MTP-GGUF`` and ``Qwen3.6-27B-MTP-GGUF`` both carry the
+``vision`` tag and ship a Lemonade-stock mmproj sidecar, so a vision slot
+can load them straight from Lemonade's bundled catalogue.
+
+These tests pin three things:
+  - the ``vision`` capability/child is a recognized slot + child, and
+  - ``models_for_capability("vision")`` surfaces a multimodal model even
+    though those entries are otherwise ``bundle_only``.
+"""
+
+from __future__ import annotations
+
+from hal0.capabilities import orchestrator as orch
+from hal0.capabilities.catalog import models_for_capability
+from hal0.registry.curated import CURATED_BY_ID
+from hal0.slots.manager import SEEDED_SLOTS
+
+# The curated multimodal MoE primaries the vision slot reuses.
+_VISION_MODELS = ("Qwen3.6-35B-A3B-MTP-GGUF", "Qwen3.6-27B-MTP-GGUF")
+
+
+def test_vision_slot_is_seeded() -> None:
+    assert "vision" in SEEDED_SLOTS
+
+
+def test_vision_child_is_recognized() -> None:
+    # The (slot, child) tuple resolves to an underlying slot name.
+    assert ("vision", "vision") in orch._CHILD_TO_SLOT
+    assert orch.child_to_slot("vision", "vision") == "vision"
+    # And the capability slot is legal for HTTP validation.
+    assert "vision" in orch.LEGAL_SLOTS
+    assert orch.legal_children("vision") == ["vision"]
+
+
+def test_vision_child_maps_to_vision_capability() -> None:
+    assert orch._CHILD_TO_CAPABILITY[("vision", "vision")] == "vision"
+
+
+def test_curated_vision_models_carry_vision_tag() -> None:
+    for model_id in _VISION_MODELS:
+        entry = CURATED_BY_ID[model_id]
+        assert "vision" in entry.tags, f"{model_id} lost its vision tag"
+
+
+def test_vision_dropdown_surfaces_a_multimodal_model() -> None:
+    rows = models_for_capability("vision", registry=None)
+    ids = {row["id"] for row in rows}
+    # At least one of the curated multimodal MoE primaries is surfaced.
+    assert ids & set(_VISION_MODELS), f"no multimodal model surfaced for vision; got {sorted(ids)}"
+
+
+def test_vision_model_offers_a_real_backend() -> None:
+    rows = models_for_capability("vision", registry=None)
+    vision_rows = [r for r in rows if r["id"] in _VISION_MODELS]
+    assert vision_rows, "no curated vision model surfaced"
+    backends = {b["id"] for row in vision_rows for b in row["backends"]}
+    # llama.cpp-compatible GGUF fans out to a real host backend.
+    assert backends & {"gpu-vulkan", "gpu-rocm", "cpu"}

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -57,7 +57,9 @@ def _no_spawn_context_refresh(monkeypatch):
 
 
 def test_seeded_slots_matches_plan_section_10_2() -> None:
-    assert SEEDED_SLOTS == ("primary", "embed", "rerank", "stt", "tts", "img")
+    # ``vision`` added in #515 (first-class vision capability, reusing the
+    # curated multimodal MoE primaries + their mmproj sidecar).
+    assert SEEDED_SLOTS == ("primary", "embed", "rerank", "stt", "tts", "img", "vision")
 
 
 def test_npu_seeded_slots_matches_plan_section_10_2() -> None:


### PR DESCRIPTION
## What

Adds a first-class `vision` capability. Until now there was no `vision`/`chat.vision` slot at all — vision models lived only in the frozen seed, and both `_CHILD_TO_SLOT` and `SEEDED_SLOTS` excluded vision.

## Approach — reuse the curated multimodal MoE, no new download

The key realization (verified): after #500, the curated primary MoE models are **already vision-capable**. `Qwen3.6-35B-A3B-MTP-GGUF` and `Qwen3.6-27B-MTP-GGUF` both carry the `vision` + `tool-calling` tags and ship a Lemonade-stock `mmproj-F16.gguf`. They're Lemonade-stock keys, so a vision slot loads them straight from Lemonade's bundled catalogue, mmproj and all (the `--mmproj` wiring already exists in `providers/llama_server.py` via `model_info["mmproj"]`).

So this PR does **not** add a new large model (no Qwen3-VL-30B download). It reuses the multimodal primaries that are already in `curated.py`.

## Changes

- **`capabilities/orchestrator.py`**: add `("vision","vision") -> "vision"` to `_CHILD_TO_SLOT` and `_CHILD_TO_CAPABILITY`; add `vision` to `LEGAL_SLOTS`.
- **`slots/manager.py`**: add `vision` to `SEEDED_SLOTS`.
- **`capabilities/catalog.py`**:
  - `_model_capabilities` now derives `vision` from an entry's `tags` (the MoE entries keep `capability="chat"` — vision is a secondary capability).
  - `_flat_rows_for_capability` lets `bundle_only` entries through **specifically for the `vision` capability** (they're `bundle_only` only because they double as the chat/primary tier).
  - add a `vision` bucket to `catalogs_by_slot` so the dashboard surfaces it.

## Why additive / safe

- No new curated id → `tests/registry/test_curation_drift.py` stays green.
- Default install and bundle manifests are unchanged (the models were already curated; we just expose the vision facet of them).

## Tests

New `tests/capabilities/test_vision_curation.py` asserts the `vision` capability exists, the slot child is recognized, the curated MoE keeps its vision tag, and `models_for_capability("vision")` surfaces a multimodal model with a real backend. Existing `test_seeded_slots_matches_plan_section_10_2` updated for the new tuple.

`pytest tests/capabilities tests/slots tests/registry` — all green. `ruff check` + `ruff format` clean.

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)