### PR TITLE
fix(dash): live TopBar hostname + kill v0.2.2 demo literal (#333,#339)

### DIFF
--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -14,6 +14,7 @@ import { useMemoryEnabled } from '@/api/hooks/useMemory'
 import { useUpdateState } from '@/api/hooks/useUpdates'
 import { useSidebarAgentRollup } from '@/api/hooks/useAgents'
 import { useConfigUrls } from '@/api/hooks/useConfigUrls'
+import { useHardware } from '@/api/hooks/useHardware'
 
 const { useState: useStateC, useEffect: useEffectC } = React;
 
@@ -89,6 +90,11 @@ const Icons = {
 
 // ─── TopBar ───
 function TopBar({ route, hostUptime = "14d 02:11", onBell, onCmdK, approvals = 0 }) {
+  // Issue #333: hostname from live /api/hardware (useHardware hook) instead of
+  // the legacy HAL0_DATA seed. Fall back to a neutral "hal0" placeholder
+  // while the first response is in flight so the layout stays stable.
+  const hw = useHardware();
+  const hostName = hw.data?.name || "hal0";
   const labels = {
     dashboard: ["Overview", "Dashboard"],
     firstrun:  ["Setup",   "FirstRun"],
@@ -119,7 +125,7 @@ function TopBar({ route, hostUptime = "14d 02:11", onBell, onCmdK, approvals = 0
       </button>
       <div className="tb-host">
         <span className="host-dot" />
-        <b>{HAL0_DATA.host.name}</b>
+        <b>{hostName}</b>
         <span className="ut">· up {hostUptime}</span>
       </div>
       <button className="tb-bell" onClick={onBell} aria-label="Agent approvals">

--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -212,6 +212,10 @@ function BannerStack({ scope = "global", route, vars: extraVars }) {
 }
 
 // ─── Banner catalog — every state the brief calls out ────────────────────
+// Issue #339: catalog entries are static demo copy for the Tweaks panel.
+// Use MOCK_VERSION so a version literal never lands in the production
+// bundle (the real UpdateBanner reads useUpdateState instead).
+const MOCK_VERSION = "<demo>";
 const BANNER_CATALOG = [
   // Global
   {
@@ -228,7 +232,7 @@ const BANNER_CATALOG = [
   {
     id: "update-available", scope: "global", kind: "info",
     eyebrow: "Update available",
-    heading: "hal0 v0.2.2 is available",
+    heading: `hal0 ${MOCK_VERSION} is available`,
     body: "Includes lemonade v10.7.0 pin bump and one FLM CHANGELOG note. Update expects a brief outage during lemond + hal0-api restart.",
     actions: [
       { label: "Update now", primary: true },


### PR DESCRIPTION
Closes #333
Closes #339

Caveman worker (minimax). TopBar reads live useHardware() hostname (#333); removes stale BANNER_CATALOG v0.2.2 literal, real UpdateBanner untouched (#339).