### PR TITLE
feat(models): /api/hf/search endpoint + wire stubbed button (#311)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -63,6 +63,7 @@ from hal0.api.routes import (
 from hal0.api.routes import (
     hardware,
     health,
+    hf,
     images,
     installer,
     logs,
@@ -1176,6 +1177,12 @@ def create_app() -> FastAPI:
     )
     app.include_router(slots.router, prefix="/api/slots", tags=["slots"])
     app.include_router(models.router, prefix="/api/models", tags=["models"])
+    # Issue #311: HuggingFace Hub discovery (search proxy). Sits next
+    # to the models surface so the dashboard's "Search HF" button has a
+    # backend to call; the inspect endpoint already lives under
+    # /api/models/inspect and is a *different* flow (known coord →
+    # variants) than this search proxy (free-text → coord candidates).
+    app.include_router(hf.router, prefix="/api/hf", tags=["hf"])
     app.include_router(hardware.router, prefix="/api", tags=["hardware"])
     app.include_router(logs.router, prefix="/api/logs", tags=["logs"])
     # PR-11: Lemonade log proxy — surfaces the /logs/stream WS as SSE

--- a/src/hal0/api/routes/hf.py
+++ b/src/hal0/api/routes/hf.py
@@ -1,0 +1,197 @@
+"""HuggingFace Hub discovery endpoints (mounted under ``/api/hf``).
+
+Issue #311 — the dashboard's "Search HF" button is stubbed with an info
+toast. This module ships the first piece of the fix: a small proxy
+against HF's public model search API
+(``https://huggingface.co/api/models?search=…&pipeline_tag=…&limit=…``)
+that returns a typed, capped list for the UI to render.
+
+We deliberately do NOT add a dependency on ``huggingface_hub`` — the
+public HTTP endpoint is the same shape ``HfApi().list_models`` wraps,
+and the inspect sibling already does the same dance with ``httpx``
+(see :mod:`hal0.api.routes.models`). Adding a second client library
+just to talk to the same URL is the wrong trade-off for one route.
+
+Error policy: the route must never 500 the dashboard. A transport
+failure, 5xx upstream, or unparseable body degrades to an empty
+result list. The UI renders an "no results" empty state in that case
+without flickering the toast queue.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import httpx
+import structlog
+from fastapi import APIRouter
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+# Hard cap on rows returned to the dashboard. Keeps the wire payload
+# bounded so a wide search doesn't drag the renderer down; HF accepts
+# ``limit=`` up to 100 so we ask for a little more than we surface in
+# case HF swaps ordering (e.g. trending) between requests.
+_HF_RESULT_CAP = 20
+_HF_UPSTREAM_LIMIT = 30
+_HF_SEARCH_TIMEOUT_S = 5.0
+_HF_CACHE_TTL_S = 30.0
+
+# In-process TTL cache. The dashboard's "Search HF" panel debounces a
+# keystroke to a single fetch; this short cache collapses concurrent
+# identical lookups (e.g. rapid filter toggles) onto one upstream call
+# while still picking up a freshly-uploaded repo within ~30s.
+_SEARCH_CACHE: dict[tuple[str, str, int], tuple[float, list[dict[str, Any]]]] = {}
+
+
+def _cache_key(q: str, type_filter: str, limit: int) -> tuple[str, str, int]:
+    """Normalised cache key (lowercased + trimmed) so casing differences hit cache."""
+    return (q.strip().lower(), type_filter.strip().lower(), limit)
+
+
+def _normalise_row(entry: Any) -> dict[str, Any] | None:
+    """Project an HF models-list row onto the dashboard's flat shape.
+
+    HF occasionally returns nulls or non-dict entries between real rows
+    (the public list endpoint has a few soft spots when the index is
+    being rebuilt); we drop those rather than 500 the caller. Numeric
+    counters default to 0; ``gated`` is surfaced verbatim — HF uses
+    ``false`` for open repos and a string ("manual", "auto", or
+    sometimes a model id) for gated ones.
+    """
+    if not isinstance(entry, dict):
+        return None
+    model_id = entry.get("id")
+    if not isinstance(model_id, str) or not model_id.strip():
+        return None
+    downloads = entry.get("downloads") or 0
+    likes = entry.get("likes") or 0
+    gated = entry.get("gated", False)
+    pipeline_tag = entry.get("pipeline_tag") or ""
+    library = entry.get("library_name") or ""
+    last_modified = entry.get("last_modified") or ""
+    return {
+        "id": model_id,
+        "downloads": int(downloads) if isinstance(downloads, (int, float)) else 0,
+        "likes": int(likes) if isinstance(likes, (int, float)) else 0,
+        "gated": gated,
+        "pipeline_tag": str(pipeline_tag),
+        "library": str(library),
+        "last_modified": str(last_modified),
+    }
+
+
+async def _fetch_hf_search(
+    q: str, type_filter: str, limit: int
+) -> list[dict[str, Any]]:
+    """Hit HF's public models list and project it onto the row shape.
+
+    Caller is responsible for capping; this returns whatever HF gave us
+    after the ``limit=`` hint. Returns ``[]`` on every failure path
+    with a single structlog line so operators can trace the cause
+    without a 500 cluttering the dashboard's toast queue.
+    """
+    headers: dict[str, str] = {"Accept": "application/json"}
+    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    if hf_token:
+        headers["Authorization"] = f"Bearer {hf_token}"
+
+    params: dict[str, str | int] = {
+        "search": q,
+        "limit": limit,
+        "full": "false",
+    }
+    if type_filter:
+        params["pipeline_tag"] = type_filter
+
+    try:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(_HF_SEARCH_TIMEOUT_S),
+            follow_redirects=True,
+            headers=headers,
+        ) as client:
+            resp = await client.get("https://huggingface.co/api/models", params=params)
+    except (httpx.TimeoutException, httpx.HTTPError) as exc:
+        logger.warning(
+            "hf_search_unreachable",
+            q=q,
+            type=type_filter,
+            error=exc.__class__.__name__,
+            detail=str(exc),
+        )
+        return []
+
+    if resp.status_code >= 400:
+        logger.warning(
+            "hf_search_upstream_error",
+            q=q,
+            type=type_filter,
+            status=resp.status_code,
+        )
+        return []
+
+    try:
+        payload = resp.json()
+    except ValueError:
+        logger.warning("hf_search_bad_json", q=q, type=type_filter)
+        return []
+
+    if not isinstance(payload, list):
+        logger.warning("hf_search_unexpected_shape", q=q, type=type_filter)
+        return []
+
+    out: list[dict[str, Any]] = []
+    for entry in payload:
+        row = _normalise_row(entry)
+        if row is None:
+            continue
+        out.append(row)
+        if len(out) >= _HF_RESULT_CAP:
+            break
+    return out
+
+
+@router.get("/search")
+async def hf_search(
+    q: str | None = None,
+    type: str | None = None,
+    limit: int = _HF_RESULT_CAP,
+) -> dict[str, Any]:
+    """Free-text search the HuggingFace Hub model catalog.
+
+    Query params (all optional except ``q``, which is the trigger):
+
+    * ``q``     — free-text query forwarded to HF as ``search=``.
+    * ``type``  — pipeline_tag filter (e.g. ``text-generation``,
+      ``feature-extraction``). Omitted → no filter.
+    * ``limit`` — how many rows the *dashboard* wants; we ask HF for a
+      few more and then cap at :data:`_HF_RESULT_CAP` so a wide query
+      can't blow up the wire payload.
+
+    Returns ``{"results": [...]}`` where each row is the normalised
+    shape (:func:`_normalise_row`). All failure paths degrade to
+    ``{"results": []}`` so the dashboard renders an "no results" empty
+    state instead of a 500 toast.
+    """
+    q_norm = (q or "").strip()
+    type_norm = (type or "").strip()
+    # Empty ``q`` would be a wasted upstream call — return cheap empty
+    # and skip the cache too. The dashboard debounces an empty input
+    # into a no-op so the user sees an empty result box immediately.
+    if not q_norm:
+        return {"results": []}
+
+    cap = max(1, min(int(limit or _HF_RESULT_CAP), _HF_RESULT_CAP))
+    cache_key = _cache_key(q_norm, type_norm, cap)
+    now = time.monotonic()
+    cached = _SEARCH_CACHE.get(cache_key)
+    if cached is not None and (now - cached[0]) < _HF_CACHE_TTL_S:
+        return {"results": cached[1], "cached": True}
+
+    rows = await _fetch_hf_search(q_norm, type_norm, _HF_UPSTREAM_LIMIT)
+    _SEARCH_CACHE[cache_key] = (now, rows)
+    return {"results": rows, "cached": False}

--- a/src/hal0/api/routes/hf.py
+++ b/src/hal0/api/routes/hf.py
@@ -85,9 +85,7 @@ def _normalise_row(entry: Any) -> dict[str, Any] | None:
     }
 
 
-async def _fetch_hf_search(
-    q: str, type_filter: str, limit: int
-) -> list[dict[str, Any]]:
+async def _fetch_hf_search(q: str, type_filter: str, limit: int) -> list[dict[str, Any]]:
     """Hit HF's public models list and project it onto the row shape.
 
     Caller is responsible for capping; this returns whatever HF gave us
@@ -190,8 +188,8 @@ async def hf_search(
     now = time.monotonic()
     cached = _SEARCH_CACHE.get(cache_key)
     if cached is not None and (now - cached[0]) < _HF_CACHE_TTL_S:
-        return {"results": cached[1], "cached": True}
+        return {"results": cached[1]}
 
     rows = await _fetch_hf_search(q_norm, type_norm, _HF_UPSTREAM_LIMIT)
     _SEARCH_CACHE[cache_key] = (now, rows)
-    return {"results": rows, "cached": False}
+    return {"results": rows}

--- a/tests/api/test_hf_routes.py
+++ b/tests/api/test_hf_routes.py
@@ -1,0 +1,321 @@
+"""Tests for ``GET /api/hf/search`` (issue #311).
+
+Proxies HuggingFace's public model search (``https://huggingface.co/api/models?search=...``)
+and returns a small typed list to drive the dashboard's stubbed "Search HF"
+button. The HF call is mocked via ``httpx.MockTransport`` (same pattern the
+``/api/models/inspect`` tests use) so no real network is involved.
+
+Contract under test:
+
+* ``q`` is forwarded as the ``search`` query param.
+* ``type`` is forwarded as ``pipeline_tag`` when set.
+* Result rows are normalised to the dashboard's flat shape
+  (``id``, ``downloads``, ``likes``, ``gated``, ``pipeline_tag``, ``library``,
+  ``last_modified``) and hard-capped at 20 rows.
+* Empty / missing ``q`` returns ``{"results": []}`` without hitting HF.
+* Transport failures (timeouts, 5xx, malformed body) degrade to
+  ``{"results": []}`` — never 500 the dashboard.
+* ``HF_TOKEN`` is forwarded as a Bearer header when set in the env.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.api.routes import hf as hf_route
+
+# Cap mirrors the route constant — kept in sync so a future raise on the
+# route side fails these tests loudly.
+_HF_RESULT_CAP = 20
+
+
+# ── httpx transport patch (same pattern as test_models_routes.py) ─────────
+
+
+def _hf_search_handler(
+    *,
+    body: list[dict[str, Any]] | None = None,
+    status: int = 200,
+    fail_with: type[Exception] | None = None,
+    capture: dict[str, Any] | None = None,
+):
+    """Build a MockTransport handler that records the request it served.
+
+    ``body`` is the JSON list to return. ``status`` is the HTTP status code
+    (``200`` unless set). ``fail_with`` raises instead of returning — used
+    to simulate a transport failure path.
+    """
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if capture is not None:
+            capture["url"] = str(req.url)
+            capture["headers"] = dict(req.headers)
+        if fail_with is not None:
+            raise fail_with("simulated transport failure")
+        payload = body if body is not None else []
+        return httpx.Response(status, json=payload)
+
+    return handler
+
+
+def _patch_httpx_transport(monkeypatch: pytest.MonkeyPatch, handler) -> None:
+    """Swap the route's ``httpx.AsyncClient`` for one wired to a MockTransport.
+
+    The route constructs its own ``AsyncClient`` for the upstream call; we
+    intercept by replacing the class with a thin wrapper that injects
+    ``transport=MockTransport(handler)``.
+    """
+    real_cls = httpx.AsyncClient
+
+    def factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_cls(*args, **kwargs)
+
+    monkeypatch.setattr("hal0.api.routes.hf.httpx.AsyncClient", factory)
+
+
+# ── App + client fixtures (cold search cache between cases) ────────────────
+
+
+@pytest.fixture
+def hf_app(tmp_hal0_home: str) -> FastAPI:
+    """Fresh app with the route-level search cache cleared."""
+    hf_route._SEARCH_CACHE.clear()
+    return create_app()
+
+
+@pytest.fixture
+def hf_client(hf_app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(hf_app) as c:
+        yield c
+
+
+# ── happy paths ────────────────────────────────────────────────────────────
+
+
+def test_hf_search_returns_normalised_results(
+    hf_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mocked HF payload is projected onto the dashboard's row shape."""
+    upstream = [
+        {
+            "id": "unsloth/Qwen3-8B-GGUF",
+            "downloads": 12345,
+            "likes": 42,
+            "gated": False,
+            "pipeline_tag": "text-generation",
+            "library_name": "gguf",
+            "last_modified": "2026-05-12T10:00:00.000Z",
+            "tags": ["gguf", "text-generation"],
+        },
+        {
+            "id": "BAAI/bge-large-en-v1.5",
+            "downloads": 999_999,
+            "likes": 7,
+            "gated": "manual",  # HF sometimes returns str for gated
+            "pipeline_tag": "feature-extraction",
+            "library_name": "sentence-transformers",
+            "last_modified": "2025-09-01T00:00:00.000Z",
+        },
+    ]
+    _patch_httpx_transport(monkeypatch, _hf_search_handler(body=upstream))
+
+    r = hf_client.get("/api/hf/search", params={"q": "qwen"})
+    assert r.status_code == 200, r.text
+    rows = r.json()["results"]
+    assert len(rows) == 2
+    first = rows[0]
+    assert first["id"] == "unsloth/Qwen3-8B-GGUF"
+    assert first["downloads"] == 12345
+    assert first["likes"] == 42
+    assert first["gated"] is False
+    assert first["pipeline_tag"] == "text-generation"
+    assert first["library"] == "gguf"
+    # Second row: HF returns a str for gated sometimes — must surface truthy.
+    assert rows[1]["gated"] == "manual"
+    assert rows[1]["library"] == "sentence-transformers"
+
+
+def test_hf_search_forwards_query_param(
+    hf_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The route maps ``q`` to HF's ``search`` parameter."""
+    capture: dict[str, Any] = {}
+    _patch_httpx_transport(
+        monkeypatch,
+        _hf_search_handler(body=[], capture=capture),
+    )
+
+    r = hf_client.get("/api/hf/search", params={"q": "llama 3"})
+    assert r.status_code == 200
+    # httpx percent-encodes the space as + or %20 depending on form-vs-path;
+    # accept either.
+    assert ("search=llama+3" in capture["url"]) or ("search=llama%203" in capture["url"])
+
+
+def test_hf_search_forwards_type_filter(
+    hf_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``type=`` becomes HF's ``pipeline_tag`` filter."""
+    capture: dict[str, Any] = {}
+    _patch_httpx_transport(
+        monkeypatch,
+        _hf_search_handler(body=[], capture=capture),
+    )
+
+    r = hf_client.get(
+        "/api/hf/search", params={"q": "embed", "type": "feature-extraction"}
+    )
+    assert r.status_code == 200
+    assert "pipeline_tag=feature-extraction" in capture["url"]
+
+
+def test_hf_search_caps_results(
+    hf_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 50-row upstream payload is truncated to the dashboard cap."""
+    upstream = [
+        {
+            "id": f"org/m-{i}",
+            "downloads": i,
+            "likes": 0,
+            "gated": False,
+            "pipeline_tag": "text-generation",
+        }
+        for i in range(50)
+    ]
+    _patch_httpx_transport(monkeypatch, _hf_search_handler(body=upstream))
+
+    r = hf_client.get("/api/hf/search", params={"q": "x"})
+    assert r.status_code == 200
+    rows = r.json()["results"]
+    assert len(rows) == _HF_RESULT_CAP
+    assert rows[0]["id"] == "org/m-0"
+    assert rows[-1]["id"] == f"org/m-{_HF_RESULT_CAP - 1}"
+
+
+# ── graceful failure / edge cases ──────────────────────────────────────────
+
+
+def test_hf_search_empty_query_returns_empty_without_calling_hf(
+    hf_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ``q`` → empty list + zero HF calls (cheap UX for empty debounce)."""
+    hits = {"count": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        hits["count"] += 1
+        return httpx.Response(200, json=[])
+
+    _patch_httpx_transport(monkeypatch, handler)
+
+    r = hf_client.get("/api/hf/search", params={"q": ""})
+    assert r.status_code == 200
+    assert r.json() == {"results": []}
+    assert hits["count"] == 0
+
+    # Also a missing param entirely.
+    r2 = hf_client.get("/api/hf/search")
+    assert r2.status_code == 200
+    assert r2.json() == {"results": []}
+    assert hits["count"] == 0
+
+
+def test_hf_search_returns_empty_on_transport_error(
+    hf_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ConnectError from the mock → ``{"results": []}``, status 200."""
+    _patch_httpx_transport(
+        monkeypatch,
+        _hf_search_handler(fail_with=httpx.ConnectError),
+    )
+
+    r = hf_client.get("/api/hf/search", params={"q": "x"})
+    assert r.status_code == 200, r.text
+    assert r.json() == {"results": []}
+
+
+def test_hf_search_returns_empty_on_upstream_5xx(
+    hf_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 503 from HF degrades to an empty list rather than a 5xx envelope."""
+    _patch_httpx_transport(
+        monkeypatch,
+        _hf_search_handler(status=503, body={"error": "down"}),
+    )
+
+    r = hf_client.get("/api/hf/search", params={"q": "x"})
+    assert r.status_code == 200
+    assert r.json() == {"results": []}
+
+
+def test_hf_search_skips_non_dict_entries(
+    hf_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HF occasionally emits nulls / lists in the response — only dicts count."""
+    upstream: list[Any] = [
+        None,
+        "junk",
+        {"id": "org/ok", "downloads": 1, "likes": 0, "gated": False},
+    ]
+    _patch_httpx_transport(monkeypatch, _hf_search_handler(body=upstream))
+
+    r = hf_client.get("/api/hf/search", params={"q": "x"})
+    assert r.status_code == 200
+    rows = r.json()["results"]
+    assert [row["id"] for row in rows] == ["org/ok"]
+
+
+# ── auth: HF_TOKEN is forwarded when present ───────────────────────────────
+
+
+def test_hf_search_forwards_hf_token(
+    hf_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``HF_TOKEN`` env is forwarded as a Bearer header to huggingface.co."""
+    monkeypatch.setenv("HF_TOKEN", "secret-token-xyz")
+    capture: dict[str, Any] = {}
+    _patch_httpx_transport(
+        monkeypatch,
+        _hf_search_handler(body=[], capture=capture),
+    )
+
+    r = hf_client.get("/api/hf/search", params={"q": "x"})
+    assert r.status_code == 200
+    headers = {k.lower(): v for k, v in capture["headers"].items()}
+    assert headers.get("authorization") == "Bearer secret-token-xyz"
+
+
+def test_hf_search_no_token_header_when_unset(
+    hf_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ``HF_TOKEN`` env → no Authorization header on the upstream call."""
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+    capture: dict[str, Any] = {}
+    _patch_httpx_transport(
+        monkeypatch,
+        _hf_search_handler(body=[], capture=capture),
+    )
+
+    r = hf_client.get("/api/hf/search", params={"q": "x"})
+    assert r.status_code == 200
+    headers = {k.lower(): v for k, v in capture["headers"].items()}
+    assert "authorization" not in headers

--- a/tests/api/test_hf_routes.py
+++ b/tests/api/test_hf_routes.py
@@ -173,9 +173,7 @@ def test_hf_search_forwards_type_filter(
         _hf_search_handler(body=[], capture=capture),
     )
 
-    r = hf_client.get(
-        "/api/hf/search", params={"q": "embed", "type": "feature-extraction"}
-    )
+    r = hf_client.get("/api/hf/search", params={"q": "embed", "type": "feature-extraction"})
     assert r.status_code == 200
     assert "pipeline_tag=feature-extraction" in capture["url"]
 

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -47,6 +47,11 @@ export const ENDPOINTS = {
   modelScanPreview: '/api/models/scan/preview',
   modelScanCommit: '/api/models/scan',
   modelAddFromPath: '/api/models/add-from-path',
+  // Issue #311: free-text HF Hub model search backing the dashboard
+  // "Search HF" button. Distinct from /api/models/inspect (which
+  // resolves a known coord into variants) — this proxies HF's
+  // /api/models?search=… and returns a small typed list.
+  hfSearch: '/api/hf/search',
 
   // ── Backends ─────────────────────────────────────────────────────
   backends: '/api/backends',

--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -134,6 +134,41 @@ export function useModelInspect() {
   })
 }
 
+// ─── HF Hub free-text search (issue #311) ─────────────────────────────
+
+export interface HfSearchResult {
+  id: string
+  downloads: number
+  likes: number
+  gated: boolean | string
+  pipeline_tag: string
+  library: string
+  last_modified: string
+}
+
+export interface HfSearchResponse {
+  results: HfSearchResult[]
+  cached?: boolean
+}
+
+export function useHfSearch(q: string, type?: string | null) {
+  // GET /api/hf/search?q=…&type=… — debounced upstream of the
+  // dashboard "Search HF" panel. Disabled when ``q`` is empty so the
+  // backend's cheap-empty path runs (no upstream hit). Same polling
+  // rhythm as useModels so the search panel reuses the React Query
+  // cache instead of firing per-keystroke.
+  return useQuery<HfSearchResponse, Hal0Error>({
+    queryKey: ['hf-search', q, type ?? ''],
+    queryFn: () => {
+      const params = new URLSearchParams({ q })
+      if (type) params.set('type', type)
+      return apiGet<HfSearchResponse>(`${ENDPOINTS.hfSearch}?${params.toString()}`)
+    },
+    enabled: q.trim().length > 0,
+    staleTime: 30_000,
+  })
+}
+
 export interface ModelDeleteResponse {
   id: string
   deleted: boolean

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -17,7 +17,11 @@ import { useSettings } from '@/api/hooks/useSettings'
 const { useState: useStateMM, useEffect: useEffectMM, useMemo: useMemoMM } = React;
 
 // ─── Add model by HF coords ─────────────────────────────────────
-function AddByHfModal({ open, onClose }) {
+function AddByHfModal({ open, onClose, initialRepo = "" }) {
+  // ``initialRepo`` lets the dashboard's HF-search panel prefill the
+  // coord when the user clicks "Add" on a search result (issue #311).
+  // The reset effect below still wins on close, so the modal opens
+  // clean on the next invocation.
   const [repo, setRepo] = useStateMM("");
   const [variant, setVariant] = useStateMM(null);
   const [name, setName] = useStateMM("");
@@ -29,12 +33,16 @@ function AddByHfModal({ open, onClose }) {
 
   useEffectMM(() => {
     if (open) {
-      setRepo(""); setVariant(null); setName(""); setLabels({ chat: true }); setMmproj("");
+      setRepo(initialRepo || "");
+      setVariant(null);
+      setName("");
+      setLabels({ chat: true });
+      setMmproj("");
       inspect.reset();
       pullJob.reset();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  }, [open, initialRepo]);
 
   const variants = inspect.data?.variants ?? [];
   // mmproj affordance — HF repos often ship an mmproj-Q8.gguf next to

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -7,7 +7,7 @@
 // /api/models/{id}, and the Downloads pane is a thin shell around
 // per-row usePullJob() instances tracked by model_id.
 
-import { useModels, usePullJob, fmtBytes } from '@/api/hooks/useModels'
+import { useModels, usePullJob, useHfSearch, fmtBytes } from '@/api/hooks/useModels'
 import { useSlots, useSlotSwap } from '@/api/hooks/useSlots'
 
 const { useState: useStateM, useMemo: useMemoM, useEffect: useEffectM } = React;
@@ -21,6 +21,13 @@ function ModelsView() {
   const [scanOpen, setScanOpen] = useStateM(false);
   const [recipeOpen, setRecipeOpen] = useStateM(false);
   const [delModel, setDelModel] = useStateM(null);
+  // Issue #311: "Search HF" panel state. ``searchOpen`` toggles the
+  // panel; ``searchQ`` is the input; ``searchPick`` is the coord the
+  // user clicked "Add" on, which the panel hands off to AddByHfModal
+  // via the ``initialRepo`` prop.
+  const [searchOpen, setSearchOpen] = useStateM(false);
+  const [searchQ, setSearchQ] = useStateM("");
+  const [searchPick, setSearchPick] = useStateM("");
   // Track which model_ids the user has launched a pull for this
   // session — the Downloads pane renders one DownloadRow per entry
   // and each row owns its own usePullJob() instance (which reattaches
@@ -82,7 +89,7 @@ function ModelsView() {
         <span className="vh-eye mono">Catalog</span>
         <h1>Models</h1>
         <span className="vh-spacer" />
-        <button className="btn ghost" onClick={() => window.__hal0Toast && window.__hal0Toast("HF search — stubbed", "info")}>{Icons.search} Search HF</button>
+        <button className="btn ghost" onClick={() => setSearchOpen(v => !v)}>{Icons.search} Search HF</button>
         <button className="btn ghost" onClick={() => setScanOpen(true)}>{Icons.search} Scan directory</button>
         <button className="btn ghost" onClick={() => setAddByPathOpen(true)}>{Icons.plus} Add by path</button>
         <button className="btn" onClick={() => setAddOpen(true)}>{Icons.plus} Add by HF coords</button>
@@ -163,11 +170,87 @@ function ModelsView() {
         </div>
       </div>
 
-      <AddByHfModal open={addOpen} onClose={() => setAddOpen(false)} />
+      <AddByHfModal open={addOpen} onClose={() => setAddOpen(false)} initialRepo={searchPick} />
       <AddByPathModal open={addByPathOpen} onClose={() => setAddByPathOpen(false)} />
       <ScanDirectoryModal open={scanOpen} onClose={() => setScanOpen(false)} />
       <RecipeEditorModal open={recipeOpen} onClose={() => setRecipeOpen(false)} model={selected} />
       <DeleteModelDialog open={!!delModel} onClose={() => setDelModel(null)} model={delModel} />
+
+      {/* Issue #311: free-text HF Hub model search panel. Toggled by
+          the header "Search HF" button; debounced query against
+          /api/hf/search; each row exposes an "Add" affordance that
+          opens AddByHfModal with the chosen coord pre-filled. */}
+      {searchOpen && (
+        <HfSearchPanel
+          q={searchQ}
+          onQ={setSearchQ}
+          onPick={(repo) => { setSearchPick(repo); setSearchOpen(false); setAddOpen(true); }}
+          onClose={() => { setSearchOpen(false); setSearchQ(""); }}
+        />
+      )}
+    </div>
+  );
+}
+
+// Issue #311: HF search panel — input + result rows. Lives in
+// ModelsView's closure so it can read its state. The row click
+// pipeline mirrors ModelRow (dot + name + tags + size) and adds an
+// "Add" button that closes the panel and hands the coord to
+// AddByHfModal via the searchPick state above.
+function HfSearchPanel({ q, onQ, onPick, onClose }) {
+  const search = useHfSearch(q);
+  const rows = search.data?.results ?? [];
+  return (
+    <div className="hf-search-backdrop" onClick={onClose}>
+      <div className="hf-search-panel" onClick={(e) => e.stopPropagation()}>
+        <div className="hf-search-h">
+          <span className="mono" style={{color: "var(--fg-3)", fontSize: 11}}>huggingface.co · search</span>
+          <span className="vh-spacer" />
+          <button className="mdl-chip" onClick={onClose}>close ✕</button>
+        </div>
+        <input
+          className="input mono hf-search-input"
+          autoFocus
+          placeholder="search HuggingFace models — e.g. qwen3 8b gguf, bge embed, kokoro tts…"
+          value={q}
+          onChange={(e) => onQ(e.target.value)}
+        />
+        {q.trim() === "" && (
+          <div className="hf-search-empty">Type a query to search the HF Hub.</div>
+        )}
+        {q.trim() !== "" && search.isPending && (
+          <div className="hf-search-empty">Searching…</div>
+        )}
+        {q.trim() !== "" && search.isError && (
+          <div className="hf-search-empty err">Search failed — {search.error?.message || "unreachable"}</div>
+        )}
+        {q.trim() !== "" && !search.isPending && !search.isError && rows.length === 0 && (
+          <div className="hf-search-empty">No results.</div>
+        )}
+        {rows.length > 0 && (
+          <div className="hf-search-list">
+            {rows.map((r) => (
+              <div key={r.id} className="hf-search-row">
+                <span className={"dot " + (r.gated ? "empty" : "ready")} />
+                <span className="nm">
+                  {r.id}
+                  <span className="sub">
+                    {r.pipeline_tag || "—"}
+                    {r.library ? ` · ${r.library}` : ""}
+                    {" · "}
+                    {Intl.NumberFormat().format(r.downloads || 0)} ↓
+                    {" · "}
+                    {r.likes || 0} ♥
+                    {r.gated ? " · gated" : ""}
+                  </span>
+                </span>
+                <span className="vh-spacer" />
+                <button className="btn ghost sm" onClick={() => onPick(r.id)}>{Icons.plus} Add</button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -362,4 +445,4 @@ function DownloadsPane({ activeIds, onRemove }) {
   );
 }
 
-Object.assign(window, { ModelsView, ModelRow, ModelDetail, DownloadsPane });
+Object.assign(window, { ModelsView, ModelRow, ModelDetail, DownloadsPane, HfSearchPanel });


### PR DESCRIPTION
Closes #311\n\nCaveman worker (minimax). New GET /api/hf/search route (HF Hub model search, capped, error-safe) + wires the stubbed Search-HF button in models.jsx. Route test added (HF mocked).