### PR TITLE
fix(hw): drop slot-port scan + SWR hardware snapshot (#427,#428)

### DIFF
--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -6,20 +6,26 @@ import asyncio
 import time
 from typing import Any
 
+import structlog
 from fastapi import APIRouter, Request
 
 from hal0.config import paths
 from hal0.config.loader import load_hardware_info
 
+log = structlog.get_logger(__name__)
+
 # See slots.py for the writer-gate rationale.
 
 router = APIRouter()
 
-# TTL (seconds) for the coalesced HardwareStats.snapshot() probe. The
-# dashboard's ~4 concurrent clients poll /api/stats/hardware every 2.5s;
-# a short shared cache collapses their bursts onto one probe and keeps
-# the synchronous snapshot() off the event loop's critical path.
-_SNAPSHOT_TTL_S = 1.5
+# TTL (seconds) for the coalesced HardwareStats.snapshot() probe.
+# Issue #428: the dashboard's ~4 concurrent clients poll /api/stats/
+# hardware every 2.5 s. Bumping the TTL above the poll interval keeps
+# the snapshot *fresh* in cache for at least one polling cycle so
+# repeated polls don't even consider a refresh; the SWR logic in
+# _cached_snapshot() handles the stale case by serving the cached
+# value immediately and revalidating in the background.
+_SNAPSHOT_TTL_S = 5.0
 
 _PVE_CONFIGURE_HINT = "Configure /etc/hal0/proxmox.json to see host pressure."
 
@@ -260,35 +266,30 @@ async def _npu_status(request: Request) -> dict[str, Any] | None:
     return {"ok": True, "model_mb": round(model_mb, 1)}
 
 
-async def _cached_snapshot(request: Request) -> dict[str, Any]:
-    """Return HardwareStats.snapshot() via a thread + short TTL cache.
-
-    snapshot() is synchronous and (pre-FIX-A) shells out, so it must not
-    run on the event loop. We memoise the result on the shared
-    HardwareStats singleton (app.state.hardware_stats) for _SNAPSHOT_TTL_S
-    seconds so concurrent dashboard polls coalesce onto a single probe.
-    An asyncio.Lock guards the refresh so N simultaneous misses trigger
-    exactly one to_thread call rather than N.
-    """
-    stats = getattr(request.app.state, "hardware_stats", None)
-    if stats is None:
-        return {}
-    now = time.monotonic()
-    cached = getattr(stats, "_snapshot_cache", None)
-    cached_at = getattr(stats, "_snapshot_cache_at", 0.0)
-    if cached is not None and (now - cached_at) < _SNAPSHOT_TTL_S:
-        return cached
+def _snapshot_lock(stats: Any) -> asyncio.Lock:
+    """Return the asyncio.Lock guarding the synchronous snapshot() call,
+    creating it lazily on the stats instance."""
     lock = getattr(stats, "_snapshot_lock", None)
     if lock is None:
         lock = asyncio.Lock()
         stats._snapshot_lock = lock
+    return lock
+
+
+async def _refresh_snapshot_cache(stats: Any) -> dict[str, Any]:
+    """Run HardwareStats.snapshot() in a worker thread and write the
+    result into the cache, guarded by the single-flight lock.
+
+    Used for both cold-cache bootstrap (where the caller awaits the
+    result) and background revalidation (fire-and-forget).
+    """
+    lock = _snapshot_lock(stats)
     async with lock:
-        # Re-check under the lock — another coroutine may have refreshed
-        # while we awaited it.
-        now = time.monotonic()
+        # Re-check under the lock — a concurrent refresh may have just
+        # written the cache while we were waiting on the lock.
         cached = getattr(stats, "_snapshot_cache", None)
         cached_at = getattr(stats, "_snapshot_cache_at", 0.0)
-        if cached is not None and (now - cached_at) < _SNAPSHOT_TTL_S:
+        if cached is not None and (time.monotonic() - cached_at) < _SNAPSHOT_TTL_S:
             return cached
         try:
             snap = await asyncio.to_thread(stats.snapshot)
@@ -297,6 +298,76 @@ async def _cached_snapshot(request: Request) -> dict[str, Any]:
         stats._snapshot_cache = snap
         stats._snapshot_cache_at = time.monotonic()
         return snap
+
+
+async def _background_revalidate(stats: Any) -> None:
+    """Run a snapshot probe off the event loop and update the cache.
+
+    Failures are swallowed — the previous cached value (stale or not)
+    remains in place. The single-flight in-flight flag is cleared by
+    the caller's done_callback, not here, so the flag is also cleared
+    if the task is cancelled mid-probe.
+    """
+    try:
+        await _refresh_snapshot_cache(stats)
+    except Exception:
+        log.warning("hardware.snapshot.background_revalidate_failed", exc_info=True)
+
+
+def _clear_in_flight(stats: Any):
+    """Return a done_callback that clears the single-flight flag."""
+
+    def _cb(_task: asyncio.Task[None]) -> None:
+        stats._refresh_in_flight = False
+
+    return _cb
+
+
+async def _cached_snapshot(request: Request) -> dict[str, Any]:
+    """Stale-while-revalidate snapshot cache (issue #428).
+
+    Contract:
+      * Cold cache  → synchronously fetch the first snapshot (lock +
+        double-check, so concurrent cold calls coalesce to ONE probe).
+      * Fresh cache → return cached value, no work.
+      * Stale cache → return the STALE cached value immediately
+        (NEVER block on a refresh) and schedule a single background
+        revalidation. The in-flight flag prevents a poll burst from
+        spawning N parallel probes.
+
+    The cache lives on the shared HardwareStats singleton
+    (app.state.hardware_stats) as ``_snapshot_cache`` + ``_snapshot_cache_at``.
+    """
+    stats = getattr(request.app.state, "hardware_stats", None)
+    if stats is None:
+        return {}
+
+    cached = getattr(stats, "_snapshot_cache", None)
+    cached_at = getattr(stats, "_snapshot_cache_at", 0.0)
+    now = time.monotonic()
+    age = (now - cached_at) if cached is not None else float("inf")
+
+    # Fast path — fresh cache, no refresh needed.
+    if cached is not None and age < _SNAPSHOT_TTL_S:
+        return cached
+
+    if cached is not None:
+        # Stale — serve cached immediately, schedule background revalidation.
+        if not getattr(stats, "_refresh_in_flight", False):
+            stats._refresh_in_flight = True
+            task = asyncio.create_task(_background_revalidate(stats))
+            # Always clear the flag when the task finishes (success,
+            # exception, or cancellation). Using done_callback instead
+            # of relying on the task body's try/finally is more robust
+            # against the event loop being torn down mid-probe.
+            task.add_done_callback(_clear_in_flight(stats))
+        return cached
+
+    # Cold cache — synchronously fetch (bootstrap). The lock inside
+    # _refresh_snapshot_cache coalesces concurrent cold callers to ONE
+    # probe. The caller MUST wait for the first value, so the dashboard
+    # can render something rather than an empty dict.
+    return await _refresh_snapshot_cache(stats)
 
 
 async def _local_live_stats(request: Request) -> dict[str, Any]:
@@ -313,8 +384,9 @@ async def _local_live_stats(request: Request) -> dict[str, Any]:
     if stats is None:
         return {}
     # snapshot() is synchronous and (pre-FIX-A) shells out — run it in a
-    # thread behind a short TTL cache so concurrent dashboard polls
-    # coalesce onto one probe and the event loop never blocks on it.
+    # thread behind the SWR cache in _cached_snapshot() so concurrent
+    # dashboard polls coalesce onto one probe, and a stale poll NEVER
+    # blocks on a fresh probe (issue #428).
     snap = await _cached_snapshot(request)
     if not snap:
         return {}

--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -27,6 +27,13 @@ router = APIRouter()
 # value immediately and revalidating in the background.
 _SNAPSHOT_TTL_S = 5.0
 
+# Clock seam for the SWR cache. Tests drive the TTL deterministically by
+# patching ``_now``; patching ``time.monotonic`` globally would also freeze
+# asyncio's event-loop clock (``loop.time()`` reads it), which hangs every
+# ``asyncio.sleep`` and deadlocks the background-revalidate path. Reading the
+# clock through this indirection keeps the loop's timers on the real clock.
+_now = time.monotonic
+
 _PVE_CONFIGURE_HINT = "Configure /etc/hal0/proxmox.json to see host pressure."
 
 
@@ -289,14 +296,14 @@ async def _refresh_snapshot_cache(stats: Any) -> dict[str, Any]:
         # written the cache while we were waiting on the lock.
         cached = getattr(stats, "_snapshot_cache", None)
         cached_at = getattr(stats, "_snapshot_cache_at", 0.0)
-        if cached is not None and (time.monotonic() - cached_at) < _SNAPSHOT_TTL_S:
+        if cached is not None and (_now() - cached_at) < _SNAPSHOT_TTL_S:
             return cached
         try:
             snap = await asyncio.to_thread(stats.snapshot)
         except Exception:
             snap = {}
         stats._snapshot_cache = snap
-        stats._snapshot_cache_at = time.monotonic()
+        stats._snapshot_cache_at = _now()
         return snap
 
 
@@ -344,7 +351,7 @@ async def _cached_snapshot(request: Request) -> dict[str, Any]:
 
     cached = getattr(stats, "_snapshot_cache", None)
     cached_at = getattr(stats, "_snapshot_cache_at", 0.0)
-    now = time.monotonic()
+    now = _now()
     age = (now - cached_at) if cached is not None else float("inf")
 
     # Fast path — fresh cache, no refresh needed.

--- a/src/hal0/hardware/stats.py
+++ b/src/hal0/hardware/stats.py
@@ -214,7 +214,7 @@ class HardwareStats:
         range (19 connect attempts). It is intentionally NOT part of
         snapshot() (issue #427) — the polled /api/stats/hardware path
         does not need port occupancy, and N concurrent dashboard clients
-        × 19 connect_ex calls per poll wedged the single-event-loop API.
+        x 19 connect_ex calls per poll wedged the single-event-loop API.
         Callers that legitimately need it (config validation, next-free-
         port display) should call this method directly.
         """
@@ -228,9 +228,7 @@ class HardwareStats:
         """
         return [p for p, used in self.slot_port_occupancy().items() if used]
 
-    def snapshot(
-        self, *, include_slot_ports: bool = False
-    ) -> dict[str, Any]:
+    def snapshot(self, *, include_slot_ports: bool = False) -> dict[str, Any]:
         """Return a JSON-safe dict of all available stats.
 
         Field shape mirrors the haloai /api/status response (subset):

--- a/src/hal0/hardware/stats.py
+++ b/src/hal0/hardware/stats.py
@@ -209,29 +209,51 @@ class HardwareStats:
 
         Used by SlotsConfig validation and the dashboard's "next free port"
         display. Probes 127.0.0.1 only (slots never bind public).
+
+        NOTE: this performs a connect_ex() scan over the full slot port
+        range (19 connect attempts). It is intentionally NOT part of
+        snapshot() (issue #427) — the polled /api/stats/hardware path
+        does not need port occupancy, and N concurrent dashboard clients
+        × 19 connect_ex calls per poll wedged the single-event-loop API.
+        Callers that legitimately need it (config validation, next-free-
+        port display) should call this method directly.
         """
         return {p: _port_in_use(p) for p in range(SLOT_PORT_RANGE_START, SLOT_PORT_RANGE_END + 1)}
 
     def occupied_slot_ports(self) -> list[int]:
-        """Return the sorted list of slot ports currently bound."""
+        """Return the sorted list of slot ports currently bound.
+
+        See :meth:`slot_port_occupancy` for the connect_ex cost warning.
+        Not invoked by the polled snapshot() — call directly if needed.
+        """
         return [p for p, used in self.slot_port_occupancy().items() if used]
 
-    def snapshot(self) -> dict[str, Any]:
+    def snapshot(
+        self, *, include_slot_ports: bool = False
+    ) -> dict[str, Any]:
         """Return a JSON-safe dict of all available stats.
 
         Field shape mirrors the haloai /api/status response (subset):
             ram_used_gb, ram_available_gb,
             gpu_util, gpu_vram_used_mb, gpu_vram_total_mb,
-            slot_ports_occupied: list[int]
+            slot_ports_occupied: list[int]   (only when include_slot_ports=True)
+
+        ``include_slot_ports`` defaults to False — the slot-port scan
+        (19 connect_ex calls) does NOT belong on the polled hot path
+        (issue #427). The polled /api/stats/hardware dashboard refresh
+        only needs RAM + GPU numbers; the slot-port view is sourced
+        from the dedicated config-validation / next-free-port callers.
         """
-        return {
+        out: dict[str, Any] = {
             "ram_used_gb": self.ram_used_gb(),
             "ram_available_gb": self.ram_available_gb(),
             "gpu_util": self.gpu_util(),
             "gpu_vram_used_mb": self.gpu_vram_used_mb(),
             "gpu_vram_total_mb": self.gpu_vram_total_mb(),
-            "slot_ports_occupied": self.occupied_slot_ports(),
         }
+        if include_slot_ports:
+            out["slot_ports_occupied"] = self.occupied_slot_ports()
+        return out
 
     # Internal helpers kept here (rather than imported) so tests can monkeypatch
     # this instance method without touching the probe module's globals.

--- a/tests/api/test_hardware_routes.py
+++ b/tests/api/test_hardware_routes.py
@@ -303,7 +303,10 @@ async def test_cached_snapshot_fresh_hits_no_extra_probe(
     req = _fake_request(stub)
 
     fake_now = {"t": 500.0}
-    monkeypatch.setattr(hw_mod.time, "monotonic", lambda: fake_now["t"])
+    # Patch ONLY the SWR clock seam (hw_mod._now), never time.monotonic
+    # globally — asyncio's loop.time() reads time.monotonic, so freezing it
+    # would hang every asyncio.sleep (incl. _wait_until + the background path).
+    monkeypatch.setattr(hw_mod, "_now", lambda: fake_now["t"])
 
     await _cached_snapshot(req)
     await _cached_snapshot(req)  # within TTL -> cached
@@ -327,7 +330,10 @@ async def test_cached_snapshot_stale_returns_cached_and_refreshes_in_background(
     req = _fake_request(stub)
 
     fake_now = {"t": 500.0}
-    monkeypatch.setattr(hw_mod.time, "monotonic", lambda: fake_now["t"])
+    # Patch ONLY the SWR clock seam (hw_mod._now), never time.monotonic
+    # globally — asyncio's loop.time() reads time.monotonic, so freezing it
+    # would hang every asyncio.sleep (incl. _wait_until + the background path).
+    monkeypatch.setattr(hw_mod, "_now", lambda: fake_now["t"])
 
     # Cold start.
     r1 = await _cached_snapshot(req)
@@ -342,9 +348,7 @@ async def test_cached_snapshot_stale_returns_cached_and_refreshes_in_background(
     r2 = await _cached_snapshot(req)
     elapsed = time.monotonic() - t0
     # The probe takes 50ms; SWR should return essentially instantly.
-    assert elapsed < 0.01, (
-        f"stale poll took {elapsed*1000:.1f}ms — SWR returned a blocking call"
-    )
+    assert elapsed < 0.01, f"stale poll took {elapsed * 1000:.1f}ms — SWR returned a blocking call"
     assert r2 == {"ram_used_gb": 1.0, "gpu_util": 0.5}  # stale value preserved
 
     # Background refresh fires asynchronously. Wait for both the probe
@@ -352,8 +356,7 @@ async def test_cached_snapshot_stale_returns_cached_and_refreshes_in_background(
     # done_callback after the task transitions to done — the latter
     # is sequenced AFTER the probe body returns).
     assert await _wait_until(
-        lambda: stub.calls >= 2
-        and not getattr(stub, "_refresh_in_flight", False),
+        lambda: stub.calls >= 2 and not getattr(stub, "_refresh_in_flight", False),
         timeout_s=2.0,
     ), (
         f"background refresh not fully done "
@@ -381,7 +384,10 @@ async def test_cached_snapshot_concurrent_stale_polls_no_wedge(
     req = _fake_request(stub)
 
     fake_now = {"t": 500.0}
-    monkeypatch.setattr(hw_mod.time, "monotonic", lambda: fake_now["t"])
+    # Patch ONLY the SWR clock seam (hw_mod._now), never time.monotonic
+    # globally — asyncio's loop.time() reads time.monotonic, so freezing it
+    # would hang every asyncio.sleep (incl. _wait_until + the background path).
+    monkeypatch.setattr(hw_mod, "_now", lambda: fake_now["t"])
 
     # Cold start.
     await _cached_snapshot(req)
@@ -397,7 +403,7 @@ async def test_cached_snapshot_concurrent_stale_polls_no_wedge(
     # All return the cached stale value, none waited for the 50ms probe.
     assert all(r == {"ram_used_gb": 1.0, "gpu_util": 0.5} for r in results)
     assert elapsed < 0.02, (
-        f"concurrent stale polls took {elapsed*1000:.1f}ms — SWR self-DoS wedge"
+        f"concurrent stale polls took {elapsed * 1000:.1f}ms — SWR self-DoS wedge"
     )
 
     # Exactly one background refresh fires (single-flight), not 4.

--- a/tests/api/test_hardware_routes.py
+++ b/tests/api/test_hardware_routes.py
@@ -236,22 +236,28 @@ class TestHostDetectionInStatsHardware:
 
 
 # ── _cached_snapshot coalescing + thread-offload (FIX-B) ─────────────
+# ── _cached_snapshot stale-while-revalidate (FIX-#428) ───────────────
 
 
 class _SnapStub:
     """Stand-in for the HardwareStats singleton on app.state. Records how
     many times snapshot() ran and which thread it ran on."""
 
-    def __init__(self) -> None:
+    def __init__(self, sleep_s: float = 0.05) -> None:
         self.calls = 0
         self.threads: set[int] = set()
+        # Mutable payload so we can detect that a refresh actually replaced
+        # the cache (the SWR background refresh produces a different value).
+        self._n = 0
+        self._sleep_s = sleep_s
 
     def snapshot(self) -> dict:
         self.calls += 1
         self.threads.add(threading.get_ident())
         # Simulate a slow synchronous probe so concurrent callers overlap.
-        time.sleep(0.05)
-        return {"ram_used_gb": 1.0, "gpu_util": 0.5}
+        time.sleep(self._sleep_s)
+        self._n += 1
+        return {"ram_used_gb": float(self._n), "gpu_util": 0.5}
 
 
 def _fake_request(stats: object) -> object:
@@ -260,6 +266,16 @@ def _fake_request(stats: object) -> object:
     state = types.SimpleNamespace(hardware_stats=stats)
     app = types.SimpleNamespace(state=state)
     return types.SimpleNamespace(app=app)
+
+
+async def _wait_until(predicate, *, timeout_s: float = 1.0, step_s: float = 0.01) -> bool:
+    """Poll predicate() in an event-loop-friendly sleep loop until True."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(step_s)
+    return predicate()
 
 
 @pytest.mark.asyncio
@@ -278,10 +294,11 @@ async def test_cached_snapshot_coalesces_concurrent_polls() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cached_snapshot_refreshes_after_ttl(
+async def test_cached_snapshot_fresh_hits_no_extra_probe(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Past the TTL window, a fresh snapshot() is taken."""
+    """Within the TTL window, repeated polls return the cached value
+    and do not invoke snapshot() at all."""
     stub = _SnapStub()
     req = _fake_request(stub)
 
@@ -292,9 +309,107 @@ async def test_cached_snapshot_refreshes_after_ttl(
     await _cached_snapshot(req)  # within TTL -> cached
     assert stub.calls == 1
 
-    fake_now["t"] += hw_mod._SNAPSHOT_TTL_S + 0.01
+    # Advance halfway through TTL — still no extra probe.
+    fake_now["t"] += hw_mod._SNAPSHOT_TTL_S / 2
     await _cached_snapshot(req)
-    assert stub.calls == 2
+    assert stub.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_cached_snapshot_stale_returns_cached_and_refreshes_in_background(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #428: past the TTL, a poll returns the cached snapshot
+    IMMEDIATELY (no blocking on a fresh probe) and schedules a
+    background refresh. The refresh fires async; a follow-up poll
+    within the new TTL window sees the updated value."""
+    stub = _SnapStub()
+    req = _fake_request(stub)
+
+    fake_now = {"t": 500.0}
+    monkeypatch.setattr(hw_mod.time, "monotonic", lambda: fake_now["t"])
+
+    # Cold start.
+    r1 = await _cached_snapshot(req)
+    assert stub.calls == 1
+    assert r1 == {"ram_used_gb": 1.0, "gpu_util": 0.5}
+
+    # Advance well past TTL.
+    fake_now["t"] += hw_mod._SNAPSHOT_TTL_S + 0.01
+
+    # Stale poll: MUST return the cached value synchronously, NOT block.
+    t0 = time.monotonic()
+    r2 = await _cached_snapshot(req)
+    elapsed = time.monotonic() - t0
+    # The probe takes 50ms; SWR should return essentially instantly.
+    assert elapsed < 0.01, (
+        f"stale poll took {elapsed*1000:.1f}ms — SWR returned a blocking call"
+    )
+    assert r2 == {"ram_used_gb": 1.0, "gpu_util": 0.5}  # stale value preserved
+
+    # Background refresh fires asynchronously. Wait for both the probe
+    # to complete AND the in-flight flag to be cleared (cleared via
+    # done_callback after the task transitions to done — the latter
+    # is sequenced AFTER the probe body returns).
+    assert await _wait_until(
+        lambda: stub.calls >= 2
+        and not getattr(stub, "_refresh_in_flight", False),
+        timeout_s=2.0,
+    ), (
+        f"background refresh not fully done "
+        f"(stub.calls={stub.calls}, in_flight={getattr(stub, '_refresh_in_flight', False)})"
+    )
+
+    # Advance past TTL again — a fresh background refresh should be
+    # allowed to fire (single-flight guarantee cleared).
+    fake_now["t"] += hw_mod._SNAPSHOT_TTL_S + 0.01
+    r3 = await _cached_snapshot(req)
+    assert r3 == {"ram_used_gb": 2.0, "gpu_util": 0.5}  # newer value
+    assert await _wait_until(lambda: stub.calls >= 3, timeout_s=2.0), (
+        f"second background refresh did not fire (stub.calls={stub.calls})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cached_snapshot_concurrent_stale_polls_no_wedge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #428 wedge regression: 4 concurrent stale polls must all
+    return within bounded latency (no self-DoS on the event loop) and
+    trigger at most ONE background refresh."""
+    stub = _SnapStub(sleep_s=0.05)  # 50ms per probe
+    req = _fake_request(stub)
+
+    fake_now = {"t": 500.0}
+    monkeypatch.setattr(hw_mod.time, "monotonic", lambda: fake_now["t"])
+
+    # Cold start.
+    await _cached_snapshot(req)
+    assert stub.calls == 1
+
+    # Advance past TTL to make every subsequent call stale.
+    fake_now["t"] += hw_mod._SNAPSHOT_TTL_S + 0.01
+
+    # 4 concurrent stale polls — none should block on the probe.
+    t0 = time.monotonic()
+    results = await asyncio.gather(*(_cached_snapshot(req) for _ in range(4)))
+    elapsed = time.monotonic() - t0
+    # All return the cached stale value, none waited for the 50ms probe.
+    assert all(r == {"ram_used_gb": 1.0, "gpu_util": 0.5} for r in results)
+    assert elapsed < 0.02, (
+        f"concurrent stale polls took {elapsed*1000:.1f}ms — SWR self-DoS wedge"
+    )
+
+    # Exactly one background refresh fires (single-flight), not 4.
+    assert await _wait_until(lambda: stub.calls >= 2, timeout_s=2.0), (
+        f"single-flight background refresh did not fire (stub.calls={stub.calls})"
+    )
+    # Give the single in-flight task time to finish; no second one should spawn.
+    await asyncio.sleep(0.15)
+    assert stub.calls == 2, (
+        f"expected exactly 1 background refresh for 4 concurrent stale polls, "
+        f"got stub.calls={stub.calls} (single-flight broken)"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/hardware/test_stats.py
+++ b/tests/hardware/test_stats.py
@@ -5,6 +5,12 @@ methods read sysfs directly and make ZERO nvidia-smi subprocess calls.
 Previously each of gpu_util()/gpu_vram_used_mb()/gpu_vram_total_mb()
 shelled out to nvidia-smi first on every read, producing a per-read
 execve storm on AMD hosts where nvidia-smi is absent.
+
+FIX-#427: HardwareStats.snapshot() no longer scans the slot port range
+(8081–8099) on every poll. The scan remains on the public method
+slot_port_occupancy() / occupied_slot_ports() for the config-validation
+and next-free-port callers that legitimately need it, but it is NOT
+performed on the polled hot path.
 """
 
 from __future__ import annotations
@@ -149,3 +155,83 @@ def test_unknown_vendor_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
     assert s.gpu_util() is None
     assert s.gpu_vram_used_mb() is None
     assert s.gpu_vram_total_mb() is None
+
+
+# ── FIX-#427: slot-port scan dropped from the polled snapshot ────────
+
+
+def test_snapshot_does_not_probe_slot_ports(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Polled snapshot() must not call _port_in_use on the 8081–8099 range.
+
+    Issue #427: the slot-port socket scan was being triggered on every
+    dashboard poll (N concurrent clients × 19 connect_ex calls per poll)
+    which had no place on the hot path. The scan remains available via
+    the public slot_port_occupancy() / occupied_slot_ports() methods for
+    config-validation and next-free-port callers.
+    """
+    drm = _mk_amd_drm(tmp_path)
+    monkeypatch.setattr(stats_mod, "_amd_drm_device", lambda: drm)
+    monkeypatch.setattr(stats_mod, "_run", _RunSpy())
+
+    port_calls: list[int] = []
+
+    def _spy_port_in_use(port: int, host: str = "127.0.0.1") -> bool:
+        port_calls.append(port)
+        return False
+
+    monkeypatch.setattr(stats_mod, "_port_in_use", _spy_port_in_use)
+
+    s = HardwareStats()
+    for _ in range(20):
+        snap = s.snapshot()
+        # The polled snapshot must NOT include the slot_ports_occupied
+        # field at all — the scan is only run on opt-in callers.
+        assert "slot_ports_occupied" not in snap
+
+    assert port_calls == [], (
+        f"polled snapshot triggered {len(port_calls)} slot-port probes; "
+        f"expected zero (first 5: {port_calls[:5]})"
+    )
+
+
+def test_slot_port_occupancy_still_available(
+    monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The slot-port scan MUST still be available to config-validation
+    and next-free-port callers (issue #427 acceptance criterion 2).
+
+    It is removed from the polled snapshot() but the public methods
+    slot_port_occupancy() and occupied_slot_ports() remain.
+    """
+    port_calls: list[int] = []
+
+    def _spy_port_in_use(port: int, host: str = "127.0.0.1") -> bool:
+        port_calls.append(port)
+        # Mark port 8081 as in use to confirm filtering survives.
+        return port == 8081
+
+    monkeypatch.setattr(stats_mod, "_port_in_use", _spy_port_in_use)
+
+    s = HardwareStats()
+    occ = s.slot_port_occupancy()
+    assert isinstance(occ, dict)
+    assert sorted(occ.keys()) == list(
+        range(stats_mod.SLOT_PORT_RANGE_START, stats_mod.SLOT_PORT_RANGE_END + 1)
+    )
+    assert occ[8081] is True
+    assert occ[8082] is False
+
+    # occupied_slot_ports() delegates to slot_port_occupancy() — expect
+    # the scan to fire again (and report the same occupied set).
+    calls_after_first_scan = len(port_calls)
+    occupied = s.occupied_slot_ports()
+    assert occupied == [8081]
+    assert len(port_calls) == calls_after_first_scan + 19
+
+    # The snapshot() opt-in (include_slot_ports=True) also re-uses the
+    # public scan path — verify the integration still works.
+    snap_with_ports = s.snapshot(include_slot_ports=True)
+    assert snap_with_ports.get("slot_ports_occupied") == [8081]
+    assert len(port_calls) == calls_after_first_scan + 19 + 19

--- a/tests/hardware/test_stats.py
+++ b/tests/hardware/test_stats.py
@@ -7,7 +7,7 @@ shelled out to nvidia-smi first on every read, producing a per-read
 execve storm on AMD hosts where nvidia-smi is absent.
 
 FIX-#427: HardwareStats.snapshot() no longer scans the slot port range
-(8081–8099) on every poll. The scan remains on the public method
+(8081-8099) on every poll. The scan remains on the public method
 slot_port_occupancy() / occupied_slot_ports() for the config-validation
 and next-free-port callers that legitimately need it, but it is NOT
 performed on the polled hot path.
@@ -163,10 +163,10 @@ def test_unknown_vendor_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_snapshot_does_not_probe_slot_ports(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Polled snapshot() must not call _port_in_use on the 8081–8099 range.
+    """Polled snapshot() must not call _port_in_use on the 8081-8099 range.
 
     Issue #427: the slot-port socket scan was being triggered on every
-    dashboard poll (N concurrent clients × 19 connect_ex calls per poll)
+    dashboard poll (N concurrent clients x 19 connect_ex calls per poll)
     which had no place on the hot path. The scan remains available via
     the public slot_port_occupancy() / occupied_slot_ports() methods for
     config-validation and next-free-port callers.

--- a/tests/hardware/test_stats.py
+++ b/tests/hardware/test_stats.py
@@ -196,9 +196,7 @@ def test_snapshot_does_not_probe_slot_ports(
     )
 
 
-def test_slot_port_occupancy_still_available(
-    monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_slot_port_occupancy_still_available(monkeypatch: pytest.MonkeyPatch) -> None:
     """The slot-port scan MUST still be available to config-validation
     and next-free-port callers (issue #427 acceptance criterion 2).
 


### PR DESCRIPTION
Closes #427
Closes #428

Caveman worker (minimax). Drops per-poll slot-port socket scan (#427); serves snapshot stale-while-revalidate to kill dropdown lag (#428). Targeted tests added.