### PR TITLE
fix(settings): trust-repair sweep — kill faked/no-op controls (#543)

### DIFF
--- a/ui/src/dash/agents/agent-view.jsx
+++ b/ui/src/dash/agents/agent-view.jsx
@@ -57,7 +57,6 @@ function AgentView() {
   const initial = _parseAgentSubroute();
   const [tab, setTab] = useStateAV(initial.tab);
   const [subsection, setSubsection] = useStateAV(initial.subsection);
-  const [resetOpen, setResetOpen] = useStateAV(false);
   const noAgent = window.__hal0Banners && window.__hal0Banners.get && window.__hal0Banners.get()["no-agent"];
 
   useEffectAV(() => {
@@ -109,18 +108,7 @@ function AgentView() {
         ))}
       </div>
 
-      {tab === "memory"   && window.MemoryTab     && <window.MemoryTab subsection={subsection} onResetNs={() => setResetOpen(true)} />}
-
-      <ConfirmDialog
-        open={resetOpen}
-        onCancel={() => setResetOpen(false)}
-        onConfirm={() => { setResetOpen(false); window.__hal0Toast && window.__hal0Toast("Cognee namespace 'shared' reset — 2,847 records deleted", "warn"); }}
-        title="Reset memory namespace 'shared'?"
-        message={<span>This permanently deletes <span className="mono" style={{color: "var(--fg)"}}>2,847</span> Cognee records across SQLite + LanceDB + Kuzu. Cannot be undone.</span>}
-        confirmLabel="Reset namespace"
-        destructive
-        typeToConfirm="shared"
-      />
+      {tab === "memory"   && window.MemoryTab     && <window.MemoryTab subsection={subsection} />}
     </div>
   );
 }

--- a/ui/src/dash/agents/memory-tab.jsx
+++ b/ui/src/dash/agents/memory-tab.jsx
@@ -17,7 +17,7 @@
 
 const { useState: useStateMT, useEffect: useEffectMT } = React;
 
-function MemoryTab({ subsection, onResetNs } = {}) {
+function MemoryTab({ subsection } = {}) {
   useEffectMT(() => {
     if (subsection === "peer") {
       const el = document.getElementById("peer-memory");
@@ -101,8 +101,6 @@ function MemoryTab({ subsection, onResetNs } = {}) {
                 <span style={{marginLeft: "auto", color: "var(--fg-3)"}} className="num">{n.recs}</span>
               </div>
             ))}
-            <button className="btn ghost sm" style={{marginTop: 10, width: "100%", justifyContent: "center"}} onClick={() => window.__hal0Toast && window.__hal0Toast("New namespace modal — stubbed", "info")}>{Icons.plus} New namespace</button>
-            <button className="btn danger sm" style={{marginTop: 6, width: "100%", justifyContent: "center"}} onClick={onResetNs}>{Icons.warn} Reset 'shared'</button>
           </div>
         </div>
       </div>

--- a/ui/src/dash/settings.jsx
+++ b/ui/src/dash/settings.jsx
@@ -438,7 +438,7 @@ function UpdatesSection() {
                 });
               }}
             >{applyM.isPending ? "Starting…" : (jobBusy ? "Installing…" : "Install update")}</button>
-            <button className="btn ghost sm" onClick={() => window.__hal0Toast && window.__hal0Toast("Opening hal0.dev/changelog", "info")}>Changelog →</button>
+            <a className="btn ghost sm" href="https://hal0.dev/changelog" target="_blank" rel="noreferrer">Changelog →</a>
           </>}
         />
         <SRow
@@ -462,7 +462,6 @@ function UpdatesSection() {
           sub="Manual deb · vendor-supplied"
           mono
           v={u.flm?.current || '—'}
-          actions={<button className="btn ghost sm" onClick={() => window.__hal0Toast && window.__hal0Toast("Opening FLM install guide", "info")}>Re-install</button>}
         />
         <SRow
           k="Auto-check"
@@ -829,9 +828,6 @@ function MemorySection() {
         <SRow k="Disk usage" mono v="184 MB" />
         <SRow k="Last write" mono v="3 min ago · pi-coder" />
       </div>
-      <div style={{marginTop: 14}}>
-        <button className="btn danger">{Icons.warn} Reset namespace</button>
-      </div>
     </div>
   );
 }
@@ -857,15 +853,20 @@ function AppearanceSection() {
 }
 
 function AboutSection() {
+  // #543: read hal0 version live from /api/updates/state instead of a
+  // hardcoded literal that drifts from the running build. Empty until the
+  // first response lands so the layout doesn't shift around a stale value.
+  const stateQuery = useUpdateState();
+  const liveVersion = stateQuery.data?.hal0?.current || "";
   return (
     <div className="s-section">
       <h2>About</h2>
       <div className="s-panel">
-        <SRow k="hal0" mono v="v0.2.1 — Lemonade-embedded slots" />
+        <SRow k="hal0" mono v={liveVersion ? `${liveVersion} — Lemonade-embedded slots` : "—"} />
         <SRow k="License" v="Apache-2.0" />
-        <SRow k="Repository" mono v="github.com/Hal0ai/hal0" actions={<button className="btn ghost sm">{Icons.ext} Open</button>} />
-        <SRow k="Docs" v="hal0.dev/docs/v0.2-upgrade" actions={<button className="btn ghost sm">{Icons.ext} Open</button>} />
-        <SRow k="Discord" v="discord.gg/hal0" actions={<button className="btn ghost sm">{Icons.ext} Join</button>} />
+        <SRow k="Repository" mono v="github.com/Hal0ai/hal0" actions={<a className="btn ghost sm" href="https://github.com/Hal0ai/hal0" target="_blank" rel="noreferrer">{Icons.ext} Open</a>} />
+        <SRow k="Docs" v="hal0.dev/docs/v0.2-upgrade" actions={<a className="btn ghost sm" href="https://hal0.dev/docs/v0.2-upgrade" target="_blank" rel="noreferrer">{Icons.ext} Open</a>} />
+        <SRow k="Discord" v="discord.gg/hal0" actions={<a className="btn ghost sm" href="https://discord.gg/hal0" target="_blank" rel="noreferrer">{Icons.ext} Join</a>} />
       </div>
       <div style={{marginTop: 14, fontFamily: "var(--jbm)", fontSize: 11, color: "var(--fg-4)"}}>
         Built on AMD Lemonade, FLM (XDNA2), llama.cpp, whisper.cpp, sd.cpp, Kokoro, Cognee.


### PR DESCRIPTION
Closes #543

Caveman worker (minimax). Removes fake-action settings controls: fake Changelog/Re-install/Reset-namespace toasts gone or wired to real links; repo/docs/discord become real anchors; About version reads live useUpdateState; memory-tab fake destructive reset removed. γ assertions updated where they referenced removed controls.