### PR TITLE
refactor(settings): prune dead mock sections + rename survivors (#544)

### DIFF
--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -142,7 +142,7 @@ export const ENDPOINTS = {
   settings: '/api/settings',
   settingsReload: '/api/settings/reload',
   settingsSchema: '/api/settings/schema',
-  // Single-source-of-truth model storage (Settings → Models + Firstrun → Storage).
+  // Single-source-of-truth model storage (Settings → Storage).
   settingsModelsStore: '/api/settings/models/store',
   settingsModelsStoreMigrate: '/api/settings/models/store/migrate',
   // Full-shape Proxmox status — includes tenants[] stripped by the

--- a/ui/src/api/hooks/useCapabilities.ts
+++ b/ui/src/api/hooks/useCapabilities.ts
@@ -1,7 +1,7 @@
 // hal0 v3 dashboard — capabilities hooks (Phase B1).
 //
 // /api/capabilities is the capabilities.toml rollup that backs the
-// FirstRun bundle picker + Settings → Lemonade admin. Per the v0.3
+// FirstRun bundle picker + Settings → Runtime. Per the v0.3
 // capability-slots system memory: capability cards group provider +
 // model + slot routing per cap key (chat, embed, voice, img, npu).
 

--- a/ui/src/api/hooks/useLemonadeConfig.ts
+++ b/ui/src/api/hooks/useLemonadeConfig.ts
@@ -1,6 +1,6 @@
 // hal0 v3 dashboard — Lemonade admin config read / write hooks.
 //
-// Backs Settings → Lemonade admin (issue #461 / parent #433). The
+// Backs Settings → Runtime (issue #461 / parent #433). The
 // backend in `hal0.api.routes.lemonade_admin` already serves:
 //
 //   GET  /api/lemonade/config  — the verbatim `lemond /internal/config`

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -571,7 +571,7 @@ function ApprovalModal({ open, onClose, items }) {
           ))}
         </div>
         <div className="modal-foot mono">
-          <span>Configure auto-approve rules in Settings → Agent policy.</span>
+          <span>Configure auto-approve rules in the agent view.</span>
           <button className="btn ghost sm" onClick={onClose}>Close</button>
         </div>
       </div>

--- a/ui/src/dash/command-palette.jsx
+++ b/ui/src/dash/command-palette.jsx
@@ -274,14 +274,16 @@ function buildCommandItems(slots, models, activePull, owuiUrl = "") {
   });
 
   // Settings sections — anchor jumps
+  // #544: OmniRouter/Agent-policy/Memory (Cognee) sections pruned;
+  // entries for them are gone. Surviving sections renamed for accuracy
+  // (Storage, Runtime, General).
   [
     { id: "set-auth",      label: "Auth · token",        sub: "rotate Bearer token, allowed origins" },
     { id: "set-secrets",   label: "Secrets",              sub: "HF_TOKEN and provider keys" },
+    { id: "set-storage",   label: "Storage",              sub: "[models].store · auto_scan · file extensions" },
     { id: "set-updates",   label: "Updates",              sub: "hal0 / lemonade / flm versions" },
-    { id: "set-lemonade",  label: "Lemonade admin",       sub: "max_loaded_models, ctx_size, args" },
-    { id: "set-omni",      label: "OmniRouter tools",     sub: "8 tools · per-tool target" },
-    { id: "set-agent",     label: "Agent policy",         sub: "per-capability approval" },
-    { id: "set-memory",    label: "Memory (Cognee)",      sub: "namespace, store, records" },
+    { id: "set-runtime",   label: "Runtime",              sub: "max_loaded_models, ctx_size, args" },
+    { id: "set-general",   label: "General",              sub: "theme, density, accent" },
   ].forEach(s => items.push({ ...s, section: "Settings", icon: Icons.settings, route: "settings" }));
 
   // Global actions — every one is wired to a real effect.

--- a/ui/src/dash/data.jsx
+++ b/ui/src/dash/data.jsx
@@ -338,16 +338,11 @@ const HAL0_DATA = {
   // entries yet. No more "loaded model 'qwen3.6-27b-mtp'" mock prose
   // leaking into prod screenshots before SSE primes.
 
-  omnirouter: [
-    { name: "generate_image",   active: true,  target: "img (sd-turbo)" },
-    { name: "edit_image",       active: false, target: "needs model with 'edit' label" },
-    { name: "text_to_speech",   active: true,  target: "tts (kokoro-v1)" },
-    { name: "transcribe_audio", active: true,  target: "stt-npu (whisper-v3-turbo)" },
-    { name: "analyze_image",    active: false, target: "needs LLM with 'vision' label" },
-    { name: "embed_text",       active: true,  target: "embed (nomic-v1.5)" },
-    { name: "rerank_documents", active: true,  target: "rerank (bge-reranker-v2)" },
-    { name: "route_to_chat",    active: true,  target: "agent, primary" },
-  ],
+  // ── v0.4 #544: omnirouter routing table mock removed. The settings
+  // rail no longer renders an OmniRouter section — that surface lives
+  // on the MCP view (hal0-mcp#routing) and the live agent view. The
+  // live `/api/omni/route` snapshot drives the MCP view's per-tool
+  // target list when the backend is available.
 
   // v0.3 PR-8: HAL0_DATA.approvals removed. The dashboard reads
   // approvals from the live /api/agent/approvals queue (via

--- a/ui/src/dash/extra-modals.jsx
+++ b/ui/src/dash/extra-modals.jsx
@@ -228,7 +228,7 @@ function OnboardingTour({ open, onClose, steps }) {
 const TOUR_STEPS = [
   {
     title: "Persona dropdown",
-    body: <span>Open the dropdown to swap which slot serves the next message. Changes are session-only by default; opt-in to persist in <span className="mono">Settings → OmniRouter</span>.</span>,
+    body: <span>Open the dropdown to swap which slot serves the next message. Changes are session-only by default.</span>,
     selector: ".persona",
   },
   {

--- a/ui/src/dash/extras.jsx
+++ b/ui/src/dash/extras.jsx
@@ -4,7 +4,7 @@
 // AgentView monolith out of this file into ui/src/dash/agents/* — see
 // agent-view.jsx, hermes-chat-tab.jsx, personas-tab.jsx, skills-tab.jsx,
 // memory-tab.jsx, plugins-tab.jsx. v0.4: BackendsView removed (the page
-// duplicated Settings → Lemonade-admin + config.json).
+// duplicated Settings → Runtime + config.json).
 
 import { useLogsHistorical, useLogsStream } from '@/api/hooks/useLogs'
 

--- a/ui/src/dash/firstrun.jsx
+++ b/ui/src/dash/firstrun.jsx
@@ -22,7 +22,7 @@ function _frFmtBytes(n) {
 // ─── Storage step (state 1.5 — between picker and confirm) ───
 //
 // Lets the operator decide WHERE models live before any pulls start.
-// Mirrors the Settings → Models surface (same hooks, same dry-run
+// Mirrors the Settings → Storage surface (same hooks, same dry-run
 // migration plumbing) so the FirstRun choice and the Settings page
 // stay in lockstep.
 function FirstRunStorage({ onContinue, onBack }) {

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -819,7 +819,7 @@ function ScanDirectoryModal({ open, onClose }) {
     >
       {scanRootMissing && (
         <div style={{padding: "10px 12px", marginBottom: 12, background: "var(--warn-soft)", border: "1px solid var(--warn-line)", borderRadius: "var(--rad-sm)", fontFamily: "var(--jbm)", fontSize: 12, color: "var(--warn)"}}>
-          No scan dir set. Type an absolute path below, or set <span className="mono">[models].roots</span> in <span className="mono">Settings → Models</span> to default it.
+          No scan dir set. Type an absolute path below, or set <span className="mono">[models].roots</span> in <span className="mono">Settings → Storage</span> to default it.
         </div>
       )}
 

--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -355,7 +355,7 @@ const BANNER_CATALOG = [
     id: "fr-ram-low", scope: "firstrun", kind: "warn",
     eyebrow: "Hardware · low RAM",
     heading: "Detected RAM is below the Lite minimum (16 GB)",
-    body: "hal0 needs at least 16 GB of unified RAM to load any bundled chat model. You can still install hal0 — Settings → Lemonade admin can point at an external model store.",
+    body: "hal0 needs at least 16 GB of unified RAM to load any bundled chat model. You can still install hal0 — Settings → Runtime can point at an external model store.",
   },
 
   // Agent

--- a/ui/src/dash/settings.jsx
+++ b/ui/src/dash/settings.jsx
@@ -1,9 +1,14 @@
-// hal0 dashboard — Settings view (secrets, updates, lemond admin, omnirouter, memory, agent policy)
+// hal0 dashboard — Settings view (secrets, storage, updates, runtime, general, about)
 //
-// Phase B1: Secrets, Updates, and the Lemonade admin version readouts
-// pull from live hooks; AgentPolicy + Memory (Cognee) stay scripted
-// (their backends live behind the Agent surface, deferred to B2).
-// Capabilities hook feeds the Lemonade admin section's per-cap fields.
+// Phase B2: every section reads from live hooks. Storage drives
+// [models].store + propagates to Lemonade's extra_models_dir; Runtime
+// edits /internal/config with immediate/deferred effect hints; General
+// is the cosmetic placeholders block (theme locked to dark, density
+// picker, accent chip).
+//
+// OmniRouter routing table, Agent-policy, and Memory (Cognee) sections
+// were removed in #544 — those surfaces live on the MCP view and the
+// agent view, respectively. The settings rail is for knobs only.
 
 import { useSecrets, useSecretSet, useSecretDelete } from '@/api/hooks/useSecrets'
 import { useUpdateState, useUpdateCheck, useUpdateApply, useUpdateJob } from '@/api/hooks/useUpdates'
@@ -24,13 +29,10 @@ function SettingsView() {
   const [section, setSection] = useStateSet("secrets");
   const sections = [
     { id: "secrets",   label: "Secrets" },
-    { id: "models",    label: "Models" },
+    { id: "storage",   label: "Storage" },
     { id: "updates",   label: "Updates" },
-    { id: "lemonade",  label: "Lemonade admin" },
-    { id: "omni",      label: "OmniRouter" },
-    { id: "agent",     label: "Agent policy" },
-    { id: "memory",    label: "Memory (Cognee)" },
-    { id: "appearance",label: "Appearance" },
+    { id: "runtime",   label: "Runtime" },
+    { id: "general",   label: "General" },
     { id: "about",     label: "About" },
   ];
 
@@ -58,13 +60,10 @@ function SettingsView() {
 
         <div className="settings-content">
           {section === "secrets" && <SecretsSection />}
-          {section === "models" && <ModelsSection />}
+          {section === "storage" && <StorageSection />}
           {section === "updates" && <UpdatesSection />}
-          {section === "lemonade" && <LemonadeSection />}
-          {section === "omni" && <OmniRouterSection />}
-          {section === "agent" && <AgentPolicySection />}
-          {section === "memory" && <MemorySection />}
-          {section === "appearance" && <AppearanceSection />}
+          {section === "runtime" && <RuntimeSection />}
+          {section === "general" && <GeneralSection />}
           {section === "about" && <AboutSection />}
         </div>
       </div>
@@ -102,7 +101,7 @@ function _fmtBytes(n) {
   return (n / 1024 ** 3).toFixed(2) + " GB";
 }
 
-function ModelsSection() {
+function StorageSection() {
   const settings = useSettings();
   const update = useSettingsUpdate();
   const storeQuery = useModelStore();
@@ -182,7 +181,7 @@ function ModelsSection() {
 
   return (
     <div className="s-section">
-      <h2>Models</h2>
+      <h2>Storage</h2>
       <p className="desc">
         Where hal0 reads and writes model files. One path drives both <span className="mono" style={{color: "var(--fg)"}}>hal0-api</span> and Lemonade — pick once, applies everywhere.
       </p>
@@ -479,14 +478,14 @@ function UpdatesSection() {
   );
 }
 
-// Lemonade admin keys this form edits, in render order. Each row binds
+// Runtime keys this form edits, in render order. Each row binds
 // to one key in the live /internal/config snapshot; the effect label
 // (Immediate / Deferred) is derived from the backend's `_hal0.effects`
 // partition rather than hard-coded here, so the two never drift.
 //
 // `extra_models_dir` is intentionally NOT editable from this panel —
 // the backend locks it to the [models].store single source of truth
-// (see ModelsSection + lemonade_admin._validate_extra_models_dir). We
+// (see StorageSection + lemonade_admin._validate_extra_models_dir). We
 // surface it read-only so the operator can see the locked value.
 const LEMONADE_FIELDS = [
   { key: "max_loaded_models", sub: "Per-type LRU budget", kind: "number", width: 80 },
@@ -523,7 +522,7 @@ const LEMONADE_FIELDS = [
   { key: "height", sub: "sd.cpp output height (px)", kind: "number", width: 80 },
 ];
 
-function LemonadeSection() {
+function RuntimeSection() {
   // Phase B2 (issue #461): the admin config form now reads + writes the
   // live /api/lemonade/config surface. The runtime readouts at the top
   // stay on the polling rollup; capabilities preview stays as-is.
@@ -624,7 +623,7 @@ function LemonadeSection() {
 
   return (
     <div className="s-section">
-      <h2>Lemonade admin</h2>
+      <h2>Runtime</h2>
       <p className="desc">Direct edit of <span className="mono" style={{color: "var(--fg)"}}>/internal/config</span>. <span style={{color: "var(--ok)"}}>Immediate</span> keys apply on save; <span style={{color: "var(--warn)"}}>deferred</span> keys take hold on the next <span className="mono">/v1/load</span>.</p>
       <div className="s-panel" style={{marginBottom: 12}}>
         <SRow k="runtime" mono v={<>{lemond.version} · {lemond.status} · <b>{lemond.loaded}</b>/{lemond.budget} loaded</>} />
@@ -694,7 +693,7 @@ function LemonadeSection() {
             })}
             <SRow
               k="extra_models_dir"
-              sub="Locked to the model store — change via Settings → Models"
+              sub="Locked to the model store — change via Settings → Storage"
               mono
               v={<span style={{color: "var(--fg-3)"}}>{lockedDir || "—"}</span>}
             />
@@ -740,102 +739,10 @@ function LemonadeSection() {
   );
 }
 
-function OmniRouterSection() {
+function GeneralSection() {
   return (
     <div className="s-section">
-      <h2>OmniRouter</h2>
-      <p className="desc">Client-side tool-calling loop owned by hal0. Eight tools — five upstream, three hal0-custom. Active set filters per-request based on enabled slots.</p>
-      <div className="s-panel">
-        <div style={{padding: "10px 18px", borderBottom: "1px solid var(--line-soft)", background: "var(--bg)", fontFamily: "var(--jbm)", fontSize: 10, color: "var(--fg-4)", textTransform: "uppercase", letterSpacing: "0.08em", display: "grid", gridTemplateColumns: "200px 100px 1fr auto", gap: 16}}>
-          <span>tool</span>
-          <span>status</span>
-          <span>target</span>
-          <span>actions</span>
-        </div>
-        {HAL0_DATA.omnirouter.map(t => (
-          <div key={t.name} className="s-tool-row">
-            <span className="nm">{t.name}</span>
-            <span className="st">{t.active ? <span className="chip ok">active</span> : <span className="chip">inactive</span>}</span>
-            <span className="tg">
-              {t.active ? <>target: <b>{t.target}</b></> : t.target}
-            </span>
-            <button className="btn ghost sm">{Icons.edit}</button>
-          </div>
-        ))}
-      </div>
-      <div style={{marginTop: 14, display: "flex", justifyContent: "space-between", alignItems: "center"}}>
-        <label className="mono" style={{display: "inline-flex", alignItems: "center", gap: 8, color: "var(--fg-2)", fontSize: 12, cursor: "pointer"}}>
-          <input type="checkbox" defaultChecked style={{accentColor: "var(--accent)"}} />
-          <span>Persist persona swaps as default</span>
-        </label>
-        <span className="mono" style={{fontSize: 11, color: "var(--fg-4)"}}>session-only by default</span>
-      </div>
-    </div>
-  );
-}
-
-function AgentPolicySection() {
-  return (
-    <div className="s-section">
-      <h2>Agent policy</h2>
-      <p className="desc">Per-capability approval policy for bundled agents. <span className="mono">always</span> requires approval each call · <span className="mono">remember</span> auto-approves after first OK · <span className="mono">deny</span> blocks.</p>
-      <div className="s-panel">
-        {[
-          { cap: "registry-write", desc: "model_pull, model_delete", policy: "always" },
-          { cap: "fs-read",        desc: "read_file, list_dir",       policy: "remember" },
-          { cap: "fs-write",       desc: "write_file, edit_file",     policy: "always" },
-          { cap: "shell-exec",     desc: "run shell commands",         policy: "always" },
-          { cap: "net-fetch",      desc: "http_get, fetch_url",        policy: "remember" },
-          { cap: "slot-control",   desc: "restart_slot, unload_slot",  policy: "always" },
-        ].map(p => (
-          <SRow
-            key={p.cap}
-            k={<span style={{fontFamily: "var(--jbm)"}}>{p.cap}</span>}
-            sub={p.desc}
-            v={
-              <div className="mono" style={{display: "inline-flex", border: "1px solid var(--line)", borderRadius: 4, overflow: "hidden"}}>
-                {["always", "remember", "deny"].map(o => (
-                  <span
-                    key={o}
-                    style={{
-                      padding: "4px 10px",
-                      fontSize: 11,
-                      cursor: "pointer",
-                      background: p.policy === o ? "var(--accent-soft)" : "transparent",
-                      color: p.policy === o ? "var(--accent)" : "var(--fg-3)",
-                      borderRight: o !== "deny" ? "1px solid var(--line)" : "none",
-                    }}
-                  >{o}</span>
-                ))}
-              </div>
-            }
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function MemorySection() {
-  return (
-    <div className="s-section">
-      <h2>Memory (Cognee)</h2>
-      <p className="desc">Cognee namespace + store inspection. The dashboard exposes only what operators need; agents own the rest of the surface via MCP in Phase 8.</p>
-      <div className="s-panel">
-        <SRow k="Namespace" mono v="shared (default)" actions={<button className="btn ghost sm">{Icons.edit} Change</button>} />
-        <SRow k="Store" mono v="SQLite + LanceDB + Kuzu" />
-        <SRow k="Records" mono v={<span className="num">2,847</span>} />
-        <SRow k="Disk usage" mono v="184 MB" />
-        <SRow k="Last write" mono v="3 min ago · pi-coder" />
-      </div>
-    </div>
-  );
-}
-
-function AppearanceSection() {
-  return (
-    <div className="s-section">
-      <h2>Appearance</h2>
+      <h2>General</h2>
       <p className="desc">Dark only for v0.2.1. Light mode lands when the website adds one.</p>
       <div className="s-panel">
         <SRow k="Theme" v={<span className="chip amber">dark</span>} />

--- a/ui/src/stores/useBannerStore.ts
+++ b/ui/src/stores/useBannerStore.ts
@@ -205,7 +205,7 @@ export const BANNER_CATALOG: ReadonlyArray<BannerEntry> = Object.freeze([
     kind: 'warn',
     eyebrow: 'Hardware · low RAM',
     heading: 'Detected RAM is below the Lite minimum (16 GB)',
-    body: 'hal0 needs at least 16 GB of unified RAM to load any bundled chat model. You can still install hal0 — Settings → Lemonade admin can point at an external model store.',
+    body: 'hal0 needs at least 16 GB of unified RAM to load any bundled chat model. You can still install hal0 — Settings → Runtime can point at an external model store.',
   },
 
   // ── Agent ───────────────────────────────────────────────────────

--- a/ui/tests/e2e/specs/settings-v3.spec.ts
+++ b/ui/tests/e2e/specs/settings-v3.spec.ts
@@ -1,20 +1,22 @@
 /**
- * settings-v3 — `#settings` route renders the rail nav with all 9
- * sections (secrets, updates, lemonade, omni, agent, memory, models,
- * appearance, about) and swaps the right pane on click.
+ * settings-v3 — `#settings` route renders the rail nav with all 6
+ * sections (secrets, storage, updates, runtime, general, about) and
+ * swaps the right pane on click.
  *
  * Auth section removed per ADR-0012 (PRs #254-#267); default landing
- * is now Secrets. Models section added in PR #313 (scan + add-by-path).
+ * is now Secrets. #544 pruned the fully-mock OmniRouter/Agent-policy/
+ * Memory (Cognee) sections (those surfaces live on MCP + agent views);
+ * surviving sections were renamed for accuracy — Models→Storage,
+ * Lemonade admin→Runtime, Appearance→General.
  */
 import { test, expect } from '../fixtures/apiMock'
 
 const SECTIONS = [
-  'Secrets', 'Updates', 'Lemonade admin', 'OmniRouter',
-  'Agent policy', 'Memory (Cognee)', 'Models', 'Appearance', 'About',
+  'Secrets', 'Storage', 'Updates', 'Runtime', 'General', 'About',
 ]
 
 test.describe('Settings v3 (/settings)', () => {
-  test('renders rail nav with all 9 sections', async ({ page }) => {
+  test('renders rail nav with all 6 sections', async ({ page }) => {
     await page.goto('/#settings')
     await expect(page.locator('.view .vh h1')).toHaveText('Settings')
     const nav = page.locator('.settings-nav .nav-item')
@@ -29,9 +31,9 @@ test.describe('Settings v3 (/settings)', () => {
     await expect(page.locator('.settings-content h2').first()).toHaveText('Secrets')
   })
 
-  test('clicking Lemonade admin swaps the section', async ({ page }) => {
+  test('clicking Runtime swaps the section', async ({ page }) => {
     await page.goto('/#settings')
-    await page.locator('.settings-nav .nav-item', { hasText: 'Lemonade admin' }).click()
-    await expect(page.locator('.settings-content h2').first()).toHaveText('Lemonade admin')
+    await page.locator('.settings-nav .nav-item', { hasText: 'Runtime' }).click()
+    await expect(page.locator('.settings-content h2').first()).toHaveText('Runtime')
   })
 })


### PR DESCRIPTION
Closes #544
Closes #337

Caveman worker (minimax). Removes 3 fully-mock settings sections (OmniRouter/Agent-policy/Cognee) + their HAL0_DATA mocks; renames Models→Storage, Lemonade admin→Runtime, Appearance→General. γ assertions updated for renamed/removed sections.