### PR TITLE
feat(npu): interactive NPU/FLM stack control section (Variant B) + Spec 1/2

### DIFF
--- a/docs/superpowers/specs/2026-06-05-npu-flm-stack-section-design.md
+++ b/docs/superpowers/specs/2026-06-05-npu-flm-stack-section-design.md
@@ -1,0 +1,185 @@
+# NPU / FLM stack section (Spec 2)
+
+**Date:** 2026-06-05
+**Status:** Approved direction (Variant B) — implementation tasked
+**Area:** dashboard SPA (`ui/src/dash/slots.jsx`) + slots/lemonade/capabilities API
+**Sibling:** Spec 1 (`2026-06-05-slot-edit-panel-controls-design.md`) — the per-slot
+controls + Capabilities 4-up grid. This spec adds the **NPU section** that sits
+above/alongside that grid.
+
+## Problem
+
+The NPU runs **one FLM process** that packs **chat + ASR + embed coresident** (the
+"FLM trio"), loaded when the NPU chat slot starts with `flm.args = "--asr 1 --embed 1"`.
+The dashboard's current `NpuBlock` (`slots.jsx:426`) only **displays** the trio — you
+can't pick the FLM chat model, toggle ASR/embed, or load/unload the stack from the UI.
+Users also can't reason about how the NPU relates to the same capabilities (embed, STT)
+running on iGPU/CPU. We're building a **control surface** (the chosen "Variant B"
+bracketed-trio shape) and wiring it to actually drive the stack.
+
+## Architecture reality (the constraints the UX must respect)
+
+- **FLM trio = chat + ASR + embed in ONE process.** Defined/seeded as `agent` /
+  `stt-npu` / `embed-npu` (`slots.py:112`, `manager.py:77`), but the **dispatch**
+  detection is generalized by `device=="npu"` + `type` (`v1.py:782-800`) — it matches
+  the request model against `slot.model.default` or `slot.name`, **not** hard-coded
+  names. The existing `NpuBlock` is likewise device-driven (`s.device === "npu"`).
+  → **The section keys off `device=="npu"`, never literal names.**
+- **`flm.args` lives in lemond's `config.json`**, set via `POST /api/lemonade/config`
+  `{flm_args}` (`lemonade_admin.py:322`, validated to require `--asr 1 --embed 1`),
+  **applied at the next FLM load**. Changing modalities ⇒ reload.
+- **TTS is NOT an FLM modality.** FLM serves chat/ASR/embed only. TTS (kokoro,
+  VibeVoice) runs on CPU/iGPU and never appears in this section.
+- **FLM has its own model namespace** (`registry/seeds/haloai_models.json`,
+  `backend:"flm"`): chat (qwen3-it:4b, llama3.2:3b, gemma3:4b, gpt-oss:20b, …),
+  embed (`embed-gemma-300m-FLM`), ASR (FLM whisper). **No arbitrary GGUFs.**
+- **The FLM child's port** is discovered at runtime via
+  `find_flm_chat_backend_url()` (`dispatcher/flm_trio.py`) — recipe=flm + type=llm in
+  `/v1/health.loaded`.
+
+### Two mechanisms that must be reconciled (the hard part)
+
+1. **The trio mechanism** (this spec): one process, driven by `flm_args` + loading the
+   NPU chat slot; ASR/embed are coresident, dispatched by `v1.py`.
+2. **The capability orchestrator** (`capabilities/orchestrator.py`): selections
+   (`capabilities.toml [selections.<cap>.<child>]` → device/provider/model/enabled)
+   reconcile into **standalone** slots. It explicitly declares **"NPU multiplex …
+   OUT OF SCOPE; NPU children spawn their own slot"** (orchestrator.py:15-17), and
+   `_NPU_FANOUT_CAPS = {chat, embed}` (catalog.py) — so the capability picker offers
+   NPU for chat/embed but **not** STT, and would try to make a *standalone* NPU embed
+   slot rather than route into the trio.
+
+These disagree about NPU embed. The design resolves it (below) and phases the work so
+Phase 1 ships value without the full orchestrator unification.
+
+## Design principles (flexible, intuitive UX)
+
+1. **Chat is the anchor; ASR/embed are coresident toggles.** The section always leads
+   with the FLM chat model. ASR and embed are bound to it (Variant B bracket) so it
+   reads as "one process, boots together."
+2. **One master power switch** loads/unloads the whole stack. Per-modality toggles set
+   intent; because `flm_args` apply at load, changing a toggle while running shows a
+   **pending "⟳ reload to apply"** state rather than lying about instant effect.
+3. **Honesty about state.** Show: loaded/unloaded, live `flm_args`, the active chat
+   model + per-modality model, the FLM child port (debug), and pending-vs-applied.
+4. **FLM-namespace pickers only.** Chat/embed/ASR pickers list FLM models; offer a pull
+   affordance for catalogued-but-not-downloaded FLM models. Never show GGUFs.
+5. **Device-partition clarity (one capability, one home).** A capability (embed, STT)
+   appears in **either** the NPU section (when on NPU) **or** the Capabilities grid
+   (when on CPU/iGPU) — never both. A small inline link ("also runnable on iGPU/CPU →
+   Capabilities") makes the relationship discoverable. TTS lives only in Capabilities.
+6. **Graceful absence.** No NPU hardware → the section hides (or shows "NPU not
+   detected"), exactly like `NpuBlock` returning null today.
+7. **Forgiving, reversible.** Toggling embed/ASR off doesn't destroy config; it flips a
+   flag. Re-enabling restores. Invalid combinations surface a clear message, never a
+   silent no-op.
+
+## The NPU section UI (Variant B — bracketed trio)
+
+A section header **"NPU · FLM Stack"** with a coresident chip + **master power Switch**,
+above three cards visually bound by a left bracket:
+
+- **Chat card (anchor, always on):** FLM chat-model picker (from FLM chat namespace),
+  live metrics (tok/s, TTFT, KV) when loaded.
+- **ASR card:** on/off Switch + FLM ASR model picker (faded when off).
+- **Embed card:** on/off Switch + FLM embed model picker (faded when off).
+
+Footer: live `flm.args = "--asr <0|1> --embed <0|1>"`, FLM child port, and a
+"reload to apply" hint when toggles are pending. Each card uses the same `.slot`
+visual language as the rest of the grid (consistency with Spec 1's Capabilities cards).
+
+This replaces the read-only `NpuBlock`/`NpuReactor` in `slots.jsx`.
+
+## Backend wiring
+
+### Reads
+- `GET /api/slots` → slots with `device=="npu"`, `coresident_group`, `lemonade_state`,
+  `backend_url`, per-slot metrics. (Drives display + which modalities are enabled.)
+- `GET /api/lemonade/config` → current `flm_args` (parse `--asr`/`--embed`).
+- FLM model lists → `GET /api/capabilities` catalogs (chat/embed) and/or
+  `models_for_capability` filtered to `backend=="flm"`.
+
+### Writes (control)
+- **Set modalities:** `POST /api/lemonade/config { flm_args: "--asr <0|1> --embed <0|1>" }`.
+  NOTE current validation *mandates* both `--asr 1` and `--embed 1`
+  (`lemonade_admin.py:212-215`). **Change required:** relax validation so the trio can
+  run chat-only or chat+one-modality (accept `--asr 0` / `--embed 0`); keep the keys
+  present so absence never silently disables.
+- **Pick chat model / load / unload:** `POST /api/slots/{npuChat}/swap` (model),
+  `/load`, `/unload`. `{npuChat}` resolved by `device=="npu" && type=="llm"`, not name.
+- **Enable/disable shadow modality slots:** `PUT /api/slots/{name}/config { enabled }`
+  for the `device=="npu"` embedding/transcription slots (so dispatch gating in
+  `v1.py:_is_npu_trio_request` matches), then reload the stack.
+
+### Backend changes needed
+1. **Relax `flm_args` validation** to allow `--asr 0` / `--embed 0` (chat-only or
+   single-modality stacks). (`lemonade_admin.py`)
+2. **A single "apply NPU stack" path** is desirable so the UI does one call: set
+   flm_args + set chat model + enable/disable shadow slots + reload, transactionally.
+   Phase 1 may compose the existing endpoints client-side; Phase 2 adds a dedicated
+   `POST /api/npu/stack` (or capability-orchestrator route) that does it atomically.
+3. **NPU ASR as a selectable capability (Phase 2):** add `asr` to `_NPU_FANOUT_CAPS`
+   so the capability picker can route STT → NPU (today only chat/embed).
+
+## Reconciliation decisions
+
+- **Identity by device, not name.** The section, dispatch, and shadow-slot gating all
+  key on `device=="npu"` + `type`. Keep seeding canonical names (`agent`/`stt-npu`/
+  `embed-npu`) for fresh installs, but never *require* them. Boxes with `npu`/`embed`/
+  `stt` work unchanged. (Document; add a test asserting device-driven detection.)
+- **NPU embed routes into the trio, not a standalone slot.** When a capability
+  selection is `device=npu`, the orchestrator must enable the trio's embed modality
+  (flm_args `--embed 1` + enable the npu embedding slot) rather than spawn an
+  independent FLM process. This closes the "NPU multiplex out of scope" gap. **Phased:**
+  Phase 1 drives the trio directly from the NPU section; Phase 2 makes the capability
+  orchestrator NPU-aware so the Capabilities picker and the NPU section stay in sync.
+- **Voice stack split.** STT may live on NPU (trio ASR) or CPU/iGPU (moonshine/whisper);
+  TTS only on CPU/iGPU (kokoro now; VibeVoice later). The NPU section shows STT only
+  when it's on NPU; TTS never appears here.
+
+## Voice stack & VibeVoice (dependency)
+
+- **kokoro** (TTS, `providers/kokoro.py`) and **moonshine** (STT, `providers/moonshine.py`)
+  are implemented; **whisper** STT runs via whisper.cpp or FLM-on-NPU.
+- **VibeVoice** (TTS) is **catalogued only** (`vibevoice-realtime-0.5b`) — **no
+  provider implemented**. Standing it up (iGPU PyTorch runtime + a `providers/vibevoice.py`
+  + toolbox) is a **separate spec/dependency**, out of scope here. Until then kokoro is
+  the working TTS. Tracked as a follow-on.
+
+## Scope / phasing
+
+- **Phase 1 (this task):** Build the Variant B NPU section and wire it to the FLM trio
+  via existing endpoints + the `flm_args` validation relaxation. Outcome: from the
+  dashboard you can pick the FLM chat model, toggle ASR/embed, and load/unload the
+  stack, with honest pending/applied state. Replaces `NpuBlock`/`NpuReactor`.
+- **Phase 2 (follow-on):** Capability-orchestrator NPU-awareness (embed/STT selections
+  with device=npu route into the trio; add `asr` to NPU fanout), a transactional
+  `POST /api/npu/stack` apply, and full NPU↔Capabilities device-partition sync.
+- **Dependency spec:** VibeVoice TTS provider.
+
+## Testing
+
+- **Backend:** `flm_args` validation accepts `--asr 0`/`--embed 0`; rejects malformed.
+  Device-driven trio detection (rename slots → still detected). Shadow-slot enable
+  toggles dispatch gating.
+- **Frontend (γ-suite / Playwright):** section renders only when an NPU slot exists;
+  chat picker lists FLM-only models; toggling ASR/embed updates the pending `flm_args`
+  preview; master switch issues load/unload; a capability shown on NPU is not also
+  shown in the Capabilities grid.
+
+## Files touched
+
+- `ui/src/dash/slots.jsx` — replace `NpuBlock`/`NpuReactor` with the Variant B
+  control section; device-keyed; wire to hooks.
+- `ui/src/api/hooks/` — add `useLemonadeConfig` (get/set `flm_args`) if absent; reuse
+  `useSlots`, `useCapabilities`.
+- `ui/src/dash/dashboard.css` — NPU section styling (bracket, bound cards).
+- `src/hal0/api/routes/lemonade_admin.py` — relax `flm_args` validation.
+- Phase 2 (separate PRs): `capabilities/orchestrator.py`, `capabilities/catalog.py`
+  (`_NPU_FANOUT_CAPS`), a `POST /api/npu/stack` route.
+- Tests: backend `flm_args` + trio-detection; γ-suite NPU section spec.
+
+## Prototype
+
+Variant B chosen from the throwaway prototype at `ui/npu-proto.html?variant=B`
+(`ui/src/npu-proto.tsx`). Delete the prototype once the section lands.

--- a/docs/superpowers/specs/2026-06-05-slot-edit-panel-controls-design.md
+++ b/docs/superpowers/specs/2026-06-05-slot-edit-panel-controls-design.md
@@ -1,0 +1,165 @@
+# Slot edit panel controls — `enable_thinking`, `enabled`, `n_gpu_layers`
+
+**Date:** 2026-06-05
+**Status:** Approved design — ready for implementation plan
+**Area:** dashboard SPA (`ui/src/dash/`) + slots API (`src/hal0/api/routes/slots.py`)
+
+## Problem
+
+Operators can only change a handful of slot settings from the dashboard
+(`device`, `default`, `ctx_size`, `idle_timeout_s`, `workers`, `extra_args`).
+Three high-value settings have no UI:
+
+- **`enable_thinking`** — the per-slot reasoning default. Turning it on/off
+  today means hand-editing `/etc/hal0/slots/<name>.toml`. This was the root of
+  a real incident (the `primary` slot's `enable_thinking=true` made the Hermes
+  TUI appear to hang on empty `reasoning_content`).
+- **`enabled`** — activate/deactivate a slot. The only "off" today is delete.
+- **`n_gpu_layers`** — GPU offload tuning on the shared 96 GB box.
+
+## Goals / non-goals
+
+**Goals**
+- Toggle `enable_thinking` per slot from the edit drawer; effect on next message.
+- Toggle `enabled` per slot directly on the slot **card**; faded card when off.
+- Edit `n_gpu_layers` from the drawer's Advanced section.
+
+**Non-goals**
+- Per-slot sampling defaults (`temperature`/`top_p`/`max_tokens`) — those are
+  per-request, not slot config. Out of scope (would be a separate `[model].extra`
+  / sampling-defaults feature).
+- `role` and `rope_freq_base` controls — deliberately excluded (`role` is a
+  routing foot-gun; `rope_freq_base` is niche).
+
+## Background — how the pieces already work
+
+- **Write path exists.** `PUT /api/slots/{name}/config` (`update_slot_config`)
+  shallow-merges a partial `SlotConfig` into the TOML. `enable_thinking: bool|None`
+  and `enabled: bool` are top-level `SlotConfig` fields
+  (`src/hal0/config/schema.py:241,253`). `PATCH /api/slots/{name}/defaults`
+  (`update_slot_defaults`) merges into the `[model]` sub-table — that's where
+  `n_gpu_layers: int` lives (`ModelConfig`, `schema.py:156`).
+- **`enable_thinking` is read live per request** by `_slot_thinking_default`
+  (`src/hal0/api/routes/v1.py:333`) and injected as `chat_template_kwargs` by
+  `src/hal0/normalize/thinking.py`. Absent/`None` → **OFF (suppression)**, so the
+  effective state is binary (a tri-state "default" would duplicate "off").
+  → Toggling `enable_thinking` takes effect on the **next message, no restart**.
+- **`enabled` is read at load/registration time** and participates in coexistence
+  rules: two `device=npu, type=llm, enabled=true` slots cannot coexist
+  (`state.py:190`); FLM-trio gating (`slots.py:260`); peer checks
+  (`manager.py:1631,1650`). → Enabling can **fail validation**; disabling does
+  **not** auto-stop a running slot.
+- **`n_gpu_layers` changes model load** → restart-required, like `ctx_size`.
+- **Payload gap.** `Slot.as_dict()` (`manager.py:166`) ships only runtime fields,
+  not `enabled`/`enable_thinking`/`n_gpu_layers`. These must be added to the slot
+  list payload so the card and drawer can seed their controls.
+
+## Design
+
+### Component 1 — Backend: expose config fields in the slot payload
+
+In the slots list serialisation (`_slot_to_dict` / `list_slots` enrichment in
+`src/hal0/api/routes/slots.py`), add three fields read from the slot's config:
+
+- `enabled: bool` (top-level, default `true`)
+- `enable_thinking: bool | null` (top-level)
+- `n_gpu_layers: int` (from `[model]`)
+
+These are cheap reads (config already loaded for other enrichment). No schema
+change — the fields already exist in `SlotConfig`/`ModelConfig`.
+
+### Component 2 — Backend: `enabled` transition safety
+
+No new endpoint; `enabled` writes through the existing `PUT /{name}/config`.
+Two behaviours must hold so the toggle is truthful (verify current behaviour,
+add where missing):
+
+- **Invalid enable** (would violate npu-exclusivity / FLM-trio) → `update_config`
+  raises a `ValidationError`/`Conflict` with a clear message. The API returns the
+  error; the UI reverts the switch and toasts the message.
+- **Disable of a running slot** → the persisted `enabled=false` write is followed
+  by a **stop** of the running slot (reuse the existing unload/stop path) so the
+  slot is actually offline, matching the faded card. If the slot is already off,
+  the write alone suffices.
+
+### Component 3 — Frontend: `enabled` toggle on the card + fade
+
+In `SlotCard` (`ui/src/dash/slots.jsx`):
+
+- Add a compact switch to the header's top-right `<div className="right">`
+  (beside the ★default / coresident chips), bound to `slot.enabled`.
+- On flip: optimistic update → `PUT /api/slots/{name}/config { enabled }`.
+  On error: revert + error toast. On disable: backend also stops the slot
+  (Component 2); the card transitions to its off/faded state.
+- **Fade:** when `!slot.enabled`, add a modifier class (e.g. `slot--disabled`)
+  to the root `.slot` div → `opacity: ~0.5` in `dashboard.css`. The toggle itself
+  stays full-opacity and interactive so the slot can be re-enabled; action
+  buttons (Start/Stop/Restart) are hidden or disabled while disabled.
+- `enabled` is **not** duplicated in the drawer — the card is the single source.
+
+### Component 4 — Frontend: `enable_thinking` instant toggle in the drawer
+
+In `EditSlotDrawer` (`ui/src/dash/slot-modals.jsx`), **llm slots only**
+(hidden for stt/tts/embed/rerank/image):
+
+- A switch bound to `slot.enable_thinking` (seed from payload; `null`→off).
+- On flip (instant-apply, mirrors the backend selector): `PUT /{name}/config
+  { enable_thinking }`, optimistic, revert + toast on error. Toast
+  `thinking on/off — applies to next message`.
+- Label/subtext: *"Stream reasoning before the answer. Off = faster, direct
+  replies."* **No** `⟳ restart required` badge (live per-request read).
+
+### Component 5 — Frontend: `n_gpu_layers` input in the drawer
+
+In `EditSlotDrawer` Advanced section, an input bound to a `nGpuLayers` state,
+saved with the **existing Save button** via `defaultsMut` →
+`PATCH /{name}/defaults { n_gpu_layers }` (alongside `ctx_size`). Shows the
+`⟳ restart required` badge. (Not instant — changes model load.)
+
+## Data flow
+
+```
+Card enabled switch ─PUT /config {enabled}─▶ update_config ─▶ TOML
+   └─ on disable: + stop running slot
+   └─ on invalid enable: ValidationError ─▶ revert switch + toast
+
+Drawer thinking switch ─PUT /config {enable_thinking}─▶ TOML
+   └─ next message: _slot_thinking_default reads it live ─▶ chat_template_kwargs
+
+Drawer n_gpu_layers + Save ─PATCH /defaults {n_gpu_layers}─▶ TOML [model]
+   └─ ⟳ restart required to apply
+```
+
+## Error handling
+
+- All writes: on non-2xx, revert the optimistic control to its prior value and
+  surface the API error message via `window.__hal0Toast(..., "warn")`.
+- Invalid `enabled` enable: show the coexistence-conflict message verbatim.
+- Non-llm slots never render the thinking toggle.
+
+## Testing
+
+**Backend**
+- `update_config` round-trips `enable_thinking` (true/false/null) and `enabled`
+  to the TOML and back through the slot payload.
+- Enabling a slot that violates npu-exclusivity / FLM-trio raises the expected
+  error (extend existing coexistence tests if present).
+- Slot list payload includes `enabled`, `enable_thinking`, `n_gpu_layers`.
+
+**Frontend (γ-suite / Playwright)**
+- Thinking toggle renders only for llm slots; flip issues `PUT /config` with the
+  correct body; error reverts the switch.
+- Card `enabled` toggle: flip issues `PUT /config`; disabling adds the fade class
+  and hides Start/Stop; invalid-enable reverts + toasts.
+- `n_gpu_layers` saves via the Save button (`PATCH /defaults`) and shows the
+  restart badge.
+
+## Files touched
+
+- `src/hal0/api/routes/slots.py` — payload fields; `enabled` stop-on-disable +
+  invalid-enable error surfacing (verify/extend).
+- `ui/src/dash/slots.jsx` — card `enabled` switch + fade.
+- `ui/src/dash/slot-modals.jsx` — drawer `enable_thinking` toggle + `n_gpu_layers`
+  input.
+- `ui/src/dash/dashboard.css` — `.slot--disabled` opacity; switch styling.
+- Tests: backend slot-config tests + γ-suite slot specs.

--- a/docs/superpowers/specs/2026-06-05-slot-edit-panel-controls-design.md
+++ b/docs/superpowers/specs/2026-06-05-slot-edit-panel-controls-design.md
@@ -1,8 +1,13 @@
-# Slot edit panel controls — `enable_thinking`, `enabled`, `n_gpu_layers`
+# Slots page: edit controls + layout (`enable_thinking`, `enabled`, `n_gpu_layers`, sort, Capabilities grid)
 
 **Date:** 2026-06-05
 **Status:** Approved design — ready for implementation plan
 **Area:** dashboard SPA (`ui/src/dash/`) + slots API (`src/hal0/api/routes/slots.py`)
+
+**Scope note:** This is "Spec 1" — pure slots-page UX (controls + layout). The
+**NPU / FLM stack management** section is a separate "Spec 2" (its own design),
+because NPU embedding is a coresident FLM-trio modality, not a standalone slot,
+and needs backend modeling decisions first.
 
 ## Problem
 
@@ -23,6 +28,10 @@ Three high-value settings have no UI:
 - Toggle `enable_thinking` per slot from the edit drawer; effect on next message.
 - Toggle `enabled` per slot directly on the slot **card**; faded card when off.
 - Edit `n_gpu_layers` from the drawer's Advanced section.
+- **Sort** enabled slots first, disabled slots to the end of the grid.
+- **Capabilities section**: render the utility slots (embedding, reranking,
+  transcription, tts) in a denser 4-up (quarter-width) grid, since their card
+  content is narrow.
 
 **Non-goals**
 - Per-slot sampling defaults (`temperature`/`top_p`/`max_tokens`) — those are
@@ -116,6 +125,28 @@ saved with the **existing Save button** via `defaultsMut` →
 `PATCH /{name}/defaults { n_gpu_layers }` (alongside `ctx_size`). Shows the
 `⟳ restart required` badge. (Not instant — changes model load.)
 
+### Component 6 — Frontend: sort enabled-first, disabled-to-end
+
+In the slots grid render (`ui/src/dash/slots.jsx`), stable-sort so `enabled`
+slots render before `!enabled` ones, preserving existing order within each group
+(don't disturb the current type/role ordering otherwise). Pairs with the faded
+card so disabled slots visually and positionally sink to the bottom.
+
+### Component 7 — Frontend: Capabilities section (4-up grid)
+
+Group the slots page into sections:
+- **Primary/chat** (llm slots) — current card width.
+- **Capabilities** — `embedding`, `reranking`, `transcription`, `tts` slots in a
+  **4-up** (quarter-width) responsive grid. These cards have minimal content
+  (a chip or two + one metric), so quarter-width avoids the wasted space of
+  full-width cards. Responsive: 4-up on wide, collapsing to 2-up / 1-up on
+  narrow viewports.
+
+This is layout/CSS only — same `SlotCard`, rendered into a `.slot-grid--quarter`
+container for the Capabilities section. No card-internal changes. (The optimal
+section composition and where a future NPU section sits will be validated via a
+throwaway UI prototype before implementation.)
+
 ## Data flow
 
 ```
@@ -158,8 +189,10 @@ Drawer n_gpu_layers + Save ─PATCH /defaults {n_gpu_layers}─▶ TOML [model]
 
 - `src/hal0/api/routes/slots.py` — payload fields; `enabled` stop-on-disable +
   invalid-enable error surfacing (verify/extend).
-- `ui/src/dash/slots.jsx` — card `enabled` switch + fade.
+- `ui/src/dash/slots.jsx` — card `enabled` switch + fade; enabled-first sort;
+  Capabilities section grouping.
 - `ui/src/dash/slot-modals.jsx` — drawer `enable_thinking` toggle + `n_gpu_layers`
   input.
-- `ui/src/dash/dashboard.css` — `.slot--disabled` opacity; switch styling.
+- `ui/src/dash/dashboard.css` — `.slot--disabled` opacity; switch styling;
+  `.slot-grid--quarter` 4-up responsive grid.
 - Tests: backend slot-config tests + γ-suite slot specs.

--- a/src/hal0/api/routes/lemonade_admin.py
+++ b/src/hal0/api/routes/lemonade_admin.py
@@ -195,24 +195,29 @@ def _validate_llamacpp_args(value: object) -> str | None:
 
 
 def _validate_flm_args(value: object) -> str | None:
-    """Return an error message if ``flm_args`` would break the FLM-trio
-    mandate, else None.
+    """Return an error message if ``flm_args`` is malformed, else None.
 
-    Per plan §5 + ADR-0009 §1, the NPU has a single AMDXDNA hardware
-    context per host — a single ``flm serve`` process. The trio flags
-    ``--asr 1 --embed 1`` pack chat + ASR + embed into that one process.
-    Without both flags the NPU stt-npu and embed-npu slots have no
-    backend; the dashboard would render those slots green while requests
-    404 against a non-existent FLM child port.
+    The NPU has a single AMDXDNA hardware context per host (ADR-0009 §1) —
+    one ``flm serve`` process. The trio flags ``--asr <0|1>`` / ``--embed <0|1>``
+    toggle whether ASR and embed ride coresident in that one process.
+
+    Relaxed 2026-06-05 (Spec 2: NPU/FLM stack section): the dashboard NPU
+    section sets these flags explicitly, so a chat-only or chat+one-modality
+    stack is a valid configuration — we no longer mandate ``--asr 1 --embed 1``.
+    We reject only MALFORMED values. NOTE: when a modality is set to 0, the
+    caller MUST also disable the corresponding NPU ``transcription`` /
+    ``embedding`` slot so dispatch gating (``v1._is_npu_trio_request``) doesn't
+    route requests to a modality the FLM child isn't serving (which would 404).
+    The dashboard NPU section keeps these in sync.
     """
     if not isinstance(value, str):
         return "must be a string"
     # Tolerate any whitespace between flag and arg ("--asr 1", "--asr  1",
-    # "--asr\t1"). Reject "--asr 0" — that's the disable form.
-    if not re.search(r"--asr\s+1(?:\s|$)", value):
-        return "must include --asr 1 (FLM trio mandate, plan §5)"
-    if not re.search(r"--embed\s+1(?:\s|$)", value):
-        return "must include --embed 1 (FLM trio mandate, plan §5)"
+    # "--asr\t1"). Accept 0 (disable) or 1 (enable); reject anything else.
+    for flag in ("asr", "embed"):
+        m = re.search(rf"--{flag}\s+(\S+)", value)
+        if m and m.group(1) not in ("0", "1"):
+            return f"--{flag} must be 0 or 1 (got {m.group(1)!r})"
     return None
 
 

--- a/tests/api/test_lemonade_admin_route.py
+++ b/tests/api/test_lemonade_admin_route.py
@@ -348,45 +348,54 @@ def test_post_config_accepts_llamacpp_args_threads_equals_form(
     assert r.status_code == 200, r.text
 
 
-def test_post_config_rejects_flm_args_missing_asr(
+def test_post_config_accepts_flm_args_chat_plus_embed_only(
     isolated_client: TestClient,
     installed_lemonade_stub: dict[str, Any],
 ) -> None:
-    """Without --asr 1 the FLM trio collapses to chat-only — the NPU
-    stt-npu slot would 404 against a non-existent backend port."""
+    """Spec 2 relaxation: a chat+embed stack (no ASR) is a valid config.
+    The dashboard NPU section sets flags explicitly and keeps the NPU
+    transcription slot disabled to match, so this no longer 404s."""
     r = isolated_client.post(
         "/api/lemonade/config",
         json={"flm_args": "--embed 1"},
     )
-    assert r.status_code == 400, r.text
-    details = r.json()["error"]["details"]
-    assert "--asr 1" in details["flm_args"]
+    assert r.status_code == 200, r.text
 
 
-def test_post_config_rejects_flm_args_missing_embed(
+def test_post_config_accepts_flm_args_chat_plus_asr_only(
     isolated_client: TestClient,
     installed_lemonade_stub: dict[str, Any],
 ) -> None:
-    """Symmetric to missing-asr: without --embed 1 the embed-npu slot
-    has no backend."""
+    """Symmetric: a chat+ASR stack (no embed) is valid under Spec 2."""
     r = isolated_client.post(
         "/api/lemonade/config",
         json={"flm_args": "--asr 1"},
     )
-    assert r.status_code == 400, r.text
-    details = r.json()["error"]["details"]
-    assert "--embed 1" in details["flm_args"]
+    assert r.status_code == 200, r.text
 
 
-def test_post_config_rejects_flm_args_with_disable_flag(
+def test_post_config_accepts_flm_args_explicit_disable(
     isolated_client: TestClient,
     installed_lemonade_stub: dict[str, Any],
 ) -> None:
-    """``--asr 0`` is the disable form — must NOT pass the trio
-    mandate, even though "--asr" appears in the string."""
+    """``--asr 0`` (explicit disable) is now a valid, accepted value — the
+    NPU section sends explicit 0/1 and disables the matching slot."""
     r = isolated_client.post(
         "/api/lemonade/config",
         json={"flm_args": "--asr 0 --embed 1"},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_post_config_rejects_flm_args_malformed_value(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """Only 0/1 are valid for --asr/--embed; a non-binary value is
+    malformed and must be rejected."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"flm_args": "--asr 2 --embed 1"},
     )
     assert r.status_code == 400, r.text
 

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -3,7 +3,6 @@ const { useState: useStateA, useEffect: useEffectA } = React;
 
 const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
   "slotVariant": "instrument",
-  "npuVariant": "block",
   "showHero": true,
   "firstRunLayout": "grid",
   "personaPlacement": "composer-left"
@@ -160,7 +159,6 @@ function App() {
           <SlotsView
             slots={HAL0_DATA.slots}
             slotVariant={tweaks.slotVariant}
-            npuVariant={tweaks.npuVariant}
             slotParam={param}
             onGo={go}
           />
@@ -259,18 +257,6 @@ function App() {
               { value: "instrument", label: "Instrument" },
               { value: "list",       label: "Compact list" },
               { value: "spec",       label: "Spec card" },
-            ]}
-          />
-        </TweakSection>
-
-        <TweakSection title="NPU trio">
-          <TweakRadio
-            label="Layout"
-            value={tweaks.npuVariant}
-            onChange={v => setTweak("npuVariant", v)}
-            options={[
-              { value: "block",   label: "Block (sub-rows)" },
-              { value: "reactor", label: "Reactor diagram" },
             ]}
           />
         </TweakSection>

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -12,7 +12,10 @@ import {
   useSlotUnload,
   useSlotLoad,
   useSlotSwap,
+  useSlotEdit,
 } from '@/api/hooks/useSlots'
+import { useModels } from '@/api/hooks/useModels'
+import { useLemonadeConfig, useLemonadeConfigSet } from '@/api/hooks/useLemonadeConfig'
 import { MemoryMap } from './memory-map'
 
 const { useState: useStateS } = React;
@@ -411,188 +414,311 @@ function npuTrioBackendUrl(slots) {
   }
   return null;
 }
-function npuTrioBackendBadge(slots) {
-  for (const s of slots) {
-    const b = s.backend || s.metadata?.backend || s.provider;
-    if (typeof b === "string" && b) return b;
-  }
-  return null;
+
+// ─── flm_args parsing helpers (pure) ───
+//
+// The FLM trio's coresident modalities are driven by lemond's
+// `flm_args` string ("--asr <0|1> --embed <0|1>"), set via
+// POST /api/lemonade/config and applied at the next FLM load. We parse
+// the live string to drive the toggles and recompose it on flip.
+// The backend now accepts explicit 0/1 for both flags, so we always
+// emit both keys (absence must never silently disable a modality).
+function parseFlmArgs(str) {
+  const s = typeof str === "string" ? str : "";
+  const asrM = s.match(/--asr\s+(\d)/);
+  const embM = s.match(/--embed\s+(\d)/);
+  return {
+    // Default ON when the flag is absent — matches the seeded trio
+    // ("--asr 1 --embed 1") so an empty/unparsed config reads as the
+    // full coresident stack rather than silently-off.
+    asr: asrM ? asrM[1] === "1" : true,
+    embed: embM ? embM[1] === "1" : true,
+  };
 }
-function chatMetric(slot, key) {
-  const v = slot?.metrics?.[key];
-  return v === undefined || v === null || v === "" ? "—" : v;
+function composeFlmArgs({ asr, embed }) {
+  return `--asr ${asr ? 1 : 0} --embed ${embed ? 1 : 0}`;
 }
 
-// ─── NPU trio — Block variant (default per brief) ───
-function NpuBlock({ slots }) {
-  const npuSlots = slots.filter(s => s.device === "npu");
-  if (!npuSlots.length) return null;
-  const chat = npuSlots.find(s => s.type === "llm");
-  const flm = chat || npuSlots[0];
-  const coresGroup = npuTrioGroupLabel(npuSlots);
-  const backendUrl = npuTrioBackendUrl(npuSlots);
-  const backendName = npuTrioBackendBadge(npuSlots);
+// FLM models live in their own namespace (registry seed backend:"flm",
+// upstream:"npu"). Filter /api/models defensively across the field
+// shapes the registry/upstream rows can present, then narrow by the
+// dispatcher `type` vocabulary the picker is for. Never offer GGUFs.
+function isFlmModel(m) {
+  const backends = Array.isArray(m?.backends) ? m.backends : [];
   return (
-    <div className="card npu-card live">
-      <div className="npu-h">
-        <span className="npu-glyph mono">NPU</span>
-        <span className="title mono">
-          FLM trio<span className="sub">one process · three roles · {chat ? chat.model : "no chat model"} active</span>
-        </span>
+    backends.includes("flm") ||
+    m?.backend === "flm" ||
+    m?.runtime === "flm" ||
+    m?.upstream === "npu"
+  );
+}
+// `normalizeApiModel` derives `type` from the plural `capabilities`
+// array and discards any backend-set type. FLM seed rows carry a
+// SINGULAR `capability` ("chat"|"embed"|"asr"), so when `capabilities`
+// is empty `type` lands as "" — fall back to the singular field so the
+// pickers still populate. (Dispatcher vocab: chat→llm, embed→embedding,
+// asr/transcription→transcription.)
+function modelSlotType(m) {
+  if (m?.type) return m.type;
+  const cap = String(m?.capability || "").toLowerCase();
+  if (cap === "chat") return "llm";
+  if (cap === "embed" || cap === "embeddings") return "embedding";
+  if (cap === "asr" || cap === "transcription") return "transcription";
+  if (cap === "rerank") return "reranking";
+  if (cap === "tts") return "tts";
+  if (cap === "image") return "image";
+  return "";
+}
+function flmModelsByType(models, type) {
+  return (Array.isArray(models) ? models : [])
+    .filter(isFlmModel)
+    .filter(m => modelSlotType(m) === type);
+}
+
+const NPU_CHIP = {
+  color: "var(--dev-npu)",
+  borderColor: "rgba(200,150,255,0.30)",
+  background: "rgba(200,150,255,0.06)",
+};
+
+function slotIsLoaded(slot) {
+  const lemo = String(slot?.lemonade_state || "");
+  const state = String(slot?.state || "");
+  return lemo === "loaded" || lemo === "ready" || state === "serving" || state === "ready";
+}
+
+// A small native-looking select for the FLM model pickers.
+function NpuModelSelect({ value, models, disabled, onChange }) {
+  const opts = Array.isArray(models) ? models : [];
+  const hasCurrent = value && opts.some(m => m.id === value);
+  return (
+    <select
+      className="input mono npu-sel"
+      value={value || ""}
+      disabled={disabled}
+      onChange={e => onChange && onChange(e.target.value)}
+    >
+      {/* Keep the live model selectable even if the catalog hasn't
+          surfaced it (offline /api/models, un-catalogued FLM tag). */}
+      {value && !hasCurrent && <option value={value}>{value}</option>}
+      {!value && <option value="">—</option>}
+      {opts.map(m => (
+        <option key={m.id} value={m.id}>{m.longName || m.id}</option>
+      ))}
+    </select>
+  );
+}
+
+// A11y-friendly on/off switch (matches the prototype's visual language).
+function NpuSwitch({ on, disabled, label, onClick }) {
+  return (
+    <button
+      type="button"
+      className="npu-switch"
+      role="switch"
+      aria-checked={!!on}
+      aria-label={label}
+      disabled={disabled}
+      data-on={on ? "1" : "0"}
+      onClick={onClick}
+    >
+      <span className="knob" />
+    </button>
+  );
+}
+
+// One modality mini-card inside the bracketed trio.
+function NpuModalityCard({ icon, label, slot, on, fixed, models, busy, onToggle, onPickModel }) {
+  return (
+    <div className="slot npu-mod" data-on={on ? "1" : "0"}>
+      <div className="slot-h">
+        <span className="npu-mod-icon" aria-hidden="true">{icon}</span>
+        <div className="slot-name"><span className="nm">{label}</span></div>
         <div className="right">
-          {coresGroup && (
-            <span className="chip" style={{color: "var(--dev-npu)", borderColor: "rgba(200,150,255,0.30)", background: "rgba(200,150,255,0.08)"}}>
-              <span className="dot" style={{width: 5, height: 5, background: "currentColor", boxShadow: "0 0 6px currentColor"}} />
-              {coresGroup}
-            </span>
-          )}
-          <span className="pid mono">
-            pid {flm?.pid ?? "—"} · port :{flm?.port ?? "—"}
-            {backendUrl ? <> · <span title={backendUrl}>{backendUrl}</span></> : null}
-          </span>
+          {fixed
+            ? <span className="chip" style={{...NPU_CHIP, fontSize: 10}}>always</span>
+            : <NpuSwitch on={on} disabled={busy} label={`Toggle ${label}`} onClick={onToggle} />}
         </div>
       </div>
-      <div className="npu-body">
-        {npuSlots.map((s, i) => {
-          const lemState = s.lemonade_state || s.state || "—";
-          const isLead = s.type === "llm";
-          return (
-            <div key={s.name} className={"npu-subrow" + (isLead ? " lead" : "")}>
-              <span className={"dot " + (i === 0 ? "ready" : "coresident")} />
-              <div className="role mono">
-                {s.name}
-                <span className="sub">{s.type}</span>
-              </div>
-              <div className="model mono">
-                {s.model}
-                {isLead && <span className="chev">{Icons.chev}</span>}
-              </div>
-              <div className="met mono">
-                {isLead && (
-                  <span>
-                    <b>{chatMetric(s, "toks")}</b> tok/s · TTFT <b>{chatMetric(s, "ttft")}</b>ms · KV <b>{chatMetric(s, "kv")}</b>%
-                  </span>
-                )}
-                {s.type === "transcription" && (
-                  <span><b>{chatMetric(s, "xrt")}</b> xrt · {s.metrics?.precision || "—"}</span>
-                )}
-                {s.type === "embedding" && (
-                  <span>{s.metrics?.dim || "—"}-dim · {lemState}</span>
-                )}
-              </div>
-              <div className="st">
-                <span className="chip" style={{color: isLead ? "var(--ok)" : "var(--dev-npu)", borderColor: isLead ? "var(--ok-line)" : "rgba(200,150,255,0.30)", background: isLead ? "var(--ok-soft)" : "rgba(200,150,255,0.06)"}}>
-                  {lemState}{isLead && s.isDefault ? " · default" : ""}
-                </span>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-      <div className="npu-foot mono">
-        <span className="item">backend <b>{backendName || "—"}</b></span>
-        <span style={{color: "var(--fg-5)"}}>·</span>
-        <span className="item">group <b>{coresGroup || "—"}</b></span>
-        <span style={{color: "var(--fg-5)"}}>·</span>
-        <span className="item">disabling stt-npu/embed-npu frees a role at next FLM restart</span>
+      <div className="npu-mod-body">
+        <NpuModelSelect
+          value={slot?.model || ""}
+          models={models}
+          disabled={!on || busy || !slot}
+          onChange={onPickModel}
+        />
       </div>
     </div>
   );
 }
 
-// ─── NPU trio — Reactor variant ───
-function NpuReactor({ slots }) {
+// ─── NPU · FLM Stack — Variant B (bracketed trio control surface) ───
+//
+// THE npu rendering. One FLM process packs chat + ASR + embed coresident
+// (the trio boots together when the NPU chat slot loads with
+// flm_args "--asr 1 --embed 1"). This section lets the operator pick the
+// FLM chat model, toggle ASR/embed modalities, and load/unload the whole
+// stack — keyed off device=="npu" (never literal slot names).
+function NpuFlmStack({ slots }) {
   const npuSlots = slots.filter(s => s.device === "npu");
+  // Hooks must run unconditionally (rules-of-hooks) — gate render below.
+  const cfgQuery = useLemonadeConfig();
+  const cfgSet = useLemonadeConfigSet();
+  const modelsQuery = useModels();
+  const swapMut = useSlotSwap();
+  const loadMut = useSlotLoad();
+  const unloadMut = useSlotUnload();
+  const editMut = useSlotEdit();
+  const [pending, setPending] = useStateS(false);
+  const [busy, setBusy] = useStateS(false);
+
   if (!npuSlots.length) return null;
+
   const chat = npuSlots.find(s => s.type === "llm");
-  const stt = npuSlots.find(s => s.type === "transcription");
-  const emb = npuSlots.find(s => s.type === "embedding");
+  const asr = npuSlots.find(s => s.type === "transcription");
+  const embed = npuSlots.find(s => s.type === "embedding");
+  const anySlot = chat || npuSlots[0];
+
   const coresGroup = npuTrioGroupLabel(npuSlots);
   const backendUrl = npuTrioBackendUrl(npuSlots);
-  const backendName = npuTrioBackendBadge(npuSlots);
+  const childPort = anySlot?.port ?? null;
+
+  const flmArgsLive = typeof cfgQuery.data?.flm_args === "string" ? cfgQuery.data.flm_args : "";
+  const parsed = parseFlmArgs(flmArgsLive);
+
+  const allModels = modelsQuery.data || [];
+  const chatModels = flmModelsByType(allModels, "llm");
+  const asrModels = flmModelsByType(allModels, "transcription");
+  const embedModels = flmModelsByType(allModels, "embedding");
+
+  const loaded = chat ? slotIsLoaded(chat) : npuSlots.some(slotIsLoaded);
+  // Live flm.args string for the footer — pending toggles preview the
+  // string that WILL apply on the next load.
+  const previewArgs = composeFlmArgs(parsed);
+
+  const toast = (msg, kind = "warn") =>
+    window.__hal0Toast && window.__hal0Toast(msg, kind);
+
+  const run = async (fn) => {
+    setBusy(true);
+    try {
+      await fn();
+    } catch (err) {
+      toast(err?.message ? err.message : "NPU action failed", "warn");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Master power — load/unload the whole stack via the chat (anchor) slot.
+  // Loading applies the current flm_args, so it clears the pending hint.
+  const onMaster = () => {
+    if (!chat) { toast("No NPU chat slot to load", "warn"); return; }
+    run(async () => {
+      if (loaded) {
+        await unloadMut.mutateAsync(chat.name);
+      } else {
+        await loadMut.mutateAsync(chat.name);
+      }
+      // Either edge resolves the pending flm_args: a load applies them,
+      // an unload tears down the process that held the stale args.
+      setPending(false);
+    });
+  };
+
+  // Reload to apply pending flm_args (unload+load the anchor slot).
+  const onReload = () => {
+    if (!chat) return;
+    run(async () => {
+      if (loaded) await unloadMut.mutateAsync(chat.name);
+      await loadMut.mutateAsync(chat.name);
+      setPending(false);
+    });
+  };
+
+  const onPickChat = (model_id) => {
+    if (!chat || !model_id || model_id === chat.model) return;
+    run(() => swapMut.mutateAsync({ name: chat.name, model_id }));
+  };
+
+  // Toggle a coresident modality: recompose flm_args (flip the one flag,
+  // keep the other), POST it to lemond, AND flip the shadow slot's
+  // `enabled` so dispatch gating (v1.py _is_npu_trio_request) stays in
+  // sync. flm_args apply at the next load → mark pending.
+  const onToggleModality = (which, slot) => {
+    const next = { ...parsed, [which]: !parsed[which] };
+    run(async () => {
+      await cfgSet.mutateAsync({ flm_args: composeFlmArgs(next) });
+      if (slot) {
+        await editMut.mutateAsync({ name: slot.name, body: { enabled: next[which] } });
+      }
+      setPending(true);
+    });
+  };
+
+  const onPickAsrModel = (model_id) => {
+    if (!asr || !model_id || model_id === asr.model) return;
+    run(() => swapMut.mutateAsync({ name: asr.name, model_id }));
+  };
+  const onPickEmbedModel = (model_id) => {
+    if (!embed || !model_id || model_id === embed.model) return;
+    run(() => swapMut.mutateAsync({ name: embed.name, model_id }));
+  };
+
   return (
-    <div className="card npu-card live">
-      <div className="npu-h">
-        <span className="npu-glyph mono">NPU</span>
-        <span className="title mono">FLM trio<span className="sub">reactor view · one process driving three roles</span></span>
-        <div className="right">
-          {coresGroup && (
-            <span className="chip" style={{color: "var(--dev-npu)", borderColor: "rgba(200,150,255,0.30)", background: "rgba(200,150,255,0.08)"}}>
-              <span className="dot" style={{width: 5, height: 5, background: "currentColor", boxShadow: "0 0 6px currentColor"}} />
-              {coresGroup}
-            </span>
-          )}
-          <span className="pid mono">pid {chat?.pid ?? "—"}</span>
+    <div className="npu-stack">
+      <div className="npu-stack-h">
+        <span className="title mono">NPU · FLM Stack</span>
+        <span className="chip" style={NPU_CHIP}>
+          <span className="dot" style={{width: 5, height: 5, background: "currentColor", boxShadow: "0 0 6px currentColor"}} />
+          coresident · boots together
+        </span>
+        <span className="npu-stack-spacer" />
+        <span className="npu-stack-master-lbl mono">master</span>
+        <NpuSwitch on={loaded} disabled={busy || !chat} label="Load/unload FLM stack" onClick={onMaster} />
+      </div>
+
+      <div className="npu-bracket">
+        <div className="npu-bracket-rail" aria-hidden="true" />
+        <div className="npu-trio">
+          <NpuModalityCard
+            icon="💬" label="Chat" slot={chat} on fixed
+            models={chatModels} busy={busy} onPickModel={onPickChat}
+          />
+          <NpuModalityCard
+            icon="🎙" label="ASR" slot={asr} on={parsed.asr}
+            models={asrModels} busy={busy}
+            onToggle={() => onToggleModality("asr", asr)}
+            onPickModel={onPickAsrModel}
+          />
+          <NpuModalityCard
+            icon="🧬" label="Embed" slot={embed} on={parsed.embed}
+            models={embedModels} busy={busy}
+            onToggle={() => onToggleModality("embed", embed)}
+            onPickModel={onPickEmbedModel}
+          />
         </div>
       </div>
-      <div className="npu-reactor">
-        <div className="reactor-core">
-          <div className="reactor-disc">
-            <div className="lbl">
-              backend<b>{backendName || "—"}</b>
-              <div style={{marginTop: 4, color: "var(--fg-4)"}}>{backendUrl || "—"}</div>
-            </div>
-          </div>
-          <div className="reactor-meta">group {coresGroup || "—"}</div>
-        </div>
-        <div className="reactor-roles">
-          {chat && (
-            <div className="reactor-role lead">
-              <span className="dot ready" />
-              <div className="lbl">
-                {chat.name}
-                <span className="sub">chat · llm{chat.isDefault ? " · default" : ""}</span>
-              </div>
-              <div className="md">{chat.model}</div>
-              <div className="met">
-                <div><b style={{color: "var(--fg)"}}>{chatMetric(chat, "toks")}</b> tok/s</div>
-                <div style={{color: "var(--fg-4)"}}>KV {chatMetric(chat, "kv")}%</div>
-              </div>
-            </div>
-          )}
-          {stt && (
-            <div className="reactor-role">
-              <span className="dot coresident" />
-              <div className="lbl">
-                {stt.name}
-                <span className="sub">transcription · passenger</span>
-              </div>
-              <div className="md">{stt.model}</div>
-              <div className="met">
-                <div><b style={{color: "var(--fg)"}}>{chatMetric(stt, "xrt")}</b> xrt</div>
-                <div style={{color: "var(--fg-4)"}}>{stt.metrics?.precision || "—"}</div>
-              </div>
-            </div>
-          )}
-          {emb && (
-            <div className="reactor-role">
-              <span className="dot coresident" />
-              <div className="lbl">
-                {emb.name}
-                <span className="sub">embedding · passenger</span>
-              </div>
-              <div className="md">{emb.model}</div>
-              <div className="met">
-                <div><b style={{color: "var(--fg)"}}>{emb.metrics?.dim || "—"}</b> dim</div>
-                <div style={{color: "var(--fg-4)"}}>{emb.lemonade_state || emb.state || "—"}</div>
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-      <div className="npu-foot mono">
-        <span className="item">backend <b>{backendName || "—"}</b></span>
-        <span style={{color: "var(--fg-5)"}}>·</span>
-        <span className="item">group <b>{coresGroup || "—"}</b></span>
-        <span style={{color: "var(--fg-5)"}}>·</span>
-        <span className="item">pauses voice + embed on chat-model swap</span>
+
+      <div className="npu-stack-foot mono">
+        <code className="npu-args">flm.args = "{previewArgs}"</code>
+        <span className="sep">·</span>
+        <span className="item">port :{childPort ?? "—"}{backendUrl ? <span title={backendUrl}> · {backendUrl}</span> : null}</span>
+        {coresGroup && <><span className="sep">·</span><span className="item">{coresGroup}</span></>}
+        {pending && (
+          <>
+            <span className="npu-stack-spacer" />
+            <span className="npu-pending" title="flm_args apply on the next FLM load">⟳ reload to apply</span>
+            <button className="btn ghost sm" disabled={busy || !chat} onClick={onReload}>Reload</button>
+          </>
+        )}
       </div>
     </div>
   );
 }
 
 // ─── Slots view ───
-function SlotsView({ slotVariant, npuVariant, slotParam, onGo }) {
+function SlotsView({ slotVariant, slotParam, onGo }) {
   const slotsQuery = useSlots();
   // Single source of truth: the hook. The Playwright apiMock fixture
   // fulfils /api/slots so mock-mode coverage is symmetric with live runs;
@@ -676,7 +802,6 @@ function SlotsView({ slotVariant, npuVariant, slotParam, onGo }) {
     embed: slots.filter(s => s.group === "embed"),
     voice: slots.filter(s => s.group === "voice"),
     img:   slots.filter(s => s.group === "img"),
-    npu:   slots.filter(s => s.group === "npu"),
   };
 
   const editSlot = (slots || []).find(s => s.name === editName);
@@ -923,13 +1048,13 @@ function SlotsView({ slotVariant, npuVariant, slotParam, onGo }) {
           {renderGroup("Voice", groups.voice)}
           {renderGroup("Image", groups.img)}
 
-          {groups.npu.length > 0 && (
+          {slots.some(s => s.device === "npu") && (
             <section style={{marginBottom: 24}}>
               <div className="sec">
                 <h2>NPU<span className="ct mono">trio · 1 process · 3 roles</span></h2>
                 <div className="rule" />
               </div>
-              {npuVariant === "reactor" ? <NpuReactor slots={slots} /> : <NpuBlock slots={slots} />}
+              <NpuFlmStack slots={slots} />
             </section>
           )}
         </div>
@@ -960,4 +1085,4 @@ function SlotsView({ slotVariant, npuVariant, slotParam, onGo }) {
   );
 }
 
-Object.assign(window, { SlotsView, SlotCard, SlotListRow, NpuBlock, NpuReactor, Spark });
+Object.assign(window, { SlotsView, SlotCard, SlotListRow, NpuFlmStack, Spark });

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -1781,165 +1781,95 @@ a { color: inherit; text-decoration: none; }
 .slot.spec .slot-met .v { font-size: 22px; }
 
 /* NPU trio card */
-.npu-card {
-  background: linear-gradient(135deg, var(--bg-1) 0%, color-mix(in oklab, rgba(200, 150, 255, 0.06) 100%, var(--bg-1)) 100%);
-  border: 1px solid var(--line);
-  border-radius: var(--rad-lg);
-  overflow: hidden;
-  position: relative;
+/* ── NPU · FLM Stack (Variant B — bracketed trio control surface) ──────
+   Replaces the read-only NpuBlock/NpuReactor. One FLM process packs
+   chat + ASR + embed coresident; this section drives the stack. */
+.npu-stack { display: flex; flex-direction: column; gap: 12px; }
+
+.npu-stack-h {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
-.npu-card.live { border-color: rgba(200, 150, 255, 0.30); }
-.npu-card::before {
-  content: ""; position: absolute; inset: 0;
-  background: radial-gradient(circle at 0% 0%, rgba(200, 150, 255, 0.08), transparent 50%);
+.npu-stack-h .title {
+  font-family: var(--jbm);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+  letter-spacing: 0.02em;
+}
+.npu-stack-spacer { flex: 1; }
+.npu-stack-master-lbl { font-size: 11px; color: var(--fg-3); text-transform: uppercase; letter-spacing: 0.08em; }
+
+/* The left bracket that binds the trio "boots together". */
+.npu-bracket { position: relative; padding-left: 18px; }
+.npu-bracket-rail {
+  position: absolute;
+  left: 0; top: 6px; bottom: 6px;
+  width: 10px;
+  border-left: 2px solid var(--dev-npu);
+  border-top: 2px solid var(--dev-npu);
+  border-bottom: 2px solid var(--dev-npu);
+  border-radius: 6px 0 0 6px;
+  opacity: 0.45;
   pointer-events: none;
 }
-.npu-h {
-  padding: 14px 18px;
-  border-bottom: 1px solid var(--line-soft);
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  position: relative;
-}
-.npu-h .npu-glyph {
-  width: 32px; height: 32px;
-  border: 1px solid rgba(200, 150, 255, 0.40);
-  border-radius: 3px;
-  background: rgba(200, 150, 255, 0.08);
-  font-family: var(--jbm);
-  font-size: 10px;
-  color: var(--dev-npu);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  letter-spacing: 0.05em;
-  font-weight: 600;
-}
-.npu-h .title { font-family: var(--jbm); font-size: 14px; font-weight: 500; color: var(--fg); }
-.npu-h .title .sub { color: var(--fg-3); font-weight: 400; font-size: 11.5px; margin-left: 8px; }
-.npu-h .right { margin-left: auto; display: flex; align-items: center; gap: 10px; }
-.npu-h .pid {
-  font-family: var(--jbm);
-  font-size: 10px;
-  color: var(--fg-4);
-  padding: 2px 7px;
+.npu-trio { display: flex; gap: 10px; align-items: stretch; }
+
+/* Each modality mini-card reuses the .slot visual language. */
+.npu-mod { flex: 1; min-width: 0; transition: opacity 0.15s, border-color 0.15s; }
+.npu-mod[data-on="1"] { border-color: rgba(200, 150, 255, 0.30); }
+.npu-mod[data-on="0"] { opacity: 0.5; }
+.npu-mod .npu-mod-icon { font-size: 15px; line-height: 1; }
+.npu-mod-body { padding: 8px 0 2px; }
+.npu-sel { width: 100%; }
+
+/* On/off switch (matches prototype). */
+.npu-switch {
+  width: 42px; height: 24px;
+  border-radius: 999px;
   border: 1px solid var(--line);
-  border-radius: 3px;
-}
-
-.npu-body { display: flex; flex-direction: column; }
-.npu-subrow {
-  display: grid;
-  grid-template-columns: 14px 120px 1fr 130px 100px;
-  gap: 14px;
-  align-items: center;
-  padding: 14px 18px;
-  border-bottom: 1px solid var(--line-soft);
-  font-family: var(--jbm);
+  background: var(--bg-3);
   position: relative;
+  cursor: pointer;
+  flex: 0 0 auto;
+  padding: 0;
+  transition: background 0.15s, border-color 0.15s;
 }
-.npu-subrow:last-child { border-bottom: none; }
-.npu-subrow.lead { background: rgba(200, 150, 255, 0.04); }
-.npu-subrow .role { color: var(--fg); font-size: 13px; font-weight: 500; }
-.npu-subrow .role .sub { color: var(--fg-4); font-size: 10px; display: block; margin-top: 2px; font-weight: 400; }
-.npu-subrow .model { color: var(--fg-2); font-size: 12px; display: flex; align-items: center; gap: 8px; }
-.npu-subrow .model .chev { color: var(--fg-4); cursor: pointer; }
-.npu-subrow .met { color: var(--fg-3); font-size: 11.5px; }
-.npu-subrow .met b { color: var(--fg); font-weight: 500; }
-.npu-subrow .st { display: flex; justify-content: flex-end; }
+.npu-switch[data-on="1"] { background: var(--dev-npu); border-color: var(--dev-npu); }
+.npu-switch:disabled { opacity: 0.5; cursor: not-allowed; }
+.npu-switch .knob {
+  position: absolute;
+  top: 2px; left: 2px;
+  width: 18px; height: 18px;
+  border-radius: 999px;
+  background: #fff;
+  transition: left 0.15s;
+}
+.npu-switch[data-on="1"] .knob { left: 20px; }
 
-.npu-foot {
-  padding: 12px 18px;
-  background: var(--bg);
-  border-top: 1px solid var(--line-soft);
-  font-family: var(--jbm);
-  font-size: 11px;
-  color: var(--fg-4);
+.npu-stack-foot {
   display: flex;
   align-items: center;
-  gap: 14px;
-}
-.npu-foot .item { display: inline-flex; align-items: center; gap: 6px; }
-.npu-foot .item b { color: var(--fg-2); font-weight: 500; }
-
-/* NPU reactor variant */
-.npu-reactor {
-  position: relative;
-  padding: 24px 24px;
-  display: grid;
-  grid-template-columns: 200px 1fr;
-  gap: 24px;
-  align-items: center;
-}
-.reactor-core {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-}
-.reactor-disc {
-  width: 140px; height: 140px;
-  border: 1px solid rgba(200, 150, 255, 0.40);
-  border-radius: 50%;
-  background:
-    radial-gradient(circle at center, rgba(200, 150, 255, 0.12), transparent 70%),
-    var(--bg);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-}
-.reactor-disc::before, .reactor-disc::after {
-  content: ""; position: absolute; inset: 12px;
-  border: 1px dashed rgba(200, 150, 255, 0.20);
-  border-radius: 50%;
-}
-.reactor-disc::after { inset: 28px; opacity: 0.5; }
-.reactor-disc .lbl { font-family: var(--jbm); font-size: 11px; color: var(--dev-npu); text-align: center; letter-spacing: 0.05em; position: relative; z-index: 2; }
-.reactor-disc .lbl b { display: block; font-size: 15px; color: var(--fg); margin-top: 2px; }
-.reactor-meta { font-family: var(--jbm); font-size: 10px; color: var(--fg-4); text-align: center; }
-.reactor-roles { display: flex; flex-direction: column; gap: 8px; }
-.reactor-role {
-  display: grid;
-  grid-template-columns: 16px 110px 1fr auto;
-  gap: 12px;
-  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
   padding: 10px 12px;
   background: var(--bg);
   border: 1px solid var(--line-soft);
-  border-radius: var(--rad);
-  font-family: var(--jbm);
-  font-size: 12px;
+  border-radius: var(--rad-sm);
+  font-size: 11px;
+  color: var(--fg-4);
 }
-.reactor-role.lead { border-color: rgba(200, 150, 255, 0.30); }
-.reactor-role .lbl { color: var(--fg); font-weight: 500; }
-.reactor-role .lbl .sub { color: var(--fg-4); font-size: 10px; display: block; margin-top: 1px; font-weight: 400; }
-.reactor-role .md { color: var(--fg-2); font-size: 11.5px; }
-.reactor-role .met { color: var(--fg-3); font-size: 11px; text-align: right; }
-
-/* NPU stack variant */
-.npu-stack { padding: 0; }
-.npu-stack-lead {
-  padding: 20px 22px;
-  border-bottom: 1px solid var(--line-soft);
-  background: rgba(200, 150, 255, 0.06);
+.npu-stack-foot .npu-args { color: var(--dev-npu); font-size: 11.5px; }
+.npu-stack-foot .item { display: inline-flex; align-items: center; gap: 6px; }
+.npu-stack-foot .sep { color: var(--fg-5); }
+.npu-pending {
+  color: var(--warn);
+  font-size: 11px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
-.npu-stack-lead .role { font-family: var(--jbm); font-size: 10px; color: var(--dev-npu); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 6px; }
-.npu-stack-lead .model { font-family: var(--jbm); font-size: 18px; font-weight: 500; color: var(--fg); letter-spacing: -0.02em; margin-bottom: 8px; }
-.npu-stack-lead .met { display: flex; gap: 16px; font-family: var(--jbm); font-size: 11px; color: var(--fg-3); }
-.npu-stack-lead .met b { color: var(--fg); font-weight: 500; }
-.npu-stack-passengers { display: grid; grid-template-columns: 1fr 1fr; }
-.npu-stack-pass {
-  padding: 14px 22px;
-  border-right: 1px solid var(--line-soft);
-  font-family: var(--jbm);
-}
-.npu-stack-pass:last-child { border-right: none; }
-.npu-stack-pass .role { font-size: 10px; color: var(--fg-4); text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 4px; }
-.npu-stack-pass .md { font-size: 13px; color: var(--fg); margin-bottom: 4px; }
-.npu-stack-pass .met { font-size: 11px; color: var(--fg-3); }
 
 /* ════════════════════════════════════════════════════════════════════
    Models view
@@ -2201,9 +2131,7 @@ a { color: inherit; text-decoration: none; }
   .fr-confirm-row .tag { display: none; }
   .s-row { grid-template-columns: 1fr; }
   .s-tool-row { grid-template-columns: 1fr; }
-  .npu-subrow { grid-template-columns: 14px 1fr; }
-  .npu-subrow .model, .npu-subrow .met, .npu-subrow .st { display: none; }
-  .reactor { grid-template-columns: 1fr; }
+  .npu-trio { flex-direction: column; }
   .dash { grid-template-columns: 1fr; }
   .dash-side { position: static; display: flex; flex-direction: column; gap: 12px; }
   .dash-5050 { grid-template-columns: 1fr; }

--- a/ui/src/stores/useTweaksStore.ts
+++ b/ui/src/stores/useTweaksStore.ts
@@ -14,7 +14,6 @@ const IS_DEV = !!(import.meta.env && (import.meta.env as any).DEV)
 
 export interface TweaksState {
   slotCardVariant: 'a' | 'b' | 'c' | 'instrument' | 'list' | 'spec'
-  npuVariant: 'block' | 'reactor'
   heroStrip: 'sparkline' | 'metrics' | 'minimal'
   composerState: 'idle' | 'sending' | 'streaming' | 'swap' | 'no-tools' | 'offline'
   firstrunLayout: 'tiers' | 'wizard' | 'grid' | 'table'
@@ -28,7 +27,6 @@ export interface TweaksState {
 
 const DEFAULTS: TweaksState = {
   slotCardVariant: 'instrument',
-  npuVariant: 'block',
   heroStrip: 'sparkline',
   composerState: 'idle',
   firstrunLayout: 'grid',


### PR DESCRIPTION
## What

Adds an **interactive NPU / FLM stack control section** to the dashboard slots view (the "Variant B" bracketed-trio design), replacing the read-only `NpuBlock`/`NpuReactor`. From the dashboard you can now pick the FLM chat model, toggle the ASR/embed coresident modalities, and load/unload the whole FLM process.

Also lands the two design specs that scoped this work.

## Why

The NPU runs **one FLM process** packing chat + ASR + embed coresident; loaded when the NPU chat slot starts with `flm.args = "--asr 1 --embed 1"`. The dashboard could only *display* the trio — not control it. This is the control surface.

## Changes

- **`docs/superpowers/specs/`** — Spec 1 (slot edit controls + Capabilities grid) and Spec 2 (NPU/FLM stack section) design docs.
- **Backend** (`lemonade_admin.py`): relaxed `flm_args` validation so chat-only / single-modality stacks are valid (`--asr 0` / `--embed 0` accepted; only malformed non-0/1 values rejected). 3 mandate tests flipped to the relaxed contract + a malformed-rejection test added (5 pass).
- **Frontend** (`slots.jsx`, `dashboard.css`): new `NpuFlmStack` component — chat-anchored (resolved by `device==="npu" && type==="llm"`, never literal names), ASR/embed coresident toggles that **dual-write** lemond `flm_args` + the shadow slot's `enabled` flag (kept in sync so `v1._is_npu_trio_request` gating matches), master load/unload switch, FLM-namespace model pickers, live `flm.args` + child-port footer, and a pending "⟳ reload to apply" hint. Removed the now-dead `npuVariant` Tweaks radio (`main.jsx`, `useTweaksStore.ts`).

## Verification

- `npm run typecheck` clean, `npm run build` green.
- Backend: targeted pytest 5 passed.
- **Live against CT105**: section renders with the real `qwen3-it-4b-FLM` anchor, master switch, toggles reflecting `flm.args = "--asr 1 --embed 1"`, port `:8088`. No app console errors.
- Code-reviewed: top-level `enabled` persistence through `PUT /config` confirmed; no rules-of-hooks issues; flm_args round-trip correct; no dangling refs.

## Scope / follow-ups (not in this PR)

- **Phase 2**: route `device=npu` embed/STT capability selections *into* the trio (add `asr` to `_NPU_FANOUT_CAPS`, orchestrator NPU-awareness, optional transactional `POST /api/npu/stack`). Today, with no npu-device asr/embed slots, those two cards degrade to disabled "—" pickers.
- **FLM model surfacing**: `/api/models` returns 0 FLM models on the reference box → FLM pickers are empty (registry surfacing gap).
- **VibeVoice TTS provider**: dependency for the full voice stack (catalogued, not implemented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
