### PR TITLE
test(npu): fix flm_args aggregation test broken by #563 (main is red)

### DIFF
--- a/tests/api/test_lemonade_admin_route.py
+++ b/tests/api/test_lemonade_admin_route.py
@@ -460,7 +460,10 @@ def test_post_config_aggregates_multiple_validation_errors(
         "/api/lemonade/config",
         json={
             "llamacpp_args": "--parallel 1",
-            "flm_args": "--asr 1",
+            # `--asr 1` is now VALID (Spec 2 relaxation); use a malformed
+            # non-binary value so flm_args still fails and the aggregation
+            # of multiple errors is exercised.
+            "flm_args": "--asr 2",
             "rocm_channel": "nightly",
         },
     )


### PR DESCRIPTION
**Fixes red `main`.** PR #563 merged with a failing test: `test_post_config_aggregates_multiple_validation_errors` sent `flm_args: "--asr 1"` expecting it to be *invalid* (old FLM-trio mandate), but #563 relaxed `flm_args` validation so `--asr 1` is now valid → `flm_args` dropped out of the aggregated-errors set and the assertion fails on `python (3.11)` + `python (3.12)`.

Switches that case to malformed `--asr 2` (still invalid → still exercises the 3-keys-fail-at-once aggregation). Test-only, one line.

Verified locally: `pytest -k "aggregates_multiple or flm_args"` → 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)