### PR TITLE
fix(hardware): cgroup-v2 LXC detection + memory.max headroom (#371,#372)

### DIFF
--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -81,6 +81,11 @@ def _flatten_for_ui(info: dict[str, Any]) -> dict[str, Any]:
         "platform": platform,
         "platform_label": _platform_label(platform, primary_gpu),
         "memory_kind": memory_kind,
+        # cgroup memory cap (issue #372). The dashboard treats this as a
+        # 3rd headroom candidate: when BELOW min(pool, host) it becomes
+        # the binding constraint and limitedBy is reported as 'cgroup'.
+        # ``None`` means "unlimited" — cgroup doesn't constrain headroom.
+        "cgroup_max_mb": info.get("cgroup_max_mb"),
     }
 
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -649,6 +649,20 @@ class HardwareInfo(BaseModel):
         ge=0,
         description="Free space on /var/lib/hal0 in MiB.",
     )
+    cgroup_max_mb: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Running cgroup memory cap in MiB (issue #372). Read at probe "
+            "time from /sys/fs/cgroup/memory.max (cgroup-v2) or the v1 "
+            "fallback /sys/fs/cgroup/memory/memory.limit_in_bytes. None "
+            "when the cgroup is unlimited (literal 'max' on v2, the "
+            "9223372036854775807 sentinel on v1) or the file is unreadable. "
+            "The dashboard treats this as a 3rd headroom candidate: when "
+            "BELOW min(pool, host) it becomes the binding constraint and "
+            "limitedBy is reported as 'cgroup'."
+        ),
+    )
     probed_at: str = Field(
         default="",
         description="ISO-8601 UTC timestamp of the last probe run.",

--- a/src/hal0/hardware/probe.py
+++ b/src/hal0/hardware/probe.py
@@ -289,6 +289,55 @@ def _derive_unified_memory_mb(ram_mb: int, gpu: GPUInfo | None) -> int:
     return ram_mb
 
 
+# cgroup memory cap paths (issue #372). v2 unified hosts use memory.max;
+# v1 hybrid hosts expose memory.limit_in_bytes under /sys/fs/cgroup/memory/.
+# v2 is the canonical location on a unified host — we read it first and
+# only fall through to v1 when v2 is missing.
+_CGROUP_V2_MEMORY_MAX = Path("/sys/fs/cgroup/memory.max")
+_CGROUP_V1_MEMORY_LIMIT = Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+# cgroup-v1's "infinite" sentinel. The kernel writes this when no limit is
+# configured; treat it the same as the v2 literal "max" — unlimited, ignore.
+_CGROUP_V1_INFINITE = 9_223_372_036_854_775_807
+
+
+def _read_cgroup_memory_max_mb() -> int | None:
+    """Return the running cgroup's memory cap in MiB, or None when unlimited.
+
+    The cgroup cap is a 3rd headroom candidate (issue #372): when below
+    min(pool, host) it becomes the binding constraint. On cgroup-v2 the
+    file holds a literal ``"max"`` (= unlimited) or a byte count; on
+    cgroup-v1 the byte count uses a 9223… sentinel for "unlimited".
+
+    Unreadable, unparseable, or "unlimited" → ``None`` (no constraint).
+    Never raises.
+    """
+    for path, sentinel_unlimited in (
+        (_CGROUP_V2_MEMORY_MAX, "max"),
+        (_CGROUP_V1_MEMORY_LIMIT, None),  # v1 uses the numeric sentinel
+    ):
+        txt = _read_text(path)
+        if txt is None:
+            continue  # missing file → try the next candidate
+        stripped = txt.strip()
+        if not stripped:
+            return None  # zero-byte file — treat as "no constraint"
+        if sentinel_unlimited is not None and stripped == sentinel_unlimited:
+            return None
+        try:
+            n = int(stripped)
+        except ValueError:
+            log.debug(
+                "hardware.probe.cgroup_memory_max_parse_fail",
+                path=str(path),
+                raw=stripped[:40],
+            )
+            return None
+        if n < 0 or n == _CGROUP_V1_INFINITE:
+            return None
+        return n // (1024 * 1024)
+    return None
+
+
 # ── GPU detection ──────────────────────────────────────────────────────────────
 
 
@@ -680,6 +729,7 @@ class HardwareProbe:
                 gpus=[gpu] if include_gpu else [],
                 npu=npu,
                 disk_free_mb=disk_mb,
+                cgroup_max_mb=_read_cgroup_memory_max_mb(),
                 platform=platform,
                 probed_at=_dt.datetime.now(_dt.UTC).isoformat(timespec="seconds"),
                 # kernel is now a first-class field; keep it in extra too for

--- a/src/hal0/hardware/pve.py
+++ b/src/hal0/hardware/pve.py
@@ -221,6 +221,9 @@ class PveDetectionState(StrEnum):
 # Module-level Paths so tests can monkeypatch the read sources.
 _PROC_VERSION = Path("/proc/version")
 _PROC_1_CGROUP = Path("/proc/1/cgroup")
+_PROC_1_ENVIRON = Path("/proc/1/environ")
+_DEV_LXC = Path("/dev/.lxc")
+_RUN_SYSTEMD_CONTAINER = Path("/run/systemd/container")
 
 
 def _has_pve_kernel() -> bool:
@@ -230,24 +233,72 @@ def _has_pve_kernel() -> bool:
         return False
 
 
+def _lxc_via_cgroup_v1(text: str) -> bool:
+    """Legacy cgroup-v1 pattern: lxc.payload.<vmid>/… or /lxc/<vmid>/…"""
+    return "lxc.payload" in text or "/lxc/" in text
+
+
+def _lxc_via_cgroup_v2_marker() -> bool:
+    """cgroup-v2 unified LXCs have a /init.scope cgroup path that looks
+    identical to a systemd host's. Distinguish them with a corroborating
+    container marker — env, /dev/.lxc, or systemd's container file. The
+    cgroup path alone is not enough: a cgroup-v2 systemd host also reads
+    ``0::/init.scope`` and we MUST NOT false-positive as LXC.
+    """
+    # /proc/1/environ uses NUL separators, not newlines.
+    try:
+        env = _PROC_1_ENVIRON.read_text(errors="ignore")
+    except OSError:
+        env = ""
+    if env and "container=lxc" in env.replace("\x00", " "):
+        return True
+    try:
+        if _DEV_LXC.exists():
+            return True
+    except OSError:
+        pass
+    try:
+        text = _RUN_SYSTEMD_CONTAINER.read_text(errors="ignore")
+    except OSError:
+        text = ""
+    return "lxc" in text.lower().strip()
+
+
 def _is_lxc_init() -> bool:
     try:
         text = _PROC_1_CGROUP.read_text(errors="ignore")
     except OSError:
         return False
-    # Proxmox LXCs put init under lxc.payload.<vmid>/… or /lxc/<vmid>/…
-    return "lxc.payload" in text or "/lxc/" in text
+    # Proxmox LXC: cgroup-v1 puts init under lxc.payload.<vmid>/… or /lxc/<vmid>/…
+    if _lxc_via_cgroup_v1(text):
+        return True
+    # cgroup-v2 unified LXCs (hal0 LXC): /proc/1/cgroup reads 0::/init.scope
+    # — identical to a systemd host. Escalate only when a positive container
+    # marker (env, /dev/.lxc, systemd/container) confirms we're inside a
+    # container at all.
+    if "0::/" in text:
+        return _lxc_via_cgroup_v2_marker()
+    return False
 
 
 def detect_proxmox_host() -> PveDetectionState:
     """Best-effort detection of whether hal0 is running inside a Proxmox LXC.
 
     Signals (each independent, none requires shelling out):
-      - /proc/version contains '-pve'   (strong)
-      - /proc/1/cgroup is lxc-shaped    (medium)
+      - /proc/version contains '-pve'                       (strong)
+      - /proc/1/cgroup matches the cgroup-v1 lxc.payload /  (medium)
+        /lxc/ pattern
+      - /proc/1/cgroup is cgroup-v2 shaped AND any of         (medium)
+        ``container=lxc`` in /proc/1/environ,
+        /dev/.lxc exists, or /run/systemd/container = lxc
 
-    Both signals present → DETECTED. Either signal alone → UNCERTAIN. Neither → NOT_DETECTED.
-    Never raises; unreadable inputs collapse to NOT_DETECTED.
+    Both kernel + cgroup signals present → DETECTED. Either signal alone →
+    UNCERTAIN. Neither → NOT_DETECTED. Never raises; unreadable inputs
+    collapse to NOT_DETECTED.
+
+    Conservative on cgroup-v2: the cgroup path alone is not sufficient,
+    because a systemd host also reads ``0::/init.scope``. We only
+    escalate to DETECTED when a corroborating container marker exists.
     """
     pve_kernel = _has_pve_kernel()
     lxc_init = _is_lxc_init()

--- a/tests/api/test_hardware_routes.py
+++ b/tests/api/test_hardware_routes.py
@@ -108,6 +108,38 @@ def test_platform_label_for_known_strings() -> None:
     assert _platform_label("nonsense-value", {}) == "Unknown platform"
 
 
+# ── cgroup_max_mb surfacing (#372) ───────────────────────────────────────────
+
+
+def test_flatten_includes_cgroup_max_mb_when_set() -> None:
+    info = HardwareInfo(
+        cpu_model="x86_64",
+        ram_mb=96 * 1024,
+        unified_memory_mb=96 * 1024,
+        gpus=[],
+        npu=NPUInfo(present=False),
+        platform="lxc",
+        cgroup_max_mb=80 * 1024,
+    ).model_dump(mode="python")
+    flat = _flatten_for_ui(info)
+    assert flat["cgroup_max_mb"] == 80 * 1024
+
+
+def test_flatten_cgroup_max_mb_none_when_unlimited() -> None:
+    info = HardwareInfo(
+        cpu_model="x86_64",
+        ram_mb=96 * 1024,
+        unified_memory_mb=96 * 1024,
+        gpus=[],
+        npu=NPUInfo(present=False),
+        platform="lxc",
+    ).model_dump(mode="python")
+    flat = _flatten_for_ui(info)
+    # When unlimited/unreadable, the field is absent (or None) — the UI
+    # falls back to pool/host as if cgroup weren't a constraint.
+    assert flat.get("cgroup_max_mb") in (None,)
+
+
 class TestHostDetectionInStatsHardware:
     """When proxmox.json is missing, /api/stats/hardware surfaces detection
     state so the dashboard's MemoryMap can render a Configure → nudge."""

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -45,6 +45,7 @@ from hal0.config.schema import (
     Hal0Config,
     HardwareInfo,
     MetaConfig,
+    NPUInfo,
     ProviderEntry,
     ProvidersConfig,
     SlotConfig,
@@ -358,6 +359,24 @@ class TestHardwareJsonRoundTrip:
         assert loaded.cpu_cores == 16
         assert len(loaded.gpus) == 1
         assert loaded.gpus[0].name == "RTX 4080"
+
+    def test_cgroup_max_mb_round_trips(self, tmp_hal0_home: str) -> None:
+        """The cgroup cap is part of the probe snapshot (#372) — make
+        sure it round-trips through the JSON file so the dashboard can
+        see it after a probe + restart."""
+        h = HardwareInfo(
+            cpu_model="AMD Ryzen",
+            cpu_cores=16,
+            cpu_threads=32,
+            ram_mb=96 * 1024,
+            unified_memory_mb=96 * 1024,
+            gpus=[],
+            npu=NPUInfo(present=False),
+            cgroup_max_mb=80 * 1024,
+        )
+        save_hardware_info(h)
+        loaded = load_hardware_info()
+        assert loaded.cgroup_max_mb == 80 * 1024
 
     def test_load_with_invalid_json_raises(self, tmp_hal0_home: str) -> None:
         paths.hardware_json().parent.mkdir(parents=True, exist_ok=True)

--- a/tests/hardware/test_probe.py
+++ b/tests/hardware/test_probe.py
@@ -703,3 +703,120 @@ def test_detect_lspci_fallback_handles_display_controller(
     info = probe_mod._detect_lspci_fallback()
     assert info is not None
     assert "Microsoft" in info.name
+
+
+# ── cgroup memory.max reader (#372) ──────────────────────────────────────────
+# The running LXC's cgroup memory cap is a candidate headroom constraint.
+# On cgroup-v2 /sys/fs/cgroup/memory.max holds a literal "max" (unlimited)
+# or an integer byte count. On cgroup-v1 the equivalent is
+# /sys/fs/cgroup/memory/memory.limit_in_bytes, with the "infinite" sentinel
+# 9223372036854775807. Both missing → None (no behavior change).
+
+_CGROUP_V2_PATH = "/sys/fs/cgroup/memory.max"
+_CGROUP_V1_PATH = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+
+
+def test_cgroup_v2_returns_mib(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 16 GiB = 16 * 1024 * 1024 * 1024 = 17_179_869_184 bytes
+    limit_bytes = 16 * 1024 * 1024 * 1024
+    table = {_CGROUP_V2_PATH: str(limit_bytes), _CGROUP_V1_PATH: None}
+    monkeypatch.setattr(probe_mod, "_read_text", lambda p: table.get(str(p)))
+    out = probe_mod._read_cgroup_memory_max_mb()
+    assert out == 16 * 1024
+
+
+def test_cgroup_v2_max_literal_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """cgroup-v2 signals 'unlimited' with the literal string 'max'."""
+    table = {_CGROUP_V2_PATH: "max\n"}
+    monkeypatch.setattr(probe_mod, "_read_text", lambda p: table.get(str(p)))
+    assert probe_mod._read_cgroup_memory_max_mb() is None
+
+
+def test_cgroup_v1_returns_mib(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 8 GiB in bytes
+    limit_bytes = 8 * 1024 * 1024 * 1024
+    table = {_CGROUP_V2_PATH: None, _CGROUP_V1_PATH: str(limit_bytes)}
+    monkeypatch.setattr(probe_mod, "_read_text", lambda p: table.get(str(p)))
+    out = probe_mod._read_cgroup_memory_max_mb()
+    assert out == 8 * 1024
+
+
+def test_cgroup_v1_infinite_sentinel_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cgroup-v1 reports the 'infinite' limit as 9223372036854775807."""
+    table = {
+        _CGROUP_V2_PATH: None,
+        _CGROUP_V1_PATH: "9223372036854775807\n",
+    }
+    monkeypatch.setattr(probe_mod, "_read_text", lambda p: table.get(str(p)))
+    assert probe_mod._read_cgroup_memory_max_mb() is None
+
+
+def test_cgroup_v2_takes_precedence_over_v1(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If both files are present, trust v2 (it's the canonical location
+    on a cgroup-v2 unified host — v1 is just a compat shim)."""
+    v2_bytes = 4 * 1024 * 1024 * 1024
+    v1_bytes = 8 * 1024 * 1024 * 1024
+    table = {
+        _CGROUP_V2_PATH: str(v2_bytes),
+        _CGROUP_V1_PATH: str(v1_bytes),
+    }
+    monkeypatch.setattr(probe_mod, "_read_text", lambda p: table.get(str(p)))
+    out = probe_mod._read_cgroup_memory_max_mb()
+    assert out == 4 * 1024
+
+
+def test_cgroup_missing_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No v2, no v1 → None (caller treats as 'no constraint')."""
+    monkeypatch.setattr(probe_mod, "_read_text", lambda _: None)
+    assert probe_mod._read_cgroup_memory_max_mb() is None
+
+
+def test_cgroup_garbage_value_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A file that exists but doesn't parse as an int must not crash."""
+    table = {_CGROUP_V2_PATH: "not a number\n"}
+    monkeypatch.setattr(probe_mod, "_read_text", lambda p: table.get(str(p)))
+    assert probe_mod._read_cgroup_memory_max_mb() is None
+
+
+def test_cgroup_empty_string_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty content (zero-byte file, or read that landed mid-stream)
+    must be treated as 'no constraint', not as 0 MiB."""
+    table = {_CGROUP_V2_PATH: ""}
+    monkeypatch.setattr(probe_mod, "_read_text", lambda p: table.get(str(p)))
+    assert probe_mod._read_cgroup_memory_max_mb() is None
+
+
+def test_probe_populates_cgroup_max_mb(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: HardwareProbe.probe() picks up the cgroup max so the
+    /api/hardware response can surface cgroup_max_mb to the dashboard."""
+    monkeypatch.setattr(probe_mod, "_parse_cpuinfo", lambda: ("CPU", 4, 4))
+    monkeypatch.setattr(probe_mod, "_parse_meminfo", lambda: (16384, 12000))
+    monkeypatch.setattr(probe_mod, "_detect_gpu", lambda: GPUInfo(vendor="unknown"))
+    monkeypatch.setattr(probe_mod, "_detect_npu", lambda: probe_mod.NPUInfo(present=False))
+    monkeypatch.setattr(probe_mod, "_disk_free_mb", lambda _: 1024)
+    monkeypatch.setattr(probe_mod, "_read_text", lambda _: None)
+    monkeypatch.setattr(probe_mod, "_detect_platform", lambda *_: "lxc")
+    monkeypatch.setattr(probe_mod, "_read_cgroup_memory_max_mb", lambda: 12 * 1024)
+
+    info = HardwareProbe().probe()
+    assert info.cgroup_max_mb == 12 * 1024
+
+
+def test_probe_cgroup_max_mb_none_when_unlimited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unlimited cgroup (literal 'max') → field stays None so the UI
+    falls back to pool/host without the cgroup constraint."""
+    monkeypatch.setattr(probe_mod, "_parse_cpuinfo", lambda: ("CPU", 4, 4))
+    monkeypatch.setattr(probe_mod, "_parse_meminfo", lambda: (16384, 12000))
+    monkeypatch.setattr(probe_mod, "_detect_gpu", lambda: GPUInfo(vendor="unknown"))
+    monkeypatch.setattr(probe_mod, "_detect_npu", lambda: probe_mod.NPUInfo(present=False))
+    monkeypatch.setattr(probe_mod, "_disk_free_mb", lambda _: 1024)
+    monkeypatch.setattr(probe_mod, "_read_text", lambda _: None)
+    monkeypatch.setattr(probe_mod, "_detect_platform", lambda *_: "lxc")
+    monkeypatch.setattr(probe_mod, "_read_cgroup_memory_max_mb", lambda: None)
+
+    info = HardwareProbe().probe()
+    assert info.cgroup_max_mb is None

--- a/tests/hardware/test_pve.py
+++ b/tests/hardware/test_pve.py
@@ -403,3 +403,121 @@ class TestDetectProxmoxHost:
         # _PROC_1_CGROUP raise when the helpers try to read them.
         with patch.object(Path, "read_text", side_effect=PermissionError("denied")):
             assert pve.detect_proxmox_host() == pve.PveDetectionState.NOT_DETECTED
+
+    # ── cgroup-v2 unified LXC detection (#371) ────────────────────────────
+    # On cgroup-v2 unified hosts (hal0 LXC) /proc/1/cgroup reads
+    # "0::/init.scope" — not the "lxc.payload" or "/lxc/" pattern the
+    # original heuristic looked for. An LXC is misclassified as the host.
+    # The fix accepts corroborating signals: container=lxc env, /dev/.lxc,
+    # or /run/systemd/container. Only escalate to DETECTED when at least
+    # one positive container marker is present.
+
+    def test_returns_detected_on_cgroup_v2_lxc_via_environ(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        version = tmp_path / "version"
+        version.write_text("Linux version 6.8.0-1-pve (builder@…)\n")
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("0::/init.scope\n")
+        environ = tmp_path / "environ"
+        # /proc/1/environ uses NUL separators, not newlines
+        environ.write_bytes(b"PATH=/usr/bin\x00container=lxc\x00HOME=/root\x00")
+        monkeypatch.setattr(pve, "_PROC_VERSION", version)
+        monkeypatch.setattr(pve, "_PROC_1_CGROUP", cgroup)
+        monkeypatch.setattr(pve, "_PROC_1_ENVIRON", environ)
+        monkeypatch.setattr(pve, "_DEV_LXC", tmp_path / "missing-lxc-dir")
+        monkeypatch.setattr(pve, "_RUN_SYSTEMD_CONTAINER", tmp_path / "missing-systemd-file")
+        assert pve.detect_proxmox_host() == pve.PveDetectionState.DETECTED
+
+    def test_returns_detected_on_cgroup_v2_lxc_via_dev_lxc(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        version = tmp_path / "version"
+        version.write_text("Linux version 6.8.0-1-pve (builder@…)\n")
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("0::/init.scope\n")
+        environ = tmp_path / "environ"
+        environ.write_text("")
+        dev_lxc = tmp_path / "lxc"
+        dev_lxc.mkdir()
+        monkeypatch.setattr(pve, "_PROC_VERSION", version)
+        monkeypatch.setattr(pve, "_PROC_1_CGROUP", cgroup)
+        monkeypatch.setattr(pve, "_PROC_1_ENVIRON", environ)
+        monkeypatch.setattr(pve, "_DEV_LXC", dev_lxc)
+        monkeypatch.setattr(pve, "_RUN_SYSTEMD_CONTAINER", tmp_path / "missing-systemd-file")
+        assert pve.detect_proxmox_host() == pve.PveDetectionState.DETECTED
+
+    def test_returns_detected_on_cgroup_v2_lxc_via_systemd_container(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        version = tmp_path / "version"
+        version.write_text("Linux version 6.8.0-1-pve (builder@…)\n")
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("0::/init.scope\n")
+        environ = tmp_path / "environ"
+        environ.write_text("")
+        systemd_container = tmp_path / "systemd-container"
+        systemd_container.write_text("lxc\n")
+        monkeypatch.setattr(pve, "_PROC_VERSION", version)
+        monkeypatch.setattr(pve, "_PROC_1_CGROUP", cgroup)
+        monkeypatch.setattr(pve, "_PROC_1_ENVIRON", environ)
+        monkeypatch.setattr(pve, "_DEV_LXC", tmp_path / "missing-lxc-dir")
+        monkeypatch.setattr(pve, "_RUN_SYSTEMD_CONTAINER", systemd_container)
+        assert pve.detect_proxmox_host() == pve.PveDetectionState.DETECTED
+
+    def test_cgroup_v2_host_root_without_markers_is_not_detected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Bare-metal / non-PVE / non-LXC: cgroup-v2 reads 0::/ with no
+        container marker → still NOT_DETECTED. Don't false-positive on
+        a fresh cgroup-v2 host just because /proc/1/cgroup looks LXC-ish.
+        """
+        version = tmp_path / "version"
+        version.write_text("Linux version 6.10.5-arch1-1\n")  # not -pve
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("0::/\n")  # host root scope, not /init.scope
+        environ = tmp_path / "environ"
+        environ.write_text("")
+        monkeypatch.setattr(pve, "_PROC_VERSION", version)
+        monkeypatch.setattr(pve, "_PROC_1_CGROUP", cgroup)
+        monkeypatch.setattr(pve, "_PROC_1_ENVIRON", environ)
+        monkeypatch.setattr(pve, "_DEV_LXC", tmp_path / "missing-lxc-dir")
+        monkeypatch.setattr(pve, "_RUN_SYSTEMD_CONTAINER", tmp_path / "missing-systemd-file")
+        assert pve.detect_proxmox_host() == pve.PveDetectionState.NOT_DETECTED
+
+    def test_cgroup_v2_init_scope_without_markers_is_uncertain(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An /init.scope cgroup path looks container-like; combined with a
+        -pve kernel it should at least surface as UNCERTAIN. We do NOT
+        escalate to DETECTED without a positive container marker — that's
+        the conservative behaviour the issue calls for.
+        """
+        version = tmp_path / "version"
+        version.write_text("Linux version 6.8.0-1-pve (builder@…)\n")
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("0::/init.scope\n")
+        environ = tmp_path / "environ"
+        environ.write_text("")
+        monkeypatch.setattr(pve, "_PROC_VERSION", version)
+        monkeypatch.setattr(pve, "_PROC_1_CGROUP", cgroup)
+        monkeypatch.setattr(pve, "_PROC_1_ENVIRON", environ)
+        monkeypatch.setattr(pve, "_DEV_LXC", tmp_path / "missing-lxc-dir")
+        monkeypatch.setattr(pve, "_RUN_SYSTEMD_CONTAINER", tmp_path / "missing-systemd-file")
+        assert pve.detect_proxmox_host() == pve.PveDetectionState.UNCERTAIN
+
+    def test_legacy_lxc_payload_pattern_still_works(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cgroup-v1 / Proxmox-V1 path: lxc.payload.<vmid> still
+        short-circuits to DETECTED on a -pve kernel, just like before.
+        """
+        version = tmp_path / "version"
+        version.write_text("Linux version 5.15.0-1-pve\n")
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("12:devices:/lxc.payload.105\n")
+        monkeypatch.setattr(pve, "_PROC_VERSION", version)
+        monkeypatch.setattr(pve, "_PROC_1_CGROUP", cgroup)
+        # No need to monkeypatch the new signals — the legacy path
+        # already returns DETECTED before they are consulted.
+        assert pve.detect_proxmox_host() == pve.PveDetectionState.DETECTED

--- a/ui/src/dash/memory-map.jsx
+++ b/ui/src/dash/memory-map.jsx
@@ -223,7 +223,11 @@ export function useMemoryMapModel() {
 
   // ── Headroom ──
   // Pool free = unified cap minus model memory actually held. Host free
-  // can be the tighter constraint when running on Proxmox.
+  // can be the tighter constraint when running on Proxmox. The running
+  // LXC's cgroup memory cap is a third candidate (issue #372): when
+  // BELOW the current min(pool, host) it becomes the binding constraint.
+  // When unlimited / unreadable, cgroup_max_mb is null and the cgroup
+  // branch is a no-op.
   const poolHeadroom = unifiedGb - modelUsedGb
   let limitedBy = 'pool'
   let candidate = poolHeadroom
@@ -231,8 +235,17 @@ export function useMemoryMapModel() {
     candidate = host.freeGb
     limitedBy = 'host'
   }
-  // cgroup branch: best-effort, defer to follow-up issue. limitedBy stays
-  // pool/host today.
+  // cgroup branch: treat the running cgroup's memory.max as a third
+  // ceiling. Subtract the same modelUsedGb the pool already accounts
+  // for — the cgroup cap is a hard absolute, not a "free" figure.
+  const cgroupMaxMb = rawHw.cgroup_max_mb
+  if (cgroupMaxMb && Number.isFinite(cgroupMaxMb)) {
+    const cgroupFreeGb = mbToGb(cgroupMaxMb) - modelUsedGb
+    if (cgroupFreeGb < candidate) {
+      candidate = cgroupFreeGb
+      limitedBy = 'cgroup'
+    }
+  }
   const availableGb = Math.max(0, round1(candidate - SAFETY_MARGIN_GB))
 
   return {


### PR DESCRIPTION
Closes #371
Closes #372

cgroup-v2 unified LXCs (hal0 LXC reads `0::/init.scope`) were misdetected as host → MemoryMap 'uncertain'. `detect_proxmox_host` now corroborates with container markers (`container=lxc` env / `/dev/.lxc` / systemd container file), never false-positiving a cgroup-v2 systemd host. Adds cgroup `memory.max` as a 3rd headroom constraint (`limitedBy=cgroup` when below pool/host; unreadable/unlimited = no-op), surfaced in the MemoryMap.

Implemented by a MiniMax worker that hit its API rate limit before committing; orchestrator salvaged the 9-file diff, fixed a missing test import, verified 129 hardware/config tests + ruff green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)