### PR TITLE
harden(mcp): manifest stream-abort + patch_config lock (#381, #382)

### DIFF
--- a/src/hal0/mcp/installed.py
+++ b/src/hal0/mcp/installed.py
@@ -27,8 +27,10 @@ what the operator chose to install + their per-server env overrides.
 from __future__ import annotations
 
 import contextlib
+import fcntl
 import os
 import tomllib
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -256,6 +258,26 @@ def uninstall(server_id: str) -> None:
     log.info("hal0.mcp.installed.removed", server_id=server_id)
 
 
+@contextlib.contextmanager
+def _registry_lock(server_id: str) -> Iterator[None]:
+    """Advisory exclusive lock serializing read-modify-write on one server's
+    registry record (#382).
+
+    Two concurrent ``patch_config`` calls would otherwise interleave
+    read -> modify -> write and clobber each other's update. The lock is
+    held on a sibling ``<record>.lock`` file for the duration of the RMW.
+    """
+    target = _registry_path(server_id)
+    lock_path = target.parent / f"{target.name}.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "w") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
 def patch_config(
     server_id: str,
     *,
@@ -269,20 +291,21 @@ def patch_config(
     sends the full intended set, not a delta). ``enabled`` flips the
     flag without touching anything else.
     """
-    record = get_installed(server_id)
-    updates: dict[str, Any] = {}
-    if env is not None:
-        # Coerce values to strings — pydantic validates the type but the
-        # FastAPI body is permissive (numbers, bools, etc).
-        updates["env"] = {k: str(v) for k, v in env.items()}
-    if enabled is not None:
-        updates["enabled"] = bool(enabled)
-    if not updates:
-        return record
-    next_record = record.model_copy(update=updates)
-    target_path = _registry_path(server_id)
-    write_toml_atomic(target_path, next_record.to_toml_dict())
-    _harden_registry_perms(target_path)
+    with _registry_lock(server_id):
+        record = get_installed(server_id)
+        updates: dict[str, Any] = {}
+        if env is not None:
+            # Coerce values to strings — pydantic validates the type but the
+            # FastAPI body is permissive (numbers, bools, etc).
+            updates["env"] = {k: str(v) for k, v in env.items()}
+        if enabled is not None:
+            updates["enabled"] = bool(enabled)
+        if not updates:
+            return record
+        next_record = record.model_copy(update=updates)
+        target_path = _registry_path(server_id)
+        write_toml_atomic(target_path, next_record.to_toml_dict())
+        _harden_registry_perms(target_path)
     log.info(
         "hal0.mcp.installed.patched",
         server_id=server_id,

--- a/src/hal0/mcp/manifest.py
+++ b/src/hal0/mcp/manifest.py
@@ -34,6 +34,7 @@ render *something* for any plausibly-shaped paste.
 from __future__ import annotations
 
 import ipaddress
+import json
 import re
 import socket
 from collections.abc import Awaitable, Callable
@@ -380,17 +381,26 @@ async def _default_fetcher(url: str) -> Any:
     final URL directly.
     """
     _enforce_safe_url(url)
-    async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT, follow_redirects=False) as client:
-        resp = await client.get(url, headers={"Accept": "application/json"})
+    # Stream the body and abort the moment we cross the cap (#381) — a
+    # misbehaving server must not be able to make us buffer an unbounded
+    # response into memory before we reject it.
+    async with (
+        httpx.AsyncClient(timeout=_FETCH_TIMEOUT, follow_redirects=False) as client,
+        client.stream("GET", url, headers={"Accept": "application/json"}) as resp,
+    ):
         resp.raise_for_status()
-        # Bound body size so a misbehaving server can't stuff us.
-        body = resp.content
-        if len(body) > _MAX_MANIFEST_BYTES:
-            raise httpx.HTTPError(f"manifest body too large ({len(body)} > {_MAX_MANIFEST_BYTES})")
-        try:
-            return resp.json()
-        except ValueError:
-            return None
+        chunks: list[bytes] = []
+        total = 0
+        async for chunk in resp.aiter_bytes():
+            total += len(chunk)
+            if total > _MAX_MANIFEST_BYTES:
+                raise httpx.HTTPError(f"manifest body too large (> {_MAX_MANIFEST_BYTES})")
+            chunks.append(chunk)
+    body = b"".join(chunks)
+    try:
+        return json.loads(body)
+    except ValueError:
+        return None
 
 
 async def resolve(url: str, *, fetcher: HttpFetcher | None = None) -> ResolvedManifest:

--- a/tests/mcp/test_installed.py
+++ b/tests/mcp/test_installed.py
@@ -163,3 +163,18 @@ def test_validate_id_rejects_path_traversal(tmp_hal0_home: str) -> None:
     with pytest.raises(BadRequest) as exc:
         registry.uninstall("../evil")
     assert exc.value.code == "mcp.id_invalid"
+
+
+def test_patch_config_locked_rmw_applies(tmp_hal0_home: str) -> None:
+    """#382: patch_config wraps its read-modify-write in an advisory lock.
+
+    Functional guard that the locked RMW still applies env + enabled
+    updates and the write lands on disk (the lock must not swallow the
+    write or corrupt the record)."""
+    registry.install(_record("filesystem", enabled=True))
+    patched = registry.patch_config("filesystem", enabled=False, env={"FOO": "bar"})
+    assert patched.enabled is False
+    assert patched.env == {"FOO": "bar"}
+    reloaded = registry.get_installed("filesystem")
+    assert reloaded.enabled is False
+    assert reloaded.env == {"FOO": "bar"}

--- a/tests/mcp/test_manifest.py
+++ b/tests/mcp/test_manifest.py
@@ -207,3 +207,42 @@ async def test_resolve_caps_tools_count_at_4096() -> None:
 
     r = await manifest.resolve("https://example.com/m.json", fetcher=_fetch)
     assert r.tools == 4096
+
+
+@pytest.mark.asyncio
+async def test_default_fetcher_aborts_oversized_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#381: the production fetcher streams and aborts once cumulative body
+    bytes exceed _MAX_MANIFEST_BYTES, rather than buffering it all first."""
+    import httpx
+
+    monkeypatch.setattr(manifest, "_enforce_safe_url", lambda url: None)
+    monkeypatch.setattr(manifest, "_MAX_MANIFEST_BYTES", 32)
+
+    class _FakeResp:
+        def raise_for_status(self) -> None:
+            return None
+
+        async def aiter_bytes(self):
+            yield b"x" * 20
+            yield b"y" * 20  # cumulative 40 > 32 -> must abort here
+
+    class _FakeStream:
+        async def __aenter__(self):
+            return _FakeResp()
+
+        async def __aexit__(self, *a):
+            return False
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        def stream(self, *a, **k):
+            return _FakeStream()
+
+    monkeypatch.setattr(manifest.httpx, "AsyncClient", lambda *a, **k: _FakeClient())
+    with pytest.raises(httpx.HTTPError, match="too large"):
+        await manifest._default_fetcher("https://example.com/big.json")


### PR DESCRIPTION
Closes #381
Closes #382

**#381** — `_default_fetcher` streamed the whole response into `resp.content` before the `_MAX_MANIFEST_BYTES` check; a misbehaving server could make hal0 buffer an unbounded body. Now streams via `client.stream` + `aiter_bytes` and raises as soon as cumulative bytes cross the cap.
**#382** — `patch_config` did read→modify→write with no lock; two concurrent calls could clobber. Now wrapped in an advisory `fcntl.flock` on a sibling `.lock` file for the duration of the RMW.

Tests: stream-abort on oversized body; locked RMW applies + persists. 36 mcp tests green, ruff clean.

Note: #383 (list_servers bundled-id shadow defense) intentionally left open — lower severity (direct-file-drop on a LAN-trust box) and a fiddlier change; queued for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)