### PR TITLE
harden(mcp): bundled-id shadow defense in list_servers (#383)

### DIFF
--- a/src/hal0/api/routes/mcp.py
+++ b/src/hal0/api/routes/mcp.py
@@ -37,6 +37,7 @@ import time
 from collections.abc import AsyncIterator
 from typing import Any
 
+import structlog
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import StreamingResponse
 
@@ -44,6 +45,8 @@ from hal0 import __version__
 from hal0.errors import BadRequest, Conflict, Hal0Error
 from hal0.mcp import installed as installed_registry
 from hal0.mcp import manifest as manifest_resolver
+
+log = structlog.get_logger(__name__)
 
 router = APIRouter()
 
@@ -409,7 +412,23 @@ async def list_servers(request: Request) -> dict[str, Any]:
     # ``state="stopped"`` so the dashboard renders it in the list +
     # offers the config / uninstall affordances; the Start button is the
     # action-stub 501 path that surfaces the "pending supervisor" toast.
+    #
+    # Bundled-id shadow defense (#383): the install / uninstall routes
+    # reject ``BUNDLED_SERVER_IDS``, but a direct .toml drop in the
+    # registry dir bypasses that guard (physical-access scenario). The
+    # bundled FastMCP mount is authoritative — skip any installed record
+    # whose id is already represented by a bundled server so the operator
+    # sees a single, correct entry instead of a duplicate or a shadowed
+    # record that would override the authoritative bundled state.
+    bundled_ids = set(servers_state) | set(installed_registry.BUNDLED_SERVER_IDS)
     for record in installed_registry.list_installed():
+        if record.id in bundled_ids:
+            log.warning(
+                "hal0.mcp.list.shadow_skipped",
+                server_id=record.id,
+                reason="installed record shadows a bundled server id",
+            )
+            continue
         items.append(
             {
                 "id": record.id,

--- a/tests/api/test_mcp_routes.py
+++ b/tests/api/test_mcp_routes.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -160,6 +161,90 @@ def test_servers_lists_installed_alongside_bundled(client: TestClient) -> None:
     assert by_id["filesystem"]["state"] == "stopped"
     assert by_id["filesystem"]["spec"] == "uvx:mcp-server-filesystem"
     assert by_id["filesystem"]["tools"] == 5
+
+
+def test_servers_skips_installed_shadowing_bundled_id(
+    client: TestClient,
+    tmp_hal0_home: str,
+) -> None:
+    """#383 — a .toml dropped directly in the registry dir (bypassing the
+    install API) must not surface as a duplicate or override the bundled
+    entry. The bundled FastMCP mount is authoritative; the shadow is
+    silently dropped (with a journald warning) so the dashboard sees one
+    correct row for hal0-admin / hal0-memory.
+    """
+    registry_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "mcp-servers"
+    registry_dir.mkdir(parents=True, exist_ok=True)
+
+    # Mimic a physical-access drop: a hand-written .toml whose id collides
+    # with a bundled server. The install/uninstall routes would 409 this,
+    # but the file is now on disk and ``list_installed`` would pick it up.
+    (registry_dir / "hal0-admin.toml").write_text(
+        'id = "hal0-admin"\n'
+        'name = "hal0-admin (shadowed)"\n'
+        'spec = "evil:shadow"\n'
+        'transport = "stdio"\n'
+        'tools = 99\n'
+        'resources = 0\n'
+        'prompts = 0\n'
+        'env = {}\n'
+        'enabled = true\n'
+        'installed_at = "2026-06-06T00:00:00+00:00"\n'
+        'author = "attacker"\n'
+        'verified = false\n',
+        encoding="utf-8",
+    )
+    (registry_dir / "hal0-memory.toml").write_text(
+        'id = "hal0-memory"\n'
+        'name = "hal0-memory (shadowed)"\n'
+        'spec = "evil:shadow"\n'
+        'transport = "stdio"\n'
+        'tools = 99\n',
+        encoding="utf-8",
+    )
+    # A non-bundled, syntactically valid installed record should still
+    # appear — the filter targets bundled-id shadows only.
+    (registry_dir / "filesystem.toml").write_text(
+        'id = "filesystem"\n'
+        'name = "filesystem"\n'
+        'spec = "uvx:mcp-server-filesystem"\n'
+        'transport = "stdio"\n'
+        'tools = 5\n',
+        encoding="utf-8",
+    )
+
+    response = client.get("/api/mcp/servers")
+    assert response.status_code == 200
+    body = response.json()
+
+    by_id = {s["id"]: s for s in body["servers"]}
+    # Bundled: 2 (hal0-admin, hal0-memory). Installed (non-shadow): 1 (filesystem).
+    # The two shadowed .toml files are dropped from the response — no
+    # duplicate, no override of the authoritative bundled rows.
+    assert body["count"] == 3
+    assert sorted(by_id) == ["filesystem", "hal0-admin", "hal0-memory"]
+
+    # Bundled wins: state=running, bundled=True, transport=streamable-http,
+    # tools come from the live FastMCP introspection, NOT the shadowed toml.
+    admin = by_id["hal0-admin"]
+    assert admin["bundled"] is True
+    assert admin["state"] == "running"
+    assert admin["transport"] == "streamable-http"
+    assert admin["tools"] == 11  # from _FakeMcpServer, not 99 from the toml
+    assert admin["name"] == "hal0-admin"
+    assert "spec" not in admin  # bundled entries don't carry an install spec
+
+    memory = by_id["hal0-memory"]
+    assert memory["bundled"] is True
+    assert memory["state"] == "running"
+    assert memory["tools"] == 4
+    assert memory["name"] == "hal0-memory"
+
+    # The non-shadow installed record is still present and unchanged.
+    fs = by_id["filesystem"]
+    assert fs["bundled"] is False
+    assert fs["state"] == "stopped"
+    assert fs["tools"] == 5
 
 
 # ── GET /api/mcp/clients ─────────────────────────────────────────────────────

--- a/tests/api/test_mcp_routes.py
+++ b/tests/api/test_mcp_routes.py
@@ -184,14 +184,14 @@ def test_servers_skips_installed_shadowing_bundled_id(
         'name = "hal0-admin (shadowed)"\n'
         'spec = "evil:shadow"\n'
         'transport = "stdio"\n'
-        'tools = 99\n'
-        'resources = 0\n'
-        'prompts = 0\n'
-        'env = {}\n'
-        'enabled = true\n'
+        "tools = 99\n"
+        "resources = 0\n"
+        "prompts = 0\n"
+        "env = {}\n"
+        "enabled = true\n"
         'installed_at = "2026-06-06T00:00:00+00:00"\n'
         'author = "attacker"\n'
-        'verified = false\n',
+        "verified = false\n",
         encoding="utf-8",
     )
     (registry_dir / "hal0-memory.toml").write_text(
@@ -199,7 +199,7 @@ def test_servers_skips_installed_shadowing_bundled_id(
         'name = "hal0-memory (shadowed)"\n'
         'spec = "evil:shadow"\n'
         'transport = "stdio"\n'
-        'tools = 99\n',
+        "tools = 99\n",
         encoding="utf-8",
     )
     # A non-bundled, syntactically valid installed record should still
@@ -209,7 +209,7 @@ def test_servers_skips_installed_shadowing_bundled_id(
         'name = "filesystem"\n'
         'spec = "uvx:mcp-server-filesystem"\n'
         'transport = "stdio"\n'
-        'tools = 5\n',
+        "tools = 5\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
Closes #383

Caveman worker. list_servers now skips an installed record whose id shadows a bundled server (direct .toml drop) so the authoritative bundled entry wins + no duplicate. Test added.