### PR TITLE
fix(installer): server_models.json 0644 so hal0 user can read it (#211)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1469,6 +1469,12 @@ if [[ "${DEV_MODE}" -eq 0 && -d "${LEMONADE_RESOURCES}" ]]; then
     if "${VENV_DIR}/bin/python" -m hal0.lemonade.server_models_gen \
         --registry "${REGISTRY_TOML}" \
         --output "${LEMONADE_SERVER_MODELS}"; then
+        # Issue #211: the file lands 0644 (set by the generator) but is
+        # owned by root because the dir-wide `chown -R hal0:hal0
+        # ${LEMONADE_PREFIX}` above ran BEFORE this file was created.
+        # Re-chown the file we just wrote so hal0-lemonade can update
+        # entries (e.g. add backend versions) without escalating.
+        chown hal0:hal0 "${LEMONADE_SERVER_MODELS}" 2>/dev/null || true
         info "wrote ${LEMONADE_SERVER_MODELS}"
     else
         warn "server_models_gen failed; Lemonade will fall back to its bundled catalog"

--- a/src/hal0/lemonade/server_models_gen.py
+++ b/src/hal0/lemonade/server_models_gen.py
@@ -505,6 +505,13 @@ def write_server_models(
     Lemonade's existing catalog intact. Same pattern as
     ``ModelRegistry._atomic_write``.
 
+    The output file is chmod'd ``0o644`` (world-readable) after the
+    replace. ``mkstemp`` leaves the temp at ``0o600``, which ``os.replace``
+    preserves; without this chmod, a root-owned write during install lands
+    ``0600 root:root`` and ``hal0-lemonade.service`` (running as
+    ``hal0:hal0``) can't read it — issue #211. The catalog is non-secret
+    (model ids, recipes, HF coords), so world-readable is correct.
+
     Idempotent: re-running with an unchanged registry produces the same
     bytes (sorted keys + stable float rounding). Safe to call from the
     install.sh hook OR from ``hal0 capabilities sync``.
@@ -534,6 +541,10 @@ def write_server_models(
             raise
         os.replace(tmp_path, output_path)
         tmp_path = None
+        # mkstemp → 0o600, os.replace preserves mode. The catalog is
+        # non-secret (model ids + recipes + HF coords) and the hal0
+        # service user must be able to read it (#211).
+        os.chmod(output_path, 0o644)
     finally:
         if tmp_path is not None:
             with contextlib.suppress(OSError):

--- a/tests/lemonade/test_server_models_gen.py
+++ b/tests/lemonade/test_server_models_gen.py
@@ -694,6 +694,38 @@ class TestAtomicWrite:
         leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(".")]
         assert leftovers == []
 
+    def test_output_is_world_readable_0644(self, tmp_path: Path) -> None:
+        """#211: mkstemp leaves the temp at 0o600; the writer must chmod
+        the final path to 0o644 so the hal0 service user can read it."""
+        registry = tmp_path / "registry.toml"
+        output = tmp_path / "server_models.json"
+        _write_registry(
+            registry, {"m": {"path": "/x.gguf", "capabilities": ["chat"], "backends": ["vulkan"]}}
+        )
+
+        write_server_models(registry, output)
+
+        mode = output.stat().st_mode & 0o777
+        assert mode == 0o644, f"expected 0o644, got {oct(mode)}"
+
+    def test_overwritten_output_keeps_world_readable_mode(self, tmp_path: Path) -> None:
+        """A re-write of an already-world-readable file must not regress
+        to 0o600 (mkstemp default for the new tempfile)."""
+        registry = tmp_path / "registry.toml"
+        output = tmp_path / "server_models.json"
+        _write_registry(
+            registry, {"m": {"path": "/x.gguf", "capabilities": ["chat"], "backends": ["vulkan"]}}
+        )
+
+        write_server_models(registry, output)
+        # Force a mode that mkstemp would not have produced, to prove the
+        # chmod runs every time and not just on the first write.
+        output.chmod(0o600)
+        write_server_models(registry, output)
+
+        mode = output.stat().st_mode & 0o777
+        assert mode == 0o644, f"expected 0o644 after rewrite, got {oct(mode)}"
+
 
 # ── Missing registry handling ────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #211

Caveman worker. chmod 0644 after the atomic write of server_models.json (mkstemp left it 0600); it's a non-secret model catalog the hal0 service user must read. Mode test added.