### PR TITLE
feat(hermes): enable live /v1/models discovery in provisioned config

### DIFF
--- a/src/hal0/agents/hermes_templates/config.yaml.j2
+++ b/src/hal0/agents/hermes_templates/config.yaml.j2
@@ -71,6 +71,19 @@ providers:
     base_url: {{ ("http://127.0.0.1:8080/v1" if live_resolve_enabled else (primary.backend_url if primary else "http://127.0.0.1:8080/v1")) | tojson }}
     request_timeout_seconds: 300
     stale_timeout_seconds: 900
+{%- if live_resolve_enabled %}
+    # Live model discovery. Under live-resolve, base_url above is the hal0-api
+    # gateway (:8080), which serves every loaded slot at /v1/models. hal0-api
+    # is unauthenticated, but Hermes's Section-3 picker only runs live
+    # /v1/models discovery when an api_key is present (see model_switch.py:
+    # ``if api_url and api_key and discover``). Without it the picker shows
+    # only ``model.default`` and never sees the other slots (e.g. a ROCm MOE
+    # slot). The placeholder key opens that gate; its value is ignored by the
+    # gateway. When live-resolve is OFF, base_url points at a single physical
+    # slot backend, so discovery is intentionally omitted there.
+    api_key: "hal0-local"
+    discover_models: true
+{%- endif %}
 
 {%- if chat_slots %}
 

--- a/tests/agents/test_hermes_live_resolve_render.py
+++ b/tests/agents/test_hermes_live_resolve_render.py
@@ -34,6 +34,23 @@ def test_disabled_renders_physical_default():
     assert "hal0/primary" not in out
 
 
+def test_live_resolve_enables_live_model_discovery():
+    """Under live-resolve, providers.custom carries an api_key + discover_models
+    so Hermes's Section-3 picker runs live /v1/models discovery against the
+    gateway (surfacing every slot, not just model.default)."""
+    out = _render_config_yaml(live_resolve_enabled=True, **_ctx())
+    assert "discover_models: true" in out
+    assert 'api_key: "hal0-local"' in out
+
+
+def test_disabled_omits_live_model_discovery():
+    """With live-resolve OFF, base_url points at a single physical slot
+    backend, so live discovery is intentionally not enabled."""
+    out = _render_config_yaml(live_resolve_enabled=False, **_ctx())
+    assert "discover_models" not in out
+    assert "hal0-local" not in out
+
+
 def test_live_resolve_forces_gateway_for_nonlocal_primary():
     """A non-8080 primary backend_url must NOT leak into either base_url
     under live_resolve — both model.base_url and providers.custom.base_url


### PR DESCRIPTION
## Problem

The Hermes model picker wasn't showing the ROCm MOE slot (`gpu-rocmfp4-moe`) — or any slot other than the default.

The picker (`hermes_cli/inventory.build_models_payload` → `model_switch.list_authenticated_providers`, **Section 3**) builds a custom provider's model list from config, and only runs **live `/v1/models` discovery** when an `api_key` is present:

```python
if api_url and api_key and discover:
    live_models = fetch_api_models(api_key, api_url)
```

The provisioned hal0 config (`config.yaml.j2`) renders `providers.custom` **with no `api_key`** — hal0-api is an unauthenticated LAN gateway. So the gate never opened, and the picker showed only `model.default` (`hal0/primary`). Every other slot the gateway serves at `/v1/models` was invisible.

## Fix

Render a placeholder `api_key` + `discover_models: true` under the **`live_resolve_enabled`** branch — the only case where `base_url` is guaranteed to be the hal0-api gateway (`:8080`) that serves all slots. The key's value is ignored by the unauthenticated gateway.

When live-resolve is OFF, `base_url` points at a single physical slot backend, so discovery is intentionally omitted (it would only echo one model).

## How the picker gathers models (for reviewers)

- **What:** config-driven via `list_authenticated_providers`; live `/v1/models` is opt-in per the `api_key` gate above.
- **When:** rebuilt every time the picker opens; `load_config()` is cache-invalidated on the config file's `(mtime_ns, size)`, so no Hermes restart is needed after a config change.

## Verification

- `tests/agents/test_hermes_live_resolve_render.py`: added 2 cases (discovery enabled under live-resolve, omitted when off). Full file + broader `test_hermes_provision.py` suite green.
- On CT105: patched the running config, picker payload now lists all 8 gateway IDs including `gpu-rocmfp4-moe`; a completion against that ID serves (routes to `CHADROCK3.6-35B…MTP-STRIX-LEAN.gguf`, ~33 tok/s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)