### PR TITLE
fix(packaging): pin OpenWebUI to a digest, drop mutable :main (#79)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -601,6 +601,11 @@ info "wrote ${API_UNIT}"
 
 OPENWEBUI_UNIT_SRC="${REPO_ROOT}/packaging/systemd/hal0-openwebui.service"
 OPENWEBUI_UNIT_DST="${UNIT_DIR}/hal0-openwebui.service"
+# pin per release (#79) — single source of truth for the OpenWebUI image
+# pulled by the background job below and referenced by the systemd unit.
+# Bump the sha256 digest here on each hal0 release; update the matching
+# digest in packaging/systemd/hal0-openwebui.service at the same time.
+OPENWEBUI_IMAGE="ghcr.io/open-webui/open-webui@sha256:d05c6ff8baf5ae701d86a3332c0db4ebb2802ca3d0d341be7fd157fa730306ab"
 if [[ -f "${OPENWEBUI_UNIT_SRC}" ]]; then
     cp "${OPENWEBUI_UNIT_SRC}" "${OPENWEBUI_UNIT_DST}"
     info "wrote ${OPENWEBUI_UNIT_DST}"
@@ -663,9 +668,9 @@ if [[ "${DEV_MODE}" -eq 0 && "${NO_START}" -eq 0 ]] && command -v docker >/dev/n
     # kicked it off. The hal0-openwebui unit also has ExecStartPre=docker
     # pull (idempotent), so missing this background pull only costs first
     # -boot latency, not correctness.
-    (docker pull ghcr.io/open-webui/open-webui:main >/dev/null 2>&1 || true) &
+    (docker pull "${OPENWEBUI_IMAGE}" >/dev/null 2>&1 || true) &
     disown
-    ui_spinner_run "Pulling ghcr.io/open-webui/open-webui:main in background" sleep 3
+    ui_spinner_run "Pulling ${OPENWEBUI_IMAGE} in background" sleep 3
 fi
 
 ui_step "Hardware probe"

--- a/packaging/systemd/hal0-openwebui.service
+++ b/packaging/systemd/hal0-openwebui.service
@@ -23,8 +23,9 @@ EnvironmentFile=/etc/hal0/openwebui.env
 
 # Pre-pull on first start so the unit doesn't sit in 'activating' for
 # minutes the first time. Idempotent — Docker reuses the cached image.
-# tracked-in: #79 — pin :main to a specific digest per hal0 release (PLAN §8).
-ExecStartPre=-/usr/bin/docker pull ghcr.io/open-webui/open-webui:main
+# pin per release (#79) — sha256 digest is deterministic; bump on each
+# hal0 release after a smoke test.
+ExecStartPre=-/usr/bin/docker pull ghcr.io/open-webui/open-webui@sha256:d05c6ff8baf5ae701d86a3332c0db4ebb2802ca3d0d341be7fd157fa730306ab
 
 # Best-effort cleanup of any stale container from a previous start that
 # didn't shut down cleanly. The leading `-` makes systemd ignore the
@@ -36,7 +37,8 @@ ExecStartPre=-/usr/bin/docker rm -f hal0-openwebui
 # Data lives in /var/lib/hal0/openwebui/ which survives container
 # restarts and hal0 updates. The host port :3001 binds 0.0.0.0 by
 # default (PLAN §2 "public" tier).
-# tracked-in: #79 — pin ghcr.io/open-webui/open-webui:main to a digest per release.
+# pin per release (#79) — sha256 digest is deterministic; bump the
+# digest on each hal0 release (match install.sh OPENWEBUI_IMAGE).
 ExecStart=/usr/bin/docker run \
   --rm \
   --name hal0-openwebui \
@@ -45,7 +47,7 @@ ExecStart=/usr/bin/docker run \
   -p 0.0.0.0:3001:8080 \
   --add-host=host.docker.internal:host-gateway \
   --security-opt apparmor=unconfined \
-  ghcr.io/open-webui/open-webui:main
+  ghcr.io/open-webui/open-webui@sha256:d05c6ff8baf5ae701d86a3332c0db4ebb2802ca3d0d341be7fd157fa730306ab
 
 # Graceful stop: tell the named container to stop (SIGTERM + 10s timeout
 # is docker's default). systemd will SIGKILL ExecStart if it doesn't

--- a/tests/openwebui/test_prewire_smoke.py
+++ b/tests/openwebui/test_prewire_smoke.py
@@ -285,7 +285,10 @@ def hal0_api(
 
 # ── OpenWebUI container fixture ──────────────────────────────────────────────
 
-OPENWEBUI_IMAGE = "ghcr.io/open-webui/open-webui:main"
+# pin per release (#79) — sha256 digest is deterministic; bump on each
+# hal0 release. Keep in sync with install.sh OPENWEBUI_IMAGE and the
+# systemd unit's ExecStartPre/ExecStart.
+OPENWEBUI_IMAGE = "ghcr.io/open-webui/open-webui@sha256:d05c6ff8baf5ae701d86a3332c0db4ebb2802ca3d0d341be7fd157fa730306ab"
 
 
 def _docker_pull(image: str) -> None:
@@ -314,7 +317,7 @@ def openwebui_container(
     tmp_path: Path,
     hal0_api: tuple[str, int],
 ) -> Iterator[tuple[str, int]]:
-    """Launch `ghcr.io/open-webui/open-webui:main` against the prewired env.
+    """Launch `OPENWEBUI_IMAGE` (sha256-pinned, #79) against the prewired env.
 
     Generates ``openwebui.env`` via the production writer (overriding
     only ``OPENAI_API_BASE_URLS`` to target the test's hal0 port),


### PR DESCRIPTION
Closes #79

Caveman worker. Pins ghcr.io/open-webui/open-webui to @sha256:d05c6ff8… across the systemd unit, install.sh (single shared var), and the prewire smoke test — deterministic pulls, no more mutable :main drift. Comment notes: bump the digest per hal0 release.