### PR TITLE
feat(npu): route device=npu embed/STT into the FLM trio (Phase 2)

### DIFF
--- a/docs/superpowers/specs/2026-06-05-npu-phase2-blueprint.md
+++ b/docs/superpowers/specs/2026-06-05-npu-phase2-blueprint.md
@@ -1,0 +1,155 @@
+# NPU Phase 2 — Implementation Blueprint
+
+**Date:** 2026-06-06 · **Branch:** `feat/npu-phase2` (off `main`) · **Spec:** `2026-06-05-npu-flm-stack-section-design.md` §Phase 2
+
+Goal: a `device=npu` capability selection for **embed** / **voice.stt** drives the
+**FLM trio** (one process) — set lemond `flm_args` + enable a `device=npu`,
+`type=embedding|transcription` slot RECORD for dispatch gating — and **never**
+spawns a standalone FLM process for the modality.
+
+## Decisions (resolved by orchestrator — these override the blueprint's "open questions")
+
+1. **No eager anchor-reload.** When enabling/disabling an NPU modality changes
+   `flm_args` and the anchor is live, **do NOT auto-restart** it. Set the config,
+   write the slot record, and return `pending_reload=True`. The user applies it via
+   the NPU section's existing "⟳ reload to apply" affordance. (Consistency with
+   Phase 1 + never interrupt an active chat unexpectedly.)
+2. **Preserve unrecognized `flm_args` flags.** `_recompose_flm_args` must replace
+   only the `--asr`/`--embed` tokens in place (append if absent) and keep all other
+   tokens (`--threads`, etc.) verbatim. Always emit explicit `0|1` for both trio
+   flags.
+3. **`/api/models` FLM surfacing is OUT of this PR.** File as a follow-up; pickers
+   degrade to empty meanwhile. The orchestrator change is complete without it.
+4. **`update_config` ordering.** Call `_rewrite_underlying_slot` (which sets the
+   `model` sub-table) BEFORE the `{enabled}`-only `update_config` write; the enabled
+   write must NOT include `model` (nested dicts are replaced wholesale).
+
+## Reconciliation decision: Design A — reuse canonical `embed`/`stt`, flip `device`
+
+`_CHILD_TO_SLOT` already maps `("embed","embed")→"embed"`, `("voice","stt")→"stt"`
+(`orchestrator.py:48-55`) — unchanged. The orchestrator operates on these canonical
+slots; detection is device-driven (`device==npu` + `type`), never literal names. The
+seeded `agent`/`stt-npu`/`embed-npu` (`manager.py:77`, `slots.py:112`) are the trio's
+own records — `stt-npu`/`embed-npu` stay `enabled=false` at seed and the orchestrator
+never touches them (prevents double-match in `_is_npu_trio_request`). The anchor is
+found by scanning `iter_configs()` for `type=="llm" && device=="npu"` — never hardcode
+`agent`.
+
+## 1. Current `apply()` lifecycle (embed) — file:line
+
+`orchestrator.py:318` entry → `:344-375` load+merge (`_CHILD_TO_SLOT`, backend→device
+alias) → `:380-381` `_validate_model_in_catalog` (calls `models_for_capability`, checks
+`device` in model's `legal_backends`) → `:386-419` lifecycle branches:
+- `:403` `if merged.enabled: _rewrite_underlying_slot(...)` (always).
+- `:406` off→on: `_ensure_slot_exists` + `slot_manager.load(slot, model_id)` ← STANDALONE SPAWN.
+- `:411` on→off: `slot_manager.unload(slot)`.
+- `:416` model/backend change: `_ensure_slot_exists` + `slot_manager.swap(slot, model)` ← STANDALONE.
+
+`_rewrite_underlying_slot` (`:557-590`) sends `{backend,device,provider,model}` (no
+`type`). `_ensure_slot_exists` (`:521-555`) creates with `{name,port,backend,device,
+provider,enabled,model}` — **no `type`**. **The gap:** `_is_npu_trio_request`
+(`v1.py:783`) gates on `cfg.get("type")==slot_type` FIRST — absent `type` → trio
+dispatch never activates. `update_config` is a shallow top-level merge
+(`manager.py:1428`), so an existing `type` survives a rewrite, but a created slot never
+gets one.
+
+## 2. The NPU-trio fork
+
+After merge+validation (`~:393`), compute `is_npu_target = merged.device=="npu" and
+child in ("embed","stt")`. Keep `if merged.enabled: _rewrite_underlying_slot(...)`,
+then branch:
+```python
+if is_npu_target:
+    pending = await self._apply_npu_trio_modality(slot_name, child, merged, before_enabled)
+else:
+    ... existing enabled/model/backend branches ...
+```
+
+### New `async _apply_npu_trio_modality(slot_name, child, merged, before_enabled) -> bool`
+1. `_ensure_slot_exists_npu(slot_name, child, merged)` (create path writes `type`).
+2. `update_config(slot_name, {"enabled": merged.enabled})` — explicit, covers enable AND
+   disable (so `_is_npu_trio_request`'s `enabled is False` check blocks dispatch). Runs
+   AFTER `_rewrite_underlying_slot` (Decision 4).
+3. Read-modify-write `flm_args` via the lemonade client:
+   `cfg = await client.internal_config(); new = _recompose_flm_args(cfg.get("flm_args") or "", child, merged.enabled); await client.internal_set({"flm_args": new})`.
+4. **Decision 1:** find anchor (`iter_configs` → `type==llm && device==npu`); if live,
+   return `pending_reload=True` (do NOT restart). If not live, also `pending_reload`
+   (won't take effect until the user loads it). Surface `pending_reload` in the
+   `apply()` response.
+5. **No `load()`/`swap()`/`unload()` on the embed/stt slot.**
+
+### `_ensure_slot_exists_npu` — like `_ensure_slot_exists` but cfg includes
+`"type": "embedding" if child=="embed" else "transcription"`, `device="npu"`,
+`provider="flm"`, `backend="flm"`.
+
+### `_recompose_flm_args(current, child, enable)` — module-level, **Decision 2**:
+parse all tokens, set only the `--asr`/`--embed` flag for `child`, preserve every other
+token, append the trio flags if absent, always emit explicit `0|1`. Unit-tested.
+
+### Lemonade client wiring
+Add `lemonade_provider` param to `CapabilityOrchestrator.__init__`; pass from
+`create_app` lifespan (same place the orchestrator is constructed). Local import to keep
+load cheap.
+
+## 3. `asr` fanout — `catalog.py`
+FLM ASR rows come from `_flm_rows_for_capability` (`catalog.py:620-672`), gated by the
+early-return `if capability not in {"chat","embed"}: return []` (`:638`) and the
+`reported_caps` filter (`:653`). Changes:
+- `:255` `_NPU_FANOUT_CAPS = frozenset({"chat","embed","stt"})` (+ update comment).
+- `:638` widen guard to `{"chat","embed","stt"}`.
+- `:653` widen `reported_caps` filter to `{"chat","embed","stt"}`.
+`providers/flm.py` `_classify_flm_model` already emits `"stt"` — no change. **Serial
+prerequisite** for the orchestrator npu-stt path (validation calls
+`models_for_capability("stt")` and would reject `npu` otherwise).
+
+## 4. Device-partition invariant
+Single `device` per selection; orchestrator is sole writer of `capabilities.toml`. After
+`apply(...,device=npu)`: capabilities.toml + the `embed`/`stt` slot TOML both say
+`device=npu, enabled=true` → frontend NPU section (keys on `device==npu`) owns it;
+Capabilities grid reads `selections.<c>.device` and suppresses/links it. Switching to
+`gpu-vulkan` flips device (trio dispatch bypassed) and the npu-disable path sets
+`--embed/asr 0` + `enabled=false`.
+
+## 6. Test plan — `tests/capabilities/test_orchestrator_reconciliation.py`
+Extend `FakeSlotManager` with `iter_configs()`/`set_configs()`/`restart`; add
+`FakeLemonadeClient` (`internal_config`/`internal_set`, records `set_calls`). Inject via
+`lemonade_provider=lambda: client`. TDD cases:
+1. NPU embed enable → `set_calls[-1]=={"flm_args":"--asr 1 --embed 1"}`, slot
+   `update_config enabled=True`, **NO** `load`, `pending_reload` set (Decision 1: no restart).
+2. NPU embed disable → `flm_args "--asr 1 --embed 0"`, slot `enabled=False` written, **NO** `unload`.
+3. NPU stt enable → `flm_args "--asr 1 --embed ?"` with asr=1, no standalone load.
+4. embed gpu-vulkan→npu → flm_args embed=1, no load/swap on embed, update_config device=npu+enabled.
+5. embed npu→gpu-vulkan (and back) → flm_args embed=0 + device flip; gpu path DOES `load`.
+6. `_recompose_flm_args` unit: `""→"--asr 0 --embed 1"` (embed,True); preserves other flags
+   e.g. `"--threads 8 --asr 1 --embed 0"` + (embed,True) → keeps `--threads 8` (Decision 2).
+7. New `tests/capabilities/test_catalog_npu_stt.py`: `models_for_capability("stt")` yields a
+   row with an `npu` backend.
+8. `_ensure_slot_exists_npu` create writes `type=="embedding"`.
+9. Anchor offline → `pending_reload=True`, no restart.
+
+## 7. Build sequence (green at each commit)
+1. `_CHILD_TO_SLOT_TYPE` + add `type` to `_ensure_slot_exists` (+Case 8). Standalone.
+2. `_recompose_flm_args` helper (+Case 6). Standalone.
+3. Catalog widen to `stt` (+Case 7). **Serial prereq for step 5.**
+4. Test stubs: `FakeSlotManager.iter_configs/restart`, `FakeLemonadeClient`. Standalone.
+5. `_apply_npu_trio_modality` + `lemonade_provider` injection + `apply()` fork + wire in
+   `create_app` (+Cases 1-5,9). Serial after 1-4.
+6. Verify standard (non-NPU) disable path not regressed (`test_apply_no_rewrite_on_pure_disable`).
+7. Update module docstring (remove "NPU multiplex OUT OF SCOPE").
+8. `tests/capabilities/test_npu_phase2_integration.py` smoke (full drift fixture + npu embed).
+
+## Files
+`src/hal0/capabilities/orchestrator.py` (main), `src/hal0/capabilities/catalog.py`
+(:255,638,653), `create_app` construction site (`src/hal0/api/__init__.py` or lifespan),
+`tests/capabilities/test_orchestrator_reconciliation.py`, + new
+`test_catalog_npu_stt.py`, `test_npu_phase2_integration.py`.
+
+## Established facts
+- STT trio dispatch already wired: `v1.py:1245` calls `_is_npu_trio_request(...,
+  slot_type="transcription")` → `dispatch_stt_npu`. Enabling the `stt` slot
+  (device=npu,type=transcription,enabled) activates it.
+- `update_config` is read-merge(top-level)-write; existing `type` survives a rewrite.
+
+## Follow-ups (separate)
+- `/api/models` surfaces 0 FLM models → empty NPU pickers (Decision 3).
+- VibeVoice TTS provider (its own spec).

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -948,9 +948,19 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # The orchestrator is intentionally constructed AFTER the slot
     # manager + registry are ready so initialize_if_missing() can lift
     # current slot config into capabilities.toml on first boot.
+    # NPU Phase 2: pass a zero-arg callable returning a LemonadeClient so
+    # the orchestrator's device=npu embed/stt path can read/write lemond
+    # ``flm_args`` (drive the FLM trio) instead of spawning a standalone FLM
+    # process. Local import keeps orchestrator import cheap.
+    def _lemonade_client():  # type: ignore[no-untyped-def]
+        from hal0.providers import lemonade_provider
+
+        return lemonade_provider().client()
+
     capability_orchestrator = CapabilityOrchestrator(
         slot_manager=slot_manager,
         registry=model_registry,
+        lemonade_provider=_lemonade_client,
     )
     try:
         await capability_orchestrator.initialize_if_missing()

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -636,7 +636,7 @@ def _flm_rows_for_capability(capability: str) -> list[dict[str, Any]]:
     next ``/api/capabilities`` GET flips ``downloaded`` to True without a
     process restart.
     """
-    if capability not in {"chat", "embed", "stt"}:
+    if capability not in _NPU_FANOUT_CAPS:
         return []
     # Local import so catalog.py doesn't drag the provider module (and
     # its httpx dependency) onto every import path.
@@ -651,7 +651,7 @@ def _flm_rows_for_capability(capability: str) -> list[dict[str, Any]]:
         # Filter capabilities reported to the dashboard down to the
         # in-scope subset; otherwise an "stt" tag would leak through on a
         # chat row and confuse the picker.
-        reported_caps = [c for c in entry["capabilities"] if c in {"chat", "embed", "stt"}]
+        reported_caps = [c for c in entry["capabilities"] if c in _NPU_FANOUT_CAPS]
         # FLM's reported `size` is the raw weights footprint; for
         # quantized models it under-reports actual disk usage, so prefer
         # the larger of size and runtime footprint as the displayed value.

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -247,12 +247,13 @@ def _model_capabilities(entry: CuratedModel | HaloaiModel | Any) -> list[str]:
 
 
 # Capabilities the AMD NPU (XDNA + FLM stack) can serve. Mirrors the
-# ``flm → caps={chat, embed}`` line in src/hal0/registry/detect.py:85.
-# Used to decide whether a llama.cpp-compatible entry should also fan
-# out to ``npu`` when the host has an NPU. Voice (stt/tts) is NOT here
-# — those route through dedicated providers (moonshine, kokoro), not
-# through FLM.
-_NPU_FANOUT_CAPS: frozenset[str] = frozenset({"chat", "embed"})
+# ``flm`` capability set in src/hal0/registry/detect.py. Used to decide
+# whether a llama.cpp-compatible entry should also fan out to ``npu``
+# when the host has an NPU. ``stt`` is included as of NPU Phase 2: the
+# FLM trio (one ``flm serve`` process) coresides ASR with chat/embed, so
+# ``voice.stt`` can run on the NPU. TTS is NOT here — it routes through a
+# dedicated provider (kokoro), not through FLM.
+_NPU_FANOUT_CAPS: frozenset[str] = frozenset({"chat", "embed", "stt"})
 
 
 def _backend_variants(entry: Any) -> list[str]:
@@ -622,10 +623,10 @@ def _flm_rows_for_capability(capability: str) -> list[dict[str, Any]]:
 
     Probes :func:`hal0.providers.flm.flm_served_models` (cached at module
     scope after first call) and projects each FLM tag into a picker row
-    with ``backend="npu"`` / ``provider="flm"``. Scope is intentionally
-    limited to ``chat`` and ``embed`` per the 2026-05-20 design call —
-    FLM also serves ``stt`` (whisper-v3, gemma4-it asr=true) but the NPU
-    voice path through the slot manager is a later slice.
+    with ``backend="npu"`` / ``provider="flm"``. Scope is ``chat``,
+    ``embed`` and ``stt`` (NPU Phase 2): the FLM trio coresides ASR with
+    chat/embed in one ``flm serve`` process, so ``voice.stt`` runs on the
+    NPU. ``tts`` is still out — it routes through kokoro, not FLM.
 
     ``pullable`` is True for FLM tags — the pull route (routes/models.py)
     detects FLM ids via :func:`hal0.providers.flm.is_flm_tag` and dispatches
@@ -635,7 +636,7 @@ def _flm_rows_for_capability(capability: str) -> list[dict[str, Any]]:
     next ``/api/capabilities`` GET flips ``downloaded`` to True without a
     process restart.
     """
-    if capability not in {"chat", "embed"}:
+    if capability not in {"chat", "embed", "stt"}:
         return []
     # Local import so catalog.py doesn't drag the provider module (and
     # its httpx dependency) onto every import path.
@@ -650,7 +651,7 @@ def _flm_rows_for_capability(capability: str) -> list[dict[str, Any]]:
         # Filter capabilities reported to the dashboard down to the
         # in-scope subset; otherwise an "stt" tag would leak through on a
         # chat row and confuse the picker.
-        reported_caps = [c for c in entry["capabilities"] if c in {"chat", "embed"}]
+        reported_caps = [c for c in entry["capabilities"] if c in {"chat", "embed", "stt"}]
         # FLM's reported `size` is the raw weights footprint; for
         # quantized models it under-reports actual disk usage, so prefer
         # the larger of size and runtime footprint as the displayed value.

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -191,10 +191,17 @@ class CapabilityOrchestrator:
         *,
         config_path: Path | None = None,
         registry: ModelRegistry | None = None,
+        lemonade_provider: Any | None = None,
     ) -> None:
         self._slot_manager = slot_manager
         self._config_path = Path(config_path) if config_path else capabilities_toml_path()
         self._registry = registry
+        # Zero-arg callable returning a LemonadeClient (NOT a provider) —
+        # used by the NPU-trio path to read/write lemond ``flm_args``. When
+        # None (e.g. unit tests that don't exercise the trio path), the
+        # device=npu embed/stt fork is bypassed and the standard slot
+        # lifecycle runs instead.
+        self._lemonade_provider = lemonade_provider
 
     # ── persistence ──────────────────────────────────────────────────────────
 
@@ -454,6 +461,21 @@ class CapabilityOrchestrator:
         # rewrite below covers it. Reintroduce if the swap path grows a
         # provider-aware case.
 
+        # NPU-trio fork (NPU Phase 2). When a lemonade client is wired AND
+        # the child is a trio modality (embed/stt), a device=npu selection
+        # drives the FLM trio (set lemond flm_args + write a device=npu,
+        # type=embedding|transcription slot RECORD) instead of spawning a
+        # standalone FLM process. ``is_npu_target`` gates lifecycle routing;
+        # ``is_npu_modality`` gates the flm_args side-effect, which must
+        # also fire on DEPARTURE from npu (Case 5: npu→gpu must zero the
+        # anchor's embed/asr flag even though the new device isn't npu).
+        is_npu_modality = (
+            child in _CHILD_TO_SLOT_TYPE and self._lemonade_provider is not None
+        )
+        is_npu_target = is_npu_modality and merged.device == "npu"
+        leaving_npu = is_npu_modality and before_device == "npu" and merged.device != "npu"
+        pending_reload = False
+
         try:
             # Reconcile the slot TOML against the merged selection whenever
             # the slot is going to be enabled. We rewrite unconditionally —
@@ -467,20 +489,37 @@ class CapabilityOrchestrator:
             if merged.enabled:
                 await self._rewrite_underlying_slot(slot_name, merged)
 
-            if enabled_changed and merged.enabled:
-                # off → on: ensure the slot exists, then load with the model.
-                await self._ensure_slot_exists(slot_name, merged)
-                if merged.model:
-                    await self._slot_manager.load(slot_name, model_id=merged.model)
-            elif enabled_changed and not merged.enabled:
-                # on → off: best-effort unload; tolerate slots that were
-                # never loaded (status() will return OFFLINE → unload is a no-op).
-                with contextlib.suppress(Exception):
-                    await self._slot_manager.unload(slot_name)
-            elif merged.enabled and (model_changed or backend_changed) and merged.model:
-                # Still on, but model / backend changed → hot-swap.
-                await self._ensure_slot_exists(slot_name, merged)
-                await self._slot_manager.swap(slot_name, merged.model)
+            if is_npu_target:
+                # NPU trio: drive flm_args + a device=npu slot RECORD; never
+                # load/swap/unload the embed/stt slot. (Decision 4: the
+                # _rewrite_underlying_slot above — which sets the model
+                # sub-table — has already run for the enabled case.)
+                pending_reload = await self._apply_npu_trio_modality(
+                    slot_name, child, merged
+                )
+            else:
+                if enabled_changed and merged.enabled:
+                    # off → on: ensure the slot exists, then load with the model.
+                    await self._ensure_slot_exists(slot_name, merged)
+                    if merged.model:
+                        await self._slot_manager.load(slot_name, model_id=merged.model)
+                elif enabled_changed and not merged.enabled:
+                    # on → off: best-effort unload; tolerate slots that were
+                    # never loaded (status() returns OFFLINE → unload is a no-op).
+                    with contextlib.suppress(Exception):
+                        await self._slot_manager.unload(slot_name)
+                elif merged.enabled and (model_changed or backend_changed) and merged.model:
+                    # Still on, but model / backend changed → hot-swap.
+                    await self._ensure_slot_exists(slot_name, merged)
+                    await self._slot_manager.swap(slot_name, merged.model)
+
+                # Leaving the NPU (npu→gpu/cpu) for a trio modality: drop it
+                # from the anchor's flm_args so the FLM child stops serving
+                # it (Case 5). The standard lifecycle above already loaded
+                # the new GPU/CPU slot.
+                if leaving_npu:
+                    await self._set_flm_modality(child, enable=False)
+                    pending_reload = True
         except Hal0Error:
             # Re-raise typed errors as the apply_failed envelope so the UI
             # surfaces a single, recognisable code.
@@ -516,6 +555,11 @@ class CapabilityOrchestrator:
             "enabled": merged.enabled,
             "slot": slot_name,
             "status": status_str,
+            # NPU Phase 2: when an embed/stt change altered the FLM anchor's
+            # flm_args, the live anchor must be reloaded to take effect. We
+            # never auto-restart it (Decision 1) — the dashboard NPU section
+            # surfaces this via its "⟳ reload to apply" affordance.
+            "pending_reload": pending_reload,
         }
 
     # ── slot TOML helpers ────────────────────────────────────────────────────
@@ -617,6 +661,118 @@ class CapabilityOrchestrator:
         slot_type = _CHILD_TO_SLOT_TYPE.get(child) if child else None
         if slot_type:
             cfg_dict["type"] = slot_type
+        try:
+            await self._slot_manager.create(slot_name, cfg_dict)
+        except Exception as exc:
+            raise CapabilityApplyFailed(
+                f"failed to create slot {slot_name!r}: {exc}",
+                details={"slot": slot_name, "error": str(exc)},
+            ) from exc
+
+    # ── NPU trio (NPU Phase 2) ────────────────────────────────────────────────
+
+    async def _apply_npu_trio_modality(
+        self,
+        slot_name: str,
+        child: str,
+        selection: CapabilitySelection,
+    ) -> bool:
+        """Drive an NPU embed/stt modality through the FLM trio.
+
+        Never load/swap/unload the embed/stt slot — the FLM anchor (a
+        single ``flm serve`` process) serves the modality coresident with
+        chat. We instead:
+
+          1. Ensure the device=npu, type=embedding|transcription slot
+             RECORD exists (create path stamps ``type``).
+          2. Write a ``{enabled}``-only ``update_config`` (covers enable AND
+             disable so ``v1._is_npu_trio_request``'s ``enabled is False``
+             check blocks dispatch). Runs AFTER ``_rewrite_underlying_slot``
+             (Decision 4) — and NEVER passes ``model`` (nested dicts are
+             replaced wholesale by the shallow merge).
+          3. Recompose the anchor's lemond ``flm_args`` for this modality.
+          4. Return ``pending_reload=True`` ALWAYS (Decision 1: never
+             auto-restart the live anchor; if the anchor is offline the new
+             flm_args won't take effect until the user loads it — still
+             pending). The anchor is found by scanning ``iter_configs()``
+             for ``type==llm && device==npu``; we never restart it here.
+        """
+        await self._ensure_slot_exists_npu(slot_name, child, selection)
+        # {enabled}-only write — explicitly NOT carrying ``model`` (Decision 4).
+        await self._slot_manager.update_config(slot_name, {"enabled": selection.enabled})
+        await self._set_flm_modality(child, enable=selection.enabled)
+        # Decision 1: surface pending_reload whether or not the anchor is
+        # live; we never eagerly bounce it. (The anchor scan is informational
+        # only — kept here so the contract "never restart" is auditable.)
+        await self._npu_anchor_is_live()
+        return True
+
+    async def _set_flm_modality(self, child: str, *, enable: bool) -> None:
+        """Read-modify-write the FLM anchor's lemond ``flm_args``.
+
+        Reads the current ``flm_args`` via the injected lemonade client,
+        recomposes only this modality's trio flag (Decision 2), and writes
+        it back. No-op when no lemonade client is wired.
+        """
+        if self._lemonade_provider is None:
+            return
+        client = self._lemonade_provider()
+        cfg = await client.internal_config()
+        current = cfg.get("flm_args") or ""
+        if not isinstance(current, str):
+            current = ""
+        new_args = _recompose_flm_args(current, child, enable)
+        await client.internal_set({"flm_args": new_args})
+
+    async def _npu_anchor_is_live(self) -> bool:
+        """Return True when the FLM trio anchor slot is currently loaded.
+
+        The anchor is the ``type==llm && device==npu`` slot — found by
+        scanning ``iter_configs()``, never by hardcoded name. We DO NOT
+        restart it regardless of the result (Decision 1).
+        """
+        try:
+            configs = await self._slot_manager.iter_configs()
+        except Exception:
+            return False
+        for cfg in configs:
+            if cfg.get("type") != "llm" or cfg.get("device") != "npu":
+                continue
+            name = str(cfg.get("name", "")).strip()
+            if not name:
+                continue
+            try:
+                snap = await self._slot_manager.status(name)
+            except Exception:
+                return False
+            return getattr(snap.state, "value", "") == "ready"
+        return False
+
+    async def _ensure_slot_exists_npu(
+        self, slot_name: str, child: str, selection: CapabilitySelection
+    ) -> None:
+        """Create the device=npu, type=embedding|transcription slot RECORD.
+
+        Like :meth:`_ensure_slot_exists` but forces the FLM-trio shape:
+        ``device=npu``, ``provider=flm``, ``backend=flm``, and always
+        stamps the trio ``type`` so dispatch gating activates. No-op when
+        the slot TOML already exists (its existing fields, including
+        ``type``, survive — ``update_config`` is a shallow top-level merge).
+        """
+        cfg_path = paths.slots_config_dir() / f"{slot_name}.toml"
+        if cfg_path.exists():
+            return
+        port = self._next_free_slot_port()
+        cfg_dict: dict[str, Any] = {
+            "name": slot_name,
+            "port": port,
+            "backend": "flm",
+            "device": "npu",
+            "provider": "flm",
+            "enabled": bool(selection.enabled),
+            "model": {"default": selection.model or ""},
+            "type": _CHILD_TO_SLOT_TYPE[child],
+        }
         try:
             await self._slot_manager.create(slot_name, cfg_dict)
         except Exception as exc:

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -478,9 +478,7 @@ class CapabilityOrchestrator:
         # ``is_npu_modality`` gates the flm_args side-effect, which must
         # also fire on DEPARTURE from npu (Case 5: npu→gpu must zero the
         # anchor's embed/asr flag even though the new device isn't npu).
-        is_npu_modality = (
-            child in _CHILD_TO_SLOT_TYPE and self._lemonade_provider is not None
-        )
+        is_npu_modality = child in _CHILD_TO_SLOT_TYPE and self._lemonade_provider is not None
         is_npu_target = is_npu_modality and merged.device == "npu"
         leaving_npu = is_npu_modality and before_device == "npu" and merged.device != "npu"
         pending_reload = False
@@ -503,9 +501,7 @@ class CapabilityOrchestrator:
                 # load/swap/unload the embed/stt slot. (Decision 4: the
                 # _rewrite_underlying_slot above — which sets the model
                 # sub-table — has already run for the enabled case.)
-                pending_reload = await self._apply_npu_trio_modality(
-                    slot_name, child, merged
-                )
+                pending_reload = await self._apply_npu_trio_modality(slot_name, child, merged)
             else:
                 if enabled_changed and merged.enabled:
                     # off → on: ensure the slot exists, then load with the model.

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -59,6 +59,17 @@ _SLOT_TO_CHILD: dict[str, tuple[str, str]] = {
     slot_name: key for key, slot_name in _CHILD_TO_SLOT.items()
 }
 
+# ── Trio dispatch discriminator: capability child → slot ``type`` ─────────────
+# The FLM trio (one ``flm serve`` process serving chat + embed + asr) is gated
+# in v1._is_npu_trio_request on the slot record's ``type`` field. Only the two
+# trio modalities carry a type; rerank/tts/img/vision are NOT trio members and
+# get no ``type`` key (their auto-created slots are plain llama-server/dedicated
+# providers). Mirrors providers/flm._classify_flm_model emitting "embed"/"stt".
+_CHILD_TO_SLOT_TYPE: dict[str, str] = {
+    "embed": "embedding",
+    "stt": "transcription",
+}
+
 # The legal capability/child surface — used by HTTP validation.
 LEGAL_SLOTS: tuple[str, ...] = ("embed", "voice", "img", "vision")
 
@@ -537,7 +548,7 @@ class CapabilityOrchestrator:
         slot_backend = self._slot_backend_for_catalog_id(selection.device)
         slot_device = self._slot_device_for_catalog_id(selection.device)
         provider = selection.provider or "llama-server"
-        cfg_dict = {
+        cfg_dict: dict[str, Any] = {
             "name": slot_name,
             "port": port,
             "backend": slot_backend or "vulkan",
@@ -546,6 +557,13 @@ class CapabilityOrchestrator:
             "enabled": True,
             "model": {"default": selection.model or ""},
         }
+        # Stamp the trio dispatch discriminator for embed/stt children so
+        # v1._is_npu_trio_request can gate on it. Non-trio children
+        # (rerank/tts/img/vision) get no ``type`` key.
+        _, child = _SLOT_TO_CHILD.get(slot_name, (None, None))
+        slot_type = _CHILD_TO_SLOT_TYPE.get(child) if child else None
+        if slot_type:
+            cfg_dict["type"] = slot_type
         try:
             await self._slot_manager.create(slot_name, cfg_dict)
         except Exception as exc:

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -74,6 +74,59 @@ _CHILD_TO_SLOT_TYPE: dict[str, str] = {
 LEGAL_SLOTS: tuple[str, ...] = ("embed", "voice", "img", "vision")
 
 
+# child → the ``flm serve`` trio flag it toggles.
+_CHILD_TO_FLM_FLAG: dict[str, str] = {
+    "embed": "--embed",
+    "stt": "--asr",
+}
+
+
+def _recompose_flm_args(current: str, child: str, enable: bool) -> str:
+    """Recompute lemond ``flm_args`` for a single trio modality toggle.
+
+    Decision 2: replace ONLY the ``--asr``/``--embed`` token for ``child``
+    (append if absent), preserving every other token verbatim
+    (``--threads 8`` etc.). Both trio flags are always emitted with an
+    explicit ``0|1`` value so the FLM child's coresident-modality state is
+    unambiguous — an absent flag is normalised to its explicit ``0`` form.
+
+    ``child`` must be ``"embed"`` or ``"stt"``. The flag for ``child`` is
+    set to ``1`` when ``enable`` else ``0``; the other trio flag keeps its
+    existing value, defaulting to ``0`` when absent.
+    """
+    target_flag = _CHILD_TO_FLM_FLAG[child]
+    tokens = current.split()
+
+    # Pull the existing explicit values for both trio flags (default 0).
+    trio_values: dict[str, str] = {"--asr": "0", "--embed": "0"}
+    # Walk tokens, copying through everything that isn't a trio flag (or its
+    # value). We rebuild the trio flags at the end so ordering is stable and
+    # exactly-once even if the input had duplicates or a missing value.
+    passthrough: list[str] = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in trio_values:
+            # Consume the following value token if present + value-shaped.
+            if i + 1 < len(tokens):
+                trio_values[tok] = tokens[i + 1]
+                i += 2
+            else:
+                i += 1
+            continue
+        passthrough.append(tok)
+        i += 1
+
+    # Apply the requested toggle for the targeted modality.
+    trio_values[target_flag] = "1" if enable else "0"
+
+    # Emit: preserved tokens first, then both trio flags in a stable order.
+    out = list(passthrough)
+    out += ["--asr", trio_values["--asr"]]
+    out += ["--embed", trio_values["--embed"]]
+    return " ".join(out)
+
+
 def legal_children(slot: str) -> list[str]:
     """Return the child names valid for ``slot``."""
     return [child for (s, child) in _CHILD_TO_SLOT if s == slot]

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -12,9 +12,18 @@ managed by :class:`~hal0.slots.manager.SlotManager`. This module owns:
     match the new selection and rewrites the underlying slot's TOML when
     the user changes backend/provider.
 
-NPU multiplex (one ``flm`` process serving multiple capability children)
-is OUT OF SCOPE for this round; NPU children spawn their own slot via
-the regular ``load()`` path when needed.
+NPU multiplex (NPU Phase 2): a ``device=npu`` selection for a trio
+modality (``embed`` / ``voice.stt``) does NOT spawn a standalone process.
+Instead ``apply()`` drives the FLM trio — one ``flm serve`` anchor process
+serving chat coresident with embed/asr — by recomposing the anchor's
+lemond ``flm_args`` and writing a ``device=npu``,
+``type=embedding|transcription`` slot RECORD for dispatch gating
+(``v1._is_npu_trio_request``). The modality slot is never
+load/swap/unloaded; the anchor is never eagerly restarted — the change
+returns ``pending_reload`` and the operator applies it via the dashboard
+NPU section's reload affordance. Non-trio children (rerank/tts/img/vision)
+and non-NPU devices keep spawning their own slot via the regular
+``load()`` path.
 """
 
 from __future__ import annotations

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -690,11 +690,16 @@ class CapabilityOrchestrator:
 
           1. Ensure the device=npu, type=embedding|transcription slot
              RECORD exists (create path stamps ``type``).
-          2. Write a ``{enabled}``-only ``update_config`` (covers enable AND
-             disable so ``v1._is_npu_trio_request``'s ``enabled is False``
-             check blocks dispatch). Runs AFTER ``_rewrite_underlying_slot``
-             (Decision 4) — and NEVER passes ``model`` (nested dicts are
-             replaced wholesale by the shallow merge).
+          2. Write ``{enabled, type}`` via ``update_config`` (covers enable
+             AND disable so ``v1._is_npu_trio_request``'s ``enabled is
+             False`` check blocks dispatch). The ``type`` stamp is essential
+             for PRE-EXISTING slots: ``_ensure_slot_exists_npu`` early-returns
+             when the TOML exists, so a real drifted ``embed.toml`` with no
+             ``type`` would otherwise never gate trio dispatch. ``type`` is a
+             top-level SCALAR, so co-writing it is safe under Decision 4 —
+             that prohibition is specifically about the nested ``model`` dict
+             (replaced wholesale by the shallow merge), which we still NEVER
+             pass here. Runs AFTER ``_rewrite_underlying_slot``.
           3. Recompose the anchor's lemond ``flm_args`` for this modality.
           4. Return ``pending_reload=True`` ALWAYS (Decision 1: never
              auto-restart the live anchor; if the anchor is offline the new
@@ -703,8 +708,13 @@ class CapabilityOrchestrator:
              for ``type==llm && device==npu``; we never restart it here.
         """
         await self._ensure_slot_exists_npu(slot_name, child, selection)
-        # {enabled}-only write — explicitly NOT carrying ``model`` (Decision 4).
-        await self._slot_manager.update_config(slot_name, {"enabled": selection.enabled})
+        # Stamp {enabled, type} — NEVER the nested ``model`` (Decision 4).
+        # ``type`` is required even for an existing slot whose TOML predates
+        # Phase 2 and carries no ``type``; without it trio dispatch no-ops.
+        await self._slot_manager.update_config(
+            slot_name,
+            {"enabled": selection.enabled, "type": _CHILD_TO_SLOT_TYPE[child]},
+        )
         await self._set_flm_modality(child, enable=selection.enabled)
         # Decision 1: surface pending_reload whether or not the anchor is
         # live; we never eagerly bounce it. (The anchor scan is informational

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -116,8 +116,10 @@ def _recompose_flm_args(current: str, child: str, enable: bool) -> str:
     while i < len(tokens):
         tok = tokens[i]
         if tok in trio_values:
-            # Consume the following value token if present + value-shaped.
-            if i + 1 < len(tokens):
+            # Consume the following value token only if present AND
+            # value-shaped (not another flag) — so "--embed --threads 8"
+            # doesn't swallow "--threads" as the embed value.
+            if i + 1 < len(tokens) and not tokens[i + 1].startswith("--"):
                 trio_values[tok] = tokens[i + 1]
                 i += 2
             else:

--- a/tests/capabilities/test_catalog_npu_stt.py
+++ b/tests/capabilities/test_catalog_npu_stt.py
@@ -1,0 +1,80 @@
+"""NPU Phase 2 — catalog must surface FLM ``stt`` rows with an ``npu`` backend.
+
+Before Phase 2 the FLM picker fan-out was deliberately scoped to
+``{chat, embed}`` (the 2026-05-20 design call) — FLM also serves ``stt``
+(whisper-v3 / gemma asr=true) but the NPU voice path through the slot
+manager was a later slice. Phase 2 enables ``device=npu`` for
+``voice.stt`` driven through the FLM trio, so the orchestrator's
+validation (``models_for_capability("stt")``) must now see an ``npu``
+backend for an FLM transcription model — otherwise it rejects the npu
+selection as an illegal backend/model pair.
+
+This pins that the catalog widens to ``stt``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hal0.capabilities import catalog
+
+
+@pytest.fixture
+def flm_entries() -> list[dict[str, Any]]:
+    """An FLM transcription row alongside a chat row."""
+    return [
+        {
+            "tag": "whisper-large-v3",
+            "size_bytes": 1_500_000_000,
+            "footprint_gb": 1.6,
+            "capabilities": ["stt"],
+            "installed": True,
+        },
+        {
+            "tag": "gemma3:1b",
+            "size_bytes": 1_000_000_000,
+            "footprint_gb": 1.2,
+            "capabilities": ["chat"],
+            "installed": True,
+        },
+    ]
+
+
+def test_flm_rows_surface_stt(
+    monkeypatch: pytest.MonkeyPatch, flm_entries: list[dict[str, Any]]
+) -> None:
+    """``_flm_rows_for_capability("stt")`` returns the npu/flm transcription row."""
+    monkeypatch.setattr("hal0.providers.flm.flm_served_models", lambda: flm_entries)
+    rows = catalog._flm_rows_for_capability("stt")
+
+    ids = {row["id"] for row in rows}
+    assert "whisper-large-v3" in ids, (
+        f"FLM stt fan-out did not surface the transcription tag: {rows!r}"
+    )
+    row = next(r for r in rows if r["id"] == "whisper-large-v3")
+    assert row["backend"] == "npu"
+    assert row["provider"] == "flm"
+    assert "stt" in row["capabilities"], (
+        f"stt was filtered out of reported_caps: {row!r}"
+    )
+
+
+def test_models_for_capability_stt_has_npu_backend(
+    monkeypatch: pytest.MonkeyPatch, flm_entries: list[dict[str, Any]]
+) -> None:
+    """The orchestrator-facing API yields a model with a legal ``npu`` backend.
+
+    This is what ``_validate_model_in_catalog`` consults to decide whether
+    ``device=npu`` is legal for the picked stt model.
+    """
+    monkeypatch.setattr("hal0.providers.flm.flm_served_models", lambda: flm_entries)
+    rows = catalog.models_for_capability("stt")
+
+    match = next((r for r in rows if r["id"] == "whisper-large-v3"), None)
+    assert match is not None, f"stt model missing from models_for_capability: {rows!r}"
+    legal_backends = [b["id"] for b in match.get("backends", [])]
+    assert "npu" in legal_backends, (
+        f"npu not a legal backend for the stt model: {legal_backends!r}"
+    )

--- a/tests/capabilities/test_catalog_npu_stt.py
+++ b/tests/capabilities/test_catalog_npu_stt.py
@@ -56,9 +56,7 @@ def test_flm_rows_surface_stt(
     row = next(r for r in rows if r["id"] == "whisper-large-v3")
     assert row["backend"] == "npu"
     assert row["provider"] == "flm"
-    assert "stt" in row["capabilities"], (
-        f"stt was filtered out of reported_caps: {row!r}"
-    )
+    assert "stt" in row["capabilities"], f"stt was filtered out of reported_caps: {row!r}"
 
 
 def test_models_for_capability_stt_has_npu_backend(
@@ -75,6 +73,4 @@ def test_models_for_capability_stt_has_npu_backend(
     match = next((r for r in rows if r["id"] == "whisper-large-v3"), None)
     assert match is not None, f"stt model missing from models_for_capability: {rows!r}"
     legal_backends = [b["id"] for b in match.get("backends", [])]
-    assert "npu" in legal_backends, (
-        f"npu not a legal backend for the stt model: {legal_backends!r}"
-    )
+    assert "npu" in legal_backends, f"npu not a legal backend for the stt model: {legal_backends!r}"

--- a/tests/capabilities/test_npu_phase2_integration.py
+++ b/tests/capabilities/test_npu_phase2_integration.py
@@ -143,9 +143,7 @@ async def test_npu_phase2_embed_enable_end_to_end(
 
     client = FakeLemonadeClient(initial_flm_args="--asr 1 --embed 0")
     fake = FakeSlotManager()
-    fake.set_configs(
-        [{"name": "agent", "type": "llm", "device": "npu", "enabled": True}]
-    )
+    fake.set_configs([{"name": "agent", "type": "llm", "device": "npu", "enabled": True}])
     orch = CapabilityOrchestrator(slot_manager=fake, lemonade_provider=lambda: client)
 
     result = await orch.apply(
@@ -169,9 +167,7 @@ async def test_npu_phase2_embed_enable_end_to_end(
     enabled_writes = [
         c
         for c in fake.calls
-        if c[0] == "update_config"
-        and c[1] == "embed"
-        and c[2]["updates"] == {"enabled": True}
+        if c[0] == "update_config" and c[1] == "embed" and c[2]["updates"] == {"enabled": True}
     ]
     assert enabled_writes, f"no {{enabled}}-only write on embed slot: {fake.calls}"
     # The {enabled}-only write must NOT carry model (Decision 4).

--- a/tests/capabilities/test_npu_phase2_integration.py
+++ b/tests/capabilities/test_npu_phase2_integration.py
@@ -110,6 +110,8 @@ async def test_npu_phase2_embed_enable_end_to_end(
     slots_dir = home / "etc" / "hal0" / "slots"
     slots_dir.mkdir(parents=True, exist_ok=True)
     # Drift: slot TOML still vulkan/llama-server while caps wants npu/flm.
+    # NB: NO ``type`` on disk — the real production drift shape. The apply
+    # must stamp ``type=embedding`` itself, else trio dispatch never gates.
     (slots_dir / "embed.toml").write_text(
         "\n".join(
             [
@@ -118,7 +120,6 @@ async def test_npu_phase2_embed_enable_end_to_end(
                 'backend = "vulkan"',
                 'provider = "llama-server"',
                 "enabled = false",
-                'type = "embedding"',
                 "[model]",
                 'default = "nomic-embed-text-v1.5-q8_0"',
                 "",
@@ -162,15 +163,18 @@ async def test_npu_phase2_embed_enable_end_to_end(
     assert client.set_calls[-1] == {"flm_args": "--asr 1 --embed 1"}, client.set_calls
 
     # 2. A device=npu, type=embedding slot record is in force. The slot TOML
-    #    already existed (drift fixture) so the type survives; the enabled
-    #    flag is flipped via a {enabled}-only update_config (Decision 4).
+    #    existed with NO type (drift shape), so the apply must stamp
+    #    type=embedding alongside enabled — WITHOUT a nested model (Decision 4).
     enabled_writes = [
         c
         for c in fake.calls
-        if c[0] == "update_config" and c[1] == "embed" and c[2]["updates"] == {"enabled": True}
+        if c[0] == "update_config"
+        and c[1] == "embed"
+        and c[2]["updates"].get("enabled") is True
+        and c[2]["updates"].get("type") == "embedding"
     ]
-    assert enabled_writes, f"no {{enabled}}-only write on embed slot: {fake.calls}"
-    # The {enabled}-only write must NOT carry model (Decision 4).
+    assert enabled_writes, f"no enabled+type write on embed slot: {fake.calls}"
+    # That write must NOT carry the nested model (Decision 4).
     assert "model" not in enabled_writes[-1][2]["updates"]
 
     # 3. ZERO standalone spawn on the embed slot.

--- a/tests/capabilities/test_npu_phase2_integration.py
+++ b/tests/capabilities/test_npu_phase2_integration.py
@@ -1,0 +1,193 @@
+"""NPU Phase 2 — end-to-end smoke for the trio-driven embed path.
+
+Drives ``CapabilityOrchestrator.apply()`` through the full reconcile +
+trio fork against on-disk capabilities.toml / slot TOML, asserting the
+whole Phase 2 contract in one pass:
+
+  - lemond ``flm_args`` recomposed to enable the modality;
+  - a ``device=npu``, ``type=embedding`` slot RECORD exists (so
+    ``v1._is_npu_trio_request`` gates dispatch on);
+  - ZERO ``load``/``swap``/``unload`` on the embed slot (the FLM anchor
+    serves it coresident — no standalone process);
+  - the anchor is never eagerly restarted; ``pending_reload`` is True;
+  - the persisted capabilities.toml reflects device=npu + enabled.
+
+The on-disk layout is the "drift" fixture: capabilities.toml says
+npu/flm/enabled while the embed slot TOML still says vulkan — exactly the
+mismatch Phase 1 left when the NPU section couldn't drive the trio.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.capabilities.config import load_capabilities_config
+from hal0.capabilities.orchestrator import CapabilityOrchestrator
+
+
+@pytest.fixture(autouse=True)
+def _no_spawn_context_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    import hal0.agents.hermes_refresh as _hr
+
+    monkeypatch.setattr(_hr, "spawn_context_refresh", lambda *a, **k: None)
+
+
+class _StubSlot:
+    def __init__(self, state: str = "ready") -> None:
+        class _S:
+            value = state
+
+        self.state = _S()
+
+
+class FakeSlotManager:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self._configs: list[dict[str, Any]] = []
+
+    def set_configs(self, configs: list[dict[str, Any]]) -> None:
+        self._configs = list(configs)
+
+    async def iter_configs(self) -> list[dict[str, Any]]:
+        self.calls.append(("iter_configs", "", {}))
+        return list(self._configs)
+
+    async def status(self, slot_name: str) -> _StubSlot:
+        self.calls.append(("status", slot_name, {}))
+        return _StubSlot("ready")
+
+    async def load(self, slot_name: str, model_id: str | None = None) -> _StubSlot:
+        self.calls.append(("load", slot_name, {"model_id": model_id}))
+        return _StubSlot("ready")
+
+    async def unload(self, slot_name: str) -> _StubSlot:
+        self.calls.append(("unload", slot_name, {}))
+        return _StubSlot("offline")
+
+    async def swap(self, slot_name: str, new_model_id: str) -> _StubSlot:
+        self.calls.append(("swap", slot_name, {"model_id": new_model_id}))
+        return _StubSlot("ready")
+
+    async def restart(self, slot_name: str) -> _StubSlot:
+        self.calls.append(("restart", slot_name, {}))
+        return _StubSlot("ready")
+
+    async def create(self, slot_name: str, cfg: dict[str, Any]) -> _StubSlot:
+        self.calls.append(("create", slot_name, {"cfg": cfg}))
+        return _StubSlot("offline")
+
+    async def update_config(self, slot_name: str, updates: dict[str, Any]) -> _StubSlot:
+        self.calls.append(("update_config", slot_name, {"updates": updates}))
+        return _StubSlot("ready")
+
+
+class FakeLemonadeClient:
+    def __init__(self, initial_flm_args: str = "") -> None:
+        self._config: dict[str, Any] = {"flm_args": initial_flm_args}
+        self.set_calls: list[dict[str, Any]] = []
+
+    async def internal_config(self) -> dict[str, Any]:
+        return dict(self._config)
+
+    async def internal_set(self, values: dict[str, Any]) -> dict[str, Any]:
+        self.set_calls.append(dict(values))
+        self._config.update(values)
+        return dict(self._config)
+
+
+async def test_npu_phase2_embed_enable_end_to_end(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        CapabilityOrchestrator,
+        "_validate_model_in_catalog",
+        lambda self, slot, child, model_id, backend_id: None,
+    )
+    home = Path(tmp_hal0_home)
+    slots_dir = home / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    # Drift: slot TOML still vulkan/llama-server while caps wants npu/flm.
+    (slots_dir / "embed.toml").write_text(
+        "\n".join(
+            [
+                'name = "embed"',
+                "port = 8082",
+                'backend = "vulkan"',
+                'provider = "llama-server"',
+                "enabled = false",
+                'type = "embedding"',
+                "[model]",
+                'default = "nomic-embed-text-v1.5-q8_0"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    caps_path = home / "etc" / "hal0" / "capabilities.toml"
+    caps_path.write_text(
+        "\n".join(
+            [
+                "[selections.embed.embed]",
+                'backend = "npu"',
+                'provider = "flm"',
+                'model = "nomic-embed-text-v1.5-q8_0"',
+                "enabled = false",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    client = FakeLemonadeClient(initial_flm_args="--asr 1 --embed 0")
+    fake = FakeSlotManager()
+    fake.set_configs(
+        [{"name": "agent", "type": "llm", "device": "npu", "enabled": True}]
+    )
+    orch = CapabilityOrchestrator(slot_manager=fake, lemonade_provider=lambda: client)
+
+    result = await orch.apply(
+        "embed",
+        "embed",
+        {
+            "enabled": True,
+            "backend": "npu",
+            "provider": "flm",
+            "model": "nomic-embed-text-v1.5-q8_0",
+        },
+    )
+
+    # 1. flm_args recomposed to enable embed on the anchor.
+    assert client.set_calls, "anchor flm_args was never set"
+    assert client.set_calls[-1] == {"flm_args": "--asr 1 --embed 1"}, client.set_calls
+
+    # 2. A device=npu, type=embedding slot record is in force. The slot TOML
+    #    already existed (drift fixture) so the type survives; the enabled
+    #    flag is flipped via a {enabled}-only update_config (Decision 4).
+    enabled_writes = [
+        c
+        for c in fake.calls
+        if c[0] == "update_config"
+        and c[1] == "embed"
+        and c[2]["updates"] == {"enabled": True}
+    ]
+    assert enabled_writes, f"no {{enabled}}-only write on embed slot: {fake.calls}"
+    # The {enabled}-only write must NOT carry model (Decision 4).
+    assert "model" not in enabled_writes[-1][2]["updates"]
+
+    # 3. ZERO standalone spawn on the embed slot.
+    assert not [c for c in fake.calls if c[0] in ("load", "swap", "unload")], (
+        f"NPU embed path must not bounce the modality slot: {fake.calls}"
+    )
+
+    # 4. Anchor never eagerly restarted; pending_reload surfaced.
+    assert not [c for c in fake.calls if c[0] == "restart"], fake.calls
+    assert result.get("pending_reload") is True
+
+    # 5. Persisted selection reflects device=npu + enabled.
+    persisted = load_capabilities_config(caps_path)
+    sel = persisted.selections["embed"]["embed"]
+    assert sel.device == "npu"
+    assert sel.enabled is True

--- a/tests/capabilities/test_orchestrator_reconciliation.py
+++ b/tests/capabilities/test_orchestrator_reconciliation.py
@@ -369,3 +369,239 @@ async def test_fake_lemonade_client_records_set() -> None:
     await client.internal_set({"flm_args": "--asr 1 --embed 0"})
     assert client.set_calls[-1] == {"flm_args": "--asr 1 --embed 0"}
     assert (await client.internal_config())["flm_args"] == "--asr 1 --embed 0"
+
+
+# ── Step 5: NPU-trio fork (Cases 1-5, 9) ──────────────────────────────────────
+
+
+def _write_embed_slot(home: Path, *, device: str = "vulkan", slot_type: str | None = None) -> None:
+    """(Re)write etc/hal0/slots/embed.toml under ``home``."""
+    slots_dir = home / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    lines = [
+        'name = "embed"',
+        "port = 8082",
+        f'backend = "{device}"',
+        'provider = "llama-server"',
+        "enabled = true",
+    ]
+    if slot_type:
+        lines.append(f'type = "{slot_type}"')
+    lines += ["[model]", 'default = "nomic-embed-text-v1.5-q8_0"', ""]
+    (slots_dir / "embed.toml").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_caps(home: Path, *, slot: str, child: str, fields: dict[str, Any]) -> None:
+    """Write a single-selection capabilities.toml under ``home``."""
+    caps_path = home / "etc" / "hal0" / "capabilities.toml"
+    caps_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"[selections.{slot}.{child}]"]
+    for k, v in fields.items():
+        if isinstance(v, bool):
+            lines.append(f"{k} = {str(v).lower()}")
+        else:
+            lines.append(f'{k} = "{v}"')
+    lines.append("")
+    caps_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+@pytest.fixture
+def npu_orchestrator(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> tuple[CapabilityOrchestrator, FakeSlotManager, FakeLemonadeClient]:
+    """Orchestrator wired with a FakeLemonadeClient — engages the trio fork.
+
+    Bypasses catalog validation (downstream of the path under test). The
+    anchor is seeded live (type=llm,device=npu) with the FLM child already
+    serving chat+asr (``--asr 1 --embed 0``) so a Case-1 embed-enable
+    yields the exact ``--asr 1 --embed 1``.
+    """
+    monkeypatch.setattr(
+        CapabilityOrchestrator,
+        "_validate_model_in_catalog",
+        lambda self, slot, child, model_id, backend_id: None,
+    )
+    client = FakeLemonadeClient(initial_flm_args="--asr 1 --embed 0")
+    fake = FakeSlotManager()
+    fake.set_configs(
+        [{"name": "agent", "type": "llm", "device": "npu", "enabled": True}]
+    )
+    orch = CapabilityOrchestrator(slot_manager=fake, lemonade_provider=lambda: client)
+    return orch, fake, client
+
+
+async def test_npu_embed_enable_sets_flm_args_no_load(
+    npu_orchestrator: tuple[CapabilityOrchestrator, FakeSlotManager, FakeLemonadeClient],
+    tmp_hal0_home: str,
+) -> None:
+    """Case 1: NPU embed enable → flm_args embed=1, update_config enabled, NO load."""
+    orch, fake, client = npu_orchestrator
+    home = Path(tmp_hal0_home)
+    _write_embed_slot(home, device="flm", slot_type="embedding")
+    _write_caps(home, slot="embed", child="embed", fields={
+        "backend": "npu", "provider": "flm",
+        "model": "nomic-embed-text-v1.5-q8_0", "enabled": False,
+    })
+
+    result = await orch.apply("embed", "embed", {
+        "enabled": True, "backend": "npu", "provider": "flm",
+        "model": "nomic-embed-text-v1.5-q8_0",
+    })
+
+    assert client.set_calls, "flm_args was never set"
+    assert client.set_calls[-1] == {"flm_args": "--asr 1 --embed 1"}, client.set_calls
+    # The embed slot must be flipped enabled=true via a {enabled}-only write.
+    enabled_writes = [
+        c for c in fake.calls
+        if c[0] == "update_config" and c[1] == "embed" and c[2]["updates"] == {"enabled": True}
+    ]
+    assert enabled_writes, f"no enabled-only update_config on embed slot: {fake.calls}"
+    # ZERO load/swap/unload on the embed slot.
+    assert not [c for c in fake.calls if c[0] in ("load", "swap", "unload")], (
+        f"NPU embed path must not bounce the slot: {fake.calls}"
+    )
+    assert result.get("pending_reload") is True, result
+
+
+async def test_npu_embed_disable_zeroes_flm_args_no_unload(
+    npu_orchestrator: tuple[CapabilityOrchestrator, FakeSlotManager, FakeLemonadeClient],
+    tmp_hal0_home: str,
+) -> None:
+    """Case 2: NPU embed disable → flm_args embed=0, slot enabled=False, NO unload."""
+    orch, fake, client = npu_orchestrator
+    home = Path(tmp_hal0_home)
+    _write_embed_slot(home, device="flm", slot_type="embedding")
+    _write_caps(home, slot="embed", child="embed", fields={
+        "backend": "npu", "provider": "flm",
+        "model": "nomic-embed-text-v1.5-q8_0", "enabled": True,
+    })
+
+    result = await orch.apply("embed", "embed", {"enabled": False})
+
+    assert client.set_calls[-1] == {"flm_args": "--asr 1 --embed 0"}, client.set_calls
+    disabled_writes = [
+        c for c in fake.calls
+        if c[0] == "update_config" and c[1] == "embed" and c[2]["updates"] == {"enabled": False}
+    ]
+    assert disabled_writes, f"no enabled=False write on embed slot: {fake.calls}"
+    assert not [c for c in fake.calls if c[0] in ("load", "swap", "unload")], (
+        f"NPU embed disable must not unload the slot: {fake.calls}"
+    )
+    assert result.get("pending_reload") is True
+
+
+async def test_npu_stt_enable_sets_asr(
+    npu_orchestrator: tuple[CapabilityOrchestrator, FakeSlotManager, FakeLemonadeClient],
+    tmp_hal0_home: str,
+) -> None:
+    """Case 3: NPU stt enable → flm_args asr=1, no standalone load."""
+    orch, fake, client = npu_orchestrator
+    home = Path(tmp_hal0_home)
+    # stt slot does not exist on disk → create path writes type=transcription.
+    _write_caps(home, slot="voice", child="stt", fields={
+        "backend": "npu", "provider": "flm", "model": "whisper-large-v3", "enabled": False,
+    })
+
+    await orch.apply("voice", "stt", {
+        "enabled": True, "backend": "npu", "provider": "flm", "model": "whisper-large-v3",
+    })
+
+    assert client.set_calls, "flm_args was never set for stt"
+    last = client.set_calls[-1]["flm_args"]
+    assert "--asr 1" in last, f"stt enable did not set asr=1: {last!r}"
+    assert not [c for c in fake.calls if c[0] in ("load", "swap", "unload")], (
+        f"NPU stt path must not bounce a slot: {fake.calls}"
+    )
+    # Created stt slot stamps type=transcription.
+    create_calls = [c for c in fake.calls if c[0] == "create" and c[1] == "stt"]
+    assert create_calls, f"stt slot not created: {fake.calls}"
+    assert create_calls[-1][2]["cfg"].get("type") == "transcription"
+
+
+async def test_embed_gpu_to_npu_no_load(
+    npu_orchestrator: tuple[CapabilityOrchestrator, FakeSlotManager, FakeLemonadeClient],
+    tmp_hal0_home: str,
+) -> None:
+    """Case 4: embed gpu-vulkan→npu → flm_args embed=1, device=npu, NO load/swap."""
+    orch, fake, client = npu_orchestrator
+    home = Path(tmp_hal0_home)
+    _write_embed_slot(home, device="vulkan", slot_type="embedding")
+    _write_caps(home, slot="embed", child="embed", fields={
+        "backend": "gpu-vulkan", "provider": "llama-server",
+        "model": "nomic-embed-text-v1.5-q8_0", "enabled": True,
+    })
+
+    await orch.apply("embed", "embed", {
+        "enabled": True, "backend": "npu", "provider": "flm",
+        "model": "nomic-embed-text-v1.5-q8_0",
+    })
+
+    assert "--embed 1" in client.set_calls[-1]["flm_args"], client.set_calls
+    # device rewritten to npu on the slot TOML.
+    dev_writes = [
+        c for c in fake.calls
+        if c[0] == "update_config" and c[1] == "embed" and c[2]["updates"].get("device") == "npu"
+    ]
+    assert dev_writes, f"device not rewritten to npu: {fake.calls}"
+    assert not [c for c in fake.calls if c[0] in ("load", "swap", "unload")], (
+        f"gpu->npu must not bounce the embed slot: {fake.calls}"
+    )
+
+
+async def test_embed_npu_to_gpu_zeroes_flm_and_loads(
+    npu_orchestrator: tuple[CapabilityOrchestrator, FakeSlotManager, FakeLemonadeClient],
+    tmp_hal0_home: str,
+) -> None:
+    """Case 5: embed npu→gpu-vulkan → flm_args embed=0 AND gpu path DOES load/swap."""
+    orch, fake, client = npu_orchestrator
+    home = Path(tmp_hal0_home)
+    _write_embed_slot(home, device="flm", slot_type="embedding")
+    _write_caps(home, slot="embed", child="embed", fields={
+        "backend": "npu", "provider": "flm",
+        "model": "nomic-embed-text-v1.5-q8_0", "enabled": True,
+    })
+
+    await orch.apply("embed", "embed", {
+        "enabled": True, "backend": "gpu-vulkan", "provider": "llama-server",
+        "model": "nomic-embed-text-v1.5-q8_0",
+    })
+
+    # Leaving NPU must drop embed from the anchor's flm_args.
+    assert client.set_calls, "leaving npu did not touch flm_args"
+    assert "--embed 0" in client.set_calls[-1]["flm_args"], client.set_calls
+    # The gpu path runs the standard lifecycle (device/model changed → swap, or load).
+    assert [c for c in fake.calls if c[0] in ("load", "swap")], (
+        f"gpu-vulkan target must run the standard load/swap path: {fake.calls}"
+    )
+
+
+async def test_npu_embed_anchor_offline_still_pending(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Case 9: anchor offline → pending_reload True, NO restart."""
+    monkeypatch.setattr(
+        CapabilityOrchestrator,
+        "_validate_model_in_catalog",
+        lambda self, slot, child, model_id, backend_id: None,
+    )
+    client = FakeLemonadeClient(initial_flm_args="--asr 1 --embed 0")
+    fake = FakeSlotManager()
+    # No anchor record at all → "offline".
+    fake.set_configs([])
+    orch = CapabilityOrchestrator(slot_manager=fake, lemonade_provider=lambda: client)
+    home = Path(tmp_hal0_home)
+    _write_embed_slot(home, device="flm", slot_type="embedding")
+    _write_caps(home, slot="embed", child="embed", fields={
+        "backend": "npu", "provider": "flm",
+        "model": "nomic-embed-text-v1.5-q8_0", "enabled": False,
+    })
+
+    result = await orch.apply("embed", "embed", {
+        "enabled": True, "backend": "npu", "provider": "flm",
+        "model": "nomic-embed-text-v1.5-q8_0",
+    })
+
+    assert result.get("pending_reload") is True
+    assert not [c for c in fake.calls if c[0] == "restart"], (
+        f"anchor must never be eagerly restarted: {fake.calls}"
+    )

--- a/tests/capabilities/test_orchestrator_reconciliation.py
+++ b/tests/capabilities/test_orchestrator_reconciliation.py
@@ -461,13 +461,18 @@ async def test_npu_embed_enable_sets_flm_args_no_load(
 
     assert client.set_calls, "flm_args was never set"
     assert client.set_calls[-1] == {"flm_args": "--asr 1 --embed 1"}, client.set_calls
-    # The embed slot must be flipped enabled=true via a {enabled}-only write.
+    # The embed slot must be flipped enabled=true + stamped type=embedding,
+    # WITHOUT a nested model in that write (Decision 4).
     enabled_writes = [
         c
         for c in fake.calls
-        if c[0] == "update_config" and c[1] == "embed" and c[2]["updates"] == {"enabled": True}
+        if c[0] == "update_config"
+        and c[1] == "embed"
+        and c[2]["updates"].get("enabled") is True
+        and c[2]["updates"].get("type") == "embedding"
     ]
-    assert enabled_writes, f"no enabled-only update_config on embed slot: {fake.calls}"
+    assert enabled_writes, f"no enabled+type update_config on embed slot: {fake.calls}"
+    assert "model" not in enabled_writes[-1][2]["updates"], enabled_writes[-1]
     # ZERO load/swap/unload on the embed slot.
     assert not [c for c in fake.calls if c[0] in ("load", "swap", "unload")], (
         f"NPU embed path must not bounce the slot: {fake.calls}"
@@ -501,9 +506,13 @@ async def test_npu_embed_disable_zeroes_flm_args_no_unload(
     disabled_writes = [
         c
         for c in fake.calls
-        if c[0] == "update_config" and c[1] == "embed" and c[2]["updates"] == {"enabled": False}
+        if c[0] == "update_config"
+        and c[1] == "embed"
+        and c[2]["updates"].get("enabled") is False
+        and c[2]["updates"].get("type") == "embedding"
     ]
-    assert disabled_writes, f"no enabled=False write on embed slot: {fake.calls}"
+    assert disabled_writes, f"no enabled=False+type write on embed slot: {fake.calls}"
+    assert "model" not in disabled_writes[-1][2]["updates"], disabled_writes[-1]
     assert not [c for c in fake.calls if c[0] in ("load", "swap", "unload")], (
         f"NPU embed disable must not unload the slot: {fake.calls}"
     )
@@ -680,3 +689,65 @@ async def test_npu_embed_anchor_offline_still_pending(
     assert not [c for c in fake.calls if c[0] == "restart"], (
         f"anchor must never be eagerly restarted: {fake.calls}"
     )
+
+
+async def test_npu_embed_existing_slot_without_type_gets_typed(
+    npu_orchestrator: tuple[CapabilityOrchestrator, FakeSlotManager, FakeLemonadeClient],
+    tmp_hal0_home: str,
+) -> None:
+    """A pre-existing embed slot with NO ``type`` must be stamped on the npu path.
+
+    The real production drift shape (the original ``drifted_state`` fixture)
+    has an ``embed.toml`` with no ``type`` key. ``_ensure_slot_exists_npu``
+    early-returns for an existing TOML, so the ``type`` discriminator must be
+    written some other way — otherwise ``v1._is_npu_trio_request`` never
+    matches (``cfg.get("type") != "embedding"``) and trio dispatch silently
+    no-ops, violating the hard constraint that the npu path leaves a
+    ``device=npu, type=embedding`` record in force.
+    """
+    orch, fake, _client = npu_orchestrator
+    home = Path(tmp_hal0_home)
+    # Existing slot, NO type (matches the production drift shape).
+    _write_embed_slot(home, device="vulkan", slot_type=None)
+    _write_caps(
+        home,
+        slot="embed",
+        child="embed",
+        fields={
+            "backend": "npu",
+            "provider": "flm",
+            "model": "nomic-embed-text-v1.5-q8_0",
+            "enabled": False,
+        },
+    )
+
+    await orch.apply(
+        "embed",
+        "embed",
+        {
+            "enabled": True,
+            "backend": "npu",
+            "provider": "flm",
+            "model": "nomic-embed-text-v1.5-q8_0",
+        },
+    )
+
+    # The embed slot record must carry type=embedding after the apply, via
+    # one of the update_config writes on the slot.
+    type_writes = [
+        c
+        for c in fake.calls
+        if c[0] == "update_config"
+        and c[1] == "embed"
+        and c[2]["updates"].get("type") == "embedding"
+    ]
+    assert type_writes, (
+        "embed slot was never stamped with type=embedding on the npu path; "
+        f"trio dispatch would silently no-op. calls: {fake.calls}"
+    )
+    # Decision 4: the write that carries type must NOT carry a nested model
+    # (nested dicts are replaced wholesale by the shallow merge).
+    for c in type_writes:
+        assert "model" not in c[2]["updates"], (
+            f"type write must not carry model (Decision 4): {c[2]['updates']!r}"
+        )

--- a/tests/capabilities/test_orchestrator_reconciliation.py
+++ b/tests/capabilities/test_orchestrator_reconciliation.py
@@ -53,6 +53,17 @@ class FakeSlotManager:
 
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        # Slot config records the orchestrator scans for the NPU anchor
+        # (type==llm && device==npu). Seed via :meth:`set_configs`.
+        self._configs: list[dict[str, Any]] = []
+
+    def set_configs(self, configs: list[dict[str, Any]]) -> None:
+        """Test helper — seed the records returned by ``iter_configs()``."""
+        self._configs = list(configs)
+
+    async def iter_configs(self) -> list[dict[str, Any]]:
+        self.calls.append(("iter_configs", "", {}))
+        return list(self._configs)
 
     async def status(self, slot_name: str) -> _StubSlot:
         self.calls.append(("status", slot_name, {}))
@@ -70,6 +81,12 @@ class FakeSlotManager:
         self.calls.append(("swap", slot_name, {"model_id": new_model_id}))
         return _StubSlot("ready")
 
+    async def restart(self, slot_name: str) -> _StubSlot:
+        # Recorded so tests can assert the NPU path NEVER eagerly restarts
+        # the anchor (Decision 1: return pending_reload, don't bounce it).
+        self.calls.append(("restart", slot_name, {}))
+        return _StubSlot("ready")
+
     async def create(self, slot_name: str, cfg: dict[str, Any]) -> _StubSlot:
         self.calls.append(("create", slot_name, {"cfg": cfg}))
         return _StubSlot("offline")
@@ -77,6 +94,29 @@ class FakeSlotManager:
     async def update_config(self, slot_name: str, updates: dict[str, Any]) -> _StubSlot:
         self.calls.append(("update_config", slot_name, {"updates": updates}))
         return _StubSlot("ready")
+
+
+class FakeLemonadeClient:
+    """Records ``internal_config`` reads + ``internal_set`` writes.
+
+    Mirrors :class:`hal0.lemonade.client.LemonadeClient` for the two
+    methods the orchestrator's NPU-trio path uses. ``flm_args`` starts at
+    whatever ``initial_flm_args`` is passed (the trio anchor's current
+    args); ``internal_set`` merges the patch so a later ``internal_config``
+    reflects it.
+    """
+
+    def __init__(self, initial_flm_args: str = "") -> None:
+        self._config: dict[str, Any] = {"flm_args": initial_flm_args}
+        self.set_calls: list[dict[str, Any]] = []
+
+    async def internal_config(self) -> dict[str, Any]:
+        return dict(self._config)
+
+    async def internal_set(self, values: dict[str, Any]) -> dict[str, Any]:
+        self.set_calls.append(dict(values))
+        self._config.update(values)
+        return dict(self._config)
 
 
 @pytest.fixture
@@ -310,3 +350,22 @@ def test_recompose_flm_args_disable_emits_explicit_zero() -> None:
     out = _recompose_flm_args("--asr 1 --embed 1", "embed", False)
     assert "--embed 0" in out
     assert "--asr 1" in out
+
+
+# ── Step 4: test stubs (FakeSlotManager.iter_configs/restart, FakeLemonadeClient)
+
+
+async def test_fake_slot_manager_iter_configs_roundtrip() -> None:
+    fake = FakeSlotManager()
+    fake.set_configs([{"name": "agent", "type": "llm", "device": "npu", "enabled": True}])
+    configs = await fake.iter_configs()
+    assert configs == [{"name": "agent", "type": "llm", "device": "npu", "enabled": True}]
+
+
+async def test_fake_lemonade_client_records_set() -> None:
+    client = FakeLemonadeClient(initial_flm_args="--asr 1 --embed 1")
+    cfg = await client.internal_config()
+    assert cfg["flm_args"] == "--asr 1 --embed 1"
+    await client.internal_set({"flm_args": "--asr 1 --embed 0"})
+    assert client.set_calls[-1] == {"flm_args": "--asr 1 --embed 0"}
+    assert (await client.internal_config())["flm_args"] == "--asr 1 --embed 0"

--- a/tests/capabilities/test_orchestrator_reconciliation.py
+++ b/tests/capabilities/test_orchestrator_reconciliation.py
@@ -270,3 +270,43 @@ def test_ensure_slot_exists_omits_type_for_rerank() -> None:
     # embed-rerank → child "rerank", not in the trio-type map.
     assert "rerank" not in _CHILD_TO_SLOT_TYPE
     assert "tts" not in _CHILD_TO_SLOT_TYPE
+
+
+# ── Step 2: _recompose_flm_args (Case 6) ──────────────────────────────────────
+
+
+def test_recompose_flm_args_empty_embed_enable() -> None:
+    """Empty current args + (embed, True) → both trio flags explicit, embed=1."""
+    from hal0.capabilities.orchestrator import _recompose_flm_args
+
+    out = _recompose_flm_args("", "embed", True)
+    assert "--embed 1" in out
+    assert "--asr 0" in out  # absent → appended explicit 0
+
+
+def test_recompose_flm_args_preserves_unrecognized_flags() -> None:
+    """Decision 2: only the targeted trio flag is touched; others verbatim."""
+    from hal0.capabilities.orchestrator import _recompose_flm_args
+
+    out = _recompose_flm_args("--threads 8 --asr 1 --embed 0", "embed", True)
+    assert "--threads 8" in out, f"unrecognized flag dropped: {out!r}"
+    assert "--embed 1" in out, f"embed not flipped on: {out!r}"
+    assert "--asr 1" in out, f"asr clobbered: {out!r}"
+
+
+def test_recompose_flm_args_stt_sets_asr() -> None:
+    """child=stt maps to --asr (not --embed)."""
+    from hal0.capabilities.orchestrator import _recompose_flm_args
+
+    out = _recompose_flm_args("--embed 1", "stt", True)
+    assert "--asr 1" in out
+    assert "--embed 1" in out  # preserved
+
+
+def test_recompose_flm_args_disable_emits_explicit_zero() -> None:
+    """Disabling a modality emits the explicit 0 form, keeps the other flag."""
+    from hal0.capabilities.orchestrator import _recompose_flm_args
+
+    out = _recompose_flm_args("--asr 1 --embed 1", "embed", False)
+    assert "--embed 0" in out
+    assert "--asr 1" in out

--- a/tests/capabilities/test_orchestrator_reconciliation.py
+++ b/tests/capabilities/test_orchestrator_reconciliation.py
@@ -423,9 +423,7 @@ def npu_orchestrator(
     )
     client = FakeLemonadeClient(initial_flm_args="--asr 1 --embed 0")
     fake = FakeSlotManager()
-    fake.set_configs(
-        [{"name": "agent", "type": "llm", "device": "npu", "enabled": True}]
-    )
+    fake.set_configs([{"name": "agent", "type": "llm", "device": "npu", "enabled": True}])
     orch = CapabilityOrchestrator(slot_manager=fake, lemonade_provider=lambda: client)
     return orch, fake, client
 
@@ -438,21 +436,35 @@ async def test_npu_embed_enable_sets_flm_args_no_load(
     orch, fake, client = npu_orchestrator
     home = Path(tmp_hal0_home)
     _write_embed_slot(home, device="flm", slot_type="embedding")
-    _write_caps(home, slot="embed", child="embed", fields={
-        "backend": "npu", "provider": "flm",
-        "model": "nomic-embed-text-v1.5-q8_0", "enabled": False,
-    })
+    _write_caps(
+        home,
+        slot="embed",
+        child="embed",
+        fields={
+            "backend": "npu",
+            "provider": "flm",
+            "model": "nomic-embed-text-v1.5-q8_0",
+            "enabled": False,
+        },
+    )
 
-    result = await orch.apply("embed", "embed", {
-        "enabled": True, "backend": "npu", "provider": "flm",
-        "model": "nomic-embed-text-v1.5-q8_0",
-    })
+    result = await orch.apply(
+        "embed",
+        "embed",
+        {
+            "enabled": True,
+            "backend": "npu",
+            "provider": "flm",
+            "model": "nomic-embed-text-v1.5-q8_0",
+        },
+    )
 
     assert client.set_calls, "flm_args was never set"
     assert client.set_calls[-1] == {"flm_args": "--asr 1 --embed 1"}, client.set_calls
     # The embed slot must be flipped enabled=true via a {enabled}-only write.
     enabled_writes = [
-        c for c in fake.calls
+        c
+        for c in fake.calls
         if c[0] == "update_config" and c[1] == "embed" and c[2]["updates"] == {"enabled": True}
     ]
     assert enabled_writes, f"no enabled-only update_config on embed slot: {fake.calls}"
@@ -471,16 +483,24 @@ async def test_npu_embed_disable_zeroes_flm_args_no_unload(
     orch, fake, client = npu_orchestrator
     home = Path(tmp_hal0_home)
     _write_embed_slot(home, device="flm", slot_type="embedding")
-    _write_caps(home, slot="embed", child="embed", fields={
-        "backend": "npu", "provider": "flm",
-        "model": "nomic-embed-text-v1.5-q8_0", "enabled": True,
-    })
+    _write_caps(
+        home,
+        slot="embed",
+        child="embed",
+        fields={
+            "backend": "npu",
+            "provider": "flm",
+            "model": "nomic-embed-text-v1.5-q8_0",
+            "enabled": True,
+        },
+    )
 
     result = await orch.apply("embed", "embed", {"enabled": False})
 
     assert client.set_calls[-1] == {"flm_args": "--asr 1 --embed 0"}, client.set_calls
     disabled_writes = [
-        c for c in fake.calls
+        c
+        for c in fake.calls
         if c[0] == "update_config" and c[1] == "embed" and c[2]["updates"] == {"enabled": False}
     ]
     assert disabled_writes, f"no enabled=False write on embed slot: {fake.calls}"
@@ -498,13 +518,28 @@ async def test_npu_stt_enable_sets_asr(
     orch, fake, client = npu_orchestrator
     home = Path(tmp_hal0_home)
     # stt slot does not exist on disk → create path writes type=transcription.
-    _write_caps(home, slot="voice", child="stt", fields={
-        "backend": "npu", "provider": "flm", "model": "whisper-large-v3", "enabled": False,
-    })
+    _write_caps(
+        home,
+        slot="voice",
+        child="stt",
+        fields={
+            "backend": "npu",
+            "provider": "flm",
+            "model": "whisper-large-v3",
+            "enabled": False,
+        },
+    )
 
-    await orch.apply("voice", "stt", {
-        "enabled": True, "backend": "npu", "provider": "flm", "model": "whisper-large-v3",
-    })
+    await orch.apply(
+        "voice",
+        "stt",
+        {
+            "enabled": True,
+            "backend": "npu",
+            "provider": "flm",
+            "model": "whisper-large-v3",
+        },
+    )
 
     assert client.set_calls, "flm_args was never set for stt"
     last = client.set_calls[-1]["flm_args"]
@@ -526,20 +561,34 @@ async def test_embed_gpu_to_npu_no_load(
     orch, fake, client = npu_orchestrator
     home = Path(tmp_hal0_home)
     _write_embed_slot(home, device="vulkan", slot_type="embedding")
-    _write_caps(home, slot="embed", child="embed", fields={
-        "backend": "gpu-vulkan", "provider": "llama-server",
-        "model": "nomic-embed-text-v1.5-q8_0", "enabled": True,
-    })
+    _write_caps(
+        home,
+        slot="embed",
+        child="embed",
+        fields={
+            "backend": "gpu-vulkan",
+            "provider": "llama-server",
+            "model": "nomic-embed-text-v1.5-q8_0",
+            "enabled": True,
+        },
+    )
 
-    await orch.apply("embed", "embed", {
-        "enabled": True, "backend": "npu", "provider": "flm",
-        "model": "nomic-embed-text-v1.5-q8_0",
-    })
+    await orch.apply(
+        "embed",
+        "embed",
+        {
+            "enabled": True,
+            "backend": "npu",
+            "provider": "flm",
+            "model": "nomic-embed-text-v1.5-q8_0",
+        },
+    )
 
     assert "--embed 1" in client.set_calls[-1]["flm_args"], client.set_calls
     # device rewritten to npu on the slot TOML.
     dev_writes = [
-        c for c in fake.calls
+        c
+        for c in fake.calls
         if c[0] == "update_config" and c[1] == "embed" and c[2]["updates"].get("device") == "npu"
     ]
     assert dev_writes, f"device not rewritten to npu: {fake.calls}"
@@ -556,15 +605,28 @@ async def test_embed_npu_to_gpu_zeroes_flm_and_loads(
     orch, fake, client = npu_orchestrator
     home = Path(tmp_hal0_home)
     _write_embed_slot(home, device="flm", slot_type="embedding")
-    _write_caps(home, slot="embed", child="embed", fields={
-        "backend": "npu", "provider": "flm",
-        "model": "nomic-embed-text-v1.5-q8_0", "enabled": True,
-    })
+    _write_caps(
+        home,
+        slot="embed",
+        child="embed",
+        fields={
+            "backend": "npu",
+            "provider": "flm",
+            "model": "nomic-embed-text-v1.5-q8_0",
+            "enabled": True,
+        },
+    )
 
-    await orch.apply("embed", "embed", {
-        "enabled": True, "backend": "gpu-vulkan", "provider": "llama-server",
-        "model": "nomic-embed-text-v1.5-q8_0",
-    })
+    await orch.apply(
+        "embed",
+        "embed",
+        {
+            "enabled": True,
+            "backend": "gpu-vulkan",
+            "provider": "llama-server",
+            "model": "nomic-embed-text-v1.5-q8_0",
+        },
+    )
 
     # Leaving NPU must drop embed from the anchor's flm_args.
     assert client.set_calls, "leaving npu did not touch flm_args"
@@ -591,15 +653,28 @@ async def test_npu_embed_anchor_offline_still_pending(
     orch = CapabilityOrchestrator(slot_manager=fake, lemonade_provider=lambda: client)
     home = Path(tmp_hal0_home)
     _write_embed_slot(home, device="flm", slot_type="embedding")
-    _write_caps(home, slot="embed", child="embed", fields={
-        "backend": "npu", "provider": "flm",
-        "model": "nomic-embed-text-v1.5-q8_0", "enabled": False,
-    })
+    _write_caps(
+        home,
+        slot="embed",
+        child="embed",
+        fields={
+            "backend": "npu",
+            "provider": "flm",
+            "model": "nomic-embed-text-v1.5-q8_0",
+            "enabled": False,
+        },
+    )
 
-    result = await orch.apply("embed", "embed", {
-        "enabled": True, "backend": "npu", "provider": "flm",
-        "model": "nomic-embed-text-v1.5-q8_0",
-    })
+    result = await orch.apply(
+        "embed",
+        "embed",
+        {
+            "enabled": True,
+            "backend": "npu",
+            "provider": "flm",
+            "model": "nomic-embed-text-v1.5-q8_0",
+        },
+    )
 
     assert result.get("pending_reload") is True
     assert not [c for c in fake.calls if c[0] == "restart"], (

--- a/tests/capabilities/test_orchestrator_reconciliation.py
+++ b/tests/capabilities/test_orchestrator_reconciliation.py
@@ -226,3 +226,47 @@ async def test_apply_no_rewrite_on_pure_disable(
 
     update_calls = [c for c in fake.calls if c[0] == "update_config"]
     assert update_calls == [], f"unexpected update_config on disable transition: {update_calls}"
+
+
+# ── Step 1: _CHILD_TO_SLOT_TYPE + type written by _ensure_slot_exists ──────────
+
+
+def test_child_to_slot_type_mapping() -> None:
+    """The trio-modality children carry their dispatch ``type`` discriminator."""
+    from hal0.capabilities.orchestrator import _CHILD_TO_SLOT_TYPE
+
+    assert _CHILD_TO_SLOT_TYPE["embed"] == "embedding"
+    assert _CHILD_TO_SLOT_TYPE["stt"] == "transcription"
+
+
+async def test_ensure_slot_exists_writes_type_for_embed(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Auto-creating the embed slot stamps ``type=embedding`` into the cfg.
+
+    The dispatch gate (`v1._is_npu_trio_request`) keys on ``type`` first;
+    a created slot that omits it never activates trio dispatch.
+    """
+    from hal0.capabilities.config import CapabilitySelection
+
+    fake = FakeSlotManager()
+    orch = CapabilityOrchestrator(slot_manager=fake)
+    selection = CapabilitySelection.model_validate(
+        {"device": "npu", "provider": "flm", "model": "some-embed", "enabled": True}
+    )
+    # No embed.toml on disk under tmp_hal0_home → create path fires.
+    await orch._ensure_slot_exists("embed", selection)
+
+    create_calls = [c for c in fake.calls if c[0] == "create"]
+    assert create_calls, f"create was never invoked: {fake.calls}"
+    cfg = create_calls[-1][2]["cfg"]
+    assert cfg.get("type") == "embedding", f"created cfg missing type: {cfg!r}"
+
+
+def test_ensure_slot_exists_omits_type_for_rerank() -> None:
+    """Non-trio children (rerank/tts/img) get no ``type`` key."""
+    from hal0.capabilities.orchestrator import _CHILD_TO_SLOT_TYPE
+
+    # embed-rerank → child "rerank", not in the trio-type map.
+    assert "rerank" not in _CHILD_TO_SLOT_TYPE
+    assert "tts" not in _CHILD_TO_SLOT_TYPE


### PR DESCRIPTION
## What
NPU Phase 2: a `device=npu` capability selection for **embed** / **voice.stt** now drives the **FLM trio** (one coresident process) instead of spawning a standalone FLM process.

When you pick NPU for embed/STT, the orchestrator: sets lemond `flm_args` (`--embed 1`/`--asr 1`, preserving the other modality + any operator flags), ensures a `device=npu`, `type=embedding|transcription` slot record exists and is `enabled` (so `v1._is_npu_trio_request` gates dispatch through the FLM child), and **never** `load()`/`swap()`/`unload()`s that slot. Disabling flips the flag to `0` and disables the record. Returns `pending_reload` (no eager anchor restart — the user applies via the NPU section's "⟳ reload to apply").

Also: `asr` is now a legal NPU/FLM capability backend (catalog fanout), so the Capabilities picker can route STT to the NPU.

Design + rationale: `docs/superpowers/specs/2026-06-05-npu-phase2-blueprint.md` (Design A + 4 decisions).

## Notable fix
Caught a real silent-failure: `_is_npu_trio_request` gates on `type` FIRST, but slots created by the orchestrator never got a `type` field — so trio dispatch would no-op. Now `type` is stamped on both create and the enabled-update (safe top-level scalar; the nested `model` dict is never co-written, per Decision 4). A regression test exercises a pre-existing untyped `embed.toml`.

## Tests
TDD, 9 commits, green at each. `tests/capabilities/` = **33 passed** (unit + catalog + integration smoke); `tests/api/test_lemonade_admin_route.py` = **26 passed**. Asserts zero `load/swap/unload` on the embed/stt slot. ruff clean.

## Out of scope (follow-ups)
- `/api/models` surfaces 0 FLM models → NPU pickers empty (registry surfacing).
- Transactional `POST /api/npu/stack`.
- VibeVoice TTS provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)