### PR TITLE
fix(lemonade): write FLM trio args to nested flm.args, not top-level flm_args

### DIFF
--- a/src/hal0/api/routes/lemonade_admin.py
+++ b/src/hal0/api/routes/lemonade_admin.py
@@ -51,6 +51,7 @@ from typing import Any
 from fastapi import APIRouter, Request
 
 from hal0.errors import BadRequest, Hal0Error
+from hal0.lemonade.client import flm_args_from_lemond_config, flm_args_set_payload
 
 router = APIRouter()
 
@@ -310,6 +311,12 @@ async def get_lemonade_config(request: Request) -> dict[str, Any]:
 
     client = lemonade_provider().client()
     snapshot = await client.internal_config()
+    # lemond stores the FLM trio args NESTED at ``flm.args`` — there is no
+    # top-level ``flm_args`` in its schema (memory
+    # ``hal0_flm_args_nested_not_toplevel``). Synthesize the convenience
+    # top-level key the dashboard reads (``data.flm_args``) from the live
+    # nested value, leaving the verbatim ``flm`` block untouched.
+    snapshot["flm_args"] = flm_args_from_lemond_config(snapshot)
     return {
         **snapshot,
         "_hal0": {
@@ -379,7 +386,18 @@ async def set_lemonade_config(request: Request) -> dict[str, Any]:
     from hal0.providers import lemonade_provider
 
     client = lemonade_provider().client()
-    result = await client.internal_set(body)
+
+    # Translate the convenient top-level ``flm_args`` contract into lemond's
+    # NESTED ``flm.args`` wire shape — lemond has no top-level ``flm_args``
+    # key and rejects it 400 (memory ``hal0_flm_args_nested_not_toplevel``).
+    # Build a separate wire payload so ``body`` stays intact for effect
+    # classification below (``flm_args`` must remain in the response's
+    # ``effects.deferred`` — the response contract is unchanged).
+    payload = dict(body)
+    if "flm_args" in payload:
+        payload.update(flm_args_set_payload(payload.pop("flm_args")))
+
+    result = await client.internal_set(payload)
 
     # Echo the immediate-vs-deferred split for exactly the keys this
     # request touched. We classify off the request body rather than the

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -44,6 +44,7 @@ from hal0.capabilities.config import (
 from hal0.config import paths
 from hal0.config.loader import load_slot_config, write_toml_atomic
 from hal0.errors import BadRequest, Hal0Error, NotFound
+from hal0.lemonade.client import flm_args_from_lemond_config, flm_args_set_payload
 from hal0.registry.store import ModelRegistry
 from hal0.slots.manager import SlotManager
 
@@ -725,21 +726,23 @@ class CapabilityOrchestrator:
         return True
 
     async def _set_flm_modality(self, child: str, *, enable: bool) -> None:
-        """Read-modify-write the FLM anchor's lemond ``flm_args``.
+        """Read-modify-write the FLM anchor's lemond trio args.
 
-        Reads the current ``flm_args`` via the injected lemonade client,
-        recomposes only this modality's trio flag (Decision 2), and writes
-        it back. No-op when no lemonade client is wired.
+        lemond stores the FLM trio args NESTED at ``flm.args`` — there is no
+        top-level ``flm_args`` key in its schema (memory
+        ``hal0_flm_args_nested_not_toplevel``). Reads the current value via
+        :func:`flm_args_from_lemond_config`, recomposes only this modality's
+        trio flag (Decision 2), and writes it back as the nested
+        ``{"flm": {"args": ...}}`` payload. No-op when no lemonade client is
+        wired.
         """
         if self._lemonade_provider is None:
             return
         client = self._lemonade_provider()
         cfg = await client.internal_config()
-        current = cfg.get("flm_args") or ""
-        if not isinstance(current, str):
-            current = ""
+        current = flm_args_from_lemond_config(cfg)
         new_args = _recompose_flm_args(current, child, enable)
-        await client.internal_set({"flm_args": new_args})
+        await client.internal_set(flm_args_set_payload(new_args))
 
     async def _npu_anchor_is_live(self) -> bool:
         """Return True when the FLM trio anchor slot is currently loaded.

--- a/src/hal0/lemonade/client.py
+++ b/src/hal0/lemonade/client.py
@@ -80,6 +80,40 @@ DEFAULT_LOAD_TIMEOUT_S = 120.0
 _HEALTH_CACHE_TTL_S = 2.0
 
 
+# ── FLM args schema bridge ────────────────────────────────────────────
+#
+# hal0's API + capability contract uses a convenient TOP-LEVEL ``flm_args``
+# string. lemond's runtime config has NO ``flm_args`` key — the FLM trio
+# args live NESTED at ``flm.args`` (e.g. ``{"flm": {"args": "--asr 1 ..."}}``).
+# Sending a top-level ``flm_args`` to ``/internal/set`` is rejected 400
+# ("unknown key"). These two helpers are the single place that knows the
+# nested wire shape, so the GET-read and POST-write sides (and the
+# capability orchestrator) can't drift apart. See memory
+# ``hal0_flm_args_nested_not_toplevel``.
+
+
+def flm_args_from_lemond_config(cfg: dict[str, Any]) -> str:
+    """Extract the FLM trio args string from a lemond config snapshot.
+
+    Reads the nested ``flm.args`` value (lemond's real schema). Returns an
+    empty string when ``flm`` is absent/non-dict or ``args`` is missing.
+    """
+    flm = cfg.get("flm")
+    if not isinstance(flm, dict):
+        return ""
+    args = flm.get("args", "")
+    return args if isinstance(args, str) else ""
+
+
+def flm_args_set_payload(value: str) -> dict[str, Any]:
+    """Return the ``/internal/set`` payload that sets the FLM trio args.
+
+    Translates the convenient ``flm_args`` string into lemond's nested
+    ``{"flm": {"args": value}}`` wire shape.
+    """
+    return {"flm": {"args": value}}
+
+
 class LemonadeClient:
     """Thin async wrapper around lemond's HTTP control plane.
 

--- a/tests/api/test_lemonade_admin_route.py
+++ b/tests/api/test_lemonade_admin_route.py
@@ -183,6 +183,22 @@ def test_get_config_attaches_locked_invariants(
     assert body["_hal0"]["locked"]["extra_models_dir"] == _locked_extra_models_dir()
 
 
+def test_get_config_synthesizes_flm_args_from_nested(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """lemond stores the trio args NESTED at ``flm.args`` — there is no
+    top-level ``flm_args`` in its schema. The GET route synthesizes a
+    convenience top-level ``flm_args`` from ``flm.args`` so the dashboard
+    (which reads ``data.flm_args``) sees the live value."""
+    r = isolated_client.get("/api/lemonade/config")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["flm_args"] == "--asr 1 --embed 1"
+    # The nested source is still present, verbatim.
+    assert body["flm"] == {"args": "--asr 1 --embed 1"}
+
+
 def test_immediate_and_deferred_partitions_are_disjoint() -> None:
     """No key may be in both halves — a key that's "immediate" can't
     also be "deferred"; if lemond ever changes this, the constants here
@@ -385,6 +401,44 @@ def test_post_config_accepts_flm_args_explicit_disable(
         json={"flm_args": "--asr 0 --embed 1"},
     )
     assert r.status_code == 200, r.text
+
+
+def test_post_config_translates_flm_args_to_nested_wire_shape(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """Callers keep the convenient top-level ``flm_args`` contract, but the
+    payload reaching lemond's ``/internal/set`` is the NESTED ``flm.args``
+    shape — never a top-level ``flm_args`` (which lemond rejects 400 as an
+    unknown key). The response contract is unchanged: ``flm_args`` still
+    appears in ``effects.deferred``."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"flm_args": "--asr 0 --embed 1"},
+    )
+    assert r.status_code == 200, r.text
+    # Wire payload: nested, no top-level flm_args.
+    sent = installed_lemonade_stub["last_set"]
+    assert sent == {"flm": {"args": "--asr 0 --embed 1"}}, sent
+    assert "flm_args" not in sent
+    # Response contract unchanged — flm_args still classified deferred.
+    assert "flm_args" in r.json()["effects"]["deferred"]
+
+
+def test_post_config_preserves_other_keys_when_translating_flm_args(
+    isolated_client: TestClient,
+    installed_lemonade_stub: dict[str, Any],
+) -> None:
+    """A mixed patch carrying ``flm_args`` plus other keys forwards the
+    other keys untouched and translates only ``flm_args`` → ``flm.args``."""
+    r = isolated_client.post(
+        "/api/lemonade/config",
+        json={"flm_args": "--asr 1 --embed 1", "log_level": "debug"},
+    )
+    assert r.status_code == 200, r.text
+    sent = installed_lemonade_stub["last_set"]
+    assert sent == {"flm": {"args": "--asr 1 --embed 1"}, "log_level": "debug"}, sent
+    assert "flm_args" not in sent
 
 
 def test_post_config_rejects_flm_args_malformed_value(

--- a/tests/capabilities/test_npu_phase2_integration.py
+++ b/tests/capabilities/test_npu_phase2_integration.py
@@ -85,8 +85,12 @@ class FakeSlotManager:
 
 
 class FakeLemonadeClient:
+    """lemond stores the FLM trio args NESTED at ``flm.args`` — there is no
+    top-level ``flm_args``; ``initial_flm_args`` seeds ``flm.args`` and
+    ``internal_set`` deep-merges the ``flm`` sub-dict."""
+
     def __init__(self, initial_flm_args: str = "") -> None:
-        self._config: dict[str, Any] = {"flm_args": initial_flm_args}
+        self._config: dict[str, Any] = {"flm": {"args": initial_flm_args}}
         self.set_calls: list[dict[str, Any]] = []
 
     async def internal_config(self) -> dict[str, Any]:
@@ -94,7 +98,14 @@ class FakeLemonadeClient:
 
     async def internal_set(self, values: dict[str, Any]) -> dict[str, Any]:
         self.set_calls.append(dict(values))
-        self._config.update(values)
+        for key, value in values.items():
+            if key == "flm" and isinstance(value, dict):
+                existing = self._config.get("flm")
+                merged = dict(existing) if isinstance(existing, dict) else {}
+                merged.update(value)
+                self._config["flm"] = merged
+            else:
+                self._config[key] = value
         return dict(self._config)
 
 
@@ -158,9 +169,10 @@ async def test_npu_phase2_embed_enable_end_to_end(
         },
     )
 
-    # 1. flm_args recomposed to enable embed on the anchor.
+    # 1. flm_args recomposed to enable embed on the anchor — written as the
+    #    NESTED ``flm.args`` wire shape (lemond has no top-level flm_args).
     assert client.set_calls, "anchor flm_args was never set"
-    assert client.set_calls[-1] == {"flm_args": "--asr 1 --embed 1"}, client.set_calls
+    assert client.set_calls[-1] == {"flm": {"args": "--asr 1 --embed 1"}}, client.set_calls
 
     # 2. A device=npu, type=embedding slot record is in force. The slot TOML
     #    existed with NO type (drift shape), so the apply must stamp

--- a/tests/capabilities/test_orchestrator_reconciliation.py
+++ b/tests/capabilities/test_orchestrator_reconciliation.py
@@ -100,14 +100,15 @@ class FakeLemonadeClient:
     """Records ``internal_config`` reads + ``internal_set`` writes.
 
     Mirrors :class:`hal0.lemonade.client.LemonadeClient` for the two
-    methods the orchestrator's NPU-trio path uses. ``flm_args`` starts at
-    whatever ``initial_flm_args`` is passed (the trio anchor's current
-    args); ``internal_set`` merges the patch so a later ``internal_config``
-    reflects it.
+    methods the orchestrator's NPU-trio path uses. The trio args live at
+    the NESTED ``flm.args`` key (lemond's real schema — there is no
+    top-level ``flm_args``); ``initial_flm_args`` seeds ``flm.args``.
+    ``internal_set`` deep-merges the ``flm`` sub-dict so a later
+    ``internal_config`` reflects it.
     """
 
     def __init__(self, initial_flm_args: str = "") -> None:
-        self._config: dict[str, Any] = {"flm_args": initial_flm_args}
+        self._config: dict[str, Any] = {"flm": {"args": initial_flm_args}}
         self.set_calls: list[dict[str, Any]] = []
 
     async def internal_config(self) -> dict[str, Any]:
@@ -115,7 +116,14 @@ class FakeLemonadeClient:
 
     async def internal_set(self, values: dict[str, Any]) -> dict[str, Any]:
         self.set_calls.append(dict(values))
-        self._config.update(values)
+        for key, value in values.items():
+            if key == "flm" and isinstance(value, dict):
+                existing = self._config.get("flm")
+                merged = dict(existing) if isinstance(existing, dict) else {}
+                merged.update(value)
+                self._config["flm"] = merged
+            else:
+                self._config[key] = value
         return dict(self._config)
 
 
@@ -365,10 +373,10 @@ async def test_fake_slot_manager_iter_configs_roundtrip() -> None:
 async def test_fake_lemonade_client_records_set() -> None:
     client = FakeLemonadeClient(initial_flm_args="--asr 1 --embed 1")
     cfg = await client.internal_config()
-    assert cfg["flm_args"] == "--asr 1 --embed 1"
-    await client.internal_set({"flm_args": "--asr 1 --embed 0"})
-    assert client.set_calls[-1] == {"flm_args": "--asr 1 --embed 0"}
-    assert (await client.internal_config())["flm_args"] == "--asr 1 --embed 0"
+    assert cfg["flm"]["args"] == "--asr 1 --embed 1"
+    await client.internal_set({"flm": {"args": "--asr 1 --embed 0"}})
+    assert client.set_calls[-1] == {"flm": {"args": "--asr 1 --embed 0"}}
+    assert (await client.internal_config())["flm"]["args"] == "--asr 1 --embed 0"
 
 
 # ── Step 5: NPU-trio fork (Cases 1-5, 9) ──────────────────────────────────────
@@ -460,7 +468,7 @@ async def test_npu_embed_enable_sets_flm_args_no_load(
     )
 
     assert client.set_calls, "flm_args was never set"
-    assert client.set_calls[-1] == {"flm_args": "--asr 1 --embed 1"}, client.set_calls
+    assert client.set_calls[-1] == {"flm": {"args": "--asr 1 --embed 1"}}, client.set_calls
     # The embed slot must be flipped enabled=true + stamped type=embedding,
     # WITHOUT a nested model in that write (Decision 4).
     enabled_writes = [
@@ -478,6 +486,60 @@ async def test_npu_embed_enable_sets_flm_args_no_load(
         f"NPU embed path must not bounce the slot: {fake.calls}"
     )
     assert result.get("pending_reload") is True, result
+
+
+async def test_npu_embed_enable_reads_prior_nested_args_and_preserves_operator_flags(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The prior trio args are read from the NESTED ``flm.args`` key and
+    operator flags (e.g. ``--pmode turbo``) are preserved on write.
+
+    Live lemond config carries operator flags alongside the trio toggles;
+    the orchestrator must recompose only ``--asr``/``--embed`` and keep the
+    rest verbatim, and must locate the current value at ``flm.args`` (not a
+    nonexistent top-level ``flm_args``)."""
+    monkeypatch.setattr(
+        CapabilityOrchestrator,
+        "_validate_model_in_catalog",
+        lambda self, slot, child, model_id, backend_id: None,
+    )
+    client = FakeLemonadeClient(initial_flm_args="--pmode turbo --asr 1 --embed 0")
+    fake = FakeSlotManager()
+    fake.set_configs([{"name": "agent", "type": "llm", "device": "npu", "enabled": True}])
+    orch = CapabilityOrchestrator(slot_manager=fake, lemonade_provider=lambda: client)
+    home = Path(tmp_hal0_home)
+    _write_embed_slot(home, device="flm", slot_type="embedding")
+    _write_caps(
+        home,
+        slot="embed",
+        child="embed",
+        fields={
+            "backend": "npu",
+            "provider": "flm",
+            "model": "nomic-embed-text-v1.5-q8_0",
+            "enabled": False,
+        },
+    )
+
+    await orch.apply(
+        "embed",
+        "embed",
+        {
+            "enabled": True,
+            "backend": "npu",
+            "provider": "flm",
+            "model": "nomic-embed-text-v1.5-q8_0",
+        },
+    )
+
+    assert client.set_calls, "flm_args was never set"
+    written = client.set_calls[-1]
+    # Nested wire shape — never a top-level flm_args.
+    assert "flm_args" not in written, written
+    args = written["flm"]["args"]
+    assert "--pmode turbo" in args, f"operator flag dropped: {args!r}"
+    assert "--embed 1" in args, f"embed not enabled: {args!r}"
+    assert "--asr 1" in args, f"prior asr value lost: {args!r}"
 
 
 async def test_npu_embed_disable_zeroes_flm_args_no_unload(
@@ -502,7 +564,7 @@ async def test_npu_embed_disable_zeroes_flm_args_no_unload(
 
     result = await orch.apply("embed", "embed", {"enabled": False})
 
-    assert client.set_calls[-1] == {"flm_args": "--asr 1 --embed 0"}, client.set_calls
+    assert client.set_calls[-1] == {"flm": {"args": "--asr 1 --embed 0"}}, client.set_calls
     disabled_writes = [
         c
         for c in fake.calls
@@ -551,7 +613,7 @@ async def test_npu_stt_enable_sets_asr(
     )
 
     assert client.set_calls, "flm_args was never set for stt"
-    last = client.set_calls[-1]["flm_args"]
+    last = client.set_calls[-1]["flm"]["args"]
     assert "--asr 1" in last, f"stt enable did not set asr=1: {last!r}"
     assert not [c for c in fake.calls if c[0] in ("load", "swap", "unload")], (
         f"NPU stt path must not bounce a slot: {fake.calls}"
@@ -593,7 +655,7 @@ async def test_embed_gpu_to_npu_no_load(
         },
     )
 
-    assert "--embed 1" in client.set_calls[-1]["flm_args"], client.set_calls
+    assert "--embed 1" in client.set_calls[-1]["flm"]["args"], client.set_calls
     # device rewritten to npu on the slot TOML.
     dev_writes = [
         c
@@ -639,7 +701,7 @@ async def test_embed_npu_to_gpu_zeroes_flm_and_loads(
 
     # Leaving NPU must drop embed from the anchor's flm_args.
     assert client.set_calls, "leaving npu did not touch flm_args"
-    assert "--embed 0" in client.set_calls[-1]["flm_args"], client.set_calls
+    assert "--embed 0" in client.set_calls[-1]["flm"]["args"], client.set_calls
     # The gpu path runs the standard lifecycle (device/model changed → swap, or load).
     assert [c for c in fake.calls if c[0] in ("load", "swap")], (
         f"gpu-vulkan target must run the standard load/swap path: {fake.calls}"


### PR DESCRIPTION
## What
hal0 wrote FLM trio args under a **top-level `flm_args`** key, but lemond's config schema has **no such key** — args live nested at **`flm.args`**. lemond's `/internal/set` rejects unknown top-level keys with **400**, surfacing as hal0-api 500 / `capability.apply_failed`. This blocked BOTH the Phase 1 NPU-section toggle and Phase 2's capability→trio routing from working end-to-end.

Verified live on CT105: `POST /internal/set {flm_args:…}` → 400; `{flm:{args:…}}` → 200.

## Fix (contract preserved — frontend untouched)
- `src/hal0/lemonade/client.py` — two shared helpers (single home for the nested shape): `flm_args_from_lemond_config(cfg)` (reads `flm.args`) and `flm_args_set_payload(value)` (`→ {"flm":{"args":value}}`).
- `lemonade_admin.py` — **GET** synthesizes the top-level `flm_args` the dashboard reads from live `flm.args`; **POST** keeps `flm_args` validation + the immediate/deferred effect partition, but translates to the nested wire shape before `internal_set` (leaves `body` intact for classification).
- `capabilities/orchestrator.py` — `_set_flm_modality` reads/writes via the helpers; `_recompose_flm_args` unchanged (preserves operator flags like the live `--pmode turbo`).

Net: callers keep the convenient `flm_args` string; only the lemond wire-format is nested. **Frontend needs no change** → the Phase 1 NPU toggle starts working too.

## Tests (TDD, red→green)
`tests/api/test_lemonade_admin_route.py` **29 passed** (GET-synthesis; POST asserts nested wire shape + no top-level `flm_args` + `flm_args` still in `effects.deferred`; mixed-key preservation; validation unchanged). `tests/capabilities/` **+ integration = 21 passed** (FakeLemonadeClient migrated to nested; trio cases assert `{flm:{args}}`; operator-flag preservation). ruff clean.

## Note
`flm_args_set_payload` wholesale-replaces lemond's `flm` sub-dict — fine today (it carries only `args`); flagged in memory for if `flm` grows siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)