### PR TITLE
feat(dash): Capabilities 4-up grid + enabled-first sort (Spec 1 C6/C7)

### DIFF
--- a/ui/src/dash/data.jsx
+++ b/ui/src/dash/data.jsx
@@ -86,6 +86,21 @@ const HAL0_DATA = {
       spark: [3, 5, 7, 6, 8, 9, 10, 8, 9, 11, 12, 9, 10, 11, 13, 10],
     },
     {
+      // Disabled slot — demonstrates the offline/faded card and C6 enabled-first
+      // sort (declared early here, but renders at the end of the Chat section).
+      name: "legacy",
+      type: "llm",
+      device: "gpu-rocm",
+      model: "qwen2.5-7b-instruct",
+      model_id: "qwen2.5-7b",
+      modelLong: "Qwen/Qwen2.5-7B-Instruct-GGUF",
+      group: "chat",
+      state: "offline",
+      enabled: false,
+      port: 8099,
+      metrics: { toks: 0, ttft: null, ctx: 4096, kv: null, mem: 7.2 },
+    },
+    {
       name: "agent",
       type: "llm",
       device: "npu",

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -989,7 +989,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
       ? <SlotCard key={s.name} slot={s} />
       : <SlotCard key={s.name} slot={s} />;
 
-  const renderGroup = (label, items) => {
+  const renderGroup = (label, items, opts = {}) => {
     if (!items.length) return null;
     if (slotVariant === "list") {
       return (
@@ -1018,7 +1018,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
           <h2>{label}<span className="ct mono">{items.length}</span></h2>
           <div className="rule" />
         </div>
-        <div className={"slots-grid" + (slotVariant === "spec" ? " spec" : "")}>
+        <div className={"slots-grid" + (slotVariant === "spec" ? " spec" : "") + (opts.quarter ? " quarter" : "")}>
           {items.map(s => {
             // Demo: show error banner on a single slot if a banner-state would fire
             const errMsg = (window.__hal0Banners && window.__hal0Banners.get && window.__hal0Banners.get()["model-missing"] && s.name === "primary")
@@ -1043,9 +1043,13 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
 
       <div className="dash">
         <div className="dash-main">
-          {renderGroup("Chat",  groups.chat)}
-          {renderGroup("Embed", groups.embed)}
-          {renderGroup("Voice", groups.voice)}
+          {renderGroup("Chat", groups.chat)}
+          {/* Capabilities (C7): embedding/reranking/transcription/tts cards are
+              content-light, so they render in a denser 4-up quarter-width grid
+              instead of two separate full-width Embed/Voice sections. NPU
+              modalities (group "npu") are excluded by grouping — they live in
+              the dedicated NPU/FLM stack section below. */}
+          {renderGroup("Capabilities", [...groups.embed, ...groups.voice], { quarter: true })}
           {renderGroup("Image", groups.img)}
 
           {slots.some(s => s.device === "npu") && (

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -989,7 +989,15 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
       ? <SlotCard key={s.name} slot={s} />
       : <SlotCard key={s.name} slot={s} />;
 
-  const renderGroup = (label, items, opts = {}) => {
+  // C6: stable-sort enabled slots before disabled ones, preserving the
+  // existing order within each bucket. Array.prototype.sort is stable, so a
+  // 0/1 key keeps the original type/role ordering intact otherwise. Pairs
+  // with the faded card so disabled slots sink to the end of their section.
+  const enabledFirst = (items) =>
+    items.slice().sort((a, b) => (a?.enabled === false ? 1 : 0) - (b?.enabled === false ? 1 : 0));
+
+  const renderGroup = (label, rawItems, opts = {}) => {
+    const items = enabledFirst(rawItems);
     if (!items.length) return null;
     if (slotVariant === "list") {
       return (

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -1700,6 +1700,13 @@ a { color: inherit; text-decoration: none; }
    Slots view
    ════════════════════════════════════════════════════════════════════ */
 .slots-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(360px, 1fr)); gap: 14px; margin-bottom: 32px; }
+/* Capabilities (C7): content-light slots in a fixed 4-up quarter-width row.
+   Explicit repeat(4,1fr) — not auto-fit — to guarantee the single
+   1/4·1/4·1/4·1/4 row at wide widths; collapses to 2-up / 1-up in the media
+   blocks below. Higher specificity (.slots-grid.quarter) means the base
+   responsive `.slots-grid { 1fr }` won't override it, so each breakpoint sets
+   .slots-grid.quarter explicitly. */
+.slots-grid.quarter { grid-template-columns: repeat(4, 1fr); }
 
 /* Variant: instrument (default) */
 .slot {
@@ -2131,6 +2138,7 @@ a { color: inherit; text-decoration: none; }
   .tb-brand .ver { display: none; }
   .tb-eyebrow .sep:nth-child(2), .tb-eyebrow .now { display: none; }
   .tiers { grid-template-columns: repeat(2, 1fr); }
+  .slots-grid.quarter { grid-template-columns: repeat(2, 1fr); }
   .settings-layout { grid-template-columns: 1fr; }
   .settings-nav { position: static; flex-direction: row; flex-wrap: wrap; }
   .models-layout { grid-template-columns: 1fr; }
@@ -2147,6 +2155,7 @@ a { color: inherit; text-decoration: none; }
   .tb-eyebrow { display: none; }
   .tiers { grid-template-columns: 1fr; }
   .slots-grid { grid-template-columns: 1fr; }
+  .slots-grid.quarter { grid-template-columns: 1fr; }
   .slot-metrics { grid-template-columns: repeat(2, 1fr); }
   .snap-row { grid-template-columns: 14px 1fr auto; }
   .snap-row .model, .snap-row .badge { display: none; }

--- a/ui/tests/e2e/specs/slots-v3.spec.ts
+++ b/ui/tests/e2e/specs/slots-v3.spec.ts
@@ -1,6 +1,8 @@
 /**
- * slots-v3 — `#slots` route renders grouped sections (Chat / Embed /
- * Voice / Image / NPU rollup) + slot cards + the "New slot" CTA.
+ * slots-v3 — `#slots` route renders grouped sections (Chat / Capabilities /
+ * Image / NPU rollup) + slot cards + the "New slot" CTA. The embedding,
+ * reranking, transcription and tts slots are merged into one denser
+ * "Capabilities" section rendered as a 4-up quarter-width grid (C7).
  */
 import { test, expect } from '../fixtures/apiMock'
 
@@ -8,11 +10,22 @@ test.describe('Slots v3 (/slots)', () => {
   test('renders grouped sections + slot cards', async ({ page }) => {
     await page.goto('/#slots')
     await expect(page.locator('.view .vh h1')).toHaveText('Slots')
-    // at least one group section h2 (chat/embed/voice) renders
+    // at least one group section h2 (chat/capabilities/image) renders
     await expect(page.locator('.view .sec h2').first()).toBeVisible()
     // slot cards or list rows present
     const cards = page.locator('.slots-grid > *, .slots-list > *')
     expect(await cards.count()).toBeGreaterThan(0)
+  })
+
+  test('Capabilities section (C7) renders the utility slots in a 4-up quarter grid', async ({ page }) => {
+    await page.goto('/#slots')
+    // The embedding/reranking/transcription/tts slots collapse into one
+    // "Capabilities" section heading (replacing the old Embed + Voice sections).
+    await expect(page.locator('.view .sec h2', { hasText: 'Capabilities' })).toBeVisible()
+    // ...and that section's grid carries the quarter-width modifier.
+    const quarterGrid = page.locator('.slots-grid.quarter')
+    await expect(quarterGrid.first()).toBeVisible()
+    expect(await quarterGrid.locator('> *').count()).toBeGreaterThan(0)
   })
 
   test('exposes New-slot button (create modal trigger)', async ({ page }) => {

--- a/ui/tests/e2e/specs/slots-v3.spec.ts
+++ b/ui/tests/e2e/specs/slots-v3.spec.ts
@@ -34,6 +34,20 @@ test.describe('Slots v3 (/slots)', () => {
     await expect(newBtn).toBeVisible()
   })
 
+  test('enabled-first sort (C6): a disabled slot sinks to the end of its section', async ({ page }) => {
+    await page.goto('/#slots')
+    // The Chat section: HAL0_DATA declares a disabled "legacy" slot early in
+    // source order; the enabled-first sort must render it last.
+    const chatSection = page.locator('.view section', {
+      has: page.locator('.sec h2', { hasText: 'Chat' }),
+    })
+    const names = await chatSection.locator('.slot .slot-name .nm').allInnerTexts()
+    expect(names.length).toBeGreaterThan(1)
+    expect(names).toContain('legacy')
+    expect(names[names.length - 1]).toBe('legacy') // disabled → last
+    expect(names[0]).not.toBe('legacy') // enabled slots come first
+  })
+
   test('NPU rollup section renders when an NPU slot is present', async ({ page }) => {
     await page.goto('/#slots')
     // HAL0_DATA seeds at least one device=npu slot, so the NPU section h2 should appear


### PR DESCRIPTION
Implements **Components 6 and 7** of the approved slot-edit-panel spec
(`docs/superpowers/specs/2026-06-05-slot-edit-panel-controls-design.md`) — the
slots-page layout pieces that were specced but never built.

## C7 — Capabilities 4-up quarter grid
Merges the separate full-width **Embed** and **Voice** sections into one denser
**Capabilities** section that renders the content-light utility slots
(embedding, reranking, transcription, tts) in a fixed 4-up quarter-width row.

- `slots.jsx`: `renderGroup` gains an `opts.quarter` flag; Embed+Voice groups
  are concatenated into one "Capabilities" section. Chat (full width) and Image
  are unchanged.
- `dashboard.css`: `.slots-grid.quarter = repeat(4, 1fr)` (explicit, not
  `auto-fit`, so the 1/4·1/4·1/4·1/4 row is guaranteed), collapsing to 2-up
  ≤1080px and 1-up ≤720px.
- **No NPU duplication**: NPU modalities carry `group:"npu"` and stay in the
  dedicated `NpuFlmStack` section — confirmed in seed data and visually.

## C6 — enabled-first sort
Stable-sorts each section so enabled slots render first and disabled slots sink
to the end (pairs with the future faded-card state, C3). The slot payload
already carries `enabled` (`slots.py` PR-18 enrichment), so it's live in prod.

- `slots.jsx`: `enabledFirst()` applied inside `renderGroup` (covers Chat,
  Capabilities, Image uniformly).
- `data.jsx`: adds a disabled `legacy` chat slot so the mock demonstrates the
  offline card and the sort.

## Verification
- Both components are **red-then-green** in `slots-v3.spec.ts` (each new
  assertion fails on `main`, passes here).
- Full `ui` e2e suite: **104 passed, 0 failed**.
- Production build clean. Computed grid is `232.5px × 4` at wide width;
  screenshot confirms the row with no slot rendered twice.

## Scope
C6/C7 only (the layout pieces). The control pieces C1–C5
(`enabled`/`enable_thinking`/`n_gpu_layers` toggles) remain unbuilt; partial
backend work lives on the unmerged `feat/slot-edit-controls-impl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)