### PR TITLE
feat(slots): slot edit panel — enable / thinking / n_gpu_layers controls (Spec 1 C1–C5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ tests/release-gate-report.json
 # OS
 Thumbs.db
 .claude/worktrees/
+.claude/wip.json

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -215,6 +215,15 @@ async def _lemonade_state_enrichment(request: Request) -> dict[str, dict[str, An
             entry["labels"] = model_labels
         entry["enabled"] = enabled
 
+        # Spec 1 / Component 1: surface the three edit-panel config fields so
+        # the card + drawer seed their controls without a per-slot /config
+        # fetch. ``enable_thinking`` is tri-valued on disk (true/false/absent);
+        # absent → null (effective OFF). ``n_gpu_layers`` falls back to the
+        # ModelConfig default sentinel (-1 = all layers) when unset.
+        entry["enable_thinking"] = cfg.get("enable_thinking")
+        n_gpu = model_section.get("n_gpu_layers") if isinstance(model_section, dict) else None
+        entry["n_gpu_layers"] = n_gpu if isinstance(n_gpu, int) else -1
+
         loaded_entry = loaded_by_model.get(model_default) if model_default else None
         if not enabled:
             entry["lemonade_state"] = "disabled"
@@ -1104,6 +1113,24 @@ async def update_slot_config(name: str, request: Request) -> dict[str, object]:
     if not isinstance(body, dict):
         raise BadRequest("request body must be a JSON object", code="request.not_an_object")
     snap = await sm.update_config(name, body)
+    # Spec 1 / Component 2: an explicit ``enabled: false`` write must take a
+    # running slot actually offline so the faded card matches reality. The
+    # config write alone only flips the on-disk flag; without this a disabled
+    # slot would keep its llama-server child resident until the next restart.
+    # ``unload`` is idempotent (short-circuits when already OFFLINE), but we
+    # gate on a live state so an offline/error slot incurs no /v1/unload call.
+    if body.get("enabled") is False:
+        from hal0.slots.state import SlotState
+
+        _LIVE = {
+            SlotState.STARTING,
+            SlotState.WARMING,
+            SlotState.READY,
+            SlotState.SERVING,
+            SlotState.IDLE,
+        }
+        if snap.state in _LIVE:
+            snap = await sm.unload(name)
     return _slot_to_dict(snap, request)
 
 

--- a/tests/api/test_slots_lemonade_state.py
+++ b/tests/api/test_slots_lemonade_state.py
@@ -251,6 +251,71 @@ def test_list_slots_no_coresident_group_when_npu_anchor_disabled(
     assert by_name["stt-npu"].get("coresident_group") is None
 
 
+# ── config-field exposure (Spec 1 / Component 1) ───────────────────────────
+#
+# The slot-edit panel seeds its card + drawer controls from the slot list
+# payload. Three SlotConfig fields must ride along so the UI doesn't have to
+# fetch /config per slot: ``enabled`` (top-level), ``enable_thinking``
+# (top-level), ``n_gpu_layers`` (from [model]).
+
+
+def test_list_slots_exposes_enable_thinking_and_n_gpu_layers(
+    tmp_hal0_home: str,
+    installed_lemonade_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """A slot's enable_thinking + [model].n_gpu_layers ride along in the payload."""
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "primary",
+        [
+            'name = "primary"',
+            "port = 8081",
+            'device = "gpu-rocm"',
+            'type = "llm"',
+            "enabled = true",
+            "enable_thinking = true",
+            "[model]",
+            'default = "qwen3"',
+            "n_gpu_layers = 99",
+        ],
+    )
+    r = isolated_client.get("/api/slots")
+    assert r.status_code == 200, r.text
+    by_name = {e["name"]: e for e in r.json()}
+    primary = by_name["primary"]
+    assert primary["enable_thinking"] is True
+    assert primary["n_gpu_layers"] == 99
+    assert primary["enabled"] is True
+
+
+def test_list_slots_enable_thinking_null_when_unset(
+    tmp_hal0_home: str,
+    installed_lemonade_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """No enable_thinking in TOML → payload reports it as null (effective OFF)."""
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "primary",
+        [
+            'name = "primary"',
+            "port = 8081",
+            'device = "gpu-rocm"',
+            'type = "llm"',
+            "enabled = true",
+            "[model]",
+            'default = "qwen3"',
+        ],
+    )
+    r = isolated_client.get("/api/slots")
+    by_name = {e["name"]: e for e in r.json()}
+    primary = by_name["primary"]
+    assert primary["enable_thinking"] is None
+    # n_gpu_layers absent from [model] → field still present, default sentinel
+    assert "n_gpu_layers" in primary
+
+
 def test_list_slots_skips_coresident_for_disabled_sibling(
     tmp_hal0_home: str,
     installed_lemonade_stub: dict[str, Any],

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -376,6 +376,84 @@ def test_unload_after_load_transitions_to_offline(
     assert systemctl_stub["_lemonade"]["unload_calls"], "expected /v1/unload"
 
 
+# ── Spec 1 / Component 2: enabled transition safety ─────────────────────────
+
+
+def test_disable_running_slot_stops_it(
+    slot_root: Path,
+    systemctl_stub: dict[str, Any],
+    stub_await_ready: None,
+    isolated_client: TestClient,
+) -> None:
+    """PUT /config {enabled: false} on a RUNNING slot persists the flag AND stops it.
+
+    The faded card must match reality — a disabled slot should not keep a
+    llama-server child resident, so the config write is followed by an unload.
+    """
+    isolated_client.post("/api/slots/primary/load")
+    # Clear the load-path bookkeeping so we assert only the disable's unload.
+    systemctl_stub["_lemonade"]["unload_calls"].clear()
+
+    r = isolated_client.put("/api/slots/primary/config", json={"enabled": False})
+    assert r.status_code == 200, r.text
+    # The persisted flag is off …
+    cfg = isolated_client.get("/api/slots/primary/config").json()
+    assert cfg.get("enabled") is False
+    # … and the running child was actually stopped.
+    assert systemctl_stub["_lemonade"]["unload_calls"], (
+        "disabling a running slot must trigger /v1/unload"
+    )
+
+
+def test_disable_offline_slot_does_not_unload(
+    slot_root: Path,
+    systemctl_stub: dict[str, Any],
+    stub_await_ready: None,
+    isolated_client: TestClient,
+) -> None:
+    """Disabling an already-offline slot writes the flag with no unload call."""
+    # Drive the slot genuinely offline: lemond reports nothing resident, so
+    # the adoption probe never marks primary running.
+    systemctl_stub["_lemonade"]["loaded"] = []
+    r = isolated_client.put("/api/slots/primary/config", json={"enabled": False})
+    assert r.status_code == 200, r.text
+    assert systemctl_stub["_lemonade"]["unload_calls"] == [], (
+        "an offline slot needs no stop — the write alone suffices"
+    )
+
+
+def test_invalid_enable_surfaces_conflict(
+    tmp_hal0_home: str,
+    systemctl_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """Enabling a 2nd NPU LLM anchor → 409 with the exclusivity message, no write."""
+    root = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    root.mkdir(parents=True, exist_ok=True)
+    for nm in ("agent", "agent2"):
+        (root / f"{nm}.toml").write_text(
+            "\n".join(
+                [
+                    f'name = "{nm}"',
+                    'device = "npu"',
+                    'type = "llm"',
+                    f"enabled = {'true' if nm == 'agent' else 'false'}",
+                    "[model]",
+                    'default = "gemma3-1b"',
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+    # agent is enabled; enabling agent2 would land a second NPU LLM anchor.
+    r = isolated_client.put("/api/slots/agent2/config", json={"enabled": True})
+    assert r.status_code == 409, r.text
+    assert r.json()["error"]["code"] == "slot.npu_exclusivity_violation"
+    # The rejected write must not have flipped agent2 on.
+    cfg = isolated_client.get("/api/slots/agent2/config").json()
+    assert cfg.get("enabled") is False
+
+
 # ── state-stream-shape ─────────────────────────────────────────────────────
 
 

--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -65,6 +65,16 @@ export interface Slot {
    *  model in memory. Source of truth for the memory-map attribution
    *  (BE-METRICS contract). Prefer this over equal-split GTT division. */
   mem_mb?: number
+  /** Whether the slot is activated. Disabled slots fade on the card, sort to
+   *  the end of the grid, and hide their lifecycle buttons. Defaults to true
+   *  when absent (a slot is enabled unless explicitly off). */
+  enabled?: boolean
+  /** Per-slot reasoning default (llm slots). true → thinking on; false/null →
+   *  off (suppressed). Seeds the drawer's Thinking toggle. */
+  enable_thinking?: boolean | null
+  /** GPU offload layer count for the slot's model (-1 = all). Seeds the
+   *  drawer's Advanced n_gpu_layers input. */
+  n_gpu_layers?: number
   /** Wall-clock epoch (seconds) of the most recent request served by
    *  this slot. ``null``/undefined means hal0-api has not seen a request
    *  for this slot since startup. Used by the slots view to render the
@@ -192,6 +202,10 @@ function normalizeSlot(s: any): Slot {
     declared_backend: s?.declared_backend ?? null,
     actual_backend: s?.actual_backend ?? null,
     backend_mismatch: !!s?.backend_mismatch,
+    // Spec 1: a slot is enabled unless explicitly off. /api/status-sourced
+    // entries in the union may omit the flag, so default it here rather than
+    // letting the card read undefined as "disabled".
+    enabled: s?.enabled !== false,
   }
 }
 

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -341,6 +341,13 @@ function EditSlotDrawer({ open, slot, onClose }) {
   const backendMut = useSlotBackend();
 
   const [ctx, setCtx] = useStateSM(slot?.metrics?.ctx || 4096);
+  // C4/C5: thinking is instant-apply (its own PUT); n_gpu_layers rides the Save
+  // button through PATCH /defaults. Both seed from the slot list payload.
+  const [thinking, setThinking] = useStateSM(slot?.enable_thinking === true);
+  const [thinkingPending, setThinkingPending] = useStateSM(false);
+  const [nGpuLayers, setNGpuLayers] = useStateSM(
+    slot?.n_gpu_layers != null ? String(slot.n_gpu_layers) : "-1"
+  );
   const [idleTimeout, setIdleTimeout] = useStateSM(900);
   const [workers, setWorkers] = useStateSM(1);
   const [extraArgs, setExtraArgs] = useStateSM("--flash-attn on --no-mmap");
@@ -358,6 +365,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
   useEffectSM(() => {
     if (slot) {
       setCtx(slot.metrics?.ctx || 4096);
+      setThinking(slot.enable_thinking === true);
+      setThinkingPending(false);
+      setNGpuLayers(slot.n_gpu_layers != null ? String(slot.n_gpu_layers) : "-1");
       setDevice(slot.device || "gpu-rocm");
       setMakeDefault(!!slot.isDefault);
       setIdleTimeout(900);
@@ -382,10 +392,12 @@ function EditSlotDrawer({ open, slot, onClose }) {
       const ctxNum = Number(ctx);
       const idleNum = Number(idleTimeout);
       const workersNum = Number(workers);
+      const nglNum = Number(nGpuLayers);
       await defaultsMut.mutateAsync({
         name: slot.name,
         body: {
           ctx_size: Number.isFinite(ctxNum) ? ctxNum : ctx,
+          n_gpu_layers: Number.isFinite(nglNum) ? nglNum : -1,
         },
       });
       await editMut.mutateAsync({
@@ -583,6 +595,49 @@ function EditSlotDrawer({ open, slot, onClose }) {
         </div>
       </div>
 
+      {/* C4: per-slot thinking default — llm slots only. Instant-apply (its
+          own PUT /config), no restart: _slot_thinking_default reads it live
+          on the next request. */}
+      {slot.type === "llm" && (
+        <div className="form-row">
+          <div className="form-lbl">
+            <span>Thinking</span>
+            <span className="sub">Stream reasoning before the answer. Off = faster, direct replies.</span>
+          </div>
+          <div className="form-ctl">
+            <label className="checkbox-row">
+              <input
+                type="checkbox"
+                checked={thinking}
+                disabled={thinkingPending}
+                onChange={async (e) => {
+                  const next = e.target.checked;
+                  setThinking(next);
+                  setThinkingPending(true);
+                  setSubmitErr(null);
+                  try {
+                    await editMut.mutateAsync({
+                      name: slot.name,
+                      body: { enable_thinking: next },
+                    });
+                    window.__hal0Toast && window.__hal0Toast(
+                      `${slot.name} thinking ${next ? "on" : "off"} — applies to next message`,
+                      "ok",
+                    );
+                  } catch (err) {
+                    setThinking(!next); // revert on failure
+                    setSubmitErr(err?.message || "thinking toggle failed");
+                  } finally {
+                    setThinkingPending(false);
+                  }
+                }}
+              />
+              <span>{thinking ? "Reasoning on" : "Reasoning off"}</span>
+            </label>
+          </div>
+        </div>
+      )}
+
       <div className="form-section">Advanced</div>
 
       <div className="form-row">
@@ -593,6 +648,20 @@ function EditSlotDrawer({ open, slot, onClose }) {
             value={ctx}
             onChange={e => setCtx(e.target.value)}
           />
+        </div>
+      </div>
+
+      {/* C5: GPU offload tuning — saved via the Save button (PATCH /defaults),
+          restart-required like ctx_size since it changes model load. */}
+      <div className="form-row">
+        <div className="form-lbl"><span>n_gpu_layers</span><span className="warn">⟳ restart required</span></div>
+        <div className="form-ctl">
+          <input
+            className="input mono"
+            value={nGpuLayers}
+            onChange={e => setNGpuLayers(e.target.value)}
+          />
+          <div className="hint">-1 offloads all layers to the GPU.</div>
         </div>
       </div>
 

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -211,10 +211,14 @@ function SlotCard({
   onViewLogs,
   swapOpen,
   onCloseSwap,
+  onToggleEnabled,
   errorMsg,
   busy,
 }) {
   const { type, device, model, state, isDefault, coresident, cpuOnly, metrics } = slot;
+  // Spec 1 / C3: a slot is enabled unless explicitly off. Disabled slots fade,
+  // hide lifecycle buttons, and sort to the end of the grid (SlotsView).
+  const enabled = slot.enabled !== false;
   // Lifecycle phase drives which action buttons render (design 2026-06-04):
   // running (loaded/serving) -> Stop+Restart; off (not loaded) -> Start;
   // transitional (warming/pulling/unloading) -> actions disabled.
@@ -272,7 +276,7 @@ function SlotCard({
   })();
 
   return (
-    <div className={"slot" + (state === "serving" ? " serving" : "") + (swapOpen ? " swap-open" : "")}>
+    <div className={"slot" + (state === "serving" ? " serving" : "") + (swapOpen ? " swap-open" : "") + (enabled ? "" : " slot--disabled")}>
       <div className="slot-h">
         <IndicatorDot slot={slot} />
         <div className="slot-name">
@@ -281,6 +285,21 @@ function SlotCard({
         <div className="right">
           {isDefault && <div className="default-badge">★ default</div>}
           {coresident && <span className="chip" style={{color: "var(--dev-npu)", borderColor: "rgba(200,150,255,0.30)", background: "rgba(200,150,255,0.06)"}}>coresident</span>}
+          {/* C3: enabled toggle — stays full-opacity + interactive even when
+              the card is faded, so a disabled slot can be re-enabled. */}
+          <label
+            className="slot-enable-toggle"
+            title={enabled ? "Disable slot" : "Enable slot"}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <input
+              type="checkbox"
+              checked={enabled}
+              disabled={!!busy}
+              onChange={() => onToggleEnabled && onToggleEnabled(!enabled)}
+            />
+            <span className="slot-enable-track" aria-hidden="true" />
+          </label>
         </div>
       </div>
       <div className="slot-model mono" onClick={onSwap} style={{position: "relative"}}>
@@ -334,7 +353,11 @@ function SlotCard({
         ))}
       </div>
       <div className="slot-actions">
-        {phase === "off" ? (
+        {/* C3: a disabled slot has no running child to Start/Stop/Restart —
+            hide the lifecycle buttons; the card's toggle is the way back on. */}
+        {!enabled ? (
+          <span className="slot-disabled-note mono">disabled</span>
+        ) : phase === "off" ? (
           <button
             className="btn ghost sm"
             disabled={!!busy}
@@ -742,6 +765,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
   const unloadMut = useSlotUnload();
   const loadMut = useSlotLoad();
   const swapMut = useSlotSwap();
+  const editMut = useSlotEdit();
 
   const toast = (msg, kind = "info") =>
     window.__hal0Toast && window.__hal0Toast(msg, kind);
@@ -830,6 +854,20 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
       swapOpen={swapName === s.name}
       onSwap={(e) => { e.stopPropagation(); setSwapName(swapName === s.name ? null : s.name); }}
       onCloseSwap={() => setSwapName(null)}
+      onToggleEnabled={async (next) => {
+        // C3: instant-apply enabled flip. Query invalidation re-renders the
+        // card from server truth; on error we leave server state untouched and
+        // toast (e.g. the npu-exclusivity 409 when enabling a 2nd NPU LLM).
+        setBusyName(s.name);
+        try {
+          await editMut.mutateAsync({ name: s.name, body: { enabled: next } });
+          toast(`${s.name} ${next ? "enabled" : "disabled"}`, "ok");
+        } catch (err) {
+          toast(err?.message ? `${s.name}: ${err.message}` : `${s.name}: toggle failed`, "warn");
+        } finally {
+          setBusyName(null);
+        }
+      }}
       onEdit={() => { window.location.hash = "#slots/" + s.name; }}
       onRestart={() =>
         runMutation(s.name, restartMut, s.name, `Restarting ${s.name}`)

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -1726,7 +1726,31 @@ a { color: inherit; text-decoration: none; }
    absolutely-positioned .swap-pop can extend past the card bottom. */
 .slot.swap-open { overflow: visible; }
 .slot.serving { border-color: var(--accent-line); }
+/* C3: disabled slot — fade the card body, but keep the enable toggle (which
+   lives in .slot-h .right) full-opacity + interactive so it can be flipped
+   back on. */
+.slot--disabled { opacity: 0.5; }
+.slot--disabled:hover { opacity: 0.72; }
+.slot--disabled .slot-enable-toggle { opacity: 1; }
+.slot-disabled-note { font-size: 11px; color: var(--fg-4); text-transform: uppercase; letter-spacing: 0.04em; }
+/* C7: Capabilities section — denser quarter-width grid for the narrow utility
+   cards (embed/rerank/stt/tts). Collapses 4-up → 2-up → 1-up. */
+.slots-grid--quarter { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
 .slot-h { display: flex; align-items: center; gap: 8px; }
+/* C3: compact enable/disable switch on the card header. */
+.slot-enable-toggle { display: inline-flex; align-items: center; cursor: pointer; }
+.slot-enable-toggle input { position: absolute; opacity: 0; width: 0; height: 0; }
+.slot-enable-track {
+  display: inline-block; width: 26px; height: 15px; border-radius: 999px;
+  background: var(--line-strong); position: relative; transition: background 0.12s ease;
+}
+.slot-enable-track::after {
+  content: ""; position: absolute; top: 2px; left: 2px; width: 11px; height: 11px;
+  border-radius: 50%; background: var(--bg); transition: transform 0.12s ease;
+}
+.slot-enable-toggle input:checked + .slot-enable-track { background: var(--accent); }
+.slot-enable-toggle input:checked + .slot-enable-track::after { transform: translateX(11px); }
+.slot-enable-toggle input:focus-visible + .slot-enable-track { outline: 2px solid var(--accent); outline-offset: 2px; }
 .slot-name {
   display: flex; align-items: center; gap: 8px;
   font-family: var(--jbm); font-size: 14.5px; font-weight: 500; color: var(--fg);

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * slot-edit-controls-v3 — Spec 1 (slot edit panel controls).
+ *
+ * Covers the operator controls added to the slots page:
+ *   C3. enabled toggle on the slot CARD → PUT /config { enabled } + fade.
+ *   C4. enable_thinking toggle in the edit DRAWER (llm slots only) →
+ *       PUT /config { enable_thinking } instantly.
+ *   C5. n_gpu_layers input in the drawer Advanced section → Save →
+ *       PATCH /defaults { n_gpu_layers }.
+ *   C6. enabled slots sort before disabled ones in the grid.
+ *
+ * The dashboard renders the slot LIST from in-bundle HAL0_DATA
+ * (VITE_MOCK_LEMONADE=1 short-circuits GET /api/slots before page.route
+ * sees it — see src/api/mock.ts). So we control the list by intercepting
+ * the `window.HAL0_DATA` assignment via addInitScript (`seedSlots`).
+ * Mutations to /config + /defaults are NOT allowlisted, so they fall
+ * through to real fetch and page.route captures their bodies.
+ */
+import { test, expect, type Page } from '../fixtures/apiMock'
+
+const PRIMARY = {
+  name: 'primary', type: 'llm', device: 'gpu-rocm',
+  model: 'qwen3.6-27b', model_id: 'qwen3.6-27b', modelLong: 'qwen3.6-27b',
+  group: 'chat', state: 'serving', port: 8092, isDefault: true,
+  enabled: true, enable_thinking: false, n_gpu_layers: -1,
+  metrics: { ctx: 8192, toks: 42, ttft: 180, kv: 35 },
+}
+const CODER = {
+  name: 'coder', type: 'llm', device: 'gpu-rocm',
+  model: 'qwen3-coder-30b', model_id: 'qwen3-coder-30b', modelLong: 'qwen3-coder-30b',
+  group: 'chat', state: 'idle', port: 8094,
+  enabled: false, enable_thinking: null, n_gpu_layers: 20,
+  metrics: { ctx: 4096 },
+}
+const EMBED = {
+  name: 'embed', type: 'embedding', device: 'gpu-rocm',
+  model: 'nomic-embed', model_id: 'nomic-embed', modelLong: 'nomic-embed',
+  group: 'embed', state: 'ready', port: 8095, isDefault: true,
+  enabled: true, enable_thinking: null, n_gpu_layers: -1,
+  metrics: {},
+}
+
+/**
+ * Override the in-bundle HAL0_DATA.slots for this page. data.jsx assigns
+ * `window.HAL0_DATA = {...}` unconditionally at module load, so we install
+ * a setter that patches `.slots` as the assignment lands — buildSlots()
+ * then reads our list on every poll.
+ */
+async function seedSlots(page: Page, slots: any[]) {
+  await page.addInitScript((slots) => {
+    let real: any
+    Object.defineProperty(window, 'HAL0_DATA', {
+      configurable: true,
+      get() {
+        return real
+      },
+      set(v) {
+        real = v
+        if (v && typeof v === 'object') v.slots = slots
+      },
+    })
+  }, slots)
+}
+
+const card = (page: Page, name: string) =>
+  page
+    .locator('.slot', { has: page.locator('.slot-name .nm', { hasText: new RegExp(`^${name}$`) }) })
+    .first()
+
+test.describe('Slot edit controls (/slots)', () => {
+  test('C3 — card enabled toggle PUTs /config { enabled:false }', async ({ page }) => {
+    const puts: any[] = []
+    await page.route('**/api/slots/primary/config', async (route) => {
+      if (route.request().method() === 'PUT') {
+        puts.push(JSON.parse(route.request().postData() || '{}'))
+      }
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await seedSlots(page, [PRIMARY, EMBED])
+
+    await page.goto('/#slots')
+    const toggle = card(page, 'primary').locator('.slot-enable-toggle')
+    await expect(toggle).toBeVisible()
+    await toggle.click()
+    await expect.poll(() => puts.length).toBeGreaterThan(0)
+    expect(puts[0].enabled).toBe(false)
+  })
+
+  test('C3 — disabled slot card carries the fade modifier class', async ({ page }) => {
+    await seedSlots(page, [PRIMARY, CODER])
+    await page.goto('/#slots')
+    await expect(card(page, 'coder')).toHaveClass(/slot--disabled/)
+    await expect(card(page, 'primary')).not.toHaveClass(/slot--disabled/)
+  })
+
+  test('C4 — drawer thinking toggle PUTs /config { enable_thinking:true }', async ({ page }) => {
+    const puts: any[] = []
+    await page.route('**/api/slots/primary/config', async (route) => {
+      if (route.request().method() === 'PUT') {
+        puts.push(JSON.parse(route.request().postData() || '{}'))
+      }
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await seedSlots(page, [PRIMARY, EMBED])
+
+    await page.goto('/#slots/primary')
+    const row = page.locator('.drawer .form-row', { hasText: 'Thinking' })
+    await expect(row).toBeVisible()
+    await row.locator('input[type="checkbox"]').click()
+    await expect.poll(() => puts.length).toBeGreaterThan(0)
+    expect(puts[0].enable_thinking).toBe(true)
+  })
+
+  test('C4 — thinking toggle is hidden for non-llm slots', async ({ page }) => {
+    await seedSlots(page, [PRIMARY, EMBED])
+    await page.goto('/#slots/embed')
+    await expect(page.locator('.drawer')).toBeVisible()
+    await expect(page.locator('.drawer .form-row', { hasText: 'Thinking' })).toHaveCount(0)
+  })
+
+  test('C5 — n_gpu_layers Save PATCHes /defaults', async ({ page }) => {
+    const patches: any[] = []
+    await page.route('**/api/slots/primary/defaults', async (route) => {
+      patches.push(JSON.parse(route.request().postData() || '{}'))
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await page.route('**/api/slots/primary/config', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+    await seedSlots(page, [PRIMARY, EMBED])
+
+    await page.goto('/#slots/primary')
+    const row = page.locator('.drawer .form-row', { hasText: 'n_gpu_layers' })
+    await expect(row).toBeVisible()
+    await row.locator('input').fill('33')
+    await page.locator('.drawer button:has-text("Save")').click()
+    await expect.poll(() => patches.length).toBeGreaterThan(0)
+    expect(patches[0].n_gpu_layers).toBe(33)
+  })
+
+  test('C6 — enabled slots sort before disabled ones', async ({ page }) => {
+    // Disabled-first input order: only a real enabled-first sort makes
+    // primary (enabled) render ahead of coder (disabled).
+    await seedSlots(page, [CODER, PRIMARY, EMBED])
+    await page.goto('/#slots')
+    const chatCards = page.locator('section', { hasText: 'Chat' }).locator('.slot')
+    await expect(chatCards.first()).toContainText('primary')
+    await expect(chatCards.nth(1)).toContainText('coder')
+  })
+})


### PR DESCRIPTION
Completes the slot edit-panel controls (Spec 1 C1–C5). **Adopted from a stalled worktree** (`wt-afk/slot-edit`, idle ~5h, no live process, never pushed, no PR) and reconciled onto current `main`.

## What's here

**Backend (`def3f0c`, C1-C2):**
- `/api/slots` payload now carries `enabled`, `enable_thinking`, `n_gpu_layers` (read from slot config / `[model]`) so card + drawer seed without a per-slot `/config` fetch.
- `PUT /api/slots/{name}/config { enabled: false }` stops a running slot after persisting (no orphaned llama-server child). Gated on live state; npu-exclusivity 409 preserved.

**UI (`a0bc8c4`, C3-C5):**
- **C3** per-card enable toggle — instant `PUT /config`, faded card + hidden lifecycle buttons when off, toggle stays interactive to flip back on.
- **C4** per-slot **Thinking** toggle in the edit drawer (llm slots) — instant PUT, no restart (`_slot_thinking_default` reads it live).
- **C5** `n_gpu_layers` field, applied on Save.
- e2e: `slot-edit-controls-v3` spec.

## Reconciliation note (important for review)

The stale branch also carried an **earlier, parallel** take on the C6/C7 capabilities-grid + enabled-first sort — but those **already shipped via #577**. I **dropped** the stale grid code and rebuilt only the unique C3/C4/C5 + backend onto #577's structure, to avoid the duplicate `renderGroup`/`enabledFirst`/grouping a naive merge produced. Also gitignores `.claude/wip.json`.

## Verification
- Backend: `tests/api/test_slots_routes.py` + `test_slots_lemonade_state.py` — **43 passed** (with dev extras / pytest-asyncio).
- UI: clean `npm run build` (126 modules, no errors); no duplicate declarations in `slots.jsx`.

Opening for **review before merge** (per request). Original WIP preserved at `/tmp/slot-edit-wip-20260606_0609.patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)