### PR TITLE
fix(ui): mobile dashboard collapses to black sliver (grid area/column mismatch)

### DIFF
--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -2201,7 +2201,7 @@ a { color: inherit; text-decoration: none; }
   .topbar { padding: 0 12px; gap: 10px; }
   .footer { display: none; }
   .bottom-tabs { display: grid; }
-  .app { grid-template-rows: var(--topbar-h) 1fr; grid-template-areas: "topbar" "main"; }
+  .app { grid-template-columns: 1fr; grid-template-rows: var(--topbar-h) 1fr; grid-template-areas: "topbar" "main"; }
 }
 
 /* ─── Persona-above-composer placement ─────────────────────────── */


### PR DESCRIPTION
## Problem
Narrowing the dashboard to a mobile-size viewport (≤720px) renders a **black screen** — actually the entire app shell collapsed into a ~24px sliver against the dark background.

## Root cause
In the `@media (max-width: 720px)` block, the `.app` rule overrode `grid-template-areas` to a single-column mobile template (`"topbar"`/`"main"`) but **left `grid-template-columns` at the desktop value** `var(--sidebar-w) 1fr` (= `0px 1fr`).

With the named areas spanning only column 1 (the `0px` sidebar track), `.topbar` and `.main` both collapsed to min-content inside that 0px column, while the real `1fr` column sat empty:

| element | before | after |
|---|---|---|
| `.topbar` | 24px | 375px |
| `.main` | 0px | 375px |
| `.view` | 32px | 369px |

Deterministic on any load at ≤720px.

## Fix
Add `grid-template-columns: 1fr` to the mobile `.app` rule — exactly what `.app.firstrun` already does for its single-column layout. One line.

## Verification
Live-injected the fix at 375px via DevTools; topbar/main/view fill the viewport (375/375/369) vs collapsed (24/0/32) before. `.app.popout` uses `display:block` and is unaffected.

⚠️ Needs `ui/dist` rebuild to go live on CT105 (deploy.sh / `make deploy`) — coordinate with the active NPU load-test session before bouncing hal0-api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)