### PR TITLE
fix(dashboard): NPU trio ASR/Embed read-only FLM labels + caret padding

### DIFF
--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -50,6 +50,7 @@ export interface Slot {
   device: string
   model: string
   model_id?: string
+  modelDefault?: string
   modelLong?: string
   group?: string
   state: string
@@ -195,6 +196,11 @@ function normalizeSlot(s: any): Slot {
     metrics: { ...DEFAULT_METRICS, ...(s?.metrics ?? {}) },
     spark: Array.isArray(s?.spark) ? s.spark : [],
     model: s?.model ?? s?.model_id ?? s?.model_default ?? '',
+    // Configured (TOML) model, surfaced separately so the NPU-trio
+    // read-only labels can show the intended FLM tag even when the live
+    // model_id is stale on the pre-trio GGUF (trio slots never load as
+    // their own process, so model_id never reconciles).
+    modelDefault: s?.model_default ?? '',
     // Backend selection (ADR-0022) — pass through verbatim. The backend
     // emits declared_backend always (when configured) and actual_backend/
     // backend_mismatch only when the child is introspectable; we surface

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -551,7 +551,14 @@ function NpuSwitch({ on, disabled, label, onClick }) {
 }
 
 // One modality mini-card inside the bracketed trio.
-function NpuModalityCard({ icon, label, slot, on, fixed, models, busy, onToggle, onPickModel }) {
+//
+// `readOnlyModel` modalities (ASR/embed) render the served model as a
+// read-only label instead of a picker: the FLM trio serves all three
+// roles from one `flm serve` process and the asr/embed model is fixed by
+// the --asr/--embed flags — the request `model` field is ignored by FLM
+// (verified 2026-06-06), so a picker there would be cosmetic. Chat (the
+// anchor) stays a real picker.
+function NpuModalityCard({ icon, label, slot, on, fixed, models, busy, onToggle, onPickModel, readOnlyModel }) {
   return (
     <div className="slot npu-mod" data-on={on ? "1" : "0"}>
       <div className="slot-h">
@@ -564,12 +571,26 @@ function NpuModalityCard({ icon, label, slot, on, fixed, models, busy, onToggle,
         </div>
       </div>
       <div className="npu-mod-body">
-        <NpuModelSelect
-          value={slot?.model || ""}
-          models={models}
-          disabled={!on || busy || !slot}
-          onChange={onPickModel}
-        />
+        {readOnlyModel ? (
+          <div
+            className="npu-mod-fixed mono"
+            title="Served by the FLM trio — the model is fixed by the --asr/--embed flags on this FLM build, not separately selectable."
+          >
+            {/* Prefer the slot's CONFIGURED model (model_default) over the live
+                model_id: an NPU-trio modality is never loaded as its own
+                process, so its live model_id stays stale on the pre-trio GGUF.
+                The configured FLM tag is what the anchor actually serves. */}
+            <span className="npu-fixed-model">{slot?.modelDefault || slot?.model || "—"}</span>
+            <span className="npu-fixed-tag" aria-hidden="true">FLM</span>
+          </div>
+        ) : (
+          <NpuModelSelect
+            value={slot?.model || ""}
+            models={models}
+            disabled={!on || busy || !slot}
+            onChange={onPickModel}
+          />
+        )}
       </div>
     </div>
   );
@@ -609,10 +630,13 @@ function NpuFlmStack({ slots }) {
   const flmArgsLive = typeof cfgQuery.data?.flm_args === "string" ? cfgQuery.data.flm_args : "";
   const parsed = parseFlmArgs(flmArgsLive);
 
+  // Only chat (the FLM anchor) is a real model choice — the operator picks
+  // which model `flm serve` runs. ASR/embed are served coresident off that
+  // one process with the model fixed by the --asr/--embed flags, so they
+  // render a read-only label (NpuModalityCard `readOnlyModel`) instead of a
+  // picker — no asr/embed model list to compute.
   const allModels = modelsQuery.data || [];
   const chatModels = flmModelsByType(allModels, "llm");
-  const asrModels = flmModelsByType(allModels, "transcription");
-  const embedModels = flmModelsByType(allModels, "embedding");
 
   const loaded = chat ? slotIsLoaded(chat) : npuSlots.some(slotIsLoaded);
   // Live flm.args string for the footer — pending toggles preview the
@@ -679,14 +703,8 @@ function NpuFlmStack({ slots }) {
     });
   };
 
-  const onPickAsrModel = (model_id) => {
-    if (!asr || !model_id || model_id === asr.model) return;
-    run(() => swapMut.mutateAsync({ name: asr.name, model_id }));
-  };
-  const onPickEmbedModel = (model_id) => {
-    if (!embed || !model_id || model_id === embed.model) return;
-    run(() => swapMut.mutateAsync({ name: embed.name, model_id }));
-  };
+  // No onPickAsr/onPickEmbed: those modalities are read-only labels (the
+  // FLM trio fixes their model via flags). Chat keeps onPickChat above.
 
   return (
     <div className="npu-stack">
@@ -709,16 +727,14 @@ function NpuFlmStack({ slots }) {
             models={chatModels} busy={busy} onPickModel={onPickChat}
           />
           <NpuModalityCard
-            icon="🎙" label="ASR" slot={asr} on={parsed.asr}
-            models={asrModels} busy={busy}
+            icon="🎙" label="ASR" slot={asr} on={parsed.asr} readOnlyModel
+            busy={busy}
             onToggle={() => onToggleModality("asr", asr)}
-            onPickModel={onPickAsrModel}
           />
           <NpuModalityCard
-            icon="🧬" label="Embed" slot={embed} on={parsed.embed}
-            models={embedModels} busy={busy}
+            icon="🧬" label="Embed" slot={embed} on={parsed.embed} readOnlyModel
+            busy={busy}
             onToggle={() => onToggleModality("embed", embed)}
-            onPickModel={onPickEmbedModel}
           />
         </div>
       </div>

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -1878,7 +1878,56 @@ a { color: inherit; text-decoration: none; }
 .npu-mod[data-on="0"] { opacity: 0.5; }
 .npu-mod .npu-mod-icon { font-size: 15px; line-height: 1; }
 .npu-mod-body { padding: 8px 0 2px; }
+
 .npu-sel { width: 100%; }
+/* The native <select> renders its caret hard against the right border and
+   lets the (mono, often long) model id run underneath it. Draw our own
+   chevron and reserve room for it so text never collides with the caret.
+   Use `select.npu-sel` (0,1,1) so it beats the base `select.input` rule
+   (same specificity, but this comes later) — a bare `.npu-sel` (0,1,0)
+   loses to `select.input`'s `padding`/`background` shorthand. */
+select.npu-sel {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 28px;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 12px;
+}
+
+/* Read-only model label for the ASR/embed modalities (model fixed by FLM). */
+.npu-mod-fixed {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+  padding: 8px 11px;
+  border: 1px solid var(--line);
+  border-radius: var(--rad);
+  background: var(--bg);
+  color: var(--fg-4);
+  font-size: 12.5px;
+  cursor: default;
+}
+.npu-mod-fixed .npu-fixed-model {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.npu-mod-fixed .npu-fixed-tag {
+  flex: 0 0 auto;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  padding: 1px 5px;
+  border-radius: 999px;
+  color: var(--dev-npu);
+  border: 1px solid rgba(200, 150, 255, 0.30);
+  background: rgba(200, 150, 255, 0.06);
+}
 
 /* On/off switch (matches prototype). */
 .npu-switch {

--- a/ui/tests/e2e/specs/slots-v3.spec.ts
+++ b/ui/tests/e2e/specs/slots-v3.spec.ts
@@ -53,4 +53,16 @@ test.describe('Slots v3 (/slots)', () => {
     // HAL0_DATA seeds at least one device=npu slot, so the NPU section h2 should appear
     await expect(page.locator('.view .sec h2', { hasText: 'NPU' })).toBeVisible()
   })
+
+  test('NPU trio: chat is a model picker; ASR/embed are read-only labels (model fixed by FLM)', async ({ page }) => {
+    await page.goto('/#slots')
+    const stack = page.locator('.npu-stack')
+    await expect(stack).toBeVisible()
+    // Chat (the FLM anchor) keeps a real <select> model picker.
+    await expect(stack.locator('.npu-sel')).toHaveCount(1)
+    // ASR + embed serve coresident off that one process with the model fixed
+    // by the --asr/--embed flags, so they render read-only labels, not pickers.
+    await expect(stack.locator('.npu-mod-fixed')).toHaveCount(2)
+    await expect(stack.locator('.npu-mod-fixed .npu-fixed-tag')).toHaveCount(2)
+  })
 })


### PR DESCRIPTION
## What

The NPU·FLM Stack card's **ASR** and **Embed** model dropdowns were empty. This fixes them, converts them to honest read-only labels, and fixes the dropdown caret padding.

## Root cause (traced on CT105)

1. **Empty options** — the pickers filtered `useModels()` (`/api/models`) for FLM asr/embed models. But `/api/models` only surfaces FLM models that are registry entries or upstream-adopted — i.e. just the loaded chat anchor (`qwen3-it-4b-FLM`). The downloaded FLM asr/embed models (`whisper-v3-turbo-FLM`, `embed-gemma-300m-FLM`) reach hal0 only through the **capability catalogue** (`/api/capabilities`), never `/api/models`.

2. **The pickers were cosmetic anyway** — the FLM trio serves chat+asr+embed from **one** `flm serve` process, with the asr/embed model fixed by the `--asr 1`/`--embed 1` flags. Verified live: POSTing a *bogus* model name to the FLM child still returns a correct transcription / 768-dim embedding. The request `model` field is ignored.

## Fix

- **ASR/Embed → read-only label** showing the served FLM model (`slot.model_default`, the configured FLM tag). The live `model_id` stays stale on the pre-trio GGUF because a trio modality never loads as its own process, so we prefer `model_default`.
- **Chat keeps a real picker** — the anchor model *is* a genuine choice.
- **Caret padding** — `select.npu-sel` now draws a custom chevron with `padding-right` (the bare `.npu-sel` rule lost to `select.input`'s specificity, so the native caret crowded the mono model id).

## Verified live (CT105 NPU)

- Loaded the FLM trio (`--asr 1 --embed 1`); a single `flm` child (port 8001) served:
  - **Embed** → `embed-gemma-300m`, 768-dim ✅
  - **ASR** → `whisper-v3-turbo`, correct transcription ✅
- Enabled the trio via capability apply (`voice.stt` + `embed.embed` → `device=npu`); the card renders Chat picker + `whisper-v3:turbo` / `embed-gemma:300m` read-only labels.
- `tsc --noEmit` clean; slots-v3 / slot-edit-controls-v3 / system-card-v3 e2e green (added a slots-v3 assertion: 1 chat picker, 2 read-only labels).

## Note

Enabling the trio moves embedding off the iGPU (nomic) and STT off CPU (whisper-tiny) onto the NPU FLM trio. That's the intended effect of selecting `device=npu` for those capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
