### PR TITLE
fix(dispatcher): FLM trio /v1/v1 double-prefix → embed+STT 404 on public API

### DIFF
--- a/src/hal0/dispatcher/flm_trio.py
+++ b/src/hal0/dispatcher/flm_trio.py
@@ -194,11 +194,19 @@ class FLMTrioRouter:
                     continue
                 backend_url = entry.get("backend_url")
                 if isinstance(backend_url, str) and backend_url.strip():
-                    # Strip trailing slashes so ``{backend_url}/v1/...``
-                    # joining never produces ``//v1/...``. lemond's
-                    # backend_url is conventionally bare (no trailing
-                    # slash) but defensiveness is cheap.
-                    return backend_url.rstrip("/")
+                    # Normalise the discovered base so the
+                    # ``{backend_url}/v1/...`` joins below always produce
+                    # exactly one ``/v1``. lemond versions disagree on the
+                    # shape: some emit a bare ``host:port``, but 10.6.0
+                    # includes the OpenAI ``/v1`` suffix
+                    # (``http://127.0.0.1:8001/v1``). Without stripping it the
+                    # dispatch URL became ``/v1/v1/embeddings`` → 404 (the
+                    # NPU embed/STT slots silently failed on the public API
+                    # path). Strip a trailing ``/v1`` and any trailing slash.
+                    url = backend_url.strip().rstrip("/")
+                    if url.endswith("/v1"):
+                        url = url[: -len("/v1")]
+                    return url
 
         return None
 

--- a/tests/dispatcher/test_flm_trio.py
+++ b/tests/dispatcher/test_flm_trio.py
@@ -195,6 +195,47 @@ async def test_find_backend_url_strips_trailing_slash() -> None:
 
 
 @pytest.mark.asyncio
+async def test_find_backend_url_strips_trailing_v1_suffix() -> None:
+    """Regression: lemond 10.6.0 reports ``backend_url`` WITH a ``/v1``
+    suffix (e.g. ``http://127.0.0.1:8001/v1``). The dispatch methods join
+    ``{backend_url}/v1/...``, so an unstripped suffix produced
+    ``/v1/v1/embeddings`` → 404. Normalise the discovered base to drop a
+    trailing ``/v1`` (and any trailing slash) so the join yields exactly
+    one ``/v1``."""
+    payload = {
+        "loaded": [
+            {
+                "recipe": "flm",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:8001/v1",
+            }
+        ]
+    }
+    client, transport = _lemonade_with_health(payload)
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() == "http://127.0.0.1:8001"
+
+
+@pytest.mark.asyncio
+async def test_find_backend_url_strips_trailing_v1_with_slash() -> None:
+    """``/v1/`` (suffix + trailing slash) normalises the same way."""
+    payload = {
+        "loaded": [
+            {
+                "recipe": "flm",
+                "type": "llm",
+                "backend_url": "http://127.0.0.1:8001/v1/",
+            }
+        ]
+    }
+    client, transport = _lemonade_with_health(payload)
+    async with transport:
+        router = FLMTrioRouter(client)
+        assert await router.find_flm_chat_backend_url() == "http://127.0.0.1:8001"
+
+
+@pytest.mark.asyncio
 async def test_find_backend_url_returns_none_when_backend_url_missing() -> None:
     payload = {
         "loaded": [{"recipe": "flm", "type": "llm"}],


### PR DESCRIPTION
fix(dispatcher): FLM trio dispatched to /v1/v1/... → embed + STT 404 on public API

The NPU FLM-trio embed/STT routing worked when hitting the lemond child
directly but 404'd through hal0-api's public OpenAI-compat path
(/v1/embeddings, /v1/audio/transcriptions).

Root cause: `FLMTrioRouter.find_flm_chat_backend_url` assumed lemond's
`backend_url` was bare (host:port) and the dispatch methods join
`{backend_url}/v1/...`. lemond 10.6.0 reports the OpenAI `/v1` suffix
already baked in (`http://127.0.0.1:8001/v1`), so the join produced
`http://127.0.0.1:8001/v1/v1/embeddings` → 404. The trio router was wired
and detection fired correctly; only the URL was malformed.

Fix: normalise the discovered base — strip a trailing `/v1` (and any
trailing slash) so the join always yields exactly one `/v1`, regardless of
which convention the lemond build uses.

Verified live (CT105): after the fix, `POST :8080/v1/embeddings` returns a
768-dim vector and `POST :8080/v1/audio/transcriptions` transcribes — both
served by the single FLM child, through hal0-api's trio dispatch.

- flm_trio.py: strip trailing `/v1` in find_flm_chat_backend_url.
- test_flm_trio.py: +2 regression tests (/v1 and /v1/ suffixes).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
