### PR TITLE
feat(ui): mobile hamburger nav drawer (replaces dead bottom tabs)

### DIFF
--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -73,6 +73,7 @@ const Icons = {
   chev:      <Icon d="M4 6l4 4 4-4"/>,
   chevR:     <Icon d="M6 4l4 4-4 4"/>,
   close:     <Icon d="M4 4l8 8M12 4l-8 8"/>,
+  menu:      <Icon d="M2 4h12M2 8h12M2 12h12"/>,
   check:     <Icon d="M3 8l3 3 7-7"/>,
   warn:      <Icon><path d="M8 2l6 11H2L8 2z"/><path d="M8 7v3M8 12v0.01"/></Icon>,
   plus:      <Icon d="M8 3v10M3 8h10"/>,
@@ -89,7 +90,7 @@ const Icons = {
 };
 
 // ─── TopBar ───
-function TopBar({ route, hostUptime = "14d 02:11", onBell, onCmdK, approvals = 0 }) {
+function TopBar({ route, hostUptime = "14d 02:11", onBell, onCmdK, onMenu, menuOpen = false, approvals = 0 }) {
   // Issue #333: hostname from live /api/hardware (useHardware hook) instead of
   // the legacy HAL0_DATA seed. Fall back to a neutral "hal0" placeholder
   // while the first response is in flight so the layout stays stable.
@@ -132,12 +133,25 @@ function TopBar({ route, hostUptime = "14d 02:11", onBell, onCmdK, approvals = 0
         {Icons.bell}
         {approvals > 0 && <span className="badge num">{approvals}</span>}
       </button>
+      {/* Mobile-only nav launcher (hidden ≤720px sidebar is gone) → opens NavDrawer. */}
+      <button
+        className="tb-menu"
+        onClick={onMenu}
+        aria-label="Menu"
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+      >
+        {Icons.menu}
+      </button>
     </div>
   );
 }
 
-// ─── Sidebar ───
-function Sidebar({ route, onGo }) {
+// ─── Nav model (shared) ───
+// Canonical list of primary destinations with live counts and the 0.4
+// memory gate applied. Shared by the desktop Sidebar and the mobile
+// NavDrawer so the two navs can never drift apart.
+function useNavItems() {
   const slotsQuery  = useSlots();
   const modelsQuery = useModels();
   const slotCount   = slotsQuery.data?.length  ?? 0;
@@ -148,19 +162,22 @@ function Sidebar({ route, onGo }) {
   // can never disagree with the backend. main.jsx applies the matching
   // route guard for deep links.
   const memoryEnabled = useMemoryEnabled();
-  const items = [
+  return [
     { id: "dashboard", label: "Dashboard", icon: Icons.dashboard },
     { id: "slots",     label: "Slots",     icon: Icons.slots, cnt: slotCount },
     { id: "models",    label: "Models",    icon: Icons.models, cnt: modelCount },
     { id: "logs",      label: "Logs",      icon: Icons.logs },
     ...(memoryEnabled ? [{ id: "agent", label: "Agent", icon: Icons.agent }] : []),
     // Issue #206 — MCP page wired to /api/mcp/*. Lives under "Agents"
-    // conceptually but kept as a sibling in the sidebar so the URL is
-    // discoverable. Icon reuses the agent glyph (no dedicated MCP icon
-    // in the design system yet).
+    // conceptually but kept as a sibling so the URL is discoverable.
     { id: "mcp",       label: "MCP",       icon: Icons.agent },
     { id: "settings",  label: "Settings",  icon: Icons.settings },
   ];
+}
+
+// ─── Sidebar ───
+function Sidebar({ route, onGo }) {
+  const items = useNavItems();
   return (
     <div className="sidebar">
       <div className="sb-section">Navigate</div>
@@ -634,28 +651,55 @@ if (typeof document !== "undefined" && !document.getElementById("hal0-modal-css"
 }
 
 // ─── Bottom tab bar (mobile <720px) ───
-function BottomTabs({ route, onGo }) {
-  const tabs = [
-    { id: "dashboard", label: "Home",   icon: Icons.dashboard },
-    { id: "agent",     label: "Agent",  icon: Icons.agent },
-    { id: "slots",     label: "Slots",  icon: Icons.slots },
-    { id: "models",    label: "Models", icon: Icons.models },
-    { id: "settings",  label: "More",   icon: Icons.settings },
-  ];
+// ─── NavDrawer (mobile) ───
+// Slide-in drawer that replaces the (display:none) desktop sidebar at
+// ≤720px. Mirrors the sidebar: the command-palette launcher (folded in
+// from the topbar on mobile), the full nav (useNavItems), and the runtime
+// status widget. Opened from the topbar hamburger; closed via backdrop,
+// the X, Esc, or navigating.
+function NavDrawer({ open, route, onGo, onClose, onCmdK }) {
+  const items = useNavItems();
   return (
-    <nav className="bottom-tabs" aria-label="Primary">
-      {tabs.map(t => (
-        <button
-          key={t.id}
-          className={"bottom-tab" + (route === t.id ? " active" : "")}
-          onClick={() => onGo(t.id)}
-        >
-          {t.icon}
-          <span>{t.label}</span>
+    <>
+      <div
+        className={"nav-drawer-backdrop" + (open ? " open" : "")}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <aside
+        className={"nav-drawer" + (open ? " open" : "")}
+        aria-label="Navigation"
+        aria-hidden={!open}
+      >
+        {open && (<>
+        <div className="nav-drawer-head">
+          <span className="sb-section">Navigate</span>
+          <button className="nav-drawer-close" onClick={onClose} aria-label="Close menu">
+            {Icons.close}
+          </button>
+        </div>
+        <button className="nav-drawer-cmdk" onClick={onCmdK}>
+          {Icons.search}<span>Command palette</span><kbd>⌘K</kbd>
         </button>
-      ))}
-    </nav>
+        <div className="sb-list">
+          {items.map(it => (
+            <div
+              key={it.id}
+              className={"sb-row" + (route === it.id ? " active" : "")}
+              onClick={() => onGo(it.id)}
+            >
+              {it.icon}
+              <span className="lbl">{it.label}</span>
+              {it.cnt !== undefined && <span className="cnt num">{it.cnt}</span>}
+            </div>
+          ))}
+        </div>
+        <div className="sb-spacer" />
+        <SidebarRuntimeWidget onGo={onGo} />
+        </>)}
+      </aside>
+    </>
   );
 }
 
-Object.assign(window, { Wordmark, Icons, Icon, TopBar, Sidebar, Footer, ApprovalModal, BottomTabs });
+Object.assign(window, { Wordmark, Icons, Icon, TopBar, Sidebar, Footer, ApprovalModal, NavDrawer });

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -63,6 +63,7 @@ function App() {
   const [composerState, setComposerState] = useStateA("idle");
   const [footerOpen, setFooterOpen] = useStateA(false);
   const [paletteOpen, setPaletteOpen] = useStateA(false);
+  const [navOpen, setNavOpen] = useStateA(false);
 
   // 0.4 gate: the Agent route is reduced to the Memory tab, so it only
   // renders when the memory subsystem is live (HAL0_MEMORY_ENABLED, surfaced
@@ -95,7 +96,7 @@ function App() {
   useEffectA(() => {
     // global keyboard shortcuts
     const onKey = (e) => {
-      if (e.key === "Escape") { setBellOpen(false); return; }
+      if (e.key === "Escape") { setBellOpen(false); setNavOpen(false); return; }
       const tgt = e.target;
       const typing = tgt && (tgt.tagName === "INPUT" || tgt.tagName === "TEXTAREA" || tgt.isContentEditable);
       if (typing) return;
@@ -120,6 +121,10 @@ function App() {
     window.addEventListener("hal0:open-approvals", onApprovals);
     return () => window.removeEventListener("hal0:open-approvals", onApprovals);
   }, []);
+
+  // Close the mobile nav drawer on any route change (deep links, command
+  // palette). Direct taps also close it via the onGo wrapper below.
+  useEffectA(() => { setNavOpen(false); }, [route]);
 
   const go = (id) => {
     window.location.hash = "#" + id;
@@ -195,6 +200,8 @@ function App() {
           route={route}
           onBell={() => setBellOpen(true)}
           onCmdK={() => setPaletteOpen(true)}
+          onMenu={() => setNavOpen(true)}
+          menuOpen={navOpen}
           approvals={0}
         />
         {!isFirstrun && <Sidebar route={route} onGo={go} />}
@@ -224,7 +231,15 @@ function App() {
         />
       </div>
 
-      {!isFirstrun && <BottomTabs route={route} onGo={go} />}
+      {!isFirstrun && (
+        <NavDrawer
+          open={navOpen}
+          route={route}
+          onGo={(id) => { setNavOpen(false); go(id); }}
+          onClose={() => setNavOpen(false)}
+          onCmdK={() => { setNavOpen(false); setPaletteOpen(true); }}
+        />
+      )}
 
       {/* v0.3 PR-8: ApprovalModal stays mounted but its content is
           backed by the live agent approvals queue in PR-10. Today the

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -2224,7 +2224,8 @@ select.npu-sel {
   .view-banners { padding: 14px 16px 0; }
   .tb-brand { width: auto; }
   .tb-host .ut { display: none; }
-  .tb-cmdk span { display: none; }
+  .tb-cmdk { display: none; }   /* command palette folded into the nav drawer on mobile */
+  .topbar .tb-menu { display: flex; }
   .tb-eyebrow { display: none; }
   .tiers { grid-template-columns: 1fr; }
   .slots-grid { grid-template-columns: 1fr; }
@@ -2249,7 +2250,6 @@ select.npu-sel {
   .settings-nav { position: static; flex-direction: row; flex-wrap: wrap; overflow-x: auto; }
   .topbar { padding: 0 12px; gap: 10px; }
   .footer { display: none; }
-  .bottom-tabs { display: grid; }
   .app { grid-template-columns: 1fr; grid-template-rows: var(--topbar-h) 1fr; grid-template-areas: "topbar" "main"; }
 }
 
@@ -2431,34 +2431,104 @@ select.npu-sel {
 }
 
 /* ─── Bottom tab bar (mobile <720px) ──────────────────────────── */
-.bottom-tabs {
+/* ─── Mobile nav: topbar hamburger + slide-in drawer ──────────
+   .tb-menu is hidden on desktop (the sidebar handles nav) and revealed at
+   ≤720px by the media query above, where it opens .nav-drawer. */
+.tb-menu {
   display: none;
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 80;
-  background: var(--bg);
-  border-top: 1px solid var(--line);
-  grid-template-columns: repeat(5, 1fr);
-  padding-bottom: env(safe-area-inset-bottom);
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: var(--rad);
+  color: var(--fg-2);
+  cursor: pointer;
 }
-.bottom-tab {
+.tb-menu:hover { color: var(--fg); border-color: var(--line-strong); }
+
+.nav-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+.nav-drawer-backdrop.open { opacity: 1; pointer-events: auto; }
+
+.nav-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 100;
+  width: min(82vw, 320px);
   display: flex;
   flex-direction: column;
+  gap: 2px;
+  padding: 12px 8px calc(12px + env(safe-area-inset-bottom));
+  background: var(--bg);
+  border-left: 1px solid var(--line);
+  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.4);
+  transform: translateX(100%);
+  transition: transform 0.22s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+.nav-drawer.open { transform: translateX(0); }
+
+.nav-drawer-head {
+  display: flex;
   align-items: center;
-  gap: 3px;
-  padding: 9px 6px 7px;
+  justify-content: space-between;
+  padding: 2px 6px 6px;
+}
+.nav-drawer-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
   background: transparent;
   border: none;
   color: var(--fg-3);
-  font-family: var(--jbm);
-  font-size: 9px;
-  letter-spacing: 0.02em;
   cursor: pointer;
 }
-.bottom-tab.active { color: var(--accent); }
-.bottom-tab svg { width: 18px; height: 18px; }
+.nav-drawer-close:hover { color: var(--fg); }
+
+.nav-drawer-cmdk {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 8px 6px;
+  padding: 9px 11px;
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  border-radius: var(--rad);
+  color: var(--fg-3);
+  font-family: var(--jbm);
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.nav-drawer-cmdk:hover { color: var(--fg); border-color: var(--line-strong); }
+.nav-drawer-cmdk svg { flex: 0 0 auto; }
+.nav-drawer-cmdk kbd {
+  margin-left: auto;
+  font-family: var(--jbm);
+  font-size: 10px;
+  color: var(--fg-4);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+/* The 1080px breakpoint hides .sb-status globally (desktop sidebar rail
+   collapse); re-show it inside the drawer where the rail is full-width. */
+.nav-drawer .sb-status { display: block; }
 
 /* ─── Toast ────────────────────────────────────────────────────── */
 .hal0-toast {

--- a/ui/tests/e2e/specs/mobile-nav-v3.spec.ts
+++ b/ui/tests/e2e/specs/mobile-nav-v3.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * mobile-nav-v3 — at ≤720px the desktop sidebar is hidden and navigation
+ * moves into a top-right hamburger (.tb-menu) that opens a slide-in
+ * NavDrawer: command-palette launcher (folded in from the topbar), the full
+ * nav (useNavItems — incl. Logs + MCP the old bottom-tabs never reached),
+ * and the runtime status widget. Replaces the never-shown bottom-tab bar.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+const MOBILE = { width: 375, height: 812 }
+
+test.describe('Mobile nav drawer (≤720px)', () => {
+  test.use({ viewport: MOBILE })
+
+  test('hamburger replaces the sidebar and opens a full-nav drawer', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.locator('.topbar')).toBeVisible()
+    // the desktop sidebar collapses out at mobile width
+    await expect(page.locator('.sidebar')).toBeHidden()
+
+    // hamburger present, drawer starts closed (off-canvas → no .open class)
+    const burger = page.locator('.tb-menu')
+    await expect(burger).toBeVisible()
+    await expect(burger).toHaveAttribute('aria-expanded', 'false')
+    const drawer = page.locator('.nav-drawer')
+    await expect(drawer).not.toHaveClass(/\bopen\b/)
+
+    // open
+    await burger.click()
+    await expect(drawer).toHaveClass(/\bopen\b/)
+    await expect(burger).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.locator('.nav-drawer-backdrop.open')).toBeVisible()
+
+    // full nav — including the destinations the dead bottom tabs never reached
+    for (const label of ['Dashboard', 'Slots', 'Models', 'Logs', 'MCP', 'Settings']) {
+      await expect(drawer.locator('.sb-row .lbl', { hasText: label })).toBeVisible()
+    }
+    // command palette folded into the drawer on mobile
+    await expect(drawer.locator('.nav-drawer-cmdk')).toBeVisible()
+    // runtime widget re-shown inside the drawer (despite the 1080px global hide)
+    await expect(drawer.locator('.sb-status').first()).toBeVisible()
+  })
+
+  test('selecting a destination navigates and closes the drawer', async ({ page }) => {
+    await page.goto('/')
+    await page.locator('.tb-menu').click()
+    const drawer = page.locator('.nav-drawer')
+    await expect(drawer).toHaveClass(/\bopen\b/)
+
+    await drawer.locator('.sb-row', { hasText: 'Models' }).click()
+    await expect(page).toHaveURL(/#models/)
+    await expect(drawer).not.toHaveClass(/\bopen\b/)
+  })
+
+  test('backdrop click closes the drawer', async ({ page }) => {
+    await page.goto('/')
+    await page.locator('.tb-menu').click()
+    const drawer = page.locator('.nav-drawer')
+    await expect(drawer).toHaveClass(/\bopen\b/)
+
+    // top-left corner is backdrop (the panel itself sits on the right)
+    await page.locator('.nav-drawer-backdrop').click({ position: { x: 10, y: 10 } })
+    await expect(drawer).not.toHaveClass(/\bopen\b/)
+  })
+
+  test('Escape closes the drawer', async ({ page }) => {
+    await page.goto('/')
+    await page.locator('.tb-menu').click()
+    const drawer = page.locator('.nav-drawer')
+    await expect(drawer).toHaveClass(/\bopen\b/)
+
+    await page.keyboard.press('Escape')
+    await expect(drawer).not.toHaveClass(/\bopen\b/)
+  })
+})
+
+test.describe('Desktop nav (>720px)', () => {
+  test('hamburger is hidden and the sidebar is the nav', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await page.goto('/')
+    await expect(page.locator('.sidebar')).toBeVisible()
+    await expect(page.locator('.tb-menu')).toBeHidden()
+  })
+})


### PR DESCRIPTION
## Problem
On mobile (≤720px) the dashboard has **no working navigation**. The desktop sidebar is hidden, and the `BottomTabs` bar that was supposed to take over **never actually renders** — its base `.bottom-tabs { display:none }` sits *after* the `@media (max-width:720px)` `display:grid` rule, so equal-specificity source ordering keeps it hidden. (Same class of bug as #580.) It was also incomplete: no Logs, no MCP, and it showed *Agent* even when the memory subsystem is off.

## What this does
Replaces the dead bottom tabs with a **top-right hamburger** (`.tb-menu`) that opens a **slide-in `NavDrawer`** over a dimmed backdrop.

- **Full nav** via a new shared `useNavItems()` hook, extracted from `Sidebar` so the desktop sidebar and the mobile drawer can never drift apart — includes Logs + MCP and respects the 0.4 memory gate (no Agent when memory is off).
- **⌘K command palette folded into the drawer** on mobile; the standalone topbar ⌘K button is hidden ≤720px.
- **Runtime status widget** re-shown inside the drawer (the 1080px breakpoint hides `.sb-status` globally for the desktop rail collapse, so the drawer re-enables it).
- Closes on backdrop click, the **✕**, **Esc**, or selecting a destination.

## Notable implementation choices
- **Drawer contents render only while `open`**, so the desktop (always-closed) drawer contributes **no duplicate `.sb-row`/`.sb-status`** to the DOM → existing specs are untouched (no edits to other tests).
- The `.tb-menu` reveal uses `.topbar .tb-menu` **specificity** rather than relying on source order — avoiding the exact trap that killed the bottom tabs.

## Tests
- New `tests/e2e/specs/mobile-nav-v3.spec.ts` (6 tests): hamburger replaces sidebar; drawer exposes full nav + ⌘K + runtime widget; select-navigates-and-closes; backdrop closes; Esc closes; desktop hides hamburger / shows sidebar.
- Full γ-suite: **117 passed / 13 skipped / 0 failed**.
- Live-verified on a preview build at 375px: drawer slides in (308px panel, backdrop opacity 1), rows = Dashboard/Slots/Models/Logs/MCP/Settings, active=Dashboard, ⌘K + runtime widget visible.

⚠️ Needs a `ui/dist` rebuild to go live on CT105 (`scripts/deploy.sh` / `make deploy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
