### PR TITLE
fix(slots): stop slot-edit Save from wiping [model].default

### DIFF
--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1422,10 +1422,23 @@ class SlotManager:
 
         cfg = await self._load_slot_config(slot_name)
         cfg_dict = _cfg_to_dict(cfg)
-        # Shallow merge — nested dicts are replaced wholesale to keep update
-        # semantics predictable. Callers wanting a partial nested update
-        # build the sub-dict on their side first.
-        cfg_dict.update(updates)
+        # One-level deep merge for nested TOML tables ([model], [server]).
+        # A bare shallow ``dict.update`` replaced a sub-table wholesale, so a
+        # partial ``PATCH /defaults`` body like ``{"model": {"ctx_size": N}}``
+        # silently dropped sibling keys — most damagingly ``[model].default``
+        # (the model name), which left the slot unable to resolve a model and
+        # turned the dashboard Start button into a silent no-op after a
+        # restart. Merge sub-table dicts key-by-key so partial updates only
+        # touch the fields they carry; scalars and lists still replace
+        # wholesale (predictable, and no caller relies on list-merge).
+        for key, value in updates.items():
+            existing = cfg_dict.get(key)
+            if isinstance(existing, dict) and isinstance(value, dict):
+                merged = dict(existing)
+                merged.update(value)
+                cfg_dict[key] = merged
+            else:
+                cfg_dict[key] = value
 
         # PR-11: re-run the NPU exclusivity guard whenever the merged
         # config could land a second device=npu, type=llm anchor (plan

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -872,3 +872,31 @@ def test_synthetic_composite_slot_serving_when_model_loaded(
     by_name = {e["name"]: e for e in r.json()}
     assert "hal0" in by_name, f"composite hal0 slot missing: {sorted(by_name)}"
     assert by_name["hal0"]["status"] == "serving"
+
+
+def test_patch_defaults_preserves_model_default(
+    slot_root: Path,
+    isolated_client: TestClient,
+) -> None:
+    """Regression: the slot-edit Save's ``PATCH /defaults`` must not wipe the
+    model name.
+
+    The dashboard edit drawer saves ctx_size / n_gpu_layers via
+    ``PATCH /api/slots/{name}/defaults`` with a partial ``[model]`` body.
+    A shallow merge replaced the whole ``[model]`` table, silently dropping
+    ``[model].default`` — so after a restart the slot had no resolvable model
+    and the Start button became a silent no-op. The partial update must touch
+    only the keys it carries.
+    """
+    # Sanity: the seeded slot starts with a model default.
+    before = isolated_client.get("/api/slots/primary/config")
+    assert before.status_code == 200, before.text
+    assert before.json()["model"]["default"] == "qwen3-4b-q4_k_m"
+
+    r = isolated_client.patch("/api/slots/primary/defaults", json={"ctx_size": 8192})
+    assert r.status_code == 200, r.text
+
+    after = isolated_client.get("/api/slots/primary/config").json()
+    assert after["model"]["ctx_size"] == 8192
+    # The model name survived the partial defaults write.
+    assert after["model"]["default"] == "qwen3-4b-q4_k_m"

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -705,3 +705,25 @@ async def test_hal0_backend_env_var_is_ignored(
     sm = SlotManager()
     snap = await sm.load("primary")
     assert snap.state == SlotState.READY
+
+
+async def test_update_config_preserves_sibling_model_keys(slot_root: Path) -> None:
+    """Regression: a partial ``{"model": {...}}`` update must not clobber siblings.
+
+    ``PATCH /api/slots/{name}/defaults`` sends only the model sub-keys it
+    is changing (e.g. ``ctx_size``/``n_gpu_layers``). The shallow merge
+    used to replace the whole ``[model]`` table, silently dropping
+    ``[model].default`` (the model name). After a restart the slot could
+    no longer resolve a model and the dashboard Start button became a
+    silent no-op. update_config must merge nested tables, not clobber.
+    """
+    from hal0.slots.state import SlotState as _S
+
+    sm = SlotManager()
+    await sm._transition("primary", _S.OFFLINE, force=True)
+    # Seeded primary.toml carries [model] default = "qwen3-4b-q4_k_m".
+    await sm.update_config("primary", {"model": {"ctx_size": 8192}})
+    cfg_text = (slot_root / "primary.toml").read_text(encoding="utf-8")
+    assert "ctx_size = 8192" in cfg_text
+    # The pre-existing model default MUST survive the partial update.
+    assert '"qwen3-4b-q4_k_m"' in cfg_text


### PR DESCRIPTION
## Problem

Reported as **"unable to start slots"**: after a restart, the dashboard Start button does nothing on affected slots (it fires a green "Starting…" toast but the slot stays offline).

## Root cause

`SlotManager.update_config` did a shallow `dict.update`, which replaces nested TOML tables **wholesale**. The new slot-edit drawer's Save saves `ctx_size` / `n_gpu_layers` via `PATCH /api/slots/{name}/defaults`, whose handler passes a partial `{"model": {...}}` body. The shallow merge therefore **deleted every other `[model]` key — most damagingly `[model].default`** (the model name).

The damage is invisible until a restart: with no resolvable model, `load()` bails to OFFLINE with *"no default model — pick one from the dropdown"*, and the UI Start (which POSTs `/load` with no body) becomes a silent no-op. A slot whose model happened to still be resident in lemond masked the bug via adoption.

## Fix

Merge nested sub-table dicts (`[model]`, `[server]`) key-by-key so a partial update only touches the fields it carries. Scalars/lists still replace wholesale (no caller relies on list-merge; audited all `update_config` callers + existing tests — only `PATCH /defaults` sends a nested partial).

## Tests (TDD — both seams)

- **manager**: `update_config({"model": {"ctx_size": N}})` preserves `[model].default` (watched it fail first: `[model]` collapsed to just `ctx_size`).
- **route**: `PATCH /defaults` preserves `model.default` end-to-end.

`tests/slots/` (123) + `tests/api/test_slots_routes.py` (24) green; ruff check + format clean.

## Operational note

The live CT105 slots that already lost their defaults (`primary`, `agent-hermes`, `gpu-rocmfp4`) were restored out-of-band by rewriting their TOMLs. This PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
