### PR TITLE
feat(dashboard): Connections surface — providers/upstreams list + test (#549)

### DIFF
--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -166,6 +166,19 @@ export const ENDPOINTS = {
   // request host, so links work on any install (localhost / LAN IP /
   // hal0.local / custom domain) without hardcoding. See routes/config.py.
   configUrls: '/api/config/urls',
+
+  // ── Connections (issue #549) — providers + upstreams + reachability test
+  // ``/api/providers`` is the alias of ``/api/upstreams`` filtered to remote
+  // (kind != "slot"); ``/api/upstreams`` returns every routing target. The
+  // POST /test probe is what the dashboard's per-upstream Test button calls.
+  providers: '/api/providers',
+  providersCatalog: '/api/providers/catalog',
+  upstreams: '/api/upstreams',
+  upstream: (name: string) =>
+    `/api/upstreams/${encodeURIComponent(name)}`,
+  upstreamTest: (name: string) =>
+    `/api/upstreams/${encodeURIComponent(name)}/test`,
+
   // Install / FirstRun
   installState: '/api/install/state',
   firstrunState: '/api/firstrun/state',

--- a/ui/src/api/hooks/useConnections.ts
+++ b/ui/src/api/hooks/useConnections.ts
@@ -1,0 +1,128 @@
+// hal0 v3 dashboard — Connections hooks (issue #549).
+//
+// Thin react-query wrappers over the providers.py routes that back the
+// dashboard's "Connections" surface:
+//
+//   GET  /api/providers            — remote (kind != "slot") upstreams
+//   GET  /api/providers/catalog    — static integration catalog (templates)
+//   GET  /api/upstreams            — all routing targets (slot + remote)
+//   POST /api/upstreams/{name}/test — probe reachability + auth
+//
+// The shape is documented in src/hal0/api/routes/providers.py
+// (_serialize_upstream). Every field is a string|bool|number|array —
+// no nested envelopes, so the hook can pass the payload through after
+// a light validation pass.
+
+import { useMutation, useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { api, apiGet, Hal0Error } from '../client'
+import { ENDPOINTS } from '../endpoints'
+
+export type UpstreamKind = 'slot' | 'remote' | string
+
+export interface Upstream {
+  /** Registry key — the name callers use to address this upstream. */
+  name: string
+  /** 'slot' for lifecycle-managed slot fronts, 'remote' for third-party APIs. */
+  kind: UpstreamKind
+  /** Base URL of the upstream (or composite endpoint for slot kind). */
+  url: string
+  /** Auth scheme declared by the upstream ('bearer', 'x-api-key', …). */
+  auth_style: string
+  /** Env-var name the upstream reads its credential from. Never the value. */
+  auth_value_env: string
+  /** Convenience flag — true when auth_value_env is set (and presumably exported). */
+  auth_configured: boolean
+  /** Probe/connect timeout in seconds. */
+  timeout_seconds: number
+  /** For kind=='slot' upstreams: the slot this upstream fronts. */
+  slot_name?: string | null
+  /** Warmup hint — 'eager' | 'lazy' | …; opaque to the UI today. */
+  warmup_strategy?: string
+  /** Models the upstream has declared (post-resolve). */
+  advertise_models?: string[]
+  /** Cached model list, populated when the upstream has been probed. */
+  models?: string[]
+}
+
+export interface UpstreamTestResult {
+  ok: boolean
+  /** HTTP status returned by the probe, when one was reached. */
+  status?: number
+  /** Round-trip latency of the probe in milliseconds. */
+  latency_ms?: number
+  /** Number of models the probe saw on /v1/models. */
+  models_count?: number
+  /** Human-readable error string on failure. */
+  error?: string
+}
+
+const POLL_UPSTREAMS_MS = 15_000
+// /api/providers is just an alias of /api/upstreams filtered server-side,
+// so a single 15s poll backs both views. Sharing the cache keeps the
+// sidebar/runtime widgets from issuing a second request per tick.
+
+export function useProviders(): UseQueryResult<Upstream[]> {
+  return useQuery({
+    queryKey: ['providers'],
+    queryFn: async () => {
+      const body = await apiGet<unknown>(ENDPOINTS.providers)
+      return normalizeUpstreamList(body)
+    },
+    refetchInterval: POLL_UPSTREAMS_MS,
+  })
+}
+
+export function useUpstreams(): UseQueryResult<Upstream[]> {
+  return useQuery({
+    queryKey: ['upstreams'],
+    queryFn: async () => {
+      const body = await apiGet<unknown>(ENDPOINTS.upstreams)
+      return normalizeUpstreamList(body)
+    },
+    refetchInterval: POLL_UPSTREAMS_MS,
+  })
+}
+
+export function useUpstream(name: string | null | undefined): UseQueryResult<Upstream> {
+  return useQuery({
+    queryKey: ['upstreams', name],
+    queryFn: () => apiGet<Upstream>(ENDPOINTS.upstream(name as string)),
+    enabled: !!name,
+    refetchInterval: POLL_UPSTREAMS_MS,
+  })
+}
+
+/**
+ * POST /api/upstreams/{name}/test — probe reachability + auth.
+ * Returns the structured result envelope (`{ok, status?, latency_ms,
+ * models_count?, error?}`) on 2xx; throws `Hal0Error` on 404 / 5xx.
+ *
+ * The dashboard keeps per-row test state in local state (so previous
+ * results stay visible while a new probe is in flight), so this hook
+ * intentionally does NOT invalidate the upstreams query on success —
+ * the upstreams list shape is unchanged by a probe.
+ */
+export function useTestUpstream() {
+  return useMutation<UpstreamTestResult, Hal0Error, string>({
+    mutationFn: (name: string) =>
+      api<UpstreamTestResult>(ENDPOINTS.upstreamTest(name), {
+        method: 'POST',
+        raw: true,
+      }),
+  })
+}
+
+/**
+ * Coerce the upstream list payload into a typed array. The backend
+ * always returns a top-level JSON array, but tolerate a `{upstreams: [...]}`
+ * envelope so older / forked backends don't break the dashboard.
+ */
+function normalizeUpstreamList(body: unknown): Upstream[] {
+  if (Array.isArray(body)) return body as Upstream[]
+  if (body && typeof body === 'object') {
+    const b = body as { upstreams?: unknown; providers?: unknown }
+    if (Array.isArray(b.upstreams)) return b.upstreams as Upstream[]
+    if (Array.isArray(b.providers)) return b.providers as Upstream[]
+  }
+  return []
+}

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -15,6 +15,7 @@ import { useUpdateState } from '@/api/hooks/useUpdates'
 import { useSidebarAgentRollup } from '@/api/hooks/useAgents'
 import { useConfigUrls } from '@/api/hooks/useConfigUrls'
 import { useHardware } from '@/api/hooks/useHardware'
+import { useUpstreams } from '@/api/hooks/useConnections'
 
 const { useState: useStateC, useEffect: useEffectC } = React;
 
@@ -63,6 +64,8 @@ const Icons = {
   hardware:  <Icon><rect x="3" y="3" width="10" height="10" rx="1"/><rect x="5.5" y="5.5" width="5" height="5" rx="0.5"/><path d="M3 6h-1M3 10h-1M13 6h1M13 10h1M6 3v-1M10 3v-1M6 13v1M10 13v1"/></Icon>,
   backends:  <Icon><circle cx="4" cy="4" r="2"/><circle cx="12" cy="4" r="2"/><circle cx="4" cy="12" r="2"/><circle cx="12" cy="12" r="2"/><path d="M6 4h4M4 6v4M12 6v4M6 12h4"/></Icon>,
   logs:      <Icon><path d="M3 3h10M3 6h10M3 9h7M3 12h5"/></Icon>,
+  // issue #549 — two linked rings echo the "remote ↔ local" connection metaphor.
+  connections: <Icon><circle cx="6" cy="8" r="2.5"/><circle cx="11" cy="11" r="1.5" fill="currentColor" stroke="none"/><path d="M8 9.5l2 1M3.5 4.5h4M3.5 6.5h3"/></Icon>,
   agent:     <Icon><circle cx="8" cy="6" r="2.5"/><path d="M3 14c0-2.5 2.2-4.5 5-4.5s5 2 5 4.5"/><circle cx="13" cy="3" r="1.5"/></Icon>,
   settings:  <Icon><circle cx="8" cy="8" r="2"/><path d="M8 1v2M8 13v2M1 8h2M13 8h2M3 3l1.5 1.5M11.5 11.5L13 13M3 13l1.5-1.5M11.5 4.5L13 3"/></Icon>,
   bell:      <Icon d="M4 11h8c-1 0-1.5-0.5-1.5-2V6.5a2.5 2.5 0 0 0-5 0V9c0 1.5-0.5 2-1.5 2zM6.5 13a1.5 1.5 0 0 0 3 0"/>,
@@ -104,6 +107,7 @@ function TopBar({ route, hostUptime = "14d 02:11", onBell, onCmdK, onMenu, menuO
     logs:      ["Runtime", "Logs"],
     agent:     ["Tools",  "Agent"],
     settings:  ["Configure", "Settings"],
+    connections: ["Network", "Connections"],
   };
   const [eyebrow, title] = labels[route] || ["", ""];
   return (
@@ -154,8 +158,12 @@ function TopBar({ route, hostUptime = "14d 02:11", onBell, onCmdK, onMenu, menuO
 function useNavItems() {
   const slotsQuery  = useSlots();
   const modelsQuery = useModels();
+  const upstreamsQuery = useUpstreams();
   const slotCount   = slotsQuery.data?.length  ?? 0;
   const modelCount  = modelsQuery.data?.length ?? 0;
+  // #549 — badge the Connections nav with the total upstream count so
+  // the operator can see "I have N routing targets" at a glance.
+  const upCount     = upstreamsQuery.data?.length ?? 0;
   // 0.4 gate: the Agent route is reduced to the Memory tab, so when the
   // memory subsystem is disabled (HAL0_MEMORY_ENABLED!=1) there is nothing
   // to show — drop the nav item entirely. Driven by /api/status so the UI
@@ -172,6 +180,11 @@ function useNavItems() {
     // conceptually but kept as a sibling so the URL is discoverable.
     { id: "mcp",       label: "MCP",       icon: Icons.agent },
     { id: "settings",  label: "Settings",  icon: Icons.settings },
+    // Issue #549 — Connections surface (read-only providers/upstreams rollup
+    // with per-row reachability test). Sits between Settings and the end so
+    // the operator-configure feel reads "settings, then look at your
+    // wiring".
+    { id: "connections", label: "Connections", icon: Icons.connections, cnt: upCount },
   ];
 }
 

--- a/ui/src/dash/connections.jsx
+++ b/ui/src/dash/connections.jsx
@@ -17,7 +17,7 @@
 //     new probe is in flight, so the operator can sweep through a
 //     stack and still see the last-known good.
 
-import { useProviders, useUpstreams, useTestUpstream, type Upstream } from '@/api/hooks/useConnections'
+import { useProviders, useUpstreams, useTestUpstream } from '@/api/hooks/useConnections'
 
 const { useState: useStateC, useMemo: useMemoC } = React;
 

--- a/ui/src/dash/connections.jsx
+++ b/ui/src/dash/connections.jsx
@@ -1,0 +1,299 @@
+// hal0 dashboard — Connections view (issue #549).
+//
+// Surface for the providers / upstreams registry that already lives at
+// /api/providers + /api/upstreams. Three sections, all read-only
+// (writes are TOML-only in v0.4):
+//
+//   • Providers  — remote upstreams (kind != "slot"), grouped by auth
+//     posture. Source: GET /api/providers.
+//   • Upstreams  — every routing target (slot fronts + remote). Source:
+//     GET /api/upstreams. The "effective mapping" column renders
+//     `<name> → <slot_name|kind:url>` so the operator can see which
+//     virtual name fronts which slot at a glance — the "useful + unique"
+//     read-out the issue calls out.
+//   • Test button — per row, calls useTestUpstream() (POST
+//     /api/upstreams/{name}/test) and shows pass/fail + latency/error
+//     inline. Per-row state keeps previous results visible while a
+//     new probe is in flight, so the operator can sweep through a
+//     stack and still see the last-known good.
+
+import { useProviders, useUpstreams, useTestUpstream, type Upstream } from '@/api/hooks/useConnections'
+
+const { useState: useStateC, useMemo: useMemoC } = React;
+
+function ConnectionsView() {
+  const providersQuery = useProviders();
+  const upstreamsQuery = useUpstreams();
+  const providers = providersQuery.data ?? [];
+  const upstreams = upstreamsQuery.data ?? [];
+
+  // Per-row test state. Keyed by upstream name so the result survives
+  // re-renders triggered by the list query's own poll. Storing a
+  // {state:'idle'|'pending'|'ok'|'err', latency, error, status} object
+  // means the previous pass/fail stays visible behind a new probe's
+  // spinner — important when the operator sweeps through a stack of
+  // 6-8 upstreams and wants to compare the roll.
+  const [results, setResults] = useStateC({});
+  const [pendingName, setPendingName] = useStateC(null);
+  const testMut = useTestUpstream();
+
+  const onTest = async (name) => {
+    setPendingName(name);
+    setResults((r) => ({ ...r, [name]: { state: 'pending' } }));
+    try {
+      const res = await testMut.mutateAsync(name);
+      setResults((r) => ({
+        ...r,
+        [name]: {
+          state: res.ok ? 'ok' : 'err',
+          latency: res.latency_ms,
+          models: res.models_count,
+          status: res.status,
+          error: res.error,
+        },
+      }));
+    } catch (e) {
+      setResults((r) => ({
+        ...r,
+        [name]: {
+          state: 'err',
+          error: e?.message || 'test failed',
+          status: e?.status,
+        },
+      }));
+    } finally {
+      setPendingName(null);
+    }
+  };
+
+  // Group providers by auth posture so the operator can spot unkeyed
+  // remotes at a glance. No enforced order — sort by name within each.
+  const providersByAuth = useMemoC(() => {
+    const groups = { configured: [], unconfigured: [] };
+    for (const p of providers) {
+      (p.auth_configured ? groups.configured : groups.unconfigured).push(p);
+    }
+    groups.configured.sort((a, b) => a.name.localeCompare(b.name));
+    groups.unconfigured.sort((a, b) => a.name.localeCompare(b.name));
+    return groups;
+  }, [providers]);
+
+  const slotCount = upstreams.filter((u) => u.kind === 'slot').length;
+  const remoteCount = upstreams.filter((u) => u.kind !== 'slot').length;
+
+  return (
+    <div className="view">
+      <div className="vh">
+        <span className="vh-eye mono">Network</span>
+        <h1>Connections</h1>
+        <span className="vh-spacer" />
+        <span className="mono" style={{fontSize: 11, color: "var(--fg-4)"}}>
+          {remoteCount} provider{remoteCount === 1 ? '' : 's'} · {slotCount} slot upstream{slotCount === 1 ? '' : 's'}
+        </span>
+      </div>
+
+      <p className="mono" style={{fontSize: 11, color: "var(--fg-4)", margin: "0 0 18px", maxWidth: 720, lineHeight: 1.55}}>
+        Effective routing targets. <b>Slot upstreams</b> front a lifecycle-managed slot;{' '}
+        <b>remote providers</b> call out to a third-party API. Author by editing{' '}
+        <code>/etc/hal0/upstreams.toml</code> + <code>hal0 config reload</code> — this view is read-only.
+      </p>
+
+      <ConnectionsSection
+        title="Providers (remote)"
+        rows={providers}
+        grouped={providersByAuth}
+        results={results}
+        pendingName={pendingName}
+        onTest={onTest}
+        showGroupHeaders
+        isLoading={providersQuery.isPending}
+        isError={providersQuery.isError}
+        errorMessage={providersQuery.error?.message}
+        emptyMessage="No remote providers configured. Add one via /etc/hal0/upstreams.toml."
+      />
+
+      <ConnectionsSection
+        title="All upstreams"
+        rows={upstreams}
+        results={results}
+        pendingName={pendingName}
+        onTest={onTest}
+        isLoading={upstreamsQuery.isPending}
+        isError={upstreamsQuery.isError}
+        errorMessage={upstreamsQuery.error?.message}
+        emptyMessage="No upstreams registered. The registry is normally primed on /api/health."
+      />
+    </div>
+  );
+}
+
+// Section shell — card-style container with a header, optional group
+// sub-headers, and the row grid. Renders loading/error/empty states.
+function ConnectionsSection({
+  title,
+  rows,
+  grouped,
+  results,
+  pendingName,
+  onTest,
+  showGroupHeaders = false,
+  isLoading = false,
+  isError = false,
+  errorMessage = '',
+  emptyMessage = 'Nothing here yet.',
+}) {
+  const renderRows = (rs) => rs.map((u) => (
+    <ConnectionRow
+      key={u.name}
+      upstream={u}
+      result={results[u.name]}
+      pending={pendingName === u.name}
+      onTest={() => onTest(u.name)}
+    />
+  ));
+
+  return (
+    <section className="card" style={{marginBottom: 18}}>
+      <div className="card-h">
+        <span className="card-h-eye mono">{title}</span>
+        <span className="card-h-ct mono">{rows.length}</span>
+      </div>
+      <div className="cn-list-h mono">
+        <span className="cn-c-name">Name</span>
+        <span className="cn-c-kind">Kind</span>
+        <span className="cn-c-target">Effective mapping</span>
+        <span className="cn-c-auth">Auth</span>
+        <span className="cn-c-models">Models</span>
+        <span className="cn-c-test">Test</span>
+      </div>
+      {isLoading && (
+        <div className="cn-empty mono">Loading…</div>
+      )}
+      {isError && (
+        <div className="cn-empty err mono">Failed to load — {errorMessage || "unreachable"}</div>
+      )}
+      {!isLoading && !isError && rows.length === 0 && (
+        <div className="cn-empty mono">{emptyMessage}</div>
+      )}
+      {!isLoading && !isError && showGroupHeaders && grouped && (
+        <>
+          {grouped.configured.length > 0 && (
+            <>
+              <div className="cn-section-label">auth configured · {grouped.configured.length}</div>
+              {renderRows(grouped.configured)}
+            </>
+          )}
+          {grouped.unconfigured.length > 0 && (
+            <>
+              <div className="cn-section-label cn-section-warn">auth missing · {grouped.unconfigured.length}</div>
+              {renderRows(grouped.unconfigured)}
+            </>
+          )}
+        </>
+      )}
+      {!isLoading && !isError && !showGroupHeaders && rows.length > 0 && renderRows(rows)}
+    </section>
+  );
+}
+
+// A single upstream row. The "effective mapping" cell is the unique
+// read-out: <name> → <slot_name> for slot fronts, <name> → <url> for
+// remotes, and we tag remote rows with the auth style so the operator
+// can tell bearer from x-api-key at a glance.
+function ConnectionRow({ upstream, result, pending, onTest }) {
+  const u = upstream;
+  const target = u.kind === 'slot'
+    ? (u.slot_name ? `→ slot ${u.slot_name}` : '→ (unbound slot)')
+    : `→ ${u.url || '(no url)'}`;
+  const modelCount = Array.isArray(u.models) ? u.models.length : 0;
+  const declaredCount = Array.isArray(u.advertise_models) ? u.advertise_models.length : 0;
+  // Show the cached model count when the registry has probed the
+  // upstream at least once; otherwise fall back to the declared list.
+  const mcount = modelCount > 0 ? modelCount : declaredCount;
+  const mlabel = mcount > 0 ? `${mcount}` : '—';
+  const authClass = u.auth_configured ? 'chip ok' : 'chip warn';
+  const authLabel = u.auth_configured
+    ? (u.auth_style || 'configured')
+    : (u.auth_value_env ? `needs ${u.auth_value_env}` : 'none');
+
+  return (
+    <div className="cn-row">
+      <span className="cn-c-name">
+        <span className={"cn-dot " + (u.kind === 'slot' ? 'ready' : 'ok')} />
+        <span className="mono">{u.name}</span>
+      </span>
+      <span className="cn-c-kind">
+        <span className="chip">{u.kind}</span>
+      </span>
+      <span className="cn-c-target mono">
+        <span className="cn-target">{target}</span>
+        {u.warmup_strategy && (
+          <span className="cn-sub mono">warmup: {u.warmup_strategy}</span>
+        )}
+      </span>
+      <span className="cn-c-auth">
+        <span className={authClass} title={u.auth_value_env || ''}>
+          {authLabel}
+        </span>
+      </span>
+      <span className="cn-c-models mono">
+        <b>{mlabel}</b>
+        {mcount > 0 && modelCount > 0 && <span className="cn-sub mono">cached</span>}
+        {mcount > 0 && modelCount === 0 && <span className="cn-sub mono">declared</span>}
+      </span>
+      <span className="cn-c-test">
+        <TestCell result={result} pending={pending} onTest={onTest} name={u.name} />
+      </span>
+    </div>
+  );
+}
+
+// Test cell — button + inline result. States:
+//   idle     — button only
+//   pending  — spinner + "testing…", button disabled
+//   ok       — green latency + small status badge, "test again" button
+//   err      — red error + status, "retry" button
+function TestCell({ result, pending, onTest, name }) {
+  if (pending) {
+    return (
+      <>
+        <span className="cn-test-pending mono">testing…</span>
+        <button className="btn ghost sm" disabled>{Icons.warn} Test</button>
+      </>
+    );
+  }
+  if (result?.state === 'ok') {
+    return (
+      <>
+        <span className="cn-test-ok mono">
+          <span className="cn-dot ok" />{result.latency != null ? `${result.latency} ms` : 'ok'}
+          {result.models != null && <span className="cn-sub mono"> · {result.models} model{result.models === 1 ? '' : 's'}</span>}
+        </span>
+        <button className="btn ghost sm" onClick={onTest} aria-label={`Re-test ${name}`}>↻</button>
+      </>
+    );
+  }
+  if (result?.state === 'err') {
+    return (
+      <>
+        <span className="cn-test-err mono" title={result.error || ''}>
+          <span className="cn-dot warn" />{result.error ? truncate(result.error, 28) : 'failed'}
+          {result.status != null && <span className="cn-sub mono"> · {result.status}</span>}
+        </span>
+        <button className="btn ghost sm" onClick={onTest} aria-label={`Retry ${name}`}>↻</button>
+      </>
+    );
+  }
+  return (
+    <button className="btn ghost sm" onClick={onTest} aria-label={`Test ${name}`}>
+      {Icons.warn} Test
+    </button>
+  );
+}
+
+function truncate(s, n) {
+  if (!s) return ''
+  return s.length > n ? s.slice(0, n - 1) + '…' : s
+}
+
+Object.assign(window, { ConnectionsView });

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -13,7 +13,7 @@ const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
 // We also accept "agents/mcp" as an alias so the canonical URL path stays
 // readable (`/agents/mcp` from the spec). Any unknown head falls back to
 // the dashboard.
-const ROUTES = ["dashboard", "firstrun", "slots", "models", "logs", "agent", "settings", "mcp"];
+const ROUTES = ["dashboard", "firstrun", "slots", "models", "logs", "agent", "settings", "mcp", "connections"];
 function parseRoute() {
   const raw = (window.location.hash || "#dashboard").replace(/^#/, "");
   const [path, qs] = raw.split("?");
@@ -182,6 +182,7 @@ function App() {
         );
       case "mcp":      return <McpView />;
       case "settings": return <SettingsView />;
+      case "connections": return <ConnectionsView />;
       default:         return <div className="view">Not found.</div>;
     }
   };

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -46,6 +46,8 @@ import './dash/slots.jsx'
 import './dash/slot-modals.jsx'
 import './dash/models.jsx'
 import './dash/model-modals.jsx'
+// issue #549 — Connections surface: providers + upstreams list + per-row test.
+import './dash/connections.jsx'
 import './dash/settings.jsx'
 
 import './dash/extras.jsx'


### PR DESCRIPTION
Closes #549

Caveman worker. New ConnectionsView (route + nav) listing providers + upstreams with effective mapping and a per-upstream connectivity Test button, via new useConnections hooks over the existing /api/providers + /api/upstreams + /upstreams/{name}/test routes.