### PR TITLE
feat(install): FHS prod layout + updater re-pip so `hal0 update` actually takes effect (#495)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -164,20 +164,33 @@ PY="${HAL0_PYTHON:-python3}"
 # the comment on TLS posture near the flag parser.
 API_BIND_HOST="0.0.0.0"
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 if [[ "${DEV_MODE}" -eq 1 ]]; then
+    # Dev: editable checkout, everything under one prefix. The updater
+    # refuses apply() in this mode (re-run `git pull && pip install -e .`).
     PREFIX="${HAL0_PREFIX:-${PWD}/.hal0ai}"
     ETC_DIR="${PREFIX}/etc/hal0"
     VAR_DIR="${PREFIX}/var/lib/hal0"
     UNIT_DIR="${PREFIX}/etc/systemd/system"
+    VENV_DIR="${PREFIX}/.venv"
+    CURRENT_LINK=""
     info "Dev mode — all paths under ${PREFIX}"
 else
-    PREFIX="${HAL0_PREFIX:-/opt/hal0}"
+    # Prod FHS (#495): code lives in a versioned dir with a `current`
+    # symlink; the venv is shared at ${FHS_ROOT}/venv so it survives
+    # `hal0 update`'s atomic symlink swaps (the updater re-pips `current`
+    # into this venv on apply).
+    HAL0_FHS_ROOT="${HAL0_PREFIX:-/usr/lib/hal0}"
+    VERSION="$(grep -m1 '^version' "${REPO_ROOT}/pyproject.toml" 2>/dev/null | sed -E 's/.*"([^"]+)".*/\1/')"
+    [[ -n "${VERSION}" ]] || VERSION="0.0.0"
+    PREFIX="${HAL0_FHS_ROOT}/hal0-${VERSION}"
+    CURRENT_LINK="${HAL0_FHS_ROOT}/current"
     ETC_DIR="/etc/hal0"
     VAR_DIR="/var/lib/hal0"
     UNIT_DIR="/etc/systemd/system"
+    VENV_DIR="${HAL0_FHS_ROOT}/venv"
+    info "FHS layout — code ${PREFIX}, current → ${CURRENT_LINK}, venv ${VENV_DIR}"
 fi
-VENV_DIR="${PREFIX}/.venv"
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # ── Release verification gate ──────────────────────────────────────────────
 # Refuse to run as root against an UNVERIFIED release tree. The signed
@@ -206,6 +219,16 @@ if [[ "${DEV_MODE}" -eq 0 \
   Or, if you trust THIS source and accept the risk:
       HAL0_INSTALL_SKIP_VERIFY=1 sudo bash installer/install.sh"
     fi
+fi
+
+# Heads-up if a legacy editable /opt/hal0 install is present (pre-#495).
+# This run installs the FHS layout under ${HAL0_FHS_ROOT} and rewrites the
+# systemd units to the shared venv, so the old tree is orphaned. We do NOT
+# auto-delete it (it may be a CT-105-style working checkout) — uninstall.sh
+# cleans /opt/hal0 if the operator later wants it gone.
+if [[ "${DEV_MODE}" -eq 0 && -e "/opt/hal0/.venv" && "${HAL0_FHS_ROOT}" != "/opt/hal0" ]]; then
+    warn "legacy install at /opt/hal0 detected — superseded by the FHS layout at ${HAL0_FHS_ROOT}"
+    warn "  the old tree is now orphaned; remove it with 'sudo bash installer/uninstall.sh' or 'sudo rm -rf /opt/hal0' once you've confirmed the new install works"
 fi
 
 # Resolve pull destination: explicit flag / env wins, then an interactive
@@ -335,12 +358,14 @@ mkdir -p \
     "${UNIT_DIR}"
 info "directories under ${PREFIX}, ${ETC_DIR}, ${VAR_DIR} (pulls → ${MODELS_DIR})"
 
-# Production install ships the source tree into ${PREFIX} so `pip install
-# --editable` ends up pointing at a persistent location, not the temp dir
-# the bootstrap unpacks into (which gets cleaned on exit — and on a
-# tmpfs /tmp, doesn't survive a reboot). Dev installs skip this: their
-# REPO_ROOT is the operator's git checkout and we want pip's editable
-# link aimed there so source edits flow without a reinstall.
+# Production (FHS, #495) ships the source tree into the versioned dir
+# ${PREFIX} (=${FHS_ROOT}/hal0-<version>) and points `current` at it, so
+# `hal0 update` can atomically swap `current` to a new versioned tree.
+# The shared venv at ${FHS_ROOT}/venv pip-installs hal0 (non-editable)
+# from this tree; the updater re-pips the swapped-in tree on apply. Dev
+# installs skip the copy: REPO_ROOT is the operator's git checkout and we
+# want pip's editable link aimed there so source edits flow without a
+# reinstall.
 if [[ "${DEV_MODE}" -eq 0 && "${REPO_ROOT}" != "${PREFIX}" ]]; then
     if command -v rsync >/dev/null 2>&1; then
         ui_spinner_run "Copying source to ${PREFIX}" \
@@ -363,6 +388,16 @@ if [[ "${DEV_MODE}" -eq 0 && "${REPO_ROOT}" != "${PREFIX}" ]]; then
         info "copied source → ${PREFIX} (tar fallback)"
     fi
     REPO_ROOT="${PREFIX}"
+fi
+
+# Point the `current` symlink at this release's versioned tree (prod only).
+# Atomic swap so a concurrent reader never sees a missing link: write a
+# temp symlink then rename over the old one. This is the same target the
+# updater swaps on `hal0 update`.
+if [[ "${DEV_MODE}" -eq 0 && -n "${CURRENT_LINK}" ]]; then
+    ln -sfn "${PREFIX}" "${CURRENT_LINK}.tmp.$$"
+    mv -T "${CURRENT_LINK}.tmp.$$" "${CURRENT_LINK}"
+    info "current → ${PREFIX}"
 fi
 
 # Seed hal0.toml's [models].pull_root when the operator picked a non-default
@@ -419,13 +454,21 @@ HAL0_BIN="${VENV_DIR}/bin/hal0"
 # installs it alongside `hal0` in the venv.
 HAL0_AGENT_BIN="${VENV_DIR}/bin/hal0-agent"
 
-# Refresh pip + install hal0 in editable mode pointing at this checkout.
+# Refresh pip, then install hal0. Prod (FHS) installs NON-editable from the
+# versioned tree so the venv owns its own copy of the code and `hal0 update`
+# can re-pip a swapped-in tree (#495). Dev installs editable so the
+# operator's source edits flow without a reinstall.
 # ui_spinner_run drops the >/dev/null — the spinner shows the live tail
 # of pip's output, and on failure replays the last 50 lines on stderr.
 ui_spinner_run "Upgrading pip / setuptools / wheel" \
     "${PIP}" install --upgrade pip setuptools wheel
-ui_spinner_run "Installing hal0 from ${REPO_ROOT}" \
-    "${PIP}" install -e "${REPO_ROOT}"
+if [[ "${DEV_MODE}" -eq 1 ]]; then
+    ui_spinner_run "Installing hal0 (editable) from ${REPO_ROOT}" \
+        "${PIP}" install -e "${REPO_ROOT}"
+else
+    ui_spinner_run "Installing hal0 from ${REPO_ROOT}" \
+        "${PIP}" install "${REPO_ROOT}"
+fi
 
 if [[ ! -x "${HAL0_BIN}" ]]; then
     die "hal0 binary not produced at ${HAL0_BIN} — check pip install output"
@@ -515,11 +558,23 @@ fi
 chmod 0755 "${ETC_DIR}" 2>/dev/null || true
 chmod 0644 "${HAL0_TOML}" 2>/dev/null || true
 
+# Pin the dashboard's built assets. Prod installs hal0 NON-editable, so the
+# package's __file__ lives in the venv site-packages and the walk-up that
+# finds ui/dist in a checkout no longer reaches it — point HAL0_UI_DIST at
+# the `current` tree's ui/dist (follows atomic update swaps). Dev points at
+# the editable checkout's build.
+if [[ -n "${CURRENT_LINK}" ]]; then
+    HAL0_UI_DIST_VAL="${CURRENT_LINK}/ui/dist"
+else
+    HAL0_UI_DIST_VAL="${UI_DIST}"
+fi
+
 API_ENV="${ETC_DIR}/api.env"
 if [[ ! -f "${API_ENV}" ]]; then
     cat > "${API_ENV}" <<EOF
 HAL0_PORT=${HAL0_PORT}
 HAL0_LOG_LEVEL=info
+HAL0_UI_DIST=${HAL0_UI_DIST_VAL}
 # Memory subsystem (Cognee engine + /mcp/memory + the Agent → Memory tab)
 # is deferred in this release and ships disabled by default. Uncomment to
 # reintroduce it — no other change needed; the dashboard Agent nav returns
@@ -569,6 +624,9 @@ fi
 
 ui_step "Systemd units"
 
+# WorkingDirectory follows `current` in prod so a `hal0 update` symlink swap
+# moves it to the new tree without rewriting the unit; dev uses the checkout.
+API_WORKDIR="${CURRENT_LINK:-${PREFIX}}"
 API_UNIT="${UNIT_DIR}/hal0-api.service"
 cat > "${API_UNIT}" <<EOF
 [Unit]
@@ -580,7 +638,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 User=${HAL0_USER}
-WorkingDirectory=${PREFIX}
+WorkingDirectory=${API_WORKDIR}
 EnvironmentFile=${API_ENV}
 ExecStart=${HAL0_BIN} serve --host ${API_BIND_HOST} --port \${HAL0_PORT}
 Restart=on-failure

--- a/scripts/fresh-test-ct.sh
+++ b/scripts/fresh-test-ct.sh
@@ -113,7 +113,10 @@ SSH "hal0 status && hal0 --version && for i in \$(seq 1 15); do curl -fsS -m 5 h
 
 # ── uninstall ────────────────────────────────────────────────────────────────
 log "uninstall"
+# `hal0 uninstall` resolves uninstall.sh for either layout (#495). Fall back to
+# running it directly — FHS prod path first, then the legacy editable path.
 if SSH "sudo hal0 uninstall --force" >&2 2>&1 \
+   || SSH "sudo bash /usr/lib/hal0/current/installer/uninstall.sh --force" >&2 2>&1 \
    || SSH "sudo bash /opt/hal0/installer/uninstall.sh --force" >&2 2>&1; then
   UNINSTALL_OK=true
 fi

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -222,13 +222,23 @@ def uninstall(
     """
     import shutil
 
-    # Editable install: src/hal0/__init__.py -> repo root is parents[2].
-    repo_root = Path(hal0.__file__).resolve().parents[2]
-    script = repo_root / "installer" / "uninstall.sh"
-    if not script.is_file():
+    from hal0.config import paths
+
+    # The uninstaller ships in the source tree, which lives in different places
+    # depending on install layout (#495):
+    #   - editable/dev:  src/hal0/__init__.py -> repo root is parents[2]
+    #   - FHS prod:      installed non-editable, so __file__ is in the venv
+    #     site-packages; the source tree is under the `current` symlink.
+    candidates = [
+        Path(hal0.__file__).resolve().parents[2] / "installer" / "uninstall.sh",
+        paths.usr_lib() / "installer" / "uninstall.sh",
+    ]
+    script = next((c for c in candidates if c.is_file()), None)
+    if script is None:
         die(
-            f"uninstall.sh not found at {script}. "
-            "This hal0 install looks packaged differently — run the script directly."
+            "uninstall.sh not found (looked in "
+            + ", ".join(str(c) for c in candidates)
+            + "). This hal0 install looks packaged differently — run the script directly."
         )
 
     if not shutil.which("bash"):

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -12,10 +12,15 @@ Updater handles the full update lifecycle:
      when ``min_data_version`` advances the schema.
   7. Atomically swap the ``/usr/lib/hal0/current`` symlink using the
      POSIX ``symlink(tmp) + os.replace(tmp, current)`` pattern.
-  8. Record the prior symlink target in ``/var/lib/hal0/hal0.previous`` for
+  8. Re-pip the swapped-in tree into the running venv (non-editable prod
+     only, #495) — the venv imports hal0 from its own site-packages, so the
+     symlink swap alone changes nothing until the code is reinstalled. A
+     failed re-pip rolls the symlink back so ``current`` and the venv stay
+     consistent. Skipped for editable/dev installs.
+  9. Record the prior symlink target in ``/var/lib/hal0/hal0.previous`` for
      rollback. Slot units are NOT touched. The ``hal0-api.service`` restart
      is the route layer's job (``routes/updater._run_apply_job``), not this
-     function - apply() only swaps the tree.
+     function — apply() swaps the tree and refreshes the venv.
 
 Rollback reads ``/var/lib/hal0/hal0.previous``, atomic-swaps the
 ``current`` symlink back, and warns (without erroring) if the
@@ -37,6 +42,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tarfile
 import tempfile
 import time
@@ -772,6 +778,55 @@ def _current_symlink() -> Path:
     return _usr_lib_root() / "current"
 
 
+def _is_editable_install() -> bool:
+    """True when hal0 runs from an editable/dev checkout, not the FHS venv.
+
+    FHS/prod (#495): hal0 is pip-installed into the venv site-packages (under
+    ``sys.prefix``). Editable/dev: ``hal0.__file__`` resolves to a source tree
+    outside the venv (e.g. ``/opt/hal0/src/hal0``). apply()'s re-pip step is a
+    no-op-and-skip in editable mode — there is no FHS venv to refresh.
+    """
+    import hal0
+
+    try:
+        Path(hal0.__file__).resolve().relative_to(Path(sys.prefix).resolve())
+        return False
+    except ValueError:
+        return True
+
+
+def _reinstall_into_venv(install_dir: Path, *, job_id: str | None = None) -> None:
+    """``pip install --no-deps --force-reinstall <install_dir>`` into the running venv.
+
+    apply() swaps the ``current`` symlink but the venv imports hal0 from its own
+    site-packages, so the swap alone changes nothing until the code is
+    reinstalled. ``--no-deps`` keeps it fast and offline-safe (deps were
+    resolved at install time); a release that changes deps needs a full
+    reinstall. Raises ``UpdateError`` on a non-zero pip exit.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--no-deps",
+        "--force-reinstall",
+        str(install_dir),
+    ]
+    log.info("updater.reinstall_start", job_id=job_id, install_dir=str(install_dir))
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise UpdateError(
+            f"pip reinstall of {install_dir} failed (rc={proc.returncode})",
+            details={
+                "install_dir": str(install_dir),
+                "returncode": proc.returncode,
+                "stderr": proc.stderr[-2000:],
+            },
+        )
+    log.info("updater.reinstall_ok", job_id=job_id, install_dir=str(install_dir))
+
+
 def _previous_record() -> Path:
     """Return ``/var/lib/hal0/hal0.previous`` — the rollback breadcrumb."""
     return paths.var_lib() / "hal0.previous"
@@ -1013,6 +1068,25 @@ class Updater:
                 f"atomic symlink swap failed: {exc}",
                 details={"link": str(link), "target": str(install_dir), "error": str(exc)},
             ) from exc
+
+        # Step 8b: re-install the swapped-in code into the running venv.
+        # apply() only swaps the `current` symlink; the venv imports hal0
+        # from its own site-packages (a normal, non-editable install), so a
+        # symlink swap alone would NOT change the running version. Re-pip the
+        # freshly-swapped tree so the next hal0-api restart actually runs the
+        # new code (#495). Editable/dev installs are exempt — there is no FHS
+        # venv to refresh and apply() is unsupported there.
+        if not _is_editable_install():
+            try:
+                await asyncio.to_thread(_reinstall_into_venv, install_dir, job_id=self.job_id)
+            except UpdateError:
+                # Re-pip failed: roll the symlink back (when there is a prior
+                # target) so `current` and the venv's installed code stay
+                # consistent — both = prior.
+                if prior is not None:
+                    with contextlib.suppress(OSError):
+                        _atomic_symlink_swap(prior, link)
+                raise
 
         if prior is not None:
             _write_atomic_text(_previous_record(), str(prior))

--- a/tests/cli/test_uninstall.py
+++ b/tests/cli/test_uninstall.py
@@ -132,14 +132,46 @@ def test_uninstall_non_tty_with_hal0_force_env(monkeypatch: pytest.MonkeyPatch) 
     assert captured["argv"][1].endswith("/installer/uninstall.sh")
 
 
+def test_uninstall_resolves_fhs_path_when_not_editable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, captured_exec: dict[str, Any]
+) -> None:
+    """Non-editable FHS install (#495): __file__ is in the venv site-packages
+    (no installer/ next to it), so the wrapper falls back to the source tree
+    under the `current` symlink (paths.usr_lib())."""
+    import hal0
+    from hal0.config import paths
+
+    # site-packages layout — parents[2]/installer/uninstall.sh does NOT exist.
+    fake_module = (
+        tmp_path / "venv" / "lib" / "python3.12" / "site-packages" / "hal0" / "__init__.py"
+    )
+    fake_module.parent.mkdir(parents=True)
+    fake_module.write_text("")
+    monkeypatch.setattr(hal0, "__file__", str(fake_module))
+
+    # A real uninstall.sh lives under the FHS `current` tree.
+    fhs_current = tmp_path / "usr-lib" / "current"
+    (fhs_current / "installer").mkdir(parents=True)
+    (fhs_current / "installer" / "uninstall.sh").write_text("#!/usr/bin/env bash\n")
+    monkeypatch.setattr(paths, "usr_lib", lambda: fhs_current)
+
+    with pytest.raises(typer.Exit) as exc:
+        uninstall(keep_data=False, force=True, dev=False)
+    assert (exc.value.exit_code or 0) == 0
+    assert captured_exec["argv"][1] == str(fhs_current / "installer" / "uninstall.sh")
+
+
 def test_uninstall_missing_script_dies(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """If uninstall.sh isn't where we expect, fail loudly instead of running."""
     import hal0
+    from hal0.config import paths
 
     fake_module = tmp_path / "src" / "hal0" / "__init__.py"
     fake_module.parent.mkdir(parents=True)
     fake_module.write_text("")
     monkeypatch.setattr(hal0, "__file__", str(fake_module))
+    # Neither layout has the script: point the FHS candidate at an empty tree.
+    monkeypatch.setattr(paths, "usr_lib", lambda: tmp_path / "nonexistent" / "current")
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
 
     called: dict[str, Any] = {}

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -440,6 +440,86 @@ def test_apply_records_previous_for_rollback(
     assert Path(os.readlink(_current_symlink())).name == "hal0-0.0.2"
 
 
+# ── apply re-pip into venv (#495) ────────────────────────────────────────────────
+
+
+def test_apply_repips_swapped_tree_when_not_editable(
+    synthetic_release: dict[str, Any], cosign_skip: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Prod (non-editable) apply re-pips the swapped-in tree into the venv."""
+    calls: list[Path] = []
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
+    monkeypatch.setattr(
+        "hal0.updater.updater._reinstall_into_venv",
+        lambda install_dir, *, job_id=None: calls.append(install_dir),
+    )
+
+    res = asyncio.run(Updater().apply())
+
+    assert res["version"] == "0.0.1"
+    assert calls == [_versioned_install_dir("0.0.1")]
+    # Re-pip succeeded → the swap stands.
+    assert Path(os.readlink(_current_symlink())).name == "hal0-0.0.1"
+
+
+def test_apply_skips_repip_in_editable_mode(
+    synthetic_release: dict[str, Any], cosign_skip: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Editable/dev installs never re-pip — there is no FHS venv to refresh."""
+    calls: list[Path] = []
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: True)
+    monkeypatch.setattr(
+        "hal0.updater.updater._reinstall_into_venv",
+        lambda install_dir, *, job_id=None: calls.append(install_dir),
+    )
+
+    asyncio.run(Updater().apply())
+
+    assert calls == []
+
+
+def test_apply_repip_failure_rolls_back_symlink(
+    synthetic_release: dict[str, Any],
+    cosign_skip: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed re-pip rolls `current` back to the prior tree (consistency)."""
+    # First apply (editable skip) lands current → 0.0.1.
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: True)
+    asyncio.run(Updater().apply())
+    assert Path(os.readlink(_current_symlink())).name == "hal0-0.0.1"
+
+    # Build v0.0.2 and rewire the manifest.
+    artifacts = tmp_path / "v2"
+    artifacts.mkdir()
+    tarball2 = _build_release_tarball(tmp=artifacts, version="0.0.2")
+    sig2 = artifacts / "hal0-0.0.2.tar.gz.sig"
+    sig2.write_bytes(b"sig")
+    cert2 = artifacts / "hal0-0.0.2.tar.gz.crt"
+    cert2.write_bytes(b"cert")
+    _write_release_manifest(
+        manifest_path=Path(os.environ["HAL0_RELEASES_URL"]),
+        tarball=tarball2,
+        sig=sig2,
+        cert=cert2,
+        version="0.0.2",
+    )
+
+    # Now force non-editable mode with a re-pip that blows up.
+    def _boom(install_dir: Path, *, job_id: str | None = None) -> None:
+        raise UpdateError("pip reinstall failed", details={})
+
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
+    monkeypatch.setattr("hal0.updater.updater._reinstall_into_venv", _boom)
+
+    with pytest.raises(UpdateError):
+        asyncio.run(Updater().apply())
+
+    # Rolled back: current still points at the prior (0.0.1) tree.
+    assert Path(os.readlink(_current_symlink())).name == "hal0-0.0.1"
+
+
 # ── apply error paths ──────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Parent
Closes #495 (corrects #406). Verified via the #407 install-smoke harness.

## What this does
Production installs now use the **FHS layout the updater already targeted**, and `hal0 update` actually changes the running version instead of being a silent no-op.

```
/usr/lib/hal0/hal0-<version>/   versioned code tree (full source incl. installer/, ui/)
/usr/lib/hal0/current -> ...    atomic-swap symlink
/usr/lib/hal0/venv             shared venv (survives update swaps)
```

### install.sh (prod path)
- copy source into the versioned dir, point `current` at it (atomic temp-symlink + `mv -T`)
- install hal0 **non-editable** into the shared venv (dev mode stays editable — protects the CT-105 `/opt/hal0` checkout)
- set `HAL0_UI_DIST=<current>/ui/dist` in `api.env` — the non-editable install moves `__file__` into site-packages, which breaks the dashboard's `ui/dist` walk-up resolution
- `WorkingDirectory` follows `current` so an update needs no unit rewrite
- warn (don't delete) when a legacy editable `/opt/hal0` install is present

### updater.apply()
- after the atomic symlink swap, **re-pip the swapped-in tree into the running venv** (`pip install --no-deps --force-reinstall <dir>`). The venv imports hal0 from its own site-packages, so the swap alone changed nothing — this is the fix for "`hal0 update` is a no-op on real installs."
- a failed re-pip rolls the symlink back so `current` and the venv stay consistent; editable/dev installs skip the step entirely

### hal0 uninstall (caught by the harness)
- resolved `uninstall.sh` via `parents[2]` of `hal0.__file__`, valid only for editable installs. Now tries the editable repo root **and** `<current>/installer/uninstall.sh` via `paths.usr_lib()`.

## Verification — #407 harness on a fresh Proxmox CT
`make harness-install ARGS="--from-tree ."` (template CT 201):
```
{"install_ok":true,"smoke_ok":true,"uninstall_ok":true,"residue":"clean"}
```
- FHS layout created correctly; non-editable install of hal0 + all deps
- api + Lemonade started; **dashboard served** (`hal0 v0.3.2a1 · slots=2`) — confirms `HAL0_UI_DIST` works under the non-editable layout
- uninstall leaves **zero residue** (paths, units, group all gone)

Run 1 caught the `hal0 uninstall` locator break; run 2 (post-fix) is fully green.

## Tests
- 3 new `apply()` cases: re-pip invoked in prod / skipped when editable / rollback on re-pip failure
- 1 new uninstall case: resolves the FHS path when not editable
- 54 updater+uninstall tests green; `ruff check` + `ruff format --check` clean; `bash -n` + shellcheck clean

## Acceptance criteria
- [x] Prod install produces the FHS layout (`/usr/lib/hal0/<versioned>` + `current` + shared venv)
- [x] `hal0 update` changes the running version (re-pip into the venv), not just the symlink
- [x] Dashboard serves under the non-editable install
- [x] `hal0 uninstall` works under FHS and leaves clean residue
- [x] Dev/editable mode unchanged (protects CT-105)
- [x] Verified e2e on a fresh CT via the #407 harness

## Follow-up dependency (not in this PR)
For the updater re-pip to work in real production, the **release tarball must ship an installable source tree** (pyproject + src + prebuilt `ui/dist`) so `pip install <dir>` succeeds offline. That's a `release.yml` packaging concern — flagging it so it's tracked before the next tagged release relies on `hal0 update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)