### PR TITLE
fix(slots): stop slot-edit Save wiping idle_timeout/extra_args/workers (#587)

### DIFF
--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -224,6 +224,35 @@ async def _lemonade_state_enrichment(request: Request) -> dict[str, dict[str, An
         n_gpu = model_section.get("n_gpu_layers") if isinstance(model_section, dict) else None
         entry["n_gpu_layers"] = n_gpu if isinstance(n_gpu, int) else -1
 
+        # Spec 1 / Component 2 (issue #587): surface idle_timeout_s,
+        # workers, and the slot's freeform llamacpp_args so the Edit
+        # drawer can seed from real on-disk values. Without these the
+        # drawer used hardcoded constants (900 / 1 /
+        # "--flash-attn on --no-mmap") and unconditionally rewrote the
+        # on-disk values on every Save — same bug class as #584. The
+        # on-disk field for the freeform overlay is ``[server].extra_args``
+        # (ServerConfig); the dashboard's wire key is ``llamacpp_args``
+        # (matches the global lemond admin panel), so we map at this
+        # boundary. ``idle_timeout_s`` and ``workers`` are flat top-level
+        # SlotConfig fields, hoisted from [slot] by the loader. Defaults
+        # are NOT applied here — the wire payload is the truth source
+        # the dashboard uses to dirty-track changes, so an absent
+        # on-disk field should surface as null/None, not the schema
+        # default (which would let a stale slot sneak in a new value
+        # on a no-op save).
+        entry["idle_timeout_s"] = cfg.get("idle_timeout_s")
+        entry["workers"] = cfg.get("workers")
+        server_cfg = cfg.get("server")
+        if server_cfg is None:
+            extra_args: Any = None
+        elif isinstance(server_cfg, dict):
+            extra_args = server_cfg.get("extra_args")
+        else:
+            # ServerConfig pydantic model — read via attribute to stay
+            # consistent with the .get() pattern above.
+            extra_args = getattr(server_cfg, "extra_args", None)
+        entry["llamacpp_args"] = extra_args
+
         loaded_entry = loaded_by_model.get(model_default) if model_default else None
         if not enabled:
             entry["lemonade_state"] = "disabled"

--- a/tests/api/test_slots_lemonade_state.py
+++ b/tests/api/test_slots_lemonade_state.py
@@ -316,6 +316,91 @@ def test_list_slots_enable_thinking_null_when_unset(
     assert "n_gpu_layers" in primary
 
 
+# ── Spec 1 / Component 2 (issue #587) ──────────────────────────────────────
+#
+# The slot-edit drawer seeds idle_timeout_s / workers / llamacpp_args from
+# the list payload. Before #587 the list omitted all three so the drawer
+# used hardcoded constants (900 / 1 / "--flash-attn on --no-mmap") and
+# clobbered the on-disk values on every Save. After the fix the payload
+# carries the slot's real on-disk values so the drawer (and its dirty-
+# tracking) can leave untouched fields alone.
+
+
+def test_list_slots_exposes_idle_timeout_workers_llamacpp_args(
+    tmp_hal0_home: str,
+    installed_lemonade_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """idle_timeout_s / workers / llamacpp_args ride along on /api/slots.
+
+    The on-disk shape is:
+      - ``workers`` + ``idle_timeout_s`` are flat top-level SlotConfig
+        fields (hoisted from the [slot] TOML table by the loader).
+      - ``llamacpp_args`` is the dashboard's wire name; the on-disk field
+        lives under ``[server].extra_args`` (ServerConfig). The list
+        payload maps to the dashboard's key so the drawer can seed
+        directly.
+    """
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "primary",
+        [
+            'name = "primary"',
+            "port = 8081",
+            'device = "gpu-rocm"',
+            'type = "llm"',
+            "enabled = true",
+            "workers = 4",
+            "idle_timeout_s = 1200",
+            "[model]",
+            'default = "qwen3"',
+            "[server]",
+            'extra_args = "--threads 6 --no-mmap"',
+        ],
+    )
+    r = isolated_client.get("/api/slots")
+    assert r.status_code == 200, r.text
+    by_name = {e["name"]: e for e in r.json()}
+    primary = by_name["primary"]
+    assert primary["idle_timeout_s"] == 1200
+    assert primary["workers"] == 4
+    assert primary["llamacpp_args"] == "--threads 6 --no-mmap"
+
+
+def test_list_slots_llamacpp_args_none_when_server_table_absent(
+    tmp_hal0_home: str,
+    installed_lemonade_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """Slot with no [server] table → payload's llamacpp_args is null.
+
+    Mirror the existing enable_thinking behaviour: absent on-disk → null
+    in the wire payload (effective unset), not omitted. The dashboard
+    uses null to skip sending the field on Save.
+    """
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "primary",
+        [
+            'name = "primary"',
+            "port = 8081",
+            'device = "gpu-rocm"',
+            'type = "llm"',
+            "enabled = true",
+            "workers = 2",
+            "idle_timeout_s = 600",
+            "[model]",
+            'default = "qwen3"',
+        ],
+    )
+    r = isolated_client.get("/api/slots")
+    by_name = {e["name"]: e for e in r.json()}
+    primary = by_name["primary"]
+    assert primary["idle_timeout_s"] == 600
+    assert primary["workers"] == 2
+    assert primary["llamacpp_args"] is None
+
+
 def test_list_slots_skips_coresident_for_disabled_sibling(
     tmp_hal0_home: str,
     installed_lemonade_stub: dict[str, Any],

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -340,6 +340,16 @@ function EditSlotDrawer({ open, slot, onClose }) {
   const deleteMut = useSlotDelete();
   const backendMut = useSlotBackend();
 
+  // Seed from the slot list payload when available (PR #587 — same fix
+  // class as #584). idle_timeout_s / workers / llamacpp_args are all
+  // surfaced on the list payload now, so the drawer mirrors them
+  // verbatim and only sends what actually changed. When the payload
+  // is missing the field (older backend, or synthetic slot), the
+  // schema defaults act as a fallback for first-time edits only.
+  const initialIdle = slot?.idle_timeout_s != null ? slot.idle_timeout_s : 900;
+  const initialWorkers = slot?.workers != null ? slot.workers : 1;
+  const initialExtraArgs = slot?.llamacpp_args != null ? slot.llamacpp_args : "";
+
   const [ctx, setCtx] = useStateSM(slot?.metrics?.ctx || 4096);
   // C4/C5: thinking is instant-apply (its own PUT); n_gpu_layers rides the Save
   // button through PATCH /defaults. Both seed from the slot list payload.
@@ -348,9 +358,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
   const [nGpuLayers, setNGpuLayers] = useStateSM(
     slot?.n_gpu_layers != null ? String(slot.n_gpu_layers) : "-1"
   );
-  const [idleTimeout, setIdleTimeout] = useStateSM(900);
-  const [workers, setWorkers] = useStateSM(1);
-  const [extraArgs, setExtraArgs] = useStateSM("--flash-attn on --no-mmap");
+  const [idleTimeout, setIdleTimeout] = useStateSM(initialIdle);
+  const [workers, setWorkers] = useStateSM(initialWorkers);
+  const [extraArgs, setExtraArgs] = useStateSM(initialExtraArgs);
   const [device, setDevice] = useStateSM(slot?.device || "gpu-rocm");
   const [makeDefault, setMakeDefault] = useStateSM(!!slot?.isDefault);
   const [submitErr, setSubmitErr] = useStateSM(null);
@@ -370,9 +380,14 @@ function EditSlotDrawer({ open, slot, onClose }) {
       setNGpuLayers(slot.n_gpu_layers != null ? String(slot.n_gpu_layers) : "-1");
       setDevice(slot.device || "gpu-rocm");
       setMakeDefault(!!slot.isDefault);
-      setIdleTimeout(900);
-      setWorkers(1);
-      setExtraArgs("--flash-attn on --no-mmap");
+      // #587: re-seed from the slot prop so the drawer tracks the real
+      // on-disk values (was hardcoded constants before — that was the
+      // bug). The dirty-tracking in onSaveClick below only ships fields
+      // that actually changed, so a no-op edit no longer rewrites
+      // anything.
+      setIdleTimeout(slot.idle_timeout_s != null ? slot.idle_timeout_s : 900);
+      setWorkers(slot.workers != null ? slot.workers : 1);
+      setExtraArgs(slot.llamacpp_args != null ? slot.llamacpp_args : "");
       setSubmitErr(null);
       setSelectedBackend(
         slot.declared_backend || (slot.device || "gpu-rocm").replace("gpu-", "") || "rocm"
@@ -393,22 +408,39 @@ function EditSlotDrawer({ open, slot, onClose }) {
       const idleNum = Number(idleTimeout);
       const workersNum = Number(workers);
       const nglNum = Number(nGpuLayers);
+      // #587 dirty-tracking: only include a field in the body if the
+      // user actually changed it from the seeded (on-disk) value.
+      // Sending every field unconditionally is what clobbered values
+      // before — same fix class as #584. ctx_size / n_gpu_layers stay
+      // unconditional because the drawer's seed is best-effort
+      // (metrics?.ctx / -1 sentinel) and NOT the truth source.
+      const ctxBody = {
+        ctx_size: Number.isFinite(ctxNum) ? ctxNum : ctx,
+        n_gpu_layers: Number.isFinite(nglNum) ? nglNum : -1,
+      };
+      const slotBody = {
+        device,
+        default: makeDefault,
+      };
+      const idleSeeded = initialIdle;
+      const workersSeeded = initialWorkers;
+      const extraArgsSeeded = initialExtraArgs;
+      if (Number(idleTimeout) !== Number(idleSeeded)) {
+        slotBody.idle_timeout_s = Number.isFinite(idleNum) ? idleNum : idleTimeout;
+      }
+      if (Number(workers) !== Number(workersSeeded)) {
+        slotBody.workers = Number.isFinite(workersNum) ? workersNum : workers;
+      }
+      if (extraArgs !== extraArgsSeeded) {
+        slotBody.llamacpp_args = extraArgs;
+      }
       await defaultsMut.mutateAsync({
         name: slot.name,
-        body: {
-          ctx_size: Number.isFinite(ctxNum) ? ctxNum : ctx,
-          n_gpu_layers: Number.isFinite(nglNum) ? nglNum : -1,
-        },
+        body: ctxBody,
       });
       await editMut.mutateAsync({
         name: slot.name,
-        body: {
-          device,
-          default: makeDefault,
-          llamacpp_args: extraArgs,
-          idle_timeout_s: Number.isFinite(idleNum) ? idleNum : idleTimeout,
-          workers: Number.isFinite(workersNum) ? workersNum : workers,
-        },
+        body: slotBody,
       });
       window.__hal0Toast && window.__hal0Toast(
         `Slot "${slot.name}" saved — restart required for ctx_size`,

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -147,4 +147,76 @@ test.describe('Slot edit controls (/slots)', () => {
     await expect(chatCards.first()).toContainText('primary')
     await expect(chatCards.nth(1)).toContainText('coder')
   })
+
+  // #587: the slot-edit drawer used to seed idle_timeout_s / workers /
+  // llamacpp_args from hardcoded constants and send all three
+  // unconditionally on Save, clobbering the on-disk values. The fix
+  // is two-layered:
+  //   - the list payload carries the slot's real on-disk values, so the
+  //     drawer seeds from truth;
+  //   - the drawer dirty-tracks the seeded values and only ships fields
+  //     that actually changed. This test exercises the second layer:
+  //     opening the drawer on a slot whose payload lists e.g.
+  //     idle_timeout_s=1200, then clicking Save without touching
+  //     anything, must NOT send idle_timeout_s on the wire.
+  test('#587 — no-op Save does not send idle_timeout_s / workers / extra_args', async ({ page }) => {
+    const puts: any[] = []
+    await page.route('**/api/slots/primary/config', async (route) => {
+      if (route.request().method() === 'PUT') {
+        puts.push(JSON.parse(route.request().postData() || '{}'))
+      }
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await page.route('**/api/slots/primary/defaults', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+    // PRIMARY carries the real on-disk values for the three clobber-
+    // prone fields. The drawer must seed from these and stay quiet on
+    // Save when nothing changed.
+    const PRIMARY_WITH_DEFAULTS = {
+      ...PRIMARY,
+      idle_timeout_s: 1200,
+      workers: 4,
+      llamacpp_args: '--threads 6 --no-mmap',
+    }
+    await seedSlots(page, [PRIMARY_WITH_DEFAULTS, EMBED])
+
+    await page.goto('/#slots/primary')
+    // Click Save immediately — no field edits.
+    await page.locator('.drawer button:has-text("Save")').click()
+    await expect.poll(() => puts.length).toBeGreaterThan(0)
+    const body = puts[0]
+    expect(body).not.toHaveProperty('idle_timeout_s')
+    expect(body).not.toHaveProperty('workers')
+    expect(body).not.toHaveProperty('llamacpp_args')
+  })
+
+  test('#587 — editing idle_timeout_s sends only that field', async ({ page }) => {
+    const puts: any[] = []
+    await page.route('**/api/slots/primary/config', async (route) => {
+      if (route.request().method() === 'PUT') {
+        puts.push(JSON.parse(route.request().postData() || '{}'))
+      }
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await page.route('**/api/slots/primary/defaults', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+    await seedSlots(page, [
+      { ...PRIMARY, idle_timeout_s: 300, workers: 2, llamacpp_args: '' },
+      EMBED,
+    ])
+
+    await page.goto('/#slots/primary')
+    const row = page.locator('.drawer .form-row', { hasText: 'idle_timeout_s' })
+    await expect(row).toBeVisible()
+    await row.locator('input').fill('1800')
+    await page.locator('.drawer button:has-text("Save")').click()
+    await expect.poll(() => puts.length).toBeGreaterThan(0)
+    const body = puts[0]
+    expect(body.idle_timeout_s).toBe(1800)
+    // workers + extra_args were untouched → must not appear in the body.
+    expect(body).not.toHaveProperty('workers')
+    expect(body).not.toHaveProperty('llamacpp_args')
+  })
 })


### PR DESCRIPTION
Closes #587

`list_slots` payload now includes `idle_timeout_s`/`llamacpp_args`/`workers` so the Edit drawer seeds from real values instead of hardcoded constants; drawer also dirty-tracks and only sends changed fields (same fix class as #584). Backend test + e2e spec added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)