### PR TITLE
feat(settings): Runtime tiers (Live/Common/Advanced/Locked) + idle-eviction (#550)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -748,7 +748,12 @@ def _build_idle_ttl_provider(
     return _provider
 
 
-async def _start_lemonade_idle_driver(app: FastAPI, slot_manager: SlotManager) -> IdleDriver | None:
+async def _start_lemonade_idle_driver(
+    app: FastAPI,
+    slot_manager: SlotManager,
+    *,
+    global_idle_timeout_s: float = 300.0,
+) -> IdleDriver | None:
     """Start the Lemonade idle-unload driver.
 
     v0.2 (ADR-0008 §1): Lemonade is the sole inference backend; this
@@ -758,6 +763,10 @@ async def _start_lemonade_idle_driver(app: FastAPI, slot_manager: SlotManager) -
     The driver consumes a per-model TTL provider (issue #414) so each
     slot's configured ``idle_timeout_s`` actually drives eviction
     instead of a single hardcoded 300s global.
+
+    ``global_idle_timeout_s`` is the fleet-level fallback from
+    ``[slots].idle_timeout_s`` in hal0.toml (default 300 s).
+    Individual slot TOML values override this via the TTL provider.
 
     Failures here MUST NOT block API startup — a busted Lemonade
     config shouldn't keep the dashboard from coming up so the user
@@ -777,6 +786,7 @@ async def _start_lemonade_idle_driver(app: FastAPI, slot_manager: SlotManager) -
         )
         driver = IdleDriver(
             client,
+            idle_timeout_s=global_idle_timeout_s,
             ttl_provider=_build_idle_ttl_provider(slot_manager),
         )
         await driver.start()
@@ -1060,7 +1070,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # makes Lemonade the sole backend, so this driver always starts —
     # the prior ``HAL0_BACKEND=lemonade`` gate retired in PR-10. Stored
     # on app.state so tests + future shutdown hooks can introspect it.
-    lemonade_idle_driver = await _start_lemonade_idle_driver(app, slot_manager)
+    lemonade_idle_driver = await _start_lemonade_idle_driver(
+        app,
+        slot_manager,
+        global_idle_timeout_s=float(hal0_cfg.slots.idle_timeout_s),
+    )
     # Lemonade metrics shim (PR-12, plan §10.1 + §11). Shares the
     # ``app.state.lemonade_client`` attached by the idle driver so we
     # don't double up on connection pools against lemond. Provides the

--- a/src/hal0/api/_settings_apply.py
+++ b/src/hal0/api/_settings_apply.py
@@ -143,6 +143,7 @@ _HAL0_REGISTRY: dict[str, ApplyPlanEntry] = {
     "slots.max_slots": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
     "slots.port_range_start": {"apply_class": "manual-restart", "services": []},
     "slots.port_range_end": {"apply_class": "manual-restart", "services": []},
+    "slots.idle_timeout_s": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
     # [models]
     "models.roots": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
     "models.auto_scan_on_start": {"apply_class": "immediate", "services": []},

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -723,6 +723,16 @@ class SlotsConfig(BaseModel):
         le=65535,
         description="Last port in the slot pool (inclusive).",
     )
+    idle_timeout_s: int = Field(
+        default=300,
+        ge=0,
+        description=(
+            "Global idle-eviction TTL (seconds). "
+            "Models that have not served a request for this long are unloaded by the "
+            "Lemonade idle driver. 0 disables global eviction (per-slot overrides still "
+            "apply). Per-slot idle_timeout_s in each slot's TOML overrides this value."
+        ),
+    )
 
     @model_validator(mode="after")
     def port_range_sane(self) -> SlotsConfig:

--- a/ui/src/dash/settings.jsx
+++ b/ui/src/dash/settings.jsx
@@ -15,6 +15,7 @@ import { useUpdateState, useUpdateCheck, useUpdateApply, useUpdateJob, useSetUpd
 import { useCapabilities, useCapabilityPatch } from '@/api/hooks/useCapabilities'
 import { useLemondRollup, useLemonadeStats } from '@/api/hooks/useLemonade'
 import { useLemonadeConfig, useLemonadeConfigSet } from '@/api/hooks/useLemonadeConfig'
+import { useSlots, useSlotEdit } from '@/api/hooks/useSlots'
 import {
   useSettings,
   useSettingsUpdate,
@@ -653,42 +654,299 @@ function extractFlagValue(s, name) {
 // never drift. The `threads` row is a typed UI over `llamacpp_args` —
 // the underlying key it writes on save is still llamacpp_args (deferred).
 //
-// `host` / `port` are read-only — changing them requires a systemd
-// unit edit (the lemond service pins the listen endpoint). `extra_models_dir`
-// stays locked to the [models].store single source of truth.
+// `host` / `port` are read-only (systemd-gated / advanced).
+// `extra_models_dir` + `kokoro.cpu_bin` are locked.
+//
+// `group` controls which disclosure tier a field appears in:
+//   "common"   — always visible
+//   "advanced" — collapsed behind a toggle (default closed)
+//   (no group) — iterated but not rendered in these panels
 const LEMONADE_FIELDS = [
-  // ── immediate-effect knobs ──
-  { key: "global_timeout",  sub: "Default per-request timeout (sec)", kind: "number", width: 100, min: 1 },
-  { key: "log_level",       sub: "Lemonade log verbosity",            kind: "select", options: ["critical","error","warn","info","debug","trace"], width: 140 },
-  { key: "no_broadcast",    sub: "Skip UDP backend discovery",        kind: "toggle" },
-  // ── deferred-effect knobs (apply on next /v1/load) ──
-  { key: "threads",         sub: "llama.cpp thread count (≥2 — typed; writes llamacpp_args)", kind: "threads", min: 2 },
-  { key: "llamacpp_backend", sub: "llama.cpp compute backend",         kind: "select", options: ["rocm","vulkan","cpu"], width: 140 },
-  { key: "max_loaded_models", sub: "Per-type LRU budget",              kind: "number", width: 100, min: 1 },
-  { key: "ctx_size",        sub: "Default per /v1/load — overridable per slot", kind: "number", width: 100, min: 256 },
-  { key: "sdcpp_backend",   sub: "sd.cpp compute backend",            kind: "select", options: ["rocm","vulkan","cpu"], width: 140 },
-  { key: "whispercpp_backend", sub: "whisper.cpp compute backend",     kind: "select", options: ["vulkan","cpu","cublas"], width: 140 },
-  { key: "steps",           sub: "sd.cpp sampling steps",             kind: "number", width: 100, min: 1 },
-  { key: "cfg_scale",       sub: "sd.cpp classifier-free guidance",   kind: "number", width: 100, min: 0, step: 0.5 },
-  { key: "width",           sub: "sd.cpp output width (px)",          kind: "number", width: 100, min: 64 },
-  { key: "height",          sub: "sd.cpp output height (px)",         kind: "number", width: 100, min: 64 },
+  // ── Common: the knobs most operators need ──
+  { key: "max_loaded_models", group: "common", sub: "Per-type LRU budget",                            kind: "number", width: 100, min: 1 },
+  { key: "ctx_size",          group: "common", sub: "Default per /v1/load — overridable per slot",    kind: "number", width: 100, min: 256 },
+  { key: "global_timeout",    group: "common", sub: "Default per-request timeout (sec)",              kind: "number", width: 100, min: 1 },
+  { key: "log_level",         group: "common", sub: "Lemonade log verbosity",                         kind: "select", options: ["critical","error","warn","info","debug","trace"], width: 140 },
+  { key: "threads",           group: "common", sub: "llama.cpp thread count (≥2 — typed; writes llamacpp_args)", kind: "threads", min: 2 },
+  // ── Advanced: host/port, backend selects, per-backend args, sd.cpp ──
+  { key: "llamacpp_backend",    group: "advanced", sub: "llama.cpp compute backend",     kind: "select", options: ["rocm","vulkan","cpu"], width: 140 },
+  { key: "sdcpp_backend",       group: "advanced", sub: "sd.cpp compute backend",        kind: "select", options: ["rocm","vulkan","cpu"], width: 140 },
+  { key: "whispercpp_backend",  group: "advanced", sub: "whisper.cpp compute backend",   kind: "select", options: ["vulkan","cpu","cublas"], width: 140 },
+  { key: "steps",       group: "advanced", sub: "sd.cpp sampling steps",               kind: "number", width: 100, min: 1 },
+  { key: "cfg_scale",   group: "advanced", sub: "sd.cpp classifier-free guidance",     kind: "number", width: 100, min: 0, step: 0.5 },
+  { key: "width",       group: "advanced", sub: "sd.cpp output width (px)",            kind: "number", width: 100, min: 64 },
+  { key: "height",      group: "advanced", sub: "sd.cpp output height (px)",           kind: "number", width: 100, min: 64 },
   {
-    key: "flm_args",
+    key: "flm_args", group: "advanced",
     sub: "FLM trio config — drives NPU coresident packing",
     kind: "text",
     warn: "--asr/--embed take 0 or 1; setting a modality to 0 requires disabling the corresponding NPU slot in dispatch.",
   },
-  // ── read-only (systemd-gated / locked) ──
-  { key: "host", sub: "Listen host — change requires systemd unit edit", kind: "readonly" },
-  { key: "port", sub: "Listen port — change requires systemd unit edit", kind: "readonly" },
+  { key: "no_broadcast", group: "advanced", sub: "Skip UDP backend discovery", kind: "toggle" },
+  { key: "host", group: "advanced", sub: "Listen host — change requires systemd unit edit", kind: "readonly" },
+  { key: "port", group: "advanced", sub: "Listen port — change requires systemd unit edit", kind: "readonly" },
 ];
 
+// ── shared field renderer (used by both Common + Advanced panels) ──
+function LemonadeFieldRow({ f, edits, setField, fieldErrors, effects }) {
+  const isDeferred = f.key === "threads" || effects.deferred.includes(f.key);
+  const isImmediate = !isDeferred && effects.immediate.includes(f.key);
+  const err = fieldErrors[f.key];
+
+  const getOriginalStr = (key, cfg) => {
+    if (!cfg) return "";
+    if (key === "threads") {
+      const t = extractThreads(cfg.llamacpp_args);
+      return t == null ? "" : t;
+    }
+    const v = cfg[key];
+    return v == null ? "" : String(v);
+  };
+
+  return (
+    <SRow
+      k={f.key}
+      sub={f.sub}
+      mono
+      v={
+        <div style={{display: "flex", flexDirection: "column", gap: 4}}>
+          {f.kind === "select" ? (
+            <select
+              className="input mono"
+              value={edits[f.key] ?? ""}
+              onChange={(e) => setField(f.key, e.target.value)}
+              style={{maxWidth: f.width}}
+            >
+              {(f.options || []).map((o) => <option key={o} value={o}>{o}</option>)}
+            </select>
+          ) : f.kind === "toggle" ? (
+            <label className="mono" style={{display: "inline-flex", alignItems: "center", gap: 8, cursor: "pointer", color: "var(--fg-2)"}}>
+              <input
+                type="checkbox"
+                checked={edits[f.key] === "true"}
+                onChange={(e) => setField(f.key, e.target.checked ? "true" : "false")}
+                style={{accentColor: "var(--accent)"}}
+              />
+              <span>{edits[f.key] === "true" ? "enabled" : "disabled"}</span>
+            </label>
+          ) : f.kind === "readonly" ? (
+            <span className="mono" style={{color: "var(--fg-3)"}}>
+              {edits[f.key] || "—"}
+            </span>
+          ) : (
+            <input
+              className="input mono"
+              type={f.kind === "threads" || f.kind === "number" ? "number" : "text"}
+              min={f.min}
+              step={f.step}
+              value={edits[f.key] ?? ""}
+              onChange={(e) => setField(f.key, e.target.value)}
+              style={f.width ? {maxWidth: f.width} : {minWidth: 320, width: "100%"}}
+            />
+          )}
+          {f.warn && (
+            <span style={{color: "var(--err)", fontFamily: "var(--jbm)", fontSize: 10, lineHeight: 1.4}}>{f.warn}</span>
+          )}
+          {err && (
+            <span className="err" style={{fontSize: 10, padding: 0, background: "none", border: "none"}}>{err}</span>
+          )}
+        </div>
+      }
+      actions={
+        f.kind === "readonly" ? null : (
+          <span
+            className="chip"
+            style={{
+              fontFamily: "var(--jbm)",
+              fontSize: 10,
+              padding: "2px 8px",
+              color: isDeferred ? "var(--warn)" : isImmediate ? "var(--ok)" : "var(--fg-4)",
+              borderColor: isDeferred ? "var(--warn)" : isImmediate ? "var(--ok)" : "var(--line)",
+              background: isDeferred ? "rgba(255,176,0,0.08)" : isImmediate ? "rgba(46,204,113,0.08)" : "transparent",
+              whiteSpace: "nowrap",
+            }}
+            title={isDeferred ? "Persists to config now; takes effect on next /v1/load" : isImmediate ? "lemond applies this value immediately on POST" : ""}
+          >
+            {isDeferred ? "⟳ restart on next load" : isImmediate ? "live" : ""}
+          </span>
+        )
+      }
+    />
+  );
+}
+
+// ── Idle-eviction sub-section ─────────────────────────────────────────
+//
+// Global idle_timeout_s → [slots].idle_timeout_s in hal0.toml, read/written
+// via useSettings / useSettingsUpdate (same path as StorageSection's models.*).
+// Per-slot idle_timeout_s → PUT /api/slots/{name}/config { idle_timeout_s: N }
+// via useSlotEdit. A null per-slot value means "inherit global".
+function IdleEvictionSection() {
+  const settingsQuery = useSettings();
+  const settingsUpdate = useSettingsUpdate();
+  const slotsQuery = useSlots();
+  const slotEdit = useSlotEdit();
+
+  const globalVal = settingsQuery.data?.slots?.idle_timeout_s ?? 300;
+  const [globalEdit, setGlobalEdit] = useStateSet("");
+  const [slotEdits, setSlotEdits] = useStateSet({});
+
+  // Populate global edit buffer when settings load or change.
+  useEffectSet(() => {
+    const v = settingsQuery.data?.slots?.idle_timeout_s;
+    setGlobalEdit(v != null ? String(v) : "300");
+  }, [settingsQuery.data]);
+
+  // Populate per-slot edit buffers when slot list loads.
+  useEffectSet(() => {
+    if (!slotsQuery.data) return;
+    const next = {};
+    for (const s of slotsQuery.data) {
+      next[s.name] = s.idle_timeout_s != null ? String(s.idle_timeout_s) : "";
+    }
+    setSlotEdits((prev) => {
+      // Only reset keys that haven't been touched (avoid clobbering in-flight edits).
+      const merged = { ...prev };
+      for (const [k, v] of Object.entries(next)) {
+        if (!(k in prev)) merged[k] = v;
+      }
+      return merged;
+    });
+  }, [slotsQuery.data]);
+
+  const globalDirty = globalEdit.trim() !== String(globalVal);
+
+  const onGlobalSave = async () => {
+    const n = Number(globalEdit.trim());
+    if (!Number.isFinite(n) || n < 0) {
+      window.__hal0Toast && window.__hal0Toast("idle_timeout_s must be a non-negative integer", "err");
+      return;
+    }
+    try {
+      await settingsUpdate.mutateAsync({ slots: { idle_timeout_s: n } });
+      window.__hal0Toast && window.__hal0Toast(
+        `Global idle timeout set to ${n}s — restart hal0-api to apply`,
+        "warn",
+      );
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(`Save failed — ${e?.message || "see logs"}`, "err");
+    }
+  };
+
+  const onSlotSave = async (slotName) => {
+    const raw = (slotEdits[slotName] ?? "").trim();
+    const n = raw === "" ? null : Number(raw);
+    if (raw !== "" && (!Number.isFinite(n) || n < 0)) {
+      window.__hal0Toast && window.__hal0Toast("idle_timeout_s must be a non-negative integer or empty (inherit global)", "err");
+      return;
+    }
+    try {
+      await slotEdit.mutateAsync({ name: slotName, body: { idle_timeout_s: n } });
+      window.__hal0Toast && window.__hal0Toast(
+        `${slotName} idle timeout ${n == null ? "cleared (inherits global)" : `set to ${n}s`}`,
+        "ok",
+      );
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(`Save failed — ${e?.message || "see logs"}`, "err");
+    }
+  };
+
+  const slots = (slotsQuery.data || []).filter((s) => !s._synthetic);
+
+  return (
+    <div style={{marginTop: 20}}>
+      <div className="mono" style={{fontSize: 10, color: "var(--fg-4)", marginBottom: 8, textTransform: "uppercase", letterSpacing: 0.6, borderBottom: "1px solid var(--line)", paddingBottom: 6}}>
+        Idle eviction
+      </div>
+      <p style={{fontFamily: "var(--jbm)", fontSize: 11, color: "var(--fg-3)", marginBottom: 10}}>
+        Models idle for longer than their TTL are unloaded by the Lemonade idle driver.
+        Per-slot values override the global fallback; empty = inherit global.
+      </p>
+      <div className="s-panel">
+        <SRow
+          k="global idle_timeout_s"
+          sub="Fleet default — [slots].idle_timeout_s in hal0.toml · applies on hal0-api restart"
+          mono
+          v={
+            <input
+              className="input mono"
+              type="number"
+              min={0}
+              value={globalEdit}
+              onChange={(e) => setGlobalEdit(e.target.value)}
+              style={{maxWidth: 100}}
+            />
+          }
+          actions={
+            <div style={{display: "inline-flex", alignItems: "center", gap: 6}}>
+              <span
+                className="chip"
+                style={{fontFamily: "var(--jbm)", fontSize: 10, padding: "2px 8px", color: "var(--warn)", borderColor: "var(--warn)", background: "rgba(255,176,0,0.08)", whiteSpace: "nowrap"}}
+                title="Requires restarting hal0-api to take effect"
+              >
+                ⟳ restart hal0-api
+              </span>
+              {globalDirty && (
+                <button
+                  className="btn ghost sm"
+                  disabled={settingsUpdate.isPending}
+                  onClick={onGlobalSave}
+                >
+                  {settingsUpdate.isPending ? "Saving…" : "Save"}
+                </button>
+              )}
+            </div>
+          }
+        />
+        {slots.length === 0 && slotsQuery.isPending && (
+          <div style={{padding: "8px 0", color: "var(--fg-4)", fontFamily: "var(--jbm)", fontSize: 11}}>Loading slots…</div>
+        )}
+        {slots.map((s) => {
+          const original = s.idle_timeout_s != null ? String(s.idle_timeout_s) : "";
+          const current = slotEdits[s.name] ?? original;
+          const dirty = current !== original;
+          return (
+            <SRow
+              key={s.name}
+              k={s.name}
+              sub={`per-slot idle_timeout_s · empty = inherit global (${globalVal}s)`}
+              mono
+              v={
+                <input
+                  className="input mono"
+                  type="number"
+                  min={0}
+                  placeholder={`${globalVal} (global)`}
+                  value={slotEdits[s.name] ?? original}
+                  onChange={(e) => setSlotEdits((prev) => ({ ...prev, [s.name]: e.target.value }))}
+                  style={{maxWidth: 100}}
+                />
+              }
+              actions={
+                dirty && (
+                  <button
+                    className="btn ghost sm"
+                    disabled={slotEdit.isPending}
+                    onClick={() => onSlotSave(s.name)}
+                  >
+                    {slotEdit.isPending ? "Saving…" : "Save"}
+                  </button>
+                )
+              }
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function RuntimeSection() {
-  // Issue #545 — typed Lemonade runtime knobs. Reads + writes the live
-  // /api/lemonade/config surface. The per-row apply badge is derived
-  // from the backend's `_hal0.effects` partition (immediate/deferred)
-  // rather than hard-coded; the typed `threads` input maps to the
-  // `llamacpp_args` wire key on save.
+  // Issue #545 — typed Lemonade runtime knobs, restructured into tiers (#550).
+  // Groups: Live read-outs (top) / Common (always visible) / Advanced (collapsed) /
+  // Locked (muted read-only) / Idle eviction (sub-section at bottom).
+  // Save/reset/validation logic is unchanged from #545 — all keys remain in
+  // LEMONADE_FIELDS; the group tag only controls rendering, not the patch path.
   const lemond = useLemondRollup();
   const stats = useLemonadeStats();
   const caps = useCapabilities();
@@ -697,6 +955,9 @@ function RuntimeSection() {
   const cfg = cfgQuery.data;
   const effects = cfg?._hal0?.effects || { immediate: [], deferred: [] };
   const lockedDir = cfg?._hal0?.locked?.extra_models_dir;
+
+  // Advanced disclosure toggle (default closed).
+  const [advancedOpen, setAdvancedOpen] = useStateSet(false);
 
   // Edit buffer holds string values per key; populated from the live
   // snapshot once it loads. We keep everything as strings so the inputs
@@ -744,6 +1005,15 @@ function RuntimeSection() {
   const touchesDeferred = dirtyKeys.some((k) =>
     k === "threads" || effects.deferred.includes(k),
   );
+
+  // If a dirty + errored key lives in the Advanced group, auto-expand it
+  // so Save doesn't silently block with no visible cause.
+  const hasAdvancedError = LEMONADE_FIELDS
+    .filter((f) => f.group === "advanced")
+    .some((f) => fieldErrors[f.key] && dirtyKeys.includes(f.key));
+  useEffectSet(() => {
+    if (hasAdvancedError) setAdvancedOpen(true);
+  }, [hasAdvancedError]);
 
   // Client-side pre-validation. The backend re-checks these — but
   // surfacing the error inline before the round-trip keeps the form
@@ -865,6 +1135,9 @@ function RuntimeSection() {
     { k: "output tok",   v: liveStats.output_tokens != null ? String(liveStats.output_tokens) : "—" },
   ];
 
+  const commonFields = LEMONADE_FIELDS.filter((f) => f.group === "common");
+  const advancedFields = LEMONADE_FIELDS.filter((f) => f.group === "advanced");
+
   return (
     <div className="s-section">
       <h2>Runtime</h2>
@@ -876,7 +1149,7 @@ function RuntimeSection() {
         keys take hold on the next <span className="mono">/v1/load</span>.
       </p>
 
-      {/* Header readouts — lemond health + capability preview (live) */}
+      {/* ── Live read-outs (top, read-only) — version/status/budget/TTFT/tok·s ── */}
       <div className="s-panel" style={{marginBottom: 12}}>
         <SRow k="runtime" mono v={<>{lemond.version} · {lemond.status} · <b>{lemond.loaded}</b>/{lemond.budget} loaded</>} />
         <SRow k="throughput" mono v={lemond.throughput != null ? `${lemond.throughput} MB/s` : '—'} />
@@ -930,83 +1203,38 @@ function RuntimeSection() {
 
       {cfg && (
         <>
-          <div className="s-panel">
-            {LEMONADE_FIELDS.map((f) => {
-              const isDeferred = f.key === "threads" || effects.deferred.includes(f.key);
-              const isImmediate = !isDeferred && effects.immediate.includes(f.key);
-              const err = fieldErrors[f.key];
-              return (
-                <SRow
-                  key={f.key}
-                  k={f.key}
-                  sub={f.sub}
-                  mono
-                  v={
-                    <div style={{display: "flex", flexDirection: "column", gap: 4}}>
-                      {f.kind === "select" ? (
-                        <select
-                          className="input mono"
-                          value={edits[f.key] ?? ""}
-                          onChange={(e) => setField(f.key, e.target.value)}
-                          style={{maxWidth: f.width}}
-                        >
-                          {(f.options || []).map((o) => <option key={o} value={o}>{o}</option>)}
-                        </select>
-                      ) : f.kind === "toggle" ? (
-                        <label className="mono" style={{display: "inline-flex", alignItems: "center", gap: 8, cursor: "pointer", color: "var(--fg-2)"}}>
-                          <input
-                            type="checkbox"
-                            checked={edits[f.key] === "true"}
-                            onChange={(e) => setField(f.key, e.target.checked ? "true" : "false")}
-                            style={{accentColor: "var(--accent)"}}
-                          />
-                          <span>{edits[f.key] === "true" ? "enabled" : "disabled"}</span>
-                        </label>
-                      ) : f.kind === "readonly" ? (
-                        <span className="mono" style={{color: "var(--fg-3)"}}>
-                          {original(f.key) || "—"}
-                        </span>
-                      ) : (
-                        <input
-                          className="input mono"
-                          type={f.kind === "threads" || f.kind === "number" ? "number" : "text"}
-                          min={f.min}
-                          step={f.step}
-                          value={edits[f.key] ?? ""}
-                          onChange={(e) => setField(f.key, e.target.value)}
-                          style={f.width ? {maxWidth: f.width} : {minWidth: 320, width: "100%"}}
-                        />
-                      )}
-                      {f.warn && (
-                        <span style={{color: "var(--err)", fontFamily: "var(--jbm)", fontSize: 10, lineHeight: 1.4}}>{f.warn}</span>
-                      )}
-                      {err && (
-                        <span className="err" style={{fontSize: 10, padding: 0, background: "none", border: "none"}}>{err}</span>
-                      )}
-                    </div>
-                  }
-                  actions={
-                    f.kind === "readonly" ? null : (
-                      <span
-                        className="chip"
-                        style={{
-                          fontFamily: "var(--jbm)",
-                          fontSize: 10,
-                          padding: "2px 8px",
-                          color: isDeferred ? "var(--warn)" : isImmediate ? "var(--ok)" : "var(--fg-4)",
-                          borderColor: isDeferred ? "var(--warn)" : isImmediate ? "var(--ok)" : "var(--line)",
-                          background: isDeferred ? "rgba(255,176,0,0.08)" : isImmediate ? "rgba(46,204,113,0.08)" : "transparent",
-                          whiteSpace: "nowrap",
-                        }}
-                        title={isDeferred ? "Persists to config now; takes effect on next /v1/load" : isImmediate ? "lemond applies this value immediately on POST" : ""}
-                      >
-                        {isDeferred ? "⟳ restart on next load" : isImmediate ? "live" : ""}
-                      </span>
-                    )
-                  }
-                />
-              );
-            })}
+          {/* ── Common: always-visible knobs ── */}
+          <div className="mono" style={{fontSize: 10, color: "var(--fg-4)", marginBottom: 6, textTransform: "uppercase", letterSpacing: 0.6}}>Common</div>
+          <div className="s-panel" style={{marginBottom: 12}}>
+            {commonFields.map((f) => (
+              <LemonadeFieldRow key={f.key} f={f} edits={edits} setField={setField} fieldErrors={fieldErrors} effects={effects} />
+            ))}
+          </div>
+
+          {/* ── Advanced: collapsed behind a toggle ── */}
+          <div
+            style={{display: "flex", alignItems: "center", gap: 8, marginBottom: 6, cursor: "pointer", userSelect: "none"}}
+            onClick={() => setAdvancedOpen((o) => !o)}
+          >
+            <span className="mono" style={{fontSize: 10, color: "var(--fg-4)", textTransform: "uppercase", letterSpacing: 0.6}}>Advanced</span>
+            <span className="mono" style={{fontSize: 10, color: "var(--fg-4)"}}>
+              {advancedOpen ? "▲" : "▼"}
+            </span>
+            <span style={{fontFamily: "var(--jbm)", fontSize: 10, color: "var(--fg-4)"}}>
+              {advancedOpen ? "hide" : `show — host/port, backends, sd.cpp${advancedFields.some((f) => dirtyKeys.includes(f.key)) ? " · unsaved" : ""}`}
+            </span>
+          </div>
+          {advancedOpen && (
+            <div className="s-panel" style={{marginBottom: 12}}>
+              {advancedFields.map((f) => (
+                <LemonadeFieldRow key={f.key} f={f} edits={edits} setField={setField} fieldErrors={fieldErrors} effects={effects} />
+              ))}
+            </div>
+          )}
+
+          {/* ── Locked: muted read-only ── */}
+          <div className="mono" style={{fontSize: 10, color: "var(--fg-4)", marginBottom: 6, textTransform: "uppercase", letterSpacing: 0.6}}>Locked</div>
+          <div className="s-panel" style={{marginBottom: 12, opacity: 0.6}}>
             <SRow
               k="extra_models_dir"
               sub="Locked to the model store — change via Settings → Storage"
@@ -1047,6 +1275,9 @@ function RuntimeSection() {
           </div>
         </>
       )}
+
+      {/* ── Idle eviction sub-section ── */}
+      <IdleEvictionSection />
 
       <ConfirmDialog
         open={confirmOpen}


### PR DESCRIPTION
Closes #550

Restructures RuntimeSection into four progressive-disclosure tiers (Live/Common/Advanced/Locked) and adds the idle-eviction sub-section (global + per-slot idle_timeout_s).