### PR TITLE
fix(dash): throughput chip uses live tokens/sec (#340)

### DIFF
--- a/ui/src/api/mock.ts
+++ b/ui/src/api/mock.ts
@@ -53,7 +53,9 @@ function buildStats() {
   const L = d.lemond || {}
   return {
     time_to_first_token: 0.22,
-    tokens_per_second: typeof L.lastTokPerSec === 'number' ? L.lastTokPerSec : 45.0,
+    // Respect an EXPLICIT null/0 clobber (e2e sets lastTokPerSec=null to test
+    // the hidden / MB/s-fallback paths); only default to 45.0 when ABSENT.
+    tokens_per_second: 'lastTokPerSec' in L ? L.lastTokPerSec : 45.0,
     prompt_tokens: 312,
     output_tokens: 188,
     input_tokens: 312,

--- a/ui/src/api/mock.ts
+++ b/ui/src/api/mock.ts
@@ -46,15 +46,14 @@ function buildHealth() {
 }
 
 function buildStats() {
-  // /v1/stats fallback (Phase 4, #326). Lemonade's real /v1/stats does
-  // not include `throughput_mbps` — throughput is sourced exclusively
-  // from /v1/health (see useLemondRollup). DO NOT synthesize
-  // `throughput_mbps: 0.0` here as a "completeness" gesture — the
-  // footer chip is gated to hide when null/0 and a synthetic zero
-  // would re-introduce the misleading "0.0 MB/s" the chip is hiding.
+  // /v1/stats fallback (Phase 4, #326). Reads lastTokPerSec from
+  // HAL0_DATA.lemond so e2e specs can clobber it via addInitScript
+  // (same pattern as lemond.throughput → buildHealth). (#340)
+  const d = data()
+  const L = d.lemond || {}
   return {
     time_to_first_token: 0.22,
-    tokens_per_second: 45.0,
+    tokens_per_second: typeof L.lastTokPerSec === 'number' ? L.lastTokPerSec : 45.0,
     prompt_tokens: 312,
     output_tokens: 188,
     input_tokens: 312,

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -482,18 +482,23 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
           <span className="v">{L.status}</span>
         </div>
         {/*
-          Throughput chip (#326): Lemonade does not yet surface
-          throughput_mbps on /v1/health for every backend. The rollup
-          coerces missing → null. Hide the chip entirely instead of
-          rendering "—" or "0.0 MB/s" — a value of 0 from a live system
-          actually serving traffic is just as meaningless as null.
+          Throughput chip (#340): prefer tok/s from /v1/stats (always
+          present on a serving backend) over throughput_mbps from
+          /v1/health (Lemonade omits it on most backends). Fall back to
+          MB/s only if lastTokPerSec is null. Both branches hide on
+          null/0 — a 0 from a live system is as meaningless as null.
         */}
-        {L.throughput != null && L.throughput > 0 && (
+        {L.lastTokPerSec != null && L.lastTokPerSec > 0 ? (
+          <div className="foot-chip">
+            <span className="k">throughput</span>
+            <span className="v num">{`${Math.round(L.lastTokPerSec)} tok/s`}</span>
+          </div>
+        ) : L.throughput != null && L.throughput > 0 ? (
           <div className="foot-chip">
             <span className="k">throughput</span>
             <span className="v num">{`${L.throughput} MB/s`}</span>
           </div>
-        )}
+        ) : null}
         {/* "models loaded N/budget" chip removed (2026-06-05) — the figure now
             lives in the sidebar Runtime widget's lemond row tooltip only. */}
         {L.coresident && (

--- a/ui/src/dash/data.jsx
+++ b/ui/src/dash/data.jsx
@@ -53,7 +53,8 @@ const HAL0_DATA = {
     version: "v10.6.0",
     loaded: 3,
     budget: 4,
-    throughput: 12.4, // MB/s
+    throughput: 12.4, // MB/s — fallback only; tok/s chip takes priority (#340)
+    lastTokPerSec: 45.0, // tok/s from /v1/stats (#340)
     queued: 0,
     coresident: true,
   },

--- a/ui/tests/e2e/fixtures/mock-data.ts
+++ b/ui/tests/e2e/fixtures/mock-data.ts
@@ -63,6 +63,7 @@ export const MOCK_DATA = {
     loaded: 3,
     budget: 4,
     throughput: 12.4,
+    lastTokPerSec: 45.0, // #340 tok/s chip
     queued: 0,
     coresident: true,
   },

--- a/ui/tests/e2e/specs/footer-throughput-chip-v3.spec.ts
+++ b/ui/tests/e2e/specs/footer-throughput-chip-v3.spec.ts
@@ -1,39 +1,41 @@
 /**
- * footer-throughput-chip-v3 — issue #326 (epic #322 Phase 4).
+ * footer-throughput-chip-v3 — issue #326 (epic #322 Phase 4), updated #340.
  *
- * The throughput chip in the footer used to render `${L.throughput} MB/s`
- * with a `—` fallback when Lemonade did not surface `throughput_mbps`.
- * That produced misleading "—" output (and would have produced "0.0 MB/s"
- * if any layer of the fallback chain ever defaulted to 0). The chip now
- * hides entirely when throughput is null or 0, matching the same null-
- * honoring discipline as queued + coresident (#221).
+ * #326: chip hid entirely when Lemonade omitted throughput_mbps.
+ * #340: chip now shows tok/s from /v1/stats (always present on a serving
+ *       backend) instead of the always-null MB/s field. MB/s remains as a
+ *       fallback in case lastTokPerSec is absent. Both branches hide on
+ *       null/0 — the same null-honoring discipline as queued + coresident
+ *       (#221).
  *
- * Spec runs against MOCK_LEMONADE-forced dev. `buildHealth` round-trips
- * HAL0_DATA.lemond.throughput so we can drive the three states by
- * clobbering HAL0_DATA before the dash modules read it.
+ * Spec runs against MOCK_LEMONADE-forced dev. `buildStats` round-trips
+ * HAL0_DATA.lemond.lastTokPerSec (added #340) and `buildHealth` round-trips
+ * HAL0_DATA.lemond.throughput, so we can drive all states by clobbering
+ * HAL0_DATA before the dash modules read it.
  */
 import { test, expect } from '../fixtures/apiMock'
 
-test.describe('Footer throughput chip hides on missing/zero (#326)', () => {
-  test('renders "12.4 MB/s" when health surfaces a positive throughput', async ({ page }) => {
+test.describe('Footer throughput chip shows tok/s (#326, #340)', () => {
+  test('renders "45 tok/s" when /v1/stats surfaces a positive tok/s', async ({ page }) => {
     await page.goto('/')
     const footer = page.locator('.footer')
     await expect(footer).toBeVisible()
-    // Wait for the 2s health poll to land — sidebar version row is a
+    // Wait for the 5s stats poll to land — sidebar version row is a
     // good proxy for "rollup data has propagated".
-    await expect(page.locator('[data-testid="runtime-row-lemond"] .v', { hasText: /v\d/ })).toBeVisible({ timeout: 6_000 })
+    await expect(page.locator('[data-testid="runtime-row-lemond"] .v', { hasText: /v\d/ })).toBeVisible({ timeout: 8_000 })
 
     const throughputChip = footer.locator('.foot-chip', { has: page.locator('.k', { hasText: /^throughput$/ }) })
     await expect(throughputChip).toBeVisible()
-    // HAL0_DATA seeds throughput=12.4.
-    await expect(throughputChip.locator('.v')).toHaveText('12.4 MB/s')
+    // HAL0_DATA seeds lastTokPerSec=45.0 → chip shows "45 tok/s".
+    await expect(throughputChip.locator('.v')).toHaveText('45 tok/s')
   })
 
-  test('chip hidden when health omits throughput_mbps', async ({ page }) => {
+  test('chip hidden when both lastTokPerSec and throughput_mbps are null', async ({ page }) => {
     await page.addInitScript(() => {
       const id = setInterval(() => {
         const d = (window as any).HAL0_DATA
         if (d && d.lemond) {
+          d.lemond.lastTokPerSec = undefined
           d.lemond.throughput = undefined
           clearInterval(id)
         }
@@ -43,21 +45,21 @@ test.describe('Footer throughput chip hides on missing/zero (#326)', () => {
     await page.goto('/')
     const footer = page.locator('.footer')
     await expect(footer).toBeVisible()
-    await expect(page.locator('[data-testid="runtime-row-lemond"] .v', { hasText: /v\d/ })).toBeVisible({ timeout: 6_000 })
-    await page.waitForTimeout(2_500)
+    await expect(page.locator('[data-testid="runtime-row-lemond"] .v', { hasText: /v\d/ })).toBeVisible({ timeout: 8_000 })
+    await page.waitForTimeout(6_000)
 
     const throughputChip = footer.locator('.foot-chip', { has: page.locator('.k', { hasText: /^throughput$/ }) })
     await expect(throughputChip).toHaveCount(0)
   })
 
-  test('chip hidden when health reports throughput_mbps=0', async ({ page }) => {
+  test('chip hidden when both lastTokPerSec and throughput_mbps are zero', async ({ page }) => {
     // Zero from a live system that's actually serving traffic is just
-    // as meaningless as null — a "0.0 MB/s" badge in the footer would
-    // look like a metrics bug. Treat 0 as "no signal" and hide.
+    // as meaningless as null — treat 0 as "no signal" and hide.
     await page.addInitScript(() => {
       const id = setInterval(() => {
         const d = (window as any).HAL0_DATA
         if (d && d.lemond) {
+          d.lemond.lastTokPerSec = 0
           d.lemond.throughput = 0
           clearInterval(id)
         }
@@ -67,10 +69,33 @@ test.describe('Footer throughput chip hides on missing/zero (#326)', () => {
     await page.goto('/')
     const footer = page.locator('.footer')
     await expect(footer).toBeVisible()
-    await expect(page.locator('[data-testid="runtime-row-lemond"] .v', { hasText: /v\d/ })).toBeVisible({ timeout: 6_000 })
-    await page.waitForTimeout(2_500)
+    await expect(page.locator('[data-testid="runtime-row-lemond"] .v', { hasText: /v\d/ })).toBeVisible({ timeout: 8_000 })
+    await page.waitForTimeout(6_000)
 
     const throughputChip = footer.locator('.foot-chip', { has: page.locator('.k', { hasText: /^throughput$/ }) })
     await expect(throughputChip).toHaveCount(0)
+  })
+
+  test('falls back to MB/s when lastTokPerSec is null but throughput_mbps present', async ({ page }) => {
+    await page.addInitScript(() => {
+      const id = setInterval(() => {
+        const d = (window as any).HAL0_DATA
+        if (d && d.lemond) {
+          d.lemond.lastTokPerSec = undefined
+          d.lemond.throughput = 12.4
+          clearInterval(id)
+        }
+      }, 5)
+    })
+
+    await page.goto('/')
+    const footer = page.locator('.footer')
+    await expect(footer).toBeVisible()
+    await expect(page.locator('[data-testid="runtime-row-lemond"] .v', { hasText: /v\d/ })).toBeVisible({ timeout: 8_000 })
+    await page.waitForTimeout(6_000)
+
+    const throughputChip = footer.locator('.foot-chip', { has: page.locator('.k', { hasText: /^throughput$/ }) })
+    await expect(throughputChip).toBeVisible()
+    await expect(throughputChip.locator('.v')).toHaveText('12.4 MB/s')
   })
 })


### PR DESCRIPTION
Closes #340

Switch footer throughput chip from always-null `throughput_mbps` (Lemonade omits it) to `lastTokPerSec` from `/v1/stats`, which is always populated on a serving backend. MB/s retained as fallback. `buildStats()` now reads `HAL0_DATA.lemond.lastTokPerSec` for e2e controllability; spec updated with tok/s assertion + fallback + zero-hide tests.