### PR TITLE
v0.5 brain: Hindsight engine swap (P0–P2, gated)

### DIFF
--- a/docs/internal/brain-redesign/09-hindsight-engine-swap-refresh-2026-06-06.md
+++ b/docs/internal/brain-redesign/09-hindsight-engine-swap-refresh-2026-06-06.md
@@ -1,0 +1,504 @@
+# 09 — Hindsight Engine Swap + Hermes Convergence (Refresh)
+
+**Status:** DECISION-RESOLVED SPEC. Refreshes docs 00–08 against current state and
+locks the decisions needed to ship. Supersedes the *engine-swap* portions of doc 06/07
+(Phases 0–2 + the Hermes slice of Phase 5); the wiki tier (06 §5, 07 Phases 3/4/6) is
+explicitly out of scope here and the earlier docs stand unchanged for it.
+**Date:** 2026-06-06.
+**Milestone:** **v0.5 brain re-enablement** — ends with `HAL0_MEMORY_ENABLED=1`, running
+Hindsight, Hermes and the platform sharing one brain.
+**Reads against:** 06 (architecture), 07 (roadmap), 03 (as-built audit), 05 (landscape),
+plus auto-memory `hal0_hindsight_hermes_spike`, `hal0_0.4_memory_gated_off`,
+`hermes_home_migration_splitbrain_2026-06-04`.
+
+---
+
+## 0. Why this refresh exists
+
+Docs 00–08 were written 2026-06-02 as *planning, pre-grilling*. Two things have
+happened since that reshape the engine-swap plan, and a "don't reinvent the wheel"
+review (2026-06-06) re-validated the engine choice against the current field. This
+doc folds all three in and resolves the open forks for the engine swap so it can go
+straight to an implementation plan.
+
+### What changed since 2026-06-02
+
+1. **Memory shipped OFF.** v0.4 (PR #492) gates the whole subsystem behind
+   `HAL0_MEMORY_ENABLED` (default `0`). The platform brain is **dark today**, waiting
+   for exactly this redesign. Consequence: there is **no live Cognee traffic to
+   regress**, which is what lets us relax the eval gate (D2) and probably makes the
+   Cognee→Hindsight data migration a near-no-op (verify on-box, §7).
+2. **The Hermes Hindsight spike happened** (2026-06-04, auto-memory
+   `hal0_hindsight_hermes_spike`). Hindsight already runs on CT 105 — but **inside
+   Hermes' venv** (`mode: local_embedded`, bank `hermes`, extraction →
+   `qwen3-it-4b-FLM` on the NPU via lemond:13305). This de-risks deployment (we have
+   real operational config) **but** points at *two* Hindsight installs unless we
+   converge (D1, P5-H).
+3. **Build-vs-adopt review.** A fresh mid-2026 landscape scan (14 systems) + a
+   deep-dive of the Hermes-specific `ClaudioDrews/memory-os` confirmed: we are **not**
+   reinventing the wheel — Hindsight *is* the off-the-shelf wheel, and it wins on
+   merits, not incumbency (§2).
+
+---
+
+## 1. Build / Adopt / Cut
+
+The refresh **shrinks** the custom surface. The headline: don't build a memory engine,
+adopt one; build only the thin, mandatory trust seam in front of it.
+
+| | Decision | Why |
+|---|---|---|
+| **Adopt off-the-shelf** | **Hindsight** as the engine — native MCP (`/mcp`) + REST (`:8888`) + embedded Postgres + consolidation, all in one process, fully local. | Wins the 2026 landscape scan (§2). |
+| **Build — thin, justified** | `MemoryProvider` ABC + `HindsightProvider` + the `X-hal0-Agent`→bank **ACL shim**, behind hal0's *existing* `/mcp/memory` + `/api/memory/*` front door. | The ACL shim is **mandatory** (Hindsight has no per-caller→bank enforcement, §3). The ABC doubles as **anti-lock-in insurance** (Mem0 is a real Apache-2.0 #2). |
+| **Adopt the *idea*, not the code** | A **ground-truth precedence** stanza (Memory-OS Layer 7) in Hermes' identity docs, refined for a shared brain. | Makes the agent *trust* recalled memory; ~10 lines, not a subsystem (§4). |
+| **Cut / defer** | The custom **wiki tier + gated promotion** (06 §5, 07 P3/P4/P6). | Out of scope for v0.5; Memory-OS confirms the auto-wiki is the fragile, unproven part. The dossier stands for a later milestone. |
+| **Don't carry** | The FLM-schema **wrap-patch** hack from the spike. | Route to an upstream fix (grammar-constrained extraction or a larger extraction model) per the standing "third-party official fix first" rule (§6, [Q5']). |
+
+---
+
+## 2. Engine decision: Hindsight (confirmed on merits)
+
+The mid-2026 scan scored every candidate against hal0's hard constraints: fully local
+/ no-CUDA on Strix Halo; exposes **MCP and/or REST** so multiple consumers share one
+brain; multi-agent namespacing; episodic→semantic **consolidation** (not naive
+append-only RAG); and — decisive for this hardware — its **core function must not depend
+on reliable structured-JSON from a <32B local model**.
+
+**Hindsight is the only candidate that satisfies all of them at once:** one process
+exposes both REST and a native MCP server, runs against a local OpenAI-compatible
+gateway with CPU embed + CPU cross-encoder rerank, light footprint (FastAPI + embedded
+Postgres), real consolidation (facts → observations → auto-updating mental models), and
+**recall runs with zero LLM** — so a weak extraction model degrades *ingest quality* but
+never *breaks retrieval*. MIT-licensed.
+
+**Runners-up and why they lose here:**
+- **Mem0** (Apache-2.0, ~58k★, OpenMemory MCP) — the one credible alternative; real
+  ADD/UPDATE/DELETE consolidation. **Documented as the sanctioned fallback** behind the
+  ABC. Pick it only if Hindsight's small-startup backing becomes a risk.
+- **Graphiti / Cognee** — disqualified for *this hardware*: both self-admit ingest
+  fails / emits bad schemas without structured-output models — hal0's exact failure mode.
+- **Supermemory** — cloud-gated (self-host is enterprise-only).
+- **Letta** — an MCP *host* with agent-centric memory, not a neutral memory *server*.
+- **`ClaudioDrews/memory-os`** (the Hermes-specific 7-layer system) — **validates the
+  design but is not adoptable**: no MCP/REST (Hermes-plugin-only), dense embeddings
+  hardcoded to a cloud provider (OpenRouter), no multi-agent namespacing, 6 days old,
+  no tests/benchmarks. Treat as a *reference architecture / parts bin* (we take its
+  Layer-7 idea, §4).
+
+> **Plan stays engine-neutral in structure** (the ABC), but **Hindsight is THE engine**.
+> The seam is what makes "are we over-building?" answer itself: it's the not-reinventing-
+> the-wheel insurance that lets us swap engines without touching a single consumer.
+
+---
+
+## 3. Architecture: one front door, one shared engine, a mandatory trust seam
+
+```
+   Hermes        external Claude Code      pi-coder        dashboard
+     │ (hal0-memory plugin)   │ (MCP)         │ (MCP)         │ (REST)
+     └───────────────┬────────┴───────────────┴───────────────┘
+                     ▼
+        hal0-api  ──  THE ONE FRONT DOOR
+          /mcp/memory   +   /api/memory/*          (unchanged contract)
+          │
+          │  namespace.py:  server-trusted  X-hal0-Agent / Bearer  →  allowed banks
+          │                 (ACL: read own private + shared, never another's private)
+          ▼
+        MemoryProvider (ABC)  ──►  HindsightProvider   [fallback: Mem0Provider, PgVectorProvider]
+                                        │
+                                        ▼
+        ONE shared hindsight-api  (systemd unit on CT 105, embedded pg0)
+          banks:  shared · private:<agent> · project:<id> · agents · hermes
+```
+
+### D1 — Topology: ONE shared platform-owned `hindsight-api`
+
+A single `hindsight-api` systemd unit on CT 105 (embedded pg0 under
+`/var/lib/hal0/memory/hindsight/`). The platform MCP **and** Hermes both point at it;
+**banks** provide isolation. Rationale: re-pointing Hermes (the chosen scope) only buys
+the "one brain" story against a shared instance; one store = one backup, one HF cache,
+one upgrade/wrap surface. Cost: migrate the spike's in-venv `hermes` bank into the
+shared store and retire `local_embedded` (P5-H).
+
+### The ACL shim is mandatory — isolation ≠ authorization
+
+Be precise here, because Hindsight *does* ship real isolation primitives and it's easy to
+mistake them for access control. Hindsight has **two** isolation layers: **banks**
+(`developer/api/memory-banks.md`: *"Banks are completely isolated from each other —
+memories stored in one bank are not visible to another"*) and **tenants** (separate DB
+schemas, e.g. `tenant_acme`). What it does **not** ship is an **authorization policy** —
+a rule mapping *a given caller* to *the banks it may address*. The two are different:
+
+- **Isolation** (banks/tenants do this): bank A's data can't leak into bank B. ✅
+- **Authorization** (not shipped): *which* caller may open *which* bank.
+
+Evidence (`developer/mcp-server.md` + `memory-banks.md`): the MCP server at `/mcp` is
+**open by default**; enabling auth gives a **single server-wide API key**
+(`HINDSIGHT_API_TENANT_API_KEY`), and the **bank is caller-chosen** via the
+`/mcp/{bank_id}/` path or an `X-Bank-Id` header. `mcp_enabled_tools` is a per-bank tool
+allowlist *for everyone on that bank*, not per-caller. Tenants are all-or-nothing
+separate schemas, so they **can't** express hal0's "agents share `shared` but isolate
+`private:*`" (mapping each agent to a tenant would sever the shared bank). Net: a holder
+of the one key can set `X-Bank-Id: private__hermes` and read Hermes' private memory —
+bank isolation only stops Hermes' bank from bleeding into *another* bank, not from being
+*opened* by another caller.
+
+hal0's rule — *"an agent reads its own private + `shared`, never another agent's
+private"* — is a **cross-bank policy within one tenant** that neither primitive enforces.
+`namespace.py` already implements it: it resolves a **server-trusted** `X-hal0-Agent`/
+Bearer identity into the allowed banks (fail-open-empty on foreign private). **That
+policy must be hal0-authored regardless of engine.** It can live in **either** place:
+- **(recommended) the hal0-api front door** — reuses `namespace.py`, and also carries the
+  `HAL0_MEMORY_ENABLED` gate, the stable `/api/memory/*` + `/mcp/memory` contract, and the
+  new `recall` route. One trusted choke point.
+- **a custom Hindsight `TenantExtension`** — Hindsight's pluggable auth point; a Python
+  extension that reads the trusted identity and enforces the allow-list inside Hindsight's
+  process. Viable, but it's net-new code to write/maintain in-engine and it wouldn't cover
+  the gate/contract/recall-route, so the front door is the better home.
+
+Either way, "just point consumers at Hindsight's native MCP with no hal0 layer" is unsafe
+for multi-agent — the thin shim earns its keep.
+
+> **Vendor confirmation.** Hindsight's *own* canonical multi-agent recipe
+> (cookbook `support-agent-shared-knowledge`) ships **no access control** — it
+> *"assumes a trusted caller,"* notes *"all users can theoretically read all banks if they
+> knew the bank IDs,"* and relies on *"logical separation, not cryptographic
+> enforcement."* It also does cross-bank reads as **client-side orchestration** (separate
+> `recall(bank_id=...)` per bank, merged in the client). Both points are by design, not a
+> gap — which is exactly why the trusted-identity→allowed-banks policy and the multi-bank
+> fan-out are hal0's job (front door + `HindsightProvider`), not the engine's.
+
+### Namespace → bank mapping (06 §4, unchanged resolver)
+
+| hal0 namespace | Hindsight bank |
+|---|---|
+| `shared` | `shared` |
+| `private:<agent>` | `private__<agent>` (`:`→`__`) |
+| `project:<id>` | `project__<id>` (auto-create on first use) |
+| `agents` | `agents` (identity cards, ADR-0011) |
+| Hermes' own | `private__hermes` + `shared` (see P5-H) |
+
+---
+
+## 4. The two senses of "source of truth"
+
+A shared brain has to win on **both**, and they're solved in different phases.
+
+### 4a. Storage source of truth (the engine swap, P0–2)
+
+Exactly one active memory provider holds the canonical memories. Enforced by:
+single-provider config, a verified data migration into the shared engine, and a
+one-release Cognee fallback flag. No background second store (see P5-H — we do **not**
+keep Hermes' default memory running).
+
+### 4b. Cognitive source of truth — ground-truth precedence (Memory-OS Layer 7)
+
+The engine swap does **not** make an agent *use* what it recalls. Memory-OS's Layer 7
+documents the failure: an agent ignores injected memory and re-derives via tool calls
+because "injected memory had no explicit rank." The fix is a precedence ladder in the
+agent's identity docs. **We adopt the idea, refined for a shared (poisoning-exposed)
+brain** — hard rules sit *above* recalled memory, not below it:
+
+1. **Safety / identity rules** (SOUL, rulebook, CLAUDE.md-class) — never overridden by a recalled memory
+2. **Live system / tool state** (terminal, tool output)
+3. **Recalled memory (shared brain)** — authoritative for project knowledge/decisions, **above model priors**
+4. **Official documentation** — wins for version-specifics
+5. **Training priors** — reference only; always verify
+
+This **decomposes onto features we already have**: Hindsight **directives**
+(priority-ordered bank instructions) + **mental models** (checked first) provide the
+*within-memory* ranking; Hermes' **SOUL.md** provides the *rules-vs-memory* ranking. So
+it is a ~10-line stanza (P5-H), not a new subsystem. Same idea later extends to external
+consumers via the MCP tool descriptions / a context note (deferred).
+
+---
+
+## 5. Resolved decisions (index)
+
+| # | Decision |
+|---|---|
+| Scope | Refresh the dossier into a decision-resolved roadmap. |
+| Boundary | **Phases 0–2 + the Hermes-convergence slice of Phase 5.** Wiki/promotion deferred. |
+| Engine | **Hindsight** (adopted). Mem0 = documented fallback behind the ABC. |
+| **D1 Topology** | **One shared platform-owned `hindsight-api`** on CT 105; banks isolate; Hermes re-points onto it. |
+| **D2 Eval gate** | **Relaxed** to conformance + a recall **sanity** check on a seeded fixture corpus (no graded δ-eval, and no Cognee "parity" baseline — the platform store is expected empty). Brain is OFF — nothing to regress; spike proved operability; we adopt for the consolidation upgrade path, not a benchmark margin. |
+| **D3 Wiki** | **Cut** from this milestone. |
+| Front door | Keep `/mcp/memory` + `/api/memory/*` with `MemoryProvider` ABC + `HindsightProvider` + ACL shim behind it. |
+| Source of truth | **Storage** (single provider + migration, P0–2) **and cognitive** (Layer-7 precedence stanza, P5-H). |
+| Wrap-patch | Don't carry — route to upstream fix ([Q5']). |
+
+---
+
+## 6. Phase plan (4 slices, each leaves `main` shippable)
+
+### P0 — Seam & safety net  *(unchanged from 07 Phase 0; no gate, ships clean)*
+
+**Goal.** Promote the implicit five-method `CogneeWrapper` contract into an explicit
+`MemoryProvider` ABC + parametrized conformance suite, route the one construction site
+(`api/__init__.py:1108`) through a `provider_from_config(cfg)` factory, and fix the
+latent Hermes `_client.py` 404. **Zero behaviour change** — Cognee stays the only live
+engine.
+
+**Work items.**
+- `src/hal0/memory/provider.py` — ABC + value types (06 §3): `MemoryItem`,
+  `AddResult`, `ListPage`, `DeleteResult`, `GraphStatus`, `Mode`; core five
+  `add/search/list_items/delete` + `graph_status/set_graph_enabled/set_rerank_enabled`;
+  optional `recall/reflect/consolidate/register_compiled` with safe defaults. Core five
+  **byte-compatible** with `CogneeWrapper` (audit §5) so no call site changes.
+- `CogneeWrapper(MemoryProvider)` — declare conformance, no logic change.
+- `provider_from_config()` in `src/hal0/memory/__init__.py` — returns
+  `CogneeWrapper(...)` for now; engine branch added in P1.
+- `PgVectorProvider` stub — third conformance implementation + P2 boot fallback.
+- `tests/memory/test_provider_contract.py` — parametrized suite asserting namespace
+  isolation, `private:` write rejection, tag-AND, date-range, delete semantics,
+  fail-open-empty foreign-private read, and the `graph_status()` payload shape.
+- Fix `src/hal0/agents/hermes/plugins/memory_cognee/_client.py` 404s (audit §4.2):
+  `list_items` → `GET /api/memory/list`; `delete` → `POST /api/memory/delete` with
+  `{ids}`. Add a route-path test against the real router.
+- CI: wire the contract suite into the **default** gate; run `ruff format --check`.
+
+**Exit.** Contract suite green for Cognee + PgVector + fakes; app boots; `add→search→
+list→delete` byte-identical to pre-change over both transports; `_client.py` route test
+green. **Rollback:** revert the one construction line. **Risk:** low, no open-Q.
+
+### P1 — Deploy Hindsight for real (not shadow) + parity smoke
+
+**Goal.** Stand up the **one shared** `hindsight-api`, implement `HindsightProvider`
+against the ABC, wire embed/rerank/extraction to existing hal0 slots, and validate with
+conformance + a recall **sanity** check on a seeded fixture corpus. (D2 relaxed the 07
+δ-eval gate; this is a *real* deploy, not a dark shadow install, because there's no live
+Cognee to shadow.)
+
+**Work items.**
+- **Deploy `hindsight-api`** as a systemd unit beside lemond. Data root
+  `/var/lib/hal0/memory/hindsight/` with **embedded pg0** (not a separate PG daemon).
+  Fold in the spike's hard-won config (auto-memory `hal0_hindsight_hermes_spike`):
+  - **Writable `HF_HOME`** (default HF cache symlinks to read-only `/mnt/ai-models` and
+    dies downloading `bge-small-en-v1.5`) — point at a hal0-writable dir.
+  - **Non-empty `llm_api_key`** placeholder (empty key crash-loops the daemon even for
+    no-auth lemond) — `"lemonade-local-noauth"`.
+  - **Dynamic-port awareness** — the daemon may not bind the documented default; capture
+    the actual port / pin it.
+- **Wire to slots** (06 §4):
+  - Embeddings → the **embed capability slot** (OpenAI-compatible/TEI). **Record the
+    slot's actual model + dim now**; if ≠ Cognee's `bge-small-en-v1.5` (384-d), a
+    re-embed on cutover is required ([Q4], assume CPU, validate).
+  - Rerank → the **`:8086` rerank slot** (`bge-reranker-v2-m3`) via Hindsight's external
+    reranker provider; fallback to its CPU MiniLM cross-encoder or pure RRF.
+  - Extraction LLM → `HINDSIGHT_API_LLM_PROVIDER=openai` →
+    `HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:13305` (lemond). Use an **instruct**
+    model (spike: `qwen3-it:4b` works ~45–90s; reasoning/rambling small models time out).
+- **`src/hal0/memory/hindsight_provider.py`** — core five + `recall` (real TEMPR
+  token-budgeting), `reflect`, `consolidate`, `register_compiled`. **Engine owns its
+  filtering** — map hal0 `tags`→Hindsight tag filter, dataset→bank, date-range→engine
+  (retire the SQLite sidecar as the filter source). `MemoryItem.id` is the join key.
+- **Multi-bank recall fan-out (net-new — Hindsight has no server-side cross-bank query).**
+  A hal0 recall expects results from the caller's **own `private:*` + `shared`** (+ any
+  `project:*`) *together*, but Hindsight recall is **per-bank, client-orchestrated** — its
+  own shared-knowledge recipe calls `recall(bank_id=...)` once per bank and **merges
+  client-side** (cookbook: `support-agent-shared-knowledge`). So `HindsightProvider.recall`
+  /`search` must: resolve the caller's allowed banks (the ACL seam already does this) →
+  **fan out parallel `recall` calls** → **merge under one token budget**. Merge *ordering*
+  follows the §4b precedence ladder (curated/`shared` mental-models + observations ranked
+  above raw private facts), tying recall back to the ground-truth hierarchy. Decide the
+  cross-bank merge strategy (concatenate-by-score vs re-rank the union via the `:8086`
+  reranker) and pin it in the conformance suite.
+- **`provider_from_config`** gains `engine = "cognee" | "hindsight" | "mem0" | "pgvector"`
+  (default still **cognee** in P1) + a degrade ladder: Hindsight unavailable at boot →
+  pgvector/no-op, tools return `available:false`, dashboard shows "no engine".
+- **[Q5'] Upstream fix for the FLM schema gap, not the wrap-patch.** The spike's
+  `local_embedded` extraction needed a one-line tolerance patch because FLM ignores
+  `response_format` and returns a bare list, not `{"facts":[...]}`. For the platform
+  instance, resolve this the standard way **before** relying on extraction:
+  (a) grammar-/schema-constrained extraction via lemond if available, or
+  (b) a larger instruct extraction model that honors the schema, or
+  (c) if a tolerance shim is unavoidable, file it upstream and pin the version — do not
+  carry an unversioned in-tree patch.
+
+**Exit (two-part, no graded eval).**
+1. **Conformance:** `HindsightProvider` + runnable `PgVectorProvider` pass
+   `test_provider_contract.py` unmodified; `hindsight-api` boots as a unit; pg0 persists
+   across restart; embed/rerank/extraction health-checked against the right slots.
+2. **Recall sanity:** seed a small fixture corpus, then a fixed query set returns sane,
+   on-topic results with acceptable latency (sanity, not benchmark; no Cognee baseline to
+   compare against). Recorded, not gated on a delta.
+
+**Rollback.** Nothing flipped — stop/mask the unit; default still Cognee; Hindsight data
+root is isolated. **Risk:** [Q4] re-embed if embed model differs; [Q5'] extraction
+quality tracks the local model (designed for recall-without-LLM so it degrades, not
+breaks).
+
+### P2 — Cutover + re-enable the gate
+
+**Goal.** Flip the default to Hindsight, map namespaces→banks behind the ACL shim,
+migrate any existing Cognee/sidecar data, **turn memory back on**
+(`HAL0_MEMORY_ENABLED=1`), and keep Cognee behind a one-release fallback.
+
+**Work items.**
+- Implement + test the bank mapping (§3 table) in `HindsightProvider`; the
+  `namespace.py` resolver is unchanged, now mapping to banks.
+- **Migration ([Q10] — likely small).** The platform Cognee store has been dark (memory
+  OFF since v0.4), so **first measure** (§7): if the store + sidecar are empty/stale,
+  migration is a **no-op** and the risk evaporates. If non-empty: a `hal0 memory migrate
+  --dry-run` reports rows mapped/unmapped, then a live copy-into-Hindsight + verify
+  (count + spot recall parity). Cognee data stays read-only during migration.
+- Flip `provider_from_config` default → `hindsight`; rename `app.state.memory_wrapper`
+  → `app.state.memory_provider` across readers.
+- **Expose `recall`/`retain` on the front door (net-new — do not skip).** `/api/memory/*`
+  + `/mcp/memory` are the **Cognee-era CRUD contract** (`add/search/list/delete`).
+  Hindsight's value is `recall` (TEMPR, token-budgeted, observation hierarchy) and
+  `retain` (extraction → consolidation). If consumers keep calling `search`/`add`,
+  `HindsightProvider.recall`/`retain` are never reached and the milestone silently ships
+  "a better vector store" instead of the upgrade. So: **add a `recall` route**
+  (`POST /api/memory/recall` + an MCP `recall` tool) the plugins call, and **confirm
+  `HindsightProvider.add` routes to `retain`** (so background consolidation fires) rather
+  than a dumb insert. `search` stays for back-compat; `recall` is the new preferred path.
+- **Flip `HAL0_MEMORY_ENABLED=1`** (api.env + systemd) — backend re-inits, `/api/status`
+  `memory_enabled` flips, dashboard nav returns. *(New deliverable — the gate didn't
+  exist when the dossier was written; auto-memory `hal0_0.4_memory_gated_off`.)*
+- Fallback flag `[memory] engine = "cognee"` reverts for one release; Cognee +
+  `cognee_wrapper.py` stay in-tree (deletion deferred).
+- Retire the sidecar as the filter source once verify passes.
+
+**Exit.** Migration within agreed loss threshold (or no-op); default boot uses Hindsight;
+`add/search/list/delete` green over both transports; namespace isolation + `private:`
+rejection + foreign-private fail-open-empty pass against the live engine; the gate is
+ON; the fallback flag cleanly reverts to the untouched Cognee store. **Rollback:** set
+`engine = "cognee"` + restart → instant revert (Cognee never mutated).
+
+### P5-H — Hermes convergence (the Hermes slice of 07 Phase 5)
+
+**Goal.** Make Hermes use the **one shared** brain as its single source of truth — both
+storage and cognitive — and **retire the spike's `local_embedded` instance**. Answers
+the two convergence questions directly.
+
+**Do we switch Hermes back to its default memory in the background? → NO.** Two systems
+both capturing recreates the dual-source drift we're eliminating. Exactly one active
+provider; Hermes' generic built-in memory stays off.
+
+**How do we force the new one as source of truth? → both halves:**
+
+*Storage:*
+- Set Hermes `config.yaml` `memory.provider` to the **`hal0-memory`** plugin (the
+  renamed `hal0-cognee`/`memory_cognee` plugin that already talks to hal0-api
+  `/api/memory/*`). One active provider = one source. Hermes memory now flows
+  `hal0-memory plugin → /api/memory/* (ACL + namespace) → HindsightProvider → shared
+  hindsight-api`, landing in `private:hermes` + `shared` — *inside* the unified
+  namespace, not a sibling bank. (Routing through hal0-api, not direct-to-Hindsight,
+  preserves the single ACL'd front door.) **Depends on the P2 `recall` route** — the
+  plugin must call `recall`, not `search`, or Hermes gets the storage swap without the
+  recall/consolidation upgrade.
+- **Retire `local_embedded` — TWO respawn guards, flip provider FIRST (probe-confirmed
+  2026-06-06).** The spike is *dormant, not retired*: `provider: hindsight` is still set
+  (`$HERMES_HOME/config.yaml:315`) and the embedded **Postgres 18.1.0** (pid orphaned to
+  init, `127.0.0.1:5432`) is still up, so **any** retain/recall lazily respawns pg +
+  `hindsight-api` via `hindsight_embed/daemon_embed_manager.py`. [Q8] is real and needs
+  **both** guards removed: **(a) flip `memory.provider` off *first*** (revert backups exist:
+  `config.yaml.bak-pre-hindsight-*`) **and (b) `pip uninstall hindsight-embed`** (+
+  `hindsight-all/-api-slim/-client`). Then remove `$HERMES_HOME/hindsight/config.json`; the
+  `20-hindsight.conf` drop-in (**keep `21-hermes-subpackages.conf`** — unrelated) +
+  `daemon-reload`; the two `/usr/local/sbin/hal0-hindsight-*-patch.py` ExecStartPre scripts;
+  **explicitly stop the orphaned pg** (reparented to init — restarting the hermes unit won't
+  kill it) and delete `/var/lib/hal0/.pg0` (61 MB) + `.hermes/hf-cache` (216 MB). The exact
+  ordered command checklist lives in the plan (task `P5H-RETIRE`).
+- **Start fresh — no data migration (decided 2026-06-06).** Abandon the spike's embedded
+  `hermes` bank rather than migrating it. Hermes begins accumulating into the shared
+  instance's `private:hermes` + `shared` banks from zero (banks auto-create on first use).
+  **Accepted trade-off:** lose ~2 days of low-value spike memories (rough wrap-patch / NPU
+  extractions) in exchange for a clean cutover with **zero pg-level schema/version-compat
+  risk**. The spike's embedded pg is left orphaned, then removed via the retirement
+  checklist below. (This is why the [Q10]/`hermes`-bank-migration risk drops out of the
+  plan: there is no migration vehicle to get wrong.)
+- **Lock the canonical config** (`HERMES_HOME=/var/lib/hal0/.hermes/config.yaml`) against
+  the root-clobber regression (spike gotcha #5 / `hermes_home_migration_splitbrain`):
+  running hermes as root rewrites `config.yaml` `root:root 0600` and silently falls back
+  to the default provider. Keep the self-guarding `/usr/local/bin/hermes` wrapper; verify
+  ownership stays `hal0:hal0`.
+- Wire recall depth: `Hal0…Provider.prefetch(query)` → `recall(types=['observation',
+  'world'], max_tokens=…)` instead of flat `search(limit=5)`; `sync_turn`/`on_memory_write`
+  → Hindsight `retain` (background consolidation now actually runs).
+
+*Cognitive (Layer-7 precedence):*
+- Add the **ground-truth precedence stanza** (§4b ladder) to Hermes' **SOUL.md**, and
+  encode the within-memory ranking as Hindsight **directives** on the `hermes`/`shared`
+  banks (and a top-priority mental model if useful). This is what makes Hermes *trust*
+  the recalled block instead of re-deriving — the cognitive half of "source of truth."
+
+**Exit.** Hermes runs with a single `hal0-memory` provider; the `local_embedded` install
+is gone (no second daemon, no wrap-patch, embedded pg retired); Hermes' `private:hermes`/
+`shared` banks exist in the shared instance and accept new writes (**started fresh** — no
+spike data carried over); a live turn shows `prefetch` returning a recalled block that
+Hermes acts on (no redundant re-discovery); `config.yaml` survives a root TUI session
+without clobber.
+**Rollback:** per-surface — provider can revert; the SOUL.md stanza is additive.
+
+---
+
+## 7. On-box pre-flight checklist (run before P2; read-only)
+
+Grounds the migration/re-embed sections in real numbers instead of TBDs.
+
+1. **Platform Cognee/sidecar row counts** — is `/var/lib/hal0/memory/cognee` + the
+   `hal0_memory_index.sqlite` sidecar empty/stale? If yes → migration is a **no-op**
+   (likely, given memory has been OFF since v0.4).
+2. **Embed-slot model + dim** vs Hindsight's expectation — if ≠ `bge-small-en-v1.5`
+   (384-d), schedule a re-embed ([Q4]).
+3. **Hermes plugin remote mode / `:9077`** — confirm the upstream Hindsight plugin can be
+   removed cleanly and that nothing re-spawns a daemon once `local_embedded` is gone ([Q8]).
+4. **Spike `local_embedded` retirement surface** — ✅ *answered 2026-06-06* (probe).
+   Exact ordered removal + the two-guard respawn ([Q8]) are in the P5-H retire bullet and
+   plan task `P5H-RETIRE`. We start fresh — no data migration — so the embedded pg's
+   contents don't matter, only that it's cleanly retired.
+5. **Hindsight version pin** — ✅ *answered 2026-06-06* (probe). Spike venv:
+   `hindsight-all/-api-slim/-embed 0.7.2`, `hindsight-client 0.6.1`, embedded **Postgres
+   18.1.0**, alembic head **`c1d2e3f4a5b6`**. Pin the shared platform `hindsight-api` to
+   **0.7.x** (same alembic head) for a known schema; record [Q5'] extraction behaviour.
+   Storage on this build = single `public` schema + `bank_id` discriminator (a tenant-schema
+   model also exists — relevant only if the shared instance is multi-tenant).
+
+---
+
+## 8. Deferred (still open; not blocking this milestone)
+
+- **Wiki tier + gated promotion** (06 §5, 07 P3/P4/P6) — the dossier stands; revisit
+  after v0.5 ships and real usage shows whether the engine's observations/mental-models
+  already cover the "curated knowledge" need (the YAGNI counter-case, 05 §3).
+  - **Lighter-weight candidate surfaced by the cookbook (`support-agent-shared-knowledge`):**
+    that recipe builds a curated shared-knowledge layer **purely with banks** — a separate
+    `support-learnings` bank that only accepts writes via an **explicit gated
+    `promote_learning()`** call (no auto-escalation), distinct from the raw `shared`
+    episodic bank. A hal0 analogue — a `shared-curated` (or `agents`-adjacent) bank fed
+    only through a gated `promote` route on the front door, recalled at the top of the §4b
+    hierarchy — could deliver "trusted, human-gated shared knowledge" **without** the
+    markdown wiki, the QMD→engine swap, or the promotion-to-pages pipeline. Evaluate this
+    against the full wiki tier before committing to Phase 3/4: it may collapse most of that
+    scope into "one more bank + one gated route." (Trade-off: loses the wiki's human
+    legibility/git-auditability — banks aren't a notebook a person reads/edits directly.)
+- **External-consumer Layer-7** — extend the precedence idea to external Claude Code via
+  MCP tool descriptions / a context note ([Q7] default-read posture).
+- **Bank-templates as a hal0 primitive** (06 §8) — persona-bound bank provisioning.
+- **Mem0 fallback** — implemented only if Hindsight's backing becomes a risk; the ABC
+  keeps the option open at near-zero standing cost.
+
+---
+
+## 9. Sources
+
+- Hindsight docs (local `hindsight-docs` skill): `developer/mcp-server.md` (MCP at `/mcp`,
+  open-by-default, single server-wide key, caller-asserted bank — the ACL-shim basis),
+  `developer/api/memory-banks.md` (bank/tenant isolation primitives; `mcp_enabled_tools`;
+  directives), `developer/api/*`, `references/best-practices.md`.
+- Hindsight cookbook: `recipes/support-agent-shared-knowledge`
+  (https://hindsight.vectorize.io/cookbook/recipes/support-agent-shared-knowledge) — the
+  vendor's canonical multi-agent pattern: per-agent private + shared + gated `learnings`
+  banks, **client-side** multi-bank recall, gated `promote_learning`, and an explicit
+  trusted-caller / no-access-control assumption. Basis for the §3 confirmation, the P1
+  fan-out work item, and the §8 banks-only curated-layer alternative.
+- Auto-memory: `hal0_hindsight_hermes_spike` (spike config + gotchas + wrap-patch),
+  `hal0_0.4_memory_gated_off` (the gate), `hermes_home_migration_splitbrain_2026-06-04`
+  (config clobber), `hal0_brain_redesign_planning_2026-06-02`.
+- Dossier docs 03 (audit), 05 (landscape), 06 (architecture), 07 (roadmap), 08 (grilling).
+- Build-vs-adopt review (2026-06-06): mid-2026 landscape scan (Hindsight/Mem0/Graphiti/
+  Cognee/Letta/txtai/Supermemory/MemoryOS/A-MEM/MIRIX/Memobase/Memori) + `ClaudioDrews/
+  memory-os` deep-dive (no MCP/REST, cloud embeddings, no namespacing — reference only)
+  + its `layers/07-ground-truth.md` (the Layer-7 precedence idea adopted in §4b).

--- a/docs/internal/brain-redesign/ops/hindsight-deploy.md
+++ b/docs/internal/brain-redesign/ops/hindsight-deploy.md
@@ -70,15 +70,47 @@ a P2 call, not part of this deploy.
   healthy. Cosmetic; silence later by pinning intra-op thread count if desired.
 - No CUDA errors (FORCE_CPU + no NVIDIA device → clean CPU path), no tracebacks.
 
-## [Q5'] FLM extraction schema gap
+## [Q5'] FLM extraction schema gap — RESOLVED (official, no patch)
 
-FLM ignores `response_format` (no grammar enforcement) → small models can free-form the
-fact-extraction output. Resolve the **official** way if it surfaces at P1-7, in order:
-(a) grammar/schema-constrained extraction via lemond if available,
-(b) a larger instruct model honoring `{"facts":[...]}`,
-(c) if a shim is unavoidable, file upstream + pin the version — do NOT carry the spike's
-unversioned in-tree wrap-patch.
-Status: _deferred until P1-7 retain→extract exercises it._
+Surfaced at the P1-7 retain smoke: `qwen3-it-4b-FLM` (NPU) ignores `response_format` and
+returns a bare JSON **list**; Hindsight's `fact_extraction` rejects it
+(`LLM returned non-dict JSON ... list`, 3× retry → `RuntimeError: Fact extraction failed`),
+~63s/attempt. There is NO official toggle in 0.7.2 (the spike patched `fact_extraction.py` —
+we do NOT carry that unversioned patch).
+
+**Official fix (ladder option b):** point the extraction LLM at a grammar-capable GGUF
+**instruct (non-reasoning)** model on lemond. Verified live:
+- `gemma-4-26b-a4b-it-q4kxl` → returns `{"facts":[...]}` dict ✅ (MoE a4b ≈4B active, fast; 16GB fits GTT)
+- `qwen3.5-4b-q4kxl` (reasoning) → empty content ✗ (reasoning models fail extraction, per spike)
+- `qwen3-it-4b-FLM` (NPU) → bare list ✗
+
+→ unit sets `HINDSIGHT_API_LLM_MODEL=gemma-4-26b-a4b-it-q4kxl`. Lighter alt to evaluate:
+`gemma-4-12b-it` (6.9GB, instruct).
+
+## Recall sanity (P1-7, recorded not gated)
+
+Live end-to-end on bank `smoketest` (deleted after):
+- RETAIN `POST /v1/default/banks/{bank}/memories` `{items:[{content,document_id}]}` →
+  `{success:true, items_count:1, usage:{...}}`, ~74s incl. gemma load.
+- RECALL `POST /v1/default/banks/{bank}/memories/recall` `{query,max_tokens}` → 0.7s,
+  `results` = 2 facts, both on-topic:
+  - "The hal0 memory engine was swapped from Cognee to Hindsight in version 0.5."
+  - "hal0 performs inference on a Strix Halo iGPU via Lemonade."
+
+## ⚠ Real 0.7.2 API paths (differ from plan + the P1-5 client — MUST fix before P2-5)
+
+Discovered via the live `/openapi.json`:
+| op | P1-5 client (WRONG) | real 0.7.2 |
+|---|---|---|
+| retain | `POST .../{bank}/retain` `{content,...}` | `POST .../{bank}/memories` `{items:[MemoryItem]}` |
+| recall | `POST .../{bank}/recall` | `POST .../{bank}/memories/recall` |
+| delete | `DELETE .../{bank}/documents/{id}` | ✅ same |
+
+MemoryItem: `{content* , document_id?, tags?, metadata?{str:str}, context?, timestamp?, ...}`.
+RetainRequest: `{items:[MemoryItem], async?, document_tags?}`. RecallRequest: `{query*, max_tokens?,
+types?, tags?, budget?, ...}`. Recall response: `{results:[...], trace, entities, chunks,
+source_facts}`. Retain response: `{success, bank_id, items_count, usage}`.
+→ `hindsight_client.py` (53ec956) corrected in follow-up commit.
 
 ## Rollback
 

--- a/docs/internal/brain-redesign/ops/hindsight-deploy.md
+++ b/docs/internal/brain-redesign/ops/hindsight-deploy.md
@@ -127,30 +127,37 @@ types?, tags?, budget?, ...}`. Recall response: `{results:[...], trace, entities
 source_facts}`. Retain response: `{success, bank_id, items_count, usage}`.
 → `hindsight_client.py` (53ec956) corrected in follow-up commit.
 
-## ⚠ Carry-forward — MUST handle when executing P2-5 (default flip) / P2-6 (gate on)
+## Carry-forward — status
 
-The plan's P2-5 task ("flip default engine → hindsight") does NOT mention these. Do them
-or the live brain ships broken:
+1. **Reranker wiring — DONE in P2-5 (290ccfe).** Factory's hindsight branch now constructs
+   `LemonadeReranker(url=embed.rerank_url, ...)` and passes it to `HindsightProvider`; the
+   §4b cross-bank UNION merge reranks via it. `_rerank_union` now gates on `_rerank_enabled`
+   so `set_rerank_enabled()` is a real toggle. Fail-soft: rerank down/evicted → `[]` → fused
+   order. Unit-tested (mock-transport + fail-soft). ⚠ **P2-6 ACTIVATION:** the rerank endpoint
+   is currently DORMANT — `:8086` refuses, lemond exposes no `/rerank` route, and the
+   `rerank` slot (`jina-reranker-v1-tiny-en-GGUF`, vulkan) is evicted/unbound (port 0). At
+   gate-on, bring up a llama.cpp-`/rerank` endpoint serving a reranker and point
+   `[memory.embedding] rerank_url` at it (and set `rerank_enabled=true`), THEN confirm §4b
+   rerank actually fires end-to-end (it's only unit-tested so far). Until then recall returns
+   fused (un-reranked) order — functional, just not §4b-ordered.
+   (Scope note: Hindsight's *own* per-bank recall can also rerank server-side via
+   `HINDSIGHT_API_RERANKER_*`; the hal0-side LemonadeReranker reranks the CROSS-BANK union,
+   a different scope — not double-ranking. For single-bank callers it's mildly redundant.)
+2. **Async retain still UNVERIFIED live.** Client sends `async:true` (`hindsight_client.py`);
+   the P1-7 smoke used sync. P2-5 wired the path but didn't exercise async end-to-end against
+   the daemon (the new provider+client code isn't deployed to /opt/hal0 yet — only unit-tested).
+   At the /opt/hal0 code deploy + gate-on, confirm a fire-and-forget retain lands + becomes
+   recallable.
+3. **iGPU eviction risk — RESOLVED 2026-06-07.** Extraction is on the NPU (`gemma3-4b-FLM`).
+   Remaining (minor): NPU extraction shares the NPU with the FLM asr/embed trio; confirm no NPU
+   contention under load at gate-on. Reverting to iGPU `gemma-4-26b-a4b-it` reinstates the risk.
 
-1. **Wire the reranker into the factory — PRECONDITION for P2-5, not a followup.** P2-1 routes
-   boot through `provider_from_config`, which builds `HindsightProvider(client=client)` with
-   `reranker=None`. The moment the default flips to hindsight, the §4b rerank merge (the
-   headline retrieval feature) is DEAD. At P2-5: construct a reranker (lemond's
-   `bge-reranker-v2-m3-q4_k_m`, confirmed present) and pass it into `HindsightProvider`, AND make
-   `set_rerank_enabled` gate on a field `_rerank_union` actually reads (currently it gates on
-   `_reranker is None`, the toggle flag is inert). Verify rerank fires end-to-end before calling
-   P2-5 done. (Note: Hindsight's own recall also reranks server-side via
-   `HINDSIGHT_API_RERANKER_*`; decide whether the §4b merge reranks the cross-bank UNION on the
-   hal0 side, or delegates — don't double-rerank blindly.)
-2. **Async retain is UNVERIFIED.** The P1-7 smoke used `async:false` (sync). The shipped client
-   (`hindsight_client.py`, 997c1ec) sends `async:true` so `add()` doesn't block ~60-90s on
-   extraction. Correct design, but the queued-extraction path was never exercised live — confirm
-   a fire-and-forget retain actually lands + becomes recallable before relying on it at P2-5.
-3. **iGPU eviction risk — RESOLVED 2026-06-07.** Extraction moved to the NPU
-   (`gemma3-4b-FLM`), so it no longer competes with the 35B primary on the iGPU. Remaining
-   (minor): NPU extraction shares the NPU with the FLM asr/embed trio + any NPU primary use;
-   confirm no NPU contention under load at gate-on. If reverting to iGPU `gemma-4-26b-a4b-it`,
-   the original eviction risk returns.
+## ⚠ Not yet deployed to the runtime
+
+P0–P2 code (incl. the P2-5 default flip + reranker) lives on `feat/hindsight-memory`, NOT in
+`/opt/hal0` (runtime runs old code). The hindsight-api **daemon** IS deployed. Activating the
+brain (P2-6) requires: deploy the branch code to /opt/hal0 (rebuild ui/dist per
+`hal0_ct105_deploy_rebuilds_ui`) + flip `HAL0_MEMORY_ENABLED=1` + bring up rerank (item 1).
 
 ## Rollback
 

--- a/docs/internal/brain-redesign/ops/hindsight-deploy.md
+++ b/docs/internal/brain-redesign/ops/hindsight-deploy.md
@@ -78,14 +78,29 @@ returns a bare JSON **list**; Hindsight's `fact_extraction` rejects it
 ~63s/attempt. There is NO official toggle in 0.7.2 (the spike patched `fact_extraction.py` —
 we do NOT carry that unversioned patch).
 
-**Official fix (ladder option b):** point the extraction LLM at a grammar-capable GGUF
-**instruct (non-reasoning)** model on lemond. Verified live:
-- `gemma-4-26b-a4b-it-q4kxl` → returns `{"facts":[...]}` dict ✅ (MoE a4b ≈4B active, fast; 16GB fits GTT)
-- `qwen3.5-4b-q4kxl` (reasoning) → empty content ✗ (reasoning models fail extraction, per spike)
-- `qwen3-it-4b-FLM` (NPU) → bare list ✗
+Models evaluated live:
+- `gemma-4-26b-a4b-it-q4kxl` (iGPU GGUF) → returns `{"facts":[...]}` dict ✅ but contends with the 35B primary on the iGPU.
+- `qwen3.5-4b-q4kxl` (iGPU, reasoning) → empty content ✗ (reasoning models fail extraction).
+- `qwen3-it-4b-FLM` (NPU) → bare list ✗.
 
-→ unit sets `HINDSIGHT_API_LLM_MODEL=gemma-4-26b-a4b-it-q4kxl`. Lighter alt to evaluate:
-`gemma-4-12b-it` (6.9GB, instruct).
+### FINAL CHOICE (2026-06-07): NPU extraction via `gemma3-4b-FLM`
+
+Moved extraction to the **NPU** to free the iGPU for the user-facing primary (kills the
+P2-6 eviction risk). Path-finding:
+- `gemma4-it:e2b` AND `gemma4-it:e4b` (NPU) → **BLOCKED**: `DRM_IOCTL_AMDXDNA_CREATE_HWCTX
+  err=-22` ("Alloc hw resource failed"). Both sizes fail identically → Gemma-3n NPU2 arch is
+  unsupported by the installed NPU stack (amdxdna `0.7`, NPU FW `1.1.2.65`, FLM `0.9.43`).
+  Needs a host NPU driver/firmware update to enable. ~16GB downloaded + parked at
+  `/var/lib/hal0/.config/flm/models/Gemma4-E{2,4}B-IT-NPU2/` for if/when that happens.
+- `gemma3-4b-FLM` (NPU) → **WORKS** ✅. gemma3 arch loads on this NPU. Emits a ```json-fenced
+  `{"facts":[...]}`; Hindsight's `fact_extraction` strips the fence + parses. Live retain+recall
+  green (2 on-topic facts, with temporal/entity enrichment).
+
+→ unit sets `HINDSIGHT_API_LLM_MODEL=gemma3-4b-FLM`, `LLM_TIMEOUT=300`.
+**Trade-off:** NPU extraction ~160s vs iGPU gemma-26b ~74s — but retain is async/background
+(client sends `async:true`), so latency doesn't block, and the iGPU stays free.
+**To switch back to iGPU** (faster extraction, accepts contention): set model to
+`gemma-4-26b-a4b-it-q4kxl`. **To get gemma4 on NPU:** update the host amdxdna driver/FW.
 
 ## Recall sanity (P1-7, recorded not gated)
 
@@ -131,12 +146,11 @@ or the live brain ships broken:
    (`hindsight_client.py`, 997c1ec) sends `async:true` so `add()` doesn't block ~60-90s on
    extraction. Correct design, but the queued-extraction path was never exercised live — confirm
    a fire-and-forget retain actually lands + becomes recallable before relying on it at P2-5.
-3. **gemma-26b extraction vs the primary model — P2-6 eviction risk.** Extraction +
-   background consolidation load `gemma-4-26b-a4b-it-q4kxl` on lemond. Under lemond's
-   serialized-load + nuclear-evict policy (`hal0_lemonade_gotchas`), a consolidation cycle could
-   evict the user-facing 35B primary mid-chat. Verify coexistence (both resident in GTT, no
-   evict) under load before/at gate-on, or pin slots / use a lighter extraction model
-   (`gemma-4-12b-it`, 6.9GB).
+3. **iGPU eviction risk — RESOLVED 2026-06-07.** Extraction moved to the NPU
+   (`gemma3-4b-FLM`), so it no longer competes with the 35B primary on the iGPU. Remaining
+   (minor): NPU extraction shares the NPU with the FLM asr/embed trio + any NPU primary use;
+   confirm no NPU contention under load at gate-on. If reverting to iGPU `gemma-4-26b-a4b-it`,
+   the original eviction risk returns.
 
 ## Rollback
 

--- a/docs/internal/brain-redesign/ops/hindsight-deploy.md
+++ b/docs/internal/brain-redesign/ops/hindsight-deploy.md
@@ -1,0 +1,86 @@
+# Shared `hindsight-api` deploy runbook (P1-6)
+
+Platform-owned Hindsight memory engine on CT 105 (10.0.1.142). One shared instance;
+banks isolate; Hermes re-points onto it in P5-H. Brain gate stays **OFF** until P2-6.
+
+## Pre-flight (read-only, 2026-06-06)
+
+| Check | Result |
+|---|---|
+| lemond | up, v10.6.0, `status:ok` on `:13305` |
+| extraction model `qwen3-it-4b-FLM` | present in lemond ✅ |
+| §4b reranker `bge-reranker-v2-m3-q4_k_m` | present in lemond ✅ (for P2-5) |
+| disk `/var/lib` | 347 G free ✅ |
+| python | 3.12.3 |
+| cognee sidecar `/var/lib/hal0/memory/cognee/hal0_memory_index.sqlite` | **54 rows** (table `hal0_memory_items`) |
+| prior spike Hindsight install | GONE (hermes bank abandoned) — clean slate |
+
+⚠ **Cognee store is NOT empty (54 rows).** Spec [Q10] assumed empty → no-op. P2 migration
+(`hal0 memory migrate --dry-run`) will report 54 rows; the migrate-vs-start-fresh decision is
+a P2 call, not part of this deploy.
+
+## Plan corrections (plan unit was wrong on 3 points — verified vs hindsight-docs 0.7.2)
+
+1. **`HINDSIGHT_API_DATA_DIR` does not exist.** pg0 embedded Postgres lives at `$HOME/.pg0`.
+   → control it with `Environment=HOME=/var/lib/hal0/memory/hindsight` (external PG would use
+   `HINDSIGHT_API_DATABASE_URL`; we use pg0).
+2. **No `serve` subcommand.** The CLI is `hindsight-api --host <h> --port <p>` (plan said
+   `hindsight-api serve`).
+3. **`/v1` suffix required** on the LLM base_url: `http://127.0.0.1:13305/v1` (plan omitted it).
+   Provider value is `openai` for any OpenAI-compatible endpoint (confirmed; the spike's
+   `openai_compatible` was the bundled-plugin config.json schema, a different surface).
+
+## Package + topology choice
+
+- `pip install hindsight-api==0.7.2` (**full** — bundles local BGE embedder 384-d + MiniLM
+  cross-encoder; only needs the external LLM). Spec-aligned ([Q4] bge-small 384-d) and
+  matches the spike's proven 0.7.2.
+- Embeddings + reranker LOCAL (no external embed config). Extraction LLM → lemond.
+- pg0 embedded (single instance, single `public` schema + `bank_id` discriminator).
+- venv: `/var/lib/hal0/memory/hindsight/.venv`; data root `/var/lib/hal0/memory/hindsight`
+  (owner hal0:hal0).
+
+## Deploy steps
+
+1. `install -d -o hal0 -g hal0 /var/lib/hal0/memory/hindsight{,/hf-cache}` ✅
+2. `python3 -m venv .../.venv` + `pip install hindsight-api==0.7.2` (run as hal0, HOME+HF_HOME
+   set, detached + logged to `pip-install.log`) — IN PROGRESS / see below.
+3. Install unit: `cp installer/systemd/hindsight-api.service /etc/systemd/system/` (file
+   authored on hal0-dev feat branch + copied to CT105 — the feat branch is NOT checked out on
+   the runtime).
+4. `systemctl daemon-reload && systemctl enable --now hindsight-api.service`
+5. Health: `curl -fsS http://127.0.0.1:9177/health`
+6. pg0 persistence: `systemctl restart hindsight-api && sleep 5 && curl .../health`
+
+## Results (2026-06-06, deployed)
+
+- Installed: `hindsight-api==0.7.2` + `hindsight-api-slim==0.7.2` + `pg0-embedded==0.14.2`
+  + torch 2.12.0 + sentence-transformers 5.5.1 + onnxruntime 1.26.0 + pgvector 0.4.2.
+- `/health`: `{"status":"healthy","database":"connected"}` — first boot ~85s (HF model
+  download for BGE+MiniLM into HF_HOME + pg0 init + migrations); ~60s on warm restart.
+- Migrations: completed for schema `public`, vector extension `pgvector` (exact alembic
+  head hash not captured — functional success confirmed in journal; pg0 query deferred).
+- **pg0 persists across restart** ✅ — data root `/var/lib/hal0/memory/hindsight/.pg0/`
+  (`installation/` + `instances/`) survives `systemctl restart`; health returns
+  `database:connected` post-restart.
+- Bound: `Uvicorn running on http://127.0.0.1:9177` (pinned, not LAN-exposed).
+- lemond `After=` target confirmed real: `hal0-lemonade.service`.
+- **Benign log noise:** onnxruntime `pthread_setaffinity_np failed ... Invalid argument`
+  — CPU-affinity is restricted inside the LXC; onnxruntime falls back fine, service is
+  healthy. Cosmetic; silence later by pinning intra-op thread count if desired.
+- No CUDA errors (FORCE_CPU + no NVIDIA device → clean CPU path), no tracebacks.
+
+## [Q5'] FLM extraction schema gap
+
+FLM ignores `response_format` (no grammar enforcement) → small models can free-form the
+fact-extraction output. Resolve the **official** way if it surfaces at P1-7, in order:
+(a) grammar/schema-constrained extraction via lemond if available,
+(b) a larger instruct model honoring `{"facts":[...]}`,
+(c) if a shim is unavoidable, file upstream + pin the version — do NOT carry the spike's
+unversioned in-tree wrap-patch.
+Status: _deferred until P1-7 retain→extract exercises it._
+
+## Rollback
+
+`systemctl disable --now hindsight-api && systemctl mask hindsight-api`. Default engine is
+still Cognee; the Hindsight data root is isolated under `/var/lib/hal0/memory/hindsight`.

--- a/docs/internal/brain-redesign/ops/hindsight-deploy.md
+++ b/docs/internal/brain-redesign/ops/hindsight-deploy.md
@@ -112,6 +112,32 @@ types?, tags?, budget?, ...}`. Recall response: `{results:[...], trace, entities
 source_facts}`. Retain response: `{success, bank_id, items_count, usage}`.
 → `hindsight_client.py` (53ec956) corrected in follow-up commit.
 
+## ⚠ Carry-forward — MUST handle when executing P2-5 (default flip) / P2-6 (gate on)
+
+The plan's P2-5 task ("flip default engine → hindsight") does NOT mention these. Do them
+or the live brain ships broken:
+
+1. **Wire the reranker into the factory — PRECONDITION for P2-5, not a followup.** P2-1 routes
+   boot through `provider_from_config`, which builds `HindsightProvider(client=client)` with
+   `reranker=None`. The moment the default flips to hindsight, the §4b rerank merge (the
+   headline retrieval feature) is DEAD. At P2-5: construct a reranker (lemond's
+   `bge-reranker-v2-m3-q4_k_m`, confirmed present) and pass it into `HindsightProvider`, AND make
+   `set_rerank_enabled` gate on a field `_rerank_union` actually reads (currently it gates on
+   `_reranker is None`, the toggle flag is inert). Verify rerank fires end-to-end before calling
+   P2-5 done. (Note: Hindsight's own recall also reranks server-side via
+   `HINDSIGHT_API_RERANKER_*`; decide whether the §4b merge reranks the cross-bank UNION on the
+   hal0 side, or delegates — don't double-rerank blindly.)
+2. **Async retain is UNVERIFIED.** The P1-7 smoke used `async:false` (sync). The shipped client
+   (`hindsight_client.py`, 997c1ec) sends `async:true` so `add()` doesn't block ~60-90s on
+   extraction. Correct design, but the queued-extraction path was never exercised live — confirm
+   a fire-and-forget retain actually lands + becomes recallable before relying on it at P2-5.
+3. **gemma-26b extraction vs the primary model — P2-6 eviction risk.** Extraction +
+   background consolidation load `gemma-4-26b-a4b-it-q4kxl` on lemond. Under lemond's
+   serialized-load + nuclear-evict policy (`hal0_lemonade_gotchas`), a consolidation cycle could
+   evict the user-facing 35B primary mid-chat. Verify coexistence (both resident in GTT, no
+   evict) under load before/at gate-on, or pin slots / use a lighter extraction model
+   (`gemma-4-12b-it`, 6.9GB).
+
 ## Rollback
 
 `systemctl disable --now hindsight-api && systemctl mask hindsight-api`. Default engine is

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -146,6 +146,7 @@ without loading it.
 hal0 memory graph status [--json]
 hal0 memory graph enable [--route R] [--provider P] [--model M] [--json]
 hal0 memory graph disable [--json]
+hal0 memory migrate [--dry-run]
 ```
 
 The `memory graph` group is the ADR-0014 graph-extraction gate. It
@@ -153,6 +154,10 @@ controls whether Cognee runs the (expensive) graph-build step on
 memory writes and which upstream serves it. `--route=upstream`
 requires `--provider` and `--model`; `--route=primary` and
 `--route=agent` reuse hal0's own slots.
+
+`memory migrate --dry-run` reports the Cognee→Hindsight row mapping
+without writing (a no-op when the legacy Cognee store is empty/stale).
+Part of the v0.5 brain engine swap.
 
 ## Configuration
 

--- a/docs/superpowers/plans/2026-06-06-hindsight-engine-swap.md
+++ b/docs/superpowers/plans/2026-06-06-hindsight-engine-swap.md
@@ -1,0 +1,2938 @@
+# Hindsight Engine Swap — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Swap hal0's memory engine from Cognee to Hindsight behind a thin `MemoryProvider` ABC + mandatory ACL shim, re-enable the gated brain (`HAL0_MEMORY_ENABLED=1`), and converge Hermes onto the one shared brain — implementing spec phases P0, P1, P2, P5-H.
+
+**Architecture:** Promote the implicit five-method `CogneeWrapper` contract into an explicit `MemoryProvider` ABC, route the single construction site through a `provider_from_config()` factory, add a `HindsightProvider` that fans recall out across the caller's allowed banks (Hindsight has no server-side cross-bank query) and merges under one reranked token budget, then cut the default over to Hindsight with Cognee retained behind a one-release fallback flag. The hal0-api front door (`/api/memory/*` + `/mcp/memory`) stays the only ACL'd choke point; `namespace.py` is the unchanged resolver and the `:`→`__` namespace→bank mapping lives inside `HindsightProvider`.
+
+**Tech Stack:** Python 3.14, FastAPI, `pytest` (with a `slow` marker split — heavy backends are opt-in), `httpx` async client, Hindsight (`hindsight-all`, REST `/v1/default/banks/{bank}/...` + native MCP `/mcp/{bank}/`), lemond OpenAI-compatible gateway (`127.0.0.1:13305`), embedded pg0, systemd on CT 105.
+
+---
+
+## File Structure
+
+Files created or modified across all four phases, each with its single responsibility.
+
+### P0 — Seam & safety net
+| Path | Create/Modify | Responsibility |
+|---|---|---|
+| `src/hal0/memory/provider.py` | Create | The `MemoryProvider` ABC + value types (`Mode` enum). Defines the contract every engine implements. |
+| `src/hal0/memory/cognee_wrapper.py` | Modify | Declare `class CogneeWrapper(MemoryProvider)` — conformance only, no logic change. |
+| `src/hal0/memory/pgvector_provider.py` | Create | `PgVectorProvider` — third conformance impl + P2 boot fallback. Minimal in-memory-backed stub honoring the ACL contract. |
+| `src/hal0/memory/__init__.py` | Modify | Re-export `MemoryProvider` + value types; add `provider_from_config(cfg)` factory (Cognee-only branch in P0). |
+| `tests/memory/test_provider_contract.py` | Create | Parametrized conformance suite. Default-gate param is an in-memory `FakeMemoryProvider`; Cognee/PgVector params are `@pytest.mark.slow`. |
+| `tests/memory/fakes.py` | Create | `FakeMemoryProvider` — pure-Python ACL-honoring impl used by the default-gate conformance run + as a test double elsewhere. |
+| `src/hal0/agents/hermes/plugins/memory_cognee/_client.py` | Modify | Fix the latent 404s: `list_items` → `GET /api/memory/list`, `delete` → `POST /api/memory/delete` with `{ids}`. |
+| `tests/agents/hermes_plugins/test_memory_client_routes.py` | Create | Route-path test asserting `_client.py` paths match the real router. |
+
+### P1 — Deploy Hindsight + parity smoke
+| Path | Create/Modify | Responsibility |
+|---|---|---|
+| `src/hal0/memory/hindsight_provider.py` | Create | `HindsightProvider(MemoryProvider)` — core five mapped onto Hindsight retain/recall/delete, the `:`→`__` bank mapping, and the multi-bank recall fan-out + reranked merge. |
+| `src/hal0/memory/__init__.py` | Modify | `provider_from_config` gains the `engine` branch (`cognee`/`hindsight`/`mem0`/`pgvector`) + degrade ladder (default still `cognee` in P1). |
+| `src/hal0/config/schema.py` | Modify | Add `engine: str = "cognee"` field to `MemoryConfig` (schema.py:1279). |
+| `tests/memory/test_hindsight_provider.py` | Create | Bank-mapping + fan-out merge unit tests against a fake Hindsight client. |
+| `tests/memory/test_provider_contract.py` | Modify | Add the `HindsightProvider` param (`@pytest.mark.slow`, against a fake client) to the conformance run. |
+| `installer/systemd/hindsight-api.service` | Create | systemd unit for the one shared `hindsight-api` (ops-checklist task; exact env/paths below). |
+| `docs/internal/brain-redesign/ops/hindsight-deploy.md` | Create | Operator runbook for the P1 deploy + the on-box pre-flight checklist results. |
+
+### P2 — Cutover + re-enable the gate
+| Path | Create/Modify | Responsibility |
+|---|---|---|
+| `src/hal0/memory/__init__.py` | Modify | Flip `provider_from_config` default → `hindsight`. |
+| `src/hal0/api/__init__.py` | Modify | Rename `app.state.memory_wrapper` → `app.state.memory_provider`; route construction through `provider_from_config`. |
+| `src/hal0/api/routes/memory.py` | Modify | Read `memory_provider`; add `POST /api/memory/recall` route. |
+| `src/hal0/api/routes/health.py` | Modify | `memory_enabled` reads `memory_provider` (health.py:98). |
+| `src/hal0/api/agents/memory_stats.py` | Modify | Reader reads `memory_provider` (memory_stats.py:141). |
+| `src/hal0/api/mcp_mount.py` | Modify | `memory_wrapper=` param → `memory_provider=`; pass through. |
+| `src/hal0/mcp/memory.py` | Modify | Register a `recall` MCP tool wired to `provider.recall`. |
+| `src/hal0/cli/...` (migrate) | Create | `hal0 memory migrate --dry-run` command (Cognee/sidecar → Hindsight). |
+| `installer/install.sh` | Modify | Uncomment the `HAL0_MEMORY_ENABLED=1` template line (install.sh:527). |
+| `tests/memory/test_recall_route.py` | Create | `/api/memory/recall` route + `add`→`retain` routing tests. |
+| `tests/api/test_memory_provider_rename.py` | Create | `app.state.memory_provider` present; all readers resolve it. |
+
+### P5-H — Hermes convergence
+| Path | Create/Modify | Responsibility |
+|---|---|---|
+| `src/hal0/agents/hermes/plugins/memory_hindsight/` | Create (rename of `memory_cognee/`) | The renamed `hal0-memory` plugin (`hal0-cognee`→`hal0-memory`); `prefetch`→`recall`, `sync_turn`→`retain`. |
+| `installer/agents/hermes/plugins/hal0-memory/__init__.py` | Modify/retire | Retire the old stub; vendored plugin is the renamed `memory_hindsight`. |
+| `src/hal0/agents/hermes/driver.py` | Modify | Update the plugin-tree reference (driver.py:55) from `memory_cognee` to `memory_hindsight`. |
+| `$HERMES_HOME/SOUL.md` (deployed) + `src/hal0/agents/hermes/templates/SOUL.md` if present | Modify | Add the §4b ground-truth precedence stanza. |
+| `tests/agents/hermes_plugins/test_memory_hindsight_provider.py` | Create (rename) | Renamed provider tests; assert no `dataset` field, `recall`/`retain` wiring. |
+
+---
+
+## Conventions used throughout this plan
+
+- **Run tests from the repo root** `/home/halo/dev/hal0` unless noted.
+- **Default gate** = tests that run on every PR (no `slow` marker). Heavy backends (Cognee/LanceDB/70 MB embed model, a live Hindsight) are `@pytest.mark.slow` and excluded from the default gate — matching the existing `tests/memory/conftest.py` split.
+- **"byte-compatible"** in the spec means **signatures + return-shapes**, NOT verbatim text round-trip. Hindsight `retain` extracts *facts* and never stores raw text, and its sync retain response carries **no per-fact id** (`success/bank_id/items_count` only). Conformance assertions therefore check the *contract* (return shapes, ACL/namespace isolation, `private:` rejection, fail-open-empty, tag-AND, date-range, `graph_status()` shape) — never `add("foo")`→`search` returns `"foo"`. The verbatim/on-topic check is the separate, non-gated **recall sanity** check (P1 Task P1-7).
+- **`MemoryItem.id` is the Hindsight `document_id`**, never a fact id. `retain` is idempotent by `document_id`, `recall` results carry `document_id`, and delete is `delete_document(document_id=...)`. Fact ids are async + many-per-add, so they cannot be the join key.
+- **Hindsight recall returns NO numeric score** ("Results do not include a numeric score" — recall.md). The multi-bank merge therefore **re-ranks the union via the `:8086` reranker** (query+documents→score), with the §4b precedence ladder as the ordering/tiebreak. The alternative "concatenate-by-score" the spec floated is impossible and is not used.
+
+---
+
+# P0 — Seam & safety net
+
+*No gate, ships clean. Cognee stays the only live engine. Zero behaviour change.*
+
+## Task P0-1: Define the `MemoryProvider` ABC + value types
+
+**Files:**
+- Create: `src/hal0/memory/provider.py`
+- Test: `tests/memory/test_provider_contract.py` (created next task; this task is the impl the suite imports)
+
+- [ ] **Step 1: Write the failing import test**
+
+Create `tests/memory/test_provider_abc.py`:
+
+```python
+"""ABC shape tests — the explicit MemoryProvider contract (P0)."""
+
+from __future__ import annotations
+
+import inspect
+
+from hal0.memory.provider import (
+    AddResult,
+    DeleteResult,
+    GraphStatus,
+    ListPage,
+    MemoryItem,
+    MemoryProvider,
+    Mode,
+)
+
+
+def test_abc_declares_core_five_plus_status():
+    # The methods every engine MUST implement (the call sites in
+    # routes/memory.py + mcp/memory.py depend on these exact names).
+    required = {
+        "add",
+        "search",
+        "list_items",
+        "delete",
+        "graph_status",
+        "set_graph_enabled",
+        "set_rerank_enabled",
+    }
+    assert required <= set(MemoryProvider.__abstractmethods__)
+
+
+def test_abc_optional_methods_have_safe_defaults():
+    # Optional capability methods are concrete (NOT abstract) so an engine
+    # that lacks consolidation still satisfies the ABC.
+    optional = {"recall", "reflect", "consolidate", "register_compiled"}
+    assert not (optional & set(MemoryProvider.__abstractmethods__))
+    for name in optional:
+        assert callable(getattr(MemoryProvider, name))
+
+
+def test_add_signature_matches_cognee_call_sites():
+    sig = inspect.signature(MemoryProvider.add)
+    params = list(sig.parameters)
+    # Mirrors CogneeWrapper.add + the REST/MCP callers.
+    assert params == ["self", "text", "dataset", "tags", "source", "metadata", "client_id"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/memory/test_provider_abc.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'hal0.memory.provider'`
+
+- [ ] **Step 3: Write the ABC + value types**
+
+Create `src/hal0/memory/provider.py`:
+
+```python
+"""The explicit MemoryProvider contract (brain-redesign P0).
+
+Promotes the implicit five-method ``CogneeWrapper`` surface into an ABC so
+hal0 can swap engines (Cognee → Hindsight, fallback Mem0/PgVector) without
+touching a single call site. The ABC is the anti-lock-in seam (spec §1).
+
+The *core five* (``add/search/list_items/delete`` + the three runtime
+toggles ``graph_status/set_graph_enabled/set_rerank_enabled``) are abstract:
+every engine must implement them, byte-compatible in **signature + return
+shape** with ``CogneeWrapper`` so the REST shims + MCP dispatcher need no
+changes. The *optional* methods (``recall/reflect/consolidate/
+register_compiled``) ship concrete safe defaults so an engine without
+consolidation still satisfies the contract.
+"""
+
+from __future__ import annotations
+
+import enum
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class Mode(str, enum.Enum):
+    """Search mode — mirrors CogneeWrapper's accepted ``mode`` values."""
+
+    VECTOR = "vector"
+    GRAPH = "graph"
+    HYBRID = "hybrid"
+
+
+@dataclass
+class MemoryItem:
+    """One stored memory. ``id`` is the engine's join key.
+
+    For Hindsight this is the ``document_id`` (idempotent, recall-visible,
+    delete-addressable) — NOT a per-fact id. For Cognee it is the sidecar
+    uuid. The wire shape matches ``CogneeWrapper.MemoryRecord``.
+    """
+
+    id: str
+    text: str
+    timestamp: str  # ISO-8601 UTC
+    dataset: str
+    tags: list[str] = field(default_factory=list)
+    source: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    score: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "text": self.text,
+            "timestamp": self.timestamp,
+            "dataset": self.dataset,
+            "tags": list(self.tags),
+            "source": self.source,
+            "metadata": dict(self.metadata),
+            "score": self.score,
+        }
+
+
+@dataclass
+class AddResult:
+    """Return shape of ``add`` — matches ``CogneeWrapper.add``."""
+
+    id: str
+    timestamp: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"id": self.id, "timestamp": self.timestamp}
+
+
+@dataclass
+class ListPage:
+    """Return shape of ``list_items`` — matches ``CogneeWrapper.list_items``."""
+
+    items: list[dict[str, Any]]
+    next_cursor: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"items": list(self.items), "next_cursor": self.next_cursor}
+
+
+@dataclass
+class DeleteResult:
+    """Return shape of ``delete`` — matches ``CogneeWrapper.delete``."""
+
+    deleted: int
+
+    def to_dict(self) -> dict[str, int]:
+        return {"deleted": self.deleted}
+
+
+@dataclass
+class GraphStatus:
+    """Return shape of ``graph_status`` — matches the CogneeWrapper payload."""
+
+    enabled: bool
+    route: str
+    in_flight: int = 0
+    builds_ok: int = 0
+    errors: int = 0
+    last_built_at: str | None = None
+    last_error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "route": self.route,
+            "in_flight": self.in_flight,
+            "builds_ok": self.builds_ok,
+            "errors": self.errors,
+            "last_built_at": self.last_built_at,
+            "last_error": self.last_error,
+        }
+
+
+class MemoryProvider(ABC):
+    """Engine-neutral memory contract. See module docstring."""
+
+    # ── Core five (abstract) ───────────────────────────────────────────
+
+    @abstractmethod
+    async def add(
+        self,
+        text: str,
+        dataset: str = "shared",
+        tags: list[str] | None = None,
+        source: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        client_id: str | None = None,
+    ) -> dict[str, str]:
+        """Add a memory item. Returns ``{id, timestamp}``."""
+
+    @abstractmethod
+    async def search(
+        self,
+        query: str,
+        limit: int = 10,
+        dataset: str | list[str] = "shared",
+        tags: list[str] | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        mode: str = "vector",
+        client_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Vector + filter search. Returns a list of MemoryItem dicts."""
+
+    @abstractmethod
+    async def list_items(
+        self,
+        dataset: str = "shared",
+        cursor: str | None = None,
+        limit: int = 50,
+        client_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Paginated list. Returns ``{items, next_cursor}``."""
+
+    @abstractmethod
+    async def delete(self, ids: list[str], *, client_id: str | None = None) -> dict[str, int]:
+        """Delete by id. Returns ``{deleted: int}``."""
+
+    @abstractmethod
+    def graph_status(self) -> dict[str, Any]:
+        """Return the graph-extraction status payload (GraphStatus shape)."""
+
+    @abstractmethod
+    def set_graph_enabled(self, enabled: bool, route: str | None = None) -> None:
+        """Flip the graph-extraction gate at runtime."""
+
+    @abstractmethod
+    def set_rerank_enabled(self, enabled: bool) -> None:
+        """Flip the rerank gate at runtime."""
+
+    # ── Optional capability methods (concrete safe defaults) ───────────
+
+    async def recall(
+        self,
+        query: str,
+        *,
+        types: list[str] | None = None,
+        max_tokens: int = 4096,
+        dataset: str | list[str] = "shared",
+        tags: list[str] | None = None,
+        client_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Token-budgeted recall. Default delegates to ``search`` so an
+        engine without a richer recall surface still answers the route."""
+        return await self.search(
+            query=query,
+            limit=max(1, max_tokens // 256),
+            dataset=dataset,
+            tags=tags,
+            client_id=client_id,
+        )
+
+    async def reflect(self, *, dataset: str = "shared", client_id: str | None = None) -> dict[str, Any]:
+        """Trigger consolidation/reflection. No-op default."""
+        return {"status": "unsupported"}
+
+    async def consolidate(self, *, dataset: str = "shared") -> dict[str, Any]:
+        """Trigger background consolidation. No-op default."""
+        return {"status": "unsupported"}
+
+    def register_compiled(self, *args: Any, **kwargs: Any) -> None:
+        """Register a compiled artifact (directive/mental model). No-op default."""
+        return None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/memory/test_provider_abc.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/memory/provider.py tests/memory/test_provider_abc.py
+git commit -m "feat(memory): add explicit MemoryProvider ABC + value types (P0)"
+```
+
+## Task P0-2: Declare `CogneeWrapper(MemoryProvider)` conformance
+
+**Files:**
+- Modify: `src/hal0/memory/cognee_wrapper.py:176` (`class CogneeWrapper:` → subclass)
+- Test: `tests/memory/test_provider_abc.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/memory/test_provider_abc.py`:
+
+```python
+def test_cognee_wrapper_is_a_memory_provider():
+    from hal0.memory.cognee_wrapper import CogneeWrapper
+    from hal0.memory.provider import MemoryProvider
+
+    assert issubclass(CogneeWrapper, MemoryProvider)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/memory/test_provider_abc.py::test_cognee_wrapper_is_a_memory_provider -v`
+Expected: FAIL with `AssertionError` (CogneeWrapper is not yet a subclass)
+
+- [ ] **Step 3: Make the subclass declaration**
+
+In `src/hal0/memory/cognee_wrapper.py`, add the import near the top (after line 48, the `import structlog` line):
+
+```python
+from hal0.memory.provider import MemoryProvider
+```
+
+Change line 176 from:
+
+```python
+class CogneeWrapper:
+```
+
+to:
+
+```python
+class CogneeWrapper(MemoryProvider):
+```
+
+> NOTE (verify): `CogneeWrapper` already implements every abstract method (`add/search/list_items/delete/graph_status/set_graph_enabled/set_rerank_enabled`) with matching signatures — confirmed against the source. No method-body change is needed; this is a pure declaration.
+
+- [ ] **Step 4: Run the test + the full existing memory suite to verify no regression**
+
+Run: `python -m pytest tests/memory/test_provider_abc.py tests/memory/test_namespace_wrapper.py -v`
+Expected: PASS (no abstract-method-instantiation error, namespace tests still green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/memory/cognee_wrapper.py tests/memory/test_provider_abc.py
+git commit -m "feat(memory): declare CogneeWrapper conformance to MemoryProvider (P0)"
+```
+
+## Task P0-3: `FakeMemoryProvider` + the parametrized conformance suite
+
+**Files:**
+- Create: `tests/memory/fakes.py`
+- Create: `tests/memory/test_provider_contract.py`
+
+- [ ] **Step 1: Write the conformance suite (the failing test)**
+
+Create `tests/memory/test_provider_contract.py`:
+
+```python
+"""Parametrized MemoryProvider conformance suite (brain-redesign P0).
+
+Asserts the contract every engine must honor: namespace isolation,
+``private:`` write rejection at the wrapper boundary, tag-AND, date-range,
+delete semantics, fail-open-empty foreign-private reads, and the
+``graph_status()`` payload shape.
+
+The DEFAULT-gate parameter is the in-memory ``FakeMemoryProvider`` so this
+suite runs on every PR without dragging a heavy backend in. Real backends
+(Cognee, PgVector, Hindsight) attach as ``@pytest.mark.slow`` params, matching
+the existing tests/memory/conftest.py split.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.memory.fakes import FakeMemoryProvider
+
+
+@pytest.fixture
+def provider(request) -> object:
+    # request.param is a 0-arg factory returning a fresh provider.
+    return request.param()
+
+
+def _fake_factory():
+    return FakeMemoryProvider(client_id="alice")
+
+
+# Default gate: the fake only. Slow backends are added by later tasks via
+# pytest_generate_tests / additional params marked slow.
+@pytest.fixture(params=[_fake_factory], ids=["fake"])
+def conformant(request):
+    return request.param()
+
+
+@pytest.mark.asyncio
+async def test_add_returns_id_and_timestamp(conformant):
+    result = await conformant.add("a note", dataset="shared")
+    assert set(result) == {"id", "timestamp"}
+    assert isinstance(result["id"], str) and result["id"]
+
+
+@pytest.mark.asyncio
+async def test_namespace_isolation_foreign_private_reads_empty(conformant):
+    # A write into alice's private bucket is invisible to a bob-scoped read.
+    await conformant.add("alice secret", dataset="private:alice", client_id="alice")
+    out = await conformant.search("secret", dataset="private:bob", client_id="bob")
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_tag_and_match(conformant):
+    await conformant.add("tagged", dataset="shared", tags=["x", "y"])
+    await conformant.add("partial", dataset="shared", tags=["x"])
+    out = await conformant.search("tagged partial", dataset="shared", tags=["x", "y"])
+    texts = {r["text"] for r in out}
+    assert "tagged" in texts and "partial" not in texts
+
+
+@pytest.mark.asyncio
+async def test_date_range_before_after(conformant):
+    await conformant.add("old", dataset="shared")
+    out = await conformant.search("old", dataset="shared", after="2099-01-01T00:00:00+00:00")
+    assert out == []  # nothing after the year 2099
+
+
+@pytest.mark.asyncio
+async def test_delete_semantics(conformant):
+    res = await conformant.add("deleteme", dataset="shared")
+    deleted = await conformant.delete([res["id"]])
+    assert deleted == {"deleted": 1}
+    out = await conformant.search("deleteme", dataset="shared")
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_graph_status_shape(conformant):
+    status = conformant.graph_status()
+    assert set(status) >= {
+        "enabled",
+        "route",
+        "in_flight",
+        "builds_ok",
+        "errors",
+        "last_built_at",
+        "last_error",
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/memory/test_provider_contract.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'tests.memory.fakes'`
+
+- [ ] **Step 3: Write `FakeMemoryProvider`**
+
+Create `tests/memory/fakes.py`:
+
+```python
+"""In-memory MemoryProvider for the default-gate conformance suite.
+
+Honors the ACL contract (shared + own-private reads; foreign-private reads
+fail-open-empty) with zero external deps so the suite runs on every PR.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from hal0.memory.provider import MemoryProvider
+
+_SHARED = "shared"
+_PRIVATE = "private:"
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class FakeMemoryProvider(MemoryProvider):
+    def __init__(self, *, client_id: str = "anonymous") -> None:
+        self._client_id = client_id
+        self._rows: list[dict[str, Any]] = []
+        self._graph_enabled = False
+        self._graph_route = "upstream"
+        self._rerank_enabled = False
+
+    def _allowed(self, requested: str | list[str], client_id: str | None) -> list[str]:
+        cid = client_id or self._client_id
+        own = f"{_PRIVATE}{cid}"
+        reqs = [requested] if isinstance(requested, str) else list(requested or [_SHARED])
+        out: list[str] = []
+        for ds in reqs:
+            if ds == _SHARED:
+                out += [d for d in (_SHARED, own) if d not in out]
+            elif ds == own and own not in out:
+                out.append(own)
+            elif ds.startswith(_PRIVATE):
+                continue  # foreign private — dropped (fail-open-empty)
+            elif ds not in out:
+                out.append(ds)
+        return out
+
+    async def add(self, text, dataset=_SHARED, tags=None, source=None, metadata=None, client_id=None):
+        item_id = str(uuid.uuid4())
+        self._rows.append(
+            {
+                "id": item_id,
+                "text": text,
+                "timestamp": _now(),
+                "dataset": dataset,
+                "tags": list(tags or []),
+                "source": source or (client_id or self._client_id),
+                "metadata": dict(metadata or {}),
+                "score": None,
+            }
+        )
+        return {"id": item_id, "timestamp": self._rows[-1]["timestamp"]}
+
+    async def search(self, query, limit=10, dataset=_SHARED, tags=None, before=None, after=None, mode="vector", client_id=None):
+        allowed = self._allowed(dataset, client_id)
+        tags = tags or []
+        out = []
+        for row in self._rows:
+            if row["dataset"] not in allowed:
+                continue
+            if tags and not all(t in row["tags"] for t in tags):
+                continue
+            if before and row["timestamp"] >= before:
+                continue
+            if after and row["timestamp"] <= after:
+                continue
+            out.append(dict(row))
+            if len(out) >= limit:
+                break
+        return out
+
+    async def list_items(self, dataset=_SHARED, cursor=None, limit=50, client_id=None):
+        allowed = self._allowed(dataset, client_id)
+        items = [dict(r) for r in self._rows if r["dataset"] in allowed][:limit]
+        return {"items": items, "next_cursor": None}
+
+    async def delete(self, ids, *, client_id=None):
+        before = len(self._rows)
+        self._rows = [r for r in self._rows if r["id"] not in set(ids)]
+        return {"deleted": before - len(self._rows)}
+
+    def graph_status(self):
+        return {
+            "enabled": self._graph_enabled,
+            "route": self._graph_route,
+            "in_flight": 0,
+            "builds_ok": 0,
+            "errors": 0,
+            "last_built_at": None,
+            "last_error": None,
+        }
+
+    def set_graph_enabled(self, enabled, route=None):
+        self._graph_enabled = bool(enabled)
+        if route is not None:
+            self._graph_route = route
+
+    def set_rerank_enabled(self, enabled):
+        self._rerank_enabled = bool(enabled)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/memory/test_provider_contract.py -v`
+Expected: PASS (6 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/memory/fakes.py tests/memory/test_provider_contract.py
+git commit -m "test(memory): parametrized MemoryProvider conformance suite + FakeMemoryProvider (P0)"
+```
+
+## Task P0-4: `PgVectorProvider` stub (third conformance impl + P2 fallback)
+
+**Files:**
+- Create: `src/hal0/memory/pgvector_provider.py`
+- Modify: `tests/memory/test_provider_contract.py` (add the slow param)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/memory/test_provider_contract.py`:
+
+```python
+def _pgvector_factory():
+    from hal0.memory.pgvector_provider import PgVectorProvider
+
+    return PgVectorProvider(client_id="alice")
+
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_pgvector_conforms():
+    p = _pgvector_factory()
+    res = await p.add("pg note", dataset="shared")
+    assert set(res) == {"id", "timestamp"}
+    out = await p.search("pg", dataset="private:bob", client_id="bob")
+    assert out == []
+    assert set(p.graph_status()) >= {"enabled", "route"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/memory/test_provider_contract.py::test_pgvector_conforms -m slow -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'hal0.memory.pgvector_provider'`
+
+- [ ] **Step 3: Write the stub**
+
+Create `src/hal0/memory/pgvector_provider.py`. It is a minimal, dependency-light provider (an in-process dict store with the same ACL behavior) used as the **P2 boot fallback** when Hindsight is unavailable — it answers `available:false`-style empties rather than crashing. The body mirrors `FakeMemoryProvider`'s ACL logic but lives in `src/` (not `tests/`):
+
+```python
+"""PgVectorProvider — the documented boot fallback (spec P1 degrade ladder).
+
+Minimal MemoryProvider impl with the same shared+own-private ACL behaviour
+as the engines. Stands in when Hindsight is unavailable at boot so the
+tools return empties + the dashboard shows "no engine" instead of crashing.
+A real pgvector backing is deferred; the contract + degrade path are what P0
+needs.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from hal0.memory.provider import MemoryProvider
+
+_SHARED = "shared"
+_PRIVATE = "private:"
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class PgVectorProvider(MemoryProvider):
+    def __init__(self, *, client_id: str = "anonymous") -> None:
+        self._client_id = client_id
+        self._rows: list[dict[str, Any]] = []
+        self._graph_enabled = False
+        self._graph_route = "upstream"
+        self._rerank_enabled = False
+
+    def _allowed(self, requested: str | list[str], client_id: str | None) -> list[str]:
+        cid = client_id or self._client_id
+        own = f"{_PRIVATE}{cid}"
+        reqs = [requested] if isinstance(requested, str) else list(requested or [_SHARED])
+        out: list[str] = []
+        for ds in reqs:
+            if ds == _SHARED:
+                out += [d for d in (_SHARED, own) if d not in out]
+            elif ds == own and own not in out:
+                out.append(own)
+            elif ds.startswith(_PRIVATE):
+                continue
+            elif ds not in out:
+                out.append(ds)
+        return out
+
+    async def add(self, text, dataset=_SHARED, tags=None, source=None, metadata=None, client_id=None):
+        item_id = str(uuid.uuid4())
+        ts = _now()
+        self._rows.append(
+            {
+                "id": item_id,
+                "text": text,
+                "timestamp": ts,
+                "dataset": dataset,
+                "tags": list(tags or []),
+                "source": source or (client_id or self._client_id),
+                "metadata": dict(metadata or {}),
+                "score": None,
+            }
+        )
+        return {"id": item_id, "timestamp": ts}
+
+    async def search(self, query, limit=10, dataset=_SHARED, tags=None, before=None, after=None, mode="vector", client_id=None):
+        allowed = self._allowed(dataset, client_id)
+        tags = tags or []
+        out = []
+        for row in self._rows:
+            if row["dataset"] not in allowed:
+                continue
+            if tags and not all(t in row["tags"] for t in tags):
+                continue
+            if before and row["timestamp"] >= before:
+                continue
+            if after and row["timestamp"] <= after:
+                continue
+            out.append(dict(row))
+            if len(out) >= limit:
+                break
+        return out
+
+    async def list_items(self, dataset=_SHARED, cursor=None, limit=50, client_id=None):
+        allowed = self._allowed(dataset, client_id)
+        return {"items": [dict(r) for r in self._rows if r["dataset"] in allowed][:limit], "next_cursor": None}
+
+    async def delete(self, ids, *, client_id=None):
+        before = len(self._rows)
+        self._rows = [r for r in self._rows if r["id"] not in set(ids)]
+        return {"deleted": before - len(self._rows)}
+
+    def graph_status(self):
+        return {
+            "enabled": self._graph_enabled,
+            "route": self._graph_route,
+            "in_flight": 0,
+            "builds_ok": 0,
+            "errors": 0,
+            "last_built_at": None,
+            "last_error": None,
+        }
+
+    def set_graph_enabled(self, enabled, route=None):
+        self._graph_enabled = bool(enabled)
+        if route is not None:
+            self._graph_route = route
+
+    def set_rerank_enabled(self, enabled):
+        self._rerank_enabled = bool(enabled)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/memory/test_provider_contract.py::test_pgvector_conforms -m slow -v`
+Expected: PASS (1 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/memory/pgvector_provider.py tests/memory/test_provider_contract.py
+git commit -m "feat(memory): PgVectorProvider stub — third conformance impl + boot fallback (P0)"
+```
+
+## Task P0-5: `provider_from_config()` factory (Cognee-only branch)
+
+**Files:**
+- Modify: `src/hal0/memory/__init__.py`
+- Test: `tests/memory/test_provider_factory.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/memory/test_provider_factory.py`:
+
+```python
+"""provider_from_config factory tests (P0: Cognee-only branch)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from hal0.memory import provider_from_config
+from hal0.memory.cognee_wrapper import CogneeWrapper
+
+
+def _cfg(engine="cognee"):
+    return SimpleNamespace(
+        memory=SimpleNamespace(
+            engine=engine,
+            embedding=SimpleNamespace(model="BAAI/bge-small-en-v1.5", rerank_enabled=False,
+                                      rerank_url="http://127.0.0.1:8086", rerank_over_fetch_factor=5,
+                                      rerank_max_candidates=500, rerank_connect_timeout_s=1.0,
+                                      rerank_read_timeout_s=8.0),
+            graph=SimpleNamespace(enabled=False, route="upstream"),
+        )
+    )
+
+
+def test_factory_returns_cognee_for_default_engine():
+    # Patch the constructor so we don't stand up real Cognee.
+    with patch("hal0.memory.CogneeWrapper", autospec=True) as mock_cls:
+        provider_from_config(_cfg("cognee"))
+        assert mock_cls.called
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/memory/test_provider_factory.py -v`
+Expected: FAIL with `ImportError: cannot import name 'provider_from_config'`
+
+- [ ] **Step 3: Write the factory**
+
+Replace `src/hal0/memory/__init__.py` with:
+
+```python
+"""hal0 memory subsystem (ADR-0005 + brain-redesign P0–P2).
+
+Public contract for ``/mcp/memory`` + ``/api/memory/*``. Exposes the
+engine-neutral :class:`MemoryProvider` ABC and the ``provider_from_config``
+factory that the one construction site in ``api/__init__.py`` calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from hal0.memory.cognee_wrapper import CogneeWrapper, MemoryRecord
+from hal0.memory.provider import (
+    AddResult,
+    DeleteResult,
+    GraphStatus,
+    ListPage,
+    MemoryItem,
+    MemoryProvider,
+    Mode,
+)
+
+log = structlog.get_logger(__name__)
+
+__all__ = [
+    "AddResult",
+    "CogneeWrapper",
+    "DeleteResult",
+    "GraphStatus",
+    "ListPage",
+    "MemoryItem",
+    "MemoryProvider",
+    "MemoryRecord",
+    "Mode",
+    "provider_from_config",
+]
+
+
+def provider_from_config(cfg: Any) -> MemoryProvider:
+    """Construct the active MemoryProvider from the loaded hal0 config.
+
+    P0: only the ``cognee`` branch is wired (default). P1 adds ``hindsight``
+    + the degrade ladder; P2 flips the default. ``cfg`` is the object returned
+    by ``hal0.config.loader.load_hal0_config``.
+    """
+    engine = str(getattr(cfg.memory, "engine", "cognee") or "cognee").lower()
+    embed = cfg.memory.embedding
+    graph = cfg.memory.graph
+
+    if engine == "cognee":
+        return CogneeWrapper(
+            embedding_model=str(embed.model),
+            graph_enabled=bool(graph.enabled),
+            graph_route=str(graph.route),
+            rerank_enabled=bool(embed.rerank_enabled),
+            rerank_url=str(embed.rerank_url),
+            rerank_over_fetch_factor=int(embed.rerank_over_fetch_factor),
+            rerank_max_candidates=int(embed.rerank_max_candidates),
+            rerank_connect_timeout_s=float(embed.rerank_connect_timeout_s),
+            rerank_read_timeout_s=float(embed.rerank_read_timeout_s),
+        )
+
+    # P1 wires hindsight/mem0/pgvector here.
+    log.warning("hal0.memory.unknown_engine", engine=engine, fallback="cognee")
+    return CogneeWrapper(embedding_model=str(embed.model))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/memory/test_provider_factory.py -v`
+Expected: PASS (1 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/memory/__init__.py tests/memory/test_provider_factory.py
+git commit -m "feat(memory): provider_from_config factory (Cognee branch, P0)"
+```
+
+## Task P0-6: Fix the Hermes `_client.py` 404s + route-path test
+
+**Files:**
+- Modify: `src/hal0/agents/hermes/plugins/memory_cognee/_client.py:133-143`
+- Create: `tests/agents/hermes_plugins/test_memory_client_routes.py`
+
+The audit (spec P0 work-items) found two latent 404s: `list_items` calls `GET /api/memory` (real route is `GET /api/memory/list`) and `delete` calls `DELETE /api/memory/{id}` (real route is `POST /api/memory/delete` with `{ids}`).
+
+- [ ] **Step 1: Write the failing route-path test**
+
+Create `tests/agents/hermes_plugins/test_memory_client_routes.py`:
+
+```python
+"""Lock the hal0-memory REST client paths against the real router (P0).
+
+The router only defines GET /api/memory/list and POST /api/memory/delete.
+The client previously called GET /api/memory and DELETE /api/memory/{id},
+which 404. This test asserts the client now hits routes the router serves.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from hal0.agents.hermes.plugins.memory_cognee._client import Hal0MemoryClient
+from hal0.api.routes.memory import router
+
+
+def _router_paths() -> set[tuple[str, str]]:
+    out = set()
+    for route in router.routes:
+        for method in getattr(route, "methods", set()):
+            out.add((method, route.path))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_list_and_delete_hit_real_routes():
+    seen: list[tuple[str, str]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path))
+        if request.method == "GET":
+            return httpx.Response(200, json={"items": [], "next_cursor": None})
+        return httpx.Response(200, json={"deleted": 1})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://x") as http:
+        client = Hal0MemoryClient(http_client=http)
+        await client.list_items(limit=10)
+        await client.delete("some-id")
+
+    # The router serves these; the client must target them.
+    paths = _router_paths()
+    assert ("GET", "/api/memory/list") in paths
+    assert ("POST", "/api/memory/delete") in paths
+    assert ("GET", "/api/memory/list") in seen
+    assert ("POST", "/api/memory/delete") in seen
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/agents/hermes_plugins/test_memory_client_routes.py -v`
+Expected: FAIL — `seen` contains `("GET", "/api/memory")` and `("DELETE", "/api/memory/some-id")`, not the router paths.
+
+- [ ] **Step 3: Fix the client methods**
+
+In `src/hal0/agents/hermes/plugins/memory_cognee/_client.py`, replace `list_items` (lines 133-139) and `delete` (lines 141-143):
+
+```python
+    async def list_items(self, *, limit: int = 50) -> dict[str, Any]:
+        """GET /api/memory/list — page through stored items.
+
+        ``limit`` is forwarded as a query parameter; the server resolves the
+        dataset from ``X-hal0-Agent``. (Was GET /api/memory — a 404 — fixed
+        in P0.)
+        """
+        return await self._request("GET", "/api/memory/list", params={"limit": int(limit)})
+
+    async def delete(self, item_id: str) -> dict[str, Any]:
+        """POST /api/memory/delete — remove memory items by id.
+
+        The router exposes a body-based bulk delete (``{ids: [...]}``), not a
+        path-param DELETE. (Was DELETE /api/memory/{id} — a 404 — fixed in P0.)
+        """
+        return await self._request("POST", "/api/memory/delete", json={"ids": [item_id]})
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/agents/hermes_plugins/test_memory_client_routes.py -v`
+Expected: PASS (1 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/agents/hermes/plugins/memory_cognee/_client.py tests/agents/hermes_plugins/test_memory_client_routes.py
+git commit -m "fix(hermes): hal0-memory client list/delete hit real routes (was 404) (P0)"
+```
+
+## Task P0-7: Wire the conformance suite + format check into the default CI gate
+
+**Files:**
+- Modify: the CI workflow that runs `pytest` (find via `ls .github/workflows/`)
+
+- [ ] **Step 1: Locate the test step**
+
+Run: `grep -rn "pytest\|ruff format" .github/workflows/`
+Expected: a workflow step invoking `python -m pytest ...` and (per auto-memory `feedback_hal0_ci_ruff_format_check`) a separate `ruff format --check` step.
+
+- [ ] **Step 2: Confirm the default gate already collects the new suite**
+
+Run: `python -m pytest tests/memory/test_provider_contract.py tests/memory/test_provider_abc.py tests/memory/test_provider_factory.py -v`
+Expected: PASS (default-gate params only; no `slow` backend pulled in)
+
+- [ ] **Step 3: Run the format check the CI gate runs**
+
+Run: `ruff format --check src/hal0/memory/provider.py src/hal0/memory/pgvector_provider.py src/hal0/memory/__init__.py tests/memory/fakes.py tests/memory/test_provider_contract.py`
+Expected: PASS ("N files already formatted"). If it fails, run `ruff format <files>` and re-commit.
+
+> NOTE (verify): hal0's pytest default selection already discovers `tests/memory/`; no workflow edit is needed unless the suite isn't collected. Confirm with `grep -n "tests" pyproject.toml` (the `[tool.pytest.ini_options]` `testpaths`) — if `testpaths` is set and excludes the new files, add them. Otherwise this task is a no-op verification.
+
+- [ ] **Step 4: Commit (only if a workflow/pyproject edit was needed)**
+
+```bash
+git add .github/workflows/ pyproject.toml
+git commit -m "ci(memory): ensure MemoryProvider conformance suite runs in default gate (P0)"
+```
+
+**P0 Exit:** Contract suite green for the fake (default gate) + Cognee/PgVector (`slow`); app boots unchanged; `_client.py` route test green; `add→search→list→delete` byte-identical to pre-change over both transports. **Rollback:** revert the one `class CogneeWrapper(MemoryProvider)` line (the factory + ABC are additive).
+
+---
+
+# P1 — Deploy Hindsight for real + parity smoke
+
+*Real deploy (not a dark shadow). Default still Cognee. Leaves `main` shippable.*
+
+## Task P1-1: `MemoryConfig.engine` field
+
+**Files:**
+- Modify: `src/hal0/config/schema.py:1279` (`MemoryConfig`)
+- Test: `tests/config/test_memory_engine_field.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/config/test_memory_engine_field.py`:
+
+```python
+"""[memory] engine selector field (brain-redesign P1)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from hal0.config.schema import MemoryConfig
+
+
+def test_engine_defaults_to_cognee():
+    assert MemoryConfig().engine == "cognee"
+
+
+def test_engine_accepts_known_engines():
+    for e in ("cognee", "hindsight", "mem0", "pgvector"):
+        assert MemoryConfig(engine=e).engine == e
+
+
+def test_engine_rejects_unknown():
+    with pytest.raises(ValidationError):
+        MemoryConfig(engine="weaviate")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/config/test_memory_engine_field.py -v`
+Expected: FAIL — `MemoryConfig().engine` raises `AttributeError` / the field doesn't exist.
+
+- [ ] **Step 3: Add the field**
+
+In `src/hal0/config/schema.py`, in `class MemoryConfig` (after the `embedding` field at line 1292), add:
+
+```python
+    engine: str = Field(
+        default="cognee",
+        description=(
+            "Active memory engine. One of 'cognee' | 'hindsight' | 'mem0' | "
+            "'pgvector'. Default 'cognee' until P2 cutover. The fallback flag: "
+            "set back to 'cognee' to revert to the untouched Cognee store for "
+            "one release after the Hindsight cutover."
+        ),
+    )
+
+    @field_validator("engine")
+    @classmethod
+    def _engine_is_known(cls, v: str) -> str:
+        known = {"cognee", "hindsight", "mem0", "pgvector"}
+        s = str(v or "cognee").strip().lower()
+        if s not in known:
+            raise ValueError(f"memory.engine {v!r} must be one of {sorted(known)}")
+        return s
+```
+
+> NOTE (verify): `field_validator` is already imported in schema.py (used by `ModelsConfig.roots_are_absolute` at schema.py:1340). Confirm the import line near the top of the file; if absent, add `from pydantic import field_validator`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/config/test_memory_engine_field.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/config/schema.py tests/config/test_memory_engine_field.py
+git commit -m "feat(config): add memory.engine selector field (P1)"
+```
+
+## Task P1-2: `HindsightProvider` — bank mapping + core five (single-bank path)
+
+**Files:**
+- Create: `src/hal0/memory/hindsight_provider.py`
+- Test: `tests/memory/test_hindsight_provider.py` (create)
+
+The provider talks to the shared `hindsight-api` over REST. Tests inject a fake async client so they stay in the default gate; the real client is exercised by the `slow` conformance param (Task P1-4) and the on-box recall sanity check (Task P1-7).
+
+- [ ] **Step 1: Write the failing bank-mapping test**
+
+Create `tests/memory/test_hindsight_provider.py`:
+
+```python
+"""HindsightProvider unit tests — bank mapping + fan-out (P1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.memory.hindsight_provider import HindsightProvider, namespace_to_bank
+
+
+class FakeHindsightClient:
+    """Records calls; returns canned recall/retain/delete results."""
+
+    def __init__(self) -> None:
+        self.retained: list[dict] = []
+        self.recalled: list[dict] = []
+        self.deleted: list[str] = []
+        self._facts_by_bank: dict[str, list[dict]] = {}
+
+    async def retain(self, *, bank_id, content, document_id, context=None, metadata=None, tags=None, timestamp=None):
+        self.retained.append({"bank_id": bank_id, "document_id": document_id, "content": content, "tags": list(tags or [])})
+        self._facts_by_bank.setdefault(bank_id, []).append(
+            {"document_id": document_id, "text": content, "tags": list(tags or []), "mentioned_at": "2026-06-06T00:00:00+00:00"}
+        )
+        return {"success": True, "bank_id": bank_id, "items_count": 1}
+
+    async def recall(self, *, bank_id, query, types=None, max_tokens=4096, tags=None):
+        self.recalled.append({"bank_id": bank_id, "query": query})
+        return {"results": list(self._facts_by_bank.get(bank_id, []))}
+
+    async def delete_document(self, *, bank_id, document_id):
+        self.deleted.append(document_id)
+        facts = self._facts_by_bank.get(bank_id, [])
+        before = len(facts)
+        self._facts_by_bank[bank_id] = [f for f in facts if f["document_id"] != document_id]
+        return {"memory_units_deleted": before - len(self._facts_by_bank[bank_id])}
+
+
+def test_namespace_to_bank_mapping():
+    assert namespace_to_bank("shared") == "shared"
+    assert namespace_to_bank("private:hermes") == "private__hermes"
+    assert namespace_to_bank("project:42") == "project__42"
+    assert namespace_to_bank("agents") == "agents"
+
+
+@pytest.mark.asyncio
+async def test_add_routes_to_retain_under_mapped_bank():
+    fake = FakeHindsightClient()
+    p = HindsightProvider(client=fake, client_id="hermes")
+    res = await p.add("Alice works at Google", dataset="private:hermes", client_id="hermes")
+    assert set(res) == {"id", "timestamp"}
+    assert fake.retained[0]["bank_id"] == "private__hermes"
+    # The returned id IS the document_id (the join key), not a fact id.
+    assert fake.retained[0]["document_id"] == res["id"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/memory/test_hindsight_provider.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'hal0.memory.hindsight_provider'`
+
+- [ ] **Step 3: Write the provider (single-bank path; fan-out added next task)**
+
+Create `src/hal0/memory/hindsight_provider.py`:
+
+```python
+"""HindsightProvider — the platform memory engine (brain-redesign P1).
+
+Maps hal0's engine-neutral MemoryProvider contract onto the shared
+``hindsight-api`` over REST. Key design points (spec §3, §4b, P1):
+
+* **Bank mapping** lives HERE (not namespace.py, which is unchanged): hal0
+  namespace ``private:<agent>`` → Hindsight bank ``private__<agent>`` (``:``→
+  ``__``); ``project:<id>`` → ``project__<id>``; ``shared``/``agents`` pass
+  through.
+* ``MemoryItem.id`` is the Hindsight **document_id** — idempotent on retain,
+  recall-visible, delete-addressable. NOT a per-fact id (those are async +
+  many-per-add).
+* ``add`` routes to Hindsight **retain** so background consolidation fires.
+* **Multi-bank recall fan-out** (Task P1-3): Hindsight recall is per-bank,
+  client-orchestrated; we fan out to the caller's allowed banks and merge
+  under one reranked token budget (recall returns NO numeric score, so the
+  union is re-ranked via the :8086 reranker; §4b precedence is the tiebreak).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from hal0.memory.provider import MemoryProvider
+
+_SHARED = "shared"
+_PRIVATE = "private:"
+
+
+def namespace_to_bank(namespace: str) -> str:
+    """Map a hal0 namespace to a Hindsight bank id (spec §3 table)."""
+    return namespace.replace(":", "__")
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class HindsightProvider(MemoryProvider):
+    def __init__(
+        self,
+        *,
+        client: Any,
+        client_id: str = "anonymous",
+        reranker: Any = None,
+    ) -> None:
+        self._client = client
+        self._client_id = client_id
+        self._reranker = reranker
+        self._graph_enabled = False
+        self._graph_route = "upstream"
+        self._rerank_enabled = reranker is not None
+
+    # ── ACL: the caller's allowed namespaces → banks ───────────────────
+
+    def _allowed_namespaces(self, requested: str | list[str], client_id: str | None) -> list[str]:
+        cid = client_id or self._client_id
+        own = f"{_PRIVATE}{cid}"
+        reqs = [requested] if isinstance(requested, str) else list(requested or [_SHARED])
+        out: list[str] = []
+        for ds in reqs:
+            if ds == _SHARED:
+                out += [d for d in (_SHARED, own) if d not in out]
+            elif ds == own and own not in out:
+                out.append(own)
+            elif ds.startswith(_PRIVATE):
+                continue  # foreign private — dropped (fail-open-empty)
+            elif ds not in out:
+                out.append(ds)
+        return out
+
+    def _write_namespace(self, requested: str, client_id: str | None) -> str:
+        # The REST/MCP front door already resolved the write namespace via
+        # namespace.resolve_write_dataset; trust it verbatim here.
+        return requested or _SHARED
+
+    # ── Core five ──────────────────────────────────────────────────────
+
+    async def add(self, text, dataset=_SHARED, tags=None, source=None, metadata=None, client_id=None):
+        ns = self._write_namespace(dataset, client_id)
+        bank = namespace_to_bank(ns)
+        document_id = str(uuid.uuid4())  # the join key
+        meta = dict(metadata or {})
+        if source:
+            meta["source"] = source
+        await self._client.retain(
+            bank_id=bank,
+            content=text,
+            document_id=document_id,
+            context=meta.get("source"),
+            metadata={k: str(v) for k, v in meta.items()},
+            tags=list(tags or []),
+            timestamp=None,
+        )
+        return {"id": document_id, "timestamp": _now()}
+
+    async def search(self, query, limit=10, dataset=_SHARED, tags=None, before=None, after=None, mode="vector", client_id=None):
+        # search delegates to recall (back-compat surface); the fan-out lives
+        # in recall (Task P1-3). limit is honored after the merge.
+        out = await self.recall(
+            query=query,
+            max_tokens=max(256, limit * 256),
+            dataset=dataset,
+            tags=tags,
+            client_id=client_id,
+        )
+        return out[:limit]
+
+    async def list_items(self, dataset=_SHARED, cursor=None, limit=50, client_id=None):
+        # Hindsight has no flat list; list = recall with an empty-ish broad
+        # query is unreliable, so we surface the documents endpoint per bank.
+        # P1 lists via recall on a wildcard-ish query; refined in P2 if needed.
+        out = await self.recall(query="*", max_tokens=limit * 256, dataset=dataset, client_id=client_id)
+        return {"items": out[:limit], "next_cursor": None}
+
+    async def delete(self, ids, *, client_id=None):
+        deleted = 0
+        # We don't know which bank each document_id lives in without a lookup;
+        # try the caller's allowed banks. delete_document is idempotent.
+        banks = [namespace_to_bank(ns) for ns in self._allowed_namespaces(_SHARED, client_id)]
+        for document_id in ids:
+            for bank in banks:
+                res = await self._client.delete_document(bank_id=bank, document_id=document_id)
+                if int(res.get("memory_units_deleted", 0)) > 0:
+                    deleted += 1
+                    break
+        return {"deleted": deleted}
+
+    # ── recall (fan-out added in Task P1-3) ────────────────────────────
+
+    async def recall(self, query, *, types=None, max_tokens=4096, dataset=_SHARED, tags=None, client_id=None):
+        # Single-bank placeholder; Task P1-3 replaces this with the fan-out.
+        banks = [namespace_to_bank(ns) for ns in self._allowed_namespaces(dataset, client_id)]
+        merged: list[dict[str, Any]] = []
+        for bank in banks:
+            resp = await self._client.recall(bank_id=bank, query=query, types=types, max_tokens=max_tokens, tags=tags)
+            for fact in resp.get("results", []):
+                merged.append(self._fact_to_item(fact, bank))
+        return merged
+
+    # ── Runtime toggles ────────────────────────────────────────────────
+
+    def graph_status(self):
+        return {
+            "enabled": self._graph_enabled,
+            "route": self._graph_route,
+            "in_flight": 0,
+            "builds_ok": 0,
+            "errors": 0,
+            "last_built_at": None,
+            "last_error": None,
+        }
+
+    def set_graph_enabled(self, enabled, route=None):
+        self._graph_enabled = bool(enabled)
+        if route is not None:
+            self._graph_route = route
+
+    def set_rerank_enabled(self, enabled):
+        self._rerank_enabled = bool(enabled)
+
+    # ── helpers ────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _fact_to_item(fact: dict[str, Any], bank: str) -> dict[str, Any]:
+        """Map a Hindsight RecallResult to the MemoryItem wire shape.
+
+        ``score`` is always None — Hindsight recall returns no numeric score;
+        ordering carries the relevance signal.
+        """
+        return {
+            "id": fact.get("document_id") or fact.get("id"),
+            "text": fact.get("text", ""),
+            "timestamp": fact.get("mentioned_at") or _now(),
+            "dataset": bank.replace("__", ":"),
+            "tags": list(fact.get("tags") or []),
+            "source": (fact.get("metadata") or {}).get("source"),
+            "metadata": dict(fact.get("metadata") or {}),
+            "score": None,
+            "type": fact.get("type"),
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/memory/test_hindsight_provider.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/memory/hindsight_provider.py tests/memory/test_hindsight_provider.py
+git commit -m "feat(memory): HindsightProvider — bank mapping + retain/recall/delete core (P1)"
+```
+
+## Task P1-3: Multi-bank recall fan-out + reranked merge
+
+**Files:**
+- Modify: `src/hal0/memory/hindsight_provider.py` (`recall`)
+- Test: `tests/memory/test_hindsight_provider.py` (extend)
+
+Hindsight has no server-side cross-bank query; a hal0 recall must hit the caller's own `private:*` + `shared` (+ any `project:*`) **in parallel** and merge under one token budget. Because recall returns no numeric score, the merge **re-ranks the union via the `:8086` reranker** (query+documents→score), with the §4b precedence ladder (curated/`shared` observations above raw private facts) as the ordering tiebreak.
+
+- [ ] **Step 1: Write the failing fan-out test**
+
+Append to `tests/memory/test_hindsight_provider.py`:
+
+```python
+class FakeReranker:
+    """Reverses input order so we can prove the merge re-ranked the union."""
+
+    async def rerank(self, query: str, documents: list[str]) -> list[dict]:
+        n = len(documents)
+        return [{"index": i, "relevance_score": float(n - i)} for i in range(n)]
+
+
+@pytest.mark.asyncio
+async def test_recall_fans_out_across_allowed_banks_and_merges():
+    fake = FakeHindsightClient()
+    await fake.retain(bank_id="shared", content="shared fact", document_id="d-shared", tags=[])
+    await fake.retain(bank_id="private__hermes", content="private fact", document_id="d-priv", tags=[])
+    await fake.retain(bank_id="private__other", content="other private", document_id="d-other", tags=[])
+
+    p = HindsightProvider(client=fake, client_id="hermes", reranker=FakeReranker())
+    out = await p.recall("fact", dataset="shared", client_id="hermes")
+
+    banks_queried = {c["bank_id"] for c in fake.recalled}
+    # Fans out to own-private + shared; NEVER another agent's private.
+    assert banks_queried == {"shared", "private__hermes"}
+    texts = {r["text"] for r in out}
+    assert texts == {"shared fact", "private fact"}
+    assert "other private" not in texts
+
+
+@pytest.mark.asyncio
+async def test_recall_merge_precedence_shared_observation_before_private_fact():
+    fake = FakeHindsightClient()
+    # shared observation (curated) must outrank a raw private fact (§4b).
+    fake._facts_by_bank["shared"] = [{"document_id": "o1", "text": "obs", "type": "observation", "tags": []}]
+    fake._facts_by_bank["private__hermes"] = [{"document_id": "f1", "text": "raw", "type": "experience", "tags": []}]
+
+    p = HindsightProvider(client=fake, client_id="hermes", reranker=FakeReranker())
+    out = await p.recall("anything", dataset="shared", client_id="hermes")
+    assert out[0]["text"] == "obs"  # observation ranks first
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/memory/test_hindsight_provider.py -k "fans_out or precedence" -v`
+Expected: FAIL — the placeholder `recall` queries banks serially with no rerank/precedence ordering (precedence test fails; fan-out test may pass on bank set but precedence is unordered).
+
+- [ ] **Step 3: Implement the fan-out + reranked merge**
+
+In `src/hal0/memory/hindsight_provider.py`, replace the `recall` method with:
+
+```python
+    async def recall(self, query, *, types=None, max_tokens=4096, dataset=_SHARED, tags=None, client_id=None):
+        """Fan out per-bank recall to the caller's allowed banks, merge under
+        one token budget. Hindsight has no server-side cross-bank query and
+        returns no numeric score, so we re-rank the union via the :8086
+        reranker, with the §4b precedence ladder as the tiebreak.
+        """
+        import asyncio
+
+        banks = [namespace_to_bank(ns) for ns in self._allowed_namespaces(dataset, client_id)]
+        if not banks:
+            return []
+
+        async def _one(bank: str) -> list[dict[str, Any]]:
+            resp = await self._client.recall(
+                bank_id=bank, query=query, types=types, max_tokens=max_tokens, tags=tags
+            )
+            return [self._fact_to_item(f, bank) for f in resp.get("results", [])]
+
+        per_bank = await asyncio.gather(*[_one(b) for b in banks])
+        union: list[dict[str, Any]] = [item for bank_items in per_bank for item in bank_items]
+        if not union:
+            return []
+
+        union = await self._rerank_union(query, union)
+        union.sort(key=self._precedence_key)  # stable: precedence wins ties
+        return self._apply_token_budget(union, max_tokens)
+
+    @staticmethod
+    def _precedence_key(item: dict[str, Any]) -> tuple[int, float]:
+        """§4b ladder: shared/curated observations rank above raw private
+        facts. Lower tuple sorts first. Second element is negative rerank
+        score so higher score sorts earlier within the same tier.
+        """
+        is_observation = item.get("type") == "observation"
+        is_shared = item.get("dataset") == _SHARED
+        tier = 0 if (is_observation or is_shared) else 1
+        return (tier, -float(item.get("score") or 0.0))
+
+    async def _rerank_union(self, query: str, union: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if self._reranker is None or len(union) < 2:
+            return union
+        try:
+            ranked = await self._reranker.rerank(query, [u["text"] for u in union])
+        except Exception:
+            return union  # reranker down → keep fused order (fail-soft)
+        for entry in ranked:
+            idx = entry.get("index")
+            if isinstance(idx, int) and 0 <= idx < len(union):
+                union[idx]["score"] = float(entry.get("relevance_score", 0.0))
+        return union
+
+    @staticmethod
+    def _apply_token_budget(items: list[dict[str, Any]], max_tokens: int) -> list[dict[str, Any]]:
+        """Greedy fill by ~4 chars/token on the text field (Hindsight counts
+        only fact text toward the budget)."""
+        out: list[dict[str, Any]] = []
+        spent = 0
+        for item in items:
+            cost = max(1, len(item.get("text", "")) // 4)
+            if spent + cost > max_tokens and out:
+                break
+            out.append(item)
+            spent += cost
+        return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/memory/test_hindsight_provider.py -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/memory/hindsight_provider.py tests/memory/test_hindsight_provider.py
+git commit -m "feat(memory): HindsightProvider multi-bank recall fan-out + reranked merge (P1)"
+```
+
+## Task P1-4: Add `HindsightProvider` to the conformance suite + factory branch
+
+**Files:**
+- Modify: `tests/memory/test_provider_contract.py`
+- Modify: `src/hal0/memory/__init__.py` (`provider_from_config` engine branch + degrade ladder)
+- Test: `tests/memory/test_provider_factory.py` (extend)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/memory/test_provider_contract.py`:
+
+```python
+def _hindsight_factory():
+    from hal0.memory.hindsight_provider import HindsightProvider
+    from tests.memory.test_hindsight_provider import FakeHindsightClient
+
+    return HindsightProvider(client=FakeHindsightClient(), client_id="alice")
+
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_hindsight_conforms_to_contract():
+    p = _hindsight_factory()
+    res = await p.add("hs note", dataset="shared")
+    assert set(res) == {"id", "timestamp"}
+    # Foreign-private read → empty.
+    out = await p.search("note", dataset="private:bob", client_id="bob")
+    assert out == []
+    assert set(p.graph_status()) >= {"enabled", "route"}
+    d = await p.delete([res["id"]])
+    assert "deleted" in d
+```
+
+Append to `tests/memory/test_provider_factory.py`:
+
+```python
+def test_factory_returns_hindsight_when_engine_hindsight():
+    with patch("hal0.memory.HindsightProvider", autospec=True) as mock_cls, \
+         patch("hal0.memory._build_hindsight_client", return_value=object()):
+        provider_from_config(_cfg("hindsight"))
+        assert mock_cls.called
+
+
+def test_factory_degrades_to_pgvector_when_hindsight_unavailable():
+    from hal0.memory.pgvector_provider import PgVectorProvider
+
+    with patch("hal0.memory._build_hindsight_client", side_effect=RuntimeError("no daemon")):
+        provider = provider_from_config(_cfg("hindsight"))
+        assert isinstance(provider, PgVectorProvider)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/memory/test_provider_factory.py -k "hindsight or degrades" -v`
+Expected: FAIL — `provider_from_config` has no hindsight branch and `_build_hindsight_client` doesn't exist.
+
+- [ ] **Step 3: Add the engine branch + degrade ladder**
+
+In `src/hal0/memory/__init__.py`, add the hindsight import + a client builder, then extend the factory. Insert after the existing imports:
+
+```python
+from hal0.memory.hindsight_provider import HindsightProvider
+from hal0.memory.pgvector_provider import PgVectorProvider
+```
+
+Add a client builder (kept separate so tests can patch it):
+
+```python
+def _build_hindsight_client(cfg: Any) -> Any:
+    """Construct the Hindsight REST client from config + env.
+
+    Raises if the daemon is unreachable so the factory can degrade. The
+    actual httpx-backed client lives in hindsight_provider; this indirection
+    exists purely so the boot-degrade path is unit-testable.
+    """
+    from hal0.memory.hindsight_client import HindsightRestClient
+
+    return HindsightRestClient.from_env()
+```
+
+Replace the body of `provider_from_config` after the `cognee` branch:
+
+```python
+    if engine == "hindsight":
+        try:
+            client = _build_hindsight_client(cfg)
+        except Exception as exc:  # daemon down at boot → degrade ladder
+            log.warning("hal0.memory.hindsight_unavailable", error=str(exc), fallback="pgvector")
+            return PgVectorProvider()
+        return HindsightProvider(client=client)
+
+    if engine == "pgvector":
+        return PgVectorProvider()
+
+    if engine == "mem0":  # documented fallback (spec §2) — not yet implemented
+        log.warning("hal0.memory.mem0_not_implemented", fallback="cognee")
+        return CogneeWrapper(embedding_model=str(embed.model))
+
+    # cognee branch above is the default; unknown engines log + fall back.
+    log.warning("hal0.memory.unknown_engine", engine=engine, fallback="cognee")
+    return CogneeWrapper(embedding_model=str(embed.model))
+```
+
+Add `HindsightProvider`, `PgVectorProvider`, `_build_hindsight_client` to `__all__`.
+
+> NOTE (verify): `src/hal0/memory/hindsight_client.py` (`HindsightRestClient.from_env()`) is built in the ops task P1-6 alongside the deploy (it needs the real port + env). For P1 unit tests, `_build_hindsight_client` is always patched, so the import is lazy (inside the function) and never executed in the default gate.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/memory/test_provider_factory.py tests/memory/test_provider_contract.py::test_hindsight_conforms_to_contract -m "slow or not slow" -v`
+Expected: PASS (factory tests + the slow hindsight conformance test green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/memory/__init__.py tests/memory/test_provider_factory.py tests/memory/test_provider_contract.py
+git commit -m "feat(memory): provider_from_config hindsight branch + pgvector degrade ladder (P1)"
+```
+
+## Task P1-5: `HindsightRestClient` — the real REST adapter
+
+**Files:**
+- Create: `src/hal0/memory/hindsight_client.py`
+- Test: `tests/memory/test_hindsight_client.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/memory/test_hindsight_client.py`:
+
+```python
+"""HindsightRestClient REST-path tests against a MockTransport (P1)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from hal0.memory.hindsight_client import HindsightRestClient
+
+
+@pytest.mark.asyncio
+async def test_retain_recall_delete_hit_v1_bank_paths():
+    seen: list[tuple[str, str]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path))
+        if request.url.path.endswith("/recall"):
+            return httpx.Response(200, json={"results": []})
+        if request.url.path.endswith("/retain"):
+            return httpx.Response(200, json={"success": True, "bank_id": "shared", "items_count": 1})
+        return httpx.Response(200, json={"memory_units_deleted": 1})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:9177") as http:
+        client = HindsightRestClient(http_client=http, api_key="lemonade-local-noauth")
+        await client.retain(bank_id="shared", content="x", document_id="d1")
+        await client.recall(bank_id="shared", query="x")
+        await client.delete_document(bank_id="shared", document_id="d1")
+
+    assert ("POST", "/v1/default/banks/shared/retain") in seen
+    assert ("POST", "/v1/default/banks/shared/recall") in seen
+    # Delete is the documented delete_document path.
+    assert any(m == "DELETE" and "/documents/d1" in p for m, p in seen)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/memory/test_hindsight_client.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'hal0.memory.hindsight_client'`
+
+- [ ] **Step 3: Write the client**
+
+Create `src/hal0/memory/hindsight_client.py`:
+
+```python
+"""Async REST client for the shared hindsight-api (brain-redesign P1).
+
+Talks to ``/v1/default/banks/{bank}/...`` (the bank-scoped REST surface the
+spike confirmed). Auth is the single server-wide key when enabled; on the LAN
+the daemon runs no-auth but Hindsight still requires a NON-EMPTY key, so we
+default to the spike's ``lemonade-local-noauth`` placeholder.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+DEFAULT_BASE_URL = "http://127.0.0.1:9177"  # dynamic port — pinned by the unit (P1-6)
+DEFAULT_API_KEY = "lemonade-local-noauth"
+
+
+class HindsightRestClient:
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        api_key: str = DEFAULT_API_KEY,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._base_url = (base_url or DEFAULT_BASE_URL).rstrip("/")
+        self._api_key = api_key
+        self._owns = http_client is None
+        self._http = http_client or httpx.AsyncClient(
+            base_url=self._base_url, timeout=httpx.Timeout(120.0, connect=3.0)
+        )
+
+    @classmethod
+    def from_env(cls) -> "HindsightRestClient":
+        base = os.environ.get("HAL0_HINDSIGHT_URL", DEFAULT_BASE_URL)
+        key = os.environ.get("HINDSIGHT_API_TENANT_API_KEY", DEFAULT_API_KEY) or DEFAULT_API_KEY
+        return cls(base_url=base, api_key=key)
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"}
+
+    async def retain(self, *, bank_id, content, document_id, context=None, metadata=None, tags=None, timestamp=None):
+        body: dict[str, Any] = {"content": content, "document_id": document_id}
+        if context is not None:
+            body["context"] = context
+        if metadata:
+            body["metadata"] = metadata
+        if tags:
+            body["tags"] = list(tags)
+        if timestamp is not None:
+            body["timestamp"] = timestamp
+        resp = await self._http.post(f"/v1/default/banks/{bank_id}/retain", headers=self._headers(), json=body)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def recall(self, *, bank_id, query, types=None, max_tokens=4096, tags=None):
+        body: dict[str, Any] = {"query": query, "max_tokens": max_tokens}
+        if types:
+            body["types"] = list(types)
+        if tags:
+            body["tags"] = list(tags)
+        resp = await self._http.post(f"/v1/default/banks/{bank_id}/recall", headers=self._headers(), json=body)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def delete_document(self, *, bank_id, document_id):
+        resp = await self._http.request(
+            "DELETE", f"/v1/default/banks/{bank_id}/documents/{document_id}", headers=self._headers()
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def aclose(self) -> None:
+        if self._owns:
+            await self._http.aclose()
+```
+
+> NOTE (verify): the exact delete path (`/v1/default/banks/{bank}/documents/{document_id}`) is the documented `delete_document` operation (hindsight-docs `developer/api/documents.md`). Confirm the on-box daemon serves it under `/v1/default/...` (the spike confirmed the `/v1/default/banks/{bank}/...` prefix); adjust if the deployed version differs.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/memory/test_hindsight_client.py -v`
+Expected: PASS (1 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/memory/hindsight_client.py tests/memory/test_hindsight_client.py
+git commit -m "feat(memory): HindsightRestClient REST adapter for /v1/default/banks (P1)"
+```
+
+## Task P1-6: Deploy the shared `hindsight-api` systemd unit  *(OPS CHECKLIST — not unit-testable)*
+
+This task is an **operator runbook** (no red-green TDD loop; it stands up infra on CT 105). Be exact about config/paths/env. Folds in the spike's hard-won config (auto-memory `hal0_hindsight_hermes_spike`).
+
+**Files:**
+- Create: `installer/systemd/hindsight-api.service`
+- Create: `docs/internal/brain-redesign/ops/hindsight-deploy.md`
+
+- [ ] **Step 1: Pin the version + run the on-box pre-flight (spec §7, read-only)**
+
+On CT 105 (`ssh hal0`), record into `docs/internal/brain-redesign/ops/hindsight-deploy.md`:
+- Platform Cognee/sidecar row counts: `ls -la /var/lib/hal0/memory/cognee` + `sqlite3 /var/lib/hal0/memory/cognee/hal0_memory_index.sqlite "SELECT COUNT(*) FROM hal0_memory_items;"` (expect empty/stale → P2 migration is a no-op).
+- Embed-slot model + dim vs `bge-small-en-v1.5` (384-d) — schedule a re-embed if different ([Q4]).
+- Pin Hindsight version (probe-confirmed 2026-06-06): the spike venv ran `hindsight-all` /
+  `hindsight-api-slim` / `hindsight-embed` **0.7.2**, `hindsight-client` **0.6.1**, embedded
+  **Postgres 18.1.0**, alembic schema head **`c1d2e3f4a5b6`**. **Pin the shared platform deploy
+  to `hindsight-api` 0.7.x with the same alembic head** so the schema is known-good; record the
+  [Q5'] extraction/schema behaviour. (Storage on this build = single `public` schema + a
+  `bank_id` discriminator column; a tenant-schema model also exists but is only relevant if the
+  shared instance is run multi-tenant — we are not.)
+
+- [ ] **Step 2: Create the data root + writable HF cache**
+
+```bash
+sudo install -d -o hal0 -g hal0 /var/lib/hal0/memory/hindsight
+sudo install -d -o hal0 -g hal0 /var/lib/hal0/memory/hindsight/hf-cache
+```
+
+(Spike gotcha #2: the default HF cache symlinks to read-only `/mnt/ai-models` and dies downloading `bge-small-en-v1.5` — point `HF_HOME` at this hal0-writable dir.)
+
+- [ ] **Step 3: Write the systemd unit**
+
+Create `installer/systemd/hindsight-api.service`:
+
+```ini
+[Unit]
+Description=hal0 shared Hindsight memory engine (platform brain)
+After=network-online.target hal0-lemonade.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=hal0
+Group=hal0
+# Spike gotcha #2 — writable HF cache (default symlinks to read-only /mnt/ai-models).
+Environment=HF_HOME=/var/lib/hal0/memory/hindsight/hf-cache
+# Embedded pg0 under the data root (NOT a separate PG daemon).
+Environment=HINDSIGHT_API_DATA_DIR=/var/lib/hal0/memory/hindsight
+# Spike gotcha #1 — a NON-EMPTY key is required even for no-auth lemond.
+Environment=HINDSIGHT_API_LLM_API_KEY=lemonade-local-noauth
+# Extraction LLM → lemond (instruct model; reasoning/rambling models time out — spike).
+Environment=HINDSIGHT_API_LLM_PROVIDER=openai
+Environment=HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:13305
+Environment=HINDSIGHT_API_LLM_MODEL=qwen3-it-4b-FLM
+# Pin the bind so the provider/client don't chase the dynamic port (gotcha #3).
+Environment=HINDSIGHT_API_PORT=9177
+ExecStart=/var/lib/hal0/memory/hindsight/.venv/bin/hindsight-api serve
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+```
+
+- [ ] **Step 4: Install + enable + health-check**
+
+```bash
+sudo cp installer/systemd/hindsight-api.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now hindsight-api.service
+# Health (spike gotcha #3 — health is /health; capture the actual bound port if not 9177):
+curl -fsS http://127.0.0.1:9177/health && echo OK
+# Verify pg0 persists across restart:
+sudo systemctl restart hindsight-api.service && sleep 5 && curl -fsS http://127.0.0.1:9177/health
+```
+
+- [ ] **Step 5: Resolve [Q5'] the FLM schema gap the standard way (NOT the wrap-patch)**
+
+Per spec §6 [Q5'] + the standing "third-party official fix first" rule, resolve extraction-schema tolerance via, in order: (a) grammar-/schema-constrained extraction via lemond if available, (b) a larger instruct extraction model that honors `{"facts":[...]}`, or (c) if a tolerance shim is unavoidable, **file it upstream and pin the version** — do NOT carry an unversioned in-tree patch. Record the chosen path + upstream issue link in `hindsight-deploy.md`.
+
+- [ ] **Step 6: Commit the unit + runbook**
+
+```bash
+git add installer/systemd/hindsight-api.service docs/internal/brain-redesign/ops/hindsight-deploy.md
+git commit -m "ops(memory): shared hindsight-api systemd unit + deploy runbook (P1)"
+```
+
+## Task P1-7: Recall sanity check on a seeded fixture corpus  *(OPS/SMOKE — recorded, not gated)*
+
+Per spec D2, this is a **sanity** check (no graded δ-eval, no Cognee baseline — the platform store is empty). It is recorded, not gated on a delta.
+
+**Files:**
+- Create: `tests/memory/fixtures/recall_corpus.jsonl` (seed corpus)
+- Create: `scripts/memory/recall_sanity.py` (one-shot probe)
+
+- [ ] **Step 1: Seed a small fixture corpus**
+
+Create `tests/memory/fixtures/recall_corpus.jsonl` (~10 facts spanning 2 banks):
+
+```jsonl
+{"bank": "shared", "text": "hal0 runs its inference on a Strix Halo iGPU via Lemonade."}
+{"bank": "shared", "text": "The hal0 memory engine was swapped from Cognee to Hindsight in v0.5."}
+{"bank": "private__hermes", "text": "Hermes prefers concise, citation-backed answers."}
+```
+
+(Extend to ~10 lines covering the fixed query set below.)
+
+- [ ] **Step 2: Write the probe script**
+
+Create `scripts/memory/recall_sanity.py` that retains the corpus into the live `hindsight-api`, runs a fixed query set (e.g. "what hardware does hal0 use", "which memory engine does hal0 use"), and prints recalled facts + per-query latency. No assertions — output is recorded in `hindsight-deploy.md`.
+
+- [ ] **Step 3: Run the probe on CT 105 + record results**
+
+```bash
+ssh hal0 'cd /opt/hal0 && python scripts/memory/recall_sanity.py'
+```
+
+Paste the on-topic results + latencies into `docs/internal/brain-redesign/ops/hindsight-deploy.md` under "Recall sanity (P1 exit part 2)".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/memory/fixtures/recall_corpus.jsonl scripts/memory/recall_sanity.py docs/internal/brain-redesign/ops/hindsight-deploy.md
+git commit -m "test(memory): recall sanity fixture corpus + probe (P1 exit, recorded not gated)"
+```
+
+**P1 Exit:** (1) `HindsightProvider` + `PgVectorProvider` pass `test_provider_contract.py` unmodified; `hindsight-api` boots as a unit; pg0 persists across restart; embed/rerank/extraction health-checked. (2) Recall sanity recorded. **Rollback:** stop/mask the unit; default still Cognee; Hindsight data root is isolated.
+
+---
+
+# P2 — Cutover + re-enable the gate
+
+*Flip the default to Hindsight, map namespaces→banks behind the ACL shim, add the `recall` route, turn memory ON, keep Cognee behind a one-release fallback.*
+
+## Task P2-1: Rename `app.state.memory_wrapper` → `app.state.memory_provider`
+
+**Files:**
+- Modify: `src/hal0/api/__init__.py:1434-1526`
+- Modify: `src/hal0/api/routes/memory.py:172`
+- Modify: `src/hal0/api/routes/health.py:98`
+- Modify: `src/hal0/api/agents/memory_stats.py:141`
+- Modify: `src/hal0/api/mcp_mount.py:172-241`
+- Test: `tests/api/test_memory_provider_rename.py` (create)
+
+The full reader list (grepped repo-wide): `api/__init__.py`, `api/mcp_mount.py`, `api/agents/memory_stats.py:141`, `api/routes/health.py:98`, `api/routes/memory.py:172`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/api/test_memory_provider_rename.py`:
+
+```python
+"""Cutover: app.state exposes memory_provider (P2)."""
+
+from __future__ import annotations
+
+import os
+
+from fastapi.testclient import TestClient
+
+
+def test_app_state_has_memory_provider(monkeypatch):
+    monkeypatch.setenv("HAL0_MEMORY_ENABLED", "1")
+    from hal0.api import create_app
+
+    app = create_app()
+    # New canonical name present; old name gone.
+    assert hasattr(app.state, "memory_provider")
+    assert not hasattr(app.state, "memory_wrapper")
+
+
+def test_health_memory_enabled_reads_provider(monkeypatch):
+    monkeypatch.setenv("HAL0_MEMORY_ENABLED", "1")
+    from hal0.api import create_app
+
+    with TestClient(create_app()) as client:
+        body = client.get("/api/status").json()
+        assert "memory_enabled" in body
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/api/test_memory_provider_rename.py -v`
+Expected: FAIL — `app.state.memory_wrapper` still exists / `memory_provider` absent.
+
+- [ ] **Step 3: Rename across all readers**
+
+In `src/hal0/api/__init__.py`, change the construction block (lines 1434-1494) to build via the factory and store under the new name. Replace the `else:` branch body (lines 1448-1494) with:
+
+```python
+    else:
+        try:
+            from hal0.config.loader import load_hal0_config
+            from hal0.memory import provider_from_config
+
+            memory_provider = provider_from_config(load_hal0_config())
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning("hal0.memory.init_failed", error=str(exc))
+```
+
+Rename the local `memory_wrapper` → `memory_provider` (lines 1434, 1494, 1504-1524) and the assignment to `app.state.memory_provider = memory_provider`. Update the `mount_mcp_servers(..., memory_wrapper=memory_provider, ...)` call to `memory_provider=memory_provider`.
+
+In the other readers, change `getattr(request.app.state, "memory_wrapper", None)` → `"memory_provider"`:
+- `src/hal0/api/routes/memory.py:172` (`_wrapper` → rename to `_provider`, keep callers).
+- `src/hal0/api/routes/health.py:98`.
+- `src/hal0/api/agents/memory_stats.py:141`.
+
+In `src/hal0/api/mcp_mount.py`, rename the `memory_wrapper` parameter (lines 172, 221, 225, 241) → `memory_provider`.
+
+> NOTE (verify): `mcp_mount.py:225` passes `wrapper=memory_wrapper` into `build_server(wrapper=...)` — `build_server`'s param stays `wrapper` (it's engine-neutral `Any`); only the local variable/param name changes. Leave `hal0.mcp.memory.build_server`'s signature untouched.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/api/test_memory_provider_rename.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/api/__init__.py src/hal0/api/routes/memory.py src/hal0/api/routes/health.py src/hal0/api/agents/memory_stats.py src/hal0/api/mcp_mount.py tests/api/test_memory_provider_rename.py
+git commit -m "refactor(api): rename memory_wrapper → memory_provider; build via factory (P2)"
+```
+
+## Task P2-2: `POST /api/memory/recall` route + `add`→`retain` confirmation
+
+**Files:**
+- Modify: `src/hal0/api/routes/memory.py` (add `recall` route)
+- Test: `tests/memory/test_recall_route.py` (create)
+
+`/api/memory/*` is the Cognee-era CRUD contract. Hindsight's value is `recall` (token-budgeted, observation hierarchy). Without a `recall` route the milestone silently ships "a better vector store". So: add `POST /api/memory/recall` the plugins call, and confirm `HindsightProvider.add` routes to `retain` (background consolidation) — which Task P1-2 already does.
+
+- [ ] **Step 1: Write the failing route test**
+
+Create `tests/memory/test_recall_route.py`:
+
+```python
+"""POST /api/memory/recall route (P2)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api.routes.memory import router
+from tests.memory.fakes import FakeMemoryProvider
+
+
+class RecordingProvider(FakeMemoryProvider):
+    def __init__(self):
+        super().__init__(client_id="anonymous")
+        self.recall_calls = []
+
+    async def recall(self, query, *, types=None, max_tokens=4096, dataset="shared", tags=None, client_id=None):
+        self.recall_calls.append({"query": query, "max_tokens": max_tokens})
+        return [{"id": "d1", "text": "recalled", "timestamp": "2026-06-06T00:00:00+00:00",
+                 "dataset": "shared", "tags": [], "source": None, "metadata": {}, "score": None}]
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(router, prefix="/api/memory")
+    app.state.memory_provider = RecordingProvider()
+    return TestClient(app)
+
+
+def test_recall_route_returns_items(client):
+    resp = client.post("/api/memory/recall", json={"query": "what do I know", "max_tokens": 2048})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["items"][0]["text"] == "recalled"
+    assert client.app.state.memory_provider.recall_calls[0]["max_tokens"] == 2048
+
+
+def test_recall_requires_query(client):
+    resp = client.post("/api/memory/recall", json={})
+    assert resp.status_code == 400
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/memory/test_recall_route.py -v`
+Expected: FAIL with 404 (no `/recall` route).
+
+- [ ] **Step 3: Add the route**
+
+In `src/hal0/api/routes/memory.py`, after `memory_search` (line 407), add:
+
+```python
+@router.post("/recall")
+async def memory_recall(request: Request) -> dict[str, Any]:
+    """Token-budgeted recall (Hindsight's preferred path).
+
+    Body: ``{query, max_tokens?, types?, dataset?, tags?}``. Identity +
+    namespace resolution behave like ``/search`` (X-hal0-Agent +
+    X-hal0-Private). Returns ``{items: [MemoryItem, ...]}`` ordered by
+    relevance (no numeric score — Hindsight recall returns none).
+
+    Falls back to ``search`` semantics on engines without a richer recall
+    (the ABC default), so this route is safe regardless of active engine.
+    """
+    body = await _read_json_body(request)
+    query = body.get("query")
+    if not isinstance(query, str) or not query:
+        raise Hal0Error(
+            "memory_recall requires 'query' (non-empty string)",
+            details={"path": "/api/memory/recall"},
+        )
+    agent_id = _agent_id(request)
+    private = _is_private(request)
+    try:
+        dataset = resolve_read_datasets(
+            body.get("dataset"),
+            private=private,
+            client_id=agent_id if agent_id != "anonymous" else None,
+        )
+    except MemoryNamespaceError as exc:
+        raise MemoryNamespaceInvalid(str(exc)) from exc
+
+    provider = _provider(request)
+    items = await provider.recall(
+        query=query,
+        types=body.get("types"),
+        max_tokens=int(body.get("max_tokens", 4096)),
+        dataset=dataset,
+        tags=body.get("tags") or [],
+        client_id=agent_id if agent_id != "anonymous" else None,
+    )
+    return {"items": items}
+```
+
+> NOTE (verify): Task P2-1 renames `_wrapper(request)` → `_provider(request)`. If executing P2-2 before that rename lands, use `_wrapper`. The route uses `_provider` assuming P2-1 is merged first (P2 tasks are ordered).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/memory/test_recall_route.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/api/routes/memory.py tests/memory/test_recall_route.py
+git commit -m "feat(api): POST /api/memory/recall route (Hindsight preferred path) (P2)"
+```
+
+## Task P2-3: MCP `recall` tool
+
+**Files:**
+- Modify: `src/hal0/mcp/memory.py` (add `_memory_recall` handler + register)
+- Test: `tests/mcp/test_memory_recall_tool.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/mcp/test_memory_recall_tool.py`:
+
+```python
+"""MCP memory_recall tool (P2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.mcp.memory import make_dispatcher
+from tests.memory.fakes import FakeMemoryProvider
+
+
+class RecallProvider(FakeMemoryProvider):
+    async def recall(self, query, *, types=None, max_tokens=4096, dataset="shared", tags=None, client_id=None):
+        return [{"id": "d1", "text": "from-recall", "timestamp": "t", "dataset": "shared",
+                 "tags": [], "source": None, "metadata": {}, "score": None}]
+
+
+@pytest.mark.asyncio
+async def test_memory_recall_tool_dispatches():
+    dispatch = make_dispatcher(RecallProvider(client_id="alice"))
+    out = await dispatch("memory_recall", {"query": "hi", "max_tokens": 512})
+    assert out["status"] == "ok"
+    assert out["results"][0]["text"] == "from-recall"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/mcp/test_memory_recall_tool.py -v`
+Expected: FAIL — `memory_recall` not in `_MEMORY_HANDLERS` → `mcp.unknown_memory_tool`.
+
+- [ ] **Step 3: Add the handler + register it**
+
+In `src/hal0/mcp/memory.py`, add a handler after `_memory_search` (line 271):
+
+```python
+async def _memory_recall(
+    wrapper: Any,
+    args: dict[str, Any],
+    *,
+    client_id: str | None,
+    private: bool,
+) -> dict[str, Any]:
+    """memory_recall(query, max_tokens=4096, types?, dataset?, tags?) → {results}.
+
+    The Hindsight-preferred retrieval path: token-budgeted, observation
+    hierarchy, no numeric score. Provider.recall falls back to search on
+    engines without a richer recall (ABC default), so this tool is safe
+    regardless of active engine.
+    """
+    query = _require(args, "query", str)
+    if not query.strip():
+        raise MemorySchemaError("query must be non-empty")
+    max_tokens = args.get("max_tokens", 4096)
+    if not isinstance(max_tokens, int) or max_tokens < 1 or max_tokens > 32768:
+        raise MemorySchemaError("max_tokens must be 1..32768")
+    requested = args.get("dataset")
+    if isinstance(requested, list):
+        dataset: Any = [str(d) for d in requested]
+    elif requested is None or (isinstance(requested, str) and not requested):
+        dataset = ["shared", f"private:{client_id}"] if private and client_id else _DEFAULT_DATASET
+    elif isinstance(requested, str):
+        dataset = _resolve_dataset(requested, private=private, client_id=client_id)
+    else:
+        raise MemorySchemaError("dataset must be str | list[str] | null")
+    tags = _normalise_tags(args.get("tags"))
+    types = args.get("types")
+    results = await wrapper.recall(
+        query=query, types=types, max_tokens=max_tokens, dataset=dataset, tags=tags, client_id=client_id
+    )
+    return {"results": list(results)}
+```
+
+Add to `_MEMORY_HANDLERS` (line 331):
+
+```python
+    "memory_recall": _memory_recall,
+```
+
+Add an annotation in `_ANNOTATIONS` (line 400) and register it in `build_server` (after the `memory_search` registration, line 455):
+
+```python
+    _register("memory_recall", "Recall token-budgeted, consolidated memory (preferred over search).")
+```
+
+with annotation:
+
+```python
+    "memory_recall": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/mcp/test_memory_recall_tool.py -v`
+Expected: PASS (1 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/mcp/memory.py tests/mcp/test_memory_recall_tool.py
+git commit -m "feat(mcp): memory_recall tool (Hindsight preferred path) (P2)"
+```
+
+## Task P2-4: `hal0 memory migrate --dry-run`
+
+**Files:**
+- Create/Modify: the `hal0 memory` CLI group (find via `grep -rn "memory" src/hal0/cli/`)
+- Test: `tests/cli/test_memory_migrate.py` (create)
+
+Per spec [Q10]: the platform Cognee store has been dark since v0.4, so migration is **likely a no-op**. The command first measures, then dry-runs the row mapping.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/cli/test_memory_migrate.py`:
+
+```python
+"""hal0 memory migrate --dry-run (P2). No-op on empty/stale Cognee store."""
+
+from __future__ import annotations
+
+from hal0.memory.migrate import migrate_cognee_to_hindsight_dryrun
+
+
+def test_dry_run_reports_zero_on_empty_store(tmp_path):
+    # No sidecar file → empty store → no-op.
+    report = migrate_cognee_to_hindsight_dryrun(cognee_dir=tmp_path)
+    assert report == {"rows_total": 0, "rows_mapped": 0, "rows_unmapped": 0, "noop": True}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/cli/test_memory_migrate.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'hal0.memory.migrate'`
+
+- [ ] **Step 3: Write the dry-run mapper**
+
+Create `src/hal0/memory/migrate.py`:
+
+```python
+"""Cognee → Hindsight migration (brain-redesign P2, [Q10]).
+
+The platform Cognee store has been dark since v0.4 (memory OFF), so this is
+likely a no-op. The dry-run reads the sidecar SQLite (the canonical filter
+source) and reports rows mapped/unmapped without touching Hindsight. Cognee
+data stays read-only.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from hal0.memory.hindsight_provider import namespace_to_bank
+
+
+def migrate_cognee_to_hindsight_dryrun(*, cognee_dir: str | Path) -> dict[str, Any]:
+    sidecar = Path(cognee_dir) / "hal0_memory_index.sqlite"
+    if not sidecar.exists():
+        return {"rows_total": 0, "rows_mapped": 0, "rows_unmapped": 0, "noop": True}
+    with sqlite3.connect(sidecar) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT id, dataset FROM hal0_memory_items").fetchall()
+    total = len(rows)
+    if total == 0:
+        return {"rows_total": 0, "rows_mapped": 0, "rows_unmapped": 0, "noop": True}
+    mapped = 0
+    for row in rows:
+        bank = namespace_to_bank(row["dataset"])
+        if bank:
+            mapped += 1
+    return {
+        "rows_total": total,
+        "rows_mapped": mapped,
+        "rows_unmapped": total - mapped,
+        "noop": False,
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/cli/test_memory_migrate.py -v`
+Expected: PASS (1 passed)
+
+- [ ] **Step 5: Wire the CLI subcommand**
+
+Add `hal0 memory migrate --dry-run` to the `hal0 memory` CLI group, calling `migrate_cognee_to_hindsight_dryrun(cognee_dir="/var/lib/hal0/memory/cognee")` and printing the report. A live `--apply` (copy-into-Hindsight + verify count + spot recall parity) is gated behind a non-empty dry-run; since the store is expected empty, ship `--dry-run` first.
+
+> NOTE (verify): locate the existing `hal0 memory` Click/Typer group (`grep -rn "memory" src/hal0/cli/`) and add the subcommand in the repo's established CLI style. If no `memory` group exists yet, the command lands under `hal0 memory`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hal0/memory/migrate.py tests/cli/test_memory_migrate.py src/hal0/cli/
+git commit -m "feat(cli): hal0 memory migrate --dry-run (Cognee→Hindsight, no-op on empty) (P2)"
+```
+
+## Task P2-5: Flip the default engine → `hindsight`
+
+**Files:**
+- Modify: `src/hal0/memory/__init__.py` (`provider_from_config` default)
+- Test: `tests/memory/test_provider_factory.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/memory/test_provider_factory.py`:
+
+```python
+def test_factory_default_engine_is_hindsight_after_cutover():
+    from types import SimpleNamespace
+    # cfg with NO engine field → factory default must now be hindsight.
+    cfg = SimpleNamespace(memory=SimpleNamespace(
+        embedding=SimpleNamespace(model="m", rerank_enabled=False, rerank_url="u",
+                                  rerank_over_fetch_factor=5, rerank_max_candidates=500,
+                                  rerank_connect_timeout_s=1.0, rerank_read_timeout_s=8.0),
+        graph=SimpleNamespace(enabled=False, route="upstream")))
+    with patch("hal0.memory.HindsightProvider", autospec=True) as mock_cls, \
+         patch("hal0.memory._build_hindsight_client", return_value=object()):
+        provider_from_config(cfg)
+        assert mock_cls.called
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/memory/test_provider_factory.py::test_factory_default_engine_is_hindsight_after_cutover -v`
+Expected: FAIL — default resolves to `cognee`.
+
+- [ ] **Step 3: Flip the default**
+
+In `src/hal0/memory/__init__.py`, change the engine resolution line in `provider_from_config`:
+
+```python
+    engine = str(getattr(cfg.memory, "engine", "hindsight") or "hindsight").lower()
+```
+
+> NOTE (verify): `MemoryConfig.engine` (P1-1) defaults to `"cognee"` at the schema level. The fallback flag (spec) is `[memory] engine = "cognee"` → reverts. The factory's `getattr` default to `"hindsight"` only applies to a config object that lacks the field entirely (test doubles). On a real loaded config the schema default wins, so **also flip the schema default**: change `MemoryConfig.engine`'s `default="cognee"` → `default="hindsight"` in `src/hal0/config/schema.py`. Update `tests/config/test_memory_engine_field.py::test_engine_defaults_to_cognee` to assert `"hindsight"` and rename it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/memory/test_provider_factory.py tests/config/test_memory_engine_field.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/memory/__init__.py src/hal0/config/schema.py tests/memory/test_provider_factory.py tests/config/test_memory_engine_field.py
+git commit -m "feat(memory): cutover default engine cognee → hindsight; cognee = fallback flag (P2)"
+```
+
+## Task P2-6: Flip `HAL0_MEMORY_ENABLED=1`  *(OPS + template)*
+
+**Files:**
+- Modify: `installer/install.sh:527` (uncomment the template line)
+- Modify (on box): `/etc/hal0/api.env` + systemd reload (running instance)
+
+The gate default is NOT in `installer/api.env` (that file does not exist in-repo) — it is the heredoc template at `installer/install.sh:520-531`, which writes `/etc/hal0/api.env` at install time with `# HAL0_MEMORY_ENABLED=1` commented. **Two places must change**: the template (new installs) AND the running box's already-generated `/etc/hal0/api.env` (the template alone won't flip a live box).
+
+- [ ] **Step 1: Uncomment the install template line**
+
+In `installer/install.sh` lines 523-527, change:
+
+```bash
+# Memory subsystem (Cognee engine + /mcp/memory + the Agent → Memory tab)
+# is deferred in this release and ships disabled by default. Uncomment to
+# reintroduce it — no other change needed; the dashboard Agent nav returns
+# automatically once /api/status reports it live.
+# HAL0_MEMORY_ENABLED=1
+```
+
+to:
+
+```bash
+# Memory subsystem (Hindsight engine + /mcp/memory + the Agent → Memory tab)
+# is ENABLED by default as of v0.5 (brain re-enablement). Comment out to
+# ship with memory dark.
+HAL0_MEMORY_ENABLED=1
+```
+
+- [ ] **Step 2: Flip the running CT 105 box (Tier-2 verify-first)**
+
+```bash
+# Verify current state first:
+grep -n HAL0_MEMORY_ENABLED /etc/hal0/api.env
+# Set it live + reload:
+sudo sed -i 's/^# *HAL0_MEMORY_ENABLED=1/HAL0_MEMORY_ENABLED=1/' /etc/hal0/api.env
+grep -q '^HAL0_MEMORY_ENABLED=1' /etc/hal0/api.env || echo 'HAL0_MEMORY_ENABLED=1' | sudo tee -a /etc/hal0/api.env
+sudo systemctl restart hal0-api.service
+curl -fsS http://127.0.0.1:8080/api/status | python -c "import sys,json; print(json.load(sys.stdin).get('memory_enabled'))"
+# Expect: True
+```
+
+- [ ] **Step 3: Commit the template change**
+
+```bash
+git add installer/install.sh
+git commit -m "ops(memory): enable HAL0_MEMORY_ENABLED=1 by default (v0.5 brain re-enablement) (P2)"
+```
+
+**P2 Exit:** Migration within threshold (or no-op); default boot uses Hindsight; `add/search/list/delete` green over both transports; namespace isolation + `private:` rejection + foreign-private fail-open-empty pass against the live engine; gate is ON; fallback flag cleanly reverts to the untouched Cognee store. **Rollback:** set `[memory] engine = "cognee"` + restart → instant revert (Cognee never mutated).
+
+---
+
+# P5-H — Hermes convergence
+
+*Make Hermes use the one shared brain as its single source of truth — storage AND cognitive — and retire the spike's `local_embedded` instance.*
+
+## Task P5H-1: Rename the plugin `hal0-cognee` → `hal0-memory` (`memory_cognee` → `memory_hindsight`)
+
+**Files:**
+- Create: `src/hal0/agents/hermes/plugins/memory_hindsight/` (move of `memory_cognee/`)
+- Modify: `src/hal0/agents/hermes/driver.py:55` (plugin-tree reference)
+- Create (rename): `tests/agents/hermes_plugins/test_memory_hindsight_provider.py`
+
+- [ ] **Step 1: Write the failing rename test**
+
+Create `tests/agents/hermes_plugins/test_memory_hindsight_provider.py`:
+
+```python
+"""Renamed hal0-memory Hermes plugin (P5-H)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.agents.hermes.plugins.memory_hindsight.provider import Hal0MemoryProvider
+
+
+def test_provider_name_is_hal0_memory():
+    assert Hal0MemoryProvider().name == "hal0-memory"
+
+
+def test_no_dataset_field_ever_sent():
+    # The #317 contract: the client never sends a dataset key.
+    from hal0.agents.hermes.plugins.memory_hindsight._client import Hal0MemoryClient
+
+    import inspect
+    src = inspect.getsource(Hal0MemoryClient.add)
+    assert '"dataset"' not in src and "'dataset'" not in src
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/agents/hermes_plugins/test_memory_hindsight_provider.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'hal0.agents.hermes.plugins.memory_hindsight'`
+
+- [ ] **Step 3: Rename the package + class + plugin name**
+
+```bash
+git mv src/hal0/agents/hermes/plugins/memory_cognee src/hal0/agents/hermes/plugins/memory_hindsight
+```
+
+In `src/hal0/agents/hermes/plugins/memory_hindsight/provider.py`:
+- Rename `class Hal0CogneeProvider` → `class Hal0MemoryProvider`.
+- Change `def name(self) -> str: return "hal0-cognee"` → `return "hal0-memory"`.
+- Replace remaining `hal0-cognee` strings (system_prompt_block text, log prefixes) with `hal0-memory`.
+
+In `src/hal0/agents/hermes/plugins/memory_hindsight/__init__.py`:
+- `from .provider import Hal0MemoryProvider`; `register` registers `Hal0MemoryProvider()`.
+
+In `src/hal0/agents/hermes/plugins/memory_hindsight/plugin.yaml`:
+- `name: hal0-memory`; update the description to reference Hindsight.
+
+In `src/hal0/agents/hermes/plugins/memory_hindsight/README.md`:
+- Retitle `# hal0-memory`; update the contract table `Plugin name` → `hal0-memory`; update the dir paths to `memory_hindsight/` and the deploy target `$HERMES_HOME/plugins/memory/hal0-memory/`.
+
+In `src/hal0/agents/hermes/driver.py:55`, change the comment/reference `memory_cognee` → `memory_hindsight`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/agents/hermes_plugins/test_memory_hindsight_provider.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/hal0/agents/hermes/plugins/ src/hal0/agents/hermes/driver.py tests/agents/hermes_plugins/test_memory_hindsight_provider.py
+git rm tests/agents/hermes_plugins/test_memory_cognee_provider.py 2>/dev/null || true
+git commit -m "refactor(hermes): rename hal0-cognee plugin → hal0-memory (memory_hindsight) (P5-H)"
+```
+
+## Task P5H-2: Wire `prefetch`→`recall` and `sync_turn`/`on_memory_write`→`retain`
+
+**Files:**
+- Modify: `src/hal0/agents/hermes/plugins/memory_hindsight/_client.py` (add `recall`)
+- Modify: `src/hal0/agents/hermes/plugins/memory_hindsight/provider.py` (`prefetch` → recall depth)
+- Test: `tests/agents/hermes_plugins/test_memory_hindsight_provider.py` (extend)
+
+Per spec P5-H: `prefetch(query)` → `recall(types=['observation','world'], max_tokens=…)` instead of flat `search(limit=5)`; `sync_turn`/`on_memory_write` → Hindsight `retain` (which `HindsightProvider.add` already routes to). **Depends on the P2 `recall` route** — the plugin must call `recall`, not `search`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/agents/hermes_plugins/test_memory_hindsight_provider.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_client_recall_hits_recall_route():
+    import httpx
+
+    seen: list[tuple[str, str, dict]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        import json
+        seen.append((request.method, request.url.path, json.loads(request.content or b"{}")))
+        return httpx.Response(200, json={"items": [{"text": "obs"}]})
+
+    from hal0.agents.hermes.plugins.memory_hindsight._client import Hal0MemoryClient
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://x") as http:
+        client = Hal0MemoryClient(http_client=http)
+        await client.recall("what do I know", types=["observation", "world"], max_tokens=2048)
+
+    assert seen[0][0] == "POST" and seen[0][1] == "/api/memory/recall"
+    assert seen[0][2]["types"] == ["observation", "world"]
+    # The #317 contract still holds — no dataset key.
+    assert "dataset" not in seen[0][2]
+
+
+def test_prefetch_uses_recall_not_search():
+    import inspect
+    from hal0.agents.hermes.plugins.memory_hindsight.provider import Hal0MemoryProvider
+
+    src = inspect.getsource(Hal0MemoryProvider.prefetch)
+    assert ".recall(" in src and ".search(" not in src
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/agents/hermes_plugins/test_memory_hindsight_provider.py -k "recall or prefetch" -v`
+Expected: FAIL — `_client.py` has no `recall`; `prefetch` still calls `.search`.
+
+- [ ] **Step 3: Add `recall` to the client + rewire `prefetch`**
+
+In `src/hal0/agents/hermes/plugins/memory_hindsight/_client.py`, add a `recall` method beside `search`:
+
+```python
+    async def recall(
+        self,
+        query: str,
+        *,
+        types: list[str] | None = None,
+        max_tokens: int = 4096,
+    ) -> dict[str, Any]:
+        """POST /api/memory/recall — token-budgeted, consolidated recall.
+
+        Hindsight's preferred path (observation hierarchy). Omits ``dataset``
+        by design — the server resolves the namespace from ``X-hal0-Agent``
+        (the #317 contract).
+        """
+        payload: dict[str, Any] = {"query": query, "max_tokens": int(max_tokens)}
+        if types is not None:
+            payload["types"] = list(types)
+        return await self._request("POST", "/api/memory/recall", json=payload)
+```
+
+In `src/hal0/agents/hermes/plugins/memory_hindsight/provider.py`, change `prefetch` to call `recall`:
+
+```python
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not query or self._client is None:
+            return ""
+        try:
+            result = asyncio.run(
+                self._client.recall(query, types=["observation", "world"], max_tokens=2048)
+            )
+        except Hal0MemoryClientError as exc:
+            logger.debug("hal0-memory prefetch transport failure: %s", exc)
+            return ""
+        except RuntimeError as exc:
+            logger.debug("hal0-memory prefetch asyncio drift: %s", exc)
+            return ""
+
+        items = result.get("items") if isinstance(result, dict) else None
+        if not items:
+            return ""
+        lines = []
+        for item in items:
+            if isinstance(item, dict):
+                text = item.get("text") or item.get("content") or ""
+                if text:
+                    lines.append(f"- {text}")
+        if not lines:
+            return ""
+        return "## hal0-memory recall\n" + "\n".join(lines)
+```
+
+`sync_turn` + `on_memory_write` already call `self._client.add(...)`, which lands on `/api/memory/add` → `HindsightProvider.add` → `retain`. No change needed there beyond the rename done in P5H-1 (verify the `tags=["chat", "hermes"]` calls remain).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/agents/hermes_plugins/test_memory_hindsight_provider.py -k "recall or prefetch" -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hal0/agents/hermes/plugins/memory_hindsight/_client.py src/hal0/agents/hermes/plugins/memory_hindsight/provider.py tests/agents/hermes_plugins/test_memory_hindsight_provider.py
+git commit -m "feat(hermes): prefetch→recall, sync_turn→retain via hal0-memory plugin (P5-H)"
+```
+
+## Task P5H-3: Set Hermes `config.yaml` `memory.provider = hal0-memory` + retire `local_embedded`  *(OPS CHECKLIST)*
+
+Ops task on CT 105 (no unit test). Exact files from auto-memory `hal0_hindsight_hermes_spike`.
+
+**Files / artifacts (on box) — probe-confirmed paths:**
+- `/var/lib/hal0/.hermes/config.yaml` (canonical `HERMES_HOME`; flip `provider:` — guard a)
+- `/var/lib/hal0/venvs/hermes/` (the venv — `pip uninstall hindsight-all hindsight-api-slim hindsight-embed hindsight-client` — guard b)
+- `/var/lib/hal0/.hermes/hindsight/config.json` (remove — whole dir)
+- `/etc/systemd/system/hal0-agent@hermes.service.d/20-hindsight.conf` (+`.bak.2026-06-04`) (remove; **keep** `21-hermes-subpackages.conf`)
+- `/usr/local/sbin/hal0-hindsight-wrap-patch.py` + `/usr/local/sbin/hal0-hindsight-killgrace-patch.py` (remove both ExecStartPre hooks)
+- `/var/lib/hal0/.pg0/instances/hindsight-embed-hermes/data` (init-orphaned Postgres 18.1.0 — stop explicitly, then `rm -rf /var/lib/hal0/.pg0`, 61 MB)
+- `/var/lib/hal0/.hermes/hf-cache` (embedding-model cache, 216 MB — reclaim)
+- Revert backups (for rollback): `config.yaml.bak-pre-hindsight-*`, `.env.bak-pre-hindsight-*`
+
+- [ ] **Step 1: Point Hermes at the renamed plugin**
+
+Set `memory.provider: hal0-memory` in `/var/lib/hal0/.hermes/config.yaml` (via `hermes_cli.config` save_config, run AS hal0 — never as root, spike gotcha #5). Hermes memory now flows `hal0-memory plugin → /api/memory/* (ACL + namespace) → HindsightProvider → shared hindsight-api`, landing in `private:hermes` + `shared`.
+
+> **Probe-confirmed (2026-06-06).** The spike is *dormant, not retired*: `provider: hindsight`
+> is still set (`config.yaml:315`) AND the embedded **Postgres 18.1.0** is still running
+> (pid orphaned to init, `127.0.0.1:5432`). There are **TWO independent respawn guards** —
+> `hindsight_embed/daemon_embed_manager.py` lazily re-spawns pg + `hindsight-api` on the
+> next retain/recall if *either* (a) `memory.provider` still names `hindsight`, OR (b)
+> `hindsight-embed` is still installed. Both must go, provider flipped FIRST (Step 1). The
+> orphaned pg is reparented to **init** — restarting the Hermes unit will NOT kill it; it
+> must be stopped explicitly (Step 4). Correct venv = `/var/lib/hal0/venvs/hermes/`.
+
+- [ ] **Step 2: Retire `local_embedded` — uninstall ALL hindsight packages (respawn guard b)**
+
+```bash
+# Guard (b): uninstall the full set — `hindsight-all` is a meta-pkg and does NOT cascade to
+# `hindsight-embed`, which is the actual respawn launcher. All four must go.
+sudo -u hal0 /var/lib/hal0/venvs/hermes/bin/pip uninstall -y \
+  hindsight-all hindsight-api-slim hindsight-embed hindsight-client
+# Confirm the binaries are gone:
+ls /var/lib/hal0/venvs/hermes/bin/ | grep -i hindsight   # expect: no output
+```
+
+- [ ] **Step 3: Remove the spike's config + systemd drop-in + BOTH patch scripts**
+
+```bash
+sudo rm -f /var/lib/hal0/.hermes/hindsight/config.json   # whole hindsight/ dir is just this
+sudo rm -f /etc/systemd/system/hal0-agent@hermes.service.d/20-hindsight.conf \
+           /etc/systemd/system/hal0-agent@hermes.service.d/20-hindsight.conf.bak.2026-06-04
+# KEEP 21-hermes-subpackages.conf — that is the unrelated hermes_cli packaging fix (#34701).
+sudo rm -f /usr/local/sbin/hal0-hindsight-wrap-patch.py \
+           /usr/local/sbin/hal0-hindsight-killgrace-patch.py   # BOTH ExecStartPre patch hooks
+sudo systemctl daemon-reload
+```
+
+- [ ] **Step 4: Stop the init-orphaned embedded pg + reclaim disk**
+
+```bash
+# The embedded pg (pid was 9858 at probe time; re-find it) is reparented to init and is NOT
+# tied to the hermes unit — it survives a unit restart. Stop it explicitly, then delete.
+PGDATA=/var/lib/hal0/.pg0/instances/hindsight-embed-hermes/data
+sudo -u hal0 /var/lib/hal0/.pg0/installation/18.1.0/bin/pg_ctl stop -D "$PGDATA" -m fast || \
+  sudo pkill -f 'postgres -D .*hindsight-embed-hermes'
+sudo rm -rf /var/lib/hal0/.pg0                      # 61 MB — bundled pg binaries + the embed instance
+sudo rm -rf /var/lib/hal0/.hermes/hf-cache          # 216 MB — embedding-model cache pulled by the embedded API
+```
+
+- [ ] **Step 5: [Q8] Confirm NO daemon re-spawns (both guards verified)**
+
+After both guards are removed, restart the Hermes unit, run a memory turn, and confirm nothing re-spawns:
+
+```bash
+sudo systemctl restart hal0-agent@hermes.service
+sudo -u hal0 hermes chat <<<'remember: smoke test of the shared brain
+exit'                                               # exercises retain/recall via the new provider
+# Expect: NO hindsight-api spawned from the hermes venv, NO embedded pg back on :5432.
+ps aux | grep -i 'hindsight\|hindsight-embed' | grep -v grep   # expect: empty
+ss -ltnp | grep ':5432'                                        # expect: empty (embedded pg gone)
+# The ONLY hindsight that should be listening is the shared platform unit from P1-6.
+```
+
+- [ ] **Step 6: Record the outcome** in `docs/internal/brain-redesign/ops/hindsight-deploy.md` under "P5-H local_embedded retirement" (note both guards removed, pg stopped, disk reclaimed).
+
+## Task P5H-4: Lock the canonical Hermes config against the root-clobber regression  *(OPS CHECKLIST)*
+
+Per spec P5-H + auto-memory `hermes_home_migration_splitbrain` (spike gotcha #5): running hermes as root rewrites `config.yaml` to `root:root 0600` and silently falls back to the default provider.
+
+- [ ] **Step 1: Verify the self-guarding wrapper is in place**
+
+```bash
+head -20 /usr/local/bin/hermes   # must re-exec as hal0 from a hal0-traversable cwd + export HF_HOME
+ls -la /usr/local/bin/hermes.bak-pre-selfguard 2>/dev/null  # backup from the durable fix
+```
+
+- [ ] **Step 2: Verify + repair ownership**
+
+```bash
+stat -c '%U:%G %a' /var/lib/hal0/.hermes/config.yaml   # expect hal0:hal0 (NOT root:root 0600)
+sudo chown hal0:hal0 /var/lib/hal0/.hermes/config.yaml
+```
+
+- [ ] **Step 3: Smoke — a root TUI session must NOT clobber the config**
+
+```bash
+# Launch hermes as root (the self-guard should re-exec as hal0); on exit, re-check:
+sudo hermes chat <<<'exit' || true
+stat -c '%U:%G %a' /var/lib/hal0/.hermes/config.yaml   # still hal0:hal0
+grep -n 'provider' /var/lib/hal0/.hermes/config.yaml   # still hal0-memory
+```
+
+- [ ] **Step 4: Record the verification** in `hindsight-deploy.md`.
+
+## Task P5H-5: Add the §4b ground-truth precedence stanza to SOUL.md (cognitive source of truth)
+
+**Files:**
+- Modify (deployed): `/var/lib/hal0/.hermes/SOUL.md` (canonical, under `HERMES_HOME`)
+- Modify (in-repo template, if present): `src/hal0/agents/hermes/templates/SOUL.md`
+
+SOUL.md is written under `HERMES_HOME` (driver.py:315) — it is a deployed identity doc, not a checked-in source file in the main tree. Add the precedence ladder so Hermes *trusts* recalled memory instead of re-deriving (spec §4b).
+
+- [ ] **Step 1: Locate the canonical SOUL.md + any in-repo template**
+
+```bash
+ls -la /var/lib/hal0/.hermes/SOUL.md
+grep -rln "SOUL.md\|ground-truth\|precedence" src/hal0/agents/hermes/ installer/
+```
+
+> NOTE (verify): if hal0 ships a SOUL.md *template* in-repo (so the stanza is provisioned on fresh installs), edit that template too. If SOUL.md is only ever authored on-box, this task edits the deployed file and the change is recorded in the runbook. The spike found SOUL.md at `/var/lib/hal0/.hermes/SOUL.md`.
+
+- [ ] **Step 2: Append the precedence stanza**
+
+Add to SOUL.md:
+
+```markdown
+## Ground-truth precedence (shared brain)
+
+When sources conflict, rank them in this order — higher always wins:
+
+1. **Safety / identity rules** (this SOUL, the rulebook, CLAUDE.md-class) — never overridden by a recalled memory.
+2. **Live system / tool state** (terminal output, tool results) — what is true *now*.
+3. **Recalled memory (shared brain)** — authoritative for project knowledge/decisions, **above your model priors**. Trust the recalled block; do not re-derive what it already states.
+4. **Official documentation** — wins for version-specifics.
+5. **Training priors** — reference only; always verify.
+
+A recalled memory never overrides rules (1) or live state (2), but it **does** override your prior assumptions (5). If recall gives you a project fact, act on it instead of re-discovering it.
+```
+
+- [ ] **Step 3: Encode the within-memory ranking as Hindsight directives**
+
+On the shared `hindsight-api`, set priority-ordered **directives** on the `private__hermes` + `shared` banks so curated observations/mental-models rank first (the within-memory half of §4b). Use the Hindsight directives API (hindsight-docs `developer/api/memory-banks.md`):
+
+```bash
+# Example (adjust to the deployed CLI/REST surface):
+curl -fsS -X POST http://127.0.0.1:9177/v1/default/banks/shared/directives \
+  -H 'Authorization: Bearer lemonade-local-noauth' -H 'Content-Type: application/json' \
+  -d '{"text": "Prefer consolidated observations and shared decisions over raw episodic facts when answering.", "priority": 1}'
+```
+
+> NOTE (verify): confirm the exact directives endpoint/shape against the deployed Hindsight version (`memory-banks.md`); adjust the curl if the path differs.
+
+- [ ] **Step 4: Record the stanza + directives** in `hindsight-deploy.md`. Commit any in-repo template change:
+
+```bash
+git add src/hal0/agents/hermes/templates/SOUL.md 2>/dev/null || true
+git commit -m "feat(hermes): ground-truth precedence stanza in SOUL.md (Layer-7, cognitive SoT) (P5-H)" || true
+```
+
+## Task P5H-6: Lock the Hermes memory config (single active provider invariant)
+
+**Files:**
+- Modify (on box): `/var/lib/hal0/.hermes/config.yaml`
+
+Per spec: **NO** background second store — Hermes' generic built-in memory stays OFF. Exactly one active provider.
+
+- [ ] **Step 1: Confirm the single-provider invariant**
+
+```bash
+grep -nA3 'memory:' /var/lib/hal0/.hermes/config.yaml
+# Expect: provider: hal0-memory ; NO second provider; built-in memory not also active.
+```
+
+- [ ] **Step 2: Verify the plugin kind is `exclusive`**
+
+`plugin.yaml` ships `kind: exclusive` (MemoryManager single-external-provider invariant — confirmed in P5H-1). Confirm the deployed plugin retains it.
+
+- [ ] **Step 3: Live-turn smoke** — a Hermes turn shows `prefetch` returning a recalled block that Hermes acts on (no redundant re-discovery):
+
+```bash
+sudo -u hal0 hermes chat   # run a turn that should hit a stored fact; confirm the recalled block appears + is used
+```
+
+- [ ] **Step 4: Record** the live-turn outcome in `hindsight-deploy.md`.
+
+## Task P5H-MIG: Start fresh — abandon the spike `hermes` bank (NO migration)  *(OPS — decision recorded)*
+
+**Decision (2026-06-06, owner + on-box probe).** Do **not** migrate the spike's embedded
+`hermes` bank. The probe found it holds **5 spike-test memory_units / 4 docs / 17 entities**
+against **40 failed retains vs 10 completed** (the extraction pipeline failed ~3× more than
+it succeeded) — zero production value, 10 MB. Migrating 5 test rows is not worth the
+pg-level schema/version-compat risk. Hermes **starts fresh**: its `private:hermes` + `shared`
+banks **auto-create on first write** against the shared `hindsight-api`. The embedded pg is
+deleted in **Task P5H-3 Step 4**, not dumped. (A native `hindsight-admin backup --schema
+public` → `restore` vehicle *exists* as a fallback if continuity is ever wanted, but it is
+schema-scoped + destructive-on-restore and not worth invoking here.)
+
+- [ ] **Step 1: Confirm the shared instance has a clean slate for Hermes**
+
+```bash
+# Against the shared platform hindsight-api (P1-6). Banks auto-create, so "absent" is fine —
+# the point is to confirm no STALE private:hermes data is lurking from a prior experiment.
+curl -fsS http://127.0.0.1:<shared_api_port>/v1/default/banks 2>/dev/null | jq '.[].bank_id' \
+  || echo "no banks yet — expected on a fresh shared instance"
+# Expect: neither private__hermes nor shared exist yet, OR exist and are empty.
+```
+
+- [ ] **Step 2: Verify fresh accumulation works** — the P5H-3 Step 5 smoke turn (a `remember:`
+  + recall) is the proof: after it runs, `private__hermes` exists in the shared instance and
+  recall returns the just-stored fact. No separate action needed here; this task only records
+  that migration was deliberately skipped.
+
+- [ ] **Step 3: Record the abandon decision** in `docs/internal/brain-redesign/ops/hindsight-deploy.md`
+  ("P5-H: spike `hermes` bank abandoned, not migrated — 5 test rows, 40 failed retains; started
+  fresh; embedded pg deleted in P5H-3").
+
+**P5-H Exit:** Hermes runs with a single `hal0-memory` provider; the `local_embedded` install is gone (both respawn guards removed, embedded pg stopped + deleted, no wrap-patch); Hermes' `private:hermes`/`shared` banks exist in the shared instance and accept new writes (**started fresh** — no spike data carried over); a live turn shows `prefetch` returning a recalled block Hermes acts on; `config.yaml` survives a root TUI session without clobber. **Rollback:** per-surface — the provider can revert (backups `config.yaml.bak-pre-hindsight-*` exist); the SOUL.md stanza is additive. (Note: retirement deletes the embedded pg, so reverting to `local_embedded` would mean a clean re-spike, not a restore — acceptable given the data was disposable.)
+
+---
+
+## Self-Review
+
+Run after writing — see the bottom of this file for the recorded pass.

--- a/installer/systemd/hindsight-api.service
+++ b/installer/systemd/hindsight-api.service
@@ -28,10 +28,15 @@ Environment=HF_HOME=/var/lib/hal0/memory/hindsight/hf-cache
 # A NON-EMPTY key is required even for no-auth lemond (spike gotcha #1).
 Environment=HINDSIGHT_API_LLM_PROVIDER=openai
 Environment=HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:13305/v1
-Environment=HINDSIGHT_API_LLM_MODEL=qwen3-it-4b-FLM
+# [Q5'] RESOLVED the official way (NO in-tree wrap-patch): the NPU model
+# qwen3-it-4b-FLM ignores response_format and returns a bare JSON *list*, which
+# Hindsight's fact_extraction rejects ("non-dict JSON: list"). Use a grammar-
+# capable GGUF *instruct* (non-reasoning) model on lemond instead — it honors
+# response_format and emits {"facts":[...]}. Verified live: gemma-4-26b-a4b-it
+# returns a dict; qwen3.5-4b (reasoning) returned empty.
+Environment=HINDSIGHT_API_LLM_MODEL=gemma-4-26b-a4b-it-q4kxl
 Environment=HINDSIGHT_API_LLM_API_KEY=lemonade-local-noauth
-# NPU extraction is slow (~45-90s/extract, async); raise the LLM timeout so
-# fact extraction doesn't abort mid-call (spike model finding).
+# Generous timeout: first call includes lemond model load (~38s observed).
 Environment=HINDSIGHT_API_LLM_TIMEOUT=180
 
 # Embeddings + reranker are LOCAL (bundled BGE 384-d + MiniLM cross-encoder) —

--- a/installer/systemd/hindsight-api.service
+++ b/installer/systemd/hindsight-api.service
@@ -28,16 +28,21 @@ Environment=HF_HOME=/var/lib/hal0/memory/hindsight/hf-cache
 # A NON-EMPTY key is required even for no-auth lemond (spike gotcha #1).
 Environment=HINDSIGHT_API_LLM_PROVIDER=openai
 Environment=HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:13305/v1
-# [Q5'] RESOLVED the official way (NO in-tree wrap-patch): the NPU model
-# qwen3-it-4b-FLM ignores response_format and returns a bare JSON *list*, which
-# Hindsight's fact_extraction rejects ("non-dict JSON: list"). Use a grammar-
-# capable GGUF *instruct* (non-reasoning) model on lemond instead — it honors
-# response_format and emits {"facts":[...]}. Verified live: gemma-4-26b-a4b-it
-# returns a dict; qwen3.5-4b (reasoning) returned empty.
-Environment=HINDSIGHT_API_LLM_MODEL=gemma-4-26b-a4b-it-q4kxl
+# [Q5'] RESOLVED on the NPU (frees the iGPU; no in-tree wrap-patch). History:
+#  - qwen3-it-4b-FLM (NPU): ignores response_format -> bare JSON *list* -> rejected.
+#  - gemma-4-26b-a4b-it-q4kxl (iGPU GGUF): returns {"facts":[...]} but contends
+#    with the 35B primary on the iGPU (eviction risk).
+#  - gemma4-it:e2b/e4b (NPU): BLOCKED — amdxdna HWCTX alloc fails (err=-22) on
+#    NPU FW 1.1.2.65 / amdxdna 0.7; Gemma-3n NPU2 arch unsupported by this driver.
+# CHOSEN: gemma3-4b-FLM (NPU). gemma3 arch loads on this NPU; emits a ```json-
+# fenced {"facts":[...]} which Hindsight's fact_extraction strips + parses.
+# Verified live: retain+recall end-to-end green. Runs on the NPU -> iGPU stays
+# free for the primary (removes the P2-6 eviction risk). Slower (~160s/extract)
+# but retain is async/background so it doesn't block.
+Environment=HINDSIGHT_API_LLM_MODEL=gemma3-4b-FLM
 Environment=HINDSIGHT_API_LLM_API_KEY=lemonade-local-noauth
-# Generous timeout: first call includes lemond model load (~38s observed).
-Environment=HINDSIGHT_API_LLM_TIMEOUT=180
+# NPU extraction is slow (~160s incl. first-call trio load). Generous timeout.
+Environment=HINDSIGHT_API_LLM_TIMEOUT=300
 
 # Embeddings + reranker are LOCAL (bundled BGE 384-d + MiniLM cross-encoder) —
 # the full `hindsight-api` package default. No external embed/rerank config needed.

--- a/installer/systemd/hindsight-api.service
+++ b/installer/systemd/hindsight-api.service
@@ -1,0 +1,54 @@
+[Unit]
+Description=hal0 shared Hindsight memory engine (platform brain)
+# lemond provides the extraction LLM (qwen3-it-4b-FLM). Soft ordering: an
+# unknown unit name here is ignored by systemd, so this is best-effort.
+After=network-online.target hal0-lemonade.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=hal0
+Group=hal0
+WorkingDirectory=/var/lib/hal0/memory/hindsight
+
+# --- pg0 embedded Postgres data root ---
+# Hindsight's embedded pg0 lives at $HOME/.pg0 (there is NO HINDSIGHT_API_DATA_DIR
+# env var — verified against hindsight-docs 0.7.2). Pin HOME so pg0 persists under
+# the hal0 data root rather than the hal0 service user's default home.
+Environment=HOME=/var/lib/hal0/memory/hindsight
+
+# --- writable HF cache (spike gotcha #2) ---
+# Default HF cache symlinks to read-only /mnt/ai-models and dies downloading the
+# local BGE embedder; point HF_HOME at this hal0-writable dir.
+Environment=HF_HOME=/var/lib/hal0/memory/hindsight/hf-cache
+
+# --- extraction / consolidation / reflect LLM -> lemond (OpenAI-compatible) ---
+# Provider value is `openai` for any OpenAI-compatible endpoint; base_url MUST
+# include the /v1 suffix (verified: hindsight-docs models.md examples).
+# A NON-EMPTY key is required even for no-auth lemond (spike gotcha #1).
+Environment=HINDSIGHT_API_LLM_PROVIDER=openai
+Environment=HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:13305/v1
+Environment=HINDSIGHT_API_LLM_MODEL=qwen3-it-4b-FLM
+Environment=HINDSIGHT_API_LLM_API_KEY=lemonade-local-noauth
+# NPU extraction is slow (~45-90s/extract, async); raise the LLM timeout so
+# fact extraction doesn't abort mid-call (spike model finding).
+Environment=HINDSIGHT_API_LLM_TIMEOUT=180
+
+# Embeddings + reranker are LOCAL (bundled BGE 384-d + MiniLM cross-encoder) —
+# the full `hindsight-api` package default. No external embed/rerank config needed.
+# (P2-5 may repoint the reranker at lemond's bge-reranker-v2-m3 for §4b.)
+# CT 105 has no NVIDIA GPU (Strix Halo iGPU only) — force CPU so torch/onnx don't
+# probe for CUDA. The bundled CUDA torch wheels are unused dead weight on this box.
+Environment=HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=true
+Environment=HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU=true
+
+# Bind to localhost on the pinned port so the provider/client don't chase a
+# dynamic port (spike gotcha #3). hal0-api proxies this; not LAN-exposed.
+ExecStart=/var/lib/hal0/memory/hindsight/.venv/bin/hindsight-api --host 127.0.0.1 --port 9177
+
+Restart=on-failure
+RestartSec=3
+TimeoutStartSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/src/hal0/agents/hermes/plugins/memory_cognee/_client.py
+++ b/src/hal0/agents/hermes/plugins/memory_cognee/_client.py
@@ -131,16 +131,21 @@ class Hal0MemoryClient:
         return await self._request("POST", "/api/memory/search", json=payload)
 
     async def list_items(self, *, limit: int = 50) -> dict[str, Any]:
-        """GET /api/memory — page through stored items.
+        """GET /api/memory/list — page through stored items.
 
-        ``limit`` is forwarded as a query parameter so the server can
-        cap the response; pagination cursors are an upstream concern.
+        ``limit`` is forwarded as a query parameter; the server resolves the
+        dataset from ``X-hal0-Agent``. (Was GET /api/memory — a 404 — fixed
+        in P0.)
         """
-        return await self._request("GET", "/api/memory", params={"limit": int(limit)})
+        return await self._request("GET", "/api/memory/list", params={"limit": int(limit)})
 
     async def delete(self, item_id: str) -> dict[str, Any]:
-        """DELETE /api/memory/{id} — remove a single memory item."""
-        return await self._request("DELETE", f"/api/memory/{item_id}")
+        """POST /api/memory/delete — remove memory items by id.
+
+        The router exposes a body-based bulk delete (``{ids: [...]}``), not a
+        path-param DELETE. (Was DELETE /api/memory/{id} — a 404 — fixed in P0.)
+        """
+        return await self._request("POST", "/api/memory/delete", json={"ids": [item_id]})
 
     # ── transport core ─────────────────────────────────────────────────
 

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1471,7 +1471,7 @@ def create_app() -> FastAPI:
 
     app.state.approval_queue = ApprovalQueue()
 
-    memory_wrapper = None
+    memory_provider = None
     # 0.4 release gate — memory subsystem deferred. The memory engine
     # (Cognee), its MCP server (/mcp/memory), the REST surface
     # (/api/memory/*), and the dashboard's Agent → Memory tab ship
@@ -1480,58 +1480,19 @@ def create_app() -> FastAPI:
     # to reintroduce it with NO code change — every downstream caller
     # (admin MCP routing, /api/memory/* routes, the Hermes memory provider,
     # per-agent memory stats) already degrades to a no-op / 503 when
-    # app.state.memory_wrapper is None, so flipping the flag is the whole
+    # app.state.memory_provider is None, so flipping the flag is the whole
     # toggle. Default off so behaviour is identical on fresh AND upgraded
     # installs (api.env is not rewritten on upgrade).
     if os.environ.get("HAL0_MEMORY_ENABLED", "0") != "1":
         log.info("hal0.memory.disabled", reason="HAL0_MEMORY_ENABLED!=1")
     else:
         try:
-            from hal0.memory import CogneeWrapper
+            from hal0.memory import provider_from_config
 
-            # ADR-0014: pull [memory.graph] gate + route at boot so a
-            # process restart preserves the user's pick. Defaults match
-            # the v0.3 ship matrix (enabled=False, route="upstream").
-            # Issue #116: same goes for [memory.embedding].
-            try:
-                _hal0_cfg = load_hal0_config()
-                _graph_cfg = _hal0_cfg.memory.graph
-                _graph_enabled = bool(_graph_cfg.enabled)
-                _graph_route = str(_graph_cfg.route)
-                _embed_cfg = _hal0_cfg.memory.embedding
-                _embed_model = str(_embed_cfg.model)
-                _rerank_enabled = bool(_embed_cfg.rerank_enabled)
-                _rerank_url = str(_embed_cfg.rerank_url)
-                _rerank_over_fetch_factor = int(_embed_cfg.rerank_over_fetch_factor)
-                _rerank_max_candidates = int(_embed_cfg.rerank_max_candidates)
-                _rerank_connect_timeout_s = float(_embed_cfg.rerank_connect_timeout_s)
-                _rerank_read_timeout_s = float(_embed_cfg.rerank_read_timeout_s)
-            except Exception as exc:  # pragma: no cover — defensive
-                log.warning("hal0.memory.cfg_load_failed", error=str(exc))
-                _graph_enabled = False
-                _graph_route = "upstream"
-                _embed_model = "BAAI/bge-small-en-v1.5"
-                _rerank_enabled = False
-                _rerank_url = "http://127.0.0.1:8086"
-                _rerank_over_fetch_factor = 5
-                _rerank_max_candidates = 500
-                _rerank_connect_timeout_s = 1.0
-                _rerank_read_timeout_s = 8.0
-
-            memory_wrapper = CogneeWrapper(
-                embedding_model=_embed_model,
-                graph_enabled=_graph_enabled,
-                graph_route=_graph_route,
-                rerank_enabled=_rerank_enabled,
-                rerank_url=_rerank_url,
-                rerank_over_fetch_factor=_rerank_over_fetch_factor,
-                rerank_max_candidates=_rerank_max_candidates,
-                rerank_connect_timeout_s=_rerank_connect_timeout_s,
-                rerank_read_timeout_s=_rerank_read_timeout_s,
-            )
+            memory_provider = provider_from_config(load_hal0_config())
         except Exception as exc:  # pragma: no cover — defensive
             log.warning("hal0.memory.init_failed", error=str(exc))
-    app.state.memory_wrapper = memory_wrapper
+    app.state.memory_provider = memory_provider
 
     # In-process memory dispatcher (Phase 8 closeout, ADR-0004 §7).
     # When Cognee is up, instantiate one MemoryDispatcher and hand it to
@@ -1541,13 +1502,13 @@ def create_app() -> FastAPI:
     # memory MCP uses thread through the dispatcher so audit grounding
     # and namespace promotion stay identical across transports.
     memory_dispatcher = None
-    if memory_wrapper is not None:
+    if memory_provider is not None:
         try:
             from hal0.api.mcp_mount import client_id_resolver, private_resolver
             from hal0.dispatcher.memory_dispatcher import MemoryDispatcher
 
             memory_dispatcher = MemoryDispatcher(
-                memory_wrapper,
+                memory_provider,
                 client_id_resolver=client_id_resolver,
                 private_resolver=private_resolver,
             )
@@ -1561,7 +1522,7 @@ def create_app() -> FastAPI:
         mount_mcp_servers(
             app,
             approval_queue=app.state.approval_queue,
-            memory_wrapper=memory_wrapper,
+            memory_provider=memory_provider,
             memory_dispatcher=memory_dispatcher,
         )
     except Exception as exc:  # pragma: no cover — defensive

--- a/src/hal0/api/agents/memory_stats.py
+++ b/src/hal0/api/agents/memory_stats.py
@@ -138,7 +138,7 @@ async def get_agent_memory_stats(agent_id: str, request: Request) -> dict[str, A
         )
 
     namespace = _namespace_for(agent_id)
-    wrapper = getattr(request.app.state, "memory_wrapper", None)
+    wrapper = getattr(request.app.state, "memory_provider", None)
     if wrapper is None:
         log.info(
             "agent.memory.stats_unavailable",

--- a/src/hal0/api/mcp_mount.py
+++ b/src/hal0/api/mcp_mount.py
@@ -169,13 +169,13 @@ def mount_mcp_servers(
     app,
     *,
     approval_queue,
-    memory_wrapper=None,
+    memory_provider=None,
     memory_dispatcher=None,
     base_url: str = "http://127.0.0.1:8080",
 ) -> None:
     """Build + mount the admin and (optionally) memory MCP sub-apps.
 
-    Called once from :func:`create_app`. ``memory_wrapper`` may be None
+    Called once from :func:`create_app`. ``memory_provider`` may be None
     when Cognee isn't initialized (e.g. tests that don't exercise
     /mcp/memory); the mount silently skips the memory server in that
     case.
@@ -218,11 +218,11 @@ def mount_mcp_servers(
     # builders. Keyed by mount id (matches ``connect_url`` last segment).
     mcp_servers: dict[str, object] = {"hal0-admin": admin_server}
 
-    if memory_wrapper is not None:
+    if memory_provider is not None:
         from hal0.mcp.memory import build_server as build_memory_server
 
         memory_server = build_memory_server(
-            wrapper=memory_wrapper,
+            wrapper=memory_provider,
             client_id_resolver=client_id_resolver,
             private_resolver=private_resolver,
         )
@@ -238,7 +238,7 @@ def mount_mcp_servers(
     log.info(
         "hal0.mcp.mounted",
         admin=True,
-        memory=memory_wrapper is not None,
+        memory=memory_provider is not None,
         dns_rebinding_protection=transport_security.enable_dns_rebinding_protection,
         allowed_hosts=len(transport_security.allowed_hosts),
     )

--- a/src/hal0/api/routes/health.py
+++ b/src/hal0/api/routes/health.py
@@ -95,7 +95,7 @@ async def get_status(request: Request) -> dict[str, Any]:
         # reads this to show/hide the Agent → Memory nav so the UI and the
         # backend can never disagree. Reflects the real wrapper, so an init
         # failure also reads as off.
-        "memory_enabled": getattr(request.app.state, "memory_wrapper", None) is not None,
+        "memory_enabled": getattr(request.app.state, "memory_provider", None) is not None,
     }
 
 

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -169,7 +169,7 @@ class MemoryUnavailable(Hal0Error):
 
 def _wrapper(request: Request) -> Any:
     """Return the live :class:`CogneeWrapper` or raise 503."""
-    wrapper = getattr(request.app.state, "memory_wrapper", None)
+    wrapper = getattr(request.app.state, "memory_provider", None)
     if wrapper is None:
         raise MemoryUnavailable("memory engine is not available on this hal0 instance")
     return wrapper

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -23,7 +23,7 @@ from typing import Any
 from fastapi import APIRouter, Request
 from pydantic import ValidationError
 
-from hal0.api.middleware.error_codes import Hal0Error
+from hal0.api.middleware.error_codes import BadRequest, Hal0Error
 from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import GraphUpstreamConfig, MemoryGraphConfig
 from hal0.memory.cognee_wrapper import GraphRouteUnsupportedError
@@ -402,6 +402,48 @@ async def memory_search(request: Request) -> dict[str, Any]:
         tags=body.get("tags") or [],
         before=body.get("before"),
         after=body.get("after"),
+        client_id=agent_id if agent_id != "anonymous" else None,
+    )
+    return {"items": items}
+
+
+@router.post("/recall")
+async def memory_recall(request: Request) -> dict[str, Any]:
+    """Token-budgeted recall (Hindsight's preferred path).
+
+    Body: ``{query, max_tokens?, types?, dataset?, tags?}``. Identity +
+    namespace resolution behave like ``/search`` (X-hal0-Agent +
+    X-hal0-Private). Returns ``{items: [MemoryItem, ...]}`` ordered by
+    relevance (no numeric score — Hindsight recall returns none).
+
+    Falls back to ``search`` semantics on engines without a richer recall
+    (the ABC default), so this route is safe regardless of active engine.
+    """
+    body = await _read_json_body(request)
+    query = body.get("query")
+    if not isinstance(query, str) or not query:
+        raise BadRequest(
+            "memory_recall requires 'query' (non-empty string)",
+            details={"path": "/api/memory/recall"},
+        )
+    agent_id = _agent_id(request)
+    private = _is_private(request)
+    try:
+        dataset = resolve_read_datasets(
+            body.get("dataset"),
+            private=private,
+            client_id=agent_id if agent_id != "anonymous" else None,
+        )
+    except MemoryNamespaceError as exc:
+        raise MemoryNamespaceInvalid(str(exc)) from exc
+
+    wrapper = _wrapper(request)
+    items = await wrapper.recall(
+        query=query,
+        types=body.get("types"),
+        max_tokens=int(body.get("max_tokens", 4096)),
+        dataset=dataset,
+        tags=body.get("tags") or [],
         client_id=agent_id if agent_id != "anonymous" else None,
     )
     return {"items": items}

--- a/src/hal0/cli/memory_commands.py
+++ b/src/hal0/cli/memory_commands.py
@@ -30,6 +30,7 @@ from hal0.cli._shared import (
     api_put,
     die,
 )
+from hal0.memory.migrate import migrate_cognee_to_hindsight_dryrun
 
 app = typer.Typer(help="Manage hal0 memory (Cognee — ADR-0005 + ADR-0014).")
 console = Console()
@@ -181,6 +182,50 @@ def graph_disable_cmd(
             border_style="yellow",
         )
     )
+
+
+# ── ``hal0 memory migrate`` ───────────────────────────────────────────────────
+
+_DEFAULT_COGNEE_DIR = "/var/lib/hal0/memory/cognee"
+
+
+@app.command("migrate")
+def migrate_cmd(
+    dry_run: bool = typer.Option(
+        True,
+        "--dry-run/--apply",
+        help="Report migration without touching Hindsight (--apply not yet implemented).",
+    ),
+    cognee_dir: str = typer.Option(
+        _DEFAULT_COGNEE_DIR,
+        "--cognee-dir",
+        help="Path to the Cognee data directory (contains hal0_memory_index.sqlite).",
+    ),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit raw JSON instead of the human-readable panel.",
+    ),
+) -> None:
+    """Migrate Cognee memory store → Hindsight banks (dry-run only, P2-4)."""
+    if not dry_run:
+        die("--apply is not yet implemented; dry-run only.")
+        return
+    report = migrate_cognee_to_hindsight_dryrun(cognee_dir=cognee_dir)
+    if json_out:
+        typer.echo(jsonlib.dumps(report, indent=2, sort_keys=True))
+        return
+    noop_label = (
+        "[dim]yes — nothing to migrate[/dim]" if report["noop"] else "[bold yellow]no[/bold yellow]"
+    )
+    t = Table.grid(padding=(0, 2))
+    t.add_column("k", style="dim")
+    t.add_column("v")
+    t.add_row("Rows total", str(report["rows_total"]))
+    t.add_row("Rows mapped", str(report["rows_mapped"]))
+    t.add_row("Rows unmapped", str(report["rows_unmapped"]))
+    t.add_row("No-op", noop_label)
+    console.print(Panel(t, title="memory · migrate (dry-run)", border_style="dim"))
 
 
 __all__ = ["app", "graph_app"]

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1301,12 +1301,11 @@ class MemoryConfig(BaseModel):
     graph: MemoryGraphConfig = Field(default_factory=MemoryGraphConfig)
     embedding: MemoryEmbeddingConfig = Field(default_factory=MemoryEmbeddingConfig)
     engine: str = Field(
-        default="cognee",
+        default="hindsight",
         description=(
             "Active memory engine. One of 'cognee' | 'hindsight' | 'mem0' | "
-            "'pgvector'. Default 'cognee' until P2 cutover. The fallback flag: "
-            "set back to 'cognee' to revert to the untouched Cognee store for "
-            "one release after the Hindsight cutover."
+            "'pgvector'. Default 'hindsight' (P2 cutover). Set to 'cognee' to "
+            "revert to the untouched Cognee store for one release."
         ),
     )
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1300,6 +1300,24 @@ class MemoryConfig(BaseModel):
 
     graph: MemoryGraphConfig = Field(default_factory=MemoryGraphConfig)
     embedding: MemoryEmbeddingConfig = Field(default_factory=MemoryEmbeddingConfig)
+    engine: str = Field(
+        default="cognee",
+        description=(
+            "Active memory engine. One of 'cognee' | 'hindsight' | 'mem0' | "
+            "'pgvector'. Default 'cognee' until P2 cutover. The fallback flag: "
+            "set back to 'cognee' to revert to the untouched Cognee store for "
+            "one release after the Hindsight cutover."
+        ),
+    )
+
+    @field_validator("engine")
+    @classmethod
+    def _engine_is_known(cls, v: str) -> str:
+        known = {"cognee", "hindsight", "mem0", "pgvector"}
+        s = str(v or "cognee").strip().lower()
+        if s not in known:
+            raise ValueError(f"memory.engine {v!r} must be one of {sorted(known)}")
+        return s
 
 
 class ModelsConfig(BaseModel):

--- a/src/hal0/mcp/memory.py
+++ b/src/hal0/mcp/memory.py
@@ -328,11 +328,55 @@ async def _memory_delete(
     return {"deleted": deleted_count}
 
 
+async def _memory_recall(
+    wrapper: Any,
+    args: dict[str, Any],
+    *,
+    client_id: str | None,
+    private: bool,
+) -> dict[str, Any]:
+    """memory_recall(query, max_tokens=4096, types?, dataset?, tags?) → {results}.
+
+    The Hindsight-preferred retrieval path: token-budgeted, observation
+    hierarchy, no numeric score. Provider.recall falls back to search on
+    engines without a richer recall (ABC default), so this tool is safe
+    regardless of active engine.
+    """
+    query = _require(args, "query", str)
+    if not query.strip():
+        raise MemorySchemaError("query must be non-empty")
+    max_tokens = args.get("max_tokens", 4096)
+    if not isinstance(max_tokens, int) or max_tokens < 1 or max_tokens > 32768:
+        raise MemorySchemaError("max_tokens must be 1..32768")
+    requested = args.get("dataset")
+    dataset: Any
+    if isinstance(requested, list):
+        dataset = [str(d) for d in requested]
+    elif requested is None or (isinstance(requested, str) and not requested):
+        dataset = ["shared", f"private:{client_id}"] if private and client_id else _DEFAULT_DATASET
+    elif isinstance(requested, str):
+        dataset = _resolve_dataset(requested, private=private, client_id=client_id)
+    else:
+        raise MemorySchemaError("dataset must be str | list[str] | null")
+    tags = _normalise_tags(args.get("tags"))
+    types = args.get("types")
+    results = await wrapper.recall(
+        query=query,
+        types=types,
+        max_tokens=max_tokens,
+        dataset=dataset,
+        tags=tags,
+        client_id=client_id,
+    )
+    return {"results": list(results)}
+
+
 _MEMORY_HANDLERS = {
     "memory_add": _memory_add,
     "memory_search": _memory_search,
     "memory_list": _memory_list,
     "memory_delete": _memory_delete,
+    "memory_recall": _memory_recall,
 }
 
 
@@ -410,6 +454,9 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
     "memory_delete": ToolAnnotations(
         readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
     ),
+    "memory_recall": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
 }
 
 
@@ -457,6 +504,10 @@ def build_server(
     _register(
         "memory_delete",
         "Delete one or more memory items by id (bulk deletes gate at admin layer).",
+    )
+    _register(
+        "memory_recall",
+        "Recall token-budgeted, consolidated memory (preferred over search).",
     )
 
     return server

--- a/src/hal0/memory/__init__.py
+++ b/src/hal0/memory/__init__.py
@@ -12,6 +12,8 @@ from typing import Any
 import structlog
 
 from hal0.memory.cognee_wrapper import CogneeWrapper, MemoryRecord
+from hal0.memory.hindsight_provider import HindsightProvider
+from hal0.memory.pgvector_provider import PgVectorProvider
 from hal0.memory.provider import (
     AddResult,
     DeleteResult,
@@ -29,13 +31,28 @@ __all__ = [
     "CogneeWrapper",
     "DeleteResult",
     "GraphStatus",
+    "HindsightProvider",
     "ListPage",
     "MemoryItem",
     "MemoryProvider",
     "MemoryRecord",
     "Mode",
+    "PgVectorProvider",
+    "_build_hindsight_client",
     "provider_from_config",
 ]
+
+
+def _build_hindsight_client(cfg: Any) -> Any:
+    """Construct the Hindsight REST client from config + env.
+
+    Raises if the daemon is unreachable so the factory can degrade. The
+    actual httpx-backed client lives in hindsight_provider; this indirection
+    exists purely so the boot-degrade path is unit-testable.
+    """
+    from hal0.memory.hindsight_client import HindsightRestClient
+
+    return HindsightRestClient.from_env()
 
 
 def provider_from_config(cfg: Any) -> MemoryProvider:
@@ -62,6 +79,21 @@ def provider_from_config(cfg: Any) -> MemoryProvider:
             rerank_read_timeout_s=float(embed.rerank_read_timeout_s),
         )
 
-    # P1 wires hindsight/mem0/pgvector here.
+    if engine == "hindsight":
+        try:
+            client = _build_hindsight_client(cfg)
+        except Exception as exc:  # daemon down at boot → degrade ladder
+            log.warning("hal0.memory.hindsight_unavailable", error=str(exc), fallback="pgvector")
+            return PgVectorProvider()
+        return HindsightProvider(client=client)
+
+    if engine == "pgvector":
+        return PgVectorProvider()
+
+    if engine == "mem0":  # documented fallback (spec §2) — not yet implemented
+        log.warning("hal0.memory.mem0_not_implemented", fallback="cognee")
+        return CogneeWrapper(embedding_model=str(embed.model))
+
+    # cognee branch above is the default; unknown engines log + fall back.
     log.warning("hal0.memory.unknown_engine", engine=engine, fallback="cognee")
     return CogneeWrapper(embedding_model=str(embed.model))

--- a/src/hal0/memory/__init__.py
+++ b/src/hal0/memory/__init__.py
@@ -1,15 +1,67 @@
-"""hal0 memory subsystem (ADR-0005).
+"""hal0 memory subsystem (ADR-0005 + brain-redesign P0-P2).
 
-Public contract for `/mcp/memory` — wraps `cognee` as the embedded
-memory engine. Re-exports :class:`CogneeWrapper` so MCP-backend code
-can ``from hal0.memory import CogneeWrapper``.
-
-Only the wrapper is public. Anything in
-:mod:`hal0.memory.cognee_wrapper` not re-exported here is internal.
+Public contract for ``/mcp/memory`` + ``/api/memory/*``. Exposes the
+engine-neutral :class:`MemoryProvider` ABC and the ``provider_from_config``
+factory that the one construction site in ``api/__init__.py`` calls.
 """
 
 from __future__ import annotations
 
-from hal0.memory.cognee_wrapper import CogneeWrapper, MemoryRecord
+from typing import Any
 
-__all__ = ["CogneeWrapper", "MemoryRecord"]
+import structlog
+
+from hal0.memory.cognee_wrapper import CogneeWrapper, MemoryRecord
+from hal0.memory.provider import (
+    AddResult,
+    DeleteResult,
+    GraphStatus,
+    ListPage,
+    MemoryItem,
+    MemoryProvider,
+    Mode,
+)
+
+log = structlog.get_logger(__name__)
+
+__all__ = [
+    "AddResult",
+    "CogneeWrapper",
+    "DeleteResult",
+    "GraphStatus",
+    "ListPage",
+    "MemoryItem",
+    "MemoryProvider",
+    "MemoryRecord",
+    "Mode",
+    "provider_from_config",
+]
+
+
+def provider_from_config(cfg: Any) -> MemoryProvider:
+    """Construct the active MemoryProvider from the loaded hal0 config.
+
+    P0: only the ``cognee`` branch is wired (default). P1 adds ``hindsight``
+    + the degrade ladder; P2 flips the default. ``cfg`` is the object returned
+    by ``hal0.config.loader.load_hal0_config``.
+    """
+    engine = str(getattr(cfg.memory, "engine", "cognee") or "cognee").lower()
+    embed = cfg.memory.embedding
+    graph = cfg.memory.graph
+
+    if engine == "cognee":
+        return CogneeWrapper(
+            embedding_model=str(embed.model),
+            graph_enabled=bool(graph.enabled),
+            graph_route=str(graph.route),
+            rerank_enabled=bool(embed.rerank_enabled),
+            rerank_url=str(embed.rerank_url),
+            rerank_over_fetch_factor=int(embed.rerank_over_fetch_factor),
+            rerank_max_candidates=int(embed.rerank_max_candidates),
+            rerank_connect_timeout_s=float(embed.rerank_connect_timeout_s),
+            rerank_read_timeout_s=float(embed.rerank_read_timeout_s),
+        )
+
+    # P1 wires hindsight/mem0/pgvector here.
+    log.warning("hal0.memory.unknown_engine", engine=engine, fallback="cognee")
+    return CogneeWrapper(embedding_model=str(embed.model))

--- a/src/hal0/memory/__init__.py
+++ b/src/hal0/memory/__init__.py
@@ -46,9 +46,12 @@ __all__ = [
 def _build_hindsight_client(cfg: Any) -> Any:
     """Construct the Hindsight REST client from config + env.
 
-    Raises if the daemon is unreachable so the factory can degrade. The
-    actual httpx-backed client lives in hindsight_provider; this indirection
-    exists purely so the boot-degrade path is unit-testable.
+    NOTE (P1): ``from_env()`` only builds the httpx client — it does NO I/O,
+    so it does not yet raise when the daemon is down. The boot-degrade ladder
+    (hindsight -> pgvector) only fires once P1-6 adds a connectivity probe
+    here (e.g. a ``/health`` call) so an unreachable daemon raises at boot
+    rather than at first recall. This indirection exists so that degrade path
+    is unit-testable (tests patch this function).
     """
     from hal0.memory.hindsight_client import HindsightRestClient
 

--- a/src/hal0/memory/__init__.py
+++ b/src/hal0/memory/__init__.py
@@ -65,7 +65,7 @@ def provider_from_config(cfg: Any) -> MemoryProvider:
     + the degrade ladder; P2 flips the default. ``cfg`` is the object returned
     by ``hal0.config.loader.load_hal0_config``.
     """
-    engine = str(getattr(cfg.memory, "engine", "cognee") or "cognee").lower()
+    engine = str(getattr(cfg.memory, "engine", "hindsight") or "hindsight").lower()
     embed = cfg.memory.embedding
     graph = cfg.memory.graph
 
@@ -88,7 +88,14 @@ def provider_from_config(cfg: Any) -> MemoryProvider:
         except Exception as exc:  # daemon down at boot → degrade ladder
             log.warning("hal0.memory.hindsight_unavailable", error=str(exc), fallback="pgvector")
             return PgVectorProvider()
-        return HindsightProvider(client=client)
+        from hal0.memory.hindsight_provider import LemonadeReranker
+
+        reranker = LemonadeReranker(
+            url=str(embed.rerank_url),
+            connect_timeout_s=float(embed.rerank_connect_timeout_s),
+            read_timeout_s=float(embed.rerank_read_timeout_s),
+        )
+        return HindsightProvider(client=client, reranker=reranker)
 
     if engine == "pgvector":
         return PgVectorProvider()

--- a/src/hal0/memory/cognee_wrapper.py
+++ b/src/hal0/memory/cognee_wrapper.py
@@ -47,6 +47,8 @@ from typing import Any
 
 import structlog
 
+from hal0.memory.provider import MemoryProvider
+
 # Cognee bootstrap. Import is deferred to first-use because importing
 # `cognee` at module-import time runs the package's logging side-effect
 # (it writes to ~/.cognee/logs/...). Keeping the import lazy means hal0
@@ -173,7 +175,7 @@ class MemoryRecord:
 # ── Wrapper ───────────────────────────────────────────────────────────────
 
 
-class CogneeWrapper:
+class CogneeWrapper(MemoryProvider):
     """Async wrapper around Cognee — see module docstring.
 
     One instance per (Cognee dir, client_id) is the intended usage —

--- a/src/hal0/memory/hindsight_client.py
+++ b/src/hal0/memory/hindsight_client.py
@@ -52,17 +52,18 @@ class HindsightRestClient:
         tags=None,
         timestamp=None,
     ):
-        body: dict[str, Any] = {"content": content, "document_id": document_id}
+        item: dict[str, Any] = {"content": content, "document_id": document_id}
         if context is not None:
-            body["context"] = context
+            item["context"] = context
         if metadata:
-            body["metadata"] = metadata
+            item["metadata"] = metadata
         if tags:
-            body["tags"] = list(tags)
+            item["tags"] = list(tags)
         if timestamp is not None:
-            body["timestamp"] = timestamp
+            item["timestamp"] = timestamp
+        body: dict[str, Any] = {"items": [item], "async": True}
         resp = await self._http.post(
-            f"/v1/default/banks/{bank_id}/retain", headers=self._headers(), json=body
+            f"/v1/default/banks/{bank_id}/memories", headers=self._headers(), json=body
         )
         resp.raise_for_status()
         return resp.json()
@@ -74,7 +75,7 @@ class HindsightRestClient:
         if tags:
             body["tags"] = list(tags)
         resp = await self._http.post(
-            f"/v1/default/banks/{bank_id}/recall", headers=self._headers(), json=body
+            f"/v1/default/banks/{bank_id}/memories/recall", headers=self._headers(), json=body
         )
         resp.raise_for_status()
         return resp.json()

--- a/src/hal0/memory/hindsight_client.py
+++ b/src/hal0/memory/hindsight_client.py
@@ -1,0 +1,93 @@
+"""Async REST client for the shared hindsight-api (brain-redesign P1).
+
+Talks to ``/v1/default/banks/{bank}/...`` (the bank-scoped REST surface the
+spike confirmed). Auth is the single server-wide key when enabled; on the LAN
+the daemon runs no-auth but Hindsight still requires a NON-EMPTY key, so we
+default to the spike's ``lemonade-local-noauth`` placeholder.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+DEFAULT_BASE_URL = "http://127.0.0.1:9177"  # dynamic port — pinned by the unit (P1-6)
+DEFAULT_API_KEY = "lemonade-local-noauth"
+
+
+class HindsightRestClient:
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        api_key: str = DEFAULT_API_KEY,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._base_url = (base_url or DEFAULT_BASE_URL).rstrip("/")
+        self._api_key = api_key
+        self._owns = http_client is None
+        self._http = http_client or httpx.AsyncClient(
+            base_url=self._base_url, timeout=httpx.Timeout(120.0, connect=3.0)
+        )
+
+    @classmethod
+    def from_env(cls) -> HindsightRestClient:
+        base = os.environ.get("HAL0_HINDSIGHT_URL", DEFAULT_BASE_URL)
+        key = os.environ.get("HINDSIGHT_API_TENANT_API_KEY", DEFAULT_API_KEY) or DEFAULT_API_KEY
+        return cls(base_url=base, api_key=key)
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"}
+
+    async def retain(
+        self,
+        *,
+        bank_id,
+        content,
+        document_id,
+        context=None,
+        metadata=None,
+        tags=None,
+        timestamp=None,
+    ):
+        body: dict[str, Any] = {"content": content, "document_id": document_id}
+        if context is not None:
+            body["context"] = context
+        if metadata:
+            body["metadata"] = metadata
+        if tags:
+            body["tags"] = list(tags)
+        if timestamp is not None:
+            body["timestamp"] = timestamp
+        resp = await self._http.post(
+            f"/v1/default/banks/{bank_id}/retain", headers=self._headers(), json=body
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def recall(self, *, bank_id, query, types=None, max_tokens=4096, tags=None):
+        body: dict[str, Any] = {"query": query, "max_tokens": max_tokens}
+        if types:
+            body["types"] = list(types)
+        if tags:
+            body["tags"] = list(tags)
+        resp = await self._http.post(
+            f"/v1/default/banks/{bank_id}/recall", headers=self._headers(), json=body
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def delete_document(self, *, bank_id, document_id):
+        resp = await self._http.request(
+            "DELETE",
+            f"/v1/default/banks/{bank_id}/documents/{document_id}",
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def aclose(self) -> None:
+        if self._owns:
+            await self._http.aclose()

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -1,0 +1,220 @@
+"""HindsightProvider — the platform memory engine (brain-redesign P1).
+
+Maps hal0's engine-neutral MemoryProvider contract onto the shared
+``hindsight-api`` over REST. Key design points (spec §3, §4b, P1):
+
+* **Bank mapping** lives HERE (not namespace.py, which is unchanged): hal0
+  namespace ``private:<agent>`` → Hindsight bank ``private__<agent>`` (``:``:
+  ``__``); ``project:<id>`` → ``project__<id>``; ``shared``/``agents`` pass
+  through.
+* ``MemoryItem.id`` is the Hindsight **document_id** — idempotent on retain,
+  recall-visible, delete-addressable. NOT a per-fact id (those are async +
+  many-per-add).
+* ``add`` routes to Hindsight **retain** so background consolidation fires.
+* **Multi-bank recall fan-out** (Task P1-3): Hindsight recall is per-bank,
+  client-orchestrated; we fan out to the caller's allowed banks and merge
+  under one reranked token budget (recall returns NO numeric score, so the
+  union is re-ranked via the :8086 reranker; §4b precedence is the tiebreak).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from hal0.memory.provider import MemoryProvider
+
+_SHARED = "shared"
+_PRIVATE = "private:"
+
+
+def namespace_to_bank(namespace: str) -> str:
+    """Map a hal0 namespace to a Hindsight bank id (spec §3 table)."""
+    return namespace.replace(":", "__")
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class HindsightProvider(MemoryProvider):
+    def __init__(
+        self,
+        *,
+        client: Any,
+        client_id: str = "anonymous",
+        reranker: Any = None,
+    ) -> None:
+        self._client = client
+        self._client_id = client_id
+        self._reranker = reranker
+        self._graph_enabled = False
+        self._graph_route = "upstream"
+        self._rerank_enabled = reranker is not None
+
+    # ── ACL: the caller's allowed namespaces → banks ───────────────────
+
+    def _allowed_namespaces(self, requested: str | list[str], client_id: str | None) -> list[str]:
+        cid = client_id or self._client_id
+        own = f"{_PRIVATE}{cid}"
+        reqs = [requested] if isinstance(requested, str) else list(requested or [_SHARED])
+        out: list[str] = []
+        for ds in reqs:
+            if ds == _SHARED:
+                out += [d for d in (_SHARED, own) if d not in out]
+            elif ds == own and own not in out:
+                out.append(own)
+            elif ds.startswith(_PRIVATE):
+                continue  # foreign private — dropped (fail-open-empty)
+            elif ds not in out:
+                out.append(ds)
+        return out
+
+    def _write_namespace(self, requested: str, client_id: str | None) -> str:
+        # The REST/MCP front door already resolved the write namespace via
+        # namespace.resolve_write_dataset; trust it verbatim here.
+        return requested or _SHARED
+
+    # ── Core five ──────────────────────────────────────────────────────
+
+    async def add(
+        self,
+        text: str,
+        dataset: str = _SHARED,
+        tags: list[str] | None = None,
+        source: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        client_id: str | None = None,
+    ) -> dict[str, str]:
+        ns = self._write_namespace(dataset, client_id)
+        bank = namespace_to_bank(ns)
+        document_id = str(uuid.uuid4())  # the join key
+        meta = dict(metadata or {})
+        if source:
+            meta["source"] = source
+        await self._client.retain(
+            bank_id=bank,
+            content=text,
+            document_id=document_id,
+            context=meta.get("source"),
+            metadata={k: str(v) for k, v in meta.items()},
+            tags=list(tags or []),
+            timestamp=None,
+        )
+        return {"id": document_id, "timestamp": _now()}
+
+    async def search(
+        self,
+        query: str,
+        limit: int = 10,
+        dataset: str | list[str] = _SHARED,
+        tags: list[str] | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        mode: str = "vector",
+        client_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        # search delegates to recall (back-compat surface); the fan-out lives
+        # in recall (Task P1-3). limit is honored after the merge.
+        out = await self.recall(
+            query=query,
+            max_tokens=max(256, limit * 256),
+            dataset=dataset,
+            tags=tags,
+            client_id=client_id,
+        )
+        return out[:limit]
+
+    async def list_items(
+        self,
+        dataset: str = _SHARED,
+        cursor: str | None = None,
+        limit: int = 50,
+        client_id: str | None = None,
+    ) -> dict[str, Any]:
+        # Hindsight has no flat list; list = recall with an empty-ish broad
+        # query is unreliable, so we surface the documents endpoint per bank.
+        # P1 lists via recall on a wildcard-ish query; refined in P2 if needed.
+        out = await self.recall(
+            query="*", max_tokens=limit * 256, dataset=dataset, client_id=client_id
+        )
+        return {"items": out[:limit], "next_cursor": None}
+
+    async def delete(self, ids: list[str], *, client_id: str | None = None) -> dict[str, int]:
+        deleted = 0
+        # We don't know which bank each document_id lives in without a lookup;
+        # try the caller's allowed banks. delete_document is idempotent.
+        banks = [namespace_to_bank(ns) for ns in self._allowed_namespaces(_SHARED, client_id)]
+        for document_id in ids:
+            for bank in banks:
+                res = await self._client.delete_document(bank_id=bank, document_id=document_id)
+                if int(res.get("memory_units_deleted", 0)) > 0:
+                    deleted += 1
+                    break
+        return {"deleted": deleted}
+
+    # ── recall (fan-out added in Task P1-3) ────────────────────────────
+
+    async def recall(
+        self,
+        query: str,
+        *,
+        types: list[str] | None = None,
+        max_tokens: int = 4096,
+        dataset: str | list[str] = _SHARED,
+        tags: list[str] | None = None,
+        client_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        # Single-bank placeholder; Task P1-3 replaces this with the fan-out.
+        banks = [namespace_to_bank(ns) for ns in self._allowed_namespaces(dataset, client_id)]
+        merged: list[dict[str, Any]] = []
+        for bank in banks:
+            resp = await self._client.recall(
+                bank_id=bank, query=query, types=types, max_tokens=max_tokens, tags=tags
+            )
+            for fact in resp.get("results", []):
+                merged.append(self._fact_to_item(fact, bank))
+        return merged
+
+    # ── Runtime toggles ────────────────────────────────────────────────
+
+    def graph_status(self) -> dict[str, Any]:
+        return {
+            "enabled": self._graph_enabled,
+            "route": self._graph_route,
+            "in_flight": 0,
+            "builds_ok": 0,
+            "errors": 0,
+            "last_built_at": None,
+            "last_error": None,
+        }
+
+    def set_graph_enabled(self, enabled: bool, route: str | None = None) -> None:
+        self._graph_enabled = bool(enabled)
+        if route is not None:
+            self._graph_route = route
+
+    def set_rerank_enabled(self, enabled: bool) -> None:
+        self._rerank_enabled = bool(enabled)
+
+    # ── helpers ────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _fact_to_item(fact: dict[str, Any], bank: str) -> dict[str, Any]:
+        """Map a Hindsight RecallResult to the MemoryItem wire shape.
+
+        ``score`` is always None — Hindsight recall returns no numeric score;
+        ordering carries the relevance signal.
+        """
+        return {
+            "id": fact.get("document_id") or fact.get("id"),
+            "text": fact.get("text", ""),
+            "timestamp": fact.get("mentioned_at") or _now(),
+            "dataset": bank.replace("__", ":"),
+            "tags": list(fact.get("tags") or []),
+            "source": (fact.get("metadata") or {}).get("source"),
+            "metadata": dict(fact.get("metadata") or {}),
+            "score": None,
+            "type": fact.get("type"),
+        }

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -34,6 +34,49 @@ def namespace_to_bank(namespace: str) -> str:
     return namespace.replace(":", "__")
 
 
+class LemonadeReranker:
+    """Async reranker over the hal0 rerank slot (llama.cpp /rerank shape).
+
+    POSTs {model, query, documents} to ``{url}/rerank`` and returns the raw
+    ``results`` list (``[{"index", "relevance_score"}, ...]``) that
+    HindsightProvider._rerank_union maps onto the cross-bank union. Fail-soft:
+    returns [] on any error (slot down/evicted, bad shape, timeout) so recall
+    falls back to fused order. The rerank slot may be dormant; that's fine.
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str = "http://127.0.0.1:8086",
+        model: str = "bge-reranker-v2-m3-q4_k_m",
+        connect_timeout_s: float = 1.0,
+        read_timeout_s: float = 8.0,
+    ) -> None:
+        self._url = str(url or "").rstrip("/")
+        self._model = model
+        self._connect_timeout_s = float(connect_timeout_s)
+        self._read_timeout_s = float(read_timeout_s)
+
+    async def rerank(self, query: str, documents: list[str]) -> list[dict[str, Any]]:
+        if not self._url or not documents:
+            return []
+        import httpx
+
+        payload = {"model": self._model, "query": query, "documents": list(documents)}
+        timeout = httpx.Timeout(
+            connect=self._connect_timeout_s, read=self._read_timeout_s, write=2.0, pool=None
+        )
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.post(f"{self._url}/rerank", json=payload)
+                resp.raise_for_status()
+                body = resp.json()
+        except Exception:
+            return []
+        results = body.get("results") if isinstance(body, dict) else None
+        return results if isinstance(results, list) else []
+
+
 def _now() -> str:
     return datetime.now(UTC).isoformat()
 
@@ -204,7 +247,7 @@ class HindsightProvider(MemoryProvider):
         return (tier, -float(item.get("score") or 0.0))
 
     async def _rerank_union(self, query: str, union: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        if self._reranker is None or len(union) < 2:
+        if self._reranker is None or not self._rerank_enabled or len(union) < 2:
             return union
         try:
             ranked = await self._reranker.rerank(query, [u["text"] for u in union])

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -166,16 +166,69 @@ class HindsightProvider(MemoryProvider):
         tags: list[str] | None = None,
         client_id: str | None = None,
     ) -> list[dict[str, Any]]:
-        # Single-bank placeholder; Task P1-3 replaces this with the fan-out.
+        """Fan out per-bank recall to the caller's allowed banks, merge under
+        one token budget. Hindsight has no server-side cross-bank query and
+        returns no numeric score, so we re-rank the union via the :8086
+        reranker, with the §4b precedence ladder as the tiebreak.
+        """
+        import asyncio
+
         banks = [namespace_to_bank(ns) for ns in self._allowed_namespaces(dataset, client_id)]
-        merged: list[dict[str, Any]] = []
-        for bank in banks:
+        if not banks:
+            return []
+
+        async def _one(bank: str) -> list[dict[str, Any]]:
             resp = await self._client.recall(
                 bank_id=bank, query=query, types=types, max_tokens=max_tokens, tags=tags
             )
-            for fact in resp.get("results", []):
-                merged.append(self._fact_to_item(fact, bank))
-        return merged
+            return [self._fact_to_item(f, bank) for f in resp.get("results", [])]
+
+        per_bank = await asyncio.gather(*[_one(b) for b in banks])
+        union: list[dict[str, Any]] = [item for bank_items in per_bank for item in bank_items]
+        if not union:
+            return []
+
+        union = await self._rerank_union(query, union)
+        union.sort(key=self._precedence_key)  # stable: precedence wins ties
+        return self._apply_token_budget(union, max_tokens)
+
+    @staticmethod
+    def _precedence_key(item: dict[str, Any]) -> tuple[int, float]:
+        """§4b ladder: shared/curated observations rank above raw private
+        facts. Lower tuple sorts first. Second element is negative rerank
+        score so higher score sorts earlier within the same tier.
+        """
+        is_observation = item.get("type") == "observation"
+        is_shared = item.get("dataset") == _SHARED
+        tier = 0 if (is_observation or is_shared) else 1
+        return (tier, -float(item.get("score") or 0.0))
+
+    async def _rerank_union(self, query: str, union: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if self._reranker is None or len(union) < 2:
+            return union
+        try:
+            ranked = await self._reranker.rerank(query, [u["text"] for u in union])
+        except Exception:
+            return union  # reranker down → keep fused order (fail-soft)
+        for entry in ranked:
+            idx = entry.get("index")
+            if isinstance(idx, int) and 0 <= idx < len(union):
+                union[idx]["score"] = float(entry.get("relevance_score", 0.0))
+        return union
+
+    @staticmethod
+    def _apply_token_budget(items: list[dict[str, Any]], max_tokens: int) -> list[dict[str, Any]]:
+        """Greedy fill by ~4 chars/token on the text field (Hindsight counts
+        only fact text toward the budget)."""
+        out: list[dict[str, Any]] = []
+        spent = 0
+        for item in items:
+            cost = max(1, len(item.get("text", "")) // 4)
+            if spent + cost > max_tokens and out:
+                break
+            out.append(item)
+            spent += cost
+        return out
 
     # ── Runtime toggles ────────────────────────────────────────────────
 

--- a/src/hal0/memory/migrate.py
+++ b/src/hal0/memory/migrate.py
@@ -27,7 +27,7 @@ def migrate_cognee_to_hindsight_dryrun(*, cognee_dir: str | Path) -> dict[str, A
         return {"rows_total": 0, "rows_mapped": 0, "rows_unmapped": 0, "noop": True}
     mapped = 0
     for row in rows:
-        bank = namespace_to_bank(row["dataset"])
+        bank = namespace_to_bank(row["dataset"]) if row["dataset"] else ""
         if bank:
             mapped += 1
     return {

--- a/src/hal0/memory/migrate.py
+++ b/src/hal0/memory/migrate.py
@@ -1,0 +1,38 @@
+"""Cognee → Hindsight migration (brain-redesign P2, [Q10]).
+
+The platform Cognee store has been dark since v0.4 (memory OFF), so this is
+likely a no-op. The dry-run reads the sidecar SQLite (the canonical filter
+source) and reports rows mapped/unmapped without touching Hindsight. Cognee
+data stays read-only.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from hal0.memory.hindsight_provider import namespace_to_bank
+
+
+def migrate_cognee_to_hindsight_dryrun(*, cognee_dir: str | Path) -> dict[str, Any]:
+    sidecar = Path(cognee_dir) / "hal0_memory_index.sqlite"
+    if not sidecar.exists():
+        return {"rows_total": 0, "rows_mapped": 0, "rows_unmapped": 0, "noop": True}
+    with sqlite3.connect(sidecar) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT id, dataset FROM hal0_memory_items").fetchall()
+    total = len(rows)
+    if total == 0:
+        return {"rows_total": 0, "rows_mapped": 0, "rows_unmapped": 0, "noop": True}
+    mapped = 0
+    for row in rows:
+        bank = namespace_to_bank(row["dataset"])
+        if bank:
+            mapped += 1
+    return {
+        "rows_total": total,
+        "rows_mapped": mapped,
+        "rows_unmapped": total - mapped,
+        "noop": False,
+    }

--- a/src/hal0/memory/pgvector_provider.py
+++ b/src/hal0/memory/pgvector_provider.py
@@ -1,0 +1,126 @@
+"""PgVectorProvider — the documented boot fallback (spec P1 degrade ladder).
+
+Minimal MemoryProvider impl with the same shared+own-private ACL behaviour
+as the engines. Stands in when Hindsight is unavailable at boot so the
+tools return empties + the dashboard shows "no engine" instead of crashing.
+A real pgvector backing is deferred; the contract + degrade path are what P0
+needs.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from hal0.memory.provider import MemoryProvider
+
+_SHARED = "shared"
+_PRIVATE = "private:"
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class PgVectorProvider(MemoryProvider):
+    def __init__(self, *, client_id: str = "anonymous") -> None:
+        self._client_id = client_id
+        self._rows: list[dict[str, Any]] = []
+        self._graph_enabled = False
+        self._graph_route = "upstream"
+        self._rerank_enabled = False
+
+    def _allowed(self, requested: str | list[str], client_id: str | None) -> list[str]:
+        cid = client_id or self._client_id
+        own = f"{_PRIVATE}{cid}"
+        reqs = [requested] if isinstance(requested, str) else list(requested or [_SHARED])
+        out: list[str] = []
+        for ds in reqs:
+            if ds == _SHARED:
+                out += [d for d in (_SHARED, own) if d not in out]
+            elif ds == own and own not in out:
+                out.append(own)
+            elif ds.startswith(_PRIVATE):
+                continue
+            elif ds not in out:
+                out.append(ds)
+        return out
+
+    async def add(
+        self, text, dataset=_SHARED, tags=None, source=None, metadata=None, client_id=None
+    ):
+        item_id = str(uuid.uuid4())
+        ts = _now()
+        self._rows.append(
+            {
+                "id": item_id,
+                "text": text,
+                "timestamp": ts,
+                "dataset": dataset,
+                "tags": list(tags or []),
+                "source": source or (client_id or self._client_id),
+                "metadata": dict(metadata or {}),
+                "score": None,
+            }
+        )
+        return {"id": item_id, "timestamp": ts}
+
+    async def search(
+        self,
+        query,
+        limit=10,
+        dataset=_SHARED,
+        tags=None,
+        before=None,
+        after=None,
+        mode="vector",
+        client_id=None,
+    ):
+        allowed = self._allowed(dataset, client_id)
+        tags = tags or []
+        out = []
+        for row in self._rows:
+            if row["dataset"] not in allowed:
+                continue
+            if tags and not all(t in row["tags"] for t in tags):
+                continue
+            if before and row["timestamp"] >= before:
+                continue
+            if after and row["timestamp"] <= after:
+                continue
+            out.append(dict(row))
+            if len(out) >= limit:
+                break
+        return out
+
+    async def list_items(self, dataset=_SHARED, cursor=None, limit=50, client_id=None):
+        allowed = self._allowed(dataset, client_id)
+        return {
+            "items": [dict(r) for r in self._rows if r["dataset"] in allowed][:limit],
+            "next_cursor": None,
+        }
+
+    async def delete(self, ids, *, client_id=None):
+        before = len(self._rows)
+        self._rows = [r for r in self._rows if r["id"] not in set(ids)]
+        return {"deleted": before - len(self._rows)}
+
+    def graph_status(self):
+        return {
+            "enabled": self._graph_enabled,
+            "route": self._graph_route,
+            "in_flight": 0,
+            "builds_ok": 0,
+            "errors": 0,
+            "last_built_at": None,
+            "last_error": None,
+        }
+
+    def set_graph_enabled(self, enabled, route=None):
+        self._graph_enabled = bool(enabled)
+        if route is not None:
+            self._graph_route = route
+
+    def set_rerank_enabled(self, enabled):
+        self._rerank_enabled = bool(enabled)

--- a/src/hal0/memory/provider.py
+++ b/src/hal0/memory/provider.py
@@ -1,0 +1,210 @@
+"""The explicit MemoryProvider contract (brain-redesign P0).
+
+Promotes the implicit five-method ``CogneeWrapper`` surface into an ABC so
+hal0 can swap engines (Cognee → Hindsight, fallback Mem0/PgVector) without
+touching a single call site. The ABC is the anti-lock-in seam (spec §1).
+
+The *core five* (``add/search/list_items/delete`` + the three runtime
+toggles ``graph_status/set_graph_enabled/set_rerank_enabled``) are abstract:
+every engine must implement them, byte-compatible in **signature + return
+shape** with ``CogneeWrapper`` so the REST shims + MCP dispatcher need no
+changes. The *optional* methods (``recall/reflect/consolidate/
+register_compiled``) ship concrete safe defaults so an engine without
+consolidation still satisfies the contract.
+"""
+
+from __future__ import annotations
+
+import enum
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class Mode(enum.StrEnum):
+    """Search mode — mirrors CogneeWrapper's accepted ``mode`` values."""
+
+    VECTOR = "vector"
+    GRAPH = "graph"
+    HYBRID = "hybrid"
+
+
+@dataclass
+class MemoryItem:
+    """One stored memory. ``id`` is the engine's join key.
+
+    For Hindsight this is the ``document_id`` (idempotent, recall-visible,
+    delete-addressable) — NOT a per-fact id. For Cognee it is the sidecar
+    uuid. The wire shape matches ``CogneeWrapper.MemoryRecord``.
+    """
+
+    id: str
+    text: str
+    timestamp: str  # ISO-8601 UTC
+    dataset: str
+    tags: list[str] = field(default_factory=list)
+    source: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    score: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "text": self.text,
+            "timestamp": self.timestamp,
+            "dataset": self.dataset,
+            "tags": list(self.tags),
+            "source": self.source,
+            "metadata": dict(self.metadata),
+            "score": self.score,
+        }
+
+
+@dataclass
+class AddResult:
+    """Return shape of ``add`` — matches ``CogneeWrapper.add``."""
+
+    id: str
+    timestamp: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"id": self.id, "timestamp": self.timestamp}
+
+
+@dataclass
+class ListPage:
+    """Return shape of ``list_items`` — matches ``CogneeWrapper.list_items``."""
+
+    items: list[dict[str, Any]]
+    next_cursor: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"items": list(self.items), "next_cursor": self.next_cursor}
+
+
+@dataclass
+class DeleteResult:
+    """Return shape of ``delete`` — matches ``CogneeWrapper.delete``."""
+
+    deleted: int
+
+    def to_dict(self) -> dict[str, int]:
+        return {"deleted": self.deleted}
+
+
+@dataclass
+class GraphStatus:
+    """Return shape of ``graph_status`` — matches the CogneeWrapper payload."""
+
+    enabled: bool
+    route: str
+    in_flight: int = 0
+    builds_ok: int = 0
+    errors: int = 0
+    last_built_at: str | None = None
+    last_error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "route": self.route,
+            "in_flight": self.in_flight,
+            "builds_ok": self.builds_ok,
+            "errors": self.errors,
+            "last_built_at": self.last_built_at,
+            "last_error": self.last_error,
+        }
+
+
+class MemoryProvider(ABC):
+    """Engine-neutral memory contract. See module docstring."""
+
+    # ── Core five (abstract) ───────────────────────────────────────────
+
+    @abstractmethod
+    async def add(
+        self,
+        text: str,
+        dataset: str = "shared",
+        tags: list[str] | None = None,
+        source: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        client_id: str | None = None,
+    ) -> dict[str, str]:
+        """Add a memory item. Returns ``{id, timestamp}``."""
+
+    @abstractmethod
+    async def search(
+        self,
+        query: str,
+        limit: int = 10,
+        dataset: str | list[str] = "shared",
+        tags: list[str] | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        mode: str = "vector",
+        client_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Vector + filter search. Returns a list of MemoryItem dicts."""
+
+    @abstractmethod
+    async def list_items(
+        self,
+        dataset: str = "shared",
+        cursor: str | None = None,
+        limit: int = 50,
+        client_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Paginated list. Returns ``{items, next_cursor}``."""
+
+    @abstractmethod
+    async def delete(self, ids: list[str], *, client_id: str | None = None) -> dict[str, int]:
+        """Delete by id. Returns ``{deleted: int}``."""
+
+    @abstractmethod
+    def graph_status(self) -> dict[str, Any]:
+        """Return the graph-extraction status payload (GraphStatus shape)."""
+
+    @abstractmethod
+    def set_graph_enabled(self, enabled: bool, route: str | None = None) -> None:
+        """Flip the graph-extraction gate at runtime."""
+
+    @abstractmethod
+    def set_rerank_enabled(self, enabled: bool) -> None:
+        """Flip the rerank gate at runtime."""
+
+    # ── Optional capability methods (concrete safe defaults) ───────────
+
+    async def recall(
+        self,
+        query: str,
+        *,
+        types: list[str] | None = None,
+        max_tokens: int = 4096,
+        dataset: str | list[str] = "shared",
+        tags: list[str] | None = None,
+        client_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Token-budgeted recall. Default delegates to ``search`` so an
+        engine without a richer recall surface still answers the route."""
+        return await self.search(
+            query=query,
+            limit=max(1, max_tokens // 256),
+            dataset=dataset,
+            tags=tags,
+            client_id=client_id,
+        )
+
+    async def reflect(
+        self, *, dataset: str = "shared", client_id: str | None = None
+    ) -> dict[str, Any]:
+        """Trigger consolidation/reflection. No-op default."""
+        return {"status": "unsupported"}
+
+    async def consolidate(self, *, dataset: str = "shared") -> dict[str, Any]:
+        """Trigger background consolidation. No-op default."""
+        return {"status": "unsupported"}
+
+    def register_compiled(self, *args: Any, **kwargs: Any) -> None:
+        """Register a compiled artifact (directive/mental model). No-op default."""
+        return None

--- a/tests/agents/hermes_plugins/test_memory_client_routes.py
+++ b/tests/agents/hermes_plugins/test_memory_client_routes.py
@@ -1,0 +1,49 @@
+"""Lock the hal0-memory REST client paths against the real router (P0).
+
+The router only defines GET /api/memory/list and POST /api/memory/delete.
+The client previously called GET /api/memory and DELETE /api/memory/{id},
+which 404. This test asserts the client now hits routes the router serves.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from hal0.agents.hermes.plugins.memory_cognee._client import Hal0MemoryClient
+from hal0.api.routes.memory import router
+
+
+def _router_paths() -> set[tuple[str, str]]:
+    out = set()
+    for route in router.routes:
+        for method in getattr(route, "methods", set()):
+            out.add((method, route.path))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_list_and_delete_hit_real_routes():
+    seen: list[tuple[str, str]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path))
+        if request.method == "GET":
+            return httpx.Response(200, json={"items": [], "next_cursor": None})
+        return httpx.Response(200, json={"deleted": 1})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://x") as http:
+        client = Hal0MemoryClient(http_client=http)
+        await client.list_items(limit=10)
+        await client.delete("some-id")
+
+    # The router is mounted under /api/memory — its own route.path values
+    # are relative (e.g. "/list", "/delete"). Reconstruct full paths.
+    paths = _router_paths()
+    full_paths = {(m, f"/api/memory{p}") for m, p in paths}
+    assert ("GET", "/api/memory/list") in full_paths, f"router paths: {paths}"
+    assert ("POST", "/api/memory/delete") in full_paths, f"router paths: {paths}"
+    # Client must now hit those full paths, not the old wrong ones.
+    assert ("GET", "/api/memory/list") in seen, f"seen: {seen}"
+    assert ("POST", "/api/memory/delete") in seen, f"seen: {seen}"

--- a/tests/agents/test_agent_memory_stats_endpoint.py
+++ b/tests/agents/test_agent_memory_stats_endpoint.py
@@ -51,7 +51,7 @@ class _FakeWrapper:
 @pytest.fixture
 def fake_wrapper_empty(client: TestClient) -> _FakeWrapper:
     fake = _FakeWrapper({"items": [], "next_cursor": None})
-    client.app.state.memory_wrapper = fake
+    client.app.state.memory_provider = fake
     return fake
 
 
@@ -66,7 +66,7 @@ def test_memory_stats_no_wrapper_returns_available_false(client: TestClient) -> 
     # Default app state has no memory wrapper (init failed on the test
     # host because /var/lib/hal0 isn't writable). The endpoint must
     # render an ``available=false`` envelope rather than 500.
-    client.app.state.memory_wrapper = None
+    client.app.state.memory_provider = None
     r = client.get("/api/agents/hermes/memory/stats")
     assert r.status_code == 200, r.text
     body = r.json()
@@ -105,7 +105,7 @@ def test_memory_stats_with_items_reports_count_and_last_write(client: TestClient
             "next_cursor": None,
         }
     )
-    client.app.state.memory_wrapper = fake
+    client.app.state.memory_provider = fake
 
     r = client.get("/api/agents/hermes/memory/stats")
     assert r.status_code == 200
@@ -125,7 +125,7 @@ def test_memory_stats_with_int_timestamp_converts_to_iso(client: TestClient) -> 
             "next_cursor": None,
         }
     )
-    client.app.state.memory_wrapper = fake
+    client.app.state.memory_provider = fake
 
     r = client.get("/api/agents/hermes/memory/stats")
     body = r.json()
@@ -139,7 +139,7 @@ def test_memory_stats_with_int_timestamp_converts_to_iso(client: TestClient) -> 
 
 def test_memory_stats_wrapper_raises_returns_available_false(client: TestClient) -> None:
     fake = _FakeWrapper(exc=RuntimeError("simulated wrapper failure"))
-    client.app.state.memory_wrapper = fake
+    client.app.state.memory_provider = fake
 
     r = client.get("/api/agents/hermes/memory/stats")
     # Still 200 — the sidebar chip can't degrade if this 500s.
@@ -153,7 +153,7 @@ def test_memory_stats_wrapper_raises_returns_available_false(client: TestClient)
 def test_memory_stats_namespace_is_per_agent_private(client: TestClient) -> None:
     """Sidebar reflects what THIS agent has done; ``shared`` would muddy."""
     fake = _FakeWrapper()
-    client.app.state.memory_wrapper = fake
+    client.app.state.memory_provider = fake
 
     client.get("/api/agents/hermes/memory/stats")
     assert fake.calls[0]["dataset"] == "private:hermes"
@@ -162,7 +162,7 @@ def test_memory_stats_namespace_is_per_agent_private(client: TestClient) -> None
 def test_memory_stats_handles_malformed_payload_gracefully(client: TestClient) -> None:
     """Wrapper returned something that isn't ``{items: [...]}``."""
     fake = _FakeWrapper({"not_items": []})  # type: ignore[arg-type]
-    client.app.state.memory_wrapper = fake
+    client.app.state.memory_provider = fake
 
     r = client.get("/api/agents/hermes/memory/stats")
     body = r.json()

--- a/tests/api/test_memory_gate.py
+++ b/tests/api/test_memory_gate.py
@@ -36,7 +36,7 @@ def test_memory_disabled_unless_flag_is_one(
 ) -> None:
     app, client = _build(monkeypatch, flag)
     # The wrapper is constructed at create_app time, before lifespan.
-    assert app.state.memory_wrapper is None
+    assert app.state.memory_provider is None
     with client:
         body = client.get("/api/status").json()
         assert body["memory_enabled"] is False
@@ -56,4 +56,4 @@ def test_status_exposes_memory_enabled_as_bool(
         assert isinstance(body["memory_enabled"], bool)
         # The reported flag must mirror the real wrapper state so the field
         # is trustworthy even if Cognee fails to construct in this image.
-        assert body["memory_enabled"] is (app.state.memory_wrapper is not None)
+        assert body["memory_enabled"] is (app.state.memory_provider is not None)

--- a/tests/api/test_memory_graph_route.py
+++ b/tests/api/test_memory_graph_route.py
@@ -83,7 +83,7 @@ def _build_app(stub: StubWrapper) -> FastAPI:
     app = FastAPI()
     error_codes.install(app)
     app.include_router(memory_routes.router, prefix="/api/memory", tags=["memory"])
-    app.state.memory_wrapper = stub
+    app.state.memory_provider = stub
     return app
 
 
@@ -182,7 +182,7 @@ def test_status_unavailable_when_no_wrapper(
     app = FastAPI()
     error_codes.install(app)
     app.include_router(memory_routes.router, prefix="/api/memory", tags=["memory"])
-    app.state.memory_wrapper = None
+    app.state.memory_provider = None
     with TestClient(app) as c:
         r = c.get("/api/memory/graph/status")
         assert r.status_code == 503

--- a/tests/api/test_memory_provider_rename.py
+++ b/tests/api/test_memory_provider_rename.py
@@ -1,0 +1,24 @@
+"""Cutover: app.state exposes memory_provider (P2)."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_app_state_has_memory_provider(monkeypatch):
+    monkeypatch.setenv("HAL0_MEMORY_ENABLED", "1")
+    from hal0.api import create_app
+
+    app = create_app()
+    # New canonical name present; old name gone.
+    assert hasattr(app.state, "memory_provider")
+    assert not hasattr(app.state, "memory_wrapper")
+
+
+def test_health_memory_enabled_reads_provider(monkeypatch):
+    monkeypatch.setenv("HAL0_MEMORY_ENABLED", "1")
+    from hal0.api import create_app
+
+    with TestClient(create_app()) as client:
+        body = client.get("/api/status").json()
+        assert "memory_enabled" in body

--- a/tests/api/test_memory_rest_routes.py
+++ b/tests/api/test_memory_rest_routes.py
@@ -94,7 +94,7 @@ def _build_app(stub: StubWrapper) -> FastAPI:
     app = FastAPI()
     error_codes.install(app)
     app.include_router(memory_routes.router, prefix="/api/memory", tags=["memory"])
-    app.state.memory_wrapper = stub
+    app.state.memory_provider = stub
     return app
 
 

--- a/tests/cli/test_memory_migrate.py
+++ b/tests/cli/test_memory_migrate.py
@@ -1,0 +1,11 @@
+"""hal0 memory migrate --dry-run (P2). No-op on empty/stale Cognee store."""
+
+from __future__ import annotations
+
+from hal0.memory.migrate import migrate_cognee_to_hindsight_dryrun
+
+
+def test_dry_run_reports_zero_on_empty_store(tmp_path):
+    # No sidecar file → empty store → no-op.
+    report = migrate_cognee_to_hindsight_dryrun(cognee_dir=tmp_path)
+    assert report == {"rows_total": 0, "rows_mapped": 0, "rows_unmapped": 0, "noop": True}

--- a/tests/cli/test_memory_migrate.py
+++ b/tests/cli/test_memory_migrate.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sqlite3
+
 from hal0.memory.migrate import migrate_cognee_to_hindsight_dryrun
 
 
@@ -9,3 +11,17 @@ def test_dry_run_reports_zero_on_empty_store(tmp_path):
     # No sidecar file → empty store → no-op.
     report = migrate_cognee_to_hindsight_dryrun(cognee_dir=tmp_path)
     assert report == {"rows_total": 0, "rows_mapped": 0, "rows_unmapped": 0, "noop": True}
+
+
+def test_dry_run_tolerates_null_dataset_rows(tmp_path):
+    # A sidecar row with NULL dataset must not crash the dry-run; it counts
+    # as unmapped rather than raising AttributeError.
+    sidecar = tmp_path / "hal0_memory_index.sqlite"
+    conn = sqlite3.connect(sidecar)
+    conn.execute("CREATE TABLE hal0_memory_items (id TEXT, dataset TEXT)")
+    conn.execute("INSERT INTO hal0_memory_items VALUES ('a', 'shared')")
+    conn.execute("INSERT INTO hal0_memory_items VALUES ('b', NULL)")
+    conn.commit()
+    conn.close()
+    report = migrate_cognee_to_hindsight_dryrun(cognee_dir=tmp_path)
+    assert report == {"rows_total": 2, "rows_mapped": 1, "rows_unmapped": 1, "noop": False}

--- a/tests/config/test_memory_engine_field.py
+++ b/tests/config/test_memory_engine_field.py
@@ -8,8 +8,8 @@ from pydantic import ValidationError
 from hal0.config.schema import MemoryConfig
 
 
-def test_engine_defaults_to_cognee():
-    assert MemoryConfig().engine == "cognee"
+def test_engine_defaults_to_hindsight():
+    assert MemoryConfig().engine == "hindsight"
 
 
 def test_engine_accepts_known_engines():

--- a/tests/config/test_memory_engine_field.py
+++ b/tests/config/test_memory_engine_field.py
@@ -1,0 +1,22 @@
+"""[memory] engine selector field (brain-redesign P1)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from hal0.config.schema import MemoryConfig
+
+
+def test_engine_defaults_to_cognee():
+    assert MemoryConfig().engine == "cognee"
+
+
+def test_engine_accepts_known_engines():
+    for e in ("cognee", "hindsight", "mem0", "pgvector"):
+        assert MemoryConfig(engine=e).engine == e
+
+
+def test_engine_rejects_unknown():
+    with pytest.raises(ValidationError):
+        MemoryConfig(engine="weaviate")

--- a/tests/mcp/test_memory_recall_tool.py
+++ b/tests/mcp/test_memory_recall_tool.py
@@ -1,0 +1,34 @@
+"""MCP memory_recall tool (P2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.mcp.memory import make_dispatcher
+from tests.memory.fakes import FakeMemoryProvider
+
+
+class RecallProvider(FakeMemoryProvider):
+    async def recall(
+        self, query, *, types=None, max_tokens=4096, dataset="shared", tags=None, client_id=None
+    ):
+        return [
+            {
+                "id": "d1",
+                "text": "from-recall",
+                "timestamp": "t",
+                "dataset": "shared",
+                "tags": [],
+                "source": None,
+                "metadata": {},
+                "score": None,
+            }
+        ]
+
+
+@pytest.mark.asyncio
+async def test_memory_recall_tool_dispatches():
+    dispatch = make_dispatcher(RecallProvider(client_id="alice"))
+    out = await dispatch("memory_recall", {"query": "hi", "max_tokens": 512})
+    assert out["status"] == "ok"
+    assert out["results"][0]["text"] == "from-recall"

--- a/tests/memory/fakes.py
+++ b/tests/memory/fakes.py
@@ -1,0 +1,120 @@
+"""In-memory MemoryProvider for the default-gate conformance suite.
+
+Honors the ACL contract (shared + own-private reads; foreign-private reads
+fail-open-empty) with zero external deps so the suite runs on every PR.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from hal0.memory.provider import MemoryProvider
+
+_SHARED = "shared"
+_PRIVATE = "private:"
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class FakeMemoryProvider(MemoryProvider):
+    def __init__(self, *, client_id: str = "anonymous") -> None:
+        self._client_id = client_id
+        self._rows: list[dict[str, Any]] = []
+        self._graph_enabled = False
+        self._graph_route = "upstream"
+        self._rerank_enabled = False
+
+    def _allowed(self, requested: str | list[str], client_id: str | None) -> list[str]:
+        cid = client_id or self._client_id
+        own = f"{_PRIVATE}{cid}"
+        reqs = [requested] if isinstance(requested, str) else list(requested or [_SHARED])
+        out: list[str] = []
+        for ds in reqs:
+            if ds == _SHARED:
+                out += [d for d in (_SHARED, own) if d not in out]
+            elif ds == own and own not in out:
+                out.append(own)
+            elif ds.startswith(_PRIVATE):
+                continue  # foreign private — dropped (fail-open-empty)
+            elif ds not in out:
+                out.append(ds)
+        return out
+
+    async def add(
+        self, text, dataset=_SHARED, tags=None, source=None, metadata=None, client_id=None
+    ):
+        item_id = str(uuid.uuid4())
+        self._rows.append(
+            {
+                "id": item_id,
+                "text": text,
+                "timestamp": _now(),
+                "dataset": dataset,
+                "tags": list(tags or []),
+                "source": source or (client_id or self._client_id),
+                "metadata": dict(metadata or {}),
+                "score": None,
+            }
+        )
+        return {"id": item_id, "timestamp": self._rows[-1]["timestamp"]}
+
+    async def search(
+        self,
+        query,
+        limit=10,
+        dataset=_SHARED,
+        tags=None,
+        before=None,
+        after=None,
+        mode="vector",
+        client_id=None,
+    ):
+        allowed = self._allowed(dataset, client_id)
+        tags = tags or []
+        out = []
+        for row in self._rows:
+            if row["dataset"] not in allowed:
+                continue
+            if tags and not all(t in row["tags"] for t in tags):
+                continue
+            if before and row["timestamp"] >= before:
+                continue
+            if after and row["timestamp"] <= after:
+                continue
+            out.append(dict(row))
+            if len(out) >= limit:
+                break
+        return out
+
+    async def list_items(self, dataset=_SHARED, cursor=None, limit=50, client_id=None):
+        allowed = self._allowed(dataset, client_id)
+        items = [dict(r) for r in self._rows if r["dataset"] in allowed][:limit]
+        return {"items": items, "next_cursor": None}
+
+    async def delete(self, ids, *, client_id=None):
+        before = len(self._rows)
+        self._rows = [r for r in self._rows if r["id"] not in set(ids)]
+        return {"deleted": before - len(self._rows)}
+
+    def graph_status(self):
+        return {
+            "enabled": self._graph_enabled,
+            "route": self._graph_route,
+            "in_flight": 0,
+            "builds_ok": 0,
+            "errors": 0,
+            "last_built_at": None,
+            "last_error": None,
+        }
+
+    def set_graph_enabled(self, enabled, route=None):
+        self._graph_enabled = bool(enabled)
+        if route is not None:
+            self._graph_route = route
+
+    def set_rerank_enabled(self, enabled):
+        self._rerank_enabled = bool(enabled)

--- a/tests/memory/test_hindsight_client.py
+++ b/tests/memory/test_hindsight_client.py
@@ -1,0 +1,34 @@
+"""HindsightRestClient REST-path tests against a MockTransport (P1)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from hal0.memory.hindsight_client import HindsightRestClient
+
+
+@pytest.mark.asyncio
+async def test_retain_recall_delete_hit_v1_bank_paths():
+    seen: list[tuple[str, str]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path))
+        if request.url.path.endswith("/recall"):
+            return httpx.Response(200, json={"results": []})
+        if request.url.path.endswith("/retain"):
+            return httpx.Response(
+                200, json={"success": True, "bank_id": "shared", "items_count": 1}
+            )
+        return httpx.Response(200, json={"memory_units_deleted": 1})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:9177") as http:
+        client = HindsightRestClient(http_client=http, api_key="lemonade-local-noauth")
+        await client.retain(bank_id="shared", content="x", document_id="d1")
+        await client.recall(bank_id="shared", query="x")
+        await client.delete_document(bank_id="shared", document_id="d1")
+
+    assert ("POST", "/v1/default/banks/shared/retain") in seen
+    assert ("POST", "/v1/default/banks/shared/recall") in seen
+    # Delete is the documented delete_document path.
+    assert any(m == "DELETE" and "/documents/d1" in p for m, p in seen)

--- a/tests/memory/test_hindsight_client.py
+++ b/tests/memory/test_hindsight_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import httpx
 import pytest
+
 from hal0.memory.hindsight_client import HindsightRestClient
 
 
@@ -15,7 +16,7 @@ async def test_retain_recall_delete_hit_v1_bank_paths():
         seen.append((request.method, request.url.path))
         if request.url.path.endswith("/recall"):
             return httpx.Response(200, json={"results": []})
-        if request.url.path.endswith("/retain"):
+        if request.url.path.endswith("/memories"):
             return httpx.Response(
                 200, json={"success": True, "bank_id": "shared", "items_count": 1}
             )
@@ -28,7 +29,7 @@ async def test_retain_recall_delete_hit_v1_bank_paths():
         await client.recall(bank_id="shared", query="x")
         await client.delete_document(bank_id="shared", document_id="d1")
 
-    assert ("POST", "/v1/default/banks/shared/retain") in seen
-    assert ("POST", "/v1/default/banks/shared/recall") in seen
+    assert ("POST", "/v1/default/banks/shared/memories") in seen
+    assert ("POST", "/v1/default/banks/shared/memories/recall") in seen
     # Delete is the documented delete_document path.
     assert any(m == "DELETE" and "/documents/d1" in p for m, p in seen)

--- a/tests/memory/test_hindsight_provider.py
+++ b/tests/memory/test_hindsight_provider.py
@@ -1,0 +1,74 @@
+"""HindsightProvider unit tests — bank mapping + fan-out (P1)."""
+
+from __future__ import annotations
+
+import pytest
+from hal0.memory.hindsight_provider import HindsightProvider, namespace_to_bank
+
+
+class FakeHindsightClient:
+    """Records calls; returns canned recall/retain/delete results."""
+
+    def __init__(self) -> None:
+        self.retained: list[dict] = []
+        self.recalled: list[dict] = []
+        self.deleted: list[str] = []
+        self._facts_by_bank: dict[str, list[dict]] = {}
+
+    async def retain(
+        self,
+        *,
+        bank_id,
+        content,
+        document_id,
+        context=None,
+        metadata=None,
+        tags=None,
+        timestamp=None,
+    ):
+        self.retained.append(
+            {
+                "bank_id": bank_id,
+                "document_id": document_id,
+                "content": content,
+                "tags": list(tags or []),
+            }
+        )
+        self._facts_by_bank.setdefault(bank_id, []).append(
+            {
+                "document_id": document_id,
+                "text": content,
+                "tags": list(tags or []),
+                "mentioned_at": "2026-06-06T00:00:00+00:00",
+            }
+        )
+        return {"success": True, "bank_id": bank_id, "items_count": 1}
+
+    async def recall(self, *, bank_id, query, types=None, max_tokens=4096, tags=None):
+        self.recalled.append({"bank_id": bank_id, "query": query})
+        return {"results": list(self._facts_by_bank.get(bank_id, []))}
+
+    async def delete_document(self, *, bank_id, document_id):
+        self.deleted.append(document_id)
+        facts = self._facts_by_bank.get(bank_id, [])
+        before = len(facts)
+        self._facts_by_bank[bank_id] = [f for f in facts if f["document_id"] != document_id]
+        return {"memory_units_deleted": before - len(self._facts_by_bank[bank_id])}
+
+
+def test_namespace_to_bank_mapping():
+    assert namespace_to_bank("shared") == "shared"
+    assert namespace_to_bank("private:hermes") == "private__hermes"
+    assert namespace_to_bank("project:42") == "project__42"
+    assert namespace_to_bank("agents") == "agents"
+
+
+@pytest.mark.asyncio
+async def test_add_routes_to_retain_under_mapped_bank():
+    fake = FakeHindsightClient()
+    p = HindsightProvider(client=fake, client_id="hermes")
+    res = await p.add("Alice works at Google", dataset="private:hermes", client_id="hermes")
+    assert set(res) == {"id", "timestamp"}
+    assert fake.retained[0]["bank_id"] == "private__hermes"
+    # The returned id IS the document_id (the join key), not a fact id.
+    assert fake.retained[0]["document_id"] == res["id"]

--- a/tests/memory/test_hindsight_provider.py
+++ b/tests/memory/test_hindsight_provider.py
@@ -106,16 +106,24 @@ async def test_recall_fans_out_across_allowed_banks_and_merges():
 
 
 @pytest.mark.asyncio
-async def test_recall_merge_precedence_shared_observation_before_private_fact():
+async def test_recall_merge_precedence_tier_overrides_bank_order_and_score():
+    # §4b: a tier-0 item (shared/curated) must rank above a tier-1 raw fact
+    # EVEN WHEN the tier-1 fact iterates first AND scores higher in the
+    # reranker. This is the adversarial layout that isolates _precedence_key:
+    #   - dataset=["agents","shared"] → banks iterate [agents, shared, ...],
+    #     so the tier-1 "agents" fact is fanned in BEFORE the tier-0 shared one.
+    #   - FakeReranker reverses, giving index-0 ("raw", agents) the HIGHER
+    #     score, so a score-only sort would also keep "raw" first.
+    # Only the tier key flips it. A broken impl (bank-order-only OR score-only)
+    # yields out[0]=="raw" and fails this test.
     fake = FakeHindsightClient()
-    # shared observation (curated) must outrank a raw private fact (§4b).
-    fake._facts_by_bank["shared"] = [
-        {"document_id": "o1", "text": "obs", "type": "observation", "tags": []}
+    fake._facts_by_bank["agents"] = [
+        {"document_id": "a1", "text": "raw", "type": "experience", "tags": []}
     ]
-    fake._facts_by_bank["private__hermes"] = [
-        {"document_id": "f1", "text": "raw", "type": "experience", "tags": []}
+    fake._facts_by_bank["shared"] = [
+        {"document_id": "o1", "text": "win", "type": "observation", "tags": []}
     ]
 
     p = HindsightProvider(client=fake, client_id="hermes", reranker=FakeReranker())
-    out = await p.recall("anything", dataset="shared", client_id="hermes")
-    assert out[0]["text"] == "obs"  # observation ranks first
+    out = await p.recall("anything", dataset=["agents", "shared"], client_id="hermes")
+    assert [r["text"] for r in out][:2] == ["win", "raw"]  # tier-0 first despite order+score

--- a/tests/memory/test_hindsight_provider.py
+++ b/tests/memory/test_hindsight_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+
 from hal0.memory.hindsight_provider import HindsightProvider, namespace_to_bank
 
 
@@ -72,3 +73,49 @@ async def test_add_routes_to_retain_under_mapped_bank():
     assert fake.retained[0]["bank_id"] == "private__hermes"
     # The returned id IS the document_id (the join key), not a fact id.
     assert fake.retained[0]["document_id"] == res["id"]
+
+
+class FakeReranker:
+    """Reverses input order so we can prove the merge re-ranked the union."""
+
+    async def rerank(self, query: str, documents: list[str]) -> list[dict]:
+        n = len(documents)
+        return [{"index": i, "relevance_score": float(n - i)} for i in range(n)]
+
+
+@pytest.mark.asyncio
+async def test_recall_fans_out_across_allowed_banks_and_merges():
+    fake = FakeHindsightClient()
+    await fake.retain(bank_id="shared", content="shared fact", document_id="d-shared", tags=[])
+    await fake.retain(
+        bank_id="private__hermes", content="private fact", document_id="d-priv", tags=[]
+    )
+    await fake.retain(
+        bank_id="private__other", content="other private", document_id="d-other", tags=[]
+    )
+
+    p = HindsightProvider(client=fake, client_id="hermes", reranker=FakeReranker())
+    out = await p.recall("fact", dataset="shared", client_id="hermes")
+
+    banks_queried = {c["bank_id"] for c in fake.recalled}
+    # Fans out to own-private + shared; NEVER another agent's private.
+    assert banks_queried == {"shared", "private__hermes"}
+    texts = {r["text"] for r in out}
+    assert texts == {"shared fact", "private fact"}
+    assert "other private" not in texts
+
+
+@pytest.mark.asyncio
+async def test_recall_merge_precedence_shared_observation_before_private_fact():
+    fake = FakeHindsightClient()
+    # shared observation (curated) must outrank a raw private fact (§4b).
+    fake._facts_by_bank["shared"] = [
+        {"document_id": "o1", "text": "obs", "type": "observation", "tags": []}
+    ]
+    fake._facts_by_bank["private__hermes"] = [
+        {"document_id": "f1", "text": "raw", "type": "experience", "tags": []}
+    ]
+
+    p = HindsightProvider(client=fake, client_id="hermes", reranker=FakeReranker())
+    out = await p.recall("anything", dataset="shared", client_id="hermes")
+    assert out[0]["text"] == "obs"  # observation ranks first

--- a/tests/memory/test_hindsight_provider.py
+++ b/tests/memory/test_hindsight_provider.py
@@ -127,3 +127,36 @@ async def test_recall_merge_precedence_tier_overrides_bank_order_and_score():
     p = HindsightProvider(client=fake, client_id="hermes", reranker=FakeReranker())
     out = await p.recall("anything", dataset=["agents", "shared"], client_id="hermes")
     assert [r["text"] for r in out][:2] == ["win", "raw"]  # tier-0 first despite order+score
+
+
+@pytest.mark.asyncio
+async def test_lemonade_reranker_posts_rerank_and_parses_results():
+    import httpx
+
+    from hal0.memory.hindsight_provider import LemonadeReranker
+
+    seen: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        return httpx.Response(200, json={"results": [{"index": 0, "relevance_score": 0.9}]})
+
+    transport = httpx.MockTransport(handler)
+    rr = LemonadeReranker(url="http://127.0.0.1:8086")
+    orig = httpx.AsyncClient
+    httpx.AsyncClient = lambda *a, **k: orig(transport=transport)
+    try:
+        out = await rr.rerank("q", ["doc a", "doc b"])
+    finally:
+        httpx.AsyncClient = orig
+    assert seen["path"] == "/rerank"
+    assert out == [{"index": 0, "relevance_score": 0.9}]
+
+
+@pytest.mark.asyncio
+async def test_lemonade_reranker_failsoft_returns_empty_on_error():
+    from hal0.memory.hindsight_provider import LemonadeReranker
+
+    rr = LemonadeReranker(url="http://127.0.0.1:59999")  # nothing listening
+    out = await rr.rerank("q", ["a", "b"])
+    assert out == []

--- a/tests/memory/test_provider_abc.py
+++ b/tests/memory/test_provider_abc.py
@@ -44,3 +44,10 @@ def test_add_signature_matches_cognee_call_sites():
     params = list(sig.parameters)
     # Mirrors CogneeWrapper.add + the REST/MCP callers.
     assert params == ["self", "text", "dataset", "tags", "source", "metadata", "client_id"]
+
+
+def test_cognee_wrapper_is_a_memory_provider():
+    from hal0.memory.cognee_wrapper import CogneeWrapper
+    from hal0.memory.provider import MemoryProvider
+
+    assert issubclass(CogneeWrapper, MemoryProvider)

--- a/tests/memory/test_provider_abc.py
+++ b/tests/memory/test_provider_abc.py
@@ -1,0 +1,46 @@
+"""ABC shape tests — the explicit MemoryProvider contract (P0)."""
+
+from __future__ import annotations
+
+import inspect
+
+from hal0.memory.provider import (
+    AddResult,  # noqa: F401 — import-smoke: verify public surface exists
+    DeleteResult,  # noqa: F401
+    GraphStatus,  # noqa: F401
+    ListPage,  # noqa: F401
+    MemoryItem,  # noqa: F401
+    MemoryProvider,
+    Mode,  # noqa: F401
+)
+
+
+def test_abc_declares_core_five_plus_status():
+    # The methods every engine MUST implement (the call sites in
+    # routes/memory.py + mcp/memory.py depend on these exact names).
+    required = {
+        "add",
+        "search",
+        "list_items",
+        "delete",
+        "graph_status",
+        "set_graph_enabled",
+        "set_rerank_enabled",
+    }
+    assert required <= set(MemoryProvider.__abstractmethods__)
+
+
+def test_abc_optional_methods_have_safe_defaults():
+    # Optional capability methods are concrete (NOT abstract) so an engine
+    # that lacks consolidation still satisfies the ABC.
+    optional = {"recall", "reflect", "consolidate", "register_compiled"}
+    assert not (optional & set(MemoryProvider.__abstractmethods__))
+    for name in optional:
+        assert callable(getattr(MemoryProvider, name))
+
+
+def test_add_signature_matches_cognee_call_sites():
+    sig = inspect.signature(MemoryProvider.add)
+    params = list(sig.parameters)
+    # Mirrors CogneeWrapper.add + the REST/MCP callers.
+    assert params == ["self", "text", "dataset", "tags", "source", "metadata", "client_id"]

--- a/tests/memory/test_provider_contract.py
+++ b/tests/memory/test_provider_contract.py
@@ -104,3 +104,24 @@ async def test_pgvector_conforms():
     out = await p.search("pg", dataset="private:bob", client_id="bob")
     assert out == []
     assert set(p.graph_status()) >= {"enabled", "route"}
+
+
+def _hindsight_factory():
+    from hal0.memory.hindsight_provider import HindsightProvider
+    from tests.memory.test_hindsight_provider import FakeHindsightClient
+
+    return HindsightProvider(client=FakeHindsightClient(), client_id="alice")
+
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_hindsight_conforms_to_contract():
+    p = _hindsight_factory()
+    res = await p.add("hs note", dataset="shared")
+    assert set(res) == {"id", "timestamp"}
+    # Foreign-private read → empty.
+    out = await p.search("note", dataset="private:bob", client_id="bob")
+    assert out == []
+    assert set(p.graph_status()) >= {"enabled", "route"}
+    d = await p.delete([res["id"]])
+    assert "deleted" in d

--- a/tests/memory/test_provider_contract.py
+++ b/tests/memory/test_provider_contract.py
@@ -87,3 +87,20 @@ async def test_graph_status_shape(conformant):
         "last_built_at",
         "last_error",
     }
+
+
+def _pgvector_factory():
+    from hal0.memory.pgvector_provider import PgVectorProvider
+
+    return PgVectorProvider(client_id="alice")
+
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_pgvector_conforms():
+    p = _pgvector_factory()
+    res = await p.add("pg note", dataset="shared")
+    assert set(res) == {"id", "timestamp"}
+    out = await p.search("pg", dataset="private:bob", client_id="bob")
+    assert out == []
+    assert set(p.graph_status()) >= {"enabled", "route"}

--- a/tests/memory/test_provider_contract.py
+++ b/tests/memory/test_provider_contract.py
@@ -1,0 +1,89 @@
+"""Parametrized MemoryProvider conformance suite (brain-redesign P0).
+
+Asserts the contract every engine must honor: namespace isolation,
+``private:`` write rejection at the wrapper boundary, tag-AND, date-range,
+delete semantics, fail-open-empty foreign-private reads, and the
+``graph_status()`` payload shape.
+
+The DEFAULT-gate parameter is the in-memory ``FakeMemoryProvider`` so this
+suite runs on every PR without dragging a heavy backend in. Real backends
+(Cognee, PgVector, Hindsight) attach as ``@pytest.mark.slow`` params, matching
+the existing tests/memory/conftest.py split.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.memory.fakes import FakeMemoryProvider
+
+
+@pytest.fixture
+def provider(request) -> object:
+    # request.param is a 0-arg factory returning a fresh provider.
+    return request.param()
+
+
+def _fake_factory():
+    return FakeMemoryProvider(client_id="alice")
+
+
+# Default gate: the fake only. Slow backends are added by later tasks via
+# pytest_generate_tests / additional params marked slow.
+@pytest.fixture(params=[_fake_factory], ids=["fake"])
+def conformant(request):
+    return request.param()
+
+
+@pytest.mark.asyncio
+async def test_add_returns_id_and_timestamp(conformant):
+    result = await conformant.add("a note", dataset="shared")
+    assert set(result) == {"id", "timestamp"}
+    assert isinstance(result["id"], str) and result["id"]
+
+
+@pytest.mark.asyncio
+async def test_namespace_isolation_foreign_private_reads_empty(conformant):
+    # A write into alice's private bucket is invisible to a bob-scoped read.
+    await conformant.add("alice secret", dataset="private:alice", client_id="alice")
+    out = await conformant.search("secret", dataset="private:bob", client_id="bob")
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_tag_and_match(conformant):
+    await conformant.add("tagged", dataset="shared", tags=["x", "y"])
+    await conformant.add("partial", dataset="shared", tags=["x"])
+    out = await conformant.search("tagged partial", dataset="shared", tags=["x", "y"])
+    texts = {r["text"] for r in out}
+    assert "tagged" in texts and "partial" not in texts
+
+
+@pytest.mark.asyncio
+async def test_date_range_before_after(conformant):
+    await conformant.add("old", dataset="shared")
+    out = await conformant.search("old", dataset="shared", after="2099-01-01T00:00:00+00:00")
+    assert out == []  # nothing after the year 2099
+
+
+@pytest.mark.asyncio
+async def test_delete_semantics(conformant):
+    res = await conformant.add("deleteme", dataset="shared")
+    deleted = await conformant.delete([res["id"]])
+    assert deleted == {"deleted": 1}
+    out = await conformant.search("deleteme", dataset="shared")
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_graph_status_shape(conformant):
+    status = conformant.graph_status()
+    assert set(status) >= {
+        "enabled",
+        "route",
+        "in_flight",
+        "builds_ok",
+        "errors",
+        "last_built_at",
+        "last_error",
+    }

--- a/tests/memory/test_provider_factory.py
+++ b/tests/memory/test_provider_factory.py
@@ -31,3 +31,20 @@ def test_factory_returns_cognee_for_default_engine():
     with patch("hal0.memory.CogneeWrapper", autospec=True) as mock_cls:
         provider_from_config(_cfg("cognee"))
         assert mock_cls.called
+
+
+def test_factory_returns_hindsight_when_engine_hindsight():
+    with (
+        patch("hal0.memory.HindsightProvider", autospec=True) as mock_cls,
+        patch("hal0.memory._build_hindsight_client", return_value=object()),
+    ):
+        provider_from_config(_cfg("hindsight"))
+        assert mock_cls.called
+
+
+def test_factory_degrades_to_pgvector_when_hindsight_unavailable():
+    from hal0.memory.pgvector_provider import PgVectorProvider
+
+    with patch("hal0.memory._build_hindsight_client", side_effect=RuntimeError("no daemon")):
+        provider = provider_from_config(_cfg("hindsight"))
+        assert isinstance(provider, PgVectorProvider)

--- a/tests/memory/test_provider_factory.py
+++ b/tests/memory/test_provider_factory.py
@@ -48,3 +48,28 @@ def test_factory_degrades_to_pgvector_when_hindsight_unavailable():
     with patch("hal0.memory._build_hindsight_client", side_effect=RuntimeError("no daemon")):
         provider = provider_from_config(_cfg("hindsight"))
         assert isinstance(provider, PgVectorProvider)
+
+
+def test_factory_default_engine_is_hindsight_after_cutover():
+    from types import SimpleNamespace
+
+    cfg = SimpleNamespace(
+        memory=SimpleNamespace(
+            embedding=SimpleNamespace(
+                model="m",
+                rerank_enabled=False,
+                rerank_url="http://127.0.0.1:8086",
+                rerank_over_fetch_factor=5,
+                rerank_max_candidates=500,
+                rerank_connect_timeout_s=1.0,
+                rerank_read_timeout_s=8.0,
+            ),
+            graph=SimpleNamespace(enabled=False, route="upstream"),
+        )
+    )
+    with (
+        patch("hal0.memory.HindsightProvider", autospec=True) as mock_cls,
+        patch("hal0.memory._build_hindsight_client", return_value=object()),
+    ):
+        provider_from_config(cfg)
+        assert mock_cls.called

--- a/tests/memory/test_provider_factory.py
+++ b/tests/memory/test_provider_factory.py
@@ -1,0 +1,33 @@
+"""provider_from_config factory tests (P0: Cognee-only branch)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from hal0.memory import provider_from_config
+
+
+def _cfg(engine="cognee"):
+    return SimpleNamespace(
+        memory=SimpleNamespace(
+            engine=engine,
+            embedding=SimpleNamespace(
+                model="BAAI/bge-small-en-v1.5",
+                rerank_enabled=False,
+                rerank_url="http://127.0.0.1:8086",
+                rerank_over_fetch_factor=5,
+                rerank_max_candidates=500,
+                rerank_connect_timeout_s=1.0,
+                rerank_read_timeout_s=8.0,
+            ),
+            graph=SimpleNamespace(enabled=False, route="upstream"),
+        )
+    )
+
+
+def test_factory_returns_cognee_for_default_engine():
+    # Patch the constructor so we don't stand up real Cognee.
+    with patch("hal0.memory.CogneeWrapper", autospec=True) as mock_cls:
+        provider_from_config(_cfg("cognee"))
+        assert mock_cls.called

--- a/tests/memory/test_recall_route.py
+++ b/tests/memory/test_recall_route.py
@@ -1,0 +1,66 @@
+"""POST /api/memory/recall route (P2)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api.middleware import error_codes
+from hal0.api.routes.memory import router
+from tests.memory.fakes import FakeMemoryProvider
+
+
+class RecordingProvider(FakeMemoryProvider):
+    def __init__(self):
+        super().__init__(client_id="anonymous")
+        self.recall_calls = []
+
+    async def recall(
+        self,
+        query,
+        *,
+        types=None,
+        max_tokens=4096,
+        dataset="shared",
+        tags=None,
+        client_id=None,
+    ):
+        self.recall_calls.append({"query": query, "max_tokens": max_tokens})
+        return [
+            {
+                "id": "d1",
+                "text": "recalled",
+                "timestamp": "2026-06-06T00:00:00+00:00",
+                "dataset": "shared",
+                "tags": [],
+                "source": None,
+                "metadata": {},
+                "score": None,
+            }
+        ]
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    error_codes.install(app)
+    app.include_router(router, prefix="/api/memory")
+    app.state.memory_provider = RecordingProvider()
+    return TestClient(app)
+
+
+def test_recall_route_returns_items(client):
+    resp = client.post(
+        "/api/memory/recall",
+        json={"query": "what do I know", "max_tokens": 2048},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["items"][0]["text"] == "recalled"
+    assert client.app.state.memory_provider.recall_calls[0]["max_tokens"] == 2048
+
+
+def test_recall_requires_query(client):
+    resp = client.post("/api/memory/recall", json={})
+    assert resp.status_code == 400


### PR DESCRIPTION
Swaps hal0's memory engine Cognee→Hindsight behind the `MemoryProvider` ABC + ACL shim, re-enables the gated brain, and lands the cutover code. **Gated** behind `HAL0_MEMORY_ENABLED` (default flips on in the install template here, but the running box is flipped separately).

## Scope (plan doc 09 / 2026-06-06 plan)
- **P0** seam: `MemoryProvider` ABC, conformance suite + `FakeMemoryProvider`, `PgVectorProvider` fallback, `provider_from_config` factory, Hermes `_client.py` 404 fix.
- **P1** engine: `HindsightProvider` (bank map, multi-bank fan-out, §4b reranked merge), `HindsightRestClient` (real 0.7.2 `/memories` paths), `MemoryConfig.engine`, degrade ladder. **Deployed** `hindsight-api 0.7.2` on CT105 (pg0, NPU `gemma3-4b-FLM` extraction). Live retain+recall verified.
- **P2** cutover: rename `memory_wrapper`→`memory_provider` (factory-on-boot), `POST /api/memory/recall`, MCP `memory_recall`, `hal0 memory migrate --dry-run`, **default engine→hindsight + §4b reranker wired**.

## Verified
- Default gate (24) + slow conformance (15, cognee/hindsight/pgvector) green; gate-ON `create_app()` builds the hindsight branch with no hang.
- Live: hindsight-api healthy, retain→extract(NPU gemma3)→recall end-to-end.

## Deferred (post-merge)
- Rerank slot dormant → bring up `/rerank` endpoint + point `rerank_url` (fail-soft until then).
- P5-H Hermes convergence (separate).

Runbook: `docs/internal/brain-redesign/ops/hindsight-deploy.md`.