### PR TITLE
fix(memory): list_items real endpoint + §4b reranker → lemond /v1/reranking

### DIFF
--- a/src/hal0/memory/__init__.py
+++ b/src/hal0/memory/__init__.py
@@ -91,7 +91,7 @@ def provider_from_config(cfg: Any) -> MemoryProvider:
         from hal0.memory.hindsight_provider import LemonadeReranker
 
         reranker = LemonadeReranker(
-            url=str(embed.rerank_url),
+            base_url=str(getattr(embed, "rerank_gateway_url", None) or "http://127.0.0.1:13305"),
             connect_timeout_s=float(embed.rerank_connect_timeout_s),
             read_timeout_s=float(embed.rerank_read_timeout_s),
         )

--- a/src/hal0/memory/hindsight_client.py
+++ b/src/hal0/memory/hindsight_client.py
@@ -80,6 +80,20 @@ class HindsightRestClient:
         resp.raise_for_status()
         return resp.json()
 
+    async def list_memories(self, *, bank_id, limit=50, offset=0, types=None, query=None):
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if types:
+            params["type"] = types if isinstance(types, str) else ",".join(types)
+        if query:
+            params["q"] = query
+        resp = await self._http.get(
+            f"/v1/default/banks/{bank_id}/memories/list",
+            headers=self._headers(),
+            params=params,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
     async def delete_document(self, *, bank_id, document_id):
         resp = await self._http.request(
             "DELETE",

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -176,13 +176,33 @@ class HindsightProvider(MemoryProvider):
         limit: int = 50,
         client_id: str | None = None,
     ) -> dict[str, Any]:
-        # Hindsight has no flat list; list = recall with an empty-ish broad
-        # query is unreliable, so we surface the documents endpoint per bank.
-        # P1 lists via recall on a wildcard-ish query; refined in P2 if needed.
-        out = await self.recall(
-            query="*", max_tokens=limit * 256, dataset=dataset, client_id=client_id
-        )
-        return {"items": out[:limit], "next_cursor": None}
+        banks = [namespace_to_bank(ns) for ns in self._allowed_namespaces(dataset, client_id)]
+        items: list[dict[str, Any]] = []
+        for bank in banks:
+            if len(items) >= limit:
+                break
+            try:
+                resp = await self._client.list_memories(bank_id=bank, limit=limit, offset=0)
+            except Exception:
+                continue  # fail-soft per bank
+            for fact in resp.get("items", []):
+                items.append(self._list_fact_to_item(fact, bank))
+        return {"items": items[:limit], "next_cursor": None}
+
+    @staticmethod
+    def _list_fact_to_item(fact: dict[str, Any], bank: str) -> dict[str, Any]:
+        """Map a Hindsight /memories/list item to the MemoryItem wire shape."""
+        return {
+            "id": fact.get("id") or fact.get("document_id"),
+            "text": fact.get("text", ""),
+            "timestamp": fact.get("mentioned_at") or fact.get("date") or _now(),
+            "dataset": bank.replace("__", ":"),
+            "tags": list(fact.get("tags") or []),
+            "source": None,
+            "metadata": {},
+            "score": None,
+            "type": fact.get("fact_type"),
+        }
 
     async def delete(self, ids: list[str], *, client_id: str | None = None) -> dict[str, int]:
         deleted = 0

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -35,30 +35,31 @@ def namespace_to_bank(namespace: str) -> str:
 
 
 class LemonadeReranker:
-    """Async reranker over the hal0 rerank slot (llama.cpp /rerank shape).
+    """Async reranker over lemond's gateway (Cohere-style ``/v1/reranking``).
 
-    POSTs {model, query, documents} to ``{url}/rerank`` and returns the raw
-    ``results`` list (``[{"index", "relevance_score"}, ...]``) that
+    POSTs {model, query, documents} to ``{base_url}/v1/reranking`` and returns
+    the raw ``results`` list (``[{"index", "relevance_score"}, ...]``, NOT
+    pre-sorted; lemond auto-loads the model on request) that
     HindsightProvider._rerank_union maps onto the cross-bank union. Fail-soft:
-    returns [] on any error (slot down/evicted, bad shape, timeout) so recall
-    falls back to fused order. The rerank slot may be dormant; that's fine.
+    returns [] on any error (gateway down, model load fail, bad shape, timeout)
+    so recall falls back to fused order.
     """
 
     def __init__(
         self,
         *,
-        url: str = "http://127.0.0.1:8086",
-        model: str = "bge-reranker-v2-m3-q4_k_m",
+        base_url: str = "http://127.0.0.1:13305",
+        model: str = "builtin.jina-reranker-v1-tiny-en-q8",
         connect_timeout_s: float = 1.0,
         read_timeout_s: float = 8.0,
     ) -> None:
-        self._url = str(url or "").rstrip("/")
+        self._base_url = str(base_url or "").rstrip("/")
         self._model = model
         self._connect_timeout_s = float(connect_timeout_s)
         self._read_timeout_s = float(read_timeout_s)
 
     async def rerank(self, query: str, documents: list[str]) -> list[dict[str, Any]]:
-        if not self._url or not documents:
+        if not self._base_url or not documents:
             return []
         import httpx
 
@@ -68,7 +69,7 @@ class LemonadeReranker:
         )
         try:
             async with httpx.AsyncClient(timeout=timeout) as client:
-                resp = await client.post(f"{self._url}/rerank", json=payload)
+                resp = await client.post(f"{self._base_url}/v1/reranking", json=payload)
                 resp.raise_for_status()
                 body = resp.json()
         except Exception:

--- a/tests/memory/test_hindsight_client.py
+++ b/tests/memory/test_hindsight_client.py
@@ -33,3 +33,37 @@ async def test_retain_recall_delete_hit_v1_bank_paths():
     assert ("POST", "/v1/default/banks/shared/memories/recall") in seen
     # Delete is the documented delete_document path.
     assert any(m == "DELETE" and "/documents/d1" in p for m, p in seen)
+
+
+@pytest.mark.asyncio
+async def test_list_memories_hits_list_endpoint_and_returns_json():
+    seen: list[tuple[str, str]] = []
+    payload = {
+        "items": [
+            {
+                "id": "fact-1",
+                "text": "Alice works at Google",
+                "fact_type": "observation",
+                "mentioned_at": "2026-06-06T00:00:00+00:00",
+                "tags": ["work"],
+            }
+        ],
+        "total": 1,
+        "limit": 50,
+        "offset": 0,
+    }
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path))
+        if request.method == "GET" and request.url.path.endswith("/memories/list"):
+            return httpx.Response(200, json=payload)
+        return httpx.Response(404, json={"error": "not found"})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:9177") as http:
+        client = HindsightRestClient(http_client=http, api_key="lemonade-local-noauth")
+        result = await client.list_memories(bank_id="shared", limit=50, offset=0)
+
+    assert ("GET", "/v1/default/banks/shared/memories/list") in seen
+    assert result == payload
+    assert result["items"][0]["id"] == "fact-1"

--- a/tests/memory/test_hindsight_provider.py
+++ b/tests/memory/test_hindsight_provider.py
@@ -56,6 +56,21 @@ class FakeHindsightClient:
         self._facts_by_bank[bank_id] = [f for f in facts if f["document_id"] != document_id]
         return {"memory_units_deleted": before - len(self._facts_by_bank[bank_id])}
 
+    async def list_memories(self, *, bank_id, limit=50, offset=0, types=None, query=None):
+        raw = list(self._facts_by_bank.get(bank_id, []))
+        # Expose stored facts in the list-endpoint shape: id falls back to document_id.
+        items = [
+            {
+                "id": f.get("id") or f.get("document_id"),
+                "text": f.get("text", ""),
+                "fact_type": f.get("fact_type", "observation"),
+                "mentioned_at": f.get("mentioned_at"),
+                "tags": list(f.get("tags") or []),
+            }
+            for f in raw
+        ]
+        return {"items": items, "total": len(items), "limit": limit, "offset": offset}
+
 
 def test_namespace_to_bank_mapping():
     assert namespace_to_bank("shared") == "shared"
@@ -160,3 +175,34 @@ async def test_lemonade_reranker_failsoft_returns_empty_on_error():
     rr = LemonadeReranker(url="http://127.0.0.1:59999")  # nothing listening
     out = await rr.rerank("q", ["a", "b"])
     assert out == []
+
+
+@pytest.mark.asyncio
+async def test_list_items_fans_out_real_endpoint():
+    """list_items fans out to shared + own private; excludes foreign private."""
+    fake = FakeHindsightClient()
+    # Retain into shared and private__hermes (allowed for client_id=hermes + dataset=shared)
+    await fake.retain(bank_id="shared", content="shared fact", document_id="d-shared", tags=["s"])
+    await fake.retain(
+        bank_id="private__hermes",
+        content="hermes private fact",
+        document_id="d-hermes",
+        tags=["h"],
+    )
+    # Retain into a foreign private bank — must be excluded
+    await fake.retain(
+        bank_id="private__other", content="other agent fact", document_id="d-other", tags=[]
+    )
+
+    p = HindsightProvider(client=fake, client_id="hermes")
+    result = await p.list_items(dataset="shared", client_id="hermes")
+
+    texts = {item["text"] for item in result["items"]}
+    assert "shared fact" in texts
+    assert "hermes private fact" in texts
+    assert "other agent fact" not in texts
+    assert result["next_cursor"] is None
+    # ids come from the list-endpoint shape (id field, not document_id)
+    ids = {item["id"] for item in result["items"]}
+    assert "d-shared" in ids
+    assert "d-hermes" in ids

--- a/tests/memory/test_hindsight_provider.py
+++ b/tests/memory/test_hindsight_provider.py
@@ -157,14 +157,14 @@ async def test_lemonade_reranker_posts_rerank_and_parses_results():
         return httpx.Response(200, json={"results": [{"index": 0, "relevance_score": 0.9}]})
 
     transport = httpx.MockTransport(handler)
-    rr = LemonadeReranker(url="http://127.0.0.1:8086")
+    rr = LemonadeReranker(base_url="http://127.0.0.1:13305")
     orig = httpx.AsyncClient
     httpx.AsyncClient = lambda *a, **k: orig(transport=transport)
     try:
         out = await rr.rerank("q", ["doc a", "doc b"])
     finally:
         httpx.AsyncClient = orig
-    assert seen["path"] == "/rerank"
+    assert seen["path"] == "/v1/reranking"
     assert out == [{"index": 0, "relevance_score": 0.9}]
 
 
@@ -172,7 +172,7 @@ async def test_lemonade_reranker_posts_rerank_and_parses_results():
 async def test_lemonade_reranker_failsoft_returns_empty_on_error():
     from hal0.memory.hindsight_provider import LemonadeReranker
 
-    rr = LemonadeReranker(url="http://127.0.0.1:59999")  # nothing listening
+    rr = LemonadeReranker(base_url="http://127.0.0.1:59999")  # nothing listening
     out = await rr.rerank("q", ["a", "b"])
     assert out == []
 


### PR DESCRIPTION
Fixes the two P2-6 follow-up gaps.

- **list_items**: was a `recall("*")` placeholder returning nothing → now calls Hindsight `GET /v1/default/banks/{bank}/memories/list` (fan-out across allowed banks, fail-soft per bank).
- **§4b reranker**: `LemonadeReranker` POSTed to a non-existent `/rerank` path → now hits lemond's real `POST /v1/reranking` (Cohere-style, model `builtin.jina-reranker-v1-tiny-en-q8`, auto-loads). Unsorted results are fine (the §4b merge sorts by score within tier).

Unit-tested both. Live verification (list returns items; rerank changes recall ordering) after deploy.