### PR TITLE
feat(slots): accept installed FLM models in slot-apply (P0) + shape audits

### DIFF
--- a/docs/internal/brain-redesign/model-shapes-audit-2026-06-07.md
+++ b/docs/internal/brain-redesign/model-shapes-audit-2026-06-07.md
@@ -1,0 +1,179 @@
+# MODEL shape audit — descriptor-field proliferation across hal0 subsystems
+
+**Date:** 2026-06-07
+**Scope:** READ-ONLY. Maps every descriptor field a "model" carries, where it is SET and READ, to enable consolidation.
+**Code read at:** `/tmp/hal0-partA` (branch `fix/flm-host-probe`). Runtime inspected on CT 105 (`ssh hal0`).
+
+---
+
+## 0. The shapes, named
+
+A "model" is **not one object**. There are at least **six** distinct row shapes, each with a different field set:
+
+| Shape | Where defined | Field naming convention |
+|-------|---------------|--------------------------|
+| **Registry `Model`** | `src/hal0/registry/model.py:50` | plural: `capabilities`, `backends`; no `device`/`type`/`provider` |
+| **`/api/models` registry-derived row** | `routes/models.py:161-169` (`_model_to_dict`) | `Model` dump + `installed`/`object`/`created`/`owned_by`/`ns`/`type` |
+| **`/api/models` upstream-synthesized row** | `routes/models.py:183-201` | `id`/`name`/`owned_by`/`upstream`/`installed`/`ns`/`type` — **no** capabilities/backends |
+| **`/api/models` FLM-synthesized row** | `routes/models.py:229-244` | `backend`(sing)/`upstream`/`capability`(sing)/`capabilities`(plur)/`device`/`type` |
+| **`CuratedModel`** | `registry/curated.py:75` | singular: `capability`, `backend`, `hf_file`; plus `recipe`(via `model_class`), `comfyui_subdir`, `bundle_only` |
+| **Capabilities catalog picker row** | `capabilities/catalog.py:378,555` | model-first with `backends[]` list of `{id,provider,downloaded,pullable}` |
+| **Lemonade `server_models.json` entry** | `lemonade/server_models_gen.py:382` | `checkpoint`/`recipe`/`labels`/`size`/`max_context_window` |
+
+The `/api/models` endpoint emits **three of these shapes in the same array** (registry, upstream, FLM), and the UI's `normalizeApiModel` then re-derives `type`/`device` client-side because the shapes disagree.
+
+---
+
+## 1. Field table — value space → SET → READ → redundancy
+
+| Field | Allowed values | SET (source of truth) | READ (consumers) | Redundant-with / derivable-from |
+|-------|----------------|------------------------|-------------------|----------------------------------|
+| **`id`** | freeform slug; FLM synthetic `<tag>-FLM`; FLM colon `family:size` | registry TOML key; `models.py:215` synth; lemond `/v1/models` | everything | irreducible (primary key) — but **value space is forked** (see Q3) |
+| **`name`** | display string | `Model.name` (model.py:66); defaults to `id` | UI `longName` fallback | cosmetic; defaults to `id` |
+| **`type`** | `chat/embed/rerank/stt/tts/img` **(W7)** OR `llm/embedding/transcription/reranking/tts/image` **(dispatcher)** | `_classify_type` (W7 vocab, models.py:167,199); `_FLM_DISPATCH_TYPE` (dispatcher vocab, models.py:240) | UI `SlotCard` (slots.jsx:229,251), `modelSlotType` (slots.jsx:484), W7 widget | **fully derivable** from `capabilities` — and is, twice, with two vocabularies (see Q3) |
+| **`device`** | `gpu-rocm/gpu-vulkan/cpu/npu` | FLM row only (`device:"npu"`, models.py:243); slot TOML `device`; UI `derivedDevice` (slot-modals.jsx:74) | `SlotCard` chip (slots.jsx:319), `NpuFlmStack` filter (`s.device==="npu"`, slots.jsx:607), `backendToDevice` | **derivable from `backend`** (see Q2). Registry `Model` has NO `device`. |
+| **`backend`** (singular) | `flm/llamacpp/llama-server/vulkan/rocm/cpu/kokoro/moonshine/whispercpp/comfyui/vibevoice` | `CuratedModel.backend` (curated.py:127); FLM row (`backend:"flm"`, models.py:238); slot TOML `backend` | `isFlmModel` (slots.jsx:473), `_provider_for_backend`, `_backend_variants` | overlaps `backends[]`; the catalog reads BOTH singular `.backend` and plural `.backends` defensively |
+| **`backends`** (plural) | list of `vulkan/rocm/cuda/cpu/npu/moonshine/...` | `Model.backends` (model.py:112); `detect()` suggestions | `_backend_variants` (catalog.py:259), `server_models_gen._resolve_recipe`, UI `derivedDevice` | same concept as `backend`, list form. Curated uses singular, Registry uses plural |
+| **`runtime`** | `flm` (only value seen) | **`metadata.runtime` ONLY** (pull.py:706,719,724) — never a top-level field | UI `m?.runtime==="flm"` (slots.jsx:474) — **reads top-level → DEAD clause** | redundant with `backend=="flm"`. **Drop candidate** (see note) |
+| **`capability`** (singular) | `chat/embed/asr/tts/image/rerank` | `CuratedModel.capability` (curated.py:120); FLM row `capability` (models.py:241) | `_model_capabilities` (catalog.py:236), `modelSlotType` fallback (slots.jsx:486) | same concept as `capabilities`, scalar form |
+| **`capabilities`** (plural) | list of `chat/embed/rerank/vision/asr/stt/tts/image` | `Model.capabilities` (model.py:89); `detect()`; FLM `_classify_flm_model` (flm.py:413) | `_classify_type`, `_model_capabilities`, `normalizeApiModel`, `server_models_gen` | canonical; `capability` is a curated/FLM-row alias |
+| **`provider`** | `flm/llama-server/kokoro/moonshine/whispercpp/comfyui/lemonade` | `available_backends()` (catalog.py:147), `_provider_for_backend` (catalog.py:333); slot TOML `provider` | catalog picker row, slot config form | **derivable from `backend`** via `_BACKEND_TO_PROVIDER` (catalog.py:47) |
+| **`recipe`** | `llamacpp/whispercpp/kokoro/sd-cpp/flm/ryzenai-llm` | `server_models_gen._resolve_recipe` (gen.py:258) from `backends` | Lemonade loader only | **derivable from `backend`/`backends`** via `_BACKEND_TO_RECIPE` (gen.py:140). Lemonade-internal alias of `backend` |
+| **`owned_by`** | `local/<upstream-name>/flm` | `models.py:166,189,235` | OpenAI-compat clients (cosmetic) | redundant with `upstream`/`ns` (`local`⇔`installed`) |
+| **`upstream`** | upstream name; `npu` for FLM | `models.py:190,237` | `isFlmModel` (`upstream==="npu"`, slots.jsx:476) | for FLM, redundant with `backend=="flm"` |
+| **`ns`** | `blessed/pulled` | `_derive_ns` (model.py:165, path-shape rule, issue #220); hardcoded `pulled` for upstream/FLM rows | UI `OnDiskPanel` ns chip (model-modals.jsx:451) | derivable from `path` prefix; pure display bucket |
+| **`installed`** / **`downloaded`** | bool | `installed` set in `/api/models` (models.py:163,191,238); `downloaded` in catalog rows (`_is_downloaded`, catalog.py:445) | UI `model.installed` guard (model-modals.jsx:436), swap popover "will pull" | **two names for one concept** (path-exists check); catalog says `downloaded`, models-API says `installed`. FLM uses `installed` from probe (flm.py:567) |
+
+**Verdict:** Of ~14 descriptor fields, **only `id`, `name`, `capabilities`, `backends`, `path`, `size_bytes`, and pull coords (`hf_repo`/`hf_filename`) are load-bearing primitives.** `type`, `device`, `provider`, `recipe`, `runtime`, `owned_by`, `upstream`, `ns`, and the `installed`/`downloaded` duplication are all **derivable or duplicated** — they exist because each subsystem re-projects the model into its own vocabulary at its own boundary rather than deriving on read.
+
+---
+
+## 2. Is `device` fully derivable from `backend`?
+
+**Yes — `device` is a lossy *rename* of `backend`, not independent information.**
+
+### The mapping (`backendToDevice`, slot-modals.jsx:25-32)
+```
+rocm   → gpu-rocm
+vulkan → gpu-vulkan
+npu|flm → npu
+cpu    → cpu
+```
+This is the **only** place `device` is computed from a backend id, and it is a clean total function from the backend token to a device token. The inverse is the `EditSlotDrawer`'s `device.replace("gpu-","")` (slot-modals.jsx:419,579,627) which recovers the bare backend token from the device — i.e. the two are **trivially inter-convertible** modulo the `gpu-` prefix.
+
+### Is the map ever many-to-one or one-to-many?
+- **Many backends → one device:** `rocm`, `vulkan`, `cpu` are *both* backends *and* devices (with the `gpu-` cosmetic prefix). `npu` and `flm` **both** map to device `npu` (slot-modals.jsx:29) — so `device=npu` is ambiguous about whether the backend token was `npu` or `flm`. In practice they're synonyms (FLM is the only npu runtime), so no information is lost.
+- **One backend → many devices:** none. Each backend token maps to exactly one device.
+- **The catalog's `backends[]` element** (catalog.py:610) carries `{id, provider, downloaded, pullable}` — it already keys by `backend` id (`gpu-vulkan`/`gpu-rocm`/`cpu`/`npu`) and never emits a separate `device`. So the *capability* surface already treats backend==device.
+
+### What concretely breaks if `device` is dropped and everything filters by `backend`?
+Three call sites would need to change from `device` to a `backend`-derived value:
+1. **`NpuFlmStack` slot grouping** (slots.jsx:607,621,1117): `slots.filter(s => s.device === "npu")`. Would become `backend === "flm"` (or `backend === "npu"`). **No semantic change** — npu.toml already carries both `device="npu"` and `backend="flm"`.
+2. **`SlotCard`/`SlotListRow` device chip** (slots.jsx:319,407; slot-modals.jsx:1013): `"chip dev-" + (device||"cpu").replace("gpu-","")`. Cosmetic; would derive the chip label from `backend`.
+3. **`CreateSlotModal`/`EditSlotDrawer` device dropdown** (slot-modals.jsx:21,274,613): operator picks a "device". This is the one **real** UX coupling — but it already round-trips through `backendToDevice`/`.replace("gpu-","")`, so it can pick a `backend` directly and drop the rename.
+
+**Conclusion:** `device` carries **zero information not in `backend`**. Dropping it requires only renaming three UI read sites; the slot TOML can stop storing `device` once the UI keys on `backend`. The only subtlety: the `gpu-` prefix and the `npu`/`flm` synonym must be preserved as a display convention.
+
+---
+
+## 3. Vocabulary collisions (what a consolidation MUST preserve)
+
+### 3a. `type`: W7 vocab vs dispatcher vocab — TWO incompatible value spaces on one field name
+- **W7 vocab** `chat/embed/rerank/stt/tts/img` — produced by `_CAPABILITY_TO_TYPE` (models.py:81) + `_classify_type` (models.py:113). Consumed by the Models view / W7 endpoints widget counter.
+- **Dispatcher vocab** `llm/embedding/transcription/reranking/tts/image` — produced by `_FLM_DISPATCH_TYPE` (models.py:102) for FLM rows, and by `normalizeApiModel`'s `derivedType` (slot-modals.jsx:64) + `modelSlotType` (slots.jsx:484). Consumed by `SlotCard` metrics switch (slots.jsx:251-274: `type==="llm"|"embedding"|"reranking"|"transcription"|"tts"|"image"`), the slot create/edit type dropdown (slot-modals.jsx:257-264), and slot grouping.
+
+**The same JSON key `type` holds different vocabularies depending on which row produced it.** Registry rows get W7 `chat` (models.py:167); FLM rows get dispatcher `llm` (models.py:240). The **shared lib normalizer** `@/lib/normalizeApiModel` (`ui/src/lib/normalizeApiModel.ts`), applied to *every* row `useModels()` returns (useModels.ts:17,43), **unconditionally discards the server-set `type` and re-derives the dispatcher form from `capabilities`**: `normalizeApiModel` spreads `...m` then overwrites `type: deriveType(caps)` (normalizeApiModel.ts:88), where `deriveType` reads only `capabilities` and never consults `m.type`. So a registry row arrives with W7 `type="chat"` and is **re-derived to dispatcher `type="llm"` client-side, throwing the server value away** — the slots.jsx:478 comment states this verbatim ("derives `type` from the plural `capabilities` array and **discards any backend-set type**"). This *strengthens* the "type fully derivable from capabilities" verdict: the client literally ignores the server's `type`.
+
+There is also a *second, local* `normalizeApiModel` in slot-modals.jsx:53 that DOES trust `m.type` — but it runs on the already-lib-normalized rows (a double pass), so by the time it sees a row the dispatcher `type` is already set; its `derivedType` branch (slot-modals.jsx:64) only fires for rows that bypassed the lib normalizer. **A consolidation must keep the dispatcher vocab** (`llm/embedding/...`) because the SlotCard metrics rows, the create-slot dropdown, and capability slots all hard-code it. The W7 `chat/embed/...` vocab is only a counting bucket and can be derived on demand. FLM rows are the one wrinkle: their `capabilities` is empty (singular `capability` only), so `deriveType([])`→`""` and `modelSlotType` (slots.jsx:484) rescues the type from the singular field.
+
+### 3b. `capability` vs `capabilities` — singular scalar vs plural list
+- `CuratedModel.capability` (curated.py:120, scalar) and FLM row `capability` (models.py:241, scalar).
+- `Model.capabilities` (model.py:89, list) everywhere else.
+- `_model_capabilities` (catalog.py:220) reads BOTH and unions them; `modelSlotType` (slots.jsx:484) falls back from plural-derived `type` to singular `capability` because **FLM seed rows carry singular `capability` and an empty `capabilities`** would leave `type=""`. **Must preserve:** the catalog's union-both behaviour, or migrate curated/FLM rows to the plural list.
+
+### 3c. `backend` vs `backends` vs `runtime` vs `recipe` — four names for "what runs it"
+- `backend` (singular): curated + FLM row + slot TOML.
+- `backends` (plural): registry Model + detect.
+- `runtime`: only `metadata.runtime="flm"` (pull.py) — a third synonym, **dead in the UI** (reads top-level which is never set).
+- `recipe`: Lemonade's name for the same thing (`_BACKEND_TO_RECIPE`, gen.py:140 — `vulkan/rocm/cuda/cpu`→`llamacpp`).
+- `provider`: a fifth, derived view (`_BACKEND_TO_PROVIDER`, catalog.py:47).
+
+**Must preserve:** the `backends→recipe` collapse (vulkan/rocm/cuda/cpu all → `llamacpp`) for Lemonade, and the `backend→provider` map for the slot form. These are pure functions of `backend` and can stay as derivation tables; the **stored** field should be one (`backends`).
+
+### 3d. FLM id: colon tag `gemma4-it:e4b` vs `-FLM` id `gemma4-it-e4b-FLM`
+- **Colon form** `family:size` (e.g. `qwen3-it:4b`, `gemma4-it:e4b`): what `flm pull`/`flm serve` consume; what `flm list -j` reports as `model`; what `is_flm_tag` (flm.py:590) matches (`":" in id`); what `flm_served_models()[].tag` carries.
+- **`-FLM` form** `<tag-with-colon→dash>-FLM` (e.g. `qwen3-it-4b-FLM`): built **one-way** at `models.py:215` (`fm["tag"].replace(":","-") + "-FLM"`); is **lemond's** `/v1/models` id (verified: 11 `-FLM` ids served, incl. `qwen3-it-4b-FLM`); is what **npu.toml `[model].default`** stores (`= "qwen3-it-4b-FLM"`).
+
+**There is NO reverse map `-FLM → colon` anywhere in hal0 source** (grep confirmed: `manager.py:1974` sets `flm_tag = model_id` *verbatim*). The two forms live in disjoint worlds: the colon form is the FLM-native/pull/catalog world; the `-FLM` form is the lemond-served/slot-default world. **Must preserve:** the `:`→`-`…`-FLM` transform (lossy: `qwen3-it:4b` and `qwen3-it-4b` would both → `qwen3-it-4b-FLM`) **and** the fact that lemond — not hal0 — owns the reverse resolution. A consolidation that "unifies" the id MUST keep the colon tag for the FLM probe/pull path and the `-FLM` id for the lemond serve/slot-default path, or move the reverse-map into hal0.
+
+---
+
+## 4. Why zero FLM models in the registry yet FLM models serve — the registry-bypass path
+
+**Registry FLM count: 0.** `grep flm /var/lib/hal0/registry/registry.toml` → no `runtime=flm`, no `backends=["npu"]` entry. The 67 registry entries are all GGUF/local. Yet lemond's `/v1/models` serves 11 `-FLM` models including `qwen3-it-4b-FLM`, and npu.toml binds to it.
+
+The bypass is **lemond's own built-in FLM recipe**, entirely independent of hal0's registry:
+
+1. **npu.toml** (`/etc/hal0/slots/npu.toml`) declares `provider = "lemonade"`, `backend = "flm"`, `device = "npu"`, `[model].default = "qwen3-it-4b-FLM"`. The slot is **lemond-mediated**, not native-FLM.
+2. The slot manager's `_resolve_model_info` (manager.py:1958) looks up `qwen3-it-4b-FLM` in the registry, gets `ModelNotFound`, logs `slot.model_not_in_registry`, and **proceeds anyway** (manager.py:1985: "not fatal — the toolbox will surface its own load error"). `flm_tag`/`_model_key` are stamped verbatim.
+3. hal0 calls lemond's `/v1/load` with model id `qwen3-it-4b-FLM`.
+4. **lemond resolves it.** lemond exposes 11 `<tag>-FLM` ids at `/v1/models` (verified live, incl. `qwen3-it-4b-FLM`) and maps `qwen3-it-4b-FLM` → the colon tag → `flm serve`, governed by lemond's `flm` recipe + `[flm].args` (`config.json`: `"flm": {"args": "--asr 0 --embed 0"}`). **Inference (exact discovery path not traced):** since these ids appear in neither hal0's registry nor hal0's generated `server_models.json`, they must originate in lemond's *own* bundled FLM catalog (FLM's `share/flm/model_list.json`, the same file `flm list -j` reads) rather than from anything hal0 emits. The keystone conclusion — hal0 does not register or generate these ids — is proven regardless of lemond's internal enumeration mechanism.
+5. hal0's `server_models_gen.py` **emits no `-FLM` ids** (it reads registry.toml, which has zero FLM rows → the `flm` recipe branch at gen.py:268 never fires). Confirmed: deployed `/opt/lemonade/resources/server_models.json` contains **zero** `-FLM` ids and zero `recipe=flm` entries. So the `-FLM` ids come from **lemond's bundled FLM catalog, not hal0's generator.**
+
+**Net:** FLM serving is a **lemond-internal capability** that hal0 *references by id* but does not *register*. hal0's registry is the source of truth for GGUF/local models only; FLM models are owned by lemond's `model_list.json`. The `/api/models` FLM-synthesized block (models.py:209-249) re-discovers them via the host `flm list -j` probe purely so the NPU slot picker has selectable rows — it does **not** write them to the registry. `_register_flm_pulled` (pull.py:688) *would* register an FLM tag (colon form, `backends=["npu"]`, `metadata.runtime="flm"`) but only fires after an explicit `flm pull` through hal0 — which hasn't happened on this host, hence zero rows.
+
+### Dormant vs live (advisor flag — keep these separate in any consolidation)
+- **LIVE path:** npu.toml `provider="lemonade"` → lemond `/v1/load` → lemond FLM recipe → `flm serve`. Uses `-FLM` ids.
+- **DORMANT path:** `FLMProvider` class (flm.py:128 — `container_spec`/`build_env`/native host probe) is a *separate* native-FLM launcher the deployed runtime does **not** use. It expects the **colon** tag (`build_env` flm.py:154 defaults `qwen3:0.6b`). Feeding it `qwen3-it-4b-FLM` verbatim (as manager.py:1974 does) would break (`flm serve qwen3-it-4b-FLM` is not a valid tag). **The `-FLM` convention is lemond-only.** A consolidation must not delete the colon/`-FLM` distinction on the assumption "FLMProvider handles it" — FLMProvider is not in the live path.
+
+---
+
+## 5. Recommended minimal consolidated model shape + migration sketch
+
+### Minimal shape (8 stored fields; everything else derived on read)
+```
+Model {
+  id:           str          # primary key. For FLM: store the COLON tag (qwen3-it:4b);
+                             #   derive the -FLM lemond id on serialization.
+  name:         str          # display; defaults to id
+  path:         str          # "" for lemond-owned/FLM models (no local bytes)
+  size_bytes:   int
+  capabilities: list[str]    # SINGLE source of truth. Vocab: chat/embed/rerank/vision/stt/tts/image
+  backends:     list[str]    # SINGLE source of truth. Tokens: rocm/vulkan/cpu/cuda/npu/flm/kokoro/...
+  hf_repo:      str          # pull coords (empty for FLM/local-only)
+  hf_filename:  str
+}
+```
+**Dropped as stored fields (all become pure read-time derivations):**
+- `type` → `derive_type(capabilities, vocab)` — one function, two vocabularies selectable by caller (W7 vs dispatcher).
+- `device` → `backend_to_device(backends[0])`.
+- `provider` → `backend_to_provider(backend)`.
+- `recipe` → `backend_to_recipe(backends)` (Lemonade boundary only).
+- `runtime` → gone (was `metadata.runtime`, dead in UI; `backend=="flm"` replaces it).
+- `owned_by` / `upstream` → derive from `path==""` + an `origin` enum if needed; `owned_by="local"`⇔installed.
+- `ns` → `derive_ns(path)` (already a function, model.py:165).
+- `capability` (singular) → fold into `capabilities`.
+- `backend` (singular) → fold into `backends`.
+- `installed`/`downloaded` → ONE name (`installed = path != "" and exists(path)`); FLM uses probe `installed`.
+
+### Per-consumer migration
+
+| Consumer | Today | After |
+|----------|-------|-------|
+| `routes/models.py` `list_models` | emits 3 shapes; hardcodes `type`/`device`/`owned_by`/`ns` per branch | emit one shape; attach `type`(dispatcher vocab) + `installed` via shared derivation; drop per-branch field-stamping |
+| `_classify_type` / `_FLM_DISPATCH_TYPE` | two type maps, two vocabularies | one `derive_type(caps, vocab="dispatcher")`; W7 counter calls `vocab="w7"` |
+| `CuratedModel` | singular `capability`/`backend`/`hf_file` | migrate to `capabilities`/`backends`/`hf_filename` (or keep an adapter — `_curated_to_registry_entry` gen.py:414 already bridges) |
+| `capabilities/catalog.py` | reads `.backend` AND `.backends`, `.capability` AND `.capabilities` | read only the plural forms; delete the dual-read defensive code (`_backend_variants`, `_model_capabilities`) |
+| `server_models_gen.py` | `_resolve_recipe(backends)` | unchanged (recipe stays a derivation at the Lemonade boundary) |
+| `slots.jsx` | `isFlmModel` checks `backends`/`backend`/`runtime`/`upstream`; `modelSlotType` falls back to singular `capability`; `s.device==="npu"` | `isFlmModel`= `backends.includes("flm")`; `modelSlotType`= derive from `capabilities`; group by `backends.includes("flm")` — drop the `runtime`/`upstream`/singular-`capability` fallbacks |
+| `@/lib/normalizeApiModel` | `deriveType(caps)` discards server `type`, re-derives dispatcher form (normalizeApiModel.ts:88) | once the server emits dispatcher `type` directly, the discard becomes redundant — `deriveType` can be deleted (or kept as a fallback for `capabilities`-only rows); the FLM empty-`capabilities` case must still be handled (singular `capability`) |
+| `slot-modals.jsx` (local `normalizeApiModel`, line 53) | second-pass normalizer that trusts `m.type`; `backendToDevice` | keep `backendToDevice` as device-display helper; this local normalizer becomes a no-op once the lib normalizer + server agree on dispatcher `type` — collapse the two passes into one |
+| `useModels.ts` `Model` iface | declares `type`/`device`/`runtime`/`ns`/`installed` | drop `runtime` (dead clause); `device` optional (display-only, derived from `backends`); keep `type`(dispatcher)/`installed`/`ns` as derived-but-present |
+| npu.toml `[model].default` | `qwen3-it-4b-FLM` (lemond id) | **keep** (lemond owns reverse resolution) OR store colon tag + add a hal0 `-FLM`↔colon map if the native FLMProvider path is ever activated |
+
+### Load-bearing invariants the migration MUST NOT break
+1. **Dispatcher `type` vocab** (`llm/embedding/transcription/reranking/tts/image`) — hard-coded in SlotCard metrics, create-slot dropdown, capability slots.
+2. **`backends→recipe` collapse** (vulkan/rocm/cuda/cpu → llamacpp) at the Lemonade boundary.
+3. **FLM colon-tag for pull/probe** + **`-FLM` id for lemond serve/slot-default**, with lemond owning the reverse map (native FLMProvider is dormant and expects colon).
+4. **`path`-shape `ns` rule** (issue #220) — keep `derive_ns` as the single derivation.
+5. **`installed`/`downloaded` semantics** = "weights exist on disk" (FLM = probe `installed`); pick one name.

--- a/docs/internal/brain-redesign/shape-consolidation-proposal-2026-06-07.md
+++ b/docs/internal/brain-redesign/shape-consolidation-proposal-2026-06-07.md
@@ -1,0 +1,134 @@
+# Shape Consolidation Proposal — models & slots (2026-06-07)
+
+Synthesis of two audits (read those for the file:line evidence):
+- `model-shapes-audit-2026-06-07.md`
+- `slot-shapes-audit-2026-06-07.md`
+
+**Problem (operator's words: "it's a mess"):** a *model* and a *slot* each get re-projected into a
+different vocabulary at every subsystem boundary. A model appears in **6+ distinct row shapes**;
+`/api/models` alone emits **three** shapes in one array, then the UI throws the server's `type` away
+and re-derives it. ~14 model descriptor fields and ~10 slot fields exist where a handful of primitives
++ read-time derivations would do.
+
+---
+
+## 1. The core asymmetry (operator's framing — correct)
+
+| | carries | meaning | cardinality |
+|---|---|---|---|
+| **Model** | **`backends`** (plural) | *capability* — what it **can** run on | some 1 (`["rocm"]`), some many (`["rocm","vulkan","cpu"]`) |
+| **Slot** | **`device`** (singular) | *target* — what it **will** run on now | exactly 1; swappable, not an identity |
+
+**Assignment rule (the thing the whole mess is really about):**
+```
+assignable(model, slot)  ⇔  model.type == slot.type
+                         AND  device_to_backend(slot.device) ∈ model.backends
+                         AND  resolvable(model.id)        # registry OR provider-known
+```
+
+### ROCmMTP / rocm-vs-vulkan — handled, no new field
+`device` stays **fine-grained**: `gpu-rocm`, `gpu-vulkan`, `npu`, `cpu` are *distinct* devices (never a
+single "gpu"). A ROCmMTP model is `backends=["rocm"]` → matches a `gpu-rocm` slot, rejected by a
+`gpu-vulkan` slot. A multi-backend GGUF is `backends=["rocm","vulkan","cpu"]` → matches any of the three.
+The distinction lives **on the model's `backends`**, matched against the slot's fine-grained `device`.
+Nothing is lost; slots do **not** need a plural backends field.
+
+---
+
+## 2. device vs backend — reconciled (both audits agree on the facts)
+
+`device ↔ backend` is a **bijection modulo the `gpu-` prefix and the `npu`/`flm` synonym**
+(`backendToDevice`, slot-modals.jsx:25): `rocm↔gpu-rocm`, `vulkan↔gpu-vulkan`, `npu|flm↔npu`, `cpu↔cpu`.
+So one of the pair is pure redundancy. **Which to keep differs by entity, and the codebase already chose:**
+
+- **Slots keep `device`** — ADR-0006 §7 is already migrating `backend`→`device`; `backend` is deprecated
+  (removed v0.3, schema.py:40). `backend` is the *worse* slot primitive: it's many-to-one and smuggles the
+  `flm` **provider** into a hardware field. → **drop slot `backend` + `provider` + `declared_backend`**
+  (all = `device_to_backend(device)`).
+- **Models keep `backends`** (plural) — the capability surface above. → **drop model singular `backend`,
+  drop model `device`** (derive `device = backend_to_device(backends[0])` on read).
+
+> The operator's original "drop device, keep backend" had the *arrow* reversed but the *instinct* right:
+> kill one of the pair. Keep `device` on slots, `backends` on models.
+
+### "Declared vs actual backend" in slot-edit
+- `declared_backend` = `device_to_backend(device)` → **redundant, drop from the wire** (UI never recomputes).
+- `actual_backend` = resolved from the live child's `/proc/<pid>/exe` build-dir (lemonade.py:147) →
+  **NOT redundant.** Diverges when a model loads outside the slot path and lemond's global default wins.
+  Keep it as **runtime-observed** state. Minimal runtime backend set = `{device (intent), actual_backend (observed)}`.
+
+---
+
+## 3. Vocabulary collisions a consolidation MUST preserve (don't naively merge)
+
+1. **`type` has two value-spaces on one key:** W7 (`chat/embed/stt/img`) vs dispatcher
+   (`llm/embedding/transcription`). The UI lib normalizer **already discards the server `type` and
+   re-derives the dispatcher form from `capabilities`** (normalizeApiModel.ts:88). → Server should emit
+   **dispatcher** `type` (hard-coded in SlotCard/create-slot/capability slots); W7 is just a counting
+   bucket, derive on demand. `type` becomes a derivation of `capabilities`, not a stored field.
+2. **FLM id fork:** colon `gemma4-it:e4b` (pull/probe/native FLM) vs `-FLM` `gemma4-it-e4b-FLM`
+   (lemond-served / slot-default). Built **one-way** (models.py:215); **lemond owns the reverse map**, hal0
+   has none. Keep both forms; the native `FLMProvider` path is **dormant** and expects the colon tag — do
+   not "unify" on the assumption it handles `-FLM`.
+3. **`capability` (sing) vs `capabilities` (plur)**, **`backend`/`backends`/`runtime`/`recipe`/`provider`**
+   (five names for "what runs it"). Fold singular→plural; keep `recipe` (`backends→llamacpp`) and
+   `provider` (`backend→provider`) as **derivation tables at their boundaries**, not stored fields.
+   `runtime` is **dead** (written only to `metadata.runtime`; UI reads top-level `m.runtime` which is never
+   set — slots.jsx:474). Drop it.
+
+---
+
+## 4. The registry-gate bug (root cause of the "not in the registry" apply error)
+
+Both audits independently flag it. The slot-apply check (`slots.py:1413/1462`, `registry.has(model_id)`)
+is **too strict and route-level**: enforced on `/swap` and `/load`-with-body, but *bypassed* by
+empty-body `/load`, `PUT /config`, `PATCH /defaults` — which is exactly how gemma4 is live now (via
+`npu.toml [model].default`, lemond-mediated, registry-blind; manager.py:1985 logs `model_not_in_registry`
+and proceeds). FLM models structurally are **never** in hal0's registry — lemond owns them.
+
+**Fix (the clean version of the patch I held):** replace `registry.has(id)` with
+`resolvable(id) = registry.has(id) OR is_installed_flm(id) OR lemond_serves(id)`. Validation should gate on
+**provider-resolvability**, not registry membership. This makes the dashboard "apply" button work for FLM
+models without registering them or reconciling shapes.
+
+---
+
+## 5. Recommended minimal shapes
+
+**Model — 8 stored fields, everything else derived on read:**
+```
+Model { id, name, path, size_bytes, capabilities[], backends[], hf_repo, hf_filename }
+```
+Derived: `type` (←capabilities, vocab-selectable), `device` (←backends[0]), `provider`/`recipe` (←backend,
+at their boundaries), `ns` (←path, #220), `installed` (←path exists / FLM probe). Drop: singular
+`capability`/`backend`, `runtime`, `owned_by`/`upstream` (→ `origin` enum if needed), the
+`installed`/`downloaded` duplication (pick `installed`).
+
+**Slot — config + runtime split:**
+```
+SlotConfig  { name, type, device, enabled, port, idle_timeout_s, [model].default, [server].extra_args }
+SlotRuntime { state, model_id, actual_backend }   # observed, not stored
+```
+Drop: `backend`, `provider`, `declared_backend`, duplicate `port`, `model_default` mirror, mostly-unused
+`role`. Trio modality on/off stays **lemond-global `flm.args`** (`--asr/--embed`), not a slot field.
+
+**Dead code to delete:** `_FLM_TRIO_SLOTS={"agent","stt-npu","embed-npu"}` (slots.py:106 — wrong names vs
+real `npu`/`stt`/`embed`; UI works only via `device==="npu"`); the top-level `runtime` read (slots.jsx:474);
+the dual singular/plural reads in `catalog.py` once curated/FLM rows move to plurals.
+
+---
+
+## 6. Suggested phasing (smallest blast radius first)
+
+- **P0 — registry-gate fix** (§4). Unblocks the dashboard apply button for FLM. ~1 route change + the
+  `resolvable()` helper + a test. Independent of everything else. *(This is the held `slots.py:1413` fix,
+  done right.)*
+- **P1 — collapse `/api/models` to one row shape**, emitting dispatcher `type` + `installed` via shared
+  derivation; delete the per-branch field-stamping (incl. the FLM block I added — it becomes a normal row).
+- **P2 — drop the redundant projections**: slot `backend`/`provider`/`declared_backend` (derive from
+  `device`); model singular `backend`/`capability`, `runtime`. Update the ~3 UI read sites + delete dead code.
+- **P3 — vocab unification**: one `derive_type(caps, vocab)`; fold curated singular fields to plurals;
+  document the colon/`-FLM` split + lemond-owns-reverse-map as the one intentional fork.
+
+Each phase is independently shippable and testable; none requires the model/slot store schema to change at
+once. P0 is the only one with user-visible payoff today.

--- a/docs/internal/brain-redesign/slot-shapes-audit-2026-06-07.md
+++ b/docs/internal/brain-redesign/slot-shapes-audit-2026-06-07.md
@@ -1,0 +1,380 @@
+# SLOT shape audit — descriptor-field proliferation & consolidation
+
+Date: 2026-06-07
+Author: audit agent (read-only)
+Code read at: `/tmp/hal0-partA` (branch `fix/flm-host-probe`)
+Runtime inspected: CT 105 (`ssh hal0`), `/etc/hal0/slots/*.toml`, live `GET /api/slots`,
+`/var/lib/hal0/lemonade/config.json`.
+
+> **Headline verdict.** The slot shape is genuinely redundant, and the operator's
+> *instinct* (too many overlapping fields) is right — but the operator's stated
+> *hypothesis* ("drop `device`, keep `backend`") points the **wrong way**. The
+> codebase is mid-migration in the **opposite** direction: `device` is the v0.2
+> canonical field, `backend` is **DEPRECATED, removed in v0.3** (ADR-0006 §7).
+> Keep `device`, drop the stored `backend`. See Q2.
+
+---
+
+## 0. Raw evidence
+
+### 0.1 Deployed slot TOMLs — `ssh hal0 cat /etc/hal0/slots/*.toml`
+
+Field usage per slot (✓ = key present on disk). `D=device, B=backend, P=provider,
+R=role, E=enabled`:
+
+| slot           | type          | D (device) | B (backend) | P (provider) | R (role) | enabled | port | model.default                  | idle | other                                   |
+|----------------|---------------|------------|-------------|--------------|----------|---------|------|--------------------------------|------|-----------------------------------------|
+| npu            | llm           | npu        | flm         | lemonade     | npu      | ✓(enabled=true) | 8088 | qwen3-it-4b-FLM                | 1800 | ctx 65536                               |
+| primary        | llm           | gpu-rocm   | rocm        | lemonade     | —        | ✓ true  | 8001 | chadrock-35b-ace-saber         | 900  | enable_thinking=false, llamacpp_args    |
+| agent-hermes   | llm           | gpu-rocm   | — (none)    | — (none)     | —        | (default=false) | 8001 | qwopus3.6-27b-v2               | 900  | group="chat", llamacpp_args             |
+| gpu-rocmfp4    | llm           | gpu-rocm   | rocm        | llama-server | —        | (default=false) | 8010 | qwopus3.6-27b-v2               | 900  | enable_thinking=true, [server].extra_args |
+| gpu-rocmfp4-moe| llm           | gpu-rocm   | rocm        | llama-server | —        | —        | 8011 | chadrock3.6-35b-uncensored     | —    | enable_thinking=true, [server].extra_args |
+| embed          | embedding     | npu        | flm         | — (none)     | —        | false   | 8082 | embed-gemma:300m               | 900  | llamacpp_args                           |
+| rerank         | reranking     | gpu-vulkan | vulkan      | — (none)     | —        | true    | 8083 | jina-reranker-v1-tiny-en-GGUF  | —    | —                                       |
+| stt            | transcription | npu        | flm         | — (none)     | —        | false   | 8085 | whisper-v3:turbo               | —    | —                                       |
+| tts            | tts           | cpu        | cpu         | — (none)     | —        | false   | 8084 | kokoro-v1                      | —    | —                                       |
+| utility        | llm           | gpu-vulkan | vulkan      | llama-server | —        | (default true) | 8081 | qwen3-zero-coder-v2-0.8b-f16   | —    | ctx 65536                               |
+
+Observations from disk:
+- Every slot redundantly carries **both** `device` AND `backend`, and they are
+  always the device↔backend mirror image (`gpu-rocm`/`rocm`, `npu`/`flm`,
+  `gpu-vulkan`/`vulkan`, `cpu`/`cpu`). Never independent. (`agent-hermes` omits
+  `backend` entirely and works fine — proving `backend` is droppable.)
+- `port` can be authored at **both** top level and under `[server]` — the loader
+  reads both (slots.py:509-514). In deployment only **npu** actually double-authors it
+  (8088 at `[slot]` AND `[server]`); `primary`'s `[server]` carries only `extra_args`
+  and `agent-hermes` has no `[server]` table — but the schema permitting two homes is the
+  redundancy.
+- `provider` is set on only 5 of 10 slots and is **ignored by SlotManager**
+  (schema.py:232-239: "SlotManager ignores them").
+- `role` is set on exactly **one** slot (npu); everywhere else it is derived from
+  the slot name (schema.py:245-252).
+
+### 0.2 Live `/api/slots` payload (CT 105)
+
+Per-slot top-level keys actually emitted:
+`name, state, port, model_id, backend, metadata{updated_at,message,adopted,backend,provider},
+last_used_at, kind, status, provider, models, type, model_default, enabled,
+enable_thinking, n_gpu_layers, rope_freq_base, idle_timeout_s, workers, llamacpp_args,
+lemonade_state, mem_mb, metrics{...}`. NPU slot additionally carries
+`backend_url, declared_backend`. (When a `loaded` slot's actual backend can be
+introspected: `actual_backend, backend_mismatch`.)
+
+Live FLM args: `/var/lib/hal0/lemonade/config.json` → `"flm": {"args": "--asr 0 --embed 0"}`
+— i.e. **the trio is currently chat-only** (stt + embed runtime-off). And `stt`/`embed`
+slot TOMLs both have `enabled=false` (hal0-side off as well).
+
+The payload also appends a **synthetic** `hal0` composite slot
+(`kind:"slot", _synthetic:true, advertised_models:5`) — not a real slot, the
+aggregate upstream (see Q6/§7).
+
+---
+
+## 1. Q1 — Field table: value · who SETS · who READS · redundancy
+
+`SlotConfig` source of truth is `src/hal0/config/schema.py:195-428`. The payload is
+assembled in `src/hal0/api/routes/slots.py` (`_slot_to_dict` :72; enrichment
+`_lemonade_state_enrichment` :123).
+
+| field | allowed values | SET (source of truth) | READ (consumers) | redundant-with / derivable-from |
+|-------|----------------|------------------------|-------------------|----------------------------------|
+| `name` | `^[a-z0-9][a-z0-9_-]{0,31}$` | TOML `[slot] name` (schema.py:207, validator :390) | everything; key in `out{}` (slots.py:307); role-derivation; UI cards | **canonical** — not redundant |
+| `type` | `llm`/`embedding`/`reranking`/`transcription`/`tts`/`image` | TOML `[slot] type` (NB: **not a typed SlotConfig field** — rides `extra="allow"`); UI create modal (slot-modals.jsx:257) | trio gating (`v1._is_npu_trio_request`); enrichment npu-llm detection (slots.py:180); UI trio split (slots.jsx:621-623); model-compat filter (slot-modals.jsx:165) | **canonical** — the real modality discriminator |
+| `device` | `gpu-rocm`/`gpu-vulkan`/`cpu`/`npu` (schema.py:51) | TOML `[slot] device` (schema.py:223); UI device select (slot-modals.jsx:274) | `device_to_backend()` (lemonade.py:89) → recipe+llamacpp_backend on `/v1/load`; `_cfg_effective_backend` (manager.py:2178); enrichment npu detect (slots.py:179); UI `NpuFlmStack` keys off `device==="npu"` (slots.jsx:607) | **CANONICAL hardware field** (v0.2) |
+| `backend` | `vulkan`/`rocm`/`flm`/`moonshine`/`kokoro`/`cpu` (schema.py:45) | TOML `[slot] backend` (schema.py:214) — **DEPRECATED** | validator only; `_promote_backend_to_device` reads it ONLY when `device` absent (schema.py:324-363); else dead on disk | **100% redundant with `device`**; removed v0.3 |
+| `provider` | `lemonade`/`llama-server`/`flm`/`moonshine`/`kokoro` (schema.py:89) | TOML `[slot] provider` (schema.py:232) — **DEPRECATED** | round-trip + UI label only; **SlotManager ignores it** (schema.py:237); payload lifts `metadata.provider` (slots.py:94) | redundant; lifecycle uses Lemonade unconditionally (ADR-0008) |
+| `role` | freeform str / None | TOML `[slot] role` (schema.py:245); set on `npu` only | normalization-chain binding hint; "when unset, derived from name" | **derivable from `name`** in 9/10 cases |
+| `enabled` | bool (default true) | TOML `[slot] enabled` (schema.py:241) | startup gating; `lemonade_state="disabled"` (slots.py:263); trio membership (slots.py:304); UI fade | **canonical** (operator on/off) |
+| `group` | freeform str (e.g. `chat`) | TOML `[slot] group` (`extra="allow"`; set on agent-hermes) | capability bucketing; UI grouping | overlaps `type`+capability catalog; weak |
+| `model.default` | registry id OR un-registered FLM tag | TOML `[model] default` (schema.py:147) | `LemonadeProvider.load` → `/v1/load` model_name (lemonade.py:608); payload `model_default` (slots.py:213); composite upstream (api/__init__.py:179) | **canonical config** (the assigned model) |
+| `model_id` | str/None | **runtime** `SlotStateSnapshot.model_id` (state.py:231) — last dispatched/loaded id | payload top-level `model_id` (slots.py via `_serialize_slot`); UI `slot.model_id` | **observed**, distinct from `model.default` (config). Both exist on purpose. Live proof of divergence: `embed` slot `model_id="builtin.nomic-embed-text-v1.5-q8"` vs `model_default="embed-gemma:300m"`; `stt` slot `model_id="whisper-tiny"` vs `model_default="whisper-v3:turbo"` |
+| `recipe` | `flm` / None (derived) | **NOT a stored slot field** | `device_to_backend(device)` (lemonade.py:89) returns `(recipe, backend)`; `npu→("flm",None)`, others→`(None,backend)`; sent on lemond `/v1/load` | **derived from `device`** |
+| `model_default` | = `model.default` | payload-only mirror (slots.py:213) | UI persona dropdown, pickers | duplicate of `model.default` for wire convenience |
+| `lemonade_state` | `disabled`/`idle`/`loaded` | enrichment computed (slots.py:262-298) from lemond `/v1/health.loaded[]` + `enabled` | UI chip (slots.jsx:64); NOT persisted | **derived** (enabled + health) |
+| `state` | SlotState enum (`offline`/`ready`/`serving`/`idle`/`error`/…) | runtime `SlotStateSnapshot.state` (state.py); SlotManager state machine | payload `state`/`status`; UI dot | **derived/runtime** (≠ lemonade_state; one is hal0 SM, other is lemond) |
+| `port` | 8081-8099 (schema.py:208) | TOML `[slot] port` and/or `[server] port` | child bind; backend_url; payload | authored in TWO places (redundant) |
+| `idle_timeout_s` | ≥0 (default 300) | TOML `[slot] idle_timeout_s` (schema.py:277) | SlotManager eviction; payload | canonical knob |
+| `backend` (payload top-level) | `rocm`/`vulkan`/`cpu`/`flm` | `_cfg_effective_backend(cfg)` = `device_to_backend(device)` (manager.py:2178, mirrored into `metadata.backend`); lifted by slots.py:92 | UI chip | **derived from `device`** — NOT the legacy TOML `backend`. Doc at manager.py:2186: legacy `backend` field "drifts the moment a user flips backend (which only rewrites `device`)" |
+| `declared_backend` | `rocm`/`vulkan`/`cpu`/`flm` | `device_to_backend(device)` (slots.py:284) | UI drift chip | **fully redundant with `device`** (see §3) |
+| `actual_backend` | `rocm`/`vulkan`/`cpu` | `resolve_actual_backend` via `/proc` binary path (lemonade.py:147-175,278) | UI drift chip; `backend_mismatch` | **NOT redundant** — observed runtime fact |
+| `enable_thinking` | true/false/None | TOML `[slot] enable_thinking` (schema.py:253) | normalize/thinking.py; payload | canonical per-slot default |
+| `n_gpu_layers`,`rope_freq_base`,`workers`,`llamacpp_args`,`context_size` | — | `[model]`/`[server]`/`[slot]` | launcher arg-build; UI edit drawer seeding | canonical tuning knobs |
+| `flm_args` (`--asr`/`--embed`) | `"--asr <0|1> --embed <0|1>"` | **NOT a slot field** — lives in lemond config `flm.args` (client.py:95-114) | trio modality gating (orchestrator.py:88); UI toggles (slots.jsx:449) | trio-global, not per-slot (see Q3) |
+
+---
+
+## 2. Q2 — device · backend · type · role · provider — relationships; can `device` be dropped for `backend`?
+
+**They are NOT five independent axes. There are two real axes plus three
+redundant/legacy fields.**
+
+- **`type`** — the modality discriminator (chat/embed/voice/img). Orthogonal to
+  hardware. **Independent, keep.**
+- **`device`** — hardware intent (`gpu-rocm|gpu-vulkan|cpu|npu`). **Independent, keep.**
+  This is v0.2 canonical (schema.py:47-52, ADR-0006 §7).
+- **`backend`** — DEPRECATED legacy enum. `device_to_backend()` (lemonade.py:89)
+  is a clean **bijection** over the 4 live hardware classes:
+  `gpu-rocm↔rocm, gpu-vulkan↔vulkan, cpu↔cpu, npu↔flm`. So `backend` carries
+  **zero** information not in `device`. Removed v0.3.
+- **`provider`** — DEPRECATED. Lemonade is the sole lifecycle driver
+  (ADR-0008 §2); SlotManager **ignores** the field (schema.py:237). Derivable/constant.
+- **`role`** — optional hint; "derived from name when unset" (schema.py:249).
+  Set on 1/10 slots. Derivable from `name`.
+
+### Can `device` be dropped in favour of `backend`? — **NO. The operator has the arrow reversed.**
+
+The migration is explicitly **the other direction** (`backend` → `device`):
+- `_VALID_BACKENDS` comment: "DEPRECATED v0.2: `SlotConfig.backend` is being retired
+  in favour of … `SlotConfig.device`" (schema.py:40-44).
+- `backend` field doc: "DEPRECATED (v0.2; removed v0.3) … Use `device` instead"
+  (schema.py:217).
+- `device` field doc: "Replaces the legacy `backend` field which mixed providers and
+  backends" (schema.py:227).
+
+And `backend` is the **strictly worse** primitive:
+1. It is **many-to-one / overloaded**: `BACKEND_TO_DEVICE` (schema.py:67-81) collapses
+   `moonshine`/`kokoro`/`cpu` → all `cpu`. It mixed *hardware* with *provider identity* —
+   the exact confusion v0.2 split apart.
+2. `npu`'s backend token is **`flm`** — a *recipe/provider*, not hardware. `device=npu`
+   is clean hardware; `backend=flm` smuggles a runtime in.
+3. The legacy TOML `backend` field **drifts and is never resynced**: flipping the
+   backend in the UI rewrites only `device` (manager.py:2186 comment), so on-disk
+   `backend` goes stale immediately. Even the runtime payload's `backend` is computed
+   from `device` (`_cfg_effective_backend`), not read from the stale TOML field.
+
+**Verdict: keep `device`, delete the stored `backend` (and `provider`). The operator's
+redundancy instinct is correct but the field to drop is `backend`, not `device`.**
+
+---
+
+## 3. Declared vs Actual backend (added scope) — is the duplication necessary?
+
+Two values, two different epistemics:
+
+| value | source | code | meaning |
+|-------|--------|------|---------|
+| `declared_backend` | `device_to_backend(cfg.device)` | slots.py:284-287; status() lemonade.py:719-724 | the slot's **intent**, a pure function of `device` |
+| `actual_backend` | resolve via `loaded[].backend_url` → port → PID → `/proc/<pid>/exe` path → classify (`/vulkan/`→vulkan, `/rocm-stable/` or `/rocmfp4-llama/`→rocm, else cpu) | lemonade.py:147-175, 278; `resolve_actual_backend` | the **observed** build dir of the live llama-server child |
+| `backend_mismatch` | `actual != declared` (only when both known) | slots.py:288-292 | drift flag for UI chip (slots.jsx:324-330) |
+
+**Why they can disagree:** when a model is loaded **outside** the normal slot path
+(e.g. name-based lazy-load with no explicit `llamacpp_backend` in the `/v1/load` body),
+lemond's **global `config.json` default backend wins** instead of the slot's device-derived
+backend (lemonade.py:127-133). The slot says `gpu-rocm` but the child actually ran on
+`vulkan` (the lemond global default in `/var/lib/hal0/lemonade/config.json` →
+`llamacpp.backend = "vulkan"`).
+
+**Is the duplication necessary?**
+- `declared_backend` is **fully redundant with `device`** — the UI even notes it never
+  recomputes (slots.jsx:73-78). It is in the payload purely so the UI compares
+  like-for-like tokens without re-running the map. **Droppable** (UI can derive from
+  `device`).
+- `actual_backend` is **necessary** — it is a genuinely independent runtime observation
+  that no config field encodes. Keep it.
+- **Minimal non-redundant runtime set = `{device (intent), actual_backend (observed)}`.**
+  Compute `declared`/`mismatch` on the client from `device`.
+
+---
+
+## 4. Q3 — the NPU "trio": one `flm serve` backs three slots
+
+### Mechanism
+One `flm serve <chat-tag> --asr <0|1> --embed <0|1>` child process answers three
+OpenAI endpoints simultaneously (`flm.py:7-9`): `/v1/chat/completions`,
+`/v1/audio/transcriptions`, `/v1/embeddings`. **Lemonade only registers the chat
+model**; it has no knowledge of the ASR/embed roles (flm_trio.py:6-9).
+
+hal0 surfaces three *slots* anyway — and here is the mess: the code constant
+`_FLM_TRIO_SLOTS = {"agent","stt-npu","embed-npu"}` (slots.py:106-112), but the
+**deployed slots are named `npu`/`stt`/`embed`**. So the hardcoded `coresident_group`
+marker (slots.py:304 `if name in _FLM_TRIO_SLOTS`) **can never fire** for the real slots
+— a **dead marker**. The UI sidesteps this entirely by keying the trio off
+`device==="npu"` (slots.jsx:607, `NpuFlmStack`), splitting by `type`
+(`llm`→chat anchor, `transcription`→stt, `embedding`→embed; slots.jsx:621-623).
+
+### How `flm_args` gates live modalities
+`flm_args` is **NOT a slot field** — it lives in lemond's config at `flm.args`
+(client.py:85-92; top-level `flm_args` is rejected 400). The orchestrator toggles a
+single `--asr`/`--embed` flag per child (orchestrator.py:88-138, `_recompose_flm_args`)
+and writes `{"flm":{"args": ...}}` (client.py:108). It applies only on the **next FLM
+load** — the anchor must be reloaded (UI "reload" affordance).
+
+- **Chat** → routes through Lemonade normally (lemond proxies to the FLM child).
+- **STT / embed** → hal0 **bypasses** lemond and POSTs straight to the FLM child's
+  `{backend_url}/v1/audio/transcriptions` / `/v1/embeddings` (flm_trio.py:215-285).
+  `backend_url` discovered from `/v1/health.loaded[]` where `recipe=="flm" && type=="llm"`
+  (flm_trio.py:184-209). If no FLM chat is loaded → `FLMTrioNotAvailable` 503 ("load an
+  NPU chat slot first").
+
+### Why the stt/embed model pickers are read-only
+The FLM build serves the asr/embed models **fixed by the `--asr`/`--embed` flags**; the
+request `model` field is **ignored by FLM** (verified 2026-06-06, slots.jsx:555-559,574-585).
+A picker would be cosmetic — so `NpuModalityCard` renders the served model as a read-only
+label (`readOnlyModel`), showing `slot.modelDefault` (the configured FLM tag) because the
+shadow modality "is never loaded as its own process, so its live `model_id` stays stale on
+the pre-trio GGUF" (slots.jsx:579-583). Only the **chat anchor** is a real picker.
+
+### Minimal correct recipe: "chat anchor = gemma4-it-e4b-FLM, stt+embed OFF"
+
+There are **two independent OFF layers** — set both:
+
+1. **Set the chat anchor model.** The FLM tag is NOT in the registry, so you
+   **cannot** use `/load` or `/swap` (they 404 on the registry gate — see Q4). Use the
+   **config-edit path** which has no registry gate:
+   `PUT /api/slots/npu/config` (or `PATCH /api/slots/npu/defaults`) writing
+   `[model].default = "gemma4-it-e4b-FLM"` (slots.py:1136 / :1172 — no `registry.has`).
+2. **Runtime modality off** — set lemond `flm.args = "--asr 0 --embed 0"`
+   (POST lemonade config; client.py:108 payload `{"flm":{"args":"--asr 0 --embed 0"}}`).
+   *The live config already shows exactly this.*
+3. **hal0-side off** — set `enabled=false` on the `stt` and `embed` slot TOMLs (already
+   true in deployment). This removes them from startup + marks `lemonade_state="disabled"`.
+4. **Reload the anchor** (`npu` slot unload+load) so the new model + `--asr 0 --embed 0`
+   take effect.
+
+Layer (2) stops the FLM child from serving those modalities at runtime; layer (3) is the
+hal0 catalog/UI off-switch. Both should agree to avoid a slot that looks enabled but has no
+backend.
+
+---
+
+## 5. Q4 — registry-bypass: config-default path vs slot-apply path
+
+**The npu slot serves `qwen3-it-4b-FLM` even though it is NOT in hal0's registry.** Why:
+
+- `LemonadeProvider.load()` (lemonade.py:582-637) reads `model.default` straight from the
+  slot cfg (`_slot_model`, lemonade.py:608) and passes it to lemond `/v1/load` as
+  `model_name`. **It never consults hal0's `model_registry`.** lemond resolves the model
+  via its own `server_models.json` / FLM cache. (Comment lemonade.py:602-605: registry
+  metadata "currently unused under Lemonade — the daemon resolves models via its own
+  server_models.json".)
+- So **anything written to `[model].default`** loads, registry or not — that is the FLM
+  tag's whole route to existence.
+
+**The slot-apply API path REQUIRES registry membership** at exactly two call sites:
+- `POST /{name}/load` — `if registry is not None and not registry.has(model_id): raise
+  ModelNotFound` — **but only when `model_id` is supplied in the body** (slots.py:1411-1419).
+  An **empty body falls through** to `sm.load(name, model_id=None)` → uses the TOML default
+  → **no registry check**.
+- `POST /{name}/swap` — registry-gated **unconditionally** (swap requires a non-empty
+  `model_id`; slots.py:1455-1468).
+
+**Where the two paths diverge:**
+
+| path | registry gate? | reaches FLM tag? |
+|------|----------------|------------------|
+| `PUT /{name}/config` `[model].default=…` (slots.py:1136) | **NO** | ✅ writes any tag to disk |
+| `PATCH /{name}/defaults` (slots.py:1172) | **NO** | ✅ |
+| `POST /{name}/load` with **empty body** (slots.py:1420) | **NO** (model_id None → TOML default) | ✅ |
+| `POST /{name}/load` with `{model_id}` (slots.py:1413) | **YES** | ❌ 404 for FLM tag |
+| `POST /{name}/swap` (slots.py:1462) | **YES** | ❌ 404 for FLM tag |
+| `LemonadeProvider.load` → lemond `/v1/load` (lemonade.py:631) | **NO** (lemond's own catalog) | ✅ |
+
+The divergence point: the registry check is an **API-route guard on operator-supplied
+model_ids**, NOT a property of the load mechanism. The actual load (provider→lemond) is
+registry-blind. So the bypass = "write the tag to `[model].default` (or load with empty
+body), never pass it as an explicit `model_id`." This is why the UI shows the FLM picker as
+read-only and drives the anchor via config-edit, not swap.
+
+---
+
+## 6. Q6 — composite `hal0` upstream
+
+`_fetch_hal0_composite_models` (api/__init__.py:135-179) aggregates **each slot's
+`[model].default`** (checks `model.default`/`model_default`/`model_id` shapes, :173-179)
+into ONE synthetic `hal0` upstream (api/__init__.py:504-547, "register exactly ONE composite
+`hal0` upstream"). The live payload's trailing `{"name":"hal0","_synthetic":true,
+"advertised_models":5}` is this aggregate — it advertises slot-default models so the
+dispatcher/OpenAI surface can name them without per-slot upstreams. It is **not a real
+slot** and should be excluded from any "slot shape" count.
+
+---
+
+## 7. Q5 — recommended MINIMAL slot shape + assignment validation
+
+### 7.1 Minimal non-redundant slot shape (config, on disk)
+
+```toml
+[slot]
+name = "primary"          # canonical id (role derives from this)
+type = "llm"              # modality: llm|embedding|reranking|transcription|tts|image
+device = "gpu-rocm"       # hardware intent: gpu-rocm|gpu-vulkan|cpu|npu
+enabled = true
+port = 8001               # single location (drop the [server] duplicate)
+idle_timeout_s = 900
+
+[model]
+default = "chadrock-35b-ace-saber"
+context_size = 65536
+
+[server]                  # optional tuning only
+extra_args = "..."
+```
+
+**Drop entirely** (all redundant or derivable):
+- `backend` — bijective with `device` (Q2). Already deprecated; finish the removal.
+- `provider` — ignored by SlotManager; Lemonade is the sole driver (ADR-0008).
+- `role` — derive from `name`; keep an override only if a slot truly needs a name≠role.
+- duplicate `port` under `[server]` — keep one.
+- payload `declared_backend` / `model_default` (mirror of `model.default`) — derive on
+  the client.
+
+**Keep as derived/runtime (payload only, never persisted):** `state`, `lemonade_state`,
+`model_id` (observed), `actual_backend`/`backend_mismatch`, `backend_url`, `mem_mb`,
+`metrics`. The only runtime-backend fields worth shipping are **`device` (intent)** +
+**`actual_backend` (observed)**.
+
+**Trio note:** `flm_args` stays a **lemond-global** setting (`flm.args`), not a slot field.
+Either fix `_FLM_TRIO_SLOTS` to the real names (`npu`/`stt`/`embed`) or delete the dead
+constant and rely solely on `device=="npu"` + `type` (as the UI already does).
+
+### 7.2 How slot↔model assignment validation SHOULD work
+
+Today the only real check is client-side (slot-modals.jsx:164-172) + the registry gate on
+explicit `model_id`. A model is assignable to a slot **iff ALL**:
+
+1. **Modality match:** `model.type == slot.type` (chat→llm, embed→embedding, asr→transcription,
+   rerank→reranking, tts→tts, image→image). This is the primary, non-negotiable gate
+   (already enforced client-side at slot-modals.jsx:165).
+2. **Device/backend capability match:**
+   - `device==npu` ⇒ model must be an FLM model (`model.device=="npu"` / backend `flm`).
+   - `device∈{gpu-rocm,gpu-vulkan,cpu}` ⇒ `model.backends` contains the device's llamacpp
+     backend token (`device.replace("gpu-","")`), per slot-modals.jsx:169-171.
+   - `rocmfp4`-tagged models ⇒ only `device==gpu-rocm` (slot-modals.jsx:168).
+3. **Existence:** registry id **OR** a provider-resolvable tag (FLM tags resolve via lemond,
+   not hal0's registry). The current hard `registry.has()` gate is **too strict** — it blocks
+   exactly the legitimate FLM-tag case and is the reason for the config-edit bypass. Replace
+   "must be in registry" with "must be registry-resolvable **or** provider(lemond)-resolvable
+   for this device's recipe."
+
+Validation should be enforced **server-side** at the config-write/load boundary (not only in
+the React modal), using `(type, device)` from the slot and `(type/capability, backends/device,
+tags)` from the model — so the API can't be made to write an incompatible assignment that then
+fails opaquely at load.
+
+---
+
+## 8. The "it's a mess" summary — blunt list of redundant/conflicting fields
+
+1. **`backend` (TOML) — pure duplicate of `device`**, deprecated, drifts when unsynced;
+   even runtime reads derive `backend` from `device` and ignore the field. **Delete.**
+2. **`provider` (TOML) — ignored by the lifecycle layer**, Lemonade is hardwired. **Delete.**
+3. **`declared_backend` (payload) — pure function of `device`.** Derive client-side. **Drop from wire.**
+4. **`model_default` (payload) — exact mirror of `model.default`.** Wire convenience only.
+5. **`port` may be authored twice** (top-level + `[server]`; loader reads both). In
+   deployment only `npu` actually does it (8088 in both). Pick one home.
+6. **`role` set on 1/10 slots**, otherwise name-derived. Override-only.
+7. **`_FLM_TRIO_SLOTS` constant names `agent`/`stt-npu`/`embed-npu` but real slots are
+   `npu`/`stt`/`embed`** → the `coresident_group` marker is **dead code**; the UI works only
+   because it ignores the constant and keys off `device==="npu"`. Naming drift.
+8. **`lemonade_state` vs `state`** — two different status notions (lemond runtime vs hal0
+   state machine) both surface; legitimately distinct but confusing without the doc.
+9. **`registry.has()` gate is conditional/inconsistent**: enforced on `/swap` and on `/load`
+   *with* a body, but bypassed by empty-body `/load`, `PUT /config`, and the provider load —
+   so "is this model allowed here?" has no single answer.
+
+**Net:** the two real, independent descriptors are **`type`** (modality) and **`device`**
+(hardware) plus **`model.default`** (assignment). Everything else is either a derived runtime
+observation (`state`, `actual_backend`, `model_id`, `lemonade_state`) or dead/redundant
+(`backend`, `provider`, `declared_backend`, `model_default`, duplicate `port`, mostly-unused
+`role`). Consolidate to `{name, type, device, enabled, port, idle_timeout_s, [model].default,
+[server].extra_args}` + runtime `{state, model_id, actual_backend}`.

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -69,6 +69,22 @@ def _get_slot_manager(request: Request) -> SlotManager:
     return sm
 
 
+def _model_resolvable(registry: Any, model_id: str) -> bool:
+    """True if ``model_id`` can actually be loaded onto a slot.
+
+    The slot-apply guard used to require ``registry.has(model_id)``, but FLM
+    models are lemond-owned and are never in hal0's registry (see the
+    2026-06-07 shape audits) — yet they load fine via npu.toml's config path.
+    So gate on *provider-resolvability*: registry-resident OR an installed FLM
+    model. (Extensible later to a general ``lemond_serves(id)`` probe.)
+    """
+    if registry is not None and registry.has(model_id):
+        return True
+    from hal0.providers.flm import is_installed_flm_id
+
+    return is_installed_flm_id(model_id)
+
+
 def _slot_to_dict(slot: Slot, request: Request | None = None) -> dict[str, Any]:
     """Serialise a real Slot snapshot into the API shape.
 
@@ -1410,11 +1426,12 @@ async def load_slot(name: str, request: Request) -> dict[str, object]:
         model_id = body.get("model")
     if model_id:
         registry = getattr(request.app.state, "model_registry", None)
-        if registry is not None and not registry.has(model_id):
+        if registry is not None and not _model_resolvable(registry, model_id):
             from hal0.registry.store import ModelNotFound
 
             raise ModelNotFound(
-                f"model {model_id!r} is not in the registry (slot {name!r} not touched)",
+                f"model {model_id!r} is not resolvable — not in the registry and "
+                f"not an installed FLM model (slot {name!r} not touched)",
                 details={"model_id": model_id, "slot": name},
             )
     snap = await sm.load(name, model_id=model_id)
@@ -1459,11 +1476,12 @@ async def swap_slot(name: str, request: Request) -> dict[str, object]:
             code="swap.missing_model",
         )
     registry = getattr(request.app.state, "model_registry", None)
-    if registry is not None and not registry.has(model_id):
+    if registry is not None and not _model_resolvable(registry, model_id):
         from hal0.registry.store import ModelNotFound
 
         raise ModelNotFound(
-            f"model {model_id!r} is not in the registry (slot {name!r} not touched)",
+            f"model {model_id!r} is not resolvable — not in the registry and "
+            f"not an installed FLM model (slot {name!r} not touched)",
             details={"model_id": model_id, "slot": name},
         )
     snap = await sm.swap(name, model_id)

--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -602,6 +602,30 @@ def is_flm_tag(model_id: str) -> bool:
     return any(m["tag"] == model_id for m in flm_served_models())
 
 
+def is_installed_flm_id(model_id: str) -> bool:
+    """True iff ``model_id`` is the ``<tag>-FLM`` id of an INSTALLED FLM model.
+
+    FLM models are lemond-owned and are **never** in hal0's ModelRegistry
+    (see docs/internal/brain-redesign/{model,slot}-shapes-audit-2026-06-07.md):
+    the registry is the source of truth for GGUF/local models only. So the
+    slot-apply registry gate (``routes/slots.py``) wrongly rejects a perfectly
+    loadable FLM model — yet the npu.toml ``[model].default`` config path loads
+    the same id fine, lemond-mediated. This lets slot-apply accept an on-disk
+    FLM model by *provider-resolvability* instead of registry membership.
+
+    ``model_id`` is the lemond-served ``-FLM`` form (``gemma4-it-e4b-FLM``); we
+    match it against the forward transform of each installed probe tag
+    (``gemma4-it:e4b`` → ``gemma4-it-e4b-FLM``), the same map used to synthesise
+    the picker rows in ``routes/models.py``.
+    """
+    if not model_id.endswith("-FLM"):
+        return False
+    return any(
+        m.get("installed") and m["tag"].replace(":", "-") + "-FLM" == model_id
+        for m in flm_served_models()
+    )
+
+
 def flm_pull_command(tag: str) -> tuple[list[str], str]:
     """Return ``(argv, host_models_dir)`` for a host ``flm pull <tag>`` run.
 

--- a/tests/providers/test_flm.py
+++ b/tests/providers/test_flm.py
@@ -432,3 +432,25 @@ def test_spawn_kwargs_sets_home_and_skips_user_when_not_root() -> None:
         kw = flm.flm_host_spawn_kwargs()
     assert kw["env"]["HOME"] == flm._HOST_FLM_HOME
     assert "user" not in kw
+
+
+# ─── is_installed_flm_id (slot-apply provider-resolvability) ─────────────────
+
+
+def test_is_installed_flm_id_matches_installed_tag() -> None:
+    """The <tag>-FLM id of an INSTALLED probe model resolves true."""
+    import hal0.providers.flm as flm
+
+    fake = [
+        {"tag": "gemma4-it:e4b", "installed": True, "capabilities": ["chat"]},
+        {"tag": "qwen3:0.6b", "installed": False, "capabilities": ["chat"]},
+    ]
+    with patch("hal0.providers.flm.flm_served_models", lambda: fake):
+        assert flm.is_installed_flm_id("gemma4-it-e4b-FLM") is True
+        # not installed → false
+        assert flm.is_installed_flm_id("qwen3-0.6b-FLM") is False
+        # unknown tag → false
+        assert flm.is_installed_flm_id("nope-7b-FLM") is False
+        # missing -FLM suffix (a colon tag or GGUF id) → false (fast path)
+        assert flm.is_installed_flm_id("gemma4-it:e4b") is False
+        assert flm.is_installed_flm_id("chadrock-35b-ace-saber") is False


### PR DESCRIPTION
## P0 of the shape-consolidation plan + the 3 research deliverables

**Fixes the "model X is not in the registry (slot Y not touched)" error** that blocked assigning ANY FLM model (gemma4, embed-gemma…) to a slot from the dashboard.

**Root cause** (from the audits): FLM models are lemond-owned and are *structurally never* in hal0's ModelRegistry — yet the slot-apply guard required `registry.has(model_id)`. The npu.toml config path loads the same ids fine (registry-blind), so the API check was enforcing a wrong invariant.

**Fix:** gate on **provider-resolvability** — `registry.has(id) OR is_installed_flm_id(id)` — applied to both `/load` and `/swap`. New `providers.flm.is_installed_flm_id()` + `slots._model_resolvable()`. 48 tests pass; ruff clean.

**Also bundles** (docs only): `model-shapes-audit`, `slot-shapes-audit`, `shape-consolidation-proposal` (2026-06-07) — the full field inventory, the device-vs-backend verdict (keep `device` on slots, `backends` on models), vocabulary collisions, and the phased P0–P3 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)