### PR TITLE
docs: version single-source sweep + fix dead README links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -420,7 +420,7 @@ locked implementation contract at
   detects v0.1.x state (presence of `/etc/hal0/slots/*.toml` AND
   absence of `/var/lib/hal0/lemonade/config.json`) and refuses to
   overwrite it, printing explicit backup + wipe instructions and
-  exiting non-zero. See [`docs/v0.2-upgrade.md`](docs/v0.2-upgrade.md)
+  exiting non-zero. See [https://hal0.dev/docs/v0.2-upgrade](https://hal0.dev/docs/v0.2-upgrade)
   for the user-facing procedure.
 - **Per-modality toolbox containers retired.** `hal0-toolbox-vulkan` /
   `rocm` / `flm` / `moonshine` / `kokoro` / `comfyui` are no longer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to hal0
 
-hal0 is licensed [Apache 2.0](./LICENSE). hal0 is at **v0.2.0** — the
+hal0 is licensed [Apache 2.0](./LICENSE). hal0 is at **v0.3.2-alpha.1** — the
 Lemonade Server adoption release. The contribution model is still
 being decided (see [`PLAN.md`](./PLAN.md) §16). External PRs aren't
 being merged yet; please open issues for discussion.

--- a/PLAN.md
+++ b/PLAN.md
@@ -7,7 +7,7 @@ one-line install) and re-architected around the things that make hal0
 different from "a wrapper around llama-server": hardware-aware slots,
 clean lifecycle, and a real reliability bar.
 
-**Status (2026-05-23):** **v0.2.0 SHIPPED** (Lemonade migration + Agents
+**Status (2026-06-07):** **v0.3.2-alpha.1** (Lemonade migration + Agents
 v0.2 + MCP/memory + bundle picker, 22-PR adoption sequence closed).
 **v0.3 is the active milestone** — five interlocking work streams:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ curl -fsSL https://hal0.dev/install.sh | bash
 > and the legacy Provider stack all retired in favour of one
 > `hal0-lemonade.service` supervising a single `lemond` daemon. v0.1.x
 > installs do **not** auto-upgrade — see
-> [`docs/v0.2-upgrade.md`](./docs/v0.2-upgrade.md) for the back-up + wipe
+> [https://hal0.dev/docs/v0.2-upgrade](https://hal0.dev/docs/v0.2-upgrade) for the back-up + wipe
 > + reinstall procedure and the `hal0 registry import` recovery path.
 > First run lands a **bundle picker** (`hal0-Lite` / `Default` / `Pro` /
 > `Max` + `LMX-Omni-52B-Halo`) — `capabilities.toml` ships empty by
@@ -150,7 +150,7 @@ be evicted out from under a streaming request.
   against the workflow OIDC identity, then hands off to
   [`installer/install.sh`](./installer/install.sh). v0.1.x installs
   are detected and refused with explicit backup/wipe instructions
-  (see [`docs/v0.2-upgrade.md`](./docs/v0.2-upgrade.md)).
+  (see [https://hal0.dev/docs/v0.2-upgrade](https://hal0.dev/docs/v0.2-upgrade)).
 - **One-line Proxmox VE install** — on a Proxmox host, `bash -c "$(curl
   -fsSL https://raw.githubusercontent.com/Hal0ai/hal0/main/scripts/proxmox-ve/hal0.sh)"`
   creates an unprivileged Debian 13 LXC and runs the standard bootstrap
@@ -174,8 +174,8 @@ upstream `hermes`). Pick one via the first-run wizard or `hal0 agent install
 calls (`model_pull`, `slot_delete`, `config_write`, etc.) gate through
 a header bell + inbox modal in the dashboard, with CLI parity via
 `hal0 agent approvals {list,approve,deny}`. See
-[docs/api/mcp.md](./docs/api/mcp.md) and
-[docs/api/agents.md](./docs/api/agents.md).
+[docs/mcp/overview.md](./docs/mcp/overview.md) and
+[docs/agents/overview.md](./docs/agents/overview.md).
 
 ## Backends
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ operating the box, with a built-in chat page for smoke-tests.
 curl -fsSL https://hal0.dev/install.sh | bash
 ```
 
-> **Status:** **v0.2.0** — first release on the Lemonade runtime.
+> **Status:** **v0.3.2-alpha.1** — first release on the Lemonade runtime.
 > Six per-modality toolbox containers, the `hal0-slot@.service` template,
 > and the legacy Provider stack all retired in favour of one
 > `hal0-lemonade.service` supervising a single `lemond` daemon. v0.1.x

--- a/installer/README.md
+++ b/installer/README.md
@@ -21,7 +21,7 @@ sudo bash installer/install.sh --models-dir=/mnt/ai-models
 > **v0.1.x users:** `install.sh` will detect existing v0.1.x state
 > (`/etc/hal0/slots/*.toml` AND no `/var/lib/hal0/lemonade/config.json`)
 > and refuse to overwrite it. See
-> [`docs/v0.2-upgrade.md`](../docs/v0.2-upgrade.md) for the backup +
+> [https://hal0.dev/docs/v0.2-upgrade](https://hal0.dev/docs/v0.2-upgrade) for the backup +
 > wipe + reinstall procedure and the `hal0 registry import` recovery
 > command.
 
@@ -38,7 +38,7 @@ are no longer required, built, or pulled.
 
 1. **Pre-flight checks** — confirms Python 3.11–3.14 is on `$PATH`, systemd is present (skipped in `--dev`).
 2. **Privilege model** — runs as `root` (re-execs under `sudo` if needed). The `lemond` daemon runs under the `hal0` system user written into `hal0-lemonade.service`. Override with `HAL0_USER=...` if you want a different unit user, but the default is intentional.
-3. **v0.1.x detection** — refuses to overwrite a v0.1.x install (`/etc/hal0/slots/*.toml` present, `/var/lib/hal0/lemonade/config.json` absent). Prints backup + wipe instructions and exits non-zero. See [`docs/v0.2-upgrade.md`](../docs/v0.2-upgrade.md).
+3. **v0.1.x detection** — refuses to overwrite a v0.1.x install (`/etc/hal0/slots/*.toml` present, `/var/lib/hal0/lemonade/config.json` absent). Prints backup + wipe instructions and exits non-zero. See [https://hal0.dev/docs/v0.2-upgrade](https://hal0.dev/docs/v0.2-upgrade).
 4. **Layout** — creates `/opt/hal0/` (code + venv), `/etc/hal0/` (config), `/var/lib/hal0/{models,registry,lemonade,openwebui,cache}` (state). In `--dev` everything lands under `$PWD/.hal0ai/` instead.
 5. **Lemonade prerequisites** — installs the `lemonade-team/stable` PPA, the Lemonade embeddable tarball pinned in `manifest.json`, system libs (libxrt-npu2, ffmpeg6, boost1.83, fftw3), and (on AMDXDNA NPU hosts) the pinned FastFlowLM `.deb`.
 6. **Installs hal0** — creates a venv at `/opt/hal0/.venv/` and `pip install -e`'s the checkout into it. There is no versioned install dir or `current` symlink yet — the venv tracks the checkout in editable mode.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
   "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release \u2014 the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See PLAN.md \u00a712 (toolbox images) and \u00a717 (Risks).",
-  "version": "0.1.0-alpha.1",
+  "version": "0.3.2-alpha.1",
   "channel": "dev",
   "toolbox_images": {
     "vulkan": {


### PR DESCRIPTION
## Summary

- Sweeps stale version strings in `README.md`, `CONTRIBUTING.md`, `PLAN.md`, and `manifest.json` to match `pyproject.toml` (`0.3.2-alpha.1`); pyproject is the single source of truth (closes #617)
- Fixes dead doc links in `README.md`, `CHANGELOG.md`, and `installer/README.md`: `docs/api/mcp.md` → `docs/mcp/overview.md`, `docs/api/agents.md` → `docs/agents/overview.md`, and `docs/v0.2-upgrade.md` → `https://hal0.dev/docs/v0.2-upgrade` hosted URL (closes #628)

## Scope

Only doc/version files touched — no source, no tests, no graphify noise:

- `CONTRIBUTING.md` — version string (line 3)
- `PLAN.md` — version string + status date (line 10)
- `README.md` — version string + three dead links
- `manifest.json` — cosmetic `version` field
- `CHANGELOG.md` — dead `v0.2-upgrade.md` link → hosted URL
- `installer/README.md` — dead `v0.2-upgrade.md` links → hosted URL (2 occurrences)

## Note on #642

PR #642 (DCO governance) also edits `CONTRIBUTING.md` but in a different section (adds DCO sign-off block). No line conflict — #642 will need a rebase after this merges, but no manual fixup required.

## Test plan

- [ ] Verify `README.md` status badge shows `v0.3.2-alpha.1`
- [ ] Verify `CONTRIBUTING.md` line 3 shows `v0.3.2-alpha.1`
- [ ] Verify `PLAN.md` status line shows `v0.3.2-alpha.1`
- [ ] Verify `manifest.json` version field is `0.3.2-alpha.1`
- [ ] Click README mcp/agents links — confirm they resolve to `docs/mcp/overview.md` and `docs/agents/overview.md`
- [ ] Click v0.2-upgrade links in README/CHANGELOG/installer README — confirm they go to `https://hal0.dev/docs/v0.2-upgrade`

🤖 Generated with [Claude Code](https://claude.com/claude-code)