### PR TITLE
fix(agents): replace hardcoded thinmint.dev with config-derived dashboard_url

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1420,6 +1420,10 @@ def _phase_context_link(state: BootstrapState) -> PhaseResult:
         "primary": primary_for_template,
         "chat_slots": chat_slots,
         "peer_agents": [],
+        "dashboard_url": os.environ.get(
+            "HAL0_DASHBOARD_URL",
+            os.environ.get("HAL0_API_URL", "http://hal0.local:8080").rstrip("/"),
+        ),
     }
 
     rendered: dict[str, str] = {}
@@ -2020,7 +2024,10 @@ def render_live_context(
         "capabilities": capabilities,
         "npu": npu,
         "igpu_sclk_mhz": _igpu_sclk_mhz(),
-        "dashboard_url": os.environ.get("HAL0_DASHBOARD_URL", "https://hal0.thinmint.dev"),
+        "dashboard_url": os.environ.get(
+            "HAL0_DASHBOARD_URL",
+            os.environ.get("HAL0_API_URL", "http://hal0.local:8080").rstrip("/"),
+        ),
         "lemonade_base": os.environ.get("HAL0_LEMONADE_BASE", "http://127.0.0.1:13305"),
         "daemon": "degraded" if degraded else "reachable",
         "as_of": now,
@@ -2072,6 +2079,10 @@ def render_live_context(
             primary=primary_for_template,
             chat_slots=chat_slots,
             peer_agents=[],
+            dashboard_url=os.environ.get(
+                "HAL0_DASHBOARD_URL",
+                os.environ.get("HAL0_API_URL", "http://hal0.local:8080").rstrip("/"),
+            ),
         )
         hpath = ETC_HAL0_DIR / "HERMES.md"
         if not hpath.exists() or hpath.read_text(encoding="utf-8") != hermes_md:

--- a/src/hal0/agents/hermes_templates/AGENTS.md.j2
+++ b/src/hal0/agents/hermes_templates/AGENTS.md.j2
@@ -7,7 +7,7 @@
 #}# hal0 — agent context
 
 You are running on a hal0 host. hal0 is the open-source home-AI
-inference platform; the dashboard at https://hal0.thinmint.dev shows
+inference platform; the dashboard at {{ dashboard_url }} shows
 live state.
 
 ## Host snapshot

--- a/src/hal0/agents/hermes_templates/HERMES.md.j2
+++ b/src/hal0/agents/hermes_templates/HERMES.md.j2
@@ -37,7 +37,7 @@ than assuming — it carries an `_as_of:` timestamp.
 
 # Conventions
 
-- The dashboard at https://hal0.thinmint.dev shows live slot state.
+- The dashboard at {{ dashboard_url }} shows live slot state.
 - Never edit slot TOMLs directly — use `hal0_admin:capability_set`.
 - Never run `hermes setup` — it will overwrite your model wiring.
 - Bootstrap is `hal0 agent bootstrap hermes`; `--repair` re-renders


### PR DESCRIPTION
## Summary

- Replaces `https://hal0.thinmint.dev` fallback in `hermes_provision.py` with `HAL0_DASHBOARD_URL → HAL0_API_URL → http://hal0.local:8080` precedence chain
- Adds `dashboard_url` to the `vars_` dict so `AGENTS.md.j2` receives it at bootstrap time
- Adds `dashboard_url` to the `HERMES.md.j2` render call in `render_live_context`
- Updates `HERMES.md.j2` and `AGENTS.md.j2` to use `{{ dashboard_url }}` instead of the hardcoded host

## Test plan

- [ ] `pytest tests/agents/test_hermes_provision*.py tests/agents/test_hermes_live_resolve_render.py tests/agents/test_hermes_state_render.py -q` — 112 passed (3 pre-existing failures on `/mnt/ai-models` not mounted on dev VM, confirmed pre-existing on main)
- [ ] No `thinmint.dev` literal in `hermes_provision.py` or any `.j2` template

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)