### PR TITLE
fix(auth): drop phantom auth comments + thinmint.dev default origin

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1213,13 +1213,9 @@ def create_app() -> FastAPI:
         tags=["v1", "lemonade-proxy"],
     )
 
-    # /api/install drives the first-run wizard. When HAL0_AUTH_ENABLED is
-    # unset, the gate is a pure pass-through (require_token short-circuits
-    # to an anonymous identity), so the wizard still works on a fresh
-    # install with no password set — see FINDINGS §29. Once auth is
-    # enabled, every install endpoint requires a valid identity; mutating
-    # endpoints additionally declare Depends(require_writer) at the route
-    # level (matches the #11 admin-router pattern).
+    # /api/install drives the first-run wizard. Auth was removed in ADR-0012
+    # so these endpoints are open; the installer surface is admin-only by
+    # convention (network-level access control).
     app.include_router(
         installer.router,
         prefix="/api/install",
@@ -1247,9 +1243,8 @@ def create_app() -> FastAPI:
     # PR-13: Lemonade admin panel — GET /api/lemonade/config + POST
     # /api/lemonade/config wrap lemond's /internal/config + /internal/set
     # so the Settings → Lemonade admin panel can read + edit runtime
-    # config without bypassing hal0's auth. Same admin gate as the log
-    # proxy; POST additionally declares require_writer at the route
-    # level so cookie sessions ride the CSRF tripwire.
+    # config. Auth removed in ADR-0012; access is open on the local
+    # network.
     app.include_router(
         lemonade_admin_routes.router,
         prefix="/api/lemonade",
@@ -1327,10 +1322,8 @@ def create_app() -> FastAPI:
     )
 
     # Health + config/urls routers carry endpoints that are entirely
-    # public (e.g. /api/status, /api/config/urls). Any future protected
-    # endpoints added to these routers should declare
-    # Depends(require_token) at the function level so the publicness of
-    # the rest is declared by absence rather than by allowlist.
+    # public (e.g. /api/status, /api/config/urls). Auth was removed in
+    # ADR-0012; all endpoints on this server are open on the local network.
     app.include_router(health.router, prefix="/api", tags=["health"])
     app.include_router(config_routes.router, prefix="/api/config", tags=["config"])
 

--- a/src/hal0/api/agents/_auth.py
+++ b/src/hal0/api/agents/_auth.py
@@ -11,9 +11,9 @@ This module fixes that for the chat-proxy WebSocket routes by:
 
 1. Origin allowlist on every WS upgrade. Configured via
    ``HAL0_ALLOWED_ORIGINS`` (comma-separated). Default covers the
-   thinmint.dev vhost, the hal0.local hostname, and dev origins
-   (``localhost:5173`` for Vite, ``127.0.0.1:8080`` for the bundled
-   SPA). The check is FREE; missing it leaves the rest of this scheme
+   hal0.local hostname and dev origins (``localhost:5173`` for Vite,
+   ``127.0.0.1:8080`` for the bundled SPA). The check is FREE; missing
+   it leaves the rest of this scheme
    moot because any drive-by site could WebSocket into hal0-api from
    the user's own browser session.
 
@@ -53,12 +53,10 @@ from starlette.websockets import WebSocket
 # Default-deny set of browser origins permitted to upgrade to chat-proxy
 # WebSockets. Operators can override at boot via ``HAL0_ALLOWED_ORIGINS``
 # (comma-separated). The default covers:
-#   - https://hal0.thinmint.dev — Traefik vhost on the LAN gateway
 #   - http://hal0.local         — mDNS / hosts-file alias
 #   - http://localhost:5173     — Vite dev server (UI hot-reload)
 #   - http://127.0.0.1:8080     — bundled SPA served from hal0-api
 DEFAULT_ALLOWED_ORIGINS: Final[tuple[str, ...]] = (
-    "https://hal0.thinmint.dev",
     "http://hal0.local",
     "http://localhost:5173",
     "http://127.0.0.1:8080",

--- a/src/hal0/api/mcp_mount.py
+++ b/src/hal0/api/mcp_mount.py
@@ -2,7 +2,7 @@
 FastAPI app.
 
 Lives here (the orchestrator's package) because every piece it touches —
-the FastAPI ``app``, the ``AuthIdentity`` middleware, the lifespan-scoped
+the FastAPI ``app``, the lifespan-scoped
 :class:`hal0.mcp.approval_queue.ApprovalQueue` — is orchestrator-owned.
 
 The trick the mount needs to solve: FastMCP runs as a sub-ASGI app

--- a/src/hal0/api/routes/approvals.py
+++ b/src/hal0/api/routes/approvals.py
@@ -23,12 +23,8 @@ queue mutates.
 Auth
 ----
 
-Mounted under ``Depends(require_writer)`` by the API factory — only
-admin / all scoped credentials can approve. GETs go through
-``require_token`` so a read-only token can observe the inbox. The
-writer enforcement on POST happens at include-router time in the
-orchestrator's wiring; this module declares no auth dependency itself
-so the orchestrator can choose the right gate per ADR-0004 §5.
+Auth was removed in ADR-0012 — all routes here are open on the local
+network. This module declares no auth dependency itself.
 """
 
 from __future__ import annotations
@@ -47,12 +43,8 @@ from hal0.mcp.approval_queue import ApprovalQueue
 
 router = APIRouter()
 
-# Writer-scope gate for mutating approval routes. Per security review
-# HIGH-1: read-only Bearer tokens must NOT be able to approve gated
-# tool calls — that would defeat the destructive-allow-list policy
-# of ADR-0004 §5. POST /approve and POST /deny carry this dep
-# explicitly; GETs (list + SSE) keep the looser require_token gate
-# applied by the include_router prefix in the API factory.
+# Auth was removed in ADR-0012. POST /approve and POST /deny are
+# unrestricted on the local network; access control is LAN-only.
 
 
 # SSE keep-alive cadence — matches /api/events to keep the proxy

--- a/src/hal0/api/routes/installer.py
+++ b/src/hal0/api/routes/installer.py
@@ -42,13 +42,8 @@ from hal0.registry.model import Model
 from hal0.registry.pull import make_job, run_pull
 from hal0.registry.store import ModelAlreadyExists
 
-# Reusable writer-scope gate, applied per-route on every mutating endpoint
-# (POST /probe, POST /complete, POST /pick-default, PUT /slots/{slot}/model).
-# The router itself is mounted with require_token at include_router() time
-# (see hal0.api.create_app), which keeps GETs open to any valid identity
-# while these per-route deps enforce the writer scope on mutations. Both
-# gates short-circuit to a pass-through when HAL0_AUTH_ENABLED is unset,
-# preserving the fresh-install / first-run wizard UX.
+# Auth was removed in ADR-0012. All endpoints are open on the local
+# network; the first-run wizard runs without any credential.
 
 # Slot-name policy — mirrors ``SlotConfig.name`` in hal0.config.schema so a
 # slot name accepted by the API installer endpoints is also accepted by the

--- a/src/hal0/api/routes/lemonade_admin.py
+++ b/src/hal0/api/routes/lemonade_admin.py
@@ -16,12 +16,7 @@ for the Settings → Lemonade admin panel. Two routes:
                                     are deferred until next load — the UI
                                     surfaces this in the success toast.
 
-Both routes are admin-gated by the parent ``_admin_auth`` dependency
-applied at ``include_router`` time (see :mod:`hal0.api.__init__`), so we
-don't redeclare auth here. Read is GET; the mutating route is also
-gated by ``require_writer`` so a cookie-based session needs CSRF in
-addition to the admin scope — matching the pattern in
-``/api/settings``.
+Auth was removed in ADR-0012. Both routes are open on the local network.
 
 Validation guardrails (plan §11 PR-13 brief + ADR-0008 §3 + §7):
 
@@ -55,9 +50,7 @@ from hal0.lemonade.client import flm_args_from_lemond_config, flm_args_set_paylo
 
 router = APIRouter()
 
-# See settings.py for the writer-gate rationale: GET stays on the parent
-# admin gate (require_token), POST additionally requires writer scope so
-# cookie sessions ride through the CSRF tripwire alongside Bearer tokens.
+# Auth was removed in ADR-0012; GET and POST are both open on the local network.
 
 
 # ── key taxonomy (plan §2.2) ──────────────────────────────────────────

--- a/src/hal0/api/routes/lemonade_proxy.py
+++ b/src/hal0/api/routes/lemonade_proxy.py
@@ -25,10 +25,8 @@ Out of scope (handled elsewhere or deferred):
     existing ``lemonade_logs`` router already proxies /logs/stream → SSE
     under ``/api/lemonade/logs/stream``; a generic /v1 WS proxy is
     deferred to a follow-up issue.
-  - Auth: the catch-all sits behind the same ``require_token`` gate the
-    rest of the /v1 inference surface uses (mounted with ``_v1_auth``
-    dependencies in :mod:`hal0.api`). Lemonade itself binds loopback
-    only — anyone reaching this proxy already crossed hal0-api's gate.
+  - Auth: removed in ADR-0012. Lemonade itself binds loopback only —
+    this proxy is open on the local network.
 """
 
 from __future__ import annotations

--- a/src/hal0/api/routes/providers.py
+++ b/src/hal0/api/routes/providers.py
@@ -268,8 +268,8 @@ async def write_provider_credential(
 
     The Phase 8 MCP admin server's ``provider_credential_write`` tool
     routes here; that path is gated on owner approval (see
-    ``hal0.mcp.admin.GATED_TOOLS``). Direct REST writes are gated by the
-    same ``require_writer`` dep all admin mutations share.
+    ``hal0.mcp.admin.GATED_TOOLS``). Auth was removed in ADR-0012;
+    direct REST writes are open on the local network.
 
     Process restart is the caller's responsibility — the registry
     re-reads env on next load (see ``UpstreamRegistry`` __init__).

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -35,10 +35,7 @@ from fastapi.responses import StreamingResponse
 from hal0.api.middleware.error_codes import BadRequest, Conflict, Hal0Error
 from hal0.slots.manager import Slot, SlotManager
 
-# Reusable writer-scope gate applied per-route on every POST/PUT/PATCH/DELETE.
-# The router itself is mounted with require_token at include_router() time
-# (see hal0.api.create_app), which keeps GETs open to read-only tokens
-# while these per-route deps enforce the writer scope on mutations.
+# Auth was removed in ADR-0012. All routes are open on the local network.
 
 router = APIRouter()
 

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -38,9 +38,8 @@ from hal0.api.deps import DispatcherDep
 
 log = structlog.get_logger("hal0-v1")
 
-# Inference router — auth-required. Mounted by hal0.api.create_app() with
-# Depends(require_token) so /v1/chat/completions, /v1/embeddings, the
-# audio + image endpoints, etc. all gate on a valid credential.
+# Inference router. Mounted by hal0.api.create_app() on /v1.
+# Auth was removed in ADR-0012; the server is open on the local network.
 router = APIRouter()
 
 # Public probe router — auth-free. Mounted on the same /v1 prefix.

--- a/src/hal0/memory/cognee_wrapper.py
+++ b/src/hal0/memory/cognee_wrapper.py
@@ -213,8 +213,9 @@ class CogneeWrapper(MemoryProvider):
 
         :param cognee_dir: Where Cognee stores its SQLite + LanceDB +
             Kuzu files. Created if missing.
-        :param client_id: Identity extracted from the Bearer token by
-            the caller (see ``hal0.api.middleware.auth.AuthIdentity``).
+        :param client_id: Caller identity string (e.g. extracted from
+            ``X-hal0-Agent`` or set to ``"anonymous"`` for unauthenticated
+            requests; auth was removed in ADR-0012).
             Stamped onto every audit-log event and into the ``source``
             field of every add.
         :param private_mode: When True, the wrapper writes to


### PR DESCRIPTION
## Summary

- Deletes stale `require_token`/`require_writer`/`HAL0_AUTH_ENABLED` comments across 9 route modules — auth was removed in ADR-0012 and these references are misleading
- Removes `https://hal0.thinmint.dev` from `DEFAULT_ALLOWED_ORIGINS` in `_auth.py` (the cookie's `HttpOnly+SameSite` makes the stray entry inert, but it's hygiene for OSS)
- Fixes stale `hal0.api.middleware.auth.AuthIdentity` reference in `cognee_wrapper.py` (no such class)
- Drops `AuthIdentity` middleware mention from `mcp_mount.py` docstring

Files touched: `api/__init__.py`, `api/agents/_auth.py`, `api/mcp_mount.py`, `api/routes/approvals.py`, `api/routes/installer.py`, `api/routes/lemonade_admin.py`, `api/routes/lemonade_proxy.py`, `api/routes/providers.py`, `api/routes/slots.py`, `api/routes/v1.py`, `memory/cognee_wrapper.py`

## Test plan

- [ ] `pytest tests/api/test_chat_proxy_auth.py tests/api/test_approvals.py tests/api/test_installer_routes.py tests/cli/test_agent_approvals_list.py tests/mcp/test_approval_queue.py -q` — 56 passed
- [ ] No `thinmint.dev` in `DEFAULT_ALLOWED_ORIGINS`
- [ ] No `require_token`/`require_writer`/`HAL0_AUTH_ENABLED`/`AuthIdentity`/`MCPAuthMiddleware` remaining in `src/hal0/api/` or `src/hal0/memory/cognee_wrapper.py`

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)