### PR TITLE
feat(profiles): profile catalog — profiles.toml schema + loader + GET /api/profiles

### DIFF
--- a/installer/etc-hal0/profiles.toml
+++ b/installer/etc-hal0/profiles.toml
@@ -1,0 +1,27 @@
+# hal0 profile catalog — bench-tuned backend templates.
+# A profile = (image, flags, mtp).  Slots reference a profile by name;
+# the profile supplies the container image + flag bundle.
+# See the container-runtime design doc (§1) for the layering rationale.
+#
+# NOTE: this file is OPTIONAL.  hal0-api returns these three seed profiles
+# as built-in defaults when the file is absent (SEED_PROFILES in schema.py).
+# Keep this file identical to SEED_PROFILES to avoid silent drift.
+
+[profile.moe-rocmfp4]
+# A3B MoE agents (ace-saber). ~52.8 tok/s gen, 131k ctx.
+image = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server"
+flags = "-fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap"
+mtp   = false
+
+[profile.dense-mtp-rocmfp4]
+# Dense chat (qwopus 27B). ~24.4 tok/s gen with MTP (~2x non-MTP). 131k ctx.
+# mtp=true expands to the full --spec-type draft-mtp bundle at resolve time.
+image = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server"
+flags = "-fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap"
+mtp   = true
+
+[profile.vulkan-std]
+# Fallback / non-FP4 models. Vulkan-radv, no FP4/MTP.
+image = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server"
+flags = "-fa on -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap"
+mtp   = false

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -79,6 +79,9 @@ from hal0.api.routes import (
     journal as journal_routes,
 )
 from hal0.api.routes import (
+    profiles as profiles_routes,
+)
+from hal0.api.routes import (
     lemonade_admin as lemonade_admin_routes,
 )
 from hal0.api.routes import (
@@ -1326,6 +1329,11 @@ def create_app() -> FastAPI:
     # ADR-0012; all endpoints on this server are open on the local network.
     app.include_router(health.router, prefix="/api", tags=["health"])
     app.include_router(config_routes.router, prefix="/api/config", tags=["config"])
+
+    # Profile catalog — read-only, no auth (ADR-0012). Returns every profile
+    # from /etc/hal0/profiles.toml (falling back to the built-in seeds on a
+    # fresh install). Profiles are P1 container-runtime templates (issue #653).
+    app.include_router(profiles_routes.router, prefix="/api/profiles", tags=["profiles"])
 
     # Dashboard footer event surface — read-only, public for the same
     # reason as /api/status: the footer renders during first-run before

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -79,9 +79,6 @@ from hal0.api.routes import (
     journal as journal_routes,
 )
 from hal0.api.routes import (
-    profiles as profiles_routes,
-)
-from hal0.api.routes import (
     lemonade_admin as lemonade_admin_routes,
 )
 from hal0.api.routes import (
@@ -95,6 +92,9 @@ from hal0.api.routes import (
 )
 from hal0.api.routes import (
     memory as memory_routes,
+)
+from hal0.api.routes import (
+    profiles as profiles_routes,
 )
 from hal0.api.routes import (
     proxmox as proxmox_routes,

--- a/src/hal0/api/routes/profiles.py
+++ b/src/hal0/api/routes/profiles.py
@@ -1,0 +1,55 @@
+"""Profile catalog endpoint.
+
+Mounted at ``GET /api/profiles`` — returns the full profile catalog from
+``/etc/hal0/profiles.toml``, falling back to the built-in seed profiles on a
+fresh install.
+
+Each profile entry includes a ``resolved_flags`` field that inlines the MTP
+bundle expansion so callers (and tests) can observe the exact flag string that
+would be passed to llama-server without having to call
+``resolve_profile_flags()`` separately.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+
+from hal0.config.loader import load_profiles_config
+from hal0.config.schema import resolve_profile_flags
+
+router = APIRouter()
+
+
+@router.get("")
+def list_profiles() -> list[dict[str, Any]]:
+    """Return every profile in the catalog as a JSON array.
+
+    Each item shape::
+
+        {
+            "name":           "moe-rocmfp4",
+            "image":          "ghcr.io/hal0ai/...:rocm-7.2.4-rocmfp4-server",
+            "flags":          "-fa on ...",
+            "mtp":            false,
+            "resolved_flags": "-fa on ..."   # flags + MTP bundle when mtp=true
+        }
+
+    Raises:
+        500 (ConfigParseError): if profiles.toml is present but malformed.
+    """
+    cfg = load_profiles_config()
+    return [
+        {
+            "name": name,
+            "image": p.image,
+            "flags": p.flags,
+            "mtp": p.mtp,
+            "resolved_flags": resolve_profile_flags(p),
+        }
+        for name, p in cfg.profile.items()
+    ]
+
+
+__all__ = ["router"]

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -27,9 +27,11 @@ import tomli_w
 from hal0.config import paths
 from hal0.config.schema import (
     CURRENT_SCHEMA_VERSION,
+    SEED_PROFILES,
     AgentConfig,
     Hal0Config,
     HardwareInfo,
+    ProfilesConfig,
     ProvidersConfig,
     SlotConfig,
     UpstreamsConfig,
@@ -377,6 +379,41 @@ def save_upstreams_config(cfg: UpstreamsConfig, path: Path | None = None) -> Non
     write_toml_atomic(target, cfg.model_dump(mode="python"))
 
 
+# ── profiles.toml ─────────────────────────────────────────────────────────────
+
+
+def load_profiles_config(path: Path | None = None) -> ProfilesConfig:
+    """Load and validate /etc/hal0/profiles.toml.
+
+    Returns a :class:`ProfilesConfig` seeded with the three built-in bench
+    profiles when the file is absent so ``GET /api/profiles`` is always
+    populated on a fresh install.  When the file *is* present, only its
+    contents are returned — the seeds are NOT merged in.
+
+    Args:
+        path: Override path.  If None, uses
+              :func:`hal0.config.paths.profiles_toml`.
+
+    Returns:
+        A validated :class:`ProfilesConfig`.
+
+    Raises:
+        ConfigParseError: If the TOML is malformed or fails pydantic
+                          validation (e.g. missing ``image`` field).
+    """
+    target = path if path is not None else paths.profiles_toml()
+    if not Path(target).exists():
+        return ProfilesConfig.model_validate({"profile": SEED_PROFILES})
+    raw = _read_toml(Path(target))
+    try:
+        return ProfilesConfig.model_validate(raw)
+    except Exception as exc:
+        raise ConfigParseError(
+            f"failed to validate profiles.toml at {target}: {exc}",
+            details={"path": str(target), "reason": str(exc)},
+        ) from exc
+
+
 # ── agents/<name>.toml (ADR-0013) ─────────────────────────────────────────────
 
 
@@ -620,6 +657,7 @@ __all__ = [
     "load_hal0_config",
     "load_hardware_info",
     "load_manifest",
+    "load_profiles_config",
     "load_providers_config",
     "load_slot_config",
     "load_upstreams_config",

--- a/src/hal0/config/paths.py
+++ b/src/hal0/config/paths.py
@@ -187,6 +187,18 @@ def bundle_chosen_marker() -> Path:
     return var_lib() / ".bundle-chosen"
 
 
+def profiles_toml() -> Path:
+    """Return the profile catalog path (/etc/hal0/profiles.toml).
+
+    The file is optional — :func:`hal0.config.loader.load_profiles_config`
+    returns the built-in seed profiles when it is absent.
+
+    FHS:       /etc/hal0/profiles.toml
+    HAL0_HOME: $HAL0_HOME/etc/hal0/profiles.toml
+    """
+    return etc() / "profiles.toml"
+
+
 def manifest_json() -> Path:
     """Return the release manifest path.
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -468,6 +468,119 @@ class ProvidersConfig(BaseModel):
     provider: list[ProviderEntry] = Field(default_factory=list)
 
 
+# ── ProfileConfig + ProfilesConfig ────────────────────────────────────────────
+
+#: MTP draft-speculation flag bundle, bench-tuned.  Appended verbatim after
+#: profile.flags when ``mtp=true``.  Keep in sync with the profiles.toml seed
+#: and the bench doc (hal0-container-bench-2026-06-08.md).
+MTP_FLAG_BUNDLE = (
+    "--spec-type draft-mtp"
+    " --spec-draft-device ROCm0"
+    " --spec-draft-ngl all"
+    " --spec-draft-n-max 4"
+    " --spec-draft-n-min 0"
+    " --spec-draft-p-min 0.0"
+    " --spec-draft-p-split 0.10"
+    " --spec-draft-type-k q4_0"
+    " --spec-draft-type-v q4_0"
+)
+
+#: Seed profiles shipped with hal0.  Returned by ``load_profiles_config()``
+#: when ``/etc/hal0/profiles.toml`` is absent so ``GET /api/profiles`` is
+#: always populated on a fresh install.
+SEED_PROFILES: dict[str, dict[str, object]] = {
+    "moe-rocmfp4": {
+        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
+        "flags": "-fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap",
+        "mtp": False,
+    },
+    "dense-mtp-rocmfp4": {
+        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
+        "flags": "-fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap",
+        "mtp": True,
+    },
+    "vulkan-std": {
+        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server",
+        "flags": "-fa on -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap",
+        "mtp": False,
+    },
+}
+
+
+class ProfileConfig(BaseModel):
+    """One ``[profile.<name>]`` entry in profiles.toml.
+
+    A profile is a reusable backend template — image + bench-tuned flag
+    bundle + optional MTP toggle.  Slots reference a profile by name;
+    the profile supplies everything except the model path, context size,
+    and port (which belong to the slot).
+
+    See the hal0 container-runtime design doc (§1) and bench doc for the
+    rationale behind each seed profile.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+    image: str = Field(
+        ...,
+        description="Container image ref, e.g. ghcr.io/hal0ai/…:rocm-7.2.4-rocmfp4-server.",
+    )
+    flags: str = Field(
+        default="",
+        description="Bench-tuned llama-server CLI flags (no model/port/ctx args).",
+    )
+    mtp: bool = Field(
+        default=False,
+        description=(
+            "When true, the MTP draft-speculation bundle is appended to ``flags`` "
+            "at resolve time (see ``resolve_profile_flags()``)."
+        ),
+    )
+
+    @field_validator("image")
+    @classmethod
+    def image_nonempty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("profile image must not be empty")
+        return v
+
+
+class ProfilesConfig(BaseModel):
+    """Parsed profiles.toml — top-level ``[profile]`` table.
+
+    Each key under ``[profile]`` becomes an entry in ``profile``:
+
+        [profile.moe-rocmfp4]
+        image = "ghcr.io/..."
+        flags = "-fa on ..."
+        mtp   = false
+    """
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+    profile: dict[str, ProfileConfig] = Field(default_factory=dict)
+
+
+def resolve_profile_flags(profile: ProfileConfig) -> str:
+    """Return the full flag string for *profile*, expanding MTP when set.
+
+    When ``profile.mtp`` is ``True``, ``MTP_FLAG_BUNDLE`` is appended
+    after ``profile.flags`` (separated by a single space).  The model
+    path, port, and context size are the slot's concern — they are NOT
+    included here.
+
+    Args:
+        profile: A validated :class:`ProfileConfig`.
+
+    Returns:
+        The complete flag string ready to pass to llama-server.
+    """
+    base = profile.flags.strip()
+    if profile.mtp:
+        return f"{base} {MTP_FLAG_BUNDLE}".strip()
+    return base
+
+
 # ── UpstreamsConfig ────────────────────────────────────────────────────────────
 
 
@@ -1442,6 +1555,8 @@ __all__ = [
     "CAPABILITIES_SCHEMA_VERSION_LEGACY",
     "CURRENT_SCHEMA_VERSION",
     "DEFAULT_DEVICE",
+    "MTP_FLAG_BUNDLE",
+    "SEED_PROFILES",
     "AgentAuthConfig",
     "AgentAuthKindLiteral",
     "AgentConfig",
@@ -1462,6 +1577,8 @@ __all__ = [
     "ModelConfig",
     "ModelsConfig",
     "NPUInfo",
+    "ProfileConfig",
+    "ProfilesConfig",
     "ProviderEntry",
     "ProvidersConfig",
     "ServerConfig",
@@ -1472,4 +1589,5 @@ __all__ = [
     "UpstreamEntry",
     "UpstreamsConfig",
     "map_backend_to_device",
+    "resolve_profile_flags",
 ]

--- a/tests/api/test_profiles_route.py
+++ b/tests/api/test_profiles_route.py
@@ -1,0 +1,113 @@
+"""Tests for GET /api/profiles.
+
+Targeted file run only (full suite hangs):
+    ~/dev/hal0/.venv/bin/python -m pytest tests/api/test_profiles_route.py -q
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.config.schema import MTP_FLAG_BUNDLE, SEED_PROFILES
+
+
+@pytest.fixture
+def app(tmp_hal0_home: str) -> FastAPI:
+    """Fresh app; tmp_hal0_home means no profiles.toml → seeds returned."""
+    return create_app()
+
+
+@pytest.fixture
+def client(app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        yield c
+
+
+# ── GET /api/profiles ─────────────────────────────────────────────────────────
+
+
+class TestListProfiles:
+    def test_returns_200(self, client: TestClient) -> None:
+        resp = client.get("/api/profiles")
+        assert resp.status_code == 200
+
+    def test_returns_list(self, client: TestClient) -> None:
+        data = client.get("/api/profiles").json()
+        assert isinstance(data, list)
+
+    def test_returns_three_seed_profiles(self, client: TestClient) -> None:
+        data = client.get("/api/profiles").json()
+        assert len(data) == 3
+
+    def test_seed_names_present(self, client: TestClient) -> None:
+        data = client.get("/api/profiles").json()
+        names = {item["name"] for item in data}
+        assert names == set(SEED_PROFILES.keys())
+
+    def test_item_has_required_fields(self, client: TestClient) -> None:
+        data = client.get("/api/profiles").json()
+        for item in data:
+            assert "name" in item
+            assert "image" in item
+            assert "flags" in item
+            assert "mtp" in item
+            assert "resolved_flags" in item
+
+    def test_moe_rocmfp4_mtp_false(self, client: TestClient) -> None:
+        data = client.get("/api/profiles").json()
+        moe = next(item for item in data if item["name"] == "moe-rocmfp4")
+        assert moe["mtp"] is False
+
+    def test_dense_mtp_rocmfp4_mtp_true(self, client: TestClient) -> None:
+        data = client.get("/api/profiles").json()
+        dense = next(item for item in data if item["name"] == "dense-mtp-rocmfp4")
+        assert dense["mtp"] is True
+
+    def test_vulkan_std_image_contains_vulkan(self, client: TestClient) -> None:
+        data = client.get("/api/profiles").json()
+        vulkan = next(item for item in data if item["name"] == "vulkan-std")
+        assert "vulkan" in vulkan["image"]
+
+    def test_mtp_true_resolved_flags_contains_spec_type(self, client: TestClient) -> None:
+        data = client.get("/api/profiles").json()
+        dense = next(item for item in data if item["name"] == "dense-mtp-rocmfp4")
+        assert "--spec-type draft-mtp" in dense["resolved_flags"]
+
+    def test_mtp_true_resolved_flags_contains_bundle(self, client: TestClient) -> None:
+        data = client.get("/api/profiles").json()
+        dense = next(item for item in data if item["name"] == "dense-mtp-rocmfp4")
+        assert MTP_FLAG_BUNDLE in dense["resolved_flags"]
+
+    def test_mtp_false_resolved_flags_no_spec_type(self, client: TestClient) -> None:
+        data = client.get("/api/profiles").json()
+        moe = next(item for item in data if item["name"] == "moe-rocmfp4")
+        assert "--spec-type" not in moe["resolved_flags"]
+
+    def test_mtp_false_resolved_flags_equals_flags(self, client: TestClient) -> None:
+        data = client.get("/api/profiles").json()
+        for item in data:
+            if not item["mtp"]:
+                assert item["resolved_flags"] == item["flags"].strip()
+
+    def test_custom_profiles_file_used_when_present(self, tmp_hal0_home: str) -> None:
+        """When profiles.toml is present, its contents are used (not seeds)."""
+        profiles_path = Path(tmp_hal0_home) / "etc" / "hal0" / "profiles.toml"
+        profiles_path.parent.mkdir(parents=True, exist_ok=True)
+        profiles_path.write_text(
+            "[profile.custom-only]\n"
+            'image = "ghcr.io/hal0ai/test:custom"\n'
+            'flags = "-b 128"\n'
+            "mtp = false\n",
+            encoding="utf-8",
+        )
+        app = create_app()
+        with TestClient(app) as c:
+            data = c.get("/api/profiles").json()
+        names = {item["name"] for item in data}
+        assert names == {"custom-only"}

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -1,0 +1,231 @@
+"""Unit tests for the profile catalog — schema, loader, and flag resolver.
+
+Targeted file run only (full suite hangs due to lemond health waits):
+    ~/dev/hal0/.venv/bin/python -m pytest tests/config/test_profiles.py -q
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from hal0.config.loader import ConfigParseError, load_profiles_config
+from hal0.config.schema import (
+    MTP_FLAG_BUNDLE,
+    SEED_PROFILES,
+    ProfileConfig,
+    ProfilesConfig,
+    resolve_profile_flags,
+)
+
+# ── ProfileConfig validation ──────────────────────────────────────────────────
+
+
+class TestProfileConfigValidation:
+    def test_valid_profile(self) -> None:
+        p = ProfileConfig(image="ghcr.io/hal0ai/foo:bar", flags="-fa on", mtp=False)
+        assert p.image == "ghcr.io/hal0ai/foo:bar"
+        assert p.flags == "-fa on"
+        assert p.mtp is False
+
+    def test_mtp_default_false(self) -> None:
+        p = ProfileConfig(image="ghcr.io/hal0ai/foo:bar")
+        assert p.mtp is False
+
+    def test_flags_default_empty(self) -> None:
+        p = ProfileConfig(image="ghcr.io/hal0ai/foo:bar")
+        assert p.flags == ""
+
+    def test_empty_image_raises(self) -> None:
+        with pytest.raises(Exception, match="image"):
+            ProfileConfig(image="")
+
+    def test_whitespace_image_raises(self) -> None:
+        with pytest.raises(Exception, match="image"):
+            ProfileConfig(image="   ")
+
+    def test_missing_image_raises(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ProfileConfig.model_validate({"flags": "-fa on"})
+
+    def test_extra_fields_forbidden(self) -> None:
+        """extra='forbid' catches typos in profile toml keys."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ProfileConfig.model_validate({"image": "ghcr.io/hal0ai/foo:bar", "unknown_key": "bad"})
+
+
+# ── ProfilesConfig ────────────────────────────────────────────────────────────
+
+
+class TestProfilesConfig:
+    def test_empty_profiles(self) -> None:
+        cfg = ProfilesConfig()
+        assert cfg.profile == {}
+
+    def test_parse_from_dict(self) -> None:
+        cfg = ProfilesConfig.model_validate(
+            {
+                "profile": {
+                    "test": {
+                        "image": "ghcr.io/hal0ai/test:v1",
+                        "flags": "-fa on",
+                        "mtp": False,
+                    }
+                }
+            }
+        )
+        assert "test" in cfg.profile
+        assert cfg.profile["test"].image == "ghcr.io/hal0ai/test:v1"
+
+
+# ── resolve_profile_flags ─────────────────────────────────────────────────────
+
+
+class TestResolveProfileFlags:
+    def test_mtp_false_returns_base_flags(self) -> None:
+        p = ProfileConfig(image="ghcr.io/hal0ai/foo:bar", flags="-fa on -b 512", mtp=False)
+        result = resolve_profile_flags(p)
+        assert result == "-fa on -b 512"
+        assert "--spec-type" not in result
+
+    def test_mtp_true_appends_bundle(self) -> None:
+        p = ProfileConfig(image="ghcr.io/hal0ai/foo:bar", flags="-fa on -b 512", mtp=True)
+        result = resolve_profile_flags(p)
+        assert result.startswith("-fa on -b 512 ")
+        assert "--spec-type draft-mtp" in result
+
+    def test_mtp_true_contains_all_key_flags(self) -> None:
+        p = ProfileConfig(image="ghcr.io/hal0ai/foo:bar", flags="-fa on", mtp=True)
+        result = resolve_profile_flags(p)
+        assert "--spec-draft-device ROCm0" in result
+        assert "--spec-draft-ngl all" in result
+        assert "--spec-draft-n-max 4" in result
+        assert "--spec-draft-type-k q4_0" in result
+        assert "--spec-draft-type-v q4_0" in result
+
+    def test_mtp_bundle_literal_match(self) -> None:
+        """MTP_FLAG_BUNDLE constant is verbatim in the resolved string."""
+        p = ProfileConfig(image="ghcr.io/hal0ai/foo:bar", flags="-fa on", mtp=True)
+        result = resolve_profile_flags(p)
+        assert MTP_FLAG_BUNDLE in result
+
+    def test_empty_flags_mtp_false_returns_empty(self) -> None:
+        p = ProfileConfig(image="ghcr.io/hal0ai/foo:bar", flags="", mtp=False)
+        assert resolve_profile_flags(p) == ""
+
+    def test_empty_flags_mtp_true_returns_bundle(self) -> None:
+        p = ProfileConfig(image="ghcr.io/hal0ai/foo:bar", flags="", mtp=True)
+        result = resolve_profile_flags(p)
+        assert result == MTP_FLAG_BUNDLE
+
+    def test_flags_stripped(self) -> None:
+        p = ProfileConfig(image="ghcr.io/hal0ai/foo:bar", flags="  -fa on  ", mtp=False)
+        assert resolve_profile_flags(p) == "-fa on"
+
+
+# ── load_profiles_config ──────────────────────────────────────────────────────
+
+
+class TestLoadProfilesConfig:
+    def test_missing_file_returns_seeds(self, tmp_path: Path) -> None:
+        """Absent file → seed defaults; no fixture needed."""
+        cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
+        assert set(cfg.profile.keys()) == set(SEED_PROFILES.keys())
+
+    def test_seed_count(self, tmp_path: Path) -> None:
+        cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
+        assert len(cfg.profile) == 3
+
+    def test_seed_profiles_have_correct_names(self, tmp_path: Path) -> None:
+        cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
+        assert "moe-rocmfp4" in cfg.profile
+        assert "dense-mtp-rocmfp4" in cfg.profile
+        assert "vulkan-std" in cfg.profile
+
+    def test_seed_moe_rocmfp4_mtp_false(self, tmp_path: Path) -> None:
+        cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
+        assert cfg.profile["moe-rocmfp4"].mtp is False
+
+    def test_seed_dense_mtp_rocmfp4_mtp_true(self, tmp_path: Path) -> None:
+        cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
+        assert cfg.profile["dense-mtp-rocmfp4"].mtp is True
+
+    def test_seed_vulkan_std_correct_image(self, tmp_path: Path) -> None:
+        cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
+        assert "vulkan-radv-server" in cfg.profile["vulkan-std"].image
+
+    def test_load_valid_file(self, tmp_path: Path) -> None:
+        toml_content = (
+            '[profile.custom]\nimage = "ghcr.io/hal0ai/test:v1"\nflags = "-fa on"\nmtp   = false\n'
+        )
+        p = tmp_path / "profiles.toml"
+        p.write_bytes(toml_content.encode())
+        cfg = load_profiles_config(path=p)
+        assert "custom" in cfg.profile
+        assert cfg.profile["custom"].flags == "-fa on"
+
+    def test_missing_image_raises_config_parse_error(self, tmp_path: Path) -> None:
+        """``image`` is required — missing it must surface as ConfigParseError."""
+        toml_content = '[profile.bad]\nflags = "-fa on"\nmtp = false\n'
+        p = tmp_path / "profiles.toml"
+        p.write_bytes(toml_content.encode())
+        with pytest.raises(ConfigParseError):
+            load_profiles_config(path=p)
+
+    def test_invalid_toml_raises_config_parse_error(self, tmp_path: Path) -> None:
+        p = tmp_path / "profiles.toml"
+        p.write_bytes(b"[profile\nbad toml <<<")
+        with pytest.raises(ConfigParseError):
+            load_profiles_config(path=p)
+
+    def test_unknown_field_raises_config_parse_error(self, tmp_path: Path) -> None:
+        """extra='forbid' on ProfileConfig: typos in profile keys raise at load."""
+        toml_content = (
+            "[profile.bad]\n"
+            'image = "ghcr.io/hal0ai/test:v1"\n'
+            'not_a_field = "surprise"\n'  # unknown key
+        )
+        p = tmp_path / "profiles.toml"
+        p.write_bytes(toml_content.encode())
+        with pytest.raises(ConfigParseError):
+            load_profiles_config(path=p)
+
+
+# ── seed file parity check ────────────────────────────────────────────────────
+
+
+class TestSeedFileParity:
+    """Installer seed file must match the code-level SEED_PROFILES constant."""
+
+    @pytest.fixture
+    def seed_file(self) -> Path:
+        here = Path(__file__).resolve()
+        # tests/config/test_profiles.py → repo root → installer/etc-hal0/profiles.toml
+        return here.parents[2] / "installer" / "etc-hal0" / "profiles.toml"
+
+    def test_seed_file_exists(self, seed_file: Path) -> None:
+        assert seed_file.is_file(), f"seed file missing at {seed_file}"
+
+    def test_seed_file_names_match_code(self, seed_file: Path) -> None:
+        raw = tomllib.loads(seed_file.read_text(encoding="utf-8"))
+        file_names = set(raw.get("profile", {}).keys())
+        code_names = set(SEED_PROFILES.keys())
+        assert file_names == code_names, f"seed file names {file_names!r} != code {code_names!r}"
+
+    def test_seed_file_mtp_flags_match_code(self, seed_file: Path) -> None:
+        raw = tomllib.loads(seed_file.read_text(encoding="utf-8"))
+        for name, code_vals in SEED_PROFILES.items():
+            file_entry = raw["profile"][name]
+            assert file_entry["mtp"] == code_vals["mtp"], (
+                f"profiles.toml mtp for {name!r} ({file_entry['mtp']}) "
+                f"!= SEED_PROFILES ({code_vals['mtp']})"
+            )
+            assert file_entry["image"] == code_vals["image"], (
+                f"profiles.toml image for {name!r} differs from SEED_PROFILES"
+            )


### PR DESCRIPTION
## Summary

- Adds `ProfileConfig`/`ProfilesConfig` pydantic models (validated on load, `extra='forbid'`)
- Adds `MTP_FLAG_BUNDLE` constant + `resolve_profile_flags()` that expands `mtp=true` to bench-tuned draft-MTP flags at resolve time
- Adds `load_profiles_config()` with seed fallback — `GET /api/profiles` returns 3 profiles on fresh install (no file required)
- Adds `GET /api/profiles` route returning catalog + per-entry `resolved_flags`
- Seeds: `moe-rocmfp4` (ROCm7.2.4 MTP-off, ~52.8 tok/s), `dense-mtp-rocmfp4` (ROCm7.2.4 MTP-on, ~24.4 tok/s), `vulkan-std` (fallback)
- 42 targeted tests (schema, validation, mtp expansion, route, seed-file/code parity)
- No behavior change to existing slots

Closes #653. Parent: #652.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/config/test_profiles.py tests/api/test_profiles_route.py -q` — 42 passed
- [x] `ruff check` + `ruff format --check` clean on all changed/new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)