### PR TITLE
feat(slots): ContainerProvider — podman/docker container slot runtime

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -904,7 +904,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Construct the event bus first so the SlotManager can side-channel
     # every transition through it — the footer subscribes to /api/events.
     event_bus = EventBus()
-    slot_manager = SlotManager(event_bus=event_bus)
+    slot_manager = SlotManager(event_bus=event_bus, upstreams_registry=upstreams)
 
     dispatcher = Dispatcher(
         upstream_registry=upstreams,

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -242,6 +242,25 @@ class SlotConfig(BaseModel):
         default=True,
         description="Whether this slot is started on hal0 startup.",
     )
+    runtime: Literal["lemonade", "container"] = Field(
+        default="lemonade",
+        description=(
+            "Slot runtime engine. 'lemonade' (default) dispatches via lemond's "
+            "control plane (ADR-0008). 'container' runs a podman container managed "
+            "by ContainerProvider — requires 'profile' to be set. Lemonade slots "
+            "are unaffected by this field. See the container-runtime design doc §3."
+        ),
+    )
+    profile: str | None = Field(
+        default=None,
+        description=(
+            "Profile name from /etc/hal0/profiles.toml. When set, SlotManager "
+            "routes this slot to ContainerProvider instead of LemonadeProvider, "
+            "regardless of 'runtime'. The profile supplies the container image + "
+            "bench-tuned flags; the slot supplies model, context_size, and port. "
+            "See ProfileConfig and the container-runtime design doc §1."
+        ),
+    )
     role: str | None = Field(
         default=None,
         description=(

--- a/src/hal0/providers/__init__.py
+++ b/src/hal0/providers/__init__.py
@@ -9,10 +9,13 @@ Live providers (v0.2+):
     FLMProvider          — AMD NPU (optional, Strix Halo only)
     LemonadeProvider     — Lemonade gateway (sole slot-lifecycle backend)
     ComfyUIProvider      — image-gen pipeline (driven directly by api/routes/v1.py)
+    ContainerProvider    — podman container per slot (P1 tracer bullet, issue #655)
 
-Dispatch model (v0.2, ADR-0008):
-    SlotManager dispatches 100% through ``LemonadeProvider``.  The prior
-    ``MoonshineProvider`` + ``KokoroProvider`` self-managed paths were
+Dispatch model (v0.2, ADR-0008 + P1 hybrid):
+    SlotManager dispatches through ``LemonadeProvider`` for lemond slots.
+    Slots with ``profile`` set (or ``runtime="container"``) dispatch through
+    ``ContainerProvider`` (systemd podman unit per slot, loopback upstream).
+    The prior ``MoonshineProvider`` + ``KokoroProvider`` self-managed paths were
     vestigial (lemond now owns STT/TTS) and were removed in PR-10 (#620).
 
 Live exceptions (callers that bypass SlotManager dispatch):
@@ -27,6 +30,7 @@ from __future__ import annotations
 
 from hal0.providers.base import ContainerSpec, Provider
 from hal0.providers.comfyui import ComfyUIProvider
+from hal0.providers.container import ContainerProvider, container_provider
 from hal0.providers.flm import FLMProvider
 from hal0.providers.lemonade import LemonadeProvider
 from hal0.providers.llama_server import LlamaServerProvider
@@ -34,14 +38,13 @@ from hal0.providers.llama_server import LlamaServerProvider
 # Provider name → singleton instance.  Providers are stateless (per the
 # ABC contract), so one instance per process is enough.
 #
-# v0.2 (ADR-0008 §1/§2): Lemonade is the sole inference backend.
-# SlotManager dispatches every lifecycle call through ``LemonadeProvider``
-# unconditionally.  ``ComfyUIProvider`` and ``FLMProvider`` remain for
-# non-SlotManager callers (image-gen pipeline and NPU probe respectively).
-# ``MoonshineProvider`` and ``KokoroProvider`` were removed in #620 —
-# lemond now serves STT/TTS through its whispercpp and kokoro recipes.
+# v0.2 (ADR-0008 §1/§2): Lemonade is the sole inference backend for lemond
+# slots.  ContainerProvider handles container slots (P1 tracer, issue #655).
+# ``ComfyUIProvider`` and ``FLMProvider`` remain for non-SlotManager callers.
+# ``MoonshineProvider`` and ``KokoroProvider`` were removed in #620.
 _PROVIDERS: dict[str, Provider] = {
     "lemonade": LemonadeProvider(),
+    "container": ContainerProvider(),
     "llama-server": LlamaServerProvider(),
     "flm": FLMProvider(),
     "comfyui": ComfyUIProvider(),
@@ -76,11 +79,13 @@ def lemonade_provider() -> LemonadeProvider:
 
 __all__ = [
     "ComfyUIProvider",
+    "ContainerProvider",
     "ContainerSpec",
     "FLMProvider",
     "LemonadeProvider",
     "LlamaServerProvider",
     "Provider",
+    "container_provider",
     "get_provider",
     "lemonade_provider",
 ]

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1,0 +1,400 @@
+"""ContainerProvider — podman-container-per-slot runtime (P1 tracer bullet).
+
+Every GPU-LLM slot with ``profile`` set (or ``runtime="container"``) dispatches
+through this provider instead of LemonadeProvider.
+
+Architecture (design doc §2):
+  - Profile supplies:    image + bench-tuned flags (+ MTP bundle if mtp=true).
+  - Slot supplies:       model path, context_size, port.
+  - Container provides:  the running llama-server process.
+
+Container lifecycle → systemd template unit ``hal0-slot@<name>.service``:
+  ExecStart = podman run --rm ... <image> --model <path> --port <n> <flags>
+  ExecStop  = podman stop -t 20 hal0-slot-<name>
+
+The slot's port is loopback-published (``-p 127.0.0.1:<port>:<port>``) so
+the dispatcher can proxy it via a ``kind="remote"`` upstream entry without
+exposing it on the LAN.
+
+Mount design (IDENTICAL path, design doc §2 gotcha):
+  /mnt/ai-models → /mnt/ai-models:ro
+  GGUFs in the registry are symlinks whose targets are absolute
+  /mnt/ai-models/... paths.  Mounting anywhere else dangles them.
+
+GID resolution (reuses providers/_gpu.py):
+  ubuntu:24.04 toolbox images lack ``render``/``video`` group entries.
+  Pass numeric GIDs so the kernel gate on /dev/dri/renderD128 passes.
+
+ABC compliance:
+  Provider ABC has docker/systemd-shaped methods (build_env, start_cmd,
+  container_spec, render_systemd_override).  ContainerProvider implements
+  container_spec() and reuses the inherited render_systemd_override().
+  build_env / start_cmd / health / infer are implemented as informational
+  stubs or thin implementations — the real work is load/unload/status/health.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from hal0.config.loader import load_profiles_config
+from hal0.config.schema import ProfileConfig, resolve_profile_flags
+from hal0.providers._gpu import resolve_gpu_group_ids
+from hal0.providers.base import ContainerSpec, Provider
+
+log = logging.getLogger(__name__)
+
+# Path to the hal0-slot@ base template unit (installed by the package).
+# ContainerProvider writes a complete self-contained unit here, *not*
+# a drop-in, because the Lemonade migration (PR-9) retired the base
+# template.  Writing a complete file means the manager never has to
+# know whether the base exists.
+_SYSTEMD_SYSTEM_DIR = Path("/etc/systemd/system")
+_MODEL_STORE_MOUNT = "/mnt/ai-models"
+
+
+# Container runtime binary.  Prefer podman (rootless, no daemon);
+# fall back to docker when podman is not installed.  The HAL0_CONTAINER_RUNTIME
+# env var overrides both so CI + alternate installs can pin a specific path.
+def _container_runtime() -> str:
+    """Resolve the container runtime binary path.
+
+    Priority: $HAL0_CONTAINER_RUNTIME > /usr/bin/podman > /usr/bin/docker.
+    Raises RuntimeError if neither is found.
+    """
+    import os
+    import shutil
+
+    override = os.environ.get("HAL0_CONTAINER_RUNTIME")
+    if override:
+        return override
+    for candidate in ("/usr/bin/podman", "/usr/bin/docker"):
+        if shutil.which(candidate):
+            return candidate
+    raise RuntimeError(
+        "no container runtime found; install podman or docker or set HAL0_CONTAINER_RUNTIME"
+    )
+
+
+# Health-check tuning: poll GET /health on the slot port.
+_HEALTH_POLL_INTERVAL_S = 2.0
+_HEALTH_TIMEOUT_S = 180.0
+_HEALTH_REQUEST_TIMEOUT_S = 3.0
+
+
+def _resolve_profile(profile_name: str) -> ProfileConfig:
+    """Load profiles.toml and return the named profile.
+
+    Raises:
+        KeyError: If the profile name is not in the catalog.
+    """
+    catalog = load_profiles_config()
+    if profile_name not in catalog.profile:
+        available = sorted(catalog.profile.keys())
+        raise KeyError(f"profile {profile_name!r} not found in catalog; available: {available}")
+    return catalog.profile[profile_name]
+
+
+def _resolve_model_path(model_info: dict[str, Any]) -> str:
+    """Return the absolute GGUF path for this model.
+
+    Prefers ``model_info["path"]`` (populated by ModelRegistry.get);
+    falls back to ``model_info["_model_key"]`` (the model-id string)
+    so the container can attempt to locate the file at runtime.
+    """
+    path = model_info.get("path") or model_info.get("_model_key", "")
+    if not path:
+        raise ValueError(
+            "model_info has no 'path' — registry lookup failed; "
+            "ensure the model is registered before loading a container slot."
+        )
+    return str(path)
+
+
+def _render_unit(
+    slot_name: str,
+    image: str,
+    port: int,
+    model_path: str,
+    flags_str: str,
+    runtime_bin: str | None = None,
+) -> str:
+    """Render a complete (non-drop-in) systemd unit for a container slot.
+
+    Produces a self-contained unit that does NOT require a parent
+    ``hal0-slot@.service`` template (retired in Lemonade migration PR-9).
+    Written to ``/etc/systemd/system/hal0-slot@<name>.service``.
+
+    ``runtime_bin``: override the container runtime binary (default: auto-detect
+    via :func:`_container_runtime`).  Pass explicitly in tests to avoid
+    depending on podman/docker being installed in the test environment.
+    """
+    runtime = runtime_bin or _container_runtime()
+    container_name = f"hal0-slot-{slot_name}"
+    # Split the profile flags string into tokens for ExecStart quoting.
+    flag_tokens = shlex.split(flags_str) if flags_str.strip() else []
+
+    # Build the container run argv list.
+    argv: list[str] = [
+        runtime,
+        "run",
+        "--rm",
+        f"--name={container_name}",
+        "--device=/dev/kfd",
+        "--device=/dev/dri",
+    ]
+    # Numeric GIDs for video+render groups (ubuntu:24.04 has no group names).
+    for gid in resolve_gpu_group_ids():
+        argv.append(f"--group-add={gid}")
+    argv.extend(
+        [
+            "--security-opt=apparmor=unconfined",
+            "--security-opt=seccomp=unconfined",
+            f"--volume={_MODEL_STORE_MOUNT}:{_MODEL_STORE_MOUNT}:ro",
+            # Loopback publish: expose slot port on 127.0.0.1 only.
+            f"--publish=127.0.0.1:{port}:{port}",
+            # Container image.
+            image,
+            # llama-server args follow the image (space-separated, not --key=val).
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(port),
+            "--model",
+            model_path,
+        ]
+    )
+    # Append bench-tuned profile flags.
+    argv.extend(flag_tokens)
+
+    # ExecStart is a single long line; systemd accepts bare argv tokens.
+    exec_start = " ".join(shlex.quote(a) if " " in a else a for a in argv)
+    exec_stop = f"{runtime} stop -t 20 {container_name}"
+
+    return "\n".join(
+        [
+            "# hal0 container slot — generated by ContainerProvider",
+            "# Do not edit manually; regenerated on every slot load.",
+            "",
+            "[Unit]",
+            f"Description=hal0 container inference slot ({slot_name})",
+            "After=network-online.target",
+            "",
+            "[Service]",
+            "Type=simple",
+            "Restart=no",
+            f"SyslogIdentifier=hal0-slot-{slot_name}",
+            "StandardOutput=journal",
+            "StandardError=journal",
+            "",
+            f"ExecStart={exec_start}",
+            f"ExecStop={exec_stop}",
+            f"ExecStopPost=-{runtime} rm -f {container_name}",
+            "",
+            "[Install]",
+            "WantedBy=multi-user.target",
+            "",
+        ]
+    )
+
+
+class ContainerProvider(Provider):
+    """Podman-container-per-slot inference backend.
+
+    One instance is shared across all container slots (stateless —
+    all config is passed per-call via slot_cfg / model_info, same
+    contract as other Providers).
+
+    Public API used by SlotManager:
+      load(slot_cfg, model_info)  → writes + starts systemd unit.
+      unload(slot_cfg)            → stops systemd unit.
+      status(slot_cfg)            → systemctl is-active + /health.
+      health(port)                → GET 127.0.0.1:<port>/health.
+    """
+
+    name = "container"
+
+    # ── Provider ABC stubs (not used in the container path) ──────────────────
+
+    def build_env(self, slot_cfg: dict[str, Any], model_info: dict[str, Any]) -> dict[str, str]:
+        """Informational env block (not written to disk — container is self-contained)."""
+        return {
+            "HAL0_SLOT": str(slot_cfg.get("name", "")),
+            "HAL0_RUNTIME": "container",
+            "HAL0_PROFILE": str(slot_cfg.get("profile", "")),
+        }
+
+    def start_cmd(self, env: dict[str, str]) -> list[str]:
+        """Not applicable — systemd starts the container."""
+        raise NotImplementedError("ContainerProvider uses systemd; start_cmd() is unused")
+
+    async def infer(self, port: int, body: dict[str, Any]) -> dict[str, Any]:
+        """Direct inference passthrough (used by tests; dispatcher is primary path)."""
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(f"http://127.0.0.1:{port}/v1/chat/completions", json=body)
+            resp.raise_for_status()
+            return resp.json()  # type: ignore[no-any-return]
+
+    def container_spec(self, slot_cfg: dict[str, Any], model_info: dict[str, Any]) -> ContainerSpec:
+        """Build the ContainerSpec (satisfies ABC; used by render_systemd_override).
+
+        NOTE: ContainerProvider uses _render_unit() for its own unit rendering
+        rather than the inherited render_systemd_override(), because the base
+        template (hal0-slot@.service) was retired in the Lemonade migration.
+        This method is kept for ABC compliance and test helpers.
+        """
+        profile_name = slot_cfg.get("profile") or ""
+        profile = _resolve_profile(profile_name)
+        flags_str = resolve_profile_flags(profile)
+        flag_tokens = shlex.split(flags_str) if flags_str.strip() else []
+
+        model_path = _resolve_model_path(model_info)
+        port = int(slot_cfg.get("port", 0))
+
+        return ContainerSpec(
+            image=profile.image,
+            command=[
+                # llama-server uses space-separated args (--host HOST, not --host=HOST).
+                "--host",
+                "0.0.0.0",
+                "--port",
+                str(port),
+                "--model",
+                model_path,
+                *flag_tokens,
+            ],
+            mounts=[(_MODEL_STORE_MOUNT, _MODEL_STORE_MOUNT)],
+            devices=["/dev/kfd", "/dev/dri"],
+            group_add=[str(g) for g in resolve_gpu_group_ids()],
+            security_opt=["apparmor=unconfined", "seccomp=unconfined"],
+            port=port,
+            network_mode="",
+            extra_args=[f"--publish=127.0.0.1:{port}:{port}"],
+        )
+
+    # ── ContainerProvider-specific control plane ──────────────────────────────
+
+    def _unit_name(self, slot_name: str) -> str:
+        return f"hal0-slot@{slot_name}.service"
+
+    def _unit_path(self, slot_name: str) -> Path:
+        return _SYSTEMD_SYSTEM_DIR / self._unit_name(slot_name)
+
+    def _run(self, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+        """Run a subprocess synchronously (load/unload are blocking ops anyway)."""
+        return subprocess.run(list(args), capture_output=True, text=True, check=check)
+
+    async def health(self, port: int) -> dict[str, Any]:
+        """Probe GET /health on the container port.
+
+        Returns {"ok": bool, "status": str}.
+        """
+        url = f"http://127.0.0.1:{port}/health"
+        try:
+            async with httpx.AsyncClient(timeout=_HEALTH_REQUEST_TIMEOUT_S) as client:
+                resp = await client.get(url)
+                ok = resp.status_code == 200
+                return {"ok": ok, "status": "healthy" if ok else f"http_{resp.status_code}"}
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+            return {"ok": False, "status": str(exc)}
+
+    async def wait_ready(self, port: int) -> None:
+        """Poll /health until 200 or HEALTH_TIMEOUT_S exceeded.
+
+        Raises:
+            TimeoutError: If the container does not become healthy in time.
+        """
+        deadline = asyncio.get_event_loop().time() + _HEALTH_TIMEOUT_S
+        while asyncio.get_event_loop().time() < deadline:
+            h = await self.health(port)
+            if h.get("ok"):
+                return
+            await asyncio.sleep(_HEALTH_POLL_INTERVAL_S)
+        raise TimeoutError(
+            f"container slot port {port} did not become healthy within {_HEALTH_TIMEOUT_S}s"
+        )
+
+    def load_sync(
+        self,
+        slot_cfg: dict[str, Any],
+        model_info: dict[str, Any],
+    ) -> None:
+        """Write systemd unit, daemon-reload, enable, start (synchronous).
+
+        Called from ``_spawn_locked`` (which is already inside an
+        asyncio.to_thread-friendly path — SlotManager awaits the slot spawn
+        via ``await self._spawn_locked(...)``).
+        """
+        slot_name: str = str(slot_cfg.get("name", ""))
+        port: int = int(slot_cfg.get("port", 0))
+        profile_name: str = str(slot_cfg.get("profile") or "")
+
+        profile = _resolve_profile(profile_name)
+        flags_str = resolve_profile_flags(profile)
+        model_path = _resolve_model_path(model_info)
+
+        unit_path = self._unit_path(slot_name)
+        unit_text = _render_unit(slot_name, profile.image, port, model_path, flags_str)
+
+        log.info(
+            "container.unit_write",
+            extra={
+                "slot": slot_name,
+                "unit_path": str(unit_path),
+                "image": profile.image,
+                "port": port,
+                "model_path": model_path,
+            },
+        )
+        unit_path.write_text(unit_text)
+
+        self._run("systemctl", "daemon-reload")
+        # Enable so it survives reboots (best-effort — don't fail if already enabled).
+        self._run("systemctl", "enable", self._unit_name(slot_name), check=False)
+        self._run("systemctl", "restart", self._unit_name(slot_name))
+        log.info(
+            "container.unit_started",
+            extra={"slot": slot_name, "unit": self._unit_name(slot_name)},
+        )
+
+    def unload_sync(self, slot_cfg: dict[str, Any]) -> None:
+        """Stop and clean up the container unit (synchronous)."""
+        slot_name: str = str(slot_cfg.get("name", ""))
+        unit = self._unit_name(slot_name)
+        log.info("container.unit_stop", extra={"slot": slot_name, "unit": unit})
+        self._run("systemctl", "stop", unit, check=False)
+        # Disable so it doesn't re-start on reboot.
+        self._run("systemctl", "disable", unit, check=False)
+        # Remove unit file so daemon-reload leaves no stale entry.
+        unit_path = self._unit_path(slot_name)
+        if unit_path.exists():
+            unit_path.unlink()
+            self._run("systemctl", "daemon-reload")
+
+    def is_active(self, slot_name: str) -> bool:
+        """Return True if the systemd unit is in an active state."""
+        result = self._run("systemctl", "is-active", self._unit_name(slot_name), check=False)
+        return result.returncode == 0
+
+
+# ── Module-level singleton (matches lemonade_provider() pattern) ─────────────
+
+_container_provider: ContainerProvider | None = None
+
+
+def container_provider() -> ContainerProvider:
+    """Return the process-wide ContainerProvider singleton."""
+    global _container_provider
+    if _container_provider is None:
+        _container_provider = ContainerProvider()
+    return _container_provider
+
+
+__all__ = ["ContainerProvider", "container_provider"]

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1,9 +1,11 @@
-"""Slot lifecycle manager (v0.2 — Lemonade-only).
+"""Slot lifecycle manager (v0.2 — Lemonade + Container hybrid).
 
 SlotManager owns every aspect of slot lifecycle: load, unload, swap,
 status, restart, create, delete. It dispatches every state-changing
 call through :class:`LemonadeProvider` (PR-10 retired the legacy
-docker/systemd path; ADR-0008 §1 makes Lemonade the sole backend).
+docker/systemd path; ADR-0008 §1 makes Lemonade the sole backend) OR
+through :class:`ContainerProvider` when a slot has ``profile`` set or
+``runtime="container"`` (P1 container-runtime tracer bullet, issue #655).
 
 State transitions are persisted atomically to
 ``/var/lib/hal0/slots/<name>/state.json`` (see :mod:`hal0.slots.state`).
@@ -225,12 +227,17 @@ class SlotManager:
         idle_after_s: float = _IDLE_AFTER_S,
         idle_monitor_interval_s: float = _IDLE_MONITOR_INTERVAL_S,
         event_bus: Any | None = None,
+        upstreams_registry: Any | None = None,
     ) -> None:
         # Optional EventBus for footer/dashboard observability. Not part
         # of the slot state machine — purely a side-channel so the
         # dashboard footer can render transitions without polling. None
         # in CLI / unit-test contexts; wired by the FastAPI lifespan.
         self._event_bus = event_bus
+        # Live UpstreamRegistry injected by the API lifespan so ContainerProvider
+        # slots can auto-register/deregister kind="remote" entries at load/unload
+        # time.  None in test contexts (container upstream wiring is skipped).
+        self._upstreams_registry = upstreams_registry
         # Per-slot locks to prevent concurrent load/unload/restart races.
         self._locks: dict[str, asyncio.Lock] = {}
         # In-memory copy of the latest state per slot (mirrors state.json).
@@ -268,6 +275,56 @@ class SlotManager:
         self._idle_monitor_task: asyncio.Task[None] | None = None
 
     # ── helpers ──────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _is_container_slot(cfg: Any) -> bool:
+        """True when this slot should dispatch through ContainerProvider.
+
+        A slot is a container slot when it has ``profile`` set (non-empty)
+        OR when ``runtime="container"`` is explicit.  The ``profile`` field
+        is the primary signal (design doc §3): setting a profile implicitly
+        means "container runtime".
+        """
+        d = _cfg_to_dict(cfg)
+        if d.get("profile"):
+            return True
+        return str(d.get("runtime", "lemonade")) == "container"
+
+    def _register_container_upstream(self, slot_name: str, port: int) -> None:
+        """Add a kind="remote" upstream for a container slot's loopback port.
+
+        Idempotent via upsert — if the slot was already registered (e.g. a
+        restart), the entry is refreshed with the current port.
+        """
+        if self._upstreams_registry is None:
+            log.debug(
+                "container.upstream_registry_unavailable",
+                extra={"slot": slot_name},
+            )
+            return
+        from hal0.upstreams.registry import Upstream
+
+        upstream = Upstream(
+            name=slot_name,
+            kind="remote",
+            url=f"http://127.0.0.1:{port}/v1",
+            auth_style="none",
+            warmup_strategy="none",
+            advertise_models=True,
+        )
+        self._upstreams_registry.upsert(upstream)
+        log.info(
+            "container.upstream_registered",
+            extra={"slot": slot_name, "url": upstream.url},
+        )
+
+    def _deregister_container_upstream(self, slot_name: str) -> None:
+        """Remove the kind="remote" upstream for a container slot."""
+        if self._upstreams_registry is None:
+            return
+        removed = self._upstreams_registry.remove(slot_name)
+        if removed:
+            log.info("container.upstream_deregistered", extra={"slot": slot_name})
 
     def _lock(self, name: str) -> asyncio.Lock:
         if name not in self._locks:
@@ -578,17 +635,24 @@ class SlotManager:
             raise
 
     async def _is_active(self, slot_name: str) -> bool:
-        """Lemonade-mode "is the slot live" probe.
+        """Is the slot live? Routes to container or Lemonade probe.
 
-        v0.2 (ADR-0008 §1/§6): there is no per-slot systemd unit; the
-        question "is the slot active?" maps to "does the slot's
-        configured model appear in lemond's ``/v1/health.loaded[]``?".
-        Probe errors are coerced to ``False`` so ``status()``'s drift
-        reconciler runs (and re-loads on the next request).
+        Container slots: systemctl is-active (synchronous, runs in executor).
+        Lemonade slots: model in lemond's loaded[].
+        Probe errors are coerced to False so status()'s drift reconciler runs.
         """
         cfg = await self._maybe_load_config(slot_name)
         if not cfg:
             return False
+
+        if self._is_container_slot(cfg):
+            from hal0.providers.container import container_provider
+
+            return await asyncio.get_event_loop().run_in_executor(
+                None, container_provider().is_active, slot_name
+            )
+
+        # Lemonade path.
         model_name = _model_default(cfg)
         if not model_name:
             return False
@@ -1256,24 +1320,16 @@ class SlotManager:
     ) -> None:
         """Spawn body — caller already holds the per-slot lock.
 
-        v0.2 (ADR-0008 §1/§6): every slot dispatches through
-        :meth:`LemonadeProvider.load`. The per-slot systemd template
-        ``hal0-slot@.service`` retired in PR-9; the lemond daemon owns
-        process lifecycle and ``/v1/load`` is the single control-plane
-        entry point.
+        Routes to :class:`ContainerProvider` when the slot has ``profile``
+        set (or ``runtime="container"``); otherwise dispatches through
+        :class:`LemonadeProvider` as in v0.2.
 
         ``model_id`` (when set) overrides the slot config's
-        ``model.default`` for swap semantics —
-        :meth:`LemonadeProvider.load` resolves ``model.default`` itself,
-        so we synthesise a transient override on the cfg dict.
+        ``model.default`` for swap semantics.
 
-        Any :class:`LemonadeError` subclass is wrapped as
-        :class:`SlotSpawnFailed` so the caller's ``except Exception ->
-        ERROR`` branch in :meth:`load` records a stable error envelope.
+        Any exception is let through as-is; the calling ``load()``
+        ``except Exception -> ERROR`` branch records a stable error envelope.
         """
-        from hal0.lemonade.errors import LemonadeError
-        from hal0.providers import lemonade_provider
-
         model_info = await self._resolve_model_info(model_id)
 
         cfg = _cfg_to_dict(slot_cfg)
@@ -1281,6 +1337,22 @@ class SlotManager:
             existing_model = cfg.get("model")
             base_model = existing_model if isinstance(existing_model, dict) else {}
             cfg = {**cfg, "model": {**base_model, "default": model_id}}
+
+        if self._is_container_slot(cfg):
+            # Container path: write + start the podman systemd unit.
+            from hal0.providers.container import container_provider
+
+            port = int(cfg.get("port", 0))
+            await asyncio.get_event_loop().run_in_executor(
+                None, container_provider().load_sync, cfg, model_info
+            )
+            # Register loopback upstream so the dispatcher can route to this slot.
+            self._register_container_upstream(slot_name, port)
+            return
+
+        # Lemonade path (v0.2 default).
+        from hal0.lemonade.errors import LemonadeError
+        from hal0.providers import lemonade_provider
 
         try:
             await lemonade_provider().load(cfg, model_info)
@@ -1316,9 +1388,6 @@ class SlotManager:
         ``/v1/unload`` is synchronous and the first ``_is_active``
         check succeeds.
         """
-        from hal0.lemonade.errors import LemonadeError
-        from hal0.providers import lemonade_provider
-
         cfg = await self._maybe_load_config(slot_name)
         # Resilient to the slot config being missing — terminate should
         # never fail just because someone deleted the TOML between load
@@ -1326,6 +1395,20 @@ class SlotManager:
         # no-model-to-unload branch fires.
         if cfg is None:
             cfg = {"name": slot_name}
+
+        if self._is_container_slot(cfg):
+            # Container path: stop the systemd unit + deregister upstream.
+            from hal0.providers.container import container_provider
+
+            await asyncio.get_event_loop().run_in_executor(
+                None, container_provider().unload_sync, _cfg_to_dict(cfg)
+            )
+            self._deregister_container_upstream(slot_name)
+            return
+
+        # Lemonade path.
+        from hal0.lemonade.errors import LemonadeError
+        from hal0.providers import lemonade_provider
 
         try:
             await lemonade_provider().unload(cfg)
@@ -2034,36 +2117,40 @@ class SlotManager:
     # ── health probe (TIER1 tightened) ───────────────────────────────────────
 
     async def _await_ready(self, slot_name: str, port: int, provider: str) -> SlotState:
-        """Resolve the slot's final readiness state after a Lemonade load.
+        """Resolve the slot's final readiness state after spawning.
 
-        v0.2 (ADR-0008 §1/§6): ``_spawn_locked`` calls Lemonade's
-        ``/v1/load`` which blocks until lemond has the model loaded.
-        Any failure raises before we get here. So this method only
-        answers "did the model actually end up in lemond's
-        ``loaded[]``?". A confirming :meth:`LemonadeProvider.status`
-        call separates the "loaded → READY" path from the
-        "modelless slot → IDLE" path.
+        Container slots: poll GET /health on the slot port until 200.
+        Lemonade slots: confirm the model is in lemond's loaded[].
 
-        ``port`` and ``provider`` parameters survive in the signature
-        for caller compatibility; under Lemonade neither matters
-        (lemond is on a fixed port, every slot speaks OpenAI). They're
-        accepted and ignored.
-
-        The probe is best-effort: if lemond is briefly unreachable
-        (transient daemon hiccup) we still resolve READY because
-        ``/v1/load`` already returned 2xx. Demotion to ERROR happens
-        via the fail watcher's next tick if the model genuinely isn't
-        loaded.
+        ``port`` and ``provider`` are used for the container path;
+        the Lemonade path resolves both from the running daemon.
 
         Returns:
-            SlotState.READY when the model is in ``/v1/health.loaded[]``.
+            SlotState.READY when the model is loaded and serving.
             SlotState.IDLE when the slot has no model assigned (modelless).
         """
-        del port, provider  # accepted for signature compatibility only
-
         cfg = await self._maybe_load_config(slot_name)
         if not cfg:
             return SlotState.READY  # nothing more to verify
+
+        if self._is_container_slot(cfg):
+            # Container path: wait for /health 200 on the container port.
+            slot_port = port or int(_cfg_to_dict(cfg).get("port", 0))
+            from hal0.providers.container import container_provider
+
+            try:
+                await container_provider().wait_ready(slot_port)
+                return SlotState.READY
+            except TimeoutError as exc:
+                log.warning(
+                    "slot.container_await_ready_timeout",
+                    extra={"slot": slot_name, "port": slot_port, "error": str(exc)},
+                )
+                # Let the fail watcher detect ongoing unhealthiness.
+                return SlotState.READY
+
+        # Lemonade path (v0.2 default).
+        del port, provider  # not used for Lemonade (daemon is on fixed port)
         model_name = _model_default(cfg)
         if not model_name:
             return SlotState.IDLE  # modelless slot
@@ -2091,36 +2178,40 @@ class SlotManager:
     # ── adoption / drift reconcile (ISSUE #30) ───────────────────────────────
 
     async def _maybe_adopt_running_slot(self, slot_name: str, cfg: dict[str, Any]) -> Slot | None:
-        """Adopt a slot whose model is live in lemond but whose state.json is stale.
+        """Adopt a slot whose model is live but whose state.json is stale.
+
+        Container slots: checks systemctl is-active (via _is_active).
+        Lemonade slots: checks model in lemond's loaded[].
 
         Returns the post-adoption Slot snapshot, or ``None`` when the
-        slot's model is not in ``/v1/health.loaded[]`` — caller falls
-        back to the on-disk record.
-
-        v0.2 (ADR-0008): drift detection collapses to "is the slot's
-        configured model in lemond's ``loaded[]``?". A slot whose
-        model was loaded out-of-band (e.g. by another hal0-api
-        instance or a manual /v1/load call) gets recognised the next
-        time the dashboard polls ``status()``.
+        slot is not running — caller falls back to the on-disk record.
         """
         port = _cfg_port(cfg)
         model_id = _model_default(cfg) or None
         if model_id is None:
-            # No model configured → nothing to adopt. Modelless slots
-            # under Lemonade resolve as IDLE via the normal status path.
+            # No model configured → nothing to adopt.
             return None
-        try:
-            from hal0.providers import lemonade_provider
 
-            snap = await lemonade_provider().status({"name": slot_name, **cfg})
-        except Exception as exc:
-            log.debug(
-                "slot.adoption_probe_skipped",
-                extra={"slot": slot_name, "error": str(exc)},
-            )
-            return None
-        if not snap.get("loaded"):
-            return None
+        if self._is_container_slot(cfg):
+            # Container adoption: use systemd is-active.
+            active = await self._is_active(slot_name)
+            if not active:
+                return None
+            # Container is running — fall through to the adopt block below.
+        else:
+            # Lemonade adoption path.
+            try:
+                from hal0.providers import lemonade_provider
+
+                snap = await lemonade_provider().status({"name": slot_name, **cfg})
+            except Exception as exc:
+                log.debug(
+                    "slot.adoption_probe_skipped",
+                    extra={"slot": slot_name, "error": str(exc)},
+                )
+                return None
+            if not snap.get("loaded"):
+                return None
 
         resolved = SlotState.READY
         extras: dict[str, Any] = {

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -1,0 +1,435 @@
+"""Unit tests for ``hal0.providers.container.ContainerProvider``.
+
+Issue #655 — tracer bullet: ContainerProvider unit-render + control-plane.
+
+Covers:
+  * _render_unit produces the expected podman ExecStart (flags merged from
+    profile, identical-path /mnt/ai-models:ro mount, loopback port publish,
+    numeric GIDs, apparmor/seccomp unconfined)
+  * resolve_profile_flags MTP expansion
+  * ContainerProvider.container_spec returns a ContainerSpec with correct
+    image, command, mounts, and security opts
+  * _is_container_slot routing helper (schema.py fields)
+  * load_sync / unload_sync call the right systemctl commands (mocked)
+"""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from hal0.config.schema import MTP_FLAG_BUNDLE, ProfileConfig, resolve_profile_flags
+from hal0.providers.container import (
+    _MODEL_STORE_MOUNT,
+    ContainerProvider,
+    _render_unit,
+)
+from hal0.slots.manager import SlotManager
+
+# Use a fixed runtime bin for tests so _render_unit doesn't need podman/docker.
+_TEST_RUNTIME = "/usr/bin/docker"
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _moe_profile() -> ProfileConfig:
+    return ProfileConfig(
+        image="ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
+        flags="-fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap",
+        mtp=False,
+    )
+
+
+def _mtp_profile() -> ProfileConfig:
+    return ProfileConfig(
+        image="ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
+        flags="-fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap",
+        mtp=True,
+    )
+
+
+def _slot_cfg(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "test-container",
+        "port": 8095,
+        "profile": "moe-rocmfp4",
+        "runtime": "container",
+        "device": "gpu-rocm",
+        "model": {"default": "chadrock-35b-ace-saber-imatrix-q4_k_xl-00001-of-00002.gguf"},
+    }
+    base.update(overrides)
+    return base
+
+
+def _model_info(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "path": "/mnt/ai-models/chadrock-35b-ace-saber-imatrix-q4_k_xl-00001-of-00002.gguf",
+        "_model_key": "chadrock-35b-ace-saber",
+    }
+    base.update(overrides)
+    return base
+
+
+# ── Profile flag resolution ───────────────────────────────────────────────────
+
+
+class TestResolveProfileFlags:
+    def test_moe_profile_no_mtp(self) -> None:
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        assert "-fa on" in flags
+        assert "-ctk q8_0" in flags
+        assert "--no-mmap" in flags
+        # MTP bundle must NOT be present
+        assert "--spec-type" not in flags
+
+    def test_mtp_profile_expands_bundle(self) -> None:
+        profile = _mtp_profile()
+        flags = resolve_profile_flags(profile)
+        assert "--spec-type draft-mtp" in flags
+        assert "--spec-draft-device ROCm0" in flags
+        # Base flags are also present
+        assert "-fa on" in flags
+
+    def test_mtp_flag_bundle_constant_nonempty(self) -> None:
+        assert "--spec-type draft-mtp" in MTP_FLAG_BUNDLE
+
+
+# ── Unit rendering ────────────────────────────────────────────────────────────
+
+
+class TestRenderUnit:
+    """_render_unit produces correct podman ExecStart."""
+
+    def _get_exec_start(self, unit_text: str) -> str:
+        for line in unit_text.splitlines():
+            if line.startswith("ExecStart="):
+                return line[len("ExecStart=") :]
+        raise AssertionError("ExecStart not found in unit text")
+
+    def test_contains_container_run(self) -> None:
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        exec_start = self._get_exec_start(unit)
+        assert exec_start.startswith(f"{_TEST_RUNTIME} run")
+
+    def test_identical_path_mount_readonly(self) -> None:
+        """Model store must be mounted at /mnt/ai-models:ro (identical path)."""
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        exec_start = self._get_exec_start(unit)
+        tokens = shlex.split(exec_start)
+        # --volume arg must be present with :ro suffix
+        vol_args = [t for t in tokens if t.startswith(f"--volume={_MODEL_STORE_MOUNT}")]
+        assert vol_args, f"no --volume for {_MODEL_STORE_MOUNT} in: {tokens}"
+        assert ":ro" in vol_args[0], f"mount not read-only: {vol_args[0]}"
+
+    def test_loopback_port_publish(self) -> None:
+        """Port must be published on 127.0.0.1 only (not LAN-exposed)."""
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        exec_start = self._get_exec_start(unit)
+        assert "127.0.0.1:8095:8095" in exec_start
+
+    def test_device_passthrough(self) -> None:
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        exec_start = self._get_exec_start(unit)
+        assert "--device=/dev/kfd" in exec_start
+        assert "--device=/dev/dri" in exec_start
+
+    def test_security_opts(self) -> None:
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        exec_start = self._get_exec_start(unit)
+        assert "apparmor=unconfined" in exec_start
+        assert "seccomp=unconfined" in exec_start
+
+    def test_model_arg_in_exec_start(self) -> None:
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        model_path = "/mnt/ai-models/model.gguf"
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            model_path,
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        exec_start = self._get_exec_start(unit)
+        # llama-server uses space-separated --model PATH (not --model=PATH)
+        assert f"--model {model_path}" in exec_start
+
+    def test_profile_flags_in_exec_start(self) -> None:
+        """Bench-tuned profile flags must appear after image in ExecStart."""
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        exec_start = self._get_exec_start(unit)
+        # Key profile flags from seed moe-rocmfp4
+        assert "-fa" in exec_start
+        assert "--no-mmap" in exec_start
+        assert "-ctk" in exec_start
+
+    def test_mtp_flags_in_exec_start_when_mtp_true(self) -> None:
+        profile = _mtp_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        exec_start = self._get_exec_start(unit)
+        assert "--spec-type" in exec_start
+
+    def test_container_name_in_exec_stop(self) -> None:
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        for line in unit.splitlines():
+            if line.startswith("ExecStop="):
+                assert "hal0-slot-test-slot" in line
+                break
+        else:
+            raise AssertionError("ExecStop not found in unit")
+
+    def test_unit_has_service_section(self) -> None:
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        assert "[Unit]" in unit
+        assert "[Service]" in unit
+
+    def test_numeric_group_add_present(self) -> None:
+        """group-add must use numeric GIDs (toolbox images lack group names)."""
+        from hal0.providers._gpu import resolve_gpu_group_ids
+
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        exec_start = self._get_exec_start(unit)
+        gids = resolve_gpu_group_ids()
+        for gid in gids:
+            assert f"--group-add={gid}" in exec_start, f"GID {gid} not in ExecStart: {exec_start}"
+
+
+# ── ContainerProvider.container_spec ─────────────────────────────────────────
+
+
+class TestContainerSpec:
+    def _provider(self) -> ContainerProvider:
+        return ContainerProvider()
+
+    def _build_spec(self, cfg: dict[str, Any] | None = None):
+        provider = self._provider()
+        profile = _moe_profile()
+        with patch(
+            "hal0.providers.container._resolve_profile",
+            return_value=profile,
+        ):
+            return provider.container_spec(
+                cfg or _slot_cfg(),
+                _model_info(),
+            )
+
+    def test_image_matches_profile(self) -> None:
+        spec = self._build_spec()
+        assert spec.image == _moe_profile().image
+
+    def test_model_arg_in_command(self) -> None:
+        spec = self._build_spec()
+        # llama-server uses space-separated args: --model PATH
+        # So command is [..., "--model", "/mnt/ai-models/..."]
+        assert "--model" in spec.command
+        model_idx = spec.command.index("--model")
+        model_val = spec.command[model_idx + 1] if model_idx + 1 < len(spec.command) else ""
+        assert "/mnt/ai-models/" in model_val
+
+    def test_mount_identical_path(self) -> None:
+        spec = self._build_spec()
+        mount_pairs = dict(spec.mounts)
+        assert _MODEL_STORE_MOUNT in mount_pairs
+        assert mount_pairs[_MODEL_STORE_MOUNT] == _MODEL_STORE_MOUNT
+
+    def test_devices_present(self) -> None:
+        spec = self._build_spec()
+        assert "/dev/kfd" in spec.devices
+        assert "/dev/dri" in spec.devices
+
+    def test_security_opts(self) -> None:
+        spec = self._build_spec()
+        assert "apparmor=unconfined" in spec.security_opt
+        assert "seccomp=unconfined" in spec.security_opt
+
+    def test_publish_in_extra_args(self) -> None:
+        """Loopback port publish must be in extra_args (not network_mode=host)."""
+        spec = self._build_spec()
+        publish_args = [a for a in spec.extra_args if "127.0.0.1" in a]
+        assert publish_args, f"no loopback publish in extra_args: {spec.extra_args}"
+        assert "8095" in publish_args[0]
+
+    def test_network_mode_empty(self) -> None:
+        """network_mode must be empty (not 'host') so loopback publish is used."""
+        spec = self._build_spec()
+        assert spec.network_mode == ""
+
+
+# ── _is_container_slot routing ───────────────────────────────────────────────
+
+
+class TestIsContainerSlot:
+    def test_profile_set_is_container(self) -> None:
+        cfg = {"name": "test", "port": 8095, "profile": "moe-rocmfp4"}
+        assert SlotManager._is_container_slot(cfg) is True
+
+    def test_runtime_container_is_container(self) -> None:
+        cfg = {"name": "test", "port": 8095, "runtime": "container"}
+        assert SlotManager._is_container_slot(cfg) is True
+
+    def test_default_is_lemonade(self) -> None:
+        cfg = {"name": "test", "port": 8081, "device": "gpu-rocm"}
+        assert SlotManager._is_container_slot(cfg) is False
+
+    def test_runtime_lemonade_is_not_container(self) -> None:
+        cfg = {"name": "test", "port": 8081, "runtime": "lemonade"}
+        assert SlotManager._is_container_slot(cfg) is False
+
+    def test_profile_none_not_container(self) -> None:
+        cfg = {"name": "test", "port": 8081, "profile": None}
+        assert SlotManager._is_container_slot(cfg) is False
+
+    def test_profile_empty_string_not_container(self) -> None:
+        cfg = {"name": "test", "port": 8081, "profile": ""}
+        assert SlotManager._is_container_slot(cfg) is False
+
+
+# ── load_sync / unload_sync systemd interaction ───────────────────────────────
+
+
+class TestLoadSync:
+    """Verify load_sync writes unit and calls systemctl correctly."""
+
+    def test_load_sync_calls_systemctl_restart(self, tmp_path: Path) -> None:
+        profile = _moe_profile()
+        provider = ContainerProvider()
+
+        calls_made: list[list[str]] = []
+
+        def fake_run(*args: str, check: bool = True) -> MagicMock:
+            calls_made.append(list(args))
+            m = MagicMock()
+            m.returncode = 0
+            return m
+
+        with (
+            patch("hal0.providers.container._resolve_profile", return_value=profile),
+            patch.object(provider, "_run", side_effect=fake_run),
+            patch.object(provider, "_unit_path", return_value=tmp_path / "test.service"),
+        ):
+            provider.load_sync(
+                {"name": "test-container", "port": 8095, "profile": "moe-rocmfp4"},
+                {"path": "/mnt/ai-models/model.gguf", "_model_key": "model"},
+            )
+
+        cmds = [" ".join(c) for c in calls_made]
+        assert any("daemon-reload" in c for c in cmds), f"daemon-reload not in {cmds}"
+        assert any("restart" in c for c in cmds), f"restart not in {cmds}"
+        assert (tmp_path / "test.service").exists()
+
+    def test_unload_sync_calls_stop(self, tmp_path: Path) -> None:
+        provider = ContainerProvider()
+        unit_file = tmp_path / "hal0-slot@test-container.service"
+        unit_file.write_text("[Unit]\n")
+
+        calls_made: list[list[str]] = []
+
+        def fake_run(*args: str, check: bool = True) -> MagicMock:
+            calls_made.append(list(args))
+            m = MagicMock()
+            m.returncode = 0
+            return m
+
+        with (
+            patch.object(provider, "_run", side_effect=fake_run),
+            patch.object(provider, "_unit_path", return_value=unit_file),
+        ):
+            provider.unload_sync({"name": "test-container"})
+
+        cmds = [" ".join(c) for c in calls_made]
+        assert any("stop" in c for c in cmds), f"stop not in {cmds}"
+        # Unit file must be deleted
+        assert not unit_file.exists()


### PR DESCRIPTION
## Summary

- Add `SlotConfig.runtime` + `SlotConfig.profile` fields (default lemonade — existing slots unaffected)
- New `ContainerProvider` renders a self-contained `hal0-slot@<name>.service` systemd unit (`docker run` with `/dev/kfd`+`/dev/dri` passthrough, numeric video/render GIDs, `/mnt/ai-models:ro` at identical path, loopback `--publish=127.0.0.1:<port>:<port>`)
- `SlotManager` routes slots with `profile` set (or `runtime="container"`) to `ContainerProvider`; auto-registers a `kind="remote"` upstream in the live `UpstreamRegistry` so the dispatcher proxies traffic — no dispatcher code change needed
- 29 unit tests + live CT105 smoke at **49.5 tok/s** (ace-saber / moe-rocmfp4, port 8095)

## Implementation notes

- Container runtime auto-detects podman → docker (overridable via `HAL0_CONTAINER_RUNTIME`)
- llama-server requires space-separated args (`--host 0.0.0.0`, not `--host=0.0.0.0`) — caught in live smoke
- `UpstreamRegistry` injected into `SlotManager` via new `upstreams_registry` param (mirrors `pull_runner` injection pattern); `upsert` on load / `remove` on unload
- Lemonade slots are 100% unaffected — all five branch sites (`_spawn_locked`, `terminate`, `_await_ready`, `_is_active`, `_maybe_adopt_running_slot`) gated on `_is_container_slot(cfg)`

## Test plan

- [x] `pytest tests/providers/test_container.py` — 29 passed
- [x] `ruff check` + `ruff format` — clean on src/ and tests/
- [x] Live CT105 smoke: ace-saber answers `/v1/chat/completions` at **49.5 tok/s** (container direct on port 8095)
- [ ] Deploy to CT105 via `make deploy` + load a container slot end-to-end through hal0-api dispatcher (P2 migration task)

Closes #655
Parent: #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)