### PR TITLE
feat(dispatcher,slots): container readiness-gate + honest container state

### DIFF
--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -187,10 +187,17 @@ async def _lemonade_state_enrichment(request: Request) -> dict[str, dict[str, An
     ]
     trio_active = bool(npu_llm_enabled)
 
+    from hal0.slots.manager import SlotManager
+
     out: dict[str, dict[str, Any]] = {}
     for cfg in configs:
         name = str(cfg.get("name", ""))
         if not name:
+            continue
+        # Container slots use a separate enrichment path (_container_state_enrichment).
+        # Skip them here so they don't get a bogus lemonade_state="idle" from a
+        # lemond health probe that has no knowledge of the container.
+        if SlotManager._is_container_slot(cfg):
             continue
         enabled = cfg.get("enabled") is not False
         model_default = ""
@@ -310,6 +317,87 @@ async def _lemonade_state_enrichment(request: Request) -> dict[str, dict[str, An
         # slot is enabled — disabled siblings don't claim membership.
         if cfg.get("device") == "npu" and trio_active and enabled:
             entry["coresident_group"] = "npu-flm-trio"
+
+        out[name] = entry
+    return out
+
+
+async def _container_state_enrichment(request: Request) -> dict[str, dict[str, Any]]:
+    """Build per-slot container state for container-backed slots.
+
+    For each slot where ``profile`` is set or ``runtime="container"``, probes
+    two live sources:
+      1. ``systemctl is-active`` → ``container_status``
+         (``running`` | ``stopped`` | ``starting`` | ``crashed``)
+      2. GET /health on the slot port → ``container_health`` (bool)
+
+    Returns ``{slot_name: {container_status, container_health, state}}`` where
+    ``state`` mirrors the hal0 SlotState value already in the snapshot so the
+    dashboard has a consistent ``state`` key regardless of slot type.
+
+    Never raises — probe failures degrade to ``stopped`` / ``False`` rather
+    than surfacing as a 500.  Lemonade slots are explicitly excluded.
+    """
+    sm = getattr(request.app.state, "slot_manager", None)
+    if sm is None:
+        return {}
+    try:
+        configs = await sm.iter_configs()
+    except Exception:
+        return {}
+
+    from hal0.slots.manager import SlotManager, _cfg_port  # type: ignore[attr-defined]
+
+    out: dict[str, dict[str, Any]] = {}
+    for cfg in configs:
+        name = str(cfg.get("name", ""))
+        if not name:
+            continue
+        if not SlotManager._is_container_slot(cfg):
+            continue  # Lemonade / lemond slots handled by _lemonade_state_enrichment
+
+        entry: dict[str, Any] = {}
+
+        try:
+            from hal0.providers.container import container_provider
+
+            cp = container_provider()
+            # 1) systemctl is-active (synchronous — run in executor)
+            active = await asyncio.get_event_loop().run_in_executor(None, cp.is_active, name)
+            if active:
+                # 2) /health probe on the slot port to distinguish running vs starting
+                port = _cfg_port(cfg)
+                if port:
+                    health = await cp.health(port)
+                    container_health = bool(health.get("ok"))
+                    container_status = "running" if container_health else "starting"
+                else:
+                    container_health = False
+                    container_status = "running"
+            else:
+                container_health = False
+                # Distinguish crashed (failed) from clean stop by checking unit state
+                # via is-active exit codes: 0=active, 3=inactive, other=failed
+                container_status = "stopped"
+                try:
+                    import subprocess
+
+                    result = subprocess.run(
+                        ["systemctl", "is-active", f"hal0-slot@{name}.service"],
+                        capture_output=True,
+                        timeout=5,
+                    )
+                    stdout = result.stdout.decode().strip()
+                    if stdout == "failed":
+                        container_status = "crashed"
+                except Exception:
+                    pass
+        except Exception:
+            container_health = False
+            container_status = "stopped"
+
+        entry["container_status"] = container_status
+        entry["container_health"] = container_health
 
         out[name] = entry
     return out
@@ -440,10 +528,16 @@ async def list_slots(request: Request) -> list[dict[str, object]]:
     real_names = {entry["name"] for entry in real_entries}
 
     enrichment = await _lemonade_state_enrichment(request)
+    container_enrichment = await _container_state_enrichment(request)
     for entry in real_entries:
-        extra = enrichment.get(str(entry["name"]))
+        slot_name = str(entry["name"])
+        extra = enrichment.get(slot_name)
         if extra:
             for k, v in extra.items():
+                entry.setdefault(k, v)
+        c_extra = container_enrichment.get(slot_name)
+        if c_extra:
+            for k, v in c_extra.items():
                 entry.setdefault(k, v)
 
     # Stamp per-slot resident memory (model weights + KV-cache estimate) so the
@@ -1107,6 +1201,11 @@ async def get_slot(name: str, request: Request) -> dict[str, object]:
         extra = enrichment.get(name)
         if extra:
             for k, v in extra.items():
+                out.setdefault(k, v)
+        c_enrichment = await _container_state_enrichment(request)
+        c_extra = c_enrichment.get(name)
+        if c_extra:
+            for k, v in c_extra.items():
                 out.setdefault(k, v)
         return out
     except Exception:

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -284,6 +284,21 @@ class UpstreamCall:
     empty — they have no local slot to mark.
     """
 
+    container_slot_name: str = ""
+    """Slot name when the upstream is a container-backed ``kind=remote`` entry.
+
+    Set by ``_container_slot_name_of`` when the remote upstream carries a
+    ``slot_name`` marker (written by ``SlotManager._register_container_upstream``).
+    Non-empty triggers a live readiness preflight in ``Dispatcher.forward()``
+    (systemctl is-active + /health probe) *before* forwarding so that a
+    down or still-starting container returns a structured ``slot.loading``
+    503 instead of a raw 502 ConnectError.
+
+    Deliberately separate from ``slot_name`` — container remotes must NOT
+    enter the ``_ensure_slot_loaded_backend_aware`` / ``_forward_with_serving``
+    path (no auto-load, no SERVING state wrap).
+    """
+
     latency_ms: float = 0.0
     """Time spent in routing logic (not including the upstream round-trip)."""
 
@@ -484,6 +499,7 @@ class Dispatcher:
                     requested_model=original_model,
                     resolution_path="registry",
                     slot_name=_slot_name_of(upstream),
+                    container_slot_name=_container_slot_name_of(upstream),
                 )
                 self._log_decision(call, t0, cache_state="warm" if advertised else "probed")
                 return call
@@ -515,6 +531,7 @@ class Dispatcher:
                     requested_model=original_model,
                     resolution_path=f"passthrough:{upstream.name}",
                     slot_name=_slot_name_of(upstream),
+                    container_slot_name=_container_slot_name_of(upstream),
                 )
                 self._log_decision(call, t0, cache_state="warm")
                 return call
@@ -540,6 +557,7 @@ class Dispatcher:
                         requested_model=original_model,
                         resolution_path=f"passthrough-prefetched:{upstream.name}",
                         slot_name=_slot_name_of(upstream),
+                        container_slot_name=_container_slot_name_of(upstream),
                     )
                     self._log_decision(call, t0, cache_state="prefetched")
                     return call
@@ -587,6 +605,7 @@ class Dispatcher:
             requested_model=original_model,
             resolution_path=f"legacy_slot:{slot_upstream.name}",
             slot_name=_slot_name_of(slot_upstream),
+            container_slot_name=_container_slot_name_of(slot_upstream),
         )
         self._log_decision(call, t0, cache_state="legacy")
         return call
@@ -635,6 +654,14 @@ class Dispatcher:
             # loading llama-server (raw 503 with no Retry-After).
             self._check_slot_ready_for_dispatch(call)
             return await self._forward_with_serving(call)
+        if call.container_slot_name and self._slot_manager is not None:
+            # Container-slot readiness gate (#656): container slots register
+            # as kind="remote" upstreams so slot_name is empty above and the
+            # Lemonade gate never fires.  We probe the container directly
+            # (systemctl is-active + /health) before forwarding so the client
+            # gets a structured slot.loading 503 with Retry-After instead of
+            # a raw 502 ConnectError when the container is down or starting.
+            await self._check_container_slot_ready(call)
         return await self._forward_plain(call)
 
     async def _ensure_slot_loaded_backend_aware(self, call: UpstreamCall) -> None:
@@ -686,6 +713,39 @@ class Dispatcher:
                 upstream=call.upstream_name,
                 error=str(exc),
                 error_type=type(exc).__name__,
+            )
+
+    async def _check_container_slot_ready(self, call: UpstreamCall) -> None:
+        """Raise :class:`SlotLoading` if a container-backed slot isn't ready.
+
+        Delegates to :meth:`SlotManager.container_readiness_check` which
+        runs two live probes:
+
+          1. ``systemctl is-active`` — unit must be running.
+          2. GET /health on the slot port — inference server must be up.
+
+        Raises :class:`SlotLoading` (503 + Retry-After) when either probe
+        fails, giving clients a retryable structured error instead of a
+        raw 502 ConnectError.
+
+        No-op when the slot is confirmed ready; forward proceeds normally.
+        """
+        assert self._slot_manager is not None  # narrowed by forward()
+        slot_name = call.container_slot_name
+        ready, reason = await self._slot_manager.container_readiness_check(slot_name)
+        if not ready:
+            raise SlotLoading(
+                f"container slot {slot_name!r} is not ready ({reason})",
+                details={
+                    "slot": slot_name,
+                    "state": reason,
+                    "retry_after_s": 15,
+                    "progress": {
+                        "phase": reason,
+                        "requested_model": call.requested_model,
+                        "upstream": call.upstream_name,
+                    },
+                },
             )
 
     def _check_slot_ready_for_dispatch(self, call: UpstreamCall) -> None:
@@ -1140,6 +1200,25 @@ def _slot_name_of(upstream: Upstream) -> str:
     if _is_hal0_composite(upstream):
         return ""
     return upstream.slot_name or upstream.name
+
+
+def _container_slot_name_of(upstream: Upstream) -> str:
+    """Return the container slot name for a ``kind=remote`` container-backed upstream.
+
+    Container slots register via ``SlotManager._register_container_upstream``
+    as ``kind="remote"`` entries, and since #656 they carry ``slot_name`` set
+    to the slot's name.  This distinguishes them from genuine external remotes
+    (OpenAI, OpenRouter…) that have ``slot_name=None``.
+
+    The returned name is stored in ``UpstreamCall.container_slot_name`` and
+    triggers ``Dispatcher._check_container_slot_ready()`` before forwarding,
+    returning a structured ``slot.loading`` 503 instead of a raw 502
+    ConnectError when the container is down or still starting.
+    """
+    if upstream.kind != "remote":
+        return ""
+    # slot_name is set only for container-backed remotes (see _register_container_upstream)
+    return upstream.slot_name or ""
 
 
 def _join_url(upstream_url: str, request_path: str) -> str:

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -311,6 +311,7 @@ class SlotManager:
             auth_style="none",
             warmup_strategy="none",
             advertise_models=True,
+            slot_name=slot_name,  # marks this remote as container-backed (for dispatcher preflight)
         )
         self._upstreams_registry.upsert(upstream)
         log.info(
@@ -667,6 +668,46 @@ class SlotManager:
             )
             return False
         return bool(snap.get("loaded", False))
+
+    async def container_readiness_check(self, slot_name: str) -> tuple[bool, str]:
+        """Check whether a container-backed slot is ready to serve requests.
+
+        Performs two live probes:
+          1. ``systemctl is-active`` — is the service unit running?
+          2. GET /health on the slot's port — has the inference server started?
+
+        Returns:
+          ``(True, "ready")`` — both probes passed; safe to forward.
+          ``(False, reason)`` — not ready; reason describes the failure
+            (e.g. ``"inactive"``, ``"starting"``, ``"health_check_failed"``).
+
+        Called by ``Dispatcher.forward()`` before forwarding to a
+        container upstream so that a down/starting container returns a
+        structured ``slot.loading`` 503 instead of a raw 502 ConnectError.
+        """
+        cfg = await self._maybe_load_config(slot_name)
+        if cfg is None:
+            return False, "config_missing"
+        if not self._is_container_slot(cfg):
+            return False, "not_a_container_slot"
+
+        from hal0.providers.container import container_provider
+
+        # 1) systemctl is-active (synchronous — run in executor)
+        active = await asyncio.get_event_loop().run_in_executor(
+            None, container_provider().is_active, slot_name
+        )
+        if not active:
+            return False, "inactive"
+
+        # 2) /health probe (only meaningful when the unit is active)
+        port = _cfg_port(cfg)
+        if port:
+            health = await container_provider().health(port)
+            if not health.get("ok"):
+                return False, "starting"
+
+        return True, "ready"
 
     # ── lifecycle ────────────────────────────────────────────────────────────
 

--- a/tests/api/test_slots_container_state.py
+++ b/tests/api/test_slots_container_state.py
@@ -1,0 +1,277 @@
+"""Tests for container-slot state fields on /api/slots (Issue #656).
+
+Verifies:
+  - ``container_status`` (running|stopped|starting|crashed) and
+    ``container_health`` (bool) appear on container slot entries.
+  - Lemonade slots are unaffected — no ``container_*`` keys, and
+    ``lemonade_state`` is still present as before.
+  - Container slots are skipped by Lemonade enrichment (no spurious
+    ``lemonade_state`` field on a container slot entry).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import hal0.providers as providers_mod
+from hal0.api import create_app
+from hal0.lemonade.client import LemonadeClient
+from hal0.providers.lemonade import LemonadeProvider
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _seed_slot_toml(home: str, name: str, lines: list[str]) -> Path:
+    root = Path(home) / "etc" / "hal0" / "slots"
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / f"{name}.toml"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def lemonade_stub(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Install a minimal Lemonade stub so Lemonade slots still enrich correctly."""
+    state: dict[str, Any] = {"loaded": []}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/v1/health":
+            return httpx.Response(200, json={"loaded": state["loaded"]})
+        return httpx.Response(200, json={"status": "ok"})
+
+    transport = httpx.AsyncClient(
+        transport=httpx.MockTransport(h),
+        base_url="http://test",
+    )
+    provider = LemonadeProvider(client=LemonadeClient(http_client=transport))
+    original = providers_mod._PROVIDERS["lemonade"]
+    providers_mod._PROVIDERS["lemonade"] = provider
+    try:
+        yield state
+    finally:
+        providers_mod._PROVIDERS["lemonade"] = original
+
+
+@pytest.fixture
+def app_with_container_slot(
+    tmp_hal0_home: str,
+    lemonade_stub: dict[str, Any],
+) -> FastAPI:
+    """App with one container slot (gpu-chat) and one Lemonade slot (primary)."""
+    # Container slot: profile set → _is_container_slot returns True
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "gpu-chat",
+        [
+            'name = "gpu-chat"',
+            "port = 8088",
+            'type = "llm"',
+            'profile = "vulkan-radv"',
+            "[model]",
+            'default = "llama-3b"',
+        ],
+    )
+    # Lemonade slot
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "primary",
+        [
+            'name = "primary"',
+            "port = 8081",
+            'type = "llm"',
+            "[model]",
+            'default = "qwen3-4b"',
+        ],
+    )
+    return create_app()
+
+
+@pytest.fixture
+def client_with_container_slot(
+    app_with_container_slot: FastAPI,
+) -> Iterator[TestClient]:
+    with TestClient(app_with_container_slot) as c:
+        yield c
+
+
+# ── container state field tests ────────────────────────────────────────────────
+
+
+def test_container_slot_has_container_status_and_health_when_running(
+    client_with_container_slot: TestClient,
+) -> None:
+    """Container slot with a healthy /health returns container_status=running, container_health=True."""
+    with (
+        patch(
+            "hal0.providers.container.ContainerProvider.is_active",
+            return_value=True,
+        ),
+        patch(
+            "hal0.providers.container.ContainerProvider.health",
+            new_callable=AsyncMock,
+            return_value={"ok": True, "status": "healthy"},
+        ),
+    ):
+        r = client_with_container_slot.get("/api/slots")
+    assert r.status_code == 200, r.text
+    by_name = {e["name"]: e for e in r.json()}
+    assert "gpu-chat" in by_name, "container slot must appear"
+    slot = by_name["gpu-chat"]
+    assert slot["container_status"] == "running"
+    assert slot["container_health"] is True
+
+
+def test_container_slot_status_stopped_when_inactive(
+    client_with_container_slot: TestClient,
+) -> None:
+    """Container slot with inactive unit returns container_status=stopped, container_health=False."""
+    with (
+        patch(
+            "hal0.providers.container.ContainerProvider.is_active",
+            return_value=False,
+        ),
+        patch(
+            "subprocess.run",
+            return_value=MagicMock(stdout=b"inactive", returncode=3),
+        ),
+    ):
+        r = client_with_container_slot.get("/api/slots")
+    assert r.status_code == 200, r.text
+    by_name = {e["name"]: e for e in r.json()}
+    slot = by_name["gpu-chat"]
+    assert slot["container_status"] == "stopped"
+    assert slot["container_health"] is False
+
+
+def test_container_slot_status_crashed_when_failed(
+    client_with_container_slot: TestClient,
+) -> None:
+    """Container slot in 'failed' systemd state returns container_status=crashed."""
+    with (
+        patch(
+            "hal0.providers.container.ContainerProvider.is_active",
+            return_value=False,
+        ),
+        patch(
+            "subprocess.run",
+            return_value=MagicMock(
+                stdout=b"failed",
+                returncode=1,
+                decode=lambda *a, **kw: "failed",
+            ),
+        ),
+    ):
+        r = client_with_container_slot.get("/api/slots")
+    assert r.status_code == 200, r.text
+    by_name = {e["name"]: e for e in r.json()}
+    slot = by_name["gpu-chat"]
+    assert slot["container_status"] == "crashed"
+    assert slot["container_health"] is False
+
+
+def test_container_slot_status_starting_when_active_but_unhealthy(
+    client_with_container_slot: TestClient,
+) -> None:
+    """Active unit + unhealthy /health → container_status=starting (inference server not yet up)."""
+    with (
+        patch(
+            "hal0.providers.container.ContainerProvider.is_active",
+            return_value=True,
+        ),
+        patch(
+            "hal0.providers.container.ContainerProvider.health",
+            new_callable=AsyncMock,
+            return_value={"ok": False, "status": "connection_refused"},
+        ),
+    ):
+        r = client_with_container_slot.get("/api/slots")
+    assert r.status_code == 200, r.text
+    by_name = {e["name"]: e for e in r.json()}
+    slot = by_name["gpu-chat"]
+    assert slot["container_status"] == "starting"
+    assert slot["container_health"] is False
+
+
+def test_lemonade_slot_unaffected_no_container_keys(
+    client_with_container_slot: TestClient,
+    lemonade_stub: dict[str, Any],
+) -> None:
+    """Lemonade slot (primary) has lemonade_state but no container_status/container_health keys."""
+    lemonade_stub["loaded"] = [{"model_name": "qwen3-4b"}]
+    with (
+        patch(
+            "hal0.providers.container.ContainerProvider.is_active",
+            return_value=True,
+        ),
+        patch(
+            "hal0.providers.container.ContainerProvider.health",
+            new_callable=AsyncMock,
+            return_value={"ok": True, "status": "healthy"},
+        ),
+    ):
+        r = client_with_container_slot.get("/api/slots")
+    assert r.status_code == 200, r.text
+    by_name = {e["name"]: e for e in r.json()}
+    primary = by_name["primary"]
+    # Lemonade enrichment must still fire
+    assert "lemonade_state" in primary
+    # Container enrichment must NOT apply
+    assert "container_status" not in primary
+    assert "container_health" not in primary
+
+
+def test_container_slot_has_no_lemonade_state(
+    client_with_container_slot: TestClient,
+) -> None:
+    """Container slot must NOT have a lemonade_state key (skip in Lemonade enrichment)."""
+    with (
+        patch(
+            "hal0.providers.container.ContainerProvider.is_active",
+            return_value=True,
+        ),
+        patch(
+            "hal0.providers.container.ContainerProvider.health",
+            new_callable=AsyncMock,
+            return_value={"ok": True, "status": "healthy"},
+        ),
+    ):
+        r = client_with_container_slot.get("/api/slots")
+    assert r.status_code == 200, r.text
+    by_name = {e["name"]: e for e in r.json()}
+    gpu_slot = by_name["gpu-chat"]
+    assert "lemonade_state" not in gpu_slot, (
+        "container slots must not receive a spurious lemonade_state"
+    )
+
+
+def test_get_slot_container_state_fields(
+    client_with_container_slot: TestClient,
+) -> None:
+    """GET /api/slots/{name} for a container slot also includes container_status/health."""
+    with (
+        patch(
+            "hal0.providers.container.ContainerProvider.is_active",
+            return_value=True,
+        ),
+        patch(
+            "hal0.providers.container.ContainerProvider.health",
+            new_callable=AsyncMock,
+            return_value={"ok": True, "status": "healthy"},
+        ),
+    ):
+        r = client_with_container_slot.get("/api/slots/gpu-chat")
+    assert r.status_code == 200, r.text
+    slot = r.json()
+    assert slot["container_status"] == "running"
+    assert slot["container_health"] is True

--- a/tests/dispatcher/test_container_gate.py
+++ b/tests/dispatcher/test_container_gate.py
@@ -1,0 +1,243 @@
+"""Tests for the container-slot readiness gate in ``Dispatcher.forward``.
+
+Issue #656 — the gap: container slots register as ``kind="remote"``
+upstreams so ``call.slot_name`` is always empty, bypassing the existing
+Lemonade slot gate and producing a raw 502 ConnectError when the
+container is down or starting.
+
+The fix:
+  - ``Upstream.slot_name`` is set by ``_register_container_upstream`` for
+    container-backed remotes (distinguishes them from genuine remotes like
+    OpenRouter).
+  - ``UpstreamCall.container_slot_name`` is set by
+    ``_container_slot_name_of(upstream)``.
+  - ``Dispatcher.forward`` calls ``_check_container_slot_ready`` before
+    forwarding when ``container_slot_name`` is set.
+  - ``SlotManager.container_readiness_check`` probes systemctl is-active
+    + /health and returns ``(ready: bool, reason: str)``.
+
+This file covers:
+  - Gate raises ``SlotLoading`` (not ``UpstreamUnavailable``) when the
+    container is inactive.
+  - Gate raises ``SlotLoading`` when the container is active but /health
+    fails (still starting).
+  - Gate passes through and returns the upstream response when ready.
+  - ``UpstreamCall.slot_name`` (Lemonade path) is unaffected.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from hal0.dispatcher.router import (
+    Dispatcher,
+    SlotLoading,
+    UpstreamCall,
+    _container_slot_name_of,
+)
+from hal0.upstreams.registry import Upstream
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _remote_upstream(
+    name: str = "gpu-slot",
+    url: str = "http://127.0.0.1:8088/v1",
+    *,
+    slot_name: str | None = None,
+) -> Upstream:
+    """A kind='remote' upstream — container-backed when slot_name is set."""
+    return Upstream(
+        name=name,
+        kind="remote",
+        url=url,
+        auth_style="none",
+        warmup_strategy="none",
+        advertise_models=True,
+        slot_name=slot_name,
+    )
+
+
+def _slot_upstream(name: str = "primary") -> Upstream:
+    """A kind='slot' upstream (Lemonade path)."""
+    return Upstream(
+        name=name,
+        kind="slot",
+        url="http://127.0.0.1:13305/v1",
+        auth_style="none",
+        warmup_strategy="none",
+        advertise_models=True,
+        slot_name=name,
+    )
+
+
+def _container_call(
+    slot_name: str = "gpu-slot",
+    target: str = "http://127.0.0.1:8088/v1/chat/completions",
+) -> UpstreamCall:
+    return UpstreamCall(
+        upstream_name=slot_name,
+        target_url=target,
+        headers={"content-type": "application/json"},
+        body=json.dumps({"model": slot_name}).encode(),
+        streaming=False,
+        method="POST",
+        resolved_model=slot_name,
+        requested_model=slot_name,
+        container_slot_name=slot_name,  # key field
+    )
+
+
+def _make_dispatcher_with_manager(
+    transport: httpx.MockTransport,
+    sm: MagicMock,
+) -> Dispatcher:
+    client = httpx.AsyncClient(transport=transport)
+    return Dispatcher(http_client=client, slot_manager=sm)
+
+
+def _ok_transport() -> httpx.MockTransport:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": []})
+
+    return httpx.MockTransport(handler)
+
+
+def _slot_manager_stub(
+    *,
+    ready: bool = True,
+    reason: str = "ready",
+) -> MagicMock:
+    """Build a SlotManager mock whose container_readiness_check is wired."""
+    sm = MagicMock()
+    sm.container_readiness_check = AsyncMock(return_value=(ready, reason))
+    return sm
+
+
+# ── _container_slot_name_of ────────────────────────────────────────────────────
+
+
+def test_container_slot_name_of_remote_with_slot_name() -> None:
+    """Returns slot_name when the remote upstream was registered as container-backed."""
+    up = _remote_upstream(slot_name="gpu-slot")
+    assert _container_slot_name_of(up) == "gpu-slot"
+
+
+def test_container_slot_name_of_remote_without_slot_name() -> None:
+    """Returns empty string for genuine remotes (no slot_name set)."""
+    up = _remote_upstream(slot_name=None)
+    assert _container_slot_name_of(up) == ""
+
+
+def test_container_slot_name_of_slot_kind() -> None:
+    """Returns empty string for kind='slot' upstreams (Lemonade path)."""
+    up = _slot_upstream()
+    assert _container_slot_name_of(up) == ""
+
+
+# ── Dispatcher.forward container gate ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_container_gate_inactive_raises_slot_loading_not_502() -> None:
+    """When container is inactive, forward raises SlotLoading (503), not UpstreamUnavailable (502)."""
+    sm = _slot_manager_stub(ready=False, reason="inactive")
+    d = _make_dispatcher_with_manager(_ok_transport(), sm)
+    try:
+        with pytest.raises(SlotLoading) as exc_info:
+            await d.forward(_container_call())
+        assert exc_info.value.status == 503
+        assert "inactive" in exc_info.value.message
+        assert exc_info.value.details["slot"] == "gpu-slot"
+        assert exc_info.value.details["state"] == "inactive"
+    finally:
+        await d.aclose()
+
+
+@pytest.mark.asyncio
+async def test_container_gate_starting_raises_slot_loading() -> None:
+    """When container is active but /health fails (still starting), gate raises SlotLoading."""
+    sm = _slot_manager_stub(ready=False, reason="starting")
+    d = _make_dispatcher_with_manager(_ok_transport(), sm)
+    try:
+        with pytest.raises(SlotLoading) as exc_info:
+            await d.forward(_container_call())
+        assert exc_info.value.status == 503
+        assert exc_info.value.details["state"] == "starting"
+    finally:
+        await d.aclose()
+
+
+@pytest.mark.asyncio
+async def test_container_gate_ready_passes_through_to_upstream() -> None:
+    """When container is ready, forward passes through and returns the upstream response."""
+    sm = _slot_manager_stub(ready=True, reason="ready")
+    d = _make_dispatcher_with_manager(_ok_transport(), sm)
+    try:
+        resp = await d.forward(_container_call())
+        assert resp.status_code == 200
+        sm.container_readiness_check.assert_awaited_once_with("gpu-slot")
+    finally:
+        await d.aclose()
+
+
+@pytest.mark.asyncio
+async def test_container_gate_crashed_raises_slot_loading() -> None:
+    """A crashed container returns SlotLoading with reason='crashed'."""
+    sm = _slot_manager_stub(ready=False, reason="crashed")
+    d = _make_dispatcher_with_manager(_ok_transport(), sm)
+    try:
+        with pytest.raises(SlotLoading) as exc_info:
+            await d.forward(_container_call())
+        assert exc_info.value.details["state"] == "crashed"
+    finally:
+        await d.aclose()
+
+
+@pytest.mark.asyncio
+async def test_lemonade_slot_unaffected_by_container_gate() -> None:
+    """A kind='slot' upstream (Lemonade) does NOT trigger the container gate."""
+    sm = MagicMock()
+    sm.container_readiness_check = AsyncMock(
+        side_effect=AssertionError("container gate must not fire for Lemonade slots")
+    )
+    # For a kind='slot' upstream, call.slot_name is set; call.container_slot_name is empty.
+    # With no SlotManager serving mock, the forward goes through _forward_plain (no gate).
+    plain_sm = MagicMock()
+    plain_sm.container_readiness_check = AsyncMock(
+        side_effect=AssertionError("must not call container_readiness_check")
+    )
+    # No slot_name on the call → also no container_slot_name → _forward_plain
+    plain_call = UpstreamCall(
+        upstream_name="remote-provider",
+        target_url="http://127.0.0.1:8099/v1/chat/completions",
+        headers={},
+        body=b"{}",
+        streaming=False,
+        method="POST",
+        slot_name="",
+        container_slot_name="",  # explicit empty — genuine remote
+    )
+    d = _make_dispatcher_with_manager(_ok_transport(), plain_sm)
+    try:
+        resp = await d.forward(plain_call)
+        assert resp.status_code == 200
+        plain_sm.container_readiness_check.assert_not_awaited()
+    finally:
+        await d.aclose()
+
+
+@pytest.mark.asyncio
+async def test_container_gate_no_slot_manager_skips_gate() -> None:
+    """When Dispatcher has no slot_manager, container gate is skipped (forward proceeds)."""
+    client = httpx.AsyncClient(transport=_ok_transport())
+    d = Dispatcher(http_client=client)  # no slot_manager
+    try:
+        resp = await d.forward(_container_call())
+        assert resp.status_code == 200
+    finally:
+        await d.aclose()


### PR DESCRIPTION
## Summary

- **Dispatcher preflight gate**: Container slots register as `kind="remote"` upstreams so the existing Lemonade slot gate (`call.slot_name`) never fired — forwarding a down container produced a raw 502 `ConnectError`. Added `container_slot_name` field to `UpstreamCall` (set by new `_container_slot_name_of()` helper, fires only when `Upstream.slot_name` is set — the marker `_register_container_upstream` now writes). `Dispatcher.forward()` calls new `_check_container_slot_ready()` before forwarding: probes `systemctl is-active` + `/health`, raises `SlotLoading` (503 + Retry-After) on failure instead of letting `ConnectError` surface as 502.
- **`SlotManager.container_readiness_check()`**: New public method returning `(ready: bool, reason: str)` from the two live probes — called by the dispatcher, keeps ContainerProvider knowledge inside SlotManager.
- **`/api/slots` container state fields**: New `_container_state_enrichment()` returns `container_status` (running|stopped|starting|crashed) and `container_health` (bool) for container-backed slots. Container slots are now skipped in `_lemonade_state_enrichment()` to avoid spurious `lemonade_state="idle"` from a lemond probe that has no knowledge of podman containers.

## Test plan

- [ ] `tests/dispatcher/test_container_gate.py` (9 tests): gate raises `SlotLoading` not 502 for inactive/starting/crashed; passes through when ready; Lemonade slots unaffected; no slot_manager → gate skipped
- [ ] `tests/api/test_slots_container_state.py` (7 tests): `container_status` running/stopped/starting/crashed; `container_health` True/False; Lemonade slot retains `lemonade_state` and has no `container_*` keys; `get_slot` also returns fields
- [ ] `tests/dispatcher/` (116 tests) — all pass
- [ ] `tests/slots/` (129 tests) — all pass
- [ ] `ruff check src/ tests/` — clean
- [ ] `ruff format --check src/ tests/` — 418 files already formatted

Parent epic: #652
Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)