### PR TITLE
fix(tests): main red — container-state fixtures use renamed chat slot (#665×#667)

### DIFF
--- a/tests/api/test_slots_container_state.py
+++ b/tests/api/test_slots_container_state.py
@@ -68,7 +68,7 @@ def app_with_container_slot(
     tmp_hal0_home: str,
     lemonade_stub: dict[str, Any],
 ) -> FastAPI:
-    """App with one container slot (gpu-chat) and one Lemonade slot (primary)."""
+    """App with one container slot (gpu-chat) and one Lemonade slot (chat)."""
     # Container slot: profile set → _is_container_slot returns True
     _seed_slot_toml(
         tmp_hal0_home,
@@ -85,9 +85,9 @@ def app_with_container_slot(
     # Lemonade slot
     _seed_slot_toml(
         tmp_hal0_home,
-        "primary",
+        "chat",
         [
-            'name = "primary"',
+            'name = "chat"',
             "port = 8081",
             'type = "llm"',
             "[model]",
@@ -207,7 +207,7 @@ def test_lemonade_slot_unaffected_no_container_keys(
     client_with_container_slot: TestClient,
     lemonade_stub: dict[str, Any],
 ) -> None:
-    """Lemonade slot (primary) has lemonade_state but no container_status/container_health keys."""
+    """Lemonade slot (chat) has lemonade_state but no container_status/container_health keys."""
     lemonade_stub["loaded"] = [{"model_name": "qwen3-4b"}]
     with (
         patch(
@@ -223,7 +223,7 @@ def test_lemonade_slot_unaffected_no_container_keys(
         r = client_with_container_slot.get("/api/slots")
     assert r.status_code == 200, r.text
     by_name = {e["name"]: e for e in r.json()}
-    primary = by_name["primary"]
+    primary = by_name["chat"]
     # Lemonade enrichment must still fire
     assert "lemonade_state" in primary
     # Container enrichment must NOT apply


### PR DESCRIPTION
main is RED (7 fails in tests/api/test_slots_container_state.py) — semantic conflict between #667 (added the tests, seeded `primary`) and #665 (renamed primary→chat + composite needs a real `chat` slot). Fixture now seeds `chat`; all 7 pass locally, no source change. Unblocks the #652 epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)