### PR TITLE
fix(providers): production-correct container slots under podman (GPU devices + ctx_size + extra_args)

### DIFF
--- a/src/hal0/providers/_gpu.py
+++ b/src/hal0/providers/_gpu.py
@@ -11,9 +11,51 @@ GIDs once and pass them through.
 
 from __future__ import annotations
 
+import os
+import stat
+
 import structlog
 
 log = structlog.get_logger(__name__)
+
+
+def resolve_gpu_device_paths(
+    kfd_path: str = "/dev/kfd",
+    dri_dir: str = "/dev/dri",
+) -> list[str]:
+    """Return explicit GPU device-node paths to pass via ``--device=``.
+
+    Docker recurses a ``--device=/dev/dri`` *directory* and adds every node
+    under it; podman does not, and errors ``no devices found in /dev/dri`` on
+    hosts whose /dev/dri holds non-standard nodes (e.g. an ``amdgpu`` node and
+    no ``card0``). So we enumerate the actual character devices and pass each
+    one explicitly — which is correct for docker too.
+
+    Includes ``kfd_path`` when it exists, then every character device directly
+    under ``dri_dir`` (sorted). Subdirectories (``by-path``) and regular files
+    are skipped.
+
+    Falls back to the legacy directory paths ``["/dev/kfd", "/dev/dri"]`` when
+    neither exists (CI / no-GPU dev box) so unit rendering stays deterministic
+    off-GPU; no container actually runs there.
+    """
+    paths: list[str] = []
+    if os.path.exists(kfd_path):
+        paths.append(kfd_path)
+    try:
+        entries = sorted(os.listdir(dri_dir))
+    except OSError:
+        entries = []
+    for name in entries:
+        node = os.path.join(dri_dir, name)
+        try:
+            if stat.S_ISCHR(os.stat(node).st_mode):
+                paths.append(node)
+        except OSError:
+            continue
+    if not paths:
+        return ["/dev/kfd", "/dev/dri"]
+    return paths
 
 
 def resolve_gpu_group_ids() -> list[int]:
@@ -38,4 +80,4 @@ def resolve_gpu_group_ids() -> list[int]:
     return gids
 
 
-__all__ = ["resolve_gpu_group_ids"]
+__all__ = ["resolve_gpu_device_paths", "resolve_gpu_group_ids"]

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -127,6 +127,8 @@ def _render_unit(
     flags_str: str,
     runtime_bin: str | None = None,
     device_paths: list[str] | None = None,
+    context_size: int | None = None,
+    extra_args: str | None = None,
 ) -> str:
     """Render a complete (non-drop-in) systemd unit for a container slot.
 
@@ -141,12 +143,19 @@ def _render_unit(
     ``device_paths``: explicit GPU device nodes to pass via ``--device=``
     (default: auto-detect via :func:`resolve_gpu_device_paths`). Podman cannot
     recurse a ``--device=/dev/dri`` directory, so we pass each node explicitly.
+
+    ``context_size``: slot context window → ``--ctx-size``.  Without it the
+    container boots at llama-server's 4096 default regardless of the slot TOML.
+
+    ``extra_args``: ``[server].extra_args`` passthrough, appended after the
+    profile flags so slot-level overrides win.
     """
     runtime = runtime_bin or _container_runtime()
     devices = device_paths if device_paths is not None else resolve_gpu_device_paths()
     container_name = f"hal0-slot-{slot_name}"
     # Split the profile flags string into tokens for ExecStart quoting.
     flag_tokens = shlex.split(flags_str) if flags_str.strip() else []
+    extra_tokens = shlex.split(extra_args) if extra_args and extra_args.strip() else []
 
     # Build the container run argv list.
     argv: list[str] = [
@@ -179,8 +188,12 @@ def _render_unit(
             model_path,
         ]
     )
-    # Append bench-tuned profile flags.
+    # Slot context window (else llama-server defaults to 4096).
+    if context_size is not None:
+        argv.extend(["--ctx-size", str(context_size)])
+    # Append bench-tuned profile flags, then [server].extra_args (slot wins).
     argv.extend(flag_tokens)
+    argv.extend(extra_tokens)
 
     # ExecStart is a single long line; systemd accepts bare argv tokens.
     exec_start = " ".join(shlex.quote(a) if " " in a else a for a in argv)
@@ -348,8 +361,21 @@ class ContainerProvider(Provider):
         flags_str = resolve_profile_flags(profile)
         model_path = _resolve_model_path(model_info)
 
+        model_table = slot_cfg.get("model") or {}
+        context_size = model_table.get("context_size") if isinstance(model_table, dict) else None
+        server_table = slot_cfg.get("server") or {}
+        extra_args = server_table.get("extra_args") if isinstance(server_table, dict) else None
+
         unit_path = self._unit_path(slot_name)
-        unit_text = _render_unit(slot_name, profile.image, port, model_path, flags_str)
+        unit_text = _render_unit(
+            slot_name,
+            profile.image,
+            port,
+            model_path,
+            flags_str,
+            context_size=context_size,
+            extra_args=extra_args,
+        )
 
         log.info(
             "container.unit_write",
@@ -538,6 +564,10 @@ def resolved_command_for_slot(
         model_table.get("default", "") if isinstance(model_table, dict) else str(model_table)
     )
     effective_model = model_path or str(default_model or "")
+    context_size = model_table.get("context_size") if isinstance(model_table, dict) else None
+    server_table = slot_cfg.get("server") or {}
+    extra_args = server_table.get("extra_args") if isinstance(server_table, dict) else None
+    extra_tokens = shlex.split(extra_args) if extra_args and extra_args.strip() else []
 
     argv: list[str] = [
         profile.image,
@@ -548,7 +578,10 @@ def resolved_command_for_slot(
     ]
     if effective_model:
         argv += ["--model", effective_model]
+    if context_size is not None:
+        argv += ["--ctx-size", str(context_size)]
     argv.extend(flag_tokens)
+    argv.extend(extra_tokens)
     return argv
 
 

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -47,7 +47,7 @@ import httpx
 
 from hal0.config.loader import load_profiles_config
 from hal0.config.schema import ProfileConfig, resolve_profile_flags
-from hal0.providers._gpu import resolve_gpu_group_ids
+from hal0.providers._gpu import resolve_gpu_device_paths, resolve_gpu_group_ids
 from hal0.providers.base import ContainerSpec, Provider
 
 log = logging.getLogger(__name__)
@@ -126,6 +126,7 @@ def _render_unit(
     model_path: str,
     flags_str: str,
     runtime_bin: str | None = None,
+    device_paths: list[str] | None = None,
 ) -> str:
     """Render a complete (non-drop-in) systemd unit for a container slot.
 
@@ -136,8 +137,13 @@ def _render_unit(
     ``runtime_bin``: override the container runtime binary (default: auto-detect
     via :func:`_container_runtime`).  Pass explicitly in tests to avoid
     depending on podman/docker being installed in the test environment.
+
+    ``device_paths``: explicit GPU device nodes to pass via ``--device=``
+    (default: auto-detect via :func:`resolve_gpu_device_paths`). Podman cannot
+    recurse a ``--device=/dev/dri`` directory, so we pass each node explicitly.
     """
     runtime = runtime_bin or _container_runtime()
+    devices = device_paths if device_paths is not None else resolve_gpu_device_paths()
     container_name = f"hal0-slot-{slot_name}"
     # Split the profile flags string into tokens for ExecStart quoting.
     flag_tokens = shlex.split(flags_str) if flags_str.strip() else []
@@ -148,9 +154,10 @@ def _render_unit(
         "run",
         "--rm",
         f"--name={container_name}",
-        "--device=/dev/kfd",
-        "--device=/dev/dri",
     ]
+    # Explicit GPU device nodes (podman won't recurse the /dev/dri directory).
+    for dev in devices:
+        argv.append(f"--device={dev}")
     # Numeric GIDs for video+render groups (ubuntu:24.04 has no group names).
     for gid in resolve_gpu_group_ids():
         argv.append(f"--group-add={gid}")
@@ -272,7 +279,7 @@ class ContainerProvider(Provider):
                 *flag_tokens,
             ],
             mounts=[(_MODEL_STORE_MOUNT, _MODEL_STORE_MOUNT)],
-            devices=["/dev/kfd", "/dev/dri"],
+            devices=resolve_gpu_device_paths(),
             group_add=[str(g) for g in resolve_gpu_group_ids()],
             security_opt=["apparmor=unconfined", "seccomp=unconfined"],
             port=port,

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -158,6 +158,31 @@ class TestRenderUnit:
         assert "127.0.0.1:8095:8095" in exec_start
 
     def test_device_passthrough(self) -> None:
+        """Default device source is resolve_gpu_device_paths(); each node is
+        passed explicitly via --device=, never the bare /dev/dri directory."""
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        with patch(
+            "hal0.providers.container.resolve_gpu_device_paths",
+            return_value=["/dev/kfd", "/dev/dri/renderD128"],
+        ):
+            unit = _render_unit(
+                "test-slot",
+                profile.image,
+                8095,
+                "/mnt/ai-models/model.gguf",
+                flags,
+                runtime_bin=_TEST_RUNTIME,
+            )
+        exec_start = self._get_exec_start(unit)
+        tokens = shlex.split(exec_start)
+        assert "--device=/dev/kfd" in tokens
+        assert "--device=/dev/dri/renderD128" in tokens
+        assert "--device=/dev/dri" not in tokens
+
+    def test_explicit_device_nodes_emitted_no_bare_dri_dir(self) -> None:
+        """With explicit device_paths, the unit passes each node verbatim and
+        never the bare /dev/dri directory (which podman cannot recurse)."""
         profile = _moe_profile()
         flags = resolve_profile_flags(profile)
         unit = _render_unit(
@@ -167,10 +192,13 @@ class TestRenderUnit:
             "/mnt/ai-models/model.gguf",
             flags,
             runtime_bin=_TEST_RUNTIME,
+            device_paths=["/dev/kfd", "/dev/dri/renderD128"],
         )
         exec_start = self._get_exec_start(unit)
-        assert "--device=/dev/kfd" in exec_start
-        assert "--device=/dev/dri" in exec_start
+        tokens = shlex.split(exec_start)
+        assert "--device=/dev/kfd" in tokens
+        assert "--device=/dev/dri/renderD128" in tokens
+        assert "--device=/dev/dri" not in tokens
 
     def test_security_opts(self) -> None:
         profile = _moe_profile()
@@ -326,9 +354,12 @@ class TestContainerSpec:
         assert mount_pairs[_MODEL_STORE_MOUNT] == _MODEL_STORE_MOUNT
 
     def test_devices_present(self) -> None:
-        spec = self._build_spec()
-        assert "/dev/kfd" in spec.devices
-        assert "/dev/dri" in spec.devices
+        with patch(
+            "hal0.providers.container.resolve_gpu_device_paths",
+            return_value=["/dev/kfd", "/dev/dri/renderD128"],
+        ):
+            spec = self._build_spec()
+        assert spec.devices == ["/dev/kfd", "/dev/dri/renderD128"]
 
     def test_security_opts(self) -> None:
         spec = self._build_spec()

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -25,6 +25,7 @@ from hal0.providers.container import (
     _MODEL_STORE_MOUNT,
     ContainerProvider,
     _render_unit,
+    resolved_command_for_slot,
 )
 from hal0.slots.manager import SlotManager
 
@@ -199,6 +200,44 @@ class TestRenderUnit:
         assert "--device=/dev/kfd" in tokens
         assert "--device=/dev/dri/renderD128" in tokens
         assert "--device=/dev/dri" not in tokens
+
+    def test_ctx_size_in_exec_start(self) -> None:
+        """The slot's context_size must reach the container as --ctx-size,
+        else llama-server boots at its 4096 default (severe ctx regression)."""
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+            device_paths=["/dev/kfd", "/dev/dri/renderD128"],
+            context_size=131072,
+        )
+        tokens = shlex.split(self._get_exec_start(unit))
+        assert "--ctx-size" in tokens
+        assert tokens[tokens.index("--ctx-size") + 1] == "131072"
+
+    def test_server_extra_args_appended(self) -> None:
+        """[server].extra_args is honored on the container path (override/legacy),
+        appended after profile flags so slot-level flags win."""
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+            device_paths=["/dev/kfd", "/dev/dri/renderD128"],
+            extra_args="--override-kv tokenizer.ggml.add_bos=bool:false",
+        )
+        tokens = shlex.split(self._get_exec_start(unit))
+        assert "--override-kv" in tokens
+        assert "tokenizer.ggml.add_bos=bool:false" in tokens
 
     def test_security_opts(self) -> None:
         profile = _moe_profile()
@@ -440,6 +479,57 @@ class TestLoadSync:
         assert any("daemon-reload" in c for c in cmds), f"daemon-reload not in {cmds}"
         assert any("restart" in c for c in cmds), f"restart not in {cmds}"
         assert (tmp_path / "test.service").exists()
+
+    def test_load_sync_threads_ctx_size_and_extra_args(self, tmp_path: Path) -> None:
+        """load_sync must pull context_size + [server].extra_args off the slot
+        cfg and bake them into the rendered unit."""
+        profile = _moe_profile()
+        provider = ContainerProvider()
+        unit_file = tmp_path / "test.service"
+
+        def fake_run(*args: str, check: bool = True) -> MagicMock:
+            m = MagicMock()
+            m.returncode = 0
+            return m
+
+        with (
+            patch("hal0.providers.container._resolve_profile", return_value=profile),
+            patch(
+                "hal0.providers.container.resolve_gpu_device_paths",
+                return_value=["/dev/kfd", "/dev/dri/renderD128"],
+            ),
+            patch.object(provider, "_run", side_effect=fake_run),
+            patch.object(provider, "_unit_path", return_value=unit_file),
+        ):
+            provider.load_sync(
+                {
+                    "name": "test-container",
+                    "port": 8095,
+                    "profile": "moe-rocmfp4",
+                    "model": {"default": "model", "context_size": 131072},
+                    "server": {"extra_args": "--override-kv k=bool:false"},
+                },
+                {"path": "/mnt/ai-models/model.gguf", "_model_key": "model"},
+            )
+
+        unit = unit_file.read_text()
+        assert "--ctx-size 131072" in unit
+        assert "--override-kv k=bool:false" in unit
+
+    def test_resolved_command_includes_ctx_size(self) -> None:
+        """The displayed resolved_command must show --ctx-size so it matches
+        what actually launches."""
+        profile = _moe_profile()
+        cfg = {
+            "profile": "moe-rocmfp4",
+            "port": 8095,
+            "model": {"default": "m", "context_size": 131072},
+        }
+        with patch("hal0.providers.container._resolve_profile", return_value=profile):
+            argv = resolved_command_for_slot(cfg, model_path="/mnt/ai-models/m.gguf")
+        assert argv is not None
+        assert "--ctx-size" in argv
+        assert argv[argv.index("--ctx-size") + 1] == "131072"
 
     def test_unload_sync_calls_stop(self, tmp_path: Path) -> None:
         provider = ContainerProvider()

--- a/tests/providers/test_gpu.py
+++ b/tests/providers/test_gpu.py
@@ -1,0 +1,61 @@
+"""Tests for GPU device-path resolution (podman/docker passthrough).
+
+Podman cannot recurse a ``--device=/dev/dri`` *directory* the way docker
+does (it errors ``no devices found in /dev/dri`` on hosts whose /dev/dri
+holds non-standard nodes and no ``card0``). The provider must therefore
+pass *explicit* device nodes (``/dev/dri/renderD128`` …). These tests
+drive that enumeration.
+
+Real char devices are needed to exercise the ``S_ISCHR`` filter; creating
+one needs root (mknod), so we symlink to ``/dev/null`` — a real character
+device — which keeps the tests hermetic and root-free.
+"""
+
+from __future__ import annotations
+
+from hal0.providers._gpu import resolve_gpu_device_paths
+
+
+class TestResolveGpuDevicePaths:
+    def test_enumerates_explicit_dri_nodes_not_the_directory(self, tmp_path) -> None:
+        """Char-device nodes under /dev/dri are listed explicitly; the bare
+        directory is never passed (that is what breaks podman)."""
+        dri = tmp_path / "dri"
+        dri.mkdir()
+        (dri / "renderD128").symlink_to("/dev/null")  # real char device
+        (dri / "amdgpu").symlink_to("/dev/null")
+        (dri / "by-path").mkdir()  # subdir — must be excluded
+        (dri / "README").write_text("not a device")  # regular file — excluded
+        kfd = tmp_path / "kfd"
+        kfd.symlink_to("/dev/null")
+
+        paths = resolve_gpu_device_paths(kfd_path=str(kfd), dri_dir=str(dri))
+
+        assert str(kfd) in paths
+        assert str(dri / "renderD128") in paths
+        assert str(dri / "amdgpu") in paths
+        assert str(dri / "by-path") not in paths
+        assert str(dri / "README") not in paths
+        # The directory itself must NOT be emitted — the whole point of the fix.
+        assert str(dri) not in paths
+
+    def test_kfd_included_only_when_present(self, tmp_path) -> None:
+        dri = tmp_path / "dri"
+        dri.mkdir()
+        (dri / "renderD128").symlink_to("/dev/null")
+        missing_kfd = tmp_path / "no-kfd"
+
+        paths = resolve_gpu_device_paths(kfd_path=str(missing_kfd), dri_dir=str(dri))
+
+        assert str(missing_kfd) not in paths
+        assert str(dri / "renderD128") in paths
+
+    def test_falls_back_to_legacy_dirs_on_non_gpu_host(self, tmp_path) -> None:
+        """When neither /dev/kfd nor /dev/dri exist (CI / no-GPU dev box),
+        return the legacy directory paths so unit rendering stays
+        deterministic — no container actually runs there."""
+        paths = resolve_gpu_device_paths(
+            kfd_path=str(tmp_path / "kfd"),
+            dri_dir=str(tmp_path / "dri"),
+        )
+        assert paths == ["/dev/kfd", "/dev/dri"]


### PR DESCRIPTION
## Why

Live-cutover prep for the container-runtime epic (#652, cutover #662). Two latent bugs in the merged container path block running real GPU slots under **podman** (the design's intended runtime) at the bench-tuned config. Found while standing up podman on CT105.

## Fixes

### 1. Explicit GPU device nodes (podman can't recurse `/dev/dri`)
Podman errors `no devices found in /dev/dri` where docker silently recurses the directory — CT105's `/dev/dri` holds an `amdgpu` node + `renderD128` and **no `card0`**, so every container slot fails to start under podman. New `resolve_gpu_device_paths()` enumerates `/dev/kfd` + each char device under `/dev/dri` and passes them explicitly (correct for docker too; faithful to docker's prior whole-dir passthrough). Falls back to legacy dir paths off-GPU so CI rendering stays deterministic.

### 2. `context_size` + `[server].extra_args` were dropped
`load_sync` passed only `--host/--port/--model` + profile flags, so `context_size=131072` in a slot TOML was **silently ignored** — llama-server booted at its 4096 default. Severe regression for the agent/chat slots whose purpose is 131k. `schema.py:260` lists these as supplied ("model, context_size, and port") but they were never wired. Now `_render_unit` / `resolved_command_for_slot` emit `--ctx-size <n>` and append `extra_args` after profile flags (slot overrides win).

## Live validation (CT105, podman, ace-saber 35B MoE)
- `n_ctx = 131072` confirmed via `/props` (ctx threading works).
- **51.7 gen tok/s** at real 131k (361-tok prompt, 723 prefill) = parity with the bench (52.8 container / 53.6 baremetal).
- 19.86 GB GTT, no OOM; podman accepts the full enumerated device set.

## Note for the cutover (not in this PR)
Container cgroup `memory.current` reads **0.88 GB vs 19.86 GB real GTT** — GPU weights aren't in cgroup RSS, so the #660 `max(cgroup, file_estimate)` floor is load-bearing for GPU-slot memory attribution (confirm the dashboard reads the floored path). This is the #662 step-7 deferred item.

## Tests
TDD throughout — `tests/providers/test_gpu.py` (device enumeration, hermetic via `/dev/null` symlinks) + `test_container.py` (explicit nodes, ctx-size, extra_args, load_sync wiring, resolved_command). 233 passed; ruff clean.

Relates to #652, #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)