### PR TITLE
fix(dispatcher): container slot preempts composite registry binding (cutover routing)

### DIFF
--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -447,6 +447,33 @@ class Dispatcher:
         model_id = original_model or self._default_for_path(path)
         streaming = bool(body.get("stream"))
 
+        # ── Step 0: container-slot preemption ────────────────────────────
+        # A loaded container slot (kind="remote" + slot_name) is the
+        # authoritative server for the models it advertises. The model
+        # registry binds every registered id — including container-served
+        # models — to the synthetic composite ``hal0`` upstream, which would
+        # forward to lemonade. So a container slot MUST win over that binding,
+        # else hal0/* requests for a container-backed model route to lemonade
+        # and 404 (cutover #662). Only fires on a warm cache hit for a
+        # container remote; lemonade-only models are untouched.
+        for upstream in self._upstreams_in_priority_order():
+            if _container_slot_name_of(upstream) and model_id in self._cached_models(upstream.name):
+                call = UpstreamCall(
+                    upstream_name=upstream.name,
+                    target_url=_resolve_target_url(upstream, path),
+                    headers=self._build_headers(request, upstream),
+                    body=_remap_model(body, model_id),
+                    streaming=streaming,
+                    method=method,
+                    resolved_model=model_id,
+                    requested_model=original_model,
+                    resolution_path=f"container:{upstream.name}",
+                    slot_name=_slot_name_of(upstream),
+                    container_slot_name=_container_slot_name_of(upstream),
+                )
+                self._log_decision(call, t0, cache_state="warm")
+                return call
+
         # ── Step 1: registry lookup ──────────────────────────────────────
         registry_entry = self._registry_route_for(model_id)
         if registry_entry is not None:

--- a/tests/dispatcher/test_router.py
+++ b/tests/dispatcher/test_router.py
@@ -531,3 +531,73 @@ async def test_forward_already_loaded_skips_load_and_forwards(
     assert forwarded.get("called") is True
     # Body never carries an injected llamacpp_backend.
     assert json.loads(forwarded["body"]) == {"model": "chat"}
+
+
+# ── container-slot preemption over composite registry binding ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_container_slot_preempts_composite_registry_binding() -> None:
+    """A loaded container slot is authoritative for its advertised model.
+
+    The model registry binds every registered id (incl. container-served
+    models) to the synthetic composite ``hal0`` upstream, which forwards to
+    lemonade. When a container remote (kind="remote" + slot_name) advertises
+    the same id, it MUST win — else hal0/* requests for a container-backed
+    model get routed to lemonade and 404 (cutover #662 regression).
+    """
+    composite = Upstream(name="hal0", kind="slot", url="http://127.0.0.1:8080/v1", slot_name=None)
+    chat = Upstream(name="chat", kind="remote", url="http://127.0.0.1:8102/v1", slot_name="chat")
+    upstreams = FakeUpstreamRegistry([composite, chat])
+    # Registry binds the model to the composite (the live bug condition).
+    models = FakeModelRegistry(routes={"qwopus3.6-27b-v2": "hal0"})
+
+    async def online(_u: Upstream) -> bool:
+        return True
+
+    cache = {"hal0": ["qwopus3.6-27b-v2"], "chat": ["qwopus3.6-27b-v2"]}
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        is_online=online,
+        cached_models=lambda name: cache.get(name, []),
+    )
+
+    call = await dispatcher.dispatch(
+        make_request(),
+        body={"model": "qwopus3.6-27b-v2", "messages": []},
+    )
+
+    assert call.upstream_name == "chat"
+    assert call.container_slot_name == "chat"
+    assert call.target_url == "http://127.0.0.1:8102/v1/chat/completions"
+
+
+@pytest.mark.asyncio
+async def test_non_container_model_still_uses_registry_binding() -> None:
+    """Preemption must not disturb models no container slot serves — they
+    still resolve via the normal registry binding."""
+    composite = Upstream(name="hal0", kind="slot", url="http://127.0.0.1:8080/v1", slot_name=None)
+    chat = Upstream(name="chat", kind="remote", url="http://127.0.0.1:8102/v1", slot_name="chat")
+    upstreams = FakeUpstreamRegistry([composite, chat])
+    models = FakeModelRegistry(routes={"gemma3-4b-FLM": "hal0"})
+
+    async def online(_u: Upstream) -> bool:
+        return True
+
+    # chat container only serves qwopus; gemma is lemonade-only.
+    cache = {"hal0": ["gemma3-4b-FLM", "qwopus3.6-27b-v2"], "chat": ["qwopus3.6-27b-v2"]}
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        is_online=online,
+        cached_models=lambda name: cache.get(name, []),
+    )
+
+    call = await dispatcher.dispatch(
+        make_request(),
+        body={"model": "gemma3-4b-FLM", "messages": []},
+    )
+
+    assert call.upstream_name == "hal0"
+    assert call.resolution_path == "registry"


### PR DESCRIPTION
## Why
The final wiring gap surfaced by the #662 live cutover: **container slots never actually receive traffic.**

The model registry binds every registered id — including models served by a container slot — to the synthetic composite `hal0` upstream (which forwards to lemonade). `dispatch()` step 1 (registry lookup) resolves there and returns *before* the container remote is considered. So `hal0/chat` → `qwopus3.6-27b-v2` → composite → lemonade → 404 (lemond can't load it), even though the `chat` container on :8102 advertises the id and is healthy. Confirmed live via `/api/upstreams`: composite `hal0` and remote `chat` both advertise `qwopus3.6-27b-v2`; the composite wins.

## Fix
Add **step 0** to `dispatch()`: a loaded container remote (`kind="remote"` + `slot_name`) that advertises the requested model wins over the registry/composite binding — a running container slot is authoritative for its model. 

- Only fires on a warm cache hit for a container remote → lemonade-only models are untouched (guard test included).
- A down container still hits the existing #656 readiness gate (`slot.loading` 503) instead of silently serving from lemonade.

## Tests
TDD: `test_container_slot_preempts_composite_registry_binding` + `test_non_container_model_still_uses_registry_binding`. 304 passed; ruff clean.

Completes the container-runtime cutover routing. Relates to #652, #662. Stacked on #674 (devices/ctx) + #675 (alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)