### PR TITLE
fix(normalize): add hal0/agent virtual name to resolver chain (cutover routing)

### DIFF
--- a/src/hal0/normalize/resolver.py
+++ b/src/hal0/normalize/resolver.py
@@ -13,6 +13,9 @@ from dataclasses import dataclass
 # Canonical virtual names -> ordered chain of roles to try against loaded slots.
 DEFAULT_CHAINS: dict[str, tuple[str, ...]] = {
     "hal0/chat": ("chat",),
+    # hal0/agent → the slot named/tagged "agent" (a first-class chat role,
+    # e.g. the GPU MoE agent slot). Falls back to chat when agent is unloaded.
+    "hal0/agent": ("agent", "chat"),
     "hal0/npu": ("npu", "utility", "chat"),
     "hal0/utility": ("utility", "npu", "chat"),
 }

--- a/tests/normalize/test_resolver.py
+++ b/tests/normalize/test_resolver.py
@@ -144,3 +144,14 @@ async def test_live_resolver_hal0_primary_alias():
     res = await resolver.resolve("hal0/primary")
     assert res is not None
     assert res.model_id == "big"
+
+
+def test_agent_virtual_name_resolves_to_agent_slot():
+    """hal0/agent must resolve to the slot named 'agent' (cutover #662: the
+    GPU MoE agent slot). Without a DEFAULT_CHAINS entry the virtual name is
+    unknown → passes through unnormalized → lemonade 404."""
+    r = resolve_chain("hal0/agent", _slots(), loaded={"qwen3-4b-FLM"})
+    assert r is not None
+    assert r.matched_role == "agent"
+    assert r.model_id == "qwen3-4b-FLM"  # the 'agent'-named slot in the fixture
+    assert r.fallback is False


### PR DESCRIPTION
## Why
`hal0/agent` requests 404 while `hal0/chat` works. `DEFAULT_CHAINS` in the chat normalizer had `hal0/chat`, `hal0/npu`, `hal0/utility` — but **no `hal0/agent`**. So `resolve_chain("hal0/agent")` returns `None`, the raw `hal0/agent` passes through unnormalized, the dispatcher finds no match, and it falls through to lemonade → `model_not_found`. (`hal0/chat` works only because it's mapped.)

This is the functional tail of the `agent`-as-NPU seed grouping: `agent` was never made a first-class GPU chat role.

## Fix
Add `"hal0/agent": ("agent", "chat")`. Resolves to the slot named/tagged `agent` (the GPU MoE agent slot), falling back to `chat` when unloaded. Role match is name/role-based, so it binds the GPU agent slot regardless of the legacy NPU seed grouping.

## Tests
TDD: `test_agent_virtual_name_resolves_to_agent_slot`. 33 passed; ruff clean.

Completes `hal0/agent` routing for the cutover. Relates to #652, #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)