### PR TITLE
fix(normalize): treat ready container-slot models as loaded (cutover routing)

### DIFF
--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -282,14 +282,30 @@ async def _rewrite_chat_slot_alias(request: Request, body: dict[str, Any]) -> di
 
 
 def _normalize_loaded_models(request: Request) -> set[str]:
-    """Currently-loaded model ids from the cached health snapshot (NO new lemond poll)."""
+    """Currently-loaded model ids (cached health snapshot; NO new lemond poll).
+
+    Unions lemond's loaded set with the models advertised by ready container
+    remotes. Container slots aren't lemond-managed, so their models never show
+    in lemond's snapshot — without this the resolver chain sees no loaded role
+    for a container slot and falls back to the configured primary (cutover #662).
+    """
+    import contextlib
+
+    loaded: set[str] = set()
     shim = getattr(request.app.state, "lemonade_metrics_shim", None)
-    if shim is None:
-        return set()
-    try:
-        return set(shim._health.loaded_models)
-    except Exception:  # pragma: no cover — defensive
-        return set()
+    if shim is not None:
+        with contextlib.suppress(Exception):
+            loaded |= set(shim._health.loaded_models)
+    # Container-backed remotes (kind="remote" + slot_name) advertise their
+    # served model only while up, so their cached catalog == "loaded".
+    upstreams = getattr(request.app.state, "upstreams", None)
+    model_cache = getattr(request.app.state, "upstream_models", None)
+    if upstreams is not None and model_cache is not None:
+        with contextlib.suppress(Exception):
+            for up in upstreams.list():
+                if getattr(up, "kind", "") == "remote" and getattr(up, "slot_name", None):
+                    loaded |= set(model_cache.get(up.name, []))
+    return loaded
 
 
 async def _normalize_slot_views(request: Request) -> list:

--- a/tests/api/test_chat_normalization.py
+++ b/tests/api/test_chat_normalization.py
@@ -276,3 +276,23 @@ async def test_dispatch_and_forward_does_not_normalize_non_chat(monkeypatch):
     await v1._dispatch_and_forward(req, _FakeDispatcher(), body=body)
 
     assert called["flag"] is False, "_dispatch_and_forward must not normalize non-chat requests"
+
+
+def test_loaded_models_includes_ready_container_slots():
+    """Container slots aren't lemond-managed, so their models never appear in
+    the lemond health snapshot. The resolver chain treats a role as available
+    only when its model is 'loaded', so container-slot models must be unioned
+    in — else hal0/agent falls back to the configured primary (cutover #662)."""
+    req = _make_request(
+        loaded={"lemond-model"},
+        upstreams=[
+            SimpleNamespace(name="agent", kind="remote", slot_name="agent"),
+            SimpleNamespace(name="or", kind="remote", slot_name=None),  # real remote
+        ],
+        upstream_models={"agent": ["chadrock-35b-ace-saber"], "or": ["gpt-x"]},
+    )
+    loaded = v1._normalize_loaded_models(req)
+    assert "lemond-model" in loaded
+    assert "chadrock-35b-ace-saber" in loaded
+    # A genuine external remote (no slot_name) is NOT a local container slot.
+    assert "gpt-x" not in loaded


### PR DESCRIPTION
## Why
`hal0/agent` served the **chat** model. Root cause: `_normalize_loaded_models` built the "loaded" set from lemond's health snapshot only. Container slots aren't lemond-managed, so `chadrock-35b-ace-saber` / `qwopus3.6-27b-v2` were never "loaded" — and `resolve_chain` only matches a role whose model is loaded, so **every** `hal0/*` name fell back to the configured primary (chat). `hal0/chat` worked by coincidence; `hal0/agent` wrongly resolved to chat.

## Fix
Union lemond's loaded set with the catalogs advertised by ready container remotes (`kind="remote"` + `slot_name`). Genuine external remotes (no `slot_name`, e.g. OpenRouter) are excluded.

## Tests
TDD: `test_loaded_models_includes_ready_container_slots` (+ excludes a real remote). 45 passed; ruff clean.

Completes correct `hal0/agent` resolution. Relates to #652, #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)