### PR TITLE
fix(normalize): apply thinking policy to container slots (cutover)

### DIFF
--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -338,6 +338,10 @@ def _is_remote_model(request: Request, model_id: str) -> bool:
         return False
     try:
         for u in upstreams.list():
+            # Container-backed remotes carry a slot_name — they are LOCAL slots,
+            # not genuine external providers, so the thinking policy must apply.
+            if getattr(u, "slot_name", None):
+                continue
             if getattr(u, "kind", "") == "remote" and model_id in set(cache.get(u.name, [])):
                 return True
     except Exception:  # pragma: no cover — defensive

--- a/tests/api/test_chat_normalization.py
+++ b/tests/api/test_chat_normalization.py
@@ -296,3 +296,21 @@ def test_loaded_models_includes_ready_container_slots():
     assert "chadrock-35b-ace-saber" in loaded
     # A genuine external remote (no slot_name) is NOT a local container slot.
     assert "gpt-x" not in loaded
+
+
+def test_container_slot_not_treated_as_remote_for_thinking():
+    """Container slots register as kind='remote' (with slot_name) but are LOCAL —
+    the thinking policy must apply to them. Only genuine external remotes
+    (slot_name=None) skip thinking injection. (cutover #662: chat reasoned by
+    default because it looked remote.)"""
+    req = _make_request(
+        upstreams=[
+            SimpleNamespace(name="chat", kind="remote", slot_name="chat"),
+            SimpleNamespace(name="or", kind="remote", slot_name=None),
+        ],
+        upstream_models={"chat": ["qwopus3.6-27b-v2"], "or": ["gpt-x"]},
+    )
+    # Container-backed remote → NOT remote-for-thinking (policy should apply).
+    assert v1._is_remote_model(req, "qwopus3.6-27b-v2") is False
+    # Genuine external remote → remote (skip thinking injection).
+    assert v1._is_remote_model(req, "gpt-x") is True


### PR DESCRIPTION
## Why
The chat container reasons by default and returns empty content at low `max_tokens` (reasoning consumes the budget). Setting `enable_thinking=false` on the slot had no effect.

Root cause: `_is_remote_model` returns True for any `kind="remote"` upstream. Container slots register as `kind="remote"` (with `slot_name`), so `_normalize_chat_body` treated their models as external and **skipped thinking injection** — the per-slot `enable_thinking` default never applied.

## Fix
Skip container-backed remotes (`slot_name` set) in `_is_remote_model` — they're local slots, so the thinking policy applies. Genuine external providers (`slot_name=None`) still bypass injection.

With this, `chat.toml`'s `enable_thinking=false` takes effect (reasoning off by default, still per-request overridable).

## Tests
TDD: `test_container_slot_not_treated_as_remote_for_thinking`. 17 passed; ruff clean.

Relates to #652, #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)