### PR TITLE
fix(slots): deterministic container backend via podman inspect image tag (#663)

### DIFF
--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -425,6 +425,24 @@ async def _container_state_enrichment(request: Request) -> dict[str, dict[str, A
             entry["image"] = None
             entry["resolved_command"] = None
 
+        # #663: deterministic backend-of-record - the running container's image
+        # IS the backend. Surface actual_image (via podman inspect) and compute
+        # image_mismatch against the slot's declared profile image. Replaces the
+        # fragile /proc actual_backend sniff for container slots (lemond slots
+        # keep resolve_actual_backend). Degrades silently - never 500 the hot path.
+        try:
+            from hal0.providers.container import _image_mismatch, container_provider
+
+            running_image = await asyncio.get_event_loop().run_in_executor(
+                None, container_provider().running_image, name
+            )
+        except Exception:
+            running_image = None
+        if running_image:
+            entry["actual_image"] = running_image
+            if image:
+                entry["image_mismatch"] = _image_mismatch(running_image, image)
+
         # image_status: present | pulling | missing
         # Check the slot_pull_jobs registry first so an in-flight pull
         # surfaces as "pulling" without an extra inspect syscall.

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -446,6 +446,36 @@ class ContainerProvider(Provider):
         )
         return result.returncode == 0
 
+    def running_image(self, slot_name: str) -> str | None:
+        """Return the image ref of the running container for *slot_name* (#663).
+
+        Deterministic backend-of-record for a container slot: the running
+        backend IS the image tag. Uses ``<runtime> inspect hal0-slot-<name>
+        --format {{.ImageName}}``. Returns None when the container is not
+        running or inspect fails. Reads stdout only - podman emits benign
+        device warnings to stderr under LXC. Never raises; callers dispatch to
+        a thread executor from the async status path.
+        """
+        try:
+            runtime = _container_runtime()
+        except RuntimeError:
+            return None
+        container_name = f"hal0-slot-{slot_name}"
+        try:
+            result = subprocess.run(
+                [runtime, "inspect", container_name, "--format", "{{.ImageName}}"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if result.returncode != 0:
+            return None
+        ref = result.stdout.strip()
+        return ref or None
+
     async def pull_image_stream(self, image: str):
         """Async generator that runs ``<runtime> pull <image>`` and yields
         layer-progress dicts.
@@ -599,3 +629,18 @@ def resolved_command_for_slot(
 
 
 __all__ = ["ContainerProvider", "container_provider", "resolved_command_for_slot"]
+
+
+def _image_mismatch(running_image: str | None, declared_image: str | None) -> bool:
+    """Return True iff both image refs are known AND differ (#663).
+
+    The deterministic replacement for the /proc ``actual_backend`` sniff on
+    container slots: the running backend IS the image tag, so drift is a plain
+    ref comparison (the running container's image vs the slot profile's
+    declared image). Returns False whenever the running image can't be
+    determined (container down / inspect failed) - never cry wolf on missing
+    data, same omit-don't-guess contract as ``resolve_actual_backend``.
+    """
+    if not running_image or not declared_image:
+        return False
+    return running_image.strip() != declared_image.strip()

--- a/tests/api/test_slots_container_state.py
+++ b/tests/api/test_slots_container_state.py
@@ -401,3 +401,92 @@ def test_lemonade_slot_has_no_runtime_container_fields(
     # Lemonade slots must not inherit container enrichment fields
     assert lemond_slot.get("runtime") != "container"
     assert "resolved_command" not in lemond_slot
+
+
+# ── #663: actual_image + image_mismatch via running_image (podman inspect) ──────
+
+_VULKAN_IMG = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server"
+_ROCM_IMG = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server"
+
+
+def _fake_vulkan_catalog() -> MagicMock:
+    """Fake profiles catalog whose 'vulkan-radv' profile declares _VULKAN_IMG."""
+    from hal0.config.schema import ProfileConfig
+
+    prof = ProfileConfig(image=_VULKAN_IMG, flags="--flash-attn on", mtp=False)
+    return MagicMock(profile={"vulkan-radv": prof})
+
+
+def test_container_actual_image_no_mismatch_when_running_matches_profile(
+    client_with_container_slot: TestClient,
+) -> None:
+    """#663: running container image == profile image -> actual_image set, image_mismatch False."""
+    cat = _fake_vulkan_catalog()
+    with (
+        patch("hal0.providers.container.ContainerProvider.is_active", return_value=True),
+        patch(
+            "hal0.providers.container.ContainerProvider.health",
+            new_callable=AsyncMock,
+            return_value={"ok": True, "status": "healthy"},
+        ),
+        patch("hal0.config.loader.load_profiles_config", return_value=cat),
+        patch("hal0.providers.container.load_profiles_config", return_value=cat),
+        patch(
+            "hal0.providers.container.ContainerProvider.running_image",
+            return_value=_VULKAN_IMG,
+        ),
+    ):
+        r = client_with_container_slot.get("/api/slots")
+    assert r.status_code == 200, r.text
+    slot = {e["name"]: e for e in r.json()}["gpu-chat"]
+    assert slot["actual_image"] == _VULKAN_IMG
+    assert slot["image_mismatch"] is False
+
+
+def test_container_image_mismatch_when_running_differs_from_profile(
+    client_with_container_slot: TestClient,
+) -> None:
+    """#663: running container image != profile image -> image_mismatch True (deterministic drift)."""
+    cat = _fake_vulkan_catalog()
+    with (
+        patch("hal0.providers.container.ContainerProvider.is_active", return_value=True),
+        patch(
+            "hal0.providers.container.ContainerProvider.health",
+            new_callable=AsyncMock,
+            return_value={"ok": True, "status": "healthy"},
+        ),
+        patch("hal0.config.loader.load_profiles_config", return_value=cat),
+        patch("hal0.providers.container.load_profiles_config", return_value=cat),
+        patch(
+            "hal0.providers.container.ContainerProvider.running_image",
+            return_value=_ROCM_IMG,  # stale: still running the old rocm image
+        ),
+    ):
+        r = client_with_container_slot.get("/api/slots")
+    assert r.status_code == 200, r.text
+    slot = {e["name"]: e for e in r.json()}["gpu-chat"]
+    assert slot["actual_image"] == _ROCM_IMG
+    assert slot["image_mismatch"] is True
+
+
+def test_lemonade_slot_has_no_image_mismatch_fields(
+    client_with_container_slot: TestClient,
+) -> None:
+    """#663: lemond slots keep existing behavior - no actual_image / image_mismatch keys."""
+    with (
+        patch("hal0.providers.container.ContainerProvider.is_active", return_value=True),
+        patch(
+            "hal0.providers.container.ContainerProvider.health",
+            new_callable=AsyncMock,
+            return_value={"ok": True, "status": "healthy"},
+        ),
+        patch(
+            "hal0.providers.container.ContainerProvider.running_image",
+            return_value=_VULKAN_IMG,
+        ),
+    ):
+        r = client_with_container_slot.get("/api/slots")
+    assert r.status_code == 200, r.text
+    chat = {e["name"]: e for e in r.json()}["chat"]
+    assert "actual_image" not in chat
+    assert "image_mismatch" not in chat

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -24,6 +24,7 @@ from hal0.config.schema import MTP_FLAG_BUNDLE, ProfileConfig, resolve_profile_f
 from hal0.providers.container import (
     _MODEL_STORE_MOUNT,
     ContainerProvider,
+    _image_mismatch,
     _render_unit,
     resolved_command_for_slot,
 )
@@ -619,3 +620,32 @@ class TestLoadSync:
         assert any("stop" in c for c in cmds), f"stop not in {cmds}"
         # Unit file must be deleted
         assert not unit_file.exists()
+
+
+class TestImageMismatch:
+    """#663 - _image_mismatch compares the running image ref vs the declared profile image.
+
+    Seeded with the real refs observed live on CT105 (both agent + chat run
+    ``ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server``) so a
+    healthy slot never reports a false mismatch.
+    """
+
+    _ROCM = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server"
+    _VULKAN = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server"
+
+    def test_no_mismatch_when_running_equals_declared(self) -> None:
+        assert _image_mismatch(self._ROCM, self._ROCM) is False
+
+    def test_mismatch_when_running_differs_from_declared(self) -> None:
+        assert _image_mismatch(self._VULKAN, self._ROCM) is True
+
+    def test_no_mismatch_when_running_unknown(self) -> None:
+        # Container down / inspect failed -> never cry wolf.
+        assert _image_mismatch(None, self._ROCM) is False
+        assert _image_mismatch("", self._ROCM) is False
+
+    def test_no_mismatch_when_declared_unknown(self) -> None:
+        assert _image_mismatch(self._ROCM, None) is False
+
+    def test_whitespace_is_ignored(self) -> None:
+        assert _image_mismatch(self._ROCM + "\n", self._ROCM) is False

--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -114,6 +114,14 @@ export interface Slot {
   /** Container image availability: "present" | "pulling" | "missing".
    *  Populated by the backend when image_status is tracked. */
   image_status?: 'present' | 'pulling' | 'missing' | null
+  /** ACTUAL running container image ref, read from ``podman inspect`` by
+   *  _container_state_enrichment (#663). Omitted/null when the container is
+   *  not running or inspect fails — treat absence as "unknown". */
+  actual_image?: string | null
+  /** True iff actual_image is known AND differs from the declared profile
+   *  ``image`` (deterministic image-tag drift; replaces the /proc backend
+   *  sniff for container slots). UI renders the warning ONLY when true. */
+  image_mismatch?: boolean
   /** Container unit state: "running" | "stopped" | "starting" | "crashed".
    *  Set by _container_state_enrichment() in /api/slots. Absent for
    *  Lemonade slots. */
@@ -249,6 +257,10 @@ function normalizeSlot(s: any): Slot {
     // be omitted; null means "unknown — don't show image chip".
     image: s?.image ?? null,
     image_status: s?.image_status ?? null,
+    // #663: actual_image (podman inspect) + image_mismatch (running != declared
+    // profile image). Absent for Lemonade slots; coerce the flag to a boolean.
+    actual_image: s?.actual_image ?? null,
+    image_mismatch: !!s?.image_mismatch,
     // container_status / container_health are set by _container_state_enrichment.
     // Absent for Lemonade slots; null here keeps the type honest.
     container_status: s?.container_status ?? null,

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -398,18 +398,32 @@ function SlotCard({
             to "no image" until that lands. container_status is always present. */}
         {isContainer ? (() => {
           const imgFull = slot.image || slot.profile || null;
-          const imgShort = imgFull
-            ? imgFull.split("/").pop() // last path segment (tag after last /)
-            : null;
-          return imgShort ? (
+          const imgShort = imgFull ? imgFull.split("/").pop() : null;
+          // #663: surface running-vs-configured image drift on the container
+          // chip (the lemond backend-mismatch block below never ran for
+          // container slots). actual_image + image_mismatch come from
+          // _container_state_enrichment via `podman inspect`.
+          const imgMismatch = !!slot.image_mismatch && !!slot.actual_image;
+          const runShort = slot.actual_image ? slot.actual_image.split("/").pop() : null;
+          if (!imgShort) {
+            return (
+              <span className="chip dim" title="Image/profile not yet emitted by backend (#658)">
+                {slot.profile ? `profile:${slot.profile}` : "no image"}
+              </span>
+            );
+          }
+          return (
             <span
               className="chip slot-image-tag mono"
-              title={imgFull}
-              style={{maxWidth: 160, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap"}}
-            >{imgShort}</span>
-          ) : (
-            <span className="chip dim" title="Image/profile not yet emitted by backend (#658)">
-              {slot.profile ? `profile:${slot.profile}` : "no image"}
+              title={imgMismatch
+                ? `Configured ${imgFull} but running ${slot.actual_image} — reload the slot to apply the declared image.`
+                : imgFull}
+              style={imgMismatch
+                ? {maxWidth: 220, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", borderColor: "var(--warn-line)", background: "var(--warn-soft)"}
+                : {maxWidth: 160, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap"}}
+            >
+              {imgShort}
+              {imgMismatch && <span style={{color: "var(--warn)", marginLeft: 4}}>≠ running {runShort}</span>}
             </span>
           );
         })() : (


### PR DESCRIPTION
## What & why

Closes #663 — the last gate on epic #652.

Retire the fragile `/proc/<pid>/exe` `actual_backend` introspection for **container** slots in favour of a deterministic image-tag check: for a container slot, **the running backend IS the container image**. `_container_state_enrichment` now reports:

- `actual_image` — the running container's image ref via `podman inspect hal0-slot-<name> --format {{.ImageName}}`
- `image_mismatch` — `true` iff the running image is known AND differs from the slot profile's declared `image`

### Acceptance criteria
- [x] **No `/proc` introspection for container slots** — they were *already* excluded from the lemond enrichment that calls `resolve_actual_backend` (`slots.py` skips `_is_container_slot`), so no `/proc` sniff ever ran for them. This change is purely **additive**: container slots now get a deterministic backend-of-record + drift signal.
- [x] **`actual_image` = image tag via `podman inspect`; mismatch computed from it** (`running image != profile image`).
- [x] **lemond slots keep existing behavior** — `resolve_actual_backend` / `backend_mismatch` path untouched.

## Design note — field naming (`actual_image`/`image_mismatch`, not `actual_backend`)

The issue text says "actual_backend = image tag", but overloading the lemond `actual_backend`/`backend_mismatch` fields would have two problems:

1. `slot-modals.jsx` reads `actual_backend`/`backend_mismatch` **unconditionally** and offers a *"Pick a backend below and Apply to reload"* resolution — a lemond concept (rocm↔vulkan). Image drift on a container slot is fixed by **reloading the slot**, not switching backends; surfacing the lemond resolution UI there would be wrong.
2. The `actual_backend` TS type documents a "bare token (rocm|vulkan|cpu|flm), NOT a device/image form" invariant. An image ref violates it.

So container slots use **separate** `actual_image`/`image_mismatch` fields. The lemond token stays invariant; the modal naturally stays lemond-only.

## Dashboard

The container **image-tag chip** turns amber and renders `<tag> ≠ running <tag>` (with a "reload the slot to apply" tooltip) when `image_mismatch` is set. Lemond slots keep the existing declared/actual backend-mismatch chip unchanged.

## Tests (TDD, RED→GREEN verified both cycles)

- `tests/providers/test_container.py::TestImageMismatch` — pure `_image_mismatch` helper, **seeded with the live CT105 refs** (`…:rocm-7.2.4-rocmfp4-server`) so a healthy slot never false-positives; covers drift, unknown-running (omit, don't cry wolf), whitespace.
- `tests/api/test_slots_container_state.py` — route emits `actual_image`/`image_mismatch` (match → false, differ → true); lemond slots get neither field.

Local: **114 passed** across container/lemonade/slots suites · `ruff check` + `ruff format --check` clean · UI `vite build` + `tsc --noEmit` clean.

> ⚠️ The `podman inspect` wrapper itself is stubbed in all tests (the comparison + wiring are what's unit-tested). It is verified live post-deploy — see checklist.

## Post-merge deploy + verify (required — do NOT skip)

`deploy.sh` restarts hal0-api, which **drops the in-memory upstream registry** → container slots de-register → routing breaks until each is force-reloaded (a plain reload no-ops on a running slot):

```
ssh hal0 'cd /opt/hal0 && git checkout main && git pull && bash scripts/deploy.sh'
for s in agent chat; do
  curl -sX POST localhost:8080/api/slots/$s/unload -d '{}'
  curl -sX POST localhost:8080/api/slots/$s/load   -d '{}'
done
# 1) actual_image populated + no false mismatch:
curl -s localhost:8080/api/slots | jq '.[] | select(.runtime=="container") | {name, image, actual_image, image_mismatch}'
# 2) inference still ROUTES (not just that actual_image appears):
curl -s localhost:8080/v1/chat/completions -d '{"model":"hal0/chat","messages":[{"role":"user","content":"hi"}],"max_tokens":8}' | jq '.choices[0].message.content'
```

Expect `actual_image: "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server"`, `image_mismatch: false` for both, and a routed completion.

## Follow-ups (out of scope)
- `slot-modals.jsx` shows "actual backend: —" for container slots (pre-existing — they never had `actual_backend`). Could surface `actual_image` in the modal.
- Minor: `running_image` runs one `inspect` per container slot per `/api/slots` poll (mirrors the existing `image_present` pattern); could gate on `container_status=="running"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
