### PR TITLE
fix(config): add comfyui to _VALID_PROVIDERS + seeded-provider guard (#650)

### DIFF
--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -85,8 +85,10 @@ BACKEND_TO_DEVICE: dict[str, str] = {
 # pre-v0.2 names remain accepted so legacy slot TOMLs round-trip
 # without raising. Non-Lemonade values are deprecated and ignored by
 # SlotManager — the provider field exists only for round-trip + UI
-# label compatibility.
-_VALID_PROVIDERS = frozenset({"lemonade", "llama-server", "flm", "moonshine", "kokoro"})
+# label compatibility. ``"comfyui"`` is the exception: it is the active
+# container image-gen provider (img.toml, ADR image slots), not a
+# deprecated legacy value.
+_VALID_PROVIDERS = frozenset({"lemonade", "llama-server", "flm", "moonshine", "kokoro", "comfyui"})
 
 # Slot port range.  8080 is the hal0 API; slots get 8081-8099.
 _SLOT_PORT_MIN = 8081

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -7,6 +7,9 @@ message and the field path — these tests pin that contract.
 
 from __future__ import annotations
 
+import tomllib
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
@@ -95,7 +98,7 @@ class TestSlotConfig:
             SlotConfig(name="x", port=8081, backend=b)
 
     def test_all_valid_providers(self) -> None:
-        for p in ("llama-server", "flm", "moonshine", "kokoro"):
+        for p in ("lemonade", "llama-server", "flm", "moonshine", "kokoro", "comfyui"):
             SlotConfig(name="x", port=8081, provider=p)
 
     def test_workers_must_be_positive(self) -> None:
@@ -304,3 +307,50 @@ class TestHal0Config:
         c = Hal0Config.model_validate({"future_section": {"foo": 1}})
         # extra='allow' keeps the unknown table.
         assert c.model_dump().get("future_section") == {"foo": 1}
+
+
+_SEEDED_SLOTS_DIR = Path(__file__).resolve().parents[2] / "installer" / "etc-hal0" / "slots"
+
+
+def _declared_provider(toml_path: Path) -> str | None:
+    """Pull the provider a seeded slot TOML declares, if any.
+
+    Container slots (e.g. img.toml) hold fields at the top level; lemonade
+    slots nest them under ``[slot]``. Either placement is accepted.
+    """
+    raw = tomllib.loads(toml_path.read_text())
+    slot = raw.get("slot") if isinstance(raw.get("slot"), dict) else {}
+    return slot.get("provider", raw.get("provider"))
+
+
+class TestSeededSlotTomls:
+    """Regression guard for #650.
+
+    Every provider a seeded slot TOML declares must be in _VALID_PROVIDERS,
+    so a SlotConfig built from that provider does not spuriously fail the
+    provider validator. (img.toml declared provider="comfyui" while comfyui
+    was absent from the set.)
+
+    Scope: this checks only the *provider-constant* invariant via the real
+    validator. It deliberately does not run load_slot_config() over img.toml
+    — img is a container slot (port 8186, outside the lemonade SlotConfig
+    8081-8099 range, flat top-level shape) and is driven by a raw dict at
+    runtime, not by SlotConfig.
+    """
+
+    def test_seeded_dir_is_non_empty(self) -> None:
+        tomls = sorted(_SEEDED_SLOTS_DIR.glob("*.toml"))
+        assert tomls, f"no seeded slot TOMLs found under {_SEEDED_SLOTS_DIR}"
+
+    @pytest.mark.parametrize(
+        "toml_path",
+        sorted(_SEEDED_SLOTS_DIR.glob("*.toml")),
+        ids=lambda p: p.name,
+    )
+    def test_seeded_slot_provider_is_valid(self, toml_path: Path) -> None:
+        provider = _declared_provider(toml_path)
+        if provider is None:
+            pytest.skip(f"{toml_path.name} declares no explicit provider (defaults to lemonade)")
+        # Constructing a SlotConfig exercises the real provider validator;
+        # a dummy in-range port keeps the assertion focused on `provider`.
+        SlotConfig(name="x", port=8081, provider=provider)


### PR DESCRIPTION
## Summary
Closes #650 — `_VALID_PROVIDERS` omitted `comfyui` even though the seeded `img.toml` declares `provider = "comfyui"`, so any `SlotConfig` built from an image slot would fail the provider validator.

- Add `comfyui` to `_VALID_PROVIDERS` and update the comment (it is the **active** container image-gen provider, not a deprecated legacy value like moonshine/kokoro).
- Add `TestSeededSlotTomls`: a parametrized regression guard that reads the provider each seeded slot TOML declares (top-level **or** `[slot]`) and asserts it passes the real `SlotConfig` provider validator. Auto-covers any future seeded slot.

## Scope note (why the test does not call `load_slot_config`)
While fixing this I traced the actual load paths:
- **Start path** is `SlotManager._load_slot_config` → a raw `dict`; container slots run off that dict via `resolved_command_for_slot(dict)`, never `SlotConfig`.
- The two `config.loader.load_slot_config` callers (orchestrator port-reservation + capability read) both `try/except Exception: continue`, so img's failure is swallowed by design.
- `img.toml` declares `port = 8186` — outside the `SlotConfig` 8081–8099 range — and uses a flat top-level shape. It is a **container** slot and cannot be a valid `SlotConfig` regardless of provider; `SlotConfig` is the lemonade-slot schema.

So the correct, in-scope fix is the provider-constant invariant. The test validates exactly that via the real validator with a dummy in-range port, keeping the assertion focused on `provider`.

## Test plan
- RED verified: both new assertions fail on `comfyui` rejection before the fix.
- GREEN: `tests/config/test_schema.py` 49 passed; `tests/config` + `tests/capabilities/test_orchestrator_reconciliation.py` 241 passed.
- `ruff check` + `ruff format --check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
