### PR TITLE
fix(slots): agent is a GPU seed slot, not the NPU FLM anchor (#679)

### DIFF
--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -69,19 +69,23 @@ log = logging.getLogger(__name__)
 
 #: Slots that exist on every hal0 install regardless of hardware. The
 #: dashboard creates these as empty cards at first run; the bundle
-#: picker (Phase 5) populates their ``model.default`` fields.
-SEEDED_SLOTS: tuple[str, ...] = ("chat", "embed", "rerank", "stt", "tts", "img", "vision")
+#: picker (Phase 5) populates their ``model.default`` fields. ``agent``
+#: is the GPU MoE chat-role sibling of ``chat`` (moved here from the NPU
+#: set in #679 — it is a GPU slot, not the NPU FLM anchor).
+SEEDED_SLOTS: tuple[str, ...] = ("chat", "embed", "rerank", "stt", "tts", "img", "vision", "agent")
 
-#: NPU slots seeded only when the FastFlowLM ``.deb`` is installed
-#: (``shutil.which('flm')`` truthy). These back the AMDXDNA hardware
-#: context's trio mode — chat + ASR + embed coresident in one FLM
-#: process (ADR-0008 §5). Opt-in enabled at Pro+ bundle tier.
-NPU_SEEDED_SLOTS: tuple[str, ...] = ("agent", "stt-npu", "embed-npu")
+#: NPU FLM shadow slots seeded only when the FastFlowLM ``.deb`` is
+#: installed (``shutil.which('flm')`` truthy): the ASR + embed tags that
+#: ride the same coresident FLM process as the NPU chat anchor — which is
+#: the separate ``npu`` slot, NOT listed here. ``agent`` was previously
+#: (wrongly) in this set; it is a GPU chat-role slot and moved to
+#: SEEDED_SLOTS in #679. Opt-in at Pro+ bundle tier (ADR-0008 §5).
+NPU_SEEDED_SLOTS: tuple[str, ...] = ("stt-npu", "embed-npu")
 
 #: Back-compat alias map: old slot names → canonical new names.
 #: Aliases resolve transparently for dispatch and config lookup but are
 #: NEVER stored on disk and NEVER appear in list() / iter_configs() /
-#: /api/slots. ``agent-hermes`` maps to ``agent`` (already NPU-seeded)
+#: /api/slots. ``agent-hermes`` maps to ``agent`` (a GPU seed slot, #679)
 #: so no new TOML is created — the alias just redirects old references.
 SLOT_ALIASES: dict[str, str] = {
     "primary": "chat",

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -60,11 +60,12 @@ def test_seeded_slots_matches_plan_section_10_2() -> None:
     # ``vision`` added in #515 (first-class vision capability, reusing the
     # curated multimodal MoE primaries + their mmproj sidecar).
     # ``primary`` renamed to ``chat`` in #654/#633.
-    assert SEEDED_SLOTS == ("chat", "embed", "rerank", "stt", "tts", "img", "vision")
+    assert SEEDED_SLOTS == ("chat", "embed", "rerank", "stt", "tts", "img", "vision", "agent")
 
 
 def test_npu_seeded_slots_matches_plan_section_10_2() -> None:
-    assert NPU_SEEDED_SLOTS == ("agent", "stt-npu", "embed-npu")
+    # #679: agent dropped — it's a GPU chat-role slot, not the NPU FLM anchor.
+    assert NPU_SEEDED_SLOTS == ("stt-npu", "embed-npu")
 
 
 def test_builtin_slots_aliases_seeded_slots() -> None:
@@ -279,6 +280,18 @@ async def test_add_slot_rejects_npu_seeded_collision(tmp_hal0_home: str) -> None
     sm = SlotManager()
     with pytest.raises(SlotConfigError, match="seeded"):
         await sm.add_slot("agent", type="llm", model="x", port=8090)
+
+
+async def test_agent_slot_non_deletable_without_flm(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # #679: agent is a GPU seed slot, so it is non-deletable regardless of FLM.
+    # Regression guard — while agent was NPU-seeded, delete protection vanished
+    # on non-FLM boxes (seeded_slots() excludes the NPU trio without flm).
+    monkeypatch.setattr("hal0.slots.manager.shutil.which", lambda name: None)
+    sm = SlotManager()
+    with pytest.raises(SlotConfigError, match="seeded"):
+        await sm.delete("agent")
 
 
 async def test_add_slot_rejects_invalid_type(tmp_hal0_home: str) -> None:

--- a/tests/slots/test_slot_aliases.py
+++ b/tests/slots/test_slot_aliases.py
@@ -26,10 +26,12 @@ def test_seeded_slots_uses_chat_not_primary():
     assert "primary" not in SEEDED_SLOTS
 
 
-def test_npu_seeded_slots_uses_agent():
-    """NPU seeded slot is still 'agent' (was never 'agent-hermes' in seeded set)."""
-    assert "agent" in NPU_SEEDED_SLOTS
+def test_agent_is_gpu_seeded_not_npu():
+    """#679: agent is a GPU chat-role seed slot, not the NPU FLM anchor."""
+    assert "agent" in SEEDED_SLOTS
+    assert "agent" not in NPU_SEEDED_SLOTS
     assert "agent-hermes" not in NPU_SEEDED_SLOTS
+    assert NPU_SEEDED_SLOTS == ("stt-npu", "embed-npu")
 
 
 def test_slot_aliases_map():


### PR DESCRIPTION
## What & why

Closes #679 — a labeling/correctness cleanup surfaced during the #662 container cutover.

`NPU_SEEDED_SLOTS` listed `agent`, classifying it as the NPU FastFlowLM chat anchor. But `agent` is a **GPU** container slot (ace-saber MoE, `device=gpu-rocm`); the real NPU FLM anchor is the separate `npu` slot (gemma3-4b-FLM). This mis-classification was the root cause of the routing fallout patched reactively in #677 (`hal0/agent` missing from `DEFAULT_CHAINS`) and #678 (loaded-set union).

## Move, don't just drop

The issue suggested considering whether `agent` belongs in `SEEDED_SLOTS`. It does — and **moving** is required, not just dropping, because `SEEDED_SLOTS ∪ NPU_SEEDED_SLOTS` is load-bearing:

| Consumer (`slots/manager.py`) | Effect of just *dropping* agent | Effect of *moving* to SEEDED |
|---|---|---|
| `add_slot` reserved-name guard | `agent` un-reserved → user could create a colliding slot | stays reserved ✓ |
| `remove_slot` / `delete` (gated on `seeded_slots()`) | **agent deletable on non-FLM boxes** (NPU trio excluded without `flm`) | non-deletable always ✓ |
| `seeded_slots()` expected set | agent no longer expected | always-expected ✓ |

Moving keeps all three protections and matches reality: `agent` is an always-present GPU chat-role slot — the MoE sibling of `chat`.

`NPU_SEEDED_SLOTS` is now `("stt-npu", "embed-npu")` (the ASR + embed FLM shadow tags). The `npu` chat anchor slot is intentionally **not** added here — out of scope for this cleanup (possible follow-up if the `npu` name should also be reserved).

## Audit

All `SEEDED_SLOTS` / `NPU_SEEDED_SLOTS` consumers live in `slots/manager.py` (the constants, `seeded_slots()`, and the `add_slot`/`remove_slot`/`delete` reserved-name checks). Grepped the whole `src/hal0` tree — **no other module** special-cases `agent` as NPU, and **no installer creates TOMLs** from these constants, so the only install-visible effect is the dashboard surfacing an `agent` seed card.

## Tests (TDD, RED→GREEN verified)

- Flipped the two constant-spec assertions (`SEEDED_SLOTS` gains `agent`; `NPU_SEEDED_SLOTS == ("stt-npu", "embed-npu")`).
- Rewrote `test_npu_seeded_slots_uses_agent` → `test_agent_is_gpu_seeded_not_npu`.
- **Added a regression guard**: `delete("agent")` raises even when FLM is absent — the protection that silently vanished while `agent` was NPU-seeded. (Verified RED against current code.)

164 slots tests + vision-curation suite green · `ruff check` + `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
