### PR TITLE
fix(container): override image HEALTHCHECK to probe the slot port (#684)

### DIFF
--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -178,6 +178,18 @@ def _render_unit(
             f"--volume={_MODEL_STORE_MOUNT}:{_MODEL_STORE_MOUNT}:ro",
             # Loopback publish: expose slot port on 127.0.0.1 only.
             f"--publish=127.0.0.1:{port}:{port}",
+            # Healthcheck override (#684): the toolbox image bakes a HEALTHCHECK
+            # that probes a hardcoded :8080, but hal0 runs llama-server on the
+            # slot's own port — so the image check fails forever and `podman ps`
+            # shows a permanent false (unhealthy) even while the server is fine.
+            # Re-point it at the real slot port. ``--health-start-period`` covers
+            # model load so probes don't trip before llama-server is listening.
+            # (hal0's own ContainerProvider.health() remains the dashboard truth.)
+            f"--health-cmd=curl -fsS http://127.0.0.1:{port}/health || exit 1",
+            "--health-start-period=180s",
+            "--health-interval=30s",
+            "--health-retries=3",
+            "--health-timeout=5s",
             # Container image.
             image,
             # llama-server args follow the image (space-separated, not --key=val).

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -159,6 +159,31 @@ class TestRenderUnit:
         exec_start = self._get_exec_start(unit)
         assert "127.0.0.1:8095:8095" in exec_start
 
+    def test_healthcheck_targets_slot_port_not_image_default(self) -> None:
+        """The toolbox image bakes a HEALTHCHECK probing a hardcoded :8080, but
+        hal0 runs llama-server on the slot port — so the unit must override
+        --health-cmd to probe the real port (else `podman ps` shows a permanent
+        false (unhealthy)). A start-period must cover model load."""
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        tokens = shlex.split(self._get_exec_start(unit))
+        health_cmd = [t for t in tokens if t.startswith("--health-cmd=")]
+        assert health_cmd, f"no --health-cmd override in: {tokens}"
+        assert "127.0.0.1:8095/health" in health_cmd[0], health_cmd[0]
+        assert ":8080/" not in health_cmd[0], "must not probe the image's :8080 default"
+        assert any(t.startswith("--health-start-period=") for t in tokens), tokens
+        # Health flags are podman run options → must precede the image token.
+        img_idx = tokens.index(profile.image)
+        assert tokens.index(health_cmd[0]) < img_idx, "health flags must precede the image"
+
     def test_device_passthrough(self) -> None:
         """Default device source is resolve_gpu_device_paths(); each node is
         passed explicitly via --device=, never the bare /dev/dri directory."""


### PR DESCRIPTION
## Symptom

`podman ps` shows container LLM slots as `(unhealthy)` even though hal0's dashboard reports them ready and inference routes fine:

```
hal0-slot-agent  Up (unhealthy)   ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server
hal0-slot-chat   Up (unhealthy)   …
```

## Root cause

The fork toolbox image bakes a `HEALTHCHECK` that probes a **hardcoded port**:

```
CMD-SHELL  curl -fsS http://127.0.0.1:8080/health || exit 1
```

But hal0 runs one container per slot, each on its **own** port (`--port 8101`/`8102`, published on `127.0.0.1:<port>`). Nothing listens on `:8080` inside the container, so the probe fails forever:

```
.State.Health.FailingStreak: 8 — "curl: (7) Failed to connect to 127.0.0.1 port 8080 … Could not connect to server"
```

It's **cosmetic** — the server is healthy on its real port; hal0's own `ContainerProvider.health(port)` probes the correct port and drives the (correct) dashboard `container_status`/`container_health`. Only raw `podman ps` is misled.

## Fix (Route A — chosen)

Override the healthcheck at `podman run` time in `ContainerProvider._render_unit`, pointing `--health-cmd` at the real slot port instead of editing/republishing the image. hal0 knows the port; the image can't. Implemented in the linked PR with a `--health-start-period` covering model load.

Alternative considered (Route B): drop/parametrize the `HEALTHCHECK` in the toolbox Dockerfile — heavier (rebuild + republish to ghcr + re-`podman load`), fixes it for all image consumers but not needed for hal0's per-slot-port model.

## Acceptance
- [x] container slots no longer report a false `(unhealthy)` on `podman ps`
- [x] healthcheck probes the slot's actual port
- [x] lemond slots unaffected (this is container-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**This PR** implements Route A (the chosen fix above). Closes #684.