### PR TITLE
feat(slots): ComfyUI Image-Gen tab + generation-engine pane

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -55,12 +55,7 @@ from hal0.api.routes import (
     capabilities as capabilities_routes,
 )
 from hal0.api.routes import (
-    config as config_routes,
-)
-from hal0.api.routes import (
-    events as events_routes,
-)
-from hal0.api.routes import (
+    comfyui,
     hardware,
     health,
     hf,
@@ -74,6 +69,12 @@ from hal0.api.routes import (
     slots,
     updater,
     v1,
+)
+from hal0.api.routes import (
+    config as config_routes,
+)
+from hal0.api.routes import (
+    events as events_routes,
 )
 from hal0.api.routes import (
     journal as journal_routes,
@@ -1187,6 +1188,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         await dispatcher.aclose()
         with contextlib.suppress(Exception):
             await lemonade_proxy_routes.aclose_client()
+        with contextlib.suppress(Exception):
+            await comfyui.aclose_client()
         log.info("hal0.api.shutdown")
 
 
@@ -1239,6 +1242,9 @@ def create_app() -> FastAPI:
         tags=["installer"],
     )
     app.include_router(slots.router, prefix="/api/slots", tags=["slots"])
+    # Read-only ComfyUI "generation engine" status for the slots-page Image-Gen
+    # tab (docker + systemd + ComfyUI HTTP), plus the feature-gated switchover.
+    app.include_router(comfyui.router, prefix="/api/comfyui", tags=["comfyui"])
     app.include_router(models.router, prefix="/api/models", tags=["models"])
     # Issue #311: HuggingFace Hub discovery (search proxy). Sits next
     # to the models surface so the dashboard's "Search HF" button has a

--- a/src/hal0/api/routes/comfyui.py
+++ b/src/hal0/api/routes/comfyui.py
@@ -1,0 +1,333 @@
+"""Read-only ComfyUI "generation engine" status aggregator (+ gated switchover).
+
+The dashboard models ComfyUI as ONE containerized generation engine, not a list
+of per-model slots (a single run loads many cooperating models at once, and it
+is mutually exclusive with the LLM stack on the single iGPU). The Image-Gen tab
+renders that engine pane from ``GET /api/comfyui/status``, which folds together:
+
+  - **docker** container state (``comfyui`` running / exited / absent),
+  - **systemd** state of the LLM stack (``hal0-lemonade`` + ``hal0-agent@hermes``)
+    so the pane can show which mode currently owns the GPU, and
+  - **ComfyUI's own HTTP API** (``/system_stats`` for GTT/RAM, ``/queue`` for the
+    running + pending job counts).
+
+Every source degrades to a safe default — the pane polls this every few seconds
+and a dead container must surface as "stopped", never a 500.
+
+The switchover *write* path (``POST /api/comfyui/switchover``) runs root-owned
+scripts (``stop-inference.sh`` / ``comfy-up.sh`` …) via systemctl + docker on the
+shared runtime. hal0-api is unprivileged, so that path needs a narrowly-scoped
+sudoers rule / root helper wired in a separate, explicitly-confirmed step. Until
+then it is feature-gated behind ``HAL0_COMFYUI_SWITCHOVER_ENABLED`` and refuses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import shutil
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+# iGPU memory ceilings on the Strix Halo target (GB). The host addresses ~80 GB
+# of the 96 GB unified pool from the GPU, with zero swap — so memory pressure is
+# the real constraint, surfaced when GTT crosses half the ceiling.
+_GTT_CEIL_GB = 80
+_RAM_CEIL_GB = 96
+_PRESSURE_GB = 50
+
+_LEMONADE_UNIT = "hal0-lemonade.service"
+_HERMES_UNIT = "hal0-agent@hermes.service"
+
+# Short connect so a dead engine surfaces fast; the read budget is modest because
+# /system_stats and /queue are cheap snapshots.
+_DEFAULT_TIMEOUT = httpx.Timeout(connect=1.5, read=4.0, write=2.0, pool=2.0)
+_POOL_LIMITS = httpx.Limits(max_connections=4, max_keepalive_connections=2)
+
+_client: httpx.AsyncClient | None = None
+
+
+def _comfyui_base_url() -> str:
+    """Base URL of the operational ComfyUI container's HTTP API.
+
+    Defaults to loopback :8188 (the container publishes there on the runtime
+    host); ``COMFYUI_BASE_URL`` re-points it for dev / off-box dashboards.
+    """
+    return os.environ.get("COMFYUI_BASE_URL", "http://127.0.0.1:8188").rstrip("/")
+
+
+def _comfyui_container() -> str:
+    return os.environ.get("COMFYUI_CONTAINER", "comfyui")
+
+
+def _build_client(timeout: httpx.Timeout) -> httpx.AsyncClient:
+    return httpx.AsyncClient(timeout=timeout, limits=_POOL_LIMITS)
+
+
+def _get_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None:
+        _client = _build_client(_DEFAULT_TIMEOUT)
+    return _client
+
+
+async def aclose_client() -> None:
+    """Close the shared client on app shutdown. Idempotent."""
+    global _client
+    if _client is not None:
+        with contextlib.suppress(Exception):
+            await _client.aclose()
+        _client = None
+
+
+def _reset_state() -> None:
+    """Drop the shared client. For test isolation only."""
+    global _client
+    _client = None
+
+
+async def _fetch_json(path: str) -> dict[str, Any] | None:
+    """GET ``path`` from ComfyUI and return parsed JSON, or None if unreachable.
+
+    Fail-soft by contract: any connection / HTTP / decode error returns None so
+    the aggregator can report ``reachable: false`` instead of erroring.
+    """
+    url = f"{_comfyui_base_url()}{path}"
+    try:
+        resp = await _get_client().get(url)
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        return data if isinstance(data, dict) else None
+    except (httpx.HTTPError, ValueError):
+        return None
+
+
+async def _container_state(name: str) -> str:
+    """Return the docker container state: 'running', 'exited', or 'absent'.
+
+    'absent' also covers "docker not installed" and any inspect failure — the
+    pane treats all non-running states as stopped.
+    """
+    docker = shutil.which("docker")
+    if not docker:
+        return "absent"
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            docker,
+            "inspect",
+            "-f",
+            "{{.State.Status}}",
+            name,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=2.0)
+    except (TimeoutError, OSError):
+        return "absent"
+    if proc.returncode != 0:
+        return "absent"
+    state = out.decode("utf-8", "replace").strip()
+    return state or "absent"
+
+
+async def _systemd_active(unit: str) -> bool:
+    """True iff ``systemctl is-active <unit>`` reports the unit active."""
+    systemctl = shutil.which("systemctl")
+    if not systemctl:
+        return False
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            systemctl,
+            "is-active",
+            unit,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=2.0)
+    except (TimeoutError, OSError):
+        return False
+    return out.decode("utf-8", "replace").strip() == "active"
+
+
+def _bytes_to_gb(value: Any) -> float | None:
+    if not isinstance(value, (int, float)) or value < 0:
+        return None
+    return round(value / 1024**3, 1)
+
+
+def _parse_memory(stats: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Fold ComfyUI's /system_stats into the pane's GTT + RAM gauges.
+
+    GTT comes from the first reported device's vram_total/vram_free; RAM from the
+    system block. Any missing field becomes ``None`` rather than a guessed value.
+    """
+    if not stats:
+        return None
+    gtt_used = gtt_ceil = None
+    devices = stats.get("devices")
+    if isinstance(devices, list) and devices and isinstance(devices[0], dict):
+        dev = devices[0]
+        total = dev.get("vram_total")
+        free = dev.get("vram_free")
+        gtt_ceil = _bytes_to_gb(total) or _GTT_CEIL_GB
+        if isinstance(total, (int, float)) and isinstance(free, (int, float)):
+            gtt_used = _bytes_to_gb(total - free)
+    ram_used = None
+    ram_ceil = None
+    system = stats.get("system")
+    if isinstance(system, dict):
+        rtotal = system.get("ram_total")
+        rfree = system.get("ram_free")
+        ram_ceil = _bytes_to_gb(rtotal)
+        if isinstance(rtotal, (int, float)) and isinstance(rfree, (int, float)):
+            ram_used = _bytes_to_gb(rtotal - rfree)
+    pressure = gtt_used is not None and gtt_used >= _PRESSURE_GB
+    return {
+        "gtt_used_gb": gtt_used,
+        "gtt_ceil_gb": int(gtt_ceil) if gtt_ceil else _GTT_CEIL_GB,
+        "ram_used_gb": ram_used,
+        # Derive from the device's reported ram_total (the Strix box reports
+        # ~128 GB, not the brief's 96) — fall back to the nominal ceiling only
+        # when the field is absent, so the gauge never shows used > ceil.
+        "ram_ceil_gb": int(ram_ceil) if ram_ceil else _RAM_CEIL_GB,
+        "pressure": pressure,
+    }
+
+
+def _queue_counts(queue: dict[str, Any] | None) -> dict[str, int]:
+    if not queue:
+        return {"running": 0, "pending": 0}
+    running = queue.get("queue_running")
+    pending = queue.get("queue_pending")
+    return {
+        "running": len(running) if isinstance(running, list) else 0,
+        "pending": len(pending) if isinstance(pending, list) else 0,
+    }
+
+
+# Model categories surfaced in the pane's "models on share" card, mapped to the
+# share subdirs. ``diffusion`` folds the standalone diffusion/video model dirs.
+_INVENTORY_DIRS: dict[str, tuple[str, ...]] = {
+    "checkpoints": ("checkpoints",),
+    "diffusion": ("diffusion_models", "unet"),
+    "loras": ("loras",),
+    "vae": ("vae",),
+    "controlnet": ("controlnet",),
+    "upscale": ("upscale_models",),
+    "text_encoders": ("text_encoders", "clip"),
+}
+# Model weight extensions worth counting; ignore configs, indexes, dotfiles.
+_MODEL_EXTS = (".safetensors", ".ckpt", ".pt", ".pth", ".gguf", ".bin", ".sft")
+
+
+def _comfyui_models_dir() -> str:
+    return os.environ.get("COMFYUI_MODELS_DIR", "/mnt/ai-models/comfyui/models")
+
+
+def _count_models(base: str, subdirs: tuple[str, ...]) -> int:
+    total = 0
+    for sub in subdirs:
+        path = os.path.join(base, sub)
+        try:
+            with os.scandir(path) as it:
+                total += sum(1 for e in it if e.is_file() and e.name.lower().endswith(_MODEL_EXTS))
+        except OSError:
+            continue
+    return total
+
+
+def _model_inventory() -> dict[str, int] | None:
+    """Count weight files per category on the model share — VERIFIED, never faked.
+
+    Returns ``None`` when the share root is absent (dev box / fresh install) so
+    the pane hides the counts rather than rendering zeros it can't stand behind.
+    """
+    base = _comfyui_models_dir()
+    if not os.path.isdir(base):
+        return None
+    return {cat: _count_models(base, subdirs) for cat, subdirs in _INVENTORY_DIRS.items()}
+
+
+def _engine_state(container: str, reachable: bool, running_jobs: int) -> str:
+    if container != "running":
+        return "stopped"
+    if not reachable:
+        return "starting"  # container up but ComfyUI hasn't bound the port yet
+    return "generating" if running_jobs > 0 else "running"
+
+
+@router.get("/status")
+async def comfyui_status(request: Request) -> dict[str, Any]:
+    """Aggregate docker + systemd + ComfyUI HTTP into one engine-status object."""
+    container_name = _comfyui_container()
+    container, lemonade, hermes, stats, queue = await asyncio.gather(
+        _container_state(container_name),
+        _systemd_active(_LEMONADE_UNIT),
+        _systemd_active(_HERMES_UNIT),
+        _fetch_json("/system_stats"),
+        _fetch_json("/queue"),
+    )
+    reachable = stats is not None
+    counts = _queue_counts(queue)
+    engine = _engine_state(container, reachable, counts["running"])
+    return {
+        "mode": "generation" if container == "running" else "inference",
+        "reachable": reachable,
+        "engine": engine,
+        "container": {"name": container_name, "state": container},
+        "endpoint": ":8188" if container == "running" else None,
+        "memory": _parse_memory(stats),
+        "queue": counts,
+        "inference": {"lemonade": lemonade, "hermes": hermes},
+        "inventory": _model_inventory(),
+    }
+
+
+@router.post("/switchover")
+async def comfyui_switchover(request: Request) -> JSONResponse:
+    """Flip the iGPU between LLM inference and ComfyUI generation.
+
+    Gated: the underlying scripts need root (systemctl + docker) and take the
+    messaging bots + memory extraction offline, so the privileged path is wired
+    only behind ``HAL0_COMFYUI_SWITCHOVER_ENABLED`` in a separate confirmed step.
+    """
+    if os.environ.get("HAL0_COMFYUI_SWITCHOVER_ENABLED", "0") != "1":
+        return JSONResponse(
+            status_code=501,
+            content={
+                "error": {
+                    "code": "comfyui.switchover_disabled",
+                    "message": (
+                        "ComfyUI switchover is not enabled. It runs root-owned "
+                        "scripts on the shared runtime; set "
+                        "HAL0_COMFYUI_SWITCHOVER_ENABLED=1 only once a scoped "
+                        "sudoers/root-helper path is in place."
+                    ),
+                }
+            },
+        )
+    # Flag on, but the privileged execution path is intentionally not wired yet.
+    return JSONResponse(
+        status_code=503,
+        content={
+            "error": {
+                "code": "comfyui.switchover_unimplemented",
+                "message": (
+                    "switchover is enabled but the privileged root path has not "
+                    "been provisioned on this host yet."
+                ),
+            }
+        },
+    )
+
+
+__all__ = ["aclose_client", "router"]

--- a/tests/api/test_comfyui_proxy.py
+++ b/tests/api/test_comfyui_proxy.py
@@ -1,0 +1,177 @@
+"""Tests for the read-only ComfyUI status aggregator + gated switchover.
+
+The dashboard's Image-Gen tab renders a single "generation engine" pane backed
+by ``GET /api/comfyui/status``. That endpoint aggregates three sources, all of
+which degrade gracefully (the pane polls it every few seconds and must never
+crash on a dead container):
+
+  - docker container state (``comfyui`` running / exited / absent)
+  - systemd state of the LLM stack (lemonade + hermes) — to show which mode
+    currently owns the single iGPU
+  - ComfyUI's own HTTP API (``/system_stats`` + ``/queue``) for live telemetry
+
+The switchover *write* path (POST /api/comfyui/switchover) is feature-gated
+behind ``HAL0_COMFYUI_SWITCHOVER_ENABLED`` and returns 501 until a privileged
+root path is wired in a separate, explicitly-confirmed step.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+# system_stats payload shaped like ComfyUI's real response on the Strix Halo box
+# (verified live 2026-06-10: vram_total reports the 80 GB GTT envelope, ram_total
+# the full ~128 GB pool — NOT the 96 GB the brief assumed). vram in bytes.
+_SYSTEM_STATS = {
+    "system": {"ram_total": 128 * 1024**3, "ram_free": 46 * 1024**3},  # → 82 used / 128 ceil
+    "devices": [
+        {
+            "name": "Radeon 8060S Graphics : native",
+            "type": "cuda",
+            "vram_total": 80 * 1024**3,
+            "vram_free": 26 * 1024**3,  # → 54 GB used
+        }
+    ],
+}
+
+# /queue: one running job, two pending. ComfyUI shape is
+# {"queue_running": [[num, id, prompt, extra, outputs]], "queue_pending": [...]}.
+_QUEUE_BUSY = {
+    "queue_running": [[0, "abc", {}, {}, {}]],
+    "queue_pending": [[1, "def", {}, {}, {}], [2, "ghi", {}, {}, {}]],
+}
+_QUEUE_IDLE = {"queue_running": [], "queue_pending": []}
+
+
+def _patch(container: str, lemonade: bool, hermes: bool, fetch):
+    """Patch the three status seams on the comfyui route module."""
+    base = "hal0.api.routes.comfyui"
+    return (
+        patch(f"{base}._container_state", new_callable=AsyncMock, return_value=container),
+        patch(
+            f"{base}._systemd_active",
+            new_callable=AsyncMock,
+            side_effect=lambda unit: hermes if "hermes" in unit else lemonade,
+        ),
+        patch(f"{base}._fetch_json", new_callable=AsyncMock, side_effect=fetch),
+    )
+
+
+async def _fetch_busy(path: str):
+    return _SYSTEM_STATS if "system_stats" in path else _QUEUE_BUSY
+
+
+async def _fetch_idle(path: str):
+    return _SYSTEM_STATS if "system_stats" in path else _QUEUE_IDLE
+
+
+async def _fetch_down(path: str):
+    return None  # ComfyUI HTTP unreachable
+
+
+def test_status_generating_when_container_running_and_queue_busy(client: TestClient) -> None:
+    c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_busy)
+    with c, s, f:
+        r = client.get("/api/comfyui/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["mode"] == "generation"
+    assert body["reachable"] is True
+    assert body["container"]["state"] == "running"
+    assert body["engine"] == "generating"
+    assert body["queue"] == {"running": 1, "pending": 2}
+    # 80 total - 26 free = 54 GB used on the iGPU; pressure trips >= 50.
+    assert body["memory"]["gtt_used_gb"] == pytest.approx(54.0, abs=0.5)
+    assert body["memory"]["gtt_ceil_gb"] == 80
+    assert body["memory"]["pressure"] is True
+    # RAM ceiling is DERIVED from ram_total (128 GB here), not hardcoded to 96.
+    assert body["memory"]["ram_used_gb"] == pytest.approx(82.0, abs=0.5)
+    assert body["memory"]["ram_ceil_gb"] == 128
+
+
+def test_status_running_idle_when_container_up_but_queue_empty(client: TestClient) -> None:
+    c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_idle)
+    with c, s, f:
+        r = client.get("/api/comfyui/status")
+    body = r.json()
+    assert body["engine"] == "running"
+    assert body["queue"] == {"running": 0, "pending": 0}
+
+
+def test_status_starting_when_container_running_but_http_unreachable(client: TestClient) -> None:
+    # Container is up but ComfyUI hasn't bound :8188 yet — fail soft, not a 500.
+    c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_down)
+    with c, s, f:
+        r = client.get("/api/comfyui/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["reachable"] is False
+    assert body["engine"] == "starting"
+    assert body["memory"] is None
+
+
+def test_status_stopped_and_inference_mode_when_container_absent(client: TestClient) -> None:
+    # ComfyUI down, LLM stack up → inference owns the GPU.
+    c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
+    with c, s, f:
+        r = client.get("/api/comfyui/status")
+    body = r.json()
+    assert body["mode"] == "inference"
+    assert body["engine"] == "stopped"
+    assert body["container"]["state"] == "absent"
+    assert body["inference"] == {"lemonade": True, "hermes": True}
+
+
+def test_status_reports_model_inventory_from_the_share(
+    client: TestClient, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The "models on share" card shows VERIFIED file counts per category — never
+    # invented. Point the scanner at a temp models dir laid out like the share.
+    models = tmp_path / "models"
+    for cat, n in {"checkpoints": 6, "loras": 11, "vae": 3, "diffusion_models": 4}.items():
+        d = models / cat
+        d.mkdir(parents=True)
+        for i in range(n):
+            (d / f"m{i}.safetensors").touch()
+    monkeypatch.setenv("COMFYUI_MODELS_DIR", str(models))
+    c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_idle)
+    with c, s, f:
+        r = client.get("/api/comfyui/status")
+    inv = r.json()["inventory"]
+    assert inv["checkpoints"] == 6
+    assert inv["loras"] == 11
+    assert inv["vae"] == 3
+    assert inv["diffusion"] == 4  # diffusion_models + unet folded together
+
+
+def test_status_inventory_is_none_when_share_absent(client: TestClient, tmp_path) -> None:
+    # No share mounted (e.g. dev box / fresh install) → inventory is null, the
+    # pane simply hides the counts rather than showing zeros it can't verify.
+    import os as _os
+
+    _os.environ.pop("COMFYUI_MODELS_DIR", None)
+    with patch.dict(_os.environ, {"COMFYUI_MODELS_DIR": str(tmp_path / "nope")}):
+        c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
+        with c, s, f:
+            r = client.get("/api/comfyui/status")
+    assert r.json()["inventory"] is None
+
+
+def test_switchover_gated_off_returns_501(client: TestClient) -> None:
+    # Default: the privileged root path is NOT wired. Must refuse, not pretend.
+    r = client.post("/api/comfyui/switchover", json={"mode": "generation"})
+    assert r.status_code == 501
+    assert "switchover" in r.json()["error"]["code"]
+
+
+def test_switchover_enabled_flag_is_read_per_request(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # When the flag is on, the gate opens (even though the stub then reports the
+    # root path is still unimplemented — proves the flag is consulted live).
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    r = client.post("/api/comfyui/switchover", json={"mode": "generation"})
+    assert r.status_code != 501

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -22,6 +22,13 @@ export const ENDPOINTS = {
   // ── Slots / status (hal0-api) ────────────────────────────────────
   status: '/api/status',
   slots: '/api/slots',
+
+  // ── ComfyUI generation engine (slots-page Image-Gen tab) ─────────
+  // Read-only aggregate of docker + systemd + ComfyUI HTTP; the
+  // switchover write-path is feature-gated server-side.
+  comfyuiStatus: '/api/comfyui/status',
+  comfyuiSwitchover: '/api/comfyui/switchover',
+
   slotMetrics: '/api/slots/metrics',
   slot: (name: string) => `/api/slots/${encodeURIComponent(name)}`,
   slotConfig: (name: string) => `/api/slots/${encodeURIComponent(name)}/config`,

--- a/ui/src/api/hooks/useComfyui.ts
+++ b/ui/src/api/hooks/useComfyui.ts
@@ -1,0 +1,84 @@
+// hal0 v3 dashboard — ComfyUI generation-engine hooks.
+//
+// /api/comfyui/status is a read-only aggregate (docker container state +
+// systemd state of the LLM stack + ComfyUI's own /system_stats + /queue). The
+// pane on the slots-page Image-Gen tab polls it; renders take minutes so a
+// 4s cadence is plenty to track queue depth + memory pressure without hammering
+// the cpp-httplib server behind :8188.
+//
+// The switchover (inference ⇄ generation) flips the single iGPU between the LLM
+// stack and ComfyUI by running root-owned scripts. That path is feature-gated
+// server-side (HAL0_COMFYUI_SWITCHOVER_ENABLED) and returns 501 until a scoped
+// privileged path is provisioned — so the mutation surfaces that refusal as a
+// toast rather than optimistically flipping the UI.
+
+import { useMutation, useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { api, apiGet } from '../client'
+import { ENDPOINTS } from '../endpoints'
+
+export type ComfyuiEngineState = 'stopped' | 'starting' | 'running' | 'generating' | 'error'
+export type ComfyuiMode = 'generation' | 'inference'
+
+export interface ComfyuiMemory {
+  gtt_used_gb: number | null
+  gtt_ceil_gb: number
+  ram_used_gb: number | null
+  ram_ceil_gb: number
+  pressure: boolean
+}
+
+export interface ComfyuiStatus {
+  mode: ComfyuiMode
+  reachable: boolean
+  engine: ComfyuiEngineState
+  container: { name: string; state: string }
+  endpoint: string | null
+  memory: ComfyuiMemory | null
+  queue: { running: number; pending: number }
+  inference: { lemonade: boolean; hermes: boolean }
+  inventory: Record<string, number> | null
+}
+
+// Neutral default so the pane renders a coherent "stopped/inference" shell on
+// first paint and whenever the backend is briefly unreachable — never undefined
+// field access.
+export const COMFYUI_FALLBACK: ComfyuiStatus = {
+  mode: 'inference',
+  reachable: false,
+  engine: 'stopped',
+  container: { name: 'comfyui', state: 'absent' },
+  endpoint: null,
+  memory: null,
+  queue: { running: 0, pending: 0 },
+  inference: { lemonade: false, hermes: false },
+  inventory: null,
+}
+
+// Active (Image-Gen tab open): 4s, fast enough to track queue + pressure.
+// Idle (other tab): 20s — keeps the tab's live dot honest without spending a
+// docker inspect + 2× systemctl + 2× HTTP probe every few seconds. The proxy
+// it mirrors (lemonade_proxy) had to add caching precisely because per-tab
+// polling starved an embedded HTTP server; this is the cheap equivalent guard.
+const POLL_ACTIVE_MS = 4_000
+const POLL_IDLE_MS = 20_000
+
+export function useComfyui(opts: { active?: boolean } = {}): UseQueryResult<ComfyuiStatus> {
+  return useQuery({
+    queryKey: ['comfyui', 'status'],
+    queryFn: () => apiGet<ComfyuiStatus>(ENDPOINTS.comfyuiStatus),
+    refetchInterval: opts.active ? POLL_ACTIVE_MS : POLL_IDLE_MS,
+  })
+}
+
+export interface SwitchoverBody {
+  mode: ComfyuiMode
+}
+
+// raw:true so the dev mockFetch GET-shim can't mask the 501/503 gate — we want
+// the real status code to drive the toast copy.
+export function useComfyuiSwitchover() {
+  return useMutation({
+    mutationFn: (body: SwitchoverBody) =>
+      api<unknown>(ENDPOINTS.comfyuiSwitchover, { method: 'POST', body: body as any, raw: true }),
+  })
+}

--- a/ui/src/dash/comfyui-pane.css
+++ b/ui/src/dash/comfyui-pane.css
@@ -1,0 +1,289 @@
+/* ComfyUI "generation engine" pane — slots-page Image-Gen tab.
+ *
+ * Ported (auto-scoped) from the hal0 Design System exploration
+ * Design System/explorations/comfyui-row/row.css. Every selector is scoped
+ * under `.comfy-pane` so the design's generic class names (.engine, .queue,
+ * .gauge, .flow, .tel, .switchover …) can't collide with dashboard globals.
+ * The design's :root token block is re-scoped to .comfy-pane below; the
+ * --comfy* accent is ALSO mirrored into dashboard.css :root so the page tabs
+ * can reference it. Motion/sunken tokens the design assumes but the live
+ * stylesheet lacks (--dur*, --ease, --bg-sunken) are added to the same block. */
+
+.comfy-pane {
+  --dur: 0.18s;
+  --dur-fast: 0.12s;
+  --dur-slow: 0.22s;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --bg-sunken: #070707;
+  font-family: var(--geist);
+  color: var(--fg);
+ --comfy:       #5EA4F9;
+  --comfy-hi:    #8CC0FF;
+  --comfy-soft:  rgba(94,164,249,0.10);
+  --comfy-line:  rgba(94,164,249,0.34);
+  --comfy-bg:    #0C1622;          
+  --comfy-glow:  rgba(94,164,249,0.20);
+  --npu:         var(--dev-npu);
+  --npu-soft:    rgba(200,150,255,0.08);
+  --npu-line:    rgba(200,150,255,0.30); }
+.comfy-pane .proto { font-family: var(--geist); color: var(--fg); background: var(--bg); }
+.comfy-pane .proto * { box-sizing: border-box; }
+.comfy-pane .sec-label { display: flex; align-items: center; gap: 10px;
+  font-family: var(--jbm); font-size: 12px; letter-spacing: 0.04em;
+  color: var(--fg-3); margin: 0 0 16px; }
+.comfy-pane .sec-label b { color: var(--comfy); font-weight: 500; text-transform: uppercase; letter-spacing: 0.1em; }
+.comfy-pane .sec-label .dim { color: var(--fg-5); }
+.comfy-pane .sec-label .meta { color: var(--fg-4); text-transform: uppercase; letter-spacing: 0.08em; font-size: 11px; }
+.comfy-pane .engine { border: 1px solid var(--line); border-radius: var(--rad-lg);
+  background: var(--bg-1); overflow: hidden; }
+.comfy-pane .engine.active { border-color: var(--comfy-line); box-shadow: 0 0 0 1px var(--comfy-line), 0 0 40px -20px var(--comfy-glow); }
+.comfy-pane .engine.active::before { content: ""; }
+.comfy-pane .engine-h { display: flex; align-items: center; gap: 12px;
+  padding: 14px 18px; border-bottom: 1px solid var(--line-soft);
+  background: var(--bg); }
+.comfy-pane .engine.active .engine-h { background: linear-gradient(90deg, var(--comfy-soft), transparent 60%); }
+.comfy-pane .engine-glyph { width: 26px; height: 26px; border-radius: var(--rad-sm);
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--comfy-soft); color: var(--comfy); border: 1px solid var(--comfy-line); }
+.comfy-pane .engine-title { font-family: var(--jbm); font-size: 15px; font-weight: 500; color: var(--fg); }
+.comfy-pane .engine-sub { font-family: var(--jbm); font-size: 11px; color: var(--fg-4); }
+.comfy-pane .engine-h .grow { flex: 1; }
+.comfy-pane .epill { display: inline-flex; align-items: center; gap: 7px;
+  padding: 3px 10px; border-radius: 999px;
+  font-family: var(--jbm); font-size: 11px;
+  border: 1px solid var(--line); color: var(--fg-3); background: var(--bg-1); }
+.comfy-pane .epill .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--fg-4); }
+.comfy-pane .epill.exclusive { color: var(--comfy); border-color: var(--comfy-line); background: var(--comfy-soft); }
+.comfy-pane .epill.exclusive .dot { background: var(--comfy); box-shadow: 0 0 8px var(--comfy); }
+.comfy-pane .epill.running { color: var(--comfy); border-color: var(--comfy-line); background: var(--comfy-soft); }
+.comfy-pane .epill.running .dot { background: var(--comfy); box-shadow: 0 0 8px var(--comfy); }
+.comfy-pane .epill.generating { color: var(--comfy); border-color: var(--comfy-line); background: var(--comfy-soft); }
+.comfy-pane .epill.generating .dot { background: var(--comfy); box-shadow: 0 0 8px var(--comfy); animation: pulse 1.2s ease-in-out infinite; }
+.comfy-pane .epill.starting { color: var(--warn); border-color: var(--warn-line); background: var(--warn-soft); }
+.comfy-pane .epill.starting .dot { background: var(--warn); box-shadow: 0 0 8px var(--warn); animation: pulse 1.2s ease-in-out infinite; }
+.comfy-pane .epill.stopped { color: var(--fg-3); }
+.comfy-pane .epill.stopped .dot { background: var(--fg-4); }
+.comfy-pane .epill.error { color: var(--err); border-color: var(--err-line); background: var(--err-soft); }
+.comfy-pane .epill.error .dot { background: var(--err); }
+.comfy-pane .switchover { display: inline-flex; align-items: center; gap: 11px; }
+.comfy-pane .switchover .mode { font-family: var(--jbm); font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--fg-4); }
+.comfy-pane .switchover .mode.on { color: var(--comfy); }
+.comfy-pane .switchover .mode.llm-on { color: var(--accent); }
+.comfy-pane .toggle { --tg-color: var(--accent);
+  position: relative; width: 38px; height: 22px; border-radius: 999px;
+  background: var(--bg-3); border: 1px solid var(--line-strong);
+  cursor: pointer; flex-shrink: 0; transition: background var(--dur) var(--ease), border-color var(--dur) var(--ease); }
+.comfy-pane .toggle .knob { position: absolute; top: 2px; left: 2px; width: 16px; height: 16px; border-radius: 50%;
+  background: var(--fg-3); transition: transform var(--dur) var(--ease), background var(--dur) var(--ease); }
+.comfy-pane .toggle.on { background: var(--tg-color); border-color: var(--tg-color); }
+.comfy-pane .toggle.on .knob { transform: translateX(16px); background: #0a0a0a; }
+.comfy-pane .toggle.comfy { --tg-color: var(--comfy); }
+.comfy-pane .toggle.big { width: 46px; height: 26px; }
+.comfy-pane .toggle.big .knob { width: 20px; height: 20px; }
+.comfy-pane .toggle.big.on .knob { transform: translateX(20px); }
+.comfy-pane .toggle.busy { opacity: 0.6; cursor: progress; }
+.comfy-pane .rchip { display: inline-flex; align-items: center; gap: 5px; padding: 2px 8px;
+  border-radius: 3px; font-family: var(--jbm); font-size: 10px; letter-spacing: 0.02em;
+  background: var(--bg-2); color: var(--fg-3); border: 1px solid var(--line); text-transform: lowercase; }
+.comfy-pane .rchip.comfy { color: var(--comfy); border-color: var(--comfy-line); background: var(--comfy-soft); }
+.comfy-pane .rchip.npu { color: var(--npu); border-color: var(--npu-line); background: var(--npu-soft); }
+.comfy-pane .rchip.ok { color: var(--ok); border-color: var(--ok-line); background: var(--ok-soft); }
+.comfy-pane .rchip.warn { color: var(--warn); border-color: var(--warn-line); background: var(--warn-soft); }
+.comfy-pane .rbtn { display: inline-flex; align-items: center; gap: 6px; padding: 5px 11px; height: 28px;
+  font-family: var(--jbm); font-size: 11px; border-radius: var(--rad-sm); cursor: pointer;
+  background: transparent; color: var(--fg-2); border: 1px solid var(--line); white-space: nowrap; }
+.comfy-pane .rbtn:hover { border-color: var(--line-strong); background: var(--bg-2); color: var(--fg); }
+.comfy-pane .rbtn.primary { background: var(--comfy); border-color: var(--comfy); color: #04111f; font-weight: 600; }
+.comfy-pane .rbtn.primary:hover { filter: brightness(1.08); background: var(--comfy); }
+.comfy-pane .rbtn.ghost-comfy { color: var(--comfy); border-color: var(--comfy-line); }
+.comfy-pane .rbtn.ghost-comfy:hover { background: var(--comfy-soft); }
+.comfy-pane .rbtn.danger { color: var(--err); border-color: var(--err-line); }
+.comfy-pane .rbtn.danger:hover { background: var(--err-soft); }
+.comfy-pane .rbtn.sm { height: 24px; padding: 3px 8px; font-size: 10.5px; }
+.comfy-pane .engine-b { padding: 16px 18px; display: flex; flex-direction: column; gap: 16px; }
+.comfy-pane .engine-foot { padding: 11px 18px; border-top: 1px solid var(--line-soft); background: var(--bg);
+  font-family: var(--jbm); font-size: 11px; color: var(--fg-4);
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.comfy-pane .engine-foot .k { color: var(--fg-5); }
+.comfy-pane .engine-foot .v { color: var(--fg-3); }
+.comfy-pane .engine-foot .v.comfy { color: var(--comfy); }
+.comfy-pane .engine-foot .sep { color: var(--fg-5); }
+.comfy-pane .subgrid { display: grid; gap: 12px; }
+.comfy-pane .subcard { border: 1px solid var(--line); border-radius: var(--rad); background: var(--bg);
+  padding: 12px 14px; display: flex; flex-direction: column; gap: 9px; }
+.comfy-pane .subcard-h { display: flex; align-items: center; gap: 8px; font-family: var(--jbm); font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-4); }
+.comfy-pane .subcard-h .grow { flex: 1; }
+.comfy-pane .card-section { margin-top: 4px; padding-top: 12px; border-top: 1px solid var(--line-soft); display: flex; flex-direction: column; gap: 10px; }
+.comfy-pane .gauge { display: flex; flex-direction: column; gap: 6px; }
+.comfy-pane .gauge-h { display: flex; justify-content: space-between; font-family: var(--jbm); font-size: 11px; color: var(--fg-3); }
+.comfy-pane .gauge-h b { color: var(--fg); font-weight: 500; }
+.comfy-pane .gauge-h .ceil { color: var(--fg-5); }
+.comfy-pane .gauge-track { height: 8px; border-radius: 2px; background: var(--bg-3); overflow: hidden; display: flex; }
+.comfy-pane .gauge-track i { display: block; height: 100%; }
+.comfy-pane .gauge-track i.comfy { background: var(--comfy); }
+.comfy-pane .gauge-track i.warnz { background: var(--warn); }
+.comfy-pane .gauge-track i.os { background: var(--bg-4); }
+.comfy-pane .gauge-note { font-family: var(--jbm); font-size: 10px; color: var(--fg-4); }
+.comfy-pane .gauge-note.pressure { color: var(--warn); }
+.comfy-pane .minigauge { display: inline-flex; flex-direction: column; gap: 4px; min-width: 132px; }
+.comfy-pane .minigauge .lbl { display: flex; justify-content: space-between; font-family: var(--jbm); font-size: 10px; color: var(--fg-4); }
+.comfy-pane .minigauge .lbl b { color: var(--fg-2); font-weight: 500; }
+.comfy-pane .minigauge .bar { height: 5px; border-radius: 2px; background: var(--bg-3); overflow: hidden; }
+.comfy-pane .minigauge .bar i { display: block; height: 100%; background: var(--comfy); }
+.comfy-pane .minigauge .bar i.warnz { background: var(--warn); }
+.comfy-pane .genbar { display: flex; flex-direction: column; gap: 7px; }
+.comfy-pane .genbar-h { display: flex; align-items: center; gap: 10px; font-family: var(--jbm); font-size: 11.5px; color: var(--fg-2); }
+.comfy-pane .genbar-h .job { color: var(--fg); }
+.comfy-pane .genbar-h .grow { flex: 1; }
+.comfy-pane .genbar-h .pct { color: var(--comfy); }
+.comfy-pane .genbar-track { height: 6px; border-radius: 2px; background: var(--bg-3); overflow: hidden; position: relative; }
+.comfy-pane .genbar-fill { height: 100%; background: var(--comfy); position: relative; overflow: hidden; }
+.comfy-pane .genbar-fill::after { content: ""; position: absolute; inset: 0; background: linear-gradient(90deg, transparent, rgba(255,255,255,0.22), transparent); animation: cf-shimmer 1.4s linear infinite; }
+@keyframes cf-shimmer {from { transform: translateX(-100%); }to { transform: translateX(100%); } }
+.comfy-pane .genbar-steps { display: flex; justify-content: space-between; font-family: var(--jbm); font-size: 10px; color: var(--fg-4); }
+.comfy-pane .inv { display: flex; flex-wrap: wrap; gap: 8px; }
+.comfy-pane .inv-pill { display: inline-flex; align-items: baseline; gap: 6px; padding: 5px 10px;
+  border: 1px solid var(--line); border-radius: var(--rad-sm); background: var(--bg);
+  font-family: var(--jbm); font-size: 11px; color: var(--fg-3); }
+.comfy-pane .inv-pill b { color: var(--fg); font-weight: 500; font-size: 13px; }
+.comfy-pane .inv-pill .u { color: var(--fg-5); }
+.comfy-pane .flows { display: flex; flex-wrap: wrap; gap: 8px; }
+.comfy-pane .flow { display: inline-flex; align-items: center; gap: 8px; padding: 7px 12px;
+  border: 1px solid var(--line); border-radius: var(--rad); background: var(--bg);
+  font-family: var(--jbm); font-size: 11.5px; color: var(--fg-2); cursor: pointer; }
+.comfy-pane .flow:hover { border-color: var(--comfy-line); color: var(--comfy); background: var(--comfy-soft); }
+.comfy-pane .flow .ic { color: var(--comfy); display: inline-flex; }
+.comfy-pane .flow .arr { color: var(--fg-5); }
+.comfy-pane .llm-rows { display: flex; flex-direction: column; gap: 8px; }
+.comfy-pane .llm-row { display: flex; align-items: center; gap: 12px; padding: 11px 16px;
+  border: 1px solid var(--line); border-radius: var(--rad); background: var(--bg-1);
+  transition: opacity var(--dur) var(--ease), filter var(--dur) var(--ease); }
+.comfy-pane .llm-row .dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+.comfy-pane .llm-row .name { font-family: var(--jbm); font-size: 13px; font-weight: 500; color: var(--fg); width: 80px; }
+.comfy-pane .llm-row .model { font-family: var(--jbm); font-size: 12px; color: var(--fg-3); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.comfy-pane .llm-row .grow { flex: 1; }
+.comfy-pane .llm-row.yielded { opacity: 0.5; }
+.comfy-pane .llm-row.yielded .dot { background: var(--warn); }
+.comfy-pane .llm-row.up .dot { background: var(--ok); box-shadow: 0 0 8px var(--ok); }
+.comfy-pane .yield-tag { font-family: var(--jbm); font-size: 10px; color: var(--warn); border: 1px solid var(--warn-line); background: var(--warn-soft); padding: 1px 7px; border-radius: 3px; text-transform: lowercase; }
+.comfy-pane .gpu-mode { display: inline-flex; border: 1px solid var(--line-strong); border-radius: var(--rad); overflow: hidden;
+  background: var(--bg-1); }
+.comfy-pane .gpu-mode button { display: inline-flex; align-items: center; gap: 8px; padding: 8px 16px;
+  background: transparent; border: none; cursor: pointer;
+  font-family: var(--jbm); font-size: 12px; color: var(--fg-3); letter-spacing: 0.02em; }
+.comfy-pane .gpu-mode button + button { border-left: 1px solid var(--line); }
+.comfy-pane .gpu-mode button.on-llm { background: var(--accent-bg); color: var(--accent); }
+.comfy-pane .gpu-mode button.on-comfy { background: var(--comfy-bg); color: var(--comfy); }
+.comfy-pane .gpu-mode button .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; box-shadow: 0 0 8px currentColor; }
+.comfy-pane .cf-scrim { position: absolute; inset: 0; background: rgba(0,0,0,0.66); backdrop-filter: blur(2px);
+  display: flex; align-items: center; justify-content: center; border-radius: var(--rad-lg); }
+.comfy-pane .cf { width: 520px; max-width: calc(100% - 40px);
+  background: var(--bg-1); border: 1px solid var(--line-strong); border-radius: var(--rad-lg);
+  box-shadow: var(--shadow-menu); overflow: hidden; }
+.comfy-pane .cf-h { padding: 18px 20px 14px; border-bottom: 1px solid var(--line-soft); }
+.comfy-pane .cf-eye { font-family: var(--jbm); font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--comfy); margin-bottom: 6px; }
+.comfy-pane .cf-eye.warn { color: var(--warn); }
+.comfy-pane .cf-title { font-family: var(--jbm); font-size: 17px; font-weight: 500; margin: 0; letter-spacing: -0.01em; color: var(--fg); }
+.comfy-pane .cf-b { padding: 16px 20px; display: flex; flex-direction: column; gap: 13px; }
+.comfy-pane .cf-lede { font-size: 13px; color: var(--fg-2); line-height: 1.55; }
+.comfy-pane .cf-lede .mono { font-family: var(--jbm); color: var(--fg); }
+.comfy-pane .cf-blast { display: flex; flex-direction: column; gap: 8px; }
+.comfy-pane .cf-blast .row { display: flex; align-items: flex-start; gap: 10px; font-size: 12.5px; color: var(--fg-2); line-height: 1.45; }
+.comfy-pane .cf-blast .row .ic { color: var(--warn); flex-shrink: 0; margin-top: 1px; }
+.comfy-pane .cf-blast .row .ic.ok { color: var(--ok); }
+.comfy-pane .cf-steps { border: 1px solid var(--line); border-radius: var(--rad); background: var(--bg-sunken);
+  padding: 11px 13px; font-family: var(--jbm); font-size: 11.5px; color: var(--fg-3); line-height: 1.7; }
+.comfy-pane .cf-steps .n { color: var(--comfy); }
+.comfy-pane .cf-steps .cmd { color: var(--fg-2); }
+.comfy-pane .cf-steps .arr { color: var(--fg-5); }
+.comfy-pane .cf-guard { display: flex; align-items: center; gap: 9px; padding: 10px 12px;
+  border: 1px solid var(--err-line); background: var(--err-soft); border-radius: var(--rad);
+  font-size: 12px; color: var(--err); font-family: var(--jbm); }
+.comfy-pane .cf-f { padding: 13px 20px; border-top: 1px solid var(--line-soft); background: var(--bg); display: flex; align-items: center; gap: 10px; }
+.comfy-pane .cf-f .note { font-family: var(--jbm); font-size: 10.5px; color: var(--fg-4); }
+.comfy-pane .cf-f .grow { flex: 1; }
+.comfy-pane .row-flex { display: flex; align-items: center; gap: 10px; }
+.comfy-pane .col { display: flex; flex-direction: column; }
+.comfy-pane .grow { flex: 1; }
+.comfy-pane .mono { font-family: var(--jbm); }
+.comfy-pane .dimx { color: var(--fg-4); }
+.comfy-pane .spin { animation: cf-spin 1s linear infinite; display: inline-flex; }
+@keyframes cf-spin {to { transform: rotate(360deg); } }
+.comfy-pane .engine-body { max-height: 0; overflow: hidden; transition: max-height var(--dur-slow) var(--ease); }
+.comfy-pane .engine.open .engine-body { max-height: 1400px; }
+.comfy-pane .collapsed-prog { padding: 12px 18px 14px; border-top: 1px solid var(--line-soft); }
+.comfy-pane .engine.open .collapsed-prog { display: none; }
+.comfy-pane .tel-strip { display: flex; align-items: center; gap: 0; flex-wrap: wrap; row-gap: 8px; margin-top: 12px; padding-top: 11px; border-top: 1px solid var(--line-soft); }
+.comfy-pane .tel { display: inline-flex; align-items: center; gap: 7px; padding: 0 14px; border-right: 1px solid var(--line-soft); font-family: var(--jbm); }
+.comfy-pane .tel:first-child { padding-left: 0; }
+.comfy-pane .tel:last-child { border-right: none; }
+.comfy-pane .tel .l { font-size: 9px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--fg-4); }
+.comfy-pane .tel .v { font-size: 12.5px; color: var(--fg); }
+.comfy-pane .tel .v.comfy { color: var(--comfy); }
+.comfy-pane .tel .v.warn { color: var(--warn); }
+.comfy-pane .tel .v .u { color: var(--fg-4); font-size: 10px; margin-left: 1px; }
+.comfy-pane .tel .minibar { width: 52px; height: 5px; border-radius: 2px; background: var(--bg-3); overflow: hidden; }
+.comfy-pane .tel .minibar i { display: block; height: 100%; }
+.comfy-pane .tel .qn { display: inline-flex; align-items: center; justify-content: center; min-width: 15px; height: 15px; padding: 0 4px; border-radius: 999px; background: var(--comfy); color: #04111f; font-size: 9.5px; font-weight: 600; }
+.comfy-pane .engine-foot.has-q { justify-content: flex-start; }
+.comfy-pane .engine-foot .foot-id { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; min-width: 0; }
+.comfy-pane .qcaret { margin-left: auto;
+  display: inline-flex; align-items: stretch;
+  border: 1px solid var(--comfy-line); border-radius: var(--rad-sm);
+  background: var(--comfy-soft); cursor: pointer; overflow: hidden;
+  transition: border-color var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease); }
+.comfy-pane .qcaret:hover { background: rgba(94,164,249,0.16); }
+.comfy-pane .qcaret .q { display: inline-flex; align-items: center; gap: 7px; padding: 5px 10px;
+  font-family: var(--jbm); font-size: 11px; color: var(--comfy); }
+.comfy-pane .qcaret .q .qn { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px;
+  padding: 0 4px; border-radius: 999px; background: var(--comfy); color: #04111f;
+  font-size: 10px; font-weight: 600; }
+.comfy-pane .qcaret .q .qrun { color: var(--fg-4); }
+.comfy-pane .qcaret .car { display: inline-flex; align-items: center; justify-content: center; width: 28px;
+  border-left: 1px solid var(--comfy-line); color: var(--comfy);
+  transition: transform var(--dur) var(--ease); }
+.comfy-pane .engine.open .qcaret .car { transform: rotate(180deg); }
+.comfy-pane .qcaret.empty { border-color: var(--line); background: transparent; }
+.comfy-pane .qcaret.empty .q { color: var(--fg-3); }
+.comfy-pane .qcaret.empty .car { border-left-color: var(--line); color: var(--fg-3); }
+.comfy-pane .queue { border: 1px solid var(--line); border-radius: var(--rad); background: var(--bg); overflow: hidden; }
+.comfy-pane .queue-h { display: flex; align-items: center; gap: 8px; padding: 9px 14px;
+  border-bottom: 1px solid var(--line-soft); font-family: var(--jbm); font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-4); }
+.comfy-pane .queue-h .grow { flex: 1; }
+.comfy-pane .queue-h .clear { color: var(--fg-4); cursor: pointer; text-transform: none; letter-spacing: 0; font-size: 11px; }
+.comfy-pane .queue-h .clear:hover { color: var(--err); }
+.comfy-pane .qrow { display: grid; grid-template-columns: 16px minmax(0,1fr) 150px 84px 28px;
+  align-items: center; gap: 12px; padding: 9px 14px;
+  border-bottom: 1px solid var(--line-soft); font-family: var(--jbm); font-size: 12px; }
+.comfy-pane .qrow:last-child { border-bottom: none; }
+.comfy-pane .qrow.running { background: var(--comfy-soft); }
+.comfy-pane .qrow .qdot { width: 7px; height: 7px; border-radius: 50%; background: var(--fg-5); }
+.comfy-pane .qrow.running .qdot { background: var(--comfy); box-shadow: 0 0 8px var(--comfy); animation: pulse 1.2s ease-in-out infinite; }
+.comfy-pane .qrow .qname { color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.comfy-pane .qrow .qname .qkind { color: var(--fg-4); }
+.comfy-pane .qrow .qmini { height: 4px; border-radius: 2px; background: var(--bg-3); overflow: hidden; }
+.comfy-pane .qrow .qmini i { display: block; height: 100%; background: var(--comfy); }
+.comfy-pane .qrow .qstat { font-size: 11px; color: var(--fg-4); text-align: right; }
+.comfy-pane .qrow.running .qstat { color: var(--comfy); }
+.comfy-pane .qrow .qx { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: var(--rad-sm); color: var(--fg-4); cursor: pointer; }
+.comfy-pane .qrow .qx:hover { color: var(--err); background: var(--err-soft); }
+.comfy-pane .queue-empty { padding: 18px 14px; text-align: center; font-family: var(--jbm); font-size: 11.5px; color: var(--fg-4); }
+.comfy-pane .qrow .qpos { color: var(--fg-5); }
+.comfy-pane .gpu-stats { display: flex; gap: 22px; padding-top: 12px; margin-top: 4px;
+  border-top: 1px solid var(--line-soft); }
+.comfy-pane .gpu-stats .gs { display: flex; flex-direction: column; gap: 2px; }
+.comfy-pane .gpu-stats .gs b { font-family: var(--jbm); font-size: 18px; font-weight: 500; color: var(--fg); letter-spacing: -0.01em; }
+.comfy-pane .gpu-stats .gs .u { font-family: var(--jbm); font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--fg-4); }
+
+/* Header right cluster + switchover toggle. These lived in the design's
+   comfyui-pane.html inline <style> (not row.css), so they're added here to
+   match. engine-h wraps on narrow widths so the toggle can't clip. */
+.comfy-pane .engine-h { flex-wrap: wrap; row-gap: 10px; }
+.comfy-pane .eh-right { display: inline-flex; align-items: center; gap: 12px; flex-shrink: 0; }
+.comfy-pane .sw-wrap { display: inline-flex; align-items: center; gap: 9px; }
+.comfy-pane .sw-wrap .mode { font-family: var(--jbm); font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-4); white-space: nowrap; }
+.comfy-pane .sw-wrap .mode.on { color: var(--comfy); }
+.comfy-pane .sw-wrap .mode.llm-on { color: var(--accent); }
+.comfy-pane .toggle { cursor: pointer; }

--- a/ui/src/dash/comfyui-pane.jsx
+++ b/ui/src/dash/comfyui-pane.jsx
@@ -1,0 +1,633 @@
+// hal0 dashboard — ComfyUI "generation engine" pane (slots-page Image-Gen tab).
+//
+// Ported from the hal0 Design System exploration
+// (Design System/explorations/comfyui-row/{comfyui-pane,row}.{html,jsx}). The
+// design models ComfyUI as ONE containerized generation engine — not per-model
+// slots — that is mutually exclusive with the LLM stack on the single iGPU.
+//
+// What's wired live (read-only, via useComfyui → /api/comfyui/status):
+//   - engine state + which mode owns the GPU (docker + systemd)
+//   - GTT / RAM gauges + memory pressure (ComfyUI /system_stats)
+//   - queue depth (ComfyUI /queue)
+//   - model inventory counts (verified file counts on the share)
+// The switchover toggle opens a blast-radius confirm dialog, then calls the
+// feature-gated POST /api/comfyui/switchover (returns 501 until a privileged
+// root path is provisioned — surfaced as a toast, never an optimistic flip).
+//
+// Deliberately NOT wired yet (need ComfyUI's WS /ws + AMDGPUMonitor, or the
+// privileged path): per-node progress %, it/s, GPU util/temp/clocks, per-job
+// queue names, and the container start/stop/restart controls. Those render in a
+// disabled/"—" state so the layout stays faithful without inventing numbers.
+
+import { useComfyui, useComfyuiSwitchover, COMFYUI_FALLBACK } from '@/api/hooks/useComfyui'
+
+const { useState } = React
+
+// ── icons (16×16, 1.5 stroke — hal0 thin-line family + generation glyphs).
+// Ported from the design's row.jsx so the pane is self-contained.
+const RI = ({ d, size = 16, sw = 1.5, children, fill = 'none' }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill={fill}
+    stroke="currentColor"
+    strokeWidth={sw}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    {d ? <path d={d} /> : children}
+  </svg>
+)
+const RIcons = {
+  comfy: (
+    <RI>
+      <circle cx="4" cy="4" r="2" />
+      <circle cx="12" cy="6" r="2" />
+      <circle cx="6" cy="12" r="2" />
+      <path d="M6 4.5l4 1M5.4 10.2l5-3.6" />
+    </RI>
+  ),
+  stop: (
+    <RI>
+      <rect x="4" y="4" width="8" height="8" rx="1" />
+    </RI>
+  ),
+  ext: <RI d="M6 3H3v10h10v-3M9 3h4v4M9 9l4-4" />,
+  image: (
+    <RI>
+      <rect x="2.5" y="3" width="11" height="10" rx="1.5" />
+      <circle cx="6" cy="6.5" r="1.2" />
+      <path d="M3 11l3-2.5 2.5 2 2-1.5L13 11.5" />
+    </RI>
+  ),
+  video: (
+    <RI>
+      <rect x="2" y="4" width="9" height="8" rx="1.5" />
+      <path d="M11 7l3-2v6l-3-2z" />
+    </RI>
+  ),
+  layers: (
+    <RI>
+      <path d="M8 2l6 3-6 3-6-3 6-3z" />
+      <path d="M2 8l6 3 6-3M2 11l6 3 6-3" />
+    </RI>
+  ),
+  cube: (
+    <RI>
+      <path d="M8 2l5.5 3v6L8 14l-5.5-3V5L8 2z" />
+      <path d="M8 8l5.5-3M8 8v6M8 8L2.5 5" />
+    </RI>
+  ),
+  bolt: <RI d="M9 2L4 9h3l-1 5 5-7H8l1-5z" fill="currentColor" />,
+  queue: <RI d="M3 4h10M3 8h10M3 12h6" />,
+  cancel: (
+    <RI>
+      <circle cx="8" cy="8" r="5.5" />
+      <path d="M6 6l4 4M10 6l-4 4" />
+    </RI>
+  ),
+  chev: <RI d="M4 6l4 4 4-4" />,
+  mem: (
+    <RI>
+      <rect x="2" y="5" width="12" height="6" rx="1" />
+      <path d="M5 5V3M8 5V3M11 5V3M5 13v-2M11 13v-2" />
+    </RI>
+  ),
+  logs: <RI d="M3 3h10M3 6h10M3 9h7M3 12h5" />,
+  refresh: (
+    <RI>
+      <path d="M14 8a6 6 0 1 1-2-4.5" />
+      <path d="M14 1v3.5h-3.5" />
+    </RI>
+  ),
+  close: <RI d="M4 4l8 8M12 4l-4 4" />,
+  warn: (
+    <RI>
+      <path d="M8 2l6 11H2L8 2z" />
+      <path d="M8 7v3M8 12v0.01" />
+    </RI>
+  ),
+}
+const Ic = ({ name, size = 16 }) =>
+  RIcons[name] ? React.cloneElement(RIcons[name], { size }) : null
+
+function Toggle({ on, comfy = false, busy = false }) {
+  return (
+    <span
+      className={'toggle' + (on ? ' on' : '') + (comfy ? ' comfy' : '') + (busy ? ' busy' : '')}
+    >
+      <span className="knob" />
+    </span>
+  )
+}
+
+function EngineGlyph() {
+  return (
+    <span className="engine-glyph">
+      <Ic name="comfy" size={16} />
+    </span>
+  )
+}
+
+// GTT (iGPU) gauge over the 80GB ceiling + a RAM bar under it. `null` used
+// values render an em-dash bar rather than a fabricated fill.
+function GttGauge({ usedGb, ceil = 80, ramGb, ramCeil = 96, pressure = false }) {
+  const pct = usedGb == null ? 0 : Math.min(100, (usedGb / ceil) * 100)
+  const ramPct = ramGb == null ? 0 : Math.min(100, (ramGb / ramCeil) * 100)
+  return (
+    <div className="gauge">
+      <div className="gauge-h">
+        <span>GTT (iGPU)</span>
+        <span>
+          <b>{usedGb == null ? '—' : usedGb}</b> / {ceil} <span className="ceil">GB</span>
+        </span>
+      </div>
+      <div className="gauge-track">
+        <i className={pressure ? 'warnz' : 'comfy'} style={{ width: pct + '%' }} />
+      </div>
+      <div className="gauge-h" style={{ marginTop: 4 }}>
+        <span style={{ color: 'var(--fg-4)' }}>RAM</span>
+        <span style={{ color: 'var(--fg-3)' }}>
+          {ramGb == null ? '—' : ramGb} / {ramCeil} GB
+        </span>
+      </div>
+      <div className="gauge-track" style={{ height: 6 }}>
+        <i className="os" style={{ width: ramPct + '%' }} />
+      </div>
+      {pressure && (
+        <div className="gauge-note pressure">⚠ memory pressure — no swap on this host</div>
+      )}
+    </div>
+  )
+}
+
+// ComfyUI's own web UI lives on the runtime host's :8188 (the dashboard is
+// served from :8080), so links derive from the current hostname.
+function comfyHref() {
+  const host =
+    typeof window !== 'undefined' && window.location ? window.location.hostname : '127.0.0.1'
+  return `http://${host}:8188`
+}
+
+function toast(msg, kind) {
+  if (typeof window !== 'undefined' && window.__hal0Toast) window.__hal0Toast(msg, kind)
+}
+
+const STATE_LABEL = {
+  stopped: 'stopped',
+  starting: 'starting…',
+  running: 'running · idle',
+  generating: 'generating',
+  error: 'error',
+}
+
+// Switchover confirm — states the blast radius before flipping the iGPU.
+function SwitchoverConfirm({ target, queuePending, busy, onCancel, onConfirm }) {
+  const toGen = target === 'generation'
+  return (
+    <div className="cf-scrim" onClick={onCancel}>
+      <div className="cf" onClick={(e) => e.stopPropagation()}>
+        <div className="cf-h">
+          <div className={'cf-eye' + (toGen ? '' : ' warn')}>
+            {toGen ? 'ComfyUI · take the iGPU' : 'Inference · restore the LLM stack'}
+          </div>
+          <h3 className="cf-title">
+            {toGen ? 'Switch to generation mode?' : 'Switch back to inference mode?'}
+          </h3>
+        </div>
+        <div className="cf-b">
+          <p className="cf-lede">
+            {toGen ? (
+              <>
+                Only one of <span className="mono">{'{ inference, ComfyUI }'}</span> can hold the
+                single iGPU. Switching stops the LLM runtime and starts the ComfyUI container.
+              </>
+            ) : (
+              <>
+                This stops the ComfyUI container and restarts the LLM runtime. In-flight renders
+                are not interrupted by the dashboard — drain the queue first.
+              </>
+            )}
+          </p>
+          {toGen && (
+            <div className="cf-blast">
+              <div className="row">
+                <span className="ic">
+                  <Ic name="warn" size={14} />
+                </span>
+                Telegram / Discord bots go dark until you switch back.
+              </div>
+              <div className="row">
+                <span className="ic">
+                  <Ic name="warn" size={14} />
+                </span>
+                Background memory extraction pauses (NPU gemma3-4b via lemonade); it recovers
+                automatically. Embeddings + rerank are CPU-pinned and unaffected.
+              </div>
+            </div>
+          )}
+          {!toGen && queuePending > 0 && (
+            <div className="cf-guard">
+              <Ic name="warn" size={14} /> {queuePending} job{queuePending === 1 ? '' : 's'} still
+              queued — they will be dropped when the container stops.
+            </div>
+          )}
+          <div className="cf-steps">
+            {toGen ? (
+              <>
+                <span className="n">1</span> <span className="cmd">stop-inference.sh</span>{' '}
+                <span className="arr">→</span> <span className="cmd">comfy-up.sh</span>
+              </>
+            ) : (
+              <>
+                <span className="n">1</span> <span className="cmd">comfy-down.sh</span>{' '}
+                <span className="arr">→</span> <span className="cmd">start-inference.sh</span>
+              </>
+            )}
+          </div>
+        </div>
+        <div className="cf-f">
+          <span className="note">runs root-owned scripts on the runtime host</span>
+          <span className="grow" style={{ flex: 1 }} />
+          <button className="rbtn" onClick={onCancel} disabled={busy}>
+            Cancel
+          </button>
+          <button
+            className={'rbtn ' + (toGen ? 'primary' : 'danger')}
+            onClick={onConfirm}
+            disabled={busy}
+          >
+            {busy ? 'switching…' : toGen ? 'Switch to generation' : 'Switch to inference'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const FLOWS = [
+  { ic: 'image', a: 'text', b: 'image', note: 'qwen-image' },
+  { ic: 'image', a: 'image', b: 'image' },
+  { ic: 'video', a: 'text', b: 'video', note: 'wan 2.2' },
+  { ic: 'video', a: 'image', b: 'video', note: 'i2v' },
+  { ic: 'layers', a: 'still', b: 'animate', note: 'chain' },
+  { ic: 'cube', a: 'upscale', b: '4×' },
+]
+
+export function ComfyuiPane() {
+  const q = useComfyui()
+  const sw = useComfyuiSwitchover()
+  const st = q.data || COMFYUI_FALLBACK
+  const [open, setOpen] = useState(false)
+  const [confirm, setConfirm] = useState(null) // target mode or null
+
+  const gen = st.mode === 'generation'
+  const containerUp = st.container?.state === 'running'
+  const engine = st.engine || 'stopped'
+  const stateLabel = STATE_LABEL[engine] || engine
+  const mem = st.memory
+  const gtt = mem?.gtt_used_gb ?? null
+  const gttCeil = mem?.gtt_ceil_gb ?? 80
+  const ram = mem?.ram_used_gb ?? null
+  const ramCeil = mem?.ram_ceil_gb ?? 96
+  const pressure = !!mem?.pressure
+  const running = st.queue?.running || 0
+  const pending = st.queue?.pending || 0
+  const queueTotal = running + pending
+  const inv = st.inventory
+
+  const href = comfyHref()
+  const openComfy = () => window.open(href, '_blank', 'noopener')
+
+  const doSwitch = async () => {
+    const target = confirm
+    try {
+      await sw.mutateAsync({ mode: target })
+      toast(`Switching to ${target} mode…`, 'ok')
+      setConfirm(null)
+      setTimeout(() => q.refetch(), 1500)
+    } catch (err) {
+      setConfirm(null)
+      // Hal0Error carries the backend envelope's code directly (e.g.
+      // comfyui.switchover_disabled / _unimplemented) + the HTTP status.
+      const code = err?.code || ''
+      if (String(code).includes('switchover') || err?.status === 501 || err?.status === 503) {
+        toast(
+          'ComfyUI switchover is not wired yet — run the switch scripts on the host, or enable ' +
+            'HAL0_COMFYUI_SWITCHOVER_ENABLED once a scoped sudoers path is in place.',
+          'warn'
+        )
+      } else {
+        toast(err?.message ? `switchover failed: ${err.message}` : 'switchover failed', 'warn')
+      }
+    }
+  }
+
+  return (
+    <div className="comfy-pane">
+      <div className="proto">
+        {/* section label */}
+        <div className="sec-label">
+          <b>Generation Engine</b>
+          <span className="dim">·</span>
+          <span className="mono" style={{ color: 'var(--comfy)' }}>
+            ComfyUI
+          </span>
+          <span className="dim">·</span>
+          <span className="meta">1 container</span>
+          <span className="dim">·</span>
+          <span className="meta">exclusive iGPU</span>
+          <span className="grow" style={{ flex: 1 }} />
+          <span className="meta">{containerUp ? 'docker · :8188' : 'docker · stopped'}</span>
+        </div>
+
+        <div className={'engine' + (gen ? ' active' : '') + (open ? ' open' : '')}>
+          {/* header */}
+          <div className="engine-h">
+            <EngineGlyph />
+            <span className="col">
+              <span className="engine-title">ComfyUI</span>
+              <span className="engine-sub">generation engine · docker</span>
+            </span>
+            <span className={'epill ' + engine}>
+              <span className="dot" />
+              {stateLabel}
+            </span>
+            <span className="grow" style={{ flex: 1 }} />
+            <span className="eh-right">
+              <button
+                className="rbtn ghost-comfy"
+                disabled={!containerUp}
+                style={!containerUp ? { opacity: 0.4 } : null}
+                onClick={openComfy}
+                title={containerUp ? 'Open ComfyUI' : 'ComfyUI is not running'}
+              >
+                <Ic name="ext" size={13} /> Open ↗
+              </button>
+              <span
+                className="sw-wrap"
+                onClick={() => setConfirm(gen ? 'inference' : 'generation')}
+                style={{ cursor: 'pointer' }}
+                title="Switch the iGPU between inference and generation"
+              >
+                <span className={'mode' + (!gen ? ' llm-on' : '')}>inference</span>
+                <Toggle on={gen} comfy busy={sw.isPending} />
+                <span className={'mode' + (gen ? ' on' : '')}>generation</span>
+              </span>
+            </span>
+          </div>
+
+          {/* collapsed telemetry strip — real read-only metrics inline */}
+          {containerUp && !open && (
+            <div className="collapsed-prog">
+              <div className="tel-strip">
+                <span className="tel">
+                  <span className="l">GTT</span>
+                  <span className="minibar">
+                    <i
+                      style={{
+                        width: (gtt == null ? 0 : (gtt / gttCeil) * 100) + '%',
+                        background: pressure ? 'var(--warn)' : 'var(--comfy)',
+                      }}
+                    />
+                  </span>
+                  <span className={'v' + (pressure ? ' warn' : '')}>
+                    {gtt == null ? '—' : gtt}
+                    <span className="u">/{gttCeil} GB</span>
+                  </span>
+                </span>
+                <span className="tel">
+                  <span className="l">RAM</span>
+                  <span className="v">
+                    {ram == null ? '—' : ram}
+                    <span className="u">/{ramCeil} GB</span>
+                  </span>
+                </span>
+                <span className="tel">
+                  <span className="l">queue</span>
+                  {queueTotal > 0 ? (
+                    <span className="qn">{queueTotal}</span>
+                  ) : (
+                    <span className="v dimx">idle</span>
+                  )}
+                  {running > 0 && (
+                    <span className="v dimx" style={{ fontSize: 11 }}>
+                      {running} running
+                    </span>
+                  )}
+                </span>
+                <span className="tel">
+                  <span className="l">engine</span>
+                  <span className="v comfy">{engine}</span>
+                </span>
+                {pressure && (
+                  <span className="tel">
+                    <span className="v warn" style={{ fontSize: 11 }}>
+                      ⚠ no swap
+                    </span>
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* expandable body */}
+          <div className="engine-body">
+            <div className="inner">
+              <div className="engine-b">
+                {/* active job — read-only summary (live per-node progress needs WS) */}
+                <div className="subcard">
+                  <div className="subcard-h">
+                    <Ic name="bolt" size={13} /> active job
+                  </div>
+                  <div className="mono dimx" style={{ fontSize: 12, padding: '2px 0' }}>
+                    {!containerUp
+                      ? 'engine stopped · switch to generation to run jobs'
+                      : running > 0
+                        ? `${running} job${running === 1 ? '' : 's'} running · open ComfyUI for live per-node progress ↗`
+                        : 'engine idle · no job running'}
+                  </div>
+                </div>
+
+                {/* queue (counts from /queue; per-job names live in ComfyUI) */}
+                <div className="queue">
+                  <div className="queue-h">
+                    <Ic name="queue" size={13} /> queue
+                    <span style={{ color: 'var(--fg-5)', marginLeft: 2 }}>· {pending} pending</span>
+                    <span className="grow" style={{ flex: 1 }} />
+                    <span
+                      className="clear"
+                      onClick={openComfy}
+                      style={{ cursor: 'pointer' }}
+                      title="Manage the queue in ComfyUI"
+                    >
+                      open queue ↗
+                    </span>
+                  </div>
+                  <div className="queue-empty">
+                    {queueTotal === 0
+                      ? 'nothing queued · drop a workflow in ComfyUI to enqueue'
+                      : `${running} running · ${pending} pending — manage in ComfyUI ↗`}
+                  </div>
+                </div>
+
+                {/* bottom 50/50 — memory + iGPU | models on share + workflows */}
+                <div className="subgrid" style={{ gridTemplateColumns: '1fr 1fr' }}>
+                  <div className="subcard">
+                    <div className="subcard-h">
+                      <Ic name="mem" size={13} /> memory <span style={{ color: 'var(--fg-5)' }}>· iGPU</span>
+                    </div>
+                    <GttGauge usedGb={gtt} ceil={gttCeil} ramGb={ram} ramCeil={ramCeil} pressure={pressure} />
+                    <div className="gpu-stats">
+                      <span className="gs">
+                        <b style={{ color: 'var(--comfy)' }}>{st.reachable ? engine : '—'}</b>
+                        <span className="u">state</span>
+                      </span>
+                      <span className="gs">
+                        <b>{st.inference?.lemonade ? 'up' : 'down'}</b>
+                        <span className="u">lemonade</span>
+                      </span>
+                      <span className="gs">
+                        <b>{containerUp ? 'up' : 'down'}</b>
+                        <span className="u">container</span>
+                      </span>
+                    </div>
+                  </div>
+                  <div className="subcard">
+                    <div className="subcard-h">
+                      <Ic name="layers" size={13} /> models on share
+                      <span className="grow" style={{ flex: 1 }} />
+                      <span className="rchip comfy" onClick={openComfy} style={{ cursor: 'pointer' }}>
+                        manager ↗
+                      </span>
+                    </div>
+                    {inv ? (
+                      <div className="inv">
+                        <span className="inv-pill">
+                          <b>{inv.checkpoints ?? 0}</b> checkpoints
+                        </span>
+                        <span className="inv-pill">
+                          <b>{inv.diffusion ?? 0}</b> <span className="u">diffusion</span>
+                        </span>
+                        <span className="inv-pill">
+                          <b>{inv.loras ?? 0}</b> loras
+                        </span>
+                        <span className="inv-pill">
+                          <b>{inv.vae ?? 0}</b> vae
+                        </span>
+                      </div>
+                    ) : (
+                      <div className="mono dimx" style={{ fontSize: 11 }}>
+                        model share not mounted
+                      </div>
+                    )}
+
+                    <div className="card-section">
+                      <div className="subcard-h">
+                        <span style={{ color: 'var(--comfy)' }}>
+                          <Ic name="bolt" size={13} />
+                        </span>{' '}
+                        workflows
+                        <span className="grow" style={{ flex: 1 }} />
+                        <span
+                          className="dimx"
+                          style={{ fontSize: 10, textTransform: 'none', letterSpacing: 0 }}
+                        >
+                          opens in ComfyUI ↗
+                        </span>
+                      </div>
+                      <div className="flows">
+                        {FLOWS.map((f, i) => (
+                          <button key={i} className="flow" onClick={openComfy}>
+                            <span className="ic">
+                              <Ic name={f.ic} size={14} />
+                            </span>
+                            <span>{f.a}</span>
+                            <span className="arr">→</span>
+                            <span>{f.b}</span>
+                            {f.note && (
+                              <span className="dimx" style={{ fontSize: 10, marginLeft: 2 }}>
+                                {f.note}
+                              </span>
+                            )}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* container controls — write ops need the privileged path; shown
+                    disabled until that's wired, so the layout stays honest. */}
+                <div className="row-flex">
+                  <button className="rbtn" disabled style={{ opacity: 0.4 }} title="needs the privileged switchover path">
+                    <Ic name="stop" size={13} /> Stop container
+                  </button>
+                  <button className="rbtn" disabled style={{ opacity: 0.4 }} title="needs the privileged switchover path">
+                    <Ic name="refresh" size={13} /> Restart
+                  </button>
+                  <button className="rbtn" onClick={openComfy} title="Open ComfyUI logs / console">
+                    <Ic name="logs" size={13} /> Logs ↗
+                  </button>
+                  <span className="grow" style={{ flex: 1 }} />
+                  <span className="mono dimx" style={{ fontSize: 11 }}>
+                    {st.inference?.lemonade ? 'inference holds the iGPU' : containerUp ? 'generation holds the iGPU' : 'iGPU idle'}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* footer — container identity + queue/caret expand control */}
+          <div className="engine-foot has-q">
+            <div className="foot-id">
+              <span className="k">container</span>
+              <span className="v comfy">{st.container?.name || 'comfyui'}</span>
+              <span className="sep">·</span>
+              <span className="k">state</span>
+              <span className="v">{st.container?.state || 'absent'}</span>
+              <span className="sep">·</span>
+              <span className="k">mode</span>
+              <span className="v comfy">{st.mode}</span>
+              <span className="sep">·</span>
+              <span className="k">endpoint</span>
+              <span className="v comfy">{st.endpoint || '—'}</span>
+            </div>
+            <button
+              className={'qcaret' + (queueTotal === 0 ? ' empty' : '')}
+              onClick={() => setOpen((o) => !o)}
+              aria-expanded={open}
+            >
+              <span className="q">
+                <Ic name="queue" size={13} /> queue
+                {queueTotal > 0 ? (
+                  <span className="qn">{queueTotal}</span>
+                ) : (
+                  <span className="qrun">empty</span>
+                )}
+                {running > 0 && <span className="qrun">· {running} running</span>}
+              </span>
+              <span className="car">
+                <Ic name="chev" size={13} />
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {confirm && (
+        <SwitchoverConfirm
+          target={confirm}
+          queuePending={pending}
+          busy={sw.isPending}
+          onCancel={() => setConfirm(null)}
+          onConfirm={doSwitch}
+        />
+      )}
+    </div>
+  )
+}
+
+Object.assign(window, { ComfyuiPane })

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -17,7 +17,9 @@ import {
 } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
 import { useLemonadeConfig, useLemonadeConfigSet } from '@/api/hooks/useLemonadeConfig'
+import { useComfyui } from '@/api/hooks/useComfyui'
 import { MemoryMap } from './memory-map'
+import { ComfyuiPane } from './comfyui-pane.jsx'
 import { slotIndicatorFromPhase, isSlotLive } from './slot-status.js'
 
 const { useState: useStateS } = React;
@@ -895,6 +897,13 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
   const [swapName, setSwapName] = useStateS(null);
   const [logsForSlot, setLogsForSlot] = useStateS(null);
   const [busyName, setBusyName] = useStateS(null);
+  // Slots-page tabs: "inference" (chat/embed/voice/npu) vs "image" (the ComfyUI
+  // generation engine pane). ComfyUI is one container engine, not per-model
+  // slots, and is mutually exclusive with the LLM stack — so it gets its own
+  // tab instead of a SlotCard in the Image group.
+  const [tab, setTab] = useStateS("inference");
+  const comfyQuery = useComfyui({ active: tab === "image" });
+  const comfyLive = comfyQuery.data?.container?.state === "running";
   const { active: activeBanners } = useBanners();
   const skipPath = !!activeBanners["skip-path"];
 
@@ -1224,25 +1233,54 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
         <button className="btn" onClick={() => setCreateOpen(true)}>{Icons.plus} New slot</button>
       </div>
 
+      {/* Inference ⇄ Image Gen tabs. Tab 1 holds every non-image slot; tab 2 is
+          the ComfyUI generation engine pane (one container, not per-model
+          slots), which replaces the old Image-group SlotCard. */}
+      <div className="slot-tabs" role="tablist">
+        <button
+          role="tab"
+          aria-selected={tab === "inference"}
+          className={"slot-tab" + (tab === "inference" ? " on" : "")}
+          onClick={() => setTab("inference")}
+        >
+          <span>Inference</span>
+          <span className="slot-tab-ct num">{slots.length - groups.img.length}</span>
+        </button>
+        <button
+          role="tab"
+          aria-selected={tab === "image"}
+          className={"slot-tab comfy" + (tab === "image" ? " on" : "")}
+          onClick={() => setTab("image")}
+        >
+          <span className={"slot-tab-dot" + (comfyLive ? " live" : "")} />
+          <span>Image Gen</span>
+        </button>
+      </div>
+
       <div className="dash">
         <div className="dash-main">
-          {renderGroup("Chat", groups.chat)}
-          {/* Capabilities (C7): embedding/reranking/transcription/tts cards are
-              content-light, so they render in a denser 4-up quarter-width grid
-              instead of two separate full-width Embed/Voice sections. NPU
-              modalities (group "npu") are excluded by grouping — they live in
-              the dedicated NPU/FLM stack section below. */}
-          {renderGroup("Capabilities", [...groups.embed, ...groups.voice], { quarter: true })}
-          {renderGroup("Image", groups.img)}
+          {tab === "image" ? (
+            <ComfyuiPane />
+          ) : (
+            <>
+              {renderGroup("Chat", groups.chat)}
+              {/* Capabilities (C7): embedding/reranking/transcription/tts cards are
+                  content-light, so they render in a denser 4-up quarter-width grid
+                  instead of two separate full-width Embed/Voice sections. NPU
+                  modalities (group "npu") are excluded by grouping — they live in
+                  the dedicated NPU/FLM stack section below. */}
+              {renderGroup("Capabilities", [...groups.embed, ...groups.voice], { quarter: true })}
 
-          {slots.some(s => s.device === "npu") && (
-            <section style={{marginBottom: 24}}>
-              <div className="sec">
-                <h2>NPU<span className="ct mono">trio · 1 process · 3 roles</span></h2>
-                <div className="rule" />
-              </div>
-              <NpuFlmStack slots={slots} />
-            </section>
+              {slots.some(s => s.device === "npu") && (
+                <section style={{marginBottom: 24}}>
+                  <div className="sec">
+                    <h2>NPU<span className="ct mono">trio · 1 process · 3 roles</span></h2>
+                    <div className="rule" />
+                  </div>
+                  <NpuFlmStack slots={slots} />
+                </section>
+              )}
+            </>
           )}
         </div>
         <div className="dash-side">

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -54,6 +54,16 @@
   --dev-cpu:      #9c9c95;
   --dev-npu:      #c896ff;
 
+  /* ComfyUI "generation engine" accent — its own blue the way the NPU stack
+     owns purple. Mirrored in comfyui-pane.css (scoped to .comfy-pane); kept
+     here so the slots-page Image-Gen tab can glow the same hue. */
+  --comfy:        #5ea4f9;
+  --comfy-hi:     #8cc0ff;
+  --comfy-soft:   rgba(94, 164, 249, 0.10);
+  --comfy-line:   rgba(94, 164, 249, 0.34);
+  --comfy-bg:     #0c1622;
+  --comfy-glow:   rgba(94, 164, 249, 0.20);
+
   /* Memory-map tenant colours — rotated for distinguishability vs the
      device colours used in slot segments. Amber-on-grey palette. */
   --mem-tenant-1: #b89060;
@@ -750,6 +760,26 @@ a { color: inherit; text-decoration: none; }
 }
 .dash-main { display: flex; flex-direction: column; gap: 16px; min-width: 0; }
 .dash-side { display: flex; flex-direction: column; gap: 16px; position: sticky; top: 12px; }
+
+/* Slots-page tabs — "Inference" (all non-image slots) ⇄ "Image Gen" (the
+   ComfyUI generation engine). Mirrors the .mcp-tabs idiom; the Image-Gen tab
+   glows ComfyUI blue when active, the way that engine owns the colour. */
+.slot-tabs { display: inline-flex; border: 1px solid var(--line); border-radius: var(--rad); overflow: hidden; margin-bottom: 20px; }
+.slot-tab {
+  display: inline-flex; align-items: center; gap: 8px; padding: 6px 14px;
+  background: transparent; border: none; border-right: 1px solid var(--line);
+  font-family: var(--jbm); font-size: 12px; color: var(--fg-3); cursor: pointer;
+  letter-spacing: 0.02em; transition: color 0.12s ease, background 0.12s ease;
+}
+.slot-tab:last-child { border-right: none; }
+.slot-tab:hover { color: var(--fg); background: var(--bg-2); }
+.slot-tab.on { color: var(--accent); background: var(--accent-bg); }
+.slot-tab.on.comfy { color: var(--comfy); background: var(--comfy-bg); }
+.slot-tab .slot-tab-ct { font-size: 10px; color: var(--fg-5); padding: 1px 6px; background: var(--bg-2); border-radius: 999px; min-width: 16px; text-align: center; }
+.slot-tab.on .slot-tab-ct { color: var(--accent); background: transparent; }
+.slot-tab.on.comfy .slot-tab-ct { color: var(--comfy); }
+.slot-tab .slot-tab-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--fg-5); }
+.slot-tab .slot-tab-dot.live { background: var(--comfy); box-shadow: 0 0 8px var(--comfy); }
 
 /* Main 50/50 row — Memory map | Throughput (home-redesign 2026-06-05).
    Both halves are .side-card so they read as a matched pair. */

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -29,6 +29,7 @@ import './globals-install'
 //    `window` via `Object.assign(window, …)`.
 import './dashboard.css'
 import './mcp.css'
+import './dash/comfyui-pane.css'
 
 import './dash/data.jsx'
 import './dash/tweaks-panel.jsx'


### PR DESCRIPTION
## What

Adds a clean **tabbed interface** to the slots page (from the Claude Design exploration `explorations/comfyui-row`):

- **Inference** tab — all current non-image slots (chat · embed · voice · NPU stack)
- **Image Gen** tab — ComfyUI rendered as **one containerized generation engine** (not per-model slots), which **replaces** the old `img.img` SlotCard so ComfyUI isn't shown twice.

The pane mirrors the design `comfyui-pane.html`: collapsed telemetry strip, expandable body (active job · queue · memory gauge · models-on-share + workflow launchers · container controls), footer identity + queue/caret, and the **inference ⇄ generation switchover toggle** with a blast-radius confirm dialog (bots dark, memory-extraction pauses, queue-drain guard).

## Backend (read-only, TDD — 8 tests)

- `GET /api/comfyui/status` — aggregates `docker inspect comfyui` + `systemctl is-active hal0-lemonade/hal0-agent@hermes` + ComfyUI `/system_stats` + `/queue`. Fail-soft (a dead container reads as `stopped`, never a 500). GTT + RAM ceilings are **derived from the device**, verified live on CT105 (`vram_total`=80 GB GTT, `ram_total`=124.5 GB — *not* the brief's 96), never hardcoded.
- `POST /api/comfyui/switchover` — **feature-gated**: `501` off / `503` unimplemented when `HAL0_COMFYUI_SWITCHOVER_ENABLED=1`. The privileged root-script path (sudoers/root-helper for `stop-inference.sh`/`comfy-up.sh`…) is a separate, explicitly-confirmed step.

## Notes

- Polling is **tab-gated** (4 s on the Image tab, 20 s idle) to spare ComfyUI's embedded HTTP server — same rationale as `lemonade_proxy`'s caching.
- CSS auto-scoped under `.comfy-pane` (no global collisions); `--comfy*` accent + `.slot-tab` styles in `dashboard.css`.
- **Deferred** (rendered disabled/"—", never faked): WS-only per-node progress, it/s, GPU util/temp/clocks; container start/stop/restart (need the privileged path).

## Verified

- 8 backend tests · ruff + format clean · UI typecheck + build green
- Parser run against the **real CT105 `comfyui` container** (GTT 39.3/80, RAM 82.8/124, queue, engine state — all sane)
- 4 UI states confirmed via Playwright (stopped · generating-collapsed · expanded · switchover dialog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)