### PR TITLE
fix(providers): FLM ctx-len reads [model].context_size (container slot shape)

### DIFF
--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -155,7 +155,13 @@ class FLMProvider(Provider):
         debug shells, native systemd fallback) can use them too.
         """
         port = slot_cfg.get("port") or slot_cfg.get("slot", {}).get("port", 8086)
-        ctx = slot_cfg.get("ctx_size") or slot_cfg.get("defaults", {}).get("context_size", 8192)
+        # [model].context_size is the SlotConfig shape (container slots);
+        # ctx_size / defaults.context_size are lemond-era legacy shapes.
+        ctx = (
+            (slot_cfg.get("model") or {}).get("context_size")
+            or slot_cfg.get("ctx_size")
+            or slot_cfg.get("defaults", {}).get("context_size", 8192)
+        )
         flm_tag = model_info.get("flm_tag") or model_info.get("_model_key") or "qwen3:0.6b"
 
         npu_table = slot_cfg.get("npu") or {}

--- a/tests/providers/test_flm_container_spec.py
+++ b/tests/providers/test_flm_container_spec.py
@@ -55,3 +55,23 @@ def test_default_models_dir_is_flm_cache() -> None:
         "/var/lib/hal0/.config/flm/models",
         "/var/lib/hal0/.config/flm/models",
     ) in spec.mounts
+
+
+def test_model_table_context_size_drives_ctx_len() -> None:
+    """[model].context_size (SlotConfig shape) must reach --ctx-len.
+
+    Regression: build_env read only the lemond-era ctx_size/defaults shapes
+    and silently fell back to 8192 for container slots (live repro on CT105,
+    Phase A deploy).
+    """
+    spec = FLMProvider().container_spec(_slot_cfg(), _model_info())
+    idx = spec.command.index("--ctx-len")
+    assert spec.command[idx + 1] == "16384"
+
+
+def test_legacy_ctx_size_still_wins_when_model_table_absent() -> None:
+    cfg = _slot_cfg(ctx_size=4096)
+    cfg["model"] = {"default": "gemma3:4b"}  # no context_size
+    spec = FLMProvider().container_spec(cfg, _model_info())
+    idx = spec.command.index("--ctx-len")
+    assert spec.command[idx + 1] == "4096"


### PR DESCRIPTION
Live repro on CT105 during the Phase A deploy (#688): npu.toml `context_size = 65536` rendered `--ctx-len 8192` — build_env only knew the lemond-era `ctx_size`/`defaults.context_size` shapes. Precedence now: model.context_size → ctx_size → defaults → 8192. Two regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)