### PR TITLE
feat(comfyui): wire the switchover write-path (inference ⇄ generation)

### DIFF
--- a/packaging/sudoers/hal0-comfyui
+++ b/packaging/sudoers/hal0-comfyui
@@ -1,0 +1,22 @@
+# hal0 — ComfyUI switchover grant for an UNPRIVILEGED hal0-api.
+#
+# On CT105 today hal0-api runs as root and execs /opt/comfyui/*.sh directly;
+# this file is for the hardened install model where hal0-api runs as the
+# `hal0` system user. The API invokes the scripts via `sudo -n <abs path>`
+# (src/hal0/api/routes/comfyui.py:_script_argv), so the grant is exactly the
+# six absolute script paths — no wildcards, no shell, no extra args.
+#
+# Install (as root):
+#   install -m 0440 packaging/sudoers/hal0-comfyui /etc/sudoers.d/hal0-comfyui
+#   visudo -cf /etc/sudoers.d/hal0-comfyui
+#
+# The scripts themselves must stay root-owned 0755 (they are the privilege
+# boundary — a hal0-writable script under this grant would be root escalation).
+
+hal0 ALL=(root) NOPASSWD: \
+    /opt/comfyui/stop-inference.sh, \
+    /opt/comfyui/start-inference.sh, \
+    /opt/comfyui/comfy-up.sh, \
+    /opt/comfyui/comfy-down.sh, \
+    /opt/comfyui/comfy-logs.sh, \
+    /opt/comfyui/comfy-postinstall.sh

--- a/src/hal0/api/routes/comfyui.py
+++ b/src/hal0/api/routes/comfyui.py
@@ -14,11 +14,14 @@ renders that engine pane from ``GET /api/comfyui/status``, which folds together:
 Every source degrades to a safe default — the pane polls this every few seconds
 and a dead container must surface as "stopped", never a 500.
 
-The switchover *write* path (``POST /api/comfyui/switchover``) runs root-owned
-scripts (``stop-inference.sh`` / ``comfy-up.sh`` …) via systemctl + docker on the
-shared runtime. hal0-api is unprivileged, so that path needs a narrowly-scoped
-sudoers rule / root helper wired in a separate, explicitly-confirmed step. Until
-then it is feature-gated behind ``HAL0_COMFYUI_SWITCHOVER_ENABLED`` and refuses.
+The switchover *write* path (``POST /api/comfyui/switchover``) runs the
+root-owned script pairs in ``/opt/comfyui`` (``stop-inference.sh`` →
+``comfy-up.sh`` for generation, ``comfy-down.sh`` → ``start-inference.sh`` for
+inference) in the background behind a 202; the ``switchover`` block on /status
+tracks the transition. Privilege-aware: as root (hal0-api on CT105 runs
+``User=root``) the scripts exec directly, otherwise via ``sudo -n`` against the
+narrow ``packaging/sudoers/hal0-comfyui`` grant. The whole path stays
+feature-gated behind ``HAL0_COMFYUI_SWITCHOVER_ENABLED`` (501 when off).
 """
 
 from __future__ import annotations
@@ -30,7 +33,7 @@ import shutil
 from typing import Any
 
 import httpx
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, BackgroundTasks, Request
 from fastapi.responses import JSONResponse
 
 router = APIRouter()
@@ -45,12 +48,25 @@ _PRESSURE_GB = 50
 _LEMONADE_UNIT = "hal0-lemonade.service"
 _HERMES_UNIT = "hal0-agent@hermes.service"
 
+# Switchover script pairs, run in order from the scripts dir on the runtime
+# host. ON hands the iGPU to ComfyUI; OFF hands it back to the LLM stack.
+_SWITCH_PAIRS: dict[str, tuple[str, ...]] = {
+    "generation": ("stop-inference.sh", "comfy-up.sh"),
+    "inference": ("comfy-down.sh", "start-inference.sh"),
+}
+
 # Short connect so a dead engine surfaces fast; the read budget is modest because
 # /system_stats and /queue are cheap snapshots.
 _DEFAULT_TIMEOUT = httpx.Timeout(connect=1.5, read=4.0, write=2.0, pool=2.0)
 _POOL_LIMITS = httpx.Limits(max_connections=4, max_keepalive_connections=2)
 
 _client: httpx.AsyncClient | None = None
+
+# In-flight switchover tracker. Module-global on purpose: there is exactly one
+# iGPU, so there is exactly one switch — /status surfaces it so the pane's poll
+# can render "switching…" and any error from the last attempt.
+_SWITCH_IDLE: dict[str, Any] = {"active": False, "target": None, "error": None}
+_switch: dict[str, Any] = dict(_SWITCH_IDLE)
 
 
 def _comfyui_base_url() -> str:
@@ -87,9 +103,11 @@ async def aclose_client() -> None:
 
 
 def _reset_state() -> None:
-    """Drop the shared client. For test isolation only."""
+    """Drop the shared client + switch tracker. For test isolation only."""
     global _client
     _client = None
+    _switch.clear()
+    _switch.update(_SWITCH_IDLE)
 
 
 async def _fetch_json(path: str) -> dict[str, Any] | None:
@@ -289,16 +307,82 @@ async def comfyui_status(request: Request) -> dict[str, Any]:
         "queue": counts,
         "inference": {"lemonade": lemonade, "hermes": hermes},
         "inventory": _model_inventory(),
+        "switchover": dict(_switch),
     }
 
 
+def _scripts_dir() -> str:
+    return os.environ.get("COMFYUI_SCRIPTS_DIR", "/opt/comfyui")
+
+
+def _script_timeout() -> float:
+    # comfy-up.sh on a FRESH container create waits for HTTP and pip-installs
+    # custom-node deps — minutes, not seconds. The resume path is fast.
+    try:
+        return float(os.environ.get("COMFYUI_SCRIPT_TIMEOUT", "600"))
+    except ValueError:
+        return 600.0
+
+
+def _script_argv(name: str) -> list[str]:
+    """Argv for one switchover script, privilege-aware.
+
+    Root (CT105 today: hal0-api runs as ``User=root``) execs the script
+    directly. An unprivileged hal0-api goes through ``sudo -n`` against the
+    narrow ``/etc/sudoers.d/hal0-comfyui`` grant (absolute paths only); ``-n``
+    so a missing grant fails immediately instead of hanging on a password
+    prompt.
+    """
+    path = os.path.join(_scripts_dir(), name)
+    return [path] if os.geteuid() == 0 else ["sudo", "-n", path]
+
+
+async def _run_script(name: str) -> None:
+    """Execute one switchover script to completion; raises on failure."""
+    argv = _script_argv(name)
+    timeout = _script_timeout()
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    try:
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        raise RuntimeError(f"{name} timed out after {timeout:.0f}s") from None
+    if proc.returncode != 0:
+        tail = out.decode("utf-8", "replace").strip().splitlines()[-5:]
+        raise RuntimeError(f"{name} exited {proc.returncode}: {' | '.join(tail)}")
+
+
+async def _run_switch(mode: str) -> None:
+    """Run the script pair for ``mode``; record failure for /status to surface."""
+    try:
+        for name in _SWITCH_PAIRS[mode]:
+            await _run_script(name)
+    except Exception as exc:  # any script failure must land in /status, never raise
+        _switch["error"] = f"{mode}: {exc}"
+    finally:
+        _switch["active"] = False
+        _switch["target"] = None
+
+
 @router.post("/switchover")
-async def comfyui_switchover(request: Request) -> JSONResponse:
+async def comfyui_switchover(request: Request, background_tasks: BackgroundTasks) -> JSONResponse:
     """Flip the iGPU between LLM inference and ComfyUI generation.
 
-    Gated: the underlying scripts need root (systemctl + docker) and take the
-    messaging bots + memory extraction offline, so the privileged path is wired
-    only behind ``HAL0_COMFYUI_SWITCHOVER_ENABLED`` in a separate confirmed step.
+    Body: ``{"mode": "generation" | "inference", "force": bool}``. Refuses while
+    a switch is in flight (409), no-ops when already in the target mode (200),
+    and refuses to drop a busy render queue without ``force`` (409). Otherwise
+    answers 202 and runs the script pair in the background — track completion
+    via the ``switchover`` block on ``GET /status``.
+
+    Stays gated behind ``HAL0_COMFYUI_SWITCHOVER_ENABLED`` because the scripts
+    take the messaging bots + memory extraction offline (an operator decision
+    per host), not because the path is unwired.
     """
     if os.environ.get("HAL0_COMFYUI_SWITCHOVER_ENABLED", "0") != "1":
         return JSONResponse(
@@ -307,26 +391,84 @@ async def comfyui_switchover(request: Request) -> JSONResponse:
                 "error": {
                     "code": "comfyui.switchover_disabled",
                     "message": (
-                        "ComfyUI switchover is not enabled. It runs root-owned "
-                        "scripts on the shared runtime; set "
-                        "HAL0_COMFYUI_SWITCHOVER_ENABLED=1 only once a scoped "
-                        "sudoers/root-helper path is in place."
+                        "ComfyUI switchover is disabled on this host. It stops "
+                        "the LLM stack (bots + memory extraction go dark) while "
+                        "generation holds the iGPU; set "
+                        "HAL0_COMFYUI_SWITCHOVER_ENABLED=1 on hal0-api to "
+                        "enable it."
                     ),
                 }
             },
         )
-    # Flag on, but the privileged execution path is intentionally not wired yet.
+    try:
+        body = await request.json()
+    except ValueError:
+        body = None
+    mode = body.get("mode") if isinstance(body, dict) else None
+    if mode not in _SWITCH_PAIRS:
+        return JSONResponse(
+            status_code=422,
+            content={
+                "error": {
+                    "code": "comfyui.invalid_mode",
+                    "message": "body must be {'mode': 'generation' | 'inference'}",
+                }
+            },
+        )
+    # One switch at a time — racing systemctl/docker pairs is never right. Checked
+    # before the noop probe so a mid-flight flip is reported as in-progress, not
+    # as "already there" based on a half-transitioned snapshot.
+    if _switch["active"]:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": {
+                    "code": "comfyui.switch_in_progress",
+                    "message": f"a switch to {_switch['target']} is already running",
+                }
+            },
+        )
+    # Idempotency: derive the current mode the same way /status does (container
+    # running ⇒ generation). Target inference additionally requires lemonade to
+    # actually be up — if both stacks are down, the switch runs as a repair.
+    container, lemonade = await asyncio.gather(
+        _container_state(_comfyui_container()),
+        _systemd_active(_LEMONADE_UNIT),
+    )
+    already_there = (
+        container == "running" if mode == "generation" else container != "running" and lemonade
+    )
+    if already_there:
+        return JSONResponse(status_code=200, content={"status": "noop", "mode": mode})
+    # Mid-render guard: switching to inference stops the container, dropping any
+    # running/pending renders. Refuse unless the caller forces it — the dashboard
+    # confirm dialog states the blast radius and passes force on user confirm.
+    force = bool(body.get("force")) if isinstance(body, dict) else False
+    if mode == "inference" and not force:
+        counts = _queue_counts(await _fetch_json("/queue"))
+        busy = counts["running"] + counts["pending"]
+        if busy:
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "error": {
+                        "code": "comfyui.busy",
+                        "message": (
+                            f"{busy} render job(s) running or queued would be dropped; "
+                            "retry with {'force': true} to switch anyway."
+                        ),
+                        "queue": counts,
+                    }
+                },
+            )
+    # Dispatch in the background and answer 202 immediately — the pair takes
+    # seconds to tens of seconds (service stop/start, container boot) and the
+    # pane's /status poll tracks the transition via the switchover block.
+    _switch.update(active=True, target=mode, error=None)
+    background_tasks.add_task(_run_switch, mode)
     return JSONResponse(
-        status_code=503,
-        content={
-            "error": {
-                "code": "comfyui.switchover_unimplemented",
-                "message": (
-                    "switchover is enabled but the privileged root path has not "
-                    "been provisioned on this host yet."
-                ),
-            }
-        },
+        status_code=202,
+        content={"status": "switching", "mode": mode, "scripts": list(_SWITCH_PAIRS[mode])},
     )
 
 

--- a/tests/api/test_comfyui_proxy.py
+++ b/tests/api/test_comfyui_proxy.py
@@ -11,8 +11,12 @@ crash on a dead container):
   - ComfyUI's own HTTP API (``/system_stats`` + ``/queue``) for live telemetry
 
 The switchover *write* path (POST /api/comfyui/switchover) is feature-gated
-behind ``HAL0_COMFYUI_SWITCHOVER_ENABLED`` and returns 501 until a privileged
-root path is wired in a separate, explicitly-confirmed step.
+behind ``HAL0_COMFYUI_SWITCHOVER_ENABLED`` (501 when off). When on it validates
+the target mode, no-ops if already there, refuses to drop a busy render queue
+without ``force``, and runs the script pair in the background behind a 202 —
+the ``switchover`` block on /status is what tracks the transition to terminal.
+Scripts are never actually executed here: the subprocess seam (``_run_script``)
+is patched, mirroring the status seams.
 """
 
 from __future__ import annotations
@@ -158,6 +162,206 @@ def test_status_inventory_is_none_when_share_absent(client: TestClient, tmp_path
         with c, s, f:
             r = client.get("/api/comfyui/status")
     assert r.json()["inventory"] is None
+
+
+_BASE = "hal0.api.routes.comfyui"
+
+
+@pytest.fixture(autouse=True)
+def _reset_comfyui_module_state():
+    # The switchover tracker is module-global (the app object is per-test but the
+    # route module is not) — reset around every test.
+    from hal0.api.routes import comfyui as comfyui_mod
+
+    comfyui_mod._reset_state()
+    yield comfyui_mod
+    comfyui_mod._reset_state()
+
+
+def test_switchover_to_generation_runs_script_pair_in_order(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # ON: stop the LLM stack, then bring the container up — exactly that pair,
+    # exactly that order, kicked off in the background behind a 202.
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
+    with c, s, f, patch(f"{_BASE}._run_script", new_callable=AsyncMock) as run:
+        r = client.post("/api/comfyui/switchover", json={"mode": "generation"})
+    assert r.status_code == 202
+    assert r.json() == {
+        "status": "switching",
+        "mode": "generation",
+        "scripts": ["stop-inference.sh", "comfy-up.sh"],
+    }
+    assert [call.args[0] for call in run.await_args_list] == ["stop-inference.sh", "comfy-up.sh"]
+
+
+def test_switchover_force_to_inference_runs_pair_despite_busy_queue(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The UI confirm dialog already warned that queued jobs drop — force wins.
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_busy)
+    with c, s, f, patch(f"{_BASE}._run_script", new_callable=AsyncMock) as run:
+        r = client.post("/api/comfyui/switchover", json={"mode": "inference", "force": True})
+    assert r.status_code == 202
+    assert [call.args[0] for call in run.await_args_list] == [
+        "comfy-down.sh",
+        "start-inference.sh",
+    ]
+
+
+def test_switchover_refused_while_another_switch_in_flight(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_comfyui_module_state,
+) -> None:
+    # One switch at a time — racing pairs of systemctl/docker is never right.
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    comfyui_mod = _reset_comfyui_module_state
+    comfyui_mod._switch["active"] = True
+    comfyui_mod._switch["target"] = "generation"
+    c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
+    with c, s, f, patch(f"{_BASE}._run_script", new_callable=AsyncMock) as run:
+        r = client.post("/api/comfyui/switchover", json={"mode": "inference"})
+    assert r.status_code == 409
+    assert r.json()["error"]["code"] == "comfyui.switch_in_progress"
+    run.assert_not_called()
+
+
+def test_switchover_noop_when_already_in_generation_mode(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Container already running → target reached; never re-run the scripts.
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_idle)
+    with c, s, f, patch(f"{_BASE}._run_script", new_callable=AsyncMock) as run:
+        r = client.post("/api/comfyui/switchover", json={"mode": "generation"})
+    assert r.status_code == 200
+    assert r.json() == {"status": "noop", "mode": "generation"}
+    run.assert_not_called()
+
+
+def test_switchover_noop_when_already_in_inference_mode(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Container down AND lemonade up → inference already owns the GPU.
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
+    with c, s, f, patch(f"{_BASE}._run_script", new_callable=AsyncMock) as run:
+        r = client.post("/api/comfyui/switchover", json={"mode": "inference"})
+    assert r.status_code == 200
+    assert r.json() == {"status": "noop", "mode": "inference"}
+    run.assert_not_called()
+
+
+def test_switchover_to_inference_refused_while_queue_busy(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Tearing ComfyUI down mid-render kills the running + queued jobs — refuse
+    # unless the caller explicitly forces it (the UI confirm dialog is the force).
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_busy)
+    with c, s, f, patch(f"{_BASE}._run_script", new_callable=AsyncMock) as run:
+        r = client.post("/api/comfyui/switchover", json={"mode": "inference"})
+    assert r.status_code == 409
+    assert r.json()["error"]["code"] == "comfyui.busy"
+    run.assert_not_called()
+
+
+def test_status_exposes_switchover_state(client: TestClient, _reset_comfyui_module_state) -> None:
+    # The pane's 4s poll drives the "switching…" UI from this block.
+    comfyui_mod = _reset_comfyui_module_state
+    c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
+    with c, s, f:
+        idle = client.get("/api/comfyui/status").json()["switchover"]
+        comfyui_mod._switch.update(active=True, target="generation", error=None)
+        active = client.get("/api/comfyui/status").json()["switchover"]
+    assert idle == {"active": False, "target": None, "error": None}
+    assert active == {"active": True, "target": "generation", "error": None}
+
+
+def test_switchover_script_failure_is_surfaced_in_status(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A failed script must not strand the tracker as active, and the error must
+    # be visible to the pane on the next poll — never silently swallowed.
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
+    boom = AsyncMock(side_effect=RuntimeError("stop-inference.sh exited 1"))
+    with c, s, f, patch(f"{_BASE}._run_script", boom):
+        r = client.post("/api/comfyui/switchover", json={"mode": "generation"})
+        assert r.status_code == 202
+        sw = client.get("/api/comfyui/status").json()["switchover"]
+    assert sw["active"] is False
+    assert "stop-inference.sh exited 1" in sw["error"]
+
+
+def test_script_argv_runs_directly_when_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    # hal0-api runs as root on CT105 today — exec the script straight.
+    from hal0.api.routes import comfyui as m
+
+    monkeypatch.setenv("COMFYUI_SCRIPTS_DIR", "/opt/comfyui")
+    monkeypatch.setattr(m.os, "geteuid", lambda: 0)
+    assert m._script_argv("comfy-up.sh") == ["/opt/comfyui/comfy-up.sh"]
+
+
+def test_script_argv_uses_sudo_n_when_unprivileged(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Hardened install (hal0-api as the hal0 user): go through the narrow
+    # sudoers.d/hal0-comfyui grant. -n so a missing grant fails fast, not hangs.
+    from hal0.api.routes import comfyui as m
+
+    monkeypatch.setenv("COMFYUI_SCRIPTS_DIR", "/opt/comfyui")
+    monkeypatch.setattr(m.os, "geteuid", lambda: 1000)
+    assert m._script_argv("stop-inference.sh") == ["sudo", "-n", "/opt/comfyui/stop-inference.sh"]
+
+
+async def test_run_script_executes_real_script(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from hal0.api.routes import comfyui as m
+
+    marker = tmp_path / "ran"
+    script = tmp_path / "ok.sh"
+    script.write_text(f"#!/usr/bin/env bash\ntouch {marker}\n")
+    script.chmod(0o755)
+    monkeypatch.setenv("COMFYUI_SCRIPTS_DIR", str(tmp_path))
+    monkeypatch.setattr(m.os, "geteuid", lambda: 0)
+    await m._run_script("ok.sh")
+    assert marker.exists()
+
+
+async def test_run_script_raises_on_nonzero_exit(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from hal0.api.routes import comfyui as m
+
+    script = tmp_path / "bad.sh"
+    script.write_text("#!/usr/bin/env bash\necho boom >&2\nexit 3\n")
+    script.chmod(0o755)
+    monkeypatch.setenv("COMFYUI_SCRIPTS_DIR", str(tmp_path))
+    monkeypatch.setattr(m.os, "geteuid", lambda: 0)
+    with pytest.raises(RuntimeError, match=r"bad\.sh.*3"):
+        await m._run_script("bad.sh")
+
+
+async def test_run_script_raises_on_timeout(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from hal0.api.routes import comfyui as m
+
+    script = tmp_path / "slow.sh"
+    script.write_text("#!/usr/bin/env bash\nsleep 5\n")
+    script.chmod(0o755)
+    monkeypatch.setenv("COMFYUI_SCRIPTS_DIR", str(tmp_path))
+    monkeypatch.setenv("COMFYUI_SCRIPT_TIMEOUT", "0.2")
+    monkeypatch.setattr(m.os, "geteuid", lambda: 0)
+    with pytest.raises(RuntimeError, match=r"slow\.sh.*timed out"):
+        await m._run_script("slow.sh")
+
+
+def test_switchover_rejects_unknown_mode(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # With the gate open, the body must name a real target mode.
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    r = client.post("/api/comfyui/switchover", json={"mode": "turbo"})
+    assert r.status_code == 422
+    assert r.json()["error"]["code"] == "comfyui.invalid_mode"
 
 
 def test_switchover_gated_off_returns_501(client: TestClient) -> None:

--- a/ui/src/api/hooks/useComfyui.ts
+++ b/ui/src/api/hooks/useComfyui.ts
@@ -7,10 +7,13 @@
 // the cpp-httplib server behind :8188.
 //
 // The switchover (inference ⇄ generation) flips the single iGPU between the LLM
-// stack and ComfyUI by running root-owned scripts. That path is feature-gated
-// server-side (HAL0_COMFYUI_SWITCHOVER_ENABLED) and returns 501 until a scoped
-// privileged path is provisioned — so the mutation surfaces that refusal as a
-// toast rather than optimistically flipping the UI.
+// stack and ComfyUI by running root-owned scripts. The endpoint answers 202 and
+// runs the script pair in the background; the `switchover` block on /status
+// (active/target/error) is what tracks the transition to terminal — the pane's
+// poll renders it, per the async-job-must-poll-to-terminal rule. Tearing down a
+// non-empty queue needs `force: true` (the confirm dialog is that consent). The
+// whole path stays feature-gated server-side (HAL0_COMFYUI_SWITCHOVER_ENABLED,
+// 501 when off) — surfaced as a toast, never an optimistic flip.
 
 import { useMutation, useQuery, type UseQueryResult } from '@tanstack/react-query'
 import { api, apiGet } from '../client'
@@ -27,6 +30,12 @@ export interface ComfyuiMemory {
   pressure: boolean
 }
 
+export interface ComfyuiSwitchover {
+  active: boolean
+  target: ComfyuiMode | null
+  error: string | null
+}
+
 export interface ComfyuiStatus {
   mode: ComfyuiMode
   reachable: boolean
@@ -37,6 +46,7 @@ export interface ComfyuiStatus {
   queue: { running: number; pending: number }
   inference: { lemonade: boolean; hermes: boolean }
   inventory: Record<string, number> | null
+  switchover: ComfyuiSwitchover
 }
 
 // Neutral default so the pane renders a coherent "stopped/inference" shell on
@@ -52,6 +62,7 @@ export const COMFYUI_FALLBACK: ComfyuiStatus = {
   queue: { running: 0, pending: 0 },
   inference: { lemonade: false, hermes: false },
   inventory: null,
+  switchover: { active: false, target: null, error: null },
 }
 
 // Active (Image-Gen tab open): 4s, fast enough to track queue + pressure.
@@ -72,6 +83,9 @@ export function useComfyui(opts: { active?: boolean } = {}): UseQueryResult<Comf
 
 export interface SwitchoverBody {
   mode: ComfyuiMode
+  // Required to tear down a non-empty render queue (jobs are dropped). The
+  // confirm dialog's warning is the consent that sets this.
+  force?: boolean
 }
 
 // raw:true so the dev mockFetch GET-shim can't mask the 501/503 gate — we want

--- a/ui/src/dash/comfyui-pane.jsx
+++ b/ui/src/dash/comfyui-pane.jsx
@@ -11,8 +11,9 @@
 //   - queue depth (ComfyUI /queue)
 //   - model inventory counts (verified file counts on the share)
 // The switchover toggle opens a blast-radius confirm dialog, then calls the
-// feature-gated POST /api/comfyui/switchover (returns 501 until a privileged
-// root path is provisioned — surfaced as a toast, never an optimistic flip).
+// feature-gated POST /api/comfyui/switchover (202 + background scripts; the
+// status poll's `switchover` block drives the transitional UI — never an
+// optimistic flip; 501 toast when the host gate is off).
 //
 // Deliberately NOT wired yet (need ComfyUI's WS /ws + AMDGPUMonitor, or the
 // privileged path): per-node progress %, it/s, GPU util/temp/clocks, per-job
@@ -286,7 +287,13 @@ export function ComfyuiPane() {
   const gen = st.mode === 'generation'
   const containerUp = st.container?.state === 'running'
   const engine = st.engine || 'stopped'
-  const stateLabel = STATE_LABEL[engine] || engine
+  // A switch in flight overrides the snapshot state: the pane's poll is what
+  // tracks the transition to terminal (202 + background scripts server-side).
+  const switching = !!st.switchover?.active
+  const switchError = st.switchover?.error || null
+  const stateLabel = switching
+    ? `switching to ${st.switchover.target}…`
+    : STATE_LABEL[engine] || engine
   const mem = st.memory
   const gtt = mem?.gtt_used_gb ?? null
   const gttCeil = mem?.gtt_ceil_gb ?? 80
@@ -304,21 +311,28 @@ export function ComfyuiPane() {
   const doSwitch = async () => {
     const target = confirm
     try {
-      await sw.mutateAsync({ mode: target })
+      // The confirm dialog already warned that queued renders drop — that
+      // consent is what authorizes force when tearing down a busy queue.
+      const force = target === 'inference' && queueTotal > 0 ? true : undefined
+      await sw.mutateAsync({ mode: target, force })
       toast(`Switching to ${target} mode…`, 'ok')
       setConfirm(null)
       setTimeout(() => q.refetch(), 1500)
     } catch (err) {
       setConfirm(null)
       // Hal0Error carries the backend envelope's code directly (e.g.
-      // comfyui.switchover_disabled / _unimplemented) + the HTTP status.
-      const code = err?.code || ''
-      if (String(code).includes('switchover') || err?.status === 501 || err?.status === 503) {
+      // comfyui.switchover_disabled / comfyui.busy) + the HTTP status.
+      const code = String(err?.code || '')
+      if (code === 'comfyui.switchover_disabled' || err?.status === 501) {
         toast(
-          'ComfyUI switchover is not wired yet — run the switch scripts on the host, or enable ' +
-            'HAL0_COMFYUI_SWITCHOVER_ENABLED once a scoped sudoers path is in place.',
+          'ComfyUI switchover is disabled on this host — set HAL0_COMFYUI_SWITCHOVER_ENABLED=1 ' +
+            'on hal0-api to enable it.',
           'warn'
         )
+      } else if (code === 'comfyui.busy') {
+        toast('Renders are still running or queued — drain the queue first.', 'warn')
+      } else if (code === 'comfyui.switch_in_progress') {
+        toast('A switchover is already in progress — wait for it to finish.', 'warn')
       } else {
         toast(err?.message ? `switchover failed: ${err.message}` : 'switchover failed', 'warn')
       }
@@ -351,10 +365,15 @@ export function ComfyuiPane() {
               <span className="engine-title">ComfyUI</span>
               <span className="engine-sub">generation engine · docker</span>
             </span>
-            <span className={'epill ' + engine}>
+            <span className={'epill ' + (switching ? 'starting' : engine)}>
               <span className="dot" />
               {stateLabel}
             </span>
+            {switchError && !switching && (
+              <span className="meta" style={{ color: 'var(--warn)' }} title={switchError}>
+                last switch failed
+              </span>
+            )}
             <span className="grow" style={{ flex: 1 }} />
             <span className="eh-right">
               <button
@@ -368,12 +387,16 @@ export function ComfyuiPane() {
               </button>
               <span
                 className="sw-wrap"
-                onClick={() => setConfirm(gen ? 'inference' : 'generation')}
-                style={{ cursor: 'pointer' }}
-                title="Switch the iGPU between inference and generation"
+                onClick={() => !switching && setConfirm(gen ? 'inference' : 'generation')}
+                style={{ cursor: switching ? 'wait' : 'pointer' }}
+                title={
+                  switching
+                    ? 'Switchover in progress…'
+                    : 'Switch the iGPU between inference and generation'
+                }
               >
                 <span className={'mode' + (!gen ? ' llm-on' : '')}>inference</span>
-                <Toggle on={gen} comfy busy={sw.isPending} />
+                <Toggle on={gen} comfy busy={sw.isPending || switching} />
                 <span className={'mode' + (gen ? ' on' : '')}>generation</span>
               </span>
             </span>


### PR DESCRIPTION
## Summary

Implements the deferred write-path from #686: the dashboard's ComfyUI switchover toggle now actually flips the single iGPU between LLM inference and ComfyUI generation.

**Endpoint behavior** (`POST /api/comfyui/switchover`, still gated behind `HAL0_COMFYUI_SWITCHOVER_ENABLED`, 501 when off):
- `422 comfyui.invalid_mode` — body must be `{"mode": "generation" | "inference", "force"?: bool}`
- `200 noop` — target mode already owns the iGPU (idempotent; reuses the status seams)
- `409 comfyui.busy` — switching to inference with renders running/queued and no `force` (the UI confirm dialog passes `force`; it already warns the jobs drop)
- `409 comfyui.switch_in_progress` — one switch at a time
- `202 switching` — script pair runs in the background (`stop-inference.sh → comfy-up.sh` / `comfy-down.sh → start-inference.sh`); the new `switchover {active, target, error}` block on `GET /api/comfyui/status` tracks the transition, satisfying the async-job-poll-to-terminal rule via the pane's existing 4s poll

**Privilege model — option B (privilege-aware, noted per the handoff):** hal0-api on CT105 runs `User=root` today, so the scripts exec directly. On a hardened install (hal0-api as the `hal0` user) the runner switches to `sudo -n` against the new `packaging/sudoers/hal0-comfyui` drop-in — NOPASSWD on exactly the six absolute `/opt/comfyui/*.sh` paths, no wildcards. Option A (root-only) was the 20-minute version; B costs ~20 extra lines and survives the intended service-user model.

**Frontend:** `doSwitch` passes `force`, the toggle/epill render "switching to …" from the status poll (toggle locked while in flight), failed switches surface as a warn marker + specific toasts for 409/501.

## Test plan
- [x] 22/22 `tests/api/test_comfyui_proxy.py` (13 new, TDD red-green on the existing `_patch`/AsyncMock seam pattern; subprocess never runs in tests except the 3 runner tests against tmp scripts)
- [x] ruff check + format clean; `npm run build` clean
- [ ] CI green
- [ ] Live CT105: gated-off 501 smoke, then a deliberate real OFF→ON→OFF flip (first ever — both stacks are currently up at once)

🤖 Generated with [Claude Code](https://claude.com/claude-code)