### PR TITLE
docs: sync dashboard/README/API docs with the ComfyUI generation engine + switchover

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ be evicted out from under a streaming request.
   SSE-backed status + log tail. Lemonade `/logs/stream` folded into
   the Journal panel. Settings → Lemonade admin panel surfaces the
   daemon's `/internal/config` for inspection. Dark by default.
+  The slots page splits into Inference | Image Gen tabs: the Image-Gen
+  tab operates a containerized ComfyUI generation engine (live GTT/RAM
+  gauges, queue depth, model inventory) with a gated inference ⇄
+  generation iGPU switchover behind a blast-radius confirm.
 - **OpenWebUI prewired** — chat at `:3001`, zero config. The installer
   writes `openwebui.env` pointing at the local hal0 API.
 - **OmniRouter (8 tools)** — `generate_image`, `edit_image`,

--- a/docs/api/images-generation.mdx
+++ b/docs/api/images-generation.mdx
@@ -19,8 +19,19 @@ provider in `src/hal0/providers/comfyui.py`. Workflow templates live
 under `src/hal0/providers/workflows/`.
 
 The `img` slot sits on the same lifecycle as the chat and embed
-slots, so it shows up in the dashboard's slot grid with the same
-states, controls, and metrics.
+slots.
+
+<Aside type="note" title="Dashboard: ComfyUI as a generation engine">
+On the dashboard, ComfyUI is no longer a per-model slot card: the
+slots page splits into **Inference | Image Gen** tabs, and the
+Image-Gen tab renders ComfyUI as one containerized *generation engine*
+pane — live GTT/RAM gauges, queue depth, verified model-inventory
+counts (PR #686). Its inference ⇄ generation toggle flips the iGPU
+between the LLM stack and ComfyUI via `POST /api/comfyui/switchover`
+(PR #690), gated per host by `HAL0_COMFYUI_SWITCHOVER_ENABLED`. See
+the dashboard docs (`docs/dashboard/v3.md`) for the switchover
+semantics.
+</Aside>
 
 <img
   src="/screenshots/capability-slots.png"

--- a/docs/dashboard/v3.md
+++ b/docs/dashboard/v3.md
@@ -104,6 +104,34 @@ Slot creation dispatches through `hal0 slot create --type <X>`, which
 derives the Lemonade device flag from the slot type (PR #282) and
 the Lemonade model name + auto-port pair (PR #281).
 
+### Image Gen tab — ComfyUI generation engine
+
+The slots page is split into **Inference | Image Gen** tabs (PR #686).
+The Image Gen tab models ComfyUI as ONE containerized "generation
+engine" pane instead of per-model slot cards — a single render loads
+many cooperating models at once, and the engine is mutually exclusive
+with the LLM stack on a single-iGPU box.
+
+The pane is backed by the read-only `GET /api/comfyui/status`
+aggregator (container state + systemd state of the LLM stack +
+ComfyUI's own `/system_stats` and `/queue`), polled every 4s while the
+tab is open (20s when idle). GTT/RAM gauges, queue depth, and the
+model-inventory counts are all verified values; per-node render
+progress and GPU util render dark until a live WS feed exists.
+
+**Switchover (PR #690)** — the pane's inference ⇄ generation toggle
+flips the iGPU between the two stacks. It opens a blast-radius confirm
+dialog (messaging bots go dark, background memory extraction pauses),
+then POSTs `/api/comfyui/switchover`. The endpoint answers `202` and
+runs the root-owned script pair on the runtime host in the background
+(`stop-inference.sh → comfy-up.sh` to generation, `comfy-down.sh →
+start-inference.sh` back); the `switchover {active, target, error}`
+block on `/status` drives the pane's "switching…" state and surfaces
+the last failure. Tearing down a busy render queue is refused
+(`409 comfyui.busy`) unless the request carries `force` — the confirm
+dialog's drop-warning is that consent. The whole write path is gated
+per host by `HAL0_COMFYUI_SWITCHOVER_ENABLED` (`501` when off).
+
 ## `/models` — Model registry
 
 The local model registry, sourced from `/api/models`. Two things you


### PR DESCRIPTION
Docs-only follow-up to #686/#690: documents the Image Gen tab, the generation-engine pane, and the switchover semantics (202 + background scripts, `switchover` status block, `force` consent, `HAL0_COMFYUI_SWITCHOVER_ENABLED` gate) in docs/dashboard/v3.md, the README dashboard bullet, and an Aside in docs/api/images-generation.mdx replacing the stale "shows up in the slot grid" claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)