### PR TITLE
feat: Phase B — voice/TTS kokoro container (lemonade-removal spec)

### DIFF
--- a/docs/superpowers/plans/2026-06-11-phase-b-voice-kokoro-container.md
+++ b/docs/superpowers/plans/2026-06-11-phase-b-voice-kokoro-container.md
@@ -1,0 +1,413 @@
+# Phase B: Voice — Kokoro TTS Container Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The `tts` slot runs the hal0 kokoro toolbox image as a podman container (`hal0-slot@tts`), `/v1/audio/speech` dispatches to it through the gateway, and the slot's current error state is gone — second slot off Lemonade.
+
+**Architecture:** Reuse the Phase A seam: a new `KokoroProvider.container_spec()` builds a generic `ContainerSpec` (no GPU devices, weights mount, port publish) rendered by `_render_unit_from_spec`. `load_sync` grows a small spec-provider dispatch (npu→FLM, kokoro→Kokoro) instead of more inline branches. Dispatch gets a path rule: `/audio/speech` → `tts` slot (path-keyed, immune to the model-id alias mismatch). Lemonade keeps rerank/utility (Phase C) and observability (Phase E).
+
+**Tech Stack:** Python 3.12/FastAPI/pydantic v2, podman+systemd, `ghcr.io/hal0ai/hal0-toolbox-kokoro:v1` (kokoro-onnx FastAPI server, digest-pinned in manifest.json), pytest + γ-suite.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-lemonade-removal-container-switchover-design.md` §3 (tts), §12-B.
+**Worktree:** `/home/halo/dev/wt-phase-b` (branch `feat/phase-b-voice`, base 28d4312). `.venv/bin/python -m pytest`. Commits `git commit -s`.
+
+**Verified facts (research 2026-06-11, don't re-derive):**
+- Image `ghcr.io/hal0ai/hal0-toolbox-kokoro:v1` published + digest-pinned (`manifest.json:49-56`); NOT yet pulled on CT105.
+- Server (`packaging/toolbox/kokoro/kokoro_server.py`): `GET /health` (`{status, model_loaded, default_voice}`), `GET /v1/models` (hardcoded id `"kokoro"`), `POST /v1/audio/speech` (OpenAI-compat), `GET /v1/audio/voices`. Default port 8090; accepts `--port`, `--host`, `--model_path` CLI flags; NO `--alias` support. mp3/opus paths shell to ffmpeg via tempfile (needs writable /tmp — podman default OK).
+- Weights already on CT105: `/mnt/ai-models/local/kokoro-v1/kokoro-onnx/{kokoro-v1.0.onnx,voices-v1.0.bin}` (311+27 MB). Without `--model_path` the server auto-downloads to `$HF_HOME/kokoro-onnx/`.
+- Live `tts.toml`: `type="tts"`, `device="cpu"`, `backend="cpu"`, `model.default="kokoro-v1"`, `[server] port=8084`, NO profile/runtime → lemonade path → error state (stale `vibevoice-1.5b` HTTP 500 in state.json).
+- `SELF_MANAGED_PROVIDERS` (state.py:124) includes `"kokoro"`; `provider_requires_model("kokoro") is False` — modelless-ready guard already permits READY.
+- Dispatch today: `/v1/audio/speech` → `_dispatch_and_forward` → no TTS rule anywhere → legacy fallback Rule 7 lands on `chat`. Container Step-0 preemption would need model-id match, but the server advertises `"kokoro"` while clients send `"kokoro-v1"`/`"tts"` → path rule is the robust fix.
+- `_render_unit` (llama-shaped) enumerates GPU devices unconditionally — do NOT use it for kokoro; use `_render_unit_from_spec` (A3 seam).
+- `_resolve_model_path` raises on path-less models — kokoro must NOT flow through it; weights path goes in the spec command via profile flags.
+- #485: STT half covered (Phase A trio + lemond whispercpp for non-NPU); rerank is broken end-to-end at lemond itself → **Phase C, out of scope here**.
+- tests: `tests/api/test_v1_audio.py` TTS happy path seeds the `chat` slot as fake TTS upstream with `model="tts"`.
+
+---
+
+### Task B1: `kokoro-cpu` seed profile
+
+**Files:**
+- Modify: `src/hal0/config/schema.py` (SEED_PROFILES)
+- Modify: `installer/etc-hal0/profiles.toml`
+- Test: extend `tests/config/test_schema_npu.py`-style coverage in `tests/config/test_profiles.py` (seed count 4→5 + parity test already guards file/SEED sync)
+
+- [ ] **Step 1: failing test** — in `tests/config/test_profiles.py` add:
+
+```python
+def test_kokoro_cpu_seed_profile() -> None:
+    prof = SEED_PROFILES["kokoro-cpu"]
+    assert prof["image"] == "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1"
+    assert "--model_path" in prof["flags"]
+    assert prof["mtp"] is False
+```
+
+Update the existing seed-count assertion (5) and `test_returns_seed_profiles`/`test_profiles_route` count in `tests/api/test_profiles_route.py` (4→5, rename-safe — it asserts `len(SEED_PROFILES)` plus a literal; bump the literal).
+
+- [ ] **Step 2: run** — `.venv/bin/python -m pytest tests/config/test_profiles.py -x -q` → KeyError.
+
+- [ ] **Step 3: implement** — `SEED_PROFILES` entry:
+
+```python
+    "kokoro-cpu": {
+        "image": "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1",
+        "flags": "--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx",
+        "mtp": False,
+    },
+```
+
+Mirror into `installer/etc-hal0/profiles.toml`:
+
+```toml
+[profile.kokoro-cpu]
+# CPU TTS slot (kokoro-onnx). No GPU devices. Flags feed kokoro_server.py;
+# --model_path points at the shared model store so no download on start.
+image = "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1"
+flags = "--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx"
+mtp   = false
+```
+
+- [ ] **Step 4:** `.venv/bin/python -m pytest tests/config tests/api/test_profiles_route.py -q` → PASS.
+- [ ] **Step 5:** `git commit -s -m "feat(config): kokoro-cpu seed profile"`
+
+---
+
+### Task B2: `KokoroProvider.container_spec()`
+
+**Files:**
+- Create: `src/hal0/providers/kokoro.py`
+- Test: `tests/providers/test_kokoro_container_spec.py` (mirror `tests/providers/test_flm_container_spec.py` style)
+
+- [ ] **Step 1: failing tests:**
+
+```python
+"""Kokoro TTS container spec (Phase B)."""
+
+from typing import Any
+
+from hal0.providers.kokoro import KokoroProvider
+
+
+def _slot_cfg(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "tts",
+        "port": 8084,
+        "device": "cpu",
+        "type": "tts",
+        "runtime": "container",
+        "profile": "kokoro-cpu",
+        "model": {"default": "kokoro-v1"},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_spec_has_no_gpu_devices_or_groups() -> None:
+    spec = KokoroProvider().container_spec(_slot_cfg(), {})
+    assert spec.devices == []
+    assert spec.group_add == []
+
+
+def test_spec_command_carries_port_host_and_model_path() -> None:
+    spec = KokoroProvider().container_spec(_slot_cfg(), {})
+    assert "--port" in spec.command
+    assert spec.command[spec.command.index("--port") + 1] == "8084"
+    assert "--host" in spec.command
+    assert spec.command[spec.command.index("--host") + 1] == "0.0.0.0"
+    assert "--model_path" in spec.command
+    assert (
+        spec.command[spec.command.index("--model_path") + 1]
+        == "/mnt/ai-models/local/kokoro-v1/kokoro-onnx"
+    )
+
+
+def test_spec_mounts_model_store_ro_and_publishes_loopback() -> None:
+    spec = KokoroProvider().container_spec(_slot_cfg(), {})
+    assert ("/mnt/ai-models", "/mnt/ai-models:ro") in spec.mounts or (
+        "/mnt/ai-models",
+        "/mnt/ai-models",
+    ) in spec.mounts  # match ContainerSpec mount convention — see Step 3 note
+    assert spec.port == 8084
+    assert spec.network_mode == ""
+
+
+def test_spec_security_opts_for_lxc() -> None:
+    spec = KokoroProvider().container_spec(_slot_cfg(), {})
+    assert "apparmor=unconfined" in spec.security_opt
+    assert "seccomp=unconfined" in spec.security_opt
+```
+
+NOTE on mounts: read `providers/base.py` `ContainerSpec.mounts` — A3's renderer emits `--volume={src}:{dst}`. If read-only needs a third component, check how FLM/GPU paths express `:ro` (the GPU `_render_unit` hardcodes `:ro` in the volume string). Express ro the way the renderer supports (e.g. `dst="/mnt/ai-models:ro"` if that's the only way, or extend `ContainerSpec`/renderer with an `ro` mount triple — prefer the smallest correct change and pin it with the test).
+
+- [ ] **Step 2: run** — ImportError expected.
+
+- [ ] **Step 3: implement** `src/hal0/providers/kokoro.py`:
+
+```python
+"""Kokoro TTS provider — builds the ContainerSpec for the CPU toolbox image.
+
+The image (ghcr.io/hal0ai/hal0-toolbox-kokoro:v1) wraps kokoro-onnx in a
+FastAPI server: /health, /v1/models, /v1/audio/speech, /v1/audio/voices.
+Self-managed weights (SELF_MANAGED_PROVIDERS includes "kokoro") — the
+--model_path flag points at the shared store; no registry GGUF resolution.
+"""
+
+from typing import Any
+
+from hal0.providers.base import ContainerSpec
+
+_MODEL_STORE = "/mnt/ai-models"
+
+
+class KokoroProvider:
+    name = "kokoro"
+
+    def container_spec(
+        self, slot_cfg: dict[str, Any], model_info: dict[str, Any]
+    ) -> ContainerSpec:
+        port = int(slot_cfg.get("port") or 8084)
+        # Profile flags carry --model_path; resolve the profile the same way
+        # ContainerProvider does (load_profiles_config) so operators can
+        # override the path in profiles.toml without code changes.
+        from hal0.config.loader import load_profiles_config
+        from hal0.config.schema import resolve_profile_flags
+        import shlex
+
+        profile_name = str(slot_cfg.get("profile") or "kokoro-cpu")
+        catalog = load_profiles_config()
+        profile = catalog.profile[profile_name]
+        flag_tokens = shlex.split(resolve_profile_flags(profile)) if resolve_profile_flags(profile).strip() else []
+
+        command = ["--host", "0.0.0.0", "--port", str(port), *flag_tokens]
+        return ContainerSpec(
+            image=profile.image,
+            command=command,
+            env={},
+            mounts=[(_MODEL_STORE, f"{_MODEL_STORE}:ro")],  # adapt per Step 1 note
+            devices=[],
+            cap_add=[],
+            security_opt=["apparmor=unconfined", "seccomp=unconfined"],
+            group_add=[],
+            port=port,
+            network_mode="",
+            extra_args=[],
+        )
+```
+
+(Adapt: check the image ENTRYPOINT before finalizing `command` — `ssh hal0 'podman pull -q ghcr.io/hal0ai/hal0-toolbox-kokoro:v1 && podman image inspect ghcr.io/hal0ai/hal0-toolbox-kokoro:v1 --format "{{.Config.Entrypoint}} {{.Config.Cmd}}"'`. If the ENTRYPOINT already includes the server binary, `command` is flags-only as drafted; if not, prepend what's needed. Record the inspect output in your report.)
+
+- [ ] **Step 4:** `.venv/bin/python -m pytest tests/providers -q` → all PASS.
+- [ ] **Step 5:** `git commit -s -m "feat(providers): KokoroProvider container spec (CPU TTS)"`
+
+---
+
+### Task B3: `load_sync` spec-provider dispatch (replace the npu special-case)
+
+**Files:**
+- Modify: `src/hal0/providers/container.py` (`load_sync` — the `device == "npu"` branch from A3)
+- Test: `tests/providers/test_container_spec_dispatch.py` (create)
+
+- [ ] **Step 1: failing tests:**
+
+```python
+"""load_sync routes slots to their spec provider (FLM/NPU, Kokoro/TTS)."""
+
+import shlex
+from typing import Any
+from unittest.mock import patch
+
+from hal0.providers.container import ContainerProvider
+
+
+def _exec_start(unit_text: str) -> list[str]:
+    for line in unit_text.splitlines():
+        if line.startswith("ExecStart="):
+            return shlex.split(line[len("ExecStart="):])
+    raise AssertionError("ExecStart not found")
+
+
+def test_tts_kokoro_slot_renders_spec_unit() -> None:
+    provider = ContainerProvider()
+    slot_cfg = {
+        "name": "tts", "port": 8084, "device": "cpu", "type": "tts",
+        "runtime": "container", "profile": "kokoro-cpu",
+        "model": {"default": "kokoro-v1"},
+    }
+    with (
+        patch.object(provider, "_write_and_start_unit") as start,
+        patch("hal0.providers.container._container_runtime", return_value="/usr/bin/docker"),
+    ):
+        provider.load_sync(slot_cfg, {"_model_key": "kokoro-v1"})
+    argv = _exec_start(start.call_args.args[1])
+    assert "--model_path" in argv          # kokoro spec path, not llama --model
+    assert "--device=/dev/kfd" not in argv  # no GPU enumeration for CPU spec
+    assert "--publish=127.0.0.1:8084:8084" in argv
+
+
+def test_npu_slot_still_renders_flm_spec() -> None:
+    # regression: Phase A behavior unchanged by the dispatch refactor
+    ...  # copy the existing npu branch test from tests/providers/test_container_npu.py
+         # (test_npu_slot_routes_through_flm_spec) and keep BOTH files' versions green
+
+
+def test_gpu_slot_unaffected() -> None:
+    ...  # profile=moe-rocmfp4 slot still goes down the llama _render_unit path
+         # (assert --model in argv / spec markers absent) — mirror existing test style
+```
+
+- [ ] **Step 2: run** — kokoro test fails (npu-only branch).
+
+- [ ] **Step 3: implement.** In `load_sync`, replace the inline npu branch with a dispatch:
+
+```python
+        spec_provider = _spec_provider_for(slot_cfg)
+        if spec_provider is not None:
+            tag = (
+                model_info.get("flm_tag")
+                or model_info.get("_model_key")
+                or (slot_cfg.get("model") or {}).get("default")
+            )
+            if str(slot_cfg.get("device", "")) == "npu" and not tag:
+                raise ValueError("npu slot has no FLM model tag — set [model].default")
+            spec = spec_provider.container_spec(slot_cfg, model_info)
+            unit_text = _render_unit_from_spec(
+                str(slot_cfg["name"]), spec, runtime_bin=_container_runtime()
+            )
+            self._write_and_start_unit(str(slot_cfg["name"]), unit_text)
+            return
+```
+
+with, module-level:
+
+```python
+def _spec_provider_for(slot_cfg: dict[str, Any]) -> Any | None:
+    """Spec-building provider for non-llama container slots, or None.
+
+    llama-server slots (GPU profiles) use the flag-bundle _render_unit path;
+    FLM (NPU) and Kokoro (CPU TTS) know their own argv and build a
+    ContainerSpec rendered by _render_unit_from_spec. ComfyUI joins in
+    Phase D.
+    """
+    if str(slot_cfg.get("device", "")) == "npu":
+        from hal0.providers.flm import FLMProvider
+
+        return FLMProvider()
+    if str(slot_cfg.get("type", "")) == "tts" or str(slot_cfg.get("profile", "")) == "kokoro-cpu":
+        from hal0.providers.kokoro import KokoroProvider
+
+        return KokoroProvider()
+    return None
+```
+
+(Read the current A3 branch first — preserve its exact loud-fail and logging behavior; the npu tag check above mirrors it. Keep `tests/providers/test_container_npu.py` green UNCHANGED — that's the regression suite for this refactor.)
+
+- [ ] **Step 4:** `.venv/bin/python -m pytest tests/providers tests/slots -q` → all PASS.
+- [ ] **Step 5:** `git commit -s -m "feat(providers): spec-provider dispatch in load_sync (kokoro joins flm)"`
+
+---
+
+### Task B4: Dispatcher — `/audio/speech` routes to the tts slot
+
+**Files:**
+- Modify: `src/hal0/dispatcher/proxy.py` (legacy fallback path rules) and/or `src/hal0/dispatcher/router.py` `_default_for_path` (read both first — there are TWO path-default mechanisms: `_RERANK_DEFAULT`/`_EMBED_DEFAULT` in router.py `_default_for_path` and `_EMBED_PATHS` in proxy.py; add TTS to BOTH the same way embed/rerank are handled, so the container Step-0 preemption AND the legacy fallback agree)
+- Test: `tests/dispatcher/test_tts_path_routing.py` (create) + update `tests/api/test_v1_audio.py` happy path
+
+- [ ] **Step 1: failing tests:**
+
+```python
+"""/v1/audio/speech path-routes to the tts slot regardless of model id."""
+
+# Mirror the fixture style of the existing dispatcher path-default tests
+# (find the tests covering _RERANK_DEFAULT/_EMBED_DEFAULT routing and clone).
+
+
+def test_audio_speech_path_defaults_to_tts_slot() -> None:
+    # request path /v1/audio/speech, body model="kokoro-v1" (NOT the slot name,
+    # NOT the served id) → dispatcher candidate/upstream == "tts"
+    ...
+
+
+def test_audio_speech_container_upstream_preempts() -> None:
+    # tts registered as container upstream (kind=remote, port 8084) → dispatch
+    # forwards there; assert via the upstream-selection seam the suite uses
+    ...
+```
+
+Update `tests/api/test_v1_audio.py::test_audio_speech_happy_path` (and `_seed_tts_upstream`) to seed a `tts` upstream instead of piggybacking on `chat`, and add a case where `model="kokoro-v1"` (registry id) still lands on tts.
+
+- [ ] **Step 2: run** — fails (path falls through to chat).
+
+- [ ] **Step 3: implement** — in router.py `_default_for_path`, add `_TTS_DEFAULT = "tts"` for paths ending `/audio/speech`; in proxy.py add `_TTS_PATHS = ("/audio/speech",)` → `candidate = "tts"` rule placed BEFORE the chat fallback (mirror the `_EMBED_PATHS` rule structure exactly, including comment style). Do NOT touch `/audio/transcriptions` (trio/STT handled in Phase A).
+
+- [ ] **Step 4:** `.venv/bin/python -m pytest tests/dispatcher tests/api/test_v1_audio.py -q` → PASS.
+- [ ] **Step 5:** `git commit -s -m "feat(dispatcher): /audio/speech path-routes to the tts slot"`
+
+---
+
+### Task B5: Seed `tts.toml` + state-mismatch reconciliation
+
+**Files:**
+- Create: `installer/etc-hal0/slots/tts.toml`
+- Modify: `installer/install.sh` (extend the A10 seed block — generalize the single-file cp into a small loop over `npu.toml tts.toml`, same no-clobber + bundle-incomplete guards)
+- Test: extend `tests/config/test_schema_npu.py`'s seed-validation pattern with `test_seed_tts_toml_validates` (new sibling test; consider renaming the file's seed section comment, not the file)
+
+- [ ] **Step 1: failing test:**
+
+```python
+def test_seed_tts_toml_validates() -> None:
+    raw = tomllib.loads(
+        (_REPO_ROOT / "installer/etc-hal0/slots/tts.toml").read_text(encoding="utf-8")
+    )
+    slot = SlotConfig.model_validate(raw)
+    assert slot.runtime == "container"
+    assert slot.profile == "kokoro-cpu"
+    assert slot.device == "cpu"
+    assert slot.port == 8084
+```
+
+(reuse the `_REPO_ROOT`/path helper the A10 test established.)
+
+- [ ] **Step 2:** FileNotFoundError.
+
+- [ ] **Step 3:** seed file:
+
+```toml
+# TTS slot — kokoro-onnx in a podman container (hal0-slot@tts), CPU-only.
+name = "tts"
+type = "tts"
+device = "cpu"
+runtime = "container"
+profile = "kokoro-cpu"
+enabled = true
+port = 8084
+
+[model]
+default = "kokoro-v1"
+```
+
+install.sh: convert the A10 single-file block into `for seed in npu tts; do ... done` preserving per-file no-clobber + `die` guard semantics (existing A10 messages/behavior must not regress — `bash -n` + re-read the block).
+
+- [ ] **Step 4:** `.venv/bin/python -m pytest tests/config -q` + `bash -n installer/install.sh` → PASS.
+- [ ] **Step 5:** `git commit -s -m "feat(installer): seed containerized tts slot TOML"`
+
+---
+
+### Task B6: Gate, PR, CT105 deploy + e2e
+
+- [ ] **Step 1: full gate** — `.venv/bin/python -m pytest tests/ -q --ignore=tests/harness` (expect: the hermes-provision docker-smoke test may fail env-dependently — pre-existing, note it), `ruff check src tests`, `ruff format --check src tests`, `cd ui && npm run build`.
+- [ ] **Step 2: PR** — push `feat/phase-b-voice`, `gh pr create --head feat/phase-b-voice` (title "feat: Phase B — voice/TTS kokoro container (lemonade-removal spec)"), CI green, squash-merge.
+- [ ] **Step 3: deploy (Tier 2/3)** — `wip hal0 claim`; backup `/etc/hal0/slots/tts.toml` → `.bak-phase-b`; pull image: `ssh hal0 'podman pull ghcr.io/hal0ai/hal0-toolbox-kokoro:v1'`; `scripts/deploy.sh`; migrate live tts.toml to seed shape (KEEP port 8084; clear stale state: delete `/var/lib/hal0/slots/tts/state.json` stale `vibevoice` entry or POST a fresh load); `POST /api/slots/tts/load`.
+- [ ] **Step 4: e2e matrix (comment results on the PR):**
+  1. `systemctl is-active hal0-slot@tts` + `podman ps` + NO GPU devices in `podman inspect ... .HostConfig.Devices`
+  2. `curl -s http://127.0.0.1:8084/health` → `{"status":"ok","model_loaded":true,...}` (weights from the mount, NOT downloaded — check container logs for download lines)
+  3. Gateway round-trip: `curl -s http://127.0.0.1:8080/v1/audio/speech -H 'content-type: application/json' -d '{"model":"kokoro-v1","input":"hal0 voice is alive","voice":"af_heart"}' -o /tmp/tts-test.wav && file /tmp/tts-test.wav` → RIFF/WAV audio bytes (also test `model="tts"`)
+  4. Dashboard: tts slot card shows container runtime, ready state, no error banner
+  5. Stale-state regression: confirm state.json no longer references `vibevoice-1.5b`
+- [ ] **Step 5: close out** — `wip release`; tracker events; memory update; Phase C next.
+
+---
+
+## Self-review notes
+- Spec coverage: tts container (B1-B3, B5), dispatch (B4), error-state fix (B6 migration), #485 voice residual = none needed (research-verified, recorded here), rerank explicitly deferred to C.
+- The B2 `:ro` mount note and ENTRYPOINT check are the two reality-checks the implementer must resolve against the actual image/renderer rather than this plan's assumption.
+- B3 keeps `test_container_npu.py` untouched as the Phase A regression suite.

--- a/installer/etc-hal0/profiles.toml
+++ b/installer/etc-hal0/profiles.toml
@@ -32,3 +32,10 @@ mtp   = false
 image = "ghcr.io/hal0ai/hal0-toolbox-flm:v1"
 flags = ""
 mtp   = false
+
+[profile.kokoro-cpu]
+# CPU TTS slot (kokoro-onnx). No GPU devices. Flags feed kokoro_server.py;
+# --model_path points at the shared model store so no download on start.
+image = "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1"
+flags = "--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx"
+mtp   = false

--- a/installer/etc-hal0/slots/tts.toml
+++ b/installer/etc-hal0/slots/tts.toml
@@ -1,0 +1,11 @@
+# TTS slot — kokoro-onnx in a podman container (hal0-slot@tts), CPU-only.
+name = "tts"
+type = "tts"
+device = "cpu"
+runtime = "container"
+profile = "kokoro-cpu"
+enabled = true
+port = 8084
+
+[model]
+default = "kokoro-v1"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -944,33 +944,34 @@ else
     fi
 fi
 
-# ── NPU slot seed (A10) ────────────────────────────────────────────────────
-# Pre-populate /etc/hal0/slots/npu.toml if absent. Idempotent: never
-# overwrite an operator-edited file. The slot is seeded unconditionally so
-# the dashboard can show the NPU tile on any hal0 install; the slot itself
-# gates on 'flm validate' at load time. runtime=container + profile=flm-npu
-# routes it to ContainerProvider (podman). type=llm keeps the slot visible
-# to the LLM dispatch path (_is_npu_trio_request checks type=="llm").
+# ── Container slot seeds (A10) ────────────────────────────────────────────
+# Pre-populate /etc/hal0/slots/{npu,tts}.toml if absent. Idempotent: never
+# overwrite an operator-edited file. Each slot is seeded unconditionally so
+# the dashboard can show its tile on any hal0 install; each gates on its own
+# runtime validation at load time. runtime=container + profile=<X> routes
+# to ContainerProvider (podman).
 #
-# Single source of truth: the seed is COPIED from the repo tree
-# (installer/etc-hal0/slots/npu.toml — same file the schema tests
+# Single source of truth: seeds are COPIED from the repo tree
+# (installer/etc-hal0/slots/<name>.toml — same files the schema tests
 # validate), never duplicated inline. Present in every install flow:
 # the release tarball ships the whole installer/ dir (release.yml
 # `cp -a installer "${STAGE}/"`), git checkouts carry it, and the prod
 # rsync to ${PREFIX} (which REPO_ROOT is re-pointed at) has no exclude
 # that touches installer/.
-NPU_SLOT_TOML="${ETC_DIR}/slots/npu.toml"
-NPU_SLOT_SRC="${REPO_ROOT}/installer/etc-hal0/slots/npu.toml"
-if [[ -f "${NPU_SLOT_TOML}" ]]; then
-    info "npu slot: ${NPU_SLOT_TOML} exists — left alone"
-else
-    [[ -f "${NPU_SLOT_SRC}" ]] \
-        || die "installer bundle incomplete: ${NPU_SLOT_SRC} missing (installer/etc-hal0/ should ship with every release tree)"
-    mkdir -p "${ETC_DIR}/slots"
-    cp "${NPU_SLOT_SRC}" "${NPU_SLOT_TOML}"
-    chmod 0644 "${NPU_SLOT_TOML}"
-    info "seeded NPU slot → ${NPU_SLOT_TOML}"
-fi
+for seed_slot in npu tts; do
+    SLOT_TOML="${ETC_DIR}/slots/${seed_slot}.toml"
+    SLOT_SRC="${REPO_ROOT}/installer/etc-hal0/slots/${seed_slot}.toml"
+    if [[ -f "${SLOT_TOML}" ]]; then
+        info "${seed_slot} slot: ${SLOT_TOML} exists — left alone"
+    else
+        [[ -f "${SLOT_SRC}" ]] \
+            || die "installer bundle incomplete: ${SLOT_SRC} missing (installer/etc-hal0/ should ship with every release tree)"
+        mkdir -p "${ETC_DIR}/slots"
+        cp "${SLOT_SRC}" "${SLOT_TOML}"
+        chmod 0644 "${SLOT_TOML}"
+        info "seeded ${seed_slot} slot → ${SLOT_TOML}"
+    fi
+done
 
 # ── Lemonade daemon bootstrap (PR-5) ──────────────────────────────────────
 # Drops the lemond binary, baseline config.json with the mandatory

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -31,6 +31,7 @@ from hal0.config.schema import (
     AgentConfig,
     Hal0Config,
     HardwareInfo,
+    ProfileConfig,
     ProfilesConfig,
     ProvidersConfig,
     SlotConfig,
@@ -414,6 +415,29 @@ def load_profiles_config(path: Path | None = None) -> ProfilesConfig:
         ) from exc
 
 
+def resolve_profile(profile_name: str) -> ProfileConfig:
+    """Look up a named profile in the profiles.toml catalog.
+
+    Shared by every provider that resolves slot profiles
+    (ContainerProvider, KokoroProvider, …).
+
+    Args:
+        profile_name: Key under ``[profile]`` in profiles.toml.
+
+    Returns:
+        The validated :class:`ProfileConfig` for *profile_name*.
+
+    Raises:
+        KeyError: If the profile name is not in the catalog; the message
+                  lists the available profile names.
+    """
+    catalog = load_profiles_config()
+    if profile_name not in catalog.profile:
+        available = sorted(catalog.profile.keys())
+        raise KeyError(f"profile {profile_name!r} not found in catalog; available: {available}")
+    return catalog.profile[profile_name]
+
+
 # ── agents/<name>.toml (ADR-0013) ─────────────────────────────────────────────
 
 
@@ -662,6 +686,7 @@ __all__ = [
     "load_slot_config",
     "load_upstreams_config",
     "manifest_image_ref",
+    "resolve_profile",
     "save_agent_config",
     "save_hal0_config",
     "save_hardware_info",

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -607,6 +607,11 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "flags": "",
         "mtp": False,
     },
+    "kokoro-cpu": {
+        "image": "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1",
+        "flags": "--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx",
+        "mtp": False,
+    },
 }
 
 

--- a/src/hal0/dispatcher/proxy.py
+++ b/src/hal0/dispatcher/proxy.py
@@ -77,6 +77,12 @@ def resolve_slot(  # TIER1
       1. ``/embeddings`` or ``/rerank`` in path → ``embed`` slot.
       2. ``/audio/speech`` in path → ``tts`` slot (kokoro; model-id unreliable).
       3. ``/images/...`` in path → ``img`` slot (ComfyUI).
+
+    Path-pinned candidates (rules 1-2) accept either a local ``kind="slot"``
+    upstream or a container-backed ``kind="remote"`` upstream whose
+    ``slot_name`` matches the candidate (container slots register as remotes
+    via ``SlotManager._register_container_upstream``, #656).  All other rules
+    require ``kind="slot"``.
       4. Model id contains ``:`` (FLM tag-style) → ``npu`` slot.
       5. Model id starts with ``sdxl``/``sd-1.5``/``sd15``/``flux`` → ``img`` slot.
       6. Model id contains ``embed`` or ``rerank`` substring → ``embed`` slot.
@@ -99,15 +105,24 @@ def resolve_slot(  # TIER1
             ``dispatch.legacy_unresolved`` code via the typed Hal0Error envelope.
     """
     candidate: str | None = None
+    # Path-pinned candidates ("route purely by path") may also resolve to a
+    # container-backed kind="remote" upstream for that slot — container slots
+    # register via SlotManager._register_container_upstream as kind="remote"
+    # with slot_name set (#656), and a registered container remote for a
+    # path-pinned slot is exactly the right target.  Model-name rules keep
+    # the strict kind=="slot" gate.
+    path_pinned = False
 
     # Rule 1 — path-based pin (embeddings/rerank).
     if any(frag in path for frag in _EMBED_PATHS):
         candidate = "embed"
+        path_pinned = True
     # Rule 2 — TTS path pin (/audio/speech → tts slot).
     # Model-id matching is unreliable for kokoro (server advertises "kokoro",
     # clients send "kokoro-v1"/"tts"/etc.) so we route purely by path.
     elif any(frag in path for frag in _TTS_PATHS):
         candidate = "tts"
+        path_pinned = True
     # Rule 3 — image-generation path pins to the img slot.
     elif any(frag in path for frag in _IMAGE_PATHS):
         candidate = "img"
@@ -138,7 +153,18 @@ def resolve_slot(  # TIER1
         candidate = "chat"
 
     upstream = upstreams.get(candidate)
-    if upstream is None or upstream.kind != "slot":
+    # Acceptance: a local slot upstream always qualifies.  For PATH-pinned
+    # candidates only, a container-backed remote (kind="remote" with
+    # slot_name == candidate — how Step 0 preemption identifies container
+    # slots) qualifies too: kokoro's tts container registers as a remote, so
+    # the old kind=="slot"-only gate sent /audio/speech to NoRouteFound and
+    # the dead lemond tts slot.  Genuine external remotes (slot_name=None)
+    # are still rejected.
+    acceptable = upstream is not None and (
+        upstream.kind == "slot"
+        or (path_pinned and upstream.kind == "remote" and upstream.slot_name == candidate)
+    )
+    if upstream is None or not acceptable:
         raise LegacyResolutionFailed(
             f"legacy fallback selected slot {candidate!r} but no matching slot upstream is registered",
             details={"slot": candidate, "path": path},

--- a/src/hal0/dispatcher/proxy.py
+++ b/src/hal0/dispatcher/proxy.py
@@ -27,6 +27,12 @@ from hal0.upstreams.registry import Upstream, UpstreamRegistry
 # Mirrors haloai lib/proxy.py:51-58 (embeddings + rerank both target embed).
 _EMBED_PATHS = ("/embeddings", "/rerank")
 
+# Path fragments that pin a request to the TTS slot (kokoro container).
+# Model-id matching is unreliable — the kokoro container advertises "kokoro"
+# while clients send "kokoro-v1", "tts", etc. — so we route by path instead.
+# Only /audio/speech (synthesis); /audio/transcriptions is STT, not TTS.
+_TTS_PATHS = ("/audio/speech",)
+
 # Path fragments that pin a request to the image-gen slot (ComfyUI). The
 # OpenAI shape is `/v1/images/generations` — when that hits the legacy
 # fallback we don't want it routed to the chat slot.
@@ -69,14 +75,15 @@ def resolve_slot(  # TIER1
 
     Resolution rules (in order):
       1. ``/embeddings`` or ``/rerank`` in path → ``embed`` slot.
-      2. ``/images/...`` in path → ``img`` slot (ComfyUI).
-      3. Model id contains ``:`` (FLM tag-style) → ``npu`` slot.
-      4. Model id starts with ``sdxl``/``sd-1.5``/``sd15``/``flux`` → ``img`` slot.
-      5. Model id contains ``embed`` or ``rerank`` substring → ``embed`` slot.
-      6. Model id exactly matches a registered slot upstream name (other
+      2. ``/audio/speech`` in path → ``tts`` slot (kokoro; model-id unreliable).
+      3. ``/images/...`` in path → ``img`` slot (ComfyUI).
+      4. Model id contains ``:`` (FLM tag-style) → ``npu`` slot.
+      5. Model id starts with ``sdxl``/``sd-1.5``/``sd15``/``flux`` → ``img`` slot.
+      6. Model id contains ``embed`` or ``rerank`` substring → ``embed`` slot.
+      7. Model id exactly matches a registered slot upstream name (other
          than ``chat``) → that slot.  Back-compat aliases (``primary``
          → ``chat``, ``agent-hermes`` → ``agent``) are resolved first.
-      7. Fallback → ``chat`` slot.
+      8. Fallback → ``chat`` slot.
 
     Args:
         path:       The original request path (e.g. "/v1/chat/completions").
@@ -96,24 +103,29 @@ def resolve_slot(  # TIER1
     # Rule 1 — path-based pin (embeddings/rerank).
     if any(frag in path for frag in _EMBED_PATHS):
         candidate = "embed"
-    # Rule 2 — image-generation path pins to the img slot.
+    # Rule 2 — TTS path pin (/audio/speech → tts slot).
+    # Model-id matching is unreliable for kokoro (server advertises "kokoro",
+    # clients send "kokoro-v1"/"tts"/etc.) so we route purely by path.
+    elif any(frag in path for frag in _TTS_PATHS):
+        candidate = "tts"
+    # Rule 3 — image-generation path pins to the img slot.
     elif any(frag in path for frag in _IMAGE_PATHS):
         candidate = "img"
     elif body:
         model = body.get("model", "")
         if isinstance(model, str) and model:
             m = model.lower()
-            # Rule 3 — FLM tag format "name:tag" routes to NPU.
+            # Rule 4 — FLM tag format "name:tag" routes to NPU.
             if ":" in model:
                 candidate = "npu"
-            # Rule 4 — image-gen model id prefix pin (sdxl-/sd-1.5-/flux-).
+            # Rule 5 — image-gen model id prefix pin (sdxl-/sd-1.5-/flux-).
             elif any(m.startswith(prefix) for prefix in _IMAGE_NAME_PREFIXES):
                 candidate = "img"
-            # Rule 5 — name-substring pin (embed/rerank).
+            # Rule 6 — name-substring pin (embed/rerank).
             elif any(hint in m for hint in _EMBED_NAME_HINTS):
                 candidate = "embed"
             else:
-                # Rule 6 — explicit slot-name addressing.
+                # Rule 7 — explicit slot-name addressing.
                 # Resolve back-compat aliases (primary→chat, agent-hermes→agent)
                 # before the upstream lookup so old callers still land correctly.
                 m_resolved = SLOT_ALIASES.get(m, m)
@@ -121,7 +133,7 @@ def resolve_slot(  # TIER1
                 if slot_match is not None and slot_match.kind == "slot" and m_resolved != "chat":
                     candidate = m_resolved
 
-    # Rule 7 — fallback default slot.
+    # Rule 8 — fallback default slot.
     if candidate is None:
         candidate = "chat"
 

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -158,6 +158,7 @@ _RECOVERABLE_TRANSPORT_ERRORS = (
 _DEFAULT_MODEL = "chat"
 _EMBED_DEFAULT = "embed"
 _RERANK_DEFAULT = "embed"
+_TTS_DEFAULT = "tts"
 
 
 # ── Typed errors ──────────────────────────────────────────────────────────────
@@ -1062,6 +1063,8 @@ class Dispatcher:
             return _EMBED_DEFAULT
         if "/rerank" in path:
             return _RERANK_DEFAULT
+        if "/audio/speech" in path:
+            return _TTS_DEFAULT
         return _DEFAULT_MODEL
 
     def _registry_route_for(self, model_id: str) -> tuple[str, str] | None:

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -416,6 +416,11 @@ class ContainerProvider(Provider):
         """Probe GET /health on the container port.
 
         For llama-server slots /health returns 200 when ready.
+        kokoro-server returns 200 with ``{"model_loaded": false}`` while
+        weights are still loading (multi-minute on auto-download) — when the
+        body is JSON and carries a ``model_loaded`` key, ok is gated on
+        ``model_loaded is True``. Bodies without the key (llama-server) keep
+        the plain-200 behavior.
         FLM containers have no /health endpoint — they return 404 there.
         When /health returns a non-connection error (e.g. 404), fall back to
         GET /v1/models; 200 there means the server is up and healthy.
@@ -429,6 +434,16 @@ class ContainerProvider(Provider):
             async with httpx.AsyncClient(timeout=_HEALTH_REQUEST_TIMEOUT_S) as client:
                 resp = await client.get(health_url)
                 if resp.status_code == 200:
+                    try:
+                        body = resp.json()
+                    except ValueError:
+                        body = None
+                    if isinstance(body, dict) and "model_loaded" in body:
+                        loaded = body.get("model_loaded") is True
+                        return {
+                            "ok": loaded,
+                            "status": "healthy" if loaded else "loading",
+                        }
                     return {"ok": True, "status": "healthy"}
                 # Non-200 (e.g. 404 from FLM) → try /v1/models fallback.
                 models_resp = await client.get(models_url)

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -307,6 +307,25 @@ def _render_unit_from_spec(
     return _unit_skeleton(slot_name, runtime, exec_start)
 
 
+def _spec_provider_for(slot_cfg: dict[str, Any]) -> Any | None:
+    """Spec-building provider for non-llama container slots, or None.
+
+    llama-server slots (GPU profiles) use the flag-bundle _render_unit path.
+    FLM (NPU) and Kokoro (CPU TTS) know their own argv; they build a
+    ContainerSpec rendered by _render_unit_from_spec. ComfyUI joins in
+    Phase D.
+    """
+    if str(slot_cfg.get("device", "")) == "npu":
+        from hal0.providers.flm import FLMProvider
+
+        return FLMProvider()
+    if str(slot_cfg.get("type", "")) == "tts" or str(slot_cfg.get("profile", "")) == "kokoro-cpu":
+        from hal0.providers.kokoro import KokoroProvider
+
+        return KokoroProvider()
+    return None
+
+
 class ContainerProvider(Provider):
     """Podman-container-per-slot inference backend.
 
@@ -471,30 +490,32 @@ class ContainerProvider(Provider):
         asyncio.to_thread-friendly path — SlotManager awaits the slot spawn
         via ``await self._spawn_locked(...)``).
 
-        NPU branch: when ``slot_cfg["device"] == "npu"``, delegates to
-        :class:`~hal0.providers.flm.FLMProvider` for the :class:`ContainerSpec`
-        and renders the unit via :func:`_render_unit_from_spec` (generic
-        spec-rendered path). All other devices use the llama-server path.
+        Spec-provider dispatch: :func:`_spec_provider_for` maps NPU→FLM and
+        TTS/kokoro-cpu→Kokoro slots to their respective providers, which build a
+        :class:`ContainerSpec` rendered by :func:`_render_unit_from_spec`.
+        GPU/llama-server slots fall through to the flag-bundle :func:`_render_unit`
+        path.
         """
         slot_name: str = str(slot_cfg.get("name", ""))
 
-        # ── NPU branch (FLM container) ─────────────────────────────────────────
-        if str(slot_cfg.get("device", "")) == "npu":
-            from hal0.providers.flm import FLMProvider
+        # ── Spec-provider dispatch (NPU/FLM, TTS/Kokoro, …) ───────────────────
+        spec_provider = _spec_provider_for(slot_cfg)
+        if spec_provider is not None:
+            # Loud-fail for NPU slots only: a missing FLM tag must not silently
+            # fall through to FLM's legacy default (kept in build_env for the
+            # lemonade path until Phase E). Kokoro is self-managed and needs no
+            # registry tag — the tag check fires ONLY when device == "npu".
+            if str(slot_cfg.get("device", "")) == "npu":
+                model_table = slot_cfg.get("model") or {}
+                tag = (
+                    model_info.get("flm_tag")
+                    or model_info.get("_model_key")
+                    or (model_table.get("default") if isinstance(model_table, dict) else None)
+                )
+                if not tag:
+                    raise ValueError("npu slot has no FLM model tag — set [model].default")
 
-            # Loud-fail parity with the GPU path's _resolve_model_path: a
-            # missing tag must not silently fall through to FLM's legacy
-            # default (kept in build_env for the lemonade path until Phase E).
-            model_table = slot_cfg.get("model") or {}
-            tag = (
-                model_info.get("flm_tag")
-                or model_info.get("_model_key")
-                or (model_table.get("default") if isinstance(model_table, dict) else None)
-            )
-            if not tag:
-                raise ValueError("npu slot has no FLM model tag — set [model].default")
-
-            spec = FLMProvider().container_spec(slot_cfg, model_info)
+            spec = spec_provider.container_spec(slot_cfg, model_info)
             unit_text = _render_unit_from_spec(
                 slot_name,
                 spec,
@@ -766,6 +787,7 @@ def resolved_command_for_slot(
 __all__ = [
     "ContainerProvider",
     "_render_unit_from_spec",
+    "_spec_provider_for",
     "container_provider",
     "resolved_command_for_slot",
 ]

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -45,8 +45,10 @@ from typing import Any
 
 import httpx
 
-from hal0.config.loader import load_profiles_config
-from hal0.config.schema import ProfileConfig, resolve_profile_flags
+# Aliased to the old private name so existing test patch targets
+# (``hal0.providers.container._resolve_profile``) keep working.
+from hal0.config.loader import resolve_profile as _resolve_profile
+from hal0.config.schema import resolve_profile_flags
 from hal0.providers._gpu import resolve_gpu_device_paths, resolve_gpu_group_ids
 from hal0.providers.base import ContainerSpec, Provider
 
@@ -88,19 +90,6 @@ def _container_runtime() -> str:
 _HEALTH_POLL_INTERVAL_S = 2.0
 _HEALTH_TIMEOUT_S = 180.0
 _HEALTH_REQUEST_TIMEOUT_S = 3.0
-
-
-def _resolve_profile(profile_name: str) -> ProfileConfig:
-    """Load profiles.toml and return the named profile.
-
-    Raises:
-        KeyError: If the profile name is not in the catalog.
-    """
-    catalog = load_profiles_config()
-    if profile_name not in catalog.profile:
-        available = sorted(catalog.profile.keys())
-        raise KeyError(f"profile {profile_name!r} not found in catalog; available: {available}")
-    return catalog.profile[profile_name]
 
 
 def _resolve_model_path(model_info: dict[str, Any]) -> str:

--- a/src/hal0/providers/kokoro.py
+++ b/src/hal0/providers/kokoro.py
@@ -186,6 +186,12 @@ class KokoroProvider(Provider):
     async def health(self, port: int) -> dict[str, Any]:
         """Probe GET /health on the kokoro-server port.
 
+        NOTE: dead code in the container deployment path — slot health checks
+        go through :meth:`ContainerProvider.health` (which implements the same
+        ``model_loaded`` gating).  Kept because ``health`` is abstract on the
+        Provider ABC: removing it would make KokoroProvider abstract and break
+        the ``_spec_provider_for`` instantiation in container.py.
+
         kokoro_server.py returns {status: "ok", model_loaded: true} when
         ready.  Returns {"ok": bool, "status": str}.
         """

--- a/src/hal0/providers/kokoro.py
+++ b/src/hal0/providers/kokoro.py
@@ -1,0 +1,226 @@
+"""KokoroProvider — CPU TTS inference backend (kokoro-onnx).
+
+Image API surface:
+  ENTRYPOINT: /usr/bin/tini -- /usr/local/bin/kokoro-server
+  CMD:        --help
+  Healthcheck: none baked in (hc=<nil> on ghcr.io/hal0ai/hal0-toolbox-kokoro:v1)
+
+  Because the server is already the ENTRYPOINT, ``container_spec.command``
+  carries flags only — no binary path or subcommand prefix needed.
+  Flags come from the resolved ``kokoro-cpu`` profile (profiles.toml), which
+  bakes ``--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx``.
+
+Weights:
+  Kokoro weights live under /mnt/ai-models (read-only NFS/local NVMe mount).
+  The model store is bind-mounted at the same absolute path inside the
+  container (identical-path convention, same as llama-server GGUFs) so the
+  ``--model_path`` flag the profile bakes in resolves correctly without
+  path translation.
+
+  The mount dst string carries the ``:ro`` suffix directly because
+  ``_render_unit_from_spec`` renders mounts as ``--volume={src}:{dst}``
+  verbatim — there is no separate read-only flag on ContainerSpec.
+
+No devices / group_add:
+  Kokoro runs ONNX inference entirely on CPU (no CUDA, ROCm, or NPU).
+  No device nodes are required; group_add is empty.
+
+Self-managed weights:
+  Kokoro is in SELF_MANAGED_PROVIDERS — the model store is operator-managed
+  (weights pre-downloaded to /mnt/ai-models) rather than hal0-registry-managed.
+"""
+
+from __future__ import annotations
+
+import shlex
+from typing import Any
+
+import httpx
+
+from hal0.config.loader import resolve_profile
+from hal0.config.schema import resolve_profile_flags
+from hal0.errors import Hal0Error
+from hal0.providers.base import ContainerSpec, Provider
+
+# Default image tag (overridable via HAL0_TOOLBOX_IMAGE_KOKORO for dev/test).
+_DEFAULT_KOKORO_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1"
+
+# Default profile name if the slot TOML omits one.
+_DEFAULT_PROFILE = "kokoro-cpu"
+
+# Model store: the same absolute path is used inside the container so that
+# ``--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx`` (baked into the
+# profile flags) resolves correctly without any path translation.
+_MODEL_STORE_HOST = "/mnt/ai-models"
+# ":ro" is appended directly because _render_unit_from_spec renders mounts as
+# --volume={src}:{dst} with no separate read-only option.  This is the only way
+# to express a read-only bind-mount with the current ContainerSpec shape.
+_MODEL_STORE_CONTAINER = "/mnt/ai-models:ro"
+
+# Providers whose model weights are pre-staged by the operator (not hal0 registry).
+SELF_MANAGED_PROVIDERS: frozenset[str] = frozenset({"kokoro", "comfyui"})
+
+# Health/infer timeouts.
+_HEALTH_TIMEOUT = httpx.Timeout(5.0)
+_INFER_TIMEOUT = httpx.Timeout(connect=5.0, read=60.0, write=5.0, pool=5.0)
+
+
+class KokoroHealthError(Hal0Error):
+    """Kokoro health probe failed."""
+
+    code = "slot.not_ready"
+    status = 503
+
+
+class KokoroInferError(Hal0Error):
+    """Kokoro inference call failed."""
+
+    code = "dispatch.upstream_failed"
+    status = 502
+
+
+class KokoroProvider(Provider):
+    """Provider for the Kokoro ONNX TTS backend.
+
+    CPU-only: no GPU devices, no group_add.  Weights are operator-staged
+    under /mnt/ai-models (``SELF_MANAGED_PROVIDERS``).  The container image
+    wraps ``kokoro_server.py`` which implements OpenAI-compat
+    ``POST /v1/audio/speech``, ``GET /v1/models``, and ``GET /health``.
+
+    Primary deployment path is ``container_spec`` → ``_render_unit_from_spec``
+    (same pattern as FLMProvider).  ``build_env`` / ``start_cmd`` are
+    informational stubs kept for ABC compliance and debug shells.
+    """
+
+    name = "kokoro"
+
+    # ── Provider ABC stubs ─────────────────────────────────────────────────────
+
+    def build_env(
+        self,
+        slot_cfg: dict[str, Any],
+        model_info: dict[str, Any],
+    ) -> dict[str, str]:
+        """Informational env block (container is self-contained)."""
+        return {
+            "HAL0_SLOT": str(slot_cfg.get("name", "")),
+            "HAL0_RUNTIME": "container",
+            "HAL0_PROFILE": str(slot_cfg.get("profile") or _DEFAULT_PROFILE),
+        }
+
+    def start_cmd(self, env: dict[str, str]) -> list[str]:
+        """Not applicable — systemd starts the container."""
+        raise NotImplementedError("KokoroProvider uses systemd; start_cmd() is unused")
+
+    # ── Image / container spec ─────────────────────────────────────────────────
+
+    def image_ref(self, slot_cfg: dict[str, Any]) -> str:
+        """Return the Kokoro toolbox image reference."""
+        import os
+
+        return os.environ.get("HAL0_TOOLBOX_IMAGE_KOKORO", _DEFAULT_KOKORO_IMAGE)
+
+    def container_spec(
+        self,
+        slot_cfg: dict[str, Any],
+        model_info: dict[str, Any],
+    ) -> ContainerSpec:
+        """Build a ContainerSpec for the Kokoro TTS slot.
+
+        The toolbox image ENTRYPOINT is ``tini -- kokoro-server``, so
+        ``command`` carries only flags (no binary path / subcommand).
+
+        Flags come from the resolved profile (``kokoro-cpu`` by default),
+        which bakes ``--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx``
+        plus any future bench-tuned additions.  ``--host`` and ``--port`` are
+        always appended so the operator cannot accidentally omit them.
+
+        No devices or group_add are emitted — Kokoro is CPU-only.
+
+        Security opts (apparmor/seccomp=unconfined) are required for
+        Proxmox LXC deployments (same rationale as FLMProvider).
+        """
+        port = int(slot_cfg.get("port") or 8084)
+        profile_name: str = str(slot_cfg.get("profile") or _DEFAULT_PROFILE)
+        profile = resolve_profile(profile_name)
+        flags_str = resolve_profile_flags(profile)
+        # Split profile flags; these include --model_path from the profile.
+        flag_tokens = shlex.split(flags_str) if flags_str.strip() else []
+
+        # command = profile flags + mandatory server binding args.
+        # The ENTRYPOINT (tini -- kokoro-server) receives these as argv.
+        # slot port appended last: argparse last-wins, so the slot's --port
+        # always beats any --port an operator put in profile flags
+        command: list[str] = [
+            *flag_tokens,
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(port),
+        ]
+
+        return ContainerSpec(
+            image=profile.image,
+            command=command,
+            env={},
+            # Mount the model store read-only.  ":ro" is appended to the
+            # container path directly — _render_unit_from_spec emits
+            # --volume={src}:{dst} verbatim (no separate ro flag on spec).
+            mounts=[(_MODEL_STORE_HOST, _MODEL_STORE_CONTAINER)],
+            # CPU-only: no GPU devices or supplementary groups required.
+            devices=[],
+            cap_add=[],
+            # Required for Proxmox LXC container deployments.
+            security_opt=["apparmor=unconfined", "seccomp=unconfined"],
+            group_add=[],
+            port=port,
+            # Port-mapped (not host networking) so multiple CPU slots can
+            # coexist.  _render_unit_from_spec derives
+            # --publish=127.0.0.1:<port>:<port> from spec.port.
+            network_mode="",
+            extra_args=[],
+        )
+
+    # ── Health / infer ─────────────────────────────────────────────────────────
+
+    async def health(self, port: int) -> dict[str, Any]:
+        """Probe GET /health on the kokoro-server port.
+
+        kokoro_server.py returns {status: "ok", model_loaded: true} when
+        ready.  Returns {"ok": bool, "status": str}.
+        """
+        url = f"http://127.0.0.1:{port}/health"
+        try:
+            async with httpx.AsyncClient(timeout=_HEALTH_TIMEOUT) as client:
+                resp = await client.get(url)
+                if resp.status_code == 200:
+                    body = resp.json()
+                    loaded = bool(body.get("model_loaded"))
+                    return {
+                        "ok": loaded,
+                        "status": "ready" if loaded else "loading",
+                    }
+                return {"ok": False, "status": f"http_{resp.status_code}"}
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+            return {"ok": False, "status": str(exc)}
+        except Exception as exc:
+            return {"ok": False, "status": "exception", "detail": str(exc)}
+
+    async def infer(self, port: int, body: dict[str, Any]) -> dict[str, Any]:
+        """Passthrough /v1/audio/speech to kokoro-server."""
+        url = f"http://127.0.0.1:{port}/v1/audio/speech"
+        try:
+            async with httpx.AsyncClient(timeout=_INFER_TIMEOUT) as client:
+                resp = await client.post(url, json=body)
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPStatusError as exc:
+            raise KokoroInferError(
+                f"Kokoro returned HTTP {exc.response.status_code}",
+                details={"port": port, "status_code": exc.response.status_code},
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise KokoroInferError(
+                f"Kokoro transport error: {exc}",
+                details={"port": port},
+            ) from exc

--- a/tests/api/test_profiles_route.py
+++ b/tests/api/test_profiles_route.py
@@ -42,16 +42,23 @@ class TestListProfiles:
         assert isinstance(data, list)
 
     def test_returns_seed_profiles(self, client: TestClient) -> None:
-        """One entry per seed profile (4 as of Phase A: flm-npu joined)."""
+        """One entry per seed profile (5 as of Phase B: kokoro-cpu joined)."""
         data = client.get("/api/profiles").json()
         assert len(data) == len(SEED_PROFILES)
-        assert len(data) == 4
+        assert len(data) == 5
 
     def test_flm_npu_seed_present(self, client: TestClient) -> None:
         """Phase A added the flm-npu container profile to the seeds."""
         data = client.get("/api/profiles").json()
         flm = next(item for item in data if item["name"] == "flm-npu")
         assert flm["mtp"] is False
+
+    def test_kokoro_cpu_seed_present(self, client: TestClient) -> None:
+        """Phase B added the kokoro-cpu TTS profile to the seeds."""
+        data = client.get("/api/profiles").json()
+        kokoro = next(item for item in data if item["name"] == "kokoro-cpu")
+        assert kokoro["mtp"] is False
+        assert "--model_path" in kokoro["flags"]
 
     def test_seed_names_present(self, client: TestClient) -> None:
         data = client.get("/api/profiles").json()

--- a/tests/api/test_slots_container_state.py
+++ b/tests/api/test_slots_container_state.py
@@ -309,7 +309,7 @@ def test_container_slot_has_runtime_profile_image_fields(
         ),
         # container.py module-level import used by resolved_command_for_slot
         patch(
-            "hal0.providers.container.load_profiles_config",
+            "hal0.config.loader.load_profiles_config",
             return_value=fake_catalog,
         ),
     ):
@@ -361,7 +361,7 @@ def test_container_slot_resolved_command_includes_flags(
         ),
         # container.py module-level import used by resolved_command_for_slot
         patch(
-            "hal0.providers.container.load_profiles_config",
+            "hal0.config.loader.load_profiles_config",
             return_value=fake_catalog,
         ),
     ):
@@ -430,7 +430,7 @@ def test_container_actual_image_no_mismatch_when_running_matches_profile(
             return_value={"ok": True, "status": "healthy"},
         ),
         patch("hal0.config.loader.load_profiles_config", return_value=cat),
-        patch("hal0.providers.container.load_profiles_config", return_value=cat),
+        patch("hal0.config.loader.load_profiles_config", return_value=cat),
         patch(
             "hal0.providers.container.ContainerProvider.running_image",
             return_value=_VULKAN_IMG,
@@ -456,7 +456,7 @@ def test_container_image_mismatch_when_running_differs_from_profile(
             return_value={"ok": True, "status": "healthy"},
         ),
         patch("hal0.config.loader.load_profiles_config", return_value=cat),
-        patch("hal0.providers.container.load_profiles_config", return_value=cat),
+        patch("hal0.config.loader.load_profiles_config", return_value=cat),
         patch(
             "hal0.providers.container.ContainerProvider.running_image",
             return_value=_ROCM_IMG,  # stale: still running the old rocm image

--- a/tests/api/test_slots_image_pull.py
+++ b/tests/api/test_slots_image_pull.py
@@ -120,7 +120,7 @@ def test_image_status_present(container_client: TestClient) -> None:
             return_value={"ok": False},
         ),
         patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
-        patch("hal0.providers.container.load_profiles_config", return_value=fake_catalog),
+        patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
         patch("hal0.providers.container.ContainerProvider.image_present", return_value=True),
     ):
         r = container_client.get("/api/slots")
@@ -140,7 +140,7 @@ def test_image_status_missing(container_client: TestClient) -> None:
             return_value={"ok": False},
         ),
         patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
-        patch("hal0.providers.container.load_profiles_config", return_value=fake_catalog),
+        patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
         patch("hal0.providers.container.ContainerProvider.image_present", return_value=False),
     ):
         r = container_client.get("/api/slots")
@@ -168,7 +168,7 @@ def test_image_status_pulling_when_job_active(
             return_value={"ok": False},
         ),
         patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
-        patch("hal0.providers.container.load_profiles_config", return_value=fake_catalog),
+        patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
     ):
         r = container_client.get("/api/slots")
     assert r.status_code == 200, r.text
@@ -194,7 +194,7 @@ def test_pull_start_returns_202(container_client: TestClient) -> None:
             return_value={"ok": False},
         ),
         patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
-        patch("hal0.providers.container.load_profiles_config", return_value=fake_catalog),
+        patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
         patch("hal0.api.routes.slots._run_image_pull", side_effect=_noop),
     ):
         r = container_client.post("/api/slots/gpu-chat/pull")
@@ -225,7 +225,7 @@ def test_pull_start_idempotent(
             return_value={"ok": False},
         ),
         patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
-        patch("hal0.providers.container.load_profiles_config", return_value=fake_catalog),
+        patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
     ):
         r = container_client.post("/api/slots/gpu-chat/pull")
     assert r.status_code == 202, r.text
@@ -252,7 +252,7 @@ def test_pull_stream_present_when_no_job(container_client: TestClient) -> None:
             return_value={"ok": False},
         ),
         patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
-        patch("hal0.providers.container.load_profiles_config", return_value=fake_catalog),
+        patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
         patch("hal0.providers.container.ContainerProvider.image_present", return_value=True),
         container_client.stream("GET", "/api/slots/gpu-chat/pull/stream") as resp,
     ):
@@ -274,7 +274,7 @@ def test_pull_stream_missing_when_no_job(container_client: TestClient) -> None:
             return_value={"ok": False},
         ),
         patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
-        patch("hal0.providers.container.load_profiles_config", return_value=fake_catalog),
+        patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
         patch("hal0.providers.container.ContainerProvider.image_present", return_value=False),
         container_client.stream("GET", "/api/slots/gpu-chat/pull/stream") as resp,
     ):

--- a/tests/api/test_v1_audio.py
+++ b/tests/api/test_v1_audio.py
@@ -75,21 +75,23 @@ def _seed_stt_upstream(client: TestClient, port: int = 8089) -> None:
 
 
 def _seed_tts_upstream(client: TestClient, port: int = 8090) -> None:
-    """Register a fake TTS slot the dispatcher's legacy fallback will land on.
+    """Register a fake TTS slot at the ``tts`` upstream name.
 
-    Same fallthrough logic as STT — the dispatcher routes unknown ``model``
-    ids to the ``chat`` slot, so we register there.
+    POST /v1/audio/speech is path-routed to the ``tts`` slot (B4 — path-based
+    routing bypasses model-id mismatches between "kokoro" / "kokoro-v1" / "tts").
+    Register under ``tts`` so both legacy-fallback Rule 2 and
+    _default_for_path land on the right upstream.
     """
     client.app.state.upstreams.upsert(
         Upstream(
-            name="chat",
+            name="tts",
             kind="slot",
             url=f"http://127.0.0.1:{port}/v1",
-            slot_name="chat",
+            slot_name="tts",
             auth_style="none",
         )
     )
-    _pin_slot_ready(client)
+    _pin_slot_ready(client, slot_name="tts")
 
 
 def _install_mock_transport(client: TestClient, handler: httpx.MockTransport | object) -> None:
@@ -282,6 +284,40 @@ def test_v1_audio_speech_happy_path(client: TestClient) -> None:
     assert r.status_code == 200, r.text
     assert r.content == fake_wav
     assert r.headers["content-type"].startswith("audio/wav")
+
+
+def test_v1_audio_speech_kokoro_v1_reaches_tts_upstream(client: TestClient) -> None:
+    """model='kokoro-v1' on /audio/speech must reach the tts upstream.
+
+    Kokoro-v1 is the client-facing model id but the container advertises
+    'kokoro'.  Path-based routing (B4) means the model id is irrelevant —
+    /audio/speech always resolves to the tts slot.
+    """
+    _seed_tts_upstream(client)
+
+    fake_wav = b"RIFF\x24\x00\x00\x00WAVEfmt " + b"\x00" * 32
+
+    captured: dict[str, object] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["path"] = req.url.path
+        return httpx.Response(
+            200,
+            content=fake_wav,
+            headers={"content-type": "audio/wav"},
+        )
+
+    _install_mock_transport(client, handler)
+
+    r = client.post(
+        "/v1/audio/speech",
+        json={"model": "kokoro-v1", "input": "hello world", "voice": "af_bella"},
+    )
+
+    assert r.status_code == 200, r.text
+    assert r.content == fake_wav
+    # Confirm the request reached the mock upstream (forwarded, not 503/404).
+    assert captured.get("path") is not None, "handler never called — dispatch failed"
 
 
 # ── Sanity: the scrubber leaves non-audio routes alone ────────────────────────

--- a/tests/api/test_v1_audio.py
+++ b/tests/api/test_v1_audio.py
@@ -74,24 +74,35 @@ def _seed_stt_upstream(client: TestClient, port: int = 8089) -> None:
     _pin_slot_ready(client)
 
 
-def _seed_tts_upstream(client: TestClient, port: int = 8090) -> None:
-    """Register a fake TTS slot at the ``tts`` upstream name.
+def _seed_tts_upstream(client: TestClient, port: int = 8084) -> None:
+    """Register the TTS upstream EXACTLY as production does: a container remote.
 
-    POST /v1/audio/speech is path-routed to the ``tts`` slot (B4 — path-based
-    routing bypasses model-id mismatches between "kokoro" / "kokoro-v1" / "tts").
-    Register under ``tts`` so both legacy-fallback Rule 2 and
-    _default_for_path land on the right upstream.
+    POST /v1/audio/speech is path-routed to the ``tts`` slot (B4).  The kokoro
+    container registers via ``SlotManager._register_container_upstream`` as
+    ``kind="remote"`` with ``slot_name="tts"`` — the path-pin rules in
+    ``hal0.dispatcher.proxy`` accept that container-backed remote (C1 fix), so
+    tests must exercise the same shape rather than a kind="slot" stand-in.
+
+    The container readiness gate in ``Dispatcher.forward`` probes systemctl +
+    /health for container remotes; no real unit exists under test, so we stub
+    ``container_readiness_check`` to report ready.
     """
     client.app.state.upstreams.upsert(
         Upstream(
             name="tts",
-            kind="slot",
+            kind="remote",
             url=f"http://127.0.0.1:{port}/v1",
-            slot_name="tts",
+            slot_name="tts",  # container-backed marker (#656)
             auth_style="none",
+            warmup_strategy="none",
+            advertise_models=True,
         )
     )
-    _pin_slot_ready(client, slot_name="tts")
+
+    async def _ready(_slot_name: str) -> tuple[bool, str]:
+        return True, "ready"
+
+    client.app.state.dispatcher._slot_manager.container_readiness_check = _ready
 
 
 def _install_mock_transport(client: TestClient, handler: httpx.MockTransport | object) -> None:
@@ -287,20 +298,22 @@ def test_v1_audio_speech_happy_path(client: TestClient) -> None:
 
 
 def test_v1_audio_speech_kokoro_v1_reaches_tts_upstream(client: TestClient) -> None:
-    """model='kokoro-v1' on /audio/speech must reach the tts upstream.
+    """model='kokoro-v1' on /audio/speech must reach the tts CONTAINER remote.
 
     Kokoro-v1 is the client-facing model id but the container advertises
-    'kokoro'.  Path-based routing (B4) means the model id is irrelevant —
-    /audio/speech always resolves to the tts slot.
+    'kokoro', so every model-based path (Step 0 preempt, registry,
+    passthrough) misses.  The legacy path-pin must resolve the
+    kind="remote" container upstream (C1) — exercised through the REAL
+    dispatch chain: route → dispatcher.dispatch → forward.
     """
-    _seed_tts_upstream(client)
+    _seed_tts_upstream(client, port=8084)
 
     fake_wav = b"RIFF\x24\x00\x00\x00WAVEfmt " + b"\x00" * 32
 
     captured: dict[str, object] = {}
 
     def handler(req: httpx.Request) -> httpx.Response:
-        captured["path"] = req.url.path
+        captured["url"] = str(req.url)
         return httpx.Response(
             200,
             content=fake_wav,
@@ -316,8 +329,11 @@ def test_v1_audio_speech_kokoro_v1_reaches_tts_upstream(client: TestClient) -> N
 
     assert r.status_code == 200, r.text
     assert r.content == fake_wav
-    # Confirm the request reached the mock upstream (forwarded, not 503/404).
-    assert captured.get("path") is not None, "handler never called — dispatch failed"
+    # The forward MUST target the tts container remote's port — not the
+    # lemonade gateway (13305) and not the chat slot.
+    assert captured.get("url") is not None, "handler never called — dispatch failed"
+    assert "127.0.0.1:8084" in str(captured["url"]), captured["url"]
+    assert str(captured["url"]).endswith("/audio/speech")
 
 
 # ── Sanity: the scrubber leaves non-audio routes alone ────────────────────────

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -140,7 +140,9 @@ class TestLoadProfilesConfig:
 
     def test_seed_count(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
-        assert len(cfg.profile) == 4  # moe-rocmfp4, dense-mtp-rocmfp4, vulkan-std, flm-npu
+        assert (
+            len(cfg.profile) == 5
+        )  # moe-rocmfp4, dense-mtp-rocmfp4, vulkan-std, flm-npu, kokoro-cpu
 
     def test_seed_profiles_have_correct_names(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
@@ -229,3 +231,13 @@ class TestSeedFileParity:
             assert file_entry["image"] == code_vals["image"], (
                 f"profiles.toml image for {name!r} differs from SEED_PROFILES"
             )
+
+
+# ── kokoro-cpu seed profile ───────────────────────────────────────────────────
+
+
+def test_kokoro_cpu_seed_profile() -> None:
+    prof = SEED_PROFILES["kokoro-cpu"]
+    assert prof["image"] == "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1"
+    assert "--model_path" in prof["flags"]
+    assert prof["mtp"] is False

--- a/tests/config/test_schema_npu.py
+++ b/tests/config/test_schema_npu.py
@@ -75,3 +75,12 @@ def test_seed_npu_toml_validates() -> None:
     assert slot.profile == "flm-npu"
     assert slot.device == "npu"
     assert slot.npu is not None and slot.npu.asr is False
+
+
+def test_seed_tts_toml_validates() -> None:
+    raw = tomllib.loads((_SEEDED_SLOTS_DIR / "tts.toml").read_text(encoding="utf-8"))
+    slot = SlotConfig.model_validate(raw)
+    assert slot.runtime == "container"
+    assert slot.profile == "kokoro-cpu"
+    assert slot.device == "cpu"
+    assert slot.port == 8084

--- a/tests/dispatcher/test_tts_path_routing.py
+++ b/tests/dispatcher/test_tts_path_routing.py
@@ -1,0 +1,266 @@
+"""Tests for TTS path-based routing to the ``tts`` slot.
+
+Phase B task B4 — ``/audio/speech`` path-routes to the ``tts`` slot at
+both the router (_default_for_path) and proxy (legacy fallback Rule 2)
+layers.  Model-id matching is intentionally bypassed because the kokoro
+container advertises ``"kokoro"`` while callers send ``"kokoro-v1"``,
+``"tts"``, etc.
+
+Mirrors the existing embed/rerank test style in test_router.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.requests import Request
+
+from hal0.dispatcher.proxy import LegacyResolutionFailed, resolve_slot
+from hal0.dispatcher.router import Dispatcher, UpstreamCall
+from hal0.upstreams.registry import Upstream, UpstreamRegistry
+
+# ── test doubles (same pattern as test_router.py) ────────────────────────────
+
+
+class FakeUpstreamRegistry(UpstreamRegistry):
+    def __init__(self, upstreams: list[Upstream]) -> None:
+        super().__init__()
+        self._store: dict[str, Upstream] = {u.name: u for u in upstreams}
+
+    def list(self) -> list[Upstream]:  # type: ignore[override]
+        return list(self._store.values())
+
+    def get(self, name: str) -> Upstream | None:  # type: ignore[override]
+        return self._store.get(name)
+
+
+class FakeModelRegistry:
+    def __init__(self, routes: dict[str, str] | None = None) -> None:
+        self._routes = routes or {}
+
+    def route_for(self, model_id: str) -> str | None:
+        return self._routes.get(model_id)
+
+
+def make_request(path: str = "/v1/audio/speech", method: str = "POST") -> Request:
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"authorization", b"Bearer test-token"),
+        ],
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 12345),
+        "http_version": "1.1",
+        "root_path": "",
+    }
+    return Request(scope)
+
+
+def make_slot(name: str, url: str = "http://127.0.0.1:8084/v1") -> Upstream:
+    return Upstream(name=name, kind="slot", url=url, slot_name=name)
+
+
+def make_remote_tts(port: int = 8084) -> Upstream:
+    """A kind='remote' container upstream registered as 'tts'."""
+    return Upstream(
+        name="tts",
+        kind="remote",
+        url=f"http://127.0.0.1:{port}/v1",
+        auth_style="none",
+        warmup_strategy="none",
+        advertise_models=True,
+        slot_name="tts",  # container-backed remote
+    )
+
+
+# ── router._default_for_path ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audio_speech_uses_tts_default_from_path() -> None:
+    """No model in body + /audio/speech path → _default_for_path returns 'tts'.
+
+    Uses a registry binding for 'tts' so the router's registry path resolves
+    cleanly, letting us assert the resolution_path rather than catching
+    LegacyResolutionFailed.
+    """
+    tts = make_slot("tts", "http://127.0.0.1:8084/v1")
+    upstreams = FakeUpstreamRegistry([tts])
+    models = FakeModelRegistry(routes={"tts": "tts"})
+
+    async def online(_u: Upstream) -> bool:
+        return True
+
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        is_online=online,
+        cached_models=lambda name: ["tts"] if name == "tts" else [],
+    )
+
+    call = await dispatcher.dispatch(
+        make_request(path="/v1/audio/speech"),
+        body={"input": "hello", "voice": "af_bella"},  # no model key
+    )
+    assert isinstance(call, UpstreamCall)
+    assert call.upstream_name == "tts"
+    assert call.resolution_path == "registry"
+
+
+@pytest.mark.asyncio
+async def test_audio_speech_kokoro_v1_reaches_tts_slot() -> None:
+    """model='kokoro-v1' body + /audio/speech → tts upstream.
+
+    The model id 'kokoro-v1' has no registry binding, so the request falls
+    to _default_for_path which uses the path to select 'tts'.
+    """
+    tts = make_slot("tts", "http://127.0.0.1:8084/v1")
+    upstreams = FakeUpstreamRegistry([tts])
+    models = FakeModelRegistry(routes={})  # no registry binding for 'kokoro-v1'
+
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+    )
+
+    call = await dispatcher.dispatch(
+        make_request(path="/v1/audio/speech"),
+        body={"model": "kokoro-v1", "input": "hello", "voice": "af_bella"},
+    )
+    assert isinstance(call, UpstreamCall)
+    assert call.upstream_name == "tts"
+    assert call.resolution_path == "legacy_slot:tts"
+
+
+# ── proxy.resolve_slot (legacy fallback) ─────────────────────────────────────
+
+
+def test_proxy_audio_speech_path_pins_to_tts() -> None:
+    """Legacy fallback Rule 2: /audio/speech in path → tts slot."""
+    tts = make_slot("tts")
+    upstreams = FakeUpstreamRegistry([tts])
+
+    upstream = resolve_slot(
+        path="/v1/audio/speech",
+        body={"model": "kokoro-v1", "input": "hi", "voice": "af_bella"},
+        upstreams=upstreams,
+    )
+    assert upstream.name == "tts"
+
+
+def test_proxy_audio_speech_no_model_pins_to_tts() -> None:
+    """path-based pin fires even when body has no model field."""
+    tts = make_slot("tts")
+    upstreams = FakeUpstreamRegistry([tts])
+
+    upstream = resolve_slot(
+        path="/v1/audio/speech",
+        body={"input": "hi", "voice": "af_bella"},
+        upstreams=upstreams,
+    )
+    assert upstream.name == "tts"
+
+
+def test_proxy_audio_speech_unknown_model_still_pins_to_tts() -> None:
+    """Any model id on /audio/speech routes to tts (not chat)."""
+    tts = make_slot("tts")
+    chat = make_slot("chat", "http://127.0.0.1:8081/v1")
+    upstreams = FakeUpstreamRegistry([tts, chat])
+
+    upstream = resolve_slot(
+        path="/v1/audio/speech",
+        body={"model": "some-unknown-tts-model", "input": "hello", "voice": "af_bella"},
+        upstreams=upstreams,
+    )
+    assert upstream.name == "tts"
+
+
+def test_proxy_audio_speech_missing_tts_slot_raises_typed_error() -> None:
+    """If tts slot not registered, legacy fallback raises LegacyResolutionFailed."""
+    chat = make_slot("chat")
+    upstreams = FakeUpstreamRegistry([chat])  # no tts
+
+    with pytest.raises(LegacyResolutionFailed) as exc:
+        resolve_slot(
+            path="/v1/audio/speech",
+            body={"model": "kokoro-v1", "input": "hi", "voice": "af_bella"},
+            upstreams=upstreams,
+        )
+    assert exc.value.code == "dispatch.legacy_unresolved"
+    assert "tts" in str(exc.value)
+
+
+# ── container upstream preemption ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_container_tts_upstream_preempts_registry() -> None:
+    """A tts container remote (kind=remote, slot_name=tts) wins Step 0 preemption.
+
+    The tts slot registers as kind='remote' (container), not kind='slot'
+    (Lemonade). Step 0 in dispatch scans container remotes first — if the
+    model id is in the cached_models for that upstream it wins immediately,
+    before registry or legacy paths run.
+    """
+    container_tts = make_remote_tts(port=8084)
+    upstreams = FakeUpstreamRegistry([container_tts])
+    models = FakeModelRegistry(routes={})
+
+    async def online(_u: Upstream) -> bool:
+        return True
+
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        is_online=online,
+        # Simulate tts container advertising "kokoro" as its model id.
+        cached_models=lambda name: ["kokoro"] if name == "tts" else [],
+    )
+
+    call = await dispatcher.dispatch(
+        make_request(path="/v1/audio/speech"),
+        body={"model": "kokoro", "input": "hello", "voice": "af_bella"},
+    )
+    assert call.upstream_name == "tts"
+    assert call.resolution_path == "container:tts"
+
+
+# ── NEGATIVE: /audio/transcriptions NOT affected ──────────────────────────────
+
+
+def test_proxy_audio_transcriptions_not_routed_to_tts() -> None:
+    """/audio/transcriptions is STT — must NOT be pinned to the tts slot.
+
+    The _TTS_PATHS check is '/audio/speech' only. Transcription requests
+    fall through to the chat fallback (or caller-specified slot).
+    """
+    chat = make_slot("chat", "http://127.0.0.1:8081/v1")
+    upstreams = FakeUpstreamRegistry([chat])
+
+    upstream = resolve_slot(
+        path="/v1/audio/transcriptions",
+        body={"model": "moonshine-small", "language": "en"},
+        upstreams=upstreams,
+    )
+    # Falls to chat (Rule 8), NOT tts.
+    assert upstream.name == "chat"
+
+
+@pytest.mark.asyncio
+async def test_router_audio_transcriptions_not_default_to_tts() -> None:
+    """_default_for_path('/v1/audio/transcriptions') must not return 'tts'."""
+    chat = make_slot("chat", "http://127.0.0.1:8081/v1")
+    upstreams = FakeUpstreamRegistry([chat])
+    models = FakeModelRegistry(routes={})
+
+    dispatcher = Dispatcher(upstream_registry=upstreams, model_registry=models)
+
+    # dispatcher._default_for_path is accessible for a direct unit check.
+    result = dispatcher._default_for_path("/v1/audio/transcriptions")
+    assert result != "tts"
+    assert result == "chat"

--- a/tests/dispatcher/test_tts_path_routing.py
+++ b/tests/dispatcher/test_tts_path_routing.py
@@ -264,3 +264,122 @@ async def test_router_audio_transcriptions_not_default_to_tts() -> None:
     result = dispatcher._default_for_path("/v1/audio/transcriptions")
     assert result != "tts"
     assert result == "chat"
+
+
+# ── C1: path-pin must resolve container-backed remote upstreams ───────────────
+#
+# Container slots register as kind="remote" (manager._register_container_upstream)
+# with slot_name set. resolve_slot's old kind=="slot" gate rejected them, so
+# kokoro-v1 requests raised LegacyResolutionFailed → NoRouteFound → fell into
+# the lemonade _proxy and died on the dead lemond tts slot.
+
+
+@pytest.mark.asyncio
+async def test_dispatch_kokoro_v1_resolves_container_remote_tts() -> None:
+    """Full dispatch(): model='kokoro-v1' + tts as kind=remote → tts remote wins.
+
+    Step 0 preempt misses (container advertises 'kokoro', not 'kokoro-v1'),
+    registry/passthrough miss, so the legacy path-pin MUST resolve the
+    container-backed remote — never NoRouteFound / lemonade fall-through.
+    """
+    container_tts = make_remote_tts(port=8084)
+    upstreams = FakeUpstreamRegistry([container_tts])
+    models = FakeModelRegistry(routes={})  # no registry binding
+
+    async def online(_u: Upstream) -> bool:
+        return True
+
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        is_online=online,
+        # Container's /v1/models advertises 'kokoro' only — Step 0 misses.
+        cached_models=lambda name: ["kokoro"] if name == "tts" else [],
+    )
+
+    call = await dispatcher.dispatch(
+        make_request(path="/v1/audio/speech"),
+        body={"model": "kokoro-v1", "input": "hello", "voice": "af_bella"},
+    )
+    assert isinstance(call, UpstreamCall)
+    assert call.upstream_name == "tts"
+    assert call.resolution_path == "legacy_slot:tts"
+    assert call.target_url == "http://127.0.0.1:8084/v1/audio/speech"
+    # Container readiness gate must still fire in forward().
+    assert call.container_slot_name == "tts"
+
+
+def test_proxy_tts_path_pin_resolves_container_remote() -> None:
+    """resolve_slot: /audio/speech + tts registered kind=remote → returned."""
+    container_tts = make_remote_tts(port=8084)
+    upstreams = FakeUpstreamRegistry([container_tts])
+
+    upstream = resolve_slot(
+        path="/v1/audio/speech",
+        body={"model": "kokoro-v1", "input": "hi", "voice": "af_bella"},
+        upstreams=upstreams,
+    )
+    assert upstream.name == "tts"
+    assert upstream.kind == "remote"
+
+
+def test_proxy_embed_path_pin_resolves_container_remote() -> None:
+    """Path-pin container acceptance applies to embed/rerank pins too."""
+    container_embed = Upstream(
+        name="embed",
+        kind="remote",
+        url="http://127.0.0.1:8086/v1",
+        auth_style="none",
+        slot_name="embed",  # container-backed
+    )
+    upstreams = FakeUpstreamRegistry([container_embed])
+
+    upstream = resolve_slot(
+        path="/v1/embeddings",
+        body={"input": "x"},
+        upstreams=upstreams,
+    )
+    assert upstream.name == "embed"
+    assert upstream.kind == "remote"
+
+
+def test_proxy_genuine_remote_not_accepted_by_path_pin() -> None:
+    """A genuine external remote (slot_name=None) named 'tts' is still rejected.
+
+    slot_name is the container-backed marker (#656); a plain remote named
+    'tts' is NOT a local slot and must not absorb path-pinned traffic.
+    """
+    genuine_remote = Upstream(
+        name="tts",
+        kind="remote",
+        url="https://api.example.com/v1",
+        auth_style="bearer",
+        # slot_name unset — genuine remote
+    )
+    upstreams = FakeUpstreamRegistry([genuine_remote])
+
+    with pytest.raises(LegacyResolutionFailed):
+        resolve_slot(
+            path="/v1/audio/speech",
+            body={"model": "kokoro-v1", "input": "hi", "voice": "af_bella"},
+            upstreams=upstreams,
+        )
+
+
+def test_proxy_model_name_rule_does_not_resolve_container_remote() -> None:
+    """Container-remote acceptance is scoped to PATH pins only.
+
+    Rule 7 (explicit slot-name addressing via model id) on a non-pinned
+    path must NOT resolve a kind=remote upstream — model='tts' on
+    /chat/completions falls through to the chat fallback as before.
+    """
+    container_tts = make_remote_tts(port=8084)
+    chat = make_slot("chat", "http://127.0.0.1:8081/v1")
+    upstreams = FakeUpstreamRegistry([container_tts, chat])
+
+    upstream = resolve_slot(
+        path="/v1/chat/completions",
+        body={"model": "tts", "messages": []},
+        upstreams=upstreams,
+    )
+    assert upstream.name == "chat"

--- a/tests/providers/test_container_health_gating.py
+++ b/tests/providers/test_container_health_gating.py
@@ -1,0 +1,125 @@
+"""ContainerProvider.health gates on model_loaded when the /health body reports it.
+
+kokoro-server returns 200 with {"status": "loading", "model_loaded": false}
+BEFORE weights load — a plain status-200 check flips the slot READY while
+/v1/audio/speech still 503s. health() must gate ok on model_loaded when the
+key is present; bodies without the key (llama-server) keep the plain-200
+behavior, and the /v1/models fallback (FLM, fires only on non-200) is
+untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hal0.providers.container import ContainerProvider
+
+
+def _mock_client(fake_get: Any) -> AsyncMock:
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.get = fake_get
+    return client
+
+
+def _json_resp(status_code: int, body: Any) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = MagicMock(return_value=body)
+    return resp
+
+
+def _non_json_resp(status_code: int) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = MagicMock(side_effect=ValueError("not JSON"))
+    return resp
+
+
+@pytest.mark.anyio
+async def test_health_200_model_loading_not_ok() -> None:
+    """200 + {"model_loaded": false} (kokoro loading) → ok False."""
+    provider = ContainerProvider()
+    health_resp = _json_resp(200, {"status": "loading", "model_loaded": False})
+
+    async def fake_get(url: str, **kwargs: Any) -> MagicMock:
+        assert url.endswith("/health")
+        return health_resp
+
+    with patch("hal0.providers.container.httpx.AsyncClient", return_value=_mock_client(fake_get)):
+        result = await provider.health(8084)
+
+    assert result["ok"] is False
+
+
+@pytest.mark.anyio
+async def test_health_200_model_loaded_ok() -> None:
+    """200 + {"model_loaded": true} (kokoro ready) → ok True."""
+    provider = ContainerProvider()
+    health_resp = _json_resp(200, {"status": "ok", "model_loaded": True})
+
+    async def fake_get(url: str, **kwargs: Any) -> MagicMock:
+        return health_resp
+
+    with patch("hal0.providers.container.httpx.AsyncClient", return_value=_mock_client(fake_get)):
+        result = await provider.health(8084)
+
+    assert result["ok"] is True
+    assert result["status"] == "healthy"
+
+
+@pytest.mark.anyio
+async def test_health_200_non_json_body_stays_ok() -> None:
+    """200 with a non-JSON body (llama-server style) → ok True (pinned)."""
+    provider = ContainerProvider()
+    health_resp = _non_json_resp(200)
+
+    async def fake_get(url: str, **kwargs: Any) -> MagicMock:
+        return health_resp
+
+    with patch("hal0.providers.container.httpx.AsyncClient", return_value=_mock_client(fake_get)):
+        result = await provider.health(8095)
+
+    assert result["ok"] is True
+    assert result["status"] == "healthy"
+
+
+@pytest.mark.anyio
+async def test_health_200_json_without_model_loaded_stays_ok() -> None:
+    """200 JSON body lacking model_loaded key → ok True (llama behavior pinned)."""
+    provider = ContainerProvider()
+    health_resp = _json_resp(200, {"status": "ok"})
+
+    async def fake_get(url: str, **kwargs: Any) -> MagicMock:
+        return health_resp
+
+    with patch("hal0.providers.container.httpx.AsyncClient", return_value=_mock_client(fake_get)):
+        result = await provider.health(8095)
+
+    assert result["ok"] is True
+    assert result["status"] == "healthy"
+
+
+@pytest.mark.anyio
+async def test_health_404_v1_models_fallback_unchanged() -> None:
+    """404 on /health + 200 on /v1/models (FLM) → ok True (fallback regression)."""
+    provider = ContainerProvider()
+    health_resp = _non_json_resp(404)
+    models_resp = _json_resp(200, {"data": []})
+
+    async def fake_get(url: str, **kwargs: Any) -> MagicMock:
+        if url.endswith("/health"):
+            return health_resp
+        if url.endswith("/v1/models"):
+            return models_resp
+        raise AssertionError(f"unexpected URL: {url}")
+
+    with patch("hal0.providers.container.httpx.AsyncClient", return_value=_mock_client(fake_get)):
+        result = await provider.health(8088)
+
+    assert result["ok"] is True
+    assert result["status"] == "healthy"

--- a/tests/providers/test_container_spec_dispatch.py
+++ b/tests/providers/test_container_spec_dispatch.py
@@ -1,0 +1,220 @@
+"""load_sync routes slots to their spec provider (FLM/NPU, Kokoro/TTS)."""
+
+from __future__ import annotations
+
+import shlex
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from hal0.providers.container import ContainerProvider, _spec_provider_for
+
+
+def _exec_start(unit_text: str) -> list[str]:
+    for line in unit_text.splitlines():
+        if line.startswith("ExecStart="):
+            return shlex.split(line[len("ExecStart=") :])
+    raise AssertionError("ExecStart not found")
+
+
+_TEST_RUNTIME = "/usr/bin/docker"
+
+
+# ── _spec_provider_for unit tests ─────────────────────────────────────────────
+
+
+def test_spec_provider_npu_returns_flm() -> None:
+    from hal0.providers.flm import FLMProvider
+
+    result = _spec_provider_for({"device": "npu"})
+    assert isinstance(result, FLMProvider)
+
+
+def test_spec_provider_tts_type_returns_kokoro() -> None:
+    from hal0.providers.kokoro import KokoroProvider
+
+    result = _spec_provider_for({"device": "cpu", "type": "tts"})
+    assert isinstance(result, KokoroProvider)
+
+
+def test_spec_provider_kokoro_profile_returns_kokoro() -> None:
+    from hal0.providers.kokoro import KokoroProvider
+
+    result = _spec_provider_for({"device": "cpu", "profile": "kokoro-cpu"})
+    assert isinstance(result, KokoroProvider)
+
+
+def test_spec_provider_gpu_returns_none() -> None:
+    result = _spec_provider_for({"device": "gpu-rocm", "profile": "moe-rocmfp4"})
+    assert result is None
+
+
+def test_spec_provider_vulkan_returns_none() -> None:
+    result = _spec_provider_for({"device": "gpu-vulkan", "profile": "vulkan-server"})
+    assert result is None
+
+
+# ── load_sync kokoro TTS path ──────────────────────────────────────────────────
+
+
+def test_tts_kokoro_slot_renders_spec_unit() -> None:
+    """TTS/kokoro slot: spec unit rendered with --model_path, no --device=, correct --publish."""
+    provider = ContainerProvider()
+    slot_cfg = {
+        "name": "tts",
+        "port": 8084,
+        "device": "cpu",
+        "type": "tts",
+        "runtime": "container",
+        "profile": "kokoro-cpu",
+        "model": {"default": "kokoro-v1"},
+    }
+
+    unit_captured: list[str] = []
+
+    def fake_write_and_start(slot_name: str, unit_text: str) -> None:
+        unit_captured.append(unit_text)
+
+    with (
+        patch("hal0.providers.container._container_runtime", return_value=_TEST_RUNTIME),
+        patch.object(provider, "_write_and_start_unit", side_effect=fake_write_and_start),
+    ):
+        provider.load_sync(slot_cfg, {"_model_key": "kokoro-v1"})
+
+    assert unit_captured, "load_sync never called _write_and_start_unit"
+    argv = _exec_start(unit_captured[0])
+
+    # Kokoro spec args present
+    assert "--model_path" in argv
+    # CPU: zero --device= flags
+    assert not any(a.startswith("--device=") for a in argv)
+    # Loopback publish present
+    assert "--publish=127.0.0.1:8084:8084" in argv
+
+
+def test_tts_slot_by_type_only_no_profile() -> None:
+    """type=tts without explicit profile still routes through Kokoro."""
+    provider = ContainerProvider()
+    slot_cfg = {
+        "name": "tts",
+        "port": 8084,
+        "device": "cpu",
+        "type": "tts",
+        "runtime": "container",
+        # no profile key — KokoroProvider falls back to _DEFAULT_PROFILE
+    }
+
+    unit_captured: list[str] = []
+
+    def fake_write_and_start(slot_name: str, unit_text: str) -> None:
+        unit_captured.append(unit_text)
+
+    with (
+        patch("hal0.providers.container._container_runtime", return_value=_TEST_RUNTIME),
+        patch.object(provider, "_write_and_start_unit", side_effect=fake_write_and_start),
+    ):
+        provider.load_sync(slot_cfg, {})
+
+    assert unit_captured, "load_sync never called _write_and_start_unit"
+    argv = _exec_start(unit_captured[0])
+    assert "--model_path" in argv
+    assert not any(a.startswith("--device=") for a in argv)
+
+
+def test_kokoro_path_does_not_require_registry_model_path() -> None:
+    """kokoro-v1 is not a GGUF; model_info with NO 'path' must not raise.
+
+    The llama path's _resolve_model_path raises ValueError on missing 'path';
+    the kokoro spec path must never hit it.
+    """
+    provider = ContainerProvider()
+    slot_cfg = {
+        "name": "tts",
+        "port": 8084,
+        "device": "cpu",
+        "type": "tts",
+        "runtime": "container",
+        "profile": "kokoro-cpu",
+    }
+
+    unit_captured: list[str] = []
+
+    def fake_write_and_start(slot_name: str, unit_text: str) -> None:
+        unit_captured.append(unit_text)
+
+    with (
+        patch("hal0.providers.container._container_runtime", return_value=_TEST_RUNTIME),
+        patch.object(provider, "_write_and_start_unit", side_effect=fake_write_and_start),
+    ):
+        # model_info = {} — no 'path', must not raise
+        provider.load_sync(slot_cfg, {})
+
+    assert unit_captured
+
+
+# ── GPU slot unaffected ────────────────────────────────────────────────────────
+
+
+def test_gpu_slot_unaffected_still_takes_llama_path(tmp_path: Any) -> None:
+    """device=gpu-rocm, profile=moe-rocmfp4 → llama _render_unit path.
+
+    Mirrors TestLoadSyncNpuBranch.test_gpu_slot_unaffected_by_npu_branch style
+    from test_container_npu.py: patches _resolve_profile + GPU helpers, then
+    asserts --model present and /dev/accel absent.
+    """
+    from hal0.config.schema import ProfileConfig
+
+    provider = ContainerProvider()
+    profile = ProfileConfig(
+        image="ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
+        flags="-fa on",
+        mtp=False,
+    )
+    unit_file = tmp_path / "hal0-slot@chat.service"
+
+    def fake_run(*args: str, check: bool = True) -> MagicMock:
+        m = MagicMock()
+        m.returncode = 0
+        return m
+
+    with (
+        patch("hal0.providers.container._resolve_profile", return_value=profile),
+        patch(
+            "hal0.providers.container.resolve_gpu_device_paths",
+            return_value=["/dev/kfd", "/dev/dri/renderD128"],
+        ),
+        patch(
+            "hal0.providers.container.resolve_gpu_group_ids",
+            return_value=[],
+        ),
+        patch.object(provider, "_run", side_effect=fake_run),
+        patch.object(provider, "_unit_path", return_value=unit_file),
+    ):
+        provider.load_sync(
+            {
+                "name": "chat",
+                "port": 8095,
+                "profile": "moe-rocmfp4",
+                "device": "gpu-rocm",
+            },
+            {"path": "/mnt/ai-models/model.gguf", "_model_key": "my-model"},
+        )
+
+    unit_text = unit_file.read_text()
+    argv = _exec_start(unit_text)
+    # llama-server path: --model present
+    assert "--model" in argv
+    assert "/mnt/ai-models/model.gguf" in argv
+    # GPU device present, NPU device absent
+    assert "--device=/dev/kfd" in argv
+    assert "/dev/accel/accel0" not in unit_text
+    # No --model_path (kokoro flag) in GPU unit
+    assert "--model_path" not in unit_text
+
+
+def test_npu_wins_over_tts_type() -> None:
+    """device=npu is more specific than type=tts — FLM takes precedence."""
+    from hal0.providers.container import _spec_provider_for
+    from hal0.providers.flm import FLMProvider
+
+    provider = _spec_provider_for({"device": "npu", "type": "tts"})
+    assert isinstance(provider, FLMProvider)

--- a/tests/providers/test_kokoro_container_spec.py
+++ b/tests/providers/test_kokoro_container_spec.py
@@ -1,0 +1,99 @@
+"""Kokoro TTS container spec (Phase B)."""
+
+from typing import Any
+
+from hal0.providers.container import _render_unit_from_spec
+from hal0.providers.kokoro import KokoroProvider
+
+
+def _slot_cfg(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "tts",
+        "port": 8084,
+        "device": "cpu",
+        "type": "tts",
+        "runtime": "container",
+        "profile": "kokoro-cpu",
+        "model": {"default": "kokoro-v1"},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_spec_has_no_gpu_devices_or_groups() -> None:
+    spec = KokoroProvider().container_spec(_slot_cfg(), {})
+    assert spec.devices == []
+    assert spec.group_add == []
+
+
+def test_spec_command_carries_port_host_and_model_path() -> None:
+    spec = KokoroProvider().container_spec(_slot_cfg(), {})
+    c = spec.command
+    assert c[c.index("--port") + 1] == "8084"
+    assert c[c.index("--host") + 1] == "0.0.0.0"
+    assert c[c.index("--model_path") + 1] == "/mnt/ai-models/local/kokoro-v1/kokoro-onnx"
+
+
+def test_spec_mounts_model_store_and_publishes_loopback() -> None:
+    spec = KokoroProvider().container_spec(_slot_cfg(), {})
+    # ":ro" is appended to the container dst — that's how ContainerSpec
+    # expresses read-only mounts (_render_unit_from_spec emits --volume={src}:{dst}).
+    assert any(m[0] == "/mnt/ai-models" for m in spec.mounts)
+    assert spec.port == 8084
+    assert spec.network_mode == ""
+
+
+def test_spec_security_opts_for_lxc() -> None:
+    spec = KokoroProvider().container_spec(_slot_cfg(), {})
+    assert "apparmor=unconfined" in spec.security_opt
+    assert "seccomp=unconfined" in spec.security_opt
+
+
+def test_spec_ro_mount_dst_has_ro_suffix() -> None:
+    """ContainerSpec mount dst must carry :ro so the rendered --volume arg is read-only."""
+    spec = KokoroProvider().container_spec(_slot_cfg(), {})
+    ai_mount = next(m for m in spec.mounts if m[0] == "/mnt/ai-models")
+    assert ai_mount[1].endswith(":ro"), (
+        f"mount dst {ai_mount[1]!r} must end with ':ro' — "
+        "_render_unit_from_spec emits --volume={src}:{dst} verbatim"
+    )
+
+
+# ── Renderer integration test ──────────────────────────────────────────────────
+
+
+def test_renderer_no_device_args_publish_volume_command() -> None:
+    """_render_unit_from_spec renders the kokoro spec correctly.
+
+    Checks:
+    - No --device= args (CPU-only slot).
+    - --publish=127.0.0.1:8084:8084 present.
+    - Volume arg with /mnt/ai-models present.
+    - Command tail contains --model_path and --port.
+    """
+    spec = KokoroProvider().container_spec(_slot_cfg(), {})
+    unit = _render_unit_from_spec("tts", spec, runtime_bin="/usr/bin/docker")
+
+    # Flatten the ExecStart line for easy assertion.
+    exec_line = next(line for line in unit.splitlines() if line.startswith("ExecStart="))
+
+    assert "--device=" not in exec_line, "CPU slot must not pass any --device= args"
+    assert "--publish=127.0.0.1:8084:8084" in exec_line
+    # Exact rendered token — pins the 3-colon podman ro syntax; a substring
+    # check would also pass on a malformed 4-colon render.
+    assert "--volume=/mnt/ai-models:/mnt/ai-models:ro" in exec_line
+    assert "--model_path" in exec_line
+    assert "--port" in exec_line
+    assert "8084" in exec_line
+
+
+def test_slot_port_override_wins() -> None:
+    """Slot port overrides the 8084 default end-to-end (spec + render)."""
+    spec = KokoroProvider().container_spec(_slot_cfg(port=8097), {})
+    c = spec.command
+    assert c[c.index("--port") + 1] == "8097"
+    assert spec.port == 8097
+
+    unit = _render_unit_from_spec("tts", spec, runtime_bin="/usr/bin/docker")
+    exec_line = next(line for line in unit.splitlines() if line.startswith("ExecStart="))
+    assert "--publish=127.0.0.1:8097:8097" in exec_line

--- a/ui/tests/e2e/fixtures/mock-data.ts
+++ b/ui/tests/e2e/fixtures/mock-data.ts
@@ -230,6 +230,22 @@ export const MOCK_DATA = {
       mtp: false,
       resolved_flags: '--flash-attn on -ngl 999',
     },
+    // Phase A seed — NPU container slot (FLM toolbox).
+    {
+      name: 'flm-npu',
+      image: 'ghcr.io/hal0ai/hal0-toolbox-flm:v1',
+      flags: '',
+      mtp: false,
+      resolved_flags: '',
+    },
+    // Phase B5 seed — TTS container slot (kokoro-onnx, CPU-only).
+    {
+      name: 'kokoro-cpu',
+      image: 'ghcr.io/hal0ai/hal0-toolbox-kokoro:v1',
+      flags: '--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx',
+      mtp: false,
+      resolved_flags: '--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx',
+    },
   ],
 }
 


### PR DESCRIPTION
Second phase of Lemonade removal (spec §3/§12-B): the tts slot moves from lemond (error state since the kokoro/vibevoice mismatch) to the hal0 kokoro toolbox container.

## What
- **kokoro-cpu seed profile** (digest-pinned hal0-toolbox-kokoro:v1, --model_path at the shared store)
- **KokoroProvider.container_spec** — CPU-clean ContainerSpec (no devices/groups, :ro store mount, loopback publish) rendered by the Phase A spec seam; resolve_profile promoted to a public config.loader helper
- **load_sync spec-provider dispatch** — npu→FLM, tts→Kokoro, else llama path; Phase A npu suite untouched-green as the regression guard
- **/audio/speech path-pin** → tts slot (router default + proxy rule 2), and **path-pinned rules now resolve container-backed kind=remote upstreams** (final-review C1: the old kind==slot gate boomeranged TTS to the dead lemond slot)
- **Container health gates on model_loaded** when reported (final-review I2: kokoro answers 200-while-loading; slot no longer flips READY before weights load — covers the auto-download case)
- **Installer seed loop** (npu+tts), ui mock profiles refreshed (5 seeds)

## Notes
- #485 voice residual: none — STT covered by Phase A static-port trio dispatch (verified); rerank is Phase C
- Lemonade untouched for rerank/utility + observability (rollback intact until Phase E)
- Every task two-stage reviewed; final cross-task opus review caught C1+I2 in the seams, both fixed + re-verified: ship

Spec: docs/superpowers/specs/2026-06-10-lemonade-removal-container-switchover-design.md
Plan: docs/superpowers/plans/2026-06-11-phase-b-voice-kokoro-container.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)