### PR TITLE
docs: architecture-deepening vocabulary (2026-06-11 review)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -326,3 +326,73 @@ The HTTP header hal0-api sets on outbound hops to hermes (and that bundled agent
 ## composite hal0 upstream
 
 A single `Upstream(name="hal0", kind="slot", url="http://127.0.0.1:8080/v1", slot_name=None)` registered automatically in the upstream registry (`src/hal0/api/__init__.py::_autoregister_slot_upstreams`). Replaces per-slot autoregistration: Lemonade serialises chat loading on a single port (R4 H2 from MASTER-PLAN), so registering one Upstream per chat slot produced duplicate entries pointing at the same URL. The composite aggregates every chat-capable slot's model id through one `/v1/models` response (5s TTL cache). Explicit `upstreams.toml` entries claiming the name `hal0` win — autoregistration is skipped when overridden.
+
+---
+
+# Architecture-deepening vocabulary (proposed 2026-06-11)
+
+Terms locked during the architecture-review grilling (skill: `improve-codebase-architecture`).
+**Status: approved design directions, not yet implemented.** Each names a deepened module
+that replaces a shallow seam. Promote to a real entry (drop the "proposed" note) when the
+PR lands.
+
+## SlotConfigStore
+
+Proposed deep module that owns *both* `capabilities.toml` selections and `slots/*.toml` as
+one reconciled truth, ending the drift between them (today reconciled by an unconditional
+rewrite in `capabilities/orchestrator.py:apply()`). Interface: **`apply(selection) -> ChangeSet`
+is compute-only** (no disk write); the store also exposes `commit(cs)` (atomic write) and
+`revert(cs)`. Decision: keeping `apply()` pure is the whole point — it makes the write an
+explicit, observable, reversible step instead of a hidden rewrite. Replaces the "thin overlay
+reconciles on every apply" pattern with an observable, testable invariant. Supersedes the
+orchestrator's defensive rewrite as the home for capabilities ⇄ slot reconciliation. See
+[[ChangeSet]], candidate 1 of the 2026-06-11 review. Touches the ARCHITECTURE.md "thin overlay"
+framing.
+
+## ChangeSet
+
+The value `SlotConfigStore.apply()` returns: `{before, after}` snapshots of the on-disk slot
+config. Makes reconciliation a pure computation separate from the write — drift is testable as
+`disk == after` after a committed apply, `disk == before` after a revert. A failed mid-flight
+apply leaves disk at `before`, never a half-reconciled state. See [[SlotConfigStore]].
+
+## is_ready_for_dispatch / SlotManager.state
+
+The public readiness seam on `SlotManager`, replacing the Dispatcher's reach into the private
+`_current_state()` (`dispatcher/router.py:723,791`). `state(name) -> SlotState` exposes the
+slot state; `is_ready_for_dispatch(name) -> bool` owns the ready-set rule (`READY | SERVING |
+IDLE`) so it is defined exactly once instead of duplicated across Dispatcher and SlotManager.
+The Dispatcher stops knowing the state-cache, the disk fallback, and the enum. Endorsed by the
+2026-06-07 audit (ANSWERS §2.1). Candidate 2 of the 2026-06-11 review.
+
+## SlotViewAggregator
+
+Proposed stateless module that lifts the five enrichment concerns inline in
+`api/routes/slots.py:list_slots()` (state serialization, Lemonade `/v1/health` enrich + drift
+detect, container systemctl/port probe, per-slot memory accounting, metric injection) behind
+**eager `snapshot() -> list[SlotView]`** (single computation, no per-concern composition seam
+until a second caller justifies one). Takes its stores as constructor dependencies
+(slot_manager, registry, metrics, lemonade shim) so tests inject fakes instead of crossing
+HTTP. The route becomes a thin adapter. Decision: resist per-concern methods — one caller today
+makes a composable enrichment pipeline a hypothetical seam; add `snapshot(include_metrics=...)`
+only when the admin MCP surface actually needs state-without-metrics. Candidate 3 of the
+2026-06-11 review. See [[SlotView]].
+
+## SlotView
+
+The enriched per-slot record `SlotViewAggregator.snapshot()` emits — one slot's state plus its
+Lemonade/container enrichment, memory attribution, and metrics, as a typed object rather than
+the ad-hoc dict assembled inline in the route today. See [[SlotViewAggregator]].
+
+## model_meta
+
+Proposed single home (`src/hal0/model_meta/`) for the model-classification and
+device→backend logic currently copy-pasted across `routes/models.py:_classify_type`,
+`routes/slots.py`, `capabilities/orchestrator.py` (four `_canonical_*` helpers), and the
+omni-router heuristic. **Stateless surface, no construction:** `classify(model_id) -> slot
+type` and `device_to_backend(device) -> (recipe, llamacpp)` are pure; **`is_resolvable(model_id,
+registry) -> bool` takes the registry explicitly** (it needs registry membership + FLM-catalog
+presence via `is_installed_flm_id`) so the module stays importable everywhere without a handle
+to thread through. Imported by routes, orchestrator, and omni-router so a classification rule
+changes in one place. Removes the "keep the two in sync" hazard (`omni_router/filter.py` ↔
+`slots/manager.py`). Candidate 4 of the 2026-06-11 review.


### PR DESCRIPTION
## Summary

Adds an "Architecture-deepening vocabulary (proposed 2026-06-11)" section to CONTEXT.md with six glossary entries locked during the architecture-review grilling:

- **SlotConfigStore** — owns capabilities ⇄ slot reconciliation; `apply(selection)` is compute-only, returning a ChangeSet, with separate `commit`/`revert` (#697)
- **ChangeSet** — `{before, after}` snapshots making reconciliation pure and drift testable (#697)
- **is_ready_for_dispatch / SlotManager.state** — public readiness seam replacing the Dispatcher's reach into private `_current_state()` (#696)
- **SlotViewAggregator** — lifts the five enrichment concerns out of `list_slots()` behind eager `snapshot()` (#698)
- **SlotView** — the typed enriched per-slot record `snapshot()` emits (#698)
- **model_meta** — single stateless home for model classification + device→backend mapping (#695)

Each entry folds in the resolved fork decisions from the grilling session, so the glossary and the issue acceptance criteria stay consistent.

**Status: approved design directions, not yet implemented** — entries are marked proposed and get promoted when the implementation PRs land.

## Related

- Issues #695, #696, #697, #698 (dependency-ordered, ready-for-agent)
- Extends the 2026-06-07 codebase audit (`docs/internal/codebase-audit-2026-06-07/ANSWERS.md`); #696 endorsed there at §2.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)