### PR TITLE
refactor: model_meta — one home for model classification + device→backend (#695)

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -23,6 +23,7 @@ from fastapi.responses import StreamingResponse
 from hal0.api.middleware.error_codes import BadRequest, NotFound
 from hal0.config.loader import load_hal0_config
 from hal0.errors import Hal0Error
+from hal0.model_meta import classify
 from hal0.registry.curated import CURATED, CuratedModel, HaloaiModel, get_curated
 from hal0.registry.detect import DetectionResult, detect
 from hal0.registry.discover import is_skippable, scan_and_register
@@ -75,26 +76,9 @@ def _is_alias(model_id: str) -> bool:
     return model_id in _ALIAS_NAMES
 
 
-# Capability → coarse modality bucket the dashboard's Models view (and the
-# endpoints widget W7) counts by. ``chat`` covers text/vision LLMs; the
-# rest map a model's primary non-chat function so embed/rerank/voice/image
-# models are counted instead of being lumped under "chat" or omitted.
-_CAPABILITY_TO_TYPE: dict[str, str] = {
-    "chat": "chat",
-    "vision": "chat",
-    "embed": "embed",
-    "rerank": "rerank",
-    "asr": "stt",
-    "stt": "stt",
-    "tts": "tts",
-    "image": "img",
-    "img": "img",
-}
-
-# Precedence when a model advertises several capabilities: a dedicated
-# embedder that also lists "chat" should still classify as embed. chat is
-# the lowest-priority fallback so genuinely non-chat models surface.
-_TYPE_PRIORITY: tuple[str, ...] = ("rerank", "embed", "stt", "tts", "img", "chat")
+# Capability/id → coarse modality bucket classification lives in
+# hal0.model_meta.classify (issue #695) — the W7 vocab tables moved
+# there with it.
 
 # FLM capability → dispatcher-vocab slot type. The NPU slot pickers
 # (ui/dash/slots.jsx ``modelSlotType``) speak the dispatcher vocabulary
@@ -109,38 +93,6 @@ _FLM_DISPATCH_TYPE: dict[str, str] = {
     "tts": "tts",
     "image": "image",
 }
-
-
-def _classify_type(capabilities: Any, model_id: str = "") -> str:
-    """Return the primary modality bucket for a model.
-
-    Reads the model's ``capabilities`` list (chat/embed/rerank/asr/tts/
-    vision/image). Falls back to filename heuristics on the id so
-    upstream-only rows (which carry no capabilities) still classify.
-    Defaults to ``"chat"`` when nothing else matches.
-    """
-    found: set[str] = set()
-    if isinstance(capabilities, (list, tuple)):
-        for cap in capabilities:
-            t = _CAPABILITY_TO_TYPE.get(str(cap).strip().lower())
-            if t:
-                found.add(t)
-    if not found and model_id:
-        mid = model_id.lower()
-        if "rerank" in mid:
-            found.add("rerank")
-        elif "embed" in mid or "bge" in mid or "nomic" in mid:
-            found.add("embed")
-        elif "whisper" in mid or "moonshine" in mid or "-stt" in mid or "asr" in mid:
-            found.add("stt")
-        elif "tts" in mid or "kokoro" in mid or "vibevoice" in mid or "-voice" in mid:
-            found.add("tts")
-        elif "flux" in mid or "sdxl" in mid or "stable-diffusion" in mid or "-img" in mid:
-            found.add("img")
-    for t in _TYPE_PRIORITY:
-        if t in found:
-            return t
-    return "chat"
 
 
 @router.get("")
@@ -165,7 +117,7 @@ async def list_models(request: Request) -> dict[str, Any]:
         dumped.setdefault("object", "model")
         dumped.setdefault("created", now)
         dumped.setdefault("owned_by", "local")
-        dumped["type"] = _classify_type(dumped.get("capabilities"), dumped.get("id", ""))
+        dumped["type"] = classify(dumped.get("id", ""), capabilities=dumped.get("capabilities"))
         data.append(dumped)
         seen.add(entry.id)
     for u in upstreams.list():
@@ -197,7 +149,7 @@ async def list_models(request: Request) -> dict[str, Any]:
                     "ns": "pulled",
                     # Upstream rows carry no capabilities; classify from
                     # the id so W7 still counts embed/rerank/voice/img.
-                    "type": _classify_type(None, mid),
+                    "type": classify(mid),
                 }
             )
     # Installed FLM/NPU models — surfaced straight from the host-flm probe so

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -33,6 +33,7 @@ from fastapi import APIRouter, BackgroundTasks, Request
 from fastapi.responses import StreamingResponse
 
 from hal0.api.middleware.error_codes import BadRequest, Conflict, Hal0Error
+from hal0.model_meta import device_to_backend, is_resolvable
 from hal0.slots.manager import Slot, SlotManager
 
 # Auth was removed in ADR-0012. All routes are open on the local network.
@@ -64,22 +65,6 @@ def _get_slot_manager(request: Request) -> SlotManager:
             details={"hint": "lifespan did not run"},
         )
     return sm
-
-
-def _model_resolvable(registry: Any, model_id: str) -> bool:
-    """True if ``model_id`` can actually be loaded onto a slot.
-
-    The slot-apply guard used to require ``registry.has(model_id)``, but FLM
-    models are lemond-owned and are never in hal0's registry (see the
-    2026-06-07 shape audits) — yet they load fine via npu.toml's config path.
-    So gate on *provider-resolvability*: registry-resident OR an installed FLM
-    model. (Extensible later to a general ``lemond_serves(id)`` probe.)
-    """
-    if registry is not None and registry.has(model_id):
-        return True
-    from hal0.providers.flm import is_installed_flm_id
-
-    return is_installed_flm_id(model_id)
 
 
 def _slot_to_dict(slot: Slot, request: Request | None = None) -> dict[str, Any]:
@@ -297,13 +282,10 @@ async def _lemonade_state_enrichment(request: Request) -> dict[str, dict[str, An
             # the child can't be introspected. Do NOT read
             # loaded_entry.get("backend") — that field does not exist.
             from hal0.providers.lemonade import (
-                device_to_backend as _device_to_backend,
-            )
-            from hal0.providers.lemonade import (
                 resolve_actual_backend as _resolve_actual_backend,
             )
 
-            _recipe, _llamacpp = _device_to_backend(cfg.get("device"))
+            _recipe, _llamacpp = device_to_backend(cfg.get("device"))
             declared_backend = _llamacpp or (_recipe if _recipe == "flm" else None)
             if declared_backend:
                 entry["declared_backend"] = declared_backend
@@ -1456,8 +1438,6 @@ async def set_slot_backend(name: str, request: Request) -> dict[str, object]:
     ``requested_backend`` / ``declared_backend`` / ``actual_backend`` /
     ``reloaded``.
     """
-    from hal0.providers.lemonade import device_to_backend
-
     sm = _get_slot_manager(request)
     try:
         body = await request.json()
@@ -1601,7 +1581,7 @@ async def load_slot(name: str, request: Request) -> dict[str, object]:
         model_id = body.get("model")
     if model_id:
         registry = getattr(request.app.state, "model_registry", None)
-        if registry is not None and not _model_resolvable(registry, model_id):
+        if registry is not None and not is_resolvable(model_id, registry):
             from hal0.registry.store import ModelNotFound
 
             raise ModelNotFound(
@@ -1651,7 +1631,7 @@ async def swap_slot(name: str, request: Request) -> dict[str, object]:
             code="swap.missing_model",
         )
     registry = getattr(request.app.state, "model_registry", None)
-    if registry is not None and not _model_resolvable(registry, model_id):
+    if registry is not None and not is_resolvable(model_id, registry):
         from hal0.registry.store import ModelNotFound
 
         raise ModelNotFound(

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -46,6 +46,7 @@ from hal0.config.loader import load_slot_config, write_toml_atomic
 from hal0.dispatcher._npu_common import is_container_npu_cfg
 from hal0.errors import BadRequest, Hal0Error, NotFound
 from hal0.lemonade.client import flm_args_from_lemond_config, flm_args_set_payload
+from hal0.model_meta import canonical_device, device_to_legacy_backend
 from hal0.registry.store import ModelRegistry
 from hal0.slots.manager import SlotManager
 
@@ -273,7 +274,7 @@ class CapabilityOrchestrator:
             # (not the deprecated ``backend``). SlotConfig auto-promotes
             # legacy ``backend`` on load, so ``slot_cfg.device`` is the
             # right v0.2 surface here.
-            selection.device = self._canonical_device_id(slot_cfg.device)
+            selection.device = canonical_device(slot_cfg.device)
             selection.provider = slot_cfg.provider
             selection.model = slot_cfg.model.default or ""
             selection.enabled = bool(slot_cfg.enabled) and bool(selection.model)
@@ -282,62 +283,12 @@ class CapabilityOrchestrator:
         self._save(cfg)
 
     # ── shape helpers ────────────────────────────────────────────────────────
-
-    @staticmethod
-    def _canonical_device_id(slot_device: str) -> str:
-        """Normalise a slot's ``device`` to the capabilities catalog id.
-
-        After ADR-0006 §7 both surfaces speak the same enum
-        (``gpu-rocm | gpu-vulkan | cpu | npu``), so this is a near-identity.
-        It still tolerates a legacy ``backend``-style input
-        (``vulkan|rocm|flm|moonshine|kokoro``) for forward compatibility
-        with hand-edited slot TOMLs by routing through
-        :func:`hal0.config.schema.map_backend_to_device`.
-        """
-        from hal0.config.schema import _VALID_DEVICES, map_backend_to_device
-
-        if not slot_device:
-            return ""
-        if slot_device in _VALID_DEVICES:
-            return slot_device
-        return map_backend_to_device(slot_device)
-
-    @staticmethod
-    def _canonical_backend_id(slot_backend: str) -> str:
-        """DEPRECATED — kept for tests / external callers.
-
-        Forward to :meth:`_canonical_device_id`. Removed when the
-        ``backend`` field is excised in v0.3.
-        """
-        return CapabilityOrchestrator._canonical_device_id(slot_backend)
-
-    @staticmethod
-    def _slot_device_for_catalog_id(device_id: str) -> str:
-        """Catalog ``device`` id → SlotConfig.device string (identity)."""
-        from hal0.config.schema import _VALID_DEVICES
-
-        if device_id in _VALID_DEVICES:
-            return device_id
-        # Legacy round-trip — accept ``vulkan|rocm|flm|cpu`` and forward.
-        from hal0.config.schema import map_backend_to_device
-
-        return map_backend_to_device(device_id) if device_id else ""
-
-    @staticmethod
-    def _slot_backend_for_catalog_id(backend_id: str) -> str:
-        """DEPRECATED — translate catalog id to the legacy ``backend`` string.
-
-        Still used by code paths that write the deprecated SlotConfig.backend
-        field (kept until v0.3 for downgrade legibility). New write paths
-        should call :meth:`_slot_device_for_catalog_id` instead.
-        """
-        mapping = {
-            "gpu-vulkan": "vulkan",
-            "gpu-rocm": "rocm",
-            "npu": "flm",
-            "cpu": "cpu",
-        }
-        return mapping.get(backend_id, backend_id)
+    #
+    # The device-namespace normalisation helpers that used to live here
+    # (``_canonical_device_id`` / ``_canonical_backend_id`` /
+    # ``_slot_device_for_catalog_id`` / ``_slot_backend_for_catalog_id``)
+    # moved to :mod:`hal0.model_meta` (issue #695) as
+    # :func:`canonical_device` and :func:`device_to_legacy_backend`.
 
     def _selection_with_defaults(
         self, cfg: CapabilityConfig, slot: str, child: str
@@ -453,7 +404,7 @@ class CapabilityOrchestrator:
             if key in partial:
                 if key == "backend":
                     # Translate legacy alias forward.
-                    merged_data["device"] = self._canonical_device_id(str(partial[key]))
+                    merged_data["device"] = canonical_device(str(partial[key]))
                 else:
                     merged_data[key] = partial[key]
         try:
@@ -658,8 +609,8 @@ class CapabilityOrchestrator:
         # Emit both ``device`` (v0.2 canonical) and ``backend`` (v0.1.x
         # alias) so downgrades remain legible. SlotConfig's
         # ``_promote_backend_to_device`` validator keeps them in sync.
-        slot_backend = self._slot_backend_for_catalog_id(selection.device)
-        slot_device = self._slot_device_for_catalog_id(selection.device)
+        slot_backend = device_to_legacy_backend(selection.device)
+        slot_device = canonical_device(selection.device)
         provider = selection.provider or "llama-server"
         cfg_dict: dict[str, Any] = {
             "name": slot_name,
@@ -843,8 +794,8 @@ class CapabilityOrchestrator:
         cfg_path = paths.slots_config_dir() / f"{slot_name}.toml"
         if not cfg_path.exists():
             return
-        slot_backend = self._slot_backend_for_catalog_id(selection.device)
-        slot_device = self._slot_device_for_catalog_id(selection.device)
+        slot_backend = device_to_legacy_backend(selection.device)
+        slot_device = canonical_device(selection.device)
         updates: dict[str, Any] = {}
         if slot_backend:
             # Deprecated field, kept for one release — see ADR-0006 §7.

--- a/src/hal0/model_meta/__init__.py
+++ b/src/hal0/model_meta/__init__.py
@@ -1,0 +1,226 @@
+"""model_meta — the one home for model classification + device→backend resolution.
+
+Issue #695. Before this module the same logic was copy-pasted across
+five sites (``routes/models.py``, ``routes/slots.py``,
+``capabilities/orchestrator.py``, ``omni_router/filter.py``,
+``slots/manager.py``); a classification-rule change meant hunting every
+copy. They all import from here now.
+
+The module is **stateless** — no classes, no construction, just
+importable functions. ``classify`` and ``device_to_backend`` are pure;
+``is_resolvable`` takes the registry explicitly as an argument so the
+module stays importable everywhere without threading a handle through.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# ── classification ───────────────────────────────────────────────────────────
+
+# Capability → coarse modality bucket the dashboard's Models view (and the
+# endpoints widget W7) counts by. ``chat`` covers text/vision LLMs; the
+# rest map a model's primary non-chat function so embed/rerank/voice/image
+# models are counted instead of being lumped under "chat" or omitted.
+_CAPABILITY_TO_TYPE: dict[str, str] = {
+    "chat": "chat",
+    "vision": "chat",
+    "embed": "embed",
+    "rerank": "rerank",
+    "asr": "stt",
+    "stt": "stt",
+    "tts": "tts",
+    "image": "img",
+    "img": "img",
+}
+
+# Precedence when a model advertises several capabilities: a dedicated
+# embedder that also lists "chat" should still classify as embed. chat is
+# the lowest-priority fallback so genuinely non-chat models surface.
+_TYPE_PRIORITY: tuple[str, ...] = ("rerank", "embed", "stt", "tts", "img", "chat")
+
+
+def classify(model_id: str = "", capabilities: Any = None) -> str:
+    """Return the primary modality bucket for a model.
+
+    Reads the model's ``capabilities`` list (chat/embed/rerank/asr/tts/
+    vision/image). Falls back to filename heuristics on the id so
+    upstream-only rows (which carry no capabilities) still classify.
+    Defaults to ``"chat"`` when nothing else matches.
+    """
+    found: set[str] = set()
+    if isinstance(capabilities, (list, tuple)):
+        for cap in capabilities:
+            t = _CAPABILITY_TO_TYPE.get(str(cap).strip().lower())
+            if t:
+                found.add(t)
+    if not found and model_id:
+        mid = model_id.lower()
+        if "rerank" in mid:
+            found.add("rerank")
+        elif "embed" in mid or "bge" in mid or "nomic" in mid:
+            found.add("embed")
+        elif "whisper" in mid or "moonshine" in mid or "-stt" in mid or "asr" in mid:
+            found.add("stt")
+        elif "tts" in mid or "kokoro" in mid or "vibevoice" in mid or "-voice" in mid:
+            found.add("tts")
+        elif "flux" in mid or "sdxl" in mid or "stable-diffusion" in mid or "-img" in mid:
+            found.add("img")
+    for t in _TYPE_PRIORITY:
+        if t in found:
+            return t
+    return "chat"
+
+
+# ── device → Lemonade recipe/backend mapping ─────────────────────────────────
+#
+# Plan §4.1 + ADR-0008 §6 locked the four-way mapping. ``gpu-*`` slots
+# load through llama.cpp with an explicit backend flag; ``cpu`` is the
+# same recipe with CPU-only inference; ``npu`` uses Lemonade's FLM
+# recipe and does not take a llamacpp_backend (FLM is its own backend).
+#
+# Returned tuple shape: ``(recipe, llamacpp_backend)``. ``recipe=None``
+# means "let Lemonade pick its default" (currently the llama.cpp recipe
+# for gpu/cpu).  Either value being ``None`` causes
+# :meth:`LemonadeClient.load` to omit the key from the request body —
+# Lemonade then falls through to its internal sentinel logic.
+
+
+def device_to_backend(device: str | None) -> tuple[str | None, str | None]:
+    """Map hal0's ``device`` enum onto Lemonade's recipe+backend pair.
+
+    Args:
+        device: One of ``gpu-rocm`` | ``gpu-vulkan`` | ``cpu`` | ``npu``.
+                Empty / unknown values fall back to ``(None, None)`` so
+                Lemonade picks its own defaults — same semantics as
+                omitting the keys from the load body.
+
+    Returns:
+        ``(recipe, llamacpp_backend)``. Either may be ``None`` to mean
+        "don't send this key in the /v1/load body". The two are
+        mutually exclusive in practice — NPU uses ``recipe="flm"`` with
+        no llamacpp_backend; everything else uses ``recipe=None`` with
+        a concrete llamacpp_backend.
+    """
+    if not device:
+        return (None, None)
+    d = device.strip().lower()
+    if d == "gpu-rocm":
+        return (None, "rocm")
+    if d == "gpu-vulkan":
+        return (None, "vulkan")
+    if d == "cpu":
+        return (None, "cpu")
+    if d == "npu":
+        # FLM recipe; ``llamacpp_backend`` is meaningless here. Lemonade
+        # routes the load to its fastflowlm_server backend.
+        return ("flm", None)
+    log.warning(
+        "lemonade.provider.unknown_device",
+        extra={"device": device},
+    )
+    return (None, None)
+
+
+# ── device-namespace normalisation (ex-orchestrator helpers) ─────────────────
+
+
+def canonical_device(value: str) -> str:
+    """Normalise a backend/device string to the canonical ``device`` enum.
+
+    After ADR-0006 §7 both the slot TOML and the capabilities catalog
+    speak the same enum (``gpu-rocm | gpu-vulkan | cpu | npu``), so this
+    is a near-identity. It still tolerates a legacy ``backend``-style
+    input (``vulkan|rocm|flm|moonshine|kokoro``) for forward
+    compatibility with hand-edited slot TOMLs by routing through
+    :func:`hal0.config.schema.map_backend_to_device`.
+
+    Empty input means "no opinion" and returns ``""``.
+    """
+    from hal0.config.schema import _VALID_DEVICES, map_backend_to_device
+
+    if not value:
+        return ""
+    if value in _VALID_DEVICES:
+        return value
+    return map_backend_to_device(value)
+
+
+# NOTE(#695): this is deliberately NOT expressed through
+# ``device_to_backend`` — the two sites disagreed on unknown input.
+# ``device_to_backend`` maps unknown devices to ``(None, None)`` (let
+# Lemonade pick), while the orchestrator's ``_slot_backend_for_catalog_id``
+# passed unknown tokens through UNCHANGED so hand-edited values stay
+# legible on downgrade. Both behaviours are preserved as-is.
+_DEVICE_TO_LEGACY_BACKEND: dict[str, str] = {
+    "gpu-vulkan": "vulkan",
+    "gpu-rocm": "rocm",
+    "npu": "flm",
+    "cpu": "cpu",
+}
+
+
+def device_to_legacy_backend(device: str) -> str:
+    """DEPRECATED namespace — translate a catalog ``device`` id to the legacy
+    ``backend`` token.
+
+    Still used by code paths that write the deprecated SlotConfig.backend
+    field (kept until the ``backend`` field is excised for downgrade
+    legibility). Unknown values pass through unchanged.
+    """
+    return _DEVICE_TO_LEGACY_BACKEND.get(device, device)
+
+
+# ── resolvability ────────────────────────────────────────────────────────────
+
+
+def is_resolvable(model_id: str, registry: Any) -> bool:
+    """True if ``model_id`` can actually be loaded onto a slot.
+
+    The slot-apply guard used to require ``registry.has(model_id)``, but FLM
+    models are lemond-owned and are never in hal0's registry (see the
+    2026-06-07 shape audits) — yet they load fine via npu.toml's config path.
+    So gate on *provider-resolvability*: registry-resident OR an installed FLM
+    model. (Extensible later to a general ``lemond_serves(id)`` probe.)
+
+    ``registry`` is passed explicitly (anything with a ``has(model_id)``
+    method, or ``None``) so this module never grows registry state.
+    """
+    if registry is not None and registry.has(model_id):
+        return True
+    from hal0.providers.flm import is_installed_flm_id
+
+    return is_installed_flm_id(model_id)
+
+
+# ── label extraction ─────────────────────────────────────────────────────────
+
+
+def labels_of(cfg: dict[str, Any]) -> set[str]:
+    """Pull the ``model.labels`` list out of a slot config dict.
+
+    Single source for both :func:`SlotManager.route_for_request` and the
+    omni-router tool filter (``omni_router/filter.py``) so the filter's
+    decision always matches what ``route_for_request`` will pick — they
+    used to be two hand-synced copies.
+    """
+    model = cfg.get("model") or {}
+    if isinstance(model, dict):
+        raw = model.get("labels", ())
+        if isinstance(raw, (list, tuple)):
+            return {str(x) for x in raw}
+    return set()
+
+
+__all__ = [
+    "canonical_device",
+    "classify",
+    "device_to_backend",
+    "device_to_legacy_backend",
+    "is_resolvable",
+    "labels_of",
+]

--- a/src/hal0/omni_router/filter.py
+++ b/src/hal0/omni_router/filter.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, Protocol
 
+from hal0.model_meta import labels_of
 from hal0.omni_router.tools import TOOL_DEFINITIONS, ToolDefinition
 
 
@@ -46,21 +47,6 @@ class SlotManagerLike(Protocol):
     ) -> str | None: ...
 
 
-def _labels_of_model(cfg: dict[str, Any]) -> set[str]:
-    """Pull the model.labels list out of a slot config.
-
-    Mirrors :func:`SlotManager.route_for_request` 's ``_labels_of``
-    helper — keep the two in sync so the filter's decision matches
-    what ``route_for_request`` will pick.
-    """
-    model = cfg.get("model") or {}
-    if isinstance(model, dict):
-        raw = model.get("labels", ())
-        if isinstance(raw, (list, tuple)):
-            return {str(x) for x in raw}
-    return set()
-
-
 def chat_slot_has_tool_calling(cfg: dict[str, Any]) -> bool:
     """Return True iff the chat slot's model carries the ``tool-calling`` label.
 
@@ -68,8 +54,12 @@ def chat_slot_has_tool_calling(cfg: dict[str, Any]) -> bool:
     on the caller's model, hal0 ships an empty tool list regardless of
     what other slots are configured. The LLM has no opinion on the
     tools because it never sees them.
+
+    Label extraction goes through :func:`hal0.model_meta.labels_of` —
+    the same source ``SlotManager.route_for_request`` uses — so the
+    filter's decision always matches what routing will pick.
     """
-    return "tool-calling" in _labels_of_model(cfg)
+    return "tool-calling" in labels_of(cfg)
 
 
 async def active_tools_for(

--- a/src/hal0/providers/lemonade.py
+++ b/src/hal0/providers/lemonade.py
@@ -67,59 +67,15 @@ from typing import Any
 from urllib.parse import urlparse
 
 from hal0.lemonade.client import LemonadeClient
+from hal0.model_meta import device_to_backend
 from hal0.providers.base import ContainerSpec, Provider
 
 log = logging.getLogger(__name__)
 
 
-# ── device → Lemonade recipe/backend mapping ─────────────────────────────────
-#
-# Plan §4.1 + ADR-0008 §6 locked the four-way mapping. ``gpu-*`` slots
-# load through llama.cpp with an explicit backend flag; ``cpu`` is the
-# same recipe with CPU-only inference; ``npu`` uses Lemonade's FLM
-# recipe and does not take a llamacpp_backend (FLM is its own backend).
-#
-# Returned tuple shape: ``(recipe, llamacpp_backend)``. ``recipe=None``
-# means "let Lemonade pick its default" (currently the llama.cpp recipe
-# for gpu/cpu).  Either value being ``None`` causes
-# :meth:`LemonadeClient.load` to omit the key from the request body —
-# Lemonade then falls through to its internal sentinel logic.
-
-
-def device_to_backend(device: str | None) -> tuple[str | None, str | None]:
-    """Map hal0's ``device`` enum onto Lemonade's recipe+backend pair.
-
-    Args:
-        device: One of ``gpu-rocm`` | ``gpu-vulkan`` | ``cpu`` | ``npu``.
-                Empty / unknown values fall back to ``(None, None)`` so
-                Lemonade picks its own defaults — same semantics as
-                omitting the keys from the load body.
-
-    Returns:
-        ``(recipe, llamacpp_backend)``. Either may be ``None`` to mean
-        "don't send this key in the /v1/load body". The two are
-        mutually exclusive in practice — NPU uses ``recipe="flm"`` with
-        no llamacpp_backend; everything else uses ``recipe=None`` with
-        a concrete llamacpp_backend.
-    """
-    if not device:
-        return (None, None)
-    d = device.strip().lower()
-    if d == "gpu-rocm":
-        return (None, "rocm")
-    if d == "gpu-vulkan":
-        return (None, "vulkan")
-    if d == "cpu":
-        return (None, "cpu")
-    if d == "npu":
-        # FLM recipe; ``llamacpp_backend`` is meaningless here. Lemonade
-        # routes the load to its fastflowlm_server backend.
-        return ("flm", None)
-    log.warning(
-        "lemonade.provider.unknown_device",
-        extra={"device": device},
-    )
-    return (None, None)
+# ``device_to_backend`` (the plan §4.1 / ADR-0008 §6 device → Lemonade
+# recipe+backend mapping) moved to :mod:`hal0.model_meta` (issue #695).
+# Re-exported here (see ``__all__``) for existing importers.
 
 
 # ── actual-backend introspection (B2) ────────────────────────────────────────

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1258,18 +1258,14 @@ class SlotManager:
           4. ``None`` when nothing matches.
         """
 
-        def _labels_of(cfg: dict[str, Any]) -> set[str]:
-            model = cfg.get("model") or {}
-            if isinstance(model, dict):
-                raw = model.get("labels", ())
-                if isinstance(raw, (list, tuple)):
-                    return {str(x) for x in raw}
-            return set()
+        # Label extraction lives in hal0.model_meta (issue #695) — shared
+        # with omni_router/filter.py so the two never drift again.
+        from hal0.model_meta import labels_of
 
         def _satisfies(cfg: dict[str, Any]) -> bool:
             if not required_labels:
                 return True
-            return set(required_labels).issubset(_labels_of(cfg))
+            return set(required_labels).issubset(labels_of(cfg))
 
         configs = [c for c in await self.iter_configs() if c.get("type") == slot_type]
 

--- a/tests/model_meta/test_model_meta.py
+++ b/tests/model_meta/test_model_meta.py
@@ -1,0 +1,259 @@
+"""Table-driven tests for :mod:`hal0.model_meta` (issue #695).
+
+One parametrized table per function. These tables capture the EXACT
+behaviour of the five prior copies before consolidation:
+
+  * ``classify``                  ← ``routes/models.py:_classify_type``
+  * ``device_to_backend``         ← ``providers/lemonade.py:device_to_backend``
+  * ``is_resolvable``             ← ``routes/slots.py:_model_resolvable``
+  * ``canonical_device``          ← ``orchestrator._canonical_device_id`` /
+                                    ``_canonical_backend_id`` /
+                                    ``_slot_device_for_catalog_id``
+  * ``device_to_legacy_backend``  ← ``orchestrator._slot_backend_for_catalog_id``
+  * ``labels_of``                 ← ``omni_router/filter.py:_labels_of_model`` /
+                                    ``SlotManager.route_for_request._labels_of``
+
+Behaviour-preserving: no expectation here may change as part of #695.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hal0.model_meta import (
+    canonical_device,
+    classify,
+    device_to_backend,
+    device_to_legacy_backend,
+    is_resolvable,
+    labels_of,
+)
+
+# ── classify ─────────────────────────────────────────────────────────────────
+#
+# (model_id, capabilities, expected)
+
+
+@pytest.mark.parametrize(
+    ("model_id", "capabilities", "expected"),
+    [
+        # Capability-driven classification (capabilities win over id).
+        ("anything", ["chat"], "chat"),
+        ("", ["vision"], "chat"),
+        ("", ["embed"], "embed"),
+        ("", ["rerank"], "rerank"),
+        ("", ["asr"], "stt"),
+        ("", ["stt"], "stt"),
+        ("", ["tts"], "tts"),
+        ("", ["image"], "img"),
+        ("", ["img"], "img"),
+        # Priority when several capabilities are advertised: rerank >
+        # embed > stt > tts > img > chat.
+        ("", ["chat", "embed"], "embed"),
+        ("", ["embed", "rerank"], "rerank"),
+        ("", ["chat", "tts", "stt"], "stt"),
+        ("", ["chat", "img", "tts"], "tts"),
+        ("", ["chat", "image"], "img"),
+        # Capabilities are normalised: strip + lower.
+        ("", ["  CHAT  "], "chat"),
+        ("", ["Embed"], "embed"),
+        # Capabilities beat id heuristics when they match something.
+        ("whisper-large-v3", ["embed"], "embed"),
+        # Unknown capability strings fall through to id heuristics.
+        ("bge-reranker-v2-m3", ["bogus"], "rerank"),
+        # Tuple is accepted like a list.
+        ("", ("rerank",), "rerank"),
+        # Non-list capabilities are ignored → id heuristics.
+        ("nomic-embed-text-v1.5", "chat", "embed"),
+        ("kokoro-82m", None, "tts"),
+        # Id heuristics (no capabilities): rerank.
+        ("bge-reranker-v2-m3-q4_k_m", None, "rerank"),
+        # rerank wins over embed in the elif chain.
+        ("bge-reranker-embed", None, "rerank"),
+        # embed: "embed" / "bge" / "nomic".
+        ("nomic-embed-text", None, "embed"),
+        ("bge-m3", None, "embed"),
+        ("nomic-text-v2", None, "embed"),
+        # stt: "whisper" / "moonshine" / "-stt" / "asr".
+        ("whisper-large-v3-turbo", None, "stt"),
+        ("moonshine-base", None, "stt"),
+        ("parakeet-stt", None, "stt"),
+        ("canary-asr-1b", None, "stt"),
+        # tts: "tts" / "kokoro" / "vibevoice" / "-voice".
+        ("tts-1-hd", None, "tts"),
+        ("kokoro-v1.0", None, "tts"),
+        ("vibevoice-1.5b", None, "tts"),
+        ("my-voice-model", None, "tts"),
+        # img: "flux" / "sdxl" / "stable-diffusion" / "-img".
+        ("flux-schnell", None, "img"),
+        ("sdxl-turbo", None, "img"),
+        ("stable-diffusion-3.5", None, "img"),
+        ("dream-img", None, "img"),
+        # Id heuristics are case-insensitive.
+        ("WHISPER-LARGE", None, "stt"),
+        # Default: chat.
+        ("llama-3.1-8b-instruct-q4", None, "chat"),
+        ("", None, "chat"),
+        ("", [], "chat"),
+    ],
+)
+def test_classify(model_id: str, capabilities: Any, expected: str) -> None:
+    assert classify(model_id, capabilities=capabilities) == expected
+
+
+# ── device_to_backend ────────────────────────────────────────────────────────
+#
+# (device, expected (recipe, llamacpp_backend)) — plan §4.1 + ADR-0008 §6.
+
+
+@pytest.mark.parametrize(
+    ("device", "expected"),
+    [
+        ("gpu-rocm", (None, "rocm")),
+        ("gpu-vulkan", (None, "vulkan")),
+        ("cpu", (None, "cpu")),
+        # NPU uses the FLM recipe; no llamacpp_backend.
+        ("npu", ("flm", None)),
+        # Empty / None → let Lemonade pick its own defaults.
+        ("", (None, None)),
+        (None, (None, None)),
+        # Unknown devices fall back to (None, None) rather than us
+        # inventing a backend tag.
+        ("rocm-xtreme-edition", (None, None)),
+        # Case / whitespace insensitive.
+        ("GPU-ROCM", (None, "rocm")),
+        ("  npu  ", ("flm", None)),
+    ],
+)
+def test_device_to_backend(device: str | None, expected: tuple[str | None, str | None]) -> None:
+    assert device_to_backend(device) == expected
+
+
+# ── is_resolvable ────────────────────────────────────────────────────────────
+
+
+class _FakeRegistry:
+    def __init__(self, ids: set[str]) -> None:
+        self._ids = ids
+
+    def has(self, model_id: str) -> bool:
+        return model_id in self._ids
+
+
+_FLM_PROBE = [
+    {"tag": "gemma4-it:e4b", "installed": True},
+    {"tag": "qwen3:0.6b", "installed": False},
+]
+
+
+@pytest.mark.parametrize(
+    ("model_id", "registry_ids", "expected"),
+    [
+        # Registry membership resolves.
+        ("llama-3.1-8b", {"llama-3.1-8b"}, True),
+        # Not in registry, not FLM → unresolvable.
+        ("llama-3.1-8b", set(), False),
+        # Installed FLM model resolves without registry membership.
+        ("gemma4-it-e4b-FLM", set(), True),
+        # FLM tag known but NOT installed → unresolvable.
+        ("qwen3-0.6b-FLM", set(), False),
+        # Unknown -FLM id → unresolvable.
+        ("nope-7b-FLM", set(), False),
+        # No registry at all: only FLM resolvability remains.
+        ("gemma4-it-e4b-FLM", None, True),
+        ("llama-3.1-8b", None, False),
+    ],
+)
+def test_is_resolvable(
+    monkeypatch: pytest.MonkeyPatch,
+    model_id: str,
+    registry_ids: set[str] | None,
+    expected: bool,
+) -> None:
+    import hal0.providers.flm as flm
+
+    monkeypatch.setattr(flm, "flm_served_models", lambda: _FLM_PROBE)
+    registry = _FakeRegistry(registry_ids) if registry_ids is not None else None
+    assert is_resolvable(model_id, registry) is expected
+
+
+# ── canonical_device ─────────────────────────────────────────────────────────
+#
+# (value, expected) — backend/device → canonical v0.2 device enum.
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # Empty → no opinion.
+        ("", ""),
+        # Already-canonical device ids pass through.
+        ("gpu-rocm", "gpu-rocm"),
+        ("gpu-vulkan", "gpu-vulkan"),
+        ("cpu", "cpu"),
+        ("npu", "npu"),
+        # Legacy backend tokens map forward (ADR-0006 §7).
+        ("rocm", "gpu-rocm"),
+        ("vulkan", "gpu-vulkan"),
+        ("flm", "npu"),
+        ("moonshine", "cpu"),
+        ("kokoro", "cpu"),
+        # Unknown values fall back to cpu (safe default, warning logged).
+        ("totally-bogus", "cpu"),
+    ],
+)
+def test_canonical_device(value: str, expected: str) -> None:
+    assert canonical_device(value) == expected
+
+
+# ── device_to_legacy_backend ─────────────────────────────────────────────────
+#
+# (device, expected) — catalog device id → deprecated SlotConfig.backend
+# token. NOTE(#695): unlike ``device_to_backend``, unknown values pass
+# through UNCHANGED (the orchestrator preserved hand-edited tokens for
+# downgrade legibility) — do not "unify" this onto (None, None) semantics.
+
+
+@pytest.mark.parametrize(
+    ("device", "expected"),
+    [
+        ("gpu-vulkan", "vulkan"),
+        ("gpu-rocm", "rocm"),
+        ("npu", "flm"),
+        ("cpu", "cpu"),
+        ("", ""),
+        ("weird-token", "weird-token"),
+    ],
+)
+def test_device_to_legacy_backend(device: str, expected: str) -> None:
+    assert device_to_legacy_backend(device) == expected
+
+
+# ── labels_of ────────────────────────────────────────────────────────────────
+#
+# (slot config dict, expected label set)
+
+
+@pytest.mark.parametrize(
+    ("cfg", "expected"),
+    [
+        ({"model": {"labels": ["tool-calling", "vision"]}}, {"tool-calling", "vision"}),
+        ({"model": {"labels": ("a", "b")}}, {"a", "b"}),
+        # Non-string labels are stringified.
+        ({"model": {"labels": [1, 2]}}, {"1", "2"}),
+        # labels not a list/tuple → empty.
+        ({"model": {"labels": "tool-calling"}}, set()),
+        # No labels key → empty.
+        ({"model": {}}, set()),
+        # model not a dict → empty.
+        ({"model": "primary"}, set()),
+        ({"model": None}, set()),
+        # No model key at all → empty.
+        ({}, set()),
+        ({"model": {"labels": []}}, set()),
+    ],
+)
+def test_labels_of(cfg: dict[str, Any], expected: set[str]) -> None:
+    assert labels_of(cfg) == expected

--- a/tests/providers/test_lemonade.py
+++ b/tests/providers/test_lemonade.py
@@ -2,7 +2,7 @@
 
 PR-8 + PR-10 capability dispatch wiring. Covers:
 
-  * ``device_to_backend`` mapping (plan §4.1 + ADR-0008 §6)
+  * ``device_to_backend`` mapping moved to tests/model_meta (issue #695)
   * ``LemonadeProvider.load`` body construction → ``LemonadeClient.load``
   * ``LemonadeProvider.unload`` idempotence + noop on modelless slot
   * ``LemonadeProvider.status`` derivation from ``/v1/health.loaded[]``
@@ -32,7 +32,6 @@ from hal0.lemonade.client import LemonadeClient
 from hal0.lemonade.errors import LemonadeHTTPError, LemonadeLoadError
 from hal0.providers.lemonade import (
     LemonadeProvider,
-    device_to_backend,
     resolve_actual_backend,
 )
 
@@ -56,42 +55,6 @@ def _slot_cfg(**overrides: Any) -> dict[str, Any]:
     }
     base.update(overrides)
     return base
-
-
-# ── device_to_backend ────────────────────────────────────────────────
-
-
-def test_device_to_backend_rocm() -> None:
-    assert device_to_backend("gpu-rocm") == (None, "rocm")
-
-
-def test_device_to_backend_vulkan() -> None:
-    assert device_to_backend("gpu-vulkan") == (None, "vulkan")
-
-
-def test_device_to_backend_cpu() -> None:
-    assert device_to_backend("cpu") == (None, "cpu")
-
-
-def test_device_to_backend_npu() -> None:
-    # NPU uses the FLM recipe; no llamacpp_backend.
-    assert device_to_backend("npu") == ("flm", None)
-
-
-def test_device_to_backend_empty_returns_double_none() -> None:
-    assert device_to_backend("") == (None, None)
-    assert device_to_backend(None) == (None, None)
-
-
-def test_device_to_backend_unknown_falls_back_to_double_none() -> None:
-    # Unknown devices return ``(None, None)`` so Lemonade picks its
-    # defaults rather than us trying to invent a backend tag.
-    assert device_to_backend("rocm-xtreme-edition") == (None, None)
-
-
-def test_device_to_backend_is_case_insensitive() -> None:
-    assert device_to_backend("GPU-ROCM") == (None, "rocm")
-    assert device_to_backend("  npu  ") == ("flm", None)
 
 
 # ── load() — request body construction ───────────────────────────────


### PR DESCRIPTION
Closes #695.

## Summary

Creates the stateless `hal0.model_meta` module as the single home for model classification and device→backend resolution, deleting five copy-pasted sites:

- `routes/models.py` `_classify_type` + W7 vocab tables → `classify(model_id, capabilities=None)`
- `routes/slots.py` `_model_resolvable` → `is_resolvable(model_id, registry)` (registry passed explicitly)
- `capabilities/orchestrator.py` four `_canonical_*`/`_slot_*_for_catalog_id` helpers → `canonical_device` / `device_to_legacy_backend`
- `providers/lemonade.py` `device_to_backend` definition moved (re-exported via `__all__` for existing importers)
- `omni_router/filter.py` ↔ `slots/manager.py` "keep the two in sync" label extraction → single `labels_of`

`classify` and `device_to_backend` are pure; `is_resolvable` takes the registry explicitly so the module stays importable everywhere with no state. Interface as locked in the 2026-06-11 architecture review (CONTEXT.md glossary, PR #699).

## Behaviour discrepancy preserved (not unified)

`device_to_backend` maps unknown devices to `(None, None)` (let Lemonade pick) while the legacy orchestrator mapping passed unknown tokens through unchanged (downgrade legibility). Kept as two functions with a `# NOTE(#695)` comment and test coverage of both behaviours.

## Tests

- New table-driven suite: `tests/model_meta/test_model_meta.py` (84 tests, one parametrized table per function); 7 scattered `device_to_backend` asserts relocated from `tests/providers/test_lemonade.py`.
- Full suite: 3096 passed / 6 skipped / 17 lemond-deselected; the 3 failures in `tests/agents/test_hermes_provision*` are pre-existing on main (verified on a pristine checkout) and unrelated.
- `ruff check` + `ruff format --check` clean.

## Notes for reviewers

- `slots/manager.py` hunk kept deliberately minimal (label-extraction only) to merge cleanly against in-flight #649; its line 2414 lazy-import of `device_to_backend` via `providers.lemonade` still works through the re-export — fold the re-point into #697 or later cleanup.
- TDD commit sequence: tests-first (`f221514`), module (`f255b45`), call-site re-point (`03f0d34`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)