### PR TITLE
refactor: SlotConfigStore + ChangeSet — own capabilities ⇄ slot reconciliation (#697)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,8 +56,12 @@ src/hal0/
 ├── lemonade/        # idle driver + metrics shim + log bridge
 ├── capabilities/    # UX overlay grouping flat slots into capability
 │                    #   cards (catalog + config + orchestrator);
-│                    #   persists selections in capabilities.toml and
-│                    #   reconciles slot TOMLs on every apply
+│                    #   selections persist in capabilities.toml,
+│                    #   reconciliation delegates to slot_config/
+├── slot_config/     # SlotConfigStore (#697): capabilities.toml +
+│                    #   slots/*.toml as one reconciled truth —
+│                    #   compute-only apply() → ChangeSet, atomic
+│                    #   commit()/revert(); single slot-TOML write path
 ├── registry/        # model registry (atomic TOML, mtime cache, GGUF
 │                    #   magic-byte detect, HF-cache repo-name fallback)
 ├── hardware/        # probe + stats (GPU, NPU, RAM, disk)
@@ -79,12 +83,24 @@ ADR-0012 removed `auth/` + `api/auth/` + `api/middleware/auth.py` —
 hal0-api binds `0.0.0.0:8080` open; LAN trust + an upstream reverse
 proxy own authentication.
 
-The capabilities layer is a **thin overlay** on the flat slot layer,
-not a replacement. Slot configs under `/etc/hal0/slots/*.toml` remain
-authoritative; `capabilities.toml` records which capability picks
-should be projected back onto those slot files. `hal0 capabilities
-migrate` cleans up persisted selections whose (backend, model) pair
-is no longer valid — primarily for FLM model-tag namespace drift.
+The capabilities layer remains a **thin overlay** on the flat slot
+layer as a UX surface, not a replacement. Slot configs under
+`/etc/hal0/slots/*.toml` remain authoritative; `capabilities.toml`
+records which capability picks should be projected back onto those
+slot files. Since #697 the projection itself is no longer an in-place
+rewrite inside the orchestrator: `hal0.slot_config.SlotConfigStore` is
+the deep module that owns both files as one reconciled truth. Its
+`apply(selection)` is compute-only and returns a
+`ChangeSet{before, after}`; `commit(cs)` writes both files atomically
+(rolling back to `before` on partial failure) and `revert(cs)` restores
+the prior state. The testable invariant: after `commit` disk equals
+`cs.after`, after `revert` disk equals `cs.before`, and a failed
+mid-apply leaves disk at `before` — the two files can never be left
+half-reconciled. `write_slot_toml()` in the same module is the single
+byte-level write path every `slots/*.toml` writer routes through.
+`hal0 capabilities migrate` still cleans up persisted selections whose
+(backend, model) pair is no longer valid — primarily for FLM model-tag
+namespace drift.
 
 ## Key boundaries
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -329,25 +329,26 @@ A single `Upstream(name="hal0", kind="slot", url="http://127.0.0.1:8080/v1", slo
 
 ---
 
-# Architecture-deepening vocabulary (proposed 2026-06-11)
+# Architecture-deepening vocabulary (2026-06-11)
 
 Terms locked during the architecture-review grilling (skill: `improve-codebase-architecture`).
-**Status: approved design directions, not yet implemented.** Each names a deepened module
-that replaces a shallow seam. Promote to a real entry (drop the "proposed" note) when the
-PR lands.
+Each names a deepened module that replaces a shallow seam. Entries are implemented unless
+explicitly marked **proposed**; promote a proposed entry (drop the note) when its PR lands.
 
 ## SlotConfigStore
 
-Proposed deep module that owns *both* `capabilities.toml` selections and `slots/*.toml` as
-one reconciled truth, ending the drift between them (today reconciled by an unconditional
-rewrite in `capabilities/orchestrator.py:apply()`). Interface: **`apply(selection) -> ChangeSet`
-is compute-only** (no disk write); the store also exposes `commit(cs)` (atomic write) and
-`revert(cs)`. Decision: keeping `apply()` pure is the whole point — it makes the write an
-explicit, observable, reversible step instead of a hidden rewrite. Replaces the "thin overlay
-reconciles on every apply" pattern with an observable, testable invariant. Supersedes the
-orchestrator's defensive rewrite as the home for capabilities ⇄ slot reconciliation. See
-[[ChangeSet]], candidate 1 of the 2026-06-11 review. Touches the ARCHITECTURE.md "thin overlay"
-framing.
+Deep module (`src/hal0/slot_config/`, issue #697) that owns *both* `capabilities.toml`
+selections and `slots/*.toml` as one reconciled truth, ending the drift between them
+(previously reconciled by an unconditional rewrite in `capabilities/orchestrator.py:apply()`).
+Interface: **`apply(selection) -> ChangeSet` is compute-only** (no disk write); the store also
+exposes `commit(cs)` (atomic per-file write with rollback-to-before on partial failure) and
+`revert(cs)`. Keeping `apply()` pure is the whole point — it makes the write an explicit,
+observable, reversible step instead of a hidden rewrite. The same module's `write_slot_toml()`
+is the single byte-level write path for `slots/*.toml`; every writer (SlotManager
+create/update/persist-default, installer pick-default, model-delete cascade) routes through it.
+First-boot seed and v1→v2 schema migrations stay on `save_capabilities_config`, which shares
+the store's `capabilities_toml_payload` serializer so shapes can't diverge. See [[ChangeSet]],
+candidate 1 of the 2026-06-11 review.
 
 ## ChangeSet
 
@@ -356,16 +357,17 @@ config. Makes reconciliation a pure computation separate from the write — drif
 `disk == after` after a committed apply, `disk == before` after a revert. A failed mid-flight
 apply leaves disk at `before`, never a half-reconciled state. See [[SlotConfigStore]].
 
-## is_ready_for_dispatch / SlotManager.state
+## is_ready_for_dispatch / SlotManager.state (proposed)
 
 The public readiness seam on `SlotManager`, replacing the Dispatcher's reach into the private
 `_current_state()` (`dispatcher/router.py:723,791`). `state(name) -> SlotState` exposes the
 slot state; `is_ready_for_dispatch(name) -> bool` owns the ready-set rule (`READY | SERVING |
 IDLE`) so it is defined exactly once instead of duplicated across Dispatcher and SlotManager.
 The Dispatcher stops knowing the state-cache, the disk fallback, and the enum. Endorsed by the
-2026-06-07 audit (ANSWERS §2.1). Candidate 2 of the 2026-06-11 review.
+2026-06-07 audit (ANSWERS §2.1). Candidate 2 of the 2026-06-11 review. **Proposed** — the
+`state()` half is implemented by in-flight PR #649; `is_ready_for_dispatch()` remains (#696).
 
-## SlotViewAggregator
+## SlotViewAggregator (proposed)
 
 Proposed stateless module that lifts the five enrichment concerns inline in
 `api/routes/slots.py:list_slots()` (state serialization, Lemonade `/v1/health` enrich + drift
@@ -378,7 +380,7 @@ makes a composable enrichment pipeline a hypothetical seam; add `snapshot(includ
 only when the admin MCP surface actually needs state-without-metrics. Candidate 3 of the
 2026-06-11 review. See [[SlotView]].
 
-## SlotView
+## SlotView (proposed)
 
 The enriched per-slot record `SlotViewAggregator.snapshot()` emits — one slot's state plus its
 Lemonade/container enrichment, memory attribution, and metrics, as a typed object rather than
@@ -386,13 +388,14 @@ the ad-hoc dict assembled inline in the route today. See [[SlotViewAggregator]].
 
 ## model_meta
 
-Proposed single home (`src/hal0/model_meta/`) for the model-classification and
-device→backend logic currently copy-pasted across `routes/models.py:_classify_type`,
-`routes/slots.py`, `capabilities/orchestrator.py` (four `_canonical_*` helpers), and the
-omni-router heuristic. **Stateless surface, no construction:** `classify(model_id) -> slot
-type` and `device_to_backend(device) -> (recipe, llamacpp)` are pure; **`is_resolvable(model_id,
-registry) -> bool` takes the registry explicitly** (it needs registry membership + FLM-catalog
-presence via `is_installed_flm_id`) so the module stays importable everywhere without a handle
-to thread through. Imported by routes, orchestrator, and omni-router so a classification rule
-changes in one place. Removes the "keep the two in sync" hazard (`omni_router/filter.py` ↔
-`slots/manager.py`). Candidate 4 of the 2026-06-11 review.
+The single home (`src/hal0/model_meta/`, issue #695 / PR #700) for the model-classification
+and device→backend logic previously copy-pasted across `routes/models.py:_classify_type`,
+`routes/slots.py`, `capabilities/orchestrator.py` (four `_canonical_*` helpers), the
+omni-router heuristic, and `providers/lemonade.py`. **Stateless surface, no construction:**
+`classify(model_id) -> slot type` and `device_to_backend(device) -> (recipe, llamacpp)` are
+pure; **`is_resolvable(model_id, registry) -> bool` takes the registry explicitly** (it needs
+registry membership + FLM-catalog presence via `is_installed_flm_id`) so the module stays
+importable everywhere without a handle to thread through. Also home to `canonical_device`,
+`device_to_legacy_backend` (deliberately separate — they disagree on unknown input, see
+`# NOTE(#695)`), and `labels_of` (the ex-"keep the two in sync" extraction shared by
+`omni_router/filter.py` and `slots/manager.py`). Candidate 4 of the 2026-06-11 review.

--- a/src/hal0/api/routes/installer.py
+++ b/src/hal0/api/routes/installer.py
@@ -357,12 +357,13 @@ def _ensure_registry_entry(registry: Any, model_id: str) -> Model:
 def _assign_to_slot(slot: str, model_id: str) -> Path:
     """Atomically update ``/etc/hal0/slots/<slot>.toml`` so ``model.default = <id>``.
 
-    Uses ``hal0.config.loader.write_toml_atomic`` so a half-written TOML
+    Routes through ``hal0.slot_config.write_slot_toml`` — the single
+    atomic slots/*.toml write path (issue #697) — so a half-written TOML
     can't take out the slot. Creates the file from scratch if it doesn't
     exist — this is the FirstRun path on a fresh install where the
     primary slot was scaffolded but never had a model assigned.
     """
-    from hal0.config.loader import write_toml_atomic
+    from hal0.slot_config import write_slot_toml
 
     slot_path = paths.slots_config_dir() / f"{slot}.toml"
     slot_path.parent.mkdir(parents=True, exist_ok=True)
@@ -403,7 +404,7 @@ def _assign_to_slot(slot: str, model_id: str) -> Path:
     data["model"] = model_section
 
     try:
-        write_toml_atomic(slot_path, data)
+        write_slot_toml(slot_path, data)
     except OSError as exc:
         raise PickDefaultError(
             f"could not write slot TOML {slot_path}: {exc}",

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -860,8 +860,12 @@ def _clear_slot_default(slot_path: Path, slot_cfg: dict[str, Any]) -> None:
     cascade — the model row is already going away, and a slot left
     pointing at a vanished id will surface as ``model.not_found`` on its
     next ``load()`` (which is the correct UX).
+
+    Routes through :func:`hal0.slot_config.write_slot_toml` (issue
+    #697) — the single, atomic slots/*.toml write path (this site used
+    to be the one non-atomic raw ``write_bytes`` writer).
     """
-    import tomli_w
+    from hal0.slot_config import write_slot_toml
 
     new_cfg = dict(slot_cfg)
     model_sect = new_cfg.get("model")
@@ -872,7 +876,7 @@ def _clear_slot_default(slot_path: Path, slot_cfg: dict[str, Any]) -> None:
     # Cascade continues if the write fails; the dangling reference is
     # surfaced later.
     with contextlib.suppress(OSError):
-        slot_path.write_bytes(tomli_w.dumps(new_cfg).encode("utf-8"))
+        write_slot_toml(slot_path, new_cfg)
 
 
 async def _unload_slot_if_running(request: Request, slot_name: str) -> None:

--- a/src/hal0/capabilities/config.py
+++ b/src/hal0/capabilities/config.py
@@ -369,7 +369,18 @@ def capabilities_toml_payload(cfg: CapabilityConfig) -> dict[str, Any]:
 
 
 def save_capabilities_config(cfg: CapabilityConfig, path: Path | None = None) -> None:
-    """Atomically rewrite ``capabilities.toml`` from a validated config."""
+    """Atomically rewrite ``capabilities.toml`` from a validated config.
+
+    NOTE(#697): the capability-apply path writes through
+    ``hal0.slot_config.SlotConfigStore`` instead (one ChangeSet covering
+    both files). This helper remains for the NON-apply writers whose
+    semantics don't fit a selection ChangeSet: the first-boot seed
+    (``CapabilityOrchestrator.initialize_if_missing``), the schema
+    migrations (``auto_migrate_capabilities_file`` + the
+    ``hal0 capabilities migrate*`` CLI with its ``.v1.bak`` backup
+    dance). Both serialise through :func:`capabilities_toml_payload`,
+    so the on-disk shape cannot diverge from the store's.
+    """
     target = path if path is not None else capabilities_toml_path()
     write_toml_atomic(target, capabilities_toml_payload(cfg))
 

--- a/src/hal0/capabilities/config.py
+++ b/src/hal0/capabilities/config.py
@@ -336,14 +336,17 @@ def load_capabilities_config(path: Path | None = None) -> CapabilityConfig:
     return CapabilityConfig.model_validate(raw)
 
 
-def save_capabilities_config(cfg: CapabilityConfig, path: Path | None = None) -> None:
-    """Atomically rewrite ``capabilities.toml`` from a validated config.
+def capabilities_toml_payload(cfg: CapabilityConfig) -> dict[str, Any]:
+    """Serialise a validated config into the canonical on-disk dict shape.
 
-    Always stamps the file with the current schema_version so a downgrade
-    that wrote v1-shaped TOML on top of a v2 install can be detected on
-    the next upgrade.
+    Single source for both :func:`save_capabilities_config` and the
+    :class:`hal0.slot_config.SlotConfigStore` ChangeSet computation
+    (issue #697) so the two can never disagree on the persisted shape.
+
+    Always stamps the current schema_version so a downgrade that wrote
+    v1-shaped TOML on top of a v2 install can be detected on the next
+    upgrade.
     """
-    target = path if path is not None else capabilities_toml_path()
     # Pydantic v2 ``model_dump`` walks the nested CapabilitySelection tables
     # into plain dicts — exactly the shape ``tomli_w.dump`` wants.
     data: dict[str, Any] = cfg.model_dump(mode="python")
@@ -362,7 +365,13 @@ def save_capabilities_config(cfg: CapabilityConfig, path: Path | None = None) ->
             for _child, entry in children.items():
                 if isinstance(entry, dict):
                     entry.pop("backend", None)
-    write_toml_atomic(target, data)
+    return data
+
+
+def save_capabilities_config(cfg: CapabilityConfig, path: Path | None = None) -> None:
+    """Atomically rewrite ``capabilities.toml`` from a validated config."""
+    target = path if path is not None else capabilities_toml_path()
+    write_toml_atomic(target, capabilities_toml_payload(cfg))
 
 
 __all__ = [
@@ -372,6 +381,7 @@ __all__ = [
     "CapabilitySelection",
     "auto_migrate_capabilities_file",
     "capabilities_toml_path",
+    "capabilities_toml_payload",
     "capabilities_v1_backup_path",
     "load_capabilities_config",
     "migrate_capabilities_v1_to_v2",

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -9,8 +9,12 @@ managed by :class:`~hal0.slots.manager.SlotManager`. This module owns:
   - Persistence of the operator's selections in
     ``/etc/hal0/capabilities.toml``.
   - The lifecycle dispatch — ``apply()`` flips slots load/swap/unload to
-    match the new selection and rewrites the underlying slot's TOML when
-    the user changes backend/provider.
+    match the new selection. Reconciling the selection against the
+    underlying slot's TOML is delegated to
+    :class:`hal0.slot_config.SlotConfigStore` (issue #697): the store
+    computes a before/after ChangeSet and commits both files atomically
+    before any lifecycle call, so capabilities.toml and slots/*.toml can
+    no longer drift across a half-finished apply.
 
 NPU multiplex (NPU Phase 2): a ``device=npu`` selection for a trio
 modality (``embed`` / ``voice.stt``) does NOT spawn a standalone process.
@@ -48,6 +52,7 @@ from hal0.errors import BadRequest, Hal0Error, NotFound
 from hal0.lemonade.client import flm_args_from_lemond_config, flm_args_set_payload
 from hal0.model_meta import canonical_device, device_to_legacy_backend
 from hal0.registry.store import ModelRegistry
+from hal0.slot_config import SlotConfigStore, SlotSelection
 from hal0.slots.manager import SlotManager
 
 log = logging.getLogger(__name__)
@@ -216,6 +221,10 @@ class CapabilityOrchestrator:
     ) -> None:
         self._slot_manager = slot_manager
         self._config_path = Path(config_path) if config_path else capabilities_toml_path()
+        # Reconciliation seam (#697): capabilities.toml + slots/*.toml are
+        # committed as one ChangeSet through the store, never via ad-hoc
+        # rewrites in this class.
+        self._store = SlotConfigStore(capabilities_path=self._config_path)
         self._registry = registry
         # Zero-arg callable returning a LemonadeClient (NOT a provider) —
         # used by the NPU-trio path to read/write lemond ``flm_args``. When
@@ -422,7 +431,30 @@ class CapabilityOrchestrator:
         if merged.model:
             self._validate_model_in_catalog(slot, child, merged.model, merged.device)
 
-        cfg.selections[slot][child] = merged
+        # ── reconcile + persist (issue #697) ──────────────────────────────
+        # The SlotConfigStore computes the post-state of BOTH
+        # capabilities.toml and the underlying slot TOML as one ChangeSet
+        # (compute-only), then commits it atomically BEFORE any lifecycle
+        # dispatch. This replaces the old unconditional in-place rewrite:
+        #
+        #   - drift can no longer survive a half-finished apply — a failed
+        #     commit rolls disk back to ``before``;
+        #   - a lifecycle failure below leaves both files already mutually
+        #     consistent, preserving the pre-#697 "persist the user's
+        #     intent even if the slot bounce failed" behaviour;
+        #   - the reconciliation itself (enabled selections projected onto
+        #     an existing slot TOML, model_meta-translated device/backend)
+        #     lives in the store where it is independently tested.
+        change_set = self._store.apply(
+            SlotSelection(slot=slot, child=child, slot_name=slot_name, selection=merged)
+        )
+        try:
+            self._store.commit(change_set)
+        except Exception as exc:
+            raise CapabilityApplyFailed(
+                f"failed to persist capability change: {exc}",
+                details={"slot": slot, "child": child, "error": str(exc)},
+            ) from exc
 
         # ── lifecycle dispatch ────────────────────────────────────────────
         enabled_changed = merged.enabled != before_enabled
@@ -446,23 +478,11 @@ class CapabilityOrchestrator:
         pending_reload = False
 
         try:
-            # Reconcile the slot TOML against the merged selection whenever
-            # the slot is going to be enabled. We rewrite unconditionally —
-            # not just on a selection diff — because capabilities.toml and
-            # the slot TOML can drift independently: a previous apply() that
-            # failed mid-flight, a manual edit, or an install/migration seed
-            # can leave the two disagreeing. Diffing the new selection
-            # against the *old selection* would miss that drift and let
-            # load()/swap() spawn against the stale slot TOML while we
-            # report the new selection as live.
-            if merged.enabled:
-                await self._rewrite_underlying_slot(slot_name, merged)
-
             if is_npu_target:
                 # NPU trio: drive flm_args + a device=npu slot RECORD; never
                 # load/swap/unload the embed/stt slot. (Decision 4: the
-                # _rewrite_underlying_slot above — which sets the model
-                # sub-table — has already run for the enabled case.)
+                # store commit above — which sets the model sub-table on an
+                # enabled selection — has already run.)
                 pending_reload = await self._apply_npu_trio_modality(slot_name, child, merged)
             else:
                 if enabled_changed and merged.enabled:
@@ -488,20 +508,15 @@ class CapabilityOrchestrator:
                     await self._set_flm_modality(child, enable=False)
                     pending_reload = True
         except Hal0Error:
-            # Re-raise typed errors as the apply_failed envelope so the UI
-            # surfaces a single, recognisable code.
-            self._save(cfg)  # persist the user's intent even if the slot bounce failed
+            # Re-raise typed errors so the UI surfaces a single,
+            # recognisable code. The selection is already committed (the
+            # user's intent persists even if the slot bounce failed).
             raise
         except Exception as exc:
-            self._save(cfg)
             raise CapabilityApplyFailed(
                 f"failed to apply capability change: {exc}",
                 details={"slot": slot, "child": child, "error": str(exc)},
             ) from exc
-
-        # Persist after the side effects so an interrupted lifecycle
-        # call doesn't leave a stale selection on disk.
-        self._save(cfg)
 
         # A capability change (enable/disable/model/backend) just altered
         # live slot state — refresh Hermes's context files (detached;
@@ -661,7 +676,8 @@ class CapabilityOrchestrator:
              top-level SCALAR, so co-writing it is safe under Decision 4 —
              that prohibition is specifically about the nested ``model`` dict
              (replaced wholesale by the shallow merge), which we still NEVER
-             pass here. Runs AFTER ``_rewrite_underlying_slot``.
+             pass here. Runs AFTER the store commit that reconciled the
+             slot TOML.
           3. Toggle the modality on the anchor via
              :meth:`_set_flm_modality` — for a container anchor this writes
              the ``[npu]`` TOML toggle; for a Lemonade anchor it recomposes
@@ -778,41 +794,6 @@ class CapabilityOrchestrator:
         except Exception as exc:
             raise CapabilityApplyFailed(
                 f"failed to create slot {slot_name!r}: {exc}",
-                details={"slot": slot_name, "error": str(exc)},
-            ) from exc
-
-    async def _rewrite_underlying_slot(
-        self, slot_name: str, selection: CapabilitySelection
-    ) -> None:
-        """Persist backend / provider changes into the underlying slot TOML.
-
-        Routes through :meth:`SlotManager.update_config` so the override
-        drop-in + env file get regenerated alongside the TOML. If the slot
-        doesn't exist yet, this is a no-op — the create path below will
-        write the config fresh.
-        """
-        cfg_path = paths.slots_config_dir() / f"{slot_name}.toml"
-        if not cfg_path.exists():
-            return
-        slot_backend = device_to_legacy_backend(selection.device)
-        slot_device = canonical_device(selection.device)
-        updates: dict[str, Any] = {}
-        if slot_backend:
-            # Deprecated field, kept for one release — see ADR-0006 §7.
-            updates["backend"] = slot_backend
-        if slot_device:
-            updates["device"] = slot_device
-        if selection.provider:
-            updates["provider"] = selection.provider
-        if selection.model:
-            updates["model"] = {"default": selection.model}
-        if not updates:
-            return
-        try:
-            await self._slot_manager.update_config(slot_name, updates)
-        except Exception as exc:
-            raise CapabilityApplyFailed(
-                f"failed to rewrite slot {slot_name!r}: {exc}",
                 details={"slot": slot_name, "error": str(exc)},
             ) from exc
 

--- a/src/hal0/slot_config/__init__.py
+++ b/src/hal0/slot_config/__init__.py
@@ -42,17 +42,22 @@ import logging
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from hal0.capabilities.config import (
-    CapabilityConfig,
-    CapabilitySelection,
-    capabilities_toml_path,
-    capabilities_toml_payload,
-)
 from hal0.config import paths
 from hal0.config.loader import write_toml_atomic
 from hal0.model_meta import canonical_device, device_to_legacy_backend
+
+if TYPE_CHECKING:
+    from hal0.capabilities.config import CapabilitySelection
+
+# NOTE: hal0.capabilities.* is imported lazily inside the store methods.
+# This module is imported by hal0.slots.manager (the write_slot_toml
+# re-point), and a module-level import of hal0.capabilities would close
+# the cycle capabilities.__init__ → orchestrator → dispatcher →
+# slots.manager → slot_config. Keeping this module import-light breaks
+# that loop while the orchestrator (which imports both) stays the
+# composition point.
 
 log = logging.getLogger(__name__)
 
@@ -145,6 +150,8 @@ class SlotConfigStore:
     # ── path helpers ─────────────────────────────────────────────────────────
 
     def _caps_path(self) -> Path:
+        from hal0.capabilities.config import capabilities_toml_path
+
         return self._capabilities_path or capabilities_toml_path()
 
     def _slot_path(self, slot_name: str) -> Path:
@@ -223,6 +230,11 @@ class SlotConfigStore:
         self, raw_before: dict[str, Any] | None, selection: SlotSelection
     ) -> dict[str, Any]:
         """Fold ``selection`` into the capabilities file's canonical shape."""
+        from hal0.capabilities.config import (
+            CapabilityConfig,
+            capabilities_toml_payload,
+        )
+
         cfg = (
             CapabilityConfig.model_validate(raw_before)
             if raw_before is not None

--- a/src/hal0/slot_config/__init__.py
+++ b/src/hal0/slot_config/__init__.py
@@ -1,0 +1,313 @@
+"""SlotConfigStore — one reconciled truth for capability + slot config (issue #697).
+
+Two files describe what a capability child should run:
+
+  - ``/etc/hal0/capabilities.toml`` — the operator's selection per
+    (slot, child), written by the dashboard's capability cards.
+  - ``/etc/hal0/slots/<name>.toml`` — the underlying slot config the
+    providers actually spawn from.
+
+Historically they were reconciled by an unconditional rewrite buried in
+``CapabilityOrchestrator.apply()``; a half-finished apply, a manual
+edit, or a migration seed could leave the two disagreeing (the
+2026-05-20 production drift). This module replaces that hidden rewrite
+with an explicit, observable, reversible step:
+
+  - :meth:`SlotConfigStore.apply` is **compute-only** — it produces a
+    :class:`ChangeSet` (before/after snapshots of the on-disk config)
+    and writes NOTHING.
+  - :meth:`SlotConfigStore.commit` writes ``after`` atomically (per
+    file via :func:`hal0.config.loader.write_toml_atomic`, with
+    roll-back to ``before`` if a later file write fails).
+  - :meth:`SlotConfigStore.revert` restores ``before``.
+
+The invariant the test-suite pins: after ``commit`` disk equals
+``cs.after``; after ``revert`` disk equals ``cs.before``; a failed
+mid-commit leaves disk at ``before`` — never half-reconciled.
+
+Device→backend translation is **imported from** :mod:`hal0.model_meta`
+(:func:`canonical_device`, :func:`device_to_legacy_backend`) — this
+module re-derives no classification logic.
+
+:func:`write_slot_toml` is the single low-level write path for
+``slots/*.toml``; every writer (SlotManager.create/update_config, the
+installer's pick-default seed, the model-delete cascade) routes its
+bytes through it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hal0.capabilities.config import (
+    CapabilityConfig,
+    CapabilitySelection,
+    capabilities_toml_path,
+    capabilities_toml_payload,
+)
+from hal0.config import paths
+from hal0.config.loader import write_toml_atomic
+from hal0.model_meta import canonical_device, device_to_legacy_backend
+
+log = logging.getLogger(__name__)
+
+
+# ── the single low-level slots/*.toml write path ─────────────────────────────
+
+
+def write_slot_toml(path: Path | str, data: dict[str, Any]) -> None:
+    """Atomically write a slot TOML.
+
+    THE byte-level write path for ``/etc/hal0/slots/*.toml`` — thin
+    wrapper over :func:`write_toml_atomic` kept as a named seam so the
+    writer inventory stays greppable (issue #697). Raises ``OSError`` on
+    filesystem failure and ``TypeError`` on non-TOML-encodable values,
+    same as the underlying writer.
+    """
+    write_toml_atomic(Path(path), data)
+
+
+# ── ChangeSet ────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class FileState:
+    """One file's snapshot inside a :class:`ChangeSet`.
+
+    ``data is None`` means "the file does not exist" — committing it
+    is a no-op, reverting to it unlinks the file.
+    """
+
+    path: Path
+    data: dict[str, Any] | None
+
+
+@dataclass(frozen=True)
+class ChangeSet:
+    """Before/after snapshots of the on-disk slot config.
+
+    ``before`` and ``after`` are parallel tuples (same paths, same
+    order). Produced by :meth:`SlotConfigStore.apply`; consumed by
+    :meth:`SlotConfigStore.commit` / :meth:`SlotConfigStore.revert`.
+    """
+
+    before: tuple[FileState, ...]
+    after: tuple[FileState, ...]
+
+    @property
+    def changed(self) -> bool:
+        """True when committing this ChangeSet would alter any file."""
+        return any(b.data != a.data for b, a in zip(self.before, self.after, strict=True))
+
+
+@dataclass(frozen=True)
+class SlotSelection:
+    """The input to :meth:`SlotConfigStore.apply`.
+
+    Carries the merged (post-validation) selection the orchestrator
+    computed for one capability child, plus the addressing needed to
+    reconcile the underlying slot file.
+    """
+
+    slot: str
+    child: str
+    slot_name: str
+    selection: CapabilitySelection
+
+
+# ── store ────────────────────────────────────────────────────────────────────
+
+
+class SlotConfigStore:
+    """Deep module owning capabilities.toml + slots/*.toml as one truth.
+
+    Stateless between calls — every ``apply`` re-reads disk so the
+    snapshots are honest even when other writers (CLI migrations,
+    SlotManager lifecycle) touched the files in between.
+    """
+
+    def __init__(
+        self,
+        *,
+        capabilities_path: Path | None = None,
+        slots_dir: Path | None = None,
+    ) -> None:
+        # Resolved lazily so a HAL0_HOME set after construction (the
+        # test fixture pattern) still lands in the right place.
+        self._capabilities_path = Path(capabilities_path) if capabilities_path else None
+        self._slots_dir = Path(slots_dir) if slots_dir else None
+
+    # ── path helpers ─────────────────────────────────────────────────────────
+
+    def _caps_path(self) -> Path:
+        return self._capabilities_path or capabilities_toml_path()
+
+    def _slot_path(self, slot_name: str) -> Path:
+        base = self._slots_dir or paths.slots_config_dir()
+        return base / f"{slot_name}.toml"
+
+    # ── apply (compute-only) ─────────────────────────────────────────────────
+
+    def apply(self, selection: SlotSelection) -> ChangeSet:
+        """Compute the reconciled post-state for ``selection``. Writes NOTHING.
+
+        Returns a :class:`ChangeSet` over exactly two files, in commit
+        order:
+
+          1. ``capabilities.toml`` — the persisted selection for
+             ``(selection.slot, selection.child)`` replaced with
+             ``selection.selection``, serialised through the canonical
+             :func:`capabilities_toml_payload` shape.
+          2. ``slots/<slot_name>.toml`` — reconciled against the
+             selection **iff** the selection is enabled AND the file
+             already exists (slot creation carries state.json + port
+             allocation side effects and stays with
+             ``SlotManager.create``). Otherwise ``after == before``.
+        """
+        caps_path = self._caps_path()
+        caps_before = _read_toml_or_none(caps_path)
+        caps_after = self._reconciled_capabilities(caps_before, selection)
+
+        slot_path = self._slot_path(selection.slot_name)
+        slot_before = _read_toml_or_none(slot_path)
+        slot_after = self._reconciled_slot(slot_before, selection.selection)
+
+        return ChangeSet(
+            before=(
+                FileState(path=caps_path, data=caps_before),
+                FileState(path=slot_path, data=slot_before),
+            ),
+            after=(
+                FileState(path=caps_path, data=caps_after),
+                FileState(path=slot_path, data=slot_after),
+            ),
+        )
+
+    # ── commit / revert ──────────────────────────────────────────────────────
+
+    def commit(self, cs: ChangeSet) -> None:
+        """Write ``cs.after`` to disk.
+
+        Each file write is atomic (tmpfile + fsync + rename). Whole-set
+        atomicity is approximated by roll-back: if a later write fails,
+        every file already written is restored to its ``before``
+        snapshot and the original exception re-raised — disk is never
+        left half-reconciled.
+        """
+        written: list[FileState] = []
+        for before, after in zip(cs.before, cs.after, strict=True):
+            if before.data == after.data:
+                continue
+            try:
+                _write_state(after)
+            except BaseException:
+                for prior in reversed(written):
+                    with contextlib.suppress(OSError):
+                        _write_state(prior)
+                raise
+            written.append(before)
+
+    def revert(self, cs: ChangeSet) -> None:
+        """Restore every file in ``cs`` to its ``before`` snapshot."""
+        for before in cs.before:
+            _write_state(before)
+
+    # ── reconciliation ───────────────────────────────────────────────────────
+
+    def _reconciled_capabilities(
+        self, raw_before: dict[str, Any] | None, selection: SlotSelection
+    ) -> dict[str, Any]:
+        """Fold ``selection`` into the capabilities file's canonical shape."""
+        cfg = (
+            CapabilityConfig.model_validate(raw_before)
+            if raw_before is not None
+            else CapabilityConfig()
+        )
+        cfg.selections.setdefault(selection.slot, {})[selection.child] = selection.selection
+        return capabilities_toml_payload(cfg)
+
+    def _reconciled_slot(
+        self, raw_before: dict[str, Any] | None, selection: CapabilitySelection
+    ) -> dict[str, Any] | None:
+        """Project an enabled selection onto the existing slot TOML dict.
+
+        Mirrors the semantics of the pre-#697 rewrite-through-
+        ``SlotManager.update_config`` path exactly:
+
+          - reconcile only when the selection is enabled (pure disable
+            never rewrote the slot file) and the file exists,
+          - one-level deep merge for the nested ``[model]`` table so
+            sibling keys (``context_size`` etc.) survive,
+          - both ``device`` (v0.2 canonical) and ``backend`` (one-release
+            legacy alias) written, translated via :mod:`hal0.model_meta`,
+          - the ``ctx_size`` → ``context_size`` alias folded (#585) so
+            the two keys can't diverge on disk.
+        """
+        if raw_before is None or not selection.enabled:
+            return raw_before
+
+        updates: dict[str, Any] = {}
+        slot_backend = device_to_legacy_backend(selection.device)
+        slot_device = canonical_device(selection.device)
+        if slot_backend:
+            # Deprecated field, kept for one release — see ADR-0006 §7.
+            updates["backend"] = slot_backend
+        if slot_device:
+            updates["device"] = slot_device
+        if selection.provider:
+            updates["provider"] = selection.provider
+        if selection.model:
+            updates["model"] = {"default": selection.model}
+        if not updates:
+            return raw_before
+
+        after = dict(raw_before)
+        for key, value in updates.items():
+            existing = after.get(key)
+            if isinstance(existing, dict) and isinstance(value, dict):
+                after[key] = {**existing, **value}
+            else:
+                after[key] = value
+
+        # #585 parity with SlotManager.update_config: fold the legacy
+        # [model].ctx_size alias into the canonical context_size key.
+        model = after.get("model")
+        if isinstance(model, dict) and "ctx_size" in model:
+            model = dict(model)
+            model["context_size"] = model.pop("ctx_size")
+            after["model"] = model
+        return after
+
+
+# ── file-state IO ────────────────────────────────────────────────────────────
+
+
+def _read_toml_or_none(path: Path) -> dict[str, Any] | None:
+    """Read a TOML file as a raw dict; ``None`` when it doesn't exist."""
+    try:
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    except FileNotFoundError:
+        return None
+
+
+def _write_state(fs: FileState) -> None:
+    """Materialise one snapshot: write its data, or unlink when absent."""
+    if fs.data is None:
+        fs.path.unlink(missing_ok=True)
+        return
+    write_toml_atomic(fs.path, fs.data)
+
+
+__all__ = [
+    "ChangeSet",
+    "FileState",
+    "SlotConfigStore",
+    "SlotSelection",
+    "write_slot_toml",
+]

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -45,6 +45,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from hal0.config import paths
+from hal0.slot_config import write_slot_toml
 from hal0.slots.state import (
     IllegalSlotTransition,
     NpuExclusivityViolation,
@@ -1526,17 +1527,10 @@ class SlotManager:
         admits exactly one NPU LLM at a time. Disabled NPU LLM slots
         coexist; only the live anchor count is bounded.
 
-        TOML serialisation depends on ``tomli_w`` (declared in
-        pyproject.toml); kept inline so this module doesn't pull in
-        ``config/loader.py``.
+        TOML serialisation routes through
+        :func:`hal0.slot_config.write_slot_toml` — the single
+        slots/*.toml write path (issue #697).
         """
-        try:
-            import tomli_w
-        except ImportError as exc:  # pragma: no cover
-            raise SlotConfigError(
-                "tomli_w not installed — required for slot config writes",
-            ) from exc
-
         cfg_dict = _cfg_to_dict(slot_cfg)
         # #585: canonicalize a ctx_size alias from the create modal too.
         _normalize_ctx_key(cfg_dict)
@@ -1544,7 +1538,7 @@ class SlotManager:
         cfg_path = self._config_file(slot_name)
         cfg_path.parent.mkdir(parents=True, exist_ok=True)
         try:
-            cfg_path.write_bytes(tomli_w.dumps(cfg_dict).encode("utf-8"))
+            write_slot_toml(cfg_path, cfg_dict)
         except OSError as exc:
             raise SlotConfigError(
                 f"failed to write slot config {cfg_path}: {exc}",
@@ -1609,11 +1603,6 @@ class SlotManager:
         """
         slot_name = self._resolve_alias(slot_name)
         self._ensure_known(slot_name)
-        try:
-            import tomli_w
-        except ImportError as exc:  # pragma: no cover
-            raise SlotConfigError("tomli_w not installed") from exc
-
         cfg = await self._load_slot_config(slot_name)
         cfg_dict = _cfg_to_dict(cfg)
         # One-level deep merge for nested TOML tables ([model], [server]).
@@ -1646,7 +1635,7 @@ class SlotManager:
 
         cfg_path = self._config_file(slot_name)
         try:
-            cfg_path.write_bytes(tomli_w.dumps(cfg_dict).encode("utf-8"))
+            write_slot_toml(cfg_path, cfg_dict)
         except OSError as exc:
             raise SlotConfigError(
                 f"failed to rewrite {cfg_path}: {exc}",
@@ -1782,15 +1771,10 @@ class SlotManager:
         reads the right default instead of drifting back to the empty
         seed value that produced the "no model.default set" ERROR.
 
-        Atomic via the same ``write_bytes`` pattern as :meth:`update_config`.
-        Failures bubble up so the caller can log + soft-fail without
-        affecting the live load state.
+        Atomic via :func:`hal0.slot_config.write_slot_toml` — the single
+        slots/*.toml write path (issue #697). Failures bubble up so the
+        caller can log + soft-fail without affecting the live load state.
         """
-        try:
-            import tomli_w
-        except ImportError as exc:  # pragma: no cover
-            raise SlotConfigError("tomli_w not installed") from exc
-
         cfg = await self._load_slot_config(slot_name)
         cfg_dict = _cfg_to_dict(cfg)
         existing_model = cfg_dict.get("model")
@@ -1799,7 +1783,7 @@ class SlotManager:
 
         cfg_path = self._config_file(slot_name)
         try:
-            cfg_path.write_bytes(tomli_w.dumps(cfg_dict).encode("utf-8"))
+            write_slot_toml(cfg_path, cfg_dict)
         except OSError as exc:
             raise SlotConfigError(
                 f"failed to persist model.default to {cfg_path}: {exc}",

--- a/tests/capabilities/test_orchestrator_reconciliation.py
+++ b/tests/capabilities/test_orchestrator_reconciliation.py
@@ -15,18 +15,28 @@ already disagreed (e.g. a previous failed apply, a manual edit, or a
 seed/migration bug), no rewrite fired and the next load() spawned
 against the stale slot TOML.
 
-The fix reconciles unconditionally whenever the slot is going to be
-enabled. These tests pin that contract.
+The fix reconciles whenever the slot is going to be enabled. Since
+issue #697 the reconciliation runs through ``hal0.slot_config``'s
+``SlotConfigStore`` (compute-only ``apply`` + atomic ``commit``), so
+these tests pin the contract against the on-disk slot TOML — the
+reconciled truth — rather than against SlotManager call recording.
 """
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from hal0.capabilities.orchestrator import CapabilityOrchestrator
+
+
+def _read_slot_toml(home: Path, slot: str = "embed") -> dict[str, Any]:
+    path = home / "etc" / "hal0" / "slots" / f"{slot}.toml"
+    with open(path, "rb") as f:
+        return tomllib.load(f)
 
 
 @pytest.fixture(autouse=True)
@@ -195,6 +205,7 @@ def orchestrator(
 
 async def test_apply_rewrites_slot_toml_when_drift_present(
     orchestrator: tuple[CapabilityOrchestrator, FakeSlotManager],
+    drifted_state: Path,
 ) -> None:
     """Re-enabling embed with the *same* selection still rewrites the slot TOML.
 
@@ -202,11 +213,11 @@ async def test_apply_rewrites_slot_toml_when_drift_present(
     enabled false->true (without changing backend/provider) does not
     introduce a selection diff -- but the slot TOML still says vulkan.
 
-    Regression: the orchestrator must call ``update_config`` with
-    ``backend="flm"`` (the slot-toml form of catalog id "npu") so the
-    next ``load()`` reads the correct backend.
+    Regression: the slot TOML on disk must end up with ``backend="flm"``
+    (the slot-toml form of catalog id "npu") so the next ``load()``
+    reads the correct backend.
     """
-    orch, fake = orchestrator
+    orch, _fake = orchestrator
 
     await orch.apply("embed", "embed", {"enabled": False})
     await orch.apply(
@@ -220,26 +231,40 @@ async def test_apply_rewrites_slot_toml_when_drift_present(
         },
     )
 
-    update_calls = [c for c in fake.calls if c[0] == "update_config"]
-    assert update_calls, (
-        "update_config was never invoked -- slot TOML drift was not reconciled. "
-        f"All calls: {fake.calls}"
+    on_disk = _read_slot_toml(drifted_state)
+    assert on_disk.get("backend") == "flm", (
+        f"slot TOML backend was not reconciled to FLM: {on_disk!r}"
     )
-
-    last_updates = update_calls[-1][2]["updates"]
-    assert last_updates.get("backend") == "flm", (
-        f"slot TOML backend was not reconciled to FLM: {last_updates!r}"
+    assert on_disk.get("provider") == "flm", (
+        f"slot TOML provider was not reconciled to FLM: {on_disk!r}"
     )
-    assert last_updates.get("provider") == "flm", (
-        f"slot TOML provider was not reconciled to FLM: {last_updates!r}"
-    )
+    assert on_disk.get("device") == "npu", f"slot TOML device not reconciled: {on_disk!r}"
 
 
 async def test_apply_reconciles_before_load(
-    orchestrator: tuple[CapabilityOrchestrator, FakeSlotManager],
+    drifted_state: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The rewrite must happen *before* load() so the spawn reads fresh config."""
-    orch, fake = orchestrator
+    """The rewrite must hit disk *before* load() so the spawn reads fresh config."""
+    monkeypatch.setattr(
+        CapabilityOrchestrator,
+        "_validate_model_in_catalog",
+        lambda self, slot, child, model_id, backend_id: None,
+    )
+
+    class DiskPeekSlotManager(FakeSlotManager):
+        """Snapshots the slot TOML at load() time — what the spawn would read."""
+
+        def __init__(self, home: Path) -> None:
+            super().__init__()
+            self._home = home
+            self.seen_at_load: list[dict[str, Any]] = []
+
+        async def load(self, slot_name: str, model_id: str | None = None) -> _StubSlot:
+            self.seen_at_load.append(_read_slot_toml(self._home, slot_name))
+            return await super().load(slot_name, model_id=model_id)
+
+    fake = DiskPeekSlotManager(drifted_state)
+    orch = CapabilityOrchestrator(slot_manager=fake)
 
     await orch.apply("embed", "embed", {"enabled": False})
     fake.calls.clear()
@@ -255,25 +280,114 @@ async def test_apply_reconciles_before_load(
         },
     )
 
-    methods = [c[0] for c in fake.calls]
-    assert "update_config" in methods, f"no rewrite happened: {methods}"
-    assert "load" in methods, f"no load happened: {methods}"
-    assert methods.index("update_config") < methods.index("load"), (
-        f"update_config must precede load so the spawn reads the new TOML; "
-        f"observed order: {methods}"
+    assert fake.seen_at_load, f"no load happened: {fake.calls}"
+    assert fake.seen_at_load[0].get("backend") == "flm", (
+        "load() observed a stale slot TOML — reconciliation must be committed "
+        f"to disk before the spawn: {fake.seen_at_load[0]!r}"
     )
 
 
 async def test_apply_no_rewrite_on_pure_disable(
     orchestrator: tuple[CapabilityOrchestrator, FakeSlotManager],
+    drifted_state: Path,
 ) -> None:
     """Disabling the slot does not require rewriting the TOML."""
     orch, fake = orchestrator
+    before = _read_slot_toml(drifted_state)
 
     await orch.apply("embed", "embed", {"enabled": False})
 
     update_calls = [c for c in fake.calls if c[0] == "update_config"]
     assert update_calls == [], f"unexpected update_config on disable transition: {update_calls}"
+    assert _read_slot_toml(drifted_state) == before, "slot TOML changed on pure disable"
+
+
+async def test_apply_commit_failure_leaves_both_files_at_before(
+    orchestrator: tuple[CapabilityOrchestrator, FakeSlotManager],
+    drifted_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invariant (#697): a failed mid-apply leaves disk at ``before``.
+
+    When the store's commit blows up partway, NEITHER capabilities.toml
+    nor the slot TOML may be left changed — the half-reconciled state is
+    exactly the drift this module exists to prevent.
+    """
+    import hal0.slot_config as slot_config_mod
+
+    orch, _fake = orchestrator
+    home = drifted_state
+    caps_path = home / "etc" / "hal0" / "capabilities.toml"
+    slot_before = _read_slot_toml(home)
+    caps_before = caps_path.read_bytes()
+
+    real_write = slot_config_mod.write_toml_atomic
+
+    def _boom_on_slot(path, data):  # type: ignore[no-untyped-def]
+        if Path(path).name == "embed.toml":
+            raise OSError("disk full")
+        real_write(path, data)
+
+    monkeypatch.setattr(slot_config_mod, "write_toml_atomic", _boom_on_slot)
+
+    from hal0.errors import Hal0Error
+
+    with pytest.raises(Hal0Error):
+        await orch.apply(
+            "embed",
+            "embed",
+            {
+                "enabled": True,
+                "backend": "npu",
+                "provider": "flm",
+                "model": "nomic-embed-text-v1.5-q8_0",
+            },
+        )
+
+    monkeypatch.setattr(slot_config_mod, "write_toml_atomic", real_write)
+    assert _read_slot_toml(home) == slot_before
+    assert caps_path.read_bytes() == caps_before
+
+
+async def test_apply_lifecycle_failure_still_persists_intent(
+    drifted_state: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A load() failure AFTER commit keeps the persisted selection (the
+    pre-#697 'persist the user's intent even if the slot bounce failed'
+    behaviour) — and both files stay mutually consistent."""
+    from hal0.capabilities.config import load_capabilities_config
+    from hal0.capabilities.orchestrator import CapabilityApplyFailed
+
+    monkeypatch.setattr(
+        CapabilityOrchestrator,
+        "_validate_model_in_catalog",
+        lambda self, slot, child, model_id, backend_id: None,
+    )
+
+    class ExplodingSlotManager(FakeSlotManager):
+        async def load(self, slot_name: str, model_id: str | None = None) -> _StubSlot:
+            raise RuntimeError("lemond is down")
+
+    orch = CapabilityOrchestrator(slot_manager=ExplodingSlotManager())
+    await orch.apply("embed", "embed", {"enabled": False})
+
+    with pytest.raises(CapabilityApplyFailed):
+        await orch.apply(
+            "embed",
+            "embed",
+            {
+                "enabled": True,
+                "backend": "npu",
+                "provider": "flm",
+                "model": "nomic-embed-text-v1.5-q8_0",
+            },
+        )
+
+    caps_path = drifted_state / "etc" / "hal0" / "capabilities.toml"
+    sel = load_capabilities_config(caps_path).selections["embed"]["embed"]
+    assert sel.enabled is True, "user intent must persist past a lifecycle failure"
+    on_disk = _read_slot_toml(drifted_state)
+    assert on_disk.get("backend") == "flm", "slot TOML must match the persisted selection"
 
 
 # ── Step 1: _CHILD_TO_SLOT_TYPE + type written by _ensure_slot_exists ──────────
@@ -656,13 +770,9 @@ async def test_embed_gpu_to_npu_no_load(
     )
 
     assert "--embed 1" in client.set_calls[-1]["flm"]["args"], client.set_calls
-    # device rewritten to npu on the slot TOML.
-    dev_writes = [
-        c
-        for c in fake.calls
-        if c[0] == "update_config" and c[1] == "embed" and c[2]["updates"].get("device") == "npu"
-    ]
-    assert dev_writes, f"device not rewritten to npu: {fake.calls}"
+    # device rewritten to npu on the slot TOML (committed by the store).
+    on_disk = _read_slot_toml(home)
+    assert on_disk.get("device") == "npu", f"device not rewritten to npu: {on_disk!r}"
     assert not [c for c in fake.calls if c[0] in ("load", "swap", "unload")], (
         f"gpu->npu must not bounce the embed slot: {fake.calls}"
     )

--- a/tests/slot_config/test_store.py
+++ b/tests/slot_config/test_store.py
@@ -1,0 +1,329 @@
+"""SlotConfigStore — invariant + behaviour tests (issue #697).
+
+The store owns BOTH ``capabilities.toml`` selections and ``slots/*.toml``
+as one reconciled truth. The locked interface:
+
+  - ``apply(selection) -> ChangeSet`` is COMPUTE-ONLY (writes nothing),
+  - ``commit(cs)`` atomically writes ``cs.after``,
+  - ``revert(cs)`` restores ``cs.before``.
+
+The drift invariant pinned here:
+
+  - after ``commit``: disk == ``cs.after``
+  - after ``revert``: disk == ``cs.before``
+  - a failed mid-commit leaves disk at ``before`` — never half-reconciled.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.capabilities.config import CapabilitySelection, load_capabilities_config
+from hal0.slot_config import ChangeSet, SlotConfigStore, SlotSelection, write_slot_toml
+
+# ── fixtures / helpers ────────────────────────────────────────────────────────
+
+
+def _etc(home: str) -> Path:
+    return Path(home) / "etc" / "hal0"
+
+
+def _write_embed_slot(home: str, *, extra_lines: list[str] | None = None) -> Path:
+    """A drifted vulkan/llama-server embed slot TOML (the prod bug shape)."""
+    slots_dir = _etc(home) / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    lines = [
+        'name = "embed"',
+        "port = 8082",
+        'backend = "vulkan"',
+        'provider = "llama-server"',
+        "enabled = true",
+        "[model]",
+        'default = "old-model"',
+    ]
+    if extra_lines:
+        lines += extra_lines
+    path = slots_dir / "embed.toml"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _write_caps(home: str) -> Path:
+    path = _etc(home) / "capabilities.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                "schema_version = 2",
+                "[selections.embed.embed]",
+                'device = "gpu-vulkan"',
+                'provider = "llama-server"',
+                'model = "old-model"',
+                "enabled = false",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _selection(
+    *,
+    device: str = "npu",
+    provider: str = "flm",
+    model: str = "nomic-embed-text-v1.5-q8_0",
+    enabled: bool = True,
+    slot: str = "embed",
+    child: str = "embed",
+    slot_name: str = "embed",
+) -> SlotSelection:
+    return SlotSelection(
+        slot=slot,
+        child=child,
+        slot_name=slot_name,
+        selection=CapabilitySelection(
+            device=device, provider=provider, model=model, enabled=enabled
+        ),
+    )
+
+
+def _read_toml(path: Path) -> dict[str, Any]:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+# ── apply() is compute-only ──────────────────────────────────────────────────
+
+
+def test_apply_writes_nothing(tmp_hal0_home: str) -> None:
+    slot_path = _write_embed_slot(tmp_hal0_home)
+    caps_path = _write_caps(tmp_hal0_home)
+    slot_bytes = slot_path.read_bytes()
+    caps_bytes = caps_path.read_bytes()
+
+    store = SlotConfigStore()
+    cs = store.apply(_selection())
+
+    assert isinstance(cs, ChangeSet)
+    assert slot_path.read_bytes() == slot_bytes, "apply() must not touch slots/*.toml"
+    assert caps_path.read_bytes() == caps_bytes, "apply() must not touch capabilities.toml"
+
+
+def test_apply_before_matches_disk(tmp_hal0_home: str) -> None:
+    slot_path = _write_embed_slot(tmp_hal0_home)
+    caps_path = _write_caps(tmp_hal0_home)
+
+    cs = SlotConfigStore().apply(_selection())
+
+    by_path = {fs.path: fs for fs in cs.before}
+    assert by_path[caps_path].data == _read_toml(caps_path)
+    assert by_path[slot_path].data == _read_toml(slot_path)
+
+
+# ── reconciliation content (model_meta-derived) ──────────────────────────────
+
+
+def test_apply_reconciles_slot_fields_for_npu(tmp_hal0_home: str) -> None:
+    """device=npu → slot TOML backend=flm (legacy token) + device=npu."""
+    slot_path = _write_embed_slot(tmp_hal0_home)
+    _write_caps(tmp_hal0_home)
+
+    cs = SlotConfigStore().apply(_selection(device="npu", provider="flm"))
+
+    after = {fs.path: fs.data for fs in cs.after}[slot_path]
+    assert after is not None
+    assert after["backend"] == "flm"
+    assert after["device"] == "npu"
+    assert after["provider"] == "flm"
+    assert after["model"]["default"] == "nomic-embed-text-v1.5-q8_0"
+    # Untouched fields survive the one-level merge.
+    assert after["port"] == 8082
+    assert after["enabled"] is True
+    assert after["name"] == "embed"
+
+
+def test_apply_reconciles_slot_fields_for_gpu_rocm(tmp_hal0_home: str) -> None:
+    slot_path = _write_embed_slot(tmp_hal0_home)
+    _write_caps(tmp_hal0_home)
+
+    cs = SlotConfigStore().apply(
+        _selection(device="gpu-rocm", provider="llama-server", model="new-model")
+    )
+
+    after = {fs.path: fs.data for fs in cs.after}[slot_path]
+    assert after is not None
+    assert after["backend"] == "rocm"
+    assert after["device"] == "gpu-rocm"
+    assert after["model"]["default"] == "new-model"
+
+
+def test_apply_preserves_model_siblings_and_folds_ctx_alias(tmp_hal0_home: str) -> None:
+    """[model] sibling keys survive; the legacy ctx_size alias folds (#585)."""
+    slot_path = _write_embed_slot(tmp_hal0_home, extra_lines=["ctx_size = 4096"])
+    _write_caps(tmp_hal0_home)
+
+    cs = SlotConfigStore().apply(_selection(model="new-model"))
+
+    after = {fs.path: fs.data for fs in cs.after}[slot_path]
+    assert after is not None
+    assert after["model"]["default"] == "new-model"
+    assert after["model"]["context_size"] == 4096
+    assert "ctx_size" not in after["model"]
+
+
+def test_apply_updates_capabilities_selection(tmp_hal0_home: str) -> None:
+    _write_embed_slot(tmp_hal0_home)
+    caps_path = _write_caps(tmp_hal0_home)
+
+    cs = SlotConfigStore().apply(_selection())
+
+    after = {fs.path: fs.data for fs in cs.after}[caps_path]
+    assert after is not None
+    sel = after["selections"]["embed"]["embed"]
+    assert sel["device"] == "npu"
+    assert sel["provider"] == "flm"
+    assert sel["enabled"] is True
+    # The canonical persisted shape drops the deprecated backend alias.
+    assert "backend" not in sel
+    assert after["schema_version"] == 2
+
+
+def test_apply_skips_slot_toml_when_disabled(tmp_hal0_home: str) -> None:
+    """A disable-only change must not reconcile the slot TOML (parity with
+    the pre-store orchestrator: pure disable never rewrote the slot)."""
+    slot_path = _write_embed_slot(tmp_hal0_home)
+    _write_caps(tmp_hal0_home)
+
+    cs = SlotConfigStore().apply(_selection(enabled=False))
+
+    before = {fs.path: fs.data for fs in cs.before}[slot_path]
+    after = {fs.path: fs.data for fs in cs.after}[slot_path]
+    assert after == before
+
+
+def test_apply_skips_slot_toml_when_missing(tmp_hal0_home: str) -> None:
+    """Slot TOML absent → creation stays with SlotManager.create; the store
+    neither invents the file nor fails."""
+    _write_caps(tmp_hal0_home)
+    slot_path = _etc(tmp_hal0_home) / "slots" / "embed.toml"
+
+    cs = SlotConfigStore().apply(_selection())
+
+    states = {fs.path: fs.data for fs in cs.after}
+    assert states[slot_path] is None
+    assert not slot_path.exists()
+
+
+# ── commit / revert invariants ───────────────────────────────────────────────
+
+
+def test_commit_writes_after_to_disk(tmp_hal0_home: str) -> None:
+    slot_path = _write_embed_slot(tmp_hal0_home)
+    caps_path = _write_caps(tmp_hal0_home)
+
+    store = SlotConfigStore()
+    cs = store.apply(_selection())
+    store.commit(cs)
+
+    after = {fs.path: fs.data for fs in cs.after}
+    assert _read_toml(slot_path) == after[slot_path]
+    assert _read_toml(caps_path) == after[caps_path]
+    # The committed selection round-trips through the canonical loader.
+    sel = load_capabilities_config(caps_path).selections["embed"]["embed"]
+    assert sel.device == "npu"
+    assert sel.enabled is True
+
+
+def test_revert_restores_before(tmp_hal0_home: str) -> None:
+    slot_path = _write_embed_slot(tmp_hal0_home)
+    caps_path = _write_caps(tmp_hal0_home)
+
+    store = SlotConfigStore()
+    cs = store.apply(_selection())
+    store.commit(cs)
+    store.revert(cs)
+
+    before = {fs.path: fs.data for fs in cs.before}
+    assert _read_toml(slot_path) == before[slot_path]
+    assert _read_toml(caps_path) == before[caps_path]
+
+
+def test_revert_removes_file_that_was_absent(tmp_hal0_home: str) -> None:
+    """capabilities.toml absent before apply → revert removes it again."""
+    _write_embed_slot(tmp_hal0_home)
+    caps_path = _etc(tmp_hal0_home) / "capabilities.toml"
+    assert not caps_path.exists()
+
+    store = SlotConfigStore()
+    cs = store.apply(_selection())
+    store.commit(cs)
+    assert caps_path.exists()
+
+    store.revert(cs)
+    assert not caps_path.exists()
+
+
+def test_failed_mid_commit_leaves_disk_at_before(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The drift invariant: a write failure mid-commit rolls the already-
+    written files back — disk is never left half-reconciled."""
+    import hal0.slot_config as slot_config_mod
+
+    slot_path = _write_embed_slot(tmp_hal0_home)
+    caps_path = _write_caps(tmp_hal0_home)
+    slot_before = _read_toml(slot_path)
+    caps_before = _read_toml(caps_path)
+
+    store = SlotConfigStore()
+    cs = store.apply(_selection())
+
+    real_write = slot_config_mod.write_toml_atomic
+
+    def _boom_on_slot(path: Path | str, data: dict[str, Any]) -> None:
+        if Path(path).name == "embed.toml":
+            raise OSError("disk full")
+        real_write(path, data)
+
+    monkeypatch.setattr(slot_config_mod, "write_toml_atomic", _boom_on_slot)
+    with pytest.raises(OSError):
+        store.commit(cs)
+    monkeypatch.setattr(slot_config_mod, "write_toml_atomic", real_write)
+
+    assert _read_toml(slot_path) == slot_before, "slot TOML must be at before"
+    assert _read_toml(caps_path) == caps_before, "capabilities.toml must be rolled back"
+
+
+def test_commit_then_reapply_is_noop(tmp_hal0_home: str) -> None:
+    """Idempotence: once committed, re-applying the same selection yields a
+    no-change ChangeSet."""
+    _write_embed_slot(tmp_hal0_home)
+    _write_caps(tmp_hal0_home)
+
+    store = SlotConfigStore()
+    first = store.apply(_selection())
+    assert first.changed
+    store.commit(first)
+
+    second = store.apply(_selection())
+    assert not second.changed
+    assert [fs.data for fs in second.before] == [fs.data for fs in second.after]
+
+
+# ── write_slot_toml (the single low-level write path) ────────────────────────
+
+
+def test_write_slot_toml_is_atomic_and_parseable(tmp_hal0_home: str) -> None:
+    path = _etc(tmp_hal0_home) / "slots" / "newslot.toml"
+    write_slot_toml(path, {"name": "newslot", "port": 8090, "model": {"default": "m"}})
+    data = _read_toml(path)
+    assert data["name"] == "newslot"
+    assert data["model"]["default"] == "m"
+    # No tmpfile droppings left behind.
+    leftovers = [p for p in path.parent.iterdir() if p.name != path.name]
+    assert leftovers == []


### PR DESCRIPTION
Closes #697. Builds on #695/#700 (model_meta).

## Summary

Introduces `hal0.slot_config.SlotConfigStore` — the deep module owning `capabilities.toml` + `slots/*.toml` as one reconciled truth — and removes the orchestrator's unconditional in-place rewrite (the recurring drift hazard).

- **`apply(selection) -> ChangeSet{before, after}` is compute-only** — re-reads disk, writes nothing.
- **`commit(cs)`** — per-file `write_toml_atomic` with rollback-to-`before` on partial failure; **`revert(cs)`** restores `before` (unlinks files absent before).
- **Invariant pinned by tests:** disk == `cs.after` after commit; disk == `cs.before` after revert; a failed mid-commit leaves disk at `before` — never half-reconciled.
- Orchestrator `apply()` delegates: ChangeSet committed atomically **before** lifecycle dispatch (preserves the pre-existing persist-intent-on-lifecycle-failure behaviour, but a *config-write* failure now rolls back instead of half-applying — that half-applied state was the exact drift bug).
- **Single write path:** `write_slot_toml()` — all `slots/*.toml` writers re-pointed (SlotManager create/update/persist-default with minimal hunks, installer pick-default, model-delete cascade — the last non-atomic raw `write_bytes` writer, now atomic).
- Reconciliation imports `model_meta` (`canonical_device`, `device_to_legacy_backend`); zero re-derived logic. `capabilities_toml_payload()` extracted so the store and `save_capabilities_config` (kept for first-boot seed + v1→v2 migrations, documented with NOTE(#697)) share one canonical shape.
- ARCHITECTURE.md thin-overlay wording updated; CONTEXT.md glossary entries for `model_meta` + `SlotConfigStore`/`ChangeSet` promoted from "proposed" to as-built.

## Notes for reviewers

- Import cycle (manager → slot_config → capabilities → … → manager) broken via lazy capability imports inside store methods; cold imports of `slots.manager`, `slot_config`, `capabilities`, `api`, `cli` verified.
- The reconciliation write no longer passes through `SlotManager.update_config`; the only side effect that drops is the opportunistic state.json `extra.backend` mirror refresh — `status()` re-derives from TOML on every read, and since v0.2 no systemd drop-in/env rendering exists on this path (manager.py:1521), so no user-visible change.
- `slots/manager.py` hunks kept minimal (write-line re-points + dead `tomli_w` guards) for clean merging against in-flight #649.

## Tests

- 14 new store tests (invariants, mid-commit rollback, idempotence, model_meta translation, sibling preservation) + 6 reworked orchestrator reconciliation tests.
- Worker full suite: 3114 passed / 1 pre-existing environmental failure (hermes-provision, fails on clean main). Reviewer targeted re-run (slot_config, capabilities, slots, api, config): 1279 passed, 0 failed.
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)