### PR TITLE
refactor: SlotViewAggregator — lift enrichment out of list_slots() (#698)

### DIFF
--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -34,6 +34,15 @@ from fastapi.responses import StreamingResponse
 
 from hal0.api.middleware.error_codes import BadRequest, Conflict, Hal0Error
 from hal0.model_meta import device_to_backend, is_resolvable
+from hal0.slot_view import (
+    SlotViewAggregator,
+    container_enrichment,
+    fetch_lemonade_health,
+    lemonade_enrichment,
+    loaded_model_names,
+    serialize_slot,
+    synthesize_upstream_entries,
+)
 from hal0.slots.manager import Slot, SlotManager
 
 # Auth was removed in ADR-0012. All routes are open on the local network.
@@ -70,35 +79,20 @@ def _get_slot_manager(request: Request) -> SlotManager:
 def _slot_to_dict(slot: Slot, request: Request | None = None) -> dict[str, Any]:
     """Serialise a real Slot snapshot into the API shape.
 
-    Adds ``kind="local"`` so the UI can distinguish real slots from the
-    synthetic upstream-backed entries (which carry ``kind="remote"`` or
-    similar and ``_synthetic: true``).
+    Request-bound adapter over :func:`hal0.slot_view.serialize_slot`
+    (issue #698) — kept here because every per-slot route (create / get /
+    config / backend / lifecycle) and ``routes/health.py`` call it with a
+    ``Request`` in hand.
 
     When ``request`` is provided, also includes a ``models`` list pulled
     from the shared model cache. For an FLM slot serving chat + embed +
     asr concurrently, this surfaces all three tags so the dashboard can
     render the slot as multi-model instead of showing only the chat tag.
     """
-    base = slot.as_dict()
-    base["kind"] = "local"
-    base["status"] = slot.state.value
-    # Lift backend / provider out of metadata to the top level so the UI
-    # doesn't have to dig — the slot snapshot's `backend` is only set on
-    # transitions that pass it explicitly, but metadata carries both
-    # consistently after create / update_config.
-    meta = base.get("metadata") or {}
-    if not base.get("backend") and meta.get("backend"):
-        base["backend"] = meta.get("backend")
-    if not base.get("provider") and meta.get("provider"):
-        base["provider"] = meta.get("provider")
+    model_cache: dict[str, Any] | None = None
     if request is not None:
-        cache = getattr(request.app.state, "model_cache", {}) or {}
-        loaded = list(cache.get(slot.name, []))
-        if slot.model_id and slot.model_id in loaded:
-            loaded.remove(slot.model_id)
-            loaded.insert(0, slot.model_id)
-        base["models"] = loaded
-    return base
+        model_cache = getattr(request.app.state, "model_cache", {}) or {}
+    return serialize_slot(slot, model_cache=model_cache)
 
 
 #: Trigger substring for the nuclear-evict log line. lemond emits this
@@ -111,18 +105,14 @@ NUCLEAR_EVICT_TRIGGER: str = (
 
 
 async def _lemonade_state_enrichment(request: Request) -> dict[str, dict[str, Any]]:
-    """Build per-slot Lemonade-derived state for list_slots.
+    """Build per-slot Lemonade-derived state for slot snapshots.
 
-    Calls ``/v1/health`` once, then walks the slot configs to build a
+    Request-bound adapter over :func:`hal0.slot_view.lemonade_enrichment`
+    (issue #698) — kept here for ``get_slot``'s per-card refresh. Calls
+    ``/v1/health`` once, then walks the slot configs to build a
     ``{slot_name: {lemonade_state, backend_url?, coresident_group?}}``
     map. Never raises — a down lemond returns an empty enrichment so
     the dashboard degrades to the on-disk view rather than 500ing.
-
-    Coresident grouping (ADR-0008 §5, plan §5.2):
-      A slot of type=llm + device=npu serving as the chat anchor and
-      any sibling ``stt-npu`` / ``embed-npu`` slots that are enabled
-      share a ``coresident_group=npu-flm-trio`` marker. The dashboard
-      uses this to render a "trio" badge linking the three cards.
     """
     sm = getattr(request.app.state, "slot_manager", None)
     if sm is None:
@@ -131,201 +121,14 @@ async def _lemonade_state_enrichment(request: Request) -> dict[str, dict[str, An
         configs = await sm.iter_configs()
     except Exception:
         return {}
-
-    # Single /v1/health probe shared across every slot — calling once
-    # per slot would 5x lemond load for a 5-slot dashboard refresh.
-    from hal0.lemonade.errors import LemonadeError
-    from hal0.providers import lemonade_provider
-
-    health: dict[str, Any] = {}
-    try:
-        health = await lemonade_provider().client().health()
-    except LemonadeError:
-        health = {}
-    except Exception:
-        # Defensive: any error reading health degrades to "no enrichment"
-        # rather than tunnelling up as a 500 — the dashboard is the
-        # primary consumer and would render a broken card.
-        health = {}
-
-    loaded_by_model: dict[str, dict[str, Any]] = {}
-    if isinstance(health, dict):
-        for key in ("loaded", "all_models_loaded"):
-            entries = health.get(key)
-            if not isinstance(entries, list):
-                continue
-            for entry in entries:
-                if not isinstance(entry, dict):
-                    continue
-                name = entry.get("model_name")
-                if isinstance(name, str) and name:
-                    loaded_by_model[name] = entry
-
-    # First pass — pick out the NPU LLM slot(s) so we can decide if
-    # the trio is "active" (i.e. there IS an npu-llm slot enabled).
-    npu_llm_enabled: list[str] = [
-        str(cfg.get("name", ""))
-        for cfg in configs
-        if cfg.get("device") == "npu"
-        and cfg.get("type") == "llm"
-        and cfg.get("enabled") is not False
-    ]
-    trio_active = bool(npu_llm_enabled)
-
-    from hal0.slots.manager import SlotManager
-
-    out: dict[str, dict[str, Any]] = {}
-    for cfg in configs:
-        name = str(cfg.get("name", ""))
-        if not name:
-            continue
-        # Container slots use a separate enrichment path (_container_state_enrichment).
-        # Skip them here so they don't get a bogus lemonade_state="idle" from a
-        # lemond health probe that has no knowledge of the container.
-        if SlotManager._is_container_slot(cfg):
-            continue
-        enabled = cfg.get("enabled") is not False
-        model_default = ""
-        model_labels: list[str] = []
-        model_section = cfg.get("model")
-        if isinstance(model_section, dict):
-            model_default = str(model_section.get("default") or "")
-            raw_labels = model_section.get("labels", ())
-            if isinstance(raw_labels, (list, tuple)):
-                model_labels = [str(x) for x in raw_labels]
-        entry: dict[str, Any] = {}
-
-        # PR-18: lift slot ``type`` + model ``labels`` + model ``default``
-        # + ``enabled`` so the dashboard's chat surface can build the
-        # persona dropdown (which chat-type slots are enabled?) and
-        # decide whether to opt in to OmniRouter (does the active
-        # persona's model carry the ``tool-calling`` label?) without
-        # making a second call to /api/slots/{name}/config per slot.
-        # The fields are purely additive — pre-PR-18 consumers ignore
-        # them.
-        slot_type = cfg.get("type")
-        if isinstance(slot_type, str) and slot_type:
-            entry["type"] = slot_type
-        if model_default:
-            entry["model_default"] = model_default
-        if model_labels:
-            entry["labels"] = model_labels
-        entry["enabled"] = enabled
-
-        # Spec 1 / Component 1: surface the three edit-panel config fields so
-        # the card + drawer seed their controls without a per-slot /config
-        # fetch. ``enable_thinking`` is tri-valued on disk (true/false/absent);
-        # absent → null (effective OFF). ``n_gpu_layers`` falls back to the
-        # ModelConfig default sentinel (-1 = all layers) when unset.
-        entry["enable_thinking"] = cfg.get("enable_thinking")
-        n_gpu = model_section.get("n_gpu_layers") if isinstance(model_section, dict) else None
-        entry["n_gpu_layers"] = n_gpu if isinstance(n_gpu, int) else -1
-        # Issue #548: expose rope_freq_base so the Edit drawer can dirty-track
-        # it and avoid clobbering the on-disk value on unrelated saves.
-        # Absent (None) is surfaced as-is — frontend treats null as "use
-        # model default" (0.0 sentinel) and only writes back when changed.
-        rope = model_section.get("rope_freq_base") if isinstance(model_section, dict) else None
-        entry["rope_freq_base"] = rope if isinstance(rope, (int, float)) else None
-
-        # Spec 1 / Component 2 (issue #587): surface idle_timeout_s,
-        # workers, and the slot's freeform llamacpp_args so the Edit
-        # drawer can seed from real on-disk values. Without these the
-        # drawer used hardcoded constants (900 / 1 /
-        # "--flash-attn on --no-mmap") and unconditionally rewrote the
-        # on-disk values on every Save — same bug class as #584. The
-        # on-disk field for the freeform overlay is ``[server].extra_args``
-        # (ServerConfig); the dashboard's wire key is ``llamacpp_args``
-        # (matches the global lemond admin panel), so we map at this
-        # boundary. ``idle_timeout_s`` and ``workers`` are flat top-level
-        # SlotConfig fields, hoisted from [slot] by the loader. Defaults
-        # are NOT applied here — the wire payload is the truth source
-        # the dashboard uses to dirty-track changes, so an absent
-        # on-disk field should surface as null/None, not the schema
-        # default (which would let a stale slot sneak in a new value
-        # on a no-op save).
-        entry["idle_timeout_s"] = cfg.get("idle_timeout_s")
-        entry["workers"] = cfg.get("workers")
-        server_cfg = cfg.get("server")
-        if server_cfg is None:
-            extra_args: Any = None
-        elif isinstance(server_cfg, dict):
-            extra_args = server_cfg.get("extra_args")
-        else:
-            # ServerConfig pydantic model — read via attribute to stay
-            # consistent with the .get() pattern above.
-            extra_args = getattr(server_cfg, "extra_args", None)
-        entry["llamacpp_args"] = extra_args
-
-        # [npu] table: expose asr/embed toggles for Lemonade-backed NPU slots.
-        # Raw TOML dict carries [npu] at the top level; also check
-        # extra["npu"] as a fallback for any validated-dump shape.
-        npu_table = cfg.get("npu") or (cfg.get("extra") or {}).get("npu")
-        if npu_table and isinstance(npu_table, dict):
-            entry["npu"] = {
-                "asr": bool(npu_table.get("asr")),
-                "embed": bool(npu_table.get("embed")),
-            }
-
-        loaded_entry = loaded_by_model.get(model_default) if model_default else None
-        if not enabled:
-            entry["lemonade_state"] = "disabled"
-        elif loaded_entry is not None:
-            entry["lemonade_state"] = "loaded"
-            backend_url = loaded_entry.get("backend_url")
-            if isinstance(backend_url, str) and backend_url:
-                entry["backend_url"] = backend_url
-            # B2: surface declared vs actual backend so the dashboard can
-            # render a drift warning. declared_backend is ALWAYS present for
-            # a configured slot (normalized token rocm|vulkan|cpu|flm, NOT
-            # the gpu- device form, so the UI compares like-for-like).
-            # actual_backend + backend_mismatch are OMITTED (not null) when
-            # the child can't be introspected. Do NOT read
-            # loaded_entry.get("backend") — that field does not exist.
-            from hal0.providers.lemonade import (
-                resolve_actual_backend as _resolve_actual_backend,
-            )
-
-            _recipe, _llamacpp = device_to_backend(cfg.get("device"))
-            declared_backend = _llamacpp or (_recipe if _recipe == "flm" else None)
-            if declared_backend:
-                entry["declared_backend"] = declared_backend
-            actual_backend = _resolve_actual_backend(loaded_entry)
-            if actual_backend:
-                entry["actual_backend"] = actual_backend
-                if declared_backend:
-                    entry["backend_mismatch"] = actual_backend != declared_backend
-        else:
-            # Enabled but not in loaded[]: idle by default. Drift into
-            # error is surfaced via the regular slot state (see
-            # SlotManager.status reconciliation); the dashboard uses
-            # ``status`` for the dot, ``lemonade_state`` for the chip.
-            entry["lemonade_state"] = "idle"
-
-        # Coresident grouping — every device=npu slot (anchor + stt/embed
-        # shadows) backs the same FLM process, so they share a group marker.
-        # Keyed on device, NOT slot name: deployment renamed the trio to
-        # npu/stt/embed, so the old name-based set never matched in prod. A
-        # slot only joins when (a) the NPU LLM anchor is enabled and (b) THIS
-        # slot is enabled — disabled siblings don't claim membership.
-        if cfg.get("device") == "npu" and trio_active and enabled:
-            entry["coresident_group"] = "npu-flm-trio"
-
-        out[name] = entry
-    return out
+    return lemonade_enrichment(configs, await fetch_lemonade_health())
 
 
 async def _container_state_enrichment(request: Request) -> dict[str, dict[str, Any]]:
     """Build per-slot container state for container-backed slots.
 
-    For each slot where ``profile`` is set or ``runtime="container"``, probes
-    two live sources:
-      1. ``systemctl is-active`` → ``container_status``
-         (``running`` | ``stopped`` | ``starting`` | ``crashed``)
-      2. GET /health on the slot port → ``container_health`` (bool)
-
-    Returns ``{slot_name: {container_status, container_health, state}}`` where
-    ``state`` mirrors the hal0 SlotState value already in the snapshot so the
-    dashboard has a consistent ``state`` key regardless of slot type.
+    Request-bound adapter over :func:`hal0.slot_view.container_enrichment`
+    (issue #698) — kept here for ``get_slot``'s per-card refresh.
 
     Never raises — probe failures degrade to ``stopped`` / ``False`` rather
     than surfacing as a 500.  Lemonade slots are explicitly excluded.
@@ -337,137 +140,10 @@ async def _container_state_enrichment(request: Request) -> dict[str, dict[str, A
         configs = await sm.iter_configs()
     except Exception:
         return {}
-
-    from hal0.slots.manager import SlotManager, _cfg_port  # type: ignore[attr-defined]
-
-    out: dict[str, dict[str, Any]] = {}
-    for cfg in configs:
-        name = str(cfg.get("name", ""))
-        if not name:
-            continue
-        if not SlotManager._is_container_slot(cfg):
-            continue  # Lemonade / lemond slots handled by _lemonade_state_enrichment
-
-        entry: dict[str, Any] = {}
-
-        try:
-            from hal0.providers.container import container_provider
-
-            cp = container_provider()
-            # 1) systemctl is-active (synchronous — run in executor)
-            active = await asyncio.get_event_loop().run_in_executor(None, cp.is_active, name)
-            if active:
-                # 2) /health probe on the slot port to distinguish running vs starting
-                port = _cfg_port(cfg)
-                if port:
-                    health = await cp.health(port)
-                    container_health = bool(health.get("ok"))
-                    container_status = "running" if container_health else "starting"
-                else:
-                    container_health = False
-                    container_status = "running"
-            else:
-                container_health = False
-                # Distinguish crashed (failed) from clean stop by checking unit state
-                # via is-active exit codes: 0=active, 3=inactive, other=failed
-                container_status = "stopped"
-                try:
-                    import subprocess
-
-                    result = subprocess.run(
-                        ["systemctl", "is-active", f"hal0-slot@{name}.service"],
-                        capture_output=True,
-                        timeout=5,
-                    )
-                    stdout = result.stdout.decode().strip()
-                    if stdout == "failed":
-                        container_status = "crashed"
-                except Exception:
-                    pass
-        except Exception:
-            container_health = False
-            container_status = "stopped"
-
-        entry["container_status"] = container_status
-        entry["container_health"] = container_health
-
-        # [npu] table: expose asr/embed toggles so the dashboard can seed
-        # its NPU modality controls without a separate /config fetch.
-        # Raw TOML dict carries [npu] at the top level; also check
-        # extra["npu"] as a fallback for any validated-dump shape.
-        npu_table = cfg.get("npu") or (cfg.get("extra") or {}).get("npu")
-        if npu_table and isinstance(npu_table, dict):
-            entry["npu"] = {
-                "asr": bool(npu_table.get("asr")),
-                "embed": bool(npu_table.get("embed")),
-            }
-
-        # Emit runtime / profile / image so the UI doesn't have to dig
-        # into metadata, and resolved_command so the drawer can show the
-        # real podman argv instead of fabricating flags client-side.
-        entry["runtime"] = "container"
-        profile_name = str(cfg.get("profile") or "")
-        entry["profile"] = profile_name
-        image: str | None = None
-        if profile_name:
-            try:
-                from hal0.config.loader import load_profiles_config
-
-                catalog = load_profiles_config()
-                prof = catalog.profile.get(profile_name)
-                image = prof.image if prof else None
-                entry["image"] = image
-                # resolved_command = llama-server argv starting from the image
-                from hal0.providers.container import resolved_command_for_slot
-
-                entry["resolved_command"] = resolved_command_for_slot(cfg)
-            except Exception:
-                entry["image"] = None
-                entry["resolved_command"] = None
-        else:
-            entry["image"] = None
-            entry["resolved_command"] = None
-
-        # #663: deterministic backend-of-record - the running container's image
-        # IS the backend. Surface actual_image (via podman inspect) and compute
-        # image_mismatch against the slot's declared profile image. Replaces the
-        # fragile /proc actual_backend sniff for container slots (lemond slots
-        # keep resolve_actual_backend). Degrades silently - never 500 the hot path.
-        try:
-            from hal0.providers.container import _image_mismatch, container_provider
-
-            running_image = await asyncio.get_event_loop().run_in_executor(
-                None, container_provider().running_image, name
-            )
-        except Exception:
-            running_image = None
-        if running_image:
-            entry["actual_image"] = running_image
-            if image:
-                entry["image_mismatch"] = _image_mismatch(running_image, image)
-
-        # image_status: present | pulling | missing
-        # Check the slot_pull_jobs registry first so an in-flight pull
-        # surfaces as "pulling" without an extra inspect syscall.
-        slot_pull_jobs: dict[str, Any] = getattr(request.app.state, "slot_pull_jobs", {})
-        active_job = slot_pull_jobs.get(name)
-        if active_job is not None and getattr(active_job, "state", None) == "pulling":
-            entry["image_status"] = "pulling"
-        elif image:
-            try:
-                from hal0.providers.container import container_provider
-
-                present = await asyncio.get_event_loop().run_in_executor(
-                    None, container_provider().image_present, image
-                )
-                entry["image_status"] = "present" if present else "missing"
-            except Exception:
-                entry["image_status"] = "missing"
-        else:
-            entry["image_status"] = "missing"
-
-        out[name] = entry
-    return out
+    return await container_enrichment(
+        configs,
+        pull_jobs=getattr(request.app.state, "slot_pull_jobs", {}),
+    )
 
 
 async def _lemonade_loaded_models(request: Request) -> set[str]:
@@ -478,28 +154,14 @@ async def _lemonade_loaded_models(request: Request) -> set[str]:
     catalogue merely lists it. Never raises — a down/unreachable lemond
     yields an empty set so the dashboard degrades to "offline" instead
     of 500ing.
-    """
-    from hal0.lemonade.errors import LemonadeError
-    from hal0.providers import lemonade_provider
 
-    try:
-        health = await lemonade_provider().client().health()
-    except LemonadeError:
-        return set()
-    except Exception:
-        return set()
-    names: set[str] = set()
-    if isinstance(health, dict):
-        for key in ("loaded", "all_models_loaded"):
-            entries = health.get(key)
-            if not isinstance(entries, list):
-                continue
-            for entry in entries:
-                if isinstance(entry, dict):
-                    name = entry.get("model_name")
-                    if isinstance(name, str) and name:
-                        names.add(name)
-    return names
+    Adapter over :func:`hal0.slot_view.loaded_model_names` (issue #698)
+    — kept here for ``routes/health.py``'s composite status payload.
+    ``request`` is unused but retained for signature stability with the
+    other request-bound enrichment helpers.
+    """
+    del request  # health comes from the process-wide Lemonade provider
+    return loaded_model_names(await fetch_lemonade_health())
 
 
 def _synthesize_slots_from_upstreams(
@@ -526,51 +188,18 @@ def _synthesize_slots_from_upstreams(
     for this upstream (tracked in ``app.state.last_used_model``); falls
     back to the first non-alias from the catalog before any inference
     has happened.
-    """
-    upstreams = request.app.state.upstreams
-    cache = getattr(request.app.state, "model_cache", {})
-    last_used = getattr(request.app.state, "last_used_model", {})
-    out: list[dict[str, Any]] = []
-    for u in upstreams.list():
-        models = cache.get(u.name, [])
-        from hal0.api.routes.models import _is_alias  # local to avoid cycle
 
-        real_models = [m for m in models if not _is_alias(m)]
-        primary_model = (
-            last_used.get(u.name)
-            or (real_models[0] if real_models else "")
-            or (models[0] if models else "")
-        )
-        if u.kind == "slot":
-            # Local composite upstream: ``models`` comes from the slot
-            # CATALOGUE (config), so a non-empty list says nothing about
-            # what is resident. Truth comes from lemond's live loaded set.
-            # If health was unreadable (loaded_models is None) fall back to
-            # the catalogue heuristic rather than flapping to offline on a
-            # transient probe error.
-            serving = bool(models) if loaded_models is None else bool(set(models) & loaded_models)
-        else:
-            # Remote upstream: ``models`` is a live /v1/models probe of the
-            # remote, so a populated list is a genuine liveness signal.
-            serving = bool(models)
-        out.append(
-            {
-                "name": u.name,
-                "kind": u.kind,
-                "model": primary_model,
-                "status": "serving" if serving else "offline",
-                "backend": "remote" if u.kind == "remote" else "vulkan",
-                "provider": "remote-upstream" if u.kind == "remote" else "llama-server",
-                "url": u.url,
-                "advertised_models": len(models),
-                "last_used_model": last_used.get(u.name) or None,
-                "_synthetic": True,
-                "_synthetic_reason": (
-                    "Backed by remote upstream; install a local slot of the same name to take over."
-                ),
-            }
-        )
-    return out
+    Request-bound adapter over
+    :func:`hal0.slot_view.synthesize_upstream_entries` (issue #698) —
+    kept here for ``get_slot``'s synthetic fall-through and
+    ``routes/health.py``'s composite status payload.
+    """
+    return synthesize_upstream_entries(
+        request.app.state.upstreams,
+        getattr(request.app.state, "model_cache", {}),
+        getattr(request.app.state, "last_used_model", {}),
+        loaded_models=loaded_models,
+    )
 
 
 # ── list / create ──────────────────────────────────────────────────────────
@@ -580,77 +209,29 @@ def _synthesize_slots_from_upstreams(
 async def list_slots(request: Request) -> list[dict[str, object]]:
     """List configured slots.
 
-    Merges real SlotManager-backed entries with synthetic upstream-backed
-    ones. Real slots win on name collision so the dashboard sees a single
-    authoritative row per slot name once a local slot is installed.
-
-    PR-11: each real entry is enriched in-place with Lemonade-derived
-    fields (``lemonade_state``, optional ``backend_url`` +
-    ``coresident_group``). Synthetic upstream entries are untouched —
-    they aren't managed by lemond and have no health row to lift.
+    Thin adapter over :meth:`hal0.slot_view.SlotViewAggregator.snapshot`
+    (issue #698): the aggregator merges real SlotManager-backed entries
+    with synthetic upstream-backed ones (real slots win on name
+    collision), enriches each real entry with Lemonade-derived state +
+    container probe results, stamps per-slot resident memory, and embeds
+    live metrics in the card-expected shape. The route only wires the
+    aggregator's dependencies off ``app.state`` and serializes the typed
+    :class:`hal0.slot_view.SlotView` rows.
     """
+    import functools
+
     sm = _get_slot_manager(request)
-    real_slots = await sm.list()
-    real_entries: list[dict[str, Any]] = [_slot_to_dict(s, request) for s in real_slots]
-    real_names = {entry["name"] for entry in real_entries}
-
-    enrichment = await _lemonade_state_enrichment(request)
-    container_enrichment = await _container_state_enrichment(request)
-    for entry in real_entries:
-        slot_name = str(entry["name"])
-        extra = enrichment.get(slot_name)
-        if extra:
-            for k, v in extra.items():
-                entry.setdefault(k, v)
-        c_extra = container_enrichment.get(slot_name)
-        if c_extra:
-            for k, v in c_extra.items():
-                entry.setdefault(k, v)
-
-    # Stamp per-slot resident memory (model weights + KV-cache estimate) so the
-    # dashboard memory map (W4) attributes a real footprint per slot. Only
-    # resident slots get a non-zero row; everything else reads 0. Never let a
-    # memory-probe failure break the slots list.
-    try:
-        from hal0.slots.capacity import build_per_slot
-
-        registry = getattr(request.app.state, "model_registry", None)
-        per_slot_mem = await build_per_slot(real_slots, registry=registry)
-    except Exception:
-        per_slot_mem = {}
-    for entry in real_entries:
-        row = per_slot_mem.get(str(entry["name"]))
-        entry["mem_mb"] = round(float(row.get("mem_mb", 0) or 0), 1) if row else 0
-
-    synthetic = _synthesize_slots_from_upstreams(
-        request, loaded_models=await _lemonade_loaded_models(request)
+    state = request.app.state
+    aggregator = SlotViewAggregator(
+        sm,
+        registry=getattr(state, "model_registry", None),
+        metrics=functools.partial(slot_metrics, request),
+        model_cache=getattr(state, "model_cache", {}) or {},
+        upstreams=state.upstreams,
+        last_used_model=getattr(state, "last_used_model", {}),
+        slot_pull_jobs=getattr(state, "slot_pull_jobs", {}),
     )
-    merged: list[dict[str, Any]] = list(real_entries)
-    for entry in synthetic:
-        if entry["name"] not in real_names:
-            merged.append(entry)
-
-    # Embed live metrics in the card-expected shape (#26 / BE-METRICS): the
-    # dashboard reads slot.metrics.{toks,ttft,ctx,kv,mem}. Source the merged
-    # per-slot rows (upstream stats + local tps/ttft + child-port scrape) and
-    # remap to the frontend keys. Never fatal — absent rows leave the
-    # frontend's zero/null defaults in place.
-    try:
-        raw_metrics = await slot_metrics(request)
-    except Exception:
-        raw_metrics = {}
-    for entry in merged:
-        rm = raw_metrics.get(str(entry.get("name"))) or {}
-        kv = rm.get("kv_cache_usage")
-        ttft_s = rm.get("ttft_seconds")
-        entry["metrics"] = {
-            "toks": round(float(rm.get("tokens_per_sec") or 0), 1),
-            "ttft": round(float(ttft_s) * 1000) if ttft_s else None,
-            "ctx": int(rm.get("ctx") or 0),
-            "kv": round(float(kv) * 100, 1) if kv is not None else None,
-            "mem": round(float(entry.get("mem_mb") or 0) / 1024.0, 2),
-        }
-    return merged
+    return [view.to_dict() for view in await aggregator.snapshot()]
 
 
 def _next_free_slot_port(start: int = 8081, end: int = 8099) -> int:

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -1,0 +1,846 @@
+"""slot_view — stateless read-model aggregation for the slots dashboard (issue #698).
+
+``GET /api/slots`` used to inline five enrichment concerns in the route
+handler (``api/routes/slots.py:list_slots``): slot-state serialization,
+Lemonade ``/v1/health`` enrichment + backend-drift detection, container
+systemctl/port probing, per-slot memory accounting, and metric
+injection. Testing any one concern meant mocking five pieces of app
+state and calling the route over HTTP.
+
+This module lifts each concern into a named, directly-testable unit:
+
+  - :func:`serialize_slot` — Slot snapshot → wire dict.
+  - :func:`lemonade_enrichment` — pure: (configs, health) → per-slot
+    Lemonade-derived state incl. declared/actual backend drift.
+  - :func:`container_enrichment` — container slots' systemctl + /health
+    + image probes (provider injectable for tests).
+  - :func:`synthesize_upstream_entries` — virtual entries for configured
+    upstreams that have no local slot yet.
+  - :class:`SlotViewAggregator` — eager composition of all of the above;
+    ``snapshot()`` returns typed :class:`SlotView` records the route
+    serializes verbatim.
+
+The aggregator is **stateless** — constructor deps are stored, nothing
+is cached between ``snapshot()`` calls; the route constructs one per
+request. There are intentionally NO per-concern composition methods or
+``include_*`` flags: ``list_slots`` is the only caller today, so the
+eager one-shot ``snapshot()`` is the whole surface (design review on
+the issue).
+
+Device→backend translation comes from :mod:`hal0.model_meta`
+(:func:`hal0.model_meta.device_to_backend`) — no re-derived heuristics
+here. (``model_meta.classify`` is the designated classifier should a
+modality bucket ever be needed in this view; the current wire shape
+carries none.)
+
+NOTE: kept import-light, mirroring ``hal0.slot_config``. Heavy
+neighbours (``hal0.providers.*``, ``hal0.slots.manager``,
+``hal0.slots.capacity``, ``hal0.api.routes.models``) are imported
+lazily inside functions both to avoid import cycles (slots.manager is
+in this module's call graph and api.routes.slots imports us) and so
+route-level tests that monkeypatch those modules' attributes keep
+working unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from hal0.model_meta import device_to_backend
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "SlotMetricsView",
+    "SlotView",
+    "SlotViewAggregator",
+    "container_enrichment",
+    "fetch_lemonade_health",
+    "lemonade_enrichment",
+    "loaded_model_names",
+    "serialize_slot",
+    "synthesize_upstream_entries",
+]
+
+
+# ── typed records ────────────────────────────────────────────────────────────
+
+
+@dataclass(slots=True)
+class SlotMetricsView:
+    """Card-shaped live metrics for one slot (``slot.metrics.*`` on the wire)."""
+
+    toks: float = 0.0
+    ttft: int | None = None
+    ctx: int = 0
+    kv: float | None = None
+    mem: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "toks": self.toks,
+            "ttft": self.ttft,
+            "ctx": self.ctx,
+            "kv": self.kv,
+            "mem": self.mem,
+        }
+
+
+@dataclass(slots=True)
+class SlotView:
+    """One row of the ``GET /api/slots`` response, typed.
+
+    ``payload`` carries the enriched wire fields exactly as the legacy
+    inline dict built them (the enrichment key set is conditional —
+    ``backend_url`` / ``coresident_group`` / ``container_*`` / … appear
+    only when applicable, and the dashboard distinguishes absent from
+    null). The aggregator-owned stamps (``mem_mb``, ``metrics``) are
+    typed fields appended by :meth:`to_dict` in the legacy key order so
+    the response stays byte-identical.
+    """
+
+    name: str
+    kind: str
+    status: str
+    synthetic: bool
+    #: Resident memory attribution in MB. ``None`` on synthetic entries —
+    #: the legacy response omits the key there (they have no local cgroup).
+    mem_mb: float | int | None
+    metrics: SlotMetricsView
+    payload: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        out = dict(self.payload)
+        if self.mem_mb is not None:
+            out["mem_mb"] = self.mem_mb
+        out["metrics"] = self.metrics.to_dict()
+        return out
+
+
+# ── concern 1: slot-state serialization ──────────────────────────────────────
+
+
+def serialize_slot(slot: Any, model_cache: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Serialise a real Slot snapshot into the API shape.
+
+    Adds ``kind="local"`` so the UI can distinguish real slots from the
+    synthetic upstream-backed entries (which carry ``kind="remote"`` or
+    similar and ``_synthetic: true``).
+
+    When ``model_cache`` is provided (a ``{slot_name: [model, ...]}``
+    map), also includes a ``models`` list pulled from it. For an FLM
+    slot serving chat + embed + asr concurrently, this surfaces all
+    three tags so the dashboard can render the slot as multi-model
+    instead of showing only the chat tag. ``model_cache=None`` omits the
+    ``models`` key entirely (legacy ``_slot_to_dict(slot)`` behaviour).
+    """
+    base = slot.as_dict()
+    base["kind"] = "local"
+    base["status"] = slot.state.value
+    # Lift backend / provider out of metadata to the top level so the UI
+    # doesn't have to dig — the slot snapshot's `backend` is only set on
+    # transitions that pass it explicitly, but metadata carries both
+    # consistently after create / update_config.
+    meta = base.get("metadata") or {}
+    if not base.get("backend") and meta.get("backend"):
+        base["backend"] = meta.get("backend")
+    if not base.get("provider") and meta.get("provider"):
+        base["provider"] = meta.get("provider")
+    if model_cache is not None:
+        loaded = list(model_cache.get(slot.name, []))
+        if slot.model_id and slot.model_id in loaded:
+            loaded.remove(slot.model_id)
+            loaded.insert(0, slot.model_id)
+        base["models"] = loaded
+    return base
+
+
+# ── lemonade /v1/health access ───────────────────────────────────────────────
+
+
+async def fetch_lemonade_health() -> dict[str, Any]:
+    """``/v1/health`` from the installed Lemonade provider; ``{}`` on any error.
+
+    Never raises — a down lemond degrades enrichment to the on-disk view
+    rather than 500ing the dashboard hot path.
+    """
+    from hal0.lemonade.errors import LemonadeError
+    from hal0.providers import lemonade_provider
+
+    try:
+        health = await lemonade_provider().client().health()
+    except LemonadeError:
+        return {}
+    except Exception:
+        # Defensive: any error reading health degrades to "no enrichment".
+        return {}
+    return health if isinstance(health, dict) else {}
+
+
+def loaded_model_names(health: Any) -> set[str]:
+    """Model names lemond reports resident, from a ``/v1/health`` payload.
+
+    Walks both ``loaded`` and ``all_models_loaded`` (lemond emitted
+    either across versions). Junk entries are skipped.
+    """
+    names: set[str] = set()
+    if isinstance(health, dict):
+        for key in ("loaded", "all_models_loaded"):
+            entries = health.get(key)
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if isinstance(entry, dict):
+                    name = entry.get("model_name")
+                    if isinstance(name, str) and name:
+                        names.add(name)
+    return names
+
+
+def _loaded_by_model(health: Any) -> dict[str, dict[str, Any]]:
+    """Index ``/v1/health`` loaded entries by ``model_name``."""
+    loaded_by_model: dict[str, dict[str, Any]] = {}
+    if isinstance(health, dict):
+        for key in ("loaded", "all_models_loaded"):
+            entries = health.get(key)
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                name = entry.get("model_name")
+                if isinstance(name, str) and name:
+                    loaded_by_model[name] = entry
+    return loaded_by_model
+
+
+# ── concern 2: lemonade enrichment + drift detection ─────────────────────────
+
+
+def lemonade_enrichment(configs: list[dict[str, Any]], health: Any) -> dict[str, dict[str, Any]]:
+    """Per-slot Lemonade-derived state from slot configs + one health payload.
+
+    Pure given its inputs (modulo the per-loaded-entry child-process
+    introspection in ``resolve_actual_backend``): builds a
+    ``{slot_name: {lemonade_state, backend_url?, coresident_group?, …}}``
+    map. Container slots are skipped — they have their own enrichment
+    path (:func:`container_enrichment`) and must not get a bogus
+    ``lemonade_state="idle"`` from a lemond probe that has no knowledge
+    of the container.
+
+    Coresident grouping (ADR-0008 §5, plan §5.2):
+      A slot of type=llm + device=npu serving as the chat anchor and
+      any sibling ``stt-npu`` / ``embed-npu`` slots that are enabled
+      share a ``coresident_group=npu-flm-trio`` marker. The dashboard
+      uses this to render a "trio" badge linking the three cards.
+
+    Drift detection (B2 / ADR-0022): for loaded slots, surfaces
+    ``declared_backend`` (normalized from the configured ``device`` via
+    :func:`hal0.model_meta.device_to_backend`) against
+    ``actual_backend`` (child-process introspection) and a computed
+    ``backend_mismatch``. ``actual_backend``/``backend_mismatch`` are
+    OMITTED (not null) when the child can't be introspected.
+    """
+    from hal0.slots.manager import SlotManager
+
+    loaded_by_model = _loaded_by_model(health)
+
+    # First pass — pick out the NPU LLM slot(s) so we can decide if
+    # the trio is "active" (i.e. there IS an npu-llm slot enabled).
+    npu_llm_enabled: list[str] = [
+        str(cfg.get("name", ""))
+        for cfg in configs
+        if cfg.get("device") == "npu"
+        and cfg.get("type") == "llm"
+        and cfg.get("enabled") is not False
+    ]
+    trio_active = bool(npu_llm_enabled)
+
+    out: dict[str, dict[str, Any]] = {}
+    for cfg in configs:
+        name = str(cfg.get("name", ""))
+        if not name:
+            continue
+        # Container slots use a separate enrichment path (container_enrichment).
+        if SlotManager._is_container_slot(cfg):
+            continue
+        enabled = cfg.get("enabled") is not False
+        model_default = ""
+        model_labels: list[str] = []
+        model_section = cfg.get("model")
+        if isinstance(model_section, dict):
+            model_default = str(model_section.get("default") or "")
+            raw_labels = model_section.get("labels", ())
+            if isinstance(raw_labels, (list, tuple)):
+                model_labels = [str(x) for x in raw_labels]
+        entry: dict[str, Any] = {}
+
+        # PR-18: lift slot ``type`` + model ``labels`` + model ``default``
+        # + ``enabled`` so the dashboard's chat surface can build the
+        # persona dropdown (which chat-type slots are enabled?) and
+        # decide whether to opt in to OmniRouter (does the active
+        # persona's model carry the ``tool-calling`` label?) without
+        # making a second call to /api/slots/{name}/config per slot.
+        # The fields are purely additive — pre-PR-18 consumers ignore
+        # them.
+        slot_type = cfg.get("type")
+        if isinstance(slot_type, str) and slot_type:
+            entry["type"] = slot_type
+        if model_default:
+            entry["model_default"] = model_default
+        if model_labels:
+            entry["labels"] = model_labels
+        entry["enabled"] = enabled
+
+        # Spec 1 / Component 1: surface the three edit-panel config fields so
+        # the card + drawer seed their controls without a per-slot /config
+        # fetch. ``enable_thinking`` is tri-valued on disk (true/false/absent);
+        # absent → null (effective OFF). ``n_gpu_layers`` falls back to the
+        # ModelConfig default sentinel (-1 = all layers) when unset.
+        entry["enable_thinking"] = cfg.get("enable_thinking")
+        n_gpu = model_section.get("n_gpu_layers") if isinstance(model_section, dict) else None
+        entry["n_gpu_layers"] = n_gpu if isinstance(n_gpu, int) else -1
+        # Issue #548: expose rope_freq_base so the Edit drawer can dirty-track
+        # it and avoid clobbering the on-disk value on unrelated saves.
+        # Absent (None) is surfaced as-is — frontend treats null as "use
+        # model default" (0.0 sentinel) and only writes back when changed.
+        rope = model_section.get("rope_freq_base") if isinstance(model_section, dict) else None
+        entry["rope_freq_base"] = rope if isinstance(rope, (int, float)) else None
+
+        # Spec 1 / Component 2 (issue #587): surface idle_timeout_s,
+        # workers, and the slot's freeform llamacpp_args so the Edit
+        # drawer can seed from real on-disk values. The on-disk field
+        # for the freeform overlay is ``[server].extra_args``
+        # (ServerConfig); the dashboard's wire key is ``llamacpp_args``
+        # (matches the global lemond admin panel), so we map at this
+        # boundary. Defaults are NOT applied here — the wire payload is
+        # the truth source the dashboard uses to dirty-track changes,
+        # so an absent on-disk field surfaces as null/None, not the
+        # schema default.
+        entry["idle_timeout_s"] = cfg.get("idle_timeout_s")
+        entry["workers"] = cfg.get("workers")
+        server_cfg = cfg.get("server")
+        if server_cfg is None:
+            extra_args: Any = None
+        elif isinstance(server_cfg, dict):
+            extra_args = server_cfg.get("extra_args")
+        else:
+            # ServerConfig pydantic model — read via attribute to stay
+            # consistent with the .get() pattern above.
+            extra_args = getattr(server_cfg, "extra_args", None)
+        entry["llamacpp_args"] = extra_args
+
+        # [npu] table: expose asr/embed toggles for Lemonade-backed NPU slots.
+        # Raw TOML dict carries [npu] at the top level; also check
+        # extra["npu"] as a fallback for any validated-dump shape.
+        npu_table = cfg.get("npu") or (cfg.get("extra") or {}).get("npu")
+        if npu_table and isinstance(npu_table, dict):
+            entry["npu"] = {
+                "asr": bool(npu_table.get("asr")),
+                "embed": bool(npu_table.get("embed")),
+            }
+
+        loaded_entry = loaded_by_model.get(model_default) if model_default else None
+        if not enabled:
+            entry["lemonade_state"] = "disabled"
+        elif loaded_entry is not None:
+            entry["lemonade_state"] = "loaded"
+            backend_url = loaded_entry.get("backend_url")
+            if isinstance(backend_url, str) and backend_url:
+                entry["backend_url"] = backend_url
+            # B2: surface declared vs actual backend so the dashboard can
+            # render a drift warning. declared_backend is ALWAYS present for
+            # a configured slot (normalized token rocm|vulkan|cpu|flm, NOT
+            # the gpu- device form, so the UI compares like-for-like).
+            # actual_backend + backend_mismatch are OMITTED (not null) when
+            # the child can't be introspected. Do NOT read
+            # loaded_entry.get("backend") — that field does not exist.
+            from hal0.providers.lemonade import (
+                resolve_actual_backend as _resolve_actual_backend,
+            )
+
+            _recipe, _llamacpp = device_to_backend(cfg.get("device"))
+            declared_backend = _llamacpp or (_recipe if _recipe == "flm" else None)
+            if declared_backend:
+                entry["declared_backend"] = declared_backend
+            actual_backend = _resolve_actual_backend(loaded_entry)
+            if actual_backend:
+                entry["actual_backend"] = actual_backend
+                if declared_backend:
+                    entry["backend_mismatch"] = actual_backend != declared_backend
+        else:
+            # Enabled but not in loaded[]: idle by default. Drift into
+            # error is surfaced via the regular slot state (see
+            # SlotManager.status reconciliation); the dashboard uses
+            # ``status`` for the dot, ``lemonade_state`` for the chip.
+            entry["lemonade_state"] = "idle"
+
+        # Coresident grouping — every device=npu slot (anchor + stt/embed
+        # shadows) backs the same FLM process, so they share a group marker.
+        # Keyed on device, NOT slot name: deployment renamed the trio to
+        # npu/stt/embed, so the old name-based set never matched in prod. A
+        # slot only joins when (a) the NPU LLM anchor is enabled and (b) THIS
+        # slot is enabled — disabled siblings don't claim membership.
+        if cfg.get("device") == "npu" and trio_active and enabled:
+            entry["coresident_group"] = "npu-flm-trio"
+
+        out[name] = entry
+    return out
+
+
+# ── concern 3: container probe ───────────────────────────────────────────────
+
+
+def _resolve_container_provider(provider: Any) -> Any:
+    """Injected provider or the process-wide real one (lazy import)."""
+    if provider is not None:
+        return provider
+    from hal0.providers.container import container_provider
+
+    return container_provider()
+
+
+async def container_enrichment(
+    configs: list[dict[str, Any]],
+    *,
+    pull_jobs: dict[str, Any] | None = None,
+    provider: Any = None,
+) -> dict[str, dict[str, Any]]:
+    """Per-slot container state for container-backed slots.
+
+    For each slot where ``profile`` is set or ``runtime="container"``, probes
+    two live sources:
+      1. ``provider.is_active`` (systemctl) → ``container_status``
+         (``running`` | ``stopped`` | ``starting`` | ``crashed``)
+      2. GET /health on the slot port → ``container_health`` (bool)
+
+    plus image facts: ``actual_image`` (podman inspect, #663),
+    ``image_mismatch`` against the declared profile image, and
+    ``image_status`` (present | pulling | missing — an in-flight job in
+    ``pull_jobs`` wins without an inspect syscall).
+
+    ``provider`` is injectable for unit tests; ``None`` resolves the real
+    ContainerProvider lazily so route-level patches on the class keep
+    working. Never raises — probe failures degrade to ``stopped`` /
+    ``False`` rather than surfacing as a 500. Lemonade slots are
+    explicitly excluded.
+    """
+    from hal0.slots.manager import SlotManager, _cfg_port  # type: ignore[attr-defined]
+
+    jobs = pull_jobs or {}
+    out: dict[str, dict[str, Any]] = {}
+    for cfg in configs:
+        name = str(cfg.get("name", ""))
+        if not name:
+            continue
+        if not SlotManager._is_container_slot(cfg):
+            continue  # Lemonade / lemond slots handled by lemonade_enrichment
+
+        entry: dict[str, Any] = {}
+
+        try:
+            cp = _resolve_container_provider(provider)
+            # 1) systemctl is-active (synchronous — run in executor)
+            active = await asyncio.get_event_loop().run_in_executor(None, cp.is_active, name)
+            if active:
+                # 2) /health probe on the slot port to distinguish running vs starting
+                port = _cfg_port(cfg)
+                if port:
+                    health = await cp.health(port)
+                    container_health = bool(health.get("ok"))
+                    container_status = "running" if container_health else "starting"
+                else:
+                    container_health = False
+                    container_status = "running"
+            else:
+                container_health = False
+                # Distinguish crashed (failed) from clean stop by checking unit state
+                # via is-active exit codes: 0=active, 3=inactive, other=failed
+                container_status = "stopped"
+                try:
+                    import subprocess
+
+                    result = subprocess.run(
+                        ["systemctl", "is-active", f"hal0-slot@{name}.service"],
+                        capture_output=True,
+                        timeout=5,
+                    )
+                    stdout = result.stdout.decode().strip()
+                    if stdout == "failed":
+                        container_status = "crashed"
+                except Exception:
+                    pass
+        except Exception:
+            container_health = False
+            container_status = "stopped"
+
+        entry["container_status"] = container_status
+        entry["container_health"] = container_health
+
+        # [npu] table: expose asr/embed toggles so the dashboard can seed
+        # its NPU modality controls without a separate /config fetch.
+        # Raw TOML dict carries [npu] at the top level; also check
+        # extra["npu"] as a fallback for any validated-dump shape.
+        npu_table = cfg.get("npu") or (cfg.get("extra") or {}).get("npu")
+        if npu_table and isinstance(npu_table, dict):
+            entry["npu"] = {
+                "asr": bool(npu_table.get("asr")),
+                "embed": bool(npu_table.get("embed")),
+            }
+
+        # Emit runtime / profile / image so the UI doesn't have to dig
+        # into metadata, and resolved_command so the drawer can show the
+        # real podman argv instead of fabricating flags client-side.
+        entry["runtime"] = "container"
+        profile_name = str(cfg.get("profile") or "")
+        entry["profile"] = profile_name
+        image: str | None = None
+        if profile_name:
+            try:
+                from hal0.config.loader import load_profiles_config
+
+                catalog = load_profiles_config()
+                prof = catalog.profile.get(profile_name)
+                image = prof.image if prof else None
+                entry["image"] = image
+                # resolved_command = llama-server argv starting from the image
+                from hal0.providers.container import resolved_command_for_slot
+
+                entry["resolved_command"] = resolved_command_for_slot(cfg)
+            except Exception:
+                entry["image"] = None
+                entry["resolved_command"] = None
+        else:
+            entry["image"] = None
+            entry["resolved_command"] = None
+
+        # #663: deterministic backend-of-record - the running container's image
+        # IS the backend. Surface actual_image (via podman inspect) and compute
+        # image_mismatch against the slot's declared profile image. Replaces the
+        # fragile /proc actual_backend sniff for container slots (lemond slots
+        # keep resolve_actual_backend). Degrades silently - never 500 the hot path.
+        try:
+            from hal0.providers.container import _image_mismatch
+
+            cp = _resolve_container_provider(provider)
+            running_image = await asyncio.get_event_loop().run_in_executor(
+                None, cp.running_image, name
+            )
+        except Exception:
+            running_image = None
+        if running_image:
+            entry["actual_image"] = running_image
+            if image:
+                entry["image_mismatch"] = _image_mismatch(running_image, image)
+
+        # image_status: present | pulling | missing
+        # Check the pull-jobs registry first so an in-flight pull
+        # surfaces as "pulling" without an extra inspect syscall.
+        active_job = jobs.get(name)
+        if active_job is not None and getattr(active_job, "state", None) == "pulling":
+            entry["image_status"] = "pulling"
+        elif image:
+            try:
+                cp = _resolve_container_provider(provider)
+                present = await asyncio.get_event_loop().run_in_executor(
+                    None, cp.image_present, image
+                )
+                entry["image_status"] = "present" if present else "missing"
+            except Exception:
+                entry["image_status"] = "missing"
+        else:
+            entry["image_status"] = "missing"
+
+        out[name] = entry
+    return out
+
+
+# ── synthetic upstream entries ───────────────────────────────────────────────
+
+
+def synthesize_upstream_entries(
+    upstreams: Any,
+    model_cache: dict[str, Any],
+    last_used_model: dict[str, str],
+    loaded_models: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Build virtual slot entries from configured upstreams.
+
+    Until every upstream has a corresponding local slot, the dashboard
+    still needs to show remote-backed inference targets. Each upstream
+    surfaces as a read-only slot entry. ``status`` is computed by kind:
+
+      * local composite (``kind="slot"``) — ``serving`` only when one of
+        the upstream's advertised models appears in lemond's live loaded
+        set (``loaded_models``). The catalogue cache lists every configured
+        chat model, so it is NOT a liveness signal; consulting the loaded
+        set is what keeps the dashboard from showing evicted models as
+        resident. Falls back to the catalogue heuristic only when health
+        was unreadable (``loaded_models is None``).
+      * remote (``kind="remote"``) — ``serving`` when its model cache is
+        populated, since that cache is a live ``/v1/models`` probe of the
+        remote. ``offline`` otherwise.
+
+    The slot's ``model`` reflects the most recently dispatched model id
+    for this upstream (tracked in ``last_used_model``); falls back to
+    the first non-alias from the catalog before any inference has
+    happened.
+    """
+    out: list[dict[str, Any]] = []
+    for u in upstreams.list():
+        models = model_cache.get(u.name, [])
+        from hal0.api.routes.models import _is_alias  # local to avoid cycle
+
+        real_models = [m for m in models if not _is_alias(m)]
+        primary_model = (
+            last_used_model.get(u.name)
+            or (real_models[0] if real_models else "")
+            or (models[0] if models else "")
+        )
+        if u.kind == "slot":
+            # Local composite upstream: ``models`` comes from the slot
+            # CATALOGUE (config), so a non-empty list says nothing about
+            # what is resident. Truth comes from lemond's live loaded set.
+            # If health was unreadable (loaded_models is None) fall back to
+            # the catalogue heuristic rather than flapping to offline on a
+            # transient probe error.
+            serving = bool(models) if loaded_models is None else bool(set(models) & loaded_models)
+        else:
+            # Remote upstream: ``models`` is a live /v1/models probe of the
+            # remote, so a populated list is a genuine liveness signal.
+            serving = bool(models)
+        out.append(
+            {
+                "name": u.name,
+                "kind": u.kind,
+                "model": primary_model,
+                "status": "serving" if serving else "offline",
+                "backend": "remote" if u.kind == "remote" else "vulkan",
+                "provider": "remote-upstream" if u.kind == "remote" else "llama-server",
+                "url": u.url,
+                "advertised_models": len(models),
+                "last_used_model": last_used_model.get(u.name) or None,
+                "_synthetic": True,
+                "_synthetic_reason": (
+                    "Backed by remote upstream; install a local slot of the same name to take over."
+                ),
+            }
+        )
+    return out
+
+
+# ── default lemonade shim ────────────────────────────────────────────────────
+
+
+class _ProviderLemonadeShim:
+    """Default health source: the process-wide Lemonade provider singleton.
+
+    Resolved lazily per call (not at construction) so tests that swap
+    ``hal0.providers._PROVIDERS["lemonade"]`` see their stub.
+    """
+
+    async def health(self) -> dict[str, Any]:
+        return await fetch_lemonade_health()
+
+
+# ── the aggregator ───────────────────────────────────────────────────────────
+
+
+class SlotViewAggregator:
+    """Eagerly compose the full ``/api/slots`` read model.
+
+    Constructor deps mirror what the route used to pull off
+    ``request.app.state`` (plus the two provider seams), so tests inject
+    fakes instead of crossing HTTP:
+
+      - ``slot_manager`` — ``list()`` + ``iter_configs()``.
+      - ``registry`` — model registry handed to the capacity probe for
+        memory attribution (``app.state.model_registry``).
+      - ``metrics`` — async zero-arg callable returning the raw per-slot
+        metrics rows (the route passes a bound ``slot_metrics`` call).
+      - ``lemonade_shim`` — object with ``async health() -> dict``;
+        defaults to the process-wide Lemonade provider.
+      - ``container_provider`` — duck-typed ContainerProvider for the
+        container probe; defaults to the real one, lazily.
+      - ``model_cache`` / ``upstreams`` / ``last_used_model`` /
+        ``slot_pull_jobs`` — the remaining ``app.state`` reads
+        (serialization's multi-model list, synthetic upstream entries,
+        and the in-flight image-pull registry).
+
+    ``snapshot()`` is **eager** — one computation, no per-concern
+    composition methods, no ``include_*`` flags (single caller today;
+    see module docstring).
+    """
+
+    def __init__(
+        self,
+        slot_manager: Any,
+        registry: Any = None,
+        metrics: Callable[[], Awaitable[dict[str, Any]]] | None = None,
+        lemonade_shim: Any = None,
+        *,
+        container_provider: Any = None,
+        model_cache: dict[str, Any] | None = None,
+        upstreams: Any = None,
+        last_used_model: dict[str, str] | None = None,
+        slot_pull_jobs: dict[str, Any] | None = None,
+    ) -> None:
+        self._slot_manager = slot_manager
+        self._registry = registry
+        self._metrics = metrics
+        self._lemonade_shim = (
+            lemonade_shim if lemonade_shim is not None else _ProviderLemonadeShim()
+        )
+        self._container_provider = container_provider
+        self._model_cache = model_cache if model_cache is not None else {}
+        self._upstreams = upstreams
+        self._last_used_model = last_used_model if last_used_model is not None else {}
+        self._slot_pull_jobs = slot_pull_jobs if slot_pull_jobs is not None else {}
+
+    # ── snapshot ─────────────────────────────────────────────────────────
+
+    async def snapshot(self) -> list[SlotView]:
+        """One eager pass over every concern; returns typed rows in wire order.
+
+        Real SlotManager-backed entries first (manager order), then
+        synthetic upstream-backed ones for upstreams without a local
+        slot of the same name — real slots win on name collision.
+        """
+        real_slots = await self._slot_manager.list()
+        payloads: list[dict[str, Any]] = [
+            serialize_slot(s, model_cache=self._model_cache) for s in real_slots
+        ]
+        real_names = {str(p["name"]) for p in payloads}
+
+        # Single /v1/health probe shared by the lemonade enrichment AND the
+        # synthetic composite's loaded-set — calling once per concern would
+        # multiply lemond load on every dashboard refresh.
+        health = await self._safe_health()
+        configs = await self._safe_configs()
+
+        enrichment = lemonade_enrichment(configs, health)
+        c_enrichment = await container_enrichment(
+            configs,
+            pull_jobs=self._slot_pull_jobs,
+            provider=self._container_provider,
+        )
+        for payload in payloads:
+            slot_name = str(payload["name"])
+            extra = enrichment.get(slot_name)
+            if extra:
+                for k, v in extra.items():
+                    payload.setdefault(k, v)
+            c_extra = c_enrichment.get(slot_name)
+            if c_extra:
+                for k, v in c_extra.items():
+                    payload.setdefault(k, v)
+
+        # Per-slot resident memory (model weights + KV-cache estimate) so the
+        # dashboard memory map (W4) attributes a real footprint per slot. Only
+        # resident slots get a non-zero row; everything else reads 0. Never let
+        # a memory-probe failure break the slots list.
+        per_slot_mem = await self._safe_per_slot_mem(real_slots)
+        mem_by_name: dict[str, float | int] = {}
+        for payload in payloads:
+            slot_name = str(payload["name"])
+            row = per_slot_mem.get(slot_name)
+            mem_by_name[slot_name] = round(float(row.get("mem_mb", 0) or 0), 1) if row else 0
+
+        synthetic: list[dict[str, Any]] = []
+        if self._upstreams is not None:
+            synthetic = synthesize_upstream_entries(
+                self._upstreams,
+                self._model_cache,
+                self._last_used_model,
+                loaded_models=loaded_model_names(health),
+            )
+
+        raw_metrics = await self._safe_metrics()
+
+        views: list[SlotView] = []
+        for payload in payloads:
+            slot_name = str(payload.get("name"))
+            mem_mb = mem_by_name.get(slot_name, 0)
+            views.append(
+                SlotView(
+                    name=slot_name,
+                    kind=str(payload.get("kind", "")),
+                    status=str(payload.get("status", "")),
+                    synthetic=False,
+                    mem_mb=mem_mb,
+                    metrics=_metrics_view(raw_metrics, slot_name, mem_mb),
+                    payload=payload,
+                )
+            )
+        for entry in synthetic:
+            if entry["name"] in real_names:
+                continue
+            slot_name = str(entry.get("name"))
+            views.append(
+                SlotView(
+                    name=slot_name,
+                    kind=str(entry.get("kind", "")),
+                    status=str(entry.get("status", "")),
+                    synthetic=True,
+                    # Synthetic entries have no local cgroup — the legacy
+                    # response omits mem_mb there entirely.
+                    mem_mb=None,
+                    metrics=_metrics_view(raw_metrics, slot_name, 0),
+                    payload=entry,
+                )
+            )
+        return views
+
+    # ── never-raise dependency wrappers ──────────────────────────────────
+
+    async def _safe_health(self) -> dict[str, Any]:
+        try:
+            health = await self._lemonade_shim.health()
+        except Exception:
+            return {}
+        return health if isinstance(health, dict) else {}
+
+    async def _safe_configs(self) -> list[dict[str, Any]]:
+        try:
+            return list(await self._slot_manager.iter_configs())
+        except Exception:
+            return []
+
+    async def _safe_per_slot_mem(self, real_slots: list[Any]) -> dict[str, Any]:
+        try:
+            from hal0.slots import capacity
+
+            return await capacity.build_per_slot(real_slots, registry=self._registry)
+        except Exception:
+            return {}
+
+    async def _safe_metrics(self) -> dict[str, Any]:
+        if self._metrics is None:
+            return {}
+        try:
+            raw = await self._metrics()
+        except Exception:
+            return {}
+        return raw if isinstance(raw, dict) else {}
+
+
+def _metrics_view(raw_metrics: dict[str, Any], name: str, mem_mb: float | int) -> SlotMetricsView:
+    """Remap one raw metrics row to the card-expected shape (#26 / BE-METRICS).
+
+    The dashboard reads ``slot.metrics.{toks,ttft,ctx,kv,mem}``. Absent
+    rows leave the frontend's zero/null defaults in place.
+    """
+    rm = raw_metrics.get(name) or {}
+    kv = rm.get("kv_cache_usage")
+    ttft_s = rm.get("ttft_seconds")
+    return SlotMetricsView(
+        toks=round(float(rm.get("tokens_per_sec") or 0), 1),
+        ttft=round(float(ttft_s) * 1000) if ttft_s else None,
+        ctx=int(rm.get("ctx") or 0),
+        kv=round(float(kv) * 100, 1) if kv is not None else None,
+        mem=round(float(mem_mb or 0) / 1024.0, 2),
+    )

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -465,9 +465,7 @@ class TestContainerEnrichment:
 
 
 class TestMemoryAttribution:
-    async def test_mem_mb_stamped_from_capacity_rows(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_mem_mb_stamped_from_capacity_rows(self, monkeypatch: pytest.MonkeyPatch) -> None:
         async def fake_build(slots: Any, registry: Any = None, **kw: Any) -> dict[str, Any]:
             return {"chat": {"mem_mb": 1234.56}}
 
@@ -494,9 +492,7 @@ class TestMemoryAttribution:
         views = await agg.snapshot()
         assert views[0].mem_mb == 0
 
-    async def test_registry_passed_to_capacity_probe(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_registry_passed_to_capacity_probe(self, monkeypatch: pytest.MonkeyPatch) -> None:
         seen: dict[str, Any] = {}
 
         async def fake_build(slots: Any, registry: Any = None, **kw: Any) -> dict[str, Any]:

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -1,0 +1,662 @@
+"""Unit tests for hal0.slot_view — SlotViewAggregator + per-concern functions.
+
+Issue #698: each enrichment concern that used to live inline in
+``api/routes/slots.py:list_slots()`` gets a direct unit test against
+fake stores — no HTTP, no five-piece app-state mock:
+
+  1. slot-state serialization        → serialize_slot
+  2. lemonade enrichment + drift     → lemonade_enrichment
+  3. container systemctl/port probe  → container_enrichment
+  4. per-slot memory accounting      → SlotViewAggregator.snapshot
+  5. metric injection                → SlotViewAggregator.snapshot
+
+The /api/slots wire shape is pinned by the existing route-level suites
+(test_slots_routes / test_slots_lemonade_state / test_slots_container_state
+/ test_slots_npu_fields) which stay UNMODIFIED as the parity oracle.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from hal0.slot_view import (
+    SlotView,
+    SlotViewAggregator,
+    container_enrichment,
+    lemonade_enrichment,
+    loaded_model_names,
+    serialize_slot,
+    synthesize_upstream_entries,
+)
+from hal0.slots.manager import Slot
+from hal0.slots.state import SlotState
+
+# ── fakes ──────────────────────────────────────────────────────────────────
+
+
+class FakeSlotManager:
+    """Just enough surface for the aggregator: list() + iter_configs()."""
+
+    def __init__(
+        self,
+        slots: list[Slot] | None = None,
+        configs: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self._slots = slots or []
+        self._configs = configs or []
+
+    async def list(self) -> list[Slot]:
+        return self._slots
+
+    async def iter_configs(self) -> list[dict[str, Any]]:
+        return self._configs
+
+
+class FakeLemonadeShim:
+    """health() returns a canned payload — or raises when told to."""
+
+    def __init__(self, health: dict[str, Any] | None = None, raise_exc: bool = False) -> None:
+        self._health = health if health is not None else {}
+        self._raise = raise_exc
+
+    async def health(self) -> dict[str, Any]:
+        if self._raise:
+            raise RuntimeError("lemond down")
+        return self._health
+
+
+class FakeContainerProvider:
+    """Duck-typed stand-in for ContainerProvider (sync + async mix matches)."""
+
+    def __init__(
+        self,
+        active: bool = True,
+        healthy: bool = True,
+        running_image: str | None = None,
+        present: bool = True,
+        raise_exc: bool = False,
+    ) -> None:
+        self._active = active
+        self._healthy = healthy
+        self._running_image = running_image
+        self._present = present
+        self._raise = raise_exc
+
+    def is_active(self, slot_name: str) -> bool:
+        if self._raise:
+            raise RuntimeError("podman exploded")
+        return self._active
+
+    async def health(self, port: int) -> dict[str, Any]:
+        return {"ok": self._healthy}
+
+    def running_image(self, slot_name: str) -> str | None:
+        return self._running_image
+
+    def image_present(self, image: str) -> bool:
+        return self._present
+
+
+class FakeUpstreams:
+    def __init__(self, entries: list[SimpleNamespace]) -> None:
+        self._entries = entries
+
+    def list(self) -> list[SimpleNamespace]:
+        return self._entries
+
+
+def _slot(
+    name: str = "chat",
+    state: SlotState = SlotState.READY,
+    port: int = 8081,
+    model_id: str | None = "qwen3-4b",
+    backend: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Slot:
+    return Slot(
+        name,
+        state=state,
+        port=port,
+        model_id=model_id,
+        backend=backend,
+        metadata=metadata,
+    )
+
+
+def _agg(
+    sm: FakeSlotManager,
+    *,
+    metrics: Any = None,
+    shim: Any = None,
+    container: Any = None,
+    model_cache: dict[str, Any] | None = None,
+    upstreams: Any = None,
+    last_used: dict[str, str] | None = None,
+    pull_jobs: dict[str, Any] | None = None,
+    registry: Any = None,
+) -> SlotViewAggregator:
+    async def _no_metrics() -> dict[str, Any]:
+        return {}
+
+    return SlotViewAggregator(
+        sm,
+        registry=registry,
+        metrics=metrics or _no_metrics,
+        lemonade_shim=shim or FakeLemonadeShim(),
+        container_provider=container or FakeContainerProvider(active=False),
+        model_cache=model_cache if model_cache is not None else {},
+        upstreams=upstreams or FakeUpstreams([]),
+        last_used_model=last_used or {},
+        slot_pull_jobs=pull_jobs or {},
+    )
+
+
+@pytest.fixture
+def no_mem(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub out the capacity probe so snapshot() never touches systemd."""
+
+    async def fake_build(slots: Any, registry: Any = None, **kw: Any) -> dict[str, Any]:
+        return {}
+
+    monkeypatch.setattr("hal0.slots.capacity.build_per_slot", fake_build)
+
+
+# ── concern 1: slot-state serialization ────────────────────────────────────
+
+
+class TestSerializeSlot:
+    def test_basic_shape(self) -> None:
+        out = serialize_slot(_slot(), model_cache={})
+        assert out["name"] == "chat"
+        assert out["kind"] == "local"
+        assert out["status"] == "ready"
+        assert out["state"] == "ready"
+        assert out["port"] == 8081
+        assert out["model_id"] == "qwen3-4b"
+        assert out["models"] == []
+
+    def test_backend_and_provider_lifted_from_metadata(self) -> None:
+        out = serialize_slot(
+            _slot(backend=None, metadata={"backend": "vulkan", "provider": "lemonade"}),
+            model_cache={},
+        )
+        assert out["backend"] == "vulkan"
+        assert out["provider"] == "lemonade"
+
+    def test_explicit_backend_wins_over_metadata(self) -> None:
+        out = serialize_slot(
+            _slot(backend="rocm", metadata={"backend": "vulkan"}),
+            model_cache={},
+        )
+        assert out["backend"] == "rocm"
+
+    def test_models_orders_active_model_first(self) -> None:
+        out = serialize_slot(
+            _slot(model_id="b-model"),
+            model_cache={"chat": ["a-model", "b-model", "c-model"]},
+        )
+        assert out["models"] == ["b-model", "a-model", "c-model"]
+
+    def test_no_cache_omits_models_key(self) -> None:
+        out = serialize_slot(_slot(), model_cache=None)
+        assert "models" not in out
+
+
+# ── concern 2: lemonade enrichment + drift detection ───────────────────────
+
+
+def _llm_cfg(name: str = "chat", **over: Any) -> dict[str, Any]:
+    cfg: dict[str, Any] = {
+        "name": name,
+        "port": 8081,
+        "type": "llm",
+        "enabled": True,
+        "model": {"default": "qwen3-4b"},
+    }
+    cfg.update(over)
+    return cfg
+
+
+class TestLemonadeEnrichment:
+    def test_idle_when_enabled_and_not_loaded(self) -> None:
+        out = lemonade_enrichment([_llm_cfg()], {"loaded": []})
+        assert out["chat"]["lemonade_state"] == "idle"
+        assert "backend_url" not in out["chat"]
+
+    def test_disabled_wins_over_loaded(self) -> None:
+        health = {"loaded": [{"model_name": "qwen3-4b"}]}
+        out = lemonade_enrichment([_llm_cfg(enabled=False)], health)
+        assert out["chat"]["lemonade_state"] == "disabled"
+
+    def test_loaded_lifts_backend_url(self) -> None:
+        health = {"loaded": [{"model_name": "qwen3-4b", "backend_url": "http://127.0.0.1:8001"}]}
+        out = lemonade_enrichment([_llm_cfg()], health)
+        assert out["chat"]["lemonade_state"] == "loaded"
+        assert out["chat"]["backend_url"] == "http://127.0.0.1:8001"
+
+    def test_drift_detection_declared_vs_actual(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "hal0.providers.lemonade.resolve_actual_backend",
+            lambda entry: "rocm",
+        )
+        health = {"loaded": [{"model_name": "qwen3-4b", "backend_url": "http://127.0.0.1:8001"}]}
+        out = lemonade_enrichment([_llm_cfg(device="gpu-vulkan")], health)
+        e = out["chat"]
+        assert e["declared_backend"] == "vulkan"
+        assert e["actual_backend"] == "rocm"
+        assert e["backend_mismatch"] is True
+
+    def test_no_drift_when_backends_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "hal0.providers.lemonade.resolve_actual_backend",
+            lambda entry: "vulkan",
+        )
+        health = {"loaded": [{"model_name": "qwen3-4b", "backend_url": "http://127.0.0.1:8001"}]}
+        out = lemonade_enrichment([_llm_cfg(device="gpu-vulkan")], health)
+        assert out["chat"]["backend_mismatch"] is False
+
+    def test_actual_backend_omitted_when_unintrospectable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "hal0.providers.lemonade.resolve_actual_backend",
+            lambda entry: None,
+        )
+        health = {"loaded": [{"model_name": "qwen3-4b", "backend_url": "http://127.0.0.1:8001"}]}
+        out = lemonade_enrichment([_llm_cfg(device="gpu-vulkan")], health)
+        e = out["chat"]
+        assert "actual_backend" not in e
+        assert "backend_mismatch" not in e
+        assert e["declared_backend"] == "vulkan"
+
+    def test_container_slots_are_skipped(self) -> None:
+        out = lemonade_enrichment(
+            [_llm_cfg(name="gpu-chat", profile="vulkan-radv")],
+            {"loaded": []},
+        )
+        assert "gpu-chat" not in out
+
+    def test_coresident_group_for_npu_trio(self) -> None:
+        configs = [
+            _llm_cfg(name="agent", device="npu"),
+            {
+                "name": "stt-npu",
+                "device": "npu",
+                "type": "transcription",
+                "enabled": True,
+                "model": {"default": "whisper-v3"},
+            },
+        ]
+        out = lemonade_enrichment(configs, {"loaded": []})
+        assert out["agent"]["coresident_group"] == "npu-flm-trio"
+        assert out["stt-npu"]["coresident_group"] == "npu-flm-trio"
+
+    def test_no_coresident_group_without_enabled_anchor(self) -> None:
+        configs = [
+            {
+                "name": "stt-npu",
+                "device": "npu",
+                "type": "transcription",
+                "enabled": True,
+                "model": {"default": "whisper-v3"},
+            },
+        ]
+        out = lemonade_enrichment(configs, {"loaded": []})
+        assert "coresident_group" not in out["stt-npu"]
+
+    def test_config_fields_surfaced(self) -> None:
+        cfg = _llm_cfg(
+            enable_thinking=True,
+            idle_timeout_s=900,
+            workers=2,
+            server={"extra_args": "--flash-attn on"},
+            npu={"asr": True, "embed": False},
+        )
+        cfg["model"]["n_gpu_layers"] = 24
+        cfg["model"]["rope_freq_base"] = 10000.0
+        cfg["model"]["labels"] = ["tool-calling"]
+        out = lemonade_enrichment([cfg], {"loaded": []})
+        e = out["chat"]
+        assert e["type"] == "llm"
+        assert e["model_default"] == "qwen3-4b"
+        assert e["labels"] == ["tool-calling"]
+        assert e["enabled"] is True
+        assert e["enable_thinking"] is True
+        assert e["n_gpu_layers"] == 24
+        assert e["rope_freq_base"] == 10000.0
+        assert e["idle_timeout_s"] == 900
+        assert e["workers"] == 2
+        assert e["llamacpp_args"] == "--flash-attn on"
+        assert e["npu"] == {"asr": True, "embed": False}
+
+    def test_absent_config_fields_surface_as_defaults(self) -> None:
+        out = lemonade_enrichment([_llm_cfg()], {"loaded": []})
+        e = out["chat"]
+        assert e["enable_thinking"] is None
+        assert e["n_gpu_layers"] == -1
+        assert e["rope_freq_base"] is None
+        assert e["idle_timeout_s"] is None
+        assert e["workers"] is None
+        assert e["llamacpp_args"] is None
+        assert "npu" not in e
+
+
+# ── concern 3: container probe ──────────────────────────────────────────────
+
+
+def _container_cfg(name: str = "gpu-chat", **over: Any) -> dict[str, Any]:
+    cfg: dict[str, Any] = {
+        "name": name,
+        "port": 8088,
+        "type": "llm",
+        "runtime": "container",
+        "model": {"default": "llama-3b"},
+    }
+    cfg.update(over)
+    return cfg
+
+
+class TestContainerEnrichment:
+    async def test_running_and_healthy(self) -> None:
+        out = await container_enrichment(
+            [_container_cfg()],
+            pull_jobs={},
+            provider=FakeContainerProvider(active=True, healthy=True),
+        )
+        e = out["gpu-chat"]
+        assert e["container_status"] == "running"
+        assert e["container_health"] is True
+        assert e["runtime"] == "container"
+        assert e["profile"] == ""
+        assert e["image"] is None
+        assert e["resolved_command"] is None
+
+    async def test_active_but_unhealthy_is_starting(self) -> None:
+        out = await container_enrichment(
+            [_container_cfg()],
+            pull_jobs={},
+            provider=FakeContainerProvider(active=True, healthy=False),
+        )
+        assert out["gpu-chat"]["container_status"] == "starting"
+
+    async def test_active_without_port_is_running_unhealthy(self) -> None:
+        cfg = _container_cfg()
+        cfg["port"] = 0
+        out = await container_enrichment(
+            [cfg],
+            pull_jobs={},
+            provider=FakeContainerProvider(active=True, healthy=True),
+        )
+        e = out["gpu-chat"]
+        assert e["container_status"] == "running"
+        assert e["container_health"] is False
+
+    async def test_inactive_is_stopped(self) -> None:
+        out = await container_enrichment(
+            [_container_cfg()],
+            pull_jobs={},
+            provider=FakeContainerProvider(active=False),
+        )
+        e = out["gpu-chat"]
+        assert e["container_status"] == "stopped"
+        assert e["container_health"] is False
+
+    async def test_provider_failure_degrades_to_stopped(self) -> None:
+        out = await container_enrichment(
+            [_container_cfg()],
+            pull_jobs={},
+            provider=FakeContainerProvider(raise_exc=True),
+        )
+        e = out["gpu-chat"]
+        assert e["container_status"] == "stopped"
+        assert e["container_health"] is False
+
+    async def test_lemonade_slots_are_skipped(self) -> None:
+        out = await container_enrichment(
+            [_llm_cfg()],
+            pull_jobs={},
+            provider=FakeContainerProvider(),
+        )
+        assert out == {}
+
+    async def test_actual_image_surfaced(self) -> None:
+        out = await container_enrichment(
+            [_container_cfg()],
+            pull_jobs={},
+            provider=FakeContainerProvider(
+                active=True, healthy=True, running_image="ghcr.io/x/y:1"
+            ),
+        )
+        e = out["gpu-chat"]
+        assert e["actual_image"] == "ghcr.io/x/y:1"
+        # No declared image (no profile) → no mismatch verdict.
+        assert "image_mismatch" not in e
+
+    async def test_inflight_pull_job_wins_image_status(self) -> None:
+        job = SimpleNamespace(state="pulling")
+        out = await container_enrichment(
+            [_container_cfg()],
+            pull_jobs={"gpu-chat": job},
+            provider=FakeContainerProvider(active=False),
+        )
+        assert out["gpu-chat"]["image_status"] == "pulling"
+
+    async def test_no_image_means_missing_status(self) -> None:
+        out = await container_enrichment(
+            [_container_cfg()],
+            pull_jobs={},
+            provider=FakeContainerProvider(active=False),
+        )
+        assert out["gpu-chat"]["image_status"] == "missing"
+
+    async def test_npu_table_surfaced(self) -> None:
+        out = await container_enrichment(
+            [_container_cfg(npu={"asr": True, "embed": True})],
+            pull_jobs={},
+            provider=FakeContainerProvider(active=False),
+        )
+        assert out["gpu-chat"]["npu"] == {"asr": True, "embed": True}
+
+
+# ── concern 4: per-slot memory accounting ───────────────────────────────────
+
+
+class TestMemoryAttribution:
+    async def test_mem_mb_stamped_from_capacity_rows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_build(slots: Any, registry: Any = None, **kw: Any) -> dict[str, Any]:
+            return {"chat": {"mem_mb": 1234.56}}
+
+        monkeypatch.setattr("hal0.slots.capacity.build_per_slot", fake_build)
+        agg = _agg(FakeSlotManager(slots=[_slot()]))
+        views = await agg.snapshot()
+        assert views[0].mem_mb == 1234.6
+        assert views[0].to_dict()["mem_mb"] == 1234.6
+
+    async def test_mem_mb_zero_when_no_row(self, no_mem: None) -> None:
+        agg = _agg(FakeSlotManager(slots=[_slot()]))
+        views = await agg.snapshot()
+        assert views[0].mem_mb == 0
+        assert views[0].to_dict()["mem_mb"] == 0
+
+    async def test_capacity_probe_failure_never_breaks_snapshot(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def boom(slots: Any, registry: Any = None, **kw: Any) -> dict[str, Any]:
+            raise RuntimeError("cgroup probe exploded")
+
+        monkeypatch.setattr("hal0.slots.capacity.build_per_slot", boom)
+        agg = _agg(FakeSlotManager(slots=[_slot()]))
+        views = await agg.snapshot()
+        assert views[0].mem_mb == 0
+
+    async def test_registry_passed_to_capacity_probe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: dict[str, Any] = {}
+
+        async def fake_build(slots: Any, registry: Any = None, **kw: Any) -> dict[str, Any]:
+            seen["registry"] = registry
+            return {}
+
+        monkeypatch.setattr("hal0.slots.capacity.build_per_slot", fake_build)
+        marker = object()
+        agg = _agg(FakeSlotManager(slots=[_slot()]), registry=marker)
+        await agg.snapshot()
+        assert seen["registry"] is marker
+
+
+# ── concern 5: metric injection ─────────────────────────────────────────────
+
+
+class TestMetricInjection:
+    async def test_metrics_remapped_to_card_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def fake_build(slots: Any, registry: Any = None, **kw: Any) -> dict[str, Any]:
+            return {"chat": {"mem_mb": 2048.0}}
+
+        monkeypatch.setattr("hal0.slots.capacity.build_per_slot", fake_build)
+
+        async def fake_metrics() -> dict[str, Any]:
+            return {
+                "chat": {
+                    "tokens_per_sec": 22.84,
+                    "ttft_seconds": 0.1234,
+                    "ctx": 32768,
+                    "kv_cache_usage": 0.4567,
+                }
+            }
+
+        agg = _agg(FakeSlotManager(slots=[_slot()]), metrics=fake_metrics)
+        views = await agg.snapshot()
+        m = views[0].to_dict()["metrics"]
+        assert m == {
+            "toks": 22.8,
+            "ttft": 123,
+            "ctx": 32768,
+            "kv": 45.7,
+            "mem": 2.0,
+        }
+
+    async def test_absent_metrics_row_yields_defaults(self, no_mem: None) -> None:
+        agg = _agg(FakeSlotManager(slots=[_slot()]))
+        views = await agg.snapshot()
+        assert views[0].to_dict()["metrics"] == {
+            "toks": 0.0,
+            "ttft": None,
+            "ctx": 0,
+            "kv": None,
+            "mem": 0.0,
+        }
+
+    async def test_metrics_source_failure_never_breaks_snapshot(self, no_mem: None) -> None:
+        async def boom() -> dict[str, Any]:
+            raise RuntimeError("metrics path exploded")
+
+        agg = _agg(FakeSlotManager(slots=[_slot()]), metrics=boom)
+        views = await agg.snapshot()
+        assert views[0].to_dict()["metrics"]["toks"] == 0.0
+
+
+# ── synthetic upstream entries + composition ───────────────────────────────
+
+
+class TestSyntheticEntries:
+    def test_local_composite_serving_only_when_loaded(self) -> None:
+        upstreams = FakeUpstreams([SimpleNamespace(name="hal0", kind="slot", url="http://l")])
+        entries = synthesize_upstream_entries(
+            upstreams,
+            model_cache={"hal0": ["qwen3-4b"]},
+            last_used_model={},
+            loaded_models={"qwen3-4b"},
+        )
+        assert entries[0]["status"] == "serving"
+        entries = synthesize_upstream_entries(
+            upstreams,
+            model_cache={"hal0": ["qwen3-4b"]},
+            last_used_model={},
+            loaded_models=set(),
+        )
+        assert entries[0]["status"] == "offline"
+
+    def test_remote_serving_when_cache_populated(self) -> None:
+        upstreams = FakeUpstreams([SimpleNamespace(name="haloai", kind="remote", url="http://r")])
+        entries = synthesize_upstream_entries(
+            upstreams,
+            model_cache={"haloai": ["m-1"]},
+            last_used_model={"haloai": "m-1"},
+            loaded_models=set(),
+        )
+        e = entries[0]
+        assert e["status"] == "serving"
+        assert e["kind"] == "remote"
+        assert e["model"] == "m-1"
+        assert e["_synthetic"] is True
+
+
+class TestSnapshotComposition:
+    async def test_real_slots_win_over_synthetic_on_name_collision(self, no_mem: None) -> None:
+        upstreams = FakeUpstreams(
+            [
+                SimpleNamespace(name="chat", kind="slot", url="http://l"),
+                SimpleNamespace(name="haloai", kind="remote", url="http://r"),
+            ]
+        )
+        agg = _agg(
+            FakeSlotManager(slots=[_slot(name="chat")]),
+            upstreams=upstreams,
+            model_cache={"haloai": ["m-1"]},
+        )
+        views = await agg.snapshot()
+        names = [v.name for v in views]
+        assert names == ["chat", "haloai"]
+        assert views[0].synthetic is False
+        assert views[0].kind == "local"
+        assert views[1].synthetic is True
+
+    async def test_synthetic_view_omits_mem_mb(self, no_mem: None) -> None:
+        upstreams = FakeUpstreams([SimpleNamespace(name="haloai", kind="remote", url="http://r")])
+        agg = _agg(FakeSlotManager(), upstreams=upstreams, model_cache={"haloai": ["m-1"]})
+        views = await agg.snapshot()
+        payload = views[0].to_dict()
+        assert "mem_mb" not in payload
+        assert payload["metrics"]["mem"] == 0.0
+
+    async def test_real_view_key_order_ends_with_mem_then_metrics(self, no_mem: None) -> None:
+        agg = _agg(FakeSlotManager(slots=[_slot()]))
+        views = await agg.snapshot()
+        keys = list(views[0].to_dict().keys())
+        assert keys[-2:] == ["mem_mb", "metrics"]
+
+    async def test_lemonade_shim_failure_degrades_to_no_enrichment(self, no_mem: None) -> None:
+        agg = _agg(
+            FakeSlotManager(
+                slots=[_slot()],
+                configs=[_llm_cfg()],
+            ),
+            shim=FakeLemonadeShim(raise_exc=True),
+        )
+        views = await agg.snapshot()
+        # Health unreadable → slot still listed, enrichment degrades to idle.
+        assert views[0].to_dict()["lemonade_state"] == "idle"
+
+    async def test_snapshot_returns_typed_views(self, no_mem: None) -> None:
+        agg = _agg(FakeSlotManager(slots=[_slot()]))
+        views = await agg.snapshot()
+        assert all(isinstance(v, SlotView) for v in views)
+        v = views[0]
+        assert v.name == "chat"
+        assert v.status == "ready"
+        assert v.metrics.toks == 0.0
+
+    async def test_loaded_model_names_parses_both_health_keys(self) -> None:
+        health = {
+            "loaded": [{"model_name": "a"}],
+            "all_models_loaded": [{"model_name": "b"}, "junk", {"model_name": ""}],
+        }
+        assert loaded_model_names(health) == {"a", "b"}
+        assert loaded_model_names({}) == set()
+        assert loaded_model_names(None) == set()


### PR DESCRIPTION
Closes #698. Completes the 2026-06-11 architecture-review build order (#695 → #697 → #698); builds on model_meta (#700) and slot_config (#704).

## Summary

Lifts the five enrichment concerns inlined in `api/routes/slots.py:list_slots()` — state serialization, Lemonade `/v1/health` enrich + drift detection, container systemctl/port probe, per-slot memory attribution, metric injection — into the stateless `hal0.slot_view` module:

- **`SlotViewAggregator(slot_manager, registry, metrics, lemonade_shim, …)`** — constructor deps mirror what the route pulled off `app.state` (the real dependency set was wider than the four nominal stores: model_cache, upstreams, last_used_model, slot_pull_jobs — documented in the class docstring).
- **`snapshot() -> list[SlotView]` is eager** — one computation, no per-concern composition methods, no `include_*` flags (locked decision: single caller today; the seam gets added only when a second caller exists).
- **`SlotView` / `SlotMetricsView`** typed records replace the ad-hoc response dict; the route serializes via `to_dict()`.
- `list_slots()` is a thin adapter: wire deps off `app.state`, return `[v.to_dict() for v in await aggregator.snapshot()]`.
- Per-concern logic lives in module-level functions (`serialize_slot`, `lemonade_enrichment`, `container_enrichment`, `synthesize_upstream_entries`, …), each unit-tested with fake stores — no HTTP, no five-piece app-state mock.
- Helpers shared with other routes (`get_slot`'s per-card refresh, `routes/health.py`) stay in `slots.py` as request-bound adapters over the slot_view functions.

## Parity

**Existing route-level tests are completely untouched** and pass — they are the oracle that the `/api/slots` response shape is unchanged.

## Tests

- 41 new unit tests in `tests/slot_view/test_aggregator.py` (per-concern, fake stores).
- Full suite: 3151 passed / 6 skipped; only failures are the known load-sensitive environmental `tests/agents/test_hermes_provision*` family (fails on clean main too — tracked as motivation in #702).
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)