### PR TITLE
ci: bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/agent-shim-smoke.yml
+++ b/.github/workflows/agent-shim-smoke.yml
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload diagnostics on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agent-shim-smoke-logs
           path: |
@@ -111,7 +111,7 @@ jobs:
       issues: write
     steps:
       - name: Find or create tracking issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:

--- a/.github/workflows/bootstrap-parity.yml
+++ b/.github/workflows/bootstrap-parity.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout hal0
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run bootstrap-parity check
         id: parity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -38,7 +38,7 @@ jobs:
         # intermittently slow-fails (could-not-load-model-from-any-source) and
         # gated unrelated PRs (#442, #445). The model id is fixed, so a static
         # key caches once and restores forever (bump -vN to refresh).
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.fastembed-cache
           key: fastembed-bge-small-en-v1.5-v2
@@ -67,8 +67,8 @@ jobs:
       run:
         working-directory: ui
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm

--- a/.github/workflows/hermes-sdk-diff.yml
+++ b/.github/workflows/hermes-sdk-diff.yml
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout hal0
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -113,7 +113,7 @@ jobs:
           PY
 
       - name: Upload diff report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: hermes-sdk-diff
           path: hermes-sdk-diff.md
@@ -135,13 +135,13 @@ jobs:
 
     steps:
       - name: Download diff report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: hermes-sdk-diff
           path: .
 
       - name: Find or create tracking issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PINNED_SHORT: ${{ needs.diff.outputs.pinned }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,10 +19,10 @@ jobs:
       run:
         working-directory: ui
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm
@@ -35,7 +35,7 @@ jobs:
       # avoid the ~250 MB Chromium download on every PR.
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('ui/package-lock.json') }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload Playwright report (failures only)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: ui/playwright-report/
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload test-results (failures only)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: ui/test-results/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       # ── 0. Resolve tag + version ────────────────────────────────────────────
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -97,7 +97,7 @@ jobs:
 
       # ── 1. Build the UI bundle so the tarball includes ui-dist/ ─────────────
       - name: Setup Node 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm
@@ -164,7 +164,7 @@ jobs:
 
       # ── 3. cosign keyless-sign the tarball via GH Actions OIDC ──────────────
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: cosign sign-blob (keyless OIDC, legacy raw .sig + .crt)
         id: sign


### PR DESCRIPTION
GitHub deprecation: Node 20 actions get forced onto Node 24 starting **June 16, 2026** (warning currently printed in every CI run), with Node 20 removed from runners in September. All eight pinned actions move to their latest majors:

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| actions/cache | v4 | v5 |
| actions/setup-python | v5 | v6 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/github-script | v7 | v9 |
| sigstore/cosign-installer | v3 | v4 |

## Breaking-change audit

- **github-script v9**: `require('@actions/github')` no longer works inside `script:` blocks. Our two usages (`agent-shim-smoke.yml`, `hermes-sdk-diff.yml`) only use the injected `github`/`core` context and `require('fs')` (Node builtin) — unaffected.
- **upload/download-artifact v5–v8**: runtime bumps only, plus an opt-in `archive: false` feature in v7; defaults unchanged.
- **cosign-installer v4**: runtime bump; stays unpinned and the release flow already uses cosign 3.x flag plumbing (`--certificate` keyless verify).
- Runner minimum 2.327.1 (artifact v6+) — GitHub-hosted runners always satisfy this; no self-hosted runners in use.

## Validation coverage

This PR's CI validates `ci.yml` + `playwright.yml` directly. Not exercised by PR CI:
- `agent-shim-smoke.yml` / `hermes-sdk-diff.yml` / `bootstrap-parity.yml` — cron/dispatch; can be smoke-tested post-merge via `workflow_dispatch`.
- `release.yml` — tag-only; validated at the next release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)