### PR TITLE
feat: Phase D — ComfyUI img slot + exclusive GPU arbiter (lemonade-removal spec)

### DIFF
--- a/docs/superpowers/plans/2026-06-11-phase-d-comfyui-img-slot-gpu-arbiter.md
+++ b/docs/superpowers/plans/2026-06-11-phase-d-comfyui-img-slot-gpu-arbiter.md
@@ -1,0 +1,392 @@
+# Phase D: ComfyUI img Slot + Exclusive GPU Arbiter — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ComfyUI runs as the `img` podman container slot (`hal0-slot@img`), the SlotManager gains an exclusive GPU arbiter (LLM slots ⇄ img with drain, idle-restore, manual pin, 503+Retry-After), the #690 switchover API is re-implemented on the arbiter (shell scripts retired), and #599/#691 close.
+
+**Architecture:** `ComfyUIProvider` already has the full OpenAI→ComfyUI pipeline (`infer()`: build_workflow → POST /prompt → poll /history → GET /view) and a `container_spec()` — Phase D reconciles that spec with the live-validated kyuz0 deployment, wires `_spec_provider_for`, and adds a `GpuArbiter` owned by SlotManager that uses the existing `in_flight_count()`/`serving()` primitives to drain before stopping. The dispatcher's legacy img path-pin exists but its acceptance gate rejects container remotes (Rule 4 never sets `path_pinned`) — one-flag fix + tests.
+
+**Tech Stack:** Python 3.12/FastAPI/pydantic v2, podman+systemd, `kyuz0/amd-strix-halo-comfyui` (digest-pinned), React dashboard, pytest + γ-suite.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-lemonade-removal-container-switchover-design.md` §3 (img row), §7, §12-D.
+**Worktree:** `/home/halo/dev/wt-phase-d` (branch `feat/phase-d-comfyui-img-gpu-arbiter`, base 5ed8793). `.venv/bin/python -m pytest`. Commits `git commit -s`.
+
+**Verified facts (research 2026-06-11 — don't re-derive):**
+- `ComfyUIProvider` (`src/hal0/providers/comfyui.py`) is COMPLETE for translation: `infer()` (line 277) consumes `_hal0_model_class`/`_hal0_ckpt_filename` injected by the `/v1/images/generations` route (`api/routes/v1.py:1015`, curated entry → `curated.hf_file` as ckpt). `health()` probes `/system_stats`. Registry lookup happens at REQUEST time, not slot-load time — `SlotManager._resolve_model_info` (manager.py:2178) treats registry miss as non-fatal (returns `{_model_key, flm_tag}`), and `container_spec` ignores `model_info["path"]` except as a diagnostic env var. No registry precheck needed for slot load (unlike Phase C llama slots) — but the curated image entries (sdxl-turbo etc.) MUST resolve at request time (deploy precheck).
+- `container_spec()` (comfyui.py:172) does NOT match the live container. Live (docker inspect, CT105): image `kyuz0/amd-strix-halo-comfyui@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2` (RepoDigest verified pullable), cmd `bash -lc 'cd /opt/ComfyUI && exec python main.py --listen 0.0.0.0 --port 8188 --disable-mmap --bf16-vae --cache-none'`, mounts `/mnt/ai-models/comfyui/{models→/root/comfy-models, output, input, user, custom_nodes}` + `extra_model_paths.yaml` (ro), `--ipc=host --shm-size=8g`, `apparmor=unconfined seccomp=unconfined label=disable`, devices kfd+dri, group-add video+render, bridge net `-p 8188:8188`, restart `no`. The kyuz0 image has ComfyUI at `/opt/ComfyUI` (venv `/opt/venv`) — NOT `/app` as the provider's `_COMFYUI_APP_DIR` assumes. Models = 241 GB under `/mnt/ai-models/comfyui/models/`.
+- The "100%-CPU idle spin" from the handoff is NOT reproducible — the container exited (137, external kill via comfy-down.sh) 5h before research; flip-on-demand is its designed mode. No debugging task; D9 adds an idle-CPU assertion post-migration instead.
+- `_spec_provider_for` (providers/container.py:311): npu→FLM, tts/kokoro-cpu→Kokoro, comment "ComfyUI joins in Phase D". `_render_unit_from_spec` handles ContainerSpec→unit incl. `--publish=127.0.0.1:{port}` when `network_mode=""`; `extra_args` is the escape hatch (FLM uses it for `--ulimit memlock=-1`).
+- Dispatcher: `_IMAGE_PATHS` (proxy.py:49) → candidate "img" via Rule 4 but `path_pinned` is NOT set (unlike embed/tts/rerank rules) → the acceptance gate (proxy.py:184) REJECTS a container-remote img upstream. Rule 6 (`_IMAGE_NAME_PREFIXES` model-prefix → img) same gap. `_UPSTREAM_PATH_REWRITES` (router.py:175) exists (rerank precedent). `_default_for_path` (router.py:1074) has no image arm (falls to "chat" — harmless once path-pin works, but add the arm for Step-0 preemption symmetry).
+- Drain primitives EXIST: `SlotManager.in_flight_count(slot)` (manager.py:2033), `serving()` ctx-mgr + `_serving_count`/`_serving_lock` (manager.py:1995-2031, 282-283). `state()`/`is_ready_for_dispatch()` public (#696, manager.py:399-427, ready-set READY|SERVING|IDLE). 503 envelope precedent: `SlotLoading` (router.py:233) + `_build_loading_response` with `retry_after_s`.
+- #690 switchover (`api/routes/comfyui.py:373`): 202 + BackgroundTasks `_run_switch(mode)` → script pairs `_SWITCH_PAIRS` (line 54: stop-inference.sh/comfy-up.sh etc., live at `/mnt/ai-models/comfyui/control-scripts/`), gate `HAL0_COMFYUI_SWITCHOVER_ENABLED=1` (ON in CT105 api.env), `_switch` dict tracks `{active, target, error}`, busy-queue 409 + `force`, root-aware exec (sudoers grant unused — api runs as root). It does NOT drain LLM requests and does NOT unload GPU containers (= #691). Phase D replaces `_run_switch`'s script body with arbiter calls; the route contract (202/409/501 + status polling) is preserved so #686/#690 UI keeps working.
+- UI: `slots.jsx:1270-1294` tabs (Inference|Image Gen) → `ComfyuiPane` (`comfyui-pane.jsx`); `useComfyui`/`useComfyuiSwitchover` hooks (`useComfyui.ts`, endpoints `/api/comfyui/status|switchover`); `SwitchoverConfirm` (lines 188-269) with force-consent + 1.5s refetch poll. Banners: `primitives.jsx` `BANNER_CATALOG` (line 219+) + `useBanners()`. Drawer fixed-profile rendering for non-GPU classes already exists (slot-modals.jsx:769-787) — comfyui profile (`device_class="img"`) renders read-only automatically. Mock data `data.jsx:209` has an img slot entry; no comfyui status mock (pane falls back to `COMFYUI_FALLBACK`).
+- Schema: `_SLOT_PORT_MIN/MAX = 8081/8099` (schema.py:94-95, `ge`/`le` on `port`) — img needs 8188 (ComfyUI stock port; operator bookmarks + kyuz0 tooling assume it). No `type` literal validation (`type="image"` is free). `_VALID_DEVICES` has gpu-rocm. `comfyui` already in `_VALID_PROVIDERS` (#682). `ProfileConfig.device_class` accepts `"img"` (reserved, unused). manifest.json HAS a `comfyui` entry but pinned to the unpublished `ghcr.io/hal0ai/hal0-toolbox-comfyui:v1` — Phase D repoints it at the live-validated kyuz0 digest; `manifest_image_ref("comfyui")` (loader.py:657) already feeds `ComfyUIProvider.image_ref` (priority: slot override → env → manifest → default tag).
+- `installer/etc-hal0/slots/img.toml` is the OLD lazy-load shape (provider=comfyui, port 8186, backend=rocm, no runtime/profile); img NOT in the install.sh seed loop (install.sh:961). Seed tests: `tests/config/test_schema.py::TestSeededSlotTomls` validates ALL seed TOMLs against `_VALID_PROVIDERS`; per-phase seed tests in `test_schema_npu.py` / `test_schema_seeds_c5.py`.
+- Issues folding in: **#599** → `[image]` section in img.toml (defaults persisted). **#691** → arbiter unloads GPU containers on switch-to-img (root cause of the GTT-resident defect). #687/#649 remain Phase E — do not touch `lemonade_proxy.py` fall-through or omni-router classification.
+
+---
+
+### Task D1: Schema + seeds — comfyui profile, manifest repin, port range, img.toml, `[image]` section (#599)
+
+**Files:**
+- Modify: `src/hal0/config/schema.py` (SEED_PROFILES ~589, `_SLOT_PORT_MAX` ~95, SlotConfig — new optional `image` section model)
+- Modify: `manifest.json` (comfyui entry)
+- Modify: `installer/etc-hal0/profiles.toml` (comfyui profile parity)
+- Rewrite: `installer/etc-hal0/slots/img.toml`
+- Modify: `installer/install.sh:961` (seed loop gains `img`)
+- Test: `tests/config/test_schema_seeds_d1.py` (create)
+
+- [ ] **Step 1: failing tests**
+
+```python
+# tests/config/test_schema_seeds_d1.py  (mirror test_schema_seeds_c5.py fixtures)
+def test_comfyui_seed_profile() -> None:
+    p = SEED_PROFILES["comfyui"]
+    assert p["device_class"] == "img"
+    assert "kyuz0/amd-strix-halo-comfyui" in p["image"]
+
+
+def test_seed_img_toml_validates(seed_slot_toml) -> None:
+    cfg = seed_slot_toml("img")          # parses via SlotConfig
+    assert cfg.runtime == "container"
+    assert cfg.profile == "comfyui"
+    assert cfg.provider == "comfyui"
+    assert cfg.port == 8188
+    assert cfg.device == "gpu-rocm"
+    assert cfg.image_gen.idle_restore_minutes == 5      # #599 section
+
+
+def test_port_range_admits_comfyui_stock_port() -> None:
+    # 8188 is ComfyUI's well-known port; range widened 8099 → 8200 for it.
+    SlotConfig(name="x", port=8188)      # no ValidationError
+
+
+def test_image_gen_section_defaults() -> None:
+    s = ImageGenConfig()
+    assert (s.idle_restore_minutes, s.default_size, s.default_steps) == (5, "1024x1024", 0)
+
+
+def test_manifest_comfyui_pinned_to_kyuz0() -> None:
+    ref = manifest_image_ref("comfyui")
+    assert ref == (
+        "docker.io/kyuz0/amd-strix-halo-comfyui"
+        "@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2"
+    )
+```
+
+- [ ] **Step 2:** run → KeyError/ValidationError/FileNotFoundError.
+- [ ] **Step 3: implement.**
+  - `_SLOT_PORT_MAX = 8200` (update the line-93 comment: "slots get 8081-8099; 8188 = ComfyUI's stock port for the img slot — kept well-known so operator bookmarks/tooling keep working").
+  - `ImageGenConfig(BaseModel)`: `idle_restore_minutes: int = Field(default=5, ge=0)` (0 = never auto-restore), `default_size: str = "1024x1024"`, `default_steps: int = Field(default=0, ge=0)` (0 = model-class default). Docstring cites #599. SlotConfig gains `image_gen: ImageGenConfig = Field(default_factory=ImageGenConfig, alias="image")` — TOML section `[image]` (alias, since `image` the string field may exist for container override — CHECK: if `SlotConfig.image` already exists as a str override field, name the section `[image_gen]` in TOML instead and skip the alias; pick whichever avoids the collision and assert it in the test).
+  - `SEED_PROFILES["comfyui"] = {"image": "docker.io/kyuz0/amd-strix-halo-comfyui:latest", "flags": "--disable-mmap --bf16-vae --cache-none", "mtp": False, "device_class": "img"}` + mirror in installer profiles.toml. (Provider resolves the DIGEST via manifest; the profile carries the human-readable tag + the bench-validated ComfyUI flags, consumed by `container_spec` in D2.)
+  - manifest.json comfyui entry → `{"tag": "docker.io/kyuz0/amd-strix-halo-comfyui:latest", "digest": "sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2", "_notes": "live-validated on CT105 2026-06-11 (Wan2.2/Qwen-Image/Flux/SDXL on gfx1151); repinned from unpublished hal0-toolbox-comfyui (Phase D)"}`.
+  - img.toml rewrite:
+
+```toml
+# hal0 image-generation slot — ComfyUI in a podman container (hal0-slot@img).
+# Exclusive-GPU slot: the GpuArbiter stops LLM GPU slots while img runs and
+# restores them after [image].idle_restore_minutes with no jobs (spec §7).
+
+name = "img"
+type = "image"
+provider = "comfyui"
+device = "gpu-rocm"
+runtime = "container"
+profile = "comfyui"
+enabled = true
+port = 8188
+
+[model]
+default = "sdxl-turbo"
+
+[image]                       # persisted image-gen settings (#599)
+idle_restore_minutes = 5
+default_size = "1024x1024"
+default_steps = 0
+```
+
+  - install.sh seed loop: `for seed_slot in npu tts rerank utility img`.
+- [ ] **Step 4:** `.venv/bin/python -m pytest tests/config -q` green + `bash -n installer/install.sh`.
+- [ ] **Step 5:** `git commit -s -m "feat(config): comfyui seed profile + img slot seed + [image] settings (#599)"`
+
+---
+
+### Task D2: ComfyUIProvider live-parity `container_spec` + `_spec_provider_for` img arm
+
+**Files:**
+- Modify: `src/hal0/providers/comfyui.py` (`container_spec`, constants)
+- Modify: `src/hal0/providers/container.py` (`_spec_provider_for` ~311)
+- Test: `tests/providers/test_comfyui_container_spec.py` (create; mirror `test_container_*` patterns), extend the `_spec_provider_for` dispatch test
+
+- [ ] **Step 1: failing tests**
+
+```python
+def test_comfyui_spec_matches_live_deployment(monkeypatch) -> None:
+    # base dir mounts redirected via monkeypatched _COMFYUI_DATA_ROOT or tmp dirs as siblings do
+    spec = ComfyUIProvider().container_spec(_IMG_CFG, {})
+    assert spec.devices and "/dev/kfd" in spec.devices            # via resolve_gpu_device_paths
+    assert ("/mnt/ai-models/comfyui/models", "/root/comfy-models") in spec.mounts
+    for sub in ("output", "input", "user", "custom_nodes"):
+        assert (f"/mnt/ai-models/comfyui/{sub}", f"/opt/ComfyUI/{sub}") in spec.mounts
+    assert any("extra_model_paths.yaml" in src for src, _ in spec.mounts)
+    assert "--ipc=host" in spec.extra_args and "--shm-size=8g" in spec.extra_args
+    assert set(spec.security_opt) == {"seccomp=unconfined", "apparmor=unconfined", "label=disable"}
+    assert spec.network_mode == "host"          # LXC = the host; web UI stays on :8188 LAN-reachable
+    assert spec.command[-1].endswith("--cache-none")  # profile flags flow into argv
+
+
+def test_comfyui_argv_uses_opt_comfyui_workdir() -> None:
+    spec = ComfyUIProvider().container_spec(_IMG_CFG, {})
+    # kyuz0 image: app at /opt/ComfyUI, venv /opt/venv — argv must cd there
+    assert spec.command[:2] == ["bash", "-lc"]
+    assert "/opt/ComfyUI" in spec.command[2] and "--port 8188" in spec.command[2]
+
+
+def test_spec_provider_for_dispatches_comfyui() -> None:
+    assert isinstance(_spec_provider_for({"provider": "comfyui", "type": "image"}), ComfyUIProvider)
+    assert isinstance(_spec_provider_for({"profile": "comfyui"}), ComfyUIProvider)
+```
+
+- [ ] **Step 2:** run → mounts/extra_args mismatch, dispatch returns None.
+- [ ] **Step 3: implement.**
+  - Rework `container_spec` to the live shape: data root constant `_COMFYUI_DATA_ROOT = "/mnt/ai-models/comfyui"` (override via `HAL0_COMFYUI_DATA_ROOT` env for tests/other installs); mounts per the test; devices via `resolve_gpu_device_paths()` (NOT the bare `["/dev/kfd", "/dev/dri"]` — podman needs explicit nodes, same fix as #674); `extra_args=["--ipc=host", "--shm-size=8g"]` (Wan/Hunyuan video need the shm); `label=disable` added to security_opt; command = `["bash", "-lc", f"cd /opt/ComfyUI && exec python main.py --listen 0.0.0.0 --port {port} {profile_flags}"]` where `profile_flags` come from the slot's resolved profile `flags` (read how llama_server's `_render_unit` pulls profile flags and mirror the lookup; fallback to the D1 defaults when no profile). Update `_COMFYUI_APP_DIR = "/opt/ComfyUI"` + module docstring (image is kyuz0, not hal0-toolbox). Keep `network_mode="host"` (document: LXC is the host, ComfyUI web UI must stay LAN-reachable on :8188, matches pre-migration behavior; `--publish` not emitted for host mode — verify `_render_unit_from_spec` skips publish when host, it does).
+  - `_spec_provider_for`: add arm before the return — `if str(slot_cfg.get("provider", "")) == "comfyui" or str(slot_cfg.get("profile", "")) == "comfyui" or str(slot_cfg.get("type", "")) == "image": return ComfyUIProvider()` (lazy import, mirror FLM/Kokoro arms). Update its docstring.
+- [ ] **Step 4:** `.venv/bin/python -m pytest tests/providers -q` green.
+- [ ] **Step 5:** `git commit -s -m "feat(providers): ComfyUI container_spec live-parity (kyuz0) + spec-provider dispatch"`
+
+---
+
+### Task D3: Dispatcher — img path-pin container acceptance + image default arm
+
+**Files:**
+- Modify: `src/hal0/dispatcher/proxy.py` (Rules 4 + 6)
+- Modify: `src/hal0/dispatcher/router.py` (`_default_for_path` ~1074)
+- Test: extend `tests/dispatcher/test_image_routing.py`
+
+- [ ] **Step 1: failing tests**
+
+```python
+def test_image_path_accepts_container_remote() -> None:
+    # upstream kind="remote" slot_name="img" registered (how container slots register, #656)
+    # resolve_slot("/v1/images/generations") → that upstream, no LegacyResolutionFailed
+def test_image_model_prefix_accepts_container_remote() -> None:
+    # body {"model": "sdxl-turbo"}, path /v1/chat-agnostic → candidate img, remote accepted
+def test_genuine_external_remote_still_rejected() -> None:
+    # kind="remote" slot_name=None for img path → LegacyResolutionFailed (unchanged)
+def test_default_for_path_images() -> None:
+    # router._default_for_path("/v1/images/generations") == "img"
+```
+
+- [ ] **Step 2:** run → LegacyResolutionFailed / "chat".
+- [ ] **Step 3: implement.** Rule 4: add `path_pinned = True` (comment: img is a container slot post-Phase-D — same acceptance as embed/tts/rerank). Rule 6 (model-prefix): also set `path_pinned = True` with a comment that the flag means "deterministically pinned" (the curated `sdxl-`/`flux-` prefixes are exact catalogue prefixes, not guesses — same trust level as a path pin; rename the variable to `pinned` ONLY if the diff stays mechanical). `_default_for_path`: insert `if "/images/" in path: return _IMAGE_DEFAULT` with `_IMAGE_DEFAULT = "img"` next to the other defaults.
+- [ ] **Step 4:** `.venv/bin/python -m pytest tests/dispatcher -q -p no:randomly` green.
+- [ ] **Step 5:** `git commit -s -m "feat(dispatcher): img container-remote acceptance + image path default"`
+
+---
+
+### Task D4: GpuArbiter core (RISKY — Opus review gate)
+
+**Files:**
+- Create: `src/hal0/slots/arbiter.py`
+- Modify: `src/hal0/slots/manager.py` (own a `GpuArbiter` instance, expose `self.arbiter`; construct with the manager + `idle_restore_minutes` read from the img slot config when present)
+- Test: `tests/slots/test_gpu_arbiter.py` (create)
+
+Design (spec §7, locked): exclusive groups derived not declared — `gpu_exclusive_group(slot_cfg) -> Literal["llm","img"] | None`: GPU device (`gpu-rocm`/`gpu-vulkan`) + `runtime=="container"` → `"img"` if provider/profile/type is comfyui/image else `"llm"`; everything else None (npu/cpu slots never arbitrated). Arbiter state persisted to `/var/lib/hal0/gpu_arbiter.json` (`{"mode", "pinned", "saved_llm_slots", "last_img_activity"}`) so an api restart mid-image-mode can still restore the LLM set.
+
+- [ ] **Step 1: failing tests** (fake SlotManager: dict-driven `state()`/`in_flight_count()`/`load()`/`unload()` recorders — mirror how existing manager tests stub):
+
+```python
+def test_group_derivation() -> None:
+    assert gpu_exclusive_group({"device": "gpu-rocm", "runtime": "container", "provider": "comfyui"}) == "img"
+    assert gpu_exclusive_group({"device": "gpu-vulkan", "runtime": "container"}) == "llm"
+    assert gpu_exclusive_group({"device": "npu", "runtime": "container"}) is None
+    assert gpu_exclusive_group({"device": "gpu-rocm", "runtime": "lemonade"}) is None
+
+async def test_ensure_img_drains_then_stops_then_starts(fake_mgr, tmp_path) -> None:
+    # chat+agent running (READY), in_flight: chat 2→1→0 across polls
+    # ensure_img(): unload NOT called until in_flight hits 0; order = drain → unload llm → load img
+    # saved_llm_slots == {"chat", "agent"}; state file written; mode == IMG
+
+async def test_ensure_img_noop_when_already_img(fake_mgr, tmp_path) -> None: ...
+async def test_drain_timeout_proceeds(fake_mgr, tmp_path) -> None:
+    # in_flight stuck at 1 → after DRAIN_TIMEOUT_S (patch to 0.1) unload proceeds + warning logged
+
+async def test_restore_llm_reloads_saved_set(fake_mgr, tmp_path) -> None:
+    # mode IMG, saved {chat, agent} → restore_llm(): img unloaded first, then both loaded; mode LLM; file updated
+
+async def test_restore_blocked_when_pinned_unless_force(fake_mgr, tmp_path) -> None: ...
+async def test_state_survives_restart(fake_mgr, tmp_path) -> None:
+    # new GpuArbiter over an existing state file → mode/saved set recovered
+
+def test_guard_llm_dispatch_raises_in_img_mode(fake_mgr, tmp_path) -> None:
+    # mode IMG → guard("chat") raises GpuImageMode (503, code "gpu.image_mode",
+    # details carry retry_after_s); guard("npu") passes; mode LLM → all pass
+```
+
+- [ ] **Step 2:** run → ImportError.
+- [ ] **Step 3: implement** `arbiter.py` (~200 lines):
+
+```python
+class GpuMode(str, Enum):
+    LLM = "llm"
+    IMG = "img"
+
+class GpuImageMode(Hal0Error):
+    """LLM dispatch refused — the GPU is in exclusive image mode."""
+    code = "gpu.image_mode"
+    status = 503
+
+_DRAIN_TIMEOUT_S = 120.0
+_DRAIN_POLL_S = 0.5
+
+class GpuArbiter:
+    def __init__(self, manager, *, state_path: Path, idle_restore_minutes: int = 5) -> None: ...
+    # mode / pinned / saved_llm_slots properties (read persisted state lazily)
+    async def ensure_img(self, *, pin: bool = False) -> None:
+        # single asyncio.Lock around the whole switch (no concurrent flips);
+        # snapshot running llm-group slots via manager slot configs + is_ready_for_dispatch;
+        # drain: while any(manager.in_flight_count(s) for s in llm) and not timeout: sleep(_DRAIN_POLL_S)
+        # for s in llm: await manager.unload(s)
+        # await manager.load("img", <img cfg [model].default>)
+        # persist; touch activity
+    async def restore_llm(self, *, force: bool = False) -> None:
+        # pinned and not force → GpuImageMode-shaped 409? NO — raise ArbiterPinned (409, code "gpu.pinned")
+        # unload img → reload saved set → persist; mode → LLM
+    def guard_llm_dispatch(self, slot_name: str) -> None: ...
+    def touch_img_activity(self) -> None: ...      # stamps last_img_activity + persists (cheap json)
+    def set_pin(self, pinned: bool) -> None: ...
+    def status(self) -> dict: ...                  # {"mode","pinned","saved_llm_slots","idle_restore_at"}
+```
+
+  Manager wiring: lazy `@property arbiter` constructing on first use (state path under the same var-lib root the manager already resolves; `idle_restore_minutes` from the img slot's `[image]` section when the slot config loads, default 5). Slot-config access for group derivation: reuse whatever the manager already holds for slot configs (read how `unload`/`load` fetch cfg — do NOT add a new config loader).
+- [ ] **Step 4:** `.venv/bin/python -m pytest tests/slots -q` green.
+- [ ] **Step 5:** `git commit -s -m "feat(slots): GpuArbiter — exclusive llm/img GPU groups with drain + persistence"`
+
+---
+
+### Task D5: Dispatch integration — auto-switch on image requests, 503 guard for LLM
+
+**Files:**
+- Modify: `src/hal0/api/routes/v1.py` (images route ~1015: `await arbiter.ensure_img()` before dispatch + `touch_img_activity()` start AND finish — long Wan jobs must keep the window open)
+- Modify: `src/hal0/dispatcher/router.py` (guard hook in `_check_slot_ready_for_dispatch` or its caller: `arbiter.guard_llm_dispatch(call.slot_name)` BEFORE the readiness check, so the 503 carries the image-mode envelope not slot.loading; Retry-After from `idle_restore_at` remaining seconds, floor 15)
+- Test: `tests/dispatcher/test_arbiter_dispatch.py` (create) + extend `tests/api/test_images_route*` if present
+
+- [ ] **Step 1: failing tests:**
+
+```python
+async def test_image_request_triggers_switch() -> None:
+    # mode LLM, img offline, POST /v1/images/generations (mock provider.infer)
+    # → arbiter.ensure_img awaited (chat unloaded, img loaded) → 200
+async def test_llm_request_in_img_mode_503_retry_after() -> None:
+    # mode IMG → /v1/chat/completions → 503, body code "gpu.image_mode",
+    # Retry-After header present and >= 15
+async def test_npu_and_cpu_slots_unaffected_in_img_mode() -> None:
+    # tts/npu/embed dispatch passes while mode IMG
+async def test_img_activity_touched_on_completion() -> None: ...
+```
+
+- [ ] **Step 2:** run → no switch / 200s.
+- [ ] **Step 3: implement.** Wire the two hooks. Error→HTTP mapping: confirm `Hal0Error.status` 503 propagates with headers — read how `SlotLoading.details.retry_after_s` becomes the Retry-After header today and reuse that exact mechanism for `GpuImageMode` (if it's response-shaping in an exception handler, add the new code there — no parallel plumbing).
+- [ ] **Step 4:** `.venv/bin/python -m pytest tests/dispatcher tests/api -q -p no:randomly` green.
+- [ ] **Step 5:** `git commit -s -m "feat(dispatcher): auto img switch on image requests + gpu.image_mode 503 guard"`
+
+---
+
+### Task D6: Idle-restore loop
+
+**Files:**
+- Modify: `src/hal0/slots/arbiter.py` (`run_idle_loop()` async task) + `src/hal0/slots/manager.py` or app lifespan (start/stop the task — find where the api app starts manager-owned background tasks today; if none exists, the FastAPI lifespan in `create_app` is the home, mirror an existing lifespan task)
+- Test: extend `tests/slots/test_gpu_arbiter.py`
+
+- [ ] **Step 1: failing tests:**
+
+```python
+async def test_idle_restore_fires_after_window(fake_mgr, tmp_path) -> None:
+    # mode IMG, last activity > window (patch window to 0.05s, loop interval 0.01)
+    # → restore_llm called once; loop keeps running; mode LLM
+async def test_idle_restore_skipped_when_pinned(fake_mgr, tmp_path) -> None: ...
+async def test_idle_restore_skipped_when_window_zero(fake_mgr, tmp_path) -> None:
+    # idle_restore_minutes=0 → never auto-restores
+async def test_in_flight_img_job_defers_restore(fake_mgr, tmp_path) -> None:
+    # manager.in_flight_count("img") > 0 → window not consumed (long video render)
+```
+
+- [ ] **Step 2-3:** implement `run_idle_loop` (30s interval constant, patchable; checks mode==IMG, not pinned, window>0, `in_flight_count("img")==0`, elapsed>window → `await restore_llm()`; exceptions logged, loop never dies). Start in lifespan, cancel on shutdown.
+- [ ] **Step 4:** `.venv/bin/python -m pytest tests/slots -q` green.
+- [ ] **Step 5:** `git commit -s -m "feat(slots): arbiter idle-restore loop (default 5 min, pin-aware)"`
+
+---
+
+### Task D7: API — switchover route on the arbiter (scripts retired), status + pin
+
+**Files:**
+- Modify: `src/hal0/api/routes/comfyui.py` (`_run_switch`, `_SWITCH_PAIRS` deleted; body gains `pin`; new `POST /api/comfyui/pin`; status gains `arbiter` block)
+- Test: extend `tests/api/test_comfyui_proxy.py`
+
+- [ ] **Step 1: failing tests:**
+
+```python
+async def test_switchover_generation_calls_arbiter(client, fake_arbiter) -> None:
+    # POST {"mode":"generation"} → 202; background invokes arbiter.ensure_img(pin=False)
+    # scripts NOT executed (no subprocess)
+async def test_switchover_inference_calls_restore(client, fake_arbiter) -> None: ...
+async def test_switchover_pin_param(client, fake_arbiter) -> None:
+    # {"mode":"generation","pin":true} → ensure_img(pin=True)
+async def test_pin_endpoint_toggles(client, fake_arbiter) -> None:
+    # POST /api/comfyui/pin {"pinned": true} → 200, arbiter.set_pin(True)
+async def test_status_carries_arbiter_block(client, fake_arbiter) -> None:
+    # GET /status → {"arbiter": {"mode","pinned","idle_restore_at","saved_llm_slots"}}
+async def test_busy_queue_409_preserved(client) -> None: ...   # force-consent contract unchanged
+```
+
+- [ ] **Step 2:** run → scripts subprocess attempted / missing keys.
+- [ ] **Step 3: implement.** `_run_switch(mode, pin)` body becomes: generation → `await arbiter.ensure_img(pin=pin)`; inference → `await arbiter.restore_llm(force=force)` (ArbiterPinned → recorded in `_switch["error"]` same as script failures were). Keep `_switch` {active,target,error} contract + the 409 busy-queue/force gate + the 501 feature gate UNCHANGED (UI #690 depends on them). Delete `_SWITCH_PAIRS`, `_script_argv`, `_run_script` + their sudoers docstring (note in PR body: control-scripts stay on disk for manual ops but the API no longer shells out; the sudoers grant story is obsolete). Status: merge `arbiter.status()` under `"arbiter"`.
+- [ ] **Step 4:** `.venv/bin/python -m pytest tests/api/test_comfyui_proxy.py -q` green.
+- [ ] **Step 5:** `git commit -s -m "feat(api): comfyui switchover drives the GpuArbiter; pin endpoint; scripts retired"`
+
+---
+
+### Task D8: UI — arbitration status, pin toggle, "GPU: image mode" banner, mocks
+
+**Files:**
+- Modify: `ui/src/api/hooks/useComfyui.ts` (status type gains `arbiter`; `useComfyuiPin` mutation)
+- Modify: `ui/src/dash/comfyui-pane.jsx` (arbiter mode chip + pin toggle + restore countdown; SwitchoverConfirm copy mentions LLM slots stopping/restoring)
+- Modify: `ui/src/dash/primitives.jsx` (`BANNER_CATALOG` entry `gpu-image-mode`: scope global, kind info, heading "GPU: image mode", body "LLM slots are stopped while image generation holds the GPU — they restore automatically after idle." action → slots page; banner active when status.arbiter.mode === "img")
+- Modify: `ui/src/dash/data.jsx` (mock comfyui status incl. arbiter block; img slot entry gains `profile: "comfyui"`, `runtime: "container"`)
+- Test: γ spec `ui/tests/e2e/specs/comfyui-arbiter-v3.spec.ts` (create; apiMock pattern per profiles-crud-v3.spec.ts)
+
+- [ ] **Steps:** failing γ spec (img-mode status → banner visible + pane shows mode chip + countdown; pin toggle issues POST /api/comfyui/pin; inference mode → banner gone) → implement → `cd ui && npx playwright test comfyui-arbiter 2>&1 | tail -3` + `npm run build` green → `git commit -s -m "feat(ui): GPU image-mode banner + arbiter status/pin in ComfyUI pane"`.
+- Note: the drawer needs NO work — `device_class:"img"` profiles render read-only via the existing fixed-profile branch (slot-modals.jsx:769-787).
+
+---
+
+### Task D9: Gate, final Opus cross-task review, PR, CT105 docker→podman migration + e2e
+
+- [ ] **Step 1:** full gate — `.venv/bin/python -m pytest tests/ --ignore=tests/harness -q -p no:randomly` (~30 min, background; known env-dependent failure: `tests/agents/test_hermes_provision_idempotency`); `ruff check src tests && ruff format --check src tests`; `cd ui && npm run build`.
+- [ ] **Step 2:** FINAL CROSS-TASK OPUS REVIEW (working agreement — caught the only showstoppers in B and C; never skip). Focus: arbiter races (concurrent ensure_img/restore; dispatch during switch), persistence-recovery edge (api restart mid-switch), the Rule-6 `path_pinned` semantic change, port-range widening blast radius.
+- [ ] **Step 3:** push, PR (`gh pr create --head feat/phase-d-comfyui-img-gpu-arbiter`), body: closes #599, closes #691; notes scripts retired (API path), sudoers story obsolete, manifest repinned to kyuz0; CI green → squash-merge, delete branch.
+- [ ] **Step 4 (deploy, Tier 3 — shared host):** `wip hal0 claim "phase D img slot deploy" /etc/hal0/slots/img.toml`; verify `wip hal0 status` clean; backups: none needed for img (new slot) but snapshot `/etc/hal0/profiles.toml.bak-phase-d`; `ssh hal0 'cd /opt/hal0 && git pull && scripts/deploy.sh'` (rebuilds ui/dist — required, memory `hal0_ct105_deploy_rebuilds_ui`).
+- [ ] **Step 5 (migration on CT105):**
+  1. Seed live config: copy new img.toml → `/etc/hal0/slots/img.toml`; add comfyui profile to `/etc/hal0/profiles.toml` (CRUD API or seed-merge — remember REPLACE-on-load: write the FULL catalog).
+  2. REQUEST-TIME REGISTRY PRECHECK: `curl 127.0.0.1:8080/api/models` — confirm curated image entries (sdxl-turbo at minimum) resolve with `model_class` + `hf_file` matching filenames under `/mnt/ai-models/comfyui/models/checkpoints/`. Missing → register via API/CLI (NEVER hand-splice registry.toml).
+  3. Stop + remove the docker container: `docker rm -f comfyui` (image stays cached for rollback); `podman pull docker.io/kyuz0/amd-strix-halo-comfyui@sha256:0066678...` (podman pulls its own copy).
+  4. `curl -X POST 127.0.0.1:8080/api/comfyui/switchover -d '{"mode":"generation"}'` → arbiter path: chat/agent/utility/rerank units stop, `hal0-slot@img` starts.
+- [ ] **Step 6 (e2e matrix → PR comment):**
+  1. `systemctl is-active hal0-slot@img` + `podman ps` shows kyuz0 digest + `curl 127.0.0.1:8188/system_stats` → 200
+  2. `curl 127.0.0.1:8080/v1/images/generations -d '{"model":"sdxl-turbo","prompt":"a lighthouse at dusk","size":"1024x1024"}'` → 200 b64 PNG (gateway → dispatcher → container remote → infer)
+  3. DURING a generation: `curl 127.0.0.1:8080/v1/chat/completions -d '{"model":"hal0/primary",...}'` → 503 + `Retry-After` header + code `gpu.image_mode`; dashboard shows the banner
+  4. tts/npu/embed round-trips still 200 during img mode (non-GPU slots unaffected)
+  5. Idle restore: temporarily set `idle_restore_minutes = 1` live → LLM slots return within ~90s; reset to 5
+  6. Pin: `POST /api/comfyui/pin {"pinned":true}` → no restore after window; unpin → restores
+  7. Switchover both directions from the dashboard UI (force-consent intact)
+  8. Idle-CPU assertion (handoff follow-up): with img resident and queue empty, `podman stats --no-stream` CPU < 10% over 60s — the old "100%-CPU spin" must not reproduce under podman; if it does, capture `podman exec img ps aux` and file upstream (kyuz0) per third-party-first rule
+  9. GTT: confirm LLM-mode GTT returns to ~51 GB after restore (#691 closed-loop evidence)
+- [ ] **Step 7:** close-out — `wip release`; `tracker event lemonade-rm "Phase D shipped"` + task statuses; comment+close #599 #691; update memory `hal0_lemonade_removal_epic_phase_a_done.md` (D done, E next + debt registry); Phase E remains: lemonade extraction per spec §12-E.
+
+---
+
+## Self-review notes
+- Spec coverage: §3 img row ✓ (D1/D2), §7 arbiter+drain+idle+pin+503 ✓ (D4/D5/D6), §7 docker→podman ✓ (D9), #599 ✓ (D1), #691 ✓ (arbiter unload + D9 evidence), builds on #686/#690 ✓ (D7/D8 preserve contracts), digest pin ✓ (D1 manifest), CPU-spin follow-up ✓ (D9.6.8 — not reproducible as a bug, assert instead).
+- Type consistency: `GpuMode/GpuImageMode/ArbiterPinned`, `ensure_img(pin)/restore_llm(force)/guard_llm_dispatch/touch_img_activity/set_pin/status` used identically in D4-D7. `ImageGenConfig` named in D1, consumed in D4 (idle window) + v1 route (defaults; D5 may defer default_size wiring if the route already defaults — implementer verifies, the FIELD ships regardless for #599).
+- Weakest points, flagged for the Opus review: (1) Rule-6 `path_pinned` reuse stretches the flag's name — semantic is "deterministic pin", acceptable; (2) `[image]` vs existing `SlotConfig.image` field-name collision — D1 Step 3 carries the contingency; (3) arbiter restore after api crash mid-switch relies on the persisted file written BEFORE unloads begin — D4 test orders persistence first.
+- NOT in scope (Phase E, do not touch): lemonade_proxy fall-through, omni-router prefix pins (#695 guardrail), control-scripts deletion from disk, #687/#649.

--- a/installer/etc-hal0/profiles.toml
+++ b/installer/etc-hal0/profiles.toml
@@ -44,3 +44,11 @@ image        = "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1"
 flags        = "--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx"
 mtp          = false
 device_class = "cpu"
+
+[profile.comfyui]
+# Image-gen slot (ComfyUI on ROCm, kyuz0 Strix Halo build). Exclusive-GPU:
+# the GpuArbiter stops LLM GPU slots while img runs (Phase D, #599).
+image        = "docker.io/kyuz0/amd-strix-halo-comfyui:latest"
+flags        = "--disable-mmap --bf16-vae --cache-none"
+mtp          = false
+device_class = "img"

--- a/installer/etc-hal0/slots/img.toml
+++ b/installer/etc-hal0/slots/img.toml
@@ -1,27 +1,20 @@
-# hal0 image-generation slot — ComfyUI + Stable Diffusion family
-#
-# Lazy-load policy: this slot is NOT enabled or auto-started by the
-# installer. It activates the first time:
-#   1. The FirstRun wizard's "Add image gen?" optional step kicks off
-#      ``POST /api/install/pick-default {model_id, slot:"img"}``, which
-#      drops a model_id into ``[model].default`` here and requests a
-#      slot start, OR
-#   2. The Settings UI flips the "Enable image gen" toggle, OR
-#   3. An operator manually runs ``hal0 slot load img --model sdxl-turbo``.
-#
-# Rationale: image-gen models are 6+ GB (SDXL Turbo) to 24 GB
-# (Flux Schnell). Booting a slot for them on every fresh install would
-# waste VRAM/RAM on hosts that never want image gen. The lazy-load
-# trigger keeps the v1 default install lean.
+# hal0 image-generation slot — ComfyUI in a podman container (hal0-slot@img).
+# Exclusive-GPU slot: the GpuArbiter stops LLM GPU slots while img runs and
+# restores them after [image].idle_restore_minutes with no jobs (spec §7).
 
 name = "img"
+type = "image"
 provider = "comfyui"
-port = 8186
-# v0.2 (ADR-0006 §7): hardware preference moved from ``backend`` →
-# ``device``. ``backend`` is retained for one release so a downgrade to
-# v0.1.x still reads this file. Drop it in v0.3.
 device = "gpu-rocm"
-backend = "rocm"
+runtime = "container"
+profile = "comfyui"
+enabled = true
+port = 8188
 
 [model]
 default = "sdxl-turbo"
+
+[image]                       # persisted image-gen settings (#599)
+idle_restore_minutes = 5
+default_size = "1024x1024"
+default_steps = 0

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -958,7 +958,7 @@ fi
 # `cp -a installer "${STAGE}/"`), git checkouts carry it, and the prod
 # rsync to ${PREFIX} (which REPO_ROOT is re-pointed at) has no exclude
 # that touches installer/.
-for seed_slot in npu tts rerank utility; do
+for seed_slot in npu tts rerank utility img; do
     SLOT_TOML="${ETC_DIR}/slots/${seed_slot}.toml"
     SLOT_SRC="${REPO_ROOT}/installer/etc-hal0/slots/${seed_slot}.toml"
     if [[ -f "${SLOT_TOML}" ]]; then

--- a/manifest.json
+++ b/manifest.json
@@ -31,9 +31,9 @@
       "_upstream_reference": "https://github.com/thewh1teagle/kokoro-onnx"
     },
     "comfyui": {
-      "tag": "ghcr.io/hal0ai/hal0-toolbox-comfyui:v1",
-      "digest": "sha256:f43fc66cc064109eecf6a2ef20d8bc68b933c122bc46d06ebf1d73a65c22c4c0",
-      "_notes": "ComfyUI image-gen on ROCm; SDXL + SD 1.5 + Flux. Translated from OpenAI /v1/images/generations.",
+      "tag": "docker.io/kyuz0/amd-strix-halo-comfyui:latest",
+      "digest": "sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2",
+      "_notes": "live-validated on CT105 2026-06-11 (Wan2.2/Qwen-Image/Flux/SDXL on gfx1151); repinned from unpublished hal0-toolbox-comfyui (Phase D)",
       "_upstream_reference": "https://github.com/comfyanonymous/ComfyUI"
     }
   },

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1084,6 +1084,26 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         with contextlib.suppress(asyncio.CancelledError):
             await lemond_bridge_task
 
+    # GpuArbiter idle-restore loop (Phase D, Task D6). Auto-restores the
+    # saved LLM set after the img (ComfyUI) slot idles out — window from the
+    # img slot's ``[image].idle_restore_minutes`` (default 5; 0 = manual-only).
+    # Mirrors the refresh_task pattern above: created at startup, cancelled +
+    # awaited on shutdown via the AsyncExitStack. Guarded so an arbiter
+    # construction failure never blocks API startup (omni-router precedent).
+    gpu_arbiter_idle_task: asyncio.Task[None] | None = None
+    try:
+        gpu_arbiter_idle_task = asyncio.create_task(slot_manager.arbiter.run_idle_loop())
+        log.info("gpu_arbiter.idle_loop_started")
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("gpu_arbiter.idle_loop_start_failed", error=str(exc))
+    app.state.gpu_arbiter_idle_task = gpu_arbiter_idle_task
+
+    async def _stop_gpu_arbiter_idle_loop() -> None:
+        if gpu_arbiter_idle_task is not None:
+            gpu_arbiter_idle_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await gpu_arbiter_idle_task
+
     # Lemonade idle-unload driver (ADR-0007 §Related, ADR-0008 §1). v0.2
     # makes Lemonade the sole backend, so this driver always starts —
     # the prior ``HAL0_BACKEND=lemonade`` gate retired in PR-10. Stored
@@ -1176,6 +1196,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 await stack.enter_async_context(mgr.run())
             stack.push_async_callback(_stop_refresh_task)
             stack.push_async_callback(_stop_lemond_bridge)
+            stack.push_async_callback(_stop_gpu_arbiter_idle_loop)
             yield
     finally:
         if lemonade_metrics_shim is not None:

--- a/src/hal0/api/routes/comfyui.py
+++ b/src/hal0/api/routes/comfyui.py
@@ -14,14 +14,15 @@ renders that engine pane from ``GET /api/comfyui/status``, which folds together:
 Every source degrades to a safe default — the pane polls this every few seconds
 and a dead container must surface as "stopped", never a 500.
 
-The switchover *write* path (``POST /api/comfyui/switchover``) runs the
-root-owned script pairs in ``/opt/comfyui`` (``stop-inference.sh`` →
-``comfy-up.sh`` for generation, ``comfy-down.sh`` → ``start-inference.sh`` for
-inference) in the background behind a 202; the ``switchover`` block on /status
-tracks the transition. Privilege-aware: as root (hal0-api on CT105 runs
-``User=root``) the scripts exec directly, otherwise via ``sudo -n`` against the
-narrow ``packaging/sudoers/hal0-comfyui`` grant. The whole path stays
-feature-gated behind ``HAL0_COMFYUI_SWITCHOVER_ENABLED`` (501 when off).
+The switchover *write* path (``POST /api/comfyui/switchover``) drives the
+SlotManager's :class:`~hal0.slots.arbiter.GpuArbiter` (Phase D): generation →
+``ensure_img(pin=...)`` (drain the llm GPU group, load the img slot), inference
+→ ``restore_llm(force=...)`` (unload img, reload the saved llm slots). It runs
+in the background behind a 202; the ``switchover`` block on /status tracks the
+transition. The API no longer shells out — the ``/opt/comfyui`` control scripts
+stay on disk for manual ops only. ``POST /api/comfyui/pin`` toggles the
+arbiter's manual pin (blocks idle-restore). Both write paths stay feature-gated
+behind ``HAL0_COMFYUI_SWITCHOVER_ENABLED`` (501 when off).
 """
 
 from __future__ import annotations
@@ -48,12 +49,10 @@ _PRESSURE_GB = 50
 _LEMONADE_UNIT = "hal0-lemonade.service"
 _HERMES_UNIT = "hal0-agent@hermes.service"
 
-# Switchover script pairs, run in order from the scripts dir on the runtime
-# host. ON hands the iGPU to ComfyUI; OFF hands it back to the LLM stack.
-_SWITCH_PAIRS: dict[str, tuple[str, ...]] = {
-    "generation": ("stop-inference.sh", "comfy-up.sh"),
-    "inference": ("comfy-down.sh", "start-inference.sh"),
-}
+# Switchover target modes. "generation" hands the iGPU to ComfyUI
+# (arbiter.ensure_img); "inference" hands it back to the LLM stack
+# (arbiter.restore_llm).
+_MODES = ("generation", "inference")
 
 # Short connect so a dead engine surfaces fast; the read budget is modest because
 # /system_stats and /queue are cheap snapshots.
@@ -283,6 +282,12 @@ def _engine_state(container: str, reachable: bool, running_jobs: int) -> str:
     return "generating" if running_jobs > 0 else "running"
 
 
+def _get_arbiter(request: Request) -> Any | None:
+    """The SlotManager's GpuArbiter off app.state, or None when unwired."""
+    manager = getattr(request.app.state, "slot_manager", None)
+    return manager.arbiter if manager is not None else None
+
+
 @router.get("/status")
 async def comfyui_status(request: Request) -> dict[str, Any]:
     """Aggregate docker + systemd + ComfyUI HTTP into one engine-status object."""
@@ -297,6 +302,15 @@ async def comfyui_status(request: Request) -> dict[str, Any]:
     reachable = stats is not None
     counts = _queue_counts(queue)
     engine = _engine_state(container, reachable, counts["running"])
+    # Arbiter snapshot is fail-soft like every other probe here: a missing
+    # manager or a corrupt state file degrades to null, never a 500.
+    arbiter_block: dict[str, Any] | None = None
+    try:
+        arbiter = _get_arbiter(request)
+        if arbiter is not None:
+            arbiter_block = arbiter.status()
+    except Exception:
+        arbiter_block = None
     return {
         "mode": "generation" if container == "running" else "inference",
         "reachable": reachable,
@@ -308,104 +322,82 @@ async def comfyui_status(request: Request) -> dict[str, Any]:
         "inference": {"lemonade": lemonade, "hermes": hermes},
         "inventory": _model_inventory(),
         "switchover": dict(_switch),
+        "arbiter": arbiter_block,
     }
 
 
-def _scripts_dir() -> str:
-    return os.environ.get("COMFYUI_SCRIPTS_DIR", "/opt/comfyui")
-
-
-def _script_timeout() -> float:
-    # comfy-up.sh on a FRESH container create waits for HTTP and pip-installs
-    # custom-node deps — minutes, not seconds. The resume path is fast.
+async def _run_switch(arbiter: Any, mode: str, *, pin: bool = False, force: bool = False) -> None:
+    """Drive the arbiter for ``mode``; record failure for /status to surface."""
     try:
-        return float(os.environ.get("COMFYUI_SCRIPT_TIMEOUT", "600"))
-    except ValueError:
-        return 600.0
-
-
-def _script_argv(name: str) -> list[str]:
-    """Argv for one switchover script, privilege-aware.
-
-    Root (CT105 today: hal0-api runs as ``User=root``) execs the script
-    directly. An unprivileged hal0-api goes through ``sudo -n`` against the
-    narrow ``/etc/sudoers.d/hal0-comfyui`` grant (absolute paths only); ``-n``
-    so a missing grant fails immediately instead of hanging on a password
-    prompt.
-    """
-    path = os.path.join(_scripts_dir(), name)
-    return [path] if os.geteuid() == 0 else ["sudo", "-n", path]
-
-
-async def _run_script(name: str) -> None:
-    """Execute one switchover script to completion; raises on failure."""
-    argv = _script_argv(name)
-    timeout = _script_timeout()
-    proc = await asyncio.create_subprocess_exec(
-        *argv,
-        stdin=asyncio.subprocess.DEVNULL,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.STDOUT,
-    )
-    try:
-        out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except TimeoutError:
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-        raise RuntimeError(f"{name} timed out after {timeout:.0f}s") from None
-    if proc.returncode != 0:
-        tail = out.decode("utf-8", "replace").strip().splitlines()[-5:]
-        raise RuntimeError(f"{name} exited {proc.returncode}: {' | '.join(tail)}")
-
-
-async def _run_switch(mode: str) -> None:
-    """Run the script pair for ``mode``; record failure for /status to surface."""
-    try:
-        for name in _SWITCH_PAIRS[mode]:
-            await _run_script(name)
-    except Exception as exc:  # any script failure must land in /status, never raise
+        if mode == "generation":
+            await arbiter.ensure_img(pin=pin)
+        else:
+            await arbiter.restore_llm(force=force)
+    except Exception as exc:  # any failure must land in /status, never raise
         _switch["error"] = f"{mode}: {exc}"
     finally:
         _switch["active"] = False
         _switch["target"] = None
 
 
+def _gate_closed() -> JSONResponse | None:
+    """501 when the operator hasn't enabled the GPU-switch write path."""
+    if os.environ.get("HAL0_COMFYUI_SWITCHOVER_ENABLED", "0") == "1":
+        return None
+    return JSONResponse(
+        status_code=501,
+        content={
+            "error": {
+                "code": "comfyui.switchover_disabled",
+                "message": (
+                    "ComfyUI switchover is disabled on this host. It stops "
+                    "the LLM stack (bots + memory extraction go dark) while "
+                    "generation holds the iGPU; set "
+                    "HAL0_COMFYUI_SWITCHOVER_ENABLED=1 on hal0-api to "
+                    "enable it."
+                ),
+            }
+        },
+    )
+
+
+def _arbiter_unavailable() -> JSONResponse:
+    return JSONResponse(
+        status_code=503,
+        content={
+            "error": {
+                "code": "comfyui.arbiter_unavailable",
+                "message": "slot manager / GPU arbiter is not wired on this app",
+            }
+        },
+    )
+
+
 @router.post("/switchover")
 async def comfyui_switchover(request: Request, background_tasks: BackgroundTasks) -> JSONResponse:
     """Flip the iGPU between LLM inference and ComfyUI generation.
 
-    Body: ``{"mode": "generation" | "inference", "force": bool}``. Refuses while
-    a switch is in flight (409), no-ops when already in the target mode (200),
-    and refuses to drop a busy render queue without ``force`` (409). Otherwise
-    answers 202 and runs the script pair in the background — track completion
-    via the ``switchover`` block on ``GET /status``.
+    Body: ``{"mode": "generation" | "inference", "force": bool, "pin": bool}``
+    (``pin`` only matters for generation: hold image mode against idle-restore).
+    Refuses while a switch is in flight (409), no-ops when already in the
+    target mode (200), and refuses to drop a busy render queue without
+    ``force`` (409). Otherwise answers 202 and drives the GpuArbiter in the
+    background — track completion via the ``switchover`` block on
+    ``GET /status``.
 
-    Stays gated behind ``HAL0_COMFYUI_SWITCHOVER_ENABLED`` because the scripts
-    take the messaging bots + memory extraction offline (an operator decision
-    per host), not because the path is unwired.
+    Stays gated behind ``HAL0_COMFYUI_SWITCHOVER_ENABLED`` because the switch
+    takes the LLM stack (bots + memory extraction) offline (an operator
+    decision per host), not because the path is unwired.
     """
-    if os.environ.get("HAL0_COMFYUI_SWITCHOVER_ENABLED", "0") != "1":
-        return JSONResponse(
-            status_code=501,
-            content={
-                "error": {
-                    "code": "comfyui.switchover_disabled",
-                    "message": (
-                        "ComfyUI switchover is disabled on this host. It stops "
-                        "the LLM stack (bots + memory extraction go dark) while "
-                        "generation holds the iGPU; set "
-                        "HAL0_COMFYUI_SWITCHOVER_ENABLED=1 on hal0-api to "
-                        "enable it."
-                    ),
-                }
-            },
-        )
+    gate = _gate_closed()
+    if gate is not None:
+        return gate
     try:
         body = await request.json()
     except ValueError:
         body = None
     mode = body.get("mode") if isinstance(body, dict) else None
-    if mode not in _SWITCH_PAIRS:
+    if mode not in _MODES:
         return JSONResponse(
             status_code=422,
             content={
@@ -461,15 +453,48 @@ async def comfyui_switchover(request: Request, background_tasks: BackgroundTasks
                     }
                 },
             )
-    # Dispatch in the background and answer 202 immediately — the pair takes
-    # seconds to tens of seconds (service stop/start, container boot) and the
+    arbiter = _get_arbiter(request)
+    if arbiter is None:
+        return _arbiter_unavailable()
+    pin = bool(body.get("pin")) if isinstance(body, dict) else False
+    # Dispatch in the background and answer 202 immediately — the drain/reload
+    # takes seconds to tens of seconds (slot unloads, container boot) and the
     # pane's /status poll tracks the transition via the switchover block.
     _switch.update(active=True, target=mode, error=None)
-    background_tasks.add_task(_run_switch, mode)
-    return JSONResponse(
-        status_code=202,
-        content={"status": "switching", "mode": mode, "scripts": list(_SWITCH_PAIRS[mode])},
-    )
+    background_tasks.add_task(_run_switch, arbiter, mode, pin=pin, force=force)
+    return JSONResponse(status_code=202, content={"status": "switching", "mode": mode})
+
+
+@router.post("/pin")
+async def comfyui_pin(request: Request) -> JSONResponse:
+    """Toggle the arbiter's manual pin (holds image mode against idle-restore).
+
+    Body: ``{"pinned": bool}``. Gated by the same env flag as the switchover —
+    pinning only matters when the GPU-switch write path is live.
+    """
+    gate = _gate_closed()
+    if gate is not None:
+        return gate
+    try:
+        body = await request.json()
+    except ValueError:
+        body = None
+    pinned = body.get("pinned") if isinstance(body, dict) else None
+    if not isinstance(pinned, bool):
+        return JSONResponse(
+            status_code=422,
+            content={
+                "error": {
+                    "code": "comfyui.invalid_pin",
+                    "message": "body must be {'pinned': true | false}",
+                }
+            },
+        )
+    arbiter = _get_arbiter(request)
+    if arbiter is None:
+        return _arbiter_unavailable()
+    arbiter.set_pin(pinned)
+    return JSONResponse(status_code=200, content={"pinned": pinned})
 
 
 __all__ = ["aclose_client", "router"]

--- a/src/hal0/api/routes/comfyui.py
+++ b/src/hal0/api/routes/comfyui.py
@@ -285,7 +285,27 @@ def _engine_state(container: str, reachable: bool, running_jobs: int) -> str:
 def _get_arbiter(request: Request) -> Any | None:
     """The SlotManager's GpuArbiter off app.state, or None when unwired."""
     manager = getattr(request.app.state, "slot_manager", None)
-    return manager.arbiter if manager is not None else None
+    return getattr(manager, "arbiter", None)
+
+
+# Arbiter GPU mode → the API's dashboard mode vocabulary.
+_ARBITER_TO_API_MODE = {"img": "generation", "llm": "inference"}
+
+
+def _arbiter_api_mode(arbiter: Any) -> str | None:
+    """Arbiter-truth current mode ("generation"|"inference"), or None.
+
+    None means "no arbiter / arbiter broken" — callers fall back to the legacy
+    docker/systemd probes. Post-migration (D9 removes the docker container,
+    hal0-lemonade stays active through Phase D) the legacy probes lie, so the
+    arbiter wins whenever it answers.
+    """
+    if arbiter is None:
+        return None
+    try:
+        return _ARBITER_TO_API_MODE.get(arbiter.status().get("mode"))
+    except Exception:
+        return None
 
 
 @router.get("/status")
@@ -311,12 +331,20 @@ async def comfyui_status(request: Request) -> dict[str, Any]:
             arbiter_block = arbiter.status()
     except Exception:
         arbiter_block = None
+    # Mode: arbiter is the source of truth (img → generation, llm → inference);
+    # the docker-derived mode is only the legacy fallback for arbiter-less apps.
+    arb_mode = (
+        _ARBITER_TO_API_MODE.get(arbiter_block.get("mode"))
+        if isinstance(arbiter_block, dict)
+        else None
+    )
+    mode = arb_mode or ("generation" if container == "running" else "inference")
     return {
-        "mode": "generation" if container == "running" else "inference",
+        "mode": mode,
         "reachable": reachable,
         "engine": engine,
         "container": {"name": container_name, "state": container},
-        "endpoint": ":8188" if container == "running" else None,
+        "endpoint": ":8188" if mode == "generation" else None,
         "memory": _parse_memory(stats),
         "queue": counts,
         "inference": {"lemonade": lemonade, "hermes": hermes},
@@ -420,16 +448,25 @@ async def comfyui_switchover(request: Request, background_tasks: BackgroundTasks
                 }
             },
         )
-    # Idempotency: derive the current mode the same way /status does (container
-    # running ⇒ generation). Target inference additionally requires lemonade to
-    # actually be up — if both stacks are down, the switch runs as a repair.
-    container, lemonade = await asyncio.gather(
-        _container_state(_comfyui_container()),
-        _systemd_active(_LEMONADE_UNIT),
-    )
-    already_there = (
-        container == "running" if mode == "generation" else container != "running" and lemonade
-    )
+    # Idempotency: the arbiter is the source of truth for the current mode.
+    # Post-migration the docker container is gone while hal0-lemonade stays
+    # active, so the legacy probe would report "already in inference" forever
+    # (= restore_llm never invokable, pinned img mode would be a permanent
+    # lockout). Legacy docker/systemd probe ONLY when the arbiter can't answer;
+    # there, target inference additionally requires lemonade to actually be up —
+    # if both stacks are down, the switch runs as a repair.
+    arbiter = _get_arbiter(request)
+    current = _arbiter_api_mode(arbiter)
+    if current is not None:
+        already_there = current == mode
+    else:
+        container, lemonade = await asyncio.gather(
+            _container_state(_comfyui_container()),
+            _systemd_active(_LEMONADE_UNIT),
+        )
+        already_there = (
+            container == "running" if mode == "generation" else container != "running" and lemonade
+        )
     if already_there:
         return JSONResponse(status_code=200, content={"status": "noop", "mode": mode})
     # Mid-render guard: switching to inference stops the container, dropping any
@@ -453,7 +490,6 @@ async def comfyui_switchover(request: Request, background_tasks: BackgroundTasks
                     }
                 },
             )
-    arbiter = _get_arbiter(request)
     if arbiter is None:
         return _arbiter_unavailable()
     pin = bool(body.get("pin")) if isinstance(body, dict) else False

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -1090,7 +1090,47 @@ async def images_generations(request: Request, dispatcher: DispatcherDep) -> Res
             details={"upstream": call.upstream_name, "url": upstream.url},
         )
 
-    # 4. Drive the ComfyUI provider directly. Inject the curated metadata
+    # 4. GPU arbitration (Phase D, spec §7). Flip the GPU to exclusive
+    #    image mode BEFORE dispatching to the img upstream (unloads llm
+    #    GPU slots, loads the img slot), and stamp img activity at request
+    #    START and again at COMPLETION so long Wan video jobs keep the
+    #    idle-restore window open. Also seed #599 request defaults from
+    #    the img slot's [image] section (default_size / default_steps).
+    manager = getattr(request.app.state, "slot_manager", None)
+    arbiter = manager.arbiter if manager is not None else None
+    if manager is not None:
+        from hal0.errors import NotFound
+        from hal0.slots.arbiter import gpu_exclusive_group
+
+        cfgs = await manager.iter_configs()
+        img_cfg = next((c for c in cfgs if gpu_exclusive_group(c) == "img"), None)
+        img_section = (img_cfg or {}).get("image") or (img_cfg or {}).get("image_gen") or {}
+        if isinstance(img_section, dict):
+            default_size = img_section.get("default_size")
+            if not body.get("size") and isinstance(default_size, str) and default_size:
+                body["size"] = default_size
+            default_steps = img_section.get("default_steps")
+            if (
+                isinstance(default_steps, int)
+                and not isinstance(default_steps, bool)
+                and default_steps > 0
+            ):
+                extra = body.get("extra_body")
+                if not isinstance(extra, dict):
+                    extra = {}
+                    body["extra_body"] = extra
+                extra.setdefault("steps", default_steps)
+
+        try:
+            await arbiter.ensure_img()
+        except NotFound as exc:
+            # No img-group slot configured (manually-registered upstream,
+            # tests) — nothing to arbitrate; generation proceeds as-is.
+            if exc.code != "gpu.img_slot_missing":
+                raise
+        arbiter.touch_img_activity()
+
+    # 5. Drive the ComfyUI provider directly. Inject the curated metadata
     #    into the body so the provider's translator knows what to render
     #    without re-looking-up the registry.
     provider = get_provider("comfyui")
@@ -1100,13 +1140,16 @@ async def images_generations(request: Request, dispatcher: DispatcherDep) -> Res
         "_hal0_ckpt_filename": curated.hf_file,
     }
     result = await provider.infer(port, body_with_meta)
+    if arbiter is not None:
+        # Completion stamp — long jobs must reset the idle-restore clock.
+        arbiter.touch_img_activity()
 
     # Track most-recent-model for dashboard.
     last_used = getattr(request.app.state, "last_used_model", None)
     if last_used is not None and call.upstream_name:
         last_used[call.upstream_name] = requested
 
-    # 5. Emit OpenAI-shaped response.
+    # 6. Emit OpenAI-shaped response.
     response_format = (body.get("response_format") or "url").lower().strip()
     images: list[dict[str, Any]] = []
     for img in result.get("images", []):

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -90,9 +90,11 @@ BACKEND_TO_DEVICE: dict[str, str] = {
 # deprecated legacy value.
 _VALID_PROVIDERS = frozenset({"lemonade", "llama-server", "flm", "moonshine", "kokoro", "comfyui"})
 
-# Slot port range.  8080 is the hal0 API; slots get 8081-8099.
+# Slot port range.  8080 is the hal0 API; slots get 8081-8099; 8188 =
+# ComfyUI's stock port for the img slot — kept well-known so operator
+# bookmarks/tooling keep working.
 _SLOT_PORT_MIN = 8081
-_SLOT_PORT_MAX = 8099
+_SLOT_PORT_MAX = 8200
 
 # Schema version for migrations.  Bumped when a backwards-incompatible
 # config-shape change lands.  See PLAN.md §5 Tier 3.
@@ -191,6 +193,37 @@ class NpuConfig(BaseModel):
     embed: bool = Field(
         default=False,
         description="Enable embedding modality via FLM --embed 1.",
+    )
+
+
+class ImageGenConfig(BaseModel):
+    """[image] table in a slot TOML — persisted image-gen settings (#599).
+
+    Carried by the img (ComfyUI) slot.  ``idle_restore_minutes`` feeds the
+    GpuArbiter's restore timer (Phase D spec §7): after the img slot has
+    had no jobs for this many minutes, the arbiter restores the LLM GPU
+    slots it stopped.  ``default_size``/``default_steps`` seed the image
+    generation request defaults surfaced in the dashboard.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    idle_restore_minutes: int = Field(
+        default=5,
+        ge=0,
+        description=(
+            "Minutes of img-slot job inactivity before the GpuArbiter "
+            "restores stopped LLM GPU slots.  0 = never auto-restore."
+        ),
+    )
+    default_size: str = Field(
+        default="1024x1024",
+        description="Default output size (WxH) for image generation requests.",
+    )
+    default_steps: int = Field(
+        default=0,
+        ge=0,
+        description="Default sampler steps.  0 = use the model-class default.",
     )
 
 
@@ -344,6 +377,20 @@ class SlotConfig(BaseModel):
         ),
     )
 
+    # Typed [image] subsection (#599) — persisted image-gen settings for
+    # the img (ComfyUI) slot.  Same hoist/tuck round-trip pattern as
+    # [server]/[npu].  Defaults apply on slots without an [image] table;
+    # the dump serializer elides an all-defaults ImageGenConfig so
+    # non-img slots don't grow a stray [image] table on disk.
+    image_gen: ImageGenConfig = Field(
+        default_factory=ImageGenConfig,
+        alias="image",
+        description=(
+            "[image] table — image-gen settings (idle_restore_minutes, "
+            "default_size, default_steps). See ImageGenConfig (#599)."
+        ),
+    )
+
     extra: dict[str, Any] = Field(
         default_factory=dict,
         description="Provider-specific slot params passed verbatim.",
@@ -403,6 +450,35 @@ class SlotConfig(BaseModel):
             new_extra = dict(extra)
             new_extra.pop("npu", None)
             new_data["npu"] = npu
+            new_data["extra"] = new_extra
+            return new_data
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def _hoist_image_from_extra(cls, data: Any) -> Any:
+        """Pull an `[image]` TOML table out of the loader's `extra` catch-all.
+
+        Mirrors ``_hoist_npu_from_extra`` for the typed ``image_gen`` field
+        (#599): ``_flatten_slot_toml`` stashes the on-disk ``[image]`` table
+        into ``extra["image"]``, so the img slot's persisted image-gen
+        settings would never reach :class:`ImageGenConfig` without this.
+        """
+        if not isinstance(data, dict):
+            return data
+        # Already top-level (direct model_validate of a flat TOML dict,
+        # where the "image" alias applies) — nothing to do.
+        if data.get("image") is not None or data.get("image_gen") is not None:
+            return data
+        extra = data.get("extra")
+        if not isinstance(extra, dict):
+            return data
+        image = extra.get("image")
+        if isinstance(image, dict):
+            new_data = dict(data)
+            new_extra = dict(extra)
+            new_extra.pop("image", None)
+            new_data["image"] = image
             new_data["extra"] = new_extra
             return new_data
         return data
@@ -482,6 +558,15 @@ class SlotConfig(BaseModel):
             extra = data.get("extra")
             extra = dict(extra) if isinstance(extra, dict) else {}
             extra["npu"] = npu
+            data["extra"] = extra
+        # Re-park [image] (typed ``image_gen``, #599) under extra the same
+        # way.  An all-defaults ImageGenConfig is elided so non-img slots
+        # don't grow a stray [image] table on disk.
+        image_gen = data.pop("image_gen", None)
+        if isinstance(image_gen, dict) and image_gen != ImageGenConfig().model_dump():
+            extra = data.get("extra")
+            extra = dict(extra) if isinstance(extra, dict) else {}
+            extra["image"] = image_gen
             data["extra"] = extra
         return data
 
@@ -616,6 +701,12 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "flags": "--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx",
         "mtp": False,
         "device_class": "cpu",
+    },
+    "comfyui": {
+        "image": "docker.io/kyuz0/amd-strix-halo-comfyui:latest",
+        "flags": "--disable-mmap --bf16-vae --cache-none",
+        "mtp": False,
+        "device_class": "img",
     },
 }
 
@@ -1705,6 +1796,7 @@ __all__ = [
     "GraphUpstreamConfig",
     "Hal0Config",
     "HardwareInfo",
+    "ImageGenConfig",
     "MCPServerConfig",
     "MemoryConfig",
     "MemoryEmbeddingConfig",

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -463,12 +463,31 @@ class SlotConfig(BaseModel):
         (#599): ``_flatten_slot_toml`` stashes the on-disk ``[image]`` table
         into ``extra["image"]``, so the img slot's persisted image-gen
         settings would never reach :class:`ImageGenConfig` without this.
+
+        Collision guard: a top-level *string* ``image`` is the documented
+        per-slot container-image override (read by ``llama_server.image_ref``
+        and ``comfyui.image_ref`` from the raw slot dict). It must NOT hit
+        the ``image_gen`` alias — pre-D1 it round-tripped via
+        ``extra="allow"``, so non-dict values are parked under
+        ``extra["image"]`` to preserve that behavior.
         """
         if not isinstance(data, dict):
             return data
+        image = data.get("image")
+        if image is not None and not isinstance(image, dict):
+            # Legacy string container-image override — park under extra so
+            # the ImageGenConfig alias never sees it and providers can keep
+            # reading it from the round-tripped config.
+            new_data = dict(data)
+            new_data.pop("image")
+            old_extra = new_data.get("extra")
+            new_extra = dict(old_extra) if isinstance(old_extra, dict) else {}
+            new_extra["image"] = image
+            new_data["extra"] = new_extra
+            return new_data
         # Already top-level (direct model_validate of a flat TOML dict,
         # where the "image" alias applies) — nothing to do.
-        if data.get("image") is not None or data.get("image_gen") is not None:
+        if isinstance(image, dict) or data.get("image_gen") is not None:
             return data
         extra = data.get("extra")
         if not isinstance(extra, dict):

--- a/src/hal0/dispatcher/proxy.py
+++ b/src/hal0/dispatcher/proxy.py
@@ -92,10 +92,11 @@ def resolve_slot(  # TIER1
       3. ``/audio/speech`` in path → ``tts`` slot (kokoro; model-id unreliable).
       4. ``/images/...`` in path → ``img`` slot (ComfyUI).
 
-    Path-pinned candidates (rules 1-3) accept either a local ``kind="slot"``
-    upstream or a container-backed ``kind="remote"`` upstream whose
-    ``slot_name`` matches the candidate (container slots register as remotes
-    via ``SlotManager._register_container_upstream``, #656).  All other rules
+    Path-pinned candidates (rules 1-4, plus the rule-6 model-prefix pin)
+    accept either a local ``kind="slot"`` upstream or a container-backed
+    ``kind="remote"`` upstream whose ``slot_name`` matches the candidate
+    (container slots register as remotes via
+    ``SlotManager._register_container_upstream``, #656).  All other rules
     require ``kind="slot"``.
       5. Model id contains ``:`` (FLM tag-style) → ``npu`` slot.
       6. Model id starts with ``sdxl``/``sd-1.5``/``sd15``/``flux`` → ``img`` slot.
@@ -144,9 +145,13 @@ def resolve_slot(  # TIER1
     elif any(frag in path for frag in _TTS_PATHS):
         candidate = "tts"
         path_pinned = True
-    # Rule 4 — image-generation path pins to the img slot.
+    # Rule 4 — image-generation path pins to the img slot.  img is a
+    # container slot post-Phase-D (ComfyUI via podman, registers as a
+    # kind="remote" upstream) — same container-remote acceptance as the
+    # embed/tts/rerank path pins.
     elif any(frag in path for frag in _IMAGE_PATHS):
         candidate = "img"
+        path_pinned = True
     elif body:
         model = body.get("model", "")
         if isinstance(model, str) and model:
@@ -155,8 +160,13 @@ def resolve_slot(  # TIER1
             if ":" in model:
                 candidate = "npu"
             # Rule 6 — image-gen model id prefix pin (sdxl-/sd-1.5-/flux-).
+            # path_pinned here means "deterministically pinned": the curated
+            # sdxl-/sd-1.5-/flux- prefixes are exact catalogue prefixes, the
+            # same trust level as a path pin — so the container-backed img
+            # remote must qualify here too (Phase D).
             elif any(m.startswith(prefix) for prefix in _IMAGE_NAME_PREFIXES):
                 candidate = "img"
+                path_pinned = True
             # Rule 7 — name-substring pin (embed/rerank → embed slot).
             elif any(hint in m for hint in _EMBED_NAME_HINTS):
                 candidate = "embed"

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -685,6 +685,15 @@ class Dispatcher:
         Mirrors haloai ``lib/dispatcher.py``'s ``_forward_direct`` and
         ``_forward_streaming`` (PLAN.md §3).
         """
+        if self._slot_manager is not None and (call.slot_name or call.container_slot_name):
+            # Phase D (spec §7): exclusive-GPU image-mode guard. Fires
+            # BEFORE the lazy-load + readiness gates so an llm-group slot
+            # refused during image mode surfaces the gpu.image_mode 503
+            # envelope (with its own Retry-After) instead of slot.loading —
+            # and so the backend-aware lazy-load below can never pull an
+            # LLM model back onto the GPU while the arbiter holds it for
+            # the img slot.
+            self._guard_gpu_image_mode(call)
         if call.slot_name and self._slot_manager is not None:
             # B1 (ADR-0022): backend-aware lazy-load. lemond auto-loads a
             # model the dispatcher forwards by name using its GLOBAL
@@ -709,6 +718,25 @@ class Dispatcher:
             # a raw 502 ConnectError when the container is down or starting.
             await self._check_container_slot_ready(call)
         return await self._forward_plain(call)
+
+    def _guard_gpu_image_mode(self, call: UpstreamCall) -> None:
+        """Refuse llm-group dispatch while the GPU is in exclusive image mode.
+
+        Delegates to :meth:`GpuArbiter.guard_llm_dispatch`, which raises the
+        typed ``GpuImageMode`` (503, code ``gpu.image_mode``, details carry
+        ``retry_after_s``) for llm-group slots and no-ops for everything
+        else (img slot itself, NPU/CPU/lemonade slots, remote upstreams).
+        The error middleware promotes ``retry_after_s`` to a ``Retry-After``
+        header exactly like it does for ``SlotLoading`` — no parallel
+        plumbing.
+
+        Test stand-ins without an ``arbiter`` attribute opt out via the
+        ``getattr`` (the real SlotManager always exposes the lazy property).
+        """
+        arbiter = getattr(self._slot_manager, "arbiter", None)
+        if arbiter is None:
+            return
+        arbiter.guard_llm_dispatch(call.slot_name or call.container_slot_name)
 
     async def _ensure_slot_loaded_backend_aware(self, call: UpstreamCall) -> None:
         """Kick a backend-aware load on a cold miss before forwarding.
@@ -831,9 +859,25 @@ class Dispatcher:
           ``False`` — recovery is not applicable (remote upstream, no slot
             manager wired) or the recover call itself raised.  Caller
             should surface the original :class:`UpstreamUnavailable`.
+
+        Raises:
+          GpuImageMode: NON-NEGOTIABLE (D4 review) — when the GpuArbiter
+            is in exclusive image mode and this is an llm-group slot, the
+            dead port is (or may as well be) the ARBITER's doing: it
+            unloaded the slot to hand the GPU to the img slot.  Recovery
+            here would reload an LLM model INTO image mode and fight the
+            arbiter for the GPU, so we suppress it and surface the same
+            structured ``gpu.image_mode`` 503 envelope the dispatch guard
+            emits (Retry-After included via the error middleware).
         """
         if not (call.slot_name and self._slot_manager is not None):
             return False
+        arbiter = getattr(self._slot_manager, "arbiter", None)
+        if arbiter is not None:
+            # Raises GpuImageMode for llm-group slots while mode == img;
+            # no-op otherwise. Covers the race where the arbiter flipped
+            # to img (and force-killed the container) mid-request.
+            arbiter.guard_llm_dispatch(call.slot_name)
         log.warning(
             "dispatch.upstream_dead_attempting_recover",
             upstream=call.upstream_name,

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -161,6 +161,8 @@ _EMBED_DEFAULT = "embed"
 # server with --reranking, port 8083). Previously this pointed at "embed".
 _RERANK_DEFAULT = "rerank"
 _TTS_DEFAULT = "tts"
+# Phase D: model-less /v1/images/* requests default to the img slot (ComfyUI).
+_IMAGE_DEFAULT = "img"
 
 # Outgoing upstream path rewrites applied before forwarding.
 # Key: incoming /v1/* path (as-is from the client).
@@ -1078,6 +1080,8 @@ class Dispatcher:
             return _RERANK_DEFAULT
         if "/audio/speech" in path:
             return _TTS_DEFAULT
+        if "/images/" in path:
+            return _IMAGE_DEFAULT
         return _DEFAULT_MODEL
 
     def _registry_route_for(self, model_id: str) -> tuple[str, str] | None:

--- a/src/hal0/providers/comfyui.py
+++ b/src/hal0/providers/comfyui.py
@@ -7,7 +7,10 @@ OpenAI-shaped ``POST /v1/images/generations`` request is translated to a
 parametric workflow (see :mod:`hal0.providers.comfyui_workflows`) and the
 result PNG bytes are unwrapped back into the OpenAI response shape.
 
-Toolbox image:    ghcr.io/hal0ai/hal0-toolbox-comfyui:v1
+Toolbox image:    docker.io/kyuz0/amd-strix-halo-comfyui (manifest digest pin
+                  is the primary path; the :latest tag is the last-resort
+                  fallback). The kyuz0 image ships ComfyUI checked out at
+                  /opt/ComfyUI with its venv at /opt/venv — NOT /app.
 Backend default:  rocm  (Strix Halo iGPU is the v1 first-class target).
 
 Endpoints we touch on the upstream:
@@ -31,13 +34,12 @@ import logging
 import os
 import time
 import uuid
-from pathlib import Path
 from typing import Any
 
 import httpx
 
 from hal0.errors import Hal0Error
-from hal0.providers._gpu import resolve_gpu_group_ids
+from hal0.providers._gpu import resolve_gpu_device_paths, resolve_gpu_group_ids
 from hal0.providers.base import ContainerSpec, Provider
 from hal0.providers.comfyui_workflows import build_workflow
 
@@ -45,14 +47,26 @@ log = logging.getLogger(__name__)
 
 
 # ── Toolbox image ──────────────────────────────────────────────────────────────
-_HAL0_COMFYUI_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-comfyui:v1"
+# Last-resort fallback only — the manifest.json digest pin is the primary
+# path (see image_ref). Points at the kyuz0 Strix Halo build that the live
+# CT105 deployment validated.
+_HAL0_COMFYUI_IMAGE = "docker.io/kyuz0/amd-strix-halo-comfyui:latest"
 
-# In-container app + working-data layout. The toolbox image has ComfyUI
-# checked out at /app and stores models / outputs / custom_nodes under
-# /var/lib/hal0/comfyui (which we bind-mount from the host so weights
-# and custom nodes persist across container restarts).
-_COMFYUI_APP_DIR = "/app"
+# In-container app + working-data layout. The kyuz0 image has ComfyUI
+# checked out at /opt/ComfyUI (venv at /opt/venv). Host-side working data
+# (models / output / input / user / custom_nodes + extra_model_paths.yaml)
+# lives under _COMFYUI_DATA_ROOT and is bind-mounted in so weights and
+# custom nodes persist across container restarts.
+_COMFYUI_APP_DIR = "/opt/ComfyUI"
 _COMFYUI_BASE_DIR = "/var/lib/hal0/comfyui"
+
+# Host data root for the bind mounts. Overridable for tests / non-standard
+# installs via HAL0_COMFYUI_DATA_ROOT.
+_COMFYUI_DATA_ROOT = "/mnt/ai-models/comfyui"
+
+# Live-validated flag bundle (matches the "comfyui" seed profile). Used
+# when the slot has no resolvable profile.
+_DEFAULT_PROFILE_FLAGS = "--disable-mmap --bf16-vae --cache-none"
 
 # Default port — ComfyUI's stock listen port.
 _DEFAULT_PORT = 8188
@@ -147,8 +161,8 @@ class ComfyUIProvider(Provider):
         Resolution order (matches ``llama_server.image_ref``):
           1. ``slot_cfg["image"]`` — explicit override from slot TOML.
           2. ``HAL0_TOOLBOX_IMAGE_COMFYUI`` env var.
-          3. ``manifest.json`` digest pin (when published).
-          4. The default tag ``ghcr.io/hal0ai/hal0-toolbox-comfyui:v1``.
+          3. ``manifest.json`` digest pin (primary path).
+          4. The fallback tag ``docker.io/kyuz0/amd-strix-halo-comfyui:latest``.
         """
         override = slot_cfg.get("image") or slot_cfg.get("slot", {}).get("image")
         if override:
@@ -169,44 +183,75 @@ class ComfyUIProvider(Provider):
             pass
         return _HAL0_COMFYUI_IMAGE
 
+    def _profile_flags(self, slot_cfg: dict[str, Any]) -> str:
+        """Resolve the slot's profile to its flag bundle.
+
+        Same lookup as the llama-server path in
+        :mod:`hal0.providers.container` (resolve_profile +
+        resolve_profile_flags). Falls back to the live-validated default
+        bundle when the slot has no profile or the lookup fails — the img
+        slot must always come up with the bench-tuned flags.
+        """
+        profile_name = str(slot_cfg.get("profile") or slot_cfg.get("slot", {}).get("profile") or "")
+        if profile_name:
+            try:
+                from hal0.config.loader import resolve_profile
+                from hal0.config.schema import resolve_profile_flags
+
+                flags = resolve_profile_flags(resolve_profile(profile_name)).strip()
+                if flags:
+                    return flags
+            except Exception:
+                log.warning(
+                    "comfyui.profile_lookup_failed; using default flags",
+                    extra={"profile": profile_name},
+                )
+        return _DEFAULT_PROFILE_FLAGS
+
     def container_spec(
         self,
         slot_cfg: dict[str, Any],
         model_info: dict[str, Any],
     ) -> ContainerSpec:
-        """Build a ContainerSpec for ComfyUI in the toolbox image.
+        """Build a ContainerSpec replicating the live-validated CT105 deployment.
 
-        Strix Halo path: pass /dev/kfd + /dev/dri (ROCm + Vulkan share
-        the same node tree on Strix). Bind-mount /var/lib/hal0/comfyui
-        so models, custom_nodes, output, and input all survive container
-        restarts — losing a 6 GB SDXL checkpoint on a `docker rm` would
-        be bad operator UX.
+        Mirrors `docker inspect comfyui` on CT105 (migration = replicate
+        what works):
+          * argv: ``bash -lc 'cd /opt/ComfyUI && exec python main.py …'``
+            — the kyuz0 image needs the login shell to activate /opt/venv.
+          * mounts: ``<data_root>/models → /root/comfy-models`` plus
+            output/input/user/custom_nodes into /opt/ComfyUI, and
+            extra_model_paths.yaml read-only into the app dir.
+          * ``--ipc=host --shm-size=8g`` — Wan/Hunyuan video models need
+            shared memory.
+          * host networking — the LXC is the host; the ComfyUI web UI must
+            stay LAN-reachable on :8188 (pre-migration behavior).
+          * devices from :func:`resolve_gpu_device_paths` — explicit nodes,
+            podman doesn't recurse /dev/dri (same fix class as #674).
         """
         env = self.build_env(slot_cfg, model_info)
         port = int(env["HAL0_PORT"])
 
-        command: list[str] = [
-            "python",
-            "main.py",
-            "--listen",
-            "0.0.0.0",
-            "--port",
-            str(port),
-            "--base-directory",
-            _COMFYUI_BASE_DIR,
-        ]
+        flags = self._profile_flags(slot_cfg)
+        payload = (
+            f"cd {_COMFYUI_APP_DIR} && exec python main.py --listen 0.0.0.0 --port {port} {flags}"
+        ).strip()
+        command: list[str] = ["bash", "-lc", payload]
 
-        # Persistent ComfyUI state (models/checkpoints, models/loras,
-        # custom_nodes, output/, input/) lives under /var/lib/hal0/comfyui
-        # on both sides — paths match so the in-container workflow refs
-        # resolve to the same files as the registry pull layer wrote them.
-        mounts: list[tuple[str, str]] = [(_COMFYUI_BASE_DIR, _COMFYUI_BASE_DIR)]
-        # Keep the etc-hal0 mount consistent with llama-server so any
-        # operator-shipped workflow JSON under /etc/hal0/workflows/
-        # (future hook) is reachable.
-        config_root = "/etc/hal0"
-        if Path(config_root).is_dir():
-            mounts.append((config_root, config_root))
+        data_root = os.environ.get("HAL0_COMFYUI_DATA_ROOT", "").strip() or _COMFYUI_DATA_ROOT
+        # ":ro" suffix on the dst is how ContainerSpec expresses read-only
+        # mounts (_render_unit_from_spec emits --volume={src}:{dst} verbatim).
+        mounts: list[tuple[str, str]] = [
+            (f"{data_root}/models", "/root/comfy-models"),
+            (f"{data_root}/output", f"{_COMFYUI_APP_DIR}/output"),
+            (f"{data_root}/input", f"{_COMFYUI_APP_DIR}/input"),
+            (f"{data_root}/user", f"{_COMFYUI_APP_DIR}/user"),
+            (f"{data_root}/custom_nodes", f"{_COMFYUI_APP_DIR}/custom_nodes"),
+            (
+                f"{data_root}/extra_model_paths.yaml",
+                f"{_COMFYUI_APP_DIR}/extra_model_paths.yaml:ro",
+            ),
+        ]
 
         # Numeric GIDs for the host's render+video groups (see _gpu.py
         # and llama_server's notes on stock-ubuntu /etc/group).
@@ -217,13 +262,13 @@ class ComfyUIProvider(Provider):
             command=command,
             env={},
             mounts=mounts,
-            devices=["/dev/kfd", "/dev/dri"],
+            devices=resolve_gpu_device_paths(),
             cap_add=[],
-            security_opt=["seccomp=unconfined", "apparmor=unconfined"],
+            security_opt=["seccomp=unconfined", "apparmor=unconfined", "label=disable"],
             group_add=group_add,
             port=port,
             network_mode="host",
-            extra_args=[],
+            extra_args=["--ipc=host", "--shm-size=8g"],
         )
 
     # ── Health ─────────────────────────────────────────────────────────────────

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -312,9 +312,8 @@ def _spec_provider_for(slot_cfg: dict[str, Any]) -> Any | None:
     """Spec-building provider for non-llama container slots, or None.
 
     llama-server slots (GPU profiles) use the flag-bundle _render_unit path.
-    FLM (NPU) and Kokoro (CPU TTS) know their own argv; they build a
-    ContainerSpec rendered by _render_unit_from_spec. ComfyUI joins in
-    Phase D.
+    FLM (NPU), Kokoro (CPU TTS), and ComfyUI (image gen) know their own
+    argv; they build a ContainerSpec rendered by _render_unit_from_spec.
     """
     if str(slot_cfg.get("device", "")) == "npu":
         from hal0.providers.flm import FLMProvider
@@ -324,6 +323,14 @@ def _spec_provider_for(slot_cfg: dict[str, Any]) -> Any | None:
         from hal0.providers.kokoro import KokoroProvider
 
         return KokoroProvider()
+    if (
+        str(slot_cfg.get("provider", "")) == "comfyui"
+        or str(slot_cfg.get("profile", "")) == "comfyui"
+        or str(slot_cfg.get("type", "")) == "image"
+    ):
+        from hal0.providers.comfyui import ComfyUIProvider
+
+        return ComfyUIProvider()
     return None
 
 

--- a/src/hal0/slots/arbiter.py
+++ b/src/hal0/slots/arbiter.py
@@ -389,6 +389,56 @@ class GpuArbiter:
             self._persist()
             log.info("gpu_arbiter.llm_mode", extra={"restored": saved})
 
+    # ── idle-restore loop (D6) ───────────────────────────────────────────────
+
+    async def run_idle_loop(self, *, interval_s: float = 30.0) -> None:
+        """Background loop auto-restoring the LLM set after img idles out.
+
+        Runs forever, one tick per ``interval_s``. A tick restores iff the
+        mode is IMG, not pinned, the idle window has elapsed since the last
+        img activity (``idle_restore_minutes``; 0 = manual-only restore per
+        the #599 schema), and the img slot has no in-flight job — a long
+        Wan video render defers the restore until it finishes.
+
+        Tick exceptions are logged (``gpu_arbiter.idle_loop_error``) and the
+        loop keeps running; ``CancelledError`` propagates so the lifespan
+        can shut the task down cleanly.
+        """
+        while True:
+            await asyncio.sleep(interval_s)
+            try:
+                await self._idle_tick()
+            except asyncio.CancelledError:  # pragma: no cover — clean shutdown
+                raise
+            except Exception as exc:
+                log.warning(
+                    "gpu_arbiter.idle_loop_error",
+                    extra={"error": str(exc), "error_type": type(exc).__name__},
+                )
+
+    async def _idle_tick(self) -> None:
+        """One idle-restore evaluation; restores the LLM set when eligible."""
+        if self.idle_restore_minutes <= 0:
+            return  # 0 = manual-only restore (#599 schema), never auto
+        # status() is the single source of truth for the window math:
+        # idle_restore_at is None unless mode==img, unpinned, activity known.
+        restore_at = self.status()["idle_restore_at"]
+        if restore_at is None or time.time() < restore_at:
+            return
+        # Same img-group lookup ensure_img/restore_llm use — never hardcoded.
+        cfgs = await self._manager.iter_configs()
+        img_name = next(
+            (str(c.get("name") or "") for c in cfgs if gpu_exclusive_group(c) == "img"),
+            None,
+        )
+        if img_name is not None and self._manager.in_flight_count(img_name) > 0:
+            return  # in-flight img job — defer until it completes
+        await self.restore_llm()
+        log.info(
+            "gpu_arbiter.idle_restored",
+            extra={"idle_restore_minutes": self.idle_restore_minutes},
+        )
+
     # ── sync surface (lock-free; see module docstring for why safe) ─────────
 
     def guard_llm_dispatch(self, slot_name: str) -> None:

--- a/src/hal0/slots/arbiter.py
+++ b/src/hal0/slots/arbiter.py
@@ -306,7 +306,45 @@ class GpuArbiter:
             model_default = (
                 str(model_section.get("default") or "") if isinstance(model_section, dict) else ""
             )
-            await self._manager.load(img_name, model_default or None)
+            try:
+                await self._manager.load(img_name, model_default or None)
+            except Exception:
+                # D5 quality-gate I1: at this point the llm slots are already
+                # unloaded and mode=img is persisted. If we re-raised without
+                # rolling back, the guard would 503 ALL llm traffic and the
+                # mode==IMG no-op fast path above would swallow every retry
+                # without re-attempting the img load — a wedge with no
+                # automated escape (D6 idle-restore is not wired yet).
+                # Rollback: best-effort reload of the saved llm set, then
+                # ALWAYS persist mode=llm (even when rollback loads fail —
+                # the guard must never stay wedged), then re-raise.
+                restored: list[str] = []
+                failed: list[str] = []
+                for slot in llm_slots:
+                    try:
+                        await self._manager.load(slot, None)
+                        restored.append(slot)
+                    except Exception as rollback_exc:  # best-effort rollback
+                        failed.append(slot)
+                        log.warning(
+                            "gpu_arbiter.rollback_load_failed",
+                            extra={"slot": slot, "error": str(rollback_exc)},
+                        )
+                st["mode"] = GpuMode.LLM.value
+                # Failed slots stay offline (operator reloads manually); a
+                # saved set is meaningless in llm mode, so clear it.
+                st["saved_llm_slots"] = []
+                st["pinned"] = False
+                self._persist()
+                log.warning(
+                    "gpu_arbiter.img_load_failed_rolled_back",
+                    extra={
+                        "img_slot": img_name,
+                        "restored": restored,
+                        "failed": failed,
+                    },
+                )
+                raise
 
             # last_img_activity was stamped in the pre-unload persist above;
             # no second persist needed here (spec-review tidy).

--- a/src/hal0/slots/arbiter.py
+++ b/src/hal0/slots/arbiter.py
@@ -81,17 +81,23 @@ def gpu_exclusive_group(slot_cfg: dict[str, Any]) -> Literal["llm", "img"] | Non
     arbitrated. The img signal is provider/profile ``comfyui`` or slot
     ``type == "image"``; any other GPU container slot is an llm-group slot.
 
+    "Container" mirrors ``SlotManager._is_container_slot`` exactly:
+    ``runtime == "container"`` OR a non-empty ``profile`` — the profile is
+    the primary signal (schema doc: profile wins regardless of ``runtime``;
+    spec §9 deprecates ``runtime``). A profile-only GPU slot MUST be
+    arbitrated or it would collide with the img slot on the single iGPU.
+
     A missing ``device`` defaults to ``gpu-rocm`` (mirrors
     ``SlotManager.add_slot`` / ``hal0.config.schema.DEFAULT_DEVICE``); a
-    missing ``runtime`` defaults to ``lemonade`` (mirrors
-    ``SlotManager._is_container_slot``).
+    missing ``runtime`` defaults to ``lemonade``.
     """
     device = str(slot_cfg.get("device") or "gpu-rocm")
     runtime = str(slot_cfg.get("runtime") or "lemonade")
-    if device not in _GPU_DEVICES or runtime != "container":
+    profile = str(slot_cfg.get("profile") or "")
+    is_container = runtime == "container" or bool(profile.strip())
+    if device not in _GPU_DEVICES or not is_container:
         return None
     provider = str(slot_cfg.get("provider") or "")
-    profile = str(slot_cfg.get("profile") or "")
     slot_type = str(slot_cfg.get("type") or "")
     if provider == "comfyui" or profile == "comfyui" or slot_type == "image":
         return "img"
@@ -302,7 +308,8 @@ class GpuArbiter:
             )
             await self._manager.load(img_name, model_default or None)
 
-            self.touch_img_activity()
+            # last_img_activity was stamped in the pre-unload persist above;
+            # no second persist needed here (spec-review tidy).
             log.info(
                 "gpu_arbiter.img_mode",
                 extra={"saved_llm_slots": llm_slots, "img_slot": img_name},

--- a/src/hal0/slots/arbiter.py
+++ b/src/hal0/slots/arbiter.py
@@ -1,0 +1,398 @@
+"""GpuArbiter — exclusive llm/img GPU group arbitration (spec §7, Phase D).
+
+Strix Halo has ONE iGPU shared via GTT. LLM containers and the ComfyUI
+image-gen container cannot share it, so the arbiter flips the GPU between
+two exclusive groups:
+
+  - ``llm`` — GPU llama-server containers (chat, agent, utility, rerank…)
+  - ``img`` — the ComfyUI container slot
+
+Groups are DERIVED from slot configs (:func:`gpu_exclusive_group`), never
+declared: a slot is arbitrated iff it runs on the GPU (``gpu-rocm`` /
+``gpu-vulkan``) AND in a container. Lemonade-runtime, NPU and CPU slots are
+never arbitrated.
+
+Crash-recovery ordering (locked): the arbiter persists its target state to
+``/var/lib/hal0/gpu_arbiter.json`` BEFORE the first unload, so an api
+restart mid-switch can still restore the saved LLM set.
+
+Concurrency model (single asyncio event loop):
+
+  - ``ensure_img()`` / ``restore_llm()`` — the only mutating switches —
+    serialize on one ``asyncio.Lock``; concurrent flips are impossible.
+  - ``guard_llm_dispatch()`` / ``status()`` / ``touch_img_activity()`` /
+    ``set_pin()`` are synchronous and lock-free. This is safe because they
+    contain no ``await`` points: on a single event loop a sync method runs
+    to completion atomically relative to the (async) switch methods, which
+    can only interleave at their own awaits. The shared ``_state`` dict is
+    only ever mutated from the loop thread, and every mutation is followed
+    by an atomic same-directory ``os.replace`` persist, so on-disk readers
+    never observe a torn file. The one deliberate "race": ensure_img
+    persists ``mode=img`` before draining, so the guard refuses NEW llm
+    dispatches during the drain window — that is desired (prevents drain
+    starvation).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+import time
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from hal0.config import paths
+from hal0.errors import Hal0Error, NotFound
+
+if TYPE_CHECKING:  # pragma: no cover — import cycle guard (manager owns us)
+    from hal0.slots.manager import SlotManager
+
+log = logging.getLogger(__name__)
+
+#: Devices that contend for the single iGPU.
+_GPU_DEVICES = frozenset({"gpu-rocm", "gpu-vulkan"})
+
+#: Drain budget before proceeding with unloads anyway (manual pin is the
+#: escape hatch per spec §7 — never wedge image mode behind a stuck request).
+_DRAIN_TIMEOUT_S = 120.0
+_DRAIN_POLL_S = 0.5
+
+#: Minimum Retry-After hint carried by GpuImageMode (matches the dispatcher's
+#: slot-loading convention in dispatcher/router.py).
+_RETRY_AFTER_FLOOR_S = 15
+
+_DEFAULT_STATE: dict[str, Any] = {
+    "mode": "llm",
+    "pinned": False,
+    "saved_llm_slots": [],
+    "last_img_activity": None,
+}
+
+
+def gpu_exclusive_group(slot_cfg: dict[str, Any]) -> Literal["llm", "img"] | None:
+    """Derive the exclusive-GPU group for a raw slot-config dict.
+
+    Returns ``"img"`` / ``"llm"`` for GPU container slots, ``None`` for
+    everything else (npu/cpu devices, lemonade runtime) — those are never
+    arbitrated. The img signal is provider/profile ``comfyui`` or slot
+    ``type == "image"``; any other GPU container slot is an llm-group slot.
+
+    A missing ``device`` defaults to ``gpu-rocm`` (mirrors
+    ``SlotManager.add_slot`` / ``hal0.config.schema.DEFAULT_DEVICE``); a
+    missing ``runtime`` defaults to ``lemonade`` (mirrors
+    ``SlotManager._is_container_slot``).
+    """
+    device = str(slot_cfg.get("device") or "gpu-rocm")
+    runtime = str(slot_cfg.get("runtime") or "lemonade")
+    if device not in _GPU_DEVICES or runtime != "container":
+        return None
+    provider = str(slot_cfg.get("provider") or "")
+    profile = str(slot_cfg.get("profile") or "")
+    slot_type = str(slot_cfg.get("type") or "")
+    if provider == "comfyui" or profile == "comfyui" or slot_type == "image":
+        return "img"
+    return "llm"
+
+
+class GpuMode(StrEnum):
+    LLM = "llm"
+    IMG = "img"
+
+
+class GpuImageMode(Hal0Error):
+    """LLM dispatch refused — the GPU is in exclusive image mode."""
+
+    code = "gpu.image_mode"
+    status = 503
+
+
+class ArbiterPinned(Hal0Error):
+    """Restore refused — image mode is manually pinned (force to override)."""
+
+    code = "gpu.pinned"
+    status = 409
+
+
+class GpuArbiter:
+    """Owns the llm ⇄ img exclusive-GPU switch for one :class:`SlotManager`."""
+
+    def __init__(
+        self,
+        manager: SlotManager,
+        *,
+        state_path: Path,
+        idle_restore_minutes: int = 5,
+    ) -> None:
+        self._manager = manager
+        self.state_path = Path(state_path)
+        self.idle_restore_minutes = int(idle_restore_minutes)
+        # ONE lock around any whole switch — no concurrent flips.
+        self._switch_lock = asyncio.Lock()
+        # Lazily-read persisted state (None until first access).
+        self._state: dict[str, Any] | None = None
+        # name → group, refreshed from iter_configs() on every switch; lets
+        # the sync guard answer without I/O for slots seen this process.
+        self._group_cache: dict[str, str | None] = {}
+
+    # ── persisted state ──────────────────────────────────────────────────────
+
+    def _load_state(self) -> dict[str, Any]:
+        """Lazily read gpu_arbiter.json; tolerate missing/corrupt files."""
+        if self._state is None:
+            st = dict(_DEFAULT_STATE)
+            try:
+                data = json.loads(self.state_path.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    st.update({k: data[k] for k in _DEFAULT_STATE if k in data})
+            except FileNotFoundError:
+                pass
+            except (OSError, json.JSONDecodeError) as exc:
+                log.warning(
+                    "gpu_arbiter.state_unreadable",
+                    extra={"path": str(self.state_path), "error": str(exc)},
+                )
+            if st.get("mode") not in (GpuMode.LLM.value, GpuMode.IMG.value):
+                st["mode"] = GpuMode.LLM.value
+            st["saved_llm_slots"] = [str(s) for s in st.get("saved_llm_slots") or []]
+            self._state = st
+        return self._state
+
+    def _persist(self) -> None:
+        """Atomic same-directory tmpfile + os.replace (state.json pattern)."""
+        st = self._load_state()
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path: Path | None = None
+        try:
+            fd, tmp_str = tempfile.mkstemp(
+                prefix=".hal0-gpu-arbiter-", suffix=".tmp", dir=self.state_path.parent
+            )
+            tmp_path = Path(tmp_str)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(st, f, indent=2)
+            os.replace(tmp_path, self.state_path)
+            tmp_path = None
+        finally:
+            if tmp_path is not None:
+                tmp_path.unlink(missing_ok=True)
+
+    @property
+    def mode(self) -> GpuMode:
+        return GpuMode(self._load_state()["mode"])
+
+    @property
+    def pinned(self) -> bool:
+        return bool(self._load_state()["pinned"])
+
+    @property
+    def saved_llm_slots(self) -> tuple[str, ...]:
+        return tuple(self._load_state()["saved_llm_slots"])
+
+    # ── group resolution ─────────────────────────────────────────────────────
+
+    def _refresh_group_cache(self, cfgs: list[dict[str, Any]]) -> None:
+        self._group_cache = {str(c.get("name") or ""): gpu_exclusive_group(c) for c in cfgs}
+
+    def _slot_group(self, name: str) -> str | None:
+        """Sync group lookup for the dispatch guard.
+
+        Cache-first (populated by every switch), then a direct slot-TOML
+        read (restart case — mirrors the sync-read precedent of
+        ``SlotManager.idle_timeout_by_model``), then saved-set membership
+        as the last resort (in-memory-only slots without a TOML).
+        """
+        if name in self._group_cache:
+            return self._group_cache[name]
+        cfg = self._read_slot_toml(name)
+        if cfg is not None:
+            group = gpu_exclusive_group(cfg)
+            self._group_cache[name] = group
+            return group
+        if name in self._load_state()["saved_llm_slots"]:
+            return "llm"
+        return None
+
+    def _read_slot_toml(self, name: str) -> dict[str, Any] | None:
+        """Best-effort sync read of the slot's TOML; None if missing/bad."""
+        import tomllib
+
+        config_file = getattr(self._manager, "_config_file", None)
+        path = (
+            config_file(name)
+            if callable(config_file)
+            else (paths.slots_config_dir() / f"{name}.toml")
+        )
+        try:
+            with open(path, "rb") as f:
+                return tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError):
+            return None
+
+    def _resolve_alias(self, name: str) -> str:
+        resolve = getattr(self._manager, "_resolve_alias", None)
+        return resolve(name) if callable(resolve) else name
+
+    # ── switches ─────────────────────────────────────────────────────────────
+
+    async def ensure_img(self, *, pin: bool = False) -> None:
+        """Flip the GPU to exclusive image mode (no-op when already there).
+
+        Order (locked): snapshot running llm slots → persist target state
+        FIRST → drain in-flight requests (bounded) → unload llm slots →
+        load the img slot's default model → stamp activity.
+        """
+        async with self._switch_lock:
+            st = self._load_state()
+            if st["mode"] == GpuMode.IMG.value:
+                if pin and not st["pinned"]:
+                    st["pinned"] = True
+                    self._persist()
+                return
+
+            cfgs = await self._manager.iter_configs()
+            self._refresh_group_cache(cfgs)
+            img_cfg = next((c for c in cfgs if gpu_exclusive_group(c) == "img"), None)
+            if img_cfg is None:
+                raise NotFound(
+                    "no image-group slot is configured; cannot enter image mode",
+                    details={"hint": "seed the img (ComfyUI) slot first"},
+                    code="gpu.img_slot_missing",
+                )
+            llm_slots = [
+                str(c.get("name") or "")
+                for c in cfgs
+                if gpu_exclusive_group(c) == "llm"
+                and self._manager.is_ready_for_dispatch(str(c.get("name") or ""))
+            ]
+
+            # Persist BEFORE unloads begin (crash-recovery ordering): a
+            # restart from here on knows the saved set and the target mode.
+            st["mode"] = GpuMode.IMG.value
+            st["saved_llm_slots"] = llm_slots
+            st["pinned"] = bool(st["pinned"] or pin)
+            st["last_img_activity"] = time.time()
+            self._persist()
+
+            # Drain in-flight llm requests, bounded — proceed on timeout
+            # (manual pin is the escape hatch per spec §7).
+            deadline = time.monotonic() + _DRAIN_TIMEOUT_S
+            while any(self._manager.in_flight_count(s) for s in llm_slots):
+                if time.monotonic() >= deadline:
+                    log.warning(
+                        "gpu_arbiter.drain_timeout",
+                        extra={
+                            "slots": llm_slots,
+                            "timeout_s": _DRAIN_TIMEOUT_S,
+                            "in_flight": {s: self._manager.in_flight_count(s) for s in llm_slots},
+                        },
+                    )
+                    break
+                await asyncio.sleep(_DRAIN_POLL_S)
+
+            for slot in llm_slots:
+                await self._manager.unload(slot)
+
+            img_name = str(img_cfg.get("name") or "img")
+            model_section = img_cfg.get("model")
+            model_default = (
+                str(model_section.get("default") or "") if isinstance(model_section, dict) else ""
+            )
+            await self._manager.load(img_name, model_default or None)
+
+            self.touch_img_activity()
+            log.info(
+                "gpu_arbiter.img_mode",
+                extra={"saved_llm_slots": llm_slots, "img_slot": img_name},
+            )
+
+    async def restore_llm(self, *, force: bool = False) -> None:
+        """Restore the saved LLM set (no-op in LLM mode).
+
+        Refuses while pinned unless ``force=True`` (which also clears the
+        pin). Order: unload img FIRST, then reload the saved set, then
+        persist ``mode=llm`` — a crash mid-restore leaves mode IMG on disk
+        so the restore can simply be retried.
+        """
+        async with self._switch_lock:
+            st = self._load_state()
+            if st["mode"] != GpuMode.IMG.value:
+                return
+            if st["pinned"] and not force:
+                raise ArbiterPinned(
+                    "GPU image mode is pinned; pass force=true to restore LLM slots",
+                    details={"pinned": True},
+                )
+
+            cfgs = await self._manager.iter_configs()
+            self._refresh_group_cache(cfgs)
+            img_name = next(
+                (str(c.get("name") or "") for c in cfgs if gpu_exclusive_group(c) == "img"),
+                "img",
+            )
+            saved = list(st["saved_llm_slots"])
+
+            await self._manager.unload(img_name)
+            for slot in saved:
+                await self._manager.load(slot, None)
+
+            st["mode"] = GpuMode.LLM.value
+            st["saved_llm_slots"] = []
+            st["pinned"] = False
+            self._persist()
+            log.info("gpu_arbiter.llm_mode", extra={"restored": saved})
+
+    # ── sync surface (lock-free; see module docstring for why safe) ─────────
+
+    def guard_llm_dispatch(self, slot_name: str) -> None:
+        """Raise :class:`GpuImageMode` when *slot_name* can't dispatch.
+
+        Cheap in the hot path: a single in-memory mode check in LLM mode;
+        group derivation only happens while the GPU is in image mode.
+        """
+        st = self._load_state()
+        if st["mode"] != GpuMode.IMG.value:
+            return
+        name = self._resolve_alias(slot_name)
+        if self._slot_group(name) != "llm":
+            return
+        raise GpuImageMode(
+            f"GPU is in exclusive image mode; LLM slot {name!r} is unavailable "
+            f"until image mode ends",
+            details={"slot": name, "retry_after_s": self._retry_after_s(st)},
+        )
+
+    def _retry_after_s(self, st: dict[str, Any]) -> int:
+        """Remaining idle-restore window, floored at 15s (D6 owns the loop)."""
+        last = st.get("last_img_activity")
+        if not isinstance(last, (int, float)):
+            return _RETRY_AFTER_FLOOR_S
+        restore_at = float(last) + self.idle_restore_minutes * 60
+        return max(_RETRY_AFTER_FLOOR_S, int(restore_at - time.time()))
+
+    def touch_img_activity(self) -> None:
+        """Stamp last_img_activity + persist (cheap json write)."""
+        st = self._load_state()
+        st["last_img_activity"] = time.time()
+        self._persist()
+
+    def set_pin(self, pinned: bool) -> None:
+        st = self._load_state()
+        st["pinned"] = bool(pinned)
+        self._persist()
+
+    def status(self) -> dict[str, Any]:
+        """Snapshot for the API / the D6 idle-restore loop."""
+        st = self._load_state()
+        idle_restore_at: float | None = None
+        last = st.get("last_img_activity")
+        if st["mode"] == GpuMode.IMG.value and not st["pinned"] and isinstance(last, (int, float)):
+            idle_restore_at = float(last) + self.idle_restore_minutes * 60
+        return {
+            "mode": st["mode"],
+            "pinned": bool(st["pinned"]),
+            "saved_llm_slots": list(st["saved_llm_slots"]),
+            "idle_restore_at": idle_restore_at,
+        }

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -62,6 +62,7 @@ from hal0.slots.state import (
 
 if TYPE_CHECKING:
     from hal0.config.schema import SlotConfig
+    from hal0.slots.arbiter import GpuArbiter
 
 log = logging.getLogger(__name__)
 
@@ -288,6 +289,10 @@ class SlotManager:
         self._idle_after_s: float = idle_after_s
         self._idle_monitor_interval_s: float = idle_monitor_interval_s
         self._idle_monitor_task: asyncio.Task[None] | None = None
+        # GpuArbiter (Phase D, spec §7) — constructed lazily on first
+        # ``.arbiter`` access so CLI/test contexts that never touch image
+        # mode pay nothing. See the ``arbiter`` property below.
+        self._arbiter: GpuArbiter | None = None
 
     # ── helpers ──────────────────────────────────────────────────────────────
 
@@ -2033,6 +2038,55 @@ class SlotManager:
     def in_flight_count(self, slot_name: str) -> int:
         """Return the number of currently-active ``serving()`` contexts."""
         return self._serving_count.get(slot_name, 0)
+
+    # ── GpuArbiter (Phase D, spec §7) ────────────────────────────────────────
+
+    @property
+    def arbiter(self) -> GpuArbiter:
+        """Lazily-constructed exclusive-GPU arbiter (llm ⇄ img groups).
+
+        State persists under the same var-lib root the slot state files
+        use (``paths.var_lib()``, HAL0_HOME-redirected in tests).
+        ``idle_restore_minutes`` comes from the img slot's ``[image]``
+        section when one is configured (D1), default 5.
+        """
+        if self._arbiter is None:
+            from hal0.slots.arbiter import GpuArbiter
+
+            self._arbiter = GpuArbiter(
+                self,
+                state_path=paths.var_lib() / "gpu_arbiter.json",
+                idle_restore_minutes=self._img_idle_restore_minutes(),
+            )
+        return self._arbiter
+
+    def _img_idle_restore_minutes(self) -> int:
+        """Read ``[image].idle_restore_minutes`` from the img-group slot TOML.
+
+        Synchronous direct TOML scan, mirroring ``idle_timeout_by_model``
+        (the ``arbiter`` property can't await). The first slot whose config
+        derives to the ``img`` exclusive group wins; missing/invalid values
+        fall back to the spec default of 5 minutes.
+        """
+        import tomllib
+
+        from hal0.slots.arbiter import gpu_exclusive_group
+
+        for name in self._all_configured_slot_names():
+            path = self._config_file(name)
+            try:
+                with open(path, "rb") as f:
+                    data = tomllib.load(f)
+            except (OSError, tomllib.TOMLDecodeError):
+                continue
+            if gpu_exclusive_group(data) != "img":
+                continue
+            image = data.get("image") or data.get("image_gen") or {}
+            val = image.get("idle_restore_minutes") if isinstance(image, dict) else None
+            if isinstance(val, int) and not isinstance(val, bool) and val > 0:
+                return val
+            return 5
+        return 5
 
     # ── IDLE monitor ─────────────────────────────────────────────────────────
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -2066,7 +2066,9 @@ class SlotManager:
         Synchronous direct TOML scan, mirroring ``idle_timeout_by_model``
         (the ``arbiter`` property can't await). The first slot whose config
         derives to the ``img`` exclusive group wins; missing/invalid values
-        fall back to the spec default of 5 minutes.
+        (negatives, bools, non-ints) fall back to the spec default of 5
+        minutes. ``0`` is VALID and means manual-only restore (#599 schema)
+        — the arbiter's idle loop never auto-restores on a zero window.
         """
         import tomllib
 
@@ -2083,7 +2085,7 @@ class SlotManager:
                 continue
             image = data.get("image") or data.get("image_gen") or {}
             val = image.get("idle_restore_minutes") if isinstance(image, dict) else None
-            if isinstance(val, int) and not isinstance(val, bool) and val > 0:
+            if isinstance(val, int) and not isinstance(val, bool) and val >= 0:
                 return val
             return 5
         return 5

--- a/tests/api/test_comfyui_proxy.py
+++ b/tests/api/test_comfyui_proxy.py
@@ -13,15 +13,17 @@ crash on a dead container):
 The switchover *write* path (POST /api/comfyui/switchover) is feature-gated
 behind ``HAL0_COMFYUI_SWITCHOVER_ENABLED`` (501 when off). When on it validates
 the target mode, no-ops if already there, refuses to drop a busy render queue
-without ``force``, and runs the script pair in the background behind a 202 —
+without ``force``, and drives the GpuArbiter in the background behind a 202 —
 the ``switchover`` block on /status is what tracks the transition to terminal.
-Scripts are never actually executed here: the subprocess seam (``_run_script``)
-is patched, mirroring the status seams.
+No subprocess is ever spawned for the switch (the shell-script path is retired):
+tests install a stub arbiter on ``app.state.slot_manager`` and assert the
+arbiter calls, mirroring the patched status seams.
 """
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -164,9 +166,6 @@ def test_status_inventory_is_none_when_share_absent(client: TestClient, tmp_path
     assert r.json()["inventory"] is None
 
 
-_BASE = "hal0.api.routes.comfyui"
-
-
 @pytest.fixture(autouse=True)
 def _reset_comfyui_module_state():
     # The switchover tracker is module-global (the app object is per-test but the
@@ -178,37 +177,85 @@ def _reset_comfyui_module_state():
     comfyui_mod._reset_state()
 
 
-def test_switchover_to_generation_runs_script_pair_in_order(
+class _StubArbiter:
+    """Stands in for ``manager.arbiter`` — the D4-D6 GpuArbiter surface."""
+
+    def __init__(self) -> None:
+        self.ensure_img = AsyncMock()
+        self.restore_llm = AsyncMock()
+        self.set_pin = Mock()
+        self.status = Mock(
+            return_value={
+                "mode": "llm",
+                "pinned": False,
+                "saved_llm_slots": [],
+                "idle_restore_at": None,
+            }
+        )
+
+
+def _install_arbiter(client: TestClient) -> _StubArbiter:
+    """Hang a stub manager+arbiter on app.state, the way the route finds it."""
+    arb = _StubArbiter()
+    client.app.state.slot_manager = SimpleNamespace(arbiter=arb)
+    return arb
+
+
+def test_switchover_generation_calls_arbiter(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # ON: stop the LLM stack, then bring the container up — exactly that pair,
-    # exactly that order, kicked off in the background behind a 202.
+    # ON: the background task drives arbiter.ensure_img — NO subprocess, the
+    # shell-script seam is gone from the module entirely.
     monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    arb = _install_arbiter(client)
     c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
-    with c, s, f, patch(f"{_BASE}._run_script", new_callable=AsyncMock) as run:
+    with c, s, f:
         r = client.post("/api/comfyui/switchover", json={"mode": "generation"})
     assert r.status_code == 202
-    assert r.json() == {
-        "status": "switching",
-        "mode": "generation",
-        "scripts": ["stop-inference.sh", "comfy-up.sh"],
-    }
-    assert [call.args[0] for call in run.await_args_list] == ["stop-inference.sh", "comfy-up.sh"]
+    assert r.json() == {"status": "switching", "mode": "generation"}
+    arb.ensure_img.assert_awaited_once_with(pin=False)
+    arb.restore_llm.assert_not_awaited()
+    from hal0.api.routes import comfyui as comfyui_mod
+
+    assert not hasattr(comfyui_mod, "_run_script")  # scripts retired for real
 
 
-def test_switchover_force_to_inference_runs_pair_despite_busy_queue(
+def test_switchover_inference_calls_restore(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # The UI confirm dialog already warned that queued jobs drop — force wins.
     monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    arb = _install_arbiter(client)
+    c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_idle)
+    with c, s, f:
+        r = client.post("/api/comfyui/switchover", json={"mode": "inference"})
+    assert r.status_code == 202
+    arb.restore_llm.assert_awaited_once_with(force=False)
+    arb.ensure_img.assert_not_awaited()
+
+
+def test_switchover_pin_param(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    # {"pin": true} rides along to ensure_img so generation can hold the GPU.
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    arb = _install_arbiter(client)
+    c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
+    with c, s, f:
+        r = client.post("/api/comfyui/switchover", json={"mode": "generation", "pin": True})
+    assert r.status_code == 202
+    arb.ensure_img.assert_awaited_once_with(pin=True)
+
+
+def test_switchover_force_passes_to_restore(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The UI confirm dialog already warned that queued jobs drop — force wins
+    # over the busy queue AND propagates to restore_llm (pin override).
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    arb = _install_arbiter(client)
     c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_busy)
-    with c, s, f, patch(f"{_BASE}._run_script", new_callable=AsyncMock) as run:
+    with c, s, f:
         r = client.post("/api/comfyui/switchover", json={"mode": "inference", "force": True})
     assert r.status_code == 202
-    assert [call.args[0] for call in run.await_args_list] == [
-        "comfy-down.sh",
-        "start-inference.sh",
-    ]
+    arb.restore_llm.assert_awaited_once_with(force=True)
 
 
 def test_switchover_refused_while_another_switch_in_flight(
@@ -221,25 +268,28 @@ def test_switchover_refused_while_another_switch_in_flight(
     comfyui_mod = _reset_comfyui_module_state
     comfyui_mod._switch["active"] = True
     comfyui_mod._switch["target"] = "generation"
+    arb = _install_arbiter(client)
     c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
-    with c, s, f, patch(f"{_BASE}._run_script", new_callable=AsyncMock) as run:
+    with c, s, f:
         r = client.post("/api/comfyui/switchover", json={"mode": "inference"})
     assert r.status_code == 409
     assert r.json()["error"]["code"] == "comfyui.switch_in_progress"
-    run.assert_not_called()
+    arb.ensure_img.assert_not_awaited()
+    arb.restore_llm.assert_not_awaited()
 
 
 def test_switchover_noop_when_already_in_generation_mode(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Container already running → target reached; never re-run the scripts.
+    # Container already running → target reached; never re-drive the arbiter.
     monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    arb = _install_arbiter(client)
     c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_idle)
-    with c, s, f, patch(f"{_BASE}._run_script", new_callable=AsyncMock) as run:
+    with c, s, f:
         r = client.post("/api/comfyui/switchover", json={"mode": "generation"})
     assert r.status_code == 200
     assert r.json() == {"status": "noop", "mode": "generation"}
-    run.assert_not_called()
+    arb.ensure_img.assert_not_awaited()
 
 
 def test_switchover_noop_when_already_in_inference_mode(
@@ -247,12 +297,13 @@ def test_switchover_noop_when_already_in_inference_mode(
 ) -> None:
     # Container down AND lemonade up → inference already owns the GPU.
     monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    arb = _install_arbiter(client)
     c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
-    with c, s, f, patch(f"{_BASE}._run_script", new_callable=AsyncMock) as run:
+    with c, s, f:
         r = client.post("/api/comfyui/switchover", json={"mode": "inference"})
     assert r.status_code == 200
     assert r.json() == {"status": "noop", "mode": "inference"}
-    run.assert_not_called()
+    arb.restore_llm.assert_not_awaited()
 
 
 def test_switchover_to_inference_refused_while_queue_busy(
@@ -261,12 +312,13 @@ def test_switchover_to_inference_refused_while_queue_busy(
     # Tearing ComfyUI down mid-render kills the running + queued jobs — refuse
     # unless the caller explicitly forces it (the UI confirm dialog is the force).
     monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    arb = _install_arbiter(client)
     c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_busy)
-    with c, s, f, patch(f"{_BASE}._run_script", new_callable=AsyncMock) as run:
+    with c, s, f:
         r = client.post("/api/comfyui/switchover", json={"mode": "inference"})
     assert r.status_code == 409
     assert r.json()["error"]["code"] == "comfyui.busy"
-    run.assert_not_called()
+    arb.restore_llm.assert_not_awaited()
 
 
 def test_status_exposes_switchover_state(client: TestClient, _reset_comfyui_module_state) -> None:
@@ -281,77 +333,86 @@ def test_status_exposes_switchover_state(client: TestClient, _reset_comfyui_modu
     assert active == {"active": True, "target": "generation", "error": None}
 
 
-def test_switchover_script_failure_is_surfaced_in_status(
+def test_switchover_arbiter_error_recorded(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # A failed script must not strand the tracker as active, and the error must
-    # be visible to the pane on the next poll — never silently swallowed.
+    # A failed arbiter switch (incl. ArbiterPinned) must not strand the tracker
+    # as active, and the error must be visible on the next poll — same contract
+    # the script failures had. Never silently swallowed, never a raised 500.
     monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    arb = _install_arbiter(client)
+    arb.ensure_img.side_effect = RuntimeError("img slot failed to load")
     c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
-    boom = AsyncMock(side_effect=RuntimeError("stop-inference.sh exited 1"))
-    with c, s, f, patch(f"{_BASE}._run_script", boom):
+    with c, s, f:
         r = client.post("/api/comfyui/switchover", json={"mode": "generation"})
         assert r.status_code == 202
         sw = client.get("/api/comfyui/status").json()["switchover"]
     assert sw["active"] is False
-    assert "stop-inference.sh exited 1" in sw["error"]
+    assert "img slot failed to load" in sw["error"]
 
 
-def test_script_argv_runs_directly_when_root(monkeypatch: pytest.MonkeyPatch) -> None:
-    # hal0-api runs as root on CT105 today — exec the script straight.
-    from hal0.api.routes import comfyui as m
+def test_pin_endpoint_toggles(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Same 501 feature gate as the switchover, then a plain set_pin passthrough
+    # that reflects the new value back.
+    arb = _install_arbiter(client)
+    r = client.post("/api/comfyui/pin", json={"pinned": True})
+    assert r.status_code == 501
+    arb.set_pin.assert_not_called()
 
-    monkeypatch.setenv("COMFYUI_SCRIPTS_DIR", "/opt/comfyui")
-    monkeypatch.setattr(m.os, "geteuid", lambda: 0)
-    assert m._script_argv("comfy-up.sh") == ["/opt/comfyui/comfy-up.sh"]
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    r = client.post("/api/comfyui/pin", json={"pinned": True})
+    assert r.status_code == 200
+    assert r.json() == {"pinned": True}
+    arb.set_pin.assert_called_once_with(True)
 
-
-def test_script_argv_uses_sudo_n_when_unprivileged(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Hardened install (hal0-api as the hal0 user): go through the narrow
-    # sudoers.d/hal0-comfyui grant. -n so a missing grant fails fast, not hangs.
-    from hal0.api.routes import comfyui as m
-
-    monkeypatch.setenv("COMFYUI_SCRIPTS_DIR", "/opt/comfyui")
-    monkeypatch.setattr(m.os, "geteuid", lambda: 1000)
-    assert m._script_argv("stop-inference.sh") == ["sudo", "-n", "/opt/comfyui/stop-inference.sh"]
-
-
-async def test_run_script_executes_real_script(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    from hal0.api.routes import comfyui as m
-
-    marker = tmp_path / "ran"
-    script = tmp_path / "ok.sh"
-    script.write_text(f"#!/usr/bin/env bash\ntouch {marker}\n")
-    script.chmod(0o755)
-    monkeypatch.setenv("COMFYUI_SCRIPTS_DIR", str(tmp_path))
-    monkeypatch.setattr(m.os, "geteuid", lambda: 0)
-    await m._run_script("ok.sh")
-    assert marker.exists()
+    r = client.post("/api/comfyui/pin", json={"pinned": False})
+    assert r.status_code == 200
+    assert r.json() == {"pinned": False}
+    arb.set_pin.assert_called_with(False)
 
 
-async def test_run_script_raises_on_nonzero_exit(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    from hal0.api.routes import comfyui as m
-
-    script = tmp_path / "bad.sh"
-    script.write_text("#!/usr/bin/env bash\necho boom >&2\nexit 3\n")
-    script.chmod(0o755)
-    monkeypatch.setenv("COMFYUI_SCRIPTS_DIR", str(tmp_path))
-    monkeypatch.setattr(m.os, "geteuid", lambda: 0)
-    with pytest.raises(RuntimeError, match=r"bad\.sh.*3"):
-        await m._run_script("bad.sh")
+def test_pin_endpoint_rejects_non_bool_body(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    arb = _install_arbiter(client)
+    r = client.post("/api/comfyui/pin", json={"pinned": "yes"})
+    assert r.status_code == 422
+    arb.set_pin.assert_not_called()
 
 
-async def test_run_script_raises_on_timeout(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    from hal0.api.routes import comfyui as m
+def test_status_carries_arbiter_block(client: TestClient) -> None:
+    # /status folds arbiter.status() in under "arbiter" so the pane can render
+    # mode/pin/idle-restore without a second endpoint.
+    arb = _install_arbiter(client)
+    arb.status.return_value = {
+        "mode": "img",
+        "pinned": True,
+        "saved_llm_slots": ["primary", "utility"],
+        "idle_restore_at": None,
+    }
+    c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_idle)
+    with c, s, f:
+        r = client.get("/api/comfyui/status")
+    assert r.status_code == 200
+    assert r.json()["arbiter"] == {
+        "mode": "img",
+        "pinned": True,
+        "saved_llm_slots": ["primary", "utility"],
+        "idle_restore_at": None,
+    }
 
-    script = tmp_path / "slow.sh"
-    script.write_text("#!/usr/bin/env bash\nsleep 5\n")
-    script.chmod(0o755)
-    monkeypatch.setenv("COMFYUI_SCRIPTS_DIR", str(tmp_path))
-    monkeypatch.setenv("COMFYUI_SCRIPT_TIMEOUT", "0.2")
-    monkeypatch.setattr(m.os, "geteuid", lambda: 0)
-    with pytest.raises(RuntimeError, match=r"slow\.sh.*timed out"):
-        await m._run_script("slow.sh")
+
+def test_status_arbiter_fail_soft(client: TestClient) -> None:
+    # The status route is fail-soft by design — an arbiter blow-up degrades to
+    # "arbiter": null, the rest of the pane keeps rendering.
+    arb = _install_arbiter(client)
+    arb.status.side_effect = RuntimeError("state file corrupt")
+    c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
+    with c, s, f:
+        r = client.get("/api/comfyui/status")
+    assert r.status_code == 200
+    assert r.json()["arbiter"] is None
 
 
 def test_switchover_rejects_unknown_mode(

--- a/tests/api/test_comfyui_proxy.py
+++ b/tests/api/test_comfyui_proxy.py
@@ -79,6 +79,7 @@ async def _fetch_down(path: str):
 
 
 def test_status_generating_when_container_running_and_queue_busy(client: TestClient) -> None:
+    _install_arbiter(client, mode="img")  # arbiter is the mode source of truth
     c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_busy)
     with c, s, f:
         r = client.get("/api/comfyui/status")
@@ -180,13 +181,13 @@ def _reset_comfyui_module_state():
 class _StubArbiter:
     """Stands in for ``manager.arbiter`` — the D4-D6 GpuArbiter surface."""
 
-    def __init__(self) -> None:
+    def __init__(self, mode: str = "llm") -> None:
         self.ensure_img = AsyncMock()
         self.restore_llm = AsyncMock()
         self.set_pin = Mock()
         self.status = Mock(
             return_value={
-                "mode": "llm",
+                "mode": mode,
                 "pinned": False,
                 "saved_llm_slots": [],
                 "idle_restore_at": None,
@@ -194,9 +195,15 @@ class _StubArbiter:
         )
 
 
-def _install_arbiter(client: TestClient) -> _StubArbiter:
-    """Hang a stub manager+arbiter on app.state, the way the route finds it."""
-    arb = _StubArbiter()
+def _install_arbiter(client: TestClient, mode: str = "llm") -> _StubArbiter:
+    """Hang a stub manager+arbiter on app.state, the way the route finds it.
+
+    ``mode`` is the arbiter's reported GPU mode ("llm" | "img"). The arbiter is
+    the source of truth for the current mode — the docker/systemd probes are
+    only a legacy fallback (post-D9 the docker container is gone while
+    hal0-lemonade stays active, so they lie).
+    """
+    arb = _StubArbiter(mode=mode)
     client.app.state.slot_manager = SimpleNamespace(arbiter=arb)
     return arb
 
@@ -224,7 +231,7 @@ def test_switchover_inference_calls_restore(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
-    arb = _install_arbiter(client)
+    arb = _install_arbiter(client, mode="img")
     c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_idle)
     with c, s, f:
         r = client.post("/api/comfyui/switchover", json={"mode": "inference"})
@@ -250,7 +257,7 @@ def test_switchover_force_passes_to_restore(
     # The UI confirm dialog already warned that queued jobs drop — force wins
     # over the busy queue AND propagates to restore_llm (pin override).
     monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
-    arb = _install_arbiter(client)
+    arb = _install_arbiter(client, mode="img")
     c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_busy)
     with c, s, f:
         r = client.post("/api/comfyui/switchover", json={"mode": "inference", "force": True})
@@ -281,9 +288,9 @@ def test_switchover_refused_while_another_switch_in_flight(
 def test_switchover_noop_when_already_in_generation_mode(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Container already running → target reached; never re-drive the arbiter.
+    # Arbiter already reports img mode → target reached; never re-drive it.
     monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
-    arb = _install_arbiter(client)
+    arb = _install_arbiter(client, mode="img")
     c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_idle)
     with c, s, f:
         r = client.post("/api/comfyui/switchover", json={"mode": "generation"})
@@ -312,13 +319,77 @@ def test_switchover_to_inference_refused_while_queue_busy(
     # Tearing ComfyUI down mid-render kills the running + queued jobs — refuse
     # unless the caller explicitly forces it (the UI confirm dialog is the force).
     monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
-    arb = _install_arbiter(client)
+    arb = _install_arbiter(client, mode="img")
     c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_busy)
     with c, s, f:
         r = client.post("/api/comfyui/switchover", json={"mode": "inference"})
     assert r.status_code == 409
     assert r.json()["error"]["code"] == "comfyui.busy"
     arb.restore_llm.assert_not_awaited()
+
+
+def test_switchover_post_migration_inference_uses_arbiter_truth(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Post-D9 reality: docker container gone ("absent") AND hal0-lemonade stays
+    # active through Phase D — the legacy probe would call this "already in
+    # inference" forever, locking restore_llm out of the API (pinned img mode =
+    # permanent lockout). Arbiter says img → the switch MUST run.
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    arb = _install_arbiter(client, mode="img")
+    c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
+    with c, s, f:
+        r = client.post("/api/comfyui/switchover", json={"mode": "inference"})
+    assert r.status_code == 202
+    arb.restore_llm.assert_awaited_once_with(force=False)
+
+
+def test_status_mode_is_arbiter_truth_post_migration(client: TestClient) -> None:
+    # Same post-migration shape on the read path: docker absent + lemonade up
+    # used to render mode "inference"/endpoint null while img owned the GPU.
+    _install_arbiter(client, mode="img")
+    c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_idle)
+    with c, s, f:
+        body = client.get("/api/comfyui/status").json()
+    assert body["mode"] == "generation"
+    assert body["endpoint"] == ":8188"
+
+
+def test_status_mode_legacy_fallback_when_arbiter_missing(client: TestClient) -> None:
+    # Arbiter unwired → fall back to the docker/systemd-derived mode.
+    client.app.state.slot_manager = None
+    c, s, f = _patch(container="running", lemonade=False, hermes=False, fetch=_fetch_idle)
+    with c, s, f:
+        body = client.get("/api/comfyui/status").json()
+    assert body["mode"] == "generation"
+    assert body["endpoint"] == ":8188"
+    assert body["arbiter"] is None
+
+
+def test_switchover_503_when_arbiter_unwired(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Gate open + valid non-noop request but no slot manager on app.state →
+    # explicit 503, never a dangling 202 that can't do anything.
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    client.app.state.slot_manager = None
+    c, s, f = _patch(container="absent", lemonade=True, hermes=True, fetch=_fetch_down)
+    with c, s, f:
+        r = client.post("/api/comfyui/switchover", json={"mode": "generation"})
+    assert r.status_code == 503
+    assert r.json()["error"]["code"] == "comfyui.arbiter_unavailable"
+
+
+def test_pin_503_when_manager_has_no_arbiter(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A manager object WITHOUT an .arbiter attribute must degrade to the same
+    # 503, not a 500 (getattr guard).
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    client.app.state.slot_manager = SimpleNamespace()  # no .arbiter
+    r = client.post("/api/comfyui/pin", json={"pinned": True})
+    assert r.status_code == 503
+    assert r.json()["error"]["code"] == "comfyui.arbiter_unavailable"
 
 
 def test_status_exposes_switchover_state(client: TestClient, _reset_comfyui_module_state) -> None:

--- a/tests/api/test_gpu_arbiter_idle_lifespan.py
+++ b/tests/api/test_gpu_arbiter_idle_lifespan.py
@@ -1,0 +1,27 @@
+"""Lifespan wiring for the GpuArbiter idle-restore loop (Phase D, Task D6).
+
+The api lifespan owns long-running background tasks (model-cache refresh,
+lemond log bridge, …): created via ``asyncio.create_task`` at startup and
+cancelled + awaited on shutdown. The arbiter idle-restore loop follows the
+same pattern — this pins that it starts with the app (exposed on
+``app.state.gpu_arbiter_idle_task``) and is cancelled cleanly at shutdown.
+
+Mirrors the create_app + ``with TestClient(app)`` lifespan-exercise pattern
+of ``tests/api/test_memory_gate.py``.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+
+
+def test_lifespan_starts_and_cancels_arbiter_idle_loop(tmp_hal0_home: str) -> None:
+    app = create_app()
+    with TestClient(app):
+        task = app.state.gpu_arbiter_idle_task
+        assert task is not None, "idle loop task must start with the lifespan"
+        assert not task.done(), "idle loop must be running while the app is up"
+    # shutdown cancels + awaits the task (no orphaned loop after lifespan exit)
+    assert task.cancelled()

--- a/tests/api/test_profiles_route.py
+++ b/tests/api/test_profiles_route.py
@@ -42,10 +42,10 @@ class TestListProfiles:
         assert isinstance(data, list)
 
     def test_returns_seed_profiles(self, client: TestClient) -> None:
-        """One entry per seed profile (5 as of Phase B: kokoro-cpu joined)."""
+        """One entry per seed profile (6 as of Phase D: comfyui joined)."""
         data = client.get("/api/profiles").json()
         assert len(data) == len(SEED_PROFILES)
-        assert len(data) == 5
+        assert len(data) == 6
 
     def test_flm_npu_seed_present(self, client: TestClient) -> None:
         """Phase A added the flm-npu container profile to the seeds."""

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -141,8 +141,8 @@ class TestLoadProfilesConfig:
     def test_seed_count(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
         assert (
-            len(cfg.profile) == 5
-        )  # moe-rocmfp4, dense-mtp-rocmfp4, vulkan-std, flm-npu, kokoro-cpu
+            len(cfg.profile) == 6
+        )  # moe-rocmfp4, dense-mtp-rocmfp4, vulkan-std, flm-npu, kokoro-cpu, comfyui
 
     def test_seed_profiles_have_correct_names(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -332,10 +332,9 @@ class TestSeededSlotTomls:
     was absent from the set.)
 
     Scope: this checks only the *provider-constant* invariant via the real
-    validator. It deliberately does not run load_slot_config() over img.toml
-    — img is a container slot (port 8186, outside the lemonade SlotConfig
-    8081-8099 range, flat top-level shape) and is driven by a raw dict at
-    runtime, not by SlotConfig.
+    validator. Full SlotConfig validation of the img.toml seed (port 8188,
+    in-range since Phase D widened _SLOT_PORT_MAX) lives in
+    tests/config/test_schema_seeds_d1.py.
     """
 
     def test_seeded_dir_is_non_empty(self) -> None:

--- a/tests/config/test_schema_seeds_d1.py
+++ b/tests/config/test_schema_seeds_d1.py
@@ -3,7 +3,12 @@
 import tomllib
 from pathlib import Path
 
-from hal0.config.loader import load_manifest, manifest_image_ref
+from hal0.config.loader import (
+    load_manifest,
+    load_slot_config,
+    manifest_image_ref,
+    save_slot_config,
+)
 from hal0.config.schema import SEED_PROFILES, ImageGenConfig, SlotConfig
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -43,6 +48,75 @@ def test_port_range_admits_comfyui_stock_port() -> None:
 def test_image_gen_section_defaults() -> None:
     s = ImageGenConfig()
     assert (s.idle_restore_minutes, s.default_size, s.default_steps) == (5, "1024x1024", 0)
+
+
+def test_string_image_override_still_validates_and_round_trips() -> None:
+    # Top-level string `image` is the documented per-slot container-image
+    # override (llama_server.image_ref / comfyui.image_ref read
+    # slot_cfg["image"]). It must not collide with the [image] alias:
+    # pre-D1 it passed via extra="allow"; post-D1 it parks under extra.
+    cfg = SlotConfig.model_validate({"name": "x", "port": 8081, "image": "ghcr.io/foo:v1"})
+    assert cfg.extra["image"] == "ghcr.io/foo:v1"
+    # image_gen stays at defaults — the string never reaches the alias.
+    assert cfg.image_gen == ImageGenConfig()
+    # Round-trip: providers read the override from the dumped config.
+    dumped = cfg.model_dump(mode="python")
+    assert dumped["extra"]["image"] == "ghcr.io/foo:v1"
+    assert "image_gen" not in dumped  # all-defaults ImageGenConfig elided
+
+
+def test_load_slot_config_populates_image_gen(tmp_path: Path) -> None:
+    # Real loader path: [image] travels via _flatten_slot_toml's extra
+    # catch-all and must be hoisted into the typed field.
+    p = tmp_path / "img.toml"
+    p.write_text(
+        "[slot]\n"
+        'name = "img"\n'
+        "port = 8188\n"
+        "\n"
+        "[image]\n"
+        "idle_restore_minutes = 9\n"
+        'default_size = "512x512"\n'
+        "default_steps = 12\n",
+        encoding="utf-8",
+    )
+    cfg = load_slot_config("img", path=p)
+    assert cfg.image_gen.idle_restore_minutes == 9
+    assert cfg.image_gen.default_size == "512x512"
+    assert cfg.image_gen.default_steps == 12
+
+
+def test_save_load_round_trip_preserves_image_gen(tmp_path: Path) -> None:
+    src = tmp_path / "img.toml"
+    src.write_text(
+        '[slot]\nname = "img"\nport = 8188\n\n[image]\nidle_restore_minutes = 9\n',
+        encoding="utf-8",
+    )
+    cfg = load_slot_config("img", path=src)
+    dst = tmp_path / "img-rt.toml"
+    save_slot_config(cfg, path=dst)
+    reloaded = load_slot_config("img", path=dst)
+    assert reloaded.image_gen.idle_restore_minutes == 9
+    assert reloaded.image_gen == cfg.image_gen
+
+
+def test_load_slot_config_string_image_survives_in_extra(tmp_path: Path) -> None:
+    # String `image` key under [slot] via the real loader: _flatten hoists
+    # it to top level, the collision guard parks it under extra["image"]
+    # (no hoist into image_gen, no ValidationError) — and it survives a
+    # save→reload round-trip for providers to read.
+    p = tmp_path / "agent.toml"
+    p.write_text(
+        '[slot]\nname = "agent"\nport = 8085\nimage = "ghcr.io/foo:v1"\n',
+        encoding="utf-8",
+    )
+    cfg = load_slot_config("agent", path=p)
+    assert cfg.extra["image"] == "ghcr.io/foo:v1"
+    assert cfg.image_gen == ImageGenConfig()
+    dst = tmp_path / "agent-rt.toml"
+    save_slot_config(cfg, path=dst)
+    reloaded = load_slot_config("agent", path=dst)
+    assert reloaded.extra["image"] == "ghcr.io/foo:v1"
 
 
 def test_manifest_comfyui_pinned_to_kyuz0() -> None:

--- a/tests/config/test_schema_seeds_d1.py
+++ b/tests/config/test_schema_seeds_d1.py
@@ -1,0 +1,54 @@
+"""Tests for Phase D1 — comfyui seed profile, img slot seed, [image] section (#599)."""
+
+import tomllib
+from pathlib import Path
+
+from hal0.config.loader import load_manifest, manifest_image_ref
+from hal0.config.schema import SEED_PROFILES, ImageGenConfig, SlotConfig
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SEEDED_SLOTS_DIR = _REPO_ROOT / "installer" / "etc-hal0" / "slots"
+
+
+def test_comfyui_seed_profile() -> None:
+    p = SEED_PROFILES["comfyui"]
+    assert p["device_class"] == "img"
+    assert "kyuz0/amd-strix-halo-comfyui" in p["image"]
+
+
+def test_seed_img_toml_validates() -> None:
+    raw = tomllib.loads((_SEEDED_SLOTS_DIR / "img.toml").read_text(encoding="utf-8"))
+    cfg = SlotConfig.model_validate(raw)
+    assert cfg.runtime == "container"
+    assert cfg.profile == "comfyui"
+    assert cfg.provider == "comfyui"
+    assert cfg.port == 8188
+    assert cfg.device == "gpu-rocm"
+    assert cfg.image_gen.idle_restore_minutes == 5  # #599 [image] section
+
+
+def test_seed_profiles_toml_has_comfyui_parity() -> None:
+    raw = tomllib.loads(
+        (_REPO_ROOT / "installer" / "etc-hal0" / "profiles.toml").read_text(encoding="utf-8")
+    )
+    assert raw["profile"]["comfyui"] == SEED_PROFILES["comfyui"]
+
+
+def test_port_range_admits_comfyui_stock_port() -> None:
+    # ComfyUI's stock port 8188 sits above the historical 8081-8099 slot
+    # range — _SLOT_PORT_MAX must admit it without ValidationError.
+    SlotConfig(name="x", port=8188)
+
+
+def test_image_gen_section_defaults() -> None:
+    s = ImageGenConfig()
+    assert (s.idle_restore_minutes, s.default_size, s.default_steps) == (5, "1024x1024", 0)
+
+
+def test_manifest_comfyui_pinned_to_kyuz0() -> None:
+    manifest = load_manifest(_REPO_ROOT / "manifest.json")
+    ref = manifest_image_ref("comfyui", manifest=manifest)
+    assert ref == (
+        "docker.io/kyuz0/amd-strix-halo-comfyui"
+        "@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2"
+    )

--- a/tests/dispatcher/test_arbiter_dispatch.py
+++ b/tests/dispatcher/test_arbiter_dispatch.py
@@ -1,0 +1,477 @@
+"""Phase D task D5 — GpuArbiter ⇄ dispatcher/images-route integration.
+
+Covers:
+
+  * Auto-switch: ``POST /v1/images/generations`` flips the GPU to image
+    mode (``ensure_img``) before driving the ComfyUI provider, and stamps
+    img activity at request start AND completion (long Wan video jobs must
+    keep the idle window open).
+  * 503 guard: LLM-group dispatch while ``mode == img`` is refused with a
+    structured ``gpu.image_mode`` envelope + ``Retry-After`` header — fired
+    BEFORE the readiness check so the client never sees ``slot.loading``.
+  * NPU/CPU isolation: non-llm-group slots dispatch normally in img mode.
+  * NON-NEGOTIABLE 1 (D4 review): the silent-eviction recovery branch is
+    SUPPRESSED while the arbiter is in img mode — a ConnectError on an
+    llm slot must NOT reload it into image mode; it surfaces the same
+    ``gpu.image_mode`` 503 instead.
+  * NON-NEGOTIABLE 2 (D4 review): an in-flight LLM request whose container
+    the arbiter force-kills (drain timeout) gets a clean structured 5xx
+    JSON envelope, not a hung socket or exception leak.
+  * #599 defaults: a request body that omits ``size`` (and
+    ``extra_body.steps``) is seeded from the img slot's ``[image]``
+    section (``default_size`` / ``default_steps``).
+
+Dispatcher-level tests mirror the _RecordingSlotManager harness in
+test_serving_integration.py; app-level tests mirror tests/api/test_v1_images.py.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import ANY, AsyncMock
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from hal0.dispatcher.router import Dispatcher, UpstreamCall
+from hal0.slots.arbiter import GpuArbiter, GpuImageMode, GpuMode
+from hal0.slots.state import SlotState
+from hal0.upstreams.registry import Upstream
+
+_DISPATCHABLE_STATES = frozenset({SlotState.READY, SlotState.SERVING, SlotState.IDLE})
+
+
+# ── dispatcher-level harness (mirrors test_serving_integration.py) ──────────
+
+
+class _ArbiterSlotManager:
+    """Minimal SlotManager surface + a REAL GpuArbiter wired to it.
+
+    The arbiter persists to a tmp state file; ``_config_file`` points at a
+    tmp dir so group lookups never touch host /etc/hal0/slots.
+    """
+
+    def __init__(self, tmp_path: Path, state: SlotState = SlotState.READY) -> None:
+        self._tmp = tmp_path
+        self._state = state
+        self.events: list[tuple[str, str]] = []
+        self._counts: dict[str, int] = {}
+        self.recover_calls: list[str] = []
+        self.load_calls: list[tuple[str, Any]] = []
+        self.unload_calls: list[str] = []
+        self.cfgs: list[dict[str, Any]] = []
+        self.arbiter = GpuArbiter(
+            self,  # type: ignore[arg-type]
+            state_path=tmp_path / "gpu_arbiter.json",
+        )
+
+    # group lookups must stay inside tmp_path (no host TOML leakage)
+    def _config_file(self, name: str) -> Path:
+        return self._tmp / "slots" / f"{name}.toml"
+
+    async def iter_configs(self) -> list[dict[str, Any]]:
+        return list(self.cfgs)
+
+    def serving(self, slot_name: str) -> Any:
+        mgr = self
+
+        class _Ctx:
+            async def __aenter__(self) -> None:
+                mgr.events.append(("enter", slot_name))
+                mgr._counts[slot_name] = mgr._counts.get(slot_name, 0) + 1
+
+            async def __aexit__(self, *_: Any) -> None:
+                mgr.events.append(("exit", slot_name))
+                mgr._counts[slot_name] = mgr._counts.get(slot_name, 1) - 1
+
+        return _Ctx()
+
+    def in_flight_count(self, slot_name: str) -> int:
+        return self._counts.get(slot_name, 0)
+
+    def state(self, _slot_name: str) -> SlotState:
+        return self._state
+
+    def is_ready_for_dispatch(self, _slot_name: str) -> bool:
+        return self._state in _DISPATCHABLE_STATES
+
+    async def recover_evicted_slot(self, slot_name: str) -> None:
+        self.recover_calls.append(slot_name)
+
+    async def load(self, slot_name: str, model: Any = None) -> None:
+        self.load_calls.append((slot_name, model))
+
+    async def unload(self, slot_name: str) -> None:
+        self.unload_calls.append(slot_name)
+
+
+def _write_img_mode_state(state_path: Path, saved: list[str]) -> None:
+    """Persist an img-mode arbiter state file the lazy loader will pick up."""
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "mode": "img",
+                "pinned": False,
+                "saved_llm_slots": saved,
+                "last_img_activity": time.time(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _make_dispatcher(transport: httpx.MockTransport, sm: _ArbiterSlotManager) -> Dispatcher:
+    return Dispatcher(
+        http_client=httpx.AsyncClient(transport=transport),
+        slot_manager=sm,  # type: ignore[arg-type]
+    )
+
+
+def _slot_call(slot_name: str = "primary") -> UpstreamCall:
+    return UpstreamCall(
+        upstream_name=slot_name,
+        target_url="http://slot/chat/completions",
+        headers={"content-type": "application/json"},
+        body=b"{}",
+        streaming=False,
+        method="POST",
+        slot_name=slot_name,
+    )
+
+
+# ── app-level harness (mirrors tests/api/test_v1_images.py) ─────────────────
+
+
+def _seed_img_upstream(client: TestClient, port: int = 8186) -> None:
+    client.app.state.upstreams.upsert(
+        Upstream(
+            name="img",
+            kind="slot",
+            url=f"http://127.0.0.1:{port}/v1",
+            slot_name="img",
+            auth_style="none",
+        )
+    )
+
+
+def _seed_chat_upstream(client: TestClient, name: str = "primary") -> None:
+    client.app.state.upstreams.upsert(
+        Upstream(
+            name=name,
+            kind="slot",
+            url="http://127.0.0.1:8001/v1",
+            slot_name=name,
+            auth_style="none",
+        )
+    )
+
+
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"x" * 64
+
+_FAKE_INFER_RESULT = {
+    "images": [
+        {"png": _FAKE_PNG, "filename": "hal0-t_00001_.png", "subfolder": "", "type": "output"}
+    ],
+    "meta": {"template": "sdxl_turbo_simple"},
+    "prompt_id": "p1",
+}
+
+
+def _arbitrated_cfgs(image_section: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    img: dict[str, Any] = {"name": "img", "device": "gpu-rocm", "profile": "comfyui", "port": 8186}
+    if image_section is not None:
+        img["image"] = image_section
+    return [
+        {"name": "chat", "device": "gpu-rocm", "profile": "llama-rocm", "port": 8081},
+        img,
+    ]
+
+
+def _wire_image_app(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    image_section: dict[str, Any] | None = None,
+) -> tuple[AsyncMock, AsyncMock, AsyncMock]:
+    """Mock manager lifecycle + provider.infer; return (unload, load, infer)."""
+    from hal0.providers import get_provider
+
+    manager = client.app.state.slot_manager
+    monkeypatch.setattr(
+        manager, "iter_configs", AsyncMock(return_value=_arbitrated_cfgs(image_section))
+    )
+    monkeypatch.setattr(manager, "is_ready_for_dispatch", lambda name: name == "chat")
+    unload = AsyncMock()
+    load = AsyncMock()
+    monkeypatch.setattr(manager, "unload", unload)
+    monkeypatch.setattr(manager, "load", load)
+    infer = AsyncMock(return_value=_FAKE_INFER_RESULT)
+    monkeypatch.setattr(get_provider("comfyui"), "infer", infer)
+    return unload, load, infer
+
+
+# ── auto-switch on image requests ────────────────────────────────────────────
+
+
+def test_image_request_triggers_switch(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_hal0_home: str
+) -> None:
+    """Image request in LLM mode flips the arbiter: chat unloaded, img loaded, 200."""
+    _seed_img_upstream(client)
+    unload, load, infer = _wire_image_app(client, monkeypatch)
+
+    r = client.post(
+        "/v1/images/generations",
+        json={"model": "sdxl-turbo", "prompt": "a cat in a hat"},
+    )
+    assert r.status_code == 200, r.text
+    unload.assert_awaited_once_with("chat")
+    load.assert_awaited_once_with("img", ANY)
+    assert client.app.state.slot_manager.arbiter.mode == GpuMode.IMG
+    infer.assert_awaited_once()
+
+
+def test_img_activity_touched_on_completion(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_hal0_home: str
+) -> None:
+    """touch_img_activity fires at request START and again at COMPLETION."""
+    _seed_img_upstream(client)
+    _, _, infer = _wire_image_app(client, monkeypatch)
+
+    manager = client.app.state.slot_manager
+    arbiter = manager.arbiter
+    events: list[str] = []
+    real_touch = arbiter.touch_img_activity
+
+    def _recording_touch() -> None:
+        events.append("touch")
+        real_touch()
+
+    monkeypatch.setattr(arbiter, "touch_img_activity", _recording_touch)
+
+    async def _recording_infer(*a: Any, **kw: Any) -> dict[str, Any]:
+        events.append("infer")
+        return _FAKE_INFER_RESULT
+
+    infer.side_effect = _recording_infer
+
+    r = client.post(
+        "/v1/images/generations",
+        json={"model": "sdxl-turbo", "prompt": "long wan video frame"},
+    )
+    assert r.status_code == 200, r.text
+    assert events == ["touch", "infer", "touch"], events
+
+
+def test_image_defaults_filled_from_image_section(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_hal0_home: str
+) -> None:
+    """#599 — body omits size/steps → seeded from [image] default_size/default_steps."""
+    _seed_img_upstream(client)
+    _, _, infer = _wire_image_app(
+        client,
+        monkeypatch,
+        image_section={"default_size": "512x512", "default_steps": 6},
+    )
+
+    r = client.post(
+        "/v1/images/generations",
+        json={"model": "sdxl-turbo", "prompt": "defaults please"},
+    )
+    assert r.status_code == 200, r.text
+    sent_body = infer.await_args.args[1]
+    assert sent_body["size"] == "512x512"
+    assert sent_body["extra_body"]["steps"] == 6
+
+
+def test_image_defaults_do_not_override_explicit_values(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_hal0_home: str
+) -> None:
+    """Caller-supplied size / extra_body.steps win over [image] defaults."""
+    _seed_img_upstream(client)
+    _, _, infer = _wire_image_app(
+        client,
+        monkeypatch,
+        image_section={"default_size": "512x512", "default_steps": 6},
+    )
+
+    r = client.post(
+        "/v1/images/generations",
+        json={
+            "model": "sdxl-turbo",
+            "prompt": "explicit",
+            "size": "1024x1024",
+            "extra_body": {"steps": 12},
+        },
+    )
+    assert r.status_code == 200, r.text
+    sent_body = infer.await_args.args[1]
+    assert sent_body["size"] == "1024x1024"
+    assert sent_body["extra_body"]["steps"] == 12
+
+
+# ── 503 guard for LLM dispatch in img mode ───────────────────────────────────
+
+
+def test_llm_request_in_img_mode_503_retry_after(client: TestClient, tmp_hal0_home: str) -> None:
+    """Chat request while mode==img → 503 gpu.image_mode + Retry-After ≥ 15."""
+    # Legacy fallback resolves model "primary" via the back-compat alias to
+    # the "chat" slot (proxy.resolve_slot rule 8), so seed "chat".
+    _seed_chat_upstream(client, "chat")
+    _write_img_mode_state(
+        Path(tmp_hal0_home) / "var-lib" / "hal0" / "gpu_arbiter.json",
+        saved=["chat"],
+    )
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={"model": "primary", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert body["error"]["code"] == "gpu.image_mode"
+    assert body["error"]["details"]["retry_after_s"] >= 15
+    assert int(r.headers["Retry-After"]) >= 15
+
+
+@pytest.mark.asyncio
+async def test_npu_and_cpu_slots_unaffected_in_img_mode(tmp_path: Path) -> None:
+    """Non-llm-group slots (tts/npu/cpu) dispatch normally while mode==img."""
+    sm = _ArbiterSlotManager(tmp_path)
+    _write_img_mode_state(tmp_path / "gpu_arbiter.json", saved=["primary"])
+
+    dispatcher = _make_dispatcher(
+        httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True})), sm
+    )
+    try:
+        for slot in ("tts", "npu", "embed"):
+            resp = await dispatcher.forward(_slot_call(slot))
+            assert resp.status_code == 200, slot
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_llm_slot_forward_guarded_in_img_mode(tmp_path: Path) -> None:
+    """Dispatcher-level: llm slot forward in img mode raises GpuImageMode pre-readiness."""
+    sm = _ArbiterSlotManager(tmp_path, state=SlotState.OFFLINE)  # NOT slot.loading
+    _write_img_mode_state(tmp_path / "gpu_arbiter.json", saved=["primary"])
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise AssertionError("must not reach upstream in img mode")
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm)
+    try:
+        with pytest.raises(GpuImageMode) as ei:
+            await dispatcher.forward(_slot_call("primary"))
+        assert ei.value.code == "gpu.image_mode"
+        assert ei.value.status == 503
+        assert ei.value.details["retry_after_s"] >= 15
+        # Guard fires BEFORE readiness/lazy-load: no load, no serving entry.
+        assert sm.load_calls == []
+        assert sm.events == []
+    finally:
+        await dispatcher.aclose()
+
+
+# ── NON-NEGOTIABLE 1: evicted-slot recovery suppression ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_evicted_recovery_suppressed_in_img_mode(tmp_path: Path) -> None:
+    """ConnectError on an llm slot while mode==img → NO recovery load, 503 gpu.image_mode.
+
+    Simulates the race: the request passed the guard in LLM mode, then the
+    arbiter flipped to img and force-killed the container mid-flight. The
+    retry-once recovery must NOT reload the llm slot into image mode.
+    """
+    sm = _ArbiterSlotManager(tmp_path)  # starts in LLM mode (no state file)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        # Arbiter flips to img between the guard and the upstream connect.
+        st = sm.arbiter._load_state()
+        st["mode"] = "img"
+        st["saved_llm_slots"] = ["primary"]
+        raise httpx.ConnectError("container force-killed", request=req)
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm)
+    try:
+        with pytest.raises(GpuImageMode) as ei:
+            await dispatcher.forward(_slot_call("primary"))
+        assert ei.value.code == "gpu.image_mode"
+        assert ei.value.status == 503
+        assert sm.recover_calls == [], "recovery must be suppressed in img mode"
+        assert sm.load_calls == [], "no slot load may fight the arbiter"
+        # serving counter must still balance (no stuck SERVING).
+        assert sm.in_flight_count("primary") == 0
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_evicted_recovery_still_runs_in_llm_mode(tmp_path: Path) -> None:
+    """Regression guard: normal silent-eviction recovery is untouched in LLM mode."""
+    sm = _ArbiterSlotManager(tmp_path)
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ConnectError("connection refused", request=req)
+        return httpx.Response(200, json={"ok": True})
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm)
+    try:
+        resp = await dispatcher.forward(_slot_call("primary"))
+        assert resp.status_code == 200
+        assert sm.recover_calls == ["primary"]
+    finally:
+        await dispatcher.aclose()
+
+
+# ── NON-NEGOTIABLE 2: clean 5xx on force-kill mid-request ───────────────────
+
+
+def test_force_killed_inflight_gets_clean_5xx(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_hal0_home: str
+) -> None:
+    """In-flight chat request whose container the arbiter kills → structured 5xx JSON.
+
+    Full-stack pin: the connect error surfaces through the error middleware
+    as a clean gpu.image_mode 503 envelope (suppressed recovery path), not
+    a hung socket or an exception leak.
+    """
+    _seed_chat_upstream(client, "chat")
+    manager = client.app.state.slot_manager
+    monkeypatch.setattr(manager, "is_ready_for_dispatch", lambda _n: True)
+    recover = AsyncMock()
+    monkeypatch.setattr(manager, "recover_evicted_slot", recover)
+    arbiter = manager.arbiter  # construct in LLM mode
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path.endswith("/models"):
+            return httpx.Response(200, json={"object": "list", "data": []})
+        # Mid-flight force-kill: arbiter persisted img mode, container gone.
+        st = arbiter._load_state()
+        st["mode"] = "img"
+        st["saved_llm_slots"] = ["chat"]
+        raise httpx.ConnectError("container force-killed", request=req)
+
+    client.app.state.dispatcher._http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler)
+    )
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={"model": "primary", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert body["error"]["code"] == "gpu.image_mode"
+    assert int(r.headers["Retry-After"]) >= 15
+    recover.assert_not_awaited()

--- a/tests/dispatcher/test_image_routing.py
+++ b/tests/dispatcher/test_image_routing.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import pytest
 
 from hal0.dispatcher.proxy import LegacyResolutionFailed, resolve_slot
+from hal0.dispatcher.router import Dispatcher
 from hal0.upstreams.registry import Upstream, UpstreamRegistry
 
 
@@ -27,6 +28,23 @@ def _registry_with_slots(*names: str) -> UpstreamRegistry:
             )
         )
     return reg
+
+
+def _container_remote_img() -> Upstream:
+    """Container-backed img upstream — how SlotManager._register_container_upstream
+    registers a podman slot (kind='remote' with slot_name set, #656)."""
+    return Upstream(
+        name="img",
+        kind="remote",
+        url="http://127.0.0.1:8188/v1",
+        slot_name="img",
+        auth_style="none",
+    )
+
+
+class _FakeModelRegistry:
+    def route_for(self, model_id: str) -> str | None:
+        return None
 
 
 def test_images_generations_path_routes_to_img_slot() -> None:
@@ -83,3 +101,58 @@ def test_image_path_without_img_slot_raises_typed_error() -> None:
     with pytest.raises(LegacyResolutionFailed) as exc:
         resolve_slot("/v1/images/generations", {"model": "sdxl-turbo"}, reg)
     assert exc.value.code == "dispatch.legacy_unresolved"
+
+
+# ── container-remote acceptance (Phase D — img is a podman slot, #656) ────────
+
+
+def test_image_path_accepts_container_remote() -> None:
+    """/v1/images/* path pin must accept a container-backed kind='remote' img
+    upstream — same acceptance as the embed/tts/rerank path pins."""
+    reg = _registry_with_slots("chat")
+    reg.upsert(_container_remote_img())
+    upstream = resolve_slot("/v1/images/generations", {"model": "sdxl-turbo"}, reg)
+    assert upstream.name == "img"
+    assert upstream.kind == "remote"
+
+
+def test_image_model_prefix_accepts_container_remote() -> None:
+    """Rule 6 (sdxl-/sd-1.5-/flux- model prefix) on a non-image path must also
+    accept the container-backed img remote."""
+    reg = _registry_with_slots("chat")
+    reg.upsert(_container_remote_img())
+    upstream = resolve_slot(
+        "/v1/chat/completions",
+        {"model": "sdxl-turbo", "messages": [{"role": "user", "content": "hi"}]},
+        reg,
+    )
+    assert upstream.name == "img"
+    assert upstream.kind == "remote"
+
+
+def test_genuine_external_remote_still_rejected() -> None:
+    """A genuine external remote (kind='remote', slot_name=None) named 'img'
+    must still be rejected — only container remotes (slot_name set) qualify."""
+    reg = _registry_with_slots("chat")
+    reg.upsert(
+        Upstream(
+            name="img",
+            kind="remote",
+            url="http://example.com/v1",
+            slot_name=None,
+            auth_style="none",
+        )
+    )
+    with pytest.raises(LegacyResolutionFailed) as exc:
+        resolve_slot("/v1/images/generations", {"model": "sdxl-turbo"}, reg)
+    assert exc.value.code == "dispatch.legacy_unresolved"
+
+
+# ── router._default_for_path image default ────────────────────────────────────
+
+
+def test_default_for_path_images() -> None:
+    """Model-less /v1/images/* request defaults to the 'img' slot, not 'chat'."""
+    reg = _registry_with_slots("img")
+    dispatcher = Dispatcher(upstream_registry=reg, model_registry=_FakeModelRegistry())
+    assert dispatcher._default_for_path("/v1/images/generations") == "img"

--- a/tests/providers/test_comfyui.py
+++ b/tests/providers/test_comfyui.py
@@ -102,29 +102,35 @@ def test_image_ref_slot_cfg_override_wins(provider: ComfyUIProvider) -> None:
 # ─── container_spec ──────────────────────────────────────────────────────────
 
 
-def test_container_spec_passes_kfd_and_dri(
+def test_container_spec_passes_gpu_device_nodes(
     provider: ComfyUIProvider,
     slot_cfg: dict[str, Any],
     model_info: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Explicit nodes from resolve_gpu_device_paths (podman doesn't recurse
+    # /dev/dri — same fix class as #674). Pinned here: dev/CI boxes vary.
+    monkeypatch.setattr(
+        "hal0.providers.comfyui.resolve_gpu_device_paths",
+        lambda: ["/dev/kfd", "/dev/dri/renderD128"],
+    )
     spec = provider.container_spec(slot_cfg, model_info)
     assert spec.port == 8186
-    # Strix Halo iGPU passthrough requires both /dev/kfd and /dev/dri.
-    assert "/dev/kfd" in spec.devices
-    assert "/dev/dri" in spec.devices
+    assert spec.devices == ["/dev/kfd", "/dev/dri/renderD128"]
     # Group_add must be numeric GIDs (resolve_gpu_group_ids on the host).
     assert all(g.isdigit() for g in spec.group_add)
 
 
-def test_container_spec_mounts_persistent_base_dir(
+def test_container_spec_mounts_persistent_data_dirs(
     provider: ComfyUIProvider,
     slot_cfg: dict[str, Any],
     model_info: dict[str, Any],
 ) -> None:
     spec = provider.container_spec(slot_cfg, model_info)
-    # The persistent directory holds models/, custom_nodes/, output/, input/
+    # The data root holds models/, custom_nodes/, output/, input/, user/
     # — losing it on a `docker rm` would discard 6+ GB of weights.
-    assert ("/var/lib/hal0/comfyui", "/var/lib/hal0/comfyui") in spec.mounts
+    assert ("/mnt/ai-models/comfyui/models", "/root/comfy-models") in spec.mounts
+    assert ("/mnt/ai-models/comfyui/custom_nodes", "/opt/ComfyUI/custom_nodes") in spec.mounts
 
 
 def test_container_spec_command_runs_python_main(
@@ -133,10 +139,11 @@ def test_container_spec_command_runs_python_main(
     model_info: dict[str, Any],
 ) -> None:
     spec = provider.container_spec(slot_cfg, model_info)
-    assert spec.command[0] == "python"
-    assert spec.command[1] == "main.py"
+    # bash -lc so the kyuz0 image's /opt/venv login-shell activation runs.
+    assert spec.command[:2] == ["bash", "-lc"]
+    assert "exec python main.py" in spec.command[2]
     # The slot port (not the ComfyUI default) is what we listen on.
-    assert "8186" in spec.command
+    assert "--port 8186" in spec.command[2]
 
 
 # ─── health ──────────────────────────────────────────────────────────────────

--- a/tests/providers/test_comfyui.py
+++ b/tests/providers/test_comfyui.py
@@ -78,12 +78,19 @@ def test_start_cmd_emits_required_flags(
     assert "--base-directory" in cmd
 
 
-def test_image_ref_is_hal0ai_comfyui(provider: ComfyUIProvider) -> None:
+def test_image_ref_follows_manifest_pin_or_fallback(provider: ComfyUIProvider) -> None:
+    # Phase D (#599): manifest.json repins comfyui to the kyuz0 Strix Halo
+    # build. With the repo manifest visible (HAL0_HOME unset), image_ref
+    # returns that digest pin; without a manifest it falls back to
+    # _HAL0_COMFYUI_IMAGE.
     ref = provider.image_ref({})
-    assert ref.startswith("ghcr.io/hal0ai/hal0-toolbox-comfyui")
-    assert _HAL0_COMFYUI_IMAGE.startswith("ghcr.io/hal0ai/hal0-toolbox-comfyui")
-    assert ref == _HAL0_COMFYUI_IMAGE or ref.startswith(
-        f"{_HAL0_COMFYUI_IMAGE.split(':', 1)[0]}@sha256:"
+    assert (
+        ref
+        == (
+            "docker.io/kyuz0/amd-strix-halo-comfyui"
+            "@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2"
+        )
+        or ref == _HAL0_COMFYUI_IMAGE
     )
 
 

--- a/tests/providers/test_comfyui_container_spec.py
+++ b/tests/providers/test_comfyui_container_spec.py
@@ -1,0 +1,149 @@
+"""ComfyUI container spec — live-parity with the validated CT105 deployment.
+
+Phase D task D2. The spec must replicate what `docker inspect comfyui`
+showed working on CT105: kyuz0 image (ComfyUI at /opt/ComfyUI, venv at
+/opt/venv), bash -lc cd+exec argv, /mnt/ai-models/comfyui data mounts,
+--ipc=host + --shm-size=8g (Wan/Hunyuan video need shm), host networking,
+and label=disable alongside the usual LXC security opts.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hal0.providers.comfyui import _HAL0_COMFYUI_IMAGE, ComfyUIProvider
+from hal0.providers.container import _render_unit_from_spec, _spec_provider_for
+
+_GPU_NODES = ["/dev/kfd", "/dev/dri/card1", "/dev/dri/renderD128"]
+
+
+def _img_cfg(**overrides: Any) -> dict[str, Any]:
+    """Slot cfg shaped like the loaded installer/etc-hal0/slots/img.toml."""
+    base: dict[str, Any] = {
+        "name": "img",
+        "type": "image",
+        "provider": "comfyui",
+        "device": "gpu-rocm",
+        "runtime": "container",
+        "profile": "comfyui",
+        "enabled": True,
+        "port": 8188,
+        "model": {"default": "sdxl-turbo"},
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture(autouse=True)
+def _gpu_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin GPU device enumeration — dev/CI boxes have no /dev/kfd."""
+    monkeypatch.setattr(
+        "hal0.providers.comfyui.resolve_gpu_device_paths",
+        lambda: list(_GPU_NODES),
+    )
+
+
+# ── container_spec live parity ────────────────────────────────────────────────
+
+
+def test_comfyui_spec_matches_live_deployment() -> None:
+    spec = ComfyUIProvider().container_spec(_img_cfg(), {})
+    # Devices via resolve_gpu_device_paths() — explicit nodes (podman, #674).
+    assert spec.devices and "/dev/kfd" in spec.devices
+    assert spec.devices == _GPU_NODES
+    # Data mounts mirror docker inspect on CT105.
+    assert ("/mnt/ai-models/comfyui/models", "/root/comfy-models") in spec.mounts
+    for sub in ("output", "input", "user", "custom_nodes"):
+        assert (f"/mnt/ai-models/comfyui/{sub}", f"/opt/ComfyUI/{sub}") in spec.mounts
+    assert any("extra_model_paths.yaml" in src for src, _ in spec.mounts)
+    # Wan/Hunyuan video models need shared memory.
+    assert "--ipc=host" in spec.extra_args and "--shm-size=8g" in spec.extra_args
+    assert set(spec.security_opt) == {
+        "seccomp=unconfined",
+        "apparmor=unconfined",
+        "label=disable",
+    }
+    assert spec.network_mode == "host"
+    assert spec.port == 8188
+    # Profile flags flow into the bash -lc payload.
+    assert spec.command[-1].endswith("--cache-none")
+
+
+def test_comfyui_argv_uses_opt_comfyui_workdir() -> None:
+    spec = ComfyUIProvider().container_spec(_img_cfg(), {})
+    assert spec.command[:2] == ["bash", "-lc"]
+    payload = spec.command[2]
+    assert "/opt/ComfyUI" in payload
+    assert "--port 8188" in payload
+    assert payload.startswith("cd /opt/ComfyUI && exec python main.py")
+    assert "--listen 0.0.0.0" in payload
+
+
+def test_comfyui_extra_model_paths_mount_is_read_only() -> None:
+    """:ro suffix on dst is how ContainerSpec expresses read-only mounts."""
+    spec = ComfyUIProvider().container_spec(_img_cfg(), {})
+    yaml_mounts = [(s, d) for s, d in spec.mounts if "extra_model_paths.yaml" in s]
+    assert yaml_mounts == [
+        (
+            "/mnt/ai-models/comfyui/extra_model_paths.yaml",
+            "/opt/ComfyUI/extra_model_paths.yaml:ro",
+        )
+    ]
+
+
+def test_comfyui_data_root_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_COMFYUI_DATA_ROOT", "/srv/comfy-data")
+    spec = ComfyUIProvider().container_spec(_img_cfg(), {})
+    assert ("/srv/comfy-data/models", "/root/comfy-models") in spec.mounts
+    assert ("/srv/comfy-data/output", "/opt/ComfyUI/output") in spec.mounts
+    assert not any(src.startswith("/mnt/ai-models/comfyui") for src, _ in spec.mounts)
+
+
+def test_comfyui_profile_flags_fallback_without_profile() -> None:
+    """No resolvable profile → live-validated default flag bundle."""
+    cfg = _img_cfg()
+    del cfg["profile"]
+    spec = ComfyUIProvider().container_spec(cfg, {})
+    assert spec.command[2].endswith("--disable-mmap --bf16-vae --cache-none")
+
+
+def test_comfyui_slot_port_override_flows_into_argv() -> None:
+    spec = ComfyUIProvider().container_spec(_img_cfg(port=8189), {})
+    assert spec.port == 8189
+    assert "--port 8189" in spec.command[2]
+
+
+def test_comfyui_fallback_image_is_kyuz0() -> None:
+    """D1 review: the last-resort fallback must not point at an unpublished image."""
+    assert _HAL0_COMFYUI_IMAGE == "docker.io/kyuz0/amd-strix-halo-comfyui:latest"
+
+
+# ── renderer integration ──────────────────────────────────────────────────────
+
+
+def test_renderer_host_network_skips_publish_and_keeps_shm() -> None:
+    spec = ComfyUIProvider().container_spec(_img_cfg(), {})
+    unit = _render_unit_from_spec("img", spec, runtime_bin="/usr/bin/podman")
+    exec_line = next(line for line in unit.splitlines() if line.startswith("ExecStart="))
+
+    assert "--network=host" in exec_line
+    assert "--publish" not in exec_line, "host networking must not publish ports"
+    assert "--ipc=host" in exec_line
+    assert "--shm-size=8g" in exec_line
+    assert "--security-opt=label=disable" in exec_line
+    assert "--device=/dev/kfd" in exec_line
+    assert (
+        "--volume=/mnt/ai-models/comfyui/extra_model_paths.yaml"
+        ":/opt/ComfyUI/extra_model_paths.yaml:ro" in exec_line
+    )
+
+
+# ── _spec_provider_for dispatch ───────────────────────────────────────────────
+
+
+def test_spec_provider_for_dispatches_comfyui() -> None:
+    assert isinstance(_spec_provider_for({"provider": "comfyui", "type": "image"}), ComfyUIProvider)
+    assert isinstance(_spec_provider_for({"profile": "comfyui"}), ComfyUIProvider)
+    assert isinstance(_spec_provider_for({"type": "image"}), ComfyUIProvider)

--- a/tests/providers/test_container_spec_dispatch.py
+++ b/tests/providers/test_container_spec_dispatch.py
@@ -43,6 +43,18 @@ def test_spec_provider_kokoro_profile_returns_kokoro() -> None:
     assert isinstance(result, KokoroProvider)
 
 
+def test_spec_provider_comfyui_returns_comfyui() -> None:
+    from hal0.providers.comfyui import ComfyUIProvider
+
+    # All three discriminators route to ComfyUI (Phase D img slot).
+    for cfg in (
+        {"provider": "comfyui", "type": "image", "device": "gpu-rocm"},
+        {"profile": "comfyui"},
+        {"type": "image"},
+    ):
+        assert isinstance(_spec_provider_for(cfg), ComfyUIProvider), cfg
+
+
 def test_spec_provider_gpu_returns_none() -> None:
     result = _spec_provider_for({"device": "gpu-rocm", "profile": "moe-rocmfp4"})
     assert result is None

--- a/tests/slots/test_gpu_arbiter.py
+++ b/tests/slots/test_gpu_arbiter.py
@@ -1,0 +1,486 @@
+"""GpuArbiter — exclusive llm/img GPU group arbitration (Phase D, Task D4).
+
+Spec §7 (locked): exclusive groups are DERIVED from slot configs, never
+declared. The arbiter drains in-flight LLM requests, persists its target
+state BEFORE unloading anything (crash-recovery ordering), flips the GPU to
+the ComfyUI img slot, and can restore the saved LLM set later — including
+after an api restart, via /var/lib/hal0/gpu_arbiter.json.
+
+The fake SlotManager here is dict-driven, mirroring how the rest of
+tests/slots stubs the manager boundary: state()/is_ready_for_dispatch()/
+in_flight_count() read from dicts, load()/unload() record calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import hal0.slots.arbiter as arbiter_mod
+from hal0.slots.arbiter import (
+    ArbiterPinned,
+    GpuArbiter,
+    GpuImageMode,
+    GpuMode,
+    gpu_exclusive_group,
+)
+
+# ── fake SlotManager ─────────────────────────────────────────────────────────
+
+
+def _base_configs() -> list[dict[str, Any]]:
+    """Raw slot-config dicts shaped like SlotManager._load_slot_config output."""
+    return [
+        {
+            "name": "chat",
+            "device": "gpu-rocm",
+            "runtime": "container",
+            "provider": "llama-server",
+            "type": "llm",
+            "model": {"default": "qwen3-4b-q4_k_m"},
+        },
+        {
+            "name": "agent",
+            "device": "gpu-vulkan",
+            "runtime": "container",
+            "provider": "llama-server",
+            "type": "llm",
+            "model": {"default": "qwen3-4b-q4_k_m"},
+        },
+        {
+            "name": "npu",
+            "device": "npu",
+            "runtime": "container",
+            "provider": "flm",
+            "type": "llm",
+            "model": {"default": "gemma3:4b"},
+        },
+        {
+            "name": "tts",
+            "device": "cpu",
+            "runtime": "container",
+            "provider": "kokoro",
+            "type": "tts",
+            "model": {"default": "kokoro-v1"},
+        },
+        {
+            "name": "img",
+            "device": "gpu-rocm",
+            "runtime": "container",
+            "provider": "comfyui",
+            "type": "image",
+            "model": {"default": "sdxl-turbo"},
+            "image": {"idle_restore_minutes": 5},
+        },
+    ]
+
+
+class FakeManager:
+    """Dict-driven SlotManager stub.
+
+    ``in_flight`` values may be an int (constant) or a list consumed one
+    entry per ``in_flight_count()`` poll (last entry sticks) — lets tests
+    script a drain curve like ``[2, 1, 0]``.
+    """
+
+    def __init__(
+        self,
+        configs: list[dict[str, Any]] | None = None,
+        *,
+        ready: set[str] | None = None,
+        in_flight: dict[str, Any] | None = None,
+    ) -> None:
+        self.configs = configs if configs is not None else _base_configs()
+        self.ready: set[str] = set(ready or {"chat", "agent", "npu", "tts"})
+        self.in_flight: dict[str, Any] = dict(in_flight or {})
+        self.calls: list[tuple[Any, ...]] = []
+        self.poll_log: list[tuple[str, int]] = []
+        self.on_unload = None  # optional hook(name) fired before recording
+
+    async def iter_configs(self) -> list[dict[str, Any]]:
+        return [dict(c) for c in self.configs]
+
+    def is_ready_for_dispatch(self, name: str) -> bool:
+        return name in self.ready
+
+    def state(self, name: str) -> str:
+        return "ready" if name in self.ready else "offline"
+
+    def in_flight_count(self, name: str) -> int:
+        val = self.in_flight.get(name, 0)
+        if isinstance(val, list):
+            count = int(val.pop(0)) if len(val) > 1 else int(val[0])
+        else:
+            count = int(val)
+        self.poll_log.append((name, count))
+        return count
+
+    async def load(self, name: str, model_id: str | None = None) -> None:
+        self.calls.append(("load", name, model_id))
+        self.ready.add(name)
+
+    async def unload(self, name: str) -> None:
+        if self.on_unload is not None:
+            self.on_unload(name)
+        self.calls.append(("unload", name))
+        self.ready.discard(name)
+
+
+@pytest.fixture
+def fake_mgr() -> FakeManager:
+    return FakeManager()
+
+
+@pytest.fixture
+def state_path(tmp_path: Path) -> Path:
+    return tmp_path / "gpu_arbiter.json"
+
+
+@pytest.fixture(autouse=True)
+def _fast_drain(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Speed the drain poll up for tests; timeout stays generous."""
+    monkeypatch.setattr(arbiter_mod, "_DRAIN_POLL_S", 0.01)
+
+
+def _read_state(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ── group derivation ─────────────────────────────────────────────────────────
+
+
+def test_group_derivation() -> None:
+    assert (
+        gpu_exclusive_group({"device": "gpu-rocm", "runtime": "container", "provider": "comfyui"})
+        == "img"
+    )
+    assert gpu_exclusive_group({"device": "gpu-vulkan", "runtime": "container"}) == "llm"
+    assert gpu_exclusive_group({"device": "npu", "runtime": "container"}) is None
+    assert gpu_exclusive_group({"device": "gpu-rocm", "runtime": "lemonade"}) is None
+    # cpu container slots (tts) are never arbitrated
+    assert gpu_exclusive_group({"device": "cpu", "runtime": "container"}) is None
+    # img can be signalled by profile or type too
+    assert (
+        gpu_exclusive_group({"device": "gpu-rocm", "runtime": "container", "profile": "comfyui"})
+        == "img"
+    )
+    assert (
+        gpu_exclusive_group({"device": "gpu-rocm", "runtime": "container", "type": "image"})
+        == "img"
+    )
+    # missing runtime defaults to lemonade → never arbitrated
+    assert gpu_exclusive_group({"device": "gpu-rocm"}) is None
+
+
+# ── ensure_img ───────────────────────────────────────────────────────────────
+
+
+async def test_ensure_img_drains_then_stops_then_starts(
+    fake_mgr: FakeManager, state_path: Path
+) -> None:
+    fake_mgr.in_flight = {"chat": [2, 1, 0]}
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+
+    seen_at_unload: list[dict[str, Any]] = []
+
+    def _on_unload(name: str) -> None:
+        # state file written BEFORE the first unload (crash-recovery ordering)
+        assert state_path.exists(), "state must be persisted before unloads begin"
+        seen_at_unload.append(_read_state(state_path))
+        # drain completed before any unload
+        assert fake_mgr.in_flight["chat"] == [0]
+
+    fake_mgr.on_unload = _on_unload
+    await arb.ensure_img()
+
+    # drain polled chat down 2 → 1 → 0 before any unload
+    chat_polls = [c for (n, c) in fake_mgr.poll_log if n == "chat"]
+    assert chat_polls[:3] == [2, 1, 0]
+    # order: unload llm slots (config order), then load img with its default
+    assert fake_mgr.calls == [
+        ("unload", "chat"),
+        ("unload", "agent"),
+        ("load", "img", "sdxl-turbo"),
+    ]
+    # npu/tts (non-llm groups) untouched — only ever arbitrate GPU slots
+    assert all(c[1] not in {"npu", "tts"} for c in fake_mgr.calls)
+
+    persisted = seen_at_unload[0]
+    assert persisted["mode"] == "img"
+    assert set(persisted["saved_llm_slots"]) == {"chat", "agent"}
+
+    assert arb.mode is GpuMode.IMG
+    assert set(arb.saved_llm_slots) == {"chat", "agent"}
+    final = _read_state(state_path)
+    assert final["mode"] == "img"
+    assert isinstance(final["last_img_activity"], float)
+
+
+async def test_ensure_img_noop_when_already_img(fake_mgr: FakeManager, state_path: Path) -> None:
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+    await arb.ensure_img()
+    calls_after_first = list(fake_mgr.calls)
+
+    await arb.ensure_img()
+    assert fake_mgr.calls == calls_after_first  # no second flip
+    assert arb.pinned is False
+
+    # pin is still applied on the no-op path
+    await arb.ensure_img(pin=True)
+    assert fake_mgr.calls == calls_after_first
+    assert arb.pinned is True
+    assert _read_state(state_path)["pinned"] is True
+
+
+async def test_drain_timeout_proceeds(
+    fake_mgr: FakeManager,
+    state_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fake_mgr.in_flight = {"chat": 1}  # stuck forever
+    monkeypatch.setattr(arbiter_mod, "_DRAIN_TIMEOUT_S", 0.05)
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+
+    with caplog.at_level(logging.WARNING, logger="hal0.slots.arbiter"):
+        await arb.ensure_img()
+
+    assert any("drain_timeout" in rec.message for rec in caplog.records)
+    # proceeded anyway: llm slots unloaded, img loaded
+    assert ("unload", "chat") in fake_mgr.calls
+    assert ("unload", "agent") in fake_mgr.calls
+    assert fake_mgr.calls[-1] == ("load", "img", "sdxl-turbo")
+    assert arb.mode is GpuMode.IMG
+
+
+# ── restore_llm ──────────────────────────────────────────────────────────────
+
+
+async def test_restore_llm_reloads_saved_set(fake_mgr: FakeManager, state_path: Path) -> None:
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+    await arb.ensure_img()
+    fake_mgr.calls.clear()
+
+    await arb.restore_llm()
+
+    # img unloaded FIRST, then the saved set reloaded (default models)
+    assert fake_mgr.calls[0] == ("unload", "img")
+    assert fake_mgr.calls[1:] == [("load", "chat", None), ("load", "agent", None)]
+    assert arb.mode is GpuMode.LLM
+    final = _read_state(state_path)
+    assert final["mode"] == "llm"
+    assert final["saved_llm_slots"] == []
+
+
+async def test_restore_llm_noop_in_llm_mode(fake_mgr: FakeManager, state_path: Path) -> None:
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+    await arb.restore_llm()
+    assert fake_mgr.calls == []
+    assert arb.mode is GpuMode.LLM
+
+
+async def test_restore_blocked_when_pinned_unless_force(
+    fake_mgr: FakeManager, state_path: Path
+) -> None:
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+    await arb.ensure_img(pin=True)
+    fake_mgr.calls.clear()
+
+    with pytest.raises(ArbiterPinned) as ei:
+        await arb.restore_llm()
+    assert ei.value.code == "gpu.pinned"
+    assert ei.value.status == 409
+    assert fake_mgr.calls == []  # nothing touched
+    assert arb.mode is GpuMode.IMG
+
+    await arb.restore_llm(force=True)
+    assert arb.mode is GpuMode.LLM
+    assert arb.pinned is False  # force-restore clears the pin
+    assert fake_mgr.calls[0] == ("unload", "img")
+
+
+# ── persistence across restarts ──────────────────────────────────────────────
+
+
+async def test_state_survives_restart(fake_mgr: FakeManager, state_path: Path) -> None:
+    arb1 = GpuArbiter(fake_mgr, state_path=state_path)
+    await arb1.ensure_img()
+
+    # new process: fresh arbiter over the same state file
+    fake2 = FakeManager()
+    fake2.ready = {"img"}
+    arb2 = GpuArbiter(fake2, state_path=state_path)
+    assert arb2.mode is GpuMode.IMG
+    assert set(arb2.saved_llm_slots) == {"chat", "agent"}
+
+    await arb2.restore_llm()
+    assert ("unload", "img") in fake2.calls
+    assert ("load", "chat", None) in fake2.calls
+    assert ("load", "agent", None) in fake2.calls
+    assert arb2.mode is GpuMode.LLM
+
+
+def test_corrupt_state_file_falls_back_to_llm(fake_mgr: FakeManager, state_path: Path) -> None:
+    state_path.write_text("{not json", encoding="utf-8")
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+    assert arb.mode is GpuMode.LLM
+    assert arb.saved_llm_slots == ()
+    arb.guard_llm_dispatch("chat")  # must not raise
+
+
+# ── guard_llm_dispatch ───────────────────────────────────────────────────────
+
+
+def _write_img_state(path: Path, *, last_activity: float | None = None) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "mode": "img",
+                "pinned": False,
+                "saved_llm_slots": ["chat", "agent"],
+                "last_img_activity": time.time() if last_activity is None else last_activity,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_guard_llm_dispatch_raises_in_img_mode(
+    fake_mgr: FakeManager, state_path: Path, tmp_hal0_home: str
+) -> None:
+    _write_img_state(state_path)
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+
+    with pytest.raises(GpuImageMode) as ei:
+        arb.guard_llm_dispatch("chat")
+    assert ei.value.code == "gpu.image_mode"
+    assert ei.value.status == 503
+    assert ei.value.details["retry_after_s"] >= 15
+    assert ei.value.details["slot"] == "chat"
+
+    # non-llm-group slots always pass
+    arb.guard_llm_dispatch("npu")
+    arb.guard_llm_dispatch("tts")
+
+    # mode LLM → everything passes
+    llm_path = state_path.parent / "llm_state.json"
+    arb_llm = GpuArbiter(fake_mgr, state_path=llm_path)
+    arb_llm.guard_llm_dispatch("chat")
+    arb_llm.guard_llm_dispatch("npu")
+
+
+def test_guard_retry_after_floor(
+    fake_mgr: FakeManager, state_path: Path, tmp_hal0_home: str
+) -> None:
+    # idle window long past → floor of 15s
+    _write_img_state(state_path, last_activity=time.time() - 10_000)
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+    with pytest.raises(GpuImageMode) as ei:
+        arb.guard_llm_dispatch("agent")
+    assert ei.value.details["retry_after_s"] == 15
+
+
+def test_guard_uses_derived_group_from_slot_toml(
+    fake_mgr: FakeManager, state_path: Path, tmp_hal0_home: str
+) -> None:
+    """Restart case: a GPU-container slot NOT in the saved set is still guarded
+    when its on-disk TOML derives to the llm group."""
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "utility.toml").write_text(
+        "\n".join(
+            [
+                'name = "utility"',
+                'type = "llm"',
+                'device = "gpu-vulkan"',
+                'runtime = "container"',
+                "port = 8081",
+                "[model]",
+                'default = "gemma-4-12b-it"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    _write_img_state(state_path)
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+    with pytest.raises(GpuImageMode):
+        arb.guard_llm_dispatch("utility")
+
+
+# ── activity / pin / status ──────────────────────────────────────────────────
+
+
+async def test_touch_and_status(fake_mgr: FakeManager, state_path: Path) -> None:
+    arb = GpuArbiter(fake_mgr, state_path=state_path, idle_restore_minutes=7)
+    st = arb.status()
+    assert st == {
+        "mode": "llm",
+        "pinned": False,
+        "saved_llm_slots": [],
+        "idle_restore_at": None,
+    }
+
+    await arb.ensure_img()
+    before = time.time()
+    arb.touch_img_activity()
+    st = arb.status()
+    assert st["mode"] == "img"
+    assert st["idle_restore_at"] is not None
+    assert st["idle_restore_at"] >= before + 7 * 60 - 1
+    assert _read_state(state_path)["last_img_activity"] >= before
+
+    # pinned → no auto-restore window advertised
+    arb.set_pin(True)
+    assert arb.status()["pinned"] is True
+    assert arb.status()["idle_restore_at"] is None
+    arb.set_pin(False)
+    assert arb.status()["idle_restore_at"] is not None
+
+
+# ── manager wiring ───────────────────────────────────────────────────────────
+
+
+def test_manager_owns_lazy_arbiter(tmp_hal0_home: str) -> None:
+    from hal0.slots.manager import SlotManager
+
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "img.toml").write_text(
+        "\n".join(
+            [
+                'name = "img"',
+                'type = "image"',
+                'provider = "comfyui"',
+                'device = "gpu-rocm"',
+                'runtime = "container"',
+                "port = 8188",
+                "[model]",
+                'default = "sdxl-turbo"',
+                "[image]",
+                "idle_restore_minutes = 7",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    sm = SlotManager()
+    arb = sm.arbiter
+    assert isinstance(arb, GpuArbiter)
+    assert sm.arbiter is arb  # constructed once, cached
+    # state path lives under the manager's var-lib root (HAL0_HOME-redirected)
+    assert arb.state_path == Path(tmp_hal0_home) / "var-lib" / "hal0" / "gpu_arbiter.json"
+    # idle_restore_minutes read from the img slot's [image] section
+    assert arb.idle_restore_minutes == 7
+
+
+def test_manager_arbiter_defaults_without_img_slot(tmp_hal0_home: str) -> None:
+    from hal0.slots.manager import SlotManager
+
+    sm = SlotManager()
+    assert sm.arbiter.idle_restore_minutes == 5

--- a/tests/slots/test_gpu_arbiter.py
+++ b/tests/slots/test_gpu_arbiter.py
@@ -14,6 +14,7 @@ in_flight_count() read from dicts, load()/unload() record calls.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import time
@@ -577,6 +578,126 @@ async def test_touch_and_status(fake_mgr: FakeManager, state_path: Path) -> None
     assert arb.status()["idle_restore_at"] is None
     arb.set_pin(False)
     assert arb.status()["idle_restore_at"] is not None
+
+
+# ── idle-restore loop (D6) ───────────────────────────────────────────────────
+
+#: ~0.05s idle window expressed in minutes (idle_restore_minutes * 60 = secs).
+_TINY_WINDOW_MIN = 0.05 / 60
+
+
+async def _img_mode_arbiter(fake_mgr: FakeManager, state_path: Path) -> GpuArbiter:
+    """Arbiter already flipped to IMG with a tiny idle window, calls cleared."""
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+    await arb.ensure_img()
+    arb.idle_restore_minutes = _TINY_WINDOW_MIN
+    fake_mgr.calls.clear()
+    return arb
+
+
+async def _cancel_loop(task: asyncio.Task[None]) -> None:
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+async def test_idle_restore_fires_after_window(fake_mgr: FakeManager, state_path: Path) -> None:
+    """Past the idle window the loop restores the LLM set EXACTLY once and
+    keeps ticking (mode flips to LLM so later ticks are no-ops)."""
+    arb = await _img_mode_arbiter(fake_mgr, state_path)
+
+    task = asyncio.create_task(arb.run_idle_loop(interval_s=0.01))
+    try:
+        await asyncio.sleep(0.3)
+        assert fake_mgr.calls.count(("unload", "img")) == 1
+        assert ("load", "chat", None) in fake_mgr.calls
+        assert ("load", "agent", None) in fake_mgr.calls
+        assert arb.mode is GpuMode.LLM
+        assert not task.done(), "loop must stay alive after restoring"
+    finally:
+        await _cancel_loop(task)
+
+
+async def test_idle_restore_skipped_when_pinned(fake_mgr: FakeManager, state_path: Path) -> None:
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+    await arb.ensure_img(pin=True)
+    arb.idle_restore_minutes = _TINY_WINDOW_MIN
+    fake_mgr.calls.clear()
+
+    task = asyncio.create_task(arb.run_idle_loop(interval_s=0.01))
+    try:
+        await asyncio.sleep(0.2)
+        assert fake_mgr.calls == []  # nothing unloaded/loaded
+        assert arb.mode is GpuMode.IMG
+        assert not task.done()
+    finally:
+        await _cancel_loop(task)
+
+
+async def test_idle_restore_skipped_when_window_zero(
+    fake_mgr: FakeManager, state_path: Path
+) -> None:
+    """idle_restore_minutes=0 → manual-only restore (#599 schema), never auto."""
+    arb = GpuArbiter(fake_mgr, state_path=state_path, idle_restore_minutes=0)
+    await arb.ensure_img()
+    # backdate activity far past ANY window so a buggy 0-window would fire
+    arb._load_state()["last_img_activity"] = time.time() - 10_000
+    arb._persist()
+    fake_mgr.calls.clear()
+
+    task = asyncio.create_task(arb.run_idle_loop(interval_s=0.01))
+    try:
+        await asyncio.sleep(0.2)
+        assert fake_mgr.calls == []
+        assert arb.mode is GpuMode.IMG
+        assert not task.done()
+    finally:
+        await _cancel_loop(task)
+
+
+async def test_in_flight_img_job_defers_restore(fake_mgr: FakeManager, state_path: Path) -> None:
+    """An in-flight img job (long Wan video render) defers the restore even
+    past the window; it fires once the job count drops to zero."""
+    arb = await _img_mode_arbiter(fake_mgr, state_path)
+    fake_mgr.in_flight = {"img": 1}
+
+    task = asyncio.create_task(arb.run_idle_loop(interval_s=0.01))
+    try:
+        await asyncio.sleep(0.2)
+        assert ("unload", "img") not in fake_mgr.calls
+        assert arb.mode is GpuMode.IMG
+
+        fake_mgr.in_flight = {"img": 0}  # render finished
+        await asyncio.sleep(0.2)
+        assert fake_mgr.calls.count(("unload", "img")) == 1
+        assert arb.mode is GpuMode.LLM
+    finally:
+        await _cancel_loop(task)
+
+
+async def test_idle_loop_survives_restore_exception(
+    fake_mgr: FakeManager, state_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """restore_llm raising must not kill the loop: the error is logged and
+    the restore succeeds on the next eligible tick."""
+    arb = await _img_mode_arbiter(fake_mgr, state_path)
+    fake_mgr.fail_loads = {"chat"}  # restore_llm raises mid-reload
+
+    with caplog.at_level(logging.WARNING, logger="hal0.slots.arbiter"):
+        task = asyncio.create_task(arb.run_idle_loop(interval_s=0.01))
+        try:
+            await asyncio.sleep(0.2)
+            assert any("idle_loop_error" in rec.message for rec in caplog.records)
+            assert arb.mode is GpuMode.IMG  # failed restore left mode persisted
+            assert not task.done(), "loop must survive tick exceptions"
+
+            fake_mgr.fail_loads = set()
+            await asyncio.sleep(0.2)
+            assert arb.mode is GpuMode.LLM
+            assert ("load", "chat", None) in fake_mgr.calls
+            assert ("load", "agent", None) in fake_mgr.calls
+        finally:
+            await _cancel_loop(task)
 
 
 # ── manager wiring ───────────────────────────────────────────────────────────

--- a/tests/slots/test_gpu_arbiter.py
+++ b/tests/slots/test_gpu_arbiter.py
@@ -741,3 +741,74 @@ def test_manager_arbiter_defaults_without_img_slot(tmp_hal0_home: str) -> None:
 
     sm = SlotManager()
     assert sm.arbiter.idle_restore_minutes == 5
+
+
+def _write_img_toml(tmp_hal0_home: str, idle_restore_minutes: str) -> None:
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "img.toml").write_text(
+        "\n".join(
+            [
+                'name = "img"',
+                'type = "image"',
+                'provider = "comfyui"',
+                'device = "gpu-rocm"',
+                'runtime = "container"',
+                "port = 8188",
+                "[model]",
+                'default = "sdxl-turbo"',
+                "[image]",
+                f"idle_restore_minutes = {idle_restore_minutes}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_manager_arbiter_accepts_zero_window_from_toml(tmp_hal0_home: str) -> None:
+    """TOML ``[image].idle_restore_minutes = 0`` reaches the arbiter as 0
+    (manual-only restore, #599 schema) — NOT coerced to the default 5.
+    Negatives/garbage still fall back to 5."""
+    from hal0.slots.manager import SlotManager
+
+    _write_img_toml(tmp_hal0_home, "0")
+    assert SlotManager().arbiter.idle_restore_minutes == 0
+
+    # invalid values still fall back to 5 (fresh managers: arbiter is cached)
+    _write_img_toml(tmp_hal0_home, "-3")
+    assert SlotManager().arbiter.idle_restore_minutes == 5
+    _write_img_toml(tmp_hal0_home, "true")
+    assert SlotManager().arbiter.idle_restore_minutes == 5
+    _write_img_toml(tmp_hal0_home, '"soon"')
+    assert SlotManager().arbiter.idle_restore_minutes == 5
+
+
+async def test_zero_window_from_toml_never_auto_restores(tmp_hal0_home: str) -> None:
+    """End-to-end #599 pin: the TOML-sourced 0 window feeds an arbiter whose
+    idle loop never auto-restores (manual restore only)."""
+    from hal0.slots.manager import SlotManager
+
+    _write_img_toml(tmp_hal0_home, "0")
+    fake_mgr = FakeManager()
+    arb = GpuArbiter(
+        fake_mgr,
+        state_path=Path(tmp_hal0_home) / "gpu_arbiter.json",
+        idle_restore_minutes=SlotManager()._img_idle_restore_minutes(),
+    )
+    assert arb.idle_restore_minutes == 0
+    await arb.ensure_img()
+    # backdate activity far past ANY window so a buggy coercion-to-5 (or a
+    # 0-window treated as "always expired") would fire
+    arb._load_state()["last_img_activity"] = time.time() - 10_000
+    arb._persist()
+    fake_mgr.calls.clear()
+
+    task = asyncio.create_task(arb.run_idle_loop(interval_s=0.01))
+    try:
+        await asyncio.sleep(0.1)
+        assert fake_mgr.calls == []
+        assert arb.mode is GpuMode.IMG
+        assert not task.done()
+    finally:
+        await _cancel_loop(task)

--- a/tests/slots/test_gpu_arbiter.py
+++ b/tests/slots/test_gpu_arbiter.py
@@ -13,6 +13,7 @@ in_flight_count() read from dicts, load()/unload() record calls.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -101,6 +102,7 @@ class FakeManager:
         self.calls: list[tuple[Any, ...]] = []
         self.poll_log: list[tuple[str, int]] = []
         self.on_unload = None  # optional hook(name) fired before recording
+        self.fail_loads: set[str] = set()  # load(name) raises for these slots
 
     async def iter_configs(self) -> list[dict[str, Any]]:
         return [dict(c) for c in self.configs]
@@ -121,6 +123,9 @@ class FakeManager:
         return count
 
     async def load(self, name: str, model_id: str | None = None) -> None:
+        if name in self.fail_loads:
+            self.calls.append(("load_failed", name, model_id))
+            raise RuntimeError(f"load failed: {name}")
         self.calls.append(("load", name, model_id))
         self.ready.add(name)
 
@@ -264,6 +269,70 @@ async def test_drain_timeout_proceeds(
     assert arb.mode is GpuMode.IMG
 
 
+# ── img-load failure rollback (D5 quality gate I1) ──────────────────────────
+
+
+async def test_img_load_failure_rolls_back_llm_set(
+    fake_mgr: FakeManager, state_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """img load raises AFTER llm unloads → saved set reloaded, mode=llm
+    persisted, original exception propagates, retry re-attempts the switch."""
+    fake_mgr.fail_loads = {"img"}
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+
+    with (
+        caplog.at_level(logging.WARNING, logger="hal0.slots.arbiter"),
+        pytest.raises(RuntimeError, match="load failed: img"),
+    ):
+        await arb.ensure_img()
+
+    assert fake_mgr.calls == [
+        ("unload", "chat"),
+        ("unload", "agent"),
+        ("load_failed", "img", "sdxl-turbo"),
+        ("load", "chat", None),
+        ("load", "agent", None),
+    ]
+    assert any("img_load_failed_rolled_back" in rec.message for rec in caplog.records)
+    assert arb.mode is GpuMode.LLM
+    final = _read_state(state_path)
+    assert final["mode"] == "llm"
+    assert final["saved_llm_slots"] == []
+    # guard must NOT be wedged
+    arb.guard_llm_dispatch("chat")
+
+    # a retried image request re-attempts the FULL switch (no IMG no-op
+    # short-circuit against a dead img port)
+    fake_mgr.fail_loads = set()
+    fake_mgr.calls.clear()
+    await arb.ensure_img()
+    assert fake_mgr.calls[-1] == ("load", "img", "sdxl-turbo")
+    assert arb.mode is GpuMode.IMG
+
+
+async def test_img_load_failure_rollback_load_also_fails(
+    fake_mgr: FakeManager, state_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """img load raises AND one rollback load raises → mode=llm STILL
+    persisted (guard never wedges), original img exception propagates."""
+    fake_mgr.fail_loads = {"img", "chat"}
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+
+    with (
+        caplog.at_level(logging.WARNING, logger="hal0.slots.arbiter"),
+        pytest.raises(RuntimeError, match="load failed: img"),
+    ):
+        await arb.ensure_img()
+
+    # rollback continued past the failed chat load and restored agent
+    assert ("load_failed", "chat", None) in fake_mgr.calls
+    assert ("load", "agent", None) in fake_mgr.calls
+    assert any("rollback_load_failed" in rec.message for rec in caplog.records)
+    assert arb.mode is GpuMode.LLM
+    assert _read_state(state_path)["mode"] == "llm"
+    arb.guard_llm_dispatch("chat")  # not wedged
+
+
 # ── restore_llm ──────────────────────────────────────────────────────────────
 
 
@@ -310,6 +379,35 @@ async def test_restore_blocked_when_pinned_unless_force(
     assert fake_mgr.calls[0] == ("unload", "img")
 
 
+# ── concurrency: one lock, no interleaved flips ──────────────────────────────
+
+
+async def test_concurrent_ensure_img_and_restore_serialize(
+    fake_mgr: FakeManager, state_path: Path
+) -> None:
+    """ensure_img + restore_llm fired concurrently: the switch lock
+    serializes them — full img switch first, then full restore, with zero
+    interleaved load/unload recorder entries."""
+    # drain curve forces awaits INSIDE the locked ensure_img section so the
+    # restore task genuinely contends for the lock
+    fake_mgr.in_flight = {"chat": [1, 1, 0]}
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+
+    await asyncio.gather(arb.ensure_img(), arb.restore_llm())
+
+    assert fake_mgr.calls == [
+        ("unload", "chat"),
+        ("unload", "agent"),
+        ("load", "img", "sdxl-turbo"),
+        ("unload", "img"),
+        ("load", "chat", None),
+        ("load", "agent", None),
+    ]
+    assert arb.mode is GpuMode.LLM
+    assert arb.saved_llm_slots == ()
+    assert _read_state(state_path)["mode"] == "llm"
+
+
 # ── persistence across restarts ──────────────────────────────────────────────
 
 
@@ -329,6 +427,38 @@ async def test_state_survives_restart(fake_mgr: FakeManager, state_path: Path) -
     assert ("load", "chat", None) in fake2.calls
     assert ("load", "agent", None) in fake2.calls
     assert arb2.mode is GpuMode.LLM
+
+
+async def test_partial_crash_recovery_via_restore(state_path: Path) -> None:
+    """Crash mid-switch: mode=img + saved set persisted (pre-unload ordering),
+    llm slots unloaded, img never loaded. A fresh arbiter over that state
+    file restores the saved set cleanly."""
+    state_path.write_text(
+        json.dumps(
+            {
+                "mode": "img",
+                "pinned": False,
+                "saved_llm_slots": ["chat", "agent"],
+                "last_img_activity": time.time(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    mgr = FakeManager()
+    mgr.ready = set()  # nothing survived the crash
+    arb = GpuArbiter(mgr, state_path=state_path)
+    assert arb.mode is GpuMode.IMG
+    assert set(arb.saved_llm_slots) == {"chat", "agent"}
+
+    await arb.restore_llm()
+
+    assert mgr.calls == [
+        ("unload", "img"),
+        ("load", "chat", None),
+        ("load", "agent", None),
+    ]
+    assert arb.mode is GpuMode.LLM
+    assert _read_state(state_path)["mode"] == "llm"
 
 
 def test_corrupt_state_file_falls_back_to_llm(fake_mgr: FakeManager, state_path: Path) -> None:

--- a/tests/slots/test_gpu_arbiter.py
+++ b/tests/slots/test_gpu_arbiter.py
@@ -173,8 +173,14 @@ def test_group_derivation() -> None:
         gpu_exclusive_group({"device": "gpu-rocm", "runtime": "container", "type": "image"})
         == "img"
     )
-    # missing runtime defaults to lemonade → never arbitrated
+    # missing runtime + no profile defaults to lemonade → never arbitrated
     assert gpu_exclusive_group({"device": "gpu-rocm"}) is None
+    # profile-only GPU slots ARE containers (mirrors _is_container_slot:
+    # profile is the primary signal, wins regardless of runtime) → arbitrated
+    assert gpu_exclusive_group({"device": "gpu-vulkan", "profile": "vulkan-std"}) == "llm"
+    assert gpu_exclusive_group({"device": "gpu-rocm", "profile": "comfyui"}) == "img"
+    # profile-only on a non-GPU device still never arbitrated
+    assert gpu_exclusive_group({"device": "npu", "profile": "flm-npu"}) is None
 
 
 # ── ensure_img ───────────────────────────────────────────────────────────────

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -28,6 +28,9 @@ export const ENDPOINTS = {
   // switchover write-path is feature-gated server-side.
   comfyuiStatus: '/api/comfyui/status',
   comfyuiSwitchover: '/api/comfyui/switchover',
+  // Pin image mode (disables the arbiter's idle auto-restore). 501 when the
+  // switchover gate is off.
+  comfyuiPin: '/api/comfyui/pin',
 
   slotMetrics: '/api/slots/metrics',
   slot: (name: string) => `/api/slots/${encodeURIComponent(name)}`,

--- a/ui/src/api/hooks/useComfyui.ts
+++ b/ui/src/api/hooks/useComfyui.ts
@@ -7,13 +7,19 @@
 // the cpp-httplib server behind :8188.
 //
 // The switchover (inference ⇄ generation) flips the single iGPU between the LLM
-// stack and ComfyUI by running root-owned scripts. The endpoint answers 202 and
-// runs the script pair in the background; the `switchover` block on /status
+// stack and ComfyUI via the API's GPU arbiter (Phase D): switching to
+// generation drains and STOPS the LLM slots, then starts the ComfyUI img slot;
+// switching back restores the saved slots. The endpoint answers 202 and the
+// arbiter runs the transition in-process; the `switchover` block on /status
 // (active/target/error) is what tracks the transition to terminal — the pane's
 // poll renders it, per the async-job-must-poll-to-terminal rule. Tearing down a
 // non-empty queue needs `force: true` (the confirm dialog is that consent). The
 // whole path stays feature-gated server-side (HAL0_COMFYUI_SWITCHOVER_ENABLED,
 // 501 when off) — surfaced as a toast, never an optimistic flip.
+//
+// `arbiter` is the arbiter-truth block ({mode img|llm, pinned, saved slots,
+// idle_restore_at}); it is null when the arbiter is unavailable (gate off /
+// older backend) and every consumer fails soft to the legacy display.
 
 import { useMutation, useQuery, type UseQueryResult } from '@tanstack/react-query'
 import { api, apiGet } from '../client'
@@ -36,6 +42,16 @@ export interface ComfyuiSwitchover {
   error: string | null
 }
 
+// GPU-arbiter truth block. `mode` is the arbiter's own vocabulary
+// ('img' | 'llm', distinct from the legacy 'generation' | 'inference');
+// `idle_restore_at` is an epoch (seconds) or null when pinned / not armed.
+export interface ComfyuiArbiter {
+  mode: string
+  pinned: boolean
+  saved_llm_slots: string[]
+  idle_restore_at: number | null
+}
+
 export interface ComfyuiStatus {
   mode: ComfyuiMode
   reachable: boolean
@@ -47,6 +63,7 @@ export interface ComfyuiStatus {
   inference: { lemonade: boolean; hermes: boolean }
   inventory: Record<string, number> | null
   switchover: ComfyuiSwitchover
+  arbiter: ComfyuiArbiter | null
 }
 
 // Neutral default so the pane renders a coherent "stopped/inference" shell on
@@ -63,6 +80,7 @@ export const COMFYUI_FALLBACK: ComfyuiStatus = {
   inference: { lemonade: false, hermes: false },
   inventory: null,
   switchover: { active: false, target: null, error: null },
+  arbiter: null,
 }
 
 // Active (Image-Gen tab open): 4s, fast enough to track queue + pressure.
@@ -86,6 +104,9 @@ export interface SwitchoverBody {
   // Required to tear down a non-empty render queue (jobs are dropped). The
   // confirm dialog's warning is the consent that sets this.
   force?: boolean
+  // Optional: pin image mode as part of the switch (disables idle
+  // auto-restore until unpinned).
+  pin?: boolean
 }
 
 // raw:true so the dev mockFetch GET-shim can't mask the 501/503 gate — we want
@@ -94,5 +115,19 @@ export function useComfyuiSwitchover() {
   return useMutation({
     mutationFn: (body: SwitchoverBody) =>
       api<unknown>(ENDPOINTS.comfyuiSwitchover, { method: 'POST', body: body as any, raw: true }),
+  })
+}
+
+// Pin / unpin image mode (disables / re-arms the arbiter's idle auto-restore).
+// Synchronous 200 {"pinned":bool} — the caller refetches /status to reflect
+// the new arbiter state. raw:true for the same 501-gate reason as switchover.
+export function useComfyuiPin() {
+  return useMutation({
+    mutationFn: (body: { pinned: boolean }) =>
+      api<{ pinned: boolean }>(ENDPOINTS.comfyuiPin, {
+        method: 'POST',
+        body: body as any,
+        raw: true,
+      }),
   })
 }

--- a/ui/src/dash/comfyui-pane.jsx
+++ b/ui/src/dash/comfyui-pane.jsx
@@ -238,7 +238,7 @@ function SwitchoverConfirm({ target, queuePending, busy, onCancel, onConfirm }) 
                   <Ic name="warn" size={14} />
                 </span>
                 Background memory extraction pauses (NPU gemma3-4b via lemonade); it recovers
-                automatically. Embeddings + rerank are CPU-pinned and unaffected.
+                automatically. Rerank pauses too (GPU slot); embeddings are unaffected (NPU).
               </div>
             </div>
           )}

--- a/ui/src/dash/comfyui-pane.jsx
+++ b/ui/src/dash/comfyui-pane.jsx
@@ -11,16 +11,26 @@
 //   - queue depth (ComfyUI /queue)
 //   - model inventory counts (verified file counts on the share)
 // The switchover toggle opens a blast-radius confirm dialog, then calls the
-// feature-gated POST /api/comfyui/switchover (202 + background scripts; the
-// status poll's `switchover` block drives the transitional UI — never an
-// optimistic flip; 501 toast when the host gate is off).
+// feature-gated POST /api/comfyui/switchover (202; the API's GPU arbiter
+// drains + stops the LLM slots and starts the ComfyUI img slot in-process —
+// no shell-out. The status poll's `switchover` block drives the transitional
+// UI — never an optimistic flip; 501 toast when the host gate is off).
+// The `arbiter` block on /status (mode img|llm, pinned, idle_restore_at) is
+// arbiter-truth: it drives the mode chip, the pin toggle and the auto-restore
+// countdown; when it is null (gate off / older backend) the pane fails soft
+// to the legacy container-telemetry display.
 //
 // Deliberately NOT wired yet (need ComfyUI's WS /ws + AMDGPUMonitor, or the
 // privileged path): per-node progress %, it/s, GPU util/temp/clocks, per-job
 // queue names, and the container start/stop/restart controls. Those render in a
 // disabled/"—" state so the layout stays faithful without inventing numbers.
 
-import { useComfyui, useComfyuiSwitchover, COMFYUI_FALLBACK } from '@/api/hooks/useComfyui'
+import {
+  useComfyui,
+  useComfyuiSwitchover,
+  useComfyuiPin,
+  COMFYUI_FALLBACK,
+} from '@/api/hooks/useComfyui'
 
 const { useState } = React
 
@@ -203,12 +213,15 @@ function SwitchoverConfirm({ target, queuePending, busy, onCancel, onConfirm }) 
             {toGen ? (
               <>
                 Only one of <span className="mono">{'{ inference, ComfyUI }'}</span> can hold the
-                single iGPU. Switching stops the LLM runtime and starts the ComfyUI container.
+                single iGPU. Switching drains in-flight requests, then <b>stops the LLM slots</b>{' '}
+                and starts the ComfyUI container. The stopped slots restore automatically after
+                the engine sits idle — pinning image mode disables that auto-restore.
               </>
             ) : (
               <>
-                This stops the ComfyUI container and restarts the LLM runtime. In-flight renders
-                are not interrupted by the dashboard — drain the queue first.
+                This stops the ComfyUI container and <b>restores the LLM slots</b> that were
+                stopped by the switchover. In-flight renders are not interrupted by the
+                dashboard — drain the queue first.
               </>
             )}
           </p>
@@ -238,19 +251,19 @@ function SwitchoverConfirm({ target, queuePending, busy, onCancel, onConfirm }) 
           <div className="cf-steps">
             {toGen ? (
               <>
-                <span className="n">1</span> <span className="cmd">stop-inference.sh</span>{' '}
-                <span className="arr">→</span> <span className="cmd">comfy-up.sh</span>
+                <span className="n">1</span> <span className="cmd">drain + stop LLM slots</span>{' '}
+                <span className="arr">→</span> <span className="cmd">start ComfyUI</span>
               </>
             ) : (
               <>
-                <span className="n">1</span> <span className="cmd">comfy-down.sh</span>{' '}
-                <span className="arr">→</span> <span className="cmd">start-inference.sh</span>
+                <span className="n">1</span> <span className="cmd">stop ComfyUI</span>{' '}
+                <span className="arr">→</span> <span className="cmd">restore LLM slots</span>
               </>
             )}
           </div>
         </div>
         <div className="cf-f">
-          <span className="note">runs root-owned scripts on the runtime host</span>
+          <span className="note">the GPU arbiter on the runtime host runs the switchover</span>
           <span className="grow" style={{ flex: 1 }} />
           <button className="rbtn" onClick={onCancel} disabled={busy}>
             Cancel
@@ -280,15 +293,36 @@ const FLOWS = [
 export function ComfyuiPane() {
   const q = useComfyui()
   const sw = useComfyuiSwitchover()
+  const pin = useComfyuiPin()
   const st = q.data || COMFYUI_FALLBACK
   const [open, setOpen] = useState(false)
   const [confirm, setConfirm] = useState(null) // target mode or null
 
   const gen = st.mode === 'generation'
   const containerUp = st.container?.state === 'running'
-  const engine = st.engine || 'stopped'
+  // GPU-arbiter truth block (null → fail soft to the legacy display).
+  const arb = st.arbiter || null
+  // Post-migration the engine IS the podman img slot, so when the arbiter
+  // block is present its mode is the engine truth: img implies the engine is
+  // up even if container telemetry lags a poll; llm implies stopped. Container
+  // telemetry stays the fallback when the arbiter is unavailable.
+  const engineRaw = st.engine || 'stopped'
+  const engine = arb
+    ? arb.mode === 'img'
+      ? engineRaw === 'stopped'
+        ? 'running'
+        : engineRaw
+      : 'stopped'
+    : engineRaw
+  // Idle auto-restore countdown — recomputed on each status poll (renders in
+  // minutes, so no per-second timer needed).
+  const restoreMin =
+    arb && arb.mode === 'img' && !arb.pinned && arb.idle_restore_at
+      ? Math.max(1, Math.ceil((arb.idle_restore_at * 1000 - Date.now()) / 60_000))
+      : null
   // A switch in flight overrides the snapshot state: the pane's poll is what
-  // tracks the transition to terminal (202 + background scripts server-side).
+  // tracks the transition to terminal (202 + the arbiter's in-process
+  // transition server-side).
   const switching = !!st.switchover?.active
   const switchError = st.switchover?.error || null
   const stateLabel = switching
@@ -307,6 +341,30 @@ export function ComfyuiPane() {
 
   const href = comfyHref()
   const openComfy = () => window.open(href, '_blank', 'noopener')
+
+  // Pin toggle — synchronous 200 {"pinned":bool}, so mirror the switchover's
+  // refetch-not-optimistic pattern: toast, then refetch /status so the arbiter
+  // block (pin state + countdown) re-renders from server truth.
+  const doPin = async () => {
+    if (!arb || pin.isPending) return
+    const next = !arb.pinned
+    try {
+      await pin.mutateAsync({ pinned: next })
+      toast(next ? 'Image mode pinned — auto-restore disabled.' : 'Unpinned — auto-restore re-armed.', 'ok')
+      q.refetch()
+    } catch (err) {
+      const code = String(err?.code || '')
+      if (code === 'comfyui.switchover_disabled' || err?.status === 501) {
+        toast(
+          'ComfyUI switchover is disabled on this host — set HAL0_COMFYUI_SWITCHOVER_ENABLED=1 ' +
+            'on hal0-api to enable it.',
+          'warn'
+        )
+      } else {
+        toast(err?.message ? `pin failed: ${err.message}` : 'pin failed', 'warn')
+      }
+    }
+  }
 
   const doSwitch = async () => {
     const target = confirm
@@ -369,6 +427,28 @@ export function ComfyuiPane() {
               <span className="dot" />
               {stateLabel}
             </span>
+            {/* Arbiter mode chip — arbiter-truth display; hidden (fail-soft)
+                when the arbiter block is null. */}
+            {arb && (
+              <span
+                className={'epill ' + (arb.mode === 'img' ? 'running' : 'stopped')}
+                data-testid="comfy-arbiter-chip"
+                title={
+                  arb.mode === 'img'
+                    ? 'The GPU arbiter holds the iGPU for image generation — LLM slots are stopped.'
+                    : 'The LLM stack holds the iGPU — the image engine is parked.'
+                }
+              >
+                <span className="dot" />
+                {arb.mode === 'img' ? 'image mode' : 'inference'}
+                {arb.pinned && arb.mode === 'img' ? ' · pinned' : ''}
+              </span>
+            )}
+            {restoreMin != null && (
+              <span className="meta" data-testid="comfy-restore-countdown">
+                auto-restore in ~{restoreMin}m
+              </span>
+            )}
             {switchError && !switching && (
               <span className="meta" style={{ color: 'var(--warn)' }} title={switchError}>
                 last switch failed
@@ -376,6 +456,22 @@ export function ComfyuiPane() {
             )}
             <span className="grow" style={{ flex: 1 }} />
             <span className="eh-right">
+              {/* Pin toggle — only with an arbiter; disables idle auto-restore. */}
+              {arb && (
+                <button
+                  className={'rbtn' + (arb.pinned ? ' primary' : '')}
+                  data-testid="comfy-pin-toggle"
+                  onClick={doPin}
+                  disabled={pin.isPending}
+                  title={
+                    arb.pinned
+                      ? 'Image mode is pinned — auto-restore disabled. Click to unpin.'
+                      : 'Pin image mode (disables the idle auto-restore of LLM slots)'
+                  }
+                >
+                  {pin.isPending ? '…' : arb.pinned ? 'pinned' : 'pin'}
+                </button>
+              )}
               <button
                 className="rbtn ghost-comfy"
                 disabled={!containerUp}

--- a/ui/src/dash/data.jsx
+++ b/ui/src/dash/data.jsx
@@ -215,6 +215,9 @@ const HAL0_DATA = {
       group: "img",
       state: "idle",
       isDefault: true,
+      // Phase D: the img slot is the podman ComfyUI container slot.
+      profile: "comfyui",
+      runtime: "container",
       port: 8098,
       pid: 28518,
       metrics: { rpm: 2, avg: 4.1, res: "512×512", mem: 1.2 },
@@ -232,6 +235,25 @@ const HAL0_DATA = {
       metrics: { toks: 0, ttft: null, ctx: 8192, kv: null, mem: 4.0 },
     },
   ],
+
+  // ComfyUI /api/comfyui/status mock — canonical shape incl. the Phase D GPU
+  // arbiter block (default: LLM stack holds the iGPU). NOTE: /api/comfyui/*
+  // is deliberately NOT in mock.ts's MOCK_ALLOWLIST so γ specs can drive the
+  // pane via page.route (profiles-crud convention); this object documents the
+  // shape and feeds any HAL0_DATA-driven demo reader.
+  comfyui: {
+    mode: "inference",
+    reachable: false,
+    engine: "stopped",
+    container: { name: "comfyui", state: "exited" },
+    endpoint: null,
+    memory: null,
+    queue: { running: 0, pending: 0 },
+    inference: { lemonade: true, hermes: true },
+    inventory: { checkpoints: 3, diffusion: 2, loras: 8, vae: 2 },
+    switchover: { active: false, target: null, error: null },
+    arbiter: { mode: "llm", pinned: false, saved_llm_slots: [], idle_restore_at: null },
+  },
 
   bundles: [
     {

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -214,6 +214,9 @@ function App() {
                 the current install. BannerStack continues to drive the
                 Tweaks-panel demo toggles for every other banner state. */}
             <UpdateBanner />
+            {/* Phase D8: self-renders while the GPU arbiter reports image
+                mode (/api/comfyui/status arbiter.mode === "img"). */}
+            <GpuImageModeBanner />
             <BannerStack scope="global" route={route} />
           </div>
           {renderView()}

--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -3,6 +3,7 @@
 
 import { useUpdateState } from '@/api/hooks/useUpdates'
 import { useInstallState, bundleNameOr } from '@/api/hooks/useInstallState'
+import { useComfyui } from '@/api/hooks/useComfyui'
 
 const { useState: useStateP, useEffect: useEffectP, useRef: useRefP, createContext: createContextP, useContext: useContextP } = React;
 
@@ -241,6 +242,17 @@ const BANNER_CATALOG = [
     ],
   },
   {
+    // Live surface is <GpuImageModeBanner> (reads the /api/comfyui/status
+    // arbiter block); this entry keeps the Tweaks-panel demo toggle working.
+    id: "gpu-image-mode", scope: "global", kind: "info",
+    eyebrow: "GPU · arbiter",
+    heading: "GPU: image mode",
+    body: "LLM slots are stopped while image generation holds the GPU — they restore automatically after idle.",
+    actions: [
+      { label: "View slots", primary: true, onClick: () => window.location.hash = "#slots" },
+    ],
+  },
+  {
     id: "restart-required", scope: "global", kind: "warn",
     eyebrow: "Restart required",
     heading: "Lemonade restart required to apply config changes",
@@ -445,6 +457,37 @@ function UpdateBanner() {
   );
 }
 
+// ─── GpuImageModeBanner — live-data wrapper around <Banner> ─────────────
+// Phase D8: mirrors the UpdateBanner pattern — the catalog entry of the
+// same id ("gpu-image-mode") stays around for the Tweaks demo toggle, but
+// the real surface is this component, fed by the polled /api/comfyui/status
+// arbiter block. Self-shows while the GPU arbiter holds the iGPU for image
+// generation (arbiter.mode === "img"); fails soft (renders nothing) when the
+// arbiter block is null (gate off / older backend). Dismiss is per-episode:
+// it resets when the GPU returns to llm mode so the next switchover
+// re-surfaces the banner.
+function GpuImageModeBanner() {
+  const q = useComfyui();
+  const [dismissed, setDismissed] = useStateP(false);
+  const isImg = q.data?.arbiter?.mode === "img";
+  useEffectP(() => { if (!isImg) setDismissed(false); }, [isImg]);
+  if (!isImg || dismissed) return null;
+  return (
+    <Banner
+      kind="info"
+      eyebrow="GPU · arbiter"
+      heading="GPU: image mode"
+      body="LLM slots are stopped while image generation holds the GPU — they restore automatically after idle."
+      actions={
+        <button className="btn sm" onClick={() => { window.location.hash = "#slots"; }}>
+          View slots
+        </button>
+      }
+      onDismiss={() => setDismissed(true)}
+    />
+  );
+}
+
 // ─── Dropdown menu ───────────────────────────────────────────────────────
 function Menu({ anchor = "right", items, onClose, style }) {
   return (
@@ -477,4 +520,4 @@ function Menu({ anchor = "right", items, onClose, style }) {
   );
 }
 
-Object.assign(window, { Modal, Drawer, ConfirmDialog, Banner, BannerStack, BannerProvider, useBanners, BANNER_CATALOG, Menu, UpdateBanner });
+Object.assign(window, { Modal, Drawer, ConfirmDialog, Banner, BannerStack, BannerProvider, useBanners, BANNER_CATALOG, Menu, UpdateBanner, GpuImageModeBanner });

--- a/ui/src/stores/useBannerStore.ts
+++ b/ui/src/stores/useBannerStore.ts
@@ -69,6 +69,16 @@ export const BANNER_CATALOG: ReadonlyArray<BannerEntry> = Object.freeze([
     ],
   },
   {
+    // Phase D8 — live surface is primitives.jsx <GpuImageModeBanner>.
+    id: 'gpu-image-mode',
+    scope: 'global',
+    kind: 'info',
+    eyebrow: 'GPU · arbiter',
+    heading: 'GPU: image mode',
+    body: 'LLM slots are stopped while image generation holds the GPU — they restore automatically after idle.',
+    actions: [{ label: 'View slots', primary: true }],
+  },
+  {
     id: 'restart-required',
     scope: 'global',
     kind: 'warn',

--- a/ui/tests/e2e/specs/comfyui-arbiter-v3.spec.ts
+++ b/ui/tests/e2e/specs/comfyui-arbiter-v3.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * comfyui-arbiter-v3 — Playwright coverage for the GPU arbiter surface
+ * (Phase D8): global "GPU: image mode" banner, arbiter mode chip, pin
+ * toggle, and idle auto-restore countdown on the ComfyUI pane.
+ *
+ * Harness mirrors profiles-crud-v3.spec.ts: VITE_MOCK_LEMONADE=1 build,
+ * but /api/comfyui/* is NOT in the mockFetch allowlist, so page.route
+ * intercepts both the status GET (read path) and the pin POST (raw:true
+ * write path).
+ */
+
+import { test, expect, json } from '../fixtures/apiMock'
+
+// Full /api/comfyui/status shape (D1-D7 backend): `mode` is arbiter-truth,
+// `arbiter` is the new block (null when the arbiter is unavailable).
+function comfyStatus(overrides: Record<string, any> = {}) {
+  return {
+    mode: 'inference',
+    reachable: false,
+    engine: 'stopped',
+    container: { name: 'comfyui', state: 'exited' },
+    endpoint: null,
+    memory: null,
+    queue: { running: 0, pending: 0 },
+    inference: { lemonade: true, hermes: true },
+    inventory: { checkpoints: 3, diffusion: 2, loras: 8, vae: 2 },
+    switchover: { active: false, target: null, error: null },
+    arbiter: null,
+    ...overrides,
+  }
+}
+
+const IMG_STATUS = () =>
+  comfyStatus({
+    mode: 'generation',
+    reachable: true,
+    engine: 'running',
+    container: { name: 'comfyui', state: 'running' },
+    endpoint: 'http://127.0.0.1:8188',
+    inference: { lemonade: false, hermes: false },
+    arbiter: {
+      mode: 'img',
+      pinned: false,
+      saved_llm_slots: ['primary', 'agent'],
+      // ~10 minutes out so the countdown renders a stable "~10m".
+      idle_restore_at: Math.floor(Date.now() / 1000) + 600,
+    },
+  })
+
+const LLM_STATUS = () =>
+  comfyStatus({
+    arbiter: { mode: 'llm', pinned: false, saved_llm_slots: [], idle_restore_at: null },
+  })
+
+async function gotoImageTab(page: any) {
+  await page.goto('/#slots')
+  await page.waitForSelector('.slot-tab.comfy', { timeout: 10_000 })
+  await page.click('.slot-tab.comfy')
+  await page.waitForSelector('.comfy-pane', { timeout: 10_000 })
+}
+
+test.describe('ComfyUI GPU arbiter — Phase D8', () => {
+  // ── 1. img mode: global banner + image-mode chip + countdown ──────────────
+
+  test('arbiter.mode img → global banner + image-mode chip + countdown', async ({ page }) => {
+    await page.route('**/api/comfyui/status', (route) => json(route, IMG_STATUS()))
+
+    await page.goto('/#slots')
+
+    // Global banner renders in the view-banners strip (any route).
+    const banner = page.locator('.banner', { hasText: 'GPU: image mode' })
+    await expect(banner).toBeVisible({ timeout: 10_000 })
+    await expect(banner).toContainText('LLM slots are stopped')
+
+    // Pane: arbiter chip shows image mode + the auto-restore countdown.
+    await page.click('.slot-tab.comfy')
+    await page.waitForSelector('.comfy-pane', { timeout: 10_000 })
+    const chip = page.locator('[data-testid="comfy-arbiter-chip"]')
+    await expect(chip).toBeVisible()
+    await expect(chip).toContainText('image mode')
+
+    const countdown = page.locator('[data-testid="comfy-restore-countdown"]')
+    await expect(countdown).toBeVisible()
+    await expect(countdown).toContainText(/auto-restore in ~\d+m/)
+  })
+
+  // ── 2. pin toggle → POST /api/comfyui/pin {"pinned":true} ────────────────
+
+  test('pin toggle POSTs {"pinned":true}; pinned reflected, countdown hidden', async ({ page }) => {
+    const posts: any[] = []
+    let pinned = false
+
+    await page.route('**/api/comfyui/status', (route) => {
+      const st = IMG_STATUS()
+      st.arbiter!.pinned = pinned
+      return json(route, st)
+    })
+    await page.route('**/api/comfyui/pin', (route) => {
+      if (route.request().method() === 'POST') {
+        try { posts.push(JSON.parse(route.request().postData() || '{}')) } catch { posts.push({}) }
+        pinned = posts[posts.length - 1].pinned === true
+        return json(route, { pinned })
+      }
+      return json(route, { pinned })
+    })
+
+    await gotoImageTab(page)
+
+    const pinBtn = page.locator('[data-testid="comfy-pin-toggle"]')
+    await expect(pinBtn).toBeVisible()
+    await expect(page.locator('[data-testid="comfy-restore-countdown"]')).toBeVisible()
+
+    await pinBtn.click()
+
+    // POST body asserted.
+    await expect.poll(() => posts.length).toBeGreaterThan(0)
+    expect(posts[0]).toEqual({ pinned: true })
+
+    // Pinned state reflected after refetch: pin active, countdown hidden.
+    await expect(pinBtn).toContainText('pinned', { timeout: 10_000 })
+    await expect(page.locator('[data-testid="comfy-restore-countdown"]')).not.toBeVisible()
+  })
+
+  // ── 3. llm mode: banner gone, inference chip ─────────────────────────────
+
+  test('arbiter.mode llm → no banner, inference chip', async ({ page }) => {
+    await page.route('**/api/comfyui/status', (route) => json(route, LLM_STATUS()))
+
+    await gotoImageTab(page)
+
+    await expect(page.locator('.banner', { hasText: 'GPU: image mode' })).not.toBeVisible()
+
+    const chip = page.locator('[data-testid="comfy-arbiter-chip"]')
+    await expect(chip).toBeVisible()
+    await expect(chip).toContainText('inference')
+
+    // No countdown in llm mode.
+    await expect(page.locator('[data-testid="comfy-restore-countdown"]')).not.toBeVisible()
+  })
+
+  // ── 4. arbiter null: fail-soft — no chip/banner/pin, legacy pane intact ──
+
+  test('arbiter null → no chip/banner/pin; legacy pane intact', async ({ page }) => {
+    await page.route('**/api/comfyui/status', (route) => json(route, comfyStatus()))
+
+    await gotoImageTab(page)
+
+    await expect(page.locator('.banner', { hasText: 'GPU: image mode' })).not.toBeVisible()
+    await expect(page.locator('[data-testid="comfy-arbiter-chip"]')).toHaveCount(0)
+    await expect(page.locator('[data-testid="comfy-pin-toggle"]')).toHaveCount(0)
+    await expect(page.locator('[data-testid="comfy-restore-countdown"]')).toHaveCount(0)
+
+    // Legacy display: engine card + mode toggle + footer identity still render.
+    await expect(page.locator('.comfy-pane .engine')).toBeVisible()
+    await expect(page.locator('.comfy-pane .sw-wrap')).toBeVisible()
+    await expect(page.locator('.comfy-pane .engine-foot')).toContainText('inference')
+  })
+})


### PR DESCRIPTION
Phase D of the lemonade-removal epic (spec §3 img row + §7, §12-D). Closes #599, closes #691.

## What

- **img slot**: ComfyUI runs as podman container slot `hal0-slot@img` — `comfyui` seed profile (`device_class="img"`), `img.toml` seed rewrite (runtime=container, port 8188, `[image]` settings section → closes #599), installer seed loop, manifest.json repinned to the live-validated `docker.io/kyuz0/amd-strix-halo-comfyui@sha256:0066678a…` (was the unpublished hal0-toolbox image).
- **ComfyUIProvider live-parity** `container_spec`: kyuz0 layout (`/opt/ComfyUI`), live mount set (`/mnt/ai-models/comfyui/{models→/root/comfy-models,output,input,user,custom_nodes}` + `extra_model_paths.yaml:ro`), `--ipc=host --shm-size=8g`, explicit GPU device nodes, host networking; `_spec_provider_for` img arm.
- **Dispatcher**: img path-pin (Rule 4) + model-prefix pin (Rule 6) now set `path_pinned` → container-backed img remotes accepted (same acceptance as embed/tts/rerank); `_default_for_path` image arm.
- **GpuArbiter** (`slots/arbiter.py`): exclusive llm/img GPU groups (derived, mirrors `_is_container_slot`); `ensure_img` drains in-flight LLM requests (`in_flight_count`), persists state BEFORE unloads (crash-ordered), unloads LLM set, loads img — with full rollback to llm mode if the img load fails (no wedge); `restore_llm` reverses; pin blocks restore (`force` overrides); state survives api restarts (`gpu_arbiter.json`).
- **Dispatch integration**: image requests auto-switch (`ensure_img` on `/v1/images/generations`); LLM dispatch in img mode → clean `gpu.image_mode` 503 + Retry-After (rides the existing retry_after_s middleware); **evicted-slot recovery suppressed in img mode** (would otherwise reload LLM slots into img mode and fight the arbiter); `[image]` defaults fill (size/steps).
- **Idle restore**: arbiter loop in the app lifespan — auto-restores the LLM set after `idle_restore_minutes` (default 5, `0` = manual-only) with no img activity; pin-aware; in-flight-aware; exception-proof.
- **Switchover API on the arbiter** (scripts retired): `POST /api/comfyui/switchover` drives `ensure_img`/`restore_llm` — the #690 shell-script pairs (`_SWITCH_PAIRS`/`_script_argv`/`_run_script`) are deleted; control-scripts stay on disk for manual ops; the sudoers grant story is obsolete. Contract preserved for the UI (202+BackgroundTasks, `_switch` status block, busy-queue 409+force, 501 gate). Mode probe + `/status` `mode`/`endpoint` are now **arbiter-truth** (the docker-derived probe would have permanently locked out the inference switch post-migration). New `POST /api/comfyui/pin`; status gains fail-soft `arbiter` block.
- **UI**: global "GPU: image mode" banner, arbiter mode chip, pin toggle, auto-restore countdown, corrected switchover blast-radius copy (rerank pauses — it's a GPU slot), mocks + 4-scenario γ spec.

## Review trail

Subagent-driven TDD (fresh implementer + per-task review; Opus gates on D4/D5/final). Caught pre-merge: `[image]` alias collision with the per-slot `image` override (D1), arbiter wedge on failed img load with no automated escape (D5 Opus → rollback + 4 tests), post-migration switchover lockout from docker-derived mode probe (D7 → arbiter-as-truth). Final cross-task Opus review: SHIP, all seven cross-task seams traced clean (config round-trip, live mount parity, route↔acceptance liveness, test isolation).

Follow-ups filed: #709 (omni-router bypasses the guard), #710 (status container telemetry still docker-derived).

## Gate

Full suite: 3246 passed, 1 failed = `tests/agents/test_hermes_provision_idempotency` (documented env-dependent docker smoke on hal0-dev), 12 deselected = known local `test_settings_models_store` hang. ruff check + format clean; ui build + γ suites green.

Deploy plan (after merge): CT105 docker→podman migration + e2e matrix per `docs/superpowers/plans/2026-06-11-phase-d-comfyui-img-slot-gpu-arbiter.md` Task D9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)