### PR TITLE
fix(providers): [image] TOML section is not an image-ref override

### DIFF
--- a/src/hal0/providers/comfyui.py
+++ b/src/hal0/providers/comfyui.py
@@ -165,8 +165,12 @@ class ComfyUIProvider(Provider):
           4. The fallback tag ``docker.io/kyuz0/amd-strix-halo-comfyui:latest``.
         """
         override = slot_cfg.get("image") or slot_cfg.get("slot", {}).get("image")
-        if override:
-            return str(override)
+        # Only a STRING is an image-ref override. In raw slot dicts the
+        # [image] TOML section (#599 image-gen settings) shares this key —
+        # treating that dict as a ref renders str(dict) into ExecStart and
+        # podman fails with 'invalid reference format' (live CT105, Phase D).
+        if isinstance(override, str) and override:
+            return override
         env_override = os.environ.get("HAL0_TOOLBOX_IMAGE_COMFYUI", "").strip()
         if env_override:
             return env_override

--- a/src/hal0/providers/llama_server.py
+++ b/src/hal0/providers/llama_server.py
@@ -331,10 +331,13 @@ class LlamaServerProvider(Provider):
         Backends: "vulkan" | "rocm" | "cpu" (cpu falls through to vulkan
         since the vulkan image runs on cpu when no GPU is exposed).
         """
-        # (1) Per-slot override always wins.
+        # (1) Per-slot override always wins — but only a STRING is an
+        # override. In raw slot dicts the [image] TOML section (#599
+        # image-gen settings) shares this key; a dict here is config,
+        # not an image ref (live CT105 'invalid reference format', Phase D).
         override = slot_cfg.get("image") or slot_cfg.get("slot", {}).get("image")
-        if override:
-            return str(override)
+        if isinstance(override, str) and override:
+            return override
 
         backend = (
             slot_cfg.get("backend")

--- a/tests/providers/test_comfyui_container_spec.py
+++ b/tests/providers/test_comfyui_container_spec.py
@@ -147,3 +147,31 @@ def test_spec_provider_for_dispatches_comfyui() -> None:
     assert isinstance(_spec_provider_for({"provider": "comfyui", "type": "image"}), ComfyUIProvider)
     assert isinstance(_spec_provider_for({"profile": "comfyui"}), ComfyUIProvider)
     assert isinstance(_spec_provider_for({"type": "image"}), ComfyUIProvider)
+
+
+def test_image_section_dict_is_not_an_image_override(monkeypatch) -> None:
+    """The [image] TOML section (#599 settings) arrives in raw slot dicts under
+    the same key as the per-slot image-ref OVERRIDE string. A dict must never
+    be treated as an image ref (live CT105 regression: ExecStart rendered
+    str(dict) -> podman 'invalid reference format', hal0-slot@img exit 125)."""
+    from hal0.providers.comfyui import ComfyUIProvider
+
+    cfg = {
+        "name": "img",
+        "port": 8188,
+        "profile": "comfyui",
+        "provider": "comfyui",
+        "image": {"idle_restore_minutes": 5, "default_size": "1024x1024"},
+    }
+    ref = ComfyUIProvider().image_ref(cfg)
+    assert isinstance(ref, str)
+    assert "idle_restore_minutes" not in ref
+    assert "kyuz0/amd-strix-halo-comfyui" in ref  # manifest pin or fallback tag
+
+
+def test_llama_image_section_dict_not_override() -> None:
+    from hal0.providers.llama_server import LlamaServerProvider
+
+    cfg = {"name": "x", "port": 8081, "profile": "vulkan-std", "image": {"idle_restore_minutes": 0}}
+    ref = LlamaServerProvider().image_ref(cfg)
+    assert isinstance(ref, str) and "idle_restore_minutes" not in ref


### PR DESCRIPTION
Phase D deploy follow-up (live CT105 regression). The img slot's `[image]` settings section (#599) arrives in RAW slot dicts under the same `image` key both `image_ref()` sites treat as the per-slot image-ref override — `str(dict)` got rendered into ExecStart and podman failed with `invalid reference format` (hal0-slot@img exit 125). D1's review caught this collision at the SlotConfig layer; the raw-dict layer slipped all gates.

Both `ComfyUIProvider.image_ref` and `llama_server.image_ref` now require a string override; dict falls through to env/manifest/default. Two regression tests pin the live failure shape.

Observed during the failed switch (separate follow-up, filed next): `ensure_img` declared success because container `load()` returns at systemd-start, so the crash never triggered the D5 rollback — the idle-restore loop rescued the box after 5 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)