### PR TITLE
fix(providers): drop --shm-size from ComfyUI spec — podman rejects it with --ipc=host

### DIFF
--- a/src/hal0/providers/comfyui.py
+++ b/src/hal0/providers/comfyui.py
@@ -226,8 +226,11 @@ class ComfyUIProvider(Provider):
           * mounts: ``<data_root>/models → /root/comfy-models`` plus
             output/input/user/custom_nodes into /opt/ComfyUI, and
             extra_model_paths.yaml read-only into the app dir.
-          * ``--ipc=host --shm-size=8g`` — Wan/Hunyuan video models need
-            shared memory.
+          * ``--ipc=host`` — Wan/Hunyuan video models need shared memory;
+            host IPC means the container uses the host's /dev/shm directly.
+            No ``--shm-size``: podman exits 125 on that combo ("cannot set
+            shmsize when running in the host IPC Namespace"), unlike docker,
+            which silently ignored it (live CT105, Phase D).
           * host networking — the LXC is the host; the ComfyUI web UI must
             stay LAN-reachable on :8188 (pre-migration behavior).
           * devices from :func:`resolve_gpu_device_paths` — explicit nodes,
@@ -272,7 +275,7 @@ class ComfyUIProvider(Provider):
             group_add=group_add,
             port=port,
             network_mode="host",
-            extra_args=["--ipc=host", "--shm-size=8g"],
+            extra_args=["--ipc=host"],
         )
 
     # ── Health ─────────────────────────────────────────────────────────────────

--- a/tests/providers/test_comfyui_container_spec.py
+++ b/tests/providers/test_comfyui_container_spec.py
@@ -3,7 +3,8 @@
 Phase D task D2. The spec must replicate what `docker inspect comfyui`
 showed working on CT105: kyuz0 image (ComfyUI at /opt/ComfyUI, venv at
 /opt/venv), bash -lc cd+exec argv, /mnt/ai-models/comfyui data mounts,
---ipc=host + --shm-size=8g (Wan/Hunyuan video need shm), host networking,
+--ipc=host (host /dev/shm serves Wan/Hunyuan video; podman rejects
+--shm-size with host IPC, unlike docker), host networking,
 and label=disable alongside the usual LXC security opts.
 """
 
@@ -59,7 +60,11 @@ def test_comfyui_spec_matches_live_deployment() -> None:
         assert (f"/mnt/ai-models/comfyui/{sub}", f"/opt/ComfyUI/{sub}") in spec.mounts
     assert any("extra_model_paths.yaml" in src for src, _ in spec.mounts)
     # Wan/Hunyuan video models need shared memory.
-    assert "--ipc=host" in spec.extra_args and "--shm-size=8g" in spec.extra_args
+    assert "--ipc=host" in spec.extra_args
+    # podman 125s on --shm-size with --ipc=host ("cannot set shmsize when
+    # running in the host IPC Namespace") — docker ignored the combo. Host
+    # /dev/shm (63G on CT105) serves the video models directly.
+    assert not any(a.startswith("--shm-size") for a in spec.extra_args)
     assert set(spec.security_opt) == {
         "seccomp=unconfined",
         "apparmor=unconfined",
@@ -131,7 +136,7 @@ def test_renderer_host_network_skips_publish_and_keeps_shm() -> None:
     assert "--network=host" in exec_line
     assert "--publish" not in exec_line, "host networking must not publish ports"
     assert "--ipc=host" in exec_line
-    assert "--shm-size=8g" in exec_line
+    assert "--shm-size" not in exec_line
     assert "--security-opt=label=disable" in exec_line
     assert "--device=/dev/kfd" in exec_line
     assert (


### PR DESCRIPTION
Second Phase D deploy follow-up. `podman run --ipc=host --shm-size=8g` exits 125 (docker silently ignored the redundant flag — the live docker container carried both). With host IPC the container uses the host's /dev/shm directly (63G on CT105), which is what Wan/Hunyuan need. Spec + renderer tests updated to pin the absence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)