### PR TITLE
refactor: PhaseContext/PhaseIO — explicit deps for the Hermes bootstrap (#702)

### DIFF
--- a/docs/agents/hermes-bootstrap.md
+++ b/docs/agents/hermes-bootstrap.md
@@ -1,6 +1,6 @@
 ---
 title: Hermes-Agent bootstrap
-description: The 12-phase, checkpointed, idempotent state machine that turns a freshly-installed Hermes-Agent into a hal0-native homelab admin.
+description: The 15-phase, checkpointed, idempotent state machine that turns a freshly-installed Hermes-Agent into a hal0-native homelab admin.
 sidebar:
   order: 2
 ---
@@ -15,31 +15,65 @@ Full design doc: [`docs/internal/hermes-bootstrap-plan-2026-05-23.md`](../intern
 
 ## What it does, in one paragraph
 
-A 12-phase pipeline runs in deterministic order. Each phase is a pure
-function `(BootstrapState) -> PhaseResult` and either `ok`, `skip`, or
-`fail`. State persists to `provision.json` after every phase, so a
-crash or `^C` re-runs from the first non-`ok` phase. No phase is
-allowed to depend on bootstrap-time output for its inputs — every
-config line can be re-derived from live hal0 state at any time.
+A 15-phase pipeline runs in deterministic order. Each phase is a
+function `(PhaseContext) -> PhaseResult` (#702) and either `ok`,
+`skip`, or `fail`. The context carries a read-only `BootstrapState`
+view, the `--repair` flag, a `PhaseIO` bundle of injectable IO seams
+(HTTP, subprocess, slot/MCP/memory fetchers), and `output_of(name)` —
+the only sanctioned way to read another phase's checkpoint, gated by
+the needs each `Phase` declares in the `PHASES` list. State persists
+to `provision.json` after every phase, so a crash or `^C` re-runs from
+the first non-`ok` phase. A failing phase never halts the run or skips
+dependents (run-all policy); `completed_at` is only stamped when no
+phase failed.
 
-Source: `src/hal0/agents/hermes_provision.py:1984` (the `PHASES` list).
+Source: `src/hal0/agents/hermes_provision.py` (the `PHASES` list).
 
-## The 12 phases
+## The 15 phases
 
-| # | Phase                | What it does | Source |
-|---|----------------------|--------------|--------|
-| 1 | `preflight`          | Python ≥ 3.11, free disk ≥ 4 GiB, hal0 API health, upstream `hermes` on PATH (unless `--offline`). | `hermes_provision.py:225` |
-| 2 | `install`            | Create hal0-managed venv at `/var/lib/hal0/venvs/hermes/`, install pinned `hermes-agent` wheel, copy hal0 plugin tree (`Hal0Profile`, `Hal0MemoryProvider`) into `$HERMES_HOME/plugins/`. | `:350` |
-| 3 | `env_probe`          | Snapshot hardware (iGPU, NPU, UMA size), container (LXC + apparmor), tooling — feeds downstream phases. | `:524` |
-| 4 | `home_init`          | Claim `HERMES_HOME=/var/lib/hal0/.hermes/` with a marker file; idempotent re-runs validate the claim. | `:465` |
-| 5 | `config_write`       | Render `config.yaml` from the env probe + the live `/api/capabilities` snapshot; apply operator overrides from `/etc/hal0/agents/hermes/overrides.yaml`. | `:678` |
-| 6 | `mcp_wire`           | Register `hal0-admin` + `hal0-memory` MCPs in Hermes's `mcp_servers` map; round-trip each one via JSON-RPC `tools/list`. Reads the per-agent allow-list at `/etc/hal0/agents/hermes.toml` (ADR-0013). | `:874` |
-| 7 | `context_link`       | Symlink `/etc/hal0/HERMES.md` + `/etc/hal0/agent-skills/` into HERMES_HOME so Hermes injects them on every session start. | `:1031` |
-| 8 | `namespace_register` | Write the immutable identity card into the `agents` Cognee dataset per [ADR-0011](../../internal/adr/0011-agent-identity-cards.md). Idempotent — re-bootstrap rewrites in-place. | `:1294` |
-| 9 | `model_automap`      | Walk active slots, turn each into a `model_aliases` entry, point Hermes at the right backend URL per slot capability (primary / agent / embed / rerank / stt / tts). | `:1466` |
-| 10 | `voice_wire`        | Wire STT / TTS slots into Hermes's voice subsystem if installed; skip otherwise. | `:1609` |
-| 11 | `smoke_tests`       | Sanity round-trips: chat one token through `primary`, `memory_search` against `private:hermes-agent`, MCP `tools/list` against `hal0-admin`. | `:1896` |
-| 12 | `self_report`       | Dump a summary to `provision-logs/self_report.json`; mark `completed_at` in `provision.json`. | `:1929` |
+| # | Phase                | What it does |
+|---|----------------------|--------------|
+| 1 | `preflight`          | Python ≥ 3.11, free disk ≥ 4 GiB, hal0 API health, upstream `hermes` on PATH (unless `--offline`). |
+| 2 | `install`            | Create hal0-managed venv at `/var/lib/hal0/venvs/hermes/`, install pinned `hermes-agent` wheel, copy the hal0 plugin tree (`Hal0MemoryProvider`) into `$HERMES_HOME/plugins/`, install the `hermes` wrapper + `hal0-hermes` back-compat symlink. |
+| 3 | `env_probe`          | Snapshot hardware (iGPU, NPU, UMA size), container (LXC + apparmor), tooling — feeds downstream phases. |
+| 4 | `home_init`          | Claim `HERMES_HOME=/var/lib/hal0/.hermes/` with a marker file; idempotent re-runs validate the claim. |
+| 5 | `install_artifacts`  | (#432) Write the manager seed at `/etc/hal0/agents/hermes.toml`, the driver env file at `/etc/hal0/agents/hermes.env`, and the `runtime.json` embed token under `$HERMES_HOME` — the three artifacts the agent manager + chat proxy key off. The embed token only rotates under `--repair`. |
+| 6 | `persona_seed`       | (PR-3) Seed the default `hermes` + `coder` personas and the `active.txt` pointer under `$HERMES_HOME/personas/`. Operator edits survive re-runs; `--repair` resets to the canonical seeds. |
+| 7 | `config_write`       | Render `config.yaml` (primary model, chat-slot aliases, persona prelude, MCP block, delegation/auxiliary role-slot blocks); apply operator overrides from `/etc/hal0/agents/hermes/overrides.yaml`. |
+| 8 | `mcp_wire`           | Probe `hal0-admin` + `hal0-memory` MCPs via JSON-RPC `tools/list`; record the validated `rendered_servers` list in its checkpoint. Reads the per-agent allow-list at `/etc/hal0/agents/hermes.toml` (ADR-0013). |
+| 9 | `context_link`       | Render SOUL.md / AGENTS.md / MCP-CLIENTS.md + the live STATE.md/HERMES.md; mirror bundled skills into `/etc/hal0/agent-skills/`. |
+| 10 | `namespace_register` | Write the identity card into the `agents` dataset per [ADR-0011](../../internal/adr/0011-agent-identity-cards.md). Idempotent — re-bootstrap rewrites in-place. |
+| 11 | `model_automap`      | Re-render `config.yaml` from live slots so `model_aliases` (and the rest) converge post-`mcp_wire`; hash-equal output skips the write. |
+| 12 | `voice_wire`        | Wire STT / TTS slots into Hermes's voice subsystem when ready; skip otherwise. |
+| 13 | `gateway_secrets_wire` | (#437) Write the SYSTEM-scope systemd drop-in wiring the gateway's secrets vault; `daemon-reload` only when the file changed. Skips when not root. |
+| 14 | `smoke_tests`       | Six diagnostic round-trips: wrapper `--hal0-ready`, `hermes doctor`, chat completion, memory round-trip, admin `tools/list`, HERMES.md content. Non-fatal. |
+| 15 | `self_report`       | Write the bootstrap-completion summary memory item (includes the smoke rollup); `completed_at` lands in `provision.json` when nothing failed. |
+
+## The needs graph (#702)
+
+Phases are independent except for four declared cross-phase reads,
+enforced at runtime by `PhaseContext.output_of()` (an undeclared read
+raises `PhaseNeedError`) and validated against the list order at
+import time:
+
+```text
+config_write  ──needs_previous──▶ mcp_wire     (cross-RUN: mcp_wire runs
+                                                after config_write; the
+                                                probed server list feeds
+                                                the NEXT run's render —
+                                                the first render falls
+                                                back to the builtin
+                                                inventory)
+model_automap ──needs───────────▶ mcp_wire     (same-run checkpoint)
+voice_wire    ──needs───────────▶ mcp_wire     (same-run checkpoint)
+self_report   ──needs───────────▶ smoke_tests  (same-run checkpoint)
+```
+
+When a phase substitutes a fallback (the default MCP inventory, the
+placeholder primary, the inline SOUL.md default, or any memory-layer
+warn-as-OK degradation in `namespace_register`), it records the site
+in `PhaseResult.details["fallbacks"]` — same behaviour as before, now
+visible in `provision.json`.
 
 ## The plugin model
 

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -649,10 +649,14 @@ def _resolve_primary_slot(
     fall-through to a placeholder URL on port 8000 — a daemon-less
     address that never wired Hermes to anything real.
     """
+    # ``placeholder`` marks the safe-but-unwired fallback so consumers can
+    # record it in details["fallbacks"] (#702 fallback observability)
+    # instead of inferring it from the model name.
     fallback = {
         "model": "primary",
         "base_url": _DEFAULT_PRIMARY_BACKEND_URL,
         "context_length": 32768,
+        "placeholder": True,
     }
     fetch = slots_fetcher or _fetch_slots
     slots = fetch() or []
@@ -685,7 +689,7 @@ def _resolve_primary_slot(
         ctx = int(ctx)
     except (TypeError, ValueError):
         ctx = fallback["context_length"]
-    return {"model": model, "base_url": base_url, "context_length": ctx}
+    return {"model": model, "base_url": base_url, "context_length": ctx, "placeholder": False}
 
 
 def _default_mcp_servers() -> list[dict[str, Any]]:
@@ -944,6 +948,26 @@ def _phase_config_write(ctx: PhaseContext) -> PhaseResult:
     # so this read can only ever see a persisted prior-run checkpoint.
     cached_servers = ctx.output_of("mcp_wire").get("rendered_servers")
     mcp_servers = cached_servers if isinstance(cached_servers, list) and cached_servers else None
+    # #702: silent fallbacks become observable. Same behaviour as before;
+    # the fallback sites are now recorded in details["fallbacks"].
+    fallbacks: list[dict[str, str]] = []
+    if primary_raw.get("placeholder"):
+        fallbacks.append(
+            {
+                "site": "primary_slot",
+                "detail": "no ready llm slot — rendered the safe-but-unwired placeholder primary",
+            }
+        )
+    if mcp_servers is None:
+        fallbacks.append(
+            {
+                "site": "mcp_servers",
+                "detail": (
+                    "no probed rendered_servers checkpoint from mcp_wire — "
+                    "rendered the default builtin MCP inventory"
+                ),
+            }
+        )
     system_prompt, personality_name = _active_persona_render(state, mcp_servers=mcp_servers)
     live_resolve_enabled = os.environ.get("HAL0_HERMES_LIVE_RESOLVE", "0") == "1"
     rendered = _render_config_yaml(
@@ -971,6 +995,7 @@ def _phase_config_write(ctx: PhaseContext) -> PhaseResult:
                 "chat_slot_count": len(chat_slots),
                 "persona": personality_name or None,
                 "mcp_server_count": len(mcp_servers) if mcp_servers else 0,
+                "fallbacks": fallbacks,
             },
         )
 
@@ -989,6 +1014,7 @@ def _phase_config_write(ctx: PhaseContext) -> PhaseResult:
             "mcp_server_count": len(mcp_servers) if mcp_servers else 0,
             "delegation_model": (delegation or {}).get("model"),
             "auxiliary_utility_model": _utility_aux_model(auxiliary_tasks),
+            "fallbacks": fallbacks,
         },
     )
 
@@ -1444,6 +1470,7 @@ def _phase_context_link(ctx: PhaseContext) -> PhaseResult:
 
     rendered: dict[str, str] = {}
     warnings: list[str] = []
+    fallbacks: list[dict[str, str]] = []
     fallback_soul = (
         "# Identity\n\n"
         "You are the hal0 admin agent — the right-hand assistant for this "
@@ -1454,6 +1481,13 @@ def _phase_context_link(ctx: PhaseContext) -> PhaseResult:
         rendered["SOUL.md"] = _render_template("SOUL.md.j2", **vars_)
     except Exception as exc:
         warnings.append(f"SOUL.md render: {exc}; falling back to default")
+        # #702: the inline-default fallback is observable, not silent.
+        fallbacks.append(
+            {
+                "site": "soul_md",
+                "detail": f"SOUL.md.j2 render failed ({exc}) — wrote the inline default SOUL.md",
+            }
+        )
         rendered["SOUL.md"] = fallback_soul
 
     for tpl_name, _out_name in (
@@ -1465,7 +1499,12 @@ def _phase_context_link(ctx: PhaseContext) -> PhaseResult:
         except Exception as exc:
             warnings.append(f"{tpl_name} render: {exc}; skipping")
 
-    details: dict[str, Any] = {"warnings": warnings, "rendered": {}, "links": []}
+    details: dict[str, Any] = {
+        "warnings": warnings,
+        "rendered": {},
+        "links": [],
+        "fallbacks": fallbacks,
+    }
 
     soul_path = hermes_home / "SOUL.md"
     h = _atomic_write(soul_path, rendered["SOUL.md"])
@@ -1691,6 +1730,9 @@ def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
     state = ctx.state
     card = _build_identity_card(state)
     warnings: list[str] = []
+    # #702: every memory-layer warn-as-OK degradation is recorded here so
+    # the fallback posture is observable in provision.json, not silent.
+    fallbacks: list[dict[str, str]] = []
 
     # Look up existing card so re-bootstrap doesn't accumulate duplicates.
     search = ctx.io.mcp_memory_call(
@@ -1717,6 +1759,12 @@ def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
                 existing_ids.append(item["id"])
     elif not search["ok"]:
         warnings.append(f"memory_search: {search['error']}")
+        fallbacks.append(
+            {
+                "site": "memory_layer",
+                "detail": f"memory_search failed ({search['error']}) — continuing without dedupe",
+            }
+        )
 
     if existing_ids:
         deleted = ctx.io.mcp_memory_call(
@@ -1731,6 +1779,12 @@ def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
         # the transport status — on any shortfall, skip the rewrite.
         if not deleted["ok"]:
             warnings.append(f"memory_delete: {deleted['error']}")
+            fallbacks.append(
+                {
+                    "site": "memory_layer",
+                    "detail": f"memory_delete failed ({deleted['error']}) — card not rewritten",
+                }
+            )
             return PhaseResult(
                 status=PhaseStatus.OK,
                 details={
@@ -1738,6 +1792,7 @@ def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
                     "refreshed_existing": False,
                     "warnings": warnings,
                     "card": card,
+                    "fallbacks": fallbacks,
                 },
                 reason="memory_delete failed; not rewriting to avoid duplicate accumulation",
             )
@@ -1747,6 +1802,15 @@ def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
                 f"memory_delete: requested {len(existing_ids)}, removed {removed} "
                 "— not rewriting to avoid duplicate accumulation"
             )
+            fallbacks.append(
+                {
+                    "site": "memory_layer",
+                    "detail": (
+                        f"memory_delete removed {removed}/{len(existing_ids)} — "
+                        "card not rewritten to avoid duplicate accumulation"
+                    ),
+                }
+            )
             return PhaseResult(
                 status=PhaseStatus.OK,
                 details={
@@ -1754,6 +1818,7 @@ def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
                     "refreshed_existing": False,
                     "warnings": warnings,
                     "card": card,
+                    "fallbacks": fallbacks,
                 },
                 reason="memory_delete count mismatch; not rewriting to avoid duplicate accumulation",
             )
@@ -1766,9 +1831,20 @@ def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
     if not add["ok"]:
         # Bootstrap continues — the card is nice-to-have, not a blocker.
         warnings.append(f"memory_add: {add['error']}")
+        fallbacks.append(
+            {
+                "site": "memory_layer",
+                "detail": f"memory_add failed ({add['error']}) — identity card not registered",
+            }
+        )
         return PhaseResult(
             status=PhaseStatus.OK,
-            details={"registered": False, "warnings": warnings, "card": card},
+            details={
+                "registered": False,
+                "warnings": warnings,
+                "card": card,
+                "fallbacks": fallbacks,
+            },
             reason="hal0-memory unreachable; identity card not registered (continuing)",
         )
 
@@ -1783,6 +1859,7 @@ def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
             "card": card,
             "warnings": warnings,
             "refreshed_existing": bool(existing_ids),
+            "fallbacks": fallbacks,
         },
     )
 

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -3219,6 +3219,135 @@ def _phase_install_artifacts(state: BootstrapState) -> PhaseResult:
     )
 
 
+# ── Phase pipeline plumbing (issue #702) ────────────────────────────────────
+#
+# The pipeline's IO seams + cross-phase reads, made explicit:
+#
+#   * ``PhaseIO`` bundles every external touchpoint a phase may use
+#     (HTTP, subprocess, the slot/MCP/memory fetchers). Defaults are the
+#     real module functions, so ``PhaseIO()`` IS production behaviour;
+#     tests construct ``PhaseIO(fetch_slots=fake, ...)`` instead of
+#     monkeypatching module globals.
+#   * ``PhaseContext`` is what a phase receives: read-only state, the
+#     ``--repair`` flag (formerly the ``_repair_flag`` sentinel smuggled
+#     through ``state.phases``), the IO bundle, and ``output_of(name)``
+#     — the ONLY sanctioned way to read another phase's checkpoint.
+#   * ``Phase`` entries in ``PHASES`` declare their cross-phase reads via
+#     ``needs`` (same-run: target precedes reader) or ``needs_previous``
+#     (previous-run checkpoint: target follows reader in the list, so the
+#     value can only come from a persisted prior run). ``output_of``
+#     raises ``PhaseNeedError`` for any undeclared read;
+#     ``_validate_phase_graph`` rejects a mis-ordered PHASES list at
+#     import time.
+#
+# Path constants intentionally stay module-level (tests redirect them
+# with monkeypatch) — only behavioural IO lives in PhaseIO.
+
+
+class PhaseNeedError(RuntimeError):
+    """A phase read another phase's output without declaring the need."""
+
+
+@dataclass(frozen=True)
+class PhaseIO:
+    """The IO seams a phase may touch — the monkeypatch tax, typed.
+
+    Defaults bind the real implementations, so a default-constructed
+    ``PhaseIO`` changes nothing in production. ``run`` is
+    :func:`subprocess.run` (gateway_secrets_wire's daemon-reload + the
+    smoke-test exec path).
+    """
+
+    http_get: Callable[..., int] = _http_get
+    fetch_slots: Callable[[], list[dict[str, Any]]] = _fetch_slots
+    fetch_model_contexts: Callable[[], dict[str, int]] = _fetch_model_contexts
+    probe_mcp_server: Callable[..., dict[str, Any]] = _probe_mcp_server
+    mcp_memory_call: Callable[..., dict[str, Any]] = _mcp_memory_call
+    install_venv: Callable[..., None] = _install_venv
+    read_env_probe: Callable[[], dict[str, Any]] = _read_env_probe
+    run: Callable[..., Any] = subprocess.run
+
+
+@dataclass(frozen=True)
+class PhaseContext:
+    """Everything a phase body is allowed to see.
+
+    ``state`` is a read-only view by convention (phases return a
+    :class:`PhaseResult`; only the orchestrator writes checkpoints).
+    ``output_of(name)`` returns the named phase's checkpoint ``details``
+    dict — empty when the phase has no checkpoint yet (e.g. the
+    cross-run ``config_write → mcp_wire`` read on a fresh install) —
+    and raises :class:`PhaseNeedError` unless ``name`` was declared in
+    the calling phase's ``needs`` / ``needs_previous``.
+    """
+
+    state: BootstrapState
+    repair: bool = False
+    io: PhaseIO = field(default_factory=PhaseIO)
+    phase_name: str = "<anonymous>"
+    allowed_needs: frozenset[str] = frozenset()
+
+    def output_of(self, name: str) -> dict[str, Any]:
+        if name not in self.allowed_needs:
+            raise PhaseNeedError(
+                f"phase {self.phase_name!r} read output of {name!r} without "
+                f"declaring it (declared needs: {sorted(self.allowed_needs)})"
+            )
+        entry = self.state.phases.get(name) or {}
+        details = entry.get("details") or {}
+        return details if isinstance(details, dict) else {}
+
+
+@dataclass(frozen=True)
+class Phase:
+    """One PHASES entry: name, body, and declared cross-phase reads.
+
+    ``needs``          — same-run reads; the target MUST precede this
+                         phase in the list (validated at import).
+    ``needs_previous`` — previous-run checkpoint reads; the target MUST
+                         follow this phase in the list (if it preceded,
+                         it would be a plain same-run need). The only
+                         such edge today is ``config_write → mcp_wire``:
+                         mcp_wire probes AFTER the first render and the
+                         probed server list feeds the NEXT run's render.
+    """
+
+    name: str
+    fn: Callable[[PhaseContext], PhaseResult]
+    needs: tuple[str, ...] = ()
+    needs_previous: tuple[str, ...] = ()
+
+    @property
+    def allowed_needs(self) -> frozenset[str]:
+        return frozenset(self.needs) | frozenset(self.needs_previous)
+
+
+def _validate_phase_graph(phases: list[Phase]) -> None:
+    """Fail fast (import time) when PHASES violates a declared need."""
+    index: dict[str, int] = {}
+    for i, phase in enumerate(phases):
+        if phase.name in index:
+            raise ValueError(f"PHASES: duplicate phase name {phase.name!r}")
+        index[phase.name] = i
+    for i, phase in enumerate(phases):
+        for need in phase.needs:
+            if need not in index:
+                raise ValueError(f"PHASES: {phase.name!r} needs unknown phase {need!r}")
+            if index[need] >= i:
+                raise ValueError(
+                    f"PHASES: {phase.name!r} needs {need!r} which does not precede it "
+                    f"(reader at {i}, target at {index[need]})"
+                )
+        for need in phase.needs_previous:
+            if need not in index:
+                raise ValueError(f"PHASES: {phase.name!r} needs_previous unknown phase {need!r}")
+            if index[need] < i:
+                raise ValueError(
+                    f"PHASES: {phase.name!r} declares needs_previous on {need!r}, "
+                    f"but {need!r} precedes it — declare it as a plain same-run need"
+                )
+
+
 PHASES: list[tuple[str, Callable[[BootstrapState], PhaseResult]]] = [
     ("preflight", _phase_preflight),
     ("install", _phase_install),

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1,8 +1,12 @@
 """Hermes-Agent bootstrap state machine (issue #238 scaffold).
 
-Twelve named phases run in a strict deterministic sequence. Each phase
-writes a checkpoint into ``provision.json``. On re-run the orchestrator
-loads the checkpoint and skips any phase already marked ``ok`` unless
+Fifteen named phases run in a strict deterministic sequence. Each phase
+is a function ``(PhaseContext) -> PhaseResult`` (#702): the context
+carries a read-only :class:`BootstrapState` view, the ``--repair`` flag,
+a :class:`PhaseIO` bundle of injectable IO seams, and ``output_of()``
+for declared cross-phase checkpoint reads. Each phase writes a
+checkpoint into ``provision.json``. On re-run the orchestrator loads
+the checkpoint and skips any phase already marked ``ok`` unless
 ``--repair`` forces re-execution.
 
 This module is the scaffold — every phase is a no-op stub that returns
@@ -171,7 +175,7 @@ class BootstrapState:
 
 # ── Phase implementations (no-op stubs in #238 scaffold) ─────────────────────
 #
-# Each phase signature: (state: BootstrapState) -> PhaseResult.
+# Each phase signature: (ctx: PhaseContext) -> PhaseResult (#702).
 #
 # Real impls land in subsequent slices:
 #   #240 — preflight, install, home_init
@@ -187,8 +191,8 @@ class BootstrapState:
 # valid.
 
 
-def _stub(name: str) -> Callable[[BootstrapState], PhaseResult]:
-    def _phase(state: BootstrapState) -> PhaseResult:
+def _stub(name: str) -> Callable[[PhaseContext], PhaseResult]:
+    def _phase(ctx: PhaseContext) -> PhaseResult:
         return PhaseResult(status=PhaseStatus.OK, details={"stub": True})
 
     _phase.__name__ = f"_phase_{name}"
@@ -258,7 +262,7 @@ def _http_get(url: str, *, timeout: float = 3.0) -> int:
         return 0
 
 
-def _phase_preflight(state: BootstrapState) -> PhaseResult:
+def _phase_preflight(ctx: PhaseContext) -> PhaseResult:
     """Hard-fail when the host can't host Hermes.
 
     Documented blockers (plan §4):
@@ -273,6 +277,7 @@ def _phase_preflight(state: BootstrapState) -> PhaseResult:
     * ≥ 4 GiB free under ``/var/lib/hal0/`` — Hermes deps + a typical
       memory cache run ~3 GiB; 4 GiB leaves headroom for venv rebuild.
     """
+    state = ctx.state
     failures: list[str] = []
     details: dict[str, Any] = {}
 
@@ -284,7 +289,7 @@ def _phase_preflight(state: BootstrapState) -> PhaseResult:
             f"have {details['python_version']} — run `apt install python3.11`",
         )
 
-    rc = _http_get(DAEMON_HEALTH_URL)
+    rc = ctx.io.http_get(DAEMON_HEALTH_URL)
     details["daemon_http_status"] = rc
     if rc != 200:
         failures.append(
@@ -400,7 +405,7 @@ def _copy_plugin_tree(src: Path, dst: Path) -> None:
     shutil.copytree(src, dst)
 
 
-def _phase_install(state: BootstrapState) -> PhaseResult:
+def _phase_install(ctx: PhaseContext) -> PhaseResult:
     """Provision the managed Hermes venv + wrapper + plugin stubs.
 
     The plugin stub at ``installer/agents/hermes/plugins/hal0-memory/``
@@ -414,6 +419,7 @@ def _phase_install(state: BootstrapState) -> PhaseResult:
     expected version — re-runs of ``hal0 agent bootstrap hermes`` are
     cheap unless ``--repair`` forces re-install.
     """
+    state = ctx.state
     details: dict[str, Any] = {}
     venv = Path(state.venv)
     requirements = REPO_ROOT_FOR_INSTALLER / "installer" / "agents" / "hermes" / "requirements.txt"
@@ -436,7 +442,7 @@ def _phase_install(state: BootstrapState) -> PhaseResult:
     hermes_bin = _venv_python(venv).parent / "hermes"
     if not hermes_bin.exists():
         try:
-            _install_venv(venv, requirements)
+            ctx.io.install_venv(venv, requirements)
         except (subprocess.SubprocessError, RuntimeError, OSError) as exc:
             return PhaseResult(
                 status=PhaseStatus.FAIL,
@@ -536,7 +542,7 @@ def _claim_hermes_home(hermes_home: Path) -> tuple[bool, str | None]:
     return (True, None)
 
 
-def _phase_home_init(state: BootstrapState) -> PhaseResult:
+def _phase_home_init(ctx: PhaseContext) -> PhaseResult:
     """Make the ``$HERMES_HOME`` layout canonical.
 
     Install (#240's first phase) already claimed the marker; home_init
@@ -545,7 +551,7 @@ def _phase_home_init(state: BootstrapState) -> PhaseResult:
     already did so, and necessary when home_init runs first
     (``--skip-phase install``).
     """
-    hermes_home = Path(state.hermes_home)
+    hermes_home = Path(ctx.state.hermes_home)
     claimed, reason = _claim_hermes_home(hermes_home)
     if not claimed:
         return PhaseResult(status=PhaseStatus.FAIL, reason=reason)
@@ -595,16 +601,16 @@ def _read_env_probe() -> dict[str, Any]:
     }
 
 
-def _phase_env_probe(state: BootstrapState) -> PhaseResult:
+def _phase_env_probe(ctx: PhaseContext) -> PhaseResult:
     """Capture a host-environment snapshot for downstream phases.
 
     Writes the snapshot to ``$HERMES_HOME/env-<ts>.json`` AND keeps a
     pointer in ``provision.json``. Snapshot is overwritten on every
     re-run because it's a point-in-time view, not a checkpoint.
     """
-    snapshot = _read_env_probe()
+    snapshot = ctx.io.read_env_probe()
     ts = _utcnow().replace(":", "").replace("-", "")
-    hermes_home = Path(state.hermes_home)
+    hermes_home = Path(ctx.state.hermes_home)
     hermes_home.mkdir(parents=True, exist_ok=True)
     snapshot_path = hermes_home / f"env-{ts}.json"
     snapshot_path.write_text(json.dumps(snapshot, indent=2, sort_keys=True), encoding="utf-8")
@@ -891,7 +897,7 @@ def _active_persona_render(
     return (prompt, persona.display_name)
 
 
-def _phase_config_write(state: BootstrapState) -> PhaseResult:
+def _phase_config_write(ctx: PhaseContext) -> PhaseResult:
     """Atomically render ``$HERMES_HOME/config.yaml`` from the template.
 
     PR-3 overhaul: passes chat_slots + persona-rendered system_prompt +
@@ -903,9 +909,10 @@ def _phase_config_write(state: BootstrapState) -> PhaseResult:
     Idempotent: hash-equal output skips the write. Overrides at
     ``/etc/hal0/agents/hermes/overrides.yaml`` deep-merge on top.
     """
+    state = ctx.state
     hermes_home = Path(state.hermes_home)
     config_path = hermes_home / "config.yaml"
-    primary_raw = _resolve_primary_slot()
+    primary_raw = _resolve_primary_slot(slots_fetcher=ctx.io.fetch_slots)
     # The template names the dict keys ``model_id``/``backend_url``;
     # _resolve_primary_slot returns ``model``/``base_url`` for less
     # cognitive load at call sites. Translate at the seam.
@@ -917,8 +924,8 @@ def _phase_config_write(state: BootstrapState) -> PhaseResult:
     # PR-3 Phase 5: pull chat_slots into the first render so the
     # ``model_aliases:`` block lands on the first config_write pass
     # (Phase 9 used to be the only place this worked).
-    slots_all = _fetch_slots()
-    chat_slots = _collect_chat_slots(slots_all, contexts=_fetch_model_contexts())
+    slots_all = ctx.io.fetch_slots()
+    chat_slots = _collect_chat_slots(slots_all, contexts=ctx.io.fetch_model_contexts())
     # feat/hermes-role-slots: resolve per-role models from live slot NAMES.
     # delegation ← `agent-hermes` slot; auxiliary ← `utility` slot. Both
     # talk to hal0's /v1 endpoint (same base_url as the main model), so a
@@ -933,7 +940,9 @@ def _phase_config_write(state: BootstrapState) -> PhaseResult:
     # config_write (before mcp_wire runs the live probe) we fall back to
     # the default inventory; mcp_wire then captures the probed shape and
     # config gets re-rendered idempotently on Phase 9 / next bootstrap.
-    cached_servers = (state.phases.get("mcp_wire") or {}).get("details", {}).get("rendered_servers")
+    # Declared as ``needs_previous`` — mcp_wire runs AFTER config_write,
+    # so this read can only ever see a persisted prior-run checkpoint.
+    cached_servers = ctx.output_of("mcp_wire").get("rendered_servers")
     mcp_servers = cached_servers if isinstance(cached_servers, list) and cached_servers else None
     system_prompt, personality_name = _active_persona_render(state, mcp_servers=mcp_servers)
     live_resolve_enabled = os.environ.get("HAL0_HERMES_LIVE_RESOLVE", "0") == "1"
@@ -1151,7 +1160,7 @@ def _probe_mcp_server(
     return {"ok": True, "tools": tools, "error": None}
 
 
-def _phase_mcp_wire(state: BootstrapState) -> PhaseResult:
+def _phase_mcp_wire(ctx: PhaseContext) -> PhaseResult:
     """Verify the two hal0-bundled MCP servers respond + record their tool list.
 
     ADR-0013 compliance: when an allow-list exists at
@@ -1161,6 +1170,7 @@ def _phase_mcp_wire(state: BootstrapState) -> PhaseResult:
     warning, NOT a hard fail — bootstrap continues so the operator
     can wire the missing piece by hand after install.
     """
+    state = ctx.state
     allowlist = _load_agent_allowlist()
     # PR-3 Phase 6: source the canonical inventory from
     # ``_default_mcp_servers()`` so the probe loop and the template loop
@@ -1179,7 +1189,9 @@ def _phase_mcp_wire(state: BootstrapState) -> PhaseResult:
             )
             results[name] = {"status": "skipped_by_allowlist"}
             continue
-        probe = _probe_mcp_server(entry["url"], agent_id=state.agent_id, private=entry["private"])
+        probe = ctx.io.probe_mcp_server(
+            entry["url"], agent_id=state.agent_id, private=entry["private"]
+        )
         if not probe["ok"]:
             warnings.append(f"{name}: {probe['error']}")
             results[name] = {"status": "degraded", "error": probe["error"]}
@@ -1226,7 +1238,7 @@ def _phase_mcp_wire(state: BootstrapState) -> PhaseResult:
 # re-seed.
 
 
-def _phase_persona_seed(state: BootstrapState) -> PhaseResult:
+def _phase_persona_seed(ctx: PhaseContext) -> PhaseResult:
     """Seed the default personas + ``active.txt`` pointer.
 
     Phase 8 (PR-3): idempotent persona file write. The next config_write
@@ -1241,10 +1253,11 @@ def _phase_persona_seed(state: BootstrapState) -> PhaseResult:
     """
     from hal0.agents import personas as _personas
 
+    state = ctx.state
     root = _personas_root_for(state)
     # Honor ``--repair`` by forcing seed overwrite. Operator edits stand
     # in the steady-state case; repair explicitly resets to known-good.
-    overwrite = bool(state.phases.get("_repair_flag"))
+    overwrite = ctx.repair
     written = _personas.seed_default_personas(
         agent_id=state.agent_id,
         root=root,
@@ -1368,7 +1381,7 @@ def _mirror_bundled_skills(src_root: Path, dst_root: Path) -> tuple[list[str], l
     return linked, warnings
 
 
-def _phase_context_link(state: BootstrapState) -> PhaseResult:
+def _phase_context_link(ctx: PhaseContext) -> PhaseResult:
     """Render persona + context files; mirror bundled skills.
 
     Files rendered (atomically):
@@ -1382,6 +1395,7 @@ def _phase_context_link(state: BootstrapState) -> PhaseResult:
     fallback is short + accurate). HERMES.md + AGENTS.md render
     failures log + skip per #244 sharpening.
     """
+    state = ctx.state
     hermes_home = Path(state.hermes_home)
     snapshot = _latest_env_snapshot(hermes_home)
     env_report = snapshot.get("env_report", {}) if isinstance(snapshot, dict) else {}
@@ -1394,9 +1408,9 @@ def _phase_context_link(state: BootstrapState) -> PhaseResult:
     slots_all: list[dict[str, Any]] = []
     # _fetch_slots is already failure-tolerant (returns [] on transport
     # error). No try/except needed here — it can't raise.
-    slots_all = _fetch_slots()
-    chat_slots = _collect_chat_slots(slots_all, contexts=_fetch_model_contexts())
-    primary_raw = _resolve_primary_slot()
+    slots_all = ctx.io.fetch_slots()
+    chat_slots = _collect_chat_slots(slots_all, contexts=ctx.io.fetch_model_contexts())
+    primary_raw = _resolve_primary_slot(slots_fetcher=lambda: slots_all)
     primary_for_template: dict[str, Any] | None = None
     primary_alias = "chat"
     primary_slot = next(
@@ -1464,7 +1478,12 @@ def _phase_context_link(state: BootstrapState) -> PhaseResult:
         # NB: render_live_context re-fetches /api/slots + /v1/models itself
         # (separate from the vars_ fetch above). Acceptable at bootstrap
         # frequency; keeps it usable standalone from the restart/swap writers.
-        live = render_live_context(hermes_home=hermes_home)
+        live = render_live_context(
+            hermes_home=hermes_home,
+            slots_fetcher=ctx.io.fetch_slots,
+            contexts_fetcher=ctx.io.fetch_model_contexts,
+            health_probe=ctx.io.http_get,
+        )
         details["rendered"]["STATE.md"] = {"path": live["state_path"]}
         details["rendered"]["HERMES.md"] = {
             "path": str(ETC_HAL0_DIR / "HERMES.md"),
@@ -1658,7 +1677,7 @@ def _mcp_memory_call(
     return {"ok": True, "result": data}
 
 
-def _phase_namespace_register(state: BootstrapState) -> PhaseResult:
+def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
     """Write the Hermes identity card to the `agents` Cognee dataset.
 
     Idempotency: search for an existing card by ``agent_id`` first;
@@ -1669,11 +1688,12 @@ def _phase_namespace_register(state: BootstrapState) -> PhaseResult:
     Failure mode: any MCP transport error logs + returns OK with a
     warning. Bootstrap MUST NOT block on registry unavailability.
     """
+    state = ctx.state
     card = _build_identity_card(state)
     warnings: list[str] = []
 
     # Look up existing card so re-bootstrap doesn't accumulate duplicates.
-    search = _mcp_memory_call(
+    search = ctx.io.mcp_memory_call(
         "tools/call",
         {
             "name": "memory_search",
@@ -1699,7 +1719,7 @@ def _phase_namespace_register(state: BootstrapState) -> PhaseResult:
         warnings.append(f"memory_search: {search['error']}")
 
     if existing_ids:
-        deleted = _mcp_memory_call(
+        deleted = ctx.io.mcp_memory_call(
             "tools/call",
             {"name": "memory_delete", "arguments": {"ids": existing_ids}},
             agent_id=state.agent_id,
@@ -1738,7 +1758,7 @@ def _phase_namespace_register(state: BootstrapState) -> PhaseResult:
                 reason="memory_delete count mismatch; not rewriting to avoid duplicate accumulation",
             )
 
-    add = _mcp_memory_call(
+    add = ctx.io.mcp_memory_call(
         "tools/call",
         {"name": "memory_add", "arguments": card},
         agent_id=state.agent_id,
@@ -1962,6 +1982,8 @@ def render_live_context(
     *,
     hermes_home: Path,
     slots_fetcher: Callable[[], list[dict[str, Any]]] | None = None,
+    contexts_fetcher: Callable[[], dict[str, int]] | None = None,
+    health_probe: Callable[..., int] | None = None,
     now_iso: str | None = None,
 ) -> dict[str, Any]:
     """Re-probe live slot/capability state; (re)write HERMES.md + STATE.md.
@@ -1983,10 +2005,11 @@ def render_live_context(
     # all — in which case we must NOT clobber a last-good snapshot. A
     # non-empty fetch implies the daemon answered, so we only probe health
     # when the slot list came back empty.
-    reachable = True if slots_all else _http_get(DAEMON_HEALTH_URL) == 200
+    probe = health_probe or _http_get
+    reachable = True if slots_all else probe(DAEMON_HEALTH_URL) == 200
     degraded = not reachable
 
-    contexts = _fetch_model_contexts()
+    contexts = (contexts_fetcher or _fetch_model_contexts)()
     chat_slots = _collect_chat_slots(slots_all, contexts=contexts)
     primary_raw = _resolve_primary_slot(slots_fetcher=lambda: slots_all)
 
@@ -2310,7 +2333,7 @@ def _resolve_auxiliary_tasks(
     return tasks
 
 
-def _phase_model_automap(state: BootstrapState) -> PhaseResult:
+def _phase_model_automap(ctx: PhaseContext) -> PhaseResult:
     """Refresh ``model_aliases`` in ``$HERMES_HOME/config.yaml``.
 
     Re-renders the whole config (so model + aliases stay consistent)
@@ -2320,6 +2343,7 @@ def _phase_model_automap(state: BootstrapState) -> PhaseResult:
     Embed/rerank/img slots are deliberately NOT mapped per ADR-0011 §3
     (Hermes has no top-level embed abstraction; memory MCP handles it).
     """
+    state = ctx.state
     hermes_home = Path(state.hermes_home)
     config_path = hermes_home / "config.yaml"
     if not config_path.exists():
@@ -2328,9 +2352,9 @@ def _phase_model_automap(state: BootstrapState) -> PhaseResult:
             reason=f"{config_path} missing — config_write must run first",
         )
 
-    slots = _fetch_slots()
-    chat_slots = _collect_chat_slots(slots, contexts=_fetch_model_contexts())
-    primary_raw = _resolve_primary_slot()
+    slots = ctx.io.fetch_slots()
+    chat_slots = _collect_chat_slots(slots, contexts=ctx.io.fetch_model_contexts())
+    primary_raw = _resolve_primary_slot(slots_fetcher=lambda: slots)
     primary = {
         "model_id": primary_raw["model"],
         "backend_url": primary_raw["base_url"],
@@ -2340,7 +2364,7 @@ def _phase_model_automap(state: BootstrapState) -> PhaseResult:
     # so a no-drift run produces a byte-identical config. Mismatch means
     # something changed (slot churn, persona swap, MCP servers came up)
     # and we want the new config; match → no-op (hash check below).
-    cached_servers = (state.phases.get("mcp_wire") or {}).get("details", {}).get("rendered_servers")
+    cached_servers = ctx.output_of("mcp_wire").get("rendered_servers")
     mcp_servers = cached_servers if isinstance(cached_servers, list) and cached_servers else None
     system_prompt, personality_name = _active_persona_render(state, mcp_servers=mcp_servers)
     # feat/hermes-role-slots: identical role-slot resolution to config_write
@@ -2464,7 +2488,7 @@ def _gateway_dropin_body() -> str:
     )
 
 
-def _phase_gateway_secrets_wire(state: BootstrapState) -> PhaseResult:
+def _phase_gateway_secrets_wire(ctx: PhaseContext) -> PhaseResult:
     """Idempotently write the gateway secrets drop-in + daemon-reload (#437).
 
     Owns ONLY the drop-in ``10-hal0-secrets.conf`` under
@@ -2563,7 +2587,7 @@ def _phase_gateway_secrets_wire(state: BootstrapState) -> PhaseResult:
         )
 
     try:
-        subprocess.run(["systemctl", "daemon-reload"], check=True)  # nosec B603 B607
+        ctx.io.run(["systemctl", "daemon-reload"], check=True)  # nosec B603 B607
     except (subprocess.SubprocessError, OSError) as exc:
         # The drop-in is on disk; the operator can daemon-reload by hand.
         # Surface as a non-fatal warning rather than failing bootstrap —
@@ -2638,14 +2662,15 @@ def _merge_env_file(path: Path, updates: dict[str, str]) -> None:
         path.chmod(0o600)
 
 
-def _phase_voice_wire(state: BootstrapState) -> PhaseResult:
+def _phase_voice_wire(ctx: PhaseContext) -> PhaseResult:
     """Emit STT/TTS provider config + secrets env when both slots are ready.
 
     Skip semantics: when neither STT nor TTS is configured + ready,
     return SKIP with a clear reason — same posture as voice_wire in
     the plan §13.
     """
-    slots = _fetch_slots()
+    state = ctx.state
+    slots = ctx.io.fetch_slots()
     stt = _find_slot(slots, "stt")
     tts = _find_slot(slots, "tts")
     if stt is None and tts is None:
@@ -2683,15 +2708,13 @@ def _phase_voice_wire(state: BootstrapState) -> PhaseResult:
     hermes_home = Path(state.hermes_home)
     config_path = hermes_home / "config.yaml"
     try:
-        primary_raw = _resolve_primary_slot()
+        primary_raw = _resolve_primary_slot(slots_fetcher=lambda: slots)
         primary = {
             "model_id": primary_raw["model"],
             "backend_url": primary_raw["base_url"],
             "context_length": primary_raw["context_length"],
         }
-        cached_servers = (
-            (state.phases.get("mcp_wire") or {}).get("details", {}).get("rendered_servers")
-        )
+        cached_servers = ctx.output_of("mcp_wire").get("rendered_servers")
         mcp_servers = (
             cached_servers if isinstance(cached_servers, list) and cached_servers else None
         )
@@ -2699,7 +2722,7 @@ def _phase_voice_wire(state: BootstrapState) -> PhaseResult:
         # feat/hermes-role-slots: keep role-slot blocks consistent with the
         # other render call sites so re-render stays idempotent.
         hal0_v1_base = primary["backend_url"]
-        chat_slots = _collect_chat_slots(slots, contexts=_fetch_model_contexts())
+        chat_slots = _collect_chat_slots(slots, contexts=ctx.io.fetch_model_contexts())
         delegation = _resolve_delegation(slots, hal0_base_url=hal0_v1_base)
         auxiliary_tasks = _resolve_auxiliary_tasks(slots, hal0_base_url=hal0_v1_base)
         custom_providers = _resolve_custom_providers(chat_slots, hal0_base_url=hal0_v1_base)
@@ -2777,7 +2800,7 @@ def _wrapper_bin() -> Path:
     return WRAPPER_INSTALL_PATH
 
 
-def _smoke_chat_completions(state: BootstrapState) -> tuple[bool, str]:
+def _smoke_chat_completions(state: BootstrapState, _io: PhaseIO) -> tuple[bool, str]:
     """POST against model.base_url/chat/completions; assert 'ready' in reply.
 
     Reads the live config.yaml so we hit whatever model_automap left
@@ -2839,8 +2862,8 @@ def _smoke_chat_completions(state: BootstrapState) -> tuple[bool, str]:
     return ("ready" in haystack, detail)
 
 
-def _smoke_memory_roundtrip(state: BootstrapState) -> tuple[bool, str]:
-    add = _mcp_memory_call(
+def _smoke_memory_roundtrip(state: BootstrapState, io: PhaseIO) -> tuple[bool, str]:
+    add = io.mcp_memory_call(
         "tools/call",
         {
             "name": "memory_add",
@@ -2855,7 +2878,7 @@ def _smoke_memory_roundtrip(state: BootstrapState) -> tuple[bool, str]:
     )
     if not add["ok"]:
         return (False, f"memory_add: {add['error']}")
-    search = _mcp_memory_call(
+    search = io.mcp_memory_call(
         "tools/call",
         {
             "name": "memory_search",
@@ -2877,8 +2900,8 @@ def _smoke_memory_roundtrip(state: BootstrapState) -> tuple[bool, str]:
     return (False, "memory_search returned no items for just-written marker")
 
 
-def _smoke_admin_tools_list(state: BootstrapState) -> tuple[bool, str]:
-    probe = _probe_mcp_server(
+def _smoke_admin_tools_list(state: BootstrapState, io: PhaseIO) -> tuple[bool, str]:
+    probe = io.probe_mcp_server(
         "http://127.0.0.1:8080/mcp/admin",
         agent_id=state.agent_id,
         private=False,
@@ -2889,7 +2912,7 @@ def _smoke_admin_tools_list(state: BootstrapState) -> tuple[bool, str]:
     return (n >= 5, f"{n} tools advertised")
 
 
-def _smoke_hermes_md_contains_primary(state: BootstrapState) -> tuple[bool, str]:
+def _smoke_hermes_md_contains_primary(state: BootstrapState, _io: PhaseIO) -> tuple[bool, str]:
     hermes_md = ETC_HAL0_DIR / "HERMES.md"
     if not hermes_md.exists():
         return (False, f"{hermes_md} not present")
@@ -2912,12 +2935,12 @@ def _smoke_hermes_md_contains_primary(state: BootstrapState) -> tuple[bool, str]
     )
 
 
-def _smoke_wrapper_ready(_state: BootstrapState) -> tuple[bool, str]:
+def _smoke_wrapper_ready(_state: BootstrapState, io: PhaseIO) -> tuple[bool, str]:
     wrapper = _wrapper_bin()
     if not wrapper.exists():
         return (False, f"wrapper missing at {wrapper}")
     try:
-        result = subprocess.run(  # nosec B603 — known-safe argv
+        result = io.run(  # nosec B603 — known-safe argv
             [str(wrapper), "--hal0-ready"],
             check=False,
             capture_output=True,
@@ -2928,12 +2951,12 @@ def _smoke_wrapper_ready(_state: BootstrapState) -> tuple[bool, str]:
     return (result.returncode == 0, f"--hal0-ready rc={result.returncode}")
 
 
-def _smoke_hermes_doctor(_state: BootstrapState) -> tuple[bool, str]:
+def _smoke_hermes_doctor(_state: BootstrapState, io: PhaseIO) -> tuple[bool, str]:
     venv_hermes = _venv_python(Path(_state.venv)).parent / "hermes"
     if not venv_hermes.exists():
         return (False, f"hermes binary missing at {venv_hermes}")
     try:
-        result = subprocess.run(  # nosec B603 — known-safe argv
+        result = io.run(  # nosec B603 — known-safe argv
             [str(venv_hermes), "doctor"],
             check=False,
             capture_output=True,
@@ -2945,8 +2968,9 @@ def _smoke_hermes_doctor(_state: BootstrapState) -> tuple[bool, str]:
     return (result.returncode == 0, f"rc={result.returncode}")
 
 
-def _phase_smoke_tests(state: BootstrapState) -> PhaseResult:
+def _phase_smoke_tests(ctx: PhaseContext) -> PhaseResult:
     """Run six diagnostic probes; collect results into the checkpoint."""
+    state = ctx.state
     probes = [
         ("wrapper_ready", _smoke_wrapper_ready),
         ("hermes_doctor", _smoke_hermes_doctor),
@@ -2959,7 +2983,7 @@ def _phase_smoke_tests(state: BootstrapState) -> PhaseResult:
     failures: list[str] = []
     for name, fn in probes:
         try:
-            passed, detail = fn(state)
+            passed, detail = fn(state, ctx.io)
         except Exception as exc:
             passed, detail = (False, f"{type(exc).__name__}: {exc}")
         results[name] = {"passed": passed, "detail": detail}
@@ -2978,14 +3002,15 @@ def _phase_smoke_tests(state: BootstrapState) -> PhaseResult:
 # rollup so a degraded install surfaces in chat.
 
 
-def _phase_self_report(state: BootstrapState) -> PhaseResult:
+def _phase_self_report(ctx: PhaseContext) -> PhaseResult:
     """Write a bootstrap-completion summary into the agent's private namespace.
 
     Failure of the memory write is non-fatal — same posture as
     namespace_register (#243): the memory layer being unavailable
     shouldn't fail bootstrap.
     """
-    smoke = (state.phases.get("smoke_tests") or {}).get("details") or {}
+    state = ctx.state
+    smoke = ctx.output_of("smoke_tests")
     smoke_failures = smoke.get("failures") or []
     primary_alias = ""
     config_path = Path(state.hermes_home) / "config.yaml"
@@ -3004,7 +3029,7 @@ def _phase_self_report(state: BootstrapState) -> PhaseResult:
         f"Primary model: {primary_alias or 'unwired'}. "
         f"Smoke failures: {len(smoke_failures)}."
     )
-    add = _mcp_memory_call(
+    add = ctx.io.mcp_memory_call(
         "tools/call",
         {
             "name": "memory_add",
@@ -3165,7 +3190,7 @@ def _write_runtime_json(state: BootstrapState, *, repair: bool) -> tuple[Path, b
     return path, True
 
 
-def _phase_install_artifacts(state: BootstrapState) -> PhaseResult:
+def _phase_install_artifacts(ctx: PhaseContext) -> PhaseResult:
     """Write the seed TOML, driver env file, and runtime.json (issue #432).
 
     These three artifacts were previously only written by
@@ -3179,7 +3204,8 @@ def _phase_install_artifacts(state: BootstrapState) -> PhaseResult:
     INSTALL_SEED_PATH / DRIVER_ENV_PATH to tmp_path; the runtime.json write
     is always tmp-safe because it tracks ``state.hermes_home``.
     """
-    repair = bool(state.phases.get("_repair_flag"))
+    state = ctx.state
+    repair = ctx.repair
 
     under_pytest = bool(os.environ.get("PYTEST_CURRENT_TEST"))
     if under_pytest and (
@@ -3348,29 +3374,30 @@ def _validate_phase_graph(phases: list[Phase]) -> None:
                 )
 
 
-PHASES: list[tuple[str, Callable[[BootstrapState], PhaseResult]]] = [
-    ("preflight", _phase_preflight),
-    ("install", _phase_install),
-    ("env_probe", _phase_env_probe),
-    ("home_init", _phase_home_init),
+PHASES: list[Phase] = [
+    Phase("preflight", _phase_preflight),
+    Phase("install", _phase_install),
+    Phase("env_probe", _phase_env_probe),
+    Phase("home_init", _phase_home_init),
     # #432: write the manager seed + driver env + runtime.json embed token
     # right after $HERMES_HOME exists and before mcp_wire reads the seed's
     # allow-list, so a single `bootstrap hermes` run leaves the artifacts the
     # manager + chat_proxy key off (previously only AgentManager.install wrote
     # them, so the bootstrap path left the agent reporting `broken`).
-    ("install_artifacts", _phase_install_artifacts),
+    Phase("install_artifacts", _phase_install_artifacts),
     # PR-3 Phase 8: seed personas BEFORE config_write so the first
     # config render gets the active persona's system_prompt prelude.
     # mcp_wire runs after config_write to probe the live MCP surface;
     # the probe results feed Phase 9 (model_automap)'s re-render so a
-    # post-bootstrap config still picks up the validated server list.
-    ("persona_seed", _phase_persona_seed),
-    ("config_write", _phase_config_write),
-    ("mcp_wire", _phase_mcp_wire),
-    ("context_link", _phase_context_link),
-    ("namespace_register", _phase_namespace_register),
-    ("model_automap", _phase_model_automap),
-    ("voice_wire", _phase_voice_wire),
+    # post-bootstrap config still picks up the validated server list —
+    # hence config_write's needs_previous (cross-run) edge on mcp_wire.
+    Phase("persona_seed", _phase_persona_seed),
+    Phase("config_write", _phase_config_write, needs_previous=("mcp_wire",)),
+    Phase("mcp_wire", _phase_mcp_wire),
+    Phase("context_link", _phase_context_link),
+    Phase("namespace_register", _phase_namespace_register),
+    Phase("model_automap", _phase_model_automap, needs=("mcp_wire",)),
+    Phase("voice_wire", _phase_voice_wire, needs=("mcp_wire",)),
     # #437 (SYSTEM scope): wire the gateway secrets drop-in so fresh
     # provisions/reinstalls come up with Telegram + Discord connected,
     # surviving hermes_cli main-unit regeneration. Runs after voice_wire
@@ -3378,12 +3405,39 @@ PHASES: list[tuple[str, Callable[[BootstrapState], PhaseResult]]] = [
     # before smoke_tests. The orchestrator runs `hermes gateway install`
     # separately to lay down the main unit; this phase only owns the
     # drop-in + daemon-reload.
-    ("gateway_secrets_wire", _phase_gateway_secrets_wire),
-    ("smoke_tests", _phase_smoke_tests),
-    ("self_report", _phase_self_report),
+    Phase("gateway_secrets_wire", _phase_gateway_secrets_wire),
+    Phase("smoke_tests", _phase_smoke_tests),
+    Phase("self_report", _phase_self_report, needs=("smoke_tests",)),
 ]
 
-PHASE_NAMES: tuple[str, ...] = tuple(name for name, _ in PHASES)
+_validate_phase_graph(PHASES)
+
+PHASE_NAMES: tuple[str, ...] = tuple(p.name for p in PHASES)
+
+
+def context_for(
+    phase_name: str,
+    state: BootstrapState,
+    *,
+    repair: bool = False,
+    io: PhaseIO | None = None,
+) -> PhaseContext:
+    """Build the :class:`PhaseContext` the orchestrator would hand ``phase_name``.
+
+    Looks the phase up in :data:`PHASES` so the context carries the
+    declared needs — the canonical way for per-phase unit tests to call
+    a phase body directly without re-stating the needs graph.
+    """
+    phase = next((p for p in PHASES if p.name == phase_name), None)
+    if phase is None:
+        raise KeyError(f"unknown phase {phase_name!r} (known: {', '.join(PHASE_NAMES)})")
+    return PhaseContext(
+        state=state,
+        repair=repair,
+        io=io if io is not None else PhaseIO(),
+        phase_name=phase.name,
+        allowed_needs=phase.allowed_needs,
+    )
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -3433,10 +3487,13 @@ def run(
     state_root: Path | None = None,
     verbose: bool = False,
     initial_state: BootstrapState | None = None,
+    io: PhaseIO | None = None,
 ) -> RunResult:
     """Run every phase in order, persisting checkpoints to ``state_root``.
 
     * ``repair`` — re-run every phase regardless of checkpoint state.
+      Surfaced to phase bodies as ``ctx.repair`` (persona_seed +
+      install_artifacts change behaviour under it).
     * ``dry_run`` — execute each phase but don't persist the state file.
     * ``skip_phases`` — skip the named phases (logged as ``skip``).
     * ``state_root`` — overrides the default ``provision.json`` location;
@@ -3444,6 +3501,13 @@ def run(
     * ``initial_state`` — seed state when no checkpoint exists; tests
       pass one with `hermes_home` + `venv` pointed at `tmp_path` so the
       real install/home_init phases don't need write access to /var/lib.
+    * ``io`` — the :class:`PhaseIO` seam bundle every phase receives;
+      ``None`` means the production wiring (``PhaseIO()``).
+
+    FAIL policy is run-all: a failing phase never halts the loop or
+    skips dependents (fallbacks keep phases independent; convergence
+    comes via ``--repair``). ``completed_at`` is only stamped when no
+    phase failed — unchanged from the pre-#702 contract.
 
     Returns a :class:`RunResult` capturing the post-run state + the
     per-phase outcomes the CLI surface pretty-prints.
@@ -3454,16 +3518,12 @@ def run(
         state.started_at = _utcnow()
         state.completed_at = None
 
+    phase_io = io if io is not None else PhaseIO()
     skipped: list[str] = []
     failed: list[str] = []
-    # Surface ``--repair`` to phase bodies that change behavior under it
-    # (persona_seed re-writes its seeds on repair). Stash a sentinel on
-    # ``state.phases`` so the runtime doesn't need a new signature. The
-    # entry is stripped before save so it never appears in provision.json.
-    if repair:
-        state.phases["_repair_flag"] = {"status": "stub", "details": {}}
 
-    for name, phase in PHASES:
+    for phase in PHASES:
+        name = phase.name
         if name in skip_phases:
             entry = {
                 "status": PhaseStatus.SKIP.value,
@@ -3485,7 +3545,14 @@ def run(
         if verbose:
             print(f"[run ] {name}")
 
-        result = phase(state)
+        ctx = PhaseContext(
+            state=state,
+            repair=repair,
+            io=phase_io,
+            phase_name=name,
+            allowed_needs=phase.allowed_needs,
+        )
+        result = phase.fn(ctx)
         entry = result.to_dict()
         entry["at"] = _utcnow()
         state.phases[name] = entry
@@ -3493,10 +3560,6 @@ def run(
         if result.status == PhaseStatus.FAIL:
             failed.append(name)
             state.errors.append(f"{name}: {result.reason or 'unspecified failure'}")
-
-    # Strip the repair sentinel before persistence — operator never sees
-    # it in provision.json, and the next run computes it from CLI flags.
-    state.phases.pop("_repair_flag", None)
 
     if not failed:
         state.completed_at = _utcnow()

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1057,6 +1057,63 @@ def test_config_write_phase_applies_overrides(
     assert "999" in cfg
 
 
+# ── #702: silent fallbacks become observable ─────────────────────────────────
+
+
+def test_config_write_records_fallbacks_for_placeholder_primary_and_default_mcp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """First-run posture: no ready slot + no mcp_wire checkpoint → both
+    fallback sites land in details["fallbacks"]. Behaviour is unchanged
+    — the fallbacks are recorded, not different."""
+    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
+    monkeypatch.setattr(hp, "OVERRIDES_PATH", tmp_path / "no.yaml")
+    from hal0.agents import personas as _personas
+
+    monkeypatch.setattr(_personas, "PERSONAS_ROOT", tmp_path / "personas-empty")
+    io = hp.PhaseIO(fetch_slots=lambda: [], fetch_model_contexts=lambda: {})
+    out = hp._phase_config_write(hp.context_for("config_write", state, io=io))
+    assert out.status == hp.PhaseStatus.OK
+    sites = {f["site"] for f in out.details["fallbacks"]}
+    assert sites == {"primary_slot", "mcp_servers"}
+
+
+def test_config_write_records_no_fallbacks_when_inputs_live(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
+    # A persisted mcp_wire checkpoint from a previous run.
+    state.phases["mcp_wire"] = {
+        "status": "ok",
+        "details": {"rendered_servers": hp._default_mcp_servers()},
+    }
+    monkeypatch.setattr(hp, "OVERRIDES_PATH", tmp_path / "no.yaml")
+    from hal0.agents import personas as _personas
+
+    monkeypatch.setattr(_personas, "PERSONAS_ROOT", tmp_path / "personas-empty")
+    io = hp.PhaseIO(fetch_slots=lambda: list(_ROLE_SLOTS), fetch_model_contexts=lambda: {})
+    out = hp._phase_config_write(hp.context_for("config_write", state, io=io))
+    assert out.status == hp.PhaseStatus.OK
+    assert out.details["fallbacks"] == []
+
+
+def test_resolve_primary_slot_marks_placeholder() -> None:
+    assert hp._resolve_primary_slot(slots_fetcher=lambda: [])["placeholder"] is True
+    live = hp._resolve_primary_slot(
+        slots_fetcher=lambda: [
+            {
+                "name": "chat",
+                "type": "llm",
+                "state": "ready",
+                "model_id": "qwen3-test",
+                "backend_url": "http://127.0.0.1:8001/v1",
+                "context_length": 32768,
+            }
+        ]
+    )
+    assert live["placeholder"] is False
+
+
 def test_deep_merge_recurses() -> None:
     base = {"a": {"b": 1, "c": 2}, "d": 3}
     overlay = {"a": {"c": 99, "e": 4}}
@@ -1230,6 +1287,8 @@ def test_namespace_register_continues_on_mcp_failure(
     assert out.status == hp.PhaseStatus.OK
     assert out.details["registered"] is False
     assert any("memory_add" in w for w in out.details["warnings"])
+    # #702: the memory-layer warn-as-OK posture is an observable fallback.
+    assert any(f["site"] == "memory_layer" for f in out.details["fallbacks"])
 
 
 def test_mcp_wire_phase_skips_server_not_in_allowlist(
@@ -1344,6 +1403,8 @@ def test_context_link_falls_back_when_soul_render_fails(
     soul = (hermes_home / "SOUL.md").read_text()
     assert "hal0 admin agent" in soul
     assert any("SOUL.md render" in w for w in out.details["warnings"])
+    # #702: the inline-default fallback is observable, not silent.
+    assert any(f["site"] == "soul_md" for f in out.details["fallbacks"])
 
 
 # ── #245 phase impls — model_automap + voice_wire ───────────────────────────

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -19,8 +19,10 @@ slice notices.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -29,31 +31,19 @@ import pytest
 from hal0.agents import hermes_provision as hp
 
 
-@pytest.fixture(autouse=True)
-def _offline_model_contexts(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Never hit the live daemon's /v1/models during unit tests.
-
-    ``_collect_chat_slots`` callers pass the result of ``_fetch_model_contexts``;
-    left un-stubbed each phase test would block on a real urlopen. Stub to empty
-    so per-model context falls back to each fixture slot's own context_length.
-    """
-    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {})
-
-
 @pytest.fixture
 def state_with_tmp_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.BootstrapState:
-    """Seed a :class:`BootstrapState` rooted in ``tmp_path`` with externals stubbed.
+    """Seed a :class:`BootstrapState` rooted in ``tmp_path``.
 
-    The real preflight + install phases reach for ``/var/lib/hal0/*``,
-    spawn ``python -m venv``, and HTTP-poke ``127.0.0.1:8080``. Every
-    pipeline-level test needs these dimmed out so the orchestrator's
-    behaviour is what's under test, not the LXC.
+    Path CONSTANTS are redirected here (they intentionally stay
+    module-level per #702); behavioural IO is faked via the companion
+    ``pipeline_io`` fixture's :class:`hp.PhaseIO` instead of
+    monkeypatching module globals.
     """
     var_lib = tmp_path / "var" / "lib" / "hal0"
     var_lib.mkdir(parents=True)
     venv = var_lib / "venvs" / "hermes"
     hermes_home = var_lib / "agents" / "hermes"
-    monkeypatch.setattr(hp, "_http_get", lambda *_a, **_kw: 200)
     monkeypatch.setattr(hp, "MIN_FREE_GIB", 0)  # /tmp may be tmpfs with little headroom
     monkeypatch.setattr(
         hp, "WRAPPER_INSTALL_PATH", tmp_path / "usr" / "local" / "bin" / "hal0-hermes"
@@ -62,18 +52,30 @@ def state_with_tmp_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.
         hp, "HERMES_CLI_INSTALL_PATH", tmp_path / "usr" / "local" / "bin" / "hermes"
     )
     # #437 gateway_secrets_wire: redirect the SYSTEM drop-in dir under
-    # tmp_path and stub `systemctl daemon-reload` so a pipeline run never
-    # touches the live /etc/systemd/system or the live systemd bus — even
-    # when the test runner is root.
+    # tmp_path so a pipeline run never touches the live /etc/systemd/system
+    # — even when the test runner is root.
     _dropin_dir = tmp_path / "etc" / "systemd" / "system" / "hermes-gateway.service.d"
     monkeypatch.setattr(hp, "GATEWAY_SYSTEMD_DROPIN_DIR", _dropin_dir)
     monkeypatch.setattr(hp, "GATEWAY_SYSTEMD_DROPIN_FILE", _dropin_dir / "10-hal0-secrets.conf")
+    return hp.BootstrapState(venv=str(venv), hermes_home=str(hermes_home))
 
-    # Intercept ONLY `systemctl daemon-reload` (the live-systemd action the
-    # gateway phase would run). Everything else — env_probe's
-    # `systemd-detect-virt`, smoke-test exec — passes through to the real
-    # subprocess so those phases behave as before.
-    _real_run = hp.subprocess.run
+
+@pytest.fixture
+def pipeline_io() -> hp.PhaseIO:
+    """The IO seam bundle for pipeline-level runs (#702).
+
+    The real preflight + install phases reach for ``/var/lib/hal0/*``,
+    spawn ``python -m venv``, and HTTP-poke ``127.0.0.1:8080``; the
+    config/mcp/memory phases would block on real urlopens. Fake every
+    seam through ``PhaseIO`` so the orchestrator's behaviour is what's
+    under test, not the LXC.
+
+    ``run`` intercepts ONLY ``systemctl daemon-reload`` (the live-systemd
+    action the gateway phase would issue). Everything else — env_probe's
+    ``systemd-detect-virt``, smoke-test exec — passes through to the real
+    subprocess so those phases behave as before.
+    """
+    real_run = subprocess.run
 
     class _NoopCompleted:
         returncode = 0
@@ -83,34 +85,22 @@ def state_with_tmp_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.
     def _guarded_run(argv: Any, *a: Any, **kw: Any) -> Any:
         if isinstance(argv, (list, tuple)) and list(argv[:2]) == ["systemctl", "daemon-reload"]:
             return _NoopCompleted()
-        return _real_run(argv, *a, **kw)
-
-    monkeypatch.setattr(hp.subprocess, "run", _guarded_run)
+        return real_run(argv, *a, **kw)
 
     def _fake_install(v: Path, _req: Path, **_kwargs: Any) -> None:
         (v / "bin").mkdir(parents=True, exist_ok=True)
         (v / "bin" / "hermes").write_text("#!/bin/sh\nexit 0\n")
         (v / "bin" / "hermes").chmod(0o755)
 
-    monkeypatch.setattr(hp, "_install_venv", _fake_install)
-    # PR-3: config_write + model_automap + voice_wire all call
-    # _fetch_slots; without a stub each call would block 3s on a real
-    # urlopen timeout. Keep the integration tests offline-fast.
-    monkeypatch.setattr(hp, "_fetch_slots", lambda: [])
-    # Same for the /v1/models context fetch — stub to empty so per-model
-    # context falls back to each slot's own context_length (set on fixtures).
-    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {})
-    monkeypatch.setattr(
-        hp,
-        "_probe_mcp_server",
-        lambda _url, **_kw: {"ok": True, "tools": ["t1"], "error": None},
+    return hp.PhaseIO(
+        http_get=lambda *_a, **_kw: 200,
+        fetch_slots=lambda: [],
+        fetch_model_contexts=lambda: {},
+        probe_mcp_server=lambda _url, **_kw: {"ok": True, "tools": ["t1"], "error": None},
+        mcp_memory_call=lambda *_a, **_kw: {"ok": True, "result": {"items": [], "id": "x"}},
+        install_venv=_fake_install,
+        run=_guarded_run,
     )
-    monkeypatch.setattr(
-        hp,
-        "_mcp_memory_call",
-        lambda *_a, **_kw: {"ok": True, "result": {"items": [], "id": "x"}},
-    )
-    return hp.BootstrapState(venv=str(venv), hermes_home=str(hermes_home))
 
 
 def test_phase_names_in_planned_order() -> None:
@@ -151,9 +141,9 @@ def test_phase_names_in_planned_order() -> None:
 
 
 def test_run_marks_every_phase_ok_on_fresh(
-    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState
+    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState, pipeline_io: hp.PhaseIO
 ) -> None:
-    result = hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths)
+    result = hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths, io=pipeline_io)
     # voice_wire legitimately returns SKIP when no STT/TTS slots are
     # configured (most CI envs); gateway_secrets_wire SKIPs when the test
     # runner is non-root (can't write /etc/systemd/system). Accept both
@@ -173,9 +163,9 @@ def test_run_marks_every_phase_ok_on_fresh(
 
 
 def test_state_file_written_and_round_trips(
-    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState
+    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState, pipeline_io: hp.PhaseIO
 ) -> None:
-    hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths)
+    hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths, io=pipeline_io)
     state_file = tmp_path / "provision.json"
     assert state_file.exists()
     loaded = hp.BootstrapState.load(tmp_path)
@@ -186,18 +176,22 @@ def test_state_file_written_and_round_trips(
 
 
 def test_rerun_is_noop_when_all_phases_ok(
-    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState
+    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState, pipeline_io: hp.PhaseIO
 ) -> None:
-    hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths)
-    second = hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths)
+    hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths, io=pipeline_io)
+    second = hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths, io=pipeline_io)
     # All phases skipped because their checkpoint is already ok.
     assert set(second.skipped) == set(hp.PHASE_NAMES)
     assert second.failed == []
 
 
-def test_repair_flag_forces_rerun(tmp_path: Path, state_with_tmp_paths: hp.BootstrapState) -> None:
-    hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths)
-    second = hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths, repair=True)
+def test_repair_flag_forces_rerun(
+    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState, pipeline_io: hp.PhaseIO
+) -> None:
+    hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths, io=pipeline_io)
+    second = hp.run(
+        state_root=tmp_path, initial_state=state_with_tmp_paths, repair=True, io=pipeline_io
+    )
     # Repair re-runs everything → nothing was skipped via checkpoint.
     assert second.skipped == []
     # voice_wire legitimately returns SKIP when no STT/TTS slots exist;
@@ -218,12 +212,13 @@ def test_repair_flag_forces_rerun(tmp_path: Path, state_with_tmp_paths: hp.Boots
 
 
 def test_skip_phase_records_skip_reason(
-    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState
+    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState, pipeline_io: hp.PhaseIO
 ) -> None:
     result = hp.run(
         state_root=tmp_path,
         initial_state=state_with_tmp_paths,
         skip_phases=("voice_wire", "smoke_tests"),
+        io=pipeline_io,
     )
     assert result.phases["voice_wire"]["status"] == hp.PhaseStatus.SKIP.value
     assert result.phases["voice_wire"]["reason"] == "--skip-phase"
@@ -233,9 +228,9 @@ def test_skip_phase_records_skip_reason(
 
 
 def test_dry_run_skips_state_persistence(
-    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState
+    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState, pipeline_io: hp.PhaseIO
 ) -> None:
-    hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths, dry_run=True)
+    hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths, dry_run=True, io=pipeline_io)
     assert not (tmp_path / "provision.json").exists()
 
 
@@ -277,21 +272,27 @@ def test_failed_phase_surfaces_in_result_and_blocks_completion(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     state_with_tmp_paths: hp.BootstrapState,
+    pipeline_io: hp.PhaseIO,
 ) -> None:
-    def _failing(_state: hp.BootstrapState) -> hp.PhaseResult:
+    def _failing(_ctx: hp.PhaseContext) -> hp.PhaseResult:
         return hp.PhaseResult(status=hp.PhaseStatus.FAIL, reason="forced")
 
-    new_phases = [(name, _failing if name == "env_probe" else fn) for name, fn in hp.PHASES]
+    new_phases = [
+        dataclasses.replace(p, fn=_failing) if p.name == "env_probe" else p for p in hp.PHASES
+    ]
     monkeypatch.setattr(hp, "PHASES", new_phases)
 
-    result = hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths)
+    result = hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths, io=pipeline_io)
     assert "env_probe" in result.failed
     assert result.state.completed_at is None
     assert any("env_probe" in e for e in result.state.errors)
 
 
 def test_cli_entry_returns_zero_on_success(
-    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    state_with_tmp_paths: hp.BootstrapState,
+    monkeypatch: pytest.MonkeyPatch,
+    pipeline_io: hp.PhaseIO,
 ) -> None:
     # bootstrap_cli doesn't take an initial_state kwarg directly — wrap
     # `run` so the test still threads the tmp-rooted state through.
@@ -299,6 +300,7 @@ def test_cli_entry_returns_zero_on_success(
 
     def _wrapped(**kwargs: Any) -> hp.RunResult:
         kwargs.setdefault("initial_state", state_with_tmp_paths)
+        kwargs.setdefault("io", pipeline_io)
         return real_run(**kwargs)
 
     monkeypatch.setattr(hp, "run", _wrapped)
@@ -316,17 +318,21 @@ def test_cli_entry_returns_one_on_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     state_with_tmp_paths: hp.BootstrapState,
+    pipeline_io: hp.PhaseIO,
 ) -> None:
-    def _failing(_state: hp.BootstrapState) -> hp.PhaseResult:
+    def _failing(_ctx: hp.PhaseContext) -> hp.PhaseResult:
         return hp.PhaseResult(status=hp.PhaseStatus.FAIL, reason="boom")
 
-    new_phases = [(name, _failing if name == "preflight" else fn) for name, fn in hp.PHASES]
+    new_phases = [
+        dataclasses.replace(p, fn=_failing) if p.name == "preflight" else p for p in hp.PHASES
+    ]
     monkeypatch.setattr(hp, "PHASES", new_phases)
 
     real_run = hp.run
 
     def _wrapped(**kwargs: Any) -> hp.RunResult:
         kwargs.setdefault("initial_state", state_with_tmp_paths)
+        kwargs.setdefault("io", pipeline_io)
         return real_run(**kwargs)
 
     monkeypatch.setattr(hp, "run", _wrapped)
@@ -350,9 +356,9 @@ def test_preflight_passes_when_inputs_meet_minimums(
     var_lib.mkdir(parents=True)
     venv = var_lib / "venvs" / "hermes"
     state = hp.BootstrapState(venv=str(venv))
-    monkeypatch.setattr(hp, "_http_get", lambda *_a, **_kw: 200)
     monkeypatch.setattr(hp, "MIN_FREE_GIB", 0)
-    out = hp._phase_preflight(state)
+    io = hp.PhaseIO(http_get=lambda *_a, **_kw: 200)
+    out = hp._phase_preflight(hp.context_for("preflight", state, io=io))
     assert out.status == hp.PhaseStatus.OK
     assert out.details["python_version"]
     assert out.details["daemon_http_status"] == 200
@@ -364,8 +370,8 @@ def test_preflight_fails_on_unreachable_daemon(
     var_lib = tmp_path / "var" / "lib" / "hal0"
     var_lib.mkdir(parents=True)
     state = hp.BootstrapState(venv=str(var_lib / "venvs" / "hermes"))
-    monkeypatch.setattr(hp, "_http_get", lambda *_a, **_kw: 0)
-    out = hp._phase_preflight(state)
+    io = hp.PhaseIO(http_get=lambda *_a, **_kw: 0)
+    out = hp._phase_preflight(hp.context_for("preflight", state, io=io))
     assert out.status == hp.PhaseStatus.FAIL
     assert "daemon unreachable" in (out.reason or "")
 
@@ -373,9 +379,9 @@ def test_preflight_fails_on_unreachable_daemon(
 def test_preflight_fails_on_var_lib_not_writable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(hp, "_http_get", lambda *_a, **_kw: 200)
+    io = hp.PhaseIO(http_get=lambda *_a, **_kw: 200)
     state = hp.BootstrapState(venv=str(tmp_path / "nope" / "venvs" / "hermes"))
-    out = hp._phase_preflight(state)
+    out = hp._phase_preflight(hp.context_for("preflight", state, io=io))
     assert out.status == hp.PhaseStatus.FAIL
     assert "not writable" in (out.reason or "")
 
@@ -383,7 +389,7 @@ def test_preflight_fails_on_var_lib_not_writable(
 def test_home_init_creates_layout_with_marker(tmp_path: Path) -> None:
     hermes_home = tmp_path / "hermes_home"
     state = hp.BootstrapState(hermes_home=str(hermes_home))
-    out = hp._phase_home_init(state)
+    out = hp._phase_home_init(hp.context_for("home_init", state))
     assert out.status == hp.PhaseStatus.OK
     assert hermes_home.is_dir()
     assert (hermes_home / ".hal0-managed").is_file()
@@ -394,9 +400,9 @@ def test_home_init_creates_layout_with_marker(tmp_path: Path) -> None:
 def test_home_init_idempotent_on_managed_dir(tmp_path: Path) -> None:
     hermes_home = tmp_path / "hermes_home"
     state = hp.BootstrapState(hermes_home=str(hermes_home))
-    hp._phase_home_init(state)
+    hp._phase_home_init(hp.context_for("home_init", state))
     marker_before = (hermes_home / ".hal0-managed").read_text()
-    out2 = hp._phase_home_init(state)
+    out2 = hp._phase_home_init(hp.context_for("home_init", state))
     assert out2.status == hp.PhaseStatus.OK
     assert (hermes_home / ".hal0-managed").read_text() == marker_before
 
@@ -406,7 +412,7 @@ def test_home_init_refuses_to_clobber_non_managed_dir(tmp_path: Path) -> None:
     hermes_home.mkdir()
     (hermes_home / "config.yaml").write_text("# user file")
     state = hp.BootstrapState(hermes_home=str(hermes_home))
-    out = hp._phase_home_init(state)
+    out = hp._phase_home_init(hp.context_for("home_init", state))
     assert out.status == hp.PhaseStatus.FAIL
     assert "not hal0-managed" in (out.reason or "")
 
@@ -431,9 +437,9 @@ def test_install_phase_skips_venv_when_binary_exists(
     def _no_install(*args: Any, **kwargs: Any) -> None:
         called.append(args)
 
-    monkeypatch.setattr(hp, "_install_venv", _no_install)
-
-    out = hp._phase_install(state)
+    out = hp._phase_install(
+        hp.context_for("install", state, io=hp.PhaseIO(install_venv=_no_install))
+    )
     assert out.status == hp.PhaseStatus.OK
     assert called == []
     # Canonical `hermes` is a real file; `hal0-hermes` is a back-compat
@@ -467,8 +473,9 @@ def test_install_phase_runs_venv_install_when_binary_missing(
         (v / "bin" / "hermes").write_text("#!/bin/sh\nexit 0\n")
         (v / "bin" / "hermes").chmod(0o755)
 
-    monkeypatch.setattr(hp, "_install_venv", _fake_install)
-    out = hp._phase_install(state)
+    out = hp._phase_install(
+        hp.context_for("install", state, io=hp.PhaseIO(install_venv=_fake_install))
+    )
     assert out.status == hp.PhaseStatus.OK
     assert install_calls == [venv]
 
@@ -489,7 +496,7 @@ def test_resolve_python311_falls_back_to_sys_executable() -> None:
 
 def test_env_probe_writes_snapshot_to_hermes_home(tmp_path: Path) -> None:
     state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
-    out = hp._phase_env_probe(state)
+    out = hp._phase_env_probe(hp.context_for("env_probe", state))
     assert out.status == hp.PhaseStatus.OK
     snap = Path(out.details["snapshot_path"])
     assert snap.exists()
@@ -840,12 +847,12 @@ def test_config_write_renders_role_slots_from_live_state(
             "context_length": 32768,
         },
     )
-    monkeypatch.setattr(hp, "_fetch_slots", lambda: list(_ROLE_SLOTS))
     monkeypatch.setattr(hp, "OVERRIDES_PATH", tmp_path / "no-overrides.yaml")
     from hal0.agents import personas as _personas
 
     monkeypatch.setattr(_personas, "PERSONAS_ROOT", tmp_path / "personas-empty")
-    out = hp._phase_config_write(state)
+    io = hp.PhaseIO(fetch_slots=lambda: list(_ROLE_SLOTS), fetch_model_contexts=lambda: {})
+    out = hp._phase_config_write(hp.context_for("config_write", state, io=io))
     assert out.status == hp.PhaseStatus.OK
     assert out.details["delegation_model"] == "hermes-4-14b-q5km"
     assert out.details["auxiliary_utility_model"] == "qwen3-zero-coder-v2-0.8b-f16"
@@ -1011,19 +1018,19 @@ def test_config_write_phase_writes_yaml_idempotently(
         lambda **_kwargs: {"model": "p", "base_url": "u", "context_length": 8000},
     )
     monkeypatch.setattr(hp, "OVERRIDES_PATH", tmp_path / "no-such-overrides.yaml")
-    # PR-3: _phase_config_write now also calls _fetch_slots + persona
-    # render. Stub both so the test stays offline.
-    monkeypatch.setattr(hp, "_fetch_slots", lambda: [])
+    # PR-3: _phase_config_write also fetches slots + renders the persona.
+    # Fake both seams so the test stays offline.
     from hal0.agents import personas as _personas
 
     monkeypatch.setattr(_personas, "PERSONAS_ROOT", tmp_path / "personas-empty")
-    out1 = hp._phase_config_write(state)
+    io = hp.PhaseIO(fetch_slots=lambda: [], fetch_model_contexts=lambda: {})
+    out1 = hp._phase_config_write(hp.context_for("config_write", state, io=io))
     assert out1.status == hp.PhaseStatus.OK
     cfg = Path(out1.details["config_path"])
     assert cfg.exists()
     first_hash = out1.hash
     # Re-run is a no-op (hash equals on-disk).
-    out2 = hp._phase_config_write(state)
+    out2 = hp._phase_config_write(hp.context_for("config_write", state, io=io))
     assert out2.details.get("unchanged") is True
     assert out2.hash == first_hash
 
@@ -1040,11 +1047,11 @@ def test_config_write_phase_applies_overrides(
         lambda **_kwargs: {"model": "p", "base_url": "u", "context_length": 8000},
     )
     monkeypatch.setattr(hp, "OVERRIDES_PATH", overrides)
-    monkeypatch.setattr(hp, "_fetch_slots", lambda: [])
     from hal0.agents import personas as _personas
 
     monkeypatch.setattr(_personas, "PERSONAS_ROOT", tmp_path / "personas-empty")
-    out = hp._phase_config_write(state)
+    io = hp.PhaseIO(fetch_slots=lambda: [], fetch_model_contexts=lambda: {})
+    out = hp._phase_config_write(hp.context_for("config_write", state, io=io))
     assert out.status == hp.PhaseStatus.OK
     cfg = Path(out.details["config_path"]).read_text()
     assert "999" in cfg
@@ -1114,13 +1121,11 @@ def test_mcp_wire_phase_returns_ok_with_tools_when_servers_respond(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     state = hp.BootstrapState()
-    monkeypatch.setattr(
-        hp,
-        "_probe_mcp_server",
-        lambda url, **_kw: {"ok": True, "tools": ["t1", "t2"], "error": None},
+    io = hp.PhaseIO(
+        probe_mcp_server=lambda url, **_kw: {"ok": True, "tools": ["t1", "t2"], "error": None}
     )
     monkeypatch.setattr(hp, "_load_agent_allowlist", lambda *_a, **_kw: None)
-    out = hp._phase_mcp_wire(state)
+    out = hp._phase_mcp_wire(hp.context_for("mcp_wire", state, io=io))
     assert out.status == hp.PhaseStatus.OK
     assert out.details["servers"]["hal0-admin"]["status"] == "ok"
     assert out.details["servers"]["hal0-admin"]["tool_count"] == 2
@@ -1132,13 +1137,15 @@ def test_mcp_wire_phase_degrades_not_fails_on_unreachable_server(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     state = hp.BootstrapState()
-    monkeypatch.setattr(
-        hp,
-        "_probe_mcp_server",
-        lambda url, **_kw: {"ok": False, "tools": [], "error": "connection refused"},
+    io = hp.PhaseIO(
+        probe_mcp_server=lambda url, **_kw: {
+            "ok": False,
+            "tools": [],
+            "error": "connection refused",
+        }
     )
     monkeypatch.setattr(hp, "_load_agent_allowlist", lambda *_a, **_kw: None)
-    out = hp._phase_mcp_wire(state)
+    out = hp._phase_mcp_wire(hp.context_for("mcp_wire", state, io=io))
     # Still OK — degraded is a warning, not a phase-blocker per ADR-0013.
     assert out.status == hp.PhaseStatus.OK
     assert out.details["servers"]["hal0-admin"]["status"] == "degraded"
@@ -1177,8 +1184,8 @@ def test_namespace_register_registers_card_on_happy_path(
             return {"ok": True, "result": {"id": "mem_abc"}}
         return {"ok": True, "result": {}}
 
-    monkeypatch.setattr(hp, "_mcp_memory_call", _fake_mcp)
-    out = hp._phase_namespace_register(state)
+    io = hp.PhaseIO(mcp_memory_call=_fake_mcp)
+    out = hp._phase_namespace_register(hp.context_for("namespace_register", state, io=io))
     assert out.status == hp.PhaseStatus.OK
     assert out.details["registered"] is True
     assert out.details["memory_id"] == "mem_abc"
@@ -1207,8 +1214,8 @@ def test_namespace_register_refreshes_existing_card(
             return {"ok": True, "result": {"id": "new_mem_id"}}
         return {"ok": True, "result": {}}
 
-    monkeypatch.setattr(hp, "_mcp_memory_call", _fake_mcp)
-    out = hp._phase_namespace_register(state)
+    io = hp.PhaseIO(mcp_memory_call=_fake_mcp)
+    out = hp._phase_namespace_register(hp.context_for("namespace_register", state, io=io))
     assert out.status == hp.PhaseStatus.OK
     assert out.details["refreshed_existing"] is True
 
@@ -1218,12 +1225,8 @@ def test_namespace_register_continues_on_mcp_failure(
 ) -> None:
     """ADR-0013: registry failure logs + continues; bootstrap doesn't block."""
     state = hp.BootstrapState()
-    monkeypatch.setattr(
-        hp,
-        "_mcp_memory_call",
-        lambda *a, **kw: {"ok": False, "error": "connection refused"},
-    )
-    out = hp._phase_namespace_register(state)
+    io = hp.PhaseIO(mcp_memory_call=lambda *a, **kw: {"ok": False, "error": "connection refused"})
+    out = hp._phase_namespace_register(hp.context_for("namespace_register", state, io=io))
     assert out.status == hp.PhaseStatus.OK
     assert out.details["registered"] is False
     assert any("memory_add" in w for w in out.details["warnings"])
@@ -1239,12 +1242,10 @@ def test_mcp_wire_phase_skips_server_not_in_allowlist(
         "_load_agent_allowlist",
         lambda *_a, **_kw: {"hal0-admin": {"builtin": True}},
     )
-    monkeypatch.setattr(
-        hp,
-        "_probe_mcp_server",
-        lambda url, **_kw: {"ok": True, "tools": ["t1"], "error": None},
+    io = hp.PhaseIO(
+        probe_mcp_server=lambda url, **_kw: {"ok": True, "tools": ["t1"], "error": None}
     )
-    out = hp._phase_mcp_wire(state)
+    out = hp._phase_mcp_wire(hp.context_for("mcp_wire", state, io=io))
     assert out.status == hp.PhaseStatus.OK
     assert out.details["servers"]["hal0-memory"]["status"] == "skipped_by_allowlist"
     assert out.details["servers"]["hal0-admin"]["status"] == "ok"
@@ -1283,10 +1284,14 @@ def test_context_link_renders_all_three_files(
     monkeypatch.setattr(hp, "ETC_HAL0_AGENT_SKILLS", etc / "agent-skills")
     monkeypatch.setattr(hp, "HAL0_BUNDLED_SKILLS", tmp_path / "no-such-skills")
     # Context-link consults /api/slots when wiring HERMES.md's primary
-    # block; stub it out so the test stays offline + deterministic.
-    monkeypatch.setattr(hp, "_fetch_slots", lambda: [])
+    # block; fake the seams so the test stays offline + deterministic.
+    io = hp.PhaseIO(
+        fetch_slots=lambda: [],
+        fetch_model_contexts=lambda: {},
+        http_get=lambda *_a, **_kw: 0,
+    )
 
-    out = hp._phase_context_link(state)
+    out = hp._phase_context_link(hp.context_for("context_link", state, io=io))
     assert out.status == hp.PhaseStatus.OK
     assert (hermes_home / "SOUL.md").exists()
     assert (etc / "HERMES.md").exists()
@@ -1322,7 +1327,11 @@ def test_context_link_falls_back_when_soul_render_fails(
     monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)  # STATE.md target (#473)
     monkeypatch.setattr(hp, "ETC_HAL0_AGENT_SKILLS", tmp_path / "etc" / "hal0" / "agent-skills")
     monkeypatch.setattr(hp, "HAL0_BUNDLED_SKILLS", tmp_path / "no-skills")
-    monkeypatch.setattr(hp, "_fetch_slots", lambda: [])
+    io = hp.PhaseIO(
+        fetch_slots=lambda: [],
+        fetch_model_contexts=lambda: {},
+        http_get=lambda *_a, **_kw: 0,
+    )
 
     def _explode(name: str, **_: Any) -> str:
         if name == "SOUL.md.j2":
@@ -1330,7 +1339,7 @@ def test_context_link_falls_back_when_soul_render_fails(
         return "ok"
 
     monkeypatch.setattr(hp, "_render_template", _explode)
-    out = hp._phase_context_link(state)
+    out = hp._phase_context_link(hp.context_for("context_link", state, io=io))
     assert out.status == hp.PhaseStatus.OK
     soul = (hermes_home / "SOUL.md").read_text()
     assert "hal0 admin agent" in soul
@@ -1359,10 +1368,8 @@ def test_model_automap_writes_aliases_from_chat_slots(
     # chat slots, NOT ``capability=="chat"``. The pre-fix filter looked
     # at ``kind`` first and let the synthetic ``capability`` field through;
     # the post-fix filter is type-first to match the live shape.
-    monkeypatch.setattr(
-        hp,
-        "_fetch_slots",
-        lambda: [
+    io = hp.PhaseIO(
+        fetch_slots=lambda: [
             {
                 "name": "primary",
                 "type": "llm",
@@ -1378,13 +1385,14 @@ def test_model_automap_writes_aliases_from_chat_slots(
                 "state": "ready",
             },
         ],
+        fetch_model_contexts=lambda: {},
     )
     monkeypatch.setattr(
         hp,
         "_resolve_primary_slot",
         lambda **_kw: {"model": "p", "base_url": "u", "context_length": 8000},
     )
-    out = hp._phase_model_automap(state)
+    out = hp._phase_model_automap(hp.context_for("model_automap", state, io=io))
     assert out.status == hp.PhaseStatus.OK
     rendered = (hermes_home / "config.yaml").read_text()
     assert "coder" in out.details["aliases_written"]
@@ -1407,14 +1415,14 @@ def test_model_automap_idempotent_hash_skip(
         encoding="utf-8",
     )
     monkeypatch.setattr(hp, "OVERRIDES_PATH", tmp_path / "no.yaml")
-    monkeypatch.setattr(hp, "_fetch_slots", lambda: [])
+    io = hp.PhaseIO(fetch_slots=lambda: [], fetch_model_contexts=lambda: {})
     monkeypatch.setattr(
         hp,
         "_resolve_primary_slot",
         lambda **_kw: {"model": "p", "base_url": "u", "context_length": 8000},
     )
-    out1 = hp._phase_model_automap(state)
-    out2 = hp._phase_model_automap(state)
+    out1 = hp._phase_model_automap(hp.context_for("model_automap", state, io=io))
+    out2 = hp._phase_model_automap(hp.context_for("model_automap", state, io=io))
     # First run rewrites (or doesn't, if already canonical); second run
     # observes hash equality and marks unchanged.
     assert out2.details.get("unchanged") is True
@@ -1425,8 +1433,8 @@ def test_voice_wire_skips_when_no_voice_slot(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
-    monkeypatch.setattr(hp, "_fetch_slots", lambda: [])
-    out = hp._phase_voice_wire(state)
+    io = hp.PhaseIO(fetch_slots=lambda: [])
+    out = hp._phase_voice_wire(hp.context_for("voice_wire", state, io=io))
     assert out.status == hp.PhaseStatus.SKIP
 
 
@@ -1439,13 +1447,13 @@ def test_smoke_tests_phase_runs_each_probe_collecting_results(
     state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
     # All six probes return (True, "...") so we exercise the rollup
     # without depending on a real Hermes binary or HTTP listener.
-    monkeypatch.setattr(hp, "_smoke_wrapper_ready", lambda s: (True, "ok"))
-    monkeypatch.setattr(hp, "_smoke_hermes_doctor", lambda s: (True, "ok"))
-    monkeypatch.setattr(hp, "_smoke_chat_completions", lambda s: (True, "ready"))
-    monkeypatch.setattr(hp, "_smoke_memory_roundtrip", lambda s: (True, "1 item"))
-    monkeypatch.setattr(hp, "_smoke_admin_tools_list", lambda s: (True, "8 tools"))
-    monkeypatch.setattr(hp, "_smoke_hermes_md_contains_primary", lambda s: (True, "ok"))
-    out = hp._phase_smoke_tests(state)
+    monkeypatch.setattr(hp, "_smoke_wrapper_ready", lambda s, io: (True, "ok"))
+    monkeypatch.setattr(hp, "_smoke_hermes_doctor", lambda s, io: (True, "ok"))
+    monkeypatch.setattr(hp, "_smoke_chat_completions", lambda s, io: (True, "ready"))
+    monkeypatch.setattr(hp, "_smoke_memory_roundtrip", lambda s, io: (True, "1 item"))
+    monkeypatch.setattr(hp, "_smoke_admin_tools_list", lambda s, io: (True, "8 tools"))
+    monkeypatch.setattr(hp, "_smoke_hermes_md_contains_primary", lambda s, io: (True, "ok"))
+    out = hp._phase_smoke_tests(hp.context_for("smoke_tests", state))
     assert out.status == hp.PhaseStatus.OK
     assert out.details["failures"] == []
     assert set(out.details["results"].keys()) == {
@@ -1462,13 +1470,13 @@ def test_smoke_tests_phase_records_failures_without_blocking(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
-    monkeypatch.setattr(hp, "_smoke_wrapper_ready", lambda s: (False, "wrapper missing"))
-    monkeypatch.setattr(hp, "_smoke_hermes_doctor", lambda s: (True, "ok"))
-    monkeypatch.setattr(hp, "_smoke_chat_completions", lambda s: (False, "503"))
-    monkeypatch.setattr(hp, "_smoke_memory_roundtrip", lambda s: (True, "1 item"))
-    monkeypatch.setattr(hp, "_smoke_admin_tools_list", lambda s: (True, "8 tools"))
-    monkeypatch.setattr(hp, "_smoke_hermes_md_contains_primary", lambda s: (True, "ok"))
-    out = hp._phase_smoke_tests(state)
+    monkeypatch.setattr(hp, "_smoke_wrapper_ready", lambda s, io: (False, "wrapper missing"))
+    monkeypatch.setattr(hp, "_smoke_hermes_doctor", lambda s, io: (True, "ok"))
+    monkeypatch.setattr(hp, "_smoke_chat_completions", lambda s, io: (False, "503"))
+    monkeypatch.setattr(hp, "_smoke_memory_roundtrip", lambda s, io: (True, "1 item"))
+    monkeypatch.setattr(hp, "_smoke_admin_tools_list", lambda s, io: (True, "8 tools"))
+    monkeypatch.setattr(hp, "_smoke_hermes_md_contains_primary", lambda s, io: (True, "ok"))
+    out = hp._phase_smoke_tests(hp.context_for("smoke_tests", state))
     assert out.status == hp.PhaseStatus.OK  # diagnostic — not a blocker
     assert len(out.details["failures"]) == 2
     assert any("wrapper_ready" in f for f in out.details["failures"])
@@ -1491,8 +1499,8 @@ def test_self_report_writes_summary_memory_and_handles_failure(
         captured.append((method, params))
         return {"ok": True, "result": {"id": "mem_xyz"}}
 
-    monkeypatch.setattr(hp, "_mcp_memory_call", _fake_mcp)
-    out = hp._phase_self_report(state)
+    io = hp.PhaseIO(mcp_memory_call=_fake_mcp)
+    out = hp._phase_self_report(hp.context_for("self_report", state, io=io))
     assert out.status == hp.PhaseStatus.OK
     assert out.details["published"] is True
     assert out.details["summary_id"] == "mem_xyz"
@@ -1507,12 +1515,8 @@ def test_self_report_continues_when_memory_unreachable(
 ) -> None:
     state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
     (tmp_path / "hh").mkdir()
-    monkeypatch.setattr(
-        hp,
-        "_mcp_memory_call",
-        lambda *a, **kw: {"ok": False, "error": "connection refused"},
-    )
-    out = hp._phase_self_report(state)
+    io = hp.PhaseIO(mcp_memory_call=lambda *a, **kw: {"ok": False, "error": "connection refused"})
+    out = hp._phase_self_report(hp.context_for("self_report", state, io=io))
     assert out.status == hp.PhaseStatus.OK
     assert out.details["published"] is False
     assert "refused" in out.details["warning"]
@@ -1546,8 +1550,8 @@ class _FakeSystemctl:
 
 def _patch_dropin_to_tmp(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> tuple[Path, _FakeSystemctl]:
-    """Point the gateway drop-in dir at tmp_path + stub subprocess + root euid."""
+) -> tuple[Path, _FakeSystemctl, hp.PhaseIO]:
+    """Point the gateway drop-in dir at tmp_path + fake systemctl + root euid."""
     dropin_dir = tmp_path / "etc" / "systemd" / "system" / "hermes-gateway.service.d"
     dropin_file = dropin_dir / "10-hal0-secrets.conf"
     monkeypatch.setattr(hp, "GATEWAY_SYSTEMD_DROPIN_DIR", dropin_dir)
@@ -1555,17 +1559,16 @@ def _patch_dropin_to_tmp(
     # Pretend we're root so the phase doesn't SKIP on the non-root guard.
     monkeypatch.setattr(hp.os, "geteuid", lambda: 0)
     fake = _FakeSystemctl()
-    monkeypatch.setattr(hp.subprocess, "run", fake.run)
-    return dropin_file, fake
+    return dropin_file, fake, hp.PhaseIO(run=fake.run)
 
 
 def test_gateway_secrets_wire_writes_dropin(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    dropin_file, fake = _patch_dropin_to_tmp(tmp_path, monkeypatch)
+    dropin_file, fake, io = _patch_dropin_to_tmp(tmp_path, monkeypatch)
     state = hp.BootstrapState()
 
-    out = hp._phase_gateway_secrets_wire(state)
+    out = hp._phase_gateway_secrets_wire(hp.context_for("gateway_secrets_wire", state, io=io))
 
     assert out.status == hp.PhaseStatus.OK
     assert dropin_file.exists()
@@ -1583,16 +1586,16 @@ def test_gateway_secrets_wire_writes_dropin(
 
 
 def test_gateway_secrets_wire_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    dropin_file, fake = _patch_dropin_to_tmp(tmp_path, monkeypatch)
+    dropin_file, fake, io = _patch_dropin_to_tmp(tmp_path, monkeypatch)
     state = hp.BootstrapState()
 
-    first = hp._phase_gateway_secrets_wire(state)
+    first = hp._phase_gateway_secrets_wire(hp.context_for("gateway_secrets_wire", state, io=io))
     assert first.status == hp.PhaseStatus.OK
     mtime_after_first = dropin_file.stat().st_mtime_ns
     body_after_first = dropin_file.read_text(encoding="utf-8")
     assert fake.calls == [["systemctl", "daemon-reload"]]
 
-    second = hp._phase_gateway_secrets_wire(state)
+    second = hp._phase_gateway_secrets_wire(hp.context_for("gateway_secrets_wire", state, io=io))
     assert second.status == hp.PhaseStatus.OK
     # Identical hash, file untouched, NO second daemon-reload (hash-skip).
     assert second.hash == first.hash
@@ -1606,12 +1609,12 @@ def test_gateway_secrets_wire_idempotent(tmp_path: Path, monkeypatch: pytest.Mon
 def test_gateway_secrets_wire_skips_non_root(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    dropin_file, fake = _patch_dropin_to_tmp(tmp_path, monkeypatch)
+    dropin_file, fake, io = _patch_dropin_to_tmp(tmp_path, monkeypatch)
     # Override the root euid the helper set — emulate a non-root provision.
     monkeypatch.setattr(hp.os, "geteuid", lambda: 1000)
     state = hp.BootstrapState()
 
-    out = hp._phase_gateway_secrets_wire(state)
+    out = hp._phase_gateway_secrets_wire(hp.context_for("gateway_secrets_wire", state, io=io))
 
     assert out.status == hp.PhaseStatus.SKIP
     assert out.reason is not None
@@ -1642,9 +1645,9 @@ def test_gateway_secrets_wire_refuses_real_etc_dropin_under_pytest(
     def _boom(*_a: Any, **_kw: Any) -> Any:
         raise AssertionError("phase invoked systemctl against the real bus")
 
-    monkeypatch.setattr(hp.subprocess, "run", _boom)
-
-    out = hp._phase_gateway_secrets_wire(hp.BootstrapState())
+    out = hp._phase_gateway_secrets_wire(
+        hp.context_for("gateway_secrets_wire", hp.BootstrapState(), io=hp.PhaseIO(run=_boom))
+    )
 
     assert out.status == hp.PhaseStatus.SKIP
     assert out.reason is not None
@@ -1663,11 +1666,11 @@ def test_bootstrap_default_home_is_dot_hermes() -> None:
 
 
 def test_fresh_run_stamps_marker_under_dot_hermes_home(
-    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState
+    tmp_path: Path, state_with_tmp_paths: hp.BootstrapState, pipeline_io: hp.PhaseIO
 ) -> None:
     # state_with_tmp_paths roots hermes_home under tmp; assert the
     # .hal0-managed marker lands under the configured (dot-shaped) home.
-    result = hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths)
+    result = hp.run(state_root=tmp_path, initial_state=state_with_tmp_paths, io=pipeline_io)
     assert result.failed == []
     marker = Path(state_with_tmp_paths.hermes_home) / ".hal0-managed"
     assert marker.is_file()
@@ -1685,10 +1688,11 @@ def test_install_phase_installs_both_wrappers(
     wrapper_dst = tmp_path / "usr" / "local" / "bin" / "hal0-hermes"
     monkeypatch.setattr(hp, "HERMES_CLI_INSTALL_PATH", hermes_cli_dst)
     monkeypatch.setattr(hp, "WRAPPER_INSTALL_PATH", wrapper_dst)
-    monkeypatch.setattr(hp, "_install_venv", lambda *a, **kw: None)
 
     state = hp.BootstrapState(venv=str(venv), hermes_home=str(tmp_path / "hh"))
-    out = hp._phase_install(state)
+    out = hp._phase_install(
+        hp.context_for("install", state, io=hp.PhaseIO(install_venv=lambda *a, **kw: None))
+    )
 
     assert out.status == hp.PhaseStatus.OK
     # Canonical `hermes` on PATH is a real executable file.

--- a/tests/agents/test_hermes_provision_context.py
+++ b/tests/agents/test_hermes_provision_context.py
@@ -1,0 +1,133 @@
+"""PhaseContext / PhaseIO / Phase-graph plumbing (issue #702).
+
+Pins the explicit-pipeline contract:
+
+* ``PhaseIO`` defaults bind the real IO seams — constructing it with no
+  arguments must be production behaviour, byte-for-byte.
+* ``PhaseContext.output_of(name)`` raises unless the calling phase
+  declared ``name`` in its needs; declared reads return the target
+  phase's checkpoint ``details`` dict (empty when absent — the
+  cross-run config_write→mcp_wire read on a fresh install).
+* ``_validate_phase_graph`` rejects, at import time, a PHASES ordering
+  that violates a declared need.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.agents import hermes_provision as hp
+
+
+def _ok_phase(_ctx: hp.PhaseContext) -> hp.PhaseResult:
+    return hp.PhaseResult(status=hp.PhaseStatus.OK)
+
+
+# ── PhaseIO ──────────────────────────────────────────────────────────────────
+
+
+def test_phaseio_defaults_bind_real_seams() -> None:
+    """A default-constructed PhaseIO is the production wiring."""
+    io = hp.PhaseIO()
+    assert io.http_get is hp._http_get
+    assert io.fetch_slots is hp._fetch_slots
+    assert io.fetch_model_contexts is hp._fetch_model_contexts
+    assert io.probe_mcp_server is hp._probe_mcp_server
+    assert io.mcp_memory_call is hp._mcp_memory_call
+    assert io.install_venv is hp._install_venv
+    assert io.read_env_probe is hp._read_env_probe
+    assert io.run is hp.subprocess.run
+
+
+def test_phaseio_is_frozen() -> None:
+    io = hp.PhaseIO()
+    with pytest.raises(AttributeError):
+        io.fetch_slots = lambda: []  # type: ignore[misc]
+
+
+# ── PhaseContext.output_of ───────────────────────────────────────────────────
+
+
+def test_output_of_raises_on_undeclared_need() -> None:
+    state = hp.BootstrapState()
+    state.phases["mcp_wire"] = {"status": "ok", "details": {"rendered_servers": []}}
+    ctx = hp.PhaseContext(state=state, phase_name="config_write")
+    with pytest.raises(hp.PhaseNeedError, match=r"config_write.*mcp_wire"):
+        ctx.output_of("mcp_wire")
+
+
+def test_output_of_returns_declared_phase_details() -> None:
+    state = hp.BootstrapState()
+    state.phases["smoke_tests"] = {
+        "status": "ok",
+        "details": {"failures": ["chat_completions: 503"]},
+    }
+    ctx = hp.PhaseContext(
+        state=state,
+        phase_name="self_report",
+        allowed_needs=frozenset({"smoke_tests"}),
+    )
+    assert ctx.output_of("smoke_tests") == {"failures": ["chat_completions: 503"]}
+
+
+def test_output_of_returns_empty_dict_when_target_never_ran() -> None:
+    """Fresh-install posture: config_write reads mcp_wire's PREVIOUS-run
+    checkpoint, which doesn't exist on run #1 — that's an empty dict,
+    not an error (the phase falls back to its default inventory)."""
+    ctx = hp.PhaseContext(
+        state=hp.BootstrapState(),
+        phase_name="config_write",
+        allowed_needs=frozenset({"mcp_wire"}),
+    )
+    assert ctx.output_of("mcp_wire") == {}
+
+
+# ── Phase graph validation ───────────────────────────────────────────────────
+
+
+def test_validate_phase_graph_accepts_ordered_needs() -> None:
+    phases = [
+        hp.Phase("a", _ok_phase),
+        hp.Phase("b", _ok_phase, needs=("a",)),
+        hp.Phase("c", _ok_phase, needs_previous=("d",)),
+        hp.Phase("d", _ok_phase, needs=("a", "b")),
+    ]
+    hp._validate_phase_graph(phases)  # must not raise
+
+
+def test_validate_phase_graph_rejects_need_that_follows_reader() -> None:
+    phases = [
+        hp.Phase("reader", _ok_phase, needs=("target",)),
+        hp.Phase("target", _ok_phase),
+    ]
+    with pytest.raises(ValueError, match=r"reader.*target"):
+        hp._validate_phase_graph(phases)
+
+
+def test_validate_phase_graph_rejects_unknown_need() -> None:
+    phases = [hp.Phase("reader", _ok_phase, needs=("ghost",))]
+    with pytest.raises(ValueError, match="ghost"):
+        hp._validate_phase_graph(phases)
+
+
+def test_validate_phase_graph_rejects_unknown_previous_need() -> None:
+    phases = [hp.Phase("reader", _ok_phase, needs_previous=("ghost",))]
+    with pytest.raises(ValueError, match="ghost"):
+        hp._validate_phase_graph(phases)
+
+
+def test_validate_phase_graph_rejects_previous_need_that_precedes_reader() -> None:
+    """A needs_previous target that runs BEFORE its reader is a plain
+    same-run need mislabelled as a cross-run read — reject loudly."""
+    phases = [
+        hp.Phase("target", _ok_phase),
+        hp.Phase("reader", _ok_phase, needs_previous=("target",)),
+    ]
+    with pytest.raises(ValueError, match="needs_previous"):
+        hp._validate_phase_graph(phases)
+
+
+def test_validate_phase_graph_rejects_duplicate_phase_names() -> None:
+    phases = [hp.Phase("a", _ok_phase), hp.Phase("a", _ok_phase)]
+    with pytest.raises(ValueError, match="duplicate"):
+        hp._validate_phase_graph(phases)

--- a/tests/agents/test_hermes_provision_context.py
+++ b/tests/agents/test_hermes_provision_context.py
@@ -131,3 +131,92 @@ def test_validate_phase_graph_rejects_duplicate_phase_names() -> None:
     phases = [hp.Phase("a", _ok_phase), hp.Phase("a", _ok_phase)]
     with pytest.raises(ValueError, match="duplicate"):
         hp._validate_phase_graph(phases)
+
+
+# ── The real PHASES graph ────────────────────────────────────────────────────
+
+
+def test_phases_declare_the_locked_needs_graph() -> None:
+    """#702 locked the 4 cross-phase edges; pin them exactly."""
+    by_name = {p.name: p for p in hp.PHASES}
+    # config_write reads mcp_wire's PREVIOUS-run checkpoint (mcp_wire
+    # runs after it in the list) — a cross-run edge, not a same-run one.
+    assert by_name["config_write"].needs == ()
+    assert by_name["config_write"].needs_previous == ("mcp_wire",)
+    assert by_name["model_automap"].needs == ("mcp_wire",)
+    assert by_name["voice_wire"].needs == ("mcp_wire",)
+    assert by_name["self_report"].needs == ("smoke_tests",)
+    # No other phase declares anything.
+    declared = {p.name for p in hp.PHASES if p.needs or p.needs_previous}
+    assert declared == {"config_write", "model_automap", "voice_wire", "self_report"}
+
+
+def test_real_phases_graph_validates() -> None:
+    hp._validate_phase_graph(hp.PHASES)  # import already ran this; pin it anyway
+
+
+def test_phases_permutation_violating_needs_fails_loudly() -> None:
+    """Moving self_report ahead of smoke_tests must be rejected."""
+    permuted = sorted(hp.PHASES, key=lambda p: 0 if p.name == "self_report" else 1)
+    with pytest.raises(ValueError, match=r"self_report.*smoke_tests"):
+        hp._validate_phase_graph(permuted)
+
+
+def test_phases_permutation_violating_needs_previous_fails_loudly() -> None:
+    """Moving mcp_wire ahead of config_write flips the cross-run edge
+    into a same-run one — the mislabelled declaration must fail."""
+    permuted = sorted(hp.PHASES, key=lambda p: 0 if p.name == "mcp_wire" else 1)
+    with pytest.raises(ValueError, match="needs_previous"):
+        hp._validate_phase_graph(permuted)
+
+
+# ── context_for + undeclared reads through real phases ──────────────────────
+
+
+def test_context_for_carries_declared_needs() -> None:
+    ctx = hp.context_for("self_report", hp.BootstrapState())
+    assert ctx.allowed_needs == frozenset({"smoke_tests"})
+    assert ctx.phase_name == "self_report"
+    assert ctx.repair is False
+
+
+def test_context_for_rejects_unknown_phase() -> None:
+    with pytest.raises(KeyError, match="no_such_phase"):
+        hp.context_for("no_such_phase", hp.BootstrapState())
+
+
+def test_self_report_with_undeclared_needs_raises(tmp_path) -> None:
+    """A phase body that reads a checkpoint without its declared needs
+    must blow up loudly — the read is never silently empty."""
+    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
+    bare_ctx = hp.PhaseContext(state=state, phase_name="self_report")  # no allowed_needs
+    with pytest.raises(hp.PhaseNeedError):
+        hp._phase_self_report(bare_ctx)
+
+
+# ── ctx.repair replaces the _repair_flag sentinel ────────────────────────────
+
+
+def test_repair_flag_sentinel_is_gone() -> None:
+    """The smuggled state.phases['_repair_flag'] sentinel is deleted —
+    no run ever stashes or strips it again."""
+    assert not hasattr(hp, "_REPAIR_FLAG")
+    import inspect
+
+    assert "_repair_flag" not in inspect.getsource(hp.run)
+
+
+def test_persona_seed_overwrites_on_ctx_repair(tmp_path) -> None:
+    from hal0.agents import personas as P
+
+    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
+    out = hp._phase_persona_seed(hp.context_for("persona_seed", state))
+    assert out.status == hp.PhaseStatus.OK
+    persona_path = tmp_path / "hh" / "personas" / "hermes.toml"
+    persona_path.write_text('[persona]\nid = "hermes"\ndisplay_name = "Custom"\n', encoding="utf-8")
+    # No repair → operator edit survives.
+    hp._phase_persona_seed(hp.context_for("persona_seed", state))
+    assert P.load_persona("hermes", root=persona_path.parent).display_name == "Custom"
+    # repair → seeds rewritten.
+    hp._phase_persona_seed(hp.context_for("persona_seed", state, repair=True))
+    assert P.load_persona("hermes", root=persona_path.parent).display_name == "Hermes"

--- a/tests/agents/test_hermes_provision_idempotency.py
+++ b/tests/agents/test_hermes_provision_idempotency.py
@@ -412,6 +412,8 @@ def test_namespace_register_skips_add_on_delete_count_mismatch(
     assert any("memory_delete" in w for w in result.details["warnings"]), (
         "expected a delete-count-mismatch warning"
     )
+    # #702: warn-as-OK memory-layer degradation is an observable fallback.
+    assert any(f["site"] == "memory_layer" for f in result.details["fallbacks"])
 
 
 def test_namespace_register_rewrites_when_delete_count_matches(

--- a/tests/agents/test_hermes_provision_idempotency.py
+++ b/tests/agents/test_hermes_provision_idempotency.py
@@ -14,6 +14,7 @@ hashes) are identical between run #1 and run #2.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -23,27 +24,25 @@ from hal0.agents import hermes_provision as hp
 from hal0.agents import personas as P
 
 
-@pytest.fixture(autouse=True)
-def _offline_model_contexts(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Never hit the live daemon's /v1/models during unit tests."""
-    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {})
-
-
 @pytest.fixture
 def hermetic_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.BootstrapState:
-    """A BootstrapState rooted entirely in ``tmp_path`` with externals stubbed."""
+    """A BootstrapState rooted entirely in ``tmp_path``.
+
+    Path CONSTANTS are redirected here (module-level by design, #702);
+    the behavioural IO seams are faked in the companion ``hermetic_io``
+    fixture's :class:`hp.PhaseIO`.
+    """
     var_lib = tmp_path / "var" / "lib" / "hal0"
     var_lib.mkdir(parents=True)
     venv = var_lib / "venvs" / "hermes"
     hermes_home = var_lib / "agents" / "hermes"
 
-    # Stub network + filesystem touchpoints. Keep them as stable as
-    # possible across calls — a flaky time.now() in `details` would
-    # falsely fail the byte-equal assertion (we strip `at` timestamps in
-    # the comparison below to side-step the legit one).
-    monkeypatch.setattr(hp, "_http_get", lambda *_a, **_kw: 200)
     monkeypatch.setattr(hp, "MIN_FREE_GIB", 0)
     monkeypatch.setattr(hp, "WRAPPER_INSTALL_PATH", tmp_path / "usr" / "bin" / "hal0-hermes")
+    # Sandbox the canonical CLI path too — without this the install phase
+    # writes the real /usr/local/bin/hermes (fails as non-root on dev
+    # boxes; CI runners happen to have it writable, which masked the gap).
+    monkeypatch.setattr(hp, "HERMES_CLI_INSTALL_PATH", tmp_path / "usr" / "bin" / "hermes")
     monkeypatch.setattr(hp, "OVERRIDES_PATH", tmp_path / "etc" / "hal0" / "overrides.yaml")
     monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path / "etc" / "hal0")
     monkeypatch.setattr(hp, "ETC_HAL0_AGENT_SKILLS", tmp_path / "etc" / "hal0" / "agent-skills")
@@ -59,24 +58,33 @@ def hermetic_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.Bootst
     _dropin_dir = tmp_path / "etc" / "systemd" / "system" / "hermes-gateway.service.d"
     monkeypatch.setattr(hp, "GATEWAY_SYSTEMD_DROPIN_DIR", _dropin_dir)
     monkeypatch.setattr(hp, "GATEWAY_SYSTEMD_DROPIN_FILE", _dropin_dir / "10-hal0-secrets.conf")
-    # Intercept ONLY `systemctl daemon-reload`; everything else passes
-    # through so env_probe / smoke phases behave as before.
-    _real_run = hp.subprocess.run
-
-    class _NoopCompleted:
-        returncode = 0
-        stdout = ""
-        stderr = ""
-
-    def _guarded_run(argv: Any, *a: Any, **kw: Any) -> Any:
-        if isinstance(argv, (list, tuple)) and list(argv[:2]) == ["systemctl", "daemon-reload"]:
-            return _NoopCompleted()
-        return _real_run(argv, *a, **kw)
-
-    monkeypatch.setattr(hp.subprocess, "run", _guarded_run)
     # Personas land under $HERMES_HOME/personas via _personas_root_for —
     # the fixture's hermes_home is already in tmp_path so no further
     # monkey-patching is needed for the persona phase.
+
+    # Wrapper copy needs a source file to exist; just create a stub.
+    wrapper_src = hp.REPO_ROOT_FOR_INSTALLER / "installer" / "wrappers" / "hal0-hermes"
+    wrapper_src.parent.mkdir(parents=True, exist_ok=True)
+    if not wrapper_src.exists():
+        wrapper_src.write_text("#!/bin/sh\nexit 0\n")
+        wrapper_src.chmod(0o755)
+
+    return hp.BootstrapState(
+        venv=str(venv),
+        hermes_home=str(hermes_home),
+        agent_id="hermes-agent",
+    )
+
+
+@pytest.fixture
+def hermetic_io() -> hp.PhaseIO:
+    """Deterministic :class:`hp.PhaseIO` fakes for hermetic pipeline runs.
+
+    Every external touchpoint (HTTP, venv install, MCP probes, memory
+    POSTs) is faked AND stable across calls — a flaky value in `details`
+    would falsely fail the byte-equal assertion (we strip `at`
+    timestamps in the comparison below to side-step the legit one).
+    """
 
     # Stable, ready-looking slot payload — the bootstrap renders aliases
     # only when slots are ``type=llm`` AND ``state=ready``.
@@ -124,17 +132,10 @@ def hermetic_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.Bootst
             },
         ]
 
-    monkeypatch.setattr(hp, "_fetch_slots", _fake_slots)
-    # /v1/models context fetch → empty so per-model context falls back to each
-    # slot's own context_length (set on the fixture), keeping renders offline.
-    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {})
-
     # MCP probes succeed deterministically with a fixed tool list so the
     # provision.json `mcp_wire.details` hash matches across runs.
     def _fake_probe(_url: str, **_kw: Any) -> dict[str, Any]:
         return {"ok": True, "tools": ["t1", "t2", "t3", "t4", "t5"], "error": None}
-
-    monkeypatch.setattr(hp, "_probe_mcp_server", _fake_probe)
 
     # Memory POSTs succeed silently — namespace_register + self_report
     # rely on these.
@@ -148,24 +149,6 @@ def hermetic_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.Bootst
             return {"ok": True, "result": {"deleted": 0}}
         return {"ok": True, "result": {}}
 
-    monkeypatch.setattr(hp, "_mcp_memory_call", _fake_memory_call)
-
-    # env_probe writes a timestamped snapshot file every run — that's
-    # legitimately non-idempotent (it's a point-in-time view). Stub
-    # ``_read_env_probe`` so the snapshot CONTENT is stable across runs
-    # and rely on the test's "ignore env_probe details" filter for the
-    # snapshot path.
-    monkeypatch.setattr(
-        hp,
-        "_read_env_probe",
-        lambda: {
-            "env_report": {"cpu": {"strix_halo": True}},
-            "gpu_target_version": {"gfx": "1151"},
-            "npu_status": {"present": True},
-            "ai_models": {"present": False},
-        },
-    )
-
     # Fake venv install so we don't shell out to ``python -m venv``.
     def _fake_install(v: Path, _req: Path, **_kw: Any) -> None:
         (v / "bin").mkdir(parents=True, exist_ok=True)
@@ -174,19 +157,41 @@ def hermetic_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.Bootst
         (v / "bin" / "python").write_text("#!/bin/sh\nexit 0\n")
         (v / "bin" / "python").chmod(0o755)
 
-    monkeypatch.setattr(hp, "_install_venv", _fake_install)
+    # Intercept ONLY `systemctl daemon-reload`; everything else passes
+    # through so env_probe / smoke phases behave as before.
+    real_run = subprocess.run
 
-    # Wrapper copy needs a source file to exist; just create a stub.
-    wrapper_src = hp.REPO_ROOT_FOR_INSTALLER / "installer" / "wrappers" / "hal0-hermes"
-    wrapper_src.parent.mkdir(parents=True, exist_ok=True)
-    if not wrapper_src.exists():
-        wrapper_src.write_text("#!/bin/sh\nexit 0\n")
-        wrapper_src.chmod(0o755)
+    class _NoopCompleted:
+        returncode = 0
+        stdout = ""
+        stderr = ""
 
-    return hp.BootstrapState(
-        venv=str(venv),
-        hermes_home=str(hermes_home),
-        agent_id="hermes-agent",
+    def _guarded_run(argv: Any, *a: Any, **kw: Any) -> Any:
+        if isinstance(argv, (list, tuple)) and list(argv[:2]) == ["systemctl", "daemon-reload"]:
+            return _NoopCompleted()
+        return real_run(argv, *a, **kw)
+
+    return hp.PhaseIO(
+        http_get=lambda *_a, **_kw: 200,
+        fetch_slots=_fake_slots,
+        # /v1/models context fetch → empty so per-model context falls back
+        # to each slot's own context_length, keeping renders offline.
+        fetch_model_contexts=lambda: {},
+        probe_mcp_server=_fake_probe,
+        mcp_memory_call=_fake_memory_call,
+        install_venv=_fake_install,
+        # env_probe writes a timestamped snapshot file every run — that's
+        # legitimately non-idempotent (it's a point-in-time view). Fake
+        # ``read_env_probe`` so the snapshot CONTENT is stable across runs
+        # and rely on the test's "ignore env_probe details" filter for the
+        # snapshot path.
+        read_env_probe=lambda: {
+            "env_report": {"cpu": {"strix_halo": True}},
+            "gpu_target_version": {"gfx": "1151"},
+            "npu_status": {"present": True},
+            "ai_models": {"present": False},
+        },
+        run=_guarded_run,
     )
 
 
@@ -212,13 +217,15 @@ def _strip_volatile(phases: dict[str, Any]) -> dict[str, Any]:
     return stable
 
 
-def test_two_consecutive_runs_converge(tmp_path: Path, hermetic_state: hp.BootstrapState) -> None:
+def test_two_consecutive_runs_converge(
+    tmp_path: Path, hermetic_state: hp.BootstrapState, hermetic_io: hp.PhaseIO
+) -> None:
     """Run #1 writes everything; run #2 must produce byte-identical
     config.yaml + persona TOMLs + (post-volatile-strip) provision.json."""
     state_root = tmp_path / "state"
 
     # Run #1
-    result_1 = hp.run(state_root=state_root, initial_state=hermetic_state)
+    result_1 = hp.run(state_root=state_root, initial_state=hermetic_state, io=hermetic_io)
     config_path = Path(hermetic_state.hermes_home) / "config.yaml"
     assert config_path.exists()
     config_after_1 = config_path.read_text(encoding="utf-8")
@@ -233,7 +240,7 @@ def test_two_consecutive_runs_converge(tmp_path: Path, hermetic_state: hp.Bootst
     # Run #2 — same state root means BootstrapState.load picks up the
     # checkpoint; phases marked OK get skipped. Even so, the on-disk
     # artefacts (config.yaml, personas) must not change.
-    result_2 = hp.run(state_root=state_root)
+    result_2 = hp.run(state_root=state_root, io=hermetic_io)
     config_after_2 = config_path.read_text(encoding="utf-8")
     hermes_toml_2 = (persona_root / "hermes.toml").read_text(encoding="utf-8")
     coder_toml_2 = (persona_root / "coder.toml").read_text(encoding="utf-8")
@@ -253,7 +260,7 @@ def test_two_consecutive_runs_converge(tmp_path: Path, hermetic_state: hp.Bootst
 
 
 def test_repair_run_rewrites_persona_seeds(
-    tmp_path: Path, hermetic_state: hp.BootstrapState
+    tmp_path: Path, hermetic_state: hp.BootstrapState, hermetic_io: hp.PhaseIO
 ) -> None:
     """``--repair`` overwrites operator persona edits with the seeds.
 
@@ -262,22 +269,22 @@ def test_repair_run_rewrites_persona_seeds(
     survives — see ``test_seed_preserves_operator_edits``.)
     """
     state_root = tmp_path / "state"
-    hp.run(state_root=state_root, initial_state=hermetic_state)
+    hp.run(state_root=state_root, initial_state=hermetic_state, io=hermetic_io)
     persona_path = Path(hermetic_state.hermes_home) / "personas" / "hermes.toml"
     persona_path.write_text('[persona]\nid = "hermes"\ndisplay_name = "Custom"\n', encoding="utf-8")
-    hp.run(state_root=state_root, repair=True)
+    hp.run(state_root=state_root, repair=True, io=hermetic_io)
     reloaded = P.load_persona("hermes", root=persona_path.parent)
     assert reloaded.display_name == "Hermes"
 
 
 def test_config_yaml_contains_persona_prelude(
-    tmp_path: Path, hermetic_state: hp.BootstrapState
+    tmp_path: Path, hermetic_state: hp.BootstrapState, hermetic_io: hp.PhaseIO
 ) -> None:
     """Phase 7 contract: rendered config.yaml carries the active persona's
     system_prompt_prelude. Without this, the agent has no way to see the
     hal0-tone / approval-policy guidance."""
     state_root = tmp_path / "state"
-    hp.run(state_root=state_root, initial_state=hermetic_state)
+    hp.run(state_root=state_root, initial_state=hermetic_state, io=hermetic_io)
     config = (Path(hermetic_state.hermes_home) / "config.yaml").read_text(encoding="utf-8")
     assert "system_prompt_prelude" in config, "Phase 7 didn't inject the persona prelude"
     # Hermes display label lands in the cosmetic personality field.
@@ -285,13 +292,13 @@ def test_config_yaml_contains_persona_prelude(
 
 
 def test_config_yaml_contains_chat_slot_aliases(
-    tmp_path: Path, hermetic_state: hp.BootstrapState
+    tmp_path: Path, hermetic_state: hp.BootstrapState, hermetic_io: hp.PhaseIO
 ) -> None:
     """Phase 5 contract: chat_slots appear in the first render
     (pre-PR-3 they only appeared after Phase 9)."""
     yaml = pytest.importorskip("yaml")
     state_root = tmp_path / "state"
-    hp.run(state_root=state_root, initial_state=hermetic_state)
+    hp.run(state_root=state_root, initial_state=hermetic_state, io=hermetic_io)
     config = (Path(hermetic_state.hermes_home) / "config.yaml").read_text(encoding="utf-8")
     assert "model_aliases:" in config
     assert "chat:" in config
@@ -310,12 +317,12 @@ def test_config_yaml_contains_chat_slot_aliases(
 
 
 def test_config_yaml_contains_mcp_servers(
-    tmp_path: Path, hermetic_state: hp.BootstrapState
+    tmp_path: Path, hermetic_state: hp.BootstrapState, hermetic_io: hp.PhaseIO
 ) -> None:
     """Phase 6 contract: rendered config carries both default MCP servers
     with X-hal0-Agent identity headers."""
     state_root = tmp_path / "state"
-    hp.run(state_root=state_root, initial_state=hermetic_state)
+    hp.run(state_root=state_root, initial_state=hermetic_state, io=hermetic_io)
     config = (Path(hermetic_state.hermes_home) / "config.yaml").read_text(encoding="utf-8")
     assert "mcp_servers:" in config
     assert "hal0-admin:" in config
@@ -324,14 +331,14 @@ def test_config_yaml_contains_mcp_servers(
 
 
 def test_config_yaml_contains_role_slot_blocks(
-    tmp_path: Path, hermetic_state: hp.BootstrapState
+    tmp_path: Path, hermetic_state: hp.BootstrapState, hermetic_io: hp.PhaseIO
 ) -> None:
     """feat/hermes-role-slots: an end-to-end bootstrap renders the
     delegation block from the ``agent`` slot and routes the
     auxiliary compaction group to the ``utility`` slot."""
     yaml = pytest.importorskip("yaml")
     state_root = tmp_path / "state"
-    hp.run(state_root=state_root, initial_state=hermetic_state)
+    hp.run(state_root=state_root, initial_state=hermetic_state, io=hermetic_io)
     config_text = (Path(hermetic_state.hermes_home) / "config.yaml").read_text(encoding="utf-8")
     cfg = yaml.safe_load(config_text)
     # delegation → agent slot model at the hal0 /v1 endpoint.
@@ -364,7 +371,7 @@ def test_config_yaml_contains_role_slot_blocks(
 
 
 def test_namespace_register_skips_add_on_delete_count_mismatch(
-    tmp_path: Path, hermetic_state: hp.BootstrapState, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, hermetic_state: hp.BootstrapState
 ) -> None:
     """#448: when memory_delete reports fewer removals than requested, the
     phase must NOT rewrite the card (avoid duplicate accumulation, #446).
@@ -393,9 +400,10 @@ def test_namespace_register_skips_add_on_delete_count_mismatch(
             return {"ok": True, "result": {"deleted": 0}}
         return {"ok": True, "result": {}}
 
-    monkeypatch.setattr(hp, "_mcp_memory_call", _mismatch_memory_call)
-
-    result = hp._phase_namespace_register(hermetic_state)
+    io = hp.PhaseIO(mcp_memory_call=_mismatch_memory_call)
+    result = hp._phase_namespace_register(
+        hp.context_for("namespace_register", hermetic_state, io=io)
+    )
 
     assert result.status == hp.PhaseStatus.OK
     assert result.details["registered"] is False
@@ -407,7 +415,7 @@ def test_namespace_register_skips_add_on_delete_count_mismatch(
 
 
 def test_namespace_register_rewrites_when_delete_count_matches(
-    tmp_path: Path, hermetic_state: hp.BootstrapState, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, hermetic_state: hp.BootstrapState
 ) -> None:
     """#448 counterpart: when the delete count matches the requested ids,
     the refresh proceeds normally (card re-added, refreshed_existing True)."""
@@ -429,9 +437,10 @@ def test_namespace_register_rewrites_when_delete_count_matches(
             return {"ok": True, "result": {"deleted": 1}}
         return {"ok": True, "result": {}}
 
-    monkeypatch.setattr(hp, "_mcp_memory_call", _matching_memory_call)
-
-    result = hp._phase_namespace_register(hermetic_state)
+    io = hp.PhaseIO(mcp_memory_call=_matching_memory_call)
+    result = hp._phase_namespace_register(
+        hp.context_for("namespace_register", hermetic_state, io=io)
+    )
 
     assert result.status == hp.PhaseStatus.OK
     assert result.details["registered"] is True

--- a/tests/agents/test_hermes_provision_install_artifacts.py
+++ b/tests/agents/test_hermes_provision_install_artifacts.py
@@ -44,7 +44,7 @@ def artifact_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> hp.Bootst
 
 def test_phase_writes_all_three_artifacts(artifact_state: hp.BootstrapState) -> None:
     """A fresh run leaves seed TOML + driver env + runtime.json on disk."""
-    result = hp._phase_install_artifacts(artifact_state)
+    result = hp._phase_install_artifacts(hp.context_for("install_artifacts", artifact_state))
     assert result.status is hp.PhaseStatus.OK
 
     seed_path = hp.INSTALL_SEED_PATH
@@ -77,11 +77,11 @@ def test_phase_writes_all_three_artifacts(artifact_state: hp.BootstrapState) -> 
 def test_token_is_stable_across_reruns(artifact_state: hp.BootstrapState) -> None:
     """Re-running without --repair must NOT rotate the embed token —
     otherwise a re-provision would break a running proxy mid-session."""
-    hp._phase_install_artifacts(artifact_state)
+    hp._phase_install_artifacts(hp.context_for("install_artifacts", artifact_state))
     runtime_path = Path(artifact_state.hermes_home) / hp.RUNTIME_JSON_NAME
     token_1 = json.loads(runtime_path.read_text(encoding="utf-8"))["token"]
 
-    result_2 = hp._phase_install_artifacts(artifact_state)
+    result_2 = hp._phase_install_artifacts(hp.context_for("install_artifacts", artifact_state))
     token_2 = json.loads(runtime_path.read_text(encoding="utf-8"))["token"]
     assert token_1 == token_2
     assert result_2.details["token_wrote"] is False
@@ -89,13 +89,12 @@ def test_token_is_stable_across_reruns(artifact_state: hp.BootstrapState) -> Non
 
 def test_repair_rotates_token(artifact_state: hp.BootstrapState) -> None:
     """``--repair`` explicitly resets to known-good — a fresh token."""
-    hp._phase_install_artifacts(artifact_state)
+    hp._phase_install_artifacts(hp.context_for("install_artifacts", artifact_state))
     runtime_path = Path(artifact_state.hermes_home) / hp.RUNTIME_JSON_NAME
     token_1 = json.loads(runtime_path.read_text(encoding="utf-8"))["token"]
 
-    # Simulate the orchestrator's --repair flag (stashed on state.phases).
-    artifact_state.phases["_repair_flag"] = {"status": "stub", "details": {}}
-    hp._phase_install_artifacts(artifact_state)
+    # The orchestrator's --repair flag arrives via ctx.repair (#702).
+    hp._phase_install_artifacts(hp.context_for("install_artifacts", artifact_state, repair=True))
     token_2 = json.loads(runtime_path.read_text(encoding="utf-8"))["token"]
     assert token_1 != token_2
 
@@ -109,7 +108,7 @@ def test_seed_write_preserves_operator_mcp_servers(artifact_state: hp.BootstrapS
         '[mcp.servers.custom]\nurl = "http://127.0.0.1:9000/mcp"\n',
         encoding="utf-8",
     )
-    hp._phase_install_artifacts(artifact_state)
+    hp._phase_install_artifacts(hp.context_for("install_artifacts", artifact_state))
 
     seed = tomllib.loads(seed_path.read_text(encoding="utf-8"))
     assert seed["mcp"]["servers"]["custom"]["url"] == "http://127.0.0.1:9000/mcp"
@@ -123,7 +122,7 @@ def test_chat_proxy_finds_token_after_provision(
     """End-to-end seam: chat_proxy._load_embed_token() resolves the token
     the install_artifacts phase wrote (previously always None — runtime.json
     had zero writers)."""
-    hp._phase_install_artifacts(artifact_state)
+    hp._phase_install_artifacts(hp.context_for("install_artifacts", artifact_state))
     runtime_path = Path(artifact_state.hermes_home) / hp.RUNTIME_JSON_NAME
     expected = json.loads(runtime_path.read_text(encoding="utf-8"))["token"]
 

--- a/tests/agents/test_hermes_state_render.py
+++ b/tests/agents/test_hermes_state_render.py
@@ -245,11 +245,8 @@ def test_phase_context_link_writes_state_md(tmp_path, monkeypatch):
             }
         )
     )
-    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {"primary": 32768})
-    monkeypatch.setattr(
-        hp,
-        "_fetch_slots",
-        lambda: [
+    io = hp.PhaseIO(
+        fetch_slots=lambda: [
             {
                 "name": "primary",
                 "type": "llm",
@@ -258,11 +255,12 @@ def test_phase_context_link_writes_state_md(tmp_path, monkeypatch):
                 "backend": "vulkan",
             }
         ],
+        fetch_model_contexts=lambda: {"primary": 32768},
     )
     monkeypatch.setattr(hp, "HAL0_BUNDLED_SKILLS", tmp_path / "nope")
 
     state = hp.BootstrapState(hermes_home=str(home))
-    res = hp._phase_context_link(state)
+    res = hp._phase_context_link(hp.context_for("context_link", state, io=io))
     assert res.status == hp.PhaseStatus.OK
     # STATE.md written with the live model.
     assert (tmp_path / "STATE.md").exists()


### PR DESCRIPTION
Closes #702. Interface locked in the 2026-06-12 grilling (CONTEXT.md: PhaseContext, PR #712), with one disclosed deepening where the locked design met reality.

## Summary

All 15 bootstrap phases (docs said 12 — now corrected) take `(ctx: PhaseContext) -> PhaseResult`:

- **`PhaseIO`** — 8 typed IO seams (`http_get`, `fetch_slots`, `fetch_model_contexts`, `probe_mcp_server`, `mcp_memory_call`, `install_venv`, `read_env_probe`, `run`), defaults bound to the real implementations (pinned by test). The fixtures' IO `monkeypatch.setattr` count: **13→5 and 19→11** — every remaining patch is a path/threshold constant (locked decision #3).
- **`PhaseContext`** — read-only state, explicit `repair` (the `_repair_flag` sentinel is deleted: inject/read/strip all gone, pinned by a regression test), and `output_of(name)` which raises `PhaseNeedError` on any undeclared cross-phase read.
- **Declared dependency graph, validated at import** — with one deepening over the locked design: `config_write` reads `mcp_wire` from the **previous run's checkpoint** (mcp_wire runs after it — the PR-3 re-render design), so `Phase` declares `needs` (same-run, target must precede) AND `needs_previous` (cross-run, target must follow; a preceding target fails import as a mislabelled same-run need). Edges: `config_write ⤺prev mcp_wire`, `model_automap→mcp_wire`, `voice_wire→mcp_wire`, `self_report→smoke_tests`.
- **FAIL policy unchanged**: run-all preserved exactly; `completed_at` only when clean.
- **Fallbacks observable, not different**: the four known silent-fallback sites now record `details["fallbacks"]` entries (placeholder primary slot, default MCP inventory, SOUL.md inline default, memory-layer warn-as-OK), each asserted, plus a no-fallbacks-when-live counter-test.
- `docs/agents/hermes-bootstrap.md`: 12→15 phases + needs-graph section.

## Bonus root-cause: the hermes-provision "flaky tests" lore

`test_two_consecutive_runs_converge`'s `install: fail` reproduced on a CLEAN tree: the hermetic fixture never sandboxed `HERMES_CLI_INSTALL_PATH`, so the install phase wrote the real `/usr/local/bin/hermes` — EACCES as non-root on dev boxes, masked on CI's writable runners. Fixed as fixture mechanics. These tests should no longer be treated as environmental.

## Tests

`tests/agents/` 306 passed (285 pre-change) incl. 24 new context/graph tests; idempotency tests unmodified except fixture mechanics; reviewer re-run `tests/agents/ + tests/cli/`: **510 passed, 0 failed**. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)