### PR TITLE
fix(slots): GpuArbiter.ensure_img verifies img readiness before declaring success (#714)

### DIFF
--- a/src/hal0/slots/arbiter.py
+++ b/src/hal0/slots/arbiter.py
@@ -47,6 +47,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from hal0.config import paths
 from hal0.errors import Hal0Error, NotFound
+from hal0.slots.state import SlotState
 
 if TYPE_CHECKING:  # pragma: no cover — import cycle guard (manager owns us)
     from hal0.slots.manager import SlotManager
@@ -64,6 +65,12 @@ _DRAIN_POLL_S = 0.5
 #: Minimum Retry-After hint carried by GpuImageMode (matches the dispatcher's
 #: slot-loading convention in dispatcher/router.py).
 _RETRY_AFTER_FLOOR_S = 15
+
+#: Readiness poll budget after img slot load() returns — containers go
+#: STARTING → WARMING → READY asynchronously; load() only waits for systemd
+#: start, not for the health probe to pass.
+_IMG_READY_TIMEOUT_S = 120.0
+_READY_POLL_S = 0.5
 
 _DEFAULT_STATE: dict[str, Any] = {
     "mode": "llm",
@@ -121,6 +128,19 @@ class ArbiterPinned(Hal0Error):
 
     code = "gpu.pinned"
     status = 409
+
+
+class GpuImgNotReady(Hal0Error):
+    """Image slot did not become ready within the readiness timeout.
+
+    Raised when the img slot fails to reach a dispatchable state after
+    load() returns (e.g. crashed at start with exit 125, or health probe
+    never passed within _IMG_READY_TIMEOUT_S seconds).  Triggers the same
+    rollback as a load() exception so the guard is never left wedged.
+    """
+
+    code = "gpu.img_not_ready"
+    status = 503
 
 
 class GpuArbiter:
@@ -243,12 +263,63 @@ class GpuArbiter:
 
     # ── switches ─────────────────────────────────────────────────────────────
 
+    async def _rollback_to_llm(
+        self, llm_slots: list[str], img_name: str, *, unload_img: bool = False
+    ) -> None:
+        """Best-effort rollback: reload saved LLM set, persist mode=llm.
+
+        Shared by the load()-raises path (D5) and the readiness-timeout path
+        (#714). Always clears mode=img and saved_llm_slots regardless of
+        whether individual slot reloads succeed — the guard must never be
+        left wedged.
+
+        ``unload_img=True`` triggers a best-effort ``unload(img_name)`` first
+        (used by the readiness-timeout path where the container may be
+        crash-looping and holding GTT).  The D5 load()-raises path skips this
+        because load() already failed — nothing was running to unload.
+        """
+        if unload_img:
+            try:
+                await self._manager.unload(img_name)
+            except Exception as exc:  # best-effort — container may be dead
+                log.warning(
+                    "gpu_arbiter.rollback_img_unload_failed",
+                    extra={"img_slot": img_name, "error": str(exc)},
+                )
+        restored: list[str] = []
+        failed: list[str] = []
+        for slot in llm_slots:
+            try:
+                await self._manager.load(slot, None)
+                restored.append(slot)
+            except Exception as rollback_exc:  # best-effort rollback
+                failed.append(slot)
+                log.warning(
+                    "gpu_arbiter.rollback_load_failed",
+                    extra={"slot": slot, "error": str(rollback_exc)},
+                )
+        st = self._load_state()
+        st["mode"] = GpuMode.LLM.value
+        # Failed slots stay offline (operator reloads manually); a
+        # saved set is meaningless in llm mode, so clear it.
+        st["saved_llm_slots"] = []
+        st["pinned"] = False
+        self._persist()
+        log.warning(
+            "gpu_arbiter.img_load_failed_rolled_back",
+            extra={
+                "img_slot": img_name,
+                "restored": restored,
+                "failed": failed,
+            },
+        )
+
     async def ensure_img(self, *, pin: bool = False) -> None:
         """Flip the GPU to exclusive image mode (no-op when already there).
 
         Order (locked): snapshot running llm slots → persist target state
         FIRST → drain in-flight requests (bounded) → unload llm slots →
-        load the img slot's default model → stamp activity.
+        load the img slot's default model → poll for readiness → stamp activity.
         """
         async with self._switch_lock:
             st = self._load_state()
@@ -309,42 +380,59 @@ class GpuArbiter:
             try:
                 await self._manager.load(img_name, model_default or None)
             except Exception:
-                # D5 quality-gate I1: at this point the llm slots are already
-                # unloaded and mode=img is persisted. If we re-raised without
-                # rolling back, the guard would 503 ALL llm traffic and the
-                # mode==IMG no-op fast path above would swallow every retry
-                # without re-attempting the img load — a wedge with no
-                # automated escape (D6 idle-restore is not wired yet).
-                # Rollback: best-effort reload of the saved llm set, then
-                # ALWAYS persist mode=llm (even when rollback loads fail —
-                # the guard must never stay wedged), then re-raise.
-                restored: list[str] = []
-                failed: list[str] = []
-                for slot in llm_slots:
-                    try:
-                        await self._manager.load(slot, None)
-                        restored.append(slot)
-                    except Exception as rollback_exc:  # best-effort rollback
-                        failed.append(slot)
-                        log.warning(
-                            "gpu_arbiter.rollback_load_failed",
-                            extra={"slot": slot, "error": str(rollback_exc)},
-                        )
-                st["mode"] = GpuMode.LLM.value
-                # Failed slots stay offline (operator reloads manually); a
-                # saved set is meaningless in llm mode, so clear it.
-                st["saved_llm_slots"] = []
-                st["pinned"] = False
-                self._persist()
-                log.warning(
-                    "gpu_arbiter.img_load_failed_rolled_back",
-                    extra={
-                        "img_slot": img_name,
-                        "restored": restored,
-                        "failed": failed,
-                    },
-                )
+                # D5 quality-gate I1: load() raised — rollback, then re-raise
+                # the ORIGINAL load exception so callers see the root cause.
+                await self._rollback_to_llm(llm_slots, img_name, unload_img=False)
                 raise
+
+            # #714: load() only waits for systemd start, not health-probe
+            # completion (containers go STARTING → WARMING → READY async).
+            # Poll until the slot reaches a dispatchable state or we time out.
+            # Call state() exactly once per iteration — terminal states
+            # (ERROR/OFFLINE) abort the poll immediately so we don't burn the
+            # full 120s on a crash-at-start.
+            _TERMINAL: frozenset[SlotState] = frozenset({SlotState.ERROR, SlotState.OFFLINE})
+            _DISPATCHABLE: frozenset[SlotState] = frozenset(
+                {SlotState.READY, SlotState.SERVING, SlotState.IDLE}
+            )
+            ready_deadline = time.monotonic() + _IMG_READY_TIMEOUT_S
+            img_slot_state: SlotState | str = SlotState.WARMING
+            while True:
+                img_slot_state = self._manager.state(img_name)
+                if img_slot_state in _DISPATCHABLE:
+                    break
+                if img_slot_state in _TERMINAL:
+                    log.warning(
+                        "gpu_arbiter.img_terminal_state_during_readiness",
+                        extra={"img_slot": img_name, "state": str(img_slot_state)},
+                    )
+                    await self._rollback_to_llm(llm_slots, img_name, unload_img=True)
+                    raise GpuImgNotReady(
+                        f"img slot {img_name!r} reached terminal state "
+                        f"{img_slot_state!r} after load; rolled back to LLM mode",
+                        details={"slot": img_name, "state": str(img_slot_state)},
+                    )
+                if time.monotonic() >= ready_deadline:
+                    log.warning(
+                        "gpu_arbiter.img_readiness_timeout",
+                        extra={
+                            "img_slot": img_name,
+                            "timeout_s": _IMG_READY_TIMEOUT_S,
+                            "state": str(img_slot_state),
+                        },
+                    )
+                    await self._rollback_to_llm(llm_slots, img_name, unload_img=True)
+                    raise GpuImgNotReady(
+                        f"img slot {img_name!r} did not become ready within "
+                        f"{_IMG_READY_TIMEOUT_S}s (last state: {img_slot_state!r}); "
+                        f"rolled back to LLM mode",
+                        details={
+                            "slot": img_name,
+                            "timeout_s": _IMG_READY_TIMEOUT_S,
+                            "state": str(img_slot_state),
+                        },
+                    )
+                await asyncio.sleep(_READY_POLL_S)
 
             # last_img_activity was stamped in the pre-unload persist above;
             # no second persist needed here (spec-review tidy).

--- a/tests/dispatcher/test_arbiter_dispatch.py
+++ b/tests/dispatcher/test_arbiter_dispatch.py
@@ -207,7 +207,16 @@ def _wire_image_app(
     )
     monkeypatch.setattr(manager, "is_ready_for_dispatch", lambda name: name == "chat")
     unload = AsyncMock()
-    load = AsyncMock()
+    # ensure_img polls state() for readiness after load (#714) — a mocked load
+    # must therefore make the slot report READY, as a real load would.
+    loaded: set[str] = set()
+    load = AsyncMock(side_effect=lambda slot_name, model=None: loaded.add(slot_name))
+    real_state = manager.state
+    monkeypatch.setattr(
+        manager,
+        "state",
+        lambda name: SlotState.READY if name in loaded else real_state(name),
+    )
     monkeypatch.setattr(manager, "unload", unload)
     monkeypatch.setattr(manager, "load", load)
     infer = AsyncMock(return_value=_FAKE_INFER_RESULT)

--- a/tests/slots/test_gpu_arbiter.py
+++ b/tests/slots/test_gpu_arbiter.py
@@ -24,6 +24,7 @@ from typing import Any
 import pytest
 
 import hal0.slots.arbiter as arbiter_mod
+from hal0.errors import Hal0Error
 from hal0.slots.arbiter import (
     ArbiterPinned,
     GpuArbiter,
@@ -96,6 +97,7 @@ class FakeManager:
         *,
         ready: set[str] | None = None,
         in_flight: dict[str, Any] | None = None,
+        slot_states: dict[str, Any] | None = None,
     ) -> None:
         self.configs = configs if configs is not None else _base_configs()
         self.ready: set[str] = set(ready or {"chat", "agent", "npu", "tts"})
@@ -104,6 +106,10 @@ class FakeManager:
         self.poll_log: list[tuple[str, int]] = []
         self.on_unload = None  # optional hook(name) fired before recording
         self.fail_loads: set[str] = set()  # load(name) raises for these slots
+        # slot_states: name → str or list[str] of states consumed per state()
+        # poll (last entry sticks). When set for a slot, load() does NOT
+        # auto-add to ready — the caller drives state via the sequence.
+        self.slot_states: dict[str, Any] = dict(slot_states or {})
 
     async def iter_configs(self) -> list[dict[str, Any]]:
         return [dict(c) for c in self.configs]
@@ -112,6 +118,13 @@ class FakeManager:
         return name in self.ready
 
     def state(self, name: str) -> str:
+        if name in self.slot_states:
+            val = self.slot_states[name]
+            if isinstance(val, list):
+                s = str(val.pop(0)) if len(val) > 1 else str(val[0])
+            else:
+                s = str(val)
+            return s
         return "ready" if name in self.ready else "offline"
 
     def in_flight_count(self, name: str) -> int:
@@ -128,7 +141,10 @@ class FakeManager:
             self.calls.append(("load_failed", name, model_id))
             raise RuntimeError(f"load failed: {name}")
         self.calls.append(("load", name, model_id))
-        self.ready.add(name)
+        # Only auto-add to ready when not scripted via slot_states (the
+        # slot_states dict drives the readiness sequence for that slot).
+        if name not in self.slot_states:
+            self.ready.add(name)
 
     async def unload(self, name: str) -> None:
         if self.on_unload is not None:
@@ -812,3 +828,134 @@ async def test_zero_window_from_toml_never_auto_restores(tmp_hal0_home: str) -> 
         assert not task.done()
     finally:
         await _cancel_loop(task)
+
+
+# ── img readiness poll after load (#714) ────────────────────────────────────
+
+
+async def test_img_never_ready_rolls_back_on_timeout(
+    fake_mgr: FakeManager,
+    state_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """load() succeeds but img slot never reaches READY within the timeout →
+    rollback fires: saved llm slots reloaded, mode=llm persisted, img
+    best-effort unloaded, new Hal0Error with code gpu.img_not_ready raised."""
+    # img state stays "warming" forever — simulate crash-at-start that never
+    # transitions away from WARMING (or a stuck container).
+    fake_mgr.slot_states = {"img": "warming"}
+    monkeypatch.setattr(arbiter_mod, "_IMG_READY_TIMEOUT_S", 0.05)
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+
+    with (
+        caplog.at_level(logging.WARNING, logger="hal0.slots.arbiter"),
+        pytest.raises(Hal0Error) as ei,
+    ):
+        await arb.ensure_img()
+
+    # New error, correct code
+    assert ei.value.code == "gpu.img_not_ready"
+
+    # img unloaded (best-effort) then llm set reloaded
+    assert ("unload", "img") in fake_mgr.calls
+    assert ("load", "chat", None) in fake_mgr.calls
+    assert ("load", "agent", None) in fake_mgr.calls
+
+    # mode rolled back to llm
+    assert arb.mode is GpuMode.LLM
+    final = _read_state(state_path)
+    assert final["mode"] == "llm"
+    assert final["saved_llm_slots"] == []
+    assert final["pinned"] is False
+
+    # guard is not wedged
+    arb.guard_llm_dispatch("chat")
+
+    # retry after rollback re-attempts the full switch
+    fake_mgr.slot_states = {}  # next time img goes ready immediately via load()
+    fake_mgr.calls.clear()
+    await arb.ensure_img()
+    assert arb.mode is GpuMode.IMG
+
+
+async def test_img_eventually_ready_succeeds(
+    fake_mgr: FakeManager,
+    state_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """img is WARMING for first N polls then READY → ensure_img succeeds,
+    no rollback, mode stays img."""
+    fake_mgr.slot_states = {"img": ["warming", "warming", "ready"]}
+    monkeypatch.setattr(arbiter_mod, "_IMG_READY_TIMEOUT_S", 5.0)
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+
+    await arb.ensure_img()
+
+    assert arb.mode is GpuMode.IMG
+    # img loaded exactly once, no rollback loads
+    assert fake_mgr.calls[-1] == ("load", "img", "sdxl-turbo")
+    rollback_calls = [c for c in fake_mgr.calls if c[0] == "load" and c[1] in {"chat", "agent"}]
+    assert rollback_calls == []
+    final = _read_state(state_path)
+    assert final["mode"] == "img"
+
+
+async def test_img_terminal_error_rolls_back_immediately(
+    fake_mgr: FakeManager,
+    state_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """img reaches ERROR state → rollback fires without burning the full
+    timeout; saved llm set reloaded, gpu.img_not_ready raised."""
+    # ERROR is terminal — arbiter must abort the poll immediately.
+    fake_mgr.slot_states = {"img": ["warming", "error"]}
+    # Set a generous timeout; the test must not need to wait for it.
+    monkeypatch.setattr(arbiter_mod, "_IMG_READY_TIMEOUT_S", 30.0)
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+
+    import time as _time
+
+    start = _time.monotonic()
+    with (
+        caplog.at_level(logging.WARNING, logger="hal0.slots.arbiter"),
+        pytest.raises(Hal0Error) as ei,
+    ):
+        await arb.ensure_img()
+    elapsed = _time.monotonic() - start
+
+    # Must finish well under the 30s timeout (should be near-instant).
+    assert elapsed < 2.0, f"terminal-error abort took too long: {elapsed:.2f}s"
+    assert ei.value.code == "gpu.img_not_ready"
+
+    assert arb.mode is GpuMode.LLM
+    assert _read_state(state_path)["mode"] == "llm"
+    assert ("unload", "img") in fake_mgr.calls
+    assert ("load", "chat", None) in fake_mgr.calls
+    assert ("load", "agent", None) in fake_mgr.calls
+    arb.guard_llm_dispatch("chat")  # not wedged
+
+
+async def test_existing_load_raises_rollback_still_works(
+    fake_mgr: FakeManager,
+    state_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Existing D5 path: load() RAISES → original RuntimeError propagates.
+    The rollback helper extraction must not break the pre-existing behavior."""
+    fake_mgr.fail_loads = {"img"}
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+
+    with (
+        caplog.at_level(logging.WARNING, logger="hal0.slots.arbiter"),
+        pytest.raises(RuntimeError, match="load failed: img"),
+    ):
+        await arb.ensure_img()
+
+    # rollback executed
+    assert any("img_load_failed_rolled_back" in rec.message for rec in caplog.records)
+    assert arb.mode is GpuMode.LLM
+    assert _read_state(state_path)["mode"] == "llm"
+    assert _read_state(state_path)["saved_llm_slots"] == []
+    arb.guard_llm_dispatch("chat")


### PR DESCRIPTION
## Summary
- `GpuArbiter.ensure_img` declared success once the ComfyUI container *started*, so a crash-at-start never fired rollback and the GPU stayed wedged in image mode (#714)
- it now polls img slot readiness (bounded by `_IMG_READY_TIMEOUT_S`): ready → success; never-ready timeout → rollback to inference mode; terminal slot error → immediate rollback

## Test plan
- 3 new TDD tests: `test_img_never_ready_rolls_back_on_timeout`, `test_img_eventually_ready_succeeds`, `test_img_terminal_error_rolls_back_immediately`
- `tests/slots/test_gpu_arbiter.py`: 30/30 pass

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)