### PR TITLE
providers: add podman --replace to container argv builders (#721)

### DIFF
--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -191,6 +191,10 @@ def _render_unit(
         "run",
         "--rm",
         f"--name={container_name}",
+        # Unclean shutdown leaves a stale same-name container record (--rm
+        # never ran) → exit 125 "name already in use" at next boot (#721).
+        # --replace removes it first; no-op when no stale record exists.
+        "--replace",
     ]
     # Explicit GPU device nodes (podman won't recurse the /dev/dri directory).
     for dev in devices:
@@ -278,6 +282,8 @@ def _render_unit_from_spec(
         "run",
         "--rm",
         f"--name={container_name}",
+        # Stale same-name record after unclean shutdown → exit 125 (#721).
+        "--replace",
     ]
     if spec.network_mode:
         argv.append(f"--network={spec.network_mode}")

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -126,6 +126,26 @@ class TestRenderUnit:
         exec_start = self._get_exec_start(unit)
         assert exec_start.startswith(f"{_TEST_RUNTIME} run")
 
+    def test_replace_flag_clears_stale_container_records(self) -> None:
+        """An unclean shutdown leaves a stale container record with the slot
+        name (``--rm`` never ran), so the next boot fails with podman exit 125
+        "name already in use" (#721). ``--replace`` removes any pre-existing
+        same-name container before starting; no-op when none exists."""
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        tokens = shlex.split(self._get_exec_start(unit))
+        assert "--replace" in tokens, f"--replace missing from argv: {tokens}"
+        # Must follow --name so the pairing is obvious in the rendered unit.
+        assert tokens.index("--replace") == tokens.index("--name=hal0-slot-test-slot") + 1
+
     def test_identical_path_mount_readonly(self) -> None:
         """Model store must be mounted at /mnt/ai-models:ro (identical path)."""
         profile = _moe_profile()

--- a/tests/providers/test_container_npu.py
+++ b/tests/providers/test_container_npu.py
@@ -79,6 +79,14 @@ class TestRenderUnitFromSpec:
         unit = _render_unit_from_spec("npu", _flm_spec(), runtime_bin=_TEST_RUNTIME)
         assert "--name=hal0-slot-npu" in unit
 
+    def test_replace_flag_clears_stale_container_records(self) -> None:
+        """Spec-rendered units need ``--replace`` too — same #721 boot race as
+        the llama-server builder (stale name record after unclean shutdown)."""
+        unit = _render_unit_from_spec("npu", _flm_spec(), runtime_bin=_TEST_RUNTIME)
+        argv = _exec_start(unit)
+        assert "--replace" in argv, f"--replace missing from argv: {argv}"
+        assert argv.index("--replace") == argv.index("--name=hal0-slot-npu") + 1
+
     def test_security_opts_included(self) -> None:
         unit = _render_unit_from_spec("npu", _flm_spec(), runtime_bin=_TEST_RUNTIME)
         argv = _exec_start(unit)


### PR DESCRIPTION
## Summary
- Add `--replace` immediately after `--name=…` in both podman-run argv builders in `src/hal0/providers/container.py` (`_render_unit` and `_render_unit_from_spec`).
- After an unclean shutdown (e.g. the 2026-06-11 pve watchdog reset), `--rm` never runs and stale container records survive into the next boot; every `hal0-slot@` unit then fails deterministically with exit 125 "name already in use" until `StartLimitBurst=5` is exhausted. `--replace` is podman's official answer: remove any pre-existing same-name container before starting, no-op otherwise.

## Test plan
- [x] TDD: new tests `test_replace_flag_clears_stale_container_records` in `tests/providers/test_container.py` and `tests/providers/test_container_npu.py` — watched both fail (flag missing) before the fix, pass after.
- [x] Full `tests/providers/` suite: 240 passed.
- [x] `tests/systemd/` + `tests/openwebui/test_prewire_smoke.py` (the other suites asserting on rendered units): 27 passed, 1 skipped.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Post-deploy on CT105: re-render deployed units (per-slot API reload), then plant a stale record (`podman create --name hal0-slot-X …`) and confirm the unit starts cleanly.

Fixes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)