### PR TITLE
v1: guard the route-level lazy-load against exclusive image mode

### DIFF
--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -387,6 +387,15 @@ async def _ensure_backend_for_model(request: Request, body: dict[str, Any]) -> N
     if slot_name is None:
         # No backing chat slot — nothing to honor.
         return
+    # D4 (route-level): NEVER lazy-load an LLM back onto the GPU while the
+    # arbiter holds exclusive image mode — that fights the arbiter and
+    # resurrects the slot it just drained. Raise the structured
+    # ``gpu.image_mode`` 503 (Retry-After via the error middleware), the
+    # same envelope the dispatch guard emits for raw model ids. NOT
+    # swallowed by the best-effort block below — the guard is the outcome.
+    arbiter = getattr(slot_manager, "arbiter", None)
+    if arbiter is not None:
+        arbiter.guard_llm_dispatch(slot_name)
     try:
         await slot_manager.load(slot_name)
     except Exception as exc:

--- a/tests/api/test_v1_backend_aware_load.py
+++ b/tests/api/test_v1_backend_aware_load.py
@@ -152,3 +152,39 @@ def test_dispatch_proceeds_even_if_backend_aware_load_fails(
     assert r.json()["error"]["code"] == "dispatch.no_route"
     assert sm.loaded == ["agent-hermes"]  # load was attempted
     assert order.index(("load", "agent-hermes")) < order.index("dispatch")
+
+
+class _ImageModeArbiter:
+    """Stands in for GpuArbiter while mode == img."""
+
+    def guard_llm_dispatch(self, slot_name: str) -> None:
+        from hal0.slots.arbiter import GpuImageMode
+
+        raise GpuImageMode(
+            f"GPU is in exclusive image mode; LLM slot {slot_name!r} is "
+            "unavailable until image mode ends",
+            details={"slot": slot_name, "retry_after_s": 300},
+        )
+
+
+def test_alias_load_refused_during_image_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D4 (route-level): the backend-aware lazy-load must NEVER pull an LLM
+    back onto the GPU while the arbiter holds exclusive image mode.
+
+    An alias-addressed chat request during image mode surfaces the
+    structured ``gpu.image_mode`` 503 — same envelope dispatch emits for
+    raw model ids — instead of kicking ``SlotManager.load`` into a fight
+    with the arbiter.
+    """
+    sm = _RecordingSlotManager()
+    sm.arbiter = _ImageModeArbiter()
+
+    r, order = _run_chat(monkeypatch, sm, model="utility")
+
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert body["error"]["code"] == "gpu.image_mode", body
+    assert sm.loaded == [], f"load must not fire during image mode: {sm.loaded}"
+    assert "dispatch" not in order, "dispatch must not be entered either"


### PR DESCRIPTION
Found during the Phase E destructive-deploy e2e on CT105: `POST /v1/chat/completions` with an alias model (`chat`/`agent`/`utility`) during exclusive image mode hung ~15s and loaded the LLM container back INTO image mode, because `_ensure_backend_for_model` (#430) kicks `SlotManager.load` at the route layer before dispatch — bypassing the arbiter guard that protects raw model ids (which correctly 503 in 0.06s).

Fix: run `arbiter.guard_llm_dispatch(slot)` before the lazy-load, surfacing the same structured `gpu.image_mode` 503 + Retry-After. TDD: red test asserts no load and no dispatch entry during image mode.

Pre-existing seam (not a Phase E regression — same code path on 036e399); D4 guarded dispatch + dead-port recovery but not this entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)