### PR TITLE
Resident ComfyUI container: switchover swaps GPU memory, not the process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ graphify-out/.rebuild.lock
 
 # knowledge graph — local-only, regenerated + served to Hermes via graphify MCP on CT105 (not committed; was 100k-line PR churn)
 graphify-out/
+.claude/branch-status.json

--- a/installer/comfyui/custom_nodes/hal0_gpu_gate.py
+++ b/installer/comfyui/custom_nodes/hal0_gpu_gate.py
@@ -1,0 +1,109 @@
+"""hal0 GPU gate — ComfyUI custom node that 403-blocks job submission while
+the Strix Halo iGPU is serving the LLM stack.
+
+The ComfyUI container is RESIDENT on hal0 (its web UI stays up in both GPU
+modes so users can build workflows/prompts any time), but GPU memory is
+exclusive: running a generation while the LLM slots hold GTT would OOM or
+evict them. hal0-api's GpuArbiter guards its own dispatch path, and this
+middleware closes the remaining door — the web UI's own "Queue Prompt"
+(``POST /prompt`` / ``POST /api/prompt``), which goes straight to ComfyUI.
+
+Deployment: this single file is dropped into the host-mounted
+``custom_nodes`` dir (``/mnt/ai-models/comfyui/custom_nodes/``) — no image
+rebuild. ComfyUI imports it at startup; ``_install()`` appends an aiohttp
+middleware to the PromptServer app (the same mechanism ComfyUI-Login uses).
+The container runs with host networking, so hal0-api is on loopback.
+
+Fail-open by design: if hal0-api is unreachable the gate allows the prompt —
+a broken hal0 must never brick standalone ComfyUI use. The pure decision
+logic (``should_block``) is unit-tested in the hal0 repo
+(tests/comfyui/test_hal0_gpu_gate.py); the aiohttp wiring is exercised by
+the CT105 live verification.
+"""
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+#: hal0-api status aggregator; its top-level ``mode`` is arbiter-truth
+#: ("generation" | "inference").
+HAL0_STATUS_URL = os.environ.get(
+    "HAL0_COMFYUI_STATUS_URL", "http://127.0.0.1:8080/api/comfyui/status"
+)
+_STATUS_TIMEOUT_S = 2.0
+
+#: Job-submission routes — and ONLY those. Everything the editor needs
+#: (/object_info, /queue GET, workflow save/load, uploads) always passes.
+_BLOCK_PATHS = frozenset({"/prompt", "/api/prompt"})
+
+#: Mirrors ComfyUI's own /prompt error envelope so the frontend renders the
+#: message instead of a generic failure toast.
+GATE_BODY = {
+    "error": {
+        "type": "hal0_gpu_gate",
+        "message": (
+            "The GPU is in inference mode (LLM slots loaded). Flip the "
+            "Image Gen switch in the hal0 dashboard, then queue again."
+        ),
+        "details": "hal0 GpuArbiter mode is 'inference'; generation is gated.",
+        "extra_info": {},
+    },
+    "node_errors": {},
+}
+
+
+def should_block(method: str, path: str, status: "dict | None") -> bool:
+    """True iff this request is a job submission while the GPU serves LLMs.
+
+    ``status`` is hal0-api's /api/comfyui/status JSON (or None when
+    unreachable / unparseable → fail-open).
+    """
+    if method != "POST" or path not in _BLOCK_PATHS:
+        return False
+    if not isinstance(status, dict):
+        return False
+    return status.get("mode") == "inference"
+
+
+def _fetch_status() -> "dict | None":
+    """Blocking status fetch via urllib (run in a thread by the middleware).
+
+    stdlib-only on purpose: custom nodes can't assume extra deps in the
+    ComfyUI venv.
+    """
+    try:
+        with urllib.request.urlopen(HAL0_STATUS_URL, timeout=_STATUS_TIMEOUT_S) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        return data if isinstance(data, dict) else None
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+
+
+def _install() -> None:
+    """Attach the gate middleware to ComfyUI's PromptServer (fail-soft)."""
+    try:
+        import asyncio
+
+        from aiohttp import web
+        from server import PromptServer
+
+        @web.middleware
+        async def hal0_gpu_gate_middleware(request, handler):
+            if request.method == "POST" and request.path in _BLOCK_PATHS:
+                status = await asyncio.to_thread(_fetch_status)
+                if should_block(request.method, request.path, status):
+                    return web.json_response(GATE_BODY, status=403)
+            return await handler(request)
+
+        PromptServer.instance.app.middlewares.append(hal0_gpu_gate_middleware)
+        print(f"[hal0_gpu_gate] /prompt gated on hal0 GPU mode ({HAL0_STATUS_URL})")
+    except Exception as exc:  # outside ComfyUI (unit tests) or API drift
+        print(f"[hal0_gpu_gate] not installed: {exc}")
+
+
+_install()
+
+# ComfyUI custom-node import contract — this node adds no graph nodes.
+NODE_CLASS_MAPPINGS = {}
+NODE_DISPLAY_NAME_MAPPINGS = {}

--- a/installer/etc-hal0/slots/img.toml
+++ b/installer/etc-hal0/slots/img.toml
@@ -1,6 +1,9 @@
 # hal0 image-generation slot — ComfyUI in a podman container (hal0-slot@img).
-# Exclusive-GPU slot: the GpuArbiter stops LLM GPU slots while img runs and
-# restores them after [image].idle_restore_minutes with no jobs (spec §7).
+# Resident container: once loaded it stays up across modes so the web UI is
+# always reachable for workflow building. The GpuArbiter only swaps what
+# holds GPU memory — LLM slots are unloaded while generation is active, and
+# ComfyUI's models are freed (POST /free) when LLM slots come back after
+# [image].idle_restore_minutes with no jobs (spec §7).
 
 name = "img"
 type = "image"
@@ -15,6 +18,6 @@ port = 8188
 default = "sdxl-turbo"
 
 [image]                       # persisted image-gen settings (#599)
-idle_restore_minutes = 5
+idle_restore_minutes = 60
 default_size = "1024x1024"
 default_steps = 0

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -880,7 +880,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # GpuArbiter idle-restore loop (Phase D, Task D6). Auto-restores the
     # saved LLM set after the img (ComfyUI) slot idles out — window from the
-    # img slot's ``[image].idle_restore_minutes`` (default 5; 0 = manual-only).
+    # img slot's ``[image].idle_restore_minutes`` (default 60; 0 = manual-only).
     # Mirrors the refresh_task pattern above: created at startup, cancelled +
     # awaited on shutdown via the AsyncExitStack. Guarded so an arbiter
     # construction failure never blocks API startup (omni-router precedent).

--- a/src/hal0/api/routes/comfyui.py
+++ b/src/hal0/api/routes/comfyui.py
@@ -16,8 +16,10 @@ and a dead container must surface as "stopped", never a 500.
 
 The switchover *write* path (``POST /api/comfyui/switchover``) drives the
 SlotManager's :class:`~hal0.slots.arbiter.GpuArbiter` (Phase D): generation →
-``ensure_img(pin=...)`` (drain the llm GPU group, load the img slot), inference
-→ ``restore_llm(force=...)`` (unload img, reload the saved llm slots). It runs
+``ensure_img(pin=...)`` (drain + unload the llm GPU group; the resident
+ComfyUI container is only cold-started when it is down), inference →
+``restore_llm(force=...)`` (free ComfyUI's models via POST /free — the
+container and its web UI stay up — then reload the saved llm slots). It runs
 in the background behind a 202; the ``switchover`` block on /status tracks the
 transition. The API no longer shells out — the ``/opt/comfyui`` control scripts
 stay on disk for manual ops only. ``POST /api/comfyui/pin`` toggles the
@@ -341,7 +343,9 @@ async def comfyui_status(request: Request) -> dict[str, Any]:
         "reachable": reachable,
         "engine": engine,
         "container": {"name": container_name, "state": container},
-        "endpoint": ":8188" if mode == "generation" else None,
+        # Resident container: the web UI is usable whenever ComfyUI answers,
+        # regardless of which mode owns the GPU memory.
+        "endpoint": ":8188" if (reachable or mode == "generation") else None,
         "memory": _parse_memory(stats),
         "queue": counts,
         "inference": {"hermes": hermes},
@@ -460,9 +464,10 @@ async def comfyui_switchover(request: Request, background_tasks: BackgroundTasks
         already_there = container == "running" if mode == "generation" else container != "running"
     if already_there:
         return JSONResponse(status_code=200, content={"status": "noop", "mode": mode})
-    # Mid-render guard: switching to inference stops the container, dropping any
-    # running/pending renders. Refuse unless the caller forces it — the dashboard
-    # confirm dialog states the blast radius and passes force on user confirm.
+    # Mid-render guard: switching to inference frees ComfyUI's models from GPU
+    # memory, killing any running/pending renders (the container itself stays
+    # up). Refuse unless the caller forces it — the dashboard confirm dialog
+    # states the blast radius and passes force on user confirm.
     force = bool(body.get("force")) if isinstance(body, dict) else False
     if mode == "inference" and not force:
         counts = _queue_counts(await _fetch_json("/queue"))

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -395,7 +395,7 @@ async def _ensure_backend_for_model(request: Request, body: dict[str, Any]) -> N
     # swallowed by the best-effort block below — the guard is the outcome.
     arbiter = getattr(slot_manager, "arbiter", None)
     if arbiter is not None:
-        arbiter.guard_llm_dispatch(slot_name)
+        arbiter.guard_dispatch(slot_name)
     try:
         await slot_manager.load(slot_name)
     except Exception as exc:

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -207,7 +207,7 @@ class ImageGenConfig(BaseModel):
     model_config = {"extra": "forbid"}
 
     idle_restore_minutes: int = Field(
-        default=5,
+        default=60,
         ge=0,
         description=(
             "Minutes of img-slot job inactivity before the GpuArbiter "

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -716,7 +716,7 @@ class Dispatcher:
     def _guard_gpu_image_mode(self, call: UpstreamCall) -> None:
         """Refuse llm-group dispatch while the GPU is in exclusive image mode.
 
-        Delegates to :meth:`GpuArbiter.guard_llm_dispatch`, which raises the
+        Delegates to :meth:`GpuArbiter.guard_dispatch`, which raises the
         typed ``GpuImageMode`` (503, code ``gpu.image_mode``, details carry
         ``retry_after_s``) for llm-group slots and no-ops for everything
         else (img slot itself, NPU/CPU slots, remote upstreams).
@@ -730,7 +730,7 @@ class Dispatcher:
         arbiter = getattr(self._slot_manager, "arbiter", None)
         if arbiter is None:
             return
-        arbiter.guard_llm_dispatch(call.slot_name or call.container_slot_name)
+        arbiter.guard_dispatch(call.slot_name or call.container_slot_name)
 
     async def _ensure_slot_loaded_backend_aware(self, call: UpstreamCall) -> None:
         """Kick a backend-aware load on a cold miss before forwarding.
@@ -854,7 +854,7 @@ class Dispatcher:
             # Raises GpuImageMode for llm-group slots while mode == img;
             # no-op otherwise. Covers the race where the arbiter flipped
             # to img (and force-killed the container) mid-request.
-            arbiter.guard_llm_dispatch(call.slot_name)
+            arbiter.guard_dispatch(call.slot_name)
 
     def _build_loading_response(
         self,

--- a/src/hal0/slots/arbiter.py
+++ b/src/hal0/slots/arbiter.py
@@ -11,6 +11,20 @@ Groups are DERIVED from slot configs (:func:`gpu_exclusive_group`), never
 declared: a slot is arbitrated iff it runs on the GPU (``gpu-rocm`` /
 ``gpu-vulkan``) AND in a container. NPU and CPU slots are never arbitrated.
 
+Resident-container design: what is exclusive is the GPU **memory** (LLM
+weights vs diffusion models), NOT the ComfyUI process — an idle ComfyUI
+holds ~0 GTT on unified memory, and its web UI must stay reachable in llm
+mode so users can build workflows before flipping the switch. So the
+arbiter never stops the img container once it is up:
+
+  - ``ensure_img``  — drain + unload the llm set; the img container is only
+    (cold-)started when it isn't already dispatchable.
+  - ``restore_llm`` — ``POST /free`` to ComfyUI (drop its models from GTT),
+    then reload the saved llm set. The container keeps serving the UI.
+  - actually *running* a generation in llm mode is refused at three gates:
+    the dispatch guard (``guard_dispatch``), and ComfyUI's own ``/prompt``
+    via the host-mounted ``hal0_gpu_gate`` custom node (403).
+
 Crash-recovery ordering (locked): the arbiter persists its target state to
 ``/var/lib/hal0/gpu_arbiter.json`` BEFORE the first unload, so an api
 restart mid-switch can still restore the saved LLM set.
@@ -19,7 +33,7 @@ Concurrency model (single asyncio event loop):
 
   - ``ensure_img()`` / ``restore_llm()`` — the only mutating switches —
     serialize on one ``asyncio.Lock``; concurrent flips are impossible.
-  - ``guard_llm_dispatch()`` / ``status()`` / ``touch_img_activity()`` /
+  - ``guard_dispatch()`` / ``status()`` / ``touch_img_activity()`` /
     ``set_pin()`` are synchronous and lock-free. This is safe because they
     contain no ``await`` points: on a single event loop a sync method runs
     to completion atomically relative to the (async) switch methods, which
@@ -71,6 +85,74 @@ _RETRY_AFTER_FLOOR_S = 15
 _IMG_READY_TIMEOUT_S = 120.0
 _READY_POLL_S = 0.5
 
+#: Slot states that can take a dispatch / mean "the img container is up".
+_DISPATCHABLE: frozenset[SlotState] = frozenset(
+    {SlotState.READY, SlotState.SERVING, SlotState.IDLE}
+)
+#: Terminal states that abort the readiness poll immediately.
+_TERMINAL: frozenset[SlotState] = frozenset({SlotState.ERROR, SlotState.OFFLINE})
+
+#: ComfyUI HTTP budget — short connect so a dead engine surfaces fast.
+_COMFYUI_HTTP_TIMEOUT_S = 5.0
+_COMFYUI_CONNECT_TIMEOUT_S = 1.5
+
+
+def _comfyui_base_url() -> str:
+    """Operational ComfyUI HTTP base (mirrors api/routes/comfyui.py).
+
+    Duplicated on purpose: the slots layer must not import the API layer.
+    """
+    return os.environ.get("COMFYUI_BASE_URL", "http://127.0.0.1:8188").rstrip("/")
+
+
+async def _comfyui_free() -> bool:
+    """Best-effort ``POST /free`` — drop ComfyUI's models from GTT.
+
+    True on a 200; False on any HTTP/connect failure (an unreachable
+    ComfyUI holds no GPU memory, so the restore proceeds either way).
+    """
+    import httpx
+
+    timeout = httpx.Timeout(_COMFYUI_HTTP_TIMEOUT_S, connect=_COMFYUI_CONNECT_TIMEOUT_S)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(
+                f"{_comfyui_base_url()}/free",
+                json={"unload_models": True, "free_memory": True},
+            )
+            return resp.status_code == 200
+    except httpx.HTTPError:
+        return False
+
+
+async def _comfyui_queue_counts() -> tuple[int, int] | None:
+    """ComfyUI ``GET /queue`` → (running, pending), or None when unreachable.
+
+    The idle loop needs this because renders queued straight into the web
+    UI never pass through the dispatcher — ``in_flight_count`` can't see
+    them.
+    """
+    import httpx
+
+    timeout = httpx.Timeout(_COMFYUI_HTTP_TIMEOUT_S, connect=_COMFYUI_CONNECT_TIMEOUT_S)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.get(f"{_comfyui_base_url()}/queue")
+            if resp.status_code != 200:
+                return None
+            data = resp.json()
+    except (httpx.HTTPError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    running = data.get("queue_running")
+    pending = data.get("queue_pending")
+    return (
+        len(running) if isinstance(running, list) else 0,
+        len(pending) if isinstance(pending, list) else 0,
+    )
+
+
 _DEFAULT_STATE: dict[str, Any] = {
     "mode": "llm",
     "pinned": False,
@@ -121,6 +203,18 @@ class GpuImageMode(Hal0Error):
     status = 503
 
 
+class GpuInferenceMode(Hal0Error):
+    """Image dispatch refused — the GPU is serving the LLM set.
+
+    The resident ComfyUI container stays READY in llm mode (its web UI is
+    always up), so this guard is what stops a generation from grabbing GTT
+    under the loaded LLM weights. Flip the switch first.
+    """
+
+    code = "gpu.inference_mode"
+    status = 503
+
+
 class ArbiterPinned(Hal0Error):
     """Restore refused — image mode is manually pinned (force to override)."""
 
@@ -149,7 +243,7 @@ class GpuArbiter:
         manager: SlotManager,
         *,
         state_path: Path,
-        idle_restore_minutes: int = 5,
+        idle_restore_minutes: int = 60,
     ) -> None:
         self._manager = manager
         self.state_path = Path(state_path)
@@ -317,7 +411,9 @@ class GpuArbiter:
 
         Order (locked): snapshot running llm slots → persist target state
         FIRST → drain in-flight requests (bounded) → unload llm slots →
-        load the img slot's default model → poll for readiness → stamp activity.
+        cold-start the img container ONLY when it isn't already dispatchable
+        (resident design: restore_llm never stops it) → re-stamp activity at
+        completion so a slow cold start can't eat the idle window.
         """
         async with self._switch_lock:
             st = self._load_state()
@@ -371,81 +467,97 @@ class GpuArbiter:
                 await self._manager.unload(slot)
 
             img_name = str(img_cfg.get("name") or "img")
-            model_section = img_cfg.get("model")
-            model_default = (
-                str(model_section.get("default") or "") if isinstance(model_section, dict) else ""
-            )
-            try:
-                await self._manager.load(img_name, model_default or None)
-            except Exception:
-                # D5 quality-gate I1: load() raised — rollback, then re-raise
-                # the ORIGINAL load exception so callers see the root cause.
-                await self._rollback_to_llm(llm_slots, img_name, unload_img=False)
-                raise
+            # Resident container: when the img slot is already dispatchable
+            # the switch is just the llm unloads above — no load, no poll.
+            if self._manager.state(img_name) not in _DISPATCHABLE:
+                await self._cold_start_img(img_cfg, img_name, llm_slots)
 
-            # #714: load() only waits for systemd start, not health-probe
-            # completion (containers go STARTING → WARMING → READY async).
-            # Poll until the slot reaches a dispatchable state or we time out.
-            # Call state() exactly once per iteration — terminal states
-            # (ERROR/OFFLINE) abort the poll immediately so we don't burn the
-            # full 120s on a crash-at-start.
-            _TERMINAL: frozenset[SlotState] = frozenset({SlotState.ERROR, SlotState.OFFLINE})
-            _DISPATCHABLE: frozenset[SlotState] = frozenset(
-                {SlotState.READY, SlotState.SERVING, SlotState.IDLE}
-            )
-            ready_deadline = time.monotonic() + _IMG_READY_TIMEOUT_S
-            img_slot_state: SlotState | str = SlotState.WARMING
-            while True:
-                img_slot_state = self._manager.state(img_name)
-                if img_slot_state in _DISPATCHABLE:
-                    break
-                if img_slot_state in _TERMINAL:
-                    log.warning(
-                        "gpu_arbiter.img_terminal_state_during_readiness",
-                        extra={"img_slot": img_name, "state": str(img_slot_state)},
-                    )
-                    await self._rollback_to_llm(llm_slots, img_name, unload_img=True)
-                    raise GpuImgNotReady(
-                        f"img slot {img_name!r} reached terminal state "
-                        f"{img_slot_state!r} after load; rolled back to LLM mode",
-                        details={"slot": img_name, "state": str(img_slot_state)},
-                    )
-                if time.monotonic() >= ready_deadline:
-                    log.warning(
-                        "gpu_arbiter.img_readiness_timeout",
-                        extra={
-                            "img_slot": img_name,
-                            "timeout_s": _IMG_READY_TIMEOUT_S,
-                            "state": str(img_slot_state),
-                        },
-                    )
-                    await self._rollback_to_llm(llm_slots, img_name, unload_img=True)
-                    raise GpuImgNotReady(
-                        f"img slot {img_name!r} did not become ready within "
-                        f"{_IMG_READY_TIMEOUT_S}s (last state: {img_slot_state!r}); "
-                        f"rolled back to LLM mode",
-                        details={
-                            "slot": img_name,
-                            "timeout_s": _IMG_READY_TIMEOUT_S,
-                            "state": str(img_slot_state),
-                        },
-                    )
-                await asyncio.sleep(_READY_POLL_S)
-
-            # last_img_activity was stamped in the pre-unload persist above;
-            # no second persist needed here (spec-review tidy).
+            # Re-stamp at COMPLETION: the idle window must start when the
+            # switch finishes, not when it began — a slow cold start used to
+            # eat most of the window (the pre-unload stamp only exists for
+            # crash-recovery ordering).
+            st = self._load_state()
+            st["last_img_activity"] = time.time()
+            self._persist()
             log.info(
                 "gpu_arbiter.img_mode",
                 extra={"saved_llm_slots": llm_slots, "img_slot": img_name},
             )
 
+    async def _cold_start_img(
+        self, img_cfg: dict[str, Any], img_name: str, llm_slots: list[str]
+    ) -> None:
+        """Load the img container and poll it to a dispatchable state.
+
+        Only runs when the resident container is down (first boot, crash,
+        deploy restart). Rollback semantics unchanged from Phase D.
+        """
+        model_section = img_cfg.get("model")
+        model_default = (
+            str(model_section.get("default") or "") if isinstance(model_section, dict) else ""
+        )
+        try:
+            await self._manager.load(img_name, model_default or None)
+        except Exception:
+            # D5 quality-gate I1: load() raised — rollback, then re-raise
+            # the ORIGINAL load exception so callers see the root cause.
+            await self._rollback_to_llm(llm_slots, img_name, unload_img=False)
+            raise
+
+        # #714: load() only waits for systemd start, not health-probe
+        # completion (containers go STARTING → WARMING → READY async).
+        # Poll until the slot reaches a dispatchable state or we time out.
+        # Call state() exactly once per iteration — terminal states
+        # (ERROR/OFFLINE) abort the poll immediately so we don't burn the
+        # full 120s on a crash-at-start.
+        ready_deadline = time.monotonic() + _IMG_READY_TIMEOUT_S
+        img_slot_state: SlotState | str = SlotState.WARMING
+        while True:
+            img_slot_state = self._manager.state(img_name)
+            if img_slot_state in _DISPATCHABLE:
+                return
+            if img_slot_state in _TERMINAL:
+                log.warning(
+                    "gpu_arbiter.img_terminal_state_during_readiness",
+                    extra={"img_slot": img_name, "state": str(img_slot_state)},
+                )
+                await self._rollback_to_llm(llm_slots, img_name, unload_img=True)
+                raise GpuImgNotReady(
+                    f"img slot {img_name!r} reached terminal state "
+                    f"{img_slot_state!r} after load; rolled back to LLM mode",
+                    details={"slot": img_name, "state": str(img_slot_state)},
+                )
+            if time.monotonic() >= ready_deadline:
+                log.warning(
+                    "gpu_arbiter.img_readiness_timeout",
+                    extra={
+                        "img_slot": img_name,
+                        "timeout_s": _IMG_READY_TIMEOUT_S,
+                        "state": str(img_slot_state),
+                    },
+                )
+                await self._rollback_to_llm(llm_slots, img_name, unload_img=True)
+                raise GpuImgNotReady(
+                    f"img slot {img_name!r} did not become ready within "
+                    f"{_IMG_READY_TIMEOUT_S}s (last state: {img_slot_state!r}); "
+                    f"rolled back to LLM mode",
+                    details={
+                        "slot": img_name,
+                        "timeout_s": _IMG_READY_TIMEOUT_S,
+                        "state": str(img_slot_state),
+                    },
+                )
+            await asyncio.sleep(_READY_POLL_S)
+
     async def restore_llm(self, *, force: bool = False) -> None:
         """Restore the saved LLM set (no-op in LLM mode).
 
         Refuses while pinned unless ``force=True`` (which also clears the
-        pin). Order: unload img FIRST, then reload the saved set, then
-        persist ``mode=llm`` — a crash mid-restore leaves mode IMG on disk
-        so the restore can simply be retried.
+        pin). Order: free ComfyUI's models FIRST (``POST /free`` — the
+        resident container is never unloaded, its web UI stays up), then
+        reload the saved set, then persist ``mode=llm`` — a crash
+        mid-restore leaves mode IMG on disk so the restore can simply be
+        retried.
         """
         async with self._switch_lock:
             st = self._load_state()
@@ -459,13 +571,12 @@ class GpuArbiter:
 
             cfgs = await self._manager.iter_configs()
             self._refresh_group_cache(cfgs)
-            img_name = next(
-                (str(c.get("name") or "") for c in cfgs if gpu_exclusive_group(c) == "img"),
-                "img",
-            )
             saved = list(st["saved_llm_slots"])
 
-            await self._manager.unload(img_name)
+            # Best-effort: an unreachable ComfyUI holds no GPU memory, so a
+            # failed /free never blocks the restore.
+            if not await _comfyui_free():
+                log.warning("gpu_arbiter.comfyui_free_failed")
             for slot in saved:
                 await self._manager.load(slot, None)
 
@@ -519,6 +630,13 @@ class GpuArbiter:
         )
         if img_name is not None and self._manager.in_flight_count(img_name) > 0:
             return  # in-flight img job — defer until it completes
+        # Renders queued straight into ComfyUI's web UI bypass the
+        # dispatcher, so also ask ComfyUI itself: busy → defer AND restart
+        # the idle window (the user is actively generating).
+        counts = await _comfyui_queue_counts()
+        if counts is not None and (counts[0] + counts[1]) > 0:
+            self.touch_img_activity()
+            return
         await self.restore_llm()
         log.info(
             "gpu_arbiter.idle_restored",
@@ -527,23 +645,36 @@ class GpuArbiter:
 
     # ── sync surface (lock-free; see module docstring for why safe) ─────────
 
-    def guard_llm_dispatch(self, slot_name: str) -> None:
-        """Raise :class:`GpuImageMode` when *slot_name* can't dispatch.
+    def guard_dispatch(self, slot_name: str) -> None:
+        """Raise when *slot_name* can't dispatch in the current GPU mode.
 
-        Cheap in the hot path: a single in-memory mode check in LLM mode;
-        group derivation only happens while the GPU is in image mode.
+        Both directions of the exclusive split:
+
+          - img mode + llm-group slot → :class:`GpuImageMode` (the arbiter
+            unloaded the slot to hand the GPU to ComfyUI);
+          - llm mode + img-group slot → :class:`GpuInferenceMode` (the
+            resident ComfyUI container is READY but must not grab GTT under
+            the loaded LLM weights — flip the switch first).
+
+        Cheap in the hot path: group lookups are cache-first and the cache
+        is warmed by every switch / first lookup.
         """
         st = self._load_state()
-        if st["mode"] != GpuMode.IMG.value:
-            return
         name = self._resolve_alias(slot_name)
-        if self._slot_group(name) != "llm":
-            return
-        raise GpuImageMode(
-            f"GPU is in exclusive image mode; LLM slot {name!r} is unavailable "
-            f"until image mode ends",
-            details={"slot": name, "retry_after_s": self._retry_after_s(st)},
-        )
+        group = self._slot_group(name)
+        if st["mode"] == GpuMode.IMG.value and group == "llm":
+            raise GpuImageMode(
+                f"GPU is in exclusive image mode; LLM slot {name!r} is unavailable "
+                f"until image mode ends",
+                details={"slot": name, "retry_after_s": self._retry_after_s(st)},
+            )
+        if st["mode"] == GpuMode.LLM.value and group == "img":
+            raise GpuInferenceMode(
+                f"GPU is in inference mode; switch to image generation first "
+                f"(POST /api/comfyui/switchover mode=generation) before "
+                f"dispatching to slot {name!r}",
+                details={"slot": name},
+            )
 
     def _retry_after_s(self, st: dict[str, Any]) -> int:
         """Remaining idle-restore window, floored at 15s (D6 owns the loop)."""

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1928,7 +1928,7 @@ class SlotManager:
         State persists under the same var-lib root the slot state files
         use (``paths.var_lib()``, HAL0_HOME-redirected in tests).
         ``idle_restore_minutes`` comes from the img slot's ``[image]``
-        section when one is configured (D1), default 5.
+        section when one is configured (D1), default 60.
         """
         if self._arbiter is None:
             from hal0.slots.arbiter import GpuArbiter
@@ -1946,7 +1946,7 @@ class SlotManager:
         Synchronous direct TOML scan, mirroring ``idle_timeout_by_model``
         (the ``arbiter`` property can't await). The first slot whose config
         derives to the ``img`` exclusive group wins; missing/invalid values
-        (negatives, bools, non-ints) fall back to the spec default of 5
+        (negatives, bools, non-ints) fall back to the default of 60
         minutes. ``0`` is VALID and means manual-only restore (#599 schema)
         — the arbiter's idle loop never auto-restores on a zero window.
         """
@@ -1967,8 +1967,8 @@ class SlotManager:
             val = image.get("idle_restore_minutes") if isinstance(image, dict) else None
             if isinstance(val, int) and not isinstance(val, bool) and val >= 0:
                 return val
-            return 5
-        return 5
+            return 60
+        return 60
 
     # ── IDLE monitor ─────────────────────────────────────────────────────────
 

--- a/tests/api/test_comfyui_proxy.py
+++ b/tests/api/test_comfyui_proxy.py
@@ -355,6 +355,18 @@ def test_status_mode_is_arbiter_truth_post_migration(client: TestClient) -> None
     assert body["endpoint"] == ":8188"
 
 
+def test_status_endpoint_exposed_in_inference_mode_when_reachable(client: TestClient) -> None:
+    # Resident container: the ComfyUI web UI stays up in inference mode so
+    # users can build workflows/prompts before flipping the switch — /status
+    # must advertise the endpoint whenever the UI is actually reachable.
+    _install_arbiter(client, mode="llm")
+    c, s, f = _patch(container="running", hermes=True, fetch=_fetch_idle)
+    with c, s, f:
+        body = client.get("/api/comfyui/status").json()
+    assert body["mode"] == "inference"
+    assert body["endpoint"] == ":8188"
+
+
 def test_status_mode_legacy_fallback_when_arbiter_missing(client: TestClient) -> None:
     # Arbiter unwired → fall back to the docker/systemd-derived mode.
     client.app.state.slot_manager = None

--- a/tests/api/test_v1_backend_aware_load.py
+++ b/tests/api/test_v1_backend_aware_load.py
@@ -157,7 +157,7 @@ def test_dispatch_proceeds_even_if_backend_aware_load_fails(
 class _ImageModeArbiter:
     """Stands in for GpuArbiter while mode == img."""
 
-    def guard_llm_dispatch(self, slot_name: str) -> None:
+    def guard_dispatch(self, slot_name: str) -> None:
         from hal0.slots.arbiter import GpuImageMode
 
         raise GpuImageMode(

--- a/tests/comfyui/test_hal0_gpu_gate.py
+++ b/tests/comfyui/test_hal0_gpu_gate.py
@@ -1,0 +1,83 @@
+"""hal0_gpu_gate — the ComfyUI custom node that 403-blocks job submission
+while the iGPU is in inference (llm) mode.
+
+The node ships in ``installer/comfyui/custom_nodes/hal0_gpu_gate.py`` and is
+host-mounted into the resident ComfyUI container's ``custom_nodes`` dir, so
+the web UI stays fully usable (editor, /object_info, workflow save/load)
+while only ``POST /prompt`` is gated on the arbiter mode.
+
+Only the pure decision logic is unit-tested here — the aiohttp middleware /
+PromptServer wiring needs a live ComfyUI process and is exercised in the
+CT105 live verification. The module MUST import cleanly outside ComfyUI
+(no top-level ``server``/``aiohttp`` imports) for these tests to even load.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+_NODE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "installer"
+    / "comfyui"
+    / "custom_nodes"
+    / "hal0_gpu_gate.py"
+)
+
+
+def _load_node() -> Any:
+    spec = importlib.util.spec_from_file_location("hal0_gpu_gate", _NODE_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_node_file_exists_and_imports_outside_comfyui() -> None:
+    """Import must fail-soft outside ComfyUI (no PromptServer available)."""
+    mod = _load_node()
+    # ComfyUI custom-node import contract
+    assert mod.NODE_CLASS_MAPPINGS == {}
+
+
+def test_blocks_prompt_post_in_inference_mode() -> None:
+    mod = _load_node()
+    status = {"mode": "inference"}
+    assert mod.should_block("POST", "/prompt", status) is True
+    # the frontend posts to /api/prompt on recent ComfyUI versions
+    assert mod.should_block("POST", "/api/prompt", status) is True
+
+
+def test_allows_prompt_post_in_generation_mode() -> None:
+    mod = _load_node()
+    assert mod.should_block("POST", "/prompt", {"mode": "generation"}) is False
+
+
+def test_fails_open_when_hal0_api_unreachable() -> None:
+    """hal0-api down → status unknown → never brick standalone ComfyUI use."""
+    mod = _load_node()
+    assert mod.should_block("POST", "/prompt", None) is False
+    assert mod.should_block("POST", "/prompt", {"unexpected": "shape"}) is False
+
+
+def test_never_blocks_other_routes_or_methods() -> None:
+    """Everything that makes the editor usable must always pass."""
+    mod = _load_node()
+    status = {"mode": "inference"}
+    assert mod.should_block("GET", "/prompt", status) is False
+    assert mod.should_block("POST", "/object_info", status) is False
+    assert mod.should_block("GET", "/queue", status) is False
+    assert mod.should_block("POST", "/upload/image", status) is False
+
+
+def test_gate_body_is_comfyui_frontend_renderable() -> None:
+    """403 body mirrors ComfyUI's /prompt error envelope so the frontend
+    surfaces the message instead of a generic failure toast."""
+    mod = _load_node()
+    body = mod.GATE_BODY
+    assert body["node_errors"] == {}
+    err = body["error"]
+    assert err["type"] == "hal0_gpu_gate"
+    assert "Image Gen" in err["message"]

--- a/tests/config/test_schema_seeds_d1.py
+++ b/tests/config/test_schema_seeds_d1.py
@@ -29,7 +29,7 @@ def test_seed_img_toml_validates() -> None:
     assert cfg.provider == "comfyui"
     assert cfg.port == 8188
     assert cfg.device == "gpu-rocm"
-    assert cfg.image_gen.idle_restore_minutes == 5  # #599 [image] section
+    assert cfg.image_gen.idle_restore_minutes == 60  # #599 [image] section
 
 
 def test_seed_profiles_toml_has_comfyui_parity() -> None:
@@ -47,7 +47,7 @@ def test_port_range_admits_comfyui_stock_port() -> None:
 
 def test_image_gen_section_defaults() -> None:
     s = ImageGenConfig()
-    assert (s.idle_restore_minutes, s.default_size, s.default_steps) == (5, "1024x1024", 0)
+    assert (s.idle_restore_minutes, s.default_size, s.default_steps) == (60, "1024x1024", 0)
 
 
 def test_string_image_override_still_validates_and_round_trips() -> None:

--- a/tests/slots/test_gpu_arbiter.py
+++ b/tests/slots/test_gpu_arbiter.py
@@ -29,6 +29,7 @@ from hal0.slots.arbiter import (
     ArbiterPinned,
     GpuArbiter,
     GpuImageMode,
+    GpuInferenceMode,
     GpuMode,
     gpu_exclusive_group,
 )
@@ -169,6 +170,28 @@ def _fast_drain(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(arbiter_mod, "_DRAIN_POLL_S", 0.01)
 
 
+@pytest.fixture(autouse=True)
+def comfyui_http(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Stub the arbiter's ComfyUI HTTP seams (resident-container design).
+
+    ``free`` counts /free calls (restore_llm frees models instead of
+    unloading the container); ``queue`` scripts the (running, pending)
+    counts the idle tick reads from /queue — ``None`` = unreachable.
+    """
+    rec: dict[str, Any] = {"free": 0, "queue": None}
+
+    async def _fake_free() -> bool:
+        rec["free"] += 1
+        return True
+
+    async def _fake_queue() -> tuple[int, int] | None:
+        return rec["queue"]
+
+    monkeypatch.setattr(arbiter_mod, "_comfyui_free", _fake_free, raising=False)
+    monkeypatch.setattr(arbiter_mod, "_comfyui_queue_counts", _fake_queue, raising=False)
+    return rec
+
+
 def _read_state(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -264,6 +287,40 @@ async def test_ensure_img_noop_when_already_img(fake_mgr: FakeManager, state_pat
     assert _read_state(state_path)["pinned"] is True
 
 
+async def test_ensure_img_skips_load_when_img_already_running(
+    fake_mgr: FakeManager, state_path: Path
+) -> None:
+    """Resident-container design: the ComfyUI container stays up across
+    modes, so when the img slot is already dispatchable the switch only
+    unloads the LLM set — no container load, no readiness poll."""
+    fake_mgr.ready.add("img")
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+
+    await arb.ensure_img()
+
+    assert fake_mgr.calls == [("unload", "chat"), ("unload", "agent")]
+    assert arb.mode is GpuMode.IMG
+    assert isinstance(_read_state(state_path)["last_img_activity"], float)
+
+
+async def test_ensure_img_restamps_activity_at_completion(
+    fake_mgr: FakeManager, state_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The idle window must start when the switch COMPLETES, not when it
+    begins — a slow container start used to eat most of the window."""
+    fake_mgr.slot_states = {"img": ["warming", "warming", "ready"]}
+    monkeypatch.setattr(arbiter_mod, "_READY_POLL_S", 0.05)
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+
+    stamps: list[float] = []
+    fake_mgr.on_unload = lambda _name: stamps.append(_read_state(state_path)["last_img_activity"])
+
+    await arb.ensure_img()
+
+    final = _read_state(state_path)["last_img_activity"]
+    assert final > stamps[0], "activity must be re-stamped after readiness"
+
+
 async def test_drain_timeout_proceeds(
     fake_mgr: FakeManager,
     state_path: Path,
@@ -315,7 +372,7 @@ async def test_img_load_failure_rolls_back_llm_set(
     assert final["mode"] == "llm"
     assert final["saved_llm_slots"] == []
     # guard must NOT be wedged
-    arb.guard_llm_dispatch("chat")
+    arb.guard_dispatch("chat")
 
     # a retried image request re-attempts the FULL switch (no IMG no-op
     # short-circuit against a dead img port)
@@ -346,22 +403,27 @@ async def test_img_load_failure_rollback_load_also_fails(
     assert any("rollback_load_failed" in rec.message for rec in caplog.records)
     assert arb.mode is GpuMode.LLM
     assert _read_state(state_path)["mode"] == "llm"
-    arb.guard_llm_dispatch("chat")  # not wedged
+    arb.guard_dispatch("chat")  # not wedged
 
 
 # ── restore_llm ──────────────────────────────────────────────────────────────
 
 
-async def test_restore_llm_reloads_saved_set(fake_mgr: FakeManager, state_path: Path) -> None:
+async def test_restore_llm_frees_comfyui_and_reloads_saved_set(
+    fake_mgr: FakeManager, state_path: Path, comfyui_http: dict[str, Any]
+) -> None:
     arb = GpuArbiter(fake_mgr, state_path=state_path)
     await arb.ensure_img()
     fake_mgr.calls.clear()
 
     await arb.restore_llm()
 
-    # img unloaded FIRST, then the saved set reloaded (default models)
-    assert fake_mgr.calls[0] == ("unload", "img")
-    assert fake_mgr.calls[1:] == [("load", "chat", None), ("load", "agent", None)]
+    # ComfyUI models freed via POST /free FIRST — the container itself is
+    # NEVER unloaded (resident design: the web UI stays up in llm mode) —
+    # then the saved set reloaded (default models).
+    assert comfyui_http["free"] == 1
+    assert ("unload", "img") not in fake_mgr.calls
+    assert fake_mgr.calls == [("load", "chat", None), ("load", "agent", None)]
     assert arb.mode is GpuMode.LLM
     final = _read_state(state_path)
     assert final["mode"] == "llm"
@@ -392,7 +454,7 @@ async def test_restore_blocked_when_pinned_unless_force(
     await arb.restore_llm(force=True)
     assert arb.mode is GpuMode.LLM
     assert arb.pinned is False  # force-restore clears the pin
-    assert fake_mgr.calls[0] == ("unload", "img")
+    assert fake_mgr.calls[0] == ("load", "chat", None)  # container never unloaded
 
 
 # ── concurrency: one lock, no interleaved flips ──────────────────────────────
@@ -415,7 +477,6 @@ async def test_concurrent_ensure_img_and_restore_serialize(
         ("unload", "chat"),
         ("unload", "agent"),
         ("load", "img", "sdxl-turbo"),
-        ("unload", "img"),
         ("load", "chat", None),
         ("load", "agent", None),
     ]
@@ -439,7 +500,7 @@ async def test_state_survives_restart(fake_mgr: FakeManager, state_path: Path) -
     assert set(arb2.saved_llm_slots) == {"chat", "agent"}
 
     await arb2.restore_llm()
-    assert ("unload", "img") in fake2.calls
+    assert ("unload", "img") not in fake2.calls  # resident container stays up
     assert ("load", "chat", None) in fake2.calls
     assert ("load", "agent", None) in fake2.calls
     assert arb2.mode is GpuMode.LLM
@@ -469,7 +530,6 @@ async def test_partial_crash_recovery_via_restore(state_path: Path) -> None:
     await arb.restore_llm()
 
     assert mgr.calls == [
-        ("unload", "img"),
         ("load", "chat", None),
         ("load", "agent", None),
     ]
@@ -482,10 +542,10 @@ def test_corrupt_state_file_falls_back_to_llm(fake_mgr: FakeManager, state_path:
     arb = GpuArbiter(fake_mgr, state_path=state_path)
     assert arb.mode is GpuMode.LLM
     assert arb.saved_llm_slots == ()
-    arb.guard_llm_dispatch("chat")  # must not raise
+    arb.guard_dispatch("chat")  # must not raise
 
 
-# ── guard_llm_dispatch ───────────────────────────────────────────────────────
+# ── guard_dispatch ───────────────────────────────────────────────────────
 
 
 def _write_img_state(path: Path, *, last_activity: float | None = None) -> None:
@@ -502,28 +562,28 @@ def _write_img_state(path: Path, *, last_activity: float | None = None) -> None:
     )
 
 
-def test_guard_llm_dispatch_raises_in_img_mode(
+def test_guard_dispatch_raises_in_img_mode(
     fake_mgr: FakeManager, state_path: Path, tmp_hal0_home: str
 ) -> None:
     _write_img_state(state_path)
     arb = GpuArbiter(fake_mgr, state_path=state_path)
 
     with pytest.raises(GpuImageMode) as ei:
-        arb.guard_llm_dispatch("chat")
+        arb.guard_dispatch("chat")
     assert ei.value.code == "gpu.image_mode"
     assert ei.value.status == 503
     assert ei.value.details["retry_after_s"] >= 15
     assert ei.value.details["slot"] == "chat"
 
     # non-llm-group slots always pass
-    arb.guard_llm_dispatch("npu")
-    arb.guard_llm_dispatch("tts")
+    arb.guard_dispatch("npu")
+    arb.guard_dispatch("tts")
 
     # mode LLM → everything passes
     llm_path = state_path.parent / "llm_state.json"
     arb_llm = GpuArbiter(fake_mgr, state_path=llm_path)
-    arb_llm.guard_llm_dispatch("chat")
-    arb_llm.guard_llm_dispatch("npu")
+    arb_llm.guard_dispatch("chat")
+    arb_llm.guard_dispatch("npu")
 
 
 def test_guard_retry_after_floor(
@@ -533,7 +593,7 @@ def test_guard_retry_after_floor(
     _write_img_state(state_path, last_activity=time.time() - 10_000)
     arb = GpuArbiter(fake_mgr, state_path=state_path)
     with pytest.raises(GpuImageMode) as ei:
-        arb.guard_llm_dispatch("agent")
+        arb.guard_dispatch("agent")
     assert ei.value.details["retry_after_s"] == 15
 
 
@@ -562,7 +622,43 @@ def test_guard_uses_derived_group_from_slot_toml(
     _write_img_state(state_path)
     arb = GpuArbiter(fake_mgr, state_path=state_path)
     with pytest.raises(GpuImageMode):
-        arb.guard_llm_dispatch("utility")
+        arb.guard_dispatch("utility")
+
+
+def test_guard_dispatch_blocks_img_slot_in_llm_mode(
+    fake_mgr: FakeManager, state_path: Path, tmp_hal0_home: str
+) -> None:
+    """Resident img container: the slot stays READY in llm mode, so the
+    dispatch guard is the only thing stopping an image generation from
+    running while the LLM set holds the GPU — refuse with a typed 503
+    telling the caller to flip the switch first."""
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "img.toml").write_text(
+        "\n".join(
+            [
+                'name = "img"',
+                'type = "image"',
+                'provider = "comfyui"',
+                'device = "gpu-rocm"',
+                'runtime = "container"',
+                "port = 8188",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    arb = GpuArbiter(fake_mgr, state_path=state_path)  # default llm mode
+
+    with pytest.raises(GpuInferenceMode) as ei:
+        arb.guard_dispatch("img")
+    assert ei.value.code == "gpu.inference_mode"
+    assert ei.value.status == 503
+    assert ei.value.details["slot"] == "img"
+
+    # llm-group + non-arbitrated slots pass untouched in llm mode
+    arb.guard_dispatch("npu")
+    arb.guard_dispatch("tts")
 
 
 # ── activity / pin / status ──────────────────────────────────────────────────
@@ -624,8 +720,8 @@ async def test_idle_restore_fires_after_window(fake_mgr: FakeManager, state_path
     task = asyncio.create_task(arb.run_idle_loop(interval_s=0.01))
     try:
         await asyncio.sleep(0.3)
-        assert fake_mgr.calls.count(("unload", "img")) == 1
-        assert ("load", "chat", None) in fake_mgr.calls
+        assert ("unload", "img") not in fake_mgr.calls  # container stays up
+        assert fake_mgr.calls.count(("load", "chat", None)) == 1  # restored ONCE
         assert ("load", "agent", None) in fake_mgr.calls
         assert arb.mode is GpuMode.LLM
         assert not task.done(), "loop must stay alive after restoring"
@@ -679,15 +775,41 @@ async def test_in_flight_img_job_defers_restore(fake_mgr: FakeManager, state_pat
     task = asyncio.create_task(arb.run_idle_loop(interval_s=0.01))
     try:
         await asyncio.sleep(0.2)
-        assert ("unload", "img") not in fake_mgr.calls
+        assert fake_mgr.calls == []  # restore deferred
         assert arb.mode is GpuMode.IMG
 
         fake_mgr.in_flight = {"img": 0}  # render finished
         await asyncio.sleep(0.2)
-        assert fake_mgr.calls.count(("unload", "img")) == 1
+        assert fake_mgr.calls.count(("load", "chat", None)) == 1
         assert arb.mode is GpuMode.LLM
     finally:
         await _cancel_loop(task)
+
+
+async def test_idle_tick_defers_and_restamps_when_comfyui_queue_busy(
+    fake_mgr: FakeManager, state_path: Path, comfyui_http: dict[str, Any]
+) -> None:
+    """Renders queued straight into ComfyUI's web UI never pass through the
+    dispatcher (in_flight_count can't see them), so the idle tick must also
+    consult ComfyUI's /queue: busy → defer the restore AND restart the idle
+    window; drained → restore on the next eligible tick."""
+    arb = await _img_mode_arbiter(fake_mgr, state_path)
+
+    comfyui_http["queue"] = (1, 0)
+    arb._load_state()["last_img_activity"] = time.time() - 10_000
+    arb._persist()
+    await arb._idle_tick()
+    assert arb.mode is GpuMode.IMG
+    assert fake_mgr.calls == []
+    # busy queue re-stamped the activity → idle window restarted
+    assert _read_state(state_path)["last_img_activity"] > time.time() - 5
+
+    comfyui_http["queue"] = (0, 0)
+    arb._load_state()["last_img_activity"] = time.time() - 10_000
+    arb._persist()
+    await arb._idle_tick()
+    assert arb.mode is GpuMode.LLM
+    assert comfyui_http["free"] == 1
 
 
 async def test_idle_loop_survives_restore_exception(
@@ -755,7 +877,12 @@ def test_manager_arbiter_defaults_without_img_slot(tmp_hal0_home: str) -> None:
     from hal0.slots.manager import SlotManager
 
     sm = SlotManager()
-    assert sm.arbiter.idle_restore_minutes == 5
+    assert sm.arbiter.idle_restore_minutes == 60
+
+
+def test_arbiter_default_idle_window_is_60(fake_mgr: FakeManager, state_path: Path) -> None:
+    """Resident design default: an hour of UI time before auto-restore."""
+    assert GpuArbiter(fake_mgr, state_path=state_path).idle_restore_minutes == 60
 
 
 def _write_img_toml(tmp_hal0_home: str, idle_restore_minutes: str) -> None:
@@ -783,20 +910,20 @@ def _write_img_toml(tmp_hal0_home: str, idle_restore_minutes: str) -> None:
 
 def test_manager_arbiter_accepts_zero_window_from_toml(tmp_hal0_home: str) -> None:
     """TOML ``[image].idle_restore_minutes = 0`` reaches the arbiter as 0
-    (manual-only restore, #599 schema) — NOT coerced to the default 5.
-    Negatives/garbage still fall back to 5."""
+    (manual-only restore, #599 schema) — NOT coerced to the default 60.
+    Negatives/garbage still fall back to 60."""
     from hal0.slots.manager import SlotManager
 
     _write_img_toml(tmp_hal0_home, "0")
     assert SlotManager().arbiter.idle_restore_minutes == 0
 
-    # invalid values still fall back to 5 (fresh managers: arbiter is cached)
+    # invalid values still fall back to 60 (fresh managers: arbiter is cached)
     _write_img_toml(tmp_hal0_home, "-3")
-    assert SlotManager().arbiter.idle_restore_minutes == 5
+    assert SlotManager().arbiter.idle_restore_minutes == 60
     _write_img_toml(tmp_hal0_home, "true")
-    assert SlotManager().arbiter.idle_restore_minutes == 5
+    assert SlotManager().arbiter.idle_restore_minutes == 60
     _write_img_toml(tmp_hal0_home, '"soon"')
-    assert SlotManager().arbiter.idle_restore_minutes == 5
+    assert SlotManager().arbiter.idle_restore_minutes == 60
 
 
 async def test_zero_window_from_toml_never_auto_restores(tmp_hal0_home: str) -> None:
@@ -869,7 +996,7 @@ async def test_img_never_ready_rolls_back_on_timeout(
     assert final["pinned"] is False
 
     # guard is not wedged
-    arb.guard_llm_dispatch("chat")
+    arb.guard_dispatch("chat")
 
     # retry after rollback re-attempts the full switch
     fake_mgr.slot_states = {}  # next time img goes ready immediately via load()
@@ -933,7 +1060,7 @@ async def test_img_terminal_error_rolls_back_immediately(
     assert ("unload", "img") in fake_mgr.calls
     assert ("load", "chat", None) in fake_mgr.calls
     assert ("load", "agent", None) in fake_mgr.calls
-    arb.guard_llm_dispatch("chat")  # not wedged
+    arb.guard_dispatch("chat")  # not wedged
 
 
 async def test_existing_load_raises_rollback_still_works(
@@ -957,4 +1084,4 @@ async def test_existing_load_raises_rollback_still_works(
     assert arb.mode is GpuMode.LLM
     assert _read_state(state_path)["mode"] == "llm"
     assert _read_state(state_path)["saved_llm_slots"] == []
-    arb.guard_llm_dispatch("chat")
+    arb.guard_dispatch("chat")


### PR DESCRIPTION
## Problem

The ComfyUI web app was unreachable until the image-gen switchover was active, and flipping the switch cold-started the entire container — measured ~3m20s per flip on CT105 (PyTorch/ROCm init 57s, ComfyUI core 34s, custom nodes 45s, plus drain/unloads) — while the 5-minute idle-restore window was already counting from switch *start* (`last_img_activity` stamped pre-drain, never re-stamped). Users got ~4.5 minutes of usable UI per 3.5-minute wait.

## Design

GPU **memory** is the exclusive resource on Strix Halo unified memory, not the ComfyUI **process** (idle ComfyUI holds ~0 GTT). The container becomes resident; the arbiter swaps only model residency:

- **→ generation**: drain + unload LLM slots only (~10–30s). Container cold-start happens solely when it's actually down (boot/crash/deploy), with the Phase-D rollback semantics intact. Idle activity is stamped at switch **completion**.
- **→ inference**: `POST /free` to ComfyUI (drops diffusion models from GTT; web UI stays up), then reload the saved LLM set.
- **Execution gating, not UI gating**: `guard_dispatch` (renamed from `guard_llm_dispatch`) now also refuses img-slot dispatch in llm mode (`gpu.inference_mode` 503), and a new host-mounted `hal0_gpu_gate` custom node 403-blocks ComfyUI's own `POST /prompt`/`/api/prompt` while hal0 reports inference mode ("flip the Image Gen switch first"), fail-open if hal0-api is down. Editor routes (`/object_info`, workflow save/load, uploads) always pass.
- **Idle tick** consults ComfyUI `/queue` (web-UI renders bypass the dispatcher) — a busy queue defers the restore and restarts the window.
- **Idle window default 5 → 60 minutes** (seed TOML + manager fallback + arbiter default).
- `/api/comfyui/status` advertises `endpoint: ":8188"` whenever ComfyUI is reachable.

## Tests

TDD throughout. `tests/slots/test_gpu_arbiter.py` (41), `tests/api/test_comfyui_proxy.py`, new `tests/comfyui/test_hal0_gpu_gate.py` (pure gate logic; aiohttp wiring verified live). Full `tests/api/` 821 passed / 3 skipped; `tests/dispatcher/ tests/slots/` 361 passed. Ruff + format clean.

## Deploy notes (CT105)

1. `scripts/deploy.sh` as usual.
2. Copy `installer/comfyui/custom_nodes/hal0_gpu_gate.py` → `/mnt/ai-models/comfyui/custom_nodes/`.
3. Set `idle_restore_minutes = 60` in `/etc/hal0/slots/img.toml`.
4. Load the img slot once (`hal0-slot@img` becomes resident).

🤖 Generated with [Claude Code](https://claude.com/claude-code)