### PR TITLE
Engine state: trust reachable ComfyUI over the blind docker probe

### DIFF
--- a/src/hal0/api/routes/comfyui.py
+++ b/src/hal0/api/routes/comfyui.py
@@ -276,11 +276,14 @@ def _model_inventory() -> dict[str, int] | None:
 
 
 def _engine_state(container: str, reachable: bool, running_jobs: int) -> str:
-    if container != "running":
-        return "stopped"
-    if not reachable:
+    # A reachable ComfyUI IS the engine truth — the docker name probe can't
+    # see the podman hal0-slot-img container (post-D9 it reports "absent"
+    # forever), and the resident container must not render as "stopped".
+    if reachable:
+        return "generating" if running_jobs > 0 else "running"
+    if container == "running":
         return "starting"  # container up but ComfyUI hasn't bound the port yet
-    return "generating" if running_jobs > 0 else "running"
+    return "stopped"
 
 
 def _get_arbiter(request: Request) -> Any | None:

--- a/tests/api/test_comfyui_proxy.py
+++ b/tests/api/test_comfyui_proxy.py
@@ -120,6 +120,19 @@ def test_status_starting_when_container_running_but_http_unreachable(client: Tes
     assert body["memory"] is None
 
 
+def test_status_engine_running_when_reachable_but_container_probe_blind(
+    client: TestClient,
+) -> None:
+    # Post-D9 the docker probe can't see the podman hal0-slot-img container
+    # ("absent" forever) — a reachable ComfyUI IS the engine truth. Without
+    # this, the resident container renders engine "stopped" 24/7 in the pane.
+    c, s, f = _patch(container="absent", hermes=True, fetch=_fetch_idle)
+    with c, s, f:
+        body = client.get("/api/comfyui/status").json()
+    assert body["reachable"] is True
+    assert body["engine"] == "running"
+
+
 def test_status_stopped_and_inference_mode_when_container_absent(client: TestClient) -> None:
     # ComfyUI down, LLM stack up → inference owns the GPU.
     c, s, f = _patch(container="absent", hermes=True, fetch=_fetch_down)


### PR DESCRIPTION
Follow-up to #728, fixes #729. The legacy docker name probe reports the resident podman container as 'absent' forever, so the pane showed engine 'stopped' while the ComfyUI UI was up and reachable (live-observed on CT105). Reachability now decides running/generating; starting/stopped only apply when ComfyUI doesn't answer. TDD: new test asserts container=absent + reachable → running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)