### PR TITLE
fix: FLM trio plumbing — seed [npu] schema, shadow slots inherit anchor status (#733)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -539,12 +539,13 @@ async def _autoregister_slot_upstreams(
 
 # ── FLM multiplex model seeding ────────────────────────────────────────────
 # An FLM slot can serve up to three models from one process — the chat tag
-# in ``model.default`` plus embed-gemma (when ``defaults.load_embed=true``)
-# plus whisper-v3:turbo (when ``defaults.load_asr=true``). Those auxiliary
-# models don't show up in FLM's ``/v1/models`` response (it only lists chat
-# tags), so the dispatcher's passthrough cache never learns about them and
-# routes ``model: "embed-gemma"`` to nowhere. Seed the cache explicitly.
-_FLM_EMBED_TAG = "embed-gemma"
+# in ``model.default`` plus embed-gemma:300m (``[npu] embed=true``) plus
+# whisper-v3:turbo (``[npu] asr=true``; legacy ``[defaults] load_*`` keys
+# still honoured, #733). Those auxiliary models don't show up in FLM's
+# ``/v1/models`` response (it only lists chat tags), so the dispatcher's
+# passthrough cache never learns about them and routes the canonical tags
+# to nowhere. Seed the cache explicitly.
+_FLM_EMBED_TAG = "embed-gemma:300m"
 _FLM_ASR_TAG = "whisper-v3:turbo"
 
 
@@ -616,14 +617,20 @@ async def _seed_multiplex_models(
     bucket = model_cache.setdefault("hal0", [])
     for cfg in cfgs:
         name = cfg.get("name", "")
-        provider = cfg.get("provider", "")
-        if provider != "flm" or not name:
+        is_flm = "flm" in (cfg.get("provider", ""), cfg.get("backend", ""))
+        if not is_flm or not name:
             continue
+        # Container-era schema is the [npu] table (what FLMProvider builds
+        # the --asr/--embed argv from); [defaults] load_* is the pre-#733
+        # legacy shape, kept so older tomls keep seeding.
+        npu_table = cfg.get("npu") or {}
         defaults = cfg.get("defaults") or {}
-        if defaults.get("load_embed") and _FLM_EMBED_TAG not in bucket:
+        load_embed = npu_table.get("embed") or defaults.get("load_embed")
+        load_asr = npu_table.get("asr") or defaults.get("load_asr")
+        if load_embed and _FLM_EMBED_TAG not in bucket:
             bucket.append(_FLM_EMBED_TAG)
             log.info("slots.multiplex_seeded", slot=name, model=_FLM_EMBED_TAG)
-        if defaults.get("load_asr") and _FLM_ASR_TAG not in bucket:
+        if load_asr and _FLM_ASR_TAG not in bucket:
             bucket.append(_FLM_ASR_TAG)
             log.info("slots.multiplex_seeded", slot=name, model=_FLM_ASR_TAG)
 

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -281,6 +281,13 @@ class CapabilityOrchestrator:
                 selection = self._selection_with_defaults(cfg, slot, child)
                 slot_name = _CHILD_TO_SLOT[(slot, child)]
                 status_str = await self._slot_status_string(slot_name)
+                # #733: npu-device selections are served coresident by the
+                # FLM trio anchor — their own shadow slot never runs, so
+                # "offline" there is meaningless; report the anchor's state.
+                if selection.device == "npu" and selection.enabled and status_str == "offline":
+                    anchor_status = await self._npu_anchor_status()
+                    if anchor_status is not None:
+                        status_str = anchor_status
                 selections_out[slot][child] = {
                     # ``device`` is the v0.2 canonical key (ADR-0006 §7).
                     "device": selection.device,
@@ -300,6 +307,29 @@ class CapabilityOrchestrator:
             "catalogs": catalogs,
             "selections": selections_out,
         }
+
+    async def _npu_anchor_status(self) -> str | None:
+        """Status of the FLM trio anchor slot (device=npu, type=llm).
+
+        Shadow selections (stt/embed served coresident by the trio) have
+        no process of their own — their effective status is the anchor's.
+        Returns ``None`` when no enabled npu-llm slot exists so callers
+        keep the selection's own status.
+        """
+        try:
+            configs = await self._slot_manager.iter_configs()
+        except Exception:
+            return None
+        for cfg in configs:
+            if (
+                cfg.get("device") == "npu"
+                and cfg.get("type") == "llm"
+                and cfg.get("enabled") is not False
+            ):
+                name = str(cfg.get("name", ""))
+                if name:
+                    return await self._slot_status_string(name)
+        return None
 
     async def _slot_status_string(self, slot_name: str) -> str:
         """Return the slot's current state.value, or 'offline' if unknown.

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -473,6 +473,36 @@ async def container_enrichment(
             entry["image_status"] = "missing"
 
         out[name] = entry
+
+    # #733: trio shadow slots (embed/stt — device=npu, non-llm) never run a
+    # unit or container of their own; the npu anchor's FLM child serves them
+    # coresident. Their own probe always reads "stopped", so inherit the
+    # anchor's live status instead and mark the relationship for the UI.
+    anchor_cfg = next(
+        (
+            c
+            for c in configs
+            if c.get("device") == "npu" and c.get("type") == "llm" and c.get("enabled") is not False
+        ),
+        None,
+    )
+    if anchor_cfg is not None:
+        anchor_name = str(anchor_cfg.get("name", ""))
+        anchor_entry = out.get(anchor_name)
+        if anchor_entry is not None:
+            for cfg in configs:
+                name = str(cfg.get("name", ""))
+                if (
+                    name
+                    and name != anchor_name
+                    and cfg.get("device") == "npu"
+                    and cfg.get("type") != "llm"
+                    and cfg.get("enabled") is not False
+                    and name in out
+                ):
+                    out[name]["container_status"] = anchor_entry["container_status"]
+                    out[name]["container_health"] = anchor_entry["container_health"]
+                    out[name]["served_by"] = anchor_name
     return out
 
 

--- a/tests/api/test_seed_multiplex_models.py
+++ b/tests/api/test_seed_multiplex_models.py
@@ -1,0 +1,96 @@
+"""``_seed_multiplex_models`` — dispatcher model-cache seeding for the FLM trio.
+
+#733: the seeder still matched the pre-container schema (``provider = "flm"``
++ ``[defaults] load_embed/load_asr``) while live slot tomls moved to
+``backend = "flm"`` + the ``[npu]`` table — so the canonical trio tags never
+reached the model cache and canonical-tag requests fell to dispatch.no_route.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hal0.api import _seed_multiplex_models
+
+CANONICAL_EMBED = "embed-gemma:300m"
+CANONICAL_ASR = "whisper-v3:turbo"
+
+
+class FakeSlotManager:
+    def __init__(self, configs: list[dict[str, Any]]) -> None:
+        self._configs = configs
+
+    async def iter_configs(self) -> list[dict[str, Any]]:
+        return self._configs
+
+
+async def _seed(
+    configs: list[dict[str, Any]],
+    cache: dict[str, list[str]] | None = None,
+) -> dict[str, list[str]]:
+    cache = cache if cache is not None else {}
+    await _seed_multiplex_models(None, FakeSlotManager(configs), cache)
+    return cache
+
+
+def _npu_cfg(**over: Any) -> dict[str, Any]:
+    """Live CT105 shape: backend key + [npu] table, no provider key."""
+    cfg: dict[str, Any] = {
+        "name": "npu",
+        "type": "llm",
+        "device": "npu",
+        "backend": "flm",
+        "npu": {"asr": True, "embed": True},
+    }
+    cfg.update(over)
+    return cfg
+
+
+class TestNpuTableSchema:
+    async def test_backend_flm_with_npu_table_seeds_canonical_tags(self) -> None:
+        cache = await _seed([_npu_cfg()])
+        assert CANONICAL_EMBED in cache["hal0"]
+        assert CANONICAL_ASR in cache["hal0"]
+
+    async def test_embed_only_seeds_embed_tag(self) -> None:
+        cache = await _seed([_npu_cfg(npu={"asr": False, "embed": True})])
+        assert CANONICAL_EMBED in cache["hal0"]
+        assert CANONICAL_ASR not in cache["hal0"]
+
+    async def test_asr_only_seeds_asr_tag(self) -> None:
+        cache = await _seed([_npu_cfg(npu={"asr": True, "embed": False})])
+        assert CANONICAL_ASR in cache["hal0"]
+        assert CANONICAL_EMBED not in cache["hal0"]
+
+
+class TestLegacyDefaultsSchema:
+    async def test_provider_flm_with_defaults_still_seeds(self) -> None:
+        cache = await _seed(
+            [
+                {
+                    "name": "npu",
+                    "provider": "flm",
+                    "defaults": {"load_embed": True, "load_asr": True},
+                }
+            ]
+        )
+        assert CANONICAL_EMBED in cache["hal0"]
+        assert CANONICAL_ASR in cache["hal0"]
+
+
+class TestNonMatching:
+    async def test_non_flm_slot_seeds_nothing(self) -> None:
+        cache = await _seed(
+            [{"name": "chat", "backend": "vulkan", "npu": {"asr": True, "embed": True}}]
+        )
+        assert cache.get("hal0", []) == []
+
+    async def test_flm_slot_without_flags_seeds_nothing(self) -> None:
+        cache = await _seed([_npu_cfg(npu={"asr": False, "embed": False})])
+        assert cache.get("hal0", []) == []
+
+    async def test_idempotent_no_duplicate_tags(self) -> None:
+        cache: dict[str, list[str]] = {"hal0": [CANONICAL_EMBED]}
+        await _seed([_npu_cfg()], cache)
+        assert cache["hal0"].count(CANONICAL_EMBED) == 1
+        assert cache["hal0"].count(CANONICAL_ASR) == 1

--- a/tests/capabilities/test_trio_status_inheritance.py
+++ b/tests/capabilities/test_trio_status_inheritance.py
@@ -1,0 +1,140 @@
+"""#733: capability status for npu-device selections served by the FLM trio.
+
+The embed/stt shadow slots never run a process of their own — the npu
+anchor's FLM child serves them coresident. ``get_state`` used to read each
+selection's own slot status, so trio-served selections always reported
+``offline`` even while the modality answered live traffic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.capabilities.orchestrator import CapabilityOrchestrator
+
+
+@pytest.fixture(autouse=True)
+def _no_spawn_context_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    import hal0.agents.hermes_refresh as _hr
+
+    monkeypatch.setattr(_hr, "spawn_context_refresh", lambda *a, **k: None)
+
+
+@pytest.fixture(autouse=True)
+def _stub_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep get_state hermetic — no hardware probe, no registry scan."""
+    import hal0.capabilities.catalog as _cat
+
+    monkeypatch.setattr(_cat, "available_backends", lambda: [])
+    monkeypatch.setattr(_cat, "catalogs_by_slot", lambda registry=None: {})
+
+
+class _StubSlot:
+    def __init__(self, state: str) -> None:
+        class _S:
+            value = state
+
+        self.state = _S()
+
+
+class StatusMapSlotManager:
+    """status() answers from a per-slot map; unknown slots are offline."""
+
+    def __init__(
+        self,
+        configs: list[dict[str, Any]] | None = None,
+        status_map: dict[str, str] | None = None,
+    ) -> None:
+        self._configs = list(configs or [])
+        self._status_map = dict(status_map or {})
+
+    async def iter_configs(self) -> list[dict[str, Any]]:
+        return list(self._configs)
+
+    async def status(self, slot_name: str) -> _StubSlot:
+        return _StubSlot(self._status_map.get(slot_name, "offline"))
+
+
+NPU_SELECTIONS_TOML = """
+[selections.embed.embed]
+device = "npu"
+model = "embed-gemma:300m"
+enabled = true
+
+[selections.voice.stt]
+device = "npu"
+model = "whisper-v3:turbo"
+enabled = true
+"""
+
+
+def _anchor_cfg(**over: Any) -> dict[str, Any]:
+    cfg: dict[str, Any] = {
+        "name": "npu",
+        "type": "llm",
+        "device": "npu",
+        "profile": "flm-npu",
+        "enabled": True,
+    }
+    cfg.update(over)
+    return cfg
+
+
+def _orch(
+    tmp_path: Path,
+    caps_toml: str,
+    configs: list[dict[str, Any]],
+    status_map: dict[str, str],
+) -> CapabilityOrchestrator:
+    caps_path = tmp_path / "capabilities.toml"
+    caps_path.write_text(caps_toml, encoding="utf-8")
+    return CapabilityOrchestrator(
+        slot_manager=StatusMapSlotManager(configs, status_map),  # type: ignore[arg-type]
+        config_path=caps_path,
+    )
+
+
+async def test_npu_selection_inherits_anchor_status(tmp_path: Path) -> None:
+    orch = _orch(tmp_path, NPU_SELECTIONS_TOML, [_anchor_cfg()], {"npu": "ready"})
+    state = await orch.get_state()
+    assert state["selections"]["embed"]["embed"]["status"] == "ready"
+    assert state["selections"]["voice"]["stt"]["status"] == "ready"
+
+
+async def test_npu_selection_without_anchor_stays_offline(tmp_path: Path) -> None:
+    orch = _orch(tmp_path, NPU_SELECTIONS_TOML, [], {})
+    state = await orch.get_state()
+    assert state["selections"]["embed"]["embed"]["status"] == "offline"
+
+
+async def test_offline_anchor_propagates_offline(tmp_path: Path) -> None:
+    orch = _orch(tmp_path, NPU_SELECTIONS_TOML, [_anchor_cfg()], {"npu": "offline"})
+    state = await orch.get_state()
+    assert state["selections"]["embed"]["embed"]["status"] == "offline"
+
+
+async def test_non_npu_selection_keeps_own_status(tmp_path: Path) -> None:
+    caps = """
+[selections.embed.embed]
+device = "gpu-vulkan"
+model = "nomic-embed-text-v1.5"
+enabled = true
+"""
+    orch = _orch(tmp_path, caps, [_anchor_cfg()], {"npu": "ready"})
+    state = await orch.get_state()
+    assert state["selections"]["embed"]["embed"]["status"] == "offline"
+
+
+async def test_disabled_npu_selection_not_inherited(tmp_path: Path) -> None:
+    caps = """
+[selections.embed.embed]
+device = "npu"
+model = "embed-gemma:300m"
+enabled = false
+"""
+    orch = _orch(tmp_path, caps, [_anchor_cfg()], {"npu": "ready"})
+    state = await orch.get_state()
+    assert state["selections"]["embed"]["embed"]["status"] == "offline"

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -437,6 +437,110 @@ class TestContainerEnrichment:
         assert out["gpu-chat"]["npu"] == {"asr": True, "embed": True}
 
 
+class MapContainerProvider(FakeContainerProvider):
+    """Per-slot ``is_active`` — the trio anchor runs, shadows have no unit."""
+
+    def __init__(self, active_map: dict[str, bool], **kw: Any) -> None:
+        super().__init__(**kw)
+        self._active_map = active_map
+
+    def is_active(self, slot_name: str) -> bool:
+        return self._active_map.get(slot_name, False)
+
+
+def _npu_anchor_cfg(**over: Any) -> dict[str, Any]:
+    cfg: dict[str, Any] = {
+        "name": "npu",
+        "port": 8088,
+        "type": "llm",
+        "device": "npu",
+        "model": {"default": "gemma3:4b"},
+    }
+    cfg.update(over)
+    return cfg
+
+
+def _shadow_cfg(name: str = "embed", slot_type: str = "embedding", **over: Any) -> dict[str, Any]:
+    cfg: dict[str, Any] = {
+        "name": name,
+        "port": 8082,
+        "type": slot_type,
+        "device": "npu",
+        "model": {"default": "embed-gemma:300m"},
+    }
+    cfg.update(over)
+    return cfg
+
+
+class TestShadowSlotStatusInheritance:
+    """#733: embed/stt shadow slots have no unit/container of their own —
+    the npu anchor's FLM process serves them coresident, so their live
+    container status must be the anchor's, not their (always-absent) own."""
+
+    async def test_shadow_inherits_running_anchor(self) -> None:
+        out = await container_enrichment(
+            [
+                _npu_anchor_cfg(),
+                _shadow_cfg("embed", "embedding"),
+                _shadow_cfg("stt", "transcription"),
+            ],
+            pull_jobs={},
+            provider=MapContainerProvider({"npu": True}, healthy=True),
+        )
+        for shadow in ("embed", "stt"):
+            assert out[shadow]["container_status"] == "running"
+            assert out[shadow]["container_health"] is True
+            assert out[shadow]["served_by"] == "npu"
+        # anchor itself is untouched by the inheritance pass
+        assert out["npu"]["container_status"] == "running"
+        assert "served_by" not in out["npu"]
+
+    async def test_stopped_anchor_propagates(self) -> None:
+        out = await container_enrichment(
+            [_npu_anchor_cfg(), _shadow_cfg()],
+            pull_jobs={},
+            provider=MapContainerProvider({"npu": False}),
+        )
+        assert out["embed"]["container_status"] == "stopped"
+        assert out["embed"]["served_by"] == "npu"
+
+    async def test_disabled_shadow_not_inherited(self) -> None:
+        out = await container_enrichment(
+            [_npu_anchor_cfg(), _shadow_cfg(enabled=False)],
+            pull_jobs={},
+            provider=MapContainerProvider({"npu": True}, healthy=True),
+        )
+        assert out["embed"]["container_status"] == "stopped"
+        assert "served_by" not in out["embed"]
+
+    async def test_shadow_without_anchor_stays_stopped(self) -> None:
+        out = await container_enrichment(
+            [_shadow_cfg()],
+            pull_jobs={},
+            provider=MapContainerProvider({}),
+        )
+        assert out["embed"]["container_status"] == "stopped"
+        assert "served_by" not in out["embed"]
+
+    async def test_disabled_anchor_does_not_serve(self) -> None:
+        out = await container_enrichment(
+            [_npu_anchor_cfg(enabled=False), _shadow_cfg()],
+            pull_jobs={},
+            provider=MapContainerProvider({"npu": True}, healthy=True),
+        )
+        assert out["embed"]["container_status"] == "stopped"
+        assert "served_by" not in out["embed"]
+
+    async def test_non_npu_slots_unaffected(self) -> None:
+        out = await container_enrichment(
+            [_npu_anchor_cfg(), _container_cfg()],
+            pull_jobs={},
+            provider=MapContainerProvider({"npu": True}, healthy=True),
+        )
+        assert out["gpu-chat"]["container_status"] == "stopped"
+        assert "served_by" not in out["gpu-chat"]
+
+
 # ── concern 4: per-slot memory accounting ───────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
Fixes the three plumbing drifts from #733. The trio itself was healthy throughout (npu container serving chat+embed+asr); the platform just observed it incorrectly:

1. **`_seed_multiplex_models` learned the live schema** — matches `backend = "flm"` and reads the `[npu]` table (the same source `FLMProvider` builds `--asr`/`--embed` argv from). Legacy `provider = "flm"` + `[defaults] load_*` still honoured. Tag constant canonicalised `embed-gemma` → `embed-gemma:300m` to match the capability catalog namespace.
2. **Shadow slots inherit the anchor's live status** — `container_enrichment` post-pass: device=npu non-llm slots (embed/stt) take the npu anchor's `container_status`/`container_health` and carry `served_by: "npu"`. Their own unit is always absent by design; probing it rendered a live modality as offline.
3. **Capability selections stop reporting trio modalities offline** — `get_state` derives status from the trio anchor for enabled npu-device selections whose own shadow slot reads offline.

Not in this PR (deploy hand-steps, live /etc only — no repo seeds exist for embed/stt):
- CT105 `/etc/hal0/slots/embed.toml` + `stt.toml` `model.default` → canonical tags (`embed-gemma:300m" / "whisper-v3:turbo`) so canonical-tag requests match the trio gate.
- Installer seed npu.toml ships trio off-by-default — left as-is (product decision, flagged in #733).

## Test plan
- [x] TDD red→green: 18 new tests (seeder schema matrix, shadow-status inheritance incl. disabled/no-anchor guards, capability status inheritance incl. non-npu/disabled guards)
- [x] 113 pass across tests/capabilities, tests/slot_view, tests/api trio suites
- [x] ruff check + format gate clean
- [ ] CI
- [ ] Live CT105: `/v1/embeddings` with canonical tag routes; dashboard embed/stt cards show running; `/api/capabilities` status ready

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)