### PR TITLE
feat(api): secrets router, persona update, real features/health, #317 identity, pull poll fallback

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -87,6 +87,9 @@ from hal0.api.routes import (
 from hal0.api.routes import (
     proxmox as proxmox_routes,
 )
+from hal0.api.routes import (
+    secrets as secrets_routes,
+)
 from hal0.capabilities.orchestrator import CapabilityOrchestrator
 from hal0.config.loader import ConfigParseError, load_hal0_config, load_upstreams_config
 from hal0.dispatcher.router import Dispatcher
@@ -1024,6 +1027,15 @@ def create_app() -> FastAPI:
         settings.router,
         prefix="/api/settings",
         tags=["settings"],
+    )
+    # Operator-managed secrets store (Settings → Secrets). Persists to the
+    # same /etc/hal0/api.env file the provider-credential writer targets,
+    # via the shared atomic mode-0600 writer in hal0.api._env_store. Values
+    # are write-only — never returned, never logged.
+    app.include_router(
+        secrets_routes.router,
+        prefix="/api/secrets",
+        tags=["secrets"],
     )
     # Proxmox integration sub-router (config file at /etc/hal0/proxmox.json).
     # Mounted as a sibling under /api/settings/proxmox so the dashboard's

--- a/src/hal0/api/_env_store.py
+++ b/src/hal0/api/_env_store.py
@@ -1,0 +1,152 @@
+"""Atomic ``api.env`` secret store shared by the providers + secrets routers.
+
+``/etc/hal0/api.env`` is the systemd ``EnvironmentFile=`` for ``hal0-api``;
+it holds provider credentials (``POST /api/providers/{name}/credentials``)
+and operator-managed secrets (``/api/secrets``). Both surfaces need the
+same atomic, mode-0600 upsert/delete posture so a partial write never
+leaves a reader (systemd, the running registry) staring at a truncated
+file.
+
+This module factors that writer out of :mod:`hal0.api.routes.providers`
+(where it lived first) so the secrets router doesn't duplicate the
+tmp-file + ``os.replace`` dance. Every path here is given by the caller
+(``hal0.config.paths.etc() / "api.env"`` in production, a
+``HAL0_HOME``-relative path under tests) — this module never resolves
+paths itself.
+
+Values are double-quoted with embedded quotes/backslashes escaped so
+systemd's ``EnvironmentFile=`` parser sees the literal secret verbatim.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from pathlib import Path
+
+
+def _escape(value: str) -> str:
+    """Escape a secret for a double-quoted ``EnvironmentFile`` value.
+
+    systemd treats a double-quoted value as a single token with the outer
+    quotes stripped; backslash + double-quote must be escaped so the
+    secret round-trips byte-for-byte.
+    """
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _line_targets_key(line: str, key: str) -> bool:
+    """True when ``line`` sets ``key`` (plain or commented out)."""
+    stripped = line.lstrip()
+    return (
+        stripped.startswith(f"{key}=")
+        or stripped.startswith(f"# {key}=")
+        or stripped.startswith(f"#{key}=")
+    )
+
+
+def _atomic_write(api_env: Path, text: str) -> None:
+    """Write ``text`` to ``api_env`` atomically with mode 0600.
+
+    tmp-file in the same directory + ``os.replace`` so a concurrent
+    reader never sees a partial file; ``0600`` because this file holds
+    secrets.
+    """
+    api_env.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=f".{api_env.name}.",
+        suffix=".tmp",
+        dir=str(api_env.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_str, 0o600)
+        os.replace(tmp_str, api_env)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_str)
+        raise
+
+
+def upsert_env_value(api_env: Path, key: str, value: str) -> None:
+    """Upsert ``key="<escaped-value>"`` in ``api_env`` atomically.
+
+    If a line for ``key`` exists (commented or not) it is replaced in
+    place; otherwise the line is appended. Raises :class:`OSError` on any
+    read/write failure — callers wrap it in their own error envelope.
+    """
+    existing = ""
+    with contextlib.suppress(FileNotFoundError):
+        existing = api_env.read_text(encoding="utf-8")
+
+    new_line = f'{key}="{_escape(value)}"\n'
+    lines = existing.splitlines(keepends=True) if existing else []
+    rewritten: list[str] = []
+    replaced = False
+    for line in lines:
+        if _line_targets_key(line, key):
+            if not replaced:
+                rewritten.append(new_line)
+                replaced = True
+            continue
+        rewritten.append(line)
+    if not replaced:
+        if rewritten and not rewritten[-1].endswith("\n"):
+            rewritten.append("\n")
+        rewritten.append(new_line)
+
+    _atomic_write(api_env, "".join(rewritten))
+
+
+def delete_env_value(api_env: Path, key: str) -> bool:
+    """Remove every line setting ``key`` from ``api_env`` atomically.
+
+    Returns ``True`` if at least one line was removed, ``False`` if the
+    key wasn't present (so the caller can decide whether that's a 404).
+    Missing file → ``False`` (nothing to delete). Raises :class:`OSError`
+    only on a genuine write failure.
+    """
+    try:
+        existing = api_env.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return False
+
+    lines = existing.splitlines(keepends=True)
+    kept = [line for line in lines if not _line_targets_key(line, key)]
+    if len(kept) == len(lines):
+        return False
+    _atomic_write(api_env, "".join(kept))
+    return True
+
+
+def list_env_keys(api_env: Path) -> list[str]:
+    """Return the sorted, de-duplicated set of keys set in ``api_env``.
+
+    Only uncommented ``KEY=...`` lines count; commented-out lines and
+    blank lines are skipped. Never returns values. Missing file → ``[]``.
+    """
+    try:
+        existing = api_env.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+
+    keys: set[str] = set()
+    for line in existing.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        head, sep, _ = stripped.partition("=")
+        if sep and head:
+            keys.add(head.strip())
+    return sorted(keys)
+
+
+__all__ = [
+    "delete_env_value",
+    "list_env_keys",
+    "upsert_env_value",
+]

--- a/src/hal0/api/agents/memory_stats.py
+++ b/src/hal0/api/agents/memory_stats.py
@@ -8,13 +8,14 @@ Flagged as missing during PR-6 + PR-8 integration: the sidebar block
 needed *some* representation of "how active is this agent's memory"
 without re-fetching the full memory list. The block degrades to
 ``"—"`` / ``"never"`` chips when this endpoint returns the
-``unavailable`` shape, so a hal0 install without Cognee still renders
-sensibly.
+``unavailable`` shape, so a hal0 install without a memory provider still
+renders sensibly.
 
 Where the data comes from
 -------------------------
-Reads through the same in-process :class:`hal0.memory.CogneeWrapper`
-hal0-memory MCP + ``/api/memory/*`` REST shims use. We do NOT hit the
+Reads through the same in-process memory provider
+(:class:`hal0.memory.MemoryProvider`) the hal0-memory MCP +
+``/api/memory/*`` REST shims use. We do NOT hit the
 ``/mcp/memory`` HTTP endpoint — it would re-enter the app over the
 loopback socket and require a real MCP session (the same
 session-establishment overhead PR-3's bootstrap fixed by switching to
@@ -30,8 +31,8 @@ namespace** so the sidebar reflects what THIS agent has done — the
 
 Fallback shape
 --------------
-When the memory wrapper is absent (Cognee init failed, hal0 install
-without the optional memory extra), the route returns:
+When the memory provider is absent (init failed, hal0 install without
+the optional memory extra), the route returns:
 
 .. code-block:: json
 

--- a/src/hal0/api/agents/personas.py
+++ b/src/hal0/api/agents/personas.py
@@ -15,6 +15,7 @@ routes are:
 
     GET  /api/agents/{agent_id}/personas
     GET  /api/agents/{agent_id}/personas/{persona_id}
+    PUT  /api/agents/{agent_id}/personas/{persona_id}
     POST /api/agents/{agent_id}/personas/{persona_id}/activate
 """
 
@@ -25,6 +26,7 @@ from typing import Any
 
 import structlog
 from fastapi import APIRouter
+from pydantic import BaseModel, Field
 
 from hal0.agents import personas as personas_mod
 from hal0.errors import BadRequest, Hal0Error, NotFound
@@ -198,6 +200,130 @@ async def get_agent_persona(agent_id: str, persona_id: str) -> dict[str, Any]:
 
     active = personas_mod.get_active(root=root)
     return _persona_detail(persona, raw_toml=raw_toml, active_id=active)
+
+
+# ── PUT /{agent_id}/personas/{persona_id} ───────────────────────────────────
+
+
+class PersonaApprovalUpdate(BaseModel):
+    """Partial ``[persona.approval]`` patch. Omitted fields are unchanged."""
+
+    default_policy: str | None = Field(default=None)
+    auto_approve: list[str] | None = Field(default=None)
+    require_approval: list[str] | None = Field(default=None)
+
+
+class PersonaUpdateBody(BaseModel):
+    """Mutable persona fields. Mirrors the GET detail schema minus the
+    server-derived bits (``id``, ``active``, ``raw_toml``) and ``budget``
+    (which has its own ``/budget`` route). Every field is optional — a PUT
+    is a partial patch; only the supplied fields are overwritten.
+    """
+
+    display_name: str | None = Field(default=None)
+    summary: str | None = Field(default=None)
+    system_prompt: str | None = Field(default=None)
+    tools_allowed: list[str] | None = Field(default=None)
+    memory_namespace: str | None = Field(default=None)
+    preferred_upstream: str | None = Field(default=None)
+    preferred_model: str | None = Field(default=None)
+    approval: PersonaApprovalUpdate | None = Field(default=None)
+
+
+@router.put("/{agent_id}/personas/{persona_id}")
+async def update_agent_persona(
+    agent_id: str,
+    persona_id: str,
+    body: PersonaUpdateBody,
+) -> dict[str, Any]:
+    """Update the mutable fields of one persona, persisting to its TOML.
+
+    Backs the dashboard's ``PersonaEditModal``. The persona ``id`` is
+    immutable (it's the filename) — only the fields in
+    :class:`PersonaUpdateBody` can change. ``budget`` is preserved
+    verbatim (it round-trips through the existing persona; the dedicated
+    ``/budget`` route owns spending-cap edits).
+
+    404 if the agent id or persona file is unknown; 400 if the existing
+    file is malformed OR the patched persona fails validation (e.g. an
+    invalid ``default_policy``). On success returns the same payload as
+    ``GET /{agent_id}/personas/{persona_id}``.
+    """
+    root = _resolve_agent(agent_id)
+
+    # Load the existing persona so unsupplied fields (and budget) survive
+    # the patch. 404/400 handling mirrors the GET detail route.
+    try:
+        existing = personas_mod.load_persona(persona_id, root=root)
+    except FileNotFoundError as exc:
+        raise NotFound(
+            f"persona {persona_id!r} not found",
+            code="persona.not_found",
+            details={"agent_id": agent_id, "persona_id": persona_id},
+        ) from exc
+    except personas_mod.PersonaError as exc:
+        raise BadRequest(
+            _safe_error_message(exc),
+            code="persona.malformed",
+            details={"agent_id": agent_id, "persona_id": persona_id},
+        ) from exc
+
+    # Start from the full TOML shape (carries budget + every sub-table),
+    # overlay the supplied fields, then round-trip through from_dict so the
+    # same validation the loader applies (default_policy enum, list-of-str
+    # shapes) gates the write.
+    data = existing.to_dict()
+    p = data["persona"]
+    p["id"] = persona_id  # immutable — the filename is authoritative.
+    if body.display_name is not None:
+        p["display_name"] = body.display_name
+    if body.summary is not None:
+        p["summary"] = body.summary
+    if body.system_prompt is not None:
+        p["prompt"]["system"] = body.system_prompt
+    if body.tools_allowed is not None:
+        p["tools"]["allowed"] = body.tools_allowed
+    if body.memory_namespace is not None:
+        p["memory"]["namespace"] = body.memory_namespace
+    if body.preferred_upstream is not None:
+        p["model"]["preferred_upstream"] = body.preferred_upstream
+    if body.preferred_model is not None:
+        p["model"]["preferred_model"] = body.preferred_model
+    if body.approval is not None:
+        if body.approval.default_policy is not None:
+            p["approval"]["default_policy"] = body.approval.default_policy
+        if body.approval.auto_approve is not None:
+            p["approval"]["auto_approve"] = body.approval.auto_approve
+        if body.approval.require_approval is not None:
+            p["approval"]["require_approval"] = body.approval.require_approval
+
+    try:
+        updated = personas_mod.Persona.from_dict(data)
+    except personas_mod.PersonaError as exc:
+        raise BadRequest(
+            _safe_error_message(exc),
+            code="persona.invalid",
+            details={"agent_id": agent_id, "persona_id": persona_id},
+        ) from exc
+
+    try:
+        target = personas_mod.save_persona(updated, root=root)
+        raw_toml = target.read_text(encoding="utf-8")
+    except OSError as exc:
+        log.warning(
+            "persona.update_write_failed",
+            agent_id=agent_id,
+            persona_id=persona_id,
+            error=str(exc),
+        )
+        raise Hal0Error(
+            "persona write failed",
+            code="persona.write_failed",
+        ) from exc
+
+    log.info("persona.updated", agent_id=agent_id, persona_id=persona_id)
+    active = personas_mod.get_active(root=root)
+    return _persona_detail(updated, raw_toml=raw_toml, active_id=active)
 
 
 # ── POST /{agent_id}/personas/{persona_id}/activate ─────────────────────────

--- a/src/hal0/api/mcp_mount.py
+++ b/src/hal0/api/mcp_mount.py
@@ -29,12 +29,25 @@ headers off that request at call time, mirroring the REST surface in
 from __future__ import annotations
 
 import os
+import re
 
 import structlog
 from starlette.requests import Request
 from starlette.types import ASGIApp
 
 log = structlog.get_logger("hal0.api.mcp_mount")
+
+# Header carrying the caller's agent identity (post-ADR-0012 — Bearer auth
+# was removed; identity flows on this header, same as the REST memory
+# surface in :mod:`hal0.api.routes.memory`).
+_AGENT_HEADER = "x-hal0-agent"
+
+# ADR-0005 §5 identity grammar — alnum + ``-`` + ``_``, ≤64 chars. The
+# value feeds the ``private:<agent>`` dataset name + the audit source, so
+# it must be path-traversal-free and bounded. Mirrors
+# ``hal0.api.routes.memory._AGENT_ID_PATTERN`` so MCP + REST resolve the
+# same identity to the same namespace (issue #317).
+_AGENT_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_\-]{1,64}$")
 
 # Localhost values FastMCP itself uses when it auto-enables DNS-rebinding
 # protection for a 127.0.0.1 server. We keep them as the secure floor so
@@ -147,9 +160,35 @@ def bearer_resolver() -> tuple[str | None, str]:
 
 
 def client_id_resolver() -> str:
-    """Return ``client_id`` for the current MCP request. See
-    :func:`bearer_resolver`."""
-    return bearer_resolver()[1]
+    """Return ``client_id`` for the current MCP request (issue #317).
+
+    Identity comes from the ``X-hal0-Agent`` header — the same header the
+    REST memory surface reads (:func:`hal0.api.routes.memory._agent_id`).
+    Before this fix the resolver returned the Bearer token, so MCP callers
+    sending ``X-hal0-Agent`` + ``X-hal0-Private`` collapsed to the
+    ``anonymous`` client and their private writes silently landed in the
+    ``shared`` namespace.
+
+    Validation mirrors the REST side: the value must match
+    ``^[a-zA-Z0-9_\\-]{1,64}$`` and must not carry a ``private:`` prefix
+    (the namespace is reached via :func:`private_resolver`, not by
+    smuggling the prefix through identity). An absent / malformed header
+    falls back to ``"anonymous"`` — the downstream namespace resolver then
+    rejects a ``private`` write with no client_id rather than mis-scoping
+    it.
+    """
+    request = _current_mcp_request()
+    if request is None:
+        return "anonymous"
+    raw = request.headers.get(_AGENT_HEADER)
+    if raw is None:
+        return "anonymous"
+    candidate = raw.strip()
+    if not candidate or candidate.startswith("private:"):
+        return "anonymous"
+    if not _AGENT_ID_PATTERN.match(candidate):
+        return "anonymous"
+    return candidate
 
 
 def private_resolver() -> bool:

--- a/src/hal0/api/routes/health.py
+++ b/src/hal0/api/routes/health.py
@@ -16,14 +16,40 @@ a follow-up (scrape each container's own ``/metrics``).
 
 from __future__ import annotations
 
+import os
+import shutil
+from pathlib import Path
 from typing import Any
 
+import structlog
 from fastapi import APIRouter, Request
 from fastapi.responses import Response
 
 from hal0 import __version__
+from hal0.config import paths
+
+log = structlog.get_logger(__name__)
 
 router = APIRouter()
+
+# Below this free-space floor a disk check reports "degraded" (not down —
+# hal0 still serves, but model pulls / state writes are at risk).
+_DISK_FREE_FLOOR_MB = 500
+
+
+def _disk_free_mb(path: Path) -> int:
+    """Free MiB on the filesystem hosting ``path`` (0 if unavailable).
+
+    Walks up to the first existing parent so a not-yet-created state dir
+    on a fresh install still reports the underlying filesystem's space.
+    """
+    try:
+        target = path
+        while not target.exists() and target != target.parent:
+            target = target.parent
+        return shutil.disk_usage(str(target)).free // (1024 * 1024)
+    except OSError:
+        return 0
 
 
 @router.get("/status")
@@ -96,8 +122,54 @@ async def get_status(request: Request) -> dict[str, Any]:
 
 
 @router.get("/health/system")
-async def health_system() -> dict[str, object]:
-    return {"status": "ok", "checks": {}}
+async def health_system(request: Request) -> dict[str, Any]:
+    """Deep health: disk headroom, slot manager, event bus.
+
+    Always returns HTTP 200 with an honest payload — the dashboard reads
+    ``status`` (``ok`` | ``degraded``) and the per-check ``checks`` map
+    rather than relying on the HTTP status, so a single soft failure
+    (low disk, slot manager not yet wired) surfaces without 5xx-ing the
+    whole liveness poll.
+    """
+    checks: dict[str, Any] = {}
+    degraded = False
+
+    # ── disk headroom on the state + config roots ───────────────────────
+    # HAL0_HOME (when set) reparents both roots, so checking var_lib()
+    # covers the dev/test sandbox AND the production /var/lib/hal0 path.
+    for label, root in (("state", paths.var_lib()), ("config", paths.etc())):
+        free_mb = _disk_free_mb(root)
+        ok = free_mb >= _DISK_FREE_FLOOR_MB
+        checks[f"disk_{label}"] = {
+            "ok": ok,
+            "free_mb": free_mb,
+            "floor_mb": _DISK_FREE_FLOOR_MB,
+            "path": str(root),
+        }
+        degraded = degraded or not ok
+
+    # ── slot manager responsive ─────────────────────────────────────────
+    sm = getattr(request.app.state, "slot_manager", None)
+    if sm is None:
+        checks["slot_manager"] = {"ok": False, "detail": "not wired"}
+        degraded = True
+    else:
+        try:
+            slots = await sm.list()
+            checks["slot_manager"] = {"ok": True, "slots": len(slots)}
+        except Exception as exc:
+            checks["slot_manager"] = {"ok": False, "detail": str(exc)}
+            degraded = True
+
+    # ── event bus alive ─────────────────────────────────────────────────
+    event_bus = getattr(request.app.state, "events", None)
+    checks["event_bus"] = {"ok": event_bus is not None}
+    degraded = degraded or event_bus is None
+
+    return {
+        "status": "degraded" if degraded else "ok",
+        "checks": checks,
+    }
 
 
 @router.get("/metrics")
@@ -137,5 +209,43 @@ async def metrics_prometheus(request: Request) -> Response:
 
 
 @router.get("/features")
-async def list_features() -> dict[str, bool]:
-    return {}
+async def list_features(request: Request) -> dict[str, Any]:
+    """Runtime feature gates the dashboard branches on.
+
+    Flat ``feature → bool | str`` map:
+
+      - ``comfyui_switchover``: image-gen engine switchover is unlocked
+        (``HAL0_COMFYUI_SWITCHOVER_ENABLED=1``).
+      - ``memory``: a memory provider is wired (HAL0_MEMORY_ENABLED + a
+        successful init).
+      - ``memory_engine``: the configured engine name (``hindsight`` |
+        ``cognee`` | ``mem0`` | …) — a string, not a bool.
+      - ``npu``: an NPU was detected by the (cached) hardware probe.
+      - ``mcp_supervisor``: the MCP process supervisor (start/stop/
+        restart) — not implemented yet (pending ADR-0015), always false.
+    """
+    features: dict[str, Any] = {
+        "comfyui_switchover": os.environ.get("HAL0_COMFYUI_SWITCHOVER_ENABLED", "") == "1",
+        "memory": getattr(request.app.state, "memory_provider", None) is not None,
+        "mcp_supervisor": False,
+    }
+
+    # memory engine name — read from hal0.toml; default to the schema
+    # default rather than 500-ing the whole feature map on a parse error.
+    try:
+        from hal0.config.loader import load_hal0_config
+
+        features["memory_engine"] = load_hal0_config().memory.engine
+    except Exception:
+        features["memory_engine"] = "unknown"
+
+    # NPU presence via the cached install-time probe (cheap: reads
+    # hardware.json, never shells out on the request path).
+    try:
+        from hal0.config.loader import load_hardware_info
+
+        features["npu"] = bool(load_hardware_info().npu.present)
+    except Exception:
+        features["npu"] = False
+
+    return features

--- a/src/hal0/api/routes/mcp.py
+++ b/src/hal0/api/routes/mcp.py
@@ -55,15 +55,17 @@ router = APIRouter()
 
 
 class McpNotImplemented(Hal0Error):
-    """``POST /{id}/{action}`` still stubs here.
+    """``POST /{id}/{action}`` (start / stop / restart) still stubs here.
 
     Install / uninstall / config-patch landed in #305; start / stop /
-    restart need the still-pending process-supervisor layer. The
-    dashboard surfaces a distinct toast on this code so operators can
-    tell ``install`` (works) from ``restart`` (not yet) apart.
+    restart need the still-pending process-supervisor layer (ADR-0015,
+    not yet written). The code is the explicit
+    ``mcp.supervisor_unavailable`` so the dashboard can key on it and
+    render a "supervisor not implemented yet" affordance distinct from a
+    generic 501.
     """
 
-    code = "mcp.not_implemented"
+    code = "mcp.supervisor_unavailable"
     status = 501
 
 
@@ -806,6 +808,6 @@ async def server_action(server_id: str, action: str) -> dict[str, Any]:
     for this 501 vs the (now-real) install/uninstall path.
     """
     raise McpNotImplemented(
-        f"MCP {action!r} pending the process-supervisor follow-up to #305",
+        "process supervisor not implemented (pending ADR-0015)",
         details={"server_id": server_id, "action": action},
     )

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -6,8 +6,9 @@ through this surface; there is no other writer for ``[memory.graph]``
 so a swap-flip from either client lands atomically through the same
 ``save_hal0_config`` pipeline.
 
-The actual cognify dispatch lives in :class:`hal0.memory.CogneeWrapper`;
-this module is the thin HTTP veneer that:
+The actual graph-extraction dispatch lives in the active memory provider
+(:class:`hal0.memory.MemoryProvider`); this module is the thin HTTP
+veneer that:
 
   - Returns ``graph_status()`` (enabled / route / counters / last-built).
   - Validates the toggle payload against :class:`MemoryGraphConfig`.

--- a/src/hal0/api/routes/providers.py
+++ b/src/hal0/api/routes/providers.py
@@ -15,10 +15,8 @@ TOML files as the source of truth; a fully reactive editor lands later.
 
 from __future__ import annotations
 
-import contextlib
 import os
 import re
-import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +24,7 @@ import structlog
 from fastapi import APIRouter, Request
 from pydantic import BaseModel, Field
 
+from hal0.api._env_store import upsert_env_value
 from hal0.api._redact import redact_config
 from hal0.api.middleware.error_codes import Hal0Error
 from hal0.config import paths
@@ -183,73 +182,19 @@ async def list_providers(request: Request) -> list[dict[str, Any]]:
 def _write_credential_to_api_env(api_env: Path, key: str, value: str) -> None:
     """Upsert ``key=<quoted-value>`` in ``api_env`` atomically.
 
-    Mirrors the tmp-file + ``os.replace`` posture used by
-    ``hal0.api.routes.auth._set_auth_disabled_in_env``: if a line for
-    ``key`` exists (commented or not) it is replaced in place;
-    otherwise the line is appended. Values are double-quoted with
-    embedded quotes/backslashes escaped so systemd's EnvironmentFile
-    parser sees the literal secret.
+    Thin wrapper over :func:`hal0.api._env_store.upsert_env_value` — the
+    atomic tmp-file + ``os.replace`` + mode-0600 writer now lives in the
+    shared env store so the ``/api/secrets`` router writes to the same
+    file with identical posture. Read/write failures surface as
+    :class:`ProviderCredentialError` so the route's envelope is unchanged.
     """
-    api_env.parent.mkdir(parents=True, exist_ok=True)
-    existing = ""
     try:
-        existing = api_env.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        pass
+        upsert_env_value(api_env, key, value)
     except OSError as exc:
         raise ProviderCredentialError(
-            f"could not read {api_env}: {exc}",
+            f"could not write {api_env}: {exc}",
             details={"path": str(api_env), "error": str(exc)},
         ) from exc
-
-    # systemd EnvironmentFile= treats double-quoted values as a single
-    # token with the outer quotes stripped. Escape backslash + double
-    # quote so the secret round-trips verbatim.
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-    new_line = f'{key}="{escaped}"\n'
-
-    lines = existing.splitlines(keepends=True) if existing else []
-    rewritten: list[str] = []
-    replaced = False
-    prefix_plain = f"{key}="
-    prefix_commented = f"# {key}="
-    prefix_commented_tight = f"#{key}="
-    for line in lines:
-        stripped = line.lstrip()
-        if (
-            stripped.startswith(prefix_plain)
-            or stripped.startswith(prefix_commented)
-            or stripped.startswith(prefix_commented_tight)
-        ):
-            if not replaced:
-                rewritten.append(new_line)
-                replaced = True
-            continue
-        rewritten.append(line)
-    if not replaced:
-        if rewritten and not rewritten[-1].endswith("\n"):
-            rewritten.append("\n")
-        rewritten.append(new_line)
-
-    fd, tmp_str = tempfile.mkstemp(
-        prefix=f".{api_env.name}.",
-        suffix=".tmp",
-        dir=str(api_env.parent),
-    )
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write("".join(rewritten))
-            f.flush()
-            os.fsync(f.fileno())
-        # Mode 0600 — this file now holds a secret. Tighter than the
-        # auth.env defaults because provider keys are higher-value than
-        # the toggle line that lives next to them.
-        os.chmod(tmp_str, 0o600)
-        os.replace(tmp_str, api_env)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            os.unlink(tmp_str)
-        raise
 
 
 @router.post("/providers/{name}/credentials")

--- a/src/hal0/api/routes/secrets.py
+++ b/src/hal0/api/routes/secrets.py
@@ -1,0 +1,220 @@
+"""Operator-managed secrets store (mounted under ``/api/secrets``).
+
+Backs the dashboard's Settings → Secrets panel (``useSecrets`` /
+``useSecretSet`` / ``useSecretDelete`` hooks). Secrets are persisted to
+``/etc/hal0/api.env`` — the same systemd ``EnvironmentFile=`` the
+provider-credential writer targets — via the shared atomic, mode-0600
+writer in :mod:`hal0.api._env_store`. The running process's
+``os.environ`` is updated in lockstep so a freshly-set secret is
+observable without a restart; the persisted line is the source of truth
+across restarts.
+
+Endpoints::
+
+    GET    /api/secrets            — list secret NAMES (never values)
+    POST   /api/secrets/{name}     — set/overwrite a secret  → 204
+    PUT    /api/secrets/{name}     — set/overwrite a secret  → 204
+    DELETE /api/secrets/{name}     — remove a secret         → 204
+
+Both POST and PUT are accepted for the set path: the v3 dashboard's
+``useSecretSet`` hook POSTs ``{value}`` while the documented contract is
+PUT — accepting both keeps the route honest with the running UI and the
+spec at once.
+
+Security posture (ADR-0012 — auth removed, open on the trusted LAN):
+
+  - Secret VALUES are NEVER returned by any endpoint, never logged, and
+    never echoed in an error body.
+  - Names are validated against ``^[A-Z][A-Z0-9_]{0,63}$`` so a caller
+    can't smuggle a newline / shell metacharacter / lowercase env-var
+    into ``api.env``.
+  - Writes + deletes emit a structured audit row (name only) and a
+    footer journal event so an operator can see *that* a secret changed
+    without the value ever touching a log line.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Request
+from fastapi.responses import Response
+from pydantic import BaseModel, Field
+
+from hal0.api._env_store import (
+    delete_env_value,
+    list_env_keys,
+    upsert_env_value,
+)
+from hal0.config import paths
+from hal0.errors import Hal0Error
+
+_audit_log = structlog.get_logger("hal0.audit")
+_log = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+# Secret names: ALL_CAPS env-var grammar, must start with a letter, ≤64
+# chars total. Tighter than the provider-credential rule (which allows a
+# leading underscore) — operator-set secrets are plain env-vars.
+_SECRET_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,63}$")
+
+# Fixed mask returned for every set secret. We do NOT keep the value, so
+# this is a constant "it is set" indicator, never a partial reveal.
+_MASK = "••••••••"
+
+
+class SecretNameInvalid(Hal0Error):
+    code = "secret.name_invalid"
+    status = 400
+
+
+class SecretValueInvalid(Hal0Error):
+    code = "secret.value_invalid"
+    status = 400
+
+
+class SecretNotFound(Hal0Error):
+    code = "secret.not_found"
+    status = 404
+
+
+class SecretWriteFailed(Hal0Error):
+    code = "secret.write_failed"
+    status = 400
+
+
+class SecretBody(BaseModel):
+    """Set-secret request body — a single opaque value."""
+
+    value: str = Field(..., min_length=1)
+
+
+def _api_env() -> Path:
+    """Resolve the api.env path (HAL0_HOME-relative under tests)."""
+    return paths.etc() / "api.env"
+
+
+def _validate_name(name: str) -> str:
+    """Return the validated secret name or raise :class:`SecretNameInvalid`."""
+    candidate = name.strip()
+    if not _SECRET_NAME_RE.match(candidate):
+        raise SecretNameInvalid(
+            "secret name must match ^[A-Z][A-Z0-9_]{0,63}$ "
+            "(ALL_CAPS env-var, leading letter, no shell metacharacters)",
+            details={"name": name},
+        )
+    return candidate
+
+
+def _updated_at(api_env: Path) -> str | None:
+    """File-mtime (ISO 8601 UTC) of api.env, or None if it doesn't exist.
+
+    An ``EnvironmentFile`` carries no per-key timestamps, so the file
+    mtime is the honest best-effort "last changed" signal for every key.
+    """
+    try:
+        mtime = api_env.stat().st_mtime
+    except OSError:
+        return None
+    return datetime.fromtimestamp(mtime, tz=UTC).isoformat()
+
+
+async def _emit(request: Request, type_: str, message: str, name: str) -> None:
+    """Best-effort footer journal event — name only, never the value."""
+    event_bus = getattr(request.app.state, "events", None)
+    if event_bus is None:
+        return
+    try:
+        await event_bus.emit(
+            type_,
+            "info",
+            f"secret:{name}",
+            message,
+            data={"name": name},
+        )
+    except Exception:  # pragma: no cover — event bus is best-effort
+        _log.debug("secret.event_emit_failed", type=type_, name=name)
+
+
+@router.get("")
+async def list_secrets() -> dict[str, Any]:
+    """List secret NAMES (never values).
+
+    Shape matches the dashboard's ``useSecrets`` hook —
+    ``{"secrets": [{name, set, masked, updated_at}]}``. Every entry is
+    ``set: true`` (a name only appears here because it's present in
+    api.env); ``masked`` is a constant indicator, never a partial reveal.
+    """
+    api_env = _api_env()
+    updated_at = _updated_at(api_env)
+    entries = [
+        {"name": name, "set": True, "masked": _MASK, "updated_at": updated_at}
+        for name in list_env_keys(api_env)
+    ]
+    return {"secrets": entries}
+
+
+async def _set_secret(name: str, body: SecretBody, request: Request) -> Response:
+    """Shared set/overwrite implementation for POST + PUT."""
+    key = _validate_name(name)
+    if not body.value:
+        raise SecretValueInvalid("secret value must be non-empty", details={"name": key})
+
+    api_env = _api_env()
+    try:
+        upsert_env_value(api_env, key, body.value)
+    except OSError as exc:
+        raise SecretWriteFailed(
+            f"could not write secret to {api_env}: {exc}",
+            details={"name": key, "error": str(exc)},
+        ) from exc
+
+    # Mirror the provider-credential path: update the live process env so
+    # the new secret is observable without a restart; persisted api.env is
+    # the source of truth across restarts.
+    os.environ[key] = body.value
+
+    _audit_log.info("secret.set", name=key, api_env_path=str(api_env))
+    await _emit(request, "system.secret_updated", f"secret {key!r} set", key)
+    return Response(status_code=204)
+
+
+@router.post("/{name}", status_code=204)
+async def set_secret_post(name: str, body: SecretBody, request: Request) -> Response:
+    """Set/overwrite a secret (POST form — matches the v3 ``useSecretSet`` hook)."""
+    return await _set_secret(name, body, request)
+
+
+@router.put("/{name}", status_code=204)
+async def set_secret_put(name: str, body: SecretBody, request: Request) -> Response:
+    """Set/overwrite a secret (PUT form — documented contract)."""
+    return await _set_secret(name, body, request)
+
+
+@router.delete("/{name}", status_code=204)
+async def delete_secret(name: str, request: Request) -> Response:
+    """Remove a secret. Idempotent — returns 204 even if it wasn't set."""
+    key = _validate_name(name)
+    api_env = _api_env()
+    try:
+        removed = delete_env_value(api_env, key)
+    except OSError as exc:
+        raise SecretWriteFailed(
+            f"could not delete secret from {api_env}: {exc}",
+            details={"name": key, "error": str(exc)},
+        ) from exc
+
+    # Drop from the live process env regardless so a restart isn't needed
+    # to stop honouring the secret.
+    os.environ.pop(key, None)
+
+    if removed:
+        _audit_log.info("secret.deleted", name=key, api_env_path=str(api_env))
+        await _emit(request, "system.secret_deleted", f"secret {key!r} deleted", key)
+    return Response(status_code=204)

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -1539,3 +1539,69 @@ async def pull_slot_image_stream(name: str, request: Request) -> StreamingRespon
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )
+
+
+@router.get("/{name}/pull/status")
+async def pull_slot_image_status(name: str, request: Request) -> dict[str, object]:
+    """Poll fallback for container image-pull progress (mirror of #9).
+
+    The SSE stream (``/{name}/pull/stream``) is the live path; this is the
+    one-shot poll equivalent for clients that can't hold an EventSource
+    open. Returns the in-flight job snapshot when a pull is active,
+    otherwise inspects the slot's image and reports ``present`` |
+    ``missing`` — the same terminal vocabulary the stream's no-job branch
+    emits, so a poller and a streamer converge on the same states.
+
+    Frame shape::
+
+        {"slot_name": "...", "image": "...", "state": "...",
+         "layer": N, "total_layers": M, "error": null}
+
+    States: ``pulling`` | ``completed`` | ``failed`` | ``present`` |
+    ``missing``.
+    """
+    slot_pull_jobs: dict[str, Any] = getattr(request.app.state, "slot_pull_jobs", {})
+    job = slot_pull_jobs.get(name)
+    if job is not None:
+        return job.as_dict()
+
+    # No active pull — resolve the slot's image + inspect presence so the
+    # poller gets the same present|missing terminal the SSE stream emits.
+    image: str | None = None
+    try:
+        sm = _get_slot_manager(request)
+        configs = await sm.iter_configs()
+        for cfg in configs:
+            if str(cfg.get("name", "")) == name:
+                profile_name = str(cfg.get("profile") or "")
+                if profile_name:
+                    from hal0.config.loader import load_profiles_config
+
+                    catalog = load_profiles_config()
+                    prof = catalog.profile.get(profile_name)
+                    if prof:
+                        image = prof.image
+                break
+    except Exception:
+        pass
+
+    state = "missing"
+    if image:
+        try:
+            from hal0.providers.container import container_provider
+
+            present = await asyncio.get_event_loop().run_in_executor(
+                None, container_provider().image_present, image
+            )
+            state = "present" if present else "missing"
+        except Exception:
+            state = "missing"
+
+    return {
+        "slot_name": name,
+        "image": image,
+        "state": state,
+        "layer": 0,
+        "total_layers": 0,
+        "error": None,
+    }

--- a/src/hal0/dispatcher/memory_dispatcher.py
+++ b/src/hal0/dispatcher/memory_dispatcher.py
@@ -1,14 +1,14 @@
 """In-process memory dispatcher for the MCP admin server.
 
 ADR-0004 §7 plus ADR-0005 §2 together demand: the admin MCP server's
-``memory_*`` tool family must reach Cognee *without* an HTTP loop-back
-through ``/mcp/memory``. The loop-back works (and was the v0.2 stopgap),
-but every round trip pays a transport tax and re-runs Bearer
-verification against the local API just to land in the same Python
-process.
+``memory_*`` tool family must reach the memory provider *without* an
+HTTP loop-back through ``/mcp/memory``. The loop-back works (and was the
+v0.2 stopgap), but every round trip pays a transport tax and re-runs
+Bearer verification against the local API just to land in the same
+Python process.
 
 :class:`MemoryDispatcher` is the thin adapter that closes the loop. It
-holds a :class:`~hal0.memory.cognee_wrapper.CogneeWrapper`, wires the
+holds a memory provider (:class:`~hal0.memory.MemoryProvider`), wires the
 same per-call ``client_id`` / ``private`` resolvers the
 out-of-process server uses, and exposes the callable shape that
 :func:`hal0.mcp.admin.dispatch` expects on its ``memory_dispatcher=``
@@ -23,7 +23,7 @@ ONE object (testable, mockable, swappable) instead of a free-floating
 closure.
 
 Construction is cheap and synchronous — the orchestrator instantiates
-in ``create_app`` next to the CogneeWrapper itself, then passes the
+in ``create_app`` next to the memory provider itself, then passes the
 instance into ``mount_mcp_servers(...)`` as ``memory_dispatcher=``.
 """
 
@@ -40,18 +40,19 @@ log = structlog.get_logger(__name__)
 
 
 class MemoryDispatcher:
-    """In-process bridge from MCP admin to a CogneeWrapper.
+    """In-process bridge from MCP admin to a memory provider.
 
     Parameters
     ----------
     wrapper:
-        The :class:`hal0.memory.cognee_wrapper.CogneeWrapper` instance
-        the dispatcher should call. Pass the same singleton the memory
-        MCP server holds so both transports see one Cognee state.
+        The memory provider (:class:`hal0.memory.MemoryProvider`) the
+        dispatcher should call. Pass the same singleton the memory MCP
+        server holds so both transports see one memory-provider state.
     client_id_resolver:
-        Zero-arg callable returning the Bearer-derived caller id for
-        the current request. Defaults to "anonymous" — tests that
-        don't care about audit grounding can leave this None.
+        Zero-arg callable returning the caller id (from the
+        ``X-hal0-Agent`` header) for the current request. Defaults to
+        "anonymous" — tests that don't care about audit grounding can
+        leave this None.
     private_resolver:
         Zero-arg callable returning whether the current call opted into
         the ``private:<client_id>`` namespace (ADR-0005 §3). Defaults
@@ -98,7 +99,7 @@ class MemoryDispatcher:
 
     @property
     def wrapper(self) -> Any:
-        """The underlying CogneeWrapper. Exposed so tests can introspect
+        """The underlying memory provider. Exposed so tests can introspect
         which instance the dispatcher is bound to without reaching into
         a private attribute."""
         return self._wrapper

--- a/tests/api/test_features_health.py
+++ b/tests/api/test_features_health.py
@@ -1,0 +1,61 @@
+"""Tests for the real /api/features + /api/health/system surfaces.
+
+Both were `{}` / `{"status":"ok","checks":{}}` stubs (health.py). Now they
+return live gates + honest deep-health checks. The dashboard branches on
+``features`` and reads ``status`` / ``checks`` from health.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_features_shape(client: TestClient) -> None:
+    r = client.get("/api/features")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # Every documented gate present.
+    for key in ("comfyui_switchover", "memory", "memory_engine", "npu", "mcp_supervisor"):
+        assert key in body, f"missing feature gate {key!r}"
+    assert isinstance(body["comfyui_switchover"], bool)
+    assert isinstance(body["memory"], bool)
+    assert isinstance(body["memory_engine"], str)
+    assert isinstance(body["npu"], bool)
+    # MCP supervisor not implemented (pending ADR-0015).
+    assert body["mcp_supervisor"] is False
+
+
+def test_features_comfyui_gate_reads_env(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
+    assert client.get("/api/features").json()["comfyui_switchover"] is True
+    monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "0")
+    assert client.get("/api/features").json()["comfyui_switchover"] is False
+
+
+def test_features_memory_reflects_state(client: TestClient) -> None:
+    """``memory`` mirrors app.state.memory_provider (HAL0_MEMORY_ENABLED=1
+    in the test env → a provider is wired)."""
+    expected = getattr(client.app.state, "memory_provider", None) is not None
+    assert client.get("/api/features").json()["memory"] is expected
+
+
+def test_health_system_ok_payload(client: TestClient) -> None:
+    r = client.get("/api/health/system")
+    assert r.status_code == 200, r.text  # always 200, honest payload
+    body = r.json()
+    assert body["status"] in ("ok", "degraded")
+    checks = body["checks"]
+    # Disk + slot-manager + event-bus checks all present.
+    assert "disk_state" in checks
+    assert "disk_config" in checks
+    assert "slot_manager" in checks
+    assert "event_bus" in checks
+    # With the lifespan run, slot manager + event bus are wired.
+    assert checks["slot_manager"]["ok"] is True
+    assert checks["event_bus"]["ok"] is True
+    # Disk checks carry a numeric free_mb.
+    assert isinstance(checks["disk_state"]["free_mb"], int)

--- a/tests/api/test_mcp_identity.py
+++ b/tests/api/test_mcp_identity.py
@@ -1,0 +1,75 @@
+"""Tests for #317 — MCP caller identity via the ``X-hal0-Agent`` header.
+
+Before the fix ``client_id_resolver`` returned the Bearer token, so an MCP
+client sending ``X-hal0-Agent`` + ``X-hal0-Private`` collapsed to
+``anonymous`` and its private writes silently landed in ``shared``. The
+resolver now reads + validates ``X-hal0-Agent`` exactly like the REST
+memory surface, so private writes resolve to ``private:<agent>``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.requests import Request
+
+from hal0.api import mcp_mount
+from hal0.memory.namespace import resolve_write_dataset
+
+
+def _fake_request(headers: dict[str, str]) -> Request:
+    """Minimal Starlette Request exposing the given headers."""
+    raw = [(k.lower().encode(), v.encode()) for k, v in headers.items()]
+    return Request({"type": "http", "headers": raw})
+
+
+@pytest.fixture
+def patch_request(monkeypatch: pytest.MonkeyPatch):
+    """Return a setter that points the MCP request context at fake headers."""
+
+    def _set(headers: dict[str, str] | None) -> None:
+        req = _fake_request(headers) if headers is not None else None
+        monkeypatch.setattr(mcp_mount, "_current_mcp_request", lambda: req)
+
+    return _set
+
+
+def test_client_id_from_agent_header(patch_request) -> None:
+    patch_request({"X-hal0-Agent": "bob"})
+    assert mcp_mount.client_id_resolver() == "bob"
+
+
+def test_client_id_anonymous_when_header_absent(patch_request) -> None:
+    patch_request({})
+    assert mcp_mount.client_id_resolver() == "anonymous"
+
+
+def test_client_id_anonymous_outside_request(patch_request) -> None:
+    patch_request(None)
+    assert mcp_mount.client_id_resolver() == "anonymous"
+
+
+def test_client_id_rejects_private_prefix(patch_request) -> None:
+    patch_request({"X-hal0-Agent": "private:bob"})
+    assert mcp_mount.client_id_resolver() == "anonymous"
+
+
+@pytest.mark.parametrize("bad", ["../etc", "has space", "x" * 65, "tab\tname"])
+def test_client_id_rejects_malformed(patch_request, bad: str) -> None:
+    patch_request({"X-hal0-Agent": bad})
+    assert mcp_mount.client_id_resolver() == "anonymous"
+
+
+def test_private_resolver_reads_header(patch_request) -> None:
+    patch_request({"X-hal0-Private": "1"})
+    assert mcp_mount.private_resolver() is True
+    patch_request({})
+    assert mcp_mount.private_resolver() is False
+
+
+def test_private_write_lands_in_agent_namespace(patch_request) -> None:
+    """End-to-end #317: X-hal0-Agent + private → private:<agent>, not shared."""
+    patch_request({"X-hal0-Agent": "bob", "X-hal0-Private": "1"})
+    client_id = mcp_mount.client_id_resolver()
+    private = mcp_mount.private_resolver()
+    dataset = resolve_write_dataset(None, private=private, client_id=client_id)
+    assert dataset == "private:bob"

--- a/tests/api/test_mcp_routes.py
+++ b/tests/api/test_mcp_routes.py
@@ -594,7 +594,11 @@ def test_patch_config_rejects_bad_env(client: TestClient) -> None:
 def test_action_returns_501(client: TestClient) -> None:
     response = client.post("/api/mcp/hal0-admin/restart")
     assert response.status_code == 501
-    assert response.json()["error"]["code"] == "mcp.not_implemented"
+    # Explicit supervisor-unavailable code (pending ADR-0015) so the UI can
+    # key on it rather than a generic 501.
+    err = response.json()["error"]
+    assert err["code"] == "mcp.supervisor_unavailable"
+    assert "ADR-0015" in err["message"]
 
 
 # ── Security hardening (#368 review) ────────────────────────────────────────

--- a/tests/api/test_persona_update.py
+++ b/tests/api/test_persona_update.py
@@ -1,0 +1,115 @@
+"""HTTP tests for ``PUT /api/agents/{agent_id}/personas/{persona_id}``.
+
+Pins the persona-update contract the dashboard's ``PersonaEditModal``
+calls. Mutable fields persist to the persona TOML; ``id`` is immutable;
+``budget`` round-trips untouched; validation rejects a bad
+``default_policy``. Personas store is redirected to tmp_path so the test
+runner never writes to /var/lib/hal0.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hal0.agents import personas as personas_mod
+from hal0.api.agents import personas as personas_route
+
+
+@pytest.fixture
+def personas_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    root = tmp_path / "personas"
+    root.mkdir()
+    monkeypatch.setattr(personas_mod, "PERSONAS_ROOT", root)
+    monkeypatch.setitem(personas_route._AGENT_PERSONAS_ROOTS, "hermes", root)
+    yield root
+
+
+@pytest.fixture
+def seeded(personas_root: Path) -> Path:
+    personas_mod.seed_default_personas(agent_id="hermes-agent", root=personas_root)
+    return personas_root
+
+
+def test_update_persists_mutable_fields(client: TestClient, seeded: Path) -> None:
+    r = client.put(
+        "/api/agents/hermes/personas/hermes",
+        json={
+            "display_name": "Hermes Prime",
+            "summary": "updated summary",
+            "system_prompt": "You are Hermes Prime.",
+            "tools_allowed": ["memory.*", "slot.read.*"],
+            "preferred_model": "qwen3-coder",
+            "approval": {"default_policy": "auto-approve"},
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["id"] == "hermes"
+    assert body["display_name"] == "Hermes Prime"
+    assert body["summary"] == "updated summary"
+    assert body["system_prompt"] == "You are Hermes Prime."
+    assert body["tools_allowed"] == ["memory.*", "slot.read.*"]
+    assert body["preferred_model"] == "qwen3-coder"
+    assert body["approval"]["default_policy"] == "auto-approve"
+
+    # Persisted to disk — reload proves the round-trip.
+    reloaded = personas_mod.load_persona("hermes", root=seeded)
+    assert reloaded.display_name == "Hermes Prime"
+    assert reloaded.approval.default_policy == "auto-approve"
+
+
+def test_update_is_partial(client: TestClient, seeded: Path) -> None:
+    """Omitted fields are left unchanged."""
+    before = personas_mod.load_persona("hermes", root=seeded)
+    r = client.put("/api/agents/hermes/personas/hermes", json={"summary": "only summary"})
+    assert r.status_code == 200, r.text
+    after = personas_mod.load_persona("hermes", root=seeded)
+    assert after.summary == "only summary"
+    # System prompt untouched.
+    assert after.system_prompt == before.system_prompt
+    assert after.tools_allowed == before.tools_allowed
+
+
+def test_update_cannot_change_id(client: TestClient, seeded: Path) -> None:
+    """An ``id`` in the body is ignored — the path/filename is authoritative."""
+    r = client.put(
+        "/api/agents/hermes/personas/hermes",
+        json={"display_name": "X"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["id"] == "hermes"
+    # No stray persona file was created.
+    assert {p.stem for p in seeded.glob("*.toml")} == {"hermes", "coder"}
+
+
+def test_update_preserves_budget(client: TestClient, seeded: Path) -> None:
+    """Budget round-trips untouched (it has its own /budget route)."""
+    before = personas_mod.load_persona("hermes", root=seeded)
+    client.put("/api/agents/hermes/personas/hermes", json={"summary": "s"})
+    after = personas_mod.load_persona("hermes", root=seeded)
+    assert after.budget == before.budget
+
+
+def test_update_rejects_bad_default_policy(client: TestClient, seeded: Path) -> None:
+    r = client.put(
+        "/api/agents/hermes/personas/hermes",
+        json={"approval": {"default_policy": "whenever"}},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "persona.invalid"
+
+
+def test_update_unknown_persona_404(client: TestClient, seeded: Path) -> None:
+    r = client.put("/api/agents/hermes/personas/ghost", json={"summary": "s"})
+    assert r.status_code == 404, r.text
+    assert r.json()["error"]["code"] == "persona.not_found"
+
+
+def test_update_unknown_agent_404(client: TestClient, seeded: Path) -> None:
+    r = client.put("/api/agents/nobody/personas/hermes", json={"summary": "s"})
+    assert r.status_code == 404, r.text
+    assert r.json()["error"]["code"] == "agent.unknown"

--- a/tests/api/test_secrets.py
+++ b/tests/api/test_secrets.py
@@ -1,0 +1,130 @@
+"""Tests for the /api/secrets router (operator-managed secret store).
+
+Covers GET (list names, never values), POST + PUT (set → 204), DELETE
+(→ 204, idempotent), name validation, and the write-only invariant:
+secret VALUES must never appear in any response body. Storage mirrors the
+provider-credential writer — atomic, mode-0600, into api.env under the
+``tmp_hal0_home`` sandbox.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _restore_environ() -> Iterator[None]:
+    """Snapshot + restore os.environ — the router mutates it on set/delete."""
+    snapshot = dict(os.environ)
+    yield
+    for key in set(os.environ) - set(snapshot):
+        del os.environ[key]
+    for key, value in snapshot.items():
+        os.environ[key] = value
+
+
+def _api_env_path(home: str) -> Path:
+    return Path(home) / "etc" / "hal0" / "api.env"
+
+
+def test_list_empty_when_no_api_env(client: TestClient) -> None:
+    r = client.get("/api/secrets")
+    assert r.status_code == 200, r.text
+    assert r.json() == {"secrets": []}
+
+
+def test_set_secret_post_persists_and_redacts(
+    client: TestClient,
+    tmp_hal0_home: str,
+) -> None:
+    r = client.post("/api/secrets/MY_TOKEN", json={"value": "super-secret-xyz"})
+    assert r.status_code == 204, r.text
+    # 204 → empty body, value must not leak anywhere.
+    assert "super-secret-xyz" not in r.text
+
+    api_env = _api_env_path(tmp_hal0_home)
+    assert api_env.exists()
+    content = api_env.read_text(encoding="utf-8")
+    assert 'MY_TOKEN="super-secret-xyz"' in content
+    # Mode 0600 — secrets file.
+    assert (api_env.stat().st_mode & 0o777) == 0o600
+    # Live process env updated so no restart needed.
+    assert os.environ["MY_TOKEN"] == "super-secret-xyz"
+
+
+def test_set_secret_put_also_supported(client: TestClient, tmp_hal0_home: str) -> None:
+    r = client.put("/api/secrets/PUT_TOKEN", json={"value": "v1"})
+    assert r.status_code == 204, r.text
+    assert 'PUT_TOKEN="v1"' in _api_env_path(tmp_hal0_home).read_text(encoding="utf-8")
+
+
+def test_list_returns_names_never_values(client: TestClient) -> None:
+    client.post("/api/secrets/ALPHA", json={"value": "secret-alpha"})
+    client.post("/api/secrets/BETA", json={"value": "secret-beta"})
+
+    r = client.get("/api/secrets")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    names = sorted(e["name"] for e in body["secrets"])
+    assert names == ["ALPHA", "BETA"]
+    for entry in body["secrets"]:
+        assert entry["set"] is True
+        assert "updated_at" in entry
+    # Values NEVER round-trip.
+    assert "secret-alpha" not in r.text
+    assert "secret-beta" not in r.text
+
+
+def test_set_overwrites_existing_line(client: TestClient, tmp_hal0_home: str) -> None:
+    client.post("/api/secrets/TOK", json={"value": "first"})
+    client.post("/api/secrets/TOK", json={"value": "second"})
+    content = _api_env_path(tmp_hal0_home).read_text(encoding="utf-8")
+    assert content.count("TOK=") == 1
+    assert 'TOK="second"' in content
+    assert "first" not in content
+
+
+def test_delete_removes_secret(client: TestClient, tmp_hal0_home: str) -> None:
+    client.post("/api/secrets/GONE", json={"value": "bye"})
+    assert os.environ.get("GONE") == "bye"
+
+    r = client.delete("/api/secrets/GONE")
+    assert r.status_code == 204, r.text
+    content = _api_env_path(tmp_hal0_home).read_text(encoding="utf-8")
+    assert "GONE" not in content
+    assert "GONE" not in os.environ
+
+
+def test_delete_is_idempotent(client: TestClient) -> None:
+    # Deleting a never-set secret is a no-op 204, not a 404.
+    r = client.delete("/api/secrets/NEVER_SET")
+    assert r.status_code == 204, r.text
+
+
+@pytest.mark.parametrize("name", ["lower_case", "1LEADING_DIGIT", "BAD-DASH"])
+def test_invalid_names_rejected(client: TestClient, name: str) -> None:
+    r = client.post(f"/api/secrets/{name}", json={"value": "x"})
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "secret.name_invalid"
+
+
+def test_set_coexists_with_provider_credentials(client: TestClient, tmp_hal0_home: str) -> None:
+    """Secrets share api.env with provider creds — both lines survive."""
+    api_env = _api_env_path(tmp_hal0_home)
+    api_env.parent.mkdir(parents=True, exist_ok=True)
+    api_env.write_text('OPENROUTER_API_KEY="provider-key"\n', encoding="utf-8")
+
+    r = client.post("/api/secrets/EXTRA_TOKEN", json={"value": "tok"})
+    assert r.status_code == 204, r.text
+    content = api_env.read_text(encoding="utf-8")
+    assert 'OPENROUTER_API_KEY="provider-key"' in content
+    assert 'EXTRA_TOKEN="tok"' in content
+
+    # The list surfaces both (every api.env key is a secret).
+    names = sorted(e["name"] for e in client.get("/api/secrets").json()["secrets"])
+    assert names == ["EXTRA_TOKEN", "OPENROUTER_API_KEY"]

--- a/tests/api/test_slots_image_pull.py
+++ b/tests/api/test_slots_image_pull.py
@@ -246,6 +246,54 @@ def test_pull_stream_missing_when_no_job(container_client: TestClient) -> None:
     assert payload["state"] == "missing"
 
 
+# ── GET /api/slots/{name}/pull/status tests (poll fallback, recon-api #9) ─────
+
+
+def test_pull_status_returns_job_snapshot_when_active(
+    container_client: TestClient,
+    container_app: FastAPI,
+) -> None:
+    """GET /pull/status returns the in-flight job snapshot when a pull is active."""
+    from hal0.api.routes.slots import _ImagePullJob
+
+    job = _ImagePullJob("gpu-chat", "ghcr.io/hal0ai/test:tag")
+    job.layer = 2
+    job.total_layers = 5
+    container_app.state.slot_pull_jobs = {"gpu-chat": job}
+
+    r = container_client.get("/api/slots/gpu-chat/pull/status")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["slot_name"] == "gpu-chat"
+    assert body["state"] == "pulling"
+    assert body["layer"] == 2
+    assert body["total_layers"] == 5
+
+
+def test_pull_status_present_when_no_job(container_client: TestClient) -> None:
+    """GET /pull/status with no active job + image present → state=present."""
+    fake_catalog, _ = _fake_profile_catalog()
+    with (
+        patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
+        patch("hal0.providers.container.ContainerProvider.image_present", return_value=True),
+    ):
+        r = container_client.get("/api/slots/gpu-chat/pull/status")
+    assert r.status_code == 200, r.text
+    assert r.json()["state"] == "present"
+
+
+def test_pull_status_missing_when_no_job(container_client: TestClient) -> None:
+    """GET /pull/status with no active job + image absent → state=missing."""
+    fake_catalog, _ = _fake_profile_catalog()
+    with (
+        patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
+        patch("hal0.providers.container.ContainerProvider.image_present", return_value=False),
+    ):
+        r = container_client.get("/api/slots/gpu-chat/pull/status")
+    assert r.status_code == 200, r.text
+    assert r.json()["state"] == "missing"
+
+
 # ── ContainerProvider.image_present() unit tests ──────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Backend gap-fill for the hal0-ship sweep (task #7). Closes the P0–P3 backend gaps flagged in RECON-api so the v3 dashboard surfaces stop 404-ing / rendering stubs. All TDD — each feature ships with pytest.

| # | Gap | Fix |
|---|-----|-----|
| P0 #3 | `/api/secrets` had UI hooks but no backend (AddSecretModal stub) | New write-only secrets router |
| P3 #13 | Personas had no UPDATE route (PersonaEditModal couldn't save) | `PUT /api/agents/{id}/personas/{pid}` |
| P1 #6 | `/api/health/system` hardcoded `{ok,{}}` | Real disk/slot/event-bus checks |
| P2 #8 | `/api/features` stub `{}` | Real gates (comfyui/memory/engine/npu/supervisor) |
| P2 #9 | Slot image-pull had SSE but no poll | `GET /api/slots/{name}/pull/status` |
| #317 | MCP private writes leaked to `shared` | `client_id` from `X-hal0-Agent` header |
| — | MCP action 501 used generic code | Explicit `mcp.supervisor_unavailable` |
| — | Stale `CogneeWrapper` docstrings | Engine-neutral `MemoryProvider` |

## New / changed contracts

**Secrets** (`/api/secrets`) — values are write-only (never returned/logged):
- `GET /api/secrets` → `{"secrets":[{name, set:true, masked, updated_at}]}`
- `POST /api/secrets/{name}` `{value}` → `204` (matches v3 `useSecretSet` hook)
- `PUT  /api/secrets/{name}` `{value}` → `204` (documented contract; both verbs accepted)
- `DELETE /api/secrets/{name}` → `204` (idempotent)
- Names: `^[A-Z][A-Z0-9_]{0,63}$`. Storage: `/etc/hal0/api.env`, atomic mode-0600, shared writer factored from providers (`hal0.api._env_store`), + `os.environ` update. Audit row + footer journal event on write/delete (name only).

**Persona update**:
- `PUT /api/agents/{agent_id}/personas/{persona_id}` — partial patch of mutable fields (`display_name, summary, system_prompt, tools_allowed, memory_namespace, preferred_upstream, preferred_model, approval.{default_policy,auto_approve,require_approval}`). `id` immutable, `budget` preserved. Validated via `Persona.from_dict`, persisted to the persona TOML. Returns the GET-detail shape. hermes-only resolution unchanged. `404 agent.unknown` / `404 persona.not_found` / `400 persona.invalid`.

## Test plan
- New: `tests/api/test_secrets.py`, `test_persona_update.py`, `test_features_health.py`, `test_mcp_identity.py`; added pull/status cases to `test_slots_image_pull.py`; updated `test_mcp_routes.py` for the new 501 code.
- `pytest tests/ -m "not slow"` → **3148 passed, 9 skipped** (skips pre-existing infra/CI).
- `ruff check src tests` ✅ · `ruff format --check src tests` ✅

## UI follow-up (not in this PR — ui/ owned by UI-sweep team)
`ui/src/dash/mcp.jsx` keys on the old `mcp.not_implemented`; needs `mcp.supervisor_unavailable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)