### PR TITLE
feat(ui): Inference engine pane + NPU engine restyle (slots page)

### DIFF
--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -244,6 +244,19 @@ def config_enrichment(configs: list[dict[str, Any]]) -> dict[str, dict[str, Any]
             entry["labels"] = model_labels
         entry["enabled"] = enabled
 
+        # ctx_max: the configured context window. The canonical TOML key is
+        # ``[model].context_size`` (the dashboard's ``ctx_size`` alias is
+        # folded to it on write — see slots.manager). Surfaced so the
+        # Inference engine pane can render "ctx used / max" without a
+        # per-slot /config fetch. Absent → key omitted; the UI shows an
+        # em-dash rather than a fabricated number.
+        if isinstance(model_section, dict):
+            ctx_max = model_section.get("context_size")
+            if ctx_max is None:
+                ctx_max = model_section.get("ctx_size")
+            if isinstance(ctx_max, int):
+                entry["ctx_max"] = ctx_max
+
         # Spec 1 / Component 1: surface the three edit-panel config fields so
         # the card + drawer seed their controls without a per-slot /config
         # fetch. ``enable_thinking`` is tri-valued on disk (true/false/absent);

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -280,6 +280,22 @@ class TestConfigEnrichment:
         assert e["llamacpp_args"] == "--flash-attn on"
         assert e["npu"] == {"asr": True, "embed": False}
 
+    def test_ctx_max_from_context_size(self) -> None:
+        # The Inference engine pane reads ctx_max to render "ctx used / max".
+        # Canonical key is [model].context_size.
+        cfg = _llm_cfg()
+        cfg["model"]["context_size"] = 32768
+        out = config_enrichment([cfg])
+        assert out["chat"]["ctx_max"] == 32768
+
+    def test_ctx_max_from_ctx_size_alias(self) -> None:
+        # The dashboard write-path alias ``ctx_size`` is honoured as a
+        # fallback (it is folded to context_size on disk, but tolerate both).
+        cfg = _llm_cfg()
+        cfg["model"]["ctx_size"] = 16384
+        out = config_enrichment([cfg])
+        assert out["chat"]["ctx_max"] == 16384
+
     def test_absent_config_fields_surface_as_defaults(self) -> None:
         out = config_enrichment([_llm_cfg()])
         e = out["chat"]
@@ -290,6 +306,8 @@ class TestConfigEnrichment:
         assert e["workers"] is None
         assert e["llamacpp_args"] is None
         assert "npu" not in e
+        # ctx_max is omitted when the slot configures no context window.
+        assert "ctx_max" not in e
 
 
 # ── loaded-model derivation from slot snapshots ──────────────────────────────

--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -77,6 +77,11 @@ export interface Slot {
   /** GPU offload layer count for the slot's model (-1 = all). Seeds the
    *  drawer's Advanced n_gpu_layers input. */
   n_gpu_layers?: number
+  /** Configured context window ([model].context_size). Surfaced by
+   *  config_enrichment so the Inference engine pane can render "ctx
+   *  used / max". Absent when the slot configures no context window —
+   *  the UI shows an em-dash, never a fabricated number. */
+  ctx_max?: number
   /** Wall-clock epoch (seconds) of the most recent request served by
    *  this slot. ``null``/undefined means hal0-api has not seen a request
    *  for this slot since startup. Used by the slots view to render the

--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -1,0 +1,1048 @@
+/* hal0 dashboard — Inference + NPU "engine" panes (slots-page Inference tab).
+ *
+ * Option A (recon-blueprint §A5): a single scoped stylesheet for BOTH panes,
+ * mirroring the proven comfyui-pane.css pattern. row.css is NOT global in the
+ * live build — comfyui-pane.css re-scopes every generic .engine/.epill/.qcaret
+ * class under .comfy-pane, so the design refs' assumption that those classes
+ * are global is FALSE here. We therefore re-declare the shell rules scoped to
+ * .infer-pane / .npu-pane (comma selectors), and recolour by swapping --comfy
+ * inside each scope. Zero risk to the ComfyUI pane.
+ *
+ *   .infer-pane → sodium-yellow accent (#E5B84F)
+ *   .npu-pane   → purple accent (var(--dev-npu))
+ *
+ * The motion/sunken tokens the design assumes but dashboard.css lacks
+ * (--dur*, --ease) are declared in both scopes, as comfyui-pane.css does. */
+
+/* ─── Accent scopes ─────────────────────────────────────────────────── */
+.infer-pane {
+  --dur: 0.18s;
+  --dur-fast: 0.12s;
+  --dur-slow: 0.22s;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --comfy: #e5b84f;
+  --comfy-hi: #f2ce74;
+  --comfy-soft: rgba(229, 184, 79, 0.1);
+  --comfy-line: rgba(229, 184, 79, 0.34);
+  --comfy-bg: #1b1605;
+  --comfy-glow: rgba(229, 184, 79, 0.2);
+  /* warming / pressure → a clear orange, far enough from the yellow accent */
+  --warn: #f2792b;
+  --warn-soft: rgba(242, 121, 43, 0.12);
+  --warn-line: rgba(242, 121, 43, 0.38);
+  font-family: var(--geist);
+  color: var(--fg);
+}
+.npu-pane {
+  --dur: 0.18s;
+  --dur-fast: 0.12s;
+  --dur-slow: 0.22s;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --comfy: var(--dev-npu);
+  --comfy-hi: #d9b3ff;
+  --comfy-soft: rgba(200, 150, 255, 0.08);
+  --comfy-line: rgba(200, 150, 255, 0.3);
+  --comfy-bg: #1a1226;
+  --comfy-glow: rgba(200, 150, 255, 0.2);
+  font-family: var(--geist);
+  color: var(--fg);
+}
+
+.infer-pane .proto,
+.npu-pane .proto {
+  font-family: var(--geist);
+  color: var(--fg);
+}
+.infer-pane .proto *,
+.npu-pane .proto * {
+  box-sizing: border-box;
+}
+
+/* ─── Section label ─────────────────────────────────────────────────── */
+.infer-pane .sec-label,
+.npu-pane .sec-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--jbm);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: var(--fg-3);
+  margin: 0 0 16px;
+}
+.infer-pane .sec-label b,
+.npu-pane .sec-label b {
+  color: var(--comfy);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.infer-pane .sec-label .dim,
+.npu-pane .sec-label .dim {
+  color: var(--fg-5);
+}
+.infer-pane .sec-label .meta,
+.npu-pane .sec-label .meta {
+  color: var(--fg-4);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 11px;
+}
+.infer-pane .sec-label .grow,
+.npu-pane .sec-label .grow,
+.infer-pane .mono,
+.npu-pane .mono {
+  font-family: var(--jbm);
+}
+
+/* ─── Engine block ──────────────────────────────────────────────────── */
+.infer-pane .engine,
+.npu-pane .engine {
+  border: 1px solid var(--line);
+  border-radius: var(--rad-lg);
+  background: var(--bg-1);
+  overflow: hidden;
+}
+.infer-pane .engine.active,
+.npu-pane .engine.active {
+  border-color: var(--comfy-line);
+  box-shadow:
+    0 0 0 1px var(--comfy-line),
+    0 0 40px -20px var(--comfy-glow);
+}
+.infer-pane .engine-h,
+.npu-pane .engine-h {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--line-soft);
+  background: var(--bg);
+  flex-wrap: wrap;
+  row-gap: 10px;
+}
+.infer-pane .engine.active .engine-h,
+.npu-pane .engine.active .engine-h {
+  background: linear-gradient(90deg, var(--comfy-soft), transparent 60%);
+}
+.infer-pane .engine-glyph,
+.npu-pane .engine-glyph {
+  width: 26px;
+  height: 26px;
+  border-radius: var(--rad-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--comfy-soft);
+  color: var(--comfy);
+  border: 1px solid var(--comfy-line);
+}
+.infer-pane .engine-title,
+.npu-pane .engine-title {
+  font-family: var(--jbm);
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--fg);
+}
+.infer-pane .engine-sub,
+.npu-pane .engine-sub {
+  font-family: var(--jbm);
+  font-size: 11px;
+  color: var(--fg-4);
+}
+.infer-pane .engine-h .grow,
+.npu-pane .engine-h .grow {
+  flex: 1;
+}
+.infer-pane .col,
+.npu-pane .col {
+  display: flex;
+  flex-direction: column;
+}
+.infer-pane .eh-right,
+.npu-pane .eh-right {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+/* ─── State pill ────────────────────────────────────────────────────── */
+.infer-pane .epill,
+.npu-pane .epill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-family: var(--jbm);
+  font-size: 11px;
+  border: 1px solid var(--line);
+  color: var(--fg-3);
+  background: var(--bg-1);
+}
+.infer-pane .epill .dot,
+.npu-pane .epill .dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--fg-4);
+}
+.infer-pane .epill.serving,
+.infer-pane .epill.running,
+.npu-pane .epill.serving,
+.npu-pane .epill.running {
+  color: var(--comfy);
+  border-color: var(--comfy-line);
+  background: var(--comfy-soft);
+}
+.infer-pane .epill.serving .dot,
+.infer-pane .epill.running .dot,
+.npu-pane .epill.serving .dot,
+.npu-pane .epill.running .dot {
+  background: var(--comfy);
+  box-shadow: 0 0 8px var(--comfy);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+.infer-pane .epill.ready,
+.npu-pane .epill.ready {
+  color: var(--ok);
+  border-color: var(--ok-line);
+  background: var(--ok-soft);
+}
+.infer-pane .epill.ready .dot,
+.npu-pane .epill.ready .dot {
+  background: var(--ok);
+  box-shadow: 0 0 8px var(--ok);
+}
+.infer-pane .epill.starting,
+.npu-pane .epill.starting {
+  color: var(--warn);
+  border-color: var(--warn-line);
+  background: var(--warn-soft);
+}
+.infer-pane .epill.starting .dot,
+.npu-pane .epill.starting .dot {
+  background: var(--warn);
+  box-shadow: 0 0 8px var(--warn);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+.infer-pane .epill.stopped,
+.npu-pane .epill.stopped {
+  color: var(--fg-3);
+}
+.infer-pane .epill.stopped .dot,
+.npu-pane .epill.stopped .dot {
+  background: var(--fg-4);
+}
+
+/* ─── Buttons ───────────────────────────────────────────────────────── */
+.infer-pane .rbtn,
+.npu-pane .rbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 11px;
+  height: 28px;
+  font-family: var(--jbm);
+  font-size: 11px;
+  border-radius: var(--rad-sm);
+  cursor: pointer;
+  background: transparent;
+  color: var(--fg-2);
+  border: 1px solid var(--line);
+  white-space: nowrap;
+}
+.infer-pane .rbtn:hover,
+.npu-pane .rbtn:hover {
+  border-color: var(--line-strong);
+  background: var(--bg-2);
+  color: var(--fg);
+}
+.infer-pane .rbtn.primary,
+.npu-pane .rbtn.primary {
+  background: var(--comfy);
+  border-color: var(--comfy);
+  color: #0d0b04;
+  font-weight: 600;
+}
+.infer-pane .rbtn.ghost-comfy,
+.npu-pane .rbtn.ghost-comfy {
+  color: var(--comfy);
+  border-color: var(--comfy-line);
+}
+.infer-pane .rbtn.ghost-comfy:hover,
+.npu-pane .rbtn.ghost-comfy:hover {
+  background: var(--comfy-soft);
+}
+
+/* ─── Body (max-height animation) ───────────────────────────────────── */
+.infer-pane .engine-body,
+.npu-pane .engine-body {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height var(--dur-slow) var(--ease);
+}
+.infer-pane .engine.open .engine-body,
+.npu-pane .engine.open .engine-body {
+  max-height: 1600px;
+}
+.infer-pane .engine-b,
+.npu-pane .engine-b {
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* ─── Footer + caret ────────────────────────────────────────────────── */
+.infer-pane .engine-foot,
+.npu-pane .engine-foot {
+  padding: 11px 18px;
+  border-top: 1px solid var(--line-soft);
+  background: var(--bg);
+  font-family: var(--jbm);
+  font-size: 11px;
+  color: var(--fg-4);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.infer-pane .engine-foot.has-q,
+.npu-pane .engine-foot.has-q {
+  justify-content: flex-start;
+}
+.infer-pane .engine-foot .foot-id,
+.npu-pane .engine-foot .foot-id {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.infer-pane .engine-foot .k,
+.npu-pane .engine-foot .k {
+  color: var(--fg-5);
+}
+.infer-pane .engine-foot .v,
+.npu-pane .engine-foot .v {
+  color: var(--fg-3);
+}
+.infer-pane .engine-foot .v.comfy,
+.npu-pane .engine-foot .v.comfy {
+  color: var(--comfy);
+}
+.infer-pane .engine-foot .sep,
+.npu-pane .engine-foot .sep {
+  color: var(--fg-5);
+}
+.infer-pane .qcaret,
+.npu-pane .qcaret {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--comfy-line);
+  border-radius: var(--rad-sm);
+  background: var(--comfy-soft);
+  cursor: pointer;
+  overflow: hidden;
+  transition:
+    border-color var(--dur-fast) var(--ease),
+    background var(--dur-fast) var(--ease);
+}
+.infer-pane .qcaret:hover,
+.npu-pane .qcaret:hover {
+  filter: brightness(1.15);
+}
+.infer-pane .qcaret .q,
+.npu-pane .qcaret .q {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 10px;
+  font-family: var(--jbm);
+  font-size: 11px;
+  color: var(--comfy);
+}
+.infer-pane .qcaret .q .qn,
+.npu-pane .qcaret .q .qn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--comfy);
+  color: #0d0b04;
+  font-size: 10px;
+  font-weight: 600;
+}
+.infer-pane .qcaret .q .qrun,
+.npu-pane .qcaret .q .qrun {
+  color: var(--fg-4);
+}
+.infer-pane .qcaret .car,
+.npu-pane .qcaret .car {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  border-left: 1px solid var(--comfy-line);
+  color: var(--comfy);
+  transition: transform var(--dur) var(--ease);
+}
+.infer-pane .engine.open .qcaret .car,
+.npu-pane .engine.open .qcaret .car {
+  transform: rotate(180deg);
+}
+
+/* ─── Collapsed telemetry strip (shared shell) ──────────────────────── */
+.infer-pane .collapsed-prog,
+.npu-pane .collapsed-prog {
+  padding: 12px 18px 14px;
+  border-top: 1px solid var(--line-soft);
+}
+.infer-pane .engine.open .collapsed-prog,
+.npu-pane .engine.open .collapsed-prog {
+  display: none;
+}
+.infer-pane .tel-strip,
+.npu-pane .tel-strip {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  flex-wrap: wrap;
+  row-gap: 8px;
+}
+.infer-pane .tel,
+.npu-pane .tel {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 14px;
+  border-right: 1px solid var(--line-soft);
+  font-family: var(--jbm);
+}
+.infer-pane .tel:first-child,
+.npu-pane .tel:first-child {
+  padding-left: 0;
+}
+.infer-pane .tel:last-child,
+.npu-pane .tel:last-child {
+  border-right: none;
+}
+.infer-pane .tel .l,
+.npu-pane .tel .l {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--fg-4);
+}
+.infer-pane .tel .v,
+.npu-pane .tel .v {
+  font-size: 12.5px;
+  color: var(--fg);
+}
+.infer-pane .tel .v.comfy,
+.npu-pane .tel .v.comfy {
+  color: var(--comfy);
+}
+.infer-pane .tel .v .u,
+.npu-pane .tel .v .u {
+  color: var(--fg-4);
+  font-size: 10px;
+  margin-left: 1px;
+}
+.infer-pane .tel .dotline,
+.npu-pane .tel .dotline {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.npu-pane .tel .rdot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--fg-5);
+}
+.npu-pane .tel .rdot.on {
+  background: var(--comfy);
+  box-shadow: 0 0 6px var(--comfy);
+}
+
+/* a labelled block header reused across mem / throughput / slots */
+.infer-pane .blk-h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--jbm);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-4);
+  margin: 0 0 10px;
+}
+.infer-pane .blk-h .ic {
+  color: var(--fg-4);
+  display: inline-flex;
+}
+.infer-pane .blk-h .grow {
+  flex: 1;
+}
+.infer-pane .blk-h .note {
+  font-size: 10px;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--fg-5);
+}
+
+/* ════════════════════════════════════════════════════════════════════
+   Inference-only content (collapsed strip + memory + throughput + list)
+   ════════════════════════════════════════════════════════════════════ */
+.infer-pane .infer-strip {
+  padding: 16px 18px;
+  border-top: 1px solid var(--line-soft);
+}
+.infer-pane .engine.open .infer-strip {
+  display: none;
+}
+.infer-pane .strip-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: 22px;
+  align-items: start;
+}
+.infer-pane .strip-divider {
+  border-left: 1px solid var(--line-soft);
+  padding-left: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+@media (max-width: 880px) {
+  .infer-pane .strip-split {
+    grid-template-columns: 1fr;
+  }
+  .infer-pane .strip-divider {
+    border-left: none;
+    padding-left: 0;
+    border-top: 1px solid var(--line-soft);
+    padding-top: 16px;
+  }
+}
+
+/* ─── Memory map ────────────────────────────────────────────────────── */
+.infer-pane .mem {
+  position: relative;
+}
+.infer-pane .mem-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-family: var(--jbm);
+  font-size: 11px;
+  color: var(--fg-3);
+  margin-bottom: 9px;
+}
+.infer-pane .mem-h b {
+  color: var(--fg);
+  font-weight: 500;
+  font-size: 13px;
+}
+.infer-pane .mem-h .ceil {
+  color: var(--fg-5);
+}
+.infer-pane .mem-h .free {
+  color: var(--fg-4);
+}
+.infer-pane .membar {
+  position: relative;
+  display: flex;
+  height: 14px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--bg-3);
+}
+.infer-pane .membar i {
+  display: block;
+  height: 100%;
+  position: relative;
+  cursor: default;
+  transition: filter 0.12s var(--ease);
+}
+.infer-pane .membar i:hover {
+  filter: brightness(1.3);
+}
+.infer-pane .membar i.free {
+  background: transparent;
+  cursor: default;
+}
+.infer-pane .membar i.free:hover {
+  filter: none;
+}
+.infer-pane .membar .seg-gap {
+  box-shadow: inset -1px 0 0 var(--bg-1);
+}
+.infer-pane .mem-tick {
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  width: 1px;
+  background: var(--fg-3);
+}
+.infer-pane .mem-tick::after {
+  content: attr(data-label);
+  position: absolute;
+  top: -15px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--jbm);
+  font-size: 8.5px;
+  color: var(--fg-4);
+  white-space: nowrap;
+}
+.infer-pane .mem-tip {
+  position: absolute;
+  transform: translateX(-50%);
+  bottom: calc(100% + 9px);
+  background: var(--bg-2);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--rad-sm);
+  padding: 6px 10px;
+  font-family: var(--jbm);
+  font-size: 10.5px;
+  color: var(--fg);
+  white-space: nowrap;
+  pointer-events: none;
+  box-shadow: var(--shadow-menu);
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.infer-pane .mem-tip .sw {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+.infer-pane .mem-legend {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
+  gap: 7px 20px;
+  margin-top: 14px;
+}
+.infer-pane .mem-legend .ln {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--jbm);
+  font-size: 11px;
+}
+.infer-pane .mem-legend .sw {
+  width: 9px;
+  height: 9px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+.infer-pane .mem-legend .sw.free {
+  background: transparent;
+  border: 1px dashed var(--line-strong);
+}
+.infer-pane .mem-legend .nm {
+  color: var(--fg-2);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.infer-pane .mem-legend .gb {
+  color: var(--fg-4);
+}
+.infer-pane .mem-legend .gb b {
+  color: var(--fg-2);
+  font-weight: 500;
+}
+
+/* ─── Throughput ────────────────────────────────────────────────────── */
+.infer-pane .tp {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.infer-pane .tp-num {
+  font-family: var(--jbm);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--comfy);
+  line-height: 1;
+}
+.infer-pane .tp-num .u {
+  font-size: 12px;
+  color: var(--fg-4);
+  margin-left: 5px;
+  letter-spacing: 0;
+  font-weight: 400;
+}
+.infer-pane .tp-big .tp-num {
+  font-size: 32px;
+}
+.infer-pane .tp-mid .tp-num {
+  font-size: 22px;
+}
+.infer-pane .tp-sub {
+  font-family: var(--jbm);
+  font-size: 10px;
+  color: var(--fg-4);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  display: flex;
+  gap: 8px;
+}
+.infer-pane .tp-sub .pk {
+  color: var(--fg-3);
+}
+.infer-pane .spark2 {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 42px;
+}
+.infer-pane .spark2 i {
+  flex: 1;
+  background: var(--comfy);
+  border-radius: 1px;
+  min-height: 2px;
+  opacity: 0.45;
+}
+.infer-pane .spark2 i.hot {
+  opacity: 1;
+}
+.infer-pane .tp-split {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+.infer-pane .tp-split .sr {
+  display: grid;
+  grid-template-columns: 64px 1fr 64px;
+  gap: 11px;
+  align-items: center;
+  font-family: var(--jbm);
+  font-size: 11px;
+}
+.infer-pane .tp-split .sr .dlbl {
+  color: var(--fg-3);
+}
+.infer-pane .tp-split .sr .dbar {
+  height: 7px;
+  border-radius: 2px;
+  background: var(--bg-3);
+  overflow: hidden;
+}
+.infer-pane .tp-split .sr .dbar i {
+  display: block;
+  height: 100%;
+}
+.infer-pane .tp-split .sr .dval {
+  text-align: right;
+  color: var(--fg);
+}
+
+/* ─── Slot list ─────────────────────────────────────────────────────── */
+.infer-pane .slist {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--line);
+  border-radius: var(--rad);
+  overflow: hidden;
+  background: var(--bg);
+}
+.infer-pane .slist .sh,
+.infer-pane .slist .sr {
+  display: grid;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 14px;
+}
+.infer-pane .slist .sh {
+  padding: 8px 14px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line-soft);
+  font-family: var(--jbm);
+  font-size: 8.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--fg-5);
+}
+.infer-pane .slist .sr {
+  border-bottom: 1px solid var(--line-soft);
+  font-family: var(--jbm);
+  font-size: 12.5px;
+  transition: background 0.12s;
+}
+.infer-pane .slist .sr:last-child {
+  border-bottom: none;
+}
+.infer-pane .slist .sr:hover {
+  background: var(--bg-2);
+}
+.infer-pane .slist .sr.dim {
+  opacity: 0.5;
+}
+.infer-pane .slist .sdot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--fg-5);
+}
+.infer-pane .slist .sdot.serving {
+  background: var(--comfy);
+  box-shadow: 0 0 7px var(--comfy);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+.infer-pane .slist .sdot.ready {
+  background: var(--ok);
+}
+.infer-pane .slist .sdot.warming {
+  background: var(--warn);
+  box-shadow: 0 0 7px var(--warn);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+.infer-pane .slist .sdot.error {
+  background: var(--err);
+}
+.infer-pane .slist .sdot.offline {
+  background: var(--fg-5);
+}
+.infer-pane .slist .snm {
+  color: var(--fg);
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+}
+.infer-pane .slist .snm-star {
+  color: var(--comfy);
+  font-size: 9px;
+  margin-left: 5px;
+}
+.infer-pane .slist .smodel {
+  color: var(--fg-3);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.infer-pane .slist .smem {
+  text-align: right;
+  color: var(--fg-2);
+}
+.infer-pane .slist .smem .u {
+  color: var(--fg-5);
+  font-size: 10px;
+}
+.infer-pane .slist .stps {
+  text-align: right;
+  color: var(--comfy);
+}
+.infer-pane .slist .stps.muted {
+  color: var(--fg-5);
+}
+.infer-pane .slist .met {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  text-align: right;
+}
+.infer-pane .slist .met .mv {
+  font-size: 11.5px;
+  color: var(--fg);
+}
+.infer-pane .slist .met .mv.acc {
+  color: var(--comfy);
+}
+.infer-pane .slist .met .mv.muted {
+  color: var(--fg-5);
+}
+
+/* model picker (expanded list) */
+.infer-pane .slist-picker {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  min-width: 0;
+  padding: 5px 24px 5px 9px;
+  border: 1px solid var(--line);
+  border-radius: var(--rad-sm);
+  background-color: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--jbm);
+  font-size: 11.5px;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  background-size: 11px;
+}
+.infer-pane .slist-picker:hover {
+  border-color: var(--comfy-line);
+}
+.infer-pane .slist-picker:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* device chip + profile pill */
+.infer-pane .dchip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 7px;
+  border-radius: 3px;
+  font-family: var(--jbm);
+  font-size: 10px;
+  border: 1px solid var(--line);
+  background: var(--bg-1);
+  color: var(--fg-3);
+  white-space: nowrap;
+}
+.infer-pane .dchip .d {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.infer-pane .dchip.vulkan {
+  color: var(--dev-vulkan);
+  border-color: rgba(127, 184, 255, 0.3);
+}
+.infer-pane .dchip.rocm {
+  color: var(--dev-rocm);
+  border-color: rgba(215, 107, 107, 0.3);
+}
+.infer-pane .dchip.npu {
+  color: var(--dev-npu);
+  border-color: rgba(200, 150, 255, 0.3);
+}
+.infer-pane .dchip.cpu {
+  color: var(--fg-3);
+}
+.infer-pane .flm-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border-radius: 3px;
+  font-family: var(--jbm);
+  font-size: 9.5px;
+  letter-spacing: 0.04em;
+  color: var(--dev-npu);
+  border: 1px solid rgba(200, 150, 255, 0.3);
+  background: rgba(200, 150, 255, 0.06);
+}
+.infer-pane .prov {
+  display: inline-flex;
+  align-items: stretch;
+}
+.infer-pane .prov .dchip,
+.infer-pane .prov .flm-chip {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.infer-pane .profile-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border: 1px solid var(--line);
+  border-left: none;
+  border-radius: 0 3px 3px 0;
+  background: var(--bg-2);
+  color: var(--fg-3);
+  font-family: var(--jbm);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+.infer-pane .profile-pill:hover {
+  color: var(--comfy);
+  border-color: var(--comfy-line);
+}
+.infer-pane .profile-pill svg {
+  color: var(--fg-4);
+}
+
+/* per-slot control icons */
+.infer-pane .slot-ctrls {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+}
+.infer-pane .sctrl {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--rad-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-1);
+  color: var(--fg-4);
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    border-color 0.12s,
+    color 0.12s;
+}
+.infer-pane .sctrl:hover {
+  border-color: var(--line-strong);
+  background: var(--bg-2);
+  color: var(--fg-2);
+}
+.infer-pane .sctrl:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.infer-pane .sctrl.start {
+  color: var(--ok);
+  border-color: var(--ok-line);
+}
+.infer-pane .sctrl.start:hover {
+  background: var(--ok-soft);
+}
+.infer-pane .sctrl.stop {
+  color: var(--err);
+  border-color: var(--err-line);
+}
+.infer-pane .sctrl.stop:hover {
+  background: var(--err-soft);
+}
+.infer-pane .sctrl.restart {
+  color: var(--comfy);
+  border-color: var(--comfy-line);
+}
+.infer-pane .sctrl.restart:hover {
+  background: var(--comfy-soft);
+}
+
+/* ════════════════════════════════════════════════════════════════════
+   NPU pane — engine shell wraps the existing .npu-stack trio (dashboard.css
+   keeps the inner trio styling; the shell + tel-strip + master switch wrap
+   live here). The master switch reuses dashboard.css .npu-switch verbatim.
+   ════════════════════════════════════════════════════════════════════ */
+.npu-pane .eh-right .npu-master-lbl {
+  font-family: var(--jbm);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-3);
+}
+.npu-pane .engine-b .npu-stack {
+  gap: 12px;
+}

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -1,0 +1,725 @@
+// hal0 dashboard — Inference "engine" pane (slots-page Inference tab).
+//
+// The yellow-accented counterpart to the ComfyUI generation-engine pane
+// (comfyui-pane.jsx). Where ComfyUI models ONE containerized generation
+// engine, this pane is a summary engine-shell over the LLM/capability slot
+// stack: a collapsed hero strip (memory map + active slot list + combined
+// throughput) that expands to the full slot list with per-slot lifecycle
+// controls, a model picker, and a by-device throughput split.
+//
+// Ported from the hal0 Design System exploration (inference-row/{infer-core,
+// infer}.{jsx,css}). Presentational components are inlined here; all data is
+// LIVE via the typed hooks:
+//   - useSlots()           → the slot rollup (every non-image slot)
+//   - useModels()          → the per-slot model picker (expanded list)
+//   - useMemoryMapModel()  → per-slot resident memory (real mem_mb) + pool
+//   - useHardware()        → the unified-RAM frame (124 GB) for the mem bar
+//   - useSlot{Restart,Unload,Load,Swap} → real lifecycle mutations
+// Throughput history is a client ring buffer (the ThroughputCard pattern) —
+// the backend exposes no rolling-60s series. Absent metrics render an
+// em-dash; the pane never fabricates a number.
+//
+// Per the design voice: lowercase mono labels, no emoji in the chrome,
+// em-dash for any metric the backend hasn't reported.
+
+import {
+  useSlots,
+  useSlotRestart,
+  useSlotUnload,
+  useSlotLoad,
+  useSlotSwap,
+} from '@/api/hooks/useSlots'
+import { useModels } from '@/api/hooks/useModels'
+import { useHardware } from '@/api/hooks/useHardware'
+import { useMemoryMapModel } from './memory-map'
+import { slotIndicatorFromPhase, isSlotLive } from './slot-status.js'
+
+const { useState: useStateI, useRef: useRefI, useEffect: useEffectI } = React
+
+// ── icons (16×16, thin-line family — ported from the design's infer-core) ──
+const II = ({ d, size = 16, sw = 1.5, children, fill = 'none' }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill={fill}
+    stroke="currentColor"
+    strokeWidth={sw}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    {d ? <path d={d} /> : children}
+  </svg>
+)
+const IIcons = {
+  slots: (
+    <II>
+      <rect x="2.5" y="3" width="11" height="3" rx="1" />
+      <rect x="2.5" y="6.6" width="11" height="3" rx="1" />
+      <rect x="2.5" y="10.2" width="11" height="3" rx="1" />
+    </II>
+  ),
+  mem: (
+    <II>
+      <rect x="2" y="5" width="12" height="6" rx="1" />
+      <path d="M5 5V3M8 5V3M11 5V3M5 13v-2M11 13v-2" />
+    </II>
+  ),
+  activity: <II d="M2 8h3l2-4 2 8 2-4h3" />,
+  chev: <II d="M4 6l4 4 4-4" />,
+  plus: <II d="M8 3v10M3 8h10" />,
+  logs: <II d="M3 3h10M3 6h10M3 9h7M3 12h5" />,
+  refresh: (
+    <II>
+      <path d="M14 8a6 6 0 1 1-2-4.5" />
+      <path d="M14 1v3.5h-3.5" />
+    </II>
+  ),
+  stop: (
+    <II>
+      <rect x="4" y="4" width="8" height="8" rx="1" />
+    </II>
+  ),
+  play: <II d="M5 3.4l8 4.6-8 4.6V3.4z" />,
+  edit: <II d="M3 13l3-1 7-7-2-2-7 7-1 3z" />,
+  ext: <II d="M6 3H3v10h10v-3M9 3h4v4M9 9l4-4" />,
+}
+const Ic = ({ name, size = 16 }) =>
+  IIcons[name] ? React.cloneElement(IIcons[name], { size }) : null
+
+const round1 = (n) => Math.round((n || 0) * 10) / 10
+const toast = (msg, kind = 'info') =>
+  typeof window !== 'undefined' && window.__hal0Toast && window.__hal0Toast(msg, kind)
+
+// Normalize a slot.device string to the chip's device-kind token.
+function devKind(device) {
+  const d = String(device || '').toLowerCase()
+  if (d === 'npu') return 'npu'
+  if (d === 'cpu') return 'cpu'
+  if (d.includes('vulkan')) return 'vulkan'
+  if (d.includes('rocm') || d.startsWith('gpu')) return 'rocm'
+  return 'cpu'
+}
+
+// Phase → dot class (reuses the design's .sdot vocabulary). Derived from the
+// shared slot-status classifier so the dot matches the rest of the page.
+function dotCls(ind) {
+  switch (ind.cls) {
+    case 'serving':
+      return 'serving'
+    case 'stale':
+      return 'ready'
+    case 'warming':
+      return 'warming'
+    case 'error':
+      return 'error'
+    default:
+      return 'offline'
+  }
+}
+
+// ctx "used / max" in k-tokens. Em-dash when no ctx_max is configured, and
+// an em-dash for the used side when the live counter hasn't reported.
+const kCtx = (n) => `${Math.round(n / 1024)}k`
+function ctxText(s) {
+  const max = typeof s.ctx_max === 'number' && s.ctx_max > 0 ? s.ctx_max : null
+  if (!max) return '—'
+  const used = typeof s.metrics?.ctx === 'number' && s.metrics.ctx > 0 ? s.metrics.ctx : null
+  return `${used ? kCtx(used) : '—'} / ${kCtx(max)}`
+}
+
+// ── memory map (one continuous segmented bar) ──────────────────────────────
+// Reuses useMemoryMapModel()'s real per-slot resident memory (mem_mb) and
+// colours. The frame is the unified RAM pool (≈124 GB); a tick marks the iGPU
+// GTT carve-out (≈80 GB). A single honest "system" segment accounts for GTT
+// in use beyond the named model weights (KV cache + runtime + buffers) — no
+// fabricated KV/OS split.
+function MemSegmented({ mm, hw, full }) {
+  const [hi, setHi] = useStateI(null)
+  const pool = mm.pool || {}
+  const self = mm.self || {}
+  const gttCapGb = pool.totalGb || 0
+  const unifiedGb = hw?.data?.ram?.total || gttCapGb || 0
+  const frame = unifiedGb || 1
+  const modelSegs = (self.slots || []).filter((s) => s.bytesGb > 0)
+  const modelUsedGb = self.modelUsedGb || 0
+  const gttUsedGb = self.gttUsedGb || 0
+  const gpuModelGb = modelSegs
+    .filter((s) => s.device === 'rocm' || s.device === 'vulkan')
+    .reduce((a, s) => a + s.bytesGb, 0)
+  const systemOtherGb = Math.max(0, round1(gttUsedGb - gpuModelGb))
+
+  const segs = [
+    ...modelSegs.map((s) => ({
+      key: s.name,
+      label: s.name,
+      gb: s.bytesGb,
+      color: s.color,
+    })),
+    ...(systemOtherGb > 0
+      ? [{ key: '__sys', label: 'system · KV + runtime', gb: systemOtherGb, color: 'var(--fg-5)' }]
+      : []),
+  ]
+  const usedGb = round1(modelUsedGb + systemOtherGb)
+  const freeGb = Math.max(0, round1(frame - usedGb))
+  const pct = (gb) => (gb / frame) * 100
+  let acc = 0
+  const placed = segs.map((s) => {
+    const left = (acc / frame) * 100
+    const w = (s.gb / frame) * 100
+    acc += s.gb
+    return { ...s, left, w }
+  })
+
+  return (
+    <div className="mem">
+      <div className="blk-h">
+        <span className="ic">
+          <Ic name="mem" size={13} />
+        </span>{' '}
+        memory map
+        <span className="grow" />
+        <span className="note">unified · {frame.toFixed(0)} GB</span>
+      </div>
+      <div className="mem-h">
+        <span>
+          <b>{usedGb.toFixed(1)}</b> / {frame.toFixed(0)} <span className="ceil">GB resident</span>
+        </span>
+        <span className="free">{freeGb.toFixed(1)} GB free</span>
+      </div>
+      <div className="membar" style={{ marginTop: 14 }} onMouseLeave={() => setHi(null)}>
+        {placed.map((s) => (
+          <i
+            key={s.key}
+            className="seg-gap"
+            style={{ width: s.w + '%', background: s.color }}
+            onMouseEnter={() => setHi(s)}
+          />
+        ))}
+        <i className="free" style={{ width: Math.max(0, 100 - pct(usedGb)) + '%' }} />
+        {gttCapGb > 0 && gttCapGb < frame && (
+          <span
+            className="mem-tick"
+            data-label={`GTT ${Math.round(gttCapGb)}`}
+            style={{ left: pct(gttCapGb) + '%' }}
+          />
+        )}
+        {hi && (
+          <span
+            className="mem-tip"
+            style={{ left: Math.min(92, Math.max(8, hi.left + hi.w / 2)) + '%' }}
+          >
+            <span className="sw" style={{ background: hi.color }} />
+            <b>{hi.label}</b> {hi.gb} GB
+          </span>
+        )}
+      </div>
+      {full && (
+        <div className="mem-legend">
+          {placed.map((s) => (
+            <div className="ln" key={s.key}>
+              <span className="sw" style={{ background: s.color }} />
+              <span className="nm">{s.label}</span>
+              <span className="gb">
+                <b>{s.gb}</b> GB
+              </span>
+            </div>
+          ))}
+          <div className="ln">
+            <span className="sw free" />
+            <span className="nm">free</span>
+            <span className="gb">
+              <b>{freeGb.toFixed(1)}</b> GB
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── throughput ─────────────────────────────────────────────────────────────
+function SparkBars({ data = [], hotN = 4 }) {
+  const max = Math.max(...data, 1)
+  if (!data.length) return <div className="spark2" />
+  return (
+    <div className="spark2">
+      {data.map((v, i) => (
+        <i
+          key={i}
+          className={i >= data.length - hotN ? 'hot' : ''}
+          style={{ height: (v / max) * 100 + '%' }}
+        />
+      ))}
+    </div>
+  )
+}
+
+function TpBig({ value, ticks, peak, servingN }) {
+  return (
+    <div className="tp tp-big">
+      <div className="blk-h">
+        <span className="ic">
+          <Ic name="activity" size={13} />
+        </span>{' '}
+        combined throughput
+        <span className="grow" />
+        <span className="note">{servingN} serving</span>
+      </div>
+      <div className="tp-num">
+        {value == null ? '—' : value}
+        <span className="u">tok/s</span>
+      </div>
+      <SparkBars data={ticks} />
+      <div className="tp-sub">
+        <span>last 60s</span>
+        <span className="pk">{peak == null ? 'peak —' : `peak ${peak} t/s`}</span>
+      </div>
+    </div>
+  )
+}
+
+function TpSplit({ igpu, flm, combined }) {
+  const total = combined || 1
+  return (
+    <div className="tp">
+      <div className="blk-h">
+        <span className="ic">
+          <Ic name="activity" size={13} />
+        </span>{' '}
+        throughput · by device
+      </div>
+      <div className="tp tp-mid" style={{ marginBottom: 4 }}>
+        <div className="tp-num">
+          {combined == null ? '—' : combined}
+          <span className="u">tok/s combined</span>
+        </div>
+      </div>
+      <div className="tp-split">
+        <div className="sr">
+          <span className="dlbl" style={{ color: 'var(--dev-vulkan)' }}>
+            iGPU
+          </span>
+          <span className="dbar">
+            <i style={{ width: (igpu / total) * 100 + '%', background: 'var(--dev-vulkan)' }} />
+          </span>
+          <span className="dval">{igpu || '—'}</span>
+        </div>
+        <div className="sr">
+          <span className="dlbl" style={{ color: 'var(--dev-npu)' }}>
+            FLM
+          </span>
+          <span className="dbar">
+            <i style={{ width: (flm / total) * 100 + '%', background: 'var(--dev-npu)' }} />
+          </span>
+          <span className="dval">{flm || '—'}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── slot list ────────────────────────────────────────────────────────────
+function DevCell({ s, withProfile, onProfile }) {
+  const dchip =
+    devKind(s.device) === 'npu' ? (
+      <span className="flm-chip">FLM · npu</span>
+    ) : (
+      <span className={'dchip ' + devKind(s.device)}>
+        <span className="d" />
+        {devKind(s.device)}
+      </span>
+    )
+  if (!withProfile || !s.profile) return dchip
+  return (
+    <span className="prov">
+      {dchip}
+      <button className="profile-pill" title="Runtime profile — edit slot" onClick={onProfile}>
+        {s.profile}
+        <Ic name="chev" size={10} />
+      </button>
+    </span>
+  )
+}
+
+function ModelPickerCell({ s, models, disabled, onSwap }) {
+  if (s.type !== 'llm') return <span className="smodel">{s.model || '—'}</span>
+  const opts = (Array.isArray(models) ? models : []).filter((m) => m.type === 'llm')
+  const cur = s.model_id || s.model || ''
+  const has = opts.some((m) => m.id === cur)
+  return (
+    <select
+      className="slist-picker mono"
+      value={cur}
+      disabled={disabled}
+      onClick={(e) => e.stopPropagation()}
+      onChange={(e) => {
+        const id = e.target.value
+        if (id && id !== cur) onSwap(id)
+      }}
+      aria-label={`Model for ${s.name}`}
+    >
+      {cur && !has && <option value={cur}>{s.model || cur}</option>}
+      {!cur && <option value="">—</option>}
+      {opts.map((m) => (
+        <option key={m.id} value={m.id}>
+          {m.longName || m.id}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+function SlotControls({ s, phase, busy, onStart, onStop, onRestart, onLogs, onEdit }) {
+  const running = phase !== 'off'
+  return (
+    <span className="slot-ctrls" onClick={(e) => e.stopPropagation()}>
+      {running ? (
+        <button
+          className="sctrl stop"
+          title="Stop"
+          disabled={busy || phase === 'transitional'}
+          onClick={onStop}
+        >
+          <Ic name="stop" size={13} />
+        </button>
+      ) : (
+        <button className="sctrl start" title="Start" disabled={busy} onClick={onStart}>
+          <Ic name="play" size={13} />
+        </button>
+      )}
+      <button
+        className="sctrl restart"
+        title="Restart"
+        disabled={busy || phase === 'transitional' || !running}
+        onClick={onRestart}
+      >
+        <Ic name="refresh" size={13} />
+      </button>
+      <button className="sctrl" title="Logs" onClick={onLogs}>
+        <Ic name="logs" size={13} />
+      </button>
+      <button className="sctrl" title="Edit" onClick={onEdit}>
+        <Ic name="edit" size={13} />
+      </button>
+    </span>
+  )
+}
+
+// classify a slot into the lifecycle phase the controls key off (mirrors the
+// SlotCard logic so Start/Stop/Restart match the per-slot card).
+function slotCtrlPhase(slot) {
+  if (slot.container_status != null) {
+    const cs = String(slot.container_status)
+    const health = !!slot.container_health
+    if (cs === 'starting' || cs === 'pulling' || (cs === 'running' && !health)) return 'transitional'
+    if (cs === 'running' && health) return 'running'
+    return 'off'
+  }
+  const st = slot.state
+  if (st === 'warming' || st === 'starting' || st === 'pulling' || st === 'unloading')
+    return 'transitional'
+  if (st === 'serving' || st === 'ready') return 'running'
+  return 'off'
+}
+
+function SlotList({ rows, full, models, busyName, handlers }) {
+  const tmplC = '10px 84px minmax(0,1fr) auto 76px 70px'
+  const tmplF = '10px 90px minmax(0,1fr) auto 64px 60px 64px 70px 132px'
+  const tmpl = full ? tmplF : tmplC
+  return (
+    <div className="slist">
+      {full && (
+        <div className="sh" style={{ gridTemplateColumns: tmpl }}>
+          <span />
+          <span>slot</span>
+          <span>model</span>
+          <span>device</span>
+          <span style={{ textAlign: 'right' }}>mem</span>
+          <span style={{ textAlign: 'right' }}>tok/s</span>
+          <span style={{ textAlign: 'right' }}>ttft</span>
+          <span style={{ textAlign: 'right' }}>ctx</span>
+          <span style={{ textAlign: 'right' }}>actions</span>
+        </div>
+      )}
+      {rows.map(({ s, ind }) => {
+        const phase = slotCtrlPhase(s)
+        const memGb = typeof s.mem_mb === 'number' && s.mem_mb > 0 ? round1(s.mem_mb / 1024) : null
+        const tps = typeof s.metrics?.toks === 'number' && s.metrics.toks > 0 ? s.metrics.toks : null
+        const ttft = typeof s.metrics?.ttft === 'number' && s.metrics.ttft > 0 ? s.metrics.ttft : null
+        const busy = busyName === s.name
+        return (
+          <div
+            className={'sr' + (phase === 'off' ? ' dim' : '')}
+            key={s.name}
+            style={{ gridTemplateColumns: tmpl }}
+            data-testid={`infer-slot-${s.name}`}
+          >
+            <span className={'sdot ' + dotCls(ind)} title={ind.tooltip} />
+            <span className="snm">
+              {s.name}
+              {s.isDefault && <span className="snm-star">★</span>}
+            </span>
+            {full ? (
+              <ModelPickerCell
+                s={s}
+                models={models}
+                disabled={busy}
+                onSwap={(id) => handlers.onSwap(s, id)}
+              />
+            ) : (
+              <span className="smodel">{s.model || '—'}</span>
+            )}
+            <DevCell s={s} withProfile={full} onProfile={() => handlers.onEdit(s)} />
+            <span className="smem">
+              {memGb == null ? '—' : memGb}
+              {memGb != null && <span className="u"> GB</span>}
+            </span>
+            {!full ? (
+              <span className={'stps' + (tps ? '' : ' muted')}>{tps || '—'}</span>
+            ) : (
+              <>
+                <span className="met">
+                  <span className={'mv' + (tps ? ' acc' : ' muted')}>{tps || '—'}</span>
+                </span>
+                <span className="met">
+                  <span className={'mv' + (ttft ? '' : ' muted')}>{ttft ? ttft + 'ms' : '—'}</span>
+                </span>
+                <span className="met">
+                  <span className={'mv' + (s.ctx_max ? '' : ' muted')}>{ctxText(s)}</span>
+                </span>
+                <SlotControls
+                  s={s}
+                  phase={phase}
+                  busy={busy}
+                  onStart={() => handlers.onStart(s)}
+                  onStop={() => handlers.onStop(s)}
+                  onRestart={() => handlers.onRestart(s)}
+                  onLogs={() => handlers.onLogs(s)}
+                  onEdit={() => handlers.onEdit(s)}
+                />
+              </>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export function InferencePane() {
+  const slotsQuery = useSlots()
+  const modelsQuery = useModels()
+  const mm = useMemoryMapModel()
+  const hw = useHardware()
+  const restartMut = useSlotRestart()
+  const unloadMut = useSlotUnload()
+  const loadMut = useSlotLoad()
+  const swapMut = useSlotSwap()
+  const [open, setOpen] = useStateI(false)
+  const [busyName, setBusyName] = useStateI(null)
+
+  // The Inference rollup is every non-image slot (chat + capabilities + the
+  // NPU/FLM trio). Image generation is its own pane (ComfyuiPane).
+  const allSlots = slotsQuery.data || []
+  const slots = allSlots.filter((s) => (s.group || '') !== 'img')
+
+  const rows = slots.map((s) => ({ s, ind: slotIndicatorFromPhase(s) }))
+  const activeRows = rows.filter((r) => isSlotLive(r.s) || r.ind.cls === 'serving')
+  const servingN = rows.filter((r) => r.ind.cls === 'serving').length
+  const loadedN = rows.filter((r) => isSlotLive(r.s)).length
+
+  const gpuN = slots.filter((s) => {
+    const k = devKind(s.device)
+    return k === 'rocm' || k === 'vulkan'
+  }).length
+  const npuN = slots.filter((s) => devKind(s.device) === 'npu').length
+
+  // Combined throughput — summed tok/s across serving slots, with a client
+  // ring buffer for the 60s spark (the backend exposes no rolling series).
+  const toksVals = slots
+    .map((s) => s?.metrics?.toks)
+    .filter((t) => typeof t === 'number' && t > 0)
+  const value = toksVals.length ? Math.round(toksVals.reduce((a, b) => a + b, 0)) : null
+  const historyRef = useRefI([])
+  const lastRef = useRefI(null)
+  const [, force] = useStateI(0)
+  useEffectI(() => {
+    if (value == null) return
+    if (lastRef.current === value) return
+    lastRef.current = value
+    historyRef.current = [...historyRef.current, value].slice(-21)
+    force((n) => n + 1)
+  }, [value])
+  const ticks = historyRef.current
+  const peak = ticks.length ? Math.max(...ticks) : null
+
+  const igpuTps = Math.round(
+    slots
+      .filter((s) => devKind(s.device) !== 'npu')
+      .reduce((a, s) => a + (typeof s.metrics?.toks === 'number' ? s.metrics.toks : 0), 0),
+  )
+  const flmTps = Math.round(
+    slots
+      .filter((s) => devKind(s.device) === 'npu')
+      .reduce((a, s) => a + (typeof s.metrics?.toks === 'number' ? s.metrics.toks : 0), 0),
+  )
+
+  const run = async (name, mut, args, okMsg) => {
+    setBusyName(name)
+    try {
+      await mut.mutateAsync(args)
+      toast(okMsg, 'ok')
+    } catch (err) {
+      toast(err?.message ? `${name}: ${err.message}` : `${name}: action failed`, 'warn')
+    } finally {
+      setBusyName(null)
+    }
+  }
+
+  const handlers = {
+    onStart: (s) => run(s.name, loadMut, s.name, `Starting ${s.name}`),
+    onStop: (s) => run(s.name, unloadMut, s.name, `Unloaded ${s.name}`),
+    onRestart: (s) => run(s.name, restartMut, s.name, `Restarting ${s.name}`),
+    onSwap: (s, model_id) =>
+      run(s.name, swapMut, { name: s.name, model_id }, `Swapping ${s.name}`),
+    onEdit: (s) => {
+      window.location.hash = '#slots/' + s.name
+    },
+    onLogs: (s) => {
+      window.dispatchEvent(new CustomEvent('hal0:slot-logs', { detail: { name: s.name } }))
+    },
+  }
+
+  const epillCls = servingN > 0 ? 'serving' : loadedN > 0 ? 'ready' : 'stopped'
+  const epillLabel =
+    servingN > 0
+      ? `${servingN} serving · ${loadedN} loaded`
+      : loadedN > 0
+        ? `${loadedN} loaded`
+        : 'idle'
+
+  const newSlot = () => window.dispatchEvent(new CustomEvent('hal0:create-slot'))
+  const openLogs = () => {
+    window.location.hash = '#logs'
+  }
+
+  return (
+    <div className="infer-pane">
+      <div className="proto">
+        <div className="sec-label">
+          <b>Inference Engine</b>
+          <span className="dim">·</span>
+          <span className="meta">slots</span>
+          <span className="mono" style={{ color: 'var(--comfy)' }}>
+            {gpuN} iGPU
+          </span>
+          {npuN > 0 && (
+            <>
+              <span className="dim">·</span>
+              <span className="mono" style={{ color: 'var(--dev-npu)' }}>
+                {npuN} FLM
+              </span>
+            </>
+          )}
+          <span className="grow" style={{ flex: 1 }} />
+          <span className="meta">podman · :8080</span>
+        </div>
+
+        <div className={'engine' + (loadedN > 0 ? ' active' : '') + (open ? ' open' : '')}>
+          <div className="engine-h">
+            <span className="engine-glyph">
+              <Ic name="slots" size={16} />
+            </span>
+            <span className="col">
+              <span className="engine-title">Inference</span>
+              <span className="engine-sub">inference engine · podman</span>
+            </span>
+            <span className={'epill ' + epillCls} data-testid="infer-epill">
+              <span className="dot" />
+              {epillLabel}
+            </span>
+            <span className="grow" style={{ flex: 1 }} />
+            <span className="eh-right">
+              <button className="rbtn" onClick={newSlot} title="Create a new slot">
+                <Ic name="plus" size={13} /> Slot
+              </button>
+              <button className="rbtn ghost-comfy" onClick={openLogs} title="Open the logs view">
+                <Ic name="logs" size={13} /> Logs ↗
+              </button>
+            </span>
+          </div>
+
+          {/* collapsed strip — hidden when the pane is open */}
+          <div className="infer-strip" data-testid="infer-strip">
+            <div className="strip-split">
+              <SlotList
+                rows={activeRows}
+                full={false}
+                models={modelsQuery.data}
+                busyName={busyName}
+                handlers={handlers}
+              />
+              <div className="strip-divider">
+                <MemSegmented mm={mm} hw={hw} full={false} />
+                <TpBig value={value} ticks={ticks} peak={peak} servingN={servingN} />
+              </div>
+            </div>
+          </div>
+
+          {/* expandable body */}
+          <div className="engine-body">
+            <div className="inner">
+              <div className="engine-b">
+                <MemSegmented mm={mm} hw={hw} full />
+                <SlotList
+                  rows={rows}
+                  full
+                  models={modelsQuery.data}
+                  busyName={busyName}
+                  handlers={handlers}
+                />
+                <TpSplit igpu={igpuTps} flm={flmTps} combined={value} />
+              </div>
+            </div>
+          </div>
+
+          {/* footer — engine identity + caret expand control */}
+          <div className="engine-foot has-q">
+            <div className="foot-id">
+              <span className="k">runtime</span>
+              <span className="v comfy">hal0</span>
+              <span className="sep">·</span>
+              <span className="k">backend</span>
+              <span className="v">podman</span>
+              <span className="sep">·</span>
+              <span className="k">slots</span>
+              <span className="v">{slots.length}</span>
+              <span className="sep">·</span>
+              <span className="k">gateway</span>
+              <span className="v comfy">:8080</span>
+            </div>
+            <button
+              className="qcaret"
+              onClick={() => setOpen((o) => !o)}
+              aria-expanded={open}
+              data-testid="infer-qcaret"
+            >
+              <span className="q">
+                <Ic name="slots" size={13} /> {open ? 'collapse' : 'all slots'}
+                <span className="qn">{slots.length}</span>
+                <span className="qrun">· {servingN} serving</span>
+              </span>
+              <span className="car">
+                <Ic name="chev" size={13} />
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+Object.assign(window, { InferencePane })

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -11,6 +11,7 @@ import {
   useSlotDelete,
   useSlotImagePull,
   useSlotRestart,
+  useSlotLoad,
 } from '@/api/hooks/useSlots'
 import { useHardware } from '@/api/hooks/useHardware'
 import { useModels } from '@/api/hooks/useModels'
@@ -130,9 +131,6 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
   const compatible = allModels.filter(m => m.type === type);
 
   const canSave = !!name && !nameError && !createMut.isPending && !!profile;
-
-  // Next available port after the highest currently-allocated
-  const nextPort = Math.max(8090, ...((existingSlots || []).map(s => s.port || 8090))) + 1;
 
   async function onCreateClick() {
     setSubmitErr(null);
@@ -276,7 +274,12 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
           <span className="sub">child process port hal0 will allocate</span>
         </div>
         <div className="form-ctl">
-          <span className="mono" style={{padding: "6px 10px", background: "var(--bg)", border: "1px solid var(--line-soft)", borderRadius: "var(--rad-sm)", display: "inline-block", color: "var(--fg-3)", fontSize: 12}}>:{nextPort}</span>
+          {/* The create body intentionally omits `port` — hal0 allocates the
+              next free slot port server-side (_next_free_slot_port). Showing a
+              client-guessed number here implied a value the POST never sends
+              and the backend need not honour, so we state the behaviour
+              instead of fabricating a specific port. */}
+          <span className="mono" style={{padding: "6px 10px", background: "var(--bg)", border: "1px solid var(--line-soft)", borderRadius: "var(--rad-sm)", display: "inline-block", color: "var(--fg-4)", fontSize: 12}}>auto · assigned on save</span>
         </div>
       </div>
 
@@ -928,7 +931,24 @@ function ImagePullBar({ pull }) {
 // ─── Error SlotCard ─────────────────────────────────────────────
 function ErrorSlotCardBanner({ slot, message }) {
   const pull = useSlotImagePull();
+  const loadMut = useSlotLoad();
   const isPulling = pull.slotName === slot?.name && pull.inFlight;
+
+  // Retry was toast-only. A "load failed" banner means the slot's child never
+  // came up, so Retry re-attempts the load (POST /api/slots/{name}/load) —
+  // the same mutation the SlotCard's Start uses. Query invalidation refreshes
+  // the card on success.
+  const handleRetry = async () => {
+    if (!slot?.name) return;
+    try {
+      await loadMut.mutateAsync(slot.name);
+      window.__hal0Toast && window.__hal0Toast(`Retrying load for ${slot.name}`, "info");
+    } catch (err) {
+      window.__hal0Toast && window.__hal0Toast(
+        `Retry failed for ${slot.name}: ${err?.message || err}`, "warn"
+      );
+    }
+  };
 
   const handleRePull = async () => {
     if (!slot?.name) return;
@@ -951,7 +971,11 @@ function ErrorSlotCardBanner({ slot, message }) {
           <ImagePullBar pull={pull} />
         )}
         <div style={{display: "flex", gap: 6, marginTop: 6}}>
-          <button className="btn ghost sm" onClick={() => window.__hal0Toast && window.__hal0Toast(`Retrying load for ${slot.name}`, "info")}>{Icons.restart} Retry</button>
+          <button
+            className="btn ghost sm"
+            disabled={loadMut.isPending}
+            onClick={handleRetry}
+          >{Icons.restart} {loadMut.isPending ? "Retrying…" : "Retry"}</button>
           <button
             className="btn ghost sm"
             disabled={isPulling}

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -19,6 +19,7 @@ import { useModels } from '@/api/hooks/useModels'
 import { useComfyui } from '@/api/hooks/useComfyui'
 import { MemoryMap } from './memory-map'
 import { ComfyuiPane } from './comfyui-pane.jsx'
+import { InferencePane } from './inference-pane.jsx'
 import { slotIndicatorFromPhase, isSlotLive } from './slot-status.js'
 
 const { useState: useStateS } = React;
@@ -145,8 +146,11 @@ function SlotCard({
   //
   // N1: classify from container_status; an un-enriched snapshot (stale
   // /api/status union entry without container_status) falls back to its
-  // bare state string.
-  const isContainer = true;
+  // bare state string. Post-Lemonade every slot dispatches through
+  // ContainerProvider, so this is effectively always true — but derive it
+  // honestly from the payload rather than hard-coding (the non-container
+  // branch below is the defensive fallback for a pre-enrichment snapshot).
+  const isContainer = slot.runtime === "container" || slot.container_status != null;
   let phase;
   if (slot.container_status != null) {
     const cs = String(slot.container_status);
@@ -302,10 +306,12 @@ function SlotCard({
           </>
         )}
         {(() => {
+          // Colour aligned to the slotIndicatorFromPhase() vocabulary
+          // (slot-status.js): serving|stale|warming|error|offline. The old
+          // map keyed on "warning"/"recent" which that classifier never
+          // emits, so every chip fell through to the default grey.
           const ind = slotIndicator(slot);
-          const chipColor = ind.cls === "warning" ? "var(--warn)"
-            : ind.cls === "recent" ? "var(--ok)"
-            : ind.cls === "serving" ? "var(--accent)"
+          const chipColor = ind.cls === "serving" ? "var(--ok)"
             : ind.cls === "stale" || ind.cls === "warming" ? "var(--warn)"
             : ind.cls === "error" ? "var(--err)"
             : "var(--fg-3)";
@@ -367,13 +373,31 @@ function SlotCard({
 // ─── SlotCard compact list variant ───
 function SlotListRow({ slot, onEdit }) {
   const { type, device, model, state, isDefault, metrics } = slot;
+  // Restart + Edit were dead (stopPropagation-only) — wire them to the real
+  // restart mutation and the Edit drawer (via the #slots/:name route, the
+  // same path SlotCard uses). `onEdit` is optional; fall through to hash.
+  const restartMut = useSlotRestart();
+  const [busy, setBusy] = useStateS(false);
+  const goEdit = onEdit || (() => { window.location.hash = "#slots/" + slot.name; });
+  const onRestart = async () => {
+    setBusy(true);
+    try {
+      await restartMut.mutateAsync(slot.name);
+      window.__hal0Toast && window.__hal0Toast(`Restarting ${slot.name}`, "ok");
+    } catch (err) {
+      window.__hal0Toast && window.__hal0Toast(
+        err?.message ? `${slot.name}: ${err.message}` : `${slot.name}: restart failed`, "warn");
+    } finally {
+      setBusy(false);
+    }
+  };
   const tps = type === "llm" ? `${metrics.toks || 0} t/s` :
               type === "embedding" ? `${metrics.rpm} r/m` :
               type === "transcription" ? `${metrics.xrt} xrt` :
               type === "image" ? `${metrics.avg}s avg` :
               `${metrics.rpm || 0} r/m`;
   return (
-    <div className="slot-list-row" onClick={onEdit}>
+    <div className="slot-list-row" onClick={goEdit}>
       <IndicatorDot slot={slot} />
       <span className="nm">
         {slot.name}
@@ -390,8 +414,17 @@ function SlotListRow({ slot, onEdit }) {
         {type === "llm" && metrics.ctx && <span>· {metrics.ctx} ctx</span>}
       </span>
       <span className="ac">
-        <button className="btn ghost sm" onClick={e => { e.stopPropagation(); }}>{Icons.restart}</button>
-        <button className="btn ghost sm" onClick={e => { e.stopPropagation(); }}>{Icons.edit}</button>
+        <button
+          className="btn ghost sm"
+          title="Restart"
+          disabled={busy}
+          onClick={e => { e.stopPropagation(); onRestart(); }}
+        >{Icons.restart}</button>
+        <button
+          className="btn ghost sm"
+          title="Edit"
+          onClick={e => { e.stopPropagation(); goEdit(); }}
+        >{Icons.edit}</button>
       </span>
     </div>
   );
@@ -567,6 +600,7 @@ function NpuFlmStack({ slots }) {
   const editMut = useSlotEdit();
   const restartMutNpu = useSlotRestart();
   const [busy, setBusy] = useStateS(false);
+  const [npuOpen, setNpuOpen] = useStateS(false);
 
   if (!npuSlots.length) return null;
 
@@ -643,44 +677,157 @@ function NpuFlmStack({ slots }) {
   // No onPickAsr/onPickEmbed: those modalities are read-only labels (the
   // FLM trio fixes their model via flags). Chat keeps onPickChat above.
 
+  // ── derived display fields for the engine shell ──
+  // Combined NPU resident memory — sum of per-slot mem_mb (the trio shares one
+  // FLM process, so its weight shows on the loaded anchor). Em-dash, never a
+  // fabricated 0, when nothing is resident.
+  const npuMemMb = npuSlots.reduce(
+    (a, s) => a + (typeof s.mem_mb === "number" ? s.mem_mb : 0), 0,
+  );
+  const npuMemGb = npuMemMb > 0 ? Math.round((npuMemMb / 1024) * 10) / 10 : null;
+  const chatModel = chat?.model || chat?.modelDefault || "—";
+  const epillCls = loaded ? "running" : "stopped";
+  const epillLabel = loaded ? "loaded · 3 roles" : "unloaded";
+
+  // small inline glyphs (purple chip + chevron) — keeps the pane self-contained
+  const ChipGlyph = (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor"
+         strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="3.5" y="3.5" width="9" height="9" rx="1" />
+      <rect x="6" y="6" width="4" height="4" rx="0.5" />
+      <path d="M6 3.5v-1.5M10 3.5v-1.5M6 14v-1.5M10 14v-1.5M3.5 6h-1.5M3.5 10h-1.5M14 6h1.5M14 10h1.5" />
+    </svg>
+  );
+  const ChevGlyph = (
+    <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor"
+         strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M4 6l4 4 4-4" />
+    </svg>
+  );
+
   return (
-    <div className="npu-stack">
-      <div className="npu-stack-h">
-        <span className="title mono">NPU · FLM Stack</span>
-        <span className="chip" style={NPU_CHIP}>
-          <span className="dot" style={{width: 5, height: 5, background: "currentColor", boxShadow: "0 0 6px currentColor"}} />
-          coresident · boots together
-        </span>
-        <span className="npu-stack-spacer" />
-        <span className="npu-stack-master-lbl mono">master</span>
-        <NpuSwitch on={loaded} disabled={busy || !chat} label="Load/unload FLM stack" onClick={onMaster} />
-      </div>
-
-      <div className="npu-bracket">
-        <div className="npu-bracket-rail" aria-hidden="true" />
-        <div className="npu-trio">
-          <NpuModalityCard
-            icon="💬" label="Chat" slot={chat} on fixed
-            models={chatModels} busy={busy} onPickModel={onPickChat}
-          />
-          <NpuModalityCard
-            icon="🎙" label="ASR" slot={asr} on={parsed.asr} readOnlyModel
-            busy={busy}
-            onToggle={() => onToggleModality("asr")}
-          />
-          <NpuModalityCard
-            icon="🧬" label="Embed" slot={embed} on={parsed.embed} readOnlyModel
-            busy={busy}
-            onToggle={() => onToggleModality("embed")}
-          />
+    <div className="npu-pane">
+      <div className="proto">
+        <div className="sec-label">
+          <b>NPU Stack</b>
+          <span className="dim">·</span>
+          <span className="mono" style={{color: "var(--dev-npu)"}}>FLM</span>
+          <span className="dim">·</span>
+          <span className="meta">coresident</span>
+          <span className="dim">·</span>
+          <span className="meta">1 process · 3 roles</span>
+          <span className="grow" style={{flex: 1}} />
+          <span className="meta">{loaded ? "npu · loaded" : "npu · idle"}</span>
         </div>
-      </div>
 
-      <div className="npu-stack-foot mono">
-        <code className="npu-args">npu = asr:{parsed.asr ? "on" : "off"} · embed:{parsed.embed ? "on" : "off"}</code>
-        <span className="sep">·</span>
-        <span className="item">port :{childPort ?? "—"}{backendUrl ? <span title={backendUrl}> · {backendUrl}</span> : null}</span>
-        {coresGroup && <><span className="sep">·</span><span className="item">{coresGroup}</span></>}
+        <div className={"engine" + (loaded ? " active" : "") + (npuOpen ? " open" : "")}>
+          <div className="engine-h">
+            <span className="engine-glyph">{ChipGlyph}</span>
+            <span className="col">
+              <span className="engine-title">NPU · FLM Stack</span>
+              <span className="engine-sub">coresident · 1 process · 3 roles</span>
+            </span>
+            <span className={"epill " + epillCls} data-testid="npu-epill">
+              <span className="dot" />
+              {epillLabel}
+            </span>
+            <span className="grow" style={{flex: 1}} />
+            <span className="eh-right">
+              <span className="npu-master-lbl">master</span>
+              <NpuSwitch on={loaded} disabled={busy || !chat} label="Load/unload FLM stack" onClick={onMaster} />
+            </span>
+          </div>
+
+          {/* collapsed telemetry strip — hidden when the pane is open */}
+          <div className="collapsed-prog" data-testid="npu-strip">
+            <div className="tel-strip">
+              <span className="tel">
+                <span className="l">mem</span>
+                <span className="v comfy">{npuMemGb == null ? "—" : npuMemGb}<span className="u"> GB</span></span>
+              </span>
+              <span className="tel">
+                <span className="l">chat</span>
+                <span className="v" style={{maxWidth: 220, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap"}}>{chatModel}</span>
+              </span>
+              <span className="tel">
+                <span className="l">asr</span>
+                <span className="dotline"><span className={"rdot" + (parsed.asr ? " on" : "")} /><span className="v">{parsed.asr ? "on" : "off"}</span></span>
+              </span>
+              <span className="tel">
+                <span className="l">embed</span>
+                <span className="dotline"><span className={"rdot" + (parsed.embed ? " on" : "")} /><span className="v">{parsed.embed ? "on" : "off"}</span></span>
+              </span>
+              <span className="tel">
+                <span className="l">port</span>
+                <span className="v">:{childPort ?? "—"}</span>
+              </span>
+            </div>
+          </div>
+
+          {/* expandable body — the existing bracketed trio, moved verbatim */}
+          <div className="engine-body">
+            <div className="inner">
+              <div className="engine-b">
+                <div className="npu-stack">
+                  <div className="npu-bracket">
+                    <div className="npu-bracket-rail" aria-hidden="true" />
+                    <div className="npu-trio">
+                      <NpuModalityCard
+                        icon="💬" label="Chat" slot={chat} on fixed
+                        models={chatModels} busy={busy} onPickModel={onPickChat}
+                      />
+                      <NpuModalityCard
+                        icon="🎙" label="ASR" slot={asr} on={parsed.asr} readOnlyModel
+                        busy={busy}
+                        onToggle={() => onToggleModality("asr")}
+                      />
+                      <NpuModalityCard
+                        icon="🧬" label="Embed" slot={embed} on={parsed.embed} readOnlyModel
+                        busy={busy}
+                        onToggle={() => onToggleModality("embed")}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="npu-stack-foot mono">
+                    <code className="npu-args">npu = asr:{parsed.asr ? "on" : "off"} · embed:{parsed.embed ? "on" : "off"}</code>
+                    <span className="sep">·</span>
+                    <span className="item">port :{childPort ?? "—"}{backendUrl ? <span title={backendUrl}> · {backendUrl}</span> : null}</span>
+                    {coresGroup && <><span className="sep">·</span><span className="item">{coresGroup}</span></>}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* footer — flm identity + caret expand control */}
+          <div className="engine-foot has-q">
+            <div className="foot-id">
+              <span className="k">runtime</span>
+              <span className="v comfy">flm serve</span>
+              <span className="sep">·</span>
+              <span className="k">port</span>
+              <span className="v">:{childPort ?? "—"}</span>
+              {coresGroup && <>
+                <span className="sep">·</span>
+                <span className="k">group</span>
+                <span className="v comfy">{coresGroup}</span>
+              </>}
+            </div>
+            <button
+              className="qcaret"
+              onClick={() => setNpuOpen(o => !o)}
+              aria-expanded={npuOpen}
+              data-testid="npu-qcaret"
+            >
+              <span className="q">
+                {ChipGlyph} {npuOpen ? "collapse" : "trio"}
+                <span className="qn">3</span>
+              </span>
+              <span className="car">{ChevGlyph}</span>
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -1047,7 +1194,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
         <button
           role="tab"
           aria-selected={tab === "inference"}
-          className={"slot-tab" + (tab === "inference" ? " on" : "")}
+          className={"slot-tab infer" + (tab === "inference" ? " on" : "")}
           onClick={() => setTab("inference")}
         >
           <span>Inference</span>
@@ -1070,23 +1217,25 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
             <ComfyuiPane />
           ) : (
             <>
+              {/* Inference "engine" pane — a summary engine-shell (yellow accent)
+                  over the whole LLM/capability slot stack: collapsed hero
+                  (memory map + active slots + combined throughput) that expands
+                  to the full slot list with per-slot lifecycle controls + a
+                  model picker + a by-device throughput split. The per-group
+                  SlotCard grids below stay the authoritative per-slot surface. */}
+              <InferencePane />
               {renderGroup("Chat", groups.chat)}
               {/* Capabilities (C7): embedding/reranking/transcription/tts cards are
                   content-light, so they render in a denser 4-up quarter-width grid
                   instead of two separate full-width Embed/Voice sections. NPU
                   modalities (group "npu") are excluded by grouping — they live in
-                  the dedicated NPU/FLM stack section below. */}
+                  the dedicated NPU/FLM stack engine pane below. */}
               {renderGroup("Capabilities", [...groups.embed, ...groups.voice], { quarter: true })}
 
-              {slots.some(s => s.device === "npu") && (
-                <section style={{marginBottom: 24}}>
-                  <div className="sec">
-                    <h2>NPU<span className="ct mono">trio · 1 process · 3 roles</span></h2>
-                    <div className="rule" />
-                  </div>
-                  <NpuFlmStack slots={slots} />
-                </section>
-              )}
+              {/* NPU · FLM stack — its own engine-shell pane (purple accent),
+                  parallel to the Inference + ComfyUI panes. No section h2: the
+                  pane supplies its own sec-label + engine header. */}
+              {slots.some(s => s.device === "npu") && <NpuFlmStack slots={slots} />}
             </>
           )}
         </div>

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -64,6 +64,13 @@
   --comfy-bg:     #0c1622;
   --comfy-glow:   rgba(94, 164, 249, 0.20);
 
+  /* Inference "engine" accent — sodium yellow, the way ComfyUI owns blue and
+     the NPU stack owns purple. Mirrored in engine-panes.css (scoped to
+     .infer-pane); kept here so the slots-page Inference tab can glow it. */
+  --yellow:       #e5b84f;
+  --yellow-hi:    #f2ce74;
+  --yellow-bg:    #1b1605;
+
   /* Memory-map tenant colours — rotated for distinguishability vs the
      device colours used in slot segments. Amber-on-grey palette. */
   --mem-tenant-1: #b89060;
@@ -774,6 +781,8 @@ a { color: inherit; text-decoration: none; }
 .slot-tab:hover { color: var(--fg); background: var(--bg-2); }
 .slot-tab.on { color: var(--accent); background: var(--accent-bg); }
 .slot-tab.on.comfy { color: var(--comfy); background: var(--comfy-bg); }
+.slot-tab.on.infer { color: var(--yellow); background: var(--yellow-bg); }
+.slot-tab.on.infer .slot-tab-ct { color: var(--yellow); }
 .slot-tab .slot-tab-ct { font-size: 10px; color: var(--fg-5); padding: 1px 6px; background: var(--bg-2); border-radius: 999px; min-width: 16px; text-align: center; }
 .slot-tab.on .slot-tab-ct { color: var(--accent); background: transparent; }
 .slot-tab.on.comfy .slot-tab-ct { color: var(--comfy); }

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -30,6 +30,7 @@ import './globals-install'
 import './dashboard.css'
 import './mcp.css'
 import './dash/comfyui-pane.css'
+import './dash/engine-panes.css'
 
 import './dash/data.jsx'
 import './dash/tweaks-panel.jsx'

--- a/ui/tests/e2e/specs/inference-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-pane-v3.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * inference-pane-v3 — the Inference "engine" pane (slots-page Inference tab).
+ *
+ * Behaviour under test:
+ *   - collapsed hero strip renders from HAL0_DATA slots (epill + active list)
+ *   - the qcaret toggles the engine open (→ full slot list + by-device split)
+ *   - per-slot tok/s is shown for a serving slot (no fabricated numbers)
+ *   - a lifecycle control fires the real mutation (Stop → POST /unload)
+ *   - the expanded list exposes a real model-picker <select> (useModels)
+ *   - the NPU/FLM pane renders its own engine shell + trio
+ *   - the Inference tab carries the yellow `infer` accent class
+ *
+ * The slot LIST comes from in-bundle HAL0_DATA (VITE_MOCK_HAL0=1); mutations
+ * go through fetch, so per-route stubs capture the write path.
+ *
+ * NOTE on expand assertions: the engine body animates via `max-height:0;
+ * overflow:hidden`, which clips but does NOT zero the bounding box of its
+ * children — Playwright still reports them "visible". So collapse/expand is
+ * asserted on the `.engine.open` class (the real state signal), not on inner
+ * content visibility.
+ */
+import { test, expect, type Page } from '../fixtures/apiMock'
+
+const pane = (page: Page) => page.locator('.infer-pane').first()
+const engine = (page: Page) => page.locator('.infer-pane .engine').first()
+const body = (page: Page) => page.locator('.infer-pane .engine-body').first()
+
+test.describe('Inference engine pane (/slots · Inference tab)', () => {
+  test('collapsed strip renders with epill + active slot rows', async ({ page }) => {
+    await page.goto('/#slots')
+    await expect(pane(page)).toBeVisible()
+    await expect(engine(page)).not.toHaveClass(/\bopen\b/)
+    // engine state pill summarises serving/loaded counts (primary is serving).
+    await expect(page.getByTestId('infer-epill')).toContainText('serving')
+    // collapsed hero strip is visible and lists the serving primary slot.
+    const strip = page.getByTestId('infer-strip')
+    await expect(strip).toBeVisible()
+    await expect(strip.getByTestId('infer-slot-primary')).toBeVisible()
+    await expect(strip.locator('.mem .blk-h')).toContainText('memory map')
+  })
+
+  test('qcaret toggles the engine open → full list + by-device split', async ({ page }) => {
+    await page.goto('/#slots')
+    await expect(engine(page)).not.toHaveClass(/\bopen\b/)
+    await page.getByTestId('infer-qcaret').click()
+    await expect(engine(page)).toHaveClass(/\bopen\b/)
+    // full-list header (actions column) + by-device split live in the body.
+    await expect(body(page).locator('.slist .sh')).toContainText('actions')
+    await expect(body(page).locator('.tp-split')).toHaveCount(1)
+    // per-slot tok/s rendered for the serving primary slot (45 in the seed).
+    await expect(body(page).getByTestId('infer-slot-primary').locator('.met').first()).toContainText(
+      '45',
+    )
+    // toggle back closed.
+    await page.getByTestId('infer-qcaret').click()
+    await expect(engine(page)).not.toHaveClass(/\bopen\b/)
+  })
+
+  test('expanded Stop control POSTs /unload for a running slot', async ({ page }) => {
+    const unloads: string[] = []
+    await page.route('**/api/slots/primary/unload', async (route) => {
+      unloads.push(route.request().url())
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await page.goto('/#slots')
+    await page.getByTestId('infer-qcaret').click()
+    await expect(engine(page)).toHaveClass(/\bopen\b/)
+    await body(page).getByTestId('infer-slot-primary').locator('.sctrl.stop').click()
+    await expect.poll(() => unloads.length).toBeGreaterThan(0)
+  })
+
+  test('expanded list exposes a real model-picker <select> (useModels)', async ({ page }) => {
+    await page.goto('/#slots')
+    // The full-list model picker lives in the (collapsible) engine body; it is
+    // present in the DOM regardless of open state, so assert on it directly —
+    // no flaky expand-click needed for a structural check.
+    const picker = body(page).getByTestId('infer-slot-primary').locator('select.slist-picker')
+    await expect(picker).toHaveCount(1)
+    // the picker is populated (at minimum the current model is an option).
+    await expect.poll(async () => picker.locator('option').count()).toBeGreaterThan(0)
+  })
+})
+
+test.describe('NPU · FLM engine pane (/slots · Inference tab)', () => {
+  test('renders an engine shell with a collapsed strip', async ({ page }) => {
+    await page.goto('/#slots')
+    await expect(page.locator('.npu-pane').first()).toBeVisible()
+    await expect(page.getByTestId('npu-epill')).toBeVisible()
+    await expect(page.getByTestId('npu-strip')).toBeVisible()
+  })
+
+  test('caret toggles the trio open (Chat / ASR / Embed)', async ({ page }) => {
+    await page.goto('/#slots')
+    const npuEngine = page.locator('.npu-pane .engine').first()
+    await expect(npuEngine).not.toHaveClass(/\bopen\b/)
+    await page.getByTestId('npu-qcaret').click()
+    await expect(npuEngine).toHaveClass(/\bopen\b/)
+    await expect(page.locator('.npu-pane .engine-body .npu-mod')).toHaveCount(3)
+  })
+})
+
+test.describe('Inference tab accent', () => {
+  test('the Inference tab carries the yellow infer accent class', async ({ page }) => {
+    await page.goto('/#slots')
+    const tab = page.locator('.slot-tab.infer').first()
+    await expect(tab).toBeVisible()
+    await expect(tab).toHaveClass(/\bon\b/)
+  })
+})

--- a/ui/tests/e2e/specs/npu-container-v3.spec.ts
+++ b/ui/tests/e2e/specs/npu-container-v3.spec.ts
@@ -113,6 +113,13 @@ test.describe('NPU container mode — NpuFlmStack (#Phase-A)', () => {
     const stack = page.locator('.npu-stack')
     await expect(stack).toBeVisible()
 
+    // The NPU/FLM stack now renders inside a collapsible "engine" pane
+    // (parallel to the ComfyUI + Inference panes); the trio lives in the
+    // expandable body, so open it via the caret before interacting with a
+    // toggle. Read-path assertions above work on the clipped DOM, but a
+    // click needs the control un-clipped.
+    await page.getByTestId('npu-qcaret').click()
+
     // Confirm embed starts unchecked (state from slot.npu.embed=false)
     const embedSwitch = stack.locator('.npu-trio .npu-mod').nth(2).locator('.npu-switch')
     await expect(embedSwitch).toHaveAttribute('aria-checked', 'false')

--- a/ui/tests/e2e/specs/slots-v3.spec.ts
+++ b/ui/tests/e2e/specs/slots-v3.spec.ts
@@ -50,8 +50,12 @@ test.describe('Slots v3 (/slots)', () => {
 
   test('NPU rollup section renders when an NPU slot is present', async ({ page }) => {
     await page.goto('/#slots')
-    // HAL0_DATA seeds at least one device=npu slot, so the NPU section h2 should appear
-    await expect(page.locator('.view .sec h2', { hasText: 'NPU' })).toBeVisible()
+    // The NPU/FLM stack now renders as its own "engine" pane (parallel to the
+    // ComfyUI + Inference panes) instead of a plain <section><h2>NPU</h2> — the
+    // standalone section header was dropped for the pane's own engine header.
+    // HAL0_DATA seeds at least one device=npu slot, so the pane appears.
+    await expect(page.locator('.npu-pane')).toBeVisible()
+    await expect(page.locator('.npu-pane .engine-title')).toContainText('NPU')
   })
 
   test('NPU trio: chat is a model picker; ASR/embed are read-only labels (model fixed by FLM)', async ({ page }) => {


### PR DESCRIPTION
## Summary

Brings the slots-page **Inference** tab in line with the ComfyUI generation-engine pane: a yellow-accented **Inference "engine" pane** that summarises the whole LLM/capability slot stack, plus a matching purple **NPU · FLM engine-pane restyle**. One backend field (`ctx_max`) added; a handful of slots-page stub bugs fixed along the way.

### A — Inference engine pane (`inference-pane.jsx` + `engine-panes.css`)
- **Collapsed hero:** memory map (real per-slot `mem_mb` via `useMemoryMapModel`, unified-RAM frame with a GTT tick + honest "system · KV+runtime" segment — no fabricated KV/OS split) · active slot list · combined throughput (client ring buffer, the `ThroughputCard` pattern).
- **Expanded (qcaret):** full slot list with per-slot tok/s · ttft · ctx-used/max, lifecycle controls wired to the real `useSlot{Restart,Unload,Load,Swap}` mutations, a `useModels` model picker, a runtime profile pill, and a by-device throughput split.
- Design voice honoured: lowercase mono labels, no emoji in the chrome, **em-dash for any metric the backend hasn't reported** — never a fabricated number.
- CSS via **Option A**: `engine-panes.css` scopes the shared engine shell under `.infer-pane`/`.npu-pane` (mirrors `comfyui-pane.css`; **zero risk to the ComfyUI pane** — `row.css` is not global in the live build). `--yellow` tokens + `.slot-tab.infer.on` added to `dashboard.css`.

### B — NPU · FLM engine restyle (`slots.jsx` `NpuFlmStack`)
- Wrapped in the same engine shell (purple accent): glyph header, state epill, master switch in the header, collapsed tel-strip (NPU mem · chat model · asr/embed dots · port) ⇄ expanded bracketed trio (verbatim data wiring + mutations), qcaret footer.
- Dropped the standalone `<section><h2>NPU…</h2>` wrapper for the pane's own header.
- **Zero backend change.**

### C — slots-page stub fixes
- `SlotListRow` Restart/Edit buttons were dead (`stopPropagation` only) → wired to the real restart mutation + Edit route.
- `slotIndicator` chip colour map keyed on `warning`/`recent` (which the classifier never emits → always grey) → aligned to the real `serving|stale|warming|error|offline` vocabulary.
- `const isContainer = true` hard-code → derived from the payload.
- `CreateSlotModal` showed a fabricated `:<nextPort>` the POST never sends (backend auto-assigns) → honest "auto · assigned on save".
- `ErrorSlotCardBanner` **Retry** was toast-only → re-attempts the load via `useSlotLoad`.

### Backend (`slot_view`)
- `config_enrichment` lifts the configured context window (`[model].context_size`, `ctx_size` alias fallback) onto each slot as `ctx_max` so the pane renders "ctx used / max" without a per-slot `/config` fetch. Additive; absent → key omitted. FE `Slot` interface gains optional `ctx_max`.

## Test plan
- **New spec** `inference-pane-v3.spec.ts` (7 tests): collapsed strip + epill, qcaret toggle → full list/by-device split, per-slot tok/s, Stop → POST `/unload`, model-picker `<select>`, NPU pane shell + trio caret, tab accent. **7/7 green.**
- Updated `npu-container-v3` (expand the collapsible NPU pane before toggling embed) + `slots-v3` (NPU pane header instead of the dropped `<h2>`).
- Regression: `slot_view` + `slots` pytest **109 passed** (post-rebase); slot/npu/comfyui/edit/lifecycle/swap/indicator playwright specs **51+40 green** in clean isolated runs.
- `make lint` ✓ · `ruff format --check src tests` ✓ · `make ui-build` ✓.

> ⚠️ The **full** local `npx playwright test` and `pytest -m "not slow"` runs were abandoned mid-run because the shared dev box was at load 55–60 (several concurrent AFK sessions) — they flaked on timing, not assertions. Every spec my change actually touches passed in clean isolated runs; **CI (`playwright.yml` + `ci.yml`) is the authoritative clean-environment gate.** Rebased onto `origin/main` (`b7bc6ec`, incl. #734/#735) — clean, no conflicts (my `ctx_max` is in `config_enrichment`, #734's change in `container_enrichment`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)