### PR TITLE
fix(mcp): model_store_probe degrades on stale NFS mount instead of raising (#718)

### DIFF
--- a/src/hal0/mcp/probes.py
+++ b/src/hal0/mcp/probes.py
@@ -199,7 +199,20 @@ def model_store_probe(path: str) -> dict[str, Any]:
     response stays JSON-serialisable.
     """
     p = Path(path)
-    if not p.exists():
+    # On a stale NFS mount exists() does not return False — it raises
+    # OSError (ENODEV when the export drops, ESTALE when the server
+    # restarts under us). /mnt/ai-models is NFS from pve, and that
+    # instability is a known recurring condition (#718) — the probe
+    # exists precisely to report store health, so degrade, don't raise.
+    try:
+        path_exists = p.exists()
+    except OSError as exc:
+        return {
+            "path": str(p),
+            "exists": False,
+            "reason": f"stat failed: {exc}",
+        }
+    if not path_exists:
         return {
             "path": str(p),
             "exists": False,

--- a/tests/mcp/test_probes.py
+++ b/tests/mcp/test_probes.py
@@ -141,6 +141,29 @@ def test_model_store_probe_nfs_not_uma_aware(
     assert out["is_uma_aware"] is False
 
 
+@pytest.mark.parametrize(
+    "exc",
+    [
+        OSError(19, "No such device"),  # ENODEV — pve NFS export dropped
+        OSError(116, "Stale file handle"),  # ESTALE — server restarted under us
+    ],
+    ids=["enodev", "estale"],
+)
+def test_model_store_probe_stale_mount_degrades(
+    monkeypatch: pytest.MonkeyPatch, exc: OSError
+) -> None:
+    """#718: Path.exists() RAISES on a stale NFS mount instead of returning
+    False — the probe must degrade to an unavailable envelope, not crash."""
+
+    def _stale(self: Path) -> bool:
+        raise exc
+
+    monkeypatch.setattr(Path, "exists", _stale)
+    out = probes.model_store_probe("/mnt/ai-models")
+    assert out["exists"] is False
+    assert exc.strerror in out["reason"]
+
+
 # ── env_report ───────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
`Path.exists()` on a stale NFS mount raises `OSError` (ENODEV — pve export dropped; ESTALE — server restarted underneath) instead of returning False, so `model_store_probe` crashed exactly when it existed to report the store unhealthy. Now caught → unavailable envelope with the errno in `reason`.

Per the issue's sweep request: the module's other `exists()` calls target `/sys`//`/dev` (kernel virtual filesystems — no stale-mount failure mode), and `statvfs`/subprocess paths were already guarded, so this is the only exposed site.

## Test plan
- [x] TDD red→green: parametrized ENODEV + ESTALE regression tests (monkeypatched `Path.exists` raise)
- [x] 111 pass in tests/mcp; ruff + format clean
- [ ] CI

Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)