### PR TITLE
fix(comfyui): container telemetry probes podman img unit, docker as legacy fallback (#710)

### DIFF
--- a/src/hal0/api/routes/comfyui.py
+++ b/src/hal0/api/routes/comfyui.py
@@ -49,6 +49,7 @@ _RAM_CEIL_GB = 96
 _PRESSURE_GB = 50
 
 _HERMES_UNIT = "hal0-agent@hermes.service"
+_IMG_UNIT = "hal0-slot@img.service"
 
 # Switchover target modes. "generation" hands the iGPU to ComfyUI
 # (arbiter.ensure_img); "inference" hands it back to the LLM stack
@@ -128,11 +129,17 @@ async def _fetch_json(path: str) -> dict[str, Any] | None:
 
 
 async def _container_state(name: str) -> str:
-    """Return the docker container state: 'running', 'exited', or 'absent'.
+    """Return the generation container state: 'running', 'exited', or 'absent'.
 
-    'absent' also covers "docker not installed" and any inspect failure — the
-    pane treats all non-running states as stopped.
+    Podman-first (#710): post-Phase-D the img slot runs as the
+    ``hal0-slot@img`` systemd unit — probe it the way the slots page
+    does. ``docker inspect`` survives only as the legacy fallback for
+    pre-migration installs. 'absent' also covers "docker not installed"
+    and any inspect failure — the pane treats all non-running states as
+    stopped.
     """
+    if await _systemd_active(_IMG_UNIT):
+        return "running"
     docker = shutil.which("docker")
     if not docker:
         return "absent"

--- a/tests/api/test_comfyui_proxy.py
+++ b/tests/api/test_comfyui_proxy.py
@@ -536,3 +536,41 @@ def test_switchover_enabled_flag_is_read_per_request(
     monkeypatch.setenv("HAL0_COMFYUI_SWITCHOVER_ENABLED", "1")
     r = client.post("/api/comfyui/switchover", json={"mode": "generation"})
     assert r.status_code != 501
+
+
+# ── _container_state: podman-first probe (#710) ──────────────────────────────
+
+
+async def test_container_state_running_when_img_unit_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#710: post-Phase-D the img slot runs as podman hal0-slot@img — the
+    systemd unit probe is the truth; docker inspect is legacy fallback only."""
+    from hal0.api.routes import comfyui as mod
+
+    probed_units: list[str] = []
+
+    async def fake_active(unit: str) -> bool:
+        probed_units.append(unit)
+        return unit == "hal0-slot@img.service"
+
+    monkeypatch.setattr(mod, "_systemd_active", fake_active)
+    # No docker binary at all — the podman path must not need it.
+    monkeypatch.setattr(mod.shutil, "which", lambda name: None)
+
+    assert await mod._container_state("comfyui") == "running"
+    assert "hal0-slot@img.service" in probed_units
+
+
+async def test_container_state_absent_when_unit_inactive_and_no_docker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hal0.api.routes import comfyui as mod
+
+    async def fake_active(unit: str) -> bool:
+        return False
+
+    monkeypatch.setattr(mod, "_systemd_active", fake_active)
+    monkeypatch.setattr(mod.shutil, "which", lambda name: None)
+
+    assert await mod._container_state("comfyui") == "absent"


### PR DESCRIPTION
## Summary
The `container` block in `/api/comfyui/status` still probed `docker inspect comfyui` — dead since the Phase D podman migration, so `container.state` read **absent** forever. (#730 already made the `engine` pill trust a reachable ComfyUI; this closes the remaining blind spot.)

`_container_state` now probes the `hal0-slot@img.service` systemd unit first — the same truth source as the slots page — with `docker inspect` demoted to legacy fallback for pre-migration installs. Bonus effects, both flagged in the issue:
- the engine pill is now bounded: a crashed img unit renders `stopped` instead of riding the arbiter-mode override;
- the arbiter-less legacy `mode` fallback derives from real container state again.

Note: the img container is resident 24/7 post-#728, so `container.state == running` in inference mode is correct — `mode` (arbiter-truth) says who owns the GPU memory.

## Test plan
- [x] TDD red→green: unit-active → running with NO docker binary; unit-inactive + no docker → absent
- [x] 38 pass across comfyui suites (route tests patch `_container_state` directly — unaffected by design)
- [x] ruff + format clean
- [ ] CI
- [ ] Live CT105: `container.state` shows `running` for the resident img container

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)