### PR TITLE
fix(ui): firstrun+MCP endpoint wiring, honest MCP lifecycle, connections e2e

### DIFF
--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -65,6 +65,9 @@ export const ENDPOINTS = {
   backendInstall: (id: string) => `/api/backends/${encodeURIComponent(id)}/install`,
   backendNpuLoad: '/api/backends/npu/load',
   backendNpuUnload: '/api/backends/npu/unload',
+  // Alias spelling used in ui-sweep-a hook files (PR #741 TODOs).
+  backendsNpuLoad: '/api/backends/npu/load',
+  backendsNpuUnload: '/api/backends/npu/unload',
 
   // ── Capabilities ─────────────────────────────────────────────────
   capabilities: '/api/capabilities',
@@ -117,10 +120,22 @@ export const ENDPOINTS = {
   agentActivity: (id: string) =>
     `/api/agents/${encodeURIComponent(id)}/activity`,
   agentApprovals: '/api/agent/approvals',
-  // The path below DOES NOT exist yet in any merged backend PR (the
-  // sidebar component degrades gracefully with "—" + warn). Recorded
-  // here so the wiring is single-place when the route lands.
-  agentMemoryStats: '/api/agents/hermes/memory/stats',
+  // Approval CRUD — list is an alias of agentApprovals; approve/deny are
+  // the action endpoints added by backend-dev task #7 (PR #741 TODOs).
+  agentApprovalsList: '/api/agent/approvals',
+  agentApprovalApprove: (id: string) =>
+    `/api/agent/approvals/${encodeURIComponent(id)}/approve`,
+  agentApprovalDeny: (id: string) =>
+    `/api/agent/approvals/${encodeURIComponent(id)}/deny`,
+  // Memory list endpoint (ADR-0014, PR #736 backend surface).
+  memoryList: '/api/memory/list',
+  // Per-agent memory stats — parameterised by agent id. Previously a
+  // hardcoded "/api/agents/hermes/memory/stats" placeholder; now generic.
+  agentMemoryStats: (id: string) =>
+    `/api/agents/${encodeURIComponent(id)}/memory/stats`,
+  // Persona update — PATCH/PUT /api/agents/{agentId}/personas/{pid}.
+  agentPersonaUpdate: (agentId: string, pid: string) =>
+    `/api/agents/${encodeURIComponent(agentId)}/personas/${encodeURIComponent(pid)}`,
 
   // ── MCP host introspection (issue #206) ──────────────────────────
   // Read-only view of hosted MCP servers, connected clients, the

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -57,7 +57,14 @@ export const ENDPOINTS = {
   // ── Backends ─────────────────────────────────────────────────────
   backends: '/api/backends',
   backend: (id: string) => `/api/backends/${encodeURIComponent(id)}`,
+  // NOTE: backendInstall has no generic backend route. The only install-
+  // like operation available is NPU: POST /api/backends/npu/load (and
+  // /api/backends/npu/unload). The UI flow-modals.jsx BackendInstallModal
+  // should route the NPU case to backendNpuLoad; remove this constant once
+  // ui-sweep-a's BackendInstallModal migration is complete.
   backendInstall: (id: string) => `/api/backends/${encodeURIComponent(id)}/install`,
+  backendNpuLoad: '/api/backends/npu/load',
+  backendNpuUnload: '/api/backends/npu/unload',
 
   // ── Capabilities ─────────────────────────────────────────────────
   capabilities: '/api/capabilities',
@@ -81,9 +88,12 @@ export const ENDPOINTS = {
   agentPersonaEnums: '/api/agents/persona-enums',
 
   // ── Agents — MCP-client allow-list (ADR-0013) ────────────────────
-  agentMcpClients: '/api/agents/mcp/clients',
+  // Backend: GET /api/mcp/clients (mcp.py:469) — note the prefix is
+  // /api/mcp, NOT /api/agents/mcp.  The original constant had the wrong
+  // prefix which caused the Clients tab to 404 on every real install.
+  agentMcpClients: '/api/mcp/clients',
   agentMcpClient: (name: string) =>
-    `/api/agents/mcp/clients/${encodeURIComponent(name)}`,
+    `/api/mcp/clients/${encodeURIComponent(name)}`,
 
   // ── Agents — bundled lifecycle + sidebar rollup (v0.3 PR-6) ──────
   // `agents` lives in the catalogue block above (one entry, used by
@@ -187,11 +197,18 @@ export const ENDPOINTS = {
   profiles: '/api/profiles',
   profile: (name: string) => `/api/profiles/${encodeURIComponent(name)}`,
 
-  // Install / FirstRun
+  // Install / FirstRun — all routes are under /api/install/* (installer.py).
+  // The old /api/firstrun/* prefix was a stale artifact; the backend mounts
+  // the router at /api/install (verified in src/hal0/api/routes/installer.py).
   installState: '/api/install/state',
-  firstrunState: '/api/firstrun/state',
-  firstrunCuratedModels: '/api/firstrun/curated-models',
-  firstrunPickDefault: '/api/firstrun/pick-default',
-  firstrunInstall: '/api/firstrun/install',
-  firstrunComplete: '/api/firstrun/complete',
+  installCuratedModels: '/api/install/curated-models',
+  installPickDefault: '/api/install/pick-default',
+  // NOTE: there is no single /api/install/install (bundle-level) endpoint.
+  // The wizard "install" step maps to POST /api/install/pick-default per model.
+  // The hook (useFirstRunInstall) calls pick-default; the UI handles graceful
+  // degradation on any error so progress stage still renders.
+  installComplete: '/api/install/complete',
+  // PUT /api/install/slots/{slot}/model — assign a model to a slot post-pick.
+  installSlotModel: (slot: string) =>
+    `/api/install/slots/${encodeURIComponent(slot)}/model`,
 } as const

--- a/ui/src/api/hooks/useFirstRun.ts
+++ b/ui/src/api/hooks/useFirstRun.ts
@@ -60,22 +60,57 @@ export function useFirstRunPickDefault() {
   })
 }
 
+// Static mapping: wizard tier ids → curated model ids accepted by
+// POST /api/install/pick-default.
+//
+// Source: installer/manifests/omni/*.json primary.model_name, cross-verified
+// against GET /api/install/curated-models (which exposes the curated catalogue
+// filtered to recommended_slot in ("chat","primary")).
+//
+// Max and LMX manifests reference Qwen3.6-35B-A3B-MTP-GGUF which is NOT
+// currently in the curated catalogue — both degrade to the 27B model.
+// Log a backend follow-up to add the 35B entry so Max/LMX can use their
+// intended primary.
+const BUNDLE_CHAT_MODELS: Record<string, string> = {
+  lite:    'qwen3.5-0.8b',  // manifest: qwen3.5-0.8b ✓
+  default: 'qwen3.5-9b',    // manifest: qwen3.5-9b ✓
+  pro:     'qwen3.6-27b',   // manifest: Qwen3.6-27B-MTP-GGUF → curated id qwen3.6-27b ✓
+  max:     'qwen3.6-27b',   // manifest 35B not curated yet — degrade to 27b
+  lmx:     'qwen3.6-27b',   // LMX 35B not curated yet — degrade to 27b
+}
+
+export interface PickDefaultResponse {
+  model_id: string
+  slot: string
+  pull_job_id: string
+  next: string
+}
+
 export function useFirstRunInstall() {
   const qc = useQueryClient()
   return useMutation({
-    // No bundle-level install endpoint exists on the backend. We call
-    // POST /api/install/pick-default with the bundle id as the model_id.
-    // The backend will return 404 for unknown bundle ids (they're not
-    // curated model ids), which the wizard's catch block swallows —
-    // the progress stage renders "Install started" and picks up any
-    // per-model SSE streams that the pick-default calls have already
-    // kicked off. This is a known gap until a bundle-level endpoint lands.
-    mutationFn: ({ bundle, withNpu }: { bundle: string; withNpu?: boolean }) =>
-      apiPost(ENDPOINTS.installPickDefault, {
-        model_id: bundle,
+    // Call POST /api/install/pick-default with the REAL curated model id
+    // for the bundle's primary chat slot — NOT the bundle string itself.
+    // Bundle ids like "pro" are not valid curated model ids and 404 on the
+    // backend (CuratedModelNotFound).
+    //
+    // The progress pane (FirstRunProgress) receives { model_ids: [id] } so
+    // FrDownloadRow can reattach to the in-flight SSE pull stream immediately.
+    mutationFn: async ({ bundle, withNpu: _withNpu }: { bundle: string; withNpu?: boolean }) => {
+      const modelId = BUNDLE_CHAT_MODELS[bundle]
+      if (!modelId) {
+        // Surface unknown bundle clearly — don't silently 404 and show fake
+        // "Install started" when nothing was actually triggered.
+        throw new Error(`No curated model mapping for bundle "${bundle}" — check BUNDLE_CHAT_MODELS`)
+      }
+      const resp = await apiPost<PickDefaultResponse>(ENDPOINTS.installPickDefault, {
+        model_id: modelId,
         slot: 'chat',
-        with_npu: !!withNpu,
-      }),
+      })
+      // Normalise to the model_ids array shape the confirm → progress handoff
+      // reads (res?.model_ids) so FrDownloadRow mounts with the real id.
+      return { model_ids: [resp.model_id] }
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['firstrun'] })
       qc.invalidateQueries({ queryKey: ['models'] })

--- a/ui/src/api/hooks/useFirstRun.ts
+++ b/ui/src/api/hooks/useFirstRun.ts
@@ -4,10 +4,12 @@
 // surface has three stages; this hook bag covers all of them:
 //   - useFirstRunState() — current stage + picked bundle
 //   - useCuratedBundles() — bundles + per-bundle details + curated models
-//   - useFirstRunPickDefault() — set the default per slot
-//   - useFirstRunInstall() — kick off the install (downloads + slot
-//                            seeding); returns a job id polled via
-//                            usePullJob per model
+//   - useFirstRunPickDefault() — set the default per slot (kicks off pull)
+//   - useFirstRunInstall() — best-effort "start install" for the wizard confirm
+//                            step. Maps to POST /api/install/pick-default with
+//                            the bundle id as the model_id; the UI handles
+//                            errors gracefully (empty model_ids → progress
+//                            stage shows "Install started" placeholder).
 //   - useFirstRunComplete() — flip the "completed" flag
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
@@ -38,14 +40,14 @@ export interface CuratedBundles {
 export function useFirstRunState() {
   return useQuery({
     queryKey: ['firstrun', 'state'],
-    queryFn: () => apiGet<FirstRunState>(ENDPOINTS.firstrunState),
+    queryFn: () => apiGet<FirstRunState>(ENDPOINTS.installState),
   })
 }
 
 export function useCuratedBundles() {
   return useQuery({
     queryKey: ['firstrun', 'curated'],
-    queryFn: () => apiGet<CuratedBundles>(ENDPOINTS.firstrunCuratedModels),
+    queryFn: () => apiGet<CuratedBundles>(ENDPOINTS.installCuratedModels),
   })
 }
 
@@ -53,7 +55,7 @@ export function useFirstRunPickDefault() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: ({ slot, model_id }: { slot: string; model_id: string }) =>
-      apiPost(ENDPOINTS.firstrunPickDefault, { slot, model_id }),
+      apiPost(ENDPOINTS.installPickDefault, { slot, model_id }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['firstrun'] }),
   })
 }
@@ -61,8 +63,19 @@ export function useFirstRunPickDefault() {
 export function useFirstRunInstall() {
   const qc = useQueryClient()
   return useMutation({
+    // No bundle-level install endpoint exists on the backend. We call
+    // POST /api/install/pick-default with the bundle id as the model_id.
+    // The backend will return 404 for unknown bundle ids (they're not
+    // curated model ids), which the wizard's catch block swallows —
+    // the progress stage renders "Install started" and picks up any
+    // per-model SSE streams that the pick-default calls have already
+    // kicked off. This is a known gap until a bundle-level endpoint lands.
     mutationFn: ({ bundle, withNpu }: { bundle: string; withNpu?: boolean }) =>
-      apiPost(ENDPOINTS.firstrunInstall, { bundle, with_npu: !!withNpu }),
+      apiPost(ENDPOINTS.installPickDefault, {
+        model_id: bundle,
+        slot: 'chat',
+        with_npu: !!withNpu,
+      }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['firstrun'] })
       qc.invalidateQueries({ queryKey: ['models'] })
@@ -73,7 +86,7 @@ export function useFirstRunInstall() {
 export function useFirstRunComplete() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: () => apiPost(ENDPOINTS.firstrunComplete),
+    mutationFn: () => apiPost(ENDPOINTS.installComplete),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['firstrun'] }),
   })
 }

--- a/ui/src/api/hooks/useMcp.ts
+++ b/ui/src/api/hooks/useMcp.ts
@@ -447,9 +447,17 @@ export function useMcpRestart() {
           raw: true,
         })
       } catch (err) {
-        if (err instanceof Hal0Error && err.status === 501) {
+        // Tolerate both the original code and the ADR-0015 rename so the
+        // transition window is seamless — backend ships the rename first,
+        // then this guard handles both sides until the old code is gone.
+        const isSupervisorPending =
+          err instanceof Hal0Error &&
+          err.status === 501 &&
+          (err.code === 'mcp.supervisor_unavailable' ||
+            err.code === 'mcp.not_implemented')
+        if (isSupervisorPending) {
           _toast(
-            'MCP restart pending supervisor follow-up to #305',
+            'Process supervisor not yet implemented (pending ADR-0015)',
             'warn',
           )
           return null

--- a/ui/src/dash/extras.jsx
+++ b/ui/src/dash/extras.jsx
@@ -104,15 +104,17 @@ function LogsView() {
       setPendingCount(0);
     }
   };
-  // simulate new lines arriving while user has scrolled up
+  // Keep pending count in sync with actual buffered live lines when
+  // the user has scrolled up. Count real unread lines rather than
+  // simulating arrivals with a fake interval.
   React.useEffect(() => {
     if (!followTail) {
-      const t = setInterval(() => setPendingCount(c => c + 1), 1800);
-      return () => clearInterval(t);
+      // Count live SSE lines not yet in view as "pending".
+      setPendingCount(live.ring?.length ?? 0);
     } else {
       setPendingCount(0);
     }
-  }, [followTail]);
+  }, [followTail, live.ring]);
 
   const allSlots = [...new Set(buf.map(e => e.slot).filter(Boolean))];
 
@@ -158,7 +160,30 @@ function LogsView() {
             <span>{followTail ? "follow tail" : "paused tail"}</span>
           </span>
           <button className="btn ghost sm" onClick={() => setPaused(p => !p)}>{paused ? "Resume" : "Pause"}</button>
-          <button className="btn ghost sm" onClick={() => window.__hal0Toast && window.__hal0Toast("Exporting .log — stubbed", "info")}>{Icons.download}</button>
+          <button className="btn ghost sm" title="Export current journal buffer as .log" onClick={async () => {
+            try {
+              // Fetch the current journal buffer (up to 5000 lines) and
+              // trigger a client-side blob download — no server-side export
+              // endpoint needed.
+              const resp = await fetch('/api/journal?limit=5000', { headers: { Accept: 'application/json' } });
+              if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+              const data = await resp.json();
+              const entries = data?.entries ?? [];
+              const text = entries.length > 0
+                ? entries.map(e => `${e.ts || ''} [${e.level || 'info'}] ${e.source ? '[' + e.source + '] ' : ''}${e.msg || ''}`.trim()).join('\n')
+                : lines.map(e => `${e.ts || ''} [${e.level || 'info'}] ${e.msg || ''}`.trim()).join('\n');
+              const blob = new Blob([text], { type: 'text/plain' });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = `hal0-journal-${new Date().toISOString().slice(0,19).replace(/[T:]/g,'-')}.log`;
+              a.click();
+              URL.revokeObjectURL(url);
+              window.__hal0Toast && window.__hal0Toast('Journal exported', 'ok');
+            } catch (err) {
+              window.__hal0Toast && window.__hal0Toast(`Export failed — ${err?.message || 'see console'}`, 'err');
+            }
+          }}>{Icons.download}</button>
         </div>
 
         <div

--- a/ui/src/dash/firstrun.jsx
+++ b/ui/src/dash/firstrun.jsx
@@ -160,10 +160,20 @@ function FirstRunPicker({ onPick, onSkip, layout }) {
         <h1 className="fr-title">Welcome to <span className="accent">hal0</span></h1>
         <p className="fr-lede">Pick a starting configuration. You can customise any slot later — or skip and configure manually.</p>
         <div className="fr-detect">
-          <span className="seg"><span className="k">RAM</span><b>128 GB</b> unified</span>
-          <span className="seg"><span className="k">GPU</span><b>Strix Halo</b> gfx1151</span>
-          <span className="seg"><span className="k">NPU</span><b>XDNA2</b><span className="ok">●</span></span>
-          <span className="seg"><span className="k">disk</span><b>412 GB</b> free</span>
+          <span className="seg">
+            <span className="k">RAM</span>
+            <b>{hwQuery.data?.ram?.total ?? HAL0_DATA.host?.ram?.total ?? '—'} GB</b>
+            {(hwQuery.data?.memoryKind ?? HAL0_DATA.host?.memory_kind) === 'unified' ? ' unified' : ''}
+          </span>
+          <span className="seg">
+            <span className="k">GPU</span>
+            <b>{hwQuery.data?.gpu || HAL0_DATA.host?.gpu || '—'}</b>
+          </span>
+          <span className="seg">
+            <span className="k">NPU</span>
+            <b>{hwQuery.data?.npu?.name || HAL0_DATA.host?.npu?.name || '—'}</b>
+            {(hwQuery.data?.npu?.present ?? HAL0_DATA.host?.npu?.present) && <span className="ok">●</span>}
+          </span>
         </div>
       </div>
 
@@ -311,7 +321,10 @@ function FirstRunConfirm({ bundleId, onBack, onInstall }) {
   const installM = useFirstRunInstall();
   const bundles = bundlesQuery.data?.bundles ?? HAL0_DATA.bundles;
   const bundle = bundles.find(b => b.id === bundleId) || HAL0_DATA.bundles.find(b => b.id === bundleId);
-  const det = HAL0_DATA.bundleDetails.pro; // detail-level data not yet over /api/firstrun
+  // Key into bundleDetails by the selected bundle id so pro/default/lite/max
+  // all show their own model list. Fall back to 'pro' when the id isn't in
+  // the static fixture (shouldn't happen on a fresh install).
+  const det = HAL0_DATA.bundleDetails[bundleId] ?? HAL0_DATA.bundleDetails.pro;
   return (
     <div className="fr-inner">
       <span className="fr-confirm-back mono" onClick={onBack}>← back to picker</span>
@@ -485,10 +498,12 @@ function FirstRunProgress({ onDone, bundleId, modelIds }) {
         )}
       </div>
 
-      <div className="fr-actions" style={{justifyContent: "space-between"}}>
-        <button className="btn ghost lg">Pause all</button>
+      <div className="fr-actions" style={{justifyContent: "flex-end"}}>
         <div style={{display: "flex", gap: 12}}>
-          <button className="btn ghost lg">View logs</button>
+          {/* No backend pause-all endpoint exists — remove button rather than fake it */}
+          <button className="btn ghost lg" onClick={() => {
+            window.location.hash = "logs";
+          }}>View logs</button>
           <button className="btn lg" onClick={() => {
             completeM.mutate();
             onDone();

--- a/ui/src/dash/mcp-modals.jsx
+++ b/ui/src/dash/mcp-modals.jsx
@@ -203,11 +203,20 @@ function InstallFromUrl({ onInstall }) {
 // ─── Edit config modal ──────────────────────────────────────────────
 function EditConfigModal({ open, server, onClose }) {
   const [env, setEnv] = useStateMM({});
-  // Config-write hook — backend currently 501s pending ADR-0013; the
-  // mutation hook surfaces the toast for us so the Save button looks
-  // alive instead of silently failing.
+  // Seed autoStart from the server record (auto_start field from the backend;
+  // also tolerate camelCase from older payloads). Defaults to false so freshly
+  // installed servers don't silently auto-start before the supervisor lands.
+  const [autoStart, setAutoStart] = useStateMM(false);
+  // Config-write hook — PATCH /api/mcp/{id}/config accepts {env, enabled}.
+  // We also include auto_start in the payload; the backend ignores unknown
+  // keys, and a future supervisor extension will pick it up.
   const configMut = useMcpConfigPatch();
-  useEffectMM(() => { if (server) setEnv({ ...(server.env || {}) }); }, [server]);
+  useEffectMM(() => {
+    if (server) {
+      setEnv({ ...(server.env || {}) });
+      setAutoStart(!!(server.auto_start ?? server.autoStart ?? false));
+    }
+  }, [server]);
   if (!server) return null;
 
   return (
@@ -223,7 +232,7 @@ function EditConfigModal({ open, server, onClose }) {
           <span style={{display: "inline-flex", gap: 8}}>
             <button className="btn ghost sm" onClick={onClose}>Cancel</button>
             <button className="btn sm" onClick={() => {
-              configMut.mutate({ id: server.id, body: { env } });
+              configMut.mutate({ id: server.id, body: { env, auto_start: autoStart } });
               onClose();
             }}>Save</button>
           </span>
@@ -266,16 +275,14 @@ function EditConfigModal({ open, server, onClose }) {
 
         <div className="mcp-cfg-sec mono">Auto-start</div>
         <label className="mcp-cfg-toggle mono">
-          <input type="checkbox" defaultChecked style={{accentColor: "var(--accent)"}} />
+          <input
+            type="checkbox"
+            checked={autoStart}
+            onChange={e => setAutoStart(e.target.checked)}
+            style={{accentColor: "var(--accent)"}}
+          />
           <span>Restart this server when hal0 restarts</span>
         </label>
-
-        <div className="mcp-cfg-sec mono">Allowed clients</div>
-        <div className="mcp-cfg-allow mono">
-          <span className="mcp-cfg-allow-pill on">any local client</span>
-          <span className="mcp-cfg-allow-pill">claude-code only</span>
-          <span className="mcp-cfg-allow-pill">require token</span>
-        </div>
       </div>
     </Modal>
   );
@@ -332,7 +339,10 @@ function LogsDrawer({ open, server, onClose }) {
             following tail
           </span>
           <span style={{display: "inline-flex", gap: 8}}>
-            <button className="btn ghost sm">Open full logs →</button>
+            <button className="btn ghost sm" onClick={() => {
+              onClose();
+              window.location.hash = "logs";
+            }}>Open full logs →</button>
             <button className="btn ghost sm" onClick={onClose}>Close</button>
           </span>
         </>

--- a/ui/src/dash/mcp.jsx
+++ b/ui/src/dash/mcp.jsx
@@ -170,7 +170,9 @@ function CopyField({ value, monoClass = "mono" }) {
 //
 // Supervisor capability flag — v0.3 alpha ships the registry layer
 // (#305) but not yet the process supervisor: ``POST /api/mcp/{id}/{action}``
-// returns 501 ``mcp.not_implemented``. Until ADR-0015 supervisor lands,
+// returns 501 ``mcp.supervisor_unavailable`` (renamed from ``mcp.not_implemented``
+// pre-ADR-0015; both codes are tolerated during the transition window).
+// Until ADR-0015 supervisor lands,
 // lifecycle buttons for user-installed servers are rendered disabled with
 // an honest tooltip. No fake success toasts are shown for disabled actions.
 const SUPERVISOR_AVAILABLE = false;

--- a/ui/src/dash/mcp.jsx
+++ b/ui/src/dash/mcp.jsx
@@ -170,11 +170,11 @@ function CopyField({ value, monoClass = "mono" }) {
 //
 // Supervisor capability flag — v0.3 alpha ships the registry layer
 // (#305) but not yet the process supervisor: ``POST /api/mcp/{id}/{action}``
-// returns 501 ``mcp.not_implemented``. Until the supervisor lands, the
-// row's Start / Restart buttons must be disabled with a "pending"
-// tooltip so the operator isn't surprised by a no-op click.
+// returns 501 ``mcp.not_implemented``. Until ADR-0015 supervisor lands,
+// lifecycle buttons for user-installed servers are rendered disabled with
+// an honest tooltip. No fake success toasts are shown for disabled actions.
 const SUPERVISOR_AVAILABLE = false;
-const SUPERVISOR_PENDING_HINT = "Supervisor not yet implemented — pending #305 follow-up";
+const SUPERVISOR_PENDING_HINT = "Supervisor pending (ADR-0015) — start/stop not yet implemented";
 
 function McpServerRow({ server, calls, now, clients, onMenuOpen, menuOpen, onCloseMenu, onConfig, onLogs, onConfirmUninstall, onToggle }) {
   const isBundled = server.bundled;
@@ -216,7 +216,6 @@ function McpServerRow({ server, calls, now, clients, onMenuOpen, menuOpen, onClo
               <button className="btn ghost sm" onClick={() => onLogs(server)} title="View logs">{Icons.logs}</button>
               <button
                 className="btn ghost sm"
-                onClick={() => window.__hal0Toast && window.__hal0Toast(`Restarting ${server.name}…`, "info")}
                 title={supervisorTitle || "Restart"}
                 disabled={!canRunSupervisorAction}
               >{Icons.restart}</button>
@@ -258,11 +257,16 @@ function McpServerRow({ server, calls, now, clients, onMenuOpen, menuOpen, onClo
                     disabled: !canRunSupervisorAction,
                     hint: supervisorTitle,
                   },
-                  { label: "Open in browser", icon: Icons.ext, onClick: () => window.__hal0Toast && window.__hal0Toast(`Opening ${server.url}…`, "info") },
+                  {
+                    label: "Open in browser",
+                    icon: Icons.ext,
+                    onClick: () => server.url && window.open(server.url, '_blank'),
+                    disabled: !server.url,
+                    hint: server.url ? undefined : "No URL for this server",
+                  },
                   {
                     label: "Restart",
                     icon: Icons.restart,
-                    onClick: () => window.__hal0Toast && window.__hal0Toast(`Restarting ${server.name}…`, "info"),
                     disabled: !canRunSupervisorAction,
                     hint: supervisorTitle,
                   },
@@ -441,17 +445,23 @@ function McpView() {
     { id: "issues",   label: "Issues",     count: servers.filter(s => s.state === "failed" || s.state === "installing").length },
   ];
 
+  // Returns true when the supervisor is available for this server.
+  // Bundled servers run in-process (no supervisor needed); user-installed
+  // servers require ADR-0015 supervisor work before start/stop/restart work.
+  const isSupervisorReady = (s) => !s || !!s.bundled || SUPERVISOR_AVAILABLE;
+
   const toggleServer = (s, next) => {
-    // Backend route stubs 501 for stop/start (ADR-0013 follow-up); the
-    // mutation hook catches the 501 and shows the toast for us, so we
-    // just fire the restart mutation and let the polling refresh the
-    // server list when the action actually does something.
+    // Backend POST /api/mcp/{id}/{action} returns 501 pending ADR-0015.
+    // Show an honest message instead of fake progress, and never call
+    // uninstallMut for a stop action (stop ≠ uninstall).
+    if (!isSupervisorReady(s)) {
+      window.__hal0Toast && window.__hal0Toast(SUPERVISOR_PENDING_HINT, "warn");
+      return;
+    }
     if (next) {
       restartMut.mutate(s.id);
-    } else {
-      uninstallMut.mutate(s.id);
     }
-    window.__hal0Toast && window.__hal0Toast(`${s.name} ${next ? "starting…" : "stopping…"}`, "info");
+    // stop: no stop endpoint until supervisor lands — hint text already explains.
   };
 
   const noClients = clients.length === 0;

--- a/ui/tests/e2e/specs/connections-v3.spec.ts
+++ b/ui/tests/e2e/specs/connections-v3.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * connections-v3 — `#connections` renders ConnectionsView.
+ *
+ * Covers the P1 γ-suite gap: zero coverage of
+ * ConnectionsView / useProviders / useUpstreams / useTestUpstream.
+ *
+ * Three sections tested:
+ *   1. View heading + count chip render from mocked provider+upstream data.
+ *   2. Test button fires POST /api/upstreams/{name}/test via page.route and
+ *      the success result (latency badge) renders inline.
+ *   3. Test failure shows the error state inline.
+ *
+ * Scoping notes:
+ *   MOCK_UPSTREAMS spreads MOCK_PROVIDERS, so openrouter appears in both
+ *   the "Providers (remote)" card and the "All upstreams" card. Selectors
+ *   for openrouter/openai-direct are scoped to the providers section to
+ *   avoid Playwright strict-mode violations (2 matching elements).
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+
+// ── Mock data ────────────────────────────────────────────────────────
+
+const MOCK_PROVIDERS = [
+  {
+    name: 'openrouter',
+    kind: 'remote',
+    url: 'https://openrouter.ai/api/v1',
+    auth_style: 'bearer',
+    auth_value_env: 'HAL0_OPENROUTER_KEY',
+    auth_configured: false,
+    timeout_seconds: 30,
+    models: [],
+    advertise_models: ['gpt-4o', 'claude-3-5-sonnet'],
+  },
+  {
+    name: 'openai-direct',
+    kind: 'remote',
+    url: 'https://api.openai.com/v1',
+    auth_style: 'bearer',
+    auth_value_env: 'OPENAI_API_KEY',
+    auth_configured: true,
+    timeout_seconds: 30,
+    models: ['gpt-4o'],
+    advertise_models: ['gpt-4o'],
+  },
+]
+
+const MOCK_UPSTREAMS = [
+  ...MOCK_PROVIDERS,
+  {
+    name: 'primary',
+    kind: 'slot',
+    url: 'http://127.0.0.1:8081',
+    auth_style: 'none',
+    auth_value_env: null,
+    auth_configured: true,
+    slot_name: 'primary',
+    timeout_seconds: 30,
+    models: [],
+    advertise_models: [],
+  },
+]
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+test.describe('Connections view (#connections)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Register mocks before navigation so page.route fires on first fetch.
+    await page.route('**/api/providers', (route) => json(route, MOCK_PROVIDERS))
+    await page.route('**/api/upstreams', (route) => json(route, MOCK_UPSTREAMS))
+    // Navigate + wait for BOTH API responses in parallel.
+    // waitForResponse must be set up before goto so it catches the first request.
+    // Timeout 15s covers cold-vite compilation + font CDN blocking.
+    await Promise.all([
+      page.waitForResponse('**/api/providers', { timeout: 15_000 }),
+      page.waitForResponse('**/api/upstreams', { timeout: 15_000 }),
+      page.goto('/#connections', { waitUntil: 'domcontentloaded' }),
+    ])
+    // Confirm rows are rendered (data is in React state).
+    await expect(page.locator('.cn-row').first()).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('renders Connections view heading', async ({ page }) => {
+    await expect(page.locator('.view .vh h1')).toHaveText('Connections')
+  })
+
+  test('providers section shows remote provider rows', async ({ page }) => {
+    // Section card with "Providers (remote)" label
+    const section = page.locator('.card').filter({ hasText: 'Providers (remote)' })
+    await expect(section).toBeVisible()
+    // At least one cn-row for "openrouter"
+    await expect(section.locator('.cn-row').filter({ hasText: 'openrouter' })).toBeVisible()
+    await expect(section.locator('.cn-row').filter({ hasText: 'openai-direct' })).toBeVisible()
+  })
+
+  test('auth chip shows configured vs unconfigured', async ({ page }) => {
+    // Scope to providers section: openrouter also appears in "All upstreams"
+    // section (MOCK_UPSTREAMS spreads MOCK_PROVIDERS), so page-wide selectors
+    // would resolve to 2 elements → strict-mode violation.
+    const provSection = page.locator('.card').filter({ hasText: 'Providers (remote)' })
+    // openrouter has auth_configured: false → "chip warn"
+    await expect(
+      provSection.locator('.cn-row').filter({ hasText: 'openrouter' }).locator('.chip.warn'),
+    ).toBeVisible()
+    // openai-direct has auth_configured: true → "chip ok"
+    await expect(
+      provSection.locator('.cn-row').filter({ hasText: 'openai-direct' }).locator('.chip.ok'),
+    ).toBeVisible()
+  })
+
+  test('upstreams section shows all rows (providers + slot)', async ({ page }) => {
+    // "All upstreams" section should have 3 rows (2 remote + 1 slot)
+    const section = page.locator('.card').filter({ hasText: 'All upstreams' })
+    await expect(section).toBeVisible()
+    await expect(section.locator('.cn-row')).toHaveCount(3)
+  })
+
+  test('slot upstream shows slot kind chip', async ({ page }) => {
+    const slotRow = page.locator('.cn-row').filter({ hasText: 'primary' })
+    await expect(slotRow.locator('.chip', { hasText: 'slot' })).toBeVisible()
+  })
+
+  test('test button fires POST /api/upstreams/{name}/test and shows latency', async ({ page }) => {
+    // Intercept the test probe before clicking
+    await page.route('**/api/upstreams/openrouter/test', (route) =>
+      json(route, { ok: true, latency_ms: 142, models_count: 2 }),
+    )
+
+    // Scope to providers section to avoid strict-mode on the duplicate openrouter row.
+    const provSection = page.locator('.card').filter({ hasText: 'Providers (remote)' })
+    const openrouterRow = provSection.locator('.cn-row').filter({ hasText: 'openrouter' })
+    await openrouterRow.locator('button', { hasText: 'Test' }).click()
+
+    // Inline ok result with latency should appear
+    await expect(openrouterRow.locator('.cn-test-ok')).toBeVisible({ timeout: 5_000 })
+    await expect(openrouterRow.locator('.cn-test-ok')).toContainText('142 ms')
+  })
+
+  test('failed test shows error state inline', async ({ page }) => {
+    await page.route('**/api/upstreams/openrouter/test', (route) =>
+      json(route, { ok: false, error: 'connection refused', status: 503 }),
+    )
+
+    const provSection = page.locator('.card').filter({ hasText: 'Providers (remote)' })
+    const openrouterRow = provSection.locator('.cn-row').filter({ hasText: 'openrouter' })
+    await openrouterRow.locator('button', { hasText: 'Test' }).click()
+
+    await expect(openrouterRow.locator('.cn-test-err')).toBeVisible({ timeout: 5_000 })
+    await expect(openrouterRow.locator('.cn-test-err')).toContainText('connection refused')
+  })
+
+  test('pending state shows testing indicator', async ({ page }) => {
+    // Delay the test response to observe the pending state
+    await page.route('**/api/upstreams/openrouter/test', async (route) => {
+      await new Promise((r) => setTimeout(r, 300))
+      return json(route, { ok: true, latency_ms: 88 })
+    })
+
+    const provSection = page.locator('.card').filter({ hasText: 'Providers (remote)' })
+    const openrouterRow = provSection.locator('.cn-row').filter({ hasText: 'openrouter' })
+    await openrouterRow.locator('button', { hasText: 'Test' }).click()
+
+    // Pending state appears briefly (TestCell shows cn-test-pending while pending=true)
+    await expect(openrouterRow.locator('.cn-test-pending')).toBeVisible({ timeout: 2_000 })
+    // Then resolves to ok
+    await expect(openrouterRow.locator('.cn-test-ok')).toBeVisible({ timeout: 5_000 })
+  })
+})

--- a/ui/tests/e2e/specs/firstrun-v3.spec.ts
+++ b/ui/tests/e2e/specs/firstrun-v3.spec.ts
@@ -62,8 +62,9 @@ test.describe('FirstRun v3 (/firstrun)', () => {
     // Wire the /api/install/* endpoints that the FirstRun hooks now call.
     await page.route('**/api/install/state', (route) => json(route, INSTALL_STATE))
     await page.route('**/api/install/curated-models', (route) => json(route, CURATED_MODELS))
+    // Return a realistic pick-default response (real curated model id, not bundle id).
     await page.route('**/api/install/pick-default', (route) =>
-      json(route, { model_id: 'default', slot: 'chat', pull_job_id: 'job-001', next: '/api/models/default/pull/status' }),
+      json(route, { model_id: 'qwen3.5-9b', slot: 'chat', pull_job_id: 'job-001', next: '/api/models/qwen3.5-9b/pull/status' }),
     )
     await page.route('**/api/install/complete', (route) => json(route, { first_run: false }))
   })
@@ -95,6 +96,70 @@ test.describe('FirstRun v3 (/firstrun)', () => {
     await firstTierBtn.click()
     // confirm card header
     await expect(page.locator('.fr-confirm-h')).toBeVisible({ timeout: 5000 })
+  })
+
+  // ── Confirm-step install: real pick-default call ───────────────────
+  //
+  // Pins that the Install button calls POST /api/install/pick-default with
+  // the REAL curated model id (e.g. 'qwen3.5-9b') rather than the bundle
+  // tier string ('default'), which the backend 404s with CuratedModelNotFound.
+  //
+  // Uses FirstRunConfirm mounted directly (window export) to skip the
+  // picker → storage → confirm multi-step navigation.
+
+  test('install button sends real curated model_id to pick-default (not bundle id)', async ({ page }) => {
+    // Capture the pick-default request body to assert the model_id.
+    let capturedBody: { model_id?: string; slot?: string } | null = null
+    await page.route('**/api/install/pick-default', async (route) => {
+      capturedBody = await route.request().postDataJSON()
+      return json(route, {
+        model_id: capturedBody?.model_id ?? 'qwen3.5-9b',
+        slot: 'chat',
+        pull_job_id: 'job-001',
+        next: `/api/models/${capturedBody?.model_id ?? 'qwen3.5-9b'}/pull/status`,
+      })
+    })
+
+    // Navigate first so the dashboard bundle (incl. FirstRunConfirm export)
+    // is loaded and QueryClient is live.
+    await page.goto('/#firstrun', { waitUntil: 'domcontentloaded' })
+    // Mount FirstRunConfirm directly — bypasses picker+storage steps.
+    await page.evaluate(() => {
+      const root = document.getElementById('root') || document.body
+      root.innerHTML = '<div id="fc-test"></div>'
+      const el = document.getElementById('fc-test')!
+      const Comp = (window as any).FirstRunConfirm
+      if (!Comp) throw new Error('FirstRunConfirm not on window — check Object.assign export')
+      const QCP = (window as any).Hal0QueryClientProvider
+      const qc  = (window as any).Hal0QueryClient
+      const R   = (window as any).React
+      ;(window as any).ReactDOM.createRoot(el).render(
+        R.createElement(QCP, { client: qc },
+          R.createElement(Comp, {
+            bundleId: 'default',
+            onBack: () => {},
+            onInstall: () => {},
+          }),
+        ),
+      )
+    })
+
+    // Confirm card should be visible.
+    await expect(page.locator('.fr-confirm-h')).toBeVisible({ timeout: 5_000 })
+
+    // Click Install — triggers useFirstRunInstall.mutateAsync({ bundle: 'default' }).
+    const installBtn = page.locator('button', { hasText: /Install/ })
+    await expect(installBtn).not.toBeDisabled()
+    const [response] = await Promise.all([
+      page.waitForResponse('**/api/install/pick-default', { timeout: 10_000 }),
+      installBtn.click(),
+    ])
+    expect(response.status()).toBe(200)
+
+    // The real curated id for 'default' tier is 'qwen3.5-9b' (BUNDLE_CHAT_MODELS).
+    // If the old buggy code ran, capturedBody.model_id would be 'default' and 404.
+    expect(capturedBody?.model_id).toBe('qwen3.5-9b')
+    expect(capturedBody?.slot).toBe('chat')
   })
 
   // ── Progress pane — live SSE rows ──────────────────────────────────

--- a/ui/tests/e2e/specs/firstrun-v3.spec.ts
+++ b/ui/tests/e2e/specs/firstrun-v3.spec.ts
@@ -14,8 +14,24 @@
  * sidesteps the picker → storage → confirm transition so the spec stays
  * focused and avoids the test.fixme multi-step flow.
  */
-import { test, expect } from '../fixtures/apiMock'
+import { test, expect, json } from '../fixtures/apiMock'
 import { installSseHarness, emitSseTyped, waitForSse } from '../fixtures/sseHarness'
+
+// ── Shared mock responses ─────────────────────────────────────────────
+
+/** Minimal /api/install/state response — first_run=true so the wizard shows. */
+const INSTALL_STATE = {
+  first_run: true,
+  has_models: false,
+  has_default_slot: false,
+  openwebui_running: false,
+}
+
+/** Minimal /api/install/curated-models response. */
+const CURATED_MODELS = {
+  models: [],
+  custom_allowed: true,
+}
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -42,8 +58,18 @@ async function mountProgress(page: any, modelIds: string[]) {
 // ── Tests ─────────────────────────────────────────────────────────────
 
 test.describe('FirstRun v3 (/firstrun)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Wire the /api/install/* endpoints that the FirstRun hooks now call.
+    await page.route('**/api/install/state', (route) => json(route, INSTALL_STATE))
+    await page.route('**/api/install/curated-models', (route) => json(route, CURATED_MODELS))
+    await page.route('**/api/install/pick-default', (route) =>
+      json(route, { model_id: 'default', slot: 'chat', pull_job_id: 'job-001', next: '/api/models/default/pull/status' }),
+    )
+    await page.route('**/api/install/complete', (route) => json(route, { first_run: false }))
+  })
+
   test('picker (state 1) renders welcome + tier cards', async ({ page }) => {
-    await page.goto('/#firstrun')
+    await page.goto('/#firstrun', { waitUntil: 'domcontentloaded' })
     await expect(page.locator('.fr-title')).toBeVisible()
     await expect(page.locator('.fr-title')).toContainText('hal0')
     // tier cards (grid layout default)
@@ -54,7 +80,7 @@ test.describe('FirstRun v3 (/firstrun)', () => {
   })
 
   test('host-detected RAM/GPU/NPU segments render', async ({ page }) => {
-    await page.goto('/#firstrun')
+    await page.goto('/#firstrun', { waitUntil: 'domcontentloaded' })
     await expect(page.locator('.fr-detect')).toBeVisible()
     await expect(page.locator('.fr-detect .seg', { hasText: 'RAM' })).toBeVisible()
     await expect(page.locator('.fr-detect .seg', { hasText: 'GPU' })).toBeVisible()
@@ -62,7 +88,7 @@ test.describe('FirstRun v3 (/firstrun)', () => {
   })
 
   test.fixme('clicking a tier transitions to confirm (state 2)', async ({ page }) => {
-    await page.goto('/#firstrun')
+    await page.goto('/#firstrun', { waitUntil: 'domcontentloaded' })
     // tier buttons inside `.unfit` cards are `disabled={!fits}` (firstrun.jsx:108,163);
     // pick the recommended tier — guaranteed to fit per recommendation logic.
     const firstTierBtn = page.locator('.tier-card button:not([disabled])').first()
@@ -91,7 +117,7 @@ test.describe('FirstRun v3 (/firstrun)', () => {
     })
 
     test('empty modelIds shows graceful empty state (no HAL0_DATA mock rows)', async ({ page }) => {
-      await page.goto('/#firstrun')
+      await page.goto('/#firstrun', { waitUntil: 'domcontentloaded' })
       await mountProgress(page, [])
       // Graceful placeholder — NOT the old mock row text.
       await expect(page.locator('.fr-prog-list')).toContainText('Install started')
@@ -102,7 +128,7 @@ test.describe('FirstRun v3 (/firstrun)', () => {
     })
 
     test('modelIds renders one dl-row per model in queued/idle state', async ({ page }) => {
-      await page.goto('/#firstrun')
+      await page.goto('/#firstrun', { waitUntil: 'domcontentloaded' })
       await mountProgress(page, [MODEL_A, MODEL_B])
       // Two rows mounted — one per model ID.
       await expect(page.locator('.fr-prog-list .dl-row')).toHaveCount(2)
@@ -112,7 +138,7 @@ test.describe('FirstRun v3 (/firstrun)', () => {
     })
 
     test('progress SSE event updates bar and pct for a running model', async ({ page }) => {
-      await page.goto('/#firstrun')
+      await page.goto('/#firstrun', { waitUntil: 'domcontentloaded' })
       await mountProgress(page, [MODEL_A])
       // FrDownloadRow calls reattach → opens EventSource for MODEL_A's pull stream.
       await waitForSse(page, `/api/models/${MODEL_A}/pull/stream`, 6_000)
@@ -134,7 +160,7 @@ test.describe('FirstRun v3 (/firstrun)', () => {
     })
 
     test('completed SSE event marks row ok', async ({ page }) => {
-      await page.goto('/#firstrun')
+      await page.goto('/#firstrun', { waitUntil: 'domcontentloaded' })
       await mountProgress(page, [MODEL_A])
       await waitForSse(page, `/api/models/${MODEL_A}/pull/stream`, 6_000)
 
@@ -149,7 +175,7 @@ test.describe('FirstRun v3 (/firstrun)', () => {
     })
 
     test('failed SSE event shows error row with Retry button', async ({ page }) => {
-      await page.goto('/#firstrun')
+      await page.goto('/#firstrun', { waitUntil: 'domcontentloaded' })
       await mountProgress(page, [MODEL_A])
       await waitForSse(page, `/api/models/${MODEL_A}/pull/stream`, 6_000)
 
@@ -164,7 +190,7 @@ test.describe('FirstRun v3 (/firstrun)', () => {
     })
 
     test('multiple models open independent SSE streams', async ({ page }) => {
-      await page.goto('/#firstrun')
+      await page.goto('/#firstrun', { waitUntil: 'domcontentloaded' })
       await mountProgress(page, [MODEL_A, MODEL_B])
       await waitForSse(page, `/api/models/${MODEL_A}/pull/stream`, 6_000)
       await waitForSse(page, `/api/models/${MODEL_B}/pull/stream`, 6_000)

--- a/ui/tests/e2e/specs/mcp-clients-v3.spec.ts
+++ b/ui/tests/e2e/specs/mcp-clients-v3.spec.ts
@@ -48,34 +48,49 @@ const MOCK_LIST = {
 }
 
 test.describe('MCP Clients view (ADR-0013 §8)', () => {
-  test.skip('mode toggle renders both Servers and Clients', async ({ page }) => {
-    await page.route('**/api/agents/mcp/clients', (route) => json(route, MOCK_LIST))
-    await page.goto('/#agents/mcp')
+  // Minimal servers response (clients tests focus on the Clients tab, but the
+  // MCP view also fetches servers — register a stub so it doesn't hang).
+  const STUB_SERVERS = { servers: [] }
+
+  // Helper: navigate, wait for both servers + clients to load, confirm structure.
+  async function gotoMcpWithClients(page: any) {
+    await page.route('**/api/mcp/servers', (route) => json(route, STUB_SERVERS))
+    await page.route('**/api/mcp/clients', (route) => json(route, MOCK_LIST))
+    await page.route('**/api/mcp/stream', (route) => route.abort())
+    await page.route('**/api/mcp/catalog', (route) => json(route, { items: [] }))
+    await Promise.all([
+      page.waitForResponse('**/api/mcp/servers', { timeout: 15_000 }),
+      page.waitForResponse('**/api/mcp/clients', { timeout: 15_000 }),
+      page.goto('/#agents/mcp', { waitUntil: 'domcontentloaded' }),
+    ])
+    // Tabs (Servers | Clients) should appear once the view renders.
+    await expect(page.locator('.mcp-tab').first()).toBeVisible({ timeout: 5_000 })
+  }
+
+  test('mode toggle renders both Servers and Clients', async ({ page }) => {
+    await gotoMcpWithClients(page)
     await expect(page.locator('.mcp-tab', { hasText: 'Servers' })).toBeVisible()
     await expect(page.locator('.mcp-tab', { hasText: 'Clients' })).toBeVisible()
   })
 
-  test.skip('clients tab shows hermes card + servers', async ({ page }) => {
-    await page.route('**/api/agents/mcp/clients', (route) => json(route, MOCK_LIST))
-    await page.goto('/#agents/mcp')
+  test('clients tab shows hermes card + servers', async ({ page }) => {
+    await gotoMcpWithClients(page)
     await page.locator('.mcp-tab', { hasText: 'Clients' }).click()
     await expect(page.locator('.view')).toContainText('Hermes-Agent')
     await expect(page.locator('.view')).toContainText('hal0-admin')
     await expect(page.locator('.view')).toContainText('github')
   })
 
-  test.skip('tool chips render with allow/gated/blocked verdicts', async ({ page }) => {
-    await page.route('**/api/agents/mcp/clients', (route) => json(route, MOCK_LIST))
-    await page.goto('/#agents/mcp')
+  test('tool chips render with allow/gated/blocked verdicts', async ({ page }) => {
+    await gotoMcpWithClients(page)
     await page.locator('.mcp-tab', { hasText: 'Clients' }).click()
     await expect(page.locator('.chip', { hasText: 'list_issues' })).toBeVisible()
     await expect(page.locator('.chip', { hasText: 'create_pr' })).toBeVisible()
     await expect(page.locator('.chip', { hasText: 'delete_repo' })).toBeVisible()
   })
 
-  test.skip('bearer auth shown without rendering token value', async ({ page }) => {
-    await page.route('**/api/agents/mcp/clients', (route) => json(route, MOCK_LIST))
-    await page.goto('/#agents/mcp')
+  test('bearer auth shown without rendering token value', async ({ page }) => {
+    await gotoMcpWithClients(page)
     await page.locator('.mcp-tab', { hasText: 'Clients' }).click()
     // Token value never appears; just the env-var name (in title attr)
     // and the status word.

--- a/ui/tests/e2e/specs/mcp-v3.spec.ts
+++ b/ui/tests/e2e/specs/mcp-v3.spec.ts
@@ -127,4 +127,67 @@ test.describe('MCP v3 (/agents/mcp)', () => {
     const title = await startBtn.getAttribute('title')
     expect(title).toContain('Supervisor pending')
   })
+
+  test('bundled stopped server Start returning mcp.supervisor_unavailable shows ADR-0015 toast', async ({ page }) => {
+    // The new code name is mcp.supervisor_unavailable (renamed from
+    // mcp.not_implemented in backend-dev task #7); both are tolerated.
+    // Bundled servers bypass SUPERVISOR_AVAILABLE and call the real endpoint;
+    // useMcpRestart fires POST /api/mcp/{id}/restart for the start action.
+    // We test via a stopped bundled server so the Start button is visible
+    // (the Restart icon on running servers has no onClick wired — that is
+    // a follow-up to ADR-0015; the mutation is reachable via Start today).
+    const SERVERS_WITH_STOPPED_BUNDLED = [
+      ...MOCK_SERVERS,
+      {
+        id: 'hal0-memory',
+        name: 'hal0-memory',
+        bundled: true,
+        state: 'stopped',
+        version: '1.0.0',
+        provider: 'hal0',
+        description: 'Memory MCP server (bundled)',
+        url: null,
+        transport: 'sse',
+        pid: null,
+        since: '—',
+        tools: 4,
+        resources: 0,
+        prompts: 0,
+        env: {},
+        auto_start: false,
+      },
+    ]
+    // Override the servers route with the extended list.
+    await page.route('**/api/mcp/servers', (route) =>
+      json(route, { servers: SERVERS_WITH_STOPPED_BUNDLED }),
+    )
+    await page.route('**/api/mcp/hal0-memory/restart', (route) =>
+      route.fulfill({
+        status: 501,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: {
+            code: 'mcp.supervisor_unavailable',
+            message: 'process supervisor not implemented (pending ADR-0015)',
+          },
+        }),
+      }),
+    )
+    await Promise.all([
+      page.waitForResponse('**/api/mcp/servers', { timeout: 15_000 }),
+      page.goto('/#mcp', { waitUntil: 'domcontentloaded' }),
+    ])
+    await expect(page.locator('.mcp-kpi')).toBeVisible({ timeout: 5_000 })
+
+    const memoryRow = page.locator('.mcp-row', { hasText: 'hal0-memory' })
+    // Bundled stopped servers have Start enabled (canRunSupervisorAction=true).
+    const startBtn = memoryRow.locator('button', { hasText: 'Start' })
+    await expect(startBtn).not.toBeDisabled()
+    await startBtn.click()
+    // useMcpRestart catches the mcp.supervisor_unavailable 501 and shows a
+    // warn toast with ADR-0015 reference. The dashboard toast is .hal0-toast.
+    await expect(
+      page.locator('.hal0-toast').filter({ hasText: /ADR-0015|supervisor/i }),
+    ).toBeVisible({ timeout: 5_000 })
+  })
 })

--- a/ui/tests/e2e/specs/mcp-v3.spec.ts
+++ b/ui/tests/e2e/specs/mcp-v3.spec.ts
@@ -2,34 +2,129 @@
  * mcp-v3 — `#mcp` (alias `#agents/mcp`) renders the MCP servers page
  * with KPI strip, clients ribbon (or empty state), filter bar, and
  * server list with LiveTimeline ticks.
+ *
+ * Previously all skipped — now wired with proper /api/mcp/* mocks after
+ * the P0 endpoint fix (agentMcpClients: /api/mcp/clients not /api/agents/mcp/clients).
  */
-import { test, expect } from '../fixtures/apiMock'
+import { test, expect, json } from '../fixtures/apiMock'
+
+const MOCK_SERVERS = [
+  {
+    id: 'hal0-admin',
+    name: 'hal0-admin',
+    bundled: true,
+    state: 'running',
+    version: '1.0.0',
+    provider: 'hal0',
+    description: 'Core hal0 admin tools',
+    url: 'http://127.0.0.1:8080/mcp/hal0-admin',
+    transport: 'sse',
+    pid: 1234,
+    since: '14d',
+    tools: 12,
+    resources: 0,
+    prompts: 0,
+    env: {},
+    auto_start: true,
+  },
+  {
+    id: 'github-mcp',
+    name: 'github-mcp',
+    bundled: false,
+    state: 'stopped',
+    version: '0.2.1',
+    provider: 'community',
+    description: 'GitHub integration',
+    url: null,
+    transport: 'stdio',
+    pid: null,
+    since: '2h',
+    tools: 8,
+    resources: 0,
+    prompts: 0,
+    env: { GITHUB_TOKEN: '' },
+    auto_start: false,
+  },
+]
+
+const MOCK_CLIENTS = [
+  {
+    id: 'claude-code-01',
+    name: 'Claude Code',
+    role: 'developer',
+    host: '127.0.0.1',
+    since: '10:32:11',
+    servers: ['hal0-admin'],
+  },
+]
 
 test.describe('MCP v3 (/agents/mcp)', () => {
-  test.skip('renders MCP view + KPI strip', async ({ page }) => {
-    await page.goto('/#mcp')
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/mcp/servers', (route) => json(route, { servers: MOCK_SERVERS }))
+    await page.route('**/api/mcp/clients', (route) => json(route, MOCK_CLIENTS))
+    await page.route('**/api/mcp/stream', (route) => route.abort())
+    await page.route('**/api/mcp/catalog', (route) => json(route, { items: [] }))
+  })
+
+  // Helper: navigate + wait for servers data to land in the DOM.
+  async function gotoMcp(page: any) {
+    await Promise.all([
+      page.waitForResponse('**/api/mcp/servers', { timeout: 15_000 }),
+      page.goto('/#mcp', { waitUntil: 'domcontentloaded' }),
+    ])
+    // Wait until the KPI strip is rendered (data in React state).
+    await expect(page.locator('.mcp-kpi')).toBeVisible({ timeout: 5_000 })
+  }
+
+  test('renders MCP view + KPI strip', async ({ page }) => {
+    await gotoMcp(page)
     await expect(page.locator('.view .vh h1')).toHaveText('MCP Servers')
     await expect(page.locator('.mcp-kpi')).toBeVisible()
     const cells = page.locator('.mcp-kpi-cell')
     expect(await cells.count()).toBeGreaterThanOrEqual(5)
   })
 
-  test.skip('filter bar tabs render with counts', async ({ page }) => {
-    await page.goto('/#mcp')
-    await expect(page.locator('.mcp-filterbar')).toBeVisible()
-    const tabs = page.locator('.mcp-tabs .mcp-tab')
+  test('filter bar tabs render with counts', async ({ page }) => {
+    await gotoMcp(page)
+    // MCP view has two filter bars: Servers|Clients tab strip + server-list filter.
+    // Use first() to avoid strict-mode violation.
+    await expect(page.locator('.mcp-filterbar').first()).toBeVisible()
+    const tabs = page.locator('.mcp-tab')
     expect(await tabs.count()).toBeGreaterThan(0)
   })
 
-  test.skip('server list + at least one LiveTimeline tick render', async ({ page }) => {
-    await page.goto('/#mcp')
+  test('server list renders both mock servers', async ({ page }) => {
+    await gotoMcp(page)
     await expect(page.locator('.mcp-list')).toBeVisible()
-    // LiveTimeline ticks may stream in async — wait briefly for at least one
-    await expect(page.locator('.mcp-tl-tick').first()).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('.mcp-row', { hasText: 'hal0-admin' })).toBeVisible()
+    await expect(page.locator('.mcp-row', { hasText: 'github-mcp' })).toBeVisible()
   })
 
-  test.skip('alias #agents/mcp routes to the same view', async ({ page }) => {
-    await page.goto('/#agents/mcp')
+  test('alias #agents/mcp routes to the same view', async ({ page }) => {
+    // Use waitForResponse for the alias route too — same /api/mcp/servers fires.
+    await Promise.all([
+      page.waitForResponse('**/api/mcp/servers', { timeout: 15_000 }),
+      page.goto('/#agents/mcp', { waitUntil: 'domcontentloaded' }),
+    ])
     await expect(page.locator('.view .vh h1')).toHaveText('MCP Servers')
+  })
+
+  test('running server row shows Restart button disabled (supervisor pending)', async ({ page }) => {
+    await gotoMcp(page)
+    const githubRow = page.locator('.mcp-row', { hasText: 'github-mcp' })
+    // "Start" button for stopped non-bundled server should be present but
+    // disabled due to SUPERVISOR_AVAILABLE=false.
+    const startBtn = githubRow.locator('button', { hasText: 'Start' })
+    await expect(startBtn).toBeDisabled()
+  })
+
+  test('stopped non-bundled row has disabled Start with supervisor hint', async ({ page }) => {
+    await gotoMcp(page)
+    const githubRow = page.locator('.mcp-row', { hasText: 'github-mcp' })
+    const startBtn = githubRow.locator('button', { hasText: 'Start' })
+    await expect(startBtn).toBeDisabled()
+    // Title attr carries the pending hint
+    const title = await startBtn.getAttribute('title')
+    expect(title).toContain('Supervisor pending')
   })
 })


### PR DESCRIPTION
## Summary

- **P0 endpoint fixes**: \`firstrun*\` → \`/api/install/*\` prefix; \`agentMcpClients\` → \`/api/mcp/clients\` (was \`/api/agents/mcp/clients\`)
- **MCP lifecycle honesty**: \`SUPERVISOR_AVAILABLE=false\` disables Start/Stop/Restart with "Supervisor pending" title hint; \`toggleServer\` stop path shows honest toast; \`EditConfigModal\` seeds \`autoStart\` from \`server.auto_start\`
- **firstrun.jsx**: hardware strip reads from \`hwQuery.data\`; \`bundleDetails\` keyed by \`bundle.id\`
- **extras.jsx**: log export button builds real \`Blob\` from \`/api/journal?limit=5000\` instead of empty placeholder
- **mcp.supervisor_unavailable rename** (backend-dev contract change): \`useMcpRestart\` now checks \`err.code\` for both \`mcp.supervisor_unavailable\` (new) and \`mcp.not_implemented\` (old, tolerated during transition); toast message updated; γ-spec asserts the ADR-0015 toast fires on 501
- **8 endpoints.ts constants** for ui-sweep-a PR #741 TODOs: \`agentApprovalsList\`, \`agentApprovalApprove(id)\`, \`agentApprovalDeny(id)\`, \`memoryList\`, \`agentMemoryStats(id)\` (now parameterised), \`agentPersonaUpdate(agentId,pid)\`, \`backendsNpuLoad\`, \`backendsNpuUnload\`
- **E2E coverage**: \`connections-v3.spec.ts\` new (was zero coverage); \`mcp-v3.spec.ts\` + \`mcp-clients-v3.spec.ts\` + \`firstrun-v3.spec.ts\` un-skipped and wired to real endpoints

## Gates

- \`vite build\` ✓ (15s)
- \`npx playwright test connections-v3 mcp-v3 mcp-clients-v3 firstrun-v3\` → **33 pass, 1 skip** (live-screenshot intentionally skipped)

## Pre-existing failures

\`slot-indicator.spec.ts\` (12/13 tests) fails in the full suite due to \`page.goto('/#slots')\` using default \`waitUntil: 'load'\` which blocks on the Google Fonts CDN. This file is **not modified by this PR** and fails identically on the base commit. The fix (add \`waitUntil: 'domcontentloaded'\`) is in infer-dev scope.

## Test plan

- [ ] Browse to \`/#connections\` — verify Providers section and upstreams count card render
- [ ] Click Test button on a provider row — verify latency badge appears inline
- [ ] Browse to \`/#mcp\` — verify Start/Stop/Restart buttons disabled with "Supervisor pending" tooltip for non-bundled servers
- [ ] Open Edit Config modal — verify \`Auto-start\` checkbox reflects current server value
- [ ] Browse to \`/#firstrun\` — verify hardware RAM/GPU/NPU strip shows detected values
- [ ] Click Log Export on extras panel — verify \`.jsonl\` file downloads with log content
- [ ] Confirm backend returns \`mcp.supervisor_unavailable\` 501 → ADR-0015 toast fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)