### PR TITLE
fix(api): reject control chars in secret/credential values (env injection hotfix)

### DIFF
--- a/src/hal0/api/_env_store.py
+++ b/src/hal0/api/_env_store.py
@@ -78,7 +78,19 @@ def upsert_env_value(api_env: Path, key: str, value: str) -> None:
     If a line for ``key`` exists (commented or not) it is replaced in
     place; otherwise the line is appended. Raises :class:`OSError` on any
     read/write failure — callers wrap it in their own error envelope.
+
+    Writer-level guard (defense-in-depth): a ``\\n`` / ``\\r`` in ``value``
+    would terminate the quoted env-file line and let everything after it
+    parse as a *new* ``KEY=value`` entry — i.e. arbitrary env-var
+    injection into api.env. We escape backslash + double-quote (so the
+    secret round-trips), but escaping can't neutralise a raw newline, so
+    we refuse it outright. Route-level validation should reject control
+    chars before reaching here; this guard ensures no future caller can
+    reintroduce the hole.
     """
+    if "\n" in value or "\r" in value:
+        raise ValueError("env value must not contain newline or carriage-return characters")
+
     existing = ""
     with contextlib.suppress(FileNotFoundError):
         existing = api_env.read_text(encoding="utf-8")

--- a/src/hal0/api/routes/providers.py
+++ b/src/hal0/api/routes/providers.py
@@ -190,6 +190,13 @@ def _write_credential_to_api_env(api_env: Path, key: str, value: str) -> None:
     """
     try:
         upsert_env_value(api_env, key, value)
+    except ValueError as exc:
+        # Writer-level guard tripped (e.g. newline in value) — surface as
+        # a 400 rather than a 500.
+        raise ProviderCredentialError(
+            str(exc),
+            details={"path": str(api_env), "error": str(exc)},
+        ) from exc
     except OSError as exc:
         raise ProviderCredentialError(
             f"could not write {api_env}: {exc}",
@@ -245,6 +252,17 @@ async def write_provider_credential(
             f"auth_value_env={expected_env!r}; refusing to write a "
             "credential the upstream won't read",
             details={"name": name, "key": key, "expected": expected_env},
+        )
+
+    # Reject control chars in the value — a newline would break out of the
+    # quoted api.env line and inject an arbitrary env-var (the file is an
+    # unauthenticated, LAN-writable systemd EnvironmentFile). The shared
+    # writer guards \n/\r too; this catches the wider control-char set with
+    # a clear 400 before we touch the file.
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in body.value):
+        raise ProviderCredentialError(
+            "control characters not allowed in credential value",
+            details={"name": name, "key": key},
         )
 
     api_env = paths.etc() / "api.env"

--- a/src/hal0/api/routes/secrets.py
+++ b/src/hal0/api/routes/secrets.py
@@ -160,11 +160,27 @@ async def list_secrets() -> dict[str, Any]:
     return {"secrets": entries}
 
 
+def _validate_value(value: str, key: str) -> None:
+    """Reject empty / control-char values.
+
+    A control character — most dangerously ``\\n`` / ``\\r`` — would let a
+    value break out of its quoted line in api.env and inject a new
+    ``KEY=value`` env-var (the file is an unauthenticated, LAN-writable
+    systemd ``EnvironmentFile``). Refuse any char ``< 0x20`` or ``0x7f``.
+    """
+    if not value:
+        raise SecretValueInvalid("secret value must be non-empty", details={"name": key})
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value):
+        raise SecretValueInvalid(
+            "control characters not allowed in secret value",
+            details={"name": key},
+        )
+
+
 async def _set_secret(name: str, body: SecretBody, request: Request) -> Response:
     """Shared set/overwrite implementation for POST + PUT."""
     key = _validate_name(name)
-    if not body.value:
-        raise SecretValueInvalid("secret value must be non-empty", details={"name": key})
+    _validate_value(body.value, key)
 
     api_env = _api_env()
     try:

--- a/tests/api/test_providers.py
+++ b/tests/api/test_providers.py
@@ -138,6 +138,25 @@ def test_credential_write_rejects_malformed_keys(
     assert response.status_code in (400, 422), response.text
 
 
+@pytest.mark.parametrize("payload", ["live\nEVIL=pwned", "live\rEVIL=pwned"])
+def test_credential_write_rejects_newline_value(
+    client: TestClient,
+    tmp_hal0_home: str,
+    payload: str,
+) -> None:
+    """A newline/CR in the VALUE must 400 (same env-var injection guard as
+    the secrets router — both share the api.env writer) and not inject a
+    line into api.env."""
+    response = client.post(
+        "/api/providers/openrouter/credentials",
+        json={"key": "OPENROUTER_API_KEY", "value": payload},
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["error"]["code"] == "provider.credential_write_failed"
+    api_env = _api_env_path(tmp_hal0_home)
+    assert not api_env.exists() or "EVIL" not in api_env.read_text(encoding="utf-8")
+
+
 def test_credential_write_sets_in_process_env(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/api/test_secrets.py
+++ b/tests/api/test_secrets.py
@@ -113,6 +113,39 @@ def test_invalid_names_rejected(client: TestClient, name: str) -> None:
     assert r.json()["error"]["code"] == "secret.name_invalid"
 
 
+@pytest.mark.parametrize(
+    "payload",
+    ["line1\nEVIL=pwned", "x\rEVIL=pwned", "tab\there", "bell\x07x", "del\x7fx"],
+)
+def test_set_rejects_control_chars_in_value(
+    client: TestClient,
+    tmp_hal0_home: str,
+    payload: str,
+) -> None:
+    """Newline/CR/control chars in a value must 400 (env-var injection guard)
+    and leave api.env untouched."""
+    r = client.post("/api/secrets/INJECT", json={"value": payload})
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "secret.value_invalid"
+    # File must NOT have been created/modified — no injected line.
+    api_env = _api_env_path(tmp_hal0_home)
+    assert not api_env.exists() or "EVIL" not in api_env.read_text(encoding="utf-8")
+    assert "INJECT" not in os.environ
+
+
+def test_writer_guard_rejects_newline(tmp_path: Path) -> None:
+    """Defense-in-depth: the shared writer itself refuses \\n / \\r."""
+    from hal0.api._env_store import upsert_env_value
+
+    target = tmp_path / "api.env"
+    with pytest.raises(ValueError, match="newline"):
+        upsert_env_value(target, "KEY", "a\nEVIL=x")
+    with pytest.raises(ValueError, match="newline"):
+        upsert_env_value(target, "KEY", "a\rEVIL=x")
+    # Nothing written.
+    assert not target.exists()
+
+
 def test_set_coexists_with_provider_credentials(client: TestClient, tmp_hal0_home: str) -> None:
     """Secrets share api.env with provider creds — both lines survive."""
     api_env = _api_env_path(tmp_hal0_home)


### PR DESCRIPTION
Security hotfix. PR #736 merged at 11:32 (88cb42e) as the pre-fix head; the control-char guard (a60e0cd) landed on the branch after the squash-merge and never reached main. CT105 deployed the vulnerable head.

VULN: /api/secrets + provider-credentials writer escaped backslash and quote but not newline/CR. A value with embedded newline breaks out of the quoted env-file line -> injects arbitrary KEY=val into /etc/hal0/api.env from any LAN client (no-auth by design). Widens LAN-trust from write-secrets to write-arbitrary-env.

FIX (cherry-pick of a60e0cd, 3 layers): (1) secrets.py rejects control chars ord<0x20 or 0x7f -> 400; (2) provider creds same check -> 400, plus catches writer ValueError -> 400 (was 500); (3) _env_store.upsert_env_value raises ValueError on CR/LF (writer guard).

TESTS: 29 passing (newline/CR/tab/bell/DEL injection -> 400 + api.env unchanged, secrets + providers; writer-guard unit test).

Generated with Claude Code