### PR TITLE
fix(api): reject unicode line separators in secret/credential values (env-injection hardening)

### DIFF
--- a/src/hal0/api/_env_store.py
+++ b/src/hal0/api/_env_store.py
@@ -25,6 +25,13 @@ import os
 import tempfile
 from pathlib import Path
 
+# Every character ``str.splitlines()`` treats as a line boundary. The file
+# is re-read with ``.splitlines()`` (see ``list_env_keys`` / the upsert
+# rewrite), so any of these inside a value could split the stored line into
+# a phantom ``KEY=value`` entry on round-trip — even the higher-codepoint
+# ones (NEL/LS/PS) that a ``< 0x20`` byte check misses. We refuse them all.
+_LINE_BREAK_CHARS = frozenset("\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029")
+
 
 def _escape(value: str) -> str:
     """Escape a secret for a double-quoted ``EnvironmentFile`` value.
@@ -79,17 +86,19 @@ def upsert_env_value(api_env: Path, key: str, value: str) -> None:
     place; otherwise the line is appended. Raises :class:`OSError` on any
     read/write failure — callers wrap it in their own error envelope.
 
-    Writer-level guard (defense-in-depth): a ``\\n`` / ``\\r`` in ``value``
-    would terminate the quoted env-file line and let everything after it
-    parse as a *new* ``KEY=value`` entry — i.e. arbitrary env-var
+    Writer-level guard (defense-in-depth): a line-break character in
+    ``value`` would terminate the quoted env-file line and let everything
+    after it parse as a *new* ``KEY=value`` entry — i.e. arbitrary env-var
     injection into api.env. We escape backslash + double-quote (so the
-    secret round-trips), but escaping can't neutralise a raw newline, so
-    we refuse it outright. Route-level validation should reject control
-    chars before reaching here; this guard ensures no future caller can
+    secret round-trips), but escaping can't neutralise a raw line break, so
+    we refuse the whole ``str.splitlines()`` set outright (not just
+    ``\\n``/``\\r`` — also NEL/LS/PS, which the file's own ``.splitlines()``
+    re-read would split on). Route-level validation should reject these
+    before reaching here; this guard ensures no future caller can
     reintroduce the hole.
     """
-    if "\n" in value or "\r" in value:
-        raise ValueError("env value must not contain newline or carriage-return characters")
+    if _LINE_BREAK_CHARS.intersection(value):
+        raise ValueError("env value must not contain line-break characters")
 
     existing = ""
     with contextlib.suppress(FileNotFoundError):

--- a/src/hal0/api/routes/secrets.py
+++ b/src/hal0/api/routes/secrets.py
@@ -161,16 +161,23 @@ async def list_secrets() -> dict[str, Any]:
 
 
 def _validate_value(value: str, key: str) -> None:
-    """Reject empty / control-char values.
+    """Reject empty / non-printable values.
 
     A control character — most dangerously ``\\n`` / ``\\r`` — would let a
     value break out of its quoted line in api.env and inject a new
     ``KEY=value`` env-var (the file is an unauthenticated, LAN-writable
-    systemd ``EnvironmentFile``). Refuse any char ``< 0x20`` or ``0x7f``.
+    systemd ``EnvironmentFile``). We reject any non-printable character via
+    ``str.isprintable()``: this covers the C0 controls + ``0x7f`` *and* the
+    higher-codepoint line separators (NEL ``U+0085``, LS ``U+2028``, PS
+    ``U+2029``) that an ``ord(ch) < 0x20`` test misses but Python's
+    ``str.splitlines()`` — which ``_env_store`` uses to re-read api.env —
+    splits on, so they could still inject a phantom line on round-trip.
+    Regular space is printable and allowed; every secret value we expect
+    (tokens, keys, URLs) is printable.
     """
     if not value:
         raise SecretValueInvalid("secret value must be non-empty", details={"name": key})
-    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value):
+    if not value.isprintable():
         raise SecretValueInvalid(
             "control characters not allowed in secret value",
             details={"name": key},

--- a/tests/api/test_secrets.py
+++ b/tests/api/test_secrets.py
@@ -115,7 +115,19 @@ def test_invalid_names_rejected(client: TestClient, name: str) -> None:
 
 @pytest.mark.parametrize(
     "payload",
-    ["line1\nEVIL=pwned", "x\rEVIL=pwned", "tab\there", "bell\x07x", "del\x7fx"],
+    [
+        "line1\nEVIL=pwned",
+        "x\rEVIL=pwned",
+        "tab\there",
+        "bell\x07x",
+        "del\x7fx",
+        # higher-codepoint line separators an `ord < 0x20` check misses but
+        # str.splitlines() (used to re-read api.env) splits on — these are
+        # the real env-injection vector once the carrier line is rewritten.
+        "x\x85INJECT=evil",  # NEL  U+0085
+        "x\u2028INJECT=evil",  # LS   U+2028
+        "x\u2029INJECT=evil",  # PS   U+2029
+    ],
 )
 def test_set_rejects_control_chars_in_value(
     client: TestClient,
@@ -133,15 +145,15 @@ def test_set_rejects_control_chars_in_value(
     assert "INJECT" not in os.environ
 
 
-def test_writer_guard_rejects_newline(tmp_path: Path) -> None:
-    """Defense-in-depth: the shared writer itself refuses \\n / \\r."""
+def test_writer_guard_rejects_line_breaks(tmp_path: Path) -> None:
+    """Defense-in-depth: the shared writer refuses the full str.splitlines()
+    set — \\n / \\r AND the higher-codepoint NEL/LS/PS separators."""
     from hal0.api._env_store import upsert_env_value
 
     target = tmp_path / "api.env"
-    with pytest.raises(ValueError, match="newline"):
-        upsert_env_value(target, "KEY", "a\nEVIL=x")
-    with pytest.raises(ValueError, match="newline"):
-        upsert_env_value(target, "KEY", "a\rEVIL=x")
+    for payload in ("a\nEVIL=x", "a\rEVIL=x", "a\x85EVIL=x", "a\u2028EVIL=x", "a\u2029EVIL=x"):
+        with pytest.raises(ValueError, match="line-break"):
+            upsert_env_value(target, "KEY", payload)
     # Nothing written.
     assert not target.exists()
 


### PR DESCRIPTION
Follow-up to #743. Found by the post-merge security audit of the live secrets surface.

## Gap
#743 closed the \n/\r env-injection but the guards missed the higher-codepoint line separators: NEL U+0085, LS U+2028, PS U+2029. Route guard checked ord<0x20 or ==0x7f; writer guard checked only \n/\r. All three pass — yet `_env_store` re-reads api.env with Python `str.splitlines()` (list_env_keys + the upsert/delete rewrite), which DOES split on them. An unauthenticated LAN client could POST a secret value like `x INJECT=evil`, then a later upsert/delete round-trips the carrier line through splitlines and promotes the attacker tail to a standalone live KEY=value in hal0-api's systemd EnvironmentFile (LD_PRELOAD-class escalation on restart). Same shared writer → same exposure on the providers-credentials route.

## Fix
- `secrets._validate_value`: ord-check → `str.isprintable()` (covers C0 + DEL **and** the separators; regular space stays allowed — every real secret is printable).
- `_env_store.upsert_env_value`: writer guard rejects the full `str.splitlines()` set (`_LINE_BREAK_CHARS`), not just \n/\r — backstops both routes.
- Regression tests: U+0085/U+2028/U+2029 on both the route and the writer.

## Live check
Audited CT105 /etc/hal0/api.env: 17 lines, zero non-ASCII bytes, no injected line — not exploited.

## Tests
ruff check + format clean; 32 passed (tests/api/test_secrets.py + test_providers.py incl. new separator cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)