### PR TITLE
feat(ui): inference pane P2 — slot cards, iGPU GTT track, profile pill, NPU cordon

### DIFF
--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -504,32 +504,24 @@
 .infer-pane .infer-strip {
   padding: 16px 18px;
   border-top: 1px solid var(--line-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 .infer-pane .engine.open .infer-strip {
   display: none;
 }
-.infer-pane .strip-split {
+/* hero band — iGPU GTT memory map (2fr) + combined-throughput tile (1fr),
+   pinned at the top of BOTH states (P2). */
+.infer-pane .hero-band {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 300px;
-  gap: 22px;
+  grid-template-columns: 2fr 1fr;
+  gap: 20px;
   align-items: start;
 }
-.infer-pane .strip-divider {
-  border-left: 1px solid var(--line-soft);
-  padding-left: 22px;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-}
 @media (max-width: 880px) {
-  .infer-pane .strip-split {
+  .infer-pane .hero-band {
     grid-template-columns: 1fr;
-  }
-  .infer-pane .strip-divider {
-    border-left: none;
-    padding-left: 0;
-    border-top: 1px solid var(--line-soft);
-    padding-top: 16px;
   }
 }
 
@@ -537,25 +529,27 @@
 .infer-pane .mem {
   position: relative;
 }
-.infer-pane .mem-h {
+/* iGPU GTT track header (P2's MemDual, iGPU-only) */
+.infer-pane .mtrack .mt-h {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
   font-family: var(--jbm);
   font-size: 11px;
-  color: var(--fg-3);
-  margin-bottom: 9px;
+  margin-bottom: 7px;
 }
-.infer-pane .mem-h b {
+.infer-pane .mtrack .mt-h .lbl {
+  color: var(--fg-3);
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+.infer-pane .mtrack .mt-h .val {
+  color: var(--fg-2);
+}
+.infer-pane .mtrack .mt-h .val b {
   color: var(--fg);
   font-weight: 500;
-  font-size: 13px;
-}
-.infer-pane .mem-h .ceil {
-  color: var(--fg-5);
-}
-.infer-pane .mem-h .free {
-  color: var(--fg-4);
 }
 .infer-pane .membar {
   position: relative;
@@ -564,6 +558,10 @@
   border-radius: 3px;
   overflow: hidden;
   background: var(--bg-3);
+}
+.infer-pane .membar.tall {
+  height: 17px;
+  border-radius: var(--rad-xs, 2px);
 }
 .infer-pane .membar i {
   display: block;
@@ -584,49 +582,6 @@
 }
 .infer-pane .membar .seg-gap {
   box-shadow: inset -1px 0 0 var(--bg-1);
-}
-.infer-pane .mem-tick {
-  position: absolute;
-  top: -4px;
-  bottom: -4px;
-  width: 1px;
-  background: var(--fg-3);
-}
-.infer-pane .mem-tick::after {
-  content: attr(data-label);
-  position: absolute;
-  top: -15px;
-  left: 50%;
-  transform: translateX(-50%);
-  font-family: var(--jbm);
-  font-size: 8.5px;
-  color: var(--fg-4);
-  white-space: nowrap;
-}
-.infer-pane .mem-tip {
-  position: absolute;
-  transform: translateX(-50%);
-  bottom: calc(100% + 9px);
-  background: var(--bg-2);
-  border: 1px solid var(--line-strong);
-  border-radius: var(--rad-sm);
-  padding: 6px 10px;
-  font-family: var(--jbm);
-  font-size: 10.5px;
-  color: var(--fg);
-  white-space: nowrap;
-  pointer-events: none;
-  box-shadow: var(--shadow-menu);
-  z-index: 6;
-  display: flex;
-  align-items: center;
-  gap: 7px;
-}
-.infer-pane .mem-tip .sw {
-  width: 8px;
-  height: 8px;
-  border-radius: 2px;
-  flex-shrink: 0;
 }
 .infer-pane .mem-legend {
   display: grid;
@@ -686,11 +641,8 @@
   letter-spacing: 0;
   font-weight: 400;
 }
-.infer-pane .tp-big .tp-num {
-  font-size: 32px;
-}
 .infer-pane .tp-mid .tp-num {
-  font-size: 22px;
+  font-size: 24px;
 }
 .infer-pane .tp-sub {
   font-family: var(--jbm);
@@ -720,163 +672,241 @@
 .infer-pane .spark2 i.hot {
   opacity: 1;
 }
-.infer-pane .tp-split {
-  display: flex;
-  flex-direction: column;
-  gap: 9px;
-}
-.infer-pane .tp-split .sr {
-  display: grid;
-  grid-template-columns: 64px 1fr 64px;
-  gap: 11px;
-  align-items: center;
-  font-family: var(--jbm);
-  font-size: 11px;
-}
-.infer-pane .tp-split .sr .dlbl {
-  color: var(--fg-3);
-}
-.infer-pane .tp-split .sr .dbar {
-  height: 7px;
-  border-radius: 2px;
-  background: var(--bg-3);
-  overflow: hidden;
-}
-.infer-pane .tp-split .sr .dbar i {
-  display: block;
-  height: 100%;
-}
-.infer-pane .tp-split .sr .dval {
-  text-align: right;
-  color: var(--fg);
-}
-
-/* ─── Slot list ─────────────────────────────────────────────────────── */
-.infer-pane .slist {
-  display: flex;
-  flex-direction: column;
+/* combined-throughput tile (P2's TpTile) — a bordered inset tile that rides
+   the hero band's right column in both states */
+.infer-pane .tp-tile {
   border: 1px solid var(--line);
   border-radius: var(--rad);
-  overflow: hidden;
   background: var(--bg);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
-.infer-pane .slist .sh,
-.infer-pane .slist .sr {
-  display: grid;
-  align-items: center;
+.infer-pane .tp-tile .spark2 {
+  height: 30px;
+}
+.infer-pane .tp-row {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
   gap: 12px;
-  padding: 9px 14px;
 }
-.infer-pane .slist .sh {
-  padding: 8px 14px;
-  background: var(--bg-1);
-  border-bottom: 1px solid var(--line-soft);
+.infer-pane .tp-aside {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-align: right;
   font-family: var(--jbm);
-  font-size: 8.5px;
+  font-size: 10px;
+  color: var(--fg-4);
   text-transform: uppercase;
   letter-spacing: 0.07em;
-  color: var(--fg-5);
 }
-.infer-pane .slist .sr {
-  border-bottom: 1px solid var(--line-soft);
-  font-family: var(--jbm);
-  font-size: 12.5px;
-  transition: background 0.12s;
-}
-.infer-pane .slist .sr:last-child {
-  border-bottom: none;
-}
-.infer-pane .slist .sr:hover {
-  background: var(--bg-2);
-}
-.infer-pane .slist .sr.dim {
-  opacity: 0.5;
-}
-.infer-pane .slist .sdot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--fg-5);
-}
-.infer-pane .slist .sdot.serving {
-  background: var(--comfy);
-  box-shadow: 0 0 7px var(--comfy);
-  animation: pulse 1.4s ease-in-out infinite;
-}
-.infer-pane .slist .sdot.ready {
-  background: var(--ok);
-}
-.infer-pane .slist .sdot.warming {
-  background: var(--warn);
-  box-shadow: 0 0 7px var(--warn);
-  animation: pulse 1.4s ease-in-out infinite;
-}
-.infer-pane .slist .sdot.error {
-  background: var(--err);
-}
-.infer-pane .slist .sdot.offline {
-  background: var(--fg-5);
-}
-.infer-pane .slist .snm {
-  color: var(--fg);
-  font-weight: 500;
-  display: inline-flex;
-  align-items: center;
-}
-.infer-pane .slist .snm-star {
-  color: var(--comfy);
-  font-size: 9px;
-  margin-left: 5px;
-}
-.infer-pane .slist .smodel {
+.infer-pane .tp-aside .pk {
   color: var(--fg-3);
+}
+
+/* ─── Slot cards (P2) ───────────────────────────────────────────────── */
+.infer-pane .scards {
+  display: grid;
+  gap: 12px;
+}
+.infer-pane .scards.compact {
+  grid-template-columns: repeat(auto-fill, minmax(232px, 1fr));
+}
+.infer-pane .scards.full {
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+}
+.infer-pane .scards-empty {
+  font-family: var(--jbm);
+  font-size: 11px;
+  color: var(--fg-4);
+  padding: 8px 2px;
+}
+.infer-pane .scard {
+  border: 1px solid var(--line);
+  border-radius: var(--rad);
+  background: var(--bg);
+  overflow: hidden;
+  transition: border-color 0.14s var(--ease);
+}
+.infer-pane .scard:hover {
+  border-color: var(--line-strong);
+}
+.infer-pane .scard.serving {
+  border-left: 2px solid var(--comfy);
+}
+.infer-pane .scard.warming {
+  border-left: 2px solid var(--warn);
+}
+.infer-pane .scard.error {
+  border-left: 2px solid var(--err);
+}
+.infer-pane .scard.dim {
+  opacity: 0.55;
+}
+.infer-pane .scard-h {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line-soft);
+  background: var(--bg-1);
+}
+.infer-pane .scard-h .snm {
+  font-family: var(--jbm);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--fg);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.infer-pane .slist .smem {
-  text-align: right;
-  color: var(--fg-2);
+.infer-pane .sdot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--fg-5);
+  flex-shrink: 0;
 }
-.infer-pane .slist .smem .u {
-  color: var(--fg-5);
+.infer-pane .sdot.serving {
+  background: var(--comfy);
+  box-shadow: 0 0 7px var(--comfy);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+.infer-pane .sdot.ready {
+  background: var(--ok);
+}
+.infer-pane .sdot.warming {
+  background: var(--warn);
+  box-shadow: 0 0 7px var(--warn);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+.infer-pane .sdot.error {
+  background: var(--err);
+}
+.infer-pane .sdot.offline {
+  background: var(--fg-5);
+}
+/* status pill — serving shows live tok/s, others the state word */
+.infer-pane .spill {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-family: var(--jbm);
   font-size: 10px;
+  border: 1px solid var(--line);
+  color: var(--fg-3);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
-.infer-pane .slist .stps {
-  text-align: right;
+.infer-pane .spill.serving {
   color: var(--comfy);
+  border-color: var(--comfy-line);
+  background: var(--comfy-soft);
 }
-.infer-pane .slist .stps.muted {
-  color: var(--fg-5);
+.infer-pane .spill.ready {
+  color: var(--ok);
+  border-color: var(--ok-line);
+  background: var(--ok-soft);
 }
-.infer-pane .slist .met {
+.infer-pane .spill.warming {
+  color: var(--warn);
+  border-color: var(--warn-line);
+  background: var(--warn-soft);
+}
+.infer-pane .spill.error {
+  color: var(--err);
+  border-color: var(--err-line);
+  background: var(--err-soft);
+}
+.infer-pane .spill.offline {
+  color: var(--fg-4);
+}
+.infer-pane .scard-b {
+  padding: 10px 12px;
   display: flex;
   flex-direction: column;
-  gap: 1px;
-  text-align: right;
+  gap: 9px;
 }
-.infer-pane .slist .met .mv {
+.infer-pane .scard .smodel {
+  font-family: var(--jbm);
   font-size: 11.5px;
+  color: var(--fg-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* meta row — tok/s · ttft · ctx (full cards) */
+.infer-pane .scard-meta {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  padding-top: 9px;
+  border-top: 1px solid var(--line-soft);
+}
+.infer-pane .scard-meta .m .l {
+  font-family: var(--jbm);
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-4);
+  margin-bottom: 2px;
+}
+.infer-pane .scard-meta .m .v {
+  font-family: var(--jbm);
+  font-size: 13px;
   color: var(--fg);
 }
-.infer-pane .slist .met .mv.acc {
+.infer-pane .scard-meta .m .v.acc {
   color: var(--comfy);
 }
-.infer-pane .slist .met .mv.muted {
+.infer-pane .scard-meta .m .v.muted {
   color: var(--fg-5);
 }
+.infer-pane .scard-foot {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding-top: 9px;
+  border-top: 1px solid var(--line-soft);
+}
+.infer-pane .scard-foot.bare {
+  border-top: none;
+  padding-top: 0;
+}
+.infer-pane .scard-foot .grow {
+  flex: 1;
+}
+.infer-pane .tag-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 7px;
+  border-radius: 3px;
+  font-family: var(--jbm);
+  font-size: 9.5px;
+  color: var(--fg-4);
+  border: 1px solid var(--line);
+  background: var(--bg-1);
+}
 
-/* model picker (expanded list) */
-.infer-pane .slist-picker {
+/* model picker (full cards) — a real <select> styled as the design's
+   full-width bordered control */
+.infer-pane .model-picker {
   appearance: none;
   -webkit-appearance: none;
   width: 100%;
   min-width: 0;
-  padding: 5px 24px 5px 9px;
-  border: 1px solid var(--line);
+  padding: 7px 28px 7px 10px;
+  border: 1px solid var(--line-strong);
   border-radius: var(--rad-sm);
   background-color: var(--bg-1);
-  color: var(--fg-2);
+  color: var(--fg);
   font-family: var(--jbm);
   font-size: 11.5px;
   cursor: pointer;
@@ -885,15 +915,25 @@
   white-space: nowrap;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
   background-repeat: no-repeat;
-  background-position: right 8px center;
+  background-position: right 9px center;
   background-size: 11px;
+  transition: border-color var(--dur-fast) var(--ease);
 }
-.infer-pane .slist-picker:hover {
+.infer-pane .model-picker:hover {
   border-color: var(--comfy-line);
 }
-.infer-pane .slist-picker:disabled {
+.infer-pane .model-picker:disabled {
   opacity: 0.6;
   cursor: default;
+}
+
+/* expanded-body status line — right-aligned mono */
+.infer-pane .body-status {
+  display: flex;
+  justify-content: flex-end;
+  font-family: var(--jbm);
+  font-size: 11px;
+  color: var(--fg-4);
 }
 
 /* device chip + profile pill */

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -2,18 +2,24 @@
 //
 // The yellow-accented counterpart to the ComfyUI generation-engine pane
 // (comfyui-pane.jsx). Where ComfyUI models ONE containerized generation
-// engine, this pane is a summary engine-shell over the LLM/capability slot
-// stack: a collapsed hero strip (memory map + active slot list + combined
-// throughput) that expands to the full slot list with per-slot lifecycle
-// controls, a model picker, and a by-device throughput split.
+// engine, this pane is a summary engine-shell over the iGPU/CPU slot stack,
+// implementing the P2 *card* direction from the design handoff
+// (design_handoff_inference_slots/P2-inference-pane.html):
+//   · collapsed = compact hero — iGPU GTT memory map + combined-throughput
+//     tile + the active (serving/ready) slots as compact cards
+//   · expanded  = the same hero pinned on top, then ALL pane slots as full
+//     cards (model picker · tok/s · ttft · ctx · per-slot controls) and a
+//     right-aligned status line
 //
-// Ported from the hal0 Design System exploration (inference-row/{infer-core,
-// infer}.{jsx,css}). Presentational components are inlined here; all data is
-// LIVE via the typed hooks:
-//   - useSlots()           → the slot rollup (every non-image slot)
-//   - useModels()          → the per-slot model picker (expanded list)
-//   - useMemoryMapModel()  → per-slot resident memory (real mem_mb) + pool
-//   - useHardware()        → the unified-RAM frame (124 GB) for the mem bar
+// NPU/FLM slots are cordoned off to the NPU · FLM stack pane below — they
+// live on the NPU budget, not the GTT carve-out, so they appear in neither
+// this pane's cards nor its memory bar (the sec-label still counts them as
+// a pointer to that pane).
+//
+// All data is LIVE via the typed hooks:
+//   - useSlots()           → the slot rollup (non-image, non-NPU)
+//   - useModels()          → the per-slot model picker (full cards)
+//   - useMemoryMapModel()  → per-slot resident memory (real mem_mb) + GTT pool
 //   - useSlot{Restart,Unload,Load,Swap} → real lifecycle mutations
 // Throughput history is a client ring buffer (the ThroughputCard pattern) —
 // the backend exposes no rolling-60s series. Absent metrics render an
@@ -30,7 +36,6 @@ import {
   useSlotSwap,
 } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
-import { useHardware } from '@/api/hooks/useHardware'
 import { useMemoryMapModel } from './memory-map'
 import { slotIndicatorFromPhase, isSlotLive } from './slot-status.js'
 
@@ -129,95 +134,85 @@ function ctxText(s) {
   return `${used ? kCtx(used) : '—'} / ${kCtx(max)}`
 }
 
-// ── memory map (one continuous segmented bar) ──────────────────────────────
+// a labelled block header reused across mem / throughput / slots
+function SubLabel({ icon, note, children }) {
+  return (
+    <div className="blk-h">
+      <span className="ic">
+        <Ic name={icon} size={13} />
+      </span>{' '}
+      {children}
+      {note != null && (
+        <>
+          <span className="grow" />
+          <span className="note">{note}</span>
+        </>
+      )}
+    </div>
+  )
+}
+
+// ── memory — the iGPU GTT carve-out track (P2's MemDual, iGPU-only) ────────
 // Reuses useMemoryMapModel()'s real per-slot resident memory (mem_mb) and
-// colours. The frame is the unified RAM pool (≈124 GB); a tick marks the iGPU
-// GTT carve-out (≈80 GB). A single honest "system" segment accounts for GTT
-// in use beyond the named model weights (KV cache + runtime + buffers) — no
-// fabricated KV/OS split.
-function MemSegmented({ mm, hw, full }) {
-  const [hi, setHi] = useStateI(null)
+// colours. The frame is the GTT pool ceiling (~80 GB carve-out on the
+// appliance); NPU/FLM models are NOT in this bar — they live on the NPU
+// budget. A single honest "system" segment accounts for GTT in use beyond
+// the named model weights (KV cache + runtime + buffers) — no fabricated
+// KV/OS split. Each segment carries a native title (name · GB).
+function MemGtt({ mm, full }) {
   const pool = mm.pool || {}
   const self = mm.self || {}
-  const gttCapGb = pool.totalGb || 0
-  const unifiedGb = hw?.data?.ram?.total || gttCapGb || 0
-  const frame = unifiedGb || 1
-  const modelSegs = (self.slots || []).filter((s) => s.bytesGb > 0)
-  const modelUsedGb = self.modelUsedGb || 0
+  const capGb = pool.totalGb || 0
+  const frame = capGb || 1
+  const gpuSegs = (self.slots || [])
+    .filter((s) => (s.device === 'rocm' || s.device === 'vulkan') && s.bytesGb > 0)
+    .sort((a, b) => b.bytesGb - a.bytesGb)
+  const gpuModelGb = gpuSegs.reduce((a, s) => a + s.bytesGb, 0)
   const gttUsedGb = self.gttUsedGb || 0
-  const gpuModelGb = modelSegs
-    .filter((s) => s.device === 'rocm' || s.device === 'vulkan')
-    .reduce((a, s) => a + s.bytesGb, 0)
-  const systemOtherGb = Math.max(0, round1(gttUsedGb - gpuModelGb))
-
+  const systemGb = Math.max(0, round1(gttUsedGb - gpuModelGb))
+  const usedGb = round1(Math.max(gttUsedGb, gpuModelGb))
   const segs = [
-    ...modelSegs.map((s) => ({
-      key: s.name,
-      label: s.name,
-      gb: s.bytesGb,
-      color: s.color,
-    })),
-    ...(systemOtherGb > 0
-      ? [{ key: '__sys', label: 'system · KV + runtime', gb: systemOtherGb, color: 'var(--fg-5)' }]
+    ...gpuSegs.map((s) => ({ key: s.name, label: s.name, gb: s.bytesGb, color: s.color })),
+    ...(systemGb > 0
+      ? [{ key: '__sys', label: 'system · KV + runtime', gb: systemGb, color: 'var(--fg-5)' }]
       : []),
   ]
-  const usedGb = round1(modelUsedGb + systemOtherGb)
   const freeGb = Math.max(0, round1(frame - usedGb))
   const pct = (gb) => (gb / frame) * 100
-  let acc = 0
-  const placed = segs.map((s) => {
-    const left = (acc / frame) * 100
-    const w = (s.gb / frame) * 100
-    acc += s.gb
-    return { ...s, left, w }
-  })
 
   return (
     <div className="mem">
-      <div className="blk-h">
-        <span className="ic">
-          <Ic name="mem" size={13} />
-        </span>{' '}
-        memory map
-        <span className="grow" />
-        <span className="note">unified · {frame.toFixed(0)} GB</span>
-      </div>
-      <div className="mem-h">
-        <span>
-          <b>{usedGb.toFixed(1)}</b> / {frame.toFixed(0)} <span className="ceil">GB resident</span>
-        </span>
-        <span className="free">{freeGb.toFixed(1)} GB free</span>
-      </div>
-      <div className="membar" style={{ marginTop: 14 }} onMouseLeave={() => setHi(null)}>
-        {placed.map((s) => (
-          <i
-            key={s.key}
-            className="seg-gap"
-            style={{ width: s.w + '%', background: s.color }}
-            onMouseEnter={() => setHi(s)}
-          />
-        ))}
-        <i className="free" style={{ width: Math.max(0, 100 - pct(usedGb)) + '%' }} />
-        {gttCapGb > 0 && gttCapGb < frame && (
-          <span
-            className="mem-tick"
-            data-label={`GTT ${Math.round(gttCapGb)}`}
-            style={{ left: pct(gttCapGb) + '%' }}
-          />
-        )}
-        {hi && (
-          <span
-            className="mem-tip"
-            style={{ left: Math.min(92, Math.max(8, hi.left + hi.w / 2)) + '%' }}
-          >
-            <span className="sw" style={{ background: hi.color }} />
-            <b>{hi.label}</b> {hi.gb} GB
+      <SubLabel icon="mem" note={capGb ? `${Math.round(capGb)} GB carve-out` : '—'}>
+        memory · iGPU GTT
+      </SubLabel>
+      <div className="mtrack">
+        <div className="mt-h">
+          <span className="lbl">
+            <span className="dchip vulkan">
+              <span className="d" />
+              iGPU
+            </span>{' '}
+            GTT carve-out
           </span>
-        )}
+          <span className="val">
+            <b>{usedGb.toFixed(1)}</b> / {Math.round(capGb)} GB
+          </span>
+        </div>
+        <div className="membar tall" data-testid="infer-membar">
+          {segs.map((s) => (
+            <i
+              key={s.key}
+              className="seg-gap"
+              style={{ width: pct(s.gb) + '%', background: s.color }}
+              title={`${s.label} · ${s.gb} GB`}
+            />
+          ))}
+          <i className="free" style={{ width: Math.max(0, 100 - pct(usedGb)) + '%' }} />
+        </div>
       </div>
       {full && (
         <div className="mem-legend">
-          {placed.map((s) => (
+          {segs.map((s) => (
             <div className="ln" key={s.key}>
               <span className="sw" style={{ background: s.color }} />
               <span className="nm">{s.label}</span>
@@ -239,7 +234,7 @@ function MemSegmented({ mm, hw, full }) {
   )
 }
 
-// ── throughput ─────────────────────────────────────────────────────────────
+// ── throughput tile (P2's TpTile) ──────────────────────────────────────────
 function SparkBars({ data = [], hotN = 4 }) {
   const max = Math.max(...data, 1)
   if (!data.length) return <div className="spark2" />
@@ -256,101 +251,78 @@ function SparkBars({ data = [], hotN = 4 }) {
   )
 }
 
-function TpBig({ value, ticks, peak, servingN }) {
+function TpTile({ value, ticks, peak, servingN }) {
   return (
-    <div className="tp tp-big">
-      <div className="blk-h">
+    <div className="tp-tile" data-testid="infer-tp">
+      <div className="blk-h" style={{ margin: 0 }}>
         <span className="ic">
           <Ic name="activity" size={13} />
         </span>{' '}
         combined throughput
-        <span className="grow" />
-        <span className="note">{servingN} serving</span>
       </div>
-      <div className="tp-num">
-        {value == null ? '—' : value}
-        <span className="u">tok/s</span>
+      <div className="tp-row">
+        <div className="tp tp-mid">
+          <div className="tp-num">
+            {value == null ? '—' : value}
+            <span className="u">tok/s</span>
+          </div>
+        </div>
+        <div className="tp-aside">
+          <span>{peak == null ? 'peak —' : `peak ${peak}`}</span>
+          <span className="pk">{servingN} serving</span>
+        </div>
       </div>
       <SparkBars data={ticks} />
-      <div className="tp-sub">
-        <span>last 60s</span>
-        <span className="pk">{peak == null ? 'peak —' : `peak ${peak} t/s`}</span>
-      </div>
     </div>
   )
 }
 
-function TpSplit({ igpu, flm, combined }) {
-  const total = combined || 1
-  return (
-    <div className="tp">
-      <div className="blk-h">
-        <span className="ic">
-          <Ic name="activity" size={13} />
-        </span>{' '}
-        throughput · by device
-      </div>
-      <div className="tp tp-mid" style={{ marginBottom: 4 }}>
-        <div className="tp-num">
-          {combined == null ? '—' : combined}
-          <span className="u">tok/s combined</span>
-        </div>
-      </div>
-      <div className="tp-split">
-        <div className="sr">
-          <span className="dlbl" style={{ color: 'var(--dev-vulkan)' }}>
-            iGPU
-          </span>
-          <span className="dbar">
-            <i style={{ width: (igpu / total) * 100 + '%', background: 'var(--dev-vulkan)' }} />
-          </span>
-          <span className="dval">{igpu || '—'}</span>
-        </div>
-        <div className="sr">
-          <span className="dlbl" style={{ color: 'var(--dev-npu)' }}>
-            FLM
-          </span>
-          <span className="dbar">
-            <i style={{ width: (flm / total) * 100 + '%', background: 'var(--dev-npu)' }} />
-          </span>
-          <span className="dval">{flm || '—'}</span>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-// ── slot list ────────────────────────────────────────────────────────────
-function DevCell({ s, withProfile, onProfile }) {
+// ── slot cards ──────────────────────────────────────────────────────────
+// provider tag — a joined [ device | PROFILE ] control. The profile pill
+// surfaces the slot's runtime profile (slot.profile, resolved from
+// /etc/hal0/profiles.toml by the backend) and opens the slot editor.
+function DevCell({ s, onProfile }) {
+  const kind = devKind(s.device)
   const dchip =
-    devKind(s.device) === 'npu' ? (
+    kind === 'npu' ? (
       <span className="flm-chip">FLM · npu</span>
     ) : (
-      <span className={'dchip ' + devKind(s.device)}>
+      <span className={'dchip ' + kind}>
         <span className="d" />
-        {devKind(s.device)}
+        {kind}
       </span>
     )
-  if (!withProfile || !s.profile) return dchip
   return (
     <span className="prov">
       {dchip}
-      <button className="profile-pill" title="Runtime profile — edit slot" onClick={onProfile}>
-        {s.profile}
+      <button
+        className="profile-pill"
+        title="Runtime profile — edit slot"
+        onClick={onProfile}
+        data-testid={`infer-profile-${s.name}`}
+      >
+        {s.profile || 'default'}
         <Ic name="chev" size={10} />
       </button>
     </span>
   )
 }
 
-function ModelPickerCell({ s, models, disabled, onSwap }) {
-  if (s.type !== 'llm') return <span className="smodel">{s.model || '—'}</span>
+// full cards get a real model picker (a styled <select> wired to useModels);
+// non-LLM slots keep their static model line.
+function ModelPicker({ s, models, disabled, onSwap }) {
+  if (s.type !== 'llm')
+    return (
+      <div className="smodel" title={s.model || ''}>
+        {s.model || '—'}
+      </div>
+    )
   const opts = (Array.isArray(models) ? models : []).filter((m) => m.type === 'llm')
   const cur = s.model_id || s.model || ''
   const has = opts.some((m) => m.id === cur)
   return (
     <select
-      className="slist-picker mono"
+      className="model-picker mono"
       value={cur}
       disabled={disabled}
       onClick={(e) => e.stopPropagation()}
@@ -371,7 +343,9 @@ function ModelPickerCell({ s, models, disabled, onSwap }) {
   )
 }
 
-function SlotControls({ s, phase, busy, onStart, onStop, onRestart, onLogs, onEdit }) {
+// per-slot controls — Start/Stop are mutually exclusive by running state;
+// compact (collapsed) cards get the minimal set (no Logs/Edit).
+function SlotControls({ phase, busy, compact, onStart, onStop, onRestart, onLogs, onEdit }) {
   const running = phase !== 'off'
   return (
     <span className="slot-ctrls" onClick={(e) => e.stopPropagation()}>
@@ -397,12 +371,16 @@ function SlotControls({ s, phase, busy, onStart, onStop, onRestart, onLogs, onEd
       >
         <Ic name="refresh" size={13} />
       </button>
-      <button className="sctrl" title="Logs" onClick={onLogs}>
-        <Ic name="logs" size={13} />
-      </button>
-      <button className="sctrl" title="Edit" onClick={onEdit}>
-        <Ic name="edit" size={13} />
-      </button>
+      {!compact && (
+        <button className="sctrl" title="Logs" onClick={onLogs}>
+          <Ic name="logs" size={13} />
+        </button>
+      )}
+      {!compact && (
+        <button className="sctrl" title="Edit" onClick={onEdit}>
+          <Ic name="edit" size={13} />
+        </button>
+      )}
     </span>
   )
 }
@@ -424,83 +402,83 @@ function slotCtrlPhase(slot) {
   return 'off'
 }
 
-function SlotList({ rows, full, models, busyName, handlers }) {
-  const tmplC = '10px 84px minmax(0,1fr) auto 76px 70px'
-  const tmplF = '10px 90px minmax(0,1fr) auto 64px 60px 64px 70px 132px'
-  const tmpl = full ? tmplF : tmplC
+function SlotCards({ rows, full, models, busyName, handlers }) {
+  if (!rows.length)
+    return <div className="scards-empty">no active slots — expand to start one</div>
   return (
-    <div className="slist">
-      {full && (
-        <div className="sh" style={{ gridTemplateColumns: tmpl }}>
-          <span />
-          <span>slot</span>
-          <span>model</span>
-          <span>device</span>
-          <span style={{ textAlign: 'right' }}>mem</span>
-          <span style={{ textAlign: 'right' }}>tok/s</span>
-          <span style={{ textAlign: 'right' }}>ttft</span>
-          <span style={{ textAlign: 'right' }}>ctx</span>
-          <span style={{ textAlign: 'right' }}>actions</span>
-        </div>
-      )}
+    <div className={'scards ' + (full ? 'full' : 'compact')}>
       {rows.map(({ s, ind }) => {
         const phase = slotCtrlPhase(s)
+        const dot = dotCls(ind)
         const memGb = typeof s.mem_mb === 'number' && s.mem_mb > 0 ? round1(s.mem_mb / 1024) : null
         const tps = typeof s.metrics?.toks === 'number' && s.metrics.toks > 0 ? s.metrics.toks : null
         const ttft = typeof s.metrics?.ttft === 'number' && s.metrics.ttft > 0 ? s.metrics.ttft : null
         const busy = busyName === s.name
+        const spill = dot === 'serving' ? (tps ? `${tps} tok/s` : 'serving') : dot
+        const ctrls = (
+          <SlotControls
+            phase={phase}
+            busy={busy}
+            compact={!full}
+            onStart={() => handlers.onStart(s)}
+            onStop={() => handlers.onStop(s)}
+            onRestart={() => handlers.onRestart(s)}
+            onLogs={() => handlers.onLogs(s)}
+            onEdit={() => handlers.onEdit(s)}
+          />
+        )
         return (
           <div
-            className={'sr' + (phase === 'off' ? ' dim' : '')}
+            className={'scard ' + dot + (phase === 'off' ? ' dim' : '')}
             key={s.name}
-            style={{ gridTemplateColumns: tmpl }}
             data-testid={`infer-slot-${s.name}`}
           >
-            <span className={'sdot ' + dotCls(ind)} title={ind.tooltip} />
-            <span className="snm">
-              {s.name}
-              {s.isDefault && <span className="snm-star">★</span>}
-            </span>
-            {full ? (
-              <ModelPickerCell
-                s={s}
-                models={models}
-                disabled={busy}
-                onSwap={(id) => handlers.onSwap(s, id)}
-              />
-            ) : (
-              <span className="smodel">{s.model || '—'}</span>
-            )}
-            <DevCell s={s} withProfile={full} onProfile={() => handlers.onEdit(s)} />
-            <span className="smem">
-              {memGb == null ? '—' : memGb}
-              {memGb != null && <span className="u"> GB</span>}
-            </span>
-            {!full ? (
-              <span className={'stps' + (tps ? '' : ' muted')}>{tps || '—'}</span>
-            ) : (
-              <>
-                <span className="met">
-                  <span className={'mv' + (tps ? ' acc' : ' muted')}>{tps || '—'}</span>
-                </span>
-                <span className="met">
-                  <span className={'mv' + (ttft ? '' : ' muted')}>{ttft ? ttft + 'ms' : '—'}</span>
-                </span>
-                <span className="met">
-                  <span className={'mv' + (s.ctx_max ? '' : ' muted')}>{ctxText(s)}</span>
-                </span>
-                <SlotControls
+            <div className="scard-h">
+              <span className={'sdot ' + dot} title={ind.tooltip} />
+              <span className="snm">{s.name}</span>
+              <span className={'spill ' + dot}>{spill}</span>
+            </div>
+            <div className="scard-b">
+              {full ? (
+                <ModelPicker
                   s={s}
-                  phase={phase}
-                  busy={busy}
-                  onStart={() => handlers.onStart(s)}
-                  onStop={() => handlers.onStop(s)}
-                  onRestart={() => handlers.onRestart(s)}
-                  onLogs={() => handlers.onLogs(s)}
-                  onEdit={() => handlers.onEdit(s)}
+                  models={models}
+                  disabled={busy}
+                  onSwap={(id) => handlers.onSwap(s, id)}
                 />
-              </>
-            )}
+              ) : (
+                <div className="smodel" title={s.model || ''}>
+                  {s.model || '—'}
+                </div>
+              )}
+              {full && (
+                <div className="scard-meta">
+                  <div className="m">
+                    <div className="l">tok/s</div>
+                    <div className={'v' + (tps ? ' acc' : ' muted')}>{tps || '—'}</div>
+                  </div>
+                  <div className="m">
+                    <div className="l">ttft</div>
+                    <div className={'v' + (ttft ? '' : ' muted')}>{ttft ? ttft + 'ms' : '—'}</div>
+                  </div>
+                  <div className="m">
+                    <div className="l">ctx</div>
+                    <div
+                      className={'v' + (s.ctx_max ? '' : ' muted')}
+                      style={{ fontSize: 12 }}
+                    >
+                      {ctxText(s)}
+                    </div>
+                  </div>
+                </div>
+              )}
+              <div className={'scard-foot' + (full ? '' : ' bare')}>
+                <DevCell s={s} onProfile={() => handlers.onEdit(s)} />
+                {full && memGb != null && <span className="tag-chip">{memGb} GB</span>}
+                <span className="grow" />
+                {ctrls}
+              </div>
+            </div>
           </div>
         )
       })}
@@ -512,7 +490,6 @@ export function InferencePane() {
   const slotsQuery = useSlots()
   const modelsQuery = useModels()
   const mm = useMemoryMapModel()
-  const hw = useHardware()
   const restartMut = useSlotRestart()
   const unloadMut = useSlotUnload()
   const loadMut = useSlotLoad()
@@ -520,13 +497,20 @@ export function InferencePane() {
   const [open, setOpen] = useStateI(false)
   const [busyName, setBusyName] = useStateI(null)
 
-  // The Inference rollup is every non-image slot (chat + capabilities + the
-  // NPU/FLM trio). Image generation is its own pane (ComfyuiPane).
+  // The Inference rollup is the iGPU/CPU slot stack. Image generation is its
+  // own pane (ComfyuiPane); NPU/FLM slots are cordoned off to the NPU · FLM
+  // stack pane below — they appear here only as the sec-label FLM count.
   const allSlots = slotsQuery.data || []
-  const slots = allSlots.filter((s) => (s.group || '') !== 'img')
+  const nonImg = allSlots.filter((s) => (s.group || '') !== 'img')
+  const slots = nonImg.filter((s) => devKind(s.device) !== 'npu')
+  const npuN = nonImg.length - slots.length
 
   const rows = slots.map((s) => ({ s, ind: slotIndicatorFromPhase(s) }))
-  const activeRows = rows.filter((r) => isSlotLive(r.s) || r.ind.cls === 'serving')
+  // collapsed view: serving + ready only (warming/idle wait for the expand)
+  const compactRows = rows.filter((r) => {
+    const d = dotCls(r.ind)
+    return d === 'serving' || d === 'ready'
+  })
   const servingN = rows.filter((r) => r.ind.cls === 'serving').length
   const loadedN = rows.filter((r) => isSlotLive(r.s)).length
 
@@ -534,10 +518,10 @@ export function InferencePane() {
     const k = devKind(s.device)
     return k === 'rocm' || k === 'vulkan'
   }).length
-  const npuN = slots.filter((s) => devKind(s.device) === 'npu').length
 
-  // Combined throughput — summed tok/s across serving slots, with a client
-  // ring buffer for the 60s spark (the backend exposes no rolling series).
+  // Combined throughput — summed tok/s across this pane's serving slots
+  // (NPU/FLM throughput belongs to the NPU pane), with a client ring buffer
+  // for the spark (the backend exposes no rolling series).
   const toksVals = slots
     .map((s) => s?.metrics?.toks)
     .filter((t) => typeof t === 'number' && t > 0)
@@ -555,16 +539,9 @@ export function InferencePane() {
   const ticks = historyRef.current
   const peak = ticks.length ? Math.max(...ticks) : null
 
-  const igpuTps = Math.round(
-    slots
-      .filter((s) => devKind(s.device) !== 'npu')
-      .reduce((a, s) => a + (typeof s.metrics?.toks === 'number' ? s.metrics.toks : 0), 0),
-  )
-  const flmTps = Math.round(
-    slots
-      .filter((s) => devKind(s.device) === 'npu')
-      .reduce((a, s) => a + (typeof s.metrics?.toks === 'number' ? s.metrics.toks : 0), 0),
-  )
+  // GTT headroom for the expanded status line (the memory map's frame).
+  const gttCapGb = mm.pool?.totalGb || 0
+  const gttFreeGb = Math.max(0, Math.round(gttCapGb - (mm.self?.gttUsedGb || 0)))
 
   const run = async (name, mut, args, okMsg) => {
     setBusyName(name)
@@ -604,6 +581,13 @@ export function InferencePane() {
   const openLogs = () => {
     window.location.hash = '#logs'
   }
+
+  const hero = (full) => (
+    <div className="hero-band">
+      <MemGtt mm={mm} full={full} />
+      <TpTile value={value} ticks={ticks} peak={peak} servingN={servingN} />
+    </div>
+  )
 
   return (
     <div className="infer-pane">
@@ -651,36 +635,44 @@ export function InferencePane() {
             </span>
           </div>
 
-          {/* collapsed strip — hidden when the pane is open */}
+          {/* collapsed strip — compact hero, hidden when the pane is open */}
           <div className="infer-strip" data-testid="infer-strip">
-            <div className="strip-split">
-              <SlotList
-                rows={activeRows}
+            {hero(false)}
+            <div>
+              <SubLabel icon="slots" note={`${loadedN} loaded`}>
+                active slots
+              </SubLabel>
+              <SlotCards
+                rows={compactRows}
                 full={false}
                 models={modelsQuery.data}
                 busyName={busyName}
                 handlers={handlers}
               />
-              <div className="strip-divider">
-                <MemSegmented mm={mm} hw={hw} full={false} />
-                <TpBig value={value} ticks={ticks} peak={peak} servingN={servingN} />
-              </div>
             </div>
           </div>
 
-          {/* expandable body */}
+          {/* expandable body — hero pinned on top, then all slots as full cards */}
           <div className="engine-body">
             <div className="inner">
               <div className="engine-b">
-                <MemSegmented mm={mm} hw={hw} full />
-                <SlotList
-                  rows={rows}
-                  full
-                  models={modelsQuery.data}
-                  busyName={busyName}
-                  handlers={handlers}
-                />
-                <TpSplit igpu={igpuTps} flm={flmTps} combined={value} />
+                {hero(true)}
+                <div>
+                  <SubLabel icon="slots" note={`all ${rows.length} · full cards`}>
+                    slots
+                  </SubLabel>
+                  <SlotCards
+                    rows={rows}
+                    full
+                    models={modelsQuery.data}
+                    busyName={busyName}
+                    handlers={handlers}
+                  />
+                </div>
+                <div className="body-status">
+                  {servingN} serving
+                  {gttCapGb > 0 ? ` · ${gttFreeGb} GB free` : ''}
+                </div>
               </div>
             </div>
           </div>

--- a/ui/tests/e2e/specs/inference-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-pane-v3.spec.ts
@@ -1,12 +1,17 @@
 /**
- * inference-pane-v3 — the Inference "engine" pane (slots-page Inference tab).
+ * inference-pane-v3 — the Inference "engine" pane (slots-page Inference tab),
+ * P2 card direction (design_handoff_inference_slots).
  *
  * Behaviour under test:
- *   - collapsed hero strip renders from HAL0_DATA slots (epill + active list)
- *   - the qcaret toggles the engine open (→ full slot list + by-device split)
- *   - per-slot tok/s is shown for a serving slot (no fabricated numbers)
+ *   - collapsed hero strip renders from HAL0_DATA slots: epill, iGPU GTT
+ *     memory map, combined-throughput tile, and compact slot CARDS
+ *   - the serving card's status pill shows live tok/s (no fabricated numbers)
+ *   - the profile pill surfaces the slot's runtime profile name (slot.profile)
+ *   - NPU/FLM slots are cordoned off — absent from the inference pane, present
+ *     in the NPU · FLM stack pane below
+ *   - the qcaret toggles the engine open (→ full cards with tok/s · ttft · ctx)
  *   - a lifecycle control fires the real mutation (Stop → POST /unload)
- *   - the expanded list exposes a real model-picker <select> (useModels)
+ *   - the full card exposes a real model-picker <select> (useModels)
  *   - the NPU/FLM pane renders its own engine shell + trio
  *   - the Inference tab carries the yellow `infer` accent class
  *
@@ -26,31 +31,61 @@ const engine = (page: Page) => page.locator('.infer-pane .engine').first()
 const body = (page: Page) => page.locator('.infer-pane .engine-body').first()
 
 test.describe('Inference engine pane (/slots · Inference tab)', () => {
-  test('collapsed strip renders with epill + active slot rows', async ({ page }) => {
+  test('collapsed strip renders epill + hero band + compact slot cards', async ({ page }) => {
     await page.goto('/#slots')
     await expect(pane(page)).toBeVisible()
     await expect(engine(page)).not.toHaveClass(/\bopen\b/)
     // engine state pill summarises serving/loaded counts (primary is serving).
     await expect(page.getByTestId('infer-epill')).toContainText('serving')
-    // collapsed hero strip is visible and lists the serving primary slot.
+    // collapsed hero strip: iGPU GTT memory map + throughput tile + cards.
     const strip = page.getByTestId('infer-strip')
     await expect(strip).toBeVisible()
-    await expect(strip.getByTestId('infer-slot-primary')).toBeVisible()
-    await expect(strip.locator('.mem .blk-h')).toContainText('memory map')
+    await expect(strip.locator('.mem .blk-h')).toContainText('memory · iGPU GTT')
+    await expect(strip.locator('.tp-tile')).toBeVisible()
+    // the serving primary slot renders as a compact CARD whose status pill
+    // carries the live tok/s (45 in the seed).
+    const card = strip.getByTestId('infer-slot-primary')
+    await expect(card).toBeVisible()
+    await expect(card).toHaveClass(/\bscard\b/)
+    await expect(card.locator('.spill')).toContainText('45 tok/s')
   })
 
-  test('qcaret toggles the engine open → full list + by-device split', async ({ page }) => {
+  test('profile pill surfaces the runtime profile name (slot.profile)', async ({ page }) => {
+    await page.goto('/#slots')
+    // primary carries profile "moe-rocmfp4" in the seed; the [ device |
+    // PROFILE ] provider tag renders it on the compact card too.
+    const pill = page
+      .getByTestId('infer-strip')
+      .getByTestId('infer-profile-primary')
+    await expect(pill).toBeVisible()
+    await expect(pill).toContainText('moe-rocmfp4')
+  })
+
+  test('NPU/FLM slots are cordoned off to the NPU pane', async ({ page }) => {
+    await page.goto('/#slots')
+    await expect(pane(page)).toBeVisible()
+    // the seed's NPU slots (agent / stt-npu / embed-npu) must NOT appear in
+    // the inference pane — collapsed or expanded.
+    for (const name of ['agent', 'stt-npu', 'embed-npu']) {
+      await expect(pane(page).locator(`[data-testid="infer-slot-${name}"]`)).toHaveCount(0)
+    }
+    // …they live in the NPU · FLM stack pane below.
+    await expect(page.locator('.npu-pane').first()).toBeVisible()
+  })
+
+  test('qcaret toggles the engine open → full cards with meta row', async ({ page }) => {
     await page.goto('/#slots')
     await expect(engine(page)).not.toHaveClass(/\bopen\b/)
     await page.getByTestId('infer-qcaret').click()
     await expect(engine(page)).toHaveClass(/\bopen\b/)
-    // full-list header (actions column) + by-device split live in the body.
-    await expect(body(page).locator('.slist .sh')).toContainText('actions')
-    await expect(body(page).locator('.tp-split')).toHaveCount(1)
-    // per-slot tok/s rendered for the serving primary slot (45 in the seed).
-    await expect(body(page).getByTestId('infer-slot-primary').locator('.met').first()).toContainText(
-      '45',
-    )
+    // full-card grid + the hero band's throughput tile live in the body.
+    await expect(body(page).locator('.scards.full')).toHaveCount(1)
+    await expect(body(page).locator('.tp-tile')).toHaveCount(1)
+    // the full card's meta row reports real metrics for the serving primary
+    // slot (toks 45 · ttft 220 in the seed; no fabricated numbers).
+    const meta = body(page).getByTestId('infer-slot-primary').locator('.scard-meta')
+    await expect(meta.locator('.m .v').nth(0)).toContainText('45')
+    await expect(meta.locator('.m .v').nth(1)).toContainText('220ms')
     // toggle back closed.
     await page.getByTestId('infer-qcaret').click()
     await expect(engine(page)).not.toHaveClass(/\bopen\b/)
@@ -69,12 +104,12 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
     await expect.poll(() => unloads.length).toBeGreaterThan(0)
   })
 
-  test('expanded list exposes a real model-picker <select> (useModels)', async ({ page }) => {
+  test('full card exposes a real model-picker <select> (useModels)', async ({ page }) => {
     await page.goto('/#slots')
-    // The full-list model picker lives in the (collapsible) engine body; it is
+    // The full-card model picker lives in the (collapsible) engine body; it is
     // present in the DOM regardless of open state, so assert on it directly —
     // no flaky expand-click needed for a structural check.
-    const picker = body(page).getByTestId('infer-slot-primary').locator('select.slist-picker')
+    const picker = body(page).getByTestId('infer-slot-primary').locator('select.model-picker')
     await expect(picker).toHaveCount(1)
     // the picker is populated (at minimum the current model is an option).
     await expect.poll(async () => picker.locator('option').count()).toBeGreaterThan(0)


### PR DESCRIPTION
Implements the chosen **P2 card direction** from the design handoff (`design_handoff_inference_slots/P2-inference-pane.html`) for the Inference engine pane, replacing the list-row layout.

## What changed
- **Slot cards** (the design's `SlotCards`) replace the inline `SlotList`:
  - *Collapsed* → compact cards for serving/ready slots: status dot + name + status pill (live `tok/s` when serving), model line, `[ device | PROFILE ]` provider tag, minimal controls (Start/Stop + Restart).
  - *Expanded* → full cards for **all** pane slots: model-picker `<select>` (useModels), `tok/s · ttft · ctx` meta row, memory tag chip, full control cluster (Start/Stop · Restart · Logs · Edit). Off slots render dimmed; serving/warming carry the accent/orange left border.
- **Hero band** pinned in both states: **iGPU GTT carve-out track** (frame = GTT pool ceiling from `useMemoryMapModel()`, per-slot `mem_mb` segments + honest `system · KV + runtime` remainder, legend when expanded) + **combined-throughput tile** (sum of this pane's serving tok/s, client ring-buffer spark, peak/serving aside).
- **Profile field wired**: the provider tag renders `slot.profile` (backend-resolved from `/etc/hal0/profiles.toml`) as the uppercase profile pill on every card; clicking opens the slot editor.
- **NPU cordon**: `device === "npu"` slots are excluded from this pane's cards, memory bar, and combined throughput — they live solely in the NPU · FLM stack pane below. The sec-label FLM count remains as a cross-pane pointer.
- Expanded body ends with the right-aligned status line (`N serving · M GB free`), replacing the old by-device throughput split.
- No fabricated numbers: every missing metric renders an em-dash.

## Tests
- `ui/tests/e2e/specs/inference-pane-v3.spec.ts` rewritten to the card contract; new assertions: profile pill shows the seed profile name, NPU slots (`agent`/`stt-npu`/`embed-npu`) absent from the pane and present in the NPU pane. **9/9 passing** locally; `npm run build` clean.

Screenshots (mock seed): collapsed = hero + compact cards; expanded = full cards w/ pickers + meta rows. Memory bar segments are empty under the mock (no GTT usage / `mem_mb` in seed) — live attribution path unchanged from the sidebar memory map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)