### PR TITLE
feat(profiles): seed "Edit a copy" + cloned_from provenance

### DIFF
--- a/src/hal0/api/routes/profiles.py
+++ b/src/hal0/api/routes/profiles.py
@@ -48,6 +48,10 @@ class ProfileBody(BaseModel):
         default="gpu",
         description="Device class this profile targets.",
     )
+    cloned_from: str | None = Field(
+        default=None,
+        description="Provenance: profile this one was cloned from (informational).",
+    )
 
     @field_validator("name")
     @classmethod
@@ -126,6 +130,7 @@ def create_profile(body: ProfileBody) -> dict[str, Any]:
             flags=body.flags,
             mtp=body.mtp,
             device_class=body.device_class,
+            cloned_from=body.cloned_from,
         ),
     )
     return profile.to_dict()

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -773,6 +773,14 @@ class ProfileConfig(BaseModel):
             "(ComfyUI image-generation slots) and is not yet used."
         ),
     )
+    cloned_from: str | None = Field(
+        default=None,
+        description=(
+            "Provenance: name of the profile this one was cloned from "
+            "(set by the dashboard clone / edit-a-copy flow).  Informational "
+            "only — never resolved or validated against the catalog."
+        ),
+    )
 
     @field_validator("image")
     @classmethod

--- a/src/hal0/profiles/__init__.py
+++ b/src/hal0/profiles/__init__.py
@@ -53,6 +53,7 @@ class ResolvedProfile:
     seed: bool
     runtime_family: RuntimeFamily
     supported_slot_types: tuple[SlotType, ...]
+    cloned_from: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -65,6 +66,7 @@ class ResolvedProfile:
             "seed": self.seed,
             "runtime_family": self.runtime_family,
             "supported_slot_types": list(self.supported_slot_types),
+            "cloned_from": self.cloned_from,
         }
 
 
@@ -156,6 +158,7 @@ class ProfileCatalog:
                 device_class=(
                     patch.device_class if patch.device_class is not None else existing.device_class
                 ),
+                cloned_from=existing.cloned_from,
             )
             catalog.profile[name] = updated
             save_profiles_config(catalog, self._path)
@@ -206,6 +209,7 @@ class ProfileCatalog:
             seed=name in SEED_PROFILES,
             runtime_family=runtime,
             supported_slot_types=_supported_slot_types(runtime),
+            cloned_from=profile.cloned_from,
         )
 
     def _guard_custom(self, name: str) -> None:

--- a/tests/api/test_profiles_crud.py
+++ b/tests/api/test_profiles_crud.py
@@ -341,3 +341,28 @@ def test_delete_succeeds_with_only_corrupt_toml_and_warns(
     log_text = captured.out + captured.err + caplog.text
     assert "profiles.in_use_scan_error" in log_text
     assert "broken-slot" in log_text
+
+
+# ── cloned_from provenance ─────────────────────────────────────────────────────
+
+
+def test_create_with_cloned_from_201_and_listed(client: TestClient) -> None:
+    r = client.post(
+        "/api/profiles",
+        json={
+            "name": "vulkan-std-custom",
+            "image": "ghcr.io/x/y:z",
+            "cloned_from": "vulkan-std",
+        },
+    )
+    assert r.status_code == 201
+    assert r.json()["cloned_from"] == "vulkan-std"
+
+    listed = client.get("/api/profiles").json()
+    item = next(p for p in listed if p["name"] == "vulkan-std-custom")
+    assert item["cloned_from"] == "vulkan-std"
+
+
+def test_seed_profiles_have_null_cloned_from(client: TestClient) -> None:
+    listed = client.get("/api/profiles").json()
+    assert listed and all(p["cloned_from"] is None for p in listed)

--- a/tests/profiles/test_catalog.py
+++ b/tests/profiles/test_catalog.py
@@ -64,3 +64,29 @@ def test_delete_profile_in_use_raises_conflict(tmp_hal0_home: str) -> None:
 
     assert exc.value.code == "profiles.in_use"
     assert exc.value.details["slots"] == ["chat"]
+
+
+def test_cloned_from_persists_and_round_trips(tmp_hal0_home: str) -> None:
+    catalog = ProfileCatalog()
+
+    created = catalog.create(
+        "vulkan-std-custom",
+        ProfileConfig(image="ghcr.io/x/y:z", flags="-fa on", cloned_from="vulkan-std"),
+    )
+    assert created.cloned_from == "vulkan-std"
+    assert created.to_dict()["cloned_from"] == "vulkan-std"
+
+    # Survives the profiles.toml round trip on a fresh catalog instance.
+    reloaded = ProfileCatalog().resolve("vulkan-std-custom")
+    assert reloaded.cloned_from == "vulkan-std"
+
+
+def test_cloned_from_defaults_to_none_and_survives_update(tmp_hal0_home: str) -> None:
+    catalog = ProfileCatalog()
+
+    plain = catalog.create("my-rocm", ProfileConfig(image="ghcr.io/x/y:z"))
+    assert plain.cloned_from is None
+
+    catalog.create("my-copy", ProfileConfig(image="ghcr.io/x/y:z", cloned_from="my-rocm"))
+    updated = catalog.update("my-copy", ProfilePatch(flags="-fa off"))
+    assert updated.cloned_from == "my-rocm"

--- a/ui/src/dash/profiles.jsx
+++ b/ui/src/dash/profiles.jsx
@@ -7,8 +7,11 @@
 // ~52.8 tok/s" rather than "moe-rocmfp4".
 //
 // Phase C6: CRUD — New profile button + create/edit form (inline drawer),
-// per-card Edit/Delete for custom profiles, Clone for all (prefills form
-// with <name>-copy). Seeds are immutable: badge shown, Edit/Delete disabled.
+// per-card Edit/Delete for custom profiles, Clone for custom (prefills form
+// with <name>-copy). Seeds are immutable: badge shown, Delete disabled, and
+// Edit becomes "Edit a copy" — opens the create form prefilled from the seed
+// (name <seed>-custom) so editing forks a custom profile instead of mutating
+// the seed. Clones carry cloned_from provenance, shown as "based on <source>".
 
 import { useState, useEffect, useCallback } from 'react'
 import {
@@ -52,7 +55,7 @@ function toast(msg, kind = 'info') {
 
 const BLANK_FORM = { name: '', image: '', flags: '', mtp: false, device_class: '' };
 
-function ProfileForm({ initial, isEdit, isSeed, onClose, onSaved }) {
+function ProfileForm({ initial, isEdit, title, onClose, onSaved }) {
   const [form, setForm] = useState(initial ?? BLANK_FORM);
   const [errors, setErrors] = useState({});
   const [submitting, setSubmitting] = useState(false);
@@ -95,6 +98,7 @@ function ProfileForm({ initial, isEdit, isSeed, onClose, onSaved }) {
       flags: form.flags ?? '',
       mtp: !!form.mtp,
       ...(form.device_class ? { device_class: form.device_class } : {}),
+      ...(form.cloned_from ? { cloned_from: form.cloned_from } : {}),
     };
     try {
       if (isEdit) {
@@ -120,12 +124,13 @@ function ProfileForm({ initial, isEdit, isSeed, onClose, onSaved }) {
     }
   }
 
-  const title = isEdit ? `Edit · ${initial?.name}` : 'New profile';
+  const fallbackTitle = isEdit ? `Edit · ${initial?.name}` : 'New profile';
+  const panelTitle = title || fallbackTitle;
 
   return (
-    <div className="pf-form-panel" role="dialog" aria-label={title}>
+    <div className="pf-form-panel" role="dialog" aria-label={panelTitle}>
       <div className="pf-form-head">
-        <span className="pf-form-title mono">{title}</span>
+        <span className="pf-form-title mono">{panelTitle}</span>
         <button className="btn ghost sm pf-form-close" onClick={onClose} aria-label="Close">×</button>
       </div>
       <form onSubmit={handleSubmit} className="pf-form-body">
@@ -318,27 +323,42 @@ function ProfileCard({ profile, onEdit, onClone, onDelete }) {
         <span className="pf-sep">·</span>
         <span className="pf-tag">{tag}</span>
       </div>
+      {profile.cloned_from && (
+        <div className="pf-based mono">based on {profile.cloned_from}</div>
+      )}
       {profile.resolved_flags && (
         <div className="pf-flags mono">{profile.resolved_flags}</div>
       )}
       <div className="pf-card-actions">
-        <button
-          className="btn ghost xs"
-          onClick={() => onClone(profile)}
-          title="Clone this profile"
-          data-testid={`pf-btn-clone-${profile.name}`}
-        >
-          Clone
-        </button>
-        <button
-          className="btn ghost xs"
-          onClick={() => onEdit(profile)}
-          disabled={isSeed}
-          title={isSeed ? 'Seed profiles are immutable' : 'Edit'}
-          data-testid={`pf-btn-edit-${profile.name}`}
-        >
-          Edit
-        </button>
+        {isSeed ? (
+          <button
+            className="btn ghost xs"
+            onClick={() => onClone(profile)}
+            title="Seed profiles are immutable — edit a custom copy instead"
+            data-testid={`pf-btn-editcopy-${profile.name}`}
+          >
+            Edit a copy
+          </button>
+        ) : (
+          <>
+            <button
+              className="btn ghost xs"
+              onClick={() => onClone(profile)}
+              title="Clone this profile"
+              data-testid={`pf-btn-clone-${profile.name}`}
+            >
+              Clone
+            </button>
+            <button
+              className="btn ghost xs"
+              onClick={() => onEdit(profile)}
+              title="Edit"
+              data-testid={`pf-btn-edit-${profile.name}`}
+            >
+              Edit
+            </button>
+          </>
+        )}
         <button
           className="btn ghost xs danger"
           onClick={() => onDelete(profile)}
@@ -394,6 +414,7 @@ function ProfilesView() {
   // Build initial form values for the drawer
   let formInitial = null;
   let isEdit = false;
+  let formTitle = null;
   if (drawer) {
     if (drawer.mode === 'create') {
       formInitial = { ...BLANK_FORM };
@@ -408,14 +429,20 @@ function ProfilesView() {
       };
       isEdit = true;
     } else if (drawer.mode === 'clone' && drawer.profile) {
+      // Seeds fork via "Edit a copy" (<seed>-custom); custom profiles clone
+      // as <name>-copy. Both record cloned_from provenance on the new profile.
+      const isSeed = !!drawer.profile.seed;
+      const suffix = isSeed ? '-custom' : '-copy';
       formInitial = {
-        name: `${drawer.profile.name}-copy`,
+        name: `${drawer.profile.name}${suffix}`.slice(0, 32),
         image: drawer.profile.image || '',
         flags: drawer.profile.flags || '',
         mtp: !!drawer.profile.mtp,
         device_class: drawer.profile.device_class || '',
+        cloned_from: drawer.profile.name,
       };
       isEdit = false;
+      if (isSeed) formTitle = `Edit a copy · ${drawer.profile.name}`;
     }
   }
 
@@ -482,7 +509,7 @@ function ProfilesView() {
         <ProfileForm
           initial={formInitial}
           isEdit={isEdit}
-          isSeed={drawer.profile?.seed}
+          title={formTitle}
           onClose={closeDrawer}
           onSaved={onSaved}
         />

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -3103,6 +3103,11 @@ select.npu-sel {
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
+.pf-based {
+  font-size: 10px;
+  color: var(--fg-4);
+  font-style: italic;
+}
 .pf-flags {
   font-size: 10px;
   color: var(--fg-4);

--- a/ui/tests/e2e/specs/profiles-crud-v3.spec.ts
+++ b/ui/tests/e2e/specs/profiles-crud-v3.spec.ts
@@ -7,8 +7,11 @@
  * Covers:
  *   - "New profile" button opens the form
  *   - Create flow: fill name/image → submit → POST body asserted → card appears
- *   - Seed immutability: vulkan-std has seed badge, Edit/Delete disabled, Clone present
- *   - Clone flow: Clone on vulkan-std prefills form (name "vulkan-std-copy") → POST
+ *   - Seed cards: seed badge, Delete disabled, single "Edit a copy" action
+ *     (no plain Edit/Clone) — seeds stay immutable, editing forks a custom copy
+ *   - Edit-a-copy flow: prefills name "<seed>-custom", POST carries cloned_from
+ *   - Clone flow (custom cards): prefills "<name>-copy", POST carries cloned_from
+ *   - Provenance: cards with cloned_from show a "based on <source>" line
  *   - Delete flow: custom card Delete → confirm → DELETE fired → 204 → card gone
  *   - Delete-in-use: 409 profiles.in_use → error toast names the slot
  */
@@ -25,6 +28,7 @@ const CUSTOM_PROFILE = {
   resolved_flags: '--flash-attn on',
   device_class: 'gpu',
   seed: false,
+  cloned_from: 'vulkan-std',
 }
 
 const PROFILES_WITH_CUSTOM = [...MOCK_DATA.profiles, CUSTOM_PROFILE]
@@ -36,6 +40,14 @@ async function gotoProfiles(page: any) {
     () => typeof (window as any).ProfilesView === 'function',
   )
   await page.waitForSelector('.pf-card', { timeout: 10_000 })
+}
+
+// Helper: locate a card by its exact slug — hasText would also match cards
+// whose "based on <source>" provenance line names this profile.
+function cardBySlug(page: any, slug: string) {
+  return page.locator('.pf-card').filter({
+    has: page.locator(`.pf-slug:text-is("${slug}")`),
+  })
 }
 
 test.describe('Profiles CRUD — Phase C6', () => {
@@ -123,34 +135,32 @@ test.describe('Profiles CRUD — Phase C6', () => {
     expect(posts).toHaveLength(0)
   })
 
-  // ── Seed immutability ────────────────────────────────────────────────────────
+  // ── Seed cards ───────────────────────────────────────────────────────────────
 
-  test('vulkan-std: seed badge visible, Edit/Delete disabled, Clone present', async ({ page }) => {
+  test('vulkan-std: seed badge, Delete disabled, single enabled "Edit a copy"', async ({ page }) => {
     await gotoProfiles(page)
 
-    const vulkanCard = page.locator('.pf-card', { hasText: 'vulkan-std' })
+    const vulkanCard = cardBySlug(page, 'vulkan-std')
     await expect(vulkanCard).toBeVisible()
 
     // Seed badge.
     await expect(vulkanCard.locator('.pf-badge.immutable')).toBeVisible()
 
-    // Edit button should be disabled.
-    const editBtn = vulkanCard.locator('[data-testid="pf-btn-edit-vulkan-std"]')
-    await expect(editBtn).toBeDisabled()
+    // "Edit a copy" replaces both the disabled Edit and the Clone button.
+    const editCopyBtn = vulkanCard.locator('[data-testid="pf-btn-editcopy-vulkan-std"]')
+    await expect(editCopyBtn).toBeVisible()
+    await expect(editCopyBtn).not.toBeDisabled()
+    await expect(vulkanCard.locator('[data-testid="pf-btn-edit-vulkan-std"]')).toHaveCount(0)
+    await expect(vulkanCard.locator('[data-testid="pf-btn-clone-vulkan-std"]')).toHaveCount(0)
 
     // Delete button should be disabled.
     const deleteBtn = vulkanCard.locator('[data-testid="pf-btn-delete-vulkan-std"]')
     await expect(deleteBtn).toBeDisabled()
-
-    // Clone button should be present and enabled.
-    const cloneBtn = vulkanCard.locator('[data-testid="pf-btn-clone-vulkan-std"]')
-    await expect(cloneBtn).toBeVisible()
-    await expect(cloneBtn).not.toBeDisabled()
   })
 
-  // ── Clone flow ───────────────────────────────────────────────────────────────
+  // ── Edit-a-copy flow (seeds) ─────────────────────────────────────────────────
 
-  test('clone: prefills name as <source>-copy and image/flags; submit POSTs', async ({ page }) => {
+  test('edit a copy: prefills <seed>-custom, POST carries cloned_from', async ({ page }) => {
     const posts: any[] = []
     await page.route('**/api/profiles', async (route) => {
       if (route.request().method() === 'POST') {
@@ -162,26 +172,76 @@ test.describe('Profiles CRUD — Phase C6', () => {
 
     await gotoProfiles(page)
 
-    // Click Clone on vulkan-std.
-    const vulkanCard = page.locator('.pf-card', { hasText: 'vulkan-std' })
-    await vulkanCard.locator('[data-testid="pf-btn-clone-vulkan-std"]').click()
+    const vulkanCard = cardBySlug(page, 'vulkan-std')
+    await vulkanCard.locator('[data-testid="pf-btn-editcopy-vulkan-std"]').click()
     await expect(page.locator('.pf-form-panel')).toBeVisible()
 
-    // Name should be pre-filled as "vulkan-std-copy".
+    // Form is the create flow titled as an edit-a-copy of the seed.
+    await expect(page.locator('.pf-form-title')).toHaveText('Edit a copy · vulkan-std')
+
+    // Name prefilled as "<seed>-custom", editable; image carried over.
     const nameInput = page.locator('[data-testid="pf-input-name"]')
-    await expect(nameInput).toHaveValue('vulkan-std-copy')
+    await expect(nameInput).toHaveValue('vulkan-std-custom')
+    await expect(nameInput).not.toBeDisabled()
+    const imageInput = page.locator('[data-testid="pf-input-image"]')
+    await expect(imageInput).toHaveValue('ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server')
+
+    await page.click('[data-testid="pf-btn-submit"]')
+    await expect(page.locator('.pf-form-panel')).not.toBeVisible({ timeout: 5_000 })
+
+    expect(posts).toHaveLength(1)
+    expect(posts[0].name).toBe('vulkan-std-custom')
+    expect(posts[0].image).toBe('ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server')
+    expect(posts[0].cloned_from).toBe('vulkan-std')
+  })
+
+  // ── Clone flow (custom cards) ────────────────────────────────────────────────
+
+  test('clone: prefills name as <source>-copy; POST carries cloned_from', async ({ page }) => {
+    const posts: any[] = []
+    await page.route('**/api/profiles', async (route) => {
+      if (route.request().method() === 'POST') {
+        try { posts.push(JSON.parse(route.request().postData() || '{}')) } catch { posts.push({}) }
+        return route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({}) })
+      }
+      return json(route, PROFILES_WITH_CUSTOM)
+    })
+
+    await gotoProfiles(page)
+
+    // Click Clone on the custom card (seeds no longer have a Clone button).
+    const customCard = page.locator('.pf-card', { hasText: 'my-custom' })
+    await customCard.locator('[data-testid="pf-btn-clone-my-custom"]').click()
+    await expect(page.locator('.pf-form-panel')).toBeVisible()
+
+    // Name should be pre-filled as "my-custom-copy".
+    const nameInput = page.locator('[data-testid="pf-input-name"]')
+    await expect(nameInput).toHaveValue('my-custom-copy')
 
     // Image should be pre-filled from the source.
     const imageInput = page.locator('[data-testid="pf-input-image"]')
-    await expect(imageInput).toHaveValue('ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server')
+    await expect(imageInput).toHaveValue('ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server')
 
     // Submit.
     await page.click('[data-testid="pf-btn-submit"]')
     await expect(page.locator('.pf-form-panel')).not.toBeVisible({ timeout: 5_000 })
 
     expect(posts).toHaveLength(1)
-    expect(posts[0].name).toBe('vulkan-std-copy')
-    expect(posts[0].image).toBe('ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server')
+    expect(posts[0].name).toBe('my-custom-copy')
+    expect(posts[0].cloned_from).toBe('my-custom')
+  })
+
+  // ── Provenance display ───────────────────────────────────────────────────────
+
+  test('card with cloned_from shows "based on <source>"', async ({ page }) => {
+    await gotoProfiles(page)
+
+    const customCard = cardBySlug(page, 'my-custom')
+    await expect(customCard.locator('.pf-based')).toHaveText(/based on\s+vulkan-std/)
+
+    // Seeds have no provenance line.
+    const vulkanCard = cardBySlug(page, 'vulkan-std')
+    await expect(vulkanCard.locator('.pf-based')).toHaveCount(0)
   })
 
   // ── Delete flow ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

With only seed profiles installed (the default), the Profiles page looks broken: Edit and Delete are disabled on every card, so "you can't edit/delete profiles". Seeds are immutable by design (the install baseline must stay restorable), but the page gave users no path to what they actually wanted — tweaking a profile.

## Change

**Edit-as-clone.** Editing a seed forks it into a custom profile instead of mutating it:

- **Seed cards**: the disabled Edit and the Clone button collapse into a single enabled **"Edit a copy"** — opens the create form prefilled from the seed with name `<seed>-custom` (editable). Delete stays disabled with an explanatory tooltip.
- **Custom cards**: Clone / Edit / Delete unchanged.
- **Provenance**: new optional `cloned_from` field on `ProfileConfig`, `POST /api/profiles`, and `ResolvedProfile`. Clone and edit-a-copy record their source; cards show *based on `<source>`*. Informational only — never resolved or validated against the catalog, not patchable via PUT, omitted from TOML when null (`exclude_none` write path).

No backend behavior change for seed immutability — `profiles.seed_immutable` guards are untouched.

## Tests (TDD, red→green)

- `tests/profiles/test_catalog.py`: cloned_from persists + round-trips profiles.toml, defaults to None, survives PUT updates.
- `tests/api/test_profiles_crud.py`: POST with cloned_from echoed + listed; seeds list `cloned_from: null`.
- `ui/tests/e2e/specs/profiles-crud-v3.spec.ts`: seed card shows single enabled "Edit a copy" (no Edit/Clone testids), edit-a-copy prefills `<seed>-custom` + POSTs cloned_from, custom Clone prefills `<name>-copy` + POSTs cloned_from, provenance line renders.

`pytest tests/profiles tests/api/test_profiles_crud.py tests/api/test_profiles_route.py tests/config tests/capabilities tests/slot_config tests/slot_view tests/model_fit tests/providers` → 600 passed. Playwright profiles specs 18/18. Ruff check + format clean. Clean `vite build` ok.

Follow-up (not in this PR): passive "N slots use <seed>" hint after forking, so users know where to repoint slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)