### PR TITLE
fix(memory): seed Hindsight graph gate from [memory.graph] config

### DIFF
--- a/src/hal0/memory/__init__.py
+++ b/src/hal0/memory/__init__.py
@@ -95,7 +95,12 @@ def provider_from_config(cfg: Any) -> MemoryProvider:
             connect_timeout_s=float(embed.rerank_connect_timeout_s),
             read_timeout_s=float(embed.rerank_read_timeout_s),
         )
-        return HindsightProvider(client=client, reranker=reranker)
+        return HindsightProvider(
+            client=client,
+            reranker=reranker,
+            graph_enabled=bool(graph.enabled),
+            graph_route=str(graph.route),
+        )
 
     if engine == "pgvector":
         return PgVectorProvider()

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -89,12 +89,17 @@ class HindsightProvider(MemoryProvider):
         client: Any,
         client_id: str = "anonymous",
         reranker: Any = None,
+        graph_enabled: bool = False,
+        graph_route: str = "upstream",
     ) -> None:
         self._client = client
         self._client_id = client_id
         self._reranker = reranker
-        self._graph_enabled = False
-        self._graph_route = "upstream"
+        # ADR-0014 gate — reporting-only on this engine (Hindsight builds its
+        # graph natively); seeded from [memory.graph] so graph_status() agrees
+        # with hal0.toml instead of always reading disabled.
+        self._graph_enabled = bool(graph_enabled)
+        self._graph_route = graph_route
         self._rerank_enabled = reranker is not None
 
     @property

--- a/tests/memory/test_provider_factory.py
+++ b/tests/memory/test_provider_factory.py
@@ -73,3 +73,20 @@ def test_factory_default_engine_is_hindsight_after_cutover():
     ):
         provider_from_config(cfg)
         assert mock_cls.called
+
+
+def test_factory_seeds_hindsight_graph_gate_from_config():
+    """hal0.toml [memory.graph] must reach the provider — the dashboard's
+    graph panel reads graph_status() and previously always saw enabled=False
+    regardless of config (config/runtime drift on CT105)."""
+    from hal0.memory.hindsight_provider import HindsightProvider
+
+    cfg = _cfg("hindsight")
+    cfg.memory.graph = SimpleNamespace(enabled=True, route="upstream")
+    with patch("hal0.memory._build_hindsight_client", return_value=object()):
+        provider = provider_from_config(cfg)
+
+    assert isinstance(provider, HindsightProvider)
+    status = provider.graph_status()
+    assert status["enabled"] is True
+    assert status["route"] == "upstream"


### PR DESCRIPTION
Fixes the CT105 config/runtime drift found during the Hindsight-dash recon: `hal0.toml [memory.graph] enabled=true` but `/api/memory/graph/status` reported `enabled: false`. The factory passed graph config to the Cognee branch only; `HindsightProvider` hardcoded the gate off. Reporting-only on this engine (Hindsight builds its graph natively) — seeding from config makes status truthful, no behavior change. TDD: `test_factory_seeds_hindsight_graph_gate_from_config` (red→green); 35 graph/factory/provider tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)