### PR TITLE
fix(memory): MCP hardening — private delete sweep, typed schemas, closed namespaces

### DIFF
--- a/installer/systemd/hindsight-api.service
+++ b/installer/systemd/hindsight-api.service
@@ -29,22 +29,24 @@ Environment=HF_HOME=/var/lib/hal0/memory/hindsight/hf-cache
 # A NON-EMPTY key is required even for a no-auth endpoint (spike gotcha #1).
 Environment=HINDSIGHT_API_LLM_PROVIDER=openai
 Environment=HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:8080/v1
-# [Q5'] RESOLVED on the NPU (frees the iGPU; no in-tree wrap-patch). History:
+# [Q5''] Moved NPU -> utility slot. The [Q5'] NPU rationale (below) predates
+# the podman container runtime: it freed a Lemonade-era iGPU that evicted
+# models on contention. Slots are resident containers now — `utility`
+# (gemma-4-12b-it, iGPU) is always loaded, so routing Hindsight there adds
+# no GTT pressure, and the Memory dashboard (#748) made reflect / mental
+# models / consolidation user-facing: ~2s/turn on utility vs 77-160s on the
+# NPU (FLM serializes, so memory ops also queued behind NPU chat traffic).
+# [Q5'] history, kept for the record:
 #  - qwen3-it-4b-FLM (NPU): ignores response_format -> bare JSON *list* -> rejected.
-#  - gemma-4-26b-a4b-it-q4kxl (iGPU GGUF): returns {"facts":[...]} but contends
-#    with the 35B primary on the iGPU (eviction risk).
-#  - gemma4-it:e2b/e4b (NPU): BLOCKED — amdxdna HWCTX alloc fails (err=-22) on
-#    NPU FW 1.1.2.65 / amdxdna 0.7; Gemma-3n NPU2 arch unsupported by this driver.
-# CHOSEN: gemma3 4B on the NPU (FLM). gemma3 arch loads on this NPU; emits a
-# ```json-fenced {"facts":[...]} which Hindsight's fact_extraction strips +
-# parses. Verified live: retain+recall end-to-end green. Runs on the NPU ->
-# iGPU stays free for the primary (removes the P2-6 eviction risk). Slower
-# (~160s/extract) but retain is async/background so it doesn't block.
-# `hal0/npu` is hal0-api's virtual model name for the npu slot (falls back
-# utility -> chat if the NPU slot is unavailable).
-Environment=HINDSIGHT_API_LLM_MODEL=hal0/npu
+#  - gemma-4-26b-a4b-it-q4kxl (iGPU GGUF): {"facts":[...]} ok but Lemonade-era
+#    eviction risk vs the 35B primary (obsolete under container runtime).
+#  - gemma4-it:e2b/e4b (NPU): BLOCKED — amdxdna HWCTX alloc fails (err=-22).
+#  - gemma3 4B NPU (FLM): worked but ~160s/extract + reflect timeouts.
+# `hal0/utility` is hal0-api's virtual model name for the utility slot
+# (falls back chat if unavailable).
+Environment=HINDSIGHT_API_LLM_MODEL=hal0/utility
 Environment=HINDSIGHT_API_LLM_API_KEY=hal0-local-noauth
-# NPU extraction is slow (~160s incl. first-call trio load). Generous timeout.
+# Generous timeout retained: covers utility-slot cold starts + long reflects.
 Environment=HINDSIGHT_API_LLM_TIMEOUT=300
 
 # Embeddings + reranker are LOCAL (bundled BGE 384-d + MiniLM cross-encoder) —

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -309,7 +309,11 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
 
 @router.post("/add")
 async def memory_add(request: Request) -> dict[str, Any]:
-    """Add a memory item. Body: ``{text, dataset?, tags?, metadata?}``.
+    """Add a memory item. Body: ``{text, dataset?, tags?, metadata?, document_id?}``.
+
+    Returns ``{id, timestamp}`` plus ``operation_id`` when the engine
+    ingests asynchronously (Hindsight retain). Reuse ``document_id``
+    across calls to upsert one logical document.
 
     Identity headers (issue #317):
 
@@ -353,6 +357,15 @@ async def memory_add(request: Request) -> dict[str, Any]:
     except MemoryNamespaceError as exc:
         raise MemoryNamespaceInvalid(str(exc)) from exc
 
+    document_id = body.get("document_id")
+    if document_id is not None and (
+        not isinstance(document_id, str) or not _AGENT_ID_PATTERN.match(document_id)
+    ):
+        raise BadRequest(
+            "memory_add 'document_id' must match the identity grammar (alnum/-/_ ≤64 chars)",
+            details={"path": "/api/memory/add"},
+        )
+
     wrapper = _wrapper(request)
     return await wrapper.add(
         text=text,
@@ -361,6 +374,7 @@ async def memory_add(request: Request) -> dict[str, Any]:
         source=agent_id,
         metadata=body.get("metadata") or {},
         client_id=agent_id if agent_id != "anonymous" else None,
+        document_id=document_id,
     )
 
 
@@ -486,12 +500,14 @@ async def memory_list(
 
 @router.post("/delete")
 async def memory_delete(request: Request) -> dict[str, int]:
-    """Delete by id. Body: ``{ids: [...]}``. Returns ``{deleted: int}``.
+    """Delete by id. Body: ``{ids: [...], dataset?}``. Returns ``{deleted: int}``.
 
-    Identity headers are not consulted: id-scoped delete bypasses the
-    namespace surface entirely (the wrapper's audit log still stamps
-    the call with the agent identity for forensics — see
-    :meth:`CogneeWrapper._audit`).
+    ``dataset`` optionally directs the engine's bank sweep (e.g.
+    ``project:<id>`` items live outside the default shared + own-private
+    sweep). Identity headers otherwise are not consulted: id-scoped
+    delete bypasses the namespace surface entirely (the wrapper's audit
+    log still stamps the call with the agent identity for forensics —
+    see :meth:`CogneeWrapper._audit`).
     """
     body = await _read_json_body(request)
     ids = body.get("ids")
@@ -501,10 +517,27 @@ async def memory_delete(request: Request) -> dict[str, int]:
             details={"path": "/api/memory/delete"},
         )
     agent_id = _agent_id(request)
+    private = _is_private(request)
+    requested = body.get("dataset")
+    dataset: str | list[str] | None
+    if requested is None or (isinstance(requested, str) and not requested.strip()):
+        dataset = None
+    elif isinstance(requested, list):
+        dataset = [str(d) for d in requested]
+    else:
+        try:
+            dataset = resolve_write_dataset(
+                str(requested),
+                private=private,
+                client_id=agent_id if agent_id != "anonymous" else None,
+            )
+        except MemoryNamespaceError as exc:
+            raise MemoryNamespaceInvalid(str(exc)) from exc
     wrapper = _wrapper(request)
     return await wrapper.delete(
         ids=ids,
         client_id=agent_id if agent_id != "anonymous" else None,
+        dataset=dataset,
     )
 
 

--- a/src/hal0/mcp/memory.py
+++ b/src/hal0/mcp/memory.py
@@ -20,12 +20,14 @@ Tool catalog (ADR-0005 §2)
 Per ADR-0005 §2 the v0.2 schema is rich from day 1 so we don't pay a
 schema-versioning tax in Phase 9::
 
-    memory_add(text, dataset="shared", tags=[], metadata={})
-        → {id: str, timestamp: iso8601}
+    memory_add(text, dataset="shared", tags=[], metadata={},
+               document_id=null)
+        → {id: str, timestamp: iso8601, operation_id?: str}
         # `source` is auto-extracted server-side from the caller's
         # client_id (Bearer-derived). Clients CANNOT pass `source`
         # themselves — that's how ADR-0005 §5 keeps the audit trail
-        # forensically grounded.
+        # forensically grounded. `document_id` reuse upserts one
+        # logical document; `operation_id` surfaces async ingestion.
 
     memory_search(query, limit=10, dataset="shared"|list, tags=[],
                   before=null, after=null)
@@ -35,7 +37,7 @@ schema-versioning tax in Phase 9::
     memory_list(dataset="shared", cursor=null, limit=50)
         → {items: [...], next_cursor: str | null}
 
-    memory_delete(ids: list[str])
+    memory_delete(ids: list[str], dataset=null)
         → {deleted: int}
 
 Namespace rule (ADR-0005 §3): writes default to dataset ``shared``;
@@ -61,6 +63,7 @@ mounts at ``/mcp/memory`` via ``app.mount()``.
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from typing import Any
 
@@ -96,6 +99,11 @@ log = structlog.get_logger(__name__)
 
 class MemorySchemaError(ValueError):
     """Raised when a memory tool call's args don't match the ADR-0005 §2 schema."""
+
+
+# document_id becomes a URL path segment on the engine's documents API —
+# same bounded grammar as agent ids (ADR-0005 §5) keeps it traversal-free.
+_AGENT_ID_LIKE = re.compile(r"^[a-zA-Z0-9_\-]{1,64}$")
 
 
 def _require(args: dict[str, Any], key: str, type_: type) -> Any:
@@ -174,7 +182,8 @@ async def _memory_add(
     client_id: str | None,
     private: bool,
 ) -> dict[str, Any]:
-    """memory_add(text, dataset?, tags?, metadata?) → {id, timestamp}.
+    """memory_add(text, dataset?, tags?, metadata?, document_id?)
+    → {id, timestamp, operation_id?}.
 
     ADR-0005 §2 schema:
       - ``text``: required, non-empty str.
@@ -182,14 +191,15 @@ async def _memory_add(
         to ``private:<client_id>``.
       - ``tags``: defaults to ``[]``.
       - ``metadata``: defaults to ``{}``.
+      - ``document_id``: optional engine grouping key — reuse one id
+        across adds to upsert the same logical document (conversation
+        evolution). Same identity grammar as agent ids.
       - ``source``: NOT accepted from the caller. Server-injected from
         ``client_id`` so callers cannot lie about their identity
         (ADR-0005 §5 audit grounding).
 
-    CogneeWrapper contract::
-
-        await wrapper.add(text, dataset, tags, source, metadata)
-            -> {"id": str, "timestamp": iso8601_str}
+    ``operation_id`` appears when the engine ingests asynchronously
+    (Hindsight retain) — poll it via the engine-admin operations surface.
     """
     text = _require(args, "text", str)
     if not text.strip():
@@ -206,6 +216,9 @@ async def _memory_add(
         raise MemorySchemaError(
             "source is server-injected from client_id and cannot be supplied by callers"
         )
+    document_id = _optional(args, "document_id", str)
+    if document_id is not None and not _AGENT_ID_LIKE.match(document_id):
+        raise MemorySchemaError("document_id must match the identity grammar (alnum/-/_ ≤64 chars)")
     source = client_id or "anonymous"
     result = await wrapper.add(
         text=text,
@@ -214,11 +227,15 @@ async def _memory_add(
         source=source,
         metadata=metadata_raw,
         client_id=client_id,
+        document_id=document_id,
     )
-    return {
+    out = {
         "id": result["id"],
         "timestamp": result.get("timestamp") or _iso_now(),
     }
+    if result.get("operation_id"):
+        out["operation_id"] = result["operation_id"]
+    return out
 
 
 async def _memory_search(
@@ -303,18 +320,30 @@ async def _memory_delete(
     client_id: str | None,
     private: bool,
 ) -> dict[str, Any]:
-    """memory_delete(ids) → {deleted: int}.
+    """memory_delete(ids, dataset?) → {deleted: int}.
 
     Returns the count of deleted rows per ADR-0005 §2. ``ids`` must be
-    non-empty. Approval-gating for bulk deletes (>1 id) lives in
-    :mod:`hal0.mcp.admin`; by the time we get here it has already been
-    approved (or is a single-id autonomous call).
+    non-empty. ``dataset`` optionally directs the engine's bank sweep
+    (e.g. ``project:<id>`` items live outside the default
+    shared + own-private sweep). Approval-gating for bulk deletes
+    (>1 id) lives in :mod:`hal0.mcp.admin`; by the time we get here it
+    has already been approved (or is a single-id autonomous call).
     """
     ids_raw = args.get("ids")
     if not isinstance(ids_raw, list) or not ids_raw:
         raise MemorySchemaError("ids must be a non-empty list[str]")
     ids = [str(i) for i in ids_raw]
-    result = await wrapper.delete(ids=ids, client_id=client_id)
+    requested = args.get("dataset")
+    dataset: str | list[str] | None
+    if requested is None or (isinstance(requested, str) and not requested.strip()):
+        dataset = None
+    elif isinstance(requested, list):
+        dataset = [str(d) for d in requested]
+    elif isinstance(requested, str):
+        dataset = _resolve_dataset(requested, private=private, client_id=client_id)
+    else:
+        raise MemorySchemaError("dataset must be str | list[str] | null")
+    result = await wrapper.delete(ids=ids, client_id=client_id, dataset=dataset)
     deleted_raw = result.get("deleted", len(ids))
     # Accept either a count or the list of deleted ids from the wrapper
     # so we're forgiving of either contract while still returning the
@@ -423,14 +452,28 @@ def make_dispatcher(
                 "status": "error",
                 "error": {"code": "mcp.memory_schema", "detail": str(exc)},
             }
-        except Exception as exc:  # pragma: no cover — surfaced to client
+        except Exception as exc:
             log.warning("mcp.memory.failed", tool=tool, error=str(exc))
             return {
                 "status": "error",
-                "error": {"code": "mcp.memory_failed", "detail": str(exc)},
+                "error": {"code": "mcp.memory_failed", "detail": _scrub_detail(exc)},
             }
 
     return _dispatch
+
+
+_URL_RE = re.compile(r"https?://\S+")
+
+
+def _scrub_detail(exc: Exception) -> str:
+    """Client-safe error detail: engine URLs (httpx repeats the full
+    internal request URL in HTTPStatusError messages) are not the
+    caller's business — redact them, keep the rest of the message."""
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if isinstance(status, int):
+        return f"memory engine returned HTTP {status}"
+    return _URL_RE.sub("<engine>", str(exc))
 
 
 # ── Tool annotations (mcp-builder Phase 2.3) ─────────────────────────────────
@@ -489,26 +532,134 @@ def build_server(
         private_resolver=private_resolver,
     )
 
-    def _register(tool: str, description: str) -> None:
-        async def _tool(args: dict[str, Any] | None = None) -> dict[str, Any]:
-            return await dispatcher(tool, args or {})
+    # Typed signatures so FastMCP publishes real parameter schemas —
+    # the old single ``args: dict`` param advertised an opaque object
+    # and every client had to guess the call shape from docs. The
+    # trailing ``args`` param keeps the legacy envelope working:
+    # explicit params win over same-named ``args`` keys.
 
-        _tool.__name__ = tool
-        _tool.__doc__ = description
-        annotations = _ANNOTATIONS.get(tool)
-        server.tool(name=tool, description=description, annotations=annotations)(_tool)
+    def _merged(args: dict[str, Any] | None, **explicit: Any) -> dict[str, Any]:
+        merged = dict(args or {})
+        merged.update({k: v for k, v in explicit.items() if v is not None})
+        return merged
 
-    _register("memory_add", "Add an item to long-term memory.")
-    _register("memory_search", "Search long-term memory.")
-    _register("memory_list", "Page through long-term memory items.")
-    _register(
-        "memory_delete",
-        "Delete one or more memory items by id (bulk deletes gate at admin layer).",
+    @server.tool(
+        name="memory_add",
+        description=(
+            "Add an item to long-term memory. Returns {id, timestamp} plus "
+            "operation_id when ingestion is asynchronous. Reuse document_id "
+            "across calls to upsert one logical document (e.g. a conversation)."
+        ),
+        annotations=_ANNOTATIONS["memory_add"],
     )
-    _register(
-        "memory_recall",
-        "Recall token-budgeted, consolidated memory (preferred over search).",
+    async def memory_add(
+        text: str | None = None,
+        dataset: str | None = None,
+        tags: list[str] | str | None = None,
+        metadata: dict[str, Any] | None = None,
+        document_id: str | None = None,
+        args: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return await dispatcher(
+            "memory_add",
+            _merged(
+                args,
+                text=text,
+                dataset=dataset,
+                tags=tags,
+                metadata=metadata,
+                document_id=document_id,
+            ),
+        )
+
+    @server.tool(
+        name="memory_search",
+        description="Search long-term memory. Returns {results: [...]}.",
+        annotations=_ANNOTATIONS["memory_search"],
     )
+    async def memory_search(
+        query: str | None = None,
+        limit: int | None = None,
+        dataset: str | list[str] | None = None,
+        tags: list[str] | str | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        args: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return await dispatcher(
+            "memory_search",
+            _merged(
+                args,
+                query=query,
+                limit=limit,
+                dataset=dataset,
+                tags=tags,
+                before=before,
+                after=after,
+            ),
+        )
+
+    @server.tool(
+        name="memory_list",
+        description="Page through long-term memory items. Returns {items, next_cursor}.",
+        annotations=_ANNOTATIONS["memory_list"],
+    )
+    async def memory_list(
+        dataset: str | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
+        args: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return await dispatcher(
+            "memory_list",
+            _merged(args, dataset=dataset, cursor=cursor, limit=limit),
+        )
+
+    @server.tool(
+        name="memory_delete",
+        description=(
+            "Delete one or more memory items by id (bulk deletes gate at admin "
+            "layer). dataset optionally directs the sweep (e.g. project:<id>)."
+        ),
+        annotations=_ANNOTATIONS["memory_delete"],
+    )
+    async def memory_delete(
+        ids: list[str] | None = None,
+        dataset: str | list[str] | None = None,
+        args: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return await dispatcher(
+            "memory_delete",
+            _merged(args, ids=ids, dataset=dataset),
+        )
+
+    @server.tool(
+        name="memory_recall",
+        description=(
+            "Recall token-budgeted, consolidated memory (preferred over search). "
+            "types defaults to world+experience+observation."
+        ),
+        annotations=_ANNOTATIONS["memory_recall"],
+    )
+    async def memory_recall(
+        query: str | None = None,
+        max_tokens: int | None = None,
+        types: list[str] | None = None,
+        dataset: str | list[str] | None = None,
+        tags: list[str] | str | None = None,
+        args: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return await dispatcher(
+            "memory_recall",
+            _merged(
+                args,
+                query=query,
+                max_tokens=max_tokens,
+                types=types,
+                dataset=dataset,
+                tags=tags,
+            ),
+        )
 
     return server
 

--- a/src/hal0/memory/cognee_wrapper.py
+++ b/src/hal0/memory/cognee_wrapper.py
@@ -522,8 +522,13 @@ class CogneeWrapper(MemoryProvider):
         source: str | None = None,
         metadata: dict[str, Any] | None = None,
         client_id: str | None = None,
+        document_id: str | None = None,
     ) -> dict[str, str]:
         """Add a memory item. Returns ``{id, timestamp}``.
+
+        ``document_id`` (engine-neutral upsert key) has no Cognee
+        equivalent — accepted for ABC parity, used as the item id when
+        supplied so delete round-trips.
 
         ``dataset`` is the caller-requested namespace; when
         ``private_mode=True`` is on the instance, ANY value here is
@@ -549,7 +554,7 @@ class CogneeWrapper(MemoryProvider):
         effective_client_id = client_id or self._client_id
         effective_dataset = self._effective_write_dataset(dataset)
         effective_source = source or effective_client_id
-        item_id = str(uuid.uuid4())
+        item_id = document_id or str(uuid.uuid4())
         timestamp = _now_iso()
 
         cognee = _cognee()
@@ -974,8 +979,17 @@ class CogneeWrapper(MemoryProvider):
         )
         return {"items": items, "next_cursor": next_cursor}
 
-    async def delete(self, ids: list[str], *, client_id: str | None = None) -> dict[str, int]:
+    async def delete(
+        self,
+        ids: list[str],
+        *,
+        client_id: str | None = None,
+        dataset: str | list[str] | None = None,
+    ) -> dict[str, int]:
         """Delete by sidecar id. Returns ``{deleted: int}``.
+
+        ``dataset`` is accepted for ABC parity (Hindsight bank-sweep
+        narrowing); sidecar rows are id-addressed here so it is unused.
 
         We delete from BOTH the sidecar AND Cognee's own dataset rows
         (via ``cognee.datasets.delete_data``) — but only wipe a Cognee

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -82,6 +82,23 @@ def _now() -> str:
     return datetime.now(UTC).isoformat()
 
 
+def _http_status(exc: Exception) -> int | None:
+    """Status code of an httpx.HTTPStatusError-shaped exception, else None.
+
+    Duck-typed (``exc.response.status_code``) so the fake clients in tests
+    don't need httpx to exercise the 404-sweep behavior."""
+    response = getattr(exc, "response", None)
+    code = getattr(response, "status_code", None)
+    return int(code) if isinstance(code, int) else None
+
+
+# Hindsight recall defaults to world+experience when ``types`` is omitted,
+# which silently hides the consolidated observation layer — the highest-value
+# tier (deduplicated, evidence-grounded beliefs). hal0's default includes it;
+# callers can still narrow with an explicit ``types``.
+_DEFAULT_RECALL_TYPES = ("world", "experience", "observation")
+
+
 class HindsightProvider(MemoryProvider):
     def __init__(
         self,
@@ -140,14 +157,18 @@ class HindsightProvider(MemoryProvider):
         source: str | None = None,
         metadata: dict[str, Any] | None = None,
         client_id: str | None = None,
+        document_id: str | None = None,
     ) -> dict[str, str]:
         ns = self._write_namespace(dataset, client_id)
         bank = namespace_to_bank(ns)
-        document_id = str(uuid.uuid4())  # the join key
+        # The join key. Caller-supplied → Hindsight upserts the same
+        # logical document across adds (conversation evolution); absent →
+        # fresh document per call.
+        document_id = document_id or str(uuid.uuid4())
         meta = dict(metadata or {})
         if source:
             meta["source"] = source
-        await self._client.retain(
+        resp = await self._client.retain(
             bank_id=bank,
             content=text,
             document_id=document_id,
@@ -156,7 +177,14 @@ class HindsightProvider(MemoryProvider):
             tags=list(tags or []),
             timestamp=None,
         )
-        return {"id": document_id, "timestamp": _now()}
+        out = {"id": document_id, "timestamp": _now()}
+        # retain is async on this engine — surface the operation id so
+        # callers (dashboard ingestion indicator, CLI) can poll instead of
+        # wondering why list doesn't show the item yet.
+        operation_id = (resp or {}).get("operation_id") if isinstance(resp, dict) else None
+        if operation_id:
+            out["operation_id"] = str(operation_id)
+        return out
 
     async def search(
         self,
@@ -215,14 +243,31 @@ class HindsightProvider(MemoryProvider):
             "type": fact.get("fact_type"),
         }
 
-    async def delete(self, ids: list[str], *, client_id: str | None = None) -> dict[str, int]:
+    async def delete(
+        self,
+        ids: list[str],
+        *,
+        client_id: str | None = None,
+        dataset: str | list[str] | None = None,
+    ) -> dict[str, int]:
         deleted = 0
-        # We don't know which bank each document_id lives in without a lookup;
-        # try the caller's allowed banks. delete_document is idempotent.
-        banks = [namespace_to_bank(ns) for ns in self._allowed_namespaces(_SHARED, client_id)]
+        # We don't know which bank each document_id lives in without a
+        # lookup; try the caller's allowed banks. Hindsight 404s a missing
+        # document (NOT idempotent-200), so a per-bank probe that misses
+        # must continue the sweep — previously the first 404 aborted the
+        # whole call, which made every private-bank item undeletable
+        # (the shared bank is probed first and always 404'd).
+        banks = [
+            namespace_to_bank(ns) for ns in self._allowed_namespaces(dataset or _SHARED, client_id)
+        ]
         for document_id in ids:
             for bank in banks:
-                res = await self._client.delete_document(bank_id=bank, document_id=document_id)
+                try:
+                    res = await self._client.delete_document(bank_id=bank, document_id=document_id)
+                except Exception as exc:
+                    if _http_status(exc) == 404:
+                        continue  # not in this bank — keep sweeping
+                    raise
                 if int(res.get("memory_units_deleted", 0)) > 0:
                     deleted += 1
                     break
@@ -250,10 +295,11 @@ class HindsightProvider(MemoryProvider):
         banks = [namespace_to_bank(ns) for ns in self._allowed_namespaces(dataset, client_id)]
         if not banks:
             return []
+        effective_types = list(types) if types else list(_DEFAULT_RECALL_TYPES)
 
         async def _one(bank: str) -> list[dict[str, Any]]:
             resp = await self._client.recall(
-                bank_id=bank, query=query, types=types, max_tokens=max_tokens, tags=tags
+                bank_id=bank, query=query, types=effective_types, max_tokens=max_tokens, tags=tags
             )
             return [self._fact_to_item(f, bank) for f in resp.get("results", [])]
 

--- a/src/hal0/memory/namespace.py
+++ b/src/hal0/memory/namespace.py
@@ -2,7 +2,7 @@
 
 The MCP server (:mod:`hal0.mcp.memory`) and the REST shims
 (:mod:`hal0.api.routes.memory`) both translate caller-supplied
-``dataset`` + identity context into the effective Cognee dataset name.
+``dataset`` + identity context into the effective dataset name.
 Keeping that logic in one place ensures the two surfaces can't drift —
 issue #317 surfaced exactly that kind of drift, where the REST handler
 hardcoded ``"shared"`` while the MCP dispatcher correctly honored
@@ -19,23 +19,52 @@ The rule (ADR-0005 §3):
     without having to opt in per-call.
   - Requesting ``private`` without an authenticated ``client_id`` is
     a usage error — the namespace promotion has no identity to scope to.
+  - The namespace set is CLOSED (spec §3 table): ``shared`` | ``agents``
+    | ``project:<id>`` | the caller's own ``private:<client_id>``.
+    Free-form names used to pass through verbatim, which let any caller
+    read/write arbitrary engine banks (and made the items undeletable
+    through the id-scoped delete sweep). Writes to unknown namespaces
+    now raise; reads silently drop them — matching the foreign-private
+    fail-open-empty posture so multi-namespace reads degrade instead of
+    erroring.
 
-This module is intentionally tiny: just two pure functions + the
+This module is intentionally tiny: pure functions + the
 ``MemoryNamespaceError`` sentinel. The wrapper-level enforcement
 (rejecting cross-client writes, intersecting read scopes) still lives
-in :mod:`hal0.memory.cognee_wrapper` — this layer is for transport-side
-resolution only.
+in the active provider — this layer is for transport-side resolution.
 """
 
 from __future__ import annotations
 
+import re
+
 DEFAULT_DATASET = "shared"
+AGENTS_DATASET = "agents"
 PRIVATE_PREFIX = "private:"
+PROJECT_PREFIX = "project:"
+
+# Spec §3 namespace grammar — the scoped suffix after ``project:`` follows
+# the same identity rules as agent ids (ADR-0005 §5): alnum + ``-`` + ``_``,
+# ≤64 chars, so bank names derived from it stay path-traversal-free.
+_SCOPED_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_\-]{1,64}$")
 
 
 class MemoryNamespaceError(ValueError):
     """Raised when namespace resolution can't be satisfied (e.g. private
-    requested without an authenticated client_id)."""
+    requested without an authenticated client_id, or an unknown
+    namespace on a write)."""
+
+
+def is_known_namespace(name: str, *, client_id: str | None = None) -> bool:
+    """Spec §3 table membership: ``shared`` | ``agents`` | ``project:<id>``
+    | the caller's own ``private:<client_id>``."""
+    if name in (DEFAULT_DATASET, AGENTS_DATASET):
+        return True
+    if name.startswith(PROJECT_PREFIX):
+        return bool(_SCOPED_ID_PATTERN.match(name[len(PROJECT_PREFIX) :]))
+    if name.startswith(PRIVATE_PREFIX):
+        return client_id is not None and name == f"{PRIVATE_PREFIX}{client_id}"
+    return False
 
 
 def resolve_write_dataset(
@@ -44,7 +73,7 @@ def resolve_write_dataset(
     private: bool,
     client_id: str | None,
 ) -> str:
-    """Translate a write request into the effective Cognee dataset name.
+    """Translate a write request into the effective dataset name.
 
     Mirrors :func:`hal0.mcp.memory._resolve_dataset` (which delegates
     here) — the docstring rule from ADR-0005 §3 applies:
@@ -58,7 +87,9 @@ def resolve_write_dataset(
         namespace by passing the prefix in the body — the toggle is
         the only path in. Surfaces as 400 at the transport layer
         instead of silently being forwarded to the wrapper.
-      - Otherwise the requested string is passed through verbatim.
+      - ``requested`` outside the spec §3 namespace table →
+        ``MemoryNamespaceError`` (closed-set hardening; see module
+        docstring).
     """
     if private:
         if not client_id:
@@ -70,6 +101,11 @@ def resolve_write_dataset(
         raise MemoryNamespaceError(
             "non-private callers cannot address the private namespace by name; "
             "send X-hal0-Private: 1 (REST) or private=true (MCP) instead"
+        )
+    if not is_known_namespace(requested, client_id=client_id):
+        raise MemoryNamespaceError(
+            f"unknown namespace {requested!r}; writes accept 'shared', 'agents', "
+            "or 'project:<id>' (private goes through the private-mode toggle)"
         )
     return requested
 
@@ -84,8 +120,10 @@ def resolve_read_datasets(
 
     Mirrors the read branch from :func:`hal0.mcp.memory._memory_search`:
 
-      - ``requested`` already a list → pass through (caller knows what
-        they want; the wrapper still intersects against the read scope).
+      - ``requested`` already a list → filtered against the spec §3
+        namespace table (unknown / foreign-private entries are dropped,
+        fail-open-empty — the provider applies the same rule, this keeps
+        the contract visible at the front door).
       - ``requested`` empty/``None`` + ``private`` + ``client_id`` →
         expand to ``[shared, private:<client_id>]`` per §3.
       - ``requested`` empty/``None`` otherwise → :data:`DEFAULT_DATASET`.
@@ -95,7 +133,7 @@ def resolve_read_datasets(
         consistent with the write side).
     """
     if isinstance(requested, list):
-        return [str(d) for d in requested]
+        return [str(d) for d in requested if is_known_namespace(str(d), client_id=client_id)]
     if requested is None or (isinstance(requested, str) and not requested.strip()):
         if private and client_id:
             return [DEFAULT_DATASET, f"{PRIVATE_PREFIX}{client_id}"]
@@ -104,9 +142,12 @@ def resolve_read_datasets(
 
 
 __all__ = [
+    "AGENTS_DATASET",
     "DEFAULT_DATASET",
     "PRIVATE_PREFIX",
+    "PROJECT_PREFIX",
     "MemoryNamespaceError",
+    "is_known_namespace",
     "resolve_read_datasets",
     "resolve_write_dataset",
 ]

--- a/src/hal0/memory/pgvector_provider.py
+++ b/src/hal0/memory/pgvector_provider.py
@@ -48,9 +48,18 @@ class PgVectorProvider(MemoryProvider):
         return out
 
     async def add(
-        self, text, dataset=_SHARED, tags=None, source=None, metadata=None, client_id=None
+        self,
+        text,
+        dataset=_SHARED,
+        tags=None,
+        source=None,
+        metadata=None,
+        client_id=None,
+        document_id=None,
     ):
-        item_id = str(uuid.uuid4())
+        # No document semantics on this engine — a caller-supplied
+        # document_id just becomes the item id so delete round-trips.
+        item_id = document_id or str(uuid.uuid4())
         ts = _now()
         self._rows.append(
             {
@@ -101,7 +110,9 @@ class PgVectorProvider(MemoryProvider):
             "next_cursor": None,
         }
 
-    async def delete(self, ids, *, client_id=None):
+    async def delete(self, ids, *, client_id=None, dataset=None):
+        # dataset narrowing is a Hindsight-bank concept; rows here carry
+        # their namespace inline, so the id match is already scoped.
         before = len(self._rows)
         self._rows = [r for r in self._rows if r["id"] not in set(ids)]
         return {"deleted": before - len(self._rows)}

--- a/src/hal0/memory/provider.py
+++ b/src/hal0/memory/provider.py
@@ -130,8 +130,16 @@ class MemoryProvider(ABC):
         source: str | None = None,
         metadata: dict[str, Any] | None = None,
         client_id: str | None = None,
+        document_id: str | None = None,
     ) -> dict[str, str]:
-        """Add a memory item. Returns ``{id, timestamp}``."""
+        """Add a memory item. Returns ``{id, timestamp}`` plus
+        ``operation_id`` when the engine processes asynchronously (poll
+        it via the engine-admin operations surface).
+
+        ``document_id`` lets a caller pin the engine's grouping key —
+        re-using one id across adds upserts the same logical document
+        (conversation evolution). ``None`` → a fresh id per call.
+        Engines without document semantics ignore it."""
 
     @abstractmethod
     async def search(
@@ -158,8 +166,18 @@ class MemoryProvider(ABC):
         """Paginated list. Returns ``{items, next_cursor}``."""
 
     @abstractmethod
-    async def delete(self, ids: list[str], *, client_id: str | None = None) -> dict[str, int]:
-        """Delete by id. Returns ``{deleted: int}``."""
+    async def delete(
+        self,
+        ids: list[str],
+        *,
+        client_id: str | None = None,
+        dataset: str | list[str] | None = None,
+    ) -> dict[str, int]:
+        """Delete by id. Returns ``{deleted: int}``.
+
+        ``dataset`` optionally narrows (or widens, e.g. ``project:<id>``)
+        the namespaces swept for each id; ``None`` keeps the default
+        sweep of ``shared`` + the caller's own private namespace."""
 
     @abstractmethod
     def graph_status(self) -> dict[str, Any]:

--- a/tests/api/test_memory_rest_routes.py
+++ b/tests/api/test_memory_rest_routes.py
@@ -58,6 +58,7 @@ class StubWrapper:
         source: str | None,
         metadata: dict[str, Any],
         client_id: str | None = None,
+        document_id: str | None = None,
     ) -> dict[str, Any]:
         self.add_calls.append(
             {
@@ -67,10 +68,11 @@ class StubWrapper:
                 "source": source,
                 "metadata": metadata,
                 "client_id": client_id,
+                "document_id": document_id,
             }
         )
         self._counter += 1
-        return {"id": f"id-{self._counter}", "timestamp": "2026-05-28T00:00:00Z"}
+        return {"id": document_id or f"id-{self._counter}", "timestamp": "2026-05-28T00:00:00Z"}
 
     async def search(self, **kwargs: Any) -> list[dict[str, Any]]:
         self.search_calls.append(kwargs)
@@ -80,8 +82,14 @@ class StubWrapper:
         self.list_calls.append(kwargs)
         return {"items": [{"id": "id-1"}], "next_cursor": None}
 
-    async def delete(self, *, ids: list[str], client_id: str | None = None) -> dict[str, Any]:
-        self.delete_calls.append({"ids": list(ids), "client_id": client_id})
+    async def delete(
+        self,
+        *,
+        ids: list[str],
+        client_id: str | None = None,
+        dataset: str | list[str] | None = None,
+    ) -> dict[str, Any]:
+        self.delete_calls.append({"ids": list(ids), "client_id": client_id, "dataset": dataset})
         return {"deleted": len(ids)}
 
 
@@ -292,7 +300,9 @@ def test_delete_passes_ids_unchanged(client: TestClient, stub_wrapper: StubWrapp
         headers={"X-hal0-Agent": "hermes-agent", "X-hal0-Private": "1"},
     )
     assert r.status_code == 200, r.text
-    assert stub_wrapper.delete_calls == [{"ids": ["a", "b"], "client_id": "hermes-agent"}]
+    assert stub_wrapper.delete_calls == [
+        {"ids": ["a", "b"], "client_id": "hermes-agent", "dataset": None}
+    ]
     assert r.json() == {"deleted": 2}
 
 
@@ -492,3 +502,62 @@ def test_anonymous_call_passes_no_client_id(client: TestClient, stub_wrapper: St
     assert r.status_code == 200, r.text
     ac = stub_wrapper.add_calls[-1]
     assert ac["client_id"] is None
+
+
+# ── PR: document_id upsert, delete dataset sweep, closed namespaces ─────────
+
+
+def test_add_document_id_passes_through(client: TestClient, stub_wrapper: StubWrapper) -> None:
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "turn 2", "document_id": "conv-42"},
+        headers={"X-hal0-Agent": "hermes-agent"},
+    )
+    assert r.status_code == 200, r.text
+    assert stub_wrapper.add_calls[0]["document_id"] == "conv-42"
+    assert r.json()["id"] == "conv-42"
+
+
+def test_add_document_id_bad_grammar_rejected(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "x", "document_id": "../escape"},
+        headers={"X-hal0-Agent": "hermes-agent"},
+    )
+    assert r.status_code == 400, r.text
+    assert not stub_wrapper.add_calls
+
+
+def test_add_unknown_namespace_rejected(client: TestClient, stub_wrapper: StubWrapper) -> None:
+    """Free-form dataset names no longer pass through to arbitrary engine banks."""
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "x", "dataset": "smoke-gemma4-e4b-v2"},
+        headers={"X-hal0-Agent": "hermes-agent"},
+    )
+    assert r.status_code == 400, r.text
+    assert not stub_wrapper.add_calls
+
+
+def test_delete_dataset_directs_sweep(client: TestClient, stub_wrapper: StubWrapper) -> None:
+    r = client.post(
+        "/api/memory/delete",
+        json={"ids": ["d1"], "dataset": "project:apollo"},
+        headers={"X-hal0-Agent": "hermes-agent"},
+    )
+    assert r.status_code == 200, r.text
+    assert stub_wrapper.delete_calls[0]["dataset"] == "project:apollo"
+
+
+def test_delete_without_dataset_keeps_default_sweep(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    r = client.post(
+        "/api/memory/delete",
+        json={"ids": ["d1"]},
+        headers={"X-hal0-Agent": "hermes-agent"},
+    )
+    assert r.status_code == 200, r.text
+    assert stub_wrapper.delete_calls[0]["dataset"] is None

--- a/tests/mcp/test_mcp_mount_private_header.py
+++ b/tests/mcp/test_mcp_mount_private_header.py
@@ -92,6 +92,7 @@ class _RecordingWrapper:
         source: str,
         metadata: dict[str, Any],
         client_id: str | None = None,
+        document_id: str | None = None,
     ) -> dict[str, Any]:
         self.add_calls.append(
             {"text": text, "dataset": dataset, "source": source, "client_id": client_id}

--- a/tests/mcp/test_memory.py
+++ b/tests/mcp/test_memory.py
@@ -35,6 +35,7 @@ class _FakeWrapper:
         source: str,
         metadata: dict[str, Any],
         client_id: str | None = None,
+        document_id: str | None = None,
     ) -> dict[str, Any]:
         self.add_calls.append(
             {
@@ -44,10 +45,11 @@ class _FakeWrapper:
                 "source": source,
                 "metadata": metadata,
                 "client_id": client_id,
+                "document_id": document_id,
             }
         )
         self._counter += 1
-        return {"id": f"id-{self._counter}", "timestamp": "2026-05-22T00:00:00Z"}
+        return {"id": document_id or f"id-{self._counter}", "timestamp": "2026-05-22T00:00:00Z"}
 
     async def search(self, **kwargs: Any) -> list[dict[str, Any]]:
         self.search_calls.append(kwargs)
@@ -57,8 +59,14 @@ class _FakeWrapper:
         self.list_calls.append(kwargs)
         return {"items": [{"id": "id-1"}], "next_cursor": None}
 
-    async def delete(self, *, ids: list[str], client_id: str | None = None) -> dict[str, Any]:
-        self.delete_calls.append({"ids": ids, "client_id": client_id})
+    async def delete(
+        self,
+        *,
+        ids: list[str],
+        client_id: str | None = None,
+        dataset: str | list[str] | None = None,
+    ) -> dict[str, Any]:
+        self.delete_calls.append({"ids": ids, "client_id": client_id, "dataset": dataset})
         return {"deleted": len(ids)}
 
 
@@ -233,3 +241,109 @@ async def test_standalone_server_tools_carry_annotations(wrapper: _FakeWrapper) 
     # memory_search + memory_list are reads.
     assert by_name["memory_search"].annotations.readOnlyHint is True
     assert by_name["memory_list"].annotations.readOnlyHint is True
+
+
+# ── PR: MCP hardening (typed schemas, document_id, delete dataset, scrub) ───
+
+
+@pytest.mark.asyncio
+async def test_memory_add_document_id_passthrough(wrapper: _FakeWrapper, dispatcher: Any) -> None:
+    """A caller-supplied document_id reaches the wrapper (conversation upsert)."""
+    out = await dispatcher("memory_add", {"text": "turn 2", "document_id": "conv-abc_1"})
+    assert out["status"] == "ok"
+    assert out["id"] == "conv-abc_1"
+    assert wrapper.add_calls[0]["document_id"] == "conv-abc_1"
+
+
+@pytest.mark.asyncio
+async def test_memory_add_document_id_grammar_enforced(
+    wrapper: _FakeWrapper, dispatcher: Any
+) -> None:
+    """document_id becomes an engine URL path segment — bad grammar is a schema error."""
+    out = await dispatcher("memory_add", {"text": "x", "document_id": "../../etc/passwd"})
+    assert out["status"] == "error"
+    assert out["error"]["code"] == "mcp.memory_schema"
+    assert not wrapper.add_calls
+
+
+@pytest.mark.asyncio
+async def test_memory_add_surfaces_async_operation_id(dispatcher_factory: Any = None) -> None:
+    """Engines that ingest asynchronously return operation_id — it must
+    survive to the caller so ingestion can be polled."""
+
+    class _AsyncEngineWrapper(_FakeWrapper):
+        async def add(self, **kwargs: Any) -> dict[str, Any]:
+            self.add_calls.append(kwargs)
+            return {"id": "doc-1", "timestamp": "t", "operation_id": "op-42"}
+
+    wrapper = _AsyncEngineWrapper()
+    disp = memory.make_dispatcher(wrapper, client_id_resolver=lambda: "a", private_resolver=None)
+    out = await disp("memory_add", {"text": "x"})
+    assert out["status"] == "ok"
+    assert out["operation_id"] == "op-42"
+
+
+@pytest.mark.asyncio
+async def test_memory_delete_dataset_directs_sweep(wrapper: _FakeWrapper, dispatcher: Any) -> None:
+    """An explicit dataset narrows/widens the engine's bank sweep (e.g.
+    project items live outside the default shared+own-private sweep)."""
+    out = await dispatcher("memory_delete", {"ids": ["d1"], "dataset": "project:apollo"})
+    assert out["status"] == "ok"
+    assert wrapper.delete_calls[0]["dataset"] == "project:apollo"
+
+
+@pytest.mark.asyncio
+async def test_memory_failed_error_scrubs_engine_urls() -> None:
+    """httpx repeats the internal engine URL in error messages — the MCP
+    envelope must not leak it to remote callers."""
+
+    class _Resp:
+        status_code = 404
+
+    class _EngineError(Exception):
+        def __init__(self) -> None:
+            super().__init__(
+                "Client error '404 Not Found' for url 'http://127.0.0.1:9177/v1/default/banks/x'"
+            )
+            self.response = _Resp()
+
+    class _BoomWrapper(_FakeWrapper):
+        async def delete(self, **kwargs: Any) -> dict[str, Any]:
+            raise _EngineError()
+
+    disp = memory.make_dispatcher(
+        _BoomWrapper(), client_id_resolver=lambda: "a", private_resolver=None
+    )
+    out = await disp("memory_delete", {"ids": ["x"]})
+    assert out["status"] == "error"
+    assert out["error"]["code"] == "mcp.memory_failed"
+    assert "127.0.0.1" not in out["error"]["detail"]
+    assert "9177" not in out["error"]["detail"]
+    assert "404" in out["error"]["detail"]
+
+
+@pytest.mark.asyncio
+async def test_standalone_server_publishes_typed_schemas(wrapper: _FakeWrapper) -> None:
+    """Tools must advertise real parameter schemas — the old single
+    ``args: object`` param made every client guess the call shape."""
+    server = memory.build_server(wrapper=wrapper)
+    tools = await server.list_tools()
+    props = {t.name: set((t.inputSchema or {}).get("properties", {})) for t in tools}
+    assert {"text", "dataset", "tags", "metadata", "document_id"} <= props["memory_add"]
+    assert {"query", "limit", "dataset", "tags", "before", "after"} <= props["memory_search"]
+    assert {"ids", "dataset"} <= props["memory_delete"]
+    assert {"query", "max_tokens", "types", "dataset", "tags"} <= props["memory_recall"]
+
+
+@pytest.mark.asyncio
+async def test_standalone_server_legacy_args_envelope_still_works(
+    wrapper: _FakeWrapper,
+) -> None:
+    """Pre-schema clients sent {"args": {...}} — that envelope keeps working,
+    with explicit params winning over same-named args keys."""
+    server = memory.build_server(wrapper=wrapper)
+    result = await server.call_tool("memory_add", {"args": {"text": "legacy shape"}})
+    # FastMCP returns (content, structured) — the structured payload carries the envelope.
+    structured = result[1] if isinstance(result, tuple) else result
+    assert structured["status"] == "ok"
+    assert wrapper.add_calls[0]["text"] == "legacy shape"

--- a/tests/memory/test_hindsight_provider.py
+++ b/tests/memory/test_hindsight_provider.py
@@ -43,10 +43,16 @@ class FakeHindsightClient:
                 "mentioned_at": "2026-06-06T00:00:00+00:00",
             }
         )
-        return {"success": True, "bank_id": bank_id, "items_count": 1}
+        return {
+            "success": True,
+            "bank_id": bank_id,
+            "items_count": 1,
+            "async": True,
+            "operation_id": "op-test",
+        }
 
     async def recall(self, *, bank_id, query, types=None, max_tokens=4096, tags=None):
-        self.recalled.append({"bank_id": bank_id, "query": query})
+        self.recalled.append({"bank_id": bank_id, "query": query, "types": types})
         return {"results": list(self._facts_by_bank.get(bank_id, []))}
 
     async def delete_document(self, *, bank_id, document_id):
@@ -84,10 +90,12 @@ async def test_add_routes_to_retain_under_mapped_bank():
     fake = FakeHindsightClient()
     p = HindsightProvider(client=fake, client_id="hermes")
     res = await p.add("Alice works at Google", dataset="private:hermes", client_id="hermes")
-    assert set(res) == {"id", "timestamp"}
+    assert set(res) == {"id", "timestamp", "operation_id"}
     assert fake.retained[0]["bank_id"] == "private__hermes"
     # The returned id IS the document_id (the join key), not a fact id.
     assert fake.retained[0]["document_id"] == res["id"]
+    # retain is async on this engine — the operation id surfaces for polling.
+    assert res["operation_id"] == "op-test"
 
 
 class FakeReranker:
@@ -206,3 +214,105 @@ async def test_list_items_fans_out_real_endpoint():
     ids = {item["id"] for item in result["items"]}
     assert "d-shared" in ids
     assert "d-hermes" in ids
+
+
+# ── PR: delete 404-sweep, add upsert/operation_id, recall type defaults ──────
+
+
+class Fake404HindsightClient(FakeHindsightClient):
+    """Models the REAL Hindsight delete contract: a document missing from a
+    bank is a 404 (httpx raise_for_status), not an idempotent zero-count."""
+
+    class _Resp:
+        status_code = 404
+
+    class NotFound(Exception):
+        def __init__(self) -> None:
+            super().__init__("Client error '404 Not Found' for url 'http://127.0.0.1:9177/...'")
+            self.response = Fake404HindsightClient._Resp()
+
+    async def delete_document(self, *, bank_id, document_id):
+        facts = self._facts_by_bank.get(bank_id, [])
+        if not any(f["document_id"] == document_id for f in facts):
+            raise Fake404HindsightClient.NotFound()
+        return await super().delete_document(bank_id=bank_id, document_id=document_id)
+
+
+@pytest.mark.asyncio
+async def test_delete_sweep_survives_404_and_reaches_private_bank():
+    """The shared bank is probed first and 404s for a private-bank item —
+    the sweep must continue, not abort (the abort made every private item
+    undeletable in production)."""
+    fake = Fake404HindsightClient()
+    await fake.retain(bank_id="private__hermes", content="secret", document_id="d-priv", tags=[])
+
+    p = HindsightProvider(client=fake, client_id="hermes")
+    res = await p.delete(["d-priv"], client_id="hermes")
+    assert res == {"deleted": 1}
+    assert not fake._facts_by_bank["private__hermes"]
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_everywhere_counts_zero():
+    fake = Fake404HindsightClient()
+    p = HindsightProvider(client=fake, client_id="hermes")
+    res = await p.delete(["nope"], client_id="hermes")
+    assert res == {"deleted": 0}
+
+
+@pytest.mark.asyncio
+async def test_delete_non_404_engine_errors_still_raise():
+    """Only the missing-document 404 is swallowed; a real engine failure
+    (5xx, connection refused) must propagate."""
+
+    class _Resp:
+        status_code = 503
+
+    class _Boom(Exception):
+        response = _Resp()
+
+    class _BoomClient(FakeHindsightClient):
+        async def delete_document(self, *, bank_id, document_id):
+            raise _Boom()
+
+    p = HindsightProvider(client=_BoomClient(), client_id="hermes")
+    with pytest.raises(_Boom):
+        await p.delete(["d1"], client_id="hermes")
+
+
+@pytest.mark.asyncio
+async def test_delete_dataset_directs_sweep_to_project_bank():
+    """An explicit dataset reaches banks outside the default sweep."""
+    fake = Fake404HindsightClient()
+    await fake.retain(bank_id="project__apollo", content="x", document_id="d-proj", tags=[])
+
+    p = HindsightProvider(client=fake, client_id="hermes")
+    res = await p.delete(["d-proj"], client_id="hermes", dataset="project:apollo")
+    assert res == {"deleted": 1}
+
+
+@pytest.mark.asyncio
+async def test_add_caller_document_id_upserts_same_document():
+    """Reusing a document_id pins the engine join key (conversation upsert)."""
+    fake = FakeHindsightClient()
+    p = HindsightProvider(client=fake, client_id="hermes")
+    r1 = await p.add("turn 1", dataset="shared", client_id="hermes", document_id="conv-1")
+    r2 = await p.add("turn 1+2", dataset="shared", client_id="hermes", document_id="conv-1")
+    assert r1["id"] == r2["id"] == "conv-1"
+    assert [r["document_id"] for r in fake.retained] == ["conv-1", "conv-1"]
+
+
+@pytest.mark.asyncio
+async def test_recall_default_types_include_observations():
+    """Hindsight's own default (world+experience) hides the consolidated
+    observation layer; hal0's default must request it explicitly."""
+    fake = FakeHindsightClient()
+    await fake.retain(bank_id="shared", content="x", document_id="d1", tags=[])
+    p = HindsightProvider(client=fake, client_id="hermes")
+
+    await p.recall("anything", dataset="shared", client_id="hermes")
+    assert fake.recalled[0]["types"] == ["world", "experience", "observation"]
+
+    fake.recalled.clear()
+    await p.recall("anything", dataset="shared", client_id="hermes", types=["world"])
+    assert fake.recalled[0]["types"] == ["world"]

--- a/tests/memory/test_namespace_policy.py
+++ b/tests/memory/test_namespace_policy.py
@@ -1,0 +1,87 @@
+"""Spec §3 closed-namespace policy — :mod:`hal0.memory.namespace`.
+
+Free-form dataset names used to pass through verbatim, which let any
+caller read/write arbitrary engine banks (live-verified on CT105:
+a probe wrote into a stale smoke-test bank, and the item was then
+unreachable by the id-scoped delete sweep). The namespace set is now
+closed: ``shared`` | ``agents`` | ``project:<id>`` | own private.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.memory.namespace import (
+    MemoryNamespaceError,
+    is_known_namespace,
+    resolve_read_datasets,
+    resolve_write_dataset,
+)
+
+# ── is_known_namespace ───────────────────────────────────────────────────────
+
+
+def test_known_namespaces_table() -> None:
+    assert is_known_namespace("shared")
+    assert is_known_namespace("agents")
+    assert is_known_namespace("project:apollo")
+    assert is_known_namespace("project:a-b_c42")
+    assert is_known_namespace("private:hermes", client_id="hermes")
+
+
+def test_unknown_namespaces_rejected() -> None:
+    assert not is_known_namespace("smoke-gemma4-e4b-v2")
+    assert not is_known_namespace("project:")  # empty scoped id
+    assert not is_known_namespace("project:has space")
+    assert not is_known_namespace("project:" + "x" * 65)  # over identity bound
+    assert not is_known_namespace("private:hermes", client_id="other")  # foreign private
+    assert not is_known_namespace("private:hermes")  # private without identity
+
+
+# ── resolve_write_dataset ────────────────────────────────────────────────────
+
+
+def test_write_allows_spec_table_names() -> None:
+    assert resolve_write_dataset("shared", private=False, client_id="a") == "shared"
+    assert resolve_write_dataset("agents", private=False, client_id="a") == "agents"
+    assert resolve_write_dataset("project:apollo", private=False, client_id="a") == "project:apollo"
+
+
+def test_write_rejects_free_form_names() -> None:
+    with pytest.raises(MemoryNamespaceError, match="unknown namespace"):
+        resolve_write_dataset("smoke-gemma4-e4b-v2", private=False, client_id="a")
+
+
+def test_write_private_prefix_still_requires_toggle() -> None:
+    # Pre-existing rule (PR #366) — unchanged by the closed-set hardening.
+    with pytest.raises(MemoryNamespaceError, match="cannot address the private namespace"):
+        resolve_write_dataset("private:a", private=False, client_id="a")
+
+
+def test_write_private_toggle_still_promotes() -> None:
+    assert resolve_write_dataset("anything", private=True, client_id="a") == "private:a"
+
+
+# ── resolve_read_datasets ────────────────────────────────────────────────────
+
+
+def test_read_list_drops_unknown_and_foreign_private() -> None:
+    out = resolve_read_datasets(
+        ["shared", "agents", "project:apollo", "private:me", "private:other", "junk-bank"],
+        private=False,
+        client_id="me",
+    )
+    assert out == ["shared", "agents", "project:apollo", "private:me"]
+
+
+def test_read_default_expansion_unchanged() -> None:
+    assert resolve_read_datasets(None, private=False, client_id=None) == "shared"
+    assert resolve_read_datasets(None, private=True, client_id="me") == [
+        "shared",
+        "private:me",
+    ]
+
+
+def test_read_string_resolves_via_write_rules() -> None:
+    with pytest.raises(MemoryNamespaceError, match="unknown namespace"):
+        resolve_read_datasets("junk-bank", private=False, client_id="me")

--- a/tests/memory/test_provider_abc.py
+++ b/tests/memory/test_provider_abc.py
@@ -43,7 +43,16 @@ def test_add_signature_matches_cognee_call_sites():
     sig = inspect.signature(MemoryProvider.add)
     params = list(sig.parameters)
     # Mirrors CogneeWrapper.add + the REST/MCP callers.
-    assert params == ["self", "text", "dataset", "tags", "source", "metadata", "client_id"]
+    assert params == [
+        "self",
+        "text",
+        "dataset",
+        "tags",
+        "source",
+        "metadata",
+        "client_id",
+        "document_id",
+    ]
 
 
 def test_cognee_wrapper_is_a_memory_provider():

--- a/tests/memory/test_provider_contract.py
+++ b/tests/memory/test_provider_contract.py
@@ -118,7 +118,8 @@ def _hindsight_factory():
 async def test_hindsight_conforms_to_contract():
     p = _hindsight_factory()
     res = await p.add("hs note", dataset="shared")
-    assert set(res) == {"id", "timestamp"}
+    # operation_id is optional contract surface (async-ingest engines).
+    assert {"id", "timestamp"} <= set(res) <= {"id", "timestamp", "operation_id"}
     # Foreign-private read → empty.
     out = await p.search("note", dataset="private:bob", client_id="bob")
     assert out == []


### PR DESCRIPTION
## Context

First external MCP client (Claude Code as `claude-dev` from hal0-dev) connected to `/mcp/memory` today and live-probed the Hindsight-backed memory surface. Several findings were verified against the running CT105 stack; this PR addresses all of them. Complements #748 (dashboard memory surface) + #749 (graph gate seed).

## Bugs fixed

1. **Private-bank items were undeletable** — `memory_delete` sweeps the caller's allowed banks, but Hindsight 404s a missing document and `raise_for_status` aborted the sweep on the first probe (`shared`). Reproduced live: deleting a `private:claude-dev` item returned a raw 404 error. Sweep is now 404-tolerant per bank; non-404 engine errors still raise.
2. **Error envelopes leaked the internal engine URL** (`http://127.0.0.1:9177/...` via httpx messages). Scrubbed to `memory engine returned HTTP <code>`.
3. **Open namespace set** — any caller could read AND write arbitrary engine banks by passing a free-form `dataset` (verified live against a stale smoke-test bank), and those items were unreachable by the delete sweep. Namespaces are now the closed spec §3 table: `shared` | `agents` | `project:<id>` | own `private:<agent>`. Writes reject (400 / schema error), list-reads drop unknown entries (fail-open-empty, matching foreign-private posture).

## Improvements

- **Typed MCP schemas**: all 5 tools published one opaque `args: object` param; clients had to guess the call shape. Now real typed signatures (FastMCP/pydantic schema). Legacy `{\"args\": {...}}` envelope still works; explicit params win.
- **`document_id` upsert + `operation_id`**: `memory_add` accepts a caller `document_id` (Hindsight join key → conversation evolution) and surfaces the retain `operation_id` so async ingestion is pollable (dashboard ingestion indicator) instead of looking like a silent no-op.
- **Recall includes observations by default**: Hindsight defaults to world+experience, hiding the consolidated observation layer (its highest-value tier). hal0 now requests world+experience+observation unless the caller narrows.
- **Hindsight LLM npu → utility** (unit template): the [Q5'] NPU rationale predates the resident-container runtime. `utility` (gemma-4-12b-it) is always loaded — no extra GTT — and answers in ~2s vs 77–160s on the NPU (FLM also serializes memory ops behind chat traffic). The #748 reflect/mental-model consoles need interactive latency. History preserved in the unit comments.

## Tests

- 19 new tests (404 sweep incl. non-404 propagation, dataset-directed delete, upsert, operation_id, recall type defaults, closed-namespace policy, typed schema publication, legacy args envelope, URL scrubbing, REST passthroughs).
- Full memory-adjacent sweep green: tests/memory, tests/mcp, memory REST/admin/gate/graph routes, hermes_plugins — 296 passed.

## Follow-ups (not in scope)

- Admin server (`/mcp/admin`) memory_* delegate tools still advertise opaque schemas — same treatment applies there if desired.
- Live CT105 hindsight-api.service drifts from the template (`HINDSIGHT_API_LLM_MODEL=npu`, bare name) — will align the live unit on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)