### PR TITLE
feat(profiles): overhaul Profiles view (design)

### DIFF
--- a/installer/etc-hal0/profiles.toml
+++ b/installer/etc-hal0/profiles.toml
@@ -17,6 +17,8 @@ flags        = "-fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 512 --parallel 1 --threads
 mtp          = false
 device_class = "gpu"
 backend      = "rocm"
+intent       = "MoE agents"
+quant        = "FP4"
 
 [profile.rocm-mtp]
 # ROCm + MTP draft speculation (dense chat, qwopus 27B). ~24.4 tok/s (~2x non-MTP).
@@ -26,6 +28,8 @@ flags        = "-fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 512 --parallel 1 --threads
 mtp          = true
 device_class = "gpu"
 backend      = "rocm"
+intent       = "Dense chat + MTP"
+quant        = "FP4"
 
 [profile.vulkan]
 # Standard Vulkan GPU template (fallback / non-FP4 models). Vulkan-radv, no FP4/MTP.
@@ -34,6 +38,8 @@ flags        = "-fa on -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap"
 mtp          = false
 device_class = "gpu"
 backend      = "vulkan"
+intent       = "Vulkan std · fallback"
+quant        = "Q4_K_M"
 
 [profile.flm]
 # NPU LLM/trio slot (FastFlowLM). Flags are built by FLMProvider.container_spec,
@@ -42,6 +48,8 @@ image        = "ghcr.io/hal0ai/hal0-toolbox-flm:v1"
 flags        = ""
 mtp          = false
 device_class = "npu"
+intent       = "FLM NPU inference"
+quant        = "W4ABF16"
 
 [profile.tts]
 # CPU TTS slot (kokoro-onnx). No GPU devices. Flags feed kokoro_server.py;
@@ -50,6 +58,8 @@ image        = "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1"
 flags        = "--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx"
 mtp          = false
 device_class = "cpu"
+intent       = "TTS · Kokoro"
+quant        = ""
 
 [profile.comfyui]
 # Image-gen slot (ComfyUI on ROCm, kyuz0 Strix Halo build). Exclusive-GPU:
@@ -58,3 +68,6 @@ image        = "docker.io/kyuz0/amd-strix-halo-comfyui:latest"
 flags        = "--disable-mmap --bf16-vae --cache-none"
 mtp          = false
 device_class = "img"
+intent       = "Image generation"
+quant        = ""
+

--- a/src/hal0/api/routes/profiles.py
+++ b/src/hal0/api/routes/profiles.py
@@ -56,6 +56,8 @@ class ProfileBody(BaseModel):
         default=None,
         description="Provenance: profile this one was cloned from (informational).",
     )
+    intent: str = Field(default="", description="Human label for the card headline.")
+    quant: str = Field(default="", description="Weight quant shown as a card chip.")
 
     @field_validator("name")
     @classmethod
@@ -88,6 +90,8 @@ class ProfileUpdateBody(BaseModel):
         default=None,
         description="GPU runtime (rocm|vulkan); None for non-GPU profiles.",
     )
+    intent: str | None = Field(default=None, description="Human label for the card headline.")
+    quant: str | None = Field(default=None, description="Weight quant shown as a card chip.")
 
     @field_validator("image")
     @classmethod
@@ -111,8 +115,14 @@ def list_profiles() -> list[dict[str, Any]]:
             "image":          "ghcr.io/hal0ai/...:rocm-7.2.4-rocmfp4-server",
             "flags":          "-fa on ...",
             "mtp":            false,
-            "device_class":   "gpu",         # gpu | cpu | npu | img
-            "resolved_flags": "-fa on ..."   # flags + MTP bundle when mtp=true
+            "device_class":   "gpu",          # gpu | cpu | npu | img
+            "backend":        "rocm",         # rocm | vulkan | null (non-GPU)
+            "resolved_flags": "-fa on ...",   # flags + MTP bundle when mtp=true
+            "intent":         "MoE agents",   # card headline label
+            "quant":          "FP4",          # weight quant chip
+            "tps":            52.8,           # bench tok/s (null when un-benched)
+            "rtf":            null,           # real-time factor for synth slots
+            "used_by":        ["primary"]     # slots bound to this profile
         }
 
     Raises:
@@ -140,6 +150,8 @@ def create_profile(body: ProfileBody) -> dict[str, Any]:
             device_class=body.device_class,
             backend=body.backend,
             cloned_from=body.cloned_from,
+            intent=body.intent,
+            quant=body.quant,
         ),
     )
     return profile.to_dict()
@@ -164,6 +176,8 @@ def update_profile(name: str, body: ProfileUpdateBody) -> dict[str, Any]:
             mtp=body.mtp,
             device_class=body.device_class,
             backend=body.backend,
+            intent=body.intent,
+            quant=body.quant,
         ),
     )
     return profile.to_dict()

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -697,6 +697,8 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "mtp": False,
         "device_class": "gpu",
         "backend": "rocm",
+        "intent": "MoE agents",
+        "quant": "FP4",
     },
     "rocm-mtp": {
         "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
@@ -704,6 +706,8 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "mtp": True,
         "device_class": "gpu",
         "backend": "rocm",
+        "intent": "Dense chat + MTP",
+        "quant": "FP4",
     },
     "vulkan": {
         "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server",
@@ -711,25 +715,45 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "mtp": False,
         "device_class": "gpu",
         "backend": "vulkan",
+        "intent": "Vulkan std · fallback",
+        "quant": "Q4_K_M",
     },
     "flm": {
         "image": "ghcr.io/hal0ai/hal0-toolbox-flm:v1",
         "flags": "",
         "mtp": False,
         "device_class": "npu",
+        "intent": "FLM NPU inference",
+        "quant": "W4ABF16",
     },
     "tts": {
         "image": "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1",
         "flags": "--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx",
         "mtp": False,
         "device_class": "cpu",
+        "intent": "TTS · Kokoro",
+        "quant": "",
     },
     "comfyui": {
         "image": "docker.io/kyuz0/amd-strix-halo-comfyui:latest",
         "flags": "--disable-mmap --bf16-vae --cache-none",
         "mtp": False,
         "device_class": "img",
+        "intent": "Image generation",
+        "quant": "",
     },
+}
+
+#: Static bench numbers for seed profiles, surfaced as the card hero metric.
+#: ``tps`` = tokens/sec (LLM throughput); ``rtf`` = real-time factor (synth,
+#: e.g. TTS).  Grounded in hal0-container-bench-2026-06-08.md.  Custom
+#: profiles have no entry → the card shows "—" until benched.
+PROFILE_BENCH: dict[str, dict[str, float]] = {
+    "rocm": {"tps": 52.8},
+    "rocm-mtp": {"tps": 24.4},
+    "vulkan": {"tps": 41.0},
+    "flm": {"tps": 38.6},
+    "tts": {"rtf": 0.18},
 }
 
 #: Preselect map for the create-modal device picker and legacy-slot
@@ -796,6 +820,22 @@ class ProfileConfig(BaseModel):
             "Provenance: name of the profile this one was cloned from "
             "(set by the dashboard clone / edit-a-copy flow).  Informational "
             "only — never resolved or validated against the catalog."
+        ),
+    )
+    intent: str = Field(
+        default="",
+        description=(
+            "Human label for what this profile is for, shown as the card "
+            "headline in the dashboard (e.g. 'MoE agents · long-ctx').  "
+            "Informational only."
+        ),
+    )
+    quant: str = Field(
+        default="",
+        description=(
+            "Weight quantization format shown as a card chip (e.g. 'FP4', "
+            "'Q4_K_M', 'W4ABF16').  Informational only — the runtime reads "
+            "the quant from the model, not this field."
         ),
     )
 
@@ -1822,6 +1862,7 @@ __all__ = [
     "DEFAULT_DEVICE",
     "DEVICE_DEFAULT_PROFILES",
     "MTP_FLAG_BUNDLE",
+    "PROFILE_BENCH",
     "SEED_PROFILES",
     "AgentAuthConfig",
     "AgentAuthKindLiteral",

--- a/src/hal0/profiles/__init__.py
+++ b/src/hal0/profiles/__init__.py
@@ -29,7 +29,12 @@ from hal0.config.loader import (
     load_slot_config,
     save_profiles_config,
 )
-from hal0.config.schema import SEED_PROFILES, ProfileConfig, resolve_profile_flags
+from hal0.config.schema import (
+    PROFILE_BENCH,
+    SEED_PROFILES,
+    ProfileConfig,
+    resolve_profile_flags,
+)
 from hal0.errors import Conflict, NotFound
 
 log = logging.getLogger(__name__)
@@ -55,6 +60,14 @@ class ResolvedProfile:
     supported_slot_types: tuple[SlotType, ...]
     backend: str | None = None
     cloned_from: str | None = None
+    #: Card display facts (profiles overhaul). The bench metrics are static
+    #: for seeds and ``None`` for custom; ``used_by`` is the set of slots
+    #: that reference this profile.
+    intent: str = ""
+    quant: str = ""
+    tps: float | None = None
+    rtf: float | None = None
+    used_by: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -69,6 +82,11 @@ class ResolvedProfile:
             "runtime_family": self.runtime_family,
             "supported_slot_types": list(self.supported_slot_types),
             "cloned_from": self.cloned_from,
+            "intent": self.intent,
+            "quant": self.quant,
+            "tps": self.tps,
+            "rtf": self.rtf,
+            "used_by": list(self.used_by),
         }
 
 
@@ -81,6 +99,8 @@ class ProfilePatch:
     mtp: bool | None = None
     device_class: Literal["gpu", "cpu", "npu", "img"] | None = None
     backend: Literal["rocm", "vulkan"] | None = None
+    intent: str | None = None
+    quant: str | None = None
 
 
 def _runtime_family(name: str, profile: ProfileConfig) -> RuntimeFamily:
@@ -118,7 +138,11 @@ class ProfileCatalog:
 
     def list(self) -> list[ResolvedProfile]:
         cfg = load_profiles_config(self._path)
-        return [self._resolve_item(name, profile) for name, profile in cfg.profile.items()]
+        used_by = self._used_by_index()
+        return [
+            self._resolve_item(name, profile, used_by=tuple(used_by.get(name, ())))
+            for name, profile in cfg.profile.items()
+        ]
 
     def resolve(self, name: str) -> ResolvedProfile:
         cfg = load_profiles_config(self._path)
@@ -165,6 +189,8 @@ class ProfileCatalog:
                 ),
                 backend=patch.backend if patch.backend is not None else existing.backend,
                 cloned_from=existing.cloned_from,
+                intent=patch.intent if patch.intent is not None else existing.intent,
+                quant=patch.quant if patch.quant is not None else existing.quant,
             )
             catalog.profile[name] = updated
             save_profiles_config(catalog, self._path)
@@ -192,19 +218,41 @@ class ProfileCatalog:
 
     def slots_using(self, name: str) -> list[str]:
         """Return slot names whose TOML references ``name``."""
-        using: list[str] = []
+        return [slot for slot, profile in self._slot_profiles() if profile == name]
+
+    def _slot_profiles(self) -> list[tuple[str, str | None]]:
+        """Return ``(slot_name, profile_name)`` for every slot, in one pass.
+
+        Malformed slot TOMLs are logged and skipped so a single bad slot
+        never breaks the whole profile listing.
+        """
+        out: list[tuple[str, str | None]] = []
         for slot_name in list_slots():
             try:
                 cfg = load_slot_config(slot_name)
             except Exception as exc:
                 log.warning("profiles.in_use_scan_error slot=%s error=%s", slot_name, exc)
                 continue
-            if cfg.profile == name:
-                using.append(slot_name)
-        return using
+            out.append((slot_name, cfg.profile))
+        return out
 
-    def _resolve_item(self, name: str, profile: ProfileConfig) -> ResolvedProfile:
+    def _used_by_index(self) -> dict[str, list[str]]:
+        """Map ``profile_name -> [slot names]`` from a single slot scan."""
+        index: dict[str, list[str]] = {}
+        for slot_name, profile_name in self._slot_profiles():
+            if profile_name:
+                index.setdefault(profile_name, []).append(slot_name)
+        return index
+
+    def _resolve_item(
+        self,
+        name: str,
+        profile: ProfileConfig,
+        *,
+        used_by: tuple[str, ...] = (),
+    ) -> ResolvedProfile:
         runtime = _runtime_family(name, profile)
+        bench = PROFILE_BENCH.get(name, {})
         return ResolvedProfile(
             name=name,
             image=profile.image,
@@ -217,6 +265,11 @@ class ProfileCatalog:
             runtime_family=runtime,
             supported_slot_types=_supported_slot_types(runtime),
             cloned_from=profile.cloned_from,
+            intent=profile.intent,
+            quant=profile.quant,
+            tps=bench.get("tps"),
+            rtf=bench.get("rtf"),
+            used_by=used_by,
         )
 
     def _guard_custom(self, name: str) -> None:

--- a/tests/api/test_profiles_route.py
+++ b/tests/api/test_profiles_route.py
@@ -157,3 +157,33 @@ class TestListProfiles:
         assert names == {"custom-only"}
         custom = next(item for item in data if item["name"] == "custom-only")
         assert custom["seed"] is False
+
+
+# ── profiles overhaul: enriched card fields ─────────────────────────────────────
+
+
+class TestEnrichedFields:
+    def test_seed_items_expose_intent_quant_bench(self, client: TestClient) -> None:
+        data = client.get("/api/profiles").json()
+        by_name = {p["name"]: p for p in data}
+        rocm = by_name["rocm"]
+        assert rocm["intent"] == "MoE agents"
+        assert rocm["quant"] == "FP4"
+        assert rocm["tps"] == 52.8
+        assert rocm["rtf"] is None
+        assert rocm["used_by"] == []
+        assert by_name["tts"]["rtf"] == 0.18
+
+    def test_create_round_trips_intent_and_quant(self, client: TestClient) -> None:
+        body = {
+            "name": "my-tuned",
+            "image": "ghcr.io/x/y:z",
+            "intent": "My workload",
+            "quant": "Q5_K_M",
+        }
+        created = client.post("/api/profiles", json=body).json()
+        assert created["intent"] == "My workload"
+        assert created["quant"] == "Q5_K_M"
+        assert created["tps"] is None
+        listed = {p["name"]: p for p in client.get("/api/profiles").json()}
+        assert listed["my-tuned"]["intent"] == "My workload"

--- a/tests/profiles/test_catalog.py
+++ b/tests/profiles/test_catalog.py
@@ -103,3 +103,54 @@ def test_cloned_from_defaults_to_none_and_survives_update(tmp_hal0_home: str) ->
     catalog.create("my-copy", ProfileConfig(image="ghcr.io/x/y:z", cloned_from="my-rocm"))
     updated = catalog.update("my-copy", ProfilePatch(flags="-fa off"))
     assert updated.cloned_from == "my-rocm"
+
+
+# ── profiles overhaul: bench / quant / intent / used_by ─────────────────────────
+
+
+def test_seed_bench_metrics_exposed(tmp_hal0_home: str) -> None:
+    by_name = {p.name: p for p in ProfileCatalog().list()}
+    assert by_name["rocm"].tps == 52.8
+    assert by_name["rocm-mtp"].tps == 24.4
+    # TTS is synth — reported as a real-time factor, not tok/s.
+    assert by_name["tts"].tps is None
+    assert by_name["tts"].rtf == 0.18
+
+
+def test_seed_intent_and_quant_exposed(tmp_hal0_home: str) -> None:
+    by_name = {p.name: p for p in ProfileCatalog().list()}
+    assert by_name["rocm"].intent == "MoE agents"
+    assert by_name["rocm"].quant == "FP4"
+    assert by_name["vulkan"].quant == "Q4_K_M"
+
+
+def test_custom_profile_has_no_bench_and_round_trips_intent_quant(
+    tmp_hal0_home: str,
+) -> None:
+    catalog = ProfileCatalog()
+    created = catalog.create(
+        "my-tuned",
+        ProfileConfig(image="ghcr.io/x/y:z", intent="My workload", quant="Q5_K_M"),
+    )
+    assert created.intent == "My workload"
+    assert created.quant == "Q5_K_M"
+    assert created.tps is None
+    assert created.rtf is None
+
+    reloaded = ProfileCatalog().resolve("my-tuned")
+    assert reloaded.intent == "My workload"
+    assert reloaded.quant == "Q5_K_M"
+
+
+def test_used_by_lists_bound_slots(tmp_hal0_home: str) -> None:
+    root = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    root.mkdir(parents=True, exist_ok=True)
+    for slot in ("primary", "agent"):
+        (root / f"{slot}.toml").write_text(
+            "\n".join(["[slot]", f'name = "{slot}"', "port = 8081", 'profile = "rocm"', ""]),
+            encoding="utf-8",
+        )
+    by_name = {p.name: p for p in ProfileCatalog().list()}
+    assert sorted(by_name["rocm"].used_by) == ["agent", "primary"]
+    assert by_name["vulkan"].used_by == ()
+    assert by_name["rocm"].to_dict()["used_by"] == ["agent", "primary"]

--- a/ui/src/api/hooks/useProfiles.ts
+++ b/ui/src/api/hooks/useProfiles.ts
@@ -21,6 +21,20 @@ export interface Profile {
   /** Emitted by the API: true when the profile is one of the immutable
    *  SEED_PROFILES (server rejects PUT/DELETE with 409 seed_immutable). */
   seed?: boolean
+  /** GPU runtime (rocm|vulkan); null for non-GPU profiles (#751). */
+  backend?: 'rocm' | 'vulkan' | null
+  /** Provenance: profile this one was cloned from (clone / edit-a-copy). */
+  cloned_from?: string | null
+  /** Human label shown as the card headline (e.g. "MoE agents"). */
+  intent?: string
+  /** Weight quant shown as a card chip (e.g. "FP4", "Q4_K_M"). */
+  quant?: string
+  /** Bench tok/s hero metric — null when un-benched (custom profiles). */
+  tps?: number | null
+  /** Real-time factor for synth slots (e.g. TTS) — null when n/a. */
+  rtf?: number | null
+  /** Slot names currently bound to this profile. */
+  used_by?: string[]
 }
 
 export interface ProfileBody {
@@ -29,6 +43,10 @@ export interface ProfileBody {
   flags?: string
   mtp?: boolean
   device_class?: string
+  backend?: 'rocm' | 'vulkan' | null
+  cloned_from?: string | null
+  intent?: string
+  quant?: string
 }
 
 export function useProfiles() {

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -122,6 +122,12 @@ const Icons = {
   unload:    <Icon d="M3 11h10M5 8l3 3 3-3M8 11V2"/>,
   start:     <Icon d="M5 3l8 5-8 5V3z"/>,
   edit:      <Icon d="M3 13l3-1 7-7-2-2-7 7-1 3z"/>,
+  // Profiles overhaul glyphs.
+  copy:      <Icon><rect x="5.5" y="5.5" width="8" height="8" rx="1.2"/><path d="M3 10.5V3.5A1 1 0 0 1 4 2.5h7"/></Icon>,
+  lock:      <Icon><rect x="3.5" y="7" width="9" height="6" rx="1"/><path d="M5.5 7V5a2.5 2.5 0 0 1 5 0v2"/></Icon>,
+  zap:       <Icon d="M9 2L3.5 9H8l-1 5 5.5-7H8l1-5z"/>,
+  trash:     <Icon d="M3 4.5h10M6 4.5V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1.5M4.5 4.5l.6 8a1 1 0 0 0 1 .9h3.8a1 1 0 0 0 1-.9l.6-8"/>,
+  alert:     <Icon><path d="M8 5.5v3.5"/><circle cx="8" cy="11.3" r="0.5" fill="currentColor" stroke="none"/><path d="M8 2.5L14 13H2L8 2.5z"/></Icon>,
   more:      <Icon><circle cx="3" cy="8" r="1" fill="currentColor" stroke="none"/><circle cx="8" cy="8" r="1" fill="currentColor" stroke="none"/><circle cx="13" cy="8" r="1" fill="currentColor" stroke="none"/></Icon>,
   cpu:       <Icon><rect x="4" y="4" width="8" height="8" rx="0.5"/><path d="M4 6h-1M4 10h-1M13 6h-1M13 10h-1M6 4v-1M10 4v-1M6 13v-1M10 13v-1"/><rect x="6.5" y="6.5" width="3" height="3"/></Icon>,
   flame:     <Icon d="M8 13c-3 0-4-2-4-4 0-2 2-3 2-5 1 2 5 2 5 6 0 2-1 3-3 3z"/>,

--- a/ui/src/dash/profiles.jsx
+++ b/ui/src/dash/profiles.jsx
@@ -1,125 +1,338 @@
-// hal0 dashboard — Profiles view (issue #658, Phase C6 CRUD).
+// hal0 dashboard — Profiles view (issue #658; overhaul 2026-06-13).
 //
-// Lists container-slot profiles from GET /api/profiles.
-// Each profile is a named image + bench-tuned flag bundle that backs
-// one or more container slots. The UI labels them by intent (what they're
-// for) rather than by slug, so operators see "MoE agents · ROCmFP4 ·
-// ~52.8 tok/s" rather than "rocm".
+// A profile is a named container image + bench-tuned flag bundle that backs
+// one or more inference slots. This view replaces the flat card grid with a
+// structured surface: a summary strip, seed/custom grouping, richer cards
+// (bench tok/s hero metric, backend-hued accent + chip, quant chip, the
+// "used by" slot binding), a slide-in form drawer, and a styled delete
+// confirm with an in-use guard.
 //
-// Phase C6: CRUD — New profile button + create/edit form (inline drawer),
-// per-card Edit/Delete for custom profiles, Clone for custom (prefills form
-// with <name>-copy). Seeds are immutable: badge shown, Delete disabled, and
-// Edit becomes "Edit a copy" — opens the create form prefilled from the seed
-// (name <seed>-custom) so editing forks a custom profile instead of mutating
-// the seed. Clones carry cloned_from provenance, shown as "based on <source>".
+// Data comes from GET /api/profiles (useProfiles). Cards read the explicit
+// `backend` field (#751) plus the overhaul's intent/quant/tps/rtf/used_by.
+//
+// Seeds are immutable: Edit becomes "Edit a copy" (forks <seed>-custom with
+// cloned_from set); Delete is disabled. Custom profiles get Clone/Edit/Delete.
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
 import {
   useProfiles,
   useProfileCreate,
   useProfileUpdate,
   useProfileDelete,
 } from '@/api/hooks/useProfiles'
-import { prettyProfile } from './profile-names.js'
+import { prettyProfile } from './profile-names'
 
-// Seed profile intent labels, mapped by slug. Slugs are the lowercase
-// backend-agnostic names (rocm/rocm-mtp/vulkan/flm/tts/comfyui); the backend
-// (ROCm vs Vulkan) lives on the profile's explicit `backend` field, not the
-// slug. Tok/s from hal0-container-bench-2026-06-08.md.
-const PROFILE_INTENT = {
-  'rocm':     'MoE agents · ROCmFP4 · ~52.8 tok/s',
-  'rocm-mtp': 'Dense chat + MTP · ~24.4 tok/s',
-  'vulkan':   'Vulkan std (fallback)',
-  'flm':      'FLM NPU inference',
-  'tts':      'TTS · Kokoro CPU',
-  'comfyui':  'ComfyUI image generation',
+// Backend runtime hue. Keys are the display backends shown on the card +
+// drawer; colors reference shared dashboard tokens. `backendField` is the
+// value persisted to ProfileConfig.backend (null for non-GPU paths, where
+// device_class carries the hardware intent — see #751).
+const BACKEND_META = {
+  rocm:   { label: 'ROCm',      color: 'var(--dev-rocm)',   device_class: 'gpu', backendField: 'rocm' },
+  vulkan: { label: 'Vulkan',    color: 'var(--dev-vulkan)', device_class: 'gpu', backendField: 'vulkan' },
+  npu:    { label: 'FLM · NPU', color: 'var(--dev-npu)',    device_class: 'npu', backendField: null },
+  cpu:    { label: 'CPU',       color: 'var(--dev-cpu)',    device_class: 'cpu', backendField: null },
 };
 
-// Mirrors the API name regex ^[a-z0-9][a-z0-9_-]{0,31}$ — lowercase alnum
-// start, hyphens/underscores allowed after, 32 chars max.
+// Mirrors the API name regex ^[a-z0-9][a-z0-9_-]{0,31}$.
 const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,31}$/;
 
-function profileIntent(p) {
-  if (PROFILE_INTENT[p.name]) return PROFILE_INTENT[p.name];
-  const base = p.image ? p.image.split(':').pop() : prettyProfile(p.name);
-  return p.mtp ? `${base} · MTP` : base;
+const BLANK = { name: '', intent: '', image: '', backend: 'rocm', quant: '', flags: '', mtp: false };
+
+function bk(name) { return BACKEND_META[name] || BACKEND_META.cpu; }
+
+// Display backend for a profile: the explicit GPU backend (rocm|vulkan) when
+// set, otherwise mapped from device_class so npu/cpu/img still get a hue.
+function backendOf(p) {
+  if (p.backend && BACKEND_META[p.backend]) return p.backend;
+  if (p.device_class === 'npu') return 'npu';
+  if (p.device_class === 'cpu') return 'cpu';
+  if ((p.image || '').toLowerCase().includes('vulkan')) return 'vulkan';
+  return 'rocm';
 }
 
-function imageTag(image) {
-  if (!image) return '—';
-  const parts = image.split(':');
-  return parts.length > 1 ? parts[parts.length - 1] : image;
+// Card headline. Prefer the server-authored intent; fall back to a pretty
+// profile name (#751 shared map) so un-labelled custom profiles read well.
+function intentOf(p) {
+  if (p.intent) return p.intent;
+  const base = p.image ? p.image.split(':').pop() : prettyProfile(p.name);
+  return p.mtp ? `${base} · MTP` : base;
 }
 
 function toast(msg, kind = 'info') {
   if (typeof window !== 'undefined' && window.__hal0Toast) window.__hal0Toast(msg, kind);
 }
 
-// ── Profile Form (create / edit) ──────────────────────────────────────────────
+// ── slot binding pill ─────────────────────────────────────────────────────────
 
-const BLANK_FORM = { name: '', image: '', flags: '', mtp: false, device_class: '' };
+function SlotPill({ name }) {
+  return (
+    <span className="pf-slot">
+      <span className="pf-slot-dot" />
+      <span className="mono">{name}</span>
+    </span>
+  );
+}
 
-function ProfileForm({ initial, isEdit, title, onClose, onSaved }) {
-  const [form, setForm] = useState(initial ?? BLANK_FORM);
-  const [errors, setErrors] = useState({});
+// ── Profile card ──────────────────────────────────────────────────────────────
+
+function ProfileCard({ p, index, onEdit, onClone, onDelete }) {
+  const meta = bk(backendOf(p));
+  const isSeed = !!p.seed;
+  const usedBy = p.used_by || [];
+  const inUse = usedBy.length;
+
+  return (
+    <div className="pf-card" style={{ '--bk': meta.color, animationDelay: (index * 34) + 'ms' }}>
+      <span className="pf-accent" />
+      <div className="pf-card-top">
+        <div className="pf-headline">
+          <div className="pf-intent">{intentOf(p)}</div>
+          <div className="pf-slug-row mono">
+            <span className="pf-slug">{p.name}</span>
+            {p.cloned_from && <span className="pf-based">↳ {p.cloned_from}</span>}
+          </div>
+        </div>
+        <div className="pf-metric">
+          {p.tps != null ? (
+            <>
+              <span className="pf-tps num">{p.tps.toFixed(1)}</span>
+              <span className="pf-tps-u mono">tok/s · bench</span>
+            </>
+          ) : p.rtf != null ? (
+            <>
+              <span className="pf-tps num">{p.rtf.toFixed(2)}×</span>
+              <span className="pf-tps-u mono">RTF · synth</span>
+            </>
+          ) : (
+            <span className="pf-tps-u mono">—</span>
+          )}
+        </div>
+      </div>
+
+      <div className="pf-chips">
+        <span className="pf-chip backend" style={{ '--bk': meta.color }}>
+          <span className="pf-chip-dot" />{meta.label}
+        </span>
+        {p.quant && <span className="pf-chip">{p.quant}</span>}
+        {p.mtp && <span className="pf-chip mtp">{Icons.zap} MTP</span>}
+        <span className="pf-grow" />
+        {isSeed
+          ? <span className="pf-chip seed immutable" title="Seed profiles are read-only">{Icons.lock} seed</span>
+          : <span className="pf-chip custom">custom</span>}
+      </div>
+
+      <div className="pf-image mono">
+        <span className="pf-image-lbl">image</span>
+        <span className="pf-image-uri">{p.image}</span>
+      </div>
+
+      {p.resolved_flags && (
+        <div className="pf-flags">
+          <span className="pf-flags-lbl mono">flags</span>
+          <code className="pf-flags-code">{p.resolved_flags}</code>
+        </div>
+      )}
+
+      <div className="pf-foot">
+        <div className="pf-usage">
+          {inUse ? (
+            <>
+              <span className="pf-usage-lbl mono">used by</span>
+              <span className="pf-slots">{usedBy.map(s => <SlotPill key={s} name={s} />)}</span>
+            </>
+          ) : (
+            <span className="pf-unused mono">unused · safe to delete</span>
+          )}
+        </div>
+        <div className="pf-actions">
+          {isSeed ? (
+            <button
+              className="pf-btn"
+              onClick={() => onClone(p)}
+              title="Seeds are immutable — fork a custom copy"
+              data-testid={`pf-btn-editcopy-${p.name}`}
+            >
+              {Icons.copy} Edit a copy
+            </button>
+          ) : (
+            <>
+              <button
+                className="pf-btn"
+                onClick={() => onClone(p)}
+                title="Clone this profile"
+                data-testid={`pf-btn-clone-${p.name}`}
+              >
+                {Icons.copy}
+              </button>
+              <button
+                className="pf-btn"
+                onClick={() => onEdit(p)}
+                title="Edit"
+                data-testid={`pf-btn-edit-${p.name}`}
+              >
+                {Icons.edit} Edit
+              </button>
+            </>
+          )}
+          <button
+            className="pf-btn danger"
+            onClick={() => onDelete(p)}
+            disabled={isSeed}
+            title={isSeed ? 'Seed profiles cannot be deleted' : inUse ? 'In use — detach slots first' : 'Delete'}
+            data-testid={`pf-btn-delete-${p.name}`}
+          >
+            {Icons.trash}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Section ───────────────────────────────────────────────────────────────────
+
+function Section({ title, count, hint, children }) {
+  return (
+    <div className="pf-section">
+      <div className="sec">
+        <h2>{title}<span className="ct num">{count}</span></h2>
+        {hint && <span className="pf-sec-hint mono">{hint}</span>}
+        <span className="rule" />
+      </div>
+      <div className="pf-grid">{children}</div>
+    </div>
+  );
+}
+
+// ── Form drawer (create / edit / clone) ─────────────────────────────────────────
+
+function FormRow({ label, sub, req, children, error, warn, ok, counter }) {
+  return (
+    <div className={'pf-row' + (error ? ' has-err' : '')}>
+      <div className="pf-row-lbl">
+        <span>{label}{req && <span className="pf-req" title="required">*</span>}</span>
+        {sub && <span className="pf-row-sub mono">{sub}</span>}
+      </div>
+      <div className="pf-row-ctl">
+        <div className={'pf-field' + (ok ? ' ok' : '') + (error ? ' err' : '')}>
+          {children}
+          {ok && <span className="pf-field-ok" aria-hidden="true">{Icons.check}</span>}
+        </div>
+        {(error || warn || counter) && (
+          <div className="pf-row-foot">
+            {error
+              ? <span className="pf-msg err mono hint err">{Icons.alert}{error}</span>
+              : warn
+              ? <span className="pf-msg warn mono">{Icons.alert}{warn}</span>
+              : <span />}
+            {counter && <span className={'pf-counter mono' + (counter.warn ? ' warn' : '')}>{counter.text}</span>}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function validateForm(form, existing) {
+  const errs = {};
+  const name = (form.name || '').trim();
+  if (!name) errs.name = 'Name is required';
+  else if (!NAME_RE.test(name)) errs.name = 'lowercase · digits · - · _ · must start alphanumeric';
+  else if (existing.includes(name)) errs.name = `“${name}” already exists`;
+  if (!(form.image || '').trim()) errs.image = 'Image is required';
+  return errs;
+}
+
+function warnForm(form) {
+  const warns = {};
+  const img = (form.image || '').trim();
+  // A tag is the part after the last ':' that isn't part of a host:port.
+  if (img && !/:[\w][\w.-]*$/.test(img)) warns.image = 'no tag — will resolve to :latest';
+  return warns;
+}
+
+function Drawer({ mode, source, existing = [], onClose, onSaved }) {
+  const isEdit = mode === 'edit';
+  const initial = (() => {
+    if (mode === 'create') return { ...BLANK };
+    const base = {
+      name: source.name,
+      intent: source.intent || '',
+      image: source.image || '',
+      backend: backendOf(source),
+      quant: source.quant || '',
+      flags: source.flags || '',
+      mtp: !!source.mtp,
+    };
+    if (mode === 'clone') {
+      const suffix = source.seed ? '-custom' : '-copy';
+      return { ...base, name: (source.name + suffix).slice(0, 32), cloned_from: source.name };
+    }
+    return base;
+  })();
+
+  const [form, setForm] = useState(initial);
+  const [touched, setTouched] = useState({});
+  const [submitted, setSubmitted] = useState(false);
+  const [closing, setClosing] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   const create = useProfileCreate();
   const update = useProfileUpdate();
 
-  // Sync form when initial changes (e.g. switching from clone to edit).
-  useEffect(() => {
-    setForm(initial ?? BLANK_FORM);
-    setErrors({});
-  }, [initial]);
+  useEffect(() => { setForm(initial); setTouched({}); setSubmitted(false); /* eslint-disable-next-line */ }, [mode, source]);
 
-  const set = useCallback((field, val) => {
-    setForm(f => ({ ...f, [field]: val }));
-    setErrors(e => ({ ...e, [field]: undefined }));
-  }, []);
+  const meta = bk(form.backend);
 
-  function validate() {
-    const errs = {};
-    if (!form.name.trim()) {
-      errs.name = 'Name is required';
-    } else if (!NAME_RE.test(form.name.trim())) {
-      errs.name = 'Lowercase letters, digits, hyphens, underscores · max 32 chars';
-    }
-    if (!form.image.trim()) {
-      errs.image = 'Image is required';
-    }
-    return errs;
-  }
+  const taken = existing.filter(n => !(isEdit && n === source.name));
+  const errs = validateForm(form, taken);
+  const warns = warnForm(form);
+  const blocking = Object.keys(errs).length > 0;
+  const show = (f) => submitted || touched[f];
+  const nameValid = !errs.name && (form.name || '').trim().length > 0;
 
-  async function handleSubmit(e) {
+  const set = (k, v) => { setForm(f => ({ ...f, [k]: v })); setTouched(t => ({ ...t, [k]: true })); };
+  const touch = (k) => setTouched(t => ({ ...t, [k]: true }));
+  const close = () => { setClosing(true); setTimeout(onClose, 200); };
+
+  async function submit(e) {
     e.preventDefault();
-    const errs = validate();
-    if (Object.keys(errs).length) { setErrors(errs); return; }
+    setSubmitted(true);
+    if (blocking) {
+      const first = document.querySelector('.pf-field.err input');
+      if (first) first.focus();
+      return;
+    }
     setSubmitting(true);
+    const choice = bk(form.backend);
     const body = {
       name: form.name.trim(),
       image: form.image.trim(),
       flags: form.flags ?? '',
       mtp: !!form.mtp,
-      ...(form.device_class ? { device_class: form.device_class } : {}),
+      device_class: choice.device_class,
+      backend: choice.backendField,
+      intent: form.intent ?? '',
+      quant: form.quant ?? '',
       ...(form.cloned_from ? { cloned_from: form.cloned_from } : {}),
     };
     try {
       if (isEdit) {
         const { name, ...rest } = body;
-        await update.mutateAsync({ name: initial.name, body: rest });
-        toast(`Profile ${initial.name} updated`, 'ok');
+        await update.mutateAsync({ name: source.name, body: rest });
+        toast(`Profile ${source.name} updated`, 'ok');
       } else {
         await create.mutateAsync(body);
         toast(`Profile ${body.name} created`, 'ok');
       }
-      onSaved?.();
+      onSaved();
     } catch (err) {
       const code = err?.code || '';
       if (code === 'profiles.exists') {
-        setErrors({ name: 'A profile with this name already exists' });
+        setTouched(t => ({ ...t, name: true }));
+        toast(`A profile named ${body.name} already exists`, 'err');
       } else if (code === 'profiles.seed_immutable') {
-        setErrors({ name: 'Seed profiles cannot be modified' });
+        toast('Seed profiles cannot be modified', 'err');
       } else {
         toast(err?.message || 'Save failed', 'err');
       }
@@ -128,140 +341,117 @@ function ProfileForm({ initial, isEdit, title, onClose, onSaved }) {
     }
   }
 
-  const fallbackTitle = isEdit ? `Edit · ${initial?.name}` : 'New profile';
-  const panelTitle = title || fallbackTitle;
+  const title = isEdit ? `Edit · ${source.name}`
+    : mode === 'clone' ? (source.seed ? `Edit a copy · ${source.name}` : `Clone · ${source.name}`)
+    : 'New profile';
+  const eyebrow = mode === 'create' ? 'CREATE' : mode === 'clone' ? (source.seed ? 'EDIT A COPY' : 'CLONE') : 'EDIT';
+  const nameLen = (form.name || '').length;
 
   return (
-    <div className="pf-form-panel" role="dialog" aria-label={panelTitle}>
-      <div className="pf-form-head">
-        <span className="pf-form-title mono">{panelTitle}</span>
-        <button className="btn ghost sm pf-form-close" onClick={onClose} aria-label="Close">×</button>
-      </div>
-      <form onSubmit={handleSubmit} className="pf-form-body">
-        {/* Name */}
-        <div className="form-row">
-          <div className="form-lbl">
-            <span>Name <span className="req">*</span></span>
-            <span className="sub">lowercase · hyphens/underscores · ≤32 chars</span>
+    <div className={'pf-scrim' + (closing ? ' out' : '')} onMouseDown={close}>
+      <div
+        className={'pf-drawer pf-form-panel' + (closing ? ' out' : '')}
+        onMouseDown={e => e.stopPropagation()}
+        role="dialog"
+        aria-label={title}
+      >
+        <div className="pf-drawer-head">
+          <div>
+            <div className="pf-drawer-eye mono">{eyebrow}</div>
+            <div className="pf-drawer-title pf-form-title mono">{title}</div>
           </div>
-          <div className="form-ctl">
-            <input
-              className={`input mono${errors.name ? ' err' : ''}`}
-              value={form.name}
-              onChange={e => set('name', e.target.value)}
-              placeholder="my-profile"
-              maxLength={32}
-              disabled={isEdit}
-              data-testid="pf-input-name"
-            />
-            {errors.name && <div className="hint err">{errors.name}</div>}
-          </div>
+          <button className="pf-x" onClick={close} aria-label="Close">{Icons.close}</button>
         </div>
 
-        {/* Image */}
-        <div className="form-row">
-          <div className="form-lbl">
-            <span>Image <span className="req">*</span></span>
-            <span className="sub">container image URI</span>
-          </div>
-          <div className="form-ctl">
-            <input
-              className={`input mono${errors.image ? ' err' : ''}`}
-              value={form.image}
-              onChange={e => set('image', e.target.value)}
-              placeholder="ghcr.io/hal0ai/…:tag"
-              data-testid="pf-input-image"
-            />
-            {errors.image && <div className="hint err">{errors.image}</div>}
-          </div>
-        </div>
+        <form className="pf-drawer-body" onSubmit={submit} noValidate>
+          <FormRow label="Name" req sub="lowercase · - _ · ≤32"
+            error={show('name') ? errs.name : null}
+            ok={!isEdit && nameValid}
+            counter={!isEdit ? { text: nameLen + '/32', warn: nameLen >= 28 } : null}>
+            <input className={'pf-input mono' + (show('name') && errs.name ? ' err' : '')} value={form.name}
+              onChange={e => set('name', e.target.value)} onBlur={() => touch('name')}
+              placeholder="my-profile" maxLength={32} disabled={isEdit}
+              aria-invalid={!!(show('name') && errs.name)} data-testid="pf-input-name" />
+          </FormRow>
 
-        {/* Flags */}
-        <div className="form-row">
-          <div className="form-lbl">
-            <span>Flags</span>
-            <span className="sub">extra CLI flags appended to the run command</span>
-          </div>
-          <div className="form-ctl">
-            <input
-              className="input mono"
-              value={form.flags}
-              onChange={e => set('flags', e.target.value)}
-              placeholder="--flash-attn on -ngl 999"
-              data-testid="pf-input-flags"
-            />
-          </div>
-        </div>
+          <FormRow label="Intent" sub="what it's for">
+            <input className="pf-input" value={form.intent} onChange={e => set('intent', e.target.value)}
+              placeholder="MoE agents · long-ctx" data-testid="pf-input-intent" />
+          </FormRow>
 
-        {/* Device class */}
-        <div className="form-row">
-          <div className="form-lbl">
-            <span>Device class</span>
-            <span className="sub">gpu · npu · cpu · auto</span>
-          </div>
-          <div className="form-ctl">
-            <select
-              className="input mono"
-              value={form.device_class || ''}
-              onChange={e => set('device_class', e.target.value)}
-              data-testid="pf-select-device"
-            >
-              <option value="">auto</option>
-              <option value="gpu">gpu</option>
-              <option value="npu">npu</option>
-              <option value="cpu">cpu</option>
-            </select>
-          </div>
-        </div>
+          <FormRow label="Image" req sub="container image URI"
+            error={show('image') ? errs.image : null}
+            warn={!errs.image ? warns.image : null}
+            ok={!!(form.image || '').trim() && !errs.image && !warns.image}>
+            <input className={'pf-input mono' + (show('image') && errs.image ? ' err' : '')} value={form.image}
+              onChange={e => set('image', e.target.value)} onBlur={() => touch('image')}
+              placeholder="ghcr.io/hal0ai/…:tag" aria-invalid={!!(show('image') && errs.image)}
+              data-testid="pf-input-image" />
+          </FormRow>
 
-        {/* MTP */}
-        <div className="form-row">
-          <div className="form-lbl">
-            <span>MTP</span>
-            <span className="sub">Multi-Token Prediction speculative decoding</span>
-          </div>
-          <div className="form-ctl">
-            <label className="pf-toggle-label">
-              <input
-                type="checkbox"
-                checked={!!form.mtp}
-                onChange={e => set('mtp', e.target.checked)}
-                data-testid="pf-check-mtp"
-              />
-              <span className="mono" style={{ fontSize: 11, marginLeft: 6 }}>
-                {form.mtp ? 'enabled' : 'disabled'}
-              </span>
-            </label>
-          </div>
-        </div>
+          <FormRow label="Backend" sub="runtime path">
+            <div className="pf-seg" data-testid="pf-seg-backend">
+              {Object.keys(BACKEND_META).map(k => (
+                <button type="button" key={k} className={'pf-seg-btn' + (form.backend === k ? ' on' : '')}
+                  style={{ '--bk': BACKEND_META[k].color }} onClick={() => set('backend', k)}>
+                  <span className="pf-chip-dot" />{BACKEND_META[k].label}
+                </button>
+              ))}
+            </div>
+          </FormRow>
 
-        <div className="pf-form-foot">
-          <button type="button" className="btn ghost sm" onClick={onClose}>Cancel</button>
-          <button
-            type="submit"
-            className="btn sm"
-            disabled={submitting}
-            data-testid="pf-btn-submit"
-          >
-            {submitting ? 'Saving…' : isEdit ? 'Save' : 'Create'}
+          <FormRow label="Quant" sub="weight format">
+            <input className="pf-input mono" value={form.quant || ''} onChange={e => set('quant', e.target.value)}
+              placeholder="FP4 · Q4_K_M …" data-testid="pf-input-quant" />
+          </FormRow>
+
+          <FormRow label="Flags" sub="appended to the run command">
+            <textarea className="pf-input mono pf-textarea" value={form.flags || ''}
+              onChange={e => set('flags', e.target.value)} rows={3} placeholder="--flash-attn on -ngl 999"
+              data-testid="pf-input-flags" />
+          </FormRow>
+
+          <FormRow label="MTP" sub="Multi-Token Prediction speculative decode">
+            <button type="button" className={'pf-switch' + (form.mtp ? ' on' : '')} onClick={() => set('mtp', !form.mtp)}
+              role="switch" aria-checked={form.mtp} data-testid="pf-check-mtp">
+              <span className="pf-switch-knob" />
+              <span className="pf-switch-lbl mono">{form.mtp ? 'enabled' : 'disabled'}</span>
+            </button>
+          </FormRow>
+        </form>
+
+        <div className="pf-drawer-foot">
+          <div className="pf-drawer-preview mono" style={{ '--bk': meta.color }}>
+            <span className="pf-chip-dot" />{meta.label}{form.mtp ? ' · MTP' : ''}
+          </div>
+          <span className="pf-grow" />
+          {submitted && blocking && (
+            <span className="pf-foot-err mono">{Icons.alert}Fix {Object.keys(errs).length} field{Object.keys(errs).length > 1 ? 's' : ''}</span>
+          )}
+          <button className="pf-btn" onClick={close} type="button">Cancel</button>
+          <button className={'pf-btn primary' + (submitted && blocking ? ' is-blocked' : '')}
+            onClick={submit} disabled={submitting} data-testid="pf-btn-submit">
+            {submitting ? 'Saving…' : isEdit ? 'Save changes' : 'Create profile'}
           </button>
         </div>
-      </form>
+      </div>
     </div>
   );
 }
 
-// ── Delete confirm ────────────────────────────────────────────────────────────
+// ── Delete confirm ──────────────────────────────────────────────────────────────
 
-function DeleteConfirm({ profile, onCancel, onConfirmed }) {
+function DeleteConfirm({ p, onCancel, onConfirmed }) {
   const del = useProfileDelete();
   const [busy, setBusy] = useState(false);
+  const usedBy = p.used_by || [];
+  const inUse = usedBy.length;
 
   async function handleDelete() {
     setBusy(true);
     try {
-      await del.mutateAsync(profile.name);
-      toast(`Profile ${profile.name} deleted`, 'ok');
+      await del.mutateAsync(p.name);
+      toast(`Profile ${p.name} deleted`, 'ok');
       onConfirmed();
     } catch (err) {
       const code = err?.code || '';
@@ -281,181 +471,60 @@ function DeleteConfirm({ profile, onCancel, onConfirmed }) {
   }
 
   return (
-    <div className="pf-confirm-scrim" onClick={onCancel} role="dialog" aria-label="Confirm delete">
-      <div className="pf-confirm" onClick={e => e.stopPropagation()}>
-        <div className="pf-confirm-title mono">Delete profile · {profile.name}?</div>
-        <div className="pf-confirm-body mono">
-          This removes the profile permanently. Slots using it will revert to defaults.
-        </div>
-        <div className="pf-confirm-foot">
-          <button className="btn ghost sm" onClick={onCancel}>Cancel</button>
-          <button
-            className="btn danger sm"
-            onClick={handleDelete}
-            disabled={busy}
-            data-testid="pf-btn-delete-confirm"
-          >
-            {busy ? 'Deleting…' : 'Delete'}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ── Profile card ──────────────────────────────────────────────────────────────
-
-function ProfileCard({ profile, onEdit, onClone, onDelete }) {
-  const intent = profileIntent(profile);
-  const tag = imageTag(profile.image);
-  const isSeed = !!profile.seed;
-
-  return (
-    <div className="pf-card">
-      <div className="pf-card-head">
-        <div className="pf-intent">{intent}</div>
-        <div className="pf-card-badges">
-          {isSeed && <span className="pf-badge immutable" title="Seed profiles are read-only">seed</span>}
-          {profile.mtp && <span className="pf-badge">MTP</span>}
-          {profile.device_class && profile.device_class !== 'gpu' && (
-            <span className="pf-badge device">{profile.device_class}</span>
-          )}
-        </div>
-      </div>
-      <div className="pf-meta mono">
-        <span className="pf-slug">{profile.name}</span>
-        <span className="pf-sep">·</span>
-        <span className="pf-tag">{tag}</span>
-      </div>
-      {profile.cloned_from && (
-        <div className="pf-based mono">based on {profile.cloned_from}</div>
-      )}
-      {profile.resolved_flags && (
-        <div className="pf-flags mono">{profile.resolved_flags}</div>
-      )}
-      <div className="pf-card-actions">
-        {isSeed ? (
-          <button
-            className="btn ghost xs"
-            onClick={() => onClone(profile)}
-            title="Seed profiles are immutable — edit a custom copy instead"
-            data-testid={`pf-btn-editcopy-${profile.name}`}
-          >
-            Edit a copy
-          </button>
+    <div className="pf-scrim center pf-confirm-scrim" onMouseDown={onCancel}>
+      <div className="pf-confirm" onMouseDown={e => e.stopPropagation()} role="dialog" aria-label="Confirm delete">
+        <div className="pf-confirm-h pf-confirm-title mono">{Icons.trash} Delete · {p.name}?</div>
+        {inUse ? (
+          <div className="pf-confirm-b">
+            <div className="pf-warn mono">In use by {inUse} slot{inUse > 1 ? 's' : ''}.</div>
+            <div className="pf-slots" style={{ margin: '8px 0 2px' }}>{usedBy.map(s => <SlotPill key={s} name={s} />)}</div>
+            <div className="pf-confirm-sub">Detach these slots before deleting — they'd revert to defaults.</div>
+          </div>
         ) : (
-          <>
-            <button
-              className="btn ghost xs"
-              onClick={() => onClone(profile)}
-              title="Clone this profile"
-              data-testid={`pf-btn-clone-${profile.name}`}
-            >
-              Clone
-            </button>
-            <button
-              className="btn ghost xs"
-              onClick={() => onEdit(profile)}
-              title="Edit"
-              data-testid={`pf-btn-edit-${profile.name}`}
-            >
-              Edit
-            </button>
-          </>
+          <div className="pf-confirm-b">
+            <div className="pf-confirm-sub">This removes the profile permanently. This cannot be undone.</div>
+          </div>
         )}
-        <button
-          className="btn ghost xs danger"
-          onClick={() => onDelete(profile)}
-          disabled={isSeed}
-          title={isSeed ? 'Seed profiles cannot be deleted' : 'Delete'}
-          data-testid={`pf-btn-delete-${profile.name}`}
-        >
-          Delete
-        </button>
+        <div className="pf-confirm-foot">
+          <button className="pf-btn" onClick={onCancel}>Cancel</button>
+          <button className="pf-btn danger solid" onClick={handleDelete} disabled={!!inUse || busy}
+            data-testid="pf-btn-delete-confirm">
+            {inUse ? 'In use' : busy ? 'Deleting…' : 'Delete profile'}
+          </button>
+        </div>
       </div>
     </div>
   );
 }
 
-// ── Main view ─────────────────────────────────────────────────────────────────
+// ── Summary cell ─────────────────────────────────────────────────────────────────
+
+function Stat({ value, label, accent }) {
+  return (
+    <div className="pf-stat">
+      <span className="pf-stat-v num" style={accent ? { color: accent } : null}>{value}</span>
+      <span className="pf-stat-l mono">{label}</span>
+    </div>
+  );
+}
+
+// ── Main view ────────────────────────────────────────────────────────────────────
 
 function ProfilesView() {
   const query = useProfiles();
   const profiles = query.data ?? [];
 
-  // Drawer state: null = closed, {mode:'create'} or {mode:'edit',profile} or {mode:'clone',profile}
-  const [drawer, setDrawer] = useState(null);
-  const [confirmDelete, setConfirmDelete] = useState(null);
+  const [drawer, setDrawer] = useState(null);   // {mode, source}
+  const [confirm, setConfirm] = useState(null);
 
-  function openCreate() {
-    setDrawer({ mode: 'create' });
-  }
-
-  function openEdit(profile) {
-    setDrawer({ mode: 'edit', profile });
-  }
-
-  function openClone(profile) {
-    setDrawer({ mode: 'clone', profile });
-  }
-
-  function openDelete(profile) {
-    setConfirmDelete(profile);
-  }
-
-  function closeDrawer() {
-    setDrawer(null);
-  }
-
-  function onSaved() {
-    setDrawer(null);
-  }
-
-  function onDeleted() {
-    setConfirmDelete(null);
-  }
-
-  // Build initial form values for the drawer
-  let formInitial = null;
-  let isEdit = false;
-  let formTitle = null;
-  if (drawer) {
-    if (drawer.mode === 'create') {
-      formInitial = { ...BLANK_FORM };
-      isEdit = false;
-    } else if (drawer.mode === 'edit' && drawer.profile) {
-      formInitial = {
-        name: drawer.profile.name,
-        image: drawer.profile.image || '',
-        flags: drawer.profile.flags || '',
-        mtp: !!drawer.profile.mtp,
-        device_class: drawer.profile.device_class || '',
-      };
-      isEdit = true;
-    } else if (drawer.mode === 'clone' && drawer.profile) {
-      // Seeds fork via "Edit a copy" (<seed>-custom); custom profiles clone
-      // as <name>-copy. Both record cloned_from provenance on the new profile.
-      const isSeed = !!drawer.profile.seed;
-      const suffix = isSeed ? '-custom' : '-copy';
-      formInitial = {
-        name: `${drawer.profile.name}${suffix}`.slice(0, 32),
-        image: drawer.profile.image || '',
-        flags: drawer.profile.flags || '',
-        mtp: !!drawer.profile.mtp,
-        device_class: drawer.profile.device_class || '',
-        cloned_from: drawer.profile.name,
-      };
-      isEdit = false;
-      if (isSeed) formTitle = `Edit a copy · ${drawer.profile.name}`;
-    }
-  }
+  const seeds = profiles.filter(p => p.seed);
+  const custom = profiles.filter(p => !p.seed);
+  const inUseCount = profiles.filter(p => (p.used_by || []).length).length;
 
   if (query.isLoading) {
     return (
       <div className="view">
-        <div className="view-head">
-          <h2>Profiles</h2>
-        </div>
+        <div className="vh"><span className="vh-eye mono">RUNTIME</span><h1>Profiles</h1></div>
         <div className="empty mono">Loading profiles…</div>
       </div>
     );
@@ -464,10 +533,8 @@ function ProfilesView() {
   if (query.isError) {
     return (
       <div className="view">
-        <div className="view-head">
-          <h2>Profiles</h2>
-        </div>
-        <div className="empty mono" style={{color: 'var(--err)'}}>
+        <div className="vh"><span className="vh-eye mono">RUNTIME</span><h1>Profiles</h1></div>
+        <div className="empty mono" style={{ color: 'var(--err)' }}>
           Failed to load profiles: {query.error?.message || 'unknown error'}
         </div>
       </div>
@@ -476,55 +543,66 @@ function ProfilesView() {
 
   return (
     <div className="view">
-      <div className="view-head">
-        <h2>Profiles</h2>
-        <div className="view-sub mono">
-          Container-slot templates — image + bench-tuned flags per inference workload.
-        </div>
+      <div className="vh">
+        <span className="vh-eye mono">RUNTIME</span>
+        <h1>Profiles</h1>
+        <div className="vh-spacer" />
+        <span className="hint mono">image + bench-tuned flags per workload</span>
+        <button className="pf-btn primary lg" onClick={() => setDrawer({ mode: 'create' })} data-testid="pf-btn-new">
+          {Icons.plus} New profile
+        </button>
       </div>
 
-      <div className="pf-toolbar">
-        <button
-          className="btn sm"
-          onClick={openCreate}
-          data-testid="pf-btn-new"
-        >
-          + New profile
-        </button>
+      <div className="pf-summary">
+        <Stat value={profiles.length} label="profiles" />
+        <span className="pf-stat-div" />
+        <Stat value={seeds.length} label="seed templates" />
+        <Stat value={custom.length} label="custom" accent="var(--accent)" />
+        <span className="pf-stat-div" />
+        <Stat value={`${inUseCount}/${profiles.length}`} label="bound to slots" accent="var(--ok)" />
+        <span className="pf-grow" />
+        <div className="pf-legend mono">
+          {Object.entries(BACKEND_META).map(([k, m]) => (
+            <span className="pf-legend-i" key={k} style={{ '--bk': m.color }}><span className="pf-chip-dot" />{m.label}</span>
+          ))}
+        </div>
       </div>
 
       {profiles.length === 0 ? (
         <div className="empty mono">No profiles configured.</div>
       ) : (
-        <div className="pf-list">
-          {profiles.map(p => (
-            <ProfileCard
-              key={p.name}
-              profile={p}
-              onEdit={openEdit}
-              onClone={openClone}
-              onDelete={openDelete}
-            />
-          ))}
-        </div>
+        <>
+          <Section title="Seed templates" count={seeds.length} hint="immutable · ship with hal0">
+            {seeds.map((p, i) => (
+              <ProfileCard key={p.name} p={p} index={i}
+                onEdit={pp => setDrawer({ mode: 'edit', source: pp })}
+                onClone={pp => setDrawer({ mode: 'clone', source: pp })}
+                onDelete={pp => setConfirm(pp)} />
+            ))}
+          </Section>
+
+          <Section title="Custom profiles" count={custom.length} hint="forked or authored on this box">
+            {custom.map((p, i) => (
+              <ProfileCard key={p.name} p={p} index={i}
+                onEdit={pp => setDrawer({ mode: 'edit', source: pp })}
+                onClone={pp => setDrawer({ mode: 'clone', source: pp })}
+                onDelete={pp => setConfirm(pp)} />
+            ))}
+          </Section>
+        </>
       )}
 
       {drawer && (
-        <ProfileForm
-          initial={formInitial}
-          isEdit={isEdit}
-          title={formTitle}
-          onClose={closeDrawer}
-          onSaved={onSaved}
+        <Drawer
+          mode={drawer.mode}
+          source={drawer.source}
+          existing={profiles.map(p => p.name)}
+          onClose={() => setDrawer(null)}
+          onSaved={() => setDrawer(null)}
         />
       )}
-
-      {confirmDelete && (
-        <DeleteConfirm
-          profile={confirmDelete}
-          onCancel={() => setConfirmDelete(null)}
-          onConfirmed={onDeleted}
-        />
+      {confirm && (
+        <DeleteConfirm p={confirm} onCancel={() => setConfirm(null)} onConfirmed={() => setConfirm(null)} />
       )}
     </div>
   );

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -3064,62 +3064,232 @@ select.npu-sel {
 .variant-row .sz { color: var(--fg-3); }
 .variant-row .info { color: var(--fg-4); font-size: 11px; text-align: right; }
 
-/* ─── Profiles view (issue #658) ───────────────────────────────── */
-.pf-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 16px 0;
+/* ─── Profiles view (issue #658; overhaul 2026-06-13) ───────────────────────
+ * Structured surface: summary strip, seed/custom grouping, backend-hued cards,
+ * slide-in form drawer, in-use-guarded delete. Ported from the design kit
+ * (hal0-design/profiles_overhaul-new); namespaced pf-*. */
+
+/* SVG icon sizing — Icons render at a fixed 16px viewport; size them down
+ * per surface to match the design's inline glyph sizes. */
+.pf-chip svg { width: 10px; height: 10px; }
+.pf-btn svg { width: 13px; height: 13px; }
+.pf-x svg { width: 14px; height: 14px; }
+.pf-field-ok svg { width: 12px; height: 12px; }
+.pf-msg svg, .pf-foot-err svg { width: 11px; height: 11px; }
+.pf-confirm-h svg { width: 13px; height: 13px; }
+
+/* Summary strip */
+.pf-summary {
+  display: flex; align-items: center; gap: 22px;
+  padding: 14px 18px; margin-bottom: 22px;
+  border: 1px solid var(--line); border-radius: var(--rad-lg); background: var(--bg-1);
 }
+.pf-stat { display: flex; flex-direction: column; gap: 2px; }
+.pf-stat-v { font-family: var(--jbm); font-size: 20px; font-weight: 500; color: var(--fg); letter-spacing: -0.01em; line-height: 1; }
+.pf-stat-l { font-size: 10px; color: var(--fg-4); letter-spacing: 0.04em; }
+.pf-stat-div { width: 1px; align-self: stretch; background: var(--line-soft); margin: 2px 0; }
+.pf-grow { flex: 1; }
+.pf-legend { display: flex; gap: 14px; }
+.pf-legend-i { display: inline-flex; align-items: center; gap: 6px; font-size: 10.5px; color: var(--fg-3); }
+.pf-chip-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--bk, var(--fg-4)); box-shadow: 0 0 6px var(--bk, transparent); flex-shrink: 0; }
+
+/* Section */
+.pf-section { margin-bottom: 26px; }
+.pf-section .sec { display: flex; align-items: baseline; gap: 14px; margin: 0 0 14px; }
+.pf-sec-hint { font-size: 10.5px; color: var(--fg-4); }
+.pf-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 14px; }
+
+/* Profile card */
 .pf-card {
-  padding: 14px 16px;
-  border: 1px solid var(--line-soft);
-  border-radius: var(--rad);
-  background: var(--bg-card);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+  position: relative; overflow: hidden;
+  border: 1px solid var(--line); border-radius: var(--rad-lg); background: var(--bg-1);
+  padding: 14px 16px 12px; padding-left: 18px;
+  display: flex; flex-direction: column; gap: 11px; opacity: 1;
+  transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
 }
-.pf-card:hover { border-color: var(--line-strong); }
-.pf-intent {
-  font-size: 13.5px;
-  font-weight: 500;
-  color: var(--fg);
+@media (prefers-reduced-motion: no-preference) {
+  .pf-card { animation: pf-rise 0.4s ease backwards; }
 }
-.pf-meta {
-  font-size: 11px;
-  color: var(--fg-3);
-  display: flex;
-  align-items: center;
-  gap: 6px;
+@keyframes pf-rise { from { transform: translateY(10px); } to { transform: translateY(0); } }
+.pf-card:hover { border-color: var(--line-strong); transform: translateY(-1px); box-shadow: 0 6px 20px rgba(0,0,0,0.28); }
+.pf-accent { position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: var(--bk, var(--fg-4)); opacity: 0.85; }
+.pf-card:hover .pf-accent { opacity: 1; box-shadow: 0 0 12px var(--bk); }
+
+.pf-card-top { display: flex; align-items: flex-start; gap: 12px; }
+.pf-headline { flex: 1; min-width: 0; }
+.pf-intent { font-size: 14.5px; font-weight: 500; color: var(--fg); letter-spacing: -0.01em; }
+.pf-slug-row { display: flex; align-items: center; gap: 8px; margin-top: 3px; font-size: 11px; }
+.pf-slug { color: var(--fg-3); }
+.pf-based { color: var(--fg-4); }
+
+.pf-metric { display: flex; flex-direction: column; align-items: flex-end; flex-shrink: 0; text-align: right; }
+.pf-tps { font-family: var(--jbm); font-size: 19px; font-weight: 500; color: var(--accent); line-height: 1; letter-spacing: -0.02em; }
+.pf-tps-u { font-size: 9px; color: var(--fg-4); letter-spacing: 0.03em; margin-top: 3px; text-transform: uppercase; }
+
+/* chip row */
+.pf-chips { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.pf-chip {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 2px 8px; border-radius: 999px; border: 1px solid var(--line);
+  font-family: var(--jbm); font-size: 10px; color: var(--fg-3); background: var(--bg-2);
+  white-space: nowrap;
 }
-.pf-slug { color: var(--fg-4); }
-.pf-sep  { color: var(--fg-5); }
-.pf-tag  { color: var(--fg-3); }
-.pf-badge {
-  font-size: 9px;
-  padding: 1px 5px;
-  border-radius: 3px;
-  background: var(--accent-soft);
-  color: var(--accent);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
+.pf-chip.backend { color: var(--bk); border-color: color-mix(in srgb, var(--bk) 34%, transparent); background: color-mix(in srgb, var(--bk) 10%, transparent); }
+.pf-chip.mtp { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.pf-chip.mtp svg { color: var(--accent); }
+.pf-chip.seed { color: var(--fg-3); border-color: var(--line); }
+.pf-chip.seed svg { color: var(--fg-4); }
+.pf-chip.custom { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+
+/* image uri */
+.pf-image { display: flex; align-items: baseline; gap: 9px; font-size: 11px; min-width: 0; }
+.pf-image-lbl { color: var(--fg-5); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; flex-shrink: 0; }
+.pf-image-uri { color: var(--fg-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* flags code well */
+.pf-flags { display: flex; flex-direction: column; gap: 5px; }
+.pf-flags-lbl { font-size: 9px; color: var(--fg-5); letter-spacing: 0.08em; text-transform: uppercase; }
+.pf-flags-code {
+  display: block; font-family: var(--jbm); font-size: 11px; line-height: 1.55;
+  color: var(--fg-2); background: var(--bg); border: 1px solid var(--line-soft);
+  border-radius: var(--rad-sm); padding: 8px 10px; white-space: pre-wrap; word-break: break-word;
 }
-.pf-based {
-  font-size: 10px;
-  color: var(--fg-4);
-  font-style: italic;
+
+/* footer: usage + actions */
+.pf-foot { display: flex; align-items: center; gap: 12px; padding-top: 11px; border-top: 1px solid var(--line-soft); }
+.pf-usage { flex: 1; min-width: 0; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.pf-usage-lbl { font-size: 9px; color: var(--fg-5); letter-spacing: 0.06em; text-transform: uppercase; }
+.pf-slots { display: inline-flex; gap: 6px; flex-wrap: wrap; }
+.pf-slot { display: inline-flex; align-items: center; gap: 5px; padding: 2px 7px 2px 6px; border-radius: 4px; background: var(--bg-2); border: 1px solid var(--line); font-size: 10.5px; color: var(--fg-2); }
+.pf-slot-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--ok); box-shadow: 0 0 6px var(--ok); }
+.pf-unused { font-size: 10.5px; color: var(--fg-4); }
+
+.pf-actions { display: flex; gap: 6px; flex-shrink: 0; }
+
+/* Buttons (profile-scoped) */
+.pf-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 10px; border-radius: var(--rad-sm);
+  border: 1px solid var(--line); background: transparent; color: var(--fg-2);
+  font-family: var(--jbm); font-size: 11px; cursor: pointer;
+  transition: all 0.15s ease;
 }
-.pf-flags {
-  font-size: 10px;
-  color: var(--fg-4);
-  background: var(--bg);
-  border: 1px solid var(--line-soft);
-  border-radius: var(--rad-sm);
-  padding: 6px 10px;
-  white-space: pre-wrap;
-  word-break: break-all;
-  margin-top: 2px;
+.pf-btn:hover { color: var(--fg); border-color: var(--line-strong); background: var(--bg-2); }
+.pf-btn svg { color: var(--fg-4); }
+.pf-btn:hover svg { color: var(--fg-2); }
+.pf-btn.primary { color: #0a0a0a; background: var(--accent); border-color: var(--accent); font-weight: 600; }
+.pf-btn.primary:hover { background: var(--hal0-accent-hover); border-color: var(--hal0-accent-hover); }
+.pf-btn.primary svg { color: #0a0a0a; }
+.pf-btn.lg { padding: 7px 13px; font-size: 12px; }
+.pf-btn.danger:hover:not(:disabled) { color: var(--err); border-color: var(--err-line); background: var(--err-soft); }
+.pf-btn.danger:hover:not(:disabled) svg { color: var(--err); }
+.pf-btn.danger.solid { color: #0a0a0a; background: var(--err); border-color: var(--err); font-weight: 600; }
+.pf-btn.danger.solid svg { color: #0a0a0a; }
+.pf-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* Scrim (shared by drawer + confirm) */
+.pf-scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.55); backdrop-filter: blur(2px); z-index: 100; animation: pf-fade 0.2s ease; }
+.pf-scrim.center { display: flex; align-items: center; justify-content: center; padding: 24px; }
+.pf-scrim.out { animation: pf-fade-out 0.2s ease forwards; }
+@keyframes pf-fade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes pf-fade-out { to { opacity: 0; } }
+
+/* Drawer */
+.pf-drawer {
+  position: absolute; top: 0; right: 0; bottom: 0; width: 460px; max-width: 92vw;
+  background: var(--bg-1); border-left: 1px solid var(--line-strong);
+  display: flex; flex-direction: column; box-shadow: -16px 0 48px rgba(0,0,0,0.4);
+  animation: pf-slide 0.26s ease;
+}
+.pf-drawer.out { animation: pf-slide-out 0.2s ease forwards; }
+@keyframes pf-slide { from { transform: translateX(100%); } to { transform: translateX(0); } }
+@keyframes pf-slide-out { to { transform: translateX(100%); } }
+
+.pf-drawer-head { display: flex; align-items: flex-start; gap: 12px; padding: 18px 20px 14px; border-bottom: 1px solid var(--line); }
+.pf-drawer-eye { font-size: 10px; color: var(--fg-4); letter-spacing: 0.1em; }
+.pf-drawer-title { font-size: 15px; color: var(--fg); font-weight: 500; margin-top: 3px; }
+.pf-x { margin-left: auto; width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--line); border-radius: var(--rad-sm); background: transparent; color: var(--fg-3); cursor: pointer; flex-shrink: 0; }
+.pf-x:hover { color: var(--fg); border-color: var(--line-strong); }
+
+.pf-drawer-body { flex: 1; overflow-y: auto; padding: 6px 20px 14px; }
+.pf-row { display: grid; grid-template-columns: 130px 1fr; gap: 14px; align-items: start; padding: 13px 0; border-bottom: 1px solid var(--line-soft); }
+.pf-row:last-child { border-bottom: none; }
+.pf-row-lbl { display: flex; flex-direction: column; gap: 3px; padding-top: 6px; }
+.pf-row-lbl > span:first-child { font-size: 12.5px; color: var(--fg); }
+.pf-row-sub { font-size: 9.5px; color: var(--fg-4); letter-spacing: 0.02em; line-height: 1.35; }
+.pf-row-ctl { min-width: 0; }
+.pf-req { color: var(--err); margin-left: 3px; font-weight: 600; }
+
+.pf-field { position: relative; display: block; }
+.pf-field.ok .pf-input { padding-right: 30px; border-color: var(--ok-line); }
+.pf-field.err .pf-input { border-color: var(--err-line); }
+.pf-field-ok { position: absolute; right: 9px; top: 50%; transform: translateY(-50%); color: var(--ok); display: inline-flex; pointer-events: none; }
+.pf-field-ok svg { color: var(--ok); }
+
+.pf-row-foot { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: 6px; min-height: 13px; }
+.pf-msg { display: inline-flex; align-items: center; gap: 5px; font-size: 10px; line-height: 1.3; }
+.pf-msg svg { flex-shrink: 0; }
+.pf-msg.err { color: var(--err); }
+.pf-msg.err svg { color: var(--err); }
+.pf-msg.warn { color: var(--warn); }
+.pf-msg.warn svg { color: var(--warn); }
+.pf-counter { font-size: 10px; color: var(--fg-5); flex-shrink: 0; margin-left: auto; }
+.pf-counter.warn { color: var(--warn); }
+
+.pf-input {
+  width: 100%; padding: 7px 10px; border-radius: var(--rad-sm);
+  border: 1px solid var(--line); background: var(--bg); color: var(--fg);
+  font-family: var(--geist); font-size: 12.5px; outline: none;
+  transition: border-color 0.15s ease;
+}
+.pf-input.mono { font-family: var(--jbm); font-size: 12px; }
+.pf-input:focus { border-color: var(--accent-line); }
+.pf-input.err { border-color: var(--err-line); }
+.pf-input::placeholder { color: var(--fg-5); }
+.pf-textarea { resize: vertical; line-height: 1.5; }
+select.pf-input { cursor: pointer; }
+
+/* backend segmented control */
+.pf-seg { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
+.pf-seg-btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 7px 8px; border-radius: var(--rad-sm); border: 1px solid var(--line);
+  background: var(--bg); color: var(--fg-3); font-family: var(--jbm); font-size: 11px; cursor: pointer;
+  transition: all 0.15s ease;
+}
+.pf-seg-btn:hover { color: var(--fg); border-color: var(--line-strong); }
+.pf-seg-btn.on { color: var(--bk); border-color: color-mix(in srgb, var(--bk) 50%, transparent); background: color-mix(in srgb, var(--bk) 12%, transparent); }
+
+/* MTP switch */
+.pf-switch { display: inline-flex; align-items: center; gap: 9px; padding: 0; border: none; background: transparent; cursor: pointer; }
+.pf-switch::before { content: ""; width: 34px; height: 19px; border-radius: 999px; background: var(--bg-3); border: 1px solid var(--line); position: relative; transition: all 0.15s ease; flex-shrink: 0; }
+.pf-switch.on::before { background: var(--accent-soft); border-color: var(--accent-line); }
+.pf-switch-knob { position: absolute; left: 3px; width: 14px; height: 14px; border-radius: 50%; background: var(--fg-4); transition: all 0.15s ease; pointer-events: none; }
+.pf-switch.on .pf-switch-knob { left: 18px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.pf-switch-lbl { font-size: 11px; color: var(--fg-3); }
+.pf-switch.on .pf-switch-lbl { color: var(--accent); }
+
+.pf-drawer-foot { display: flex; align-items: center; gap: 8px; padding: 14px 20px; border-top: 1px solid var(--line); background: var(--bg); }
+.pf-drawer-preview { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; color: var(--bk); padding: 4px 9px; border-radius: 999px; border: 1px solid color-mix(in srgb, var(--bk) 34%, transparent); background: color-mix(in srgb, var(--bk) 10%, transparent); }
+.pf-foot-err { display: inline-flex; align-items: center; gap: 5px; font-size: 10.5px; color: var(--err); margin-right: 4px; }
+.pf-foot-err svg { color: var(--err); }
+.pf-btn.primary.is-blocked { animation: pf-shake 0.32s ease; }
+@keyframes pf-shake { 0%,100% { transform: translateX(0); } 20% { transform: translateX(-4px); } 40% { transform: translateX(4px); } 60% { transform: translateX(-3px); } 80% { transform: translateX(2px); } }
+
+/* Delete confirm */
+.pf-confirm { width: 100%; max-width: 400px; background: var(--bg-1); border: 1px solid var(--line-strong); border-radius: var(--rad-lg); box-shadow: var(--shadow-menu, 0 16px 48px rgba(0,0,0,0.5)); overflow: hidden; animation: pf-pop 0.22s ease; }
+@keyframes pf-pop { from { opacity: 0; transform: scale(0.96) translateY(6px); } to { opacity: 1; transform: scale(1) translateY(0); } }
+.pf-confirm-h { display: flex; align-items: center; gap: 8px; padding: 14px 16px; font-size: 13px; color: var(--fg); border-bottom: 1px solid var(--line-soft); }
+.pf-confirm-h svg { color: var(--err); }
+.pf-confirm-b { padding: 14px 16px; }
+.pf-warn { font-size: 12px; color: var(--warn); }
+.pf-confirm-sub { font-size: 12px; color: var(--fg-3); line-height: 1.5; margin-top: 6px; }
+.pf-confirm-foot { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 16px; border-top: 1px solid var(--line-soft); background: var(--bg); }
+
+@media (prefers-reduced-motion: reduce) {
+  .pf-card, .pf-scrim, .pf-drawer, .pf-confirm { animation: none !important; }
+  .pf-btn.primary.is-blocked { animation: none !important; }
+  .pf-card:hover { transform: none; }
 }
 
 /* ── Memory view (Hindsight engine surface) ─────────────────────────────── */

--- a/ui/tests/e2e/fixtures/mock-data.ts
+++ b/ui/tests/e2e/fixtures/mock-data.ts
@@ -256,6 +256,11 @@ export const MOCK_DATA = {
       device_class: 'gpu',
       backend: 'rocm',
       seed: true,
+      intent: 'MoE agents',
+      quant: 'FP4',
+      tps: 52.8,
+      rtf: null,
+      used_by: ['primary'],
     },
     {
       name: 'rocm-mtp',
@@ -266,6 +271,11 @@ export const MOCK_DATA = {
       device_class: 'gpu',
       backend: 'rocm',
       seed: true,
+      intent: 'Dense chat + MTP',
+      quant: 'FP4',
+      tps: 24.4,
+      rtf: null,
+      used_by: [],
     },
     {
       name: 'vulkan',
@@ -276,6 +286,11 @@ export const MOCK_DATA = {
       device_class: 'gpu',
       backend: 'vulkan',
       seed: true,
+      intent: 'Vulkan std · fallback',
+      quant: 'Q4_K_M',
+      tps: 41.0,
+      rtf: null,
+      used_by: [],
     },
     // Phase A seed — NPU container slot (FLM toolbox).
     {
@@ -287,6 +302,11 @@ export const MOCK_DATA = {
       device_class: 'npu',
       backend: null,
       seed: true,
+      intent: 'FLM NPU inference',
+      quant: 'W4ABF16',
+      tps: 38.6,
+      rtf: null,
+      used_by: [],
     },
     // Phase B5 seed — TTS container slot (kokoro-onnx, CPU-only).
     {
@@ -298,6 +318,11 @@ export const MOCK_DATA = {
       device_class: 'cpu',
       backend: null,
       seed: true,
+      intent: 'TTS · Kokoro',
+      quant: '',
+      tps: null,
+      rtf: 0.18,
+      used_by: ['tts'],
     },
     // ComfyUI image-generation seed (Phase D).
     {
@@ -309,6 +334,11 @@ export const MOCK_DATA = {
       device_class: 'img',
       backend: null,
       seed: true,
+      intent: 'Image generation',
+      quant: '',
+      tps: null,
+      rtf: null,
+      used_by: [],
     },
   ],
 }

--- a/ui/tests/e2e/specs/profiles-crud-v3.spec.ts
+++ b/ui/tests/e2e/specs/profiles-crud-v3.spec.ts
@@ -27,8 +27,15 @@ const CUSTOM_PROFILE = {
   mtp: false,
   resolved_flags: '--flash-attn on',
   device_class: 'gpu',
+  backend: 'rocm',
   seed: false,
   cloned_from: 'vulkan',
+  intent: 'Custom workload',
+  quant: 'FP4',
+  tps: null,
+  rtf: null,
+  // Unbound — keeps the card's Delete action enabled so the confirm flow runs.
+  used_by: [],
 }
 
 const PROFILES_WITH_CUSTOM = [...MOCK_DATA.profiles, CUSTOM_PROFILE]
@@ -84,17 +91,21 @@ test.describe('Profiles CRUD — Phase C6', () => {
     }
 
     // Intercept POST — capture body, respond 201 with the new profile.
+    // The GET only includes the new profile AFTER the POST fires; before
+    // that it must be absent so the form's client-side duplicate guard
+    // doesn't flag the name the user is typing.
+    let created = false
     await page.route('**/api/profiles', async (route) => {
       if (route.request().method() === 'POST') {
         try { posts.push(JSON.parse(route.request().postData() || '{}')) } catch { posts.push({}) }
+        created = true
         return route.fulfill({
           status: 201,
           contentType: 'application/json',
           body: JSON.stringify(NEW_PROFILE),
         })
       }
-      // GET returns updated list after create.
-      return json(route, [...PROFILES_WITH_CUSTOM, NEW_PROFILE])
+      return json(route, created ? [...PROFILES_WITH_CUSTOM, NEW_PROFILE] : PROFILES_WITH_CUSTOM)
     })
 
     await gotoProfiles(page)
@@ -144,7 +155,7 @@ test.describe('Profiles CRUD — Phase C6', () => {
     await expect(vulkanCard).toBeVisible()
 
     // Seed badge.
-    await expect(vulkanCard.locator('.pf-badge.immutable')).toBeVisible()
+    await expect(vulkanCard.locator('.pf-chip.seed.immutable')).toBeVisible()
 
     // "Edit a copy" replaces both the disabled Edit and the Clone button.
     const editCopyBtn = vulkanCard.locator('[data-testid="pf-btn-editcopy-vulkan"]')
@@ -237,7 +248,7 @@ test.describe('Profiles CRUD — Phase C6', () => {
     await gotoProfiles(page)
 
     const customCard = cardBySlug(page, 'my-custom')
-    await expect(customCard.locator('.pf-based')).toHaveText(/based on\s+vulkan/)
+    await expect(customCard.locator('.pf-based')).toHaveText(/vulkan/)
 
     // Seeds have no provenance line.
     const vulkanCard = cardBySlug(page, 'vulkan')

--- a/ui/tests/e2e/specs/profiles-page-v3.spec.ts
+++ b/ui/tests/e2e/specs/profiles-page-v3.spec.ts
@@ -119,7 +119,17 @@ test.describe('Profiles page (#658)', () => {
     const vulkanCard = page.locator('.pf-card', {
       has: page.locator('.pf-slug', { hasText: /^vulkan$/ }),
     })
-    await expect(vulkanCard.locator('.pf-intent')).toContainText('Vulkan std (fallback)')
+    await expect(vulkanCard.locator('.pf-intent')).toContainText('Vulkan std · fallback')
+  })
+
+  test('overhaul: summary strip + sectioned cards + backend chip + bench metric', async ({ page }) => {
+    await page.waitForSelector('.pf-card', { timeout: 10_000 })
+    await expect(page.locator('.pf-summary')).toBeVisible()
+    const seedSection = page.locator('.pf-section', { hasText: 'Seed templates' })
+    await expect(seedSection.locator('.pf-card')).toHaveCount(MOCK_DATA.profiles.length)
+    const rocm = page.locator('.pf-card', { has: page.locator('.pf-slug', { hasText: /^rocm$/ }) })
+    await expect(rocm.locator('.pf-chip.backend')).toContainText('ROCm')
+    await expect(rocm.locator('.pf-tps')).toHaveText('52.8')
   })
 })
 


### PR DESCRIPTION
Implements the profiles_overhaul-new design (IMPLEMENTATION.md handoff) into the dashboard, on top of #751 (rename + explicit backend) and #752 (memory).

## Backend (additive to #751)
- `ProfileConfig` gains persisted `intent` + `quant` (drawer-editable).
- `ResolvedProfile`/`to_dict` emit static bench `tps`/`rtf` (seeds only, null for custom) and `used_by` (one-pass slot reverse index).
- `SEED_PROFILES` + `installer/etc-hal0/profiles.toml` carry intent/quant for the renamed slugs.
- POST/PUT bodies accept intent/quant; `backend` stays #751's explicit field.

## Frontend
- `profiles.jsx` rewritten to the design: summary strip, seed/custom sections, backend-hued cards (bench hero metric, quant chip, image URI, flags well, "used by" pills), slide-in form drawer with inline validation + live backend preview, in-use-guarded delete confirm.
- Card hue reads explicit `backend`, falls back to `device_class` for non-GPU paths; headline falls back to `prettyProfile()`.
- 4 new `Icons` glyphs (copy/lock/zap/alert); ported `pf-*` CSS; extended TS types.

## Tests
Backend (catalog/route/config/slot_view) 307 green; ruff clean. UI typecheck + build clean; profiles e2e 19/19, slot-drawer/comfyui 10/10.

Note: CT105's live `/etc/hal0/profiles.toml` overrides `SEED_PROFILES` and isn't synced by deploy.sh — the deploy step syncs it so seed intent/quant render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)