### PR TITLE
feat(memory): cap Direction-C ego ring for high-degree nodes (#752 follow-up)

### DIFF
--- a/ui/src/api/mock.ts
+++ b/ui/src/api/mock.ts
@@ -512,7 +512,34 @@ function buildBankOperations(_url: string, match: RegExpMatchArray) {
 // filters handle type/q narrowing, and the prototype keeps every mentioned
 // entity (min_count defaults to 1), so the unfiltered payload is the right
 // forced-mock shape.
-function buildMemFactGraphRoute() {
+// A deliberately dense star graph for the `ingest` bank: one hub fact with
+// 40 semantic neighbours (+ a couple causal/temporal) so the Direction-C ego
+// ring-cap (>24 neighbours → "+K more") is exercisable in mock-mode e2e.
+function buildDenseFactGraph() {
+  const FT = ['world', 'experience', 'observation']
+  const nodes = [
+    { data: { id: 'hub', label: 'ingest hub note', text: 'Central note that many ingested chunks reference.', type: 'world', date: '2026-06-01T09:00', entities: 'ingest, hal0', color: '#7fb8ff' } },
+  ]
+  const edges: { data: Record<string, unknown> }[] = []
+  for (let i = 0; i < 40; i++) {
+    const id = 'leaf' + i
+    nodes.push({
+      data: {
+        id, label: 'ingested chunk ' + i, text: 'Ingested document chunk #' + i + ' referencing the hub.',
+        type: FT[i % 3], date: '2026-06-0' + (1 + (i % 7)) + 'T1' + (i % 9) + ':00',
+        entities: 'ingest', color: '#7fb8ff',
+      },
+    })
+    // most are semantic (the noisy bulk); a few causal/temporal stay salient.
+    const linkType = i < 2 ? 'causal' : i < 5 ? 'temporal' : 'cooccurrence'
+    edges.push({ data: { id: 'e' + i, source: 'hub', target: id, linkType: i < 8 ? linkType : 'semantic', weight: i < 8 ? 3 : 1 } })
+  }
+  return { nodes, edges, total_units: nodes.length }
+}
+
+function buildMemFactGraphRoute(_url: string, match: RegExpMatchArray) {
+  const bank = match && match[1]
+  if (bank === 'ingest') return buildDenseFactGraph()
   return buildMemFactGraph()
 }
 

--- a/ui/src/dash/memory-graph-ego.jsx
+++ b/ui/src/dash/memory-graph-ego.jsx
@@ -19,6 +19,12 @@
 
 const { useState, useRef, useEffect, useMemo } = React;
 
+// Ring-1 is capped to keep high-degree nodes legible (Hindsight's semantic
+// graph is far denser than curated banks — a single node can have dozens–
+// hundreds of neighbours). "+K more" steps the cap up; nothing is hidden
+// silently. Salience keeps the storyline edges (causal/temporal) on top.
+const RING1_CAP_STEP = 24;
+
 function GraphEgo({ graph, query, width, height, banner }) {
   const W = width, H = height;
   const nodes = (graph && graph.nodes) || [];
@@ -48,7 +54,11 @@ function GraphEgo({ graph, query, width, height, banner }) {
   const [centerId, setCenterId] = useState(null);
   const [trail, setTrail] = useState([]);
   const [hover, setHover] = useState(null);
+  const [ringCap, setRingCap] = useState(RING1_CAP_STEP);
   const center = (centerId && byId[centerId]) ? centerId : defaultCenter;
+
+  // reset the ring cap whenever the centre changes (each node starts collapsed)
+  useEffect(() => { setRingCap(RING1_CAP_STEP); }, [center]);
 
   // ── layout for current center ──────────────────────────────────────────────
   const layout = useMemo(() => {
@@ -60,19 +70,34 @@ function GraphEgo({ graph, query, width, height, banner }) {
     all.forEach(({ id, link, dir }) => {
       (map[id] = map[id] || { id, links: [] }).links.push({ link, dir });
     });
-    const ring1 = Object.values(map);
-    // order by dominant link type then time
-    const order = { causal: 0, temporal: 1, semantic: 2, cooccurrence: 3 };
-    ring1.sort((a, b) =>
-      (order[a.links[0].link.linkType] - order[b.links[0].link.linkType]) ||
-      ((byId[a.id]?.t || 0) - (byId[b.id]?.t || 0)));
+    const fullRing1 = Object.values(map);
+    // salience order: link-type priority (causal > temporal > cooccurrence >
+    // semantic), then strongest edge weight, then most recent. Keeps the
+    // storyline edges on top and sheds the noisy bulk-semantic fan first.
+    const order = { causal: 0, temporal: 1, cooccurrence: 2, semantic: 3 };
+    const rank = (lks) => Math.min(...lks.map((x) => order[x.link.linkType] ?? 9));
+    const maxW = (lks) => Math.max(...lks.map((x) => x.link.weight || 1));
+    fullRing1.sort((a, b) =>
+      (rank(a.links) - rank(b.links)) ||
+      (maxW(b.links) - maxW(a.links)) ||
+      ((byId[b.id]?.t || 0) - (byId[a.id]?.t || 0)));
+    const totalNbrs = fullRing1.length;
+    const ring1 = fullRing1.slice(0, ringCap);
+    const hidden = Math.max(0, totalNbrs - ring1.length);
     const R1 = Math.min(W * 0.26, H * 0.34, 200);
     const pos = { [center]: { x: cx, y: cy } };
-    const n1 = ring1.length;
+    const slots = ring1.length + (hidden > 0 ? 1 : 0); // reserve one slot for "+K more"
     ring1.forEach((nb, i) => {
-      const ang = -Math.PI / 2 + (i / Math.max(1, n1)) * Math.PI * 2;
+      const ang = -Math.PI / 2 + (i / Math.max(1, slots)) * Math.PI * 2;
       pos[nb.id] = { x: cx + Math.cos(ang) * R1, y: cy + Math.sin(ang) * R1, ang };
     });
+    let more = null;
+    if (hidden > 0) {
+      const ang = -Math.PI / 2 + (ring1.length / Math.max(1, slots)) * Math.PI * 2;
+      const mx = cx + Math.cos(ang) * R1, my = cy + Math.sin(ang) * R1;
+      more = { count: hidden, x: mx, y: my, ang };
+      pos.__more__ = { x: mx, y: my, ang };
+    }
     // ring2 (2-hop context), capped + faded
     const seen = new Set([center, ...ring1.map((r) => r.id)]);
     const outer = [];
@@ -89,8 +114,8 @@ function GraphEgo({ graph, query, width, height, banner }) {
       const ang = parentAng + spread;
       pos[o.id] = { x: cx + Math.cos(ang) * R2, y: cy + Math.sin(ang) * R2 };
     });
-    return { pos, ring1, ring2: cap, R1, R2, cx, cy };
-  }, [center, links, byId, W, H]);
+    return { pos, ring1, ring2: cap, R1, R2, cx, cy, more, totalNbrs };
+  }, [center, links, byId, W, H, ringCap]);
 
   // ── tween between centres (rAF cubic-ease ~560ms; instant if reduced-motion) ─
   const [pos, setPos] = useState(layout.pos);
@@ -133,6 +158,9 @@ function GraphEgo({ graph, query, width, height, banner }) {
     const i = sortedByTime.findIndex((n) => n.id === center);
     const j = Math.max(0, Math.min(sortedByTime.length - 1, i + dir));
     if (sortedByTime[j] && sortedByTime[j].id !== center) goTo(sortedByTime[j].id);
+  }
+  function expandRing() {
+    setRingCap((c) => Math.min(layout.totalNbrs, c + RING1_CAP_STEP));
   }
 
   // ── empty state ─────────────────────────────────────────────────────────────
@@ -234,6 +262,20 @@ function GraphEgo({ graph, query, width, height, banner }) {
             );
           })}
 
+          {/* "+K more" ring slot — expands the cap (nothing hidden silently) */}
+          {layout.more && pos.__more__ && (
+            <g
+              data-testid="mem-ego-more" transform={`translate(${pos.__more__.x},${pos.__more__.y})`}
+              style={{ cursor: 'pointer' }} onClick={expandRing}
+              role="button" tabIndex={0}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); expandRing(); } }}
+            >
+              <title>{`Show ${Math.min(RING1_CAP_STEP, layout.more.count)} more of ${layout.more.count} hidden neighbours`}</title>
+              <circle r="11" fill="var(--bg-3)" stroke="var(--line-strong)" strokeWidth="1.2" />
+              <text textAnchor="middle" dy="3.4" className="mono" style={{ fontSize: 9.5, fill: 'var(--fg-2)' }}>+{layout.more.count}</text>
+            </g>
+          )}
+
           {/* center node */}
           {(() => {
             const p = pos[center]; if (!p || !centerNode) return null;
@@ -258,6 +300,10 @@ function GraphEgo({ graph, query, width, height, banner }) {
               {centerNode.date && <span className="mg-ego-when">{window.fmtMemDate(centerNode.date, true)}</span>}
             </div>
             <div className="mg-ego-text">{centerNode.text || centerNode.label}</div>
+            <div className="mono" data-testid="mem-ego-nbr-count" style={{ fontSize: 10, color: 'var(--fg-4)', marginBottom: 8 }}>
+              neighbours · <b style={{ color: 'var(--fg-2)' }}>{layout.totalNbrs}</b>
+              {layout.more ? ` · showing ${layout.ring1.length}` : ''}
+            </div>
             <div className="mg-ego-deg">
               {Object.entries(deg).filter(([, n]) => n > 0).map(([k, n]) => (
                 <span key={k} className="mono"><i style={{ background: window.MEM_LINK_COLORS[k] }} />{k} <b>{n}</b></span>

--- a/ui/tests/e2e/specs/memory-graph-explorer-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-graph-explorer-v3.spec.ts
@@ -115,4 +115,28 @@ test.describe('Memory graph explorer', () => {
     // the explorer re-fetches + re-renders for the new bank.
     await expect(page.locator('[data-testid="mem-graph-svg"]')).toBeVisible()
   })
+
+  test('direction C (Ego) caps the ring on a high-degree node and "+K more" expands it', async ({ page }) => {
+    await gotoGraph(page)
+    // the baked `ingest` bank returns a dense star: a hub with 40 neighbours.
+    await page.selectOption('[data-testid="mem-graph-bank"]', 'ingest')
+    await page.locator('.mg-dirswitch button', { hasText: 'Ego' }).click()
+    // Ego renders its own .mg-svg (the mem-graph-svg testid is Direction-A only).
+    await expect(page.locator('.mg-ego-card')).toBeVisible()
+
+    // ring-1 is capped (RING1_CAP_STEP=24): the "+K more" slot appears and the
+    // card reports more total neighbours than are currently shown.
+    const more = page.locator('[data-testid="mem-ego-more"]')
+    await expect(more).toBeVisible()
+    const countText = page.locator('[data-testid="mem-ego-nbr-count"]')
+    await expect(countText).toContainText('neighbours · 40')
+    await expect(countText).toContainText('showing 24')
+
+    // expanding bumps the cap (24→48 ≥ 40) → all 40 shown, the "+K more" slot
+    // disappears and the "showing" qualifier drops (nothing hidden anymore).
+    await more.click()
+    await expect(more).toHaveCount(0)
+    await expect(countText).toContainText('neighbours · 40')
+    await expect(countText).not.toContainText('showing')
+  })
 })


### PR DESCRIPTION
Follow-up 1 from the Memory overhaul (PR #752). Closes the Direction-C ego ring-density issue surfaced during live validation.

## Problem
The ego explorer drew **every** direct neighbour on ring-1. Live Hindsight banks are far denser than the curated mock — the CT105 `shared` bank's busiest node has **83 neighbours**, so ring-1 became a mini-hairball (the exact problem the overhaul set out to kill). The 2-hop ring was already capped; ring-1 was not.

## Fix (`ui/src/dash/memory-graph-ego.jsx`)
- **Cap ring-1 to 24 by salience**: link-type priority (causal > temporal > cooccurrence > semantic), then strongest edge weight, then recency — keeps the storyline edges and sheds the noisy bulk-semantic fan first.
- **"+K more" ring slot** steps the cap up (24 → 48 → …); nothing is hidden silently. Centre card shows `neighbours · N · showing M`. Cap resets on every re-center.
- Keyboard-activatable (`role=button`, Enter/Space), `prefers-reduced-motion` safe (reuses the existing tween).

## Test surface
- `ui/src/api/mock.ts`: the `ingest` bank now returns a dense 40-neighbour star so the cap is exercisable under forced-mock (`VITE_MOCK_HAL0=1`).
- New spec in `memory-graph-explorer-v3.spec.ts` asserts the "+K more" pill appears (showing 24 of 40), expanding reveals all 40, and the pill then disappears.

## Verification
- `vite build` + `tsc` clean.
- Playwright e2e **232 passed / 0 failed** (incl. the new cap test).
- **Live-validated against CT105** `shared` bank: busiest node (83 neighbours) now renders a legible 24-node ring + "+59 more", vs the dense fan before.

Leaves Follow-up 2 (server-side ego/top-K for 1000s-of-node banks) parked as #755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)