### PR TITLE
fix(slots): drop duplicate Chat SlotCard grid (covered by InferencePane)

### DIFF
--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -1271,8 +1271,11 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
                   to the full slot list with per-slot lifecycle controls + a
                   model picker + a by-device throughput split. The per-group
                   SlotCard grids below stay the authoritative per-slot surface. */}
+              {/* Chat/LLM (gpu) slots are rendered inside the InferencePane's
+                  expanded slot list (model picker + per-slot lifecycle), so the
+                  former standalone "Chat" SlotCard grid is dropped — it only
+                  duplicated agent/chat below the pane. */}
               <InferencePane />
-              {renderGroup("Chat", groups.chat)}
               {/* Capabilities (C7): embedding/reranking/transcription/tts cards are
                   content-light, so they render in a denser 4-up quarter-width grid
                   instead of two separate full-width Embed/Voice sections. NPU

--- a/ui/tests/e2e/specs/profiles-page-v3.spec.ts
+++ b/ui/tests/e2e/specs/profiles-page-v3.spec.ts
@@ -150,7 +150,15 @@ test.describe('Container slot edit drawer (#658)', () => {
         },
         configurable: true,
       })
-    }, [CONTAINER_SLOT, BASIC_CONTAINER_SLOT])
+      // gpu-chat / chat are LLM slots — they render in the InferencePane now.
+      // Add a capability container slot so the card-open test has a `.slot` card
+      // (the Capabilities SlotCard grid) to click.
+    }, [CONTAINER_SLOT, BASIC_CONTAINER_SLOT, {
+      name: 'embed-cap', type: 'embedding', device: 'gpu-rocm',
+      model: 'nomic-embed', model_id: 'nomic-embed', group: 'embed',
+      state: 'ready', port: 8082, runtime: 'container', profile: 'vulkan',
+      container_status: 'running', container_health: true, enabled: true,
+    }])
 
     await page.route('**/api/profiles', (route) =>
       json(route, MOCK_DATA.profiles),
@@ -161,15 +169,14 @@ test.describe('Container slot edit drawer (#658)', () => {
   })
 
   test('container slot card opens edit drawer', async ({ page }) => {
-    // Click the settings/edit button on the container slot card
-    const card = page.locator('.slot', { has: page.locator('[data-slot-name="gpu-chat"]') })
-      .or(page.locator('.slot').filter({ hasText: 'gpu-chat' }))
-    // If no data-slot-name, find the card by text and click settings gear
-    await page.locator('.slot').filter({ hasText: 'gpu-chat' }).locator('.slot-settings, .btn-icon, button').first().click()
-    // Drawer should open
-    await expect(page.locator('.drawer, [data-testid="slot-drawer"]').or(page.locator('.slot-drawer'))).toBeVisible({ timeout: 5000 }).catch(() => {
-      // Drawer may render differently — verify any modal/overlay opened
-    })
+    // The capability container card's Edit button routes to #slots/<name>,
+    // which opens the EditSlotDrawer.
+    const card = page.locator('.slot', {
+      has: page.locator('.slot-name .nm', { hasText: /^embed-cap$/ }),
+    }).first()
+    await expect(card).toBeVisible()
+    await card.locator('button:has-text("Edit")').click()
+    await expect(page.locator('.drawer')).toBeVisible({ timeout: 5000 })
   })
 
   test('container slot shows "defined by profile" hint for n_gpu_layers', async ({ page }) => {

--- a/ui/tests/e2e/specs/slot-card-container-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-card-container-v3.spec.ts
@@ -276,15 +276,16 @@ test.describe('SlotCard container variant (#657)', () => {
   })
 
   test('slot cards carry the container runtime micro-tag (HAL0_DATA default)', async ({ page }) => {
-    // Every slot is a podman container now — the Chat section cards all
-    // render the .slot-runtime-tag micro-chip.
-    const chatSection = page.locator('.view section', {
-      has: page.locator('.sec h2', { hasText: 'Chat' }),
+    // Every slot is a podman container now — the Capabilities section cards all
+    // render the .slot-runtime-tag micro-chip. (Chat/LLM slots moved into the
+    // InferencePane; the standalone Chat grid was removed.)
+    const capSection = page.locator('.view section', {
+      has: page.locator('.sec h2', { hasText: 'Capabilities' }),
     })
-    await expect(chatSection).toBeVisible()
-    await expect(chatSection.locator('.slots-grid > .slot').first()).toBeVisible()
-    const cardCount = await chatSection.locator('.slots-grid > .slot').count()
-    const containerTagCount = await chatSection.locator('.slot-runtime-tag').count()
+    await expect(capSection).toBeVisible()
+    await expect(capSection.locator('.slots-grid > .slot').first()).toBeVisible()
+    const cardCount = await capSection.locator('.slots-grid > .slot').count()
+    const containerTagCount = await capSection.locator('.slot-runtime-tag').count()
     expect(cardCount).toBeGreaterThan(0)
     expect(containerTagCount).toBe(cardCount)
   })

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -25,13 +25,6 @@ const PRIMARY = {
   enabled: true, enable_thinking: false, n_gpu_layers: -1,
   metrics: { ctx: 8192, toks: 42, ttft: 180, kv: 35 },
 }
-const CODER = {
-  name: 'coder', type: 'llm', device: 'gpu-rocm',
-  model: 'qwen3-coder-30b', model_id: 'qwen3-coder-30b', modelLong: 'qwen3-coder-30b',
-  group: 'chat', state: 'idle', port: 8094,
-  enabled: false, enable_thinking: null, n_gpu_layers: 20,
-  metrics: { ctx: 4096 },
-}
 const EMBED = {
   name: 'embed', type: 'embedding', device: 'gpu-rocm',
   model: 'nomic-embed', model_id: 'nomic-embed', modelLong: 'nomic-embed',
@@ -68,18 +61,20 @@ const card = (page: Page, name: string) =>
     .first()
 
 test.describe('Slot edit controls (/slots)', () => {
+  // Chat/LLM slots moved into the InferencePane; the enabled toggle + fade are
+  // SlotCard-grid features, now exercised on the Capabilities grid (embed/rerank).
   test('C3 — card enabled toggle PUTs /config { enabled:false }', async ({ page }) => {
     const puts: any[] = []
-    await page.route('**/api/slots/primary/config', async (route) => {
+    await page.route('**/api/slots/embed/config', async (route) => {
       if (route.request().method() === 'PUT') {
         puts.push(JSON.parse(route.request().postData() || '{}'))
       }
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
     })
-    await seedSlots(page, [PRIMARY, EMBED])
+    await seedSlots(page, [EMBED, PRIMARY])
 
     await page.goto('/#slots')
-    const toggle = card(page, 'primary').locator('.slot-enable-toggle')
+    const toggle = card(page, 'embed').locator('.slot-enable-toggle')
     await expect(toggle).toBeVisible()
     await toggle.click()
     await expect.poll(() => puts.length).toBeGreaterThan(0)
@@ -87,10 +82,14 @@ test.describe('Slot edit controls (/slots)', () => {
   })
 
   test('C3 — disabled slot card carries the fade modifier class', async ({ page }) => {
-    await seedSlots(page, [PRIMARY, CODER])
+    const RERANK_OFF = {
+      name: 'rerank-off', type: 'reranking', device: 'gpu-rocm',
+      group: 'embed', state: 'idle', enabled: false, runtime: 'container', port: 8096,
+    }
+    await seedSlots(page, [EMBED, RERANK_OFF])
     await page.goto('/#slots')
-    await expect(card(page, 'coder')).toHaveClass(/slot--disabled/)
-    await expect(card(page, 'primary')).not.toHaveClass(/slot--disabled/)
+    await expect(card(page, 'rerank-off')).toHaveClass(/slot--disabled/)
+    await expect(card(page, 'embed')).not.toHaveClass(/slot--disabled/)
   })
 
   test('C4 — drawer thinking toggle PUTs /config { enable_thinking:true }', async ({ page }) => {
@@ -151,13 +150,19 @@ test.describe('Slot edit controls (/slots)', () => {
   })
 
   test('C6 — enabled slots sort before disabled ones', async ({ page }) => {
-    // Disabled-first input order: only a real enabled-first sort makes
-    // primary (enabled) render ahead of coder (disabled).
-    await seedSlots(page, [CODER, PRIMARY, EMBED])
+    // Chat/LLM slots moved into the InferencePane; the standalone Chat grid was
+    // removed. The enabled-first sort still runs via renderGroup for the
+    // Capabilities grid. Disabled-first input order: only a real enabled-first
+    // sort makes the enabled embed render ahead of the disabled rerank.
+    const RERANK_OFF = {
+      name: 'rerank-off', type: 'reranking', device: 'gpu-rocm',
+      group: 'embed', state: 'idle', enabled: false, runtime: 'container', port: 8096,
+    }
+    await seedSlots(page, [RERANK_OFF, EMBED])
     await page.goto('/#slots')
-    const chatCards = page.locator('section', { hasText: 'Chat' }).locator('.slot')
-    await expect(chatCards.first()).toContainText('primary')
-    await expect(chatCards.nth(1)).toContainText('coder')
+    const capCards = page.locator('section', { hasText: 'Capabilities' }).locator('.slot')
+    await expect(capCards.first()).toContainText('embed')
+    await expect(capCards.nth(1)).toContainText('rerank-off')
   })
 
   // #587: the slot-edit drawer used to seed idle_timeout_s / workers /

--- a/ui/tests/e2e/specs/slot-lifecycle-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-lifecycle-controls-v3.spec.ts
@@ -8,11 +8,10 @@
  *
  * Start → POST /load · Stop → POST /unload · Restart → POST /restart.
  *
- * The dashboard renders the slot LIST from in-bundle HAL0_DATA
- * (VITE_MOCK_HAL0=1), so we target real seed slots by exact name:
- *   primary = serving (running) · coder = stopped via HAL0_DATA clobber
- *   (the seed runs its container) · warming-demo = starting (transitional).
- * Mutations still go through fetch, so per-route stubs capture them.
+ * Chat/LLM slots moved into the InferencePane; the SlotCard grid now holds the
+ * Capabilities slots, so we target a capability (reranking) `.slot` card in
+ * each lifecycle state. Slots are injected via window.HAL0_DATA (VITE_MOCK_HAL0);
+ * mutations still go through fetch, so per-route stubs capture them.
  */
 import { test, expect, type Page } from '../fixtures/apiMock'
 
@@ -21,61 +20,74 @@ const cardByName = (page: Page, name: string) =>
     .locator('.slot', { has: page.locator('.slot-name .nm', { hasText: new RegExp(`^${name}$`) }) })
     .first()
 
+// Inject a single capability slot (renders in the Capabilities grid as a
+// `.slot` card) via the HAL0_DATA setter the dashboard reads on boot.
+async function seedCapSlot(page: Page, slot: any) {
+  await page.addInitScript((s) => {
+    let real: any
+    Object.defineProperty(window, 'HAL0_DATA', {
+      configurable: true,
+      get() { return real },
+      set(v) { real = v; if (v && typeof v === 'object') v.slots = [s] },
+    })
+  }, slot)
+}
+
+const CAP = {
+  name: 'rerank', type: 'reranking', device: 'gpu-rocm', group: 'embed',
+  model: 'bge-reranker-v2-m3', model_id: 'bge-reranker-v2-m3',
+  enabled: true, runtime: 'container', port: 8083,
+}
+
 test.describe('Slot lifecycle controls (/slots)', () => {
-  test('off slot (coder/stopped) shows Start, not Stop/Restart; Start POSTs /load', async ({ page }) => {
+  test('off slot (stopped) shows Start, not Stop/Restart; Start POSTs /load', async ({ page }) => {
     const loads: string[] = []
-    await page.route('**/api/slots/coder/load', async (route) => {
+    await page.route('**/api/slots/rerank/load', async (route) => {
       loads.push(route.request().url())
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
     })
-
-    // The seed coder slot runs its container — stop it so the card takes
-    // the "off" branch (container stopped → Start only).
-    await page.addInitScript(() => {
-      const id = setInterval(() => {
-        const d = (window as any).HAL0_DATA
-        const coder = d?.slots?.find((s: any) => s.name === 'coder')
-        if (coder) {
-          coder.container_status = 'stopped'
-          coder.container_health = false
-          coder.state = 'offline'
-          clearInterval(id)
-        }
-      }, 5)
+    await seedCapSlot(page, {
+      ...CAP, state: 'offline', container_status: 'stopped', container_health: false,
     })
 
     await page.goto('/#slots')
-    const card = cardByName(page, 'coder')
-    await expect(card.getByRole("button", { name: "Start", exact: true })).toBeVisible()
+    const card = cardByName(page, 'rerank')
+    await expect(card.getByRole('button', { name: 'Start', exact: true })).toBeVisible()
     await expect(card.locator('button:has-text("Stop")')).toHaveCount(0)
     await expect(card.locator('button:has-text("Restart")')).toHaveCount(0)
 
-    await card.getByRole("button", { name: "Start", exact: true }).click()
+    await card.getByRole('button', { name: 'Start', exact: true }).click()
     await expect.poll(() => loads.length).toBeGreaterThan(0)
   })
 
-  test('running slot (primary/serving) shows Stop + Restart, not Start; Stop POSTs /unload', async ({ page }) => {
+  test('running slot (serving) shows Stop + Restart, not Start; Stop POSTs /unload', async ({ page }) => {
     const unloads: string[] = []
-    await page.route('**/api/slots/primary/unload', async (route) => {
+    await page.route('**/api/slots/rerank/unload', async (route) => {
       unloads.push(route.request().url())
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
     })
+    await seedCapSlot(page, {
+      ...CAP, state: 'serving', container_status: 'running', container_health: true,
+    })
 
     await page.goto('/#slots')
-    const card = cardByName(page, 'primary')
+    const card = cardByName(page, 'rerank')
     await expect(card.locator('button:has-text("Stop")')).toBeVisible()
     await expect(card.locator('button:has-text("Restart")')).toBeVisible()
-    await expect(card.getByRole("button", { name: "Start", exact: true })).toHaveCount(0)
+    await expect(card.getByRole('button', { name: 'Start', exact: true })).toHaveCount(0)
 
     await card.locator('button:has-text("Stop")').click()
     await expect.poll(() => unloads.length).toBeGreaterThan(0)
   })
 
   test('transitional slot (warming) shows no Start and a disabled Restart', async ({ page }) => {
+    await seedCapSlot(page, {
+      ...CAP, state: 'warming', container_status: 'starting', container_health: false,
+    })
     await page.goto('/#slots')
-    const card = cardByName(page, 'warming-demo')
+    const card = cardByName(page, 'rerank')
     await expect(card).toBeVisible()
-    await expect(card.getByRole("button", { name: "Start", exact: true })).toHaveCount(0)
+    await expect(card.getByRole('button', { name: 'Start', exact: true })).toHaveCount(0)
     await expect(card.locator('button:has-text("Restart")')).toBeDisabled()
   })
 })

--- a/ui/tests/e2e/specs/slot-swap-clip-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-swap-clip-v3.spec.ts
@@ -15,8 +15,10 @@ const cardByName = (page: Page, name: string) =>
 
 test.describe('Slot swap dropdown — not clipped by card', () => {
   test('card stops clipping (overflow-y visible) while the swap dropdown is open', async ({ page }) => {
+    // Chat/LLM slots moved into the InferencePane; the overflow-clip behaviour
+    // is a `.slot` SlotCard concern, exercised on a Capabilities card (embed).
     await page.goto('/#slots')
-    const card = cardByName(page, 'primary')
+    const card = cardByName(page, 'embed')
 
     // Closed: card clips its content (rounded-corner aesthetic).
     expect(await card.evaluate((el) => getComputedStyle(el).overflowY)).toBe('hidden')

--- a/ui/tests/e2e/specs/slots-v3.spec.ts
+++ b/ui/tests/e2e/specs/slots-v3.spec.ts
@@ -35,17 +35,34 @@ test.describe('Slots v3 (/slots)', () => {
   })
 
   test('enabled-first sort (C6): a disabled slot sinks to the end of its section', async ({ page }) => {
+    // The Chat SlotCard grid was removed (chat/LLM slots now live in the
+    // InferencePane). The enabled-first sort still runs via renderGroup for the
+    // Capabilities section, so assert it there. Inject capability slots with a
+    // disabled one mid-order; the sort must render it last.
+    await page.addInitScript((slots) => {
+      let real: any
+      Object.defineProperty(window, 'HAL0_DATA', {
+        configurable: true,
+        get() { return real },
+        set(v) { real = v; if (v && typeof v === 'object') v.slots = slots },
+      })
+    }, [
+      { name: 'embed', type: 'embedding', device: 'gpu-rocm', group: 'embed', state: 'ready', enabled: true, runtime: 'container', port: 8082 },
+      { name: 'legacy-cap', type: 'reranking', device: 'gpu-rocm', group: 'embed', state: 'idle', enabled: false, runtime: 'container', port: 8083 },
+      { name: 'rerank', type: 'reranking', device: 'gpu-rocm', group: 'embed', state: 'ready', enabled: true, runtime: 'container', port: 8084 },
+    ])
     await page.goto('/#slots')
-    // The Chat section: HAL0_DATA declares a disabled "legacy" slot early in
-    // source order; the enabled-first sort must render it last.
-    const chatSection = page.locator('.view section', {
-      has: page.locator('.sec h2', { hasText: 'Chat' }),
+    const capSection = page.locator('.view section', {
+      has: page.locator('.sec h2', { hasText: 'Capabilities' }),
     })
-    const names = await chatSection.locator('.slot .slot-name .nm').allInnerTexts()
+    // Wait for all three cards to render before reading order (allInnerTexts
+    // does not auto-wait, so assert the count first to avoid a render race).
+    await expect(capSection.locator('.slot .slot-name .nm')).toHaveCount(3)
+    const names = await capSection.locator('.slot .slot-name .nm').allInnerTexts()
     expect(names.length).toBeGreaterThan(1)
-    expect(names).toContain('legacy')
-    expect(names[names.length - 1]).toBe('legacy') // disabled → last
-    expect(names[0]).not.toBe('legacy') // enabled slots come first
+    expect(names).toContain('legacy-cap')
+    expect(names[names.length - 1]).toBe('legacy-cap') // disabled → last
+    expect(names[0]).not.toBe('legacy-cap') // enabled slots come first
   })
 
   test('NPU rollup section renders when an NPU slot is present', async ({ page }) => {

--- a/ui/tests/e2e/specs/slots-wireup-v3.spec.ts
+++ b/ui/tests/e2e/specs/slots-wireup-v3.spec.ts
@@ -23,7 +23,19 @@ const BASE_SLOTS = [
     group: 'chat', state: 'serving', port: 8092, isDefault: true,
     metrics: { ctx: 8192, toks: 42, ttft: 180, kv: 35 },
   },
+  // Chat/LLM slots render in the InferencePane now; the swap/restart/unload
+  // card interactions target a capability slot (the Capabilities SlotCard grid).
+  {
+    name: 'embed', type: 'embedding', device: 'gpu-rocm',
+    model: 'nomic-embed', model_id: 'nomic-embed',
+    group: 'embed', state: 'serving', port: 8082, runtime: 'container',
+    container_status: 'running', container_health: true, metrics: {},
+  },
 ]
+
+// Exact-name card locator (avoids matching model text that contains the name).
+const cardByName = (page: any, name: string) =>
+  page.locator('.slot', { has: page.locator('.slot-name .nm', { hasText: new RegExp(`^${name}$`) }) }).first()
 
 test.describe('Slots v3 wire-up (/slots)', () => {
   test('Create slot — modal POSTs /api/slots with form body', async ({ page }) => {
@@ -125,7 +137,7 @@ test.describe('Slots v3 wire-up (/slots)', () => {
 
   test('Swap model — inline popover POSTs /api/slots/{name}/swap', async ({ page }) => {
     const swaps: any[] = []
-    await page.route('**/api/slots/primary/swap', async (route) => {
+    await page.route('**/api/slots/embed/swap', async (route) => {
       swaps.push(JSON.parse(route.request().postData() || '{}'))
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
     })
@@ -138,7 +150,7 @@ test.describe('Slots v3 wire-up (/slots)', () => {
     )
 
     await page.goto('/#slots')
-    const card = page.locator('.slot', { hasText: 'primary' }).first()
+    const card = cardByName(page, 'embed')
     await card.locator('.slot-model').click()
     const pick = page.locator('.swap-pop-item').first()
     await expect(pick).toBeVisible()
@@ -149,7 +161,7 @@ test.describe('Slots v3 wire-up (/slots)', () => {
 
   test('Restart slot — card button POSTs /api/slots/{name}/restart', async ({ page }) => {
     const restarts: string[] = []
-    await page.route('**/api/slots/primary/restart', async (route) => {
+    await page.route('**/api/slots/embed/restart', async (route) => {
       restarts.push(route.request().url())
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
     })
@@ -162,14 +174,14 @@ test.describe('Slots v3 wire-up (/slots)', () => {
     )
 
     await page.goto('/#slots')
-    const card = page.locator('.slot', { hasText: 'primary' }).first()
+    const card = cardByName(page, 'embed')
     await card.locator('button:has-text("Restart")').click()
     await expect.poll(() => restarts.length).toBeGreaterThan(0)
   })
 
   test('Unload slot — card button POSTs /api/slots/{name}/unload', async ({ page }) => {
     const unloads: string[] = []
-    await page.route('**/api/slots/primary/unload', async (route) => {
+    await page.route('**/api/slots/embed/unload', async (route) => {
       unloads.push(route.request().url())
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
     })
@@ -182,7 +194,7 @@ test.describe('Slots v3 wire-up (/slots)', () => {
     )
 
     await page.goto('/#slots')
-    const card = page.locator('.slot', { hasText: 'primary' }).first()
+    const card = cardByName(page, 'embed')
     await card.locator('button:has-text("Stop")').click()
     await expect.poll(() => unloads.length).toBeGreaterThan(0)
   })


### PR DESCRIPTION
The InferencePane already lists every non-NPU/non-image inference slot (agent/chat + capabilities) with a model picker + per-slot lifecycle controls, so the standalone **Chat** SlotCard grid below it only duplicated the `agent`/`chat` cards. This removes that grid — chat/LLM slots now render solely in the pane.

## Tests
The Chat grid was the canonical `.slot`-card surface for several slot specs (enabled-first sort, enable-toggle, fade, lifecycle Start/Stop/Restart, swap/restart/unload, container edit-drawer, runtime micro-tag). Retargeted those to the still-present **Capabilities** `.slot` grid (embed/rerank) — same `SlotCard` component, equivalent behaviour. Full e2e suite green (231 passed, 5 skipped); typecheck clean.

Note: the Capabilities grid still mirrors the pane's capability rows the same way; left intact per the scoped request (agent/chat only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)