### PR TITLE
fix(slots): hoist [slot] table in manager._load_slot_config (#754 follow-up)

### DIFF
--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -2168,6 +2168,16 @@ class SlotManager:
                 f"slot config {path} is not valid TOML: {exc}",
                 details={"slot": slot_name, "path": str(path)},
             ) from exc
+        # PR #754 follow-up: the on-disk slot TOML nests fields under a
+        # [slot] table (the shape config.loader / capabilities / profiles
+        # consume). The flat readers in this module (load_sync, _cfg_*
+        # helpers) expect those keys at the top level, so hoist the [slot]
+        # table up while leaving the sibling [model]/[image]/[npu]/[server]
+        # tables in place. A no-op for already-flat configs.
+        slot_tbl = data.pop("slot", None)
+        if isinstance(slot_tbl, dict):
+            for _k, _v in slot_tbl.items():
+                data[_k] = _v
         if "name" not in data:
             data["name"] = slot_name
         return data


### PR DESCRIPTION
## Problem
PR #754 migrated slot TOMLs to nested `[slot]` and updated `config.loader` (used by **capabilities** + **profiles**), but `manager._load_slot_config` returns the **raw** TOML dict and the flat readers in that module (`load_sync`, the `_cfg_*` helpers) expect slot fields at the **top level**.

Result: any fresh slot **load/restart/swap** fails with `KeyError: profile  not found in catalog` on the nested configs. Already-running (adopted) containers survive only until they next cycle — so the regression is latent until a slot is restarted.

## Fix
Hoist the `[slot]` table to top level in `_load_slot_config`, leaving the sibling `[model]`/`[image]`/`[npu]`/`[server]` tables in place. No-op for already-flat configs. Now the manager (flat) and `config.loader`/capabilities/profiles (nested) read the same nested on-disk format.

## Verification (live on CT105)
- Fresh-load of an offline slot (`rerank`) → `ready` (previously 500 `profile `).
- Chat slot hot-swap to `Qwopus3.6-27B-Coder-MTP` + reasoning works.
- `/api/profiles` used_by scan and `/api/capabilities` → **0** SlotConfig validation warnings.
- All 9 slot TOMLs validate through both `config.loader.load_slot_config` and the manager path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)