### PR TITLE
refactor(providers): fold dual container argv builders into one RuntimeLaunchPlan renderer

### DIFF
--- a/src/hal0/providers/base.py
+++ b/src/hal0/providers/base.py
@@ -68,14 +68,27 @@ class Mount:
     source: str
     target: str
     read_only: bool = False
+    #: SELinux relabel option ("z" shared, "Z" private) appended to the mount
+    #: opts. Required on SELinux-enforcing hosts (Fedora) so the container can
+    #: read the bind; a harmless no-op where SELinux is disabled. Empty = none.
+    selinux: str = ""
 
     def render(self) -> str:
-        """Return the ``{src}:{dst}[:ro]`` value for ``--volume=``."""
-        # Tolerate a target that already carries ``:ro`` (legacy callers /
-        # coerced tuples) so we never emit a doubled ``:ro:ro``.
-        if self.read_only and not self.target.endswith(":ro"):
-            return f"{self.source}:{self.target}:ro"
-        return f"{self.source}:{self.target}"
+        """Return the ``{src}:{dst}[:ro[,z]]`` value for ``--volume=``."""
+        target = self.target
+        read_only = self.read_only
+        # Tolerate a target that already smuggles ``:ro`` (legacy callers /
+        # coerced tuples) so we never emit a doubled ``:ro``.
+        if target.endswith(":ro"):
+            target = target[: -len(":ro")]
+            read_only = True
+        opts: list[str] = []
+        if read_only:
+            opts.append("ro")
+        if self.selinux:
+            opts.append(self.selinux)
+        suffix = (":" + ",".join(opts)) if opts else ""
+        return f"{self.source}:{target}{suffix}"
 
     @classmethod
     def coerce(cls, mount: Mount | tuple[str, str]) -> Mount:

--- a/src/hal0/providers/base.py
+++ b/src/hal0/providers/base.py
@@ -54,15 +54,87 @@ def _quote_for_systemd(value: str) -> str:
     return quoted
 
 
+@dataclass(frozen=True, slots=True)
+class Mount:
+    """A single volume mount, with read-only as a first-class flag.
+
+    Replaces the old convention of smuggling ``:ro`` into the container
+    target string.  The renderer calls :meth:`render` to produce the
+    ``--volume`` value, so providers declare intent (``read_only=True``)
+    instead of hand-appending ``:ro`` and hoping the renderer passes it
+    through verbatim.
+    """
+
+    source: str
+    target: str
+    read_only: bool = False
+
+    def render(self) -> str:
+        """Return the ``{src}:{dst}[:ro]`` value for ``--volume=``."""
+        # Tolerate a target that already carries ``:ro`` (legacy callers /
+        # coerced tuples) so we never emit a doubled ``:ro:ro``.
+        if self.read_only and not self.target.endswith(":ro"):
+            return f"{self.source}:{self.target}:ro"
+        return f"{self.source}:{self.target}"
+
+    @classmethod
+    def coerce(cls, mount: Mount | tuple[str, str]) -> Mount:
+        """Normalise a ``Mount`` or a legacy ``(src, dst)`` tuple to ``Mount``.
+
+        A tuple whose target ends in ``:ro`` is interpreted as a read-only
+        mount — the renderer stays correct whether callers were migrated to
+        :class:`Mount` or still pass the old tuple shape.
+        """
+        if isinstance(mount, Mount):
+            return mount
+        source, target = mount
+        if target.endswith(":ro"):
+            return cls(source, target[: -len(":ro")], read_only=True)
+        return cls(source, target, read_only=False)
+
+
+@dataclass(frozen=True, slots=True)
+class HealthCheck:
+    """A podman ``--health-*`` override for a slot container.
+
+    The toolbox images bake a HEALTHCHECK that probes a hardcoded port; a
+    slot runs its server on its own port, so the unit must override the
+    health command (else ``podman ps`` shows a permanent ``unhealthy``).
+    Carrying it on the launch plan keeps that knowledge declarative instead
+    of inlined in the renderer (#684).
+    """
+
+    cmd: str
+    start_period: str = "180s"
+    interval: str = "30s"
+    retries: int = 3
+    timeout: str = "5s"
+
+    def render_flags(self) -> list[str]:
+        """Return the ``--health-*`` podman-run flags in a stable order."""
+        return [
+            f"--health-cmd={self.cmd}",
+            f"--health-start-period={self.start_period}",
+            f"--health-interval={self.interval}",
+            f"--health-retries={self.retries}",
+            f"--health-timeout={self.timeout}",
+        ]
+
+
 @dataclass(frozen=True)
-class ContainerSpec:
-    """Docker/podman run specification for a container-per-slot systemd unit.
+class RuntimeLaunchPlan:
+    """Typed launch plan for a container-per-slot systemd unit.
 
-    Carries everything SlotManager needs to render a docker run command
-    inside the hal0-slot@.service template.
+    Carries everything the systemd/podman adapter needs to render one
+    ``hal0-slot@<name>.service`` unit: image, in-container argv, mounts
+    (read-only as a first-class flag), devices, security, port, and the
+    optional health-check override.  Providers build one plan per
+    (slot, model) pair from a :class:`hal0.profiles.ResolvedProfile`; the
+    adapter (:func:`hal0.providers.container._render_unit_from_plan`)
+    executes it.  There is exactly one argv builder.
 
-    Frozen for safety: Providers build a ContainerSpec per (slot, model)
-    pair and hand it to SlotManager which renders the unit template.
+    Frozen for safety: a plan is computed once and never mutated, so two
+    slots can never share mutable launch state.
 
     See ARCHITECTURE.md §Key boundaries and PLAN.md §2 (deployment model).
     """
@@ -76,8 +148,9 @@ class ContainerSpec:
     env: dict[str, str] = field(default_factory=dict)
     """Environment variables injected via docker run --env."""
 
-    mounts: list[tuple[str, str]] = field(default_factory=list)
-    """(host_path, container_path) volume mounts."""
+    mounts: list[Mount | tuple[str, str]] = field(default_factory=list)
+    """Volume mounts.  Prefer :class:`Mount`; legacy ``(src, dst)`` tuples are
+    coerced by the renderer (``:ro`` target suffix → ``read_only``)."""
 
     devices: list[str] = field(default_factory=list)
     """Device paths to pass through, e.g. ["/dev/dri/renderD128"]."""
@@ -99,6 +172,15 @@ class ContainerSpec:
 
     extra_args: list[str] = field(default_factory=list)
     """Escape hatch: additional docker run arguments appended verbatim."""
+
+    health: HealthCheck | None = None
+    """Optional ``--health-*`` override (None = inherit the image's HEALTHCHECK)."""
+
+
+#: Backwards-compatible alias.  ``RuntimeLaunchPlan`` is the canonical name
+#: (it carries health + first-class read-only mounts, not just a container
+#: spec); existing imports of ``ContainerSpec`` keep working.
+ContainerSpec = RuntimeLaunchPlan
 
 
 class Provider(ABC):

--- a/src/hal0/providers/comfyui.py
+++ b/src/hal0/providers/comfyui.py
@@ -55,14 +55,15 @@ _HAL0_COMFYUI_IMAGE = "docker.io/kyuz0/amd-strix-halo-comfyui:latest"
 # In-container app + working-data layout. The kyuz0 image has ComfyUI
 # checked out at /opt/ComfyUI (venv at /opt/venv). Host-side working data
 # (models / output / input / user / custom_nodes + extra_model_paths.yaml)
-# lives under _COMFYUI_DATA_ROOT and is bind-mounted in so weights and
+# lives under "<model-store>/comfyui" and is bind-mounted in so weights and
 # custom nodes persist across container restarts.
 _COMFYUI_APP_DIR = "/opt/ComfyUI"
 _COMFYUI_BASE_DIR = "/var/lib/hal0/comfyui"
 
-# Host data root for the bind mounts. Overridable for tests / non-standard
-# installs via HAL0_COMFYUI_DATA_ROOT.
-_COMFYUI_DATA_ROOT = "/mnt/ai-models/comfyui"
+# ComfyUI's working data tracks the configured model store ([models].store /
+# HAL0_MODEL_STORE, default /mnt/ai-models) under a "comfyui" subdir, resolved
+# per-render in container_spec(). Still overridable via HAL0_COMFYUI_DATA_ROOT.
+_COMFYUI_DATA_SUBDIR = "comfyui"
 
 # Live-validated flag bundle (matches the "comfyui" seed profile). Used
 # when the slot has no resolvable profile.
@@ -244,7 +245,12 @@ class ComfyUIProvider(Provider):
         ).strip()
         command: list[str] = ["bash", "-lc", payload]
 
-        data_root = os.environ.get("HAL0_COMFYUI_DATA_ROOT", "").strip() or _COMFYUI_DATA_ROOT
+        from hal0.config.paths import model_store_root
+
+        data_root = (
+            os.environ.get("HAL0_COMFYUI_DATA_ROOT", "").strip()
+            or f"{model_store_root()}/{_COMFYUI_DATA_SUBDIR}"
+        )
         # read_only is a first-class Mount flag; extra_model_paths.yaml is the
         # only read-only mount (the renderer appends ":ro").
         mounts: list[Mount] = [

--- a/src/hal0/providers/comfyui.py
+++ b/src/hal0/providers/comfyui.py
@@ -40,7 +40,7 @@ import httpx
 
 from hal0.errors import Hal0Error
 from hal0.providers._gpu import resolve_gpu_device_paths, resolve_gpu_group_ids
-from hal0.providers.base import ContainerSpec, Provider
+from hal0.providers.base import ContainerSpec, Mount, Provider
 from hal0.providers.comfyui_workflows import build_workflow
 
 log = logging.getLogger(__name__)
@@ -55,16 +55,14 @@ _HAL0_COMFYUI_IMAGE = "docker.io/kyuz0/amd-strix-halo-comfyui:latest"
 # In-container app + working-data layout. The kyuz0 image has ComfyUI
 # checked out at /opt/ComfyUI (venv at /opt/venv). Host-side working data
 # (models / output / input / user / custom_nodes + extra_model_paths.yaml)
-# lives under "<model-store>/comfyui" and is bind-mounted in so weights and
+# lives under _COMFYUI_DATA_ROOT and is bind-mounted in so weights and
 # custom nodes persist across container restarts.
 _COMFYUI_APP_DIR = "/opt/ComfyUI"
 _COMFYUI_BASE_DIR = "/var/lib/hal0/comfyui"
 
-# ComfyUI's working data lives under "<model-store>/comfyui" so it tracks the
-# configured model store ([models].store / HAL0_MODEL_STORE, default
-# /mnt/ai-models) — resolved per-render in container_spec(). Still directly
-# overridable via HAL0_COMFYUI_DATA_ROOT for tests / non-standard installs.
-_COMFYUI_DATA_SUBDIR = "comfyui"
+# Host data root for the bind mounts. Overridable for tests / non-standard
+# installs via HAL0_COMFYUI_DATA_ROOT.
+_COMFYUI_DATA_ROOT = "/mnt/ai-models/comfyui"
 
 # Live-validated flag bundle (matches the "comfyui" seed profile). Used
 # when the slot has no resolvable profile.
@@ -192,19 +190,18 @@ class ComfyUIProvider(Provider):
     def _profile_flags(self, slot_cfg: dict[str, Any]) -> str:
         """Resolve the slot's profile to its flag bundle.
 
-        Same lookup as the llama-server path in
-        :mod:`hal0.providers.container` (resolve_profile +
-        resolve_profile_flags). Falls back to the live-validated default
-        bundle when the slot has no profile or the lookup fails — the img
-        slot must always come up with the bench-tuned flags.
+        Resolves through :class:`~hal0.profiles.ProfileCatalog` (one profile
+        interface, ``resolved_flags`` already MTP-expanded). Falls back to the
+        live-validated default bundle when the slot has no profile or the
+        lookup fails — the img slot must always come up with the bench-tuned
+        flags.
         """
         profile_name = str(slot_cfg.get("profile") or slot_cfg.get("slot", {}).get("profile") or "")
         if profile_name:
             try:
-                from hal0.config.loader import resolve_profile
-                from hal0.config.schema import resolve_profile_flags
+                from hal0.profiles import ProfileCatalog
 
-                flags = resolve_profile_flags(resolve_profile(profile_name)).strip()
+                flags = ProfileCatalog().resolve(profile_name).resolved_flags.strip()
                 if flags:
                     return flags
             except Exception:
@@ -247,23 +244,19 @@ class ComfyUIProvider(Provider):
         ).strip()
         command: list[str] = ["bash", "-lc", payload]
 
-        from hal0.config.paths import model_store_root
-
-        data_root = (
-            os.environ.get("HAL0_COMFYUI_DATA_ROOT", "").strip()
-            or f"{model_store_root()}/{_COMFYUI_DATA_SUBDIR}"
-        )
-        # ":ro" suffix on the dst is how ContainerSpec expresses read-only
-        # mounts (_render_unit_from_spec emits --volume={src}:{dst} verbatim).
-        mounts: list[tuple[str, str]] = [
-            (f"{data_root}/models", "/root/comfy-models"),
-            (f"{data_root}/output", f"{_COMFYUI_APP_DIR}/output"),
-            (f"{data_root}/input", f"{_COMFYUI_APP_DIR}/input"),
-            (f"{data_root}/user", f"{_COMFYUI_APP_DIR}/user"),
-            (f"{data_root}/custom_nodes", f"{_COMFYUI_APP_DIR}/custom_nodes"),
-            (
+        data_root = os.environ.get("HAL0_COMFYUI_DATA_ROOT", "").strip() or _COMFYUI_DATA_ROOT
+        # read_only is a first-class Mount flag; extra_model_paths.yaml is the
+        # only read-only mount (the renderer appends ":ro").
+        mounts: list[Mount] = [
+            Mount(f"{data_root}/models", "/root/comfy-models"),
+            Mount(f"{data_root}/output", f"{_COMFYUI_APP_DIR}/output"),
+            Mount(f"{data_root}/input", f"{_COMFYUI_APP_DIR}/input"),
+            Mount(f"{data_root}/user", f"{_COMFYUI_APP_DIR}/user"),
+            Mount(f"{data_root}/custom_nodes", f"{_COMFYUI_APP_DIR}/custom_nodes"),
+            Mount(
                 f"{data_root}/extra_model_paths.yaml",
-                f"{_COMFYUI_APP_DIR}/extra_model_paths.yaml:ro",
+                f"{_COMFYUI_APP_DIR}/extra_model_paths.yaml",
+                read_only=True,
             ),
         ]
 

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -46,6 +46,7 @@ from typing import Any
 
 import httpx
 
+from hal0.config.paths import DEFAULT_MODEL_STORE, model_store_root
 from hal0.config.schema import resolve_profile_flags
 from hal0.profiles import ProfileCatalog
 from hal0.providers._gpu import resolve_gpu_device_paths, resolve_gpu_group_ids
@@ -92,7 +93,10 @@ log = logging.getLogger(__name__)
 # template.  Writing a complete file means the manager never has to
 # know whether the base exists.
 _SYSTEMD_SYSTEM_DIR = Path("/etc/systemd/system")
-_MODEL_STORE_MOUNT = "/mnt/ai-models"
+# Back-compat alias for the historic default. The *effective* mount root is
+# resolved per-render via model_store_root() ([models].store / HAL0_MODEL_STORE
+# / this default) so a custom model directory actually reaches the container.
+_MODEL_STORE_MOUNT = DEFAULT_MODEL_STORE
 
 
 # Container runtime binary.  Prefer podman (rootless, no daemon);
@@ -344,10 +348,15 @@ def _llama_launch_plan(
     command += flag_tokens
     command += extra_tokens
 
+    # Effective model-store root (honours [models].store / HAL0_MODEL_STORE,
+    # default /mnt/ai-models). Mounted identical-path, read-only, with an
+    # SELinux relabel so it works on enforcing hosts (Fedora).
+    model_store = model_store_root()
+
     return RuntimeLaunchPlan(
         image=image,
         command=command,
-        mounts=[Mount(_MODEL_STORE_MOUNT, _MODEL_STORE_MOUNT, read_only=True)],
+        mounts=[Mount(model_store, model_store, read_only=True, selinux="z")],
         devices=list(devices),
         group_add=list(group_ids),
         security_opt=["apparmor=unconfined", "seccomp=unconfined"],

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -46,13 +46,43 @@ from typing import Any
 
 import httpx
 
-# Aliased to the old private name so existing test patch targets
-# (``hal0.providers.container._resolve_profile``) keep working.
-from hal0.config.loader import resolve_profile as _resolve_profile
-from hal0.config.paths import DEFAULT_MODEL_STORE, model_store_root
 from hal0.config.schema import resolve_profile_flags
+from hal0.profiles import ProfileCatalog
 from hal0.providers._gpu import resolve_gpu_device_paths, resolve_gpu_group_ids
-from hal0.providers.base import ContainerSpec, Provider
+from hal0.providers.base import HealthCheck, Mount, Provider, RuntimeLaunchPlan
+
+# ``ContainerSpec`` is the back-compat alias for ``RuntimeLaunchPlan``; some
+# callers/tests still import the old name from this module.
+ContainerSpec = RuntimeLaunchPlan
+
+
+def _resolve_profile(name: str) -> Any:
+    """Resolve a profile name to a :class:`~hal0.profiles.ResolvedProfile`.
+
+    Kept as a module-level indirection so it stays the single patch point
+    for tests (``hal0.providers.container._resolve_profile``).  The default
+    implementation goes through :class:`~hal0.profiles.ProfileCatalog`, so
+    providers consume one profile interface instead of re-parsing
+    profiles.toml — :func:`_profile_image_and_flags` accepts either a
+    ``ResolvedProfile`` or a bare ``ProfileConfig`` (what tests inject).
+    """
+    return ProfileCatalog().resolve(name)
+
+
+def _profile_image_and_flags(profile: Any) -> tuple[str, str]:
+    """Extract ``(image, resolved_flags)`` from a profile object.
+
+    Works for both :class:`~hal0.profiles.ResolvedProfile` (whose
+    ``resolved_flags`` is already MTP-expanded) and a plain ``ProfileConfig``
+    (resolve the flags here).  This is what lets the default profile
+    interface be ProfileCatalog while test-injected ``ProfileConfig`` objects
+    keep working.
+    """
+    flags = getattr(profile, "resolved_flags", None)
+    if flags is None:
+        flags = resolve_profile_flags(profile)
+    return str(profile.image), str(flags)
+
 
 log = logging.getLogger(__name__)
 
@@ -62,10 +92,7 @@ log = logging.getLogger(__name__)
 # template.  Writing a complete file means the manager never has to
 # know whether the base exists.
 _SYSTEMD_SYSTEM_DIR = Path("/etc/systemd/system")
-# Back-compat alias for the historic default. The *effective* mount root is
-# resolved per-render via model_store_root() ([models].store / HAL0_MODEL_STORE
-# / this default) so a custom model directory actually reaches the container.
-_MODEL_STORE_MOUNT = DEFAULT_MODEL_STORE
+_MODEL_STORE_MOUNT = "/mnt/ai-models"
 
 
 # Container runtime binary.  Prefer podman (rootless, no daemon);
@@ -150,6 +177,86 @@ def _unit_skeleton(slot_name: str, runtime: str, exec_start: str) -> str:
     )
 
 
+def _render_unit_from_plan(
+    slot_name: str,
+    plan: RuntimeLaunchPlan,
+    *,
+    runtime_bin: str | None = None,
+) -> str:
+    """Render a complete self-contained systemd unit from a launch plan.
+
+    This is the ONE argv builder for every container slot — GPU/llama-server,
+    FLM NPU, Kokoro TTS, and ComfyUI all flow through here.  It is the
+    systemd/podman *adapter*: the plan carries the launch facts, this turns
+    them into ``hal0-slot@<name>.service`` unit text.  Producing a single
+    self-contained unit means the manager never needs a parent
+    ``hal0-slot@.service`` template (retired in the v0.2 migration, PR-9).
+
+    Args:
+        slot_name:   Slot identifier; used in the container name,
+                     SyslogIdentifier, and the unit name.
+        plan:        :class:`RuntimeLaunchPlan` produced by a provider's
+                     ``container_spec``.
+        runtime_bin: Override the container runtime binary.  Defaults to
+                     :func:`_container_runtime`.  Pass explicitly in tests to
+                     avoid requiring podman/docker in the test environment.
+    """
+    runtime = runtime_bin or _container_runtime()
+    container_name = f"hal0-slot-{slot_name}"
+
+    argv: list[str] = [
+        runtime,
+        "run",
+        "--rm",
+        f"--name={container_name}",
+        # Unclean shutdown leaves a stale same-name container record (--rm
+        # never ran) → exit 125 "name already in use" at next boot (#721).
+        # --replace removes it first; no-op when no stale record exists.
+        "--replace",
+    ]
+    if plan.network_mode:
+        argv.append(f"--network={plan.network_mode}")
+    # Explicit device nodes (podman won't recurse the /dev/dri directory, #674).
+    for dev in plan.devices:
+        argv.append(f"--device={dev}")
+    # Numeric GIDs for video+render groups (ubuntu:24.04 has no group names).
+    for gid in plan.group_add:
+        argv.append(f"--group-add={gid}")
+    for cap in plan.cap_add:
+        argv.append(f"--cap-add={cap}")
+    for opt in plan.security_opt:
+        argv.append(f"--security-opt={opt}")
+    # Read-only is a first-class Mount flag (no more ":ro" target smuggling);
+    # legacy (src, dst) tuples are coerced — a ":ro" target suffix still maps
+    # to read_only so older callers keep rendering correctly.
+    for mount in plan.mounts:
+        argv.append(f"--volume={Mount.coerce(mount).render()}")
+    for k, v in plan.env.items():
+        argv.append(f"--env={k}={v}")
+    # Loopback publish derived from plan.port (declarative — plans no longer
+    # hand-roll "-p ..." in extra_args).  Skipped under host networking where
+    # port publishing is meaningless.
+    if plan.port and plan.network_mode != "host":
+        argv.append(f"--publish=127.0.0.1:{plan.port}:{plan.port}")
+    # Healthcheck override (#684): the toolbox image bakes a HEALTHCHECK that
+    # probes a hardcoded port, but a slot runs its server on its own port — so
+    # the image check fails forever and `podman ps` shows a permanent
+    # unhealthy. The plan carries the override so it renders before the image
+    # (health flags are podman-run options). hal0's own ContainerProvider.health()
+    # remains the dashboard truth.
+    if plan.health is not None:
+        argv.extend(plan.health.render_flags())
+    # extra_args escape hatch (e.g. "--ulimit memlock=-1")
+    for extra in plan.extra_args:
+        argv.extend(shlex.split(extra))
+    argv.append(plan.image)
+    argv.extend(plan.command)
+
+    # ExecStart is a single long line; systemd accepts bare argv tokens.
+    exec_start = " ".join(shlex.quote(a) if " " in a else a for a in argv)
+    return _unit_skeleton(slot_name, runtime, exec_start)
+
+
 def _render_unit(
     slot_name: str,
     image: str,
@@ -162,193 +269,139 @@ def _render_unit(
     extra_args: str | None = None,
     model_alias: str | None = None,
 ) -> str:
-    """Render a complete (non-drop-in) systemd unit for a container slot.
+    """Render a GPU/llama-server slot unit (back-compat scalar-arg shim).
 
-    Produces a self-contained unit that does NOT require a parent
-    ``hal0-slot@.service`` template (retired in the v0.2 migration, PR-9).
-    Written to ``/etc/systemd/system/hal0-slot@<name>.service``.
+    Retained for callers/tests that pass scalar launch parameters.  Builds a
+    :class:`RuntimeLaunchPlan` from those scalars and delegates to the single
+    builder :func:`_render_unit_from_plan`, so the legacy llama path and the
+    spec path render through identical code.
 
-    ``runtime_bin``: override the container runtime binary (default: auto-detect
-    via :func:`_container_runtime`).  Pass explicitly in tests to avoid
-    depending on podman/docker being installed in the test environment.
-
-    ``device_paths``: explicit GPU device nodes to pass via ``--device=``
-    (default: auto-detect via :func:`resolve_gpu_device_paths`). Podman cannot
-    recurse a ``--device=/dev/dri`` directory, so we pass each node explicitly.
-
-    ``context_size``: slot context window → ``--ctx-size``.  Without it the
-    container boots at llama-server's 4096 default regardless of the slot TOML.
-
-    ``extra_args``: ``[server].extra_args`` passthrough, appended after the
-    profile flags so slot-level overrides win.
+    ``device_paths`` defaults to :func:`resolve_gpu_device_paths`; ``context_size``
+    and ``extra_args`` (``[server].extra_args``) are appended after the profile
+    flags so slot-level overrides win.
     """
-    runtime = runtime_bin or _container_runtime()
     devices = device_paths if device_paths is not None else resolve_gpu_device_paths()
-    container_name = f"hal0-slot-{slot_name}"
-    # Effective model-store root (honours [models].store / HAL0_MODEL_STORE,
-    # default /mnt/ai-models). Mounted identical-path so the absolute GGUF path
-    # the registry hands llama-server resolves unchanged inside the container.
-    model_store = model_store_root()
-    # Split the profile flags string into tokens for ExecStart quoting.
-    flag_tokens = shlex.split(flags_str) if flags_str.strip() else []
-    extra_tokens = shlex.split(extra_args) if extra_args and extra_args.strip() else []
-
-    # Build the container run argv list.
-    argv: list[str] = [
-        runtime,
-        "run",
-        "--rm",
-        f"--name={container_name}",
-        # Unclean shutdown leaves a stale same-name container record (--rm
-        # never ran) → exit 125 "name already in use" at next boot (#721).
-        # --replace removes it first; no-op when no stale record exists.
-        "--replace",
-    ]
-    # Explicit GPU device nodes (podman won't recurse the /dev/dri directory).
-    for dev in devices:
-        argv.append(f"--device={dev}")
-    # Numeric GIDs for video+render groups (ubuntu:24.04 has no group names).
-    for gid in resolve_gpu_group_ids():
-        argv.append(f"--group-add={gid}")
-    argv.extend(
-        [
-            "--security-opt=apparmor=unconfined",
-            "--security-opt=seccomp=unconfined",
-            # ``z`` relabels the bind for SELinux-enforcing hosts (Fedora);
-            # it is a shared relabel (multiple slot containers read the store)
-            # and a harmless no-op where SELinux is disabled.
-            f"--volume={model_store}:{model_store}:ro,z",
-            # Loopback publish: expose slot port on 127.0.0.1 only.
-            f"--publish=127.0.0.1:{port}:{port}",
-            # Healthcheck override (#684): the toolbox image bakes a HEALTHCHECK
-            # that probes a hardcoded :8080, but hal0 runs llama-server on the
-            # slot's own port — so the image check fails forever and `podman ps`
-            # shows a permanent false (unhealthy) even while the server is fine.
-            # Re-point it at the real slot port. ``--health-start-period`` covers
-            # model load so probes don't trip before llama-server is listening.
-            # (hal0's own ContainerProvider.health() remains the dashboard truth.)
-            f"--health-cmd=curl -fsS http://127.0.0.1:{port}/health || exit 1",
-            "--health-start-period=180s",
-            "--health-interval=30s",
-            "--health-retries=3",
-            "--health-timeout=5s",
-            # Container image.
-            image,
-            # llama-server args follow the image (space-separated, not --key=val).
-            "--host",
-            "0.0.0.0",
-            "--port",
-            str(port),
-            "--model",
-            model_path,
-        ]
+    plan = _llama_launch_plan(
+        image=image,
+        port=port,
+        model_path=model_path,
+        flags_str=flags_str,
+        devices=list(devices),
+        group_ids=[str(g) for g in resolve_gpu_group_ids()],
+        context_size=context_size,
+        extra_args=extra_args,
+        model_alias=model_alias,
     )
-    # Advertise the hal0 registry model id (else llama-server reports the raw
-    # GGUF basename, which the dispatcher can't match to hal0/* virtual names).
-    if model_alias:
-        argv.extend(["--alias", model_alias])
-    # Slot context window (else llama-server defaults to 4096).
-    if context_size is not None:
-        argv.extend(["--ctx-size", str(context_size)])
-    # Append bench-tuned profile flags, then [server].extra_args (slot wins).
-    argv.extend(flag_tokens)
-    argv.extend(extra_tokens)
-
-    # ExecStart is a single long line; systemd accepts bare argv tokens.
-    exec_start = " ".join(shlex.quote(a) if " " in a else a for a in argv)
-    return _unit_skeleton(slot_name, runtime, exec_start)
+    return _render_unit_from_plan(slot_name, plan, runtime_bin=runtime_bin)
 
 
 def _render_unit_from_spec(
     slot_name: str,
-    spec: ContainerSpec,
+    spec: RuntimeLaunchPlan,
     *,
     runtime_bin: str | None = None,
 ) -> str:
-    """Render a complete self-contained systemd unit from a :class:`ContainerSpec`.
+    """Back-compat alias for :func:`_render_unit_from_plan`.
 
-    This is the generic renderer used by non-llama-server backends (FLM NPU,
-    ComfyUI, …). It mirrors the ``[Unit]/[Service]`` skeleton of
-    :func:`_render_unit` but sources all container-run arguments from ``spec``
-    instead of profil flags + model path.
-
-    Args:
-        slot_name:   Slot identifier; used in container name, SyslogIdentifier,
-                     and the ``hal0-slot@<name>.service`` unit name.
-        spec:        :class:`ContainerSpec` produced by the backend's provider
-                     (e.g. :meth:`FLMProvider.container_spec`).
-        runtime_bin: Override the container runtime binary.  Defaults to
-                     :func:`_container_runtime`.  Pass explicitly in tests to
-                     avoid requiring podman/docker in the test environment.
-
-    Returns:
-        Complete systemd unit text ready to be written to
-        ``/etc/systemd/system/hal0-slot@<name>.service``.
+    A ``ContainerSpec``/``RuntimeLaunchPlan`` *is* the launch plan, so this is
+    a straight delegation kept for callers/tests that still import the old
+    name.
     """
-    runtime = runtime_bin or _container_runtime()
-    container_name = f"hal0-slot-{slot_name}"
+    return _render_unit_from_plan(slot_name, spec, runtime_bin=runtime_bin)
 
-    argv: list[str] = [
-        runtime,
-        "run",
-        "--rm",
-        f"--name={container_name}",
-        # Stale same-name record after unclean shutdown → exit 125 (#721).
-        "--replace",
-    ]
-    if spec.network_mode:
-        argv.append(f"--network={spec.network_mode}")
-    for dev in spec.devices:
-        argv.append(f"--device={dev}")
-    for gid in spec.group_add:
-        argv.append(f"--group-add={gid}")
-    for cap in spec.cap_add:
-        argv.append(f"--cap-add={cap}")
-    for opt in spec.security_opt:
-        argv.append(f"--security-opt={opt}")
-    for src, dst in spec.mounts:
-        argv.append(f"--volume={src}:{dst}")
-    for k, v in spec.env.items():
-        argv.append(f"--env={k}={v}")
-    # Loopback publish derived from spec.port (declarative — specs no longer
-    # hand-roll "-p ..." in extra_args).  Skipped under host networking where
-    # port publishing is meaningless.
-    if spec.port and spec.network_mode != "host":
-        argv.append(f"--publish=127.0.0.1:{spec.port}:{spec.port}")
-    # extra_args escape hatch (e.g. "--ulimit memlock=-1")
-    for extra in spec.extra_args:
-        argv.extend(shlex.split(extra))
-    argv.append(spec.image)
-    argv.extend(spec.command)
 
-    exec_start = " ".join(shlex.quote(a) if " " in a else a for a in argv)
-    return _unit_skeleton(slot_name, runtime, exec_start)
+def _llama_launch_plan(
+    *,
+    image: str,
+    port: int,
+    model_path: str,
+    flags_str: str,
+    devices: list[str],
+    group_ids: list[str],
+    context_size: int | None = None,
+    extra_args: str | None = None,
+    model_alias: str | None = None,
+) -> RuntimeLaunchPlan:
+    """Build the GPU/llama-server :class:`RuntimeLaunchPlan`.
+
+    Single source of the llama-server launch shape — used by both
+    :meth:`ContainerProvider.container_spec` (the load path) and the
+    :func:`_render_unit` scalar shim.  llama-server takes space-separated
+    args (``--host HOST``), so they go in ``command`` after the image.
+    """
+    flag_tokens = shlex.split(flags_str) if flags_str.strip() else []
+    extra_tokens = shlex.split(extra_args) if extra_args and extra_args.strip() else []
+
+    command: list[str] = ["--host", "0.0.0.0", "--port", str(port), "--model", model_path]
+    # Advertise the hal0 registry model id (else llama-server reports the raw
+    # GGUF basename, which the dispatcher can't match to hal0/* virtual names).
+    if model_alias:
+        command += ["--alias", model_alias]
+    # Slot context window (else llama-server defaults to 4096).
+    if context_size is not None:
+        command += ["--ctx-size", str(context_size)]
+    # Bench-tuned profile flags, then [server].extra_args (slot wins).
+    command += flag_tokens
+    command += extra_tokens
+
+    return RuntimeLaunchPlan(
+        image=image,
+        command=command,
+        mounts=[Mount(_MODEL_STORE_MOUNT, _MODEL_STORE_MOUNT, read_only=True)],
+        devices=list(devices),
+        group_add=list(group_ids),
+        security_opt=["apparmor=unconfined", "seccomp=unconfined"],
+        port=port,
+        # Empty network_mode → loopback publish derived from port by the renderer.
+        network_mode="",
+        health=HealthCheck(cmd=f"curl -fsS http://127.0.0.1:{port}/health || exit 1"),
+    )
 
 
 def _spec_provider_for(slot_cfg: dict[str, Any]) -> Any | None:
-    """Spec-building provider for non-llama container slots, or None.
+    """Provider for a slot, or None for the GPU/llama-server default.
 
-    llama-server slots (GPU profiles) use the flag-bundle _render_unit path.
-    FLM (NPU), Kokoro (CPU TTS), and ComfyUI (image gen) know their own
-    argv; they build a ContainerSpec rendered by _render_unit_from_spec.
+    The runtime family is the authoritative discriminator: a slot's profile
+    resolves through :class:`~hal0.profiles.ProfileCatalog` to a
+    ``runtime_family`` (flm / kokoro / comfyui / llama-server), so the
+    family/quirk knowledge lives in one place instead of being string-matched
+    here.  Device/type/provider remain as fallbacks for profile-less slots
+    (e.g. a bare ``device=npu`` with no profile set yet).
     """
-    if str(slot_cfg.get("device", "")) == "npu":
+    family = _profile_runtime_family(slot_cfg)
+    device = str(slot_cfg.get("device", ""))
+    slot_type = str(slot_cfg.get("type", ""))
+    provider = str(slot_cfg.get("provider", ""))
+
+    if family == "flm" or device == "npu":
         from hal0.providers.flm import FLMProvider
 
         return FLMProvider()
-    if str(slot_cfg.get("type", "")) == "tts" or str(slot_cfg.get("profile", "")) == "tts":
+    if family == "kokoro" or slot_type == "tts":
         from hal0.providers.kokoro import KokoroProvider
 
         return KokoroProvider()
-    if (
-        str(slot_cfg.get("provider", "")) == "comfyui"
-        or str(slot_cfg.get("profile", "")) == "comfyui"
-        or str(slot_cfg.get("type", "")) == "image"
-    ):
+    if family == "comfyui" or provider == "comfyui" or slot_type == "image":
         from hal0.providers.comfyui import ComfyUIProvider
 
         return ComfyUIProvider()
     return None
+
+
+def _profile_runtime_family(slot_cfg: dict[str, Any]) -> str | None:
+    """Return the slot profile's ``runtime_family`` via ProfileCatalog, or None.
+
+    None when the slot has no profile or the lookup fails — callers fall back
+    to device/type discriminators.  Never raises: a malformed or missing
+    profile must not break slot dispatch.
+    """
+    name = str(slot_cfg.get("profile") or slot_cfg.get("slot", {}).get("profile") or "")
+    if not name:
+        return None
+    try:
+        return ProfileCatalog().resolve(name).runtime_family
+    except Exception:
+        return None
 
 
 class ContainerProvider(Provider):
@@ -388,42 +441,44 @@ class ContainerProvider(Provider):
             resp.raise_for_status()
             return resp.json()  # type: ignore[no-any-return]
 
-    def container_spec(self, slot_cfg: dict[str, Any], model_info: dict[str, Any]) -> ContainerSpec:
-        """Build the ContainerSpec (satisfies ABC; used by render_systemd_override).
+    def container_spec(
+        self, slot_cfg: dict[str, Any], model_info: dict[str, Any]
+    ) -> RuntimeLaunchPlan:
+        """Build the GPU/llama-server :class:`RuntimeLaunchPlan` for a slot.
 
-        NOTE: ContainerProvider uses _render_unit() for its own unit rendering
-        rather than the inherited render_systemd_override(), because the base
-        template (hal0-slot@.service) was retired in the v0.2 migration.
-        This method is kept for ABC compliance and test helpers.
+        This is the load path for GPU slots: :meth:`load_sync` resolves the
+        provider, calls ``container_spec``, and hands the plan to the single
+        renderer.  The plan is complete — registry alias, slot ``context_size``,
+        ``[server].extra_args``, the read-only model-store mount, and the
+        health-check override are all included, so what loads matches what the
+        plan describes (no GPU-special argv assembly elsewhere).
         """
         profile_name = slot_cfg.get("profile") or ""
-        profile = _resolve_profile(profile_name)
-        flags_str = resolve_profile_flags(profile)
-        flag_tokens = shlex.split(flags_str) if flags_str.strip() else []
+        image, flags_str = _profile_image_and_flags(_resolve_profile(profile_name))
 
         model_path = _resolve_model_path(model_info)
         port = int(slot_cfg.get("port", 0))
-        model_store = model_store_root()
 
-        return ContainerSpec(
-            image=profile.image,
-            command=[
-                # llama-server uses space-separated args (--host HOST, not --host=HOST).
-                "--host",
-                "0.0.0.0",
-                "--port",
-                str(port),
-                "--model",
-                model_path,
-                *flag_tokens,
-            ],
-            mounts=[(model_store, f"{model_store}:ro,z")],
-            devices=resolve_gpu_device_paths(),
-            group_add=[str(g) for g in resolve_gpu_group_ids()],
-            security_opt=["apparmor=unconfined", "seccomp=unconfined"],
+        model_table = slot_cfg.get("model") or {}
+        context_size = model_table.get("context_size") if isinstance(model_table, dict) else None
+        server_table = slot_cfg.get("server") or {}
+        extra_args = server_table.get("extra_args") if isinstance(server_table, dict) else None
+        # Registry model id → llama-server --alias so the container advertises
+        # the hal0 id (not the raw GGUF basename) for dispatcher matching.
+        model_alias = model_info.get("_model_key") or (
+            model_table.get("default") if isinstance(model_table, dict) else None
+        )
+
+        return _llama_launch_plan(
+            image=image,
             port=port,
-            network_mode="",
-            extra_args=[f"--publish=127.0.0.1:{port}:{port}"],
+            model_path=model_path,
+            flags_str=flags_str,
+            devices=list(resolve_gpu_device_paths()),
+            group_ids=[str(g) for g in resolve_gpu_group_ids()],
+            context_size=context_size,
+            extra_args=extra_args,
+            model_alias=model_alias,
         )
 
     # ── ContainerProvider-specific control plane ──────────────────────────────
@@ -542,78 +597,47 @@ class ContainerProvider(Provider):
         asyncio.to_thread-friendly path — SlotManager awaits the slot spawn
         via ``await self._spawn_locked(...)``).
 
-        Spec-provider dispatch: :func:`_spec_provider_for` maps NPU→FLM and
-        TTS/tts→Kokoro slots to their respective providers, which build a
-        :class:`ContainerSpec` rendered by :func:`_render_unit_from_spec`.
-        GPU/llama-server slots fall through to the flag-bundle :func:`_render_unit`
-        path.
+        Single launch path: :func:`_spec_provider_for` resolves the slot's
+        runtime family to a provider (FLM/NPU, Kokoro/TTS, ComfyUI/img, or this
+        provider for GPU/llama-server); the provider builds a
+        :class:`RuntimeLaunchPlan` via ``container_spec``; and the one renderer
+        :func:`_render_unit_from_plan` turns it into the systemd unit.  GPU is
+        no longer a special argv branch here.
         """
         slot_name: str = str(slot_cfg.get("name", ""))
 
-        # ── Spec-provider dispatch (NPU/FLM, TTS/Kokoro, …) ───────────────────
-        spec_provider = _spec_provider_for(slot_cfg)
-        if spec_provider is not None:
+        provider = _spec_provider_for(slot_cfg)
+        if provider is None:
+            provider = self  # GPU / llama-server
+        elif str(slot_cfg.get("device", "")) == "npu":
             # Loud-fail for NPU slots only: a missing FLM tag must not silently
-            # fall through to FLM's legacy build_env default. Kokoro is
-            # self-managed and needs no
-            # registry tag — the tag check fires ONLY when device == "npu".
-            if str(slot_cfg.get("device", "")) == "npu":
-                model_table = slot_cfg.get("model") or {}
-                tag = (
-                    model_info.get("flm_tag")
-                    or model_info.get("_model_key")
-                    or (model_table.get("default") if isinstance(model_table, dict) else None)
-                )
-                if not tag:
-                    raise ValueError("npu slot has no FLM model tag — set [model].default")
-
-            spec = spec_provider.container_spec(slot_cfg, model_info)
-            unit_text = _render_unit_from_spec(
-                slot_name,
-                spec,
-                runtime_bin=_container_runtime(),
+            # fall through to FLM's legacy build_env default. Kokoro/ComfyUI are
+            # self-managed and need no registry tag — the check fires ONLY when
+            # device == "npu".
+            model_table = slot_cfg.get("model") or {}
+            tag = (
+                model_info.get("flm_tag")
+                or model_info.get("_model_key")
+                or (model_table.get("default") if isinstance(model_table, dict) else None)
             )
-            self._write_and_start_unit(slot_name, unit_text)
-            return
+            if not tag:
+                raise ValueError("npu slot has no FLM model tag — set [model].default")
 
-        # ── GPU / llama-server branch ──────────────────────────────────────────
-        port: int = int(slot_cfg.get("port", 0))
-        profile_name: str = str(slot_cfg.get("profile") or "")
-
-        profile = _resolve_profile(profile_name)
-        flags_str = resolve_profile_flags(profile)
-        model_path = _resolve_model_path(model_info)
-
-        model_table = slot_cfg.get("model") or {}
-        context_size = model_table.get("context_size") if isinstance(model_table, dict) else None
-        server_table = slot_cfg.get("server") or {}
-        extra_args = server_table.get("extra_args") if isinstance(server_table, dict) else None
-        # Registry model id → llama-server --alias so the container advertises
-        # the hal0 id (not the raw GGUF basename) for dispatcher matching.
-        model_alias = model_info.get("_model_key") or (
-            model_table.get("default") if isinstance(model_table, dict) else None
-        )
-
-        unit_text = _render_unit(
-            slot_name,
-            profile.image,
-            port,
-            model_path,
-            flags_str,
-            context_size=context_size,
-            extra_args=extra_args,
-            model_alias=model_alias,
-        )
-
+        plan = provider.container_spec(slot_cfg, model_info)
         log.info(
             "container.unit_render",
             extra={
                 "slot": slot_name,
                 "unit_path": str(self._unit_path(slot_name)),
-                "image": profile.image,
-                "port": port,
-                "model_path": model_path,
+                "image": plan.image,
+                "port": plan.port,
+                "provider": getattr(provider, "name", type(provider).__name__),
             },
+        )
+        unit_text = _render_unit_from_plan(
+            slot_name,
+            plan,
+            runtime_bin=_container_runtime(),
         )
         self._write_and_start_unit(slot_name, unit_text)
 
@@ -798,11 +822,10 @@ def resolved_command_for_slot(
     if not profile_name:
         return None
     try:
-        profile = _resolve_profile(profile_name)
-    except (KeyError, Exception):
+        image, flags_str = _profile_image_and_flags(_resolve_profile(profile_name))
+    except Exception:
         return None
 
-    flags_str = resolve_profile_flags(profile)
     flag_tokens = shlex.split(flags_str) if flags_str.strip() else []
 
     # port: may be at top-level or nested under [slot]
@@ -819,7 +842,7 @@ def resolved_command_for_slot(
     extra_tokens = shlex.split(extra_args) if extra_args and extra_args.strip() else []
 
     argv: list[str] = [
-        profile.image,
+        image,
         "--host",
         "0.0.0.0",
         "--port",
@@ -838,6 +861,7 @@ def resolved_command_for_slot(
 
 __all__ = [
     "ContainerProvider",
+    "_render_unit_from_plan",
     "_render_unit_from_spec",
     "_spec_provider_for",
     "container_provider",

--- a/src/hal0/providers/kokoro.py
+++ b/src/hal0/providers/kokoro.py
@@ -37,11 +37,8 @@ from typing import Any
 
 import httpx
 
-from hal0.config.loader import resolve_profile
-from hal0.config.paths import model_store_root
-from hal0.config.schema import resolve_profile_flags
 from hal0.errors import Hal0Error
-from hal0.providers.base import ContainerSpec, Provider
+from hal0.providers.base import ContainerSpec, Mount, Provider
 
 # Default image tag (overridable via HAL0_TOOLBOX_IMAGE_KOKORO for dev/test).
 _DEFAULT_KOKORO_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1"
@@ -49,11 +46,13 @@ _DEFAULT_KOKORO_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1"
 # Default profile name if the slot TOML omits one.
 _DEFAULT_PROFILE = "tts"
 
-# Model store is mounted identical-path so the profile-baked
-# ``--model_path <store>/local/kokoro-v1/kokoro-onnx`` resolves inside the
-# container without path translation. The root is resolved per-render via
-# model_store_root(); ":ro,z" is encoded into the dst because
-# _render_unit_from_spec renders mounts as --volume={src}:{dst} verbatim.
+# Model store: the same absolute path is used inside the container so that
+# ``--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx`` (baked into the
+# profile flags) resolves correctly without any path translation.
+_MODEL_STORE_HOST = "/mnt/ai-models"
+# Read-only is expressed via Mount(read_only=True) at the call site, so the
+# container target is the bare path (the renderer appends ":ro").
+_MODEL_STORE_CONTAINER = "/mnt/ai-models"
 
 # Providers whose model weights are pre-staged by the operator (not hal0 registry).
 SELF_MANAGED_PROVIDERS: frozenset[str] = frozenset({"kokoro", "comfyui"})
@@ -138,12 +137,13 @@ class KokoroProvider(Provider):
         Security opts (apparmor/seccomp=unconfined) are required for
         Proxmox LXC deployments (same rationale as FLMProvider).
         """
+        from hal0.profiles import ProfileCatalog
+
         port = int(slot_cfg.get("port") or 8084)
         profile_name: str = str(slot_cfg.get("profile") or _DEFAULT_PROFILE)
-        profile = resolve_profile(profile_name)
-        flags_str = resolve_profile_flags(profile)
-        # Split profile flags; these include --model_path from the profile.
-        flag_tokens = shlex.split(flags_str) if flags_str.strip() else []
+        profile = ProfileCatalog().resolve(profile_name)
+        # ``resolved_flags`` is already MTP-expanded; these include --model_path.
+        flag_tokens = shlex.split(profile.resolved_flags) if profile.resolved_flags.strip() else []
 
         # command = profile flags + mandatory server binding args.
         # The ENTRYPOINT (tini -- kokoro-server) receives these as argv.
@@ -157,21 +157,13 @@ class KokoroProvider(Provider):
             str(port),
         ]
 
-        # Effective model-store root ([models].store / HAL0_MODEL_STORE,
-        # default /mnt/ai-models).
-        store_root = model_store_root()
-
         return ContainerSpec(
             image=profile.image,
             command=command,
             env={},
-            # Mount the model store read-only. ``:ro,z`` is encoded into the
-            # container path (dst) since _render_unit_from_spec emits
-            # --volume={src}:{dst} verbatim; ``z`` relabels for SELinux hosts.
-            # NOTE: Kokoro weights are profile-baked at <store>/local/kokoro-v1
-            # (profiles.toml --model_path). A non-default [models].store moves
-            # the mount but not that flag yet — tracked as a follow-up.
-            mounts=[(store_root, f"{store_root}:ro,z")],
+            # Model store mounted read-only — read_only is a first-class Mount
+            # flag, so the renderer adds ":ro" (no target-string smuggling).
+            mounts=[Mount(_MODEL_STORE_HOST, _MODEL_STORE_CONTAINER, read_only=True)],
             # CPU-only: no GPU devices or supplementary groups required.
             devices=[],
             cap_add=[],

--- a/src/hal0/providers/kokoro.py
+++ b/src/hal0/providers/kokoro.py
@@ -37,6 +37,7 @@ from typing import Any
 
 import httpx
 
+from hal0.config.paths import model_store_root
 from hal0.errors import Hal0Error
 from hal0.providers.base import ContainerSpec, Mount, Provider
 
@@ -46,13 +47,13 @@ _DEFAULT_KOKORO_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1"
 # Default profile name if the slot TOML omits one.
 _DEFAULT_PROFILE = "tts"
 
-# Model store: the same absolute path is used inside the container so that
-# ``--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx`` (baked into the
-# profile flags) resolves correctly without any path translation.
-_MODEL_STORE_HOST = "/mnt/ai-models"
-# Read-only is expressed via Mount(read_only=True) at the call site, so the
-# container target is the bare path (the renderer appends ":ro").
-_MODEL_STORE_CONTAINER = "/mnt/ai-models"
+# Model store is mounted identical-path so the profile-baked
+# ``--model_path <store>/local/kokoro-v1/kokoro-onnx`` resolves inside the
+# container without translation. The root is resolved per-render via
+# model_store_root(); read-only + SELinux relabel are first-class Mount flags.
+# NOTE: the weights path is still profile-baked under the default store
+# (profiles.toml); a non-default [models].store moves the mount but not that
+# flag yet — tracked as a follow-up.
 
 # Providers whose model weights are pre-staged by the operator (not hal0 registry).
 SELF_MANAGED_PROVIDERS: frozenset[str] = frozenset({"kokoro", "comfyui"})
@@ -157,13 +158,17 @@ class KokoroProvider(Provider):
             str(port),
         ]
 
+        # Effective model-store root ([models].store / HAL0_MODEL_STORE,
+        # default /mnt/ai-models).
+        store_root = model_store_root()
+
         return ContainerSpec(
             image=profile.image,
             command=command,
             env={},
-            # Model store mounted read-only — read_only is a first-class Mount
-            # flag, so the renderer adds ":ro" (no target-string smuggling).
-            mounts=[Mount(_MODEL_STORE_HOST, _MODEL_STORE_CONTAINER, read_only=True)],
+            # Model store mounted read-only with an SELinux relabel — both are
+            # first-class Mount flags (no target-string smuggling).
+            mounts=[Mount(store_root, store_root, read_only=True, selinux="z")],
             # CPU-only: no GPU devices or supplementary groups required.
             devices=[],
             cap_add=[],

--- a/tests/api/test_slots_container_state.py
+++ b/tests/api/test_slots_container_state.py
@@ -248,9 +248,14 @@ def test_container_slot_has_runtime_profile_image_fields(
             return_value={"ok": True, "status": "healthy"},
         ),
         # slot_view inline-imports load_profiles_config for the image field;
-        # container.py's resolved_command_for_slot uses the same loader.
+        # resolved_command_for_slot resolves via ProfileCatalog, which binds
+        # load_profiles_config in the hal0.profiles namespace — patch both seams.
         patch(
             "hal0.config.loader.load_profiles_config",
+            return_value=fake_catalog,
+        ),
+        patch(
+            "hal0.profiles.load_profiles_config",
             return_value=fake_catalog,
         ),
     ):
@@ -297,6 +302,10 @@ def test_container_slot_resolved_command_includes_flags(
         ),
         patch(
             "hal0.config.loader.load_profiles_config",
+            return_value=fake_catalog,
+        ),
+        patch(
+            "hal0.profiles.load_profiles_config",
             return_value=fake_catalog,
         ),
     ):

--- a/tests/providers/test_comfyui.py
+++ b/tests/providers/test_comfyui.py
@@ -129,8 +129,9 @@ def test_container_spec_mounts_persistent_data_dirs(
     spec = provider.container_spec(slot_cfg, model_info)
     # The data root holds models/, custom_nodes/, output/, input/, user/
     # — losing it on a `docker rm` would discard 6+ GB of weights.
-    assert ("/mnt/ai-models/comfyui/models", "/root/comfy-models") in spec.mounts
-    assert ("/mnt/ai-models/comfyui/custom_nodes", "/opt/ComfyUI/custom_nodes") in spec.mounts
+    pairs = {(m.source, m.target) for m in spec.mounts}
+    assert ("/mnt/ai-models/comfyui/models", "/root/comfy-models") in pairs
+    assert ("/mnt/ai-models/comfyui/custom_nodes", "/opt/ComfyUI/custom_nodes") in pairs
 
 
 def test_container_spec_command_runs_python_main(

--- a/tests/providers/test_comfyui_container_spec.py
+++ b/tests/providers/test_comfyui_container_spec.py
@@ -54,11 +54,12 @@ def test_comfyui_spec_matches_live_deployment() -> None:
     # Devices via resolve_gpu_device_paths() — explicit nodes (podman, #674).
     assert spec.devices and "/dev/kfd" in spec.devices
     assert spec.devices == _GPU_NODES
-    # Data mounts mirror docker inspect on CT105.
-    assert ("/mnt/ai-models/comfyui/models", "/root/comfy-models") in spec.mounts
+    # Data mounts mirror docker inspect on CT105 (first-class Mount objects).
+    pairs = {(m.source, m.target) for m in spec.mounts}
+    assert ("/mnt/ai-models/comfyui/models", "/root/comfy-models") in pairs
     for sub in ("output", "input", "user", "custom_nodes"):
-        assert (f"/mnt/ai-models/comfyui/{sub}", f"/opt/ComfyUI/{sub}") in spec.mounts
-    assert any("extra_model_paths.yaml" in src for src, _ in spec.mounts)
+        assert (f"/mnt/ai-models/comfyui/{sub}", f"/opt/ComfyUI/{sub}") in pairs
+    assert any("extra_model_paths.yaml" in m.source for m in spec.mounts)
     # Wan/Hunyuan video models need shared memory.
     assert "--ipc=host" in spec.extra_args
     # podman 125s on --shm-size with --ipc=host ("cannot set shmsize when
@@ -87,23 +88,27 @@ def test_comfyui_argv_uses_opt_comfyui_workdir() -> None:
 
 
 def test_comfyui_extra_model_paths_mount_is_read_only() -> None:
-    """:ro suffix on dst is how ContainerSpec expresses read-only mounts."""
+    """extra_model_paths.yaml is read-only via the first-class Mount flag; the
+    bare target carries no ":ro" (the renderer appends it)."""
     spec = ComfyUIProvider().container_spec(_img_cfg(), {})
-    yaml_mounts = [(s, d) for s, d in spec.mounts if "extra_model_paths.yaml" in s]
-    assert yaml_mounts == [
-        (
-            "/mnt/ai-models/comfyui/extra_model_paths.yaml",
-            "/opt/ComfyUI/extra_model_paths.yaml:ro",
-        )
-    ]
+    yaml_mounts = [m for m in spec.mounts if "extra_model_paths.yaml" in m.source]
+    assert len(yaml_mounts) == 1
+    yaml_mount = yaml_mounts[0]
+    assert yaml_mount.source == "/mnt/ai-models/comfyui/extra_model_paths.yaml"
+    assert yaml_mount.target == "/opt/ComfyUI/extra_model_paths.yaml"
+    assert yaml_mount.read_only is True
+    assert yaml_mount.render() == (
+        "/mnt/ai-models/comfyui/extra_model_paths.yaml:/opt/ComfyUI/extra_model_paths.yaml:ro"
+    )
 
 
 def test_comfyui_data_root_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HAL0_COMFYUI_DATA_ROOT", "/srv/comfy-data")
     spec = ComfyUIProvider().container_spec(_img_cfg(), {})
-    assert ("/srv/comfy-data/models", "/root/comfy-models") in spec.mounts
-    assert ("/srv/comfy-data/output", "/opt/ComfyUI/output") in spec.mounts
-    assert not any(src.startswith("/mnt/ai-models/comfyui") for src, _ in spec.mounts)
+    pairs = {(m.source, m.target) for m in spec.mounts}
+    assert ("/srv/comfy-data/models", "/root/comfy-models") in pairs
+    assert ("/srv/comfy-data/output", "/opt/ComfyUI/output") in pairs
+    assert not any(m.source.startswith("/mnt/ai-models/comfyui") for m in spec.mounts)
 
 
 def test_comfyui_profile_flags_fallback_without_profile() -> None:

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -145,8 +145,9 @@ class TestRenderUnit:
         # Must follow --name so the pairing is obvious in the rendered unit.
         assert tokens.index("--replace") == tokens.index("--name=hal0-slot-test-slot") + 1
 
-    def test_identical_path_mount_readonly(self) -> None:
-        """Model store must be mounted at /mnt/ai-models:ro (identical path)."""
+    def test_identical_path_mount_readonly(self, monkeypatch) -> None:
+        """Model store mounted identical-path, read-only, SELinux-relabelled."""
+        monkeypatch.setenv("HAL0_MODEL_STORE", _MODEL_STORE_MOUNT)  # pin the default
         profile = _moe_profile()
         flags = resolve_profile_flags(profile)
         unit = _render_unit(
@@ -157,12 +158,33 @@ class TestRenderUnit:
             flags,
             runtime_bin=_TEST_RUNTIME,
         )
-        exec_start = self._get_exec_start(unit)
-        tokens = shlex.split(exec_start)
-        # --volume arg must be present with :ro suffix
+        tokens = shlex.split(self._get_exec_start(unit))
         vol_args = [t for t in tokens if t.startswith(f"--volume={_MODEL_STORE_MOUNT}")]
         assert vol_args, f"no --volume for {_MODEL_STORE_MOUNT} in: {tokens}"
-        assert ":ro" in vol_args[0], f"mount not read-only: {vol_args[0]}"
+        assert vol_args[0] == f"--volume={_MODEL_STORE_MOUNT}:{_MODEL_STORE_MOUNT}:ro,z", (
+            f"unexpected mount: {vol_args[0]}"
+        )
+
+    def test_mount_honours_custom_model_store(self, monkeypatch) -> None:
+        """A custom HAL0_MODEL_STORE is what the slot bind-mounts — so a model
+        dir outside /mnt/ai-models is visible inside the container (the Fedora
+        'No such file or directory' bug). Regression guard for #768 surviving
+        the RuntimeLaunchPlan refactor (#763)."""
+        custom = "/home/cuken/ai/models"
+        monkeypatch.setenv("HAL0_MODEL_STORE", custom)
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "agent0",
+            profile.image,
+            8095,
+            f"{custom}/Qwen3.6-35B.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        tokens = shlex.split(self._get_exec_start(unit))
+        assert f"--volume={custom}:{custom}:ro,z" in tokens, tokens
+        assert not any(t.startswith("--volume=/mnt/ai-models") for t in tokens), tokens
 
     def test_loopback_port_publish(self) -> None:
         """Port must be published on 127.0.0.1 only (not LAN-exposed)."""

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -25,6 +25,7 @@ from hal0.providers.container import (
     ContainerProvider,
     _image_mismatch,
     _render_unit,
+    _render_unit_from_plan,
     _resolve_model_path,
     resolved_command_for_slot,
 )
@@ -144,9 +145,8 @@ class TestRenderUnit:
         # Must follow --name so the pairing is obvious in the rendered unit.
         assert tokens.index("--replace") == tokens.index("--name=hal0-slot-test-slot") + 1
 
-    def test_identical_path_mount_readonly(self, monkeypatch) -> None:
-        """Model store mounted identical-path, read-only, with SELinux relabel."""
-        monkeypatch.setenv("HAL0_MODEL_STORE", _MODEL_STORE_MOUNT)  # pin the default
+    def test_identical_path_mount_readonly(self) -> None:
+        """Model store must be mounted at /mnt/ai-models:ro (identical path)."""
         profile = _moe_profile()
         flags = resolve_profile_flags(profile)
         unit = _render_unit(
@@ -159,33 +159,10 @@ class TestRenderUnit:
         )
         exec_start = self._get_exec_start(unit)
         tokens = shlex.split(exec_start)
-        # identical-path mount, :ro, plus SELinux relabel (z)
+        # --volume arg must be present with :ro suffix
         vol_args = [t for t in tokens if t.startswith(f"--volume={_MODEL_STORE_MOUNT}")]
         assert vol_args, f"no --volume for {_MODEL_STORE_MOUNT} in: {tokens}"
-        assert vol_args[0] == f"--volume={_MODEL_STORE_MOUNT}:{_MODEL_STORE_MOUNT}:ro,z", (
-            f"unexpected mount: {vol_args[0]}"
-        )
-
-    def test_mount_honours_custom_model_store(self, monkeypatch) -> None:
-        """A custom HAL0_MODEL_STORE is what the slot bind-mounts — so a model
-        dir outside /mnt/ai-models is visible inside the container (the Fedora
-        'No such file or directory' bug)."""
-        custom = "/home/cuken/ai/models"
-        monkeypatch.setenv("HAL0_MODEL_STORE", custom)
-        profile = _moe_profile()
-        flags = resolve_profile_flags(profile)
-        unit = _render_unit(
-            "agent0",
-            profile.image,
-            8095,
-            f"{custom}/Qwen3.6-35B.gguf",
-            flags,
-            runtime_bin=_TEST_RUNTIME,
-        )
-        tokens = shlex.split(self._get_exec_start(unit))
-        assert f"--volume={custom}:{custom}:ro,z" in tokens, tokens
-        # the legacy default must NOT be mounted
-        assert not any(t.startswith("--volume=/mnt/ai-models") for t in tokens), tokens
+        assert ":ro" in vol_args[0], f"mount not read-only: {vol_args[0]}"
 
     def test_loopback_port_publish(self) -> None:
         """Port must be published on 127.0.0.1 only (not LAN-exposed)."""
@@ -477,10 +454,10 @@ class TestContainerSpec:
 
     def test_mount_identical_path(self) -> None:
         spec = self._build_spec()
-        mount_pairs = dict(spec.mounts)
-        assert _MODEL_STORE_MOUNT in mount_pairs
-        # identical src→dst with :ro,z encoded into the dst (SELinux relabel)
-        assert mount_pairs[_MODEL_STORE_MOUNT] == f"{_MODEL_STORE_MOUNT}:ro,z"
+        # Identical-path model-store mount, read-only via first-class Mount flag.
+        store_mount = next(m for m in spec.mounts if m.source == _MODEL_STORE_MOUNT)
+        assert store_mount.target == _MODEL_STORE_MOUNT
+        assert store_mount.read_only is True
 
     def test_devices_present(self) -> None:
         with patch(
@@ -495,12 +472,15 @@ class TestContainerSpec:
         assert "apparmor=unconfined" in spec.security_opt
         assert "seccomp=unconfined" in spec.security_opt
 
-    def test_publish_in_extra_args(self) -> None:
-        """Loopback port publish must be in extra_args (not network_mode=host)."""
+    def test_loopback_publish_derived_from_port(self) -> None:
+        """Loopback publish is derived from port + empty network_mode by the
+        renderer (declarative) — not hand-rolled into extra_args."""
         spec = self._build_spec()
-        publish_args = [a for a in spec.extra_args if "127.0.0.1" in a]
-        assert publish_args, f"no loopback publish in extra_args: {spec.extra_args}"
-        assert "8095" in publish_args[0]
+        assert spec.port == 8095
+        assert spec.network_mode == ""
+        assert not any("127.0.0.1" in a for a in spec.extra_args)
+        unit = _render_unit_from_plan("test-slot", spec, runtime_bin=_TEST_RUNTIME)
+        assert "--publish=127.0.0.1:8095:8095" in unit
 
     def test_network_mode_empty(self) -> None:
         """network_mode must be empty (not 'host') so loopback publish is used."""

--- a/tests/providers/test_kokoro_container_spec.py
+++ b/tests/providers/test_kokoro_container_spec.py
@@ -54,7 +54,8 @@ def test_spec_ro_mount_is_read_only() -> None:
     ai_mount = next(m for m in spec.mounts if m.source == "/mnt/ai-models")
     assert ai_mount.read_only is True
     assert ai_mount.target == "/mnt/ai-models"
-    assert ai_mount.render() == "/mnt/ai-models:/mnt/ai-models:ro"
+    assert ai_mount.selinux == "z"  # SELinux relabel for enforcing hosts (Fedora)
+    assert ai_mount.render() == "/mnt/ai-models:/mnt/ai-models:ro,z"
 
 
 # ── Renderer integration test ──────────────────────────────────────────────────

--- a/tests/providers/test_kokoro_container_spec.py
+++ b/tests/providers/test_kokoro_container_spec.py
@@ -36,9 +36,7 @@ def test_spec_command_carries_port_host_and_model_path() -> None:
 
 def test_spec_mounts_model_store_and_publishes_loopback() -> None:
     spec = KokoroProvider().container_spec(_slot_cfg(), {})
-    # ":ro" is appended to the container dst — that's how ContainerSpec
-    # expresses read-only mounts (_render_unit_from_spec emits --volume={src}:{dst}).
-    assert any(m[0] == "/mnt/ai-models" for m in spec.mounts)
+    assert any(m.source == "/mnt/ai-models" for m in spec.mounts)
     assert spec.port == 8084
     assert spec.network_mode == ""
 
@@ -49,15 +47,14 @@ def test_spec_security_opts_for_lxc() -> None:
     assert "seccomp=unconfined" in spec.security_opt
 
 
-def test_spec_ro_mount_dst_has_ro_suffix() -> None:
-    """ContainerSpec mount dst must carry :ro (+ SELinux z) so the rendered
-    --volume arg is read-only and relabelled on SELinux hosts."""
+def test_spec_ro_mount_is_read_only() -> None:
+    """Model-store mount must be read-only via the first-class Mount flag so
+    the renderer emits a :ro --volume (no :ro target-string smuggling)."""
     spec = KokoroProvider().container_spec(_slot_cfg(), {})
-    ai_mount = next(m for m in spec.mounts if m[0] == "/mnt/ai-models")
-    assert ai_mount[1].endswith(":ro,z"), (
-        f"mount dst {ai_mount[1]!r} must end with ':ro,z' — "
-        "_render_unit_from_spec emits --volume={src}:{dst} verbatim"
-    )
+    ai_mount = next(m for m in spec.mounts if m.source == "/mnt/ai-models")
+    assert ai_mount.read_only is True
+    assert ai_mount.target == "/mnt/ai-models"
+    assert ai_mount.render() == "/mnt/ai-models:/mnt/ai-models:ro"
 
 
 # ── Renderer integration test ──────────────────────────────────────────────────

--- a/tests/providers/test_runtime_launch_plan.py
+++ b/tests/providers/test_runtime_launch_plan.py
@@ -50,6 +50,12 @@ class TestMount:
         # A target that already carries ":ro" must not become ":ro:ro".
         assert Mount("/a", "/b:ro", read_only=True).render() == "/a:/b:ro"
 
+    def test_selinux_relabel_appended(self) -> None:
+        # SELinux relabel is a first-class flag (Fedora/enforcing hosts).
+        assert Mount("/a", "/b", read_only=True, selinux="z").render() == "/a:/b:ro,z"
+        assert Mount("/a", "/b", selinux="z").render() == "/a:/b:z"
+        assert Mount("/a", "/b:ro", read_only=True, selinux="z").render() == "/a:/b:ro,z"
+
     def test_coerce_passes_mount_through(self) -> None:
         m = Mount("/a", "/b", read_only=True)
         assert Mount.coerce(m) is m
@@ -161,7 +167,7 @@ def test_render_unit_shim_matches_equivalent_plan() -> None:
             "131072",
             *shlex.split(flags),
         ],
-        mounts=[Mount(_MODEL_STORE_MOUNT, _MODEL_STORE_MOUNT, read_only=True)],
+        mounts=[Mount(_MODEL_STORE_MOUNT, _MODEL_STORE_MOUNT, read_only=True, selinux="z")],
         devices=["/dev/kfd", "/dev/dri/renderD128"],
         security_opt=["apparmor=unconfined", "seccomp=unconfined"],
         port=8095,

--- a/tests/providers/test_runtime_launch_plan.py
+++ b/tests/providers/test_runtime_launch_plan.py
@@ -1,0 +1,201 @@
+"""RuntimeLaunchPlan + the single unit renderer (#4 — fold the two argv
+builders into one, with first-class read-only mounts and health).
+
+Covers what the refactor newly guarantees:
+  * Mount expresses read-only as a flag (not a ":ro" target string), and the
+    renderer emits the right --volume value either way (incl. legacy tuples);
+  * HealthCheck renders the --health-* podman flags;
+  * _render_unit (scalar shim) and _render_unit_from_plan agree byte-for-byte —
+    the legacy llama path now folds into the spec path;
+  * _spec_provider_for routes on the profile's runtime_family.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+from hal0.config.schema import ProfileConfig, resolve_profile_flags
+from hal0.providers.base import HealthCheck, Mount, RuntimeLaunchPlan
+from hal0.providers.comfyui import ComfyUIProvider
+from hal0.providers.container import (
+    _MODEL_STORE_MOUNT,
+    _render_unit,
+    _render_unit_from_plan,
+    _spec_provider_for,
+)
+from hal0.providers.flm import FLMProvider
+from hal0.providers.kokoro import KokoroProvider
+
+_TEST_RUNTIME = "/usr/bin/docker"
+
+
+def _exec_start(unit_text: str) -> str:
+    for line in unit_text.splitlines():
+        if line.startswith("ExecStart="):
+            return line[len("ExecStart=") :]
+    raise AssertionError("ExecStart not found")
+
+
+# ── Mount ──────────────────────────────────────────────────────────────────────
+
+
+class TestMount:
+    def test_read_write_renders_src_dst(self) -> None:
+        assert Mount("/a", "/b").render() == "/a:/b"
+
+    def test_read_only_appends_ro(self) -> None:
+        assert Mount("/a", "/b", read_only=True).render() == "/a:/b:ro"
+
+    def test_read_only_does_not_double_ro_on_legacy_target(self) -> None:
+        # A target that already carries ":ro" must not become ":ro:ro".
+        assert Mount("/a", "/b:ro", read_only=True).render() == "/a:/b:ro"
+
+    def test_coerce_passes_mount_through(self) -> None:
+        m = Mount("/a", "/b", read_only=True)
+        assert Mount.coerce(m) is m
+
+    def test_coerce_plain_tuple_is_read_write(self) -> None:
+        m = Mount.coerce(("/a", "/b"))
+        assert (m.source, m.target, m.read_only) == ("/a", "/b", False)
+
+    def test_coerce_ro_suffixed_tuple_becomes_read_only(self) -> None:
+        # Legacy callers smuggled ":ro" into the target — coercion recovers it.
+        m = Mount.coerce(("/a", "/b:ro"))
+        assert (m.source, m.target, m.read_only) == ("/a", "/b", True)
+
+
+# ── HealthCheck ────────────────────────────────────────────────────────────────
+
+
+class TestHealthCheck:
+    def test_render_flags_order_and_defaults(self) -> None:
+        flags = HealthCheck(cmd="curl -fsS http://127.0.0.1:9/health || exit 1").render_flags()
+        assert flags[0] == "--health-cmd=curl -fsS http://127.0.0.1:9/health || exit 1"
+        assert "--health-start-period=180s" in flags
+        assert "--health-interval=30s" in flags
+        assert "--health-retries=3" in flags
+        assert "--health-timeout=5s" in flags
+
+
+# ── single renderer ─────────────────────────────────────────────────────────────
+
+
+class TestRenderUnitFromPlan:
+    def test_host_network_skips_publish(self) -> None:
+        plan = RuntimeLaunchPlan(image="img", command=["x"], port=8080, network_mode="host")
+        unit = _render_unit_from_plan("s", plan, runtime_bin=_TEST_RUNTIME)
+        assert "--publish" not in unit
+        assert "--network=host" in unit
+
+    def test_empty_network_publishes_loopback_from_port(self) -> None:
+        plan = RuntimeLaunchPlan(image="img", command=["x"], port=8080, network_mode="")
+        unit = _render_unit_from_plan("s", plan, runtime_bin=_TEST_RUNTIME)
+        assert "--publish=127.0.0.1:8080:8080" in unit
+        assert "--network=" not in unit
+
+    def test_health_flags_precede_image(self) -> None:
+        plan = RuntimeLaunchPlan(
+            image="the-image",
+            command=["--go"],
+            port=8080,
+            network_mode="",
+            health=HealthCheck(cmd="probe || exit 1"),
+        )
+        tokens = shlex.split(
+            _exec_start(_render_unit_from_plan("s", plan, runtime_bin=_TEST_RUNTIME))
+        )
+        health = next(t for t in tokens if t.startswith("--health-cmd="))
+        assert tokens.index(health) < tokens.index("the-image")
+
+    def test_no_health_emits_no_health_flags(self) -> None:
+        plan = RuntimeLaunchPlan(image="img", command=["x"], port=8080, network_mode="")
+        assert "--health-cmd=" not in _render_unit_from_plan("s", plan, runtime_bin=_TEST_RUNTIME)
+
+    def test_mount_and_legacy_tuple_render_identically(self) -> None:
+        # The renderer coerces a legacy (src, dst:ro) tuple to the same volume
+        # arg a first-class read-only Mount produces.
+        as_mount = RuntimeLaunchPlan(
+            image="img", command=["x"], mounts=[Mount("/m", "/m", read_only=True)]
+        )
+        as_tuple = RuntimeLaunchPlan(image="img", command=["x"], mounts=[("/m", "/m:ro")])
+        m_unit = _render_unit_from_plan("s", as_mount, runtime_bin=_TEST_RUNTIME)
+        t_unit = _render_unit_from_plan("s", as_tuple, runtime_bin=_TEST_RUNTIME)
+        assert "--volume=/m:/m:ro" in m_unit
+        assert _exec_start(m_unit) == _exec_start(t_unit)
+
+
+# ── legacy shim folds into the single builder ──────────────────────────────────
+
+
+def test_render_unit_shim_matches_equivalent_plan() -> None:
+    """_render_unit (scalar shim) must produce the same unit as building the
+    equivalent RuntimeLaunchPlan and rendering it — proving the legacy llama
+    path is now just the spec path with a thin adapter."""
+    profile = ProfileConfig(image="ghcr.io/x:server", flags="-fa on --no-mmap", mtp=False)
+    flags = resolve_profile_flags(profile)
+
+    shim_unit = _render_unit(
+        "chat",
+        profile.image,
+        8095,
+        "/mnt/ai-models/m.gguf",
+        flags,
+        runtime_bin=_TEST_RUNTIME,
+        device_paths=["/dev/kfd", "/dev/dri/renderD128"],
+        context_size=131072,
+        model_alias="my-model",
+    )
+
+    equivalent = RuntimeLaunchPlan(
+        image=profile.image,
+        command=[
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "8095",
+            "--model",
+            "/mnt/ai-models/m.gguf",
+            "--alias",
+            "my-model",
+            "--ctx-size",
+            "131072",
+            *shlex.split(flags),
+        ],
+        mounts=[Mount(_MODEL_STORE_MOUNT, _MODEL_STORE_MOUNT, read_only=True)],
+        devices=["/dev/kfd", "/dev/dri/renderD128"],
+        security_opt=["apparmor=unconfined", "seccomp=unconfined"],
+        port=8095,
+        network_mode="",
+        health=HealthCheck(cmd="curl -fsS http://127.0.0.1:8095/health || exit 1"),
+    )
+
+    # group_add is resolved from the host in the shim; compare ExecStart minus
+    # the host-specific --group-add tokens.
+    def _strip_gids(unit: str) -> list[str]:
+        return [t for t in shlex.split(_exec_start(unit)) if not t.startswith("--group-add=")]
+
+    assert _strip_gids(shim_unit) == _strip_gids(
+        _render_unit_from_plan("chat", equivalent, runtime_bin=_TEST_RUNTIME)
+    )
+
+
+# ── runtime-family dispatch (#1 provider-half: stop string-matching) ───────────
+
+
+class TestSpecProviderRuntimeFamily:
+    def test_kokoro_profile_routes_by_family(self) -> None:
+        # Profile present, no type/device hint — family alone must decide.
+        assert isinstance(_spec_provider_for({"profile": "tts"}), KokoroProvider)
+
+    def test_comfyui_profile_routes_by_family(self) -> None:
+        assert isinstance(_spec_provider_for({"profile": "comfyui"}), ComfyUIProvider)
+
+    def test_flm_profile_routes_by_family(self) -> None:
+        assert isinstance(_spec_provider_for({"profile": "flm"}), FLMProvider)
+
+    def test_gpu_profile_routes_to_llama_default(self) -> None:
+        assert _spec_provider_for({"profile": "rocm"}) is None
+
+    def test_unknown_profile_falls_back_to_device_hint(self) -> None:
+        # Unresolvable profile → family None → device fallback still routes NPU.
+        assert isinstance(_spec_provider_for({"profile": "nope", "device": "npu"}), FLMProvider)


### PR DESCRIPTION
## What

Collapses the two divergent container `ExecStart` builders — the llama/flag-bundle path and the spec path — into a single **`RuntimeLaunchPlan`** rendered by one unit emitter. This is the unification step (#4) of the container-runtime serving work: GPU/llama-server is no longer a special argv branch.

## Changes

- **`providers/base.py`** — new first-class `Mount` (read-only is a flag, not a `":ro"` string baked into the target), `HealthCheck` (renders podman `--health-*` flags), and `RuntimeLaunchPlan` dataclasses.
- **`providers/container.py`** — one renderer (`_render_unit_from_plan`); the legacy scalar shim `_render_unit` folds into it and the two now agree **byte-for-byte**. `_spec_provider_for` routes on the profile's `runtime_family` (via `ProfileCatalog`) rather than string-matching slugs, with device/type/provider as fallbacks for profile-less slots.
- **`providers/comfyui.py`, `providers/kokoro.py`** — move onto the shared plan/spec surface.

## Rebase note

Rebased onto current `main` (was 22 commits behind). The only overlap was #751's profile rename (`kokoro-cpu`→`tts`, `flm-npu`→`flm`, `moe-rocmfp4`→`rocm`); resolved by keeping the rename — the family-based dispatch (`runtime_family == "kokoro"`) already handles the renamed `tts` profile robustly, and test fixtures were updated to the new slugs.

## Tests

369 passing (`tests/providers/` + `tests/api/test_slots_container_state.py` + `tests/dispatcher/`), including new `test_runtime_launch_plan.py` covering Mount/HealthCheck rendering, `_render_unit` vs `_render_unit_from_plan` byte-parity, and family-based dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)