### PR TITLE
fix(installer): fresh install leaves every slot dead — require podman, seed chat profile, run OpenWebUI on podman

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -34,7 +34,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/ui.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/lib/distro.sh"
 
 # Re-runnable pre-flight checks (preflight_systemd / preflight_python /
-# preflight_docker / preflight_disk / preflight_ports / preflight_all).
+# preflight_container_runtime / preflight_disk / preflight_ports / preflight_all).
 # Sourcing only loads the functions — the installer dispatches the
 # subset it cares about below. `hal0 doctor` shells the same file in
 # executable mode to run preflight_all post-install.
@@ -272,9 +272,14 @@ fi
 # missing" case before it fails with an opaque ensurepip error.
 preflight_venv || die "python venv module missing — install with: $(python_venv_hint)"
 
-# preflight_docker is soft (always returns 0 with a warning when
-# Docker is absent), so we don't need to guard the call.
-preflight_docker
+# Every inference slot runs in a container, so a container runtime is a hard
+# requirement. HAL0_CONTAINER_REQUIRED=1 flips preflight_container_runtime into
+# install-podman-or-fail mode (podman auto-installed via the detected package
+# manager; hard-fail with the exact one-liner otherwise). Without this a fresh
+# box finishes "successfully" but every slot sits in error "no container runtime
+# found". `hal0 doctor` leaves the flag unset and stays soft/report-only.
+HAL0_CONTAINER_REQUIRED=1 preflight_container_runtime \
+    || die "no container runtime — install podman (see above), then re-run install.sh"
 
 # Disk + port-collision checks only matter for the live install — dev
 # mode lays files under $PWD/.hal0ai and never binds 8080/3001. We
@@ -606,7 +611,11 @@ OPENWEBUI_UNIT_DST="${UNIT_DIR}/hal0-openwebui.service"
 # pulled by the background job below and referenced by the systemd unit.
 # Bump the sha256 digest here on each hal0 release; update the matching
 # digest in packaging/systemd/hal0-openwebui.service at the same time.
-OPENWEBUI_IMAGE="ghcr.io/open-webui/open-webui@sha256:d05c6ff8baf5ae701d86a3332c0db4ebb2802ca3d0d341be7fd157fa730306ab"
+# IMPORTANT: this MUST be the multi-arch *manifest list* (index) digest, NOT a
+# per-arch sub-manifest — a sub-manifest digest pins one architecture on every
+# host (the prior arm64 pin died on amd64 with "exec ... Exec format error").
+# Verify with: podman manifest inspect <ref> (mediaType ...manifest.list...).
+OPENWEBUI_IMAGE="ghcr.io/open-webui/open-webui@sha256:7f1b0a1a50cfbac23da3b16f96bc968fd757b26dc9e54e93813d61768ea9184e"
 if [[ -f "${OPENWEBUI_UNIT_SRC}" ]]; then
     cp "${OPENWEBUI_UNIT_SRC}" "${OPENWEBUI_UNIT_DST}"
     info "wrote ${OPENWEBUI_UNIT_DST}"
@@ -662,14 +671,14 @@ fi
 
 # Kick off a background pull of the OpenWebUI image so the unit start
 # below isn't blocked by a multi-hundred-MB download on first install.
-# The unit also has ExecStartPre=docker pull (idempotent), so a missed
+# The unit also has ExecStartPre=podman pull (idempotent), so a missed
 # background pull never breaks correctness — only first-boot latency.
-if [[ "${DEV_MODE}" -eq 0 && "${NO_START}" -eq 0 ]] && command -v docker >/dev/null && docker info >/dev/null 2>&1; then
+if [[ "${DEV_MODE}" -eq 0 && "${NO_START}" -eq 0 ]] && command -v podman >/dev/null 2>&1; then
     # Background the actual pull, but spin briefly so the user sees we
-    # kicked it off. The hal0-openwebui unit also has ExecStartPre=docker
+    # kicked it off. The hal0-openwebui unit also has ExecStartPre=podman
     # pull (idempotent), so missing this background pull only costs first
     # -boot latency, not correctness.
-    (docker pull "${OPENWEBUI_IMAGE}" >/dev/null 2>&1 || true) &
+    (podman pull "${OPENWEBUI_IMAGE}" >/dev/null 2>&1 || true) &
     disown
     ui_spinner_run "Pulling ${OPENWEBUI_IMAGE} in background" sleep 3
 fi
@@ -1028,14 +1037,12 @@ else
     fi
 
     if [[ -f "${OPENWEBUI_UNIT_DST}" ]]; then
-        # OpenWebUI runs as a docker container (ExecStart=docker run …).
-        # Without a reachable docker daemon the unit just restart-loops
-        # with status=203/EXEC ("docker: No such file or directory"), so
-        # gate the enable/start on docker actually being usable — the
-        # same fail-soft posture as the hermes agent gating below. The
-        # dashboard/API are unaffected; the operator installs docker and
-        # then enables the unit. preflight already warned about the gap.
-        if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+        # OpenWebUI runs as a podman container (ExecStart=podman run …) — the
+        # same runtime as the slots, so the preflight that installed podman
+        # already satisfies it. Without a usable runtime the unit would
+        # restart-loop with status=203/EXEC, so guard the enable anyway — the
+        # dashboard/API are unaffected and the built-in chat works without it.
+        if command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
             systemctl enable --now hal0-openwebui
             # OpenWebUI can take a moment to come up while it pulls the
             # image / initialises its sqlite db. Don't fail the installer
@@ -1046,14 +1053,14 @@ else
                 warn "hal0-openwebui not yet active; check 'journalctl -u hal0-openwebui -n 40'"
             fi
         else
-            # A prior install on a box that has since lost docker (or an
+            # A prior install on a box that has since lost its runtime (or an
             # upgrade where openwebui was enabled) may have left the unit
             # restart-looping with 203/EXEC. Actively quiesce it so the
             # status reflects reality (inactive, not failed/looping).
             systemctl disable --now hal0-openwebui >/dev/null 2>&1 || true
             systemctl reset-failed hal0-openwebui >/dev/null 2>&1 || true
-            info "hal0-openwebui not started — docker is unavailable"
-            info "  install docker, then: systemctl enable --now hal0-openwebui  (chat at :3001)"
+            info "hal0-openwebui not started — no usable container runtime"
+            info "  install podman, then: systemctl enable --now hal0-openwebui  (chat at :3001)"
         fi
     fi
 

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -10,20 +10,20 @@
 # none of them exit the calling shell):
 #   preflight_systemd          — systemctl on PATH
 #   preflight_python           — `${PY:-python3}` resolvable + version 3.11–3.14
-#   preflight_docker           — `docker info` reachable. Soft by default
-#                                (returns 0 with a warning, since the API
-#                                can run without Docker until a slot is
-#                                launched and `hal0 doctor` should report
-#                                the full picture rather than abort). Set
-#                                HAL0_DOCKER_REQUIRED=1 to flip it hard:
-#                                on apt-based hosts the function then
-#                                auto-installs docker.io + enables the
-#                                docker.service; on rpm/pacman/etc. it
-#                                emits the exact one-liner to run and
-#                                returns non-zero. install.sh sets the
-#                                flag so a fresh box doesn't end up with
-#                                hal0-openwebui.service restart-looping
-#                                with status=203/EXEC.
+#   preflight_container_runtime — a usable container runtime (podman
+#                                preferred, docker accepted). Soft by
+#                                default (returns 0 with a warning, since
+#                                the API/dashboard come up without a runtime
+#                                and `hal0 doctor` should report the full
+#                                picture rather than abort). Set
+#                                HAL0_CONTAINER_REQUIRED=1 to flip it hard:
+#                                the function then auto-installs podman via
+#                                the detected package manager (lib/distro.sh)
+#                                and hard-fails with the exact one-liner if
+#                                that's not possible. install.sh sets the
+#                                flag so a fresh box never finishes with every
+#                                slot dead ("no container runtime found").
+#                                `preflight_docker` is a back-compat alias.
 #   preflight_disk MIN_GB DIR  — at least MIN_GB free in DIR (default 20 / /var/lib)
 #   preflight_ports P1 [P2…]   — none of the named TCP ports are LISTENing
 #   preflight_all              — run all of the above; aggregate non-zero
@@ -36,10 +36,11 @@
 #                        when running `hal0 doctor` on a fresh container)
 #   HAL0_DOCTOR_PORTS  — space-separated port list for preflight_ports
 #                        (default "8080 3001")
-#   HAL0_DOCKER_REQUIRED — when "1", preflight_docker auto-installs
-#                        docker.io on apt hosts and hard-fails (returns
-#                        non-zero) elsewhere. Default empty → soft mode
-#                        for `hal0 doctor`.
+#   HAL0_CONTAINER_REQUIRED — when "1", preflight_container_runtime
+#                        auto-installs podman (via the detected package
+#                        manager) and hard-fails (returns non-zero) when it
+#                        can't. Default empty → soft mode for `hal0 doctor`.
+#                        Legacy HAL0_DOCKER_REQUIRED is still honoured.
 
 # shellcheck shell=bash
 
@@ -159,86 +160,101 @@ preflight_network() {
     return 0
 }
 
-preflight_docker() {
-    # Fast path: docker is on PATH and the daemon answers. Same as before.
+# Resolve a usable container runtime. Mirrors providers/container.py's
+# _container_runtime(), which prefers /usr/bin/podman over /usr/bin/docker —
+# podman is daemonless + rootless-capable and is what the hal0 slot stack
+# standardises on. `<rt> info` is the functional probe (docker: daemon up;
+# podman: storage/conf usable). Echoes the runtime name; non-zero on failure.
+_resolve_container_runtime() {
+    if command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
+        echo podman
+        return 0
+    fi
     if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-        info "docker: $(docker version --format '{{.Server.Version}}' 2>/dev/null || echo unknown)"
+        echo docker
+        return 0
+    fi
+    return 1
+}
+
+preflight_container_runtime() {
+    # Fast path: a runtime is already installed and working.
+    local rt
+    if rt="$(_resolve_container_runtime)"; then
+        if [[ "${rt}" == podman ]]; then
+            info "podman: $(podman version --format '{{.Version}}' 2>/dev/null || echo unknown)"
+        else
+            info "docker: $(docker version --format '{{.Server.Version}}' 2>/dev/null || echo unknown)"
+        fi
         return 0
     fi
 
-    # Docker is missing or the daemon is unreachable. Two modes:
+    # No usable runtime. Two modes:
     #
-    #   HAL0_DOCKER_REQUIRED=1 (set by install.sh) — try to fix it on apt
-    #     hosts, hard-fail with remediation elsewhere. hal0-openwebui
-    #     and the slot containers genuinely need docker; letting the
-    #     installer finish "successfully" only to have systemd restart-
-    #     loop the unit with status=203/EXEC is worse than refusing to
-    #     proceed (real fallout: LXC 105 burned ~191 restarts before a
-    #     human noticed).
+    #   HAL0_CONTAINER_REQUIRED=1 (set by install.sh; legacy HAL0_DOCKER_REQUIRED
+    #     honoured) — install podman, hard-fail with remediation if that's not
+    #     possible. Every inference slot runs in a container; letting the install
+    #     finish "successfully" only to have every slot sit in `error` with
+    #     "no container runtime found" is worse than refusing to proceed.
     #
-    #   Unset (default, e.g. `hal0 doctor`) — keep the legacy soft
-    #     behaviour: warn and return 0 so the rest of the report runs.
-    if [[ "${HAL0_DOCKER_REQUIRED:-0}" != "1" ]]; then
-        warn "docker is not available — slot launches will fail until it is installed"
+    #   Unset (default, e.g. `hal0 doctor`) — soft: warn and return 0 so the
+    #     rest of the report runs.
+    if [[ "${HAL0_CONTAINER_REQUIRED:-${HAL0_DOCKER_REQUIRED:-0}}" != "1" ]]; then
+        warn "no container runtime (podman/docker) — slot launches will fail until one is installed"
         return 0
     fi
 
     # ── required mode ───────────────────────────────────────────────────
-    # If the binary is there but the daemon isn't reachable, we don't
-    # try to "fix" it by reinstalling — surfacing a clear "daemon down"
-    # message is more honest than an apt-get that won't help.
+    # A binary present but failing its probe is a real config problem (podman
+    # storage/subuid, or docker daemon down). Reinstalling won't help — surface
+    # it rather than churn the package manager.
+    if command -v podman >/dev/null 2>&1; then
+        err "podman present but 'podman info' failed — inspect 'podman info' output"
+        warn "  (in an unprivileged container this often needs newuidmap/subuid setup)"
+        return 1
+    fi
     if command -v docker >/dev/null 2>&1; then
         err "docker binary present but 'docker info' failed — is the daemon running?"
         warn "  start it with: systemctl enable --now docker"
         return 1
     fi
 
-    # Apt-based host → auto-install docker.io. The package name is
-    # deliberate: Debian/Ubuntu ship the upstream-maintained docker.io
-    # in main, which is what our docs already point operators at. We
-    # don't add Docker Inc.'s third-party repo here — it's a heavier
-    # change that an operator can opt into manually.
-    if command -v apt-get >/dev/null 2>&1; then
-        info "installing docker.io (required for OpenWebUI + ComfyUI containers)"
-        # -q to keep apt's per-line progress chatter out of the spinner-
-        # less preflight phase; -y for non-interactive. We don't pipe to
-        # /dev/null — if the install fails the operator needs to see why.
-        if ! DEBIAN_FRONTEND=noninteractive apt-get install -y -q docker.io; then
-            err "apt-get install docker.io failed — see output above"
-            return 1
-        fi
-        # Enable + start the daemon so the very next step (which may be
-        # `docker pull` for OpenWebUI) actually has something to talk to.
-        if command -v systemctl >/dev/null 2>&1; then
-            systemctl enable --now docker >/dev/null 2>&1 || \
-                warn "could not 'systemctl enable --now docker' — start it manually if the daemon isn't running"
-        fi
-        # Re-probe. If the daemon still isn't reachable (e.g. inside an
-        # unprivileged container) we surface that rather than press on.
-        if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-            info "docker: $(docker version --format '{{.Server.Version}}' 2>/dev/null || echo unknown)"
+    # Auto-install podman via the detected package manager (lib/distro.sh).
+    # podman is daemonless, so unlike docker there is nothing to enable.
+    local pm
+    if pm="$(pkg_mgr)"; then
+        info "installing podman (required for hal0 inference slots)"
+        local ok=1
+        case "${pm}" in
+            apt-get) DEBIAN_FRONTEND=noninteractive apt-get install -y -q podman || ok=0 ;;
+            dnf) dnf install -y podman || ok=0 ;;
+            yum) yum install -y podman || ok=0 ;;
+            zypper) zypper install -y podman || ok=0 ;;
+            pacman) pacman -S --noconfirm podman || ok=0 ;;
+            apk) apk add podman || ok=0 ;;
+            *) ok=0 ;;
+        esac
+        if [[ "${ok}" -eq 1 ]] && rt="$(_resolve_container_runtime)" && [[ "${rt}" == podman ]]; then
+            info "podman: $(podman version --format '{{.Version}}' 2>/dev/null || echo unknown)"
             return 0
         fi
-        err "docker installed but daemon still unreachable — check 'systemctl status docker' and 'journalctl -u docker -n 40'"
+        err "podman install/initialisation failed — see output above; check 'podman info'"
         return 1
     fi
 
-    # Non-apt host: emit the right one-liner for the detected package
-    # manager (via lib/distro.sh), then hard-fail. Operator runs it, reruns
-    # install.sh. Alpine uses OpenRC, not systemd, so its enable step differs.
-    err "docker not installed — hal0 requires docker for OpenWebUI + slot containers"
-    local docker_install
-    if docker_install="$(pkg_install_cmd docker)"; then
-        if [[ "$(pkg_mgr)" == "apk" ]]; then
-            warn "  install with: ${docker_install} && sudo rc-update add docker default && sudo service docker start"
-        else
-            warn "  install with: ${docker_install} && sudo systemctl enable --now docker"
-        fi
+    # No recognised package manager → hard-fail with the best hint available.
+    err "no container runtime — hal0 requires podman (or docker) for inference slots"
+    local podman_install
+    if podman_install="$(pkg_install_cmd podman)"; then
+        warn "  install with: ${podman_install}"
     else
-        warn "  no recognised package manager — install docker from https://docs.docker.com/engine/install/ then re-run install.sh"
+        warn "  install podman from https://podman.io/docs/installation then re-run install.sh"
     fi
     return 1
 }
+
+# Back-compat alias: older docs / `hal0 doctor` builds call preflight_docker.
+preflight_docker() { preflight_container_runtime "$@"; }
 
 preflight_disk() {
     local min_gb="${1:-${HAL0_DISK_MIN_GB:-20}}"
@@ -330,7 +346,7 @@ preflight_all() {
     preflight_venv    || rc=$?
     preflight_writable || rc=$?
     preflight_network || rc=$?
-    preflight_docker  || rc=$?
+    preflight_container_runtime || rc=$?
     preflight_disk    || rc=$?
     preflight_ports   || rc=$?
     if (( rc == 0 )); then

--- a/installer/uninstall.sh
+++ b/installer/uninstall.sh
@@ -141,11 +141,16 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
         fi
     done
 
-    # Stop OpenWebUI container explicitly in case docker didn't get the memo
-    if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^hal0-openwebui$'; then
-        docker stop hal0-openwebui &>/dev/null || true
-        info "Stopped Docker container hal0-openwebui"
-    fi
+    # Stop the OpenWebUI container explicitly in case the unit stop didn't get
+    # the memo. It runs under podman now; check docker too so docker-era
+    # installs are cleaned up on the same pass.
+    for _rt in podman docker; do
+        if command -v "${_rt}" >/dev/null 2>&1 \
+            && "${_rt}" ps --format '{{.Names}}' 2>/dev/null | grep -q '^hal0-openwebui$'; then
+            "${_rt}" stop hal0-openwebui &>/dev/null || true
+            info "Stopped ${_rt} container hal0-openwebui"
+        fi
+    done
 else
     step "Skipping systemd / docker stop (dev mode)"
 fi

--- a/packaging/systemd/hal0-openwebui.service
+++ b/packaging/systemd/hal0-openwebui.service
@@ -1,16 +1,13 @@
 [Unit]
 Description=hal0 OpenWebUI companion (ghcr.io/open-webui/open-webui)
 Documentation=https://github.com/open-webui/open-webui
-# Docker must be up before we try to run a container. 'Wants' (not
-# 'Requires') so a transient docker restart doesn't force-kill this
-# unit before the on-failure restart loop gets a chance.
-After=docker.service
-Wants=docker.service
-# The API should be reachable so OpenWebUI's OPENAI_API_BASE_URLS health
-# check on first boot finds a live endpoint, but it is not strictly
-# required — OpenWebUI will retry the upstream on its own.
-After=hal0-api.service
-Wants=hal0-api.service
+# Runs as a podman container (daemonless) — the same runtime as the
+# inference slots, so the box needs no docker. The API should be reachable
+# so OpenWebUI's OPENAI_API_BASE_URLS health check on first boot finds a
+# live endpoint, but it is not strictly required — OpenWebUI retries the
+# upstream on its own.
+After=network-online.target hal0-api.service
+Wants=network-online.target hal0-api.service
 
 [Service]
 Type=simple
@@ -22,24 +19,27 @@ Type=simple
 EnvironmentFile=/etc/hal0/openwebui.env
 
 # Pre-pull on first start so the unit doesn't sit in 'activating' for
-# minutes the first time. Idempotent — Docker reuses the cached image.
+# minutes the first time. Idempotent — podman reuses the cached image.
 # pin per release (#79) — sha256 digest is deterministic; bump on each
 # hal0 release after a smoke test.
-ExecStartPre=-/usr/bin/docker pull ghcr.io/open-webui/open-webui@sha256:d05c6ff8baf5ae701d86a3332c0db4ebb2802ca3d0d341be7fd157fa730306ab
+ExecStartPre=-/usr/bin/podman pull ghcr.io/open-webui/open-webui@sha256:7f1b0a1a50cfbac23da3b16f96bc968fd757b26dc9e54e93813d61768ea9184e
 
 # Best-effort cleanup of any stale container from a previous start that
 # didn't shut down cleanly. The leading `-` makes systemd ignore the
 # exit code so a missing container isn't a failure.
-ExecStartPre=-/usr/bin/docker rm -f hal0-openwebui
+ExecStartPre=-/usr/bin/podman rm -f hal0-openwebui
 
 # --rm so the container is cleaned up on any exit (normal or crash).
 # The container name is stable so ExecStop can target it by name.
 # Data lives in /var/lib/hal0/openwebui/ which survives container
 # restarts and hal0 updates. The host port :3001 binds 0.0.0.0 by
 # default (PLAN §2 "public" tier).
+# --add-host host.docker.internal:host-gateway: podman (>=4.0) honours the
+# host-gateway magic value, so OPENAI_API_BASE_URLS can reach hal0-api on
+# the host the same way it did under docker.
 # pin per release (#79) — sha256 digest is deterministic; bump the
 # digest on each hal0 release (match install.sh OPENWEBUI_IMAGE).
-ExecStart=/usr/bin/docker run \
+ExecStart=/usr/bin/podman run \
   --rm \
   --name hal0-openwebui \
   --env-file /etc/hal0/openwebui.env \
@@ -47,14 +47,13 @@ ExecStart=/usr/bin/docker run \
   -p 0.0.0.0:3001:8080 \
   --add-host=host.docker.internal:host-gateway \
   --security-opt apparmor=unconfined \
-  ghcr.io/open-webui/open-webui@sha256:d05c6ff8baf5ae701d86a3332c0db4ebb2802ca3d0d341be7fd157fa730306ab
+  ghcr.io/open-webui/open-webui@sha256:7f1b0a1a50cfbac23da3b16f96bc968fd757b26dc9e54e93813d61768ea9184e
 
-# Graceful stop: tell the named container to stop (SIGTERM + 10s timeout
-# is docker's default). systemd will SIGKILL ExecStart if it doesn't
-# exit within TimeoutStopSec.
-ExecStop=/usr/bin/docker stop hal0-openwebui
+# Graceful stop: tell the named container to stop (SIGTERM + 10s timeout).
+# systemd will SIGKILL ExecStart if it doesn't exit within TimeoutStopSec.
+ExecStop=/usr/bin/podman stop hal0-openwebui
 
-# Always restart — even on a clean exit. If a user runs `docker stop`
+# Always restart — even on a clean exit. If a user runs `podman stop`
 # manually we still want the unit back up.
 Restart=always
 RestartSec=5

--- a/src/hal0/hardware/recommend.py
+++ b/src/hal0/hardware/recommend.py
@@ -20,7 +20,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from hal0.config.schema import HardwareInfo, map_backend_to_device
+from hal0.config.schema import (
+    DEVICE_DEFAULT_PROFILES,
+    HardwareInfo,
+    map_backend_to_device,
+)
 from hal0.registry.curated import get_curated
 
 # Curated chat models suitable for the primary slot, ordered from
@@ -164,7 +168,8 @@ def recommend_primary_slot(hw: HardwareInfo) -> dict[str, Any]:
     dict
         Slot config keyed in TOML order::
 
-          name, port, backend, provider, enabled, [model], [meta]
+          name, port, backend, device, runtime, profile, provider,
+          enabled, [model], [meta]
     """
     backend, backend_why = _backend_for(hw)
     # RAM-gate the GPU pick on total/unified host RAM (the same signal the
@@ -189,11 +194,21 @@ def recommend_primary_slot(hw: HardwareInfo) -> dict[str, Any]:
     # v0.1.x can still read the file before re-running the recommender.
     device = map_backend_to_device(backend)
 
+    # Container-runtime era: a slot resolves its image + tuned flags from a
+    # named profile, not from ``backend``. Without this the seeded chat slot
+    # loads with ``profile = None`` and the resolver rejects it with
+    # "profile '' not found in catalog", so the primary slot is born broken
+    # on every fresh install. Map the device to its default profile using
+    # the same table the create-modal + legacy-slot migration use.
+    profile = DEVICE_DEFAULT_PROFILES.get(device)
+
     return {
         "name": "chat",
         "port": 8081,
         "backend": backend,
         "device": device,
+        "runtime": "container",
+        "profile": profile,
         "provider": "llama-server",
         "enabled": False,  # operator runs `hal0 model pull <id>` first
         "model": {

--- a/src/hal0/openwebui/env_writer.py
+++ b/src/hal0/openwebui/env_writer.py
@@ -65,12 +65,12 @@ write_env_atomic = _load_write_env_atomic()
 #
 # OPENAI_API_BASE_URLS:
 #   PLAN.md §8 documents "http://127.0.0.1:8080/v1" but that's the
-#   *host's* loopback — and OpenWebUI runs inside a Docker container,
-#   where 127.0.0.1 is the container itself (serving OpenWebUI on
-#   :8080).  ``host.docker.internal`` is the conventional Docker name
-#   for the host gateway; the unit injects it via
-#   ``--add-host=host.docker.internal:host-gateway`` so this works on
-#   Linux too (Docker only auto-resolves the name on Mac/Windows).
+#   *host's* loopback — and OpenWebUI runs inside a container, where
+#   127.0.0.1 is the container itself (serving OpenWebUI on :8080).
+#   ``host.docker.internal`` is the conventional name for the host
+#   gateway; the unit injects it via
+#   ``--add-host=host.docker.internal:host-gateway``. podman (>=4.0)
+#   honours the host-gateway magic value just like Docker does on Linux.
 _DEFAULT_OPENWEBUI_ENV: dict[str, str] = {
     "DATA_DIR": "/app/backend/data",
     "DEFAULT_LOCALE": "en",

--- a/tests/hardware/test_recommend.py
+++ b/tests/hardware/test_recommend.py
@@ -126,3 +126,36 @@ def test_cpu_host_gets_small_conservative_model() -> None:
     rec = recommend_primary_slot(_cpu_only_host(64))
     assert rec["model"]["default"] != "Qwen3.6-35B-A3B-MTP-GGUF"
     assert rec["backend"] == "cpu"
+
+
+# ── seeded chat slot must resolve a profile (container-runtime era) ──────────
+# Regression: recommend_primary_slot used to emit no ``profile``/``runtime``,
+# so the seeded chat.toml loaded with profile=None and the resolver rejected
+# it ("profile '' not found in catalog") — the primary slot was born broken on
+# every fresh install.
+
+
+def test_seeded_slot_carries_container_runtime_and_profile() -> None:
+    rec = recommend_primary_slot(_amd_uma_host(96))
+    assert rec["runtime"] == "container"
+    # Strix-Halo-class AMD UMA → vulkan device → vulkan profile.
+    assert rec["device"] == "gpu-vulkan"
+    assert rec["profile"] == "vulkan"
+
+
+def test_seeded_slot_profile_is_a_known_seed_profile() -> None:
+    from hal0.config.schema import DEVICE_DEFAULT_PROFILES
+
+    rec = recommend_primary_slot(_amd_uma_host(96))
+    assert rec["profile"], "seeded chat slot must name a profile, not None"
+    assert rec["profile"] in set(DEVICE_DEFAULT_PROFILES.values())
+
+
+def test_seeded_slot_validates_as_slotconfig() -> None:
+    from hal0.config.schema import SlotConfig
+
+    rec = recommend_primary_slot(_amd_uma_host(96))
+    rec.pop("_meta", None)
+    slot = SlotConfig.model_validate(rec)
+    assert slot.profile == "vulkan"
+    assert slot.runtime == "container"


### PR DESCRIPTION
## Problem

A fresh `install.sh` on Ubuntu 24.04 finishes "successfully" but **every inference slot is dead on arrival**. Diagnosed + fixed + validated on a clean Strix-Halo LXC (Ubuntu 24.04, amd64).

```
chat     | error | "profile '' not found in catalog; available: [...]"
npu      | error | no container runtime found; install podman or docker ...
rerank   | error | no container runtime found; install podman or docker ...
utility  | error | no container runtime found; install podman or docker ...
```

## Root causes (all in the installer)

1. **No container runtime is ever installed.** Every slot runs in a container (`providers/container.py:_container_runtime()` resolves `/usr/bin/podman` first), but `install.sh` ran the runtime preflight in **soft mode** — it never set `HAL0_DOCKER_REQUIRED`, so the auto-install/hard-fail branch was **dead code** (the function's comment even claimed "install.sh sets the flag"; it didn't). And that dead branch installed **docker.io**, not podman.
2. **The seeded chat slot has no profile.** `recommend_primary_slot()` emitted the legacy `backend`/`provider` shape with no `profile`/`runtime`, so `chat.toml` loaded with `profile=None` → `"profile '' not found in catalog"`. The primary chat slot was **born broken on every fresh install**, independent of cause #1.
3. **OpenWebUI was pinned to docker** (`/usr/bin/docker run` + `After=docker.service`). With podman as the runtime, a fresh box would restart-loop it (`203/EXEC`).
4. **OpenWebUI's image digest was the arm64 sub-manifest**, not the multi-arch index — so even once it ran, on amd64 it died with `exec /usr/bin/bash: Exec format error`. Latent (OWUI rarely started); the podman move surfaced it.

## Fix (4 commits)

1. `preflight_docker` → `preflight_container_runtime` (podman-preferred, docker accepted, back-compat alias); `install.sh` sets `HAL0_CONTAINER_REQUIRED=1` → auto-install **podman** on apt / hard-fail elsewhere. `HAL0_DOCKER_REQUIRED` still honoured; `hal0 doctor` stays soft.
2. `recommend_primary_slot()` maps device → profile via canonical `DEVICE_DEFAULT_PROFILES` + emits `runtime="container"`. +3 tests.
3. OpenWebUI unit → **podman** (pull/run/rm/stop; dropped `docker.service` deps; kept `--add-host=...:host-gateway`, which podman ≥4.0 honours). `install.sh`/`uninstall.sh` updated to use/guard podman.
4. Re-pin OpenWebUI to the **multi-arch index digest** (`7f1b0a1a…`) instead of the arm64 sub-manifest; added a comment requiring the index digest going forward.

## Validation — full uninstall → reinstall on a clean amd64 Ubuntu 24.04 LXC

- `uninstall.sh --force` then `install.sh` completes cleanly.
- Preflight: podman present (auto-install path separately verified live, apt → podman 4.9.3).
- **All slots seed `offline` with correct profiles and zero errors** (chat=vulkan, utility=vulkan, rerank=vulkan, npu=flm, tts=tts, img=comfyui) — no more "no container runtime" / "profile '' not found".
- `chat.toml` seeded with `runtime="container"`, `profile="vulkan"`.
- **hal0-openwebui active under podman, HTTP 200 on :3001** (amd64, with the index digest).
- `tests/hardware/test_recommend.py`: **15 passed**; `bash -n` + `shellcheck -S error` clean.

## Notes / follow-ups
- Latent inconsistency (not touched): `config/loader.py:load_slot_config` only accepts `[slot]`-nested TOML, but all shipped seed files + the API's `manager._load_slot_config` are flat. Worth reconciling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)