### PR TITLE
fix(dashboard): black screen when an agent approval is queued (enqueued_at.slice crash)

### DIFF
--- a/ui/src/api/hooks/useAgents.ts
+++ b/ui/src/api/hooks/useAgents.ts
@@ -67,7 +67,8 @@ export interface ApprovalEntry {
   tool: string
   args: Record<string, unknown>
   client_id?: string
-  enqueued_at?: string
+  /** Epoch seconds (float) from ApprovalEntry.as_dict() — NOT an ISO string. */
+  enqueued_at?: number
   state?: string
 }
 

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -1,6 +1,21 @@
 // hal0 dashboard — root App, hash routing, tweaks panel, keyboard shortcuts
 const { useState: useStateA, useEffect: useEffectA } = React;
 
+// ApprovalEntry.as_dict() emits ``enqueued_at`` as epoch seconds (a float),
+// not an ISO string — calling .slice() on it threw "enqueued_at.slice is not
+// a function" and black-screened the whole dashboard whenever an approval was
+// queued. Format defensively: epoch float → UTC HH:MM:SS, tolerate an ISO
+// string (mock fixtures) and missing values.
+function fmtApprovalTs(v) {
+  if (v == null) return "—";
+  if (typeof v === "number") {
+    const d = new Date(v * 1000);
+    return Number.isNaN(d.getTime()) ? "—" : d.toISOString().slice(11, 19);
+  }
+  if (typeof v === "string" && v.length >= 19) return v.slice(11, 19);
+  return "—";
+}
+
 const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
   "slotVariant": "instrument",
   "showHero": true,
@@ -91,7 +106,7 @@ function App() {
   // Map ApprovalEntry → shape expected by ApprovalModal
   const approvalItems = (approvalQuery.data?.approvals ?? []).map(e => ({
     id: e.id,
-    ts: e.enqueued_at ? e.enqueued_at.slice(11, 19) : "—",
+    ts: fmtApprovalTs(e.enqueued_at),
     agent: e.client_id || "hermes",
     tool: e.tool,
     arg: e.args ? JSON.stringify(e.args).slice(0, 120) : "—",


### PR DESCRIPTION
## Symptom
The dashboard **flashes on load/refresh then goes black**. Reproduced on production (CT105 / hal0.thinmint.dev).

## Root cause
The approval-list mapper assumed `enqueued_at` is an ISO string:

```js
ts: e.enqueued_at ? e.enqueued_at.slice(11, 19) : "—",
```

But `ApprovalEntry.as_dict()` (`src/hal0/mcp/approval_queue.py`) emits it as **epoch seconds (a float)** — `enqueued_at=time.time()`. So the moment any approval is queued, the render throws:

```
TypeError: enqueued_at.slice is not a function   (inside Array.map → component render)
```

React unmounts the whole tree → black screen.

**Why it hid:** the mock fixture omits `enqueued_at` entirely (so dev/e2e never hit it), and an empty queue skips the `.map` (so idle boxes look fine). It only bites a live box with a pending approval. The TS type (`ApprovalEntry.enqueued_at?: string`) was also wrong; the CLI (`agent_commands._fmt_enqueued_at`) already treats it as a float — the dashboard was the odd one out.

## Fix
- `main.jsx`: format defensively via `fmtApprovalTs()` — epoch float → UTC `HH:MM:SS`, tolerating an ISO string (mock) and missing values.
- `useAgents.ts`: correct the type to `enqueued_at?: number`.

## Verified
On CT105 against the live pending approval (`provider_credential_write`, `enqueued_at: 1781388423.97`): dashboard renders, **0 console errors**, and the approvals modal shows the enqueue time **`22:07:03`** instead of crashing. (Hotfixed the built bundle onto CT105 to confirm; merge keeps it across the next `deploy.sh`.)

## Recommended follow-up
A top-level **React error boundary** would stop any *single* bad field from black-screening the entire app — this class of bug should degrade to a fallback panel, not a blank `#root`. Happy to do it as a fast follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)