### PR TITLE
feat(slots): honor a configurable model store (not hardcoded /mnt/ai-models)

### DIFF
--- a/src/hal0/config/paths.py
+++ b/src/hal0/config/paths.py
@@ -122,6 +122,48 @@ def models_dir() -> Path:
     return var_lib() / "models"
 
 
+#: Conventional external model-store mount and the historic default for slot
+#: container bind-mounts. Most hal0 deployments target an NFS / fast-disk
+#: mount here; overridable per-install via ``[models].store`` or the
+#: ``HAL0_MODEL_STORE`` env var (see :func:`model_store_root`).
+DEFAULT_MODEL_STORE = "/mnt/ai-models"
+
+
+def model_store_root() -> str:
+    """Resolve the model-store directory that slot containers bind-mount.
+
+    Single source of truth shared by the registry/pull engine
+    (``[models].store``) and the provider container mounts, so the path the
+    registry hands to llama-server can never drift from what the container
+    actually mounts. Precedence:
+
+      1. ``HAL0_MODEL_STORE`` env var — explicit operator / CI override,
+      2. ``[models].store`` from hal0.toml — the documented single-source-of
+         -truth field (``ModelsConfig.store``),
+      3. :data:`DEFAULT_MODEL_STORE` (``/mnt/ai-models``) — the conventional
+         mount + historic default.
+
+    The mount default deliberately stays ``/mnt/ai-models`` (NOT
+    ``pull_root`` / ``models_dir()``) so existing deployments that never set
+    ``store`` keep mounting the same path; once ``store`` is set, the pull
+    engine and the slot mounts align on it. Config is read lazily so this is
+    safe to call from low-level provider code without an import cycle, and it
+    degrades to the default if the config can't be read (early bootstrap).
+    """
+    env = os.environ.get("HAL0_MODEL_STORE", "").strip()
+    if env:
+        return env
+    try:
+        from hal0.config.loader import load_hal0_config
+
+        store = (load_hal0_config().models.store or "").strip()
+        if store:
+            return store
+    except Exception:
+        pass
+    return DEFAULT_MODEL_STORE
+
+
 def slot_data_dir(slot_name: str) -> Path:
     """Return the per-slot working directory (/var/lib/hal0/slots/<name>/)."""
     return var_lib() / "slots" / slot_name

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1775,10 +1775,13 @@ class ModelsConfig(BaseModel):
         description=(
             "Single source of truth for where hal0 reads + writes model files. "
             "When set (absolute path, e.g. ``/mnt/ai-models``), the pull engine "
-            "writes here AND slot containers mount the path (observed on the "
-            "next slot restart). "
-            "Empty falls back to ``pull_root`` for PR-#313 compatibility, "
-            "which itself defaults to ``paths.models_dir()``."
+            "writes here AND slot containers bind-mount the path identical-path "
+            "with an SELinux relabel (observed on the next slot restart; see "
+            "``paths.model_store_root``). ``HAL0_MODEL_STORE`` env overrides it. "
+            "Empty falls back to ``pull_root`` for PR-#313 compatibility, which "
+            "itself defaults to ``paths.models_dir()``; note the mount default "
+            "stays ``/mnt/ai-models`` (not ``pull_root``) so existing "
+            "deployments are unaffected until ``store`` is set."
         ),
     )
 

--- a/src/hal0/providers/comfyui.py
+++ b/src/hal0/providers/comfyui.py
@@ -55,14 +55,16 @@ _HAL0_COMFYUI_IMAGE = "docker.io/kyuz0/amd-strix-halo-comfyui:latest"
 # In-container app + working-data layout. The kyuz0 image has ComfyUI
 # checked out at /opt/ComfyUI (venv at /opt/venv). Host-side working data
 # (models / output / input / user / custom_nodes + extra_model_paths.yaml)
-# lives under _COMFYUI_DATA_ROOT and is bind-mounted in so weights and
+# lives under "<model-store>/comfyui" and is bind-mounted in so weights and
 # custom nodes persist across container restarts.
 _COMFYUI_APP_DIR = "/opt/ComfyUI"
 _COMFYUI_BASE_DIR = "/var/lib/hal0/comfyui"
 
-# Host data root for the bind mounts. Overridable for tests / non-standard
-# installs via HAL0_COMFYUI_DATA_ROOT.
-_COMFYUI_DATA_ROOT = "/mnt/ai-models/comfyui"
+# ComfyUI's working data lives under "<model-store>/comfyui" so it tracks the
+# configured model store ([models].store / HAL0_MODEL_STORE, default
+# /mnt/ai-models) — resolved per-render in container_spec(). Still directly
+# overridable via HAL0_COMFYUI_DATA_ROOT for tests / non-standard installs.
+_COMFYUI_DATA_SUBDIR = "comfyui"
 
 # Live-validated flag bundle (matches the "comfyui" seed profile). Used
 # when the slot has no resolvable profile.
@@ -245,7 +247,12 @@ class ComfyUIProvider(Provider):
         ).strip()
         command: list[str] = ["bash", "-lc", payload]
 
-        data_root = os.environ.get("HAL0_COMFYUI_DATA_ROOT", "").strip() or _COMFYUI_DATA_ROOT
+        from hal0.config.paths import model_store_root
+
+        data_root = (
+            os.environ.get("HAL0_COMFYUI_DATA_ROOT", "").strip()
+            or f"{model_store_root()}/{_COMFYUI_DATA_SUBDIR}"
+        )
         # ":ro" suffix on the dst is how ContainerSpec expresses read-only
         # mounts (_render_unit_from_spec emits --volume={src}:{dst} verbatim).
         mounts: list[tuple[str, str]] = [

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -49,6 +49,7 @@ import httpx
 # Aliased to the old private name so existing test patch targets
 # (``hal0.providers.container._resolve_profile``) keep working.
 from hal0.config.loader import resolve_profile as _resolve_profile
+from hal0.config.paths import DEFAULT_MODEL_STORE, model_store_root
 from hal0.config.schema import resolve_profile_flags
 from hal0.providers._gpu import resolve_gpu_device_paths, resolve_gpu_group_ids
 from hal0.providers.base import ContainerSpec, Provider
@@ -61,7 +62,10 @@ log = logging.getLogger(__name__)
 # template.  Writing a complete file means the manager never has to
 # know whether the base exists.
 _SYSTEMD_SYSTEM_DIR = Path("/etc/systemd/system")
-_MODEL_STORE_MOUNT = "/mnt/ai-models"
+# Back-compat alias for the historic default. The *effective* mount root is
+# resolved per-render via model_store_root() ([models].store / HAL0_MODEL_STORE
+# / this default) so a custom model directory actually reaches the container.
+_MODEL_STORE_MOUNT = DEFAULT_MODEL_STORE
 
 
 # Container runtime binary.  Prefer podman (rootless, no daemon);
@@ -181,6 +185,10 @@ def _render_unit(
     runtime = runtime_bin or _container_runtime()
     devices = device_paths if device_paths is not None else resolve_gpu_device_paths()
     container_name = f"hal0-slot-{slot_name}"
+    # Effective model-store root (honours [models].store / HAL0_MODEL_STORE,
+    # default /mnt/ai-models). Mounted identical-path so the absolute GGUF path
+    # the registry hands llama-server resolves unchanged inside the container.
+    model_store = model_store_root()
     # Split the profile flags string into tokens for ExecStart quoting.
     flag_tokens = shlex.split(flags_str) if flags_str.strip() else []
     extra_tokens = shlex.split(extra_args) if extra_args and extra_args.strip() else []
@@ -206,7 +214,10 @@ def _render_unit(
         [
             "--security-opt=apparmor=unconfined",
             "--security-opt=seccomp=unconfined",
-            f"--volume={_MODEL_STORE_MOUNT}:{_MODEL_STORE_MOUNT}:ro",
+            # ``z`` relabels the bind for SELinux-enforcing hosts (Fedora);
+            # it is a shared relabel (multiple slot containers read the store)
+            # and a harmless no-op where SELinux is disabled.
+            f"--volume={model_store}:{model_store}:ro,z",
             # Loopback publish: expose slot port on 127.0.0.1 only.
             f"--publish=127.0.0.1:{port}:{port}",
             # Healthcheck override (#684): the toolbox image bakes a HEALTHCHECK
@@ -392,6 +403,7 @@ class ContainerProvider(Provider):
 
         model_path = _resolve_model_path(model_info)
         port = int(slot_cfg.get("port", 0))
+        model_store = model_store_root()
 
         return ContainerSpec(
             image=profile.image,
@@ -405,7 +417,7 @@ class ContainerProvider(Provider):
                 model_path,
                 *flag_tokens,
             ],
-            mounts=[(_MODEL_STORE_MOUNT, _MODEL_STORE_MOUNT)],
+            mounts=[(model_store, f"{model_store}:ro,z")],
             devices=resolve_gpu_device_paths(),
             group_add=[str(g) for g in resolve_gpu_group_ids()],
             security_opt=["apparmor=unconfined", "seccomp=unconfined"],

--- a/src/hal0/providers/kokoro.py
+++ b/src/hal0/providers/kokoro.py
@@ -38,6 +38,7 @@ from typing import Any
 import httpx
 
 from hal0.config.loader import resolve_profile
+from hal0.config.paths import model_store_root
 from hal0.config.schema import resolve_profile_flags
 from hal0.errors import Hal0Error
 from hal0.providers.base import ContainerSpec, Provider
@@ -48,14 +49,11 @@ _DEFAULT_KOKORO_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1"
 # Default profile name if the slot TOML omits one.
 _DEFAULT_PROFILE = "tts"
 
-# Model store: the same absolute path is used inside the container so that
-# ``--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx`` (baked into the
-# profile flags) resolves correctly without any path translation.
-_MODEL_STORE_HOST = "/mnt/ai-models"
-# ":ro" is appended directly because _render_unit_from_spec renders mounts as
-# --volume={src}:{dst} with no separate read-only option.  This is the only way
-# to express a read-only bind-mount with the current ContainerSpec shape.
-_MODEL_STORE_CONTAINER = "/mnt/ai-models:ro"
+# Model store is mounted identical-path so the profile-baked
+# ``--model_path <store>/local/kokoro-v1/kokoro-onnx`` resolves inside the
+# container without path translation. The root is resolved per-render via
+# model_store_root(); ":ro,z" is encoded into the dst because
+# _render_unit_from_spec renders mounts as --volume={src}:{dst} verbatim.
 
 # Providers whose model weights are pre-staged by the operator (not hal0 registry).
 SELF_MANAGED_PROVIDERS: frozenset[str] = frozenset({"kokoro", "comfyui"})
@@ -159,14 +157,21 @@ class KokoroProvider(Provider):
             str(port),
         ]
 
+        # Effective model-store root ([models].store / HAL0_MODEL_STORE,
+        # default /mnt/ai-models).
+        store_root = model_store_root()
+
         return ContainerSpec(
             image=profile.image,
             command=command,
             env={},
-            # Mount the model store read-only.  ":ro" is appended to the
-            # container path directly — _render_unit_from_spec emits
-            # --volume={src}:{dst} verbatim (no separate ro flag on spec).
-            mounts=[(_MODEL_STORE_HOST, _MODEL_STORE_CONTAINER)],
+            # Mount the model store read-only. ``:ro,z`` is encoded into the
+            # container path (dst) since _render_unit_from_spec emits
+            # --volume={src}:{dst} verbatim; ``z`` relabels for SELinux hosts.
+            # NOTE: Kokoro weights are profile-baked at <store>/local/kokoro-v1
+            # (profiles.toml --model_path). A non-default [models].store moves
+            # the mount but not that flag yet — tracked as a follow-up.
+            mounts=[(store_root, f"{store_root}:ro,z")],
             # CPU-only: no GPU devices or supplementary groups required.
             devices=[],
             cap_add=[],

--- a/tests/config/test_model_store_root.py
+++ b/tests/config/test_model_store_root.py
@@ -1,0 +1,54 @@
+"""model_store_root() — the single source of truth for the model-store mount.
+
+Precedence: HAL0_MODEL_STORE env > [models].store config > /mnt/ai-models.
+This is what makes a custom model directory actually reach slot containers
+(providers mount this, the registry/pull engine resolves the same store).
+"""
+
+from __future__ import annotations
+
+from hal0.config import loader, paths
+
+
+class _Models:
+    def __init__(self, store: str) -> None:
+        self.store = store
+
+
+class _Cfg:
+    def __init__(self, store: str) -> None:
+        self.models = _Models(store)
+
+
+def test_env_var_wins(monkeypatch) -> None:
+    monkeypatch.setenv("HAL0_MODEL_STORE", "/srv/ggufs")
+    # config store is ignored when the env override is present
+    monkeypatch.setattr(loader, "load_hal0_config", lambda: _Cfg("/data/models"))
+    assert paths.model_store_root() == "/srv/ggufs"
+
+
+def test_config_store_used_when_no_env(monkeypatch) -> None:
+    monkeypatch.delenv("HAL0_MODEL_STORE", raising=False)
+    monkeypatch.setattr(loader, "load_hal0_config", lambda: _Cfg("/home/cuken/ai/models"))
+    assert paths.model_store_root() == "/home/cuken/ai/models"
+
+
+def test_default_when_store_empty(monkeypatch) -> None:
+    monkeypatch.delenv("HAL0_MODEL_STORE", raising=False)
+    monkeypatch.setattr(loader, "load_hal0_config", lambda: _Cfg(""))
+    assert paths.model_store_root() == paths.DEFAULT_MODEL_STORE == "/mnt/ai-models"
+
+
+def test_default_when_config_unreadable(monkeypatch) -> None:
+    monkeypatch.delenv("HAL0_MODEL_STORE", raising=False)
+
+    def _boom() -> object:
+        raise RuntimeError("no config on a fresh box")
+
+    monkeypatch.setattr(loader, "load_hal0_config", _boom)
+    assert paths.model_store_root() == "/mnt/ai-models"
+
+
+def test_env_is_stripped(monkeypatch) -> None:
+    monkeypatch.setenv("HAL0_MODEL_STORE", "  /srv/ggufs  ")
+    assert paths.model_store_root() == "/srv/ggufs"

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -144,8 +144,9 @@ class TestRenderUnit:
         # Must follow --name so the pairing is obvious in the rendered unit.
         assert tokens.index("--replace") == tokens.index("--name=hal0-slot-test-slot") + 1
 
-    def test_identical_path_mount_readonly(self) -> None:
-        """Model store must be mounted at /mnt/ai-models:ro (identical path)."""
+    def test_identical_path_mount_readonly(self, monkeypatch) -> None:
+        """Model store mounted identical-path, read-only, with SELinux relabel."""
+        monkeypatch.setenv("HAL0_MODEL_STORE", _MODEL_STORE_MOUNT)  # pin the default
         profile = _moe_profile()
         flags = resolve_profile_flags(profile)
         unit = _render_unit(
@@ -158,10 +159,33 @@ class TestRenderUnit:
         )
         exec_start = self._get_exec_start(unit)
         tokens = shlex.split(exec_start)
-        # --volume arg must be present with :ro suffix
+        # identical-path mount, :ro, plus SELinux relabel (z)
         vol_args = [t for t in tokens if t.startswith(f"--volume={_MODEL_STORE_MOUNT}")]
         assert vol_args, f"no --volume for {_MODEL_STORE_MOUNT} in: {tokens}"
-        assert ":ro" in vol_args[0], f"mount not read-only: {vol_args[0]}"
+        assert vol_args[0] == f"--volume={_MODEL_STORE_MOUNT}:{_MODEL_STORE_MOUNT}:ro,z", (
+            f"unexpected mount: {vol_args[0]}"
+        )
+
+    def test_mount_honours_custom_model_store(self, monkeypatch) -> None:
+        """A custom HAL0_MODEL_STORE is what the slot bind-mounts — so a model
+        dir outside /mnt/ai-models is visible inside the container (the Fedora
+        'No such file or directory' bug)."""
+        custom = "/home/cuken/ai/models"
+        monkeypatch.setenv("HAL0_MODEL_STORE", custom)
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "agent0",
+            profile.image,
+            8095,
+            f"{custom}/Qwen3.6-35B.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        tokens = shlex.split(self._get_exec_start(unit))
+        assert f"--volume={custom}:{custom}:ro,z" in tokens, tokens
+        # the legacy default must NOT be mounted
+        assert not any(t.startswith("--volume=/mnt/ai-models") for t in tokens), tokens
 
     def test_loopback_port_publish(self) -> None:
         """Port must be published on 127.0.0.1 only (not LAN-exposed)."""
@@ -455,7 +479,8 @@ class TestContainerSpec:
         spec = self._build_spec()
         mount_pairs = dict(spec.mounts)
         assert _MODEL_STORE_MOUNT in mount_pairs
-        assert mount_pairs[_MODEL_STORE_MOUNT] == _MODEL_STORE_MOUNT
+        # identical src→dst with :ro,z encoded into the dst (SELinux relabel)
+        assert mount_pairs[_MODEL_STORE_MOUNT] == f"{_MODEL_STORE_MOUNT}:ro,z"
 
     def test_devices_present(self) -> None:
         with patch(

--- a/tests/providers/test_kokoro_container_spec.py
+++ b/tests/providers/test_kokoro_container_spec.py
@@ -50,11 +50,12 @@ def test_spec_security_opts_for_lxc() -> None:
 
 
 def test_spec_ro_mount_dst_has_ro_suffix() -> None:
-    """ContainerSpec mount dst must carry :ro so the rendered --volume arg is read-only."""
+    """ContainerSpec mount dst must carry :ro (+ SELinux z) so the rendered
+    --volume arg is read-only and relabelled on SELinux hosts."""
     spec = KokoroProvider().container_spec(_slot_cfg(), {})
     ai_mount = next(m for m in spec.mounts if m[0] == "/mnt/ai-models")
-    assert ai_mount[1].endswith(":ro"), (
-        f"mount dst {ai_mount[1]!r} must end with ':ro' — "
+    assert ai_mount[1].endswith(":ro,z"), (
+        f"mount dst {ai_mount[1]!r} must end with ':ro,z' — "
         "_render_unit_from_spec emits --volume={src}:{dst} verbatim"
     )
 


### PR DESCRIPTION
## Problem (from a Fedora user)

A friend on Fedora couldn't get a slot to load. The slot container starts, ROCm is detected, then:
```
loading model '/home/cuken/ai/models/Qwen3.6-...-STRIX_LEAN.gguf'
gguf_init_from_file: failed to open GGUF file '...' (No such file or directory)
```
(earlier attempt: `Error: statfs /mnt/ai-models: no such file or directory`, exit 125.)

## Root cause: two layers disagree about where models live

- The **registry/pull engine is configurable** — `model_store.py` scans multiple roots and `[models].store` is documented as the *single source of truth* ("…AND slot containers mount the path"). The pull engine honors it (`pull.py:_pull_root → effective_store()`).
- But **every container provider hardcoded** `/mnt/ai-models`:
  - `providers/container.py` — `--volume=/mnt/ai-models:/mnt/ai-models:ro`
  - `providers/kokoro.py` — `_MODEL_STORE_HOST = "/mnt/ai-models"`
  - `providers/comfyui.py` — `_COMFYUI_DATA_ROOT = "/mnt/ai-models/comfyui"`

So a model registered under a custom dir is known to the registry but **not mounted** into the slot → "No such file or directory" inside the container. It only ever worked because dev/prod boxes mount the real store at `/mnt/ai-models`; the first user off that path hit the wall. (Plus: no `:z` SELinux relabel → the next wall on Fedora.)

## Fix
- **`paths.model_store_root()`** — one resolver, used by providers and aligned with the pull engine. Precedence: `HAL0_MODEL_STORE` env → `[models].store` → `/mnt/ai-models`. The mount **default stays `/mnt/ai-models`** (not `pull_root`) so existing deployments don't change until `store` is set.
- Wired through the bind mounts: **llama-server** (both render paths), **kokoro**, and **ComfyUI** data root.
- **`:z` SELinux relabel** on the read-only model-store mounts → slots work on SELinux-enforcing hosts (Fedora).

Now `HAL0_MODEL_STORE=/home/cuken/ai/models` (or `[models].store`) makes slots mount + load from there.

## Validation
- New `tests/config/test_model_store_root.py`: precedence (env / config / default / config-unreadable / strip).
- `tests/providers/test_container.py`: mount honors a custom store with `:ro,z`; legacy default not mounted.
- Updated the kokoro + container spec mount assertions to `:ro,z`.
- **451 provider+config tests pass**; `ruff check` + `ruff format --check` clean. Live: resolver returns the default from real config and honors the env override (no import cycle).

## Scope notes / follow-ups (flagged in-code)
- Kokoro's weights path is still profile-baked under the default store (`profiles.toml --model_path`); a non-default store moves the mount but not that flag yet.
- ComfyUI's **RW** working dirs don't get `:z` here (separate from the read-only model store) — follow-up for ComfyUI-on-SELinux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)