### PR TITLE
fix(hermes): fail fast on non-root `agent install` instead of EACCES traceback

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -297,6 +297,36 @@ def _http_get(url: str, *, timeout: float = 3.0) -> int:
         return 0
 
 
+def path_is_writable(target: str | Path) -> bool:
+    """Whether we can actually create a file at (or under) ``target``.
+
+    Walks up to ``target``'s nearest existing ancestor — the directory the
+    bootstrap will start creating things in — and attempts a real
+    ``touch``/``unlink`` there. We probe rather than calling
+    :func:`os.access` because ``os.access`` reports stale answers under
+    SELinux, POSIX ACLs and NFS root-squash, and because it can't see that an
+    *existing* root-owned ``$HERMES_HOME`` (created by the root daemon before
+    ``agent install`` runs) is unwritable to a non-root installer — exactly
+    the case that detonated several phases deep on a Fedora install.
+    """
+    anchor = Path(target)
+    while not anchor.exists():
+        parent = anchor.parent
+        if parent == anchor:  # reached the filesystem root with nothing existing
+            return False
+        anchor = parent
+    if not anchor.is_dir():
+        return False
+    probe = anchor / f".hal0-writeprobe-{os.getpid()}"
+    try:
+        probe.touch()
+    except OSError:
+        return False
+    with contextlib.suppress(OSError):  # created but cleanup may fail — still writable
+        probe.unlink()
+    return True
+
+
 def _phase_preflight(ctx: PhaseContext) -> PhaseResult:
     """Hard-fail when the host can't host Hermes.
 
@@ -307,8 +337,9 @@ def _phase_preflight(ctx: PhaseContext) -> PhaseResult:
       we can re-use ``sys.executable`` instead of hunting PATH.
     * ``hal0`` daemon reachable at ``/api/status`` — agents that can't
       reach hal0 are useless. Catch it now instead of during config_write.
-    * ``/var/lib/hal0/`` writable — we'll be writing the venv + HERMES_HOME
-      there in the next phase.
+    * venv tree + ``$HERMES_HOME`` write-probed — we create both in later
+      phases; a real touch/unlink catches a root-owned ``$HERMES_HOME`` (or
+      SELinux/ACL block) that an ``os.access`` check on ``/var/lib/hal0`` misses.
     * ≥ 4 GiB free under ``/var/lib/hal0/`` — Hermes deps + a typical
       memory cache run ~3 GiB; 4 GiB leaves headroom for venv rebuild.
     """
@@ -334,12 +365,30 @@ def _phase_preflight(ctx: PhaseContext) -> PhaseResult:
 
     var_lib = Path(state.venv).parent.parent  # /var/lib/hal0/
     details["var_lib_path"] = str(var_lib)
-    if not var_lib.exists() or not os.access(var_lib, os.W_OK):
-        failures.append(
-            f"{var_lib} not writable — run `sudo install -d -o hal0 -g hal0 -m 0755 {var_lib}`",
+
+    # Write-probe the ACTUAL targets — the venv tree and $HERMES_HOME — not
+    # just os.access() on /var/lib/hal0. A root-owned $HERMES_HOME created by
+    # the (root) daemon before `agent install` sails past a var_lib-only check,
+    # then env_probe detonates with a raw EACCES several phases deep (observed
+    # on Fedora: hermes provisioned as a non-root login user against root-owned
+    # /var/lib/hal0). os.access() also lies under SELinux / ACLs / NFS.
+    blocked = sorted(
+        str(p) for p in (Path(state.venv), Path(state.hermes_home)) if not path_is_writable(p)
+    )
+    details["write_blocked"] = blocked
+    if blocked:
+        hint = (
+            f"run `sudo install -d -o hal0 -g hal0 -m 0755 {var_lib}`"
+            if os.geteuid() == 0
+            else "re-run as root: `sudo hal0 agent install hermes`"
         )
+        failures.append(f"not writable: {', '.join(blocked)} — {hint}")
     else:
-        st = os.statvfs(var_lib)
+        # var_lib's nearest existing ancestor (it exists if the probe passed).
+        anchor = var_lib
+        while not anchor.exists():
+            anchor = anchor.parent
+        st = os.statvfs(anchor)
         free_gib = st.f_bavail * st.f_frsize / (1024**3)
         details["free_gib"] = round(free_gib, 2)
         if free_gib < MIN_FREE_GIB:

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -118,6 +118,11 @@ def _install_hermes(*, switch: bool) -> None:
 
     from hal0.agents.hermes_provision import REPO_ROOT_FOR_INSTALLER, bootstrap_cli
 
+    # Bail out cleanly (before the toolchain shell-out) when we can't write the
+    # provisioning trees — otherwise the bootstrap crashes several phases deep
+    # with a raw PermissionError and leaves half-owned dirs behind.
+    _ensure_hermes_writable_or_die()
+
     prereqs = REPO_ROOT_FOR_INSTALLER / "installer" / "agents" / "hermes-prereqs.sh"
     if prereqs.is_file():
         console.print("[bold]Ensuring toolchain[/bold] (python · venv · pip · pipx)…")
@@ -174,6 +179,41 @@ _HERMES_AGENT_TREES = (
     "/var/lib/hal0/.hermes",
     "/var/lib/hal0/state/agents/hermes",
 )
+
+
+def _ensure_hermes_writable_or_die() -> None:
+    """Abort with a sudo hint when provisioning can't write its trees.
+
+    ``hal0 agent install hermes`` provisions into root-owned ``/var/lib/hal0``
+    and is built to run as root on a system install — it chowns the result to
+    the ``hal0`` agent user afterwards (:func:`_chown_hermes_trees_to_agent_user`).
+    Run as a normal login user it used to crash several phases into the
+    bootstrap with a raw ``PermissionError`` and leave half-owned trees behind
+    (observed on a Fedora install). Catch the privilege mismatch up front, before
+    the toolchain shell-out, so we abort cleanly with no side effects.
+
+    No-op when we're root (root writes anywhere; the post-provision chown hands
+    the trees to ``hal0``) or on a dev / rootless install that already owns the
+    trees (the probe passes).
+    """
+    import os as _os
+
+    from hal0.agents.hermes_provision import path_is_writable
+
+    if _os.geteuid() == 0:
+        return
+    blocked = [t for t in _HERMES_AGENT_TREES if not path_is_writable(t)]
+    if not blocked:
+        return
+    die(
+        "Hermes provisioning needs write access to "
+        + ", ".join(blocked)
+        + f", but you're running as uid={_os.getuid()} and those live under "
+        "root-owned /var/lib/hal0.\n\n"
+        "Re-run as root:\n    sudo hal0 agent install hermes\n\n"
+        f"(Provisioning runs as root, then hands the trees to the "
+        f"'{_AGENT_RUNTIME_USER}' agent user automatically.)"
+    )
 
 
 def _chown_hermes_trees_to_agent_user() -> None:

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -355,7 +355,9 @@ def test_preflight_passes_when_inputs_meet_minimums(
     var_lib = tmp_path / "var" / "lib" / "hal0"
     var_lib.mkdir(parents=True)
     venv = var_lib / "venvs" / "hermes"
-    state = hp.BootstrapState(venv=str(venv))
+    # Pin hermes_home under the tmp tree too — preflight now write-probes the
+    # real $HERMES_HOME, and the default points at the live /var/lib/hal0/.hermes.
+    state = hp.BootstrapState(venv=str(venv), hermes_home=str(var_lib / ".hermes"))
     monkeypatch.setattr(hp, "MIN_FREE_GIB", 0)
     io = hp.PhaseIO(http_get=lambda *_a, **_kw: 200)
     out = hp._phase_preflight(hp.context_for("preflight", state, io=io))
@@ -369,7 +371,9 @@ def test_preflight_fails_on_unreachable_daemon(
 ) -> None:
     var_lib = tmp_path / "var" / "lib" / "hal0"
     var_lib.mkdir(parents=True)
-    state = hp.BootstrapState(venv=str(var_lib / "venvs" / "hermes"))
+    state = hp.BootstrapState(
+        venv=str(var_lib / "venvs" / "hermes"), hermes_home=str(var_lib / ".hermes")
+    )
     io = hp.PhaseIO(http_get=lambda *_a, **_kw: 0)
     out = hp._phase_preflight(hp.context_for("preflight", state, io=io))
     assert out.status == hp.PhaseStatus.FAIL
@@ -381,9 +385,50 @@ def test_preflight_fails_on_var_lib_not_writable(
 ) -> None:
     io = hp.PhaseIO(http_get=lambda *_a, **_kw: 200)
     state = hp.BootstrapState(venv=str(tmp_path / "nope" / "venvs" / "hermes"))
+    # /var/lib (nearest existing ancestor of the default $HERMES_HOME) isn't
+    # writable to a normal user — stub the probe so the test is deterministic
+    # regardless of the runner's uid (CI may run as root).
+    monkeypatch.setattr(hp, "path_is_writable", lambda _p: False)
     out = hp._phase_preflight(hp.context_for("preflight", state, io=io))
     assert out.status == hp.PhaseStatus.FAIL
     assert "not writable" in (out.reason or "")
+
+
+def test_preflight_fails_when_hermes_home_unwritable_but_var_lib_ok(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Fedora bug: /var/lib/hal0 is writable (venv provisions fine) but a
+    pre-existing root-owned $HERMES_HOME isn't — a var_lib-only check sailed
+    past this and detonated at env_probe. Preflight must now catch it."""
+    var_lib = tmp_path / "var" / "lib" / "hal0"
+    var_lib.mkdir(parents=True)
+    venv = var_lib / "venvs" / "hermes"
+    hermes_home = var_lib / ".hermes"
+    hermes_home.mkdir()  # exists, "owned by root" → unwritable to us
+    state = hp.BootstrapState(venv=str(venv), hermes_home=str(hermes_home))
+    monkeypatch.setattr(hp, "MIN_FREE_GIB", 0)
+    io = hp.PhaseIO(http_get=lambda *_a, **_kw: 200)
+
+    real = hp.path_is_writable
+    monkeypatch.setattr(
+        hp,
+        "path_is_writable",
+        lambda p: False if str(p) == str(hermes_home) else real(p),
+    )
+    out = hp._phase_preflight(hp.context_for("preflight", state, io=io))
+    assert out.status == hp.PhaseStatus.FAIL
+    assert "not writable" in (out.reason or "")
+    assert str(hermes_home) in (out.reason or "")
+
+
+def test_path_is_writable_probes_real_filesystem(tmp_path: Path) -> None:
+    """Unit-cover the probe helper: writable dir → True; non-existent target
+    resolves to its nearest existing ancestor."""
+    writable = tmp_path / "writable"
+    writable.mkdir()
+    assert hp.path_is_writable(writable) is True
+    # A target that doesn't exist yet resolves up to tmp_path (writable).
+    assert hp.path_is_writable(writable / "deep" / "nested" / "venv") is True
 
 
 def test_home_init_creates_layout_with_marker(tmp_path: Path) -> None:

--- a/tests/cli/test_agent_install_hermes.py
+++ b/tests/cli/test_agent_install_hermes.py
@@ -50,8 +50,11 @@ def test_install_hermes_runs_prereqs_then_bootstrap_then_register(
     monkeypatch.setattr(ac, "api_post", _fake_api_post)
     monkeypatch.setattr(ac, "_api_unreachable", lambda _url: False)
     # Isolate the core sequence: no systemctl (skip enable/start). chown is
-    # geteuid-guarded so it no-ops under the test runner anyway.
+    # geteuid-guarded so it no-ops under the test runner anyway. The
+    # privilege/writability guard is its own concern (tested below) — neutralise
+    # it here so this test exercises only the toolchain→bootstrap→register order.
     monkeypatch.setattr("shutil.which", lambda _n: None)
+    monkeypatch.setattr(ac, "_ensure_hermes_writable_or_die", lambda: None)
 
     ac._install_hermes(switch=True)
 
@@ -95,6 +98,7 @@ def test_install_hermes_aborts_when_provisioning_fails(monkeypatch) -> None:
     monkeypatch.setattr("hal0.agents.hermes_provision.bootstrap_cli", _fail_bootstrap, raising=True)
     monkeypatch.setattr(ac, "api_post", _fake_api_post)
     monkeypatch.setattr(ac, "_api_unreachable", lambda _url: False)
+    monkeypatch.setattr(ac, "_ensure_hermes_writable_or_die", lambda: None)
 
     with pytest.raises((SystemExit, typer.Exit)):
         ac._install_hermes(switch=False)
@@ -134,3 +138,57 @@ def test_enable_and_start_unit_noops_without_systemd(monkeypatch) -> None:
     monkeypatch.setattr(subprocess, "run", _fake_run)
     ac._enable_and_start_hermes_unit()
     assert called["ran"] is False
+
+
+# ── privilege/writability guard (issue: Fedora non-root `agent install`) ─────
+#
+# `hal0 agent install hermes` provisions into root-owned /var/lib/hal0 and is
+# built to run as root on a system install (it chowns the trees to the `hal0`
+# agent user afterwards). Run as a normal login user it used to crash several
+# phases deep with a raw PermissionError and leave half-owned trees behind.
+# The guard must abort BEFORE the toolchain/bootstrap steps, with a sudo hint.
+
+
+def test_install_hermes_guard_aborts_non_root_when_unwritable(monkeypatch) -> None:
+    import os
+
+    import pytest
+
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.setattr("hal0.agents.hermes_provision.path_is_writable", lambda _p: False)
+
+    ran = {"toolchain": False, "bootstrap": False}
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: ran.__setitem__("toolchain", True))
+    monkeypatch.setattr(
+        "hal0.agents.hermes_provision.bootstrap_cli",
+        lambda **_k: ran.__setitem__("bootstrap", True),
+        raising=True,
+    )
+
+    with pytest.raises(SystemExit):
+        ac._install_hermes(switch=False)
+
+    # The guard fired first: no toolchain shell-out, no bootstrap, no half-state.
+    assert ran == {"toolchain": False, "bootstrap": False}
+
+
+def test_install_hermes_guard_noop_when_root(monkeypatch) -> None:
+    """Root writes anywhere — the guard must not even probe the filesystem."""
+    import os
+
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+
+    def _boom(_p):  # pragma: no cover - must never be called
+        raise AssertionError("path_is_writable probed despite running as root")
+
+    monkeypatch.setattr("hal0.agents.hermes_provision.path_is_writable", _boom)
+    ac._ensure_hermes_writable_or_die()  # returns cleanly, no raise
+
+
+def test_install_hermes_guard_noop_when_writable(monkeypatch) -> None:
+    """Dev / rootless install already owns the trees — proceed silently."""
+    import os
+
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.setattr("hal0.agents.hermes_provision.path_is_writable", lambda _p: True)
+    ac._ensure_hermes_writable_or_die()  # no raise


### PR DESCRIPTION
## Problem

A friend's **Fedora** install hit this running `hal0 agent install hermes` as a normal login user:

```
PermissionError: [Errno 13] Permission denied: '/var/lib/hal0/.hermes/env-20260613T233136.289614Z.json'
  ... in _phase_env_probe → snapshot_path.write_text(...)
```

The bootstrap plowed several phases deep before crashing, leaving half-owned trees behind.

## Root cause

`hal0 agent install hermes` provisions into **root-owned `/var/lib/hal0`** and is built to run as root on a system install (`HAL0_USER` defaults to `root`; `_chown_hermes_trees_to_agent_user()` only acts when `geteuid()==0`, then hands the trees to the `hal0` agent user). Run as a non-root login user against a `$HERMES_HOME` the root daemon had already created, every write phase walks into a directory it can't write.

The preflight gate **should** have caught this but only did `os.access(W_OK)` on `/var/lib/hal0` — never the actual write targets (`$HERMES_HOME`, the venv) — and `os.access` reports stale answers under SELinux / POSIX ACLs / NFS root-squash anyway. A root-owned `$HERMES_HOME` sailed straight past it and detonated at `env_probe`.

## Fix — two layers of the same writability check

- **`path_is_writable()`** (`hermes_provision.py`): a real `touch`/`unlink` probe of a path's nearest existing ancestor. Replaces the `os.access` check in `_phase_preflight`, which now probes **both** the venv tree and `$HERMES_HOME` and emits a uid-aware remediation hint.
- **`_ensure_hermes_writable_or_die()`** (`agent_commands.py`): CLI guard at the top of `_install_hermes` that aborts **before** the toolchain shell-out (no side effects) with `sudo hal0 agent install hermes` when running non-root against unwritable trees. No-op as root, or on a dev/rootless install that already owns the trees.

### Behaviour now (real-FS, non-root, root-owned `.hermes`)
```
preflight status = fail
reason = not writable: /var/lib/hal0/.hermes — re-run as root: `sudo hal0 agent install hermes`
```

## Tests
- `path_is_writable` unit cover (writable dir + nearest-ancestor resolution)
- preflight regression for the **exact** writable-`var_lib` / unwritable-`$HERMES_HOME` case (the Fedora bug)
- CLI guard: aborts-non-root-before-toolchain / noop-as-root / noop-when-writable
- Existing sequence tests neutralise the guard (separate concern)

`96 passed` across the two affected test files. `ruff check` + `ruff format --check` clean; no new mypy errors (baseline already has 16, none in the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)