### PR TITLE
fix(installer): drop sticky bit on /var/lib/hal0 so the hermes agent can refresh STATE.md

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -982,14 +982,19 @@ else
     # Shared STATE.md (#766). The hermes agent runs as hal0 and its
     # render-context (re)writes ${VAR_DIR}/STATE.md — the live snapshot the
     # Claude session-start hook cats — via a tmp+rename that needs *directory*
-    # write on ${VAR_DIR}. Grant the hal0 group write on the top dir ONLY
-    # (setgid so new entries inherit group hal0; sticky so hal0 can only
-    # remove/rename files it owns — root-owned slots/registry/models stay
-    # protected). Ownership stays root; this preserves the ".cache NOT the
-    # whole VAR_DIR" posture above. Pre-create STATE.md hal0-owned so the
-    # rename-over works under the sticky bit even on a re-install.
+    # write on ${VAR_DIR}. Grant the hal0 group write on the top dir
+    # (setgid so new entries inherit group hal0). Ownership stays root, so
+    # root-owned slots/registry/models are untouched; this preserves the
+    # ".cache NOT the whole VAR_DIR" posture above.
+    #
+    # NOT sticky (#766 follow-up): render runs as root during provisioning
+    # (creating a root-owned STATE.md) but as hal0 at runtime — the hal0
+    # rename-over of a root-owned STATE.md needs plain directory write, which
+    # the sticky bit would deny (it'd require owning the existing file). The
+    # group-write grant is what systemd's `ReadWritePaths=/var/lib/hal0`
+    # already assumes, so this just makes the filesystem agree.
     chgrp hal0 "${VAR_DIR}"
-    chmod 3775 "${VAR_DIR}"
+    chmod 2775 "${VAR_DIR}"
     touch "${VAR_DIR}/STATE.md"
     chown hal0:hal0 "${VAR_DIR}/STATE.md"
 


### PR DESCRIPTION
Follow-up to #766, found by a clean install-from-`main` on a fresh Ubuntu container.

## Problem
`render-context` runs **as root** during provisioning (creating a root-owned `/var/lib/hal0/STATE.md`) but **as `hal0`** at runtime. Under the sticky bit (`3775`) `hal0` can only rename-over a file it owns, so the agent's tmp+rename hit `[Errno 1] Operation not permitted` and STATE.md went stale — the exact bug #766 set out to fix, masked earlier by a manual `chown` during validation.

## Fix
Drop the sticky bit: **`3775` → `2775`** (setgid + group-write; ownership stays root). Group-write lets `hal0` rename-over the root-owned STATE.md via plain directory write — which is what the agent unit's `ReadWritePaths=/var/lib/hal0` already assumes. Root-owned subdirs (slots/registry/models) stay root-owned; the agent only ever writes STATE.md there.

## Validation
Fresh CT (clone of the #407 test template, installed from `main`), single `hal0 agent install hermes`:
- agent **active + enabled**, hermes health **200**
- `render-context` `state_written=True`, STATE.md `hal0`-owned and refreshing, no EPERM
- (HERMES.md staying read-only for the agent is by design — #473)

🤖 Generated with [Claude Code](https://claude.com/claude-code)