### PR TITLE
fix(installer): auto-install the python venv stdlib on clean Debian/Ubuntu

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -268,9 +268,12 @@ if ! preflight_python; then
 fi
 
 # `python3 -m venv` capability is a hard requirement — the install always
-# creates a venv. Catches the common Debian "python3 present, python3-venv
-# missing" case before it fails with an opaque ensurepip error.
-preflight_venv || die "python venv module missing — install with: $(python_venv_hint)"
+# creates a venv. HAL0_VENV_REQUIRED=1 flips preflight_venv into
+# install-the-venv-stdlib-or-fail mode (the common clean-Debian/Ubuntu
+# "python3 present, python3-venv missing" case auto-installs via the
+# detected package manager), mirroring preflight_container_runtime above.
+HAL0_VENV_REQUIRED=1 preflight_venv \
+    || die "python venv module missing and could not be installed — $(python_venv_hint), then re-run install.sh"
 
 # Every inference slot runs in a container, so a container runtime is a hard
 # requirement. HAL0_CONTAINER_REQUIRED=1 flips preflight_container_runtime into

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -116,8 +116,51 @@ preflight_venv() {
         info "python venv: available"
         return 0
     fi
-    err "'${py} -m venv' is unavailable (missing ensurepip/venv)"
-    warn "  install the venv stdlib, e.g.: $(python_venv_hint)"
+
+    # Missing venv/ensurepip. Debian/Ubuntu ship the venv stdlib as the
+    # separate python3-venv package (the classic clean-Ubuntu trap), so a
+    # `python3` that's present still can't `-m venv`. Two modes, mirroring
+    # preflight_container_runtime:
+    #
+    #   HAL0_VENV_REQUIRED=1 (set by install.sh) — auto-install the venv
+    #     stdlib via the detected package manager, hard-fail if that doesn't
+    #     resolve it. The install ALWAYS builds a venv, so dying with a hint
+    #     and making the operator hand-install + re-run is pure friction.
+    #
+    #   Unset (default, e.g. `hal0 doctor`) — soft: warn + return 1 so a
+    #     read-only report finishes without mutating the system.
+    if [[ "${HAL0_VENV_REQUIRED:-0}" != "1" ]]; then
+        err "'${py} -m venv' is unavailable (missing ensurepip/venv)"
+        warn "  install the venv stdlib, e.g.: $(python_venv_hint)"
+        return 1
+    fi
+
+    local pm
+    if pm="$(pkg_mgr)"; then
+        info "installing the python venv stdlib (required to build hal0's venv)"
+        local ok=1
+        case "$(distro_family)" in
+            debian)
+                DEBIAN_FRONTEND=noninteractive apt-get update -qq || true
+                DEBIAN_FRONTEND=noninteractive apt-get install -y -q python3-venv python3-pip || ok=0
+                ;;
+            fedora) "${pm}" install -y python3 python3-pip || ok=0 ;;
+            suse) zypper install -y python3 python3-pip || ok=0 ;;
+            arch) pacman -S --noconfirm python python-pip || ok=0 ;;
+            alpine) apk add python3 py3-pip || ok=0 ;;
+            *) ok=0 ;;
+        esac
+        if [[ "${ok}" -eq 1 ]] && "${py}" -c 'import ensurepip, venv' >/dev/null 2>&1; then
+            info "python venv: available"
+            return 0
+        fi
+        err "python venv stdlib install did not resolve '${py} -m venv' — see output above"
+        warn "  install manually: $(python_venv_hint)"
+        return 1
+    fi
+
+    err "'${py} -m venv' is unavailable and no package manager was detected"
+    warn "  install the venv stdlib manually: $(python_venv_hint)"
     return 1
 }
 


### PR DESCRIPTION
## Problem
A truly clean Ubuntu box has `python3` but not `python3-venv` (Debian splits the venv stdlib into a separate package). So `curl install.sh | bash` aborted at `preflight_venv || die` **before hal0 installed at all** — the "Ubuntu python3-venv fail" seen during fresh-container testing of #766/#777.

## Fix
Flip `preflight_venv` into install-or-fail mode under `HAL0_VENV_REQUIRED=1` (set by install.sh), mirroring `preflight_container_runtime`'s podman auto-install: when `python3 -m venv` is unavailable, install the venv stdlib via the detected package manager (apt `python3-venv`+`python3-pip`; other families bundle venv with python3), re-check, and hard-fail with the manual hint only if unresolved. Unset (e.g. `hal0 doctor`) stays **soft/report-only** — no system mutation.

## Validation
Found on a fresh CT clone (clean Ubuntu 24.04) where install.sh died at this preflight and had to be unblocked with a manual `apt install python3-venv`. End-to-end turnkey install re-validated after this change (see follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)