### PR TITLE
fix(installer): make NPU host-lib prereqs best-effort, not fatal

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -816,15 +816,28 @@ else
         warn "  the npu container slot bundles its own XRT runtime and is unaffected"
     fi
 
-    # 2. Runtime libs. apt is naturally idempotent — already-installed
-    #    packages are a no-op. Listed explicitly (not via a metapackage)
-    #    so a future libavformat ABI bump is a visible single-line edit
-    #    rather than a silent metapackage drift.
-    ui_spinner_run "Installing FLM runtime libs (ffmpeg6 + boost1.83 + fftw3)" \
+    # 2. Runtime libs — BEST-EFFORT, same rationale as libxrt-npu2 above:
+    #    the FLM container image bundles these, so a host-side miss only
+    #    disables the HOST `flm validate` probe, not the npu slot itself.
+    #    Listed explicitly (not a metapackage) so a future libavformat ABI
+    #    bump is a visible single-line edit rather than silent drift. apt is
+    #    idempotent, so already-installed packages are a no-op.
+    #
+    #    Must NOT be fatal: a transient apt hiccup (a stale `universe` index
+    #    where these ffmpeg6 libs momentarily resolve to "no installation
+    #    candidate", a mirror flake) used to abort the entire hal0 install
+    #    here — over optional host-side NPU libs the containerized slot
+    #    doesn't even need. Warn + continue, mirroring libxrt-npu2.
+    if ui_spinner_run "Installing FLM runtime libs (ffmpeg6 + boost1.83 + fftw3)" \
         apt-get install -y \
             libavformat60 libavcodec60 libavutil58 libswscale7 libswresample4 \
             libboost-program-options1.83.0 \
-            libfftw3-single3
+            libfftw3-single3; then
+        :
+    else
+        warn "FLM runtime libs not fully available from configured apt sources — host 'flm validate' may fail"
+        warn "  the npu container slot bundles its own runtime and is unaffected"
+    fi
 
     # 3. FLM .deb. Fail-soft: if upstream is unreachable or the SHA-256
     #    doesn't match, warn + skip. NPU paths gate on `flm validate`


### PR DESCRIPTION
## Problem
A fresh install on the Strix Halo **NPU host** aborted at **step 8/11 "NPU prerequisites (FastFlowLM)"**:
```
✗ Installing FLM runtime libs (ffmpeg6 + boost1.83 + fftw3) (exit 100)
E: Package 'libavcodec60' has no installation candidate   (… libavformat60/libavutil58/libswscale7/libswresample4)
✗ install failed at line 818 during: NPU prerequisites (FastFlowLM)
```
The packages exist (Ubuntu 24.04 `universe`, `6.1.1-3ubuntu5`) and install fine on a real `apt-get update` — the failure was a **transient stale-index** "no installation candidate", but it killed the **entire** hal0 install over *optional, host-side* NPU libs.

## Fix
The `libxrt-npu2` install in the **same step** is already best-effort, with the rationale that applies verbatim here: *"the FLM container image bundles its own runtime, so a miss only disables the host `flm validate` probe, not the npu slot itself."* Make the ffmpeg/boost/fftw runtime libs warn-and-continue too (instead of `ui_spinner_run`'s unconsumed non-zero tripping the ERR trap).

- GPU-only installs unaffected — the step only runs on NPU hardware.
- NPU slot itself is containerized and bundles these libs; only the host `flm validate` probe depends on them, and that already fails soft downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)