### PR TITLE
UI CRUD overhaul: non-blocking slot save/swap + model dropdown + save audits

### DIFF
--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -350,6 +350,10 @@ export function usePullJob(): PullSnapshot {
       await apiPost(ENDPOINTS.modelPullCancel(modelId))
       setState('cancelled')
       closeStream()
+      // Cancelling via the POST bypasses the SSE terminal path that
+      // normally refetches the catalog, so invalidate here too — the
+      // registry row may flip back to its pre-pull state.
+      qc.invalidateQueries({ queryKey: ['models'] })
       if (typeof window !== 'undefined') {
         window.dispatchEvent(new CustomEvent('hal0:pull-ended', { detail: { modelId } }))
       }

--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -407,11 +407,19 @@ export function useSlotCreate() {
  * for the single-field backend switch.
  */
 export function useSlotEdit() {
+  const qc = useQueryClient()
   const invalidate = useSlotsInvalidator()
   return useMutation({
     mutationFn: ({ name, body }: { name: string; body: Record<string, unknown> }) =>
       slotPut(ENDPOINTS.slotConfig(name), body),
-    onSuccess: invalidate,
+    // Refetch the slot list AND the per-slot config read. The Settings →
+    // Voice section reflects fields that only live in the slot TOML (e.g.
+    // default_voice) via useSlotConfig(['slot-config', name]); without this
+    // the dropdown stays stale after a save and reverts on reopen.
+    onSuccess: (_data, { name }) => {
+      invalidate()
+      qc.invalidateQueries({ queryKey: ['slot-config', name] })
+    },
   })
 }
 

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -471,14 +471,23 @@ function DownloadRow({ modelId, onRemove }) {
 
   const state = job.state;
   const pct = job.pct ?? 0;
-  const onPause = () => {
-    // The pull engine doesn't support pause — degrade gracefully
-    // by cancelling the in-flight transfer; the row can be re-pulled
-    // from the catalog.
-    job.cancel();
+  const [cancelling, setCancelling] = useStateMM(false);
+  const doCancel = async () => {
+    // The hook re-throws Hal0Error on a failed cancel; surface it as a
+    // toast instead of letting the rejection float as unhandled.
+    setCancelling(true);
+    try {
+      await job.cancel();
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(
+        `Cancel failed — ${e?.message || "see logs"}`, "err",
+      );
+    } finally {
+      setCancelling(false);
+    }
   };
-  const onResume = () => { /* see Pause comment */ };
-  const onCancel = () => { job.cancel(); };
+  const onPause = doCancel;  // engine has no pause; degrade to cancel.
+  const onCancel = doCancel;
   const onRetry = () => { job.start(modelId); };
 
   return (
@@ -524,12 +533,12 @@ function DownloadRow({ modelId, onRemove }) {
       <div style={{display: "flex", gap: 4, marginTop: 6}}>
         {state === "running" && (
           <>
-            <button className="btn ghost sm" onClick={onPause}>Pause</button>
-            <button className="btn ghost sm" onClick={onCancel}>Cancel</button>
+            <button className="btn ghost sm" onClick={onPause} disabled={cancelling}>Pause</button>
+            <button className="btn ghost sm" onClick={onCancel} disabled={cancelling}>{cancelling ? "Cancelling…" : "Cancel"}</button>
           </>
         )}
         {state === "queued" && (
-          <button className="btn ghost sm" onClick={onCancel}>Cancel</button>
+          <button className="btn ghost sm" onClick={onCancel} disabled={cancelling}>{cancelling ? "Cancelling…" : "Cancel"}</button>
         )}
         {state === "failed" && (
           <>

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -287,6 +287,7 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
   const pull = usePullJob();
   const slotsQuery = useSlots();
   const swap = useSlotSwap();
+  const [cancelling, setCancelling] = useStateM(false);
   if (!model) {
     return (
       <div className="mdl-detail">
@@ -317,6 +318,25 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
       window.__hal0Toast && window.__hal0Toast(
         `Pull failed — ${e?.message || "see logs"}`, "err",
       );
+    }
+  };
+
+  // Cancel an in-flight pull started from this pane. The hook hits
+  // POST /api/models/{id}/pull/cancel and invalidates ['models']; we
+  // surface the same error-toast pattern as the other mutations.
+  const onCancelPull = async () => {
+    setCancelling(true);
+    try {
+      await pull.cancel();
+      window.__hal0Toast && window.__hal0Toast(
+        `Cancelled pull · ${model.longName || model.id}`, "info",
+      );
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(
+        `Cancel failed — ${e?.message || "see logs"}`, "err",
+      );
+    } finally {
+      setCancelling(false);
     }
   };
 
@@ -416,6 +436,11 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
             <button className="btn" onClick={onPull} disabled={pull.inFlight}>
               {Icons.download} {pull.inFlight ? `Pulling ${pull.pct ?? 0}%` : `Pull (${model.size || (model.size_bytes ? fmtBytes(model.size_bytes) : "—")})`}
             </button>
+            {pull.inFlight && (
+              <button className="btn ghost sm" onClick={onCancelPull} disabled={cancelling}>
+                {cancelling ? "Cancelling…" : "Cancel"}
+              </button>
+            )}
             <button className="btn ghost sm" onClick={() => window.open(`https://huggingface.co/${model.hf_repo || model.repo || ""}`, "_blank")}>View on HF →</button>
           </>
         )}

--- a/ui/src/dash/profiles.jsx
+++ b/ui/src/dash/profiles.jsx
@@ -293,7 +293,7 @@ function Drawer({ mode, source, existing = [], onClose, onSaved }) {
 
   const set = (k, v) => { setForm(f => ({ ...f, [k]: v })); setTouched(t => ({ ...t, [k]: true })); };
   const touch = (k) => setTouched(t => ({ ...t, [k]: true }));
-  const close = () => { setClosing(true); setTimeout(onClose, 200); };
+  const close = () => { if (submitting) return; setClosing(true); setTimeout(onClose, 200); };
 
   async function submit(e) {
     e.preventDefault();
@@ -354,13 +354,14 @@ function Drawer({ mode, source, existing = [], onClose, onSaved }) {
         onMouseDown={e => e.stopPropagation()}
         role="dialog"
         aria-label={title}
+        aria-busy={submitting}
       >
         <div className="pf-drawer-head">
           <div>
             <div className="pf-drawer-eye mono">{eyebrow}</div>
             <div className="pf-drawer-title pf-form-title mono">{title}</div>
           </div>
-          <button className="pf-x" onClick={close} aria-label="Close">{Icons.close}</button>
+          <button className="pf-x" onClick={close} aria-label="Close" disabled={submitting}>{Icons.close}</button>
         </div>
 
         <form className="pf-drawer-body" onSubmit={submit} noValidate>
@@ -428,7 +429,7 @@ function Drawer({ mode, source, existing = [], onClose, onSaved }) {
           {submitted && blocking && (
             <span className="pf-foot-err mono">{Icons.alert}Fix {Object.keys(errs).length} field{Object.keys(errs).length > 1 ? 's' : ''}</span>
           )}
-          <button className="pf-btn" onClick={close} type="button">Cancel</button>
+          <button className="pf-btn" onClick={close} type="button" disabled={submitting}>Cancel</button>
           <button className={'pf-btn primary' + (submitted && blocking ? ' is-blocked' : '')}
             onClick={submit} disabled={submitting} data-testid="pf-btn-submit">
             {submitting ? 'Saving…' : isEdit ? 'Save changes' : 'Create profile'}
@@ -471,8 +472,8 @@ function DeleteConfirm({ p, onCancel, onConfirmed }) {
   }
 
   return (
-    <div className="pf-scrim center pf-confirm-scrim" onMouseDown={onCancel}>
-      <div className="pf-confirm" onMouseDown={e => e.stopPropagation()} role="dialog" aria-label="Confirm delete">
+    <div className="pf-scrim center pf-confirm-scrim" onMouseDown={() => { if (!busy) onCancel(); }}>
+      <div className="pf-confirm" onMouseDown={e => e.stopPropagation()} role="dialog" aria-label="Confirm delete" aria-busy={busy}>
         <div className="pf-confirm-h pf-confirm-title mono">{Icons.trash} Delete · {p.name}?</div>
         {inUse ? (
           <div className="pf-confirm-b">
@@ -486,7 +487,7 @@ function DeleteConfirm({ p, onCancel, onConfirmed }) {
           </div>
         )}
         <div className="pf-confirm-foot">
-          <button className="pf-btn" onClick={onCancel}>Cancel</button>
+          <button className="pf-btn" onClick={onCancel} disabled={busy}>Cancel</button>
           <button className="pf-btn danger solid" onClick={handleDelete} disabled={!!inUse || busy}
             data-testid="pf-btn-delete-confirm">
             {inUse ? 'In use' : busy ? 'Deleting…' : 'Delete profile'}

--- a/ui/src/dash/settings.jsx
+++ b/ui/src/dash/settings.jsx
@@ -707,7 +707,8 @@ function VoiceSection() {
       await applyCapability.mutateAsync({ slot: "voice", child: "tts", body: { model: ttsModel, enabled: ttsEnabled } });
       // Persist default_voice via slot config if changed
       const origVoice = ttsCfg.default_voice ? String(ttsCfg.default_voice) : "";
-      if (ttsVoice !== origVoice && ttsVoice) {
+      if (ttsVoice !== origVoice) {
+        // ttsVoice === "" intentionally clears default_voice back to the server default
         await editSlot.mutateAsync({ name: "tts", body: { default_voice: ttsVoice } });
       }
       window.__hal0Toast && window.__hal0Toast("TTS settings saved", "ok");

--- a/ui/src/dash/settings.jsx
+++ b/ui/src/dash/settings.jsx
@@ -461,11 +461,19 @@ function SecretsSection() {
             actions={s.set
               ? (<>
                   <button className="btn ghost sm" onClick={() => setAddOpen(true)}>Update</button>
-                  <button className="btn danger sm" onClick={() => {
-                    delSecret.mutate(s.name, {
-                      onSuccess: () => window.__hal0Toast && window.__hal0Toast(`${s.name} removed`, "warn"),
-                    });
-                  }}>Remove</button>
+                  <button
+                    className="btn danger sm"
+                    disabled={delSecret.isPending && delSecret.variables === s.name}
+                    onClick={() => {
+                      delSecret.mutate(s.name, {
+                        onSuccess: () => window.__hal0Toast && window.__hal0Toast(`${s.name} removed`, "warn"),
+                        onError: (err) => window.__hal0Toast && window.__hal0Toast(
+                          `Remove failed — ${err?.message || "see logs"}`,
+                          "err",
+                        ),
+                      });
+                    }}
+                  >{delSecret.isPending && delSecret.variables === s.name ? "Removing…" : "Remove"}</button>
                 </>)
               : <button className="btn ghost sm" onClick={() => setAddOpen(true)}>Add</button>}
           />

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -409,20 +409,21 @@ function EditSlotDrawer({ open, slot, onClose }) {
       return;
     }
     setFieldErrs({});
+    // C7: include profile only when changed; restart after save
+    // (profile swap = cold restart, same semantics as model swap).
+    const profileChanged = !!selectedProfile && selectedProfile !== (slot.profile || "");
     try {
       // Two-step: defaults (ctx_size lives under [model]) + slot config
       // for the top-level keys (default, profile). n_gpu_layers /
       // rope_freq_base / llamacpp_args are owned by the profile — never
-      // include them in a save.
+      // include them in a save. These are fast on-disk writes, so we await
+      // them and keep the drawer open to surface any write error.
       const ctxBody = {
         ctx_size: ctxNum,
       };
       const slotBody = {
         default: makeDefault,
       };
-      // C7: include profile only when changed; restart after save
-      // (profile swap = cold restart, same semantics as model swap).
-      const profileChanged = !!selectedProfile && selectedProfile !== (slot.profile || "");
       if (profileChanged) {
         slotBody.profile = selectedProfile;
       }
@@ -434,22 +435,34 @@ function EditSlotDrawer({ open, slot, onClose }) {
         name: slot.name,
         body: slotBody,
       });
-      if (profileChanged) {
-        await restartMut.mutateAsync(slot.name);
-        window.__hal0Toast && window.__hal0Toast(
-          `Slot "${slot.name}" profile changed — restarting`,
-          "warn",
-        );
-      } else {
-        window.__hal0Toast && window.__hal0Toast(
-          `Slot "${slot.name}" saved — restart required for ctx_size`,
-          "warn",
-        );
-      }
-      onClose();
     } catch (err) {
       setSubmitErr(err?.message || "save failed");
+      return;
     }
+    // Non-blocking apply: a profile change requires a cold restart that can
+    // take model-load seconds-to-minutes. Fire it in the BACKGROUND (do NOT
+    // await) and close the drawer immediately — the slots list polls every 5s
+    // and reflects the transitional → running phase as the restart progresses.
+    // Restart failures surface via toast since the drawer is already gone.
+    if (profileChanged) {
+      restartMut.mutate(slot.name, {
+        onError: (err) =>
+          window.__hal0Toast && window.__hal0Toast(
+            `Slot "${slot.name}" restart failed — ${err?.message || "see logs"}`,
+            "err",
+          ),
+      });
+      window.__hal0Toast && window.__hal0Toast(
+        `Slot "${slot.name}" saved — restarting in the background`,
+        "info",
+      );
+    } else {
+      window.__hal0Toast && window.__hal0Toast(
+        `Slot "${slot.name}" saved — restart required for ctx_size`,
+        "warn",
+      );
+    }
+    onClose();
   }
 
   async function onDeleteClick() {
@@ -464,7 +477,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
     }
   }
 
-  const saving = editMut.isPending || defaultsMut.isPending || restartMut.isPending;
+  // `saving` gates the Save button on the fast config writes only — the
+  // restart is fired in the background (see onSaveClick) and must not keep the
+  // drawer in a blocked "Saving…" state for the whole model-load.
+  const saving = editMut.isPending || defaultsMut.isPending;
   const deleting = deleteMut.isPending;
 
   return (
@@ -604,6 +620,8 @@ function EditSlotDrawer({ open, slot, onClose }) {
           );
         const cur = slot.model_id || slot.model || "";
         const has = compatible.some(m => m.id === cur);
+        // A background swap is in flight — the select stays usable, but show a
+        // "Swapping…" hint so the operator knows the load is happening.
         const swapping = swapMut.isPending;
         return (
           <div className="form-row">
@@ -617,30 +635,26 @@ function EditSlotDrawer({ open, slot, onClose }) {
               <select
                 className="input mono"
                 value={cur}
-                disabled={swapping || saving}
+                disabled={saving}
                 aria-label={`Model for ${slot.name}`}
-                onChange={async (e) => {
+                onChange={(e) => {
                   const id = e.target.value;
                   if (!id || id === cur) return;
                   setSubmitErr(null);
                   const picked = compatible.find(m => m.id === id);
                   const label = picked?.longName || id;
-                  try {
-                    await swapMut.mutateAsync({ name: slot.name, model_id: id });
-                    if (isContainer) {
-                      window.__hal0Toast && window.__hal0Toast(
-                        `Restarting ${slot.name} to load ${label} — ~model-load seconds`,
-                        "info",
-                      );
-                    } else {
-                      window.__hal0Toast && window.__hal0Toast(
-                        `${slot.name} → ${label}`,
-                        "ok",
-                      );
-                    }
-                  } catch (err) {
-                    setSubmitErr(err?.message || "model swap failed");
-                  }
+                  // Non-blocking: a swap cold-restarts container slots to load
+                  // the model (slow). Fire it and let the slots poll reflect the
+                  // transitional phase — never freeze the drawer on the load.
+                  swapMut.mutate({ name: slot.name, model_id: id }, {
+                    onError: (err) => setSubmitErr(err?.message || "model swap failed"),
+                  });
+                  window.__hal0Toast && window.__hal0Toast(
+                    isContainer
+                      ? `Restarting ${slot.name} to load ${label} — loading in the background`
+                      : `${slot.name} → ${label}`,
+                    "info",
+                  );
                 }}
               >
                 {cur && !has && <option value={cur}>{slot.modelLong || slot.model || cur}</option>}

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -12,6 +12,7 @@ import {
   useSlotImagePull,
   useSlotRestart,
   useSlotLoad,
+  useSlotSwap,
 } from '@/api/hooks/useSlots'
 import { useHardware } from '@/api/hooks/useHardware'
 import { useModels } from '@/api/hooks/useModels'
@@ -326,7 +327,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
   const defaultsMut = useSlotDefaults();
   const deleteMut = useSlotDelete();
   const restartMut = useSlotRestart();
+  const swapMut = useSlotSwap();
   const profilesQuery = useProfiles();
+  const modelsQuery = useModels();
 
   // Seed from the slot list payload when available (PR #587 — same fix
   // class as #584). llamacpp_args / n_gpu_layers / rope_freq_base are
@@ -349,6 +352,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
   const [extraArgs, setExtraArgs] = useStateSM(initialExtraArgs);
   const [makeDefault, setMakeDefault] = useStateSM(!!slot?.isDefault);
   const [submitErr, setSubmitErr] = useStateSM(null);
+  // Inline error for the instant-apply thinking toggle (task 3): surface the
+  // failure next to the control instead of only reverting state silently.
+  const [thinkingErr, setThinkingErr] = useStateSM(null);
   // Per-field validation errors for numeric inputs (#548).
   const [fieldErrs, setFieldErrs] = useStateSM({});
   // C7: profile swap for GPU container slots.
@@ -369,6 +375,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
       // on-disk values.
       setExtraArgs(slot.llamacpp_args != null ? slot.llamacpp_args : "");
       setSubmitErr(null);
+      setThinkingErr(null);
       setFieldErrs({});
       // C7: re-seed profile from the (possibly-updated) slot prop.
       setSelectedProfile(slot.profile || "");
@@ -385,6 +392,17 @@ function EditSlotDrawer({ open, slot, onClose }) {
     const errs = {};
     if (!Number.isFinite(ctxNum) || !Number.isInteger(ctxNum) || ctxNum < 128) {
       errs.ctx = "Must be an integer ≥ 128";
+    }
+    // Task 5: GPU-class slots have an editable profile select; mirror the
+    // create-slot modal's guard and block Save when it's been cleared. NPU/CPU
+    // slots render fixed text (no select) so they can never hit this.
+    const allProfiles = profilesQuery.data ?? [];
+    const currentProfileMeta = allProfiles.find(p => p.name === (slot.profile || ""));
+    const slotDeviceIsGpu = !["npu", "cpu"].includes(slot.device || "");
+    const profileDeviceClass = currentProfileMeta?.device_class
+      ?? (slotDeviceIsGpu ? "gpu" : slot.device === "npu" ? "npu" : "cpu");
+    if (profileDeviceClass === "gpu" && !selectedProfile) {
+      errs.profile = "Profile is required";
     }
     if (Object.keys(errs).length > 0) {
       setFieldErrs(errs);
@@ -535,10 +553,13 @@ function EditSlotDrawer({ open, slot, onClose }) {
             <div className="form-ctl">
               {isGpuProfile ? (
                 <select
-                  className="input mono"
+                  className={"input mono" + (fieldErrs.profile ? " input-err" : "")}
                   value={selectedProfile}
-                  onChange={e => setSelectedProfile(e.target.value)}
+                  onChange={e => { setSelectedProfile(e.target.value); setFieldErrs(p => ({...p, profile: undefined})); }}
                 >
+                  {/* Task 5: an empty option lets the field be cleared, which
+                      the Save guard then rejects (mirrors the create modal). */}
+                  {!selectedProfile && <option value="">— select a profile —</option>}
                   {gpuProfiles.map(p => (
                     <option key={p.name} value={p.name}>{p.name}</option>
                   ))}
@@ -546,20 +567,93 @@ function EditSlotDrawer({ open, slot, onClose }) {
               ) : (
                 <input className="input mono" value={slot.profile || "—"} readOnly />
               )}
+              {fieldErrs.profile && (
+                <div className="hint" style={{color: "var(--err)"}}>{fieldErrs.profile}</div>
+              )}
               {profileImageHint && (
                 <div className="hint mono">{profileImageHint}</div>
+              )}
+              {/* Task 2: announce the pending restart before Save fires it. */}
+              {!!selectedProfile && selectedProfile !== (slot.profile || "") && (
+                <div
+                  className="hint"
+                  style={{marginTop: 6, padding: "6px 10px", borderRadius: "var(--rad-sm)", color: "var(--warn)", border: "1px solid var(--warn-line)", background: "var(--warn-soft)"}}
+                >
+                  ⟳ Profile change requires a restart — applied on Save.
+                </div>
               )}
             </div>
           </div>
         );
       })()}
 
-      <div className="form-row">
-        <div className="form-lbl"><span>Model</span><span className="sub">use inline swap from the card for live changes</span></div>
-        <div className="form-ctl">
-          <input className="input mono" value={slot.modelLong || slot.model} readOnly />
-        </div>
-      </div>
+      {/* Task 1: live model swap — mirrors the card's ModelPicker but with the
+          full type+rocmfp4 compatibility filter (same as InlineSwapPopover).
+          Swap is its own POST /slots/{name}/swap (not part of the batched
+          Save); container slots cold-restart to load, so we toast like the
+          popover does. */}
+      {(() => {
+        const isContainer = slot.runtime === "container";
+        const compatible = (modelsQuery.data ?? [])
+          .map(normalizeApiModel)
+          .filter(m =>
+            m.type === slot.type &&
+            // ROCmFP4-quantized models only run on the rocm fork binary — hide
+            // them when the slot isn't on the rocm backend (mirror the popover).
+            !(Array.isArray(m.tags) && m.tags.includes("rocmfp4") && slot.backend !== "rocm")
+          );
+        const cur = slot.model_id || slot.model || "";
+        const has = compatible.some(m => m.id === cur);
+        const swapping = swapMut.isPending;
+        return (
+          <div className="form-row">
+            <div className="form-lbl">
+              <span>Model</span>
+              <span className="sub">
+                {isContainer ? "swap restarts the container to load" : "applies immediately"}
+              </span>
+            </div>
+            <div className="form-ctl">
+              <select
+                className="input mono"
+                value={cur}
+                disabled={swapping || saving}
+                aria-label={`Model for ${slot.name}`}
+                onChange={async (e) => {
+                  const id = e.target.value;
+                  if (!id || id === cur) return;
+                  setSubmitErr(null);
+                  const picked = compatible.find(m => m.id === id);
+                  const label = picked?.longName || id;
+                  try {
+                    await swapMut.mutateAsync({ name: slot.name, model_id: id });
+                    if (isContainer) {
+                      window.__hal0Toast && window.__hal0Toast(
+                        `Restarting ${slot.name} to load ${label} — ~model-load seconds`,
+                        "info",
+                      );
+                    } else {
+                      window.__hal0Toast && window.__hal0Toast(
+                        `${slot.name} → ${label}`,
+                        "ok",
+                      );
+                    }
+                  } catch (err) {
+                    setSubmitErr(err?.message || "model swap failed");
+                  }
+                }}
+              >
+                {cur && !has && <option value={cur}>{slot.modelLong || slot.model || cur}</option>}
+                {!cur && <option value="">—</option>}
+                {compatible.map(m => (
+                  <option key={m.id} value={m.id}>{m.longName || m.id}</option>
+                ))}
+              </select>
+              {swapping && <div className="hint">Swapping…</div>}
+            </div>
+          </div>
+        );
+      })()}
 
       <div className="form-row">
         <div className="form-lbl">
@@ -586,6 +680,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
           <div className="form-lbl">
             <span>Thinking</span>
             <span className="sub">Stream reasoning before the answer. Off = faster, direct replies.</span>
+            {/* Task 3: make the instant-apply contract explicit — unlike the
+                ctx_size/profile fields, this saves on toggle, not on Save. */}
+            <span className="sub">applies immediately (no Save needed)</span>
           </div>
           <div className="form-ctl">
             <label className="checkbox-row">
@@ -597,7 +694,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
                   const next = e.target.checked;
                   setThinking(next);
                   setThinkingPending(true);
-                  setSubmitErr(null);
+                  setThinkingErr(null);
                   try {
                     await editMut.mutateAsync({
                       name: slot.name,
@@ -609,7 +706,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
                     );
                   } catch (err) {
                     setThinking(!next); // revert on failure
-                    setSubmitErr(err?.message || "thinking toggle failed");
+                    // Task 3: surface the failure inline near the toggle, not
+                    // only via the silent revert above.
+                    setThinkingErr(err?.message || "thinking toggle failed");
                   } finally {
                     setThinkingPending(false);
                   }
@@ -617,11 +716,18 @@ function EditSlotDrawer({ open, slot, onClose }) {
               />
               <span>{thinking ? "Reasoning on" : "Reasoning off"}</span>
             </label>
+            {thinkingErr && (
+              <div className="hint" style={{color: "var(--err)"}}>{thinkingErr}</div>
+            )}
           </div>
         </div>
       )}
 
-      <div className="form-section">Advanced</div>
+      {/* Task 4: Advanced fields (mostly read-only, profile-owned) are
+          collapsed by default — minimal native <details> disclosure (no
+          disclosure primitive exists in primitives.jsx). */}
+      <details className="adv-disclosure">
+      <summary className="form-section" style={{cursor: "pointer", listStyle: "revert"}}>Advanced</summary>
 
       <div className="form-row">
         <div className="form-lbl">
@@ -680,6 +786,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
       <div className="hint" style={{paddingTop: 6, fontSize: 10.5, color: "var(--fg-5)", fontFamily: "var(--jbm)"}}>
         Real podman argv from profile image + flags. Read-only.
       </div>
+      </details>
     </Drawer>
   );
 }

--- a/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
@@ -146,6 +146,45 @@ test.describe('C7 — drawer-editable profile + create-modal device derivation',
     expect(restartCalled).toBe(false)
   })
 
+  // C7g — non-blocking save: a profile change kicks off the cold restart in
+  // the BACKGROUND. The drawer must close immediately after the (fast) config
+  // writes land, WITHOUT waiting for the slow POST /restart to resolve. This
+  // is the fix for "save/edit hangs the dash" — restart can take model-load
+  // seconds-to-minutes and must never block the UI.
+  test('C7g — profile-change Save closes the drawer without awaiting restart', async ({ page }) => {
+    let restartStarted = false
+    let releaseRestart: () => void = () => {}
+    const restartGate = new Promise<void>((resolve) => { releaseRestart = resolve })
+
+    await page.route('**/api/slots/chat/config', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+    await page.route('**/api/slots/chat/defaults', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+    // Hold the restart request open for the whole assertion window — it stays
+    // "in flight" so we can prove the drawer does not wait on it.
+    await page.route('**/api/slots/chat/restart', async (route) => {
+      restartStarted = true
+      await restartGate
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+
+    await seedSlots(page, [CHAT_CONTAINER])
+    await page.goto('/#slots/chat')
+    await expect(page.locator('.drawer')).toBeVisible()
+
+    await page.locator('.drawer .form-row', { hasText: 'Profile' }).locator('select').selectOption('vulkan')
+    await page.locator('.drawer button:has-text("Save")').click()
+
+    // The restart must have been kicked off…
+    await expect.poll(() => restartStarted).toBe(true)
+    // …but the drawer must close while it is STILL pending (non-blocking).
+    await expect(page.locator('.drawer')).toBeHidden()
+
+    releaseRestart() // let the held request settle for clean teardown
+  })
+
   // C7d — NPU slot: profile is fixed text (no select)
   test('C7d — NPU slot: profile rendered as fixed text, no select', async ({ page }) => {
     await seedSlots(page, [NPU_SLOT])

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -19,7 +19,7 @@
 import { test, expect, type Page } from '../fixtures/apiMock'
 
 const PRIMARY = {
-  name: 'primary', type: 'llm', device: 'gpu-rocm',
+  name: 'primary', type: 'llm', device: 'gpu-rocm', profile: 'rocm',
   model: 'qwen3.6-27b', model_id: 'qwen3.6-27b', modelLong: 'qwen3.6-27b',
   group: 'chat', state: 'serving', port: 8092, isDefault: true,
   enabled: true, enable_thinking: false, n_gpu_layers: -1,
@@ -91,6 +91,8 @@ test.describe('Slot edit controls (/slots)', () => {
     await seedSlots(page, [PRIMARY, EMBED])
 
     await page.goto('/#slots/primary')
+    // The Advanced section is collapsed by default — open the disclosure.
+    await page.locator('.drawer details.adv-disclosure summary').click()
     const row = page.locator('.drawer .form-row', { hasText: 'n_gpu_layers' })
     await expect(row).toBeVisible()
     await expect(row.locator('.form-lbl .sub')).toContainText('defined by profile')
@@ -109,6 +111,8 @@ test.describe('Slot edit controls (/slots)', () => {
     await seedSlots(page, [PRIMARY, EMBED])
 
     await page.goto('/#slots/primary')
+    // ctx_size lives in the collapsed Advanced section — expand it first.
+    await page.locator('.drawer details.adv-disclosure summary').click()
     const row = page.locator('.drawer .form-row', { hasText: 'ctx_size' })
     await expect(row).toBeVisible()
     await row.locator('input').fill('16384')

--- a/ui/tests/e2e/specs/slots-wireup-v3.spec.ts
+++ b/ui/tests/e2e/specs/slots-wireup-v3.spec.ts
@@ -18,7 +18,7 @@ import { test, expect } from '../fixtures/apiMock'
 
 const BASE_SLOTS = [
   {
-    name: 'primary', type: 'llm', device: 'gpu-rocm',
+    name: 'primary', type: 'llm', device: 'gpu-rocm', profile: 'rocm',
     model: 'qwen3.6-27b-mtp-q4_k_m', model_id: 'qwen3.6-27b-mtp',
     group: 'chat', state: 'serving', port: 8092, isDefault: true,
     metrics: { ctx: 8192, toks: 42, ttft: 180, kv: 35 },
@@ -97,6 +97,8 @@ test.describe('Slots v3 wire-up (/slots)', () => {
     )
 
     await page.goto('/#slots/primary')
+    // ctx_size lives in the now-collapsed Advanced section — expand it first.
+    await page.locator('.drawer details.adv-disclosure summary').click()
     const ctxInput = page.locator('.drawer .form-row', { hasText: 'ctx_size' }).locator('input')
     await expect(ctxInput).toBeVisible()
     await ctxInput.fill('16384')


### PR DESCRIPTION
## Why

The slot **edit drawer's Save/swap felt like it hung the dash** — it awaited the cold restart (which reloads the model, seconds-to-minutes) before the drawer would close. This PR makes saves non-blocking and folds in the rest of the CRUD-surface improvements that were in flight.

## Headline fix — non-blocking save/swap (`slot-modals.jsx`)

- Save now **persists the fast config writes (defaults + config) awaited**, then **fires the restart in the background** (`mutate`, not `mutateAsync`) and **closes the drawer immediately**.
- The slots list polls every 5s and reflects the `transitional → running` phase as the restart progresses; restart failures surface via toast (the drawer is already gone).
- Save button no longer gates on `restartMut.isPending`. The drawer model swap is fire-and-forget the same way, with a `Swapping…` hint.
- New e2e **`C7g`** holds `POST /restart` open and asserts the drawer closes while the restart is still in flight — the regression guard for "save hangs the dash".

> Note: `tsc`/`vite build` do **not** catch undefined-var runtime errors in `.jsx` — the e2e suite is the real correctness gate here (it caught a render crash this PR fixes).

## Also included (per-surface, from the AFK pass)

- **slots** — editable **model dropdown in the edit drawer** (was read-only), profile-change restart banner, collapsible Advanced section, GPU empty-profile validation.
- **models** — wired the **pull-cancel** button (the hook exposed cancel but no UI did) + save-path audit.
- **profiles** — guard form/delete dialogs against mid-flight dismissal.
- **settings** — surface secret-delete failures; refresh TTS voice after save (extra `slot-config` invalidation in `useSlotEdit`).

## Verification

- `npm run typecheck` ✓ (exit 0)
- `npm run build` ✓ (exit 0)
- Full Playwright e2e: **223 passed, 6 skipped, 0 failed** (incl. new `C7g`)

## Follow-up (not in this PR)

- The slot **card's** model swap / restart still block per-card (`runMutation` awaits). Same fire-and-forget treatment could be applied for full consistency — left out to keep the card's deliberate double-click guard intact and scope tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)