### PR TITLE
feat(activity): durable audit store + slots ActivityLog + logs/health fixes

### DIFF
--- a/docs/superpowers/specs/2026-06-14-activity-audit-store-design.md
+++ b/docs/superpowers/specs/2026-06-14-activity-audit-store-design.md
@@ -1,0 +1,342 @@
+# Activity / Audit Store — Design
+
+**Date:** 2026-06-14
+**Branch:** `feat/activity-audit-store`
+**Status:** Approved (AFK execution, autonomy granted)
+
+## Problem
+
+As hal0's configuration surface grows (slots, models, profiles, capabilities,
+backends, providers), there is no durable, trustworthy record of *what changed,
+who changed it, and whether the change actually took effect*. Today:
+
+- The only event surface is `EventBus` — an **in-memory ring of 500 events**
+  (`src/hal0/events/__init__.py:44,90`). It is lost on every restart/deploy,
+  has no before/after state, and records no success/failure outcome.
+- **~25 mutation routes emit nothing at all** (slot delete/edit/swap, every
+  profile CRUD op, capability apply, config writes, approvals deny, updater
+  switchover/rollback, comfyui switchover, backend load/unload, mcp/agent
+  install). Actions happen silently.
+- The footer/journal and `/api/logs` + `/api/health` surfaces are **partially
+  broken** (13 catalogued defects; the health endpoint actively *lies* — a
+  systemd-FAILED slot reports `status: ok`; `/api/health` 404s in production;
+  slot logs are doubled in journald; the footer blanks after restart because
+  the event-id counter resets to 1).
+
+The user wants a **source of truth**: a clean, readable, colorized, filterable
+Activity Log on the slots page that confirms edits *actually took place* — and
+the broken log/health plumbing diagnosed and fixed.
+
+## Goals
+
+1. **Durable audit store** (SQLite) that is the single source of truth for
+   user actions and system state changes — survives restarts, queryable,
+   exportable.
+2. **Confirmation guarantee**: every tracked action records its *outcome*
+   (`ok` / `error`) captured **after** the operation, with before/after state
+   for config edits. If an edit failed, the record says so.
+3. **Comprehensive coverage**: every CRUD/lifecycle action across slots,
+   models, profiles, capabilities, backends, providers, mcp, agents, approvals,
+   updater, comfyui — plus state transitions, model pulls, health/drift
+   transitions, and **denied/failed actions**.
+4. **Readable UI**: a slots-page ActivityLog that is colorized, severity/kind
+   filterable, **bounded** (fixed-height contained scroll, not an infinite
+   spinning firehose), with export. Replaces the now-redundant sidebar widgets.
+5. **Fix the broken plumbing** that is in-scope (health lie, event epoch,
+   stream filters, duplicate logs, UI honest-health), and **file every
+   defect** as a GitHub issue.
+
+## Non-goals
+
+- Not replacing journald / `/api/logs` (raw unit logs stay as-is; we fix bugs).
+- Not a distributed/remote audit sink. Single-node SQLite on `/var/lib/hal0`.
+- Not auth/RBAC on the audit surface (read-only, LAN-open like the rest).
+- Not migrating the footer journal off EventBus this round (it stays live +
+  gets its bugs fixed; durability is delivered via the new Activity surface).
+
+---
+
+## Architecture
+
+Two complementary layers, one durable source of truth:
+
+```
+                       ┌─────────────────────────────────────────┐
+   mutation routes ───▶│  audit_action(...) context manager       │
+   (slots, models,     │  • capture before-state                  │
+    profiles, caps,    │  • run the operation                     │
+    backends, mcp,     │  • on success → record outcome=ok + after│
+    agents, approvals, │  • on exception → record outcome=error   │──┐
+    updater, comfyui)  │    + message, then re-raise              │  │
+                       └─────────────────────────────────────────┘  │
+                                                                     ▼
+   EventBus.emit() ──────────(mirror, durable forward)──────▶ ┌──────────────┐
+   (slot.state, pull.*,                                       │  AuditStore  │
+    system.*)                                                 │  (SQLite,    │
+                                                              │  stdlib)     │
+                                                              │  app.state   │
+                                                              │  .audit      │
+                                                              └──────┬───────┘
+                                                                     │
+   ActivityLog (slots page) ◀── GET /api/activity (filter+SSE+export)┘
+```
+
+- **EventBus stays** as the fast, in-RAM live stream for the footer + SSE. Its
+  `emit()` already documents itself as the hook for "forwarding to journald"
+  (`events/__init__.py:80`). We add a durable forward there: every emitted
+  event is also written to `AuditStore` as a `kind="event"` record. This
+  captures structural state changes (`slot.state`, `pull.*`, `system.*`) for
+  free, durably.
+- **`audit_action`** is the richer path for user-initiated mutations. It writes
+  `kind="action"` records carrying `before`/`after` JSON and a truthful
+  `outcome`. This is the "confirmation it actually took place" mechanism: the
+  outcome is recorded *after* the operation returns or raises.
+- **`AuditStore`** is the single durable sink and the only thing `/api/activity`
+  reads from. ActivityLog → `/api/activity` → durable truth.
+
+### Why this split
+
+`audit_action` gives the confirmation + before/after that EventBus events
+structurally lack, while the EventBus mirror guarantees we never *miss* a state
+change that doesn't flow through an instrumented handler (e.g. a background
+dispatcher preempt, a health transition). Together they are comprehensive.
+De-dup is by design: state transitions arrive as `kind=event`; user actions as
+`kind=action`. The UI can show both, filtered.
+
+---
+
+## Component 1 — `AuditStore` (`src/hal0/activity/__init__.py`)
+
+New single-file package mirroring `events/__init__.py`. Uses **stdlib
+`sqlite3`** (per house pattern `memory/cognee_wrapper.py:352-390`; aiosqlite /
+sqlalchemy are in `uv.lock` but **not installed** — stdlib is the only safe
+choice). Per-call connection, `row_factory=sqlite3.Row`, WAL mode, schema via
+idempotent `CREATE TABLE IF NOT EXISTS`. Writes wrapped in `asyncio.to_thread`
+so the event loop never blocks on disk.
+
+### Schema (`audit` table)
+
+| column        | type    | notes |
+|---------------|---------|-------|
+| `id`          | INTEGER PK AUTOINCREMENT | monotonic, durable cursor |
+| `ts`          | TEXT    | ISO-8601 UTC |
+| `kind`        | TEXT    | `action` \| `event` |
+| `category`    | TEXT    | `slot`\|`model`\|`profile`\|`capability`\|`backend`\|`provider`\|`mcp`\|`agent`\|`approval`\|`updater`\|`comfyui`\|`system` |
+| `action`      | TEXT    | dotted verb, e.g. `slot.delete`, `profile.update`, `capability.apply` |
+| `target`      | TEXT    | the entity acted on, e.g. slot name / model id |
+| `actor`       | TEXT    | `dashboard` \| `cli` \| `mcp:<agent>` \| `system` (from request header / context) |
+| `severity`    | TEXT    | `info` \| `warn` \| `error` \| `ok` (success) |
+| `outcome`     | TEXT    | `ok` \| `error` \| `pending` (events: NULL) |
+| `message`     | TEXT    | human-readable one-liner |
+| `before`      | TEXT    | JSON snapshot (config edits) or NULL |
+| `after`       | TEXT    | JSON snapshot or NULL |
+| `error`       | TEXT    | error message when outcome=error |
+| `duration_ms` | INTEGER | wall time of the action |
+| `request_id`  | TEXT    | correlate with logs / multi-step ops |
+
+Indexes on `ts`, `category`, `action`, `outcome`, `severity` for filterable
+queries. `PRAGMA user_version` gate in `init_schema()` for future migrations
+(we are first; keep it simple).
+
+### Public API
+
+```python
+class AuditStore:
+    def __init__(self, db_path: Path, *, retention_days: int, max_rows: int | None): ...
+    def init_schema(self) -> None: ...                       # idempotent, first-boot
+    async def record(self, *, kind, category, action, target, actor,
+                     severity, outcome, message, before=None, after=None,
+                     error=None, duration_ms=None, request_id=None) -> int: ...
+    async def record_event(self, event: dict) -> int: ...     # EventBus mirror adapter
+    def query(self, *, since=0, category=None, action=None, severity=None,
+              outcome=None, actor=None, kind=None, search=None, limit=200) -> list[Row]: ...
+    def export(self, *, fmt: "csv"|"json", **filters) -> str | bytes: ...
+    async def prune(self) -> int: ...                         # retention enforcement
+```
+
+`audit_action` helper (async context manager) lives here:
+
+```python
+@asynccontextmanager
+async def audit_action(store, *, category, action, target, actor,
+                       before=None, message=None):
+    rec = ActionInProgress(...)   # holds after/outcome to be filled
+    t0 = monotonic()
+    try:
+        yield rec                  # handler runs, may set rec.after
+        await store.record(..., outcome="ok", severity="ok",
+                           after=rec.after, duration_ms=elapsed)
+    except Exception as exc:
+        await store.record(..., outcome="error", severity="error",
+                           error=str(exc), duration_ms=elapsed)
+        raise
+```
+
+### Retention
+
+`ActivityConfig` (pydantic `BaseModel` in `config/schema.py`, registered on
+`Hal0Config`): `enabled: bool = True`, `retention_days: int = 30`,
+`max_rows: int | None = 50_000`. Env override `HAL0_ACTIVITY_RETENTION_DAYS`.
+`prune()` runs on startup and after every N writes (cheap `DELETE WHERE ts <`).
+This keeps the DB bounded without ever losing recent history.
+
+---
+
+## Component 2 — `/api/activity` route (`src/hal0/api/routes/activity.py`)
+
+Mirrors `routes/events.py`. Read-only, no auth dep.
+
+```
+GET /api/activity?since=<id>&category=<c>&action=<glob>&severity=<s>
+                 &outcome=<o>&actor=<a>&kind=<k>&search=<q>&limit=<n=200>
+    → {"records": [...], "next_since": int, "epoch": "<boot-id>"}
+
+GET /api/activity/stream?since=<id>&<same filters>
+    → SSE: durable backfill (id > since) then live tail. Filters honored
+      server-side (fixes the B10 class of bug for this surface from day one).
+
+GET /api/activity/export?fmt=csv|json&<same filters>
+    → file download (Content-Disposition attachment).
+```
+
+Inline `Hal0Error` subclasses: `ActivityUnavailable` (503),
+`ActivityInvalidQuery` (400). Mounted near `__init__.py:1155`.
+
+Includes an `epoch` (process boot-id) in every response so the client can
+detect a restart and reset its cursor — closing the **B8** footer-blanking
+class of bug for this surface.
+
+---
+
+## Component 3 — Instrumentation (the coverage)
+
+`audit_action` (or `store.record`) added to every mutation site. Full list
+(file:line from the backend-map agent):
+
+| Category | Routes instrumented |
+|----------|---------------------|
+| **slot** | create `slots.py:292`, **delete :816**, **edit-config :837**, **defaults :873**, **set-backend :937**, load :1074, unload :1110, restart :1117, **swap :1124**, pull :1410 |
+| **model** | pull/add/update/delete/swap (`models.py` — already emit events; add action records w/ outcome for delete/swap) |
+| **profile** | **create :134, update :160, delete :186** (`profiles.py`) |
+| **capability** | **apply/set :39** (`capabilities.py`) |
+| **backend** | npu load :327 / unload :399 (`backends.py`) |
+| **provider** | credential write `providers.py:207` (**redacted** — never store secret values) |
+| **config** | `PUT /models` `config.py:228`, `settings.py` config_save |
+| **mcp** | install :771, delete :831, config :849, action :884 (`mcp.py`) |
+| **agent** | install :97, delete :298 (`agents.py`) |
+| **approval** | **approve :100, deny :125** (`approvals.py`) — denied actions captured |
+| **updater** | apply :415, rollback :500, channel :533 (`updater.py`) — switchover-class |
+| **comfyui** | switchover :415, pin :510 (`comfyui.py`) |
+| **system** | EventBus mirror: `slot.state`, `pull.*`, `system.*`, health/drift transitions |
+
+**Bold** = currently emits *nothing*. Provider credential writes record the
+*fact* and *actor* only — never the secret (redaction enforced in the helper).
+
+State transitions, model-pull lifecycle, health/drift, and dispatch-preempt
+arrive via the EventBus durable mirror, so they are covered without touching
+every internal call site.
+
+---
+
+## Component 4 — ActivityLog UI (`ui/src/dash/`)
+
+Replace the three sidebar widgets (`SnapshotStrip`, `MemoryMap`,
+`ThroughputCard`) inside `.dash-side` at all four `slots.jsx` render branches
+(`1078-1082`, `1114-1116`, `1144-1146`, `1274-1278`) with a single
+`<ActivityLog/>`. Keep the `.dash-side` wrapper (the 320px grid column) and the
+`.side-card` shell. Drop the now-unused imports.
+
+Clone the footer journal pane (`chrome.jsx:416-545`) for structure, but back it
+with the **durable** `/api/activity` (new `useActivity` hook in
+`ui/src/api/hooks/`, following the `useLogs.ts` SSE + `useQuery` backfill
+convention). Differences from the footer:
+
+- **Severity filter chips** (the footer lacks these): `All · ok · info · warn ·
+  error`, mirroring `.foot-pane-chip`/`.on` toggle pattern. Plus a compact
+  **kind/category** dropdown (slot/model/profile/…).
+- **Colorized lines** using existing CSS vars: `--ok #6fcf97` (success),
+  `--warn #e8b94e` (amber), `--err #ef6b6b` (red), `--accent #feaf00` (brand),
+  neutral for info. Left border + level badge per `.foot-line.{warn,error}`.
+  Each row shows: time · actor · action · target · ✓/✗ outcome glyph · message.
+  A failed edit renders red with ✗ — instant "did it actually take?" read.
+- **Bounded, not a firehose**: fixed `max-height` contained scroll
+  (`overflow-y:auto`), newest-first, default shows the most recent ~200, with a
+  "load older" affordance and a per-`pull.progress`-style throttle so progress
+  spam can't drown lifecycle rows. Pause-on-hover so it doesn't scroll out from
+  under you.
+- **Export button** → `/api/activity/export?fmt=csv` (and JSON) honoring the
+  active filters, so you never have to keep an overflowing pane open to keep
+  history.
+- **Live tail** via `/api/activity/stream`, with the `epoch` reset guard.
+
+Styling in a new `ui/src/dash/activity-log.css` (imported like the other
+per-pane css files), reusing `dashboard.css` severity vars + `.side-card`.
+
+### Tests
+Update specs that assert the removed widgets (`memory-map-v3.spec.ts`,
+`sidebar-runtime-widget.spec.ts`, `footer-journal-pane-v3.spec.ts`) and add
+`activity-log.spec.ts` (filter chips, colorization, bounded scroll, export).
+
+---
+
+## Component 5 — In-scope logs/health fixes
+
+Diagnosed defects (all filed via `/to-issues`; these fixed this round):
+
+- **B1** — `/api/health` 404 in prod. Verify deploy-lag (route exists at
+  `health.py:124` in source); add smoke test asserting 200 JSON.
+- **B2/B4** — health endpoint lies. `health/system` (`health.py:177`) reports
+  `ok` ignoring `s.state`; slot `status()` (`manager.py:1037`) trusts
+  `systemctl is-active` without probing the model server. Fix: count
+  ERROR/failed slots → `degraded`; gate ready-set states on
+  `container_readiness_check`/`ContainerProvider.health`.
+- **B8** — event-id resets to 1 on restart → footer blanks. Add per-process
+  `epoch`/boot-id to `/api/events` + `/api/activity` responses; client resets
+  cursor on epoch change.
+- **B10** — `/api/events/stream` ignores `type`/`severity`. Accept + apply
+  server-side. (`/api/activity/stream` is built correct from the start.)
+- **B12** — UI ignores honest `/api/health/system`. Add `useHealthSystem`;
+  drive the runtime chip color + tooltip from real `degraded`/`checks`.
+- **B13** — slot log drawer drops the named `event: error` SSE frame
+  (`slot-modals.jsx:807`) → spins forever. Rename backend frame to
+  `event: degraded` and `addEventListener` for it.
+- **B3** — slot logs doubled in journald (podman `journald` log-driver *and*
+  unit `StandardOutput=journal`). Pick one path (`--log-driver=none`,
+  conmon→unit owns stdout).
+
+Deferred to follow-up issues (filed, not fixed this round): B5, B6, B7, B9,
+B11, and the LOW/cosmetic items (stale docstrings, journal sort-by-ts, dead
+source chip).
+
+---
+
+## Data flow — a worked example
+
+User edits slot `chat` context_size via the dashboard:
+
+1. `PUT /api/slots/chat/config` handler enters
+   `audit_action(category="slot", action="slot.edit_config", target="chat",
+   actor="dashboard", before=<current toml>)`.
+2. Handler writes the new TOML, reloads.
+3. On success: `AuditStore.record(outcome="ok", severity="ok",
+   after=<new toml>, duration_ms=…)`. On failure: `outcome="error",
+   error="…"`, and the exception propagates to the normal error envelope.
+4. The slot reload triggers `slot.state` transitions → EventBus emits → durable
+   mirror writes `kind="event"` rows.
+5. ActivityLog's SSE tail shows a green `✓ slot.edit_config chat` row, followed
+   by the state-transition rows — the user *sees the edit landed*. If it
+   failed, a red `✗` row with the reason.
+
+---
+
+## Risks / mitigations
+
+- **Write amplification** (every event hits disk): writes are tiny, WAL +
+  `asyncio.to_thread`, and `pull.progress` is the only high-frequency emitter —
+  we down-sample progress rows in the mirror (keep start/end + every Nth).
+- **Schema drift over time**: `PRAGMA user_version` gate from day one.
+- **Another session holds the repo branch**: all work in the
+  `feat/activity-audit-store` worktree off `origin/main`; `wip claim` the files.
+- **Deploy parity**: CT105 deploy via `scripts/deploy.sh` (rebuilds gitignored
+  `ui/dist`), then live-validate `/api/activity`, health fixes, and the UI.
+```

--- a/src/hal0/activity/__init__.py
+++ b/src/hal0/activity/__init__.py
@@ -1,0 +1,372 @@
+"""Durable activity / audit store — hal0's source of truth for change.
+
+The footer :class:`hal0.events.EventBus` is a fast, in-RAM ring that is lost
+on restart and carries no before/after state or success/failure outcome. This
+module is its durable complement: a SQLite table recording every
+config-mutating user action and system state change, with the *outcome*
+captured **after** the operation runs — so the record confirms the change
+actually took effect (or truthfully says it failed).
+
+Design: single-file package mirroring ``events/__init__.py``. Uses the stdlib
+``sqlite3`` (the house pattern, see ``memory/cognee_wrapper.py``) with a
+per-call connection, WAL journaling, and an idempotent ``CREATE TABLE IF NOT
+EXISTS`` schema. Writes are wrapped in ``asyncio.to_thread`` so the event loop
+never blocks on disk.
+
+Two write paths feed one table:
+  * :func:`audit_action` — context manager around a mutation handler. Captures
+    before-state, runs the body, records ``outcome="ok"`` + after-state on
+    success or ``outcome="error"`` + the exception message on failure (then
+    re-raises). This is the confirmation guarantee.
+  * :meth:`AuditStore.record_event` — adapts an EventBus event into a durable
+    ``kind="event"`` row, so structural state changes (``slot.state``,
+    ``pull.*``, ``system.*``) are persisted for free.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import io
+import json
+import sqlite3
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Literal
+
+__all__ = ["AuditStore", "ActionRecorder", "audit_action"]
+
+Kind = Literal["action", "event"]
+Severity = Literal["info", "warn", "error", "ok"]
+Outcome = Literal["ok", "error", "pending"]
+
+# Keys whose values must never be persisted, even inside before/after blobs.
+# Provider credential writes record the *fact* and *actor*, never the secret.
+_SECRET_KEYS = {"api_key", "apikey", "key", "token", "secret", "password", "credential"}
+_REDACTED = "***"
+
+# Categories the type-prefix → category mapping recognises for mirrored events.
+_KNOWN_CATEGORIES = {
+    "slot", "model", "profile", "capability", "backend", "provider", "mcp",
+    "agent", "approval", "updater", "comfyui", "pull", "system",
+}
+
+_COLUMNS = [
+    "id", "ts", "kind", "category", "action", "target", "actor", "severity",
+    "outcome", "message", "before", "after", "error", "duration_ms", "request_id",
+]
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS audit (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts          TEXT NOT NULL,
+    kind        TEXT NOT NULL,
+    category    TEXT NOT NULL,
+    action      TEXT NOT NULL,
+    target      TEXT,
+    actor       TEXT,
+    severity    TEXT NOT NULL,
+    outcome     TEXT,
+    message     TEXT,
+    before      TEXT,
+    after       TEXT,
+    error       TEXT,
+    duration_ms INTEGER,
+    request_id  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_audit_ts        ON audit(ts);
+CREATE INDEX IF NOT EXISTS idx_audit_category  ON audit(category);
+CREATE INDEX IF NOT EXISTS idx_audit_action    ON audit(action);
+CREATE INDEX IF NOT EXISTS idx_audit_severity  ON audit(severity);
+CREATE INDEX IF NOT EXISTS idx_audit_outcome   ON audit(outcome);
+"""
+
+_SCHEMA_VERSION = 1
+
+
+def _now_iso() -> str:
+    """ISO-8601 UTC timestamp with microsecond precision (matches EventBus)."""
+    return datetime.now(UTC).isoformat()
+
+
+def _redact(value: Any) -> Any:
+    """Recursively replace secret-looking values so they never hit disk."""
+    if isinstance(value, dict):
+        return {
+            k: (_REDACTED if k.lower() in _SECRET_KEYS else _redact(v))
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact(v) for v in value]
+    return value
+
+
+def _dump(value: Any) -> str | None:
+    """JSON-encode a before/after blob (after redaction), or None."""
+    if value is None:
+        return None
+    return json.dumps(_redact(value), separators=(",", ":"), default=str)
+
+
+@dataclass
+class ActionRecorder:
+    """Mutable handle yielded by :func:`audit_action`.
+
+    The handler fills ``after`` (and may override ``message``) to enrich the
+    record written when the ``with`` block exits successfully.
+    """
+
+    after: dict[str, Any] | None = None
+    message: str | None = None
+    target: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+class AuditStore:
+    """Durable SQLite-backed audit trail. The single source of truth surfaced
+    by ``/api/activity``."""
+
+    def __init__(
+        self,
+        db_path: Path | str,
+        *,
+        retention_days: int = 30,
+        max_rows: int | None = 50_000,
+    ) -> None:
+        self.db_path = Path(db_path)
+        self.retention_days = retention_days
+        self.max_rows = max_rows
+
+    # ── connection ────────────────────────────────────────────────────────
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(self.db_path, timeout=5.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        return conn
+
+    def init_schema(self) -> None:
+        """Create the table + indexes if absent. Idempotent; first-boot safe."""
+        with self._connect() as conn:
+            conn.executescript(_SCHEMA)
+            conn.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
+            conn.commit()
+
+    # ── write ─────────────────────────────────────────────────────────────
+    def _insert(
+        self,
+        *,
+        kind: Kind,
+        category: str,
+        action: str,
+        target: str | None,
+        actor: str | None,
+        severity: Severity,
+        outcome: Outcome | None,
+        message: str | None,
+        before: Any,
+        after: Any,
+        error: str | None,
+        duration_ms: int | None,
+        request_id: str | None,
+    ) -> int:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                INSERT INTO audit
+                    (ts, kind, category, action, target, actor, severity,
+                     outcome, message, before, after, error, duration_ms, request_id)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    _now_iso(), kind, category, action, target, actor, severity,
+                    outcome, message, _dump(before), _dump(after), error,
+                    duration_ms, request_id,
+                ),
+            )
+            conn.commit()
+            return int(cur.lastrowid or 0)
+
+    async def record(
+        self,
+        *,
+        kind: Kind,
+        category: str,
+        action: str,
+        target: str | None = None,
+        actor: str | None = None,
+        severity: Severity = "info",
+        outcome: Outcome | None = None,
+        message: str | None = None,
+        before: Any = None,
+        after: Any = None,
+        error: str | None = None,
+        duration_ms: int | None = None,
+        request_id: str | None = None,
+    ) -> int:
+        """Persist one audit row and return its monotonic id. Never blocks the
+        event loop (offloaded to a worker thread)."""
+        return await asyncio.to_thread(
+            self._insert,
+            kind=kind, category=category, action=action, target=target,
+            actor=actor, severity=severity, outcome=outcome, message=message,
+            before=before, after=after, error=error, duration_ms=duration_ms,
+            request_id=request_id,
+        )
+
+    async def record_event(self, event: dict[str, Any]) -> int:
+        """Adapt a :class:`hal0.events.EventBus` event into a durable row."""
+        etype = str(event.get("type", "system.event"))
+        data = event.get("data") or {}
+        head = etype.split(".", 1)[0]
+        category = head if head in _KNOWN_CATEGORIES else "system"
+        target = data.get("slot") or data.get("target") or data.get("model") \
+            or _source_target(event.get("source"))
+        return await self.record(
+            kind="event",
+            category=category,
+            action=etype,
+            target=target,
+            actor="system",
+            severity=event.get("severity", "info"),
+            outcome=None,
+            message=event.get("message"),
+            after=data or None,
+        )
+
+    # ── read ──────────────────────────────────────────────────────────────
+    def query(
+        self,
+        *,
+        since: int = 0,
+        category: str | None = None,
+        action: str | None = None,
+        severity: str | None = None,
+        outcome: str | None = None,
+        actor: str | None = None,
+        kind: str | None = None,
+        search: str | None = None,
+        limit: int = 200,
+    ) -> list[sqlite3.Row]:
+        """Return rows newest-first matching the filters. ``action`` accepts a
+        glob (``slot.*``); ``search`` is a free-text LIKE across
+        message/target/action."""
+        clauses: list[str] = ["id > ?"]
+        params: list[Any] = [since]
+        if category:
+            clauses.append("category = ?"); params.append(category)
+        if severity:
+            clauses.append("severity = ?"); params.append(severity)
+        if outcome:
+            clauses.append("outcome = ?"); params.append(outcome)
+        if actor:
+            clauses.append("actor = ?"); params.append(actor)
+        if kind:
+            clauses.append("kind = ?"); params.append(kind)
+        if action:
+            clauses.append("action GLOB ?"); params.append(action)
+        if search:
+            like = f"%{search}%"
+            clauses.append("(message LIKE ? OR target LIKE ? OR action LIKE ?)")
+            params.extend([like, like, like])
+        sql = (
+            f"SELECT {', '.join(_COLUMNS)} FROM audit "
+            f"WHERE {' AND '.join(clauses)} "
+            f"ORDER BY id DESC LIMIT ?"
+        )
+        params.append(max(1, min(limit, 5000)))
+        with self._connect() as conn:
+            return conn.execute(sql, params).fetchall()
+
+    def export(self, *, fmt: Literal["csv", "json"], **filters: Any) -> str:
+        """Render the (filtered) trail as CSV or JSON for download/archival."""
+        filters.setdefault("limit", 5000)
+        rows = self.query(**filters)
+        dicts = [{c: r[c] for c in _COLUMNS} for r in rows]
+        if fmt == "json":
+            return json.dumps(dicts, indent=2, default=str)
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=_COLUMNS, extrasaction="ignore")
+        writer.writeheader()
+        for d in dicts:
+            writer.writerow(d)
+        return buf.getvalue()
+
+    # ── retention ─────────────────────────────────────────────────────────
+    def _prune_sync(self) -> int:
+        cutoff = (datetime.now(UTC) - timedelta(days=self.retention_days)).isoformat()
+        dropped = 0
+        with self._connect() as conn:
+            cur = conn.execute("DELETE FROM audit WHERE ts < ?", (cutoff,))
+            dropped += cur.rowcount or 0
+            if self.max_rows is not None:
+                cur = conn.execute(
+                    "DELETE FROM audit WHERE id NOT IN "
+                    "(SELECT id FROM audit ORDER BY id DESC LIMIT ?)",
+                    (self.max_rows,),
+                )
+                dropped += cur.rowcount or 0
+            conn.commit()
+        return dropped
+
+    async def prune(self) -> int:
+        """Drop rows older than ``retention_days`` and trim to ``max_rows``,
+        keeping the newest. Returns the number deleted."""
+        return await asyncio.to_thread(self._prune_sync)
+
+
+def _source_target(source: Any) -> str | None:
+    """Best-effort target from an event ``source`` like ``slot:chat``."""
+    if isinstance(source, str) and ":" in source:
+        return source.split(":", 1)[1]
+    return source if isinstance(source, str) else None
+
+
+@asynccontextmanager
+async def audit_action(
+    store: AuditStore,
+    *,
+    category: str,
+    action: str,
+    target: str | None,
+    actor: str | None,
+    before: dict[str, Any] | None = None,
+    message: str | None = None,
+    request_id: str | None = None,
+) -> AsyncIterator[ActionRecorder]:
+    """Record a user-initiated mutation with a truthful outcome.
+
+    On clean exit, writes ``outcome="ok"`` (severity ``ok``) with the
+    recorder's ``after`` state and elapsed time. On exception, writes
+    ``outcome="error"`` (severity ``error``) carrying the exception message,
+    then re-raises so the normal error envelope still fires. This is the
+    "confirmation it actually took place" guarantee.
+    """
+    rec = ActionRecorder(target=target)
+    t0 = time.monotonic()
+    try:
+        yield rec
+    except Exception as exc:  # noqa: BLE001 — record then re-raise
+        await store.record(
+            kind="action", category=category, action=action,
+            target=rec.target if rec.target is not None else target,
+            actor=actor, severity="error", outcome="error",
+            message=rec.message or message or f"{action} failed",
+            before=before, after=rec.after, error=str(exc),
+            duration_ms=int((time.monotonic() - t0) * 1000), request_id=request_id,
+        )
+        raise
+    else:
+        await store.record(
+            kind="action", category=category, action=action,
+            target=rec.target if rec.target is not None else target,
+            actor=actor, severity="ok", outcome="ok",
+            message=rec.message or message or action,
+            before=before, after=rec.after, error=None,
+            duration_ms=int((time.monotonic() - t0) * 1000), request_id=request_id,
+        )

--- a/src/hal0/activity/__init__.py
+++ b/src/hal0/activity/__init__.py
@@ -38,7 +38,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal
 
-__all__ = ["AuditStore", "ActionRecorder", "audit_action"]
+__all__ = ["ActionRecorder", "AuditStore", "audit_action"]
 
 Kind = Literal["action", "event"]
 Severity = Literal["info", "warn", "error", "ok"]
@@ -51,13 +51,37 @@ _REDACTED = "***"
 
 # Categories the type-prefix → category mapping recognises for mirrored events.
 _KNOWN_CATEGORIES = {
-    "slot", "model", "profile", "capability", "backend", "provider", "mcp",
-    "agent", "approval", "updater", "comfyui", "pull", "system",
+    "slot",
+    "model",
+    "profile",
+    "capability",
+    "backend",
+    "provider",
+    "mcp",
+    "agent",
+    "approval",
+    "updater",
+    "comfyui",
+    "pull",
+    "system",
 }
 
 _COLUMNS = [
-    "id", "ts", "kind", "category", "action", "target", "actor", "severity",
-    "outcome", "message", "before", "after", "error", "duration_ms", "request_id",
+    "id",
+    "ts",
+    "kind",
+    "category",
+    "action",
+    "target",
+    "actor",
+    "severity",
+    "outcome",
+    "message",
+    "before",
+    "after",
+    "error",
+    "duration_ms",
+    "request_id",
 ]
 
 _SCHEMA = """
@@ -97,8 +121,7 @@ def _redact(value: Any) -> Any:
     """Recursively replace secret-looking values so they never hit disk."""
     if isinstance(value, dict):
         return {
-            k: (_REDACTED if k.lower() in _SECRET_KEYS else _redact(v))
-            for k, v in value.items()
+            k: (_REDACTED if k.lower() in _SECRET_KEYS else _redact(v)) for k, v in value.items()
         }
     if isinstance(value, list):
         return [_redact(v) for v in value]
@@ -184,9 +207,20 @@ class AuditStore:
                 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                 """,
                 (
-                    _now_iso(), kind, category, action, target, actor, severity,
-                    outcome, message, _dump(before), _dump(after), error,
-                    duration_ms, request_id,
+                    _now_iso(),
+                    kind,
+                    category,
+                    action,
+                    target,
+                    actor,
+                    severity,
+                    outcome,
+                    message,
+                    _dump(before),
+                    _dump(after),
+                    error,
+                    duration_ms,
+                    request_id,
                 ),
             )
             conn.commit()
@@ -213,9 +247,18 @@ class AuditStore:
         event loop (offloaded to a worker thread)."""
         return await asyncio.to_thread(
             self._insert,
-            kind=kind, category=category, action=action, target=target,
-            actor=actor, severity=severity, outcome=outcome, message=message,
-            before=before, after=after, error=error, duration_ms=duration_ms,
+            kind=kind,
+            category=category,
+            action=action,
+            target=target,
+            actor=actor,
+            severity=severity,
+            outcome=outcome,
+            message=message,
+            before=before,
+            after=after,
+            error=error,
+            duration_ms=duration_ms,
             request_id=request_id,
         )
 
@@ -225,8 +268,12 @@ class AuditStore:
         data = event.get("data") or {}
         head = etype.split(".", 1)[0]
         category = head if head in _KNOWN_CATEGORIES else "system"
-        target = data.get("slot") or data.get("target") or data.get("model") \
+        target = (
+            data.get("slot")
+            or data.get("target")
+            or data.get("model")
             or _source_target(event.get("source"))
+        )
         return await self.record(
             kind="event",
             category=category,
@@ -258,18 +305,19 @@ class AuditStore:
         message/target/action."""
         clauses: list[str] = ["id > ?"]
         params: list[Any] = [since]
-        if category:
-            clauses.append("category = ?"); params.append(category)
-        if severity:
-            clauses.append("severity = ?"); params.append(severity)
-        if outcome:
-            clauses.append("outcome = ?"); params.append(outcome)
-        if actor:
-            clauses.append("actor = ?"); params.append(actor)
-        if kind:
-            clauses.append("kind = ?"); params.append(kind)
+        for col, val in (
+            ("category", category),
+            ("severity", severity),
+            ("outcome", outcome),
+            ("actor", actor),
+            ("kind", kind),
+        ):
+            if val:
+                clauses.append(f"{col} = ?")
+                params.append(val)
         if action:
-            clauses.append("action GLOB ?"); params.append(action)
+            clauses.append("action GLOB ?")
+            params.append(action)
         if search:
             like = f"%{search}%"
             clauses.append("(message LIKE ? OR target LIKE ? OR action LIKE ?)")
@@ -351,22 +399,36 @@ async def audit_action(
     t0 = time.monotonic()
     try:
         yield rec
-    except Exception as exc:  # noqa: BLE001 — record then re-raise
+    except Exception as exc:
         await store.record(
-            kind="action", category=category, action=action,
+            kind="action",
+            category=category,
+            action=action,
             target=rec.target if rec.target is not None else target,
-            actor=actor, severity="error", outcome="error",
+            actor=actor,
+            severity="error",
+            outcome="error",
             message=rec.message or message or f"{action} failed",
-            before=before, after=rec.after, error=str(exc),
-            duration_ms=int((time.monotonic() - t0) * 1000), request_id=request_id,
+            before=before,
+            after=rec.after,
+            error=str(exc),
+            duration_ms=int((time.monotonic() - t0) * 1000),
+            request_id=request_id,
         )
         raise
     else:
         await store.record(
-            kind="action", category=category, action=action,
+            kind="action",
+            category=category,
+            action=action,
             target=rec.target if rec.target is not None else target,
-            actor=actor, severity="ok", outcome="ok",
+            actor=actor,
+            severity="ok",
+            outcome="ok",
             message=rec.message or message or action,
-            before=before, after=rec.after, error=None,
-            duration_ms=int((time.monotonic() - t0) * 1000), request_id=request_id,
+            before=before,
+            after=rec.after,
+            error=None,
+            duration_ms=int((time.monotonic() - t0) * 1000),
+            request_id=request_id,
         )

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -20,6 +20,7 @@ import structlog
 from fastapi import FastAPI
 
 from hal0 import __version__
+from hal0.activity import AuditStore
 from hal0.api.agents import (
     budget as agents_budget_routes,
 )
@@ -97,7 +98,6 @@ from hal0.api.routes import (
 from hal0.api.routes import (
     secrets as secrets_routes,
 )
-from hal0.activity import AuditStore
 from hal0.capabilities.orchestrator import CapabilityOrchestrator
 from hal0.config.loader import ConfigParseError, load_hal0_config, load_upstreams_config
 from hal0.config.paths import activity_db
@@ -761,8 +761,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     audit_epoch = uuid.uuid4().hex
     if hal0_cfg.activity.enabled:
         retention = int(
-            os.environ.get("HAL0_ACTIVITY_RETENTION_DAYS")
-            or hal0_cfg.activity.retention_days
+            os.environ.get("HAL0_ACTIVITY_RETENTION_DAYS") or hal0_cfg.activity.retention_days
         )
         audit_store = AuditStore(
             activity_db(),

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -10,6 +10,7 @@ import asyncio
 import contextlib
 import os
 import time
+import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from typing import Any
@@ -35,6 +36,9 @@ from hal0.api.agents.chat_proxy import router as chat_proxy_router
 from hal0.api.middleware import error_codes, log_scrub, request_id
 from hal0.api.openrouter import router as openrouter_auth_router
 from hal0.api.plugins import router as plugin_manifest_router
+from hal0.api.routes import (
+    activity as activity_routes,
+)
 from hal0.api.routes import (
     agents as agents_routes,
 )
@@ -93,8 +97,10 @@ from hal0.api.routes import (
 from hal0.api.routes import (
     secrets as secrets_routes,
 )
+from hal0.activity import AuditStore
 from hal0.capabilities.orchestrator import CapabilityOrchestrator
 from hal0.config.loader import ConfigParseError, load_hal0_config, load_upstreams_config
+from hal0.config.paths import activity_db
 from hal0.dispatcher.router import Dispatcher
 from hal0.events import EventBus
 from hal0.hardware.probe import HardwareProbe
@@ -745,11 +751,41 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         model_cache[u.name] = merged
         return merged
 
+    # Durable audit/activity store — the source of truth surfaced by
+    # /api/activity. Constructed before the event bus so the bus can forward
+    # every emitted event into it (the durable mirror). High-frequency
+    # pull.progress is filtered out of the mirror so it can't evict
+    # lifecycle history; the explicit audit_action() path carries the richer
+    # user-action records with before/after + outcome.
+    audit_store: AuditStore | None = None
+    audit_epoch = uuid.uuid4().hex
+    if hal0_cfg.activity.enabled:
+        retention = int(
+            os.environ.get("HAL0_ACTIVITY_RETENTION_DAYS")
+            or hal0_cfg.activity.retention_days
+        )
+        audit_store = AuditStore(
+            activity_db(),
+            retention_days=retention,
+            max_rows=hal0_cfg.activity.max_rows,
+        )
+        try:
+            audit_store.init_schema()
+            await audit_store.prune()
+        except Exception as exc:  # init must never block startup
+            log.warning("activity.init_failed", error=str(exc))
+            audit_store = None
+
+    async def _audit_sink(event: dict[str, Any]) -> None:
+        if audit_store is None or event.get("type") == "pull.progress":
+            return
+        await audit_store.record_event(event)
+
     # SlotManager owns slot state.  Built before Dispatcher so it can be
     # threaded in and forward() can flip slots into SERVING per request.
     # Construct the event bus first so the SlotManager can side-channel
     # every transition through it — the footer subscribes to /api/events.
-    event_bus = EventBus()
+    event_bus = EventBus(sink=_audit_sink if audit_store is not None else None)
     slot_manager = SlotManager(event_bus=event_bus, upstreams_registry=upstreams)
 
     dispatcher = Dispatcher(
@@ -828,6 +864,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # be wired with the same instance); published on app.state here so
     # request handlers can reach it via ``request.app.state.events``.
     app.state.events = event_bus
+    # Durable audit/activity store + a per-process epoch so the ActivityLog
+    # can detect a restart and reset its cursor (events ids restart at 1).
+    app.state.audit = audit_store
+    app.state.audit_epoch = audit_epoch
     await event_bus.emit(
         "system.restart",
         "info",
@@ -1153,6 +1193,11 @@ def create_app() -> FastAPI:
     # reason as /api/status: the footer renders during first-run before
     # any credential exists. No mutating endpoints live on this router.
     app.include_router(events_routes.router, prefix="/api/events", tags=["events"])
+
+    # Durable activity / audit surface — the source of truth for config
+    # changes + state transitions, backing the slots-page ActivityLog.
+    # Read-only + public for the same first-run reason as /api/events.
+    app.include_router(activity_routes.router, prefix="/api/activity", tags=["activity"])
 
     # Unified journal panel (issue #323, epic #322 Phase 1). Serves
     # /api/events in the journal envelope for the dashboard's journal

--- a/src/hal0/api/_audit.py
+++ b/src/hal0/api/_audit.py
@@ -1,0 +1,74 @@
+"""Request-scoped helper for recording user actions to the audit store.
+
+Thin wrapper over :func:`hal0.activity.audit_action` that pulls the actor from
+the request and no-ops gracefully when the activity store is disabled. Use it
+in any mutation handler::
+
+    @router.delete("/{name}")
+    async def delete_slot(name: str, request: Request):
+        async with record_action(request, category="slot",
+                                 action="slot.delete", target=name):
+            manager.delete(name)        # raises → recorded as outcome=error
+        return {"ok": True}             # returns → recorded as outcome=ok
+
+For edits, pass ``before=`` and set ``rec.after`` inside the block to capture
+the config diff that proves the change landed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+from fastapi import Request
+
+from hal0.activity import ActionRecorder, audit_action
+
+# Header the MCP admin surface sets to identify the calling agent
+# (see hal0_memory_mcp_connected memory). Absent → a dashboard/local caller.
+_AGENT_HEADER = "X-hal0-Agent"
+
+
+def actor_of(request: Request) -> str:
+    """Derive the audit actor string from the request.
+
+    ``mcp:<agent>`` when an agent header is present, else ``dashboard`` (the
+    web UI and local curl callers). The CLI records its own actor directly
+    when it writes config out-of-band.
+    """
+    agent = request.headers.get(_AGENT_HEADER)
+    if agent:
+        return f"mcp:{agent}"
+    return "dashboard"
+
+
+@asynccontextmanager
+async def record_action(
+    request: Request,
+    *,
+    category: str,
+    action: str,
+    target: str | None,
+    before: dict[str, Any] | None = None,
+    message: str | None = None,
+) -> AsyncIterator[ActionRecorder]:
+    """Record a mutation with a truthful outcome, or no-op if audit is off."""
+    store = getattr(request.app.state, "audit", None)
+    if store is None:
+        # Activity disabled (or odd entrypoint) — hand back a throwaway
+        # recorder so handler code is identical either way.
+        yield ActionRecorder(target=target)
+        return
+    request_id = request.headers.get("X-Request-ID")
+    async with audit_action(
+        store,
+        category=category,
+        action=action,
+        target=target,
+        actor=actor_of(request),
+        before=before,
+        message=message,
+        request_id=request_id,
+    ) as rec:
+        yield rec

--- a/src/hal0/api/routes/activity.py
+++ b/src/hal0/api/routes/activity.py
@@ -1,0 +1,200 @@
+"""Durable activity / audit surface — mounted under ``/api/activity``.
+
+Reads the SQLite :class:`hal0.activity.AuditStore` (``app.state.audit``), the
+source of truth for config-mutating actions and system state changes. Unlike
+``/api/events`` (volatile ring), this surface survives restarts and carries
+before/after state + a success/failure outcome per action.
+
+Read-only; no auth dependency — the slots-page ActivityLog must render during
+first-run before any credential exists (same rationale as ``/api/events``).
+
+Endpoints::
+
+    GET /api/activity?since=&category=&action=&severity=&outcome=&actor=
+                     &kind=&search=&limit=
+        → {"records": [...], "next_since": int, "epoch": str}
+
+    GET /api/activity/stream?since=&<same filters>
+        → SSE: durable backfill then live tail (filters honored server-side).
+
+    GET /api/activity/export?fmt=csv|json&<same filters>
+        → file download (Content-Disposition: attachment).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import Any
+
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import Response, StreamingResponse
+
+from hal0.api.middleware.error_codes import Hal0Error
+
+router = APIRouter()
+
+_LIMIT_MAX = 1000
+_KEEPALIVE_S = 15.0
+
+_VALID_SEVERITY = {"info", "warn", "error", "ok"}
+_VALID_KIND = {"action", "event"}
+_VALID_OUTCOME = {"ok", "error", "pending"}
+_JSON_COLS = ("before", "after")
+
+
+class ActivityUnavailable(Hal0Error):
+    """The audit store was not initialised on app.state (odd entrypoint)."""
+
+    code = "activity.unavailable"
+    status = 503
+
+
+class ActivityInvalidQuery(Hal0Error):
+    """Caller supplied an unsupported filter value (e.g. unknown severity)."""
+
+    code = "activity.invalid_query"
+    status = 400
+
+
+def _store(request: Request):
+    store = getattr(request.app.state, "audit", None)
+    if store is None:
+        raise ActivityUnavailable("activity store unavailable")
+    return store
+
+
+def _epoch(request: Request) -> str:
+    return getattr(request.app.state, "audit_epoch", "")
+
+
+def _validate(severity: str | None, kind: str | None, outcome: str | None) -> None:
+    if severity and severity not in _VALID_SEVERITY:
+        raise ActivityInvalidQuery(f"unknown severity {severity!r}")
+    if kind and kind not in _VALID_KIND:
+        raise ActivityInvalidQuery(f"unknown kind {kind!r}")
+    if outcome and outcome not in _VALID_OUTCOME:
+        raise ActivityInvalidQuery(f"unknown outcome {outcome!r}")
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+    d = {k: row[k] for k in row.keys()}
+    # Parse the JSON blobs back into objects so the UI doesn't double-decode.
+    for col in _JSON_COLS:
+        if d.get(col):
+            with contextlib.suppress(json.JSONDecodeError, TypeError):
+                d[col] = json.loads(d[col])
+    return d
+
+
+@router.get("")
+@router.get("/")
+async def list_activity(
+    request: Request,
+    since: int = Query(0, ge=0),
+    category: str | None = None,
+    action: str | None = None,
+    severity: str | None = None,
+    outcome: str | None = None,
+    actor: str | None = None,
+    kind: str | None = None,
+    search: str | None = None,
+    limit: int = Query(200, ge=1, le=_LIMIT_MAX),
+) -> dict[str, Any]:
+    _validate(severity, kind, outcome)
+    store = _store(request)
+    rows = store.query(
+        since=since, category=category, action=action, severity=severity,
+        outcome=outcome, actor=actor, kind=kind, search=search, limit=limit,
+    )
+    records = [_row_to_dict(r) for r in rows]
+    # Rows come back newest-first; the highest id is the cursor to poll next.
+    next_since = records[0]["id"] if records else since
+    return {"records": records, "next_since": next_since, "epoch": _epoch(request)}
+
+
+@router.get("/export")
+async def export_activity(
+    request: Request,
+    fmt: str = Query("json"),
+    category: str | None = None,
+    action: str | None = None,
+    severity: str | None = None,
+    outcome: str | None = None,
+    actor: str | None = None,
+    kind: str | None = None,
+    search: str | None = None,
+) -> Response:
+    if fmt not in ("csv", "json"):
+        raise ActivityInvalidQuery(f"unsupported export fmt {fmt!r}")
+    _validate(severity, kind, outcome)
+    store = _store(request)
+    blob = store.export(
+        fmt=fmt, category=category, action=action, severity=severity,
+        outcome=outcome, actor=actor, kind=kind, search=search,
+    )
+    media = "text/csv" if fmt == "csv" else "application/json"
+    return Response(
+        content=blob,
+        media_type=media,
+        headers={"Content-Disposition": f'attachment; filename="hal0-activity.{fmt}"'},
+    )
+
+
+@router.get("/stream")
+async def stream_activity(
+    request: Request,
+    since: int = Query(0, ge=0),
+    category: str | None = None,
+    action: str | None = None,
+    severity: str | None = None,
+    outcome: str | None = None,
+    actor: str | None = None,
+    kind: str | None = None,
+    search: str | None = None,
+) -> StreamingResponse:
+    _validate(severity, kind, outcome)
+    store = _store(request)
+    bus = getattr(request.app.state, "events", None)
+    epoch = _epoch(request)
+
+    filters = dict(category=category, action=action, severity=severity,
+                   outcome=outcome, actor=actor, kind=kind, search=search)
+
+    def _matches(rec: dict[str, Any]) -> bool:
+        if category and rec.get("category") != category:
+            return False
+        if severity and rec.get("severity") != severity:
+            return False
+        if outcome and rec.get("outcome") != outcome:
+            return False
+        if actor and rec.get("actor") != actor:
+            return False
+        if kind and rec.get("kind") != kind:
+            return False
+        return True
+
+    async def gen():
+        # Durable backfill first (id > since), oldest→newest for replay.
+        backfill = list(reversed([_row_to_dict(r) for r in store.query(since=since, limit=_LIMIT_MAX, **filters)]))
+        cursor = since
+        for rec in backfill:
+            cursor = max(cursor, rec["id"])
+            yield f"data: {json.dumps({'record': rec, 'epoch': epoch})}\n\n"
+        # Live tail: poll the store (the audit sink writes async, so we
+        # re-query rather than subscribe to the bus — keeps one source of
+        # truth and applies the same filters).
+        while True:
+            if await request.is_disconnected():
+                break
+            new = list(reversed([_row_to_dict(r) for r in store.query(since=cursor, limit=_LIMIT_MAX, **filters)]))
+            if new:
+                for rec in new:
+                    cursor = max(cursor, rec["id"])
+                    yield f"data: {json.dumps({'record': rec, 'epoch': epoch})}\n\n"
+            else:
+                yield ": keep-alive\n\n"
+            await asyncio.sleep(_KEEPALIVE_S if not new else 1.0)
+
+    return StreamingResponse(gen(), media_type="text/event-stream")

--- a/src/hal0/api/routes/activity.py
+++ b/src/hal0/api/routes/activity.py
@@ -79,7 +79,7 @@ def _validate(severity: str | None, kind: str | None, outcome: str | None) -> No
 
 
 def _row_to_dict(row: Any) -> dict[str, Any]:
-    d = {k: row[k] for k in row.keys()}
+    d = dict(row)
     # Parse the JSON blobs back into objects so the UI doesn't double-decode.
     for col in _JSON_COLS:
         if d.get(col):
@@ -105,8 +105,15 @@ async def list_activity(
     _validate(severity, kind, outcome)
     store = _store(request)
     rows = store.query(
-        since=since, category=category, action=action, severity=severity,
-        outcome=outcome, actor=actor, kind=kind, search=search, limit=limit,
+        since=since,
+        category=category,
+        action=action,
+        severity=severity,
+        outcome=outcome,
+        actor=actor,
+        kind=kind,
+        search=search,
+        limit=limit,
     )
     records = [_row_to_dict(r) for r in rows]
     # Rows come back newest-first; the highest id is the cursor to poll next.
@@ -131,8 +138,14 @@ async def export_activity(
     _validate(severity, kind, outcome)
     store = _store(request)
     blob = store.export(
-        fmt=fmt, category=category, action=action, severity=severity,
-        outcome=outcome, actor=actor, kind=kind, search=search,
+        fmt=fmt,
+        category=category,
+        action=action,
+        severity=severity,
+        outcome=outcome,
+        actor=actor,
+        kind=kind,
+        search=search,
     )
     media = "text/csv" if fmt == "csv" else "application/json"
     return Response(
@@ -156,28 +169,25 @@ async def stream_activity(
 ) -> StreamingResponse:
     _validate(severity, kind, outcome)
     store = _store(request)
-    bus = getattr(request.app.state, "events", None)
     epoch = _epoch(request)
 
-    filters = dict(category=category, action=action, severity=severity,
-                   outcome=outcome, actor=actor, kind=kind, search=search)
-
-    def _matches(rec: dict[str, Any]) -> bool:
-        if category and rec.get("category") != category:
-            return False
-        if severity and rec.get("severity") != severity:
-            return False
-        if outcome and rec.get("outcome") != outcome:
-            return False
-        if actor and rec.get("actor") != actor:
-            return False
-        if kind and rec.get("kind") != kind:
-            return False
-        return True
+    filters = dict(
+        category=category,
+        action=action,
+        severity=severity,
+        outcome=outcome,
+        actor=actor,
+        kind=kind,
+        search=search,
+    )
 
     async def gen():
         # Durable backfill first (id > since), oldest→newest for replay.
-        backfill = list(reversed([_row_to_dict(r) for r in store.query(since=since, limit=_LIMIT_MAX, **filters)]))
+        backfill = list(
+            reversed(
+                [_row_to_dict(r) for r in store.query(since=since, limit=_LIMIT_MAX, **filters)]
+            )
+        )
         cursor = since
         for rec in backfill:
             cursor = max(cursor, rec["id"])
@@ -188,7 +198,14 @@ async def stream_activity(
         while True:
             if await request.is_disconnected():
                 break
-            new = list(reversed([_row_to_dict(r) for r in store.query(since=cursor, limit=_LIMIT_MAX, **filters)]))
+            new = list(
+                reversed(
+                    [
+                        _row_to_dict(r)
+                        for r in store.query(since=cursor, limit=_LIMIT_MAX, **filters)
+                    ]
+                )
+            )
             if new:
                 for rec in new:
                     cursor = max(cursor, rec["id"])

--- a/src/hal0/api/routes/approvals.py
+++ b/src/hal0/api/routes/approvals.py
@@ -38,6 +38,7 @@ from typing import Any
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
+from hal0.api._audit import record_action
 from hal0.api.middleware.error_codes import Hal0Error
 from hal0.mcp.approval_queue import ApprovalQueue
 
@@ -107,18 +108,22 @@ async def approve_approval(approval_id: str, request: Request) -> dict[str, Any]
     behaviour is distinguishable from a stale dashboard tab.
     """
     queue = _queue(request)
-    try:
-        result = await queue.approve(approval_id)
-    except KeyError:
-        raise ApprovalNotFound(
-            f"approval {approval_id!r} not found",
-            details={"approval_id": approval_id},
-        ) from None
-    except ValueError as exc:
-        raise ApprovalAlreadyResolved(
-            str(exc),
-            details={"approval_id": approval_id},
-        ) from None
+    async with record_action(
+        request, category="approval", action="approval.approve", target=approval_id
+    ) as rec:
+        try:
+            result = await queue.approve(approval_id)
+        except KeyError:
+            raise ApprovalNotFound(
+                f"approval {approval_id!r} not found",
+                details={"approval_id": approval_id},
+            ) from None
+        except ValueError as exc:
+            raise ApprovalAlreadyResolved(
+                str(exc),
+                details={"approval_id": approval_id},
+            ) from None
+        rec.after = {"id": approval_id, "state": result.get("state")}
     return {"approval": result}
 
 
@@ -126,18 +131,22 @@ async def approve_approval(approval_id: str, request: Request) -> dict[str, Any]
 async def deny_approval(approval_id: str, request: Request) -> dict[str, Any]:
     """Deny one pending entry; no executor runs."""
     queue = _queue(request)
-    try:
-        result = await queue.deny(approval_id)
-    except KeyError:
-        raise ApprovalNotFound(
-            f"approval {approval_id!r} not found",
-            details={"approval_id": approval_id},
-        ) from None
-    except ValueError as exc:
-        raise ApprovalAlreadyResolved(
-            str(exc),
-            details={"approval_id": approval_id},
-        ) from None
+    async with record_action(
+        request, category="approval", action="approval.deny", target=approval_id
+    ) as rec:
+        try:
+            result = await queue.deny(approval_id)
+        except KeyError:
+            raise ApprovalNotFound(
+                f"approval {approval_id!r} not found",
+                details={"approval_id": approval_id},
+            ) from None
+        except ValueError as exc:
+            raise ApprovalAlreadyResolved(
+                str(exc),
+                details={"approval_id": approval_id},
+            ) from None
+        rec.after = {"id": approval_id, "state": result.get("state")}
     return {"approval": result}
 
 

--- a/src/hal0/api/routes/capabilities.py
+++ b/src/hal0/api/routes/capabilities.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from fastapi import APIRouter, Request
 
+from hal0.api._audit import record_action
 from hal0.api.deps import CapabilityOrchestratorDep
 from hal0.capabilities.orchestrator import LEGAL_SLOTS, legal_children
 from hal0.errors import BadRequest
@@ -86,7 +87,18 @@ async def apply_capability(
             details={"allowed": sorted(allowed_keys), "unexpected": sorted(extras)},
         )
 
-    selection = await orchestrator.apply(slot, child, body)
+    async with record_action(
+        request,
+        category="capability",
+        action="capability.apply",
+        target=f"{slot}/{child}",
+    ) as rec:
+        selection = await orchestrator.apply(slot, child, body)
+        rec.after = {
+            "slot": slot,
+            "child": child,
+            **{k: body[k] for k in ("backend", "provider", "model", "enabled") if k in body},
+        }
     return {"ok": True, "selection": selection}
 
 

--- a/src/hal0/api/routes/events.py
+++ b/src/hal0/api/routes/events.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import fnmatch
 import json
 from typing import Any
 
@@ -27,7 +28,7 @@ from fastapi import APIRouter, Query, Request
 from fastapi.responses import StreamingResponse
 
 from hal0.api.middleware.error_codes import Hal0Error
-from hal0.events import EventBus
+from hal0.events import _SEVERITY_ORDER, EventBus
 
 router = APIRouter()
 
@@ -96,15 +97,28 @@ async def list_events(
     sev = _normalise_severity(severity)
     events = bus.backfill(since=since, type_glob=type, min_severity=sev, limit=limit)
     next_since = events[-1]["id"] if events else (since or 0)
-    return {"events": events, "next_since": next_since}
+    # Per-process epoch: event ids restart at 1 on every boot, so a client
+    # holding a stale ``since`` would skip all post-restart events until the
+    # counter climbed past it. Surfacing the epoch lets the client detect the
+    # reset and rewind its cursor to 0 (fixes the footer-blank-after-restart
+    # bug). The audit epoch doubles as the process epoch.
+    epoch = getattr(request.app.state, "audit_epoch", "")
+    return {"events": events, "next_since": next_since, "epoch": epoch}
 
 
 @router.get("/stream")
 async def stream_events(
     request: Request,
     since: int | None = Query(default=None, ge=0),
+    type: str | None = Query(default=None),
+    severity: str | None = Query(default=None),
 ) -> StreamingResponse:
     """Server-Sent Events stream: backfill then live tail.
+
+    ``type`` (fnmatch glob, e.g. ``slot.*``) and ``severity`` (min level,
+    inclusive) narrow BOTH the backfill and the live tail server-side, so a
+    footer wanting only ``slot.*`` no longer receives the full pull-progress
+    firehose (which could overflow the subscriber queue and drop frames).
 
     The replay window is bounded by the ring (500 entries). Clients that
     have been disconnected longer than that lose anything older than the
@@ -112,17 +126,23 @@ async def stream_events(
     ``/api/health`` + ``/api/slots`` after a long outage.
     """
     bus = _bus(request)
+    sev = _normalise_severity(severity)
+    min_rank = _SEVERITY_ORDER.get(sev, -1) if sev else -1
+
+    def _passes(ev: dict[str, Any]) -> bool:
+        if type and not fnmatch.fnmatchcase(ev.get("type", ""), type):
+            return False
+        if min_rank >= 0 and _SEVERITY_ORDER.get(ev.get("severity", "info"), 0) < min_rank:
+            return False
+        return True
 
     async def _gen() -> Any:
         # 1. Subscribe FIRST so events emitted between backfill snapshot
         #    and live tail get queued instead of dropped.
         async with bus.subscribe() as q:
-            # 2. Snapshot whatever is already in the ring with id > since.
-            #    We use the bus's own backfill so the filter logic stays
-            #    in one place; no type/severity narrowing on the stream
-            #    surface (clients filter client-side or use the polling
-            #    endpoint for narrow scopes).
-            replay = bus.backfill(since=since, limit=_LIMIT_MAX)
+            # 2. Snapshot whatever is already in the ring with id > since,
+            #    narrowed by the same type/severity filters as the live tail.
+            replay = bus.backfill(since=since, type_glob=type, min_severity=sev, limit=_LIMIT_MAX)
             last_id = since or 0
             for ev in replay:
                 yield f"data: {json.dumps(ev)}\n\n"
@@ -145,6 +165,8 @@ async def stream_events(
                 if ev["id"] <= last_id:
                     continue
                 last_id = ev["id"]
+                if not _passes(ev):
+                    continue
                 yield f"data: {json.dumps(ev)}\n\n"
 
     async def _safe_gen() -> Any:

--- a/src/hal0/api/routes/events.py
+++ b/src/hal0/api/routes/events.py
@@ -132,9 +132,7 @@ async def stream_events(
     def _passes(ev: dict[str, Any]) -> bool:
         if type and not fnmatch.fnmatchcase(ev.get("type", ""), type):
             return False
-        if min_rank >= 0 and _SEVERITY_ORDER.get(ev.get("severity", "info"), 0) < min_rank:
-            return False
-        return True
+        return not (min_rank >= 0 and _SEVERITY_ORDER.get(ev.get("severity", "info"), 0) < min_rank)
 
     async def _gen() -> Any:
         # 1. Subscribe FIRST so events emitted between backfill snapshot

--- a/src/hal0/api/routes/health.py
+++ b/src/hal0/api/routes/health.py
@@ -27,6 +27,7 @@ from fastapi.responses import Response
 
 from hal0 import __version__
 from hal0.config import paths
+from hal0.slots.state import SlotState
 
 log = structlog.get_logger(__name__)
 
@@ -176,7 +177,18 @@ async def health_system(request: Request) -> dict[str, Any]:
     else:
         try:
             slots = await sm.list()
-            checks["slot_manager"] = {"ok": True, "slots": len(slots)}
+            # B2: a slot stuck in ERROR is a real degradation — the previous
+            # check reported ok=True regardless, so a systemd-FAILED slot
+            # rendered the whole system "ok". Surface the errored slots so the
+            # dashboard chip + tooltip can tell the truth.
+            errored = [s.name for s in slots if s.state == SlotState.ERROR]
+            sm_ok = not errored
+            checks["slot_manager"] = {
+                "ok": sm_ok,
+                "slots": len(slots),
+                "errored": errored,
+            }
+            degraded = degraded or not sm_ok
         except Exception as exc:
             checks["slot_manager"] = {"ok": False, "detail": str(exc)}
             degraded = True

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -20,6 +20,7 @@ import httpx
 from fastapi import APIRouter, BackgroundTasks, Request
 from fastapi.responses import StreamingResponse
 
+from hal0.api._audit import record_action
 from hal0.api.middleware.error_codes import BadRequest, NotFound
 from hal0.config.loader import load_hal0_config
 from hal0.errors import Hal0Error
@@ -923,41 +924,53 @@ async def delete_model(
     operator's call. Registry rows hold metadata, not bytes.
     """
     registry = request.app.state.model_registry
-    if not registry.has(model_id):
-        # Mirror the registry's typed envelope. We don't raise ModelNotFound
-        # directly to avoid importing it at module scope; the registry's
-        # remove() returns False silently, so we need an explicit guard.
-        from hal0.registry.store import ModelNotFound
+    # Wrap the whole resolve+cascade+remove so the durable audit row captures
+    # BOTH the denied/unknown-id paths (404 / 409) and the successful delete
+    # with a before/after summary. The EventBus ``model.deleted`` emit below is
+    # a separate footer-ticker signal, not the audit record.
+    async with record_action(
+        request, category="model", action="model.delete", target=model_id
+    ) as rec:
+        if not registry.has(model_id):
+            # Mirror the registry's typed envelope. We don't raise ModelNotFound
+            # directly to avoid importing it at module scope; the registry's
+            # remove() returns False silently, so we need an explicit guard.
+            from hal0.registry.store import ModelNotFound
 
-        raise ModelNotFound(
-            f"model {model_id!r} not in registry",
-            details={"model_id": model_id},
-        )
+            raise ModelNotFound(
+                f"model {model_id!r} not in registry",
+                details={"model_id": model_id},
+            )
 
-    affected = _slots_referencing_model(request, model_id)
-    affected_names = [entry["name"] for entry in affected]
+        affected = _slots_referencing_model(request, model_id)
+        affected_names = [entry["name"] for entry in affected]
 
-    if affected and not force_cascade:
-        from hal0.errors import Conflict
+        if affected and not force_cascade:
+            from hal0.errors import Conflict
 
-        raise Conflict(
-            f"model {model_id!r} is referenced by {len(affected)} slot(s); "
-            f"retry with force_cascade=true to cascade",
-            code="model.in_use",
-            details={"model_id": model_id, "affected_slots": affected_names},
-        )
+            raise Conflict(
+                f"model {model_id!r} is referenced by {len(affected)} slot(s); "
+                f"retry with force_cascade=true to cascade",
+                code="model.in_use",
+                details={"model_id": model_id, "affected_slots": affected_names},
+            )
 
-    # Cascade order is load-bearing for the footer's ticker UX:
-    #   1. unload running referrers (each fires slot.state)
-    #   2. clear [model].default in slot TOMLs
-    #   3. registry delete
-    #   4. emit model.deleted LAST
-    for entry in affected:
-        await _unload_slot_if_running(request, entry["name"])
-    for entry in affected:
-        _clear_slot_default(Path(entry["path"]), entry["config"])
+        # Cascade order is load-bearing for the footer's ticker UX:
+        #   1. unload running referrers (each fires slot.state)
+        #   2. clear [model].default in slot TOMLs
+        #   3. registry delete
+        #   4. emit model.deleted LAST
+        for entry in affected:
+            await _unload_slot_if_running(request, entry["name"])
+        for entry in affected:
+            _clear_slot_default(Path(entry["path"]), entry["config"])
 
-    removed = registry.remove(model_id)
+        removed = registry.remove(model_id)
+        rec.after = {
+            "id": model_id,
+            "deleted": bool(removed),
+            "cascaded_slots": affected_names,
+        }
 
     event_bus = getattr(request.app.state, "events", None)
     if event_bus is not None:

--- a/src/hal0/api/routes/profiles.py
+++ b/src/hal0/api/routes/profiles.py
@@ -19,9 +19,10 @@ from __future__ import annotations
 import re
 from typing import Any, Literal
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from pydantic import BaseModel, Field, field_validator
 
+from hal0.api._audit import record_action
 from hal0.config.schema import ProfileConfig
 from hal0.profiles import ProfileCatalog, ProfilePatch
 
@@ -132,7 +133,7 @@ def list_profiles() -> list[dict[str, Any]]:
 
 
 @router.post("", status_code=201)
-def create_profile(body: ProfileBody) -> dict[str, Any]:
+async def create_profile(body: ProfileBody, request: Request) -> dict[str, Any]:
     """Create a custom profile.
 
     Returns the created profile item (same shape as list).
@@ -141,24 +142,35 @@ def create_profile(body: ProfileBody) -> dict[str, Any]:
         409 profiles.exists: name already exists (seed or custom).
         422: pydantic validation failure (empty image, bad name, …).
     """
-    profile = ProfileCatalog().create(
-        body.name,
-        ProfileConfig(
-            image=body.image,
-            flags=body.flags,
-            mtp=body.mtp,
-            device_class=body.device_class,
-            backend=body.backend,
-            cloned_from=body.cloned_from,
-            intent=body.intent,
-            quant=body.quant,
-        ),
-    )
+    async with record_action(
+        request, category="profile", action="profile.create", target=body.name
+    ) as rec:
+        profile = ProfileCatalog().create(
+            body.name,
+            ProfileConfig(
+                image=body.image,
+                flags=body.flags,
+                mtp=body.mtp,
+                device_class=body.device_class,
+                backend=body.backend,
+                cloned_from=body.cloned_from,
+                intent=body.intent,
+                quant=body.quant,
+            ),
+        )
+        rec.after = {
+            "name": body.name,
+            "image": body.image,
+            "device_class": body.device_class,
+            "backend": body.backend,
+        }
     return profile.to_dict()
 
 
 @router.put("/{name}")
-def update_profile(name: str, body: ProfileUpdateBody) -> dict[str, Any]:
+async def update_profile(
+    name: str, body: ProfileUpdateBody, request: Request
+) -> dict[str, Any]:
     """Update an existing custom profile (shallow merge).
 
     Returns the updated profile item.
@@ -168,23 +180,36 @@ def update_profile(name: str, body: ProfileUpdateBody) -> dict[str, Any]:
         404 profiles.not_found: custom profile not found.
         422: pydantic validation failure.
     """
-    profile = ProfileCatalog().update(
-        name,
-        ProfilePatch(
-            image=body.image,
-            flags=body.flags,
-            mtp=body.mtp,
-            device_class=body.device_class,
-            backend=body.backend,
-            intent=body.intent,
-            quant=body.quant,
-        ),
-    )
+    catalog = ProfileCatalog()
+    before = None
+    existing = next((p for p in catalog.list() if p.name == name), None)
+    if existing is not None:
+        before = existing.to_dict()
+    async with record_action(
+        request,
+        category="profile",
+        action="profile.update",
+        target=name,
+        before=before,
+    ) as rec:
+        profile = catalog.update(
+            name,
+            ProfilePatch(
+                image=body.image,
+                flags=body.flags,
+                mtp=body.mtp,
+                device_class=body.device_class,
+                backend=body.backend,
+                intent=body.intent,
+                quant=body.quant,
+            ),
+        )
+        rec.after = profile.to_dict()
     return profile.to_dict()
 
 
 @router.delete("/{name}", status_code=204)
-def delete_profile(name: str) -> None:
+async def delete_profile(name: str, request: Request) -> None:
     """Delete a custom profile.
 
     Raises:
@@ -192,7 +217,10 @@ def delete_profile(name: str) -> None:
         404 profiles.not_found: custom profile not found.
         409 profiles.in_use: one or more slots reference this profile.
     """
-    ProfileCatalog().delete(name)
+    async with record_action(
+        request, category="profile", action="profile.delete", target=name
+    ):
+        ProfileCatalog().delete(name)
 
 
 __all__ = ["router"]

--- a/src/hal0/api/routes/profiles.py
+++ b/src/hal0/api/routes/profiles.py
@@ -168,9 +168,7 @@ async def create_profile(body: ProfileBody, request: Request) -> dict[str, Any]:
 
 
 @router.put("/{name}")
-async def update_profile(
-    name: str, body: ProfileUpdateBody, request: Request
-) -> dict[str, Any]:
+async def update_profile(name: str, body: ProfileUpdateBody, request: Request) -> dict[str, Any]:
     """Update an existing custom profile (shallow merge).
 
     Returns the updated profile item.
@@ -217,9 +215,7 @@ async def delete_profile(name: str, request: Request) -> None:
         404 profiles.not_found: custom profile not found.
         409 profiles.in_use: one or more slots reference this profile.
     """
-    async with record_action(
-        request, category="profile", action="profile.delete", target=name
-    ):
+    async with record_action(request, category="profile", action="profile.delete", target=name):
         ProfileCatalog().delete(name)
 
 

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -1280,7 +1280,11 @@ async def slot_logs_stream(name: str, request: Request) -> StreamingResponse:
 
     async def event_source() -> Any:
         if shutil.which("journalctl") is None:
-            yield 'event: error\ndata: {"message":"journalctl unavailable"}\n\n'
+            # B13: use a custom 'degraded' event name, NOT the reserved SSE
+            # 'error' name — EventSource's onmessage/onerror never fire for a
+            # named 'error' frame, so the log drawer used to spin forever on
+            # "waiting for log lines…". The client listens for 'degraded'.
+            yield 'event: degraded\ndata: {"message":"journalctl unavailable"}\n\n'
             return
         cmd = [
             "journalctl",

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -31,6 +31,7 @@ from typing import Any
 from fastapi import APIRouter, BackgroundTasks, Request
 from fastapi.responses import StreamingResponse
 
+from hal0.api._audit import record_action
 from hal0.api.middleware.error_codes import BadRequest, Conflict, Hal0Error
 from hal0.model_meta import device_to_backend, is_resolvable
 from hal0.slot_view import (
@@ -324,7 +325,11 @@ async def create_slot(request: Request) -> dict[str, object]:
         )
 
     body = _normalize_create_body(body)
-    snap = await sm.create(name, body)
+    async with record_action(
+        request, category="slot", action="slot.create", target=name,
+    ) as _rec:
+        snap = await sm.create(name, body)
+        _rec.after = {"config": body}
     return _slot_to_dict(snap, request)
 
 
@@ -813,6 +818,21 @@ async def get_slot(name: str, request: Request) -> dict[str, object]:
         raise
 
 
+def _state_value(snap: Any) -> str | None:
+    """Extract a serialisable state string from a slot snapshot for audit."""
+    state = getattr(snap, "state", None)
+    return getattr(state, "value", None) or (str(state) if state is not None else None)
+
+
+async def _safe_config(sm: Any, name: str) -> dict[str, Any] | None:
+    """Best-effort current config snapshot for an audit before-image."""
+    try:
+        cfg = await sm.get_config(name)
+        return cfg if isinstance(cfg, dict) else None
+    except Exception:
+        return None
+
+
 @router.delete("/{name}")
 async def delete_slot(name: str, request: Request) -> dict[str, object]:
     """Delete a slot. If the slot is running, it is stopped first.
@@ -822,7 +842,8 @@ async def delete_slot(name: str, request: Request) -> dict[str, object]:
     surfaces as 4xx.
     """
     sm = _get_slot_manager(request)
-    await sm.delete(name)
+    async with record_action(request, category="slot", action="slot.delete", target=name):
+        await sm.delete(name)
     return {"name": name, "deleted": True}
 
 
@@ -848,7 +869,12 @@ async def update_slot_config(name: str, request: Request) -> dict[str, object]:
         ) from exc
     if not isinstance(body, dict):
         raise BadRequest("request body must be a JSON object", code="request.not_an_object")
-    snap = await sm.update_config(name, body)
+    before = await _safe_config(sm, name)
+    async with record_action(
+        request, category="slot", action="slot.edit_config", target=name, before=before
+    ) as _rec:
+        snap = await sm.update_config(name, body)
+        _rec.after = body
     # Spec 1 / Component 2: an explicit ``enabled: false`` write must take a
     # running slot actually offline so the faded card matches reality. The
     # config write alone only flips the on-disk flag; without this a disabled
@@ -888,7 +914,12 @@ async def update_slot_defaults(name: str, request: Request) -> dict[str, object]
         ) from exc
     if not isinstance(body, dict):
         raise BadRequest("request body must be a JSON object", code="request.not_an_object")
-    snap = await sm.update_config(name, {"model": body})
+    before = await _safe_config(sm, name)
+    async with record_action(
+        request, category="slot", action="slot.edit_defaults", target=name, before=before
+    ) as _rec:
+        snap = await sm.update_config(name, {"model": body})
+        _rec.after = {"model": body}
     return _slot_to_dict(snap, request)
 
 
@@ -1044,14 +1075,19 @@ async def set_slot_backend(name: str, request: Request) -> dict[str, object]:
 
     # Persist the new device. ``auto`` clears the device field entirely so
     # the load path falls back to its default on the next load.
-    await sm.update_config(name, {"device": target_device or ""})
+    async with record_action(
+        request, category="slot", action="slot.set_backend", target=name,
+        before={"device": current_declared}, message=f"backend → {backend}",
+    ) as _rec:
+        await sm.update_config(name, {"device": target_device or ""})
 
-    reloaded = False
-    if is_loaded:
-        # Restart so the model reloads under the new backend (the
-        # container unit re-renders from the updated TOML).
-        await sm.restart(name)
-        reloaded = True
+        reloaded = False
+        if is_loaded:
+            # Restart so the model reloads under the new backend (the
+            # container unit re-renders from the updated TOML).
+            await sm.restart(name)
+            reloaded = True
+        _rec.after = {"backend": backend, "device": target_device}
 
     snap = await sm.status(name)
     out = _slot_to_dict(snap, request)
@@ -1103,21 +1139,30 @@ async def load_slot(name: str, request: Request) -> dict[str, object]:
                 f"not an installed FLM model (slot {name!r} not touched)",
                 details={"model_id": model_id, "slot": name},
             )
-    snap = await sm.load(name, model_id=model_id)
+    async with record_action(
+        request, category="slot", action="slot.load", target=name,
+        message=f"load {model_id or 'default'}",
+    ) as _rec:
+        snap = await sm.load(name, model_id=model_id)
+        _rec.after = {"model_id": model_id, "state": _state_value(snap)}
     return _slot_to_dict(snap, request)
 
 
 @router.post("/{name}/unload")
 async def unload_slot(name: str, request: Request) -> dict[str, object]:
     sm = _get_slot_manager(request)
-    snap = await sm.unload(name)
+    async with record_action(request, category="slot", action="slot.unload", target=name) as _rec:
+        snap = await sm.unload(name)
+        _rec.after = {"state": _state_value(snap)}
     return _slot_to_dict(snap, request)
 
 
 @router.post("/{name}/restart")
 async def restart_slot(name: str, request: Request) -> dict[str, object]:
     sm = _get_slot_manager(request)
-    snap = await sm.restart(name)
+    async with record_action(request, category="slot", action="slot.restart", target=name) as _rec:
+        snap = await sm.restart(name)
+        _rec.after = {"state": _state_value(snap)}
     return _slot_to_dict(snap, request)
 
 
@@ -1153,7 +1198,12 @@ async def swap_slot(name: str, request: Request) -> dict[str, object]:
             f"not an installed FLM model (slot {name!r} not touched)",
             details={"model_id": model_id, "slot": name},
         )
-    snap = await sm.swap(name, model_id)
+    async with record_action(
+        request, category="slot", action="slot.swap", target=name,
+        message=f"swap → {model_id}",
+    ) as _rec:
+        snap = await sm.swap(name, model_id)
+        _rec.after = {"model_id": model_id, "state": _state_value(snap)}
     return _slot_to_dict(snap, request)
 
 

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -326,7 +326,10 @@ async def create_slot(request: Request) -> dict[str, object]:
 
     body = _normalize_create_body(body)
     async with record_action(
-        request, category="slot", action="slot.create", target=name,
+        request,
+        category="slot",
+        action="slot.create",
+        target=name,
     ) as _rec:
         snap = await sm.create(name, body)
         _rec.after = {"config": body}
@@ -1076,8 +1079,12 @@ async def set_slot_backend(name: str, request: Request) -> dict[str, object]:
     # Persist the new device. ``auto`` clears the device field entirely so
     # the load path falls back to its default on the next load.
     async with record_action(
-        request, category="slot", action="slot.set_backend", target=name,
-        before={"device": current_declared}, message=f"backend → {backend}",
+        request,
+        category="slot",
+        action="slot.set_backend",
+        target=name,
+        before={"device": current_declared},
+        message=f"backend → {backend}",
     ) as _rec:
         await sm.update_config(name, {"device": target_device or ""})
 
@@ -1140,7 +1147,10 @@ async def load_slot(name: str, request: Request) -> dict[str, object]:
                 details={"model_id": model_id, "slot": name},
             )
     async with record_action(
-        request, category="slot", action="slot.load", target=name,
+        request,
+        category="slot",
+        action="slot.load",
+        target=name,
         message=f"load {model_id or 'default'}",
     ) as _rec:
         snap = await sm.load(name, model_id=model_id)
@@ -1199,7 +1209,10 @@ async def swap_slot(name: str, request: Request) -> dict[str, object]:
             details={"model_id": model_id, "slot": name},
         )
     async with record_action(
-        request, category="slot", action="slot.swap", target=name,
+        request,
+        category="slot",
+        action="slot.swap",
+        target=name,
         message=f"swap → {model_id}",
     ) as _rec:
         snap = await sm.swap(name, model_id)

--- a/src/hal0/config/paths.py
+++ b/src/hal0/config/paths.py
@@ -122,6 +122,17 @@ def models_dir() -> Path:
     return var_lib() / "models"
 
 
+def activity_db() -> Path:
+    """Return the durable activity/audit store path (/var/lib/hal0/activity.db).
+
+    SQLite file (plus its -wal/-shm siblings) holding the audit trail of
+    every config-mutating user action and system state change. Preserved
+    across updates like the rest of ``var_lib()``. Under HAL0_HOME it lands
+    in the tmp tree, so tests are auto-isolated.
+    """
+    return var_lib() / "activity.db"
+
+
 #: Conventional external model-store mount and the historic default for slot
 #: container bind-mounts. Most hal0 deployments target an NFS / fast-disk
 #: mount here; overridable per-install via ``[models].store`` or the

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1835,6 +1835,21 @@ class ModelsConfig(BaseModel):
         return self.pull_root
 
 
+class ActivityConfig(BaseModel):
+    """``[activity]`` — the durable audit/activity store (see hal0.activity).
+
+    Records every config-mutating action and system state change to a SQLite
+    table that survives restarts. ``retention_days`` and ``max_rows`` keep the
+    DB bounded without losing recent history. ``HAL0_ACTIVITY_RETENTION_DAYS``
+    overrides retention at the env layer.
+    """
+
+    enabled: bool = True
+    retention_days: int = Field(default=30, ge=1)
+    # None disables the row cap (retention_days still applies).
+    max_rows: int | None = Field(default=50_000, ge=100)
+
+
 class Hal0Config(BaseModel):
     """Top-level hal0.toml pydantic model.
 
@@ -1854,6 +1869,7 @@ class Hal0Config(BaseModel):
     telemetry: TelemetryConfig = Field(default_factory=TelemetryConfig)
     models: ModelsConfig = Field(default_factory=ModelsConfig)
     memory: MemoryConfig = Field(default_factory=MemoryConfig)
+    activity: ActivityConfig = Field(default_factory=ActivityConfig)
 
 
 __all__ = [
@@ -1867,6 +1883,7 @@ __all__ = [
     "MTP_FLAG_BUNDLE",
     "PROFILE_BENCH",
     "SEED_PROFILES",
+    "ActivityConfig",
     "AgentAuthConfig",
     "AgentAuthKindLiteral",
     "AgentConfig",

--- a/src/hal0/events/__init__.py
+++ b/src/hal0/events/__init__.py
@@ -26,13 +26,16 @@ import asyncio
 import contextlib
 import fnmatch
 import itertools
+import logging
 from collections import deque
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from typing import Any
 
 __all__ = ["EventBus", "Severity", "make_event"]
+
+_log = logging.getLogger("hal0.events")
 
 Severity = str  # "info" | "warn" | "error" — kept loose to avoid Literal import noise
 
@@ -86,11 +89,17 @@ class EventBus:
         *,
         ring_maxlen: int = _RING_MAXLEN,
         subscriber_maxsize: int = _SUBSCRIBER_MAXSIZE,
+        sink: "Callable[[dict[str, Any]], Awaitable[Any]] | None" = None,
     ) -> None:
         self.ring: deque[dict[str, Any]] = deque(maxlen=ring_maxlen)
         self.subscribers: set[asyncio.Queue[dict[str, Any]]] = set()
         self._next_id: itertools.count[int] = itertools.count(1)
         self._subscriber_maxsize = subscriber_maxsize
+        # Optional durable forwarder (the "future enrichment" hook noted in
+        # the class docstring). When set, every emitted event is also handed
+        # to ``sink`` — e.g. the AuditStore, which persists it. A sink that
+        # raises must never break emit, so we swallow + log its failures.
+        self._sink = sink
 
     # ── Emit ──────────────────────────────────────────────────────────
 
@@ -121,6 +130,11 @@ class EventBus:
         # (subscribers exit on task cancel) doesn't raise RuntimeError.
         for q in list(self.subscribers):
             self._enqueue(q, event)
+        if self._sink is not None:
+            try:
+                await self._sink(event)
+            except Exception:  # noqa: BLE001 — durability is best-effort
+                _log.warning("events.sink_failed", exc_info=True)
         return event
 
     def _enqueue(self, q: asyncio.Queue[dict[str, Any]], event: dict[str, Any]) -> None:

--- a/src/hal0/events/__init__.py
+++ b/src/hal0/events/__init__.py
@@ -89,7 +89,7 @@ class EventBus:
         *,
         ring_maxlen: int = _RING_MAXLEN,
         subscriber_maxsize: int = _SUBSCRIBER_MAXSIZE,
-        sink: "Callable[[dict[str, Any]], Awaitable[Any]] | None" = None,
+        sink: Callable[[dict[str, Any]], Awaitable[Any]] | None = None,
     ) -> None:
         self.ring: deque[dict[str, Any]] = deque(maxlen=ring_maxlen)
         self.subscribers: set[asyncio.Queue[dict[str, Any]]] = set()
@@ -133,7 +133,7 @@ class EventBus:
         if self._sink is not None:
             try:
                 await self._sink(event)
-            except Exception:  # noqa: BLE001 — durability is best-effort
+            except Exception:
                 _log.warning("events.sink_failed", exc_info=True)
         return event
 

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -217,6 +217,14 @@ def _render_unit_from_plan(
         # never ran) → exit 125 "name already in use" at next boot (#721).
         # --replace removes it first; no-op when no stale record exists.
         "--replace",
+        # B3: the unit already routes conmon's inherited container stdout to
+        # journald via StandardOutput=journal. podman's DEFAULT journald log
+        # driver ALSO writes the same stdout to journald (tagged CONTAINER_NAME),
+        # so `journalctl -u hal0-slot@<name>` matched both copies and every
+        # line appeared twice. Disable podman's own log driver so conmon→unit
+        # is the single sink. (docker ignores an unknown value gracefully; it
+        # accepts --log-driver=none too.)
+        "--log-driver=none",
     ]
     if plan.network_mode:
         argv.append(f"--network={plan.network_mode}")

--- a/tests/activity/test_store.py
+++ b/tests/activity/test_store.py
@@ -61,21 +61,43 @@ async def test_record_persists_and_survives_new_connection(tmp_path: Path) -> No
 
 @pytest.mark.asyncio
 async def test_record_assigns_monotonic_ids(store: AuditStore) -> None:
-    a = await store.record(kind="action", category="model", action="model.pull",
-                           target="qwen", actor="cli", severity="info", outcome="pending",
-                           message="pull start")
-    b = await store.record(kind="action", category="model", action="model.delete",
-                           target="qwen", actor="cli", severity="ok", outcome="ok",
-                           message="deleted")
+    a = await store.record(
+        kind="action",
+        category="model",
+        action="model.pull",
+        target="qwen",
+        actor="cli",
+        severity="info",
+        outcome="pending",
+        message="pull start",
+    )
+    b = await store.record(
+        kind="action",
+        category="model",
+        action="model.delete",
+        target="qwen",
+        actor="cli",
+        severity="ok",
+        outcome="ok",
+        message="deleted",
+    )
     assert (a, b) == (1, 2)
 
 
 @pytest.mark.asyncio
 async def test_before_after_roundtrip_as_json(store: AuditStore) -> None:
-    await store.record(kind="action", category="slot", action="slot.edit_config",
-                       target="chat", actor="dashboard", severity="ok", outcome="ok",
-                       message="ctx 4096→8192",
-                       before={"context_size": 4096}, after={"context_size": 8192})
+    await store.record(
+        kind="action",
+        category="slot",
+        action="slot.edit_config",
+        target="chat",
+        actor="dashboard",
+        severity="ok",
+        outcome="ok",
+        message="ctx 4096→8192",
+        before={"context_size": 4096},
+        after={"context_size": 8192},
+    )
     row = store.query()[0]
     assert json.loads(row["before"]) == {"context_size": 4096}
     assert json.loads(row["after"]) == {"context_size": 8192}
@@ -86,23 +108,53 @@ async def test_before_after_roundtrip_as_json(store: AuditStore) -> None:
 
 @pytest.mark.asyncio
 async def test_query_since_cursor_excludes_seen(store: AuditStore) -> None:
-    i1 = await store.record(kind="event", category="system", action="system.restart",
-                            target="api", actor="system", severity="info", outcome=None,
-                            message="boot")
-    i2 = await store.record(kind="action", category="profile", action="profile.create",
-                            target="p1", actor="dashboard", severity="ok", outcome="ok",
-                            message="created p1")
+    i1 = await store.record(
+        kind="event",
+        category="system",
+        action="system.restart",
+        target="api",
+        actor="system",
+        severity="info",
+        outcome=None,
+        message="boot",
+    )
+    i2 = await store.record(
+        kind="action",
+        category="profile",
+        action="profile.create",
+        target="p1",
+        actor="dashboard",
+        severity="ok",
+        outcome="ok",
+        message="created p1",
+    )
     rows = store.query(since=i1)
     assert [r["id"] for r in rows] == [i2]
 
 
 @pytest.mark.asyncio
 async def test_query_filters_by_severity_and_outcome(store: AuditStore) -> None:
-    await store.record(kind="action", category="slot", action="slot.load", target="chat",
-                       actor="dashboard", severity="ok", outcome="ok", message="loaded")
-    await store.record(kind="action", category="slot", action="slot.load", target="npu",
-                       actor="dashboard", severity="error", outcome="error",
-                       message="failed", error="OOM")
+    await store.record(
+        kind="action",
+        category="slot",
+        action="slot.load",
+        target="chat",
+        actor="dashboard",
+        severity="ok",
+        outcome="ok",
+        message="loaded",
+    )
+    await store.record(
+        kind="action",
+        category="slot",
+        action="slot.load",
+        target="npu",
+        actor="dashboard",
+        severity="error",
+        outcome="error",
+        message="failed",
+        error="OOM",
+    )
     errs = store.query(severity="error")
     assert len(errs) == 1 and errs[0]["target"] == "npu"
     oks = store.query(outcome="ok")
@@ -111,11 +163,26 @@ async def test_query_filters_by_severity_and_outcome(store: AuditStore) -> None:
 
 @pytest.mark.asyncio
 async def test_query_filters_by_category_actor_kind(store: AuditStore) -> None:
-    await store.record(kind="action", category="capability", action="capability.apply",
-                       target="stt", actor="mcp:claude-dev", severity="ok", outcome="ok",
-                       message="stt→npu")
-    await store.record(kind="event", category="system", action="slot.state", target="chat",
-                       actor="system", severity="info", outcome=None, message="ready")
+    await store.record(
+        kind="action",
+        category="capability",
+        action="capability.apply",
+        target="stt",
+        actor="mcp:claude-dev",
+        severity="ok",
+        outcome="ok",
+        message="stt→npu",
+    )
+    await store.record(
+        kind="event",
+        category="system",
+        action="slot.state",
+        target="chat",
+        actor="system",
+        severity="info",
+        outcome=None,
+        message="ready",
+    )
     assert len(store.query(category="capability")) == 1
     assert len(store.query(actor="mcp:claude-dev")) == 1
     assert len(store.query(kind="event")) == 1
@@ -123,10 +190,26 @@ async def test_query_filters_by_category_actor_kind(store: AuditStore) -> None:
 
 @pytest.mark.asyncio
 async def test_query_action_glob_and_search(store: AuditStore) -> None:
-    await store.record(kind="action", category="slot", action="slot.restart", target="chat",
-                       actor="dashboard", severity="ok", outcome="ok", message="restarted chat")
-    await store.record(kind="action", category="model", action="model.pull", target="qwen3",
-                       actor="cli", severity="ok", outcome="ok", message="pulled qwen3")
+    await store.record(
+        kind="action",
+        category="slot",
+        action="slot.restart",
+        target="chat",
+        actor="dashboard",
+        severity="ok",
+        outcome="ok",
+        message="restarted chat",
+    )
+    await store.record(
+        kind="action",
+        category="model",
+        action="model.pull",
+        target="qwen3",
+        actor="cli",
+        severity="ok",
+        outcome="ok",
+        message="pulled qwen3",
+    )
     assert {r["target"] for r in store.query(action="slot.*")} == {"chat"}
     assert {r["target"] for r in store.query(search="qwen")} == {"qwen3"}
 
@@ -134,9 +217,16 @@ async def test_query_action_glob_and_search(store: AuditStore) -> None:
 @pytest.mark.asyncio
 async def test_query_limit_returns_newest_first(store: AuditStore) -> None:
     for i in range(5):
-        await store.record(kind="event", category="system", action="slot.state",
-                           target=f"s{i}", actor="system", severity="info", outcome=None,
-                           message=str(i))
+        await store.record(
+            kind="event",
+            category="system",
+            action="slot.state",
+            target=f"s{i}",
+            actor="system",
+            severity="info",
+            outcome=None,
+            message=str(i),
+        )
     rows = store.query(limit=2)
     assert [r["target"] for r in rows] == ["s4", "s3"]
 
@@ -146,9 +236,14 @@ async def test_query_limit_returns_newest_first(store: AuditStore) -> None:
 
 @pytest.mark.asyncio
 async def test_audit_action_records_ok_on_success(store: AuditStore) -> None:
-    async with audit_action(store, category="slot", action="slot.edit_config",
-                            target="chat", actor="dashboard",
-                            before={"context_size": 4096}) as rec:
+    async with audit_action(
+        store,
+        category="slot",
+        action="slot.edit_config",
+        target="chat",
+        actor="dashboard",
+        before={"context_size": 4096},
+    ) as rec:
         rec.after = {"context_size": 8192}
     row = store.query()[0]
     assert row["outcome"] == "ok"
@@ -160,8 +255,9 @@ async def test_audit_action_records_ok_on_success(store: AuditStore) -> None:
 @pytest.mark.asyncio
 async def test_audit_action_records_error_and_reraises(store: AuditStore) -> None:
     with pytest.raises(ValueError, match="boom"):
-        async with audit_action(store, category="slot", action="slot.delete",
-                                target="chat", actor="dashboard"):
+        async with audit_action(
+            store, category="slot", action="slot.delete", target="chat", actor="dashboard"
+        ):
             raise ValueError("boom")
     row = store.query()[0]
     assert row["outcome"] == "error"
@@ -199,13 +295,29 @@ async def test_prune_drops_rows_older_than_retention(tmp_path: Path) -> None:
     s = AuditStore(tmp_path / "activity.db", retention_days=7, max_rows=None)
     s.init_schema()
     # Hand-insert an ancient row + a fresh one.
-    await s.record(kind="event", category="system", action="slot.state", target="old",
-                   actor="system", severity="info", outcome=None, message="old")
+    await s.record(
+        kind="event",
+        category="system",
+        action="slot.state",
+        target="old",
+        actor="system",
+        severity="info",
+        outcome=None,
+        message="old",
+    )
     with sqlite3.connect(s.db_path) as conn:
         conn.execute("UPDATE audit SET ts = '2000-01-01T00:00:00+00:00' WHERE target='old'")
         conn.commit()
-    await s.record(kind="event", category="system", action="slot.state", target="new",
-                   actor="system", severity="info", outcome=None, message="new")
+    await s.record(
+        kind="event",
+        category="system",
+        action="slot.state",
+        target="new",
+        actor="system",
+        severity="info",
+        outcome=None,
+        message="new",
+    )
     dropped = await s.prune()
     assert dropped == 1
     assert {r["target"] for r in s.query()} == {"new"}
@@ -216,9 +328,16 @@ async def test_prune_enforces_max_rows_keeping_newest(tmp_path: Path) -> None:
     s = AuditStore(tmp_path / "activity.db", retention_days=3650, max_rows=3)
     s.init_schema()
     for i in range(6):
-        await s.record(kind="event", category="system", action="slot.state",
-                       target=f"s{i}", actor="system", severity="info", outcome=None,
-                       message=str(i))
+        await s.record(
+            kind="event",
+            category="system",
+            action="slot.state",
+            target=f"s{i}",
+            actor="system",
+            severity="info",
+            outcome=None,
+            message=str(i),
+        )
     await s.prune()
     rows = s.query(limit=100)
     assert [r["target"] for r in rows] == ["s5", "s4", "s3"]
@@ -229,8 +348,16 @@ async def test_prune_enforces_max_rows_keeping_newest(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_export_json_and_csv(store: AuditStore) -> None:
-    await store.record(kind="action", category="slot", action="slot.load", target="chat",
-                       actor="dashboard", severity="ok", outcome="ok", message="loaded chat")
+    await store.record(
+        kind="action",
+        category="slot",
+        action="slot.load",
+        target="chat",
+        actor="dashboard",
+        severity="ok",
+        outcome="ok",
+        message="loaded chat",
+    )
     blob = store.export(fmt="json")
     assert json.loads(blob)[0]["action"] == "slot.load"
     csv_blob = store.export(fmt="csv")
@@ -243,8 +370,16 @@ async def test_export_json_and_csv(store: AuditStore) -> None:
 
 @pytest.mark.asyncio
 async def test_secret_values_are_redacted_in_before_after(store: AuditStore) -> None:
-    await store.record(kind="action", category="provider", action="provider.credential_write",
-                       target="openrouter", actor="dashboard", severity="ok", outcome="ok",
-                       message="set key", after={"api_key": "sk-supersecret-123"})
+    await store.record(
+        kind="action",
+        category="provider",
+        action="provider.credential_write",
+        target="openrouter",
+        actor="dashboard",
+        severity="ok",
+        outcome="ok",
+        message="set key",
+        after={"api_key": "sk-supersecret-123"},
+    )
     row = store.query()[0]
     assert "supersecret" not in (row["after"] or "")

--- a/tests/activity/test_store.py
+++ b/tests/activity/test_store.py
@@ -1,0 +1,250 @@
+"""Unit tests for the durable AuditStore (SQLite source of truth).
+
+Covers the contract the rest of the Activity subsystem depends on:
+  * record() persists a row that survives a fresh connection (durability).
+  * query() filters by since-cursor, category, severity, outcome, actor,
+    kind, action glob, and free-text search.
+  * audit_action() records outcome=ok on success and outcome=error (with
+    the exception message) on failure — the "confirmation it actually
+    took place" guarantee.
+  * record_event() adapts an EventBus event into a durable kind="event" row.
+  * prune() enforces retention without dropping recent history.
+  * export() renders CSV and JSON honoring filters.
+  * Provider secrets are never persisted (redaction).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hal0.activity import AuditStore, audit_action
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> AuditStore:
+    s = AuditStore(tmp_path / "activity.db", retention_days=30, max_rows=None)
+    s.init_schema()
+    return s
+
+
+# ── record + durability ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_record_persists_and_survives_new_connection(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    s1 = AuditStore(db, retention_days=30, max_rows=None)
+    s1.init_schema()
+    rid = await s1.record(
+        kind="action",
+        category="slot",
+        action="slot.delete",
+        target="chat",
+        actor="dashboard",
+        severity="ok",
+        outcome="ok",
+        message="deleted slot chat",
+    )
+    assert rid == 1
+    # Fresh store object → fresh connection → proves it hit disk, not RAM.
+    s2 = AuditStore(db, retention_days=30, max_rows=None)
+    rows = s2.query()
+    assert len(rows) == 1
+    assert rows[0]["action"] == "slot.delete"
+    assert rows[0]["outcome"] == "ok"
+    assert rows[0]["target"] == "chat"
+
+
+@pytest.mark.asyncio
+async def test_record_assigns_monotonic_ids(store: AuditStore) -> None:
+    a = await store.record(kind="action", category="model", action="model.pull",
+                           target="qwen", actor="cli", severity="info", outcome="pending",
+                           message="pull start")
+    b = await store.record(kind="action", category="model", action="model.delete",
+                           target="qwen", actor="cli", severity="ok", outcome="ok",
+                           message="deleted")
+    assert (a, b) == (1, 2)
+
+
+@pytest.mark.asyncio
+async def test_before_after_roundtrip_as_json(store: AuditStore) -> None:
+    await store.record(kind="action", category="slot", action="slot.edit_config",
+                       target="chat", actor="dashboard", severity="ok", outcome="ok",
+                       message="ctx 4096→8192",
+                       before={"context_size": 4096}, after={"context_size": 8192})
+    row = store.query()[0]
+    assert json.loads(row["before"]) == {"context_size": 4096}
+    assert json.loads(row["after"]) == {"context_size": 8192}
+
+
+# ── query filters ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_query_since_cursor_excludes_seen(store: AuditStore) -> None:
+    i1 = await store.record(kind="event", category="system", action="system.restart",
+                            target="api", actor="system", severity="info", outcome=None,
+                            message="boot")
+    i2 = await store.record(kind="action", category="profile", action="profile.create",
+                            target="p1", actor="dashboard", severity="ok", outcome="ok",
+                            message="created p1")
+    rows = store.query(since=i1)
+    assert [r["id"] for r in rows] == [i2]
+
+
+@pytest.mark.asyncio
+async def test_query_filters_by_severity_and_outcome(store: AuditStore) -> None:
+    await store.record(kind="action", category="slot", action="slot.load", target="chat",
+                       actor="dashboard", severity="ok", outcome="ok", message="loaded")
+    await store.record(kind="action", category="slot", action="slot.load", target="npu",
+                       actor="dashboard", severity="error", outcome="error",
+                       message="failed", error="OOM")
+    errs = store.query(severity="error")
+    assert len(errs) == 1 and errs[0]["target"] == "npu"
+    oks = store.query(outcome="ok")
+    assert len(oks) == 1 and oks[0]["target"] == "chat"
+
+
+@pytest.mark.asyncio
+async def test_query_filters_by_category_actor_kind(store: AuditStore) -> None:
+    await store.record(kind="action", category="capability", action="capability.apply",
+                       target="stt", actor="mcp:claude-dev", severity="ok", outcome="ok",
+                       message="stt→npu")
+    await store.record(kind="event", category="system", action="slot.state", target="chat",
+                       actor="system", severity="info", outcome=None, message="ready")
+    assert len(store.query(category="capability")) == 1
+    assert len(store.query(actor="mcp:claude-dev")) == 1
+    assert len(store.query(kind="event")) == 1
+
+
+@pytest.mark.asyncio
+async def test_query_action_glob_and_search(store: AuditStore) -> None:
+    await store.record(kind="action", category="slot", action="slot.restart", target="chat",
+                       actor="dashboard", severity="ok", outcome="ok", message="restarted chat")
+    await store.record(kind="action", category="model", action="model.pull", target="qwen3",
+                       actor="cli", severity="ok", outcome="ok", message="pulled qwen3")
+    assert {r["target"] for r in store.query(action="slot.*")} == {"chat"}
+    assert {r["target"] for r in store.query(search="qwen")} == {"qwen3"}
+
+
+@pytest.mark.asyncio
+async def test_query_limit_returns_newest_first(store: AuditStore) -> None:
+    for i in range(5):
+        await store.record(kind="event", category="system", action="slot.state",
+                           target=f"s{i}", actor="system", severity="info", outcome=None,
+                           message=str(i))
+    rows = store.query(limit=2)
+    assert [r["target"] for r in rows] == ["s4", "s3"]
+
+
+# ── audit_action confirmation guarantee ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_action_records_ok_on_success(store: AuditStore) -> None:
+    async with audit_action(store, category="slot", action="slot.edit_config",
+                            target="chat", actor="dashboard",
+                            before={"context_size": 4096}) as rec:
+        rec.after = {"context_size": 8192}
+    row = store.query()[0]
+    assert row["outcome"] == "ok"
+    assert row["severity"] == "ok"
+    assert json.loads(row["after"]) == {"context_size": 8192}
+    assert row["duration_ms"] is not None
+
+
+@pytest.mark.asyncio
+async def test_audit_action_records_error_and_reraises(store: AuditStore) -> None:
+    with pytest.raises(ValueError, match="boom"):
+        async with audit_action(store, category="slot", action="slot.delete",
+                                target="chat", actor="dashboard"):
+            raise ValueError("boom")
+    row = store.query()[0]
+    assert row["outcome"] == "error"
+    assert row["severity"] == "error"
+    assert "boom" in row["error"]
+
+
+# ── EventBus mirror ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_record_event_adapts_bus_event(store: AuditStore) -> None:
+    event = {
+        "id": 7,
+        "ts": "2026-06-14T00:00:00+00:00",
+        "type": "slot.state",
+        "severity": "warn",
+        "source": "slot:chat",
+        "message": "chat: ready → error",
+        "data": {"slot": "chat", "from": "ready", "to": "error"},
+    }
+    await store.record_event(event)
+    row = store.query()[0]
+    assert row["kind"] == "event"
+    assert row["action"] == "slot.state"
+    assert row["severity"] == "warn"
+    assert row["target"] == "chat"
+
+
+# ── retention ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_prune_drops_rows_older_than_retention(tmp_path: Path) -> None:
+    s = AuditStore(tmp_path / "activity.db", retention_days=7, max_rows=None)
+    s.init_schema()
+    # Hand-insert an ancient row + a fresh one.
+    await s.record(kind="event", category="system", action="slot.state", target="old",
+                   actor="system", severity="info", outcome=None, message="old")
+    with sqlite3.connect(s.db_path) as conn:
+        conn.execute("UPDATE audit SET ts = '2000-01-01T00:00:00+00:00' WHERE target='old'")
+        conn.commit()
+    await s.record(kind="event", category="system", action="slot.state", target="new",
+                   actor="system", severity="info", outcome=None, message="new")
+    dropped = await s.prune()
+    assert dropped == 1
+    assert {r["target"] for r in s.query()} == {"new"}
+
+
+@pytest.mark.asyncio
+async def test_prune_enforces_max_rows_keeping_newest(tmp_path: Path) -> None:
+    s = AuditStore(tmp_path / "activity.db", retention_days=3650, max_rows=3)
+    s.init_schema()
+    for i in range(6):
+        await s.record(kind="event", category="system", action="slot.state",
+                       target=f"s{i}", actor="system", severity="info", outcome=None,
+                       message=str(i))
+    await s.prune()
+    rows = s.query(limit=100)
+    assert [r["target"] for r in rows] == ["s5", "s4", "s3"]
+
+
+# ── export ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_export_json_and_csv(store: AuditStore) -> None:
+    await store.record(kind="action", category="slot", action="slot.load", target="chat",
+                       actor="dashboard", severity="ok", outcome="ok", message="loaded chat")
+    blob = store.export(fmt="json")
+    assert json.loads(blob)[0]["action"] == "slot.load"
+    csv_blob = store.export(fmt="csv")
+    assert "slot.load" in csv_blob
+    assert csv_blob.splitlines()[0].startswith("id,ts,kind,category,action")
+
+
+# ── redaction ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_secret_values_are_redacted_in_before_after(store: AuditStore) -> None:
+    await store.record(kind="action", category="provider", action="provider.credential_write",
+                       target="openrouter", actor="dashboard", severity="ok", outcome="ok",
+                       message="set key", after={"api_key": "sk-supersecret-123"})
+    row = store.query()[0]
+    assert "supersecret" not in (row["after"] or "")

--- a/tests/api/test_activity.py
+++ b/tests/api/test_activity.py
@@ -1,0 +1,86 @@
+"""Tests for the durable /api/activity surface.
+
+The lifespan wires ``app.state.audit`` (an AuditStore) and mirrors every
+EventBus emit into it, so a freshly-booted client already carries the
+``system.restart`` boot event. We seed extra rows directly through the store
+to exercise the filter + export + epoch contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi.testclient import TestClient
+
+
+def _seed(client: TestClient, **kw) -> int:
+    """Record one row through the live store (async helper run to completion)."""
+    return asyncio.run(client.app.state.audit.record(**kw))
+
+
+def test_activity_returns_records_envelope_with_epoch(client: TestClient) -> None:
+    r = client.get("/api/activity")
+    assert r.status_code == 200
+    body = r.json()
+    assert "records" in body and "next_since" in body and "epoch" in body
+    assert isinstance(body["epoch"], str) and body["epoch"]
+    # The boot system.restart event was mirrored into the durable store.
+    actions = {rec["action"] for rec in body["records"]}
+    assert "system.restart" in actions
+
+
+def test_activity_filters_by_severity(client: TestClient) -> None:
+    _seed(client, kind="action", category="slot", action="slot.load", target="npu",
+          actor="dashboard", severity="error", outcome="error", message="OOM", error="OOM")
+    r = client.get("/api/activity", params={"severity": "error"})
+    assert r.status_code == 200
+    recs = r.json()["records"]
+    assert recs and all(x["severity"] == "error" for x in recs)
+    assert any(x["target"] == "npu" for x in recs)
+
+
+def test_activity_filters_by_category_and_kind(client: TestClient) -> None:
+    _seed(client, kind="action", category="profile", action="profile.create", target="p1",
+          actor="dashboard", severity="ok", outcome="ok", message="created p1")
+    r = client.get("/api/activity", params={"category": "profile", "kind": "action"})
+    recs = r.json()["records"]
+    assert recs and all(x["category"] == "profile" for x in recs)
+
+
+def test_activity_rejects_invalid_severity(client: TestClient) -> None:
+    r = client.get("/api/activity", params={"severity": "bogus"})
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "activity.invalid_query"
+
+
+def test_activity_since_cursor_advances(client: TestClient) -> None:
+    first = client.get("/api/activity").json()
+    nxt = first["next_since"]
+    _seed(client, kind="action", category="model", action="model.delete", target="qwen",
+          actor="cli", severity="ok", outcome="ok", message="deleted qwen")
+    r = client.get("/api/activity", params={"since": nxt})
+    recs = r.json()["records"]
+    assert [x["action"] for x in recs] == ["model.delete"]
+
+
+def test_activity_export_csv(client: TestClient) -> None:
+    _seed(client, kind="action", category="slot", action="slot.restart", target="chat",
+          actor="dashboard", severity="ok", outcome="ok", message="restarted chat")
+    r = client.get("/api/activity/export", params={"fmt": "csv"})
+    assert r.status_code == 200
+    assert "text/csv" in r.headers["content-type"]
+    assert "attachment" in r.headers.get("content-disposition", "")
+    assert r.text.splitlines()[0].startswith("id,ts,kind,category,action")
+    assert "slot.restart" in r.text
+
+
+def test_activity_export_json(client: TestClient) -> None:
+    r = client.get("/api/activity/export", params={"fmt": "json"})
+    assert r.status_code == 200
+    assert "application/json" in r.headers["content-type"]
+
+
+def test_activity_epoch_is_stable_within_process(client: TestClient) -> None:
+    a = client.get("/api/activity").json()["epoch"]
+    b = client.get("/api/activity").json()["epoch"]
+    assert a == b

--- a/tests/api/test_activity.py
+++ b/tests/api/test_activity.py
@@ -30,8 +30,18 @@ def test_activity_returns_records_envelope_with_epoch(client: TestClient) -> Non
 
 
 def test_activity_filters_by_severity(client: TestClient) -> None:
-    _seed(client, kind="action", category="slot", action="slot.load", target="npu",
-          actor="dashboard", severity="error", outcome="error", message="OOM", error="OOM")
+    _seed(
+        client,
+        kind="action",
+        category="slot",
+        action="slot.load",
+        target="npu",
+        actor="dashboard",
+        severity="error",
+        outcome="error",
+        message="OOM",
+        error="OOM",
+    )
     r = client.get("/api/activity", params={"severity": "error"})
     assert r.status_code == 200
     recs = r.json()["records"]
@@ -40,8 +50,17 @@ def test_activity_filters_by_severity(client: TestClient) -> None:
 
 
 def test_activity_filters_by_category_and_kind(client: TestClient) -> None:
-    _seed(client, kind="action", category="profile", action="profile.create", target="p1",
-          actor="dashboard", severity="ok", outcome="ok", message="created p1")
+    _seed(
+        client,
+        kind="action",
+        category="profile",
+        action="profile.create",
+        target="p1",
+        actor="dashboard",
+        severity="ok",
+        outcome="ok",
+        message="created p1",
+    )
     r = client.get("/api/activity", params={"category": "profile", "kind": "action"})
     recs = r.json()["records"]
     assert recs and all(x["category"] == "profile" for x in recs)
@@ -56,16 +75,34 @@ def test_activity_rejects_invalid_severity(client: TestClient) -> None:
 def test_activity_since_cursor_advances(client: TestClient) -> None:
     first = client.get("/api/activity").json()
     nxt = first["next_since"]
-    _seed(client, kind="action", category="model", action="model.delete", target="qwen",
-          actor="cli", severity="ok", outcome="ok", message="deleted qwen")
+    _seed(
+        client,
+        kind="action",
+        category="model",
+        action="model.delete",
+        target="qwen",
+        actor="cli",
+        severity="ok",
+        outcome="ok",
+        message="deleted qwen",
+    )
     r = client.get("/api/activity", params={"since": nxt})
     recs = r.json()["records"]
     assert [x["action"] for x in recs] == ["model.delete"]
 
 
 def test_activity_export_csv(client: TestClient) -> None:
-    _seed(client, kind="action", category="slot", action="slot.restart", target="chat",
-          actor="dashboard", severity="ok", outcome="ok", message="restarted chat")
+    _seed(
+        client,
+        kind="action",
+        category="slot",
+        action="slot.restart",
+        target="chat",
+        actor="dashboard",
+        severity="ok",
+        outcome="ok",
+        message="restarted chat",
+    )
     r = client.get("/api/activity/export", params={"fmt": "csv"})
     assert r.status_code == 200
     assert "text/csv" in r.headers["content-type"]

--- a/tests/api/test_activity_instrumentation.py
+++ b/tests/api/test_activity_instrumentation.py
@@ -1,0 +1,33 @@
+"""Integration tests: mutation routes write durable audit rows.
+
+We exercise the error path (deleting an unknown slot raises a typed error)
+because it needs no slot seeding and proves the audit_action wrapper records
+a truthful ``outcome=error`` and re-raises so the normal envelope still fires.
+The ok path is unit-covered in tests/activity/test_store.py.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def _activity(client: TestClient, **params):
+    return client.get("/api/activity", params=params).json()["records"]
+
+
+def test_delete_unknown_slot_records_error_outcome(client: TestClient) -> None:
+    r = client.delete("/api/slots/__nope__")
+    assert r.status_code >= 400  # typed error surfaced
+    rows = _activity(client, action="slot.delete")
+    assert rows, "expected a slot.delete audit row"
+    row = rows[0]
+    assert row["outcome"] == "error"
+    assert row["severity"] == "error"
+    assert row["target"] == "__nope__"
+    assert row["actor"] == "dashboard"
+
+
+def test_actor_from_agent_header(client: TestClient) -> None:
+    client.delete("/api/slots/__nope2__", headers={"X-hal0-Agent": "claude-dev"})
+    rows = _activity(client, action="slot.delete", actor="mcp:claude-dev")
+    assert rows and rows[0]["target"] == "__nope2__"

--- a/tests/api/test_activity_routes_instrumented.py
+++ b/tests/api/test_activity_routes_instrumented.py
@@ -1,0 +1,129 @@
+"""Integration tests: the remaining config-mutating routes write durable audit rows.
+
+Mirrors ``tests/api/test_activity_instrumentation.py`` (the slots exemplar): each
+test drives the ERROR path of an instrumented endpoint — which needs no seeding —
+and asserts a durable ``outcome=error`` row lands with the right target. This proves
+the :func:`hal0.api._audit.record_action` wrapper records denied/failed actions and
+re-raises so the normal error envelope still fires.
+
+Covers: profiles (create/update/delete), capabilities (apply), approvals
+(approve/deny), models (delete).
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def _activity(client: TestClient, **params):
+    return client.get("/api/activity", params=params).json()["records"]
+
+
+# ── profiles ────────────────────────────────────────────────────────────────
+
+
+def test_delete_unknown_profile_records_error(client: TestClient) -> None:
+    r = client.delete("/api/profiles/__nope__")
+    assert r.status_code >= 400
+    rows = _activity(client, action="profile.delete")
+    assert rows, "expected a profile.delete audit row"
+    row = rows[0]
+    assert row["outcome"] == "error"
+    assert row["severity"] == "error"
+    assert row["target"] == "__nope__"
+    assert row["actor"] == "dashboard"
+
+
+def test_update_unknown_profile_records_error(client: TestClient) -> None:
+    # Unknown custom profile → 404 profiles.not_found, raised inside the wrap.
+    r = client.put("/api/profiles/__nope__", json={"image": "ghcr.io/x:y"})
+    assert r.status_code >= 400
+    rows = _activity(client, action="profile.update")
+    assert rows, "expected a profile.update audit row"
+    assert rows[0]["outcome"] == "error"
+    assert rows[0]["target"] == "__nope__"
+
+
+def test_create_duplicate_profile_records_error(client: TestClient) -> None:
+    # Re-creating a seed profile name → 409 profiles.exists, inside the wrap.
+    # 'rocm' is a seed profile, so create collides.
+    r = client.post(
+        "/api/profiles",
+        json={"name": "rocm", "image": "ghcr.io/x:y"},
+    )
+    assert r.status_code >= 400
+    rows = _activity(client, action="profile.create")
+    assert rows, "expected a profile.create audit row"
+    assert rows[0]["outcome"] == "error"
+    assert rows[0]["target"] == "rocm"
+
+
+def test_create_profile_records_ok(client: TestClient) -> None:
+    # Happy path is cheap to seed (no slots needed) — assert outcome=ok + after.
+    r = client.post(
+        "/api/profiles",
+        json={
+            "name": "auditprof",
+            "image": "ghcr.io/hal0ai/x:rocm",
+            "device_class": "gpu",
+        },
+    )
+    assert r.status_code == 201, r.text
+    rows = _activity(client, action="profile.create")
+    ok = [row for row in rows if row["target"] == "auditprof"]
+    assert ok, "expected a profile.create ok row"
+    assert ok[0]["outcome"] == "ok"
+    assert ok[0]["severity"] == "ok"
+
+
+# ── capabilities ─────────────────────────────────────────────────────────────
+
+
+def test_apply_capability_unknown_model_records_error(client: TestClient) -> None:
+    # Valid slot/child (passes route-level validation) but a bogus model →
+    # orchestrator.apply raises catalog validation inside the wrap.
+    r = client.post("/api/capabilities/embed/embed", json={"model": "__nope__"})
+    assert r.status_code >= 400
+    rows = _activity(client, action="capability.apply")
+    assert rows, "expected a capability.apply audit row"
+    assert rows[0]["outcome"] == "error"
+    assert rows[0]["target"] == "embed/embed"
+
+
+# ── approvals ────────────────────────────────────────────────────────────────
+
+
+def test_approve_unknown_approval_records_error(client: TestClient) -> None:
+    r = client.post("/api/agent/approvals/__nope__/approve")
+    assert r.status_code >= 400
+    rows = _activity(client, action="approval.approve")
+    assert rows, "expected an approval.approve audit row"
+    assert rows[0]["outcome"] == "error"
+    assert rows[0]["target"] == "__nope__"
+
+
+def test_deny_unknown_approval_records_error(client: TestClient) -> None:
+    r = client.post("/api/agent/approvals/__nope__/deny")
+    assert r.status_code >= 400
+    rows = _activity(client, action="approval.deny")
+    assert rows, "expected an approval.deny audit row"
+    assert rows[0]["outcome"] == "error"
+    assert rows[0]["target"] == "__nope__"
+
+
+# ── models ───────────────────────────────────────────────────────────────────
+
+
+def test_delete_unknown_model_records_error(client: TestClient) -> None:
+    r = client.delete("/api/models/__nope__")
+    assert r.status_code >= 400
+    rows = _activity(client, action="model.delete")
+    assert rows, "expected a model.delete audit row"
+    assert rows[0]["outcome"] == "error"
+    assert rows[0]["target"] == "__nope__"
+
+
+def test_actor_from_agent_header_on_profile_delete(client: TestClient) -> None:
+    client.delete("/api/profiles/__hdr__", headers={"X-hal0-Agent": "claude-dev"})
+    rows = _activity(client, action="profile.delete", actor="mcp:claude-dev")
+    assert rows and rows[0]["target"] == "__hdr__"

--- a/tests/api/test_events.py
+++ b/tests/api/test_events.py
@@ -232,7 +232,7 @@ async def test_stream_replay_then_live() -> None:
             async def is_disconnected(self) -> bool:
                 return False
 
-        resp = await stream_events(_StubRequest(), since=None)  # type: ignore[arg-type]
+        resp = await stream_events(_StubRequest(), since=None, type=None, severity=None)  # type: ignore[arg-type]
         gen = resp.body_iterator
 
         # Drain the replay frames (system.restart + first + second).
@@ -300,7 +300,7 @@ async def test_stream_since_skips_backfill() -> None:
             async def is_disconnected(self) -> bool:
                 return False
 
-        resp = await stream_events(_StubRequest(), since=cursor)  # type: ignore[arg-type]
+        resp = await stream_events(_StubRequest(), since=cursor, type=None, severity=None)  # type: ignore[arg-type]
         gen = resp.body_iterator
 
         async def _drain_one(*, timeout: float = 3.0) -> list[dict[str, Any]]:

--- a/tests/api/test_events_fixes.py
+++ b/tests/api/test_events_fixes.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 import pytest

--- a/tests/api/test_events_fixes.py
+++ b/tests/api/test_events_fixes.py
@@ -1,0 +1,91 @@
+"""Regression tests for the events surface fixes (B8 epoch, B10 stream filters)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.api.routes.events import stream_events
+from hal0.events import EventBus
+
+
+def test_list_events_includes_epoch(client: TestClient) -> None:
+    """B8: /api/events advertises a per-process epoch so a client can detect a
+    restart (ids reset to 1) and rewind its cursor."""
+    body = client.get("/api/events").json()
+    assert "epoch" in body and isinstance(body["epoch"], str) and body["epoch"]
+
+
+def test_epoch_differs_across_process_instances() -> None:
+    """Two app instances (≈ two boots) carry distinct epochs."""
+    a = create_app()
+    b = create_app()
+    with TestClient(a) as ca, TestClient(b) as cb:
+        ea = ca.get("/api/events").json()["epoch"]
+        eb = cb.get("/api/events").json()["epoch"]
+        assert ea and eb and ea != eb
+
+
+def _parse(buf: str) -> list[dict[str, Any]]:
+    import json
+
+    out = []
+    for frame in buf.split("\n\n"):
+        line = frame.strip()
+        if line.startswith("data: "):
+            out.append(json.loads(line[6:]))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_stream_severity_filter_excludes_lower() -> None:
+    """B10: /api/events/stream?severity=error replays only error+ frames."""
+    app = create_app()
+    async with app.router.lifespan_context(app):  # type: ignore[attr-defined]
+        bus: EventBus = app.state.events
+        await bus.emit("slot.state", "info", "slot:a", "info-msg")
+        await bus.emit("slot.state", "error", "slot:a", "error-msg")
+
+        class _Stub:
+            def __init__(self) -> None:
+                self.app = app
+
+            async def is_disconnected(self) -> bool:
+                return True  # stop after backfill
+
+        resp = await stream_events(_Stub(), since=None, type=None, severity="error")  # type: ignore[arg-type]
+        buf = ""
+        async for chunk in resp.body_iterator:
+            buf += chunk.decode() if isinstance(chunk, bytes) else str(chunk)
+        msgs = [e["message"] for e in _parse(buf)]
+        assert "error-msg" in msgs
+        assert "info-msg" not in msgs
+
+
+@pytest.mark.asyncio
+async def test_stream_type_glob_filter() -> None:
+    """B10: /api/events/stream?type=slot.* drops non-matching frames."""
+    app = create_app()
+    async with app.router.lifespan_context(app):  # type: ignore[attr-defined]
+        bus: EventBus = app.state.events
+        await bus.emit("slot.state", "info", "slot:a", "slot-msg")
+        await bus.emit("pull.progress", "info", "pull:x", "pull-msg")
+
+        class _Stub:
+            def __init__(self) -> None:
+                self.app = app
+
+            async def is_disconnected(self) -> bool:
+                return True
+
+        resp = await stream_events(_Stub(), since=None, type="slot.*", severity=None)  # type: ignore[arg-type]
+        buf = ""
+        async for chunk in resp.body_iterator:
+            buf += chunk.decode() if isinstance(chunk, bytes) else str(chunk)
+        msgs = [e["message"] for e in _parse(buf)]
+        assert "slot-msg" in msgs
+        assert "pull-msg" not in msgs

--- a/tests/api/test_health_degraded.py
+++ b/tests/api/test_health_degraded.py
@@ -1,0 +1,50 @@
+"""B2: /api/health/system must report degraded when a slot is in ERROR.
+
+Previously the slot_manager check reported ok=True regardless of slot state,
+so a systemd-FAILED slot still rendered the whole system "ok" — the health
+endpoint lied.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hal0.slots.manager import Slot
+from hal0.slots.state import SlotState
+
+
+class _FakeSM:
+    def __init__(self, slots: list[Slot]) -> None:
+        self._slots = slots
+
+    async def list(self) -> list[Slot]:
+        return self._slots
+
+
+def _slot(name: str, state: SlotState) -> Slot:
+    return Slot(name=name, state=state)
+
+
+def test_health_system_ok_when_no_errored_slots(client: TestClient) -> None:
+    client.app.state.slot_manager = _FakeSM([
+        _slot("chat", SlotState.READY),
+        _slot("embed", SlotState.OFFLINE),
+    ])
+    body = client.get("/api/health/system").json()
+    assert body["status"] == "ok"
+    assert body["checks"]["slot_manager"]["ok"] is True
+    assert body["checks"]["slot_manager"]["errored"] == []
+
+
+def test_health_system_degraded_when_slot_errored(client: TestClient) -> None:
+    client.app.state.slot_manager = _FakeSM([
+        _slot("chat", SlotState.READY),
+        _slot("npu", SlotState.ERROR),
+    ])
+    body = client.get("/api/health/system").json()
+    assert body["status"] == "degraded"
+    assert body["checks"]["slot_manager"]["ok"] is False
+    assert body["checks"]["slot_manager"]["errored"] == ["npu"]

--- a/tests/api/test_health_degraded.py
+++ b/tests/api/test_health_degraded.py
@@ -7,9 +7,6 @@ endpoint lied.
 
 from __future__ import annotations
 
-from typing import Any
-
-import pytest
 from fastapi.testclient import TestClient
 
 from hal0.slots.manager import Slot
@@ -29,10 +26,12 @@ def _slot(name: str, state: SlotState) -> Slot:
 
 
 def test_health_system_ok_when_no_errored_slots(client: TestClient) -> None:
-    client.app.state.slot_manager = _FakeSM([
-        _slot("chat", SlotState.READY),
-        _slot("embed", SlotState.OFFLINE),
-    ])
+    client.app.state.slot_manager = _FakeSM(
+        [
+            _slot("chat", SlotState.READY),
+            _slot("embed", SlotState.OFFLINE),
+        ]
+    )
     body = client.get("/api/health/system").json()
     assert body["status"] == "ok"
     assert body["checks"]["slot_manager"]["ok"] is True
@@ -40,10 +39,12 @@ def test_health_system_ok_when_no_errored_slots(client: TestClient) -> None:
 
 
 def test_health_system_degraded_when_slot_errored(client: TestClient) -> None:
-    client.app.state.slot_manager = _FakeSM([
-        _slot("chat", SlotState.READY),
-        _slot("npu", SlotState.ERROR),
-    ])
+    client.app.state.slot_manager = _FakeSM(
+        [
+            _slot("chat", SlotState.READY),
+            _slot("npu", SlotState.ERROR),
+        ]
+    )
     body = client.get("/api/health/system").json()
     assert body["status"] == "degraded"
     assert body["checks"]["slot_manager"]["ok"] is False

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -198,6 +198,21 @@ export const ENDPOINTS = {
   journal: '/api/journal',
   journalStream: '/api/journal/stream',
 
+  // ── Activity log (durable structured audit trail) ────────────────
+  // Backfill + SSE tail + export, all honouring the same filter set
+  // (since/category/action/severity/outcome/actor/kind/search/limit).
+  // `epoch` rides every payload: a per-process id that, when it CHANGES
+  // between polls, means the backend restarted → reset the `since`
+  // cursor to 0 (fixes the footer-blank-after-restart bug).
+  activity: '/api/activity',
+  activityStream: '/api/activity/stream',
+  activityExport: '/api/activity/export',
+
+  // ── System health (honest degraded probe) ───────────────────────
+  // {status:"ok"|"degraded", checks:{...}} — drives the runtime chip
+  // colour + a tooltip listing failing checks (B12).
+  healthSystem: '/api/health/system',
+
   // ── Settings (hal0.toml read/write) ──────────────────────────────
   settings: '/api/settings',
   settingsReload: '/api/settings/reload',

--- a/ui/src/api/hooks/useActivity.ts
+++ b/ui/src/api/hooks/useActivity.ts
@@ -1,0 +1,242 @@
+// hal0 v3 dashboard — activity-log hook (durable structured audit trail).
+//
+// Backs the sidebar ActivityLog pane on the Slots page. Mirrors the
+// `useLogs` journal hook in shape, against the `/api/activity` surface:
+//   - GET  /api/activity         — historical backfill (one-shot, paged)
+//   - SSE  /api/activity/stream   — durable backfill then live tail
+//   - GET  /api/activity/export   — file download (csv|json), filters honoured
+//
+// Filter semantics: every filter (since/category/action/severity/outcome/
+// actor/kind/search/limit) is forwarded to the backend so the wire payload
+// is already filtered server-side. Callers MAY also filter the returned
+// records client-side for instant feedback without re-opening the SSE.
+//
+// Epoch handling: each payload carries an `epoch` (per-process id). When it
+// CHANGES between frames the backend restarted, so we reset the cursor to 0
+// and clear the ring — otherwise a stale `since` would silently skip the
+// backlog (the footer-blank-after-restart bug). The SSE reconnect uses the
+// same capped-backoff pattern as useLogs.
+
+import { useEffect, useRef, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { apiGet } from '../client'
+import { ENDPOINTS } from '../endpoints'
+
+/** A single activity record — mirrors the backend record shape. */
+export interface ActivityRecord {
+  id: number
+  ts: string
+  kind: 'action' | 'event'
+  category: string
+  /** Dotted action, e.g. "slot.edit_config". */
+  action: string
+  target: string | null
+  actor: 'dashboard' | 'cli' | string // also "mcp:<agent>" | "system"
+  severity: 'info' | 'warn' | 'error' | 'ok'
+  outcome: 'ok' | 'error' | 'pending' | null
+  message: string
+  before: Record<string, unknown> | null
+  after: Record<string, unknown> | null
+  error: string | null
+  duration_ms: number | null
+  request_id: string | null
+}
+
+export type ActivitySeverity = 'info' | 'warn' | 'error' | 'ok'
+
+/** Newest-first ring cap — bounded so a burst can't make the pane a
+ *  firehose. The export button is the escape hatch for full history. */
+export const ACTIVITY_RING_MAX = 200
+/** Debounce SSE reconnect on rapid filter chip toggling. */
+const SSE_RECONNECT_DEBOUNCE_MS = 200
+
+export interface ActivityFilters {
+  since?: number | null
+  category?: string | null
+  action?: string | null
+  severity?: ActivitySeverity | null
+  outcome?: string | null
+  actor?: string | null
+  kind?: 'action' | 'event' | null
+  search?: string | null
+  limit?: number | null
+}
+
+/** Build the shared `?…` query string from a filter set. */
+export function buildActivityQuery(opts: ActivityFilters): string {
+  const params = new URLSearchParams()
+  if (opts.since != null) params.set('since', String(opts.since))
+  if (opts.category) params.set('category', opts.category)
+  if (opts.action) params.set('action', opts.action)
+  if (opts.severity) params.set('severity', opts.severity)
+  if (opts.outcome) params.set('outcome', opts.outcome)
+  if (opts.actor) params.set('actor', opts.actor)
+  if (opts.kind) params.set('kind', opts.kind)
+  if (opts.search) params.set('search', opts.search)
+  if (opts.limit != null) params.set('limit', String(opts.limit))
+  const qs = params.toString()
+  return qs ? `?${qs}` : ''
+}
+
+/** A direct (non-hook) URL builder for the export link / download. */
+export function activityExportUrl(fmt: 'csv' | 'json', filters: ActivityFilters): string {
+  const params = new URLSearchParams(buildActivityQuery(filters).replace(/^\?/, ''))
+  params.set('fmt', fmt)
+  return `${ENDPOINTS.activityExport}?${params.toString()}`
+}
+
+export interface ActivityEnvelope {
+  records: ActivityRecord[]
+  next_since: number | null
+  epoch: string | null
+}
+
+export interface UseActivityHistoricalOptions extends ActivityFilters {
+  /** When false the query is disabled. */
+  enabled?: boolean
+}
+
+/**
+ * One-shot historical backfill. Returns the parsed envelope so callers can
+ * advance a cursor (`next_since`) and detect an epoch change.
+ */
+export function useActivityHistorical(opts: UseActivityHistoricalOptions = {}) {
+  const { enabled = true, ...filters } = opts
+  return useQuery({
+    queryKey: ['activity', 'historical', filters],
+    enabled,
+    queryFn: async (): Promise<ActivityEnvelope> => {
+      const qs = buildActivityQuery(filters)
+      const body = await apiGet<Partial<ActivityEnvelope> & ActivityRecord[]>(
+        `${ENDPOINTS.activity}${qs}`,
+      )
+      // Guard against a bare-array (older/mocked) payload.
+      if (Array.isArray(body)) {
+        return { records: body as ActivityRecord[], next_since: null, epoch: null }
+      }
+      return {
+        records: Array.isArray(body?.records) ? body.records : [],
+        next_since: body?.next_since ?? null,
+        epoch: body?.epoch ?? null,
+      }
+    },
+  })
+}
+
+export interface UseActivityStreamOptions extends ActivityFilters {
+  /** When false, no SSE connection is opened. Defaults to true. */
+  follow?: boolean
+}
+
+export interface ActivityStreamResult {
+  /** Live ring, NEWEST-FIRST, capped at ACTIVITY_RING_MAX. */
+  records: ActivityRecord[]
+  /** True when the SSE is down / reconnecting. */
+  disconnected: boolean
+  /** Latest epoch seen — exposed for debugging / display. */
+  epoch: string | null
+}
+
+/**
+ * SSE tail. The backend replays a durable backfill then live-tails, all
+ * filtered server-side. Returns the ring newest-first so the pane renders
+ * most-recent-at-top without re-sorting on every frame.
+ *
+ * Reconnects on any filter change with a 200ms debounce so a fast cascade
+ * of chip clicks coalesces into one new connection. On an `epoch` change
+ * the ring is cleared (backend restarted — the stream replays fresh).
+ */
+export function useActivityStream(opts: UseActivityStreamOptions = {}): ActivityStreamResult {
+  const { follow = true, ...filters } = opts
+  const [records, setRecords] = useState<ActivityRecord[]>([])
+  const [disconnected, setDisconnected] = useState(false)
+  const [epoch, setEpoch] = useState<string | null>(null)
+  const esRef = useRef<EventSource | null>(null)
+  const epochRef = useRef<string | null>(null)
+  const errorCountRef = useRef(0)
+
+  const push = (record: ActivityRecord) => {
+    setRecords((prev) => {
+      // Dedup by id (durable backfill can overlap a reconnect replay).
+      if (record.id != null && prev.some((r) => r.id === record.id)) return prev
+      const next = [record, ...prev]
+      return next.length > ACTIVITY_RING_MAX ? next.slice(0, ACTIVITY_RING_MAX) : next
+    })
+  }
+
+  // Stable filter key so the effect only re-subscribes on a real change.
+  const filterKey = JSON.stringify(filters)
+
+  useEffect(() => {
+    if (!follow) {
+      if (esRef.current) {
+        esRef.current.close()
+        esRef.current = null
+      }
+      return
+    }
+
+    let cancelled = false
+    let backoffTimer: ReturnType<typeof setTimeout> | null = null
+
+    const connect = () => {
+      if (cancelled) return
+      try {
+        const url = `${ENDPOINTS.activityStream}${buildActivityQuery(filters)}`
+        esRef.current = new EventSource(url)
+      } catch {
+        setDisconnected(true)
+        return
+      }
+      const es = esRef.current
+      if (!es) return
+      es.onmessage = (evt) => {
+        try {
+          const frame = JSON.parse(evt.data) as { record?: ActivityRecord; epoch?: string }
+          const ep = frame?.epoch ?? null
+          if (ep && ep !== epochRef.current) {
+            // Backend restarted → fresh stream. Reset cursor + ring.
+            if (epochRef.current != null) setRecords([])
+            epochRef.current = ep
+            setEpoch(ep)
+          }
+          const record = frame?.record
+          if (record && record.ts && record.message != null) push(record)
+        } catch {
+          // ignore malformed frame
+        }
+      }
+      es.onerror = () => {
+        setDisconnected(true)
+        errorCountRef.current += 1
+        if (esRef.current) {
+          esRef.current.close()
+          esRef.current = null
+        }
+        const delay = Math.min(1000 * 2 ** Math.min(errorCountRef.current - 1, 4), 16_000)
+        backoffTimer = setTimeout(connect, delay)
+      }
+      es.onopen = () => {
+        setDisconnected(false)
+        errorCountRef.current = 0
+      }
+    }
+
+    const debounceTimer = setTimeout(connect, SSE_RECONNECT_DEBOUNCE_MS)
+
+    return () => {
+      cancelled = true
+      clearTimeout(debounceTimer)
+      if (backoffTimer) clearTimeout(backoffTimer)
+      if (esRef.current) {
+        esRef.current.close()
+        esRef.current = null
+      }
+    }
+    // filterKey collapses the filter object into a stable dep; follow
+    // toggles the connection on/off.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [follow, filterKey])
+
+  return { records, disconnected, epoch }
+}

--- a/ui/src/api/hooks/useActivity.ts
+++ b/ui/src/api/hooks/useActivity.ts
@@ -107,17 +107,16 @@ export function useActivityHistorical(opts: UseActivityHistoricalOptions = {}) {
     enabled,
     queryFn: async (): Promise<ActivityEnvelope> => {
       const qs = buildActivityQuery(filters)
-      const body = await apiGet<Partial<ActivityEnvelope> & ActivityRecord[]>(
-        `${ENDPOINTS.activity}${qs}`,
-      )
+      const body = await apiGet<unknown>(`${ENDPOINTS.activity}${qs}`)
       // Guard against a bare-array (older/mocked) payload.
       if (Array.isArray(body)) {
         return { records: body as ActivityRecord[], next_since: null, epoch: null }
       }
+      const env = (body ?? {}) as Partial<ActivityEnvelope>
       return {
-        records: Array.isArray(body?.records) ? body.records : [],
-        next_since: body?.next_since ?? null,
-        epoch: body?.epoch ?? null,
+        records: Array.isArray(env.records) ? env.records : [],
+        next_since: env.next_since ?? null,
+        epoch: env.epoch ?? null,
       }
     },
   })

--- a/ui/src/api/hooks/useRuntime.ts
+++ b/ui/src/api/hooks/useRuntime.ts
@@ -5,6 +5,9 @@
 // container, so "runtime up" simply means the slots query resolves and
 // readiness counts come from per-slot container_status/state.
 
+import { useQuery } from '@tanstack/react-query'
+import { apiGet } from '../client'
+import { ENDPOINTS } from '../endpoints'
 import { useSlots, type Slot } from './useSlots'
 
 /** A slot counts as ready when its container is running or its state
@@ -43,4 +46,60 @@ export function useRuntimeRollup(): RuntimeRollup {
     total: enabled.length,
     loaded: ready,
   }
+}
+
+// ─── B12: honest system-health probe ─────────────────────────────────
+// The runtime rollup above only knows whether /api/slots resolved — it
+// can't see a runtime that is up-but-degraded (e.g. a failed dependency
+// check). /api/health/system is the honest signal: it returns an overall
+// `status` plus a per-check map so the chip can colour amber on degraded
+// and tooltip the failing checks.
+
+export interface HealthCheck {
+  /** Per-check status. Anything other than 'ok' is treated as failing. */
+  status: 'ok' | 'degraded' | 'error' | string
+  /** Optional human detail for the tooltip. */
+  detail?: string | null
+  [k: string]: unknown
+}
+
+export interface HealthSystem {
+  status: 'ok' | 'degraded'
+  checks: Record<string, HealthCheck>
+}
+
+function normalizeHealth(raw: any): HealthSystem {
+  const checks: Record<string, HealthCheck> =
+    raw && typeof raw.checks === 'object' && raw.checks ? raw.checks : {}
+  // Default to 'ok' when the endpoint is missing/empty (older backend) so
+  // the chip doesn't false-alarm degraded on a partial deploy.
+  const status = raw?.status === 'degraded' ? 'degraded' : 'ok'
+  return { status, checks }
+}
+
+/** Names of checks not reporting 'ok' — drives the degraded tooltip. */
+export function failingChecks(health: HealthSystem | undefined): string[] {
+  if (!health) return []
+  return Object.entries(health.checks)
+    .filter(([, c]) => c && c.status !== 'ok')
+    .map(([name, c]) => (c?.detail ? `${name}: ${c.detail}` : name))
+}
+
+const HEALTH_POLL_MS = 10_000
+
+/**
+ * Polls /api/health/system. Fail-soft: a 404 / network error from an older
+ * backend resolves to an 'ok' status with no checks (the query's error is
+ * still surfaced via `isError` for callers that care), so the runtime chip
+ * never flips to a false "degraded".
+ */
+export function useHealthSystem() {
+  return useQuery({
+    queryKey: ['health', 'system'],
+    queryFn: async () => normalizeHealth(await apiGet<any>(ENDPOINTS.healthSystem)),
+    refetchInterval: HEALTH_POLL_MS,
+    // Treat the endpoint as best-effort — don't spam retries on a backend
+    // that doesn't ship it yet.
+    retry: false,
+  })
 }

--- a/ui/src/dash/activity-log.css
+++ b/ui/src/dash/activity-log.css
@@ -1,0 +1,235 @@
+/* hal0 v3 dashboard — ActivityLog sidebar pane.
+ *
+ * Plain global `.act-*` classes (imported from main.tsx, mirroring the
+ * comfyui-pane.css / engine-panes.css side-effect pattern). Reuses the
+ * dashboard.css severity vars (--ok/--warn/--err/--accent/--fg-*) and the
+ * `.side-card` shell. Bounded scroll body + sticky filter bar at the top.
+ */
+
+.act-card {
+  display: flex;
+  flex-direction: column;
+  /* The card never grows unbounded — the body owns the scroll. */
+  max-height: 560px;
+}
+
+/* ── header ─────────────────────────────────────────────────────── */
+.act-h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--line-soft);
+  font-family: var(--jbm);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--fg-3);
+}
+.act-title { color: var(--fg-3); }
+.act-ct {
+  color: var(--fg-4);
+  text-transform: none;
+  letter-spacing: 0;
+}
+.act-conn {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--ok);
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 10.5px;
+}
+.act-conn.off { color: var(--warn); }
+.act-conn .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.act-conn .dot.ready { box-shadow: 0 0 7px var(--ok); }
+
+/* ── sticky filter bar ──────────────────────────────────────────── */
+.act-filters {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line-soft);
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.act-chips {
+  display: inline-flex;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  overflow: hidden;
+  width: fit-content;
+}
+.act-chip {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--line);
+  color: var(--fg-3);
+  font-family: var(--jbm);
+  font-size: 10.5px;
+  padding: 3px 9px;
+  cursor: pointer;
+  transition: color 0.12s ease, background 0.12s ease;
+}
+.act-chip:last-child { border-right: none; }
+.act-chip:hover { color: var(--fg); }
+/* On-state uses the chip's OWN severity tone so the active filter reads
+   as the colour it selects. */
+.act-chip.on { color: var(--accent); background: var(--accent-soft); }
+.act-chip-ok.on { color: var(--ok); background: var(--ok-soft); }
+.act-chip-info.on { color: var(--fg-2); background: rgba(255, 255, 255, 0.04); }
+.act-chip-warn.on { color: var(--warn); background: var(--warn-soft); }
+.act-chip-error.on { color: var(--err); background: var(--err-soft); }
+
+.act-filters-row {
+  display: flex;
+  gap: 7px;
+}
+.act-cat,
+.act-search {
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--fg-2);
+  font-family: var(--jbm);
+  font-size: 11px;
+  padding: 4px 8px;
+  outline: none;
+}
+.act-cat { flex: 0 0 auto; }
+.act-search { flex: 1 1 auto; min-width: 0; }
+.act-cat:focus,
+.act-search:focus { border-color: var(--accent-line); }
+.act-search::placeholder { color: var(--fg-4); }
+
+/* ── bounded scroll body ────────────────────────────────────────── */
+.act-body {
+  flex: 1 1 auto;
+  min-height: 120px;
+  max-height: 420px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  font-family: var(--jbm);
+}
+/* Hover-pause indicator (subtle — the auto-scroll logic lives in JS, this
+   just hints the pane is "held"). */
+.act-body.paused { scroll-behavior: auto; }
+
+.act-empty {
+  padding: 22px 16px;
+  text-align: center;
+  color: var(--fg-4);
+  font-size: 11.5px;
+}
+.act-clear {
+  appearance: none;
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+}
+
+/* ── a row ──────────────────────────────────────────────────────── */
+.act-line {
+  display: grid;
+  grid-template-columns: auto auto auto minmax(0, 1fr);
+  align-items: baseline;
+  gap: 6px;
+  padding: 4px 12px 4px 10px;
+  border-left: 2px solid transparent;
+  font-size: 11px;
+  line-height: 1.45;
+  border-bottom: 1px solid var(--line-soft);
+}
+.act-line:hover { background: rgba(255, 255, 255, 0.02); }
+.act-line.ok { border-left-color: var(--ok); }
+.act-line.warn { border-left-color: var(--warn); }
+.act-line.error { border-left-color: var(--err); background: var(--err-soft); }
+.act-line.info { border-left-color: var(--line-strong); }
+
+.act-ts {
+  color: var(--fg-5);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.act-glyph {
+  font-weight: 700;
+  text-align: center;
+  width: 1em;
+}
+.act-glyph.ok { color: var(--ok); }
+.act-glyph.warn { color: var(--warn); }
+.act-glyph.error { color: var(--err); }
+.act-glyph.info { color: var(--fg-4); }
+
+.act-actor {
+  color: var(--accent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 90px;
+}
+/* The action + target + message wrap onto the grid's 4th (flex) column so
+   the meta columns stay aligned and only the prose truncates. */
+.act-action {
+  grid-column: 4;
+  color: var(--fg-2);
+  font-size: 10.5px;
+}
+.act-target {
+  grid-column: 4;
+  color: var(--fg-3);
+  font-size: 10.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.act-msg {
+  grid-column: 4;
+  color: var(--fg-3);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.act-line.error .act-msg { color: var(--err); }
+.act-line.ok .act-msg { color: var(--fg-2); }
+
+/* ── export footer ──────────────────────────────────────────────── */
+.act-foot {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  border-top: 1px solid var(--line-soft);
+  font-size: 10.5px;
+}
+.act-foot-label {
+  color: var(--fg-4);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.act-export {
+  color: var(--fg-3);
+  text-decoration: none;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 2px 9px;
+  transition: color 0.12s ease, border-color 0.12s ease;
+}
+.act-export:hover {
+  color: var(--accent);
+  border-color: var(--accent-line);
+}

--- a/ui/src/dash/activity-log.jsx
+++ b/ui/src/dash/activity-log.jsx
@@ -13,21 +13,27 @@
 // button is the escape hatch for full history.
 //
 // Data: useActivityStream (durable backfill + live tail, epoch-aware) with
-// the active severity/kind filters forwarded server-side. Auto-scroll
+// the active severity/category filters forwarded server-side. Auto-scroll
 // pauses while the cursor hovers the list so a live tail can't yank the
 // row you're reading.
+//
+// NOTE: this is a `.jsx` file (no TS type annotations) — it sits in the
+// same component layer as slots.jsx / chrome.jsx. The typed contract lives
+// in the useActivity.ts hook.
 
 import { useMemo, useRef, useState } from 'react'
-import {
-  useActivityStream,
-  activityExportUrl,
-  type ActivityRecord,
-  type ActivitySeverity,
-} from '@/api/hooks/useActivity'
+import { useActivityStream, activityExportUrl } from '@/api/hooks/useActivity'
+
+// Normalize severity into one of the four CSS row classes.
+function sevOf(rec) {
+  const s = String(rec.severity || '').toLowerCase()
+  if (s === 'ok' || s === 'warn' || s === 'error' || s === 'info') return s
+  return 'info'
+}
 
 // Severity → outcome glyph + class. `ok` = ✓ green confirmation, `error`
 // = ✗ red, everything else = · neutral dot.
-function outcomeGlyph(rec: ActivityRecord): { glyph: string; cls: string } {
+function outcomeGlyph(rec) {
   const sev = sevOf(rec)
   if (sev === 'ok' || rec.outcome === 'ok') return { glyph: '✓', cls: 'ok' }
   if (sev === 'error' || rec.outcome === 'error') return { glyph: '✗', cls: 'error' }
@@ -36,15 +42,8 @@ function outcomeGlyph(rec: ActivityRecord): { glyph: string; cls: string } {
   return { glyph: '·', cls: 'info' }
 }
 
-// Normalize severity into one of the four CSS row classes.
-function sevOf(rec: ActivityRecord): 'ok' | 'warn' | 'error' | 'info' {
-  const s = String(rec.severity || '').toLowerCase()
-  if (s === 'ok' || s === 'warn' || s === 'error' || s === 'info') return s
-  return 'info'
-}
-
 // Short HH:MM:SS from an ISO/epoch ts; falls back to the raw string.
-function shortTime(ts: string): string {
+function shortTime(ts) {
   if (!ts) return ''
   const d = new Date(ts)
   if (!Number.isNaN(d.getTime())) {
@@ -55,13 +54,13 @@ function shortTime(ts: string): string {
 }
 
 // Compact actor label: "mcp:hermes" → "hermes (mcp)", else as-is.
-function actorLabel(actor: string): string {
+function actorLabel(actor) {
   if (!actor) return 'system'
   if (actor.startsWith('mcp:')) return `${actor.slice(4)} (mcp)`
   return actor
 }
 
-const SEVERITY_CHIPS: Array<{ key: 'all' | ActivitySeverity; label: string }> = [
+const SEVERITY_CHIPS = [
   { key: 'all', label: 'all' },
   { key: 'ok', label: 'ok' },
   { key: 'info', label: 'info' },
@@ -79,13 +78,13 @@ const CATEGORY_OPTIONS = [
 ]
 
 export function ActivityLog() {
-  const [severity, setSeverity] = useState<'all' | ActivitySeverity>('all')
-  const [category, setCategory] = useState<string>('all')
+  const [severity, setSeverity] = useState('all')
+  const [category, setCategory] = useState('all')
   const [search, setSearch] = useState('')
   // Auto-scroll-to-top pauses while hovering so a live frame can't yank
   // the row you're reading. (Newest-first → "scroll" is really the top.)
   const [paused, setPaused] = useState(false)
-  const listRef = useRef<HTMLDivElement | null>(null)
+  const listRef = useRef(null)
 
   const stream = useActivityStream({
     follow: true,
@@ -104,7 +103,8 @@ export function ActivityLog() {
       if (severity !== 'all' && sevOf(r) !== severity) return false
       if (category !== 'all' && r.category !== category) return false
       if (q) {
-        const hay = `${r.message || ''} ${r.action || ''} ${r.target || ''} ${r.actor || ''}`.toLowerCase()
+        const hay =
+          `${r.message || ''} ${r.action || ''} ${r.target || ''} ${r.actor || ''}`.toLowerCase()
         if (!hay.includes(q)) return false
       }
       return true
@@ -235,20 +235,10 @@ export function ActivityLog() {
       {/* Export footer — full history without keeping the pane open */}
       <div className="act-foot">
         <span className="act-foot-label mono">export</span>
-        <a
-          className="act-export mono"
-          data-testid="act-export-csv"
-          href={csvHref}
-          download
-        >
+        <a className="act-export mono" data-testid="act-export-csv" href={csvHref} download>
           CSV
         </a>
-        <a
-          className="act-export mono"
-          data-testid="act-export-json"
-          href={jsonHref}
-          download
-        >
+        <a className="act-export mono" data-testid="act-export-json" href={jsonHref} download>
           JSON
         </a>
       </div>

--- a/ui/src/dash/activity-log.jsx
+++ b/ui/src/dash/activity-log.jsx
@@ -1,0 +1,259 @@
+// hal0 v3 dashboard — ActivityLog sidebar pane (Slots page).
+//
+// A durable, colorized, severity-filterable, BOUNDED audit-trail pane that
+// replaces the old SnapshotStrip / MemoryMap / ThroughputCard sidebar stack
+// on the Slots page. Structurally cloned from the Footer "Live journal"
+// pane (chrome.jsx) but wrapped in the `.side-card` shell so it sits in the
+// 320px sidebar column.
+//
+// Priority: readability + confirmation. A failed action renders a RED row
+// with a ✗ glyph so the user can answer "did it take?" at a glance. The
+// pane is bounded (fixed max-height contained scroll, newest-first, capped
+// ring) so a burst can't turn it into an unusable firehose; the Export
+// button is the escape hatch for full history.
+//
+// Data: useActivityStream (durable backfill + live tail, epoch-aware) with
+// the active severity/kind filters forwarded server-side. Auto-scroll
+// pauses while the cursor hovers the list so a live tail can't yank the
+// row you're reading.
+
+import { useMemo, useRef, useState } from 'react'
+import {
+  useActivityStream,
+  activityExportUrl,
+  type ActivityRecord,
+  type ActivitySeverity,
+} from '@/api/hooks/useActivity'
+
+// Severity → outcome glyph + class. `ok` = ✓ green confirmation, `error`
+// = ✗ red, everything else = · neutral dot.
+function outcomeGlyph(rec: ActivityRecord): { glyph: string; cls: string } {
+  const sev = sevOf(rec)
+  if (sev === 'ok' || rec.outcome === 'ok') return { glyph: '✓', cls: 'ok' }
+  if (sev === 'error' || rec.outcome === 'error') return { glyph: '✗', cls: 'error' }
+  if (rec.outcome === 'pending') return { glyph: '…', cls: 'warn' }
+  if (sev === 'warn') return { glyph: '!', cls: 'warn' }
+  return { glyph: '·', cls: 'info' }
+}
+
+// Normalize severity into one of the four CSS row classes.
+function sevOf(rec: ActivityRecord): 'ok' | 'warn' | 'error' | 'info' {
+  const s = String(rec.severity || '').toLowerCase()
+  if (s === 'ok' || s === 'warn' || s === 'error' || s === 'info') return s
+  return 'info'
+}
+
+// Short HH:MM:SS from an ISO/epoch ts; falls back to the raw string.
+function shortTime(ts: string): string {
+  if (!ts) return ''
+  const d = new Date(ts)
+  if (!Number.isNaN(d.getTime())) {
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+  }
+  // Already-short or non-parseable — show the tail.
+  return ts.length > 8 ? ts.slice(11, 19) || ts : ts
+}
+
+// Compact actor label: "mcp:hermes" → "hermes (mcp)", else as-is.
+function actorLabel(actor: string): string {
+  if (!actor) return 'system'
+  if (actor.startsWith('mcp:')) return `${actor.slice(4)} (mcp)`
+  return actor
+}
+
+const SEVERITY_CHIPS: Array<{ key: 'all' | ActivitySeverity; label: string }> = [
+  { key: 'all', label: 'all' },
+  { key: 'ok', label: 'ok' },
+  { key: 'info', label: 'info' },
+  { key: 'warn', label: 'warn' },
+  { key: 'error', label: 'error' },
+]
+
+const CATEGORY_OPTIONS = [
+  { key: 'all', label: 'All' },
+  { key: 'slot', label: 'slot' },
+  { key: 'model', label: 'model' },
+  { key: 'profile', label: 'profile' },
+  { key: 'capability', label: 'capability' },
+  { key: 'system', label: 'system' },
+]
+
+export function ActivityLog() {
+  const [severity, setSeverity] = useState<'all' | ActivitySeverity>('all')
+  const [category, setCategory] = useState<string>('all')
+  const [search, setSearch] = useState('')
+  // Auto-scroll-to-top pauses while hovering so a live frame can't yank
+  // the row you're reading. (Newest-first → "scroll" is really the top.)
+  const [paused, setPaused] = useState(false)
+  const listRef = useRef<HTMLDivElement | null>(null)
+
+  const stream = useActivityStream({
+    follow: true,
+    severity: severity === 'all' ? null : severity,
+    category: category === 'all' ? null : category,
+    // search is forwarded server-side; the client filter below gives
+    // instant feedback for the residual ring while the SSE reconnects.
+    search: search || null,
+  })
+
+  // Residual client filter so records already in the ring honour a tightened
+  // filter immediately (server-side filtering only gates FUTURE frames).
+  const rows = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return stream.records.filter((r) => {
+      if (severity !== 'all' && sevOf(r) !== severity) return false
+      if (category !== 'all' && r.category !== category) return false
+      if (q) {
+        const hay = `${r.message || ''} ${r.action || ''} ${r.target || ''} ${r.actor || ''}`.toLowerCase()
+        if (!hay.includes(q)) return false
+      }
+      return true
+    })
+  }, [stream.records, severity, category, search])
+
+  const exportFilters = {
+    severity: severity === 'all' ? null : severity,
+    category: category === 'all' ? null : category,
+    search: search || null,
+  }
+  const csvHref = activityExportUrl('csv', exportFilters)
+  const jsonHref = activityExportUrl('json', exportFilters)
+
+  return (
+    <div className="side-card act-card" data-testid="activity-log">
+      <div className="act-h">
+        <span className="act-title">Activity</span>
+        <span className="act-ct mono">
+          {rows.length}
+          {stream.records.length !== rows.length ? ` / ${stream.records.length}` : ''}
+        </span>
+        <span
+          className={'act-conn' + (stream.disconnected ? ' off' : '')}
+          title={stream.disconnected ? 'stream reconnecting' : 'live tail'}
+        >
+          <span className={'dot' + (stream.disconnected ? '' : ' ready')} />
+          {stream.disconnected ? 'reconnecting…' : 'live'}
+        </span>
+      </div>
+
+      {/* Sticky filter bar */}
+      <div className="act-filters">
+        <div className="act-chips mono" role="group" aria-label="Filter by severity">
+          {SEVERITY_CHIPS.map((c) => (
+            <button
+              key={c.key}
+              type="button"
+              data-testid={`act-sev-${c.key}`}
+              className={'act-chip act-chip-' + c.key + (severity === c.key ? ' on' : '')}
+              aria-pressed={severity === c.key}
+              onClick={() => setSeverity(c.key)}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+        <div className="act-filters-row">
+          <select
+            className="act-cat mono"
+            data-testid="act-category"
+            aria-label="Filter by category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+          >
+            {CATEGORY_OPTIONS.map((o) => (
+              <option key={o.key} value={o.key}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+          <input
+            className="act-search mono"
+            data-testid="act-search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="search…"
+            aria-label="Search activity"
+          />
+        </div>
+      </div>
+
+      {/* Bounded, scroll-contained, newest-first body */}
+      <div
+        ref={listRef}
+        className={'act-body' + (paused ? ' paused' : '')}
+        data-testid="activity-log-body"
+        onMouseEnter={() => setPaused(true)}
+        onMouseLeave={() => setPaused(false)}
+      >
+        {rows.length === 0 ? (
+          <div className="act-empty mono">
+            {stream.records.length === 0 ? (
+              'No activity yet'
+            ) : (
+              <>
+                No activity matches.{' '}
+                <button
+                  type="button"
+                  className="act-clear"
+                  onClick={() => {
+                    setSeverity('all')
+                    setCategory('all')
+                    setSearch('')
+                  }}
+                >
+                  Clear filters
+                </button>
+              </>
+            )}
+          </div>
+        ) : (
+          rows.map((r, i) => {
+            const g = outcomeGlyph(r)
+            const sev = sevOf(r)
+            return (
+              <div
+                key={r.id ?? `${r.ts}-${i}`}
+                className={'act-line ' + sev}
+                data-testid="act-row"
+                data-severity={sev}
+                title={r.error || r.message || r.action}
+              >
+                <span className="act-ts">{shortTime(r.ts)}</span>
+                <span className={'act-glyph ' + g.cls} aria-hidden="true">
+                  {g.glyph}
+                </span>
+                <span className="act-actor">{actorLabel(r.actor)}</span>
+                <span className="act-action mono">{r.action}</span>
+                {r.target ? <span className="act-target">{r.target}</span> : null}
+                <span className="act-msg">{r.message}</span>
+              </div>
+            )
+          })
+        )}
+      </div>
+
+      {/* Export footer — full history without keeping the pane open */}
+      <div className="act-foot">
+        <span className="act-foot-label mono">export</span>
+        <a
+          className="act-export mono"
+          data-testid="act-export-csv"
+          href={csvHref}
+          download
+        >
+          CSV
+        </a>
+        <a
+          className="act-export mono"
+          data-testid="act-export-json"
+          href={jsonHref}
+          download
+        >
+          JSON
+        </a>
+      </div>
+    </div>
+  )
+}
+
+export default ActivityLog

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -4,7 +4,7 @@
 // `useRuntimeRollup` hook (derived from the shared /api/slots poll), so
 // prototype layout stays unchanged before the first response lands.
 
-import { useRuntimeRollup } from '@/api/hooks/useRuntime'
+import { useRuntimeRollup, useHealthSystem, failingChecks } from '@/api/hooks/useRuntime'
 import { useLogsStream } from '@/api/hooks/useLogs'
 import { useSlots, useEndpoints } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
@@ -287,7 +287,19 @@ function SidebarRuntimeWidget({ onGo }) {
   const urls      = useConfigUrls();
 
   // ── runtime ──
-  const runtimeClass = L.status === 'up' ? 'up' : L.status === 'down' ? 'down' : '';
+  // B12: the slot-poll rollup only knows up/down; /api/health/system is the
+  // honest signal for up-but-DEGRADED. When the probe says degraded we force
+  // the chip amber and tooltip the failing checks, even if every slot is up.
+  const health        = useHealthSystem();
+  const degraded      = health.data?.status === 'degraded';
+  const failing       = failingChecks(health.data);
+  const runtimeClass  = degraded ? 'warn'
+    : L.status === 'up' ? 'up'
+      : L.status === 'down' ? 'down'
+        : '';
+  const runtimeTitle = degraded
+    ? `degraded — ${failing.length ? failing.join("; ") : "see /api/health/system"}`
+    : `${L.ready}/${L.total} slot container${L.total === 1 ? "" : "s"} ready`;
 
   // ── hermes ── honest dot tone: green=running, red=broken, amber=unknown.
   // "off" when no agent is installed (no false-broken red on a fresh box).
@@ -371,12 +383,14 @@ function SidebarRuntimeWidget({ onGo }) {
       <div
         className="row"
         data-testid="runtime-row-runtime"
-        title={`${L.ready}/${L.total} slot container${L.total === 1 ? "" : "s"} ready`}
+        title={runtimeTitle}
       >
         <span className="k">runtime</span>
-        <span className={"v " + runtimeClass}>
+        <span className={"v " + runtimeClass} data-degraded={degraded ? "1" : undefined}>
           <span className="dot" />
-          {L.status}{L.status === 'up' ? ` · ${L.ready}/${L.total} slots ready` : ''}
+          {degraded
+            ? `degraded · ${L.ready}/${L.total} ready`
+            : `${L.status}${L.status === 'up' ? ` · ${L.ready}/${L.total} slots ready` : ''}`}
         </span>
       </div>
 

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -789,6 +789,11 @@ function InlineSwapPopover({ slot, open, onClose, onPick }) {
 // automatically when the drawer unmounts.
 function SlotLogsDrawer({ open, slot, onClose }) {
   const [lines, setLines] = useStateSM([]);
+  // B13: when journalctl is unavailable the backend emits a NAMED
+  // `event: degraded` SSE frame instead of streaming lines. Surfacing it
+  // tells the user *why* there are no lines, instead of spinning forever
+  // on "waiting for log lines…".
+  const [degraded, setDegraded] = useStateSM(null);
   const esRef = useRefSM(null);
 
   useEffectSM(() => {
@@ -798,9 +803,11 @@ function SlotLogsDrawer({ open, slot, onClose }) {
         esRef.current = null;
       }
       setLines([]);
+      setDegraded(null);
       return;
     }
     setLines([]);
+    setDegraded(null);
     try {
       const es = new EventSource(ENDPOINTS.slotLogsStream(slot.name));
       esRef.current = es;
@@ -810,6 +817,20 @@ function SlotLogsDrawer({ open, slot, onClose }) {
           return next.length > 500 ? next.slice(next.length - 500) : next;
         });
       };
+      // Named "degraded" frame — journalctl unavailable for this slot.
+      // Parse the payload for a human reason; fall back to a generic note.
+      es.addEventListener("degraded", (ev) => {
+        let reason = "Log streaming unavailable (journalctl not reachable for this slot).";
+        try {
+          const data = JSON.parse(ev.data);
+          if (data && (data.message || data.reason || data.detail)) {
+            reason = data.message || data.reason || data.detail;
+          }
+        } catch {
+          if (typeof ev.data === "string" && ev.data.trim()) reason = ev.data;
+        }
+        setDegraded(reason);
+      });
       es.onerror = () => {
         // Leave the stream open — server can resume; drawer close cleans up.
       };
@@ -839,6 +860,24 @@ function SlotLogsDrawer({ open, slot, onClose }) {
         </span>
       }
     >
+      {degraded && (
+        <div
+          className="mono"
+          data-testid="slot-logs-degraded"
+          style={{
+            background: "var(--warn-soft)",
+            border: "1px solid var(--warn-line)",
+            borderRadius: "var(--rad-sm)",
+            padding: "8px 10px",
+            fontSize: 11.5,
+            color: "var(--warn)",
+            lineHeight: 1.5,
+            marginBottom: 8,
+          }}
+        >
+          {degraded}
+        </div>
+      )}
       <div
         className="mono"
         style={{
@@ -849,13 +888,17 @@ function SlotLogsDrawer({ open, slot, onClose }) {
           fontSize: 11.5,
           color: "var(--fg-2)",
           lineHeight: 1.5,
-          height: 460,
+          height: degraded ? 414 : 460,
           overflow: "auto",
           whiteSpace: "pre-wrap",
         }}
       >
         {lines.length === 0
-          ? <span style={{color: "var(--fg-4)", fontStyle: "italic"}}>waiting for log lines…</span>
+          ? (
+            <span style={{color: "var(--fg-4)", fontStyle: "italic"}}>
+              {degraded ? "No log lines — see the notice above." : "waiting for log lines…"}
+            </span>
+          )
           : lines.join("\n")}
       </div>
     </Drawer>

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -1024,11 +1024,6 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
     />
   );
 
-  // `onGo` may be omitted (some legacy call sites); fall through to hash
-  // routing so the snapshot row clicks still navigate. Keeps the sidebar
-  // working in tests/storybook-y harnesses that mount SlotsView directly.
-  const goTo = onGo || ((r) => { window.location.hash = "#" + r; });
-
   // Skip-path layout: render six seeded empty cards under their default groups.
   if (skipPath) {
     const seededByGroup = {
@@ -1076,9 +1071,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
             })}
           </div>
           <div className="dash-side">
-            <SnapshotStrip slots={slots} onGo={goTo} />
-            <MemoryMap variant="sidebar" />
-            <ThroughputCard />
+            <ActivityLog />
           </div>
         </div>
 
@@ -1112,7 +1105,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
             </div>
           </div>
           <div className="dash-side">
-            <MemoryMap variant="sidebar" />
+            <ActivityLog />
           </div>
         </div>
       </div>
@@ -1142,7 +1135,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
             </div>
           </div>
           <div className="dash-side">
-            <MemoryMap variant="sidebar" />
+            <ActivityLog />
           </div>
         </div>
         <CreateSlotModal
@@ -1272,9 +1265,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
           )}
         </div>
         <div className="dash-side">
-          <SnapshotStrip slots={slots} onGo={goTo} />
-          <MemoryMap variant="sidebar" />
-          <ThroughputCard />
+          <ActivityLog />
         </div>
       </div>
 

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -17,7 +17,7 @@ import {
 } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
 import { useComfyui } from '@/api/hooks/useComfyui'
-import { MemoryMap } from './memory-map'
+import { ActivityLog } from './activity-log.jsx'
 import { ComfyuiPane } from './comfyui-pane.jsx'
 import {
   InferencePane,

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -31,6 +31,7 @@ import './dashboard.css'
 import './dash/comfyui-pane.css'
 import './dash/engine-panes.css'
 import './dash/memory-overhaul.css'
+import './dash/activity-log.css'
 
 import './dash/data.jsx'
 import './dash/tweaks-panel.jsx'

--- a/ui/tests/e2e/specs/activity-log.spec.ts
+++ b/ui/tests/e2e/specs/activity-log.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * activity-log — the durable ActivityLog sidebar pane on the Slots page.
+ *
+ * Replaces the old SnapshotStrip / MemoryMap / ThroughputCard sidebar stack
+ * (#slots → .dash-side). The pane streams /api/activity/stream and renders a
+ * colorized, severity-filterable, BOUNDED audit trail. Specs pin:
+ *
+ *   1. The pane mounts in the Slots sidebar (.dash-side > [data-testid=activity-log])
+ *      and the three removed widgets are gone.
+ *   2. Records pushed through the SSE harness render newest-first, colorized
+ *      by severity (an `error` row carries the `error` class + a ✗ glyph; an
+ *      `ok` row carries the `ok` class + a ✓ glyph).
+ *   3. The severity filter chips narrow the visible rows.
+ *   4. The export buttons (CSV/JSON) are present and honour the active filter.
+ *   5. The body is a bounded scroll container (max-height + overflow-y:auto).
+ *
+ * SSE frame shape (per backend contract):
+ *   data: {"record": {...}, "epoch": "<str>"}
+ */
+import { test, expect } from '../fixtures/apiMock'
+import { installSseHarness, emitSse, waitForSse } from '../fixtures/sseHarness'
+
+const STREAM = '/api/activity/stream'
+
+function rec(over: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    ts: '2026-06-14T12:00:00.000000+00:00',
+    kind: 'action',
+    category: 'slot',
+    action: 'slot.edit_config',
+    target: 'primary',
+    actor: 'dashboard',
+    severity: 'ok',
+    outcome: 'ok',
+    message: 'updated primary context_size',
+    before: null,
+    after: null,
+    error: null,
+    duration_ms: 12,
+    request_id: 'req-1',
+    ...over,
+  }
+}
+
+const OK_REC = rec({ id: 1, severity: 'ok', outcome: 'ok', message: 'edit applied' })
+const ERR_REC = rec({
+  id: 2,
+  ts: '2026-06-14T12:00:01.000000+00:00',
+  severity: 'error',
+  outcome: 'error',
+  action: 'slot.restart',
+  message: 'restart failed: container exited 1',
+  error: 'container exited 1',
+})
+const WARN_REC = rec({
+  id: 3,
+  ts: '2026-06-14T12:00:02.000000+00:00',
+  category: 'model',
+  severity: 'warn',
+  outcome: null,
+  kind: 'event',
+  action: 'model.pull',
+  message: 'pull slow — retrying',
+})
+
+const EPOCH = 'epoch-test-1'
+function frame(record: Record<string, unknown>) {
+  return { record, epoch: EPOCH }
+}
+
+test.describe('ActivityLog sidebar pane (#slots)', () => {
+  test.beforeEach(async ({ page }) => {
+    await installSseHarness(page)
+  })
+
+  test('mounts in the Slots sidebar; the 3 old widgets are gone', async ({ page }) => {
+    await page.goto('/#slots')
+    const card = page.locator('.dash-side [data-testid="activity-log"]')
+    await expect(card).toBeVisible({ timeout: 6_000 })
+    // The retired sidebar widgets no longer render on the slots page.
+    await expect(page.locator('.dash-side .memmap-sidebar')).toHaveCount(0)
+    await expect(page.locator('.dash-side .snapshot-strip')).toHaveCount(0)
+    await expect(page.locator('.dash-side .throughput-card')).toHaveCount(0)
+  })
+
+  test('opens the activity SSE and renders pushed records newest-first', async ({ page }) => {
+    await page.goto('/#slots')
+    await waitForSse(page, STREAM, 6_000)
+
+    await emitSse(page, STREAM, frame(OK_REC))
+    await emitSse(page, STREAM, frame(ERR_REC))
+
+    const rows = page.locator('[data-testid="act-row"]')
+    await expect(rows).toHaveCount(2)
+    // Newest-first: the error (id 2, later ts) is pushed last so it sits on top.
+    await expect(rows.first()).toContainText('restart failed')
+  })
+
+  test('rows are colorized by severity (error → red class + ✗; ok → green + ✓)', async ({
+    page,
+  }) => {
+    await page.goto('/#slots')
+    await waitForSse(page, STREAM, 6_000)
+
+    await emitSse(page, STREAM, frame(OK_REC))
+    await emitSse(page, STREAM, frame(ERR_REC))
+
+    const okRow = page.locator('[data-testid="act-row"][data-severity="ok"]')
+    const errRow = page.locator('[data-testid="act-row"][data-severity="error"]')
+    await expect(okRow).toHaveClass(/\bok\b/)
+    await expect(okRow.locator('.act-glyph')).toHaveText('✓')
+    await expect(errRow).toHaveClass(/\berror\b/)
+    await expect(errRow.locator('.act-glyph')).toHaveText('✗')
+  })
+
+  test('severity chips filter the visible rows', async ({ page }) => {
+    await page.goto('/#slots')
+    await waitForSse(page, STREAM, 6_000)
+
+    await emitSse(page, STREAM, frame(OK_REC))
+    await emitSse(page, STREAM, frame(ERR_REC))
+    await emitSse(page, STREAM, frame(WARN_REC))
+    await expect(page.locator('[data-testid="act-row"]')).toHaveCount(3)
+
+    // Click the `error` chip — only the error row should remain (client-side
+    // residual filter applies immediately to the ring).
+    await page.locator('[data-testid="act-sev-error"]').click()
+    const rows = page.locator('[data-testid="act-row"]')
+    await expect(rows).toHaveCount(1)
+    await expect(rows.first()).toHaveAttribute('data-severity', 'error')
+
+    // Back to All restores every row.
+    await page.locator('[data-testid="act-sev-all"]').click()
+    await expect(page.locator('[data-testid="act-row"]')).toHaveCount(3)
+  })
+
+  test('export buttons present + honour the active severity filter', async ({ page }) => {
+    await page.goto('/#slots')
+    const csv = page.locator('[data-testid="act-export-csv"]')
+    const json = page.locator('[data-testid="act-export-json"]')
+    await expect(csv).toBeVisible({ timeout: 6_000 })
+    await expect(json).toBeVisible()
+    await expect(csv).toHaveAttribute('href', /\/api\/activity\/export\?.*fmt=csv/)
+    await expect(json).toHaveAttribute('href', /\/api\/activity\/export\?.*fmt=json/)
+
+    // Selecting a severity threads it into the export URL.
+    await page.locator('[data-testid="act-sev-error"]').click()
+    await expect(csv).toHaveAttribute('href', /severity=error/)
+  })
+
+  test('body is a BOUNDED scroll container (not an infinite firehose)', async ({ page }) => {
+    await page.goto('/#slots')
+    const body = page.locator('[data-testid="activity-log-body"]')
+    await expect(body).toBeVisible({ timeout: 6_000 })
+    const overflowY = await body.evaluate((el) => getComputedStyle(el).overflowY)
+    expect(['auto', 'scroll']).toContain(overflowY)
+    const maxH = await body.evaluate((el) => getComputedStyle(el).maxHeight)
+    // A real px cap (not "none") proves the pane is bounded.
+    expect(maxH).not.toBe('none')
+    expect(parseFloat(maxH)).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a **durable activity/audit store** — hal0's source of truth for config
changes — and the slots-page **ActivityLog** that surfaces it, plus fixes for
the broken logs/health plumbing this work uncovered.

The footer `EventBus` is a volatile 500-entry RAM ring (lost on restart, no
before/after, no success/failure). As the config surface grew (slots, models,
profiles, capabilities, backends…) there was no trustworthy record of *what
changed, who changed it, and whether it actually took effect*. This PR closes
that gap.

Design spec: `docs/superpowers/specs/2026-06-14-activity-audit-store-design.md`

## What's new

**Durable audit store** (`src/hal0/activity/`, stdlib `sqlite3`, WAL):
- `AuditStore` — query/filter/export/prune over a durable `audit` table at
  `var_lib()/activity.db`. Survives restarts; bounded by `retention_days` +
  `max_rows` (`[activity]` config, `HAL0_ACTIVITY_RETENTION_DAYS`).
- `audit_action()` — context manager around a mutation that records a **truthful
  outcome** (`ok`/`error`) captured *after* the op, with before/after state.
  This is the "confirmation it actually took place" guarantee.
- `EventBus` gains an optional durable **sink** so every emitted event is also
  persisted (`kind="event"`) — state transitions, pulls, system events covered
  for free. `pull.progress` is filtered out of the mirror so it can't evict
  lifecycle history.
- Secret-keyed values are redacted before they ever hit disk.

**Coverage** — `record_action` instrumented across slot create/delete/edit-
config/edit-defaults/set-backend/load/unload/restart/swap, profile CRUD,
capability apply, approval **approve/deny** (denied actions captured), model
delete — each with actor (`dashboard` / `mcp:<agent>`), before/after, outcome.

**`/api/activity`** — list+filter (severity/kind/category/actor/action/search/
since), SSE live tail (filters server-side), CSV/JSON export, per-process epoch.

**ActivityLog UI** (slots page) — replaces the redundant SnapshotStrip/MemoryMap/
ThroughputCard sidebar widgets. Severity filter chips, category filter, search,
**colorized rows** (green ✓ ok / red ✗ error / neutral), **bounded** contained
scroll (no firehose), pause-on-hover, live/reconnecting indicator, CSV/JSON
export. Readability + confirmation first.

## Logs / health fixes (diagnosed + filed as #782–794)

Fixed here: **#783** health endpoint no longer lies (degraded when a slot is
ERROR), **#784** slot logs no longer doubled in journald (`--log-driver=none`),
**#785** events advertise an epoch so the footer doesn't blank after restart,
**#786** `/api/events/stream` honors type/severity filters, **#787** UI runtime
chip reads the honest `/api/health/system`, **#788** slot-log SSE uses a
`degraded` event name (the reserved `error` name never fired client handlers →
spinner). **#782** (`/api/health` 404) was a deploy-lag — the route is in this
branch; verified at deploy.

Deferred follow-ups (filed, `ready-for-agent`): #789–794.

## Tests

New: `tests/activity/test_store.py` (15), `tests/api/test_activity*.py`,
`tests/api/test_events_fixes.py`, `tests/api/test_health_degraded.py`; UI
`ui/tests/e2e/specs/activity-log.spec.ts` (6). Touched-area backend suites +
full UI e2e green; UI typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
