### PR TITLE
Slot config UX Phase 1: grouped drawer, reasoning pill, type-default pane, reactive model dropdown

### DIFF
--- a/docs/superpowers/plans/2026-06-14-slot-config-phase1-ui-reorg.md
+++ b/docs/superpowers/plans/2026-06-14-slot-config-phase1-ui-reorg.md
@@ -1,0 +1,488 @@
+# Slot Config Phase 1 (UI reorg) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reorganize the slot edit drawer into owner-grouped sections, replace the reasoning checkbox with a two-state pill, remove the "Default for type" checkbox (relocated to a new Settings pane), and make the model dropdown re-filter live from the selected profile — all UI-only, no backend changes.
+
+**Architecture:** Add two presentational primitives (`FieldGroup`, `PillToggle`) to `primitives.jsx`, then restructure `EditSlotDrawer` (`slot-modals.jsx`) to use them. The type-default moves to a new `DefaultSlotsSection` in `settings.jsx` that sets the chosen slot's `default=true` and clears its same-type siblings via the existing `PUT /api/slots/{name}/config`. Verified by Playwright e2e (the correctness gate for `.jsx`).
+
+**Tech Stack:** React (.jsx), TanStack Query, Playwright e2e (`apiMock` + `seedSlots` harness), Vite, `tsc --noEmit`.
+
+**Base branch:** `afk/ui-crud-overhaul` (PR #781). Phase 1 builds directly on #781's editable model dropdown, collapsible Advanced (`details.adv-disclosure`), and non-blocking swap. **Gate: #781 must be merged (or branch from it).** Spec: `docs/superpowers/specs/2026-06-14-slot-config-grouping-mtp-templates-design.md`.
+
+**Verify commands (from the worktree's `ui/` dir; node_modules is symlinked — do NOT install):**
+- `npm run typecheck` → exit 0
+- `npm run build` → exit 0
+- `npx playwright test <spec> --project=chromium` → all pass
+
+---
+
+### Task 1: `FieldGroup` + `PillToggle` primitives
+
+**Files:**
+- Modify: `ui/src/dash/primitives.jsx` (add two exported components)
+- Modify: `ui/src/dashboard.css` (styles; reuse `.npu-switch` knob pattern at line ~1514)
+
+These are presentational; they are exercised by the consumer e2e in Tasks 2 and 5 (no standalone spec).
+
+- [ ] **Step 1: Add the components to `primitives.jsx`**
+
+```jsx
+// FieldGroup — a labeled config section. Groups fields by owner (slot/model/…).
+export function FieldGroup({ label, hint, children }) {
+  return (
+    <div className="field-group">
+      <div className="field-group-head">
+        <span className="field-group-label">{label}</span>
+        {hint && <span className="field-group-hint">{hint}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// PillToggle — two-state sliding pill (generalized from slots.jsx NpuSwitch).
+// Fixed label; the on/off STATE is shown by the pill, never by a changing label.
+export function PillToggle({ on, disabled, label, stateText, onToggle }) {
+  return (
+    <div className="pill-toggle-row">
+      <button
+        type="button"
+        className="npu-switch"
+        role="switch"
+        aria-checked={!!on}
+        aria-label={label}
+        disabled={disabled}
+        data-on={on ? "1" : "0"}
+        onClick={() => onToggle(!on)}
+      >
+        <span className="knob" />
+      </button>
+      {stateText && <span className="pill-toggle-state mono">{stateText}</span>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add styles to `dashboard.css`** (place near `.npu-switch`, ~line 1514)
+
+```css
+.field-group { margin: 18px 0 4px; }
+.field-group-head { display: flex; align-items: baseline; gap: 8px; padding: 0 0 6px; border-bottom: 1px solid var(--line-soft); margin-bottom: 8px; }
+.field-group-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--fg-4); font-weight: 600; }
+.field-group-hint { font-size: 10.5px; color: var(--fg-5); }
+.pill-toggle-row { display: flex; align-items: center; gap: 10px; }
+.pill-toggle-state { font-size: 12px; color: var(--fg-3); }
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `npm run typecheck && npm run build`
+Expected: both exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/dash/primitives.jsx ui/src/dashboard.css
+git commit -m "feat(ui): FieldGroup + PillToggle config primitives"
+```
+
+---
+
+### Task 2: Reasoning pill (replace the checkbox)
+
+**Files:**
+- Modify: `ui/src/dash/slot-modals.jsx` (the Thinking `form-row`, ~line 700–735; label flips "Reasoning on/off" at ~731)
+- Test: `ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts`
+
+- [ ] **Step 1: Write the failing test** (add to the `describe` block)
+
+```ts
+test('C4 — reasoning pill toggles enable_thinking and keeps a fixed label', async ({ page }) => {
+  const puts: any[] = []
+  await page.route('**/api/slots/primary/config', async (route) => {
+    if (route.request().method() === 'PUT') puts.push(JSON.parse(route.request().postData() || '{}'))
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+  })
+  await seedSlots(page, [PRIMARY, EMBED]) // PRIMARY enable_thinking:false
+  await page.goto('/#slots/primary')
+
+  const row = page.locator('.drawer .form-row', { hasText: 'Reasoning' })
+  await expect(row).toBeVisible()
+  // Fixed label — the word "Reasoning" is always present, never "Reasoning on/off".
+  await expect(row.locator('.form-lbl span').first()).toHaveText('Reasoning')
+  const pill = row.locator('button[role="switch"]')
+  await expect(pill).toHaveAttribute('aria-checked', 'false')
+
+  await pill.click()
+  await expect.poll(() => puts.length).toBeGreaterThan(0)
+  expect(puts[0].enable_thinking).toBe(true)
+  await expect(pill).toHaveAttribute('aria-checked', 'true')
+})
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx playwright test slot-edit-controls-v3 --project=chromium -g "reasoning pill"`
+Expected: FAIL (no `button[role="switch"]` in the Thinking row; label is "Reasoning on/off").
+
+- [ ] **Step 3: Replace the Thinking checkbox with the pill**
+
+In `slot-modals.jsx`, import the primitive: add `PillToggle` to the existing `primitives.jsx` import. Replace the `<label className="checkbox-row">…</label>` block inside the `slot.type === "llm"` Thinking `form-row` (and rename the visible label to "Reasoning") with:
+
+```jsx
+<div className="form-row">
+  <div className="form-lbl">
+    <span>Reasoning</span>
+    <span className="sub">Stream reasoning before the answer. Off = faster, direct replies. Applies to the next message.</span>
+  </div>
+  <div className="form-ctl">
+    <PillToggle
+      on={thinking}
+      disabled={thinkingPending}
+      label="Reasoning"
+      stateText={thinking ? "On" : "Off"}
+      onToggle={async (next) => {
+        setThinking(next);
+        setThinkingPending(true);
+        setSubmitErr(null);
+        setThinkingErr(null);
+        try {
+          await editMut.mutateAsync({ name: slot.name, body: { enable_thinking: next } });
+          window.__hal0Toast && window.__hal0Toast(`${slot.name} reasoning ${next ? "on" : "off"} — applies to next message`, "ok");
+        } catch (err) {
+          setThinking(!next);
+          setThinkingErr(err?.message || "reasoning toggle failed");
+        } finally {
+          setThinkingPending(false);
+        }
+      }}
+    />
+    {thinkingErr && <div className="hint" style={{ color: "var(--err)" }}>{thinkingErr}</div>}
+  </div>
+</div>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx playwright test slot-edit-controls-v3 --project=chromium`
+Expected: all pass (new test + existing C4/C5/#587).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/dash/slot-modals.jsx ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+git commit -m "feat(slots): reasoning checkbox -> two-state pill with fixed label"
+```
+
+---
+
+### Task 3: Remove "Default for type" from the edit drawer
+
+**Files:**
+- Modify: `ui/src/dash/slot-modals.jsx` (drawer Default `form-row` ~line 672–690; `makeDefault` state ~353; save body `default: makeDefault` ~425)
+- Test: `ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts`
+
+Scope: remove from the **edit drawer only**. The create-slot modal's default checkbox stays (creating the first slot of a type as default remains convenient); Task 6 adds the relocation target.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test('default-for-type row is gone from the edit drawer and Save omits default', async ({ page }) => {
+  const puts: any[] = []
+  await page.route('**/api/slots/primary/config', async (route) => {
+    if (route.request().method() === 'PUT') puts.push(JSON.parse(route.request().postData() || '{}'))
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+  })
+  await page.route('**/api/slots/primary/defaults', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }))
+  await seedSlots(page, [PRIMARY, EMBED])
+  await page.goto('/#slots/primary')
+  await expect(page.locator('.drawer')).toBeVisible()
+  await expect(page.locator('.drawer .form-row', { hasText: 'Default for type' })).toHaveCount(0)
+  await page.locator('.drawer button:has-text("Save")').click()
+  await expect.poll(() => puts.length).toBeGreaterThan(0)
+  expect(puts[0]).not.toHaveProperty('default')
+})
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx playwright test slot-edit-controls-v3 --project=chromium -g "default-for-type row is gone"`
+Expected: FAIL (row present; Save sends `default`).
+
+- [ ] **Step 3: Remove the row + the save field**
+
+In `slot-modals.jsx`: (a) delete the entire `<div className="form-row">…Default for type…</div>` block in `EditSlotDrawer`; (b) delete the `const [makeDefault, setMakeDefault] = useStateSM(!!slot?.isDefault);` line and its `setMakeDefault(...)` in the re-seed `useEffect`; (c) in `onSaveClick`, change the slot body from `const slotBody = { default: makeDefault };` to `const slotBody = {};` (keep the `if (profileChanged) slotBody.profile = selectedProfile;` line). Leave the create-slot modal's `makeDefault` untouched.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx playwright test slot-edit-controls-v3 slot-drawer-profile-v3 --project=chromium`
+Expected: all pass (note: C7c asserts the no-op-profile Save body has no `profile` — still true; it never asserted `default`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/dash/slot-modals.jsx ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+git commit -m "feat(slots): drop Default-for-type from edit drawer (moves to Settings)"
+```
+
+---
+
+### Task 4: Reactive model dropdown — filter by the selected profile
+
+**Files:**
+- Modify: `ui/src/dash/slot-modals.jsx` (the Model `<select>` block from #781, ~line 595–660; filter uses `slot.backend`)
+- Test: `ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts`
+
+- [ ] **Step 1: Write the failing test** (uses the `chat` container slot, profiles `rocm`/`vulkan`; rocmfp4 models must drop when vulkan is selected)
+
+```ts
+test('C7h — model options re-filter from the SELECTED profile, not the persisted one', async ({ page }) => {
+  // CHAT_CONTAINER is on a rocm profile; seed an rocmfp4-tagged model + a plain one.
+  await page.addInitScript(() => {
+    (window as any).__HAL0_TEST_MODELS = [
+      { id: 'qwen-fp4', longName: 'qwen-fp4', type: 'llm', tags: ['rocmfp4'] },
+      { id: 'qwen-plain', longName: 'qwen-plain', type: 'llm', tags: [] },
+    ]
+  })
+  await page.route('**/api/models', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify([
+        { id: 'qwen-fp4', name: 'qwen-fp4', type: 'llm', tags: ['rocmfp4'] },
+        { id: 'qwen-plain', name: 'qwen-plain', type: 'llm', tags: [] },
+      ]) }))
+  await seedSlots(page, [CHAT_CONTAINER])
+  await page.goto('/#slots/chat')
+  const modelSel = page.locator('.drawer .form-row', { hasText: 'Model' }).locator('select')
+  // rocm profile selected → fp4 model present
+  await expect(modelSel.locator('option[value="qwen-fp4"]')).toHaveCount(1)
+  // switch profile to vulkan → fp4 model filtered out
+  await page.locator('.drawer .form-row', { hasText: 'Profile' }).locator('select').selectOption('vulkan')
+  await expect(modelSel.locator('option[value="qwen-fp4"]')).toHaveCount(0)
+  await expect(modelSel.locator('option[value="qwen-plain"]')).toHaveCount(1)
+})
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx playwright test slot-drawer-profile-v3 --project=chromium -g "C7h"`
+Expected: FAIL (filter keyed on `slot.backend`, so changing the Profile select doesn't re-filter).
+
+- [ ] **Step 3: Make the filter depend on `selectedProfile`**
+
+In the Model `<select>` block, replace the `slot.backend` reference in the compatibility filter with the backend of the **selected** profile:
+
+```jsx
+// Derive the backend from the SELECTED profile (reactive), falling back to the
+// slot's persisted backend when the profile carries none / isn't found.
+const selProfileMeta = (profilesQuery.data ?? []).find(p => p.name === selectedProfile);
+const selBackend = selProfileMeta?.backend ?? slot.backend;
+const compatible = (modelsQuery.data ?? [])
+  .map(normalizeApiModel)
+  .filter(m =>
+    m.type === slot.type &&
+    !(Array.isArray(m.tags) && m.tags.includes("rocmfp4") && selBackend !== "rocm")
+  );
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx playwright test slot-drawer-profile-v3 --project=chromium`
+Expected: all pass (new C7h + existing C7a–C7g).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/dash/slot-modals.jsx ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
+git commit -m "feat(slots): model dropdown re-filters live from the selected profile"
+```
+
+---
+
+### Task 5: Regroup the drawer into FieldGroup sections
+
+**Files:**
+- Modify: `ui/src/dash/slot-modals.jsx` (`EditSlotDrawer` body — wrap existing rows in `FieldGroup`s; SLOT/MODEL/INFERENCE; Advanced stays the `details.adv-disclosure`)
+- Test: `ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test('drawer fields are grouped under SLOT / MODEL / INFERENCE', async ({ page }) => {
+  await seedSlots(page, [PRIMARY, EMBED])
+  await page.goto('/#slots/primary')
+  await expect(page.locator('.drawer')).toBeVisible()
+  for (const label of ['Slot', 'Model', 'Inference']) {
+    await expect(page.locator('.field-group-label', { hasText: new RegExp(`^${label}$`, 'i') })).toHaveCount(1)
+  }
+  // Model dropdown sits inside the MODEL group.
+  const modelGroup = page.locator('.field-group', { has: page.locator('.field-group-label', { hasText: /^Model$/i }) })
+  await expect(modelGroup.locator('.form-row', { hasText: 'Model' }).locator('select')).toBeVisible()
+  // Reasoning pill sits inside the INFERENCE group.
+  const infGroup = page.locator('.field-group', { has: page.locator('.field-group-label', { hasText: /^Inference$/i }) })
+  await expect(infGroup.locator('.form-row', { hasText: 'Reasoning' })).toBeVisible()
+})
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx playwright test slot-edit-controls-v3 --project=chromium -g "grouped under"`
+Expected: FAIL (no `.field-group-label` elements yet).
+
+- [ ] **Step 3: Wrap the existing rows in `FieldGroup`s**
+
+Add `FieldGroup` to the `primitives.jsx` import. In `EditSlotDrawer`'s returned JSX, wrap (do not rewrite the inner rows):
+- `<FieldGroup label="Slot" hint="this instance">` around the Profile row and any slot-level read-only rows.
+- `<FieldGroup label="Model" hint="what it loads">` around the Model `<select>` row and the ctx_size row (move ctx_size out of Advanced into MODEL; keep its restart warning).
+- `<FieldGroup label="Inference" hint="behavior">` around the Reasoning pill row. (MTP pill lands here in Phase 2.)
+- Keep the existing `<details className="adv-disclosure">` Advanced block (n_gpu_layers / rope_freq_base / extra_args / resolved command) as-is, after the groups.
+
+Net structural change only — no field logic changes.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx playwright test slot-edit-controls-v3 slot-drawer-profile-v3 --project=chromium`
+Expected: all pass. (If a prior spec located ctx_size via `details.adv-disclosure summary` click, update it to find ctx_size in the MODEL group — adjust those specs in this step.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/dash/slot-modals.jsx ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+git commit -m "feat(slots): group edit drawer fields by owner (Slot/Model/Inference)"
+```
+
+---
+
+### Task 6: Settings "Default slots" pane
+
+**Files:**
+- Modify: `ui/src/dash/settings.jsx` (new `DefaultSlotsSection`; add `defaults` to the section switch ~line 67 and to the nav list)
+- Test: `ui/tests/e2e/specs/` — new `settings-default-slots-v3.spec.ts`
+
+No backend change: setting a default = `PUT /config { default: true }` on the chosen slot and `PUT /config { default: false }` on the previously-default sibling of the same type.
+
+- [ ] **Step 1: Write the failing test** (`ui/tests/e2e/specs/settings-default-slots-v3.spec.ts`)
+
+```ts
+import { test, expect, type Page } from '../fixtures/apiMock'
+
+async function seedSlots(page: Page, slots: any[]) {
+  await page.addInitScript((slots) => {
+    let real: any
+    Object.defineProperty(window, 'HAL0_DATA', {
+      configurable: true, get() { return real },
+      set(v) { real = v; if (v && typeof v === 'object') v.slots = slots },
+    })
+  }, slots)
+}
+
+const A = { name: 'primary', type: 'llm', device: 'gpu-rocm', state: 'serving', port: 8092, isDefault: true, enabled: true }
+const B = { name: 'backup',  type: 'llm', device: 'gpu-rocm', state: 'ready',   port: 8093, isDefault: false, enabled: true }
+
+test('Default slots pane sets the chosen slot default and clears the prior one', async ({ page }) => {
+  const puts: Record<string, any[]> = { primary: [], backup: [] }
+  for (const n of ['primary', 'backup']) {
+    await page.route(`**/api/slots/${n}/config`, async (route) => {
+      if (route.request().method() === 'PUT') puts[n].push(JSON.parse(route.request().postData() || '{}'))
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+  }
+  await seedSlots(page, [A, B])
+  await page.goto('/#settings/defaults')
+  const row = page.locator('.default-slot-row', { hasText: 'llm' })
+  await expect(row).toBeVisible()
+  await row.locator('select').selectOption('backup')
+  await expect.poll(() => puts.backup.length).toBeGreaterThan(0)
+  expect(puts.backup[0].default).toBe(true)   // new default set
+  await expect.poll(() => puts.primary.length).toBeGreaterThan(0)
+  expect(puts.primary[0].default).toBe(false)  // prior default cleared
+})
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx playwright test settings-default-slots-v3 --project=chromium`
+Expected: FAIL (route `#settings/defaults` and `.default-slot-row` don't exist).
+
+- [ ] **Step 3: Add `DefaultSlotsSection` + wire the nav**
+
+In `settings.jsx`, add the component (uses `useSlots` + `useSlotEdit`; group slots by `type`, render a row per type with ≥2 slots):
+
+```jsx
+function DefaultSlotsSection() {
+  const slotsQuery = useSlots();
+  const editSlot = useSlotEdit();
+  const slots = slotsQuery.data || [];
+  const byType = {};
+  for (const s of slots) { (byType[s.type] ||= []).push(s); }
+  const types = Object.keys(byType).filter(t => byType[t].length >= 2).sort();
+
+  const setDefault = async (type, name) => {
+    const sibs = byType[type] || [];
+    const prev = sibs.find(s => s.isDefault && s.name !== name);
+    try {
+      await editSlot.mutateAsync({ name, body: { default: true } });
+      if (prev) await editSlot.mutateAsync({ name: prev.name, body: { default: false } });
+      window.__hal0Toast && window.__hal0Toast(`Default ${type} slot → ${name}`, "ok");
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(`Couldn't set default — ${e?.message || "see logs"}`, "err");
+    }
+  };
+
+  return (
+    <div className="settings-section">
+      <h3>Default slots</h3>
+      <p className="sub">For each modality with more than one slot, choose which slot serves type-routed requests.</p>
+      {types.length === 0 && <p className="hint">No modality has multiple slots yet.</p>}
+      {types.map(type => {
+        const cur = (byType[type].find(s => s.isDefault) || {}).name || "";
+        return (
+          <div className="default-slot-row form-row" key={type}>
+            <div className="form-lbl"><span>{type}</span></div>
+            <div className="form-ctl">
+              <select className="input mono" value={cur} disabled={editSlot.isPending}
+                onChange={e => { const n = e.target.value; if (n && n !== cur) setDefault(type, n); }}>
+                {byType[type].map(s => <option key={s.name} value={s.name}>{s.name}</option>)}
+              </select>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+Then wire it into the nav: add `{section === "defaults" && <DefaultSlotsSection />}` alongside the other `section === …` lines (~67), and add a `{ key: "defaults", label: "Default slots" }` entry to the settings nav list (search for where `storage`/`voice`/`secrets` labels are defined and mirror the shape).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx playwright test settings-default-slots-v3 --project=chromium`
+Expected: PASS.
+
+- [ ] **Step 5: Full gate + commit**
+
+```bash
+npm run typecheck && npm run build && npx playwright test --project=chromium
+git add ui/src/dash/settings.jsx ui/tests/e2e/specs/settings-default-slots-v3.spec.ts
+git commit -m "feat(settings): Default slots pane (relocated type-default control)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 1 rows of the spec's phasing table):**
+- FieldGroup grouping → Tasks 1, 5 ✓
+- Reasoning pill → Task 2 ✓
+- Remove type-default checkbox → Task 3 ✓
+- Reactive model dropdown (filter by selected profile) → Task 4 ✓
+- Settings "Default slots" pane → Task 6 ✓
+- (Phases 2–3: MTP pill, chat templates — separate plans, out of scope here.)
+
+**Placeholder scan:** none — every code/test step carries concrete code. The single "mirror the nav-list shape" in Task 6 Step 3 is a locate-and-copy instruction against an existing pattern, with the exact entry shape given.
+
+**Type/name consistency:** `FieldGroup({label,hint,children})` and `PillToggle({on,disabled,label,stateText,onToggle})` are defined in Task 1 and consumed with those exact props in Tasks 2/5. `selectedProfile`, `profilesQuery`, `normalizeApiModel`, `editMut`, `useSlots`, `useSlotEdit` all already exist in the touched files (#781 base).
+
+**Risk note:** Task 5 may require touching prior specs that located ctx_size via the Advanced disclosure (now in the MODEL group) — handled in Task 5 Step 4.

--- a/docs/superpowers/specs/2026-06-14-slot-config-grouping-mtp-templates-design.md
+++ b/docs/superpowers/specs/2026-06-14-slot-config-grouping-mtp-templates-design.md
@@ -1,0 +1,126 @@
+# Slot config UX: grouped fields, type-default relocation, reasoning/MTP pills, non-manual chat templates
+
+- **Date:** 2026-06-14
+- **Status:** Approved (brainstorm) → ready for implementation plan
+- **Surface:** hal0 dashboard slot edit drawer (`ui/src/dash/slot-modals.jsx`), Settings (`ui/src/dash/settings.jsx`), model recipe editor (`ui/src/dash/model-modals.jsx`); backend `src/hal0/config/schema.py`, `src/hal0/slots/flag_merge.py`, `src/hal0/providers/llama_server.py`.
+- **Builds on:** PR #781 (non-blocking slot save/swap), `2026-06-05-slot-edit-panel-controls-design.md`.
+
+## Problem
+
+The slot edit drawer is a flat list of fields with no indication of which knob targets the **slot**, the **model**, or the **profile**. Specific pain points the operator hit:
+
+1. No visual grouping — slot-level vs model-level fields are indistinguishable.
+2. The **"Default for type"** checkbox is confusing in this context; the only "default" that matters while editing a slot is *which model it loads*.
+3. The **reasoning** control is a checkbox whose label flips ("Reasoning Off" ↔ on) so it's ambiguous which state enables it.
+4. **MTP** can only be had by switching to the `rocm-mtp` profile — there's no first-class toggle, and no guidance on when it helps.
+5. The **chat template** (jinja) some models require is only settable by hand-editing TOML.
+
+## How config works today (grounding)
+
+- **Field ownership** (`schema.py`):
+  - `[slot]` (`SlotConfig`): `name`, `port`, `device`, `profile`, `enabled`, `role`, `enable_thinking`, `workers`, `idle_timeout_s`, and `default` (the type-routing default).
+  - `[model]` (`ModelConfig`): `default` (model id), `context_size`, `n_gpu_layers`, `rope_freq_base`, `extra`.
+  - `[server]` (`ServerConfig`): `extra_args` (freeform llama-server passthrough).
+  - **Profile** (`ProfileConfig`): `image`, `flags`, `mtp`, `device_class`, `backend` — shared across slots that reference it.
+- **Type default** = exactly one `default=true` slot per type drives routing (`manager.default_slot_for`).
+- **Reasoning** = `enable_thinking` tri-state (`true`/`false`/`None`=inherit-global), applied via `chat_template_kwargs.enable_thinking` with llama-server `--jinja` (`normalize/thinking.py`).
+- **MTP** = profile flag (`ProfileConfig.mtp`); when true the `MTP_FLAG_BUNDLE` (`--spec-type draft-mtp --spec-draft-*`) is appended to profile flags. Seed profiles `rocm` (mtp off) and `rocm-mtp` (mtp on) share an image and differ only by this.
+- **Chat template** = `chat_template` resolved via `_slot_or_backend("chat_template", "defaults", "chat_template_file")` (`llama_server.py:205`) → llama-server `--chat-template-file`. A slot value already wins over the model's `defaults`.
+
+## Decisions (this brainstorm)
+
+| Fork | Decision | Rationale |
+|---|---|---|
+| Type default | **Remove from drawer → new Settings "Default slots" pane** | One place to set all type defaults; the drawer stays about *this* slot. |
+| MTP toggle | **Per-slot `mtp` override**, capability-gated pill | Decouples MTP from profile pairing; only meaningful when the model supports it. |
+| Chat template | **Model-level default + per-slot override** | Set once per model (auto-applies everywhere), override per slot when needed. |
+| Reasoning control | **Two-state sliding pill (On/Off)** | Explicit; drops the rarely-used inherit-global state. Fixed label removes the flip ambiguity. |
+
+### MTP research findings (informs the design)
+
+- MTP is model-native speculative decoding (built-in draft heads; no separate draft model). Mainlined in llama.cpp PR #22673 (May 2026).
+- **MTP helps dense models (~2×), hurts MoE.** Confirmed by our own bench: `rocm` (MoE) 52.8 tps vs `rocm-mtp` 24.4 tps. The verify-overhead is a net loss on already-sparse MoE.
+- **MTP requires an MTP-capable GGUF** (must ship the draft heads). A normal GGUF cannot use it.
+- **Our bundle is likely mistuned:** `--spec-draft-p-min 0.0 --spec-draft-n-max 4`. Guidance: p-min matters more than n-max; ~0.75 is the sweet spot, n-max 5 for dense. Tracked as a **separate bench ticket** (do not change blind).
+- Sources: johnpaulwile.substack.com/p/multi-token-prediction-mtp-in-llamacpp; github.com/ggml-org/llama.cpp/blob/master/docs/speculative.md; dredyson.com Qwen3.6-27B MTP guide; allenkuo.medium.com when-speculative-decoding-helps.
+
+**Consequence:** the MTP pill renders only when `model.mtp_capable && slot device is rocm`, with an inline hint ("dense models only — MoE runs slower").
+
+## Design
+
+### Reusable grouping primitive
+
+Introduce `FieldGroup({ label, hint, children })` — a labeled section wrapper (small caps header + subtle rule). Used by the drawer now and reusable across profiles/models/settings config surfaces. Lives in `ui/src/dash/primitives.jsx`.
+
+### Grouped edit drawer
+
+```
+SLOT · this instance
+  Name      (read-only)   Port (read-only)   Status (read-only)
+  Profile   <select>  (GPU slots; live-filters the Model list)
+  Enabled   pill
+
+MODEL · what it loads
+  Model     <select>  → sets the slot's default model; options recompute
+                        from the *selected* Profile; persists model.default
+                        and applies via the non-blocking swap (PR #781)
+  Context   <int>
+  Template  <model's chat_template, read-only>  [Override]
+
+INFERENCE · behavior
+  Reasoning <pill On/Off>
+  MTP       <pill On/Off>   (only when model MTP-capable + rocm; hint shown)
+
+▸ Advanced  (collapsed) — n_gpu_layers / rope_freq_base / extra_args
+            (profile-owned, read-only) + resolved command
+```
+
+- **Removed:** the "Default for type" checkbox.
+- **Model dropdown is reactive:** its compatible-model filter depends on `selectedProfile` (not the persisted profile), so changing Profile re-filters models immediately (e.g. picking `vulkan` drops rocmfp4 models). Selecting a model persists `model.default` via `PUT /config { model: { default } }` and applies it via the existing non-blocking swap path.
+
+### Type-default → Settings "Default slots" pane
+
+New section in `settings.jsx`: for each slot type that has ≥2 slots, a row with a dropdown to choose the default slot. Backend: a `POST /api/slots/{name}/default` (or `PUT /api/settings/default-slots`) that sets `default=true` on the chosen slot and clears it on its siblings of the same type (atomic). **Verify whether a set-default endpoint already exists** before adding one; today the drawer wrote `default` via `PUT /config`.
+
+### Reasoning pill
+
+Two-state sliding pill, fixed label "Reasoning". Maps `enable_thinking` `true`/`false`. The drawer no longer authors `None`; existing `None` slots seed the pill to Off and only write on change (preserve #587 dirty-tracking so a no-op save doesn't clobber). Instant-apply behavior unchanged (its own `PUT /config`).
+
+### MTP pill (Phase 2 — backend + UI)
+
+- **Backend:** add `SlotConfig.mtp: bool | None` (override). `flag_merge`/`profile_flags` expansion appends `MTP_FLAG_BUNDLE` when `slot.mtp` is set, else falls back to `profile.mtp`. Keeps the bundle as the single source of truth.
+- **Model capability:** mark MTP-capable models in the registry (a `mtp` tag/`labels` entry or detected from GGUF metadata at scan time). Surface `mtp_capable: bool` on the `/api/models` payload (`normalizeApiModel`).
+- **UI:** pill in the INFERENCE group, rendered only when `model.mtp_capable && device starts with "gpu-rocm"`. Toggling writes `slot.mtp` (non-blocking restart, same as profile change). Hint links the dense-vs-MoE caveat.
+- **Separate ticket:** retune `MTP_FLAG_BUNDLE` (p-min 0→~0.75, n-max→5) behind a bench.
+
+### Chat template: model-level + slot override (Phase 3 — backend + UI)
+
+- **Template library:** ship a small catalog of common jinja templates (chatml, qwen3, llama3, gemma, …) under the package (e.g. `src/hal0/templates/chat/*.jinja`), exposed via `GET /api/chat-templates` (id, label, preview). Plus a "Custom" path: paste jinja → stored as a file the slot/model references; and "Auto" = use the GGUF-embedded template (no `--chat-template-file`).
+- **Model level:** model recipe editor (`model-modals.jsx`) gains a "Chat template" field writing the model's `defaults.chat_template_file` (already read by `_slot_or_backend`). Default "Auto".
+- **Slot override:** drawer Template row shows the model's value read-only; **[Override]** opens the same picker and writes the slot's `chat_template` (slot wins over model defaults, already supported).
+
+## Phasing
+
+| Phase | Backend | Ships |
+|---|---|---|
+| **1 — UI reorg** | none (unless set-default endpoint missing) | `FieldGroup`, grouped drawer, reasoning pill, remove type-default checkbox, reactive model dropdown, Settings "Default slots" pane |
+| **2 — MTP** | small (`SlotConfig.mtp`, flag-merge, model `mtp_capable`) | capability-gated MTP pill; bench ticket filed |
+| **3 — Chat templates** | medium (template catalog + storage + endpoint) | model recipe template field + slot override picker |
+
+## Testing
+
+- **e2e (Playwright) is the correctness gate for `.jsx`** — `tsc`/`vite build` do not catch undefined-var runtime errors in `.jsx` (learned in PR #781). Every phase adds/updates specs under `ui/tests/e2e/specs/` using the `apiMock` + `seedSlots` harness:
+  - Phase 1: groups render with correct field membership; model dropdown re-filters when Profile changes; reasoning pill writes `enable_thinking` true/false and no-op save stays quiet; type-default checkbox absent; Settings pane sets default and clears siblings.
+  - Phase 2: MTP pill hidden when model not capable / non-rocm; toggling writes `slot.mtp`; backend flag-merge unit test asserts bundle appended on `slot.mtp` override.
+  - Phase 3: template picker lists catalog + custom; model recipe writes `defaults.chat_template_file`; slot override writes slot `chat_template` and wins over model.
+- Backend: pytest for `flag_merge` MTP override and `mtp_capable` detection.
+
+## Out of scope / follow-ups
+
+- Retuning `MTP_FLAG_BUNDLE` (separate bench ticket).
+- Applying the same non-blocking pattern to the slot **card's** `runMutation` (noted in PR #781).
+- Extending `FieldGroup` grouping to profiles/models/settings surfaces beyond what each phase touches.
+
+## Open questions
+
+None blocking. Set-default endpoint existence to be confirmed during Phase 1 (additive if missing).

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -229,7 +229,7 @@ function App() {
         if (memoryStatusPending) return null;
         return <MemoryView param={param} />;
       case "profiles":  return <ProfilesView />;
-      case "settings": return <SettingsView />;
+      case "settings": return <SettingsView param={param} />;
       // MCP folded into Connections (connections-overhaul) — #mcp + #agents/mcp
       // stay as aliases so old deep-links resolve to the new surface.
       case "mcp":

--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -440,6 +440,43 @@ function GpuImageModeBanner() {
   );
 }
 
+// ─── FieldGroup — a labeled config section ───────────────────────────────
+// Groups fields by owner (slot/model/…).
+function FieldGroup({ label, hint, children }) {
+  return (
+    <div className="field-group">
+      <div className="field-group-head">
+        <span className="field-group-label">{label}</span>
+        {hint && <span className="field-group-hint">{hint}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ─── PillToggle — two-state sliding pill ─────────────────────────────────
+// Generalized from slots.jsx NpuSwitch.
+// Fixed label; the on/off STATE is shown by the pill, never by a changing label.
+function PillToggle({ on, disabled, label, stateText, onToggle }) {
+  return (
+    <div className="pill-toggle-row">
+      <button
+        type="button"
+        className="npu-switch"
+        role="switch"
+        aria-checked={!!on}
+        aria-label={label}
+        disabled={disabled}
+        data-on={on ? "1" : "0"}
+        onClick={() => onToggle(!on)}
+      >
+        <span className="knob" />
+      </button>
+      {stateText && <span className="pill-toggle-state mono">{stateText}</span>}
+    </div>
+  );
+}
+
 // ─── Dropdown menu ───────────────────────────────────────────────────────
 function Menu({ anchor = "right", items, onClose, style }) {
   return (
@@ -472,4 +509,4 @@ function Menu({ anchor = "right", items, onClose, style }) {
   );
 }
 
-Object.assign(window, { Modal, Drawer, ConfirmDialog, Banner, BannerStack, BannerProvider, useBanners, BANNER_CATALOG, Menu, UpdateBanner, GpuImageModeBanner });
+Object.assign(window, { Modal, Drawer, ConfirmDialog, Banner, BannerStack, BannerProvider, useBanners, BANNER_CATALOG, Menu, UpdateBanner, GpuImageModeBanner, FieldGroup, PillToggle });

--- a/ui/src/dash/settings.jsx
+++ b/ui/src/dash/settings.jsx
@@ -18,7 +18,7 @@
 import { useSecrets, useSecretSet, useSecretDelete } from '@/api/hooks/useSecrets'
 import { useUpdateState, useUpdateCheck, useUpdateApply, useUpdateJob, useSetUpdateChannel } from '@/api/hooks/useUpdates'
 import { useCapabilities, useCapabilityPatch, useCapabilityApply } from '@/api/hooks/useCapabilities'
-import { useSlotEdit, useSlotConfig } from '@/api/hooks/useSlots'
+import { useSlots, useSlotEdit, useSlotConfig } from '@/api/hooks/useSlots'
 import {
   useSettings,
   useSettingsUpdate,
@@ -30,14 +30,17 @@ import {
 
 const { useState: useStateSet, useEffect: useEffectSet, useRef: useRefSet } = React;
 
-function SettingsView() {
-  const [section, setSection] = useStateSet("secrets");
+function SettingsView({ param }) {
+  const VALID_IDS = ["secrets", "storage", "updates", "voice", "imagegen", "defaults", "general", "about"];
+  const initialSection = param && VALID_IDS.includes(param) ? param : "secrets";
+  const [section, setSection] = useStateSet(initialSection);
   const sections = [
     { id: "secrets",   label: "Secrets" },
     { id: "storage",   label: "Storage" },
     { id: "updates",   label: "Updates" },
     { id: "voice",     label: "Voice" },
     { id: "imagegen",  label: "Image-gen" },
+    { id: "defaults",  label: "Default slots" },
     { id: "general",   label: "General" },
     { id: "about",     label: "About" },
   ];
@@ -69,6 +72,7 @@ function SettingsView() {
           {section === "updates" && <UpdatesSection />}
           {section === "voice" && <VoiceSection />}
           {section === "imagegen" && <ImageGenSection />}
+          {section === "defaults" && <DefaultSlotsSection />}
           {section === "general" && <GeneralSection />}
           {section === "about" && <AboutSection />}
         </div>
@@ -909,6 +913,77 @@ function ImageGenSection() {
           <button className="btn sm" disabled={!imgDirty || loading || applyCapability.isPending} onClick={doSave}>Save Image-gen</button>
         </div>
       </div>
+    </div>
+  );
+}
+
+// ─── DefaultSlotsSection ─────────────────────────────────────────────────────
+//
+// For each slot type with ≥2 slots, lets the operator pick which slot is the
+// default for type-routed requests. Setting a default:
+//   PUT /api/slots/{name}/config { default: true }  — on chosen slot
+//   PUT /api/slots/{name}/config { default: false } — on previously-default sibling
+// Both calls route through the existing useSlotEdit hook.
+// No backend schema change is needed — `default` is already an accepted field.
+// Relocated from the slot edit drawer (removed in earlier task).
+function DefaultSlotsSection() {
+  const slotsQuery = useSlots();
+  const editSlot = useSlotEdit();
+  const slots = slotsQuery.data || [];
+  const byType = {};
+  for (const s of slots) { (byType[s.type] ||= []).push(s); }
+  const types = Object.keys(byType).filter(t => byType[t].length >= 2).sort();
+
+  const setDefault = async (type, name) => {
+    const sibs = byType[type] || [];
+    const prev = sibs.find(s => s.isDefault && s.name !== name);
+    try {
+      await editSlot.mutateAsync({ name, body: { default: true } });
+      if (prev) await editSlot.mutateAsync({ name: prev.name, body: { default: false } });
+      window.__hal0Toast && window.__hal0Toast(`Default ${type} slot → ${name}`, "ok");
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(`Couldn't set default — ${e?.message || "see logs"}`, "err");
+    }
+  };
+
+  return (
+    <div className="s-section">
+      <h2>Default slots</h2>
+      <p className="desc">
+        For each modality with more than one slot, choose which slot serves type-routed requests.
+      </p>
+      {slotsQuery.isPending && (
+        <div style={{padding: 16, color: "var(--fg-4)", fontFamily: "var(--jbm)", fontSize: 12}}>Loading slots…</div>
+      )}
+      {slotsQuery.isError && (
+        <div className="err">{slotsQuery.error?.message || "Failed to load slots"}</div>
+      )}
+      {!slotsQuery.isPending && !slotsQuery.isError && types.length === 0 && (
+        <p className="hint" style={{fontFamily: "var(--jbm)", fontSize: 12, color: "var(--fg-4)"}}>No modality has multiple slots yet.</p>
+      )}
+      {types.length > 0 && (
+        <div className="s-panel">
+          {types.map(type => {
+            const cur = (byType[type].find(s => s.isDefault) || {}).name || "";
+            return (
+              <div className="default-slot-row form-row s-row" key={type}>
+                <div className="k"><span>{type}</span></div>
+                <div className="v">
+                  <select
+                    className="input mono"
+                    value={cur}
+                    disabled={editSlot.isPending}
+                    onChange={e => { const n = e.target.value; if (n && n !== cur) setDefault(type, n); }}
+                    style={{fontFamily: "var(--jbm)", fontSize: 11, background: "var(--bg-2)", color: "var(--fg)", border: "1px solid var(--line)", borderRadius: 4, padding: "3px 6px"}}
+                  >
+                    {byType[type].map(s => <option key={s.name} value={s.name}>{s.name}</option>)}
+                  </select>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -518,6 +518,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
         <ReadOnlyStrip k="image status" v={slot.image_status || "present"} />
       </div>
 
+      <FieldGroup label="Slot" hint="this instance">
       <div className="form-row">
         <div className="form-lbl"><span>Name</span><span className="sub">seeded slots can't be renamed</span></div>
         <div className="form-ctl"><input className="input mono" value={slot.name} disabled /></div>
@@ -599,6 +600,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
         );
       })()}
 
+      </FieldGroup>
+
+      <FieldGroup label="Model" hint="what it loads">
       {/* Task 1: live model swap — mirrors the card's ModelPicker but with the
           full type+rocmfp4 compatibility filter (same as InlineSwapPopover).
           Swap is its own POST /slots/{name}/swap (not part of the batched
@@ -671,6 +675,23 @@ function EditSlotDrawer({ open, slot, onClose }) {
         );
       })()}
 
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>ctx_size</span>
+          <span className="warn">⟳ restarts the container (~model-load seconds)</span>
+        </div>
+        <div className="form-ctl">
+          <input
+            className={"input mono" + (fieldErrs.ctx ? " input-err" : "")}
+            value={ctx}
+            onChange={e => { setCtx(e.target.value); setFieldErrs(p => ({...p, ctx: undefined})); }}
+          />
+          {fieldErrs.ctx && <div className="hint" style={{color: "var(--err)"}}>{fieldErrs.ctx}</div>}
+        </div>
+      </div>
+      </FieldGroup>
+
+      <FieldGroup label="Inference" hint="behavior">
       {/* C4: per-slot thinking default — llm slots only. Instant-apply (its
           own PUT /config), no restart: _slot_thinking_default reads it live
           on the next request. */}
@@ -706,27 +727,13 @@ function EditSlotDrawer({ open, slot, onClose }) {
           </div>
         </div>
       )}
+      </FieldGroup>
 
       {/* Task 4: Advanced fields (mostly read-only, profile-owned) are
           collapsed by default — minimal native <details> disclosure (no
           disclosure primitive exists in primitives.jsx). */}
       <details className="adv-disclosure">
       <summary className="form-section" style={{cursor: "pointer", listStyle: "revert"}}>Advanced</summary>
-
-      <div className="form-row">
-        <div className="form-lbl">
-          <span>ctx_size</span>
-          <span className="warn">⟳ restarts the container (~model-load seconds)</span>
-        </div>
-        <div className="form-ctl">
-          <input
-            className={"input mono" + (fieldErrs.ctx ? " input-err" : "")}
-            value={ctx}
-            onChange={e => { setCtx(e.target.value); setFieldErrs(p => ({...p, ctx: undefined})); }}
-          />
-          {fieldErrs.ctx && <div className="hint" style={{color: "var(--err)"}}>{fieldErrs.ctx}</div>}
-        </div>
-      </div>
 
       {/* C5: GPU offload tuning — read-only, defined by the profile. */}
       <div className="form-row">

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -692,47 +692,32 @@ function EditSlotDrawer({ open, slot, onClose }) {
       {slot.type === "llm" && (
         <div className="form-row">
           <div className="form-lbl">
-            <span>Thinking</span>
-            <span className="sub">Stream reasoning before the answer. Off = faster, direct replies.</span>
-            {/* Task 3: make the instant-apply contract explicit — unlike the
-                ctx_size/profile fields, this saves on toggle, not on Save. */}
-            <span className="sub">applies immediately (no Save needed)</span>
+            <span>Reasoning</span>
+            <span className="sub">Stream reasoning before the answer. Off = faster, direct replies. Applies to the next message.</span>
           </div>
           <div className="form-ctl">
-            <label className="checkbox-row">
-              <input
-                type="checkbox"
-                checked={thinking}
-                disabled={thinkingPending}
-                onChange={async (e) => {
-                  const next = e.target.checked;
-                  setThinking(next);
-                  setThinkingPending(true);
-                  setThinkingErr(null);
-                  try {
-                    await editMut.mutateAsync({
-                      name: slot.name,
-                      body: { enable_thinking: next },
-                    });
-                    window.__hal0Toast && window.__hal0Toast(
-                      `${slot.name} thinking ${next ? "on" : "off"} — applies to next message`,
-                      "ok",
-                    );
-                  } catch (err) {
-                    setThinking(!next); // revert on failure
-                    // Task 3: surface the failure inline near the toggle, not
-                    // only via the silent revert above.
-                    setThinkingErr(err?.message || "thinking toggle failed");
-                  } finally {
-                    setThinkingPending(false);
-                  }
-                }}
-              />
-              <span>{thinking ? "Reasoning on" : "Reasoning off"}</span>
-            </label>
-            {thinkingErr && (
-              <div className="hint" style={{color: "var(--err)"}}>{thinkingErr}</div>
-            )}
+            <PillToggle
+              on={thinking}
+              disabled={thinkingPending}
+              label="Reasoning"
+              stateText={thinking ? "On" : "Off"}
+              onToggle={async (next) => {
+                setThinking(next);
+                setThinkingPending(true);
+                setSubmitErr(null);
+                setThinkingErr(null);
+                try {
+                  await editMut.mutateAsync({ name: slot.name, body: { enable_thinking: next } });
+                  window.__hal0Toast && window.__hal0Toast(`${slot.name} reasoning ${next ? "on" : "off"} — applies to next message`, "ok");
+                } catch (err) {
+                  setThinking(!next);
+                  setThinkingErr(err?.message || "reasoning toggle failed");
+                } finally {
+                  setThinkingPending(false);
+                }
+              }}
+            />
+            {thinkingErr && <div className="hint" style={{ color: "var(--err)" }}>{thinkingErr}</div>}
           </div>
         </div>
       )}

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -350,7 +350,6 @@ function EditSlotDrawer({ open, slot, onClose }) {
     slot?.rope_freq_base != null ? String(slot.rope_freq_base) : "0"
   );
   const [extraArgs, setExtraArgs] = useStateSM(initialExtraArgs);
-  const [makeDefault, setMakeDefault] = useStateSM(!!slot?.isDefault);
   const [submitErr, setSubmitErr] = useStateSM(null);
   // Inline error for the instant-apply thinking toggle (task 3): surface the
   // failure next to the control instead of only reverting state silently.
@@ -370,7 +369,6 @@ function EditSlotDrawer({ open, slot, onClose }) {
       setThinkingPending(false);
       setNGpuLayers(slot.n_gpu_layers != null ? String(slot.n_gpu_layers) : "-1");
       setRopeFreqBase(slot.rope_freq_base != null ? String(slot.rope_freq_base) : "0");
-      setMakeDefault(!!slot.isDefault);
       // #587: re-seed from the slot prop so the drawer tracks the real
       // on-disk values.
       setExtraArgs(slot.llamacpp_args != null ? slot.llamacpp_args : "");
@@ -421,9 +419,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
       const ctxBody = {
         ctx_size: ctxNum,
       };
-      const slotBody = {
-        default: makeDefault,
-      };
+      const slotBody = {};
       if (profileChanged) {
         slotBody.profile = selectedProfile;
       }
@@ -668,23 +664,6 @@ function EditSlotDrawer({ open, slot, onClose }) {
           </div>
         );
       })()}
-
-      <div className="form-row">
-        <div className="form-lbl">
-          <span>Default for type {slot.type}?</span>
-          <span className="sub">{slot.isDefault ? "currently default" : "another slot is default"}</span>
-        </div>
-        <div className="form-ctl">
-          <label className="checkbox-row">
-            <input
-              type="checkbox"
-              checked={makeDefault}
-              onChange={e => setMakeDefault(e.target.checked)}
-            />
-            <span>Set as default</span>
-          </label>
-        </div>
-      </div>
 
       {/* C4: per-slot thinking default — llm slots only. Instant-apply (its
           own PUT /config), no restart: _slot_thinking_default reads it live

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -606,13 +606,19 @@ function EditSlotDrawer({ open, slot, onClose }) {
           popover does. */}
       {(() => {
         const isContainer = slot.runtime === "container";
+        // Derive the backend from the SELECTED profile (reactive), falling back
+        // to the slot's persisted backend when the profile carries none or isn't
+        // found yet. This makes the rocmfp4 filter re-evaluate immediately when
+        // the operator switches profiles — before Save is clicked.
+        const selProfileMeta = (profilesQuery.data ?? []).find(p => p.name === selectedProfile);
+        const selBackend = selProfileMeta?.backend ?? slot.backend;
         const compatible = (modelsQuery.data ?? [])
           .map(normalizeApiModel)
           .filter(m =>
             m.type === slot.type &&
             // ROCmFP4-quantized models only run on the rocm fork binary — hide
-            // them when the slot isn't on the rocm backend (mirror the popover).
-            !(Array.isArray(m.tags) && m.tags.includes("rocmfp4") && slot.backend !== "rocm")
+            // them when the selected profile isn't on the rocm backend.
+            !(Array.isArray(m.tags) && m.tags.includes("rocmfp4") && selBackend !== "rocm")
           );
         const cur = slot.model_id || slot.model || "";
         const has = compatible.some(m => m.id === cur);

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -1534,6 +1534,13 @@ select.npu-sel {
 }
 .npu-switch[data-on="1"] .knob { left: 20px; }
 
+.field-group { margin: 18px 0 4px; }
+.field-group-head { display: flex; align-items: baseline; gap: 8px; padding: 0 0 6px; border-bottom: 1px solid var(--line-soft); margin-bottom: 8px; }
+.field-group-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--fg-4); font-weight: 600; }
+.field-group-hint { font-size: 10.5px; color: var(--fg-5); }
+.pill-toggle-row { display: flex; align-items: center; gap: 10px; }
+.pill-toggle-state { font-size: 12px; color: var(--fg-3); }
+
 .npu-stack-foot {
   display: flex;
   align-items: center;

--- a/ui/tests/e2e/specs/settings-default-slots-v3.spec.ts
+++ b/ui/tests/e2e/specs/settings-default-slots-v3.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect, type Page } from '../fixtures/apiMock'
+
+async function seedSlots(page: Page, slots: any[]) {
+  await page.addInitScript((slots) => {
+    let real: any
+    Object.defineProperty(window, 'HAL0_DATA', {
+      configurable: true, get() { return real },
+      set(v) { real = v; if (v && typeof v === 'object') v.slots = slots },
+    })
+  }, slots)
+}
+
+const A = { name: 'primary', type: 'llm', device: 'gpu-rocm', state: 'serving', port: 8092, isDefault: true,  enabled: true }
+const B = { name: 'backup',  type: 'llm', device: 'gpu-rocm', state: 'ready',   port: 8093, isDefault: false, enabled: true }
+
+test('Default slots pane sets the chosen slot default and clears the prior one', async ({ page }) => {
+  const puts: Record<string, any[]> = { primary: [], backup: [] }
+  for (const n of ['primary', 'backup']) {
+    await page.route(`**/api/slots/${n}/config`, async (route) => {
+      if (route.request().method() === 'PUT') puts[n].push(JSON.parse(route.request().postData() || '{}'))
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+  }
+  await seedSlots(page, [A, B])
+  await page.goto('/#settings/defaults')
+  const row = page.locator('.default-slot-row', { hasText: 'llm' })
+  await expect(row).toBeVisible()
+  await row.locator('select').selectOption('backup')
+  await expect.poll(() => puts.backup.length).toBeGreaterThan(0)
+  expect(puts.backup[0].default).toBe(true)
+  await expect.poll(() => puts.primary.length).toBeGreaterThan(0)
+  expect(puts.primary[0].default).toBe(false)
+})

--- a/ui/tests/e2e/specs/settings-v3.spec.ts
+++ b/ui/tests/e2e/specs/settings-v3.spec.ts
@@ -1,7 +1,7 @@
 /**
- * settings-v3 — `#settings` route renders the rail nav with all 7
- * sections (secrets, storage, updates, voice, image-gen, general, about)
- * and swaps the right pane on click.
+ * settings-v3 — `#settings` route renders the rail nav with all 8
+ * sections (secrets, storage, updates, voice, image-gen, default slots,
+ * general, about) and swaps the right pane on click.
  *
  * Auth section removed per ADR-0012 (PRs #254-#267); default landing
  * is now Secrets. #544 pruned the fully-mock OmniRouter/Agent-policy/
@@ -10,15 +10,16 @@
  * Appearance→General. #554 added Voice + Image-gen sections.
  * #687 Phase E removed the Runtime section (the old runtime admin pane) —
  * runtime status now lives on the sidebar rollup + footer chip.
+ * Task 6 added the Default slots section (relocated from slot edit drawer).
  */
 import { test, expect } from '../fixtures/apiMock'
 
 const SECTIONS = [
-  'Secrets', 'Storage', 'Updates', 'Voice', 'Image-gen', 'General', 'About',
+  'Secrets', 'Storage', 'Updates', 'Voice', 'Image-gen', 'Default slots', 'General', 'About',
 ]
 
 test.describe('Settings v3 (/settings)', () => {
-  test('renders rail nav with all 7 sections', async ({ page }) => {
+  test('renders rail nav with all 8 sections', async ({ page }) => {
     await page.goto('/#settings')
     await expect(page.locator('.view .vh h1')).toHaveText('Settings')
     const nav = page.locator('.settings-nav .nav-item')

--- a/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
@@ -258,4 +258,38 @@ test.describe('C7 — drawer-editable profile + create-modal device derivation',
     expect(createBodies[0].device).toBe('gpu-vulkan')
     expect(createBodies[0].profile).toBe('vulkan')
   })
+
+  // C7h — model options re-filter from the SELECTED profile, not the persisted one
+  test('C7h — model options re-filter from the SELECTED profile, not the persisted one', async ({ page }) => {
+    // The dashboard uses mockFetch (VITE_MOCK_HAL0=1) which short-circuits
+    // page.route for allowlisted endpoints like /api/models — it reads
+    // HAL0_DATA.models directly. Seed both slots AND models in a single
+    // addInitScript so the setter patch covers both fields in one pass.
+    // NOTE: capabilities: ['chat'] is required for the lib normalizeApiModel
+    // to derive type='llm'; a bare type field is overwritten by deriveType().
+    const testModels = [
+      { id: 'qwen-fp4', name: 'qwen-fp4', capabilities: ['chat'], tags: ['rocmfp4'] },
+      { id: 'qwen-plain', name: 'qwen-plain', capabilities: ['chat'], tags: [] },
+    ]
+    await page.addInitScript(({ slots, models }: { slots: any[], models: any[] }) => {
+      let real: any
+      Object.defineProperty(window, 'HAL0_DATA', {
+        configurable: true,
+        get() { return real },
+        set(v) {
+          real = v
+          if (v && typeof v === 'object') {
+            v.slots = slots
+            v.models = models
+          }
+        },
+      })
+    }, { slots: [CHAT_CONTAINER], models: testModels })
+    await page.goto('/#slots/chat')
+    const modelSel = page.locator('.drawer .form-row', { hasText: 'Model' }).locator('select')
+    await expect(modelSel.locator('option[value="qwen-fp4"]')).toHaveCount(1)   // rocm profile → fp4 present
+    await page.locator('.drawer .form-row', { hasText: 'Profile' }).locator('select').selectOption('vulkan')
+    await expect(modelSel.locator('option[value="qwen-fp4"]')).toHaveCount(0)   // vulkan → fp4 filtered out
+    await expect(modelSel.locator('option[value="qwen-plain"]')).toHaveCount(1)
+  })
 })

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -62,7 +62,7 @@ async function seedSlots(page: Page, slots: any[]) {
 // slot *edit drawer* (opened via the #slots/:name route), which is unchanged.
 
 test.describe('Slot edit controls (/slots)', () => {
-  test('C4 — drawer thinking toggle PUTs /config { enable_thinking:true }', async ({ page }) => {
+  test('C4 — drawer reasoning pill PUTs /config { enable_thinking:true }', async ({ page }) => {
     const puts: any[] = []
     await page.route('**/api/slots/primary/config', async (route) => {
       if (route.request().method() === 'PUT') {
@@ -73,18 +73,18 @@ test.describe('Slot edit controls (/slots)', () => {
     await seedSlots(page, [PRIMARY, EMBED])
 
     await page.goto('/#slots/primary')
-    const row = page.locator('.drawer .form-row', { hasText: 'Thinking' })
+    const row = page.locator('.drawer .form-row', { hasText: 'Reasoning' })
     await expect(row).toBeVisible()
-    await row.locator('input[type="checkbox"]').click()
+    await row.locator('button[role="switch"]').click()
     await expect.poll(() => puts.length).toBeGreaterThan(0)
     expect(puts[0].enable_thinking).toBe(true)
   })
 
-  test('C4 — thinking toggle is hidden for non-llm slots', async ({ page }) => {
+  test('C4 — reasoning pill is hidden for non-llm slots', async ({ page }) => {
     await seedSlots(page, [PRIMARY, EMBED])
     await page.goto('/#slots/embed')
     await expect(page.locator('.drawer')).toBeVisible()
-    await expect(page.locator('.drawer .form-row', { hasText: 'Thinking' })).toHaveCount(0)
+    await expect(page.locator('.drawer .form-row', { hasText: 'Reasoning' })).toHaveCount(0)
   })
 
   test('C5 — n_gpu_layers is read-only, owned by the profile', async ({ page }) => {
@@ -178,5 +178,26 @@ test.describe('Slot edit controls (/slots)', () => {
     await expect(page.locator('.drawer')).toBeVisible()
     await expect(page.locator('.drawer .form-row', { hasText: 'idle_timeout_s' })).toHaveCount(0)
     await expect(page.locator('.drawer .form-row', { hasText: 'workers' })).toHaveCount(0)
+  })
+
+  test('C4 — reasoning pill toggles enable_thinking and keeps a fixed label', async ({ page }) => {
+    const puts: any[] = []
+    await page.route('**/api/slots/primary/config', async (route) => {
+      if (route.request().method() === 'PUT') puts.push(JSON.parse(route.request().postData() || '{}'))
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await seedSlots(page, [PRIMARY, EMBED])
+    await page.goto('/#slots/primary')
+
+    const row = page.locator('.drawer .form-row', { hasText: 'Reasoning' })
+    await expect(row).toBeVisible()
+    await expect(row.locator('.form-lbl span').first()).toHaveText('Reasoning')
+    const pill = row.locator('button[role="switch"]')
+    await expect(pill).toHaveAttribute('aria-checked', 'false')
+
+    await pill.click()
+    await expect.poll(() => puts.length).toBeGreaterThan(0)
+    expect(puts[0].enable_thinking).toBe(true)
+    await expect(pill).toHaveAttribute('aria-checked', 'true')
   })
 })

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -200,4 +200,21 @@ test.describe('Slot edit controls (/slots)', () => {
     expect(puts[0].enable_thinking).toBe(true)
     await expect(pill).toHaveAttribute('aria-checked', 'true')
   })
+
+  test('default-for-type row is gone from the edit drawer and Save omits default', async ({ page }) => {
+    const puts: any[] = []
+    await page.route('**/api/slots/primary/config', async (route) => {
+      if (route.request().method() === 'PUT') puts.push(JSON.parse(route.request().postData() || '{}'))
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await page.route('**/api/slots/primary/defaults', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }))
+    await seedSlots(page, [PRIMARY, EMBED])
+    await page.goto('/#slots/primary')
+    await expect(page.locator('.drawer')).toBeVisible()
+    await expect(page.locator('.drawer .form-row', { hasText: 'Default for type' })).toHaveCount(0)
+    await page.locator('.drawer button:has-text("Save")').click()
+    await expect.poll(() => puts.length).toBeGreaterThan(0)
+    expect(puts[0]).not.toHaveProperty('default')
+  })
 })

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -111,8 +111,7 @@ test.describe('Slot edit controls (/slots)', () => {
     await seedSlots(page, [PRIMARY, EMBED])
 
     await page.goto('/#slots/primary')
-    // ctx_size lives in the collapsed Advanced section — expand it first.
-    await page.locator('.drawer details.adv-disclosure summary').click()
+    // ctx_size is now in the Model group (directly visible, not inside Advanced).
     const row = page.locator('.drawer .form-row', { hasText: 'ctx_size' })
     await expect(row).toBeVisible()
     await row.locator('input').fill('16384')
@@ -199,6 +198,19 @@ test.describe('Slot edit controls (/slots)', () => {
     await expect.poll(() => puts.length).toBeGreaterThan(0)
     expect(puts[0].enable_thinking).toBe(true)
     await expect(pill).toHaveAttribute('aria-checked', 'true')
+  })
+
+  test('drawer fields are grouped under SLOT / MODEL / INFERENCE', async ({ page }) => {
+    await seedSlots(page, [PRIMARY, EMBED])
+    await page.goto('/#slots/primary')
+    await expect(page.locator('.drawer')).toBeVisible()
+    for (const label of ['Slot', 'Model', 'Inference']) {
+      await expect(page.locator('.field-group-label', { hasText: new RegExp(`^${label}$`, 'i') })).toHaveCount(1)
+    }
+    const modelGroup = page.locator('.field-group', { has: page.locator('.field-group-label', { hasText: /^Model$/i }) })
+    await expect(modelGroup.locator('.form-row', { hasText: 'Model' }).locator('select')).toBeVisible()
+    const infGroup = page.locator('.field-group', { has: page.locator('.field-group-label', { hasText: /^Inference$/i }) })
+    await expect(infGroup.locator('.form-row', { hasText: 'Reasoning' })).toBeVisible()
   })
 
   test('default-for-type row is gone from the edit drawer and Save omits default', async ({ page }) => {


### PR DESCRIPTION
Phase 1 of the slot-config UX redesign (spec + plan included in this PR under `docs/superpowers/`). **UI-only, no backend changes.** Builds on #781.

## What changes (operator-facing)
- **Grouped edit drawer** — fields are now organized under **Slot / Model / Inference** sections (`FieldGroup`), so it's clear what targets the slot instance vs. the model vs. inference behavior. `ctx_size` moved up into Model; profile-owned knobs stay in collapsed Advanced.
- **Reasoning pill** — the confusing reasoning checkbox (whose label flipped "Reasoning on/off") is now a two-state sliding pill with a **fixed label**.
- **"Default for type" removed from the drawer** → relocated to a new **Settings → "Default slots"** pane that sets the default per modality in one place (sets the chosen slot `default=true`, clears the prior sibling).
- **Model dropdown re-filters live from the *selected* profile** — pick the `vulkan` profile and rocmfp4-only models drop out immediately (was keyed on the persisted backend).

## New primitives
`FieldGroup` and `PillToggle` added to `primitives.jsx` (reusable across config surfaces in later phases).

## Verification
- `npm run typecheck` ✓ (0) · `npm run build` ✓ (0)
- Full Playwright e2e: **228 passed, 6 skipped, 0 failed**, including 4 new specs (reasoning pill, default-row-removed, reactive dropdown `C7h`, grouping) + the new `settings-default-slots-v3`.
- Note: `tsc`/`vite build` don't catch undefined-var runtime errors in `.jsx` — e2e is the correctness gate here, and every change is e2e-covered.

## Follow-ups (speced, not in this PR)
Spec `docs/superpowers/specs/2026-06-14-slot-config-grouping-mtp-templates-design.md` defines two more phases:
- **Phase 2 — MTP:** capability-gated per-slot MTP pill (research finding: MTP helps dense models, hurts MoE, needs an MTP-capable GGUF; our flag bundle likely needs a p-min retune — separate bench ticket).
- **Phase 3 — Chat templates:** model-level + slot-override (no more hand-edited TOML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)