### PR TITLE
chore(release): v0.4.1-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Tags older than v0.2.0 ship release notes inside the GitHub release
 page; this CHANGELOG starts at v0.2.0 (the Lemonade migration cut).
 For ADR-level architecture context see `docs/internal/adr/`.
 
+## [v0.4.1-alpha.1] — 2026-06-14
+
+Pre-Alpha. First release carrying the clean-install hardening proven end-to-end
+on fresh Ubuntu 24.04 containers:
+
+- Bundled-agent install converges on the hal0-managed venv — `hal0 agent
+  install hermes` provisions toolchain → venv → wrapper → unit in one
+  foreground command, and the API path becomes a thin register-or-hint (#766).
+- Installer auto-installs the python venv stdlib on clean Debian/Ubuntu instead
+  of aborting at preflight (#778); NPU host-lib prereqs (ffmpeg6/XRT) are now
+  best-effort, not fatal (#779).
+- `/var/lib/hal0` permissions let the `hal0` agent refresh the shared STATE.md
+  the session hook reads (#777).
+- Slot config UX Phase 1: grouped drawer, reasoning pill, type-default pane,
+  reactive model dropdown (#796).
+
 ## [v0.3.2-alpha.1] — 2026-05-29
 
 End-of-stream cut for v0.3. Bundles MCP-completion, memory-map redesign,

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
   "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release \u2014 the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See PLAN.md \u00a712 (toolbox images) and \u00a717 (Risks).",
-  "version": "0.3.2-alpha.1",
+  "version": "0.4.1-alpha.1",
   "channel": "dev",
   "toolbox_images": {
     "vulkan": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.3.2-alpha.1"
+version = "0.4.1-alpha.1"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1380,7 +1380,7 @@ wheels = [
 
 [[package]]
 name = "hal0"
-version = "0.3.2a1"
+version = "0.4.1a1"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },


### PR DESCRIPTION
Pre-Alpha release cut. Bumps version to `0.4.1-alpha.1` (pyproject + uv.lock + manifest.json) and adds the CHANGELOG entry.

First release that carries the clean-install hardening landed today, so `hal0 update` can deliver it to FHS installs:
- #766 bundled-agent install → managed venv
- #777 STATE.md perms
- #778 installer auto-installs python3-venv
- #779 NPU host-libs best-effort
- #796 Slot config UX Phase 1

Merging this, then tagging `v0.4.1-alpha.1` triggers `release.yml` (build → cosign → manifest → publish; `releases.hal0.dev/stable.json` picks it up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)