### PR TITLE
fix(release): cosign-installer @v4 → @v3 (no v4 exists)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
 
       # ── 3. cosign keyless-sign the tarball via GH Actions OIDC ──────────────
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v3
 
       - name: cosign sign-blob (keyless OIDC, legacy raw .sig + .crt)
         id: sign


### PR DESCRIPTION
The release workflow failed at `Set up job` with `unable to resolve action sigstore/cosign-installer@v4` — #708 bumped it to a nonexistent major (cosign-installer max is v3). `checkout@v6`/`setup-node@v6` are valid; only cosign was wrong. Unblocks the v0.4.1-alpha.1 release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)