### PR TITLE
Non-blocking slot controls + npu/image-gen toggles (cancel mid-load)

### DIFF
--- a/ui/src/dash/comfyui-pane.jsx
+++ b/ui/src/dash/comfyui-pane.jsx
@@ -345,56 +345,71 @@ export function ComfyuiPane() {
   // Pin toggle — synchronous 200 {"pinned":bool}, so mirror the switchover's
   // refetch-not-optimistic pattern: toast, then refetch /status so the arbiter
   // block (pin state + countdown) re-renders from server truth.
-  const doPin = async () => {
+  // Fire-and-forget pin flip — toast immediately and refetch on success so the
+  // arbiter block re-renders from server truth; never block the toggle on the
+  // round-trip. (Mirrors the non-blocking control pattern from PR #781.)
+  const doPin = () => {
     if (!arb || pin.isPending) return
     const next = !arb.pinned
-    try {
-      await pin.mutateAsync({ pinned: next })
-      toast(next ? 'Image mode pinned — auto-restore disabled.' : 'Unpinned — auto-restore re-armed.', 'ok')
-      q.refetch()
-    } catch (err) {
-      const code = String(err?.code || '')
-      if (code === 'comfyui.switchover_disabled' || err?.status === 501) {
-        toast(
-          'ComfyUI switchover is disabled on this host — set HAL0_COMFYUI_SWITCHOVER_ENABLED=1 ' +
-            'on hal0-api to enable it.',
-          'warn'
-        )
-      } else {
-        toast(err?.message ? `pin failed: ${err.message}` : 'pin failed', 'warn')
+    pin.mutate(
+      { pinned: next },
+      {
+        onSuccess: () => {
+          toast(next ? 'Image mode pinned — auto-restore disabled.' : 'Unpinned — auto-restore re-armed.', 'ok')
+          q.refetch()
+        },
+        onError: (err) => {
+          const code = String(err?.code || '')
+          if (code === 'comfyui.switchover_disabled' || err?.status === 501) {
+            toast(
+              'ComfyUI switchover is disabled on this host — set HAL0_COMFYUI_SWITCHOVER_ENABLED=1 ' +
+                'on hal0-api to enable it.',
+              'warn'
+            )
+          } else {
+            toast(err?.message ? `pin failed: ${err.message}` : 'pin failed', 'warn')
+          }
+        },
       }
-    }
+    )
   }
 
-  const doSwitch = async () => {
+  // Fire-and-forget switchover — close the confirm dialog and toast the moment
+  // the user commits, rather than after the round-trip. The switchover POST is
+  // already async (202; the GPU arbiter drains/flips in the background) and the
+  // status poll's `switchover` block drives the transitional UI, so the click
+  // never has to wait. (Mirrors the non-blocking control pattern from PR #781.)
+  const doSwitch = () => {
     const target = confirm
-    try {
-      // The confirm dialog already warned that queued renders drop — that
-      // consent is what authorizes force when tearing down a busy queue.
-      const force = target === 'inference' && queueTotal > 0 ? true : undefined
-      await sw.mutateAsync({ mode: target, force })
-      toast(`Switching to ${target} mode…`, 'ok')
-      setConfirm(null)
-      setTimeout(() => q.refetch(), 1500)
-    } catch (err) {
-      setConfirm(null)
-      // Hal0Error carries the backend envelope's code directly (e.g.
-      // comfyui.switchover_disabled / comfyui.busy) + the HTTP status.
-      const code = String(err?.code || '')
-      if (code === 'comfyui.switchover_disabled' || err?.status === 501) {
-        toast(
-          'ComfyUI switchover is disabled on this host — set HAL0_COMFYUI_SWITCHOVER_ENABLED=1 ' +
-            'on hal0-api to enable it.',
-          'warn'
-        )
-      } else if (code === 'comfyui.busy') {
-        toast('Renders are still running or queued — drain the queue first.', 'warn')
-      } else if (code === 'comfyui.switch_in_progress') {
-        toast('A switchover is already in progress — wait for it to finish.', 'warn')
-      } else {
-        toast(err?.message ? `switchover failed: ${err.message}` : 'switchover failed', 'warn')
+    // The confirm dialog already warned that queued renders drop — that
+    // consent is what authorizes force when tearing down a busy queue.
+    const force = target === 'inference' && queueTotal > 0 ? true : undefined
+    setConfirm(null)
+    toast(`Switching to ${target} mode…`, 'info')
+    sw.mutate(
+      { mode: target, force },
+      {
+        onError: (err) => {
+          // Hal0Error carries the backend envelope's code directly (e.g.
+          // comfyui.switchover_disabled / comfyui.busy) + the HTTP status.
+          const code = String(err?.code || '')
+          if (code === 'comfyui.switchover_disabled' || err?.status === 501) {
+            toast(
+              'ComfyUI switchover is disabled on this host — set HAL0_COMFYUI_SWITCHOVER_ENABLED=1 ' +
+                'on hal0-api to enable it.',
+              'warn'
+            )
+          } else if (code === 'comfyui.busy') {
+            toast('Renders are still running or queued — drain the queue first.', 'warn')
+          } else if (code === 'comfyui.switch_in_progress') {
+            toast('A switchover is already in progress — wait for it to finish.', 'warn')
+          } else {
+            toast(err?.message ? `switchover failed: ${err.message}` : 'switchover failed', 'warn')
+          }
+        },
+        onSettled: () => setTimeout(() => q.refetch(), 1500),
       }
-    }
+    )
   }
 
   return (

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -355,7 +355,6 @@ export function SlotControls({ phase, busy, compact, onStart, onStop, onRestart,
         <button
           className="sctrl stop"
           title="Stop"
-          disabled={busy || phase === 'transitional'}
           onClick={onStop}
         >
           <Ic name="stop" size={13} />
@@ -564,24 +563,26 @@ export function InferencePane() {
   const gttCapGb = mm.pool?.totalGb || 0
   const gttFreeGb = Math.max(0, Math.round(gttCapGb - (mm.self?.gttUsedGb || 0)))
 
-  const run = async (name, mut, args, okMsg) => {
+  // Fire-and-forget lifecycle action (mirrors SlotsView/PR #781): fire the
+  // mutation, toast immediately, and let the slots poll reflect the phase.
+  // `busy` marks the in-flight action to gate Start against a double-trigger;
+  // Stop is never gated (see SlotControls) so a slow load stays cancelable.
+  const run = (name, mut, args, okMsg) => {
     setBusyName(name)
-    try {
-      await mut.mutateAsync(args)
-      toast(okMsg, 'ok')
-    } catch (err) {
-      toast(err?.message ? `${name}: ${err.message}` : `${name}: action failed`, 'warn')
-    } finally {
-      setBusyName(null)
-    }
+    mut.mutate(args, {
+      onError: (err) =>
+        toast(err?.message ? `${name}: ${err.message}` : `${name}: action failed`, 'warn'),
+      onSettled: () => setBusyName(null),
+    })
+    toast(okMsg, 'info')
   }
 
   const handlers = {
-    onStart: (s) => run(s.name, loadMut, s.name, `Starting ${s.name}`),
-    onStop: (s) => run(s.name, unloadMut, s.name, `Unloaded ${s.name}`),
-    onRestart: (s) => run(s.name, restartMut, s.name, `Restarting ${s.name}`),
+    onStart: (s) => run(s.name, loadMut, s.name, `Starting ${s.name}…`),
+    onStop: (s) => run(s.name, unloadMut, s.name, `Stopping ${s.name}…`),
+    onRestart: (s) => run(s.name, restartMut, s.name, `Restarting ${s.name}…`),
     onSwap: (s, model_id) =>
-      run(s.name, swapMut, { name: s.name, model_id }, `Swapping ${s.name}`),
+      run(s.name, swapMut, { name: s.name, model_id }, `Swapping ${s.name}…`),
     onEdit: (s) => {
       window.location.hash = '#slots/' + s.name
     },

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -380,7 +380,6 @@ function SlotCard({
           <>
             <button
               className="btn ghost sm"
-              disabled={!!busy || phase === "transitional"}
               onClick={() => onUnload && onUnload()}
             >{Icons.unload} Stop</button>
             <button
@@ -406,19 +405,15 @@ function SlotListRow({ slot, onEdit }) {
   // restart mutation and the Edit drawer (via the #slots/:name route, the
   // same path SlotCard uses). `onEdit` is optional; fall through to hash.
   const restartMut = useSlotRestart();
-  const [busy, setBusy] = useStateS(false);
   const goEdit = onEdit || (() => { window.location.hash = "#slots/" + slot.name; });
-  const onRestart = async () => {
-    setBusy(true);
-    try {
-      await restartMut.mutateAsync(slot.name);
-      window.__hal0Toast && window.__hal0Toast(`Restarting ${slot.name}`, "ok");
-    } catch (err) {
-      window.__hal0Toast && window.__hal0Toast(
-        err?.message ? `${slot.name}: ${err.message}` : `${slot.name}: restart failed`, "warn");
-    } finally {
-      setBusy(false);
-    }
+  // Fire-and-forget restart — never block the row on the model reload.
+  const onRestart = () => {
+    restartMut.mutate(slot.name, {
+      onError: (err) =>
+        window.__hal0Toast && window.__hal0Toast(
+          err?.message ? `${slot.name}: ${err.message}` : `${slot.name}: restart failed`, "warn"),
+    });
+    window.__hal0Toast && window.__hal0Toast(`Restarting ${slot.name}…`, "info");
   };
   const tps = type === "llm" ? `${metrics.toks || 0} t/s` :
               type === "embedding" ? `${metrics.rpm} r/m` :
@@ -446,7 +441,6 @@ function SlotListRow({ slot, onEdit }) {
         <button
           className="btn ghost sm"
           title="Restart"
-          disabled={busy}
           onClick={e => { e.stopPropagation(); onRestart(); }}
         >{Icons.restart}</button>
         <button
@@ -560,7 +554,6 @@ function NpuFlmStack({ slots }) {
   const unloadMut = useSlotUnload();
   const editMut = useSlotEdit();
   const restartMutNpu = useSlotRestart();
-  const [busy, setBusy] = useStateS(false);
   const [npuOpen, setNpuOpen] = useStateS(false);
 
   if (!npuSlots.length) return null;
@@ -590,32 +583,35 @@ function NpuFlmStack({ slots }) {
   const toast = (msg, kind = "warn") =>
     window.__hal0Toast && window.__hal0Toast(msg, kind);
 
-  const run = async (fn) => {
-    setBusy(true);
-    try {
-      await fn();
-    } catch (err) {
-      toast(err?.message ? err.message : "NPU action failed", "warn");
-    } finally {
-      setBusy(false);
-    }
+  // Fire-and-forget NPU action — the FLM load/restart blocks for the whole
+  // stack warm-up (seconds), so awaiting it froze the trio's controls and the
+  // master switch for the entire load. Fire it, toast immediately, and let the
+  // 5s slots poll reflect the transition. (Mirrors the SlotsView/PR #781
+  // non-blocking pattern.)
+  const fire = (mut, args, msg) => {
+    mut.mutate(args, {
+      onError: (err) => toast(err?.message ? err.message : "NPU action failed", "warn"),
+    });
+    toast(msg, "info");
   };
 
   // Master power — load/unload the whole stack via the chat (anchor) slot.
+  // Flip-to-cancel: if the stack is loaded OR mid-load (transitional), the
+  // master fires an unload so a slow warm-up can be aborted without waiting.
   const onMaster = () => {
     if (!chat) { toast("No NPU chat slot to load", "warn"); return; }
-    run(async () => {
-      if (loaded) {
-        await unloadMut.mutateAsync(chat.name);
-      } else {
-        await loadMut.mutateAsync(chat.name);
-      }
-    });
+    const p = slotCtrlPhase(chat);
+    const stopping = loaded || p === "running" || p === "transitional";
+    fire(
+      stopping ? unloadMut : loadMut,
+      chat.name,
+      stopping ? "Unloading NPU stack…" : "Loading NPU stack…",
+    );
   };
 
   const onPickChat = (model_id) => {
     if (!chat || !model_id || model_id === chat.model) return;
-    run(() => swapMut.mutateAsync({ name: chat.name, model_id }));
+    fire(swapMut, { name: chat.name, model_id }, "Swapping NPU chat model…");
   };
 
   // Toggle a coresident modality (Phase A): write the flip to TOML via
@@ -626,13 +622,23 @@ function NpuFlmStack({ slots }) {
   const onToggleModality = (which) => {
     if (!chat) { toast("No NPU chat slot", "warn"); return; }
     const nextVal = !(parsed[which]);
-    run(async () => {
-      await editMut.mutateAsync({
-        name: chat.name,
-        body: { npu: { [which]: nextVal } },
-      });
-      await restartMutNpu.mutateAsync(chat.name);
-    });
+    // Await only the fast config write (surfaces a TOML/validation error
+    // inline); then FIRE the cold restart that picks up the new modality —
+    // never block the trio on the FLM reload.
+    editMut.mutate(
+      { name: chat.name, body: { npu: { [which]: nextVal } } },
+      {
+        onSuccess: () => {
+          fire(
+            restartMutNpu,
+            chat.name,
+            `${which} ${nextVal ? "enabled" : "disabled"} — restarting NPU stack…`,
+          );
+        },
+        onError: (err) =>
+          toast(err?.message ? err.message : "NPU config write failed", "warn"),
+      },
+    );
   };
 
   // No onPickAsr/onPickEmbed: those modalities are read-only labels (the
@@ -650,13 +656,13 @@ function NpuFlmStack({ slots }) {
   const chatCardNode = chat && (
     <SlotScard
       key="chat" s={chat} ind={slotIndicator(chat)} full
-      modelNode={<ModelPicker s={chat} models={chatModels} disabled={busy || !chat} onSwap={onPickChat} />}
+      modelNode={<ModelPicker s={chat} models={chatModels} disabled={!chat} onSwap={onPickChat} />}
       controls={
         <SlotControls
-          phase={slotCtrlPhase(chat)} busy={busy} compact={false}
-          onStart={() => run(() => loadMut.mutateAsync(chat.name))}
-          onStop={() => run(() => unloadMut.mutateAsync(chat.name))}
-          onRestart={() => run(() => restartMutNpu.mutateAsync(chat.name))}
+          phase={slotCtrlPhase(chat)} busy={false} compact={false}
+          onStart={() => fire(loadMut, chat.name, `Starting ${chat.name}…`)}
+          onStop={() => fire(unloadMut, chat.name, `Stopping ${chat.name}…`)}
+          onRestart={() => fire(restartMutNpu, chat.name, `Restarting ${chat.name}…`)}
           onLogs={() => dispatchLogs(chat.name)}
           onEdit={() => goEdit(chat.name)}
         />
@@ -686,10 +692,10 @@ function NpuFlmStack({ slots }) {
         }
         controls={
           <SlotControls
-            phase={phase} busy={busy} compact={false}
+            phase={phase} busy={false} compact={false}
             onStart={() => onToggleModality(which)}
             onStop={() => onToggleModality(which)}
-            onRestart={() => run(() => restartMutNpu.mutateAsync(chat?.name))}
+            onRestart={() => fire(restartMutNpu, chat?.name, "Restarting NPU stack…")}
             onLogs={() => dispatchLogs(tgt)}
             onEdit={() => goEdit(tgt)}
           />
@@ -756,7 +762,7 @@ function NpuFlmStack({ slots }) {
             <span className="grow" style={{flex: 1}} />
             <span className="eh-right">
               <span className="npu-master-lbl">master</span>
-              <NpuSwitch on={loaded} disabled={busy || !chat} label="Load/unload FLM stack" onClick={onMaster} />
+              <NpuSwitch on={loaded} disabled={!chat} label="Load/unload FLM stack" onClick={onMaster} />
             </span>
           </div>
 
@@ -886,19 +892,27 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
   const toast = (msg, kind = "info") =>
     window.__hal0Toast && window.__hal0Toast(msg, kind);
 
-  const runMutation = async (name, mut, args, okMsg) => {
+  // Fire-and-forget lifecycle action. The backend load/restart/unload/swap
+  // POST blocks for the whole model-load (seconds-to-minutes); awaiting it
+  // froze the card AND left Stop disabled for the entire load, so a user
+  // couldn't cancel a slow-loading slot. Instead we FIRE the mutation (mutate,
+  // not mutateAsync), toast immediately, and let the 5s slots poll drive the
+  // transitional → running phase. `busy` marks the action in-flight (gates
+  // Start/Restart against a double-trigger) but never gates Stop — see
+  // SlotCard — so cancel stays live throughout the load. Errors surface via
+  // toast since there's no spinner to clear. (Mirrors the non-blocking
+  // save/swap from PR #781.)
+  const runMutation = (name, mut, args, okMsg) => {
     setBusyName(name);
-    try {
-      await mut.mutateAsync(args);
-      toast(okMsg, "ok");
-    } catch (err) {
-      toast(
-        err?.message ? `${name}: ${err.message}` : `${name}: action failed`,
-        "warn",
-      );
-    } finally {
-      setBusyName(null);
-    }
+    mut.mutate(args, {
+      onError: (err) =>
+        toast(
+          err?.message ? `${name}: ${err.message}` : `${name}: action failed`,
+          "warn",
+        ),
+      onSettled: () => setBusyName(null),
+    });
+    toast(okMsg, "info");
   };
 
   // Open Edit drawer when route is #slots/:name
@@ -1004,20 +1018,20 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
       }}
       onEdit={() => { window.location.hash = "#slots/" + s.name; }}
       onRestart={() =>
-        runMutation(s.name, restartMut, s.name, `Restarting ${s.name}`)
+        runMutation(s.name, restartMut, s.name, `Restarting ${s.name}…`)
       }
       onUnload={() =>
-        runMutation(s.name, unloadMut, s.name, `Unloaded ${s.name}`)
+        runMutation(s.name, unloadMut, s.name, `Stopping ${s.name}…`)
       }
       onStart={() =>
-        runMutation(s.name, loadMut, s.name, `Starting ${s.name}`)
+        runMutation(s.name, loadMut, s.name, `Starting ${s.name}…`)
       }
       onSwapPick={(m) =>
         runMutation(
           s.name,
           swapMut,
           { name: s.name, model_id: m.id },
-          `Swapping ${s.name} → ${m.longName || m.id}`,
+          `Swapping ${s.name} → ${m.longName || m.id}…`,
         )
       }
       onViewLogs={() => { setLogsForSlot(s.name); }}

--- a/ui/tests/e2e/specs/inference-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-pane-v3.spec.ts
@@ -104,6 +104,58 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
     await expect.poll(() => unloads.length).toBeGreaterThan(0)
   })
 
+  test('Stop stays enabled mid-load (transitional) → cancel fires /unload without waiting', async ({ page }) => {
+    // Regression for the non-blocking control rework: a slot that is still
+    // loading (container_status "starting" → transitional phase) must keep its
+    // Stop control LIVE so the user can cancel a slow model-load instead of
+    // waiting for it to finish. Previously Stop was `disabled` during
+    // transitional.
+    const LOADING_LLM_SLOT = {
+      name: 'loading-llm',
+      type: 'llm',
+      device: 'gpu-rocm',
+      device_class: 'gpu',
+      backend: 'rocm',
+      model: 'qwen3.6-35b-a3b-q4_k_m',
+      model_id: 'qwen3.6-35b-a3b',
+      group: 'chat',
+      state: 'starting',
+      port: 8099,
+      runtime: 'container',
+      profile: 'rocm',
+      container_status: 'starting',
+      container_health: false,
+      mem_mb: 0,
+      enabled: true,
+      isDefault: false,
+      metrics: { toks: 0, ttft: null, ctx: 0, kv: null },
+    }
+    const unloads: string[] = []
+    await page.route('**/api/slots/loading-llm/unload', async (route) => {
+      unloads.push(route.request().url())
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await page.addInitScript((slot) => {
+      document.addEventListener('DOMContentLoaded', () => {
+        const w = window as any
+        if (w.HAL0_DATA) {
+          const existing = (w.HAL0_DATA.slots || []).filter((s: any) => s.name !== slot.name)
+          w.HAL0_DATA.slots = [slot, ...existing]
+        }
+      })
+    }, LOADING_LLM_SLOT)
+
+    await page.goto('/#slots')
+    await page.getByTestId('infer-qcaret').click()
+    await expect(engine(page)).toHaveClass(/\bopen\b/)
+
+    const stop = body(page).getByTestId('infer-slot-loading-llm').locator('.sctrl.stop')
+    await expect(stop).toBeVisible()
+    await expect(stop).toBeEnabled() // ← the cancel-mid-load affordance
+    await stop.click()
+    await expect.poll(() => unloads.length).toBeGreaterThan(0)
+  })
+
   test('expanded Restart control POSTs /restart for a running slot', async ({ page }) => {
     const restarts: string[] = []
     await page.route('**/api/slots/primary/restart', async (route) => {


### PR DESCRIPTION
## What

Extends the fire-and-forget pattern from the save/swap rework (#781) to **every** slot control surface so clicks register instantly and a slow-loading slot can be **cancelled mid-load** instead of waiting for the model to finish loading.

## Why

Lifecycle controls `await`ed the backend POST, which blocks for the whole model-load (seconds-to-minutes). That:
1. Froze the card while the request was in flight, and
2. Disabled the **Stop** button during the `transitional` phase — so a user who started a slow load (or hit the wrong slot) had no way to cancel until it completed.

## Changes

- **SlotsView / SlotCard** — `runMutation` fires (`mutate`, not `mutateAsync`) and toasts immediately. **Stop is no longer gated by `busy`/`transitional`**, so it stays live throughout a load. Start/Restart keep their double-trigger guards.
- **SlotListRow** — restart is fire-and-forget.
- **NpuFlmStack** — `run`→`fire`; the **master** switch is flip-to-cancel (unloads when loaded *or* mid-load); the modality toggle awaits only the fast config write, then fires the cold restart. Drops the long-lived `busy` flag that froze the whole trio during an FLM reload.
- **InferencePane `SlotControls`** (shared with the NPU trio) — Stop always cancelable.
- **ComfyUI pane** — `doSwitch`/`doPin` close the confirm dialog + toast on commit rather than after the round-trip (the switchover is already a `202`-async arbiter flip; the status poll drives the transitional UI).

Toasts switched to present-progressive ("Stopping X…", "Restarting X…", "Loading NPU stack…") since the action is now in-flight rather than complete.

## Test

- New regression: **Stop stays enabled on a transitional slot and cancel fires `/unload` without waiting**.
- Full UI e2e: **237 passed / 6 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)