### PR TITLE
installer: zero-boot Hermes — provision on fresh install + fix live-resolve clobber

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1085,12 +1085,37 @@ else
         fi
     fi
 
-    # hal0-agent@hermes — gated on the hermes venv existing. PR-3 owns the
-    # actual `hal0 agent bootstrap hermes` invocation; until that lands,
-    # this branch is a no-op on fresh installs (correct — there's no
-    # agent to run yet). On upgrade installs where the venv is already
-    # present from a previous bootstrap, this enables the unit so the
-    # agent comes back up after the upgrade.
+    # hal0-agent@hermes — provision Hermes end-to-end on a FRESH install so the
+    # box comes up with a fully-configured agent (config.yaml + MCP wiring +
+    # personas + skills + install artifacts) WITHOUT a manual bootstrap step.
+    # `hal0 agent install hermes` runs the toolchain (python·venv·pip·pipx)
+    # then the full bootstrap pipeline in the foreground, chowns the
+    # provisioned trees to the hal0 runtime user, and enables the unit. It is
+    # multi-minute (pip-installs hermes-agent), so it streams into the install
+    # log. Escape hatch: HAL0_SKIP_HERMES=1 for operators who don't want the
+    # bundled agent. On UPGRADE installs the venv already exists, so the
+    # provision is skipped and the block below just (re)enables the unit.
+    # hal0-api is already up at this point (enabled + wait_active above), which
+    # the bootstrap preflight requires.
+    if [[ -f "${AGENT_UNIT_DST}" && ! -x "/var/lib/hal0/venvs/hermes/bin/hermes" ]]; then
+        if [[ "${HAL0_SKIP_HERMES:-0}" -eq 1 ]]; then
+            info "skipping hermes provisioning (HAL0_SKIP_HERMES=1) — run '${HAL0_BIN} agent install hermes' later"
+        else
+            info "provisioning Hermes agent (toolchain + bootstrap) — this can take a few minutes…"
+            if "${HAL0_BIN}" agent install hermes; then
+                info "hermes provisioned — config.yaml + MCP servers + skills wired"
+            else
+                warn "hermes provisioning failed — run '${HAL0_BIN} agent install hermes' manually"
+                warn "  diagnose with '${HAL0_BIN} agent log hermes' / '${HAL0_BIN} agent status hermes'"
+            fi
+        fi
+    fi
+
+    # Enable the unit + gateway for both fresh (just-provisioned) and upgrade
+    # installs. `hal0 agent install hermes` already enables the agent unit, so
+    # the enable here is idempotent; it also covers the upgrade path where no
+    # provision ran, plus the system-scope gateway (which the provision does
+    # not install).
     if [[ -f "${AGENT_UNIT_DST}" && -x "/var/lib/hal0/venvs/hermes/bin/hermes" ]]; then
         systemctl enable --now hal0-agent@hermes.service
         if wait_active hal0-agent@hermes.service 20; then
@@ -1116,7 +1141,9 @@ else
             warn "hermes-gateway not yet active; check 'journalctl -u hermes-gateway -n 40'"
         fi
     elif [[ -f "${AGENT_UNIT_DST}" ]]; then
-        info "hal0-agent@hermes not enabled — run 'hal0 agent bootstrap hermes' first"
+        # No venv after the provision block: it was skipped (HAL0_SKIP_HERMES=1)
+        # or failed. The warnings above already explain; this is the summary line.
+        info "hal0-agent@hermes not enabled — provision with '${HAL0_BIN} agent install hermes'"
     fi
 
 fi

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -809,6 +809,25 @@ def _default_mcp_servers() -> list[dict[str, Any]]:
     ]
 
 
+def _live_resolve_enabled() -> bool:
+    """Single source of truth for live-resolve mode.
+
+    Live-resolve is the hal0 default: ``model.default`` → the virtual
+    ``hal0/primary`` and ``providers.custom`` → the hal0-api gateway
+    (:8080/v1) with ``discover_models`` + an api_key, so Hermes' model picker
+    live-discovers every loaded slot (responsive, auto-updating, context-aware)
+    instead of pinning one physical backend. hal0-api always serves
+    ``/v1/models`` with the ``hal0/*`` virtuals + ``context_length``, so this is
+    correct even before a model is pulled. Set ``HAL0_HERMES_LIVE_RESOLVE=0`` to
+    opt back into single-backend pinning.
+
+    BOTH config_write (Phase 5) and model_automap (Phase 9) must read this so
+    their renders stay byte-identical (#245 idempotency) — otherwise the
+    automap re-render silently clobbers config_write's live-resolve output.
+    """
+    return os.environ.get("HAL0_HERMES_LIVE_RESOLVE", "1") == "1"
+
+
 def _render_config_yaml(
     *,
     primary: dict[str, Any] | None,
@@ -1053,7 +1072,7 @@ def _phase_config_write(ctx: PhaseContext) -> PhaseResult:
             }
         )
     system_prompt, personality_name = _active_persona_render(state, mcp_servers=mcp_servers)
-    live_resolve_enabled = os.environ.get("HAL0_HERMES_LIVE_RESOLVE", "0") == "1"
+    live_resolve_enabled = _live_resolve_enabled()
     rendered = _render_config_yaml(
         primary=primary,
         chat_slots=chat_slots,
@@ -2546,6 +2565,9 @@ def _phase_model_automap(ctx: PhaseContext) -> PhaseResult:
             delegation=delegation,
             custom_providers=custom_providers,
             auxiliary_tasks=auxiliary_tasks,
+            # Must match config_write (Phase 5) or this re-render clobbers the
+            # live-resolve provider block. Single source of truth.
+            live_resolve_enabled=_live_resolve_enabled(),
         )
         rendered = _apply_overrides(rendered, OVERRIDES_PATH)
     except Exception as exc:


### PR DESCRIPTION
## What
First slice of the **zero-boot Hermes** work: a fresh `install.sh` ends with a fully-configured Hermes agent — **no `hal0 agent bootstrap hermes`** — whose chat provider matches the live CT105 setup.

## Changes
1. **install.sh folds in the hermes provision.** The old branch printed *"run 'hal0 agent bootstrap hermes' first"* and did nothing on fresh installs. It now runs `hal0 agent install hermes` (toolchain + full bootstrap pipeline: config.yaml, MCP wiring, personas, skills, install artifacts, chown to `hal0`) once hal0-api is up. Escape hatch: `HAL0_SKIP_HERMES=1`.
2. **Live-resolve default + clobber fix.** `HAL0_HERMES_LIVE_RESOLVE` now defaults to `1`. Root cause of the prior silent failure: `_phase_model_automap` re-rendered `config.yaml` **without** `live_resolve_enabled`, falling back to the param default `False` and clobbering `config_write`'s live-resolve provider block (despite its #245 byte-identical-render contract). Both phases now share `_live_resolve_enabled()`.

## Verification (clean Ubuntu 24.04 LXC, fresh install, no follow-up commands)
- config.yaml (hal0-owned) renders the responsive provider: `model.default: hal0/primary`, `providers.custom.discover_models: true` + `api_key`, pointing at `:8080/v1` so the `/model` picker live-discovers loaded slots, context-aware via `/v1/models` `context_length`.
- Both MCP servers (`hal0-admin` + `hal0-memory`) present and auto-connect.
- `hal0-agent@hermes` active; `hermes status` works (no first-run setup).
- 114 hermes-provision tests pass; ruff clean.

## Acceptance criteria hit
M1 ✅ M2 ✅ M3 ✅ M4 ✅ M5 ✅ (M6 skills + F1/F2 Hindsight follow in later slices.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)