### PR TITLE
installer: stand up local Hindsight memory engine + seed banks (zero-boot F1/F2)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1088,6 +1088,66 @@ else
         warn "hal0-api failed to start; check 'journalctl -u hal0-api -n 40'"
     fi
 
+    # ── Memory engine (Hindsight) ─────────────────────────────────────────────
+    # Stand up the local hindsight-api daemon (the shared memory brain) and seed
+    # the global shared bank + the hermes private bank. The unit ships in
+    # installer/systemd/ but was never installed before, so a fresh box had
+    # HAL0_MEMORY_ENABLED=1 (api.env above) pointing at a dead engine. The daemon
+    # runs in its own venv at ${VAR_DIR}/memory/hindsight/.venv (pinned to the
+    # version CT105 runs) with an embedded postgres + local BGE/MiniLM models;
+    # its extraction/reflection LLM is hal0/utility on :8080 (used lazily — the
+    # unit sets HINDSIGHT_API_SKIP_LLM_VERIFICATION so it binds without a loaded
+    # model). Escape hatch: HAL0_SKIP_HINDSIGHT=1.
+    HS_DIR="${VAR_DIR}/memory/hindsight"
+    HINDSIGHT_UNIT_SRC="${REPO_ROOT}/installer/systemd/hindsight-api.service"
+    if [[ "${HAL0_SKIP_HINDSIGHT:-0}" -ne 1 && -f "${HINDSIGHT_UNIT_SRC}" ]]; then
+        info "setting up Hindsight memory engine (venv + daemon) — this can take a few minutes…"
+        mkdir -p "${HS_DIR}/hf-cache" "${HS_DIR}/.cache"
+        if [[ ! -x "${HS_DIR}/.venv/bin/hindsight-api" ]]; then
+            "${PY}" -m venv "${HS_DIR}/.venv"
+            "${HS_DIR}/.venv/bin/pip" install --upgrade pip wheel -q 2>/dev/null || true
+            if ! "${HS_DIR}/.venv/bin/pip" install "hindsight-api==0.7.2" -q; then
+                warn "hindsight-api install failed — memory engine will be unavailable"
+            fi
+        else
+            info "hindsight-api venv already present — skipping pip install"
+        fi
+        # The unit runs as hal0 with HOME=${HS_DIR}; hand it the whole tree.
+        chown -R hal0:hal0 "${VAR_DIR}/memory" 2>/dev/null || true
+        if [[ -x "${HS_DIR}/.venv/bin/hindsight-api" ]]; then
+            install -m644 "${HINDSIGHT_UNIT_SRC}" /etc/systemd/system/hindsight-api.service
+            systemctl daemon-reload
+            systemctl enable --now hindsight-api
+            # First boot: embedded pg0 init + local embed/rerank model load can
+            # take ~30-60s. Skip-LLM-verification means it binds without a model.
+            hs_up=0
+            for _ in $(seq 1 40); do
+                if curl -fsS "http://127.0.0.1:9177/health" >/dev/null 2>&1; then hs_up=1; break; fi
+                sleep 3
+            done
+            if [[ "${hs_up}" -eq 1 ]]; then
+                info "hindsight-api is running (memory engine on 127.0.0.1:9177)"
+                # Seed banks through hal0-api (idempotent import, config-by-field):
+                # `shared` = the global cross-agent brain; `private__hermes-agent`
+                # = hermes' private store. Other private/project banks lazy-create.
+                _seed_bank() {
+                    curl -fsS -m 20 -X POST \
+                        "http://127.0.0.1:${HAL0_PORT}/api/memory/banks/$1/import" \
+                        -H "Content-Type: application/json" -H "X-hal0-Agent: installer" \
+                        -d "$2" >/dev/null 2>&1
+                }
+                if _seed_bank shared '{"version":"1","bank":{"retain_mission":"Extract technical decisions and rationale, gotchas and fixes, PRs and status changes, conventions, commands, endpoints, flags, incidents and resolutions, and cross-session coordination facts. Ignore routine edits, transient state, secrets, and anything already in git.","enable_observations":true,"disposition_skepticism":4,"disposition_literalism":4,"disposition_empathy":1}}' \
+                    && _seed_bank private__hermes-agent '{"version":"1","bank":{"retain_mission":"This agent private working notes, scratch decisions, and per-task state. Never store shared facts here.","disposition_skepticism":4,"disposition_literalism":4,"disposition_empathy":2}}'; then
+                    info "seeded memory banks: shared (global) + private__hermes-agent"
+                else
+                    warn "memory bank seeding incomplete — banks also lazy-create on first write"
+                fi
+            else
+                warn "hindsight-api not healthy yet; check 'journalctl -u hindsight-api -n 40'"
+            fi
+        fi
+    fi
+
     if [[ -f "${OPENWEBUI_UNIT_DST}" ]]; then
         # OpenWebUI runs as a podman container (ExecStart=podman run …) — the
         # same runtime as the slots, so the preflight that installed podman

--- a/installer/systemd/hindsight-api.service
+++ b/installer/systemd/hindsight-api.service
@@ -48,6 +48,13 @@ Environment=HINDSIGHT_API_LLM_MODEL=hal0/utility
 Environment=HINDSIGHT_API_LLM_API_KEY=hal0-local-noauth
 # Generous timeout retained: covers utility-slot cold starts + long reflects.
 Environment=HINDSIGHT_API_LLM_TIMEOUT=300
+# Skip the blocking startup LLM verification. On a fresh box no model is loaded
+# yet, so verifying hal0/utility would hang application startup (the daemon never
+# binds :9177) until the timeout. The LLM is only needed for extraction/reflection,
+# which runs lazily after a model is loaded — so the engine can serve, create, and
+# seed banks immediately without one. (When a utility model IS loaded, extraction
+# just works; verification was only ever a startup nicety.)
+Environment=HINDSIGHT_API_SKIP_LLM_VERIFICATION=true
 
 # Embeddings + reranker are LOCAL (bundled BGE 384-d + MiniLM cross-encoder) —
 # the full `hindsight-api` package default. No external embed/rerank config needed.


### PR DESCRIPTION
## What
Third slice of zero-boot Hermes (F1/F2). Fresh installs come up with a working memory system — **no manual ops steps**. Previously the installer set `HAL0_MEMORY_ENABLED=1` but never installed the `hindsight-api` daemon, so the Memory tab pointed at a dead engine.

## Changes
`install.sh` now (after hal0-api is up; gated by `HAL0_SKIP_HINDSIGHT=1`):
- creates `/var/lib/hal0/memory/hindsight`, a dedicated venv, and pip-installs `hindsight-api==0.7.2` (the version CT105 runs), chowned to `hal0`;
- installs + enables the `hindsight-api` unit (embedded postgres + local BGE/MiniLM; extraction LLM = `hal0/utility` on :8080, lazy);
- waits for `:9177/health`, then seeds two banks via hal0-api's idempotent import API: **`shared`** (global cross-agent brain, with retain mission + research dispositions) and **`private__hermes-agent`** (private store). Other private/project banks lazy-create.

**Unit fix:** `HINDSIGHT_API_SKIP_LLM_VERIFICATION=true`. On a fresh box (no model loaded), the startup LLM verification to `hal0/utility` hung application startup — the daemon never bound `:9177` until the 300s timeout. The LLM is only needed for lazy extraction/reflection, so skipping the startup probe lets the engine serve + seed banks immediately.

## Verification (fresh Ubuntu 24.04 LXC)
- All four units active (api, openwebui, **hindsight**, hermes).
- `/api/memory/engine` → `reachable:true, v0.7.2, banks_total:3`.
- Banks `shared` + `private__hermes-agent` seeded; shared overrides applied (retain_mission set, skepticism 4).
- New bank via one import call → `project__demo` HTTP 200 (F4).
- Regression: provider/MCP/skills all intact.

## Acceptance
F1 ✅ F2 ✅ F4 ✅. Semantic retrieval (F3) + live chat additionally need a loaded utility model (runtime step, not installer scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)