### PR TITLE
fix(slots): enforce device↔profile backend coherence (utility slot vulkan+rocm-mtp)

### DIFF
--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1533,6 +1533,12 @@ class SlotManager:
         cfg_dict = _cfg_to_dict(slot_cfg)
         # #585: canonicalize a ctx_size alias from the create modal too.
         _normalize_ctx_key(cfg_dict)
+        # Reject (or normalize) an incoherent device/profile backend pairing
+        # before it ever lands on disk — the door the dashboard left open for
+        # the utility slot (vulkan device + rocm-mtp profile). Every field is
+        # "new" at create time, so a conflicting device+profile is an explicit
+        # operator error and raises.
+        _reconcile_device_profile(cfg_dict, set(cfg_dict.keys()))
         await self._check_npu_exclusivity(slot_name, cfg_dict)
         cfg_path = self._config_file(slot_name)
         cfg_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1625,6 +1631,14 @@ class SlotManager:
         # context_size so the two keys can't diverge on disk.
         _normalize_ctx_key(cfg_dict)
 
+        # Keep device↔profile backend coherent: a profile switch re-derives
+        # device (the drawer path that previously left a vulkan device under a
+        # rocm-mtp profile), a cross-backend device flip re-points the profile
+        # (the POST /backend path, which writes device only), and an explicit
+        # conflicting pair raises. Only the field(s) the caller changed drive
+        # reconciliation.
+        _reconcile_device_profile(cfg_dict, set(updates.keys()))
+
         # PR-11: re-run the NPU exclusivity guard whenever the merged
         # config could land a second device=npu, type=llm anchor (plan
         # §5.3). Cheap when no NPU LLM is involved — the helper short-
@@ -1663,8 +1677,11 @@ class SlotManager:
             # ``backend``) must re-derive the mirrored ``extra.backend`` token
             # too, or state.json keeps advertising the stale seeded backend
             # forever. Without this the chip thrashes back to the old value
-            # on the next status read that trusts the mirror.
-            if "device" in updates:
+            # on the next status read that trusts the mirror. A ``profile``
+            # change can also move the effective backend now (it re-derives
+            # ``device`` via _reconcile_device_profile), so refresh the mirror
+            # for either trigger off the reconciled cfg.
+            if "device" in updates or "profile" in updates:
                 eff = _cfg_effective_backend(cfg_dict)
                 if eff is not None:
                     new_extra["backend"] = eff
@@ -2394,6 +2411,91 @@ def _cfg_effective_backend(cfg: SlotConfig | dict[str, Any]) -> str | None:
     recipe, llamacpp_backend = device_to_backend(str(device))
     # NPU → recipe="flm" with no llamacpp_backend; surface "flm".
     return llamacpp_backend or (recipe if recipe == "flm" else None)
+
+
+def _base_profile_for_backend(catalog: Any, backend: str) -> str:
+    """Pick the canonical (non-MTP) seed profile name for a GPU backend.
+
+    Prefers the seed profile named after the backend (``rocm`` / ``vulkan``);
+    falls back to any non-MTP then any profile that declares ``backend``.
+    """
+    named = catalog.profile.get(backend)
+    if named is not None and getattr(named, "backend", None) == backend:
+        return backend
+    for name, prof in catalog.profile.items():
+        if getattr(prof, "backend", None) == backend and not getattr(prof, "mtp", False):
+            return str(name)
+    for name, prof in catalog.profile.items():
+        if getattr(prof, "backend", None) == backend:
+            return str(name)
+    return backend
+
+
+def _reconcile_device_profile(cfg_dict: dict[str, Any], changed: set[str]) -> None:
+    """Keep a GPU slot's ``device`` and ``profile.backend`` coherent in place.
+
+    A GPU slot implies its backend twice: ``device`` (``gpu-rocm`` /
+    ``gpu-vulkan``) drives the llama-server backend, while ``profile`` selects
+    the container image + flags. They must agree — a vulkan device under a
+    rocm-mtp profile launches a Vulkan binary with ROCm-only MTP draft flags
+    (issue: utility slot). The field the operator changed wins; the stale side
+    is re-derived. Both changed to conflicting backends → operator error.
+
+    No-ops for slots without a GPU profile (npu/cpu/img profiles declare
+    ``backend=None``) and for ``auto`` device (empty) unless the profile
+    itself changed. Mutates ``cfg_dict`` in place.
+    """
+    profile_name = cfg_dict.get("profile")
+    if not isinstance(profile_name, str) or not profile_name:
+        return
+
+    from hal0.config.loader import load_profiles_config
+
+    prof = load_profiles_config().profile.get(profile_name)
+    prof_backend = getattr(prof, "backend", None) if prof is not None else None
+    if not prof_backend:
+        # Non-GPU profile (or unknown profile with no backend) — leave alone.
+        return
+
+    from hal0.config.schema import map_backend_to_device
+    from hal0.model_meta import device_to_backend
+
+    device = cfg_dict.get("device")
+    dev_backend = device_to_backend(str(device))[1] if device else None
+    if dev_backend == prof_backend:
+        return  # already coherent
+
+    prof_changed = "profile" in changed
+    dev_changed = "device" in changed
+
+    if not device:
+        # ``auto``/unset device: only adopt the profile's backend when the
+        # operator explicitly (re)selected the profile; otherwise leave auto.
+        if prof_changed:
+            cfg_dict["device"] = map_backend_to_device(prof_backend)
+        return
+
+    if prof_changed and not dev_changed:
+        cfg_dict["device"] = map_backend_to_device(prof_backend)
+    elif dev_changed and not prof_changed and dev_backend is not None:
+        catalog = load_profiles_config()
+        cfg_dict["profile"] = _base_profile_for_backend(catalog, dev_backend)
+    elif prof_changed and dev_changed:
+        raise SlotConfigError(
+            f"slot device {device!r} (backend {dev_backend!r}) conflicts with "
+            f"profile {profile_name!r} (backend {prof_backend!r}); "
+            "pick a device and profile with the same backend",
+            details={
+                "device": device,
+                "profile": profile_name,
+                "device_backend": dev_backend,
+                "profile_backend": prof_backend,
+            },
+        )
+    # neither changed (pre-existing on-disk drift surfaced by an unrelated
+    # update): leave both fields untouched so the unrelated edit doesn't
+    # silently mutate hardware intent. Drift heals on the next device/profile
+    # edit.
 
 
 __all__ = [

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -1576,3 +1576,71 @@ def test_json_serialisation_roundtrips(
     # text + parsing both succeed → no infinite floats or set leaks
     body = json.loads(r.text)
     assert isinstance(body, list)
+
+
+def test_config_profile_change_drives_device_via_route(
+    tmp_hal0_home: str,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """PUT /config with a new profile re-derives device (drawer path).
+
+    Re-points a vulkan slot at the rocm-mtp profile; the device must follow
+    to gpu-rocm so the slot no longer reports vulkan under a ROCm profile.
+    """
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "utility",
+        [
+            'name = "utility"',
+            "port = 8081",
+            'device = "gpu-vulkan"',
+            'provider = "llama-server"',
+            'runtime = "container"',
+            'profile = "vulkan"',
+            "enabled = true",
+            "[model]",
+            'default = "m"',
+        ],
+    )
+
+    r = isolated_client.put("/api/slots/utility/config", json={"profile": "rocm-mtp"})
+    assert r.status_code == 200, r.text
+
+    cfg = isolated_client.get("/api/slots/utility/config").json()
+    assert cfg["profile"] == "rocm-mtp"
+    assert cfg["device"] == "gpu-rocm"
+
+
+def test_backend_flip_reconciles_profile_via_route(
+    tmp_hal0_home: str,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """POST /backend (writes device only) re-points an incompatible profile.
+
+    Flipping a rocm-mtp slot to the vulkan backend must drop the rocm-only
+    profile rather than persist a vulkan device under rocm-mtp.
+    """
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "utility",
+        [
+            'name = "utility"',
+            "port = 8081",
+            'device = "gpu-rocm"',
+            'provider = "llama-server"',
+            'runtime = "container"',
+            'profile = "rocm-mtp"',
+            "enabled = true",
+            "[model]",
+            'default = "m"',
+        ],
+    )
+
+    r = isolated_client.post("/api/slots/utility/backend", json={"backend": "vulkan"})
+    assert r.status_code == 200, r.text
+
+    cfg = isolated_client.get("/api/slots/utility/config").json()
+    assert cfg["device"] == "gpu-vulkan"
+    assert cfg["profile"] == "vulkan"

--- a/tests/slots/test_device_profile_coherence.py
+++ b/tests/slots/test_device_profile_coherence.py
@@ -1,0 +1,130 @@
+"""Device↔profile backend coherence on slot create / update_config.
+
+A GPU slot carries two fields that each imply a backend: ``device``
+(``gpu-rocm``/``gpu-vulkan`` → the llama-server backend) and ``profile``
+(the ProfileConfig, whose ``backend`` selects the container image + flags).
+Before this guard they could diverge silently: the dashboard set the
+``utility`` slot's ``device`` to ``gpu-vulkan`` while leaving its
+``profile`` at ``rocm-mtp``, so the slot reported ``backend=vulkan`` yet
+resolved the ROCm image + ROCm-only MTP draft flags — and re-picking the
+profile in the drawer never corrected the device.
+
+The invariant: for a GPU slot, ``device`` must agree with
+``profile.backend``. Whichever field the operator changes wins; the other
+is reconciled. An explicit contradiction (both changed, still conflicting)
+is rejected rather than silently resolved. Non-GPU profiles (npu/cpu/img,
+``backend=None``) are left untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.slots.manager import SlotManager
+from hal0.slots.state import SlotConfigError
+
+
+def _gpu_cfg(name: str, *, device: str, profile: str, model: str = "m") -> dict:
+    return {
+        "name": name,
+        "port": 8090,
+        "type": "llm",
+        "device": device,
+        "profile": profile,
+        "provider": "llama-server",
+        "enabled": True,
+        "group": "custom",
+        "model": {"default": model},
+    }
+
+
+async def test_profile_change_drives_device(tmp_hal0_home: str) -> None:
+    """Switching the profile re-derives device — the exact utility-slot bug.
+
+    A vulkan slot re-pointed at the rocm-mtp profile must end up on
+    ``device=gpu-rocm``; otherwise the drawer 'changes' the profile but the
+    backend stays vulkan forever.
+    """
+    sm = SlotManager()
+    await sm.create("util", _gpu_cfg("util", device="gpu-vulkan", profile="vulkan"))
+
+    await sm.update_config("util", {"profile": "rocm-mtp"})
+
+    cfg = await sm.get_config("util")
+    assert cfg["profile"] == "rocm-mtp"
+    assert cfg["device"] == "gpu-rocm"
+
+
+async def test_device_change_reconciles_conflicting_profile(tmp_hal0_home: str) -> None:
+    """Flipping device across backends drops an incompatible profile.
+
+    The ``POST /api/slots/{name}/backend`` control writes only ``device``;
+    a cross-backend flip must reconcile the profile to a compatible one so
+    no rocm-mtp+vulkan pair is ever persisted.
+    """
+    sm = SlotManager()
+    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm-mtp"))
+
+    await sm.update_config("util", {"device": "gpu-vulkan"})
+
+    cfg = await sm.get_config("util")
+    assert cfg["device"] == "gpu-vulkan"
+    assert cfg["profile"] == "vulkan"
+
+
+async def test_unrelated_update_preserves_coherent_pair(tmp_hal0_home: str) -> None:
+    """A change that touches neither device nor profile leaves both intact."""
+    sm = SlotManager()
+    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm-mtp"))
+
+    await sm.update_config("util", {"model": {"context_size": 32768}})
+
+    cfg = await sm.get_config("util")
+    assert cfg["device"] == "gpu-rocm"
+    assert cfg["profile"] == "rocm-mtp"
+    assert cfg["model"]["context_size"] == 32768
+
+
+async def test_explicit_contradiction_rejected(tmp_hal0_home: str) -> None:
+    """Changing both fields to conflicting backends is an operator error."""
+    sm = SlotManager()
+    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm-mtp"))
+
+    with pytest.raises(SlotConfigError, match=r"(?i)backend"):
+        await sm.update_config("util", {"profile": "rocm-mtp", "device": "gpu-vulkan"})
+
+
+async def test_create_rejects_incoherent_pair(tmp_hal0_home: str) -> None:
+    """create() must refuse a vulkan device paired with a rocm profile.
+
+    This is the door the dashboard left open — 'allowed the utility slot to
+    be set to vulkan but with a ROCM-MTP profile'.
+    """
+    sm = SlotManager()
+    with pytest.raises(SlotConfigError, match=r"(?i)backend"):
+        await sm.create("util", _gpu_cfg("util", device="gpu-vulkan", profile="rocm-mtp"))
+
+
+async def test_non_gpu_profile_untouched(tmp_hal0_home: str) -> None:
+    """A non-GPU profile (backend=None) never triggers device reconciliation."""
+    sm = SlotManager()
+    await sm.create(
+        "voice",
+        {
+            "name": "voice",
+            "port": 8091,
+            "type": "tts",
+            "device": "cpu",
+            "profile": "tts",
+            "provider": "llama-server",
+            "enabled": True,
+            "group": "custom",
+            "model": {"default": "kokoro"},
+        },
+    )
+
+    await sm.update_config("voice", {"model": {"context_size": 2048}})
+
+    cfg = await sm.get_config("voice")
+    assert cfg["device"] == "cpu"
+    assert cfg["profile"] == "tts"


### PR DESCRIPTION
## Problem

A GPU slot implies its backend **twice**: `device` (`gpu-rocm`/`gpu-vulkan`) drives the llama-server backend, while `profile` selects the container image + flags. Nothing kept them in sync.

The live `utility` slot ended up with:
```toml
device  = "gpu-vulkan"     # → backend resolves to vulkan
profile = "rocm-mtp"       # → ROCm image + ROCm-only MTP draft flags
```
So `/api/slots` reported `backend=vulkan` while the resolved command carried `--spec-draft-device ROCm0` against the ROCm image. If started, a Vulkan binary would launch with ROCm-only MTP flags → fail/degrade. And **re-picking the profile in the drawer never fixed it**, because:

- `POST /api/slots/{name}/backend` writes only `device`
- `PUT /api/slots/{name}/config` shallow-merges only what the drawer sends
- `update_config` reconciled only the `extra.backend` mirror from `device`, never the `profile`
- there was **no coherence validation** in `create()` or `update_config()`

## Fix

`_reconcile_device_profile()`, called from `create()` and `update_config()`:

| Trigger | Behavior |
|---|---|
| profile change (drawer) | re-derive `device` from `profile.backend` |
| cross-backend device flip (`POST /backend`) | re-point `profile` to the base seed profile for the new backend |
| both changed, conflicting | raise `SlotConfigError` (operator error) |
| non-GPU profile (npu/cpu/img) or `auto` device | left untouched |
| pre-existing on-disk drift surfaced by an unrelated edit | left untouched (no silent hardware-intent mutation) |

Also broadens the `state.json` backend-mirror refresh to fire on a profile change.

## Tests
- `tests/slots/test_device_profile_coherence.py` — 6 manager-level (incl. exact utility-slot repro + create-time rejection)
- `tests/api/test_slots_routes.py` — 2 route-level (`PUT /config` drives device; `POST /backend` reconciles profile)
- Full sweep: `tests/slots tests/api/test_slots_routes.py tests/slot_config tests/capabilities` → **333 passed**, ruff + mypy clean on changed code.

## Live runtime
The live CT105 `utility.toml` was hand-corrected to `device=gpu-rocm` (intent: ROCm+MTP; backup at `utility.toml.bak-predevicefix`). This PR prevents the incoherent pairing from recurring via the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)