### PR TITLE
ci: test against latest supported Python (3.12) only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,10 @@ jobs:
       FASTEMBED_CACHE_PATH: ${{ github.workspace }}/.fastembed-cache
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        # Test against the latest supported Python only (matches the 3.12
+        # runtime on CT105/CT132 and the other workflows). Re-add older
+        # versions here if we need to support them again.
+        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "hal0"
 version = "0.4.1-alpha.1"
 description = "Open-source home AI inference platform"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = { text = "Apache-2.0" }
 authors = [{ name = "hal0 contributors" }]
 keywords = ["ai", "llm", "inference", "openai-compatible", "homeai"]
@@ -16,7 +16,6 @@ classifiers = [
   "Intended Audience :: End Users/Desktop",
   "Intended Audience :: System Administrators",
   "Operating System :: POSIX :: Linux",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
@@ -99,7 +98,7 @@ packages = ["src/hal0"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py312"
 src = ["src", "tests"]
 
 [tool.ruff.lint]
@@ -121,7 +120,7 @@ markers = [
 ]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 strict = true
 warn_return_any = true
 warn_unused_configs = true


### PR DESCRIPTION
## What

1. **CI** (`.github/workflows/ci.yml`): reduce the `python` job matrix from `["3.11", "3.12"]` to `["3.12"]` — run the suite against the latest supported Python only.
2. **Packaging** (`pyproject.toml`): align declared support with what CI now verifies —
   - `requires-python`: `">=3.11"` → `">=3.12"`
   - drop the `Python :: 3.11` trove classifier
   - `ruff` `target-version`: `py311` → `py312`
   - `mypy` `python_version`: `3.11` → `3.12`

## Why

3.12 is the latest supported version and already matches reality everywhere:
- Runtime hosts CT105 / CT132 run Python 3.12
- The other workflows (`agent-shim-smoke`, `hermes-sdk-diff`) already pin 3.12
- Halves the `python` job's matrix → faster, cheaper CI

Bumping the packaging metadata too keeps the *declared* support (`requires-python`/classifiers/tool targets) consistent with what CI actually gates on, rather than promising untested 3.11 support. `ruff check` + `ruff format --check` pass clean under `target-version = py312` (no new findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)