### PR TITLE
chore: gitignore .superpowers/ brainstorm scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ graphify-out/
 # never track node_modules anywhere (incl. symlinks)
 node_modules
 **/node_modules
+
+# superpowers brainstorm/visual-companion scratch (mockups, server state)
+.superpowers/


### PR DESCRIPTION
Adds `.superpowers/` to `.gitignore` so superpowers brainstorm / visual-companion mockups + local server state don't get committed to the public repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)