### PR TITLE
fix(ui): show profile intent in slot edit drawer dropdown

### DIFF
--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -574,7 +574,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
                       the Save guard then rejects (mirrors the create modal). */}
                   {!selectedProfile && <option value="">— select a profile —</option>}
                   {gpuProfiles.map(p => (
-                    <option key={p.name} value={p.name}>{p.name}</option>
+                    <option key={p.name} value={p.name}>
+                      {p.intent ? `${p.name} · ${p.intent}` : p.name}
+                    </option>
                   ))}
                 </select>
               ) : (

--- a/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
@@ -75,6 +75,19 @@ test.describe('C7 — drawer-editable profile + create-modal device derivation',
     await expect(sel.locator('option[value="flm"]')).toHaveCount(0)
   })
 
+  // C7a2 — profile options surface the intent label so custom profiles
+  // (auto-named e.g. "rocm-custom") are recognizable, not just the bare name.
+  test('C7a2 — GPU profile options show name · intent', async ({ page }) => {
+    await seedSlots(page, [CHAT_CONTAINER])
+    await page.goto('/#slots/chat')
+    await expect(page.locator('.drawer')).toBeVisible()
+
+    const sel = page.locator('.drawer .form-row', { hasText: 'Profile' }).first().locator('select')
+    // The rocm-mtp option carries its intent ("Dense chat + MTP") in the label.
+    await expect(sel.locator('option[value="rocm-mtp"]')).toContainText('Dense chat + MTP')
+    await expect(sel.locator('option[value="vulkan"]')).toContainText('Vulkan std · fallback')
+  })
+
   // C7b — profile change Save: PUT with profile + restart fires
   test('C7b — profile change: PUT includes profile + restart fires', async ({ page }) => {
     const configPuts: any[] = []


### PR DESCRIPTION
## Problem
The slot **edit** drawer's GPU profile `<select>` labeled options by bare **name** only. When you clone a profile, hal0 auto-names it (e.g. `rocm-custom`) and your descriptive label goes into the profile's `intent` field — which the drawer never rendered. Result: a user added a profile they think of as **"MTP+MOE"**, but the agent drawer only showed `rocm-custom`, so they couldn't find it.

(The profile was always present and selectable — `device_class==="gpu"` profiles are all listed — this was purely a labeling/discoverability gap.)

## Fix
Render `name · intent` in the edit drawer's profile options (fallback to bare name when `intent` is empty), mirroring the create modal's richer labels.

```jsx
<option value={p.name}>{p.intent ? `${p.name} · ${p.intent}` : p.name}</option>
// → "rocm-custom · MTP+MOE"
```

## Test
- `slot-drawer-profile-v3.spec.ts` → new **C7a2**: asserts `rocm-mtp` / `vulkan` options carry their intent text. Watched it fail (bare name) → pass.
- Full spec **11/11 green** (C7a still validates option *values* — only display text changed). Production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)