### PR TITLE
FirstRun: per-slot model/profile override fields in Advanced drawer

### DIFF
--- a/tests/api/test_install_apply.py
+++ b/tests/api/test_install_apply.py
@@ -87,3 +87,43 @@ def test_apply_unknown_tier_400(isolated_app_client):
     _app, client = isolated_app_client
     r = client.post("/api/install/apply", json={"tier": "nope", "storage_dir": "/tmp"})
     assert r.status_code in (400, 404)
+
+
+def test_apply_honors_per_slot_override(isolated_app_client, tmp_hal0_home, monkeypatch):
+    """The Advanced-drawer overrides (model_id + profile + device) win over the
+    auto-derived defaults and land in the slot TOML."""
+    app, client = isolated_app_client
+    app.state.hardware_probe = _FakeProbe()
+
+    import hal0.api.routes.installer as inst
+
+    async def _fake_run_pull(job, **kw):
+        job.state = "completed"
+
+    monkeypatch.setattr(inst, "run_pull", _fake_run_pull)
+
+    r = client.post(
+        "/api/install/apply",
+        json={
+            "tier": "hal0-default",
+            "storage_dir": tmp_hal0_home,
+            "npu_opt_in": False,
+            # Override chat: a different curated model + the vulkan profile/device
+            # (coherent pair) instead of the auto-derived rocm-mtp.
+            "overrides": {
+                "chat": {"model_id": "qwen3.6-27b", "profile": "vulkan", "device": "gpu-vulkan"}
+            },
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    chat = next(s for s in body["slots"] if s["slot"] == "chat")
+    assert chat["model_id"] == "qwen3.6-27b"
+    assert chat["profile"] == "vulkan"
+    assert chat["device"] == "gpu-vulkan"
+    assert "qwen3.6-27b" in body["model_ids"]
+
+    cfg = tomllib.loads((Path(tmp_hal0_home) / "etc" / "hal0" / "slots" / "chat.toml").read_text())
+    assert cfg["model"]["default"] == "qwen3.6-27b"
+    assert cfg["profile"] == "vulkan"
+    assert cfg["device"] == "gpu-vulkan"

--- a/ui/src/dash/firstrun.jsx
+++ b/ui/src/dash/firstrun.jsx
@@ -8,6 +8,7 @@
 import { useCuratedBundles, useInstallApply, useFirstRunComplete, useInstallServices, useServiceRepair } from '@/api/hooks/useFirstRun'
 import { useHardware } from '@/api/hooks/useHardware'
 import { useModelStore, useModelStoreSet, useModelStoreMigrate } from '@/api/hooks/useSettings'
+import { useProfiles } from '@/api/hooks/useProfiles'
 import { usePullJob, fmtBytes, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
 
 const { useState: useStateF, useEffect: useEffectF } = React;
@@ -18,6 +19,48 @@ function _frFmtBytes(n) {
   if (n < 1024 ** 2) return (n / 1024).toFixed(1) + " KB";
   if (n < 1024 ** 3) return (n / 1024 ** 2).toFixed(1) + " MB";
   return (n / 1024 ** 3).toFixed(2) + " GB";
+}
+
+// Canonical slots the Advanced drawer can override. The /apply backend only
+// reads an override for a slot that the chosen tier's manifest actually
+// installs, so listing the full set here is safe — extra rows are ignored.
+const _FR_OVERRIDE_SLOTS = [
+  { slot: "chat",  label: "Chat" },
+  { slot: "coder", label: "Coder" },
+  { slot: "embed", label: "Embed" },
+  { slot: "stt",   label: "Speech-to-text" },
+  { slot: "tts",   label: "Text-to-speech" },
+];
+
+// Derive the DeviceLiteral that matches a profile's backend so an override
+// pair stays #807-coherent (a vulkan-device + rocm-profile slot is rejected
+// by SlotManager.create). Returns undefined for img/unknown profiles (their
+// backend is null → the create-time reconcile leaves device untouched).
+function _frDeviceForProfile(p) {
+  if (!p) return undefined;
+  if (p.backend === "rocm") return "gpu-rocm";
+  if (p.backend === "vulkan") return "gpu-vulkan";
+  if (p.device_class === "cpu") return "cpu";
+  if (p.device_class === "npu") return "npu";
+  return undefined;
+}
+
+// Build the { "<slot>": {model_id?, profile?, device?} } map for POST /apply
+// from the drawer's per-slot edits. Only slots with a real edit are included;
+// when a profile is chosen we send its coherent device alongside it.
+function _frBuildOverrides(ovr, profiles) {
+  const out = {};
+  for (const [slot, v] of Object.entries(ovr || {})) {
+    const o = {};
+    if (v.model_id && v.model_id.trim()) o.model_id = v.model_id.trim();
+    if (v.profile) {
+      o.profile = v.profile;
+      const dev = _frDeviceForProfile((profiles || []).find(p => p.name === v.profile));
+      if (dev) o.device = dev;
+    }
+    if (Object.keys(o).length) out[slot] = o;
+  }
+  return out;
 }
 
 // ─── Storage step (state 1.5 — between picker and confirm) ───
@@ -421,9 +464,11 @@ function FirstRunQuick({ onInstalled, onSkip, layout }) {
   const hwQuery = useHardware();
   const storeQuery = useModelStore();
   const storeSet = useModelStoreSet();
+  const profilesQuery = useProfiles();
   const applyM = useInstallApply();
 
   const bundles = bundlesQuery.data?.bundles ?? HAL0_DATA.bundles;
+  const profiles = profilesQuery.data ?? [];
   const ram = hwQuery.data?.ram?.total ?? HAL0_DATA.host?.ram?.total ?? 0;
   const fit = bundles.filter(b => b.ram <= ram);
   const recId = fit.length ? fit[fit.length - 1].id : (bundles[0]?.id ?? null);
@@ -432,6 +477,10 @@ function FirstRunQuick({ onInstalled, onSkip, layout }) {
   const [npu, setNpu] = useStateF(false);
   const [path, setPath] = useStateF("");
   const [advanced, setAdvanced] = useStateF(false);
+  // Per-slot Advanced-drawer overrides: { "<slot>": { model_id, profile } }.
+  const [ovr, setOvr] = useStateF({});
+  const setSlotOverride = (slot, key, value) =>
+    setOvr(prev => ({ ...prev, [slot]: { ...prev[slot], [key]: value } }));
 
   useEffectF(() => { if (tier == null && recId) setTier(recId); }, [recId]);
   useEffectF(() => { if (!path && storeQuery.data?.effective) setPath(storeQuery.data.effective); }, [storeQuery.data]);
@@ -446,7 +495,8 @@ function FirstRunQuick({ onInstalled, onSkip, layout }) {
       if (path && path !== storeQuery.data?.effective) {
         try { await storeSet.mutateAsync({ path, migrate: false }); } catch (_e) { /* non-fatal */ }
       }
-      const res = await applyM.mutateAsync({ tier: tierName, storageDir: path, npuOptIn: npu });
+      const overrides = _frBuildOverrides(ovr, profiles);
+      const res = await applyM.mutateAsync({ tier: tierName, storageDir: path, npuOptIn: npu, overrides });
       onInstalled(Array.isArray(res?.model_ids) ? res.model_ids : [], tierName);
     } catch (e) {
       window.__hal0Toast && window.__hal0Toast(`Install failed — ${e?.message || "see logs"}`, "err");
@@ -487,10 +537,41 @@ function FirstRunQuick({ onInstalled, onSkip, layout }) {
             <input type="checkbox" checked={npu} onChange={e => setNpu(e.target.checked)} style={{accentColor: "var(--accent)"}} />
             Enable NPU trio (agent + stt/embed passengers) — requires an NPU
           </label>
-          <p style={{fontSize: 11.5, color: "var(--fg-4)", marginTop: 10, lineHeight: 1.5}}>
-            The installer auto-derives each slot's device + profile from the hardware probe
-            (GPU → ROCm/Vulkan, NPU when opted in). Per-slot model + profile overrides land here in a follow-up.
+          <p style={{fontSize: 11.5, color: "var(--fg-4)", margin: "10px 0 14px", lineHeight: 1.5}}>
+            Each slot auto-derives its device + profile from the hardware probe
+            (GPU → ROCm/Vulkan, NPU when opted in). Override a model or profile below —
+            blank rows keep the smart default. Overrides only apply to slots the chosen tier installs.
           </p>
+          <div className="fr-ovr" data-testid="fr-overrides">
+            <div className="fr-ovr-row fr-ovr-head mono" style={{display: "grid", gridTemplateColumns: "110px 1fr 160px", gap: 8, fontSize: 10, color: "var(--fg-4)", textTransform: "uppercase", letterSpacing: "0.08em", paddingBottom: 6}}>
+              <span>slot</span><span>model id (curated)</span><span>profile</span>
+            </div>
+            {_FR_OVERRIDE_SLOTS.map(({ slot, label }) => (
+              <div key={slot} className="fr-ovr-row" data-slot={slot} style={{display: "grid", gridTemplateColumns: "110px 1fr 160px", gap: 8, alignItems: "center", padding: "5px 0"}}>
+                <span className="mono" style={{fontSize: 12, color: "var(--fg-2)"}}>{label}</span>
+                <input
+                  className="input mono"
+                  aria-label={`${slot} model override`}
+                  value={ovr[slot]?.model_id ?? ""}
+                  onChange={e => setSlotOverride(slot, "model_id", e.target.value)}
+                  placeholder="auto"
+                  style={{padding: "6px 9px", fontSize: 12}}
+                />
+                <select
+                  className="input mono"
+                  aria-label={`${slot} profile override`}
+                  value={ovr[slot]?.profile ?? ""}
+                  onChange={e => setSlotOverride(slot, "profile", e.target.value)}
+                  style={{padding: "6px 9px", fontSize: 12}}
+                >
+                  <option value="">auto (derive)</option>
+                  {profiles.map(p => (
+                    <option key={p.name} value={p.name}>{p.name}{p.intent ? ` · ${p.intent}` : ""}</option>
+                  ))}
+                </select>
+              </div>
+            ))}
+          </div>
         </div>
       </details>
 

--- a/ui/tests/e2e/specs/firstrun-v2.spec.ts
+++ b/ui/tests/e2e/specs/firstrun-v2.spec.ts
@@ -74,6 +74,12 @@ test.describe('FirstRun v2 — quick install', () => {
     await page.route('**/api/install/curated-models', (r) => json(r, { models: [], custom_allowed: true }))
     await page.route('**/api/settings/models/store', (r) => json(r, MODEL_STORE))
     await page.route('**/api/hardware', (r) => json(r, HARDWARE))
+    await page.route('**/api/profiles', (r) =>
+      json(r, [
+        { name: 'rocm-mtp', backend: 'rocm', device_class: 'gpu', intent: 'Dense chat + MTP' },
+        { name: 'vulkan', backend: 'vulkan', device_class: 'gpu', intent: 'Vulkan std' },
+      ]),
+    )
     await page.route('**/api/install/complete', (r) => json(r, { first_run: false }))
   })
 
@@ -108,6 +114,38 @@ test.describe('FirstRun v2 — quick install', () => {
     // onInstalled fired with the returned model_ids → progress would mount.
     const installed = await page.evaluate(() => (window as any).__frInstalled)
     expect(installed.ids).toContain('qwen3.5-9b')
+  })
+
+  test('Advanced drawer per-slot overrides are sent (model + profile + coherent device)', async ({ page }) => {
+    let capturedBody: any = null
+    await page.route('**/api/install/apply', async (r) => {
+      capturedBody = await r.request().postDataJSON()
+      return json(r, { tier: 'hal0-Default', model_ids: ['my-chat'], slots: [], next: '' })
+    })
+
+    await page.goto('/#firstrun', { waitUntil: 'domcontentloaded' })
+    await mountQuick(page)
+
+    // Open the Advanced drawer.
+    await page.locator('summary', { hasText: /Advanced/ }).click()
+    await expect(page.locator('[data-testid="fr-overrides"]')).toBeVisible()
+
+    // Override the chat slot: a custom model id + the rocm-mtp profile.
+    await page.getByLabel('chat model override').fill('my-chat')
+    await page.getByLabel('chat profile override').selectOption('rocm-mtp')
+
+    await Promise.all([
+      page.waitForResponse('**/api/install/apply', { timeout: 10_000 }),
+      page.locator('button', { hasText: /Install/ }).click(),
+    ])
+
+    expect(capturedBody?.overrides?.chat).toEqual({
+      model_id: 'my-chat',
+      profile: 'rocm-mtp',
+      device: 'gpu-rocm', // derived from the rocm profile → #807-coherent
+    })
+    // Slots left on "auto" are omitted entirely.
+    expect(capturedBody?.overrides?.embed).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## What
Completes the FirstRun v2 Advanced drawer (follow-up to #809): per-slot **model id** + **profile** override fields, wired into `POST /api/install/apply`'s `overrides` map. Blank rows keep the auto-derived default.

## Details
- `firstrun.jsx` `FirstRunQuick`: drawer now renders a row per canonical slot (chat/coder/embed/stt/tts) with a model-id text input + a profile dropdown sourced from `useProfiles()` (`GET /api/profiles`).
- Picking a profile also sends its **matching `device`** (derived from the profile's backend) so the (device, profile) pair stays coherent and `SlotManager.create` won't reject it per #807.
- Only edited slots are sent; the backend ignores overrides for slots the chosen tier doesn't install.
- Backend already accepted `overrides` (shipped in #809) — this is the UI half plus a backend test pinning the end-to-end contract.

## Tests
- e2e: `firstrun-v2.spec.ts` +1 — opens the drawer, sets chat model+profile, asserts `/apply` body `overrides.chat = {model_id, profile, device}` and that auto rows are omitted. **3 passed.**
- backend: `test_install_apply.py` +1 — `test_apply_honors_per_slot_override` asserts the override lands in the slot TOML. **4 passed.**
- UI build + typecheck + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)