### PR TITLE
feat(flm): NPU telemetry + repoint to hal0-toolbox-flm:0.9.43

### DIFF
--- a/docs/superpowers/specs/2026-06-14-flm-universal-install-toolbox-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-14-flm-universal-install-toolbox-hardening-design.md
@@ -1,0 +1,149 @@
+# FLM Universal Install + Toolbox Hardening — Design
+
+**Date:** 2026-06-14
+**Status:** Draft (awaiting review)
+**Author:** Claude (brainstorming session)
+**Related:** [NPU Hardware-Usage Dashboard Pane](./2026-06-14-npu-hardware-usage-dashboard-design.md) (Spec B — depends on this)
+
+---
+
+## 1. Why this exists
+
+FLM (FastFlowLM, the NPU LLM path) is **the trickiest, least portable part of the hal0 setup**. The recurring failure mode: a user on a non-Ubuntu distro (Debian, in the motivating case) cannot get FLM installed at all. This spec makes the FLM runtime **install easily and behave uniformly across distros**, and — as a rider — fixes the missing library that currently prevents NPU telemetry (`xrt-smi`) from running, which Spec B depends on.
+
+This is the priority workstream. The dashboard pane (Spec B) is the occasion that surfaced it; broad, reliable FLM install is the higher-value outcome.
+
+### The two Debian blockers (root-caused)
+
+A user's friend could not install FLM on Debian. Research identified **two independent, real traps**, both Ubuntu-centricity bugs in the *bare-metal* path:
+
+1. **The PPA trap.** FLM/Lemonade's Linux recipe says `add-apt-repository ppa:lemonade-team/stable` to get `libxrt-npu2` + `amdxdna-dkms`. That is a **Launchpad PPA — Ubuntu suites only** (Noble/Questing/Resolute). On Debian, apt looks for a `trixie` Release file that was never built → `E: The repository '… Release' does not have a Release file`. (https://launchpad.net/~lemonade-team/+archive/ubuntu/stable)
+2. **The ffmpeg ABI trap.** FLM links `libav*` (ffmpeg) at runtime. The **Ubuntu 24.04** `.deb` depends on **ffmpeg-6 → `libavcodec60`**. **Debian 13 (trixie) ships ffmpeg-7 → `libavcodec61`** and has no `libavcodec60`, so the Ubuntu `.deb` is uninstallable: `fastflowlm depends on libavcodec60; however: Package libavcodec60 is not installed`. (https://packages.debian.org/trixie/amd64/ffmpeg)
+
+FLM already partly solved (2) upstream by shipping **per-distro `.deb`s** including `fastflowlm_<ver>_debian13_amd64.deb` (ffmpeg-7). The friend almost certainly grabbed the Ubuntu-24.04 `.deb`. (1) remains: the surrounding driver tooling is still Ubuntu-only, so Debian users must avoid the PPA.
+
+### The telemetry-blocker rider
+
+The current published image `ghcr.io/hal0ai/hal0-toolbox-flm:v1` ships `xrt-smi` but it **cannot run**: it dies with `error while loading shared libraries: libboost_filesystem.so.1.83.0`. XRT's CMake links **both** `boost_filesystem` and `boost_program_options` (Xilinx/XRT `boostUtil.cmake`), but the image installs only `libboost-program-options1.83.0` (`packaging/toolbox/flm.Dockerfile:180`). XRT does not declare its boost dependency (Xilinx/XRT #6295), so it was missed. This one missing lib is why Spec B's column map can't read the NPU today.
+
+---
+
+## 2. Goals / Non-goals
+
+### Goals
+- **G1.** Container-first FLM install works identically on Ubuntu 24.04, Debian 13, Ubuntu 25.10/26.04, Arch, Fedora — the host requirement reduces to "recent kernel + firmware + `/dev/accel`."
+- **G2.** `xrt-smi examine` runs cleanly inside the image (no `unwrapped` + `LD_LIBRARY_PATH` hack), enabling Spec B telemetry.
+- **G3.** Bare-metal install (for users who refuse containers) picks the **distro-matched** `.deb` and **never** touches the Ubuntu-only PPA on non-Ubuntu.
+- **G4.** A host **preflight/doctor** check that diagnoses the real prerequisites with cross-distro remediation, replacing trial-and-error.
+- **G5.** Correct the stale kernel-version claim in docs/manifest.
+
+### Non-goals
+- Shipping the kernel `amdxdna` driver or NPU firmware in the container (they are host-side, by definition — containers share the host kernel).
+- Supporting XDNA1 (Phoenix/Hawk Point) — FLM is XDNA2-only.
+- Bundling AMD's login-gated prebuilt XRT debs (cannot be fetched anonymously in CI).
+- Replacing FLM or changing the NPU serving architecture (FLM trio stays as-is).
+
+---
+
+## 3. Current state (sourced facts)
+
+| Aspect | Current | Source |
+|---|---|---|
+| Image recipe | Retired from tree; last at `packaging/toolbox/flm.Dockerfile` @ `c71f04d9` | repo |
+| Image pinned in | `manifest.json:18`, `src/hal0/providers/flm.py:46`, `src/hal0/capabilities/catalog.py:95` | repo |
+| Base | `ubuntu:24.04` (boost 1.83, ffmpeg 6 era) | `flm.Dockerfile` |
+| XRT | built from source, `amd/xdna-driver` `XDNA_REF=main` (unpinned) | `flm.Dockerfile:54-101` |
+| FLM (image) | built from source, `FastFlowLM` `FLM_REF=main` | `flm.Dockerfile:103-167` |
+| FLM (installer/bare-metal) | `.deb` v0.9.43 `ubuntu24.04`, SHA pinned | `installer/install.sh:755-760` |
+| ffmpeg | 6 — hardcoded `libavformat60 libavcodec60 libswscale7` | `flm.Dockerfile:170-194` |
+| Missing lib | `libboost-filesystem1.83.0` (only `-program-options` installed) → `xrt-smi` broken | `flm.Dockerfile:180` |
+| `xrt-smi`/telemetry wiring | none anywhere in repo | repo grep |
+| Kernel claim | `manifest.json:20` "kernel ≥ 6.11" — **wrong** | repo |
+
+### Reference facts
+- `amdxdna` mainlined in **Linux 6.14**; out-of-tree `amd/xdna-driver` DKMS targets **≥6.10**. (https://www.phoronix.com/news/Ryzen-AI-NPU6-Linux-6.14, https://docs.kernel.org/accel/amdxdna/)
+- NPU firmware lives host-side in `linux-firmware` at `/usr/lib/firmware/amdnpu/`; FLM needs **≥1.1.0.0**.
+- Current Strix-Halo pairing: **xdna-driver 2.21.75 ↔ XRT 2.21.75** (Ryzen AI Software 1.7.1). (https://ryzenai.docs.amd.com/en/latest/linux.html)
+- FLM latest **v0.9.43** (2026-05-26); per-distro `.deb`s: `ubuntu24.04`, `ubuntu25.10`, `ubuntu26.04`, `debian13`. (https://github.com/FastFlowLM/FastFlowLM/releases)
+- Lemonade dropped its standalone `.deb` in v10.0.1 → Ubuntu-only PPA; Debian = "build from source"/Docker. The official Lemonade Docker image is **CPU/ROCm-GPU only, no NPU** — NPU-in-a-container needs the FLM-specific image. (https://lemonade-server.ai/docs/guide/install/)
+- Linux **7.1** adds NPU power + utilization telemetry via `DRM_IOCTL_AMDXDNA_GET_INFO` (`npu_tops_curr`, power) — relevant to Spec B's future, not this spec. CT105 is on 7.0.6.
+- Host gotchas: never `amd_iommu=off` (NPU vanishes; use `amd_iommu=pt`); `memlock` unlimited; in-tree module supports an older firmware protocol than DKMS — match them.
+
+---
+
+## 4. Design
+
+### 4.1 Thesis: container-first is the universal install
+
+The host kernel driver + firmware *must* live host-side regardless of distro. Everything else (XRT userspace, ffmpeg, FLM, boost) can be sealed in the image. So the robust cross-distro story is: **run FLM in hal0's container; require only a sane host kernel + firmware.** hal0 already does this — this spec hardens it and makes the host side honest.
+
+### 4.2 Toolbox image rebuild (`hal0-toolbox-flm`)
+
+Restore/refresh `packaging/toolbox/flm.Dockerfile` and republish. Changes grouped by purpose:
+
+**Group 1 — enable `xrt-smi` telemetry (unblocks Spec B):**
+- Add runtime deps `libboost-filesystem1.83.0 libboost-system1.83.0` to stage-3 apt line.
+- Bake XRT env so `xrt-smi` runs cleanly: `ENV XILINX_XRT=/opt/xilinx/xrt`, extend `PATH`/`LD_LIBRARY_PATH`, add `PYTHONPATH=/opt/xilinx/xrt/python` (the vars `setup.sh` exports).
+- Build-time smoke: `RUN xrt-smi --version` (no NPU needed) so a missing-lib regression fails the build, not runtime.
+
+**Group 2 — cross-distro robustness:**
+- Keep **XRT source-build** as the default (only fully-anonymous path; AMD prebuilt debs are login-gated).
+- For the **bare-metal `.deb` fallback only**, parameterize `ARG FLM_DEB_DISTRO=ubuntu24.04` and fetch the matching asset; never cross a `.deb` onto a mismatched base. The container itself can keep building FLM from source against the base's own `libav*-dev` so the ffmpeg soname is implicit (no hardcoded `libavcodec60`).
+- Drop any reliance on the Lemonade PPA (the source-build already avoids it — keep it that way; document the prohibition for Debian).
+
+**Group 3 — version hygiene:**
+- Pin `ARG XDNA_REF=2.21.75` and matching XRT (no more `main`).
+- Bump FLM pin to v0.9.43 (verify latest at build); keep the dual pin in sync (`installer/install.sh` `FLM_DEB_VERSION` + lemonade `backend_versions.json`).
+
+### 4.3 Host preflight / `doctor`
+
+Extend the installer/`hal0 doctor` path with an **NPU readiness check** that reports pass/fail + remediation per item:
+
+| Check | Pass condition | Remediation (cross-distro) |
+|---|---|---|
+| Kernel `amdxdna` | `/dev/accel/accel0` exists, driver bound | kernel ≥6.14 (in-tree) or `amdxdna-dkms` (Ubuntu: PPA; **Debian: debian-backports**; Arch: AUR) |
+| Firmware | `/usr/lib/firmware/amdnpu/` present, ≥1.1.0.0 | update `linux-firmware` |
+| IOMMU | not `amd_iommu=off` | set `amd_iommu=pt` |
+| memlock | unlimited (or container `--ulimit memlock=-1:-1`) | raise limit |
+| Device passthrough | container can open `/dev/accel/accel0` | (hal0 ContainerSpec already maps it) |
+
+**Debian-specific:** the doctor must explicitly *not* suggest the PPA on Debian, and point to debian-backports or a ≥7.0 kernel.
+
+### 4.4 Doc corrections
+- `manifest.json:20`: kernel ≥6.11 → **"≥6.14 in-tree, ≥6.10 via amdxdna-dkms"**.
+- `src/hal0/providers/flm.py:16` comment: keep accurate to the rebuilt image (base, XRT/FLM versions).
+
+---
+
+## 5. What changes (file map)
+
+- `packaging/toolbox/flm.Dockerfile` — restore + Group 1/2/3 edits.
+- `manifest.json` — image tag bump (`:v2`), kernel-version correction.
+- `src/hal0/providers/flm.py`, `src/hal0/capabilities/catalog.py` — image tag references.
+- `installer/install.sh` — distro-matched `.deb` selection for bare-metal; FLM version pin.
+- Host preflight: wherever `hal0 doctor`/preflight lives (TBD during planning) — add NPU readiness checks.
+- Docs: Proxmox/LXC install guide + README NPU section — container-first guidance, no-PPA-on-Debian.
+
+---
+
+## 6. Risks / caveats
+- **boost SONAME lock:** XRT links against the base's boost (Ubuntu 24.04 = 1.83.0, matches the new lib). A future base rebase (Ubuntu 26.04) moves boost → re-pin.
+- **Per-distro fan-out:** base ⇄ FLM `.deb` ⇄ XRT boost soname must move together. ARG-driven base, default `ubuntu24.04`.
+- **Unverified `.deb` Depends line:** the exact ffmpeg soname in each FLM `.deb` is inferred (per-distro asset names + Arch's `ffmpeg` dep + distro ABIs), not read from the control file. **Verify with `dpkg-deb -I fastflowlm_*_debian13_amd64.deb` before committing the rebuild.**
+- **In-tree vs DKMS firmware protocol mismatch:** forcing 1.1 firmware on a stock kernel can make the NPU vanish — doctor should detect/warn.
+
+---
+
+## 7. Testing
+- **Image build:** `xrt-smi --version` build smoke passes; image boots; `flm validate` OK.
+- **Telemetry:** in a running FLM container, `xrt-smi examine -r aie-partitions -f JSON` returns valid JSON (loaded slot → non-empty HW Contexts; idle → empty) — the contract Spec B consumes.
+- **Cross-distro host matrix:** validate container run on Ubuntu 24.04 (CT105 baseline) and at least one Debian 13 host; confirm `/dev/accel0` passthrough + inference.
+- **Doctor:** unit-test each check's pass/fail + remediation string; manual run on a deliberately-misconfigured host (iommu off, old firmware).
+- **Bare-metal fallback:** dry-run the distro-matched `.deb` selection logic per distro.
+
+---
+
+## 8. Open questions (resolve in planning)
+- Where exactly does host preflight live today, and is `hal0 doctor` the right home for the NPU checks?
+- Source-build FLM in-image vs distro-matched `.deb` in-image — pick one as the container default (lean: source-build for implicit ffmpeg soname).
+- Image tag scheme (`:v2` vs date tag) and republish/CI flow for the toolbox image now that the recipe was retired from the tree.

--- a/docs/superpowers/specs/2026-06-14-npu-hardware-usage-dashboard-design.md
+++ b/docs/superpowers/specs/2026-06-14-npu-hardware-usage-dashboard-design.md
@@ -62,10 +62,10 @@ Verified on CT105 (kernel 7.0.6, XDNA2 "RyzenAI-npu5", `amdxdna` 0.7.0). Both an
 New **`NpuPane`** = the third accordion section on the slots page, parallel to Inference and Image Gen (single-open mutual exclusion preserved). It **absorbs** `NpuFlmStack`: the FLM trio controls (chat model picker, asr/embed toggles, master load/unload) move into the pane's lower half.
 
 ### 4.2 Layout
-**Collapsed strip:** `NPU ● active · 3/8 cols · duty 35% · 41 tok/s · 7.2 GB ▾`
+**Collapsed strip:** `NPU ● active · 8/8 cols (claimed) · duty 35% · 41 tok/s · 7.2 GB ▾`
 
 **Expanded — hardware header (new):**
-- **Hero: 4×8 AIE grid.** 8 columns × 4 rows; allocated columns lit `--dev-npu`, free columns dim. Caption: "AIE array · 4×8 · *allocated* (not utilized)" and "headroom: N / 8 free". (Allocation is per-column, so a column lights whole.)
+- **Hero: 4×8 AIE grid.** 8 columns × 4 rows; allocated columns lit `--dev-npu`, free columns dim. Caption: "AIE array · 4×8 · *allocated* (not utilized)". (Allocation is per-column, so a column lights whole.) **NOTE (verified, see §4.5): an FLM model claims all 8 columns → in practice the grid is all-lit-or-all-dark. Frame headroom as binary ("NPU free" vs "claimed by `<slot>`"), not "N/8 free". The 4×8 grid is still the right honest visual — it shows the whole array going hot when FLM loads.**
 - **Stat cluster:** tri-state dot (idle/loaded/active) + "1 process · 3 roles"; **duty-cycle** bar (labelled "runtime_active_time — real, coarse"); **throughput** bar (tok/s, "serving layer"); **Model RAM** and **Unified free** tiles.
 
 **Expanded — absorbed FLM trio:** chat (model picker) · asr (on/off) · embed (on/off) + master load/unload, as today.
@@ -97,6 +97,63 @@ New **`NpuPane`** = the third accordion section on the slots page, parallel to I
 - Accordion wiring in the slots-page container (alongside `inference-pane.jsx` / `comfyui-pane.jsx`).
 - Consume extended `npu_status` via the existing `useStatsHardware()` hook (2.5 s).
 - Colors from `dashboard.css` device palette (`--dev-npu` #c896ff); reuse `engine-panes.css` accent + `.subcard` styling.
+
+### 4.5 Data layer — verified access (proven live on CT105 2026-06-14)
+
+The three signals come from **three different places** — there is no single NPU
+telemetry endpoint. All verified against a live `flm serve gemma3:1b` on the
+`ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43` image (the rebuilt image is the
+prerequisite — `:v1` cannot run `xrt-smi`, missing `libboost-filesystem`).
+
+**Signal 1 — Column allocation + contexts (`xrt-smi`, in the running FLM container).**
+The hal0 API runs on the host and can `podman exec` the live FLM slot container
+(`hal0-slot-<npu-slot>`), which already holds `/dev/accel/accel0` and has
+`xrt-smi` + `LD_LIBRARY_PATH` baked:
+```bash
+podman exec <flm-slot-container> \
+  /opt/xilinx/xrt/bin/unwrapped/xrt-smi examine -r aie-partitions -f JSON -o /dev/stdout
+# fallback if /dev/stdout rejected: -o /tmp/aie.json then `podman exec ... cat /tmp/aie.json`
+```
+Use the **`unwrapped`** binary (wrapped `xrt-smi` is a python shim needing `setup.sh`).
+JSON contract:
+```
+devices[0].aie_partitions.partitions[] → { start_col, num_cols, partition_index,
+  hw_contexts[] → { pid, context_id, status, command_submissions, command_completions, ... } }
+```
+- `allocated = sum(num_cols)`, `total = 8`. **Proven: one FLM model takes
+  `num_cols:8` → NPU is single-tenant. Render headroom as binary (free vs.
+  wholly claimed), NOT "N/8".** (Confirms ADR-0009 / `hal0_npu_flm_trio`.)
+- `contexts = len(hw_contexts)`; `active = count(status=="Active")`.
+- `command_submissions` **increments with inference** (observed 0→26) — usable as
+  a coarse activity rate (Δ/interval).
+- **`gops`/`egops`/`fps`/`latency` are always `"N/A"` on this part — do not surface.**
+- **Cost:** `podman exec` ~hundreds of ms → cache; refresh on slot load/unload +
+  ~30 s periodic, **never** on the 2.5 s path (reuse the ComfyUI status-aggregator
+  cache pattern, PR #686).
+
+**Signal 2 — Duty-cycle + state (host sysfs, ~0 ms, no sudo, safe at 2.5 s).**
+```
+/sys/class/accel/accel0/device/power/runtime_status      # "active" | "suspended"
+/sys/class/accel/accel0/device/power/runtime_active_time  # ms accumulator
+```
+`duty_pct = clamp(Δactive_time_ms / Δwall_ms, 0, 1) * 100` between polls.
+
+**Signal 3 — Throughput / TTFT / KV (FLM `usage`, serving layer).** FLM has **no
+`/metrics` endpoint**; values arrive in each `/v1/chat/completions` response
+`usage` block (verified):
+```json
+"usage": { "decoding_speed_tps":39.7, "prefill_speed_tps":18.6,
+  "prefill_duration_ttft":0.70, "kv_token_occupancy_rate_percentage":0.049 }
+```
+hal0 already proxies FLM completions — capture `usage` per NPU-slot request and
+keep the last-seen `decoding_speed_tps` (+ ttft, kv occupancy).
+
+**Signal 4 — Model RAM.** `_npu_status().model_mb` already wired — keep.
+
+**Degraded-safe (must):** if the NPU slot isn't loaded or the `xrt-smi` exec
+fails (e.g., slot still on `:v1`), set `columns/contexts = null` and still emit
+`state`, `duty_pct`, `model_mb`. Pane never blanks. Label columns **"allocated,"
+not "utilized"**; no busy-%/power/temp (not available pre-Linux-7.1).
 
 ---
 

--- a/docs/superpowers/specs/2026-06-14-npu-hardware-usage-dashboard-design.md
+++ b/docs/superpowers/specs/2026-06-14-npu-hardware-usage-dashboard-design.md
@@ -1,0 +1,135 @@
+# NPU Hardware-Usage Dashboard Pane — Design
+
+**Date:** 2026-06-14
+**Status:** Draft (awaiting review)
+**Author:** Claude (brainstorming session)
+**Depends on:** [FLM Universal Install + Toolbox Hardening](./2026-06-14-flm-universal-install-toolbox-hardening-design.md) (Spec A — provides a working `xrt-smi` for the real column map)
+
+---
+
+## 1. Why this exists
+
+The dashboard has an honest, useful **iGPU memory map** (`memory-map.jsx`) because the iGPU's GTT is a fixed, partitionable pool — "what fits alongside what" is a real bin-packing question against a hard ceiling. Users asked whether we can build the same for the **NPU**.
+
+The honest answer, after hardware investigation:
+- The NPU has **no dedicated memory** — it shares the 128 GiB unified pool (XDNA2 is a spatial-dataflow accelerator: a 4×8 array of AIE-ML tiles streaming weights/activations from system DRAM). So a second "VRAM bar" would be a lie.
+- The NPU's binding constraint is **compute (columns) + the single FLM process**, not memory.
+- Memory is **already represented**: `memory-map.jsx` draws a purple NPU segment from `npu_status.model_mb`, and there's already an `NpuFlmStack` pane.
+
+So the gap worth filling is a **compute + capacity** view, presented honestly. This spec adds a dedicated NPU pane that shows **headroom and live activity, co-equal** (the chosen framing).
+
+---
+
+## 2. The data reality (what we can honestly show)
+
+Verified on CT105 (kernel 7.0.6, XDNA2 "RyzenAI-npu5", `amdxdna` 0.7.0). Both an on-box probe and official-docs research agree:
+
+| Signal | Available? | Source / note |
+|---|---|---|
+| Model RAM (`model_mb`) | ✅ wired | already in `memory-map` via `_npu_status()` |
+| Loaded / idle / active | ✅ free | slot state + `/sys/class/accel/accel0/device/power/runtime_status` |
+| Duty-cycle % (coarse "busy") | ✅ free | `runtime_active_time` delta ÷ wall delta; ~0 ms, no sudo |
+| Throughput (tok/s) | ✅ serving | FLM/slot `usage` — the real "how hard" signal |
+| Columns **allocated** N/8 | ⚠ needs Spec A | `xrt-smi examine -r aie-partitions`; **allocation-time, static — NOT live utilization**; container exec, cache it |
+| True util %, power, temp, clock | ❌ none | no sensors on this part; `xrt-smi` Estimated Power is Windows-only; arrives on **Linux 7.1** via `npu_tops_curr`/PMF |
+
+### Honesty rules (load-bearing)
+- The AIE grid shows **allocated** columns, labelled as such — *not* utilized. Column allocation is bookkeeping done by the amdxdna Resource Solver at hardware-context creation; there is no per-column busy meter on Linux today.
+- **No** fake busy-%, power, temp, or clock gauges. "Live activity" = duty-cycle (real, coarse) + tok/s (real).
+- Footer notes the true-utilization path (Linux 7.1 + `npu_tops_curr`) as a labeled future, with a TODO to switch when CT105 is on 7.1+.
+
+---
+
+## 3. Goals / Non-goals
+
+### Goals
+- **G1.** A dedicated, co-equal NPU pane answering both "can another workload fit alongside?" (headroom) and "is it working, how hard?" (live activity).
+- **G2.** Reuse existing patterns: accordion (Inference | Image Gen | NPU), device palette (`--dev-npu` #c896ff), `_npu_status()` telemetry block, 2.5 s poll.
+- **G3.** Absorb the existing `NpuFlmStack` trio controls — one NPU surface, not two.
+- **G4.** Degrade gracefully: when `xrt-smi` can't run (pre-Spec-A), the grid greys but every free signal stays live. Pane never blanks.
+
+### Non-goals
+- A second "NPU VRAM" bar (dishonest — no dedicated pool).
+- True utilization %, power, thermal (not available on this kernel).
+- Changing FLM serving (trio = one process, asr/embed model fixed by build flags — unchanged).
+- Per-column live heat/utilization (allocation only).
+
+---
+
+## 4. Design
+
+### 4.1 Placement
+New **`NpuPane`** = the third accordion section on the slots page, parallel to Inference and Image Gen (single-open mutual exclusion preserved). It **absorbs** `NpuFlmStack`: the FLM trio controls (chat model picker, asr/embed toggles, master load/unload) move into the pane's lower half.
+
+### 4.2 Layout
+**Collapsed strip:** `NPU ● active · 3/8 cols · duty 35% · 41 tok/s · 7.2 GB ▾`
+
+**Expanded — hardware header (new):**
+- **Hero: 4×8 AIE grid.** 8 columns × 4 rows; allocated columns lit `--dev-npu`, free columns dim. Caption: "AIE array · 4×8 · *allocated* (not utilized)" and "headroom: N / 8 free". (Allocation is per-column, so a column lights whole.)
+- **Stat cluster:** tri-state dot (idle/loaded/active) + "1 process · 3 roles"; **duty-cycle** bar (labelled "runtime_active_time — real, coarse"); **throughput** bar (tok/s, "serving layer"); **Model RAM** and **Unified free** tiles.
+
+**Expanded — absorbed FLM trio:** chat (model picker) · asr (on/off) · embed (on/off) + master load/unload, as today.
+
+**Footer:** `RyzenAI-npu5 · amdxdna 0.7.0 · fw 1.1.2.65` + "ⓘ true util % & power arrive with Linux 7.1 (box on 7.0.6)".
+
+**States:**
+- **Idle (loaded, no traffic):** grid shows allocated columns dim, duty 0%, 0 tok/s, amber dot.
+- **Degraded (`xrt-smi` unavailable):** grid greys → "column map unavailable — needs flm image rebuild"; duty/tok-s/RAM/state stay live.
+
+### 4.3 Data flow
+- **Extend `_npu_status()`** in `src/hal0/api/routes/hardware.py` (served by `/api/stats/hardware`, already consumed by the frontend) to add:
+  ```
+  npu_status: {
+    ok, model_mb,                      // existing
+    state: "absent|idle|loaded|active",
+    duty_pct: number|null,             // runtime_active_time delta
+    tok_s: number|null,                // from serving/slot metrics
+    columns: { allocated: number, total: 8 } | null,  // null when xrt-smi unavailable
+  }
+  ```
+- **Cadence:** `state`, `duty_pct`, `tok_s`, `model_mb` on the existing 2.5 s poll (all ~0 ms). **`columns`** comes from an `xrt-smi` container exec (~hundreds of ms) → **cached**, refreshed on slot load/unload + a slow periodic (~30 s). Never on the 2.5 s path. (Reuse the existing SWR/snapshot cache pattern.)
+- **duty_pct math:** sample `runtime_active_time` (ms) and wall clock at each poll; `duty = clamp(Δactive / Δwall, 0, 1)`. `runtime_status` gives the active/suspended state cheaply.
+- **columns source:** `xrt-smi examine -r aie-partitions -f JSON` exec'd into the live FLM container (which already has `/dev/accel/accel0` + apparmor=unconfined + XRT on path post-Spec-A). Parse partition column span → `allocated`; `total` = 8.
+
+### 4.4 Frontend
+- New `ui/src/dash/npu-pane.jsx` (`NpuPane`) — absorbs `NpuFlmStack` from `slots.jsx`.
+- New `AieGrid` subcomponent (4×8, allocated/free/degraded states).
+- Accordion wiring in the slots-page container (alongside `inference-pane.jsx` / `comfyui-pane.jsx`).
+- Consume extended `npu_status` via the existing `useStatsHardware()` hook (2.5 s).
+- Colors from `dashboard.css` device palette (`--dev-npu` #c896ff); reuse `engine-panes.css` accent + `.subcard` styling.
+
+---
+
+## 5. What changes (file map)
+- `src/hal0/api/routes/hardware.py` — extend `_npu_status()` (state/duty/tok_s/columns) + cached `xrt-smi` column reader.
+- `src/hal0/slots/capacity.py` — if tok/s per-slot lands here, expose it.
+- `ui/src/dash/npu-pane.jsx` (new) + `AieGrid`; remove `NpuFlmStack` from `ui/src/dash/slots.jsx`.
+- Slots-page accordion container — register the NPU pane.
+- `ui/src/dashboard.css` / `engine-panes.css` — minor grid styles (palette already exists).
+- e2e: new `ui/tests/e2e/specs/npu-pane-*.spec.ts`.
+
+> **Collision note:** as of 2026-06-14 the `refactor/runtime-launch-plan` branch has heavy uncommitted edits to `slots.jsx`, `engine-panes.css`, `inference-pane.jsx`, `dashboard.css`. **Sequence Spec B implementation after that branch lands**, or coordinate via `wip` + worktree to avoid conflicts on these exact files.
+
+---
+
+## 6. Risks / caveats
+- **"Allocated ≠ utilized" misread.** Mitigation: explicit label + caption + footer note. Do not animate the grid as if it were live load.
+- **`xrt-smi` exec cost / flakiness.** Mitigation: cache + slow refresh; never block the 2.5 s poll; degrade to "unavailable" cleanly.
+- **Dependency on Spec A.** Without the image rebuild, `columns` is always null (degraded grid). The pane still ships value (duty + tok/s + RAM + state). Decide at planning whether to ship degraded-first or gate on Spec A.
+- **tok/s availability when idle/asr/embed.** tok/s is chat-path; asr/embed throughput may not map cleanly — show tok/s for chat, fall back to "active request present" as the binary busy signal.
+
+---
+
+## 7. Testing
+- **Backend:** unit-test extended `_npu_status()` shapes for absent/idle/loaded/active; duty math from synthetic `runtime_active_time` deltas; `columns` parser against captured `xrt-smi … -f JSON` fixtures (loaded + idle); cache refresh-on-load behavior.
+- **Frontend:** `AieGrid` renders allocated/free/degraded; pane collapsed/expanded/idle/degraded snapshots; absorbed trio controls still drive load/unload/model swap.
+- **e2e:** mock extended `npu_status` via the γ-suite forced-mock; verify co-equal accordion behavior + degraded state.
+- **Live (CT105):** with FLM loaded, grid shows real allocated columns matching `xrt-smi`; duty/tok-s move under inference.
+
+---
+
+## 8. Open questions (resolve in planning)
+- Ship Spec B degraded-first (free signals now) or gate on Spec A's image rebuild for the real grid?
+- Does per-slot tok/s already exist in `capacity.py`/metrics, or is new plumbing needed?
+- Exact home of the `xrt-smi` exec+cache (reuse ComfyUI status aggregator pattern, or a dedicated NPU reader)?
+- Sequencing vs the `refactor/runtime-launch-plan` UI changes (file collisions above).

--- a/manifest.json
+++ b/manifest.json
@@ -15,9 +15,9 @@
       "_notes": "llama.cpp ROCm backend; multi-arch (gfx1030..gfx1151)"
     },
     "flm": {
-      "tag": "ghcr.io/hal0ai/hal0-toolbox-flm:v1",
-      "digest": "sha256:561a101f078e93a0d3b9c35ca121c6d23e08ea15d630b61db68712f897666a83",
-      "_notes": "FastFlowLM on AMD XDNA2 NPU; requires kernel >= 6.11 + amdxdna driver on the host"
+      "tag": "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43",
+      "digest": "sha256:7e975f49f4385ef9cc7cc008972ddb2d9f6b66a5fe8687eb4dba66fe1609e3a1",
+      "_notes": "FastFlowLM v0.9.43 on AMD XDNA2 NPU; requires amdxdna driver on the host (kernel >= 6.14 in-tree, or >= 6.10 via amdxdna-dkms) + NPU firmware >= 1.1.0.0. NOTE: digest is the local build digest — re-confirm with the value printed by `podman push` once the image is pushed to GHCR."
     },
     "moonshine": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-moonshine:v1",

--- a/manifest.json
+++ b/manifest.json
@@ -16,8 +16,8 @@
     },
     "flm": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43",
-      "digest": "sha256:7e975f49f4385ef9cc7cc008972ddb2d9f6b66a5fe8687eb4dba66fe1609e3a1",
-      "_notes": "FastFlowLM v0.9.43 on AMD XDNA2 NPU; requires amdxdna driver on the host (kernel >= 6.14 in-tree, or >= 6.10 via amdxdna-dkms) + NPU firmware >= 1.1.0.0. NOTE: digest is the local build digest — re-confirm with the value printed by `podman push` once the image is pushed to GHCR."
+      "digest": "sha256:5f4c8a08a269077d8d24b1a93cfa39aebd1bfa10c868048796e8d2e5f589fcad",
+      "_notes": "FastFlowLM v0.9.43 on AMD XDNA2 NPU; requires amdxdna driver on the host (kernel >= 6.14 in-tree, or >= 6.10 via amdxdna-dkms) + NPU firmware >= 1.1.0.0. Digest is the GHCR registry digest (confirmed post-push 2026-06-14)."
     },
     "moonshine": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-moonshine:v1",

--- a/packaging/toolbox/flm.Dockerfile
+++ b/packaging/toolbox/flm.Dockerfile
@@ -39,7 +39,10 @@
 FROM ubuntu:24.04 AS xrt-builder
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG XDNA_REF=main
+# Pinned to the Ryzen AI 1.7.1 stable pairing (xdna-driver 2.21.75 ↔ XRT
+# 2.21.75), matching the CT105 host's libxrt. Was `main` (unreproducible,
+# drifted to XRT 2.23.0). Tag verified to exist upstream.
+ARG XDNA_REF=2.21.75
 
 # Minimal bootstrap deps — just enough to clone the repo and run XRT's
 # own dependency installer. After three rounds of whack-a-mole with
@@ -54,8 +57,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
-RUN git clone --recurse-submodules \
-        https://github.com/amd/xdna-driver.git . \
+# NOTE: clone WITHOUT --recurse-submodules, then init submodules AFTER the
+# tag checkout. When pinning XDNA_REF to a release tag, the bundled XRT
+# submodule points at a specific commit; a recursive clone would first
+# populate xrt/ at the default-branch commit, and the later
+# `submodule update` then fails to switch it ("Unable to checkout <sha> in
+# submodule path 'xrt'"). Initialising submodules post-checkout fetches the
+# tag's pinned XRT commit cleanly.
+RUN git clone https://github.com/amd/xdna-driver.git . \
     && git checkout "${XDNA_REF}" \
     && git submodule update --init --recursive
 
@@ -100,7 +109,9 @@ RUN mkdir -p build && cd build \
 FROM ubuntu:24.04 AS flm-builder
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG FLM_REF=main
+# Pinned to v0.9.43 (latest, 2026-05-26) — matches the host model cache and
+# clears the "0.9.43 > 0.9.42" incompatibility warning the old image emitted.
+ARG FLM_REF=v0.9.43
 
 # Pull the freshly-built XRT in so FLM can link against it.
 COPY --from=xrt-builder /opt/xilinx/xrt /opt/xilinx/xrt

--- a/packaging/toolbox/flm.Dockerfile
+++ b/packaging/toolbox/flm.Dockerfile
@@ -1,0 +1,253 @@
+# hal0-toolbox-flm — FastFlowLM (FLM) on AMD Strix Halo XDNA2 NPU.
+#
+# Target image:    ghcr.io/<owner>/hal0-toolbox-flm:v1
+# Local dev tag:   hal0-toolbox-flm:dev
+#
+# Provider contract (src/hal0/providers/flm.py):
+#   - binary path:      /usr/local/bin/flm
+#   - subcommand:       `flm serve <model_tag> --port N --host 0.0.0.0 --ctx-len C`
+#   - endpoints:        /v1/models, /v1/chat/completions, /v1/embeddings,
+#                       /v1/audio/transcriptions (when --asr is enabled)
+#   - runtime devices:  /dev/accel (XDNA2 NPU), /dev/dri (iGPU helpers)
+#   - runtime ulimits:  --ulimit memlock=-1:-1 (NPU buffer pinning)
+#   - model cache:      /root/.config/flm (bind-mount via slot_cfg._paths.flm_cache)
+#
+# Upstream: https://github.com/FastFlowLM/FastFlowLM — Apache 2.0
+# Driver:   https://github.com/amd/xdna-driver (XRT + xdna NPU plugin)
+# Reference: https://github.com/hpenedones/fastflowlm-docker (3-stage build,
+#            ~440MB final, ~15-25 min build time on a fast box).
+#
+# HOST REQUIREMENTS (cannot be satisfied inside the image):
+#   - Linux kernel ≥ 6.11 with `amdxdna` loaded
+#   - NPU firmware ≥ 1.1.0.0
+#   - /dev/accel/accel0 visible on the host
+#
+# Build:
+#   docker build -t hal0-toolbox-flm:dev -f packaging/toolbox/flm.Dockerfile .
+#
+# Smoke (on a Strix Halo host with NPU passthrough):
+#   docker run --rm --device=/dev/accel --device=/dev/dri \
+#       --ulimit memlock=-1:-1 --group-add video --group-add render \
+#       hal0-toolbox-flm:dev flm validate
+#
+# NOTE: This Dockerfile builds FLM + XRT from source. Build hosts WITHOUT
+# the xdna driver kernel headers will still compile cleanly — the
+# xdna-driver userspace bits are headers + libraries, not kernel modules.
+# Only RUNTIME requires the host kernel + /dev/accel.
+
+# ─── Stage 1 — XRT + xdna-driver userspace builder ────────────────────────────
+FROM ubuntu:24.04 AS xrt-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG XDNA_REF=main
+
+# Minimal bootstrap deps — just enough to clone the repo and run XRT's
+# own dependency installer. After three rounds of whack-a-mole with
+# missing find_package() targets (OpenCL → Boost components → Curses →
+# Protobuf → …), it's faster to defer to XRT's canonical dep script
+# which knows every package the configure step touches on each
+# Ubuntu release.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN git clone --recurse-submodules \
+        https://github.com/amd/xdna-driver.git . \
+    && git checkout "${XDNA_REF}" \
+    && git submodule update --init --recursive
+
+# XRT ships its own apt installer for every Ubuntu release it supports.
+# `-docker` skips kernel-module-build deps (we're never going to insmod
+# inside the image). It's idempotent and covers GTest, Protobuf, ncurses,
+# Boost (full), OpenCL, systemd, pybind11, rapidjson, uuid, ffmpeg-libs,
+# etc. — i.e. the same packages we were enumerating by hand.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && ./xrt/src/runtime_src/tools/scripts/xrtdeps.sh -docker \
+    && rm -rf /var/lib/apt/lists/*
+
+# xdna-driver bundles upstream XRT as a submodule under xrt/.
+# Build XRT first, then the xdna plugin against it.
+#
+# -noert: skip ERT MicroBlaze firmware build. ERT requires the Xilinx
+#   Vitis toolchain (XILINX_VITIS env) which we don't ship in CI — and
+#   the XDNA2 NPU on Strix Halo doesn't use the MicroBlaze firmware path
+#   anyway (it has its own AIE compiler output). Without this flag the
+#   build aborts with "XILINX_VITIS is undefined" before any compilation
+#   happens. Confirmed by upstream xrt build.sh: "To treat as a warning
+#   use -noert option."
+#
+# `./build.sh -opt` already runs `cmake --install` into the staging dir
+# `build/Release/opt/xilinx/xrt`. The companion `./build.sh -install`
+# step is the .deb-packaging path which (a) expects ERT firmware to be
+# present and (b) prints help + exits 1 when called twice in a row.
+# So: drop the second invocation and copy the staging tree directly
+# into /opt/xilinx/xrt — that's exactly what the .deb would put there.
+RUN cd xrt/build && ./build.sh -noert -opt \
+    && mkdir -p /opt/xilinx \
+    && cp -a Release/opt/xilinx/xrt /opt/xilinx/xrt
+
+# Build the xdna NPU plugin against the XRT we just installed.
+RUN mkdir -p build && cd build \
+    && cmake -DCMAKE_INSTALL_PREFIX=/opt/xilinx/xrt .. \
+    && make -j"$(nproc)" \
+    && make install
+
+# ─── Stage 2 — FLM builder ────────────────────────────────────────────────────
+FROM ubuntu:24.04 AS flm-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG FLM_REF=main
+
+# Pull the freshly-built XRT in so FLM can link against it.
+COPY --from=xrt-builder /opt/xilinx/xrt /opt/xilinx/xrt
+
+# Dep list mirrors upstream FastFlowLM/Dockerfile (main): adds rust
+# toolchain (FLM ships Rust components since 2026-04), nasm + patchelf
+# (xclbin packaging), and the full ffmpeg dev libs (libavutil,
+# libswresample) — the prior hand-picked subset compiled against an
+# older release that predated the Rust rewrite of FLM's tokenizer.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        ninja-build \
+        git \
+        curl \
+        ca-certificates \
+        libboost-program-options-dev \
+        libcurl4-openssl-dev \
+        libfftw3-dev \
+        libavformat-dev \
+        libavcodec-dev \
+        libavutil-dev \
+        libswscale-dev \
+        libswresample-dev \
+        libreadline-dev \
+        libdrm-dev \
+        nasm \
+        patchelf \
+        pkg-config \
+        uuid-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install a recent Rust via rustup. Ubuntu 24.04 ships rustc 1.75 in
+# apt which is too old. FLM's tokenizers-cpp pulls a dependency graph
+# that requires rustc >= 1.85 — the floor moved twice while debugging:
+# `monostate v0.1.18` needs 1.79, and `unicode-segmentation v1.13.2`
+# (pulled transitively) needs 1.85. Pinning to 1.85.0 stable keeps
+# the build reproducible.
+ARG RUST_VERSION=1.85.0
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:${PATH}
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal --no-modify-path \
+    && rustc --version && cargo --version
+
+WORKDIR /src
+RUN git clone --recurse-submodules \
+        https://github.com/FastFlowLM/FastFlowLM.git . \
+    && git checkout "${FLM_REF}" \
+    && git submodule update --init --recursive
+
+# Upstream layout note: FastFlowLM's CMakeLists.txt + CMakePresets.json
+# live under src/ (not the repo root). The previous Dockerfile config
+# step `cmake --preset linux-default` ran from /src and bailed with
+# "Could not read presets from /src" — the presets file is actually
+# at /src/src/CMakePresets.json. cd into the source dir first.
+WORKDIR /src/src
+RUN cmake --preset linux-default \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/opt/fastflowlm \
+        -DXRT_INCLUDE_DIR=/opt/xilinx/xrt/include \
+        -DXRT_LIB_DIR=/opt/xilinx/xrt/lib \
+    && cmake --build build -j"$(nproc)" \
+    && cmake --install build
+
+# ─── Stage 3 — runtime ────────────────────────────────────────────────────────
+FROM ubuntu:24.04 AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Runtime deps only — no compilers, headers, or source.
+# Boost-program-options, FFTW, ffmpeg-libs, readline are FLM's runtime
+# link-time deps; libdrm/libelf/libudev are XRT's; curl/ca-certificates
+# for FLM's model pull from HF.
+# NOTE: XRT links BOTH boost_program_options AND boost_filesystem (see XRT
+# boostUtil.cmake) but XRT does not declare the filesystem dep (Xilinx/XRT
+# #6295). Without libboost-filesystem, `xrt-smi` dies with
+# "error while loading shared libraries: libboost_filesystem.so.1.83.0",
+# which breaks NPU telemetry (aie-partitions). Keep both boost runtime libs.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libboost-program-options1.83.0 \
+        libboost-filesystem1.83.0 \
+        libboost-system1.83.0 \
+        libcurl4 \
+        libfftw3-single3 \
+        libavformat60 \
+        libavcodec60 \
+        libswscale7 \
+        libreadline8t64 \
+        libdrm2 \
+        libelf1t64 \
+        libudev1 \
+        libgomp1 \
+        ca-certificates \
+        curl \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy XRT runtime libs + xdna plugin.
+COPY --from=xrt-builder /opt/xilinx/xrt/lib /opt/xilinx/xrt/lib
+COPY --from=xrt-builder /opt/xilinx/xrt/bin /opt/xilinx/xrt/bin
+COPY --from=xrt-builder /opt/xilinx/xrt/share /opt/xilinx/xrt/share
+
+# Copy FLM tree (binary + xclbins + share assets).
+COPY --from=flm-builder /opt/fastflowlm /opt/fastflowlm
+
+# Symlink the binary so the Provider's start_cmd default (/usr/local/bin/flm)
+# resolves. The Provider also accepts HAL0_FLM_BINARY override.
+RUN ln -sf /opt/fastflowlm/bin/flm /usr/local/bin/flm
+
+ENV LD_LIBRARY_PATH=/opt/xilinx/xrt/lib:/opt/fastflowlm/lib \
+    PATH=/opt/xilinx/xrt/bin:/opt/fastflowlm/bin:${PATH} \
+    XILINX_XRT=/opt/xilinx/xrt \
+    FLM_XCLBIN_PATH=/opt/fastflowlm/share/flm/xclbins
+
+# Build-time smoke: xrt-smi must load its shared libs (catches a missing
+# boost regression at build, not at runtime on the NPU box). The `unwrapped`
+# binary is used because the wrapped `xrt-smi` is a python shim that expects
+# `source setup.sh`; the unwrapped binary runs directly off LD_LIBRARY_PATH.
+RUN /opt/xilinx/xrt/bin/unwrapped/xrt-smi --version
+
+# UID/GID match host hal0; bind-mounted model cache reads cleanly.
+# NOTE: FLM defaults its model cache to ~/.config/flm; the slot's
+# ContainerSpec bind-mounts host flm_cache into the same in-container
+# path (see flm.py:container_spec).
+#
+# Pre-create render/video groups so docker --group-add (FLM ContainerSpec
+# passes ["video", "render"]) resolves inside the container.
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && groupadd --system --gid 44  video  2>/dev/null || true \
+    && groupadd --system --gid 993 render 2>/dev/null || true \
+    && groupadd --system --gid 1000 hal0 \
+    && useradd  --system --uid 1000 --gid 1000 --shell /usr/sbin/nologin \
+                --home-dir /var/lib/hal0 --create-home hal0 \
+    && usermod -aG video,render hal0 \
+    && mkdir -p /var/lib/hal0/.config/flm /var/lib/hal0/models \
+    && chown -R hal0:hal0 /var/lib/hal0
+
+USER hal0
+WORKDIR /var/lib/hal0
+
+EXPOSE 8086
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 \
+    CMD curl -fsS "http://127.0.0.1:${HAL0_PORT:-8086}/v1/models" || exit 1
+
+# tini → flm. ContainerSpec.command[] supplies ["serve", <tag>, "--port", ...].
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/flm"]
+CMD ["--help"]

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -92,7 +92,7 @@ _CAPABILITY_TO_SLOT_TYPE: dict[str, str] = {
 # ── Backends ──────────────────────────────────────────────────────────────────
 
 
-_FLM_TOOLBOX_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-flm:v1"
+_FLM_TOOLBOX_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43"
 
 
 # FLM tags hidden from the dashboard catalog because of upstream FLM

--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -43,7 +43,7 @@ from hal0.providers.base import ContainerSpec, Provider
 # ── Toolbox image ─────────────────────────────────────────────────────────────
 # Default tag. Override via HAL0_TOOLBOX_IMAGE_FLM in api.env when running
 # on hal0-test before the GHCR org is provisioned (PLAN §17).
-_DEFAULT_FLM_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-flm:v1"
+_DEFAULT_FLM_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43"
 
 # ── On-disk layout ────────────────────────────────────────────────────────────
 # The toolbox image is self-contained: it bundles FLM at /opt/fastflowlm/


### PR DESCRIPTION
## What

Repoints the FLM toolbox image to a rebuilt **`hal0-toolbox-flm:0.9.43`** that enables NPU telemetry and ships the latest FLM, restores the image recipe to the tree, and lands the design specs for the NPU work.

## Why

The NPU (XDNA2) exposed no live telemetry to the dashboard, and the shipped `:v1` image had two real defects found while wiring it up:

1. **`xrt-smi` was broken** — `:v1` ships only `libboost-program-options1.83.0`, but XRT links `boost_filesystem` too (undeclared dep, [Xilinx/XRT #6295](https://github.com/Xilinx/XRT/issues/6295)). `xrt-smi` died with `libboost_filesystem.so.1.83.0: cannot open shared object file`, so NPU column telemetry was unreadable.
2. **FLM version drift** — `:v1` ships FLM **v0.9.42** while the host model cache is **v0.9.43** → "may not be compatible" warnings and queued-inference hangs.

## Changes

- **`packaging/toolbox/flm.Dockerfile`** (restored to the tree — was retired at `c71f04d9`):
  - `+libboost-filesystem1.83.0` `+libboost-system1.83.0`; set `XILINX_XRT`; build-time `xrt-smi --version` smoke.
  - Pin **`FLM_REF=v0.9.43`** (latest, matches host cache) + **`XDNA_REF=2.21.75`** (Ryzen AI 1.7.1 stable pairing, matches host libxrt).
  - Fix submodule ordering: clone **without** `--recurse-submodules`, init submodules **after** the tag checkout (recursive-clone-then-checkout-tag can't pin the XRT submodule — only surfaces when pinning to a release tag).
- **Repoint** `:v1` → `:0.9.43`: `src/hal0/providers/flm.py`, `src/hal0/capabilities/catalog.py`, `manifest.json` (tag + digest).
- **`manifest.json`** kernel note corrected: `>=6.11` → `>=6.14 in-tree / >=6.10 dkms` + firmware `>=1.1.0.0`.
- **Design specs** (`docs/superpowers/specs/2026-06-14-*`): FLM universal-install/toolbox-hardening (Spec A) + NPU hardware-usage dashboard pane (Spec B, incl. §4.5 verified data-layer access).

## Validation (live on CT105, XDNA2)

Built from source on CT105 (506 MB) and validated against the real NPU:

| Check | Result |
|---|---|
| `flm validate` | NPU 8 columns, FW 1.1.2.65, amdxdna 0.7, memlock ∞ |
| Versions | FLM **v0.9.43**, XRT 2.21.0, **0 missing libs**, no drift warning |
| Trio | chat ✅ (`decoding_speed_tps` 22–40), embed ✅ (real vector), asr ✅ (routed) |
| `xrt-smi -r aie-partitions -f JSON` | `num_cols:8`, Active contexts, `command_submissions` increments |

## ⚠️ Before merge / deploy

- **GHCR push pending auth.** The image is built locally on CT105 but **not yet pushed** — the `gh` token (`thinmintdev`) lacks `write:packages`. Push requires a `write:packages` token, then **re-confirm `manifest.json` digest** with the value `podman push` prints (current digest is the local build digest).
- **CT105 will run `:0.9.43` from its local image** without a pull; fresh/other hosts need the GHCR push first.

## Test plan

- CI: ruff + pytest (`PYTHONPATH=src`).
- Post-push: `podman pull ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43` on a clean host → digest matches manifest → `flm validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
