### PR TITLE
P3: standalone /pull uses capability-grouped paths

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -1020,6 +1020,38 @@ def _resolve_pull_source(request: Request, model_id: str) -> tuple[str, str]:
     )
 
 
+def _resolve_pull_capability(
+    request: Request,
+    model_id: str,
+    body: dict[str, Any] | None,
+) -> tuple[str | None, str | None]:
+    """Resolve ``(capability, comfyui_subdir)`` for a pull (P3 grouped layout).
+
+    Priority for capability: explicit ``body.capability`` → the registry row's
+    first capability → the curated entry's capability. ``comfyui_subdir`` comes
+    from the curated entry only. Returns ``(None, None)`` for an unknown ad-hoc
+    model so :func:`run_pull` falls back to the legacy flat layout.
+    """
+    if isinstance(body, dict):
+        cap_raw = body.get("capability")
+        if isinstance(cap_raw, str) and cap_raw.strip():
+            return cap_raw.strip(), None
+
+    try:
+        existing = request.app.state.model_registry.get(model_id)
+        caps = getattr(existing, "capabilities", None) or []
+        if caps:
+            return str(caps[0]), None
+    except Exception:
+        pass
+
+    curated = get_curated(model_id)
+    if curated is not None:
+        subdir = (getattr(curated, "comfyui_subdir", "") or "").strip() or None
+        return (curated.capability or None), subdir
+    return None, None
+
+
 def _seed_registry_from_body(
     request: Request,
     model_id: str,

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -1143,6 +1143,8 @@ async def _run_pull_with_events(
     registry: Any,
     hf_token: str | None,
     event_bus: Any | None,
+    capability: str | None = None,
+    comfyui_subdir: str | None = None,
 ) -> None:
     """Wrap ``run_pull`` so footer-visible progress events fan out.
 
@@ -1151,9 +1153,20 @@ async def _run_pull_with_events(
     attr) plus terminal events on success / failure / cancellation. The
     HF download itself is untouched; we listen to the same progress
     signal SSE listens to so the byte counts stay authoritative.
+
+    ``capability``/``comfyui_subdir`` (P3) route the download into the
+    capability-grouped store layout; both default to None → legacy flat layout.
     """
     if event_bus is None:
-        await run_pull(job, hf_repo=hf_repo, hf_file=hf_file, registry=registry, hf_token=hf_token)
+        await run_pull(
+            job,
+            hf_repo=hf_repo,
+            hf_file=hf_file,
+            registry=registry,
+            hf_token=hf_token,
+            capability=capability,
+            comfyui_subdir=comfyui_subdir,
+        )
         return
 
     async def _emit_progress() -> None:
@@ -1189,7 +1202,15 @@ async def _run_pull_with_events(
 
     progress_task = asyncio.create_task(_emit_progress())
     try:
-        await run_pull(job, hf_repo=hf_repo, hf_file=hf_file, registry=registry, hf_token=hf_token)
+        await run_pull(
+            job,
+            hf_repo=hf_repo,
+            hf_file=hf_file,
+            registry=registry,
+            hf_token=hf_token,
+            capability=capability,
+            comfyui_subdir=comfyui_subdir,
+        )
     finally:
         progress_task.cancel()
         with contextlib.suppress(asyncio.CancelledError, Exception):
@@ -1345,6 +1366,9 @@ async def pull_model(
 
     hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
     registry = request.app.state.model_registry
+    # P3: route the download into the capability-grouped store layout when the
+    # capability is resolvable (body → registry → curated); None → flat fallback.
+    capability, comfyui_subdir = _resolve_pull_capability(request, model_id, body)
     background.add_task(
         _run_pull_with_events,
         job,
@@ -1353,6 +1377,8 @@ async def pull_model(
         registry=registry,
         hf_token=hf_token,
         event_bus=event_bus,
+        capability=capability,
+        comfyui_subdir=comfyui_subdir,
     )
     return {
         "id": job.job_id,

--- a/tests/api/test_models_pull_capability.py
+++ b/tests/api/test_models_pull_capability.py
@@ -1,0 +1,53 @@
+"""_resolve_pull_capability — capability + comfyui_subdir for a pull (P3)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from hal0.api.routes.models import _resolve_pull_capability
+
+
+class _Reg:
+    def __init__(self, entry=None):
+        self._entry = entry
+
+    def get(self, _mid):
+        if self._entry is None:
+            raise KeyError(_mid)
+        return self._entry
+
+
+def _req(entry=None):
+    app = SimpleNamespace(state=SimpleNamespace(model_registry=_Reg(entry)))
+    return SimpleNamespace(app=app)
+
+
+def test_body_capability_wins():
+    cap, subdir = _resolve_pull_capability(_req(), "anything", {"capability": "embed"})
+    assert cap == "embed"
+    assert subdir is None
+
+
+def test_registry_capability_used_when_no_body():
+    entry = SimpleNamespace(capabilities=["stt", "chat"], hf_repo="r", hf_filename="f")
+    cap, _ = _resolve_pull_capability(_req(entry), "m", None)
+    assert cap == "stt"
+
+
+def test_curated_capability_and_subdir_fallback(monkeypatch):
+    import hal0.api.routes.models as m
+
+    curated = SimpleNamespace(capability="image", comfyui_subdir="checkpoints")
+    monkeypatch.setattr(m, "get_curated", lambda _mid: curated)
+    cap, subdir = _resolve_pull_capability(_req(), "sd-turbo", None)
+    assert cap == "image"
+    assert subdir == "checkpoints"
+
+
+def test_unknown_model_returns_none(monkeypatch):
+    import hal0.api.routes.models as m
+
+    monkeypatch.setattr(m, "get_curated", lambda _mid: None)
+    cap, subdir = _resolve_pull_capability(_req(), "ad-hoc", None)
+    assert cap is None
+    assert subdir is None

--- a/tests/api/test_pull_routes.py
+++ b/tests/api/test_pull_routes.py
@@ -317,3 +317,23 @@ def test_pick_default_preserves_existing_slot_port_and_backend(
     assert cfg["port"] == 9999
     assert cfg["backend"] == "rocm"
     assert cfg["model"]["default"] == "qwen3-4b"
+
+
+def test_pull_threads_capability_to_run_pull(
+    client_isolated: TestClient, fake_run_pull: list[dict[str, Any]]
+) -> None:
+    """P3: the standalone /pull resolves a curated model's capability and passes
+    it to run_pull so the file lands in the capability-grouped layout."""
+    r = client_isolated.post("/api/models/qwen3-4b/pull")
+    assert r.status_code == 202, r.text
+    assert len(fake_run_pull) == 1
+    assert fake_run_pull[0]["capability"] == "chat"
+
+
+def test_pull_body_capability_overrides(
+    client_isolated: TestClient, fake_run_pull: list[dict[str, Any]]
+) -> None:
+    """An explicit body.capability wins over the curated default."""
+    r = client_isolated.post("/api/models/qwen3-4b/pull", json={"capability": "embed"})
+    assert r.status_code == 202, r.text
+    assert fake_run_pull[0]["capability"] == "embed"


### PR DESCRIPTION
## What
The standalone `POST /api/models/{id}/pull` now writes the capability-grouped layout `<store>/<cap>/<id>/model.gguf` + `meta.json` (the helper #809 shipped for `/apply`), instead of the legacy flat `<store>/<id>/<file>`.

## How
- New `_resolve_pull_capability(request, model_id, body)` → `(capability, comfyui_subdir)`: body.capability → registry row's `capabilities[0]` → curated `.capability`; `comfyui_subdir` from the curated entry.
- Threaded through `_run_pull_with_events` → `run_pull(capability=…, comfyui_subdir=…)`.
- **New pulls only.** Unknown ad-hoc models (no registry/curated row) → `capability=None` → flat-layout fallback (no regression). Existing on-disk models keep their absolute registry paths.

## Tests
- `test_models_pull_capability.py` (resolver precedence: body > registry > curated; unknown → None).
- `test_pull_routes.py` +2 (capability threaded to run_pull; body capability overrides).
- Full pull-route + registry suite: **141 passed**. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)