### PR TITLE
P4: HuggingFace token Settings field + api.env hint

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -536,6 +536,10 @@ HAL0_UI_DIST=${HAL0_UI_DIST_VAL}
 # with memory dark. Needs the shared hindsight-api daemon (installer/systemd/
 # hindsight-api.service); set [memory] engine = "cognee" to fall back.
 HAL0_MEMORY_ENABLED=1
+# HF_TOKEN — HuggingFace token for gated / large model pulls. Easiest path:
+# set it in the dashboard (Settings -> Secrets -> HuggingFace token) for a live,
+# no-restart update. Or uncomment below and \`systemctl restart hal0-api\`.
+# HF_TOKEN=
 # HAL0_TOOLBOX_IMAGE_VULKAN / HAL0_TOOLBOX_IMAGE_ROCM — optional overrides for
 # the per-backend container image refs used by providers/llama_server.py.
 # Unset = use the image pinned in the provider at release time.

--- a/tests/api/test_secrets.py
+++ b/tests/api/test_secrets.py
@@ -173,3 +173,18 @@ def test_set_coexists_with_provider_credentials(client: TestClient, tmp_hal0_hom
     # The list surfaces both (every api.env key is a secret).
     names = sorted(e["name"] for e in client.get("/api/secrets").json()["secrets"])
     assert names == ["EXTRA_TOKEN", "OPENROUTER_API_KEY"]
+
+
+def test_hf_token_secret_roundtrip(client: TestClient) -> None:
+    """P4: HF_TOKEN behaves like any secret — set → listed + live in os.environ;
+    delete clears both. This is the storage the Settings HuggingFace-token field
+    and every pull path (os.environ reads) rely on."""
+    r = client.put("/api/secrets/HF_TOKEN", json={"value": "hf_abc123"})
+    assert r.status_code == 204, r.text
+    assert os.environ.get("HF_TOKEN") == "hf_abc123"
+    names = [s["name"] for s in client.get("/api/secrets").json()["secrets"]]
+    assert "HF_TOKEN" in names
+
+    r = client.delete("/api/secrets/HF_TOKEN")
+    assert r.status_code == 204
+    assert os.environ.get("HF_TOKEN") is None

--- a/ui/src/dash/settings.jsx
+++ b/ui/src/dash/settings.jsx
@@ -432,6 +432,49 @@ function StorageSection() {
   );
 }
 
+// Dedicated, discoverable HuggingFace-token field (P4). Wraps the existing
+// /api/secrets store under the fixed name HF_TOKEN — set/delete update os.environ
+// live (no restart), so the next gated/large pull authenticates immediately.
+function HfTokenField() {
+  const secretsQuery = useSecrets();
+  const setSecret = useSecretSet();
+  const delSecret = useSecretDelete();
+  const [val, setVal] = useStateSet("");
+  const isSet = (secretsQuery.data ?? []).some(s => s.name === "HF_TOKEN" && s.set);
+  return (
+    <div className="s-panel" style={{padding: 16, marginBottom: 16}}>
+      <div className="mono" style={{fontSize: 10, color: "var(--fg-4)", textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 6}}>HuggingFace token</div>
+      <p className="desc" style={{margin: "0 0 10px"}}>
+        Needed for gated / large model pulls. Stored encrypted; applied live (no restart).
+        Status: {isSet ? <span style={{color: "var(--ok)"}}>set ✓</span> : <span style={{color: "var(--fg-4)"}}>not set</span>}
+      </p>
+      <div style={{display: "flex", gap: 8}}>
+        <input
+          type="password"
+          className="input mono"
+          aria-label="HuggingFace token"
+          value={val}
+          onChange={e => setVal(e.target.value)}
+          placeholder={isSet ? "•••••••• (set) — enter to replace" : "hf_…"}
+          style={{flex: 1, padding: "8px 10px", fontSize: 13}}
+        />
+        <button
+          className="btn"
+          disabled={!val.trim() || setSecret.isPending}
+          onClick={() => setSecret.mutate({ name: "HF_TOKEN", value: val.trim() }, { onSuccess: () => setVal("") })}
+        >
+          {setSecret.isPending ? "Saving…" : "Save"}
+        </button>
+        {isSet && (
+          <button className="btn ghost" disabled={delSecret.isPending} onClick={() => delSecret.mutate("HF_TOKEN")}>
+            {delSecret.isPending ? "Clearing…" : "Clear"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function SecretsSection() {
   const [addOpen, setAddOpen] = useStateSet(false);
   const secretsQuery = useSecrets();
@@ -441,6 +484,7 @@ function SecretsSection() {
     <div className="s-section">
       <h2>Secrets</h2>
       <p className="desc">Encrypted at rest. Used for gated HF repos and provider auth.</p>
+      <HfTokenField />
       {secretsQuery.isLoading && (
         <div style={{padding: 16, color: "var(--fg-4)", fontFamily: "var(--jbm)", fontSize: 12}}>Loading…</div>
       )}

--- a/ui/tests/e2e/specs/hf-token-setting.spec.ts
+++ b/ui/tests/e2e/specs/hf-token-setting.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * P4 — the dedicated HuggingFace-token field in Settings → Secrets writes through
+ * the existing /api/secrets/HF_TOKEN store and reflects set/not-set status.
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+
+test.describe('Settings — HuggingFace token', () => {
+  test('save posts to /api/secrets/HF_TOKEN; status reflects set', async ({ page }) => {
+    let putBody: any = null
+    let hasToken = false
+    await page.route('**/api/secrets', (r) =>
+      json(r, { secrets: hasToken ? [{ name: 'HF_TOKEN', set: true, masked: '••• · set' }] : [] }))
+    await page.route('**/api/secrets/HF_TOKEN', async (r) => {
+      if (r.request().method() === 'PUT') {
+        putBody = await r.request().postDataJSON()
+        hasToken = true
+      }
+      return r.fulfill({ status: 204, body: '' })
+    })
+
+    await page.goto('/#settings', { waitUntil: 'domcontentloaded' })
+
+    const field = page.getByLabel('HuggingFace token')
+    await expect(field).toBeVisible()
+
+    await field.fill('hf_abc123')
+
+    // Subscribe to the response BEFORE the click — otherwise the 204 can land
+    // before waitForResponse attaches (race).
+    await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().endsWith('/api/secrets/HF_TOKEN') && r.request().method() === 'PUT',
+      ),
+      page.locator('button', { hasText: /^Save$/ }).first().click(),
+    ])
+    expect(putBody?.value).toBe('hf_abc123')
+  })
+})


### PR DESCRIPTION
## What
Closes the HF-token set-side gap: gated/large model pulls need a token, but there was no discoverable way to set one (api.env had no hint; only the generic Secrets panel could do it, and only if you knew to name a secret `HF_TOKEN`).

## How (reuses existing infra — no new endpoint)
- **UI:** a dedicated "HuggingFace token" field in Settings → Secrets (`settings.jsx` `HfTokenField`) — password input + Save/Clear + set/not-set status — wrapping the **existing** `useSecrets`/`useSecretSet`/`useSecretDelete` hooks against the fixed name `HF_TOKEN`.
- **Live, no restart:** `/api/secrets` already updates `os.environ` in lockstep on set/delete (`secrets.py:204/238`), and every pull path reads `os.environ` → a saved token authenticates the next pull immediately.
- **Installer:** `api.env` now ships a commented `# HF_TOKEN=` hint pointing at the Settings field.
- No `resolve_hf_token()` / new route (YAGNI — the os.environ lockstep already makes the existing reads work).

## Tests
- `test_secrets.py::test_hf_token_secret_roundtrip` — set → listed + `os.environ` live; delete clears both.
- `hf-token-setting.spec.ts` (e2e) — field renders, Save PUTs `/api/secrets/HF_TOKEN` with the value.
- UI build + typecheck + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)