### PR TITLE
fix(e2e): scope AddSecretModal password selector (regression from #816)

### DIFF
--- a/ui/tests/e2e/specs/ui-sweep-a-v3.spec.ts
+++ b/ui/tests/e2e/specs/ui-sweep-a-v3.spec.ts
@@ -43,8 +43,10 @@ test.describe('AddSecretModal — real save', () => {
     // Wait for modal to open
     await expect(page.locator('.modal-shell')).toBeVisible({ timeout: FIVE_S })
 
-    // Fill in a value that matches HF_TOKEN prefix
-    const valueInput = page.locator('input[type="password"]')
+    // Fill in a value that matches HF_TOKEN prefix. Scope to the modal — the
+    // Secrets section also renders a password input (the dedicated HuggingFace
+    // token field, #816), so an unscoped selector is now ambiguous.
+    const valueInput = page.locator('.modal-shell input[type="password"]')
     await valueInput.fill('hf_teststub1234567890ABCDEFGHIJKLMNOPQRSTUVWxyz')
 
     // The "Add secret" save button should be enabled


### PR DESCRIPTION
γ-suite regression from #816 (merged via the γ-suite carve-out before this was caught): the new HuggingFace-token field added a second `input[type="password"]` to the Secrets section, so `ui-sweep-a-v3.spec.ts`'s unscoped `input[type="password"]` became a strict-mode violation. Scoped it to `.modal-shell`. Test-only; ui-sweep-a-v3 + hf-token specs pass locally (14 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)