### PR TITLE
fix(installer): accept bare tier names in /install/apply — fixes 'unknown tier' on every FirstRun pick

### DIFF
--- a/src/hal0/api/routes/installer.py
+++ b/src/hal0/api/routes/installer.py
@@ -459,12 +459,19 @@ _SLOT_META: dict[str, tuple[str, str, int]] = {
 
 
 def _resolve_tier(name: str) -> str:
-    """Map a tier name (any case) to its canonical key, or raise 404."""
+    """Map a tier name (any case) to its canonical key, or raise 404.
+
+    Accepts both the canonical name (``hal0-Pro``) and the bare display
+    suffix the FirstRun picker sends (``Pro``) — ``firstrun.jsx`` POSTs
+    ``tierObj.name`` (e.g. ``"Pro"``), not the ``hal0-`` prefixed slug.
+    Matching is case-insensitive on both forms.
+    """
     if name in bundle_tiers.BUNDLES:
         return name
     lower = name.lower()
     for canonical in bundle_tiers.BUNDLES:
-        if canonical.lower() == lower:
+        clower = canonical.lower()
+        if lower in (clower, clower.removeprefix("hal0-")):
             return canonical
     raise CuratedModelNotFound(
         f"unknown tier {name!r}",

--- a/tests/api/test_install_apply.py
+++ b/tests/api/test_install_apply.py
@@ -5,7 +5,40 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-from hal0.api.routes.installer import _build_slot_cfg
+import pytest
+
+from hal0.api.routes.installer import (
+    CuratedModelNotFound,
+    _build_slot_cfg,
+    _resolve_tier,
+)
+
+
+@pytest.mark.parametrize(
+    "sent, canonical",
+    [
+        # Canonical names (what the docstring originally documented).
+        ("hal0-Pro", "hal0-Pro"),
+        ("hal0-pro", "hal0-Pro"),
+        # Bare display names — what firstrun.jsx actually POSTs (tierObj.name).
+        # Regression: these all 404'd with "unknown tier" before the fix.
+        ("Lite", "hal0-Lite"),
+        ("Default", "hal0-Default"),
+        ("Pro", "hal0-Pro"),
+        ("Max", "hal0-Max"),
+        ("pro", "hal0-Pro"),
+        # Vendor kit keeps its verbatim mixed-case name (no hal0- prefix).
+        ("LMX-Omni-52B-Halo", "LMX-Omni-52B-Halo"),
+        ("lmx-omni-52b-halo", "LMX-Omni-52B-Halo"),
+    ],
+)
+def test_resolve_tier_accepts_bare_and_canonical(sent, canonical):
+    assert _resolve_tier(sent) == canonical
+
+
+def test_resolve_tier_rejects_unknown():
+    with pytest.raises(CuratedModelNotFound, match="unknown tier 'Nope'"):
+        _resolve_tier("Nope")
 
 
 def test_build_slot_cfg_sets_device_profile_model():


### PR DESCRIPTION
## Symptom
The new FirstRun picker returns **`Install failed — unknown tier 'Pro'`** for *every* tier (Lite/Default/Pro/Max).

## Root cause (reproduced on deployed CT105)
- `firstrun.jsx:488-489` sets `tierName = tierObj.name` — the **bare display name** (`"Pro"`), and POSTs `{ tier: "Pro" }` to `/api/install/apply` (`:499`).
- `installer.py:_resolve_tier` only matched the **full canonical key** (`"hal0-Pro"`) case-insensitively. `bundle_tiers.BUNDLES = ("hal0-Lite", "hal0-Default", "hal0-Pro", "hal0-Max", "LMX-Omni-52B-Halo")`, so `"Pro"` never matched → `CuratedModelNotFound("unknown tier 'Pro'")`, surfaced by the toast `Install failed — ${e.message}`.
- Every pickable tier sends its display name (the LMX kit button maps to `onPick("max")`), so **all** picks fail.

Verified directly against the live tree:
```
'Pro'      -> ERROR: unknown tier 'Pro'
'hal0-Pro' -> hal0-Pro
```

## Fix
Loosen `_resolve_tier` to also match the `hal0-`-stripped form. `"Pro"`/`"pro"`/`"hal0-Pro"`/`"hal0-pro"` → `"hal0-Pro"`. The vendor `LMX-Omni-52B-Halo` (no `hal0-` prefix) still matches verbatim; no suffix collisions across the locked tier list. Keeps the resolver's stated "any case" contract and needs no UI rebuild (`tierName` keeps doubling as wire + post-install display value).

## Test
Regression test at the installer unit seam (`test_install_apply.py`): bare + canonical + vendor + reject cases. `14 passed`, ruff + format clean.

## Note (not changed here)
`firstrun.jsx` sending the bare display name as the tier id is loose — a follow-up could send the canonical key — but the backend resolver is the robust seam and fully restores function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)