### PR TITLE
fix(npu): translate hal0 FLM id → native colon tag so NPU chat loads

### DIFF
--- a/installer/etc-hal0/profiles.toml
+++ b/installer/etc-hal0/profiles.toml
@@ -44,7 +44,7 @@ quant        = "Q4_K_M"
 [profile.flm]
 # NPU LLM/trio slot (FastFlowLM). Flags are built by FLMProvider.container_spec,
 # not by this profile — image pin only. No backend (device_class drives display).
-image        = "ghcr.io/hal0ai/hal0-toolbox-flm:v1"
+image        = "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43"
 flags        = ""
 mtp          = false
 device_class = "npu"

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -736,7 +736,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "quant": "Q4_K_M",
     },
     "flm": {
-        "image": "ghcr.io/hal0ai/hal0-toolbox-flm:v1",
+        "image": "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43",
         "flags": "",
         "mtp": False,
         "device_class": "npu",

--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -651,6 +651,29 @@ def is_installed_flm_id(model_id: str) -> bool:
     )
 
 
+def flm_id_to_tag(model_id: str) -> str | None:
+    """Resolve a hal0 ``<tag>-FLM`` id back to FLM's native ``family:size`` tag.
+
+    Inverse of the forward map in :func:`is_installed_flm_id`
+    (``gemma4-it:e2b`` → ``gemma4-it-e2b-FLM``). FLM's ``serve``/``pull``
+    subcommands only accept the colon tag, so any code that hands a hal0
+    catalog id straight to FLM (the slot manager's ``flm_tag`` stamp) must
+    translate first — otherwise FLM answers ``Model not found``.
+
+    Matches on the served-catalog tag regardless of ``installed`` (the
+    transform is a pure naming map). Returns the colon tag, or ``None`` when
+    ``model_id`` isn't a recognised FLM id or the catalog probe is empty —
+    the caller then falls back to the raw id.
+    """
+    if not model_id.endswith("-FLM"):
+        return None
+    for m in flm_served_models():
+        tag = m.get("tag")
+        if isinstance(tag, str) and tag.replace(":", "-") + "-FLM" == model_id:
+            return tag
+    return None
+
+
 def flm_pull_command(tag: str) -> tuple[list[str], str]:
     """Return ``(argv, host_models_dir)`` for a host ``flm pull <tag>`` run.
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -2215,7 +2215,23 @@ class SlotManager:
         # "model_id" is a FastFlowLM tag like ``qwen3.5:4b`` rather than a
         # local-file model) use them as the canonical lookup key. Mirrors
         # haloai's haloai-launch behaviour.
-        info: dict[str, Any] = {"_model_key": model_id, "flm_tag": model_id}
+        #
+        # FLM's ``serve`` only accepts the native ``family:size`` tag
+        # (``gemma4-it:e2b``), but slots persist the hal0 catalog id
+        # (``gemma4-it-e2b-FLM``). Translate so the FLM provider serves the
+        # right tag instead of passing the ``-FLM`` id straight through, which
+        # makes FLM answer "Model not found" and the slot crash-loop. Falls
+        # back to the raw id when the catalog can't resolve it.
+        flm_tag = model_id
+        try:
+            from hal0.providers.flm import flm_id_to_tag
+        except ImportError:
+            flm_id_to_tag = None  # type: ignore[assignment]
+        if flm_id_to_tag is not None:
+            resolved_tag = flm_id_to_tag(model_id)
+            if resolved_tag:
+                flm_tag = resolved_tag
+        info: dict[str, Any] = {"_model_key": model_id, "flm_tag": flm_tag}
 
         try:
             from hal0.registry.store import ModelNotFound, ModelRegistry

--- a/tests/config/test_schema_npu.py
+++ b/tests/config/test_schema_npu.py
@@ -63,7 +63,7 @@ def test_npu_tucked_into_extra_on_dump() -> None:
 
 def test_flm_npu_seed_profile() -> None:
     prof = SEED_PROFILES["flm"]
-    assert prof["image"] == "ghcr.io/hal0ai/hal0-toolbox-flm:v1"
+    assert prof["image"] == "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43"
     assert prof["flags"] == ""
     assert prof["mtp"] is False
 

--- a/tests/providers/test_flm.py
+++ b/tests/providers/test_flm.py
@@ -454,3 +454,41 @@ def test_is_installed_flm_id_matches_installed_tag() -> None:
         # missing -FLM suffix (a colon tag or GGUF id) → false (fast path)
         assert flm.is_installed_flm_id("gemma4-it:e4b") is False
         assert flm.is_installed_flm_id("chadrock-35b-ace-saber") is False
+
+
+# ─── flm_id_to_tag (hal0 <tag>-FLM id → FLM native colon tag) ────────────────
+
+
+def test_flm_id_to_tag_resolves_colon_tag() -> None:
+    """A hal0 ``<tag>-FLM`` id resolves to FLM's native ``family:size`` tag.
+
+    Regression for the slot crash-loop where the FLM provider was handed the
+    raw ``-FLM`` id and FLM answered "Model not found" (manager._resolve_model_info
+    stamped ``flm_tag = model_id`` without translating).
+    """
+    import hal0.providers.flm as flm
+
+    fake = [
+        {"tag": "gemma4-it:e2b", "installed": True, "capabilities": ["chat"]},
+        {"tag": "embed-gemma:300m", "installed": True, "capabilities": ["embed"]},
+        {"tag": "whisper-v3:turbo", "installed": False, "capabilities": ["stt"]},
+    ]
+    with patch("hal0.providers.flm.flm_served_models", lambda: fake):
+        # family with embedded dashes still maps off the LAST segment
+        assert flm.flm_id_to_tag("gemma4-it-e2b-FLM") == "gemma4-it:e2b"
+        assert flm.flm_id_to_tag("embed-gemma-300m-FLM") == "embed-gemma:300m"
+        # resolves regardless of installed flag (pure naming transform)
+        assert flm.flm_id_to_tag("whisper-v3-turbo-FLM") == "whisper-v3:turbo"
+        # unknown id → None (caller falls back to the raw id)
+        assert flm.flm_id_to_tag("nope-7b-FLM") is None
+        # already a colon tag / not an -FLM id → None (fast path)
+        assert flm.flm_id_to_tag("gemma4-it:e2b") is None
+        assert flm.flm_id_to_tag("chadrock-35b-ace-saber") is None
+
+
+def test_flm_id_to_tag_empty_catalog_returns_none() -> None:
+    """When the catalog probe is empty, resolution yields None (no crash)."""
+    import hal0.providers.flm as flm
+
+    with patch("hal0.providers.flm.flm_served_models", list):
+        assert flm.flm_id_to_tag("gemma4-it-e2b-FLM") is None


### PR DESCRIPTION
## Problem
The NPU (FLM) slot crash-looped on every chat load: `[ERROR] Model not found: gemma4-it-e2b-FLM`. `/api/slots/npu/load` returned 200 but the container exited 1 before binding :8088; slot stuck `warming`→`crashed`. **User symptom: "unable to load a chat model on the NPU."**

## Root cause — two stacked faults
1. **Tag namespace mismatch.** `manager._resolve_model_info` stamped `flm_tag = model_id`, passing the hal0 catalog id (`gemma4-it-e2b-FLM`) into `flm serve`, which only accepts the native `family:size` tag (`gemma4-it:e2b`). The provider already prefers `model_info["flm_tag"]` — it just never got the translated value.
2. **Stale seed image.** The `flm` seed profile still pinned `hal0-toolbox-flm:v1` (FLM 0.9.42, missing libboost_filesystem, XRT#6295 → instant crash). #813 repointed the provider default to `:0.9.43` but missed the seed.

## Fix
- Add `flm_id_to_tag()` in `providers/flm.py` (inverse of `is_installed_flm_id`'s map, resolved via the host `flm list` catalog — reads static `model_list.json`, no running server, so no deadlock). Use it at the `flm_tag` stamp site in `slots/manager.py`. Fall back to the raw id when unresolvable.
- Bump the `flm` seed image `:v1` → `:0.9.43` in `config/schema.py`.

## Verification
On CT105 with `:0.9.43` + the correct colon tag, FLM binds in ~4s and serves chat on the NPU at **~23 tok/s** (weights already cached). New regression tests cover the id→tag map (dashed families, installed-agnostic, empty-catalog fallback) and the seed. 36 tests pass; ruff check + format clean.

## Notes
- Live `/etc/hal0/profiles.toml` on CT105 already repointed to `:0.9.43` out-of-band; this fixes the seed for fresh installs.
- `routes/updater.py` still reports host FLM `current=v0.9.42` (manual-deb) — separate version-reporting drift.
- The "master trio gated system" (`is_npu_trio_shadow`) was **not** the blocker and is left intact (per decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)