### PR TITLE
fix(firstrun): skip durably dismisses the wizard (was returning on reload)

### DIFF
--- a/ui/src/api/hooks/useFirstRun.ts
+++ b/ui/src/api/hooks/useFirstRun.ts
@@ -138,6 +138,14 @@ export function useFirstRunComplete() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: () => apiPost(ENDPOINTS.installComplete),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['firstrun'] }),
+    // Invalidate BOTH the firstrun queries AND the install-state query that
+    // actually gates the wizard (useInstallState → ['install', 'state'],
+    // staleTime 60s). Without the ['install', 'state'] invalidation the gate
+    // keeps its cached first_run=true and bounces the operator back into the
+    // wizard until a hard reload.
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['firstrun'] })
+      qc.invalidateQueries({ queryKey: ['install', 'state'] })
+    },
   })
 }

--- a/ui/src/dash/firstrun.jsx
+++ b/ui/src/dash/firstrun.jsx
@@ -635,6 +635,12 @@ function FirstRunServices({ onDone }) {
 // ─── FirstRun view shell ───
 function FirstRunView({ frStage, setFrStage, onComplete, layout }) {
   const [skipOpen, setSkipOpen] = useStateF(false);
+  // Skip must DURABLY dismiss the wizard, not just navigate away: write the
+  // first-run sentinel (POST /api/install/complete) exactly like the finish
+  // path's "Open dashboard" button. Without this, /api/install/state still
+  // reports first_run=true (no models + no sentinel) and the wizard returns
+  // on every reload.
+  const completeM = useFirstRunComplete();
   // model IDs + tier name returned by /apply so the progress pane can reattach
   // live SSE streams per model and label the heading.
   const [frModelIds, setFrModelIds] = useStateF([]);
@@ -657,7 +663,7 @@ function FirstRunView({ frStage, setFrStage, onComplete, layout }) {
       <SkipBundleDialog
         open={skipOpen}
         onCancel={() => setSkipOpen(false)}
-        onConfirm={() => { setSkipOpen(false); onComplete(); }}
+        onConfirm={() => { setSkipOpen(false); completeM.mutate(); onComplete(); }}
       />
     </div>
   );

--- a/ui/tests/e2e/specs/firstrun-v3.spec.ts
+++ b/ui/tests/e2e/specs/firstrun-v3.spec.ts
@@ -88,6 +88,25 @@ test.describe('FirstRun v3 (/firstrun)', () => {
     await expect(page.locator('.fr-detect .seg', { hasText: 'NPU' })).toBeVisible()
   })
 
+  test('skip durably dismisses the wizard by writing the sentinel', async ({ page }) => {
+    // Regression: skip used to only navigate away (onComplete), never POSTing
+    // /api/install/complete. Since first_run = (no models) AND (no sentinel),
+    // the wizard returned on every reload. Skip must write the sentinel just
+    // like the finish path.
+    await page.goto('/#firstrun', { waitUntil: 'domcontentloaded' })
+
+    const completeCall = page.waitForRequest(
+      (req) => req.url().includes('/api/install/complete') && req.method() === 'POST',
+      { timeout: 5000 },
+    )
+
+    await page.locator('.fr-skip').first().click()
+    await page.getByRole('button', { name: 'Skip and configure manually' }).click()
+
+    // The sentinel-writing POST is what hides the wizard across reloads.
+    await completeCall
+  })
+
 
   // ── Progress pane — live SSE rows ──────────────────────────────────
 


### PR DESCRIPTION
## Symptom
Clicking **Skip — configure manually** in the FirstRun picker doesn't stick — the wizard returns on every reload.

## Root cause
Two issues in the skip → complete flow:

1. **Skip never writes the sentinel.** The finish path (`FirstRunServices` → "Open dashboard") calls `completeM.mutate()` → `POST /api/install/complete`, which writes `/var/lib/hal0/.first_run_done`. The skip path (`SkipBundleDialog` `onConfirm` → `onComplete` → `onFirstRunComplete`) only did `setFrStage("pick"); go("dashboard")` — no sentinel write. Since the gate is `first_run = (not has_models) and (not sentinel_present)` (`installer.py:install_state`), a skip on a fresh install (no models) leaves `first_run=true` → wizard returns on reload.

2. **`useFirstRunComplete` invalidated the wrong query.** It invalidated `['firstrun']`, but the wizard *gate* reads `useInstallState` → `['install', 'state']` (`staleTime: 60_000`). So completing never refreshed the gate in-session — only a hard reload re-read `/api/install/state`. (Latent bug affecting the finish path too.)

## Fix
1. `firstrun.jsx` — `SkipBundleDialog` `onConfirm` now fires `completeM.mutate()` before navigating, mirroring the "Open dashboard" finish button.
2. `useFirstRun.ts` — `useFirstRunComplete.onSuccess` now also invalidates `['install', 'state']` so the gate updates without a hard reload.

## Test
`firstrun-v3.spec.ts`: clicking skip → confirm asserts `POST /api/install/complete` fires. **Verified red→green** (fails on the reverted `onConfirm`, passes with the fix). Full `firstrun-v3` suite **9/9 green**; `tsc --noEmit` clean; `vite build` clean.

## Notes
- CT105's live `/api/install/state` is `first_run:false` only because `has_models:true` (it's a fully set-up box), so the wizard is hidden there regardless — the bug reproduces on a fresh install. The fix is verified via the e2e mock + the backend contract.
- Follows [#821](https://github.com/Hal0ai/hal0/pull/821) (the `unknown tier` fix) on the same FirstRun flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)