### PR TITLE
fix(installer): version-agnostic hermes web_dist + resilient newer-distro install

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -808,6 +808,25 @@ else
     ui_spinner_run "apt-get update (refresh package index)" \
         apt-get update -qq
 
+    # FLM host-support gate. Upstream ships ONE Ubuntu-24.04 .deb whose hard
+    # deps are the ffmpeg6-era SONAMEs (libavcodec60 …) + boost1.83. Newer
+    # Ubuntu (25.10 "resolute" onward ships ffmpeg7 = libav*62 / boost1.90), so
+    # those candidates don't exist and BOTH the runtime-libs apt call and the
+    # `.deb` install fail with a noisy `exit 100`. Probe the keystone SONAME up
+    # front: if it isn't even a known package, skip the host-FLM steps with ONE
+    # honest line instead of two scary dumps. The npu container slot bundles its
+    # own runtime, so NPU inference is unaffected — only the host `flm validate`
+    # probe is disabled. (Upstream fix = a FLM build for this release; the
+    # package-name pins can't be satisfied here regardless of what we request.)
+    if apt-cache show libavcodec60 >/dev/null 2>&1; then
+        FLM_HOST_LIBS_OK=1
+    else
+        FLM_HOST_LIBS_OK=0
+        warn "$(distro_pretty): host FastFlowLM unsupported — upstream ships an Ubuntu-24.04 .deb (ffmpeg6/boost1.83); this release has ffmpeg7/boost1.90"
+        warn "  skipping host FLM libs + .deb. The npu container slot bundles its own runtime, so NPU inference is unaffected"
+        warn "  (only the host 'flm validate' probe is disabled). Install FastFlowLM manually if upstream ships a build for this release."
+    fi
+
     # 1. libxrt-npu2 — best-effort. Available only when the host's apt
     #    sources carry an XRT NPU build (e.g. a pre-existing vendor repo
     #    on upgraded boxes). The FLM container image bundles its own
@@ -832,13 +851,14 @@ else
     #    candidate", a mirror flake) used to abort the entire hal0 install
     #    here — over optional host-side NPU libs the containerized slot
     #    doesn't even need. Warn + continue, mirroring libxrt-npu2.
-    if ui_spinner_run "Installing FLM runtime libs (ffmpeg6 + boost1.83 + fftw3)" \
+    if [[ "${FLM_HOST_LIBS_OK}" -eq 1 ]] \
+        && ui_spinner_run "Installing FLM runtime libs (ffmpeg6 + boost1.83 + fftw3)" \
         apt-get install -y \
             libavformat60 libavcodec60 libavutil58 libswscale7 libswresample4 \
             libboost-program-options1.83.0 \
             libfftw3-single3; then
         :
-    else
+    elif [[ "${FLM_HOST_LIBS_OK}" -eq 1 ]]; then
         warn "FLM runtime libs not fully available from configured apt sources — host 'flm validate' may fail"
         warn "  the npu container slot bundles its own runtime and is unaffected"
     fi
@@ -847,7 +867,9 @@ else
     #    doesn't match, warn + skip. NPU paths gate on `flm validate`
     #    succeeding later — GPU-only hal0 still ships fine.
     FLM_DEB_TMP="/tmp/fastflowlm_${FLM_DEB_VERSION}.deb"
-    NEED_FLM_INSTALL=1
+    # 0 when the host-FLM gate above found this release can't satisfy the .deb's
+    # ffmpeg6/boost1.83 deps — skip download+install entirely (no noisy exit).
+    NEED_FLM_INSTALL="${FLM_HOST_LIBS_OK}"
     if command -v dpkg-query >/dev/null 2>&1 && \
        dpkg-query -W -f='${Version}\n' fastflowlm 2>/dev/null | grep -qx "${FLM_DEB_VERSION}"; then
         info "fastflowlm ${FLM_DEB_VERSION} already installed — skipping download"
@@ -1212,7 +1234,12 @@ else
     # provision ran, plus the system-scope gateway (which the provision does
     # not install).
     if [[ -f "${AGENT_UNIT_DST}" && -x "/var/lib/hal0/venvs/hermes/bin/hermes" ]]; then
-        systemctl enable --now hal0-agent@hermes.service
+        # Non-fatal: a hermes start hiccup must NOT abort an otherwise-good
+        # install (hal0-api + chat are already up). Under `set -e` a failed
+        # `enable --now` (e.g. the unit tripped StartLimitBurst) would fire the
+        # ERR trap; `|| warn` downgrades it to the wait_active warning below.
+        systemctl enable --now hal0-agent@hermes.service \
+            || warn "hal0-agent@hermes enable returned non-zero — continuing (check 'journalctl -u hal0-agent@hermes -n 40')"
         if wait_active hal0-agent@hermes.service 20; then
             info "hal0-agent@hermes is running (chat at 127.0.0.1:9119, proxied by hal0-api)"
         else
@@ -1227,9 +1254,11 @@ else
         # HERMES_HOME is unset so the generator bakes the hal0 default
         # (~/.hermes), not a value inherited from the installer env.
         info "installing system-scope hermes gateway (User=hal0)"
-        env -u HERMES_HOME /var/lib/hal0/venvs/hermes/bin/hermes gateway install --system --run-as-user hal0
+        env -u HERMES_HOME /var/lib/hal0/venvs/hermes/bin/hermes gateway install --system --run-as-user hal0 \
+            || warn "hermes gateway install failed — Telegram/Discord bridge unavailable; continuing"
         systemctl daemon-reload
-        systemctl enable --now hermes-gateway.service
+        systemctl enable --now hermes-gateway.service \
+            || warn "hermes-gateway enable returned non-zero — continuing (check 'journalctl -u hermes-gateway -n 40')"
         if wait_active hermes-gateway.service 20; then
             info "hermes-gateway is running (Telegram/Discord)"
         else

--- a/installer/systemd/hal0-agent@.service
+++ b/installer/systemd/hal0-agent@.service
@@ -88,8 +88,13 @@ LogsDirectory=hal0
 
 # Carve out the exact paths Hermes + hal0 need to write to under the
 # `ProtectSystem=strict` lockdown. /run/hal0 is for sockets, lock
-# files, and the agent's NOTIFY_SOCKET helpers.
-ReadWritePaths=/var/lib/hal0 /var/log/hal0 /run/hal0
+# files, and the agent's NOTIFY_SOCKET helpers. /etc/hal0 is needed by
+# the `render-context` ExecStartPre, which (re)writes HERMES.md/STATE.md
+# there — without it the render fails with a read-only-fs error and the
+# agent boots with stale live-context. File perms still gate writes:
+# tokens.toml / auth.toml stay root-owned 0600, so the hal0 user can't
+# read or rewrite secrets even with the path made writable.
+ReadWritePaths=/etc/hal0 /var/lib/hal0 /var/log/hal0 /run/hal0
 
 # Stream stdout/stderr into journald with a per-instance identifier
 # so `journalctl -u hal0-agent@hermes` / `-t hal0-agent@hermes` both

--- a/installer/systemd/hal0-agent@hermes.service.d/override.conf
+++ b/installer/systemd/hal0-agent@hermes.service.d/override.conf
@@ -21,11 +21,16 @@ Environment="HERMES_HOME=/var/lib/hal0/.hermes"
 # dashboard-TUI mode the parent was started in.
 Environment="HERMES_DASHBOARD_TUI=1"
 
-# Pin the dashboard's web dist next to the wheel-installed hermes
-# binary so `--skip-build` finds it without needing npm at runtime.
-# The path is overridable in /etc/hal0/agents/hermes.env if a user
-# wants to point at a hand-built tree.
-Environment="HERMES_WEB_DIST=/var/lib/hal0/venvs/hermes/lib/python3.12/site-packages/hermes_cli/web_dist"
+# HERMES_WEB_DIST (the pre-built dashboard assets that let `--skip-build`
+# run without npm) is resolved AT RUNTIME by the agent shim
+# (`src/hal0/cli/agent_shim.py` `_resolve_web_dist`) from the agent venv's
+# actual `python3.X` site-packages — so it stays correct on any interpreter
+# (3.11-3.14+). We no longer pin a version here: an older hardcoded
+# `python3.12` path made hermes hard-exit ("no web dist found") and
+# crash-loop the unit on Python-3.14 hosts. To point at a hand-built tree,
+# set HERMES_WEB_DIST in /etc/hal0/agents/hermes.env (loaded via the base
+# template's EnvironmentFile); the shim honors an existing path when it
+# resolves to a real directory and only auto-resolves otherwise.
 
 # Inference endpoint hint — Hermes's `hal0` model-provider plugin
 # reads this to discover the OpenAI-compatible base. Default matches

--- a/src/hal0/cli/agent_shim.py
+++ b/src/hal0/cli/agent_shim.py
@@ -207,6 +207,25 @@ def _is_ready(cfg: AgentConfig, *, timeout: float = 1.0) -> bool:
 # ----------------------------------------------------------------------------
 
 
+def _resolve_web_dist(cfg: AgentConfig) -> Path | None:
+    """Locate the pre-built Hermes dashboard assets inside the agent venv.
+
+    The wheel ships the bundle at
+    ``<venv>/lib/pythonX.Y/site-packages/hermes_cli/web_dist``. We GLOB the
+    ``pythonX.Y`` segment rather than hardcode a minor version: the agent venv
+    is built with whatever ``python3`` the host provides (3.11-3.14+), so a
+    pinned ``python3.12`` path silently breaks on every other interpreter — the
+    cause of the install-time hermes crash-loop on a Python-3.14 box. Returns
+    the first existing match, or ``None`` when no built dist is present.
+    """
+
+    matches = sorted(cfg.venv.glob("lib/python3.*/site-packages/hermes_cli/web_dist"))
+    for path in matches:
+        if path.is_dir():
+            return path
+    return None
+
+
 def _build_hermes_argv(cfg: AgentConfig) -> list[str]:
     """Build the argv that boots Hermes with ``/api/events`` + ``/api/pty``.
 
@@ -225,7 +244,12 @@ def _build_hermes_argv(cfg: AgentConfig) -> list[str]:
       surface needs both.
     * ``--skip-build`` keeps the unit start fast and works without npm
       on the production box — the wheel ships ``hermes_cli/web_dist/``
-      pre-built.
+      pre-built. Added ONLY when a built dist is actually found (see
+      :func:`_resolve_web_dist`): passing it with a missing/wrong-path
+      dist makes hermes hard-exit 1 ("no web dist found") and crash-loop
+      the unit. If the dist is absent we drop the flag so a box with npm
+      can build it; ``HERMES_WEB_DIST`` (set in the env) independently
+      points hermes at the right tree regardless of the venv Python minor.
     * ``--no-open`` because we're running headless (no browser open).
     * ``--host 127.0.0.1`` — hal0-api proxies the WS; binding to all
       interfaces would let any LAN host reach the agent's PTY without
@@ -236,7 +260,7 @@ def _build_hermes_argv(cfg: AgentConfig) -> list[str]:
       would have nothing to render (DA-sec-ops MUST-FIX #1).
     """
 
-    return [
+    argv = [
         str(cfg.hermes_bin),
         "dashboard",
         "--host",
@@ -245,8 +269,10 @@ def _build_hermes_argv(cfg: AgentConfig) -> list[str]:
         str(cfg.port),
         "--tui",
         "--no-open",
-        "--skip-build",
     ]
+    if _resolve_web_dist(cfg) is not None:
+        argv.append("--skip-build")
+    return argv
 
 
 def _build_hermes_env(cfg: AgentConfig) -> dict[str, str]:
@@ -258,6 +284,21 @@ def _build_hermes_env(cfg: AgentConfig) -> dict[str, str]:
     # Mirror ``--tui`` so any nested hermes-cli invocation (e.g. an
     # in-process subprocess.run) sees the same flag without parsing argv.
     env["HERMES_DASHBOARD_TUI"] = "1"
+    # Point hermes at the version-correct pre-built dashboard assets. We honor
+    # an existing HERMES_WEB_DIST ONLY when it resolves to a real directory (a
+    # deliberate hand-built tree set via /etc/hal0/agents/hermes.env); a stale
+    # value inherited from an older unit drop-in — notably the pre-fix
+    # python3.12 path that breaks on other interpreters — won't exist, so we
+    # replace it with the auto-resolved path. When no built dist is found at
+    # all we drop the var so hermes falls back to its own __file__-relative
+    # default rather than a known-wrong path.
+    existing = env.get("HERMES_WEB_DIST")
+    if not (existing and Path(existing).is_dir()):
+        web_dist = _resolve_web_dist(cfg)
+        if web_dist is not None:
+            env["HERMES_WEB_DIST"] = str(web_dist)
+        else:
+            env.pop("HERMES_WEB_DIST", None)
     # Drop NOTIFY_SOCKET from the child — the shim owns sd_notify,
     # and a misbehaving Hermes plugin shouldn't be able to send
     # READY=1 / STOPPING=1 to systemd on our behalf.

--- a/tests/cli/test_agent_shim.py
+++ b/tests/cli/test_agent_shim.py
@@ -174,8 +174,30 @@ class TestHermesArgv:
         argv = agent_shim._build_hermes_argv(_cfg())
         assert "--tui" in argv
 
-    def test_skip_build_to_avoid_npm_on_runtime_box(self) -> None:
-        argv = agent_shim._build_hermes_argv(_cfg())
+    @staticmethod
+    def _mk_web_dist(venv: Path, pyver: str = "python3.14") -> Path:
+        dist = venv / "lib" / pyver / "site-packages" / "hermes_cli" / "web_dist"
+        dist.mkdir(parents=True)
+        return dist
+
+    def test_skip_build_present_when_web_dist_exists(self, tmp_path: Path) -> None:
+        # Built dist present → pass --skip-build to avoid npm at runtime.
+        self._mk_web_dist(tmp_path)
+        argv = agent_shim._build_hermes_argv(_cfg(venv=tmp_path))
+        assert "--skip-build" in argv
+
+    def test_skip_build_omitted_when_web_dist_missing(self, tmp_path: Path) -> None:
+        # No built dist → DON'T pass --skip-build: that combo makes hermes
+        # hard-exit 1 and crash-loop the unit (the original install failure).
+        # Drop it so a box with npm can build instead.
+        argv = agent_shim._build_hermes_argv(_cfg(venv=tmp_path))
+        assert "--skip-build" not in argv
+
+    def test_skip_build_version_agnostic_not_pinned_to_312(self, tmp_path: Path) -> None:
+        # Regression for the hardcoded python3.12 path: a python3.14 venv must
+        # still be recognized so --skip-build is passed.
+        self._mk_web_dist(tmp_path, "python3.14")
+        argv = agent_shim._build_hermes_argv(_cfg(venv=tmp_path))
         assert "--skip-build" in argv
 
     def test_binds_loopback_only(self) -> None:
@@ -225,6 +247,49 @@ class TestHermesEnv:
         with patch.dict(os.environ, {"NOTIFY_SOCKET": "/run/systemd/notify"}):
             env = agent_shim._build_hermes_env(_cfg())
         assert "NOTIFY_SOCKET" not in env
+
+    @staticmethod
+    def _mk_web_dist(venv: Path, pyver: str = "python3.14") -> Path:
+        dist = venv / "lib" / pyver / "site-packages" / "hermes_cli" / "web_dist"
+        dist.mkdir(parents=True)
+        return dist
+
+    def test_web_dist_resolved_to_actual_venv_python(self, tmp_path: Path) -> None:
+        # HERMES_WEB_DIST is set to the version-correct resolved path.
+        dist = self._mk_web_dist(tmp_path, "python3.14")
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_WEB_DIST", None)
+            env = agent_shim._build_hermes_env(_cfg(venv=tmp_path))
+        assert env["HERMES_WEB_DIST"] == str(dist)
+
+    def test_stale_web_dist_env_replaced_with_resolved(self, tmp_path: Path) -> None:
+        # A stale python3.12 path inherited from an old unit drop-in does NOT
+        # exist → must be replaced by the auto-resolved python3.14 dir. This is
+        # the in-place fix for boxes that didn't re-run the installer.
+        dist = self._mk_web_dist(tmp_path, "python3.14")
+        stale = "/var/lib/hal0/venvs/hermes/lib/python3.12/site-packages/hermes_cli/web_dist"
+        with patch.dict(os.environ, {"HERMES_WEB_DIST": stale}):
+            env = agent_shim._build_hermes_env(_cfg(venv=tmp_path))
+        assert env["HERMES_WEB_DIST"] == str(dist)
+
+    def test_valid_user_web_dist_env_honored(self, tmp_path: Path) -> None:
+        # An operator-set HERMES_WEB_DIST that resolves to a real dir (hand-built
+        # tree via hermes.env) wins — the shim must not clobber it.
+        user_dist = tmp_path / "custom-dist"
+        user_dist.mkdir()
+        venv = tmp_path / "venv"
+        self._mk_web_dist(venv, "python3.14")
+        with patch.dict(os.environ, {"HERMES_WEB_DIST": str(user_dist)}):
+            env = agent_shim._build_hermes_env(_cfg(venv=venv))
+        assert env["HERMES_WEB_DIST"] == str(user_dist)
+
+    def test_web_dist_env_dropped_when_missing(self, tmp_path: Path) -> None:
+        # No built dist anywhere + a stale inherited value → pop it so hermes
+        # falls back to its own __file__ default, not a known-wrong path.
+        stale = "/var/lib/hal0/venvs/hermes/lib/python3.12/site-packages/hermes_cli/web_dist"
+        with patch.dict(os.environ, {"HERMES_WEB_DIST": stale}):
+            env = agent_shim._build_hermes_env(_cfg(venv=tmp_path))
+        assert "HERMES_WEB_DIST" not in env
 
 
 # ---------------------------------------------------------------------------

--- a/tests/systemd/test_unit_files.py
+++ b/tests/systemd/test_unit_files.py
@@ -153,11 +153,12 @@ class TestSandboxing:
     def test_readwritepaths_covers_runtime_dirs(self, template_text: str) -> None:
         # `ProtectSystem=strict` mounts /usr + /etc + /boot read-only;
         # without ReadWritePaths the agent can't write to its own state
-        # dir. Assert all three required paths are listed.
+        # dir. /etc/hal0 is required so the render-context ExecStartPre can
+        # (re)write HERMES.md/STATE.md — otherwise it fails read-only-fs.
         m = re.search(r"^ReadWritePaths=(.+)$", template_text, re.MULTILINE)
         assert m is not None
         paths = m.group(1).split()
-        for required in ("/var/lib/hal0", "/var/log/hal0", "/run/hal0"):
+        for required in ("/etc/hal0", "/var/lib/hal0", "/var/log/hal0", "/run/hal0"):
             assert required in paths, (
                 f"ReadWritePaths missing {required} — agent will fail to write state"
             )
@@ -223,6 +224,17 @@ class TestHermesOverride:
             r'^Environment="HAL0_INFERENCE_BASE=http://127\.0\.0\.1:8080"',
             override_text,
             re.MULTILINE,
+        )
+
+    def test_no_hardcoded_python_minor_in_web_dist(self, override_text: str) -> None:
+        # Regression: the override used to pin
+        # HERMES_WEB_DIST=…/lib/python3.12/site-packages/… which crash-looped
+        # the agent on any other interpreter (py3.14 install). The path is now
+        # resolved at runtime by the shim — the override must not hardcode a
+        # `python3.<minor>` web_dist path anymore.
+        assert not re.search(r"python3\.\d+.*web_dist", override_text), (
+            "override.conf still pins a python3.<minor> web_dist path — resolve it "
+            "at runtime in agent_shim._resolve_web_dist instead"
         )
 
 


### PR DESCRIPTION
## Problem

A fresh **v0.5.0-alpha.1** install on Ubuntu *resolute* / **Python 3.14** (AMD Strix Halo) aborted at *Service start* (`install failed at line 1215`). Diagnosed from a real user install + the hermes journal.

**Root cause:** the hermes systemd drop-in pinned
`HERMES_WEB_DIST=…/lib/python3.12/site-packages/hermes_cli/web_dist` — a literal Python-minor path. The venv on this box is `python3.14`, so that dir doesn't exist; `hermes dashboard --skip-build` hard-exits 1 (*"no web dist found"*) and crash-loops the unit. Under `set -e`, the failing `systemctl enable --now hal0-agent@hermes` then aborted the **whole install** — even though `hal0-api` + chat were already up.

This is the same "installer assumes the 24.04 / py3.12 baseline" failure family that also degraded the FLM and Hindsight steps on that box.

## Fixes

| Area | Change |
|---|---|
| `agent_shim.py` | New `_resolve_web_dist()` globs the venv's actual `python3.X` site-packages. `_build_hermes_env` sets `HERMES_WEB_DIST` authoritatively — **honors** a valid operator override, **replaces** a stale/non-existent one (self-heals boxes that didn't re-run the installer), **drops** it when no dist exists (hermes falls back to its own `__file__` default). `--skip-build` is passed **only when a built dist is present**, else a box with npm can build. |
| `override.conf` | Removed the hardcoded `python3.12` `HERMES_WEB_DIST` line; resolution is now runtime. |
| `hal0-agent@.service` | Added `/etc/hal0` to `ReadWritePaths` — `render-context` was failing read-only-fs writing `HERMES.md`/`STATE.md`. File perms still gate secrets (`tokens.toml`/`auth.toml` stay root 0600). |
| `install.sh` | hermes/gateway `enable --now` + `gateway install` made **non-fatal** — a hermes hiccup no longer aborts an otherwise-good install. |
| `install.sh` | Host-FLM (libs + `.deb`) gated behind a `libavcodec60` candidate probe. On ffmpeg7/boost1.90 distros the upstream **24.04-only** `.deb` is unsatisfiable regardless of what we request — skip with **one** honest line instead of two noisy `exit 100` dumps. NPU still runs via the container slot. |

## Tests
- `tests/cli/test_agent_shim.py`: web_dist present/absent, **version-agnostic** (py3.14), stale-replaced, operator-honored, dropped-when-missing; conditional `--skip-build`.
- `tests/systemd/test_unit_files.py`: `ReadWritePaths` includes `/etc/hal0`; override has **no** hardcoded `python3.<minor>` web_dist.
- **78 passing** locally on Python 3.14; `ruff check` + `ruff format --check` + `shellcheck` clean; `bash -n` ok.

## Notes
- The FLM `.deb` itself remains upstream-limited (24.04-only). This PR makes hal0 **degrade cleanly** on newer distros; it does not make host FLM installable there — that needs an upstream FLM build.
- Companion branch `fix/uninstall-clean-slate` makes uninstall a true clean-slate (the stale state from a failed teardown is what this class of collision feeds on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)