### PR TITLE
fix(installer): clean-slate uninstall — never abort mid-teardown, add --purge

### DIFF
--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -286,13 +286,28 @@ kernel upgrade, a Docker daemon swap, or whenever something feels off.
 sudo bash /usr/lib/hal0/current/installer/uninstall.sh
 ```
 
-Stops the services, removes the unit files, and (with `--keep-data`)
-leaves config and models in place. Without `--keep-data` it also
-clears `/etc/hal0` and `/var/lib/hal0`.
+By default this is **conservative**: it stops the services and removes the
+unit files, code tree, venvs, CLI shims and every hal0 container, but **keeps**
+`/etc/hal0` (config) and `/var/lib/hal0` (models, registry, OpenWebUI state,
+memory banks) so a re-install reuses them.
+
+For a full **clean slate** — wiping config, data, the `hal0` system user, and
+all pulled container images too — pass `--purge`:
+
+```sh frame="terminal"
+sudo bash /usr/lib/hal0/current/installer/uninstall.sh --purge
+```
+
+`--purge` prompts for a typed `DELETE` confirmation unless you pass `--force`
+(or set `HAL0_FORCE=1`). Every step is best-effort: the uninstaller never
+aborts mid-teardown on an already-gone target, and reports any soft failures
+at the end (it leaves general-purpose host packages like `ffmpeg`/`libxrt`
+and podman itself installed).
 
 <Aside type="tip" title="hal0 uninstall — wired to installer/uninstall.sh">
-`hal0 uninstall [--keep-data] [--force] [--dev]` is a thin wrapper
+`hal0 uninstall [--purge] [--keep-data] [--force] [--dev]` is a thin wrapper
 that exec's `installer/uninstall.sh`. The shell script is the source
 of truth; the CLI forwards flags and inherits the live TTY so the
-DELETE confirmation prompt works.
+`--purge` DELETE confirmation prompt works. `--clean-slate` is an alias of
+`--purge`; `--keep-data` is the (default) conservative mode.
 </Aside>

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -188,14 +188,21 @@ symlink-swap mechanics.
 ## Uninstall
 
 ```sh
-hal0 uninstall [--keep-data] [--force] [--dev]
+hal0 uninstall [--purge | --clean-slate] [--keep-data] [--force] [--dev]
 ```
 
-Thin wrapper over `installer/uninstall.sh`. The CLI exec's the script
-so the DELETE confirmation prompt inherits the live TTY; in
-non-interactive contexts pass `--force` or `--keep-data` to skip the
-prompt. `--dev` mirrors `install.sh --dev` for a `$PWD/.hal0ai`
-tree.
+Thin wrapper over `installer/uninstall.sh`. The **default is conservative**:
+it removes code, units, venvs, CLI shims and containers but keeps `/etc/hal0`
+and `/var/lib/hal0`. Pass `--purge` (alias `--clean-slate`) for a full clean
+slate — config, data, the `hal0` system user, and all hal0 container images.
+
+`--purge` prompts for a typed `DELETE`; the CLI exec's the script so that
+prompt inherits the live TTY. In non-interactive contexts pass `--force`
+(or `HAL0_FORCE=1`) to skip it — a conservative (non-`--purge`) run never
+prompts and is always safe non-interactively. Every step is best-effort and
+the script never aborts mid-teardown on an already-gone target (it exits
+non-zero only if something could not be removed). `--dev` mirrors
+`install.sh --dev` for a `$PWD/.hal0ai` tree.
 
 
 ## Talking to the daemon

--- a/installer/uninstall.sh
+++ b/installer/uninstall.sh
@@ -2,18 +2,41 @@
 # hal0 uninstaller
 #
 # Usage:
-#   sudo bash uninstall.sh             # stops services, prompts before deleting data
-#   sudo bash uninstall.sh --keep-data # leaves config/state intact
-#   sudo bash uninstall.sh --force     # skip confirmation prompt
+#   sudo bash uninstall.sh             # conservative: stop+remove code/units/
+#                                      #   venvs/binaries/containers; KEEP
+#                                      #   /etc/hal0 + /var/lib/hal0 (models)
+#   sudo bash uninstall.sh --purge     # clean slate: ALSO delete /etc/hal0,
+#                                      #   /var/lib/hal0, the hal0 user+group,
+#                                      #   podman images and the fastflowlm .deb
+#   sudo bash uninstall.sh --keep-data # legacy alias for the conservative default
+#   sudo bash uninstall.sh --force     # skip the --purge DELETE confirmation
 #        bash uninstall.sh --dev       # remove dev-mode tree under $PWD/.hal0ai
 #   HAL0_FORCE=1 sudo bash uninstall.sh # equivalent to --force
 #
-# What it removes (system mode): the hal0-api / hal0-openwebui /
-# hal0-slot@ / hal0-agent@ / hermes-gateway units (+ their drop-in
-# dirs), the install PREFIX (/opt/hal0), the hal0 system user AND group,
-# and the fastflowlm .deb. Config + state (/etc/hal0, /var/lib/hal0) go
-# too unless --keep-data. Idempotent — never hard-fails on an
-# already-gone target.
+# What the CONSERVATIVE default removes (system mode): the hal0-api /
+# hal0-openwebui / hal0-slot@ / hal0-agent@ / hermes-gateway /
+# hindsight-api units (+ drop-in dirs), every hal0 podman CONTAINER
+# (openwebui, hal0-slot-*, comfyui), the FHS code tree + shared venv
+# (/usr/lib/hal0), the install PREFIX (/opt/hal0), the per-agent venvs
+# (/var/lib/hal0/venvs/*), the Hindsight engine venv, and the
+# /usr/local/bin/{hal0,hal0-agent,hermes} shims. It deliberately KEEPS
+# /etc/hal0 (config) and /var/lib/hal0 (models, registry, OpenWebUI
+# state) so a re-install reuses them.
+#
+# --purge (== --clean-slate) ALSO removes: /etc/hal0, /var/lib/hal0,
+# the hal0 system user AND group, all hal0/toolbox podman IMAGES, and
+# the fastflowlm .deb — a true clean slate for fresh test installs.
+#
+# Every step is best-effort and continue-on-error: the uninstaller NEVER
+# aborts mid-teardown on an already-gone target or a failing step. It
+# tallies soft failures and reports them at the end (non-zero exit only
+# if something could not be torn down).
+#
+# What --purge does NOT remove (documented, deliberate): host apt
+# packages other than fastflowlm (libxrt-npu2, ffmpeg, boost, podman
+# itself) — these are general-purpose system libraries that other
+# software may depend on, so removing them is out of scope. podman/
+# docker themselves are left installed.
 #
 # Env overrides:
 #   HAL0_PREFIX        installation root (default /opt/hal0; --dev defaults
@@ -22,7 +45,18 @@
 #   HAL0_PATH_LINK     PATH symlink to remove (default /usr/local/bin/hal0;
 #                      ignored in --dev mode)
 
-set -euo pipefail
+# NOTE on shell options: we deliberately do NOT use `set -e` (errexit) here.
+# An uninstaller's whole job is to tear down a possibly-partial install where
+# many targets are legitimately already gone, services already stopped, or
+# external tools (systemctl/podman/userdel/apt) return non-zero for benign
+# reasons. Under `set -e` + a fatal ERR trap, the FIRST such non-zero aborted
+# the entire teardown — this is the root cause of the "v0.4 uninstall threw
+# lots of errors and left state behind" report: one early failure (e.g.
+# `systemctl disable` of an absent unit, or `podman rm` of a running
+# container) killed the run before it reached the data/user/image cleanup.
+# Instead we keep `-u` (catch unset vars) and `pipefail`, make every
+# destructive step best-effort, and tally soft failures for a final report.
+set -uo pipefail
 IFS=$'\n\t'
 
 # ── Colour helpers ────────────────────────────────────────────────────────────
@@ -39,28 +73,71 @@ error() { printf "${RED}✗${RESET}  %s\n" "$*" >&2; }
 step()  { printf "\n${BOLD}── %s${RESET}\n" "$*"; }
 die()   { error "$*"; exit 1; }
 
+# ── Soft-failure tally ────────────────────────────────────────────────────────
+# Every teardown step that COULD fail records a soft failure instead of
+# aborting. The count drives the final exit code so CI / scripted callers can
+# still tell a fully-clean teardown from a partial one, without ever leaving
+# state behind because of an early error.
+SOFT_FAILURES=0
+soft_fail() { warn "$*"; SOFT_FAILURES=$((SOFT_FAILURES + 1)); }
+
+# rm_path <path> — best-effort recursive remove with a uniform log line.
+# Reports "removed" / "not present" / soft-fails (never aborts).
+rm_path() {
+    local target="$1"
+    if [[ -e "$target" || -L "$target" ]]; then
+        if rm -rf "$target" 2>/dev/null; then
+            info "Removed ${target}"
+        else
+            soft_fail "Could not remove ${target}"
+        fi
+    else
+        info "${target} not present"
+    fi
+}
+
 # ── Parse flags ───────────────────────────────────────────────────────────────
-KEEP_DATA=0
+# Default is now CONSERVATIVE: keep /etc/hal0 + /var/lib/hal0 (models) so a
+# re-install reuses them. --purge (== --clean-slate) flips PURGE=1 to wipe
+# config, data, the system user/group, and podman images for a true reset.
+# --keep-data is retained as an explicit alias of the conservative default
+# (back-compat for old runbooks / the `hal0 uninstall --keep-data` wrapper).
+PURGE=0
 DEV_MODE=0
 HAL0_FORCE="${HAL0_FORCE:-0}"
 
 for arg in "$@"; do
     case "$arg" in
-        --keep-data) KEEP_DATA=1 ;;
+        --purge|--clean-slate) PURGE=1 ;;
+        --keep-data) PURGE=0 ;;   # explicit conservative (now the default)
         --force)     HAL0_FORCE=1 ;;
         --dev)       DEV_MODE=1 ;;
         --help|-h)
             cat <<'EOF'
-Usage: uninstall.sh [--keep-data] [--force] [--dev]
-  --keep-data  preserve config + state directories
-  --force      skip data-deletion confirmation prompt
-  --dev        remove the dev-mode tree under $PWD/.hal0ai (or $HAL0_PREFIX);
-               no systemd / system-user / PATH-symlink operations performed.
-               Required to undo `install.sh --dev` without clobbering a host
-               install.
-  HAL0_FORCE=1 env var is equivalent to --force
-  HAL0_PREFIX  override install root (default /opt/hal0, or $PWD/.hal0ai
-               when --dev). Path layout always mirrors install.sh.
+Usage: uninstall.sh [--purge|--clean-slate] [--keep-data] [--force] [--dev]
+
+  (default)      Conservative teardown: stop services, remove code/units/
+                 venvs/binaries and every hal0 podman container, but KEEP
+                 /etc/hal0 (config) and /var/lib/hal0 (models, registry,
+                 OpenWebUI state) so a re-install reuses them.
+  --purge        Clean slate: everything the default removes, PLUS /etc/hal0,
+  --clean-slate    /var/lib/hal0, the hal0 system user+group, all hal0/toolbox
+                 podman images, and the fastflowlm .deb. Prompts for DELETE
+                 confirmation unless --force / HAL0_FORCE=1.
+  --keep-data    Explicit conservative mode (alias of the default).
+  --force        Skip the --purge DELETE confirmation prompt.
+  --dev          Remove the dev-mode tree under $PWD/.hal0ai (or $HAL0_PREFIX);
+                 no systemd / system-user / PATH-symlink operations performed.
+                 Required to undo `install.sh --dev` without clobbering a host
+                 install. (--purge under --dev removes the whole dev tree.)
+
+  HAL0_FORCE=1   env var is equivalent to --force
+  HAL0_PREFIX    override install root (default /opt/hal0, or $PWD/.hal0ai
+                 when --dev). Path layout always mirrors install.sh.
+
+Every step is best-effort: the uninstaller never aborts mid-teardown on an
+already-gone target. It reports any soft failures and exits non-zero only if
+something could not be removed.
 EOF
             exit 0
             ;;
@@ -93,7 +170,11 @@ if [[ "${DEV_MODE}" -eq 0 && "$(id -u)" -ne 0 ]]; then
     fi
 fi
 
-trap 'error "Uninstall failed at line ${LINENO}."; exit 1' ERR
+# Intentionally NO fatal ERR trap. Earlier versions ran
+#   trap 'error "Uninstall failed at line ${LINENO}."; exit 1' ERR
+# under `set -e`, so the first benign non-zero (a missing unit, an
+# already-stopped container) aborted the whole teardown and left state
+# behind. Teardown steps below are all best-effort (see soft_fail/rm_path).
 
 # ── Stop + disable units (system mode only) ───────────────────────────────────
 if [[ "${DEV_MODE}" -eq 0 ]]; then
@@ -106,7 +187,7 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
     # has the unit on disk — and a stale hal0-lemonade restart-loops with
     # 203/EXEC once its placeholder binary is gone, so tear it down too.
     UNITS=(hal0-api hal0-openwebui hal0-caddy hal0-lemonade \
-           hal0-agent@hermes hermes-gateway)
+           hindsight-api hal0-agent@hermes hermes-gateway)
 
     # Discover any running slot instances
     while IFS= read -r UNIT; do
@@ -141,15 +222,29 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
         fi
     done
 
-    # Stop the OpenWebUI container explicitly in case the unit stop didn't get
-    # the memo. It runs under podman now; check docker too so docker-era
-    # installs are cleaned up on the same pass.
+    # Stop + remove every hal0-created container. The unit stops above SHOULD
+    # have taken the slot/openwebui containers down (ExecStopPost=podman rm -f),
+    # but a half-installed box can have orphaned containers whose units never
+    # got the memo. Match hal0's container naming:
+    #   - hal0-openwebui                (OpenWebUI)
+    #   - hal0-slot-<slot>              (inference slots, base.py:327)
+    #   - the ComfyUI image-gen container
+    # Check both podman (current) and docker (docker-era installs) on one pass.
+    # `rm -f` stops-then-removes; absent containers are skipped silently.
     for _rt in podman docker; do
-        if command -v "${_rt}" >/dev/null 2>&1 \
-            && "${_rt}" ps --format '{{.Names}}' 2>/dev/null | grep -q '^hal0-openwebui$'; then
-            "${_rt}" stop hal0-openwebui &>/dev/null || true
-            info "Stopped ${_rt} container hal0-openwebui"
-        fi
+        command -v "${_rt}" >/dev/null 2>&1 || continue
+        while IFS= read -r _cname; do
+            [[ -n "${_cname}" ]] || continue
+            case "${_cname}" in
+                hal0-openwebui|hal0-slot-*|*comfyui*)
+                    if "${_rt}" rm -f "${_cname}" &>/dev/null; then
+                        info "Removed ${_rt} container ${_cname}"
+                    else
+                        soft_fail "Could not remove ${_rt} container ${_cname}"
+                    fi
+                    ;;
+            esac
+        done < <("${_rt}" ps -a --format '{{.Names}}' 2>/dev/null || true)
     done
 else
     step "Skipping systemd / docker stop (dev mode)"
@@ -209,44 +304,52 @@ for UNIT_FILE in \
     "${UNIT_DIR}/hal0-openwebui.service" \
     "${UNIT_DIR}/hal0-caddy.service" \
     "${UNIT_DIR}/hal0-lemonade.service" \
+    "${UNIT_DIR}/hindsight-api.service" \
+    "${UNIT_DIR}/hal0-slot@.service" \
     "${UNIT_DIR}/hal0-agent@.service" \
     "${UNIT_DIR}/hermes-gateway.service"
 do
-    if [[ -f "${UNIT_FILE}" ]]; then
-        rm -f "${UNIT_FILE}"
-        info "Removed ${UNIT_FILE}"
-    else
-        info "${UNIT_FILE} not present"
-    fi
+    rm_path "${UNIT_FILE}"
 done
 
-# Drop-in directories the installer creates alongside the units:
-#   hal0-agent@hermes.service.d/  — override.conf (hermes-specific env)
-#   hermes-gateway.service.d/     — 10-hal0-secrets.conf (bootstrap secrets)
+# Per-instance slot/agent drop-in dirs the orchestrator renders at runtime
+# (hal0-slot@<name>.service.d/, hal0-agent@<name>.service.d/) plus the named
+# drop-ins the installer ships. Glob-sweep so extra agents/slots come clean.
 for DROPIN_DIR in \
-    "${UNIT_DIR}/hal0-agent@hermes.service.d" \
+    "${UNIT_DIR}"/hal0-slot@*.service.d \
+    "${UNIT_DIR}"/hal0-agent@*.service.d \
     "${UNIT_DIR}/hermes-gateway.service.d"
 do
-    if [[ -d "${DROPIN_DIR}" ]]; then
-        rm -rf "${DROPIN_DIR}"
-        info "Removed ${DROPIN_DIR}"
-    fi
+    [[ -d "${DROPIN_DIR}" ]] && rm_path "${DROPIN_DIR}"
+done
+
+# Stale enablement symlinks under multi-user.target.wants/ — `systemctl
+# disable` above should have removed them, but a half-installed box can have
+# a dangling symlink whose target unit was never written. Sweep defensively.
+for WANTS_LINK in \
+    "${UNIT_DIR}/multi-user.target.wants"/hal0-*.service \
+    "${UNIT_DIR}/multi-user.target.wants"/hindsight-api.service \
+    "${UNIT_DIR}/multi-user.target.wants"/hermes-gateway.service
+do
+    [[ -L "${WANTS_LINK}" ]] && rm_path "${WANTS_LINK}"
 done
 
 if [[ "${DEV_MODE}" -eq 0 ]]; then
-    systemctl daemon-reload
-    info "systemctl daemon-reload done"
+    systemctl daemon-reload 2>/dev/null \
+        && info "systemctl daemon-reload done" \
+        || soft_fail "systemctl daemon-reload failed"
 fi
 
-# ── Remove code ───────────────────────────────────────────────────────────────
+# ── Remove code + venvs ───────────────────────────────────────────────────────
 step "Removing code"
 
-# /usr/lib/hal0 — Hermes hooks + any FHS-migrated tree (#495). The
-# `[[ -L .../current ]]` test catches the editable→FHS layout where
-# `current` is a symlink into a versioned dir.
-if [[ -d "${LIB_DIR}" ]] || [[ -L "${LIB_DIR}/current" ]]; then
-    rm -rf "${LIB_DIR}"
-    info "Removed ${LIB_DIR}"
+# /usr/lib/hal0 — FHS code tree (hal0-<version>/), the `current` symlink, the
+# shared venv (venv/), and the Hermes hooks (hermes-hooks/). Removing the whole
+# dir gets all of them in one shot (#495). The `[[ -L .../current ]]` test
+# catches the editable→FHS layout where `current` is a symlink into a
+# versioned dir even if LIB_DIR itself isn't a plain dir.
+if [[ -d "${LIB_DIR}" || -L "${LIB_DIR}/current" ]]; then
+    rm_path "${LIB_DIR}"
 else
     info "${LIB_DIR} not present"
 fi
@@ -257,78 +360,94 @@ fi
 # dev-tree cleanup block lower down (it lives under $PWD/.hal0ai), so we
 # only sweep it here for a system install.
 if [[ "${DEV_MODE}" -eq 0 ]]; then
-    if [[ -d "${PREFIX}" ]]; then
-        rm -rf "${PREFIX}"
-        info "Removed ${PREFIX}"
-    else
-        info "${PREFIX} not present"
-    fi
+    rm_path "${PREFIX}"
 fi
 
-# ── PATH symlink (system mode only) ───────────────────────────────────────────
+# Bundled agent-skills SHIP dir (/usr/share/hal0/skills, install.sh:1063).
+# This is read-only source the hermes provision symlink-mirrors into
+# /etc/hal0/agent-skills. It lives OUTSIDE /etc + /var, so neither the data
+# sweep nor the code sweep above touches it — a leftover here re-seeds stale
+# skills into the next install's mirror. Always removed (it's pure code).
+if [[ "${DEV_MODE}" -eq 0 ]]; then
+    rm_path "/usr/share/hal0/skills"
+    # Drop the now-empty parent so /usr/share/hal0 doesn't linger.
+    [[ -d /usr/share/hal0 ]] && rmdir /usr/share/hal0 2>/dev/null \
+        && info "Removed /usr/share/hal0"
+fi
+
+# Per-agent + Hindsight venvs live UNDER ${VAR_DIR}, but they are pure
+# executable code (toolchain-built), not user data. The conservative default
+# keeps ${VAR_DIR} for the models/registry/OpenWebUI state — so we MUST remove
+# the venvs explicitly here, otherwise a stale venv (wrong Python ABI after a
+# distro upgrade, half-provisioned hermes) collides with the next install's
+# `hal0 agent install hermes` / hindsight bootstrap. --purge wipes all of
+# ${VAR_DIR} below anyway, so this is a no-op-then-redundant in that mode.
+#   /var/lib/hal0/venvs/<agent>   — hermes (+ any other agent) managed venvs
+#   /var/lib/hal0/memory/hindsight/.venv — Hindsight engine venv (pg0/hf-cache
+#       under that dir are engine STATE; keep them in conservative mode so the
+#       memory banks survive a re-install, drop them under --purge with VAR_DIR)
+rm_path "${VAR_DIR}/venvs"
+rm_path "${VAR_DIR}/memory/hindsight/.venv"
+
+# ── PATH symlinks / CLI shims (system mode only) ──────────────────────────────
 if [[ "${DEV_MODE}" -eq 0 ]]; then
     HAL0_PATH_LINK="${HAL0_PATH_LINK:-/usr/local/bin/hal0}"
-    if [[ -L "${HAL0_PATH_LINK}" ]] || [[ -f "${HAL0_PATH_LINK}" ]]; then
-        rm -f "${HAL0_PATH_LINK}"
-        info "Removed ${HAL0_PATH_LINK}"
-    else
-        info "${HAL0_PATH_LINK} not present"
-    fi
-    # hal0-agent shim symlink (created alongside hal0 by install.sh)
-    HAL0_AGENT_LINK="$(dirname "${HAL0_PATH_LINK}")/hal0-agent"
-    if [[ -L "${HAL0_AGENT_LINK}" ]] || [[ -f "${HAL0_AGENT_LINK}" ]]; then
-        rm -f "${HAL0_AGENT_LINK}"
-        info "Removed ${HAL0_AGENT_LINK}"
-    fi
+    BIN_DIR="$(dirname "${HAL0_PATH_LINK}")"
+    # hal0 (main CLI), hal0-agent (agent shim), hermes (hermes_provision.py
+    # installs /usr/local/bin/hermes as the hermes-agent CLI shim — never
+    # removed before this fix, so it shadowed a fresh provision's shim).
+    for SHIM in "${HAL0_PATH_LINK}" "${BIN_DIR}/hal0-agent" "${BIN_DIR}/hermes"; do
+        if [[ -L "${SHIM}" || -f "${SHIM}" ]]; then
+            rm_path "${SHIM}"
+        fi
+    done
 fi
 
 # ── Data dirs ─────────────────────────────────────────────────────────────────
 step "Data directories"
 
-if [[ "${KEEP_DATA}" -eq 1 ]]; then
-    warn "Keeping data dirs (--keep-data):"
+if [[ "${PURGE}" -eq 0 ]]; then
+    # Conservative default — keep config + state so a re-install reuses them.
+    warn "Keeping data dirs (conservative default — pass --purge to wipe):"
     warn "  ${ETC_DIR}      — config"
-    warn "  ${VAR_DIR}  — models, registry, openwebui state"
+    warn "  ${VAR_DIR}  — models, registry, openwebui state, memory banks"
     warn "Re-run install.sh to restore services using this data."
 else
-    # Confirmation unless forced
+    # --purge: confirmation unless forced
     if [[ "${HAL0_FORCE}" -ne 1 ]]; then
         # %b interprets backslash escapes in the substituted strings —
         # the BOLD/RED/RESET helpers are stored as literal `\033[...m`
-        # sequences (line 23), so %s would print them verbatim instead of
-        # invoking the terminal's SGR. Same gotcha bit the WARNING + the
-        # "Type DELETE" prompt; both now use %b.
-        printf '\n%b%bWARNING:%b This will delete:\n' "${RED}" "${BOLD}" "${RESET}"
+        # sequences, so %s would print them verbatim instead of invoking
+        # the terminal's SGR. Same gotcha bit the WARNING + the
+        # "Type DELETE" prompt; both use %b.
+        printf '\n%b%bWARNING:%b --purge will delete:\n' "${RED}" "${BOLD}" "${RESET}"
         printf '  %s      (config + slot definitions)\n' "${ETC_DIR}"
-        printf '  %s  (models, registry, openwebui state)\n\n' "${VAR_DIR}"
+        printf '  %s  (models, registry, openwebui state, memory banks)\n\n' "${VAR_DIR}"
         printf 'Type %bDELETE%b to confirm, or Ctrl-C to cancel: ' "${BOLD}" "${RESET}"
         read -r CONFIRM
         if [[ "${CONFIRM}" != "DELETE" ]]; then
-            warn "Aborted — data preserved."
-            exit 0
+            warn "Aborted — data preserved (code/services already removed)."
+            CONFIRM=""
+            PURGE=0   # fall through to the conservative summary
         fi
     fi
 
-    for DATA_DIR in "${ETC_DIR}" "${VAR_DIR}"; do
-        if [[ -d "${DATA_DIR}" ]]; then
-            rm -rf "${DATA_DIR}"
-            info "Removed ${DATA_DIR}"
-        else
-            info "${DATA_DIR} not present"
-        fi
-    done
+    if [[ "${PURGE}" -eq 1 ]]; then
+        for DATA_DIR in "${ETC_DIR}" "${VAR_DIR}"; do
+            rm_path "${DATA_DIR}"
+        done
+    fi
 fi
 
 # ── First-run claim lockfile ──────────────────────────────────────────────────
-# Always cleaned up — even on --keep-data — because the lockfile only has
-# meaning during the first-run claim window, and a leftover OTP after an
-# uninstall is a credential lying around with no semantics. Belt-and-braces
-# even though the file lives under ${VAR_DIR} (which we just rm -rf'd
-# when --keep-data was NOT passed).
+# Always cleaned up — even in the conservative (keep-data) default — because
+# the lockfile only has meaning during the first-run claim window, and a
+# leftover OTP after an uninstall is a credential lying around with no
+# semantics. Belt-and-braces even though the file lives under ${VAR_DIR}
+# (which --purge rm -rf's above).
 FIRST_RUN_LOCK="${VAR_DIR}/.first-run.lock"
 if [[ -f "${FIRST_RUN_LOCK}" ]]; then
-    rm -f "${FIRST_RUN_LOCK}"
-    info "Removed ${FIRST_RUN_LOCK}"
+    rm_path "${FIRST_RUN_LOCK}"
 fi
 
 # ── Dev-mode tree cleanup ─────────────────────────────────────────────────────
@@ -336,27 +455,59 @@ fi
 # `install.sh --dev` can be re-run cleanly. Only do this if PREFIX is otherwise
 # empty (don't blow away unrelated user files that happened to share the dir).
 if [[ "${DEV_MODE}" -eq 1 && -d "${PREFIX}" ]]; then
-    # Remove obvious leftover dirs first
-    for D in "${PREFIX}/etc" "${PREFIX}/var" "${PREFIX}/usr" "${PREFIX}/.venv"; do
-        [[ -d "${D}" ]] && rm -rf "${D}" && info "Removed ${D}"
+    # Remove obvious leftover dirs first. In conservative mode the dev tree's
+    # var/ (models, memory) is kept; --purge removes it too.
+    DEV_SUBDIRS=("${PREFIX}/usr" "${PREFIX}/.venv")
+    [[ "${PURGE}" -eq 1 ]] && DEV_SUBDIRS+=("${PREFIX}/etc" "${PREFIX}/var")
+    for D in "${DEV_SUBDIRS[@]}"; do
+        [[ -d "${D}" ]] && rm_path "${D}"
     done
     if [[ -z "$(ls -A "${PREFIX}" 2>/dev/null)" ]]; then
-        rmdir "${PREFIX}"
-        info "Removed empty ${PREFIX}"
+        rmdir "${PREFIX}" 2>/dev/null && info "Removed empty ${PREFIX}"
     else
         warn "${PREFIX} not empty — leaving in place"
     fi
 fi
 
-# ── System user + group (system mode only) ────────────────────────────────────
-if [[ "${DEV_MODE}" -eq 0 ]]; then
+# ── podman/docker images (clean-slate only) ───────────────────────────────────
+# install.sh + the providers pull a stack of toolbox/serving images
+# (open-webui, hal0-toolbox-{vulkan,rocm,flm,kokoro}, comfyui). These are large
+# (multi-GB) and survive a code uninstall. The conservative default LEAVES them
+# (a re-install reuses the pulled layers — faster, no re-download). --purge
+# removes them for a true clean slate. Best-effort per image.
+if [[ "${DEV_MODE}" -eq 0 && "${PURGE}" -eq 1 ]]; then
+    step "Container images (--purge)"
+    for _rt in podman docker; do
+        command -v "${_rt}" >/dev/null 2>&1 || continue
+        # Match hal0's images by repository substring so tag/digest pins and
+        # local dev builds (hal0-toolbox-*:dev) are all caught.
+        while IFS= read -r _img; do
+            [[ -n "${_img}" ]] || continue
+            case "${_img}" in
+                *open-webui*|*openwebui*|*hal0-toolbox*|ghcr.io/hal0ai/*|*amd-strix-halo-comfyui*|*kyuz0/*comfyui*)
+                    if "${_rt}" rmi -f "${_img}" &>/dev/null; then
+                        info "Removed ${_rt} image ${_img}"
+                    else
+                        soft_fail "Could not remove ${_rt} image ${_img}"
+                    fi
+                    ;;
+            esac
+        done < <("${_rt}" images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null || true)
+    done
+fi
+
+# ── System user + group (clean-slate only) ────────────────────────────────────
+# The hal0 system user owns ${VAR_DIR} content. The conservative default keeps
+# ${VAR_DIR}, so it MUST keep the user too (else the kept data is left orphaned
+# with a numeric uid that a later user could reuse). --purge removes both.
+if [[ "${DEV_MODE}" -eq 0 && "${PURGE}" -eq 1 ]]; then
     step "System user + group"
 
     if id hal0 &>/dev/null 2>&1; then
-        if userdel hal0; then
+        if userdel hal0 2>/dev/null; then
             info "Removed system user hal0"
         else
-            warn "Could not remove hal0 user"
+            soft_fail "Could not remove hal0 user"
         fi
     else
         info "System user hal0 not present"
@@ -378,20 +529,22 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
     fi
 fi
 
-# ── FLM .deb (apt hosts only) ─────────────────────────────────────────────────
+# ── FLM .deb (clean-slate, apt hosts only) ────────────────────────────────────
 # install.sh installs the `fastflowlm` .deb on Debian/Ubuntu hosts (NPU
-# host probe + device sanity). Reverse it. Guarded by `command -v apt-get`
-# so non-apt hosts skip cleanly, and every step is fail-soft — a leftover
-# package must never abort the uninstall. dev mode never touched apt, so
-# it skips this entirely.
-if [[ "${DEV_MODE}" -eq 0 ]] && command -v apt-get &>/dev/null 2>&1; then
-    step "FLM package"
+# host probe + device sanity). Reverse it under --purge only — it's a hal0-
+# specific package, but on a shared box a user may have grown to depend on it,
+# so the conservative default leaves it. Guarded by `command -v apt-get`
+# so non-apt hosts skip cleanly, and every step is fail-soft.
+# NOTE: other host packages install.sh may touch (libxrt-npu2, ffmpeg, boost,
+# podman) are general-purpose system libraries and are deliberately NOT removed.
+if [[ "${DEV_MODE}" -eq 0 && "${PURGE}" -eq 1 ]] && command -v apt-get &>/dev/null 2>&1; then
+    step "FLM package (--purge)"
 
     if dpkg-query -W -f='${Status}' fastflowlm 2>/dev/null | grep -q "install ok installed"; then
         if apt-get remove -y fastflowlm &>/dev/null; then
             info "Removed fastflowlm package"
         else
-            warn "Could not remove fastflowlm package (continuing)"
+            soft_fail "Could not remove fastflowlm package"
         fi
     else
         info "fastflowlm package not installed"
@@ -400,7 +553,20 @@ if [[ "${DEV_MODE}" -eq 0 ]] && command -v apt-get &>/dev/null 2>&1; then
 fi
 
 # ── Done ──────────────────────────────────────────────────────────────────────
-printf '\n%s%shal0 uninstalled.%s\n' "${GREEN}" "${BOLD}" "${RESET}"
-if [[ "${KEEP_DATA}" -eq 1 ]]; then
-    printf '  Config + data preserved in %s and %s.\n\n' "${ETC_DIR}" "${VAR_DIR}"
+if [[ "${SOFT_FAILURES}" -gt 0 ]]; then
+    printf '\n%s%shal0 uninstalled with %d soft failure(s).%s\n' \
+        "${YELLOW}" "${BOLD}" "${SOFT_FAILURES}" "${RESET}"
+    warn "Some targets could not be removed (see warnings above) — re-run to retry."
+else
+    printf '\n%s%shal0 uninstalled.%s\n' "${GREEN}" "${BOLD}" "${RESET}"
 fi
+if [[ "${PURGE}" -eq 0 && "${DEV_MODE}" -eq 0 ]]; then
+    printf '  Config + data preserved in %s and %s.\n' "${ETC_DIR}" "${VAR_DIR}"
+    printf '  Run %ssudo bash uninstall.sh --purge%s for a full clean slate.\n\n' \
+        "${BOLD}" "${RESET}"
+fi
+
+# Non-zero exit when something could not be torn down, so CI / test loops can
+# tell a clean teardown from a partial one — WITHOUT ever having aborted early.
+[[ "${SOFT_FAILURES}" -eq 0 ]] || exit 1
+exit 0

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -197,16 +197,25 @@ def serve(
 
 @app.command()
 def uninstall(
+    purge: bool = typer.Option(
+        False,
+        "--purge",
+        "--clean-slate",
+        help="Clean slate: ALSO delete /etc/hal0, /var/lib/hal0 (models, "
+        "registry, memory banks), the hal0 system user, and all hal0 podman "
+        "images. Prompts for DELETE unless --force.",
+    ),
     keep_data: bool = typer.Option(
         False,
         "--keep-data",
-        help="Preserve /var/lib/hal0/ (model cache, openwebui state, slot data).",
+        help="Conservative mode (the default): keep /etc/hal0 + /var/lib/hal0. "
+        "Accepted for back-compat / explicitness.",
     ),
     force: bool = typer.Option(
         False,
         "--force",
         "-f",
-        help="Skip the DELETE confirmation prompt (also honours HAL0_FORCE=1).",
+        help="Skip the --purge DELETE confirmation prompt (also honours HAL0_FORCE=1).",
     ),
     dev: bool = typer.Option(
         False,
@@ -219,6 +228,11 @@ def uninstall(
     Thin wrapper around ``installer/uninstall.sh`` — the shell script is the
     source of truth and mirrors install.sh's path layout. We exec it so the
     script inherits the live TTY for its DELETE confirmation prompt.
+
+    By default this is conservative: it stops services and removes code, units,
+    venvs, binaries, and containers but KEEPS /etc/hal0 and /var/lib/hal0 so a
+    re-install reuses them. Pass ``--purge`` for a full clean slate (wipes
+    config, data, the system user, and pulled container images).
     """
     import shutil
 
@@ -244,16 +258,20 @@ def uninstall(
     if not shutil.which("bash"):
         die("bash is required to run the uninstaller.")
 
-    # The script's DELETE prompt needs an interactive stdin. Refuse early in
-    # non-interactive contexts unless the caller has opted out of the prompt.
+    # The script's DELETE prompt only fires under --purge. A conservative run
+    # (the default, or --keep-data) never prompts, so it's safe non-interactive.
+    # For --purge we still require a TTY unless the caller opted out of the
+    # prompt (--force / HAL0_FORCE=1), else the prompt would hang silently.
     force_env = os.environ.get("HAL0_FORCE") == "1"
-    if not (keep_data or force or force_env) and not sys.stdin.isatty():
+    if purge and not (force or force_env) and not sys.stdin.isatty():
         die(
-            "Refusing to uninstall non-interactively without --force or "
-            "--keep-data — the shell script's DELETE prompt would hang."
+            "Refusing to --purge non-interactively without --force — "
+            "the shell script's DELETE prompt would hang."
         )
 
     argv = ["bash", str(script)]
+    if purge:
+        argv.append("--purge")
     if keep_data:
         argv.append("--keep-data")
     if force:

--- a/tests/cli/test_uninstall.py
+++ b/tests/cli/test_uninstall.py
@@ -46,7 +46,7 @@ def test_uninstall_default_args(captured_exec: dict[str, Any]) -> None:
     the Typer command function directly so the production isatty() check
     sees the True we monkeypatched."""
     with pytest.raises(typer.Exit) as exc:
-        uninstall(keep_data=False, force=False, dev=False)
+        uninstall(purge=False, keep_data=False, force=False, dev=False)
     assert (exc.value.exit_code or 0) == 0
     assert captured_exec["file"] == "bash"
     assert captured_exec["argv"][0] == "bash"
@@ -78,8 +78,42 @@ def test_uninstall_dev_flag(captured_exec: dict[str, Any]) -> None:
     assert captured_exec["argv"][2:] == ["--keep-data", "--dev"]
 
 
-def test_uninstall_refuses_without_tty(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Bare `hal0 uninstall` from a non-TTY context must refuse, so the
+def test_uninstall_purge_flag(captured_exec: dict[str, Any]) -> None:
+    """--purge forwards to the script (with --force here to skip the prompt)."""
+    result = runner.invoke(app, ["uninstall", "--purge", "--force"])
+    assert result.exit_code == 0
+    assert captured_exec["argv"][2:] == ["--purge", "--force"]
+
+
+def test_uninstall_clean_slate_alias(captured_exec: dict[str, Any]) -> None:
+    """--clean-slate is an alias of --purge and forwards --purge to the script."""
+    result = runner.invoke(app, ["uninstall", "--clean-slate", "--force"])
+    assert result.exit_code == 0
+    assert captured_exec["argv"][2:] == ["--purge", "--force"]
+
+
+def test_uninstall_default_non_tty_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Conservative default never prompts, so a bare `hal0 uninstall` is safe
+    non-interactively — it must NOT refuse (the old contract did, when the
+    default deleted data)."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.delenv("HAL0_FORCE", raising=False)
+
+    captured: dict[str, Any] = {}
+
+    def fake_execvp(file: str, argv: list[str]) -> None:
+        captured["argv"] = list(argv)
+        raise typer.Exit(0)
+
+    monkeypatch.setattr("os.execvp", fake_execvp)
+
+    result = runner.invoke(app, ["uninstall"])
+    assert result.exit_code == 0
+    assert captured["argv"][2:] == []
+
+
+def test_uninstall_purge_refuses_without_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`hal0 uninstall --purge` from a non-TTY context must refuse, so the
     shell script's DELETE prompt doesn't hang silently."""
     monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
     monkeypatch.delenv("HAL0_FORCE", raising=False)
@@ -91,13 +125,13 @@ def test_uninstall_refuses_without_tty(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr("os.execvp", fake_execvp)
 
-    result = runner.invoke(app, ["uninstall"])
+    result = runner.invoke(app, ["uninstall", "--purge"])
     assert result.exit_code == 1
     assert "yes" not in called
 
 
-def test_uninstall_non_tty_with_force_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
-    """--force bypasses the prompt — no TTY needed."""
+def test_uninstall_purge_non_tty_with_force_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--force bypasses the --purge prompt — no TTY needed."""
     monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
     monkeypatch.delenv("HAL0_FORCE", raising=False)
 
@@ -109,13 +143,14 @@ def test_uninstall_non_tty_with_force_proceeds(monkeypatch: pytest.MonkeyPatch) 
 
     monkeypatch.setattr("os.execvp", fake_execvp)
 
-    result = runner.invoke(app, ["uninstall", "--force"])
+    result = runner.invoke(app, ["uninstall", "--purge", "--force"])
     assert result.exit_code == 0
+    assert "--purge" in captured["argv"]
     assert "--force" in captured["argv"]
 
 
-def test_uninstall_non_tty_with_hal0_force_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """HAL0_FORCE=1 also bypasses the TTY requirement."""
+def test_uninstall_purge_non_tty_with_hal0_force_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HAL0_FORCE=1 also bypasses the --purge TTY requirement."""
     monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
     monkeypatch.setenv("HAL0_FORCE", "1")
 
@@ -127,9 +162,9 @@ def test_uninstall_non_tty_with_hal0_force_env(monkeypatch: pytest.MonkeyPatch) 
 
     monkeypatch.setattr("os.execvp", fake_execvp)
 
-    result = runner.invoke(app, ["uninstall"])
+    result = runner.invoke(app, ["uninstall", "--purge"])
     assert result.exit_code == 0
-    assert captured["argv"][1].endswith("/installer/uninstall.sh")
+    assert "--purge" in captured["argv"]
 
 
 def test_uninstall_resolves_fhs_path_when_not_editable(
@@ -156,7 +191,7 @@ def test_uninstall_resolves_fhs_path_when_not_editable(
     monkeypatch.setattr(paths, "usr_lib", lambda: fhs_current)
 
     with pytest.raises(typer.Exit) as exc:
-        uninstall(keep_data=False, force=True, dev=False)
+        uninstall(purge=False, keep_data=False, force=True, dev=False)
     assert (exc.value.exit_code or 0) == 0
     assert captured_exec["argv"][1] == str(fhs_current / "installer" / "uninstall.sh")
 


### PR DESCRIPTION
## Problem

Uninstall didn't fully reset slate, so leftover state collided with the next install — the exact failure a user hit ("uninstalled v0.4, got lots of errors, then the v0.5 install partially failed").

**Root cause of the "lots of errors":** the old `uninstall.sh` ran under `set -euo pipefail` + an `ERR` trap, so any *benign* non-zero (`systemctl disable` of an absent unit, `podman stop` of an already-stopped container, `userdel`/`groupdel` quirks) tripped the trap and **aborted the whole teardown mid-way** — leaving precisely the stale state that then breaks the next install.

## What it missed (now cleaned)
- `hindsight-api.service` — never stopped/disabled/removed (orphaned unit, restart-loops next install)
- Per-agent venvs + the Hindsight engine venv (`/var/lib/hal0/venvs/*`, `…/memory/hindsight/.venv`) — stale ABI collides with re-provision
- `/usr/local/bin/hermes` shim — shadowed a fresh provision
- `/usr/share/hal0/skills` ship dir — re-seeded stale skills
- podman containers (`hal0-slot-*`, comfyui) — only `hal0-openwebui` was stopped, never `rm`'d
- per-instance drop-in dirs + `multi-user.target.wants` symlinks

## Changes
- Dropped `set -e` + the ERR trap; every destructive step is **best-effort** via `rm_path`/`soft_fail` helpers that continue-on-error, tally failures, and exit non-zero **only after** trying everything.
- Added all the missed targets above.
- **Flag semantics:** default = conservative (removes code/units/venvs/shims/containers; **keeps** `/etc/hal0` + `/var/lib/hal0`). `--purge` / `--clean-slate` = full wipe incl. config, data, `hal0` user+group, hal0 images, fastflowlm `.deb`. `--keep-data` = explicit default. Host pkgs (ffmpeg/libxrt/boost) + podman itself left (documented).
- Invoke: `sudo bash installer/uninstall.sh [--purge] [--force]` or `hal0 uninstall [--purge|--clean-slate] [--keep-data] [--force] [--dev]`.

## Tests
- `tests/cli/test_uninstall.py` 13/13 pass; `ruff` + `ruff format --check` + `shellcheck -S warning` clean; `bash -n` ok.
- Exercised in throwaway `--dev` trees: conservative keeps data/removes code; `--purge` fully wipes; idempotent re-run = RC 0; forced `rm` failure soft-fails + continues + exits RC 1 with tally. No real system/CT105 state touched.

## Notes
- Independent of #824 (touches `uninstall.sh` + `cli/{main,agent_commands}.py`, not `install.sh`/`override.conf`); the two can merge in any order. Together they make test-iteration reliable: #824 fixes the install, this makes the between-test wipe trustworthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)