### PR TITLE
feat(npu): NPU as chat-only utility slot (alias) + installer/updater align

### DIFF
--- a/docs/superpowers/specs/2026-06-15-npu-utility-slot-design.md
+++ b/docs/superpowers/specs/2026-06-15-npu-utility-slot-design.md
@@ -1,0 +1,153 @@
+# NPU as the chat-only `utility` slot
+
+**Date:** 2026-06-15
+**Status:** Approved (design) — pending spec review
+**Author:** Claude (with Alexander)
+**Related:** PR #822 (FLM tag/image fix, merged), memory `hal0-flm-trio-npu`, ADR-0008 §5 (NPU exclusivity), ADR-0009 (NPU packing)
+
+## Problem / context
+
+The NPU FLM "trio" (one `flm serve` process serving chat + embed + ASR via
+`--embed 1 --asr 1`) is the only way the NPU is modelled today. It is bespoke,
+caused a multi-fault outage (see PR #822), and blocks the model we actually want:
+
+- **gemma4-it:e2b** runs fine **chat-only** (~23 tok/s) but **fails under the
+  trio flags** — `DRM_IOCTL_AMDXDNA_CREATE_HWCTX IOCTL failed (err=-22)`: the
+  e2b model + co-resident embed + ASR exceed the single-tenant NPU's 8-column
+  hardware-context budget. The trio forces the slower gemma3:4b (~12 tok/s).
+- The NPU-served **embed/ASR are unused**: Hindsight embeds on CPU and only
+  needs an LLM for inference. So the trio buys complexity with no current payoff.
+
+We also want the NPU to carry the **`utility` role** (background/utility LLM
+inference — Hindsight memory extract/reflect, etc.), replacing the iGPU utility
+slot (ROCm `qwopus3.5-9b-coder-mtp`, ~7 GB). That offloads utility work to the
+NPU and frees the iGPU for the `chat`/`agent` slots.
+
+## Decision
+
+Make the NPU a **single chat-only slot** running **gemma4-it:e2b**, bound to the
+**`utility` role via an alias (the `role` field) — not a rename**. Disable the
+iGPU utility slot and the unused NPU embed/ASR shadow slots. Leave the trio code
+**dormant** for a future "stacks" feature (model/slot/config snapshots that can
+be switched) to generalise. Apply to the live box **and** the repo seeds /
+installer / updater so fresh installs and upgrades match.
+
+### Why alias, not rename
+
+`normalize/resolver.py` routes virtual names by a role chain:
+
+```python
+DEFAULT_CHAINS = {
+    "hal0/npu":     ("npu", "utility", "chat"),
+    "hal0/utility": ("utility", "npu", "chat"),
+}
+# _slot_matches_role: role=="npu" matches device=="npu" OR role tag "npu";
+# otherwise matches (slot.role or slot.name)
+```
+
+Setting `role = "utility"` on the NPU slot makes `hal0/utility` bind to it
+explicitly, while `hal0/npu` still resolves to it because it matches by
+**device** (`device=="npu"`). The slot keeps its **name `npu`**, so all the
+name-keyed code (`routes/npu.py`, `dispatcher/npu_swap_status.py`,
+`routes/models.py` upstream `"npu"`, NPU telemetry in `routes/hardware.py`,
+the dashboard NPU card) is untouched. A rename would ripple through all of it
+for no benefit.
+
+## Design
+
+### Slot end-state
+
+| Slot | Before | After |
+|------|--------|-------|
+| `npu` | device=npu, FLM, `gemma3-4b-FLM`, trio (`[npu] asr=true embed=true`), `role=npu` | device=npu, FLM, **`gemma4-it-e2b-FLM`**, **chat-only** (no `[npu]` table), **`role="utility"`**, port 8088 |
+| `utility` (iGPU) | device=gpu-rocm, `qwopus3.5-9b-coder-mtp`, role=utility, port 8081 | **`enabled=false`** on this NPU-present box (frees ~7 GB iGPU; reversible). NPU-absent boxes keep it. |
+| `embed`, `stt` (NPU shadows) | trio shadows (offline) | **`enabled=false`** (unused — Hindsight embeds on CPU) |
+
+Routing after the change:
+- `hal0/utility` → NPU slot (explicit `role` match; iGPU utility disabled so no contention)
+- `hal0/npu` → NPU slot (device match — unchanged)
+- `gemma4-it-e2b-FLM` resolves to FLM tag `gemma4-it:e2b` via `flm_id_to_tag()` (PR #822). Load via the `-FLM` id form, never the bare colon tag (the `/load` gate rejects colon tags).
+
+### Consumer repoint — Hindsight
+
+Hindsight is the main `utility` consumer. The `hermes.env` profile is **stale**
+(`HINDSIGHT_API_LLM_MODEL=qwen3-it-4b-FLM`, `BASE_URL=…:13305` — the retired
+lemond port). Implementation step:
+1. Identify the **live** operator memory-engine LLM config (not the stale
+   `hermes` profile).
+2. Point it at the virtual **`hal0/utility`** (role-tracking) rather than a
+   hardcoded model id, so it follows the role wherever it lives.
+3. Restart/verify the memory engine performs an inference round-trip against the
+   NPU gemma4 slot.
+
+### Installer / firstrun seeding
+
+`install/profile_derive.py` currently provisions the NPU as a trio:
+
+```python
+NPU_TRIO_CAPS = frozenset({"agent", "stt-npu", "embed-npu"})
+```
+
+Change fresh-install provisioning to be **hardware-conditional**:
+- **NPU present:** the NPU slot is chat-only and carries the `utility` role; the
+  iGPU `utility` slot is **not** provisioned (or provisioned disabled); `stt-npu`
+  / `embed-npu` passengers are **not** auto-provisioned (embed/STT, if selected,
+  derive to GPU/CPU).
+- **NPU absent:** unchanged — `utility` stays on the iGPU as today.
+
+This lives in `profile_derive.py` (hardware-conditional logic), not the static
+seed files. The static `utility.toml` seed is retained for the NPU-absent path;
+`derive_device` / the firstrun bundle decides whether to enable it.
+
+### Updater
+
+`routes/updater.py` `/state` reports `flm: {current: "v0.9.42", source:
+"manual-deb"}` and a `_parse_flm_version` helper with a `v0.9.42` literal.
+Update so it reflects the **`0.9.43` toolbox image** (the source of truth post
+PR #822 — `providers/flm.py` `_DEFAULT_FLM_IMAGE`, `capabilities/catalog.py`
+`_FLM_TOOLBOX_IMAGE`) rather than a stale literal, and degrades gracefully.
+
+### Seeds (repo)
+
+Mirror the intended defaults into the checked-in seeds so fresh installs match,
+keeping the hardware-conditional behaviour above:
+- `installer/etc-hal0/slots/npu.toml` → role=utility, gemma4-it-e2b-FLM default, no `[npu]` table.
+- `installer/etc-hal0/slots/utility.toml` → retained for NPU-absent boxes; `profile_derive` disables it when the NPU takes the utility role.
+- NPU `embed`/`stt` shadow seeding → gated off by `profile_derive` (not auto-provisioned on NPU-present boxes).
+- Keep `SEED_PROFILES`/seed-parity in lockstep (the `TestSeedFileParity` guard).
+
+## Out of scope (deferred to "stacks")
+
+- Removing the trio code (`is_npu_trio_shadow`, `dispatcher/npu_trio.py`,
+  `NPU_SEEDED_SLOTS` shadows, the `[npu]` toggle schema). Left **dormant**.
+- The "stacks" feature itself (switchable model/slot/config snapshots) — the
+  trio becomes one stack later. Not designed here.
+- Re-homing embed/ASR onto GPU/CPU as first-class slots (only needed if a
+  consumer asks for them; today none does).
+
+## Testing
+
+- **Unit:** installer `derive_device` provisions NPU-present box as chat-only
+  utility (no `stt-npu`/`embed-npu`); updater `/state` returns `0.9.43`.
+- **Config/seed:** seed-parity tests pass; npu seed has `role=utility`, no `[npu]`.
+- **Live verification (CT105):** `hal0/utility` resolves to the NPU gemma4 slot;
+  gemma4-it:e2b serves chat (no HWCTX error); iGPU freed (~7 GB); Hindsight
+  performs an inference round-trip via `hal0/utility`.
+
+## Rollout
+
+1. Live CT105: reconfigure `npu.toml` (role/model/drop trio), disable iGPU
+   `utility` + `embed`/`stt` shadows, repoint Hindsight, verify.
+2. Repo PR: seeds + `profile_derive.py` + `updater.py` + tests.
+3. Deploy PR via `scripts/deploy.sh`; re-verify.
+
+## Risks
+
+- **Hindsight wiring unknown until inspected live** — the one step requiring
+  live verification before flip. Mitigated by step-1 ordering (verify first).
+- **gemma4-it:e2b capability vs qwopus-9b** for utility tasks (smaller model).
+  User has chosen gemma4 for speed/intelligence; fall back to gemma3:4b or the
+  iGPU slot is a one-line re-enable if quality regresses.
+- **Other `hal0/utility` consumers** beyond Hindsight follow the role
+  automatically; enumerate during implementation to confirm none expect the
+  iGPU qwopus specifically.

--- a/installer/etc-hal0/slots/npu.toml
+++ b/installer/etc-hal0/slots/npu.toml
@@ -1,17 +1,14 @@
 # NPU LLM slot — FastFlowLM in a podman container (hal0-slot@npu).
-# One FLM process per NPU; model swap = container restart.
+# Chat-only utility slot: gemma4-it:e2b, no trio (asr/embed disabled).
+# role="utility" lets hal0/utility resolve here; hal0/npu still matches by device.
 name = "npu"
 port = 8088
 device = "npu"
 runtime = "container"
 profile = "flm"
 type = "llm"
+role = "utility"
 
 [model]
-default = "gemma3:4b"
+default = "gemma4-it-e2b-FLM"
 context_size = 16384
-
-[npu]
-# Trio modalities (flm serve --asr/--embed). Toggled from the dashboard.
-asr = false
-embed = false

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -461,6 +461,18 @@ async def hal0_llm_slot_views(
         model_id = _slot_model_id(cfg)
         if not name or not model_id:
             continue
+        # FLM/NPU slots: the resolver matches against the loaded set (FLM's
+        # advertised catalog of native ``family:size`` tags) and returns the
+        # model id dispatched downstream. Both must be the colon tag
+        # (``gemma4-it:e2b``), not hal0's ``-FLM`` catalog id — otherwise
+        # ``hal0/utility``/``hal0/npu`` never match the slot and fall through
+        # to the chat slot. Translate via the same map as the FLM provider.
+        if (cfg.get("device") or "").strip() == "npu" or (cfg.get("backend") or "") == "flm":
+            from hal0.providers.flm import flm_id_to_tag
+
+            tag = flm_id_to_tag(model_id)
+            if tag:
+                model_id = tag
         out.append(
             {
                 "name": name,

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -272,21 +272,58 @@ def _probe_version(candidates: tuple[str, ...]) -> str | None:
     return None
 
 
+def _flm_toolbox_image() -> str:
+    """Return the bundled FLM toolbox image reference (source of truth post-PR #822).
+
+    Delegates to ``providers.flm._DEFAULT_FLM_IMAGE`` so the version is
+    never duplicated — updating the image constant updates the updater
+    surface automatically. Returns an empty string on import failure so
+    callers can degrade gracefully.
+    """
+    try:
+        from hal0.providers.flm import _DEFAULT_FLM_IMAGE
+
+        return _DEFAULT_FLM_IMAGE
+    except Exception:  # pragma: no cover
+        return ""
+
+
 def _parse_flm_version(raw: str | None) -> str | None:
-    """``FLM v0.9.42`` → ``v0.9.42``."""
+    """``FLM v0.9.43`` → ``v0.9.43`` (probe output normalisation).
+
+    Strips the leading ``FLM `` prefix emitted by ``flm --version`` and
+    returns the version token. Returns ``None`` on empty / ``None`` input.
+    """
     if not raw:
         return None
     parts = raw.split()
     return parts[-1] if parts else raw
 
 
+def _parse_flm_version_from_image(image_ref: str | None) -> str | None:
+    """``ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43`` → ``0.9.43``.
+
+    Parses the tag off an OCI image reference (everything after the last
+    ``:``) and returns it, or ``None`` if the ref is empty / has no tag.
+    """
+    if not image_ref:
+        return None
+    # image_ref may be "repo/image:tag" or "registry/repo/image:tag".
+    # The tag is always the fragment after the last colon, provided it
+    # exists and is non-empty.
+    if ":" not in image_ref:
+        return None
+    tag = image_ref.rsplit(":", 1)[-1].strip()
+    return tag if tag else None
+
+
 @router.get("/state")
 async def update_state(request: Request) -> dict[str, Any]:
     """Aggregate update state for the Settings → Updates surface.
 
-    Combines the hal0 self-update channel + local probes of bundled
-    components (flm) so the dashboard renders real versions instead of
-    hardcoded literals (issue #233).
+    Combines the hal0 self-update channel + the bundled FLM toolbox image
+    version so the dashboard renders real versions instead of hardcoded
+    literals (issue #233).
 
     Response shape (matches ``ui/src/api/hooks/useUpdates.ts``)::
 
@@ -296,12 +333,15 @@ async def update_state(request: Request) -> dict[str, Any]:
                 "available": "0.3.0" | null,
                 "channel": "stable"
             },
-            "flm":      {"current": "v0.9.42", "source": "manual-deb"},
+            "flm":      {"current": "0.9.43", "source": "toolbox-image"},
             "autoCheck": true
         }
 
-    Failures in any single probe degrade gracefully — the corresponding
-    field comes back as ``None`` rather than 5xx'ing the whole response.
+    The ``flm.current`` version is derived from the bundled toolbox image
+    tag (``providers.flm._DEFAULT_FLM_IMAGE``) — the single source of truth
+    post PR #822. Failures in any single probe degrade gracefully — the
+    corresponding field comes back as ``None`` rather than 5xx'ing the whole
+    response.
     """
     channel = _current_channel(request)
 
@@ -327,7 +367,10 @@ async def update_state(request: Request) -> dict[str, Any]:
     except (OSError, ValueError):
         pass
 
-    flm_raw = await asyncio.to_thread(_probe_version, _FLM_BIN_CANDIDATES)
+    # Derive FLM version from the bundled toolbox image tag — the source of
+    # truth post PR #822. Gracefully degrades to None if the import fails
+    # (e.g. FLM provider not installed on this host).
+    flm_version = _parse_flm_version_from_image(_flm_toolbox_image())
 
     return {
         "hal0": {
@@ -339,8 +382,8 @@ async def update_state(request: Request) -> dict[str, Any]:
             "revoked_version": hal0_revoked_version,
         },
         "flm": {
-            "current": _parse_flm_version(flm_raw),
-            "source": "manual-deb",
+            "current": flm_version,
+            "source": "toolbox-image",
         },
         "autoCheck": True,
     }

--- a/src/hal0/install/profile_derive.py
+++ b/src/hal0/install/profile_derive.py
@@ -14,19 +14,62 @@ from __future__ import annotations
 
 from hal0.config.schema import HardwareInfo
 
-#: NPU-trio capabilities (NPU chat agent + npu stt/embed passengers). Only
-#: provisioned when the NPU is present and the operator opted in.
+#: NPU-trio capabilities (NPU chat agent + npu stt/embed passengers). Kept as a
+#: symbol because the trio code is left **dormant** (out of scope to remove,
+#: design 2026-06-15) — but fresh-install provisioning no longer derives the
+#: passengers. See :data:`NPU_ONLY_CHAT_CAPS` / :data:`NPU_FALLBACK_CHAT_CAPS`
+#: for what actually lands on the NPU.
 NPU_TRIO_CAPS = frozenset({"agent", "stt-npu", "embed-npu"})
+
+#: Trio *passenger* capabilities (npu stt/embed shadows). These are no longer
+#: auto-provisioned on fresh installs — they derive to None so the NPU box is
+#: chat-only. The plain ``embed`` / ``stt`` capabilities are unaffected and
+#: derive to the GPU/CPU lanes as usual.
+NPU_TRIO_PASSENGER_CAPS = frozenset({"stt-npu", "embed-npu"})
+
+#: NPU-only chat capability. ``agent`` lands on the NPU when claimed and is
+#: skipped (None) otherwise — there is no GPU agent slot in the seed set.
+NPU_ONLY_CHAT_CAPS = frozenset({"agent"})
+
+#: Role-tracking chat capability. ``utility`` rides the NPU chat lane when the
+#: NPU is claimed, but **falls back to the GPU/CPU lane** when the NPU is absent
+#: or opted out, so the iGPU ``utility`` seed stays coherent (design
+#: 2026-06-15).
+NPU_FALLBACK_CHAT_CAPS = frozenset({"utility"})
+
+
+def npu_takes_utility(hw: HardwareInfo, *, npu_opt_in: bool) -> bool:
+    """True when the NPU claims the ``utility`` role on this box.
+
+    When True, the firstrun bundle should NOT provision (or should disable) the
+    iGPU ``utility`` slot — the chat-only NPU slot carries the role instead
+    (design 2026-06-15). False on NPU-absent or opted-out boxes, where
+    ``utility`` stays on the iGPU as before.
+    """
+    return bool(hw.npu.present and npu_opt_in)
 
 
 def derive_device(capability: str, hw: HardwareInfo, *, npu_opt_in: bool) -> str | None:
     """Return a ``DeviceLiteral`` for the capability, or None to skip it.
 
-    None means "do not provision this slot on this box" — e.g. an NPU-trio
-    member when the NPU is absent or the operator didn't opt in.
+    None means "do not provision this slot on this box" — e.g. the NPU chat
+    lane when the NPU is absent / not opted in, or a (now-dormant) NPU-trio
+    passenger which is never auto-provisioned (design 2026-06-15).
     """
-    if capability in NPU_TRIO_CAPS:
+    if capability in NPU_TRIO_PASSENGER_CAPS:
+        # Trio passengers (stt-npu / embed-npu) are no longer auto-seeded on
+        # fresh installs; the NPU box is chat-only. Plain embed/stt fall
+        # through to the GPU/CPU lanes below.
+        return None
+    if capability in NPU_ONLY_CHAT_CAPS:
+        # NPU agent lane: NPU when present and opted in, else skip (no GPU
+        # agent slot exists in the seed set).
         return "npu" if (hw.npu.present and npu_opt_in) else None
+    if capability in NPU_FALLBACK_CHAT_CAPS and npu_takes_utility(hw, npu_opt_in=npu_opt_in):
+        # utility role on the NPU when claimed; otherwise fall through to the
+        # GPU/CPU lane so the iGPU utility slot stays coherent on NPU-absent /
+        # opted-out boxes (design 2026-06-15).
+        return "npu"
     if capability == "tts":
         # kokoro runs on CPU (the `tts` seed profile, backend-None → coherent).
         return "cpu"

--- a/tests/api/test_llm_slot_views.py
+++ b/tests/api/test_llm_slot_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from hal0.api import hal0_llm_slot_views
@@ -51,3 +53,29 @@ async def test_llm_slot_views_filters_and_projects():
     assert by_name["utility"]["context_length"] == 8192
     # ctx_size key (not context_size) must also be read correctly
     assert by_name["agent"]["context_length"] == 32768
+
+
+@pytest.mark.asyncio
+async def test_llm_slot_views_translates_flm_id_to_colon_tag():
+    """NPU/FLM slot model_id is projected as FLM's native colon tag.
+
+    The resolver matches SlotView.model_id against the loaded set (FLM's
+    advertised colon tags) and dispatches it downstream; the hal0 ``-FLM``
+    catalog id would never match, so ``hal0/utility``/``hal0/npu`` would fall
+    through to the chat slot.
+    """
+    cfgs = [
+        {
+            "name": "npu",
+            "type": "llm",
+            "enabled": True,
+            "device": "npu",
+            "role": "utility",
+            "model": {"default": "gemma4-it-e2b-FLM", "context_size": 18000},
+        },
+    ]
+    fake_catalog = [{"tag": "gemma4-it:e2b", "installed": True, "capabilities": ["chat"]}]
+    with patch("hal0.providers.flm.flm_served_models", lambda: fake_catalog):
+        views = await hal0_llm_slot_views(_FakeSlotManager(cfgs))
+    assert views[0]["model_id"] == "gemma4-it:e2b"
+    assert views[0]["role"] == "utility"

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -63,12 +63,15 @@ def test_state_returns_shape_expected_by_dashboard(
 ) -> None:
     """GET /api/updates/state matches the UpdateState shape in useUpdates.ts.
 
-    Probes are stubbed so the test doesn't depend on flm being
-    installed on the test host. Issue #233.
+    flm.current is derived from the bundled toolbox image tag (PR #822),
+    not from a subprocess probe. Issue #233.
     """
     from hal0.api.routes import updater as u_mod
 
-    monkeypatch.setattr(u_mod, "_probe_version", lambda _c: None)
+    # Stub the image-ref helper so the test is independent of the real constant.
+    monkeypatch.setattr(
+        u_mod, "_flm_toolbox_image", lambda: "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43"
+    )
 
     r = isolated_client.get("/api/updates/state")
     assert r.status_code == 200, r.text
@@ -78,28 +81,37 @@ def test_state_returns_shape_expected_by_dashboard(
     assert body["hal0"]["current"]  # __version__ is non-empty
     assert body["hal0"]["available"] == "9.9.9"
     assert body["hal0"]["channel"] == "stable"
-    # Probe returned None — UI should render '—' rather than a fabricated version.
-    assert body["flm"]["current"] is None
+    # flm.current comes from the image tag; source is "toolbox-image".
+    assert body["flm"]["current"] == "0.9.43"
+    assert body["flm"]["source"] == "toolbox-image"
     assert body["autoCheck"] is True
 
 
-def test_state_parses_flm_version_string(
+def test_state_flm_version_from_image_tag(
     isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Probe output ``FLM v0.9.42`` parses cleanly."""
+    """flm.current is derived from the bundled toolbox image tag, not a probe.
+
+    The source of truth post-PR #822 is the ``_DEFAULT_FLM_IMAGE`` /
+    ``_FLM_TOOLBOX_IMAGE`` constant (``ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43``).
+    The route parses the tag off the image ref and reports it with
+    ``source="toolbox-image"`` — no subprocess probe required.
+    """
     from hal0.api.routes import updater as u_mod
 
-    def fake_probe(candidates: tuple[str, ...]) -> str | None:
-        if candidates[0] == "flm":
-            return "FLM v0.9.42"
-        return None
-
-    monkeypatch.setattr(u_mod, "_probe_version", fake_probe)
+    # Stub _flm_toolbox_image to return a known image ref so the test is
+    # independent of the real constant's value.
+    monkeypatch.setattr(
+        u_mod,
+        "_flm_toolbox_image",
+        lambda: "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43",
+    )
 
     r = isolated_client.get("/api/updates/state")
-    assert r.status_code == 200
+    assert r.status_code == 200, r.text
     body = r.json()
-    assert body["flm"]["current"] == "v0.9.42"
+    assert body["flm"]["current"] == "0.9.43"
+    assert body["flm"]["source"] == "toolbox-image"
 
 
 def test_state_survives_manifest_fetch_failure(

--- a/tests/config/test_schema_npu.py
+++ b/tests/config/test_schema_npu.py
@@ -74,7 +74,10 @@ def test_seed_npu_toml_validates() -> None:
     assert slot.runtime == "container"
     assert slot.profile == "flm"
     assert slot.device == "npu"
-    assert slot.npu is not None and slot.npu.asr is False
+    # chat-only utility: no [npu] trio table, role aliased to utility
+    assert slot.npu is None
+    assert slot.role == "utility"
+    assert slot.model is not None and slot.model.default == "gemma4-it-e2b-FLM"
 
 
 def test_seed_tts_toml_validates() -> None:

--- a/tests/install/test_profile_derive.py
+++ b/tests/install/test_profile_derive.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
-from hal0.install.profile_derive import derive_device, derive_profile
+from hal0.install.profile_derive import (
+    derive_device,
+    derive_profile,
+    npu_takes_utility,
+)
 
 
 def _hw(*, platform="bare-metal-amd-gpu", compute=True, vulkan=True, npu=False):
@@ -43,11 +47,54 @@ def test_embed_on_rocm_box_is_rocm_not_mtp():
     assert derive_profile("embed", "gpu-rocm") == "rocm"
 
 
-def test_npu_trio_requires_present_and_optin():
+def test_npu_chat_lane_requires_present_and_optin():
+    # The NPU chat lane (agent / utility role) is selected only when the NPU
+    # is present AND the operator opted in.
     assert derive_device("agent", _hw(npu=True), npu_opt_in=True) == "npu"
     assert derive_device("agent", _hw(npu=True), npu_opt_in=False) is None
     assert derive_device("agent", _hw(npu=False), npu_opt_in=True) is None
     assert derive_profile("agent", "npu") == "flm"
+
+
+def test_npu_present_is_chat_only_no_trio_passengers():
+    """NPU-present box: chat lane goes to NPU, but the stt/embed trio
+    passengers are NOT auto-provisioned (design 2026-06-15)."""
+    hw = _hw(npu=True)
+    # chat lane on the NPU
+    assert derive_device("agent", hw, npu_opt_in=True) == "npu"
+    # trio shadow passengers are gated off entirely
+    assert derive_device("stt-npu", hw, npu_opt_in=True) is None
+    assert derive_device("embed-npu", hw, npu_opt_in=True) is None
+
+
+def test_embed_on_npu_box_derives_to_gpu_not_npu():
+    """If embed is selected on an NPU box, it derives to the GPU lane,
+    never to the NPU (design 2026-06-15)."""
+    hw = _hw(npu=True, compute=True)
+    assert derive_device("embed", hw, npu_opt_in=True) == "gpu-rocm"
+    assert derive_profile("embed", "gpu-rocm") == "rocm"
+
+
+def test_npu_takes_utility_when_present_and_optin():
+    """The iGPU `utility` slot is suppressed when the NPU claims the
+    utility role; otherwise utility stays on the iGPU (design 2026-06-15)."""
+    # NPU present + opted in → NPU takes utility, iGPU utility suppressed.
+    assert npu_takes_utility(_hw(npu=True), npu_opt_in=True) is True
+    # opted out → iGPU keeps utility.
+    assert npu_takes_utility(_hw(npu=True), npu_opt_in=False) is False
+    # no NPU → iGPU keeps utility.
+    assert npu_takes_utility(_hw(npu=False), npu_opt_in=True) is False
+
+
+def test_utility_capability_routes_like_chat_lane():
+    """The `utility` capability follows the chat lane: NPU when claimed,
+    else the GPU lane (so the iGPU utility seed stays coherent)."""
+    npu_box = _hw(npu=True, compute=True)
+    assert derive_device("utility", npu_box, npu_opt_in=True) == "npu"
+    assert derive_profile("utility", "npu") == "flm"
+    # NPU-absent → utility stays on the iGPU.
+    igpu_box = _hw(npu=False, compute=True)
+    assert derive_device("utility", igpu_box, npu_opt_in=False) == "gpu-rocm"
 
 
 def test_tts_is_cpu_kokoro():


### PR DESCRIPTION
Implements approved spec `docs/superpowers/specs/2026-06-15-npu-utility-slot-design.md`.

## What
Move the `utility` role onto a **chat-only NPU `gemma4-it:e2b`** slot via the **role alias** (no rename — slot keeps name `npu`, still answers `hal0/npu` by device match). Frees the iGPU utility slot. Trio code left **dormant** for the future "stacks" feature.

## Why
- `gemma4-it:e2b` fails under trio flags (`CREATE_HWCTX err=-22`) but runs chat-only at ~23 tok/s. Embed/ASR on NPU are unused (Hindsight embeds on CPU). Dropping the trio unblocks the faster/smarter model.
- Utility inference (Hindsight) moves off the iGPU onto the NPU; frees ~7 GB iGPU.

## Changes
- **`api/__init__.py`** (`hal0_llm_slot_views`): translate FLM slot `model_id` → native colon tag (`gemma4-it:e2b`) via `flm_id_to_tag`, so the resolver's loaded-set match + dispatched id are FLM-correct → `hal0/utility`/`hal0/npu` resolve to the NPU slot instead of falling through to chat.
- **`install/profile_derive.py`**: hardware-conditional — NPU-present box runs NPU chat-only with the utility role, no `stt-npu`/`embed-npu` passengers, iGPU utility gated via `npu_takes_utility()`; NPU-absent unchanged.
- **`routes/updater.py`**: report the bundled FLM toolbox image version (`0.9.43`) off `providers.flm._DEFAULT_FLM_IMAGE`, not the stale `v0.9.42` literal.
- **`installer/etc-hal0/slots/npu.toml`** seed: `role=utility`, `gemma4-it-e2b-FLM`, no `[npu]` table.

## Live
Already applied to CT105 (config flips): NPU serves `gemma4-it:e2b` chat-only, iGPU utility/embed/stt disabled. This PR codifies it + makes fresh installs match. The `hal0/utility`→NPU resolver fix lands live on deploy.

## Out of scope (deferred to "stacks")
Trio code removal (`is_npu_trio_shadow`, `npu_trio.py`, shadow seeding). Re-homing embed/ASR as first-class GPU/CPU slots.

## Tests
119 passed (profile_derive, install apply, updater, seed parity/schema, slot views, flm provider); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)