### PR TITLE
fix(hermes): aux-utility follows utility role onto NPU slot (closes #827)

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -2457,6 +2457,28 @@ def _find_named_ready_slot(slots: list[dict[str, Any]], name: str) -> dict[str, 
     return None
 
 
+def _has_ready_npu_llm_slot(slots: list[dict[str, Any]]) -> bool:
+    """True if a ready ``type=='llm'`` slot reports ``device_class``/``device`` npu.
+
+    Used to detect the utility role living on the NPU slot (name ``npu``, not
+    ``utility``) when ``/api/slots`` doesn't expose ``role``. Callers then route
+    the utility aux group to the ``hal0/utility`` virtual.
+    """
+    for s in slots:
+        if not isinstance(s, dict):
+            continue
+        if (s.get("device_class") or s.get("device") or "").lower() != "npu":
+            continue
+        if (s.get("type") or "").lower() != "llm":
+            continue
+        if not _is_ready(s):
+            continue
+        if not _slot_model_id(s):
+            continue
+        return True
+    return False
+
+
 def _resolve_delegation(
     slots: list[dict[str, Any]],
     *,
@@ -2500,6 +2522,13 @@ def _resolve_auxiliary_tasks(
         tasks[task] = {"provider": "main", "model": "", "base_url": ""}
 
     utility = _find_named_ready_slot(slots, _UTILITY_SLOT_NAME)
+    # The utility role can live on a slot NOT named ``utility`` — e.g. the NPU
+    # slot (name ``npu``, ``role='utility'``) when the NPU serves utility
+    # inference. ``/api/slots`` doesn't surface ``role``, so we can't match it
+    # by name; instead, when no named utility slot exists but a ready NPU llm
+    # slot does, target the ``hal0/utility`` virtual and let the gateway resolve
+    # to it (the resolver falls back to chat if it is ever not loaded).
+    npu_utility = utility is None and _has_ready_npu_llm_slot(slots)
     for task in _UTILITY_AUX_TASKS:
         if utility is not None:
             tasks[task] = {
@@ -2507,8 +2536,14 @@ def _resolve_auxiliary_tasks(
                 "model": _slot_model_id(utility),
                 "base_url": hal0_base_url,
             }
+        elif npu_utility:
+            tasks[task] = {
+                "provider": "custom",
+                "model": "hal0/utility",
+                "base_url": hal0_base_url,
+            }
         else:
-            # Degrade safely: no utility slot → inherit the chat model.
+            # Degrade safely: no utility target → inherit the chat model.
             tasks[task] = {"provider": "main", "model": "", "base_url": ""}
     return tasks
 

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -815,6 +815,32 @@ def test_resolve_auxiliary_tasks_degrades_to_main_without_utility_slot() -> None
         assert aux[task]["model"] == ""
 
 
+def test_resolve_auxiliary_tasks_routes_to_npu_virtual_when_utility_on_npu() -> None:
+    # Utility role lives on the NPU slot (name 'npu', role not surfaced by
+    # /api/slots) and there is NO slot named 'utility'. Aux group must target
+    # the hal0/utility virtual so the gateway routes to the NPU slot.
+    slots = [
+        _ROLE_SLOTS[0],  # chat
+        {
+            "name": "npu",
+            "type": "llm",
+            "state": "ready",
+            "device_class": "npu",
+            "model_id": "gemma4-it-e2b-FLM",
+            "context_length": 18000,
+        },
+    ]
+    aux = hp._resolve_auxiliary_tasks(slots, hal0_base_url=_HAL0_V1)
+    for task in ("compression", "session_search", "title_generation", "skills_hub", "mcp"):
+        assert aux[task] == {
+            "provider": "custom",
+            "model": "hal0/utility",
+            "base_url": _HAL0_V1,
+        }
+    for task in ("vision", "web_extract"):
+        assert aux[task] == {"provider": "main", "model": "", "base_url": ""}
+
+
 def test_render_config_yaml_emits_delegation_and_auxiliary_blocks() -> None:
     yaml = pytest.importorskip("yaml")
     deleg = hp._resolve_delegation(_ROLE_SLOTS, hal0_base_url=_HAL0_V1)


### PR DESCRIPTION
Closes #827.

## Problem
After #826 the `utility` role lives on the NPU slot (name `npu`). Hermes aux routing keys off slot **name** `utility` (`_slot_alias`), which is now disabled → compaction/search/title group silently degraded to the chat model.

## Fix
`_resolve_auxiliary_tasks`: when no named `utility` slot exists but a ready `device_class=="npu"` llm slot does (`_has_ready_npu_llm_slot`), route the utility aux group to the **`hal0/utility`** virtual (gateway resolves → NPU). `/api/slots` doesn't expose `role`, so name-match can't find it and device_class is the available signal. Sending the virtual also sidesteps the FLM `-FLM`-id-vs-colon-tag issue (gateway resolves).

Unchanged: named-utility (iGPU boxes) still use the concrete model; no-target still degrades to `main`.

## Tests
95 pass (incl. new `test_resolve_auxiliary_tasks_routes_to_npu_virtual_when_utility_on_npu`); existing named-utility + degrade tests still green. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)