### PR TITLE
fix(installer): Ubuntu 26.04 / Python 3.14 install support

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -759,12 +759,12 @@ fi
 #      missing libxrt only degrades the host probe — the container image
 #      bundles its own runtime.
 #
-#   2. FLM transitive runtime libs (apt) —
-#        * libavformat60/libavcodec60/   ffmpeg6 — FLM's audio transcribe
-#          libavutil58/libswscale7/        path (Whisper-V3-Turbo on NPU)
-#          libswresample4
-#        * libboost-program-options1.83.0  FLM CLI flag parsing
-#        * libfftw3-single3              FLM signal processing
+#   2. FLM transitive runtime libs (ffmpeg for the audio-transcribe path,
+#      libboost-program-options for CLI parsing, libfftw3 for signal
+#      processing). NOT hand-installed — the per-distro .deb (3.) declares the
+#      exact versions for its release, and `apt-get install ./deb` pulls them
+#      from the host's repos. (Hardcoding the ffmpeg6 SONAMEs was the old bug:
+#      they don't exist on ffmpeg7/8 hosts like Ubuntu 25.10+/26.04.)
 #
 #   3. FastFlowLM .deb — pinned URL + SHA-256, fetched from upstream
 #      releases. Verified BEFORE dpkg install; fail-soft if unreachable
@@ -780,18 +780,50 @@ ui_step "NPU prerequisites (FastFlowLM)"
 # twice, so FLMProvider.container_spec must never repeat a mode flag
 # (--asr/--embed) the model already implies.
 FLM_DEB_VERSION="0.9.43"
-FLM_DEB_URL="https://github.com/FastFlowLM/FastFlowLM/releases/download/v${FLM_DEB_VERSION}/fastflowlm_${FLM_DEB_VERSION}_ubuntu24.04_amd64.deb"
-# SHA-256 of the upstream ubuntu24.04 artefact at v0.9.43 (verified on
-# download 2026-06-03). If upstream rebuilds under the same tag this will
-# drift; bump in lockstep with FLM_DEB_VERSION.
-FLM_DEB_SHA256="4173fa82f0043a4ff14cf7b84c7d24188fac4ac64346942601b7d2b915308479"
+# Upstream ships a SEPARATE .deb per distro, each built against that release's
+# ffmpeg/boost ABI: ubuntu24.04 (ffmpeg6/boost1.83), ubuntu25.10 + ubuntu26.04
+# (ffmpeg7/8 / boost1.90), and debian13. Pick the artefact matching THIS host
+# so `apt-get install ./deb` resolves the .deb's ffmpeg/boost/fftw deps from the
+# host's own repos — no hardcoded SONAME list, and newer Ubuntu is first-class.
+# (Older installers pinned ONLY the ubuntu24.04 build and then had to SKIP host
+# FastFlowLM on every ffmpeg>=7 distro — even though the matching build existed.)
+# SHA-256 pinned per artefact, verified on download 2026-06-15; if upstream
+# rebuilds under the same tag these drift — bump in lockstep with FLM_DEB_VERSION.
+_flm_sha_for_suffix() {
+    case "$1" in
+        ubuntu24.04) echo "4173fa82f0043a4ff14cf7b84c7d24188fac4ac64346942601b7d2b915308479" ;;
+        ubuntu25.10) echo "7ff4d9a621c94aaa8bf783c05759dcd40ca43bdb5d07c31d4ccf04946dda0b69" ;;
+        ubuntu26.04) echo "20ab2ba4f338837be2aabdf463d1369ffe56ad7f7c6a3eacd112630d983aa357" ;;
+        debian13)    echo "acad5a520165956016bdadcb4983538f24f3ada9d1e5ac591c5e9ba11c0e22d1" ;;
+    esac
+}
+# Resolve host distro -> .deb suffix. For Ubuntu, pick the HIGHEST shipped build
+# whose version is <= the host's (sort -V), so a future 26.10/27.04 still uses
+# the ffmpeg-newest ubuntu26.04 artefact rather than falling back to ffmpeg6.
+# Empty suffix => no upstream build for this host (handled as an honest skip).
+FLM_DEB_SUFFIX=""
+case "$(distro_id)" in
+    ubuntu)
+        # `|| true`: _os_release_field returns 1 on a missing field, which would
+        # abort under `set -e`; an empty version just falls through to no match.
+        _flm_host_ver="$(_os_release_field VERSION_ID 2>/dev/null || true)"
+        for _cand in 24.04 25.10 26.04; do
+            if [[ "$(printf '%s\n%s\n' "${_cand}" "${_flm_host_ver:-0}" | sort -V | head -1)" == "${_cand}" ]]; then
+                FLM_DEB_SUFFIX="ubuntu${_cand}"
+            fi
+        done
+        ;;
+    debian) FLM_DEB_SUFFIX="debian13" ;;
+esac
+FLM_DEB_SHA256="$(_flm_sha_for_suffix "${FLM_DEB_SUFFIX}")"
+FLM_DEB_URL="https://github.com/FastFlowLM/FastFlowLM/releases/download/v${FLM_DEB_VERSION}/fastflowlm_${FLM_DEB_VERSION}_${FLM_DEB_SUFFIX}_amd64.deb"
 
 if [[ "${DEV_MODE}" -eq 1 ]]; then
     # Dev installs don't touch the host's apt or third-party package
     # sources — devs install once manually (see installer/README.md).
     # We still log what *would* have happened so the dev knows the gap
     # exists for production installs.
-    info "dev mode — skipping NPU prereqs (libxrt-npu2 + ffmpeg6 + boost1.83 + fftw3 + FLM .deb v${FLM_DEB_VERSION})"
+    info "dev mode — skipping NPU prereqs (libxrt-npu2 + per-distro FastFlowLM .deb v${FLM_DEB_VERSION} + its ffmpeg/boost/fftw deps)"
     info "          install manually if exercising NPU paths: see installer/README.md"
 elif ! command -v apt-get >/dev/null 2>&1; then
     # Non-Debian host (Fedora, Arch/CachyOS, openSUSE…). FastFlowLM upstream
@@ -808,30 +840,26 @@ else
     ui_spinner_run "apt-get update (refresh package index)" \
         apt-get update -qq
 
-    # FLM host-support gate. Upstream ships ONE Ubuntu-24.04 .deb whose hard
-    # deps are the ffmpeg6-era SONAMEs (libavcodec60 …) + boost1.83. Newer
-    # Ubuntu (25.10 "resolute" onward ships ffmpeg7 = libav*62 / boost1.90), so
-    # those candidates don't exist and BOTH the runtime-libs apt call and the
-    # `.deb` install fail with a noisy `exit 100`. Probe the keystone SONAME up
-    # front: if it isn't even a known package, skip the host-FLM steps with ONE
-    # honest line instead of two scary dumps. The npu container slot bundles its
-    # own runtime, so NPU inference is unaffected — only the host `flm validate`
-    # probe is disabled. (Upstream fix = a FLM build for this release; the
-    # package-name pins can't be satisfied here regardless of what we request.)
-    if apt-cache show libavcodec60 >/dev/null 2>&1; then
+    # FLM host-support gate. Upstream now ships a per-distro .deb (ubuntu24.04 /
+    # ubuntu25.10 / ubuntu26.04 / debian13), each pinned against that release's
+    # ffmpeg/boost ABI — so the host probe works on ffmpeg6/7/8 alike. The
+    # resolution above set FLM_DEB_SUFFIX iff a matching build exists; when it
+    # didn't, skip host-FLM with ONE honest line. The npu CONTAINER slot bundles
+    # its own runtime, so NPU inference is unaffected — only the host `flm
+    # validate` probe is disabled.
+    if [[ -n "${FLM_DEB_SUFFIX}" ]]; then
         FLM_HOST_LIBS_OK=1
     else
         FLM_HOST_LIBS_OK=0
-        warn "$(distro_pretty): host FastFlowLM unsupported — upstream ships an Ubuntu-24.04 .deb (ffmpeg6/boost1.83); this release has ffmpeg7/boost1.90"
-        warn "  skipping host FLM libs + .deb. The npu container slot bundles its own runtime, so NPU inference is unaffected"
-        warn "  (only the host 'flm validate' probe is disabled). Install FastFlowLM manually if upstream ships a build for this release."
+        warn "$(distro_pretty): no matching upstream FastFlowLM .deb (builds: ubuntu 24.04/25.10/26.04, debian 13)"
+        warn "  skipping host FLM .deb. The npu container slot bundles its own runtime, so NPU inference is unaffected"
+        warn "  (only the host 'flm validate' probe is disabled). Install FastFlowLM manually if upstream ships a build for this host."
     fi
 
-    # 1. libxrt-npu2 — best-effort. Available only when the host's apt
-    #    sources carry an XRT NPU build (e.g. a pre-existing vendor repo
-    #    on upgraded boxes). The FLM container image bundles its own
-    #    runtime, so a miss here only disables the HOST `flm validate`
-    #    probe, not the npu slot itself.
+    # libxrt-npu2 — best-effort. Available only when the host's apt sources
+    # carry an XRT NPU build (e.g. a pre-existing vendor repo on upgraded
+    # boxes). The FLM container image bundles its own runtime, so a miss here
+    # only disables the HOST `flm validate` probe, not the npu slot itself.
     if apt-get install -y libxrt-npu2 >/dev/null 2>&1; then
         info "libxrt-npu2 installed (AMDXDNA NPU runtime for the host flm probe)"
     else
@@ -839,36 +867,18 @@ else
         warn "  the npu container slot bundles its own XRT runtime and is unaffected"
     fi
 
-    # 2. Runtime libs — BEST-EFFORT, same rationale as libxrt-npu2 above:
-    #    the FLM container image bundles these, so a host-side miss only
-    #    disables the HOST `flm validate` probe, not the npu slot itself.
-    #    Listed explicitly (not a metapackage) so a future libavformat ABI
-    #    bump is a visible single-line edit rather than silent drift. apt is
-    #    idempotent, so already-installed packages are a no-op.
-    #
-    #    Must NOT be fatal: a transient apt hiccup (a stale `universe` index
-    #    where these ffmpeg6 libs momentarily resolve to "no installation
-    #    candidate", a mirror flake) used to abort the entire hal0 install
-    #    here — over optional host-side NPU libs the containerized slot
-    #    doesn't even need. Warn + continue, mirroring libxrt-npu2.
-    if [[ "${FLM_HOST_LIBS_OK}" -eq 1 ]] \
-        && ui_spinner_run "Installing FLM runtime libs (ffmpeg6 + boost1.83 + fftw3)" \
-        apt-get install -y \
-            libavformat60 libavcodec60 libavutil58 libswscale7 libswresample4 \
-            libboost-program-options1.83.0 \
-            libfftw3-single3; then
-        :
-    elif [[ "${FLM_HOST_LIBS_OK}" -eq 1 ]]; then
-        warn "FLM runtime libs not fully available from configured apt sources — host 'flm validate' may fail"
-        warn "  the npu container slot bundles its own runtime and is unaffected"
-    fi
+    # NB: the FLM ffmpeg/boost/fftw runtime libs are NOT pre-installed by hand
+    # anymore — `apt-get install ./fastflowlm_*.deb` (below) pulls the exact
+    # versions THIS .deb declares from the host's repos. That's why the build
+    # must match the host distro: it's what makes the dep resolution clean on
+    # ffmpeg7/8 hosts instead of demanding the ffmpeg6 SONAMEs that don't exist.
 
     # 3. FLM .deb. Fail-soft: if upstream is unreachable or the SHA-256
     #    doesn't match, warn + skip. NPU paths gate on `flm validate`
     #    succeeding later — GPU-only hal0 still ships fine.
     FLM_DEB_TMP="/tmp/fastflowlm_${FLM_DEB_VERSION}.deb"
-    # 0 when the host-FLM gate above found this release can't satisfy the .deb's
-    # ffmpeg6/boost1.83 deps — skip download+install entirely (no noisy exit).
+    # 0 when the host-FLM gate above found no upstream .deb for this distro —
+    # skip download+install entirely (no noisy exit).
     NEED_FLM_INSTALL="${FLM_HOST_LIBS_OK}"
     if command -v dpkg-query >/dev/null 2>&1 && \
        dpkg-query -W -f='${Version}\n' fastflowlm 2>/dev/null | grep -qx "${FLM_DEB_VERSION}"; then
@@ -1131,9 +1141,21 @@ else
         mkdir -p "${HS_DIR}/hf-cache" "${HS_DIR}/.cache"
         if [[ ! -x "${HS_DIR}/.venv/bin/hindsight-api" ]]; then
             "${PY}" -m venv "${HS_DIR}/.venv"
-            "${HS_DIR}/.venv/bin/pip" install --upgrade pip wheel -q 2>/dev/null || true
-            if ! "${HS_DIR}/.venv/bin/pip" install "hindsight-api==0.7.2" -q; then
-                warn "hindsight-api install failed — memory engine will be unavailable"
+            hs_pip="${HS_DIR}/.venv/bin/pip"
+            "${hs_pip}" install --upgrade pip wheel -q 2>/dev/null || true
+            if ! "${hs_pip}" install "hindsight-api==0.7.2" -q; then
+                # Newer distros (Ubuntu 25.10+/26.04) ship Python 3.14, which
+                # litellm>=1.83.14 (a hindsight-api dep) gates out via its
+                # requires-python metadata — even though the pinned stack runs
+                # fine on 3.14 (litellm dropped the 3.14 classifier over a
+                # since-resolved fastuuid wheel gap; BerriAI/litellm#26343).
+                # Retry past the metadata gate; the hindsight-api /health poll
+                # below is the real gate on whether the engine actually came up.
+                hs_pyver="$("${HS_DIR}/.venv/bin/python" -c 'import sys;print("%d.%d"%sys.version_info[:2])' 2>/dev/null || echo '?')"
+                warn "hindsight-api hit a requires-python gate on Python ${hs_pyver}; retrying with --ignore-requires-python"
+                if ! "${hs_pip}" install --ignore-requires-python "hindsight-api==0.7.2" -q; then
+                    warn "hindsight-api install failed — memory engine will be unavailable"
+                fi
             fi
         else
             info "hindsight-api venv already present — skipping pip install"

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1423,13 +1423,16 @@ HAL0_BUNDLED_SKILLS = Path("/usr/share/hal0/skills")
 ETC_HAL0_DIR = Path("/etc/hal0")
 ETC_HAL0_AGENT_SKILLS = ETC_HAL0_DIR / "agent-skills"
 
-# STATE.md — the volatile live snapshot rewritten on every restart / model
-# swap — lives under the hal0-owned /var/lib/hal0 rather than the root-owned
+# STATE.md AND HERMES.md — the live files rewritten on every restart / model
+# swap — live under the hal0-owned /var/lib/hal0 rather than the root-owned
 # /etc/hal0 (#473): the hermes unit runs User=hal0 with ProtectSystem=strict,
-# so its ExecStartPre `render-context` can only write to paths in
-# ReadWritePaths — /var/lib/hal0 is already there, /etc/hal0 is not. HERMES.md
-# (structural, cwd-injected from /etc/hal0) and the rest of the config stay
-# under ETC_HAL0_DIR, written at provision time as root.
+# AND the runtime re-render is spawned detached from hal0-api (whose sandbox
+# also makes /etc/hal0 read-only), so the writer can only touch ReadWritePaths
+# — /var/lib/hal0 is in them, /etc/hal0 is not. HERMES.md is cwd-injected from
+# /etc/hal0, so /etc/hal0/HERMES.md is kept as a symlink to the /var/lib copy
+# (provision, running as root, maintains the link). The rest of the config
+# (AGENTS.md, MCP-CLIENTS.md, seeds) stays under ETC_HAL0_DIR, written once at
+# provision time as root.
 RUNTIME_SNAPSHOT_DIR = Path("/var/lib/hal0")
 
 
@@ -1488,6 +1491,32 @@ def _safe_symlink(target: Path, link: Path) -> bool:
     return True
 
 
+def _relink_managed(target: Path, link: Path) -> bool:
+    """Force ``link`` to be a symlink -> ``target``, atomically replacing a
+    stale regular file or a wrong symlink. Returns True when a (re)link
+    happened, False when ``link`` already points at ``target``.
+
+    Unlike :func:`_safe_symlink`, this DOES clobber a pre-existing regular
+    file — it's only used for hal0-MANAGED paths (HERMES.md) where the file
+    is ours. It exists to migrate the pre-relocation layout, where HERMES.md
+    was a real file under /etc/hal0, to the new symlink -> /var/lib/hal0 form
+    in place (so the read path /etc/hal0/HERMES.md is unchanged for consumers).
+    """
+    if link.is_symlink():
+        try:
+            if os.readlink(link) == str(target):
+                return False
+        except OSError:
+            pass
+    link.parent.mkdir(parents=True, exist_ok=True)
+    tmp = link.with_suffix(link.suffix + ".lnktmp")
+    if tmp.is_symlink() or tmp.exists():
+        tmp.unlink()
+    os.symlink(str(target), str(tmp))
+    os.replace(tmp, link)  # atomic over an existing file OR symlink
+    return True
+
+
 def _mirror_bundled_skills(src_root: Path, dst_root: Path) -> tuple[list[str], list[str]]:
     """Symlink every immediate child of ``src_root`` into ``dst_root``.
 
@@ -1515,7 +1544,7 @@ def _phase_context_link(ctx: PhaseContext) -> PhaseResult:
 
     Files rendered (atomically):
       - $HERMES_HOME/SOUL.md
-      - /etc/hal0/HERMES.md
+      - /var/lib/hal0/HERMES.md (read via the /etc/hal0/HERMES.md symlink)
       - /etc/hal0/AGENTS.md
       - $HERMES_HOME/memories/HOST.md (symlink -> /etc/hal0/HERMES.md)
 
@@ -1627,20 +1656,40 @@ def _phase_context_link(ctx: PhaseContext) -> PhaseResult:
             health_probe=ctx.io.http_get,
         )
         details["rendered"]["STATE.md"] = {"path": live["state_path"]}
+        # render_live_context writes the REAL HERMES.md under the hal0-owned
+        # RUNTIME_SNAPSHOT_DIR (so the User=hal0 runtime re-render isn't blocked
+        # by /etc/hal0 being read-only in the hal0-api spawn sandbox). Provision
+        # runs as root, so it (re)establishes /etc/hal0/HERMES.md as a symlink to
+        # that file — keeping the stable read path consumers (Hermes cwd-inject,
+        # the HOST.md mirror, the smoke test) already use. Migrates an older
+        # install where /etc/hal0/HERMES.md was a real file.
+        etc_hermes = ETC_HAL0_DIR / "HERMES.md"
+        runtime_hermes = Path(live.get("hermes_path") or (RUNTIME_SNAPSHOT_DIR / "HERMES.md"))
         details["rendered"]["HERMES.md"] = {
-            "path": str(ETC_HAL0_DIR / "HERMES.md"),
+            "path": str(etc_hermes),
             "written": live["hermes_written"],
         }
         if live["degraded"]:
             warnings.append("STATE.md rendered with daemon degraded")
         if live.get("hermes_error"):
             warnings.append(f"HERMES.md render: {live['hermes_error']}")
-        # render_live_context writes HERMES.md but not the HOST.md mirror;
-        # re-establish the symlink that the memory tier reads.
-        hpath = ETC_HAL0_DIR / "HERMES.md"
-        if hpath.exists():
+        try:
+            # Skip when the two resolve to the same file (e.g. tests that point
+            # both dirs at one tmp_path) — can't symlink a file onto itself.
+            same_file = runtime_hermes.exists() and etc_hermes.resolve() == runtime_hermes.resolve()
+            if (
+                not same_file
+                and runtime_hermes.exists()
+                and _relink_managed(runtime_hermes, etc_hermes)
+            ):
+                details["links"].append(f"{etc_hermes} -> {runtime_hermes}")
+        except OSError as exc:
+            warnings.append(f"HERMES.md /etc symlink: {exc}")
+        # The memory tier reads $HERMES_HOME/memories/HOST.md; mirror it to the
+        # stable /etc/hal0/HERMES.md read path (which now follows the symlink).
+        if etc_hermes.exists():
             host_md = hermes_home / "memories" / "HOST.md"
-            if _safe_symlink(hpath, host_md):
+            if _safe_symlink(etc_hermes, host_md):
                 details["links"].append(str(host_md))
     except Exception as exc:  # best-effort
         warnings.append(f"render_live_context: {exc}")
@@ -2171,11 +2220,14 @@ def render_live_context(
     STATE.md is content-hash gated: rewritten (and its ``_as_of`` line
     bumped) only when the substantive body changes. HERMES.md is written
     atomically (identical content => identical bytes => prompt-cache safe).
+    Both land under the hal0-writable RUNTIME_SNAPSHOT_DIR (/var/lib/hal0);
+    /etc/hal0/HERMES.md is a provision-maintained symlink to the latter, so
+    this writer never touches the read-only /etc/hal0 in its sandbox.
     Never raises on a daemon-unreachable read — leaves last-good files and
     reports ``degraded=True``.
 
     Returns: {"state_written": bool, "hermes_written": bool,
-              "degraded": bool, "state_path": str}.
+              "degraded": bool, "state_path": str, "hermes_path": str}.
     """
     fetch = slots_fetcher or _fetch_slots
     slots_all = fetch() or []
@@ -2244,6 +2296,7 @@ def render_live_context(
         "hermes_written": False,
         "degraded": degraded,
         "state_path": str(RUNTIME_SNAPSHOT_DIR / "STATE.md"),
+        "hermes_path": str(RUNTIME_SNAPSHOT_DIR / "HERMES.md"),
     }
 
     # STATE.md — content-hash gated (ignore the as_of line). Written under the
@@ -2275,6 +2328,14 @@ def render_live_context(
 
     # HERMES.md — structural map; atomic write (identical content => identical
     # bytes => prompt-cache safe). Render failure is non-fatal.
+    #
+    # Written under the hal0-owned RUNTIME_SNAPSHOT_DIR (like STATE.md, #473),
+    # NOT /etc/hal0: the runtime re-render is spawned detached from hal0-api
+    # (hermes_refresh) on a slot/model swap and inherits *that* unit's
+    # ProtectSystem=strict sandbox, where /etc/hal0 is read-only — writing it
+    # there raised the non-fatal "Read-only file system: /etc/hal0/HERMES.md.tmp"
+    # warning and silently froze HERMES.md on slot changes. /etc/hal0/HERMES.md
+    # stays the stable read path via a symlink that provision (root) maintains.
     try:
         hermes_md = _render_template(
             "HERMES.md.j2",
@@ -2289,7 +2350,8 @@ def render_live_context(
                 os.environ.get("HAL0_API_URL", "http://hal0.local:8080").rstrip("/"),
             ),
         )
-        hpath = ETC_HAL0_DIR / "HERMES.md"
+        hpath = RUNTIME_SNAPSHOT_DIR / "HERMES.md"
+        out["hermes_path"] = str(hpath)
         if not hpath.exists() or hpath.read_text(encoding="utf-8") != hermes_md:
             _atomic_write(hpath, hermes_md)
             out["hermes_written"] = True

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1396,6 +1396,11 @@ def test_context_link_renders_all_three_files(
     assert out.status == hp.PhaseStatus.OK
     assert (hermes_home / "SOUL.md").exists()
     assert (etc / "HERMES.md").exists()
+    # /etc/hal0/HERMES.md is the stable READ path but is a symlink to the
+    # hal0-writable runtime copy; the real file lives under RUNTIME_SNAPSHOT_DIR.
+    assert (etc / "HERMES.md").is_symlink()
+    assert (etc / "HERMES.md").resolve() == (tmp_path / "HERMES.md").resolve()
+    assert (tmp_path / "HERMES.md").is_file()
     assert (etc / "AGENTS.md").exists()
     soul = (hermes_home / "SOUL.md").read_text()
     # Templates reference Strix Halo signals — confirm at least one
@@ -1410,6 +1415,25 @@ def test_context_link_idempotent_symlink(tmp_path: Path) -> None:
     assert hp._safe_symlink(src, link) is True
     # Second call: no-op (target unchanged).
     assert hp._safe_symlink(src, link) is False
+
+
+def test_relink_managed_migrates_real_file_to_symlink(tmp_path: Path) -> None:
+    # Upgrade path: a pre-relocation install has a REAL /etc/hal0/HERMES.md.
+    # _relink_managed must replace it in place with a symlink to the new
+    # /var/lib copy (so the read path is unchanged for consumers).
+    target = tmp_path / "var" / "HERMES.md"
+    target.parent.mkdir()
+    target.write_text("real body\n", encoding="utf-8")
+    link = tmp_path / "etc" / "HERMES.md"
+    link.parent.mkdir()
+    link.write_text("stale real file from old install\n", encoding="utf-8")  # not a symlink
+
+    assert hp._relink_managed(target, link) is True
+    assert link.is_symlink()
+    assert link.resolve() == target.resolve()
+    assert link.read_text(encoding="utf-8") == "real body\n"
+    # Idempotent: already points at target -> no-op, no churn.
+    assert hp._relink_managed(target, link) is False
 
 
 def test_context_link_skill_mirror_warns_when_src_missing(tmp_path: Path) -> None:

--- a/tests/agents/test_hermes_state_render.py
+++ b/tests/agents/test_hermes_state_render.py
@@ -137,6 +137,61 @@ def test_render_live_context_writes_then_skips_when_unchanged(tmp_path, monkeypa
     assert "10:00:00" in (tmp_path / "STATE.md").read_text()  # as_of unchanged
 
 
+def test_render_live_context_writes_hermes_to_runtime_dir_not_etc(tmp_path, monkeypatch):
+    # HERMES.md must land in the hal0-writable RUNTIME_SNAPSHOT_DIR, never in
+    # /etc/hal0 — regression for the non-fatal "Read-only file system:
+    # /etc/hal0/HERMES.md.tmp" warning the detached hal0-api re-render raised
+    # (its sandbox makes /etc/hal0 read-only). /etc/hal0/HERMES.md is a
+    # provision-maintained symlink, so the runtime writer never touches /etc.
+    etc = tmp_path / "etc"
+    runtime = tmp_path / "var"
+    etc.mkdir()
+    runtime.mkdir()
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", etc)
+    monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", runtime)
+    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {"primary": 32768})
+    home = tmp_path / "home"
+    home.mkdir()
+    # Seed an env snapshot so HERMES.md (env.container/env.cpu) renders.
+    import json
+
+    (home / "env-1.json").write_text(
+        json.dumps(
+            {
+                "env_report": {
+                    "container": {"product_name": "hal0-test", "kind": "lxc"},
+                    "cpu": {"model": "AMD Strix Halo", "logical_online": 16},
+                    "npu": {"present": True},
+                }
+            }
+        )
+    )
+    slots = [
+        {
+            "name": "primary",
+            "type": "llm",
+            "model_id": "qwen3-25b",
+            "status": "ready",
+            "backend": "vulkan",
+        }
+    ]
+
+    r = hp.render_live_context(
+        hermes_home=home,
+        slots_fetcher=lambda: slots,
+        now_iso="2026-06-04T10:00:00+00:00",
+    )
+    assert r["hermes_written"] is True
+    assert r["hermes_path"] == str(runtime / "HERMES.md")
+    assert (runtime / "HERMES.md").exists()
+    # HERMES.md is the structural map (points at STATE.md), rendered from the
+    # env snapshot — confirm it actually rendered rather than being empty.
+    assert "STATE.md" in (runtime / "HERMES.md").read_text()
+    # The writer must NOT create anything under /etc/hal0.
+    assert not (etc / "HERMES.md").exists()
+    assert not (etc / "HERMES.md.tmp").exists()
+
+
 def test_render_live_context_degraded_when_daemon_unreachable(tmp_path, monkeypatch):
     monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
     monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)


### PR DESCRIPTION
Fresh **Ubuntu 26.04** (Python 3.14, ffmpeg8) installs hit three independent failures, plus a residual Hermes warning. All four are addressed here. Surfaced from a user's live box; their hotfixes informed the diagnosis but are replaced with proper, upstream-aligned fixes.

## ① Host FastFlowLM on newer Ubuntu — distro-aware `.deb` (official fix)
FastFlowLM **already ships a separate `.deb` per distro** — `ubuntu24.04`, `ubuntu25.10`, `ubuntu26.04`, `debian13` — each built against that release's ffmpeg/boost ABI. The installer hardcoded only the `ubuntu24.04` build (ffmpeg6 SONAMEs) and then *skipped* host-FLM on every ffmpeg≥7 distro, even though the matching build existed.

- Resolve the `.deb` to the host distro (Ubuntu: highest shipped ≤ host via `sort -V`; Debian → `debian13`).
- Pin per-distro SHA-256 (the `ubuntu24.04` pin is unchanged — validates the others).
- Drop the hardcoded ffmpeg6 SONAME pre-install; `apt-get install ./deb` pulls the correct ffmpeg/boost/fftw from the host's repos.
- `flm validate` now works on Ubuntu 26.04 via the **official** build, not a force-install.

Non-Ubuntu/Debian hosts still get the honest "no matching upstream build → host probe skipped, NPU container unaffected" line.

## ② Hindsight memory engine on Python 3.14
`hindsight-api==0.7.2` → `litellm>=1.83.14`, whose `requires-python` metadata rejects 3.14 (litellm dropped the 3.14 classifier over a since-resolved `fastuuid` wheel gap — BerriAI/litellm#26343). The venv install failed and memory went dark.

- Retry the venv install with `--ignore-requires-python` when the first pass hits the gate; the existing `/health` poll remains the real success gate. Verified running on Ubuntu 26.04.

## ③ Hermes `HERMES.md.tmp` read-only warning (runtime path)
`render_live_context` re-renders HERMES.md on a slot/model swap, **spawned detached from `hal0-api`** whose `ProtectSystem=strict` sandbox makes `/etc/hal0` read-only → non-fatal `Read-only file system: /etc/hal0/HERMES.md.tmp`, and HERMES.md silently froze on slot changes.

- Relocate the write to the hal0-owned `/var/lib/hal0` (like STATE.md, #473); `/etc/hal0/HERMES.md` becomes a provision-maintained **symlink**, so the read path is unchanged for consumers (Hermes cwd-inject, HOST.md mirror, the smoke test). Migrates an older install's real file in place.
- Covers **both** the `ExecStartPre` and the detached-runtime spawn contexts — a `+ExecStartPre` root-escalation would only cover the former (and run the whole render as root).

## Also note (not in this PR)
The **`python3.12` hardcode in the hermes drop-in** that some boxes hit is already fixed on `main` by #824 (the shim resolves the web-dist at runtime); affected boxes are on pre-#824 **v0.5.0-alpha.1**. The action there is cutting **v0.5.0-alpha.2** so these merged fixes actually ship.

## Tests
- New regression tests: HERMES.md writes to `RUNTIME_SNAPSHOT_DIR` not `/etc/hal0`; `/etc/hal0/HERMES.md` is a symlink into the runtime dir; `_relink_managed` migrates a pre-existing real file.
- Full hermes provision / state-render / wrapper / systemd suites pass (**153**).
- `installer/install.sh`: `bash -n` + `shellcheck -S error` clean; distro→`.deb` resolution unit-simulated across 24.04/24.10/25.04/25.10/26.04/26.10/27.04/debian13/fedora/arch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)