### PR TITLE
feat(profiles): split MTP rocm profiles into rocm-moe + rocm-dnse, default KV q4_0

### DIFF
--- a/installer/etc-hal0/profiles.toml
+++ b/installer/etc-hal0/profiles.toml
@@ -20,15 +20,24 @@ backend      = "rocm"
 intent       = "MoE agents"
 quant        = "FP4"
 
-[profile.rocm-mtp]
-# ROCm + MTP draft speculation (dense chat, qwopus 27B). ~24.4 tok/s (~2x non-MTP).
-# mtp=true expands to the full --spec-type draft-mtp bundle at resolve time.
+[profile.rocm-dnse]
+# ROCm + MTP draft-mtp, q4 KV (dense chat, qwopus 27B). ~30.4 tok/s.
 image        = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server"
-flags        = "-fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap"
+flags        = "-fa on -ctk q4_0 -ctv q4_0 -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap"
 mtp          = true
 device_class = "gpu"
 backend      = "rocm"
-intent       = "Dense chat + MTP"
+intent       = "Dense + MTP · q4 KV"
+quant        = "FP4"
+
+[profile.rocm-moe]
+# ROCm + MTP draft-mtp for MoE (ace-saber 35B-A3B), q4 KV, 16 threads + jinja. ~90 tok/s.
+image        = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server"
+flags        = "-fa on -ctk q4_0 -ctv q4_0 -b 512 -ub 512 --parallel 1 --threads 16 --no-mmap --jinja"
+mtp          = true
+device_class = "gpu"
+backend      = "rocm"
+intent       = "MoE + MTP · q4 KV"
 quant        = "FP4"
 
 [profile.vulkan]

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -717,13 +717,22 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "intent": "MoE agents",
         "quant": "FP4",
     },
-    "rocm-mtp": {
+    "rocm-dnse": {
         "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
-        "flags": "-fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap",
+        "flags": "-fa on -ctk q4_0 -ctv q4_0 -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap",
         "mtp": True,
         "device_class": "gpu",
         "backend": "rocm",
-        "intent": "Dense chat + MTP",
+        "intent": "Dense + MTP · q4 KV",
+        "quant": "FP4",
+    },
+    "rocm-moe": {
+        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
+        "flags": "-fa on -ctk q4_0 -ctv q4_0 -b 512 -ub 512 --parallel 1 --threads 16 --no-mmap --jinja",
+        "mtp": True,
+        "device_class": "gpu",
+        "backend": "rocm",
+        "intent": "MoE + MTP · q4 KV",
         "quant": "FP4",
     },
     "vulkan": {
@@ -767,7 +776,8 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
 #: profiles have no entry → the card shows "—" until benched.
 PROFILE_BENCH: dict[str, dict[str, float]] = {
     "rocm": {"tps": 52.8},
-    "rocm-mtp": {"tps": 24.4},
+    "rocm-moe": {"tps": 90.0},
+    "rocm-dnse": {"tps": 30.4},
     "vulkan": {"tps": 41.0},
     "flm": {"tps": 38.6},
     "tts": {"rtf": 0.18},

--- a/src/hal0/install/profile_derive.py
+++ b/src/hal0/install/profile_derive.py
@@ -6,7 +6,7 @@ embed/aux take the plain GPU profile. NPU lanes are selected only when the
 NPU is present AND the operator opted in.
 
 The (device, profile) pairs this produces are backend-coherent per #807:
-``gpu-rocm``→``rocm``/``rocm-mtp`` (backend rocm), ``gpu-vulkan``→``vulkan``,
+``gpu-rocm``→``rocm``/``rocm-dnse`` (backend rocm), ``gpu-vulkan``→``vulkan``,
 ``npu``→``flm``, ``cpu``→``tts``/``vulkan``.
 """
 
@@ -94,7 +94,7 @@ def derive_profile(capability: str, device: str) -> str:
         return "flm"
     if device == "gpu-rocm":
         # Dense chat/coder benefit from MTP; embed + others take plain rocm.
-        return "rocm-mtp" if capability in ("chat", "coder") else "rocm"
+        return "rocm-dnse" if capability in ("chat", "coder") else "rocm"
     if device == "gpu-vulkan":
         return "vulkan"
     if device == "cpu":

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1535,7 +1535,7 @@ class SlotManager:
         _normalize_ctx_key(cfg_dict)
         # Reject (or normalize) an incoherent device/profile backend pairing
         # before it ever lands on disk — the door the dashboard left open for
-        # the utility slot (vulkan device + rocm-mtp profile). Every field is
+        # the utility slot (vulkan device + rocm-dnse profile). Every field is
         # "new" at create time, so a conflicting device+profile is an explicit
         # operator error and raises.
         _reconcile_device_profile(cfg_dict, set(cfg_dict.keys()))
@@ -1633,7 +1633,7 @@ class SlotManager:
 
         # Keep device↔profile backend coherent: a profile switch re-derives
         # device (the drawer path that previously left a vulkan device under a
-        # rocm-mtp profile), a cross-backend device flip re-points the profile
+        # rocm-dnse profile), a cross-backend device flip re-points the profile
         # (the POST /backend path, which writes device only), and an explicit
         # conflicting pair raises. Only the field(s) the caller changed drive
         # reconciliation.
@@ -2453,7 +2453,7 @@ def _reconcile_device_profile(cfg_dict: dict[str, Any], changed: set[str]) -> No
     A GPU slot implies its backend twice: ``device`` (``gpu-rocm`` /
     ``gpu-vulkan``) drives the llama-server backend, while ``profile`` selects
     the container image + flags. They must agree — a vulkan device under a
-    rocm-mtp profile launches a Vulkan binary with ROCm-only MTP draft flags
+    rocm-dnse profile launches a Vulkan binary with ROCm-only MTP draft flags
     (issue: utility slot). The field the operator changed wins; the stale side
     is re-derived. Both changed to conflicting backends → operator error.
 

--- a/tests/api/test_install_apply.py
+++ b/tests/api/test_install_apply.py
@@ -46,13 +46,13 @@ def test_build_slot_cfg_sets_device_profile_model():
         slot="chat",
         model_id="qwen3.6-27b",
         device="gpu-rocm",
-        profile="rocm-mtp",
+        profile="rocm-dnse",
         port=8081,
         context_size=32768,
     )
     assert cfg["name"] == "chat"
     assert cfg["device"] == "gpu-rocm"
-    assert cfg["profile"] == "rocm-mtp"
+    assert cfg["profile"] == "rocm-dnse"
     assert cfg["enabled"] is True
     assert cfg["model"]["default"] == "qwen3.6-27b"
     assert cfg["model"]["context_size"] == 32768
@@ -107,7 +107,7 @@ def test_apply_seeds_jobs_and_creates_slots(isolated_app_client, tmp_hal0_home, 
     # The default tier's primary is a curated chat model → a job + slot exist.
     assert "qwen3.5-9b" in body["model_ids"]
     chat = next(s for s in body["slots"] if s["slot"] == "chat")
-    assert chat["profile"] in ("rocm-mtp", "vulkan")
+    assert chat["profile"] in ("rocm-dnse", "vulkan")
     assert chat["created"] is True
     # Slot TOML written OFFLINE (not started).
     toml = Path(tmp_hal0_home) / "etc" / "hal0" / "slots" / "chat.toml"
@@ -142,7 +142,7 @@ def test_apply_honors_per_slot_override(isolated_app_client, tmp_hal0_home, monk
             "storage_dir": tmp_hal0_home,
             "npu_opt_in": False,
             # Override chat: a different curated model + the vulkan profile/device
-            # (coherent pair) instead of the auto-derived rocm-mtp.
+            # (coherent pair) instead of the auto-derived rocm-dnse.
             "overrides": {
                 "chat": {"model_id": "qwen3.6-27b", "profile": "vulkan", "device": "gpu-vulkan"}
             },

--- a/tests/api/test_profiles_route.py
+++ b/tests/api/test_profiles_route.py
@@ -42,10 +42,10 @@ class TestListProfiles:
         assert isinstance(data, list)
 
     def test_returns_seed_profiles(self, client: TestClient) -> None:
-        """One entry per seed profile (6 as of Phase D: comfyui joined)."""
+        """One entry per seed profile (7: rocm-moe + rocm-dnse split, Phase D comfyui)."""
         data = client.get("/api/profiles").json()
         assert len(data) == len(SEED_PROFILES)
-        assert len(data) == 6
+        assert len(data) == 7
 
     def test_flm_npu_seed_present(self, client: TestClient) -> None:
         """Phase A added the flm container profile to the seeds."""
@@ -97,7 +97,7 @@ class TestListProfiles:
         data = client.get("/api/profiles").json()
         by_name = {item["name"]: item for item in data}
         assert by_name["rocm"]["backend"] == "rocm"
-        assert by_name["rocm-mtp"]["backend"] == "rocm"
+        assert by_name["rocm-dnse"]["backend"] == "rocm"
         assert by_name["vulkan"]["backend"] == "vulkan"
         assert by_name["flm"]["backend"] is None
         assert by_name["tts"]["backend"] is None
@@ -110,7 +110,7 @@ class TestListProfiles:
 
     def test_dense_mtp_rocmfp4_mtp_true(self, client: TestClient) -> None:
         data = client.get("/api/profiles").json()
-        dense = next(item for item in data if item["name"] == "rocm-mtp")
+        dense = next(item for item in data if item["name"] == "rocm-dnse")
         assert dense["mtp"] is True
 
     def test_vulkan_std_image_contains_vulkan(self, client: TestClient) -> None:
@@ -120,12 +120,12 @@ class TestListProfiles:
 
     def test_mtp_true_resolved_flags_contains_spec_type(self, client: TestClient) -> None:
         data = client.get("/api/profiles").json()
-        dense = next(item for item in data if item["name"] == "rocm-mtp")
+        dense = next(item for item in data if item["name"] == "rocm-dnse")
         assert "--spec-type draft-mtp" in dense["resolved_flags"]
 
     def test_mtp_true_resolved_flags_contains_bundle(self, client: TestClient) -> None:
         data = client.get("/api/profiles").json()
-        dense = next(item for item in data if item["name"] == "rocm-mtp")
+        dense = next(item for item in data if item["name"] == "rocm-dnse")
         assert MTP_FLAG_BUNDLE in dense["resolved_flags"]
 
     def test_mtp_false_resolved_flags_no_spec_type(self, client: TestClient) -> None:

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -1585,7 +1585,7 @@ def test_config_profile_change_drives_device_via_route(
 ) -> None:
     """PUT /config with a new profile re-derives device (drawer path).
 
-    Re-points a vulkan slot at the rocm-mtp profile; the device must follow
+    Re-points a vulkan slot at the rocm-dnse profile; the device must follow
     to gpu-rocm so the slot no longer reports vulkan under a ROCm profile.
     """
     _seed_slot_toml(
@@ -1604,11 +1604,11 @@ def test_config_profile_change_drives_device_via_route(
         ],
     )
 
-    r = isolated_client.put("/api/slots/utility/config", json={"profile": "rocm-mtp"})
+    r = isolated_client.put("/api/slots/utility/config", json={"profile": "rocm-dnse"})
     assert r.status_code == 200, r.text
 
     cfg = isolated_client.get("/api/slots/utility/config").json()
-    assert cfg["profile"] == "rocm-mtp"
+    assert cfg["profile"] == "rocm-dnse"
     assert cfg["device"] == "gpu-rocm"
 
 
@@ -1619,8 +1619,8 @@ def test_backend_flip_reconciles_profile_via_route(
 ) -> None:
     """POST /backend (writes device only) re-points an incompatible profile.
 
-    Flipping a rocm-mtp slot to the vulkan backend must drop the rocm-only
-    profile rather than persist a vulkan device under rocm-mtp.
+    Flipping a rocm-dnse slot to the vulkan backend must drop the rocm-only
+    profile rather than persist a vulkan device under rocm-dnse.
     """
     _seed_slot_toml(
         tmp_hal0_home,
@@ -1631,7 +1631,7 @@ def test_backend_flip_reconciles_profile_via_route(
             'device = "gpu-rocm"',
             'provider = "llama-server"',
             'runtime = "container"',
-            'profile = "rocm-mtp"',
+            'profile = "rocm-dnse"',
             "enabled = true",
             "[model]",
             'default = "m"',

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -154,12 +154,12 @@ class TestLoadProfilesConfig:
 
     def test_seed_count(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
-        assert len(cfg.profile) == 6  # rocm, rocm-mtp, vulkan, flm, tts, comfyui
+        assert len(cfg.profile) == 7  # rocm, rocm-dnse, rocm-moe, vulkan, flm, tts, comfyui
 
     def test_seed_profiles_have_correct_names(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
         assert "rocm" in cfg.profile
-        assert "rocm-mtp" in cfg.profile
+        assert "rocm-dnse" in cfg.profile
         assert "vulkan" in cfg.profile
 
     def test_seed_rocm_mtp_false(self, tmp_path: Path) -> None:
@@ -168,7 +168,7 @@ class TestLoadProfilesConfig:
 
     def test_seed_rocm_mtp_mtp_true(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
-        assert cfg.profile["rocm-mtp"].mtp is True
+        assert cfg.profile["rocm-dnse"].mtp is True
 
     def test_seed_vulkan_correct_image(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
@@ -177,7 +177,7 @@ class TestLoadProfilesConfig:
     def test_seed_gpu_profiles_have_backend(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
         assert cfg.profile["rocm"].backend == "rocm"
-        assert cfg.profile["rocm-mtp"].backend == "rocm"
+        assert cfg.profile["rocm-dnse"].backend == "rocm"
         assert cfg.profile["vulkan"].backend == "vulkan"
         assert cfg.profile["flm"].backend is None
         assert cfg.profile["tts"].backend is None
@@ -274,7 +274,7 @@ def test_profile_device_class_defaults_gpu() -> None:
 def test_seed_device_classes() -> None:
     assert SEED_PROFILES["vulkan"]["device_class"] == "gpu"
     assert SEED_PROFILES["rocm"]["device_class"] == "gpu"
-    assert SEED_PROFILES["rocm-mtp"]["device_class"] == "gpu"
+    assert SEED_PROFILES["rocm-dnse"]["device_class"] == "gpu"
     assert SEED_PROFILES["flm"]["device_class"] == "npu"
     assert SEED_PROFILES["tts"]["device_class"] == "cpu"
     assert SEED_PROFILES["comfyui"]["device_class"] == "img"
@@ -282,7 +282,7 @@ def test_seed_device_classes() -> None:
 
 def test_seed_backends() -> None:
     assert SEED_PROFILES["rocm"]["backend"] == "rocm"
-    assert SEED_PROFILES["rocm-mtp"]["backend"] == "rocm"
+    assert SEED_PROFILES["rocm-dnse"]["backend"] == "rocm"
     assert SEED_PROFILES["vulkan"]["backend"] == "vulkan"
     # non-GPU profiles carry no backend (device_class drives display)
     assert SEED_PROFILES["flm"].get("backend") is None

--- a/tests/install/test_profile_derive.py
+++ b/tests/install/test_profile_derive.py
@@ -34,7 +34,7 @@ def _hw(*, platform="bare-metal-amd-gpu", compute=True, vulkan=True, npu=False):
 def test_chat_on_rocm_box_picks_rocm_mtp():
     hw = _hw(compute=True)
     assert derive_device("chat", hw, npu_opt_in=False) == "gpu-rocm"
-    assert derive_profile("chat", "gpu-rocm") == "rocm-mtp"
+    assert derive_profile("chat", "gpu-rocm") == "rocm-dnse"
 
 
 def test_chat_on_vulkan_only_box_picks_vulkan():

--- a/tests/profiles/test_catalog.py
+++ b/tests/profiles/test_catalog.py
@@ -20,7 +20,7 @@ def test_resolve_seed_profile_includes_runtime_facts(tmp_hal0_home: str) -> None
 def test_resolve_exposes_backend(tmp_hal0_home: str) -> None:
     catalog = ProfileCatalog()
     assert catalog.resolve("rocm").backend == "rocm"
-    assert catalog.resolve("rocm-mtp").backend == "rocm"
+    assert catalog.resolve("rocm-dnse").backend == "rocm"
     assert catalog.resolve("vulkan").backend == "vulkan"
     # non-GPU seeds carry no backend
     assert catalog.resolve("flm").backend is None
@@ -111,7 +111,7 @@ def test_cloned_from_defaults_to_none_and_survives_update(tmp_hal0_home: str) ->
 def test_seed_bench_metrics_exposed(tmp_hal0_home: str) -> None:
     by_name = {p.name: p for p in ProfileCatalog().list()}
     assert by_name["rocm"].tps == 52.8
-    assert by_name["rocm-mtp"].tps == 24.4
+    assert by_name["rocm-dnse"].tps == 30.4
     # TTS is synth — reported as a real-time factor, not tok/s.
     assert by_name["tts"].tps is None
     assert by_name["tts"].rtf == 0.18

--- a/tests/slots/test_device_profile_coherence.py
+++ b/tests/slots/test_device_profile_coherence.py
@@ -5,7 +5,7 @@ A GPU slot carries two fields that each imply a backend: ``device``
 (the ProfileConfig, whose ``backend`` selects the container image + flags).
 Before this guard they could diverge silently: the dashboard set the
 ``utility`` slot's ``device`` to ``gpu-vulkan`` while leaving its
-``profile`` at ``rocm-mtp``, so the slot reported ``backend=vulkan`` yet
+``profile`` at ``rocm-dnse``, so the slot reported ``backend=vulkan`` yet
 resolved the ROCm image + ROCm-only MTP draft flags — and re-picking the
 profile in the drawer never corrected the device.
 
@@ -41,17 +41,17 @@ def _gpu_cfg(name: str, *, device: str, profile: str, model: str = "m") -> dict:
 async def test_profile_change_drives_device(tmp_hal0_home: str) -> None:
     """Switching the profile re-derives device — the exact utility-slot bug.
 
-    A vulkan slot re-pointed at the rocm-mtp profile must end up on
+    A vulkan slot re-pointed at the rocm-dnse profile must end up on
     ``device=gpu-rocm``; otherwise the drawer 'changes' the profile but the
     backend stays vulkan forever.
     """
     sm = SlotManager()
     await sm.create("util", _gpu_cfg("util", device="gpu-vulkan", profile="vulkan"))
 
-    await sm.update_config("util", {"profile": "rocm-mtp"})
+    await sm.update_config("util", {"profile": "rocm-dnse"})
 
     cfg = await sm.get_config("util")
-    assert cfg["profile"] == "rocm-mtp"
+    assert cfg["profile"] == "rocm-dnse"
     assert cfg["device"] == "gpu-rocm"
 
 
@@ -60,10 +60,10 @@ async def test_device_change_reconciles_conflicting_profile(tmp_hal0_home: str) 
 
     The ``POST /api/slots/{name}/backend`` control writes only ``device``;
     a cross-backend flip must reconcile the profile to a compatible one so
-    no rocm-mtp+vulkan pair is ever persisted.
+    no rocm-dnse+vulkan pair is ever persisted.
     """
     sm = SlotManager()
-    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm-mtp"))
+    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm-dnse"))
 
     await sm.update_config("util", {"device": "gpu-vulkan"})
 
@@ -75,23 +75,23 @@ async def test_device_change_reconciles_conflicting_profile(tmp_hal0_home: str) 
 async def test_unrelated_update_preserves_coherent_pair(tmp_hal0_home: str) -> None:
     """A change that touches neither device nor profile leaves both intact."""
     sm = SlotManager()
-    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm-mtp"))
+    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm-dnse"))
 
     await sm.update_config("util", {"model": {"context_size": 32768}})
 
     cfg = await sm.get_config("util")
     assert cfg["device"] == "gpu-rocm"
-    assert cfg["profile"] == "rocm-mtp"
+    assert cfg["profile"] == "rocm-dnse"
     assert cfg["model"]["context_size"] == 32768
 
 
 async def test_explicit_contradiction_rejected(tmp_hal0_home: str) -> None:
     """Changing both fields to conflicting backends is an operator error."""
     sm = SlotManager()
-    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm-mtp"))
+    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm-dnse"))
 
     with pytest.raises(SlotConfigError, match=r"(?i)backend"):
-        await sm.update_config("util", {"profile": "rocm-mtp", "device": "gpu-vulkan"})
+        await sm.update_config("util", {"profile": "rocm-dnse", "device": "gpu-vulkan"})
 
 
 async def test_create_rejects_incoherent_pair(tmp_hal0_home: str) -> None:
@@ -102,7 +102,7 @@ async def test_create_rejects_incoherent_pair(tmp_hal0_home: str) -> None:
     """
     sm = SlotManager()
     with pytest.raises(SlotConfigError, match=r"(?i)backend"):
-        await sm.create("util", _gpu_cfg("util", device="gpu-vulkan", profile="rocm-mtp"))
+        await sm.create("util", _gpu_cfg("util", device="gpu-vulkan", profile="rocm-dnse"))
 
 
 async def test_non_gpu_profile_untouched(tmp_hal0_home: str) -> None:


### PR DESCRIPTION
## What
Split the single `rocm-mtp` MTP profile into two workload-scoped profiles and make `q4_0` KV cache the default for both:

| profile | for | key flags |
|---|---|---|
| `rocm-moe` | MoE (ace-saber 35B-A3B) | q4 KV, threads 16, `--jinja`, `draft-mtp` |
| `rocm-dnse` | dense (qwopus 27B) | q4 KV, threads 8, `draft-mtp` |

## Why
Bench sweep on the rocmfp4 serving image (Strix Halo), measured before/after on the agent (AceSaber 35B-A3B) and chat (Qwopus 27B) slots:

- **q4_0 main-model KV**: +7% TG (MoE long-ctx) / +10% (dense 27B), and halves KV memory vs q8_0. The MTP draft-head KV was already q4_0.
- Everything kryoz-`llama.ini`-style (batch/ubatch 1024–4096, `--mlock`, `-dio`, `p-split 0.45`, stacked `ngram-map-k`) **regressed or netted zero** on this FP4 fork. `ngram-map-k` raised spec acceptance 73.5→85.8% but cost ~7% wall-clock TG. Base flags stay at the proven `-b 512 -ub 512`.

## Changes
- `schema.py`: `SEED_PROFILES` `rocm-mtp` → `rocm-dnse` (q4) + new `rocm-moe`; `PROFILE_BENCH` 30.4 / 90.0
- `profile_derive.py`: chat/coder → `rocm-dnse`
- `installer/etc-hal0/profiles.toml`: seed kept in parity (guard test)
- tests updated for rename + added profile (131 affected tests green, ruff clean)

## Deploy note
Already applied **live on CT105** (slot repoint: agent→rocm-moe, chat/utility→rocm-dnse; all 3 verified healthy on q4). This PR makes it the shipped default so a deploy/regen won't revert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
