### PR TITLE
fix(release): cosign identity is release.yml@<caller-ref>, not github.workflow_ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,11 +239,14 @@ jobs:
           # manifest below — keep these two strings in lock-step.
           # github.repository preserves case (Hal0ai/hal0); use (?i) to
           # absorb the lowercase `hal0ai` redirect form too.
-          # The Fulcio cert SAN is the ENTRY-POINT workflow ref: release.yml@<tag>
-          # on a direct tag push, or nightly.yml@refs/heads/main when invoked as
-          # a reusable workflow. github.workflow_ref gives exactly that, so the
-          # verify identity is correct in both modes (and matches the manifest).
-          IDENT="^(?i)https://github\\.com/${{ github.workflow_ref }}$"
+          # The Fulcio cert SAN is the workflow that OWNS the signing job
+          # (release.yml — the job_workflow_ref) at the CALLER's ref:
+          # release.yml@refs/tags/vX on a direct tag push, or
+          # release.yml@refs/heads/main when invoked via workflow_call from
+          # nightly.yml. github.ref is the caller's ref in BOTH cases — NOT
+          # github.workflow_ref, which is the entry-point (nightly.yml) and
+          # does NOT match the cert SAN under workflow_call.
+          IDENT="^(?i)https://github\\.com/${{ github.repository }}/\\.github/workflows/release\\.yml@${{ github.ref }}$"
           ISSUER="https://token.actions.githubusercontent.com"
           cosign verify-blob \
               --signature "${SIG}" \
@@ -266,9 +269,9 @@ jobs:
           MANIFEST_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/${CHANNEL}.json"
 
           # Must match the Self-verify identity above (and the cert SAN) so the
-          # updater's cosign verify-blob succeeds. Derived from the entry-point
-          # workflow ref to stay correct under workflow_call (nightly).
-          IDENT="^(?i)https://github\\.com/${{ github.workflow_ref }}$"
+          # updater's cosign verify-blob succeeds. release.yml@<caller-ref> via
+          # github.ref — correct for both tag-push and workflow_call (nightly).
+          IDENT="^(?i)https://github\\.com/${{ github.repository }}/\\.github/workflows/release\\.yml@${{ github.ref }}$"
 
           python3 - "${OUT}" "${VERSION}" "${TAG}" "${CHANNEL}" "${DIGEST}" \
                    "${BASE_URL}" "${MANIFEST_URL}" "${IDENT}" <<'PY'


### PR DESCRIPTION
## Fix for the nightly smoke failure (follow-up to #830)

The first real nightly build (`gh workflow run nightly.yml -f force=true`) tagged fine but the called `release.yml` **failed at self-verify**:

```
none of the expected identities matched what was in the certificate,
got subjects [https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/heads/main]
```

**Root cause:** I assumed the cosign Fulcio cert SAN under `workflow_call` follows the *entry-point* workflow (`nightly.yml`, what `${{ github.workflow_ref }}` returns). It does not — the SAN is the workflow that **owns the signing job** (`release.yml`, the `job_workflow_ref`) at the **caller's ref**, i.e. `release.yml@refs/heads/main` for the scheduled nightly.

**Fix:** both IDENT lines (self-verify + manifest) now use
`release.yml@${{ github.ref }}`. `github.ref` is the caller's ref in **both** modes — `refs/tags/vX` on a direct stable tag push, `refs/heads/main` under `workflow_call` from nightly — so the verify identity matches the cert SAN and the manifest's `signer_identity` in both cases. (This is the original self-verify expression; #830's mistake was switching it to `github.workflow_ref` and only "fixing" the manifest to match the wrong value.)

**No bad release shipped** — `release.yml`'s self-verify gate failed closed, exactly as intended. The dangling `v0.5.0-nightly.20260615` tag (no GH release attached) has been deleted; the post-merge smoke will recreate it.

## Validation plan after merge
`gh workflow run nightly.yml -f force=true` once `main` CI is green → expect the called `release.yml` to pass self-verify, publish a `prerelease:true / not-latest` release with `tarball/.sig/.crt/nightly.json`, and `HAL0_RELEASES_URL=<nightly.json> hal0 update --check` to report the nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)