### PR TITLE
fix(routing): translate FLM `<tag>-FLM` ids to served tags in chat-slot rewrite

### DIFF
--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -203,27 +203,53 @@ async def _rewrite_chat_slot_alias(request: Request, body: dict[str, Any]) -> di
         downstream consumer that re-reads ``request.body()`` verbatim
         forwards the rewritten model name rather than the bare alias.
 
-    No-op when: the model isn't a known chat-slot alias, equals its own
-    model id already, the slot manager is absent, or the config read
-    raises (best-effort — never blocks the request).
+    FLM-backed slots get a second translation step: the alias resolves to the
+    hal0 ``<tag>-FLM`` catalog id (``gemma4-it-e2b-FLM``), but ``flm serve``
+    advertises only the native ``family:size`` tag (``gemma4-it:e2b``). Routing
+    keys off the advertised set, so an un-translated ``-FLM`` id — reached via
+    the ``npu`` alias OR requested directly by a consumer pinned to the catalog
+    id — matches no upstream and 404s with ``dispatch.no_route``. We normalise
+    it to the served tag here, mirroring ``SlotManager._resolve_model_info``.
+
+    No-op when: the model isn't a known chat-slot alias and isn't a ``-FLM``
+    id, already equals its served name, the slot manager is absent, or the
+    config read raises (best-effort — never blocks the request).
     """
     raw_model = body.get("model")
     if not isinstance(raw_model, str) or not raw_model:
         return body
+
+    # Step 1: alias → configured model id (co-resident chat slots). Skipped
+    # when the slot manager is absent; a direct model id still flows on.
+    target = raw_model
     slot_manager = getattr(request.app.state, "slot_manager", None)
-    if slot_manager is None:
-        return body
-    from hal0.api import hal0_chat_slot_alias_map
+    if slot_manager is not None:
+        from hal0.api import hal0_chat_slot_alias_map
 
-    try:
-        alias_to_model = await hal0_chat_slot_alias_map(slot_manager)
-    except Exception:
-        return body
-    mapped = alias_to_model.get(raw_model)
-    if not mapped or mapped == raw_model:
+        try:
+            alias_to_model = await hal0_chat_slot_alias_map(slot_manager)
+        except Exception:
+            alias_to_model = {}
+        target = alias_to_model.get(raw_model) or raw_model
+
+    # Step 2: FLM catalog id → native served tag (gemma4-it-e2b-FLM →
+    # gemma4-it:e2b). Independent of the slot manager — a directly-requested
+    # -FLM id normalises too. Only fires on the ``-FLM`` suffix, so non-FLM
+    # requests never pay the catalog probe.
+    if target.endswith("-FLM"):
+        try:
+            from hal0.providers.flm import flm_id_to_tag
+        except ImportError:
+            flm_id_to_tag = None  # type: ignore[assignment]
+        if flm_id_to_tag is not None:
+            tag = flm_id_to_tag(target)
+            if tag:
+                target = tag
+
+    if target == raw_model:
         return body
 
-    new_body = {**body, "model": mapped}
+    new_body = {**body, "model": target}
     # Overwrite the cached request body so downstream consumers that
     # re-read request.body() see the rewritten model name. If we can't
     # (unexpected request shape), still return the rewritten dict — the

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -97,11 +97,7 @@ def _instrument_streaming_throughput(
     """
     original = response.body_iterator
     events = _slot_events(app_state, slot_name)
-    ttft_events = (
-        _slot_ttft_events(app_state, slot_name)
-        if dispatch_started is not None
-        else None
-    )
+    ttft_events = _slot_ttft_events(app_state, slot_name) if dispatch_started is not None else None
     if events is None and ttft_events is None:
         return response
     ttft_pending = ttft_events is not None  # one-shot per response
@@ -119,11 +115,7 @@ def _instrument_streaming_throughput(
                 now = time.monotonic()
                 if events is not None:
                     events.append((now, tokens))
-                if (
-                    ttft_pending
-                    and ttft_events is not None
-                    and dispatch_started is not None
-                ):
+                if ttft_pending and ttft_events is not None and dispatch_started is not None:
                     ttft_events.append((now, max(0.0, now - dispatch_started)))
                     ttft_pending = False
             yield chunk
@@ -193,9 +185,7 @@ async def _read_json_body(request: Request) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
-async def _rewrite_chat_slot_alias(
-    request: Request, body: dict[str, Any]
-) -> dict[str, Any]:
+async def _rewrite_chat_slot_alias(request: Request, body: dict[str, Any]) -> dict[str, Any]:
     """Translate a chat-slot ALIAS in ``body["model"]`` to its model id.
 
     hermes-role-slots: a request may address a co-resident chat slot by
@@ -287,9 +277,7 @@ def _normalize_loaded_models(request: Request) -> set[str]:
     if upstreams is not None and model_cache is not None:
         with contextlib.suppress(Exception):
             for up in upstreams.list():
-                if getattr(up, "kind", "") == "remote" and getattr(
-                    up, "slot_name", None
-                ):
+                if getattr(up, "kind", "") == "remote" and getattr(up, "slot_name", None):
                     loaded |= set(model_cache.get(up.name, []))
     return loaded
 
@@ -303,9 +291,7 @@ async def _normalize_slot_views(request: Request) -> list:
     sm = getattr(request.app.state, "slot_manager", None)
     if sm is None:
         return []
-    rows = await hal0_llm_slot_views(
-        sm, getattr(request.app.state, "model_registry", None)
-    )
+    rows = await hal0_llm_slot_views(sm, getattr(request.app.state, "model_registry", None))
     return [
         SlotView(
             name=r["name"],
@@ -330,9 +316,7 @@ def _is_remote_model(request: Request, model_id: str) -> bool:
             # not genuine external providers, so the thinking policy must apply.
             if getattr(u, "slot_name", None):
                 continue
-            if getattr(u, "kind", "") == "remote" and model_id in set(
-                cache.get(u.name, [])
-            ):
+            if getattr(u, "kind", "") == "remote" and model_id in set(cache.get(u.name, [])):
                 return True
     except Exception:  # pragma: no cover — defensive
         return False
@@ -359,9 +343,7 @@ async def _slot_thinking_default(request: Request, model_id: str) -> bool:
     return False
 
 
-async def _normalize_chat_body(
-    request: Request, body: dict[str, Any]
-) -> dict[str, Any]:
+async def _normalize_chat_body(request: Request, body: dict[str, Any]) -> dict[str, Any]:
     """Resolve hal0/* virtual model names + inject thinking policy.
 
     Rewrites request._body so every downstream consumer observes the
@@ -427,9 +409,7 @@ async def _ensure_backend_for_model(request: Request, body: dict[str, Any]) -> N
     except Exception:
         return
     # Reverse the alias→model_id map: find the chat slot that owns this model.
-    slot_name = next(
-        (slot for slot, mid in alias_to_model.items() if mid == model_id), None
-    )
+    slot_name = next((slot for slot, mid in alias_to_model.items() if mid == model_id), None)
     if slot_name is None:
         # No backing chat slot — nothing to honor.
         return
@@ -490,9 +470,7 @@ async def _dispatch_and_forward(
             dispatch_started=dispatch_started,
         )
     if isinstance(response, Response) and getattr(response, "body", None):
-        _record_nonstreaming_throughput(
-            response.body, request.app.state, call.upstream_name
-        )
+        _record_nonstreaming_throughput(response.body, request.app.state, call.upstream_name)
     return response
 
 
@@ -531,9 +509,7 @@ async def list_models(
     from hal0.api import hal0_chat_slot_model_ids, hal0_slot_alias_models
 
     upstreams = request.app.state.upstreams
-    model_cache: dict[str, list[str]] = (
-        getattr(request.app.state, "upstream_models", {}) or {}
-    )
+    model_cache: dict[str, list[str]] = getattr(request.app.state, "upstream_models", {}) or {}
     seen: set[str] = set()
     data: list[dict[str, Any]] = []
     now = int(time.time())
@@ -545,9 +521,7 @@ async def list_models(
     # the id over any same-named raw model id an upstream might advertise.
     if slot_manager is not None and model_registry is not None:
         try:
-            alias_entries = await hal0_slot_alias_models(
-                slot_manager, model_registry, now=now
-            )
+            alias_entries = await hal0_slot_alias_models(slot_manager, model_registry, now=now)
         except Exception:
             alias_entries = []
         for entry in alias_entries:
@@ -610,9 +584,7 @@ async def list_models(
     # All 3 canonical names are advertised whenever they resolve. hal0/npu and
     # hal0/utility fall back to the primary when no npu/utility slot is loaded —
     # intentional: the name always routes (see resolve_chain's fallback contract).
-    for (
-        vname
-    ) in DEFAULT_CHAINS:  # canonical names only (aliases excluded from the picker)
+    for vname in DEFAULT_CHAINS:  # canonical names only (aliases excluded from the picker)
         if vname in seen:
             continue
         res = await resolver.resolve(vname)
@@ -836,9 +808,7 @@ def _wrap_npu_trio_response(upstream: Any) -> Response:
     )
 
 
-async def _maybe_run_omni_loop(
-    request: Request, body: dict[str, Any]
-) -> Response | None:
+async def _maybe_run_omni_loop(request: Request, body: dict[str, Any]) -> Response | None:
     """Attempt to run the OmniRouter loop for this chat request.
 
     Returns:
@@ -1064,9 +1034,7 @@ async def images_generations(request: Request, dispatcher: DispatcherDep) -> Res
 
         cfgs = await manager.iter_configs()
         img_cfg = next((c for c in cfgs if gpu_exclusive_group(c) == "img"), None)
-        img_section = (
-            (img_cfg or {}).get("image") or (img_cfg or {}).get("image_gen") or {}
-        )
+        img_section = (img_cfg or {}).get("image") or (img_cfg or {}).get("image_gen") or {}
         if isinstance(img_section, dict):
             default_size = img_section.get("default_size")
             if not body.get("size") and isinstance(default_size, str) and default_size:
@@ -1267,9 +1235,7 @@ async def _forward_multipart(
     # path would 404. Plan §5.2.
     if model_value and request.url.path.endswith("/audio/transcriptions"):
         synthetic_body = {"model": model_value}
-        if await _is_npu_trio_request(
-            request, synthetic_body, slot_type="transcription"
-        ):
+        if await _is_npu_trio_request(request, synthetic_body, slot_type="transcription"):
             router_obj = getattr(request.app.state, "npu_trio_router", None)
             if router_obj is not None:
                 upstream_resp = await router_obj.dispatch_stt_npu(
@@ -1278,9 +1244,7 @@ async def _forward_multipart(
                 )
                 return _wrap_npu_trio_response(upstream_resp)
 
-    call = await dispatcher.dispatch(
-        request, body={"model": model_value} if model_value else {}
-    )
+    call = await dispatcher.dispatch(request, body={"model": model_value} if model_value else {})
 
     last_used = getattr(request.app.state, "last_used_model", None)
     if last_used is not None and call.upstream_name and call.resolved_model:

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -97,7 +97,11 @@ def _instrument_streaming_throughput(
     """
     original = response.body_iterator
     events = _slot_events(app_state, slot_name)
-    ttft_events = _slot_ttft_events(app_state, slot_name) if dispatch_started is not None else None
+    ttft_events = (
+        _slot_ttft_events(app_state, slot_name)
+        if dispatch_started is not None
+        else None
+    )
     if events is None and ttft_events is None:
         return response
     ttft_pending = ttft_events is not None  # one-shot per response
@@ -115,7 +119,11 @@ def _instrument_streaming_throughput(
                 now = time.monotonic()
                 if events is not None:
                     events.append((now, tokens))
-                if ttft_pending and ttft_events is not None and dispatch_started is not None:
+                if (
+                    ttft_pending
+                    and ttft_events is not None
+                    and dispatch_started is not None
+                ):
                     ttft_events.append((now, max(0.0, now - dispatch_started)))
                     ttft_pending = False
             yield chunk
@@ -185,7 +193,9 @@ async def _read_json_body(request: Request) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
-async def _rewrite_chat_slot_alias(request: Request, body: dict[str, Any]) -> dict[str, Any]:
+async def _rewrite_chat_slot_alias(
+    request: Request, body: dict[str, Any]
+) -> dict[str, Any]:
     """Translate a chat-slot ALIAS in ``body["model"]`` to its model id.
 
     hermes-role-slots: a request may address a co-resident chat slot by
@@ -277,7 +287,9 @@ def _normalize_loaded_models(request: Request) -> set[str]:
     if upstreams is not None and model_cache is not None:
         with contextlib.suppress(Exception):
             for up in upstreams.list():
-                if getattr(up, "kind", "") == "remote" and getattr(up, "slot_name", None):
+                if getattr(up, "kind", "") == "remote" and getattr(
+                    up, "slot_name", None
+                ):
                     loaded |= set(model_cache.get(up.name, []))
     return loaded
 
@@ -291,7 +303,9 @@ async def _normalize_slot_views(request: Request) -> list:
     sm = getattr(request.app.state, "slot_manager", None)
     if sm is None:
         return []
-    rows = await hal0_llm_slot_views(sm, getattr(request.app.state, "model_registry", None))
+    rows = await hal0_llm_slot_views(
+        sm, getattr(request.app.state, "model_registry", None)
+    )
     return [
         SlotView(
             name=r["name"],
@@ -316,7 +330,9 @@ def _is_remote_model(request: Request, model_id: str) -> bool:
             # not genuine external providers, so the thinking policy must apply.
             if getattr(u, "slot_name", None):
                 continue
-            if getattr(u, "kind", "") == "remote" and model_id in set(cache.get(u.name, [])):
+            if getattr(u, "kind", "") == "remote" and model_id in set(
+                cache.get(u.name, [])
+            ):
                 return True
     except Exception:  # pragma: no cover — defensive
         return False
@@ -343,7 +359,9 @@ async def _slot_thinking_default(request: Request, model_id: str) -> bool:
     return False
 
 
-async def _normalize_chat_body(request: Request, body: dict[str, Any]) -> dict[str, Any]:
+async def _normalize_chat_body(
+    request: Request, body: dict[str, Any]
+) -> dict[str, Any]:
     """Resolve hal0/* virtual model names + inject thinking policy.
 
     Rewrites request._body so every downstream consumer observes the
@@ -409,7 +427,9 @@ async def _ensure_backend_for_model(request: Request, body: dict[str, Any]) -> N
     except Exception:
         return
     # Reverse the alias→model_id map: find the chat slot that owns this model.
-    slot_name = next((slot for slot, mid in alias_to_model.items() if mid == model_id), None)
+    slot_name = next(
+        (slot for slot, mid in alias_to_model.items() if mid == model_id), None
+    )
     if slot_name is None:
         # No backing chat slot — nothing to honor.
         return
@@ -470,7 +490,9 @@ async def _dispatch_and_forward(
             dispatch_started=dispatch_started,
         )
     if isinstance(response, Response) and getattr(response, "body", None):
-        _record_nonstreaming_throughput(response.body, request.app.state, call.upstream_name)
+        _record_nonstreaming_throughput(
+            response.body, request.app.state, call.upstream_name
+        )
     return response
 
 
@@ -509,7 +531,9 @@ async def list_models(
     from hal0.api import hal0_chat_slot_model_ids, hal0_slot_alias_models
 
     upstreams = request.app.state.upstreams
-    model_cache: dict[str, list[str]] = getattr(request.app.state, "upstream_models", {}) or {}
+    model_cache: dict[str, list[str]] = (
+        getattr(request.app.state, "upstream_models", {}) or {}
+    )
     seen: set[str] = set()
     data: list[dict[str, Any]] = []
     now = int(time.time())
@@ -521,7 +545,9 @@ async def list_models(
     # the id over any same-named raw model id an upstream might advertise.
     if slot_manager is not None and model_registry is not None:
         try:
-            alias_entries = await hal0_slot_alias_models(slot_manager, model_registry, now=now)
+            alias_entries = await hal0_slot_alias_models(
+                slot_manager, model_registry, now=now
+            )
         except Exception:
             alias_entries = []
         for entry in alias_entries:
@@ -584,7 +610,9 @@ async def list_models(
     # All 3 canonical names are advertised whenever they resolve. hal0/npu and
     # hal0/utility fall back to the primary when no npu/utility slot is loaded —
     # intentional: the name always routes (see resolve_chain's fallback contract).
-    for vname in DEFAULT_CHAINS:  # canonical names only (aliases excluded from the picker)
+    for (
+        vname
+    ) in DEFAULT_CHAINS:  # canonical names only (aliases excluded from the picker)
         if vname in seen:
             continue
         res = await resolver.resolve(vname)
@@ -808,7 +836,9 @@ def _wrap_npu_trio_response(upstream: Any) -> Response:
     )
 
 
-async def _maybe_run_omni_loop(request: Request, body: dict[str, Any]) -> Response | None:
+async def _maybe_run_omni_loop(
+    request: Request, body: dict[str, Any]
+) -> Response | None:
     """Attempt to run the OmniRouter loop for this chat request.
 
     Returns:
@@ -1034,7 +1064,9 @@ async def images_generations(request: Request, dispatcher: DispatcherDep) -> Res
 
         cfgs = await manager.iter_configs()
         img_cfg = next((c for c in cfgs if gpu_exclusive_group(c) == "img"), None)
-        img_section = (img_cfg or {}).get("image") or (img_cfg or {}).get("image_gen") or {}
+        img_section = (
+            (img_cfg or {}).get("image") or (img_cfg or {}).get("image_gen") or {}
+        )
         if isinstance(img_section, dict):
             default_size = img_section.get("default_size")
             if not body.get("size") and isinstance(default_size, str) and default_size:
@@ -1235,7 +1267,9 @@ async def _forward_multipart(
     # path would 404. Plan §5.2.
     if model_value and request.url.path.endswith("/audio/transcriptions"):
         synthetic_body = {"model": model_value}
-        if await _is_npu_trio_request(request, synthetic_body, slot_type="transcription"):
+        if await _is_npu_trio_request(
+            request, synthetic_body, slot_type="transcription"
+        ):
             router_obj = getattr(request.app.state, "npu_trio_router", None)
             if router_obj is not None:
                 upstream_resp = await router_obj.dispatch_stt_npu(
@@ -1244,7 +1278,9 @@ async def _forward_multipart(
                 )
                 return _wrap_npu_trio_response(upstream_resp)
 
-    call = await dispatcher.dispatch(request, body={"model": model_value} if model_value else {})
+    call = await dispatcher.dispatch(
+        request, body={"model": model_value} if model_value else {}
+    )
 
     last_used = getattr(request.app.state, "last_used_model", None)
     if last_used is not None and call.upstream_name and call.resolved_model:

--- a/tests/api/test_v1_chat_slot_alias.py
+++ b/tests/api/test_v1_chat_slot_alias.py
@@ -166,6 +166,88 @@ async def test_rewrite_is_noop_without_slot_manager() -> None:
     assert body["model"] == "primary"
 
 
+# ── FLM-backed slot: catalog-id ↔ served-tag translation ────────────────────
+
+
+def _npu_flm_slot() -> list[dict[str, Any]]:
+    """An FLM-backed NPU chat slot whose configured model is the hal0 catalog
+    id ``gemma4-it-e2b-FLM``; the FLM upstream serves the native tag
+    ``gemma4-it:e2b`` (the id `flm serve` accepts and advertises)."""
+    return [
+        {
+            "name": "npu",
+            "type": "llm",
+            "enabled": True,
+            "port": 8088,
+            "model": {"default": "gemma4-it-e2b-FLM", "context_size": 75000},
+        },
+    ]
+
+
+def _patch_flm_id_to_tag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the FLM catalog probe so tests don't shell out to the host FLM
+    binary. Maps the one id under test to its native tag."""
+    import hal0.providers.flm as flm_mod
+
+    monkeypatch.setattr(
+        flm_mod,
+        "flm_id_to_tag",
+        lambda mid: "gemma4-it:e2b" if mid == "gemma4-it-e2b-FLM" else None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rewrite_translates_flm_alias_to_served_tag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An FLM chat slot addressed by its alias (``npu``) rewrites to FLM's
+    native served tag — NOT the hal0 ``<tag>-FLM`` catalog id, which no
+    upstream advertises (→ dispatch.no_route)."""
+    from hal0.api.routes.v1 import _rewrite_chat_slot_alias
+
+    _patch_flm_id_to_tag(monkeypatch)
+    req = _FakeRequest(_FakeSlotManager(_npu_flm_slot()))
+    body = await _rewrite_chat_slot_alias(req, {"model": "npu", "messages": []})
+
+    assert body["model"] == "gemma4-it:e2b"
+    assert json.loads(req._body)["model"] == "gemma4-it:e2b"
+
+
+@pytest.mark.asyncio
+async def test_rewrite_normalizes_direct_flm_catalog_id_to_tag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A request keyed directly on the hal0 ``<tag>-FLM`` catalog id (e.g. a
+    consumer pinned to ``gemma4-it-e2b-FLM``) is normalized to the served tag
+    so it routes to the FLM upstream instead of 404ing."""
+    from hal0.api.routes.v1 import _rewrite_chat_slot_alias
+
+    _patch_flm_id_to_tag(monkeypatch)
+    req = _FakeRequest(_FakeSlotManager(_npu_flm_slot()))
+    body = await _rewrite_chat_slot_alias(
+        req, {"model": "gemma4-it-e2b-FLM", "messages": []}
+    )
+
+    assert body["model"] == "gemma4-it:e2b"
+    assert json.loads(req._body)["model"] == "gemma4-it:e2b"
+
+
+@pytest.mark.asyncio
+async def test_rewrite_flm_tag_passthrough_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A request already keyed on the native FLM tag is untouched — it is what
+    the FLM upstream advertises."""
+    from hal0.api.routes.v1 import _rewrite_chat_slot_alias
+
+    _patch_flm_id_to_tag(monkeypatch)
+    req = _FakeRequest(_FakeSlotManager(_npu_flm_slot()))
+    body = await _rewrite_chat_slot_alias(req, {"model": "gemma4-it:e2b", "messages": []})
+
+    assert body["model"] == "gemma4-it:e2b"
+    assert req._body == b""  # not rewritten
+
+
 # ── dispatcher non-regression ───────────────────────────────────────────────
 
 

--- a/tests/api/test_v1_chat_slot_alias.py
+++ b/tests/api/test_v1_chat_slot_alias.py
@@ -152,9 +152,7 @@ async def test_rewrite_is_noop_for_bare_model_id() -> None:
     from hal0.api.routes.v1 import _rewrite_chat_slot_alias
 
     req = _FakeRequest(_FakeSlotManager(_three_chat_slots()))
-    body = await _rewrite_chat_slot_alias(
-        req, {"model": "hermes-4-14b-q5km", "messages": []}
-    )
+    body = await _rewrite_chat_slot_alias(req, {"model": "hermes-4-14b-q5km", "messages": []})
     assert body["model"] == "hermes-4-14b-q5km"
     assert req._body == b""  # not rewritten
 
@@ -226,9 +224,7 @@ async def test_rewrite_normalizes_direct_flm_catalog_id_to_tag(
 
     _patch_flm_id_to_tag(monkeypatch)
     req = _FakeRequest(_FakeSlotManager(_npu_flm_slot()))
-    body = await _rewrite_chat_slot_alias(
-        req, {"model": "gemma4-it-e2b-FLM", "messages": []}
-    )
+    body = await _rewrite_chat_slot_alias(req, {"model": "gemma4-it-e2b-FLM", "messages": []})
 
     assert body["model"] == "gemma4-it:e2b"
     assert json.loads(req._body)["model"] == "gemma4-it:e2b"
@@ -244,9 +240,7 @@ async def test_rewrite_flm_tag_passthrough_is_noop(
 
     _patch_flm_id_to_tag(monkeypatch)
     req = _FakeRequest(_FakeSlotManager(_npu_flm_slot()))
-    body = await _rewrite_chat_slot_alias(
-        req, {"model": "gemma4-it:e2b", "messages": []}
-    )
+    body = await _rewrite_chat_slot_alias(req, {"model": "gemma4-it:e2b", "messages": []})
 
     assert body["model"] == "gemma4-it:e2b"
     assert req._body == b""  # not rewritten

--- a/tests/api/test_v1_chat_slot_alias.py
+++ b/tests/api/test_v1_chat_slot_alias.py
@@ -152,7 +152,9 @@ async def test_rewrite_is_noop_for_bare_model_id() -> None:
     from hal0.api.routes.v1 import _rewrite_chat_slot_alias
 
     req = _FakeRequest(_FakeSlotManager(_three_chat_slots()))
-    body = await _rewrite_chat_slot_alias(req, {"model": "hermes-4-14b-q5km", "messages": []})
+    body = await _rewrite_chat_slot_alias(
+        req, {"model": "hermes-4-14b-q5km", "messages": []}
+    )
     assert body["model"] == "hermes-4-14b-q5km"
     assert req._body == b""  # not rewritten
 
@@ -242,7 +244,9 @@ async def test_rewrite_flm_tag_passthrough_is_noop(
 
     _patch_flm_id_to_tag(monkeypatch)
     req = _FakeRequest(_FakeSlotManager(_npu_flm_slot()))
-    body = await _rewrite_chat_slot_alias(req, {"model": "gemma4-it:e2b", "messages": []})
+    body = await _rewrite_chat_slot_alias(
+        req, {"model": "gemma4-it:e2b", "messages": []}
+    )
 
     assert body["model"] == "gemma4-it:e2b"
     assert req._body == b""  # not rewritten


### PR DESCRIPTION
## Problem

The FLM-backed `npu` slot 404'd with `dispatch.no_route` for `model 'gemma4-it-e2b-FLM'` when addressed by its **bare alias** (`npu`) or by its **raw catalog id** (`gemma4-it-e2b-FLM`) — the form Hermes compaction / Hindsight reflection (and the dashboard) use. Reproduced live on CT105:

| request `model` | result |
|---|---|
| `gemma4-it:e2b` (FLM tag) | works |
| `hal0/npu` (virtual) | works → `gemma4-it:e2b` |
| `npu` (bare alias) | `dispatch.no_route` for `gemma4-it-e2b-FLM` |
| `gemma4-it-e2b-FLM` (catalog id) | `dispatch.no_route` |

## Root cause

FLM slots persist the hal0 `<tag>-FLM` catalog id (`gemma4-it-e2b-FLM`), but `flm serve` advertises only the native `family:size` tag (`gemma4-it:e2b`). The `/v1` route-layer rewrite (`_rewrite_chat_slot_alias`) mapped the `npu` alias to the raw `-FLM` id and passed a directly-requested `-FLM` id through unchanged. Routing keys off the upstream's advertised set, which contains the tag, not the `-FLM` id → no match → `dispatch.no_route`. The `hal0/npu` and direct-tag paths already resolved to the served tag, which is why only the bare-alias / catalog-id paths broke.

## Fix

`_rewrite_chat_slot_alias` gains a second normalization step: any `<tag>-FLM` id (whether reached via a chat-slot alias or requested directly) is translated to its served tag via `flm_id_to_tag`, mirroring `SlotManager._resolve_model_info`'s existing `flm_tag` stamp. Guarded on the `-FLM` suffix, so non-FLM requests never pay the (module-cached) catalog probe. Also fixes the `embed`/`stt` FLM slot aliases, which share the id shape.

## Tests

TDD: 3 new tests in `tests/api/test_v1_chat_slot_alias.py` (alias→tag, direct-id→tag, tag-passthrough no-op). Watched them fail RED, then GREEN. Full `tests/api/` + `tests/providers/test_flm.py` + `tests/slots/test_slot_aliases.py` = **1048 passed, 1 skipped** (env-only). Live CT105 confirmed `flm_id_to_tag('gemma4-it-e2b-FLM') == 'gemma4-it:e2b'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)