### PR TITLE
fix(nightly): monotonic sub-day nightly versions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,9 +2,11 @@ name: Nightly
 
 # Cut a nightly hal0 build from green `main` and publish it on the `nightly`
 # release channel. This workflow is only the scheduler/guard/tagger — it does
-# NOT build or sign. It computes a dated v<base>-nightly.<YYYYMMDD> tag at
-# main HEAD, pushes it, then invokes release.yml (workflow_call) which builds,
-# cosign-signs, and publishes nightly.json (channel auto-derived from the tag).
+# NOT build or sign. It computes a timestamped v<base>-nightly.<YYYYMMDDHHMMSS>
+# tag at main HEAD, pushes it, then invokes release.yml (workflow_call) which
+# builds, cosign-signs, and publishes nightly.json (channel auto-derived from
+# the tag). The full UTC timestamp (vs. date-only) ensures same-day re-cuts
+# produce strictly monotonic version strings the updater can distinguish.
 #
 # Testers follow it with a one-time `hal0 update --channel nightly`, then plain
 # `hal0 update`. See docs/operate/updates.mdx and
@@ -87,7 +89,7 @@ jobs:
           import tomllib
           print(tomllib.loads(open("pyproject.toml","rb").read().decode())["project"]["version"])
           ')"
-          DATE="$(date -u +%Y%m%d)"
+          DATE="$(date -u +%Y%m%d%H%M%S)"
           TAG="$(PYV="${PYV}" DATE="${DATE}" PYTHONPATH=src python3 -c "import os; from hal0.release.channel import base_version, nightly_tag; print(nightly_tag(base_version(os.environ['PYV']), os.environ['DATE']))")"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "::notice::nightly tag ${TAG}"

--- a/src/hal0/release/channel.py
+++ b/src/hal0/release/channel.py
@@ -32,14 +32,26 @@ def base_version(version: str) -> str:
     return v.split("-", 1)[0]
 
 
-def nightly_version(base: str, date: str) -> str:
-    """Compose a nightly version from a base ``X.Y.Z`` and a ``YYYYMMDD`` date."""
-    return f"{base}-nightly.{date}"
+def nightly_version(base: str, stamp: str) -> str:
+    """Compose a nightly version from a base ``X.Y.Z`` and a UTC ``stamp``.
+
+    ``stamp`` should be ``YYYYMMDDHHMMSS`` (sub-day resolution) so multiple
+    cuts on the same calendar day produce strictly monotonic version strings —
+    a date-only ``YYYYMMDD`` stamp would collide on same-day re-cuts and the
+    updater's ``_version_tuple`` comparison would see no change and skip the
+    update.  Legacy ``YYYYMMDD`` tags still sort correctly: the shorter numeric
+    segment (8 digits) is always less than a 14-digit timestamp with the same
+    date prefix.
+    """
+    return f"{base}-nightly.{stamp}"
 
 
-def nightly_tag(base: str, date: str) -> str:
-    """Compose the nightly git tag (``v`` + nightly version)."""
-    return f"v{nightly_version(base, date)}"
+def nightly_tag(base: str, stamp: str) -> str:
+    """Compose the nightly git tag (``v`` + nightly version).
+
+    See :func:`nightly_version` for the ``stamp`` format (``YYYYMMDDHHMMSS``).
+    """
+    return f"v{nightly_version(base, stamp)}"
 
 
 def base_matches(pyproject_version: str, tag: str) -> bool:
@@ -55,8 +67,12 @@ def base_matches(pyproject_version: str, tag: str) -> bool:
 def nightlies_to_prune(tags: list[str], keep: int = 7) -> list[str]:
     """Return the nightly tags to delete, keeping the ``keep`` most recent.
 
-    Only ``*-nightly.<date>`` tags are eligible; stable/alpha/rc tags are
-    never returned. Ordering is by the numeric date segment, newest first.
+    Only ``*-nightly.<stamp>`` tags are eligible; stable/alpha/rc tags are
+    never returned.  Ordering is by the numeric timestamp segment (newest
+    first), which handles both legacy ``YYYYMMDD`` (8-digit) stamps and
+    current ``YYYYMMDDHHMMSS`` (14-digit) stamps — a longer digit string for
+    the same date always sorts higher, so old date-only tags naturally fall
+    below new timestamp tags.
     """
     dated: list[tuple[int, str]] = []
     for t in tags:

--- a/tests/release/test_channel.py
+++ b/tests/release/test_channel.py
@@ -72,3 +72,22 @@ def test_nightlies_to_prune_keeps_newest():
 def test_nightlies_to_prune_nothing_when_under_keep():
     tags = ["v0.5.0-nightly.20260613", "v0.5.0-nightly.20260614"]
     assert nightlies_to_prune(tags, keep=7) == []
+
+
+def test_nightly_version_uses_full_stamp_and_is_monotonic():
+    # a sub-day timestamp stamp is interpolated verbatim
+    assert nightly_version("0.5.1", "20260615120000") == "0.5.1-nightly.20260615120000"
+    assert nightly_tag("0.5.1", "20260615120000") == "v0.5.1-nightly.20260615120000"
+
+
+def test_nightlies_to_prune_orders_by_full_numeric_stamp():
+    tags = [
+        "v0.5.1-nightly.20260615120000",
+        "v0.5.1-nightly.20260615",  # legacy date-only (older)
+        "v0.5.1-nightly.20260615130000",  # newest
+        "v0.5.1-alpha.1",  # not a nightly — never pruned
+    ]
+    pruned = nightlies_to_prune(tags, keep=1)
+    assert "v0.5.1-alpha.1" not in pruned  # stable never pruned
+    assert "v0.5.1-nightly.20260615130000" not in pruned  # newest kept
+    assert "v0.5.1-nightly.20260615" in pruned  # oldest pruned

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -41,6 +41,7 @@ from hal0.updater.updater import (
     _is_pre_release,
     _parse_manifest,
     _previous_record,
+    _version_tuple,
     _versioned_install_dir,
 )
 
@@ -833,3 +834,18 @@ def test_apply_hard_refuses_on_editable_install(
     assert "editable" in str(err).lower() or "git pull" in str(err).lower()
     # No network call, no file I/O — the guard fires before Step 1.
     # (Verified implicitly: no HAL0_RELEASES_URL env → would fail if reached.)
+
+
+# ── _version_tuple ordering — nightly timestamp monotonicity ──────────────────
+
+
+def test_version_tuple_timestamp_nightly_beats_date_only_same_base() -> None:
+    """A 14-digit UTC timestamp nightly sorts strictly above a date-only nightly.
+
+    The nightly workflow now emits YYYYMMDDHHMMSS so same-day re-cuts produce
+    a strictly larger version that the updater will recognise as newer.  Legacy
+    YYYYMMDD tags still order below any timestamp tag with the same base (because
+    20260615 < 20260615000000 as integers).
+    """
+    assert _version_tuple("0.5.1-nightly.20260615120000") > _version_tuple("0.5.1-nightly.20260615")
+    assert _version_tuple("0.5.1-nightly.20260615") > _version_tuple("0.5.0-nightly.20260615")


### PR DESCRIPTION
## Problem

Nightly versions were date-only (`YYYYMMDD`). Two cuts on the same calendar day produced the same version string, e.g. `0.5.1-nightly.20260615`. The updater's `_version_tuple` comparison saw no change and `hal0 update --channel nightly` silently skipped the newer build.

## Fix

- **`.github/workflows/nightly.yml`**: stamp changed from `date -u +%Y%m%d` → `date -u +%Y%m%d%H%M%S`, producing `YYYYMMDDHHMMSS` (e.g. `0.5.1-nightly.20260615143022`). Every cut is now strictly monotonic.
- **`src/hal0/release/channel.py`**: renamed `date` param to `stamp` in `nightly_version`/`nightly_tag`; updated all docstrings to document the new format and explain backward-compatibility with legacy date-only tags.

## No logic changes needed

`_version_tuple` splits on `.` and int-parses each segment, stripping non-digits. `(0,5,1,20260615143022) > (0,5,1,20260615)` already holds. `_NIGHTLY_RE` and `nightlies_to_prune` both already handle any-length digit strings. **Only stamps, docstrings, and tests changed.**

## Backward compatibility

Legacy `YYYYMMDD` tags order correctly below any `YYYYMMDDHHMMSS` tag with the same date prefix (8-digit integer < 14-digit integer). Pruning also sorts them correctly.

## Tests added

- `test_nightly_version_uses_full_stamp_and_is_monotonic` — verifies the new stamp passes through verbatim
- `test_nightlies_to_prune_orders_by_full_numeric_stamp` — verifies legacy date-only tag sorts below timestamp tags and is pruned first
- `test_version_tuple_timestamp_nightly_beats_date_only_same_base` — regression-locks `_version_tuple` ordering for timestamp vs. date-only nightlies

All 62 tests pass (`tests/release/` + `tests/updater/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)