### PR TITLE
feat(release): changelog/release-notes in every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,7 +322,81 @@ jobs:
           print(f"manifest OK: version={mf.version} digest_sha256={mf.digest_sha256[:12]}…")
           PY
 
-      # ── 6. Publish GitHub Release with all three assets ─────────────────────
+      # ── 6. Generate release notes ────────────────────────────────────────────
+      - name: Generate release notes
+        id: notes
+        run: |
+          TAG="${{ steps.ver.outputs.tag }}"
+          CHANNEL="${{ steps.ver.outputs.channel }}"
+          NOTES_FILE="${RUNNER_TEMP}/RELEASE_NOTES.md"
+
+          # Non-fatal wrapper: if anything goes wrong we still publish.
+          generate_notes() {
+            if [[ "${CHANNEL}" == "nightly" ]]; then
+              # Nightly: summarise commits since the previous nightly tag.
+              # The current tag was already pushed by the nightly.yml tag job,
+              # so the "previous" nightly is the second entry in newest-first order.
+              PREV_NIGHTLY="$(git tag --list 'v*-nightly.*' --sort=-creatordate | grep -v "^${TAG}$" | head -n1)"
+
+              if [[ -n "${PREV_NIGHTLY}" ]]; then
+                FROM_REF="${PREV_NIGHTLY}"
+                FROM_LABEL="since ${PREV_NIGHTLY}"
+              else
+                # No prior nightly — fall back to the most recent stable tag.
+                PREV_STABLE="$(git tag --list 'v*' --sort=-creatordate \
+                  | grep -v '\-nightly\.' | grep -v "^${TAG}$" | head -n1)"
+                FROM_REF="${PREV_STABLE:-}"
+                FROM_LABEL="since ${PREV_STABLE:-initial commit}"
+              fi
+
+              {
+                echo "Nightly ${TAG} — changes ${FROM_LABEL}:"
+                echo ""
+                if [[ -n "${FROM_REF}" ]]; then
+                  git log --pretty='- %s (%h)' "${FROM_REF}..HEAD"
+                else
+                  git log --pretty='- %s (%h)' HEAD
+                fi
+              } > "${NOTES_FILE}"
+
+            else
+              # Stable / alpha: extract the matching section from CHANGELOG.md.
+              VERSION="${TAG#v}"
+              SECTION="$(PYTHONPATH=src python3 -c "
+          import sys
+          from hal0.release.notes import extract_changelog_section
+          body = extract_changelog_section(open('CHANGELOG.md').read(), sys.argv[1])
+          print(body)
+          " "${TAG}" 2>/dev/null || true)"
+
+              if [[ -n "${SECTION}" ]]; then
+                echo "${SECTION}" > "${NOTES_FILE}"
+              else
+                # Fallback: commit log since the previous stable tag.
+                PREV_STABLE="$(git tag --list 'v*' --sort=-creatordate \
+                  | grep -v '\-nightly\.' | grep -v "^${TAG}$" | head -n1)"
+                {
+                  echo "Changes in ${TAG}:"
+                  echo ""
+                  if [[ -n "${PREV_STABLE}" ]]; then
+                    git log --pretty='- %s' "${PREV_STABLE}..${TAG}"
+                  else
+                    git log --pretty='- %s' "${TAG}"
+                  fi
+                  echo ""
+                  echo "See CHANGELOG.md for full details."
+                } > "${NOTES_FILE}"
+              fi
+            fi
+          }
+
+          if ! generate_notes 2>/dev/null; then
+            echo "See CHANGELOG.md for release notes." > "${NOTES_FILE}"
+          fi
+
+          echo "path=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
+
+      # ── 7. Publish GitHub Release with all three assets ─────────────────────
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -332,6 +406,7 @@ jobs:
           SIG="${{ steps.sign.outputs.sig }}"
           CRT="${{ steps.sign.outputs.cert }}"
           MANIFEST="${{ steps.manifest.outputs.path }}"
+          NOTES_FILE="${{ steps.notes.outputs.path }}"
 
           # Create the release if it doesn't already exist (workflow_dispatch
           # rebuild path) — otherwise just upload the assets, replacing
@@ -345,7 +420,7 @@ jobs:
               # /nightly.json, not /releases/latest.
               gh release create "${TAG}" \
                 --title "hal0 ${TAG}" \
-                --notes "Automated nightly build from green main. Follow with: hal0 update --channel nightly. See docs/operate/updates.mdx." \
+                --notes-file "${NOTES_FILE}" \
                 --draft=false \
                 --prerelease=true
             else
@@ -354,7 +429,7 @@ jobs:
               # on purpose so /releases/latest works while we're pre-stable.
               gh release create "${TAG}" \
                 --title "hal0 ${TAG}" \
-                --notes "Automated release. See docs/internal/release-manifest.md for the verify path." \
+                --notes-file "${NOTES_FILE}" \
                 --draft=false \
                 --prerelease=false \
                 --latest

--- a/src/hal0/release/notes.py
+++ b/src/hal0/release/notes.py
@@ -1,0 +1,67 @@
+"""Changelog / release-notes helpers shared by the release + nightly workflows.
+
+Pure functions — no I/O, stdlib only — so both .github/workflows/release.yml
+and .github/workflows/nightly.yml can call them via a bare
+``PYTHONPATH=src python3 -c …`` (no editable install needed).
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def extract_changelog_section(changelog: str, version: str) -> str:
+    """Return the body of the ``## [<version>]`` section of a Keep-a-Changelog
+    document (everything from that header up to the next ``## `` header,
+    header line excluded), stripped.
+
+    *version* is matched with or without a leading ``v``; e.g. both
+    ``"v0.5.1-alpha.1"`` and ``"0.5.1-alpha.1"`` find the
+    ``## [v0.5.1-alpha.1]`` section.
+
+    Returns ``""`` if no matching section is found.
+
+    Notes
+    -----
+    The regex uses a word-boundary-like anchor after the version string so
+    that ``v0.5.1`` does **not** match ``## [v0.5.10-alpha.1]``.  A version
+    string ends at a ``]`` (or ``-``, ``+``, whitespace…) — never at another
+    digit — so requiring the next character to be ``]`` or ``-`` or ``+``
+    prevents prefix collisions.
+    """
+    if not changelog or not version:
+        return ""
+
+    # Normalise: strip leading "v" so we can build a pattern that accepts
+    # both "v0.5.1-alpha.1" and "0.5.1-alpha.1".
+    bare = version.lstrip("v")
+    if not bare:
+        return ""
+
+    # Escape the version string so dots / + are treated literally.
+    escaped = re.escape(bare)
+
+    # Match:  ## [  (optional v)  <version>  ]   (optional rest of header line)
+    # The (?:] is a non-capturing group that requires the character immediately
+    # following the version to be ] or - or + (i.e. not another digit/letter),
+    # preventing "v0.5.1" from matching "v0.5.10".
+    header_re = re.compile(
+        r"^##\s+\[v?" + escaped + r"(?=[^\w]|\Z)",
+        re.MULTILINE,
+    )
+
+    m = header_re.search(changelog)
+    if not m:
+        return ""
+
+    # The section body starts after the matched header line.
+    body_start = (
+        changelog.index("\n", m.start()) + 1 if "\n" in changelog[m.start() :] else len(changelog)
+    )
+
+    # Find the next "## " header (start of the following section).
+    next_section_re = re.compile(r"^## ", re.MULTILINE)
+    n = next_section_re.search(changelog, body_start)
+    body_end = n.start() if n else len(changelog)
+
+    return changelog[body_start:body_end].strip()

--- a/tests/release/test_notes.py
+++ b/tests/release/test_notes.py
@@ -1,0 +1,157 @@
+"""Unit tests for hal0.release.notes — the CHANGELOG section extractor."""
+
+from __future__ import annotations
+
+from hal0.release.notes import extract_changelog_section
+
+# ── Sample CHANGELOG document used across tests ────────────────────────────
+
+_CHANGELOG = """\
+# Changelog
+
+All notable changes to hal0 are recorded here.
+
+## [v0.5.1-alpha.1] — 2026-06-15
+
+Pre-Alpha. Added hal0 setup TUI.
+
+### Added
+- hal0 setup TUI replaces the web FirstRun picker.
+- Ubuntu 26.04 / Python 3.14 install support.
+
+### Removed
+- Web FirstRun picker.
+
+## [v0.5.0-alpha.1] — 2026-06-14
+
+Pre-Alpha. Zero-boot install + FirstRun v2.
+
+### Added
+- FirstRun v2 wizard.
+- Zero-boot installer.
+
+## [v0.4.1-alpha.1] — 2026-06-14
+
+Only one line here.
+"""
+
+_CHANGELOG_LAST_ONLY = """\
+# Changelog
+
+## [v0.3.2-alpha.1] — 2026-05-29
+
+End-of-stream cut for v0.3. Bundles MCP-completion.
+"""
+
+_CHANGELOG_PREFIX_COLLISION = """\
+# Changelog
+
+## [v0.5.10-alpha.1] — 2026-07-01
+
+This is v0.5.10, NOT v0.5.1.
+
+## [v0.5.1-alpha.1] — 2026-06-15
+
+This is v0.5.1.
+"""
+
+
+# ── Basic extraction ────────────────────────────────────────────────────────
+
+
+def test_extracts_first_section():
+    body = extract_changelog_section(_CHANGELOG, "v0.5.1-alpha.1")
+    assert "Pre-Alpha. Added hal0 setup TUI." in body
+    assert "hal0 setup TUI replaces the web FirstRun picker." in body
+    # Must not bleed into the next section
+    assert "Zero-boot install" not in body
+    assert "## [v0.5.0" not in body
+
+
+def test_extracts_middle_section():
+    body = extract_changelog_section(_CHANGELOG, "v0.5.0-alpha.1")
+    assert "Zero-boot install" in body
+    assert "FirstRun v2 wizard." in body
+    # Must not bleed into prior or next section
+    assert "hal0 setup TUI" not in body
+    assert "Only one line" not in body
+
+
+def test_extracts_last_section_no_trailing_header():
+    """Section at end of document (no following ## header) must be captured."""
+    body = extract_changelog_section(_CHANGELOG, "v0.4.1-alpha.1")
+    assert "Only one line here." in body
+
+
+def test_last_section_in_single_entry_document():
+    """Document with only one ## section (no trailing ##) is captured."""
+    body = extract_changelog_section(_CHANGELOG_LAST_ONLY, "v0.3.2-alpha.1")
+    assert "End-of-stream cut for v0.3." in body
+
+
+# ── v-prefix handling ───────────────────────────────────────────────────────
+
+
+def test_accepts_version_with_leading_v():
+    body = extract_changelog_section(_CHANGELOG, "v0.5.1-alpha.1")
+    assert body != ""
+
+
+def test_accepts_version_without_leading_v():
+    body = extract_changelog_section(_CHANGELOG, "0.5.1-alpha.1")
+    # Must find the section even without the leading v
+    assert "Pre-Alpha. Added hal0 setup TUI." in body
+
+
+def test_with_and_without_v_return_same_result():
+    with_v = extract_changelog_section(_CHANGELOG, "v0.5.1-alpha.1")
+    without_v = extract_changelog_section(_CHANGELOG, "0.5.1-alpha.1")
+    assert with_v == without_v
+
+
+# ── Missing version ─────────────────────────────────────────────────────────
+
+
+def test_missing_version_returns_empty_string():
+    body = extract_changelog_section(_CHANGELOG, "v9.9.9")
+    assert body == ""
+
+
+def test_empty_changelog_returns_empty_string():
+    assert extract_changelog_section("", "v0.5.1-alpha.1") == ""
+
+
+def test_empty_version_returns_empty_string():
+    assert extract_changelog_section(_CHANGELOG, "") == ""
+
+
+# ── Prefix-collision guard ──────────────────────────────────────────────────
+
+
+def test_does_not_match_version_that_is_prefix_of_another():
+    """v0.5.1 must NOT match ## [v0.5.10-alpha.1]."""
+    body = extract_changelog_section(_CHANGELOG_PREFIX_COLLISION, "v0.5.1-alpha.1")
+    assert "This is v0.5.1." in body
+    assert "This is v0.5.10" not in body
+
+
+def test_longer_version_not_matched_by_shorter_query():
+    """Querying v0.5.10 must NOT match ## [v0.5.1-alpha.1]."""
+    body = extract_changelog_section(_CHANGELOG_PREFIX_COLLISION, "v0.5.10-alpha.1")
+    assert "This is v0.5.10" in body
+    assert "This is v0.5.1." not in body
+
+
+# ── Return value properties ─────────────────────────────────────────────────
+
+
+def test_result_is_stripped():
+    """No leading/trailing whitespace in the returned body."""
+    body = extract_changelog_section(_CHANGELOG, "v0.5.1-alpha.1")
+    assert body == body.strip()
+
+
+def test_header_line_excluded():
+    """The ## [vX.Y.Z] header line itself is not in the output."""
+    body = extract_changelog_section(_CHANGELOG, "v0.5.1-alpha.1")
+    assert "## [v0.5.1-alpha.1]" not in body


### PR DESCRIPTION
## Summary

- **Stable/alpha releases** extract the matching `## [vX.Y.Z]` section from `CHANGELOG.md` via a new pure helper `extract_changelog_section()` in `src/hal0/release/notes.py`. If no section matches the tag, the release body falls back to a `git log --pretty='- %s'` summary since the previous stable tag.
- **Nightly releases** auto-generate release notes from commits since the previous nightly tag (second-most-recent `v*-nightly.*` tag, since the current tag is already pushed before `release.yml` runs); fallback is commits since the last stable tag.
- Both paths write to a `RELEASE_NOTES.md` temp file, passed as `--notes-file` to `gh release create`. The notes-generation step is wrapped non-fatally: any failure falls back to `"See CHANGELOG.md for release notes."` so the release always publishes.
- `nightly.yml` required **zero changes** — it already delegates to `release.yml` via `workflow_call` with `channel: nightly`; the new "Generate release notes" step in `release.yml` branches on the channel input.
- `extract_changelog_section()` is stdlib-only (no I/O), matching the design of `channel.py`.

## Test plan

- [ ] `PYTHONPATH=src uv run --no-sync pytest tests/release/ -v` → 30 passed (16 existing channel tests + 14 new notes tests)
- [ ] Smoke: `PYTHONPATH=src python3 -c "from hal0.release.notes import extract_changelog_section; print(extract_changelog_section(open('CHANGELOG.md').read(), 'v0.5.1-alpha.1')[:200])"` → prints the v0.5.1-alpha.1 section body ✓
- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` → valid ✓
- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/nightly.yml'))"` → valid ✓
- [ ] `ruff check` + `ruff format --check` → clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)