### PR TITLE
fix(hermes): run-as-hal0 guard + ownership handover — prevent root-clobber (#843)

### DIFF
--- a/docs/agents/hermes/SERVICE.md
+++ b/docs/agents/hermes/SERVICE.md
@@ -157,6 +157,52 @@ port/address. The default (`http://127.0.0.1:8080`) matches the
 hal0-api bind in `installer/install.sh` — only override if you have
 a non-standard layout.
 
+### Root ran Hermes — config clobbered or split-brain (`root:root` files)
+
+Hermes is meant to run **only** as the unprivileged `hal0` user, with
+`HERMES_HOME=/var/lib/hal0/.hermes`. The systemd unit enforces this
+(`User=hal0`), but a human at a root shell does not: running `sudo hermes …`,
+or letting the installer/bootstrap create artifacts as root, triggers the
+**root-clobber regression**. Two distinct breakages, often together:
+
+1. **Split-brain home.** As root, Hermes resolves `~/.hermes` →
+   **`/root/.hermes`** instead of `/var/lib/hal0/.hermes`. It writes a
+   competing config/state tree there that the `hal0`-user service never reads.
+2. **Permission clobber.** Where root *does* write into
+   `/var/lib/hal0/.hermes`, the files land `root:root` (e.g. `config.yaml`
+   `0600`, the `runtime.json` embed token `0600`, the venv). The `hal0`-user
+   service then hits `EACCES` — or Hermes silently falls back to the **default
+   provider** because it cannot read its own `config.yaml`.
+
+**Symptoms:** chat answers from the wrong/default model with no error; embed
+features fail; `journalctl -u hal0-agent@hermes.service` shows permission
+errors; a stray `/root/.hermes` exists.
+
+**Diagnose** (all should read `hal0:hal0`, NOT `root:root 0600`):
+
+```bash
+stat -c '%U:%G %a' /var/lib/hal0/.hermes/config.yaml
+stat -c '%U:%G %a' /var/lib/hal0/.hermes/runtime.json
+stat -c '%U:%G %a' /var/lib/hal0/venvs/hermes/bin/hermes
+ls -ld /root/.hermes 2>/dev/null && echo "!! split-brain tree exists"
+```
+
+**Remediate** (hand ownership back to `hal0`, drop the split-brain tree):
+
+```bash
+sudo chown -R hal0:hal0 /var/lib/hal0/.hermes /var/lib/hal0/venvs/hermes
+sudo rm -rf /root/.hermes          # only after confirming nothing unique lives here
+hal0 agent bootstrap hermes --repair
+sudo systemctl restart hal0-agent@hermes.service
+```
+
+**Never** invoke `hermes` from a root shell to "just check something" — use
+`sudo -H -u hal0 hermes …` (or `runuser -u hal0 -- hermes …`) so it runs as
+the service user with the correct `HOME`. The structural fix — a self-guarding
+wrapper that re-execs as `hal0` when invoked as root, plus bootstrap chowning
+its artifacts to `hal0:hal0` — is tracked in **issue #843** (see also the
+P5H-4 contract in `docs/superpowers/plans/2026-06-06-hindsight-engine-swap.md`).
+
 ## Customising the unit
 
 **Don't edit `hal0-agent@.service` directly** — `hal0 update` will

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -179,6 +179,7 @@ hal0 migrate model-layout                    # migrate model store to canonical 
 ```sh
 hal0 doctor                                  # run preflight health checks
 hal0 doctor toolbox-pull                     # pull latest inference toolbox images
+hal0 doctor perms                            # audit Hermes ownership (root-clobber regression)
 ```
 
 ## Updates

--- a/docs/superpowers/specs/2026-06-15-hal0-runas-guard-design.md
+++ b/docs/superpowers/specs/2026-06-15-hal0-runas-guard-design.md
@@ -1,0 +1,204 @@
+# Design: hal0 run-as guard — prevent wrong-user clobber of agent state
+
+- **Date:** 2026-06-15
+- **Issue:** [#843](https://github.com/Hal0ai/hal0/issues/843)
+- **Status:** Approved design, pre-implementation
+- **Related:** PR #769 (non-root install fails fast), P5H-4 in
+  `docs/superpowers/plans/2026-06-06-hindsight-engine-swap.md`,
+  `docs/agents/hermes/SERVICE.md` (operator runbook)
+
+## Problem
+
+hal0-managed processes must run as the unprivileged `hal0` user with
+`HOME=/var/lib/hal0`. The systemd template (`hal0-agent@.service` → `User=hal0`)
+enforces this for the *service* path, but nothing stops a human (or the
+installer) from launching the same binaries as **root** — `sudo hermes …`, a
+root TUI session, or root-context bootstrap. When that happens, two failures
+occur, usually together:
+
+1. **Split-brain home.** As root, a `HOME`-relative path like `~/.hermes`
+   resolves to `/root/.hermes` instead of `/var/lib/hal0/.hermes`. The process
+   writes a competing config/state tree the `hal0`-user service never reads.
+2. **Permission clobber.** Where root writes into `/var/lib/hal0/.hermes`, files
+   land `root:root` (`config.yaml` 0600, the `runtime.json` embed token 0600,
+   the venv). The `hal0`-user service then hits `EACCES` — or worse, silently
+   falls back to the **default provider** because it cannot read its own config.
+
+The silent fallback is the real villain: the system keeps "working" while
+answering from the wrong model. This is the documented "root-clobber regression"
+(P5H-4); it keeps coming back because past fixes were applied on the live CT105
+box rather than in the repo's wrapper/installer.
+
+This design generalises the fix: **one enforcement primitive that every
+hal0-managed process inherits**, so no hal0 process can run as the wrong user
+and clobber state — Hermes today, any future `hal0-agent@` instance tomorrow.
+
+## Goals / Non-goals
+
+**Goals**
+- A single, shared chokepoint that auto-corrects wrong-user launches by
+  re-execing as the canonical user with the correct `HOME`.
+- Fixing the privilege-clobber *and* the split-brain home in one move (a correct
+  re-exec sets `HOME=/var/lib/hal0`, so `~`-relative paths resolve correctly).
+- Defense-in-depth ownership handover for artifacts the installer/bootstrap
+  legitimately creates as root.
+- Loud detection of pre-existing drift; convergence via an explicit repair.
+
+**Non-goals**
+- No automatic, behind-your-back `chown -R` from healthchecks/timers (footgun:
+  a misconfigured canonical path would happily chown the wrong tree).
+- Not changing the supported install model (system install still runs as root;
+  PR #769's non-root-install fail-fast stays as is — this is its inverse).
+- Not hardening against a malicious root; this prevents *accidental* misuse, not
+  an adversary who already has root and means harm.
+
+## Architecture: three layers
+
+### Layer 1 — Prevent: shared shell guard (`runas.sh`)
+
+A tiny POSIX shell library installed once at a stable absolute path (e.g.
+`/usr/local/lib/hal0/runas.sh`, final path confirmed against install.sh
+conventions). It exposes one function:
+
+```sh
+# hal0_ensure_runas <user>
+# If EUID != 0  -> return (we are some user; the caller's own perms apply).
+# If EUID == 0:
+#   - honor opt-out: if $HAL0_ALLOW_ROOT (or per-tool $HAL0_HERMES_ALLOW_ROOT)
+#     is set, return without re-exec (deliberate root debugging).
+#   - if target <user> does not exist -> return (nothing to drop to).
+#   - else exec the current command as <user> with a clean, correct env:
+#       prefer:  runuser -u <user> --        (util-linux; sets HOME via PAM)
+#       else:    setpriv --reuid <user> --regid <user> --init-groups env -- ...
+#       else:    sudo -H -u <user> --
+#     stripping any inherited HERMES_HOME (env -u HERMES_HOME semantics) so the
+#     re-exec resolves HOME=/var/lib/hal0 and never /root.
+```
+
+Every generated wrapper sources this lib as its **first executable line** and
+calls `hal0_ensure_runas hal0` before doing anything else. Because it `exec`s,
+the rest of the wrapper (including the existing cwd-guard at `hermes:64-74`)
+then runs *as hal0* and behaves correctly.
+
+**Why a shared shell lib (approach A), not a launcher binary or Python guard:**
+Hermes is a third-party binary we only control at the wrapper. Wrappers are
+already generated/installed by `install.sh`, so one sourced file is inherited by
+every wrapper with no per-wrapper duplication, and it works for both
+third-party-wrapped binaries and hal0's own shell entrypoints. A standalone
+`hal0-run` launcher adds a command + indirection for the same edit surface; a
+Python-entry guard can't cover the wrapped Hermes binary, so we'd build the
+shell guard anyway.
+
+**Coverage of the systemd path:** the unit's `ExecStart` reaches the wrapper
+(confirmed via recon of the `hal0-agent` shim). Running as `hal0` already, the
+guard is a no-op there — correct and harmless. If the shim execs the venv binary
+directly (bypassing the wrapper), the design routes it through the wrapper or
+sources the guard in the shim launch path so the chokepoint is not bypassable.
+
+**Opt-out:** `HAL0_ALLOW_ROOT=1` (global) / `HAL0_HERMES_ALLOW_ROOT=1` (per
+tool) lets a deliberate root debug session through, explicitly.
+
+### Layer 2 — Prevent: bootstrap chowns its own artifacts
+
+The installer/bootstrap legitimately runs as root and creates files *before* any
+service runs; the guard can't cover that. So each creation site hands ownership
+to `hal0:hal0` immediately after creating, guarded on running-as-root and the
+hal0 user existing, idempotent:
+
+- `hermes_provision.py:_install_venv` (~:447) → `chown -R hal0:hal0` the venv.
+- `_claim_hermes_home` (~:620-626) / `_phase_home_init` (~:654-655) →
+  `chown -R hal0:hal0` the `HERMES_HOME` tree.
+- `_write_runtime_json` (~:3340-3373) → chown `runtime.json` to hal0 *after* the
+  0600 chmod (embed token must be hal0-readable).
+- `install.sh` → explicit `chown -R hal0:hal0 /var/lib/hal0/venvs/hermes`
+  alongside the existing `.cache`/`memory` chowns (~:1022,:1142), matching their
+  idiom. Reuse existing canonical user/home vars, do not hardcode.
+
+### Layer 3 — Detect (auto, read-only) + Repair (explicit)
+
+- **Detect:** a read-only check surfaced in the agent healthcheck /
+  `hal0`-doctor path that flags, loudly: `root:root` ownership on
+  `config.yaml` / `runtime.json` / venv root, and the existence of
+  `/root/.hermes`. This converts the silent "wrong model" failure into a visible
+  one. Exact host of the check confirmed against the CLI surface (a `doctor`
+  subcommand if one exists, else the existing `hal0-agent <id> status` path).
+- **Repair:** an *explicit*, idempotent reconciliation the operator invokes —
+  extend `hal0 agent bootstrap hermes --repair` to also chown the `.hermes`
+  tree/venv/runtime.json to `hal0:hal0` and (after confirmation) drop a stray
+  `/root/.hermes`. Convergence for already-broken boxes (incl. CT105) without
+  any automatic filesystem mutation.
+
+## Data flow
+
+```
+launch (any user) ──▶ wrapper sources runas.sh ──▶ hal0_ensure_runas hal0
+   EUID!=0 ─────────────────────────────────────▶ proceed as caller
+   EUID==0 + opt-out ───────────────────────────▶ proceed as root (explicit)
+   EUID==0 ─────────────▶ exec runuser/setpriv/sudo as hal0 (HOME=/var/lib/hal0)
+                          └▶ wrapper re-runs as hal0 ▶ cwd-guard ▶ exec hermes
+```
+
+Install/bootstrap (root) ─▶ create artifact ─▶ chown hal0:hal0 (Layer 2).
+Healthcheck/doctor (any) ─▶ stat probe ─▶ flag drift (Layer 3 detect).
+`bootstrap --repair` (root) ─▶ reconcile ownership + drop /root/.hermes (Layer 3 repair).
+
+## Components & isolation
+
+| Unit | Purpose | Interface | Depends on |
+|---|---|---|---|
+| `runas.sh` | re-exec a command as a target user | `hal0_ensure_runas <user>` (sourced) | `runuser`/`setpriv`/`sudo`, `id` |
+| wrapper edit | invoke the guard first | sources `runas.sh`, calls the fn | `runas.sh` at a fixed path |
+| install.sh wiring | install the lib + chown artifacts | shell, root-guarded | existing canonical vars |
+| provision chowns | hand artifact ownership to hal0 | python helper, root-guarded | hal0 user, canonical paths |
+| detect check | read-only drift report | `stat` probe in healthcheck/doctor | canonical paths |
+| repair action | explicit ownership reconcile | `bootstrap … --repair` | hal0 user, canonical paths |
+
+Each unit is independently testable: the guard via a fake-`runuser` shim, the
+chowns via a root-context install assertion, the detect/repair via crafted
+`root:root` fixtures.
+
+## Testing
+
+A regression smoke test (mirrors P5H-4 checks), runnable in CI/harness:
+
+1. **Guard re-exec:** invoke the wrapper with `EUID==0` simulated and a stubbed
+   `runuser` on `PATH`; assert the stub is called with `-u hal0`, the original
+   args are preserved, and `HERMES_HOME` is not leaked from root's env.
+2. **Opt-out:** with `HAL0_ALLOW_ROOT=1`, assert no re-exec attempt.
+3. **Non-root passthrough:** `EUID!=0` → guard is a no-op, command runs as-is.
+4. **Bootstrap ownership:** after a root-context install/bootstrap,
+   `stat -c '%U:%G %a'` on `config.yaml`, `runtime.json`, and the venv root all
+   read `hal0:hal0` (NOT `root:root 0600`); `/root/.hermes` does not exist.
+5. **No-clobber:** `sudo hermes <version>` creates/rewrites no `root:root` file
+   under `/var/lib/hal0/.hermes`.
+6. **Detect:** with crafted `root:root` fixtures, the detect check reports drift
+   (non-zero / flagged); clean fixtures report healthy.
+
+Test home + style confirmed against the existing installer/wrapper test layout
+(recon). Shell-level assertions where the unit is shell; pytest where python.
+
+## Risks & mitigations
+
+- **`runuser`/`setpriv` absent on a host** → fall back through the tool chain
+  (`runuser` → `setpriv` → `sudo -H -u`); if none can drop privilege, the guard
+  must not proceed as root silently — log a clear message. (Per the chosen
+  philosophy we auto-correct; the unreachable-tool case degrades to a loud
+  no-drop warning, not a silent root run.)
+- **Re-exec loop** → the guard returns immediately when already `EUID!=0`, so a
+  re-exec'd invocation cannot re-trigger it.
+- **Breaking the systemd path** → guard is a no-op when already `hal0`; covered
+  by health smoke test post-change. Do NOT deploy to CT105 (shared host) as part
+  of this change; ship a green PR and let an operator deploy.
+- **Chown touching the wrong tree** → all chowns reference existing canonical
+  vars, are root-guarded, and only target the known `.hermes`/venv paths.
+- **`/var/lib/hal0` is `2775` setgid root:hal0** (install.sh) — preserve; this
+  design only changes the `.hermes` subtree + venv ownership, not the parent.
+
+## Rollout
+
+1. Implement Layers 1–3 in the repo via TDD on `fix/hal0-runas-guard`.
+2. Smoke test green in CI.
+3. Open PR referencing #843; include the SERVICE.md runbook edit (already on the
+   branch).
+4. Operator deploys to CT105 (out of scope here; another session is currently
+   active on that runtime) and runs `bootstrap --repair` to converge the box.

--- a/docs/superpowers/specs/2026-06-15-hal0-runas-guard-design.md
+++ b/docs/superpowers/specs/2026-06-15-hal0-runas-guard-design.md
@@ -202,3 +202,32 @@ Test home + style confirmed against the existing installer/wrapper test layout
    branch).
 4. Operator deploys to CT105 (out of scope here; another session is currently
    active on that runtime) and runs `bootstrap --repair` to converge the box.
+
+## As-built (implemented on `fix/hal0-runas-guard`)
+
+Concrete decisions made during TDD implementation:
+
+- **Layer 1 (wrapper):** guard lib lives at `installer/lib/run-as-hal0.sh`,
+  installed by `install.sh` to `/usr/lib/hal0/guards/run-as-hal0.sh` (matches the
+  hermes-hooks `install -m 0755` idiom; dev-mode PREFIX shadows it). Only
+  `installer/wrappers/hermes` sources it — `hal0-hermes` is a symlink to that
+  wrapper, so it inherits the guard for free. Re-exec wraps the command in
+  `env HOME=<home> -u HERMES_HOME` so HOME is correct and HERMES_HOME is dropped
+  regardless of which dropper (runuser → setpriv → sudo) is used.
+- **Layer 1 (systemd path):** the `hal0-agent` shim execs the venv binary
+  directly (NOT the wrapper), so the guard there is `_runas_popen_extras()` in
+  `agent_shim.py`, which adds `user=`/`group=` to the `Popen` and corrects
+  `env['HOME']` when running as root. No-op under the unit (already `User=hal0`).
+- **Layer 2 (chown):** `_chown_tree_to_hal0()` in `hermes_provision.py`, called
+  from `_phase_install` (venv), `_phase_home_init` (HERMES_HOME tree), and
+  `_phase_install_artifacts` (runtime.json). No-op unless root, so `--repair`
+  reconciles ownership on already-broken boxes.
+- **Layer 3 (detect):** `hal0 doctor perms` — read-only ownership audit
+  (`check_hermes_ownership` / `has_ownership_drift` in `doctor_commands.py`).
+  Exits non-zero and points at `bootstrap --repair` on drift. No auto-repair.
+- **Opt-out:** `HAL0_ALLOW_ROOT=1` honored by both the shell guard and the shim.
+- **Test seam:** `HAL0_RUNAS_TEST_UID` lets the guard's euid be faked in CI
+  (we can't become root); production never sets it.
+- **Deferred:** a root-context harness smoke row (real `stat` ownership +
+  no-`/root/.hermes` after a root install) — can't run in non-root CI; tracked
+  as a follow-up. Ownership behavior is covered by the helper unit tests.

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -660,6 +660,18 @@ if [[ -f "${AGENT_UNIT_SRC}" ]]; then
     else
         warn "${HOOK_SRC} not found — Hermes session-state hook not installed"
     fi
+
+    # run-as-hal0 guard: the hermes wrapper sources this at the absolute path
+    # ${LIB_DIR}/guards/run-as-hal0.sh and re-execs as the hal0 service user
+    # when launched as root, preventing the root-clobber regression (#843).
+    GUARD_SRC="${REPO_ROOT}/installer/lib/run-as-hal0.sh"
+    if [[ -f "${GUARD_SRC}" ]]; then
+        install -d "${LIB_DIR}/guards"
+        install -m 0755 "${GUARD_SRC}" "${LIB_DIR}/guards/run-as-hal0.sh"
+        info "wrote ${LIB_DIR}/guards/run-as-hal0.sh"
+    else
+        warn "${GUARD_SRC} not found — run-as-hal0 guard not installed"
+    fi
 else
     warn "${AGENT_UNIT_SRC} not found — hal0-agent@ template not installed"
 fi

--- a/installer/lib/run-as-hal0.sh
+++ b/installer/lib/run-as-hal0.sh
@@ -1,0 +1,57 @@
+# shellcheck shell=sh
+# run-as-hal0.sh — sourced privilege-drop guard for hal0-managed wrappers.
+#
+# hal0_ensure_runas <user> <cmd> [args...]
+#
+#   When the caller is root, RE-EXEC <cmd> as <user> with that user's HOME and
+#   a sanitized env (HERMES_HOME stripped), so a hal0-managed process never runs
+#   as root. Running as root would resolve `~/.hermes` to /root/.hermes (a
+#   split-brain state tree the hal0 service never reads) and create root:root
+#   files the hal0 user later can't read — the "root-clobber regression" (#843).
+#
+#   * non-root caller      -> return 0; the caller proceeds with its own perms.
+#   * root + HAL0_ALLOW_ROOT (1/true/yes) -> return 0; deliberate root debug.
+#   * root, no <user>       -> return 0; nothing to drop to.
+#   * root                  -> exec <cmd...> as <user> (this process is replaced).
+#   * root, no dropper tool -> return non-zero + a refusal on stderr; we never
+#                              proceed silently as root.
+#
+#   Privilege-drop tool preference: runuser (util-linux, sets HOME via passwd)
+#   -> setpriv --init-groups -> sudo -H. The command is always wrapped in
+#   `env HOME=<home> -u HERMES_HOME` so HOME is correct and any inherited
+#   HERMES_HOME is dropped regardless of which tool is used.
+#
+#   HAL0_RUNAS_TEST_UID overrides the detected euid — TEST ONLY (we can't become
+#   root in CI). Never set it in production.
+
+hal0_ensure_runas() {
+    _hru_user="${1:-}"
+    [ -n "$_hru_user" ] || return 0
+    shift
+    [ "$#" -gt 0 ] || return 0
+
+    _hru_uid="${HAL0_RUNAS_TEST_UID:-$(id -u 2>/dev/null || echo 0)}"
+    [ "$_hru_uid" = "0" ] || return 0
+
+    case "${HAL0_ALLOW_ROOT:-}" in
+        1 | true | yes | TRUE | YES) return 0 ;;
+    esac
+
+    id "$_hru_user" >/dev/null 2>&1 || return 0
+
+    _hru_home="$(getent passwd "$_hru_user" 2>/dev/null | cut -d: -f6)"
+    [ -n "$_hru_home" ] || _hru_home="/var/lib/hal0"
+
+    if command -v runuser >/dev/null 2>&1; then
+        exec runuser -u "$_hru_user" -- env "HOME=$_hru_home" -u HERMES_HOME "$@"
+    elif command -v setpriv >/dev/null 2>&1; then
+        exec setpriv --reuid "$_hru_user" --regid "$_hru_user" --init-groups -- \
+            env "HOME=$_hru_home" -u HERMES_HOME "$@"
+    elif command -v sudo >/dev/null 2>&1; then
+        exec sudo -H -u "$_hru_user" -- env -u HERMES_HOME "$@"
+    fi
+
+    printf 'hal0: refusing to run as root and cannot drop privileges to %s ' "$_hru_user" >&2
+    printf '(no runuser/setpriv/sudo found). Set HAL0_ALLOW_ROOT=1 to override.\n' >&2
+    return 1
+}

--- a/installer/wrappers/hermes
+++ b/installer/wrappers/hermes
@@ -33,6 +33,18 @@
 
 set -eu
 
+# run-as-hal0 guard: if launched as root, re-exec as the unprivileged hal0
+# service user (correct HOME, HERMES_HOME stripped) BEFORE we touch any state.
+# Otherwise hermes would resolve ~/.hermes to /root/.hermes and write root:root
+# files the hal0 service can't read — the root-clobber regression (#843).
+# Sourced defensively: a dev/uninstalled box without the lib runs unguarded.
+HAL0_GUARD_LIB="${HAL0_GUARD_LIB:-/usr/lib/hal0/guards/run-as-hal0.sh}"
+if [ -r "$HAL0_GUARD_LIB" ]; then
+    # shellcheck disable=SC1090
+    . "$HAL0_GUARD_LIB"
+    hal0_ensure_runas hal0 "$0" "$@" || exit $?
+fi
+
 HAL0_AGENT_ID="${HAL0_AGENT_ID:-hermes-agent}"
 HAL0_HERMES_BIN="${HAL0_HERMES_BIN:-/var/lib/hal0/venvs/hermes/bin/hermes}"
 HAL0_HERMES_SECRETS="${HAL0_HERMES_SECRETS:-/var/lib/hal0/secrets/agents/hermes.env}"

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -33,6 +33,7 @@ import datetime
 import hashlib
 import json
 import os
+import pwd
 import shutil
 import subprocess  # nosec B404 — needed to spawn python -m venv + pip
 import sys
@@ -458,6 +459,54 @@ def _install_venv(
     )
 
 
+_HAL0_SERVICE_USER = "hal0"
+
+
+def _resolve_user_ids(user: str) -> tuple[int, int] | None:
+    """Return ``(uid, gid)`` for ``user``, or ``None`` if the user is absent."""
+    try:
+        ent = pwd.getpwnam(user)
+    except KeyError:
+        return None
+    return (ent.pw_uid, ent.pw_gid)
+
+
+def _chown_tree_to_hal0(
+    path: Path,
+    *,
+    user: str = _HAL0_SERVICE_USER,
+    geteuid: Callable[[], int] = os.geteuid,
+    resolve_ids: Callable[[str], tuple[int, int] | None] = _resolve_user_ids,
+    chown: Callable[[str, int, int], None] = os.chown,
+) -> int:
+    """Recursively chown ``path`` to the hal0 service user, returning the count.
+
+    Hands ownership of root-created artifacts (venv, ``$HERMES_HOME`` tree,
+    ``runtime.json``) to the unprivileged ``hal0`` user so the ``User=hal0``
+    systemd unit can read/write them instead of hitting EACCES or silently
+    falling back to the default provider — the root-clobber regression (#843).
+
+    A no-op (returns 0) when not root, when ``user`` doesn't exist, or when
+    ``path`` is missing, so it's safe in dev/non-root installs and idempotent
+    under ``bootstrap --repair``.
+    """
+    if geteuid() != 0:
+        return 0
+    ids = resolve_ids(user)
+    if ids is None:
+        return 0
+    if not path.exists():
+        return 0
+    uid, gid = ids
+    count = 0
+    chown(str(path), uid, gid)
+    count += 1
+    for sub in path.rglob("*"):
+        chown(str(sub), uid, gid)
+        count += 1
+    return count
+
+
 def _copy_wrapper(wrapper_src: Path, wrapper_dst: Path) -> None:
     """Copy + chmod the wrapper into ``wrapper_dst``."""
     wrapper_dst.parent.mkdir(parents=True, exist_ok=True)
@@ -592,6 +641,12 @@ def _phase_install(ctx: PhaseContext) -> PhaseResult:
                 reason=f"plugin copy {src} -> {dst} failed: {exc}",
             )
     details["plugins"] = [str(p) for p in plugin_targets.values()]
+
+    # The venv lives outside HERMES_HOME (/var/lib/hal0/venvs/hermes); hand it to
+    # hal0 too so a root install doesn't leave a root-owned venv (#843). No-op
+    # when not root.
+    _chown_tree_to_hal0(venv)
+
     return PhaseResult(status=PhaseStatus.OK, details=details)
 
 
@@ -653,6 +708,11 @@ def _phase_home_init(ctx: PhaseContext) -> PhaseResult:
     )
     for sub in standard_subdirs:
         (hermes_home / sub).mkdir(parents=True, exist_ok=True)
+
+    # Hand the whole tree to the hal0 service user so a root-context bootstrap
+    # never leaves root:root files the User=hal0 unit can't read (#843).
+    # No-op when not root; also reconciles ownership under --repair.
+    _chown_tree_to_hal0(hermes_home)
 
     return PhaseResult(
         status=PhaseStatus.OK,
@@ -3511,6 +3571,10 @@ def _phase_install_artifacts(ctx: PhaseContext) -> PhaseResult:
     seed_path, seed_wrote = _write_seed_toml(state, repair=repair)
     env_path, env_wrote = _write_driver_env(state)
     runtime_path, token_wrote = _write_runtime_json(state, repair=repair)
+
+    # runtime.json carries the embed token at 0600 — chown it to hal0 so the
+    # User=hal0 chat proxy can read it instead of falling back silently (#843).
+    _chown_tree_to_hal0(runtime_path)
 
     return PhaseResult(
         status=PhaseStatus.OK,

--- a/src/hal0/cli/agent_shim.py
+++ b/src/hal0/cli/agent_shim.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import os
+import pwd
 import shutil
 import signal
 import socket
@@ -48,6 +49,7 @@ import urllib.request
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 # ----------------------------------------------------------------------------
 # Configuration discovery
@@ -275,6 +277,39 @@ def _build_hermes_argv(cfg: AgentConfig) -> list[str]:
     return argv
 
 
+_RUNAS_USER = "hal0"
+
+
+def _runas_popen_extras(
+    env: dict[str, str],
+    *,
+    user: str = _RUNAS_USER,
+    geteuid: Callable[[], int] = os.geteuid,
+    getpwnam: Callable[[str], Any] = pwd.getpwnam,
+    allow_root: bool | None = None,
+) -> dict[str, Any]:
+    """Popen kwargs that drop the child to ``user`` when we're running as root.
+
+    The systemd ExecStart path execs the venv binary directly (bypassing the
+    /usr/local/bin/hermes wrapper guard). Under the unit we're already
+    ``User=hal0``, but a manual ``hal0-agent hermes serve`` as root would spawn a
+    root-owned Hermes that clobbers state (#843). When root, return
+    ``{"user", "group"}`` for ``subprocess.Popen`` and correct ``env['HOME']`` to
+    the target user's home. A no-op (``{}``) when not root, when
+    ``HAL0_ALLOW_ROOT`` is set, or when ``user`` doesn't exist.
+    """
+    if allow_root is None:
+        allow_root = os.environ.get("HAL0_ALLOW_ROOT", "") in ("1", "true", "yes")
+    if allow_root or geteuid() != 0:
+        return {}
+    try:
+        ent = getpwnam(user)
+    except KeyError:
+        return {}
+    env["HOME"] = ent.pw_dir
+    return {"user": ent.pw_uid, "group": ent.pw_gid}
+
+
 def _build_hermes_env(cfg: AgentConfig) -> dict[str, str]:
     """Build the child env for Hermes — inherits parent + adds hal0 keys."""
 
@@ -341,6 +376,11 @@ def cmd_serve(cfg: AgentConfig) -> int:
     argv = _build_hermes_argv(cfg)
     env = _build_hermes_env(cfg)
 
+    # If launched as root (manual `hal0-agent hermes serve` — the systemd unit
+    # is already User=hal0), drop the child to hal0 so it can't write root-owned
+    # state (#843). No-op under the unit / non-root / HAL0_ALLOW_ROOT.
+    runas = _runas_popen_extras(env)
+
     # Don't ``exec`` — we need a parent process to drive sd_notify
     # READY/WATCHDOG. Forward signals into the child via the SIGTERM
     # handler below.
@@ -349,6 +389,7 @@ def cmd_serve(cfg: AgentConfig) -> int:
         env=env,
         cwd=str(cfg.home if cfg.home.exists() else Path.cwd()),
         stdin=subprocess.DEVNULL,
+        **runas,
     )
 
     def _forward_signal(signum: int, _frame: object) -> None:

--- a/src/hal0/cli/doctor_commands.py
+++ b/src/hal0/cli/doctor_commands.py
@@ -27,9 +27,11 @@ Sub-commands:
 from __future__ import annotations
 
 import os
+import pwd
 import shutil
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -353,3 +355,108 @@ def toolbox_pull(
 
     failures = [r for r in rows if not r["ok"]]
     raise typer.Exit(1 if failures else 0)
+
+
+# ── hal0 doctor perms — Hermes ownership drift (#843) ─────────────────────────
+#
+# Read-only audit for the root-clobber regression: when root runs Hermes it
+# writes a split-brain /root/.hermes tree and/or leaves root:root files the
+# User=hal0 unit can't read (so Hermes silently falls back to the default
+# provider). This surfaces that loudly. It NEVER repairs — reconciliation is the
+# explicit `sudo hal0 agent bootstrap hermes --repair` path.
+
+_HERMES_HOME = Path("/var/lib/hal0/.hermes")
+_HERMES_VENV = Path("/var/lib/hal0/venvs/hermes")
+_STRAY_ROOT_HOME = Path("/root/.hermes")
+_EXPECTED_OWNER = "hal0"
+
+
+def check_hermes_ownership(
+    *,
+    expected_user: str = _EXPECTED_OWNER,
+    hermes_home: Path = _HERMES_HOME,
+    venv: Path = _HERMES_VENV,
+    stray_home: Path = _STRAY_ROOT_HOME,
+    owner_of: Callable[[Path], str | None],
+    exists: Callable[[Path], bool],
+) -> list[dict[str, str]]:
+    """Audit Hermes runtime ownership; return rows ``{path,label,status,detail}``.
+
+    ``status`` is ``ok`` (owned by ``expected_user``), ``drift`` (wrong owner, or
+    a stray /root/.hermes), or ``absent`` (not present — not a problem).
+    """
+    rows: list[dict[str, str]] = []
+    checks = (
+        (hermes_home, "HERMES_HOME tree"),
+        (hermes_home / "config.yaml", "config.yaml"),
+        (hermes_home / "runtime.json", "runtime.json (embed token)"),
+        (venv, "hermes venv"),
+    )
+    for path, label in checks:
+        if not exists(path):
+            rows.append(
+                {"path": str(path), "label": label, "status": "absent", "detail": "not present"}
+            )
+            continue
+        owner = owner_of(path)
+        if owner == expected_user:
+            rows.append(
+                {"path": str(path), "label": label, "status": "ok", "detail": f"owned by {owner}"}
+            )
+        else:
+            rows.append(
+                {
+                    "path": str(path),
+                    "label": label,
+                    "status": "drift",
+                    "detail": f"owned by {owner or '?'} (expected {expected_user})",
+                }
+            )
+    if exists(stray_home):
+        rows.append(
+            {
+                "path": str(stray_home),
+                "label": "split-brain /root/.hermes",
+                "status": "drift",
+                "detail": "root ran Hermes; remove after reconciling",
+            }
+        )
+    return rows
+
+
+def has_ownership_drift(rows: list[dict[str, str]]) -> bool:
+    """True iff any row is in the ``drift`` state."""
+    return any(r["status"] == "drift" for r in rows)
+
+
+@app.command("perms")
+def perms() -> None:
+    """Audit Hermes runtime ownership for the root-clobber regression (#843)."""
+
+    def _owner(p: Path) -> str | None:
+        try:
+            return pwd.getpwuid(p.stat().st_uid).pw_name
+        except (OSError, KeyError):
+            return None
+
+    rows = check_hermes_ownership(owner_of=_owner, exists=lambda p: p.exists())
+    table = Table(title="Hermes ownership audit (#843)")
+    table.add_column("Check", style="bold")
+    table.add_column("Status")
+    table.add_column("Detail")
+    badge = {
+        "ok": "[green]ok[/green]",
+        "drift": "[red]DRIFT[/red]",
+        "absent": "[dim]absent[/dim]",
+    }
+    for r in rows:
+        table.add_row(r["label"], badge[r["status"]], r["detail"])
+    console.print(table)
+    if has_ownership_drift(rows):
+        console.print(
+            "[red]✗[/red]  ownership drift — run `sudo hal0 agent bootstrap hermes --repair`"
+            " to reconcile."
+        )
+        raise typer.Exit(1)
+    console.print("[green]✓[/green]  Hermes ownership clean.")
+    raise typer.Exit(0)

--- a/tests/agents/test_hermes_provision_ownership.py
+++ b/tests/agents/test_hermes_provision_ownership.py
@@ -1,0 +1,102 @@
+"""Tests for the Layer-2 ownership handover in hermes provisioning (#843).
+
+The installer/bootstrap legitimately runs as root and creates the venv,
+``$HERMES_HOME`` tree, and ``runtime.json``. If those stay ``root:root`` the
+``User=hal0`` systemd unit can't read them (EACCES, or a silent fallback to the
+default provider). ``_chown_tree_to_hal0`` hands ownership to the hal0 service
+user — but only when actually root, so it's a safe no-op in dev/non-root
+installs and idempotent under ``bootstrap --repair``.
+
+We can't chown to a real ``hal0`` user in CI, so the euid check, id resolution,
+and the chown syscall are injected seams.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hal0.agents import hermes_provision as hp
+
+
+def _recorder():
+    calls: list[tuple[str, int, int]] = []
+
+    def _chown(path: str, uid: int, gid: int) -> None:
+        calls.append((path, uid, gid))
+
+    return calls, _chown
+
+
+def test_noop_when_not_root(tmp_path: Path) -> None:
+    (tmp_path / "f").write_text("x")
+    calls, chown = _recorder()
+    n = hp._chown_tree_to_hal0(
+        tmp_path,
+        geteuid=lambda: 1000,
+        resolve_ids=lambda _u: (1, 1),
+        chown=chown,
+    )
+    assert n == 0
+    assert calls == []
+
+
+def test_noop_when_user_unknown(tmp_path: Path) -> None:
+    (tmp_path / "f").write_text("x")
+    calls, chown = _recorder()
+    n = hp._chown_tree_to_hal0(
+        tmp_path,
+        geteuid=lambda: 0,
+        resolve_ids=lambda _u: None,
+        chown=chown,
+    )
+    assert n == 0
+    assert calls == []
+
+
+def test_noop_when_path_missing(tmp_path: Path) -> None:
+    calls, chown = _recorder()
+    n = hp._chown_tree_to_hal0(
+        tmp_path / "does-not-exist",
+        geteuid=lambda: 0,
+        resolve_ids=lambda _u: (1, 1),
+        chown=chown,
+    )
+    assert n == 0
+    assert calls == []
+
+
+def test_recursive_chown_to_hal0_ids_when_root(tmp_path: Path) -> None:
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "deep.txt").write_text("x")
+    (tmp_path / "top.txt").write_text("y")
+    calls, chown = _recorder()
+    n = hp._chown_tree_to_hal0(
+        tmp_path,
+        geteuid=lambda: 0,
+        resolve_ids=lambda _u: (4242, 4243),
+        chown=chown,
+    )
+    chowned = {Path(p) for p, _, _ in calls}
+    assert tmp_path in chowned  # the root itself
+    assert tmp_path / "sub" in chowned
+    assert tmp_path / "sub" / "deep.txt" in chowned
+    assert tmp_path / "top.txt" in chowned
+    assert n == len(calls) == 4
+    assert all((uid, gid) == (4242, 4243) for _, uid, gid in calls)
+
+
+def test_resolve_user_ids_returns_none_for_unknown_user() -> None:
+    assert hp._resolve_user_ids("definitely-not-a-real-user-xyz") is None
+
+
+def test_home_init_hands_hermes_home_to_hal0(tmp_path, monkeypatch) -> None:
+    """_phase_home_init must chown the canonical HERMES_HOME tree to hal0 so a
+    root-context bootstrap doesn't leave root:root files (#843). Spy on the
+    helper so the assertion holds without being root."""
+    hermes_home = tmp_path / "hermes_home"
+    state = hp.BootstrapState(hermes_home=str(hermes_home))
+    chowned: list[Path] = []
+    monkeypatch.setattr(hp, "_chown_tree_to_hal0", lambda p, **_k: chowned.append(Path(p)) or 0)
+    out = hp._phase_home_init(hp.context_for("home_init", state))
+    assert out.status == hp.PhaseStatus.OK
+    assert hermes_home in chowned

--- a/tests/agents/test_run_as_hal0_guard.py
+++ b/tests/agents/test_run_as_hal0_guard.py
@@ -1,0 +1,154 @@
+"""Tests for the shared run-as-hal0 privilege-drop guard.
+
+``installer/lib/run-as-hal0.sh`` is sourced by the hermes wrapper (and any
+future agent wrapper). Its sole job: when a hal0-managed process is launched
+as root, re-exec it as the unprivileged service user with that user's HOME and
+a sanitized env, so we never write a split-brain ``/root/.hermes`` tree or
+``root:root`` perms (#843). It is a no-op for non-root callers.
+
+The guard exposes one function, ``hal0_ensure_runas <user> <cmd...>``:
+  * non-root          -> return 0 (caller proceeds with its own perms)
+  * root + opt-out    -> return 0 (HAL0_ALLOW_ROOT=1 — deliberate root debug)
+  * root              -> exec <cmd...> as <user> (process is replaced)
+  * root, no dropper  -> return non-zero + refuse (never proceed as root)
+
+Tests drive the guard through ``sh`` with:
+  * ``HAL0_RUNAS_TEST_UID`` — a documented test-only seam to fake the euid
+    (we can't become root in CI).
+  * a stub ``runuser`` on PATH that echoes its argv instead of switching users,
+    so we can assert exactly what would be exec'd.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GUARD = _REPO_ROOT / "installer" / "lib" / "run-as-hal0.sh"
+
+
+def _existing_unprivileged_user() -> str:
+    """A user that exists on the test host but isn't us — 'nobody' on Linux."""
+    if subprocess.run(["id", "nobody"], capture_output=True).returncode == 0:
+        return "nobody"
+    return os.environ.get("USER", "")
+
+
+def _run_guard(
+    script: str,
+    *,
+    env: dict[str, str] | None = None,
+    extra_path: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Source the guard and run ``script`` under /bin/sh, capturing output."""
+    full_env = dict(os.environ)
+    if extra_path is not None:
+        full_env["PATH"] = f"{extra_path}{os.pathsep}{full_env['PATH']}"
+    if env:
+        full_env.update(env)
+    body = f". {_GUARD}\n{script}\n"
+    return subprocess.run(
+        ["/bin/sh", "-c", body],
+        capture_output=True,
+        text=True,
+        env=full_env,
+    )
+
+
+def _write_stub(dir_: Path, name: str, body: str) -> None:
+    p = dir_ / name
+    p.write_text("#!/bin/sh\n" + body + "\n", encoding="utf-8")
+    p.chmod(0o755)
+
+
+def test_guard_file_exists() -> None:
+    assert _GUARD.is_file(), f"guard library missing at {_GUARD}"
+
+
+def test_non_root_returns_without_running_command() -> None:
+    """A non-root caller proceeds with its own perms — the guard must NOT
+    run (or exec) the command; the wrapper runs the real command itself."""
+    res = _run_guard(
+        "hal0_ensure_runas hal0 echo SHOULD_NOT_RUN; echo RETURNED",
+        env={"HAL0_RUNAS_TEST_UID": "1000"},
+    )
+    assert res.returncode == 0, res.stderr
+    assert "RETURNED" in res.stdout
+    assert "SHOULD_NOT_RUN" not in res.stdout
+
+
+def test_root_with_opt_out_does_not_reexec() -> None:
+    """HAL0_ALLOW_ROOT=1 lets a deliberate root session through unchanged."""
+    res = _run_guard(
+        "hal0_ensure_runas hal0 echo X; echo RETURNED",
+        env={"HAL0_RUNAS_TEST_UID": "0", "HAL0_ALLOW_ROOT": "1"},
+    )
+    assert res.returncode == 0, res.stderr
+    assert "RETURNED" in res.stdout
+
+
+def test_root_reexecs_as_target_user_via_runuser(tmp_path: Path) -> None:
+    """As root, the guard re-execs the command as the target user with HOME
+    set and HERMES_HOME stripped, preferring runuser. The stub captures argv."""
+    user = _existing_unprivileged_user()
+    if not user:
+        pytest.skip("no unprivileged target user available on this host")
+    _write_stub(tmp_path, "runuser", 'echo "RUNUSER $*"')
+    res = _run_guard(
+        f"hal0_ensure_runas {user} echo HELLO; echo SHOULD_NOT_REACH",
+        env={"HAL0_RUNAS_TEST_UID": "0"},
+        extra_path=tmp_path,
+    )
+    assert res.returncode == 0, res.stderr
+    assert f"-u {user}" in res.stdout
+    assert "echo HELLO" in res.stdout
+    assert "HERMES_HOME" in res.stdout  # explicitly stripped via `env -u`
+    assert "HOME=" in res.stdout  # target HOME forced
+    assert "SHOULD_NOT_REACH" not in res.stdout
+
+
+_HERMES_WRAPPER = _REPO_ROOT / "installer" / "wrappers" / "hermes"
+_INSTALL_SH = _REPO_ROOT / "installer" / "install.sh"
+
+
+def test_install_sh_installs_guard_into_lib_dir() -> None:
+    """install.sh must drop the guard lib at the absolute path the wrapper
+    sources (``${LIB_DIR}/guards/run-as-hal0.sh``), matching the hermes-hooks
+    install idiom so dev-mode PREFIX shadowing works."""
+    text = _INSTALL_SH.read_text(encoding="utf-8")
+    assert "run-as-hal0.sh" in text
+    assert "guards" in text
+    assert "install -m 0755" in text and "guards/run-as-hal0.sh" in text
+
+
+def test_hermes_wrapper_sources_guard_and_calls_it_first() -> None:
+    """The hermes wrapper must source the guard and invoke it before doing any
+    real work (sourcing secrets, exec'ing the venv binary), so a root launch is
+    re-exec'd as hal0 before anything touches state."""
+    text = _HERMES_WRAPPER.read_text(encoding="utf-8")
+    assert "run-as-hal0.sh" in text
+    assert "hal0_ensure_runas hal0" in text
+    # Guard call precedes both the secrets sourcing and the final exec.
+    guard_at = text.index("hal0_ensure_runas hal0")
+    assert guard_at < text.index("HAL0_HERMES_SECRETS")
+    assert guard_at < text.rindex("exec ")
+
+
+def test_root_without_any_dropper_refuses(tmp_path: Path) -> None:
+    """If no runuser/setpriv/sudo is available, the guard refuses (non-zero)
+    rather than silently proceeding as root."""
+    # Minimal PATH: only id + getent stubs, NO privilege-drop tools.
+    _write_stub(tmp_path, "id", "echo 0")  # `id <user>` -> exists (exit 0)
+    _write_stub(tmp_path, "getent", 'echo "x:x:0:0:x:/nonexistent:/bin/sh"')
+    res = subprocess.run(
+        ["/bin/sh", "-c", f". {_GUARD}\nhal0_ensure_runas hal0 echo X\n"],
+        capture_output=True,
+        text=True,
+        env={"PATH": str(tmp_path), "HAL0_RUNAS_TEST_UID": "0"},
+    )
+    assert res.returncode != 0
+    assert "root" in (res.stderr + res.stdout).lower()

--- a/tests/cli/test_agent_shim.py
+++ b/tests/cli/test_agent_shim.py
@@ -13,6 +13,7 @@ import socket
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace as _NS
 from typing import Any
 from unittest.mock import patch
 
@@ -539,3 +540,55 @@ def test_render_context_in_parser_choices() -> None:
     parser = agent_shim._build_parser()
     args = parser.parse_args(["hermes", "render-context"])
     assert args.subcommand == "render-context"
+
+
+# ── run-as-hal0 privilege drop (#843) ────────────────────────────────────────
+#
+# The shim is the systemd ExecStart path and execs the venv binary directly,
+# bypassing the /usr/local/bin/hermes wrapper guard. Under the unit it already
+# runs as User=hal0, but a manual `hal0-agent hermes serve` as root would spawn
+# a root-owned hermes that clobbers state. `_runas_popen_extras` drops the child
+# to hal0 when (and only when) we're root.
+
+
+def _fake_pw(uid: int, gid: int, home: str):
+    def _getpwnam(name: str):
+        return _NS(pw_uid=uid, pw_gid=gid, pw_dir=home)
+
+    return _getpwnam
+
+
+def test_runas_extras_noop_when_not_root() -> None:
+    env: dict[str, str] = {"HOME": "/root"}
+    extras = agent_shim._runas_popen_extras(
+        env, geteuid=lambda: 1000, getpwnam=_fake_pw(33, 33, "/var/lib/hal0")
+    )
+    assert extras == {}
+    assert env["HOME"] == "/root"  # untouched
+
+
+def test_runas_extras_drops_to_hal0_when_root() -> None:
+    env: dict[str, str] = {"HOME": "/root"}
+    extras = agent_shim._runas_popen_extras(
+        env, geteuid=lambda: 0, getpwnam=_fake_pw(33, 33, "/var/lib/hal0")
+    )
+    assert extras == {"user": 33, "group": 33}
+    assert env["HOME"] == "/var/lib/hal0"  # corrected to target home
+
+
+def test_runas_extras_respects_opt_out() -> None:
+    env: dict[str, str] = {"HOME": "/root"}
+    extras = agent_shim._runas_popen_extras(
+        env, geteuid=lambda: 0, getpwnam=_fake_pw(33, 33, "/var/lib/hal0"), allow_root=True
+    )
+    assert extras == {}
+    assert env["HOME"] == "/root"
+
+
+def test_runas_extras_noop_when_user_absent() -> None:
+    def _raise(name: str):
+        raise KeyError(name)
+
+    env: dict[str, str] = {"HOME": "/root"}
+    extras = agent_shim._runas_popen_extras(env, geteuid=lambda: 0, getpwnam=_raise)
+    assert extras == {}

--- a/tests/cli/test_doctor_perms.py
+++ b/tests/cli/test_doctor_perms.py
@@ -1,0 +1,62 @@
+"""Tests for the Layer-3 ownership-drift check behind ``hal0 doctor perms`` (#843).
+
+Read-only: it reports when Hermes state is ``root:root`` (the silent
+root-clobber failure) or when a split-brain ``/root/.hermes`` exists. It never
+repairs — that's the explicit ``bootstrap --repair`` path. The owner lookup and
+existence checks are injected seams so the logic is testable without root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hal0.cli import doctor_commands as dc
+
+_HOME = Path("/var/lib/hal0/.hermes")
+_VENV = Path("/var/lib/hal0/venvs/hermes")
+_STRAY = Path("/root/.hermes")
+
+
+def _check(owners: dict[Path, str | None], *, present: set[Path]):
+    return dc.check_hermes_ownership(
+        owner_of=lambda p: owners.get(p),
+        exists=lambda p: p in present,
+    )
+
+
+def test_clean_install_reports_no_drift() -> None:
+    owners = {
+        _HOME: "hal0",
+        _HOME / "config.yaml": "hal0",
+        _HOME / "runtime.json": "hal0",
+        _VENV: "hal0",
+    }
+    rows = _check(owners, present=set(owners))
+    assert dc.has_ownership_drift(rows) is False
+    assert all(r["status"] in ("ok", "absent") for r in rows)
+
+
+def test_root_owned_config_is_drift() -> None:
+    owners = {
+        _HOME: "hal0",
+        _HOME / "config.yaml": "root",  # the clobber
+        _HOME / "runtime.json": "hal0",
+        _VENV: "hal0",
+    }
+    rows = _check(owners, present=set(owners))
+    assert dc.has_ownership_drift(rows) is True
+    drift = [r for r in rows if r["status"] == "drift"]
+    assert any("config.yaml" in r["path"] for r in drift)
+
+
+def test_stray_root_home_is_drift() -> None:
+    owners = {_HOME: "hal0", _VENV: "hal0"}
+    rows = _check(owners, present=set(owners) | {_STRAY})
+    assert dc.has_ownership_drift(rows) is True
+    assert any(str(_STRAY) in r["path"] and r["status"] == "drift" for r in rows)
+
+
+def test_missing_paths_are_absent_not_drift() -> None:
+    rows = _check({}, present=set())
+    assert dc.has_ownership_drift(rows) is False
+    assert all(r["status"] == "absent" for r in rows if str(_STRAY) not in r["path"])


### PR DESCRIPTION
Closes #843.

## Problem
hal0-managed processes must run as the unprivileged `hal0` user, but nothing
stopped root from running Hermes (`sudo hermes …`, a root TUI, or root-context
bootstrap). When that happened: (1) `~/.hermes` resolved to **`/root/.hermes`**
(split-brain tree the service never reads), and (2) files landed `root:root`
(`config.yaml`/`runtime.json` 0600, the venv) so the `User=hal0` unit hit EACCES
— or Hermes **silently fell back to the default provider**. The regression kept
returning because past fixes were applied on the live box, not in the repo.

This generalises the fix into one primitive every hal0-managed process inherits.

## Fix (three layers)
**Layer 1 — prevent at entry**
- `installer/lib/run-as-hal0.sh` — sourced guard; when EUID==0 it re-execs the
  command as `hal0` with the correct `HOME` and `HERMES_HOME` stripped
  (`runuser` → `setpriv` → `sudo -H`; refuses loudly if none). `HAL0_ALLOW_ROOT=1`
  opts out for deliberate root debugging.
- `installer/wrappers/hermes` sources it first; `install.sh` installs it to
  `/usr/lib/hal0/guards/run-as-hal0.sh`.
- `agent_shim._runas_popen_extras()` drops the child to `hal0` on the systemd
  ExecStart path (it execs the venv binary directly, bypassing the wrapper).

**Layer 2 — hand artifacts to hal0** (also reconciles under `--repair`)
- `hermes_provision._chown_tree_to_hal0()` chowns the venv, `$HERMES_HOME` tree,
  and `runtime.json` to `hal0` when root; no-op otherwise.

**Layer 3 — detect (read-only)**
- `hal0 doctor perms` audits Hermes ownership + flags a stray `/root/.hermes`,
  pointing at `bootstrap --repair`. Never auto-repairs (no silent `chown -R`).

## Tests
TDD throughout (guard via `sh` with a `runuser` stub + `HAL0_RUNAS_TEST_UID`
seam; wrapper/install wiring; chown helper + phase wiring; shim drop; doctor
check). **563 passed** in `tests/cli` + `tests/agents`; ruff + shellcheck clean.
(Full `pytest tests/` hangs on the dev box per the known lemond gotcha — CI runs
the rest.)

## Scope / notes
- Design spec: `docs/superpowers/specs/2026-06-15-hal0-runas-guard-design.md`
  (with as-built notes). Operator runbook: `docs/agents/hermes/SERVICE.md`.
- Preserves the `2775` setgid on `/var/lib/hal0`; only the `.hermes` subtree +
  venv ownership change.
- **Not deployed to CT105** (shared host — another session is active on that
  runtime). Deploy + `sudo hal0 agent bootstrap hermes --repair` will converge
  the live box.
- Deferred follow-up: a root-context harness smoke row (real `stat` + no
  `/root/.hermes`) — can't run in non-root CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)