### PR TITLE
fix(hermes): correct env arg order in run-as-hal0 guard (#843 follow-up)

### DIFF
--- a/installer/lib/run-as-hal0.sh
+++ b/installer/lib/run-as-hal0.sh
@@ -42,11 +42,14 @@ hal0_ensure_runas() {
     _hru_home="$(getent passwd "$_hru_user" 2>/dev/null | cut -d: -f6)"
     [ -n "$_hru_home" ] || _hru_home="/var/lib/hal0"
 
+    # NOTE: `env` requires options (-u) BEFORE NAME=VALUE assignments — once env
+    # sees an assignment or non-option it treats the rest as the command. Putting
+    # `-u HERMES_HOME` after `HOME=...` makes env exec "-u" (issue #843 follow-up).
     if command -v runuser >/dev/null 2>&1; then
-        exec runuser -u "$_hru_user" -- env "HOME=$_hru_home" -u HERMES_HOME "$@"
+        exec runuser -u "$_hru_user" -- env -u HERMES_HOME "HOME=$_hru_home" "$@"
     elif command -v setpriv >/dev/null 2>&1; then
         exec setpriv --reuid "$_hru_user" --regid "$_hru_user" --init-groups -- \
-            env "HOME=$_hru_home" -u HERMES_HOME "$@"
+            env -u HERMES_HOME "HOME=$_hru_home" "$@"
     elif command -v sudo >/dev/null 2>&1; then
         exec sudo -H -u "$_hru_user" -- env -u HERMES_HOME "$@"
     fi

--- a/tests/agents/test_run_as_hal0_guard.py
+++ b/tests/agents/test_run_as_hal0_guard.py
@@ -22,6 +22,7 @@ Tests drive the guard through ``sh`` with:
 from __future__ import annotations
 
 import os
+import pwd
 import subprocess
 from pathlib import Path
 
@@ -109,6 +110,27 @@ def test_root_reexecs_as_target_user_via_runuser(tmp_path: Path) -> None:
     assert "HERMES_HOME" in res.stdout  # explicitly stripped via `env -u`
     assert "HOME=" in res.stdout  # target HOME forced
     assert "SHOULD_NOT_REACH" not in res.stdout
+
+
+def test_reexec_actually_runs_with_clean_env(tmp_path: Path) -> None:
+    """Execute the re-exec for real (stub runuser EXECS the wrapped command) so
+    `env`'s arg order is exercised, not just string-matched. Verifies HERMES_HOME
+    is stripped and HOME is set to the target user's home — this is the test that
+    catches a malformed `env -u/NAME=VALUE` ordering (which exits non-zero)."""
+    user = _existing_unprivileged_user()
+    if not user:
+        pytest.skip("no unprivileged target user available on this host")
+    target_home = pwd.getpwnam(user).pw_dir
+    # stub runuser: drop `-u <user> --`, then exec the rest so `env` runs for real.
+    _write_stub(tmp_path, "runuser", 'shift 3; exec "$@"')
+    res = _run_guard(
+        f"hal0_ensure_runas {user} sh -c 'echo HOME=$HOME; echo HERMES=${{HERMES_HOME:-unset}}'",
+        env={"HAL0_RUNAS_TEST_UID": "0", "HERMES_HOME": "/should/be/stripped"},
+        extra_path=tmp_path,
+    )
+    assert res.returncode == 0, f"re-exec failed (env ordering?): {res.stderr}"
+    assert f"HOME={target_home}" in res.stdout
+    assert "HERMES=unset" in res.stdout
 
 
 _HERMES_WRAPPER = _REPO_ROOT / "installer" / "wrappers" / "hermes"


### PR DESCRIPTION
Follow-up to #844.

## Bug
The guard re-exec wrapped the command as `env HOME=<h> -u HERMES_HOME <cmd>`.
GNU `env` stops option parsing at the first `NAME=VALUE`, so `-u` was treated as
the **command** → `env: '-u': No such file or directory` (exit 127) when `hermes`
is run as root. The systemd service path is unaffected (it runs as `hal0`, guard
is a no-op), so this only broke interactive root invocations — i.e. the guard
errored instead of cleanly re-execing as hal0.

Caught during the live CT105 deploy, not by CI: the original test only
string-matched the argv and never executed `env`.

## Fix
Reorder to `env -u HERMES_HOME HOME=<h> <cmd>` (options before assignments) in
the runuser + setpriv branches (sudo branch was already correct). Add a test
whose stub `runuser` **execs** the wrapped command, so `env` runs for real —
verifies `HERMES_HOME` stripped and `HOME` = the target user's home. This test
fails (exit 127) against the old lib and passes against the fix.

## Verification
- 8/8 guard tests pass; shellcheck clean.
- **Hotfixed live on CT105** and verified: `hal0_ensure_runas hal0 id -un` → `hal0`;
  `printenv HOME` under the guard → `/var/lib/hal0`; `hermes` as root re-execs
  (exit 0) without recreating `/root/.hermes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)