### PR TITLE
fix(slots): default edit-drawer context to 16k instead of 4096

### DIFF
--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -339,7 +339,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
   // owns them for container slots).
   const initialExtraArgs = slot?.llamacpp_args != null ? slot.llamacpp_args : "";
 
-  const [ctx, setCtx] = useStateSM(slot?.metrics?.ctx || 4096);
+  const [ctx, setCtx] = useStateSM(slot?.metrics?.ctx || 16384);
   // C4/C5: thinking is instant-apply (its own PUT); n_gpu_layers rides the Save
   // button through PATCH /defaults. Both seed from the slot list payload.
   const [thinking, setThinking] = useStateSM(slot?.enable_thinking === true);
@@ -371,7 +371,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 
   useEffectSM(() => {
     if (slot) {
-      setCtx(slot.metrics?.ctx || 4096);
+      setCtx(slot.metrics?.ctx || 16384);
       setThinking(slot.enable_thinking === true);
       setThinkingPending(false);
       setNGpuLayers(slot.n_gpu_layers != null ? String(slot.n_gpu_layers) : "-1");


### PR DESCRIPTION
## Problem
The edit-slot drawer always listed **context = 4096** for slots that report no `ctx` metric (e.g. a newly created / not-yet-loaded slot). 4096 was the hardcoded fallback default.

## Fix
Bump the fallback default from `4096` → `16384` (16k) in `ui/src/dash/slot-modals.jsx`:
- L342 — initial `useState` seed
- L374 — slot-switch re-seed effect

The `slot?.metrics?.ctx || 16384` idiom still **preserves any assigned ctx value** — only the missing-metric default changes, exactly as requested ("update the default to 16k but leave the values assigned in place").

Mock fixtures with explicit `ctx: 4096` are left untouched (those are assigned values, displayed verbatim via the `||`).

## Test
- `npm run build` ✓ (189 modules)
- No test asserted the old 4096 fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)