### PR TITLE
fix(dashboard): row-align home grid so card bottoms line up

### DIFF
--- a/ui/src/dash/dash-grid.jsx
+++ b/ui/src/dash/dash-grid.jsx
@@ -1,7 +1,9 @@
 // hal0 dashboard — DashGrid + DashboardOverhaulView (W3)
 //
-// 12-column CSS masonry grid with edit mode: drag-reorder, resize,
+// 12-column row-aligned CSS grid with edit mode: drag-reorder, resize,
 // card library, pin/unpin. Layout state from useDashLayout + reconcile.
+// Rows size to their tallest card and cells stretch to fill, so card
+// bottoms line up across a band (not masonry — see overhaul.css .dash-grid).
 //
 // Window-global module — exports DashGrid + DashboardOverhaulView onto
 // window so other dash modules can reference them without ES imports.
@@ -24,7 +26,6 @@
 const { React: _R } = window;
 const {
   useState,
-  useEffect,
   useRef,
   useCallback,
   useMemo,
@@ -32,7 +33,6 @@ const {
 
 // ─── constants ────────────────────────────────────────────────────────────────
 const GRID_COLS = 12;
-const ROW_UNIT  = 8;
 const GRID_GAP  = 16;
 
 // ─── CARD_REGISTRY ────────────────────────────────────────────────────────────
@@ -110,40 +110,16 @@ function reconcileLayout(layout, slots) {
   return { v: 2, order: newOrder, enabled, spans, pinned };
 }
 
-// ─── Grid helpers ─────────────────────────────────────────────────────────────
-
-// useRowSpan: ResizeObserver on a card element → CSS gridRowEnd span value
-// Formula: ceil((height + gap) / (rowUnit + gap))
-function useRowSpan(ref) {
-  const [rowSpan, setRowSpan] = useState(1);
-
-  useEffect(() => {
-    if (!ref.current) return;
-    const el = ref.current;
-    const compute = () => {
-      const h = el.offsetHeight;
-      const span = Math.max(1, Math.ceil((h + GRID_GAP) / (ROW_UNIT + GRID_GAP)));
-      setRowSpan(span);
-    };
-    compute();
-    const ro = new ResizeObserver(compute);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [ref]);
-
-  return rowSpan;
-}
-
 // ─── GridCell ─────────────────────────────────────────────────────────────────
-// Wraps one card with: row-span measurement, edit overlay (grip/span/remove/resize).
+// Wraps one card with: column span, edit overlay (grip/span/remove/resize).
+// Height is row-aligned by the grid (no per-card measurement).
 
 function GridCell({ layoutKey, colSpan, editing, isLocked, onRemove, onDragStart, onDragEnter, onDragEnd, onResizeStart, children }) {
-  const cardRef = useRef(null);
-  const rowSpan = useRowSpan(cardRef);
-
+  // Row-aligned layout: the cell only declares its column span; height comes
+  // from the implicit grid row (sized to the tallest card in the band) via
+  // `align-items: stretch`. No JS height measurement needed.
   const style = {
     gridColumn: `span ${colSpan}`,
-    gridRow: `span ${rowSpan}`,
   };
 
   const handleDragStart = (e) => {
@@ -164,7 +140,6 @@ function GridCell({ layoutKey, colSpan, editing, isLocked, onRemove, onDragStart
 
   return (
     <div
-      ref={cardRef}
       className={'dash-cell' + (editing ? ' editing' : '')}
       style={style}
       draggable={editing && !isLocked}
@@ -546,7 +521,7 @@ function DashGrid({ editing: editingProp, onToggleEdit, layout, slots, onLayoutC
         />
       )}
 
-      {/* Masonry grid */}
+      {/* Row-aligned grid */}
       <div className={'dash-grid' + (editing ? ' dash-grid-editing' : '')}>
         {visibleItems.map(key => {
           const span = layout.spans?.[key] ?? (

--- a/ui/src/dash/overhaul.css
+++ b/ui/src/dash/overhaul.css
@@ -482,10 +482,15 @@
 .dash-grid {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
-  grid-auto-rows: 8px;
+  /* Row-aligned (not masonry): each implicit row sizes to its tallest card,
+     and cells stretch to fill it so neighbouring card bottoms line up. The
+     minmax floor keeps a short single card from collapsing too far. Dropped
+     `dense` — it backfilled gaps by pulling unrelated cards up beside taller
+     ones, which is what produced the config-dependent jaggedness. */
+  grid-auto-rows: minmax(120px, auto);
   gap: 16px;
-  grid-auto-flow: row dense;
-  align-items: start;
+  grid-auto-flow: row;
+  align-items: stretch;
 }
 
 /* <1200px: single-column (each cell forced to span 6 of the 6-col grid) */
@@ -502,6 +507,16 @@
 .dash-cell {
   position: relative;
   min-width: 0;
+  /* Stretch the card to the full (row-aligned) cell height so card bottoms
+     align across a band. .dcard is already a flex column; flex:1 makes it
+     fill, and .dcard-b grows so footers/charts settle at the bottom. */
+  display: flex;
+}
+.dash-cell > .dcard {
+  flex: 1;
+}
+.dash-cell > .dcard > .dcard-b {
+  flex: 1;
 }
 .dash-cell.editing {
   outline: 1px dashed var(--line-strong);


### PR DESCRIPTION
## Problem
The home dashboard widgets were differing heights and looked jagged when sitting next to each other in certain configs.

**Root cause:** the home board (`dash-grid.jsx` + `overhaul.css`) was a **JS-driven masonry grid**. Each `.dash-cell` got a runtime-measured `grid-row: span N` (the `useRowSpan` `ResizeObserver`), and the grid used `align-items: start` + `grid-auto-flow: row dense`. So every card was exactly as tall as its own content → cards sharing a horizontal band had mismatched bottoms. `dense` made it config-dependent by backfilling gaps with short cards beside taller unrelated ones.

## Fix — row-aligned grid
Each implicit row now sizes to its tallest card and cells stretch to fill it, so bottoms line up across a band (standard Grafana/Datadog-style dashboard look).

- `.dash-grid`: `grid-auto-rows: minmax(120px, auto)`, `align-items: stretch`, drop `dense` (`grid-auto-flow: row`).
- `.dash-cell` becomes a flex container; `.dcard` + `.dcard-b` get `flex: 1` so the card fills the cell and footers/charts settle at the bottom.
- Deleted the `useRowSpan` ResizeObserver hook, its `cardRef`, and the now-unused `ROW_UNIT` / `useEffect` import — height is purely CSS now (removes a class of measurement/reflow jank).

```
BEFORE (masonry, dense)        AFTER (row-aligned)
┌──────┐┌────┐                 ┌──────┐┌────┐
│Memory││Thr.│  ← ragged       │Memory││Thr.│  ← bottoms align
│      │└────┘                 │      ││    │
└──────┘┌────┐                 └──────┘└────┘
┌────┐  │Util│                 ┌────┐┌────┐┌────┐
│QC  │  └────┘                 │QC  ││Svc ││Util│ ← clean band
└────┘                         └────┘└────┘└────┘
```

**Unchanged:** column spans, drag-reorder, resize, pin/unpin, persisted layouts, and the `<1200px` single-column collapse. Only the height model changed.

**Tradeoff:** the shorter card in a row gains internal whitespace instead of being short — the intended tidy look.

## Test
- `npm run build` ✓
- No test asserted the old masonry row mechanics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)