### PR TITLE
feat(slots): lift memory+throughput band above tabs; free slot cards from accordion

### DIFF
--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -511,6 +511,18 @@
 .infer-pane .engine.open .infer-strip {
   display: none;
 }
+/* Page-level hero band (InferenceHeroBand) — the memory map + throughput tile
+   lifted to the top of the Slots page, above the tabs. Mirrors the engine
+   shell's card chrome so it reads as an anchored banner rather than a loose
+   bar, and spaces itself from the tab row below. */
+.infer-pane.infer-hero-top {
+  margin-bottom: 18px;
+  padding: 16px 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--rad-lg);
+  background: var(--bg-1);
+}
+
 /* hero band — iGPU GTT memory map (2fr) + combined-throughput tile (1fr),
    pinned at the top of BOTH states (P2). */
 .infer-pane .hero-band {

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -461,7 +461,7 @@ export function SlotScard({ s, ind, full, modelNode, controls, phase, onEdit }) 
 
 function SlotCards({ rows, full, models, busyName, handlers }) {
   if (!rows.length)
-    return <div className="scards-empty">no active slots — expand to start one</div>
+    return <div className="scards-empty">no inference slots — create one to start</div>
   return (
     <div className={'scards ' + (full ? 'full' : 'compact')}>
       {rows.map(({ s, ind }) => {
@@ -506,42 +506,25 @@ function SlotCards({ rows, full, models, busyName, handlers }) {
   )
 }
 
-export function InferencePane() {
+// Page-level hero band — the iGPU GTT memory map + combined-throughput tile,
+// lifted out of the Inference engine shell so it sits at the very top of the
+// Slots page (above the Inference ⇄ Image Gen tabs) and stays visible across
+// tabs. Self-contained: owns its own slots/memory queries + throughput ring
+// buffer, so SlotsView can drop it in without threading any state down. Wrapped
+// in `.infer-pane .proto` so it inherits the pane's accent vars + box-sizing
+// and reuses the existing .hero-band / .mem / .tp styling verbatim.
+export function InferenceHeroBand() {
   const slotsQuery = useSlots()
-  const modelsQuery = useModels()
   const mm = useMemoryMapModel()
-  const restartMut = useSlotRestart()
-  const unloadMut = useSlotUnload()
-  const loadMut = useSlotLoad()
-  const swapMut = useSlotSwap()
-  const [open, setOpen] = useStateI(false)
-  const [busyName, setBusyName] = useStateI(null)
 
-  // The Inference rollup is the iGPU/CPU slot stack. Image generation is its
-  // own pane (ComfyuiPane); NPU/FLM slots are cordoned off to the NPU · FLM
-  // stack pane below — they appear here only as the sec-label FLM count.
   const allSlots = slotsQuery.data || []
   const nonImg = allSlots.filter((s) => (s.group || '') !== 'img')
   const slots = nonImg.filter((s) => devKind(s.device) !== 'npu')
-  const npuN = nonImg.length - slots.length
-
   const rows = slots.map((s) => ({ s, ind: slotIndicatorFromPhase(s) }))
-  // collapsed view: serving + ready only (warming/idle wait for the expand)
-  const compactRows = rows.filter((r) => {
-    const d = dotCls(r.ind)
-    return d === 'serving' || d === 'ready'
-  })
   const servingN = rows.filter((r) => r.ind.cls === 'serving').length
-  const loadedN = rows.filter((r) => isSlotLive(r.s)).length
 
-  const gpuN = slots.filter((s) => {
-    const k = devKind(s.device)
-    return k === 'rocm' || k === 'vulkan'
-  }).length
-
-  // Combined throughput — summed tok/s across this pane's serving slots
-  // (NPU/FLM throughput belongs to the NPU pane), with a client ring buffer
-  // for the spark (the backend exposes no rolling series).
+  // Combined throughput — summed tok/s across this pane's serving slots, with a
+  // client ring buffer for the spark (the backend exposes no rolling series).
   const toksVals = slots
     .map((s) => s?.metrics?.toks)
     .filter((t) => typeof t === 'number' && t > 0)
@@ -559,7 +542,46 @@ export function InferencePane() {
   const ticks = historyRef.current
   const peak = ticks.length ? Math.max(...ticks) : null
 
-  // GTT headroom for the expanded status line (the memory map's frame).
+  return (
+    <div className="infer-pane infer-hero-top" data-testid="infer-hero-band">
+      <div className="proto">
+        <div className="hero-band">
+          <MemGtt mm={mm} full />
+          <TpTile value={value} ticks={ticks} peak={peak} servingN={servingN} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function InferencePane() {
+  const slotsQuery = useSlots()
+  const modelsQuery = useModels()
+  const mm = useMemoryMapModel()
+  const restartMut = useSlotRestart()
+  const unloadMut = useSlotUnload()
+  const loadMut = useSlotLoad()
+  const swapMut = useSlotSwap()
+  const [busyName, setBusyName] = useStateI(null)
+
+  // The Inference rollup is the iGPU/CPU slot stack. Image generation is its
+  // own pane (ComfyuiPane); NPU/FLM slots are cordoned off to the NPU · FLM
+  // stack pane below — they appear here only as the sec-label FLM count.
+  const allSlots = slotsQuery.data || []
+  const nonImg = allSlots.filter((s) => (s.group || '') !== 'img')
+  const slots = nonImg.filter((s) => devKind(s.device) !== 'npu')
+  const npuN = nonImg.length - slots.length
+
+  const rows = slots.map((s) => ({ s, ind: slotIndicatorFromPhase(s) }))
+  const servingN = rows.filter((r) => r.ind.cls === 'serving').length
+  const loadedN = rows.filter((r) => isSlotLive(r.s)).length
+
+  const gpuN = slots.filter((s) => {
+    const k = devKind(s.device)
+    return k === 'rocm' || k === 'vulkan'
+  }).length
+
+  // GTT headroom for the slots status line (the memory map's frame).
   const gttCapGb = mm.pool?.totalGb || 0
   const gttFreeGb = Math.max(0, Math.round(gttCapGb - (mm.self?.gttUsedGb || 0)))
 
@@ -604,13 +626,6 @@ export function InferencePane() {
     window.location.hash = '#logs'
   }
 
-  const hero = (full) => (
-    <div className="hero-band">
-      <MemGtt mm={mm} full={full} />
-      <TpTile value={value} ticks={ticks} peak={peak} servingN={servingN} />
-    </div>
-  )
-
   return (
     <div className="infer-pane">
       <div className="proto">
@@ -633,7 +648,7 @@ export function InferencePane() {
           <span className="meta">podman · :8080</span>
         </div>
 
-        <div className={'engine' + (loadedN > 0 ? ' active' : '') + (open ? ' open' : '')}>
+        <div className={'engine' + (loadedN > 0 ? ' active' : '')}>
           <div className="engine-h">
             <span className="engine-glyph">
               <Ic name="slots" size={16} />
@@ -657,50 +672,30 @@ export function InferencePane() {
             </span>
           </div>
 
-          {/* collapsed strip — compact hero, hidden when the pane is open */}
-          <div className="infer-strip" data-testid="infer-strip">
-            {hero(false)}
+          {/* All slots as full cards — always visible (freed from the old
+              collapse/expand accordion). The memory + throughput hero now lives
+              in the page-level InferenceHeroBand above the tabs. */}
+          <div className="engine-b" data-testid="infer-slots">
             <div>
-              <SubLabel icon="slots" note={`${loadedN} loaded`}>
-                active slots
+              <SubLabel icon="slots" note={`all ${rows.length} · full cards`}>
+                slots
               </SubLabel>
               <SlotCards
-                rows={compactRows}
-                full={false}
+                rows={rows}
+                full
                 models={modelsQuery.data}
                 busyName={busyName}
                 handlers={handlers}
               />
             </div>
-          </div>
-
-          {/* expandable body — hero pinned on top, then all slots as full cards */}
-          <div className="engine-body">
-            <div className="inner">
-              <div className="engine-b">
-                {hero(true)}
-                <div>
-                  <SubLabel icon="slots" note={`all ${rows.length} · full cards`}>
-                    slots
-                  </SubLabel>
-                  <SlotCards
-                    rows={rows}
-                    full
-                    models={modelsQuery.data}
-                    busyName={busyName}
-                    handlers={handlers}
-                  />
-                </div>
-                <div className="body-status">
-                  {servingN} serving
-                  {gttCapGb > 0 ? ` · ${gttFreeGb} GB free` : ''}
-                </div>
-              </div>
+            <div className="body-status">
+              {servingN} serving
+              {gttCapGb > 0 ? ` · ${gttFreeGb} GB free` : ''}
             </div>
           </div>
 
-          {/* footer — engine identity + caret expand control */}
-          <div className="engine-foot has-q">
+          {/* footer — engine identity (caret expander removed) */}
+          <div className="engine-foot">
             <div className="foot-id">
               <span className="k">runtime</span>
               <span className="v comfy">hal0</span>
@@ -714,21 +709,6 @@ export function InferencePane() {
               <span className="k">gateway</span>
               <span className="v comfy">:8080</span>
             </div>
-            <button
-              className="qcaret"
-              onClick={() => setOpen((o) => !o)}
-              aria-expanded={open}
-              data-testid="infer-qcaret"
-            >
-              <span className="q">
-                <Ic name="slots" size={13} /> {open ? 'collapse' : 'all slots'}
-                <span className="qn">{slots.length}</span>
-                <span className="qrun">· {servingN} serving</span>
-              </span>
-              <span className="car">
-                <Ic name="chev" size={13} />
-              </span>
-            </button>
           </div>
         </div>
       </div>
@@ -736,4 +716,4 @@ export function InferencePane() {
   )
 }
 
-Object.assign(window, { InferencePane })
+Object.assign(window, { InferencePane, InferenceHeroBand })

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -21,6 +21,7 @@ import { ActivityLog } from './activity-log.jsx'
 import { ComfyuiPane } from './comfyui-pane.jsx'
 import {
   InferencePane,
+  InferenceHeroBand,
   SlotScard,
   ModelPicker,
   SlotControls,
@@ -1225,6 +1226,11 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
         <span className="hint">Press <kbd>N</kbd> to create</span>
         <button className="btn" onClick={() => setCreateOpen(true)}>{Icons.plus} New slot</button>
       </div>
+
+      {/* Memory map + combined-throughput band — lifted out of the Inference
+          engine shell to the top of the page, above the tabs, so iGPU GTT usage
+          and live throughput stay visible regardless of which tab is active. */}
+      <InferenceHeroBand />
 
       {/* Inference ⇄ Image Gen tabs. Tab 1 holds every non-image slot; tab 2 is
           the ComfyUI generation engine pane (one container, not per-model

--- a/ui/tests/e2e/specs/inference-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-pane-v3.spec.ts
@@ -3,13 +3,14 @@
  * P2 card direction (design_handoff_inference_slots).
  *
  * Behaviour under test:
- *   - collapsed hero strip renders from HAL0_DATA slots: epill, iGPU GTT
- *     memory map, combined-throughput tile, and compact slot CARDS
+ *   - the page-level hero band (InferenceHeroBand, above the tabs) renders the
+ *     iGPU GTT memory map + combined-throughput tile from HAL0_DATA
+ *   - the engine pane renders the epill + ALL slots as full cards, always
+ *     visible (the old collapse/expand accordion + qcaret were removed)
  *   - the serving card's status pill shows live tok/s (no fabricated numbers)
  *   - the profile pill surfaces the slot's runtime profile name (slot.profile)
  *   - NPU/FLM slots are cordoned off — absent from the inference pane, present
  *     in the NPU · FLM stack pane below
- *   - the qcaret toggles the engine open (→ full cards with tok/s · ttft · ctx)
  *   - a lifecycle control fires the real mutation (Stop → POST /unload)
  *   - the full card exposes a real model-picker <select> (useModels)
  *   - the NPU/FLM pane renders its own engine shell + trio
@@ -18,33 +19,32 @@
  * The slot LIST comes from in-bundle HAL0_DATA (VITE_MOCK_HAL0=1); mutations
  * go through fetch, so per-route stubs capture the write path.
  *
- * NOTE on expand assertions: the engine body animates via `max-height:0;
- * overflow:hidden`, which clips but does NOT zero the bounding box of its
- * children — Playwright still reports them "visible". So collapse/expand is
- * asserted on the `.engine.open` class (the real state signal), not on inner
- * content visibility.
+ * NOTE: the page now carries TWO `.infer-pane` roots — the hero band
+ * (`.infer-hero-top`, above the tabs) and the engine pane below it. The engine
+ * locators scope to `.infer-pane:not(.infer-hero-top)` to target the pane; the
+ * hero band is reached via its `infer-hero-band` testid.
  */
 import { test, expect, type Page } from '../fixtures/apiMock'
 
-const pane = (page: Page) => page.locator('.infer-pane').first()
-const engine = (page: Page) => page.locator('.infer-pane .engine').first()
-const body = (page: Page) => page.locator('.infer-pane .engine-body').first()
+const pane = (page: Page) => page.locator('.infer-pane:not(.infer-hero-top)').first()
+const engine = (page: Page) => pane(page).locator('.engine').first()
+const body = (page: Page) => pane(page).locator('.engine-b').first()
+const hero = (page: Page) => page.getByTestId('infer-hero-band')
 
 test.describe('Inference engine pane (/slots · Inference tab)', () => {
-  test('collapsed strip renders epill + hero band + compact slot cards', async ({ page }) => {
+  test('hero band renders memory + throughput; engine renders epill + full slot cards', async ({ page }) => {
     await page.goto('/#slots')
+    // page-level hero band (above the tabs): iGPU GTT memory map + throughput.
+    await expect(hero(page)).toBeVisible()
+    await expect(hero(page).locator('.mem .blk-h')).toContainText('memory · iGPU GTT')
+    await expect(hero(page).locator('.tp-tile')).toBeVisible()
+    // engine pane: state pill summarises serving/loaded counts (primary serving).
     await expect(pane(page)).toBeVisible()
-    await expect(engine(page)).not.toHaveClass(/\bopen\b/)
-    // engine state pill summarises serving/loaded counts (primary is serving).
     await expect(page.getByTestId('infer-epill')).toContainText('serving')
-    // collapsed hero strip: iGPU GTT memory map + throughput tile + cards.
-    const strip = page.getByTestId('infer-strip')
-    await expect(strip).toBeVisible()
-    await expect(strip.locator('.mem .blk-h')).toContainText('memory · iGPU GTT')
-    await expect(strip.locator('.tp-tile')).toBeVisible()
-    // the serving primary slot renders as a compact CARD whose status pill
-    // carries the live tok/s (45 in the seed).
-    const card = strip.getByTestId('infer-slot-primary')
+    // every slot renders as a FULL card now (no accordion); the serving primary
+    // card's status pill carries the live tok/s (45 in the seed).
+    await expect(body(page).locator('.scards.full')).toHaveCount(1)
+    const card = body(page).getByTestId('infer-slot-primary')
     await expect(card).toBeVisible()
     await expect(card).toHaveClass(/\bscard\b/)
     await expect(card.locator('.spill')).toContainText('45 tok/s')
@@ -52,11 +52,9 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
 
   test('profile pill surfaces the runtime profile name (slot.profile)', async ({ page }) => {
     await page.goto('/#slots')
-    // primary carries profile "rocm" in the seed; the [ device |
-    // PROFILE ] provider tag renders it on the compact card too.
-    const pill = page
-      .getByTestId('infer-strip')
-      .getByTestId('infer-profile-primary')
+    // primary carries profile "rocm" in the seed; the [ device | PROFILE ]
+    // provider tag renders it on the full card.
+    const pill = body(page).getByTestId('infer-profile-primary')
     await expect(pill).toBeVisible()
     await expect(pill).toContainText('rocm')
   })
@@ -65,7 +63,7 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
     await page.goto('/#slots')
     await expect(pane(page)).toBeVisible()
     // the seed's NPU slots (agent / stt-npu / embed-npu) must NOT appear in
-    // the inference pane — collapsed or expanded.
+    // the inference pane.
     for (const name of ['agent', 'stt-npu', 'embed-npu']) {
       await expect(pane(page).locator(`[data-testid="infer-slot-${name}"]`)).toHaveCount(0)
     }
@@ -73,33 +71,27 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
     await expect(page.locator('.npu-pane').first()).toBeVisible()
   })
 
-  test('qcaret toggles the engine open → full cards with meta row', async ({ page }) => {
+  test('engine renders full slot cards with the metric meta row (no accordion)', async ({ page }) => {
     await page.goto('/#slots')
-    await expect(engine(page)).not.toHaveClass(/\bopen\b/)
-    await page.getByTestId('infer-qcaret').click()
-    await expect(engine(page)).toHaveClass(/\bopen\b/)
-    // full-card grid + the hero band's throughput tile live in the body.
+    // full-card grid is always present; the throughput tile now lives in the
+    // page hero band, not the engine body.
     await expect(body(page).locator('.scards.full')).toHaveCount(1)
-    await expect(body(page).locator('.tp-tile')).toHaveCount(1)
+    await expect(hero(page).locator('.tp-tile')).toHaveCount(1)
+    await expect(body(page).locator('.tp-tile')).toHaveCount(0)
     // the full card's meta row reports real metrics for the serving primary
     // slot (toks 45 · ttft 220 in the seed; no fabricated numbers).
     const meta = body(page).getByTestId('infer-slot-primary').locator('.scard-meta')
     await expect(meta.locator('.m .v').nth(0)).toContainText('45')
     await expect(meta.locator('.m .v').nth(1)).toContainText('220ms')
-    // toggle back closed.
-    await page.getByTestId('infer-qcaret').click()
-    await expect(engine(page)).not.toHaveClass(/\bopen\b/)
   })
 
-  test('expanded Stop control POSTs /unload for a running slot', async ({ page }) => {
+  test('Stop control POSTs /unload for a running slot', async ({ page }) => {
     const unloads: string[] = []
     await page.route('**/api/slots/primary/unload', async (route) => {
       unloads.push(route.request().url())
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
     })
     await page.goto('/#slots')
-    await page.getByTestId('infer-qcaret').click()
-    await expect(engine(page)).toHaveClass(/\bopen\b/)
     await body(page).getByTestId('infer-slot-primary').locator('.sctrl.stop').click()
     await expect.poll(() => unloads.length).toBeGreaterThan(0)
   })
@@ -146,8 +138,6 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
     }, LOADING_LLM_SLOT)
 
     await page.goto('/#slots')
-    await page.getByTestId('infer-qcaret').click()
-    await expect(engine(page)).toHaveClass(/\bopen\b/)
 
     const stop = body(page).getByTestId('infer-slot-loading-llm').locator('.sctrl.stop')
     await expect(stop).toBeVisible()
@@ -156,27 +146,25 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
     await expect.poll(() => unloads.length).toBeGreaterThan(0)
   })
 
-  test('expanded Restart control POSTs /restart for a running slot', async ({ page }) => {
+  test('Restart control POSTs /restart for a running slot', async ({ page }) => {
     const restarts: string[] = []
     await page.route('**/api/slots/primary/restart', async (route) => {
       restarts.push(route.request().url())
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
     })
     await page.goto('/#slots')
-    await page.getByTestId('infer-qcaret').click()
     await body(page).getByTestId('infer-slot-primary').locator('.sctrl.restart').click()
     await expect.poll(() => restarts.length).toBeGreaterThan(0)
   })
 
-  test('expanded Start control POSTs /load for an off slot', async ({ page }) => {
+  test('Start control POSTs /load for an off slot', async ({ page }) => {
     const loads: string[] = []
     await page.route('**/api/slots/legacy/load', async (route) => {
       loads.push(route.request().url())
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
     })
     await page.goto('/#slots')
-    await page.getByTestId('infer-qcaret').click()
-    // `legacy` is the disabled (off) seed slot — only in the expanded body.
+    // `legacy` is the disabled (off) seed slot — now always rendered as a card.
     await body(page).getByTestId('infer-slot-legacy').locator('.sctrl.start').click()
     await expect.poll(() => loads.length).toBeGreaterThan(0)
   })
@@ -202,9 +190,7 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
 
   test('full card exposes a real model-picker <select> (useModels)', async ({ page }) => {
     await page.goto('/#slots')
-    // The full-card model picker lives in the (collapsible) engine body; it is
-    // present in the DOM regardless of open state, so assert on it directly —
-    // no flaky expand-click needed for a structural check.
+    // The full-card model picker is always rendered in the engine body now.
     const picker = body(page).getByTestId('infer-slot-primary').locator('select.model-picker')
     await expect(picker).toHaveCount(1)
     // the picker is populated (at minimum the current model is an option).

--- a/ui/tests/e2e/specs/profiles-page-v3.spec.ts
+++ b/ui/tests/e2e/specs/profiles-page-v3.spec.ts
@@ -163,12 +163,9 @@ test.describe('Container slot edit drawer (#658)', () => {
 
   test('container slot card opens edit drawer', async ({ page }) => {
     // The InferencePane slot card's Edit control routes to #slots/<name>,
-    // which opens the EditSlotDrawer. Expand the pane to reveal full controls.
-    await page.getByTestId('infer-qcaret').click()
-    // The full card (with Logs/Edit controls) lives in the expanded engine body;
-    // the collapsed strip also shows a compact card for the same slot, so scope
-    // to the body to avoid matching both.
-    const card = page.locator('.infer-pane .engine-body [data-testid="infer-slot-gpu-chat"]')
+    // which opens the EditSlotDrawer. All slots render as full cards in the
+    // engine body now (no accordion), so the Logs/Edit controls are visible.
+    const card = page.locator('.infer-pane .engine-b [data-testid="infer-slot-gpu-chat"]')
     await expect(card).toBeVisible()
     await card.locator('.sctrl[title="Edit"]').click()
     await expect(page.locator('.drawer')).toBeVisible({ timeout: 5000 })


### PR DESCRIPTION
## What

Two UI changes to the Slots page, per request:

1. **Memory + throughput lifted to the top of the page, above the tabs.** The iGPU GTT memory map and combined-throughput tile move out of the Inference engine shell into a new page-level `InferenceHeroBand` component, rendered above the `Inference / Image Gen / Endpoints / Profiles` tab row. They now stay visible across all tabs. `InferenceHeroBand` is self-contained (owns its own slots/memory queries + throughput ring buffer), wrapped in `.infer-pane .proto` so it reuses the existing `.hero-band`/`.mem`/`.tp` styling; new `.infer-hero-top` rule gives it the engine-shell card chrome.

2. **Slot cards freed from the accordion.** Removed the `InferencePane` collapse/expand machinery — `open` state, the `infer-strip` collapsed view, the `engine-body` max-height animation, and the `qcaret` toggle. All inference slots now render as full cards directly in `.engine-b`, always visible.

## Tests

- `inference-pane-v3.spec.ts` and `profiles-page-v3.spec.ts` rewritten for the flat layout: no more `infer-qcaret`/`infer-strip`; the engine pane is scoped to `.infer-pane:not(.infer-hero-top)` because the hero band now adds a *first* `.infer-pane` root to the page; throughput-tile assertions moved to the hero band.
- Affected specs: **22 passed, 1 skipped** (swap test needs >=2 llm models in catalog).
- `vite build` clean (197 modules); visually verified against the mock dev server.

## Notes

- The band is persistent **above all tabs** (literal reading of "above tabs"). Trivial to gate to the Inference tab only if preferred.
- NPU/FLM pane keeps its own accordion (unchanged - out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)