### PR TITLE
fix(board): make Operator Board task creation actually work (+Add wiring + columns render)

### DIFF
--- a/ui/src/api/hooks/useBoard.ts
+++ b/ui/src/api/hooks/useBoard.ts
@@ -259,10 +259,11 @@ function normaliseTask(raw: Record<string, unknown>): BoardTask {
 
 // ── Board response normaliser ─────────────────────────────────────────
 //
-// Handles three wire shapes the server may return:
+// Handles four wire shapes the server may return:
 //   1. {lanes: {status: [task, ...]}}
 //   2. {tasks: [...]}
 //   3. [task, ...]  (bare array)
+//   4. {columns: [{name, tasks: [...]}]}  (what Hermes kanban GET /board emits)
 
 function normaliseBoardResponse(
   raw: unknown,
@@ -285,6 +286,17 @@ function normaliseBoardResponse(
       }
     } else if (Array.isArray(obj.tasks)) {
       flatTasks = (obj.tasks as Record<string, unknown>[]).map(normaliseTask)
+    } else if (Array.isArray(obj.columns)) {
+      // Hermes kanban GET /board returns {columns: [{name, tasks: [...]}]}.
+      // Flatten every column's tasks; lane bucketing below re-groups by status.
+      for (const col of obj.columns as Record<string, unknown>[]) {
+        const colTasks = (col as { tasks?: unknown }).tasks
+        if (Array.isArray(colTasks)) {
+          flatTasks.push(
+            ...(colTasks as Record<string, unknown>[]).map(normaliseTask),
+          )
+        }
+      }
     }
   }
 

--- a/ui/src/dash/board/board-view.jsx
+++ b/ui/src/dash/board/board-view.jsx
@@ -28,6 +28,8 @@
 //   window.__hal0UseReassignTask
 //   window.__hal0UseNudgeDispatch
 //   window.__hal0UseSwitchBoard
+//   window.__hal0UseCreateBoard
+//   window.__hal0UseCreateTask
 //   window.__hal0UseBoardEventsStream
 
 const { useState, useEffect, useMemo, useRef } = React;
@@ -162,6 +164,7 @@ function BoardView() {
   const useNudgeDispatch    = window.__hal0UseNudgeDispatch;
   const useSwitchBoard      = window.__hal0UseSwitchBoard;
   const useCreateBoard      = window.__hal0UseCreateBoard;
+  const useCreateTask       = window.__hal0UseCreateTask;
   const useBoardEventsStream = window.__hal0UseBoardEventsStream;
 
   // ── keep WS stream alive ──
@@ -182,6 +185,7 @@ function BoardView() {
   const nudge       = useNudgeDispatch ? useNudgeDispatch() : null;
   const switchBoard = useSwitchBoard ? useSwitchBoard()  : null;
   const createBoard = useCreateBoard ? useCreateBoard()  : null;
+  const createTask  = useCreateTask  ? useCreateTask()   : null;
 
   // ── local state ──
   const [board, setBoard]           = useState("default");
@@ -578,7 +582,14 @@ function BoardView() {
                       onToggle={toggleSel}
                       onOpen={setOpenTask}
                       openTask={openTask}
-                      onAdd={(id) => toast("new task in " + id)}
+                      onAdd={(laneId) => {
+                        if (createTask) {
+                          createTask.mutate(
+                            { title: "New task", status: laneId },
+                            { onSuccess: () => toast("task created in " + laneId) }
+                          );
+                        }
+                      }}
                       dnd={dnd}
                     />
                   : null


### PR DESCRIPTION
## Why
The Operator Board on CT105 looked broken: the board rendered **0 tasks** and clicking a lane **+ Add** did nothing. Two independent bugs, both shipped in #852:

1. **+Add was a dead stub.** Each lane rendered `onAdd={(id) => toast(...)}` — it fired a toast and never called the API, even though the `useCreateTask` hook + backend proxy were already live. → wired `onAdd` to `createTask.mutate({title, status: laneId})`.
2. **Board never rendered any tasks.** `normaliseBoardResponse` understood `{lanes}`/`{tasks}`/bare-array, but Hermes kanban `GET /board` actually returns `{columns:[{name,tasks:[...]}]}`. With no `columns` branch, `flatTasks` stayed empty for every real board, so even successfully-created tasks were invisible. → added a `columns` branch that flattens each column's tasks (existing status-bucketing re-groups into lanes).

Backend proxy + token auto-harvest were already correct — verified a live `POST /api/board/tasks` returned 200 and persisted to `kanban.db` before touching the FE.

## Verification (live, CT105, real browser via Playwright)
- Board now renders existing tasks: `Default · 7`, Ready/Running/Done lanes show their cards (DOM card counts match the API exactly).
- Clicking **+Add** creates a real task that appears in the UI after refetch (confirmed 2 clicks → 2 new tasks in `kanban.db`, then cleaned up).
- hal0-api healthy after rebuild+restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)