### PR TITLE
fix(dash): NPU occupancy slot buttons match the standard slot cards

### DIFF
--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -1030,13 +1030,13 @@
 }
 
 /* per-slot control icons */
-:is(.infer-pane, .npu-pane) .slot-ctrls {
+:is(.infer-pane, .npu-pane, .npu-card) .slot-ctrls {
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
   gap: 4px;
 }
-:is(.infer-pane, .npu-pane) .sctrl {
+:is(.infer-pane, .npu-pane, .npu-card) .sctrl {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1052,34 +1052,34 @@
     border-color 0.12s,
     color 0.12s;
 }
-:is(.infer-pane, .npu-pane) .sctrl:hover {
+:is(.infer-pane, .npu-pane, .npu-card) .sctrl:hover {
   border-color: var(--line-strong);
   background: var(--bg-2);
   color: var(--fg-2);
 }
-:is(.infer-pane, .npu-pane) .sctrl:disabled {
+:is(.infer-pane, .npu-pane, .npu-card) .sctrl:disabled {
   opacity: 0.4;
   cursor: default;
 }
-:is(.infer-pane, .npu-pane) .sctrl.start {
+:is(.infer-pane, .npu-pane, .npu-card) .sctrl.start {
   color: var(--ok);
   border-color: var(--ok-line);
 }
-:is(.infer-pane, .npu-pane) .sctrl.start:hover {
+:is(.infer-pane, .npu-pane, .npu-card) .sctrl.start:hover {
   background: var(--ok-soft);
 }
-:is(.infer-pane, .npu-pane) .sctrl.stop {
+:is(.infer-pane, .npu-pane, .npu-card) .sctrl.stop {
   color: var(--err);
   border-color: var(--err-line);
 }
-:is(.infer-pane, .npu-pane) .sctrl.stop:hover {
+:is(.infer-pane, .npu-pane, .npu-card) .sctrl.stop:hover {
   background: var(--err-soft);
 }
-:is(.infer-pane, .npu-pane) .sctrl.restart {
+:is(.infer-pane, .npu-pane, .npu-card) .sctrl.restart {
   color: var(--comfy);
   border-color: var(--comfy-line);
 }
-:is(.infer-pane, .npu-pane) .sctrl.restart:hover {
+:is(.infer-pane, .npu-pane, .npu-card) .sctrl.restart:hover {
   background: var(--comfy-soft);
 }
 

--- a/ui/src/dash/npu.css
+++ b/ui/src/dash/npu.css
@@ -9,7 +9,8 @@
  * Everything is scoped under .npu-card so the generic class names (.combo,
  * .aie-tile, .gauge…) can't collide with other panes. Slot-control buttons
  * (.sctrl / .slot-ctrls) are intentionally NOT redefined here — they reuse the
- * global definitions shared with the inference/comfyui slot cards. */
+ * shared definitions in engine-panes.css, whose selector includes .npu-card
+ * so the buttons match the inference/comfyui slot cards exactly. */
 
 .npu-card {
   --npu: var(--dev-npu); /* #c896ff — NPU device hue, the card accent */


### PR DESCRIPTION
## What

The NPU occupancy card (#859) was rendering its Start/Stop/Restart/Logs/Edit buttons as **raw, unstyled browser buttons** instead of the standard slot-card control buttons.

## Why

The shared button styles in `engine-panes.css` are scoped to `:is(.infer-pane, .npu-pane)`, but the NPU card's root element is `.npu-card` (what all of `npu.css` is scoped under). `.npu-pane` exists **nowhere** in the JSX, so the `.sctrl` / `.slot-ctrls` rules matched nothing and the buttons fell back to browser defaults.

`npu.css` intentionally does *not* redefine these buttons (line-11 comment) — it expects them to inherit the global definitions shared with the inference/ComfyUI cards.

## Fix

Add `.npu-card` to the button selectors' `:is()` list (10 rules: `.slot-ctrls` + `.sctrl` variants). The controls now render identically to every other slot card.

**Surgical by design:** only the button selectors are extended. Adding `.npu-pane` to the card root would activate all 132 shared `:is(.infer-pane, .npu-pane)` rules and collide with `npu.css`'s deliberately-scoped generic class names (`.combo`, `.md`, `.nm`…).

## Test

- `npm run build` clean
- Buttons visually match inference/ComfyUI slot cards (verify on slots page after deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)