### PR TITLE
feat(dash): living NPU occupancy grid — per-slot accents + activity-driven breathing

### DIFF
--- a/ui/src/dash/npu-pane.jsx
+++ b/ui/src/dash/npu-pane.jsx
@@ -21,8 +21,6 @@ import { useSlotRestart, useSlotUnload, useSlotLoad } from '@/api/hooks/useSlots
 import { SlotControls, slotCtrlPhase } from './inference-pane.jsx'
 import { slotIndicatorFromPhase } from './slot-status.js'
 
-const { useState: useStateN, useEffect: useEffectN } = React
-
 // ─── icons (16×16, hal0 thin-line family — ported from the design) ─────────
 const NI = ({ d, size = 16, sw = 1.5, children, fill = 'none' }) => (
   <svg
@@ -64,35 +62,61 @@ const devKind = (device) => {
 }
 const isNpuSlot = (s) => s.device_class === 'npu' || devKind(s.device) === 'npu'
 
-// owner hues — distinct so each FLM reads as its own owner. The serving/primary
-// slot is the dominant purple; co-resident slots get a quieter slate-blue.
+// owner hues — assigned by slot index so each resident FLM reads as its own
+// owner. Three cohesive accents (deep-indigo → teal → sage); single-tenant NPU
+// usually shows just the first. The hue fills the slot's claimed columns in the
+// grid AND its mini column strip; glow/line drive the active-tile halo.
 const HUES = [
-  { hue: 'var(--npu)', glow: 'var(--npu-glow)', line: 'var(--npu-line)', dim: 'var(--npu-dim)' },
-  { hue: 'var(--npu-b)', glow: 'var(--npu-b-glow)', line: 'var(--npu-b-line)', dim: 'var(--npu-b-dim)' },
+  { hue: 'var(--npu-s0)', glow: 'var(--npu-s0-glow)', line: 'var(--npu-s0-line)', dim: 'var(--npu-s0-dim)' },
+  { hue: 'var(--npu-s1)', glow: 'var(--npu-s1-glow)', line: 'var(--npu-s1-line)', dim: 'var(--npu-s1-dim)' },
+  { hue: 'var(--npu-s2)', glow: 'var(--npu-s2-glow)', line: 'var(--npu-s2-line)', dim: 'var(--npu-s2-dim)' },
 ]
 
-// honour reduced-motion → frozen snapshot (no shimmer, no pulse)
+// honour reduced-motion → frozen snapshot (no breathing, no glow pulse)
 const REDUCE =
   typeof window !== 'undefined' &&
   window.matchMedia &&
   window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
-// one shared clock so every region of the card breathes together
-function useTick(ms = 800) {
-  const [t, setT] = useStateN(0)
-  useEffectN(() => {
-    if (REDUCE) return
-    const id = setInterval(() => setT((x) => x + 1), ms)
-    return () => clearInterval(id)
-  }, [ms])
-  return t
-}
-// smooth pseudo-noise per (col,row) so active tiles shimmer independently.
-// COSMETIC ONLY — there is no real per-tile counter on this kernel.
-const tnoise = (c, r, t) => 0.5 + 0.5 * Math.sin(t * 0.9 + c * 1.27 + r * 2.11)
-
 const NPU_ROWS = 4
 const NPU_COLS = 8
+
+// ─── "aliveness" model ─────────────────────────────────────────────────────
+// The claimed columns breathe harder the more the NPU is actually working.
+// Blend (per design intent): the coarse duty-cycle sets the baseline energy,
+// live tok/s adds transient spikes on top. The aggregate signal is REAL; the
+// per-tile variation (phase, jitter) is decorative — there is no per-tile
+// counter on this kernel, so we never claim one.
+const TPS_CEIL = 60 // tok/s that maps to a full throughput spike
+const activityLevel = (dutyPct, tpsSum) => {
+  const duty = Math.max(0, Math.min(1, (dutyPct || 0) / 100))
+  const tps = Math.max(0, Math.min(1, (tpsSum || 0) / TPS_CEIL))
+  return Math.max(0, Math.min(1, 0.5 * duty + 0.7 * tps))
+}
+// deterministic per-tile hash → [0,1), stable across renders (no reshuffle)
+const hash01 = (n) => {
+  const x = Math.sin(n) * 43758.5453
+  return x - Math.floor(x)
+}
+// map activity (0..1) + a tile's base opacity → the CSS-animation custom props
+// for that tile. Anchors: 0% solid + faint breath · 25% ≈ ±20% swing / 10–20
+// pulses-per-min · 80%+ wider swing / ≈30–45 ppm, randomised per tile.
+const tileAnim = (act, base, c, r) => {
+  const amp = Math.min(0.45, 0.05 + 0.6 * act) // opacity swing ±amp
+  const ppm = 3 + 46 * act // pulses per 60s
+  const baseDur = 60 / ppm // seconds per pulse
+  const spread = 0.3 + 0.5 * act // per-tile duration jitter widens with load
+  const s1 = hash01(c * 12.9898 + r * 78.233)
+  const s2 = hash01(c * 39.346 + r * 11.135)
+  const dur = baseDur * (1 - spread / 2 + s1 * spread)
+  return {
+    '--lo': Math.max(0.06, base - amp).toFixed(3),
+    '--hi': Math.min(1, base + amp).toFixed(3),
+    '--dur': dur.toFixed(2) + 's',
+    '--delay': (-s2 * dur).toFixed(2) + 's', // negative → tiles start mid-cycle, desynced
+    '--gmax': (4 + 11 * act).toFixed(1) + 'px', // glow blur grows with load
+  }
+}
 
 // ═══ RADIAL GAUGE (270° sweep) ═════════════════════════════════════════
 function Gauge({ pct, label, sub, size = 184 }) {
@@ -143,8 +167,7 @@ function Gauge({ pct, label, sub, size = 184 }) {
 // ═══ AIE TILE GRID — the shared spatial primitive (4 rows × 8 columns) ══
 // `owners` is a length-8 array: owner descriptor per column (or null = free).
 // `available` false → degraded (probe couldn't read columns); grid greys.
-function AieGrid({ owners, available, size = 30, cgap = 6, rgap = 5, showHeaders = true, showParts = true }) {
-  const t = useTick(700)
+function AieGrid({ owners, available, act = 0, size = 30, cgap = 6, rgap = 5, showHeaders = true, showParts = true }) {
   const cols = Array.from({ length: NPU_COLS }, (_, c) => c)
   const rows = Array.from({ length: NPU_ROWS }, (_, r) => r)
   // partition runs — collapse consecutive columns with the same owner
@@ -178,14 +201,22 @@ function AieGrid({ owners, available, size = 30, cgap = 6, rgap = 5, showHeaders
             <div className="aie-col" key={c}>
               {rows.map((r) => {
                 const serving = owner && owner.serving
-                const op = !owner ? 0 : serving ? 0.5 + 0.5 * tnoise(c, r, t) : 0.2
+                // solid base fill — the colour IS the claim (was a near-invisible
+                // 0.2/0.5); the animation breathes around this base.
+                const base = !owner ? 0 : serving ? 0.82 : 0.5
                 const cls = 'aie-tile' + (owner ? (serving ? ' active' : ' claimed') : '')
                 const style = owner
-                  ? { '--tile-hue': owner.hue, '--tile-glow': owner.glow, '--tile-line': owner.line }
+                  ? {
+                      '--tile-hue': owner.hue,
+                      '--tile-glow': owner.glow,
+                      '--tile-line': owner.line,
+                      '--base': base,
+                      ...(REDUCE ? {} : tileAnim(act, base, c, r)),
+                    }
                   : null
                 return (
                   <div className={cls} key={r} style={style}>
-                    <span className="core" style={{ opacity: op, background: owner ? owner.hue : undefined }} />
+                    <span className="core" style={{ background: owner ? owner.hue : undefined }} />
                   </div>
                 )
               })}
@@ -215,8 +246,7 @@ function AieGrid({ owners, available, size = 30, cgap = 6, rgap = 5, showHeaders
 }
 
 // mini single-row strip of the 8 columns, filtered to one owner (slot rail)
-function TileStrip({ owners, ownerName, w = 10, h = 10 }) {
-  const t = useTick(700)
+function TileStrip({ owners, ownerName, act = 0, w = 10, h = 10 }) {
   const cols = Array.from({ length: NPU_COLS }, (_, c) => c)
   return (
     <div className="tstrip" style={{ '--ts-w': w + 'px', '--ts-h': h + 'px' }}>
@@ -224,22 +254,24 @@ function TileStrip({ owners, ownerName, w = 10, h = 10 }) {
         const o = owners[c]
         const mine = o && o.name === ownerName
         const serving = mine && o.serving
-        const op = serving ? 0.55 + 0.45 * (0.5 + 0.5 * tnoise(c, 0, t)) : 0.32
+        const base = !mine ? 0 : serving ? 0.85 : 0.5
         const cls = 't' + (mine ? (serving ? ' active' : ' claimed') : '')
-        return (
-          <span
-            className={cls}
-            key={c}
-            style={mine ? { background: o.hue, opacity: op, '--tile-glow': o.glow } : null}
-          />
-        )
+        const style = mine
+          ? {
+              background: o.hue,
+              '--tile-glow': o.glow,
+              '--base': base,
+              ...(REDUCE ? {} : tileAnim(act, base, c, 0)),
+            }
+          : null
+        return <span className={cls} key={c} style={style} />
       })}
     </div>
   )
 }
 
 // ═══ per-slot card (right rail) ════════════════════════════════════════
-function ComboSlot({ slot, occ, owners, hue, handlers }) {
+function ComboSlot({ slot, occ, owners, hue, handlers, act = 0 }) {
   const ind = slotIndicatorFromPhase(slot)
   const serving = ind.cls === 'serving'
   const m = slot.metrics || {}
@@ -270,7 +302,7 @@ function ComboSlot({ slot, occ, owners, hue, handlers }) {
       </div>
       <div className="cslot-row">
         <span className="cslot-strip">
-          <TileStrip owners={owners} ownerName={slot.name} />
+          <TileStrip owners={owners} ownerName={slot.name} act={act} />
         </span>
       </div>
       <div className="cslot-foot">
@@ -315,6 +347,8 @@ export function NpuOccupancyCard({ slots }) {
     .map((s) => s.metrics?.toks)
     .filter((t) => typeof t === 'number' && t > 0)
     .reduce((a, b) => a + b, 0)
+  // blended activity (duty floor + tok/s spike) → drives how hard the tiles breathe
+  const act = activityLevel(dutyPct, tpsSum)
 
   // owner descriptor per column (length 8). Built from the occupancy probe so
   // the grid + every slot strip share one source of truth.
@@ -396,7 +430,7 @@ export function NpuOccupancyCard({ slots }) {
               </div>
             </div>
             <div className="combo-grid">
-              <AieGrid owners={owners} available={colsAvailable} size={30} cgap={6} rgap={5} />
+              <AieGrid owners={owners} available={colsAvailable} act={act} size={30} cgap={6} rgap={5} />
               <div className="aie-foot">allocated columns — not per-tile utilisation</div>
             </div>
             <div className="combo-slots">
@@ -408,6 +442,7 @@ export function NpuOccupancyCard({ slots }) {
                   owners={owners}
                   hue={HUES[idx % HUES.length]}
                   handlers={handlers}
+                  act={act}
                 />
               ))}
               {colsUsed < colsTotal && (

--- a/ui/src/dash/npu.css
+++ b/ui/src/dash/npu.css
@@ -25,6 +25,23 @@
   --npu-b-dim: rgba(104, 112, 149, 0.18);
   --npu-b-glow: rgba(104, 112, 149, 0.5);
   --npu-b-line: rgba(104, 112, 149, 0.45);
+
+  /* per-slot owner accents — assigned by slot index in npu-pane HUES. These
+     fill the slot's claimed columns (grid + mini strip). The glow/line halos
+     are deliberately *lightened* tints of each base so the colours (esp. the
+     dark indigo s0) read as a halo against the dark grid. */
+  --npu-s0: #4a4466; /* slot 0 — deep indigo */
+  --npu-s0-dim: rgba(74, 68, 102, 0.2);
+  --npu-s0-glow: rgba(138, 130, 184, 0.62); /* lightened indigo halo */
+  --npu-s0-line: rgba(138, 130, 184, 0.5);
+  --npu-s1: #6eadbc; /* slot 1 — teal */
+  --npu-s1-dim: rgba(110, 173, 188, 0.2);
+  --npu-s1-glow: rgba(140, 205, 220, 0.62);
+  --npu-s1-line: rgba(140, 205, 220, 0.5);
+  --npu-s2: #9fcbad; /* slot 2 — sage */
+  --npu-s2-dim: rgba(159, 203, 173, 0.2);
+  --npu-s2-glow: rgba(183, 224, 196, 0.62);
+  --npu-s2-line: rgba(183, 224, 196, 0.5);
 }
 .npu-card * {
   box-sizing: border-box;
@@ -301,13 +318,46 @@
   position: absolute;
   inset: 0;
   background: var(--tile-hue, var(--npu));
-  opacity: 0;
+  opacity: var(--base, 0); /* solid base fill — the colour IS the claim; empty tiles stay 0 */
   transition: opacity 0.45s var(--ease, ease);
+}
+/* claimed/serving cores breathe between --lo and --hi (set per-tile in JS from
+   the live activity level). Empty tiles carry no class → no keyframe → stay dark. */
+.npu-card .aie-tile.claimed .core,
+.npu-card .aie-tile.active .core {
+  animation: npuTilePulse var(--dur, 8s) ease-in-out infinite;
+  animation-delay: var(--delay, 0s);
 }
 .npu-card .aie-tile.active {
   box-shadow:
     0 0 0 1px var(--tile-line, var(--npu-line)) inset,
     0 0 9px -2px var(--tile-glow, var(--npu-glow));
+  /* glow blur swells with load via --gmax; static box-shadow above is the
+     at-rest / reduced-motion fallback */
+  animation: npuTileGlow var(--dur, 8s) ease-in-out infinite;
+  animation-delay: var(--delay, 0s);
+}
+@keyframes npuTilePulse {
+  0%,
+  100% {
+    opacity: var(--lo, var(--base, 0.5));
+  }
+  50% {
+    opacity: var(--hi, var(--base, 0.9));
+  }
+}
+@keyframes npuTileGlow {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 1px var(--tile-line, var(--npu-line)) inset,
+      0 0 3px -2px var(--tile-glow, var(--npu-glow));
+  }
+  50% {
+    box-shadow:
+      0 0 0 1px var(--tile-line, var(--npu-line)) inset,
+      0 0 var(--gmax, 9px) -2px var(--tile-glow, var(--npu-glow));
+  }
 }
 /* degraded — probe could not read columns */
 .npu-card .aie.degraded {
@@ -366,12 +416,24 @@
   background: var(--bg-3);
   border: 1px solid var(--line);
 }
-.npu-card .tstrip .t.claimed {
-  border-color: transparent;
-}
+.npu-card .tstrip .t.claimed,
 .npu-card .tstrip .t.active {
   border-color: transparent;
+  opacity: var(--base, 0.5); /* solid fill; breathes via the shared keyframe */
+  animation: npuTilePulse var(--dur, 8s) ease-in-out infinite;
+  animation-delay: var(--delay, 0s);
+}
+.npu-card .tstrip .t.active {
   box-shadow: 0 0 6px -1px var(--tile-glow, var(--npu-glow));
+}
+
+/* reduced motion — freeze every tile at its solid base: no breath, no glow pulse */
+@media (prefers-reduced-motion: reduce) {
+  .npu-card .aie-tile .core,
+  .npu-card .aie-tile.active,
+  .npu-card .tstrip .t {
+    animation: none !important;
+  }
 }
 
 /* ── per-slot cards (right rail) ───────────────────────────────────── */


### PR DESCRIPTION
## What

Makes the NPU occupancy grid (PR #859) **read as alive** and gives each FLM slot a distinct accent.

### Per-slot accents
Three accent colors mapped by slot index, used to (a) fill a tile's column usage in the large 4×8 AIE-ML grid and (b) color the miniature column line below the model name:

- slot 0 → `#4A4466` (deep indigo)
- slot 1 → `#6EADBC` (teal)
- slot 2 → `#9FCBAD` (sage)

Each color ships with `-dim` / `-glow` / `-line` variants. The existing `--npu` / `--npu-b` vars are left untouched (`--npu-b` still tints the tok/s number).

### Grid-fill fix
Claimed tiles previously rendered at `0.2` opacity of a pale hue → the large grid looked empty/washed out. Now a tile gets a **solid base fill** (`0.5` claimed, `0.82` serving) and animates *around* that base.

### Activity-driven "alive" effect
The more inference the NPU sees, the more the individual squares come alive — opacity fades + timed glows that scale with a blended activity level:

```
activityLevel = clamp(0.5 * dutyCycle + 0.7 * (tok/s ÷ 60))
```

Per-tile, this drives:
- **opacity amplitude** — `±5%` at idle → up to `±45%` at full tilt
- **pulse rate** — ~3/min idle → ~49/min at full tilt
- **glow radius** — `4px` → `15px`
- **phase/duration jitter** — deterministic per-tile hash desyncs tiles so the array shimmers rather than blinking in unison

Animation is **CSS-driven** (per-tile CSS vars from JS, `@keyframes` do the work — no per-frame React), and fully respects `prefers-reduced-motion`.

## Files
- `ui/src/dash/npu.css` — accent vars, `.core` solid base + breathing, tstrip pulse, reduced-motion guard
- `ui/src/dash/npu-pane.jsx` — activity model, per-tile hash/jitter, accent wiring through AieGrid / TileStrip / ComboSlot

## Test
- `npm run build` clean
- `npu-occupancy-v3.spec.ts` assertions all still valid (grid shape, active tiles, partition bracket, slot card, tok/s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)