### PR TITLE
fix(slots): derive slot ctx, never silently inherit llama-server 4096

### DIFF
--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -315,6 +315,11 @@ def _unflatten_slot_toml(cfg: SlotConfig) -> dict[str, Any]:
         },
         "model": data["model"],
     }
+    # context_size is Optional (unset → derived at load by the provider);
+    # None has no TOML representation, so elide any None in the model table.
+    model_tbl = out.get("model")
+    if isinstance(model_tbl, dict):
+        out["model"] = {k: v for k, v in model_tbl.items() if v is not None}
     extra = data.get("extra") or {}
     if isinstance(extra, dict):
         for k, v in extra.items():

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -150,10 +150,15 @@ class ModelConfig(BaseModel):
         default="",
         description="Default model id from the registry.  Must exist in /var/lib/hal0/registry/.",
     )
-    context_size: int = Field(
-        default=4096,
+    context_size: int | None = Field(
+        default=None,
         ge=128,
-        description="Context window size in tokens.",
+        description=(
+            "Context window size in tokens. Unset (None) is NOT 4096: the "
+            "load path derives the model's native window (dense-capped) or a "
+            "safe 8192 floor, so a slot never silently inherits llama-server's "
+            "4096 default (chat@4096 incident, 2026-06-15)."
+        ),
     )
     n_gpu_layers: int = Field(
         default=-1,

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -439,6 +439,54 @@ def _profile_runtime_family(slot_cfg: dict[str, Any]) -> str | None:
         return None
 
 
+# Native context-window resolution (chat@4096 incident, 2026-06-15).
+#
+# A slot whose [model].context_size is unset must NEVER fall through to
+# llama-server's silent 4096 default. We derive the model's native window
+# from the registry (GGUF arch max), cap dense models so an unconfigured
+# slot can't request an impractically large KV cache, and otherwise use a
+# safe floor. Mirrors hal0.hardware.recommend's installer-side policy.
+_CTX_SAFE_FALLBACK = 8192
+_CTX_DENSE_CAP = 32768
+
+
+def _native_ctx(model_info: dict[str, Any]) -> int | None:
+    """Best-effort native context window for a model, or None if unknown.
+
+    GGUF arch max (registry metadata.context_length) is authoritative;
+    a model's own defaults.context_size is the secondary source.
+    """
+    md = model_info.get("metadata")
+    if isinstance(md, dict) and md.get("context_length"):
+        try:
+            return int(md["context_length"])
+        except (TypeError, ValueError):
+            pass
+    defaults = model_info.get("defaults")
+    if isinstance(defaults, dict) and defaults.get("context_size"):
+        try:
+            return int(defaults["context_size"])
+        except (TypeError, ValueError):
+            pass
+    return None
+
+
+def _resolve_context_size(explicit: int | None, model_info: dict[str, Any]) -> int:
+    """The slot's effective context window.
+
+    The explicit slot value wins when set; otherwise derive the model's
+    native window (dense-capped); otherwise a safe _CTX_SAFE_FALLBACK.
+    Guarantees a non-None int so the slot never silently inherits
+    llama-server's 4096 default.
+    """
+    if explicit is not None:
+        return int(explicit)
+    native = _native_ctx(model_info)
+    if native:
+        return min(native, _CTX_DENSE_CAP)
+    return _CTX_SAFE_FALLBACK
+
+
 class ContainerProvider(Provider):
     """Podman-container-per-slot inference backend.
 
@@ -497,7 +545,10 @@ class ContainerProvider(Provider):
         port = int(slot_cfg.get("port", 0))
 
         model_table = slot_cfg.get("model") or {}
-        context_size = model_table.get("context_size") if isinstance(model_table, dict) else None
+        context_size = _resolve_context_size(
+            model_table.get("context_size") if isinstance(model_table, dict) else None,
+            model_info,
+        )
         server_table = slot_cfg.get("server") or {}
         extra_args = server_table.get("extra_args") if isinstance(server_table, dict) else None
         # Registry model id → llama-server --alias so the container advertises

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1548,6 +1548,16 @@ class SlotManager:
         cfg_dict = _cfg_to_dict(slot_cfg)
         # #585: canonicalize a ctx_size alias from the create modal too.
         _normalize_ctx_key(cfg_dict)
+        # Persist a concrete context window when the operator left it unset, so
+        # the TOML, the dashboard, and the running container all agree. The
+        # provider's load-path derive is the belt-and-suspenders fallback; this
+        # makes the chosen window visible at create time (chat@4096 incident).
+        model_tbl = cfg_dict.get("model")
+        if isinstance(model_tbl, dict) and model_tbl.get("context_size") is None:
+            from hal0.providers.container import _resolve_context_size
+
+            model_info = await self._resolve_model_info(model_tbl.get("default"))
+            model_tbl["context_size"] = _resolve_context_size(None, model_info)
         # Reject (or normalize) an incoherent device/profile backend pairing
         # before it ever lands on disk — the door the dashboard left open for
         # the utility slot (vulkan device + rocm-dnse profile). Every field is
@@ -2369,10 +2379,19 @@ class SlotManager:
 
 def _cfg_to_dict(cfg: SlotConfig | dict[str, Any]) -> dict[str, Any]:
     if hasattr(cfg, "model_dump"):
-        return cfg.model_dump()  # type: ignore[no-any-return]
-    if isinstance(cfg, dict):
-        return dict(cfg)
-    raise SlotConfigError(f"unsupported slot cfg type {type(cfg).__name__}")
+        d: dict[str, Any] = cfg.model_dump()
+    elif isinstance(cfg, dict):
+        d = dict(cfg)
+    else:
+        raise SlotConfigError(f"unsupported slot cfg type {type(cfg).__name__}")
+    # An unset context_size (schema default None) must never reach the TOML
+    # writer: write_toml_atomic rejects None, and a persisted 4096 was the
+    # chat@4096 incident. Drop the key so the load path derives the model's
+    # native window instead (see providers.container._resolve_context_size).
+    model = d.get("model")
+    if isinstance(model, dict) and model.get("context_size") is None:
+        model.pop("context_size", None)
+    return d
 
 
 def _cfg_port(cfg: SlotConfig | dict[str, Any]) -> int:

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -124,7 +124,9 @@ class TestModelConfig:
     def test_defaults(self) -> None:
         m = ModelConfig()
         assert m.default == ""
-        assert m.context_size == 4096
+        # Unset is None (NOT 4096): the load path derives the model's native
+        # window or a safe 8192 floor (chat@4096 incident, 2026-06-15).
+        assert m.context_size is None
         assert m.n_gpu_layers == -1
 
     def test_context_size_below_minimum_raises(self) -> None:

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -701,3 +701,44 @@ def test_resolve_model_path_registry_miss_falls_back_to_bare_id() -> None:
     GGUF path — the C8 deploy precheck enforces this on CT105.
     """
     assert _resolve_model_path({"_model_key": "gemma-4-12b-it"}) == "gemma-4-12b-it"
+
+
+class TestContextSizeDerive:
+    """Regression guard for the 2026-06-15 chat@4096 incident: a slot whose
+    TOML pins no context_size must NEVER silently inherit llama-server's 4096
+    default. container_spec derives the model's native window (dense-capped),
+    or falls back to a safe 8192 when the native window is unknown."""
+
+    def _spec(self, cfg: dict[str, Any], model_info: dict[str, Any]):
+        provider = ContainerProvider()
+        with patch(
+            "hal0.providers.container._resolve_profile",
+            return_value=_moe_profile(),
+        ):
+            return provider.container_spec(cfg, model_info)
+
+    @staticmethod
+    def _ctx(command: list[str]) -> str | None:
+        return command[command.index("--ctx-size") + 1] if "--ctx-size" in command else None
+
+    def test_unset_ctx_derives_native_dense_capped(self) -> None:
+        cfg = _slot_cfg()  # [model] has no context_size
+        mi = _model_info(metadata={"context_length": 131072})
+        assert self._ctx(self._spec(cfg, mi).command) == "32768"
+
+    def test_unset_ctx_unknown_native_falls_back_8192_not_4096(self) -> None:
+        cfg = _slot_cfg()
+        mi = _model_info()  # no metadata.context_length, no defaults.context_size
+        ctx = self._ctx(self._spec(cfg, mi).command)
+        assert ctx == "8192"
+        assert ctx != "4096"
+
+    def test_unset_ctx_uses_model_defaults_when_no_metadata(self) -> None:
+        cfg = _slot_cfg()
+        mi = _model_info(defaults={"context_size": 16384})
+        assert self._ctx(self._spec(cfg, mi).command) == "16384"
+
+    def test_explicit_ctx_always_wins_over_native(self) -> None:
+        cfg = _slot_cfg(model={"default": "m.gguf", "context_size": 131072})
+        mi = _model_info(metadata={"context_length": 262144})
+        assert self._ctx(self._spec(cfg, mi).command) == "131072"


### PR DESCRIPTION
## Root cause — the 2026-06-15 chat@4096 incident

Hermes reported "broken": the **chat** slot was serving at `--ctx-size 4096` instead of its configured window, so `hal0/primary` 400'd (`exceed_context_size_error n_ctx:4096`) on any conversation > 4096 tokens.

Two compounding defects were found (see auto-memory `hermes_chat_slot_ctx4096_compaction_2026-06-15`):

- **Defect A (this PR):** `ModelConfig.context_size` defaulted to **4096**, and `model_dump()` wrote that verbatim. The installer normally derives a real window from a model's *curated* arch max — but a **non-curated** model with empty registry metadata (`qwopus3.6-27b-v2`) had no native window to derive from, so it fell to the schema default 4096. When `context_size` was unset entirely, `container_spec` emitted **no** `--ctx-size` flag and llama-server silently booted at its own 4096 default.
- **Defect B (not this PR):** stale baked systemd unit — editing `chat.toml` doesn't re-render the unit; only `hal0 slot restart` re-reads. Tracked separately (proposed: extend the slot drift reconciler / `hal0 slot status` to compare running `--ctx-size` vs toml and WARN).

## What this PR changes (Defect A)

Make "unset" explicit and **derive a real window** — a slot can never again silently inherit 4096:

- **schema:** `context_size` default `4096` → `None`.
- **providers/container.`container_spec`** (load path): when the slot pins no ctx, derive the model's native window from the registry (`metadata.context_length` → `defaults.context_size`), **dense-capped at 32768**, else a safe **8192** floor.
- **slots/manager.`create_config`:** persist the derived window at create time so the TOML, dashboard, and running container all agree; the load-path derive remains a belt-and-suspenders fallback.
- **`_cfg_to_dict` + `config.loader._unflatten_slot_toml`:** elide a `None` `context_size` before the TOML writer (`write_toml_atomic` rejects `None`).

The dense cap means an *unconfigured* slot can't request an impractically large KV cache (operators set `context_size` explicitly for full windows, as `chat.toml` does at 131072).

## Tests

- New `TestContextSizeDerive`: native-dense-capped / model-defaults / **8192-floor-not-4096** / explicit-wins.
- Updated `ModelConfig` default expectation (`is None`) + loader round-trip None-elision.
- Targeted suites green: providers, slots, config, install, registry — **600+ passed**. (`test_slot_backend_control::...normalizes_gpu_form` is a pre-existing cross-test ordering flake — passes standalone, untouched here.)

## Diagnostic note (from the incident)
`/v1/models` advertises a uniform 32100 for the npu/utility/chat virtual aliases — **do not trust it**; probe the real served `n_ctx` via a >4096-token request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)