### PR TITLE
fix(dash): split runtime indicator into sidebar launcher + footer health chip

### DIFF
--- a/src/hal0/api/routes/config.py
+++ b/src/hal0/api/routes/config.py
@@ -132,6 +132,14 @@ def _behind_proxy(request: Request) -> bool:
     return any(fwd.get(h) for h in ("x-forwarded-host", "x-forwarded-proto", "x-forwarded-for"))
 
 
+def _host_without_port(host: str) -> str:
+    """Return a hostname suitable for adding the OpenWebUI fixed port."""
+    if host.startswith("["):
+        end = host.find("]")
+        return host[: end + 1] if end >= 0 else host
+    return host.rsplit(":", 1)[0] if ":" in host else host
+
+
 @router.get("/urls")
 async def get_urls(request: Request) -> dict[str, object]:
     """Return the canonical URLs the dashboard should advertise.
@@ -151,14 +159,16 @@ async def get_urls(request: Request) -> dict[str, object]:
     whenever it's defined — it's how a reverse-proxy deploy declares the
     public hostname for OpenWebUI (e.g. ``https://hal0-chat.example.com``).
     Open WebUI emits root-absolute asset URLs and cannot be served under
-    a path prefix, so the proxy must give it its own (sub)domain; there
-    is no safe way to synthesise that from the request alone.
+    a path prefix, so a polished proxy deployment should give it its own
+    (sub)domain.
 
     Without the env var, LAN-direct deploys fall back to
     ``http://<host>:3001`` (matching the systemd unit's bound port).
-    Reverse-proxy deploys without the env var get ``openwebui_enabled =
-    false`` so the dashboard hides the Chat link instead of dangling it
-    at a broken URL.
+    Reverse-proxy deploys without the env var fall back to the same
+    hostname on OpenWebUI's fixed port, ``http://<host>:3001``. This is
+    the open-source default path: operators can expose the service port
+    directly without needing custom DNS. Set ``HAL0_OPENWEBUI_PUBLIC_URL``
+    when OpenWebUI lives on a distinct hostname.
 
     Hermes is different: its dashboard binds ``127.0.0.1:9119`` (loopback)
     so — unlike OpenWebUI — there is NO browser-reachable host:port
@@ -191,10 +201,11 @@ async def get_urls(request: Request) -> dict[str, object]:
     if _behind_proxy(request):
         scheme = request.headers.get("x-forwarded-proto") or request.url.scheme
         forwarded_host = request.headers.get("x-forwarded-host") or host
+        openwebui_host = _host_without_port(forwarded_host)
         return {
             "api": f"{scheme}://{forwarded_host}",
-            "openwebui": "",
-            "openwebui_enabled": False,
+            "openwebui": f"http://{openwebui_host}:{_OPENWEBUI_PORT}",
+            "openwebui_enabled": enabled,
             "hermes": hermes,
             "hermes_enabled": bool(hermes),
         }

--- a/tests/api/test_config_urls.py
+++ b/tests/api/test_config_urls.py
@@ -56,13 +56,8 @@ def test_urls_openwebui_enabled_false_when_systemctl_missing(
     assert resp.json()["openwebui_enabled"] is False
 
 
-def test_urls_behind_proxy_without_public_url_hides_chat(client: TestClient) -> None:
-    """Proxy deploys must declare HAL0_OPENWEBUI_PUBLIC_URL.
-
-    Without it we can't know where OpenWebUI is publicly reachable
-    (it can't be served under a path prefix), so the Chat link is
-    hidden rather than dangled at a broken URL.
-    """
+def test_urls_behind_proxy_without_public_url_uses_openwebui_port(client: TestClient) -> None:
+    """Proxy deploys without custom DNS still get the default :3001 link."""
     resp = client.get(
         "/api/config/urls",
         headers={
@@ -72,7 +67,7 @@ def test_urls_behind_proxy_without_public_url_hides_chat(client: TestClient) -> 
     )
     assert resp.status_code == 200
     body = resp.json()
-    assert body["openwebui"] == "", body
+    assert body["openwebui"] == "http://ai-dev.thinmint.dev:3001", body
     assert body["openwebui_enabled"] is False, body
     assert body["api"] == "https://ai-dev.thinmint.dev", body
 

--- a/ui/src/api/hooks/useConfigUrls.ts
+++ b/ui/src/api/hooks/useConfigUrls.ts
@@ -6,8 +6,8 @@
 // a raw LAN IP, an mDNS `hal0.local` name, or a custom reverse-proxy domain.
 //
 // Per-service `*_enabled` flags say whether to advertise a link at all:
-//   - openwebui: false on a host with the unit down, or behind a proxy with
-//     no HAL0_OPENWEBUI_PUBLIC_URL (OWUI can't be path-prefixed).
+//   - openwebui: false on a host with the unit down; otherwise points at
+//     HAL0_OPENWEBUI_PUBLIC_URL or the default http://<host>:3001 fallback.
 //   - hermes:    false unless HAL0_HERMES_PUBLIC_URL is set — the dashboard
 //     binds loopback-only (127.0.0.1:9119), so there's no host:port fallback.
 

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -13,6 +13,7 @@ import { useUpdateState } from '@/api/hooks/useUpdates'
 import { useSidebarAgentRollup, useApprovalList, useApproveApproval, useDenyApproval } from '@/api/hooks/useAgents'
 import { useConfigUrls } from '@/api/hooks/useConfigUrls'
 import { useHardware } from '@/api/hooks/useHardware'
+import { useServicesHealth } from '@/api/hooks/useServicesHealth'
 
 const { useState: useStateC, useEffect: useEffectC } = React;
 
@@ -321,47 +322,20 @@ function Sidebar({ route, param, onGo }) {
 //                 the chat figure (advertised_models) plus a non-chat modality
 //                 breakdown counted from the real slots by group.
 //   - runtime   — container-slot readiness (useRuntimeRollup → /api/slots).
-//   - openwebui — the external chat UI unit (useInstallState.openwebui_running).
+//   - openwebui — the external chat UI link from /api/config/urls.
 //                 Row key deep-links to the OpenWebUI app.
 //
 // hermes + openwebui link targets are NOT hardcoded — useConfigUrls() reads
 // GET /api/config/urls, where the backend derives the reachable host from the
 // request (so links work on localhost / LAN IP / hal0.local / a custom
 // reverse-proxy domain) and honours the HAL0_{OPENWEBUI,HERMES}_PUBLIC_URL
-// env overrides. Each `*_enabled` flag gates whether we render a link at all.
+// env overrides.
 function SidebarRuntimeWidget({ onGo }) {
-  const L         = useRuntimeRollup();
   const agent     = useSidebarAgentRollup();
   const endpoints = useEndpoints().data || [];
   const slots     = useSlots().data     || [];
   const urls      = useConfigUrls();
 
-  // ── runtime ──
-  // B12: the slot-poll rollup only knows up/down; /api/health/system is the
-  // honest signal for up-but-DEGRADED. When the probe says degraded we force
-  // the chip amber and tooltip the failing checks, even if every slot is up.
-  const health        = useHealthSystem();
-  const degraded      = health.data?.status === 'degraded';
-  const failing       = failingChecks(health.data);
-  const runtimeClass  = degraded ? 'warn'
-    : L.status === 'up' ? 'up'
-      : L.status === 'down' ? 'down'
-        : '';
-  const runtimeTitle = degraded
-    ? `degraded — ${failing.length ? failing.join("; ") : "see /api/health/system"}`
-    : `${L.ready}/${L.total} slot container${L.total === 1 ? "" : "s"} ready`;
-
-  // ── hermes ── honest dot tone: green=running, red=broken, amber=unknown.
-  // "off" when no agent is installed (no false-broken red on a fresh box).
-  const agentClass =
-    agent.agentStatus === 'running' ? 'up'
-      : agent.agentStatus === 'broken' ? 'down'
-        : 'warn';
-  const agentLabel =
-    !agent.installed ? 'off'
-      : agent.agentStatus === 'running' ? 'running'
-        : agent.agentStatus === 'broken' ? 'broken'
-          : '—';
   // hermes web dashboard link — only when the backend advertises a public
   // URL (loopback-only otherwise, so no host:port fallback exists).
   const hermesUrl      = urls.data?.hermes || "";
@@ -369,9 +343,6 @@ function SidebarRuntimeWidget({ onGo }) {
 
   // ── hal0 endpoint ── the synthetic composite upstream (first/only one).
   const ep        = endpoints[0];
-  const epServing = !!ep && ep.status === 'serving';
-  const epClass   = !ep ? 'warn' : epServing ? 'up' : 'down';
-  const epLabel   = !ep ? '—' : epServing ? 'serving' : 'offline';
   const chatCount = ep?.advertised_models ?? 0;
   const embedCount = slots.filter(s => s.group === "embed").length;
   const voiceCount = slots.filter(s => s.group === "voice").length;
@@ -382,15 +353,10 @@ function SidebarRuntimeWidget({ onGo }) {
   if (imgCount   > 0) extraParts.push(`${imgCount} img`);
   const modelsTitle = [`${chatCount} chat`, ...extraParts].join(" · ");
 
-  // ── openwebui ── "—" until /api/config/urls resolves, then running/off.
-  // `openwebui_enabled` already folds in "unit up AND reachably linkable",
-  // so it drives both the dot and whether the key is a link.
+  // ── openwebui ── /api/config/urls is link discovery only. Health lives in
+  // the footer runtime chip, driven by /api/services/health.
   const owuiUrl      = urls.data?.openwebui || "";
-  const owuiKnown    = urls.isSuccess;
-  const owuiEnabled  = urls.data?.openwebui_enabled === true;
-  const owuiClass    = !owuiKnown ? 'warn' : owuiEnabled ? 'up' : 'down';
-  const owuiLabel    = !owuiKnown ? '—' : owuiEnabled ? 'running' : 'off';
-  const owuiLinkable = owuiEnabled && !!owuiUrl;
+  const owuiLinkable = !!owuiUrl;
 
   return (
     <div className="sb-status sb-runtime" data-testid="sidebar-runtime-widget">
@@ -409,42 +375,22 @@ function SidebarRuntimeWidget({ onGo }) {
         ) : (
           <span className="k">hermes</span>
         )}
-        <span className={"v " + agentClass} title={`agent ${agent.agentId ?? ""} — ${agentLabel}`}>
-          <span className="dot" />{agentLabel}
-        </span>
+        <span className="v">{agent.installed ? "agent" : "not installed"}</span>
       </div>
 
-      {/* hal0 — composite /v1 endpoint (read-only) */}
-      <div className="row" data-testid="runtime-row-hal0" title={ep?._synthetic_reason || ""}>
+      {/* hal0 — composite /v1 endpoint (read-only) + model count */}
+      <div className="row" data-testid="runtime-row-hal0" title={modelsTitle || ep?._synthetic_reason || ""}>
         <span className="k">hal0</span>
-        <span className={"v " + epClass}><span className="dot" />{epLabel}</span>
-      </div>
-      <div className="row rt-sub" title={modelsTitle}>
-        <span className="k">models</span>
         <span className="v">
           <b>{chatCount}</b>
+          <span className="rt-model-label"> models</span>
           {extraParts.length > 0 && (
             <span className="rt-extra"> + {extraParts.join(" · ")}</span>
           )}
         </span>
       </div>
 
-      {/* runtime — container slot readiness */}
-      <div
-        className="row"
-        data-testid="runtime-row-runtime"
-        title={runtimeTitle}
-      >
-        <span className="k">runtime</span>
-        <span className={"v " + runtimeClass} data-degraded={degraded ? "1" : undefined}>
-          <span className="dot" />
-          {degraded
-            ? `degraded · ${L.ready}/${L.total} ready`
-            : `${L.status}${L.status === 'up' ? ` · ${L.ready}/${L.total} slots ready` : ''}`}
-        </span>
-      </div>
-
-      {/* openwebui — deep-links to the external chat UI when reachable */}
+      {/* openwebui — deep-links to the external chat UI when a URL is known */}
       <div className="row" data-testid="runtime-row-openwebui">
         {owuiLinkable ? (
           <a
@@ -457,7 +403,7 @@ function SidebarRuntimeWidget({ onGo }) {
         ) : (
           <span className="k">openwebui</span>
         )}
-        <span className={"v " + owuiClass}><span className="dot" />{owuiLabel}</span>
+        <span className="v">chat</span>
       </div>
 
       <div className="ln" />
@@ -482,6 +428,8 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
   // useLogsStream subscribes to /api/journal/stream when the pane is
   // expanded (saves opening an SSE we don't render).
   const L = useRuntimeRollup();
+  const health = useHealthSystem();
+  const serviceHealth = useServicesHealth();
   const [paneSrc, setPaneSrc] = useStateC("merged");
   const [paneQ, setPaneQ] = useStateC("");
   // Source filter rides the SSE URL so the backend pre-filters; search
@@ -520,6 +468,33 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
   // chip stays hidden even when a real update exists (used to honour
   // the banner-stack dismiss). Default (undefined) is "no suppression".
   const showUpdateChip = hasUpdate && updateAvailable !== false;
+  const degraded = health.data?.status === 'degraded';
+  const failing = failingChecks(health.data);
+  const runtimeTone = degraded ? 'warn' : L.status === 'up' ? 'up' : L.status === 'down' ? 'err' : 'warn';
+  const runtimeTitle = degraded
+    ? `degraded — ${failing.length ? failing.join("; ") : "see /api/health/system"}`
+    : `${L.ready}/${L.total} slot container${L.total === 1 ? "" : "s"} ready`;
+  const serviceById = Object.fromEntries((serviceHealth.services || []).map((s) => [s.id, s]));
+  const footerIndicators = [
+    {
+      id: 'hal0',
+      label: 'hal0',
+      tone: degraded ? 'warn' : health.isError ? 'warn' : 'up',
+      title: degraded ? `hal0 degraded — ${failing.join("; ") || "see /api/health/system"}` : 'hal0 api ok',
+    },
+    {
+      id: 'hermes',
+      label: 'hermes',
+      tone: serviceHealth.pending ? 'warn' : serviceById.hermes?.up ? 'up' : 'err',
+      title: serviceById.hermes?.detail || (serviceHealth.pending ? 'service health pending' : 'hermes down'),
+    },
+    {
+      id: 'openwebui',
+      label: 'openwebui',
+      tone: serviceHealth.pending ? 'warn' : serviceById.openwebui?.up ? 'up' : 'err',
+      title: serviceById.openwebui?.detail || (serviceHealth.pending ? 'service health pending' : 'openwebui down'),
+    },
+  ];
 
   return (
     <div className={"footer" + (expanded ? " expanded" : "")}>
@@ -572,10 +547,23 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
         </div>
       )}
       <div className="foot-chips">
-        <div className={"foot-chip " + (L.status === 'up' ? 'up' : '')}>
+        <div className={"foot-chip " + runtimeTone} title={runtimeTitle}>
           <span className="dot" />
           <span className="k">runtime:</span>
           <span className="v">{L.status === 'up' ? `${L.ready}/${L.total} ready` : L.status}</span>
+          <span className="foot-service-dots" aria-label="service health">
+            {footerIndicators.map((svc) => (
+              <span
+                key={svc.id}
+                className={"foot-service-dot " + svc.tone}
+                title={`${svc.label}: ${svc.title}`}
+                aria-label={`${svc.label}: ${svc.tone}`}
+              >
+                <span className="dot" />
+                <span>{svc.label}</span>
+              </span>
+            ))}
+          </span>
         </div>
         {showUpdateChip && (
           <div className="foot-chip accent">

--- a/ui/tests/e2e/specs/sidebar-runtime-widget.spec.ts
+++ b/ui/tests/e2e/specs/sidebar-runtime-widget.spec.ts
@@ -11,12 +11,10 @@
  *                 binds loopback-only, so there's no host:port fallback).
  *   - hal0      — the composite /v1 endpoint (synthetic /api/slots entry,
  *                 served from HAL0_DATA in forced-mock) + model count.
- *   - runtime   — container slot readiness (useRuntimeRollup over the
- *                 shared /api/slots poll): "up · N/M slots ready".
- *   - openwebui — external chat UI; status + link both derived from
- *                 /api/config/urls (openwebui + openwebui_enabled), which the
- *                 backend resolves from the request host — so links work on
- *                 any install without hardcoding.
+ *   - openwebui — external chat UI link derived from /api/config/urls.
+ *
+ * Health indicators live in the footer runtime chip: slot readiness from
+ * useRuntimeRollup plus service dots from /api/services/health.
  *
  * Mock seams: /api/agents and /api/config/urls are NOT in the forced-mock
  * allowlist, so page.route drives them. /api/slots IS allowlisted, so the
@@ -51,11 +49,49 @@ const URLS_NONE = {
   hermes: '',
   hermes_enabled: false,
 }
+const SERVICES_HEALTH_UP = {
+  services: [
+    { id: 'comfyui', name: 'ComfyUI', up: false, detail: 'unreachable', url: null, stat: null },
+    { id: 'hermes', name: 'Hermes', up: true, detail: 'systemd unit active', url: null, stat: null },
+    {
+      id: 'openwebui',
+      name: 'OpenWebUI',
+      up: true,
+      detail: 'reachable — /health ok',
+      url: null,
+      stat: null,
+    },
+    { id: 'n8n', name: 'n8n', up: false, detail: 'unmonitored', url: null, stat: null },
+  ],
+}
+const SERVICES_HEALTH_DOWN = {
+  services: [
+    { id: 'comfyui', name: 'ComfyUI', up: false, detail: 'unreachable', url: null, stat: null },
+    {
+      id: 'hermes',
+      name: 'Hermes',
+      up: false,
+      detail: 'systemd unit inactive or absent',
+      url: null,
+      stat: null,
+    },
+    {
+      id: 'openwebui',
+      name: 'OpenWebUI',
+      up: false,
+      detail: 'unreachable (ConnectError)',
+      url: null,
+      stat: null,
+    },
+    { id: 'n8n', name: 'n8n', up: false, detail: 'unmonitored', url: null, stat: null },
+  ],
+}
 
 test.describe('Sidebar Runtime widget — populated', () => {
   test.beforeEach(async ({ page }) => {
     await page.route('**/api/agents', (route) => json(route, AGENTS_RUNNING))
     await page.route('**/api/config/urls', (route) => json(route, URLS_ALL))
+    await page.route('**/api/services/health', (route) => json(route, SERVICES_HEALTH_UP))
   })
 
   test('renders one widget with hermes / hal0 / runtime / openwebui rows', async ({ page }) => {
@@ -65,13 +101,12 @@ test.describe('Sidebar Runtime widget — populated', () => {
     await expect(widget.locator('.sb-runtime-h')).toHaveText('Runtime')
     await expect(page.locator('[data-testid="runtime-row-hermes"]')).toBeVisible()
     await expect(page.locator('[data-testid="runtime-row-hal0"]')).toBeVisible()
-    await expect(page.locator('[data-testid="runtime-row-runtime"]')).toBeVisible()
     await expect(page.locator('[data-testid="runtime-row-openwebui"]')).toBeVisible()
     // The old standalone block is gone.
     await expect(page.locator('[data-testid="sidebar-agent-block"]')).toHaveCount(0)
   })
 
-  test('hermes row deep-links to the backend-advertised dashboard + shows running', async ({
+  test('hermes row deep-links to the backend-advertised dashboard', async ({
     page,
   }) => {
     await page.goto('/')
@@ -81,12 +116,11 @@ test.describe('Sidebar Runtime widget — populated', () => {
     await expect(link).toContainText('hermes')
     await expect(link).toHaveAttribute('href', HERMES_URL)
     await expect(link).toHaveAttribute('target', '_blank')
-    await expect(row.locator('.v')).toContainText('running')
-    await expect(row.locator('.v')).toHaveClass(/up/)
-    await expect(row.locator('.v .dot')).toBeVisible()
+    await expect(row.locator('.v')).toContainText('agent')
+    await expect(row.locator('.v .dot')).toHaveCount(0)
   })
 
-  test('openwebui row deep-links to the backend-advertised URL + shows running', async ({
+  test('openwebui row deep-links to the backend-advertised URL', async ({
     page,
   }) => {
     await page.goto('/')
@@ -96,28 +130,24 @@ test.describe('Sidebar Runtime widget — populated', () => {
     await expect(link).toContainText('openwebui')
     await expect(link).toHaveAttribute('href', OPENWEBUI_URL)
     await expect(link).toHaveAttribute('target', '_blank')
-    await expect(row.locator('.v')).toContainText('running')
-    await expect(row.locator('.v')).toHaveClass(/up/)
+    await expect(row.locator('.v')).toContainText('chat')
+    await expect(row.locator('.v .dot')).toHaveCount(0)
   })
 
-  test('hal0 row shows serving + the advertised model count', async ({ page }) => {
+  test('hal0 row shows the advertised model count', async ({ page }) => {
     await page.goto('/')
     const row = page.locator('[data-testid="runtime-row-hal0"]')
     await expect(row).toBeVisible({ timeout: FIVE_S })
-    await expect(row.locator('.v')).toContainText('serving')
-    await expect(row.locator('.v')).toHaveClass(/up/)
-    // model count sub-row reflects HAL0_DATA's synthetic endpoint (2 chat).
-    const sub = page.locator('[data-testid="sidebar-runtime-widget"] .row.rt-sub')
-    await expect(sub.locator('.k')).toHaveText('models')
-    await expect(sub.locator('.v b')).toHaveText('2')
+    // model count reflects HAL0_DATA's synthetic endpoint (2 chat).
+    await expect(row.locator('.v b')).toHaveText('2')
   })
 
-  test('runtime row shows status + slot readiness inline', async ({ page }) => {
+  test('footer runtime chip shows readiness and service health dots', async ({ page }) => {
     await page.goto('/')
-    const row = page.locator('[data-testid="runtime-row-runtime"]')
-    await expect(row.locator('.k')).toHaveText('runtime')
+    const chip = page.locator('.foot-chip').filter({ hasText: 'runtime:' })
     // HAL0_DATA seeds 8 enabled slots (legacy is disabled); all are ready.
-    await expect(row.locator('.v')).toContainText('up · 8/8 slots ready', { timeout: FIVE_S })
+    await expect(chip.locator('.v')).toContainText('8/8 ready', { timeout: FIVE_S })
+    await expect(chip.locator('.foot-service-dot.up')).toContainText(['hal0', 'hermes', 'openwebui'])
   })
 })
 
@@ -125,30 +155,32 @@ test.describe('Sidebar Runtime widget — no advertised service links', () => {
   test.beforeEach(async ({ page }) => {
     await page.route('**/api/agents', (route) => json(route, AGENTS_RUNNING))
     await page.route('**/api/config/urls', (route) => json(route, URLS_NONE))
+    await page.route('**/api/services/health', (route) => json(route, SERVICES_HEALTH_UP))
   })
 
-  test('hermes row stays plain text (no dead-end link) but keeps health', async ({ page }) => {
+  test('hermes row stays plain text when no dashboard URL is advertised', async ({ page }) => {
     await page.goto('/')
     const row = page.locator('[data-testid="runtime-row-hermes"]')
     await expect(row).toBeVisible({ timeout: FIVE_S })
     // No anchor — just the bare key — while health still renders.
     await expect(row.locator('a.rt-link')).toHaveCount(0)
     await expect(row.locator('.k')).toHaveText('hermes')
-    await expect(row.locator('.v')).toContainText('running')
+    await expect(row.locator('.v')).toContainText('agent')
   })
 
-  test('openwebui row shows "off" (red) with no link when not reachable', async ({ page }) => {
+  test('openwebui health can be up even when no link is advertised', async ({ page }) => {
     await page.goto('/')
     const row = page.locator('[data-testid="runtime-row-openwebui"]')
-    await expect(row.locator('.v')).toContainText('off', { timeout: FIVE_S })
-    await expect(row.locator('.v')).toHaveClass(/down/)
+    await expect(row.locator('.v')).toContainText('chat', { timeout: FIVE_S })
     await expect(row.locator('a.rt-link')).toHaveCount(0)
     await expect(row.locator('.k')).toHaveText('openwebui')
+    const chip = page.locator('.foot-chip').filter({ hasText: 'runtime:' })
+    await expect(chip.locator('.foot-service-dot.up')).toContainText(['openwebui'])
   })
 })
 
 test.describe('Sidebar Runtime widget — hermes tone mapping', () => {
-  test('broken agent renders a down (red) dot', async ({ page }) => {
+  test('service health renders a down (red) hermes dot', async ({ page }) => {
     await page.route('**/api/agents', (route) =>
       json(route, {
         agents: [{ name: 'hermes', installed_at: '2026-05-25T12:00:00Z', status: 'broken' }],
@@ -156,19 +188,20 @@ test.describe('Sidebar Runtime widget — hermes tone mapping', () => {
       }),
     )
     await page.route('**/api/config/urls', (route) => json(route, URLS_ALL))
+    await page.route('**/api/services/health', (route) => json(route, SERVICES_HEALTH_DOWN))
     await page.goto('/')
-    const v = page.locator('[data-testid="runtime-row-hermes"] .v')
-    await expect(v).toHaveClass(/down/, { timeout: FIVE_S })
-    await expect(v).toContainText('broken')
+    const v = page.locator('.foot-chip').filter({ hasText: 'runtime:' }).locator('.foot-service-dot').filter({ hasText: 'hermes' })
+    await expect(v).toHaveClass(/err/, { timeout: FIVE_S })
+    await expect(v).toContainText('hermes')
   })
 
-  test('no agent installed renders "off" (amber)', async ({ page }) => {
+  test('no agent installed renders sidebar copy without a health dot', async ({ page }) => {
     await page.route('**/api/agents', (route) => json(route, AGENTS_EMPTY))
     await page.route('**/api/config/urls', (route) => json(route, URLS_ALL))
+    await page.route('**/api/services/health', (route) => json(route, SERVICES_HEALTH_UP))
     await page.goto('/')
     const v = page.locator('[data-testid="runtime-row-hermes"] .v')
-    await expect(v).toHaveClass(/warn/, { timeout: FIVE_S })
-    await expect(v).toContainText('off')
+    await expect(v).toContainText('not installed', { timeout: FIVE_S })
     // The widget itself still renders (hermes never hides the whole card).
     await expect(page.locator('[data-testid="sidebar-runtime-widget"]')).toBeVisible()
   })


### PR DESCRIPTION
## What

Splits the dashboard runtime indicator into two pieces:

- **Sidebar** (`chrome.jsx`): compact launcher/count block — drops the per-row health dots.
- **Footer** (`chrome.jsx`): the `runtime:` chip now carries **hal0 / hermes / openwebui** health dots. OpenWebUI status comes from `/api/services/health` (probes `127.0.0.1:3001/health`).
- **Backend** (`config.py`): `/api/config/urls` falls back to `http://<host>:3001` for OpenWebUI behind a proxy when `HAL0_OPENWEBUI_PUBLIC_URL` is unset, so the footer openwebui dot/link resolves on a default install.

## Provenance / base

Authored as working-tree edits by a parallel session on top of the (now-merged) NPU-occupancy branch. Cleanly **re-based onto `main`** (the production `chrome.jsx` regions are disjoint from the NPU card). The one e2e assertion that referenced the NPU branch's unmerged 10-slot mock was adapted to main's mock (`8/8 ready`); the footer-chip + service-dot assertion is unchanged.

## Verified on main
- `tsc --noEmit` clean
- `pytest tests/api/test_config_urls.py tests/api/test_services_health.py` → **17 passed**
- `playwright sidebar-runtime-widget.spec.ts --project=chromium` → **9 passed** (incl. footer-chip readiness + service dots)
- `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)