### PR TITLE
fix(slots): slot health-probe honesty — gate ready-set on real /health (#783 #790 #791 #792)

### DIFF
--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -154,6 +154,21 @@ def serialize_slot(slot: Any, model_cache: dict[str, Any] | None = None) -> dict
             loaded.remove(slot.model_id)
             loaded.insert(0, slot.model_id)
         base["models"] = loaded
+        # #792: a model-requiring slot that reports "serving" with zero
+        # resident models is lying — nothing is actually loaded to serve.
+        # The provided model_cache is the authoritative live loaded set, so
+        # an empty list means nothing is resident. Downgrade the surfaced
+        # status to idle — the documented "process up but /v1/models empty"
+        # state (issue #31). Only SERVING is corrected: an empty cache for a
+        # READY/IDLE slot can mean "not yet observed" rather than "definitely
+        # empty". The true FSM ``state`` is preserved; only ``status`` moves.
+        if base.get("status") == "serving" and not loaded:
+            # Lazy import: top-level would cycle (hal0.slots.__init__ pulls in
+            # the heavy manager, which imports this module). See module note.
+            from hal0.slots.state import provider_requires_model
+
+            if provider_requires_model(base.get("provider")):
+                base["status"] = "idle"
     return base
 
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -106,6 +106,11 @@ _FAIL_WATCH_INTERVAL_S: float = 2.0
 _FAIL_WATCH_LIVE_STATES: frozenset[SlotState] = frozenset(
     {SlotState.READY, SlotState.SERVING, SlotState.IDLE}
 )
+# #783/B4: an active unit is not necessarily healthy. The watcher also probes
+# the model server's /health; a crashed-but-active server (active unit, failing
+# /health) is demoted to ERROR — but only after this many CONSECUTIVE failures,
+# so a single transient blip doesn't trigger a disruptive model reload.
+_HEALTH_FAIL_STRIKES: int = 2
 
 # Idle-monitor defaults. A READY slot whose last activity is older than
 # _IDLE_AFTER_S gets demoted to IDLE so dashboards / unload heuristics
@@ -720,6 +725,7 @@ class SlotManager:
         once the slot leaves the live-state set, by self-cancel via the
         ERROR transition, or via outer ``task.cancel()``.
         """
+        health_failures = 0
         try:
             while True:
                 await asyncio.sleep(_FAIL_WATCH_INTERVAL_S)
@@ -740,7 +746,39 @@ class SlotManager:
                     )
                     continue
                 if active:
-                    continue
+                    # #783/B4: active is necessary but not sufficient. Probe
+                    # the model server's /health — a crashed/wedged server is
+                    # active to systemd while /health fails, so an is-active-
+                    # only watcher leaves it lying as dispatchable READY.
+                    if await self._probe_health(slot_name):
+                        health_failures = 0
+                        continue
+                    health_failures += 1
+                    if health_failures < _HEALTH_FAIL_STRIKES:
+                        # Tolerate a transient blip; a real crash fails again.
+                        continue
+                    # Re-check state in case load/unload moved us mid-probe.
+                    current = self._current_state(slot_name)
+                    if current not in _FAIL_WATCH_LIVE_STATES:
+                        return
+                    # Confirmed unhealthy → ERROR (red dot, operator cue). The
+                    # health endpoint (#783 cr1) then reports degraded and
+                    # hal0_slot_up reads health_ok=False (#791). Recoverable —
+                    # the dispatcher reloads on the next request.
+                    try:
+                        await self._transition(
+                            slot_name,
+                            SlotState.ERROR,
+                            message="model server failed /health probe",
+                            extra={"health_ok": False},
+                            force=True,
+                        )
+                    except Exception as exc:
+                        log.warning(
+                            "slot.fail_watch_transition_failed",
+                            extra={"slot": slot_name, "error": str(exc)},
+                        )
+                    return
                 # The container unit went inactive while we believed it
                 # was live. Re-check state once more — load/unload may
                 # have moved us legitimately during the probe.
@@ -795,6 +833,37 @@ class SlotManager:
                 extra={"slot": slot_name, "error": str(exc)},
             )
             return False
+
+    async def _probe_health(self, slot_name: str) -> bool:
+        """Probe the slot's model-server ``/health`` (#783/B4).
+
+        Returns ``False`` only on a *definitive* not-ok response. Anything
+        inconclusive — missing config, no port, an NPU trio shadow (whose
+        /health would target a non-existent child port), or a probe
+        exception — returns ``True`` so the fail-watch never demotes a slot
+        it cannot actually judge. The watcher's strike counter handles
+        transient single failures; this method only reports one probe.
+        """
+        cfg = await self._maybe_load_config(slot_name)
+        if not cfg or is_npu_trio_shadow(cfg):
+            return True
+        port = _cfg_port(cfg)
+        if not port:
+            return True
+
+        from hal0.providers.container import container_provider
+
+        try:
+            health = await container_provider().health(port)
+        except Exception as exc:
+            # Inconclusive — a transport error is not proof the model server
+            # is dead. Don't demote; the next poll re-probes.
+            log.warning(
+                "slot.health_probe_failed",
+                extra={"slot": slot_name, "error": str(exc)},
+            )
+            return True
+        return bool(health.get("ok"))
 
     async def container_readiness_check(self, slot_name: str) -> tuple[bool, str]:
         """Check whether a container-backed slot is ready to serve requests.
@@ -2330,13 +2399,26 @@ class SlotManager:
         if not active:
             return None
 
-        resolved = SlotState.READY
+        # #790: an active unit is not necessarily ready. A still-loading or
+        # wedged container is active to systemd while its model server isn't
+        # answering /health — adopting it straight to READY publishes it as
+        # dispatchable and live traffic 502s. is_active is already confirmed
+        # above, so only the /health half remains: probe it and adopt to
+        # WARMING (not READY) on a definitive not-ok. _probe_health degrades
+        # gracefully (inconclusive → True) so a probe transport error never
+        # 500s the best-effort /api/slots list, and short-circuits NPU trio
+        # shadows (no own model server) to healthy.
+        healthy = await self._probe_health(slot_name)
+        resolved = SlotState.READY if healthy else SlotState.WARMING
         extras: dict[str, Any] = {
             "backend": cfg.get("backend", "vulkan"),
             "provider": cfg.get("provider", "llama-server"),
             "adopted": True,
+            # Record the probe result so /api/health + hal0_slot_up can fold
+            # in real readiness rather than trusting FSM state alone (#791).
+            "health_ok": healthy,
         }
-        detail = "container unit active"
+        detail = "container unit active" if healthy else "container active, model server not ready"
         # ``force=True`` is required: the legal-transition map does not
         # contain offline→ready. Adoption is the exception — the state
         # machine is recovering from drift, not following load().

--- a/src/hal0/slots/metrics.py
+++ b/src/hal0/slots/metrics.py
@@ -58,6 +58,14 @@ def render_slot_metrics(slots: list[Any]) -> str:
         raw_state = getattr(slot, "state", "")
         state = str(getattr(raw_state, "value", raw_state) or "").lower()
         up = 1 if state in _READY_STATES else 0
+        # #791: don't trust FSM state alone. The last health probe records its
+        # ok-flag on the snapshot's ``metadata["health_ok"]``; an explicit
+        # False means the unit is active to systemd but the model server is
+        # dead (crashed-but-active) — force up=0 so alerting isn't blind. An
+        # absent/None flag (not yet probed) falls back to FSM state.
+        meta = getattr(slot, "metadata", None) or {}
+        if up and meta.get("health_ok") is False:
+            up = 0
         ready_total += up
         lines.append(f'hal0_slot_up{{slot="{name}"}} {up}')
         state_lines.append(f'hal0_slot_state{{slot="{name}",state="{_escape_label(state)}"}} 1')

--- a/tests/api/test_metrics_prometheus_route.py
+++ b/tests/api/test_metrics_prometheus_route.py
@@ -155,3 +155,45 @@ def test_route_is_public(client: TestClient) -> None:
     resp = client.get("/api/metrics/prometheus")
     # 200 even without credentials — public route.
     assert resp.status_code == 200
+
+
+# ── #791: hal0_slot_up folds in the real /health ok-flag ────────────────────
+
+
+def test_crashed_but_active_slot_reports_up_zero() -> None:
+    # A slot whose last health probe FAILED while its FSM still reads a
+    # ready-set state (crashed-but-active) must report up=0 — otherwise
+    # alerting is blind to a slot that is "active" to systemd but whose
+    # model server is dead. ready_total must drop with it.
+    from types import SimpleNamespace
+
+    from hal0.slots.metrics import render_slot_metrics
+
+    crashed = SimpleNamespace(name="chat", state="ready", metadata={"health_ok": False})
+    body = render_slot_metrics([crashed])
+    assert 'hal0_slot_up{slot="chat"} 0' in body
+    # The one-hot state line still reflects the true FSM state.
+    assert 'hal0_slot_state{slot="chat",state="ready"} 1' in body
+    assert "hal0_slots_ready_total 0" in body
+
+
+def test_ready_slot_without_health_flag_stays_up() -> None:
+    # Backward-compat: an absent/unknown health flag must NOT force up=0 —
+    # the metric falls back to FSM state (slot not yet probed / cache lag).
+    from types import SimpleNamespace
+
+    from hal0.slots.metrics import render_slot_metrics
+
+    body = render_slot_metrics([SimpleNamespace(name="chat", state="ready", metadata={})])
+    assert 'hal0_slot_up{slot="chat"} 1' in body
+
+
+def test_health_ok_true_ready_slot_reports_up() -> None:
+    from types import SimpleNamespace
+
+    from hal0.slots.metrics import render_slot_metrics
+
+    body = render_slot_metrics(
+        [SimpleNamespace(name="chat", state="ready", metadata={"health_ok": True})]
+    )
+    assert 'hal0_slot_up{slot="chat"} 1' in body

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -189,6 +189,40 @@ class TestSerializeSlot:
         out = serialize_slot(_slot(), model_cache=None)
         assert "models" not in out
 
+    def test_serving_with_empty_models_downgraded_to_idle(self) -> None:
+        # #792: a model-requiring slot cannot be "serving" with zero resident
+        # models. With an authoritative (provided) model_cache that lists none,
+        # the surfaced status must downgrade to idle (the documented "process
+        # up but /v1/models empty" state, issue #31). The true FSM ``state``
+        # is preserved; only the surfaced ``status`` is corrected.
+        out = serialize_slot(
+            _slot(state=SlotState.SERVING, model_id="qwen3-4b"),
+            model_cache={},
+        )
+        assert out["status"] == "idle"
+        assert out["state"] == "serving"
+
+    def test_serving_with_resident_models_stays_serving(self) -> None:
+        # Guard: a real loaded model means "serving" is honest — no downgrade.
+        out = serialize_slot(
+            _slot(state=SlotState.SERVING, model_id="qwen3-4b"),
+            model_cache={"chat": ["qwen3-4b"]},
+        )
+        assert out["status"] == "serving"
+
+    def test_self_managed_provider_serving_empty_not_downgraded(self) -> None:
+        # Guard: kokoro/moonshine/vibevoice serve a baked-in model and report
+        # no model_id, so an empty model list is not a lie — leave it alone.
+        out = serialize_slot(
+            _slot(
+                state=SlotState.SERVING,
+                model_id=None,
+                metadata={"provider": "kokoro"},
+            ),
+            model_cache={},
+        )
+        assert out["status"] == "serving"
+
 
 # ── concern 2: config-field lifting (pure TOML lift) ────────────────────────
 

--- a/tests/slots/conftest.py
+++ b/tests/slots/conftest.py
@@ -49,6 +49,10 @@ class FakeContainerProvider:
         self.load_calls: list[tuple[dict[str, Any], dict[str, Any]]] = []
         self.unload_calls: list[dict[str, Any]] = []
         self.fail_load: Exception | None = None
+        # /health probe result. Default True: an active unit is also ready.
+        # Set False to simulate a still-loading / wedged model server (unit
+        # active but the inference server isn't answering /health yet).
+        self.healthy: bool = True
 
     # — SlotManager._spawn_locked / terminate (sync, executor-run) —
 
@@ -71,7 +75,7 @@ class FakeContainerProvider:
         return None
 
     async def health(self, port: int) -> dict[str, Any]:
-        return {"ok": True}
+        return {"ok": self.healthy}
 
     # — slot_view container_enrichment extras —
 

--- a/tests/slots/test_fail_watcher.py
+++ b/tests/slots/test_fail_watcher.py
@@ -133,3 +133,42 @@ async def test_fail_watcher_does_not_fire_when_slot_unloads_cleanly(
     # Give any stray watcher time to misbehave; then assert OFFLINE held.
     await asyncio.sleep(0.6)  # > _FAIL_WATCH_INTERVAL_S
     assert sm._states["chat"].state == SlotState.OFFLINE
+
+
+async def test_fail_watcher_demotes_to_error_when_health_fails(
+    slot_root: Any,
+    container_stub: FakeContainerProvider,
+    fast_fail_watch: None,
+) -> None:
+    """#783/B4: a ready slot whose unit stays active but whose /health probe
+    starts failing (model server crashed / wedged) is demoted to ERROR.
+
+    Previously the watcher only checked ``is_active`` — a crashed-but-active
+    container kept publishing as dispatchable READY, so /api/health/system
+    and hal0_slot_up both lied. Demoting to ERROR makes the health endpoint
+    report degraded and drops the slot from the dispatchable set. The probe
+    result is recorded as health_ok=False for the metric fold-in (#791).
+    """
+    sm = SlotManager()
+    await sm.load("chat")
+    assert "chat" in sm._fail_watchers
+    # Unit stays active, but the model server stops answering /health.
+    container_stub.healthy = False
+    observed = await _wait_for_state(sm, "chat", SlotState.ERROR, timeout_s=5.0)
+    assert observed == SlotState.ERROR
+    rec = sm._states["chat"]
+    assert rec.extra.get("health_ok") is False
+
+
+async def test_fail_watcher_keeps_ready_while_health_ok(
+    slot_root: Any,
+    container_stub: FakeContainerProvider,
+    fast_fail_watch: None,
+) -> None:
+    """Guard: a healthy active slot must NOT be demoted by the watcher."""
+    sm = SlotManager()
+    await sm.load("chat")
+    assert "chat" in sm._fail_watchers
+    # Let several poll intervals elapse with the unit active + healthy.
+    await asyncio.sleep(0.8)  # > 3 * _FAIL_WATCH_INTERVAL_S (0.2)
+    assert sm._states["chat"].state == SlotState.READY

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -402,6 +402,29 @@ async def test_status_adopts_running_slot_when_unit_active(
     assert snap.state == SlotState.READY
     # extras carry the adoption marker.
     assert snap.metadata.get("adopted") is True
+    # #790: a healthy adoption records the probe result so metrics / health
+    # can fold it in (health_ok=True is what keeps hal0_slot_up honest).
+    assert snap.metadata.get("health_ok") is True
+
+
+async def test_status_adopts_active_but_unhealthy_slot_as_warming(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """#790: an active unit whose /health probe fails adopts to WARMING.
+
+    A still-loading or wedged container is active to systemd but its model
+    server isn't answering /health. Adopting it straight to READY publishes
+    it as dispatchable and live traffic 502s. It must adopt to WARMING and
+    record health_ok=False instead.
+    """
+    sm = SlotManager()
+    await sm._transition("chat", SlotState.OFFLINE, force=True)
+    container_stub.active.add("chat")
+    container_stub.healthy = False  # unit up, model server not ready
+    snap = await sm.status("chat")
+    assert snap.state == SlotState.WARMING
+    assert snap.metadata.get("health_ok") is False
 
 
 async def test_status_rehydrates_backend_from_toml(


### PR DESCRIPTION
## Why

The health-honesty cluster from the chat@4096 incident triage: across four layers, a container that was **active to systemd but whose model server was dead/empty/loading** still reported as healthy and dispatchable. `/api/health/system` lied, `hal0_slot_up` lied, adoption published wedged containers as READY, and `serialize_slot` rendered "serving" with zero models. This PR makes every layer ask the model server, not just systemd.

## What

Test-first (TDD), one behavior per commit:

- **#792 — `serialize_slot`**: a model-requiring slot in SERVING with an empty resident-model list downgrades surfaced `status` → `idle` (the documented "/v1/models empty" state, #31). Only SERVING is corrected (an empty cache for READY/IDLE can mean "not yet observed"); self-managed providers (kokoro/moonshine/vibevoice) exempt; true FSM `state` preserved.
- **#791 — `hal0_slot_up`**: folds in the snapshot's `metadata["health_ok"]`. Explicit `False` → `up=0` (and drops from `ready_total`); absent/None → falls back to FSM state (backward-compatible for not-yet-probed slots).
- **#790 — `_maybe_adopt_running_slot`**: adoption gated on a real `/health` probe — ready→READY, else→WARMING — recording `health_ok`. NPU trio shadows keep the is-active-only path. Probe degrades gracefully (inconclusive → no block) so a transport error never 500s `/api/slots`.
- **#783 cr2 (Defect B/B4) — `_fail_watch_loop`**: the background watcher now also probes `/health` and demotes a crashed-but-active slot to ERROR after `_HEALTH_FAIL_STRIKES` (2) **consecutive** failures — the strike counter stops a transient blip from triggering a disruptive model reload. ERROR then surfaces via the existing #783-cr1 health endpoint (degraded + `errored[]`) and drops `hal0_slot_up` to 0.

### Design note
Probing lives in the **background fail-watch**, not `status()` — adding a per-poll `/health` network call to the best-effort `/api/slots` hot path would let a hung model server stall the dashboard. `status()` carries the cached `health_ok` for free (it already merges `rec.extra`). #783 cr1 (health endpoint surfaces ERROR slots) already shipped via #795.

## Tests
New/changed: serving-empty→idle (+ resident/self-managed guards); crashed-but-active metric `up=0` (+ backward-compat guards); active-but-unhealthy adopts WARMING / healthy adopts READY w/ `health_ok`; fail-watch demotes to ERROR on sustained `/health` failure, holds READY while ok; `/api/slots` still degrades (not 500) when the probe raises.

Full local sweep: **1338 passed, 1 skipped** (env guard). ruff format + check clean.

Closes #783
Closes #790
Closes #791
Closes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)