### PR TITLE
feat(dash): live-journal footer — runtimes + services health groups + log cleanup

### DIFF
--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -412,6 +412,34 @@ function SidebarRuntimeWidget({ onGo }) {
   );
 }
 
+// ─── Footer health vocabulary (live-journal redesign) ───
+// The ribbon reads as two glanceable LED-pip groups — `runtimes` (one pip per
+// enabled slot) and `services` (one pip per backing service) — each with a
+// ready count, replacing the crammed single "X/Y ready hal0hermesopenwebui"
+// chip. Journal rows gain a device-hued source dot + a level stripe.
+
+// Journal source → device hue (mirrors the slot device palette).
+const _SRC_HUE = {
+  hal0: 'var(--accent)',
+  lemond: 'var(--dev-vulkan)',
+  npu: 'var(--dev-npu)',
+  openwebui: 'var(--info)',
+  comfyui: '#5ea4f9',
+  hermes: 'var(--fg-2)',
+};
+const _srcHue = (s) => _SRC_HUE[s] || 'var(--fg-3)';
+
+// A slot's LED tone for the `runtimes` group: green ready · amber warming ·
+// grey offline. Mirrors useRuntimeRollup's readiness rule.
+const _slotPip = (s) => {
+  const st = String(s?.state ?? '').toLowerCase();
+  if (s?.container_status === 'running' || ['ready', 'serving', 'idle'].includes(st)) return 'ok';
+  if (['warming', 'starting', 'loading', 'connecting'].includes(st)) return 'warm';
+  return 'off';
+};
+// A service indicator's tone (up/warn/err) → LED tone (ok/warm/err).
+const _svcPip = (tone) => (tone === 'up' ? 'ok' : tone === 'warn' ? 'warm' : 'err');
+
 // ─── Footer ───
 // Phase 3 of #322: the journal pane reads `useLogsStream` against
 // /api/journal/stream (no more HAL0_DATA.journal fallback) and the
@@ -495,6 +523,9 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
       title: serviceById.openwebui?.detail || (serviceHealth.pending ? 'service health pending' : 'openwebui down'),
     },
   ];
+  // runtimes group — one LED pip per enabled slot, plus the ready count.
+  const enabledSlots = (useSlots().data || []).filter((s) => s.enabled !== false);
+  const servicesReady = footerIndicators.filter((s) => s.tone === 'up').length;
 
   return (
     <div className={"footer" + (expanded ? " expanded" : "")}>
@@ -536,9 +567,10 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
                 No journal entries match. <span style={{color: "var(--accent)", cursor: "pointer"}} onClick={() => { setPaneSrc("merged"); setPaneQ(""); }}>Clear filters</span>
               </div>
             ) : filtered.map((e, i) => (
-              <div key={e.id ?? i} className={"foot-line " + e.level}>
+              <div key={e.id ?? i} className={"foot-line " + e.level} style={{"--src": _srcHue(e.source)}}>
+                <span className="stripe" />
                 <span className="ts">{e.ts}</span>
-                <span className={"sl " + e.source}>[{e.source}]</span>
+                <span className={"src " + e.source}><span className="d" />{e.source}</span>
                 <span className="lvl">{e.level}</span>
                 <span className="msg">{paneQ ? highlightFoot(e.msg, paneQ) : e.msg}</span>
               </div>
@@ -547,29 +579,47 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
         </div>
       )}
       <div className="foot-chips">
-        <div className={"foot-chip " + runtimeTone} title={runtimeTitle}>
-          <span className="dot" />
-          <span className="k">runtime:</span>
-          <span className="v">{L.status === 'up' ? `${L.ready}/${L.total} ready` : L.status}</span>
-          <span className="foot-service-dots" aria-label="service health">
+        {/* runtimes — one LED pip per enabled slot + ready count */}
+        <div className="foot-health" data-testid="foot-health-runtimes" title={runtimeTitle}>
+          <span className="pips" aria-hidden="true">
+            {enabledSlots.map((s, i) => (
+              <span key={s.name ?? i} className={"pip " + _slotPip(s)} />
+            ))}
+          </span>
+          <span className="lbl">
+            <span className="k">runtimes</span>
+            <span className={"v" + (L.ready < L.total ? " warn" : "")}>
+              <b>{L.ready} / {L.total}</b> ready
+            </span>
+          </span>
+        </div>
+
+        {/* services — one LED pip per backing service + ready count */}
+        <div className="foot-health" data-testid="foot-health-services" title="service health">
+          <span className="pips" aria-label="service health">
             {footerIndicators.map((svc) => (
               <span
                 key={svc.id}
-                className={"foot-service-dot " + svc.tone}
+                className={"pip " + _svcPip(svc.tone)}
                 title={`${svc.label}: ${svc.title}`}
                 aria-label={`${svc.label}: ${svc.tone}`}
-              >
-                <span className="dot" />
-                <span>{svc.label}</span>
-              </span>
+              />
             ))}
           </span>
+          <span className="lbl">
+            <span className="k">services</span>
+            <span className={"v" + (servicesReady < footerIndicators.length ? " warn" : "")}>
+              <b>{servicesReady} / {footerIndicators.length}</b> ready
+            </span>
+          </span>
         </div>
+
+        <span className="foot-spacer" />
+
         {showUpdateChip && (
-          <div className="foot-chip accent">
-            <span className="k">●</span>
-            <span className="v">{`hal0 ${hal0Channel.available} available`}</span>
-          </div>
+          <span className="foot-update" title={`hal0 ${hal0Channel.available} available`}>
+            <span className="bullet">●</span> <b>hal0 {hal0Channel.available}</b> available
+          </span>
         )}
         <button className="foot-toggle" onClick={onToggle} aria-expanded={expanded} aria-label="Toggle journal pane">
           <span style={{transform: expanded ? "rotate(180deg)" : "rotate(0)", transition: "transform 0.18s ease", display: "inline-block"}}>⌃</span>

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -529,56 +529,59 @@ a { color: inherit; text-decoration: none; }
   font-size: 11px;
   line-height: 1.55;
 }
+/* Live-journal rows: single-line tabular grid, device-hued source dot,
+   right-aligned level, level-tinted row + left stripe for warn/error. */
 .foot-line {
-  padding: 1px 16px;
   display: grid;
-  grid-template-columns: 96px 76px 50px 1fr;
-  gap: 10px;
-  border-left: 2px solid transparent;
+  grid-template-columns: 3px 104px 90px 46px minmax(0, 1fr);
+  align-items: baseline;
+  gap: 11px;
+  padding: 2px 16px 2px 0;
+  position: relative;
 }
-.foot-line:hover { background: rgba(255, 255, 255, 0.02); }
-.foot-line.warn  { border-left-color: var(--warn); }
-.foot-line.error { border-left-color: var(--err); }
-.foot-line .ts { color: var(--fg-5); }
-.foot-line .sl { color: var(--info); }
-.foot-line .sl:nth-child(2) { color: var(--accent); }
-.foot-line .lvl { color: var(--fg-3); }
+.foot-line:hover { background: var(--bg-2); }
+.foot-line .stripe { grid-column: 1; align-self: stretch; width: 3px; border-radius: 0 2px 2px 0; background: transparent; }
+.foot-line.warn  { background: rgba(232, 185, 78, 0.045); }
+.foot-line.warn  .stripe { background: var(--warn); }
+.foot-line.error { background: rgba(239, 107, 107, 0.05); }
+.foot-line.error .stripe { background: var(--err); }
+.foot-line .ts { color: var(--fg-5); white-space: nowrap; font-size: 11px; }
+.foot-line .src { display: inline-flex; align-items: center; gap: 6px; color: var(--src, var(--fg-3)); font-weight: 500; white-space: nowrap; overflow: hidden; }
+.foot-line .src .d { width: 6px; height: 6px; border-radius: 50%; background: currentColor; flex-shrink: 0; box-shadow: 0 0 6px currentColor; opacity: 0.9; }
+.foot-line .lvl { font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; text-align: right; color: var(--fg-4); }
 .foot-line.ok    .lvl { color: var(--ok); }
+.foot-line.info  .lvl { color: var(--info); }
 .foot-line.warn  .lvl { color: var(--warn); }
 .foot-line.error .lvl { color: var(--err); }
-.foot-line.info  .lvl { color: var(--fg-3); }
 .foot-line .msg { color: var(--fg-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.foot-line .sl[class*="hal0"] { color: var(--accent); }
 
+/* Ribbon: two glanceable LED-pip health groups (runtimes · services) +
+   a ready count each, replacing the crammed single runtime chip. */
 .foot-chips {
   display: flex;
   align-items: center;
   gap: 0;
-  padding: 0 14px;
+  height: 46px;
+  padding: 0 6px 0 8px;
   border-bottom: 1px solid var(--line-soft);
-  overflow-x: auto;
   white-space: nowrap;
 }
-.foot-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 0 14px;
-  height: 26px;
-  border-right: 1px solid var(--line-soft);
-  color: var(--fg-3);
-  font-size: 11px;
-}
-.foot-chip:first-child { padding-left: 0; }
-.foot-chip:last-child { border-right: none; }
-.foot-chip .k { color: var(--fg-4); }
-.foot-chip .v { color: var(--fg); }
-.foot-chip .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; box-shadow: 0 0 6px currentColor; }
-.foot-chip.up { color: var(--ok); }
-.foot-chip.warn { color: var(--warn); }
-.foot-chip.err { color: var(--err); }
-.foot-chip.accent { color: var(--accent); }
-.foot-chip .v.dim { color: var(--fg-3); }
+.foot-health { display: inline-flex; align-items: center; gap: 9px; padding: 0 16px; height: 100%; position: relative; }
+.foot-health + .foot-health::before { content: ""; position: absolute; left: 0; top: 13px; bottom: 13px; width: 1px; background: var(--line-soft); }
+.foot-health .pips { display: inline-flex; gap: 3px; }
+.foot-health .pip { width: 7px; height: 7px; border-radius: 50%; background: var(--bg-4); border: 1px solid var(--line-strong); }
+.foot-health .pip.ok { background: var(--ok); border-color: transparent; box-shadow: 0 0 6px var(--ok); }
+.foot-health .pip.warm { background: var(--warn); border-color: transparent; box-shadow: 0 0 6px var(--warn); animation: pulse 1.5s var(--ease) infinite; }
+.foot-health .pip.err { background: var(--err); border-color: transparent; box-shadow: 0 0 6px var(--err); }
+.foot-health .pip.off { background: var(--bg-4); border-color: var(--line-strong); }
+.foot-health .lbl { display: inline-flex; flex-direction: column; gap: 1px; line-height: 1.15; }
+.foot-health .lbl .k { font-size: 9px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-5); }
+.foot-health .lbl .v { font-size: 11.5px; color: var(--fg-2); }
+.foot-health .lbl .v b { color: var(--ok); font-weight: 600; }
+.foot-health .lbl .v.warn b { color: var(--warn); }
+.foot-update { display: inline-flex; align-items: center; gap: 8px; padding: 0 14px; font-size: 11px; color: var(--fg-3); font-family: var(--jbm); }
+.foot-update .bullet { color: var(--accent); font-size: 9px; }
+.foot-update b { color: var(--fg-2); font-weight: 500; }
 .foot-spacer { flex: 1; }
 .foot-toggle {
   margin-left: auto;

--- a/ui/tests/e2e/specs/footer-chips-v3.spec.ts
+++ b/ui/tests/e2e/specs/footer-chips-v3.spec.ts
@@ -21,14 +21,13 @@ test.describe('Footer runtime chip reflects container readiness (#221)', () => {
     const footer = page.locator('.footer')
     await expect(footer).toBeVisible()
 
-    const runtimeChip = footer.locator('.foot-chip', {
-      has: page.locator('.k', { hasText: /^runtime:$/ }),
-    })
-    await expect(runtimeChip).toBeVisible()
+    const runtimes = footer.locator('[data-testid="foot-health-runtimes"]')
+    await expect(runtimes).toBeVisible()
     // HAL0_DATA seeds 8 enabled slots (legacy is disabled); all are ready
-    // → "8/8 ready", chip dot lit "up".
-    await expect(runtimeChip.locator('.v')).toHaveText('8/8 ready')
-    await expect(runtimeChip).toHaveClass(/\bup\b/)
+    // → "8 / 8 ready", all LED pips lit green.
+    await expect(runtimes.locator('.lbl .v')).toContainText('8 / 8 ready')
+    await expect(runtimes.locator('.pip.ok')).toHaveCount(8)
+    await expect(runtimes.locator('.pip.off')).toHaveCount(0)
   })
 
   test('runtime chip counts drop when containers stop', async ({ page }) => {
@@ -53,10 +52,9 @@ test.describe('Footer runtime chip reflects container readiness (#221)', () => {
     const footer = page.locator('.footer')
     await expect(footer).toBeVisible()
 
-    const runtimeChip = footer.locator('.foot-chip', {
-      has: page.locator('.k', { hasText: /^runtime:$/ }),
-    })
-    await expect(runtimeChip).toBeVisible()
-    await expect(runtimeChip.locator('.v')).toHaveText('0/8 ready')
+    const runtimes = footer.locator('[data-testid="foot-health-runtimes"]')
+    await expect(runtimes).toBeVisible()
+    await expect(runtimes.locator('.lbl .v')).toContainText('0 / 8 ready')
+    await expect(runtimes.locator('.pip.off')).toHaveCount(8)
   })
 })

--- a/ui/tests/e2e/specs/footer-update-chip-v3.spec.ts
+++ b/ui/tests/e2e/specs/footer-update-chip-v3.spec.ts
@@ -32,7 +32,7 @@ async function withUpdateState(
 }
 
 const UPDATE_CHIP = (page: import('@playwright/test').Page) =>
-  page.locator('.footer .foot-chip.accent', { hasText: /hal0 .* available/ })
+  page.locator('.footer .foot-update', { hasText: /hal0 .* available/ })
 
 test.describe('Footer update chip (#325)', () => {
   test('chip hidden when useUpdateState returns no available release', async ({ page }) => {
@@ -46,7 +46,7 @@ test.describe('Footer update chip (#325)', () => {
     // Wait for the rollup poll to land — the runtime-chip text proves
     // useRuntimeRollup has settled, which means useUpdateState has had
     // time to run too.
-    await expect(page.locator('.footer .foot-chip', { hasText: 'runtime' })).toBeVisible({
+    await expect(page.locator('.footer [data-testid="foot-health-runtimes"]')).toBeVisible({
       timeout: 6_000,
     })
     await expect(UPDATE_CHIP(page)).toHaveCount(0)
@@ -60,7 +60,7 @@ test.describe('Footer update chip (#325)', () => {
     })
     await page.goto('/')
     await expect(page.locator('.footer')).toBeVisible()
-    await expect(page.locator('.footer .foot-chip', { hasText: 'runtime' })).toBeVisible({
+    await expect(page.locator('.footer [data-testid="foot-health-runtimes"]')).toBeVisible({
       timeout: 6_000,
     })
     await expect(UPDATE_CHIP(page)).toHaveCount(0)

--- a/ui/tests/e2e/specs/sidebar-runtime-widget.spec.ts
+++ b/ui/tests/e2e/specs/sidebar-runtime-widget.spec.ts
@@ -142,12 +142,16 @@ test.describe('Sidebar Runtime widget — populated', () => {
     await expect(row.locator('.v b')).toHaveText('2')
   })
 
-  test('footer runtime chip shows readiness and service health dots', async ({ page }) => {
+  test('footer ribbon shows runtimes + services health groups', async ({ page }) => {
     await page.goto('/')
-    const chip = page.locator('.foot-chip').filter({ hasText: 'runtime:' })
     // HAL0_DATA seeds 8 enabled slots (legacy is disabled); all are ready.
-    await expect(chip.locator('.v')).toContainText('8/8 ready', { timeout: FIVE_S })
-    await expect(chip.locator('.foot-service-dot.up')).toContainText(['hal0', 'hermes', 'openwebui'])
+    const runtimes = page.locator('[data-testid="foot-health-runtimes"]')
+    await expect(runtimes.locator('.lbl .v')).toContainText('8 / 8 ready', { timeout: FIVE_S })
+    await expect(runtimes.locator('.pip.ok')).toHaveCount(8)
+    // services group — one LED pip per backing service, all up here.
+    const services = page.locator('[data-testid="foot-health-services"]')
+    await expect(services.locator('.lbl .v')).toContainText('3 / 3 ready')
+    await expect(services.locator('.pip.ok')).toHaveCount(3)
   })
 })
 
@@ -174,8 +178,9 @@ test.describe('Sidebar Runtime widget — no advertised service links', () => {
     await expect(row.locator('.v')).toContainText('chat', { timeout: FIVE_S })
     await expect(row.locator('a.rt-link')).toHaveCount(0)
     await expect(row.locator('.k')).toHaveText('openwebui')
-    const chip = page.locator('.foot-chip').filter({ hasText: 'runtime:' })
-    await expect(chip.locator('.foot-service-dot.up')).toContainText(['openwebui'])
+    // footer services pip still reads the openwebui health as up.
+    const services = page.locator('[data-testid="foot-health-services"]')
+    await expect(services.locator('.pip[aria-label="openwebui: up"]')).toHaveCount(1)
   })
 })
 
@@ -190,9 +195,8 @@ test.describe('Sidebar Runtime widget — hermes tone mapping', () => {
     await page.route('**/api/config/urls', (route) => json(route, URLS_ALL))
     await page.route('**/api/services/health', (route) => json(route, SERVICES_HEALTH_DOWN))
     await page.goto('/')
-    const v = page.locator('.foot-chip').filter({ hasText: 'runtime:' }).locator('.foot-service-dot').filter({ hasText: 'hermes' })
-    await expect(v).toHaveClass(/err/, { timeout: FIVE_S })
-    await expect(v).toContainText('hermes')
+    const pip = page.locator('[data-testid="foot-health-services"] .pip[aria-label^="hermes:"]')
+    await expect(pip).toHaveClass(/\berr\b/, { timeout: FIVE_S })
   })
 
   test('no agent installed renders sidebar copy without a health dot', async ({ page }) => {


### PR DESCRIPTION
Implements the **live-journal** design handoff (`explorations/live-journal/index.html` from claude.ai/design).

## Why
The footer crammed slot-readiness and service-health into one chip — `runtime: 3/5 ready  hal0hermesopenwebui` — which made "what is 3/5 counting?" genuinely ambiguous (it's *slots*, not services).

## What
The ribbon is now **two glanceable LED-pip health groups**, exactly as the design specifies:

- **runtimes** — one pip per enabled slot (green ready · amber warming · grey offline) + an `N / M ready` count. The 3/5 is now explicitly labelled slot readiness.
- **services** — one pip per backing service (hal0 / hermes / openwebui), tone from `/api/services/health`, with its own ready count. Service identity lives in each pip's `title`/`aria-label`.

Update pill + journal toggle keep their behaviour (restyled to `.foot-update`).

**Journal rows** get the design's "quick cleanup": single-line tabular grid, device-hued source dot + name, right-aligned level tag, level-tinted row + left stripe for warn/error.

All design tokens already existed in `dashboard.css` (comfyui/npu language) — no new tokens.

## Tests
Footer assertions in `sidebar-runtime-widget`, `footer-chips-v3`, `footer-update-chip-v3` retargeted to the new `.foot-health` pip structure; `footer-journal-pane-v3` unchanged and still green.
- `tsc --noEmit` clean · `vite build` clean · **21 e2e passed** (chromium).

## Note / open follow-up
This is the **footer** half of the earlier "remove sidebar widget, monitors in the bottom bar" ask. The sidebar `SidebarRuntimeWidget` (which still holds the `hermes ↗` / `openwebui ↗` launch links) is intentionally **not** removed in this PR — that + where the launch links should live is the one open decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)