### PR TITLE
fix(dash): dedup journal SSE ring — stop lines duplicating on pane re-open

### DIFF
--- a/ui/src/api/hooks/__tests__/logRing.test.mjs
+++ b/ui/src/api/hooks/__tests__/logRing.test.mjs
@@ -1,0 +1,66 @@
+// Dependency-free test for the journal SSE ring-append dedup.
+//
+// Run: node ui/src/api/hooks/__tests__/logRing.test.mjs
+//
+// Bug of record: opening the footer journal pane flips `follow` on, which
+// reconnects the SSE; the server replays the recent tail, and push() used
+// to blind-append every replayed entry — so each open re-rendered a second
+// copy of every message (the "hal0 0.5.0a1 starting" line duplicating on
+// every open). appendEntry must dedup by content signature so a replay is
+// idempotent, regardless of whether the server reassigns numeric ids.
+
+import { appendEntry, entryKey } from "../logRing.js";
+
+let failures = 0;
+const ok = (cond, msg) => { if (!cond) { failures += 1; console.error("  ✗ " + msg); } else { console.log("  ✓ " + msg); } };
+
+const E = (id, ts, source, msg, level = "info") => ({ id, ts, source, msg, level });
+const MAX = 5;
+
+// 1. a fresh entry appends.
+{
+  const out = appendEntry([], E(1, "t1", "hal0", "starting"), MAX);
+  ok(out.length === 1 && out[0].msg === "starting", "appends a new entry");
+}
+
+// 2. THE BUG: re-opening the pane replays the tail — the same line must not
+//    double up, even if the server hands it a different numeric id.
+{
+  const ring = [E(1, "2026-06-16T21:12:56.942581+00:00", "hal0", "hal0 0.5.0a1 starting")];
+  const replaySameId = appendEntry(ring, E(1, "2026-06-16T21:12:56.942581+00:00", "hal0", "hal0 0.5.0a1 starting"), MAX);
+  ok(replaySameId.length === 1, "replay with same id is not duplicated");
+  const replayNewId = appendEntry(ring, E(99, "2026-06-16T21:12:56.942581+00:00", "hal0", "hal0 0.5.0a1 starting"), MAX);
+  ok(replayNewId.length === 1, "replay with a reassigned id is still not duplicated (content key)");
+}
+
+// 3. genuinely distinct lines (same msg, different ts) are both kept.
+{
+  let ring = [];
+  ring = appendEntry(ring, E(1, "t1", "hal0", "tick"), MAX);
+  ring = appendEntry(ring, E(2, "t2", "hal0", "tick"), MAX);
+  ok(ring.length === 2, "same message at different timestamps is kept");
+}
+
+// 4. ring evicts oldest at max, keeping newest.
+{
+  let ring = [];
+  for (let i = 1; i <= MAX + 2; i++) ring = appendEntry(ring, E(i, "t" + i, "hal0", "m" + i), MAX);
+  ok(ring.length === MAX, "ring is capped at max");
+  ok(ring[ring.length - 1].msg === "m" + (MAX + 2), "newest entry retained after eviction");
+  ok(ring[0].msg === "m3", "oldest entries evicted");
+}
+
+// 5. malformed entries (missing ts/msg) are ignored, not appended.
+{
+  const ring = [E(1, "t1", "hal0", "ok")];
+  ok(appendEntry(ring, { id: 2, source: "hal0" }, MAX).length === 1, "entry without ts/msg is ignored");
+  ok(appendEntry(ring, null, MAX).length === 1, "null entry is ignored");
+}
+
+// 6. entryKey ignores id so replays collapse.
+{
+  ok(entryKey(E(1, "t", "s", "m")) === entryKey(E(2, "t", "s", "m")), "entryKey is id-independent");
+}
+
+if (failures) { console.error(`\n${failures} assertion(s) failed`); process.exit(1); }
+console.log("\nall logRing assertions passed");

--- a/ui/src/api/hooks/logRing.js
+++ b/ui/src/api/hooks/logRing.js
@@ -1,0 +1,28 @@
+// Pure ring-append for the journal SSE tail. Extracted from useLogs so the
+// dedup invariant is unit-testable without a DOM/EventSource.
+//
+// Why dedup: opening the footer journal pane flips `follow` on, which
+// reconnects the SSE; the server replays the recent tail. A blind append
+// then renders a SECOND copy of every replayed line on every open (the
+// "hal0 0.5.0a1 starting" line piling up). We key on the entry's CONTENT
+// signature — microsecond timestamp + source + message — not the numeric
+// id, so a replay is idempotent even if the server reassigns ids per stream.
+
+/** Stable, id-independent signature for a journal line. */
+export function entryKey(e) {
+  return `${e.ts}|${e.source ?? ''}|${e.msg}`;
+}
+
+/**
+ * Append `entry` to the bounded ring `prev` (newest last), skipping a line
+ * already present (SSE replay) and evicting the oldest past `max`. Pure:
+ * returns `prev` unchanged when the entry is malformed or a duplicate.
+ */
+export function appendEntry(prev, entry, max) {
+  if (entry == null || entry.ts == null || entry.msg == null) return prev;
+  const key = entryKey(entry);
+  if (prev.some((e) => entryKey(e) === key)) return prev;
+  const next = prev.length >= max ? prev.slice(prev.length - max + 1) : prev.slice();
+  next.push(entry);
+  return next;
+}

--- a/ui/src/api/hooks/useLogs.ts
+++ b/ui/src/api/hooks/useLogs.ts
@@ -19,6 +19,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { apiGet } from '../client'
 import { ENDPOINTS } from '../endpoints'
+import { appendEntry } from './logRing.js'
 
 /** Unified journal entry — mirrors ``hal0.api.routes.journal.JournalEntry``. */
 export interface JournalEntry {
@@ -133,12 +134,9 @@ export function useLogsStream(opts: UseLogsStreamOptions = {}) {
   const errorCountRef = useRef(0)
 
   const push = (entry: JournalEntry) => {
-    setRing((prev) => {
-      const next =
-        prev.length >= RING_MAX ? prev.slice(prev.length - RING_MAX + 1) : prev.slice()
-      next.push(entry)
-      return next
-    })
+    // appendEntry dedups by content signature so re-opening the pane (which
+    // reconnects the SSE and replays the tail) never double-renders a line.
+    setRing((prev) => appendEntry(prev, entry, RING_MAX))
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Bug
Every time you open the footer journal pane, every message re-renders a second copy (the `hal0 0.5.0a1 starting` line piling up on each open).

## Cause
Opening the pane flips `follow` on → reconnects the SSE → the server **replays the recent tail**. `useLogs.push()` blind-appended every replayed entry with no dedup, so each open duplicated the whole tail (visible in both the expanded pane and the always-on `.foot-journal` ribbon, which read the same ring).

## Fix
Extract the ring append into a pure `appendEntry(prev, entry, max)` that dedups by **content signature** (`ts | source | msg`) — id-independent, so replays are idempotent even if the server reassigns numeric ids — then evicts oldest past `RING_MAX`. `useLogs` calls it.

## Tests
Dependency-free `logRing.test.mjs` (10 assertions): replay-same-id, replay-reassigned-id, distinct-line-same-msg, eviction, malformed/null ignored. tsc + vite build clean; `footer-journal-pane-v3` e2e green (6 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)