### PR TITLE
fix(slots): warn on container config drift

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -50,6 +50,7 @@ hal0 podman images (prompts for a `DELETE` confirmation unless `--force` or
 | Command | Purpose | Key options |
 |---|---|---|
 | `slot list` | List configured slots and live state. | `--json` |
+| `slot status <name>` | Show a slot status summary, including config-drift warnings. | `--json` |
 | `slot show <name>` | Full slot config + status. | `--json` |
 | `slot load <name>` | Load a slot (optionally assign a model first). | `--model`/`-m` |
 | `slot unload <name>` | Unload a running slot gracefully. | — |

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -798,7 +798,7 @@ async def get_slot(name: str, request: Request) -> dict[str, object]:
     """
     sm = _get_slot_manager(request)
     try:
-        snap = await sm.status(name)
+        snap = await sm.status(name, include_config_drift=True)
         out = _slot_to_dict(snap, request)
         enrichment = await _config_field_enrichment(request)
         extra = enrichment.get(name)

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -172,6 +172,56 @@ def slot_list(
     console.print(table)
 
 
+def _drift_warning(status: dict[str, Any]) -> str | None:
+    drift = status.get("config_drift") or {}
+    if not isinstance(drift, dict) or drift.get("drifted") is not True:
+        return None
+    diffs = drift.get("diffs") or []
+    parts: list[str] = []
+    if isinstance(diffs, list):
+        for diff in diffs:
+            if not isinstance(diff, dict):
+                continue
+            parts.append(
+                f"{diff.get('key')}: running={diff.get('running')} rendered={diff.get('rendered')}"
+            )
+    detail = "; ".join(parts) if parts else "running argv differs from rendered config"
+    return f"WARN config drift: {detail}"
+
+
+@app.command("status")
+def slot_status(
+    name: str = typer.Argument(..., help="Slot name to inspect"),
+    json_out: bool = typer.Option(False, "--json", help="Emit raw /api/slots/{name} JSON."),
+) -> None:
+    """Show a slot status summary, including config-drift warnings."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        status = api_get(f"/api/slots/{name}")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    if json_out:
+        typer.echo(jsonlib.dumps(status, indent=2))
+        return
+
+    table = Table(title=f"hal0 slot: {name}")
+    table.add_column("State")
+    table.add_column("Model")
+    table.add_column("Port", justify="right")
+    table.add_row(
+        _fmt_state(status.get("status") or status.get("state")),
+        (status.get("model") or status.get("model_id") or "—") or "—",
+        str(status.get("port") or "—"),
+    )
+    console.print(table)
+    warning = _drift_warning(status)
+    if warning:
+        console.print(f"[bold yellow]{warning}[/bold yellow]")
+
+
 @app.command("load")
 def slot_load(
     name: str = typer.Argument(..., help="Slot name (e.g. primary)"),

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import logging
 import shlex
 import shutil
@@ -741,6 +742,23 @@ class ContainerProvider(Provider):
         )
         self._write_and_start_unit(slot_name, unit_text)
 
+    def expected_argv(
+        self, slot_cfg: dict[str, Any], model_info: dict[str, Any]
+    ) -> list[str] | None:
+        """Return the freshly-rendered runtime command for drift checks.
+
+        This is the command portion passed to the container image, not the
+        podman/systemd preamble. It goes through the same provider plan path as
+        ``load_sync`` so derived context size, profile flags, model alias, and
+        slot ``[server].extra_args`` match what a restart would render now.
+        """
+        try:
+            provider = _spec_provider_for(slot_cfg) or self
+            plan = provider.container_spec(slot_cfg, model_info)
+        except Exception:
+            return None
+        return list(plan.command)
+
     def unload_sync(self, slot_cfg: dict[str, Any]) -> None:
         """Stop and clean up the container unit (synchronous)."""
         slot_name: str = str(slot_cfg.get("name", ""))
@@ -807,6 +825,39 @@ class ContainerProvider(Provider):
             return None
         ref = result.stdout.strip()
         return ref or None
+
+    def running_argv(self, slot_name: str) -> list[str] | None:
+        """Return the live container command argv for *slot_name*.
+
+        Uses ``<runtime> inspect hal0-slot-<name> --format {{json .Config.Cmd}}``.
+        Returns None when the container is not running, inspect fails, or the
+        runtime returns an unexpected shape. Never raises; status callers treat
+        missing data as "unknown", not drift.
+        """
+        try:
+            runtime = _container_runtime()
+        except RuntimeError:
+            return None
+        container_name = f"hal0-slot-{slot_name}"
+        try:
+            result = subprocess.run(
+                [runtime, "inspect", container_name, "--format", "{{json .Config.Cmd}}"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if result.returncode != 0:
+            return None
+        try:
+            payload = json.loads(result.stdout.strip())
+        except ValueError:
+            return None
+        if not isinstance(payload, list):
+            return None
+        return [str(part) for part in payload]
 
     async def pull_image_stream(self, image: str):
         """Async generator that runs ``<runtime> pull <image>`` and yields

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -148,6 +148,8 @@ def serialize_slot(slot: Any, model_cache: dict[str, Any] | None = None) -> dict
         base["backend"] = meta.get("backend")
     if not base.get("provider") and meta.get("provider"):
         base["provider"] = meta.get("provider")
+    if "config_drift" in meta:
+        base["config_drift"] = meta.get("config_drift")
     if model_cache is not None:
         loaded = list(model_cache.get(slot.name, []))
         if slot.model_id and slot.model_id in loaded:

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -111,6 +111,7 @@ _FAIL_WATCH_LIVE_STATES: frozenset[SlotState] = frozenset(
 # /health) is demoted to ERROR — but only after this many CONSECUTIVE failures,
 # so a single transient blip doesn't trigger a disruptive model reload.
 _HEALTH_FAIL_STRIKES: int = 2
+_CONFIG_DRIFT_KEYS: tuple[str, ...] = ("--ctx-size", "--model", "--alias", "-b", "-ub")
 
 # Idle-monitor defaults. A READY slot whose last activity is older than
 # _IDLE_AFTER_S gets demoted to IDLE so dashboards / unload heuristics
@@ -1102,7 +1103,7 @@ class SlotManager:
 
     # ── queries ──────────────────────────────────────────────────────────────
 
-    async def status(self, slot_name: str) -> Slot:
+    async def status(self, slot_name: str, *, include_config_drift: bool = False) -> Slot:
         """Return a snapshot of the current slot state.
 
         Combines the persisted state.json with a live "is the container
@@ -1198,6 +1199,10 @@ class SlotManager:
         }
         if backend:
             meta["backend"] = backend
+        if include_config_drift:
+            config_drift = await self.compute_config_drift(slot_name, cfg=cfg, active=active)
+            if config_drift is not None:
+                meta["config_drift"] = config_drift
         return Slot(
             name=slot_name,
             state=observed,
@@ -1207,6 +1212,49 @@ class SlotManager:
             metadata=meta,
             last_used_at=self._last_used.get(slot_name),
         )
+
+    async def compute_config_drift(
+        self,
+        slot_name: str,
+        *,
+        cfg: dict[str, Any] | None = None,
+        active: bool | None = None,
+    ) -> dict[str, Any] | None:
+        """Compare live container argv to the command a restart would render.
+
+        Returns a structured payload when the comparison is meaningful, or
+        None when the slot is inactive, lacks a config, is an NPU trio shadow,
+        or the provider cannot read either side of the comparison.
+        """
+        if active is None:
+            active = await self._is_active(slot_name)
+        if not active:
+            return None
+        if cfg is None:
+            cfg = await self._maybe_load_config(slot_name)
+        if not cfg or is_npu_trio_shadow(cfg):
+            return None
+
+        model_info = await self._resolve_model_info(_model_default(cfg))
+        from hal0.providers.container import container_provider
+
+        provider = container_provider()
+        loop = asyncio.get_event_loop()
+        running, rendered = await asyncio.gather(
+            loop.run_in_executor(None, provider.running_argv, slot_name),
+            loop.run_in_executor(None, provider.expected_argv, cfg, model_info),
+        )
+        if not running or not rendered:
+            return None
+
+        running_flags = _argv_values(running, _CONFIG_DRIFT_KEYS)
+        rendered_flags = _argv_values(rendered, _CONFIG_DRIFT_KEYS)
+        diffs = [
+            {"key": key, "running": running_flags.get(key), "rendered": rendered_flags.get(key)}
+            for key in _CONFIG_DRIFT_KEYS
+            if running_flags.get(key) != rendered_flags.get(key)
+        ]
+        return {"drifted": bool(diffs), "diffs": diffs}
 
     async def _maybe_load_config(self, slot_name: str) -> dict[str, Any] | None:
         """Read the slot's TOML if it exists, swallowing parse errors.
@@ -2493,6 +2541,30 @@ def _model_default(cfg: SlotConfig | dict[str, Any]) -> str:
     if isinstance(model, dict):
         return str(model.get("default") or "")
     return ""
+
+
+def _argv_values(argv: list[str], keys: tuple[str, ...]) -> dict[str, str | None]:
+    """Return the last value for each flag key in argv.
+
+    Last value wins because slot ``[server].extra_args`` intentionally follows
+    profile flags and can override them.
+    """
+    wanted = set(keys)
+    out: dict[str, str | None] = {}
+    i = 0
+    while i < len(argv):
+        token = argv[i]
+        if token in wanted:
+            out[token] = argv[i + 1] if i + 1 < len(argv) else None
+            i += 2
+            continue
+        for key in keys:
+            prefix = f"{key}="
+            if token.startswith(prefix):
+                out[key] = token[len(prefix) :]
+                break
+        i += 1
+    return out
 
 
 def _normalize_ctx_key(cfg_dict: dict[str, Any]) -> None:

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -68,6 +68,10 @@ def container_stub() -> Iterator[dict[str, Any]]:
     provider.is_active = MagicMock(side_effect=lambda name: name in state["active"])
     provider.health = AsyncMock(side_effect=lambda port: {"ok": True, "status": "healthy"})
     provider.running_image = MagicMock(return_value=None)
+    provider.running_argv = MagicMock(side_effect=lambda name: state.get("running_argv"))
+    provider.expected_argv = MagicMock(
+        side_effect=lambda cfg, model_info: state.get("expected_argv")
+    )
     provider.image_present = MagicMock(return_value=True)
 
     with patch("hal0.providers.container.container_provider", return_value=provider):
@@ -1367,6 +1371,27 @@ def test_get_slot_includes_config_enrichment(
     assert body["coresident_group"] == "npu-flm-trio"
     assert body["type"] == "llm"
     assert body["model_default"] == "gemma3-1b"
+
+
+def test_get_slot_includes_config_drift_when_requested(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """#863: single-slot status includes argv drift without burdening list()."""
+    isolated_client.post("/api/slots/chat/load")
+    container_stub["running_argv"] = ["--ctx-size", "4096", "-b", "512"]
+    container_stub["expected_argv"] = ["--ctx-size", "131072", "-b", "2048"]
+
+    r = isolated_client.get("/api/slots/chat")
+
+    assert r.status_code == 200, r.text
+    drift = r.json()["config_drift"]
+    assert drift["drifted"] is True
+    assert drift["diffs"] == [
+        {"key": "--ctx-size", "running": "4096", "rendered": "131072"},
+        {"key": "-b", "running": "512", "rendered": "2048"},
+    ]
 
 
 # ── Backwards compatibility ────────────────────────────────────────────────

--- a/tests/cli/test_slot_status.py
+++ b/tests/cli/test_slot_status.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import slot_commands
+
+runner = CliRunner()
+
+
+def test_slot_status_warns_on_config_drift(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(slot_commands, "_api_unreachable", lambda _url: False)
+
+    def fake_get(path: str, **_kw: Any) -> dict[str, Any]:
+        assert path == "/api/slots/chat"
+        return {
+            "name": "chat",
+            "status": "ready",
+            "model_id": "qwen3-4b-q4_k_m",
+            "port": 8081,
+            "config_drift": {
+                "drifted": True,
+                "diffs": [
+                    {"key": "--ctx-size", "running": "4096", "rendered": "131072"},
+                    {"key": "-b", "running": "512", "rendered": "2048"},
+                ],
+            },
+        }
+
+    monkeypatch.setattr(slot_commands, "api_get", fake_get)
+
+    result = runner.invoke(slot_commands.app, ["status", "chat"])
+
+    assert result.exit_code == 0, result.output
+    assert "WARN" in result.output
+    assert "--ctx-size" in result.output
+    assert "4096" in result.output
+    assert "131072" in result.output
+    assert "-b" in result.output

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -509,6 +509,21 @@ class TestContainerSpec:
         spec = self._build_spec()
         assert spec.network_mode == ""
 
+    def test_expected_argv_uses_launch_plan_context_derive(self) -> None:
+        """#863: drift's rendered side must match the real load-path derive."""
+        provider = self._provider()
+        with patch(
+            "hal0.providers.container._resolve_profile",
+            return_value=_moe_profile(),
+        ):
+            argv = provider.expected_argv(
+                _slot_cfg(),
+                _model_info(metadata={"context_length": 131072}),
+            )
+
+        assert argv is not None
+        assert argv[argv.index("--ctx-size") + 1] == "32768"
+
 
 # ── load_sync / unload_sync systemd interaction ───────────────────────────────
 
@@ -662,6 +677,34 @@ class TestLoadSync:
         assert any("stop" in c for c in cmds), f"stop not in {cmds}"
         # Unit file must be deleted
         assert not unit_file.exists()
+
+    def test_running_argv_reads_podman_config_cmd(self) -> None:
+        provider = ContainerProvider()
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = '["--ctx-size","4096","-b","512"]\n'
+
+        with (
+            patch("hal0.providers.container._container_runtime", return_value="/usr/bin/podman"),
+            patch("hal0.providers.container.subprocess.run", return_value=result) as run,
+        ):
+            argv = provider.running_argv("chat")
+
+        assert argv == ["--ctx-size", "4096", "-b", "512"]
+        run.assert_called_once()
+        assert "hal0-slot-chat" in run.call_args.args[0]
+
+    def test_running_argv_returns_none_on_unexpected_inspect_payload(self) -> None:
+        provider = ContainerProvider()
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = '{"Cmd":["--ctx-size","4096"]}\n'
+
+        with (
+            patch("hal0.providers.container._container_runtime", return_value="/usr/bin/podman"),
+            patch("hal0.providers.container.subprocess.run", return_value=result),
+        ):
+            assert provider.running_argv("chat") is None
 
 
 class TestImageMismatch:

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -171,6 +171,14 @@ class TestSerializeSlot:
         assert out["backend"] == "vulkan"
         assert out["provider"] == "llama-server"
 
+    def test_config_drift_lifted_from_metadata(self) -> None:
+        drift = {
+            "drifted": True,
+            "diffs": [{"key": "--ctx-size", "running": "4096", "rendered": "131072"}],
+        }
+        out = serialize_slot(_slot(metadata={"config_drift": drift}), model_cache={})
+        assert out["config_drift"] == drift
+
     def test_explicit_backend_wins_over_metadata(self) -> None:
         out = serialize_slot(
             _slot(backend="rocm", metadata={"backend": "vulkan"}),

--- a/tests/slots/conftest.py
+++ b/tests/slots/conftest.py
@@ -49,6 +49,8 @@ class FakeContainerProvider:
         self.load_calls: list[tuple[dict[str, Any], dict[str, Any]]] = []
         self.unload_calls: list[dict[str, Any]] = []
         self.fail_load: Exception | None = None
+        self.running_argv_by_slot: dict[str, list[str] | None] = {}
+        self.expected_argv_by_slot: dict[str, list[str] | None] = {}
         # /health probe result. Default True: an active unit is also ready.
         # Set False to simulate a still-loading / wedged model server (unit
         # active but the inference server isn't answering /health yet).
@@ -81,6 +83,14 @@ class FakeContainerProvider:
 
     def running_image(self, slot_name: str) -> str | None:
         return None
+
+    def running_argv(self, slot_name: str) -> list[str] | None:
+        return self.running_argv_by_slot.get(slot_name)
+
+    def expected_argv(
+        self, slot_cfg: dict[str, Any], model_info: dict[str, Any]
+    ) -> list[str] | None:
+        return self.expected_argv_by_slot.get(str(slot_cfg.get("name")))
 
     def image_present(self, image: str) -> bool:
         return False

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -427,6 +427,122 @@ async def test_status_adopts_active_but_unhealthy_slot_as_warming(
     assert snap.metadata.get("health_ok") is False
 
 
+async def test_status_flags_running_container_config_drift(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """#863: a live unit whose argv no longer matches rendered config warns."""
+    (slot_root / "chat.toml").write_text(
+        "\n".join(
+            [
+                'name = "chat"',
+                "port = 8081",
+                'backend = "vulkan"',
+                'provider = "llama-server"',
+                'profile = "vulkan"',
+                "enabled = true",
+                "[model]",
+                'default = "qwen3-4b-q4_k_m"',
+                "context_size = 131072",
+                "[server]",
+                'extra_args = "-b 2048 -ub 2048"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    container_stub.expected_argv_by_slot["chat"] = [
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8081",
+        "--model",
+        "/mnt/ai-models/qwen.gguf",
+        "--alias",
+        "qwen3-4b-q4_k_m",
+        "--ctx-size",
+        "131072",
+        "-b",
+        "2048",
+        "-ub",
+        "2048",
+    ]
+    container_stub.running_argv_by_slot["chat"] = [
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8081",
+        "--model",
+        "/mnt/ai-models/qwen.gguf",
+        "--alias",
+        "qwen3-4b-q4_k_m",
+        "--ctx-size",
+        "4096",
+        "-b",
+        "512",
+        "-ub",
+        "512",
+    ]
+
+    sm = SlotManager()
+    await sm.load("chat")
+    snap = await sm.status("chat", include_config_drift=True)
+
+    drift = snap.metadata.get("config_drift")
+    assert drift == {
+        "drifted": True,
+        "diffs": [
+            {"key": "--ctx-size", "running": "4096", "rendered": "131072"},
+            {"key": "-b", "running": "512", "rendered": "2048"},
+            {"key": "-ub", "running": "512", "rendered": "2048"},
+        ],
+    }
+
+
+async def test_status_omits_config_drift_when_argv_matches(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    expected = [
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8081",
+        "--model",
+        "/mnt/ai-models/qwen.gguf",
+        "--alias",
+        "qwen3-4b-q4_k_m",
+        "--ctx-size",
+        "131072",
+        "-b",
+        "2048",
+    ]
+    container_stub.expected_argv_by_slot["chat"] = list(expected)
+    container_stub.running_argv_by_slot["chat"] = list(expected)
+
+    sm = SlotManager()
+    await sm.load("chat")
+    snap = await sm.status("chat", include_config_drift=True)
+
+    assert snap.metadata.get("config_drift") == {"drifted": False, "diffs": []}
+
+
+async def test_list_does_not_compute_config_drift_on_poll_path(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """#863: /api/slots polling must not podman-inspect argv for every slot."""
+    container_stub.expected_argv_by_slot["chat"] = ["--ctx-size", "131072"]
+    container_stub.running_argv_by_slot["chat"] = ["--ctx-size", "4096"]
+
+    sm = SlotManager()
+    await sm.load("chat")
+    snaps = await sm.list()
+
+    chat = next(s for s in snaps if s.name == "chat")
+    assert "config_drift" not in chat.metadata
+
+
 async def test_status_rehydrates_backend_from_toml(
     slot_root: Path,
     tmp_hal0_home: str,


### PR DESCRIPTION
Closes #863

## Summary
- compare live container argv with the freshly rendered provider command for single-slot status
- surface structured config_drift through /api/slots/{name} and add hal0 slot status warnings
- keep /api/slots list polling cheap by making drift detection opt-in

## Tests
- PYTHONPATH=src /home/halo/dev/hal0/.venv/bin/python -m pytest tests/slots/test_manager.py tests/providers/test_container.py tests/slot_view/test_aggregator.py tests/api/test_slots_routes.py::test_get_slot_includes_config_drift_when_requested tests/cli/test_slot_status.py tests/cli/test_cli_docs_parity.py tests/cli/test_json_output.py -q
- /home/halo/dev/hal0/.venv/bin/python -m ruff format --check src/hal0/api/routes/slots.py src/hal0/providers/container.py src/hal0/slots/manager.py src/hal0/slot_view/__init__.py src/hal0/cli/slot_commands.py tests/api/test_slots_routes.py tests/slots/conftest.py tests/slots/test_manager.py tests/providers/test_container.py tests/slot_view/test_aggregator.py tests/cli/test_slot_status.py
- /home/halo/dev/hal0/.venv/bin/python -m ruff check src/hal0/api/routes/slots.py src/hal0/providers/container.py src/hal0/slots/manager.py src/hal0/slot_view/__init__.py src/hal0/cli/slot_commands.py tests/api/test_slots_routes.py tests/slots/conftest.py tests/slots/test_manager.py tests/providers/test_container.py tests/slot_view/test_aggregator.py tests/cli/test_slot_status.py