### PR TITLE
fix(dash): journal rows show short wall-clock timestamp (no source overlap)

### DIFF
--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -429,6 +429,15 @@ const _SRC_HUE = {
 };
 const _srcHue = (s) => _SRC_HUE[s] || 'var(--fg-3)';
 
+// Journal rows show wall-clock time only (HH:MM:SS.mmm), like the design —
+// the full ISO `2026-06-16T21:12:56.942581+00:00` overflowed the ts column
+// and collided with the source dot. Pure string slice (no TZ conversion):
+// take the time component, truncate the fractional seconds to milliseconds.
+const _shortTs = (ts) => {
+  const m = String(ts ?? '').match(/(\d{2}:\d{2}:\d{2})(?:\.(\d{1,3}))?/);
+  return m ? (m[2] ? `${m[1]}.${m[2]}` : m[1]) : String(ts ?? '');
+};
+
 // A slot's LED tone for the `runtimes` group: green ready · amber warming ·
 // grey offline. Mirrors useRuntimeRollup's readiness rule.
 const _slotPip = (s) => {
@@ -569,7 +578,7 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
             ) : filtered.map((e, i) => (
               <div key={e.id ?? i} className={"foot-line " + e.level} style={{"--src": _srcHue(e.source)}}>
                 <span className="stripe" />
-                <span className="ts">{e.ts}</span>
+                <span className="ts">{_shortTs(e.ts)}</span>
                 <span className={"src " + e.source}><span className="d" />{e.source}</span>
                 <span className="lvl">{e.level}</span>
                 <span className="msg">{paneQ ? highlightFoot(e.msg, paneQ) : e.msg}</span>
@@ -635,7 +644,7 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
         <div className="foot-journal mono">
           {ringSorted.slice(-6).map((e, i, arr) => (
             <span key={e.id ?? i} className={"ent " + e.level}>
-              <span className="ts">{e.ts}</span>
+              <span className="ts">{_shortTs(e.ts)}</span>
               <span className="sl">[{e.source}]</span>
               <span className="ar">·</span>
               <span>{e.msg}</span>

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -533,7 +533,7 @@ a { color: inherit; text-decoration: none; }
    right-aligned level, level-tinted row + left stripe for warn/error. */
 .foot-line {
   display: grid;
-  grid-template-columns: 3px 104px 90px 46px minmax(0, 1fr);
+  grid-template-columns: 3px 92px 88px 44px minmax(0, 1fr);
   align-items: baseline;
   gap: 11px;
   padding: 2px 16px 2px 0;
@@ -545,7 +545,7 @@ a { color: inherit; text-decoration: none; }
 .foot-line.warn  .stripe { background: var(--warn); }
 .foot-line.error { background: rgba(239, 107, 107, 0.05); }
 .foot-line.error .stripe { background: var(--err); }
-.foot-line .ts { color: var(--fg-5); white-space: nowrap; font-size: 11px; }
+.foot-line .ts { color: var(--fg-5); white-space: nowrap; overflow: hidden; text-overflow: clip; font-size: 11px; }
 .foot-line .src { display: inline-flex; align-items: center; gap: 6px; color: var(--src, var(--fg-3)); font-weight: 500; white-space: nowrap; overflow: hidden; }
 .foot-line .src .d { width: 6px; height: 6px; border-radius: 50%; background: currentColor; flex-shrink: 0; box-shadow: 0 0 6px currentColor; opacity: 0.9; }
 .foot-line .lvl { font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; text-align: right; color: var(--fg-4); }


### PR DESCRIPTION
Follow-up to #867. The journal rows rendered the full ISO timestamp (`2026-06-16T21:12:56.942581+00:00`), which overflowed the `ts` grid column and collided with the source dot/name.

Renders the **time component only** (`HH:MM:SS.mmm`), matching the design, in both the expanded pane rows and the always-on journal tail. Tightens the `ts` column + clips overflow defensively. Pure string slice (no TZ conversion).

tsc + vite build clean; footer-journal-pane + sidebar-runtime-widget e2e green (15 passed). Already live on the CT105 preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)