### PR TITLE
Show ready inference slot rail

### DIFF
--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -753,6 +753,9 @@
 :is(.infer-pane, .npu-pane) .scard:hover {
   border-color: var(--line-strong);
 }
+:is(.infer-pane, .npu-pane) .scard.ready {
+  border-left: 2px solid var(--comfy);
+}
 :is(.infer-pane, .npu-pane) .scard.serving {
   border-left: 2px solid var(--comfy);
 }


### PR DESCRIPTION
## Summary
- add the missing yellow left rail for ready inference slot cards (`.scard.ready`)
- keeps serving/warming/error behavior unchanged

## Verification
- cd ui && npm run typecheck
- cd ui && npm run build
- git diff --check -- ui/src/dash/engine-panes.css
