### PR TITLE
Fix Hermes dashboard TUI startup

### DIFF
--- a/src/hal0/cli/agent_shim.py
+++ b/src/hal0/cli/agent_shim.py
@@ -231,7 +231,7 @@ def _resolve_web_dist(cfg: AgentConfig) -> Path | None:
 def _build_hermes_argv(cfg: AgentConfig) -> list[str]:
     """Build the argv that boots Hermes with ``/api/events`` + ``/api/pty``.
 
-    The chosen subcommand is ``hermes dashboard --tui`` per ``hermes_cli/
+    The chosen invocation is ``hermes --tui dashboard`` per ``hermes_cli/
     main.py:14050-14102`` and ``hermes_cli/main.py:10930-10939``:
 
     * ``cmd_dashboard`` is the ONLY subcommand that imports + calls
@@ -264,12 +264,12 @@ def _build_hermes_argv(cfg: AgentConfig) -> list[str]:
 
     argv = [
         str(cfg.hermes_bin),
+        "--tui",
         "dashboard",
         "--host",
         cfg.host,
         "--port",
         str(cfg.port),
-        "--tui",
         "--no-open",
     ]
     if _resolve_web_dist(cfg) is not None:


### PR DESCRIPTION
## Summary
- update hal0-agent shim to invoke Hermes as `hermes --tui dashboard ...`
- fixes CT 105 `hal0-agent@hermes.service` crash-loop on `unrecognized arguments: --tui`

## Verification
- PYTHONPATH=src .venv/bin/python -m pytest tests -q -k agent_shim
- .venv/bin/ruff check src/hal0/cli/agent_shim.py
- .venv/bin/ruff format --check src/hal0/cli/agent_shim.py
- manually verified installed Hermes accepts `hermes --tui dashboard --host 127.0.0.1 --port 9119 --no-open --skip-build` on CT 105
