### PR TITLE
fix(ui): align image gen and endpoints panels

### DIFF
--- a/ui/src/dash/comfyui-pane.css
+++ b/ui/src/dash/comfyui-pane.css
@@ -34,32 +34,51 @@
   overflow: hidden;
 }
 .comfy-page .wcard.active {
-  border-color: var(--comfy-line);
-  box-shadow: 0 0 0 1px var(--comfy-line), 0 0 44px -22px var(--comfy-glow);
+  border-color: var(--line);
+  box-shadow: none;
 }
 
 /* ── Card header ────────────────────────────────────────────────────────────── */
+.comfy-page .engine-h,
 .comfy-page .wcard-h {
   display: flex;
   align-items: center;
-  gap: 11px;
-  padding: 13px 16px;
+  gap: 12px;
+  padding: 14px 18px;
   border-bottom: 1px solid var(--line-soft);
-  background: linear-gradient(90deg, var(--comfy-soft), transparent 58%);
+  background: var(--bg);
+  flex-wrap: wrap;
+  row-gap: 10px;
 }
+.comfy-page .engine.active .engine-h {
+  background: linear-gradient(90deg, var(--comfy-soft), transparent 60%);
+}
+.comfy-page .engine-glyph,
 .comfy-page .wcard-h .glyph {
-  width: 26px; height: 26px;
+  width: 26px;
+  height: 26px;
   border-radius: var(--rad-sm);
-  display: inline-flex; align-items: center; justify-content: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: var(--comfy-soft);
   color: var(--comfy);
   border: 1px solid var(--comfy-line);
   flex-shrink: 0;
 }
+.comfy-page .engine-h .col,
 .comfy-page .wcard-h .col  { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.comfy-page .wcard-h .ttl  { font-family: var(--jbm); font-size: 14.5px; font-weight: 500; color: var(--fg); letter-spacing: -0.01em; line-height: 1.1; }
-.comfy-page .wcard-h .sub  { font-family: var(--jbm); font-size: 10.5px; color: var(--fg-4); }
+.comfy-page .engine-title,
+.comfy-page .wcard-h .ttl  { font-family: var(--jbm); font-size: 15px; font-weight: 500; color: var(--fg); line-height: 1.1; }
+.comfy-page .engine-sub,
+.comfy-page .wcard-h .sub  { font-family: var(--jbm); font-size: 11px; color: var(--fg-4); }
 .comfy-page .wcard-h .grow { flex: 1; }
+.comfy-page .eh-right {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
 .comfy-page .wcard-h .meta { font-family: var(--jbm); font-size: 10px; color: var(--fg-4); white-space: nowrap; }
 .comfy-page .wcard-h .meta b { color: var(--fg-2); font-weight: 500; }
 .comfy-page .wcard-b { padding: 16px; }
@@ -167,6 +186,61 @@
 .comfy-page .gauge.sm .gc .lbl { font-size: 8px; margin-top: 4px; letter-spacing: 0.07em; }
 .comfy-page .gauge.sm .gc .sub { font-size: 9px; margin-top: 2px; }
 
+/* ── Activity/metrics + queue/assets layout ─────────────────────────────────── */
+.comfy-page .activity-metrics-row,
+.comfy-page .queue-assets-row {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(280px, 2fr);
+  gap: 22px;
+  align-items: start;
+}
+
+.comfy-page .queue-assets-row {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line-soft);
+}
+
+.comfy-page .render-grid {
+  display: grid;
+  grid-template-columns: minmax(160px, 220px) minmax(0, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+
+.comfy-page .render-detail {
+  min-width: 0;
+}
+
+.comfy-page .metrics-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.comfy-page .metric-top {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.comfy-page .ram-metric {
+  min-width: 0;
+}
+
+.comfy-page .ram-metric .blk-h {
+  margin: 0 0 5px;
+}
+
+.comfy-page .ram-metric .tp-num {
+  font-size: 22px;
+}
+
+.comfy-page .ram-metric .cspark {
+  height: 24px;
+  margin-top: 8px;
+}
+
 /* ── 2×2 device metric grid ─────────────────────────────────────────────────── */
 .comfy-page .mx2 {
   display: grid; grid-template-columns: 1fr 1fr;
@@ -186,7 +260,36 @@
 .comfy-page .job-h .kind { font-family: var(--jbm); font-size: 11px; color: var(--fg-4); }
 .comfy-page .job-h .grow { flex: 1; }
 .comfy-page .job-h .pct { font-family: var(--jbm); font-size: 22px; font-weight: 500; letter-spacing: -0.02em; color: var(--comfy); line-height: 1; }
-.comfy-page .job-h .pct.big { font-size: 40px; }
+.comfy-page .job-h .pct.big { font-size: 34px; }
+
+.comfy-page .render-job {
+  background: transparent;
+  border: none;
+  padding: 0;
+  gap: 11px;
+}
+
+.comfy-page .render-job .job-h {
+  align-items: flex-end;
+}
+
+.comfy-page .render-job .col {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.comfy-page .render-job .job-steps {
+  margin-top: 0;
+}
+
+.comfy-page .render-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 2px;
+}
 
 .comfy-page .gbar { height: 7px; border-radius: 3px; background: var(--bg-3); overflow: hidden; position: relative; }
 .comfy-page .gbar.tall { height: 10px; }
@@ -222,8 +325,12 @@
   background-color: var(--bg-sunken);
   background-image: repeating-linear-gradient(135deg, transparent 0 9px, rgba(94,164,249,0.05) 9px 18px);
   display: flex; flex-direction: column; align-items: center; justify-content: center;
-  gap: 8px; min-height: 184px;
+  gap: 7px;
+  min-height: 136px;
+  aspect-ratio: 16 / 10;
 }
+.comfy-page .preview.active { border-color: var(--comfy-line); }
+.comfy-page .preview-img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; opacity: 0.7; }
 .comfy-page .preview .scan {
   position: absolute; left: 0; right: 0; height: 2px;
   background: linear-gradient(90deg, transparent, var(--comfy), transparent);
@@ -302,6 +409,14 @@
   margin-top: 16px; padding-top: 16px; border-top: 1px solid var(--line-soft);
 }
 
+.comfy-page .queue-assets-row .wcard-sub {
+  grid-template-columns: 1fr;
+  gap: 16px;
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
+}
+
 .comfy-page .flows { display: flex; flex-wrap: wrap; gap: 8px; }
 .comfy-page .flow {
   display: inline-flex; align-items: center; gap: 7px;
@@ -351,3 +466,34 @@
 .comfy-page .rbtn:hover { border-color: var(--line-strong); background: var(--bg-2); color: var(--fg); }
 .comfy-page .rbtn.acc { color: var(--comfy); border-color: var(--comfy-line); }
 .comfy-page .rbtn.acc:hover { background: var(--comfy-soft); }
+
+@media (max-width: 980px) {
+  .comfy-page .activity-metrics-row,
+  .comfy-page .queue-assets-row,
+  .comfy-page .wcard-sub {
+    grid-template-columns: 1fr;
+  }
+
+  .comfy-page .render-grid {
+    grid-template-columns: minmax(140px, 0.75fr) minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 720px) {
+  .comfy-page .render-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .comfy-page .metric-top {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .comfy-page .preview {
+    min-height: 128px;
+  }
+
+  .comfy-page .qcard.row {
+    flex-wrap: wrap;
+  }
+}

--- a/ui/src/dash/comfyui-pane.jsx
+++ b/ui/src/dash/comfyui-pane.jsx
@@ -336,11 +336,11 @@ export const COMFYUI_V2_MOCK = {
 function CardHead({ engine, run, pct }) {
   const hasRun = run != null
   return (
-    <div className="wcard-h">
-      <span className="glyph"><Ci name="comfy" size={16} /></span>
+    <div className="engine-h wcard-h">
+      <span className="engine-glyph"><Ci name="comfy" size={16} /></span>
       <span className="col">
-        <span className="ttl">ComfyUI</span>
-        <span className="sub">image-gen engine · docker</span>
+        <span className="engine-title">ComfyUI</span>
+        <span className="engine-sub">image-gen engine · docker</span>
       </span>
       <span className={'epill' + (hasRun ? ' generating' : '')}>
         <span className="dot" />
@@ -351,10 +351,12 @@ function CardHead({ engine, run, pct }) {
         iGPU · exclusive
       </span>
       <span className="grow" />
-      <span className="gpu-note">
-        <Ci name="bolt" size={11} /> inference slots <span className="b">paused</span> while rendering
+      <span className="eh-right">
+        <span className="gpu-note">
+          <Ci name="bolt" size={11} /> inference slots <span className="b">paused</span> while rendering
+        </span>
+        <span className="meta">docker · <b>{engine.endpoint}</b></span>
       </span>
-      <span className="meta">docker · <b>{engine.endpoint}</b></span>
     </div>
   )
 }
@@ -429,86 +431,123 @@ export function ImageGenCard({
   const gttWarn = gttPct >= 80
 
   return (
-    <div className="wcard active">
+    <div className="engine wcard active">
       <CardHead engine={engine} run={run} pct={pct} />
       <div className="wcard-b">
 
-        {/* ── Render hero: preview frame + active-render progress ── */}
-        <div style={{ display: 'grid', gridTemplateColumns: '300px 1fr', gap: 22, alignItems: 'stretch' }}>
-          {/* Preview frame */}
-          <div className="preview">
-            <span className="scan" />
-            {hasRun && comfyBaseUrl ? (
-              <img
-                src="/api/comfyui/preview"
-                alt="latest render output"
-                className="preview-img"
-                style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover', opacity: 0.7 }}
-              />
-            ) : (
-              <span className="glyph"><Ci name="video" size={30} /></span>
-            )}
-            {hasRun ? (
-              <span className="lab">
-                <b>{run.name}</b><br />{run.kind}<br />
-                live preview ↦ frame {Math.round(pct / 100 * 81)}/81
-              </span>
-            ) : (
-              <span className="lab">no active render</span>
-            )}
+        {/* ── Top row: active render activity (60%) + metrics (40%) ── */}
+        <div className="activity-metrics-row">
+          <div className="activity-panel">
+            <div className="render-grid">
+              {/* Preview frame */}
+              <div className={'preview' + (hasRun ? ' active' : '')}>
+                {hasRun ? <span className="scan" /> : null}
+                {hasRun && comfyBaseUrl ? (
+                  <img
+                    src="/api/comfyui/preview"
+                    alt="latest render output"
+                    className="preview-img"
+                  />
+                ) : (
+                  <span className="glyph"><Ci name="video" size={24} /></span>
+                )}
+                {hasRun ? (
+                  <span className="lab">
+                    <b>{run.name}</b><br />{run.kind}<br />
+                    frame {Math.round(pct / 100 * 81)}/81
+                  </span>
+                ) : (
+                  <span className="lab">no active render</span>
+                )}
+              </div>
+
+              {/* Active render progress detail */}
+              <div className="render-detail">
+                <BlkH icon="bolt" acc note={hasRun ? `eta ${run.eta}` : undefined}>
+                  active render
+                </BlkH>
+                {hasRun ? (
+                  <div className="job render-job">
+                    <div className="job-h">
+                      <div className="col">
+                        <span className="nm">
+                          {run.name} <span className="kind">· {run.kind}</span>
+                        </span>
+                        <span className="job-loaded">{run.node} · step {run.step}/{run.total}</span>
+                      </div>
+                      <span className="grow" />
+                      <span className="pct big">{Math.round(pct)}%</span>
+                    </div>
+                    <div className="gbar tall">
+                      <i style={{ width: pct + '%' }} />
+                    </div>
+                    <StepPips step={run.step} total={run.total} />
+                    <div className="job-steps">
+                      <span className="node">loaded: {run.loaded}</span>
+                      <span>{its} it/s</span>
+                    </div>
+                    <div className="render-actions">
+                      <button className="rbtn" onClick={onCancel}><Ci name="stop" size={13} /> Cancel render</button>
+                      {comfyBaseUrl ? (
+                        <a className="rbtn acc" href={comfyBaseUrl} target="_blank" rel="noopener noreferrer">
+                          <Ci name="ext" size={13} /> Open ComfyUI ↗
+                        </a>
+                      ) : (
+                        <button className="rbtn acc"><Ci name="ext" size={13} /> Open ComfyUI ↗</button>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="job-empty">engine idle · no job running</div>
+                )}
+              </div>
+            </div>
           </div>
 
-          {/* Active render progress detail */}
-          <div>
-            <BlkH icon="bolt" acc note={hasRun ? `eta ${run.eta}` : undefined}>
-              active render
-            </BlkH>
-            {hasRun ? (
-              <div className="job" style={{ background: 'transparent', border: 'none', padding: 0, gap: 13 }}>
-                <div className="job-h" style={{ alignItems: 'flex-end' }}>
-                  <div className="col" style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-                    <span className="nm">
-                      {run.name} <span className="kind">· {run.kind}</span>
-                    </span>
-                    <span className="job-loaded">{run.node} · step {run.step}/{run.total}</span>
-                  </div>
-                  <span className="grow" />
-                  <span className="pct big">{Math.round(pct)}%</span>
+          {/* Telemetry: GTT gauge + RAM spark + device metric grid */}
+          <div className="metrics-panel">
+            <div className="metric-top">
+              <Gauge
+                pct={gttPct}
+                label="gtt"
+                sub={`${used} / ${gtt.ceil}`}
+                size={104}
+                warn={gttWarn}
+              />
+              <div className="ram-metric">
+                <div className="blk-h">system ram</div>
+                <div className="tp-num">
+                  {ram.used}<span className="u">/ {ram.ceil} GB</span>
                 </div>
-                <div className="gbar tall">
-                  <i style={{ width: pct + '%' }} />
+                <BarSpark />
+              </div>
+            </div>
+            <div>
+              <BlkH icon="gauge" note="iGPU">device</BlkH>
+              <div className="mx2">
+                <div className="cstat">
+                  <span className="cl">util</span>
+                  <span className="cv acc">{stats.util}<span className="u">%</span></span>
                 </div>
-                <StepPips step={run.step} total={run.total} />
-                <div className="job-steps" style={{ marginTop: 2 }}>
-                  <span className="node">loaded: {run.loaded}</span>
-                  <span>{its} it/s</span>
+                <div className="cstat">
+                  <span className="cl">temp</span>
+                  <span className="cv">{stats.temp}<span className="u">°C</span></span>
                 </div>
-                <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
-                  <button className="rbtn" onClick={onCancel}><Ci name="stop" size={13} /> Cancel render</button>
-                  {comfyBaseUrl ? (
-                    <a className="rbtn acc" href={comfyBaseUrl} target="_blank" rel="noopener noreferrer">
-                      <Ci name="ext" size={13} /> Open ComfyUI ↗
-                    </a>
-                  ) : (
-                    <button className="rbtn acc"><Ci name="ext" size={13} /> Open ComfyUI ↗</button>
-                  )}
+                <div className="cstat">
+                  <span className="cl">clock</span>
+                  <span className="cv">{stats.clk}<span className="u">GHz</span></span>
+                </div>
+                <div className="cstat">
+                  <span className="cl">speed</span>
+                  <span className="cv acc">{stats.its}<span className="u">it/s</span></span>
                 </div>
               </div>
-            ) : (
-              <div className="job-empty">engine idle · no job running</div>
-            )}
+            </div>
           </div>
         </div>
 
-        {/* ── Lower row: queue (2/3) + telemetry (1/3) ── */}
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: '2fr 1fr',
-          gap: 22,
-          marginTop: 18,
-          paddingTop: 16,
-          borderTop: '1px solid var(--line-soft)',
-        }}>
+        {/* ── Lower row: queue (60%) + workflows/models (40%) ── */}
+        <div className="queue-assets-row">
           {/* Queue */}
           <div>
             <BlkH icon="queue" note={`${hasRun ? '1 running' : '0 running'} · ${queue.length} pending`}>
@@ -558,52 +597,10 @@ export function ImageGenCard({
             )}
           </div>
 
-          {/* Telemetry: GTT gauge + RAM spark + device metric grid */}
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-              <Gauge
-                pct={gttPct}
-                label="gtt"
-                sub={`${used} / ${gtt.ceil}`}
-                size={116}
-                warn={gttWarn}
-              />
-              <div style={{ minWidth: 0 }}>
-                <div className="blk-h" style={{ margin: '0 0 5px' }}>system ram</div>
-                <div className="tp-num" style={{ fontSize: 22 }}>
-                  {ram.used}<span className="u">/ {ram.ceil} GB</span>
-                </div>
-                <BarSpark style={{ height: 24, marginTop: 8 }} />
-              </div>
-            </div>
-            <div>
-              <BlkH icon="gauge" note="iGPU">device</BlkH>
-              <div className="mx2">
-                <div className="cstat">
-                  <span className="cl">util</span>
-                  <span className="cv acc">{stats.util}<span className="u">%</span></span>
-                </div>
-                <div className="cstat">
-                  <span className="cl">temp</span>
-                  <span className="cv">{stats.temp}<span className="u">°C</span></span>
-                </div>
-                <div className="cstat">
-                  <span className="cl">clock</span>
-                  <span className="cv">{stats.clk}<span className="u">GHz</span></span>
-                </div>
-                <div className="cstat">
-                  <span className="cl">speed</span>
-                  <span className="cv acc">{stats.its}<span className="u">it/s</span></span>
-                </div>
-              </div>
-            </div>
+          <div className="wcard-sub">
+            <WorkflowsBlock comfyBaseUrl={comfyBaseUrl} />
+            <ModelsBlock />
           </div>
-        </div>
-
-        {/* ── Workflows + Models lower section ── */}
-        <div className="wcard-sub">
-          <WorkflowsBlock comfyBaseUrl={comfyBaseUrl} />
-          <ModelsBlock />
         </div>
       </div>
 

--- a/ui/src/dash/connections.css
+++ b/ui/src/dash/connections.css
@@ -38,26 +38,34 @@
 
 /* ── Engine pane shell ───────────────────────────────────────────── */
 .cpane { border: 1px solid var(--line); border-radius: var(--rad-lg); background: var(--bg-1); overflow: hidden; }
-.cpane.live { border-color: var(--accent-line); box-shadow: 0 0 0 1px var(--accent-line), 0 0 44px -22px var(--accent-glow); }
+.cpane.live { border-color: var(--line); box-shadow: none; }
 
+.engine-h,
 .cpane-h {
   display: flex; align-items: center; gap: 12px; padding: 14px 18px;
   border-bottom: 1px solid var(--line-soft); background: var(--bg); cursor: pointer;
   transition: background var(--dur-fast) var(--ease);
+  flex-wrap: wrap;
+  row-gap: 10px;
 }
-.cpane.live .cpane-h { background: linear-gradient(90deg, var(--accent-soft), transparent 58%); }
+.engine.active .engine-h,
+.cpane.live .cpane-h { background: linear-gradient(90deg, var(--accent-soft), transparent 60%); }
 .cpane-h:hover { background: var(--bg-2); }
-.cpane.live .cpane-h:hover { background: linear-gradient(90deg, rgba(255,176,0,0.14), transparent 58%); }
+.cpane.live .cpane-h:hover { background: linear-gradient(90deg, rgba(255,176,0,0.14), transparent 60%); }
+.engine-glyph,
 .cpane-glyph {
-  width: 28px; height: 28px; border-radius: var(--rad-sm); flex-shrink: 0;
+  width: 26px; height: 26px; border-radius: var(--rad-sm); flex-shrink: 0;
   display: inline-flex; align-items: center; justify-content: center;
   background: var(--bg-2); color: var(--fg-3); border: 1px solid var(--line);
 }
 .cpane.live .cpane-glyph { background: var(--accent-soft); color: var(--accent); border-color: var(--accent-line); }
 .cpane-titles { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.engine-title,
 .cpane-title { font-family: var(--jbm); font-size: 15px; font-weight: 500; color: var(--fg); white-space: nowrap; }
+.engine-sub,
 .cpane-sub { font-family: var(--jbm); font-size: 11px; color: var(--fg-4); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .cpane-h .grow { flex: 1; }
+.eh-right { display: inline-flex; align-items: center; gap: 8px; flex-shrink: 0; }
 
 /* state pill */
 .cpill { display: inline-flex; align-items: center; gap: 7px; padding: 3px 10px; border-radius: var(--rad-pill); font-family: var(--jbm); font-size: 11px; border: 1px solid var(--line); color: var(--fg-3); background: var(--bg-1); white-space: nowrap; }

--- a/ui/src/dash/connections.jsx
+++ b/ui/src/dash/connections.jsx
@@ -443,14 +443,14 @@ function EnginePane({ live, glyph, eyebrow, title, sub, pill, headRight, strip, 
   return (
     <section>
       <div className="conn-eyebrow">{eyebrow}</div>
-      <div className={'cpane' + (live ? ' live' : '') + (open ? ' open' : '')}>
-        <div className="cpane-h" onClick={() => setOpen((o) => !o)}>
-          <span className="cpane-glyph">
+      <div className={'engine cpane' + (live ? ' live active' : '') + (open ? ' open' : '')}>
+        <div className="engine-h cpane-h" onClick={() => setOpen((o) => !o)}>
+          <span className="engine-glyph cpane-glyph">
             <CIcon name={glyph} size={16} />
           </span>
           <span className="cpane-titles">
-            <span className="cpane-title">{title}</span>
-            <span className="cpane-sub">{sub}</span>
+            <span className="engine-title cpane-title">{title}</span>
+            <span className="engine-sub cpane-sub">{sub}</span>
           </span>
           <span className={'cpill ' + (pill.tone || '')}>
             <span className="dot" />
@@ -458,7 +458,7 @@ function EnginePane({ live, glyph, eyebrow, title, sub, pill, headRight, strip, 
           </span>
           <span className="grow" />
           {headRight && (
-            <span style={{ display: 'inline-flex', gap: 8 }} onClick={(e) => e.stopPropagation()}>
+            <span className="eh-right" onClick={(e) => e.stopPropagation()}>
               {headRight}
             </span>
           )}

--- a/ui/tests/e2e/specs/imagegen-v2.spec.ts
+++ b/ui/tests/e2e/specs/imagegen-v2.spec.ts
@@ -185,6 +185,7 @@ test.describe('ImageGen V2 render-hero pane', () => {
     const pane = page.locator('.comfy-v2-pane')
     // Empty-queue state shows an in-flow message (not a bleed overlay)
     await expect(pane.locator('.queue-empty-state')).toBeVisible()
+    await expect(pane.locator('.preview .scan')).toHaveCount(0)
 
     // Verify the Open ComfyUI button (below/near empty state) is clickable.
     // A full-bleed overlay would intercept this click and cause an error or wrong element.


### PR DESCRIPTION
## Summary
- move ComfyUI metrics beside active render activity and move workflows/models beside queue
- shrink the ComfyUI render preview and only run its scan animation during generation
- align ComfyUI and Endpoints headers with the newer Inference engine header style
- remove the active accent border/ring around the ComfyUI and Endpoints containers

## Verification
- npm run typecheck
- npm run build
- npx playwright test tests/e2e/specs/imagegen-v2.spec.ts tests/e2e/specs/comfyui-arbiter-v3.spec.ts --project=chromium
- npx playwright test tests/e2e/specs/connections-v3.spec.ts --project=chromium
- graphify update .
