### PR TITLE
Unify inference/NPU/ComfyUI cards to profile-card style

### DIFF
--- a/ui/src/dash/comfyui-pane.css
+++ b/ui/src/dash/comfyui-pane.css
@@ -344,15 +344,20 @@
 
 /* ── Queue rows (card-styled, V2 row layout) ────────────────────────────────── */
 .comfy-page .qcard {
-  border: 1px solid var(--line); border-radius: var(--rad-sm);
-  background: var(--bg-2); padding: 10px 12px;
+  border: 1px solid var(--line); border-radius: var(--rad-lg);
+  background: var(--bg-1); padding: 10px 12px;
   display: flex; flex-direction: column; gap: 8px;
   position: relative; overflow: hidden;
+  transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
 }
-.comfy-page .qcard::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: var(--qc-hue, var(--line)); }
+.comfy-page .qcard::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: var(--qc-hue, var(--line)); opacity: 0.85; }
 .comfy-page .qcard.running::before { background: var(--comfy); }
 .comfy-page .qcard.pending { opacity: 0.78; }
 .comfy-page .qcard.pending::before { background: var(--fg-5); }
+.comfy-page .qcard:hover { border-color: var(--line-strong); transform: translateY(-1px); box-shadow: 0 6px 20px rgba(0, 0, 0, 0.28); }
+.comfy-page .qcard:hover::before { opacity: 1; box-shadow: 0 0 12px var(--qc-hue, var(--line)); }
+.comfy-page .qcard.running:hover::before { box-shadow: 0 0 12px var(--comfy); }
+.comfy-page .qcard.pending:hover::before { box-shadow: 0 0 12px var(--fg-5); }
 
 /* Row layout for V2 queue */
 .comfy-page .qcard.row { flex-direction: row; align-items: center; gap: 11px; padding: 11px 14px; }

--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -744,20 +744,38 @@
   padding: 8px 2px;
 }
 :is(.infer-pane, .npu-pane) .scard {
+  position: relative;
   border: 1px solid var(--line);
-  border-radius: var(--rad);
-  background: var(--bg);
+  border-radius: var(--rad-lg);
+  background: var(--bg-1);
   overflow: hidden;
-  transition: border-color 0.14s var(--ease);
+  transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+}
+/* left accent — colour per state, matching the profile-card .pf-accent treatment */
+:is(.infer-pane, .npu-pane) .scard::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--bk, transparent);
+  opacity: 0.85;
 }
 :is(.infer-pane, .npu-pane) .scard:hover {
   border-color: var(--line-strong);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.28);
+}
+:is(.infer-pane, .npu-pane) .scard:hover::before {
+  opacity: 1;
+  box-shadow: 0 0 12px var(--bk);
 }
 :is(.infer-pane, .npu-pane) .scard.ready {
-  border-left: 2px solid var(--comfy);
+  --bk: var(--dev-vulkan);
 }
 :is(.infer-pane, .npu-pane) .scard.serving {
-  border-left: 2px solid var(--comfy);
+  --bk: var(--dev-vulkan);
 }
 /* living-grid breathe — a subtle glow on the headline serving cards (infer-pane
    only; the NPU pane uses its own .cslot markup). */
@@ -774,10 +792,10 @@
   }
 }
 :is(.infer-pane, .npu-pane) .scard.warming {
-  border-left: 2px solid var(--warn);
+  --bk: var(--warn);
 }
 :is(.infer-pane, .npu-pane) .scard.error {
-  border-left: 2px solid var(--err);
+  --bk: var(--err);
 }
 :is(.infer-pane, .npu-pane) .scard.dim {
   opacity: 0.55;
@@ -1116,27 +1134,44 @@
   grid-template-columns: repeat(auto-fill, minmax(218px, 1fr));
 }
 .infer-pane .mcard {
+  position: relative;
   border: 1px solid var(--line);
-  border-radius: var(--rad);
-  background: var(--bg);
+  border-radius: var(--rad-lg);
+  background: var(--bg-1);
   overflow: hidden;
-  transition: border-color 0.14s var(--ease);
+  transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+}
+.infer-pane .mcard::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--bk, transparent);
+  opacity: 0.85;
 }
 .infer-pane .mcard:hover {
   border-color: var(--line-strong);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.28);
+}
+.infer-pane .mcard:hover::before {
+  opacity: 1;
+  box-shadow: 0 0 12px var(--bk);
 }
 .infer-pane .mcard.ready {
-  border-left: 2px solid var(--comfy);
+  --bk: var(--dev-vulkan);
 }
 .infer-pane .mcard.serving {
-  border-left: 2px solid var(--comfy);
+  --bk: var(--dev-vulkan);
   animation: breathe 3.4s ease-in-out infinite;
 }
 .infer-pane .mcard.warming {
-  border-left: 2px solid var(--warn);
+  --bk: var(--warn);
 }
 .infer-pane .mcard.error {
-  border-left: 2px solid var(--err);
+  --bk: var(--err);
 }
 .infer-pane .mcard.offline {
   opacity: 0.6;

--- a/ui/src/dash/npu.css
+++ b/ui/src/dash/npu.css
@@ -439,14 +439,15 @@
 /* ── per-slot cards (right rail) ───────────────────────────────────── */
 .npu-card .cslot {
   border: 1px solid var(--line);
-  border-radius: var(--rad-sm);
-  background: var(--bg-2);
+  border-radius: var(--rad-lg);
+  background: var(--bg-1);
   padding: 10px 12px;
   display: flex;
   flex-direction: column;
   gap: 8px;
   position: relative;
   overflow: hidden;
+  transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
 }
 .npu-card .cslot::before {
   content: '';
@@ -456,6 +457,16 @@
   bottom: 0;
   width: 2px;
   background: var(--slot-hue, var(--line));
+  opacity: 0.85;
+}
+.npu-card .cslot:hover {
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.28);
+}
+.npu-card .cslot:hover::before {
+  opacity: 1;
+  box-shadow: 0 0 12px var(--slot-hue);
 }
 .npu-card .cslot.dim {
   opacity: 0.62;


### PR DESCRIPTION
## Summary
Unifies the tile cards across the **Inference**, **NPU**, and **ComfyUI** dashboard containers to match the profile-section `.pf-card` style, including its hover effect (border lift, `translateY(-1px)`, drop shadow, and a glowing left accent on hover).

Left-border colours are preserved for every card. Section panels (`.wcard`) and the active-render `.job` highlight are intentionally untouched (they're containers/highlights, not left-accent tiles).

## Changes
| Pane | Card | Change |
|------|------|--------|
| Inference (`engine-panes.css`) | `.scard`, `.mcard` | `--rad-lg`, `--bg-1`, `border-left` → `::before` accent (`--bk`), pf-card hover |
| NPU (`npu.css`) | `.cslot` | pf-card shell + hover; per-slot `--slot-hue` accent preserved |
| ComfyUI (`comfyui-pane.css`) | `.qcard` | pf-card shell + hover; `--comfy`/`--qc-hue` + running/pending colours preserved |

## Running-state yellow → vulkan yellow
`.infer-pane` remaps `--comfy` to `#e5b84f`, so the **running** cards (`ready`/`serving`) were the yellow-bordered ones. Those now use `--dev-vulkan` (`#f9d884`) — the exact yellow the profile **vulkan** card uses. `warming` stays `--warn`, `error` stays `--err`.

## Verification
- `vite build` passes (212 modules), CSS braces balanced.
- Verified live in-browser against the CT105 backend: running inference accent renders `rgb(249,216,132)` = `#f9d884`; NPU `.cslot` and ComfyUI `.qcard` adopt `--rad-lg`/`--bg-1`/accent-opacity 0.85 with hover lift + accent glow; per-card left-border colours preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)