### PR TITLE
Give Profiles tab an engine-style section header

### DIFF
--- a/ui/src/dash/profiles.jsx
+++ b/ui/src/dash/profiles.jsx
@@ -511,6 +511,37 @@ function Stat({ value, label, accent }) {
 
 // ── Main view ────────────────────────────────────────────────────────────────────
 
+// Section header — mirrors the engine-h header the Inference / Image Gen /
+// Endpoints tabs use (glyph · title · sub · status pill · actions), so the
+// Profiles tab reads as part of the same family instead of the old big-h1 view
+// header. The base .engine-h styling is global (connections.css); .pf-engine-h
+// only de-emphasises the pointer cursor and accent the panel owns.
+function ProfilesHeader({ count, onNew }) {
+  return (
+    <div className="engine-h pf-engine-h">
+      <span className="engine-glyph">{Icons.slots}</span>
+      <span className="cpane-titles">
+        <span className="engine-title">Profiles</span>
+        <span className="engine-sub">launch profiles · image + bench-tuned flags per workload</span>
+      </span>
+      {count != null && (
+        <span className="cpill">
+          <span className="dot" />
+          {count} profile{count === 1 ? '' : 's'}
+        </span>
+      )}
+      <span className="grow" />
+      {onNew && (
+        <span className="eh-right">
+          <button className="pf-btn primary" onClick={onNew} data-testid="pf-btn-new">
+            {Icons.plus} New profile
+          </button>
+        </span>
+      )}
+    </div>
+  );
+}
+
 function ProfilesView() {
   const query = useProfiles();
   const profiles = query.data ?? [];
@@ -525,7 +556,7 @@ function ProfilesView() {
   if (query.isLoading) {
     return (
       <div className="view">
-        <div className="vh"><span className="vh-eye mono">RUNTIME</span><h1>Profiles</h1></div>
+        <div className="pf-engine"><ProfilesHeader /></div>
         <div className="empty mono">Loading profiles…</div>
       </div>
     );
@@ -534,7 +565,7 @@ function ProfilesView() {
   if (query.isError) {
     return (
       <div className="view">
-        <div className="vh"><span className="vh-eye mono">RUNTIME</span><h1>Profiles</h1></div>
+        <div className="pf-engine"><ProfilesHeader /></div>
         <div className="empty mono" style={{ color: 'var(--err)' }}>
           Failed to load profiles: {query.error?.message || 'unknown error'}
         </div>
@@ -544,28 +575,21 @@ function ProfilesView() {
 
   return (
     <div className="view">
-      <div className="vh">
-        <span className="vh-eye mono">RUNTIME</span>
-        <h1>Profiles</h1>
-        <div className="vh-spacer" />
-        <span className="hint mono">image + bench-tuned flags per workload</span>
-        <button className="pf-btn primary lg" onClick={() => setDrawer({ mode: 'create' })} data-testid="pf-btn-new">
-          {Icons.plus} New profile
-        </button>
-      </div>
-
-      <div className="pf-summary">
-        <Stat value={profiles.length} label="profiles" />
-        <span className="pf-stat-div" />
-        <Stat value={seeds.length} label="seed templates" />
-        <Stat value={custom.length} label="custom" accent="var(--accent)" />
-        <span className="pf-stat-div" />
-        <Stat value={`${inUseCount}/${profiles.length}`} label="bound to slots" accent="var(--ok)" />
-        <span className="pf-grow" />
-        <div className="pf-legend mono">
-          {Object.entries(BACKEND_META).map(([k, m]) => (
-            <span className="pf-legend-i" key={k} style={{ '--bk': m.color }}><span className="pf-chip-dot" />{m.label}</span>
-          ))}
+      <div className="pf-engine">
+        <ProfilesHeader count={profiles.length} onNew={() => setDrawer({ mode: 'create' })} />
+        <div className="pf-summary">
+          <Stat value={profiles.length} label="profiles" />
+          <span className="pf-stat-div" />
+          <Stat value={seeds.length} label="seed templates" />
+          <Stat value={custom.length} label="custom" accent="var(--accent)" />
+          <span className="pf-stat-div" />
+          <Stat value={`${inUseCount}/${profiles.length}`} label="bound to slots" accent="var(--ok)" />
+          <span className="pf-grow" />
+          <div className="pf-legend mono">
+            {Object.entries(BACKEND_META).map(([k, m]) => (
+              <span className="pf-legend-i" key={k} style={{ '--bk': m.color }}><span className="pf-chip-dot" />{m.label}</span>
+            ))}
+          </div>
         </div>
       </div>
 

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -2651,6 +2651,17 @@ select.npu-sel {
   padding: 14px 18px; margin-bottom: 22px;
   border: 1px solid var(--line); border-radius: var(--rad-lg); background: var(--bg-1);
 }
+
+/* Profiles section panel — an engine-h header + the summary in one bordered
+   card, mirroring the Inference / Image Gen / Endpoints tab shells so the tab
+   reads as part of the same family. .engine-h base styling is global
+   (connections.css); the wrapper just owns the border + body. */
+.pf-engine {
+  border: 1px solid var(--line); border-radius: var(--rad-lg);
+  background: var(--bg-1); overflow: hidden; margin-bottom: 22px;
+}
+.pf-engine-h { background: var(--bg); cursor: default; }
+.pf-engine .pf-summary { border: 0; border-radius: 0; margin-bottom: 0; background: transparent; }
 .pf-stat { display: flex; flex-direction: column; gap: 2px; }
 .pf-stat-v { font-family: var(--jbm); font-size: 20px; font-weight: 500; color: var(--fg); letter-spacing: -0.01em; line-height: 1; }
 .pf-stat-l { font-size: 10px; color: var(--fg-4); letter-spacing: 0.04em; }


### PR DESCRIPTION
## Summary
The **Profiles** tab led with the old big-`h1` `.vh` header (RUNTIME / Profiles), inconsistent with the **Inference**, **Image Gen**, and **Endpoints** tabs — which lead with an `engine-h` header (glyph · title · sub · status pill · actions) atop a bordered card shell.

This gives Profiles a matching header so the tab reads as part of the same family.

## Changes
- New `<ProfilesHeader>` renders the shared `engine-h` row: slots glyph, **Profiles** title, `launch profiles · image + bench-tuned flags per workload` sub, a `{n} profiles` count pill (`cpill`), and the **New profile** action in `eh-right`.
- Header + the existing summary-stats strip are wrapped in one bordered `.pf-engine` card (mirrors the engine/wcard/cpane shells). Base `engine-h` styling is global (`connections.css`); `.pf-engine-h` only drops the pointer cursor; nested `.pf-summary` loses its own border to become the card body.
- Loading/error states reuse the same header.

Follows #888 (card-style unification) — same cohesive-design goal.

## Verification
- `vite build` passes (212 modules).
- All 10 `profiles-page-v3` e2e tests pass (`.pf-summary`, `.pf-card`, sections, drawer all intact).
- Verified live in-browser (CT105 backend): header shows glyph + Profiles + sub + "8 profiles" pill + New-profile button; `.pf-engine` is the bordered card, `.pf-summary` border collapsed into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)