### PR TITLE
feat(dashboard): collapse ComfyUI queue/workflows + add Inference tab dot

### DIFF
--- a/ui/src/dash/comfyui-pane.css
+++ b/ui/src/dash/comfyui-pane.css
@@ -201,6 +201,50 @@
   border-top: 1px solid var(--line-soft);
 }
 
+/* ── Queue/workflows expander (collapses the lower half by default) ───────── */
+.comfy-page .queue-expander {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  margin-top: 18px;
+  padding: 11px 13px;
+  background: transparent;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--rad);
+  color: var(--fg-3);
+  font-family: var(--jbm);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: border-color 0.14s ease, background 0.14s ease, color 0.14s ease;
+}
+.comfy-page .queue-expander:hover {
+  border-color: var(--comfy-line);
+  background: var(--comfy-soft);
+  color: var(--fg);
+}
+.comfy-page .queue-expander.open { border-color: var(--comfy-line); color: var(--comfy); }
+.comfy-page .queue-expander .qx-ic { display: inline-flex; color: var(--fg-4); }
+.comfy-page .queue-expander.open .qx-ic { color: var(--comfy); }
+.comfy-page .queue-expander .qx-label { font-weight: 600; }
+.comfy-page .queue-expander .qx-sub {
+  text-transform: none; letter-spacing: 0; font-size: 10px; color: var(--fg-5);
+}
+.comfy-page .queue-expander .grow { flex: 1; }
+.comfy-page .queue-expander .qx-chev {
+  display: inline-flex; color: var(--fg-4); transition: transform 0.16s ease;
+}
+.comfy-page .queue-expander.open .qx-chev { transform: rotate(180deg); color: var(--comfy); }
+
+/* When open the expander supplies the separator — drop the row's own. */
+.comfy-page .queue-expander.open + .queue-assets-row {
+  margin-top: 12px;
+  padding-top: 0;
+  border-top: none;
+}
+
 .comfy-page .render-grid {
   display: grid;
   grid-template-columns: minmax(160px, 220px) minmax(0, 1fr);

--- a/ui/src/dash/comfyui-pane.jsx
+++ b/ui/src/dash/comfyui-pane.jsx
@@ -105,6 +105,7 @@ const CIcons = {
   ),
   logs:  <CI d="M3 3h10M3 6h10M3 9h7M3 12h5" />,
   close: <CI d="M4 4l8 8M12 4l-4 4" />,
+  chev:  <CI d="M4 6l4 4 4-4" />,
 }
 
 const Ci = ({ name, size = 16 }) =>
@@ -419,6 +420,12 @@ export function ImageGenCard({
   const { engine, run, queue, gtt, ram, stats } = mock
   const t = useTick(900)
 
+  // Queue + workflows (bottom half) collapse by default; the top render/metrics
+  // row is always visible. Keeping the lower half behind an expander keeps the
+  // card compact in the common "watch the active render" case and only reveals
+  // the queue list + workflow/model inventory on demand.
+  const [expanded, setExpanded] = useState(false)
+
   // Active render state (null = no render running)
   const hasRun = run != null
 
@@ -546,7 +553,22 @@ export function ImageGenCard({
           </div>
         </div>
 
+        {/* ── Expander: queue + workflows are hidden until opened ── */}
+        <button
+          type="button"
+          className={'queue-expander' + (expanded ? ' open' : '')}
+          aria-expanded={expanded}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          <span className="qx-ic"><Ci name="queue" size={13} /></span>
+          <span className="qx-label">queue &amp; workflows</span>
+          <span className="qx-sub">{hasRun ? '1 running' : '0 running'} · {queue.length} pending</span>
+          <span className="grow" />
+          <span className="qx-chev"><Ci name="chev" size={14} /></span>
+        </button>
+
         {/* ── Lower row: queue (60%) + workflows/models (40%) ── */}
+        {expanded && (
         <div className="queue-assets-row">
           {/* Queue */}
           <div>
@@ -602,6 +624,7 @@ export function ImageGenCard({
             <ModelsBlock />
           </div>
         </div>
+        )}
       </div>
 
       <CardFoot engine={engine} onRestart={onRestart} onLogs={onLogs} />

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -574,6 +574,12 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
     img:   cardSlots.filter(s => dc(s) === "img" || s.type === "image"),
   };
 
+  // Any non-image slot currently holding GPU/loaded → drives the Inference-tab
+  // status dot (mirrors comfyLive for the Image Gen tab, but yellow).
+  const inferLive = cardSlots.some(
+    s => dc(s) !== "img" && s.type !== "image" && isSlotLive(s),
+  );
+
   const editSlot = (slots || []).find(s => s.name === editName);
   const logsSlot = logsForSlot
     ? (slots || []).find(s => s.name === logsForSlot)
@@ -824,6 +830,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
           className={"slot-tab infer" + (tab === "inference" ? " on" : "")}
           onClick={() => { setTab("inference"); if (slotParam) window.location.hash = "#slots"; }}
         >
+          {inferLive && <span className="slot-tab-dot infer live" />}
           <span>Inference</span>
           <span className="slot-tab-ct num">{cardSlots.length - groups.img.length}</span>
         </button>
@@ -833,7 +840,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
           className={"slot-tab comfy" + (tab === "image" ? " on" : "")}
           onClick={() => { setTab("image"); if (slotParam) window.location.hash = "#slots"; }}
         >
-          <span className={"slot-tab-dot" + (comfyLive ? " live" : "")} />
+          {comfyLive && <span className="slot-tab-dot live" />}
           <span>Image Gen</span>
         </button>
         <button

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -805,6 +805,8 @@ a { color: inherit; text-decoration: none; }
 .slot-tab.on.comfy .slot-tab-ct { color: var(--comfy); }
 .slot-tab .slot-tab-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--fg-5); }
 .slot-tab .slot-tab-dot.live { background: var(--comfy); box-shadow: 0 0 8px var(--comfy); }
+/* Inference tab dot — yellow, to match the Inference accent (not comfy blue). */
+.slot-tab .slot-tab-dot.infer.live { background: var(--yellow); box-shadow: 0 0 8px var(--yellow); }
 
 /* Logs page rows */
 .log-row {

--- a/ui/tests/e2e/specs/comfyui-arbiter-v3.spec.ts
+++ b/ui/tests/e2e/specs/comfyui-arbiter-v3.spec.ts
@@ -85,6 +85,12 @@ async function gotoImageTab(page: any) {
   await page.waitForSelector('.comfy-v2-pane', { timeout: 10_000 })
 }
 
+// Queue rows live in the collapsed lower half — open the expander first.
+async function openQueue(page: any) {
+  await page.click('.comfy-v2-pane .queue-expander')
+  await page.waitForSelector('.comfy-v2-pane .queue-assets-row', { timeout: 5_000 })
+}
+
 test.describe('ComfyUI V2 live-wired pane (Task 5.2)', () => {
 
   // ── 1. status renders into hero ──────────────────────────────────────────
@@ -105,6 +111,7 @@ test.describe('ComfyUI V2 live-wired pane (Task 5.2)', () => {
   test('status: queue rows bind — 1 running + 2 pending', async ({ page }) => {
     await page.route('**/api/comfyui/status', (route: any) => json(route, comfyV2Status()))
     await gotoImageTab(page)
+    await openQueue(page)
 
     const pane = page.locator('.comfy-v2-pane')
     await expect(pane.locator('.qcard.row.running')).toBeVisible()
@@ -169,6 +176,7 @@ test.describe('ComfyUI V2 live-wired pane (Task 5.2)', () => {
     await page.route('**/api/comfyui/status', (route: any) => json(route, comfyV2Status()))
 
     await gotoImageTab(page)
+    await openQueue(page)
 
     const chips = page.locator('.comfy-v2-pane .flow')
     await expect(chips).toHaveCount(6)
@@ -208,6 +216,7 @@ test.describe('ComfyUI V2 live-wired pane (Task 5.2)', () => {
   test('idle: empty-queue state renders in-flow, no click-blocking overlay', async ({ page }) => {
     await page.route('**/api/comfyui/status', (route: any) => json(route, comfyV2Idle()))
     await gotoImageTab(page)
+    await openQueue(page)
 
     const pane = page.locator('.comfy-v2-pane')
     await expect(pane.locator('.queue-empty-state')).toBeVisible()
@@ -233,7 +242,8 @@ test.describe('ComfyUI V2 live-wired pane (Task 5.2)', () => {
     const pane = page.locator('.comfy-v2-pane')
     // Pane must not crash — the card header should be visible
     await expect(pane.locator('.wcard-h')).toBeVisible()
-    // running row is shown (1 running)
+    // running row is shown (1 running) — in the collapsed lower half
+    await openQueue(page)
     await expect(pane.locator('.qcard.row.running')).toBeVisible()
   })
 })

--- a/ui/tests/e2e/specs/imagegen-v2.spec.ts
+++ b/ui/tests/e2e/specs/imagegen-v2.spec.ts
@@ -64,6 +64,13 @@ async function gotoImageTab(page: any) {
   await page.waitForSelector('.comfy-v2-pane', { timeout: 10_000 })
 }
 
+// Queue + workflows/models are collapsed by default behind the expander;
+// open it before asserting on the lower-half elements.
+async function openQueue(page: any) {
+  await page.click('.comfy-v2-pane .queue-expander')
+  await page.waitForSelector('.comfy-v2-pane .queue-assets-row', { timeout: 5_000 })
+}
+
 test.describe('ImageGen V2 render-hero pane', () => {
   // ── 1. Render hero renders ──────────────────────────────────────────────
   test('render-hero: job name, progress bar, step info, it/s, eta, controls', async ({ page }) => {
@@ -95,6 +102,7 @@ test.describe('ImageGen V2 render-hero pane', () => {
   // ── 2. Queue rows ───────────────────────────────────────────────────────
   test('queue: running row + 2 pending rows render', async ({ page }) => {
     await gotoImageTab(page)
+    await openQueue(page)
     const pane = page.locator('.comfy-v2-pane')
 
     // running row: ldot.generating
@@ -129,6 +137,7 @@ test.describe('ImageGen V2 render-hero pane', () => {
   // ── 4. Workflows strip ──────────────────────────────────────────────────
   test('workflows strip renders 6 flow buttons', async ({ page }) => {
     await gotoImageTab(page)
+    await openQueue(page)
     const pane = page.locator('.comfy-v2-pane')
 
     await expect(pane.locator('.flows')).toBeVisible()
@@ -138,6 +147,7 @@ test.describe('ImageGen V2 render-hero pane', () => {
   // ── 5. Models on share ─────────────────────────────────────────────────
   test('models block: inv pills render (checkpoints, loras, vae…)', async ({ page }) => {
     await gotoImageTab(page)
+    await openQueue(page)
     const pane = page.locator('.comfy-v2-pane')
 
     await expect(pane.locator('.inv')).toBeVisible()
@@ -181,6 +191,7 @@ test.describe('ImageGen V2 render-hero pane', () => {
     await page.waitForSelector('.slot-tab.comfy', { timeout: 10_000 })
     await page.click('.slot-tab.comfy')
     await page.waitForSelector('.comfy-v2-pane', { timeout: 10_000 })
+    await openQueue(page)
 
     const pane = page.locator('.comfy-v2-pane')
     // Empty-queue state shows an in-flow message (not a bleed overlay)
@@ -203,6 +214,7 @@ test.describe('ImageGen V2 render-hero pane', () => {
     // Emulate prefers-reduced-motion: reduce
     await page.emulateMedia({ reducedMotion: 'reduce' })
     await gotoImageTab(page)
+    await openQueue(page)
     const pane = page.locator('.comfy-v2-pane')
 
     // The generating dot should exist but its computed animation should be none/paused


### PR DESCRIPTION
## Summary
Two dashboard tweaks plus a consistency fix, all on the Slots page.

### 1. ComfyUI card — expandable lower half
The queue + workflows/models row (the bottom ~40% of the ComfyUI card) is now collapsed by default behind a **"queue & workflows" expander**. The top render/metrics row stays always-visible. The expander shows a live `N running · M pending` summary and a rotating chevron, and reveals the lower half on click.

### 2. Inference tab — yellow status dot
Adds a status dot to the **Inference** tab, mirroring the existing ComfyUI/Image-Gen tab dot but in **yellow** (`--yellow`, the Inference accent). Driven by `isSlotLive()` over all non-image slots.

### 3. Both tab dots: show only when active
Previously the dots rendered grey when idle and colored when live. Now **both** the Inference (yellow) and Image Gen (blue) dots render **only when their slot is live** — no idle grey dot.

## Tests
- e2e specs updated to open the new expander before asserting on queue/workflow/empty-state elements (`imagegen-v2`, `comfyui-arbiter-v3`).
- Full suite: **340 passed, 11 skipped, 0 failed**. Typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)