### PR TITLE
fix(hardware): report live GTT total, not the stale cached probe value

### DIFF
--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -120,6 +120,12 @@ def _flatten_for_ui(info: dict[str, Any], gpu: GPUMemorySample | None = None) ->
     # only for non-UMA. This stops the dashboard from treating GTT and VRAM
     # as independent buckets.
     is_uma = gpu.is_uma if gpu is not None else False
+    # Prefer the LIVE sysfs GTT total over the cached probe's vram_mb. amdgpu
+    # grows the GART limit dynamically, so the boot-time probe (max(vram,gtt)
+    # frozen in hardware.json) goes stale — e.g. 80 GiB cached vs 96 GiB live.
+    # The gpu sample is read fresh from mem_info_gtt_total each request; fall
+    # back to the cached pool only when no live sample is available.
+    live_gtt_total_mb = gpu.gtt_total_mb if (gpu is not None and gpu.gtt_total_mb) else None
     platform = info.get("platform", "unknown") or "unknown"
     # memory_kind tells the UI whether to label the pool "unified" or
     # "system". Only strix-halo is genuinely unified for our purposes;
@@ -131,7 +137,7 @@ def _flatten_for_ui(info: dict[str, Any], gpu: GPUMemorySample | None = None) ->
         "gpu_name": primary_gpu.get("name", ""),
         "gpu_vendor": vendor,
         "vram_total_mb": 0 if is_uma else vram_mb,
-        "gtt_total_mb": vram_mb if is_uma else 0,
+        "gtt_total_mb": (live_gtt_total_mb or vram_mb) if is_uma else 0,
         "ram_total_mb": ram_mb,
         "ram_available_mb": info.get("ram_available_mb", 0),
         "unified_memory_mb": unified_mb,

--- a/tests/api/test_hardware_routes.py
+++ b/tests/api/test_hardware_routes.py
@@ -86,22 +86,26 @@ def test_flatten_strix_halo_is_unified() -> None:
     """is_uma comes from the live gpu_view sample (#703) — the old
     ``vram > ram*0.5`` route heuristic is deleted. For this fixture both
     derivations agree (96GB pooled vram > 128GB ram * 0.5)."""
+    # Mirror production: the cached probe's pooled vram_mb is STALE (80 GiB,
+    # frozen at boot) while the live sysfs sample is fresh (96 GiB). The live
+    # sample must win so the GTT total tracks amdgpu's grown GART limit.
     info = HardwareInfo(
         cpu_model="AMD Ryzen AI Max+ PRO 395",
         cpu_cores=16,
         cpu_threads=32,
         ram_mb=128 * 1024,
         unified_memory_mb=128 * 1024,
-        gpus=[GPUInfo(vendor="amd", name="Radeon 8060S", vram_mb=96 * 1024)],
+        gpus=[GPUInfo(vendor="amd", name="Radeon 8060S", vram_mb=80 * 1024)],
         npu=NPUInfo(present=True, vendor="amd", name="AMD NPU (XDNA)"),
         platform="strix-halo",
     ).model_dump(mode="python")
-    flat = _flatten_for_ui(info, _uma_sample())
+    flat = _flatten_for_ui(info, _uma_sample(gtt_total_mb=96 * 1024, total_mb=96 * 1024))
     assert flat["platform"] == "strix-halo"
     assert flat["platform_label"] == "Strix Halo (unified memory)"
     assert flat["memory_kind"] == "unified"
     assert flat["is_uma"] is True
-    # UMA split: the probe's pooled vram_mb surfaces as GTT, not VRAM.
+    # UMA split: the GTT pool surfaces as GTT (not VRAM), sourced from the
+    # LIVE sample (96 GiB), not the stale cached vram_mb (80 GiB).
     assert flat["vram_total_mb"] == 0
     assert flat["gtt_total_mb"] == 96 * 1024
 


### PR DESCRIPTION
## Problem
The ComfyUI card's memory widget looked like it had a discrepancy: it showed `gtt 41/96` while hal0's own `/api/hardware` reported `gtt_total = 80 GiB`. Investigation on the live Strix Halo box (CT 105):

```
kernel mem_info_gtt_total = 103079215104 B = 96 GiB   ← truth
/api/hardware gtt_total_mb = 81920        = 80 GiB   ← stale
ComfyUI card gtt gauge      = 41.3 / 96             ← correct
```

`_flatten_for_ui` sourced `gtt_total_mb` from the **cached** probe's `vram_mb` (`max(vram,gtt)` frozen in `hardware.json` at boot). amdgpu grows the GART limit dynamically, so the boot snapshot (80 GiB) drifts from the live value (96 GiB). The function already receives a fresh `GPUMemorySample` but only used it for `is_uma`.

## Fix
Prefer the **live** sample's `gtt_total_mb` (read fresh from `mem_info_gtt_total` each request); fall back to the cached pool only when no live sample is available. The ComfyUI card was already correct — this brings `/api/hardware` into agreement at the live 96 GiB.

## Tests
- `test_flatten_strix_halo_is_unified` rewritten to mirror production (stale cached 80 + fresh live 96 → live wins).
- `tests/api/test_hardware_routes.py` + `tests/hardware/test_gpu_view.py`: **42 passed**.

Found while running a live GPU/memory pressure test on CT 105 (heavy SDXL batch vs. resident LLMs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)