### PR TITLE
fix(npu): probe AIE columns via temp file, not -o /dev/stdout

### DIFF
--- a/src/hal0/providers/npu_columns.py
+++ b/src/hal0/providers/npu_columns.py
@@ -39,17 +39,21 @@ from typing import Any
 # sourced; under a bare `podman exec` it fails, so we call the real ELF.
 _XRT_SMI_BIN = "/opt/xilinx/xrt/bin/unwrapped/xrt-smi"
 
-# AIE-partition examine command. `-o /dev/stdout` keeps the JSON on the
-# pipe (no /tmp file dance). Empty stdout → fail-soft None.
-_XRT_SMI_CMD: tuple[str, ...] = (
-    _XRT_SMI_BIN,
-    "examine",
-    "-r",
-    "aie-partitions",
-    "-f",
-    "JSON",
-    "-o",
-    "/dev/stdout",
+# AIE-partition examine probe, run through `sh -c` inside the container.
+#
+# We cannot stream JSON via `-o /dev/stdout`: the live xrt-smi build rejects it
+# ("output file '/dev/stdout' already exists", exit 1), and with `--force` it
+# interleaves its human-readable console report onto stdout *alongside* the
+# JSON, so the captured payload no longer parses. The robust path is the /tmp
+# dance — write JSON to a private per-exec temp file (``$$`` is the in-container
+# shell PID, unique even under concurrent probes), ``cat`` it back (JSON only),
+# then remove it. A failed probe propagates a non-zero exit so the returncode
+# check in :func:`read_aie_columns` degrades to None.
+_XRT_SMI_SH = (
+    'f="/tmp/hal0-aie-$$.json"; '
+    '"' + _XRT_SMI_BIN + '" examine -r aie-partitions -f JSON -o "$f" --force '
+    '>/dev/null 2>&1 || { rm -f "$f"; exit 1; }; '
+    'cat "$f"; rm -f "$f"'
 )
 
 # Exec timeout — xrt-smi examine is sub-second when healthy.
@@ -167,7 +171,9 @@ async def read_aie_columns(container_name: str) -> dict[str, Any] | None:
             runtime,
             "exec",
             container_name,
-            *_XRT_SMI_CMD,
+            "sh",
+            "-c",
+            _XRT_SMI_SH,
             stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/tests/providers/test_npu_columns.py
+++ b/tests/providers/test_npu_columns.py
@@ -112,6 +112,35 @@ def test_read_success(monkeypatch):
     assert out["partitions"][0]["num_cols"] == 8
 
 
+def test_read_uses_tempfile_shell_not_dev_stdout(monkeypatch):
+    """Regression: the live xrt-smi build rejects ``-o /dev/stdout`` ("output
+    file already exists", exit 1), and with ``--force`` it interleaves its
+    human-readable console report onto stdout alongside the JSON — so the JSON
+    must be written to a private temp file inside the container and read back.
+    The probe therefore runs through ``sh -c`` with ``--force`` and a temp file,
+    never ``-o /dev/stdout``.
+    """
+    captured: list[tuple] = []
+
+    async def _fake_exec(*args, **kwargs):
+        captured.append(args)
+        return _FakeProc(stdout=_XRT_JSON_FULL.encode(), returncode=0)
+
+    monkeypatch.setattr(npu_columns.asyncio, "create_subprocess_exec", _fake_exec)
+    monkeypatch.setattr(npu_columns, "_container_runtime", lambda: "/usr/bin/podman")
+
+    out = asyncio.run(npu_columns.read_aie_columns("hal0-slot-npu"))
+    assert out is not None  # clean JSON (cat of the temp file) still parses
+    assert captured, "exec was not invoked"
+    argv = captured[0]
+    assert argv[:5] == ("/usr/bin/podman", "exec", "hal0-slot-npu", "sh", "-c")
+    script = argv[5]
+    assert "--force" in script
+    assert "/dev/stdout" not in script
+    assert "cat " in script  # JSON read back from the temp file
+    assert npu_columns._XRT_SMI_BIN in script
+
+
 def test_read_nonzero_returncode_none(monkeypatch):
     _patch_exec(monkeypatch, _FakeProc(stdout=b"garbage", returncode=1))
     assert asyncio.run(npu_columns.read_aie_columns("hal0-slot-npu")) is None


### PR DESCRIPTION
## Problem

The **NPU occupancy** dashboard card always showed `column probe unavailable` instead of `N/8 columns claimed`. Root cause: the AIE-column probe (`xrt-smi examine -r aie-partitions`) always failed against the live FLM image:

1. As written (`-o /dev/stdout`) → `ERROR: output file '/dev/stdout' already exists` → **exit 1** → `read_aie_columns` returns `None`.
2. Even with `--force`, xrt-smi writes JSON to the `-o` target **and** prints its human-readable console report to stdout — with `-o /dev/stdout` the two interleave, so `json.loads` chokes on the leading banner → `None`.

Either way `columns_available` stayed `False`, and the route silently degraded to the single-tenant "all 8 columns" fallback. The gauge looked plausible (8/8 is right for one slot), so the honest multi-tenant path never actually ran.

## Fix

Run the probe through `sh -c` inside the container: write JSON to a private per-exec temp file (`$$`), `cat` it back (JSON only), then remove it. A failed probe propagates a non-zero exit so the existing returncode check degrades cleanly.

Verified end-to-end against `hal0-slot-npu` on CT 105 — returns clean JSON, `partitions: [(0, 8)]`, exit 0.

## Tests

- New regression test `test_read_uses_tempfile_shell_not_dev_stdout` pins the `sh -c` + `--force` + temp-file shape and asserts `/dev/stdout` never reappears.
- All existing probe + occupancy tests pass (20 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)