### PR TITLE
feat(dashboard): sidebar nav accordion + bottom Services launch zone

### DIFF
--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -12,6 +12,7 @@ import { useMemoryEnabled } from '@/api/hooks/useMemory'
 import { useUpdateState } from '@/api/hooks/useUpdates'
 import { useApprovalList, useApproveApproval, useDenyApproval } from '@/api/hooks/useAgents'
 import { useServicesHealth } from '@/api/hooks/useServicesHealth'
+import { useConfigUrls } from '@/api/hooks/useConfigUrls'
 
 const { useState: useStateC, useEffect: useEffectC } = React;
 
@@ -167,17 +168,8 @@ function TopBar({ route, onCmdK, onMenu, menuOpen = false }) {
         </div>
       )}
       <div className="tb-spacer" />
-      {/* Operator Board launcher — command-palette-styled, ⌘B. Navigates by
-          hash so it works without threading a handler through main.jsx. */}
-      <button
-        className={"tb-board" + (route === "board" ? " on" : "")}
-        data-testid="tb-board"
-        onClick={() => { window.location.hash = "#board"; }}
-        aria-label="Operator Board"
-      >
-        {Icons.board}<span>Board</span>
-        <kbd>⌘B</kbd>
-      </button>
+      {/* Operator Board launcher moved to the sidebar Services section (Kanban).
+          The ⌘B shortcut (main.jsx) still jumps to #board. */}
       <button className="tb-cmdk" onClick={onCmdK}>
         {Icons.zap}<span>Quick actions</span>
         <kbd>⌘K</kbd>
@@ -250,38 +242,137 @@ function _navActive(route, param, id) {
   return false;
 }
 
-// ─── Sidebar ───
-function Sidebar({ route, param, onGo }) {
+// ─── NavList (shared accordion) ───
+// The single source of nav markup for both the desktop Sidebar and the mobile
+// NavDrawer — they used to duplicate the map (and a "never drift" comment), so
+// the accordion state lives here once. Parent rows with `children` collapse by
+// default; a child group is revealed when its parent is expanded. The section
+// you're currently in auto-expands (and re-opens whenever you navigate into it),
+// so endpoints/profiles + agent sub-links don't show until you open Slots/Agents.
+// `testPrefix` keeps the desktop ("nav-") and drawer ("nav-drawer-") test ids apart.
+function NavList({ route, param, onGo, testPrefix }) {
   const items = useNavItems();
+  // The active parent is the section whose route is currently showing. It drives
+  // auto-expand so navigating into a section always reveals its sub-links.
+  const activeParent = items.find(it => it.children && _navActive(route, param, it.id))?.id;
+  const [open, setOpen] = useStateC(() => (activeParent ? { [activeParent]: true } : {}));
+  useEffectC(() => {
+    if (activeParent) setOpen(o => (o[activeParent] ? o : { ...o, [activeParent]: true }));
+  }, [activeParent]);
+  const tid = (id) => testPrefix + id.replace(/\//g, "-");
   return (
-    <div className="sidebar">
-      <div className="sb-section">Navigate</div>
-      <div className="sb-list">
-        {items.map(it => (
+    <div className="sb-list">
+      {items.map(it => {
+        const expanded = !!open[it.id];
+        return (
           <React.Fragment key={it.id}>
             <div
-              className={"sb-row" + (_navActive(route, param, it.id) ? " active" : "")}
-              data-testid={"nav-" + it.id.replace(/\//g, "-")}
-              onClick={() => onGo(it.id)}
+              className={"sb-row" + (_navActive(route, param, it.id) ? " active" : "") + (it.children ? " has-children" : "")}
+              data-testid={tid(it.id)}
+              onClick={() => { if (it.children) setOpen(o => ({ ...o, [it.id]: true })); onGo(it.id); }}
             >
               {it.icon}
               <span className="lbl">{it.label}</span>
               {it.cnt !== undefined && <span className="cnt num">{it.cnt}</span>}
+              {it.children && (
+                <button
+                  className={"sb-caret" + (expanded ? " open" : "")}
+                  data-testid={tid(it.id) + "-toggle"}
+                  onClick={(e) => { e.stopPropagation(); setOpen(o => ({ ...o, [it.id]: !o[it.id] })); }}
+                  aria-label={(expanded ? "Collapse " : "Expand ") + it.label}
+                  aria-expanded={expanded}
+                >
+                  {Icons.chev}
+                </button>
+              )}
             </div>
-            {it.children && it.children.map(ch => (
+            {it.children && expanded && it.children.map(ch => (
               <div
                 key={ch.id}
                 className={"sb-row sb-sub" + (_navActive(route, param, ch.id) ? " active" : "")}
-                data-testid={"nav-" + ch.id.replace(/\//g, "-")}
+                data-testid={tid(ch.id)}
                 onClick={() => onGo(ch.id)}
               >
                 <span className="lbl">{ch.label}</span>
               </div>
             ))}
           </React.Fragment>
-        ))}
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── ServiceLinks (sidebar bottom) ───
+// A separate launch zone, pinned to the sidebar bottom below the spacer, away
+// from the app/config nav above. Holds the three sibling-service shortcuts:
+//   - Kanban    → the internal Operator Board (#board) — same target as ⌘B.
+//   - OpenWebUI → external chat UI, link host-derived by GET /api/config/urls.
+//   - Hermes    → external Hermes dashboard, likewise host-derived.
+// The external links come from `useConfigUrls`, whose backend resolves the
+// hostname from the *request* (loopback, LAN IP, mDNS, or proxy domain) — so
+// they resolve correctly on every install, not just this dev box. Each is gated
+// by its `*_enabled` flag (systemd unit active / public-URL configured); a row
+// is simply omitted when the service isn't reachable on this host.
+// `testPrefix` keeps desktop ("svc-") vs drawer ("svc-drawer-") ids apart;
+// `onLaunch` lets the mobile drawer close itself after a tap.
+function ServiceLinks({ onGo, onLaunch, testPrefix }) {
+  const cfg = useConfigUrls();
+  const owui = cfg.data?.openwebui_enabled ? (cfg.data.openwebui || "") : "";
+  const hermes = cfg.data?.hermes_enabled ? (cfg.data.hermes || "") : "";
+  return (
+    <div className="sb-services">
+      <div className="sb-section">Services</div>
+      <div className="sb-svc-list">
+        <div
+          className="sb-row sb-svc"
+          data-testid={testPrefix + "kanban"}
+          onClick={() => { onGo("board"); onLaunch && onLaunch(); }}
+        >
+          {Icons.board}
+          <span className="lbl">Kanban</span>
+        </div>
+        {owui && (
+          <a
+            className="sb-row sb-svc"
+            data-testid={testPrefix + "openwebui"}
+            href={owui}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => onLaunch && onLaunch()}
+          >
+            {Icons.chat}
+            <span className="lbl">OpenWebUI</span>
+            <span className="sb-svc-ext">{Icons.ext}</span>
+          </a>
+        )}
+        {hermes && (
+          <a
+            className="sb-row sb-svc"
+            data-testid={testPrefix + "hermes"}
+            href={hermes}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => onLaunch && onLaunch()}
+          >
+            {Icons.agent}
+            <span className="lbl">Hermes Dash</span>
+            <span className="sb-svc-ext">{Icons.ext}</span>
+          </a>
+        )}
       </div>
+    </div>
+  );
+}
+
+// ─── Sidebar ───
+function Sidebar({ route, param, onGo }) {
+  return (
+    <div className="sidebar">
+      <div className="sb-section">Navigate</div>
+      <NavList route={route} param={param} onGo={onGo} testPrefix="nav-" />
       <div className="sb-spacer" />
+      <ServiceLinks onGo={onGo} testPrefix="svc-" />
     </div>
   );
 }
@@ -666,7 +757,6 @@ if (typeof document !== "undefined" && !document.getElementById("hal0-modal-css"
 // from the topbar on mobile) and the full nav (useNavItems). Opened from the topbar hamburger; closed via backdrop,
 // the X, Esc, or navigating.
 function NavDrawer({ open, route, param, onGo, onClose, onCmdK }) {
-  const items = useNavItems();
   return (
     <>
       <div
@@ -689,32 +779,9 @@ function NavDrawer({ open, route, param, onGo, onClose, onCmdK }) {
         <button className="nav-drawer-cmdk" onClick={onCmdK}>
           {Icons.zap}<span>Quick actions</span><kbd>⌘K</kbd>
         </button>
-        <div className="sb-list">
-          {items.map(it => (
-            <React.Fragment key={it.id}>
-              <div
-                className={"sb-row" + (_navActive(route, param, it.id) ? " active" : "")}
-                data-testid={"nav-drawer-" + it.id.replace(/\//g, "-")}
-                onClick={() => onGo(it.id)}
-              >
-                {it.icon}
-                <span className="lbl">{it.label}</span>
-                {it.cnt !== undefined && <span className="cnt num">{it.cnt}</span>}
-              </div>
-              {it.children && it.children.map(ch => (
-                <div
-                  key={ch.id}
-                  className={"sb-row sb-sub" + (_navActive(route, param, ch.id) ? " active" : "")}
-                  data-testid={"nav-drawer-" + ch.id.replace(/\//g, "-")}
-                  onClick={() => onGo(ch.id)}
-                >
-                  <span className="lbl">{ch.label}</span>
-                </div>
-              ))}
-            </React.Fragment>
-          ))}
-        </div>
+        <NavList route={route} param={param} onGo={onGo} testPrefix="nav-drawer-" />
         <div className="sb-spacer" />
+        <ServiceLinks onGo={onGo} onLaunch={onClose} testPrefix="svc-drawer-" />
         </>)}
       </aside>
     </>

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -315,12 +315,41 @@ a { color: inherit; text-decoration: none; }
   background: var(--bg-2);
 }
 .sb-row.active .cnt { background: var(--accent-soft); color: var(--accent); }
-/* v0.5 nav: sub-links under Slots / Agent (always shown). Their text starts at
-   the centre of the parent's icon: row padding 10px + half the 16px icon = 18px. */
+/* v0.5 nav: sub-links under Slots / Agent. Accordion: hidden until the parent
+   row is expanded (the active section auto-opens). Their text starts at the
+   centre of the parent's icon: row padding 10px + half the 16px icon = 18px. */
 .sb-row.sb-sub { padding-left: 18px; font-size: 12.5px; color: var(--fg-3); }
 .sb-row.sb-sub .lbl { font-weight: 400; }
 .sb-row.sb-sub:hover { color: var(--fg); }
 .sb-row.sb-sub.active { color: var(--fg); }
+/* Accordion caret on parent rows — a flat button that toggles its sub-links
+   without triggering the row's own navigation (click handler stops propagation). */
+.sb-row.has-children .lbl { flex: 1; }
+.sb-caret {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 20px; height: 20px; margin: -4px -4px -4px 2px; padding: 0;
+  background: transparent; border: 0; border-radius: var(--rad-sm);
+  color: var(--fg-4); cursor: pointer; flex-shrink: 0;
+}
+.sb-caret:hover { color: var(--fg); background: var(--bg-3); }
+.sb-caret svg { transition: transform 0.18s ease; transform: rotate(-90deg); }
+.sb-caret.open svg { transform: rotate(0deg); }
+.sb-row.active .sb-caret { color: var(--accent); }
+
+/* Services launch zone — pinned to the sidebar bottom (after .sb-spacer),
+   visually fenced off from the app/config nav above by a top divider. Holds
+   the Kanban (internal #board) + external OpenWebUI/Hermes shortcuts. */
+.sb-services { border-top: 1px solid var(--line); padding-bottom: 8px; }
+.sb-services .sb-section { padding-top: 10px; }
+/* Distinct from .sb-list so test/nav selectors targeting the main nav list
+   stay unambiguous; same flex-column layout. */
+.sb-svc-list { display: flex; flex-direction: column; gap: 1px; padding: 0 8px; }
+.sb-row.sb-svc { color: var(--fg-2); text-decoration: none; }
+.sb-row.sb-svc:hover { background: var(--bg-2); color: var(--fg); }
+.sb-row.sb-svc .lbl { flex: 1; }
+/* The ↗ external-link glyph sits muted at the row's trailing edge. */
+.sb-row.sb-svc .sb-svc-ext { display: inline-flex; color: var(--fg-5); }
+.sb-row.sb-svc:hover .sb-svc-ext { color: var(--fg-3); }
 
 .sb-spacer { flex: 1; }
 .sb-status {
@@ -1870,6 +1899,9 @@ select.npu-sel {
 @media (max-width: 1080px) {
   :root { --sidebar-w: 56px; }
   .sidebar .lbl, .sidebar .cnt, .sidebar .sb-section, .sb-status { display: none; }
+  /* Rail mode has no labels, so the accordion caret + label-only sub-rows have
+     nothing to show — hide them and keep the rail to single parent glyphs. */
+  .sidebar .sb-caret, .sidebar .sb-row.sb-sub, .sidebar .sb-svc-ext { display: none; }
   .sidebar .sb-row { justify-content: center; }
   .tb-brand { width: calc(56px - 18px); justify-content: center; }
   .tb-brand .ver { display: none; }

--- a/ui/tests/e2e/specs/board-render-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-render-v3.spec.ts
@@ -2,7 +2,7 @@
  * board-render-v3 — Operator Board render contract.
  *
  * Covers:
- *   - Entry via #board hash, ⌘B shortcut, ⌘K palette, sidebar nav, .tb-board
+ *   - Entry via #board hash, ⌘B shortcut, ⌘K palette, sidebar nav, Services Kanban link
  *   - Populated board: 8 lanes, cards in correct lanes, card fields
  *   - Empty board: 8 lanes each with "no tasks" / empty sentinel
  *   - Show-archived toggle: board-lane-archived appears
@@ -75,10 +75,10 @@ test.describe('BoardView — render', () => {
     await expect(page.locator('[data-testid="board-view"]')).toBeVisible({ timeout: FIVE_S })
   })
 
-  test('entry via .tb-board topbar button', async ({ page }) => {
+  test('entry via sidebar Services Kanban link', async ({ page }) => {
     await page.goto('/')
     await page.waitForLoadState('domcontentloaded')
-    await page.locator('[data-testid="tb-board"]').click()
+    await page.locator('[data-testid="svc-kanban"]').click()
     await expect(page.locator('[data-testid="board-view"]')).toBeVisible({ timeout: FIVE_S })
   })
 

--- a/ui/tests/e2e/specs/memory-gate-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-gate-v3.spec.ts
@@ -43,8 +43,11 @@ test.describe('memory gate OFF (HAL0_MEMORY_ENABLED unset)', () => {
     await expect(navList.getByText('Models', { exact: true })).toBeVisible()
     // v0.5: the Agent nav item ALWAYS renders (the MCP sub-link is ungated).
     await expect(navList.locator('[data-testid="nav-agent"]')).toBeVisible()
+    // Accordion: sub-links are collapsed until the parent is expanded. Open the
+    // Agent section so its sub-links render.
+    await navList.locator('[data-testid="nav-agent-toggle"]').click()
     await expect(navList.locator('[data-testid="nav-mcp"]')).toBeVisible()
-    // ...but its gated Memory sub-link is gone.
+    // ...but its gated Memory sub-link is gone (absent whether collapsed or not).
     await expect(navList.locator('[data-testid="nav-memory"]')).toHaveCount(0)
   })
 

--- a/ui/tests/e2e/specs/memory-view-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-view-v3.spec.ts
@@ -142,6 +142,8 @@ test.describe('Memory view — Hindsight surface', () => {
 
   test('nav shows Memory item and routes to #memory', async ({ page }) => {
     await page.goto('/#dashboard')
+    // Accordion: the Memory sub-link sits under Agents, collapsed until opened.
+    await page.locator('[data-testid="nav-agent-toggle"]').click()
     const nav = page.locator('[data-testid="nav-memory"]')
     await expect(nav).toBeVisible()
     await nav.click()

--- a/ui/tests/e2e/specs/mobile-nav-v3.spec.ts
+++ b/ui/tests/e2e/specs/mobile-nav-v3.spec.ts
@@ -40,6 +40,10 @@ test.describe('Mobile nav drawer (≤720px)', () => {
       ).toBeVisible()
     }
     // v0.5 sub-link rows now carry data-testids (the drawer rows had none before).
+    // Accordion: they're collapsed until the parent is expanded, so open the
+    // Slots + Agents sections via their carets first.
+    await drawer.locator('[data-testid="nav-drawer-slots-toggle"]').click()
+    await drawer.locator('[data-testid="nav-drawer-agent-toggle"]').click()
     await expect(drawer.locator('[data-testid="nav-drawer-slots-endpoints"]')).toBeVisible()
     await expect(drawer.locator('[data-testid="nav-drawer-slots-profiles"]')).toBeVisible()
     await expect(drawer.locator('[data-testid="nav-drawer-memory"]')).toBeVisible()

--- a/ui/tests/e2e/specs/sidebar-accordion-v3.spec.ts
+++ b/ui/tests/e2e/specs/sidebar-accordion-v3.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * sidebar-accordion-v3 — sidebar nav accordion + bottom Services launch zone.
+ *
+ * Two behaviours pinned here:
+ *
+ *  1. Accordion — parent rows with sub-links (Slots ▸ Endpoints/Profiles,
+ *     Agents ▸ Memory/MCP) start COLLAPSED. The sub-links don't render until
+ *     the parent is opened (via its caret), and the section you navigate into
+ *     auto-expands. This is the "endpoints/profiles don't show until Slots is
+ *     clicked" contract.
+ *
+ *  2. Services zone — a separate group pinned to the sidebar bottom, fenced off
+ *     from the app/config nav above. Holds Kanban (internal #board) plus the
+ *     external OpenWebUI + Hermes shortcuts. The external links are resolved by
+ *     GET /api/config/urls, whose backend derives the hostname from the request
+ *     so they work on every install; each row is gated by its *_enabled flag.
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+
+const FIVE_S = 5_500
+
+// Mock /api/config/urls with both external services enabled so all three
+// Services rows render with install-derived hrefs.
+async function mockConfigUrls(page: import('@playwright/test').Page) {
+  await page.route('**/api/config/urls', (route) =>
+    json(route, {
+      api: 'http://hal0.example:8080',
+      openwebui: 'http://hal0.example:3001',
+      openwebui_enabled: true,
+      hermes: 'http://hal0.example:9119',
+      hermes_enabled: true,
+      comfyui: 'http://hal0.example:8188',
+    }),
+  )
+}
+
+test.describe('sidebar accordion', () => {
+  test('Slots/Agents sub-links are hidden until the parent is expanded', async ({ page }) => {
+    await page.goto('/#dashboard')
+    const sb = page.locator('.sidebar')
+    await expect(sb.locator('[data-testid="nav-slots"]')).toBeVisible({ timeout: FIVE_S })
+
+    // Collapsed by default on an unrelated route — sub-links absent.
+    await expect(sb.locator('[data-testid="nav-slots-endpoints"]')).toHaveCount(0)
+    await expect(sb.locator('[data-testid="nav-slots-profiles"]')).toHaveCount(0)
+    await expect(sb.locator('[data-testid="nav-mcp"]')).toHaveCount(0)
+
+    // Expand Slots via its caret → its sub-links appear; Agents stays closed.
+    await sb.locator('[data-testid="nav-slots-toggle"]').click()
+    await expect(sb.locator('[data-testid="nav-slots-endpoints"]')).toBeVisible()
+    await expect(sb.locator('[data-testid="nav-slots-profiles"]')).toBeVisible()
+    await expect(sb.locator('[data-testid="nav-mcp"]')).toHaveCount(0)
+
+    // Collapse again — sub-links go away.
+    await sb.locator('[data-testid="nav-slots-toggle"]').click()
+    await expect(sb.locator('[data-testid="nav-slots-endpoints"]')).toHaveCount(0)
+  })
+
+  test('navigating into a section auto-expands it', async ({ page }) => {
+    // Deep-link straight to a Slots sub-route: the parent must auto-open so the
+    // active sub-link is visible without a manual toggle.
+    await page.goto('/#slots/endpoints')
+    const sb = page.locator('.sidebar')
+    await expect(sb.locator('[data-testid="nav-slots-endpoints"]')).toBeVisible({ timeout: FIVE_S })
+    await expect(sb.locator('[data-testid="nav-slots-profiles"]')).toBeVisible()
+  })
+})
+
+test.describe('sidebar Services zone', () => {
+  test('renders Kanban + install-derived OpenWebUI/Hermes links', async ({ page }) => {
+    await mockConfigUrls(page)
+    await page.goto('/#dashboard')
+    const svc = page.locator('.sb-services')
+    await expect(svc).toBeVisible({ timeout: FIVE_S })
+
+    // Kanban is an internal nav (no href); OpenWebUI/Hermes are external <a>s
+    // whose href comes straight from the backend-resolved config URLs.
+    await expect(svc.locator('[data-testid="svc-kanban"]')).toBeVisible()
+    await expect(svc.locator('[data-testid="svc-openwebui"]')).toHaveAttribute(
+      'href',
+      'http://hal0.example:3001',
+    )
+    await expect(svc.locator('[data-testid="svc-hermes"]')).toHaveAttribute(
+      'href',
+      'http://hal0.example:9119',
+    )
+    // External links open in a new tab safely.
+    await expect(svc.locator('[data-testid="svc-openwebui"]')).toHaveAttribute('target', '_blank')
+    await expect(svc.locator('[data-testid="svc-openwebui"]')).toHaveAttribute('rel', /noopener/)
+  })
+
+  test('Kanban link routes to the Operator Board', async ({ page }) => {
+    await page.goto('/#dashboard')
+    await page.locator('[data-testid="svc-kanban"]').click()
+    await expect(page).toHaveURL(/#board/)
+    await expect(page.locator('[data-testid="board-view"]')).toBeVisible({ timeout: FIVE_S })
+  })
+
+  test('disabled services are omitted (no host:port fallback leaks)', async ({ page }) => {
+    // hermes disabled (loopback-only, no public URL) → its row must not render;
+    // OpenWebUI enabled → its row stays.
+    await page.route('**/api/config/urls', (route) =>
+      json(route, {
+        api: 'http://hal0.example:8080',
+        openwebui: 'http://hal0.example:3001',
+        openwebui_enabled: true,
+        hermes: '',
+        hermes_enabled: false,
+        comfyui: 'http://hal0.example:8188',
+      }),
+    )
+    await page.goto('/#dashboard')
+    const svc = page.locator('.sb-services')
+    await expect(svc.locator('[data-testid="svc-kanban"]')).toBeVisible({ timeout: FIVE_S })
+    await expect(svc.locator('[data-testid="svc-openwebui"]')).toBeVisible()
+    await expect(svc.locator('[data-testid="svc-hermes"]')).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## What

Two sidebar changes, plus an install-portability fix for service links.

### 1. Accordion nav
Slots ▸ Endpoints/Profiles and Agents ▸ Memory/MCP sub-links now collapse into
an accordion — they stay hidden until the parent row is opened via its caret
(chevron rotates), and the section you navigate into auto-expands. Factored a
shared `NavList` component so the desktop `Sidebar` and mobile `NavDrawer` can
no longer drift (they previously duplicated the nav markup behind a "never
drift" comment).

### 2. Services launch zone
A separate group pinned to the sidebar bottom, fenced off from the app/config
nav by a divider:
- **Kanban** → internal `#board` (moved off the TopBar — ⌘B still works)
- **OpenWebUI** + **Hermes Dash** → external shortcuts

### 3. Links work on every install
The external links come from the existing `useConfigUrls` → `GET /api/config/urls`,
whose backend (`_resolve_host`) derives the hostname from the *request* (localhost,
LAN IP, mDNS, or reverse-proxy domain) — nothing hardcoded. Each row is gated by
its `*_enabled` flag (systemd unit active / public URL set), so a service that
isn't reachable on a given install simply isn't shown.

## Tests
- New `sidebar-accordion-v3` spec: collapse/expand, auto-expand on deep link,
  install-derived Service hrefs, disabled-link omission.
- Updated `mobile-nav-v3`, `memory-gate-v3`, `memory-view-v3`, `board-render-v3`
  to expand parents before asserting sub-links / use the new Kanban entry.
- Full e2e suite green; build + typecheck clean.

## Note for reviewers
The same 5 files currently also appear in PR #891 (fix/hardware-gtt-total-live)
due to an accidental `git add -A` in a shared working tree. #891 should drop
them (restore to main) so it stays hardware-only; this PR is the canonical home
for the sidebar work. De-scope #891 before merging either to avoid a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)