### PR TITLE
feat(dashboard): edit model display name + curated type tags in edit pane

### DIFF
--- a/ui/src/dash/__tests__/model-types.test.mjs
+++ b/ui/src/dash/__tests__/model-types.test.mjs
@@ -1,0 +1,82 @@
+// Dependency-free tests for the model "type" tag helpers used by the
+// model edit pane (RecipeEditorModal).
+//
+// Run: node ui/src/dash/__tests__/model-types.test.mjs
+//
+// The edit pane lets operators flip a curated set of capability tags while
+// PRESERVING any provenance/quant tags the model already carries. These tests
+// pin the split (prefill) + merge (save) round-trip so a future refactor can't
+// silently clobber tags like `user-added`.
+
+import {
+  MODEL_TYPE_TAGS,
+  splitModelTags,
+  mergeModelTags,
+} from "../model-types.js";
+
+let failures = 0;
+const fail = (msg) => {
+  failures += 1;
+  console.error("  ✗ " + msg);
+};
+const eq = (a, b, msg) => {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    fail(`${msg} — expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`);
+  }
+};
+
+// ── split: prefill from a model's tags ──────────────────────────────
+{
+  const { selected, other } = splitModelTags(["user-added", "coder", "rocmfp4", "mtp"]);
+  eq(selected, ["mtp", "coder"], "split selects curated in canonical order");
+  eq(other, ["user-added", "rocmfp4"], "split preserves non-curated tags");
+}
+{
+  const { selected, other } = splitModelTags(undefined);
+  eq(selected, [], "split tolerates undefined tags (selected)");
+  eq(other, [], "split tolerates undefined tags (other)");
+}
+{
+  const { selected } = splitModelTags(["MTP"]); // wrong case is NOT curated
+  eq(selected, [], "split is case-sensitive — 'MTP' is not the curated 'mtp'");
+}
+
+// ── merge: save union, provenance-first, deduped ────────────────────
+{
+  eq(
+    mergeModelTags(["user-added", "coder"], ["coder", "mtp"]),
+    ["user-added", "coder", "mtp"],
+    "merge preserves provenance, adds new types, de-dupes overlap",
+  );
+}
+{
+  eq(mergeModelTags([], ["mtp"]), ["mtp"], "merge with no other tags = just types");
+}
+{
+  eq(mergeModelTags(["user-added"], []), ["user-added"], "merge with no types keeps provenance");
+}
+
+// ── round-trip: split then merge with the same selection is identity ─
+{
+  const tags = ["user-added", "coder", "strix"];
+  const { selected, other } = splitModelTags(tags);
+  // toggling nothing: merge(other, selected) preserves the original set
+  eq(
+    mergeModelTags(other, selected).sort(),
+    [...tags].sort(),
+    "split→merge round-trip preserves the full tag set",
+  );
+}
+
+// ── the curated set is what we expect ───────────────────────────────
+eq(
+  MODEL_TYPE_TAGS,
+  ["mtp", "moe", "tool-calling", "reasoning", "coder", "vision"],
+  "curated type set matches the agreed list",
+);
+
+if (failures) {
+  console.error(`\n${failures} assertion(s) failed`);
+  process.exit(1);
+}
+console.log("✓ model-types: all assertions passed");

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -14,6 +14,7 @@ import { useModels, useModelInspect, useModelUpdate, useModelDelete, usePullJob,
 import { useSlots } from '@/api/hooks/useSlots'
 import { useSettings } from '@/api/hooks/useSettings'
 import { useChatTemplates } from '@/api/hooks/useChatTemplates'
+import { MODEL_TYPE_TAGS, splitModelTags, mergeModelTags } from '@/dash/model-types.js'
 
 const { useState: useStateMM, useEffect: useEffectMM, useMemo: useMemoMM } = React;
 
@@ -262,6 +263,12 @@ function RecipeEditorModal({ open, onClose, model }) {
   const [ngl, setNgl] = useStateMM("");
   const [extra, setExtra] = useStateMM("");
   const [chatTemplate, setChatTemplate] = useStateMM("auto");
+  // Identity + types. `name` is the editable display name; `types` is the
+  // selected subset of MODEL_TYPE_TAGS; `otherTags` snapshots the model's
+  // non-curated tags so we can re-emit them verbatim on save (never clobber).
+  const [name, setName] = useStateMM("");
+  const [types, setTypes] = useStateMM([]);
+  const [otherTags, setOtherTags] = useStateMM([]);
 
   useEffectMM(() => {
     if (open && model) {
@@ -269,9 +276,16 @@ function RecipeEditorModal({ open, onClose, model }) {
       setNgl(init.n_gpu_layers != null ? String(init.n_gpu_layers) : "");
       setExtra(init.extra_args || "");
       setChatTemplate(init.chat_template ?? "auto");
+      setName(model.name || "");
+      const split = splitModelTags(model.tags);
+      setTypes(split.selected);
+      setOtherTags(split.other);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, model?.id]);
+
+  const toggleType = (tag) =>
+    setTypes(prev => prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]);
 
   if (!model) return null;
 
@@ -289,8 +303,21 @@ function RecipeEditorModal({ open, onClose, model }) {
     // Only persist a real template choice — 'auto' means GGUF-embedded, which
     // is the absence of an override, so don't pollute defaults with it.
     if (chatTemplate && chatTemplate !== "auto") defaults.chat_template = chatTemplate;
+    const body = { defaults };
+    // Display name: only persist a real, changed value — never blank it out.
+    const trimmedName = name.trim();
+    if (trimmedName && trimmedName !== (model.name || "")) body.name = trimmedName;
+    // Tags: union of preserved (non-curated) tags + selected types. Only
+    // emit when the set actually changed (order-insensitive) so a
+    // defaults-only save doesn't spuriously report a tag edit.
+    const nextTags = mergeModelTags(otherTags, types);
+    const prevTags = Array.isArray(model.tags) ? model.tags : [];
+    const sameTags =
+      nextTags.length === prevTags.length &&
+      [...nextTags].sort().join(" ") === [...prevTags].sort().join(" ");
+    if (!sameTags) body.tags = nextTags;
     try {
-      await update.mutateAsync({ id: model.id, body: { defaults } });
+      await update.mutateAsync({ id: model.id, body });
       window.__hal0Toast && window.__hal0Toast(`Updated ${model.longName || model.id}`, "ok");
       onClose();
     } catch (e) {
@@ -304,7 +331,7 @@ function RecipeEditorModal({ open, onClose, model }) {
     <Modal
       open={open}
       onClose={onClose}
-      eyebrow="Recipe · edit defaults"
+      eyebrow="Edit model · name, types & defaults"
       title={`Edit options · ${model.longName || model.name || model.id}`}
       width={560}
       foot={
@@ -319,6 +346,45 @@ function RecipeEditorModal({ open, onClose, model }) {
         </>
       }
     >
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>display name</span>
+          <span className="sub">what the dashboard shows · empty keeps the model id</span>
+        </div>
+        <div className="form-ctl">
+          <input
+            className="input"
+            data-testid="model-name-input"
+            placeholder={model.id}
+            value={name}
+            onChange={e => setName(e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>types</span>
+          <span className="sub">capability tags · drive routing &amp; slot features (e.g. mtp shows the slot MTP toggle)</span>
+        </div>
+        <div className="form-ctl" style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {MODEL_TYPE_TAGS.map(tag => {
+            const on = types.includes(tag);
+            return (
+              <button
+                key={tag}
+                type="button"
+                role="switch"
+                aria-checked={on}
+                data-testid={`type-toggle-${tag}`}
+                className={"mdl-chip" + (on ? " on" : "")}
+                onClick={() => toggleType(tag)}
+              >
+                {tag}
+              </button>
+            );
+          })}
+        </div>
+      </div>
       <div className="form-row">
         <div className="form-lbl">
           <span>context_size</span>

--- a/ui/src/dash/model-types.js
+++ b/ui/src/dash/model-types.js
@@ -1,0 +1,59 @@
+// Curated model "type" tags surfaced as toggles in the model edit pane.
+//
+// These are the operator-meaningful, behaviour-driving tags — distinct from
+// provenance tags (`user-added`, `curated`) and quant/arch markers
+// (`rocmfp4`, `strix`) that a model may also carry. The edit pane only lets
+// operators flip the curated set; everything else is preserved verbatim.
+//
+//   mtp          → gates the per-slot MTP toggle (rocm dense speculative decode)
+//   moe          → feeds the arbiter's is_moe context sizing
+//   tool-calling → chat/agent routing signal
+//   reasoning    → chat routing signal
+//   coder        → coder-slot auto-selection
+//   vision       → multimodal; normally GGUF-derived, toggle forces it on
+export const MODEL_TYPE_TAGS = [
+  "mtp",
+  "moe",
+  "tool-calling",
+  "reasoning",
+  "coder",
+  "vision",
+];
+
+/**
+ * Split a model's tag list into the curated types that are currently set and
+ * the remaining (non-curated) tags to preserve untouched.
+ *
+ * @param {string[]|undefined} tags
+ * @param {string[]} curated
+ * @returns {{ selected: string[], other: string[] }}
+ */
+export function splitModelTags(tags, curated = MODEL_TYPE_TAGS) {
+  const list = Array.isArray(tags) ? tags : [];
+  const curatedSet = new Set(curated);
+  return {
+    selected: curated.filter((t) => list.includes(t)),
+    other: list.filter((t) => !curatedSet.has(t)),
+  };
+}
+
+/**
+ * Recombine preserved (non-curated) tags with the operator's selected types
+ * into the tag list to persist. Provenance-first ordering keeps the PUT diff
+ * stable across saves, and de-dupes defensively.
+ *
+ * @param {string[]} otherTags  non-curated tags to preserve
+ * @param {string[]} selectedTypes  curated types the operator turned on
+ * @returns {string[]}
+ */
+export function mergeModelTags(otherTags, selectedTypes) {
+  const seen = new Set();
+  const out = [];
+  for (const t of [...(otherTags || []), ...(selectedTypes || [])]) {
+    if (!seen.has(t)) {
+      seen.add(t);
+      out.push(t);
+    }
+  }
+  return out;
+}

--- a/ui/tests/e2e/specs/model-edit-identity-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-edit-identity-v3.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * model-edit-identity-v3 — display name + curated type toggles in the
+ * model "Edit options" pane (RecipeEditorModal).
+ *
+ * The editor gains:
+ *   1. A display-name text input, prefilled from the model's `name`
+ *      (placeholder = model id), written to PUT /api/models/{id} as `name`
+ *      only when changed.
+ *   2. A curated row of type toggles (mtp, moe, tool-calling, reasoning,
+ *      coder, vision) prefilled from the model's `tags`, written back as a
+ *      `tags` union that preserves non-curated provenance tags. The union
+ *      logic itself is pinned by ../../src/dash/__tests__/model-types.test.mjs;
+ *      here we assert the UI wiring + the PUT contract end-to-end.
+ *
+ * The recipe editor auto-targets the first installed model exposed by the
+ * dashboard mock — `qwen3.6-27b-mtp` — mirroring model-recipe-template-v3.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+const CURATED = ['mtp', 'moe', 'tool-calling', 'reasoning', 'coder', 'vision']
+
+function mockChatTemplates(page: import('@playwright/test').Page) {
+  return page.route('**/api/chat-templates', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ id: 'auto', label: 'Auto (GGUF embedded)' }]),
+    }),
+  )
+}
+
+test.describe('Model edit — display name + type toggles', () => {
+  test('name input and all curated type toggles render', async ({ page }) => {
+    await mockChatTemplates(page)
+    await page.goto('/#models')
+    await page.locator('button:has-text("Edit options")').click()
+
+    const nameInput = page.getByTestId('model-name-input')
+    await expect(nameInput).toBeVisible()
+    // Placeholder falls back to the model id so the field is self-describing
+    // even when no display name is set.
+    await expect(nameInput).toHaveAttribute('placeholder', 'qwen3.6-27b-mtp')
+
+    for (const tag of CURATED) {
+      await expect(page.getByTestId(`type-toggle-${tag}`)).toBeVisible()
+    }
+  })
+
+  test('toggling a type flips its aria-checked state', async ({ page }) => {
+    await mockChatTemplates(page)
+    await page.goto('/#models')
+    await page.locator('button:has-text("Edit options")').click()
+
+    const mtp = page.getByTestId('type-toggle-mtp')
+    await expect(mtp).toHaveAttribute('aria-checked', 'false')
+    await mtp.click()
+    await expect(mtp).toHaveAttribute('aria-checked', 'true')
+  })
+
+  test('editing the name and toggling a type writes name + tags on Save', async ({ page }) => {
+    let putBody: any = null
+    await page.route('**/api/models/qwen3.6-27b-mtp', async (route) => {
+      if (route.request().method() === 'PUT') {
+        putBody = JSON.parse(route.request().postData() || '{}')
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: 'qwen3.6-27b-mtp',
+            name: putBody.name,
+            tags: putBody.tags,
+          }),
+        })
+      }
+      return route.fallback()
+    })
+    await mockChatTemplates(page)
+
+    await page.goto('/#models')
+    await page.locator('button:has-text("Edit options")').click()
+
+    await page.getByTestId('model-name-input').fill('My Renamed Qwen')
+    await page.getByTestId('type-toggle-mtp').click()
+    await page.locator('button:has-text("Save options")').click()
+
+    await expect.poll(() => putBody?.name).toBe('My Renamed Qwen')
+    await expect.poll(() => putBody?.tags).toContain('mtp')
+  })
+})


### PR DESCRIPTION
## What

The model **Edit options** pane (`RecipeEditorModal`) previously only edited launcher defaults (ctx / ngl / extra_args / chat_template). Display name and capability tags could only be set at *add* time.

This adds two controls, both backed by the existing `PUT /api/models/{id}` (no backend change):

- **Display name** input — prefilled from `name` (placeholder = model id). Persisted only when changed and non-empty; never blanks the name.
- **Types** — a curated row of toggle pills: `mtp`, `moe`, `tool-calling`, `reasoning`, `coder`, `vision`. Prefilled from `tags`. On save the tag list is a **union** that preserves non-curated provenance tags (`user-added`, quant markers like `rocmfp4`/`strix`) and is only emitted when the set actually changed.

## Why

This is the UI for the exact gap that hid the slot **MTP toggle**: locally-built GGUFs often carry `mtp` in the *id* but ship with an empty `tags` array, and the slot toggle gates on `tags.includes("mtp")`. Operators had no way to fix a model's tags from the dashboard — only a manual `PUT`. Now they can.

## Design notes

- Split/merge tag logic extracted to a dependency-free module `ui/src/dash/model-types.js` (curated set + `splitModelTags`/`mergeModelTags`), so the provenance-preservation invariant is unit-tested in isolation.
- `vision` is included per request even though it's normally GGUF-derived — lets operators force it on when detection missed it.

## Tests

- `model-types.test.mjs` — split/merge round-trip, provenance preservation, case-sensitivity, dedupe (dependency-free, `node`).
- `model-edit-identity-v3.spec.ts` — name input + 6 toggles render, toggle aria-checked flips, Save writes `name` + `tags` to PUT.
- Sibling `models-v3` / `model-recipe-template-v3` specs still green (11 passed); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)