### PR TITLE
fix(dashboard): route utility slots to the support footer by type, not group

### DIFF
--- a/docs/superpowers/plans/2026-06-19-type-driven-utility-routing.md
+++ b/docs/superpowers/plans/2026-06-19-type-driven-utility-routing.md
@@ -1,0 +1,317 @@
+# Type-Driven Utility Slot Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a slot card's dashboard placement (main engine grid vs. support footer) derive entirely from its capability `type`, and retire the redundant free-form `group` field so placement can never drift again.
+
+**Architecture:** The inference pane currently splits slots into headline vs. utility rows using a hand-set `group` string that can disagree with the slot's `type` (e.g. a `tts` slot created with the default `group:"chat"` wrongly lands in the main grid). Task 1 rewrites the split to key on `type`. Task 2 removes the now-vestigial `group` field from the create modal, skip-path layout, three incidental readers, and the CLI `add_slot` path. `group` is not a schema field — it rides as a Pydantic `extra:"allow"` passthrough (`src/hal0/config/schema.py:147`) — so removing it needs no migration and no backend test changes; existing on-disk TOMLs with a stray `group` key keep loading and are simply ignored.
+
+**Tech Stack:** Preact/JSX dashboard (`ui/src/dash/`), in-bundle mock data (`VITE_MOCK_HAL0=1`), Playwright e2e (`ui/tests/e2e/`), FastAPI + Pydantic backend (`src/hal0/`).
+
+## Global Constraints
+
+- Work happens in the worktree `/home/halo/dev/hal0-utility-routing` on branch `feat/type-driven-utility-routing` (isolated off `main`; two other sessions share the `fix/hardware-gtt-total-live` checkout). Do not `git checkout`/switch branches in `/home/halo/dev/hal0`.
+- The four utility capability types are exactly: `embedding`, `reranking`, `tts`, `transcription`. Image (`image`) is its own pane; LLM (`llm`) is a headline slot.
+- NPU and image slots are already cordoned off *before* the utility split (by `devKind(s.device) !== 'npu'` and the image filter); the type split only re-partitions the remaining iGPU/CPU slots.
+- Run UI e2e from `ui/`: `npx playwright test specs/<spec>.ts`. Run backend tests from repo root: `pytest <path> -v`.
+- End every commit message with: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Type-driven zone split in the inference pane
+
+The user-visible fix: a utility-type slot (e.g. the live `test-tts`) drops into the support footer regardless of its `group`. Frontend-only; independently shippable. We encode the footgun directly in the mock by mislabeling the `tts` slot's group, then prove `type` overrides it.
+
+**Files:**
+- Modify: `ui/src/dash/inference-pane.jsx` (lines 110-116, 575, 625, 633-639)
+- Modify: `ui/src/dash/data.jsx` (the `tts` slot, ~lines 208-219)
+- Modify (test): `ui/tests/e2e/specs/inference-pane-v3.spec.ts`
+
+**Interfaces:**
+- Produces: module-local `const UTIL_TYPES = new Set(['embedding','reranking','tts','transcription'])` and `function isUtil(s)` in `inference-pane.jsx`, replacing `UTIL_GROUPS` / `isUtilGroup`. No exports change; consumers are all in-file.
+
+- [ ] **Step 1: Mislabel the mock `tts` slot to encode the footgun**
+
+In `ui/src/dash/data.jsx`, the `tts` slot object (name `"tts"`, type `"tts"`) currently has `group: "voice"`. Change it to `group: "chat"` and add a comment so the intent is clear:
+
+```js
+      name: "tts",
+      type: "tts",
+      // …existing fields (port/model/state/device/metrics)…
+      group: "chat",   // intentionally MISLABELED: regression fixture — a tts
+                       // slot with a non-utility group must STILL route to the
+                       // util footer (placement is type-driven, not group-driven).
+```
+
+Leave every other field on the slot untouched.
+
+- [ ] **Step 2: Write the failing e2e assertion**
+
+In `ui/tests/e2e/specs/inference-pane-v3.spec.ts`, add a test inside the existing `test.describe('Inference engine pane (/slots · Inference tab)', …)` block. The util zone wraps in `data-testid="infer-util"`; each card (full or mini) renders `data-testid="infer-slot-<name>"`.
+
+```ts
+  test('utility-type slots route to the support footer regardless of group', async ({ page }) => {
+    await page.goto('/#slots')
+    await expect(pane(page)).toBeVisible()
+    const util = pane(page).getByTestId('infer-util')
+    await expect(util).toBeVisible()
+    // embed + rerank (util types) live in the footer…
+    await expect(util.getByTestId('infer-slot-embed')).toHaveCount(1)
+    await expect(util.getByTestId('infer-slot-rerank')).toHaveCount(1)
+    // …and the tts slot does too, EVEN THOUGH its mock group is "chat"
+    // (type-driven routing overrides the mislabeled group).
+    await expect(util.getByTestId('infer-slot-tts')).toHaveCount(1)
+    // it must NOT appear among the headline (full) cards.
+    await expect(body(page).locator('.scards.full').getByTestId('infer-slot-tts')).toHaveCount(0)
+  })
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+cd ui && npx playwright test specs/inference-pane-v3.spec.ts -g "route to the support footer"
+```
+Expected: FAIL — with group-based routing the `tts` slot (group `"chat"`) renders as a headline full card, so `util.getByTestId('infer-slot-tts')` resolves to 0 and the headline assertion finds 1.
+
+- [ ] **Step 4: Rewrite the predicate to key on `type`**
+
+In `ui/src/dash/inference-pane.jsx`, replace the `UTIL_GROUPS` block (lines 110-116):
+
+```js
+// Utility (support) slot types — the non-conversational tier that renders as
+// the compact mini-card row below the headline chat/agent cards. Placement is
+// derived from the slot's capability type, never a hand-set label, so a
+// mislabeled slot can't escape its tier. Anything else (llm) is a headline slot;
+// image is its own pane.
+const UTIL_TYPES = new Set(['embedding', 'reranking', 'tts', 'transcription'])
+function isUtil(s) {
+  return UTIL_TYPES.has(String(s?.type || '').toLowerCase())
+}
+```
+
+- [ ] **Step 5: Switch the image filters and the tier split to `type`**
+
+In `ui/src/dash/inference-pane.jsx`, the two identical image-filter lines (575 in `InferenceHeroBand`, 625 in `InferencePane`):
+
+```js
+  const nonImg = allSlots.filter((s) => String(s.type) !== 'image')
+```
+(replacing `(s.group || '') !== 'img'` in both places).
+
+Then update the tier split (lines 633-639):
+
+```js
+  // Tier split — headline = the conversational LLM slots; utility = the support
+  // slots (embed / rerank / tts / transcription). Keyed off slot.type so the
+  // split can't be thrown off by a mislabeled group. This pane is always
+  // expanded (no accordion), so the utility tier shows ALL its slots; the live
+  // count drives the SubLabel note.
+  const headlineRows = rows.filter((r) => !isUtil(r.s))
+  const utilRows = rows.filter((r) => isUtil(r.s))
+```
+
+- [ ] **Step 6: Run the new test to verify it passes**
+
+```bash
+cd ui && npx playwright test specs/inference-pane-v3.spec.ts -g "route to the support footer"
+```
+Expected: PASS.
+
+- [ ] **Step 7: Run the full inference-pane spec to confirm no regression**
+
+```bash
+cd ui && npx playwright test specs/inference-pane-v3.spec.ts
+```
+Expected: PASS — the existing seed's groups already agree with their types, so headline/util membership is unchanged for every other slot (`primary`/`legacy` headline; `embed`/`rerank` util; `agent`/`stt-npu`/`embed-npu` NPU-cordoned by device; `img` in the image pane).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/halo/dev/hal0-utility-routing
+git add ui/src/dash/inference-pane.jsx ui/src/dash/data.jsx ui/tests/e2e/specs/inference-pane-v3.spec.ts
+git commit -m "fix(dashboard): route utility slots to the support footer by type, not group
+
+The inference pane split headline vs. utility cards on a hand-set \`group\`
+string that can disagree with the slot's type — a tts slot created with the
+default group=chat wrongly landed in the main engine grid. Derive the split
+(and the image filter) from slot.type instead. Mock fixture mislabels the tts
+slot group=chat as a regression guard.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Retire the `group` field
+
+Pure cleanup now that nothing routes on `group`. Removes the create-modal dropdown, the skip-path group sectioning (re-derived from `type`), three incidental readers, and the CLI `add_slot` write. Independently reviewable: a reviewer could accept Task 1's fix while rejecting this cleanup.
+
+**Files:**
+- Modify: `ui/src/dash/slot-modals.jsx` (state 96 & 110; POST body 160; dropdown 290-304; `EmptySlotCard` 1279 & 1289-1293)
+- Modify: `ui/src/dash/slots.jsx` (skip-path `SEEDED` 589-596; `seededByGroup` 632-637; `EmptySlotCard` call 661-668)
+- Modify: `ui/src/dash/quickchat-card.jsx` (`isChatCapable` 89-96)
+- Modify: `ui/src/dash/connections.jsx` (`slotGroup` 140-148)
+- Modify: `ui/src/dash/command-palette.jsx` (keywords 256)
+- Modify: `src/hal0/slots/manager.py` (`add_slot` signature 1497; docstring 1516; cfg dict 1545)
+
+**Interfaces:**
+- Consumes: `isUtil` / `UTIL_TYPES` from Task 1 (no direct call, but the type-driven routing is the reason `group` is now dead).
+- Produces: a module-local `SECTION_FOR_TYPE` map in `slots.jsx` mapping `type → 'chat'|'embed'|'voice'|'img'` for the skip-path layout. `EmptySlotCard` loses its `group` prop. `add_slot` loses its `group` keyword arg.
+
+- [ ] **Step 1: Re-grep for any `slot.group` readers added since planning**
+
+```bash
+cd /home/halo/dev/hal0-utility-routing
+grep -rn "\.group\b\|[\"']group[\"']" ui/src --include=*.jsx --include=*.js | grep -v node_modules
+grep -rn "\bgroup\b" src/hal0/slots/manager.py
+```
+Expected: only the sites listed in this task plus unrelated matches (`extras.jsx` log groups, `activity-log.jsx` ARIA `role="group"`, `arbiter.py`/`manager.py:2167,2171` image *exclusive group*). If a new slot-rollup `group` reader appears, convert it to `type` the same way before continuing.
+
+- [ ] **Step 2: Remove the `group` dropdown, state, and POST field from the create modal**
+
+In `ui/src/dash/slot-modals.jsx`:
+- Delete the state declaration (line 96): `const [group, setGroup] = useStateSM(defaults.group || "chat");`
+- Delete the reset line inside the `open` effect (line 110): `setGroup(defaults.group || "chat");`
+- Delete the `group,` line from the POST `body` object (line 160).
+- Delete the entire `<div className="form-row">` for the Group select (lines 290-304, the block containing `<span>Group</span>` … `</select>`).
+
+- [ ] **Step 3: Drop `group` from `EmptySlotCard`**
+
+In `ui/src/dash/slot-modals.jsx`, change the signature (line 1279) from `function EmptySlotCard({ name, type, group, device, onConfigure })` to `function EmptySlotCard({ name, type, device, onConfigure })`, and delete the group chip line (1292): `<span className="chip">{group}</span>`. The `type` chip (1290) already shows the real category.
+
+- [ ] **Step 4: Re-derive the skip-path sections from `type` in `slots.jsx`**
+
+In `ui/src/dash/slots.jsx`, replace the `SEEDED` array (lines 589-596) — drop each `group:` key — and add a type→section map just above it:
+
+```js
+  // Seeded slot identities for the skip-path empty layout. Section membership
+  // is derived from the capability type (mirrors the live pane's type-driven
+  // split), so seeded cards never disagree with their type.
+  const SECTION_FOR_TYPE = {
+    llm: "chat", embedding: "embed", reranking: "embed",
+    transcription: "voice", tts: "voice", image: "img",
+  };
+  const SEEDED = [
+    { name: "primary", type: "llm",           device: "gpu-rocm" },
+    { name: "embed",   type: "embedding",     device: "gpu-rocm" },
+    { name: "rerank",  type: "reranking",     device: "gpu-rocm" },
+    { name: "stt",     type: "transcription", device: "cpu"      },
+    { name: "tts",     type: "tts",           device: "cpu"      },
+    { name: "img",     type: "image",         device: "gpu-rocm" },
+  ];
+```
+
+Then change `seededByGroup` (lines 632-637) to bucket by derived section:
+
+```js
+    const seededByGroup = {
+      chat:  SEEDED.filter(s => SECTION_FOR_TYPE[s.type] === "chat"),
+      embed: SEEDED.filter(s => SECTION_FOR_TYPE[s.type] === "embed"),
+      voice: SEEDED.filter(s => SECTION_FOR_TYPE[s.type] === "voice"),
+      img:   SEEDED.filter(s => SECTION_FOR_TYPE[s.type] === "img"),
+    };
+```
+
+And in the `EmptySlotCard` call (lines 661-668), drop the `group={c.group}` prop and the `group: c.group` key from the `openCreatePrefilled` argument:
+
+```js
+                      <EmptySlotCard
+                        key={c.name}
+                        name={c.name}
+                        type={c.type}
+                        device={c.device}
+                        onConfigure={() => openCreatePrefilled({ name: c.name, type: c.type, device: c.device })}
+                      />
+```
+
+- [ ] **Step 5: Drop the vestigial `group` fallback in `quickchat-card.jsx`**
+
+In `ui/src/dash/quickchat-card.jsx`, `isChatCapable` (lines 89-96). `type === 'llm'` already covers every chat slot, so the `g === 'chat'` branch is dead. Remove the `g` line and the branch:
+
+```js
+function isChatCapable(slot) {
+  if (slot._synthetic) return false
+  const t = (slot.type ?? '').toLowerCase()
+  const chatType = t === 'llm' || t === 'chat'
+  const liveState = slot.state === 'serving' || slot.state === 'ready'
+  return chatType && liveState
+}
+```
+
+- [ ] **Step 6: Drop the `group` fallback in `connections.jsx`**
+
+In `ui/src/dash/connections.jsx`, `slotGroup` (lines 140-148) already maps every real `type` before the `group` fallback at line 146. Remove that line so the function is type-only:
+
+```js
+function slotGroup(s) {
+  const t = s.type
+  if (t === 'llm') return 'chat'
+  if (t === 'embedding' || t === 'reranking') return 'embed'
+  if (t === 'image') return 'img'
+  if (t === 'tts' || t === 'transcription') return 'voice'
+  return 'chat'
+}
+```
+
+- [ ] **Step 7: Drop `group` from the command-palette search keywords**
+
+In `ui/src/dash/command-palette.jsx` line 256, remove the `s.group` term:
+
+```js
+      keywords: `${s.type} ${s.device}`,
+```
+
+- [ ] **Step 8: Remove `group` from the CLI `add_slot` path**
+
+In `src/hal0/slots/manager.py`:
+- Delete the `group: str = "custom",` parameter from the `add_slot` signature (line 1497).
+- Delete the `group:` line from the docstring Args block (line 1516).
+- Delete the `"group": group,` entry from the `cfg` dict (line 1545).
+
+The API create route (`src/hal0/api/routes/slots.py:create_slot`) calls `sm.create(name, body)` directly and does not reference `group`, so it needs no change — once the modal (Step 2) stops sending `group`, new slots simply omit it.
+
+- [ ] **Step 9: Run the backend slot tests**
+
+```bash
+cd /home/halo/dev/hal0-utility-routing && pytest tests/slots/test_manager.py -v
+```
+Expected: PASS. The `add_slot` callers in this file (lines 196, 214, 221, 239, 245, 247, 264) pass no `group=` argument, and no test asserts the slot `group` field (all `group` matches in the suite are `coresident_group`/`cgroup`).
+
+- [ ] **Step 10: Run the affected UI e2e specs**
+
+```bash
+cd ui && npx playwright test specs/inference-pane-v3.spec.ts specs/slots-v3.spec.ts specs/slots-wireup-v3.spec.ts specs/settings-default-slots-v3.spec.ts
+```
+Expected: PASS. If any spec asserts the removed Group `<select>` or an `EmptySlotCard` group chip, update that assertion to drop the group expectation (the field no longer exists) — do not re-add `group`.
+
+- [ ] **Step 11: Final sweep — no live `slot.group` readers remain**
+
+```bash
+cd /home/halo/dev/hal0-utility-routing
+grep -rn "\.group\b\|setGroup\|defaults.group\|c.group\|s.group" ui/src --include=*.jsx --include=*.js | grep -v node_modules
+```
+Expected: only `extras.jsx` (log-line groups) and `activity-log.jsx` (ARIA role) remain — no slot-rollup `group` readers.
+
+- [ ] **Step 12: Commit**
+
+```bash
+cd /home/halo/dev/hal0-utility-routing
+git add ui/src/dash/slot-modals.jsx ui/src/dash/slots.jsx ui/src/dash/quickchat-card.jsx ui/src/dash/connections.jsx ui/src/dash/command-palette.jsx src/hal0/slots/manager.py
+git commit -m "refactor(slots): retire the redundant slot \`group\` field
+
+Placement and routing are now derived entirely from slot.type (see prior
+commit). Remove the free-form \`group\`: the create-modal dropdown, the
+skip-path sectioning (re-derived from type), the vestigial group fallbacks in
+quickchat/connections/command-palette, and the CLI add_slot write. \`group\`
+was never a schema field (extra=allow passthrough), so on-disk TOMLs carrying
+it still load and are ignored — no migration needed.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Notes for the implementer
+
+- After both tasks, run `graphify update .` from the worktree root to refresh the knowledge graph (AST-only, no API cost), per repo convention.
+- Do not seed iGPU utility slots (the original Idea A): embed/rerank already default to the iGPU, and tts (kokoro) / stt (FastFlowLM) have no iGPU runtime — explicitly out of scope.

--- a/docs/superpowers/specs/2026-06-19-type-driven-utility-routing-design.md
+++ b/docs/superpowers/specs/2026-06-19-type-driven-utility-routing-design.md
@@ -1,0 +1,156 @@
+# Type-driven utility slot routing
+
+**Date:** 2026-06-19
+**Branch:** `feat/type-driven-utility-routing` (worktree off `main`)
+**Status:** approved design
+
+## Problem
+
+On the inference dashboard, slot cards are split into two zones:
+
+- **Main engine grid** — conversational LLM cards (chat / agent), full-size with metrics.
+- **Support footer** ("utility · embed · rerank · voice") — compact mini-cards for the non-conversational tier.
+
+Which zone a card lands in is decided by a free-form `group` field, not by the
+slot's capability `type`:
+
+```js
+// ui/src/dash/inference-pane.jsx:113-116
+const UTIL_GROUPS = new Set(['embed', 'rerank', 'tts', 'stt', 'voice'])
+function isUtilGroup(group) {
+  return UTIL_GROUPS.has(String(group || '').toLowerCase())
+}
+// :638-639
+const headlineRows = rows.filter((r) => !isUtilGroup(r.s.group))
+const utilRows     = rows.filter((r) =>  isUtilGroup(r.s.group))
+```
+
+`group` is a separate dropdown in the create modal (`chat / embed / voice /
+img / custom`, slot-modals.jsx:296), set independently of **Type**, defaulting
+to `"chat"` in the modal (slot-modals.jsx:96) and `"custom"` in the backend
+(manager.py:1516,1545). The backend stores it verbatim — it is **not** derived
+from `type`.
+
+**Symptom:** a slot created with `Type=tts` but the default `group="chat"`
+(e.g. the live `test-tts` slot) renders in the main engine grid instead of the
+support footer. A slot's nature already lives in `type`; the layout decision was
+wired to a second, hand-set field that can disagree with it. Two fields that
+should never diverge, can.
+
+## Goal
+
+A slot's dashboard placement is derived **entirely** from its capability
+`type`. The redundant `group` field is retired so placement can never drift
+again.
+
+## Non-goals
+
+- **Seeding iGPU utility slots for all four capabilities (rejected).** Embed and
+  rerank already seed to the iGPU (rerank → `gpu-vulkan`, embed →
+  `gpu-vulkan/rocm`; `installer/etc-hal0/slots/*.toml`). TTS (kokoro) and STT
+  (FastFlowLM) have no iGPU runtime in this stack — the non-NPU alternative for
+  STT is CPU whisper, not the iGPU; TTS is CPU-only. Seeding dormant iGPU
+  tts/stt slots would add clutter for zero new capability. Out of scope.
+- No backend routing / `default_slot_for` changes. `group` is a UI-only rollup;
+  request routing already keys on `type` + `default` (manager.py:1432-1448) and
+  is unaffected.
+
+## Design
+
+### 1. Type-driven split (ui/src/dash/inference-pane.jsx)
+
+Replace the `group`-keyed predicate with a `type`-keyed one:
+
+```js
+const UTIL_TYPES = new Set(['embedding', 'reranking', 'tts', 'transcription'])
+const isUtil = (s) => UTIL_TYPES.has(String(s.type || '').toLowerCase())
+```
+
+- `headlineRows` = `!isUtil(s)` and not image → chat/agent LLM cards (main grid)
+- `utilRows`     = `isUtil(s)` → support footer
+- The two image filters (inference-pane.jsx:575, 625) switch from
+  `(s.group || '') !== 'img'` to `String(s.type) !== 'image'`.
+
+Effect: any utility-type slot lands in the footer regardless of how it was
+created. The existing `test-tts` slot moves down automatically — no migration,
+no user action.
+
+### 2. Retire the `group` field
+
+- **Create modal (ui/src/dash/slot-modals.jsx):** remove the `group` dropdown
+  (296), the `group` / `setGroup` state (96, 110), and `group` from the POST
+  body (160).
+- **EmptySlotCard (slot-modals.jsx:1279, 1292):** the placeholder chip shows
+  `type` instead of `group` (type is now the real category). Drop the `group`
+  prop.
+- **Skip-path seeded list (ui/src/dash/slots.jsx:588-596):** drop the `group`
+  key from each `SEEDED` entry; callers that pre-fill the modal pass `type`
+  only.
+- **Backend (src/hal0/slots/manager.py):** `add_slot` stops requiring and
+  writing `group` (1497, 1516, 1545). Serialization drops the `group` key.
+  Loading a TOML that still carries a stray `group` key is tolerated (ignored),
+  so existing on-disk slots upgrade cleanly.
+
+### 2a. Other `slot.group` readers (full inventory)
+
+Every remaining reader already prefers `type`; `group` is a vestigial fallback
+in each, so retiring it is a removal, not a rewrite:
+
+| File:line | Current use | Disposition |
+|---|---|---|
+| `inference-pane.jsx:575,625,638,639` | zone split + img filter | rewritten to `type` (§1) |
+| `slot-modals.jsx:96,110,160,296` | modal state + dropdown + POST | removed (§2) |
+| `slot-modals.jsx:1279,1292` | EmptySlotCard chip | show `type` (§2) |
+| `slots.jsx:633-636,666,667` | skip-path SEEDED grouping | drop `group`, derive from `type` (§2) |
+| `quickchat-card.jsx:89-95` | `isChatCapable`: `g==='chat'` OR `t==='llm'` | drop the `g==='chat'` fallback; `type==='llm'` already covers it |
+| `connections.jsx:140-148` | `slotGroup`: type-first, group as last resort (146) | drop line 146 fallback; every real type maps before it |
+| `command-palette.jsx:256` | search keyword `${s.group||""}` | drop the `group` term |
+
+**Not affected** (different `group` concept, left untouched): `extras.jsx`
+(log-line groups), `activity-log.jsx` (ARIA `role="group"`), and
+`manager.py:2167,2171` (the image *exclusive group* / idle-restore mechanism,
+keyed on `type==='image'`/device, not the slot rollup attribute).
+
+### 3. Compatibility
+
+- Old slot TOMLs and `state.json` may carry `group` — these are ignored on
+  load, never written back. No migration step required.
+- Seeded slot catalog (`SEEDED_SLOTS`, manager.py:70) is unchanged; only the
+  per-slot `group` attribute is dropped.
+
+## Data flow
+
+```
+create modal (type, profile, model, device)   ← no `group`
+        │  POST /api/slots
+        ▼
+manager.add_slot(...)                          ← no `group` written
+        │  slot serialized with `type`
+        ▼
+GET /api/slots → UI
+        │
+inference-pane: isUtil(s) keyed on s.type
+        ├─ true  → support footer (MiniCard)
+        └─ false → main engine grid (SlotCard) / image pane (type==='image')
+```
+
+## Testing
+
+- **Backend:** update `tests/config/test_profiles.py`,
+  `tests/api/test_profiles_route.py`, and any slot-create test asserting
+  `group`; add a test that `add_slot` ignores/omits `group` and that a TOML
+  carrying a stray `group` loads without error.
+- **Frontend e2e:** add a case to the inference-pane util-zone spec asserting a
+  `tts`-type slot with a non-utility group (or no group) renders in `utilRows`,
+  not the main grid. Update existing specs that assert the `group` chip on empty
+  cards to assert `type`.
+
+## Risks
+
+- All current `slot.group` readers are inventoried in §2a; each already keys on
+  `type` with `group` as a fallback, so the change is low-risk. Re-grep
+  `\.group` / `"group"` / `'group'` across `ui/` and `tests/` during
+  implementation to catch anything added since.
+- Two live sessions share the `fix/hardware-gtt-total-live` checkout; this work
+  is isolated in the `feat/type-driven-utility-routing` worktree off `main` to
+  avoid colliding with their uncommitted changes.

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1494,7 +1494,6 @@ class SlotManager:
         type: str,
         model: str,
         device: str = "gpu-rocm",
-        group: str = "custom",
         port: int = 8081,
     ) -> Slot:
         """Programmatic ``hal0 slot add`` (plan §4.3).
@@ -1513,7 +1512,6 @@ class SlotManager:
             device: Hardware preference (``gpu-rocm | gpu-vulkan | cpu
                 | npu``); see ``map_backend_to_device``. Default
                 ``gpu-rocm`` matches Strix Halo seed semantics.
-            group: Dashboard rollup group (default ``custom``).
             port: SlotConfig.port — the container's loopback port.
         """
         if not _SLOT_NAME_RE.match(name):
@@ -1542,7 +1540,6 @@ class SlotManager:
             "device": device,
             "provider": "llama-server",
             "enabled": True,
-            "group": group,
             "model": {"default": model},
         }
         return await self.create(name, cfg)

--- a/ui/src/dash/command-palette.jsx
+++ b/ui/src/dash/command-palette.jsx
@@ -253,7 +253,7 @@ function buildCommandItems(slots, models, activePull, owuiUrl = "") {
       icon: <span className={"dot " + s.state} style={{display: "inline-block"}} />,
       sub: `${s.model || "—"} · ${s.type} · ${s.device}${isDefault ? " · default" : ""}`,
       tag: s.state === "serving" ? <span className="chip amber">{s.state}</span> : null,
-      keywords: `${s.type} ${s.device} ${s.group || ""}`,
+      keywords: `${s.type} ${s.device}`,
       hint: "open edit drawer",
     });
   });

--- a/ui/src/dash/connections.jsx
+++ b/ui/src/dash/connections.jsx
@@ -143,7 +143,6 @@ function slotGroup(s) {
   if (t === 'embedding' || t === 'reranking') return 'embed'
   if (t === 'image') return 'img'
   if (t === 'tts' || t === 'transcription') return 'voice'
-  if (['chat', 'embed', 'img', 'voice'].includes(s.group)) return s.group
   return 'chat'
 }
 function isStt(s) {

--- a/ui/src/dash/connections.jsx
+++ b/ui/src/dash/connections.jsx
@@ -134,9 +134,8 @@ function epState(s) {
   return 'idle'
 }
 
-// Slot → the OpenAI route family. Prefer the slot `type` (a true modality)
-// over `group` — the latter can be a device bucket (e.g. "npu") rather than a
-// modality. Fall back to an explicit chat|embed|img|voice group, else chat.
+// Slot → the OpenAI route family. Maps the slot `type` (a true modality) onto
+// a route family; any unrecognised type defaults to chat.
 function slotGroup(s) {
   const t = s.type
   if (t === 'llm') return 'chat'

--- a/ui/src/dash/data.jsx
+++ b/ui/src/dash/data.jsx
@@ -216,7 +216,9 @@ const HAL0_DATA = {
       model: "kokoro-v1",
       model_id: "kokoro-v1",
       modelLong: "hexgrad/Kokoro-82M",
-      group: "voice",
+      group: "chat",   // intentionally MISLABELED: regression fixture — a tts
+                       // slot with a non-utility group must STILL route to the
+                       // util footer (placement is type-driven, not group-driven).
       state: "ready",
       isDefault: true,
       cpuOnly: true,

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -574,7 +574,7 @@ export function InferenceHeroBand() {
   const mm = useMemoryMapModel()
 
   const allSlots = slotsQuery.data || []
-  const nonImg = allSlots.filter((s) => String(s.type) !== 'image')
+  const nonImg = allSlots.filter((s) => String(s?.type) !== 'image')
   const slots = nonImg.filter((s) => devKind(s.device) !== 'npu')
   const rows = slots.map((s) => ({ s, ind: slotIndicatorFromPhase(s) }))
   const servingN = rows.filter((r) => r.ind.cls === 'serving').length
@@ -624,7 +624,7 @@ export function InferencePane() {
   // own pane (ComfyuiPane); NPU/FLM slots are cordoned off to the NPU · FLM
   // stack pane below — they appear here only as the sec-label FLM count.
   const allSlots = slotsQuery.data || []
-  const nonImg = allSlots.filter((s) => String(s.type) !== 'image')
+  const nonImg = allSlots.filter((s) => String(s?.type) !== 'image')
   const slots = nonImg.filter((s) => devKind(s.device) !== 'npu')
   const npuN = nonImg.length - slots.length
 

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -107,12 +107,14 @@ function devKind(device) {
   return 'cpu'
 }
 
-// Utility (support) slot groups — the non-conversational tier that renders as
-// the compact mini-card row below the headline chat/agent cards. Anything else
-// (chat/agent LLMs) is a headline slot.
-const UTIL_GROUPS = new Set(['embed', 'rerank', 'tts', 'stt', 'voice'])
-function isUtilGroup(group) {
-  return UTIL_GROUPS.has(String(group || '').toLowerCase())
+// Utility (support) slot types — the non-conversational tier that renders as
+// the compact mini-card row below the headline chat/agent cards. Placement is
+// derived from the slot's capability type, never a hand-set label, so a
+// mislabeled slot can't escape its tier. Anything else (llm) is a headline slot;
+// image is its own pane.
+const UTIL_TYPES = new Set(['embedding', 'reranking', 'tts', 'transcription'])
+function isUtil(s) {
+  return UTIL_TYPES.has(String(s?.type || '').toLowerCase())
 }
 
 // Phase → dot class (reuses the design's .sdot vocabulary). Derived from the
@@ -572,7 +574,7 @@ export function InferenceHeroBand() {
   const mm = useMemoryMapModel()
 
   const allSlots = slotsQuery.data || []
-  const nonImg = allSlots.filter((s) => (s.group || '') !== 'img')
+  const nonImg = allSlots.filter((s) => String(s.type) !== 'image')
   const slots = nonImg.filter((s) => devKind(s.device) !== 'npu')
   const rows = slots.map((s) => ({ s, ind: slotIndicatorFromPhase(s) }))
   const servingN = rows.filter((r) => r.ind.cls === 'serving').length
@@ -622,7 +624,7 @@ export function InferencePane() {
   // own pane (ComfyuiPane); NPU/FLM slots are cordoned off to the NPU · FLM
   // stack pane below — they appear here only as the sec-label FLM count.
   const allSlots = slotsQuery.data || []
-  const nonImg = allSlots.filter((s) => (s.group || '') !== 'img')
+  const nonImg = allSlots.filter((s) => String(s.type) !== 'image')
   const slots = nonImg.filter((s) => devKind(s.device) !== 'npu')
   const npuN = nonImg.length - slots.length
 
@@ -630,13 +632,13 @@ export function InferencePane() {
   const servingN = rows.filter((r) => r.ind.cls === 'serving').length
   const loadedN = rows.filter((r) => isSlotLive(r.s)).length
 
-  // Tier split — headline = the conversational LLM slots (chat / agent groups);
-  // utility = the support slots (embed / rerank / voice). Keyed off slot.group
-  // so the split tracks the backend's own grouping; voice covers tts/stt too.
-  // This pane is always expanded (no accordion), so the utility tier shows ALL
-  // its slots; the live count drives the SubLabel note.
-  const headlineRows = rows.filter((r) => !isUtilGroup(r.s.group))
-  const utilRows = rows.filter((r) => isUtilGroup(r.s.group))
+  // Tier split — headline = the conversational LLM slots; utility = the support
+  // slots (embed / rerank / tts / transcription). Keyed off slot.type so the
+  // split can't be thrown off by a mislabeled group. This pane is always
+  // expanded (no accordion), so the utility tier shows ALL its slots; the live
+  // count drives the SubLabel note.
+  const headlineRows = rows.filter((r) => !isUtil(r.s))
+  const utilRows = rows.filter((r) => isUtil(r.s))
 
   const gpuN = slots.filter((s) => {
     const k = devKind(s.device)

--- a/ui/src/dash/quickchat-card.jsx
+++ b/ui/src/dash/quickchat-card.jsx
@@ -85,12 +85,11 @@ function openChatStream({ model, messages, onDelta, onDone, onError }) {
 }
 
 // ── Slot picker ───────────────────────────────────────────────────────────────
-// Filters to chat-capable (group=chat or type=llm) + serving/ready.
+// Filters to chat-capable (type llm/chat) + serving/ready.
 function isChatCapable(slot) {
   if (slot._synthetic) return false
-  const g = (slot.group ?? '').toLowerCase()
   const t = (slot.type ?? '').toLowerCase()
-  const chatType = g === 'chat' || t === 'llm' || t === 'chat'
+  const chatType = t === 'llm' || t === 'chat'
   const liveState = slot.state === 'serving' || slot.state === 'ready'
   return chatType && liveState
 }

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -93,7 +93,6 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
   const [type, setType] = useStateSM(defaults.type || "llm");
   const [profile, setProfile] = useStateSM(defaults.profile || "");
   const [model, setModel] = useStateSM(defaults.model || "");
-  const [group, setGroup] = useStateSM(defaults.group || "chat");
   const [makeDefault, setMakeDefault] = useStateSM(false);
   const [submitErr, setSubmitErr] = useStateSM(null);
 
@@ -107,7 +106,6 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
       setName(defaults.name || "");
       setType(defaults.type || "llm");
       setProfile(defaults.profile || "");
-      setGroup(defaults.group || "chat");
       setModel("");
       setMakeDefault(false);
       setSubmitErr(null);
@@ -157,7 +155,6 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
         if (dc === "cpu") return "cpu";
         return "gpu-rocm";
       })(),
-      group,
       ...(model ? { model } : {}),
       ...(makeDefault ? { default: true } : {}),
     };
@@ -284,22 +281,6 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
               and the backend need not honour, so we state the behaviour
               instead of fabricating a specific port. */}
           <span className="mono" style={{padding: "6px 10px", background: "var(--bg)", border: "1px solid var(--line-soft)", borderRadius: "var(--rad-sm)", display: "inline-block", color: "var(--fg-4)", fontSize: 12}}>auto · assigned on save</span>
-        </div>
-      </div>
-
-      <div className="form-row">
-        <div className="form-lbl">
-          <span>Group</span>
-          <span className="sub">pure UI rollup label</span>
-        </div>
-        <div className="form-ctl">
-          <select className="input mono" value={group} onChange={e => setGroup(e.target.value)}>
-            <option value="chat">chat</option>
-            <option value="embed">embed</option>
-            <option value="voice">voice</option>
-            <option value="img">img</option>
-            <option value="custom">custom</option>
-          </select>
         </div>
       </div>
 
@@ -1276,7 +1257,7 @@ function SlotLogsDrawer({ open, slot, onClose }) {
 }
 
 // ─── Empty SlotCard (no model loaded) ────────────────────────────
-function EmptySlotCard({ name, type, group, device, onConfigure }) {
+function EmptySlotCard({ name, type, device, onConfigure }) {
   return (
     <div className="slot" style={{borderStyle: "dashed", borderColor: "var(--line)"}}>
       <div className="slot-h">
@@ -1289,7 +1270,6 @@ function EmptySlotCard({ name, type, group, device, onConfigure }) {
       <div className="slot-chips">
         <span className="chip">{type}</span>
         <span className={"chip dev-" + (device || "cpu").replace("gpu-", "")}>{device}</span>
-        <span className="chip">{group}</span>
       </div>
       <div style={{padding: "10px 12px", background: "var(--accent-soft)", border: "1px solid var(--accent-line)", borderRadius: "var(--rad-sm)", display: "flex", alignItems: "center", gap: 8}}>
         <span className="mono" style={{fontSize: 11, color: "var(--accent)", flex: 1}}>seeded · ready to configure</span>

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -585,14 +585,20 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
     ? (slots || []).find(s => s.name === logsForSlot)
     : null;
 
-  // Seeded slot identities for the skip-path empty layout.
+  // Seeded slot identities for the skip-path empty layout. Section membership
+  // is derived from the capability type (mirrors the live pane's type-driven
+  // split), so seeded cards never disagree with their type.
+  const SECTION_FOR_TYPE = {
+    llm: "chat", embedding: "embed", reranking: "embed",
+    transcription: "voice", tts: "voice", image: "img",
+  };
   const SEEDED = [
-    { name: "primary", type: "llm",           device: "gpu-rocm", group: "chat"  },
-    { name: "embed",   type: "embedding",     device: "gpu-rocm", group: "embed" },
-    { name: "rerank",  type: "reranking",     device: "gpu-rocm", group: "embed" },
-    { name: "stt",     type: "transcription", device: "cpu",      group: "voice" },
-    { name: "tts",     type: "tts",           device: "cpu",      group: "voice" },
-    { name: "img",     type: "image",         device: "gpu-rocm", group: "img"   },
+    { name: "primary", type: "llm",           device: "gpu-rocm" },
+    { name: "embed",   type: "embedding",     device: "gpu-rocm" },
+    { name: "rerank",  type: "reranking",     device: "gpu-rocm" },
+    { name: "stt",     type: "transcription", device: "cpu"      },
+    { name: "tts",     type: "tts",           device: "cpu"      },
+    { name: "img",     type: "image",         device: "gpu-rocm" },
   ];
   const openCreatePrefilled = (def) => { setCreateDefaults(def); setCreateOpen(true); };
 
@@ -630,10 +636,10 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
   // Skip-path layout: render six seeded empty cards under their default groups.
   if (skipPath) {
     const seededByGroup = {
-      chat:  SEEDED.filter(s => s.group === "chat"),
-      embed: SEEDED.filter(s => s.group === "embed"),
-      voice: SEEDED.filter(s => s.group === "voice"),
-      img:   SEEDED.filter(s => s.group === "img"),
+      chat:  SEEDED.filter(s => SECTION_FOR_TYPE[s.type] === "chat"),
+      embed: SEEDED.filter(s => SECTION_FOR_TYPE[s.type] === "embed"),
+      voice: SEEDED.filter(s => SECTION_FOR_TYPE[s.type] === "voice"),
+      img:   SEEDED.filter(s => SECTION_FOR_TYPE[s.type] === "img"),
     };
     return (
       <div className="view">
@@ -663,8 +669,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
                         name={c.name}
                         type={c.type}
                         device={c.device}
-                        group={c.group}
-                        onConfigure={() => openCreatePrefilled({ name: c.name, type: c.type, device: c.device, group: c.group })}
+                        onConfigure={() => openCreatePrefilled({ name: c.name, type: c.type, device: c.device })}
                       />
                     ))}
                   </div>

--- a/ui/tests/e2e/specs/inference-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-pane-v3.spec.ts
@@ -199,6 +199,21 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
     // the picker is populated (at minimum the current model is an option).
     await expect.poll(async () => picker.locator('option').count()).toBeGreaterThan(0)
   })
+
+  test('utility-type slots route to the support footer regardless of group', async ({ page }) => {
+    await page.goto('/#slots')
+    await expect(pane(page)).toBeVisible()
+    const util = pane(page).getByTestId('infer-util')
+    await expect(util).toBeVisible()
+    // embed + rerank (util types) live in the footer…
+    await expect(util.getByTestId('infer-slot-embed')).toHaveCount(1)
+    await expect(util.getByTestId('infer-slot-rerank')).toHaveCount(1)
+    // …and the tts slot does too, EVEN THOUGH its mock group is "chat"
+    // (type-driven routing overrides the mislabeled group).
+    await expect(util.getByTestId('infer-slot-tts')).toHaveCount(1)
+    // it must NOT appear among the headline (full) cards.
+    await expect(body(page).locator('.scards.full').getByTestId('infer-slot-tts')).toHaveCount(0)
+  })
 })
 
 test.describe('NPU occupancy card (/slots · Inference tab)', () => {


### PR DESCRIPTION
## Problem

On the Inference pane, a slot card's placement (main engine grid vs. support footer) was decided by a free-form `group` string that could disagree with the slot's capability `type`. A `tts`-type slot created with the create-modal's default `group: "chat"` (e.g. the live `test-tts` slot) wrongly rendered in the main grid instead of dropping down with the other utility cards.

## Fix

- **Route by `type`, not `group`.** The headline/utility split (and the image-pane filter) now derive entirely from `slot.type` — `embedding | reranking | tts | transcription` → support footer; `image` → its own pane; everything else (`llm`) → headline. Any utility-type slot lands in the footer regardless of how it was created.
- **Retire the redundant `group` field.** Removed the create-modal dropdown, the skip-path empty-state sectioning (re-derived from `type` via `SECTION_FOR_TYPE`), the vestigial `group` fallbacks in `quickchat-card` / `connections` / `command-palette`, the `EmptySlotCard` prop, and the CLI `add_slot` write. `group` was never a `SlotConfig` schema field — it rode as a Pydantic `extra:"allow"` passthrough — so **no migration is needed**: existing on-disk TOMLs carrying `group` still load and are simply ignored.

## Out of scope (considered, rejected)

Seeding iGPU utility slots for all four capabilities: embed/rerank already default to the iGPU, and tts (kokoro) / stt (FastFlowLM) have no iGPU runtime in this stack — so seeding dormant iGPU tts/stt slots would add clutter for zero new capability.

## Tests

- New e2e regression: the mock `tts` slot is deliberately mislabeled `group: "chat"`; the test asserts it still renders in the `infer-util` footer and **not** among the headline cards (RED→GREEN verified).
- Backend `tests/slots/test_manager.py`: 54 passed.
- e2e: inference-pane 13 passed, slots/wireup/settings 8 passed (1 pre-existing skip).

## Notes

- Convention shift: speech-to-text routes via `type: "transcription"` (the old `'stt'` group alias is gone). No mock/runtime regression.
- Spec & plan: `docs/superpowers/specs/2026-06-19-type-driven-utility-routing-design.md`, `docs/superpowers/plans/2026-06-19-type-driven-utility-routing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)