### PR TITLE
feat(slots): TTL-driven hard eviction frees idle slot RAM (#902)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -822,10 +822,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await slot_manager.reconcile_unconfigured_slots()
 
     # Idle monitor — demotes READY → IDLE after the configured timeout
-    # so the dashboard distinguishes "warm but quiet" from "warm and
-    # actively serving" without operator help.  Defaults to 300s; the
-    # constructor accepts overrides for tests.
-    await slot_manager.start_idle_monitor()
+    # (so the dashboard distinguishes "warm but quiet" from "warm and
+    # actively serving") AND hard-evicts slots idle past their TTL to free
+    # host RAM (#902).  The global default evict TTL comes from
+    # slots.idle_timeout_s; per-slot TOML idle_timeout_s overrides it and
+    # idle_timeout_s = 0 pins a slot.  Defaults to 300s for tests.
+    await slot_manager.start_idle_monitor(evict_after_s=hal0_cfg.slots.idle_timeout_s)
 
     # Auto-register one composite ``hal0`` upstream so the dispatcher can
     # route ``model: <slot_name>`` requests without requiring the user to

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -121,6 +121,18 @@ _CONFIG_DRIFT_KEYS: tuple[str, ...] = ("--ctx-size", "--model", "--alias", "-b",
 # can distinguish "warm but quiet" from "warm and serving".
 _IDLE_AFTER_S: float = 300.0
 _IDLE_MONITOR_INTERVAL_S: float = 30.0
+# Hard-eviction default TTL (#902). A slot idle past this long (resolved
+# per-slot: TOML idle_timeout_s overrides, then this global default) is
+# *unloaded* — freeing host RAM — not merely relabeled IDLE. 0 disables
+# eviction; per-slot idle_timeout_s = 0 pins that slot.
+_EVICT_AFTER_S: float = 300.0
+
+# Anchor slots pinned against TTL eviction *under default config* — i.e.
+# when their TOML carries no explicit idle_timeout_s. Evicting these would
+# defeat always-warm chat, the agent loop, and the NPU trio anchor. An
+# explicit per-slot idle_timeout_s in TOML still wins (lets an operator
+# opt a named anchor back into eviction); explicit 0 keeps it pinned.
+_PINNED_BY_DEFAULT: frozenset[str] = frozenset({"chat", "agent", "npu"})
 
 
 # ── Hook protocols ───────────────────────────────────────────────────────────
@@ -263,6 +275,7 @@ class SlotManager:
         pull_runner: PullRunner | None = None,
         model_cache_check: ModelCacheCheck | None = None,
         idle_after_s: float = _IDLE_AFTER_S,
+        evict_after_s: float = _EVICT_AFTER_S,
         idle_monitor_interval_s: float = _IDLE_MONITOR_INTERVAL_S,
         event_bus: Any | None = None,
         upstreams_registry: Any | None = None,
@@ -309,6 +322,10 @@ class SlotManager:
         # ``start_idle_monitor()`` (the API lifespan owns the lifecycle so
         # tests can inject shorter intervals).
         self._idle_after_s: float = idle_after_s
+        # Hard-eviction TTL default (#902): a slot idle past its resolved
+        # idle_timeout_s is unloaded, not just relabeled.  Per-slot TOML
+        # idle_timeout_s overrides this global default.
+        self._evict_after_s: float = evict_after_s
         self._idle_monitor_interval_s: float = idle_monitor_interval_s
         self._idle_monitor_task: asyncio.Task[None] | None = None
         # GpuArbiter (Phase D, spec §7) — constructed lazily on first
@@ -2196,17 +2213,20 @@ class SlotManager:
         self,
         *,
         idle_after_s: float | None = None,
+        evict_after_s: float | None = None,
         interval_s: float | None = None,
     ) -> None:
-        """Start the background sweeper that demotes READY → IDLE.
+        """Start the background sweeper that demotes READY → IDLE and evicts.
 
         Idempotent — calling twice while the task is alive is a no-op.
-        Callers in the API lifespan invoke this once at startup; tests
-        construct a SlotManager with shorter intervals and start the
-        monitor explicitly.
+        Callers in the API lifespan invoke this once at startup (wiring
+        ``evict_after_s`` from ``slots.idle_timeout_s``); tests construct a
+        SlotManager with shorter intervals and start the monitor explicitly.
         """
         if idle_after_s is not None:
             self._idle_after_s = idle_after_s
+        if evict_after_s is not None:
+            self._evict_after_s = evict_after_s
         if interval_s is not None:
             self._idle_monitor_interval_s = interval_s
         existing = self._idle_monitor_task
@@ -2244,25 +2264,91 @@ class SlotManager:
         except asyncio.CancelledError:
             raise
 
+    async def _evict_timeout_for(self, slot_name: str) -> float | None:
+        """Resolve the idle TTL after which a slot is hard-evicted (#902).
+
+        Returns ``None`` when the slot is pinned (never TTL-evicted):
+          * an explicit ``idle_timeout_s = 0`` in the slot's TOML, or
+          * a default-pinned anchor (chat / agent / npu) with no explicit
+            per-slot value, or
+          * a non-positive global default with no explicit per-slot value.
+
+        Otherwise returns the effective TTL in seconds: the per-slot TOML
+        ``idle_timeout_s`` when set (overrides the global), else the global
+        ``_evict_after_s`` default.  ``0`` consistently means "disabled" at
+        both levels, matching the config-schema contract.
+        """
+        canonical = self._resolve_alias(slot_name)
+        try:
+            cfg = await self._load_slot_config(canonical)
+        except (SlotConfigError, SlotNotFound):
+            cfg = {}
+        raw = cfg.get("idle_timeout_s")
+        if isinstance(raw, bool):  # bool is an int subclass — never a TTL
+            raw = None
+        if isinstance(raw, int):
+            return None if raw <= 0 else float(raw)
+        # No explicit per-slot value: pin the named anchors, else fall back
+        # to the global default (itself disabled when non-positive).
+        if canonical in _PINNED_BY_DEFAULT:
+            return None
+        return float(self._evict_after_s) if self._evict_after_s > 0 else None
+
     async def _sweep_idle_once(self) -> None:
-        """One pass: flip any READY slot past idle-timeout to IDLE."""
+        """One idle-sweep pass over every tracked slot.
+
+        Stage 1 (soft): a READY slot idle past ``_idle_after_s`` is
+        relabeled IDLE so dashboards distinguish "warm but quiet" from
+        "warm and serving".
+
+        Stage 2 (hard, #902): a slot idle past its resolved per-slot TTL
+        (:meth:`_evict_timeout_for`) is **unloaded**, freeing host RAM —
+        the only way to reclaim it, since llama-server allocates KV
+        statically at ``ctx_size``.  ``idle_timeout_s = 0`` (or a pinned
+        anchor) is never evicted.  A slot mid-request
+        (``serving_count > 0``) is never touched; the dispatcher reloads an
+        evicted slot transparently on its next request (wake-on-request),
+        so eviction is safe.
+        """
         now = time.time()
         for slot_name, ts in list(self._last_used.items()):
-            if (now - ts) < self._idle_after_s:
-                continue
+            idle_for = now - ts
             if self._serving_count.get(slot_name, 0) > 0:
                 continue
-            if self._current_state(slot_name) != SlotState.READY:
+            state = self._current_state(slot_name)
+            if state not in (SlotState.READY, SlotState.IDLE):
                 continue
-            try:
-                await self._transition(
-                    slot_name,
-                    SlotState.IDLE,
-                    message=f"idle for {now - ts:.0f}s",
-                )
-            except IllegalSlotTransition:
-                # Raced with an unload — fine; next sweep will skip it.
+
+            # Stage 2 — hard TTL eviction.
+            evict_after = await self._evict_timeout_for(slot_name)
+            if evict_after is not None and idle_for >= evict_after:
+                try:
+                    await self.unload(slot_name)
+                    log.info(
+                        "slot.idle_evicted",
+                        extra={"slot": slot_name, "idle_s": round(idle_for)},
+                    )
+                except IllegalSlotTransition:
+                    # Raced with another transition — next sweep retries.
+                    pass
+                except Exception as exc:  # never let one slot kill the sweep
+                    log.warning(
+                        "slot.idle_evict_failed",
+                        extra={"slot": slot_name, "error": str(exc)},
+                    )
                 continue
+
+            # Stage 1 — soft demotion READY → IDLE.
+            if state == SlotState.READY and idle_for >= self._idle_after_s:
+                try:
+                    await self._transition(
+                        slot_name,
+                        SlotState.IDLE,
+                        message=f"idle for {idle_for:.0f}s",
+                    )
+                except IllegalSlotTransition:
+                    # Raced with an unload — fine; next sweep will skip it.
+                    continue
 
     async def get_config(self, slot_name: str) -> dict[str, Any]:
         """Return the slot's TOML config as a plain dict (read-only view).

--- a/tests/slots/test_pulling_serving_idle.py
+++ b/tests/slots/test_pulling_serving_idle.py
@@ -17,6 +17,7 @@ is hermetic.
 from __future__ import annotations
 
 import asyncio
+import time
 from pathlib import Path
 
 import pytest
@@ -264,3 +265,134 @@ async def test_serving_resets_idle_clock(
         pass
     ts = sm.last_used("chat")
     assert ts is not None and ts > 0.1, "serving() must bump last_used on exit"
+
+
+# ── IDLE eviction (#902) ─────────────────────────────────────────────────────
+
+
+def _write_min_slot(
+    root: Path,
+    name: str,
+    *,
+    port: int,
+    idle_timeout_s: int | None = None,
+) -> None:
+    """Write a minimal llama-server slot TOML, optionally pinning idle_timeout_s."""
+    lines = [
+        f'name = "{name}"',
+        f"port = {port}",
+        'backend = "vulkan"',
+        'provider = "llama-server"',
+        "enabled = true",
+    ]
+    if idle_timeout_s is not None:
+        lines.append(f"idle_timeout_s = {idle_timeout_s}")
+    lines += ["[model]", 'default = "qwen3-4b-q4_k_m"', ""]
+    (root / f"{name}.toml").write_text("\n".join(lines), encoding="utf-8")
+
+
+async def test_idle_sweep_unloads_slot_past_ttl(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """A non-pinned slot idle past its TTL is unloaded (RAM freed), not just relabeled."""
+    _write_min_slot(slot_root, "rerank", port=8090)
+    sm = SlotManager(idle_after_s=0.0, evict_after_s=0.01, idle_monitor_interval_s=10.0)
+    await sm.load("rerank")
+    assert (await sm.status("rerank")).state == SlotState.READY
+    sm._last_used["rerank"] = 0.0  # ancient — well past the 0.01s TTL
+
+    await sm._sweep_idle_once()
+
+    assert (await sm.status("rerank")).state == SlotState.OFFLINE
+    assert any(c.get("name") == "rerank" for c in container_stub.unload_calls)
+
+
+async def test_idle_sweep_pins_slot_with_zero_timeout(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """idle_timeout_s = 0 pins a slot — never TTL-evicted even when long idle."""
+    _write_min_slot(slot_root, "rerank", port=8090, idle_timeout_s=0)
+    sm = SlotManager(idle_after_s=0.0, evict_after_s=0.01, idle_monitor_interval_s=10.0)
+    await sm.load("rerank")
+    sm._last_used["rerank"] = 0.0  # ancient
+
+    await sm._sweep_idle_once()
+
+    # Demoted to IDLE (stage 1) but NOT unloaded (stage 2 skipped).
+    assert (await sm.status("rerank")).state == SlotState.IDLE
+    assert not container_stub.unload_calls
+
+
+async def test_idle_sweep_does_not_evict_default_anchor(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """chat (a default-pinned anchor) relabels IDLE but is never evicted under default config."""
+    # slot_root already provides chat.toml with no explicit idle_timeout_s.
+    sm = SlotManager(idle_after_s=0.0, evict_after_s=0.01, idle_monitor_interval_s=10.0)
+    await sm.load("chat")
+    sm._last_used["chat"] = 0.0  # ancient
+
+    await sm._sweep_idle_once()
+
+    assert (await sm.status("chat")).state == SlotState.IDLE
+    assert not container_stub.unload_calls
+
+
+async def test_idle_sweep_never_evicts_serving_slot(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """A slot with an in-flight request is never evicted mid-request."""
+    _write_min_slot(slot_root, "rerank", port=8090)
+    sm = SlotManager(idle_after_s=0.0, evict_after_s=0.01, idle_monitor_interval_s=10.0)
+    await sm.load("rerank")
+    async with sm.serving("rerank"):
+        sm._last_used["rerank"] = 0.0  # ancient, but serving_count > 0
+        await sm._sweep_idle_once()
+        assert (await sm.status("rerank")).state == SlotState.SERVING
+    assert not container_stub.unload_calls
+
+
+async def test_explicit_positive_ttl_is_honored(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """A per-slot idle_timeout_s overrides the global default in both directions."""
+    _write_min_slot(slot_root, "rerank", port=8090, idle_timeout_s=2)
+    # Global default is tiny, but the per-slot 2s override must win.
+    sm = SlotManager(idle_after_s=0.0, evict_after_s=0.01, idle_monitor_interval_s=10.0)
+    await sm.load("rerank")
+
+    # Idle for ~1s: under the 2s TTL → still loaded.
+    sm._last_used["rerank"] = time.time() - 1.0
+    await sm._sweep_idle_once()
+    assert (await sm.status("rerank")).state in (SlotState.READY, SlotState.IDLE)
+    assert not container_stub.unload_calls
+
+    # Idle for ~3s: past the 2s TTL → evicted.
+    sm._last_used["rerank"] = time.time() - 3.0
+    await sm._sweep_idle_once()
+    assert (await sm.status("rerank")).state == SlotState.OFFLINE
+    assert any(c.get("name") == "rerank" for c in container_stub.unload_calls)
+
+
+async def test_evicted_slot_wakes_on_next_request(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """An evicted slot reloads transparently when used again (wake-on-request)."""
+    _write_min_slot(slot_root, "rerank", port=8090)
+    sm = SlotManager(idle_after_s=0.0, evict_after_s=0.01, idle_monitor_interval_s=10.0)
+    await sm.load("rerank")
+    sm._last_used["rerank"] = 0.0
+    await sm._sweep_idle_once()
+    assert (await sm.status("rerank")).state == SlotState.OFFLINE
+
+    # Next request path (dispatcher wake-on-request uses start()/load()).
+    woke = await sm.start("rerank")
+    assert woke.state == SlotState.READY
+    # A fresh container load happened after the eviction unload.
+    assert sum(1 for c in container_stub.load_calls if c[0].get("name") == "rerank") == 2


### PR DESCRIPTION
Closes #902.

## Problem
The idle sweep (`_sweep_idle_once`) only relabeled READY→IDLE and **never unloaded**. Containers kept weights + statically-allocated KV resident forever (~30 GB on CT105), which on 2026-06-19 pushed the Proxmox host into OOM and killed the RDP VM. IDLE was cosmetic.

## Change
Adds **Stage 2** to the idle sweep — the soft→hard completion:

- **Stage 1 (existing):** READY→IDLE relabel past `idle_after_s`. Kept.
- **Stage 2 (new, #902):** a slot idle past its resolved `idle_timeout_s`, not serving, gets `unload()`ed → host RAM freed. The dispatcher reloads it transparently on the next request (wake-on-request), so eviction is safe.

`_evict_timeout_for()` resolves the TTL:
- per-slot TOML `idle_timeout_s` **overrides** the global default (wired into the lifespan from `slots.idle_timeout_s` — previously a dead field);
- `0` = **pinned** (never evict) at either level, matching the schema contract;
- `chat` / `agent` / `npu` anchors are pinned **by default** (no explicit value) via `_PINNED_BY_DEFAULT`, but an explicit per-slot value still wins — so the live `npu=1800` / `embed=900` values **start being honored** while default config never evicts the anchors.

Since llama-server allocates KV statically at `ctx_size`, only a full `unload()` reclaims RAM — erasing KV frees nothing.

## Acceptance criteria
- [x] Idle sweep unloads a slot once idle past its (per-slot) `idle_timeout_s`
- [x] `idle_timeout_s = 0` pins a slot — never evicted
- [x] `serving_count > 0` → never evicted (no mid-request unload)
- [x] Evicted slot reloads transparently on its next request (wake-on-request)
- [x] `chat` + NPU anchor + `agent` not evicted under default config
- [x] Tests: TTL-expiry→unload, pinned(0)→no unload, serving→no unload, post-evict wake, default-anchor→no evict, explicit positive TTL honored both ways
- [ ] **Host free-mem delta verified live** — pending a CT105 deploy window (the box is currently owned by another session; this PR is backend-only and needs `hal0 slot restart` after deploy, not `podman restart`)

## Tests
`tests/slots/test_pulling_serving_idle.py` — 6 new tests; full `tests/slots/` suite green (239 passed). `ruff format`/`check` clean.

## Scope notes
- Backend-only; no UI. Pressure-triggered eviction is the follow-up #903; dashboard pin/LRU surface is #904.
- Seed TOMLs intentionally untouched — code-level default-pin keeps anchors safe without baking `idle_timeout_s=0`, leaving operators free to opt anchors into eviction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)