### PR TITLE
feat(registry): associate mmproj sidecars with their parent model (#899)

### DIFF
--- a/src/hal0/registry/discover.py
+++ b/src/hal0/registry/discover.py
@@ -95,6 +95,9 @@ class CandidateModel:
     suggested_id: str
     curated_match: CuratedModel | None
     capability_guess: str
+    # Resolved path to a multimodal projector (mmproj) GGUF sidecar that sits
+    # in the same directory, or None. Associated post-walk by find_candidates.
+    mmproj: Path | None = None
 
 
 # ── helpers ───────────────────────────────────────────────────────────────
@@ -131,6 +134,16 @@ def _match_curated(filename: str) -> CuratedModel | None:
     return None
 
 
+def _is_mmproj_sidecar(p: Path) -> bool:
+    """True for a multimodal-projector (mmproj) sidecar file.
+
+    Matched by filename rather than suffix: the real artifact is named
+    ``mmproj-F32.mmproj`` and ``.mmproj`` is not one of the configured model
+    ``file_extensions``, so an extension check would miss it.
+    """
+    return "mmproj" in p.name.lower()
+
+
 def _is_skippable(p: Path) -> bool:
     """Skip dotfiles, .tmp partials, hash-only blob names, shards, accessory dirs."""
     name = p.name
@@ -164,6 +177,10 @@ def find_candidates(
     exts = {e.lower() for e in extensions}
     seen: set[Path] = set()
     out: list[CandidateModel] = []
+    # Resolved directory → resolved mmproj sidecar path. Collected during the
+    # walk and associated with sibling candidates once the walk completes, so
+    # ordering (sidecar before or after its model) doesn't matter.
+    mmproj_by_dir: dict[Path, Path] = {}
     started = time.monotonic()
     for root in roots:
         root_path = Path(root).expanduser()
@@ -186,6 +203,17 @@ def find_candidates(
                 if not candidate.is_file():
                     continue
             except OSError:
+                continue
+            # Record mmproj sidecars for association, then skip them so they
+            # never become standalone routable candidates. Done before the
+            # generic skip rule (which also drops mmproj) and before the
+            # extension check (the real sidecar's .mmproj suffix isn't listed).
+            if _is_mmproj_sidecar(candidate):
+                try:
+                    mmproj_abs = candidate.resolve()
+                except OSError:
+                    mmproj_abs = candidate
+                mmproj_by_dir.setdefault(mmproj_abs.parent, mmproj_abs)
                 continue
             if _is_skippable(candidate):
                 continue
@@ -220,6 +248,11 @@ def find_candidates(
                     capability_guess=_guess_capability(naming_source.name),
                 )
             )
+    # Associate each sidecar with sibling main models in the same directory.
+    for cand in out:
+        sidecar = mmproj_by_dir.get(cand.path.parent)
+        if sidecar is not None:
+            cand.mmproj = sidecar
     return out
 
 
@@ -248,6 +281,10 @@ def register_candidate(registry: ModelRegistry, candidate: CandidateModel) -> Mo
             capabilities=[candidate.capability_guess],
             metadata={"discovered": True, "source": "auto-scan"},
         )
+    # Carry a discovered mmproj sidecar onto the model so the llama-server
+    # provider can surface it as --mmproj. None when no sidecar was found.
+    if candidate.mmproj is not None:
+        model.mmproj = str(candidate.mmproj)
     try:
         registry.add(model)
     except ModelAlreadyExists:

--- a/src/hal0/registry/model.py
+++ b/src/hal0/registry/model.py
@@ -122,6 +122,16 @@ class Model(BaseModel):
         ),
     )
 
+    mmproj: str | None = Field(
+        default=None,
+        description=(
+            "Absolute path to a multimodal projector (mmproj) GGUF sidecar that "
+            "sits beside this model, or None. Surfaced verbatim to the "
+            "llama-server provider as --mmproj to enable vision; the sidecar is "
+            "never registered as a standalone routable model."
+        ),
+    )
+
     defaults: ModelDefaults | None = Field(
         default=None,
         description=(

--- a/tests/registry/test_discover.py
+++ b/tests/registry/test_discover.py
@@ -12,7 +12,15 @@ from hal0.registry.discover import (
     register_candidate,
     scan_and_register,
 )
+from hal0.registry.model import Model
 from hal0.registry.store import ModelRegistry
+
+
+def test_model_mmproj_defaults_none() -> None:
+    """A Model with no sidecar carries mmproj=None (the registry contract
+    the llama-server provider reads via model_info.get('mmproj'))."""
+    m = Model(id="x", path="/tmp/x.gguf")
+    assert m.mmproj is None
 
 
 @pytest.fixture
@@ -156,6 +164,73 @@ def test_scan_and_register_idempotent(model_root: Path, registry: ModelRegistry)
     # Second run finds no new files.
     second = scan_and_register(registry, cfg)
     assert second["added"] == []
+
+
+@pytest.fixture
+def vision_root(tmp_path: Path) -> Path:
+    """A model directory laid out like the real chat model + mmproj sidecar."""
+    root = tmp_path / "models"
+    root.mkdir()
+    vision_dir = root / "qwopus3.6-27b-v2"
+    vision_dir.mkdir()
+    (vision_dir / "qwopus3.6-27b-v2.STRIX_LEAN.gguf").write_bytes(b"m" * 256)
+    # The sidecar — note the .mmproj extension is NOT in file_extensions,
+    # so association must key on the filename, not the suffix.
+    (vision_dir / "mmproj-F32.mmproj").write_bytes(b"p" * 64)
+    # A plain chat model with no sidecar in its own directory.
+    plain_dir = root / "plain-chat"
+    plain_dir.mkdir()
+    (plain_dir / "plain-chat-q4_k_m.gguf").write_bytes(b"c" * 128)
+    return root
+
+
+def test_find_candidates_associates_sidecar(vision_root: Path) -> None:
+    """A *mmproj* file beside a main model attaches to that model's
+    candidate; the sidecar itself is never emitted as a candidate."""
+    candidates = find_candidates(
+        roots=[vision_root],
+        extensions=[".gguf", ".safetensors"],
+        known_paths=set(),
+    )
+    by_name = {c.path.name: c for c in candidates}
+    # The sidecar is not a routable candidate.
+    assert "mmproj-F32.mmproj" not in by_name
+    # The main model carries the sidecar's resolved path.
+    main = by_name["qwopus3.6-27b-v2.STRIX_LEAN.gguf"]
+    assert main.mmproj is not None
+    assert Path(main.mmproj).name == "mmproj-F32.mmproj"
+    assert Path(main.mmproj).is_file()
+
+
+def test_find_candidates_no_sidecar_is_none(vision_root: Path) -> None:
+    """A model in a directory with no sidecar resolves mmproj=None
+    (no false positives leaking across directories)."""
+    candidates = find_candidates(
+        roots=[vision_root],
+        extensions=[".gguf", ".safetensors"],
+        known_paths=set(),
+    )
+    by_name = {c.path.name: c for c in candidates}
+    assert by_name["plain-chat-q4_k_m.gguf"].mmproj is None
+
+
+def test_scan_and_register_attaches_and_omits_sidecar(
+    vision_root: Path, registry: ModelRegistry
+) -> None:
+    """End-to-end: the registered main model resolves its mmproj path, and
+    no standalone model is registered for the sidecar."""
+    cfg = ModelsConfig(roots=[str(vision_root)])
+    scan_and_register(registry, cfg)
+    models = registry.list()
+    # No registered model points at the sidecar.
+    assert all("mmproj" not in Path(m.path).name.lower() for m in models)
+    # The main vision model carries its sidecar path.
+    main = next(m for m in models if m.path.endswith("STRIX_LEAN.gguf"))
+    assert main.mmproj is not None
+    assert Path(main.mmproj).name == "mmproj-F32.mmproj"
+    # The plain model has no sidecar.
+    plain = next(m for m in models if m.path.endswith("plain-chat-q4_k_m.gguf"))
+    assert plain.mmproj is None
 
 
 def test_scan_and_register_missing_root_is_silent(tmp_path: Path, registry: ModelRegistry) -> None:


### PR DESCRIPTION
## What

Teaches the model registry that a model can carry a multimodal projector (mmproj) sidecar. Closes #899 — the registry-only foundation of the chat-slot-vision epic (#899 → #900 → #901).

Today an mmproj GGUF beside a main model is **discarded** during discovery, and `Model` has no field for it — so the consumer that already exists (`llama_server.py` reads `model_info["mmproj"]` → `--mmproj`) is permanently fed `None`. This wires the association without registering the sidecar as a standalone routable model.

## How

- `Model` gains an optional `mmproj: str | None = None`.
- Discovery detects sidecars by **filename** (`"mmproj" in name.lower()`) — the real artifact is `mmproj-F32.mmproj`, whose `.mmproj` suffix isn't in `file_extensions`, so a suffix check would miss it.
- Detection happens **before** the skip rules fire; sidecars are recorded per-directory and associated with sibling candidates **after** the walk, so file ordering doesn't matter. They are never emitted as standalone candidates.
- `register_candidate` copies the discovered path onto the `Model`.

No provider changes: `model.model_dump()` already flows through `SlotManager._resolve_model_info` into `model_info`, which `llama_server.py` consumes. Emitting `--mmproj` from the container provider is the next slice (#900).

## Acceptance criteria

- [x] `Model` carries optional `mmproj`, defaulting to `None`
- [x] Discovery associates a `*mmproj*` sidecar with its sibling main model in the same directory
- [x] The sidecar is NOT registered as a standalone routable model
- [x] A model with no sidecar resolves `mmproj = None` (no false positives)
- [x] `qwopus3-6-27b-v2-mtp-bf16-to-rocmfp4-strix-lean` resolves its `mmproj-F32.mmproj` path after a rescan
- [x] Unit tests cover: sidecar present → associated, absent → `None`, sidecar-not-registered-standalone

## Testing

- `tests/registry/test_discover.py` — 13 pass (4 new behaviors via TDD).
- Wider sweep: `tests/registry tests/api/test_models_{scan,routes,preview}.py tests/capabilities` → **207 passed**.
- `ruff format --check` + `ruff check` clean.
- **Real-data verification** against `/mnt/ai-models/qwopus3.6-27b-v2/`: the real `STRIX_LEAN.gguf` associates `mmproj-F32.mmproj`, the derived id matches the acceptance criterion exactly, and the path round-trips through registry TOML persistence (fresh re-read returns `model_dump()["mmproj"]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)