### PR TITLE
fix(comfyui): read logs from journald + rework card layout

### DIFF
--- a/src/hal0/api/routes/comfyui.py
+++ b/src/hal0/api/routes/comfyui.py
@@ -738,34 +738,43 @@ async def comfyui_restart(request: Request, background_tasks: BackgroundTasks) -
 
 @router.get("/logs")
 async def comfyui_logs(tail: int = 60) -> JSONResponse:
-    """Return the last N lines of the ComfyUI container logs.
+    """Return the last N lines of the ComfyUI slot's journal output.
 
-    Uses ``docker logs --tail N`` (or ``podman``) against the container
-    name. Returns ``{"lines": []}`` when the container runtime is absent
-    or the container has no logs yet — never a 500.
+    Post-D9 the img slot runs as the podman ``hal0-slot-img`` container
+    under the ``hal0-slot@img`` systemd unit with ``StandardOutput=journal``
+    (the container itself uses the ``none`` log driver, so ``podman logs``
+    yields nothing). We therefore read the journal — matching the regular
+    slot logs endpoint — rather than ``podman/docker logs``.
+
+    Returns ``{"lines": []}`` when ``journalctl`` is absent or the slot
+    has no journal entries yet — never a 500.
     """
-    container = _comfyui_container()
-    # Prefer podman if available (post-D9 the img slot runs under podman)
-    runtime = shutil.which("podman") or shutil.which("docker")
-    if not runtime:
+    if shutil.which("journalctl") is None:
         return JSONResponse(status_code=200, content={"lines": []})
+    n = max(1, min(int(tail or 60), 5000))
     try:
         proc = await asyncio.create_subprocess_exec(
-            runtime,
-            "logs",
-            "--tail",
-            str(tail),
-            container,
+            "journalctl",
+            "-u",
+            _IMG_UNIT,
+            "-n",
+            str(n),
+            "--no-pager",
+            "-o",
+            "short-iso",
             stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        out, err = await asyncio.wait_for(proc.communicate(), timeout=10.0)
+        out, _err = await asyncio.wait_for(proc.communicate(), timeout=10.0)
     except (TimeoutError, OSError):
         return JSONResponse(status_code=200, content={"lines": []})
-    # docker logs writes to stderr for container output; combine both
-    combined = (out + err).decode("utf-8", "replace")
+    combined = out.decode("utf-8", "replace")
     lines = [ln for ln in combined.splitlines() if ln]
+    # journalctl emits a "-- No entries --" placeholder when the unit has
+    # never logged; normalise that to an empty list for the UI's contract.
+    if len(lines) == 1 and lines[0].strip().startswith("-- No entries"):
+        lines = []
     return JSONResponse(status_code=200, content={"lines": lines})
 
 

--- a/tests/api/test_comfyui_phase4.py
+++ b/tests/api/test_comfyui_phase4.py
@@ -3,7 +3,7 @@
 Covers:
   POST /api/comfyui/render/cancel   — clears queue + interrupts
   POST /api/comfyui/restart         — restarts the slot-managed img runtime
-  GET  /api/comfyui/logs?tail=N     — container log lines
+  GET  /api/comfyui/logs?tail=N     — img-slot journal lines
   POST /api/comfyui/workflows/{name}/launch — reads workflow file + posts /prompt
   GET  /api/comfyui/preview         — proxies latest output image bytes
 
@@ -153,13 +153,38 @@ class TestLogs:
         log_lines = ["2026-06-16 startup ok", "loading model", "ready"]
         proc = self._make_log_proc(log_lines)
 
-        with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with (
+            patch("shutil.which", return_value="/usr/bin/journalctl"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+        ):
             r = client.get("/api/comfyui/logs?tail=60")
 
         assert r.status_code == 200
         body = r.json()
         assert "lines" in body
         assert body["lines"] == log_lines
+
+    def test_logs_reads_img_slot_journal_unit(self, client: TestClient):
+        """Logs must come from the hal0-slot@img journal, not `podman logs`.
+
+        Post-D9 the img container uses the 'none' log driver, so its output
+        is only reachable via journalctl on its systemd unit.
+        """
+        call_args_store = []
+
+        async def capture(*args, **kwargs):
+            call_args_store.extend(args)
+            return _make_proc(stdout=b"line1\nline2")
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/journalctl"),
+            patch("asyncio.create_subprocess_exec", side_effect=capture),
+        ):
+            r = client.get("/api/comfyui/logs")
+
+        assert r.status_code == 200
+        assert call_args_store[0] == "journalctl"
+        assert "hal0-slot@img.service" in call_args_store
 
     def test_logs_default_tail_60(self, client: TestClient):
         """Default tail when not supplied must be 60."""
@@ -169,7 +194,10 @@ class TestLogs:
             call_args_store.extend(args)
             return _make_proc(stdout=b"line1\nline2")
 
-        with patch("asyncio.create_subprocess_exec", side_effect=capture):
+        with (
+            patch("shutil.which", return_value="/usr/bin/journalctl"),
+            patch("asyncio.create_subprocess_exec", side_effect=capture),
+        ):
             r = client.get("/api/comfyui/logs")
 
         assert r.status_code == 200
@@ -177,23 +205,39 @@ class TestLogs:
         assert "60" in joined, f"tail=60 not found in subprocess args: {call_args_store}"
 
     def test_logs_custom_tail(self, client: TestClient):
-        """tail= query param must be forwarded to the container runtime."""
+        """tail= query param must be forwarded to journalctl (-n)."""
         call_args_store = []
 
         async def capture(*args, **kwargs):
             call_args_store.extend(args)
             return _make_proc(stdout=b"x")
 
-        with patch("asyncio.create_subprocess_exec", side_effect=capture):
+        with (
+            patch("shutil.which", return_value="/usr/bin/journalctl"),
+            patch("asyncio.create_subprocess_exec", side_effect=capture),
+        ):
             r = client.get("/api/comfyui/logs?tail=10")
 
         assert r.status_code == 200
         joined = " ".join(str(a) for a in call_args_store)
         assert "10" in joined
 
-    def test_logs_empty_when_no_container_runtime(self, client: TestClient):
-        """If docker/podman not found, return empty lines not a 500."""
+    def test_logs_empty_when_no_journalctl(self, client: TestClient):
+        """If journalctl is not found, return empty lines not a 500."""
         with patch("shutil.which", return_value=None):
+            r = client.get("/api/comfyui/logs")
+
+        assert r.status_code == 200
+        assert r.json() == {"lines": []}
+
+    def test_logs_empty_on_no_journal_entries(self, client: TestClient):
+        """journalctl's '-- No entries --' placeholder normalises to []."""
+        proc = _make_proc(stdout=b"-- No entries --")
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/journalctl"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+        ):
             r = client.get("/api/comfyui/logs")
 
         assert r.status_code == 200

--- a/ui/src/dash/comfyui-pane.css
+++ b/ui/src/dash/comfyui-pane.css
@@ -187,18 +187,29 @@
 .comfy-page .gauge.sm .gc .sub { font-size: 9px; margin-top: 2px; }
 
 /* ── Activity/metrics + queue/assets layout ─────────────────────────────────── */
-.comfy-page .activity-metrics-row,
-.comfy-page .queue-assets-row {
+.comfy-page .activity-metrics-row {
   display: grid;
   grid-template-columns: minmax(0, 3fr) minmax(280px, 2fr);
   gap: 22px;
   align-items: start;
 }
 
+/* Queue lives alone under the expander now (workflows + models moved up
+   beside the device metrics), so it spans the full width. */
 .comfy-page .queue-assets-row {
   margin-top: 18px;
   padding-top: 16px;
   border-top: 1px solid var(--line-soft);
+}
+
+/* Workflows + models stacked below the render, in the left activity column. */
+.comfy-page .activity-extras {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--line-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 /* ── Queue/workflows expander (collapses the lower half by default) ───────── */
@@ -249,7 +260,7 @@
   display: grid;
   grid-template-columns: minmax(160px, 220px) minmax(0, 1fr);
   gap: 18px;
-  align-items: stretch;
+  align-items: start;
 }
 
 .comfy-page .render-detail {
@@ -265,11 +276,13 @@
 .comfy-page .metric-top {
   display: flex;
   align-items: center;
-  gap: 14px;
+  justify-content: space-between;
+  gap: 24px;
 }
 
 .comfy-page .ram-metric {
   min-width: 0;
+  flex: 1;
 }
 
 .comfy-page .ram-metric .blk-h {
@@ -281,8 +294,8 @@
 }
 
 .comfy-page .ram-metric .cspark {
-  height: 24px;
-  margin-top: 8px;
+  height: 40px;
+  margin-top: 10px;
 }
 
 /* ── 2×2 device metric grid ─────────────────────────────────────────────────── */
@@ -370,8 +383,9 @@
   background-image: repeating-linear-gradient(135deg, transparent 0 9px, rgba(94,164,249,0.05) 9px 18px);
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 7px;
-  min-height: 136px;
-  aspect-ratio: 16 / 10;
+  /* Match the top half of the metrics stack (gauge arch + RAM bar) on the
+     other side rather than stretching to the render-detail height. */
+  height: 124px;
 }
 .comfy-page .preview.active { border-color: var(--comfy-line); }
 .comfy-page .preview-img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; opacity: 0.7; }

--- a/ui/src/dash/comfyui-pane.jsx
+++ b/ui/src/dash/comfyui-pane.jsx
@@ -239,25 +239,44 @@ function StepPips({ step, total }) {
 // true deep-link if/when #9858 lands. `upscale-4x` has no curated file yet,
 // so it opens the editor root.
 const FLOWS_DEFAULT = [
-  { ic: 'image',  a: 'text',   b: 'image',   tag: 'qwen-image', name: 'qwen-image',  wf: 'Qwen-Image-2512-BF16-4-Step-LoRA.json' },
-  { ic: 'image',  a: 'image',  b: 'image',                       name: 'img2img',     wf: 'Qwen-Image-Edit-2511-BF16-4-Step-LoRA.json' },
-  { ic: 'video',  a: 'text',   b: 'video',   tag: 'wan 2.2',    name: 'wan2.2-t2v',  wf: 'Wan2.2-T2V-A14B-FP16-4steps-lora-rank64-Seko-V2.json' },
-  { ic: 'video',  a: 'image',  b: 'video',   tag: 'i2v',        name: 'wan2.2-i2v',  wf: 'Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1-FP16.json' },
-  { ic: 'layers', a: 'still',  b: 'animate', tag: 'chain',      name: 'animate',     wf: 'Hunyuan-Video-1.5_720p_i2v-4-step-lora.json' },
-  { ic: 'cube',   a: 'upscale',b: '4×',                          name: 'upscale-4x' },
+  { ic: 'image',  a: 'text',   b: 'image',   tag: 'qwen-image', name: 'qwen-image',  type: 'image',   wf: 'Qwen-Image-2512-BF16-4-Step-LoRA.json' },
+  { ic: 'image',  a: 'image',  b: 'image',                       name: 'img2img',     type: 'image',   wf: 'Qwen-Image-Edit-2511-BF16-4-Step-LoRA.json' },
+  { ic: 'video',  a: 'text',   b: 'video',   tag: 'wan 2.2',    name: 'wan2.2-t2v',  type: 'video',   wf: 'Wan2.2-T2V-A14B-FP16-4steps-lora-rank64-Seko-V2.json' },
+  { ic: 'video',  a: 'image',  b: 'video',   tag: 'i2v',        name: 'wan2.2-i2v',  type: 'video',   wf: 'Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1-FP16.json' },
+  { ic: 'layers', a: 'still',  b: 'animate', tag: 'chain',      name: 'animate',     type: 'video',   wf: 'Hunyuan-Video-1.5_720p_i2v-4-step-lora.json' },
+  { ic: 'cube',   a: 'upscale',b: '4×',                          name: 'upscale-4x',  type: 'enhance' },
 ]
+
+// Type grouping order for the workflow strip — keeps like-with-like
+// (image → video → enhance) so a quick scan reads by capability.
+const FLOW_TYPE_ORDER = ['image', 'video', 'enhance']
+
+function sortFlowsByType(flows) {
+  const rank = (f) => {
+    const i = FLOW_TYPE_ORDER.indexOf(f.type)
+    return i === -1 ? FLOW_TYPE_ORDER.length : i
+  }
+  // Stable sort: preserve authored order within a type.
+  return flows
+    .map((f, i) => [f, i])
+    .sort((a, b) => rank(a[0]) - rank(b[0]) || a[1] - b[1])
+    .map(([f]) => f)
+}
 
 function workflowHref(comfyBaseUrl, wf) {
   if (!comfyBaseUrl) return undefined
   return wf ? `${comfyBaseUrl}/?workflow=${encodeURIComponent(wf)}` : comfyBaseUrl
 }
 
-function WorkflowsBlock({ flows = FLOWS_DEFAULT, comfyBaseUrl }) {
+// `max` caps the strip so it stays ~2 rows — a curated, varied set sorted by
+// type rather than an unbounded wall of tags.
+function WorkflowsBlock({ flows = FLOWS_DEFAULT, comfyBaseUrl, max = 6 }) {
+  const shown = sortFlowsByType(flows).slice(0, max)
   return (
     <div>
       <BlkH icon="bolt" acc note="opens in ComfyUI ↗">workflows</BlkH>
       <div className="flows">
-        {flows.map((f, i) => {
+        {shown.map((f, i) => {
           const href = workflowHref(comfyBaseUrl, f.wf)
           return (
             <a
@@ -282,7 +301,7 @@ function WorkflowsBlock({ flows = FLOWS_DEFAULT, comfyBaseUrl }) {
   )
 }
 
-// ── Models on share inventory ─────────────────────────────────────────────────
+// ── Models inventory ──────────────────────────────────────────────────────────
 const INV_DEFAULT = [
   { n: 6,  l: 'checkpoints' },
   { n: 4,  l: 'video', u: true },
@@ -294,7 +313,7 @@ const MODELS_DEFAULT = 'Wan 2.2 · Qwen-Image · HunyuanVideo 1.5 · LTX-2'
 function ModelsBlock({ inv = INV_DEFAULT, models = MODELS_DEFAULT }) {
   return (
     <div>
-      <BlkH icon="layers" note="manager ↗">models on share</BlkH>
+      <BlkH icon="layers" note="manager ↗">models</BlkH>
       <div className="inv">
         {inv.map((m, i) => (
           <span className="inv-pill" key={i}>
@@ -423,10 +442,12 @@ export function ImageGenCard({
   const { engine, run, queue, gtt, ram, stats } = mock
   const t = useTick(900)
 
-  // Queue + workflows (bottom half) collapse by default; the top render/metrics
-  // row is always visible. Keeping the lower half behind an expander keeps the
-  // card compact in the common "watch the active render" case and only reveals
-  // the queue list + workflow/model inventory on demand.
+  // Queue + model inventory (bottom half) collapse by default; the top
+  // render/metrics row — which now also carries the always-visible workflows
+  // quick-launch beside the device metrics — stays visible. Keeping the lower
+  // half behind an expander keeps the card compact in the common "watch the
+  // active render" case and only reveals the queue list + model inventory on
+  // demand.
   const [expanded, setExpanded] = useState(false)
 
   // Live preview frame. /api/comfyui/preview 404s until the running render emits
@@ -526,6 +547,14 @@ export function ImageGenCard({
                 )}
               </div>
             </div>
+
+            {/* Workflows (sorted by type, 2 rows) + model inventory fill the
+                area below the render, beside the device metrics. Always
+                visible (no longer tucked behind the queue expander). */}
+            <div className="activity-extras">
+              <WorkflowsBlock comfyBaseUrl={comfyBaseUrl} />
+              <ModelsBlock />
+            </div>
           </div>
 
           {/* Telemetry: GTT gauge + RAM spark + device metric grid */}
@@ -578,17 +607,17 @@ export function ImageGenCard({
           onClick={() => setExpanded((v) => !v)}
         >
           <span className="qx-ic"><Ci name="queue" size={13} /></span>
-          <span className="qx-label">queue &amp; workflows</span>
+          <span className="qx-label">queue</span>
           <span className="qx-sub">{hasRun ? '1 running' : '0 running'} · {queue.length} pending</span>
           <span className="grow" />
           <span className="qx-chev"><Ci name="chev" size={14} /></span>
         </button>
 
-        {/* ── Lower row: queue (60%) + workflows/models (40%) ── */}
+        {/* ── Lower row: queue (workflows + models now live up top) ── */}
         {expanded && (
         <div className="queue-assets-row">
           {/* Queue */}
-          <div>
+          <div className="queue-col">
             <BlkH icon="queue" note={`${hasRun ? '1 running' : '0 running'} · ${queue.length} pending`}>
               queue
             </BlkH>
@@ -634,11 +663,6 @@ export function ImageGenCard({
                 ))}
               </div>
             )}
-          </div>
-
-          <div className="wcard-sub">
-            <WorkflowsBlock comfyBaseUrl={comfyBaseUrl} />
-            <ModelsBlock />
           </div>
         </div>
         )}

--- a/ui/tests/e2e/specs/imagegen-v2.spec.ts
+++ b/ui/tests/e2e/specs/imagegen-v2.spec.ts
@@ -64,8 +64,9 @@ async function gotoImageTab(page: any) {
   await page.waitForSelector('.comfy-v2-pane', { timeout: 10_000 })
 }
 
-// Queue + workflows/models are collapsed by default behind the expander;
-// open it before asserting on the lower-half elements.
+// Queue + model inventory are collapsed by default behind the expander;
+// open it before asserting on the lower-half elements. (Workflows are no
+// longer down here — they live in the always-visible metrics column.)
 async function openQueue(page: any) {
   await page.click('.comfy-v2-pane .queue-expander')
   await page.waitForSelector('.comfy-v2-pane .queue-assets-row', { timeout: 5_000 })
@@ -135,22 +136,43 @@ test.describe('ImageGen V2 render-hero pane', () => {
   })
 
   // ── 4. Workflows strip ──────────────────────────────────────────────────
-  test('workflows strip renders 6 flow buttons', async ({ page }) => {
+  test('workflows strip renders 6 flow buttons below the render (always visible)', async ({
+    page,
+  }) => {
     await gotoImageTab(page)
-    await openQueue(page)
     const pane = page.locator('.comfy-v2-pane')
 
-    await expect(pane.locator('.flows')).toBeVisible()
+    // Workflows now live in the left activity column, below the render and
+    // beside the device metrics — visible without opening the queue expander.
+    await expect(pane.locator('.activity-extras .flows')).toBeVisible()
     await expect(pane.locator('.flow')).toHaveCount(6)
   })
 
-  // ── 5. Models on share ─────────────────────────────────────────────────
+  // ── 4b. Workflows are sorted by type (image → video → enhance) ───────────
+  test('workflows are grouped by type', async ({ page }) => {
+    await gotoImageTab(page)
+    const names = await page
+      .locator('.comfy-v2-pane .activity-extras .flow')
+      .evaluateAll((els: Element[]) => els.map((e) => e.getAttribute('data-workflow')))
+
+    expect(names).toEqual([
+      'qwen-image',
+      'img2img',
+      'wan2.2-t2v',
+      'wan2.2-i2v',
+      'animate',
+      'upscale-4x',
+    ])
+  })
+
+  // ── 5. Models inventory ─────────────────────────────────────────────────
   test('models block: inv pills render (checkpoints, loras, vae…)', async ({ page }) => {
     await gotoImageTab(page)
-    await openQueue(page)
     const pane = page.locator('.comfy-v2-pane')
 
-    await expect(pane.locator('.inv')).toBeVisible()
+    // Models moved up into the always-visible activity column (out of the
+    // expander), below the workflows.
+    await expect(pane.locator('.activity-extras .inv')).toBeVisible()
     // "6 checkpoints" pill
     await expect(pane.locator('.inv-pill').first()).toContainText('6')
   })


### PR DESCRIPTION
## Why

Two issues reported against the dashboard ComfyUI card:

1. **The "logs" button returns nothing.** The endpoint ran `podman logs comfyui`, but post-D9 the container is `hal0-slot-img` **and** it uses the `none` log driver — its stdout/stderr go to the systemd journal (`StandardOutput=journal`). So `podman logs` could never return output, even with the correct container name. Verified on CT105: `podman logs hal0-slot-img` → *"this container is using the 'none' log driver"*, while `journalctl -u hal0-slot@img.service` returns real logs.
2. **Card layout feedback** — workflows/models were hidden behind the queue expander, leaving a blank area below the render.

## What

**Logs fix**
- Rewrote `GET /api/comfyui/logs` to read `journalctl -u hal0-slot@img.service` (reusing the existing `_IMG_UNIT` constant), matching the working `slots.py` logs endpoint.
- Preserves the fail-soft `{"lines": []}` contract; normalises journald's `-- No entries --` placeholder to an empty list.

**Card layout**
- Moved **workflows + model inventory** out of the hidden expander into the always-visible left activity column, below the render and beside the device metrics. Expander now holds the **queue only**.
- **Workflow tags sorted by type** (image → video → enhance), capped to ~2 rows.
- Renamed **"models on share" → "models"**.
- **Shrunk the render preview** to match the top half of the metrics stack (gauge + RAM bar); `render-grid` aligns to `start` instead of stretching.
- **Extended the RAM bar** and spread the gauge/RAM apart so each sits near its container edge.

## Tests
- `tests/api/test_comfyui_phase4.py` — added journald-source + sort coverage, updated the empty/no-runtime cases (25 passing).
- `imagegen-v2` e2e — updated for the new placement (workflows/models always visible) + a grouped-by-type assertion.
- `tsc --noEmit`, e2e (`imagegen-v2` + `comfyui-arbiter-v3`, 18 passing), and production build all clean.

## Deploy note
The logs fix is backend — it needs a CT105 `deploy.sh` to take effect there. Hold until merged; at push time CT105 `/opt/hal0` had uncommitted edits from another session, so a `reset --hard` deploy would clobber them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)