### PR TITLE
feat(hermes-memory): stamp the agent:hermes author tag on writes

### DIFF
--- a/src/hal0/agents/hermes/plugins/memory_hindsight/provider.py
+++ b/src/hal0/agents/hermes/plugins/memory_hindsight/provider.py
@@ -131,7 +131,9 @@ class Hal0MemoryProvider(MemoryProvider):  # type: ignore[misc]
             "You have a durable memory store at hal0-memory "
             f"(private:{agent_id} namespace, resolved server-side). "
             "Use memory_search before asking repeat-questions; "
-            "memory_add to persist facts worth recalling across sessions."
+            "memory_add to persist facts worth recalling across sessions. "
+            "When you memory_add, tag the author with agent:hermes and the "
+            "scope with repo:/topic:/kind: — tag the author, bank the scope."
         )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
@@ -177,7 +179,7 @@ class Hal0MemoryProvider(MemoryProvider):  # type: ignore[misc]
             return
         text = f"User: {user_content}\nAssistant: {assistant_content}"
         try:
-            asyncio.run(self._client.add(text, tags=["chat", "hermes"]))
+            asyncio.run(self._client.add(text, tags=["chat", "agent:hermes"]))
         except Hal0MemoryClientError as exc:
             logger.debug("hal0-memory sync_turn transport failure: %s", exc)
         except RuntimeError as exc:
@@ -217,7 +219,8 @@ class Hal0MemoryProvider(MemoryProvider):  # type: ignore[misc]
             return
         if self._agent_context in _SKIP_WRITE_CONTEXTS:
             return
-        tags = ["builtin-memory", target] if target else ["builtin-memory"]
+        base = ["builtin-memory", "agent:hermes"]
+        tags = [*base, target] if target else base
         try:
             asyncio.run(self._client.add(content, tags=tags, metadata=metadata))
         except Hal0MemoryClientError as exc:

--- a/tests/agents/hermes_plugins/test_memory_hindsight_provider.py
+++ b/tests/agents/hermes_plugins/test_memory_hindsight_provider.py
@@ -42,3 +42,13 @@ async def test_client_recall_hits_recall_route():
 def test_prefetch_uses_recall_not_search():
     src = inspect.getsource(Hal0MemoryProvider.prefetch)
     assert ".recall(" in src and ".search(" not in src
+
+
+def test_writes_stamp_the_author_tag():
+    # Convention: tag the author (agent:<id>), bank the scope. Hermes's
+    # automatic writes must carry agent:hermes so they're filterable by author
+    # without giving each author its own bank.
+    for fn in (Hal0MemoryProvider.sync_turn, Hal0MemoryProvider.on_memory_write):
+        assert '"agent:hermes"' in inspect.getsource(fn)
+    # and the system prompt teaches the convention to model-driven memory_add
+    assert "agent:hermes" in inspect.getsource(Hal0MemoryProvider.system_prompt_block)


### PR DESCRIPTION
## What
Adopt the **"tag the author, bank the scope"** memory convention for Hermes's automatic Hindsight writes.

- `sync_turn`: `["chat","hermes"]` → `["chat","agent:hermes"]`
- `on_memory_write`: now stamps `agent:hermes` alongside `builtin-memory`
- `system_prompt_block`: teaches the convention so model-driven `memory_add` follows it too

## Why
Author identity ("who wrote this") belongs on a **tag** (`agent:<id>`), not a separate bank — so memories stay filterable by author without fragmenting banks. Scope (project/client) stays the bank axis. This mirrors the convention now documented in the `hal0-memory` skill and keeps Hermes's writes consistent with Claude Code sessions (`agent:claude-code`).

## Tests
Added `test_writes_stamp_the_author_tag` (source-inspection style, matching the file). `5 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)