### PR TITLE
feat(capabilities): auto-surface vision from mmproj + per-slot vision toggle (#901)

### DIFF
--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -261,6 +261,12 @@ def _model_capabilities(entry: CuratedModel | HaloaiModel | Any) -> list[str]:
     tags = getattr(entry, "tags", None)
     if isinstance(tags, list) and "vision" in tags and "vision" not in caps:
         caps.append("vision")
+    # Auto-surface vision from an associated mmproj sidecar (#901): a model
+    # that carries a projector can serve images, so it advertises ``vision``
+    # as a secondary capability without a hand-added tag (its primary
+    # ``chat`` capability is preserved above).
+    if getattr(entry, "mmproj", None) and "vision" not in caps:
+        caps.append("vision")
     return caps
 
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -354,6 +354,17 @@ class SlotConfig(BaseModel):
             "default. See resolve_chat_template."
         ),
     )
+    vision: bool = Field(
+        default=True,
+        description=(
+            "Per-slot vision toggle (#901). When the bound model carries an "
+            "mmproj sidecar, the container provider loads it (--mmproj) so the "
+            "slot accepts images — default-on. Set false to boot the slot "
+            "text-only (no --mmproj, modalities.vision:false) on memory-tight "
+            "hosts; the projector is ~0.9 GB resident. No effect when the model "
+            "has no sidecar."
+        ),
+    )
 
     # [model] section (nested)
     model: ModelConfig = Field(default_factory=ModelConfig)

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -577,8 +577,12 @@ class ContainerProvider(Provider):
 
         # Vision projector sidecar associated with the model in the registry
         # (#899). Bind-mounted at its identical host path, so the container sees
-        # the same path. None for text-only models — no flag emitted.
+        # the same path. None for text-only models — no flag emitted. Gated by
+        # the per-slot ``vision`` toggle (#901, default-on): vision=false boots
+        # the slot text-only even when a sidecar exists.
         mmproj = model_info.get("mmproj")
+        if not slot_cfg.get("vision", True):
+            mmproj = None
 
         return _llama_launch_plan(
             image=image,

--- a/tests/capabilities/test_vision_mmproj_autosurface.py
+++ b/tests/capabilities/test_vision_mmproj_autosurface.py
@@ -1,0 +1,67 @@
+"""Auto-surface `vision` from an associated mmproj sidecar (#901).
+
+Before #901 a model only advertised `vision` if a human hand-added a
+`vision` tag. This pins the automatic path: a registry model that carries
+an `mmproj` sidecar (the #899 association) advertises `vision` as a
+secondary capability — keeping its primary `chat` — and therefore appears
+under the `vision` capability without any hand-added tag.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hal0.capabilities.catalog import _model_capabilities, models_for_capability
+from hal0.registry.model import Model
+from hal0.registry.store import ModelRegistry
+
+
+def _reg(tmp_path: Path) -> ModelRegistry:
+    return ModelRegistry(registry_dir=tmp_path / "registry")
+
+
+def test_mmproj_model_advertises_vision_keeping_chat(tmp_path: Path) -> None:
+    reg = _reg(tmp_path)
+    reg.add(
+        Model(
+            id="chat-vlm",
+            path="/mnt/ai-models/qwopus/qwopus.gguf",
+            capabilities=["chat"],
+            backends=["gpu-rocm"],
+            mmproj="/mnt/ai-models/qwopus/mmproj-F32.mmproj",
+        )
+    )
+    caps = _model_capabilities(reg.get("chat-vlm"))
+    assert "chat" in caps, f"primary chat capability must remain: {caps}"
+    assert "vision" in caps, f"vision must be auto-surfaced from the sidecar: {caps}"
+
+
+def test_mmproj_model_listed_under_vision_capability(tmp_path: Path) -> None:
+    reg = _reg(tmp_path)
+    reg.add(
+        Model(
+            id="chat-vlm",
+            path="/mnt/ai-models/qwopus/qwopus.gguf",
+            capabilities=["chat"],
+            backends=["gpu-rocm"],
+            mmproj="/mnt/ai-models/qwopus/mmproj-F32.mmproj",
+        )
+    )
+    rows = models_for_capability("vision", registry=reg)
+    assert "chat-vlm" in {r["id"] for r in rows}, (
+        f"sidecar-bearing model missing from vision capability: {[r['id'] for r in rows]}"
+    )
+
+
+def test_model_without_sidecar_does_not_advertise_vision(tmp_path: Path) -> None:
+    reg = _reg(tmp_path)
+    reg.add(
+        Model(
+            id="plain-chat",
+            path="/mnt/ai-models/plain/plain.gguf",
+            capabilities=["chat"],
+            backends=["gpu-rocm"],
+        )
+    )
+    caps = _model_capabilities(reg.get("plain-chat"))
+    assert "vision" not in caps, f"no sidecar → no vision (no false positive): {caps}"

--- a/tests/providers/test_container_vision_toggle.py
+++ b/tests/providers/test_container_vision_toggle.py
@@ -1,0 +1,97 @@
+"""Per-slot `vision` toggle gates the --mmproj emit (#901).
+
+The container provider emits --mmproj from the model sidecar (#900). This
+adds a per-slot opt-out: `vision = false` boots the slot text-only (no
+--mmproj → modalities.vision:false), default-on where a sidecar exists so
+the chat slot gets vision for free.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from hal0.config.schema import ProfileConfig, SlotConfig
+from hal0.providers.container import ContainerProvider
+
+_SIDECAR = "/mnt/ai-models/qwopus3.6-27b-v2/mmproj-F32.mmproj"
+
+
+def _moe_profile() -> ProfileConfig:
+    return ProfileConfig(
+        image="ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
+        flags="-fa on -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap",
+        mtp=False,
+    )
+
+
+def _slot_cfg(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "chat",
+        "port": 8102,
+        "profile": "rocm",
+        "runtime": "container",
+        "device": "gpu-rocm",
+        "model": {"default": "chat-vlm"},
+    }
+    base.update(overrides)
+    return base
+
+
+def _model_info(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {"path": "/mnt/ai-models/qwopus/qwopus.gguf", "_model_key": "chat-vlm"}
+    base.update(overrides)
+    return base
+
+
+def _build_spec(slot_cfg: dict[str, Any], model_info: dict[str, Any]):
+    provider = ContainerProvider()
+    with (
+        patch("hal0.providers.container._resolve_profile", return_value=_moe_profile()),
+        patch(
+            "hal0.providers.container.resolve_gpu_device_paths",
+            return_value=["/dev/kfd", "/dev/dri/renderD128"],
+        ),
+        patch("hal0.providers.container.resolve_gpu_group_ids", return_value=[]),
+    ):
+        return provider.container_spec(slot_cfg, model_info)
+
+
+# ── schema: the flag exists, default-on ──────────────────────────────────────
+
+
+class TestSlotConfigVisionField:
+    def test_vision_defaults_on(self) -> None:
+        cfg = SlotConfig(name="chat", port=8102, model={"default": "chat-vlm"})
+        assert cfg.vision is True
+
+    def test_vision_opt_out_round_trips(self) -> None:
+        cfg = SlotConfig(name="chat", port=8102, model={"default": "chat-vlm"}, vision=False)
+        assert cfg.vision is False
+        assert cfg.model_dump()["vision"] is False
+
+
+# ── container_spec gating ────────────────────────────────────────────────────
+
+
+class TestVisionToggleGatesMmproj:
+    def test_default_on_emits_mmproj(self) -> None:
+        """No explicit vision flag + sidecar present → --mmproj emitted."""
+        spec = _build_spec(_slot_cfg(), _model_info(mmproj=_SIDECAR))
+        assert "--mmproj" in spec.command
+        assert spec.command[spec.command.index("--mmproj") + 1] == _SIDECAR
+
+    def test_vision_true_emits_mmproj(self) -> None:
+        spec = _build_spec(_slot_cfg(vision=True), _model_info(mmproj=_SIDECAR))
+        assert "--mmproj" in spec.command
+
+    def test_vision_false_suppresses_mmproj(self) -> None:
+        """vision=false → text-only, no --mmproj even though a sidecar exists."""
+        spec = _build_spec(_slot_cfg(vision=False), _model_info(mmproj=_SIDECAR))
+        assert "--mmproj" not in spec.command, (
+            f"vision=false must suppress --mmproj: {spec.command}"
+        )
+
+    def test_no_sidecar_no_mmproj_regardless(self) -> None:
+        spec = _build_spec(_slot_cfg(vision=True), _model_info())  # no sidecar
+        assert "--mmproj" not in spec.command


### PR DESCRIPTION
## What

Closes the mmproj-sidecar vision epic (**#899 → #900 → #901**). Two pieces:

**Part A — auto-surface vision.** `_model_capabilities` now advertises `vision` when a model carries an mmproj sidecar (the #899 association), on top of the existing hand-added-tag path. The primary `chat` capability is preserved (vision is secondary), so the same entry surfaces under `/api/capabilities` → vision **with no manual tag and no new model download**.

**Part B — per-slot toggle.** `SlotConfig` gains a flat `vision: bool = True`. `container_spec` gates the `--mmproj` emit on it — default-on where a sidecar exists (chat slot gets vision for free); `vision = false` boots the slot text-only (no `--mmproj` → `modalities.vision:false`) as a one-line opt-out for memory-tight hosts (projector ≈0.9 GB resident). No effect when the model has no sidecar.

This also **retires the manual `PUT /api/models/{id}` mmproj step** that #900's live bring-up needed: newly discovered sidecar models now advertise vision automatically.

### Posture (ADR, per the issue)
Vision is served on the **existing chat slot** (reuse the resident 27B + bundled projector, ~0.9 GB marginal), **not** a dedicated ~15 GB vision slot. The aggregate-resident / OOM concern belongs to the separate idle/pressure-eviction epic, not to disabling vision.

## Acceptance criteria

- [x] A model with an associated mmproj sidecar advertises `vision` without a hand-added tag
- [x] The model still reports its primary `chat` capability (vision secondary)
- [x] `/api/capabilities` lists the sidecar-bearing model under `vision`
- [x] Per-slot `vision = true/false` flag exists; default-on when a sidecar is present
- [x] `vision = false` boots the slot text-only (no `--mmproj`)
- [x] Tests cover auto-surface on sidecar + opt-out suppression

> Interpretation note: the `vision` capability is a **model** property (the model *can* do vision); the per-slot `vision=false` is a **slot** choice not to load the projector (→ `--mmproj` suppressed → runtime `modalities.vision:false`). The opt-out gates the slot's emit, not the model's catalog entry.

## Testing

- `tests/capabilities/test_vision_mmproj_autosurface.py` — auto-surface + keeps `chat` + no false positive + listed under vision.
- `tests/providers/test_container_vision_toggle.py` — schema default-on + round-trip; gate emits/suppresses `--mmproj`.
- Wider sweep: capabilities + providers + config + slots + slots-API → **684 passed**. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)