### PR TITLE
Board chat: run on the agent slot (chat slot wedged)

### DIFF
--- a/src/hal0/api/routes/board_chat.py
+++ b/src/hal0/api/routes/board_chat.py
@@ -50,8 +50,12 @@ log = structlog.get_logger(__name__)
 # forever (mirrors OmniRouter._MAX_LOOP_ROUNDS).
 _MAX_ROUNDS = 8
 
-# The chat slot the orchestrator drives. hal0's `primary` virtual slot name.
-PRIMARY_SLOT_MODEL = "hal0/primary"
+# The slot the orchestrator drives. Points at the `agent` slot — the
+# tool-calling orchestrator model — rather than the conversational `chat`
+# slot (hal0/primary): board chat IS an agentic surface (it drives audited
+# board mutations via tool-calls), so the agent model is the correct brain.
+# (Named PRIMARY_SLOT_MODEL for back-compat; resolves via the hal0/ alias map.)
+PRIMARY_SLOT_MODEL = "hal0/agent"
 
 #: LLM backend signature: an OpenAI chat-completion request body in, the
 #: parsed response dict out.

--- a/ui/src/api/hooks/useBoard.ts
+++ b/ui/src/api/hooks/useBoard.ts
@@ -921,6 +921,11 @@ export interface UseBoardChatResult {
   streaming: boolean
 }
 
+// Board chat runs on the `agent` slot (the tool-calling orchestrator model),
+// not the conversational `chat` slot. Sent explicitly so it routes correctly
+// regardless of the backend's PRIMARY_SLOT_MODEL default.
+const BOARD_CHAT_MODEL = 'hal0/agent'
+
 export function useBoardChat(board?: string): UseBoardChatResult {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [streaming, setStreaming] = useState(false)
@@ -961,15 +966,20 @@ export function useBoardChat(board?: string): UseBoardChatResult {
       : ENDPOINTS.boardChat
 
     // Open SSE stream via fetch POST. Contract (see board_chat.py): the body
-    // carries `messages` (OpenAI format) + optional `board`; the response is
-    // SSE frames `{type: token|tool_call|tool_result|done|error}`.
+    // carries `messages` (OpenAI format), optional `board`, and `model`; the
+    // response is SSE frames `{type: token|tool_call|tool_result|done|error}`.
+    // `model` is sent explicitly so board chat runs on the `agent` slot (the
+    // tool-calling orchestrator model) — board_chat.py honours payload.model
+    // over its default, so this routes correctly without a backend restart.
+    const body: Record<string, unknown> = { messages: outbound, model: BOARD_CHAT_MODEL }
+    if (board) body.board = board
     fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Accept: 'text/event-stream',
       },
-      body: JSON.stringify(board ? { messages: outbound, board } : { messages: outbound }),
+      body: JSON.stringify(body),
       signal,
     })
       .then(async (res) => {

--- a/ui/tests/e2e/specs/board-chat-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-chat-v3.spec.ts
@@ -146,12 +146,14 @@ test.describe('BoardView — agent chat', () => {
   // ── SSE streaming path ────────────────────────────────────────────────
 
   test('send message → POST /api/board/chat → assistant tokens stream in', async ({ page }) => {
+    let postBody: any = null
     // Mock chat SSE endpoint with proper streaming body
     await page.route('**/api/board/chat', async (route) => {
       if (route.request().method() !== 'POST') {
         await route.fallback()
         return
       }
+      postBody = route.request().postDataJSON()
       const sseBody = [
         'data: {"type":"token","text":"Hello"}\n\n',
         'data: {"type":"token","text":", board"}\n\n',
@@ -178,6 +180,12 @@ test.describe('BoardView — agent chat', () => {
     // Assistant message with streamed content appears
     await expect(msgs.nth(1)).toBeVisible({ timeout: FIVE_S })
     await expect(msgs.nth(1)).toContainText('Hello')
+
+    // Board chat must run on the agent slot (orchestrator model), and send
+    // OpenAI-style `messages` (not the legacy `{message}`).
+    expect(postBody.model).toBe('hal0/agent')
+    expect(Array.isArray(postBody.messages)).toBe(true)
+    expect(postBody.messages.at(-1)).toMatchObject({ role: 'user', content: 'what is blocked?' })
   })
 
   test('send via Enter key fires chat POST', async ({ page }) => {


### PR DESCRIPTION
Board chat is agentic (drives audited board mutations via tool-calls), so its brain should be the **agent** slot, not the conversational chat slot.

It targeted `hal0/primary` → the `chat` slot, which is currently **wedged** (loads but every generation hangs at 188% CPU, zero tokens — ruled out mmproj, MTP, GPU contention; see incident memory). So chat never replied.

- **backend**: `PRIMARY_SLOT_MODEL` `hal0/primary`→`hal0/agent`.
- **frontend**: `useBoardChat` sends `model: hal0/agent` so it routes correctly against the **running** api with **no restart** (board_chat honours payload.model). The last api restart is what wedged the chat slot — avoiding another.

Board data + tool execution already flow through Hermes' kanban plugin; routing the chat *brain* through the full Hermes agent (chat_proxy) is a separate larger change.

Test: board-chat-v3 asserts POST carries `model: hal0/agent` + OpenAI `messages`. 11 chat specs pass; tsc clean.