### PR TITLE
feat(chat-templates): render-validate the catalog so bad templates can't hide

### DIFF
--- a/src/hal0/api/routes/chat_templates.py
+++ b/src/hal0/api/routes/chat_templates.py
@@ -79,7 +79,7 @@ def _render_check(text: str) -> str | None:
     env.globals["strftime_now"] = _strftime_now
     try:
         env.from_string(text).render(**_SAMPLE_CONTEXT)
-    except Exception as exc:  # noqa: BLE001 — a lint must never crash the catalog
+    except Exception as exc:  # a lint must never crash the catalog
         return f"{type(exc).__name__}: {exc}".strip()
     return None
 

--- a/src/hal0/api/routes/chat_templates.py
+++ b/src/hal0/api/routes/chat_templates.py
@@ -7,6 +7,11 @@ Mounted under ``/api/chat-templates`` (see :mod:`hal0.api.__init__`):
 
 Templates live at ``<model_store_root>/chat-templates/<id>.jinja``.
 ``auto`` is a synthetic sentinel that means "use the model's embedded template".
+
+Each catalog entry carries a best-effort ``valid``/``error`` lint (see
+:func:`_render_check`) so the slot-edit dropdown can flag a malformed template
+that an operator dropped into the store dir, instead of letting it surface only
+as a slot cold-start crash.
 """
 
 from __future__ import annotations
@@ -16,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
+from jinja2.sandbox import ImmutableSandboxedEnvironment
 from pydantic import BaseModel
 
 from hal0.config.paths import model_store_root
@@ -25,18 +31,79 @@ router = APIRouter()
 # Valid template id: lowercase alphanumeric, underscore, hyphen; 1-41 chars.
 _VALID_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,40}$")
 
+# A benign 4-turn conversation used to render-check a template. Covers the
+# variables chat templates almost always reference. Kept deliberately simple:
+# the goal is to catch gross syntax/render breakage, not to exercise tools or
+# multimodal content.
+_SAMPLE_CONTEXT: dict[str, Any] = {
+    "messages": [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"},
+        {"role": "user", "content": "How are you?"},
+    ],
+    "add_generation_prompt": True,
+    "enable_thinking": False,
+    "bos_token": "<s>",
+    "eos_token": "</s>",
+    "tools": None,
+}
+
+
+def _render_check(text: str) -> str | None:
+    """Best-effort render lint for a chat template.
+
+    Returns ``None`` when the template parses and renders against
+    :data:`_SAMPLE_CONTEXT`, else a short ``"ErrorType: message"`` string.
+
+    NOTE: this uses Jinja2, while llama.cpp renders chat templates with its
+    own ``minja`` engine. The two are close but not identical, so a ``valid``
+    result is a strong signal — not a guarantee — of minja compatibility. It
+    reliably catches the common failure (a syntactically broken template) that
+    would otherwise only show up when the slot fails to start.
+    """
+
+    def _raise_exception(message: str = "") -> str:
+        # minja exposes raise_exception(); templates call it in guard branches.
+        # On our benign sample it should not fire — if it does, the template is
+        # rejecting an ordinary conversation, which is a real problem to flag.
+        raise ValueError(message or "template called raise_exception")
+
+    def _strftime_now(_fmt: str = "") -> str:
+        # Gemma / Llama-3.1 templates call strftime_now(); a fixed stub keeps
+        # the render deterministic.
+        return "2026-01-01"
+
+    env = ImmutableSandboxedEnvironment(trim_blocks=True, lstrip_blocks=True)
+    env.globals["raise_exception"] = _raise_exception
+    env.globals["strftime_now"] = _strftime_now
+    try:
+        env.from_string(text).render(**_SAMPLE_CONTEXT)
+    except Exception as exc:  # noqa: BLE001 — a lint must never crash the catalog
+        return f"{type(exc).__name__}: {exc}".strip()
+    return None
+
 
 def _templates_dir() -> Path:
     return Path(model_store_root()) / "chat-templates"
 
 
+def _entry(template_id: str, label: str, error: str | None) -> dict[str, Any]:
+    return {"id": template_id, "label": label, "valid": error is None, "error": error}
+
+
 def _catalog() -> list[dict[str, Any]]:
     """Build the full catalog: ``auto`` first, then store entries sorted by id."""
-    entries: list[dict[str, Any]] = [{"id": "auto", "label": "Auto (GGUF embedded)"}]
+    # ``auto`` defers to the GGUF's embedded template — nothing for us to lint.
+    entries: list[dict[str, Any]] = [_entry("auto", "Auto (GGUF embedded)", None)]
     store = _templates_dir()
     if store.is_dir():
         for p in sorted(store.glob("*.jinja")):
-            entries.append({"id": p.stem, "label": p.stem})
+            try:
+                error = _render_check(p.read_text())
+            except OSError as exc:
+                error = f"unreadable: {exc}"
+            entries.append(_entry(p.stem, p.stem, error))
     return entries
 
 
@@ -68,4 +135,7 @@ async def create_chat_template(body: _TemplateBody) -> dict[str, Any]:
     except OSError as exc:
         raise HTTPException(status_code=500, detail=f"Could not write template: {exc}") from exc
 
-    return {"id": body.id, "label": body.id}
+    # Write succeeds regardless of lint result (mirrors the filesystem-drop
+    # path, which never runs through here) — but report the lint so a caller
+    # writing a broken template gets immediate feedback.
+    return _entry(body.id, body.id, _render_check(body.content))

--- a/tests/api/test_chat_templates.py
+++ b/tests/api/test_chat_templates.py
@@ -152,3 +152,68 @@ def test_post_invalid_id_writes_nothing(
     )
     evil_path = tmp_path / "evil.jinja"
     assert not evil_path.exists(), "Path traversal must not write outside store"
+
+
+# ── render-validation (valid / error fields) ──────────────────────────────────
+
+# A minimal but real chat template that renders cleanly against the sample.
+_GOOD_TEMPLATE = (
+    "{% for m in messages %}<|{{ m['role'] }}|>\n{{ m['content'] }}\n{% endfor %}"
+    "{% if add_generation_prompt %}<|assistant|>\n{% endif %}"
+)
+# Broken: unterminated {% for %} block → Jinja TemplateSyntaxError.
+_BROKEN_TEMPLATE = "{% for m in messages %}{{ m['content'] }}"
+
+
+def test_auto_entry_is_valid(store_client: TestClient) -> None:
+    """The synthetic ``auto`` entry is always reported valid (nothing to lint)."""
+    r = store_client.get("/api/chat-templates")
+    assert r.status_code == 200, r.text
+    auto = next(e for e in r.json() if e["id"] == "auto")
+    assert auto["valid"] is True
+    assert auto["error"] is None
+
+
+def test_bundled_templates_lint_clean(store_client: TestClient) -> None:
+    """The bundled templates (chatml/llama3/qwen3.6-27b-mtp) render-check clean."""
+    r = store_client.get("/api/chat-templates")
+    assert r.status_code == 200, r.text
+    by_id = {e["id"]: e for e in r.json()}
+    for tid in ("chatml", "llama3", "qwen3.6-27b-mtp"):
+        assert by_id[tid]["valid"] is True, f"{tid} unexpectedly invalid: {by_id[tid]['error']}"
+
+
+def test_valid_template_reports_valid(store_client: TestClient) -> None:
+    store_client.post("/api/chat-templates", json={"id": "goodtpl", "content": _GOOD_TEMPLATE})
+    r = store_client.get("/api/chat-templates")
+    entry = next(e for e in r.json() if e["id"] == "goodtpl")
+    assert entry["valid"] is True
+    assert entry["error"] is None
+
+
+def test_malformed_template_reports_invalid_with_error(
+    store_client: TestClient, tmp_path: Path
+) -> None:
+    """A malformed template dropped in the store dir is flagged, not hidden."""
+    # Drop straight onto the filesystem to exercise the catalog's own lint
+    # (the path that bypasses POST, i.e. an operator copying a file in).
+    store = tmp_path / "chat-templates"
+    store.mkdir(parents=True, exist_ok=True)
+    (store / "brokentpl.jinja").write_text(_BROKEN_TEMPLATE)
+
+    r = store_client.get("/api/chat-templates")
+    entry = next(e for e in r.json() if e["id"] == "brokentpl")
+    assert entry["valid"] is False
+    assert entry["error"], "an invalid template must carry a non-empty error string"
+
+
+def test_post_returns_lint_result(store_client: TestClient) -> None:
+    """POST echoes the lint result so a caller writing a broken template knows."""
+    r = store_client.post(
+        "/api/chat-templates", json={"id": "postbroken", "content": _BROKEN_TEMPLATE}
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # The write still succeeds (mirrors filesystem-drop), but it's flagged.
+    assert body["valid"] is False
+    assert body["error"]

--- a/ui/src/api/hooks/useChatTemplates.ts
+++ b/ui/src/api/hooks/useChatTemplates.ts
@@ -12,6 +12,12 @@ import { ENDPOINTS } from '../endpoints'
 export interface ChatTemplate {
   id: string
   label: string
+  // Best-effort render lint from the backend (see api/routes/chat_templates.py).
+  // `valid` is false when a template in the store dir fails to render against a
+  // sample conversation; `error` carries the short reason. `auto` is always
+  // valid. Absent on older backends → treat as valid (optional fields).
+  valid?: boolean
+  error?: string | null
 }
 
 // `enabled` gates the fetch — pass the host modal/drawer's `open` so the

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -830,10 +830,24 @@ function EditSlotDrawer({ open, slot, onClose }) {
                     onChange={e => setChatTemplate(e.target.value)}
                   >
                     <option value="auto">Auto (GGUF embedded)</option>
-                    {templates.map(t => (
-                      <option key={t.id} value={t.id}>{t.label || t.id}</option>
+                    {/* Filter out the backend's own "auto" entry — it's rendered
+                        above as a fixed first option. A template the render-lint
+                        flagged invalid is disabled so it can't be pinned (it would
+                        only crash the slot at cold-start). */}
+                    {templates.filter(t => t.id !== "auto").map(t => (
+                      <option key={t.id} value={t.id} disabled={t.valid === false}>
+                        {(t.label || t.id) + (t.valid === false ? "  ⚠ invalid" : "")}
+                      </option>
                     ))}
                   </select>
+                  {(() => {
+                    const sel = templates.find(t => t.id === chatTemplate);
+                    return sel && sel.valid === false ? (
+                      <div className="hint" style={{color: "var(--err)", marginTop: 4}}>
+                        ⚠ Template failed to render: {sel.error}
+                      </div>
+                    ) : null;
+                  })()}
                   <button
                     type="button"
                     className="btn ghost sm"


### PR DESCRIPTION
## What

The chat-template catalog already shipped end-to-end (store dir under `<model_store>/chat-templates/`, startup seed, `GET/POST /api/chat-templates`, `useChatTemplates` hook, slot-edit dropdown). The one gap: **no validation.** A malformed `.jinja` — dropped on the filesystem or POSTed with a typo — listed identically to a good template and only blew up when the slot tried to cold-start with it.

## Change

- **Backend** (`api/routes/chat_templates.py`): each catalog entry is render-checked against a sample 4-turn conversation in an `ImmutableSandboxedEnvironment` (with `raise_exception`/`strftime_now` stubs that real chat templates call). Entries now carry `valid: bool` + `error: str | null`; `auto` is always valid. `POST` echoes the same lint (write still lands — mirrors the filesystem-drop path).
- **UI** (`slot-modals.jsx`, `useChatTemplates.ts`): invalid templates are **disabled** in the dropdown, badged `⚠ invalid`, and the render error is shown under the select. Also de-dupes the backend's `auto` entry (it's a fixed first option).

## Caveat (documented in code)

Lint uses **Jinja2**, while llama.cpp renders with its own **minja** engine. They're close but not identical, so `valid` is a strong signal — not a guarantee — of minja compatibility. It reliably catches the common failure (a syntactically broken template).

## Tests

`tests/api/test_chat_templates.py` — valid / invalid (filesystem-drop) / `auto` / bundled-templates-lint-clean / POST-lint-echo. **15 pass.**

## Context

Fell out of diagnosing `<think></think>` tag leakage on the agent/chat/util slots (separate, already-applied slot-config fix: `--jinja --reasoning-format deepseek`). This hardens the template-override path so a hand-authored template fails loud in the UI instead of silently at slot start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)