### PR TITLE
fix(dashboard): harden slot MTP gate (backend) + strip NUL bytes in model-modals

### DIFF
--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -314,7 +314,7 @@ function RecipeEditorModal({ open, onClose, model }) {
     const prevTags = Array.isArray(model.tags) ? model.tags : [];
     const sameTags =
       nextTags.length === prevTags.length &&
-      [...nextTags].sort().join(" ") === [...prevTags].sort().join(" ");
+      [...nextTags].sort().join(" ") === [...prevTags].sort().join(" ");
     if (!sameTags) body.tags = nextTags;
     try {
       await update.mutateAsync({ id: model.id, body });

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -886,14 +886,19 @@ function EditSlotDrawer({ open, slot, onClose }) {
       )}
       {/* Task 2: MTP pill — capability-gated, rocm-only.
           Renders ONLY when the slot's loaded model has the "mtp" tag AND
-          the slot's device starts with "gpu-rocm". Toggle is instant-apply
+          the slot's backend is "rocm". Toggle is instant-apply
           via PUT /config (editMut) + non-blocking restart (mirrors the
           profile-change pattern above). */}
       {(() => {
         const cur = slot.model_id || slot.model || "";
         const m = (modelsQuery.data ?? []).map(normalizeApiModel).find(x => x.id === cur);
         const mtpCapable = Array.isArray(m?.tags) && m.tags.includes("mtp");
-        const isRocm = String(slot.device || "").startsWith("gpu-rocm");
+        // Gate on `backend` — the authoritative slot field the API emits.
+        // `device` ("gpu-rocm") is a client-side convenience synthesized by
+        // normalizeSlot from backend and is ABSENT on the raw slot shape, so
+        // keying off it alone is fragile; the device check stays only as a
+        // defensive fallback for any path that bypasses the normalizer.
+        const isRocm = slot.backend === "rocm" || String(slot.device || "").startsWith("gpu-rocm");
         if (!mtpCapable || !isRocm) return null;
         const mtpOn = slot.mtp === true;
         return (


### PR DESCRIPTION
## What
Two latent dashboard UI defects found while investigating a report that the per-slot **MTP toggle** and model **MTP-tag assignment** couldn't be used.

Both flows were verified working end-to-end against the live dashboard (model-editor tag PUT persists; slot toggle renders for mtp-tagged rocm slots) — the reported failure did not reproduce on the current build (likely a stale bundle from mid-session redeploys). But the investigation surfaced two real fragilities:

### 1. Slot MTP gate read a non-existent API field
`slot-modals.jsx` gated the MTP pill on `String(slot.device).startsWith("gpu-rocm")`. The `/api/slots` payload **never emits `device`** (it emits `backend` + `device_class`). The toggle only appeared because `normalizeSlot()` synthesizes `device` from `backend` before the slot reaches the drawer — so any code path bypassing the normalizer silently hides the toggle.

**Fix:** gate on `slot.backend === "rocm"` (authoritative field), keeping the `device` check as a defensive fallback.

### 2. Committed NUL bytes in model-modals.jsx
Line 317's `.join(" ")` delimiters were committed (in #895) as two literal **NUL bytes** (`.join("\x00")`). Behaviourally harmless (consistent delimiter; esbuild tolerates it) but it made the file register as **binary**, so `grep`/tooling silently skipped it. Restored the intended single-space delimiter — file is valid UTF-8 again.

## Verification
- 17/17 `slot-drawer-profile-v3` e2e tests pass (incl. C7i/C7j MTP pill)
- Both files esbuild-parse clean
- `model-modals.jsx` no longer registers as binary
- Live dashboard re-checked: model MTP-tag assignment + slot MTP toggle both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)