### PR TITLE
Stacks (feature) — design spec + PR-1: schema & catalog

### DIFF
--- a/docs/superpowers/plans/2026-06-19-stacks-pr1-schema-catalog.md
+++ b/docs/superpowers/plans/2026-06-19-stacks-pr1-schema-catalog.md
@@ -608,9 +608,11 @@ class TestUpdateAndDelete:
 class TestSeedGuard:
     def test_seed_stack_is_immutable(self, catalog: StacksCatalog, monkeypatch: pytest.MonkeyPatch) -> None:
         # Inject a seed entry so the guard has something to protect (SEED_STACKS
-        # is empty until PR-6). The catalog reads SEED_STACKS from the schema module.
+        # is empty until PR-6). The catalog reads SEED_STACKS from the schema
+        # module. No create() call: update()/delete() run _guard_custom() FIRST,
+        # so they raise on a seed slug regardless of whether it is on disk —
+        # and load_stacks_config already surfaces seeds when the file is absent.
         monkeypatch.setitem(schema.SEED_STACKS, "saber", _saber())
-        catalog.create("saber", _saber())
         with pytest.raises(Conflict):
             catalog.update("saber", StackConfig(name="hijack"))
         with pytest.raises(Conflict):

--- a/docs/superpowers/plans/2026-06-19-stacks-pr1-schema-catalog.md
+++ b/docs/superpowers/plans/2026-06-19-stacks-pr1-schema-catalog.md
@@ -1,0 +1,834 @@
+# Stacks — PR-1: Schema + Catalog — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the `StackConfig` data model and a `StacksCatalog` that reads/writes a single atomic `stacks.toml`, giving hal0 a validated, persisted, CRUD-able catalog of Stacks — the foundation all later PRs bind to.
+
+**Architecture:** Mirror the existing Profile subsystem exactly. New Pydantic models live beside `ProfileConfig` in `config/schema.py`; a single-file `stacks.toml` (keyed by slug) is read/written through `config/loader.py` using the existing `write_toml_atomic`; a `StacksCatalog` class in a new `hal0/stacks/` package provides list/resolve/create/update/delete with seed-immutability + slug guards, copying `ProfileCatalog` method-for-method.
+
+**Tech Stack:** Python 3.12, Pydantic v2, `tomllib`/`tomli_w`, pytest. No new dependencies.
+
+## Global Constraints
+
+- **Scope of this PR:** schema models + loader + catalog ONLY. No REST routes, no MCP tools, no apply engine, no export/import, no UI, no seed-stack content. Those are PRs 2–6.
+- **Storage layout:** single `stacks.toml` keyed by slug (mirrors `profiles.toml`), NOT per-file. This deviates from spec §4's per-file suggestion to reuse the verified `ProfileCatalog`/`load_profiles_config` code with zero invented helpers; the storage layout is internal and does not affect the JSON export envelope (PR-3) or the apply engine (PR-2). Recorded as a deliberate deviation.
+- **Pydantic config on every new model:** `model_config = {"populate_by_name": True, "extra": "forbid"}` — typos in TOML keys must raise at load, exactly like `ProfileConfig`.
+- **Slug rule (verbatim from existing slot/profile policy):** `^[a-z0-9][a-z0-9_-]{0,31}$` — lowercase alphanumeric + `-`/`_`, start alphanumeric, ≤32 chars.
+- **Errors:** raise `hal0.errors.NotFound` (404) and `hal0.errors.Conflict` (409) with `code=` strings under the `stacks.*` namespace; loader validation failures surface as `hal0.config.loader.ConfigParseError`.
+- **Atomic writes:** all persistence goes through `hal0.config.loader.write_toml_atomic`; serialize with `cfg.model_dump(mode="python", exclude_none=True)` (mirrors `save_profiles_config`).
+- **Stacks schema version:** `STACK_SCHEMA_VERSION_CURRENT = 1`, stored on `StackConfig.schema_version`. No migration is wired in this PR (v1 is the first shape); envelope migration is PR-3's concern.
+- **Test runner:** `~/dev/hal0/.venv/bin/python -m pytest <path> -q`. Tests isolate the filesystem with the existing `tmp_hal0_home` fixture (root `tests/conftest.py`) or an explicit `path=` argument. **Worktree caveat:** ensure the worktree is the active editable install (`~/dev/hal0/.venv/bin/pip install -e .` from the worktree root) or run with `PYTHONPATH=src` so pytest imports the worktree's `hal0`, not the main checkout's.
+- **Conventions:** test files `tests/<area>/test_*.py`; classes `Test<Feature>`; functions `test_<behavior>`; plain `assert`.
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `src/hal0/config/schema.py` | Add `StackModelMeta`, `StackCapabilityRow`, `StackSlotEntry`, `StackConfig`, `StacksConfig`, the version constant, and `SEED_STACKS` (empty until PR-6). | Modify (append a Stacks section after `ProfilesConfig`, ~line 906) |
+| `src/hal0/config/paths.py` | Add `stacks_toml()` path helper. | Modify (after `profiles_toml`, ~line 252) |
+| `src/hal0/config/loader.py` | Add `load_stacks_config()` / `save_stacks_config()`. | Modify (after `save_profiles_config`, ~line 449; extend the schema import) |
+| `src/hal0/stacks/__init__.py` | `StacksCatalog` + `ResolvedStack` + slug/seed guards. | Create |
+| `tests/config/test_stacks_schema.py` | Model validation tests. | Create |
+| `tests/config/test_stacks_loader.py` | Load/save round-trip + parse-error tests. | Create |
+| `tests/stacks/test_stacks_catalog.py` | Catalog CRUD + guard tests. | Create |
+
+---
+
+## Task 1: Stack schema models
+
+**Files:**
+- Modify: `src/hal0/config/schema.py` (append after `ProfilesConfig`, which ends ~line 906)
+- Test: `tests/config/test_stacks_schema.py`
+
+**Interfaces:**
+- Consumes: `pydantic.BaseModel/Field/field_validator`, the module's existing `_VALID_DEVICES` frozenset (schema.py:52) and `ProfileConfig` (schema.py:814).
+- Produces:
+  - `STACK_SCHEMA_VERSION_CURRENT: int = 1`
+  - `StackModelMeta(BaseModel)` — fields `id: str`, `name: str = ""`, `hf_repo: str = ""`, `hf_filename: str = ""`, `size_bytes: int = 0`, `quant: str = ""`, `capabilities: list[str] = []`, `backends: list[str] = []`, `mmproj: str | None = None`.
+  - `StackCapabilityRow(BaseModel)` — `child: str`, `device: str`, `provider: str`, `model: str`, `enabled: bool = True`.
+  - `StackSlotEntry(BaseModel)` — `slot: str`, `profile: str | None = None`, `model: str | None = None`, `device: str | None = None`, `provider: str | None = None`, `role: str | None = None`, `vision: bool = False`, `mtp: bool | None = None`, `enable_thinking: bool | None = None`, `server_extra_args: str | None = None`, `capabilities: list[StackCapabilityRow] = []`.
+  - `StackConfig(BaseModel)` — `name: str = ""`, `description: str = ""`, `author: str = ""`, `icon: str = ""`, `tags: list[str] = []`, `schema_version: int = STACK_SCHEMA_VERSION_CURRENT`, `hal0_version: str = ""`, `slots: list[StackSlotEntry] = []`, `profiles: dict[str, ProfileConfig] = {}`, `models: dict[str, StackModelMeta] = {}`.
+  - `StacksConfig(BaseModel)` — `stack: dict[str, StackConfig] = {}`.
+  - `SEED_STACKS: dict[str, StackConfig] = {}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/config/test_stacks_schema.py`:
+
+```python
+"""Unit tests for the Stack schema models.
+
+Targeted file run:
+    ~/dev/hal0/.venv/bin/python -m pytest tests/config/test_stacks_schema.py -q
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from hal0.config.schema import (
+    STACK_SCHEMA_VERSION_CURRENT,
+    StackCapabilityRow,
+    StackConfig,
+    StackModelMeta,
+    StackSlotEntry,
+    StacksConfig,
+)
+
+
+class TestStackModelMeta:
+    def test_minimal_requires_id(self) -> None:
+        m = StackModelMeta(id="chadrock-35b-ace-saber")
+        assert m.id == "chadrock-35b-ace-saber"
+        assert m.size_bytes == 0
+        assert m.capabilities == []
+        assert m.mmproj is None
+
+    def test_empty_id_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            StackModelMeta(id="   ")
+
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            StackModelMeta(id="m1", path="/mnt/ai-models/x.gguf")  # path is machine-specific, excluded
+
+
+class TestStackCapabilityRow:
+    def test_valid_row(self) -> None:
+        r = StackCapabilityRow(child="embed", device="npu", provider="flm", model="bge-m3")
+        assert r.enabled is True
+
+    def test_bad_device_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            StackCapabilityRow(child="embed", device="quantum", provider="flm", model="bge-m3")
+
+
+class TestStackSlotEntry:
+    def test_minimal_requires_slot(self) -> None:
+        e = StackSlotEntry(slot="agent")
+        assert e.slot == "agent"
+        assert e.vision is False
+        assert e.capabilities == []
+
+    def test_bad_slot_name_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            StackSlotEntry(slot="Agent Slot!")
+
+    def test_bad_device_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            StackSlotEntry(slot="agent", device="gpu-quantum")
+
+
+class TestStackConfig:
+    def test_defaults(self) -> None:
+        s = StackConfig()
+        assert s.name == ""
+        assert s.schema_version == STACK_SCHEMA_VERSION_CURRENT
+        assert s.slots == []
+        assert s.profiles == {}
+        assert s.models == {}
+
+    def test_full_round_trip_through_dict(self) -> None:
+        s = StackConfig(
+            name="Saber",
+            description="high-speed agentic MoE",
+            slots=[StackSlotEntry(slot="agent", model="chadrock-35b-ace-saber")],
+            models={"chadrock-35b-ace-saber": StackModelMeta(id="chadrock-35b-ace-saber")},
+        )
+        dumped = s.model_dump(mode="python", exclude_none=True)
+        again = StackConfig.model_validate(dumped)
+        assert again.slots[0].slot == "agent"
+        assert again.models["chadrock-35b-ace-saber"].id == "chadrock-35b-ace-saber"
+
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            StackConfig(surprise="nope")
+
+
+class TestStacksConfig:
+    def test_empty_default(self) -> None:
+        c = StacksConfig()
+        assert c.stack == {}
+
+    def test_keyed_by_slug(self) -> None:
+        c = StacksConfig(stack={"saber": StackConfig(name="Saber")})
+        assert c.stack["saber"].name == "Saber"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `~/dev/hal0/.venv/bin/python -m pytest tests/config/test_stacks_schema.py -q`
+Expected: FAIL with `ImportError: cannot import name 'StackConfig' from 'hal0.config.schema'`
+
+- [ ] **Step 3: Add the models to `schema.py`**
+
+Append immediately after the `ProfilesConfig` class (which ends ~line 906) in `src/hal0/config/schema.py`. The `_VALID_DEVICES` frozenset and `ProfileConfig` are already defined above in this module; no new imports are needed (`re` is imported lazily inside the validator, matching `name_valid` at schema.py:622).
+
+```python
+# ── Stacks ────────────────────────────────────────────────────────────────────
+# A Stack is a named, portable bundle of slots + their profiles + model
+# assignments + capability selections. Stored single-file in stacks.toml keyed
+# by slug, mirroring profiles.toml. See docs/superpowers/specs/2026-06-19-stacks-design.md.
+
+# Stacks carry their own schema version (independent of hal0.toml meta.schema_version),
+# stamped on every StackConfig and on the export envelope (PR-3).
+STACK_SCHEMA_VERSION_CURRENT = 1
+
+_STACK_NAME_RE = r"^[a-z0-9][a-z0-9_-]{0,31}$"
+
+
+class StackModelMeta(BaseModel):
+    """Transport-safe metadata subset of a registry ``Model``.
+
+    Embedded in a stack so an importer on another machine can resolve or
+    pull a referenced model by id. Deliberately excludes the machine-specific
+    ``path`` and any host-local fields — see spec §3/§6.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+    id: str = Field(..., description="Registry model id this entry describes.")
+    name: str = Field(default="", description="Human-readable display name.")
+    hf_repo: str = Field(default="", description="HuggingFace repo id, for resolve-and-pull on import.")
+    hf_filename: str = Field(default="", description="Filename within the HF repo.")
+    size_bytes: int = Field(default=0, description="Total model size in bytes; 0 = unknown.")
+    quant: str = Field(default="", description="Quantization label shown on cards (e.g. 'FP4', 'Q4_K_M').")
+    capabilities: list[str] = Field(default_factory=list, description="Capability strings, e.g. ['chat','vision'].")
+    backends: list[str] = Field(default_factory=list, description="Runnable backends, e.g. ['rocm','vulkan'].")
+    mmproj: str | None = Field(default=None, description="mmproj sidecar marker (presence flag); never a host path on import.")
+
+    @field_validator("id")
+    @classmethod
+    def id_nonempty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("stack model meta id must not be empty")
+        return v
+
+
+class StackCapabilityRow(BaseModel):
+    """One (slot, child) capability selection carried by a stack slot entry.
+
+    Mirrors the fields of ``hal0.capabilities.config.CapabilitySelection`` that
+    are portable; the apply engine (PR-2) translates these into real
+    CapabilitySelection rows at apply time.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+    child: str = Field(..., description="Capability child key, e.g. 'embed', 'rerank', 'stt', 'tts', 'vision'.")
+    device: str = Field(..., description="Device target for this child.")
+    provider: str = Field(..., description="Provider name for this child.")
+    model: str = Field(..., description="Model id bound to this child.")
+    enabled: bool = Field(default=True, description="Whether this child is active in the stack.")
+
+    @field_validator("device")
+    @classmethod
+    def device_valid(cls, v: str) -> str:
+        if v not in _VALID_DEVICES:
+            raise ValueError(f"device {v!r}: must be one of {sorted(_VALID_DEVICES)}")
+        return v
+
+
+class StackSlotEntry(BaseModel):
+    """One slot's contribution to a stack: which model/profile/caps it carries.
+
+    References models and profiles by name/id; the embedded ``profiles`` and
+    ``models`` maps on the parent ``StackConfig`` carry the metadata needed to
+    resolve those references on another machine.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+    slot: str = Field(..., description="Slot name this entry configures (kebab-case).")
+    profile: str | None = Field(default=None, description="Profile name reference (resolved against StackConfig.profiles).")
+    model: str | None = Field(default=None, description="Model id reference (resolved against StackConfig.models).")
+    device: str | None = Field(default=None, description="Device override for the slot.")
+    provider: str | None = Field(default=None, description="Provider override for the slot.")
+    role: str | None = Field(default=None, description="Normalization role hint, e.g. 'primary'.")
+    vision: bool = Field(default=False, description="Enable the mmproj vision sidecar for this slot.")
+    mtp: bool | None = Field(default=None, description="Per-slot MTP override (inherits profile default when None).")
+    enable_thinking: bool | None = Field(default=None, description="Per-slot reasoning override.")
+    server_extra_args: str | None = Field(default=None, description="Freeform llama-server CLI flags for this slot.")
+    capabilities: list[StackCapabilityRow] = Field(default_factory=list, description="Capability child selections.")
+
+    @field_validator("slot")
+    @classmethod
+    def slot_valid(cls, v: str) -> str:
+        import re
+
+        if not v or not v.strip():
+            raise ValueError("slot name must not be empty")
+        if not re.match(_STACK_NAME_RE, v):
+            raise ValueError(
+                f"slot name {v!r}: use lowercase alphanumeric, hyphens, underscores; "
+                f"start with alphanumeric; max 32 chars"
+            )
+        return v
+
+    @field_validator("device")
+    @classmethod
+    def device_valid(cls, v: str | None) -> str | None:
+        if v is not None and v not in _VALID_DEVICES:
+            raise ValueError(f"device {v!r}: must be one of {sorted(_VALID_DEVICES)}")
+        return v
+
+
+class StackConfig(BaseModel):
+    """One ``[stack.<slug>]`` entry in stacks.toml.
+
+    A curated bundle of slots + embedded profiles + embedded model metadata.
+    The slug is the dict key (validated by StacksCatalog on create), not a
+    field here — mirroring ProfileConfig. ``name`` is the human display label.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+    name: str = Field(default="", description="Human display label (falls back to slug in the UI).")
+    description: str = Field(default="", description="What this stack is for.")
+    author: str = Field(default="", description="Author/provenance, for the future directory.")
+    icon: str = Field(default="", description="Accent token or emoji shown on the card.")
+    tags: list[str] = Field(default_factory=list, description="Freeform tags for listing/filtering.")
+    schema_version: int = Field(
+        default=STACK_SCHEMA_VERSION_CURRENT,
+        description="Stack schema version, stamped for forward-compat / envelope migration.",
+    )
+    hal0_version: str = Field(default="", description="hal0 version that produced this stack (provenance).")
+    slots: list[StackSlotEntry] = Field(default_factory=list, description="Slots this stack configures.")
+    profiles: dict[str, ProfileConfig] = Field(
+        default_factory=dict,
+        description="Embedded profiles referenced by slots, so the stack is self-contained.",
+    )
+    models: dict[str, StackModelMeta] = Field(
+        default_factory=dict,
+        description="Embedded model metadata (no weights) for referenced model ids.",
+    )
+
+
+class StacksConfig(BaseModel):
+    """Parsed stacks.toml — top-level ``[stack]`` table, keyed by slug."""
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+    stack: dict[str, StackConfig] = Field(default_factory=dict)
+
+
+# Built-in seed stacks (immutable, clone-only). Empty until PR-6 fills it with
+# saber/forge/pi. StacksCatalog consults this for the seed-immutability guard.
+SEED_STACKS: dict[str, StackConfig] = {}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `~/dev/hal0/.venv/bin/python -m pytest tests/config/test_stacks_schema.py -q`
+Expected: PASS (13 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/halo/dev/wt/stacks-spec
+git add src/hal0/config/schema.py tests/config/test_stacks_schema.py
+git commit -m "feat(stacks): StackConfig schema models + validation"
+```
+
+---
+
+## Task 2: Path helper + loader (load/save stacks.toml)
+
+**Files:**
+- Modify: `src/hal0/config/paths.py` (after `profiles_toml`, ~line 252)
+- Modify: `src/hal0/config/loader.py` (extend the `hal0.config.schema` import block ~line 29; add functions after `save_profiles_config`, ~line 449)
+- Test: `tests/config/test_stacks_loader.py`
+
+**Interfaces:**
+- Consumes: `write_toml_atomic` (loader.py:69), `_read_toml` (loader.py:117), `ConfigParseError` (loader.py:62), `paths.etc()` (paths.py:55), and `StacksConfig`/`SEED_STACKS` from Task 1.
+- Produces:
+  - `paths.stacks_toml() -> Path` → `etc() / "stacks.toml"`.
+  - `loader.load_stacks_config(path: Path | None = None) -> StacksConfig` — absent file returns `StacksConfig.model_validate({"stack": SEED_STACKS})`; malformed/invalid raises `ConfigParseError`.
+  - `loader.save_stacks_config(cfg: StacksConfig, path: Path | None = None) -> None` — atomic write via `write_toml_atomic` with `model_dump(mode="python", exclude_none=True)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/config/test_stacks_loader.py`:
+
+```python
+"""Unit tests for the stacks.toml loader/saver.
+
+Targeted file run:
+    ~/dev/hal0/.venv/bin/python -m pytest tests/config/test_stacks_loader.py -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.config.loader import ConfigParseError, load_stacks_config, save_stacks_config
+from hal0.config.schema import StackConfig, StackSlotEntry, StacksConfig
+
+
+class TestLoadStacksConfig:
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        cfg = load_stacks_config(path=tmp_path / "nonexistent.toml")
+        assert cfg.stack == {}
+
+    def test_round_trip_save_then_load(self, tmp_path: Path) -> None:
+        target = tmp_path / "stacks.toml"
+        cfg = StacksConfig(
+            stack={
+                "saber": StackConfig(
+                    name="Saber",
+                    description="high-speed agentic MoE",
+                    slots=[StackSlotEntry(slot="agent", model="chadrock-35b-ace-saber")],
+                )
+            }
+        )
+        save_stacks_config(cfg, path=target)
+        assert target.exists()
+        loaded = load_stacks_config(path=target)
+        assert "saber" in loaded.stack
+        assert loaded.stack["saber"].name == "Saber"
+        assert loaded.stack["saber"].slots[0].model == "chadrock-35b-ace-saber"
+
+    def test_invalid_toml_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "stacks.toml"
+        p.write_bytes(b"[stack\nbad toml <<<")
+        with pytest.raises(ConfigParseError):
+            load_stacks_config(path=p)
+
+    def test_unknown_field_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "stacks.toml"
+        p.write_bytes(b'[stack.x]\nname = "X"\nnot_a_field = "surprise"\n')
+        with pytest.raises(ConfigParseError):
+            load_stacks_config(path=p)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `~/dev/hal0/.venv/bin/python -m pytest tests/config/test_stacks_loader.py -q`
+Expected: FAIL with `ImportError: cannot import name 'load_stacks_config' from 'hal0.config.loader'`
+
+- [ ] **Step 3a: Add the path helper**
+
+In `src/hal0/config/paths.py`, after `profiles_toml()` (~line 252), add:
+
+```python
+def stacks_toml() -> Path:
+    """Return the stack catalog path (/etc/hal0/stacks.toml).
+
+    The file is optional — :func:`hal0.config.loader.load_stacks_config`
+    returns the built-in seed stacks (empty until they ship) when absent.
+
+    FHS:       /etc/hal0/stacks.toml
+    HAL0_HOME: $HAL0_HOME/etc/hal0/stacks.toml
+    """
+    return etc() / "stacks.toml"
+```
+
+- [ ] **Step 3b: Extend the loader's schema import**
+
+In `src/hal0/config/loader.py`, the import from `hal0.config.schema` (~line 29-39) currently lists `ProfileConfig, ProfilesConfig, ...`. Add `SEED_STACKS` and `StacksConfig` to that import list (alphabetical placement within the existing parenthesized import):
+
+```python
+from hal0.config.schema import (
+    CURRENT_SCHEMA_VERSION,
+    SEED_PROFILES,
+    SEED_STACKS,
+    AgentConfig,
+    Hal0Config,
+    HardwareInfo,
+    ProfileConfig,
+    ProfilesConfig,
+    ProvidersConfig,
+    SlotConfig,
+    StacksConfig,
+    UpstreamsConfig,
+)
+```
+
+- [ ] **Step 3c: Add the loader functions**
+
+In `src/hal0/config/loader.py`, after `save_profiles_config` (~line 449), add:
+
+```python
+# ── stacks.toml ───────────────────────────────────────────────────────────────
+
+
+def load_stacks_config(path: Path | None = None) -> StacksConfig:
+    """Load and validate /etc/hal0/stacks.toml.
+
+    Returns the built-in seed stacks (``SEED_STACKS``, empty until they ship)
+    when the file is absent, so the catalog is always well-formed on a fresh
+    install. When the file is present, only its contents are returned — seeds
+    are NOT merged in (load REPLACES, mirroring ``load_profiles_config``).
+
+    Raises:
+        ConfigParseError: If the TOML is malformed or fails validation.
+    """
+    target = path if path is not None else paths.stacks_toml()
+    if not Path(target).exists():
+        return StacksConfig.model_validate({"stack": SEED_STACKS})
+    raw = _read_toml(Path(target))
+    try:
+        return StacksConfig.model_validate(raw)
+    except Exception as exc:
+        raise ConfigParseError(
+            f"failed to validate stacks.toml at {target}: {exc}",
+            details={"path": str(target), "reason": str(exc)},
+        ) from exc
+
+
+def save_stacks_config(cfg: StacksConfig, path: Path | None = None) -> None:
+    """Atomically write the full stack catalog to stacks.toml.
+
+    The written file is the single source of truth; callers must pass the
+    COMPLETE catalog (start from ``load_stacks_config()``, then add/modify)
+    so existing stacks survive the round trip. ``exclude_none=True`` keeps
+    tomli_w from raising on optional None fields, mirroring
+    :func:`save_profiles_config`.
+    """
+    target = Path(path) if path is not None else paths.stacks_toml()
+    write_toml_atomic(target, cfg.model_dump(mode="python", exclude_none=True))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `~/dev/hal0/.venv/bin/python -m pytest tests/config/test_stacks_loader.py -q`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/halo/dev/wt/stacks-spec
+git add src/hal0/config/paths.py src/hal0/config/loader.py tests/config/test_stacks_loader.py
+git commit -m "feat(stacks): stacks.toml path helper + atomic loader/saver"
+```
+
+---
+
+## Task 3: StacksCatalog (CRUD + guards)
+
+**Files:**
+- Create: `src/hal0/stacks/__init__.py`
+- Test: `tests/stacks/test_stacks_catalog.py`
+
+**Interfaces:**
+- Consumes: `load_stacks_config`/`save_stacks_config` (Task 2); `StackConfig`/`StackSlotEntry`/`StackModelMeta`/`ProfileConfig` (for `ResolvedStack` typing) and the `schema.SEED_STACKS` module attribute (Task 1); `NotFound`/`Conflict` (`hal0.errors`); `paths.stacks_toml`. Defines its own compiled `_STACK_NAME_RE` (does not import the schema string version).
+- Produces:
+  - `ResolvedStack` dataclass — `slug: str`, `name: str`, `description: str`, `author: str`, `icon: str`, `tags: tuple[str, ...]`, `slots: list[StackSlotEntry]`, `profiles: dict[str, ProfileConfig]`, `models: dict[str, StackModelMeta]`, `schema_version: int`, `hal0_version: str`, `seed: bool`.
+  - `StacksCatalog` class with `list() -> list[ResolvedStack]`, `resolve(slug) -> ResolvedStack`, `create(slug, StackConfig) -> ResolvedStack`, `update(slug, StackConfig) -> ResolvedStack` (full replace), `delete(slug) -> None`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/stacks/test_stacks_catalog.py`:
+
+```python
+"""Unit tests for StacksCatalog CRUD + guards.
+
+Targeted file run:
+    ~/dev/hal0/.venv/bin/python -m pytest tests/stacks/test_stacks_catalog.py -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.config import schema
+from hal0.config.schema import StackConfig, StackSlotEntry
+from hal0.errors import Conflict, NotFound
+from hal0.stacks import ResolvedStack, StacksCatalog
+
+
+@pytest.fixture
+def catalog(tmp_path: Path) -> StacksCatalog:
+    return StacksCatalog(path=tmp_path / "stacks.toml")
+
+
+def _saber() -> StackConfig:
+    return StackConfig(
+        name="Saber",
+        description="high-speed agentic MoE",
+        slots=[StackSlotEntry(slot="agent", model="chadrock-35b-ace-saber")],
+    )
+
+
+class TestCreateAndRead:
+    def test_create_then_resolve(self, catalog: StacksCatalog) -> None:
+        created = catalog.create("saber", _saber())
+        assert isinstance(created, ResolvedStack)
+        assert created.slug == "saber"
+        assert created.seed is False
+        got = catalog.resolve("saber")
+        assert got.name == "Saber"
+        assert got.slots[0].slot == "agent"
+
+    def test_create_then_list(self, catalog: StacksCatalog) -> None:
+        catalog.create("saber", _saber())
+        slugs = [r.slug for r in catalog.list()]
+        assert slugs == ["saber"]
+
+    def test_create_duplicate_raises_conflict(self, catalog: StacksCatalog) -> None:
+        catalog.create("saber", _saber())
+        with pytest.raises(Conflict):
+            catalog.create("saber", _saber())
+
+    def test_create_invalid_slug_raises_conflict(self, catalog: StacksCatalog) -> None:
+        with pytest.raises(Conflict):
+            catalog.create("Saber Slot!", _saber())
+
+    def test_resolve_missing_raises_not_found(self, catalog: StacksCatalog) -> None:
+        with pytest.raises(NotFound):
+            catalog.resolve("ghost")
+
+
+class TestUpdateAndDelete:
+    def test_update_replaces(self, catalog: StacksCatalog) -> None:
+        catalog.create("saber", _saber())
+        updated = catalog.update("saber", StackConfig(name="Saber v2"))
+        assert updated.name == "Saber v2"
+        assert updated.slots == []
+
+    def test_update_missing_raises_not_found(self, catalog: StacksCatalog) -> None:
+        with pytest.raises(NotFound):
+            catalog.update("ghost", _saber())
+
+    def test_delete(self, catalog: StacksCatalog) -> None:
+        catalog.create("saber", _saber())
+        catalog.delete("saber")
+        assert catalog.list() == []
+
+    def test_delete_missing_raises_not_found(self, catalog: StacksCatalog) -> None:
+        with pytest.raises(NotFound):
+            catalog.delete("ghost")
+
+
+class TestSeedGuard:
+    def test_seed_stack_is_immutable(self, catalog: StacksCatalog, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Inject a seed entry so the guard has something to protect (SEED_STACKS
+        # is empty until PR-6). The catalog reads SEED_STACKS from the schema module.
+        monkeypatch.setitem(schema.SEED_STACKS, "saber", _saber())
+        catalog.create("saber", _saber())
+        with pytest.raises(Conflict):
+            catalog.update("saber", StackConfig(name="hijack"))
+        with pytest.raises(Conflict):
+            catalog.delete("saber")
+
+
+class TestPersistence:
+    def test_persists_across_catalog_instances(self, tmp_path: Path) -> None:
+        path = tmp_path / "stacks.toml"
+        StacksCatalog(path=path).create("saber", _saber())
+        # Fresh catalog instance reads the written file.
+        assert any(r.slug == "saber" for r in StacksCatalog(path=path).list())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `~/dev/hal0/.venv/bin/python -m pytest tests/stacks/test_stacks_catalog.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'hal0.stacks'`
+
+- [ ] **Step 3: Implement the catalog**
+
+Create `src/hal0/stacks/__init__.py`:
+
+```python
+"""StacksCatalog — read and mutate the stack catalog through one interface.
+
+A stack is a named bundle of slots + embedded profiles + embedded model
+metadata. This module concentrates the stack interface, mirroring
+``hal0.profiles.ProfileCatalog``:
+
+* full-catalog reads and atomic full-catalog writes (single stacks.toml);
+* seed immutability and duplicate-slug checks;
+* slug validation.
+
+Routes (PR-4) and the apply engine (PR-2) are adapters over this module.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+from hal0.config import paths, schema
+from hal0.config.loader import load_stacks_config, save_stacks_config
+from hal0.config.schema import (
+    ProfileConfig,
+    StackConfig,
+    StackModelMeta,
+    StackSlotEntry,
+)
+from hal0.errors import Conflict, NotFound
+
+log = logging.getLogger(__name__)
+
+_STACK_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
+
+
+@dataclass(frozen=True)
+class ResolvedStack:
+    """A stack plus derived fields (slug + seed flag) for API/UI consumption."""
+
+    slug: str
+    name: str
+    description: str
+    author: str
+    icon: str
+    tags: tuple[str, ...]
+    slots: list[StackSlotEntry]
+    profiles: dict[str, ProfileConfig]
+    models: dict[str, StackModelMeta]
+    schema_version: int
+    hal0_version: str
+    seed: bool
+
+
+class StacksCatalog:
+    """Read and mutate the stack catalog through one interface."""
+
+    def __init__(self, *, path: Path | None = None) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+
+    def _path_or_default(self) -> Path:
+        return self._path or paths.stacks_toml()
+
+    def list(self) -> list[ResolvedStack]:
+        cfg = load_stacks_config(self._path)
+        return [self._resolve_item(slug, stack) for slug, stack in cfg.stack.items()]
+
+    def resolve(self, slug: str) -> ResolvedStack:
+        cfg = load_stacks_config(self._path)
+        stack = cfg.stack.get(slug)
+        if stack is None:
+            raise NotFound(
+                f"stack {slug!r} not found",
+                code="stacks.not_found",
+                details={"stack": slug, "available": sorted(cfg.stack)},
+            )
+        return self._resolve_item(slug, stack)
+
+    def create(self, slug: str, stack: StackConfig) -> ResolvedStack:
+        self._validate_name(slug)
+        with self._lock:
+            catalog = load_stacks_config(self._path)
+            if slug in catalog.stack:
+                raise Conflict(
+                    f"stack {slug!r} already exists",
+                    code="stacks.exists",
+                    details={"stack": slug},
+                )
+            catalog.stack[slug] = stack
+            save_stacks_config(catalog, self._path)
+        return self._resolve_item(slug, stack)
+
+    def update(self, slug: str, stack: StackConfig) -> ResolvedStack:
+        """Replace the stack body wholesale (PUT semantics)."""
+        self._guard_custom(slug)
+        with self._lock:
+            catalog = load_stacks_config(self._path)
+            if slug not in catalog.stack:
+                raise NotFound(
+                    f"stack {slug!r} not found",
+                    code="stacks.not_found",
+                    details={"stack": slug},
+                )
+            catalog.stack[slug] = stack
+            save_stacks_config(catalog, self._path)
+        return self._resolve_item(slug, stack)
+
+    def delete(self, slug: str) -> None:
+        self._guard_custom(slug)
+        with self._lock:
+            catalog = load_stacks_config(self._path)
+            if slug not in catalog.stack:
+                raise NotFound(
+                    f"stack {slug!r} not found",
+                    code="stacks.not_found",
+                    details={"stack": slug},
+                )
+            del catalog.stack[slug]
+            save_stacks_config(catalog, self._path)
+
+    def _resolve_item(self, slug: str, stack: StackConfig) -> ResolvedStack:
+        return ResolvedStack(
+            slug=slug,
+            name=stack.name,
+            description=stack.description,
+            author=stack.author,
+            icon=stack.icon,
+            tags=tuple(stack.tags),
+            slots=stack.slots,
+            profiles=stack.profiles,
+            models=stack.models,
+            schema_version=stack.schema_version,
+            hal0_version=stack.hal0_version,
+            seed=slug in schema.SEED_STACKS,
+        )
+
+    def _guard_custom(self, slug: str) -> None:
+        if slug in schema.SEED_STACKS:
+            raise Conflict(
+                f"stack {slug!r} is a seed stack — seed stacks are immutable; "
+                "clone under a new name",
+                code="stacks.seed_immutable",
+                details={"stack": slug},
+            )
+
+    def _validate_name(self, slug: str) -> None:
+        if not _STACK_NAME_RE.match(slug):
+            raise Conflict(
+                "stack slug must be kebab-case (a-z0-9_-), ≤32 chars, start with alphanumeric",
+                code="stacks.invalid_name",
+                details={"stack": slug},
+            )
+```
+
+Note: the seed guard reads `schema.SEED_STACKS` (module attribute access, not a captured import) so the test's `monkeypatch.setitem(schema.SEED_STACKS, ...)` is observed.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `~/dev/hal0/.venv/bin/python -m pytest tests/stacks/test_stacks_catalog.py -q`
+Expected: PASS (11 tests)
+
+- [ ] **Step 5: Run the full new-test set + a sanity import**
+
+Run: `~/dev/hal0/.venv/bin/python -m pytest tests/config/test_stacks_schema.py tests/config/test_stacks_loader.py tests/stacks/test_stacks_catalog.py -q`
+Expected: PASS (28 tests total)
+
+Run: `~/dev/hal0/.venv/bin/python -c "from hal0.stacks import StacksCatalog; from hal0.config.loader import load_stacks_config; print('ok')"`
+Expected: prints `ok`
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/halo/dev/wt/stacks-spec
+git add src/hal0/stacks/__init__.py tests/stacks/test_stacks_catalog.py
+git commit -m "feat(stacks): StacksCatalog CRUD with slug + seed guards"
+```
+
+---
+
+## PR-1 Done — Definition of Done
+
+- `StackConfig` and friends validate and round-trip through TOML.
+- `stacks.toml` loads/saves atomically; absent file yields the (empty) seed set; malformed file raises `ConfigParseError`.
+- `StacksCatalog` does list/resolve/create/update/delete with duplicate, slug, seed, and not-found guards, and persists across instances.
+- 28 new tests pass; no existing test regressed (`~/dev/hal0/.venv/bin/python -m pytest tests/config tests/stacks -q`).
+- No routes/MCP/UI/apply/export yet — those are PRs 2–6.
+
+---
+
+## Roadmap — remaining PRs (each gets its own plan, written against PR-1's merged code)
+
+- **PR-2 — Apply engine + drift.** Translate a `StackConfig` into a `SlotConfigStore` `ChangeSet` (slot TOML + capabilities.toml + embedded profiles), expose dry-run (compute-only) vs commit (atomic, rollback) + Phase-B `SlotManager` lifecycle convergence (load named, unload rest), and add the active-stack pointer (`/var/lib/hal0/stacks/state.json`) + content-hash drift status (`clean`/`modified`/`none`). Plan written against the real `SlotConfigStore.apply/commit/revert` and `CapabilityOrchestrator.apply` signatures.
+- **PR-3 — Export / import.** `.hal0stack.json` envelope (`kind`, `schema_version`, `hal0_version`, `exported_at`, `checksum`, `stack`); build `StackModelMeta` from registry `Model`s on export; on import, run the schema-version walk, then the resolve-pass (present / pullable via `registry/pull.py` / unresolvable) and snapshot-from-live.
+- **PR-4 — REST + MCP.** `src/hal0/api/routes/stacks.py` mirroring `routes/profiles.py` (list/create/get/update/delete + apply?dry_run + export + import?dry_run + snapshot); register on the app; MCP admin tools `stack_list`/`stack_status` (autonomous) + `stack_apply`/`stack_import`/`stack_delete` (gated via ApprovalQueue). Route tests mirror `tests/api/test_profiles_*`.
+- **PR-5 — Dashboard UI.** `#slots/stacks` sub-page (nav child in `chrome.jsx` + `renderView` case in `main.jsx`); `ui/src/api/hooks/useStacks.ts` + `endpoints.ts` constants copying `useProfiles.ts`; card grid (reuse `DCard`/`StatusDot`) with Active ribbon + drift badge; editor `Drawer` slot-picker; diff-preview modal; import file-drop with resolve report + Pull buttons.
+- **PR-6 — Seed stacks + docs.** Fill `SEED_STACKS` with `saber`/`forge`/`pi` (exact registry ids per spec §10) as installer seed TOML under `installer/etc-hal0/`; add a Stacks doc page in `hal0-web`.

--- a/docs/superpowers/specs/2026-06-19-stacks-design.md
+++ b/docs/superpowers/specs/2026-06-19-stacks-design.md
@@ -1,0 +1,327 @@
+# Stacks — Design Spec
+
+- **Status:** Approved design, pre-implementation
+- **Date:** 2026-06-19
+- **Author:** Alexander (via Claude)
+- **Target repo:** `hal0` (runtime + `ui/` dashboard). Docs page lands in `hal0-web`.
+- **Branch:** `feat/stacks-spec`
+
+## 1. Summary
+
+A **Stack** is a named, portable, editable bundle that captures *"what models are
+serving, and how"* — a curated grouping of slots, their profiles, their model
+assignments, and their capability selections. Stacks can be created, edited,
+cloned, applied (loaded), snapshotted from live state, exported to a shareable
+file, and imported. They are the runtime, user-facing successor to the existing
+first-run-only **Bundles** picker (`src/hal0/bundles/`).
+
+The feature is a quality-of-life multiplier: instead of hand-configuring eight
+slots one at a time, a user loads "Coding" or "Voice" in one action, with a
+diff preview before anything changes. Exported stacks let users share working
+configurations with each other; the export format is shaped so a future public
+**directory of stacks** is "just a server that lists these files."
+
+### Approved decisions (brainstorming, 2026-06-19)
+
+| Decision | Choice |
+| --- | --- |
+| **Composition** | Curated bundle — user hand-picks slots + profile + model + capabilities. Carries model **ids + registry metadata**, never weights. Embeds referenced custom profiles. |
+| **Apply mode** | Declarative / replace — applying makes the system *match* the stack; un-named slots are unloaded (config preserved). Always shows a dry-run diff first. |
+| **Import resolve** | Resolve & offer to pull — diff model refs vs local registry; offer one-click pull for missing models that carry `hf_repo`; flag unresolvable refs. |
+| **Scope reach** | Inference surface only — slots, profiles, model assignments, capabilities. No providers/upstreams, dispatcher, memory, telemetry in v1. |
+| **Drift layer** | In v1 — active-stack pointer + clean/modified drift status + "update from live" / "re-apply". |
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Group slots + profiles + model assignments + capability selections into a named, editable unit.
+- One-action **apply** with a mandatory dry-run diff preview and transactional, reversible commit.
+- **Snapshot** the current live config into a new stack.
+- **Export / import** as a single portable `.hal0stack.json`, secrets excluded by construction.
+- **Resolve & pull** missing models on import via the existing pull engine.
+- Track the **active stack** and surface **drift** (live config diverged from applied stack).
+- Ship a handful of curated **seed stacks** (clone-only) for day-one value.
+
+**Non-goals (v1)**
+- No public stack directory/registry (format is shaped for it; the service is out of scope).
+- No bundling of GGUF weights on the default export path (optional local-backup mode only).
+- No providers/upstreams, dispatcher, memory, or telemetry config in a stack.
+- No cross-version downgrade migrations (forward-only, matching existing framework).
+
+## 3. Data model
+
+A Stack composes existing primitives **by reference**, with two deliberate
+exceptions (profiles embedded, model metadata embedded) so a stack survives
+transport to another machine.
+
+```
+Stack
+├─ meta:           name, slug, description, author, icon/accent, tags[]
+├─ schema_version, hal0_version          # provenance
+├─ slots[]:        for each included slot →
+│                    slot config fields (device, provider, role, vision, mtp,
+│                                        enable_thinking, server.extra_args, npu, image)
+│                    + profile  (by name → resolved against embedded profiles{})
+│                    + model    (model id → resolved against embedded models{})
+│                    + capabilities[]  (the (slot, child) device/provider/model/enabled rows)
+├─ profiles{}:     embedded ProfileConfig for each referenced profile name
+│                    (so a custom profile travels with the stack)
+└─ models{}:       registry METADATA per referenced model id
+                     (id, name, hf_repo, hf_filename, quant, size_bytes,
+                      capabilities[], backends[], mmproj) — metadata only, no weights
+```
+
+**Why two binding layers.** Slots already reference models by id string
+(`config/schema.py:149`) and profiles by name (`config/schema.py` SlotConfig
+`profile`). A stack keeps those references intact, and additionally carries:
+- an **embedded profile** per referenced name — because a shared stack that only
+  referenced a custom profile would import broken on a box that lacks it;
+- a **model-metadata sidecar** per referenced id — because the importer needs
+  `hf_repo`/`hf_filename` to offer a pull when the model is absent.
+
+**Excluded by construction.**
+- **GGUF weights** — models bind by id (`registry/model.py:54`), weights live
+  separately under the model store and are multi-GB.
+- **Secrets** — provider/upstream auth is stored as env-var *names* in `api.env`
+  (`config/schema.py:678`, `api/_env_store.py`), never in slot/profile/capability
+  config. The inference-surface scope never touches them, so exports carry no secret.
+- **Machine-specific absolute paths** — model `path` / model roots are *never
+  trusted from an import*; the importer always re-resolves by id against the
+  local registry (see §6).
+
+### Pydantic models (new)
+
+Mirrors `ProfileCatalog` (`src/hal0/profiles/__init__.py:129`):
+
+- `StackSlotEntry` — one slot's contribution (config fields + profile name + model id + capability rows).
+- `StackConfig` — meta + `schema_version` + `slots: list[StackSlotEntry]` + `profiles: dict[str, ProfileConfig]` + `models: dict[str, StackModelMeta]`.
+- `StackModelMeta` — the metadata subset of `registry/model.py:Model` safe to embed.
+- `StacksCatalog` — CRUD + atomic TOML I/O + seed-immutability guard, mirroring `ProfileCatalog`.
+
+Field validators reuse existing conventions: slug regex `^[a-z0-9][a-z0-9_-]{0,31}$`
+(as `SlotConfig.name`, `config/schema.py:620`).
+
+## 4. Storage & format
+
+| Artifact | Path | Format | Written via |
+| --- | --- | --- | --- |
+| Stack (canonical) | `/etc/hal0/stacks/<slug>.toml` | TOML | `write_toml_atomic()` (`config/loader.py:69`) |
+| Active pointer | `/var/lib/hal0/stacks/state.json` | JSON | `write_state_atomic()` pattern (`slots/state.py:269`) |
+| Export/import wire | `<name>.hal0stack.json` | JSON | API download / upload |
+
+Paths added to `src/hal0/config/paths.py` alongside the existing slot/profile/
+registry path helpers.
+
+**On-disk = TOML** to match every other hal0 config file and the atomic-write
+discipline. **Wire = JSON** because it is web-native, diff-friendly, trivially
+signable, and directory-ready.
+
+### Wire envelope (`.hal0stack.json`)
+
+```jsonc
+{
+  "kind": "hal0.stack",
+  "schema_version": 1,
+  "hal0_version": "0.7.x",
+  "exported_at": "<ISO8601>",     // stamped by the API handler at export time
+  "checksum": "sha256:…",         // over the canonicalized `stack` body
+  "stack": { /* StackConfig with profiles{} and models{} embedded */ }
+}
+```
+
+The envelope rides the **existing schema-version + migration framework**
+(`src/hal0/config/migrations/`): on import, an older `schema_version` is walked
+forward via `run_migrations()` (`config/migrations/__init__.py:75`) before validation.
+
+## 5. Apply engine — declarative, two-phase, reversible
+
+Applying a stack converges the system to match it. Built on the transactional
+primitive that already exists.
+
+**Phase A — config (atomic, reversible).** Compute one `ChangeSet` spanning every
+affected `slots/<name>.toml` + `capabilities.toml` + any new `profiles.toml`
+entries, via `SlotConfigStore.apply()` (`src/hal0/slot_config/__init__.py:163`).
+`apply()` writes nothing — it returns before/after snapshots.
+- `commit()` (`slot_config/__init__.py:200`) writes all files atomically with
+  rollback-on-partial-failure.
+- `revert()` (`slot_config/__init__.py:222`) restores the before snapshots.
+- Slots **named** in the stack are configured (profile + model + capabilities + slot fields).
+- Slots **not** in the stack are marked disabled for unload; their TOML is preserved.
+
+**Phase B — lifecycle convergence.** Drive `SlotManager` to match the committed
+config: load/swap named slots to their assigned models, unload the rest. Reuses
+the exact lifecycle path `CapabilityOrchestrator.apply` already uses
+(`src/hal0/capabilities/orchestrator.py:164+` → SlotManager).
+
+**Dry-run diff preview (always).** Because Phase A is compute-only, the API and
+UI render a real before→after diff before any commit (e.g. *"start `agent` on
+ace-saber, swap `chat` to crown-halo, stop `img`"*). No surprise applies. This
+is the safety rail that makes declarative/replace comfortable.
+
+**Failure handling.** A Phase-A commit failure rolls back to `before` (existing
+`SlotConfigStore` invariant). A Phase-B lifecycle failure on an individual slot
+is surfaced per-slot (the slot state machine already models `ERROR`,
+`slots/state.py:51`) without unwinding the committed config; the user sees which
+slots converged and which need attention.
+
+## 6. Import / export & portability
+
+**Export.** Serialize the stack, embed each referenced `ProfileConfig`, embed
+each referenced model's metadata subset, stamp `exported_at` + `checksum`, emit
+`.hal0stack.json`. Two paths:
+- **Export** (default) — lightweight, metadata-only, the sharing/directory path.
+- **Export with weights** (guarded) — large `.tar` including GGUFs, for *local
+  full-backup only*; visually de-emphasized and never the directory path.
+
+**Import.** Parse + validate envelope → `run_migrations()` to current schema →
+**resolve pass** diffing model refs against the local registry. Per model:
+- ✅ **present** → bind by id.
+- ⬇️ **missing, has `hf_repo`** → offer one-click pull via the existing pull
+  engine (`src/hal0/registry/pull.py`), with progress over the existing SSE pull
+  stream (`/api/models/{id}/pull/stream`).
+- ⚠️ **missing, unresolvable** → flag; that slot imports disabled with a clear reason.
+
+Embedded profiles are reconciled into `profiles.toml` on import (created if
+absent; name-collision prompts clone-with-suffix, never silent overwrite).
+
+**Machine-specific safety.** Absolute model `path`, model roots, and any host URL
+are *never* applied from an import. The importer re-resolves every model by id
+against the local registry, so a stack from another box cannot inject a bad path.
+
+## 7. Active-stack tracking & drift detection
+
+This is the layer that makes Stacks first-class rather than a one-shot importer.
+
+- After a successful apply, `state.json` records the applied stack `slug` + a
+  **content hash** of the applied slot/capability/profile set.
+- A cheap reconcile compares a hash of the *current* live config against the
+  applied stack's hash → **status**:
+  - `clean` — live config equals the applied stack.
+  - `modified` — the user hand-edited a slot/capability since applying (git-"dirty").
+  - `none` — no stack is currently applied.
+- UX payoffs:
+  - Stacks page shows the **Active** stack and a **drift badge**.
+  - `modified` invites **"Update stack from current state"** (capture live edits
+    back into the stack) or **"Re-apply to discard drift."**
+  - Slots page can show a small *"part of stack: Coding"* chip per slot.
+- The same hashing/capture code powers **snapshot-to-new-stack** at create time.
+
+## 8. Backend API + MCP
+
+### REST — new `src/hal0/api/routes/stacks.py` (mirrors `routes/profiles.py`)
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/stacks` | list (with active flag + drift status) |
+| POST | `/api/stacks` | create (hand-built or from snapshot payload) |
+| GET | `/api/stacks/{slug}` | detail |
+| PUT | `/api/stacks/{slug}` | edit |
+| DELETE | `/api/stacks/{slug}` | delete (guard seed stacks) |
+| POST | `/api/stacks/{slug}/apply?dry_run=true` | diff preview (returns ChangeSet) |
+| POST | `/api/stacks/{slug}/apply` | commit + lifecycle convergence |
+| POST | `/api/stacks/{slug}/export` | download `.hal0stack.json` |
+| POST | `/api/stacks/import?dry_run=true` | validate + resolve report |
+| POST | `/api/stacks/import` | create from uploaded envelope |
+| POST | `/api/stacks/snapshot` | build a stack from current live config |
+
+Endpoint constants added to `ui/src/api/endpoints.ts`; client hooks mirror
+`ui/src/api/hooks/useProfiles.ts`.
+
+### MCP admin tools — `src/hal0/mcp/admin.py` (existing gated-write pattern)
+
+- **Autonomous read:** `stack_list`, `stack_status`.
+- **Gated write (ApprovalQueue):** `stack_apply`, `stack_import`, `stack_delete`.
+
+Lets Hermes/agents swap stacks under owner approval, consistent with
+`slot_create`/`capability_set`/`config_write`.
+
+## 9. Dashboard UI — `#slots/stacks` sub-page
+
+A near-clone of the Profiles page (`ui/src/dash/profiles.jsx`).
+
+- **Nav:** add a third Slots child in `useNavItems()` (`ui/src/dash/chrome.jsx:210`)
+  + a `renderView` case in `ui/src/dash/main.jsx` for `slotParam === "stacks"`.
+- **Card grid** (reuse `DCard`/`StatusDot`, `ui/src/dash/cards-shell.jsx`): each
+  card shows accent, name, description, contained slots as chips, an **Active**
+  ribbon + drift badge, and actions: **Apply** (→ diff-preview modal), Edit,
+  Clone, Export, Delete. Seed stacks are clone-only (reuse the Profiles
+  immutability guard, `profiles.jsx:78`).
+- **Editor `Drawer`** (reuse `Drawer` + `FormRow`): name/desc/icon + a slot-picker
+  (add slot → choose profile + model + capabilities), populated from
+  `/api/slots`, `/api/profiles`, `/api/models`.
+- **Import** = file-drop → import-dry-run → resolve report (missing models with
+  Pull buttons) → confirm.
+- **Apply** = diff-preview modal (the §5 before→after) → Confirm.
+- **Data layer:** new `ui/src/api/hooks/useStacks.ts` + endpoint constants,
+  copying `useProfiles.ts`. CSS scoped under a `.st-*` prefix mirroring `.pf-*`.
+
+## 10. Seed / starter stacks
+
+Ship curated, clone-only stacks mapping onto the 7-tab loadout research from this
+week: **coding, chat, voice, RAG, image, agentic, small**. Stored as seed TOML
+under the installer (`installer/etc-hal0/`, alongside the seed `profiles.toml`).
+These double as the seed content for the future directory.
+
+## 11. Directory-readiness (format only — not built)
+
+The `.hal0stack.json` envelope is shaped so the future directory is just "a
+server that lists and serves these files": stable `kind`, `schema_version`,
+`checksum` (→ signing), and author/tags/description/icon (→ listing cards).
+Nothing in v1 blocks it; the directory service itself is out of scope.
+
+## 12. Error handling & edge cases
+
+- **Slug collision** on create/import → reject with `StackConflict` (mirrors
+  profile conflict handling); import offers clone-with-suffix.
+- **Seed stack mutation** → blocked by catalog guard; Edit becomes "Edit a copy"
+  (Profiles pattern, `profiles.jsx:78`).
+- **Apply with a missing model** (registry changed since stack saved) → dry-run
+  surfaces it; commit blocked until resolved (pull or edit).
+- **Partial Phase-B failure** → committed config stands; per-slot ERROR surfaced;
+  user can re-converge.
+- **Malformed import envelope** → reject with field-path error (wraps validation
+  like `loader.py:161`); never partially applies.
+- **Drift during apply** (live config changed mid-flow) → apply operates on the
+  ChangeSet computed at preview time; a stale preview is detected by hash and the
+  user is asked to re-preview.
+
+## 13. Testing strategy
+
+- **Unit:** `StackConfig`/`StacksCatalog` validation, round-trip TOML I/O,
+  seed-immutability guard, envelope checksum, migration walk.
+- **Apply engine:** ChangeSet correctness vs `SlotConfigStore`; commit rollback
+  on injected write failure; declarative unload of un-named slots; drift hashing
+  (clean vs modified).
+- **Import/export:** round-trip a stack across an empty registry; resolve-and-pull
+  decision matrix (present / pullable / unresolvable); secret-exclusion assertion
+  (no env values ever appear in an export); machine-path re-resolution.
+- **API:** route contract tests mirroring the profiles route tests; gated-MCP
+  approval path for `stack_apply`.
+- **UI:** hook tests for `useStacks`; diff-preview modal renders a ChangeSet;
+  import flow surfaces Pull buttons for missing models.
+
+## 14. Build sequence (one feature, staged PRs)
+
+1. **PR-1 — Schema + catalog:** `StackConfig`/`StacksCatalog`, TOML persistence,
+   paths, migration hook, unit tests.
+2. **PR-2 — Apply engine + drift:** dry-run ChangeSet + commit + lifecycle
+   convergence + active-pointer/drift hashing, tests against `SlotConfigStore`.
+3. **PR-3 — Export/import:** envelope, checksum, resolve-and-pull, snapshot-from-live.
+4. **PR-4 — REST + MCP:** `routes/stacks.py` + admin tools.
+5. **PR-5 — Dashboard UI:** `#slots/stacks` sub-page, `useStacks` hooks,
+   diff-preview & import modals.
+6. **PR-6 — Seed stacks + docs:** curated seed stacks + a Stacks doc page in
+   `hal0-web` (the only change that touches that repo).
+
+## 15. Key file references (anchors for implementation)
+
+- Slot schema & validators — `src/hal0/config/schema.py:257` (SlotConfig), `:620` (validators), `:149` (model ref).
+- Profile schema/catalog — `src/hal0/config/schema.py:814`, `src/hal0/profiles/__init__.py:129`.
+- Capability config/orchestrator — `src/hal0/capabilities/config.py:52`, `src/hal0/capabilities/orchestrator.py:164`.
+- Transactional apply — `src/hal0/slot_config/__init__.py:131` (`apply`/`commit`/`revert`).
+- Atomic TOML/JSON writes — `src/hal0/config/loader.py:69`, `src/hal0/slots/state.py:269`.
+- Migrations — `src/hal0/config/migrations/__init__.py:75`.
+- Model registry — `src/hal0/registry/model.py:54`, `src/hal0/registry/store.py`, pull `src/hal0/registry/pull.py`.
+- REST precedent — `src/hal0/api/routes/profiles.py`; MCP — `src/hal0/mcp/admin.py`.
+- Dashboard: nav `ui/src/dash/chrome.jsx:195`; router `ui/src/dash/main.jsx:25`; Profiles page `ui/src/dash/profiles.jsx`; primitives `ui/src/dash/primitives.jsx`, `ui/src/dash/cards-shell.jsx`; client `ui/src/api/client.ts`, `ui/src/api/endpoints.ts`, `ui/src/api/hooks/useProfiles.ts`.
+- Prior art (Bundles) — `src/hal0/bundles/schema.py`.

--- a/docs/superpowers/specs/2026-06-19-stacks-design.md
+++ b/docs/superpowers/specs/2026-06-19-stacks-design.md
@@ -257,10 +257,60 @@ A near-clone of the Profiles page (`ui/src/dash/profiles.jsx`).
 
 ## 10. Seed / starter stacks
 
-Ship curated, clone-only stacks mapping onto the 7-tab loadout research from this
-week: **coding, chat, voice, RAG, image, agentic, small**. Stored as seed TOML
-under the installer (`installer/etc-hal0/`, alongside the seed `profiles.toml`).
-These double as the seed content for the future directory.
+Ship three curated, clone-only seed stacks, chosen from the 2026-06-19 model
+roster benchmark (exclusive-GPU sweep, 26 models). Bench bands: 🟢 ≥60 t/s ·
+🟡 25–60 · 🔴 <25 decode. Embed/rerank/stt/tts slots use hal0's seeded
+NPU/FLM + `moonshine`/`kokoro` providers (not in the LLM bench). Non-seed slot
+names (`util`, `quick`) are created on apply via `slot_create` if absent.
+Stored as seed TOML under the installer (`installer/etc-hal0/stacks/`, alongside
+the seed `profiles.toml`); they double as seed content for the future directory.
+
+### `saber` — high-speed agentic MoE
+
+Max-throughput autonomous loadout. Decode-per-GB leader on the board.
+
+| Slot | Model (registry id) | Notes |
+| --- | --- | --- |
+| **agent** (star) | `chadrock-35b-ace-saber` | 35B-A3B MoE · 19.0 GB · f16 KV · 🟢 92.9 t/s · 94.3% MTP · vision + tools · 262k ctx. Current live agent slot. |
+| **chat** | `qwen3.6-35b-a3b-crown-halo-mtp-dynamic` | 35B-A3B · 22.6 GB · 🟢 83.8 t/s · vision · 91.3% MTP. Same MoE family. |
+| **util** | `gemma-4-12B-agentic-fable5` | 12B dense · 7.4 GB · **tool-calling** router/util · run on **Vulkan** (🟡 26.2 t/s vs 🔴 22.4 ROCm). |
+| **stt** | seeded `moonshine` (NPU) | voice in. |
+| **tts** | seeded `kokoro` (CPU) | voice out. |
+| **embed + rerank** | seeded NPU/FLM | memory recall + precision. |
+
+*Personal-only speed alt (not shipped as public seed):*
+`chadrock3-6-35b-uncensored-mtp` — fastest 35B at 🟢 102.1 t/s, but uncensored.
+
+### `forge` — coding-first developer
+
+Fast coder primary + agentic muscle + a draft coder + repo RAG.
+
+| Slot | Model (registry id) | Notes |
+| --- | --- | --- |
+| **chat** (primary) | `qwen3-coder-reap-25b-a3b-q5km` | 25B-A3B MoE · 17.7 GB · 🟡 54.7 t/s · **1368 prefill** (file ingest) · coding. |
+| **agent** | `chadrock-35b-ace-saber` | 19.0 GB · 🟢 92.9 t/s · tools + vision — drives edits/tool-calls. |
+| **quick** | `qwopus3-5-4b-coder-mtp-q6-k` | 3.6 GB · 🟢 85.0 t/s · MTP · coder — inline/draft completions. |
+| **embed + rerank** | seeded NPU/FLM | codebase retrieval. |
+
+*Heavy alt:* `qwen3-coder-next-q4kxl` (49.6 GB · 🟡 37.8 t/s) for max coding
+quality when the agent slot need not be resident.
+
+### `pi` — always-on support (compaction, recall, voice)
+
+The background brain: faithful summarization, memory recall, voice I/O. Quality
+over speed — q8 weights for faithful compaction.
+
+| Slot | Model (registry id) | Notes |
+| --- | --- | --- |
+| **util** (star) | `chadrock3.6-27b-pi-agent-rocmfp4-mtp` | 27B dense · **q8** · 14.8 GB · 🟡 33.3 t/s · 89.4% MTP · tools. q8 fidelity for compaction/recall. |
+| **stt** | seeded `moonshine` (NPU) | voice in. |
+| **tts** | seeded `kokoro` (CPU) | voice out. |
+| **embed + rerank** | seeded NPU/FLM | memory recall + precision. |
+
+*Documented swap-in #4 (`researcher`):* long-context reasoning primary
+`qwen3.6-35b-a3b-q4kxl` (🟡 46.1 t/s · **1300 prefill**) + embed + rerank for
+heavy RAG. Folded into `forge`/`pi` retrieval by default; promotable to a
+first-class seed on request.
 
 ## 11. Directory-readiness (format only — not built)
 

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -28,6 +28,7 @@ from hal0.config import paths
 from hal0.config.schema import (
     CURRENT_SCHEMA_VERSION,
     SEED_PROFILES,
+    SEED_STACKS,
     AgentConfig,
     Hal0Config,
     HardwareInfo,
@@ -35,6 +36,7 @@ from hal0.config.schema import (
     ProfilesConfig,
     ProvidersConfig,
     SlotConfig,
+    StacksConfig,
     UpstreamsConfig,
 )
 from hal0.errors import Hal0Error
@@ -445,6 +447,46 @@ def save_profiles_config(cfg: ProfilesConfig, path: Path | None = None) -> None:
               :func:`hal0.config.paths.profiles_toml`.
     """
     target = Path(path) if path is not None else paths.profiles_toml()
+    write_toml_atomic(target, cfg.model_dump(mode="python", exclude_none=True))
+
+
+# ── stacks.toml ───────────────────────────────────────────────────────────────
+
+
+def load_stacks_config(path: Path | None = None) -> StacksConfig:
+    """Load and validate /etc/hal0/stacks.toml.
+
+    Returns the built-in seed stacks (``SEED_STACKS``, empty until they ship)
+    when the file is absent, so the catalog is always well-formed on a fresh
+    install. When the file is present, only its contents are returned — seeds
+    are NOT merged in (load REPLACES, mirroring ``load_profiles_config``).
+
+    Raises:
+        ConfigParseError: If the TOML is malformed or fails validation.
+    """
+    target = path if path is not None else paths.stacks_toml()
+    if not Path(target).exists():
+        return StacksConfig.model_validate({"stack": SEED_STACKS})
+    raw = _read_toml(Path(target))
+    try:
+        return StacksConfig.model_validate(raw)
+    except Exception as exc:
+        raise ConfigParseError(
+            f"failed to validate stacks.toml at {target}: {exc}",
+            details={"path": str(target), "reason": str(exc)},
+        ) from exc
+
+
+def save_stacks_config(cfg: StacksConfig, path: Path | None = None) -> None:
+    """Atomically write the full stack catalog to stacks.toml.
+
+    The written file is the single source of truth; callers must pass the
+    COMPLETE catalog (start from ``load_stacks_config()``, then add/modify)
+    so existing stacks survive the round trip. ``exclude_none=True`` keeps
+    tomli_w from raising on optional None fields, mirroring
+    :func:`save_profiles_config`.
+    """
+    target = Path(path) if path is not None else paths.stacks_toml()
     write_toml_atomic(target, cfg.model_dump(mode="python", exclude_none=True))
 
 

--- a/src/hal0/config/paths.py
+++ b/src/hal0/config/paths.py
@@ -252,6 +252,18 @@ def profiles_toml() -> Path:
     return etc() / "profiles.toml"
 
 
+def stacks_toml() -> Path:
+    """Return the stack catalog path (/etc/hal0/stacks.toml).
+
+    The file is optional — :func:`hal0.config.loader.load_stacks_config`
+    returns the built-in seed stacks (empty until they ship) when absent.
+
+    FHS:       /etc/hal0/stacks.toml
+    HAL0_HOME: $HAL0_HOME/etc/hal0/stacks.toml
+    """
+    return etc() / "stacks.toml"
+
+
 def manifest_json() -> Path:
     """Return the release manifest path.
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -943,7 +943,7 @@ class StackModelMeta(BaseModel):
     def id_nonempty(cls, v: str) -> str:
         if not v.strip():
             raise ValueError("stack model meta id must not be empty")
-        return v
+        return v.strip()
 
 
 class StackCapabilityRow(BaseModel):

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -906,6 +906,158 @@ class ProfilesConfig(BaseModel):
     profile: dict[str, ProfileConfig] = Field(default_factory=dict)
 
 
+# ── Stacks ────────────────────────────────────────────────────────────────────
+# A Stack is a named, portable bundle of slots + their profiles + model
+# assignments + capability selections. Stored single-file in stacks.toml keyed
+# by slug, mirroring profiles.toml. See docs/superpowers/specs/2026-06-19-stacks-design.md.
+
+# Stacks carry their own schema version (independent of hal0.toml meta.schema_version),
+# stamped on every StackConfig and on the export envelope (PR-3).
+STACK_SCHEMA_VERSION_CURRENT = 1
+
+_STACK_NAME_RE = r"^[a-z0-9][a-z0-9_-]{0,31}$"
+
+
+class StackModelMeta(BaseModel):
+    """Transport-safe metadata subset of a registry ``Model``.
+
+    Embedded in a stack so an importer on another machine can resolve or
+    pull a referenced model by id. Deliberately excludes the machine-specific
+    ``path`` and any host-local fields — see spec §3/§6.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+    id: str = Field(..., description="Registry model id this entry describes.")
+    name: str = Field(default="", description="Human-readable display name.")
+    hf_repo: str = Field(default="", description="HuggingFace repo id, for resolve-and-pull on import.")
+    hf_filename: str = Field(default="", description="Filename within the HF repo.")
+    size_bytes: int = Field(default=0, description="Total model size in bytes; 0 = unknown.")
+    quant: str = Field(default="", description="Quantization label shown on cards (e.g. 'FP4', 'Q4_K_M').")
+    capabilities: list[str] = Field(default_factory=list, description="Capability strings, e.g. ['chat','vision'].")
+    backends: list[str] = Field(default_factory=list, description="Runnable backends, e.g. ['rocm','vulkan'].")
+    mmproj: str | None = Field(default=None, description="mmproj sidecar marker (presence flag); never a host path on import.")
+
+    @field_validator("id")
+    @classmethod
+    def id_nonempty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("stack model meta id must not be empty")
+        return v
+
+
+class StackCapabilityRow(BaseModel):
+    """One (slot, child) capability selection carried by a stack slot entry.
+
+    Mirrors the fields of ``hal0.capabilities.config.CapabilitySelection`` that
+    are portable; the apply engine (PR-2) translates these into real
+    CapabilitySelection rows at apply time.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+    child: str = Field(..., description="Capability child key, e.g. 'embed', 'rerank', 'stt', 'tts', 'vision'.")
+    device: str = Field(..., description="Device target for this child.")
+    provider: str = Field(..., description="Provider name for this child.")
+    model: str = Field(..., description="Model id bound to this child.")
+    enabled: bool = Field(default=True, description="Whether this child is active in the stack.")
+
+    @field_validator("device")
+    @classmethod
+    def device_valid(cls, v: str) -> str:
+        if v not in _VALID_DEVICES:
+            raise ValueError(f"device {v!r}: must be one of {sorted(_VALID_DEVICES)}")
+        return v
+
+
+class StackSlotEntry(BaseModel):
+    """One slot's contribution to a stack: which model/profile/caps it carries.
+
+    References models and profiles by name/id; the embedded ``profiles`` and
+    ``models`` maps on the parent ``StackConfig`` carry the metadata needed to
+    resolve those references on another machine.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+    slot: str = Field(..., description="Slot name this entry configures (kebab-case).")
+    profile: str | None = Field(default=None, description="Profile name reference (resolved against StackConfig.profiles).")
+    model: str | None = Field(default=None, description="Model id reference (resolved against StackConfig.models).")
+    device: str | None = Field(default=None, description="Device override for the slot.")
+    provider: str | None = Field(default=None, description="Provider override for the slot.")
+    role: str | None = Field(default=None, description="Normalization role hint, e.g. 'primary'.")
+    vision: bool = Field(default=False, description="Enable the mmproj vision sidecar for this slot.")
+    mtp: bool | None = Field(default=None, description="Per-slot MTP override (inherits profile default when None).")
+    enable_thinking: bool | None = Field(default=None, description="Per-slot reasoning override.")
+    server_extra_args: str | None = Field(default=None, description="Freeform llama-server CLI flags for this slot.")
+    capabilities: list[StackCapabilityRow] = Field(default_factory=list, description="Capability child selections.")
+
+    @field_validator("slot")
+    @classmethod
+    def slot_valid(cls, v: str) -> str:
+        import re
+
+        if not v or not v.strip():
+            raise ValueError("slot name must not be empty")
+        if not re.match(_STACK_NAME_RE, v):
+            raise ValueError(
+                f"slot name {v!r}: use lowercase alphanumeric, hyphens, underscores; "
+                f"start with alphanumeric; max 32 chars"
+            )
+        return v
+
+    @field_validator("device")
+    @classmethod
+    def device_valid(cls, v: str | None) -> str | None:
+        if v is not None and v not in _VALID_DEVICES:
+            raise ValueError(f"device {v!r}: must be one of {sorted(_VALID_DEVICES)}")
+        return v
+
+
+class StackConfig(BaseModel):
+    """One ``[stack.<slug>]`` entry in stacks.toml.
+
+    A curated bundle of slots + embedded profiles + embedded model metadata.
+    The slug is the dict key (validated by StacksCatalog on create), not a
+    field here — mirroring ProfileConfig. ``name`` is the human display label.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+    name: str = Field(default="", description="Human display label (falls back to slug in the UI).")
+    description: str = Field(default="", description="What this stack is for.")
+    author: str = Field(default="", description="Author/provenance, for the future directory.")
+    icon: str = Field(default="", description="Accent token or emoji shown on the card.")
+    tags: list[str] = Field(default_factory=list, description="Freeform tags for listing/filtering.")
+    schema_version: int = Field(
+        default=STACK_SCHEMA_VERSION_CURRENT,
+        description="Stack schema version, stamped for forward-compat / envelope migration.",
+    )
+    hal0_version: str = Field(default="", description="hal0 version that produced this stack (provenance).")
+    slots: list[StackSlotEntry] = Field(default_factory=list, description="Slots this stack configures.")
+    profiles: dict[str, ProfileConfig] = Field(
+        default_factory=dict,
+        description="Embedded profiles referenced by slots, so the stack is self-contained.",
+    )
+    models: dict[str, StackModelMeta] = Field(
+        default_factory=dict,
+        description="Embedded model metadata (no weights) for referenced model ids.",
+    )
+
+
+class StacksConfig(BaseModel):
+    """Parsed stacks.toml — top-level ``[stack]`` table, keyed by slug."""
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+    stack: dict[str, StackConfig] = Field(default_factory=dict)
+
+
+# Built-in seed stacks (immutable, clone-only). Empty until PR-6 fills it with
+# saber/forge/pi. StacksCatalog consults this for the seed-immutability guard.
+SEED_STACKS: dict[str, StackConfig] = {}
+
+
 def resolve_profile_flags(profile: ProfileConfig, mtp_override: bool | None = None) -> str:
     """Return the full flag string for *profile*, expanding MTP when set.
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -930,13 +930,24 @@ class StackModelMeta(BaseModel):
 
     id: str = Field(..., description="Registry model id this entry describes.")
     name: str = Field(default="", description="Human-readable display name.")
-    hf_repo: str = Field(default="", description="HuggingFace repo id, for resolve-and-pull on import.")
+    hf_repo: str = Field(
+        default="", description="HuggingFace repo id, for resolve-and-pull on import."
+    )
     hf_filename: str = Field(default="", description="Filename within the HF repo.")
     size_bytes: int = Field(default=0, description="Total model size in bytes; 0 = unknown.")
-    quant: str = Field(default="", description="Quantization label shown on cards (e.g. 'FP4', 'Q4_K_M').")
-    capabilities: list[str] = Field(default_factory=list, description="Capability strings, e.g. ['chat','vision'].")
-    backends: list[str] = Field(default_factory=list, description="Runnable backends, e.g. ['rocm','vulkan'].")
-    mmproj: str | None = Field(default=None, description="mmproj sidecar marker (presence flag); never a host path on import.")
+    quant: str = Field(
+        default="", description="Quantization label shown on cards (e.g. 'FP4', 'Q4_K_M')."
+    )
+    capabilities: list[str] = Field(
+        default_factory=list, description="Capability strings, e.g. ['chat','vision']."
+    )
+    backends: list[str] = Field(
+        default_factory=list, description="Runnable backends, e.g. ['rocm','vulkan']."
+    )
+    mmproj: str | None = Field(
+        default=None,
+        description="mmproj sidecar marker (presence flag); never a host path on import.",
+    )
 
     @field_validator("id")
     @classmethod
@@ -956,7 +967,9 @@ class StackCapabilityRow(BaseModel):
 
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
-    child: str = Field(..., description="Capability child key, e.g. 'embed', 'rerank', 'stt', 'tts', 'vision'.")
+    child: str = Field(
+        ..., description="Capability child key, e.g. 'embed', 'rerank', 'stt', 'tts', 'vision'."
+    )
     device: str = Field(..., description="Device target for this child.")
     provider: str = Field(..., description="Provider name for this child.")
     model: str = Field(..., description="Model id bound to this child.")
@@ -981,16 +994,28 @@ class StackSlotEntry(BaseModel):
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
     slot: str = Field(..., description="Slot name this entry configures (kebab-case).")
-    profile: str | None = Field(default=None, description="Profile name reference (resolved against StackConfig.profiles).")
-    model: str | None = Field(default=None, description="Model id reference (resolved against StackConfig.models).")
+    profile: str | None = Field(
+        default=None, description="Profile name reference (resolved against StackConfig.profiles)."
+    )
+    model: str | None = Field(
+        default=None, description="Model id reference (resolved against StackConfig.models)."
+    )
     device: str | None = Field(default=None, description="Device override for the slot.")
     provider: str | None = Field(default=None, description="Provider override for the slot.")
     role: str | None = Field(default=None, description="Normalization role hint, e.g. 'primary'.")
-    vision: bool = Field(default=False, description="Enable the mmproj vision sidecar for this slot.")
-    mtp: bool | None = Field(default=None, description="Per-slot MTP override (inherits profile default when None).")
+    vision: bool = Field(
+        default=False, description="Enable the mmproj vision sidecar for this slot."
+    )
+    mtp: bool | None = Field(
+        default=None, description="Per-slot MTP override (inherits profile default when None)."
+    )
     enable_thinking: bool | None = Field(default=None, description="Per-slot reasoning override.")
-    server_extra_args: str | None = Field(default=None, description="Freeform llama-server CLI flags for this slot.")
-    capabilities: list[StackCapabilityRow] = Field(default_factory=list, description="Capability child selections.")
+    server_extra_args: str | None = Field(
+        default=None, description="Freeform llama-server CLI flags for this slot."
+    )
+    capabilities: list[StackCapabilityRow] = Field(
+        default_factory=list, description="Capability child selections."
+    )
 
     @field_validator("slot")
     @classmethod
@@ -1028,13 +1053,19 @@ class StackConfig(BaseModel):
     description: str = Field(default="", description="What this stack is for.")
     author: str = Field(default="", description="Author/provenance, for the future directory.")
     icon: str = Field(default="", description="Accent token or emoji shown on the card.")
-    tags: list[str] = Field(default_factory=list, description="Freeform tags for listing/filtering.")
+    tags: list[str] = Field(
+        default_factory=list, description="Freeform tags for listing/filtering."
+    )
     schema_version: int = Field(
         default=STACK_SCHEMA_VERSION_CURRENT,
         description="Stack schema version, stamped for forward-compat / envelope migration.",
     )
-    hal0_version: str = Field(default="", description="hal0 version that produced this stack (provenance).")
-    slots: list[StackSlotEntry] = Field(default_factory=list, description="Slots this stack configures.")
+    hal0_version: str = Field(
+        default="", description="hal0 version that produced this stack (provenance)."
+    )
+    slots: list[StackSlotEntry] = Field(
+        default_factory=list, description="Slots this stack configures."
+    )
     profiles: dict[str, ProfileConfig] = Field(
         default_factory=dict,
         description="Embedded profiles referenced by slots, so the stack is self-contained.",

--- a/src/hal0/stacks/__init__.py
+++ b/src/hal0/stacks/__init__.py
@@ -1,0 +1,153 @@
+"""StacksCatalog — read and mutate the stack catalog through one interface.
+
+A stack is a named bundle of slots + embedded profiles + embedded model
+metadata. This module concentrates the stack interface, mirroring
+``hal0.profiles.ProfileCatalog``:
+
+* full-catalog reads and atomic full-catalog writes (single stacks.toml);
+* seed immutability and duplicate-slug checks;
+* slug validation.
+
+Routes (PR-4) and the apply engine (PR-2) are adapters over this module.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+from hal0.config import paths, schema
+from hal0.config.loader import load_stacks_config, save_stacks_config
+from hal0.config.schema import (
+    ProfileConfig,
+    StackConfig,
+    StackModelMeta,
+    StackSlotEntry,
+)
+from hal0.errors import Conflict, NotFound
+
+log = logging.getLogger(__name__)
+
+_STACK_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
+
+
+@dataclass(frozen=True)
+class ResolvedStack:
+    """A stack plus derived fields (slug + seed flag) for API/UI consumption."""
+
+    slug: str
+    name: str
+    description: str
+    author: str
+    icon: str
+    tags: tuple[str, ...]
+    slots: list[StackSlotEntry]
+    profiles: dict[str, ProfileConfig]
+    models: dict[str, StackModelMeta]
+    schema_version: int
+    hal0_version: str
+    seed: bool
+
+
+class StacksCatalog:
+    """Read and mutate the stack catalog through one interface."""
+
+    def __init__(self, *, path: Path | None = None) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+
+    def _path_or_default(self) -> Path:
+        return self._path or paths.stacks_toml()
+
+    def list(self) -> list[ResolvedStack]:
+        cfg = load_stacks_config(self._path)
+        return [self._resolve_item(slug, stack) for slug, stack in cfg.stack.items()]
+
+    def resolve(self, slug: str) -> ResolvedStack:
+        cfg = load_stacks_config(self._path)
+        stack = cfg.stack.get(slug)
+        if stack is None:
+            raise NotFound(
+                f"stack {slug!r} not found",
+                code="stacks.not_found",
+                details={"stack": slug, "available": sorted(cfg.stack)},
+            )
+        return self._resolve_item(slug, stack)
+
+    def create(self, slug: str, stack: StackConfig) -> ResolvedStack:
+        self._validate_name(slug)
+        with self._lock:
+            catalog = load_stacks_config(self._path)
+            if slug in catalog.stack:
+                raise Conflict(
+                    f"stack {slug!r} already exists",
+                    code="stacks.exists",
+                    details={"stack": slug},
+                )
+            catalog.stack[slug] = stack
+            save_stacks_config(catalog, self._path)
+        return self._resolve_item(slug, stack)
+
+    def update(self, slug: str, stack: StackConfig) -> ResolvedStack:
+        """Replace the stack body wholesale (PUT semantics)."""
+        self._guard_custom(slug)
+        with self._lock:
+            catalog = load_stacks_config(self._path)
+            if slug not in catalog.stack:
+                raise NotFound(
+                    f"stack {slug!r} not found",
+                    code="stacks.not_found",
+                    details={"stack": slug},
+                )
+            catalog.stack[slug] = stack
+            save_stacks_config(catalog, self._path)
+        return self._resolve_item(slug, stack)
+
+    def delete(self, slug: str) -> None:
+        self._guard_custom(slug)
+        with self._lock:
+            catalog = load_stacks_config(self._path)
+            if slug not in catalog.stack:
+                raise NotFound(
+                    f"stack {slug!r} not found",
+                    code="stacks.not_found",
+                    details={"stack": slug},
+                )
+            del catalog.stack[slug]
+            save_stacks_config(catalog, self._path)
+
+    def _resolve_item(self, slug: str, stack: StackConfig) -> ResolvedStack:
+        return ResolvedStack(
+            slug=slug,
+            name=stack.name,
+            description=stack.description,
+            author=stack.author,
+            icon=stack.icon,
+            tags=tuple(stack.tags),
+            slots=stack.slots,
+            profiles=stack.profiles,
+            models=stack.models,
+            schema_version=stack.schema_version,
+            hal0_version=stack.hal0_version,
+            seed=slug in schema.SEED_STACKS,
+        )
+
+    def _guard_custom(self, slug: str) -> None:
+        if slug in schema.SEED_STACKS:
+            raise Conflict(
+                f"stack {slug!r} is a seed stack — seed stacks are immutable; "
+                "clone under a new name",
+                code="stacks.seed_immutable",
+                details={"stack": slug},
+            )
+
+    def _validate_name(self, slug: str) -> None:
+        if not _STACK_NAME_RE.match(slug):
+            raise Conflict(
+                "stack slug must be kebab-case (a-z0-9_-), ≤32 chars, start with alphanumeric",
+                code="stacks.invalid_name",
+                details={"stack": slug},
+            )

--- a/tests/config/test_stacks_loader.py
+++ b/tests/config/test_stacks_loader.py
@@ -1,0 +1,50 @@
+"""Unit tests for the stacks.toml loader/saver.
+
+Targeted file run:
+    ~/dev/hal0/.venv/bin/python -m pytest tests/config/test_stacks_loader.py -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.config.loader import ConfigParseError, load_stacks_config, save_stacks_config
+from hal0.config.schema import StackConfig, StackSlotEntry, StacksConfig
+
+
+class TestLoadStacksConfig:
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        cfg = load_stacks_config(path=tmp_path / "nonexistent.toml")
+        assert cfg.stack == {}
+
+    def test_round_trip_save_then_load(self, tmp_path: Path) -> None:
+        target = tmp_path / "stacks.toml"
+        cfg = StacksConfig(
+            stack={
+                "saber": StackConfig(
+                    name="Saber",
+                    description="high-speed agentic MoE",
+                    slots=[StackSlotEntry(slot="agent", model="chadrock-35b-ace-saber")],
+                )
+            }
+        )
+        save_stacks_config(cfg, path=target)
+        assert target.exists()
+        loaded = load_stacks_config(path=target)
+        assert "saber" in loaded.stack
+        assert loaded.stack["saber"].name == "Saber"
+        assert loaded.stack["saber"].slots[0].model == "chadrock-35b-ace-saber"
+
+    def test_invalid_toml_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "stacks.toml"
+        p.write_bytes(b"[stack\nbad toml <<<")
+        with pytest.raises(ConfigParseError):
+            load_stacks_config(path=p)
+
+    def test_unknown_field_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "stacks.toml"
+        p.write_bytes(b'[stack.x]\nname = "X"\nnot_a_field = "surprise"\n')
+        with pytest.raises(ConfigParseError):
+            load_stacks_config(path=p)

--- a/tests/config/test_stacks_loader.py
+++ b/tests/config/test_stacks_loader.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 from hal0.config.loader import ConfigParseError, load_stacks_config, save_stacks_config
-from hal0.config.schema import StackConfig, StackSlotEntry, StacksConfig
+from hal0.config.schema import StackConfig, StacksConfig, StackSlotEntry
 
 
 class TestLoadStacksConfig:

--- a/tests/config/test_stacks_schema.py
+++ b/tests/config/test_stacks_schema.py
@@ -34,7 +34,9 @@ class TestStackModelMeta:
 
     def test_extra_field_forbidden(self) -> None:
         with pytest.raises(ValidationError):
-            StackModelMeta(id="m1", path="/mnt/ai-models/x.gguf")  # path is machine-specific, excluded
+            StackModelMeta(
+                id="m1", path="/mnt/ai-models/x.gguf"
+            )  # path is machine-specific, excluded
 
     def test_id_is_stripped(self) -> None:
         assert StackModelMeta(id="  chadrock-35b-ace-saber  ").id == "chadrock-35b-ace-saber"

--- a/tests/config/test_stacks_schema.py
+++ b/tests/config/test_stacks_schema.py
@@ -15,8 +15,8 @@ from hal0.config.schema import (
     StackCapabilityRow,
     StackConfig,
     StackModelMeta,
-    StackSlotEntry,
     StacksConfig,
+    StackSlotEntry,
 )
 
 

--- a/tests/config/test_stacks_schema.py
+++ b/tests/config/test_stacks_schema.py
@@ -1,0 +1,98 @@
+"""Unit tests for the Stack schema models.
+
+Targeted file run:
+    ~/dev/hal0/.venv/bin/python -m pytest tests/config/test_stacks_schema.py -q
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from hal0.config.schema import (
+    STACK_SCHEMA_VERSION_CURRENT,
+    StackCapabilityRow,
+    StackConfig,
+    StackModelMeta,
+    StackSlotEntry,
+    StacksConfig,
+)
+
+
+class TestStackModelMeta:
+    def test_minimal_requires_id(self) -> None:
+        m = StackModelMeta(id="chadrock-35b-ace-saber")
+        assert m.id == "chadrock-35b-ace-saber"
+        assert m.size_bytes == 0
+        assert m.capabilities == []
+        assert m.mmproj is None
+
+    def test_empty_id_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            StackModelMeta(id="   ")
+
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            StackModelMeta(id="m1", path="/mnt/ai-models/x.gguf")  # path is machine-specific, excluded
+
+
+class TestStackCapabilityRow:
+    def test_valid_row(self) -> None:
+        r = StackCapabilityRow(child="embed", device="npu", provider="flm", model="bge-m3")
+        assert r.enabled is True
+
+    def test_bad_device_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            StackCapabilityRow(child="embed", device="quantum", provider="flm", model="bge-m3")
+
+
+class TestStackSlotEntry:
+    def test_minimal_requires_slot(self) -> None:
+        e = StackSlotEntry(slot="agent")
+        assert e.slot == "agent"
+        assert e.vision is False
+        assert e.capabilities == []
+
+    def test_bad_slot_name_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            StackSlotEntry(slot="Agent Slot!")
+
+    def test_bad_device_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            StackSlotEntry(slot="agent", device="gpu-quantum")
+
+
+class TestStackConfig:
+    def test_defaults(self) -> None:
+        s = StackConfig()
+        assert s.name == ""
+        assert s.schema_version == STACK_SCHEMA_VERSION_CURRENT
+        assert s.slots == []
+        assert s.profiles == {}
+        assert s.models == {}
+
+    def test_full_round_trip_through_dict(self) -> None:
+        s = StackConfig(
+            name="Saber",
+            description="high-speed agentic MoE",
+            slots=[StackSlotEntry(slot="agent", model="chadrock-35b-ace-saber")],
+            models={"chadrock-35b-ace-saber": StackModelMeta(id="chadrock-35b-ace-saber")},
+        )
+        dumped = s.model_dump(mode="python", exclude_none=True)
+        again = StackConfig.model_validate(dumped)
+        assert again.slots[0].slot == "agent"
+        assert again.models["chadrock-35b-ace-saber"].id == "chadrock-35b-ace-saber"
+
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            StackConfig(surprise="nope")
+
+
+class TestStacksConfig:
+    def test_empty_default(self) -> None:
+        c = StacksConfig()
+        assert c.stack == {}
+
+    def test_keyed_by_slug(self) -> None:
+        c = StacksConfig(stack={"saber": StackConfig(name="Saber")})
+        assert c.stack["saber"].name == "Saber"

--- a/tests/config/test_stacks_schema.py
+++ b/tests/config/test_stacks_schema.py
@@ -10,6 +10,7 @@ import pytest
 from pydantic import ValidationError
 
 from hal0.config.schema import (
+    SEED_STACKS,
     STACK_SCHEMA_VERSION_CURRENT,
     StackCapabilityRow,
     StackConfig,
@@ -34,6 +35,9 @@ class TestStackModelMeta:
     def test_extra_field_forbidden(self) -> None:
         with pytest.raises(ValidationError):
             StackModelMeta(id="m1", path="/mnt/ai-models/x.gguf")  # path is machine-specific, excluded
+
+    def test_id_is_stripped(self) -> None:
+        assert StackModelMeta(id="  chadrock-35b-ace-saber  ").id == "chadrock-35b-ace-saber"
 
 
 class TestStackCapabilityRow:
@@ -96,3 +100,8 @@ class TestStacksConfig:
     def test_keyed_by_slug(self) -> None:
         c = StacksConfig(stack={"saber": StackConfig(name="Saber")})
         assert c.stack["saber"].name == "Saber"
+
+
+class TestSeedStacks:
+    def test_seed_stacks_is_empty_until_pr6(self) -> None:
+        assert SEED_STACKS == {}

--- a/tests/stacks/test_stacks_catalog.py
+++ b/tests/stacks/test_stacks_catalog.py
@@ -1,0 +1,101 @@
+"""Unit tests for StacksCatalog CRUD + guards.
+
+Targeted file run:
+    ~/dev/hal0/.venv/bin/python -m pytest tests/stacks/test_stacks_catalog.py -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.config import schema
+from hal0.config.schema import StackConfig, StackSlotEntry
+from hal0.errors import Conflict, NotFound
+from hal0.stacks import ResolvedStack, StacksCatalog
+
+
+@pytest.fixture
+def catalog(tmp_path: Path) -> StacksCatalog:
+    return StacksCatalog(path=tmp_path / "stacks.toml")
+
+
+def _saber() -> StackConfig:
+    return StackConfig(
+        name="Saber",
+        description="high-speed agentic MoE",
+        slots=[StackSlotEntry(slot="agent", model="chadrock-35b-ace-saber")],
+    )
+
+
+class TestCreateAndRead:
+    def test_create_then_resolve(self, catalog: StacksCatalog) -> None:
+        created = catalog.create("saber", _saber())
+        assert isinstance(created, ResolvedStack)
+        assert created.slug == "saber"
+        assert created.seed is False
+        got = catalog.resolve("saber")
+        assert got.name == "Saber"
+        assert got.slots[0].slot == "agent"
+
+    def test_create_then_list(self, catalog: StacksCatalog) -> None:
+        catalog.create("saber", _saber())
+        slugs = [r.slug for r in catalog.list()]
+        assert slugs == ["saber"]
+
+    def test_create_duplicate_raises_conflict(self, catalog: StacksCatalog) -> None:
+        catalog.create("saber", _saber())
+        with pytest.raises(Conflict):
+            catalog.create("saber", _saber())
+
+    def test_create_invalid_slug_raises_conflict(self, catalog: StacksCatalog) -> None:
+        with pytest.raises(Conflict):
+            catalog.create("Saber Slot!", _saber())
+
+    def test_resolve_missing_raises_not_found(self, catalog: StacksCatalog) -> None:
+        with pytest.raises(NotFound):
+            catalog.resolve("ghost")
+
+
+class TestUpdateAndDelete:
+    def test_update_replaces(self, catalog: StacksCatalog) -> None:
+        catalog.create("saber", _saber())
+        updated = catalog.update("saber", StackConfig(name="Saber v2"))
+        assert updated.name == "Saber v2"
+        assert updated.slots == []
+
+    def test_update_missing_raises_not_found(self, catalog: StacksCatalog) -> None:
+        with pytest.raises(NotFound):
+            catalog.update("ghost", _saber())
+
+    def test_delete(self, catalog: StacksCatalog) -> None:
+        catalog.create("saber", _saber())
+        catalog.delete("saber")
+        assert catalog.list() == []
+
+    def test_delete_missing_raises_not_found(self, catalog: StacksCatalog) -> None:
+        with pytest.raises(NotFound):
+            catalog.delete("ghost")
+
+
+class TestSeedGuard:
+    def test_seed_stack_is_immutable(self, catalog: StacksCatalog, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Inject a seed entry so the guard has something to protect (SEED_STACKS
+        # is empty until PR-6). The catalog reads SEED_STACKS from the schema
+        # module. No create() call: update()/delete() run _guard_custom() FIRST,
+        # so they raise on a seed slug regardless of whether it is on disk —
+        # and load_stacks_config already surfaces seeds when the file is absent.
+        monkeypatch.setitem(schema.SEED_STACKS, "saber", _saber())
+        with pytest.raises(Conflict):
+            catalog.update("saber", StackConfig(name="hijack"))
+        with pytest.raises(Conflict):
+            catalog.delete("saber")
+
+
+class TestPersistence:
+    def test_persists_across_catalog_instances(self, tmp_path: Path) -> None:
+        path = tmp_path / "stacks.toml"
+        StacksCatalog(path=path).create("saber", _saber())
+        # Fresh catalog instance reads the written file.
+        assert any(r.slug == "saber" for r in StacksCatalog(path=path).list())

--- a/tests/stacks/test_stacks_catalog.py
+++ b/tests/stacks/test_stacks_catalog.py
@@ -80,7 +80,9 @@ class TestUpdateAndDelete:
 
 
 class TestSeedGuard:
-    def test_seed_stack_is_immutable(self, catalog: StacksCatalog, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_seed_stack_is_immutable(
+        self, catalog: StacksCatalog, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # Inject a seed entry so the guard has something to protect (SEED_STACKS
         # is empty until PR-6). The catalog reads SEED_STACKS from the schema
         # module. No create() call: update()/delete() run _guard_custom() FIRST,


### PR DESCRIPTION
## Stacks — a portable, editable bundle of slots + profiles + model assignments + capabilities

Stacks let a user load a whole loadout (e.g. "Saber", "Forge", "Pi") in one declarative action, save/clone/edit them, and **export/import** them as a portable file — the runtime, user-editable successor to the first-run-only `bundles/` picker. Eventually a public directory of shareable stacks.

This PR contains the **approved design** plus **PR-1 (the foundation)**. Apply engine, export/import, REST+MCP, dashboard sub-page, and seed-stack content land in follow-up PRs (roadmap in the plan).

### Design (docs)
- `docs/superpowers/specs/2026-06-19-stacks-design.md` — full design. Decisions: curated-bundle composition; **declarative/replace apply** with a dry-run diff built on the existing `SlotConfigStore.apply/commit/revert`; **resolve-and-pull import**; active-stack **drift** tracking; inference-surface scope only (secrets/weights/machine-paths excluded by construction). Three seed stacks chosen from the 2026-06-19 roster benchmark: `saber` / `forge` / `pi`.
- `docs/superpowers/plans/2026-06-19-stacks-pr1-schema-catalog.md` — the TDD plan this PR implements, plus the PR-2…6 roadmap.

### PR-1 — Schema + Catalog (code)
Mirrors the existing Profile subsystem method-for-method.
- `config/schema.py` — `StackConfig` + `StackSlotEntry` + `StackCapabilityRow` + `StackModelMeta` + `StacksConfig` + `SEED_STACKS` (empty until the seed PR). `extra="forbid"` on every model; slug rule `^[a-z0-9][a-z0-9_-]{0,31}$`; `StackModelMeta` omits the machine-specific `path` (transport-safe by construction).
- `config/paths.py` + `config/loader.py` — single-file `stacks.toml` (atomic via `write_toml_atomic`), `load_stacks_config`/`save_stacks_config`. (Single-file deviates from the spec's per-file suggestion to reuse verified `ProfileCatalog` code — documented in the plan's Global Constraints; internal-only, no effect on the export format.)
- `stacks/__init__.py` — `StacksCatalog` (list/resolve/create/update/delete) + `ResolvedStack`, with slug + seed-immutability guards and `NotFound`/`Conflict` errors under the `stacks.*` namespace.

### Tests & review
- **30 new tests**, all green; broader `tests/config` + `tests/stacks` suite clean (297 passed / 4 pre-existing skips, no regressions).
- Built subagent-driven TDD: per-task spec+quality review on each task, then a whole-branch review (verdict: ready to merge; two one-line foundation-hardening fixes folded in — `id.strip()` + a `SEED_STACKS == {}` invariant assertion). Non-blocking follow-up hygiene is listed in the final review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)