### PR TITLE
fix(openwebui): disable PersistentConfig so env prewire wins (chat connection)

### DIFF
--- a/src/hal0/openwebui/env_writer.py
+++ b/src/hal0/openwebui/env_writer.py
@@ -13,6 +13,7 @@ Prewired variables (PLAN.md §8):
     WEBUI_NAME=hal0
     ENABLE_OPENAI_API=True
     ENABLE_OLLAMA_API=False
+    ENABLE_PERSISTENT_CONFIG=False
     DATA_DIR=/app/backend/data
     DEFAULT_LOCALE=en
 
@@ -99,6 +100,11 @@ _DEFAULT_OPENWEBUI_ENV: dict[str, str] = {
     "DEFAULT_LOCALE": "en",
     "ENABLE_OLLAMA_API": "False",
     "ENABLE_OPENAI_API": "True",
+    # Disable OWUI's PersistentConfig so env vars always win.  Without this,
+    # OWUI pins values like OPENAI_API_BASE_URLS in its DB on first boot and
+    # ignores env on subsequent boots — so a stale DB entry (e.g. the container
+    # loopback 127.0.0.1:8080) silently overrides the correct env value.
+    "ENABLE_PERSISTENT_CONFIG": "False",
     "OPENAI_API_BASE_URLS": "http://host.docker.internal:8080/v1",
     "WEBUI_AUTH": "False",
     "WEBUI_NAME": "hal0",

--- a/tests/openwebui/test_env_writer.py
+++ b/tests/openwebui/test_env_writer.py
@@ -161,3 +161,14 @@ def test_trusted_email_header_via_explicit_override(
     env = _parse_env(target.read_text())
     assert env["WEBUI_AUTH"] == "True"
     assert env["WEBUI_AUTH_TRUSTED_EMAIL_HEADER"] == "X-Forwarded-Email"
+
+
+def test_enable_persistent_config_is_false(tmp_path: Path) -> None:
+    """ENABLE_PERSISTENT_CONFIG=False must be prewired so env vars always
+    win over OWUI's PersistentConfig DB, which can pin a stale base URL
+    (e.g. the container-loopback 127.0.0.1:8080 overriding the correct
+    host.docker.internal value on subsequent boots)."""
+    target = tmp_path / "openwebui.env"
+    write_openwebui_env(target)
+    env = _parse_env(target.read_text())
+    assert env["ENABLE_PERSISTENT_CONFIG"] == "False"


### PR DESCRIPTION
## Root cause

Open WebUI's `OPENAI_API_BASE_URLS` is a `PersistentConfig` key — on first boot OWUI reads it from env and pins the value into its internal DB. On subsequent boots it reads **only from the DB**, ignoring env entirely.

On the live box the DB had been seeded with `http://127.0.0.1:8080/v1` — the container's own loopback (OpenWebUI listens on :8080 inside the container). This silently overrode the correct env value `http://host.docker.internal:8080/v1`, so every chat request looped back to OWUI itself instead of reaching hal0's API.

## Fix

Add `ENABLE_PERSISTENT_CONFIG=False` to the default prewired env. This is the [official OWUI mechanism](https://docs.openwebui.com/getting-started/env-configuration/#enable_persistent_config) for making env vars always win over the DB — the correct posture for a prewired appliance where env is the single source of truth.

## Changes

- `src/hal0/openwebui/env_writer.py` — add `ENABLE_PERSISTENT_CONFIG=False` to `_DEFAULT_OPENWEBUI_ENV` (alphabetical order, between `ENABLE_OPENAI_API` and `OPENAI_API_BASE_URLS`); update module docstring prewired-vars list; inline comment explains why.
- `tests/openwebui/test_env_writer.py` — add `test_enable_persistent_config_is_false` (TDD: written red, then green).

## Test

```
uv run python -m pytest tests/openwebui/test_env_writer.py -v
# 11 passed, 1 skipped (docker smoke — infra condition)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)