### PR TITLE
fix(hermes): voice_wire auto-provisions STT for the NPU-trio facade

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -2975,6 +2975,18 @@ def _find_slot(slots: list[dict[str, Any]], kind: str) -> dict[str, Any] | None:
         slot_type = (s.get("type") or s.get("capability") or "").lower()
         if slot_type in accept and _is_ready(s):
             return s
+    # STT special case: the NPU-trio transcription facade (type=transcription,
+    # served_by=<anchor>) always reports state=offline — it has no unit of its
+    # own and routes through the npu anchor's FLM child. container_enrichment
+    # stamps served_by on these shadows. Accept the facade when its anchor is
+    # ready so voice_wire auto-provisions STT_OPENAI_BASE_URL.
+    if kind == "stt":
+        ready_names = {str(s.get("name")) for s in slots if _is_ready(s) and s.get("name")}
+        for s in slots:
+            slot_type = (s.get("type") or s.get("capability") or "").lower()
+            anchor = s.get("served_by")
+            if slot_type in accept and isinstance(anchor, str) and anchor in ready_names:
+                return s
     return None
 
 

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1657,6 +1657,78 @@ def test_voice_wire_finds_local_tts_and_transcription_slots(
     )
 
 
+def test_voice_wire_provisions_stt_for_npu_trio_facade(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: NPU-trio stt facade (type=transcription, state=offline, served_by=anchor)
+    was rejected by _find_slot because _is_ready checks state and 'offline' is not in the
+    ready set. The facade has no unit of its own — the npu anchor's FLM child serves it.
+    Fix: _find_slot should accept the facade when its named anchor is ready.
+    """
+    hermes_home = tmp_path / "hh"
+    hermes_home.mkdir()
+    secrets_env = tmp_path / "hermes.env"
+    monkeypatch.setattr(hp, "HERMES_SECRETS_ENV", secrets_env)
+    monkeypatch.setattr(hp, "OVERRIDES_PATH", tmp_path / "no.yaml")
+    (hermes_home / "config.yaml").write_text(
+        hp._render_config_yaml(
+            primary={
+                "model_id": "primary",
+                "backend_url": "http://127.0.0.1:8080/v1",
+                "context_length": 8000,
+            },
+            agent_id="hermes-agent",
+        ),
+        encoding="utf-8",
+    )
+    tts_url = "http://127.0.0.1:8084/v1"
+    # NPU trio: anchor (llm, ready) + stt facade (transcription, offline, served_by anchor)
+    # The facade mirrors live container_enrichment output: served_by is the anchor name.
+    slots = [
+        {
+            "name": "kokoro",
+            "type": "tts",
+            "kind": "local",
+            "state": "ready",
+            "backend_url": tts_url,
+        },
+        {
+            "name": "npu",
+            "type": "llm",
+            "kind": "local",
+            "state": "ready",
+        },
+        {
+            "name": "stt",
+            "type": "transcription",
+            "kind": "local",
+            "state": "offline",  # facade has no unit; routes through npu anchor
+            "served_by": "npu",
+        },
+    ]
+    state = hp.BootstrapState(hermes_home=str(hermes_home))
+    io = hp.PhaseIO(
+        fetch_slots=lambda: slots,
+        fetch_model_contexts=lambda: {},
+    )
+    out = hp._phase_voice_wire(hp.context_for("voice_wire", state, io=io))
+    assert out.status == hp.PhaseStatus.OK, (
+        f"expected OK but got {out.status!r}: {out.reason!r} — "
+        "voice_wire skipped NPU-trio stt facade (offline state bug)"
+    )
+    env_text = secrets_env.read_text()
+    assert f"TTS_OPENAI_BASE_URL={tts_url}" in env_text
+    assert "STT_OPENAI_BASE_URL=" in env_text, (
+        f"STT URL not written to secrets env. env contents:\n{env_text}"
+    )
+    # The facade has no explicit backend_url, so _slot_backend_url falls back
+    # to the default HAL0 API gateway — voice clients send STT there, which
+    # routes to the NPU trio.
+    assert f"STT_OPENAI_BASE_URL={hp._DEFAULT_PRIMARY_BACKEND_URL}" in env_text, (
+        f"STT URL incorrect. env contents:\n{env_text}"
+    )
+
+
 # ── #246 phase impls — smoke_tests + self_report ────────────────────────────
 
 

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1729,6 +1729,71 @@ def test_voice_wire_provisions_stt_for_npu_trio_facade(
     )
 
 
+def test_voice_wire_does_not_provision_stt_when_npu_anchor_is_not_ready(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Safety: stt facade served_by an offline anchor must NOT write STT_OPENAI_BASE_URL.
+
+    The secondary _find_slot pass should only accept a facade when its named
+    anchor is _is_ready — if the anchor is offline/error/starting the facade
+    has no live backend and voice_wire must not point voice clients at it.
+    TTS may still be written (independent slot), or SKIP if neither is ready.
+    """
+    hermes_home = tmp_path / "hh"
+    hermes_home.mkdir()
+    secrets_env = tmp_path / "hermes.env"
+    monkeypatch.setattr(hp, "HERMES_SECRETS_ENV", secrets_env)
+    monkeypatch.setattr(hp, "OVERRIDES_PATH", tmp_path / "no.yaml")
+    (hermes_home / "config.yaml").write_text(
+        hp._render_config_yaml(
+            primary={
+                "model_id": "primary",
+                "backend_url": "http://127.0.0.1:8080/v1",
+                "context_length": 8000,
+            },
+            agent_id="hermes-agent",
+        ),
+        encoding="utf-8",
+    )
+    tts_url = "http://127.0.0.1:8084/v1"
+    # NPU anchor is offline — facade must not be accepted.
+    slots = [
+        {
+            "name": "kokoro",
+            "type": "tts",
+            "kind": "local",
+            "state": "ready",
+            "backend_url": tts_url,
+        },
+        {
+            "name": "npu",
+            "type": "llm",
+            "kind": "local",
+            "state": "offline",  # anchor is not ready
+        },
+        {
+            "name": "stt",
+            "type": "transcription",
+            "kind": "local",
+            "state": "offline",
+            "served_by": "npu",
+        },
+    ]
+    state = hp.BootstrapState(hermes_home=str(hermes_home))
+    io = hp.PhaseIO(
+        fetch_slots=lambda: slots,
+        fetch_model_contexts=lambda: {},
+    )
+    out = hp._phase_voice_wire(hp.context_for("voice_wire", state, io=io))
+    # TTS is ready so we get OK (not SKIP), but STT must be absent.
+    assert out.status in (hp.PhaseStatus.OK, hp.PhaseStatus.SKIP)
+    if secrets_env.exists():
+        env_text = secrets_env.read_text()
+        assert "STT_OPENAI_BASE_URL=" not in env_text, (
+            f"STT URL must not be written when anchor is offline. env:\n{env_text}"
+        )
+
+
 # ── #246 phase impls — smoke_tests + self_report ────────────────────────────
 
 


### PR DESCRIPTION
## Root cause

The `stt` slot is a routing facade with no systemd unit of its own. It routes `/v1/audio/transcriptions` through the `npu` anchor's FLM child (port 8088). Because no container runs for the facade itself, its reported `state` is always `offline`.

`_is_ready(slot)` accepts only `{ready, running, loaded, ok, online}`, so the facade was always rejected. `_find_slot(slots, "stt")` returned `None`, and `_phase_voice_wire` never wrote `STT_OPENAI_BASE_URL` — only a hand-written value on the box kept STT working.

## Fix

After the main `_is_ready` loop in `_find_slot`, add a secondary STT-only pass that accepts an `stt`/`transcription` slot whose `served_by` field names a slot that **is** ready. `container_enrichment` stamps `served_by` on NPU trio shadow slots when the anchor exists, so this is the precise signal. The secondary path is gated on `kind == "stt"` and never runs for `tts` or any other kind — all other `_is_ready` callers are unaffected.

## Test

Added `test_voice_wire_provisions_stt_for_npu_trio_facade`: given an npu anchor (`state=ready`) + transcription facade (`state=offline`, `served_by=npu`), asserts `voice_wire` returns OK and writes `STT_OPENAI_BASE_URL`. Red before fix, green after.

329 agents tests pass. 349 npu/dispatcher/stt-scoped tests pass. Zero regressions.

Follows up on #924 (voice_wire `kind='local'` bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)