### PR TITLE
feat(slots): single-source argv resolver — dedup the launch flag soup (overhaul stream A)

### DIFF
--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -246,10 +246,11 @@ class ServerConfig(BaseModel):
     extra_args: str | None = Field(
         default=None,
         description=(
-            "Freeform llama-server CLI passthrough.  Tokenised via shlex; "
-            "merged with the model's defaults.extra_args by "
-            "hal0.slots.flag_merge.merge_flags so slot flags win on collisions "
-            "(except for append-list flags like --lora / --draft-model / --override-kv)."
+            "Freeform llama-server CLI passthrough.  Tokenised via shlex and "
+            "appended last in the launch argv; hal0.slots.argv.normalize_argv "
+            "then collapses cross-source duplicates last-wins, so a flag set here "
+            "overrides the same flag from the profile / model defaults "
+            "(append-list flags like --lora / --draft-model / --override-kv are kept)."
         ),
     )
 

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -52,6 +52,7 @@ from hal0.config.schema import resolve_chat_template, resolve_profile_flags
 from hal0.profiles import ProfileCatalog
 from hal0.providers._gpu import resolve_gpu_device_paths, resolve_gpu_group_ids
 from hal0.providers.base import HealthCheck, Mount, Provider, RuntimeLaunchPlan
+from hal0.slots.argv import normalize_argv
 
 # ``ContainerSpec`` is the back-compat alias for ``RuntimeLaunchPlan``; some
 # callers/tests still import the old name from this module.
@@ -380,6 +381,12 @@ def _llama_launch_plan(
     if mmproj:
         command += ["--mmproj", mmproj]
     command += extra_tokens
+
+    # Collapse cross-segment duplicates (profile flags vs [server].extra_args vs
+    # toggle-derived flags) to one source of truth: last-wins dedup, which is
+    # effective-value-preserving because llama-server already used the last
+    # occurrence. See hal0.slots.argv.normalize_argv.
+    command = normalize_argv(command).argv
 
     # Effective model-store root (honours [models].store / HAL0_MODEL_STORE,
     # default /mnt/ai-models). Mounted identical-path, read-only, with an
@@ -1023,7 +1030,9 @@ def resolved_command_for_slot(
         argv += ["--ctx-size", str(context_size)]
     argv.extend(flag_tokens)
     argv.extend(extra_tokens)
-    return argv
+    # Dedup the flag portion (everything after the image) the same way the
+    # launch path does, so the preview matches what actually runs.
+    return [argv[0], *normalize_argv(argv[1:]).argv]
 
 
 __all__ = [

--- a/src/hal0/registry/model.py
+++ b/src/hal0/registry/model.py
@@ -22,9 +22,9 @@ Capability = str  # e.g. "chat", "embed", "rerank", "vision", "asr", "tts"
 class ModelDefaults(BaseModel):
     """Per-model default knobs surfaced as launcher defaults.
 
-    All fields optional. ``extra_args`` is appended verbatim to the
-    launcher arg list and is later merged with the slot's own
-    ``[server].extra_args`` by :func:`hal0.launchers.flag_merge.merge_flags`.
+    All fields optional. ``extra_args`` is appended to the launcher arg
+    list; cross-source duplicates (profile flags, slot ``[server].extra_args``)
+    are collapsed last-wins by :func:`hal0.slots.argv.normalize_argv` at launch.
     """
 
     model_config = {"populate_by_name": True, "str_strip_whitespace": True}

--- a/src/hal0/slots/argv.py
+++ b/src/hal0/slots/argv.py
@@ -1,0 +1,173 @@
+"""normalize_argv — the single dedup/last-wins pass for llama-server argv.
+
+The launch argv for a slot is assembled from several sources that historically
+just concatenate (``container._llama_launch_plan``): the structural prefix
+(``--host``/``--port``/``--model``/``--alias``/``--ctx-size``), the profile's
+bench-tuned ``flags``, a resolved ``--chat-template-file``, and the slot's
+``[server].extra_args``. Nothing dedups *across* those segments, so a flag the
+profile sets and the slot also overrides (``-b``, ``-ctk``, ``-ngl``,
+``--jinja`` …) is emitted twice. llama-server silently takes the **last**
+occurrence, so the command still runs — but the rendered argv is a confusing,
+unauditable soup of conflicting duplicates (the live ``agent`` slot ships
+``-b`` x2, ``-ngl 999`` then ``-ngl 99``, ``--jinja`` x2).
+
+This module collapses that to one source of truth at the argv layer:
+
+  * **Dedup by canonical key, keep the LAST occurrence.** Because llama-server
+    already used the last value, keeping it is *effective-value-preserving* —
+    the slot launches identically, the argv is just clean. This is the property
+    the golden-parity tests pin.
+  * **Canonicalize for the key only; emit the original spelling.** ``-b`` and
+    ``--batch-size`` share a key (so they dedup against each other), but the
+    surviving token keeps whatever spelling the winning source used — we never
+    rewrite ``-b`` into ``--batch-size`` behind the operator's back.
+  * **Append-list flags are never deduped** (``--lora``/``--draft-model``/
+    ``--override-kv``): llama-server treats repeats additively.
+  * **Order is preserved** (each surviving flag stays at its last position),
+    so the structural prefix stays first and the diff vs today is exactly "the
+    earlier duplicates removed".
+
+It is a pure function over a token list, so every assembly path
+(``_llama_launch_plan``, the resolved-command preview) can route through it
+without restructuring how they build the list.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Short→long canonicalisation. Used ONLY to compute the dedup key; the emitted
+# token keeps its original spelling. Seeded from the flags hal0 profiles +
+# slots actually use on llama-server; unknown flags fall through unaliased and
+# dedup against their own literal spelling (still correct, just less aggressive).
+FLAG_ALIASES: dict[str, str] = {
+    "-b": "--batch-size",
+    "-ub": "--ubatch-size",
+    "-ngl": "--n-gpu-layers",
+    "-ctk": "--cache-type-k",
+    "-ctv": "--cache-type-v",
+    "-t": "--threads",
+    "-tb": "--threads-batch",
+    "-fa": "--flash-attn",
+    "-dev": "--device",
+    "-sm": "--split-mode",
+    "-c": "--ctx-size",
+    "-ts": "--tensor-split",
+    "-mg": "--main-gpu",
+    "-np": "--parallel",
+    "-ngld": "--n-gpu-layers-draft",
+}
+
+# Flags whose semantics are "may be repeated" — never deduped. Keyed by the
+# canonical (long) spelling.
+APPEND_FLAGS: frozenset[str] = frozenset(
+    {
+        "--lora",
+        "--draft-model",
+        "--override-kv",
+    }
+)
+
+
+@dataclass(frozen=True)
+class NormalizedArgv:
+    """Result of :func:`normalize_argv`.
+
+    ``argv`` is the deduped token list. ``removed`` is the count of duplicate
+    tokens dropped (for logging / the dashboard "cleaned N duplicate flags"
+    affordance). ``winners`` maps each canonical flag key to the spelling that
+    survived — the seed of a future provenance view.
+    """
+
+    argv: list[str]
+    removed: int
+    winners: dict[str, str]
+
+
+def _is_flag(tok: str) -> bool:
+    """True for ``--long`` and ``-x``/``-ngl`` short flags; False for values.
+
+    A leading ``-`` followed by a letter is a flag; a leading ``-`` followed by
+    a digit/dot is a negative number (a value, e.g. ``-1`` for ``-ngl -1``).
+    """
+    if tok.startswith("--"):
+        return len(tok) > 2
+    return len(tok) > 1 and tok[0] == "-" and tok[1].isalpha()
+
+
+def _canon(flag: str) -> str:
+    return FLAG_ALIASES.get(flag, flag)
+
+
+@dataclass(frozen=True)
+class _Pair:
+    canon: str | None  # None => bare positional (never deduped)
+    flag: str | None
+    values: tuple[str, ...]
+
+
+def _split_pairs(tokens: list[str]) -> list[_Pair]:
+    """Group a flat token list into ``(flag, value?)`` pairs, order preserved.
+
+    A flag consumes the following token as its value iff that token is not
+    itself a flag (so ``--jinja --metrics`` are two valueless bools, while
+    ``-b 8192`` and ``--temp 0`` carry a value). Bare positionals are kept
+    under ``canon=None`` so dedup never touches them.
+    """
+    pairs: list[_Pair] = []
+    i = 0
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        if _is_flag(tok):
+            if i + 1 < n and not _is_flag(tokens[i + 1]):
+                pairs.append(_Pair(_canon(tok), tok, (tokens[i + 1],)))
+                i += 2
+            else:
+                pairs.append(_Pair(_canon(tok), tok, ()))
+                i += 1
+        else:
+            pairs.append(_Pair(None, None, (tok,)))
+            i += 1
+    return pairs
+
+
+def normalize_argv(tokens: list[str]) -> NormalizedArgv:
+    """Dedup ``tokens`` keeping the last occurrence of each scalar/bool flag.
+
+    Effective-value-preserving: the surviving value for every flag equals the
+    last value in ``tokens`` (what llama-server used anyway). Append-list flags
+    and bare positionals are kept verbatim, in order.
+    """
+    pairs = _split_pairs(tokens)
+
+    # The index of the last occurrence of each dedupable canonical flag.
+    last_index: dict[str, int] = {}
+    for idx, p in enumerate(pairs):
+        if p.canon is not None and p.canon not in APPEND_FLAGS:
+            last_index[p.canon] = idx
+
+    out: list[str] = []
+    winners: dict[str, str] = {}
+    removed = 0
+    for idx, p in enumerate(pairs):
+        if p.canon is None:  # positional
+            out.extend(p.values)
+            continue
+        if p.canon in APPEND_FLAGS:
+            assert p.flag is not None
+            out.append(p.flag)
+            out.extend(p.values)
+            continue
+        if last_index[p.canon] == idx:
+            assert p.flag is not None
+            out.append(p.flag)
+            out.extend(p.values)
+            winners[p.canon] = p.flag
+        else:
+            removed += 1  # earlier duplicate, dropped in favour of a later one
+
+    return NormalizedArgv(argv=out, removed=removed, winners=winners)
+
+
+__all__ = ["APPEND_FLAGS", "FLAG_ALIASES", "NormalizedArgv", "normalize_argv"]

--- a/tests/providers/test_container_chat_template.py
+++ b/tests/providers/test_container_chat_template.py
@@ -103,11 +103,13 @@ class TestLlamaLaunchPlanChatTemplate:
         )
         assert "--chat-template-file" not in plan.command
 
-    def test_chat_template_flag_precedes_extra_tokens(self) -> None:
-        """--chat-template-file must appear before extra_args tokens so a manual
-        ``--chat-template-file`` in [server].extra_args can still override it."""
+    def test_chat_template_override_in_extra_args_wins(self) -> None:
+        """A manual ``--chat-template-file`` in [server].extra_args overrides the
+        resolved one. normalize_argv dedups to a single flag whose value is the
+        extra_args override (last-wins) — the documented precedence, now without
+        the confusing duplicate."""
         tmpl_path = "/mnt/ai-models/chat-templates/llama3.jinja"
-        extra = "--chat-template-file /mnt/ai-models/chat-templates/override.jinja"
+        override = "/mnt/ai-models/chat-templates/override.jinja"
         plan = _llama_launch_plan(
             image="img:latest",
             port=8095,
@@ -115,17 +117,13 @@ class TestLlamaLaunchPlanChatTemplate:
             flags_str="",
             devices=[],
             group_ids=[],
-            extra_args=extra,
+            extra_args=f"--chat-template-file {override}",
             chat_template_path=tmpl_path,
         )
         cmd = plan.command
-        # Both occurrences are present (template from resolve + override from extra_args)
-        assert "--chat-template-file" in cmd
-        first_idx = cmd.index("--chat-template-file")
-        assert cmd[first_idx + 1] == tmpl_path
-        # The extra_args override appears later
-        extra_idx = cmd.index("--chat-template-file", first_idx + 1)
-        assert extra_idx > first_idx
+        assert cmd.count("--chat-template-file") == 1
+        idx = cmd.index("--chat-template-file")
+        assert cmd[idx + 1] == override
 
 
 # ── container_spec integration tests ─────────────────────────────────────────

--- a/tests/providers/test_container_mmproj.py
+++ b/tests/providers/test_container_mmproj.py
@@ -8,7 +8,8 @@ hack that previously lived in the live chat.toml.
 
 Covers:
   * ``_llama_launch_plan`` appends ``--mmproj <path>`` when given, omits it when None.
-  * The flag precedes ``extra_args`` tokens (so a manual override could still win).
+  * A manual ``--mmproj`` in ``extra_args`` overrides the sidecar; normalize_argv
+    dedups to one flag (last-wins) so there's no duplicate in the command.
   * ``container_spec`` reads ``model_info["mmproj"]`` and emits the flag.
   * No flag when the model carries no sidecar (no regression for text-only slots).
   * ``load_sync`` writes a unit file containing the flag when a sidecar is present.
@@ -101,10 +102,11 @@ class TestLlamaLaunchPlanMmproj:
         )
         assert "--mmproj" not in plan.command
 
-    def test_mmproj_precedes_extra_tokens(self) -> None:
-        """--mmproj must appear before [server].extra_args tokens so a manual
-        override in extra_args can still take precedence."""
-        extra = "--mmproj /mnt/ai-models/override/mmproj.gguf"
+    def test_mmproj_override_in_extra_args_wins(self) -> None:
+        """A manual ``--mmproj`` in [server].extra_args overrides the sidecar.
+        normalize_argv dedups to one --mmproj whose value is the extra_args
+        override (last-wins) — the documented precedence, sans duplicate."""
+        override = "/mnt/ai-models/override/mmproj.gguf"
         plan = _llama_launch_plan(
             image="img:latest",
             port=8095,
@@ -112,14 +114,13 @@ class TestLlamaLaunchPlanMmproj:
             flags_str="",
             devices=[],
             group_ids=[],
-            extra_args=extra,
+            extra_args=f"--mmproj {override}",
             mmproj=_SIDECAR,
         )
         cmd = plan.command
-        first_idx = cmd.index("--mmproj")
-        assert cmd[first_idx + 1] == _SIDECAR
-        override_idx = cmd.index("--mmproj", first_idx + 1)
-        assert override_idx > first_idx
+        assert cmd.count("--mmproj") == 1
+        idx = cmd.index("--mmproj")
+        assert cmd[idx + 1] == override
 
 
 # ── container_spec integration tests ─────────────────────────────────────────

--- a/tests/slots/test_argv.py
+++ b/tests/slots/test_argv.py
@@ -1,0 +1,241 @@
+"""Unit + golden-parity tests for hal0.slots.argv.normalize_argv.
+
+The golden fixture is the *live* ``agent`` slot's resolved command (captured
+from ``slot_list`` on CT105), which carries the real duplicate-flag soup
+(``-b`` x2, ``-ctk`` x2, ``--jinja`` x2, ``--threads`` long + ``-t`` short).
+The parity property: normalising it preserves every flag's effective (last)
+value and drops only the earlier duplicates — so the slot launches identically.
+"""
+
+from __future__ import annotations
+
+from hal0.slots.argv import normalize_argv
+
+# The flag portion of the live `agent` slot resolved_command (post `--port`).
+# Verbatim from `mcp__hal0-admin__slot_list` — includes the profile MTP bundle
+# AND the slot extra_args repeating many of the same flags.
+AGENT_LIVE = [
+    "--host",
+    "0.0.0.0",
+    "--port",
+    "8101",
+    "--model",
+    "qwen3.6-35b-a3b-crown-halo-mtp-dynamic",
+    "--alias",
+    "qwen3.6-35b-a3b-crown-halo-mtp-dynamic",
+    "--ctx-size",
+    "164000",
+    "-fa",
+    "on",
+    "-ctk",
+    "q4_0",
+    "-ctv",
+    "q4_0",
+    "-b",
+    "8192",
+    "-ub",
+    "2048",
+    "--parallel",
+    "1",
+    "--threads",
+    "16",
+    "--threads-batch",
+    "32",
+    "--no-mmap",
+    "--poll",
+    "100",
+    "--poll-batch",
+    "1",
+    "--jinja",
+    "--spec-type",
+    "draft-mtp",
+    "--spec-draft-device",
+    "ROCm0",
+    "--spec-draft-ngl",
+    "all",
+    "--spec-draft-n-max",
+    "4",
+    "--spec-draft-n-min",
+    "0",
+    "--spec-draft-p-min",
+    "0.0",
+    "--spec-draft-p-split",
+    "0.10",
+    "--spec-draft-type-k",
+    "f16",
+    "--spec-draft-type-v",
+    "f16",
+    "--spec-draft-threads",
+    "16",
+    "--spec-draft-threads-batch",
+    "32",
+    "--spec-draft-poll",
+    "1",
+    "--spec-draft-poll-batch",
+    "1",
+    # ── slot [server].extra_args begins here — repeats much of the above ──
+    "-ngl",
+    "999",
+    "-dev",
+    "ROCm0",
+    "-sm",
+    "row",
+    "-b",
+    "8192",
+    "-ub",
+    "2048",
+    "-t",
+    "16",
+    "-tb",
+    "32",
+    "-ctk",
+    "q4_0",
+    "-ctv",
+    "q4_0",
+    "--spec-draft-device",
+    "ROCm0",
+    "--spec-draft-ngl",
+    "all",
+    "--spec-draft-type-k",
+    "f16",
+    "--spec-draft-type-v",
+    "f16",
+    "--spec-draft-threads",
+    "16",
+    "--spec-draft-threads-batch",
+    "32",
+    "--spec-draft-n-max",
+    "4",
+    "--spec-draft-n-min",
+    "0",
+    "--spec-draft-p-min",
+    "0.0",
+    "--spec-draft-p-split",
+    "0.10",
+    "--poll",
+    "100",
+    "--poll-batch",
+    "1",
+    "--spec-draft-poll",
+    "1",
+    "--spec-draft-poll-batch",
+    "1",
+    "--temp",
+    "0",
+    "--min-p",
+    "0.0",
+    "--top-p",
+    "0.9",
+    "--top-k",
+    "20",
+    "--repeat-penalty",
+    "1.0",
+    "--seed",
+    "123",
+    "--cache-ram",
+    "0",
+    "--parallel",
+    "1",
+    "--image-min-tokens",
+    "1024",
+    "--metrics",
+    "--jinja",
+    "--reasoning-format",
+    "deepseek",
+    "--reasoning-budget",
+    "0",
+]
+
+
+def _value_after(tokens: list[str], flag: str) -> str | None:
+    """Last value following ``flag`` in ``tokens`` (the effective value)."""
+    val = None
+    for i, t in enumerate(tokens):
+        if t == flag and i + 1 < len(tokens):
+            val = tokens[i + 1]
+    return val
+
+
+# ── golden parity on the live agent slot ──────────────────────────────────────
+
+
+def test_agent_live_dedups_but_preserves_effective_values() -> None:
+    res = normalize_argv(AGENT_LIVE)
+    out = res.argv
+
+    # 1) duplicates were actually removed
+    assert res.removed > 0
+    assert len(out) < len(AGENT_LIVE)
+
+    # 2) each dedupable flag now appears exactly once
+    for flag in ("-b", "-ub", "-ctk", "-ctv", "--jinja", "--parallel", "--poll"):
+        assert out.count(flag) <= 1, f"{flag} still duplicated: {out.count(flag)}"
+
+    # 3) effective (last) value preserved for representative scalar flags
+    assert _value_after(out, "-b") == "8192"
+    assert _value_after(out, "-ctk") == "q4_0"
+    assert _value_after(out, "--spec-draft-type-k") == "f16"
+    assert _value_after(out, "--reasoning-budget") == "0"
+    assert _value_after(out, "--temp") == "0"
+
+    # 4) structural prefix intact
+    assert out[:4] == ["--host", "0.0.0.0", "--port", "8101"]
+    assert _value_after(out, "--model") == "qwen3.6-35b-a3b-crown-halo-mtp-dynamic"
+    assert _value_after(out, "--ctx-size") == "164000"
+
+    # 5) bool flag survives exactly once
+    assert out.count("--jinja") == 1
+    assert out.count("--metrics") == 1
+
+
+def test_alias_dedups_short_against_long() -> None:
+    # --threads (long, from profile) and -t (short, from extra_args) share a key.
+    res = normalize_argv(["--threads", "16", "-t", "16"])
+    assert res.argv == ["-t", "16"]  # last occurrence wins, short spelling kept
+    assert res.removed == 1
+
+
+def test_normalize_is_idempotent() -> None:
+    once = normalize_argv(AGENT_LIVE).argv
+    twice = normalize_argv(once)
+    assert twice.argv == once
+    assert twice.removed == 0
+
+
+# ── focused unit cases ────────────────────────────────────────────────────────
+
+
+def test_last_value_wins_on_conflict() -> None:
+    res = normalize_argv(["-b", "512", "-b", "8192"])
+    assert res.argv == ["-b", "8192"]
+    assert res.removed == 1
+
+
+def test_bool_flags_collapse_to_one() -> None:
+    res = normalize_argv(["--jinja", "--metrics", "--jinja"])
+    assert res.argv == ["--metrics", "--jinja"]  # --jinja kept at its last spot
+    assert res.removed == 1
+
+
+def test_append_flags_are_never_deduped() -> None:
+    res = normalize_argv(["--lora", "a.gguf", "--lora", "b.gguf"])
+    assert res.argv == ["--lora", "a.gguf", "--lora", "b.gguf"]
+    assert res.removed == 0
+
+
+def test_negative_number_is_a_value_not_a_flag() -> None:
+    res = normalize_argv(["-ngl", "-1"])
+    assert res.argv == ["-ngl", "-1"]
+    assert _value_after(res.argv, "-ngl") == "-1"
+
+
+def test_bare_positionals_preserved() -> None:
+    res = normalize_argv(["--model", "/m.gguf", "extra-positional"])
+    assert "extra-positional" in res.argv
+
+
+def test_empty_is_noop() -> None:
+    res = normalize_argv([])
+    assert res.argv == []
+    assert res.removed == 0
+    assert res.winners == {}


### PR DESCRIPTION
## What

Stream A of the hal0 overhaul: **one source of truth for a slot's launch flags.** Today a slot's llama-server argv is assembled by concatenating several sources with no cross-dedup — `_llama_launch_plan` glues the profile's bench-tuned `flags`, the resolved `--chat-template-file`/`--mmproj`, and `[server].extra_args`. A flag the profile sets and the slot overrides is therefore emitted **twice**; llama-server silently takes the last occurrence.

The live `agent` slot ships the result:
```
-b 8192 ... -b 8192   -ctk q4_0 ... -ctk q4_0   --jinja ... --jinja
--threads 16 ... -t 16   --parallel 1 ... --parallel 1   (+ a dozen more)
```
A confusing, unauditable command where the effective value is decided by llama-server's last-wins parse luck.

## How

New `hal0.slots.argv.normalize_argv`: a single **last-wins dedup pass** over the token list, routed through by both assembly paths in `providers/container.py` (the launch path *and* the resolved-command preview, so the dashboard matches what runs).

It is **effective-value-preserving**: llama-server already used the last occurrence, so keeping that value and dropping the earlier duplicates changes nothing at runtime — the argv is just clean. Details:
- short flags canonicalise against their long form for the **dedup key only** (`-b` and `--batch-size` collide) but keep their original spelling on output — we never rewrite `-b` into `--batch-size` behind the operator's back;
- append-list flags (`--lora`/`--draft-model`/`--override-kv`) and bare positionals are never deduped;
- order preserved (each surviving flag stays at its last position), so the diff vs today is exactly "earlier duplicates removed".

This is the layer **below** the `stacks` declarative engine (which writes slot TOMLs but passes `extra_args` verbatim) — together they make the slot→argv path one auditable source of truth.

## Tests
- `tests/slots/test_argv.py` — golden parity on the **live `agent` slot tokens**: effective value preserved per flag, duplicates removed, idempotent; plus unit cases (alias dedup, last-wins, bool collapse, append-never-deduped, negative-number-as-value).
- Updated `container` chat-template/mmproj tests: the documented "a manual override in `extra_args` wins" contract now holds with a **single** (deduped) flag instead of a duplicate.
- `798 passed` across `tests/providers tests/slots tests/config`; `99 passed` across the slot-view API + install suites. ruff check + format clean.

## Behaviour change (intentional, documented)
`--chat-template-file` / `--mmproj` were previously emitted twice (resolved + extra_args override) and relied on last-wins; they're now emitted once with the override value. Effective inference behaviour is identical. The two tests asserting the old duplicate-present layout were updated to assert the effective contract.

## Note
A pre-existing set of environment-dependent tests fails on `main` independently of this PR (pve-kernel detection on a Proxmox host, root-writable-path, hermes/openwebui install-layout, bundle-tier tables) — verified identical pass/fail on the base commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)