### PR TITLE
feat(slots): per-flag provenance + GET /slots/{name}/resolved (overhaul stream A)

### DIFF
--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -858,6 +858,25 @@ async def get_slot_config(name: str, request: Request) -> dict[str, object]:
     return cfg
 
 
+@router.get("/{name}/resolved")
+async def get_slot_resolved(name: str, request: Request) -> dict[str, object]:
+    """Return the resolved llama-server argv with per-flag provenance.
+
+    The auditable single-source-of-truth view: the deduped command plus, for
+    each surviving flag, which segment (``base`` / ``profile`` / ``extra_args``)
+    set its final value and how many duplicate flags were collapsed. Non-llama
+    slots (no profile) get ``{"argv": None, ...}`` rather than an error.
+    """
+    from hal0.providers.container import resolved_argv_detail_for_slot
+
+    sm = _get_slot_manager(request)
+    cfg = await sm.get_config(name)
+    detail = resolved_argv_detail_for_slot(cfg)
+    if detail is None:
+        return {"name": name, "argv": None, "provenance": [], "removed": 0}
+    return {"name": name, **detail}
+
+
 @router.put("/{name}/config")
 async def update_slot_config(name: str, request: Request) -> dict[str, object]:
     """Update a slot's config. Body: partial SlotConfig (shallow merge)."""

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -52,7 +52,7 @@ from hal0.config.schema import resolve_chat_template, resolve_profile_flags
 from hal0.profiles import ProfileCatalog
 from hal0.providers._gpu import resolve_gpu_device_paths, resolve_gpu_group_ids
 from hal0.providers.base import HealthCheck, Mount, Provider, RuntimeLaunchPlan
-from hal0.slots.argv import normalize_argv
+from hal0.slots.argv import ResolvedArgv, normalize_argv, resolve_argv
 
 # ``ContainerSpec`` is the back-compat alias for ``RuntimeLaunchPlan``; some
 # callers/tests still import the old name from this module.
@@ -992,6 +992,25 @@ def resolved_command_for_slot(
     Returns ``None`` when the slot has no profile (not a container slot)
     or the profile lookup fails.
     """
+    resolved = _resolve_slot_argv(slot_cfg, model_path)
+    if resolved is None:
+        return None
+    image, result = resolved
+    return [image, *result.argv]
+
+
+def _resolve_slot_argv(
+    slot_cfg: dict[str, Any],
+    model_path: str | None = None,
+) -> tuple[str, ResolvedArgv] | None:
+    """Build the labelled argv segments for a slot and resolve them.
+
+    Returns ``(image, ResolvedArgv)`` — the deduped flag portion (image
+    excluded) plus per-flag provenance — or ``None`` when the slot has no
+    profile / the profile lookup fails. Segments are ordered lowest-precedence
+    first (base < profile < extra_args) so ``resolve_argv``'s last-wins matches
+    the launch path: a flag in ``[server].extra_args`` overrides the profile.
+    """
     profile_name = str(slot_cfg.get("profile") or "")
     if not profile_name:
         return None
@@ -1015,24 +1034,47 @@ def resolved_command_for_slot(
     extra_args = server_table.get("extra_args") if isinstance(server_table, dict) else None
     extra_tokens = shlex.split(extra_args) if extra_args and extra_args.strip() else []
 
-    argv: list[str] = [
-        image,
-        "--host",
-        "0.0.0.0",
-        "--port",
-        str(port),
-    ]
+    base: list[str] = ["--host", "0.0.0.0", "--port", str(port)]
     if effective_model:
-        argv += ["--model", effective_model]
+        base += ["--model", effective_model]
     if default_model:
-        argv += ["--alias", str(default_model)]
+        base += ["--alias", str(default_model)]
     if context_size is not None:
-        argv += ["--ctx-size", str(context_size)]
-    argv.extend(flag_tokens)
-    argv.extend(extra_tokens)
-    # Dedup the flag portion (everything after the image) the same way the
-    # launch path does, so the preview matches what actually runs.
-    return [argv[0], *normalize_argv(argv[1:]).argv]
+        base += ["--ctx-size", str(context_size)]
+
+    result = resolve_argv(
+        [
+            ("base", base),
+            ("profile", flag_tokens),
+            ("extra_args", extra_tokens),
+        ]
+    )
+    return image, result
+
+
+def resolved_argv_detail_for_slot(
+    slot_cfg: dict[str, Any],
+    model_path: str | None = None,
+) -> dict[str, Any] | None:
+    """Structured resolution for the dashboard's "resolved command" drawer.
+
+    Returns ``{"argv", "provenance", "removed"}`` where ``provenance`` lists each
+    surviving flag with the segment that set its final value (``base`` /
+    ``profile`` / ``extra_args``) — so an operator can see exactly which source
+    won each flag and how many duplicates were collapsed. ``None`` for a slot
+    with no profile.
+    """
+    resolved = _resolve_slot_argv(slot_cfg, model_path)
+    if resolved is None:
+        return None
+    image, result = resolved
+    return {
+        "argv": [image, *result.argv],
+        "provenance": [
+            {"flag": p.flag, "value": p.value, "source": p.source} for p in result.provenance
+        ],
+        "removed": result.removed,
+    }
 
 
 __all__ = [
@@ -1041,6 +1083,7 @@ __all__ = [
     "_render_unit_from_spec",
     "_spec_provider_for",
     "container_provider",
+    "resolved_argv_detail_for_slot",
     "resolved_command_for_slot",
 ]
 

--- a/src/hal0/slots/argv.py
+++ b/src/hal0/slots/argv.py
@@ -104,32 +104,71 @@ class _Pair:
     canon: str | None  # None => bare positional (never deduped)
     flag: str | None
     values: tuple[str, ...]
+    source: str = ""  # which input segment this token came from (provenance)
 
 
-def _split_pairs(tokens: list[str]) -> list[_Pair]:
+def _split_pairs(tokens: list[str], sources: list[str] | None = None) -> list[_Pair]:
     """Group a flat token list into ``(flag, value?)`` pairs, order preserved.
 
     A flag consumes the following token as its value iff that token is not
     itself a flag (so ``--jinja --metrics`` are two valueless bools, while
     ``-b 8192`` and ``--temp 0`` carry a value). Bare positionals are kept
     under ``canon=None`` so dedup never touches them.
+
+    ``sources`` is an optional parallel list labelling each token's origin
+    segment; a pair takes the source of its flag (or positional) token.
     """
     pairs: list[_Pair] = []
     i = 0
     n = len(tokens)
     while i < n:
         tok = tokens[i]
+        src = sources[i] if sources is not None else ""
         if _is_flag(tok):
             if i + 1 < n and not _is_flag(tokens[i + 1]):
-                pairs.append(_Pair(_canon(tok), tok, (tokens[i + 1],)))
+                pairs.append(_Pair(_canon(tok), tok, (tokens[i + 1],), src))
                 i += 2
             else:
-                pairs.append(_Pair(_canon(tok), tok, ()))
+                pairs.append(_Pair(_canon(tok), tok, (), src))
                 i += 1
         else:
-            pairs.append(_Pair(None, None, (tok,)))
+            pairs.append(_Pair(None, None, (tok,), src))
             i += 1
     return pairs
+
+
+def _dedup(pairs: list[_Pair]) -> tuple[list[str], int, dict[str, _Pair]]:
+    """Last-wins dedup over ``pairs``. Shared core of the two public entrypoints.
+
+    Returns ``(argv, removed, winners)`` where ``winners`` maps each surviving
+    canonical flag key to the winning :class:`_Pair` (in emission order, so the
+    dict iteration order matches the flag order in ``argv``).
+    """
+    last_index: dict[str, int] = {}
+    for idx, p in enumerate(pairs):
+        if p.canon is not None and p.canon not in APPEND_FLAGS:
+            last_index[p.canon] = idx
+
+    out: list[str] = []
+    winners: dict[str, _Pair] = {}
+    removed = 0
+    for idx, p in enumerate(pairs):
+        if p.canon is None:  # positional — never deduped
+            out.extend(p.values)
+            continue
+        if p.canon in APPEND_FLAGS:  # repeatable — kept verbatim
+            assert p.flag is not None
+            out.append(p.flag)
+            out.extend(p.values)
+            continue
+        if last_index[p.canon] == idx:
+            assert p.flag is not None
+            out.append(p.flag)
+            out.extend(p.values)
+            winners[p.canon] = p
+        else:
+            removed += 1  # earlier duplicate, dropped in favour of a later one
+    return out, removed, winners
 
 
 def normalize_argv(tokens: list[str]) -> NormalizedArgv:
@@ -139,35 +178,69 @@ def normalize_argv(tokens: list[str]) -> NormalizedArgv:
     last value in ``tokens`` (what llama-server used anyway). Append-list flags
     and bare positionals are kept verbatim, in order.
     """
-    pairs = _split_pairs(tokens)
-
-    # The index of the last occurrence of each dedupable canonical flag.
-    last_index: dict[str, int] = {}
-    for idx, p in enumerate(pairs):
-        if p.canon is not None and p.canon not in APPEND_FLAGS:
-            last_index[p.canon] = idx
-
-    out: list[str] = []
-    winners: dict[str, str] = {}
-    removed = 0
-    for idx, p in enumerate(pairs):
-        if p.canon is None:  # positional
-            out.extend(p.values)
-            continue
-        if p.canon in APPEND_FLAGS:
-            assert p.flag is not None
-            out.append(p.flag)
-            out.extend(p.values)
-            continue
-        if last_index[p.canon] == idx:
-            assert p.flag is not None
-            out.append(p.flag)
-            out.extend(p.values)
-            winners[p.canon] = p.flag
-        else:
-            removed += 1  # earlier duplicate, dropped in favour of a later one
-
-    return NormalizedArgv(argv=out, removed=removed, winners=winners)
+    out, removed, winners = _dedup(_split_pairs(tokens))
+    return NormalizedArgv(
+        argv=out, removed=removed, winners={k: p.flag for k, p in winners.items() if p.flag}
+    )
 
 
-__all__ = ["APPEND_FLAGS", "FLAG_ALIASES", "NormalizedArgv", "normalize_argv"]
+@dataclass(frozen=True)
+class FlagProvenance:
+    """One surviving flag and the input segment it was resolved from."""
+
+    flag: str
+    value: str | None
+    source: str
+
+
+@dataclass(frozen=True)
+class ResolvedArgv:
+    """Deduped argv plus per-flag provenance — the auditable resolution.
+
+    ``provenance`` lists each surviving scalar/bool flag (append-list flags are
+    omitted — they aren't deduped, so "which source won" is meaningless) with
+    the segment that won it, in argv order.
+    """
+
+    argv: list[str]
+    provenance: list[FlagProvenance]
+    removed: int
+
+
+def resolve_argv(segments: list[tuple[str, list[str]]]) -> ResolvedArgv:
+    """Resolve ordered ``(source_label, tokens)`` segments into one deduped argv.
+
+    Same last-wins semantics as :func:`normalize_argv`, but each segment's
+    tokens carry its label, so the result records which source set each flag's
+    final value (e.g. ``-b`` from ``profile`` vs ``--jinja`` from
+    ``extra_args``). Segments are concatenated in order before dedup, so a later
+    segment overrides an earlier one — pass them lowest-precedence first.
+    """
+    tokens: list[str] = []
+    sources: list[str] = []
+    for label, seg in segments:
+        for tok in seg:
+            tokens.append(tok)
+            sources.append(label)
+
+    out, removed, winners = _dedup(_split_pairs(tokens, sources))
+    provenance = [
+        FlagProvenance(
+            flag=p.flag,  # type: ignore[arg-type]  # winners only holds real flags
+            value=(p.values[0] if p.values else None),
+            source=p.source,
+        )
+        for p in winners.values()
+    ]
+    return ResolvedArgv(argv=out, provenance=provenance, removed=removed)
+
+
+__all__ = [
+    "APPEND_FLAGS",
+    "FLAG_ALIASES",
+    "FlagProvenance",
+    "NormalizedArgv",
+    "ResolvedArgv",
+    "normalize_argv",
+    "resolve_argv",
+]

--- a/tests/providers/test_container_resolved_detail.py
+++ b/tests/providers/test_container_resolved_detail.py
@@ -1,0 +1,48 @@
+"""Tests: resolved_argv_detail_for_slot — the provenance-annotated resolution.
+
+Backs the dashboard's "resolved command" drawer and GET /api/slots/{name}/resolved:
+the deduped argv plus, per flag, which segment (base / profile / extra_args) set
+its final value and how many duplicates were collapsed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from hal0.config.schema import ProfileConfig
+from hal0.providers.container import resolved_argv_detail_for_slot
+
+
+def _profile() -> ProfileConfig:
+    return ProfileConfig(image="img:1", flags="-b 512 --jinja", mtp=False)
+
+
+def test_detail_dedups_and_attributes_provenance() -> None:
+    cfg = {
+        "profile": "p",
+        "port": 8101,
+        "model": {"default": "m", "context_size": 4096},
+        "server": {"extra_args": "-b 8192"},  # overrides the profile's -b
+    }
+    with patch("hal0.providers.container._resolve_profile", return_value=_profile()):
+        detail = resolved_argv_detail_for_slot(cfg)
+
+    assert detail is not None
+    assert detail["argv"][0] == "img:1"
+    # -b deduped to one occurrence, extra_args value wins
+    assert detail["argv"].count("-b") == 1
+    assert detail["removed"] == 1
+
+    prov = {p["flag"]: p for p in detail["provenance"]}
+    assert prov["-b"]["source"] == "extra_args"
+    assert prov["-b"]["value"] == "8192"
+    assert prov["--jinja"]["source"] == "profile"
+    assert prov["--jinja"]["value"] is None
+    # base-segment structural flags are credited to "base"
+    assert prov["--model"]["source"] == "base"
+    assert prov["--model"]["value"] == "m"
+    assert prov["--ctx-size"]["value"] == "4096"
+
+
+def test_detail_none_without_profile() -> None:
+    assert resolved_argv_detail_for_slot({"model": {"default": "m"}}) is None

--- a/tests/slots/test_argv.py
+++ b/tests/slots/test_argv.py
@@ -9,7 +9,7 @@ value and drops only the earlier duplicates — so the slot launches identically
 
 from __future__ import annotations
 
-from hal0.slots.argv import normalize_argv
+from hal0.slots.argv import normalize_argv, resolve_argv
 
 # The flag portion of the live `agent` slot resolved_command (post `--port`).
 # Verbatim from `mcp__hal0-admin__slot_list` — includes the profile MTP bundle
@@ -239,3 +239,41 @@ def test_empty_is_noop() -> None:
     assert res.argv == []
     assert res.removed == 0
     assert res.winners == {}
+
+
+# ── resolve_argv: provenance over labelled segments ───────────────────────────
+
+
+def test_resolve_argv_attributes_winning_source() -> None:
+    res = resolve_argv(
+        [
+            ("base", ["--host", "0.0.0.0"]),
+            ("profile", ["-b", "512", "--jinja"]),
+            ("extra_args", ["-b", "8192"]),  # overrides the profile's -b
+        ]
+    )
+    assert res.argv == ["--host", "0.0.0.0", "--jinja", "-b", "8192"]
+    prov = {p.flag: p for p in res.provenance}
+    # -b was set last by extra_args -> that segment is credited, value preserved
+    assert prov["-b"].source == "extra_args"
+    assert prov["-b"].value == "8192"
+    # --jinja only came from the profile
+    assert prov["--jinja"].source == "profile"
+    assert prov["--jinja"].value is None
+    # --host from base
+    assert prov["--host"].source == "base"
+    assert res.removed == 1
+
+
+def test_resolve_argv_equivalent_argv_to_normalize() -> None:
+    # Same tokens, segmented vs flat, produce the same deduped argv.
+    flat = ["--host", "0.0.0.0", "-b", "512", "--jinja", "-b", "8192"]
+    seg = resolve_argv([("base", flat[:2]), ("profile", flat[2:5]), ("extra_args", flat[5:])])
+    assert seg.argv == normalize_argv(flat).argv
+
+
+def test_resolve_argv_omits_append_flags_from_provenance() -> None:
+    res = resolve_argv([("profile", ["--lora", "a", "--lora", "b"]), ("extra_args", ["--jinja"])])
+    flags = {p.flag for p in res.provenance}
+    assert "--lora" not in flags  # append flags aren't deduped -> no single "winner"
+    assert "--jinja" in flags


### PR DESCRIPTION
## What

Builds on the argv resolver (#930) to make a slot's resolved command **auditable**: not just the deduped argv, but *which source set each flag*.

- `argv.py`: factor the dedup into a shared core; add `resolve_argv(segments)` over labelled `(source, tokens)` segments → `ResolvedArgv{argv, provenance, removed}`. Each surviving flag is credited to the segment that won its value (last-wins). `normalize_argv` is unchanged (now a thin wrapper over the shared core).
- `container.py`: `_resolve_slot_argv` builds `base` / `profile` / `extra_args` segments; `resolved_command_for_slot` delegates to it (byte-identical argv); `resolved_argv_detail_for_slot` returns the structured view.
- `api/routes/slots.py`: **`GET /api/slots/{name}/resolved`** → `{argv, provenance:[{flag,value,source}], removed}`. Non-llama slots (no profile) return `argv: null` rather than an error.

So an operator can see `-b 8192` came from `extra_args` (overriding the profile's `-b 512`), `--jinja` from the `profile`, `--model` from `base` — and that N duplicates were collapsed. This is the "single source of truth, made visible" half of stream A.

## Tests
- `resolve_argv` provenance: winning-source attribution, argv-equivalence to `normalize_argv`, append-flags omitted from provenance.
- `resolved_argv_detail_for_slot`: `-b` from extra_args wins over profile, `--jinja` from profile, base flags credited to `base`, `removed` count.
- `569 passed` across `tests/slots tests/providers tests/api/test_slots_routes tests/api/test_llm_slot_views`; ruff clean.

Stacks on #930 (merged). Pre-existing host-only test failures (pve-kernel-on-pve-host etc.) are unrelated and pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)