### PR TITLE
feat(ui): resolved-command provenance in the slot Edit drawer (overhaul stream A)

### DIFF
--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -41,6 +41,8 @@ export const ENDPOINTS = {
     `/api/slots/${encodeURIComponent(name)}/pull`,
   slotPullStream: (name: string) =>
     `/api/slots/${encodeURIComponent(name)}/pull/stream`,
+  slotResolved: (name: string) =>
+    `/api/slots/${encodeURIComponent(name)}/resolved`,
 
   // ── Models / pull lifecycle ──────────────────────────────────────
   models: '/api/models',

--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -514,6 +514,51 @@ export function useSlotConfig(name: string | null | undefined) {
   })
 }
 
+// ─── useSlotResolved ──────────────────────────────────────────────────────────
+
+/** Source segment that supplied the surviving value for a flag. */
+export type ProvenanceSource = 'base' | 'profile' | 'extra_args'
+
+/** Per-flag provenance entry returned by GET /api/slots/{name}/resolved. */
+export interface FlagProvenance {
+  /** The flag token, e.g. "--model", "-b". */
+  flag: string
+  /** The value following the flag, or null for bare flags. */
+  value: string | null
+  /** Which config segment set the final (surviving) value. */
+  source: ProvenanceSource
+}
+
+/** Full resolved-command payload from GET /api/slots/{name}/resolved. */
+export interface SlotResolved {
+  name: string
+  /** Deduped llama-server argv (image first), or null for non-llama slots. */
+  argv: string[] | null
+  /** One entry per surviving flag: which segment owns the final value. */
+  provenance: FlagProvenance[]
+  /** Number of duplicate flags that were collapsed. */
+  removed: number
+}
+
+/**
+ * GET /api/slots/{name}/resolved — resolved command provenance for a slot.
+ *
+ * Only fetched when the Edit drawer is open (`enabled`). Uses a moderate
+ * staleTime so repeat opens don't hammer the backend, but the data stays
+ * fresh enough to reflect a recent Regenerate click.
+ */
+export function useSlotResolved(
+  name: string | null | undefined,
+  options: { enabled?: boolean } = {},
+) {
+  return useQuery<SlotResolved>({
+    queryKey: ['slot-resolved', name],
+    queryFn: () => apiGet<SlotResolved>(ENDPOINTS.slotResolved(name as string)),
+    enabled: !!name && (options.enabled !== false),
+    staleTime: 8_000,
+  })
+}
+
 // ─── useSlotImagePull ─────────────────────────────────────────────────────────
 
 export type ImagePullState = 'idle' | 'pulling' | 'completed' | 'failed' | 'present' | 'missing'

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -13,6 +13,7 @@ import {
   useSlotRestart,
   useSlotLoad,
   useSlotSwap,
+  useSlotResolved,
 } from '@/api/hooks/useSlots'
 import { useHardware } from '@/api/hooks/useHardware'
 import { useModels } from '@/api/hooks/useModels'
@@ -370,6 +371,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
   // overrideOpen tracks whether the user has clicked [Override] to reveal the select.
   const [chatTemplate, setChatTemplate] = useStateSM(slot?.chat_template || "");
   const [overrideOpen, setOverrideOpen] = useStateSM(!!(slot?.chat_template));
+
+  // Resolved command provenance — only fetched while the drawer is open.
+  // Falls back gracefully when null (non-llama slots) or on error.
+  const resolvedQuery = useSlotResolved(slot?.name, { enabled: !!open });
 
   useEffectSM(() => {
     if (slot) {
@@ -1004,7 +1009,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
           The resolved command is computed SERVER-SIDE (profile + MTP + image
           resolution), so when extra_args is dirty the displayed command is
           stale: dim it and overlay a Regenerate prompt that persists the slot
-          override and refetches the freshly-resolved command. */}
+          override and refetches the freshly-resolved command.
+          When the /resolved endpoint returns provenance data, we enhance this
+          view with per-flag source badges and a duplicate-collapse note. */}
       <div className="form-section">Resolved command</div>
       <div style={{position: "relative"}}>
         <div style={{
@@ -1015,9 +1022,19 @@ function EditSlotDrawer({ open, slot, onClose }) {
           filter: extraArgsDirty ? "grayscale(1)" : "none",
           transition: "opacity .15s ease",
         }}>
-          {Array.isArray(slot.resolved_command)
-            ? slot.resolved_command.join(" \\\n  ")
-            : slot.resolved_command || "— not yet available (slot not loaded)"}
+          {(() => {
+            // Prefer deduped argv from /resolved when available; fall back to
+            // slot.resolved_command (list-payload) then a "not yet" sentinel.
+            const resolvedData = resolvedQuery.data;
+            const argv = resolvedData?.argv ?? null;
+            if (Array.isArray(argv) && argv.length > 0) {
+              return argv.join(" \\\n  ");
+            }
+            if (Array.isArray(slot.resolved_command)) {
+              return slot.resolved_command.join(" \\\n  ");
+            }
+            return slot.resolved_command || "— not yet available (slot not loaded)";
+          })()}
         </div>
         {extraArgsDirty && (
           <div style={{
@@ -1046,6 +1063,83 @@ function EditSlotDrawer({ open, slot, onClose }) {
           </div>
         )}
       </div>
+      {/* Provenance legend + per-flag badges — only when the /resolved endpoint
+          returns data with at least one provenance entry. Gracefully absent for
+          non-llama slots (argv null) or when the endpoint hasn't loaded yet. */}
+      {(() => {
+        const resolvedData = resolvedQuery.data;
+        if (!resolvedData || !Array.isArray(resolvedData.provenance) || resolvedData.provenance.length === 0) {
+          return null;
+        }
+        // Source → display label + CSS variable colour
+        const SOURCE_META = {
+          base:       { label: "base",       color: "var(--fg-4)" },
+          profile:    { label: "profile",    color: "var(--info)" },
+          extra_args: { label: "extra_args", color: "var(--accent)" },
+        };
+        const badgeStyle = (source) => {
+          const meta = SOURCE_META[source] || SOURCE_META.base;
+          return {
+            display: "inline-block",
+            padding: "1px 5px",
+            borderRadius: "var(--rad-sm)",
+            border: `1px solid ${meta.color}`,
+            color: meta.color,
+            fontFamily: "var(--jbm)",
+            fontSize: 9,
+            lineHeight: 1.5,
+            letterSpacing: "0.04em",
+            verticalAlign: "middle",
+            whiteSpace: "nowrap",
+          };
+        };
+        return (
+          <div style={{marginTop: 8}}>
+            {/* Legend */}
+            <div style={{
+              display: "flex", alignItems: "center", gap: 8,
+              paddingBottom: 6, flexWrap: "wrap",
+            }}>
+              <span style={{fontSize: 10, color: "var(--fg-5)", fontFamily: "var(--jbm)"}}>source:</span>
+              {Object.entries(SOURCE_META).map(([src, meta]) => (
+                <span key={src} style={badgeStyle(src)}>{meta.label}</span>
+              ))}
+            </div>
+            {/* Per-flag provenance rows */}
+            <div style={{
+              display: "flex", flexDirection: "column", gap: 2,
+              padding: "8px 10px", background: "var(--bg)",
+              border: "1px solid var(--line-soft)", borderRadius: "var(--rad-sm)",
+            }}>
+              {resolvedData.provenance.map((entry, i) => (
+                <div key={i} style={{
+                  display: "flex", alignItems: "center", gap: 6,
+                  fontFamily: "var(--jbm)", fontSize: 10.5,
+                }}>
+                  <span style={{color: "var(--fg-3)", minWidth: 120, flexShrink: 0}}>
+                    {entry.flag}
+                    {entry.value != null && (
+                      <span style={{color: "var(--fg-5)"}}>{" "}{entry.value}</span>
+                    )}
+                  </span>
+                  <span style={badgeStyle(entry.source)}>
+                    {SOURCE_META[entry.source]?.label ?? entry.source}
+                  </span>
+                </div>
+              ))}
+            </div>
+            {/* Duplicate-collapse note */}
+            {resolvedData.removed > 0 && (
+              <div style={{
+                marginTop: 5, fontSize: 10, color: "var(--fg-5)",
+                fontFamily: "var(--jbm)",
+              }}>
+                {resolvedData.removed} duplicate flag{resolvedData.removed !== 1 ? "s" : ""} collapsed
+              </div>
+            )}
+          </div>
+        );
+      })()}
       <div className="hint" style={{paddingTop: 6, fontSize: 10.5, color: "var(--fg-5)", fontFamily: "var(--jbm)"}}>
         Real podman argv: profile image + flags, then slot extra_args (slot wins). Restart the slot to run with new flags.
       </div>


### PR DESCRIPTION
## What

The dashboard payoff of the argv-resolver work (#930/#931): the **Edit-slot drawer** now shows *which source set each flag*, not just the command string.

Consumes `GET /api/slots/{name}/resolved` and renders:
- the **deduped** command (preferred over the list-payload `resolved_command`),
- a **per-flag provenance** list with source badges — `base` (grey) / `profile` (blue) / `extra_args` (amber) — so an operator sees that e.g. `-b 8192` came from `extra_args` (overriding the profile's `-b 512`),
- a **"N duplicate flags collapsed"** note when the resolver removed dups.

Gracefully absent for non-llama slots (`argv: null`) or before the endpoint responds; falls back to the existing `slot.resolved_command` rendering. Fetched only while the drawer is open.

## Files
- `ui/src/api/endpoints.ts` — `slotResolved(name)` endpoint
- `ui/src/api/hooks/useSlots.ts` — `SlotResolved`/`FlagProvenance` types + `useSlotResolved` (TanQuery, `enabled` gated on drawer-open, 8s staleTime)
- `ui/src/dash/slot-modals.jsx` — provenance legend + per-flag badges + collapse note in the Resolved-command section

## Verify
- `npm run typecheck` — pass
- `npm run build` — pass (✓ built; chunk-size warning is pre-existing)
- No new dependencies; styling via existing CSS variable tokens.

Built by a delegated frontend agent, reviewed + re-verified by the orchestrator. Stacks on the merged #931 endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)