### PR TITLE
config(profiles): q8_0 KV cache universally — main + MTP draft

### DIFF
--- a/installer/etc-hal0/profiles.toml
+++ b/installer/etc-hal0/profiles.toml
@@ -21,28 +21,31 @@ intent       = "MoE agents"
 quant        = "FP4"
 
 [profile.rocm-dnse]
-# ROCm + MTP draft-mtp, q4 KV (dense chat, qwopus 27B). Bench-tuned throughput
-# flags (-b 8192/-ub 2048, 16+32 threads, poll) but KV stays q4 — f16 KV on a
-# dense 27B at large ctx is too heavy to coexist with other GPU slots.
+# ROCm + MTP draft-mtp, q8 KV (dense chat, qwopus 27B). Bench-tuned throughput
+# flags (-b 8192/-ub 2048, 16+32 threads, poll). KV is q8_0 (k+v): near-lossless
+# (<0.1% PPL vs f16) where q4 V-cache measurably hurts tool-use on high-GQA Qwen;
+# symmetric q8 keeps the fast fused flash-attn kernel on AMD HIP (asymmetric K!=V
+# silently falls back); ~+4 GB at 164k ctx is trivial on 128 GB unified.
 image        = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server"
-flags        = "-fa on -ctk q4_0 -ctv q4_0 -b 8192 -ub 2048 --parallel 1 --threads 16 --threads-batch 32 --no-mmap --poll 100 --poll-batch 1"
+flags        = "-fa on -ctk q8_0 -ctv q8_0 -b 8192 -ub 2048 --parallel 1 --threads 16 --threads-batch 32 --no-mmap --poll 100 --poll-batch 1"
 mtp          = true
 device_class = "gpu"
 backend      = "rocm"
-intent       = "Dense + MTP · q4 KV"
+intent       = "Dense + MTP · q8 KV"
 quant        = "FP4"
 
 [profile.rocm-moe]
 # ROCm + MTP draft-mtp for MoE (crown-halo / ace-saber 35B-A3B). Bench-tuned:
-# q4 KV, -b 8192/-ub 2048, 16+32 threads, poll, jinja. ~78 tok/s (n-max 4).
-# A/B on crown-halo: q4 vs f16 KV is within noise (~78 vs ~77 tok/s) since
-# decode is MoE-weight/MTP-bound, not KV-bound — so q4 for the memory savings.
+# q8 KV, -b 8192/-ub 2048, 16+32 threads, poll, jinja. q4-vs-f16 was within noise
+# on crown-halo (decode is MoE/MTP-bound, not KV-bound), so q8 buys quality for
+# ~free — symmetric q8 keeps the fused FA path on AMD and avoids q4's ~37% decode
+# slowdown at long ctx. Re-bench tok/s after switching.
 image        = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server"
-flags        = "-fa on -ctk q4_0 -ctv q4_0 -b 8192 -ub 2048 --parallel 1 --threads 16 --threads-batch 32 --no-mmap --poll 100 --poll-batch 1 --jinja"
+flags        = "-fa on -ctk q8_0 -ctv q8_0 -b 8192 -ub 2048 --parallel 1 --threads 16 --threads-batch 32 --no-mmap --poll 100 --poll-batch 1 --jinja"
 mtp          = true
 device_class = "gpu"
 backend      = "rocm"
-intent       = "MoE + MTP · q4 KV"
+intent       = "MoE + MTP · q8 KV"
 quant        = "FP4"
 
 [profile.vulkan]

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -712,8 +712,8 @@ MTP_FLAG_BUNDLE = (
     " --spec-draft-n-min 0"
     " --spec-draft-p-min 0.0"
     " --spec-draft-p-split 0.10"
-    " --spec-draft-type-k f16"
-    " --spec-draft-type-v f16"
+    " --spec-draft-type-k q8_0"
+    " --spec-draft-type-v q8_0"
     " --spec-draft-threads 16"
     " --spec-draft-threads-batch 32"
     " --spec-draft-poll 1"
@@ -740,20 +740,20 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
     },
     "rocm-dnse": {
         "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
-        "flags": "-fa on -ctk q4_0 -ctv q4_0 -b 8192 -ub 2048 --parallel 1 --threads 16 --threads-batch 32 --no-mmap --poll 100 --poll-batch 1",
+        "flags": "-fa on -ctk q8_0 -ctv q8_0 -b 8192 -ub 2048 --parallel 1 --threads 16 --threads-batch 32 --no-mmap --poll 100 --poll-batch 1",
         "mtp": True,
         "device_class": "gpu",
         "backend": "rocm",
-        "intent": "Dense + MTP · q4 KV",
+        "intent": "Dense + MTP · q8 KV",
         "quant": "FP4",
     },
     "rocm-moe": {
         "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
-        "flags": "-fa on -ctk q4_0 -ctv q4_0 -b 8192 -ub 2048 --parallel 1 --threads 16 --threads-batch 32 --no-mmap --poll 100 --poll-batch 1 --jinja",
+        "flags": "-fa on -ctk q8_0 -ctv q8_0 -b 8192 -ub 2048 --parallel 1 --threads 16 --threads-batch 32 --no-mmap --poll 100 --poll-batch 1 --jinja",
         "mtp": True,
         "device_class": "gpu",
         "backend": "rocm",
-        "intent": "MoE + MTP · q4 KV",
+        "intent": "MoE + MTP · q8 KV",
         "quant": "FP4",
     },
     "vulkan": {

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -120,8 +120,8 @@ class TestResolveProfileFlags:
         assert "--spec-draft-device ROCm0" in result
         assert "--spec-draft-ngl all" in result
         assert "--spec-draft-n-max 4" in result
-        assert "--spec-draft-type-k f16" in result
-        assert "--spec-draft-type-v f16" in result
+        assert "--spec-draft-type-k q8_0" in result
+        assert "--spec-draft-type-v q8_0" in result
         assert "--spec-draft-threads 16" in result
         assert "--spec-draft-poll 1" in result
 


### PR DESCRIPTION
## What
Set the KV cache to **q8_0 everywhere it's declared** — main K/V (was q4_0) and MTP draft K/V (was f16) — at the two source-of-truth points:
- `MTP_FLAG_BUNDLE` (`schema.py`): `--spec-draft-type-k/-v f16` → `q8_0`
- `SEED_PROFILES` rocm-dnse/rocm-moe + `installer/etc-hal0/profiles.toml`: `-ctk/-ctv q4_0` → `q8_0` (+ intent/comment updates)

## Why (verified against Strix Halo + Qwen3 MoE/dense)
- q8_0 KV is **near-lossless** (<0.1% PPL vs f16); q4_0 V-cache measurably degrades **tool-use** on high-GQA Qwen — the agent/devops slots.
- On **AMD HIP/ROCm, symmetric q8_0/q8_0 keeps the fast fused flash-attn kernel**; asymmetric K≠V silently falls back to the slow path — so symmetric q8 is the right call here, not the usual "q4 K + q8 V".
- q4_0 costs **~37% decode slowdown at long ctx**; the agent runs 164k, so q8_0 is likely *faster* there.
- Cost: **~+4 GB** at 164k — trivial on 128 GB unified.

[Research sources in the commit body.]

## Tests
`test_profiles.py` updated to assert the q8_0 draft bundle. `97 passed` across config/profiles/mtp/schema; ruff clean.

## Note
This is the codebase SSOT. The live `agent` slot's `[server].extra_args` (live-only config, not in repo) still hardcodes q4/f16 at highest precedence — applied separately on the host. Re-bench tok/s after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)