### PR TITLE
feat(hermes): unpin runtime + real upgrade path (easy updates, no blocking)

### DIFF
--- a/installer/agents/hermes/requirements.txt
+++ b/installer/agents/hermes/requirements.txt
@@ -1,17 +1,23 @@
-# hal0 — hard-pinned Hermes-Agent runtime requirements (v0.3, issue #240).
+# hal0 — Hermes-Agent runtime requirements.
 #
 # The hal0 bootstrap creates a managed venv at /var/lib/hal0/venvs/hermes/
-# with explicit Python 3.11 and installs from this file. Bumping the pin
-# requires a hal0 release; the `hal0 agent upgrade hermes [--to=<version>]`
-# CLI exists for power users + compat-testing escape hatches.
+# and installs from this file. `hal0 agent upgrade hermes` pulls the latest
+# matching release (pip install -U), runs `hermes config migrate` to reconcile
+# the config schema, and reprovisions — so updates are a single command and
+# our customizations don't block them.
 #
-# Why a hard pin: Hermes ships breaking config-schema changes between
-# minor releases. Pinning here means a hal0 upgrade is the single point
-# at which Hermes moves — operators don't get surprised by `hermes setup`
-# rewriting their config.yaml.
-
+# Posture (changed from the old hard pin, issue #240): we DON'T hard-pin
+# anymore. The old `==0.14.0` pin existed only because hal0 used to RENDER and
+# OWN the whole $HERMES_HOME/config.yaml, so a hermes minor bump could rewrite
+# the schema underneath us. The fix is that hermes owns + migrates its own
+# config.yaml (`hermes config migrate`) and hal0 applies only its specific keys
+# on top — so hermes can move freely. We keep a FLOOR (the oldest release whose
+# config CLI + `custom` provider we rely on) and a MAJOR CAP (1.0 may break the
+# CLI contract; lift the cap deliberately after validating). Operators who want
+# a specific build use `hal0 agent upgrade hermes --to=<version>`.
+#
 # The `web` extra pulls fastapi + uvicorn[standard], which the hal0 agent
 # unit needs: it runs `hermes serve` in web/dashboard mode (HERMES_WEB_DIST
 # + HERMES_DASHBOARD_TUI in the unit drop-in). Without it the unit
 # crash-loops on `No module named 'fastapi'`.
-hermes-agent[web]==0.14.0
+hermes-agent[web]>=0.14.0,<1.0

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -459,6 +459,70 @@ def _install_venv(
     )
 
 
+#: Default managed-venv + requirements + HERMES_HOME for the upgrade path.
+#: Mirrors the BootstrapState defaults so `hal0 agent upgrade hermes` can run
+#: standalone (it pip-upgrades + migrates before re-running the state machine).
+HERMES_VENV_DEFAULT = Path("/var/lib/hal0/venvs/hermes")
+HERMES_HOME_DEFAULT = Path("/var/lib/hal0/.hermes")
+HERMES_REQUIREMENTS = (
+    REPO_ROOT_FOR_INSTALLER / "installer" / "agents" / "hermes" / "requirements.txt"
+)
+
+
+def upgrade_hermes_runtime(
+    *,
+    venv: Path = HERMES_VENV_DEFAULT,
+    requirements: Path = HERMES_REQUIREMENTS,
+    hermes_home: Path = HERMES_HOME_DEFAULT,
+    version: str | None = None,
+    runner: Any = subprocess,
+) -> tuple[bool, str]:
+    """Pull the latest matching ``hermes-agent`` into the venv + reconcile config.
+
+    This is the runtime half of ``hal0 agent upgrade hermes`` — the package move
+    that the old hard pin (issue #240) used to forbid:
+
+      1. ``pip install -U`` the requirements (floor/cap from requirements.txt),
+         or an exact ``--to=<version>`` when the operator pins one.
+      2. ``hermes config migrate`` so the on-disk config.yaml schema matches the
+         newly-installed hermes build — hermes owns + migrates its own config,
+         hal0 only layers its keys on top, so a minor bump no longer strands us.
+
+    Non-fatal on the migrate step: a migrate hiccup is surfaced but doesn't fail
+    the upgrade (the subsequent reprovision re-renders + re-chowns to hal0). The
+    caller runs ``bootstrap hermes --repair`` afterwards to converge the rest.
+
+    Returns ``(ok, message)``. ``ok`` is False only when the pip upgrade itself
+    fails (no venv, network/resolver error) — that's a real, actionable stop.
+    """
+    pip = _venv_python(venv)
+    if not pip.exists():
+        return False, f"hermes venv missing at {venv} — run `hal0 agent install hermes` first"
+
+    spec = f"hermes-agent[web]=={version}" if version else None
+    pip_argv = [str(pip), "-m", "pip", "install", "--upgrade"]
+    pip_argv += [spec] if spec else ["-r", str(requirements)]
+    try:
+        runner.run(pip_argv, check=True)  # nosec B603 — argv from local config
+    except (subprocess.SubprocessError, OSError) as exc:
+        return False, f"pip upgrade failed: {exc}"
+
+    # Reconcile the config schema to the freshly-installed hermes. hermes owns
+    # the file; this adds/migrates ITS keys without touching hal0's overlay.
+    hermes_bin = pip.parent / "hermes"
+    migrated = False
+    try:
+        env = {**os.environ, "HERMES_HOME": str(hermes_home)}
+        runner.run([str(hermes_bin), "config", "migrate"], check=True, env=env)  # nosec B603
+        migrated = True
+    except (subprocess.SubprocessError, OSError) as exc:
+        log.warning("hermes_provision.config_migrate_failed", error=str(exc))
+
+    target = version or "latest matching requirements"
+    suffix = " + config migrated" if migrated else " (config migrate skipped — see logs)"
+    return True, f"hermes-agent upgraded → {target}{suffix}"
+
+
 _HAL0_SERVICE_USER = "hal0"
 
 

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -809,15 +809,31 @@ def agent_upgrade(
         None, "--to", help="Pin to a specific version (power-user / compat-testing flag)."
     ),
 ) -> None:
-    """Bump the agent's version pin and re-run bootstrap with --repair."""
+    """Upgrade Hermes to the latest matching release, then reprovision.
+
+    Pulls the newest ``hermes-agent`` within the requirements floor/cap (or the
+    exact ``--to=<version>``), runs ``hermes config migrate`` so the config
+    schema matches the new build, then re-runs bootstrap to re-render hal0's
+    config keys and reconcile ownership. No hard pin blocks the update — hermes
+    owns + migrates its own config; hal0 layers its keys on top.
+    """
     if name != "hermes":
         die(f"upgrade currently only supports `hermes`; got {name!r}.")
         return
-    import os as _os
     import subprocess as _subprocess  # nosec B404 — known argv
 
-    if to:
-        _os.environ["HAL0_HERMES_VERSION_PIN"] = to
+    from hal0.agents.hermes_provision import upgrade_hermes_runtime
+
+    ok, msg = upgrade_hermes_runtime(version=to)
+    if not ok:
+        console.print(f"[red]✗[/red]  {msg}")
+        raise typer.Exit(1)
+    console.print(f"[green]✓[/green]  {msg}")
+
+    # Reprovision: re-render hal0's config keys against the new build and
+    # re-chown the venv + HERMES_HOME back to the hal0 service user (pip ran as
+    # the invoking user). bootstrap --repair is idempotent.
+    console.print("[dim]reprovisioning (config render + ownership reconcile)…[/dim]")
     rc = _subprocess.run(  # nosec B603 — known argv
         ["hal0", "agent", "bootstrap", "hermes", "--repair"],
         check=False,

--- a/tests/agents/test_hermes_upgrade.py
+++ b/tests/agents/test_hermes_upgrade.py
@@ -1,0 +1,113 @@
+"""Tests for hal0.agents.hermes_provision.upgrade_hermes_runtime.
+
+The runtime half of ``hal0 agent upgrade hermes``: pip-upgrade the unpinned
+``hermes-agent`` (floor/cap or an exact ``--to``) + ``hermes config migrate`` so
+the schema matches the new build. Verifies the argv, the version-pin branch, the
+non-fatal migrate, and the real-stop pip failure — all via an injected runner so
+no network or real venv is touched.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from hal0.agents.hermes_provision import upgrade_hermes_runtime
+
+
+class FakeRunner:
+    def __init__(self, fail_on: Any = None) -> None:
+        self.calls: list[list[str]] = []
+        self.fail_on = fail_on  # Callable[[list[str]], bool] | None
+
+    def run(self, argv: list[str], **_kwargs: Any) -> Any:
+        self.calls.append(list(argv))
+        if self.fail_on is not None and self.fail_on(list(argv)):
+            raise subprocess.CalledProcessError(1, argv)
+        return None
+
+
+def _is_pip(argv: list[str]) -> bool:
+    return "install" in argv and "--upgrade" in argv
+
+
+def _is_migrate(argv: list[str]) -> bool:
+    return argv[-2:] == ["config", "migrate"]
+
+
+def _fake_venv(tmp_path: Path) -> Path:
+    """A venv whose bin/python exists so the missing-venv guard passes."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    py = bindir / "python"
+    py.write_text("#!/bin/sh\n")
+    py.chmod(0o755)
+    return tmp_path
+
+
+def _pip_call(calls: list[list[str]]) -> list[str] | None:
+    return next((c for c in calls if "pip" in c and "install" in c and "--upgrade" in c), None)
+
+
+def _migrate_call(calls: list[list[str]]) -> list[str] | None:
+    return next((c for c in calls if c[-2:] == ["config", "migrate"]), None)
+
+
+def test_missing_venv_is_actionable_stop(tmp_path: Path) -> None:
+    ok, msg = upgrade_hermes_runtime(venv=tmp_path / "nope", runner=FakeRunner())
+    assert ok is False
+    assert "venv missing" in msg
+
+
+def test_happy_path_upgrades_then_migrates(tmp_path: Path) -> None:
+    venv = _fake_venv(tmp_path)
+    r = FakeRunner()
+    ok, msg = upgrade_hermes_runtime(
+        venv=venv, requirements=Path("/req.txt"), hermes_home=tmp_path, runner=r
+    )
+    assert ok is True
+    pip = _pip_call(r.calls)
+    assert pip is not None
+    # no --to → installs from the requirements file (floor/cap)
+    assert pip[-2:] == ["-r", "/req.txt"]
+    assert _migrate_call(r.calls) is not None
+    assert "config migrated" in msg
+
+
+def test_version_pin_installs_exact_spec(tmp_path: Path) -> None:
+    venv = _fake_venv(tmp_path)
+    r = FakeRunner()
+    ok, _ = upgrade_hermes_runtime(venv=venv, version="0.15.2", runner=r)
+    assert ok is True
+    pip = _pip_call(r.calls)
+    assert pip is not None
+    assert pip[-1] == "hermes-agent[web]==0.15.2"
+    assert "-r" not in pip
+
+
+def test_migrate_failure_is_non_fatal(tmp_path: Path) -> None:
+    venv = _fake_venv(tmp_path)
+    r = FakeRunner(fail_on=_is_migrate)  # pip ok, migrate raises
+    ok, msg = upgrade_hermes_runtime(venv=venv, runner=r)
+    assert ok is True  # upgrade still succeeds
+    assert "migrate skipped" in msg
+
+
+def test_pip_failure_is_a_real_stop(tmp_path: Path) -> None:
+    venv = _fake_venv(tmp_path)
+    r = FakeRunner(fail_on=_is_pip)  # pip upgrade fails
+    ok, msg = upgrade_hermes_runtime(venv=venv, runner=r)
+    assert ok is False
+    assert "pip upgrade failed" in msg
+    assert _migrate_call(r.calls) is None  # never reached migrate
+
+
+def test_requirements_floor_not_hard_pinned() -> None:
+    """The shipped requirements no longer hard-pin (the update-blocker)."""
+    from hal0.agents.hermes_provision import HERMES_REQUIREMENTS
+
+    text = HERMES_REQUIREMENTS.read_text(encoding="utf-8")
+    reqs = [ln.strip() for ln in text.splitlines() if ln.strip() and not ln.lstrip().startswith("#")]
+    # The single requirement line is the floored+capped spec, not a hard pin.
+    assert reqs == ["hermes-agent[web]>=0.14.0,<1.0"]

--- a/tests/agents/test_hermes_upgrade.py
+++ b/tests/agents/test_hermes_upgrade.py
@@ -108,6 +108,8 @@ def test_requirements_floor_not_hard_pinned() -> None:
     from hal0.agents.hermes_provision import HERMES_REQUIREMENTS
 
     text = HERMES_REQUIREMENTS.read_text(encoding="utf-8")
-    reqs = [ln.strip() for ln in text.splitlines() if ln.strip() and not ln.lstrip().startswith("#")]
+    reqs = [
+        ln.strip() for ln in text.splitlines() if ln.strip() and not ln.lstrip().startswith("#")
+    ]
     # The single requirement line is the floored+capped spec, not a hard pin.
     assert reqs == ["hermes-agent[web]>=0.14.0,<1.0"]


### PR DESCRIPTION
## What
Make hermes updates a single command without our customizations blocking them — the goal from the overhaul.

**The knot:** `requirements.txt` hard-pinned `hermes-agent[web]==0.14.0`. The comment said why: hal0 *renders and owns* the whole `config.yaml`, so a hermes minor bump could rewrite the schema underneath us — the pin was "the single point at which Hermes moves." That pin blocked updates.

**The cut:** hermes owns + migrates its **own** config (`hermes config migrate` — "update config with new options"); hal0 only layers its keys on top. So hermes can move freely.

- `requirements.txt`: `==0.14.0` → `>=0.14.0,<1.0` (floor + major cap) + rewritten rationale.
- `upgrade_hermes_runtime()`: `pip install -U` (floor or `--to=<version>`) → `hermes config migrate`. Migrate is non-fatal; only a pip failure hard-stops.
- `hal0 agent upgrade hermes`: a **real** upgrade now (pip -U + migrate + reprovision), replacing the old re-pin no-op.

## Validated on a fresh box (CT107 `hal0-next`)
- `pip install -U` jumped hermes **0.14.0 → 0.17.0** (3 minors the pin forbade).
- `hermes config migrate` → **"✓ Configuration updated!"**.
- hal0's keys (`model.provider=custom`, `base_url=…:8080/v1`, `max_tokens`) **survived** the migrate.
- hermes 0.17 **still completed a chat through hal0**.

## Tests
`tests/agents/test_hermes_upgrade.py` — argv shape, `--to` pin, non-fatal migrate, pip-fail stop, floor assertion. `109 passed` across the agent provision suite (no regressions); ruff clean.

## Next (validated, follow-up)
Move config ownership fully to the `hermes config set` overlay so hal0 never writes a key hermes wants to manage (handoff `hermes-installer-redesign-validated-20260620.md`). This PR is the unblock; that's the elegant end-state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)