### PR TITLE
fix(registry): scan effective store/pull_root so headless installs find their models

### DIFF
--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -2039,6 +2039,24 @@ class ModelsConfig(BaseModel):
         ),
     )
 
+    def scan_roots(self) -> list[str]:
+        """Roots the discovery scan actually walks: declared ``roots`` plus the
+        effective store (``store`` when set, else the legacy ``pull_root``).
+
+        The installer writes ``pull_root`` from ``--models-dir`` but historically
+        never added it to ``roots`` (despite the pull_root doc claiming it's
+        "auto-included"), so a headless install whose models live under a custom
+        store/pull_root scanned only the default ``models_dir`` and found nothing
+        — slots then failed to load (no path resolved for the model name). Folding
+        the effective store in here makes discovery robust regardless of how the
+        TOML was written. Order-preserving, deduped.
+        """
+        out: list[str] = list(self.roots)
+        effective_store = (self.store or self.pull_root or "").strip()
+        if effective_store and effective_store not in out:
+            out.append(effective_store)
+        return out
+
     @field_validator("roots")
     @classmethod
     def roots_are_absolute(cls, v: list[str]) -> list[str]:

--- a/src/hal0/registry/discover.py
+++ b/src/hal0/registry/discover.py
@@ -309,8 +309,12 @@ def scan_and_register(registry: ModelRegistry, cfg: ModelsConfig) -> dict:
             known_paths.add(existing.path)
         known_paths.add(existing.path)
 
+    # scan_roots() folds the effective store/pull_root into the declared roots
+    # so a headless install (where --models-dir wrote pull_root but not roots)
+    # still scans where the models actually are.
+    roots = cfg.scan_roots()
     candidates = find_candidates(
-        roots=list(cfg.roots),
+        roots=list(roots),
         extensions=list(cfg.file_extensions),
         known_paths=known_paths,
     )
@@ -338,7 +342,7 @@ def scan_and_register(registry: ModelRegistry, cfg: ModelsConfig) -> dict:
     return {
         "added": added,
         "skipped": skipped,
-        "scanned_roots": [str(r) for r in cfg.roots],
+        "scanned_roots": [str(r) for r in roots],
     }
 
 

--- a/tests/config/test_models_config.py
+++ b/tests/config/test_models_config.py
@@ -42,3 +42,33 @@ class TestRootsValidator:
     def test_dot_relative_rejected(self) -> None:
         with pytest.raises(ValidationError):
             ModelsConfig(roots=["./local-models"])
+
+
+class TestScanRoots:
+    """scan_roots() folds the effective store/pull_root into the scanned set so
+    a headless install (--models-dir → pull_root, but roots left default) still
+    discovers its models. Regression for the fresh-install scan gap."""
+
+    def test_store_folded_into_scan_roots(self) -> None:
+        cfg = ModelsConfig(roots=["/var/lib/hal0/models"], store="/mnt/ai-models")
+        assert cfg.scan_roots() == ["/var/lib/hal0/models", "/mnt/ai-models"]
+
+    def test_pull_root_folded_when_store_unset(self) -> None:
+        # The exact CT107 shape: --models-dir wrote pull_root, roots left default.
+        cfg = ModelsConfig(roots=["/var/lib/hal0/models"], pull_root="/mnt/ai-models")
+        assert "/mnt/ai-models" in cfg.scan_roots()
+
+    def test_store_wins_over_pull_root(self) -> None:
+        cfg = ModelsConfig(roots=["/a"], store="/store", pull_root="/pull")
+        assert cfg.scan_roots() == ["/a", "/store"]
+        assert "/pull" not in cfg.scan_roots()
+
+    def test_no_duplicate_when_store_already_in_roots(self) -> None:
+        cfg = ModelsConfig(roots=["/mnt/ai-models"], store="/mnt/ai-models")
+        assert cfg.scan_roots() == ["/mnt/ai-models"]
+
+    def test_default_config_scans_pull_root_default(self) -> None:
+        # Even a bare ModelsConfig() scans somewhere (pull_root defaults to models_dir).
+        roots = ModelsConfig().scan_roots()
+        assert roots  # non-empty
+        assert all(r for r in roots)

--- a/tests/registry/test_discover.py
+++ b/tests/registry/test_discover.py
@@ -237,4 +237,6 @@ def test_scan_and_register_missing_root_is_silent(tmp_path: Path, registry: Mode
     cfg = ModelsConfig(roots=[str(tmp_path / "does-not-exist")])
     result = scan_and_register(registry, cfg)
     assert result["added"] == []
-    assert result["scanned_roots"] == [str(tmp_path / "does-not-exist")]
+    # The configured (missing) root is scanned silently. scan_roots() also folds
+    # in the effective store/pull_root, so this is a membership check, not exact.
+    assert str(tmp_path / "does-not-exist") in result["scanned_roots"]


### PR DESCRIPTION
## What
Fresh-install bug found while provisioning a clean box (CT107): the installer writes `[models].pull_root` from `--models-dir` but never adds it to `[models].roots`. So `roots` stays the default `[/var/lib/hal0/models]`, the startup discovery scan walks the wrong (empty) dir, and the operator's models (e.g. under `/mnt/ai-models`) are never registered. Every slot then fails to load:
```
gguf_init_from_file: failed to open GGUF file 'gemma-4-12b-it' (No such file or directory)
```
because the registry resolves the model *name* to a bare name, not a GGUF path. (The `pull_root` doc even claims it's "auto-included in roots" — nothing did that.)

## Fix
`ModelsConfig.scan_roots()` = declared `roots` ∪ effective store (`store`, else `pull_root`), deduped + order-preserving. `scan_and_register` uses it. Discovery is now robust regardless of how the TOML was written — a headless `curl | bash` install (no interactive `hal0 setup`) finds its models out of the box, and existing installs with this shape self-heal on next scan/restart.

## Tests
`148 passed`; new `TestScanRoots` (store/pull_root folding, store-wins, dedup, default-non-empty); relaxed one missing-root test's incidental exact-match to membership. ruff clean.

Found end-to-end on CT107 (the staging box) — manually adding `store`/`roots`/`auto_scan_on_start` there made the scan pick up all 27 models and slots load on the iGPU; this makes that automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)