### PR TITLE
fix(hermes): optional gateway EnvironmentFile so fresh installs don't crash-loop

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -2893,8 +2893,14 @@ def _gateway_dropin_body() -> str:
         "# the main .service body. pid1 (root) reads the 0600 vault below.\n"
         "#\n"
         "# Re-apply: `systemctl daemon-reload && systemctl restart hermes-gateway`.\n"
+        "#\n"
+        "# The `-` prefix makes the vault OPTIONAL: on a fresh install with no\n"
+        "# platform tokens provisioned yet, the file doesn't exist — without the\n"
+        "# `-`, systemd hard-fails the unit with `Failed to load environment\n"
+        "# files` and crash-loops it. Optional lets the gateway come up (idle,\n"
+        "# no platform) until tokens are added.\n"
         "[Service]\n"
-        f"EnvironmentFile={HERMES_SECRETS_ENV}\n"
+        f"EnvironmentFile=-{HERMES_SECRETS_ENV}\n"
     )
 
 

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1929,7 +1929,9 @@ def test_gateway_secrets_wire_writes_dropin(
     assert out.status == hp.PhaseStatus.OK
     assert dropin_file.exists()
     body = dropin_file.read_text(encoding="utf-8")
-    assert "EnvironmentFile=/var/lib/hal0/secrets/agents/hermes.env" in body
+    # Optional (`-`): a missing vault on a fresh install must not hard-fail the
+    # unit (matches hal0-agent@.service's EnvironmentFile=-).
+    assert "EnvironmentFile=-/var/lib/hal0/secrets/agents/hermes.env" in body
     assert "[Service]" in body
     # Mode 0o644 — NOT 0o600, which would block systemd from reading the
     # unit fragment. The secrets themselves are in the 0600 vault.

--- a/tests/systemd/test_unit_files.py
+++ b/tests/systemd/test_unit_files.py
@@ -276,7 +276,9 @@ class TestHermesGatewaySecretsDropin:
 
         body = hp._gateway_dropin_body()
         assert "[Service]" in body
-        assert "EnvironmentFile=/var/lib/hal0/secrets/agents/hermes.env" in body
+        # Optional (`-` prefix): a missing vault on a fresh install must not
+        # hard-fail the unit — mirrors hal0-agent@.service's EnvironmentFile=-.
+        assert "EnvironmentFile=-/var/lib/hal0/secrets/agents/hermes.env" in body
 
     def test_dropin_does_not_reference_legacy_home(self) -> None:
         from hal0.agents import hermes_provision as hp


### PR DESCRIPTION
## What
On a fresh install with no messaging-platform tokens yet, the secrets vault `/var/lib/hal0/secrets/agents/hermes.env` doesn't exist. The gateway drop-in (`10-hal0-secrets.conf`) referenced it with a **non-optional** `EnvironmentFile=`, so systemd hard-failed the unit (`Failed to load environment files`, result `resources`) and crash-looped it forever.

## Fix
Prefix the path with `-` — the systemd "optional, missing is fine" idiom, the **same one `hal0-agent@.service` already uses** for `/etc/hal0/agents/%i.env`. The gateway comes up idle (no platform enabled) on a fresh box instead of crash-looping, and picks up tokens automatically once the vault is written.

## Validated (CT107 staging box)
Gateway went from restart-looping → `active (running)` after applying the optional prefix + `daemon-reload` + restart. Remaining output is expected soft warnings ("No messaging platforms enabled" — fresh box has no tokens).

`27 passed` in `tests/systemd/`; the drop-in body test updated to assert the `-` prefix. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)