### PR TITLE
refactor(normalize): drop hal0/primary + hal0/flm virtual aliases

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -934,7 +934,7 @@ def _live_resolve_enabled() -> bool:
     """Single source of truth for live-resolve mode.
 
     Live-resolve is the hal0 default: ``model.default`` → the virtual
-    ``hal0/primary`` and ``providers.custom`` → the hal0-api gateway
+    ``hal0/chat`` and ``providers.custom`` → the hal0-api gateway
     (:8080/v1) with ``discover_models`` + an api_key, so Hermes' model picker
     live-discovers every loaded slot (responsive, auto-updating, context-aware)
     instead of pinning one physical backend. hal0-api always serves
@@ -1019,7 +1019,7 @@ def _build_config_overlay(
     from live ``/v1/models`` discovery instead).
 
     Under live-resolve (the hal0 default) ``model.default`` is the virtual
-    ``hal0/primary`` against the gateway with ``discover_models`` on, so the
+    ``hal0/chat`` against the gateway with ``discover_models`` on, so the
     picker live-discovers every loaded slot. ``HAL0_HERMES_LIVE_RESOLVE=0``
     pins the single physical backend instead.
     """
@@ -1029,7 +1029,7 @@ def _build_config_overlay(
     # model.* — the OpenAI-compatible-LAN wiring. ``provider: custom`` is
     # hermes's built-in bucket for Ollama/vLLM/llama.cpp endpoints; hal0 is
     # that endpoint. max_tokens guards the thinking-model silent-TUI (#635).
-    pairs.append(("model.default", "hal0/primary" if live_resolve_enabled else primary["model_id"]))
+    pairs.append(("model.default", "hal0/chat" if live_resolve_enabled else primary["model_id"]))
     pairs += [
         ("model.provider", "custom"),
         ("model.base_url", base_url),
@@ -1319,7 +1319,7 @@ def _phase_config_write(ctx: PhaseContext) -> PhaseResult:
                 "site": "primary_slot",
                 "detail": (
                     "no ready llm slot — overlay points model.default at the "
-                    "hal0/primary virtual against the gateway"
+                    "hal0/chat virtual against the gateway"
                 ),
             }
         )
@@ -2905,7 +2905,7 @@ def _phase_model_automap(ctx: PhaseContext) -> PhaseResult:
     base_url = "http://127.0.0.1:8080/v1" if live_resolve_enabled else primary_raw["base_url"]
 
     pairs: list[tuple[str, Any]] = [
-        ("model.default", "hal0/primary" if live_resolve_enabled else primary_raw["model"]),
+        ("model.default", "hal0/chat" if live_resolve_enabled else primary_raw["model"]),
         ("model.provider", "custom"),
         ("model.base_url", base_url),
     ]

--- a/src/hal0/api/routes/board_chat.py
+++ b/src/hal0/api/routes/board_chat.py
@@ -52,9 +52,9 @@ _MAX_ROUNDS = 8
 
 # The slot the orchestrator drives. Points at the `agent` slot — the
 # tool-calling orchestrator model — rather than the conversational `chat`
-# slot (hal0/primary): board chat IS an agentic surface (it drives audited
+# slot (hal0/chat): board chat IS an agentic surface (it drives audited
 # board mutations via tool-calls), so the agent model is the correct brain.
-# (Named PRIMARY_SLOT_MODEL for back-compat; resolves via the hal0/ alias map.)
+# (Named PRIMARY_SLOT_MODEL for back-compat; resolves via the resolver chains.)
 PRIMARY_SLOT_MODEL = "hal0/agent"
 
 #: LLM backend signature: an OpenAI chat-completion request body in, the

--- a/src/hal0/cli/setup_copy.py
+++ b/src/hal0/cli/setup_copy.py
@@ -28,7 +28,7 @@ PANE_COPY: dict[str, PaneCopy] = {
     ),
     "main": PaneCopy(
         "Your Main model",
-        "The primary model every app and agent routes to (hal0/primary). "
+        "The primary model every app and agent routes to (hal0/chat). "
         "We recommend the largest pick that fits your memory.",
     ),
     "agent": PaneCopy(

--- a/src/hal0/normalize/__init__.py
+++ b/src/hal0/normalize/__init__.py
@@ -2,7 +2,6 @@
 
 from hal0.normalize.resolver import (  # noqa: F401
     DEFAULT_CHAINS,
-    VIRTUAL_ALIASES,
     LiveSlotResolver,
     Resolution,
     SlotView,

--- a/src/hal0/normalize/resolver.py
+++ b/src/hal0/normalize/resolver.py
@@ -20,13 +20,6 @@ DEFAULT_CHAINS: dict[str, tuple[str, ...]] = {
     "hal0/utility": ("utility", "npu", "chat"),
 }
 
-# Aliases that resolve to a canonical name before chain lookup.
-VIRTUAL_ALIASES: dict[str, str] = {
-    "hal0/flm": "hal0/npu",
-    # Back-compat: hal0/primary was the pre-v0.4 name for hal0/chat.
-    "hal0/primary": "hal0/chat",
-}
-
 
 @dataclass(frozen=True)
 class SlotView:
@@ -77,8 +70,7 @@ def resolve_chain(
     always returns a ``Resolution`` (falling back to the configured primary,
     ``fallback=True``, when no chain role is currently loaded).
     """
-    canonical = VIRTUAL_ALIASES.get(virtual_name, virtual_name)
-    chain = DEFAULT_CHAINS.get(canonical)
+    chain = DEFAULT_CHAINS.get(virtual_name)
     if chain is None:
         return None
 
@@ -114,7 +106,7 @@ class LiveSlotResolver:
         self._loaded = loaded_models_provider
 
     async def resolve(self, model_name: str) -> Resolution | None:
-        if model_name not in DEFAULT_CHAINS and model_name not in VIRTUAL_ALIASES:
+        if model_name not in DEFAULT_CHAINS:
             return None
         try:
             views = list(self._views() or [])

--- a/tests/agents/test_hermes_live_resolve_render.py
+++ b/tests/agents/test_hermes_live_resolve_render.py
@@ -30,7 +30,7 @@ def _overlay(*, live_resolve_enabled, **over):
 
 def test_live_resolve_uses_virtual_default():
     keys = _overlay(live_resolve_enabled=True)
-    assert keys["model.default"] == "hal0/primary"
+    assert keys["model.default"] == "hal0/chat"
     assert keys["model.provider"] == "custom"
     assert keys["model.base_url"] == "http://127.0.0.1:8080/v1"
 
@@ -38,7 +38,7 @@ def test_live_resolve_uses_virtual_default():
 def test_disabled_uses_physical_default():
     keys = _overlay(live_resolve_enabled=False)
     assert keys["model.default"] == "phys-35b"
-    assert "hal0/primary" not in keys.values()
+    assert "hal0/chat" not in keys.values()
 
 
 def test_live_resolve_enables_live_model_discovery():

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -619,7 +619,7 @@ def test_overlay_includes_provider_and_identity_keys() -> None:
 
 def test_overlay_no_primary_under_live_resolve_uses_virtual() -> None:
     # No ready slot → _resolve_primary_slot hands a placeholder primary, but
-    # under live-resolve the overlay still points at the hal0/primary virtual
+    # under live-resolve the overlay still points at the hal0/chat virtual
     # against the gateway (not a dead default).
     keys = _build_overlay_keys(
         primary={
@@ -628,7 +628,7 @@ def test_overlay_no_primary_under_live_resolve_uses_virtual() -> None:
             "context_length": 32768,
         },
     )
-    assert keys["model.default"] == "hal0/primary"
+    assert keys["model.default"] == "hal0/chat"
     assert "127.0.0.1:8080/v1" in keys["model.base_url"]
 
 

--- a/tests/api/test_chat_normalization.py
+++ b/tests/api/test_chat_normalization.py
@@ -57,7 +57,7 @@ _PRIMARY = [
 @pytest.mark.asyncio
 async def test_virtual_name_resolved_and_thinking_injected():
     req = _make_request(cfgs=_PRIMARY, loaded={"big"})
-    out = await v1._normalize_chat_body(req, {"model": "hal0/primary", "messages": []})
+    out = await v1._normalize_chat_body(req, {"model": "hal0/chat", "messages": []})
     assert out["model"] == "big"
     assert out["chat_template_kwargs"]["enable_thinking"] is False
 
@@ -83,7 +83,7 @@ async def test_remote_model_not_thinking_injected():
 @pytest.mark.asyncio
 async def test_caller_top_level_thinking_translated_to_kwarg():
     req = _make_request(cfgs=_PRIMARY, loaded={"big"})
-    out = await v1._normalize_chat_body(req, {"model": "hal0/primary", "enable_thinking": True})
+    out = await v1._normalize_chat_body(req, {"model": "hal0/chat", "enable_thinking": True})
     # #487: top-level enable_thinking is translated to the chat-template lever
     # (a bare /no_think marker is ineffective on abliterated Qwen3), not passed through.
     assert out["chat_template_kwargs"]["enable_thinking"] is True
@@ -123,7 +123,7 @@ async def test_request_body_rewritten_for_downstream_consumers():
     import json
 
     req = _make_request(cfgs=_PRIMARY, loaded={"big"})
-    await v1._normalize_chat_body(req, {"model": "hal0/primary", "messages": []})
+    await v1._normalize_chat_body(req, {"model": "hal0/chat", "messages": []})
     # any downstream consumer re-reading request.body() must observe the
     # normalized body, so request._body carries the rewrite
     assert json.loads(req._body)["model"] == "big"
@@ -168,7 +168,7 @@ async def test_omni_path_receives_normalized_body(monkeypatch):
     from hal0.normalize.resolver import SlotView
 
     # Pin the resolver inputs so resolution is deterministic regardless of
-    # alias-map internals: hal0/primary -> "big" (loaded on gpu-vulkan).
+    # alias-map internals: hal0/chat -> "big" (loaded on gpu-vulkan).
     async def _fake_views(request):
         return [
             SlotView(
@@ -191,7 +191,7 @@ async def test_omni_path_receives_normalized_body(monkeypatch):
 
     monkeypatch.setattr(v1, "_maybe_run_omni_loop", _fake_omni)
 
-    raw = json.dumps({"model": "hal0/primary", "omni": True, "messages": []}).encode("utf-8")
+    raw = json.dumps({"model": "hal0/chat", "omni": True, "messages": []}).encode("utf-8")
     req = _OmniRequest(raw)
 
     resp = await v1.chat_completions(req, dispatcher=None)
@@ -241,7 +241,7 @@ class _FakeDispatcher:
 async def test_chat_template_kwargs_opt_out_through_seam():
     req = _make_request(cfgs=_PRIMARY, loaded={"big"})
     out = await v1._normalize_chat_body(
-        req, {"model": "hal0/primary", "chat_template_kwargs": {"enable_thinking": True}}
+        req, {"model": "hal0/chat", "chat_template_kwargs": {"enable_thinking": True}}
     )
     assert "enable_thinking" not in out
     assert out["chat_template_kwargs"] == {"enable_thinking": True}

--- a/tests/api/test_virtual_models.py
+++ b/tests/api/test_virtual_models.py
@@ -6,8 +6,8 @@ loaded, and that each row carries a context_length field (required by
 Hermes' custom provider for correct context-window sizing).
 
 #654: the canonical chat virtual name is ``hal0/chat`` (was ``hal0/primary``).
-``hal0/primary`` remains a HIDDEN back-compat alias — it resolves for dispatch
-but is NOT advertised in /v1/models.
+The ``hal0/primary`` alias has since been removed — it is neither advertised in
+/v1/models nor resolvable for dispatch.
 """
 
 from __future__ import annotations
@@ -52,7 +52,7 @@ def test_virtual_rows_do_not_duplicate(client, monkeypatch):
 
 
 def test_legacy_primary_virtual_name_is_hidden(client, monkeypatch):
-    """#654: hal0/primary is a hidden alias — it must NOT be advertised."""
+    """#654: hal0/primary was removed — it must NOT be advertised in /v1/models."""
 
     async def fake_views(request):
         return _views()

--- a/tests/normalize/test_resolver.py
+++ b/tests/normalize/test_resolver.py
@@ -32,12 +32,12 @@ def test_chat_prefers_igpu_when_loaded():
     assert r.fallback is False
 
 
-def test_primary_alias_resolves_to_chat():
-    """Back-compat: hal0/primary still resolves (via VIRTUAL_ALIASES → hal0/chat)."""
-    r = resolve_chain("hal0/primary", _slots(), loaded={"big-35b", "qwen3-4b-FLM"})
-    assert r is not None
-    assert r.model_id == "big-35b"
-    assert r.fallback is False
+def test_removed_aliases_are_unknown():
+    """The hal0/primary and hal0/flm aliases were removed — they are no longer
+    known virtual names, so resolve_chain returns None (callers leave the body
+    alone). Use the canonical hal0/chat and hal0/npu instead."""
+    assert resolve_chain("hal0/primary", _slots(), loaded={"big-35b"}) is None
+    assert resolve_chain("hal0/flm", _slots(), loaded={"qwen3-4b-FLM"}) is None
 
 
 def test_npu_picks_npu_first_never_commandeers_primary():
@@ -79,21 +79,8 @@ def test_full_miss_falls_back_to_configured_primary_unloaded():
     assert r.fallback is True
 
 
-def test_flm_alias_resolves_same_as_npu():
-    r = resolve_chain("hal0/flm", _slots(), loaded={"qwen3-4b-FLM"})
-    assert r.model_id == "qwen3-4b-FLM"
-
-
 def test_empty_slots_degrades_to_blank_resolution():
     r = resolve_chain("hal0/chat", [], loaded=set())
-    assert r is not None
-    assert r.model_id == ""
-    assert r.fallback is True
-
-
-def test_empty_slots_via_primary_alias_degrades():
-    """Back-compat: hal0/primary on empty slots still degrades gracefully."""
-    r = resolve_chain("hal0/primary", [], loaded=set())
     assert r is not None
     assert r.model_id == ""
     assert r.fallback is True
@@ -130,8 +117,9 @@ async def test_live_resolver_reads_views_and_health():
 
 
 @pytest.mark.asyncio
-async def test_live_resolver_hal0_primary_alias():
-    """hal0/primary is accepted by LiveSlotResolver via VIRTUAL_ALIASES."""
+async def test_live_resolver_rejects_removed_alias():
+    """hal0/primary is no longer a virtual name — LiveSlotResolver returns None
+    (passthrough) so the caller leaves a literal 'hal0/primary' body alone."""
     from hal0.normalize.resolver import LiveSlotResolver, SlotView
 
     views = [
@@ -141,9 +129,7 @@ async def test_live_resolver_hal0_primary_alias():
         slot_views_provider=lambda: views,
         loaded_models_provider=lambda: {"big"},
     )
-    res = await resolver.resolve("hal0/primary")
-    assert res is not None
-    assert res.model_id == "big"
+    assert await resolver.resolve("hal0/primary") is None
 
 
 def test_agent_virtual_name_resolves_to_agent_slot():

--- a/tests/slots/test_slot_aliases.py
+++ b/tests/slots/test_slot_aliases.py
@@ -3,7 +3,7 @@
 Verifies:
   1. Old names ("primary", "agent-hermes") resolve to canonical slots.
   2. Aliases do NOT appear in SlotManager.list() or iter_configs().
-  3. hal0/primary virtual name resolves via the resolver layer.
+  3. The hal0/primary VIRTUAL name was removed — only canonical hal0/chat is known.
   4. dispatcher/router Rule 6 + 7 handle the renamed slot.
   5. hal0_chat_slot_alias_map injects back-compat aliases.
 """
@@ -126,21 +126,23 @@ async def test_iter_configs_does_not_leak_aliases(tmp_slots_dir):
     assert "agent-hermes" not in names
 
 
-# ── 5. normalize/resolver virtual alias ──────────────────────────────────────
+# ── 5. normalize/resolver canonical virtual name (aliases removed) ────────────
 
 
-def test_resolver_hal0_primary_in_virtual_aliases():
-    from hal0.normalize.resolver import VIRTUAL_ALIASES
+def test_resolver_hal0_primary_virtual_removed():
+    """The hal0/primary virtual alias was removed — there is no alias map and
+    the name is not a known virtual."""
+    from hal0.normalize import resolver as R
 
-    assert "hal0/primary" in VIRTUAL_ALIASES
-    assert VIRTUAL_ALIASES["hal0/primary"] == "hal0/chat"
+    assert not hasattr(R, "VIRTUAL_ALIASES")
+    assert "hal0/primary" not in R.DEFAULT_CHAINS
 
 
 def test_resolver_hal0_chat_in_default_chains():
     from hal0.normalize.resolver import DEFAULT_CHAINS
 
     assert "hal0/chat" in DEFAULT_CHAINS
-    assert "hal0/primary" not in DEFAULT_CHAINS  # moved to VIRTUAL_ALIASES
+    assert "hal0/primary" not in DEFAULT_CHAINS  # never an alias either — removed
 
 
 def test_resolver_npu_chain_uses_chat_fallback():
@@ -151,13 +153,17 @@ def test_resolver_npu_chain_uses_chat_fallback():
     assert DEFAULT_CHAINS["hal0/utility"][-1] == "chat"
 
 
-def test_resolve_chain_hal0_primary_resolves():
+def test_resolve_chain_hal0_primary_is_unknown():
+    """hal0/primary was removed as a virtual name — resolve_chain returns None.
+    Callers must use the canonical hal0/chat."""
     from hal0.normalize.resolver import SlotView, resolve_chain
 
     slots = [
         SlotView(name="chat", role=None, device="gpu-vulkan", model_id="big", context_length=65536),
     ]
-    r = resolve_chain("hal0/primary", slots, loaded={"big"})
+    assert resolve_chain("hal0/primary", slots, loaded={"big"}) is None
+    # canonical name still resolves
+    r = resolve_chain("hal0/chat", slots, loaded={"big"})
     assert r is not None
     assert r.model_id == "big"
     assert r.fallback is False


### PR DESCRIPTION
## What

Removes the `VIRTUAL_ALIASES` back-compat layer so virtual model names map 1:1 to canonical chains. `hal0/primary` (pre-v0.4 name for `hal0/chat`) and `hal0/flm` (= `hal0/npu`) are no longer resolved — callers must use the canonical `hal0/chat` / `hal0/npu`, which is what `/v1/models` advertises.

## Why

While picking up the hal0-overhaul handoff, the Hermes config-set overlay was found emitting `model.default: hal0/primary` under live-resolve — a name **absent from `/v1/models` discovery** (which only lists canonical `hal0/chat`). So the picker's discovered model list and the configured default disagreed. Rather than keep emitting a deprecated alias, the aliases are dropped and the overlay emits canonical `hal0/chat`.

Confirmed live on CT107: `/v1/models` exposes `hal0/chat` (+ `hal0/npu`/`hal0/utility`), never `hal0/primary`.

## Changes

- **`resolver.py`** — delete `VIRTUAL_ALIASES`; `resolve_chain` / `LiveSlotResolver` look up `DEFAULT_CHAINS` directly. Unknown names return `None` (passthrough, body left alone).
- **`normalize/__init__.py`** — drop the `VIRTUAL_ALIASES` export.
- **`hermes_provision.py`** — both overlay emitters set `hal0/chat` under live-resolve (+ docstrings / fallback message).
- **`setup_copy.py`, `board_chat.py`** — copy + comment references → `hal0/chat`.
- **tests** (6 files) — convert "alias resolves" cases to "alias removed → `None` / not advertised"; swap request-model inputs to `hal0/chat`.

## Scope

Virtual-name aliases **only**. The slot-name back-compat (`SLOT_ALIASES`, `chat_slot_alias_map`, dispatcher Rule 6, resolver's legacy `primary` role) is intentionally left in place.

## Test

- 143 passed across the six affected test files
- `ruff check` clean; `ruff format` reports all files unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)