### PR TITLE
feat(slots): load-time capability fallback for non-servable model.default

### DIFF
--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -969,6 +969,14 @@ class SlotManager:
                 )
                 return await self.status(slot_name)
 
+            # Seed/default may pin a model id that never landed locally under
+            # that exact id (e.g. a catalog id like ``gemma-4-12b-it`` while the
+            # scanned gguf registered as ``gemma-4-12b-it-ud-q4-k-xl``). Rather
+            # than crash-loop on a non-servable id, fall back to a locally
+            # registered model matching the slot's capability. No-op for FLM/NPU
+            # (tag-served), already-local ids, and pullable catalog ids.
+            resolved_model = self._resolve_servable_model(resolved_model, cfg)
+
             # NPU FLM trio shadow (stt/embed, device=npu): the chat anchor's
             # single FLM process serves these via the anchor's [npu] toggles.
             # They are NOT independently loadable on the busy single-tenant
@@ -2061,6 +2069,87 @@ class SlotManager:
             )
             return False
 
+    def _resolve_servable_model(self, model_id: str, cfg: SlotConfig | dict[str, Any]) -> str:
+        """Resolve a slot's configured model id to one that can actually serve.
+
+        A seed/default may pin an id that never landed locally under that exact
+        id — e.g. a catalog id (``gemma-4-12b-it``, ``upstream=hal0``, no file)
+        while the operator's scanned gguf registered under the normalised stem
+        (``gemma-4-12b-it-ud-q4-k-xl``). Pinned to the ghost, the slot would
+        crash-loop on a ``--model`` path that doesn't exist. When that happens
+        we fall back to a locally-registered model matching the slot's
+        capability and log it loudly so the operator can fix the config.
+
+        Returns ``model_id`` unchanged when:
+          * the slot is FLM/NPU (``device=npu``) — those are served by tag, not
+            a local gguf file, so registry-path checks don't apply;
+          * the configured model is already registered with a file on disk;
+          * the configured id is a known curated model (still to be pulled —
+            don't pre-empt a legitimate download with a fallback);
+          * no local model matches the slot's capability.
+        """
+        d = _cfg_to_dict(cfg)
+        device = d.get("device") or d.get("slot", {}).get("device")
+        if device == "npu":
+            return model_id
+        if self._default_model_cache_check(model_id):
+            return model_id
+        try:
+            from hal0.registry.curated import get_curated
+
+            if get_curated(model_id) is not None:
+                return model_id  # pullable as configured — let load() pull it
+        except ImportError:
+            pass
+        slot_type = (d.get("type") or d.get("slot", {}).get("type") or "").lower()
+        capability = _SLOT_TYPE_TO_CAPABILITY.get(slot_type)
+        if not capability:
+            return model_id
+        fallback = self._fallback_local_model(capability)
+        if fallback is None or fallback.id == model_id:
+            return model_id
+        log.warning(
+            "slot.model_default_fallback",
+            extra={
+                "configured": model_id,
+                "fallback": fallback.id,
+                "capability": capability,
+            },
+        )
+        return fallback.id
+
+    @staticmethod
+    def _fallback_local_model(capability: str):
+        """Largest locally-registered model (file on disk) whose capabilities
+        include ``capability``; ``None`` when none match. Deterministic:
+        largest-on-disk first, tie-broken by id."""
+        try:
+            from hal0.registry.store import ModelRegistry
+        except ImportError:
+            return None
+        try:
+            models = ModelRegistry().list()
+        except Exception:
+            return None
+        candidates = []
+        for m in models:
+            caps = getattr(m, "capabilities", None) or []
+            if capability not in caps:
+                continue
+            path = getattr(m, "path", "") or ""
+            if not path:
+                continue
+            try:
+                if not Path(path).exists():
+                    continue
+            except OSError:
+                continue
+            candidates.append(m)
+        if not candidates:
+            return None
+        candidates.sort(key=lambda m: (-(getattr(m, "size_bytes", 0) or 0), m.id))
+        return candidates[0]
+
     @staticmethod
     def _default_model_cache_check(model_id: str) -> bool:
         """Default predicate: registered + path-on-disk → cached.
@@ -2591,6 +2680,21 @@ class SlotManager:
 
 
 # ── module-level helpers ─────────────────────────────────────────────────────
+
+
+# Slot ``type`` → the model capability a fallback search should match when the
+# slot's configured ``model.default`` is not locally servable. Inverse of
+# ``capabilities.catalog._CAPABILITY_TO_SLOT_TYPE`` — duplicated here (not
+# imported) to stay clear of the capabilities import cycle that ``slots.*``
+# deliberately avoids.
+_SLOT_TYPE_TO_CAPABILITY: dict[str, str] = {
+    "llm": "chat",
+    "embedding": "embed",
+    "reranking": "rerank",
+    "transcription": "asr",
+    "tts": "tts",
+    "image": "image",
+}
 
 
 def _cfg_to_dict(cfg: SlotConfig | dict[str, Any]) -> dict[str, Any]:

--- a/tests/slots/test_model_fallback.py
+++ b/tests/slots/test_model_fallback.py
@@ -1,0 +1,108 @@
+"""Load-time capability fallback for a non-servable slot ``model.default``.
+
+A seed/default may pin a model id that never landed locally under that exact
+id — e.g. the catalog id ``gemma-4-12b-it`` (``upstream=hal0``, no file) while
+the operator's scanned gguf registered as ``gemma-4-12b-it-ud-q4-k-xl``. Pinned
+to the ghost, the slot would crash-loop on a ``--model`` path that doesn't
+exist. ``SlotManager._resolve_servable_model`` falls back to a locally
+registered model matching the slot's capability instead.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hal0.registry.curated import CURATED_MODELS
+from hal0.registry.model import Model
+from hal0.registry.store import ModelRegistry
+from hal0.slots.manager import SlotManager
+
+
+def _add_model(home: str, *, id: str, capability: str, size_bytes: int, exists: bool = True) -> str:
+    """Register a Model under HAL0_HOME, optionally materialising its file."""
+    gguf = Path(home) / f"{id}.gguf"
+    if exists:
+        gguf.write_bytes(b"\0")
+    ModelRegistry().add(
+        Model(
+            id=id,
+            name=id,
+            path=str(gguf),
+            size_bytes=size_bytes,
+            capabilities=[capability],
+        )
+    )
+    return id
+
+
+def _mgr() -> SlotManager:
+    # _resolve_servable_model only touches static helpers + the registry, so a
+    # bare instance (no __init__) is enough to exercise it.
+    return SlotManager.__new__(SlotManager)
+
+
+def _llm_cfg(default: str, *, device: str = "gpu-vulkan") -> dict:
+    return {
+        "name": "utility",
+        "type": "llm",
+        "device": device,
+        "model": {"default": default},
+    }
+
+
+def test_falls_back_to_local_when_configured_id_is_ghost(tmp_hal0_home):
+    real = _add_model(
+        tmp_hal0_home, id="gemma-4-12b-it-ud-q4-k-xl", capability="chat", size_bytes=6_900_000_000
+    )
+    cfg = _llm_cfg("gemma-4-12b-it")  # ghost: not registered, not curated
+    assert _mgr()._resolve_servable_model("gemma-4-12b-it", cfg) == real
+
+
+def test_no_fallback_when_configured_model_is_local(tmp_hal0_home):
+    _add_model(tmp_hal0_home, id="gemma-4-12b-it", capability="chat", size_bytes=6_000_000_000)
+    cfg = _llm_cfg("gemma-4-12b-it")
+    assert _mgr()._resolve_servable_model("gemma-4-12b-it", cfg) == "gemma-4-12b-it"
+
+
+def test_no_fallback_for_npu_device_flm_tag(tmp_hal0_home):
+    # A local chat model exists, but an NPU/FLM slot is served by tag — never
+    # repoint it at a gguf file.
+    _add_model(tmp_hal0_home, id="some-local-chat", capability="chat", size_bytes=5_000_000_000)
+    cfg = _llm_cfg("gemma4-it-e2b-FLM", device="npu")
+    assert _mgr()._resolve_servable_model("gemma4-it-e2b-FLM", cfg) == "gemma4-it-e2b-FLM"
+
+
+def test_no_fallback_when_configured_id_is_curated_pullable(tmp_hal0_home):
+    # A curated id is still-to-be-pulled; don't pre-empt the download with a
+    # fallback even though a different local chat model is present.
+    curated_id = next(m.id for m in CURATED_MODELS if m.capability == "chat")
+    _add_model(tmp_hal0_home, id="other-local-chat", capability="chat", size_bytes=4_000_000_000)
+    cfg = _llm_cfg(curated_id)
+    assert _mgr()._resolve_servable_model(curated_id, cfg) == curated_id
+
+
+def test_no_fallback_when_no_capability_match(tmp_hal0_home):
+    # Only an embed model is local; an llm (chat) slot finds no chat fallback.
+    _add_model(tmp_hal0_home, id="some-embed", capability="embed", size_bytes=500_000_000)
+    cfg = _llm_cfg("gemma-4-12b-it")
+    assert _mgr()._resolve_servable_model("gemma-4-12b-it", cfg) == "gemma-4-12b-it"
+
+
+def test_fallback_picks_largest_on_disk(tmp_hal0_home):
+    _add_model(tmp_hal0_home, id="small-chat", capability="chat", size_bytes=1_000_000_000)
+    big = _add_model(tmp_hal0_home, id="big-chat", capability="chat", size_bytes=20_000_000_000)
+    cfg = _llm_cfg("ghost-id")
+    assert _mgr()._resolve_servable_model("ghost-id", cfg) == big
+
+
+def test_fallback_skips_registered_models_with_missing_file(tmp_hal0_home):
+    # Registered but the file isn't on disk → not a valid fallback target.
+    _add_model(
+        tmp_hal0_home, id="phantom-chat", capability="chat", size_bytes=3_000_000_000, exists=False
+    )
+    cfg = _llm_cfg("ghost-id")
+    assert _mgr()._resolve_servable_model("ghost-id", cfg) == "ghost-id"
+
+
+def test_fallback_local_model_returns_none_when_empty(tmp_hal0_home):
+    assert SlotManager._fallback_local_model("chat") is None


### PR DESCRIPTION
## What

A slot's seed/default can pin a model id that never landed locally under that exact id — e.g. the catalog id `gemma-4-12b-it` (`upstream=hal0`, no file) while the operator's scanned gguf registered under the normalised stem `gemma-4-12b-it-ud-q4-k-xl`. Pinned to the ghost, the slot **crash-loops** on a `--model` path that doesn't exist, because nothing reconciles a scanned gguf with a catalog id.

`load()` now resolves the configured model id through a new `_resolve_servable_model` **before** the pull/spawn step: when the id isn't locally servable, it falls back to the largest locally-registered model matching the slot's capability and logs `slot.model_default_fallback` so the operator can fix the config.

## Why

This is the still-open half of the "seed-slot-name ≠ scanned-id" UX gap (the `hal0/primary` virtual-name half shipped in #939). Observed live on CT107: registry had a ghost `gemma-4-12b-it` (`upstream=hal0`, size `—`) alongside the real `gemma-4-12b-it-ud-q4-k-xl` (`local`, 6.9GB); a slot pinned to the ghost can't serve. Chosen approach (operator decision): **load-time capability fallback** — resilient for *any* operator-supplied gguf, not just curated pulls.

## No-op (returns the id unchanged) when

- FLM/NPU slots (`device=npu`) — served by tag, not a local gguf file;
- the id is already registered with a file on disk;
- the id is a known curated model still to be pulled — **don't pre-empt a legitimate download** with a fallback;
- no local model matches the slot's capability.

## Notes

- `_SLOT_TYPE_TO_CAPABILITY` inverts `capabilities.catalog._CAPABILITY_TO_SLOT_TYPE` — duplicated (not imported) to stay clear of the import cycle `slots.*` deliberately avoids.
- Fallback is **runtime-only**: it does not rewrite the slot's TOML `model.default`; the operator's configured id is preserved.

## Test

- 8 new unit tests (`tests/slots/test_model_fallback.py`): ghost→fallback, already-local, npu, curated-pullable, no-match, largest-wins, missing-file-skip, empty-registry.
- Full local sweep: `tests/slots` 251, `tests/registry` + `tests/capabilities` green, `tests/dispatcher` + `tests/api` 1200 passed. The 3 api failures are pre-existing on base main (root/pve-host env: config-urls, models-preview, store-writable-path) — confirmed by re-running on the unmodified tree; this PR adds zero new failures.
- `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)