### PR TITLE
fix(installer): non-interactive hermes-gateway install + honest skip when unit absent

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1324,16 +1324,40 @@ else
         # the drop-in BEFORE first start so platforms connect on boot.
         # HERMES_HOME is unset so the generator bakes the hal0 default
         # (~/.hermes), not a value inherited from the installer env.
+        #
+        # `hermes gateway install` on the systemd path PROMPTS interactively
+        # ("Start the gateway now…?" / "…on boot?") with no flag to bypass.
+        # The installer's contract is non-interactive (see DEBIAN_FRONTEND
+        # above), so we feed it </dev/null: a TTY-less read hits EOF and
+        # hermes falls back to its built-in defaults (install + enable on
+        # boot + start now). Without this, two failure modes appear:
+        #   - on a real TTY the install BLOCKS on the prompt;
+        #   - under a launcher that *closes* fd 0 (some headless/CI runners),
+        #     hermes' input() raises `RuntimeError: lost sys.stdin` — which it
+        #     does NOT catch — so the install aborts AFTER printing the prompt
+        #     but BEFORE writing the unit file. That is what produced the
+        #     "Unit file hermes-gateway.service does not exist" error below.
+        # Redirecting from /dev/null turns that crash into a clean EOF.
+        GATEWAY_UNIT_DST="${UNIT_DIR}/hermes-gateway.service"
         info "installing system-scope hermes gateway (User=hal0)"
-        env -u HERMES_HOME /var/lib/hal0/venvs/hermes/bin/hermes gateway install --system --run-as-user hal0 \
+        env -u HERMES_HOME /var/lib/hal0/venvs/hermes/bin/hermes gateway install --system --run-as-user hal0 </dev/null \
             || warn "hermes gateway install failed — Telegram/Discord bridge unavailable; continuing"
-        systemctl daemon-reload
-        systemctl enable --now hermes-gateway.service \
-            || warn "hermes-gateway enable returned non-zero — continuing (check 'journalctl -u hermes-gateway -n 40')"
-        if wait_active hermes-gateway.service 20; then
-            info "hermes-gateway is running (Telegram/Discord)"
+        # Only enable/start if hermes actually laid down the unit. If the
+        # install genuinely failed the file is absent; `systemctl enable` would
+        # otherwise emit a scary "Unit file … does not exist" error and trip
+        # the ERR trap. Skip honestly with a warning instead.
+        if [[ -f "${GATEWAY_UNIT_DST}" ]]; then
+            systemctl daemon-reload
+            systemctl enable --now hermes-gateway.service \
+                || warn "hermes-gateway enable returned non-zero — continuing (check 'journalctl -u hermes-gateway -n 40')"
+            if wait_active hermes-gateway.service 20; then
+                info "hermes-gateway is running (Telegram/Discord)"
+            else
+                warn "hermes-gateway not yet active; check 'journalctl -u hermes-gateway -n 40'"
+            fi
         else
-            warn "hermes-gateway not yet active; check 'journalctl -u hermes-gateway -n 40'"
+            warn "hermes-gateway unit not installed (${GATEWAY_UNIT_DST} missing) — Telegram/Discord bridge unavailable"
+            warn "  retry with 'sudo -u hal0 env -u HERMES_HOME /var/lib/hal0/venvs/hermes/bin/hermes gateway install --system --run-as-user hal0 </dev/null'"
         fi
     elif [[ -f "${AGENT_UNIT_DST}" ]]; then
         # No venv after the provision block: it was skipped (HAL0_SKIP_HERMES=1)


### PR DESCRIPTION
## Problem (found on a fresh CT105 headless install)

`installer/install.sh` is documented as idempotent / non-interactive, but its
system-scope hermes-gateway step hangs or fails-soft under a non-tty run. Observed:

```
OK  installing system-scope hermes gateway (User=hal0)
Start the gateway now after installing the service? [Y/n]:
!!  hermes gateway install failed — Telegram/Discord bridge unavailable; continuing
Failed to enable unit: Unit file hermes-gateway.service does not exist.
!!  hermes-gateway enable returned non-zero — continuing
```

The Telegram/Discord bridge never gets wired on a headless install.

## Root cause

`hermes gateway install` (external package, installed in `/var/lib/hal0/venvs/hermes`)
prompts interactively on the systemd/Linux path — `prompt_yes_no("Start the gateway
now after installing the service?")` and `"…on boot?"` — with **no flag** to bypass
(the `start_now`/`start_on_login` args are only wired for the Windows branch).

Hermes' prompt helper calls `input()` and catches **only** `(KeyboardInterrupt, EOFError)`.

- On a real TTY, the step **blocks** on the prompt.
- Under `</dev/null` (nohup-style), `input()` raises `EOFError` → caught → returns the
  default → install proceeds. (This case is fine.)
- Under a launcher that **closes fd 0** (some headless/CI runners), `input()` raises
  `RuntimeError: input(): lost sys.stdin` — **uncaught** — so `hermes gateway install`
  aborts **after printing the prompt but before writing the unit file**. install.sh's
  own `systemctl enable --now hermes-gateway.service` then hits the missing unit and
  emits the scary "Unit file … does not exist" error. This is the exact live failure.

## Fix (install.sh only — hermes is external and out of scope)

1. **Non-interactive**: invoke `hermes gateway install` with `</dev/null`. The TTY-less
   read hits a clean EOF, hermes falls back to its built-in defaults (install + enable
   on boot + start now). Fixes both the TTY hang and the closed-stdin `RuntimeError`
   crash, consistent with the installer's non-interactive contract (cf.
   `DEBIAN_FRONTEND=noninteractive` at the top of the script).
2. **Unit-exists guard**: only run `systemctl enable --now` when
   `/etc/systemd/system/hermes-gateway.service` actually exists. A genuinely-failed
   install now warns honestly (with a copy-paste retry command) instead of emitting the
   "Unit file … does not exist" error and tripping the ERR trap.

The dual-unit nuance (system `hermes-gateway.service` vs user-scope
`hermes-gateway-{discord,hal0}`) is untouched.

## Validation

- `bash -n installer/install.sh` → OK (shellcheck not available on the box).
- Reproduced the `RuntimeError: input(): lost sys.stdin` crash with a closed fd 0, and
  confirmed `</dev/null` turns it into a clean EOF that returns hermes' defaults.
- Diff is one file, +31/-7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)