### PR TITLE
fix(slots): harden capability fallback against diffusion/video models

### DIFF
--- a/src/hal0/registry/discover.py
+++ b/src/hal0/registry/discover.py
@@ -111,6 +111,18 @@ def _normalise_id(stem: str) -> str:
     return collapsed or "model"
 
 
+# Filename tokens that mark an image/video diffusion artifact. Classifying
+# these as ``image``/``video`` (instead of defaulting to ``chat``) keeps them
+# out of the chat candidate pool that ``SlotManager._fallback_local_model``
+# draws from — the live ltx-2 incident, where a 25GB video diffusion gguf was
+# default-guessed ``chat`` and selected as the chat slot's fallback. The
+# fallback's own diffusion guard is the must-have backstop; this is defence in
+# depth at the source. Conservative: only well-known families, matched as
+# substrings of the lower-cased filename.
+_VIDEO_NAME_TOKENS = ("ltx", "wan", "hunyuan-video", "hunyuanvideo", "cogvideo", "svd")
+_IMAGE_NAME_TOKENS = ("sdxl", "flux", "stable-diffusion", "stable_diffusion")
+
+
 def _guess_capability(filename: str) -> str:
     """Best-effort capability inference from the filename."""
     lower = filename.lower()
@@ -122,6 +134,12 @@ def _guess_capability(filename: str) -> str:
         return "tts"
     if any(tok in lower for tok in ("whisper", "moonshine", "asr", "stt")):
         return "asr"
+    # Clearly-diffusion media: classify as image/video rather than the chat
+    # default so they never pollute the chat fallback pool (#940 hardening).
+    if any(tok in lower for tok in _VIDEO_NAME_TOKENS):
+        return "video"
+    if any(tok in lower for tok in _IMAGE_NAME_TOKENS):
+        return "image"
     return "chat"
 
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -2105,7 +2105,7 @@ class SlotManager:
         capability = _SLOT_TYPE_TO_CAPABILITY.get(slot_type)
         if not capability:
             return model_id
-        fallback = self._fallback_local_model(capability)
+        fallback = self._fallback_local_model(capability, configured_id=model_id)
         if fallback is None or fallback.id == model_id:
             return model_id
         log.warning(
@@ -2119,10 +2119,27 @@ class SlotManager:
         return fallback.id
 
     @staticmethod
-    def _fallback_local_model(capability: str):
-        """Largest locally-registered model (file on disk) whose capabilities
-        include ``capability``; ``None`` when none match. Deterministic:
-        largest-on-disk first, tie-broken by id."""
+    def _fallback_local_model(capability: str, configured_id: str = ""):
+        """Pick a locally-registered model (file on disk) to stand in for a
+        non-servable slot default.
+
+        Candidates must carry ``capability`` AND a real on-disk file. They are
+        additionally filtered through :func:`_looks_diffusion_or_nontext` so an
+        image/video/diffusion artifact (which :func:`discover._guess_capability`
+        may have mislabelled ``chat``) can never be served into a text slot —
+        the live ``ltx-2-19b-dev-fp8`` incident, where a 25GB video model was
+        the largest "chat" candidate and llama-server then failed to load it.
+
+        Selection order (a text slot wants a look-alike of its configured id,
+        not merely the biggest model on the box):
+          1. **Name similarity** — the candidate sharing the most leading
+             hyphen tokens with ``configured_id`` (e.g. ``gemma-4-12b-it`` →
+             ``gemma-4-12b-it-ud-q4-k-xl``). Ties broken by larger size, then id.
+          2. **Size** — only when nothing shares a leading token: the largest
+             on-disk model, tie-broken by id (the legacy behaviour).
+
+        ``None`` when no candidate matches.
+        """
         try:
             from hal0.registry.store import ModelRegistry
         except ImportError:
@@ -2136,6 +2153,11 @@ class SlotManager:
             caps = getattr(m, "capabilities", None) or []
             if capability not in caps:
                 continue
+            # Never serve a diffusion/image/video artifact into a text slot,
+            # even if it leaked into the chat candidate pool via a default
+            # capability guess (see _looks_diffusion_or_nontext).
+            if _looks_diffusion_or_nontext(m):
+                continue
             path = getattr(m, "path", "") or ""
             if not path:
                 continue
@@ -2147,7 +2169,25 @@ class SlotManager:
             candidates.append(m)
         if not candidates:
             return None
-        candidates.sort(key=lambda m: (-(getattr(m, "size_bytes", 0) or 0), m.id))
+        config_tokens = _id_tokens(configured_id)
+
+        def _shared_leading(m) -> int:
+            return _leading_token_overlap(config_tokens, _id_tokens(getattr(m, "id", "")))
+
+        best_overlap = max(_shared_leading(m) for m in candidates)
+        if best_overlap > 0:
+            # Prefer the closest name match; size + id only tie-break peers
+            # that share the same number of leading tokens.
+            candidates.sort(
+                key=lambda m: (
+                    -_shared_leading(m),
+                    -(getattr(m, "size_bytes", 0) or 0),
+                    getattr(m, "id", ""),
+                )
+            )
+        else:
+            # Nothing resembles the configured id — fall back to size.
+            candidates.sort(key=lambda m: (-(getattr(m, "size_bytes", 0) or 0), m.id))
         return candidates[0]
 
     @staticmethod
@@ -2695,6 +2735,97 @@ _SLOT_TYPE_TO_CAPABILITY: dict[str, str] = {
     "tts": "tts",
     "image": "image",
 }
+
+# ── Diffusion / non-text fallback guard (#940 hardening) ──────────────────────
+#
+# discover._guess_capability defaults any unrecognised gguf to "chat", so
+# video/image/diffusion ggufs land in the chat candidate pool. Combined with
+# the fallback's old "largest-first" pick this grabbed the biggest wrong model
+# — live, the chat utility slot fell back to ltx-2-19b-dev-fp8, a 25GB VIDEO
+# diffusion model, which llama-server then failed to load. The fallback must
+# never select an image/video/diffusion/non-text model for a text slot, so we
+# screen candidates by several independent signals before they qualify.
+
+#: Substrings in a model id / name / path that mark a diffusion / image /
+#: video artifact (matched on a normalised lower-case, separator-collapsed
+#: form so ``sd-``/``sd_``/``SDXL`` all hit). Word-ish tokens are matched on
+#: token boundaries; the rest are plain substring contains.
+_DIFFUSION_NAME_TOKENS: frozenset[str] = frozenset(
+    {"sdxl", "sd", "flux", "ltx", "wan", "comfyui", "turbo", "refiner", "upscaler", "esrgan", "vae"}
+)
+_DIFFUSION_NAME_SUBSTRINGS: tuple[str, ...] = ("diffus", "lora", "unet", "controlnet")
+#: Non-text model file suffixes the llama-server / FLM text providers cannot
+#: serve — a gguf default-guessed as chat is fine, these are not. Kept to the
+#: diffusion/checkpoint formats; ``.bin`` is deliberately excluded (ggml ASR
+#: weights use it and are legitimately text-adjacent).
+_NONTEXT_MODEL_SUFFIXES: frozenset[str] = frozenset({".safetensors", ".ckpt", ".pth", ".onnx"})
+#: Capabilities that are inherently non-text. A candidate advertising any of
+#: these can never serve a chat/embed/rerank/asr/tts slot.
+_NONTEXT_CAPABILITIES: frozenset[str] = frozenset({"image", "video"})
+
+
+def _looks_diffusion_or_nontext(model: Any) -> bool:
+    """True when *model* looks like a diffusion / image / video / non-text artifact.
+
+    Robust to mislabelled capabilities: a video gguf that
+    :func:`discover._guess_capability` defaulted to ``chat`` is still caught
+    by its id/name/path tokens and (for non-gguf checkpoints) its file suffix.
+    Conservative — only fires on strong signals so a legitimately-named text
+    model (e.g. ``wandb``-tagged) is not excluded by an accidental substring.
+    """
+    caps = {str(c).lower() for c in (getattr(model, "capabilities", None) or [])}
+    if caps & _NONTEXT_CAPABILITIES:
+        return True
+    tags = {str(t).lower() for t in (getattr(model, "tags", None) or [])}
+    if tags & _NONTEXT_CAPABILITIES or "diffusion" in tags:
+        return True
+    path = str(getattr(model, "path", "") or "")
+    if path:
+        suffix = Path(path).suffix.lower()
+        if suffix in _NONTEXT_MODEL_SUFFIXES:
+            return True
+    haystacks = (
+        str(getattr(model, "id", "") or ""),
+        str(getattr(model, "name", "") or ""),
+        path,
+    )
+    for raw in haystacks:
+        if not raw:
+            continue
+        tokens = set(_id_tokens(raw))
+        if tokens & _DIFFUSION_NAME_TOKENS:
+            return True
+        collapsed = raw.lower()
+        if any(sub in collapsed for sub in _DIFFUSION_NAME_SUBSTRINGS):
+            return True
+    return False
+
+
+def _id_tokens(value: str) -> list[str]:
+    """Split a model id / name / path into lower-case alphanumeric tokens.
+
+    ``gemma-4-12b-it_UD-Q4_K_XL`` → ``['gemma', '4', '12b', 'it', 'ud', ...]``.
+    Any run of non-alphanumeric characters is a separator, so ``sd-``, ``sd_``,
+    ``sd.`` and ``SDXL`` all tokenise predictably.
+    """
+    return [tok for tok in re.split(r"[^a-z0-9]+", value.lower()) if tok]
+
+
+def _leading_token_overlap(a: list[str], b: list[str]) -> int:
+    """Count of shared leading tokens between two token lists.
+
+    Used to rank fallback candidates by name similarity to the configured id:
+    ``gemma-4-12b-it`` vs ``gemma-4-12b-it-ud-q4-k-xl`` shares 4 leading
+    tokens, beating an unrelated (0-overlap) but larger chat model.
+    """
+    if not a or not b:
+        return 0
+    shared = 0
+    for x, y in zip(a, b, strict=False):
+        if x != y:
+            break
+        shared += 1
+    return shared
 
 
 def _cfg_to_dict(cfg: SlotConfig | dict[str, Any]) -> dict[str, Any]:

--- a/tests/registry/test_discover.py
+++ b/tests/registry/test_discover.py
@@ -98,6 +98,19 @@ def test_capability_guess(model_root: Path) -> None:
     assert caps["qwen3-4b-instruct-q4_k_m.gguf"] == "chat"
 
 
+def test_capability_guess_classifies_diffusion_media() -> None:
+    """Clearly-diffusion media files classify as image/video, not the chat
+    default — keeps them out of the chat fallback pool (#940 hardening)."""
+    from hal0.registry.discover import _guess_capability
+
+    assert _guess_capability("ltx-2-19b-dev-fp8.gguf") == "video"
+    assert _guess_capability("wan2.1-t2v-14b.gguf") == "video"
+    assert _guess_capability("flux1-dev.gguf") == "image"
+    assert _guess_capability("sdxl-base-1.0.safetensors") == "image"
+    # A plain chat model is still 'chat' — the new branches are last-resort.
+    assert _guess_capability("qwen3-4b-instruct-q4_k_m.gguf") == "chat"
+
+
 def test_curated_match_by_filename(model_root: Path) -> None:
     """A discovered file whose name matches a curated entry's hf_file
     must surface that curated entry on the candidate."""

--- a/tests/slots/test_model_fallback.py
+++ b/tests/slots/test_model_fallback.py
@@ -18,18 +18,28 @@ from hal0.registry.store import ModelRegistry
 from hal0.slots.manager import SlotManager
 
 
-def _add_model(home: str, *, id: str, capability: str, size_bytes: int, exists: bool = True) -> str:
+def _add_model(
+    home: str,
+    *,
+    id: str,
+    capability: str,
+    size_bytes: int,
+    exists: bool = True,
+    suffix: str = ".gguf",
+    tags: list[str] | None = None,
+) -> str:
     """Register a Model under HAL0_HOME, optionally materialising its file."""
-    gguf = Path(home) / f"{id}.gguf"
+    model_file = Path(home) / f"{id}{suffix}"
     if exists:
-        gguf.write_bytes(b"\0")
+        model_file.write_bytes(b"\0")
     ModelRegistry().add(
         Model(
             id=id,
             name=id,
-            path=str(gguf),
+            path=str(model_file),
             size_bytes=size_bytes,
             capabilities=[capability],
+            tags=tags or [],
         )
     )
     return id
@@ -106,3 +116,77 @@ def test_fallback_skips_registered_models_with_missing_file(tmp_hal0_home):
 
 def test_fallback_local_model_returns_none_when_empty(tmp_hal0_home):
     assert SlotManager._fallback_local_model("chat") is None
+
+
+# ── #940 hardening: diffusion guard + name-similarity ─────────────────────────
+
+
+def test_ghost_chat_slot_never_picks_video_model(tmp_hal0_home):
+    # The live failure: a 25GB video diffusion gguf got capabilities=['chat']
+    # (default guess) and, being the largest, was selected for the chat slot.
+    # It must be excluded — leaving a real (smaller) chat model as the pick.
+    _add_model(tmp_hal0_home, id="ltx-2-19b-dev-fp8", capability="chat", size_bytes=25_000_000_000)
+    real = _add_model(
+        tmp_hal0_home, id="gemma-4-12b-it-ud-q4-k-xl", capability="chat", size_bytes=6_900_000_000
+    )
+    cfg = _llm_cfg("gemma-4-12b-it")  # ghost
+    assert _mgr()._resolve_servable_model("gemma-4-12b-it", cfg) == real
+
+
+def test_ghost_chat_slot_with_only_video_model_does_not_fall_back(tmp_hal0_home):
+    # If the *only* chat-tagged candidate is a video model, there is no valid
+    # fallback at all — keep the configured (ghost) id rather than serve video.
+    _add_model(tmp_hal0_home, id="ltx-2-19b-dev-fp8", capability="chat", size_bytes=25_000_000_000)
+    cfg = _llm_cfg("gemma-4-12b-it")
+    assert _mgr()._resolve_servable_model("gemma-4-12b-it", cfg) == "gemma-4-12b-it"
+
+
+def test_excludes_safetensors_diffusion_checkpoint(tmp_hal0_home):
+    # A .safetensors checkpoint mislabelled chat must not be a fallback target.
+    _add_model(
+        tmp_hal0_home,
+        id="v1-5-pruned-emaonly",
+        capability="chat",
+        size_bytes=4_000_000_000,
+        suffix=".safetensors",
+    )
+    cfg = _llm_cfg("gemma-4-12b-it")
+    assert _mgr()._resolve_servable_model("gemma-4-12b-it", cfg) == "gemma-4-12b-it"
+
+
+def test_excludes_image_capability_model(tmp_hal0_home):
+    # An explicit image-capability model is never a text-slot fallback even
+    # when it is the only candidate carrying the requested 'chat' cap too.
+    gguf = Path(tmp_hal0_home) / "flux-dev.gguf"
+    gguf.write_bytes(b"\0")
+    ModelRegistry().add(
+        Model(
+            id="flux-dev",
+            name="flux-dev",
+            path=str(gguf),
+            size_bytes=12_000_000_000,
+            capabilities=["chat", "image"],
+        )
+    )
+    cfg = _llm_cfg("gemma-4-12b-it")
+    assert _mgr()._resolve_servable_model("gemma-4-12b-it", cfg) == "gemma-4-12b-it"
+
+
+def test_name_similarity_beats_larger_unrelated_chat_model(tmp_hal0_home):
+    # A much larger but unrelated chat model must lose to the look-alike that
+    # shares leading tokens with the configured (ghost) id.
+    _add_model(tmp_hal0_home, id="qwen3-coder-30b", capability="chat", size_bytes=30_000_000_000)
+    lookalike = _add_model(
+        tmp_hal0_home, id="gemma-4-12b-it-ud-q4-k-xl", capability="chat", size_bytes=6_900_000_000
+    )
+    cfg = _llm_cfg("gemma-4-12b-it")
+    assert _mgr()._resolve_servable_model("gemma-4-12b-it", cfg) == lookalike
+
+
+def test_size_tiebreak_when_no_name_similarity(tmp_hal0_home):
+    # No candidate shares a leading token with the ghost id → size wins
+    # (legacy behaviour preserved).
+    _add_model(tmp_hal0_home, id="alpha-chat", capability="chat", size_bytes=1_000_000_000)
+    big = _add_model(tmp_hal0_home, id="beta-chat", capability="chat", size_bytes=9_000_000_000)
+    cfg = _llm_cfg("zeta-ghost-id")
+    assert _mgr()._resolve_servable_model("zeta-ghost-id", cfg) == big


### PR DESCRIPTION
## Problem (found live on CT105)

PR #940 added a load-time capability fallback in `SlotManager`
(`_resolve_servable_model` + `_fallback_local_model`): when a slot's
configured `model.default` isn't locally servable, it falls back to the
largest locally-registered model whose `capabilities` include the slot's
target capability.

**Live failure:** loading the chat `utility` slot (seed pins the ghost id
`gemma-4-12b-it`) made the fallback pick **`ltx-2-19b-dev-fp8` — a 25GB VIDEO
diffusion model** — which llama-server then failed to load.

**Root cause:** `registry/discover.py::_guess_capability` DEFAULTS any
unrecognised gguf to `"chat"`, so video/image/diffusion ggufs get
`capabilities=["chat"]` and pollute the chat candidate pool; combined with
the fallback's "largest-first" pick, it grabs the biggest wrong model.

## Fix

**`slots/manager.py` (primary, must-have):**
- New `_looks_diffusion_or_nontext()` screens every fallback candidate by
  several independent signals so an image/video/diffusion artifact can
  never be served into a text slot, even if it leaked into the chat pool
  via a default capability guess:
  - `capabilities` / `tags` containing `image`/`video` (or `diffusion` tag)
  - id/name/path tokens: `sdxl`, `sd`, `flux`, `ltx`, `wan`, `comfyui`,
    `turbo`, `refiner`, `upscaler`, `esrgan`, `vae`, plus substrings
    `diffus`/`lora`/`unet`/`controlnet`
  - non-gguf checkpoint suffixes `.safetensors`/`.ckpt`/`.pth`/`.onnx`
    (`.bin` deliberately excluded — ggml ASR weights use it)
- `_fallback_local_model()` now prefers **name-similarity** to the
  configured id (most shared leading hyphen-tokens) over raw size, so
  `gemma-4-12b-it` resolves to `gemma-4-12b-it-ud-q4-k-xl` rather than a
  larger unrelated chat model. Size-based selection is retained only when
  no candidate shares a leading token (legacy behaviour preserved).

**`registry/discover.py` (defence in depth):**
- `_guess_capability()` now classifies clearly-diffusion media
  (`ltx`/`wan`/`cogvideo`/`svd`/... → `video`;
  `sdxl`/`flux`/`stable-diffusion` → `image`) instead of the `chat`
  default, keeping these out of the chat fallback pool at the source. The
  fallback's own guard remains the must-have backstop.

## Tests

`tests/slots/test_model_fallback.py` extended (8 → 14): ghost chat slot
with a video model present must NOT pick the video model; only-video means
no fallback at all; `.safetensors` / `image`-capability candidates
excluded; name-similarity beats a larger unrelated chat model; size
tie-break preserved when nothing is similar.

`tests/registry/test_discover.py` extended: diffusion-media filenames
classify as `image`/`video`, plain chat still `chat`.

```
401 passed   (tests/slots/ + tests/registry/)
ruff format: clean    ruff check: All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)