### PR TITLE
feat: privileged seam for unprivileged hal0-api (D hardened-perms)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -676,6 +676,39 @@ if [[ -f "${AGENT_UNIT_SRC}" ]]; then
     else
         warn "${GUARD_SRC} not found — run-as-hal0 guard not installed"
     fi
+
+    # Privileged seam (D hardened-perms): hal0-slotctl is the entire root
+    # surface an UNPRIVILEGED hal0-api needs — write/remove the per-slot unit
+    # and run systemctl on hal0-slot@<name>. It MUST land at the absolute
+    # /usr/lib/hal0/bin path the provider's _HAL0_SLOTCTL default hardcodes
+    # (dev mode shadows it under PREFIX/usr/lib/hal0). The matching sudoers
+    # drop-in below grants only `hal0 -> hal0-slotctl`, no wildcards.
+    SLOTCTL_SRC="${REPO_ROOT}/installer/wrappers/hal0-slotctl"
+    if [[ -f "${SLOTCTL_SRC}" ]]; then
+        install -d "${LIB_DIR}/bin"
+        install -m 0755 "${SLOTCTL_SRC}" "${LIB_DIR}/bin/hal0-slotctl"
+        info "wrote ${LIB_DIR}/bin/hal0-slotctl"
+    else
+        warn "${SLOTCTL_SRC} not found — privileged seam helper not installed"
+    fi
+
+    # sudoers grant for the seam. Real installs only (dev mode never touches
+    # /etc/sudoers.d). visudo-validate before activating so a malformed drop-in
+    # can never wedge sudo for the box.
+    if [[ "${DEV_MODE}" -eq 0 ]]; then
+        SLOTCTL_SUDOERS_SRC="${REPO_ROOT}/packaging/sudoers/hal0-slotctl"
+        SLOTCTL_SUDOERS_DST="/etc/sudoers.d/hal0-slotctl"
+        if [[ -f "${SLOTCTL_SUDOERS_SRC}" ]]; then
+            if visudo -cf "${SLOTCTL_SUDOERS_SRC}" >/dev/null 2>&1; then
+                install -m 0440 "${SLOTCTL_SUDOERS_SRC}" "${SLOTCTL_SUDOERS_DST}"
+                info "wrote ${SLOTCTL_SUDOERS_DST}"
+            else
+                warn "${SLOTCTL_SUDOERS_SRC} failed visudo check — slotctl sudoers grant not installed"
+            fi
+        else
+            warn "${SLOTCTL_SUDOERS_SRC} not found — slotctl sudoers grant not installed"
+        fi
+    fi
 else
     warn "${AGENT_UNIT_SRC} not found — hal0-agent@ template not installed"
 fi

--- a/installer/wrappers/hal0-slotctl
+++ b/installer/wrappers/hal0-slotctl
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Privileged seam for the unprivileged hal0-api: only ever touches hal0-slot@<name>.
+#
+# Background (D hardened-perms): hal0-api can run as the unprivileged `hal0`
+# system user while the per-slot podman containers stay rootful (the container
+# IS the sandbox boundary). The only two root operations the orchestrator
+# needs are (a) writing the per-slot unit under /etc/systemd/system and (b)
+# running systemctl on hal0-slot@<name>. Everything else stays unprivileged.
+#
+# This script is the entire privileged surface. The slot-name regex below is a
+# security requirement: it rejects path traversal (../), shell metacharacters
+# (;, &, |), and anything that is not a literal slot name, so the grant in
+# /etc/sudoers.d/hal0-slotctl can never be widened into arbitrary unit control.
+set -euo pipefail
+cmd="${1:-}"; slot="${2:-}"
+[[ "$slot" =~ ^[a-z0-9_-]+$ ]] || { echo "hal0-slotctl: bad slot name" >&2; exit 2; }
+unit="hal0-slot@${slot}.service"
+case "$cmd" in
+  write-unit)  umask 022; cat > "/etc/systemd/system/${unit}"; systemctl daemon-reload ;;   # unit text on stdin
+  remove-unit) rm -f "/etc/systemd/system/${unit}"; systemctl daemon-reload ;;
+  start|stop|restart|enable|disable) systemctl "$cmd" "$unit" ;;
+  reload) systemctl daemon-reload ;;
+  *) echo "hal0-slotctl: bad cmd: ${cmd}" >&2; exit 2 ;;
+esac

--- a/packaging/sudoers/hal0-slotctl
+++ b/packaging/sudoers/hal0-slotctl
@@ -1,0 +1,17 @@
+# hal0 — privileged seam grant for an UNPRIVILEGED hal0-api (D hardened-perms).
+#
+# When hal0-api runs as the `hal0` system user, it cannot write per-slot units
+# under /etc/systemd/system or run systemctl on hal0-slot@<name>. It delegates
+# exactly those two root operations to /usr/lib/hal0/bin/hal0-slotctl, which is
+# the entire privileged surface: the helper validates the slot name and only
+# ever touches hal0-slot@<name>.service — no wildcards, no shell, no arbitrary
+# unit control.
+#
+# Install (as root):
+#   install -m 0440 packaging/sudoers/hal0-slotctl /etc/sudoers.d/hal0-slotctl
+#   visudo -cf /etc/sudoers.d/hal0-slotctl
+#
+# Keep this grant pinned to the helper binary; broad systemctl access would let
+# the API control arbitrary services.
+
+hal0 ALL=(root) NOPASSWD: /usr/lib/hal0/bin/hal0-slotctl

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -39,6 +39,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import os
 import shlex
 import shutil
 import subprocess
@@ -108,6 +109,12 @@ log = logging.getLogger(__name__)
 # template.  Writing a complete file means the manager never has to
 # know whether the base exists.
 _SYSTEMD_SYSTEM_DIR = Path("/etc/systemd/system")
+# Privileged seam (D hardened-perms): when hal0-api runs as the unprivileged
+# `hal0` user it cannot write per-slot units or run systemctl on hal0-slot@.
+# It delegates exactly those two root operations to this helper, invoked via
+# `sudo -n`. Overridable so tests can point at a stub. Routing is gated on
+# os.geteuid() != 0 — running as root keeps today's direct path unchanged.
+_HAL0_SLOTCTL = os.environ.get("HAL0_SLOTCTL", "/usr/lib/hal0/bin/hal0-slotctl")
 # Back-compat alias for the historic default. The *effective* mount root is
 # resolved per-render via model_store_root() ([models].store / HAL0_MODEL_STORE
 # / this default) so a custom model directory actually reaches the container.
@@ -123,9 +130,6 @@ def _container_runtime() -> str:
     Priority: $HAL0_CONTAINER_RUNTIME > /usr/bin/podman > /usr/bin/docker.
     Raises RuntimeError if neither is found.
     """
-    import os
-    import shutil
-
     override = os.environ.get("HAL0_CONTAINER_RUNTIME")
     if override:
         return override
@@ -617,6 +621,27 @@ class ContainerProvider(Provider):
         """Run a subprocess synchronously (load/unload are blocking ops anyway)."""
         return subprocess.run(list(args), capture_output=True, text=True, check=check)
 
+    def _privileged(
+        self, verb: str, slot_name: str, *, stdin: str | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        """Run a hal0-slotctl verb via the privileged seam (D hardened-perms).
+
+        When the API runs as the unprivileged ``hal0`` user (euid != 0) the
+        verb is dispatched through ``sudo -n <_HAL0_SLOTCTL> <verb> <slot>``;
+        the helper does the actual root op (write-unit, remove-unit, the
+        systemctl lifecycle verbs, or reload). ``stdin`` carries the unit text
+        for ``write-unit``. This method is only ever called from the non-root
+        branches — the root path keeps the historic direct ``write_text`` /
+        ``systemctl`` behavior, so there is no behavior change for euid == 0.
+        """
+        return subprocess.run(
+            ["sudo", "-n", _HAL0_SLOTCTL, verb, slot_name],
+            input=stdin,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
     async def health(self, port: int) -> dict[str, Any]:
         """Probe GET /health on the container port.
 
@@ -700,11 +725,19 @@ class ContainerProvider(Provider):
             "container.unit_write",
             extra={"slot": slot_name, "unit_path": str(unit_path)},
         )
-        unit_path.write_text(unit_text)
-        self._run("systemctl", "daemon-reload")
-        # Enable so it survives reboots (best-effort — don't fail if already enabled).
-        self._run("systemctl", "enable", self._unit_name(slot_name), check=False)
-        self._run("systemctl", "restart", self._unit_name(slot_name))
+        if os.geteuid() == 0:
+            unit_path.write_text(unit_text)
+            self._run("systemctl", "daemon-reload")
+            # Enable so it survives reboots (best-effort — don't fail if already enabled).
+            self._run("systemctl", "enable", self._unit_name(slot_name), check=False)
+            self._run("systemctl", "restart", self._unit_name(slot_name))
+        else:
+            # Unprivileged hal0-api: write-unit writes the file + daemon-reload
+            # through the seam; enable/restart go through the same helper.
+            self._privileged("write-unit", slot_name, stdin=unit_text)
+            with contextlib.suppress(subprocess.CalledProcessError):
+                self._privileged("enable", slot_name)
+            self._privileged("restart", slot_name)
         log.info(
             "container.unit_started",
             extra={"slot": slot_name, "unit": self._unit_name(slot_name)},
@@ -787,14 +820,24 @@ class ContainerProvider(Provider):
         slot_name: str = str(slot_cfg.get("name", ""))
         unit = self._unit_name(slot_name)
         log.info("container.unit_stop", extra={"slot": slot_name, "unit": unit})
-        self._run("systemctl", "stop", unit, check=False)
-        # Disable so it doesn't re-start on reboot.
-        self._run("systemctl", "disable", unit, check=False)
-        # Remove unit file so daemon-reload leaves no stale entry.
-        unit_path = self._unit_path(slot_name)
-        if unit_path.exists():
-            unit_path.unlink()
-            self._run("systemctl", "daemon-reload")
+        if os.geteuid() == 0:
+            self._run("systemctl", "stop", unit, check=False)
+            # Disable so it doesn't re-start on reboot.
+            self._run("systemctl", "disable", unit, check=False)
+            # Remove unit file so daemon-reload leaves no stale entry.
+            unit_path = self._unit_path(slot_name)
+            if unit_path.exists():
+                unit_path.unlink()
+                self._run("systemctl", "daemon-reload")
+        else:
+            # Unprivileged hal0-api: stop/disable through the seam (best-effort,
+            # the unit may already be gone), then remove-unit does the unlink +
+            # daemon-reload in one root op.
+            with contextlib.suppress(subprocess.CalledProcessError):
+                self._privileged("stop", slot_name)
+            with contextlib.suppress(subprocess.CalledProcessError):
+                self._privileged("disable", slot_name)
+            self._privileged("remove-unit", slot_name)
 
     def is_active(self, slot_name: str) -> bool:
         """Return True if the systemd unit is in an active state."""

--- a/tests/providers/conftest.py
+++ b/tests/providers/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixtures for the container-provider test suite.
+
+The privileged seam (D hardened-perms) routes unit writes + systemctl through
+``sudo -n hal0-slotctl`` only when ``os.geteuid() != 0``. Every pre-existing
+provider test was written for the **root** (direct) path — it mocks
+``self._run`` and writes the unit into a tmp dir, assuming euid == 0. CI runs
+pytest as a non-root user, so without this fixture those tests would fall into
+the seam branch and make a real ``sudo`` call.
+
+Default every test in this package to the root path by patching
+``hal0.providers.container.os.geteuid`` to return 0. The dedicated seam test
+(``test_container_privileged_seam.py``) patches the *same* target to a non-zero
+value inside each ``with`` block, which nests correctly and overrides this
+autouse default for the duration of that block.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from hal0.providers import container as container_mod
+
+
+@pytest.fixture(autouse=True)
+def _euid_root_by_default():
+    """Run provider tests as if euid == 0 (the unchanged direct path)."""
+    with patch.object(container_mod.os, "geteuid", return_value=0):
+        yield

--- a/tests/providers/test_container_privileged_seam.py
+++ b/tests/providers/test_container_privileged_seam.py
@@ -1,0 +1,176 @@
+"""Tests for the privileged seam (D hardened-perms).
+
+When hal0-api runs as the unprivileged ``hal0`` user (euid != 0) the container
+provider must route the two root operations — writing the per-slot unit +
+daemon-reload, and running systemctl on hal0-slot@<name> — through
+``sudo -n <_HAL0_SLOTCTL> <verb> <slot>`` instead of touching
+/etc/systemd/system or calling systemctl directly.
+
+When running as root (euid == 0) the behavior is unchanged: the unit file is
+written with ``write_text`` and the systemctl verbs go through ``_run``. These
+tests pin both branches so the seam stays a no-op for root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from hal0.providers import container as container_mod
+from hal0.providers.container import ContainerProvider
+
+_STUB_SLOTCTL = "/stub/hal0-slotctl"
+
+
+def _ok() -> MagicMock:
+    m = MagicMock()
+    m.returncode = 0
+    return m
+
+
+# ── non-root (euid != 0): everything routes through sudo hal0-slotctl ────────
+
+
+def test_load_path_uses_sudo_slotctl_when_unprivileged(tmp_path: Path) -> None:
+    """Load writes the unit + restarts via the seam, never touching disk/_run."""
+    slot_name = "chat"
+    provider = ContainerProvider()
+    unit_path = tmp_path / f"hal0-slot@{slot_name}.service"
+    unit_text = "[Unit]\nDescription=test\n"
+
+    priv_calls: list[tuple[list[str], str | None]] = []
+
+    def fake_subprocess_run(argv, *, input=None, **kwargs):
+        priv_calls.append((list(argv), input))
+        return _ok()
+
+    run_calls: list[list[str]] = []
+
+    def fake_run(*args: str, check: bool = True) -> MagicMock:
+        run_calls.append(list(args))
+        return _ok()
+
+    with (
+        patch.object(container_mod.os, "geteuid", return_value=1000),
+        patch.object(container_mod, "_HAL0_SLOTCTL", _STUB_SLOTCTL),
+        patch.object(container_mod.subprocess, "run", side_effect=fake_subprocess_run),
+        patch.object(provider, "_run", side_effect=fake_run),
+        patch.object(provider, "_unit_path", return_value=unit_path),
+    ):
+        provider._write_and_start_unit(slot_name, unit_text)
+
+    # No direct systemctl via _run, and the unit file was NOT written to disk.
+    assert run_calls == [], f"unprivileged path must not use _run directly: {run_calls}"
+    assert not unit_path.exists(), "unprivileged path must not write the unit file directly"
+
+    cmds = [argv for argv, _ in priv_calls]
+    # write-unit carries the unit text on stdin.
+    write = [(argv, stdin) for argv, stdin in priv_calls if "write-unit" in argv]
+    assert write, f"expected a write-unit seam call; got {cmds}"
+    write_argv, write_stdin = write[0]
+    assert write_argv == ["sudo", "-n", _STUB_SLOTCTL, "write-unit", slot_name]
+    assert write_stdin == unit_text, "unit text must be piped to write-unit"
+
+    # enable + restart routed through the seam with the bare slot name.
+    assert ["sudo", "-n", _STUB_SLOTCTL, "enable", slot_name] in cmds
+    assert ["sudo", "-n", _STUB_SLOTCTL, "restart", slot_name] in cmds
+
+
+def test_unload_path_uses_remove_unit_when_unprivileged(tmp_path: Path) -> None:
+    """Teardown stops/disables + remove-units via the seam, never _run/unlink."""
+    slot_name = "chat"
+    provider = ContainerProvider()
+    unit_path = tmp_path / f"hal0-slot@{slot_name}.service"
+    unit_path.write_text("[Unit]\nDescription=stale\n")
+
+    priv_calls: list[list[str]] = []
+
+    def fake_subprocess_run(argv, *, input=None, **kwargs):
+        priv_calls.append(list(argv))
+        return _ok()
+
+    run_calls: list[list[str]] = []
+
+    def fake_run(*args: str, check: bool = True) -> MagicMock:
+        run_calls.append(list(args))
+        return _ok()
+
+    with (
+        patch.object(container_mod.os, "geteuid", return_value=1000),
+        patch.object(container_mod, "_HAL0_SLOTCTL", _STUB_SLOTCTL),
+        patch.object(container_mod.subprocess, "run", side_effect=fake_subprocess_run),
+        patch.object(provider, "_run", side_effect=fake_run),
+        patch.object(provider, "_unit_path", return_value=unit_path),
+    ):
+        provider.unload_sync({"name": slot_name})
+
+    assert run_calls == [], f"unprivileged teardown must not use _run directly: {run_calls}"
+    # remove-unit owns the file removal; the provider must not unlink it itself.
+    assert ["sudo", "-n", _STUB_SLOTCTL, "stop", slot_name] in priv_calls
+    assert ["sudo", "-n", _STUB_SLOTCTL, "disable", slot_name] in priv_calls
+    assert ["sudo", "-n", _STUB_SLOTCTL, "remove-unit", slot_name] in priv_calls
+
+
+# ── root (euid == 0): unchanged direct path ──────────────────────────────────
+
+
+def test_load_path_direct_when_root(tmp_path: Path) -> None:
+    """As root the unit is written with write_text and systemctl goes via _run."""
+    slot_name = "chat"
+    provider = ContainerProvider()
+    unit_path = tmp_path / f"hal0-slot@{slot_name}.service"
+    unit_text = "[Unit]\nDescription=test\n"
+
+    run_calls: list[list[str]] = []
+
+    def fake_run(*args: str, check: bool = True) -> MagicMock:
+        run_calls.append(list(args))
+        return _ok()
+
+    # If the seam were ever used as root this would fire and fail the test.
+    def boom_subprocess_run(*a, **k):
+        raise AssertionError("root path must not invoke subprocess.run (the seam)")
+
+    with (
+        patch.object(container_mod.os, "geteuid", return_value=0),
+        patch.object(container_mod.subprocess, "run", side_effect=boom_subprocess_run),
+        patch.object(provider, "_run", side_effect=fake_run),
+        patch.object(provider, "_unit_path", return_value=unit_path),
+    ):
+        provider._write_and_start_unit(slot_name, unit_text)
+
+    # Unit file written directly to disk.
+    assert unit_path.read_text() == unit_text
+    cmds = [" ".join(c) for c in run_calls]
+    assert any("daemon-reload" in c for c in cmds), cmds
+    assert any(c == f"systemctl restart {provider._unit_name(slot_name)}" for c in cmds), cmds
+
+
+def test_unload_path_direct_when_root(tmp_path: Path) -> None:
+    """As root teardown unlinks the unit and uses _run for systemctl."""
+    slot_name = "chat"
+    provider = ContainerProvider()
+    unit_path = tmp_path / f"hal0-slot@{slot_name}.service"
+    unit_path.write_text("[Unit]\nDescription=stale\n")
+
+    run_calls: list[list[str]] = []
+
+    def fake_run(*args: str, check: bool = True) -> MagicMock:
+        run_calls.append(list(args))
+        return _ok()
+
+    def boom_subprocess_run(*a, **k):
+        raise AssertionError("root teardown must not invoke subprocess.run (the seam)")
+
+    with (
+        patch.object(container_mod.os, "geteuid", return_value=0),
+        patch.object(container_mod.subprocess, "run", side_effect=boom_subprocess_run),
+        patch.object(provider, "_run", side_effect=fake_run),
+        patch.object(provider, "_unit_path", return_value=unit_path),
+    ):
+        provider.unload_sync({"name": slot_name})
+
+    assert not unit_path.exists(), "root teardown should unlink the unit file directly"
+    cmds = [" ".join(c) for c in run_calls]
+    assert any("systemctl stop" in c for c in cmds), cmds
+    assert any("daemon-reload" in c for c in cmds), cmds


### PR DESCRIPTION
## Why

Foundation for the **D hardened-perms** redesign: run `hal0-api` as the unprivileged `hal0` user while the per-slot podman containers stay **rootful** (the container is the sandbox boundary). A rehearsal proved rootless podman can't run in the LXC nodes (nested-userns proc-mount denied), but `hal0-slot@<name>.service` units run podman as **root** regardless of who calls `systemctl`. So the orchestrator only needs to delegate **two** root operations:

1. writing the per-slot unit file under `/etc/systemd/system`
2. running `systemctl` on `hal0-slot@*`

This PR adds that delegation seam. It is **a no-op when running as root** (`euid == 0` keeps today's exact `write_text` + `systemctl` behavior) and only routes through the seam when `euid != 0`, so it is safe to merge **before** the actual `User=hal0` flip.

## What

- **`installer/wrappers/hal0-slotctl`** (→ `/usr/lib/hal0/bin/hal0-slotctl`, 0755, root-owned): the entire privileged surface. A slot-name regex guard (`^[a-z0-9_-]+$`) rejects `../`, `;`, and other metacharacters before any fs/systemctl op — a security requirement so the sudoers grant can never be widened into arbitrary unit control. Verbs: `write-unit` (stdin → file + daemon-reload), `remove-unit` (rm + daemon-reload), `start|stop|restart|enable|disable`, `reload`.
- **`packaging/sudoers/hal0-slotctl`** (→ `/etc/sudoers.d/hal0-slotctl`, 0440): pinned `hal0 ALL=(root) NOPASSWD: /usr/lib/hal0/bin/hal0-slotctl` — no wildcards. Installer `visudo -cf`-validates before activating.
- **`installer/install.sh`**: installs the helper (0755) under `/usr/lib/hal0/bin` and the sudoers drop-in (0440, visudo-checked). Idempotent, non-interactive, real-installs only (dev mode never touches `/etc/sudoers.d`).
- **`src/hal0/providers/container.py`**: euid-gated routing via a small `_privileged(verb, slot, *, stdin=None)` helper and an overridable `_HAL0_SLOTCTL` constant (`HAL0_SLOTCTL` env override for tests).
  - `_write_and_start_unit`: root → `write_text` + `daemon-reload` + `enable` + `restart` (unchanged); non-root → `write-unit` (text on stdin) + `enable` + `restart` through the seam.
  - `unload_sync`: root → `stop`/`disable`/`unlink`+`daemon-reload` (unchanged); non-root → `stop`/`disable` + `remove-unit` through the seam.
  - `is-active` stays **direct** (read-only — non-root can query it; not routed through sudo).

## euid routing

`os.geteuid() == 0` selects the existing direct path everywhere; the `else` branch dispatches `["sudo", "-n", _HAL0_SLOTCTL, verb, slot]` (unit text piped via stdin for `write-unit`). Lifecycle verbs that are best-effort today (`enable`, and `stop`/`disable` on teardown) suppress `CalledProcessError` in the seam path to match the prior `check=False` semantics.

## Tests

`tests/providers/test_container_privileged_seam.py` pins both branches: with `os.geteuid` monkeypatched non-zero and `subprocess.run` stubbed, the load path invokes `sudo … hal0-slotctl write-unit <slot>` (with the unit text on stdin) plus the right verbs, the teardown path invokes `remove-unit`, and neither touches disk nor `_run`; with `euid == 0` it uses the direct `write_text` + `systemctl` path and never invokes the seam.

- `tests/providers/` — 270 passed (incl. 4 new)
- `ruff check src tests` — clean; `ruff format` — clean
- `bash -n` on `install.sh` and `hal0-slotctl` — clean
- helper smoke-tested: slot-name guard rejects `../etc/passwd` and `chat;rm` (exit 2), bad cmd rejected (exit 2), good verbs dispatch correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)