### PR TITLE
feat(install): codify D hardened-perms flip behind HAL0_USER

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -609,6 +609,31 @@ WantedBy=multi-user.target
 EOF
 info "wrote ${API_UNIT}"
 
+# D hardened-perms flip (gated on HAL0_USER != root). The base unit above
+# already substitutes `User=${HAL0_USER}` inline; this drop-in re-asserts it and
+# adds the matching `Group=` (the generated unit carries no Group= line) so the
+# dropped daemon's group on the shared setgid /etc/hal0 + /var/lib/hal0 trees is
+# deterministic. With the default HAL0_USER=root the drop-in is NOT installed, so
+# existing root installs are byte-for-byte unchanged. The privileged seam
+# (PR #943) is what lets the unprivileged daemon still manage slots.
+API_DROPIN_SRC="${REPO_ROOT}/installer/systemd/hal0-api.service.d/20-run-as-hal0.conf"
+API_DROPIN_DST_DIR="${UNIT_DIR}/hal0-api.service.d"
+if [[ "${HAL0_USER}" != "root" ]]; then
+    if [[ -f "${API_DROPIN_SRC}" ]]; then
+        mkdir -p "${API_DROPIN_DST_DIR}"
+        sed "s/__HAL0_USER__/${HAL0_USER}/g" "${API_DROPIN_SRC}" \
+            > "${API_DROPIN_DST_DIR}/20-run-as-hal0.conf"
+        info "wrote ${API_DROPIN_DST_DIR}/20-run-as-hal0.conf (run hal0-api as ${HAL0_USER})"
+    else
+        warn "${API_DROPIN_SRC} not found — hal0-api run-as drop-in not installed"
+    fi
+else
+    # Idempotent downgrade path: if a previous flip wrote the drop-in but this
+    # run is back on root, drop it so the unit reverts cleanly to User=root.
+    rm -f "${API_DROPIN_DST_DIR}/20-run-as-hal0.conf" 2>/dev/null || true
+    rmdir "${API_DROPIN_DST_DIR}" 2>/dev/null || true
+fi
+
 OPENWEBUI_UNIT_SRC="${REPO_ROOT}/packaging/systemd/hal0-openwebui.service"
 OPENWEBUI_UNIT_DST="${UNIT_DIR}/hal0-openwebui.service"
 # pin per release (#79) — single source of truth for the OpenWebUI image
@@ -1131,6 +1156,71 @@ else
     chmod 2775 "${VAR_DIR}"
     touch "${VAR_DIR}/STATE.md"
     chown hal0:hal0 "${VAR_DIR}/STATE.md"
+
+    # ── D hardened-perms flip (gated on HAL0_USER != root) ────────────────────
+    # When hal0-api runs unprivileged, /etc/hal0 + its mutable contents must be
+    # owned by the service user so the daemon's atomic temp-file+rename rewrites
+    # (slots/*.toml, capabilities.toml, hal0.toml, api.env, chat-templates,
+    # profiles.toml) succeed — rename needs *directory* write, not just file
+    # write. This mirrors src/hal0/install/perms.py::ownership_table(
+    # service_user=...) exactly: the config root is setgid 2775 so the shared
+    # hal0 group keeps write; agents/ + secrets/ stay root:root (the API only
+    # reads agents/, and systemd reads the secrets/ EnvironmentFile AS ROOT
+    # before dropping to ${HAL0_USER}). With HAL0_USER=root this whole block is
+    # skipped, so existing installs are unchanged. Idempotent: chown/chmod
+    # converge to the same state on every re-run.
+    if [[ "${HAL0_USER}" != "root" ]]; then
+        info "hardened-perms flip: chowning config + state to ${HAL0_USER}"
+
+        # /etc/hal0 config root + its mutable files -> ${HAL0_USER}:hal0, dir
+        # setgid 2775. We chown only the dir and the known mutable seed files
+        # (NOT agents/ or secrets/, handled below) so a stray root-owned file
+        # under /etc/hal0 is left for `hal0 doctor perms` to surface.
+        chown "${HAL0_USER}:hal0" "${ETC_DIR}"
+        chmod 2775 "${ETC_DIR}"
+        chown "${HAL0_USER}:hal0" "${ETC_DIR}/slots"
+        chmod 2775 "${ETC_DIR}/slots"
+        # slots/*.toml + the flat config seeds — only those that exist.
+        for _f in \
+            "${ETC_DIR}"/slots/*.toml \
+            "${ETC_DIR}/hal0.toml" \
+            "${ETC_DIR}/profiles.toml" \
+            "${ETC_DIR}/api.env" \
+            "${ETC_DIR}/capabilities.toml" \
+            "${ETC_DIR}/upstreams.toml" \
+            "${ETC_DIR}/hardware.json" \
+            "${ETC_DIR}/openwebui.env"; do
+            [[ -e "${_f}" ]] && chown "${HAL0_USER}:hal0" "${_f}"
+        done
+
+        # agents/ + secrets/ pinned root:root even under the flip (re-assert in
+        # case a prior run flipped them, keeping the block self-correcting).
+        if [[ -d "${ETC_DIR}/agents" ]]; then
+            chown root:root "${ETC_DIR}/agents"
+        fi
+        if [[ -d "${VAR_DIR}/secrets" ]]; then
+            chown root:root "${VAR_DIR}/secrets"
+        fi
+
+        # /var/lib/hal0 state root + HERMES_HOME -> service-owned. VAR_DIR was
+        # already chgrp hal0 + chmod 2775 above; flip the owner too so the
+        # unprivileged daemon owns the state root (registry/, slots/, cache/).
+        chown "${HAL0_USER}:hal0" "${VAR_DIR}"
+        if [[ -d "${VAR_DIR}/.hermes" ]]; then
+            chown "${HAL0_USER}:hal0" "${VAR_DIR}/.hermes"
+        fi
+
+        # Model store: root-owned but group-writable so the daemon can create
+        # pull subdirs + chat-templates/. We do NOT chown the (huge) existing
+        # model files — they stay world-readable; only the store dir itself
+        # gets root:hal0 0775. MODELS_DIR may live outside VAR_DIR (e.g.
+        # /mnt/ai-models) per --models-dir / [models].pull_root.
+        if [[ -d "${MODELS_DIR}" ]]; then
+            chown root:hal0 "${MODELS_DIR}"
+            chmod 0775 "${MODELS_DIR}"
+            info "hardened-perms flip: ${MODELS_DIR} -> root:hal0 0775 (group-writable)"
+        fi
+    fi
 
 fi
 

--- a/installer/systemd/hal0-api.service.d/20-run-as-hal0.conf
+++ b/installer/systemd/hal0-api.service.d/20-run-as-hal0.conf
@@ -1,0 +1,22 @@
+# hal0-api run-as drop-in (D hardened-perms flip).
+#
+# Installed ONLY when the installer is run with HAL0_USER != root (the
+# hardened-perms flip). It drops hal0-api from root to the unprivileged
+# ${HAL0_USER} service account and pins its supplementary primary group to
+# the same name, mirroring the hal0-agent@ run-as pattern. The base unit
+# already substitutes `User=${HAL0_USER}` inline; this drop-in re-asserts it
+# AND adds the matching `Group=` (the generated base unit carries no Group=
+# line), so the daemon's group on the shared /etc/hal0 + /var/lib/hal0 setgid
+# trees is deterministic.
+#
+# The `__HAL0_USER__` token below is substituted by installer/install.sh at
+# write time (it is NOT a systemd specifier). With HAL0_USER=root this file is
+# never installed, so default (root) installs are unchanged.
+#
+# Prerequisite: the privileged seam (PR #943 — hal0-slotctl + sudoers +
+# container.py euid routing) is what lets the dropped daemon still manage slots
+# without being root.
+
+[Service]
+User=__HAL0_USER__
+Group=__HAL0_USER__

--- a/src/hal0/install/perms.py
+++ b/src/hal0/install/perms.py
@@ -14,17 +14,18 @@ deliberately: :class:`PermObservation` is the ownership analogue of
 content), :class:`OwnershipPlan` is the analogue of ``ChangeSet``, and
 :meth:`OwnershipStore.commit` rolls back exactly like ``SlotConfigStore.commit``.
 
-PHASE 0 (this change) is a **pure no-op**: :func:`ownership_table` encodes the
+With ``service_user="root"`` (the default) :func:`ownership_table` encodes the
 *current* root-era values, so ``plan()`` on a freshly-installed box reports
-nothing changed and ``commit()`` writes nothing. The point is to introduce the
-machinery + the single table + the ``doctor perms`` audit with zero behaviour
-change.
+nothing changed and ``commit()`` writes nothing — the machinery + single table +
+``doctor perms`` audit are a pure no-op for existing installs.
 
-PHASE 4 (later) flips the values to the hardened model (overhaul plan §5:
-``/etc/hal0`` becomes ``root:hal0 0750`` read-only seed, ``hal0-api`` drops to
-``User=hal0``, mutable state lives under ``/var/lib/hal0`` owned by the service
-user). That is a data-only edit to :func:`ownership_table` plus the
-``service_user`` flip — the machinery here does not change.
+THE HARDENED FLIP (``service_user != "root"``, gated behind the ``HAL0_USER``
+installer env) is a data-only change in :func:`ownership_table`: ``/etc/hal0``
+and its mutable contents become ``service_user``-owned (the config root setgid
+``2775`` so the daemon's temp-file+rename rewrites work), while ``agents/`` and
+``secrets/`` stay ``root:root``; ``hal0-api`` drops to ``User=hal0`` via an
+installer drop-in. The privileged seam from #943 is the prerequisite. The
+plan/commit/audit machinery here does not change.
 
 Design notes:
   - ``owner``/``group`` are resolved to uid/gid at *commit* time via
@@ -86,46 +87,84 @@ def ownership_table(
 ) -> list[PermRow]:
     """THE single source of truth for hal0 path ownership.
 
-    PHASE 0: ``service_user="root"`` reproduces the current on-disk root-era
-    layout, so applying it is a no-op. ``service_group`` is the shared ``hal0``
-    group that already owns ``/opt/hal0`` (setgid) and ``/var/lib/hal0``.
+    ``service_user="root"`` (the default) reproduces the current on-disk
+    root-era layout, so applying it is a no-op — existing installs are
+    untouched. ``service_group`` is the shared ``hal0`` group that already
+    owns ``/opt/hal0`` (setgid) and ``/var/lib/hal0``.
 
-    The values below are the *current* observed root-era values, intentionally —
-    including the warts (``api.env`` 0644, ``hal0.toml`` 0600). Those are flagged
-    for the phase-4 hardening pass, NOT changed here; Phase 0 changes mechanism,
-    not policy. See module docstring.
+    THE HARDENED FLIP (``service_user != "root"``, gated behind ``HAL0_USER``):
+    when the API runs as an unprivileged service user, ``/etc/hal0`` and its
+    *mutable* contents become ``service_user``-owned so the daemon can atomically
+    rewrite them (temp-file + ``rename``, which needs *directory* write — not
+    just file write). The config root itself is ``2775`` (setgid) so files the
+    service or the ``hal0`` group create there inherit the shared group. The
+    privileged seam from #943 (``hal0-slotctl`` + sudoers + ``container.py`` euid
+    routing) is the prerequisite that lets the dropped daemon still manage slots.
+
+    Two subtrees stay ``root:root`` even under the flip:
+      * ``agents/`` — the dashboard-only Hermes allow-list world (#843); the API
+        only reads it.
+      * ``secrets/`` — systemd reads ``EnvironmentFile`` here *as root* before
+        dropping to the service user, so it must not be service-writable.
+
+    The root-era values below are the *current* observed values, intentionally —
+    including the warts (``api.env`` 0644, ``hal0.toml`` 0600). Those are not
+    changed by the flip either; the flip changes *ownership*, not the file modes.
+    See module docstring.
     """
     etc = paths.etc()
     var_lib = paths.var_lib()
     var_log = paths.var_log()
+
+    # Whether to apply the hardened flip. When False, every row below is
+    # byte-identical to the root-era table (existing installs unchanged).
+    flipped = service_user != "root"
+    # Owner/group for the service-writable config surface. Under the flip the
+    # config root is setgid (2775) so the shared hal0 group keeps write across
+    # both daemon- and group-created files; root-era keeps the plain 0755 dir.
+    etc_owner = service_user if flipped else "root"
+    etc_group = service_group if flipped else "root"
+    etc_dir_mode = 0o2775 if flipped else 0o755
+    slots_dir_mode = 0o2775 if flipped else 0o755
+    # Slot/state runtime owner — already service-owned today (defaulting the
+    # root-era "root" service_user to the literal hal0 service account).
+    state_owner = service_user if flipped else "hal0"
+
     return [
-        # ── /etc/hal0 — config seed (root-owned today) ────────────────────────
-        PermRow(etc, "root", "root", 0o755, optional=False, role="/etc/hal0 (config root)"),
-        PermRow(paths.hal0_toml(), "root", "root", 0o600, role="hal0.toml"),
-        PermRow(etc / "profiles.toml", "root", "root", 0o600, role="profiles.toml"),
+        # ── /etc/hal0 — config seed (root-owned today; service-owned under flip) ─
+        # The API atomically rewrites slots/*.toml, capabilities.toml, hal0.toml,
+        # api.env and chat-templates via temp-file + rename, which needs *dir*
+        # write on /etc/hal0 — hence the dir (and its mutable files) flip to the
+        # service user. agents/ + secrets/ below stay root:root.
+        PermRow(
+            etc, etc_owner, etc_group, etc_dir_mode, optional=False, role="/etc/hal0 (config root)"
+        ),
+        PermRow(paths.hal0_toml(), etc_owner, etc_group, 0o600, role="hal0.toml"),
+        PermRow(etc / "profiles.toml", etc_owner, etc_group, 0o600, role="profiles.toml"),
         # FIXME(phase4): api.env is 0644 (world-readable) but may carry tokens —
         # candidate for 0640 root:hal0 under the hardened model.
-        PermRow(etc / "api.env", "root", "root", 0o644, role="api.env"),
-        PermRow(etc / "capabilities.toml", "root", "root", 0o600, role="capabilities.toml"),
-        PermRow(etc / "upstreams.toml", "root", "root", 0o644, role="upstreams.toml"),
-        PermRow(paths.hardware_json(), "root", "root", 0o644, role="hardware.json"),
-        PermRow(paths.openwebui_env(), "root", "root", 0o600, role="openwebui.env"),
+        PermRow(etc / "api.env", etc_owner, etc_group, 0o644, role="api.env"),
+        PermRow(etc / "capabilities.toml", etc_owner, etc_group, 0o600, role="capabilities.toml"),
+        PermRow(etc / "upstreams.toml", etc_owner, etc_group, 0o644, role="upstreams.toml"),
+        PermRow(paths.hardware_json(), etc_owner, etc_group, 0o644, role="hardware.json"),
+        PermRow(paths.openwebui_env(), etc_owner, etc_group, 0o600, role="openwebui.env"),
         PermRow(
             paths.slots_config_dir(),
-            "root",
-            "root",
-            0o755,
+            etc_owner,
+            etc_group,
+            slots_dir_mode,
             glob="*.toml",
-            child_mode=0o600,  # slots/*.toml are root:root 0600 on disk
+            child_mode=0o600,  # slots/*.toml are 0600 on disk (owner flips with the dir)
             optional=False,
             role="slots/ (+ *.toml)",
         ),
-        # agents/ is the dashboard-only Hermes world — pinned root:root (#843).
+        # agents/ is the dashboard-only Hermes world — pinned root:root (#843),
+        # under the flip too: the API only reads it.
         PermRow(paths.agents_config_dir(), "root", "root", 0o755, role="agents/"),
         # ── /var/lib/hal0 — mutable state (already service-owned) ──────────────
         PermRow(
             var_lib,
-            service_user if service_user != "root" else "hal0",
+            state_owner,
             service_group,
             0o2775,
             optional=False,
@@ -133,13 +172,14 @@ def ownership_table(
         ),
         PermRow(
             paths.var_lib() / ".hermes",
-            service_user if service_user != "root" else "hal0",
+            state_owner,
             service_group,
             0o700,
             role="HERMES_HOME",
         ),
-        # secrets/ is root:root today; hardened model moves runtime-rotatable
-        # creds here as hal0:hal0 0600 (phase-4 decision #6).
+        # secrets/ stays root:root even under the flip: systemd reads the
+        # EnvironmentFile here AS ROOT before dropping to the service user, so it
+        # must not be service-writable (hardened-model decision).
         PermRow(var_lib / "secrets", "root", "root", 0o755, role="secrets/"),
         # ── /var/log/hal0 ─────────────────────────────────────────────────────
         PermRow(var_log, "hal0", "hal0", 0o755, role="/var/log/hal0"),

--- a/tests/install/test_perms.py
+++ b/tests/install/test_perms.py
@@ -175,3 +175,92 @@ def test_ownership_table_builds_under_hal0_home(tmp_hal0_home: str) -> None:
     targets = {r.target for r in table}
     assert paths.etc() in targets
     assert paths.slots_config_dir() in targets
+
+
+# ── the D hardened-perms flip (service_user != root) ──────────────────────────
+
+
+def _by_target(table: list[perms.PermRow]) -> dict[Path, perms.PermRow]:
+    return {r.target: r for r in table}
+
+
+def test_root_table_is_unchanged_by_the_flip(tmp_hal0_home: str) -> None:
+    """service_user="root" must reproduce the byte-identical root-era table.
+
+    Existing root installs must not move a single bit when the flip code lands.
+    """
+    rows = _by_target(perms.ownership_table(service_user="root"))
+    etc = paths.etc()
+    # /etc/hal0 + every mutable seed stays root:root with the legacy modes.
+    assert (rows[etc].owner, rows[etc].group, rows[etc].mode) == ("root", "root", 0o755)
+    assert rows[paths.hal0_toml()].owner == "root"
+    assert rows[paths.hal0_toml()].group == "root"
+    slots = rows[paths.slots_config_dir()]
+    assert (slots.owner, slots.group, slots.mode) == ("root", "root", 0o755)
+    assert slots.child_mode == 0o600
+    # agents/ + secrets/ root:root; state root defaults to the literal hal0 acct.
+    assert rows[paths.agents_config_dir()].owner == "root"
+    assert rows[paths.var_lib() / "secrets"].owner == "root"
+    assert rows[paths.var_lib()].owner == "hal0"
+
+
+def test_flip_makes_etc_hal0_service_owned_and_setgid(tmp_hal0_home: str) -> None:
+    """service_user="hal0" hands /etc/hal0 + its mutable contents to the daemon.
+
+    The config root (and slots/) go service-owned + setgid 2775 so the daemon's
+    temp-file+rename rewrites work; the flat seed files become service-owned too.
+    """
+    rows = _by_target(perms.ownership_table(service_user="hal0"))
+    etc = paths.etc()
+    assert (rows[etc].owner, rows[etc].group, rows[etc].mode) == ("hal0", "hal0", 0o2775)
+    # slots dir flips to setgid + service-owned; children keep 0600.
+    slots = rows[paths.slots_config_dir()]
+    assert (slots.owner, slots.group, slots.mode) == ("hal0", "hal0", 0o2775)
+    assert slots.child_mode == 0o600
+    # the mutable flat seeds the API rewrites all flip to hal0; modes unchanged.
+    for target in (
+        paths.hal0_toml(),
+        etc / "profiles.toml",
+        etc / "api.env",
+        etc / "capabilities.toml",
+        etc / "upstreams.toml",
+        paths.hardware_json(),
+        paths.openwebui_env(),
+    ):
+        assert rows[target].owner == "hal0", target
+        assert rows[target].group == "hal0", target
+    # mode warts are NOT touched by the flip (ownership only).
+    assert rows[paths.hal0_toml()].mode == 0o600
+    assert rows[etc / "api.env"].mode == 0o644
+
+
+def test_flip_keeps_agents_and_secrets_root_owned(tmp_hal0_home: str) -> None:
+    """agents/ + secrets/ must stay root:root even under the flip.
+
+    The API only reads agents/; systemd reads the secrets/ EnvironmentFile as
+    root before dropping to the service user, so neither may be service-writable.
+    """
+    rows = _by_target(perms.ownership_table(service_user="hal0"))
+    agents = rows[paths.agents_config_dir()]
+    assert (agents.owner, agents.group) == ("root", "root")
+    secrets = rows[paths.var_lib() / "secrets"]
+    assert (secrets.owner, secrets.group) == ("root", "root")
+
+
+def test_flip_makes_state_root_service_owned(tmp_hal0_home: str) -> None:
+    """/var/lib/hal0 + HERMES_HOME flip to the service user under the flip."""
+    rows = _by_target(perms.ownership_table(service_user="hal0"))
+    state = rows[paths.var_lib()]
+    assert (state.owner, state.group, state.mode) == ("hal0", "hal0", 0o2775)
+    hermes = rows[paths.var_lib() / ".hermes"]
+    assert (hermes.owner, hermes.group, hermes.mode) == ("hal0", "hal0", 0o700)
+
+
+def test_flip_honors_custom_service_group(tmp_hal0_home: str) -> None:
+    """A non-default service_group threads through the service-owned rows."""
+    rows = _by_target(perms.ownership_table(service_user="svc", service_group="svcgrp"))
+    etc = paths.etc()
+    assert (rows[etc].owner, rows[etc].group) == ("svc", "svcgrp")
+    assert rows[paths.var_lib()].group == "svcgrp"
+    # pinned-root rows ignore the service group.
+    assert rows[paths.agents_config_dir()].group == "root"


### PR DESCRIPTION
## What

Turns the manually-validated **D hardened-perms flip** — running `hal0-api` as the unprivileged `hal0` user instead of root — into installer + perms code. This was already proven end-to-end on a staging box; this PR codifies the steps.

## Gating: `HAL0_USER` (default `root`)

The whole flip is gated behind the existing `HAL0_USER` installer env:

- **`HAL0_USER=root` (default)** → behaviour is **byte-for-byte identical to today**. The perms table reproduces the current root-era ownership, the run-as drop-in is *not* installed, and no extra chowns run. Existing installs do not move a bit.
- **`HAL0_USER=hal0`** → the flip is applied.

## The validated ownership model (applied when `service_user != root`)

- `/etc/hal0` → `hal0:hal0`, dir setgid **2775**, plus its **mutable** contents (`slots/*.toml`, `capabilities.toml`, `hal0.toml`, `api.env`, `upstreams.toml`, `profiles.toml`, `hardware.json`, `openwebui.env`).
  - **Why service-writable, not read-only?** `hal0-api` rewrites these atomically (temp-file + `rename`), and `rename` needs **directory** write — not just file write. Setgid keeps the shared `hal0` group on anything the daemon or group creates. File *modes* are unchanged (the flip changes ownership, not the 0644/0600 warts).
- `/etc/hal0/agents` and `/etc/hal0/secrets` → **stay `root:root`** even under the flip. The API only *reads* `agents/`; systemd reads the `secrets/` `EnvironmentFile` **as root** before dropping to the service user, so neither may be service-writable.
- `/var/lib/hal0` + `HERMES_HOME` → service-owned (`secrets/` there stays `root:root` for the same systemd reason).
- Model store (`MODELS_DIR` / `[models].pull_root`) → `root:hal0` **0775** (group-writable) so the daemon can create pull subdirs + `chat-templates/`. The huge existing model files are **not** chowned — they stay world-readable.
- `hal0-api` unit → dropped to `User`/`Group=${HAL0_USER}` via a `hal0-api.service.d/20-run-as-hal0.conf` drop-in (the base unit already substitutes `User=${HAL0_USER}` inline; the drop-in re-asserts it and adds the missing `Group=`).

## Prerequisite

The privileged seam (PR #943 — `hal0-slotctl` + sudoers + `container.py` euid routing) is the enabler that lets the dropped daemon still manage slots. This PR does not touch it.

## Files

- `src/hal0/install/perms.py` — parameterized `ownership_table(service_user=...)` per the model; `service_user="root"` kept identical.
- `installer/install.sh` — when `HAL0_USER != root`: install the drop-in, chown config + state, chown the model store; idempotent + non-interactive; skipped on root.
- `installer/systemd/hal0-api.service.d/20-run-as-hal0.conf` — run-as drop-in template (token substituted at install time).
- `tests/install/test_perms.py` — asserts the `hal0` table flips `/etc/hal0`, keeps `agents/`+`secrets/` root, and that the `root` table is unchanged.

## Tests

- `tests/install/` + `tests/cli/test_doctor_perms.py`: **70 passed**.
- `ruff format` + `ruff check src tests`: clean.
- `bash -n installer/install.sh`: OK.

## Note on the spec

`chat-templates/` lives under the **model store** (`<model_store_root>/chat-templates`), not `/etc/hal0` — it's covered by the `root:hal0 0775` model-store chown, not the `/etc/hal0` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)