### PR TITLE
fix(installer): pass setup --storage-dir as a separate argv token

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -768,8 +768,14 @@ else
     # curl|bash installer must stay fast). --no-extensions: OpenWebUI + Hermes
     # are installed by the dedicated stages below, not here. Interactive
     # `hal0 setup` (post-install) handles model downloads + extension choices.
-    "${HAL0_BIN}" setup --auto --no-pull --no-extensions \
-        ${MODELS_DIR:+--storage-dir "${MODELS_DIR}"} \
+    # Build argv as an array so --storage-dir and its value stay TWO separate
+    # tokens. The old `${MODELS_DIR:+--storage-dir "${MODELS_DIR}"}` collapsed
+    # into a single arg ("--storage-dir /mnt/ai-models") that typer rejected
+    # with "No such option", silently skipping --auto seeding on --models-dir
+    # installs.
+    _setup_args=(--auto --no-pull --no-extensions)
+    [[ -n "${MODELS_DIR}" ]] && _setup_args+=(--storage-dir "${MODELS_DIR}")
+    "${HAL0_BIN}" setup "${_setup_args[@]}" \
         || warn "first-run setup failed; run 'hal0 setup' after install"
 fi
 


### PR DESCRIPTION
## What
`${MODELS_DIR:+--storage-dir "${MODELS_DIR}"}` in the `hal0 setup --auto` call expanded into a **single** argv token (`--storage-dir /mnt/ai-models`), which typer rejected with *"No such option"* — so `setup --auto` was silently skipped on any install passing `--models-dir` / `HAL0_MODELS_DIR`, and **no slots got seeded** on a fresh box.

## How
Build the argv as a bash array so the flag and its value stay two separate tokens:
```bash
_setup_args=(--auto --no-pull --no-extensions)
[[ -n "${MODELS_DIR}" ]] && _setup_args+=(--storage-dir "${MODELS_DIR}")
"${HAL0_BIN}" setup "${_setup_args[@]}" || warn ...
```

## Impact
Harmless on existing boxes (slot configs are preserved across re-runs), but it blocked first-run `--auto` slot-seeding on a brand-new `--models-dir` install. Found while reinstalling CT105 with `--models-dir=/mnt/ai-models`.

## Test
`bash -n installer/install.sh` OK; verified the array expands to 5 distinct argv tokens (`--storage-dir` and the path separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)