### PR TITLE
release: v0.8.0-beta.1 — model-config / Hermes / permissions overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,80 @@ Tags older than v0.2.0 ship release notes inside the GitHub release
 page; this CHANGELOG starts at v0.2.0 (the Lemonade migration cut).
 For ADR-level architecture context see `docs/internal/adr/`.
 
+## [v0.8.0-beta.1] — 2026-06-21
+
+First beta of the 0.8.0 line — the model-config, Hermes, and permissions
+overhaul. Configuration becomes a declarative single source of truth
+(**Stacks** + single-source launch argv), Hermes consolidates onto its own
+config ownership, and `hal0-api` can finally drop root. Voice (TTS + STT)
+lands end-to-end. One behaviour change to be aware of: the `hal0/primary`
+and `hal0/flm` virtual aliases are gone — see **Changed**.
+
+### Added
+- **Stacks — declarative config SSOT.** A `StackConfig` schema plus a
+  `StackApplyEngine` that `plan()`s a Stack into a ChangeSet, `apply_config()`s
+  it as an atomic commit with rollback, and `converge()`s the live slot set
+  (primary-slot load/swap/skip + capability-child routing through the
+  orchestrator). Content-hash drift detection and an active-stack pointer,
+  export/import via a checksummed `.hal0stack.json` envelope, snapshot of live
+  config into a Stack, and a `StacksCatalog` CRUD with seed guards. Seed stacks
+  (saber / forge / pi) derived from the roster bench.
+  (#921, #923, #925, #926)
+- **Voice stack — TTS + STT.** Brought up and verified end-to-end: `voice_wire`
+  fixed, Open WebUI Call mode wired, and the NPU-trio facade auto-provisions
+  STT. (#924, #928)
+- **Single-source slot argv (overhaul stream A).** A resolver dedups the launch
+  flag soup down to a last-wins canonical command; per-flag provenance is
+  exposed at `GET /api/slots/{name}/resolved`, and the slot Edit drawer renders
+  the resolved command with per-flag source badges (base / profile /
+  extra_args). (#929, #930, #931, #932)
+- **Capability-based slot fallback.** When a slot's `model.default` isn't
+  locally servable (registered-but-no-file, or pulled-away), `load()` falls back
+  to the best locally-registered model matching the slot's capability —
+  excluding diffusion / image / video models and preferring name-similarity to
+  the configured id. (#940, #942)
+- **Hardened permissions — run `hal0-api` unprivileged (opt-in).** Set
+  `HAL0_USER=hal0` and the installer drops the API off root: a declarative
+  ownership table (audited read-only by `hal0 doctor perms`), a narrow
+  privileged seam (`hal0-slotctl` + a no-wildcard sudoers grant) so the
+  unprivileged API can still write per-slot units and drive `hal0-slot@*`, and
+  a codified flip (run-as drop-in + recursive chown of config + state, pruning
+  `agents/` + `secrets/` + the models dir). Slot containers stay rootful — the
+  container remains the sandbox boundary. Default `HAL0_USER=root` is
+  byte-for-byte unchanged. (#929, #943, #944, #945)
+- **Hermes owns its own config.** The runtime is unpinned with a real upgrade
+  path, and a config-set overlay replaces the whole-file `config.yaml` render —
+  Hermes owns and self-migrates its config while hal0 layers only its keys.
+  (#934, #938)
+- **Chat-template render-validation.** The template catalog is render-validated
+  so a broken template can no longer ship silently. (#917)
+
+### Changed
+- **Breaking — `hal0/primary` and `hal0/flm` virtual aliases removed.** Virtual
+  model names now map 1:1 to their resolution chains; `hal0/primary` no longer
+  resolves (use `hal0/chat`) and `hal0/flm` is gone (use `hal0/npu`). Slot-name
+  back-compat is intentionally kept, and the Hermes overlay now emits
+  `model.default: hal0/chat`. (#939)
+- **q8_0 KV cache, universally.** Main and MTP-draft KV caches are now `q8_0`
+  across slots — near-lossless and keeps fused FlashAttention on AMD HIP. (#933)
+- **Profiles** lift bench-tuned MTP config into `rocm-moe` / `rocm-dnse`. (#922)
+- **Open WebUI** disables PersistentConfig so the env prewire wins the chat
+  connection. (#927)
+- Docs mirrored from hal0-web.
+
+### Fixed
+- **Installer** — `setup --storage-dir` is passed as a separate argv token so
+  fresh `--models-dir` installs seed slots correctly (#946); the hardened-perms
+  flip chowns config + state recursively so a root→hal0 upgrade doesn't strand
+  root-owned state subdirs (#945); `hermes gateway install` runs
+  non-interactively and skips `enable` when the unit is absent (#941); a
+  lemonade-team PPA is added so the FLM/NPU `.deb` resolves on a fresh Ubuntu
+  box (#937); the registry scans the effective store / pull_root rather than
+  only declared roots (#935).
+- **Hermes gateway** marks its `EnvironmentFile` optional (`-`) so fresh
+  installs don't crash-loop on a missing secrets vault. (#936)
+- **Dependencies** — bump vulnerable deps flagged by Dependabot. (#919)
+
 ## [v0.7.3-beta.2] — 2026-06-19
 
 Second beta in the 0.7.3 line. Vision lands on the chat slot, idle slots

--- a/README.md
+++ b/README.md
@@ -28,15 +28,19 @@ shared inference daemon; no extra process to babysit.
 curl -fsSL https://hal0.dev/install.sh | bash
 ```
 
-> **Status:** **v0.5.0-alpha.1** — container-runtime era. Each slot
-> (`chat`, `embed`, `rerank`, `stt`, `tts`, `img`, NPU trio) runs as
-> a dedicated podman container (`hal0-slot@<name>.service`). Slot
-> definitions live in `/etc/hal0/slots/<name>.toml`; backend profiles
-> in `/etc/hal0/profiles.toml`; the model catalog is
-> `registry.toml` — the single source of truth for every HuggingFace
-> coordinate and SHA-256 digest. The one-liner seeds the recommended
-> Main slot non-interactively; run `hal0 setup` anytime to configure
-> models, extensions, and NPU interactively. See
+> **Status:** **v0.8.0-beta.1** — container-runtime era, declarative
+> config. Each slot (`chat`, `embed`, `rerank`, `stt`, `tts`, `img`, NPU
+> trio) runs as a dedicated podman container (`hal0-slot@<name>.service`).
+> Slot definitions live in `/etc/hal0/slots/<name>.toml`; backend profiles
+> in `/etc/hal0/profiles.toml`; the model catalog is `registry.toml` — the
+> single source of truth for every HuggingFace coordinate and SHA-256
+> digest. The launch command for every slot is now resolved from a single
+> source (deduped, with per-flag provenance), and **Stacks** apply
+> declarative model/slot layouts atomically. `hal0-api` can run
+> unprivileged — install with `HAL0_USER=hal0` to drop it off root (slot
+> containers stay rootful; default `root` is unchanged). The one-liner
+> seeds the recommended Main slot non-interactively; run `hal0 setup`
+> anytime to configure models, extensions, and NPU interactively. See
 > [`PLAN.md`](./PLAN.md) §1 for what ships now and the path to v1.0.
 
 ## Why hal0
@@ -133,9 +137,13 @@ be evicted out from under a streaming request.
   depth, model inventory) with a gated inference ⇄ generation iGPU
   switchover behind a blast-radius confirm.
 - **Extensions** — selectable Apps (Open WebUI) and Agents (Hermes,
-  Pi) that `hal0 setup` auto-wires into the platform. A future
-  **Stacks** feature will add runtime-switchable model/slot layouts as
-  a replacement for install-time bundle tiers.
+  Pi) that `hal0 setup` auto-wires into the platform.
+- **Stacks** — declarative, runtime-switchable model/slot layouts as a
+  replacement for install-time bundle tiers. A `StackConfig` is planned
+  into a change set, applied atomically (with rollback) and converged
+  against the live slot set; drift is detected by content hash. Stacks
+  export/import via a checksummed `.hal0stack.json` envelope, and a live
+  config can be snapshotted back into a Stack.
 - **OpenWebUI prewired** — chat at `:3001`, zero config. The installer
   writes `openwebui.env` pointing at the local hal0 API.
 - **OmniRouter (8 tools)** — `generate_image`, `edit_image`,

--- a/manifest.json
+++ b/manifest.json
@@ -1,17 +1,17 @@
 {
   "_schema": "hal0.manifest.v1",
-  "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release \u2014 the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See PLAN.md \u00a712 (toolbox images) and \u00a717 (Risks).",
+  "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release — the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See PLAN.md §12 (toolbox images) and §17 (Risks).",
   "version": "0.5.0-alpha.1",
   "channel": "dev",
   "toolbox_images": {
     "vulkan": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1",
-      "digest": "sha256:dd6dbd4c07792d1a7ef98f1a0b8099f3ec7519282bf0b168283fe7148ae76cfd",
+      "digest": "sha256:a970d47c864b4bc83e34a1ebf11216353efc1b3a2340f4dd436086ce454ac856",
       "_notes": "llama.cpp Vulkan backend; default for Strix Halo iGPU"
     },
     "rocm": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-rocm:v1",
-      "digest": "sha256:6141a3d349d04f0dab7aa6c7db9d5a84bfb156e16dc3622f8dcc8b41dd8fa393",
+      "digest": "sha256:a47ca05ea08bc895e355d28153aa60873f1a13919eb40b16876bf9f2827499fd",
       "_notes": "llama.cpp ROCm backend; multi-arch (gfx1030..gfx1151)"
     },
     "flm": {
@@ -21,12 +21,12 @@
     },
     "moonshine": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-moonshine:v1",
-      "digest": "sha256:f1f43976bd1677c43876dc29efdb99a238f379114b62668e97a92c81d90d2e0f",
+      "digest": "sha256:bf07e3d5640fc1d009298be0600b62ec24185f80d7c8bed47321742fce17aa31",
       "_notes": "Moonshine STT (CPU/Vulkan); OpenAI-compat /v1/audio/transcriptions + WS"
     },
     "kokoro": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1",
-      "digest": "sha256:cb6d706dcc58f5b20284fe56636a7c7998f36b78fcaced86c6d80b84573ed2d2",
+      "digest": "sha256:1ac80acc00a2e9d578b077fa0a3f2c3e3f32f4f3da5080f346838e1c5a540456",
       "_notes": "Kokoro-82M TTS (CPU ONNX); OpenAI-compat /v1/audio/speech",
       "_upstream_reference": "https://github.com/thewh1teagle/kokoro-onnx"
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.7.3-beta.2"
+version = "0.8.0-beta.1"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
First beta of the **0.8.0** line — release-prep only (version + changelog + README + toolbox digests). **No tag is pushed**; cutting the release is a separate, deliberate step (`git tag v0.8.0-beta.1 && git push origin v0.8.0-beta.1` fires `release.yml`).

## What's in this PR
- **`pyproject`** `0.7.3-beta.2` → `0.8.0-beta.1` (base `0.8.0` satisfies the `release.yml` `base_matches` gate).
- **`CHANGELOG.md`** — new `## [v0.8.0-beta.1]` entry covering #917–#946. Verified it extracts via `hal0.release.notes.extract_changelog_section`.
- **`README.md`** — fixed the stale `v0.5.0-alpha.1` status line → `v0.8.0-beta.1`; promoted **Stacks** from "future feature" to shipped.
- **`manifest.json`** — refreshed toolbox image digests via `scripts/update-toolbox-digests.sh` (vulkan / rocm / moonshine / kokoro updated; flm unchanged). **comfyui digest kept pinned** — it lives on docker.io and the ghcr-only refresh script nulls it; restoring the prior validated pin avoids a regression.

## Release scope (since v0.7.3-beta.2)
The model-config / Hermes / permissions overhaul, plus everything merged after beta.2:
- **Stacks** declarative config SSOT (#921, #923, #925, #926)
- **Voice** TTS + STT end-to-end (#924, #928)
- **Single-source slot argv** + provenance API + UI drawer — stream A (#929–932)
- **Capability-based slot fallback** w/ diffusion/video exclusion (#940, #942)
- **D hardened-perms** — opt-in unprivileged `hal0-api` via `HAL0_USER=hal0` (#929, #943, #944, #945)
- **Hermes** config-set overlay + unpin/upgrade (#934, #938)
- **q8_0 KV** universally (#933); chat-template render-validation (#917)
- Installer fixes (#935, #937, #941, #946); gateway optional EnvironmentFile (#936); dep bumps (#919)

## ⚠️ Breaking change
`hal0/primary` and `hal0/flm` virtual aliases removed (#939) — use `hal0/chat` / `hal0/npu`. Slot-name back-compat is retained.

## To cut after merge
1. Merge this PR to `main`.
2. (Optional) re-run `scripts/update-toolbox-digests.sh` on `main` if images moved.
3. `git tag v0.8.0-beta.1 && git push origin v0.8.0-beta.1` → `release.yml` builds, cosign-signs, publishes the GH release + manifest at `releases.hal0.dev/stable.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)