### PR TITLE
fix(hermes): privileged env seam for unprivileged provisioner (root:root .env writes)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -734,6 +734,40 @@ if [[ -f "${AGENT_UNIT_SRC}" ]]; then
             warn "${SLOTCTL_SUDOERS_SRC} not found — slotctl sudoers grant not installed"
         fi
     fi
+
+    # Privileged seam #2 (D hardened-perms): hal0-agentenv writes the per-agent
+    # .env files that the hardened model pins root:root — the secrets vault
+    # (/var/lib/hal0/secrets/agents/<agent>.env) and the driver env
+    # (/etc/hal0/agents/<agent>.env). When hal0-api runs unprivileged it cannot
+    # write those root-owned dirs, so the hermes provisioner delegates the two
+    # writes here. Inert under the default root install (the provisioner branches
+    # on euid). Lands at the absolute /usr/lib/hal0/bin path the provider's
+    # _HAL0_AGENTENV default hardcodes (dev mode shadows it under PREFIX).
+    AGENTENV_SRC="${REPO_ROOT}/installer/wrappers/hal0-agentenv"
+    if [[ -f "${AGENTENV_SRC}" ]]; then
+        install -d "${LIB_DIR}/bin"
+        install -m 0755 "${AGENTENV_SRC}" "${LIB_DIR}/bin/hal0-agentenv"
+        info "wrote ${LIB_DIR}/bin/hal0-agentenv"
+    else
+        warn "${AGENTENV_SRC} not found — agent-env seam helper not installed"
+    fi
+
+    # sudoers grant for the agent-env seam. Real installs only; visudo-validate
+    # before activating so a malformed drop-in can never wedge sudo for the box.
+    if [[ "${DEV_MODE}" -eq 0 ]]; then
+        AGENTENV_SUDOERS_SRC="${REPO_ROOT}/packaging/sudoers/hal0-agentenv"
+        AGENTENV_SUDOERS_DST="/etc/sudoers.d/hal0-agentenv"
+        if [[ -f "${AGENTENV_SUDOERS_SRC}" ]]; then
+            if visudo -cf "${AGENTENV_SUDOERS_SRC}" >/dev/null 2>&1; then
+                install -m 0440 "${AGENTENV_SUDOERS_SRC}" "${AGENTENV_SUDOERS_DST}"
+                info "wrote ${AGENTENV_SUDOERS_DST}"
+            else
+                warn "${AGENTENV_SUDOERS_SRC} failed visudo check — agent-env sudoers grant not installed"
+            fi
+        else
+            warn "${AGENTENV_SUDOERS_SRC} not found — agent-env sudoers grant not installed"
+        fi
+    fi
 else
     warn "${AGENT_UNIT_SRC} not found — hal0-agent@ template not installed"
 fi
@@ -1177,6 +1211,16 @@ else
     # converge to the same state on every re-run.
     if [[ "${HAL0_USER}" != "root" ]]; then
         info "hardened-perms flip: chowning config + state to ${HAL0_USER}"
+
+        # Ensure the root-pinned secret-bearing dirs EXIST before the re-pin
+        # below. On a blank install secrets/ doesn't exist yet (the early mkdir
+        # seeds registry/slots/cache, not secrets/), so the `[[ -d ]]`-guarded
+        # `chown -R root:root` further down would silently no-op and the hermes
+        # provisioner's first .env write could land owned by ${HAL0_USER}. Create
+        # them root:root NOW (installer is root) so the find-prunes match and the
+        # re-pin always runs. These are also the dirs the hal0-agentenv seam
+        # writes into.
+        mkdir -p "${ETC_DIR}/agents" "${VAR_DIR}/secrets/agents"
 
         # /etc/hal0 config root + ALL its contents -> ${HAL0_USER}:hal0,
         # RECURSIVELY: a root->hal0 UPGRADE must flip pre-existing root-owned

--- a/installer/wrappers/hal0-agentenv
+++ b/installer/wrappers/hal0-agentenv
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Privileged seam for the unprivileged hal0-api / hermes provisioner: only ever
+# writes the per-agent .env files that the D hardened-perms model pins root:root.
+#
+# Background (D hardened-perms): hal0-api can run as the unprivileged `hal0`
+# system user, but the hermes provisioner still has to write two .env files
+# that live in root:root directories:
+#   * the outbound secrets vault /var/lib/hal0/secrets/agents/<agent>.env
+#     (0600 root:root — pid1/root reads it as the unit's EnvironmentFile), and
+#   * the non-secret driver env /etc/hal0/agents/<agent>.env (0644 root:root —
+#     hal0 API/MCP URLs the hermes wrapper sources).
+# An unprivileged provisioner cannot write into those root-owned dirs, so it
+# delegates exactly those two writes here, just like hal0-slotctl delegates the
+# slot-unit + systemctl ops.
+#
+# This script is the entire privileged surface for agent env writes. The agent
+# regex below is a security requirement: it rejects path traversal (../), shell
+# metacharacters, and anything that is not a literal agent name, so the grant in
+# /etc/sudoers.d/hal0-agentenv can never be widened into arbitrary file writes.
+# The target paths are constructed HERE from the validated name; the caller
+# never supplies a path. File CONTENT arrives on stdin.
+set -euo pipefail
+cmd="${1:-}"; agent="${2:-}"
+[[ "$agent" =~ ^[a-z0-9][a-z0-9-]{0,31}$ ]] || { echo "hal0-agentenv: bad agent name" >&2; exit 2; }
+secrets="/var/lib/hal0/secrets/agents/${agent}.env"
+driver="/etc/hal0/agents/${agent}.env"
+case "$cmd" in
+  merge-secrets)
+    # stdin = KEY=VALUE update lines. Read-merge-write AS ROOT: the unprivileged
+    # caller cannot read the 0600 vault to merge it, so the merge happens here.
+    # Operator-added lines/comments and unrelated keys are preserved; matching
+    # keys are replaced; new keys are appended. Atomic (tmp + os.replace),
+    # 0600 root:root.
+    install -d -m 0700 -o root -g root /var/lib/hal0/secrets /var/lib/hal0/secrets/agents
+    # NB: the script is passed via `-c` (an argv), NOT a `<<heredoc` — a heredoc
+    # would become python's stdin and shadow the caller's piped KEY=VALUE
+    # updates, silently no-op'ing the merge. With `-c`, stdin stays the caller's.
+    python3 -c '
+import os, sys, tempfile
+path = sys.argv[1]
+updates = {}
+for line in sys.stdin.read().splitlines():
+    s = line.strip()
+    if not s or s.startswith("#") or "=" not in s:
+        continue
+    k, v = s.split("=", 1)
+    updates[k.strip()] = v
+existing = []
+if os.path.exists(path):
+    with open(path, encoding="utf-8") as f:
+        existing = f.read().splitlines()
+seen, out = set(), []
+for line in existing:
+    s = line.strip()
+    if not s or s.startswith("#"):
+        out.append(line)
+        continue
+    k = s.split("=", 1)[0].strip()
+    if k in updates:
+        out.append(f"{k}={updates[k]}")
+        seen.add(k)
+    else:
+        out.append(line)
+for k, v in updates.items():
+    if k not in seen:
+        out.append(f"{k}={v}")
+d = os.path.dirname(path)
+fd, tmp = tempfile.mkstemp(dir=d)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write("\n".join(out) + "\n")
+    os.chmod(tmp, 0o600)
+    os.chown(tmp, 0, 0)
+    os.replace(tmp, path)
+except BaseException:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
+' "$secrets"
+    ;;
+  write-driver-env)
+    # stdin = full driver-env body (non-secret URLs). Atomic, 0644 root:root.
+    install -d -m 0755 -o root -g root /etc/hal0/agents
+    umask 022
+    tmp="$(mktemp "${driver}.XXXXXX")"
+    trap 'rm -f "$tmp"' EXIT
+    cat > "$tmp"
+    chown root:root "$tmp"
+    chmod 0644 "$tmp"
+    mv -f "$tmp" "$driver"
+    trap - EXIT
+    ;;
+  *)
+    echo "hal0-agentenv: bad cmd: ${cmd}" >&2
+    exit 2
+    ;;
+esac

--- a/packaging/sudoers/hal0-agentenv
+++ b/packaging/sudoers/hal0-agentenv
@@ -1,0 +1,21 @@
+# hal0 — privileged seam grant for an UNPRIVILEGED hal0-api / hermes provisioner
+# (D hardened-perms).
+#
+# When hal0-api runs as the `hal0` system user, it cannot write the per-agent
+# .env files that the hardened model pins root:root:
+#   * /var/lib/hal0/secrets/agents/<agent>.env  (0600 root:root secrets vault)
+#   * /etc/hal0/agents/<agent>.env              (0644 root:root driver env)
+# It delegates exactly those writes to /usr/lib/hal0/bin/hal0-agentenv, which is
+# the entire privileged surface: the helper validates the agent name, builds the
+# target path itself, takes content on stdin, and only ever touches
+# <agent>.env under those two fixed directories — no wildcards, no shell, no
+# arbitrary file writes.
+#
+# Install (as root):
+#   install -m 0440 packaging/sudoers/hal0-agentenv /etc/sudoers.d/hal0-agentenv
+#   visudo -cf /etc/sudoers.d/hal0-agentenv
+#
+# Keep this grant pinned to the helper binary; a broader file-write grant would
+# let the API clobber arbitrary root-owned files.
+
+hal0 ALL=(root) NOPASSWD: /usr/lib/hal0/bin/hal0-agentenv

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -3194,6 +3194,52 @@ def _merge_env_file(path: Path, updates: dict[str, str]) -> None:
         path.chmod(0o600)
 
 
+#: Privileged seam for writing the root:root agent .env files when hal0-api runs
+#: unprivileged (D hardened-perms). Mirrors the hal0-slotctl seam: a non-root
+#: provisioner cannot write the secrets vault
+#: (/var/lib/hal0/secrets/agents/<agent>.env, 0600 root:root) or the driver env
+#: (/etc/hal0/agents/<agent>.env, 0644 root:root) directly, so it delegates the
+#: write to this root helper over `sudo -n`. Env-overridable for tests.
+_HAL0_AGENTENV = os.environ.get("HAL0_AGENTENV", "/usr/lib/hal0/bin/hal0-agentenv")
+
+#: The agent this provisioner manages; the seam re-validates it server-side.
+_HERMES_AGENT_NAME = "hermes"
+
+
+def _privileged_env_write(verb: str, body: str) -> None:
+    """Pipe ``body`` to the hal0-agentenv seam as root via ``sudo -n``.
+
+    The unprivileged path for an env write that lands in a root:root dir. Raises
+    ``subprocess.CalledProcessError`` on a non-zero seam exit (no sudo grant,
+    bad verb, write failure) so the caller surfaces it loudly — the optional
+    ``EnvironmentFile=-`` would otherwise let a swallowed failure masquerade as
+    "gateway up, no tokens".
+    """
+    subprocess.run(  # nosec B603 — fixed argv; agent name re-validated by the seam
+        ["sudo", "-n", _HAL0_AGENTENV, verb, _HERMES_AGENT_NAME],
+        input=body,
+        text=True,
+        check=True,
+    )
+
+
+def _write_secrets_env(updates: dict[str, str]) -> None:
+    """Merge ``updates`` into the root:root secrets vault, privilege-aware.
+
+    Root (install-time) writes directly via :func:`_merge_env_file` and re-pins
+    the file root:root. Unprivileged (the flipped hal0-api at runtime) routes
+    the merge through the hal0-agentenv seam, which read-merges AS ROOT so the
+    0600 vault never has to be readable by the ``hal0`` user.
+    """
+    if os.geteuid() == 0:
+        _merge_env_file(HERMES_SECRETS_ENV, updates)
+        with contextlib.suppress(OSError):
+            os.chown(HERMES_SECRETS_ENV, 0, 0)
+    else:
+        body = "".join(f"{k}={v}\n" for k, v in updates.items())
+        _privileged_env_write("merge-secrets", body)
+
+
 def _phase_voice_wire(ctx: PhaseContext) -> PhaseResult:
     """Emit STT/TTS provider config + secrets env when both slots are ready.
 
@@ -3226,8 +3272,8 @@ def _phase_voice_wire(ctx: PhaseContext) -> PhaseResult:
         details["tts"] = {"backend_url": url, "model": _slot_model_id(tts)}
 
     try:
-        _merge_env_file(HERMES_SECRETS_ENV, updates)
-    except OSError as exc:
+        _write_secrets_env(updates)
+    except (OSError, subprocess.SubprocessError) as exc:
         return PhaseResult(
             status=PhaseStatus.FAIL,
             reason=f"secrets env write to {HERMES_SECRETS_ENV} failed: {exc}",
@@ -3626,10 +3672,17 @@ def _write_driver_env(state: BootstrapState) -> tuple[Path, bool]:
                 return path, False
         except OSError:
             pass
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".env.tmp")
-    tmp.write_text(body, encoding="utf-8")
-    os.replace(tmp, path)
+    if os.geteuid() == 0:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".env.tmp")
+        tmp.write_text(body, encoding="utf-8")
+        os.replace(tmp, path)
+        with contextlib.suppress(OSError):
+            os.chown(path, 0, 0)
+    else:
+        # Driver env lives in root:root /etc/hal0/agents — delegate the write
+        # to the seam (it builds the path from the validated agent name).
+        _privileged_env_write("write-driver-env", body)
     return path, True
 
 

--- a/tests/agents/conftest.py
+++ b/tests/agents/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixtures for the hermes-provision test suite.
+
+After the D hardened-perms env seam (hal0-agentenv), the provisioner's env
+writers (``_write_secrets_env`` / ``_write_driver_env``) branch on
+``os.geteuid()``: root writes the root:root files directly, an unprivileged
+process delegates to ``sudo -n hal0-agentenv``. CI runs pytest as a NON-root
+user, so without this fixture every pre-existing test that reaches those writers
+would fall into the seam branch and shell out to sudo.
+
+Default the whole suite to euid == 0 — the unchanged, historical direct-write
+path these tests were written against. The dedicated seam tests in
+``test_hermes_env_seam.py`` (and the gateway/ownership tests that already set
+euid explicitly) override per-test, which takes precedence over this autouse
+default for the duration of that test.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from hal0.agents import hermes_provision as hp
+
+
+@pytest.fixture(autouse=True)
+def _euid_root_by_default():
+    """Run hermes-provision tests as if euid == 0 (the direct-write path)."""
+    with patch.object(hp.os, "geteuid", return_value=0):
+        yield

--- a/tests/agents/test_hermes_env_seam.py
+++ b/tests/agents/test_hermes_env_seam.py
@@ -1,0 +1,149 @@
+"""Tests for the D hardened-perms env seam (hal0-agentenv).
+
+The provisioner writes two .env files into directories the hardened model pins
+root:root — the secrets vault (/var/lib/hal0/secrets/agents/hermes.env) and the
+driver env (/etc/hal0/agents/hermes.env). When hal0-api runs unprivileged it
+can't write those dirs, so ``_write_secrets_env`` / ``_write_driver_env`` branch
+on euid: root writes directly (+ re-pins root:root), non-root delegates to
+``sudo -n hal0-agentenv``.
+
+These tests assert both branches. The autouse ``_euid_root_by_default`` fixture
+(conftest) makes euid==0 the default; the seam tests override to non-root.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hal0.agents import hermes_provision as hp
+
+# ── secrets vault ────────────────────────────────────────────────────────────
+
+
+def test_secrets_env_root_writes_directly(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """euid==0: merge into the vault directly, 0600, no sudo."""
+    vault = tmp_path / "hermes.env"
+    monkeypatch.setattr(hp, "HERMES_SECRETS_ENV", vault)
+    # default fixture already forces euid==0; be explicit for clarity.
+    monkeypatch.setattr(hp.os, "geteuid", lambda: 0)
+    with patch.object(hp.subprocess, "run") as run:
+        hp._write_secrets_env({"A": "1", "B": "2"})
+    run.assert_not_called()
+    assert vault.read_text() == "A=1\nB=2\n"
+    assert (vault.stat().st_mode & 0o777) == 0o600
+
+
+def test_secrets_env_root_preserves_existing_lines(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """euid==0 merge keeps operator comments + unrelated keys, replaces matches."""
+    vault = tmp_path / "hermes.env"
+    vault.write_text("# operator note\nA=1\nKEEP=yes\n")
+    monkeypatch.setattr(hp, "HERMES_SECRETS_ENV", vault)
+    monkeypatch.setattr(hp.os, "geteuid", lambda: 0)
+    hp._write_secrets_env({"A": "99", "C": "3"})
+    assert vault.read_text() == "# operator note\nA=99\nKEEP=yes\nC=3\n"
+
+
+def test_secrets_env_nonroot_routes_through_seam(monkeypatch: pytest.MonkeyPatch) -> None:
+    """euid!=0: pipe KEY=VALUE updates to `sudo -n hal0-agentenv merge-secrets`."""
+    monkeypatch.setattr(hp.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(hp, "_HAL0_AGENTENV", "/usr/lib/hal0/bin/hal0-agentenv")
+    with patch.object(hp.subprocess, "run") as run:
+        hp._write_secrets_env({"A": "1", "B": "2"})
+    run.assert_called_once()
+    args, kwargs = run.call_args
+    assert args[0] == [
+        "sudo",
+        "-n",
+        "/usr/lib/hal0/bin/hal0-agentenv",
+        "merge-secrets",
+        "hermes",
+    ]
+    assert kwargs["input"] == "A=1\nB=2\n"
+    assert kwargs["check"] is True
+    assert kwargs["text"] is True
+
+
+def test_secrets_env_nonroot_propagates_seam_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-zero seam exit must raise (so voice_wire surfaces it, not swallow)."""
+    monkeypatch.setattr(hp.os, "geteuid", lambda: 1000)
+
+    def _boom(*_a, **_k):
+        raise subprocess.CalledProcessError(1, ["sudo"])
+
+    monkeypatch.setattr(hp.subprocess, "run", _boom)
+    with pytest.raises(subprocess.CalledProcessError):
+        hp._write_secrets_env({"A": "1"})
+
+
+def test_voice_wire_surfaces_seam_failure_as_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    """voice_wire returns FAIL (not a swallowed OK) when the seam write fails."""
+    monkeypatch.setattr(hp.os, "geteuid", lambda: 1000)
+
+    def _boom(*_a, **_k):
+        raise subprocess.CalledProcessError(1, ["sudo", "-n", "hal0-agentenv"])
+
+    monkeypatch.setattr(hp.subprocess, "run", _boom)
+
+    class _IO:
+        def fetch_slots(self):
+            return [
+                {
+                    "name": "kokoro",
+                    "type": "tts",
+                    "state": "ready",
+                    "backend_url": "http://127.0.0.1:8084/v1",
+                },
+            ]
+
+        def run(self, *_a, **_k):  # config-set path; unreached on the FAIL above
+            raise AssertionError("config-set should not run after a secrets failure")
+
+    state = hp.BootstrapState(hermes_home="/tmp/hh", agent_id="hermes-agent")
+    out = hp._phase_voice_wire(hp.context_for("voice_wire", state, io=_IO()))
+    assert out.status == hp.PhaseStatus.FAIL
+    assert "secrets env write" in out.reason
+
+
+# ── driver env ───────────────────────────────────────────────────────────────
+
+
+def test_driver_env_nonroot_routes_through_seam(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """euid!=0: the non-secret driver env is written via the seam too."""
+    # Point at a non-existent path so the hash-skip doesn't early-return.
+    monkeypatch.setattr(hp, "DRIVER_ENV_PATH", tmp_path / "agents" / "hermes.env")
+    monkeypatch.setattr(hp.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(hp, "_HAL0_AGENTENV", "/usr/lib/hal0/bin/hal0-agentenv")
+    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"), agent_id="hermes-agent")
+    with patch.object(hp.subprocess, "run") as run:
+        path, wrote = hp._write_driver_env(state)
+    assert wrote is True
+    run.assert_called_once()
+    args, kwargs = run.call_args
+    assert args[0][:4] == ["sudo", "-n", "/usr/lib/hal0/bin/hal0-agentenv", "write-driver-env"]
+    assert "HAL0_API_URL=" in kwargs["input"]
+    # Seam path was used — nothing written to the real (root-owned) location.
+    assert not path.exists()
+
+
+def test_driver_env_root_writes_directly(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """euid==0: write the driver env directly, no sudo."""
+    target = tmp_path / "agents" / "hermes.env"
+    monkeypatch.setattr(hp, "DRIVER_ENV_PATH", target)
+    monkeypatch.setattr(hp.os, "geteuid", lambda: 0)
+    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"), agent_id="hermes-agent")
+    with patch.object(hp.subprocess, "run") as run:
+        path, wrote = hp._write_driver_env(state)
+    run.assert_not_called()
+    assert wrote is True
+    assert path.exists()
+    assert "HAL0_API_URL=" in path.read_text()


### PR DESCRIPTION
## The bug
D hardened-perms (`HAL0_USER=hal0`) pins `/etc/hal0/agents` + `/var/lib/hal0/secrets` to **root:root**, but the hermes provisioner writes its two `.env` files into those dirs:
- secrets vault `/var/lib/hal0/secrets/agents/hermes.env` (`_merge_env_file`, 0600, **no chown**)
- driver env `/etc/hal0/agents/hermes.env` (`_write_driver_env`, **no chmod/chown**)

Neither writer chowns and there was **no privileged seam**. So an unprivileged (hal0) provision/runtime either:
- creates the secrets vault **`hal0:hal0`** (silently breaking the root-only posture), or
- **hard-fails** the write when the dir is already root-owned.

And the flip's re-pin couldn't catch it: it runs **before** the provision and is guarded on the dir already existing → a silent no-op on a blank box (the early `mkdir` seeds `registry/slots/cache`, not `secrets/`).

Surfaced by a contributor: *"blank, no hermes, run as the hal0 user → permission gap on the .env file."* The runtime trigger is the flipped `hal0-api` driving `hal0 agent upgrade hermes` / `voice_wire` as `hal0`.

## Part 1 — privileged seam (mirrors #943 `hal0-slotctl`)
- **`installer/wrappers/hal0-agentenv`** — stdin-fed root helper, agent-name regex-guarded, paths built server-side (no traversal). `merge-secrets` **read-merges the vault AS ROOT** (the 0600 file never has to be hal0-readable); `write-driver-env` writes root:root 0644.
  - ⚠️ the merge python is invoked via `python3 -c`, **not a heredoc** — a heredoc would become python's stdin and shadow the caller's piped `KEY=VALUE` updates, silently no-op'ing the merge (caught during testing — exactly the kind of bug that yields an empty token vault).
- **`packaging/sudoers/hal0-agentenv`** — narrow `hal0 → hal0-agentenv` grant (0440, visudo-checked).
- **`hermes_provision.py`** — `_write_secrets_env` / `_write_driver_env` branch on `os.geteuid()`: root writes direct (+ explicit chown root:root), non-root pipes through the seam. `voice_wire` now surfaces a seam failure as **FAIL** (the `EnvironmentFile=-` optionality from #936 would otherwise let a swallowed failure read as "gateway up, no tokens").
- **`install.sh`** installs the wrapper + sudoers (inert under the default root install — provisioner branches on euid, like the slotctl seam).

## Part 2 — flip ordering
`install.sh` flip now `mkdir -p`'s `agents/` + `secrets/agents` **before** the `root:root` re-pin, so a blank `HAL0_USER=hal0` install actually pins them instead of no-op'ing the `[[ -d ]]` guard.

## Tests
- `tests/agents/test_hermes_env_seam.py` — 7 tests: root direct-write (0600 + merge-preserves-lines), non-root → correct `sudo … hal0-agentenv` argv/stdin, seam-failure propagation, `voice_wire` surfaces FAIL, driver-env both branches.
- `tests/agents/conftest.py` — autouse `geteuid==0` default so the existing suite keeps the historical direct path (mirrors `tests/providers/conftest.py` from #943).
- Full `tests/agents`: **334 pass / 3 fail** — the 3 (2 order-dependent `state_render` + 1 wrapper) are **pre-existing on base `c9029dea`** (verified by stashing all changes), not regressions.
- Wrapper validated in a sandbox (merge applies, operator lines preserved, bad name/cmd rejected exit 2); sudoers `visudo`-clean; `install.sh` `bash -n` clean.

## Rollout
**No-op until `HAL0_USER=hal0`.** Plan: merge → rehearse on CT107 (flipped staging) → CT105 at a maintenance window. Not deploying to CT105 in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)