### PR TITLE
fix(board): harvest rotating Hermes token for the events WS bridge

### DIFF
--- a/src/hal0/api/routes/board_ws.py
+++ b/src/hal0/api/routes/board_ws.py
@@ -91,7 +91,9 @@ async def _pump(
         log.warning("hal0.board_ws.pump_error", direction=direction, error=str(exc))
 
 
-async def _resolve_session_token(browser_ws: WebSocket, *, force_refresh: bool = False) -> str | None:
+async def _resolve_session_token(
+    browser_ws: WebSocket, *, force_refresh: bool = False
+) -> str | None:
     """Resolve the Hermes session bearer for the upstream WS upgrade.
 
     Mirrors the REST path's resolution (``HermesKanbanClient._current_token``):

--- a/src/hal0/api/routes/board_ws.py
+++ b/src/hal0/api/routes/board_ws.py
@@ -32,7 +32,12 @@ import websockets
 from fastapi import WebSocket
 from starlette.websockets import WebSocketDisconnect, WebSocketState
 
-from hal0.board import DEFAULT_BASE_URL, KANBAN_BASE_PATH, _default_session_token
+from hal0.board import (
+    DEFAULT_BASE_URL,
+    KANBAN_BASE_PATH,
+    HermesKanbanClient,
+    _default_session_token,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -86,22 +91,57 @@ async def _pump(
         log.warning("hal0.board_ws.pump_error", direction=direction, error=str(exc))
 
 
+async def _resolve_session_token(browser_ws: WebSocket, *, force_refresh: bool = False) -> str | None:
+    """Resolve the Hermes session bearer for the upstream WS upgrade.
+
+    Mirrors the REST path's resolution (``HermesKanbanClient._current_token``):
+    an explicit ``HERMES_SESSION_TOKEN`` pin wins, otherwise the rotating
+    per-process token is harvested from the dashboard HTML at ``/`` and cached.
+    We route through the SHARED client on ``app.state.hermes_kanban`` so the
+    env-pin + HTML-harvest + rotation cache live in exactly one place and a
+    token refreshed by either surface (REST or WS) benefits both.
+
+    The bare ``_default_session_token()`` env read — which the WS bridge used
+    to use directly — only ever saw the env pin, so once deployments stopped
+    pinning ``HERMES_SESSION_TOKEN`` and relied on the harvest, the events WS
+    silently connected upstream with NO token and Hermes rejected the upgrade
+    (403) while REST reads kept working. Falls back to the env resolver only
+    when the shared client isn't wired (e.g. unit tests that stub app.state).
+    """
+    app = browser_ws.scope.get("app")
+    client = getattr(getattr(app, "state", None), "hermes_kanban", None)
+    if isinstance(client, HermesKanbanClient):
+        return await client._current_token(force_refresh=force_refresh)
+    return _default_session_token()
+
+
 async def proxy_board_events(browser_ws: WebSocket) -> None:
     """Bridge an accepted browser WS to the upstream kanban events WS."""
-    token = _default_session_token()
-    upstream_url = _build_upstream_url(browser_ws, token=token)
 
-    try:
-        upstream = await websockets.connect(
-            upstream_url,
+    async def _connect(*, force_refresh: bool) -> websockets.WebSocketClientProtocol:
+        token = await _resolve_session_token(browser_ws, force_refresh=force_refresh)
+        url = _build_upstream_url(browser_ws, token=token)
+        return await websockets.connect(
+            url,
             ping_interval=WS_PING_INTERVAL_SECONDS,
             open_timeout=WS_OPEN_TIMEOUT_SECONDS,
         )
+
+    try:
+        upstream = await _connect(force_refresh=False)
     except Exception as exc:
-        log.warning("hal0.board_ws.upstream_connect_failed", upstream=upstream_url, error=str(exc))
-        if browser_ws.application_state == WebSocketState.CONNECTED:
-            await browser_ws.close(code=1011)
-        return
+        # The harvested per-process token may have rotated on a Hermes restart;
+        # the upstream then rejects the upgrade (403). Drop the cached token,
+        # re-harvest once, and retry — mirrors the REST client's 401 path. A
+        # pinned env token re-reads identically, so this is a no-op there.
+        log.info("hal0.board_ws.upstream_retry_after_refresh", error=str(exc))
+        try:
+            upstream = await _connect(force_refresh=True)
+        except Exception as exc2:
+            log.warning("hal0.board_ws.upstream_connect_failed", error=str(exc2))
+            if browser_ws.application_state == WebSocketState.CONNECTED:
+                await browser_ws.close(code=1011)
+            return
 
     async def to_browser(raw: str) -> None:
         if browser_ws.application_state == WebSocketState.CONNECTED:

--- a/tests/board/test_board_ws.py
+++ b/tests/board/test_board_ws.py
@@ -143,9 +143,7 @@ def test_ws_proxy_forwards_upstream_frames(monkeypatch) -> None:
     assert qs.get("board") == ["alpha"]
 
 
-_DASHBOARD_HTML = (
-    '<!doctype html><script>window.__HERMES_SESSION_TOKEN__="HARVESTED_TOK";</script>'
-)
+_DASHBOARD_HTML = '<!doctype html><script>window.__HERMES_SESSION_TOKEN__="HARVESTED_TOK";</script>'
 
 
 def _make_harvesting_client() -> HermesKanbanClient:

--- a/tests/board/test_board_ws.py
+++ b/tests/board/test_board_ws.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import contextlib
 from urllib.parse import parse_qs, urlsplit
 
+import httpx
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.datastructures import QueryParams
@@ -18,6 +19,7 @@ import hal0.api.routes.board_ws as board_ws_mod
 from hal0.api.middleware.error_codes import install as install_errors
 from hal0.api.routes import board
 from hal0.api.routes.board_ws import _build_upstream_url, _http_to_ws
+from hal0.board import HermesKanbanClient
 
 # ── _http_to_ws ──────────────────────────────────────────────────────────────
 
@@ -139,6 +141,70 @@ def test_ws_proxy_forwards_upstream_frames(monkeypatch) -> None:
     assert qs.get("token") == ["TOK"]
     assert qs.get("since") == ["0"]
     assert qs.get("board") == ["alpha"]
+
+
+_DASHBOARD_HTML = (
+    '<!doctype html><script>window.__HERMES_SESSION_TOKEN__="HARVESTED_TOK";</script>'
+)
+
+
+def _make_harvesting_client() -> HermesKanbanClient:
+    """A real client whose MockTransport serves the dashboard HTML at ``/``.
+
+    No env pin → the client harvests ``window.__HERMES_SESSION_TOKEN__`` from
+    the HTML, exactly as it does against the live loopback dashboard.
+    """
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/":
+            return httpx.Response(200, text=_DASHBOARD_HTML)
+        return httpx.Response(200, json={})
+
+    http = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://127.0.0.1:9119"
+    )
+    return HermesKanbanClient(http_client=http)
+
+
+def test_ws_proxy_harvests_token_when_env_unpinned(monkeypatch) -> None:
+    """Regression: the events WS must use the HARVESTED session token, not just
+    the ``HERMES_SESSION_TOKEN`` env pin.
+
+    Production never pins the env var (the per-process token rotates), so the
+    bridge relied on harvest for REST but sent NO token on the WS upgrade —
+    Hermes answered 403 and live task events never reached the board. This
+    asserts the upstream connect URL carries the harvested bearer with the env
+    var explicitly unset.
+    """
+    monkeypatch.setenv("HERMES_DASHBOARD_BASE_URL", "http://127.0.0.1:9119")
+    monkeypatch.delenv("HERMES_SESSION_TOKEN", raising=False)
+
+    frame = '{"events":[{"id":1}],"cursor":1}'
+    connect_calls: list[str] = []
+
+    async def fake_connect(url, **kwargs):
+        connect_calls.append(url)
+        return _FakeUpstreamWS([frame])
+
+    monkeypatch.setattr(board_ws_mod.websockets, "connect", fake_connect)
+
+    app = FastAPI()
+    install_errors(app)
+    app.include_router(board.router, prefix="/api/board")
+    app.state.hermes_kanban = _make_harvesting_client()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    received: list[str] = []
+    with (
+        client.websocket_connect("/api/board/events?since=0") as ws,
+        contextlib.suppress(Exception),
+    ):
+        received.append(ws.receive_text())
+
+    assert received == [frame]
+    assert len(connect_calls) == 1
+    qs = parse_qs(urlsplit(connect_calls[0]).query)
+    assert qs.get("token") == ["HARVESTED_TOK"]
 
 
 def test_ws_proxy_upstream_connect_fails_closes_browser(monkeypatch) -> None:


### PR DESCRIPTION
## Symptom
Tasks created in Hermes weren't showing up on the Hal0 Operator Board "anymore" — the board still loaded existing tasks on refresh, but never updated live.

## Root cause
`hal0-api` proxies the Hermes kanban plugin, which is gated behind a **per-process bearer that rotates on every Hermes restart**. Two code paths consume it and had diverged:

| Path | Token resolution | Result |
|------|-----------------|--------|
| REST reads (`/api/board/board`) | `HermesKanbanClient._current_token` → env-pin **then HTML-harvest** + 401 re-harvest | ✅ worked |
| Live events WS (`/api/board/events`) | `_default_session_token()` → **env var only** | ❌ 403 → WS closed 1011 |

Production doesn't pin `HERMES_SESSION_TOKEN` (the token rotates, so it's harvested). REST kept working via harvest; the WS bridge sent **no token**, Hermes rejected the upgrade (403), and the browser WS died with 1011 in a perpetual reconnect loop. So the board loaded via REST but never received live `created` pushes.

### Verified (deterministic)
- upstream WS, no token → `403`; with harvested token → streams `created` events; hal0-api bridge → `1011`.
- After the fix: `hermes kanban create` pushed live through `:8080/api/board/events` in real time.

## Fix
Route the WS token through the shared `HermesKanbanClient` so env-pin → HTML-harvest → rotation cache live in one place, plus a re-harvest+retry on connect failure mirroring the REST 401 path.

## Tests
The existing WS tests always pinned `HERMES_SESSION_TOKEN`, which masked the bug. Added `test_ws_proxy_harvests_token_when_env_unpinned` (fails on old code with `token=None`, passes on fix). Full `tests/board/` suite: 89 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)