### PR TITLE
release: v0.8.0-beta.2 — board live-updates + hermes env-seam bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ Tags older than v0.2.0 ship release notes inside the GitHub release
 page; this CHANGELOG starts at v0.2.0 (the Lemonade migration cut).
 For ADR-level architecture context see `docs/internal/adr/`.
 
+## [v0.8.0-beta.2] — 2026-06-22
+
+Bugfix release on the 0.8.0 beta line. No behaviour changes beyond the two
+fixes below — a safe upgrade from v0.8.0-beta.1. First release to carry #948.
+
+### Fixed
+- **Operator Board live updates restored.** The board's events-WS proxy
+  (`/api/board/events`) resolved its upstream Hermes session token from the
+  `HERMES_SESSION_TOKEN` env var only, while the REST path harvests the
+  rotating per-process token from the dashboard HTML. With no env pin (the
+  default), the WS connected upstream with no token, Hermes rejected the
+  upgrade (403), and the browser socket died with 1011 — so tasks created in
+  Hermes loaded on refresh but never pushed live to the board. The WS bridge
+  now shares the REST client's token resolution (env-pin → HTML-harvest →
+  rotation cache) and re-harvests + retries once on connect failure. (#949)
+- **Hermes privileged env seam.** A privileged env-write seam lets the
+  unprivileged provisioner write `root:root` `.env` files, so Hermes agent
+  config provisioning works under the dropped-root `hal0-api`. (#948)
+
 ## [v0.8.0-beta.1] — 2026-06-21
 
 First beta of the 0.8.0 line — the model-config, Hermes, and permissions

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ shared inference daemon; no extra process to babysit.
 curl -fsSL https://hal0.dev/install.sh | bash
 ```
 
-> **Status:** **v0.8.0-beta.1** — container-runtime era, declarative
+> **Status:** **v0.8.0-beta.2** — container-runtime era, declarative
 > config. Each slot (`chat`, `embed`, `rerank`, `stt`, `tts`, `img`, NPU
 > trio) runs as a dedicated podman container (`hal0-slot@<name>.service`).
 > Slot definitions live in `/etc/hal0/slots/<name>.toml`; backend profiles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.8.0-beta.1"
+version = "0.8.0-beta.2"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Release-prep only (version + changelog + README status line). **No tag is pushed** — cutting the release is a separate, deliberate step (`git tag v0.8.0-beta.2 && git push github v0.8.0-beta.2` fires `release.yml`).

## What's in this PR
- **`pyproject`** `0.8.0-beta.1` → `0.8.0-beta.2` (base `0.8.0` still satisfies the `release.yml` `base_matches` gate).
- **`CHANGELOG.md`** — new `## [v0.8.0-beta.2]` entry. Verified it extracts via `hal0.release.notes.extract_changelog_section` (1051 chars, both PR refs present).
- **`README.md`** — status line `v0.8.0-beta.1` → `v0.8.0-beta.2`.

No `manifest.json` changes — this is a code-only line, no toolbox-digest churn.

## Fixes shipped (first release to carry both)
- **#949** — Operator Board live updates restored. The events-WS proxy resolved its upstream Hermes session token from `HERMES_SESSION_TOKEN` env only, while REST harvests the rotating per-process token from the dashboard HTML. With no env pin (the default) the WS connected upstream tokenless → Hermes 403 → browser socket 1011, so tasks created in Hermes loaded on refresh but never pushed live. WS bridge now shares the REST token resolution + re-harvest/retry on connect failure.
- **#948** — Hermes privileged env seam so the unprivileged provisioner can write `root:root` `.env` files under the dropped-root `hal0-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)