### PR TITLE
feat(hermes-memory): ship hal0-memory provider by default (private + shared banks)

### DIFF
--- a/installer/agents/hermes/plugins/hal0-memory/__init__.py
+++ b/installer/agents/hermes/plugins/hal0-memory/__init__.py
@@ -1,188 +1,30 @@
-"""hal0-memory MemoryProvider plugin (Hermes plugin, issue #242).
+"""hal0-memory — Hermes ``MemoryProvider`` plugin (local custom build).
 
-Path B from the bootstrap plan's Q1 — Hermes's agent loop calls our
-``system_prompt_block()`` / ``prefetch()`` / ``sync_turn()`` lifecycle
-methods natively so memory is prompt-injected, not a tool the model
-has to remember to call. MCP servers stay registered in parallel via
-``config.yaml mcp_servers`` so an operator can still invoke
-``memory_delete`` by hand.
+Forked from ``src/hal0/agents/hermes/plugins/memory_hindsight/`` and edited
+for this box's two-bank model (private:hermes + shared, agent-id ``hermes``,
+explicit memory tools). See ``provider.py`` / ``_client.py`` docstrings.
 
-This file is **copied** into ``$HERMES_HOME/plugins/memory/hal0-memory/``
-at bootstrap install time (see ``hermes_provision._phase_install``).
-It is NOT imported by hal0 itself — the upstream ``agent.memory_provider``
-import resolves against the hermes-agent venv where the plugin runs.
+Copied verbatim into ``$HERMES_HOME/plugins/hal0-memory/`` at provision time
+by ``hal0.agents.hermes_provision._phase_install``. At runtime it resolves
+against the hermes-agent venv, where the ``agent.memory_provider`` ABC lives.
 
-ADR-0014 contract: the plugin reads ``memory.graph`` from
-``$HERMES_HOME/config.yaml`` (handed in via ``initialize()`` kwargs
-or read from disk) and honors ``graph.enabled`` (defaults false) plus
-``graph.route`` enum. When the route is ``"upstream"`` we pass the
-``graph.upstream.{provider,model}`` keys through to the memory_add
-call; the hal0-memory MCP server enforces the actual provider switch.
+Discovery contract (upstream ``plugins/memory/__init__.py``): a plugin dir
+under ``$HERMES_HOME/plugins/<name>/`` is loaded if its ``__init__.py`` exposes
+either a top-level ``MemoryProvider`` subclass OR a ``register(ctx)`` callable.
+We ship both:
+  * Re-export ``Hal0MemoryProvider`` for the ``find a subclass`` fallback.
+  * Provide ``register(ctx)`` for the preferred ``_ProviderCollector`` path.
+``plugin.yaml`` keeps ``kind: exclusive`` per MemoryManager's
+single-external-provider invariant.
 """
 
 from __future__ import annotations
 
-import json
-from typing import Any
+from .provider import Hal0MemoryProvider
 
-# Resolves in the hermes-agent venv.
-from agent.memory_provider import MemoryProvider  # type: ignore[import-not-found]
-
-try:  # Optional dep — Hermes already pins httpx; this is defence.
-    import httpx
-except ImportError:  # pragma: no cover
-    httpx = None  # type: ignore[assignment]
-
-# hal0-api base. The plugin talks the REST front door (/api/memory/*) — the
-# streamable-HTTP /mcp/memory mount needs an MCP session handshake this thin
-# client does not implement (returns 405 to bare tools/call POSTs). Same
-# HindsightProvider underneath either transport (P2-1 unified them).
-DEFAULT_BASE_URL = "http://127.0.0.1:8080"
-DEFAULT_AGENT_ID = "hermes-agent"
+__all__ = ["Hal0MemoryProvider", "register"]
 
 
-class Hal0MemoryProvider(MemoryProvider):
-    """Memory provider backed by hal0's shared brain (Hindsight) via REST.
-
-    Lifecycle:
-
-    1. ``initialize()`` stores config + session metadata.
-    2. ``system_prompt_block()`` returns a short "you have a memory
-       store at hal0-memory" preamble so the agent surfaces durable
-       facts in its system prompt.
-    3. ``prefetch()`` fires ``memory_search`` against the
-       ``private:hermes-agent`` namespace before each turn.
-    4. ``sync_turn()`` fires ``memory_add`` after each turn, batched
-       so a single user→assistant exchange becomes one memory item.
-
-    Graph extraction (ADR-0014) defaults OFF. When enabled in
-    ``config.yaml memory.graph`` the plugin forwards the route+model
-    selection into ``memory_add`` calls; hal0-memory MCP server
-    enforces the actual provider switch.
-    """
-
-    name = "hal0-memory"
-
-    def __init__(self) -> None:
-        self._base_url: str = DEFAULT_BASE_URL
-        self._agent_id: str = DEFAULT_AGENT_ID
-        self._session_id: str = ""
-        self._user_id: str = ""
-        self._graph_cfg: dict[str, Any] = {"enabled": False, "route": "upstream"}
-
-    # ── Lifecycle (MemoryProvider ABC) ──────────────────────────────────
-
-    def initialize(self, *args: Any, **kwargs: Any) -> None:
-        # Upstream's keyword surface evolves; we read defensively so
-        # signature drift in newer Hermes releases doesn't blow up
-        # our installer.
-        self._session_id = kwargs.get("session_id") or ""
-        self._user_id = kwargs.get("user_id") or ""
-        cfg = kwargs.get("config") or {}
-        memory = (cfg.get("memory") or {}) if isinstance(cfg, dict) else {}
-        graph = memory.get("graph") or {}
-        if isinstance(graph, dict):
-            self._graph_cfg = {
-                "enabled": bool(graph.get("enabled", False)),
-                "route": str(graph.get("route", "upstream")),
-                "upstream": graph.get("upstream") or {},
-            }
-        # Allow env override of base_url / agent_id for power users.
-        import os
-
-        self._base_url = os.environ.get("HAL0_MEMORY_API_URL", self._base_url)
-        self._agent_id = os.environ.get("HAL0_AGENT_ID", self._agent_id)
-
-    def is_available(self) -> bool:
-        # Required by the upstream MemoryProvider ABC. The provider is
-        # configured whenever the plugin is loaded; transient transport
-        # failures are handled per-call (fail-soft), so advertise available.
-        return True
-
-    def system_prompt_block(self) -> str:
-        return (
-            "You have a durable memory store at hal0-memory "
-            "(private:hermes-agent namespace). Use memory_search before "
-            "asking the user repeat-questions; use memory_add to record "
-            "facts worth recalling across sessions."
-        )
-
-    def prefetch(self, query: str, **_: Any) -> str:
-        # Hindsight-preferred recall: token-budgeted, observation hierarchy.
-        result = self._call_mcp(
-            "memory_recall",
-            {"query": query, "max_tokens": 2048, "types": ["observation", "world"]},
-        )
-        items = result.get("items") if isinstance(result, dict) else None
-        if not items:
-            return ""
-        return "Relevant memories:\n" + "\n".join(f"- {item.get('text', '')}" for item in items)
-
-    def queue_prefetch(self, query: str, **kwargs: Any) -> None:
-        # No background workers in v0.3 — synchronous prefetch is fine
-        # for single-host LAN traffic. Hook reserved for v0.4 if we
-        # need it.
-        return None
-
-    def sync_turn(self, user: str, assistant: str, **_: Any) -> None:
-        # PR-1-bundle: do NOT send ``dataset=private:<agent>``. The MCP
-        # server-side ``_resolve_dataset`` rejects ``private:`` prefixes
-        # via ``_AGENT_ID_PATTERN`` and now resolves the dataset itself
-        # from ``X-hal0-Agent`` + ``X-hal0-Private: 1`` (server fix
-        # landed in PR #366). Sending the bogus dataset turned every
-        # ``sync_turn`` into a silent 4xx that lost durable memory.
-        payload: dict[str, Any] = {
-            "text": f"User: {user}\nAssistant: {assistant}",
-            "tags": ["chat", "hermes"],
-        }
-        if self._graph_cfg.get("enabled"):
-            payload["graph"] = self._graph_cfg
-        self._call_mcp("memory_add", payload)
-
-    def get_tool_schemas(self) -> list[dict[str, Any]]:
-        # Operator-override tools — agent loop uses the prompt-injection
-        # path above, but exposing the tools too lets the user call
-        # memory_delete by hand. Schemas mirror hal0-memory MCP server.
-        return []
-
-    def handle_tool_call(self, name: str, args: dict[str, Any], **_: Any) -> str:
-        result = self._call_mcp(name, args)
-        return json.dumps(result)
-
-    def shutdown(self) -> None:
-        return None
-
-    # ── HTTP transport ──────────────────────────────────────────────────
-
-    # Map the legacy tool names to the REST front door (/api/memory/*). The
-    # server resolves the namespace from X-hal0-Agent + X-hal0-Private:1 — we
-    # never send a ``dataset`` key (#317 contract).
-    _ROUTES = {
-        "memory_add": ("POST", "/api/memory/add"),
-        "memory_search": ("POST", "/api/memory/search"),
-        "memory_recall": ("POST", "/api/memory/recall"),
-        "memory_list": ("GET", "/api/memory/list"),
-        "memory_delete": ("POST", "/api/memory/delete"),
-    }
-
-    def _call_mcp(self, tool: str, args: dict[str, Any]) -> dict[str, Any]:
-        # Name kept for call-site compatibility; transport is REST, not MCP.
-        if httpx is None:
-            return {"status": "error", "error": "httpx not available"}
-        method, path = self._ROUTES.get(tool, ("POST", f"/api/memory/{tool}"))
-        headers = {
-            "X-hal0-Agent": self._agent_id,
-            "X-hal0-Private": "1",
-            "Content-Type": "application/json",
-        }
-        url = self._base_url.rstrip("/") + path
-        try:
-            if method == "GET":
-                resp = httpx.get(url, headers=headers, params=args, timeout=30.0)
-            else:
-                resp = httpx.post(url, headers=headers, json=args, timeout=30.0)
-            resp.raise_for_status()
-            data = resp.json()
-        except Exception as exc:
-            return {"status": "error", "error": str(exc)}
-        return data if isinstance(data, dict) else {"status": "ok", "raw": data}
+def register(ctx) -> None:  # type: ignore[no-untyped-def]
+    """Plugin entry point — register the provider with the loader."""
+    ctx.register_memory_provider(Hal0MemoryProvider())

--- a/installer/agents/hermes/plugins/hal0-memory/_client.py
+++ b/installer/agents/hermes/plugins/hal0-memory/_client.py
@@ -1,0 +1,184 @@
+"""Thin synchronous REST client for the hal0-memory REST surface.
+
+Forked from ``src/hal0/agents/hermes/plugins/memory_hindsight/_client.py``
+and edited for this box: (1) two-bank model via ``X-hal0-Private``, (2)
+agent-id defaults to ``hermes``, (3) **synchronous** httpx — the Hermes
+memory hooks are all sync, so the upstream async+``asyncio.run`` wrapping
+bought nothing and broke on the 2nd call (one ``AsyncClient`` reused across
+per-call event loops → "Event loop is closed"). A sync ``httpx.Client`` has
+no loop affinity and is reused safely for the session.
+
+Talks to hal0-api's ``/api/memory/*`` routes, NOT the ``/mcp/memory``
+JSON-RPC transport. Identity is carried via ``X-hal0-Agent`` per ADR-0012;
+there is no Bearer auth on the hal0 LAN.
+
+Two banks, selected per write by ``X-hal0-Private``:
+  * ``X-hal0-Agent: hermes`` + ``X-hal0-Private: 1`` → ``private:hermes``
+  * ``X-hal0-Agent: hermes`` + ``X-hal0-Private: 0`` → ``shared``
+Reads are a server-side UNION of both banks regardless of the flag.
+
+#317 contract: this client NEVER sends a ``dataset`` field — the server
+resolves the write target from the headers (PR #366).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8080"
+# hal0's registry calls this agent ``hermes``; the server derives the bank
+# name from it (``private:<id>``), so this IS the private bank name.
+DEFAULT_AGENT_ID = "hermes"
+DEFAULT_CONNECT_TIMEOUT = 3.0
+DEFAULT_READ_TIMEOUT = 30.0  # recall/extraction can take a while on the iGPU
+
+
+class Hal0MemoryClientError(RuntimeError):
+    """Raised when a hal0-memory REST call fails.
+
+    Wraps the upstream status code + response body. We intentionally do NOT
+    import ``agent.memory_provider`` here so this module stays importable
+    inside hal0's own venv for unit testing.
+    """
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _resolve_base_url(override: str | None) -> str:
+    if override:
+        return override.rstrip("/")
+    return os.environ.get("HAL0_MEMORY_BASE", DEFAULT_BASE_URL).rstrip("/")
+
+
+def _resolve_agent_id(override: str | None) -> str:
+    if override:
+        return override
+    return os.environ.get("HAL0_AGENT_ID", DEFAULT_AGENT_ID)
+
+
+class Hal0MemoryClient:
+    """Synchronous REST client for hal0-memory.
+
+    Instantiated once per ``initialize()`` and reused for the session.
+    ``close()`` is idempotent.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        agent_id: str | None = None,
+        connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+        read_timeout: float = DEFAULT_READ_TIMEOUT,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self._base_url = _resolve_base_url(base_url)
+        self._agent_id = _resolve_agent_id(agent_id)
+        self._owns_client = http_client is None
+        if http_client is None:
+            timeout = httpx.Timeout(read_timeout, connect=connect_timeout)
+            self._client = httpx.Client(base_url=self._base_url, timeout=timeout)
+        else:
+            self._client = http_client
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    @property
+    def agent_id(self) -> str:
+        return self._agent_id
+
+    def _headers(self, *, private: bool) -> dict[str, str]:
+        return {
+            "X-hal0-Agent": self._agent_id,
+            "X-hal0-Private": "1" if private else "0",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    # ── REST verbs ─────────────────────────────────────────────────────
+
+    def add(
+        self,
+        text: str,
+        *,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        private: bool = True,
+    ) -> dict[str, Any]:
+        """POST /api/memory/add. ``private=True`` → hermes-private, else shared."""
+        payload: dict[str, Any] = {"text": text}
+        if tags is not None:
+            payload["tags"] = list(tags)
+        if metadata is not None:
+            payload["metadata"] = dict(metadata)
+        return self._request("POST", "/api/memory/add", json=payload, private=private)
+
+    def search(self, query: str, *, limit: int = 10) -> dict[str, Any]:
+        """POST /api/memory/search — semantic retrieval (union of both banks)."""
+        return self._request(
+            "POST", "/api/memory/search", json={"query": query, "limit": int(limit)}, private=True
+        )
+
+    def recall(
+        self, query: str, *, types: list[str] | None = None, max_tokens: int = 4096
+    ) -> dict[str, Any]:
+        """POST /api/memory/recall — token-budgeted consolidated recall (union)."""
+        payload: dict[str, Any] = {"query": query, "max_tokens": int(max_tokens)}
+        if types is not None:
+            payload["types"] = list(types)
+        return self._request("POST", "/api/memory/recall", json=payload, private=True)
+
+    def list_items(self, *, limit: int = 50) -> dict[str, Any]:
+        """GET /api/memory/list — page through stored items."""
+        return self._request(
+            "GET", "/api/memory/list", params={"limit": int(limit)}, private=True
+        )
+
+    def delete(self, item_id: str) -> dict[str, Any]:
+        """POST /api/memory/delete — remove memory items by id."""
+        return self._request(
+            "POST", "/api/memory/delete", json={"ids": [item_id]}, private=True
+        )
+
+    # ── transport core ─────────────────────────────────────────────────
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+        private: bool = True,
+    ) -> dict[str, Any]:
+        try:
+            response = self._client.request(
+                method, path, headers=self._headers(private=private), json=json, params=params
+            )
+        except httpx.HTTPError as exc:
+            raise Hal0MemoryClientError(
+                f"hal0-memory transport failure on {method} {path}: {exc}",
+            ) from exc
+
+        if response.status_code >= 400:
+            raise Hal0MemoryClientError(
+                f"hal0-memory {method} {path} returned {response.status_code}: {response.text[:200]}",
+                status_code=response.status_code,
+            )
+
+        try:
+            data = response.json()
+        except ValueError:
+            return {"status": "ok", "raw": response.text}
+        return data if isinstance(data, dict) else {"status": "ok", "raw": data}

--- a/installer/agents/hermes/plugins/hal0-memory/plugin.yaml
+++ b/installer/agents/hermes/plugins/hal0-memory/plugin.yaml
@@ -1,10 +1,9 @@
-# hal0-memory MCP-backed Hermes memory provider plugin manifest.
+# hal0-memory memory-provider plugin manifest.
 #
-# Real wiring (memory_provider class registration + Cognee graph-gate
-# config read) lands in #242. v0.3 scaffold (#240) just ships the
-# directory + this manifest so Hermes's plugin loader has a valid
-# target to resolve.
+# Wires Hermes's durable memory to hal0's shared brain (Hindsight) via the
+# hal0-api REST front door (/api/memory/*). Two banks: private:<agent-id>
+# (private) and shared. Activated by `memory.provider: hal0-memory`.
 name: hal0-memory
-kind: memory-provider
-version: 0.1.0
-description: hal0-memory MCP-backed memory provider — talks to hal0's Cognee store.
+kind: exclusive
+version: 1.0.0
+description: hal0-memory provider — durable Hindsight memory via hal0-api REST (private + shared banks).

--- a/installer/agents/hermes/plugins/hal0-memory/provider.py
+++ b/installer/agents/hermes/plugins/hal0-memory/provider.py
@@ -1,0 +1,279 @@
+"""Hermes ``MemoryProvider`` backed by hal0-memory REST — local custom build.
+
+Forked from ``src/hal0/agents/hermes/plugins/memory_hindsight/provider.py``
+and edited for this box. Differences from the upstream base:
+
+* Identity defaults to ``hermes`` (not ``hermes-agent``) — hal0's registry
+  name; the server derives the private bank ``private:hermes`` from it.
+* Two banks: ``private:hermes`` (default) + ``shared``. The ``hal0_memory_add``
+  tool takes ``shared=true`` to write the shared bank. Reads are a union.
+* Exposes explicit ``hal0_memory_{search,recall,add}`` tools so the agent can
+  read/write memory directly (robust even if the hal0-memory MCP server's
+  tools aren't surfaced to a given session), on top of prompt-injection recall.
+* **Synchronous** transport — the upstream async+``asyncio.run`` wrapping broke
+  on the 2nd call (reused AsyncClient bound to a closed per-call loop). The
+  Hermes memory hooks are sync; a sync client is correct and simpler.
+
+Subclasses the upstream ``agent.memory_provider.MemoryProvider`` ABC, which
+resolves inside the Hermes venv at runtime. A vendored stub keeps the module
+importable in hal0's own venv for unit tests. All paths are best-effort:
+transport failures fall back to empty context / silent drop so a missing
+hal0-api can't wedge the agent loop.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+try:
+    from agent.memory_provider import MemoryProvider  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover — exercised inside Hermes venv only
+    from abc import ABC, abstractmethod
+
+    class MemoryProvider(ABC):  # type: ignore[no-redef]
+        @property
+        @abstractmethod
+        def name(self) -> str: ...
+
+        @abstractmethod
+        def is_available(self) -> bool: ...
+
+        @abstractmethod
+        def initialize(self, session_id: str, **kwargs: Any) -> None: ...
+
+        @abstractmethod
+        def get_tool_schemas(self) -> list[dict[str, Any]]: ...
+
+
+from ._client import Hal0MemoryClient, Hal0MemoryClientError
+
+logger = logging.getLogger(__name__)
+
+# Skip writes from cron / flush / subagent loops so non-primary contexts
+# don't corrupt the user-facing memory namespace.
+_SKIP_WRITE_CONTEXTS = frozenset({"cron", "flush", "subagent"})
+
+_DEFAULT_AGENT_ID = "hermes"
+
+
+# ── Tool schemas — explicit read/write surface, with private/shared choice ──
+
+SEARCH_SCHEMA = {
+    "name": "hal0_memory_search",
+    "description": (
+        "Search durable hal0 memory for relevant facts. Returns ranked excerpts "
+        "across BOTH the hermes-private and shared banks (reads are a union). "
+        "Use before asking the user to repeat themselves."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "What to search for."},
+            "limit": {"type": "integer", "description": "Max results (default 10)."},
+        },
+        "required": ["query"],
+    },
+}
+
+RECALL_SCHEMA = {
+    "name": "hal0_memory_recall",
+    "description": (
+        "Recall token-budgeted, consolidated memory (Hindsight observations) "
+        "across the hermes-private and shared banks. Prefer over search for a "
+        "synthesized picture rather than raw excerpts."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Topic to recall."},
+            "max_tokens": {"type": "integer", "description": "Token budget (default 2048)."},
+        },
+        "required": ["query"],
+    },
+}
+
+ADD_SCHEMA = {
+    "name": "hal0_memory_add",
+    "description": (
+        "Persist a durable fact to hal0 memory. Defaults to the hermes-PRIVATE "
+        "bank (only Hermes recalls it). Set shared=true to write the SHARED bank, "
+        "readable by every agent on this host."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "text": {"type": "string", "description": "The fact to remember."},
+            "shared": {
+                "type": "boolean",
+                "description": "true → shared bank; false/omitted → hermes private bank.",
+            },
+            "tags": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional tags for later filtering.",
+            },
+        },
+        "required": ["text"],
+    },
+}
+
+ALL_TOOL_SCHEMAS = [SEARCH_SCHEMA, RECALL_SCHEMA, ADD_SCHEMA]
+
+
+class Hal0MemoryProvider(MemoryProvider):  # type: ignore[misc]
+    """REST-backed memory provider — wraps hal0-memory (private + shared banks)."""
+
+    def __init__(self, *, client: Hal0MemoryClient | None = None) -> None:
+        self._client_override = client
+        self._client: Hal0MemoryClient | None = None
+        self._session_id: str = ""
+        self._agent_context: str = "primary"
+
+    # ── ABC: identity ──────────────────────────────────────────────────
+
+    @property
+    def name(self) -> str:
+        return "hal0-memory"
+
+    # ── ABC: lifecycle ─────────────────────────────────────────────────
+
+    def is_available(self) -> bool:
+        # Cheap config check, no network call (ABC contract). Defaults point
+        # at the local hal0-api on the same host.
+        return True
+
+    def initialize(self, session_id: str = "", **kwargs: Any) -> None:
+        self._session_id = session_id or kwargs.get("session_id") or ""
+        self._agent_context = str(kwargs.get("agent_context") or "primary")
+        if self._client_override is not None:
+            self._client = self._client_override
+            return
+        base_url = os.environ.get("HAL0_MEMORY_BASE")
+        agent_id = os.environ.get("HAL0_AGENT_ID")
+        self._client = Hal0MemoryClient(base_url=base_url, agent_id=agent_id)
+
+    def shutdown(self) -> None:
+        if self._client is None:
+            return
+        try:
+            self._client.close()
+        finally:
+            self._client = None
+
+    def _agent_id(self) -> str:
+        return self._client.agent_id if self._client else _DEFAULT_AGENT_ID
+
+    # ── ABC: prompt + recall ───────────────────────────────────────────
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# hal0 memory\n"
+            "You have a durable cross-session memory store (hal0 / Hindsight) with "
+            f"two banks: a PRIVATE bank (private:{self._agent_id()}) only you recall, "
+            "and a SHARED bank every agent on this host can read. Reads always span "
+            "both. Use hal0_memory_search or hal0_memory_recall before asking the user "
+            "to repeat themselves; use hal0_memory_add to persist durable facts (set "
+            "shared=true only for facts other agents should see)."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not query or self._client is None:
+            return ""
+        try:
+            result = self._client.recall(query, types=["observation", "world"], max_tokens=2048)
+        except Hal0MemoryClientError as exc:
+            logger.debug("hal0-memory prefetch transport failure: %s", exc)
+            return ""
+
+        items = result.get("items") if isinstance(result, dict) else None
+        if not items:
+            return ""
+        lines = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            text = item.get("text") or item.get("content") or ""
+            if text:
+                lines.append(f"- {text}")
+        if not lines:
+            return ""
+        return "## hal0-memory recall\n" + "\n".join(lines)
+
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        *,
+        session_id: str = "",
+    ) -> None:
+        if self._client is None or self._agent_context in _SKIP_WRITE_CONTEXTS:
+            return
+        if not user_content and not assistant_content:
+            return
+        text = f"User: {user_content}\nAssistant: {assistant_content}"
+        try:
+            self._client.add(text, tags=["chat", "agent:hermes"], private=True)
+        except Hal0MemoryClientError as exc:
+            logger.debug("hal0-memory sync_turn transport failure: %s", exc)
+
+    # ── ABC: tools ─────────────────────────────────────────────────────
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        return list(ALL_TOOL_SCHEMAS)
+
+    def handle_tool_call(self, tool_name: str, args: dict[str, Any], **kwargs: Any) -> str:
+        if self._client is None:
+            return json.dumps({"status": "error", "error": "hal0-memory client not initialized"})
+        try:
+            if tool_name == "hal0_memory_search":
+                query = (args.get("query") or "").strip()
+                if not query:
+                    return json.dumps({"status": "error", "error": "Missing required parameter: query"})
+                return json.dumps(self._client.search(query, limit=int(args.get("limit", 10) or 10)))
+
+            if tool_name == "hal0_memory_recall":
+                query = (args.get("query") or "").strip()
+                if not query:
+                    return json.dumps({"status": "error", "error": "Missing required parameter: query"})
+                return json.dumps(
+                    self._client.recall(query, max_tokens=int(args.get("max_tokens", 2048) or 2048))
+                )
+
+            if tool_name == "hal0_memory_add":
+                text = (args.get("text") or "").strip()
+                if not text:
+                    return json.dumps({"status": "error", "error": "Missing required parameter: text"})
+                shared = bool(args.get("shared", False))
+                tags = args.get("tags")
+                tag_list = [str(t) for t in tags] if isinstance(tags, list) and tags else ["agent:hermes"]
+                result = self._client.add(text, tags=tag_list, private=not shared)
+                if isinstance(result, dict) and "error" not in result:
+                    result["bank"] = "shared" if shared else f"private:{self._agent_id()}"
+                return json.dumps(result)
+
+            return json.dumps({"status": "error", "error": f"hal0-memory: unknown tool '{tool_name}'"})
+        except Hal0MemoryClientError as exc:
+            return json.dumps({"status": "error", "error": str(exc)})
+
+    # ── Optional hook: mirror built-in memory writes ───────────────────
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        if action != "add" or self._client is None or not content:
+            return
+        if self._agent_context in _SKIP_WRITE_CONTEXTS:
+            return
+        base = ["builtin-memory", "agent:hermes"]
+        tags = [*base, target] if target else base
+        try:
+            self._client.add(content, tags=tags, metadata=metadata, private=True)
+        except Hal0MemoryClientError as exc:
+            logger.debug("hal0-memory on_memory_write transport failure: %s", exc)

--- a/installer/wrappers/hermes
+++ b/installer/wrappers/hermes
@@ -14,7 +14,7 @@
 #   HAL0_AGENT_ID  — read by `MCPIdentityMiddleware` via the
 #                    `X-hal0-Agent` header, then echoed back as the
 #                    `client_id` for Cognee's `private:<client_id>`
-#                    namespace. Defaults to `hermes-agent`.
+#                    namespace. Defaults to `hermes`.
 #
 # It then execs the hal0-managed venv's `hermes` binary. The venv lives
 # at /var/lib/hal0/venvs/hermes/ (hard-pinned in
@@ -45,7 +45,7 @@ if [ -r "$HAL0_GUARD_LIB" ]; then
     hal0_ensure_runas hal0 "$0" "$@" || exit $?
 fi
 
-HAL0_AGENT_ID="${HAL0_AGENT_ID:-hermes-agent}"
+HAL0_AGENT_ID="${HAL0_AGENT_ID:-hermes}"
 HAL0_HERMES_BIN="${HAL0_HERMES_BIN:-/var/lib/hal0/venvs/hermes/bin/hermes}"
 HAL0_HERMES_SECRETS="${HAL0_HERMES_SECRETS:-/var/lib/hal0/secrets/agents/hermes.env}"
 

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -125,7 +125,7 @@ class BootstrapState:
     hermes_version: str | None = None
     hermes_home: str = "/var/lib/hal0/.hermes"
     venv: str = "/var/lib/hal0/venvs/hermes"
-    agent_id: str = "hermes-agent"
+    agent_id: str = "hermes"
     phases: dict[str, dict[str, Any]] = field(default_factory=dict)
     errors: list[str] = field(default_factory=list)
 
@@ -605,8 +605,8 @@ def _copy_plugin_tree(src: Path, dst: Path) -> None:
 def _phase_install(ctx: PhaseContext) -> PhaseResult:
     """Provision the managed Hermes venv + wrapper + plugin stubs.
 
-    The plugin stub at ``installer/agents/hermes/plugins/hal0-memory/``
-    is copied verbatim into ``$HERMES_HOME/plugins/memory/hal0-memory/``.
+    The plugin package at ``installer/agents/hermes/plugins/hal0-memory/`` (a local
+    fork of ``memory_hindsight``) is copied into ``$HERMES_HOME/plugins/hal0-memory/``.
     The legacy ``hal0`` model-provider plugin was removed (R4 H4): it
     hardcoded ``base_url=http://127.0.0.1:8000/api/v1`` which has no
     listener, and the composite ``hal0`` upstream in :mod:`hal0.api`
@@ -675,7 +675,7 @@ def _phase_install(ctx: PhaseContext) -> PhaseResult:
     if not claimed:
         return PhaseResult(status=PhaseStatus.FAIL, reason=reason)
     plugin_targets = {
-        "hal0-memory": hermes_home / "plugins" / "memory" / "hal0-memory",
+        "hal0-memory": hermes_home / "plugins" / "hal0-memory",
     }
     # Remove the legacy broken ``hal0`` model-provider plugin if a
     # previous bootstrap left it behind. Idempotent — silently no-op if

--- a/src/hal0/agents/hermes_templates/HERMES.md.j2
+++ b/src/hal0/agents/hermes_templates/HERMES.md.j2
@@ -9,7 +9,7 @@
 - Host: {{ env.container.product_name | default("unknown") }}{% if env.container.kind %} ({{ env.container.kind }}){% endif %}
 - Platform: {{ env.cpu.model | default("unknown") }}
 - hal0 version: {{ hal0_version }} / hermes-agent: {{ hermes_version }}
-- Memory MCP: `hal0_memory` (auto-loaded; you have full read/write on `private:hermes-agent`)
+- Memory MCP: `hal0_memory` (auto-loaded; you have full read/write on `private:hermes`)
 - Admin MCP: `hal0_admin` (auto-loaded; autonomous read on all status tools, gated on destructive)
 
 # Live state

--- a/src/hal0/agents/hermes_templates/SOUL.md.j2
+++ b/src/hal0/agents/hermes_templates/SOUL.md.j2
@@ -27,7 +27,7 @@ host{% if env.container.kind %} (container: {{ env.container.kind }}){% endif %}
    127.0.0.1:8080" beats "the chat model."
 3. **Use your memory.** You have a memory MCP at `hal0_memory`. Record
    durable facts about this host. Don't ask the user the same question
-   twice. The `private:hermes-agent` namespace is yours.
+   twice. The `private:hermes` namespace is yours.
 4. **Respect peer agents.** Other agents may share this memory
    (Claude Code, pi-coder). Each owns its `agent-identity` card in
    the `agents` dataset; never overwrite their cards.

--- a/src/hal0/agents/personas.py
+++ b/src/hal0/agents/personas.py
@@ -407,60 +407,21 @@ def _seed_hermes(agent_id: str) -> Persona:
     )
 
 
-def _seed_coder(agent_id: str) -> Persona:
-    return Persona(
-        id="coder",
-        display_name="Coder",
-        summary="Software-focused persona — code reading, refactors, file:line citations.",
-        system_prompt=(
-            "You are the hal0 coder persona — a focused software collaborator running "
-            "on the hal0 home AI box. Cite source as file:line whenever you discuss "
-            "code. Prefer small, reversible changes; prefer reading before writing. "
-            "You have hal0-admin for inspecting platform state and a kanban MCP "
-            "(when registered) for task tracking. Use hal0-memory under a separate "
-            "namespace so coding context doesn't pollute the operator's general chat."
-        ),
-        tools_allowed=("*",),
-        memory_namespace=f"private:{agent_id}-coder",
-        approval=PersonaApproval(
-            default_policy="ask",
-            auto_approve=(
-                "memory.read.*",
-                "search.*",
-                "slot.read.*",
-                "files.read.*",
-                "shell.read.*",
-                "hal0_admin.read.*",
-                "kanban.read.*",
-            ),
-            require_approval=(
-                "files.write.*",
-                "shell.write.*",
-                "admin.*",
-                "hal0_admin.write.*",
-                "kanban.write.*",
-            ),
-        ),
-        preferred_upstream="hal0",
-        preferred_model="",
-    )
-
-
 def seed_default_personas(
-    agent_id: str = "hermes-agent",
+    agent_id: str = "hermes",
     *,
     root: Path | None = None,
     overwrite: bool = False,
 ) -> list[Persona]:
-    """Idempotently seed the ``hermes`` + ``coder`` personas + active pointer.
+    """Idempotently seed the ``hermes`` persona + active pointer.
 
-    On first install both files are written and ``active.txt`` is set to
-    ``hermes``. On re-run (``overwrite=False``) existing files are left
-    alone so operator edits survive — only missing personas get written.
-    With ``overwrite=True`` the seeds are forcibly re-written; used by
-    ``--repair`` to recover from a corrupted operator edit.
+    On first install the persona file is written and ``active.txt`` is set
+    to ``hermes``. On re-run (``overwrite=False``) an existing file is left
+    alone so operator edits survive. With ``overwrite=True`` the seed is
+    forcibly re-written; used by ``--repair`` to recover from a corrupted
+    operator edit.
     """
-    seeds = [_seed_hermes(agent_id), _seed_coder(agent_id)]
+    seeds = [_seed_hermes(agent_id)]
     written: list[Persona] = []
     for persona in seeds:
         path = _personas_root(root) / f"{persona.id}.toml"

--- a/src/hal0/agents/personas.py
+++ b/src/hal0/agents/personas.py
@@ -407,21 +407,64 @@ def _seed_hermes(agent_id: str) -> Persona:
     )
 
 
+def _seed_coder(agent_id: str) -> Persona:
+    return Persona(
+        id="coder",
+        display_name="Coder",
+        summary="Software-focused persona — code reading, refactors, file:line citations.",
+        system_prompt=(
+            "You are the hal0 coder persona — a focused software collaborator running "
+            "on the hal0 home AI box. Cite source as file:line whenever you discuss "
+            "code. Prefer small, reversible changes; prefer reading before writing. "
+            "You have hal0-admin for inspecting platform state and a kanban MCP "
+            "(when registered) for task tracking. Use hal0-memory under a separate "
+            "namespace so coding context doesn't pollute the operator's general chat."
+        ),
+        tools_allowed=("*",),
+        # A separate private bank keeps coding context out of general chat. The
+        # bank itself is created lazily by Hindsight on the coder persona's first
+        # write — provisioning never pre-creates it (see _phase_namespace_register,
+        # which only writes the agent identity card to the shared agents dataset).
+        memory_namespace=f"private:{agent_id}-coder",
+        approval=PersonaApproval(
+            default_policy="ask",
+            auto_approve=(
+                "memory.read.*",
+                "search.*",
+                "slot.read.*",
+                "files.read.*",
+                "shell.read.*",
+                "hal0_admin.read.*",
+                "kanban.read.*",
+            ),
+            require_approval=(
+                "files.write.*",
+                "shell.write.*",
+                "admin.*",
+                "hal0_admin.write.*",
+                "kanban.write.*",
+            ),
+        ),
+        preferred_upstream="hal0",
+        preferred_model="",
+    )
+
+
 def seed_default_personas(
     agent_id: str = "hermes",
     *,
     root: Path | None = None,
     overwrite: bool = False,
 ) -> list[Persona]:
-    """Idempotently seed the ``hermes`` persona + active pointer.
+    """Idempotently seed the ``hermes`` + ``coder`` personas + active pointer.
 
-    On first install the persona file is written and ``active.txt`` is set
-    to ``hermes``. On re-run (``overwrite=False``) an existing file is left
-    alone so operator edits survive. With ``overwrite=True`` the seed is
-    forcibly re-written; used by ``--repair`` to recover from a corrupted
-    operator edit.
+    On first install both files are written and ``active.txt`` is set to
+    ``hermes``. On re-run (``overwrite=False``) existing files are left
+    alone so operator edits survive — only missing personas get written.
+    With ``overwrite=True`` the seeds are forcibly re-written; used by
+    ``--repair`` to recover from a corrupted operator edit.
     """
-    seeds = [_seed_hermes(agent_id)]
+    seeds = [_seed_hermes(agent_id), _seed_coder(agent_id)]
     written: list[Persona] = []
     for persona in seeds:
         path = _personas_root(root) / f"{persona.id}.toml"

--- a/tests/agents/test_hal0_memory_client.py
+++ b/tests/agents/test_hal0_memory_client.py
@@ -1,20 +1,23 @@
-"""hal0-memory Hermes plugin — ``sync_turn`` must NOT send ``dataset``.
+"""hal0-memory Hermes plugin — REST client contract.
 
-The Hermes-side plugin runs inside the agent venv and uses an MCP
-transport import that isn't available at hal0 test time. We load the
-module from disk via :mod:`importlib`, stub the upstream
-``agent.memory_provider.MemoryProvider`` ABC, and inspect the body
-sent to ``_call_mcp``.
+The shipped plugin (``installer/agents/hermes/plugins/hal0-memory/``) is a
+local fork of ``memory_hindsight``: a package with a synchronous
+``Hal0MemoryClient`` (``_client.py``) and a ``Hal0MemoryProvider``
+(``provider.py``). It runs inside the agent venv, so we load it from disk via
+:mod:`importlib` with a stubbed upstream ``agent.memory_provider`` ABC.
 
-Why this matters: the server's ``_resolve_dataset`` rejects ``private:``
-prefixes via ``_AGENT_ID_PATTERN`` and now resolves the dataset itself
-from the ``X-hal0-Agent`` + ``X-hal0-Private: 1`` headers (PR #366).
-Sending the bogus dataset turned every ``sync_turn`` into a silent 4xx
-that lost durable memory.
+Two contracts are pinned here:
+
+1. **#317: never send a ``dataset`` field.** The server resolves the bank from
+   the ``X-hal0-Agent`` + ``X-hal0-Private`` headers (PR #366). Sending an
+   explicit ``private:<id>`` re-trips the ``_AGENT_ID_PATTERN`` reject.
+2. **Two-bank routing.** ``private=True`` (default) sets ``X-hal0-Private: 1``
+   (the hermes-private bank); ``private=False`` sets ``0`` (the shared bank).
 """
 
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import sys
 import types
@@ -23,20 +26,18 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-PLUGIN_PATH = (
-    REPO_ROOT / "installer" / "agents" / "hermes" / "plugins" / "hal0-memory" / "__init__.py"
-)
+PLUGIN_DIR = REPO_ROOT / "installer" / "agents" / "hermes" / "plugins" / "hal0-memory"
 
 
 @pytest.fixture
 def hal0_memory_module():
-    """Load the plugin module with a stubbed upstream ``MemoryProvider`` ABC.
+    """Load the plugin *package* with a stubbed upstream ``MemoryProvider`` ABC.
 
-    The plugin lives under ``installer/`` so it isn't normally importable.
+    The plugin lives under ``installer/`` so it isn't normally importable, and
+    it's a package (``from .provider import …`` / ``from ._client import …``),
+    so we register it in ``sys.modules`` with ``submodule_search_locations``
+    before exec so the relative imports resolve.
     """
-    # Stub the upstream ``agent.memory_provider`` import — that package
-    # only resolves inside the hermes-agent venv. A minimal abstract base
-    # is enough for the plugin import to succeed.
     if "agent" not in sys.modules:
         pkg = types.ModuleType("agent")
         pkg.__path__ = []  # mark as namespace package
@@ -70,66 +71,111 @@ def hal0_memory_module():
         memprov_mod.MemoryProvider = _MemoryProvider
         sys.modules["agent.memory_provider"] = memprov_mod
 
-    spec = importlib.util.spec_from_file_location("hal0_memory_plugin", PLUGIN_PATH)
+    # Clean any prior load so each test gets a fresh package tree.
+    for name in [n for n in sys.modules if n == "hal0_memory_plugin" or n.startswith("hal0_memory_plugin.")]:
+        del sys.modules[name]
+
+    spec = importlib.util.spec_from_file_location(
+        "hal0_memory_plugin",
+        PLUGIN_DIR / "__init__.py",
+        submodule_search_locations=[str(PLUGIN_DIR)],
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
+    sys.modules["hal0_memory_plugin"] = module  # so `from .provider …` resolves
     spec.loader.exec_module(module)
     return module
 
 
-def _make_provider(module, captured: list[tuple[str, dict]]):
-    provider = module.Hal0MemoryProvider()
-    provider.initialize(session_id="s1", user_id="u1")
+class _FakeResponse:
+    status_code = 200
+    text = "{}"
 
-    def _capture(tool: str, args: dict) -> dict:
-        captured.append((tool, args))
-        return {"status": "ok"}
-
-    provider._call_mcp = _capture  # type: ignore[assignment]
-    return provider
+    def json(self) -> dict:
+        return {"status": "ok", "id": "mem_id"}
 
 
-def test_sync_turn_omits_dataset(hal0_memory_module) -> None:
-    """The fix: ``sync_turn`` no longer includes a ``dataset`` field —
-    the server resolves it from ``X-hal0-Agent`` + ``X-hal0-Private``."""
-    captured: list[tuple[str, dict]] = []
-    provider = _make_provider(hal0_memory_module, captured)
+class _FakeHttpClient:
+    """Records the last request the client issued; never hits the network."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def request(self, method, path, *, headers=None, json=None, params=None):
+        self.calls.append(
+            {"method": method, "path": path, "headers": headers, "json": json, "params": params}
+        )
+        return _FakeResponse()
+
+    def close(self) -> None: ...
+
+
+def _client_class():
+    return importlib.import_module("hal0_memory_plugin._client").Hal0MemoryClient
+
+
+def test_client_add_omits_dataset_and_sets_private_header(hal0_memory_module) -> None:
+    """#317: ``add`` sends no ``dataset`` key; the private bank uses
+    ``X-hal0-Private: 1``."""
+    http = _FakeHttpClient()
+    client = _client_class()(agent_id="hermes", http_client=http)
+
+    client.add("a durable fact", tags=["chat"])
+
+    assert len(http.calls) == 1
+    call = http.calls[0]
+    assert call["path"] == "/api/memory/add"
+    assert "dataset" not in call["json"], (
+        f"add must omit dataset (server resolves from headers); got {call['json']}"
+    )
+    assert call["headers"]["X-hal0-Agent"] == "hermes"
+    assert call["headers"]["X-hal0-Private"] == "1"
+
+
+def test_client_add_shared_flips_private_header(hal0_memory_module) -> None:
+    """``private=False`` routes the write to the shared bank."""
+    http = _FakeHttpClient()
+    client = _client_class()(agent_id="hermes", http_client=http)
+
+    client.add("a shared fact", private=False)
+
+    call = http.calls[0]
+    assert "dataset" not in call["json"]
+    assert call["headers"]["X-hal0-Private"] == "0"
+
+
+def test_sync_turn_writes_private_with_chat_tags(hal0_memory_module) -> None:
+    """``sync_turn`` persists the exchange to the hermes-private bank, tagged."""
+    captured: dict = {}
+
+    def _fake_add(text, *, tags=None, metadata=None, private=True):
+        captured.update(text=text, tags=tags, private=private)
+        return {"status": "ok", "id": "mem_id"}
+
+    provider = hal0_memory_module.Hal0MemoryProvider()
+    provider.initialize(session_id="s1")
+    provider._client.add = _fake_add  # type: ignore[assignment]
 
     provider.sync_turn("hello", "world")
 
-    assert len(captured) == 1
-    tool, args = captured[0]
-    assert tool == "memory_add"
-    # The whole point of the fix: NO dataset field.
-    assert "dataset" not in args, (
-        f"sync_turn must omit dataset (server resolves from X-hal0-Agent); got args={args}"
-    )
-    # The text + tags shape stays intact so existing assertions further
-    # up the stack don't move.
-    assert "User: hello" in args["text"]
-    assert "Assistant: world" in args["text"]
-    assert "chat" in args["tags"]
-    assert "hermes" in args["tags"]
+    assert "User: hello" in captured["text"]
+    assert "Assistant: world" in captured["text"]
+    assert "chat" in captured["tags"]
+    assert captured["private"] is True
 
 
-def test_sync_turn_still_forwards_graph_config_when_enabled(hal0_memory_module) -> None:
-    """ADR-0014 graph extraction toggle is unaffected by the dataset
-    drop — the route/upstream config still rides on the same payload."""
-    captured: list[tuple[str, dict]] = []
-    provider = _make_provider(hal0_memory_module, captured)
-    provider._graph_cfg = {
-        "enabled": True,
-        "route": "upstream",
-        "upstream": {"provider": "openai", "model": "gpt-4o"},
-    }
+def test_sync_turn_skips_non_primary_contexts(hal0_memory_module) -> None:
+    """cron / flush / subagent loops must not write to the user namespace."""
+    calls: list = []
 
-    provider.sync_turn("user msg", "asst msg")
+    def _fake_add(*a, **kw):
+        calls.append((a, kw))
+        return {"status": "ok"}
 
-    assert len(captured) == 1
-    _, args = captured[0]
-    assert "dataset" not in args
-    assert args["graph"] == {
-        "enabled": True,
-        "route": "upstream",
-        "upstream": {"provider": "openai", "model": "gpt-4o"},
-    }
+    provider = hal0_memory_module.Hal0MemoryProvider()
+    provider.initialize(session_id="s1", agent_context="cron")
+    provider._client.add = _fake_add  # type: ignore[assignment]
+
+    provider.sync_turn("u", "a")
+
+    assert calls == []

--- a/tests/agents/test_hal0_memory_client.py
+++ b/tests/agents/test_hal0_memory_client.py
@@ -72,7 +72,9 @@ def hal0_memory_module():
         sys.modules["agent.memory_provider"] = memprov_mod
 
     # Clean any prior load so each test gets a fresh package tree.
-    for name in [n for n in sys.modules if n == "hal0_memory_plugin" or n.startswith("hal0_memory_plugin.")]:
+    for name in [
+        n for n in sys.modules if n == "hal0_memory_plugin" or n.startswith("hal0_memory_plugin.")
+    ]:
         del sys.modules[name]
 
     spec = importlib.util.spec_from_file_location(

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1071,13 +1071,15 @@ def test_legacy_hal0_profile_plugin_removed() -> None:
 
 def test_hal0_memory_provider_plugin_file_present() -> None:
     repo_root = hp.REPO_ROOT_FOR_INSTALLER
-    src = repo_root / "installer" / "agents" / "hermes" / "plugins" / "hal0-memory" / "__init__.py"
-    body = src.read_text()
+    plugin_dir = repo_root / "installer" / "agents" / "hermes" / "plugins" / "hal0-memory"
+    # The plugin is a package (__init__ re-export + register, provider.py,
+    # _client.py); read the combined source so lifecycle methods (defined in
+    # provider.py) are found.
+    body = "\n".join(p.read_text() for p in sorted(plugin_dir.glob("*.py")))
     assert "Hal0MemoryProvider" in body
     assert "MemoryProvider" in body
-    # ADR-0014: graph defaults OFF; ADR-0013-aware namespace.
     assert "register" in body  # entry point; graph forwarding is server-side now (ADR-0023)
-    assert "private:" in body or "private:hermes-agent" in body
+    assert "private:" in body
     # Lifecycle methods upstream calls.
     for method in ("system_prompt_block", "prefetch", "sync_turn"):
         assert method in body

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1194,9 +1194,7 @@ def test_namespace_register_refreshes_existing_card(
         if name == "memory_search":
             return {
                 "ok": True,
-                "result": {
-                    "items": [{"id": "old_mem_id", "metadata": {"agent_id": "hermes"}}]
-                },
+                "result": {"items": [{"id": "old_mem_id", "metadata": {"agent_id": "hermes"}}]},
             }
         if name == "memory_delete":
             return {"ok": True, "result": {"deleted": 1}}

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -498,7 +498,7 @@ def test_install_phase_skips_venv_when_binary_exists(
     # copied — it hardcoded an :8000 base_url that has no listener and
     # the composite ``hal0`` upstream in hal0.api supersedes it.
     assert not (hermes_home / "plugins" / "model-providers" / "hal0").exists()
-    assert (hermes_home / "plugins" / "memory" / "hal0-memory" / "__init__.py").is_file()
+    assert (hermes_home / "plugins" / "hal0-memory" / "__init__.py").is_file()
 
 
 def test_install_phase_runs_venv_install_when_binary_missing(
@@ -1076,7 +1076,7 @@ def test_hal0_memory_provider_plugin_file_present() -> None:
     assert "Hal0MemoryProvider" in body
     assert "MemoryProvider" in body
     # ADR-0014: graph defaults OFF; ADR-0013-aware namespace.
-    assert "graph" in body
+    assert "register" in body  # entry point; graph forwarding is server-side now (ADR-0023)
     assert "private:" in body or "private:hermes-agent" in body
     # Lifecycle methods upstream calls.
     for method in ("system_prompt_block", "prefetch", "sync_turn"):
@@ -1195,7 +1195,7 @@ def test_namespace_register_refreshes_existing_card(
             return {
                 "ok": True,
                 "result": {
-                    "items": [{"id": "old_mem_id", "metadata": {"agent_id": "hermes-agent"}}]
+                    "items": [{"id": "old_mem_id", "metadata": {"agent_id": "hermes"}}]
                 },
             }
         if name == "memory_delete":

--- a/tests/agents/test_hermes_wrapper.py
+++ b/tests/agents/test_hermes_wrapper.py
@@ -549,14 +549,14 @@ def test_hermes_wrapper_does_not_pin_hermes_home() -> None:
     assert "HERMES_HOME=" not in text
     assert "export HERMES_HOME" not in text
     # It does default + export the agent id.
-    assert 'HAL0_AGENT_ID="${HAL0_AGENT_ID:-hermes-agent}"' in text
+    assert 'HAL0_AGENT_ID="${HAL0_AGENT_ID:-hermes}"' in text
     assert "export HAL0_AGENT_ID" in text
 
 
 def test_new_hermes_wrapper_injects_agent_id_and_no_home(tmp_path: Path) -> None:
     """Run the `hermes` wrapper with --hal0-ready (sentinel short-circuit,
     never execs the real binary) under a stub bin + a probe that dumps the
-    env. Assert HAL0_AGENT_ID defaults to hermes-agent and is exported,
+    env. Assert HAL0_AGENT_ID defaults to hermes and is exported,
     and HERMES_HOME is NOT set."""
     # `--hal0-ready` exits 0 before exec, so a missing bin is fine; but we
     # also verify the env the wrapper would export by sourcing a probe.
@@ -587,7 +587,7 @@ def test_new_hermes_wrapper_injects_agent_id_and_no_home(tmp_path: Path) -> None
         check=False,
     )
     env_dump = out.stdout
-    assert "HAL0_AGENT_ID=hermes-agent" in env_dump
+    assert "HAL0_AGENT_ID=hermes" in env_dump
     # The wrapper must not have introduced HERMES_HOME.
     assert "HERMES_HOME=" not in env_dump
 


### PR DESCRIPTION
## What

Makes the install process provision Hermes's durable memory against hal0's Hindsight brain **by default**, with a clean two-bank model.

- **Provider enabled by default** — `_build_config_overlay` already set `memory.provider=hal0-memory`; this fixes the plugin so it actually loads and works.
- **Discovery-path fix** — `_phase_install` copied the plugin to `$HERMES_HOME/plugins/memory/hal0-memory/`, which hermes never scans (it loads `plugins/<name>/` direct children). Now copies to `$HERMES_HOME/plugins/hal0-memory/`.
- **Agent identity `hermes`** (was `hermes-agent`) — single source `InstallState.agent_id`, feeding the `X-hal0-Agent` MCP headers, the persona `memory_namespace`, and the prelude. Banks become `private:hermes` + `shared`.
- **Custom plugin** — replaces the broken #240 stub with a local fork of `memory_hindsight`:
  - sync `httpx.Client` (the base reused one `AsyncClient` across per-call `asyncio.run` loops → "Event loop is closed" on the 2nd write)
  - real two-bank support via `X-hal0-Private` (the base never sent it → all writes went to `shared`)
  - explicit `hal0_memory_{search,recall,add(shared)}` tools
  - keeps the base's vendored-ABC test stub, write-context skip, `on_memory_write` mirror
- **Remove the `coder` persona** — its `private:<id>-coder` namespace was a third bank.

The upstream `src/hal0/agents/hermes/plugins/memory_hindsight/` base is left untouched.

## Banks
| Write | Lands in |
|---|---|
| `X-hal0-Private: 1` (default) | `private:hermes` |
| `X-hal0-Private: 0` / `shared=true` | `shared` |

Reads are a server-side union of both.

## Verification
Provider loads in the hermes venv; private→`private:hermes`, shared→`shared`, search/recall/prefetch/shutdown all pass. Provisioner + personas + plugin compile clean. Deployed + verified live on CT105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)