### PR TITLE
fix(updater): compare versions with PEP 440, not a digit-tuple

### DIFF
--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -91,6 +91,24 @@ def _version_tuple(v: str) -> tuple[int, ...]:
     return tuple(parts) or (0,)
 
 
+def _is_newer(candidate: str, current: str) -> bool:
+    """Return True if PEP 440 version ``candidate`` is strictly newer than ``current``.
+
+    Uses ``packaging.version.Version`` so pip-normalised forms (``0.8.0b3``) order
+    correctly against tag-derived manifest forms (``0.8.1-beta.1``); the naive
+    ``_version_tuple`` digit-parser read ``0.8.0b3`` as ``(0, 8, 3)`` and missed the
+    upgrade. Falls back to the tuple compare only when a string is not valid PEP 440.
+    """
+    try:
+        from packaging.version import InvalidVersion, Version
+    except Exception:
+        return _version_tuple(candidate) > _version_tuple(current)
+    try:
+        return Version(candidate) > Version(current)
+    except InvalidVersion:
+        return _version_tuple(candidate) > _version_tuple(current)
+
+
 def _current_channel(request: Request) -> str:
     """Read the current channel from the cached Hal0Config (falls back to load)."""
     cfg = getattr(request.app.state, "hal0_config", None)
@@ -362,7 +380,7 @@ async def update_state(request: Request) -> dict[str, Any]:
             if hal0_revoked and latest:
                 hal0_revoked_version = latest
             # A revoked latest is not offered (but its reason is surfaced).
-            if latest and not hal0_revoked and _version_tuple(latest) > _version_tuple(__version__):
+            if latest and not hal0_revoked and _is_newer(latest, __version__):
                 hal0_available = latest
     except (OSError, ValueError):
         pass
@@ -437,9 +455,7 @@ async def check_updates(request: Request) -> dict[str, Any]:
         revoked_reason = str(manifest.get("revoked_reason") or "")
 
     # A revoked (yanked) latest is never offered as an available update.
-    update_available = (
-        bool(latest) and not revoked and _version_tuple(latest) > _version_tuple(__version__)
-    )
+    update_available = bool(latest) and not revoked and _is_newer(latest, __version__)
     return {
         "current": __version__,
         "latest": latest or None,

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -326,6 +326,26 @@ def _version_tuple(v: str) -> tuple[int, ...]:
     return tuple(parts) or (0,)
 
 
+def _is_newer(candidate: str, current: str) -> bool:
+    """Return True if PEP 440 version ``candidate`` is strictly newer than ``current``.
+
+    Uses ``packaging.version.Version`` so pip-normalised forms (``0.8.0b3``) order
+    correctly against tag-derived manifest forms (``0.8.1-beta.1``). The naive
+    ``_version_tuple`` digit-parser conflated the beta number with the patch
+    component (``0.8.0b3`` → ``(0, 8, 3)``), so every box on a ``0.8.0bN`` beta saw
+    ``0.8.1-beta.1`` as "not newer" and ``hal0 update`` reported nothing to apply.
+    Falls back to the tuple compare only when a string is not valid PEP 440.
+    """
+    try:
+        from packaging.version import InvalidVersion, Version
+    except Exception:  # packaging absent — keep the best-effort tuple compare
+        return _version_tuple(candidate) > _version_tuple(current)
+    try:
+        return Version(candidate) > Version(current)
+    except InvalidVersion:
+        return _version_tuple(candidate) > _version_tuple(current)
+
+
 # ── Atomic helpers ─────────────────────────────────────────────────────────────
 
 
@@ -903,11 +923,7 @@ class Updater:
         # operator should not be nudged toward a release we've pulled. The
         # version is still surfaced (revoked + reason) so the dashboard can
         # explain why no update is offered. See docs/internal/release-manifest.md.
-        update_available = (
-            bool(latest)
-            and not revoked
-            and _version_tuple(latest) > _version_tuple(hal0.__version__)
-        )
+        update_available = bool(latest) and not revoked and _is_newer(latest, hal0.__version__)
         if revoked and bool(latest):
             log.warning(
                 "updater.latest_revoked",

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -38,6 +38,7 @@ from hal0.updater.updater import (
     _atomic_symlink_swap,
     _cosign_skip,
     _current_symlink,
+    _is_newer,
     _is_pre_release,
     _parse_manifest,
     _previous_record,
@@ -849,3 +850,29 @@ def test_version_tuple_timestamp_nightly_beats_date_only_same_base() -> None:
     """
     assert _version_tuple("0.5.1-nightly.20260615120000") > _version_tuple("0.5.1-nightly.20260615")
     assert _version_tuple("0.5.1-nightly.20260615") > _version_tuple("0.5.0-nightly.20260615")
+
+
+# ── _is_newer — PEP 440 comparison (regression for the 0.8.0b3→0.8.1-beta.1 miss) ──
+
+
+def test_is_newer_beta_across_patch_boundary() -> None:
+    """Regression: a pip-normalised beta (``0.8.0b3``) must order *below* the next
+    patch's beta in tag form (``0.8.1-beta.1``).
+
+    The old ``_version_tuple`` digit-parser read ``0.8.0b3`` as ``(0, 8, 3)`` and
+    ``0.8.1-beta.1`` as ``(0, 8, 1, 1)``, so every box on a ``0.8.0bN`` beta saw the
+    new ``0.8.1`` as "not newer" and ``hal0 update`` reported nothing to apply.
+    """
+    assert _is_newer("0.8.1-beta.1", "0.8.0b3") is True
+    assert _is_newer("0.8.0b3", "0.8.1-beta.1") is False
+    # Same release (tag form vs pip-normalised) is not an upgrade.
+    assert _is_newer("0.8.1-beta.1", "0.8.1b1") is False
+    # Within a beta line still advances.
+    assert _is_newer("0.8.1-beta.2", "0.8.1-beta.1") is True
+
+
+def test_is_newer_falls_back_to_tuple_for_nightly() -> None:
+    """Nightly tags are not valid PEP 440, so ``_is_newer`` falls back to the
+    digit-tuple compare and keeps timestamp monotonicity."""
+    assert _is_newer("0.5.1-nightly.20260615120000", "0.5.1-nightly.20260615") is True
+    assert _is_newer("0.5.1-nightly.20260615", "0.5.0-nightly.20260615") is True


### PR DESCRIPTION
## The bug (fleet rollout blocker)
`hal0 update` reported **"nothing to apply"** on boxes running `0.8.0b3`, despite `0.8.1-beta.1` being published.

`_version_tuple` splits on `.` and strips non-digits per segment:
- `"0.8.0b3"` (pip-normalised) → `["0","8","0b3"]` → `"0b3"`→`"03"`→**3** → `(0,8,3)`
- `"0.8.1-beta.1"` (tag-form manifest) → `(0,8,1,1)`
- `(0,8,1,1) > (0,8,3)` → **False** — the installed beta-N was misread as patch-N.

So **no box on a `0.8.0bN` beta could auto-update to `0.8.1-beta.1`** (CT105, CT107). The first `0.8.0→0.8.1` release exposed it.

## The fix
Add `_is_newer()` — in `updater/updater.py` **and** the `api/routes/updater.py` mirror — using `packaging.version.Version` (already a dependency). It orders pip-normalised and tag forms correctly, and **falls back to the tuple compare only for non-PEP-440 strings** (nightly `…-nightly.<ts>` tags, whose timestamp ordering still needs the tuple).

Regression tests cover the beta-across-patch case and the nightly fallback. Existing 68 updater tests still pass.

> Follow-up: cut `0.8.1-beta.2` carrying this so the fleet can auto-update; until then boxes need `hal0 update --target v0.8.1-beta.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)