### PR TITLE
chore(release): 0.8.1-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Tags older than v0.2.0 ship release notes inside the GitHub release
 page; this CHANGELOG starts at v0.2.0 (the Lemonade migration cut).
 For ADR-level architecture context see `docs/internal/adr/`.
 
+## [v0.8.1-beta.2] — 2026-06-23
+
+Bugfix on the 0.8.1 beta line — restores fleet auto-update. Safe upgrade from
+v0.8.1-beta.1.
+
+### Fixed
+- **Updater version comparison uses PEP 440.** `hal0 update` compared versions with
+  a digit-tuple parser that split on `.` and stripped non-digits per segment, so the
+  pip-normalised installed beta `0.8.0b3` parsed to `(0, 8, 3)` and the tag-form
+  manifest `0.8.1-beta.1` to `(0, 8, 1, 1)` — `(0,8,1,1) > (0,8,3)` is false, so
+  every box on a `0.8.0bN` beta saw the new release as "not newer" and `hal0 update`
+  reported nothing to apply (the installed beta number was misread as the patch
+  component). The comparator now uses `packaging.version.Version` in both the updater
+  and the API route, falling back to the digit-tuple only for non-PEP-440 nightly
+  tags (whose timestamp ordering still relies on it). (#957)
+
 ## [v0.8.1-beta.1] — 2026-06-23
 
 Installer/privilege simplification + Hermes durable memory on by default. The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.8.1-beta.1"
+version = "0.8.1-beta.2"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Release prep for **v0.8.1-beta.2** — version bump + CHANGELOG.

Bugfix release carrying **#957** (updater compares versions with PEP 440), which restores fleet auto-update — boxes on `0.8.0bN` / `0.8.1-beta.1` will now correctly detect the upgrade via plain `hal0 update`.

After merge: tag `v0.8.1-beta.2` → `release.yml` builds, cosign-signs, publishes to releases.hal0.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)