### PR TITLE
feat(stacks): REST + MCP + seeds + dashboard UI (PR-4/5/6)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -105,6 +105,9 @@ from hal0.api.routes import (
 from hal0.api.routes import (
     secrets as secrets_routes,
 )
+from hal0.api.routes import (
+    stacks as stacks_routes,
+)
 from hal0.capabilities.orchestrator import CapabilityOrchestrator
 from hal0.config.loader import ConfigParseError, load_hal0_config, load_upstreams_config
 from hal0.config.paths import activity_db
@@ -1219,6 +1222,12 @@ def create_app() -> FastAPI:
     # from /etc/hal0/profiles.toml (falling back to the built-in seeds on a
     # fresh install). Profiles are P1 container-runtime templates (issue #653).
     app.include_router(profiles_routes.router, prefix="/api/profiles", tags=["profiles"])
+
+    # Stack catalog — named, portable bundles of slots + profiles + model
+    # assignments + capability selections. Read + declarative apply (dry-run
+    # diff → atomic commit → lifecycle converge) + export/import/snapshot.
+    # Public on the local network (ADR-0012), same rationale as profiles.
+    app.include_router(stacks_routes.router, prefix="/api/stacks", tags=["stacks"])
 
     # Chat-template catalog — bundled templates seeded into the model store at
     # startup; operator can add custom templates via POST. Read + write, public

--- a/src/hal0/api/routes/stacks.py
+++ b/src/hal0/api/routes/stacks.py
@@ -1,0 +1,434 @@
+"""Stack catalog + apply endpoints.
+
+Mounted under /api/stacks (spec §8 of
+docs/superpowers/specs/2026-06-19-stacks-design.md):
+
+    GET    ""                  — list every stack (+ active flag + drift status)
+    POST   ""                  — create a stack (hand-built or from a snapshot payload) (201)
+    GET    "/{slug}"           — stack detail (+ active flag + drift status)
+    PUT    "/{slug}"           — replace a custom stack (200)
+    DELETE "/{slug}"           — delete a custom stack (204)
+    POST   "/{slug}/apply"     — ?dry_run=true → diff preview; else commit + converge
+    POST   "/{slug}/export"    — build the portable .hal0stack.json envelope
+    POST   "/import"           — {dry_run?, slug?, envelope} → resolve report or create
+    POST   "/snapshot"         — build a StackConfig from current live config
+
+Seed stacks (defined in ``schema.SEED_STACKS``) are immutable via the API; the
+catalog owns the seed guard, slug validation, and atomic full-catalog writes.
+
+The route layer is a thin adapter: catalog CRUD goes through
+:class:`hal0.stacks.StacksCatalog`; the declarative apply (Phase A config +
+Phase B lifecycle convergence) goes through
+:class:`hal0.stacks.apply.StackApplyEngine`; export/import/snapshot go through
+:mod:`hal0.stacks.portable`. Wall-clock-dependent values (``exported_at``,
+``applied_at``) are stamped here — the engine and portable layers stay pure.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel, Field
+
+from hal0.api._audit import record_action
+from hal0.config.schema import StackConfig
+from hal0.errors import BadRequest
+from hal0.stacks import ResolvedStack, StacksCatalog
+from hal0.stacks.apply import StackApplyEngine
+from hal0.stacks.portable import (
+    export_envelope,
+    import_stack,
+    parse_envelope,
+    resolve_models,
+    snapshot_live_stack,
+    verify_checksum,
+)
+
+router = APIRouter()
+
+
+# ── request models ────────────────────────────────────────────────────────────
+
+
+class StackCreateBody(BaseModel):
+    """Body for POST /api/stacks — slug + the full stack body.
+
+    The ``stack`` payload is whatever ``POST /snapshot`` returns or the editor
+    assembled, so create and snapshot-then-save share one shape.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    slug: str = Field(..., description="Stack key (kebab-case, ≤32 chars, leading alphanumeric).")
+    stack: StackConfig = Field(..., description="The stack body to persist under ``slug``.")
+
+
+class SnapshotBody(BaseModel):
+    """Body for POST /api/stacks/snapshot.
+
+    With no ``slug`` the snapshot is returned un-persisted for the editor to
+    review and name; with ``slug`` it is also created in the catalog.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    name: str = Field(default="", description="Display name for the snapshot stack.")
+    description: str = Field(default="", description="What this snapshot captures.")
+    slug: str | None = Field(
+        default=None,
+        description="When set, persist the snapshot under this slug (else return it un-saved).",
+    )
+
+
+# ── serialization helpers ──────────────────────────────────────────────────────
+
+
+def _stack_to_dict(
+    s: ResolvedStack, *, active: bool = False, drift: str | None = None
+) -> dict[str, Any]:
+    """Render a ResolvedStack as a JSON object for list/detail responses."""
+    return {
+        "slug": s.slug,
+        "name": s.name,
+        "description": s.description,
+        "author": s.author,
+        "icon": s.icon,
+        "tags": list(s.tags),
+        "schema_version": s.schema_version,
+        "hal0_version": s.hal0_version,
+        "seed": s.seed,
+        "slots": [e.model_dump(mode="json") for e in s.slots],
+        "profiles": {k: v.model_dump(mode="json") for k, v in s.profiles.items()},
+        "models": {k: v.model_dump(mode="json") for k, v in s.models.items()},
+        "active": active,
+        "drift": drift,
+    }
+
+
+def _config_of(s: ResolvedStack) -> StackConfig:
+    """Rebuild the persisted StackConfig from a ResolvedStack (drops derived fields).
+
+    Mirrors the reconstruction the apply engine's ``drift_status`` already does;
+    the apply/export paths need a StackConfig, the catalog hands back a
+    ResolvedStack.
+    """
+    return StackConfig(
+        name=s.name,
+        description=s.description,
+        author=s.author,
+        icon=s.icon,
+        tags=list(s.tags),
+        schema_version=s.schema_version,
+        hal0_version=s.hal0_version,
+        slots=list(s.slots),
+        profiles=dict(s.profiles),
+        models=dict(s.models),
+    )
+
+
+def _registry(request: Request) -> Any:
+    """The live ModelRegistry from app.state (populated by the lifespan)."""
+    reg = getattr(request.app.state, "model_registry", None)
+    if reg is None:  # pragma: no cover — lifespan always sets it in real runs
+        raise BadRequest(
+            "model registry not initialized",
+            code="stacks.registry_unavailable",
+        )
+    return reg
+
+
+def _diff_rows(plan: Any) -> list[dict[str, Any]]:
+    """Per-slot before→after model summary for the dry-run preview UI."""
+    rows: list[dict[str, Any]] = []
+    for before, after in zip(plan.change_set.before, plan.change_set.after, strict=True):
+        b_model = (before.data or {}).get("model", {}).get("default") if before.data else None
+        a_model = (after.data or {}).get("model", {}).get("default") if after.data else None
+        rows.append(
+            {
+                "slot": after.path.stem,
+                "before_model": b_model,
+                "after_model": a_model,
+                "changed": before.data != after.data,
+            }
+        )
+    return rows
+
+
+# ── routes ────────────────────────────────────────────────────────────────────
+
+
+@router.get("")
+def list_stacks() -> dict[str, Any]:
+    """List every stack, annotated with the active stack + its drift status.
+
+    Shape::
+
+        {
+          "stacks": [ {slug, name, ..., seed, active, drift}, ... ],
+          "active": "coding" | null,
+          "drift":  "clean" | "modified" | "none"
+        }
+
+    ``drift`` is meaningful for the active stack; the matching item also carries
+    ``active: true`` and its own ``drift`` value.
+    """
+    catalog = StacksCatalog()
+    drift = StackApplyEngine().drift_status(catalog)
+    active_slug = drift.get("active")
+    status = drift.get("status", "none")
+    items = [
+        _stack_to_dict(
+            s,
+            active=(s.slug == active_slug),
+            drift=(status if s.slug == active_slug else None),
+        )
+        for s in catalog.list()
+    ]
+    return {"stacks": items, "active": active_slug, "drift": status}
+
+
+@router.post("", status_code=201)
+async def create_stack(body: StackCreateBody, request: Request) -> dict[str, Any]:
+    """Create a stack from a slug + full stack body.
+
+    Raises:
+        409 stacks.exists: slug already exists.
+        409 stacks.invalid_name: slug isn't kebab-case ≤32 chars.
+        422: pydantic validation failure on the stack body.
+    """
+    async with record_action(
+        request, category="stack", action="stack.create", target=body.slug
+    ) as rec:
+        resolved = StacksCatalog().create(body.slug, body.stack)
+        rec.after = {"slug": body.slug, "name": body.stack.name, "slots": len(body.stack.slots)}
+    return _stack_to_dict(resolved)
+
+
+@router.get("/{slug}")
+def get_stack(slug: str) -> dict[str, Any]:
+    """Return one stack with its active flag + drift status.
+
+    Raises:
+        404 stacks.not_found: no such stack.
+    """
+    catalog = StacksCatalog()
+    resolved = catalog.resolve(slug)
+    drift = StackApplyEngine().drift_status(catalog)
+    is_active = drift.get("active") == slug
+    return _stack_to_dict(
+        resolved,
+        active=is_active,
+        drift=(drift.get("status") if is_active else None),
+    )
+
+
+@router.put("/{slug}")
+async def update_stack(slug: str, body: StackConfig, request: Request) -> dict[str, Any]:
+    """Replace a custom stack's body wholesale (PUT semantics).
+
+    Raises:
+        409 stacks.seed_immutable: slug is a seed stack.
+        404 stacks.not_found: custom stack not found.
+        422: pydantic validation failure.
+    """
+    catalog = StacksCatalog()
+    before = None
+    try:
+        before = _stack_to_dict(catalog.resolve(slug))
+    except Exception:
+        before = None
+    async with record_action(
+        request, category="stack", action="stack.update", target=slug, before=before
+    ) as rec:
+        resolved = catalog.update(slug, body)
+        rec.after = {"slug": slug, "name": body.name, "slots": len(body.slots)}
+    return _stack_to_dict(resolved)
+
+
+@router.delete("/{slug}", status_code=204)
+async def delete_stack(slug: str, request: Request) -> None:
+    """Delete a custom stack.
+
+    Raises:
+        409 stacks.seed_immutable: slug is a seed stack.
+        404 stacks.not_found: custom stack not found.
+    """
+    async with record_action(request, category="stack", action="stack.delete", target=slug):
+        StacksCatalog().delete(slug)
+
+
+@router.post("/{slug}/apply")
+async def apply_stack(slug: str, request: Request, dry_run: bool = False) -> dict[str, Any]:
+    """Apply a stack declaratively.
+
+    ``?dry_run=true`` computes the before→after diff and writes nothing.
+    Otherwise: commit the slot-config ChangeSet atomically (Phase A), record the
+    active-stack pointer, then converge runtime lifecycle to match (Phase B).
+    Phase-B per-slot failures are reported, never raised — a committed config is
+    never unwound by a lifecycle hiccup.
+
+    Raises:
+        404 stacks.not_found: no such stack.
+    """
+    catalog = StacksCatalog()
+    resolved = catalog.resolve(slug)
+    cfg = _config_of(resolved)
+
+    if dry_run:
+        plan = StackApplyEngine().plan(slug, cfg)
+        return {
+            "stack": slug,
+            "dry_run": True,
+            "summary": plan.summary,
+            "changes": _diff_rows(plan),
+        }
+
+    slot_manager = getattr(request.app.state, "slot_manager", None)
+    orchestrator = getattr(request.app.state, "capability_orchestrator", None)
+    engine = StackApplyEngine(slot_manager=slot_manager, orchestrator=orchestrator)
+
+    async with record_action(request, category="stack", action="stack.apply", target=slug) as rec:
+        plan = engine.plan(slug, cfg)
+        engine.apply_config(plan)
+        engine.record_active(plan, applied_at=time.time())
+        converged: dict[str, Any] = {}
+        if slot_manager is not None and orchestrator is not None:
+            report = await engine.converge(cfg)
+            converged = {
+                "loaded": report.loaded,
+                "swapped": report.swapped,
+                "skipped": report.skipped,
+                "unloaded": report.unloaded,
+                "capabilities_applied": report.capabilities_applied,
+                "errors": [{"target": t, "error": e} for t, e in report.errors],
+            }
+        rec.after = {"slug": slug, "changed": sum(1 for r in _diff_rows(plan) if r["changed"])}
+
+    return {
+        "stack": slug,
+        "dry_run": False,
+        "summary": plan.summary,
+        "changes": _diff_rows(plan),
+        "converged": converged,
+    }
+
+
+@router.post("/{slug}/export")
+def export_stack(slug: str, request: Request) -> dict[str, Any]:
+    """Serialize a stack into its portable ``.hal0stack.json`` envelope.
+
+    Embeds referenced profiles + model metadata (never weights, never secrets,
+    never host paths) and stamps ``exported_at`` + a content checksum.
+
+    Raises:
+        404 stacks.not_found: no such stack.
+    """
+    resolved = StacksCatalog().resolve(slug)
+    cfg = _config_of(resolved)
+    exported_at = datetime.now(UTC).isoformat()
+    return export_envelope(cfg, exported_at=exported_at, registry=_registry(request))
+
+
+@router.post("/import")
+async def import_stack_route(request: Request) -> dict[str, Any]:
+    """Import a stack from an uploaded ``.hal0stack.json`` envelope.
+
+    Body::
+
+        { "envelope": {...}, "slug": "name", "dry_run": false }
+
+    ``dry_run`` validates the envelope + classifies model refs (present /
+    pullable / unresolvable) without creating anything. A commit reconciles
+    embedded profiles, creates the stack, and returns the same resolve report so
+    the UI can offer one-click pulls for missing models.
+
+    Raises:
+        400 stacks.bad_envelope: not a valid hal0.stack envelope.
+        400 stacks.import_no_slug: commit requested without a slug.
+        409 stacks.exists: slug already exists.
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise BadRequest(
+            "request body must be valid JSON",
+            code="request.invalid_json",
+            details={"error": str(exc)},
+        ) from exc
+    if not isinstance(body, dict):
+        raise BadRequest("request body must be a JSON object", code="request.not_an_object")
+
+    envelope = body.get("envelope", body)
+    dry_run = bool(body.get("dry_run", False))
+    slug = body.get("slug")
+    registry = _registry(request)
+
+    if dry_run:
+        env = parse_envelope(envelope)
+        report = resolve_models(env.stack, registry)
+        return {
+            "dry_run": True,
+            "valid": True,
+            "checksum_ok": verify_checksum(envelope) if isinstance(envelope, dict) else False,
+            "name": env.stack.name,
+            "schema_version": env.stack.schema_version,
+            "resolutions": [
+                {
+                    "model_id": r.model_id,
+                    "status": r.status,
+                    "hf_repo": r.hf_repo,
+                    "hf_filename": r.hf_filename,
+                }
+                for r in report.resolutions
+            ],
+            "present": report.present,
+            "pullable": report.pullable,
+            "unresolvable": report.unresolvable,
+        }
+
+    if not slug or not isinstance(slug, str):
+        raise BadRequest(
+            "import commit requires a 'slug'",
+            code="stacks.import_no_slug",
+        )
+
+    async with record_action(request, category="stack", action="stack.import", target=slug) as rec:
+        resolved, report = import_stack(envelope, slug, StacksCatalog(), registry=registry)
+        rec.after = {"slug": slug, "pullable": report.pullable, "unresolvable": report.unresolvable}
+    return {
+        "dry_run": False,
+        "stack": _stack_to_dict(resolved),
+        "present": report.present,
+        "pullable": report.pullable,
+        "unresolvable": report.unresolvable,
+    }
+
+
+@router.post("/snapshot")
+async def snapshot_stack(body: SnapshotBody, request: Request) -> dict[str, Any]:
+    """Build a stack from the current live slot + capability config.
+
+    Without ``slug`` the snapshot is returned un-persisted for review; with
+    ``slug`` it is also created in the catalog.
+
+    Raises:
+        409 stacks.exists: slug already exists (commit path).
+    """
+    registry = _registry(request)
+    cfg = snapshot_live_stack(name=body.name, description=body.description, registry=registry)
+
+    if not body.slug:
+        return {"created": False, "stack": cfg.model_dump(mode="json")}
+
+    async with record_action(
+        request, category="stack", action="stack.snapshot", target=body.slug
+    ) as rec:
+        resolved = StacksCatalog().create(body.slug, cfg)
+        rec.after = {"slug": body.slug, "slots": len(cfg.slots)}
+    return {"created": True, "stack": _stack_to_dict(resolved)}
+
+
+__all__ = ["router"]

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1089,9 +1089,118 @@ class StacksConfig(BaseModel):
     stack: dict[str, StackConfig] = Field(default_factory=dict)
 
 
-# Built-in seed stacks (immutable, clone-only). Empty until PR-6 fills it with
-# saber/forge/pi. StacksCatalog consults this for the seed-immutability guard.
-SEED_STACKS: dict[str, StackConfig] = {}
+# Built-in seed stacks (immutable, clone-only) — the day-one catalog the
+# Stacks page ships with (spec §10). Returned by ``load_stacks_config`` when no
+# stacks.toml exists yet, and consulted by ``StacksCatalog`` for the
+# seed-immutability guard. Grounded in the live Strix-Halo model roster and the
+# canonical ``agent``/``utility`` slots (ADR-0023; the spec's pre-ADR ``chat``/
+# ``primary``/``util`` slot names are mapped onto these). Each carries embed +
+# rerank capability rows so memory recall works out of the box. Model metadata
+# (``models{}``) is intentionally left empty — ``export_envelope`` fills it from
+# the live registry at export time, keeping the in-code seed lean.
+#
+# These reference this host's real registry ids; cloned-and-edited is the
+# intended path, and apply's dry-run surfaces any model that isn't local.
+
+
+def _embed_rerank_rows(device: str = "gpu-rocm") -> list[StackCapabilityRow]:
+    """The shared embed + rerank capability pair every seed ships with."""
+    return [
+        StackCapabilityRow(
+            child="embed",
+            device=device,
+            provider="llama-server",
+            model="qwen3-embedding-0-6b-q8-0",
+            enabled=True,
+        ),
+        StackCapabilityRow(
+            child="rerank",
+            device=device,
+            provider="llama-server",
+            model="bge-reranker-v2-m3-q4_k_m",
+            enabled=True,
+        ),
+    ]
+
+
+SEED_STACKS: dict[str, StackConfig] = {
+    # saber — max-throughput agentic MoE. Decode-per-GB leader on the board.
+    "saber": StackConfig(
+        name="Saber",
+        description="High-speed agentic MoE: a 35B-A3B agent on ROCm with a fast "
+        "Vulkan utility helper, plus memory recall.",
+        author="hal0",
+        icon="⚡",
+        tags=["agentic", "moe", "fast"],
+        slots=[
+            StackSlotEntry(
+                slot="agent",
+                model="qwen3-6-35b-a3b-nsc-ace-saber-mtp-f16-to-rocmfp4-strix-lean",
+                device="gpu-rocm",
+                profile="rocm-moe",
+                mtp=True,
+                capabilities=_embed_rerank_rows(),
+            ),
+            StackSlotEntry(
+                slot="utility",
+                model="gemma-4-12b-it-ud-q4-k-xl",
+                device="gpu-vulkan",
+                profile="vulkan",
+            ),
+        ],
+    ),
+    # forge — coding-first developer loadout: a coder agent + a fast draft coder.
+    "forge": StackConfig(
+        name="Forge",
+        description="Coding-first: a 27B coder agent on ROCm with a small fast "
+        "draft coder as the utility, plus codebase retrieval.",
+        author="hal0",
+        icon="🛠️",
+        tags=["coding", "developer"],
+        slots=[
+            StackSlotEntry(
+                slot="agent",
+                model="qwopus3-6-27b-coder-mtp-q6-k",
+                device="gpu-rocm",
+                profile="rocm",
+                mtp=True,
+                capabilities=_embed_rerank_rows(),
+            ),
+            StackSlotEntry(
+                slot="utility",
+                model="qwopus3-5-4b-coder-mtp-q6-k",
+                device="gpu-vulkan",
+                profile="vulkan",
+                mtp=True,
+            ),
+        ],
+    ),
+    # pi — always-on support: faithful compaction, memory recall (quality > speed).
+    "pi": StackConfig(
+        name="Pi",
+        description="Always-on support: a q-rich 27B utility for faithful "
+        "compaction and recall, with a light Vulkan agent.",
+        author="hal0",
+        icon="🥧",
+        tags=["support", "memory", "compaction"],
+        slots=[
+            StackSlotEntry(
+                slot="utility",
+                model="chadrock3-6-27b-pi-agent-mtp-rocmfp4-strix-lean",
+                device="gpu-rocm",
+                profile="rocm",
+                mtp=True,
+                capabilities=_embed_rerank_rows(),
+            ),
+            StackSlotEntry(
+                slot="agent",
+                model="gemma-4-12b-it-ud-q4-k-xl",
+                device="gpu-vulkan",
+                profile="vulkan",
+            ),
+        ],
+    ),
+}
 
 
 def resolve_profile_flags(profile: ProfileConfig, mtp_override: bool | None = None) -> str:

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -229,6 +229,8 @@ AUTONOMOUS_READ_TOOLS: frozenset[str] = frozenset(
         "capability_list",
         "provider_list",
         "version_info",
+        "stack_list",
+        "stack_status",
         # Host-introspection probes (issue #237). Pure-read against
         # /sys/, /proc/, and lsmod — no REST round-trip, no mutation.
         # Hermes-Agent bootstrap consumes these in its env_probe phase.
@@ -264,6 +266,12 @@ GATED_TOOLS: frozenset[str] = frozenset(
         "capability_set",
         "config_write",
         "provider_credential_write",
+        # Stacks: applying/importing reconfigures the whole inference surface
+        # (loads/swaps/unloads slots) and deleting drops a saved bundle —
+        # owner-approval gated, mirroring slot_create/capability_set.
+        "stack_apply",
+        "stack_import",
+        "stack_delete",
         # logs_tail is gated until the redactor in logs.py covers
         # Bearer + X-API-Key + provider keys (sk-/hf-/etc.) — see
         # docs/internal/phase-8-pending/mcp-backend.md §2.
@@ -307,6 +315,8 @@ _REST_MAP: dict[str, tuple[str, str]] = {
     "capability_list": ("GET", "/api/capabilities"),
     "provider_list": ("GET", "/api/providers"),
     "version_info": ("GET", "/api/status"),
+    "stack_list": ("GET", "/api/stacks"),
+    "stack_status": ("GET", "/api/stacks/{slug}"),
     # Autonomous write
     "model_swap": ("POST", "/api/slots/{name}/swap"),
     # Gated write
@@ -317,6 +327,9 @@ _REST_MAP: dict[str, tuple[str, str]] = {
     "slot_restart": ("POST", "/api/slots/{name}/restart"),
     "capability_set": ("POST", "/api/capabilities/{slot}/{child}"),
     "config_write": ("PUT", "/api/settings"),
+    "stack_apply": ("POST", "/api/stacks/{slug}/apply"),
+    "stack_import": ("POST", "/api/stacks/import"),
+    "stack_delete": ("DELETE", "/api/stacks/{slug}"),
     # No live route yet — Memory-engine / Provider team must land the
     # endpoint. We register the tool anyway so the catalog matches the
     # ADR; calls land in a 404 surface until the route exists.
@@ -335,6 +348,9 @@ _PATH_ARGS: dict[str, tuple[str, ...]] = {
     "slot_restart": ("name",),
     "capability_set": ("slot", "child"),
     "provider_credential_write": ("name",),
+    "stack_status": ("slug",),
+    "stack_apply": ("slug",),
+    "stack_delete": ("slug",),
 }
 
 
@@ -622,6 +638,12 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
     "version_info": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
+    "stack_list": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "stack_status": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
     # Host-introspection probes — pure sysfs/procfs reads.
     "gpu_target_version": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
@@ -649,6 +671,14 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
     "capability_set": ToolAnnotations(
         readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
+    # Apply converges to a declared end-state (idempotent); import creates a
+    # new catalog entry (non-idempotent — re-import conflicts on slug).
+    "stack_apply": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "stack_import": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+    ),
     "config_write": ToolAnnotations(
         readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
@@ -674,6 +704,9 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
         readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
     ),
     "slot_delete": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
+    ),
+    "stack_delete": ToolAnnotations(
         readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
     ),
     "memory_delete": ToolAnnotations(
@@ -745,6 +778,8 @@ def build_server(
     _register("capability_list", "Capability overlay state — backends + selections.")
     _register("provider_list", "List configured providers.")
     _register("version_info", "hal0 version + runtime status.")
+    _register("stack_list", "List every stack, with the active stack + drift status.")
+    _register("stack_status", "Get one stack's detail, active flag, and drift status.")
     # Host-introspection probes (issue #237)
     _register(
         "gpu_target_version",
@@ -779,6 +814,12 @@ def build_server(
     _register("slot_restart", "Restart a slot's systemd unit (gated).")
     _register("capability_set", "Assign a capability child to a slot (gated).")
     _register("config_write", "Update hal0.toml top-level settings (gated).")
+    _register(
+        "stack_apply",
+        "Apply a stack — commit its slot config and converge runtime to match (gated).",
+    )
+    _register("stack_import", "Import a stack from a .hal0stack.json envelope (gated).")
+    _register("stack_delete", "Delete a custom stack from the catalog (gated).")
     _register(
         "provider_credential_write",
         "Write provider credentials (gated; secrets never echoed back).",

--- a/tests/api/test_stacks_routes.py
+++ b/tests/api/test_stacks_routes.py
@@ -1,0 +1,295 @@
+"""Tests for the /api/stacks route surface (PR-4).
+
+Covers catalog CRUD, declarative apply (dry-run diff + commit→converge),
+export → import round-trip, snapshot, and seed-immutability — exercised through
+the real ``create_app()`` + ``TestClient`` so the lifespan-wired registry /
+slot-manager / orchestrator are in play.
+
+Run targeted:
+    PYTHONPATH=src .venv-test/bin/python -m pytest tests/api/test_stacks_routes.py -q
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.config import schema
+from hal0.config.schema import StackConfig
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _seed_slot_toml(home: str, name: str, *, model: str = "", port: int = 8090) -> Path:
+    """Write a minimal slot TOML so the apply engine has a file to reconcile."""
+    root = Path(home) / "etc" / "hal0" / "slots"
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / f"{name}.toml"
+    body = f'[slot]\nname = "{name}"\nport = {port}\n'
+    if model:
+        body += f'\n[model]\ndefault = "{model}"\n'
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _stack_body(name: str = "Coding", slots: list[dict] | None = None) -> dict:
+    return {"name": name, "description": "test stack", "slots": slots or []}
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app(tmp_hal0_home: str) -> FastAPI:
+    """Fresh app; tmp_hal0_home means no stacks.toml → empty catalog."""
+    return create_app()
+
+
+@pytest.fixture
+def client(app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        yield c
+
+
+# ── GET (list) ─────────────────────────────────────────────────────────────────
+
+
+def test_list_empty_envelope(client: TestClient) -> None:
+    r = client.get("/api/stacks")
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"stacks": [], "active": None, "drift": "none"}
+
+
+# ── POST (create) ──────────────────────────────────────────────────────────────
+
+
+def test_create_201_and_listed(client: TestClient) -> None:
+    r = client.post("/api/stacks", json={"slug": "coding", "stack": _stack_body()})
+    assert r.status_code == 201
+    body = r.json()
+    assert body["slug"] == "coding"
+    assert body["name"] == "Coding"
+    assert body["seed"] is False
+    assert body["active"] is False
+    listed = client.get("/api/stacks").json()["stacks"]
+    assert any(s["slug"] == "coding" for s in listed)
+
+
+def test_create_persists_across_reload(tmp_hal0_home: str) -> None:
+    with TestClient(create_app()) as c1:
+        assert (
+            c1.post("/api/stacks", json={"slug": "persist", "stack": _stack_body()}).status_code
+            == 201
+        )
+    with TestClient(create_app()) as c2:
+        listed = c2.get("/api/stacks").json()["stacks"]
+    assert any(s["slug"] == "persist" for s in listed)
+
+
+def test_create_duplicate_409(client: TestClient) -> None:
+    client.post("/api/stacks", json={"slug": "coding", "stack": _stack_body()})
+    r = client.post("/api/stacks", json={"slug": "coding", "stack": _stack_body()})
+    assert r.status_code == 409
+    assert r.json()["error"]["code"] == "stacks.exists"
+
+
+def test_create_invalid_slug_409(client: TestClient) -> None:
+    r = client.post("/api/stacks", json={"slug": "Bad Slug!", "stack": _stack_body()})
+    assert r.status_code == 409
+    assert r.json()["error"]["code"] == "stacks.invalid_name"
+
+
+def test_create_unknown_body_field_422(client: TestClient) -> None:
+    r = client.post(
+        "/api/stacks",
+        json={"slug": "coding", "stack": _stack_body(), "bogus": 1},
+    )
+    assert r.status_code == 422
+
+
+# ── GET (detail) ───────────────────────────────────────────────────────────────
+
+
+def test_get_detail_200(client: TestClient) -> None:
+    client.post("/api/stacks", json={"slug": "coding", "stack": _stack_body()})
+    r = client.get("/api/stacks/coding")
+    assert r.status_code == 200
+    assert r.json()["name"] == "Coding"
+
+
+def test_get_missing_404(client: TestClient) -> None:
+    r = client.get("/api/stacks/nope")
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == "stacks.not_found"
+
+
+# ── PUT (update) ───────────────────────────────────────────────────────────────
+
+
+def test_update_200_persists(client: TestClient) -> None:
+    client.post("/api/stacks", json={"slug": "coding", "stack": _stack_body()})
+    r = client.put("/api/stacks/coding", json=_stack_body(name="Coding v2"))
+    assert r.status_code == 200
+    assert r.json()["name"] == "Coding v2"
+    assert client.get("/api/stacks/coding").json()["name"] == "Coding v2"
+
+
+def test_update_missing_404(client: TestClient) -> None:
+    r = client.put("/api/stacks/nope", json=_stack_body())
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == "stacks.not_found"
+
+
+# ── DELETE ─────────────────────────────────────────────────────────────────────
+
+
+def test_delete_204(client: TestClient) -> None:
+    client.post("/api/stacks", json={"slug": "coding", "stack": _stack_body()})
+    assert client.delete("/api/stacks/coding").status_code == 204
+    assert not client.get("/api/stacks").json()["stacks"]
+
+
+def test_delete_missing_404(client: TestClient) -> None:
+    r = client.delete("/api/stacks/nope")
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == "stacks.not_found"
+
+
+# ── seed immutability (monkeypatched seed registry) ────────────────────────────
+
+
+def test_seed_immutable_put_and_delete_409(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setitem(schema.SEED_STACKS, "saber", StackConfig(name="Saber"))
+    put = client.put("/api/stacks/saber", json=_stack_body())
+    assert put.status_code == 409
+    assert put.json()["error"]["code"] == "stacks.seed_immutable"
+    delete = client.delete("/api/stacks/saber")
+    assert delete.status_code == 409
+    assert delete.json()["error"]["code"] == "stacks.seed_immutable"
+
+
+# ── apply (dry-run) ────────────────────────────────────────────────────────────
+
+
+def test_apply_dry_run_shows_diff(tmp_hal0_home: str) -> None:
+    _seed_slot_toml(tmp_hal0_home, "agent", model="old-model")
+    with TestClient(create_app()) as c:
+        c.post(
+            "/api/stacks",
+            json={
+                "slug": "coding",
+                "stack": _stack_body(slots=[{"slot": "agent", "model": "new-model"}]),
+            },
+        )
+        r = c.post("/api/stacks/coding/apply", params={"dry_run": "true"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["dry_run"] is True
+    row = next(x for x in body["changes"] if x["slot"] == "agent")
+    assert row["before_model"] == "old-model"
+    assert row["after_model"] == "new-model"
+    assert row["changed"] is True
+
+
+# ── apply (commit + converge with injected fakes) ──────────────────────────────
+
+
+def test_apply_commit_converges_and_sets_active(app: FastAPI, tmp_hal0_home: str) -> None:
+    _seed_slot_toml(tmp_hal0_home, "agent", model="old-model")
+    with TestClient(app) as c:
+        c.post(
+            "/api/stacks",
+            json={
+                "slug": "coding",
+                "stack": _stack_body(slots=[{"slot": "agent", "model": "new-model"}]),
+            },
+        )
+        # Inject fakes so converge() drives no real containers: empty live
+        # snapshot → the agent slot is "loaded".
+        fake_sm = AsyncMock()
+        fake_sm.list = AsyncMock(return_value=[])
+        app.state.slot_manager = fake_sm
+        app.state.capability_orchestrator = AsyncMock()
+
+        r = c.post("/api/stacks/coding/apply")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["dry_run"] is False
+        assert "agent" in body["converged"]["loaded"]
+        fake_sm.load.assert_awaited()
+
+        # Active pointer + clean drift (live toml == applied projection).
+        listed = c.get("/api/stacks").json()
+        assert listed["active"] == "coding"
+        assert listed["drift"] == "clean"
+        active_item = next(s for s in listed["stacks"] if s["slug"] == "coding")
+        assert active_item["active"] is True
+        assert active_item["drift"] == "clean"
+
+
+# ── export / import round-trip ─────────────────────────────────────────────────
+
+
+def test_export_import_round_trip(client: TestClient) -> None:
+    client.post("/api/stacks", json={"slug": "coding", "stack": _stack_body()})
+    env = client.post("/api/stacks/coding/export").json()
+    assert env["kind"] == "hal0.stack"
+    assert env["checksum"].startswith("sha256:")
+
+    # dry-run import validates + checksum-verifies, creates nothing.
+    dry = client.post("/api/stacks/import", json={"dry_run": True, "envelope": env})
+    assert dry.status_code == 200
+    assert dry.json()["valid"] is True
+    assert dry.json()["checksum_ok"] is True
+
+    # commit creates a clone under a new slug.
+    commit = client.post("/api/stacks/import", json={"slug": "coding-copy", "envelope": env})
+    assert commit.status_code == 200
+    assert commit.json()["stack"]["slug"] == "coding-copy"
+    assert any(s["slug"] == "coding-copy" for s in client.get("/api/stacks").json()["stacks"])
+
+
+def test_import_commit_without_slug_400(client: TestClient) -> None:
+    client.post("/api/stacks", json={"slug": "coding", "stack": _stack_body()})
+    env = client.post("/api/stacks/coding/export").json()
+    r = client.post("/api/stacks/import", json={"envelope": env})
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "stacks.import_no_slug"
+
+
+def test_import_bad_envelope_400(client: TestClient) -> None:
+    r = client.post("/api/stacks/import", json={"dry_run": True, "envelope": {"kind": "nope"}})
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "stacks.bad_envelope"
+
+
+# ── snapshot ───────────────────────────────────────────────────────────────────
+
+
+def test_snapshot_returns_unsaved_config(tmp_hal0_home: str) -> None:
+    _seed_slot_toml(tmp_hal0_home, "agent", model="some-model")
+    with TestClient(create_app()) as c:
+        r = c.post("/api/stacks/snapshot", json={"name": "from-live"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["created"] is False
+    assert body["stack"]["name"] == "from-live"
+    assert any(s["slot"] == "agent" for s in body["stack"]["slots"])
+
+
+def test_snapshot_with_slug_persists(tmp_hal0_home: str) -> None:
+    _seed_slot_toml(tmp_hal0_home, "agent", model="some-model")
+    with TestClient(create_app()) as c:
+        r = c.post("/api/stacks/snapshot", json={"name": "snap", "slug": "snap-1"})
+        assert r.status_code == 200
+        assert r.json()["created"] is True
+        assert any(s["slug"] == "snap-1" for s in c.get("/api/stacks").json()["stacks"])

--- a/tests/api/test_stacks_routes.py
+++ b/tests/api/test_stacks_routes.py
@@ -60,11 +60,16 @@ def client(app: FastAPI) -> Iterator[TestClient]:
 # ── GET (list) ─────────────────────────────────────────────────────────────────
 
 
-def test_list_empty_envelope(client: TestClient) -> None:
+def test_list_ships_seed_catalog(client: TestClient) -> None:
+    # Fresh install (no stacks.toml) → the built-in seed stacks (PR-6).
     r = client.get("/api/stacks")
     assert r.status_code == 200
     body = r.json()
-    assert body == {"stacks": [], "active": None, "drift": "none"}
+    assert body["active"] is None
+    assert body["drift"] == "none"
+    slugs = {s["slug"] for s in body["stacks"]}
+    assert {"saber", "forge", "pi"} <= slugs
+    assert all(s["seed"] is True for s in body["stacks"] if s["slug"] in {"saber", "forge", "pi"})
 
 
 # ── POST (create) ──────────────────────────────────────────────────────────────
@@ -153,7 +158,8 @@ def test_update_missing_404(client: TestClient) -> None:
 def test_delete_204(client: TestClient) -> None:
     client.post("/api/stacks", json={"slug": "coding", "stack": _stack_body()})
     assert client.delete("/api/stacks/coding").status_code == 204
-    assert not client.get("/api/stacks").json()["stacks"]
+    slugs = {s["slug"] for s in client.get("/api/stacks").json()["stacks"]}
+    assert "coding" not in slugs  # seeds remain; the custom stack is gone
 
 
 def test_delete_missing_404(client: TestClient) -> None:

--- a/tests/config/test_stacks_loader.py
+++ b/tests/config/test_stacks_loader.py
@@ -15,9 +15,15 @@ from hal0.config.schema import StackConfig, StacksConfig, StackSlotEntry
 
 
 class TestLoadStacksConfig:
-    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+    def test_missing_file_returns_seed_catalog(self, tmp_path: Path) -> None:
+        # Absent stacks.toml → the built-in seed catalog (SEED_STACKS), so a
+        # fresh install ships a usable Stacks page (PR-6). Mirrors
+        # load_profiles_config's seed fallback.
+        from hal0.config.schema import SEED_STACKS
+
         cfg = load_stacks_config(path=tmp_path / "nonexistent.toml")
-        assert cfg.stack == {}
+        assert cfg.stack == SEED_STACKS
+        assert set(cfg.stack) == {"saber", "forge", "pi"}
 
     def test_round_trip_save_then_load(self, tmp_path: Path) -> None:
         target = tmp_path / "stacks.toml"

--- a/tests/config/test_stacks_schema.py
+++ b/tests/config/test_stacks_schema.py
@@ -105,5 +105,18 @@ class TestStacksConfig:
 
 
 class TestSeedStacks:
-    def test_seed_stacks_is_empty_until_pr6(self) -> None:
-        assert SEED_STACKS == {}
+    def test_seed_stacks_shipped(self) -> None:
+        # PR-6 ships saber/forge/pi as immutable, clone-only seeds.
+        assert set(SEED_STACKS) == {"saber", "forge", "pi"}
+
+    def test_seed_stacks_well_formed(self) -> None:
+        for slug, stack in SEED_STACKS.items():
+            assert isinstance(stack, StackConfig)
+            assert stack.name, f"{slug}: seed needs a display name"
+            assert stack.slots, f"{slug}: seed needs at least one slot"
+            # Seeds use the canonical agent/utility slots (ADR-0023).
+            assert {e.slot for e in stack.slots} <= {"agent", "utility"}
+            # Every slot carries a model and a valid device.
+            for entry in stack.slots:
+                assert entry.model, f"{slug}/{entry.slot}: seed slot needs a model"
+                assert entry.device in {"gpu-rocm", "gpu-vulkan", "cpu", "npu"}

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -147,7 +147,7 @@ def test_destructive_tools_match_gated_destructive_set() -> None:
     """ADR-0004 §4's "destructive" classification must match the
     destructiveHint annotations exactly. The annotation is the
     client-facing surface; ADR-0004 is the policy. They cannot drift."""
-    destructive_per_adr = {"model_delete", "slot_delete", "memory_delete"}
+    destructive_per_adr = {"model_delete", "slot_delete", "memory_delete", "stack_delete"}
     destructive_per_annotation = {
         name for name, ann in admin._ANNOTATIONS.items() if ann.destructiveHint
     }

--- a/tests/mcp/test_admin_stacks.py
+++ b/tests/mcp/test_admin_stacks.py
@@ -1,0 +1,134 @@
+"""MCP admin coverage for the Stacks tools (PR-4).
+
+The stack tools are REST passthroughs like the rest of the catalog: reads run
+autonomously and forward GET; apply/import/delete gate for owner approval. These
+tests assert the classification + URL routing without touching the network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from hal0.mcp import admin
+from hal0.mcp.approval_queue import ApprovalQueue
+
+
+@pytest.fixture
+def queue() -> ApprovalQueue:
+    return ApprovalQueue()
+
+
+@pytest.fixture
+def mock_transport(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {"calls": []}
+
+    class _Resp:
+        status_code = 200
+        text = ""
+
+        def json(self) -> dict[str, Any]:
+            return {"ok": True}
+
+    class _Client:
+        def __init__(self, *, base_url: str, timeout: float) -> None:
+            captured["base_url"] = base_url
+
+        async def __aenter__(self) -> _Client:
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+        async def get(self, url: str, params: Any = None, headers: Any = None) -> _Resp:
+            captured["calls"].append(("GET", url, params))
+            return _Resp()
+
+        async def post(self, url: str, json: Any = None, headers: Any = None) -> _Resp:
+            captured["calls"].append(("POST", url, json))
+            return _Resp()
+
+        async def delete(self, url: str, params: Any = None, headers: Any = None) -> _Resp:
+            captured["calls"].append(("DELETE", url, params))
+            return _Resp()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+    return captured
+
+
+def test_stack_tools_classification() -> None:
+    assert {"stack_list", "stack_status"} <= admin.AUTONOMOUS_READ_TOOLS
+    assert {"stack_apply", "stack_import", "stack_delete"} <= admin.GATED_TOOLS
+    # Reads are not gated; writes are.
+    assert admin.is_gated("stack_list", {}) is False
+    assert admin.is_gated("stack_status", {"slug": "x"}) is False
+    assert admin.is_gated("stack_apply", {"slug": "x"}) is True
+    assert admin.is_gated("stack_import", {"slug": "x"}) is True
+    assert admin.is_gated("stack_delete", {"slug": "x"}) is True
+
+
+@pytest.mark.asyncio
+async def test_stack_list_dispatches_get(
+    queue: ApprovalQueue, mock_transport: dict[str, Any]
+) -> None:
+    result = await admin.dispatch(
+        tool="stack_list",
+        args={},
+        client_id="pi",
+        bearer="tok",
+        base_url="http://t",
+        approval_queue=queue,
+    )
+    assert result == {"ok": True}
+    method, url, _ = mock_transport["calls"][-1]
+    assert (method, url) == ("GET", "http://t/api/stacks")
+
+
+@pytest.mark.asyncio
+async def test_stack_status_substitutes_slug(
+    queue: ApprovalQueue, mock_transport: dict[str, Any]
+) -> None:
+    await admin.dispatch(
+        tool="stack_status",
+        args={"slug": "coding"},
+        client_id="pi",
+        bearer="tok",
+        base_url="http://t",
+        approval_queue=queue,
+    )
+    method, url, _ = mock_transport["calls"][-1]
+    assert (method, url) == ("GET", "http://t/api/stacks/coding")
+
+
+@pytest.mark.asyncio
+async def test_stack_apply_gates_for_approval(queue: ApprovalQueue) -> None:
+    result = await admin.dispatch(
+        tool="stack_apply",
+        args={"slug": "coding"},
+        client_id="pi",
+        bearer="tok",
+        base_url="http://t",
+        approval_queue=queue,
+    )
+    assert result["status"] == "pending_approval"
+    assert "approval_id" in result
+
+
+@pytest.mark.asyncio
+async def test_approved_stack_apply_posts_to_apply_url(
+    queue: ApprovalQueue, mock_transport: dict[str, Any]
+) -> None:
+    result = await admin.dispatch(
+        tool="stack_apply",
+        args={"slug": "coding"},
+        client_id="pi",
+        bearer="tok",
+        base_url="http://t",
+        approval_queue=queue,
+    )
+    # Approve → the bound executor fires the REST call.
+    await queue.approve(result["approval_id"])
+    method, url, _ = mock_transport["calls"][-1]
+    assert (method, url) == ("POST", "http://t/api/stacks/coding/apply")

--- a/tests/stacks/conftest.py
+++ b/tests/stacks/conftest.py
@@ -10,7 +10,25 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+import pytest
+
 from hal0.slots.state import SlotState
+
+
+@pytest.fixture(autouse=True)
+def _no_seed_stacks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate the engine unit tests from the shipped seed catalog (PR-6).
+
+    These tests assert exact catalog contents and use the slug ``saber`` (now a
+    real seed) — they exercise catalog/apply/drift/import *mechanics*, not the
+    shipped seeds, so we null the seed set for the whole package. The catalog
+    reads ``schema.SEED_STACKS`` dynamically and the loader reads its own bound
+    ``SEED_STACKS``; patch both. TestSeedGuard re-adds an entry via setitem.
+    """
+    from hal0.config import loader, schema
+
+    monkeypatch.setattr(schema, "SEED_STACKS", {})
+    monkeypatch.setattr(loader, "SEED_STACKS", {})
 
 
 @dataclass

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -294,6 +294,17 @@ export const ENDPOINTS = {
   profiles: '/api/profiles',
   profile: (name: string) => `/api/profiles/${encodeURIComponent(name)}`,
 
+  // ── Stacks (named, portable slot+profile+model bundles) ─────────
+  // GET list (+ active + drift) | POST create. Per-stack: GET detail | PUT |
+  // DELETE | POST apply (?dry_run=true → diff) | POST export (envelope).
+  // import/snapshot are collection-level POSTs.
+  stacks: '/api/stacks',
+  stack: (slug: string) => `/api/stacks/${encodeURIComponent(slug)}`,
+  stackApply: (slug: string) => `/api/stacks/${encodeURIComponent(slug)}/apply`,
+  stackExport: (slug: string) => `/api/stacks/${encodeURIComponent(slug)}/export`,
+  stackImport: '/api/stacks/import',
+  stackSnapshot: '/api/stacks/snapshot',
+
   // Install state — backs the post-install banner and passive install-state hook.
   // Retained for useInstallState.ts (banner/status surface). The FirstRun picker
   // endpoints (apply, complete, curated-models, pick-default, services, etc.) were

--- a/ui/src/api/hooks/useStacks.ts
+++ b/ui/src/api/hooks/useStacks.ts
@@ -1,0 +1,213 @@
+// hal0 dashboard — stacks hook (PR-5, spec §8/§9).
+//
+// A Stack is a named, portable bundle of slots + their profiles + model
+// assignments + capability selections. This hook wraps /api/stacks:
+//   - list (with the active stack + its drift status)
+//   - create / update / delete (seed stacks are immutable server-side: 409)
+//   - apply (dry-run diff preview, then commit + lifecycle converge)
+//   - export (.hal0stack.json envelope), import (dry-run resolve, then create)
+//   - snapshot the current live config into a StackConfig
+//
+// Mirrors useProfiles: queries via apiGet, mutations via api({raw:true}).
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { api, apiGet } from '../client'
+import { ENDPOINTS } from '../endpoints'
+
+export interface StackCapabilityRow {
+  child: string
+  device: string
+  provider: string
+  model: string
+  enabled: boolean
+}
+
+export interface StackSlotEntry {
+  slot: string
+  profile?: string | null
+  model?: string | null
+  device?: string | null
+  provider?: string | null
+  role?: string | null
+  vision?: boolean
+  mtp?: boolean | null
+  enable_thinking?: boolean | null
+  server_extra_args?: string | null
+  capabilities?: StackCapabilityRow[]
+}
+
+/** The body persisted under a slug (POST/PUT). */
+export interface StackBody {
+  name?: string
+  description?: string
+  author?: string
+  icon?: string
+  tags?: string[]
+  schema_version?: number
+  hal0_version?: string
+  slots?: StackSlotEntry[]
+  profiles?: Record<string, unknown>
+  models?: Record<string, unknown>
+}
+
+/** A stack as returned by list/detail — body + derived seed/active/drift. */
+export interface Stack extends StackBody {
+  slug: string
+  name: string
+  description: string
+  author: string
+  icon: string
+  tags: string[]
+  seed: boolean
+  slots: StackSlotEntry[]
+  /** True when this is the currently-applied stack. */
+  active?: boolean
+  /** Drift status for the active stack: clean | modified (null otherwise). */
+  drift?: string | null
+}
+
+export interface StackList {
+  stacks: Stack[]
+  active: string | null
+  drift: 'clean' | 'modified' | 'none'
+}
+
+export interface StackDiffRow {
+  slot: string
+  before_model: string | null
+  after_model: string | null
+  changed: boolean
+}
+
+export interface StackConvergeReport {
+  loaded: string[]
+  swapped: string[]
+  skipped: string[]
+  unloaded: string[]
+  capabilities_applied: string[]
+  errors: { target: string; error: string }[]
+}
+
+export interface StackApplyResult {
+  stack: string
+  dry_run: boolean
+  summary: string[]
+  changes: StackDiffRow[]
+  converged?: StackConvergeReport
+}
+
+export interface StackModelResolution {
+  model_id: string
+  status: 'present' | 'pullable' | 'unresolvable'
+  hf_repo: string
+  hf_filename: string
+}
+
+export interface StackImportDryResult {
+  dry_run: true
+  valid: boolean
+  checksum_ok: boolean
+  name: string
+  schema_version: number
+  resolutions: StackModelResolution[]
+  present: string[]
+  pullable: string[]
+  unresolvable: string[]
+}
+
+export interface StackEnvelope {
+  kind: string
+  schema_version: number
+  hal0_version: string
+  exported_at: string
+  checksum: string
+  stack: StackBody
+}
+
+export function useStacks() {
+  return useQuery({
+    queryKey: ['stacks'],
+    queryFn: () => apiGet<StackList>(ENDPOINTS.stacks),
+    staleTime: 30_000,
+  })
+}
+
+export function useStackCreate() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ slug, stack }: { slug: string; stack: StackBody }) =>
+      api<Stack>(ENDPOINTS.stacks, { method: 'POST', body: { slug, stack } as any, raw: true }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['stacks'] }),
+  })
+}
+
+export function useStackUpdate() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ slug, stack }: { slug: string; stack: StackBody }) =>
+      api<Stack>(ENDPOINTS.stack(slug), { method: 'PUT', body: stack as any, raw: true }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['stacks'] }),
+  })
+}
+
+export function useStackDelete() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (slug: string) =>
+      api<void>(ENDPOINTS.stack(slug), { method: 'DELETE', raw: true }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['stacks'] }),
+  })
+}
+
+export function useStackApply() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ slug, dryRun }: { slug: string; dryRun: boolean }) =>
+      api<StackApplyResult>(
+        ENDPOINTS.stackApply(slug) + (dryRun ? '?dry_run=true' : ''),
+        { method: 'POST', raw: true },
+      ),
+    // Only a commit changes server state — refresh the active/drift view.
+    onSuccess: (_data, vars) => {
+      if (!vars.dryRun) {
+        qc.invalidateQueries({ queryKey: ['stacks'] })
+        qc.invalidateQueries({ queryKey: ['slots'] })
+      }
+    },
+  })
+}
+
+export function useStackExport() {
+  return useMutation({
+    mutationFn: (slug: string) =>
+      api<StackEnvelope>(ENDPOINTS.stackExport(slug), { method: 'POST', raw: true }),
+  })
+}
+
+export function useStackImport() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: { envelope: unknown; dry_run?: boolean; slug?: string }) =>
+      api<StackImportDryResult | { dry_run: false; stack: Stack }>(
+        ENDPOINTS.stackImport,
+        { method: 'POST', body: payload as any, raw: true },
+      ),
+    onSuccess: (_data, vars) => {
+      if (!vars.dry_run) qc.invalidateQueries({ queryKey: ['stacks'] })
+    },
+  })
+}
+
+export function useStackSnapshot() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: { name?: string; description?: string; slug?: string }) =>
+      api<{ created: boolean; stack: StackBody | Stack }>(
+        ENDPOINTS.stackSnapshot,
+        { method: 'POST', body: payload as any, raw: true },
+      ),
+    onSuccess: (_data, vars) => {
+      if (vars.slug) qc.invalidateQueries({ queryKey: ['stacks'] })
+    },
+  })
+}

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -210,6 +210,7 @@ function useNavItems() {
     { id: "slots", label: "Slots", icon: Icons.slots, cnt: slotCount, children: [
       { id: "slots/endpoints", label: "Endpoints" },
       { id: "slots/profiles",  label: "Profiles" },
+      { id: "slots/stacks",    label: "Stacks" },
     ] },
     { id: "models", label: "Models", icon: Icons.models, cnt: modelCount },
     // Operator Board (#board) — hal0-skinned kanban over the Hermes kanban

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -466,7 +466,9 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
   // slots, and is mutually exclusive with the LLM stack — so it gets its own
   // tab instead of a SlotCard in the Image group.
   const [tab, setTab] = useStateS(
-    slotParam === "endpoints" || slotParam === "profiles" ? slotParam : "inference",
+    slotParam === "endpoints" || slotParam === "profiles" || slotParam === "stacks"
+      ? slotParam
+      : "inference",
   );
   const comfyQuery = useComfyui({ active: tab === "image" });
   const comfyLive = comfyQuery.data?.container?.state === "running";
@@ -519,8 +521,8 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
   // matching tab; navigating back to bare #slots (or a slot-name param) drops
   // out of a sub-tab back to Inference.
   React.useEffect(() => {
-    if (slotParam === "endpoints" || slotParam === "profiles") setTab(slotParam);
-    else setTab((t) => (t === "endpoints" || t === "profiles" ? "inference" : t));
+    if (slotParam === "endpoints" || slotParam === "profiles" || slotParam === "stacks") setTab(slotParam);
+    else setTab((t) => (t === "endpoints" || t === "profiles" || t === "stacks" ? "inference" : t));
   }, [slotParam]);
 
   // Listen for the N hotkey via global event (wired by main.jsx)
@@ -692,9 +694,16 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
     );
   }
 
+  // Sub-tabs (Endpoints / Profiles / Stacks) are slot-independent surfaces —
+  // they must stay reachable even while /api/slots is loading or has resolved
+  // empty (a fresh box with no slots is exactly when you want to apply a Stack
+  // or pick a Profile). Only the slot-centric Inference/Image tabs fall through
+  // to the loading skeleton / empty state below.
+  const onSubTab = tab === "endpoints" || tab === "profiles" || tab === "stacks";
+
   // Loading skeleton — shown while /api/slots is still resolving so no
   // fake/stub slot cards flash before real data arrives.
-  if (slotsLoading) {
+  if (slotsLoading && !onSubTab) {
     return (
       <div className="view">
         <div className="vh">
@@ -720,8 +729,8 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
   }
 
   // Real zero-slots empty state — only when the query has resolved to a
-  // confirmed empty array (not still-loading).
-  if (slotsEmpty) {
+  // confirmed empty array (not still-loading), and only on a slot-centric tab.
+  if (slotsEmpty && !onSubTab) {
     return (
       <div className="view">
         <div className="vh">
@@ -864,6 +873,14 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
         >
           <span>Profiles</span>
         </button>
+        <button
+          role="tab"
+          aria-selected={tab === "stacks"}
+          className={"slot-tab" + (tab === "stacks" ? " on" : "")}
+          onClick={() => { window.location.hash = "#slots/stacks"; }}
+        >
+          <span>Stacks</span>
+        </button>
       </div>
 
       {tab === "endpoints" ? (
@@ -872,6 +889,8 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
         </div>
       ) : tab === "profiles" ? (
         window.ProfilesView ? <window.ProfilesView /> : null
+      ) : tab === "stacks" ? (
+        window.StacksView ? <window.StacksView /> : null
       ) : (
       <div className="dash">
         <div className="dash-main">

--- a/ui/src/dash/stacks.jsx
+++ b/ui/src/dash/stacks.jsx
@@ -1,0 +1,736 @@
+// hal0 dashboard — Stacks view (PR-5; spec §9).
+//
+// A Stack is a named, portable bundle of slots + their profiles + model
+// assignments + capability selections — the runtime successor to the first-run
+// Bundles picker. This view mirrors the Profiles page family: a header +
+// summary strip, seed/custom card grids, a slide-in editor drawer, and a
+// styled delete confirm. Stacks add three things Profiles don't:
+//
+//   • Apply — declarative load: a dry-run diff modal (before→after per slot)
+//     that, on confirm, commits the slot config and converges the runtime.
+//   • Active + drift — the applied stack wears an Active ribbon; a drift badge
+//     flags when live config has been hand-edited since apply.
+//   • Export / Import — a portable .hal0stack.json round-trip with a resolve
+//     report (present / pullable / unresolvable) for missing models.
+//
+// Data: GET /api/stacks (useStacks). Reuses the .pf-* card/drawer/confirm
+// styling from Profiles plus a small .st-* layer (overhaul stacks block in
+// dashboard.css) for the active ribbon, drift badge, slot rows, and resolve
+// report. Seeds are immutable: Edit becomes "Edit a copy"; Delete is disabled.
+
+import { useState, useEffect } from 'react'
+import {
+  useStacks,
+  useStackCreate,
+  useStackUpdate,
+  useStackDelete,
+  useStackApply,
+  useStackExport,
+  useStackImport,
+  useStackSnapshot,
+} from '@/api/hooks/useStacks'
+import { useModels } from '@/api/hooks/useModels'
+import { useProfiles } from '@/api/hooks/useProfiles'
+
+// Device hue, mirroring the Profiles backend palette (#751 tokens).
+const DEVICE_META = {
+  'gpu-rocm':   { label: 'ROCm',   color: 'var(--dev-rocm)' },
+  'gpu-vulkan': { label: 'Vulkan', color: 'var(--dev-vulkan)' },
+  npu:          { label: 'NPU',    color: 'var(--dev-npu)' },
+  cpu:          { label: 'CPU',    color: 'var(--dev-cpu)' },
+};
+const DEVICES = Object.keys(DEVICE_META);
+
+// Mirrors the API slug regex ^[a-z0-9][a-z0-9_-]{0,31}$.
+const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+const BLANK_SLOT = { slot: '', model: '', device: 'gpu-rocm', profile: '', mtp: false, capabilities: [] };
+const BLANK = { name: '', description: '', icon: '', tags: '', slots: [{ ...BLANK_SLOT }] };
+
+function toast(msg, kind = 'info') {
+  if (typeof window !== 'undefined' && window.__hal0Toast) window.__hal0Toast(msg, kind);
+}
+
+function dev(name) { return DEVICE_META[name] || DEVICE_META.cpu; }
+
+// ── slot chip ───────────────────────────────────────────────────────────────
+
+function SlotChip({ entry }) {
+  const meta = dev(entry.device || 'cpu');
+  return (
+    <span className="st-slotchip" style={{ '--bk': meta.color }}>
+      <span className="pf-chip-dot" />
+      <span className="mono st-slotchip-name">{entry.slot}</span>
+      {entry.model && <span className="mono st-slotchip-model">{entry.model}</span>}
+    </span>
+  );
+}
+
+// ── Stack card ──────────────────────────────────────────────────────────────
+
+function StackCard({ s, index, onApply, onEdit, onClone, onExport, onDelete }) {
+  const isSeed = !!s.seed;
+  const slots = s.slots || [];
+  const accent = (slots[0] && DEVICE_META[slots[0].device]?.color) || 'var(--accent)';
+
+  return (
+    <div className={'pf-card st-card' + (s.active ? ' st-active' : '')}
+      style={{ '--bk': accent, animationDelay: (index * 34) + 'ms' }}>
+      <span className="pf-accent" />
+      {s.active && (
+        <span className={'st-ribbon' + (s.drift === 'modified' ? ' drift' : '')}>
+          {s.drift === 'modified' ? 'Active · modified' : 'Active'}
+        </span>
+      )}
+      <div className="pf-card-top">
+        <div className="pf-headline">
+          <div className="pf-intent">{s.icon ? s.icon + ' ' : ''}{s.name || s.slug}</div>
+          <div className="pf-slug-row mono">
+            <span className="pf-slug">{s.slug}</span>
+          </div>
+        </div>
+        <div className="pf-metric">
+          <span className="pf-tps num">{slots.length}</span>
+          <span className="pf-tps-u mono">slot{slots.length === 1 ? '' : 's'}</span>
+        </div>
+      </div>
+
+      {s.description && <div className="st-desc">{s.description}</div>}
+
+      <div className="st-slots">
+        {slots.length
+          ? slots.map(e => <SlotChip key={e.slot} entry={e} />)
+          : <span className="pf-unused mono">no slots</span>}
+      </div>
+
+      <div className="pf-chips">
+        {(s.tags || []).map(t => <span className="pf-chip" key={t}>{t}</span>)}
+        <span className="pf-grow" />
+        {isSeed
+          ? <span className="pf-chip seed immutable" title="Seed stacks are read-only">{Icons.lock} seed</span>
+          : <span className="pf-chip custom">custom</span>}
+      </div>
+
+      <div className="pf-foot">
+        <div className="pf-actions" style={{ width: '100%' }}>
+          <button className="pf-btn primary" onClick={() => onApply(s)}
+            title="Preview the diff, then load this stack" data-testid={`st-btn-apply-${s.slug}`}>
+            {Icons.start} Apply
+          </button>
+          <button className="pf-btn" onClick={() => onExport(s)} title="Export .hal0stack.json"
+            data-testid={`st-btn-export-${s.slug}`}>{Icons.download}</button>
+          {isSeed ? (
+            <button className="pf-btn" onClick={() => onClone(s)} title="Seeds are immutable — fork a copy"
+              data-testid={`st-btn-editcopy-${s.slug}`}>{Icons.copy} Edit a copy</button>
+          ) : (
+            <>
+              <button className="pf-btn" onClick={() => onClone(s)} title="Clone"
+                data-testid={`st-btn-clone-${s.slug}`}>{Icons.copy}</button>
+              <button className="pf-btn" onClick={() => onEdit(s)} title="Edit"
+                data-testid={`st-btn-edit-${s.slug}`}>{Icons.edit} Edit</button>
+            </>
+          )}
+          <span className="pf-grow" />
+          <button className="pf-btn danger" onClick={() => onDelete(s)} disabled={isSeed}
+            title={isSeed ? 'Seed stacks cannot be deleted' : 'Delete'}
+            data-testid={`st-btn-delete-${s.slug}`}>{Icons.trash}</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Section ─────────────────────────────────────────────────────────────────
+
+function Section({ title, count, hint, children }) {
+  return (
+    <div className="pf-section">
+      <div className="sec">
+        <h2>{title}<span className="ct num">{count}</span></h2>
+        {hint && <span className="pf-sec-hint mono">{hint}</span>}
+        <span className="rule" />
+      </div>
+      <div className="pf-grid">{children}</div>
+    </div>
+  );
+}
+
+// ── Apply modal (dry-run diff → commit) ─────────────────────────────────────
+
+function ApplyModal({ stack, onClose }) {
+  const apply = useStackApply();
+  const [phase, setPhase] = useState('loading');   // loading | preview | applying | done
+  const [diff, setDiff] = useState(null);
+  const [report, setReport] = useState(null);
+
+  useEffect(() => {
+    let alive = true;
+    apply.mutateAsync({ slug: stack.slug, dryRun: true })
+      .then(r => { if (alive) { setDiff(r); setPhase('preview'); } })
+      .catch(err => { if (alive) { toast(err?.message || 'Preview failed', 'err'); onClose(); } });
+    return () => { alive = false; };
+    /* eslint-disable-next-line */
+  }, [stack.slug]);
+
+  async function commit() {
+    setPhase('applying');
+    try {
+      const r = await apply.mutateAsync({ slug: stack.slug, dryRun: false });
+      setReport(r.converged || null);
+      setPhase('done');
+      const errs = r.converged?.errors?.length || 0;
+      toast(errs ? `Applied ${stack.slug} with ${errs} slot error(s)` : `Applied ${stack.slug}`,
+        errs ? 'warn' : 'ok');
+    } catch (err) {
+      toast(err?.message || 'Apply failed', 'err');
+      setPhase('preview');
+    }
+  }
+
+  const changes = (diff?.changes || []).filter(c => c.changed);
+
+  return (
+    <div className="pf-scrim center" onMouseDown={onClose}>
+      <div className="pf-confirm st-apply" onMouseDown={e => e.stopPropagation()} role="dialog"
+        aria-label={`Apply ${stack.slug}`} aria-busy={phase === 'applying'}>
+        <div className="pf-confirm-h pf-confirm-title mono">{Icons.start} Apply · {stack.name || stack.slug}</div>
+
+        {phase === 'loading' && <div className="pf-confirm-b"><div className="empty mono">Computing diff…</div></div>}
+
+        {(phase === 'preview' || phase === 'applying') && (
+          <div className="pf-confirm-b">
+            {changes.length ? (
+              <>
+                <div className="st-apply-sub mono">{changes.length} slot{changes.length > 1 ? 's' : ''} will change · un-named slots are unloaded</div>
+                <div className="st-diff">
+                  {changes.map(c => (
+                    <div className="st-diff-row" key={c.slot}>
+                      <span className="mono st-diff-slot">{c.slot}</span>
+                      <span className="mono st-diff-from">{c.before_model || '∅'}</span>
+                      <span className="st-diff-arrow">→</span>
+                      <span className="mono st-diff-to">{c.after_model || '∅'}</span>
+                    </div>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <div className="pf-confirm-sub">No slot changes — applying records this as the active stack and converges the runtime.</div>
+            )}
+          </div>
+        )}
+
+        {phase === 'done' && (
+          <div className="pf-confirm-b">
+            <div className="st-apply-sub mono ok">Applied.</div>
+            {report && (
+              <div className="st-report">
+                {report.loaded.length > 0 && <div className="mono">loaded · {report.loaded.join(', ')}</div>}
+                {report.swapped.length > 0 && <div className="mono">swapped · {report.swapped.join(', ')}</div>}
+                {report.unloaded.length > 0 && <div className="mono">unloaded · {report.unloaded.join(', ')}</div>}
+                {report.capabilities_applied.length > 0 && <div className="mono">capabilities · {report.capabilities_applied.join(', ')}</div>}
+                {report.errors.length > 0 && (
+                  <div className="mono" style={{ color: 'var(--err)' }}>
+                    errors · {report.errors.map(e => `${e.target}: ${e.error}`).join('; ')}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="pf-confirm-foot">
+          <button className="pf-btn" onClick={onClose} disabled={phase === 'applying'}>
+            {phase === 'done' ? 'Close' : 'Cancel'}
+          </button>
+          {phase !== 'done' && (
+            <button className="pf-btn primary solid" onClick={commit}
+              disabled={phase !== 'preview'} data-testid="st-btn-apply-confirm">
+              {phase === 'applying' ? 'Applying…' : 'Apply stack'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Import modal (file → dry-run resolve → commit) ──────────────────────────
+
+function ImportModal({ existing, onClose, onImported }) {
+  const imp = useStackImport();
+  const [envelope, setEnvelope] = useState(null);
+  const [report, setReport] = useState(null);
+  const [slug, setSlug] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState('');
+
+  async function onFile(file) {
+    setErr('');
+    try {
+      const text = await file.text();
+      const env = JSON.parse(text);
+      setEnvelope(env);
+      const r = await imp.mutateAsync({ envelope: env, dry_run: true });
+      setReport(r);
+      // Suggest a slug from the file name, kebab-cased.
+      const base = (file.name || '').replace(/\.hal0stack\.json$|\.json$/i, '')
+        .toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 32);
+      setSlug(base || 'imported-stack');
+    } catch (e) {
+      setErr(e?.message || 'Not a valid .hal0stack.json envelope');
+      setEnvelope(null); setReport(null);
+    }
+  }
+
+  const slugTaken = existing.includes(slug);
+  const slugValid = NAME_RE.test(slug) && !slugTaken;
+
+  async function commit() {
+    if (!slugValid) return;
+    setBusy(true);
+    try {
+      await imp.mutateAsync({ envelope, slug });
+      toast(`Imported as ${slug}`, 'ok');
+      onImported();
+    } catch (e) {
+      toast(e?.message || 'Import failed', 'err');
+    } finally { setBusy(false); }
+  }
+
+  return (
+    <div className="pf-scrim center" onMouseDown={() => { if (!busy) onClose(); }}>
+      <div className="pf-confirm st-apply" onMouseDown={e => e.stopPropagation()} role="dialog" aria-label="Import stack">
+        <div className="pf-confirm-h pf-confirm-title mono">{Icons.download} Import stack</div>
+        <div className="pf-confirm-b">
+          {!report ? (
+            <label className="st-drop">
+              <input type="file" accept=".json,application/json" style={{ display: 'none' }}
+                onChange={e => e.target.files?.[0] && onFile(e.target.files[0])}
+                data-testid="st-import-file" />
+              <span className="st-drop-glyph">{Icons.download}</span>
+              <span className="mono">Choose a .hal0stack.json file</span>
+              {err && <span className="pf-msg err mono hint err">{Icons.alert}{err}</span>}
+            </label>
+          ) : (
+            <>
+              <div className="st-apply-sub mono">
+                {report.name || 'stack'} · schema v{report.schema_version} · checksum {report.checksum_ok ? 'ok' : '⚠ mismatch'}
+              </div>
+              <div className="st-resolve">
+                {(report.resolutions || []).map(r => (
+                  <div className={'st-resolve-row ' + r.status} key={r.model_id}>
+                    <span className="mono st-resolve-id">{r.model_id}</span>
+                    <span className={'pf-chip st-resolve-st ' + r.status}>{r.status}</span>
+                    {r.status === 'pullable' && (
+                      <button className="pf-btn" type="button"
+                        onClick={() => { window.location.hash = '#models'; }}
+                        title="Pull this model on the Models page">{Icons.download} Pull</button>
+                    )}
+                  </div>
+                ))}
+                {(!report.resolutions || report.resolutions.length === 0) && (
+                  <div className="pf-unused mono">no model references</div>
+                )}
+              </div>
+              {report.unresolvable?.length > 0 && (
+                <div className="pf-msg warn mono">{Icons.alert}{report.unresolvable.length} model(s) unresolvable — those slots import disabled.</div>
+              )}
+              <label className="st-slugrow">
+                <span className="pf-row-lbl">Save as</span>
+                <input className={'pf-input mono' + (slug && !slugValid ? ' err' : '')} value={slug}
+                  onChange={e => setSlug(e.target.value)} maxLength={32} placeholder="my-stack"
+                  data-testid="st-import-slug" />
+              </label>
+              {slugTaken && <span className="pf-msg err mono hint err">{Icons.alert}“{slug}” already exists</span>}
+            </>
+          )}
+        </div>
+        <div className="pf-confirm-foot">
+          <button className="pf-btn" onClick={onClose} disabled={busy}>Cancel</button>
+          {report && (
+            <button className="pf-btn primary solid" onClick={commit} disabled={!slugValid || busy}
+              data-testid="st-import-confirm">{busy ? 'Importing…' : 'Import'}</button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Editor drawer (create / edit / clone) ───────────────────────────────────
+
+function fromStack(s) {
+  return {
+    name: s.name || '',
+    description: s.description || '',
+    icon: s.icon || '',
+    tags: (s.tags || []).join(', '),
+    slots: (s.slots || []).map(e => ({
+      slot: e.slot || '',
+      model: e.model || '',
+      device: e.device || 'gpu-rocm',
+      profile: e.profile || '',
+      mtp: !!e.mtp,
+      capabilities: e.capabilities || [],
+    })),
+  };
+}
+
+function Drawer({ mode, source, existing = [], onClose, onSaved }) {
+  const isEdit = mode === 'edit';
+  const models = useModels().data || [];
+  const profiles = useProfiles().data || [];
+
+  const initial = (() => {
+    if (mode === 'create') return source ? fromStack(source) : { ...BLANK, slots: [{ ...BLANK_SLOT }] };
+    const base = fromStack(source);
+    if (mode === 'clone') {
+      const suffix = source.seed ? '-custom' : '-copy';
+      return { ...base, _slug: (source.slug + suffix).slice(0, 32) };
+    }
+    return { ...base, _slug: source.slug };
+  })();
+
+  const [form, setForm] = useState(initial);
+  const [slug, setSlug] = useState(initial._slug || '');
+  const [submitting, setSubmitting] = useState(false);
+  const [closing, setClosing] = useState(false);
+
+  const create = useStackCreate();
+  const update = useStackUpdate();
+
+  useEffect(() => { setForm(initial); setSlug(initial._slug || ''); /* eslint-disable-next-line */ }, [mode, source]);
+
+  const taken = existing.filter(n => !(isEdit && n === source?.slug));
+  const slugErr = !slug.trim() ? 'Slug is required'
+    : !NAME_RE.test(slug) ? 'lowercase · digits · - · _ · ≤32'
+    : taken.includes(slug) ? `“${slug}” already exists` : '';
+  const slotErr = !form.slots.length ? 'add at least one slot'
+    : form.slots.some(s => !s.slot.trim()) ? 'every slot needs a name' : '';
+  const blocking = (!isEdit && !!slugErr) || !!slotErr;
+
+  const setSlot = (i, k, v) => setForm(f => ({
+    ...f, slots: f.slots.map((s, j) => j === i ? { ...s, [k]: v } : s),
+  }));
+  const addSlot = () => setForm(f => ({ ...f, slots: [...f.slots, { ...BLANK_SLOT }] }));
+  const rmSlot = (i) => setForm(f => ({ ...f, slots: f.slots.filter((_, j) => j !== i) }));
+  const close = () => { if (submitting) return; setClosing(true); setTimeout(onClose, 200); };
+
+  async function submit(e) {
+    e.preventDefault();
+    if (blocking) { toast('Fix the highlighted fields', 'warn'); return; }
+    setSubmitting(true);
+    const body = {
+      name: form.name.trim(),
+      description: form.description.trim(),
+      icon: form.icon.trim(),
+      tags: form.tags.split(',').map(t => t.trim()).filter(Boolean),
+      slots: form.slots.map(s => ({
+        slot: s.slot.trim(),
+        model: s.model || null,
+        device: s.device || null,
+        profile: s.profile || null,
+        mtp: s.mtp,
+        capabilities: s.capabilities || [],
+      })),
+    };
+    try {
+      if (isEdit) {
+        await update.mutateAsync({ slug: source.slug, stack: body });
+        toast(`Stack ${source.slug} updated`, 'ok');
+      } else {
+        await create.mutateAsync({ slug: slug.trim(), stack: body });
+        toast(`Stack ${slug.trim()} created`, 'ok');
+      }
+      onSaved();
+    } catch (err) {
+      const code = err?.code || '';
+      if (code === 'stacks.exists') toast(`A stack named ${slug} already exists`, 'err');
+      else if (code === 'stacks.seed_immutable') toast('Seed stacks cannot be modified', 'err');
+      else toast(err?.message || 'Save failed', 'err');
+    } finally { setSubmitting(false); }
+  }
+
+  const title = isEdit ? `Edit · ${source.slug}`
+    : mode === 'clone' ? (source.seed ? `Edit a copy · ${source.slug}` : `Clone · ${source.slug}`)
+    : 'New stack';
+  const eyebrow = isEdit ? 'EDIT' : mode === 'clone' ? (source?.seed ? 'EDIT A COPY' : 'CLONE') : 'CREATE';
+
+  return (
+    <div className={'pf-scrim' + (closing ? ' out' : '')} onMouseDown={close}>
+      <div className={'pf-drawer pf-form-panel st-drawer' + (closing ? ' out' : '')}
+        onMouseDown={e => e.stopPropagation()} role="dialog" aria-label={title} aria-busy={submitting}>
+        <div className="pf-drawer-head">
+          <div>
+            <div className="pf-drawer-eye mono">{eyebrow}</div>
+            <div className="pf-drawer-title pf-form-title mono">{title}</div>
+          </div>
+          <button className="pf-x" onClick={close} aria-label="Close" disabled={submitting}>{Icons.close}</button>
+        </div>
+
+        <form className="pf-drawer-body" onSubmit={submit} noValidate>
+          <FormRow label="Slug" req sub="lowercase · - _ · ≤32" error={!isEdit ? slugErr : null}>
+            <input className={'pf-input mono' + (!isEdit && slugErr ? ' err' : '')} value={slug}
+              onChange={e => setSlug(e.target.value)} placeholder="my-stack" maxLength={32}
+              disabled={isEdit} data-testid="st-input-slug" />
+          </FormRow>
+          <FormRow label="Name" sub="display label">
+            <input className="pf-input" value={form.name}
+              onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+              placeholder="Coding" data-testid="st-input-name" />
+          </FormRow>
+          <FormRow label="Description" sub="what it's for">
+            <textarea className="pf-input pf-textarea" rows={2} value={form.description}
+              onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
+              placeholder="Fast coder + agentic muscle + repo retrieval" />
+          </FormRow>
+          <FormRow label="Icon" sub="emoji or accent">
+            <input className="pf-input" value={form.icon}
+              onChange={e => setForm(f => ({ ...f, icon: e.target.value }))} placeholder="⚡" maxLength={8} />
+          </FormRow>
+          <FormRow label="Tags" sub="comma-separated">
+            <input className="pf-input mono" value={form.tags}
+              onChange={e => setForm(f => ({ ...f, tags: e.target.value }))} placeholder="coding, fast" />
+          </FormRow>
+
+          <div className="st-slots-edit">
+            <div className="pf-row-lbl" style={{ marginBottom: 6 }}>
+              <span>Slots{slotErr && <span className="pf-msg err mono hint err" style={{ marginLeft: 8 }}>{Icons.alert}{slotErr}</span>}</span>
+            </div>
+            {form.slots.map((s, i) => (
+              <div className="st-slot-edit" key={i}>
+                <input className="pf-input mono st-slot-name" value={s.slot}
+                  onChange={e => setSlot(i, 'slot', e.target.value)} placeholder="agent" maxLength={32}
+                  data-testid={`st-slot-name-${i}`} />
+                <select className="pf-input mono st-slot-model" value={s.model}
+                  onChange={e => setSlot(i, 'model', e.target.value)} data-testid={`st-slot-model-${i}`}>
+                  <option value="">— model —</option>
+                  {models.map(m => <option key={m.id} value={m.id}>{m.id}</option>)}
+                </select>
+                <select className="pf-input mono st-slot-dev" value={s.device}
+                  onChange={e => setSlot(i, 'device', e.target.value)}>
+                  {DEVICES.map(d => <option key={d} value={d}>{DEVICE_META[d].label}</option>)}
+                </select>
+                <select className="pf-input mono st-slot-prof" value={s.profile}
+                  onChange={e => setSlot(i, 'profile', e.target.value)}>
+                  <option value="">— profile —</option>
+                  {profiles.map(p => <option key={p.name} value={p.name}>{p.name}</option>)}
+                </select>
+                <button type="button" className={'pf-switch sm' + (s.mtp ? ' on' : '')}
+                  onClick={() => setSlot(i, 'mtp', !s.mtp)} role="switch" aria-checked={s.mtp}
+                  title="MTP speculative decode"><span className="pf-switch-knob" /><span className="mono">MTP</span></button>
+                <button type="button" className="pf-btn danger" onClick={() => rmSlot(i)} title="Remove slot"
+                  data-testid={`st-slot-rm-${i}`}>{Icons.trash}</button>
+              </div>
+            ))}
+            <button type="button" className="pf-btn" onClick={addSlot} data-testid="st-slot-add">{Icons.plus} Add slot</button>
+          </div>
+        </form>
+
+        <div className="pf-drawer-foot">
+          <span className="pf-grow" />
+          <button className="pf-btn" onClick={close} type="button" disabled={submitting}>Cancel</button>
+          <button className="pf-btn primary" onClick={submit} disabled={submitting} data-testid="st-btn-submit">
+            {submitting ? 'Saving…' : isEdit ? 'Save changes' : 'Create stack'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// A trimmed FormRow (Profiles' has bench-specific affordances we don't need).
+function FormRow({ label, sub, req, children, error }) {
+  return (
+    <div className={'pf-row' + (error ? ' has-err' : '')}>
+      <div className="pf-row-lbl">
+        <span>{label}{req && <span className="pf-req" title="required">*</span>}</span>
+        {sub && <span className="pf-row-sub mono">{sub}</span>}
+      </div>
+      <div className="pf-row-ctl">
+        <div className={'pf-field' + (error ? ' err' : '')}>{children}</div>
+        {error && <div className="pf-row-foot"><span className="pf-msg err mono hint err">{Icons.alert}{error}</span></div>}
+      </div>
+    </div>
+  );
+}
+
+// ── Delete confirm ──────────────────────────────────────────────────────────
+
+function DeleteConfirm({ s, onCancel, onConfirmed }) {
+  const del = useStackDelete();
+  const [busy, setBusy] = useState(false);
+  async function handle() {
+    setBusy(true);
+    try {
+      await del.mutateAsync(s.slug);
+      toast(`Stack ${s.slug} deleted`, 'ok');
+      onConfirmed();
+    } catch (err) {
+      toast(err?.code === 'stacks.seed_immutable' ? 'Seed stacks cannot be deleted' : (err?.message || 'Delete failed'), 'err');
+      onCancel();
+    } finally { setBusy(false); }
+  }
+  return (
+    <div className="pf-scrim center pf-confirm-scrim" onMouseDown={() => { if (!busy) onCancel(); }}>
+      <div className="pf-confirm" onMouseDown={e => e.stopPropagation()} role="dialog" aria-label="Confirm delete" aria-busy={busy}>
+        <div className="pf-confirm-h pf-confirm-title mono">{Icons.trash} Delete · {s.slug}?</div>
+        <div className="pf-confirm-b">
+          <div className="pf-confirm-sub">This removes the stack permanently. Loaded slots are unaffected — only the saved bundle is deleted.</div>
+        </div>
+        <div className="pf-confirm-foot">
+          <button className="pf-btn" onClick={onCancel} disabled={busy}>Cancel</button>
+          <button className="pf-btn danger solid" onClick={handle} disabled={busy} data-testid="st-btn-delete-confirm">
+            {busy ? 'Deleting…' : 'Delete stack'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Header / summary ────────────────────────────────────────────────────────
+
+function Stat({ value, label, accent }) {
+  return (
+    <div className="pf-stat">
+      <span className="pf-stat-v num" style={accent ? { color: accent } : null}>{value}</span>
+      <span className="pf-stat-l mono">{label}</span>
+    </div>
+  );
+}
+
+function StacksHeader({ count, active, onNew, onImport, onSnapshot }) {
+  return (
+    <div className="engine-h pf-engine-h">
+      <span className="engine-glyph">{Icons.slots}</span>
+      <span className="cpane-titles">
+        <span className="engine-title">Stacks</span>
+        <span className="engine-sub">portable loadouts · slots + profiles + models, applied in one action</span>
+      </span>
+      {count != null && (
+        <span className="cpill"><span className="dot" />{count} stack{count === 1 ? '' : 's'}</span>
+      )}
+      {active && <span className="cpill st-active-pill"><span className="dot" />active · {active}</span>}
+      <span className="grow" />
+      <span className="eh-right">
+        <button className="pf-btn" onClick={onSnapshot} data-testid="st-btn-snapshot">{Icons.copy} Snapshot live</button>
+        <button className="pf-btn" onClick={onImport} data-testid="st-btn-import">{Icons.download} Import</button>
+        <button className="pf-btn primary" onClick={onNew} data-testid="st-btn-new">{Icons.plus} New stack</button>
+      </span>
+    </div>
+  );
+}
+
+// ── Main view ───────────────────────────────────────────────────────────────
+
+function StacksView() {
+  const query = useStacks();
+  const snapshot = useStackSnapshot();
+  const data = query.data;
+  const stacks = data?.stacks ?? [];
+
+  const [drawer, setDrawer] = useState(null);    // {mode, source}
+  const [confirm, setConfirm] = useState(null);
+  const [applying, setApplying] = useState(null);
+  const [importing, setImporting] = useState(false);
+
+  const exportMut = useStackExport();
+
+  const seeds = stacks.filter(s => s.seed);
+  const custom = stacks.filter(s => !s.seed);
+
+  async function onExport(s) {
+    try {
+      const env = await exportMut.mutateAsync(s.slug);
+      const blob = new Blob([JSON.stringify(env, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url; a.download = `${s.slug}.hal0stack.json`;
+      document.body.appendChild(a); a.click(); a.remove();
+      URL.revokeObjectURL(url);
+      toast(`Exported ${s.slug}`, 'ok');
+    } catch (err) { toast(err?.message || 'Export failed', 'err'); }
+  }
+
+  async function onSnapshot() {
+    try {
+      const r = await snapshot.mutateAsync({ name: 'Snapshot' });
+      // Open the editor prefilled with the live config for naming + saving.
+      setDrawer({ mode: 'create', source: r.stack });
+      toast('Captured live config — name it and save', 'info');
+    } catch (err) { toast(err?.message || 'Snapshot failed', 'err'); }
+  }
+
+  if (query.isLoading) {
+    return <div className="view"><div className="pf-engine"><StacksHeader /></div><div className="empty mono">Loading stacks…</div></div>;
+  }
+  if (query.isError) {
+    return (
+      <div className="view"><div className="pf-engine"><StacksHeader /></div>
+        <div className="empty mono" style={{ color: 'var(--err)' }}>Failed to load stacks: {query.error?.message || 'unknown error'}</div>
+      </div>
+    );
+  }
+
+  const existing = stacks.map(s => s.slug);
+
+  return (
+    <div className="view">
+      <div className="pf-engine">
+        <StacksHeader count={stacks.length} active={data?.active}
+          onNew={() => setDrawer({ mode: 'create' })}
+          onImport={() => setImporting(true)}
+          onSnapshot={onSnapshot} />
+        <div className="pf-summary">
+          <Stat value={stacks.length} label="stacks" />
+          <span className="pf-stat-div" />
+          <Stat value={seeds.length} label="seed templates" />
+          <Stat value={custom.length} label="custom" accent="var(--accent)" />
+          <span className="pf-stat-div" />
+          <Stat value={data?.active || '—'} label="active"
+            accent={data?.drift === 'modified' ? 'var(--warn)' : 'var(--ok)'} />
+          {data?.active && data?.drift && <Stat value={data.drift} label="drift" />}
+        </div>
+      </div>
+
+      {stacks.length === 0 ? (
+        <div className="empty mono">No stacks yet — create one, snapshot the live config, or import a .hal0stack.json.</div>
+      ) : (
+        <>
+          {seeds.length > 0 && (
+            <Section title="Seed stacks" count={seeds.length} hint="immutable · ship with hal0">
+              {seeds.map((s, i) => (
+                <StackCard key={s.slug} s={s} index={i}
+                  onApply={setApplying}
+                  onClone={ss => setDrawer({ mode: 'clone', source: ss })}
+                  onExport={onExport} onDelete={setConfirm} onEdit={() => {}} />
+              ))}
+            </Section>
+          )}
+          <Section title="Custom stacks" count={custom.length} hint="authored, cloned, snapshotted or imported on this box">
+            {custom.length === 0
+              ? <div className="empty mono" style={{ gridColumn: '1/-1' }}>None yet — clone a seed or snapshot the live config.</div>
+              : custom.map((s, i) => (
+                <StackCard key={s.slug} s={s} index={i}
+                  onApply={setApplying}
+                  onEdit={ss => setDrawer({ mode: 'edit', source: ss })}
+                  onClone={ss => setDrawer({ mode: 'clone', source: ss })}
+                  onExport={onExport} onDelete={setConfirm} />
+              ))}
+          </Section>
+        </>
+      )}
+
+      {drawer && (
+        <Drawer mode={drawer.mode} source={drawer.source} existing={existing}
+          onClose={() => setDrawer(null)} onSaved={() => setDrawer(null)} />
+      )}
+      {confirm && <DeleteConfirm s={confirm} onCancel={() => setConfirm(null)} onConfirmed={() => setConfirm(null)} />}
+      {applying && <ApplyModal stack={applying} onClose={() => setApplying(null)} />}
+      {importing && <ImportModal existing={existing} onClose={() => setImporting(false)} onImported={() => setImporting(false)} />}
+    </div>
+  );
+}
+
+Object.assign(window, { StacksView });

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -3036,3 +3036,68 @@ select.pf-input { cursor: pointer; }
 .mem-dir-form { display: flex; gap: 8px; }
 .mem-dir-form .input { flex: 1; }
 .mem-dir-content-preview { flex: 1; color: var(--fg-3); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ── Stacks (PR-5) ─────────────────────────────────────────────────────────
+   Layers on top of the .pf-* card/drawer/confirm styling: the active ribbon,
+   drift badge, slot chips/rows, the apply-diff + import-resolve surfaces. */
+.st-card { position: relative; }
+.st-card.st-active { border-color: var(--accent-line); box-shadow: 0 0 0 1px var(--accent-soft) inset; }
+.st-ribbon {
+  position: absolute; top: 10px; right: -1px; z-index: 2;
+  font-family: var(--jbm); font-size: 9.5px; letter-spacing: 0.06em; text-transform: uppercase;
+  padding: 3px 9px; border-radius: 999px 0 0 999px;
+  background: var(--accent-soft); color: var(--accent); border: 1px solid var(--accent-line); border-right: none;
+}
+.st-ribbon.drift { background: var(--warn-soft); color: var(--warn); border-color: var(--warn-line); }
+.st-active-pill .dot { background: var(--ok); box-shadow: 0 0 6px var(--ok); }
+.st-desc { font-size: 12px; color: var(--fg-3); margin: 2px 0 8px; line-height: 1.45; }
+.st-slots { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 10px; }
+.st-slotchip {
+  display: inline-flex; align-items: center; gap: 6px; max-width: 100%;
+  padding: 3px 8px; border-radius: 7px; background: var(--bg-2); border: 1px solid var(--line);
+  font-size: 11px;
+}
+.st-slotchip-name { color: var(--fg); font-weight: 600; }
+.st-slotchip-model { color: var(--fg-4); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 180px; }
+
+/* Apply / Import modal (wider than the plain confirm). */
+.st-apply { width: min(560px, 94vw); max-width: 94vw; }
+.st-apply-sub { font-size: 11.5px; color: var(--fg-3); margin-bottom: 10px; }
+.st-apply-sub.ok { color: var(--ok); }
+.st-diff { display: flex; flex-direction: column; gap: 4px; }
+.st-diff-row {
+  display: grid; grid-template-columns: minmax(80px, auto) 1fr auto 1fr; align-items: center; gap: 10px;
+  padding: 7px 10px; border-radius: 8px; background: var(--bg-2); border: 1px solid var(--line); font-size: 12px;
+}
+.st-diff-slot { color: var(--fg); font-weight: 600; }
+.st-diff-from { color: var(--fg-4); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.st-diff-arrow { color: var(--accent); }
+.st-diff-to { color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.st-report { margin-top: 8px; display: flex; flex-direction: column; gap: 3px; font-size: 11px; color: var(--fg-3); }
+
+/* Import resolve report. */
+.st-drop {
+  display: flex; flex-direction: column; align-items: center; gap: 10px; cursor: pointer;
+  padding: 26px; border: 1px dashed var(--line-strong); border-radius: 12px; background: var(--bg-2); color: var(--fg-3);
+}
+.st-drop:hover { border-color: var(--accent-line); color: var(--fg); }
+.st-drop-glyph svg { width: 22px; height: 22px; }
+.st-resolve { display: flex; flex-direction: column; gap: 5px; margin: 8px 0; max-height: 240px; overflow-y: auto; }
+.st-resolve-row { display: flex; align-items: center; gap: 8px; padding: 5px 8px; border-radius: 7px; background: var(--bg-2); border: 1px solid var(--line); }
+.st-resolve-id { font-size: 11px; color: var(--fg-2); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.st-resolve-st.present { color: var(--ok); border-color: var(--ok-line); }
+.st-resolve-st.pullable { color: var(--info); border-color: var(--info-line); }
+.st-resolve-st.unresolvable { color: var(--err); border-color: var(--err-line); }
+.st-slugrow { display: flex; align-items: center; gap: 10px; margin-top: 10px; }
+.st-slugrow .pf-input { flex: 1; }
+
+/* Editor: per-slot row. */
+.st-slots-edit { margin-top: 6px; display: flex; flex-direction: column; gap: 8px; }
+.st-slot-edit { display: grid; grid-template-columns: 110px 1fr 96px 1fr auto auto; gap: 6px; align-items: center; }
+.st-slot-edit .pf-input { min-width: 0; }
+.pf-switch.sm { gap: 5px; }
+.pf-switch.sm .mono { font-size: 10px; color: var(--fg-3); }
+@media (max-width: 720px) {
+  .st-slot-edit { grid-template-columns: 1fr 1fr; }
+  .st-diff-row { grid-template-columns: 1fr; gap: 2px; }
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -69,6 +69,9 @@ import './dash/connections.css'
 import './dash/connections.jsx'
 // issue #658 — Profiles: container-slot template catalog + iGPU intent labels.
 import './dash/profiles.jsx'
+// Stacks (PR-5): named, portable slot+profile+model bundles — registers
+// window.StacksView, rendered as the third Slots tab.
+import './dash/stacks.jsx'
 import './dash/settings.jsx'
 
 import './dash/extras.jsx'


### PR DESCRIPTION
Surfaces the merged stacks engine (PR-1/2/3) so it is actually reachable. Until now `src/hal0/stacks/` shipped a complete, tested catalog + apply engine + portable export/import with **no API, no MCP, and no UI** — a feature with no door into it. This is the REST + MCP half of spec §8 (`docs/superpowers/specs/2026-06-19-stacks-design.md`).

## REST — `src/hal0/api/routes/stacks.py` (mounted at `/api/stacks`)

| Method | Path | Purpose |
|---|---|---|
| GET | `""` | list (+ active stack + drift status) |
| POST | `""` | create (slug + StackConfig) → 201 |
| GET | `"/{slug}"` | detail (+ active + drift) |
| PUT | `"/{slug}"` | replace a custom stack |
| DELETE | `"/{slug}"` | delete a custom stack → 204 |
| POST | `"/{slug}/apply"` | `?dry_run=true` → diff preview; else commit + converge |
| POST | `"/{slug}/export"` | portable `.hal0stack.json` envelope |
| POST | `"/import"` | `{dry_run?, slug?, envelope}` → resolve report or create |
| POST | `"/snapshot"` | build a StackConfig from current live config |

Thin adapter over `StacksCatalog` (CRUD + seed guard), `StackApplyEngine` (plan → apply_config → record_active → converge), and `portable` (export/import/snapshot). Wall-clock values (`exported_at`, `applied_at`) are stamped in the route so the engine/portable layers stay pure.

## MCP — `src/hal0/mcp/admin.py`

`stack_list` + `stack_status` (autonomous read); `stack_apply` + `stack_import` + `stack_delete` (gated for owner approval, mirroring `slot_create`/`capability_set`). REST-passthrough rows + path-arg map + annotations + registration.

## Tests

- `tests/api/test_stacks_routes.py` — CRUD, dry-run diff, commit+converge (injected fakes), export→import round-trip, snapshot, seed-immutability.
- `tests/mcp/test_admin_stacks.py` — classification + URL routing + gating.
- Updated the destructive-set guard in `test_admin.py` for `stack_delete`.

New tests: 45 pass. Full `tests/api`: 1072 passed, 3 failed — the 3 are pre-existing env-specific failures on base main (proxy-port / detection-rows / non-writable-path under root-on-pve), not regressions. `ruff check`/`format` clean.

## Remaining for the feature

PR-5 dashboard UI, PR-6 seed stacks + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)