### PR TITLE
fix(stacks): live snapshot + create-on-apply + slot picker

### DIFF
--- a/src/hal0/api/routes/stacks.py
+++ b/src/hal0/api/routes/stacks.py
@@ -34,6 +34,7 @@ from fastapi import APIRouter, Request
 from pydantic import BaseModel, Field
 
 from hal0.api._audit import record_action
+from hal0.config import paths
 from hal0.config.schema import StackConfig
 from hal0.errors import BadRequest
 from hal0.stacks import ResolvedStack, StacksCatalog
@@ -138,6 +139,66 @@ def _registry(request: Request) -> Any:
             code="stacks.registry_unavailable",
         )
     return reg
+
+
+# A stack may name a slot that doesn't exist yet (e.g. a "quick" coder slot in a
+# cloned/imported stack). Apply must create it before the converge load, the way
+# the spec's seed copy expects. Without a profile a fresh slot fails to load
+# ("profile '' not found"), so default a coherent profile from the device.
+_PROFILE_BY_DEVICE = {
+    "gpu-rocm": "rocm",
+    "gpu-vulkan": "vulkan",
+    "npu": "flm",
+    "cpu": "",
+}
+
+
+def _slot_toml_exists(slot: str) -> bool:
+    return (paths.slots_config_dir() / f"{slot}.toml").exists()
+
+
+def _missing_slot_names(cfg: StackConfig) -> list[str]:
+    """Stack slots (with a model) whose TOML doesn't exist yet."""
+    return [e.slot for e in cfg.slots if e.model and not _slot_toml_exists(e.slot)]
+
+
+async def _create_missing_slots(
+    cfg: StackConfig, slot_manager: Any
+) -> tuple[list[str], list[dict[str, str]]]:
+    """Create any stack slot whose TOML is absent, via the live slot-create path.
+
+    Reuses ``routes/slots._normalize_create_body`` (flat→nested + free-port
+    assignment) and ``SlotManager.create`` so a created slot is identical to one
+    made through POST /api/slots. Per-slot failures are collected, not raised, so
+    one bad entry doesn't sink the whole apply. Returns ``(created, errors)``.
+    """
+    from hal0.api.routes.slots import _normalize_create_body
+
+    created: list[str] = []
+    errors: list[dict[str, str]] = []
+    for entry in cfg.slots:
+        if not entry.model or _slot_toml_exists(entry.slot):
+            continue
+        device = entry.device or "gpu-vulkan"
+        profile = entry.profile or _PROFILE_BY_DEVICE.get(device, "")
+        body: dict[str, Any] = {
+            "name": entry.slot,
+            "type": "llm",
+            "model": entry.model,
+            "device": device,
+            "profile": profile,
+            "vision": bool(entry.vision),
+        }
+        if entry.mtp is not None:
+            body["mtp"] = bool(entry.mtp)
+        if entry.server_extra_args:
+            body["server"] = {"extra_args": entry.server_extra_args}
+        try:
+            await slot_manager.create(entry.slot, _normalize_create_body(body))
+            created.append(entry.slot)
+        except Exception as exc:
+            errors.append({"target": entry.slot, "error": str(exc)})
+    return created, errors
 
 
 def _diff_rows(plan: Any) -> list[dict[str, Any]]:
@@ -284,6 +345,8 @@ async def apply_stack(slug: str, request: Request, dry_run: bool = False) -> dic
             "dry_run": True,
             "summary": plan.summary,
             "changes": _diff_rows(plan),
+            # Slots the stack names that don't exist yet — apply will create them.
+            "creates": _missing_slot_names(cfg),
         }
 
     slot_manager = getattr(request.app.state, "slot_manager", None)
@@ -291,6 +354,15 @@ async def apply_stack(slug: str, request: Request, dry_run: bool = False) -> dic
     engine = StackApplyEngine(slot_manager=slot_manager, orchestrator=orchestrator)
 
     async with record_action(request, category="stack", action="stack.apply", target=slug) as rec:
+        # Create-on-apply: a stack may reference a slot that doesn't exist yet.
+        # Create it BEFORE planning so Phase A reconciles it and converge loads
+        # it (spec §10 "non-seed slots are created on apply"). Needs a live slot
+        # manager; without one (degraded), missing slots are simply skipped.
+        created: list[str] = []
+        create_errors: list[dict[str, str]] = []
+        if slot_manager is not None:
+            created, create_errors = await _create_missing_slots(cfg, slot_manager)
+
         plan = engine.plan(slug, cfg)
         engine.apply_config(plan)
         engine.record_active(plan, applied_at=time.time())
@@ -303,12 +375,17 @@ async def apply_stack(slug: str, request: Request, dry_run: bool = False) -> dic
                 "skipped": report.skipped,
                 "unloaded": report.unloaded,
                 "capabilities_applied": report.capabilities_applied,
-                "errors": [{"target": t, "error": e} for t, e in report.errors],
+                "errors": [{"target": t, "error": e} for t, e in report.errors] + create_errors,
             }
-        rec.after = {"slug": slug, "changed": sum(1 for r in _diff_rows(plan) if r["changed"])}
+        rec.after = {
+            "slug": slug,
+            "changed": sum(1 for r in _diff_rows(plan) if r["changed"]),
+            "created": created,
+        }
 
     return {
         "stack": slug,
+        "created": created,
         "dry_run": False,
         "summary": plan.summary,
         "changes": _diff_rows(plan),

--- a/src/hal0/stacks/portable.py
+++ b/src/hal0/stacks/portable.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -20,10 +21,10 @@ from pydantic import BaseModel
 
 from hal0 import __version__
 from hal0.capabilities.config import load_capabilities_config
+from hal0.config import paths
 from hal0.config.loader import (
     list_slots,
     load_profiles_config,
-    load_slot_config,
     save_profiles_config,
 )
 from hal0.config.schema import (
@@ -270,6 +271,52 @@ def import_stack(
 # ── snapshot from live ───────────────────────────────────────────────────────
 
 
+def _read_slot_raw(slot_name: str) -> dict[str, Any] | None:
+    """Tolerantly read a slot TOML into the fields a snapshot needs.
+
+    Deliberately does NOT go through :func:`load_slot_config` /
+    ``SlotConfig`` validation: the strict loader assumes the legacy nested
+    ``[slot]`` shape and rejects the live flat shape the runtime writes (it
+    drops ``port`` and raises) — which silently emptied every snapshot. A
+    snapshot only needs the inference-surface fields, so we read the raw dict
+    and accept BOTH shapes: top-level keys (flat) and a ``[slot]`` section
+    (nested). ``[model]`` is a top-level section in both. Returns ``None`` only
+    when the file is absent or unparseable.
+    """
+    path = paths.slots_config_dir() / f"{slot_name}.toml"
+    try:
+        with open(path, "rb") as f:
+            raw = tomllib.load(f)
+    except (FileNotFoundError, OSError, tomllib.TOMLDecodeError):
+        return None
+
+    slot_sec = raw.get("slot") if isinstance(raw.get("slot"), dict) else {}
+
+    def g(key: str, default: Any = None) -> Any:
+        return raw.get(key, slot_sec.get(key, default))
+
+    model_tbl = raw.get("model")
+    if not isinstance(model_tbl, dict):
+        model_tbl = slot_sec.get("model") if isinstance(slot_sec.get("model"), dict) else {}
+    model = (model_tbl.get("default") if isinstance(model_tbl, dict) else None) or None
+
+    server = raw.get("server") if isinstance(raw.get("server"), dict) else {}
+    device = g("device")
+    return {
+        "model": model,
+        # device must be a canonical _VALID_DEVICES value or None — a legacy
+        # backend string (e.g. "rocm") would fail StackSlotEntry validation.
+        "device": device if device in _VALID_DEVICES else None,
+        "provider": g("provider"),
+        "role": g("role"),
+        "profile": g("profile"),
+        "vision": bool(g("vision", False)),
+        "mtp": g("mtp"),
+        "enable_thinking": g("enable_thinking"),
+        "server_extra_args": server.get("extra_args"),
+    }
+
+
 def snapshot_live_stack(
     *,
     name: str = "",
@@ -283,17 +330,18 @@ def snapshot_live_stack(
     and projects each configured slot into a StackSlotEntry. Empty seeded slots
     (no model, no capability rows) are skipped so the snapshot stays clean.
     Blank-picker capability selections (device unset) are dropped — they would
-    fail StackCapabilityRow validation and carry no real config. The result is
-    run through :func:`embed_references` so it is self-contained.
+    fail StackCapabilityRow validation and carry no real config. Slot TOMLs are
+    read tolerantly (see :func:`_read_slot_raw`) so the live flat shape is
+    captured, not silently dropped. The result is run through
+    :func:`embed_references` so it is self-contained.
     """
     caps = load_capabilities_config()
     entries: list[StackSlotEntry] = []
 
     for slot_name in list_slots():
-        try:
-            sc = load_slot_config(slot_name)
-        except Exception:
-            # A malformed slot TOML never breaks the whole snapshot.
+        sc = _read_slot_raw(slot_name)
+        if sc is None:
+            # A missing/unparseable slot TOML never breaks the whole snapshot.
             continue
 
         rows: list[StackCapabilityRow] = []
@@ -310,7 +358,7 @@ def snapshot_live_stack(
                 )
             )
 
-        model = sc.model.default or None
+        model = sc["model"]
         if model is None and not rows:
             continue  # empty seeded slot
 
@@ -318,14 +366,14 @@ def snapshot_live_stack(
             StackSlotEntry(
                 slot=slot_name,
                 model=model,
-                device=sc.device,
-                provider=sc.provider,
-                role=sc.role,
-                vision=sc.vision,
-                mtp=sc.mtp,
-                enable_thinking=sc.enable_thinking,
-                server_extra_args=sc.server.extra_args,
-                profile=sc.profile,
+                device=sc["device"],
+                provider=sc["provider"],
+                role=sc["role"],
+                vision=sc["vision"],
+                mtp=sc["mtp"],
+                enable_thinking=sc["enable_thinking"],
+                server_extra_args=sc["server_extra_args"],
+                profile=sc["profile"],
                 capabilities=rows,
             )
         )

--- a/tests/api/test_stacks_routes.py
+++ b/tests/api/test_stacks_routes.py
@@ -242,6 +242,54 @@ def test_apply_commit_converges_and_sets_active(app: FastAPI, tmp_hal0_home: str
         assert active_item["drift"] == "clean"
 
 
+# ── create-on-apply (slots that don't exist yet) ───────────────────────────────
+
+
+def test_apply_dry_run_lists_slots_to_create(client: TestClient) -> None:
+    # "quick" has no slot TOML → dry-run flags it under `creates`.
+    client.post(
+        "/api/stacks",
+        json={
+            "slug": "coding",
+            "stack": _stack_body(slots=[{"slot": "quick", "model": "m", "device": "gpu-vulkan"}]),
+        },
+    )
+    r = client.post("/api/stacks/coding/apply", params={"dry_run": "true"})
+    assert r.status_code == 200
+    assert r.json()["creates"] == ["quick"]
+
+
+def test_apply_commit_creates_missing_slot(app: FastAPI, tmp_hal0_home: str) -> None:
+    with TestClient(app) as c:
+        c.post(
+            "/api/stacks",
+            json={
+                "slug": "coding",
+                "stack": _stack_body(
+                    slots=[
+                        {"slot": "quick", "model": "m", "device": "gpu-vulkan", "profile": "vulkan"}
+                    ]
+                ),
+            },
+        )
+        fake_sm = AsyncMock()
+        fake_sm.list = AsyncMock(return_value=[])
+        app.state.slot_manager = fake_sm
+        app.state.capability_orchestrator = AsyncMock()
+
+        r = c.post("/api/stacks/coding/apply")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["created"] == ["quick"]
+        # The slot was created through the live slot-create path before converge.
+        fake_sm.create.assert_awaited()
+        created_name = fake_sm.create.await_args.args[0]
+        assert created_name == "quick"
+        # A port was auto-assigned by _normalize_create_body.
+        created_body = fake_sm.create.await_args.args[1]
+        assert isinstance(created_body.get("port"), int) and created_body["port"] > 0
+
+
 # ── export / import round-trip ─────────────────────────────────────────────────
 
 

--- a/tests/stacks/test_snapshot.py
+++ b/tests/stacks/test_snapshot.py
@@ -60,6 +60,46 @@ class TestSnapshot:
         assert agent.device == "gpu-rocm"
         assert stack.name == "Live"
 
+    def test_captures_flat_shape_slot(self, reg: ModelRegistry, tmp_hal0_home: str) -> None:
+        # The live runtime writes the FLAT slot shape (no [slot] section). The
+        # strict load_slot_config mishandles it (drops port, raises) which
+        # silently emptied every live snapshot — regression guard for that.
+        from pathlib import Path
+
+        d = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "agent.toml").write_text(
+            'name = "agent"\n'
+            'type = "llm"\n'
+            'device = "gpu-rocm"\n'
+            'backend = "rocm"\n'
+            'profile = "rocm-moe"\n'
+            "port = 8082\n"
+            "mtp = true\n\n"
+            "[model]\n"
+            'default = "ace-saber"\n',
+            encoding="utf-8",
+        )
+        stack = snapshot_live_stack(registry=reg, name="Live")
+        agent = next(e for e in stack.slots if e.slot == "agent")
+        assert agent.model == "ace-saber"
+        assert agent.device == "gpu-rocm"
+        assert agent.profile == "rocm-moe"
+        assert agent.mtp is True
+
+    def test_legacy_backend_device_dropped(self, reg: ModelRegistry, tmp_hal0_home: str) -> None:
+        # A non-canonical device (legacy "rocm" backend) would fail
+        # StackSlotEntry validation → it's read as None, not raised.
+        _write_slot(
+            tmp_hal0_home,
+            "old",
+            ['name = "old"', "port = 8088", 'device = "rocm"', "[model]", 'default = "m"'],
+        )
+        stack = snapshot_live_stack(registry=reg)
+        entry = next(e for e in stack.slots if e.slot == "old")
+        assert entry.model == "m"
+        assert entry.device is None
+
     def test_captures_capability_rows(self, reg: ModelRegistry, tmp_hal0_home: str) -> None:
         _write_slot(
             tmp_hal0_home, "embed", ['name = "embed"', "port = 8082", "[model]", 'default = ""']

--- a/ui/src/api/hooks/useStacks.ts
+++ b/ui/src/api/hooks/useStacks.ts
@@ -93,6 +93,10 @@ export interface StackApplyResult {
   dry_run: boolean
   summary: string[]
   changes: StackDiffRow[]
+  /** Dry-run: slot names the stack will create (don't exist yet). */
+  creates?: string[]
+  /** Commit: slot names that were created during apply. */
+  created?: string[]
   converged?: StackConvergeReport
 }
 

--- a/ui/src/dash/stacks.jsx
+++ b/ui/src/dash/stacks.jsx
@@ -31,6 +31,7 @@ import {
 } from '@/api/hooks/useStacks'
 import { useModels } from '@/api/hooks/useModels'
 import { useProfiles } from '@/api/hooks/useProfiles'
+import { useSlots } from '@/api/hooks/useSlots'
 
 // Device hue, mirroring the Profiles backend palette (#751 tokens).
 const DEVICE_META = {
@@ -162,6 +163,7 @@ function ApplyModal({ stack, onClose }) {
   const [phase, setPhase] = useState('loading');   // loading | preview | applying | done
   const [diff, setDiff] = useState(null);
   const [report, setReport] = useState(null);
+  const [created, setCreated] = useState([]);
 
   useEffect(() => {
     let alive = true;
@@ -177,6 +179,7 @@ function ApplyModal({ stack, onClose }) {
     try {
       const r = await apply.mutateAsync({ slug: stack.slug, dryRun: false });
       setReport(r.converged || null);
+      setCreated(r.created || []);
       setPhase('done');
       const errs = r.converged?.errors?.length || 0;
       toast(errs ? `Applied ${stack.slug} with ${errs} slot error(s)` : `Applied ${stack.slug}`,
@@ -199,6 +202,11 @@ function ApplyModal({ stack, onClose }) {
 
         {(phase === 'preview' || phase === 'applying') && (
           <div className="pf-confirm-b">
+            {diff?.creates?.length > 0 && (
+              <div className="st-apply-sub mono" style={{ color: 'var(--accent)' }}>
+                {Icons.plus} creates {diff.creates.length} new slot{diff.creates.length > 1 ? 's' : ''}: {diff.creates.join(', ')}
+              </div>
+            )}
             {changes.length ? (
               <>
                 <div className="st-apply-sub mono">{changes.length} slot{changes.length > 1 ? 's' : ''} will change · un-named slots are unloaded</div>
@@ -224,6 +232,7 @@ function ApplyModal({ stack, onClose }) {
             <div className="st-apply-sub mono ok">Applied.</div>
             {report && (
               <div className="st-report">
+                {created.length > 0 && <div className="mono">created · {created.join(', ')}</div>}
                 {report.loaded.length > 0 && <div className="mono">loaded · {report.loaded.join(', ')}</div>}
                 {report.swapped.length > 0 && <div className="mono">swapped · {report.swapped.join(', ')}</div>}
                 {report.unloaded.length > 0 && <div className="mono">unloaded · {report.unloaded.join(', ')}</div>}
@@ -380,6 +389,9 @@ function Drawer({ mode, source, existing = [], onClose, onSaved }) {
   const isEdit = mode === 'edit';
   const models = useModels().data || [];
   const profiles = useProfiles().data || [];
+  // Existing live slots feed the slot-name datalist: pick an existing slot from
+  // the dropdown, or type a new name to create one on apply.
+  const liveSlots = (useSlots().data || []).filter(s => (s.kind ?? 'local') === 'local');
 
   const initial = (() => {
     if (mode === 'create') return source ? fromStack(source) : { ...BLANK, slots: [{ ...BLANK_SLOT }] };
@@ -497,11 +509,19 @@ function Drawer({ mode, source, existing = [], onClose, onSaved }) {
             <div className="pf-row-lbl" style={{ marginBottom: 6 }}>
               <span>Slots{slotErr && <span className="pf-msg err mono hint err" style={{ marginLeft: 8 }}>{Icons.alert}{slotErr}</span>}</span>
             </div>
-            {form.slots.map((s, i) => (
+            <datalist id="st-existing-slots">
+              {liveSlots.map(s => <option key={s.name} value={s.name} />)}
+            </datalist>
+            {form.slots.map((s, i) => {
+              const isNew = !!s.slot && !liveSlots.some(ls => ls.name === s.slot);
+              return (
               <div className="st-slot-edit" key={i}>
-                <input className="pf-input mono st-slot-name" value={s.slot}
-                  onChange={e => setSlot(i, 'slot', e.target.value)} placeholder="agent" maxLength={32}
+                <input className="pf-input mono st-slot-name" value={s.slot} list="st-existing-slots"
+                  onChange={e => setSlot(i, 'slot', e.target.value)}
+                  placeholder="pick or name…" maxLength={32}
+                  title={isNew ? 'New slot — created on apply' : 'Existing slot'}
                   data-testid={`st-slot-name-${i}`} />
+                {isNew && <span className="st-slot-new mono" title="Created on apply">new</span>}
                 <select className="pf-input mono st-slot-model" value={s.model}
                   onChange={e => setSlot(i, 'model', e.target.value)} data-testid={`st-slot-model-${i}`}>
                   <option value="">— model —</option>
@@ -522,7 +542,8 @@ function Drawer({ mode, source, existing = [], onClose, onSaved }) {
                 <button type="button" className="pf-btn danger" onClick={() => rmSlot(i)} title="Remove slot"
                   data-testid={`st-slot-rm-${i}`}>{Icons.trash}</button>
               </div>
-            ))}
+              );
+            })}
             <button type="button" className="pf-btn" onClick={addSlot} data-testid="st-slot-add">{Icons.plus} Add slot</button>
           </div>
         </form>

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -3101,3 +3101,10 @@ select.pf-input { cursor: pointer; }
   .st-slot-edit { grid-template-columns: 1fr 1fr; }
   .st-diff-row { grid-template-columns: 1fr; gap: 2px; }
 }
+
+/* Stacks editor — "new slot" badge (a slot name not in the live set). */
+.st-slot-new {
+  font-size: 9px; letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--accent); background: var(--accent-soft); border: 1px solid var(--accent-line);
+  border-radius: 5px; padding: 1px 5px; align-self: center; white-space: nowrap;
+}


### PR DESCRIPTION
Three gaps surfaced while using the deployed Stacks UI on CT105.

### 1. Snapshot live returned 0 slots
`snapshot_live_stack` read slots via the strict `load_slot_config`, which assumes the legacy nested `[slot]` shape and **rejects the live flat shape** the runtime writes (drops `port`, raises) — so every slot was silently skipped and "Snapshot live" opened an empty editor. Now reads the TOML tolerantly (`_read_slot_raw`, handles flat + nested; a non-canonical device degrades to `None` instead of raising).

### 2. Apply couldn't create slots that don't exist
A stack may name a slot with no TOML yet (a cloned/imported `quick` coder, etc.). Apply now creates each missing slot **before** planning, through the live slot-create path (`_normalize_create_body` → free-port + flat→nested, then `SlotManager.create`), with a coherent profile defaulted from the device. Dry-run lists them under `creates`; commit returns `created`. Per-slot create failures are reported, not raised.

### 3. Editor slot field was free-text only
Now an input backed by a **datalist of the live slots** (`useSlots`) — pick an existing slot, or type a new name (flagged "new", created on apply). The Apply modal shows a "creates N new slots" line.

## Tests
- `test_snapshot`: flat-shape capture (the CT105 regression) + legacy-device degrade-to-None.
- `test_stacks_routes`: dry-run `creates` + commit `created` (slot created via the real create path with a port assigned).
- Backend stacks sweep **114 pass**; `tsc --noEmit` + `vite build` clean.

Follow-up to #959.

🤖 Generated with [Claude Code](https://claude.com/claude-code)