### PR TITLE
feat(profiles): portable export/import + sharing (mirrors stacks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ Tags older than v0.2.0 ship release notes inside the GitHub release
 page; this CHANGELOG starts at v0.2.0 (the Lemonade migration cut).
 For ADR-level architecture context see `docs/internal/adr/`.
 
+## [v0.8.2b1] — 2026-06-23
+
+Profiles gain the same portable export/import/sharing model stacks already have.
+Safe upgrade from v0.8.1-beta.2.
+
+### Added
+- **Portable profile export/import.** A profile can now be exported to a
+  self-contained, checksummed `.hal0profile.json` envelope and imported on another
+  host — the same file-based sharing model stacks use. The envelope carries the
+  profile template plus a sha256 content checksum and an independent
+  `schema_version`; no secrets or host paths are serialized. New routes
+  `GET /api/profiles/{name}`, `POST /api/profiles/{name}/export`, and
+  `POST /api/profiles/import` (dry-run reports checksum validity + name collision;
+  commit creates under a chosen name, `409 profiles.exists` on a duplicate). New
+  MCP tools mirror the `stack_*` set: `profile_list` / `profile_status` /
+  `profile_export` (autonomous read) and `profile_import` / `profile_delete`
+  (gated). The dashboard adds an Export button to every profile card and an Import
+  dialog (file → dry-run preview → commit). (#962)
+
 ## [v0.8.1-beta.2] — 2026-06-23
 
 Bugfix on the 0.8.1 beta line — restores fleet auto-update. Safe upgrade from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.8.1-beta.2"
+version = "0.8.2b1"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hal0/api/routes/profiles.py
+++ b/src/hal0/api/routes/profiles.py
@@ -2,10 +2,13 @@
 
 Mounted under /api/profiles:
 
-    GET    ""          — list all profiles
-    POST   ""          — create a custom profile (201)
-    PUT    "/{name}"   — update a custom profile (200)
-    DELETE "/{name}"   — delete a custom profile (204)
+    GET    ""              — list all profiles
+    POST   ""              — create a custom profile (201)
+    POST   "/import"       — import a profile from a portable envelope
+    GET    "/{name}"       — resolve a single profile
+    POST   "/{name}/export"— export a profile to a portable envelope
+    PUT    "/{name}"       — update a custom profile (200)
+    DELETE "/{name}"       — delete a custom profile (204)
 
 Seed profiles (defined in SEED_PROFILES) are immutable via the API.
 
@@ -17,6 +20,7 @@ atomic writes.
 from __future__ import annotations
 
 import re
+from datetime import UTC, datetime
 from typing import Any, Literal
 
 from fastapi import APIRouter, Request
@@ -24,7 +28,14 @@ from pydantic import BaseModel, Field, field_validator
 
 from hal0.api._audit import record_action
 from hal0.config.schema import ProfileConfig
+from hal0.errors import BadRequest
 from hal0.profiles import ProfileCatalog, ProfilePatch
+from hal0.profiles.portable import (
+    export_envelope,
+    import_profile,
+    parse_envelope,
+    verify_checksum,
+)
 
 router = APIRouter()
 
@@ -165,6 +176,102 @@ async def create_profile(body: ProfileBody, request: Request) -> dict[str, Any]:
             "backend": body.backend,
         }
     return profile.to_dict()
+
+
+@router.post("/import")
+async def import_profile_route(request: Request) -> dict[str, Any]:
+    """Import a profile from an uploaded ``.hal0profile.json`` envelope.
+
+    Body::
+
+        { "envelope": {...}, "name": "name", "dry_run": false }
+
+    ``dry_run`` validates the envelope + checksum and reports whether the target
+    name already exists, without creating anything. A commit creates the profile
+    under ``name`` and returns the resolved profile item.
+
+    Raises:
+        400 profiles.bad_envelope: not a valid hal0.profile envelope.
+        400 profiles.import_no_name: commit requested without a name.
+        409 profiles.exists: name already exists.
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise BadRequest(
+            "request body must be valid JSON",
+            code="request.invalid_json",
+            details={"error": str(exc)},
+        ) from exc
+    if not isinstance(body, dict):
+        raise BadRequest("request body must be a JSON object", code="request.not_an_object")
+
+    envelope = body.get("envelope", body)
+    dry_run = bool(body.get("dry_run", False))
+    name = body.get("name")
+
+    if dry_run:
+        env = parse_envelope(envelope)
+        existing = {p.name for p in ProfileCatalog().list()}
+        target = name or env.name
+        collides = bool(target) and target in existing
+        return {
+            "dry_run": True,
+            "valid": True,
+            "checksum_ok": verify_checksum(envelope) if isinstance(envelope, dict) else False,
+            "name": env.name or "",
+            "schema_version": env.schema_version,
+            "collides": collides,
+        }
+
+    if not name or not isinstance(name, str):
+        raise BadRequest(
+            "import commit requires a 'name'",
+            code="profiles.import_no_name",
+        )
+
+    async with record_action(
+        request, category="profile", action="profile.import", target=name
+    ) as rec:
+        resolved = import_profile(envelope, name, ProfileCatalog())
+        rec.after = {"name": name}
+    return {"dry_run": False, "profile": resolved.to_dict()}
+
+
+@router.get("/{name}")
+def get_profile(name: str) -> dict[str, Any]:
+    """Resolve a single profile by name.
+
+    Returns the profile item (same shape as list).
+
+    Raises:
+        404 profiles.not_found: no such profile.
+    """
+    return ProfileCatalog().resolve(name).to_dict()
+
+
+@router.post("/{name}/export")
+def export_profile(name: str) -> dict[str, Any]:
+    """Serialize a profile into its portable ``.hal0profile.json`` envelope.
+
+    Embeds the profile template only (no secrets, no host paths) and stamps
+    ``exported_at`` + a content checksum.
+
+    Raises:
+        404 profiles.not_found: no such profile.
+    """
+    resolved = ProfileCatalog().resolve(name)
+    cfg = ProfileConfig(
+        image=resolved.image,
+        flags=resolved.flags,
+        mtp=resolved.mtp,
+        device_class=resolved.device_class,
+        backend=resolved.backend,
+        cloned_from=resolved.cloned_from,
+        intent=resolved.intent,
+        quant=resolved.quant,
+    )
+    return export_envelope(name, cfg, exported_at=datetime.now(UTC).isoformat())
 
 
 @router.put("/{name}")

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -920,6 +920,10 @@ class ProfilesConfig(BaseModel):
 # stamped on every StackConfig and on the export envelope (PR-3).
 STACK_SCHEMA_VERSION_CURRENT = 1
 
+#: Profile export envelopes carry their own schema version (independent of
+#: hal0.toml meta.schema_version), stamped on every ``.hal0profile.json`` export.
+PROFILE_SCHEMA_VERSION_CURRENT = 1
+
 _STACK_NAME_RE = r"^[a-z0-9][a-z0-9_-]{0,31}$"
 
 
@@ -2197,6 +2201,7 @@ __all__ = [
     "DEVICE_DEFAULT_PROFILES",
     "MTP_FLAG_BUNDLE",
     "PROFILE_BENCH",
+    "PROFILE_SCHEMA_VERSION_CURRENT",
     "SEED_PROFILES",
     "ActivityConfig",
     "AgentAuthConfig",

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -231,6 +231,12 @@ AUTONOMOUS_READ_TOOLS: frozenset[str] = frozenset(
         "version_info",
         "stack_list",
         "stack_status",
+        "profile_list",
+        "profile_status",
+        # profile_export is a POST but performs no state change — it
+        # builds a portable envelope from existing catalog data, so it
+        # classifies read-shaped (autonomous) like the other reads.
+        "profile_export",
         # Host-introspection probes (issue #237). Pure-read against
         # /sys/, /proc/, and lsmod — no REST round-trip, no mutation.
         # Hermes-Agent bootstrap consumes these in its env_probe phase.
@@ -272,6 +278,11 @@ GATED_TOOLS: frozenset[str] = frozenset(
         "stack_apply",
         "stack_import",
         "stack_delete",
+        # Profiles: importing creates a new catalog entry and deleting
+        # drops a saved profile — owner-approval gated, mirroring
+        # stack_import/stack_delete.
+        "profile_import",
+        "profile_delete",
         # logs_tail is gated until the redactor in logs.py covers
         # Bearer + X-API-Key + provider keys (sk-/hf-/etc.) — see
         # docs/internal/phase-8-pending/mcp-backend.md §2.
@@ -317,6 +328,10 @@ _REST_MAP: dict[str, tuple[str, str]] = {
     "version_info": ("GET", "/api/status"),
     "stack_list": ("GET", "/api/stacks"),
     "stack_status": ("GET", "/api/stacks/{slug}"),
+    "profile_list": ("GET", "/api/profiles"),
+    "profile_status": ("GET", "/api/profiles/{name}"),
+    # profile_export is a read-shaped POST — builds the envelope, no state change.
+    "profile_export": ("POST", "/api/profiles/{name}/export"),
     # Autonomous write
     "model_swap": ("POST", "/api/slots/{name}/swap"),
     # Gated write
@@ -330,6 +345,8 @@ _REST_MAP: dict[str, tuple[str, str]] = {
     "stack_apply": ("POST", "/api/stacks/{slug}/apply"),
     "stack_import": ("POST", "/api/stacks/import"),
     "stack_delete": ("DELETE", "/api/stacks/{slug}"),
+    "profile_import": ("POST", "/api/profiles/import"),
+    "profile_delete": ("DELETE", "/api/profiles/{name}"),
     # No live route yet — Memory-engine / Provider team must land the
     # endpoint. We register the tool anyway so the catalog matches the
     # ADR; calls land in a 404 surface until the route exists.
@@ -351,6 +368,9 @@ _PATH_ARGS: dict[str, tuple[str, ...]] = {
     "stack_status": ("slug",),
     "stack_apply": ("slug",),
     "stack_delete": ("slug",),
+    "profile_status": ("name",),
+    "profile_export": ("name",),
+    "profile_delete": ("name",),
 }
 
 
@@ -644,6 +664,17 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
     "stack_status": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
+    "profile_list": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "profile_status": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    # profile_export is a POST but builds an envelope from existing data —
+    # no state change, so it carries the read-shaped annotation.
+    "profile_export": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
     # Host-introspection probes — pure sysfs/procfs reads.
     "gpu_target_version": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
@@ -679,6 +710,10 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
     "stack_import": ToolAnnotations(
         readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
     ),
+    # Import creates a new catalog entry (non-idempotent — re-import conflicts on name).
+    "profile_import": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+    ),
     "config_write": ToolAnnotations(
         readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
@@ -707,6 +742,9 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
         readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
     ),
     "stack_delete": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
+    ),
+    "profile_delete": ToolAnnotations(
         readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
     ),
     "memory_delete": ToolAnnotations(
@@ -780,6 +818,16 @@ def build_server(
     _register("version_info", "hal0 version + runtime status.")
     _register("stack_list", "List every stack, with the active stack + drift status.")
     _register("stack_status", "Get one stack's detail, active flag, and drift status.")
+    _register("profile_list", "List every profile in the catalog (seed + custom).")
+    _register(
+        "profile_status",
+        "Get one profile's resolved detail (image, flags, backend, used-by).",
+    )
+    # profile_export is a read-shaped POST — builds the envelope, no state change.
+    _register(
+        "profile_export",
+        "Export a profile to a portable .hal0profile.json envelope (no secrets/host-paths).",
+    )
     # Host-introspection probes (issue #237)
     _register(
         "gpu_target_version",
@@ -820,6 +868,11 @@ def build_server(
     )
     _register("stack_import", "Import a stack from a .hal0stack.json envelope (gated).")
     _register("stack_delete", "Delete a custom stack from the catalog (gated).")
+    _register(
+        "profile_import",
+        "Import a profile from a .hal0profile.json envelope (gated).",
+    )
+    _register("profile_delete", "Delete a custom profile from the catalog (gated).")
     _register(
         "provider_credential_write",
         "Write provider credentials (gated; secrets never echoed back).",

--- a/src/hal0/profiles/portable.py
+++ b/src/hal0/profiles/portable.py
@@ -1,0 +1,119 @@
+"""Portable profiles — export/import (mirrors stacks/portable.py, simpler).
+
+Export serializes a single profile (image + flag bundle + display facts; never
+secrets, never host paths) into a self-contained ``.hal0profile.json`` envelope
+with a content checksum. Import validates the envelope and creates the profile.
+Pure functions — the caller stamps ``exported_at``, so there is no clock or
+hidden global here. Profiles carry no models/slots, so there is no embedding or
+model resolution (unlike stacks).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+from hal0 import __version__
+from hal0.config.schema import PROFILE_SCHEMA_VERSION_CURRENT, ProfileConfig
+from hal0.errors import BadRequest
+
+ENVELOPE_KIND = "hal0.profile"
+
+
+def _checksum(body: dict[str, Any]) -> str:
+    """sha256 over the canonical profile body — deterministic, order-independent."""
+    payload = json.dumps(body, sort_keys=True, default=str)
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def export_envelope(name: str, profile: ProfileConfig, *, exported_at: str) -> dict[str, Any]:
+    """Build the ``.hal0profile.json`` envelope dict for ``profile``.
+
+    ``exported_at`` is caller-supplied (no clock here). The checksum covers the
+    profile body only — re-exporting the same profile yields the same checksum
+    regardless of ``exported_at``.
+    """
+    body = profile.model_dump(mode="json", exclude_none=True)
+    return {
+        "kind": ENVELOPE_KIND,
+        "schema_version": PROFILE_SCHEMA_VERSION_CURRENT,
+        "hal0_version": __version__,
+        "exported_at": exported_at,
+        "name": name,
+        "checksum": _checksum(body),
+        "profile": body,
+    }
+
+
+# ── import ───────────────────────────────────────────────────────────────────
+
+
+class ProfileEnvelope(BaseModel):
+    """Parsed ``.hal0profile.json`` wire shape. ``extra="ignore"`` keeps a newer
+    producer's extra envelope keys from breaking import; the inner ProfileConfig
+    still forbids unknown fields."""
+
+    model_config = {"extra": "ignore"}
+
+    kind: str
+    schema_version: int = PROFILE_SCHEMA_VERSION_CURRENT
+    hal0_version: str = ""
+    exported_at: str = ""
+    name: str = ""
+    checksum: str = ""
+    profile: ProfileConfig
+
+
+def parse_envelope(data: Any) -> ProfileEnvelope:
+    """Validate the wire shape. Raises BadRequest on a non-envelope/invalid input."""
+    if not isinstance(data, dict) or data.get("kind") != ENVELOPE_KIND:
+        raise BadRequest(
+            "not a hal0.profile envelope",
+            code="profiles.bad_envelope",
+            details={"kind": (data.get("kind") if isinstance(data, dict) else None)},
+        )
+    try:
+        return ProfileEnvelope.model_validate(data)
+    except Exception as exc:
+        raise BadRequest(
+            f"invalid profile envelope: {exc}",
+            code="profiles.bad_envelope",
+            details={"reason": str(exc)},
+        ) from exc
+
+
+def verify_checksum(envelope: dict[str, Any]) -> bool:
+    """True when the envelope's checksum matches its profile body."""
+    body = envelope.get("profile")
+    if not isinstance(body, dict):
+        return False
+    return envelope.get("checksum") == _checksum(body)
+
+
+def import_profile(
+    data: Any,
+    name: str,
+    catalog: Any,
+    *,
+    profile_path: Path | None = None,
+) -> Any:
+    """Validate the envelope and create the profile under ``name``.
+
+    ``catalog`` is a ProfileCatalog (duck-typed: needs ``create(name, ProfileConfig)``).
+    Raises BadRequest for a bad/too-new envelope; the catalog raises Conflict
+    (``profiles.exists``) on a duplicate name. Returns the created ResolvedProfile.
+    """
+    env = parse_envelope(data)
+    if env.schema_version > PROFILE_SCHEMA_VERSION_CURRENT:
+        raise BadRequest(
+            f"profile schema v{env.schema_version} is newer than supported "
+            f"v{PROFILE_SCHEMA_VERSION_CURRENT}",
+            code="profiles.envelope_too_new",
+            details={"got": env.schema_version, "supported": PROFILE_SCHEMA_VERSION_CURRENT},
+        )
+    # (forward-compat seam: older schema_version would migrate here; only v1 exists.)
+    return catalog.create(name, env.profile)

--- a/tests/api/test_profiles_portable_routes.py
+++ b/tests/api/test_profiles_portable_routes.py
@@ -1,0 +1,186 @@
+"""Tests for the portable profile routes — export/import over HTTP.
+
+Mirrors tests/api/test_stacks_routes.py + the profiles CRUD route style:
+fresh TestClient over a tmp_hal0_home-isolated app, asserting status codes
+and error ``code`` fields.
+
+Targeted file run only (full suite hangs):
+    ~/dev/hal0/.venv/bin/python -m pytest tests/api/test_profiles_portable_routes.py -q
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.config.schema import SEED_PROFILES
+
+
+@pytest.fixture
+def app(tmp_hal0_home: str) -> FastAPI:
+    """Fresh app; tmp_hal0_home means no profiles.toml → seeds returned."""
+    return create_app()
+
+
+@pytest.fixture
+def client(app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        yield c
+
+
+def _seed_name() -> str:
+    return next(iter(SEED_PROFILES))
+
+
+def _create_custom(client: TestClient, name: str = "my-custom") -> None:
+    r = client.post(
+        "/api/profiles",
+        json={
+            "name": name,
+            "image": "ghcr.io/x/y:z",
+            "flags": "-fa on",
+            "mtp": True,
+            "device_class": "gpu",
+            "backend": "rocm",
+            "intent": "My workload",
+            "quant": "Q5_K_M",
+        },
+    )
+    assert r.status_code == 201
+
+
+# ── POST /api/profiles/{name}/export ────────────────────────────────────────
+
+
+class TestExportRoute:
+    def test_export_seed_profile_200_valid_envelope(self, client: TestClient) -> None:
+        name = _seed_name()
+        r = client.post(f"/api/profiles/{name}/export")
+        assert r.status_code == 200
+        env = r.json()
+        assert env["kind"] == "hal0.profile"
+        assert env["name"] == name
+        assert env["checksum"].startswith("sha256:")
+        assert env["profile"]["image"]
+
+    def test_export_custom_profile_200_valid_envelope(self, client: TestClient) -> None:
+        _create_custom(client)
+        r = client.post("/api/profiles/my-custom/export")
+        assert r.status_code == 200
+        env = r.json()
+        assert env["kind"] == "hal0.profile"
+        assert env["name"] == "my-custom"
+        assert env["profile"]["flags"] == "-fa on"
+        assert env["profile"]["backend"] == "rocm"
+
+    def test_export_unknown_404(self, client: TestClient) -> None:
+        r = client.post("/api/profiles/does-not-exist/export")
+        assert r.status_code == 404
+        assert r.json()["error"]["code"] == "profiles.not_found"
+
+
+# ── POST /api/profiles/import (dry_run) ─────────────────────────────────────
+
+
+class TestImportDryRun:
+    def test_dry_run_shape_and_checksum_ok(self, client: TestClient) -> None:
+        env = client.post(f"/api/profiles/{_seed_name()}/export").json()
+        r = client.post("/api/profiles/import", json={"envelope": env, "dry_run": True})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["dry_run"] is True
+        assert body["valid"] is True
+        assert body["checksum_ok"] is True
+        assert body["name"] == _seed_name()
+        assert body["schema_version"] == env["schema_version"]
+        assert isinstance(body["collides"], bool)
+
+    def test_dry_run_collides_true_for_existing_name(self, client: TestClient) -> None:
+        env = client.post(f"/api/profiles/{_seed_name()}/export").json()
+        # Default target name is the envelope's own (seed) name → collides.
+        r = client.post("/api/profiles/import", json={"envelope": env, "dry_run": True})
+        assert r.json()["collides"] is True
+
+    def test_dry_run_collides_false_for_fresh_name(self, client: TestClient) -> None:
+        env = client.post(f"/api/profiles/{_seed_name()}/export").json()
+        r = client.post(
+            "/api/profiles/import",
+            json={"envelope": env, "name": "brand-new-name", "dry_run": True},
+        )
+        assert r.json()["collides"] is False
+
+    def test_dry_run_checksum_ok_false_when_tampered(self, client: TestClient) -> None:
+        env = client.post(f"/api/profiles/{_seed_name()}/export").json()
+        env["profile"]["flags"] = "-fa off TAMPERED"
+        r = client.post("/api/profiles/import", json={"envelope": env, "dry_run": True})
+        assert r.json()["checksum_ok"] is False
+
+
+# ── POST /api/profiles/import (commit) ──────────────────────────────────────
+
+
+class TestImportCommit:
+    def test_commit_creates_profile(self, client: TestClient) -> None:
+        env = client.post(f"/api/profiles/{_seed_name()}/export").json()
+        r = client.post("/api/profiles/import", json={"envelope": env, "name": "imported-one"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["dry_run"] is False
+        assert body["profile"]["name"] == "imported-one"
+        # Now resolvable via GET /api/profiles/{name}.
+        got = client.get("/api/profiles/imported-one")
+        assert got.status_code == 200
+        assert got.json()["name"] == "imported-one"
+
+    def test_commit_without_name_400(self, client: TestClient) -> None:
+        env = client.post(f"/api/profiles/{_seed_name()}/export").json()
+        r = client.post("/api/profiles/import", json={"envelope": env})
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] == "profiles.import_no_name"
+
+    def test_commit_duplicate_name_409(self, client: TestClient) -> None:
+        env = client.post(f"/api/profiles/{_seed_name()}/export").json()
+        client.post("/api/profiles/import", json={"envelope": env, "name": "dup"})
+        r = client.post("/api/profiles/import", json={"envelope": env, "name": "dup"})
+        assert r.status_code == 409
+        assert r.json()["error"]["code"] == "profiles.exists"
+
+    def test_commit_bad_envelope_400(self, client: TestClient) -> None:
+        r = client.post(
+            "/api/profiles/import",
+            json={"envelope": {"kind": "nope"}, "name": "whatever"},
+        )
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] == "profiles.bad_envelope"
+
+    def test_commit_too_new_schema_400(self, client: TestClient) -> None:
+        env = client.post(f"/api/profiles/{_seed_name()}/export").json()
+        env["schema_version"] = env["schema_version"] + 1
+        r = client.post("/api/profiles/import", json={"envelope": env, "name": "too-new"})
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] == "profiles.envelope_too_new"
+
+
+# ── round-trip over HTTP ────────────────────────────────────────────────────
+
+
+class TestRoundTripHttp:
+    def test_export_then_import_under_new_name_appears_in_list(self, client: TestClient) -> None:
+        _create_custom(client, name="source")
+        env = client.post("/api/profiles/source/export").json()
+
+        r = client.post("/api/profiles/import", json={"envelope": env, "name": "round-tripped"})
+        assert r.status_code == 200
+
+        names = {p["name"] for p in client.get("/api/profiles").json()}
+        assert "round-tripped" in names
+
+        imported = client.get("/api/profiles/round-tripped").json()
+        assert imported["flags"] == "-fa on"
+        assert imported["intent"] == "My workload"
+        assert imported["quant"] == "Q5_K_M"
+        assert imported["backend"] == "rocm"

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -147,7 +147,13 @@ def test_destructive_tools_match_gated_destructive_set() -> None:
     """ADR-0004 §4's "destructive" classification must match the
     destructiveHint annotations exactly. The annotation is the
     client-facing surface; ADR-0004 is the policy. They cannot drift."""
-    destructive_per_adr = {"model_delete", "slot_delete", "memory_delete", "stack_delete"}
+    destructive_per_adr = {
+        "model_delete",
+        "slot_delete",
+        "memory_delete",
+        "stack_delete",
+        "profile_delete",
+    }
     destructive_per_annotation = {
         name for name, ann in admin._ANNOTATIONS.items() if ann.destructiveHint
     }

--- a/tests/profiles/test_portable.py
+++ b/tests/profiles/test_portable.py
@@ -1,0 +1,191 @@
+"""Tests for portable profiles: export envelope + checksum + import.
+
+Mirrors tests/stacks/test_export.py + test_import.py — profiles carry no
+models/slots, so there is no embedding/resolve pass to assert.
+
+Targeted file run only (full suite hangs):
+    ~/dev/hal0/.venv/bin/python -m pytest tests/profiles/test_portable.py -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.config.schema import PROFILE_SCHEMA_VERSION_CURRENT, ProfileConfig
+from hal0.errors import BadRequest, Conflict
+from hal0.profiles import ProfileCatalog
+from hal0.profiles.portable import (
+    ENVELOPE_KIND,
+    export_envelope,
+    import_profile,
+    parse_envelope,
+    verify_checksum,
+)
+
+
+def _profile() -> ProfileConfig:
+    """A custom (non-seed) profile with a representative mix of fields."""
+    return ProfileConfig(
+        image="ghcr.io/hal0ai/test:custom",
+        flags="-fa on -ngl 99",
+        mtp=True,
+        device_class="gpu",
+        backend="rocm",
+        cloned_from="vulkan",
+        intent="My workload",
+        quant="Q5_K_M",
+    )
+
+
+def _catalog(home: str, name: str = "profiles.toml") -> ProfileCatalog:
+    """Isolated catalog backed by its own profiles.toml under ``home``."""
+    path = Path(home) / "etc" / "hal0" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return ProfileCatalog(path=path)
+
+
+# ── round-trip ──────────────────────────────────────────────────────────────
+
+
+class TestRoundTrip:
+    def test_export_import_round_trips_fields(self, tmp_hal0_home: str) -> None:
+        src = _catalog(tmp_hal0_home, "src.toml")
+        src.create("orig", _profile())
+
+        env = export_envelope("orig", _profile(), exported_at="t")
+
+        # Fresh, fully isolated catalog → import under a new name.
+        dst = _catalog(tmp_hal0_home, "dst.toml")
+        resolved = import_profile(env, "copied", dst)
+
+        assert resolved.name == "copied"
+        assert any(p.name == "copied" for p in dst.list())
+
+        imported = dst.resolve("copied")
+        original = _profile()
+        assert imported.image == original.image
+        assert imported.flags == original.flags
+        assert imported.mtp == original.mtp
+        assert imported.device_class == original.device_class
+        assert imported.backend == original.backend
+        assert imported.cloned_from == original.cloned_from
+        assert imported.intent == original.intent
+        assert imported.quant == original.quant
+
+
+# ── export envelope shape ────────────────────────────────────────────────────
+
+
+class TestExportEnvelope:
+    def test_envelope_shape(self, tmp_hal0_home: str) -> None:
+        env = export_envelope("orig", _profile(), exported_at="2026-06-20T00:00:00Z")
+        assert env["kind"] == ENVELOPE_KIND
+        assert env["kind"] == "hal0.profile"
+        assert env["schema_version"] == PROFILE_SCHEMA_VERSION_CURRENT
+        assert env["name"] == "orig"
+        assert env["exported_at"] == "2026-06-20T00:00:00Z"
+        assert env["checksum"].startswith("sha256:")
+
+    def test_profile_body_has_expected_fields(self, tmp_hal0_home: str) -> None:
+        env = export_envelope("orig", _profile(), exported_at="t")
+        body = env["profile"]
+        assert body["image"] == "ghcr.io/hal0ai/test:custom"
+        assert body["flags"] == "-fa on -ngl 99"
+        assert body["mtp"] is True
+        assert body["device_class"] == "gpu"
+        assert body["backend"] == "rocm"
+
+    def test_exclude_none_drops_unset_optional_fields(self, tmp_hal0_home: str) -> None:
+        # A bare profile leaves backend/cloned_from None → exclude_none drops them.
+        env = export_envelope("bare", ProfileConfig(image="ghcr.io/x/y:z"), exported_at="t")
+        body = env["profile"]
+        assert None not in body.values()
+        assert "backend" not in body
+        assert "cloned_from" not in body
+
+
+# ── checksum ─────────────────────────────────────────────────────────────────
+
+
+class TestVerifyChecksum:
+    def test_intact_checksum_verifies(self, tmp_hal0_home: str) -> None:
+        env = export_envelope("orig", _profile(), exported_at="t")
+        assert verify_checksum(env) is True
+
+    def test_tampered_body_fails(self, tmp_hal0_home: str) -> None:
+        env = export_envelope("orig", _profile(), exported_at="t")
+        env["profile"]["flags"] = "-fa off TAMPERED"
+        assert verify_checksum(env) is False
+
+    def test_checksum_is_deterministic_and_ignores_exported_at(self, tmp_hal0_home: str) -> None:
+        a = export_envelope("orig", _profile(), exported_at="2026-06-20T00:00:00Z")
+        b = export_envelope("orig", _profile(), exported_at="2099-01-01T00:00:00Z")
+        assert a["checksum"] == b["checksum"], (
+            "checksum must cover the profile body only, not exported_at"
+        )
+
+    def test_checksum_is_field_order_independent(self, tmp_hal0_home: str) -> None:
+        env = export_envelope("orig", _profile(), exported_at="t")
+        # Rebuild the body dict with keys inserted in reverse order.
+        reordered = dict(reversed(list(env["profile"].items())))
+        env_reordered = {**env, "profile": reordered}
+        assert verify_checksum(env_reordered) is True
+
+
+# ── parse_envelope ───────────────────────────────────────────────────────────
+
+
+class TestParseEnvelope:
+    def test_valid_envelope_parses(self, tmp_hal0_home: str) -> None:
+        env = export_envelope("orig", _profile(), exported_at="t")
+        parsed = parse_envelope(env)
+        assert parsed.kind == "hal0.profile"
+        assert parsed.profile.image == "ghcr.io/hal0ai/test:custom"
+
+    def test_non_dict_rejected(self, tmp_hal0_home: str) -> None:
+        with pytest.raises(BadRequest) as exc:
+            parse_envelope("nope")  # type: ignore[arg-type]
+        assert exc.value.code == "profiles.bad_envelope"
+
+    def test_wrong_kind_rejected(self, tmp_hal0_home: str) -> None:
+        with pytest.raises(BadRequest) as exc:
+            parse_envelope({"kind": "not-a-profile", "profile": {"image": "ghcr.io/x/y:z"}})
+        assert exc.value.code == "profiles.bad_envelope"
+
+    def test_missing_profile_rejected(self, tmp_hal0_home: str) -> None:
+        with pytest.raises(BadRequest) as exc:
+            parse_envelope({"kind": ENVELOPE_KIND})
+        assert exc.value.code == "profiles.bad_envelope"
+
+    def test_invalid_profile_rejected(self, tmp_hal0_home: str) -> None:
+        # image is required by ProfileConfig → empty inner profile is invalid.
+        with pytest.raises(BadRequest) as exc:
+            parse_envelope({"kind": ENVELOPE_KIND, "profile": {"image": ""}})
+        assert exc.value.code == "profiles.bad_envelope"
+
+
+# ── import_profile ───────────────────────────────────────────────────────────
+
+
+class TestImportProfile:
+    def test_too_new_schema_rejected(self, tmp_hal0_home: str) -> None:
+        env = export_envelope("orig", _profile(), exported_at="t")
+        env["schema_version"] = PROFILE_SCHEMA_VERSION_CURRENT + 1
+        with pytest.raises(BadRequest) as exc:
+            import_profile(env, "copied", _catalog(tmp_hal0_home))
+        assert exc.value.code == "profiles.envelope_too_new"
+
+    def test_bad_envelope_rejected(self, tmp_hal0_home: str) -> None:
+        with pytest.raises(BadRequest) as exc:
+            import_profile({"kind": "nope"}, "copied", _catalog(tmp_hal0_home))
+        assert exc.value.code == "profiles.bad_envelope"
+
+    def test_duplicate_name_raises_conflict(self, tmp_hal0_home: str) -> None:
+        catalog = _catalog(tmp_hal0_home)
+        catalog.create("taken", ProfileConfig(image="ghcr.io/x/y:z"))
+        env = export_envelope("orig", _profile(), exported_at="t")
+        with pytest.raises(Conflict) as exc:
+            import_profile(env, "taken", catalog)
+        assert exc.value.code == "profiles.exists"

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -293,6 +293,9 @@ export const ENDPOINTS = {
   // ── Profiles (container slot templates) ─────────────────────────
   profiles: '/api/profiles',
   profile: (name: string) => `/api/profiles/${encodeURIComponent(name)}`,
+  // POST export (envelope) | import (collection-level POST: dry-run, then create).
+  profileExport: (name: string) => `/api/profiles/${encodeURIComponent(name)}/export`,
+  profileImport: '/api/profiles/import',
 
   // ── Stacks (named, portable slot+profile+model bundles) ─────────
   // GET list (+ active + drift) | POST create. Per-stack: GET detail | PUT |

--- a/ui/src/api/hooks/useProfiles.ts
+++ b/ui/src/api/hooks/useProfiles.ts
@@ -49,6 +49,27 @@ export interface ProfileBody {
   quant?: string
 }
 
+/** Portable profile bundle (.hal0profile.json), mirrors StackEnvelope. */
+export interface ProfileEnvelope {
+  kind: string
+  schema_version: number
+  hal0_version: string
+  exported_at: string
+  name: string
+  checksum: string
+  profile: ProfileBody
+}
+
+/** Dry-run import result — identity + integrity + collision (no model refs). */
+export interface ProfileImportDryResult {
+  dry_run: true
+  valid: boolean
+  checksum_ok: boolean
+  name: string
+  schema_version: number
+  collides: boolean
+}
+
 export function useProfiles() {
   return useQuery({
     queryKey: ['profiles'],
@@ -81,5 +102,26 @@ export function useProfileDelete() {
     mutationFn: (name: string) =>
       api<void>(ENDPOINTS.profile(name), { method: 'DELETE', raw: true }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['profiles'] }),
+  })
+}
+
+export function useProfileExport() {
+  return useMutation({
+    mutationFn: (name: string) =>
+      api<ProfileEnvelope>(ENDPOINTS.profileExport(name), { method: 'POST', raw: true }),
+  })
+}
+
+export function useProfileImport() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: { envelope: unknown; dry_run?: boolean; name?: string }) =>
+      api<ProfileImportDryResult | { dry_run: false; profile: Profile }>(
+        ENDPOINTS.profileImport,
+        { method: 'POST', body: payload as any, raw: true },
+      ),
+    onSuccess: (_d, vars) => {
+      if (!vars.dry_run) qc.invalidateQueries({ queryKey: ['profiles'] })
+    },
   })
 }

--- a/ui/src/dash/profiles.jsx
+++ b/ui/src/dash/profiles.jsx
@@ -19,6 +19,8 @@ import {
   useProfileCreate,
   useProfileUpdate,
   useProfileDelete,
+  useProfileExport,
+  useProfileImport,
 } from '@/api/hooks/useProfiles'
 import { prettyProfile } from './profile-names'
 
@@ -88,7 +90,7 @@ function PfRow({ label, value, hue }) {
 
 // Profile card — adopts the Stacks library-card shell (.stk-lib-*) so the
 // Profiles and Stacks grids read as one family. Same data + actions as before.
-function ProfileCard({ p, index, onEdit, onClone, onDelete }) {
+function ProfileCard({ p, index, onEdit, onClone, onDelete, onExport }) {
   const meta = bk(backendOf(p));
   const isSeed = !!p.seed;
   const usedBy = p.used_by || [];
@@ -144,6 +146,8 @@ function ProfileCard({ p, index, onEdit, onClone, onDelete }) {
         <button className="stk-icon-btn" style={{ width: 26, height: 26 }} onClick={() => onDelete(p)} disabled={isSeed}
           title={isSeed ? 'Seed profiles cannot be deleted' : inUse ? 'In use — detach slots first' : 'Delete'}
           data-testid={`pf-btn-delete-${p.name}`}>{Icons.trash}</button>
+        <button className="stk-icon-btn" style={{ width: 26, height: 26 }} onClick={() => onExport(p)}
+          title="Export this profile as a .hal0profile.json" data-testid={`pf-btn-export-${p.name}`}>{Icons.download}</button>
       </div>
     </div>
   );
@@ -458,6 +462,106 @@ function DeleteConfirm({ p, onCancel, onConfirmed }) {
   );
 }
 
+// ── Import modal (file → dry-run → commit) ────────────────────────────────────
+// Reuses the Stacks dialog shell (.stk-scrim / .stk-dialog / .stk-dlg-*). A
+// profile references no models, so the preview is just identity + integrity +
+// collision — no model resolve/pull affordance.
+
+function ImportModal({ existing, onClose, onImported }) {
+  const imp = useProfileImport();
+  const [envelope, setEnvelope] = useState(null);
+  const [report, setReport] = useState(null);
+  const [name, setName] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState('');
+
+  async function onFile(file) {
+    setErr('');
+    try {
+      const text = await file.text();
+      const env = JSON.parse(text);
+      setEnvelope(env);
+      const r = await imp.mutateAsync({ envelope: env, dry_run: true });
+      setReport(r);
+      setName(r.name || '');
+    } catch (e) {
+      setErr(e?.message || 'Not a valid .hal0profile.json envelope');
+      setEnvelope(null); setReport(null);
+    }
+  }
+
+  const taken = existing.includes(name);
+  const nameValid = NAME_RE.test(name);
+  const canCommit = !!report && nameValid && !busy;
+
+  async function commit() {
+    if (!report || !name.trim()) return;
+    setBusy(true);
+    try {
+      await imp.mutateAsync({ envelope, name, dry_run: false });
+      toast(`Imported ${name}`, 'ok');
+      onImported();
+    } catch (e) {
+      if (e?.code === 'profiles.exists' || e?.status === 409) {
+        setErr(`“${name}” already exists — pick another name`);
+      } else {
+        toast(e?.message || 'Import failed', 'err');
+      }
+    } finally { setBusy(false); }
+  }
+
+  return (
+    <div className="stk-scrim" onMouseDown={() => { if (!busy) onClose(); }}>
+      <div className="stk-dialog" onMouseDown={e => e.stopPropagation()} role="dialog" aria-label="Import profile" aria-busy={busy}>
+        <div className="stk-dlg-h">
+          <span className="stk-dlg-eye">Import profile</span>
+          <button className="stk-dlg-x" onClick={onClose} aria-label="Close" disabled={busy}>{Icons.close}</button>
+        </div>
+        <div className="stk-dlg-b">
+          {!report ? (
+            <label className="stk-drop">
+              <input type="file" accept=".hal0profile.json,.json,application/json" style={{ display: 'none' }}
+                onChange={e => e.target.files?.[0] && onFile(e.target.files[0])} data-testid="pf-import-file" />
+              <span className="stk-drop-glyph">{Icons.attach}</span>
+              <span className="mono">Choose a .hal0profile.json file</span>
+              {err && <span className="stk-dlg-warn">{Icons.alert}{err}</span>}
+            </label>
+          ) : (
+            <>
+              <div className="stk-dlg-hint">
+                {report.name || 'profile'} · schema v{report.schema_version} · checksum {report.checksum_ok ? '✓ ok' : '✗ mismatch'}
+              </div>
+              {report.collides && (
+                <div className="stk-dlg-warn">{Icons.alert}A profile named “{report.name}” already exists — choose a different name to import.</div>
+              )}
+              <div className="stk-slot-list">
+                <div className="stk-slot-row">
+                  <span className="sname">Save as</span>
+                  <input className={'pf-input mono' + (name && !nameValid ? ' err' : '')} value={name}
+                    onChange={e => { setName(e.target.value); setErr(''); }} maxLength={32} placeholder="my-profile"
+                    style={{ flex: 1, background: 'transparent', border: 'none', color: 'var(--fg)', fontFamily: 'var(--jbm)' }}
+                    data-testid="pf-import-name" />
+                </div>
+              </div>
+              {name && !nameValid && <div className="stk-dlg-warn">{Icons.alert}lowercase · digits · - · _ · ≤32</div>}
+              {taken && nameValid && <div className="stk-dlg-warn">{Icons.alert}“{name}” already exists</div>}
+              {err && <div className="stk-dlg-warn">{Icons.alert}{err}</div>}
+            </>
+          )}
+        </div>
+        <div className="stk-dlg-f">
+          <button className="btn ghost sm" onClick={onClose} disabled={busy}>Cancel</button>
+          {report && (
+            <button className="btn sm" onClick={commit} disabled={!canCommit} data-testid="pf-import-confirm">
+              {busy ? 'Importing…' : 'Import'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ── Summary cell ─────────────────────────────────────────────────────────────────
 
 function Stat({ value, label, accent }) {
@@ -476,7 +580,7 @@ function Stat({ value, label, accent }) {
 // Profiles tab reads as part of the same family instead of the old big-h1 view
 // header. The base .engine-h styling is global (connections.css); .pf-engine-h
 // only de-emphasises the pointer cursor and accent the panel owns.
-function ProfilesHeader({ count, onNew }) {
+function ProfilesHeader({ count, onNew, onImport }) {
   return (
     <div className="engine-h pf-engine-h">
       <span className="engine-glyph">{Icons.slots}</span>
@@ -491,11 +595,18 @@ function ProfilesHeader({ count, onNew }) {
         </span>
       )}
       <span className="grow" />
-      {onNew && (
+      {(onNew || onImport) && (
         <span className="eh-right">
-          <button className="pf-btn primary" onClick={onNew} data-testid="pf-btn-new">
-            {Icons.plus} New profile
-          </button>
+          {onImport && (
+            <button className="pf-btn" onClick={onImport} data-testid="pf-btn-import">
+              {Icons.attach} Import
+            </button>
+          )}
+          {onNew && (
+            <button className="pf-btn primary" onClick={onNew} data-testid="pf-btn-new">
+              {Icons.plus} New profile
+            </button>
+          )}
         </span>
       )}
     </div>
@@ -505,13 +616,29 @@ function ProfilesHeader({ count, onNew }) {
 function ProfilesView() {
   const query = useProfiles();
   const profiles = query.data ?? [];
+  const exportMut = useProfileExport();
 
   const [drawer, setDrawer] = useState(null);   // {mode, source}
   const [confirm, setConfirm] = useState(null);
+  const [importing, setImporting] = useState(false);
 
   const seeds = profiles.filter(p => p.seed);
   const custom = profiles.filter(p => !p.seed);
   const inUseCount = profiles.filter(p => (p.used_by || []).length).length;
+
+  async function onExport(p) {
+    const name = p.name;
+    try {
+      const env = await exportMut.mutateAsync(name);
+      const blob = new Blob([JSON.stringify(env, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url; a.download = `${name}.hal0profile.json`;
+      document.body.appendChild(a); a.click(); a.remove();
+      URL.revokeObjectURL(url);
+      toast(`Exported ${name}`, 'ok');
+    } catch (err) { toast(err?.message || 'Export failed', 'err'); }
+  }
 
   if (query.isLoading) {
     return (
@@ -536,7 +663,7 @@ function ProfilesView() {
   return (
     <div className="view">
       <div className="pf-engine">
-        <ProfilesHeader count={profiles.length} onNew={() => setDrawer({ mode: 'create' })} />
+        <ProfilesHeader count={profiles.length} onNew={() => setDrawer({ mode: 'create' })} onImport={() => setImporting(true)} />
         <div className="pf-summary">
           <Stat value={profiles.length} label="profiles" />
           <span className="pf-stat-div" />
@@ -562,7 +689,8 @@ function ProfilesView() {
               <ProfileCard key={p.name} p={p} index={i}
                 onEdit={pp => setDrawer({ mode: 'edit', source: pp })}
                 onClone={pp => setDrawer({ mode: 'clone', source: pp })}
-                onDelete={pp => setConfirm(pp)} />
+                onDelete={pp => setConfirm(pp)}
+                onExport={onExport} />
             ))}
           </Section>
 
@@ -571,7 +699,8 @@ function ProfilesView() {
               <ProfileCard key={p.name} p={p} index={i}
                 onEdit={pp => setDrawer({ mode: 'edit', source: pp })}
                 onClone={pp => setDrawer({ mode: 'clone', source: pp })}
-                onDelete={pp => setConfirm(pp)} />
+                onDelete={pp => setConfirm(pp)}
+                onExport={onExport} />
             ))}
           </Section>
         </>
@@ -588,6 +717,13 @@ function ProfilesView() {
       )}
       {confirm && (
         <DeleteConfirm p={confirm} onCancel={() => setConfirm(null)} onConfirmed={() => setConfirm(null)} />
+      )}
+      {importing && (
+        <ImportModal
+          existing={profiles.map(p => p.name)}
+          onClose={() => setImporting(false)}
+          onImported={() => setImporting(false)}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Profiles can now be **exported to a self-contained, checksummed `.hal0profile.json` envelope and imported on another host** — the same file-based sharing model stacks already use. This is a deliberate, leaner subset of `stacks/portable.py`: a profile references no models or slots, so there's no reference embedding and no model resolution.

No secrets or host paths are serialized; the envelope carries the profile template + a sha256 content checksum + an independent `schema_version`.

## Backend

- **`profiles/portable.py`** (new) — pure `export_envelope` / `parse_envelope` / `verify_checksum` / `import_profile` (caller stamps `exported_at`; no clock/global).
- **`api/routes/profiles.py`** — `GET /api/profiles/{name}`, `POST /api/profiles/{name}/export`, `POST /api/profiles/import`. `/import` is declared before `/{name}` to avoid path-param shadowing. Dry-run reports `checksum_ok` + name `collides`; commit creates under a chosen name.
- **`config/schema.py`** — `PROFILE_SCHEMA_VERSION_CURRENT = 1`.
- **`mcp/admin.py`** — five tools mirroring `stack_*`: `profile_list` / `profile_status` / `profile_export` (autonomous read) and `profile_import` / `profile_delete` (gated), wired through all six registries (read/gated sets, REST map, path args, annotations, registration).

## Frontend (`ui/`)

- `useProfileExport` / `useProfileImport` hooks + endpoints + types.
- **Export** button on every profile card (seeds included); **Import** button + dialog (file → dry-run preview → commit) reusing the stacks dialog shell (`.stk-*`, already globally imported via `main.tsx`).

## Collision behavior

Conflict + rename: import never overwrites. A duplicate name returns `409 profiles.exists`; the import dialog surfaces the collision and prompts for a new name before commit.

## Tests

- `tests/profiles/test_portable.py` — round-trip, envelope shape, `exclude_none`, checksum determinism + tamper detection, `bad_envelope` / `envelope_too_new` guards, `profiles.exists` propagation.
- `tests/api/test_profiles_portable_routes.py` — export 200 (seed + custom) / 404, import dry-run shape + `collides` + `checksum_ok`, commit + `import_no_name` + `exists` + `bad_envelope`, full HTTP round-trip.
- `tests/mcp/test_admin.py` — destructive-set invariant updated for `profile_delete`.

**Verification:** 276 passed across profiles + stacks + mcp + profile-route suites; `ruff check` clean; `tsc --noEmit` clean; `vite build` succeeds.

## Notes

- This is the file-based portable model — hal0 has no per-user ownership/visibility for stacks either. A central profile directory/registry remains a separate future effort.
- `uv.lock` intentionally untouched (its only local diff was a stale version-string resync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)