### PR TITLE
fix(profiles): explicit profile spec flags win over the MTP bundle

### DIFF
--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1231,7 +1231,20 @@ def resolve_profile_flags(profile: ProfileConfig, mtp_override: bool | None = No
     base = profile.flags.strip()
     effective_mtp = mtp_override if mtp_override is not None else profile.mtp
     if effective_mtp:
-        return f"{base} {MTP_FLAG_BUNDLE}".strip()
+        # MTP_FLAG_BUNDLE is a set of DEFAULTS. A profile may pin its own
+        # ``--spec-draft-*`` values (a hand-tuned draft KV type, p-min, …); those
+        # must WIN, with the bundle only supplying the flags the profile left
+        # unset. ``merge_flags(defaults, override)`` gives exactly that
+        # precedence — the override (here ``base``) strips any matching flag from
+        # the defaults. Appending the bundle verbatim (the old behaviour) let it
+        # silently clobber a profile's explicit spec flags, e.g. a profile
+        # asking for ``--spec-draft-type-k f16`` still launched with q8_0.
+        #
+        # Local import: ``hal0.config`` is imported before ``hal0.slots``, so a
+        # module-level import would create a cycle.
+        from hal0.slots.flag_merge import merge_flags
+
+        return merge_flags(MTP_FLAG_BUNDLE, base)
     return base
 
 

--- a/tests/api/test_profiles_crud.py
+++ b/tests/api/test_profiles_crud.py
@@ -145,7 +145,9 @@ def test_create_mtp_true_resolved_flags_contains_bundle(client: TestClient) -> N
     assert r.status_code == 201
     body = r.json()
     assert MTP_FLAG_BUNDLE in body["resolved_flags"]
-    assert body["resolved_flags"].startswith("-fa on")
+    # base flags are preserved (the bundle leads as defaults; the profile's own
+    # flags follow and win on any conflict).
+    assert "-fa on" in body["resolved_flags"]
 
 
 def test_create_invalid_empty_image_422(client: TestClient) -> None:

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -111,8 +111,32 @@ class TestResolveProfileFlags:
     def test_mtp_true_appends_bundle(self) -> None:
         p = ProfileConfig(image="ghcr.io/hal0ai/foo:bar", flags="-fa on -b 512", mtp=True)
         result = resolve_profile_flags(p)
-        assert result.startswith("-fa on -b 512 ")
+        # base flags are preserved verbatim and the MTP bundle is present. The
+        # bundle now leads (it supplies defaults the profile's explicit flags
+        # override); a profile with no --spec flags keeps the bundle intact.
+        assert "-fa on -b 512" in result
         assert "--spec-type draft-mtp" in result
+
+    def test_explicit_profile_spec_flags_win_over_bundle(self) -> None:
+        """A profile that pins its own --spec-draft-* values keeps them; the MTP
+        bundle only fills the gaps. Regression: the bundle used to be appended
+        verbatim and silently clobbered explicit profile spec flags."""
+        p = ProfileConfig(
+            image="ghcr.io/hal0ai/foo:bar",
+            flags="-fa on --spec-draft-type-k f16 --spec-draft-type-v f16 --spec-draft-p-min 0.25",
+            mtp=True,
+        )
+        result = resolve_profile_flags(p)
+        # explicit values survive, exactly once, with no clobber/duplication
+        assert "--spec-draft-type-k f16" in result
+        assert "--spec-draft-p-min 0.25" in result
+        assert "--spec-draft-type-k q8_0" not in result
+        assert "--spec-draft-p-min 0.0" not in result
+        assert result.split().count("--spec-draft-type-k") == 1
+        assert result.split().count("--spec-draft-p-min") == 1
+        # gap-filling: bundle flags the profile did not set are still supplied
+        assert "--spec-type draft-mtp" in result
+        assert "--spec-draft-n-max 4" in result
 
     def test_mtp_true_contains_all_key_flags(self) -> None:
         p = ProfileConfig(image="ghcr.io/hal0ai/foo:bar", flags="-fa on", mtp=True)


### PR DESCRIPTION
## Problem

`resolve_profile_flags` appended `MTP_FLAG_BUNDLE` **verbatim after** a profile's own flags:

```python
return f"{base} {MTP_FLAG_BUNDLE}".strip()
```

Because the launch argv does last-wins dedup, the bundle's spec-draft **defaults silently clobbered** any `--spec-draft-*` a profile pinned. A profile asking for `--spec-draft-type-k f16` or `--spec-draft-p-min 0.25` still launched with the bundle's `q8_0` / `0.0`. There was effectively **no way to tune the MTP draft through a profile** — confirmed in practice while benchmarking the agent slot (the slot kept launching q8_0 / p-min 0.0 no matter what the profile said).

## Fix

Treat `MTP_FLAG_BUNDLE` as **defaults** and merge with `merge_flags(MTP_FLAG_BUNDLE, base)` (the same precedence helper used for `model.defaults` vs `[server].extra_args`): the profile's explicit flags strip the matching bundle entries and win, while the bundle only supplies the flags the profile left unset.

- Profile with **no** `--spec` flags + `mtp=true` → full bundle, unchanged.
- Profile pinning e.g. `--spec-draft-type-k f16 --spec-draft-p-min 0.25` + `mtp=true` → keeps f16 / 0.25, bundle fills the rest, no duplicates.
- This also fixes the `resolved_flags` shown in `GET /api/profiles` (previously showed the clobbering/duplication).

The only behavioural change for existing profiles is cosmetic: the bundle now **leads** the resolved string (it's the defaults) and the profile's flags follow. Effective launch flags are identical for any profile that didn't pin spec flags.

## Tests

- New regression test `test_explicit_profile_spec_flags_win_over_bundle`: explicit `--spec-draft-*` survive exactly once, bundle gap-fills, no clobber/dup.
- Updated two order-dependent assertions that hard-coded base-then-bundle ordering (now presence checks).
- Full sweep: **945 passed, 4 skipped** across `tests/config`, `tests/providers`, `tests/slots`, `tests/profiles`, and the profile/slot API routes. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)