### PR TITLE
feat(dash): topbar Kanban/Agent-Chat launchers, global agent chat, Archived lane

### DIFF
--- a/ui/src/dash/board/board-view.jsx
+++ b/ui/src/dash/board/board-view.jsx
@@ -94,6 +94,10 @@ const BOARD_LANES = [
   { id: "blocked",   name: "Blocked",   desc: "Waiting for resource or input" },
   { id: "review",    name: "Review",    desc: "Needs operator sign-off" },
   { id: "done",      name: "Done",      desc: "Completed" },
+  // Hidden by default — revealed only when the "Show archived" filter is on
+  // (see the BOARD_LANES.filter on showArchived below). Tasks reach this lane
+  // via the bulk "archive" action and the task-drawer archive button.
+  { id: "archived",  name: "Archived",  desc: "Archived tasks" },
 ];
 
 // ─── Lightweight dropdown (filter selects) ────────────────────────────────────
@@ -164,7 +168,6 @@ function BoardView() {
   const useSwitchBoard      = window.__hal0UseSwitchBoard;
   const useCreateBoard      = window.__hal0UseCreateBoard;
   const useCreateTask       = window.__hal0UseCreateTask;
-  const useBoardChat        = window.__hal0UseBoardChat;
   const useBoardEventsStream = window.__hal0UseBoardEventsStream;
 
   // ── keep WS stream alive ──
@@ -186,9 +189,11 @@ function BoardView() {
   const switchBoard = useSwitchBoard ? useSwitchBoard()  : null;
   const createBoard = useCreateBoard ? useCreateBoard()  : null;
   const createTask  = useCreateTask  ? useCreateTask()   : null;
-  // Chat state lives HERE (BoardView stays mounted) rather than inside
-  // AgentChat, so the conversation survives closing/reopening the drawer.
-  const chat        = useBoardChat   ? useBoardChat()    : null;
+  // The agent-chat slide-out (and its persistent conversation hook) now lives
+  // in App (main.jsx) so it can be triggered from anywhere in the dash, not
+  // just this page. The board's chat button toggles that global slide-out via
+  // a window event; `chatOpen` here is only a mirror for the button's lit
+  // state. byId is published below so the global chat can resolve task refs.
 
   // ── local state ──
   const [board, setBoard]           = useState("default");
@@ -229,7 +234,6 @@ function BoardView() {
     const onKey = (e) => {
       if (e.key === "Escape") {
         setOpenTask(null);
-        setChatOpen(false);
         setOrchOpen(false);
         setBoardMenu(false);
         setNewTaskLane(null);
@@ -363,7 +367,6 @@ function BoardView() {
 
   // ── window component lookups ──
   const TaskDrawer     = window.TaskDrawer;
-  const AgentChat      = window.AgentChat;
   const NewBoardModal  = window.NewBoardModal;
   const NewTaskModal   = window.NewTaskModal;
   const OrchPopover    = window.OrchPopover;
@@ -371,6 +374,25 @@ function BoardView() {
 
   const opened = openTask ? tasks.find(t => t.id === openTask) : null;
   const byId   = useMemo(() => Object.fromEntries(tasks.map(t => [t.id, t])), [tasks]);
+
+  // Publish the task map so the global agent chat (App-owned) can resolve
+  // task-ref chips, and accept an "open this task" request from it.
+  useEffect(() => {
+    window.__hal0BoardById = byId;
+    return () => { if (window.__hal0BoardById === byId) delete window.__hal0BoardById; };
+  }, [byId]);
+  useEffect(() => {
+    const onOpen = (e) => { if (e.detail) setOpenTask(e.detail); };
+    window.addEventListener("hal0:open-board-task", onOpen);
+    return () => window.removeEventListener("hal0:open-board-task", onOpen);
+  }, []);
+  // Mirror the global agent-chat open state so the toolbar button lights up.
+  useEffect(() => {
+    setChatOpen(!!window.__hal0AgentChatOpen);
+    const onChg = (e) => setChatOpen(!!e.detail);
+    window.addEventListener("hal0:agent-chat-changed", onChg);
+    return () => window.removeEventListener("hal0:agent-chat-changed", onChg);
+  }, []);
 
   return (
     <React.Fragment>
@@ -501,11 +523,12 @@ function BoardView() {
               </BoardCheckFlt>
               <span className="flt-spacer" />
               <div className="flt-actions">
-                {/* agent chat toggle — FIRST in flt-actions */}
+                {/* agent chat toggle — FIRST in flt-actions. Drives the global
+                    App-owned slide-out (also reachable from the topbar). */}
                 <button
                   className={"tb-chat" + (chatOpen ? " on" : "")}
                   data-testid="board-action-chat"
-                  onClick={() => setChatOpen(o => !o)}
+                  onClick={() => window.dispatchEvent(new CustomEvent("hal0:toggle-agent-chat"))}
                 >
                   <BoardIcon name="chat" size={14} />
                   <span>agent</span>
@@ -642,15 +665,8 @@ function BoardView() {
         />
       )}
 
-      {/* agent chat */}
-      {chatOpen && AgentChat && (
-        <AgentChat
-          chat={chat}
-          byId={byId}
-          onClose={() => setChatOpen(false)}
-          onOpenTask={(id) => { setChatOpen(false); setOpenTask(id); }}
-        />
-      )}
+      {/* agent chat is mounted globally by App (main.jsx) so it can be opened
+          from anywhere in the dash; the board's chat button toggles it. */}
 
       {/* new task modal — explicit creation; nothing is POSTed until submit.
           Wrapped in `.board` so the `.board .modal-*` scoped styles apply

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -136,7 +136,17 @@ const Icons = {
 };
 
 // ─── TopBar ───
-function TopBar({ route, onCmdK, onMenu, menuOpen = false }) {
+function TopBar({ route, onCmdK, onBoard, onAgentChat, onMenu, menuOpen = false }) {
+  // Mirror the global agent-chat open state so the Agent Chat launcher lights
+  // up while the slide-out is open (App broadcasts hal0:agent-chat-changed).
+  const [chatOn, setChatOn] = useStateC(
+    typeof window !== "undefined" ? !!window.__hal0AgentChatOpen : false,
+  );
+  useEffectC(() => {
+    const onChg = (e) => setChatOn(!!e.detail);
+    window.addEventListener("hal0:agent-chat-changed", onChg);
+    return () => window.removeEventListener("hal0:agent-chat-changed", onChg);
+  }, []);
   // Brand-bar version badge — live from /api/updates/state (hal0.current,
   // sourced from hal0.__version__) so it never goes stale; the static fallback
   // keeps it correct before the first response lands.
@@ -168,12 +178,29 @@ function TopBar({ route, onCmdK, onMenu, menuOpen = false }) {
         </div>
       )}
       <div className="tb-spacer" />
-      {/* Operator Board launcher moved to the sidebar Services section (Kanban).
-          The ⌘B shortcut (main.jsx) still jumps to #board. */}
-      <button className="tb-cmdk" onClick={onCmdK}>
-        {Icons.zap}<span>Quick actions</span>
-        <kbd>⌘K</kbd>
-      </button>
+      {/* Primary launchers — Kanban board + the agent-chat slide-out. These
+          replace the old "Quick actions" button (the ⌘K command palette is
+          still reachable via the shortcut). White icons by default, glowing
+          amber on hover/active. */}
+      <div className="tb-launch">
+        <button
+          className={"tb-launch-btn" + (route === "board" ? " on" : "")}
+          data-testid="tb-launch-board"
+          onClick={onBoard}
+          title="Open the Kanban board (⌘B)"
+        >
+          {Icons.board}<span>Kanban</span>
+        </button>
+        <button
+          className={"tb-launch-btn" + (chatOn ? " on" : "")}
+          data-testid="tb-launch-chat"
+          onClick={onAgentChat}
+          title="Open the agent chat"
+          aria-pressed={chatOn}
+        >
+          {Icons.agent}<span>Agent Chat</span>
+        </button>
+      </div>
       {/* Mobile-only nav launcher (hidden ≤720px sidebar is gone) → opens NavDrawer. */}
       <button
         className="tb-menu"
@@ -306,10 +333,11 @@ function NavList({ route, param, onGo, testPrefix }) {
 
 // ─── ServiceLinks (sidebar bottom) ───
 // A separate launch zone, pinned to the sidebar bottom below the spacer, away
-// from the app/config nav above. Holds the three sibling-service shortcuts:
-//   - Kanban    → the internal Operator Board (#board) — same target as ⌘B.
+// from the app/config nav above. Holds the external sibling-service shortcuts:
 //   - OpenWebUI → external chat UI, link host-derived by GET /api/config/urls.
 //   - Hermes    → external Hermes dashboard, likewise host-derived.
+// (The Kanban shortcut moved to the topbar launcher; the Operator Board is
+// also in the main nav and on ⌘B.)
 // The external links come from `useConfigUrls`, whose backend resolves the
 // hostname from the *request* (loopback, LAN IP, mDNS, or proxy domain) — so
 // they resolve correctly on every install, not just this dev box. Each is gated
@@ -325,14 +353,6 @@ function ServiceLinks({ onGo, onLaunch, testPrefix }) {
     <div className="sb-services">
       <div className="sb-section">Services</div>
       <div className="sb-svc-list">
-        <div
-          className="sb-row sb-svc"
-          data-testid={testPrefix + "kanban"}
-          onClick={() => { onGo("board"); onLaunch && onLaunch(); }}
-        >
-          {Icons.board}
-          <span className="lbl">Kanban</span>
-        </div>
         {owui && (
           <a
             className="sb-row sb-svc"

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -136,6 +136,16 @@ function App() {
   const [footerOpen, setFooterOpen] = useStateA(false);
   const [paletteOpen, setPaletteOpen] = useStateA(false);
   const [navOpen, setNavOpen] = useStateA(false);
+  const [chatOpen, setChatOpen] = useStateA(false);
+
+  // Agent-chat slide-out (the orchestrator) is hoisted to App so it can be
+  // opened from anywhere in the dash — the topbar Agent Chat button and the
+  // board toolbar both toggle it via the `hal0:toggle-agent-chat` event. The
+  // conversation hook lives here (App stays mounted) so the thread survives
+  // closing/reopening the slide-out. The board-hook bridge loads before
+  // main.jsx (see main.tsx), so this window ref is set on first render.
+  const useBoardChatHook = (typeof window !== "undefined" && window.__hal0UseBoardChat) || null;
+  const agentChat = useBoardChatHook ? useBoardChatHook() : undefined;
 
   // 0.4 gate: the Agent route is reduced to the Memory tab, so it only
   // renders when the memory subsystem is live (HAL0_MEMORY_ENABLED, surfaced
@@ -190,7 +200,7 @@ function App() {
   useEffectA(() => {
     // global keyboard shortcuts
     const onKey = (e) => {
-      if (e.key === "Escape") { setBellOpen(false); setNavOpen(false); return; }
+      if (e.key === "Escape") { setBellOpen(false); setNavOpen(false); setChatOpen(false); return; }
       const tgt = e.target;
       const typing = tgt && (tgt.tagName === "INPUT" || tgt.tagName === "TEXTAREA" || tgt.isContentEditable);
       if (typing) return;
@@ -219,6 +229,22 @@ function App() {
     const onApprovals = () => setBellOpen(true);
     window.addEventListener("hal0:open-approvals", onApprovals);
     return () => window.removeEventListener("hal0:open-approvals", onApprovals);
+  }, []);
+
+  // Agent-chat: broadcast open state (so triggers everywhere can light up) and
+  // expose a global toggle driven by the `hal0:toggle-agent-chat` event.
+  useEffectA(() => {
+    window.__hal0AgentChatOpen = chatOpen;
+    window.dispatchEvent(new CustomEvent("hal0:agent-chat-changed", { detail: chatOpen }));
+  }, [chatOpen]);
+  useEffectA(() => {
+    const onToggle = () => setChatOpen(o => !o);
+    window.__hal0ToggleAgentChat = () => setChatOpen(o => !o);
+    window.addEventListener("hal0:toggle-agent-chat", onToggle);
+    return () => {
+      window.removeEventListener("hal0:toggle-agent-chat", onToggle);
+      delete window.__hal0ToggleAgentChat;
+    };
   }, []);
 
   // Close the mobile nav drawer on any route change (deep links, command
@@ -293,6 +319,8 @@ function App() {
         <TopBar
           route={route}
           onCmdK={() => setPaletteOpen(true)}
+          onBoard={() => go("board")}
+          onAgentChat={() => setChatOpen(o => !o)}
           onMenu={() => setNavOpen(true)}
           menuOpen={navOpen}
         />
@@ -348,6 +376,23 @@ function App() {
 
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
       <SlotActionBridge />
+
+      {/* Agent-chat slide-out — global, triggered from the topbar or the board.
+          Renders only when open; the conversation hook lives in App so the
+          thread persists across open/close. byId comes from the board (when
+          mounted) so task-ref chips resolve; a ref click jumps to the board. */}
+      {chatOpen && typeof AgentChat === "function" && (
+        <AgentChat
+          chat={agentChat}
+          byId={(typeof window !== "undefined" && window.__hal0BoardById) || {}}
+          onClose={() => setChatOpen(false)}
+          onOpenTask={(id) => {
+            setChatOpen(false);
+            window.location.hash = "#board";
+            window.dispatchEvent(new CustomEvent("hal0:open-board-task", { detail: id }));
+          }}
+        />
+      )}
 
       {toast && (
         <div className={"hal0-toast " + (toast.kind || "info")} role="status" aria-live="polite">

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -263,6 +263,50 @@ a { color: inherit; text-decoration: none; }
   color: var(--fg-3);
 }
 
+/* Topbar primary launchers — Kanban + Agent Chat. Replaces the old
+   "Quick actions" button. Icons read white at rest with a soft cast shadow,
+   then glow amber (the accent) on hover / when their surface is active. */
+.tb-launch {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.tb-launch-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 11px;
+  border: 1px solid var(--line);
+  border-radius: var(--rad);
+  font-family: var(--jbm);
+  font-size: 11px;
+  color: var(--fg-2);
+  background: var(--bg-2);
+  cursor: pointer;
+  transition: color .16s ease, border-color .16s ease, background .16s ease, box-shadow .16s ease;
+}
+.tb-launch-btn svg {
+  color: #fff;                                       /* white at rest */
+  filter: drop-shadow(0 1px 1.5px rgba(0, 0, 0, 0.55)); /* shadow */
+  transition: color .16s ease, filter .16s ease;
+}
+.tb-launch-btn:hover {
+  color: var(--fg);
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+}
+.tb-launch-btn:hover svg,
+.tb-launch-btn.on svg {
+  color: var(--accent);                              /* yellow/amber */
+  filter: drop-shadow(0 0 5px var(--accent)) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5)); /* glow */
+}
+.tb-launch-btn.on {
+  color: var(--accent);
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 0 14px -4px var(--accent);
+}
+
 /* wordmark — inline SVG renders at currentColor */
 .wm svg { display: block; }
 .wm .zero { fill: var(--accent); }
@@ -1936,6 +1980,7 @@ select.npu-sel {
   .view-banners { padding: 14px 16px 0; }
   .tb-brand { width: auto; }
   .tb-cmdk { display: none; }   /* command palette folded into the nav drawer on mobile */
+  .tb-launch { display: none; } /* Kanban + Agent Chat launchers: use the nav drawer on mobile */
   .topbar .tb-menu { display: flex; }
   .tb-eyebrow { display: none; }
   .tiers { grid-template-columns: 1fr; }

--- a/ui/tests/e2e/specs/board-filters-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-filters-v3.spec.ts
@@ -71,8 +71,10 @@ test.describe('BoardView — filters', () => {
   })
 
   test('show-archived toggle toggles on/off (affects visibleIds for select-all)', async ({ page }) => {
-    // BOARD_LANES in board-view.jsx has no archived entry — toggle affects
-    // visibleIds (select-all count) and triggers include_archived=true refetch.
+    // The toggle reveals the archived lane (BOARD_LANES includes it, filtered
+    // out by default), widens visibleIds (select-all count), and triggers an
+    // include_archived=true refetch. (Lane visibility is asserted in
+    // board-render-v3; here we just check the on/off state.)
     await gotoBoardAndWait(page)
     const toggleLabel = page.locator('[data-testid="board-toggle-archived"]')
     await expect(toggleLabel).toBeVisible()

--- a/ui/tests/e2e/specs/board-render-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-render-v3.spec.ts
@@ -57,8 +57,9 @@ test.describe('BoardView — render', () => {
   test('entry via ⌘K palette → Operator Board', async ({ page }) => {
     await page.goto('/')
     await expect(page.locator('.topbar')).toBeVisible({ timeout: FIVE_S })
-    // Click the command palette button in topbar
-    await page.locator('.tb-cmdk').click()
+    // The topbar "Quick actions" button was replaced by the Kanban + Agent Chat
+    // launchers; the command palette is now reached via the ⌘K shortcut.
+    await page.keyboard.press('Control+k')
     const palette = page.locator('.cp-shell')
     await expect(palette).toBeVisible({ timeout: FIVE_S })
     // Type to find board
@@ -75,10 +76,10 @@ test.describe('BoardView — render', () => {
     await expect(page.locator('[data-testid="board-view"]')).toBeVisible({ timeout: FIVE_S })
   })
 
-  test('entry via sidebar Services Kanban link', async ({ page }) => {
+  test('entry via topbar Kanban launcher', async ({ page }) => {
     await page.goto('/')
     await page.waitForLoadState('domcontentloaded')
-    await page.locator('[data-testid="svc-kanban"]').click()
+    await page.locator('[data-testid="tb-launch-board"]').click()
     await expect(page.locator('[data-testid="board-view"]')).toBeVisible({ timeout: FIVE_S })
   })
 
@@ -158,21 +159,25 @@ test.describe('BoardView — render', () => {
 
   // ── Show-archived toggle ──────────────────────────────────────────────
 
-  test('show-archived toggle is visible and clickable', async ({ page }) => {
-    // The BOARD_LANES in board-view.jsx has 8 lanes; no archived lane is added
-    // by the local toggle — it affects visibleIds (select-all includes archived)
-    // and triggers a refetch with include_archived=true via the hook.
+  test('show-archived toggle reveals the Archived lane', async ({ page }) => {
+    // BOARD_LANES includes an `archived` lane that is filtered out by default
+    // and revealed when "Show archived" is on (it also widens visibleIds for
+    // select-all + triggers an include_archived=true refetch via the hook).
     await gotoBoardAndWait(page)
     const toggleLabel = page.locator('[data-testid="board-toggle-archived"]')
     await expect(toggleLabel).toBeVisible()
-    // Toggle on
+    // Hidden by default.
+    const archivedLane = page.locator('[data-testid="board-lane-archived"]')
+    await expect(archivedLane).toHaveCount(0)
+    // Toggle on → the check lights up and the Archived lane appears.
     await toggleLabel.click()
-    // The check element gets the "on" class when active
     const check = toggleLabel.locator('..').locator('.kcheck').first()
     await expect(check).toHaveClass(/on/, { timeout: FIVE_S })
-    // Toggle off again
+    await expect(archivedLane).toBeVisible({ timeout: FIVE_S })
+    // Toggle off again → lane hidden.
     await toggleLabel.click()
     await expect(check).not.toHaveClass(/on/)
+    await expect(archivedLane).toHaveCount(0)
   })
 
   // ── By-profile toggle ─────────────────────────────────────────────────

--- a/ui/tests/e2e/specs/dashboard-v3.spec.ts
+++ b/ui/tests/e2e/specs/dashboard-v3.spec.ts
@@ -28,11 +28,15 @@ test.describe('Dashboard v3 (/)', () => {
     await expect(page.locator('.sb-row.active .lbl')).toHaveText('Overview')
   })
 
-  test('topbar exposes brand + quick actions without stale host/bell chrome', async ({ page }) => {
+  test('topbar exposes brand + Kanban/Agent Chat launchers without stale host/bell chrome', async ({ page }) => {
     await page.goto('/')
     await expect(page.locator('.tb-brand')).toBeVisible()
-    await expect(page.locator('.tb-cmdk')).toBeVisible()
-    await expect(page.locator('.tb-cmdk')).toContainText('Quick actions')
+    // The old "Quick actions" button was replaced by two launchers.
+    await expect(page.locator('[data-testid="tb-launch-board"]')).toBeVisible()
+    await expect(page.locator('[data-testid="tb-launch-board"]')).toContainText('Kanban')
+    await expect(page.locator('[data-testid="tb-launch-chat"]')).toBeVisible()
+    await expect(page.locator('[data-testid="tb-launch-chat"]')).toContainText('Agent Chat')
+    await expect(page.locator('.tb-cmdk')).toHaveCount(0)
     await expect(page.locator('.tb-host')).toHaveCount(0)
     await expect(page.locator('.tb-bell')).toHaveCount(0)
   })

--- a/ui/tests/e2e/specs/sidebar-accordion-v3.spec.ts
+++ b/ui/tests/e2e/specs/sidebar-accordion-v3.spec.ts
@@ -67,15 +67,15 @@ test.describe('sidebar accordion', () => {
 })
 
 test.describe('sidebar Services zone', () => {
-  test('renders Kanban + install-derived OpenWebUI/Hermes links', async ({ page }) => {
+  test('renders install-derived OpenWebUI/Hermes links (no Kanban — moved to topbar)', async ({ page }) => {
     await mockConfigUrls(page)
     await page.goto('/#dashboard')
     const svc = page.locator('.sb-services')
     await expect(svc).toBeVisible({ timeout: FIVE_S })
 
-    // Kanban is an internal nav (no href); OpenWebUI/Hermes are external <a>s
-    // whose href comes straight from the backend-resolved config URLs.
-    await expect(svc.locator('[data-testid="svc-kanban"]')).toBeVisible()
+    // Kanban moved to the topbar launcher; Services now holds only the external
+    // OpenWebUI/Hermes <a>s, hrefs straight from the backend-resolved config.
+    await expect(svc.locator('[data-testid="svc-kanban"]')).toHaveCount(0)
     await expect(svc.locator('[data-testid="svc-openwebui"]')).toHaveAttribute(
       'href',
       'http://hal0.example:3001',
@@ -89,9 +89,9 @@ test.describe('sidebar Services zone', () => {
     await expect(svc.locator('[data-testid="svc-openwebui"]')).toHaveAttribute('rel', /noopener/)
   })
 
-  test('Kanban link routes to the Operator Board', async ({ page }) => {
+  test('topbar Kanban launcher routes to the Operator Board', async ({ page }) => {
     await page.goto('/#dashboard')
-    await page.locator('[data-testid="svc-kanban"]').click()
+    await page.locator('[data-testid="tb-launch-board"]').click()
     await expect(page).toHaveURL(/#board/)
     await expect(page.locator('[data-testid="board-view"]')).toBeVisible({ timeout: FIVE_S })
   })
@@ -111,7 +111,7 @@ test.describe('sidebar Services zone', () => {
     )
     await page.goto('/#dashboard')
     const svc = page.locator('.sb-services')
-    await expect(svc.locator('[data-testid="svc-kanban"]')).toBeVisible({ timeout: FIVE_S })
+    await expect(svc).toBeVisible({ timeout: FIVE_S })
     await expect(svc.locator('[data-testid="svc-openwebui"]')).toBeVisible()
     await expect(svc.locator('[data-testid="svc-hermes"]')).toHaveCount(0)
   })


### PR DESCRIPTION
## Summary
Dashboard chrome + board changes:

1. **Archived row on the board** — `BOARD_LANES` was missing the `archived` entry, so the existing **Show archived** checkbox had no lane to reveal. Added it; hidden by default, shown when checked. Tasks reach it via the bulk **archive** action / task-drawer archive.
2. **Global agent (Hermes) chat** — the orchestrator slide-out moved from `BoardView` to the App shell so it's triggerable **from anywhere** via the `hal0:toggle-agent-chat` event. The conversation hook now lives in the always-mounted App (persists across open/close); `BoardView` publishes its task map for ref chips and opens the drawer on a ref click via `hal0:open-board-task`.
3. **Topbar launchers** — replaced the **Quick actions** button with **Kanban** (→ `#board`) and **Agent Chat** (→ global slide-out). White icons at rest, amber glow on hover/active. The ⌘K command palette is still on the keyboard shortcut.
4. **Sidebar Services** — trimmed to **OpenWebUI** + **Hermes Dash** (Kanban moved to the topbar).

## Files
- `ui/src/dash/board/board-view.jsx` — archived lane, global-chat wiring, byId publish + open-task listener
- `ui/src/dash/main.jsx` — App-owned chat hook + open state + global toggle + slide-out mount
- `ui/src/dash/chrome.jsx` — topbar launchers, Services trimmed
- `ui/src/dashboard.css` — `.tb-launch` white→amber-glow icon styling
- `ui/tests/e2e/specs/*` — specs updated to the new contract

## Testing
- `vite build` ✅  ·  `tsc --noEmit` ✅
- Playwright e2e: **357 passed, 11 skipped, 0 failed**

## Notes
- Launchers are hidden on mobile (≤720px), matching how Quick actions folded into the nav drawer; the mobile nav drawer's own Quick-actions button is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)