### PR TITLE
feat(bench): GPU benchmark harness + hal0-benchctl seam + agent skills

### DIFF
--- a/installer/agent-skills/hal0-bench/SKILL.md
+++ b/installer/agent-skills/hal0-bench/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: hal0-bench
+category: homelab-ops
+description: Running LLM inference benchmarks on hal0 / Strix Halo. Use when asked to benchmark a model, measure tokens/sec (prompt-processing or generation), compare the ROCm vs Vulkan backends, sweep context lengths, or refresh benchmark data. Encodes the structural fact that benchmarking is a rootful GPU op the unprivileged agent reaches ONLY through the hal0-benchctl sudo seam, and that the single iGPU is shared with the live inference slots.
+---
+
+# hal0 benchmarking
+
+Benchmarks llama.cpp inference on this box across **both runtimes (ROCm and Vulkan)**
+using the official `llama-bench`, and writes structured JSON for Hal0 tracking.
+
+You (the `hal0` agent user) are unprivileged. Benchmark containers are **rootful** and
+need `/dev/kfd` + root's podman image store, so you drive everything through the
+**`hal0-benchctl` sudo seam** — the same hardened-seam pattern as `hal0-slotctl`. Never
+call `podman`/`systemctl` directly; you don't have rights and shouldn't.
+
+```bash
+sudo -n /usr/lib/hal0/bin/hal0-benchctl <command>
+```
+
+- **Engine** (root-owned, you cannot edit): `/usr/lib/hal0/bench/`
+- **Results** (yours to read): `/var/lib/hal0/benchmarks/` → `SUMMARY.md`, `index.json`, `runs/`
+- **Backends:** `rocm` (`ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server`),
+  `vulkan_radv` (`…:vulkan-radv-server`) — images already in root's podman.
+
+## When to use this skill
+
+- "Benchmark <model>" / "ROCm vs Vulkan speed?" / "measure tg or pp t/s".
+- Refresh the dataset after a new model/quant/image.
+- As the measurement engine for the [`hal0-tune`](../hal0-tune/SKILL.md) skill.
+
+## Commands (via the seam)
+
+```bash
+S="sudo -n /usr/lib/hal0/bin/hal0-benchctl"
+
+$S list                                            # what results exist
+$S run-model qwen3.5-0.8b/Qwen3.5-0.8B-UD-Q4_K_XL.gguf   # one model, both backends, all ctx
+$S run                                             # full curated sweep (config.sh DEFAULT_MODELS)
+$S run --exclusive                                 # clean numbers (see GPU rule below)
+$S aggregate                                       # rebuild index.json + SUMMARY.md
+$S help
+```
+
+Model paths are relative to `/mnt/ai-models` and validated by the seam (must exist, end
+in `.gguf`, no traversal). Runs are **resumable** — an existing result cell is skipped.
+
+## ⚠️ The GPU rule (most important)
+
+There is **one iGPU**, shared with the live inference slots (`hal0-slot@agent`,
+`@nano`, …). Benchmarking a busy GPU gives meaningless numbers, so the harness
+**refuses to run while any GPU slot is active**:
+
+```
+[abort] GPU inference slots are active; results would be skewed: ...
+```
+
+- For **authoritative numbers**: add `--exclusive` — it stops the GPU slots, runs, and
+  restarts them on exit. This briefly takes production inference offline, so only do it
+  when nothing is mid-request, and afterwards confirm recovery:
+  `hal0 slot status` (or `systemctl is-active hal0-slot@agent`).
+- There is no `--force` via the seam by design: the agent must not silently publish
+  contended results.
+- `hal0-slot@npu` does not use the GPU and is ignored.
+
+## Reading results
+
+- `SUMMARY.md` — model × context × tag, pp/tg t/s per backend. Read first.
+- `index.json` — `{generated, count, records[]}`; each record has `backend`, `gpu`,
+  `llamacpp_build`, `model{name,size,type}`, `config{n_prompt,n_gen,n_depth,n_batch,
+  n_ubatch,n_gpu_layers,flash_attn,type_k,type_v}`, `test` (`pp`/`tg`), `metric{avg_ts,stddev_ts}`.
+- A `runs/<cell>.json.failed` + `logs/<cell>.log` means that cell errored (usually OOM on
+  a big model, or a GPU hang). Read the log; don't report that cell.
+
+**Sanity gate:** a real GPU run shows `backend`=`rocm`/`vulkan_radv` and `gpu` naming the
+Radeon 8060S. CPU-low t/s with a blank GPU means the run was wrong — don't report it.
+
+## How this fits hal0 (D hardened-perms)
+
+The seam `/usr/lib/hal0/bin/hal0-benchctl` is the entire privileged surface: it validates
+the model path, backend, and (for tuning) a llama-bench flag whitelist, then execs the
+root-owned harness — no shell, no arbitrary args. Grant:
+`/etc/sudoers.d/hal0-benchctl`. See `references/seam.md` for internals and the model
+sweep matrix. To extend the curated models/contexts, an operator edits
+`/usr/lib/hal0/bench/config.sh` (root).

--- a/installer/agent-skills/hal0-bench/references/seam.md
+++ b/installer/agent-skills/hal0-bench/references/seam.md
@@ -1,0 +1,53 @@
+# hal0-benchctl seam — internals & layout
+
+Benchmarking is a rootful GPU operation; the unprivileged `hal0` user reaches it only
+through this seam, following hal0's D hardened-perms model (cf. `hal0-slotctl`,
+`hal0-agentenv`).
+
+## Components (installed)
+
+| Path | Owner | Purpose |
+|------|-------|---------|
+| `/usr/lib/hal0/bin/hal0-benchctl` | `root:root 0755` | the seam — validates args, execs harness |
+| `/etc/sudoers.d/hal0-benchctl` | `root:root 0440` | `hal0 ALL=(root) NOPASSWD: …/hal0-benchctl` |
+| `/usr/lib/hal0/bench/` | `root:root` | harness (`run_benchmarks.sh`, `generate_results_json.py`, `config.sh`) — **not** agent-writable |
+| `/var/lib/hal0/benchmarks/` | `hal0:hal0` | results (`runs/`, `logs/`, `index.json`, `SUMMARY.md`) |
+
+The harness lives on a **local root-owned path** (not the `/mnt` NFS mount) precisely so
+the agent can't tamper with a script that runs as root. Results are chowned back to
+`hal0` after every run so the agent + UI can read them.
+
+## Seam verbs & validation
+
+- `run [--exclusive]` — curated sweep, all contexts.
+- `run-model <rel.gguf> [--exclusive]` — one model, both backends.
+- `sweep <rel.gguf> <backend> [--exclusive] <flags…>` — tuning; flags whitelisted.
+- `aggregate` — rebuild `index.json` + `SUMMARY.md`.
+- `list` — list result files.
+
+Hardening:
+- model path: no `..`, must match `^[A-Za-z0-9][A-Za-z0-9._/-]*\.gguf$`, must exist under `/mnt/ai-models`.
+- backend: `rocm | vulkan_radv` only.
+- sweep flags: only `-b -ub -ngl -fa -ctk -ctv -p -n -d -r -t -mmp -pg` with
+  numeric/comma/quant values; `-m`, `-o`, and anything else are rejected.
+- no shell evaluation; the harness execs `podman` with fixed device/mount flags.
+
+## Sweep matrix (config.sh)
+
+- Backends: `rocm` (bench bin `/usr/local/bin/llama-bench`, `-ub 2048`,
+  `HSA_OVERRIDE_GFX_VERSION=11.5.1`, `GGML_HIP_ENABLE_UNIFIED_MEMORY=1`),
+  `vulkan_radv` (`/usr/bin/llama-bench`, `-ub 512`).
+- Contexts: `default` (pp512/tg128, r5), `ctx32k`, `ctx65k` (`-p 2048 -n 32 -d …`, r3).
+- Common: `-ngl 99 -fa 1 -mmp 0`. Curated `DEFAULT_MODELS` one per size class.
+
+## Revoke
+
+```bash
+sudo rm /etc/sudoers.d/hal0-benchctl     # removes the grant; harness stays, agent can't invoke it
+```
+
+## Upstreaming (future)
+
+The "official Hal0 feature" end-state is a `hal0 bench` CLI subcommand + `/api/benchmarks`
+route reading `index.json`, landed in the hal0 git repo (not edited into the packaged
+`/usr/lib/hal0/current`, which is replaced on update). This seam is the bridge until then.

--- a/installer/agent-skills/hal0-tune/SKILL.md
+++ b/installer/agent-skills/hal0-tune/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: hal0-tune
+category: homelab-ops
+description: Tuning LLM inference settings on hal0 / Strix Halo for throughput, latency, or memory. Use when asked to optimize/tune a model's llama.cpp flags & values (batch, ubatch, ngl, flash-attn, KV-cache quant, threads), find the fastest config, or close a gap vs other people's numbers. Combines benchmark-driven sweeps (via hal0-bench) with external research (r/LocalLLaMA, llama.cpp GitHub issues/PRs, the kyuz0 toolbox repo). Core rule: never apply a community claim without measuring it locally first.
+---
+
+# hal0 tuning
+
+Find the flags/values that maximize a target metric for a model on this box, by
+**measuring**, not guessing. The measurement engine is the [`hal0-bench`](../hal0-bench/SKILL.md)
+seam; this skill is the method that drives it.
+
+Pick **one** target up front — they trade off:
+- **tg t/s** (decode speed) — memory-bandwidth bound on Strix Halo (unified LPDDR5X).
+- **pp t/s** (prefill) — compute bound.
+- **TTFT / latency**, or **memory footprint** (fit a bigger model / longer context).
+- Always subject to a **quality floor** (a faster config that degrades output is a regression).
+
+## The loop (RED→GREEN per change)
+
+1. **Baseline.** `sudo -n /usr/lib/hal0/bin/hal0-benchctl run-model <rel.gguf> --exclusive`,
+   then `… aggregate`; read `/var/lib/hal0/benchmarks/SUMMARY.md`. Record current pp/tg per backend.
+2. **Research** (below) → a short list of *candidate* flags/values with a hypothesis for *why*
+   each should help on gfx1151. Don't apply anything yet.
+3. **Sweep** each candidate against the baseline model + backend (one variable at a time, or a
+   small grid). Measure.
+4. **Keep winners, discard the rest.** A change that doesn't beat baseline ± noise is dropped.
+5. **Iterate** on the new best; stop when gains fall below noise (~stddev) or you hit the memory wall.
+6. **Quality-check** the winning config before recommending it (see Quality floor).
+7. **Report** (and optionally apply to a slot).
+
+## Sweeping (the workhorse)
+
+`llama-bench` benchmarks the **cartesian product** of comma-separated values in one run — use
+that. Through the seam:
+
+```bash
+S="sudo -n /usr/lib/hal0/bin/hal0-benchctl"
+M=qwen3.6-27b/Qwen3.6-27B-UD-Q5_K_XL.gguf
+
+# ubatch is the biggest single lever; sweep it per backend
+$S sweep "$M" rocm        --exclusive -ub 512,1024,2048,4096 -p 2048 -n 64
+$S sweep "$M" vulkan_radv --exclusive -ub 256,512,1024       -p 2048 -n 64
+
+# batch x flash-attn grid
+$S sweep "$M" rocm --exclusive -b 2048,4096,8192 -fa 0,1 -p 2048 -n 64
+
+# KV-cache quant (memory + speed vs quality) at depth
+$S sweep "$M" rocm --exclusive -ctk q8_0,f16 -ctv q8_0,f16 -p 2048 -n 64 -d 16384
+
+$S aggregate   # then read SUMMARY.md — sweep rows are tagged "sweep"
+```
+
+Allowed sweep flags (seam whitelist): `-b -ub -ngl -fa -ctk -ctv -p -n -d -r -t -mmp -pg`.
+Tuning needs a quiet GPU, so `--exclusive` is normally required — only when nothing is
+serving; it restarts the slots on exit (see hal0-bench's GPU rule).
+
+## What's worth tuning on Strix Halo (gfx1151, Radeon 8060S)
+
+Priors from the production `hal0-slot@agent` config: `-b 8192 -ub 2048 -ctk q8_0 -ctv q8_0
+-fa on --no-mmap`, threads 16/32. Start near these.
+
+| Flag | Effect | Notes |
+|------|--------|-------|
+| `-ub` (ubatch) | biggest lever on both pp and tg | **optimum differs per backend** — ROCm likes large (2048+), Vulkan often smaller (512). Always sweep. |
+| `-b` (batch) | prefill throughput | pair with ub; diminishing returns past 8192. |
+| `-fa` (flash-attn) | speed + memory at depth | usually a win on; verify on this gfx — Vulkan FA support has changed across versions. |
+| `-ctk`/`-ctv` (KV quant) | memory + bandwidth | `q8_0` ≈ big memory save, tiny quality cost; `f16` = baseline quality. Matters most at long context (decode is bandwidth bound). |
+| `-t` (threads) | CPU-side work | sweep around physical cores (16); rarely the bottleneck for GPU offload. |
+| `-ngl` | fixed at 99 (full offload) | only lower to study CPU/GPU split. |
+
+Out of llama-bench scope (server-level, tune separately): **draft/MTP speculative decode**
+(`--spec-draft-*`) and `--parallel`/slots — hal0 has `/root/bench_mtp.py` for that.
+
+## External research (then verify locally)
+
+Surface ideas, **then prove them with a sweep** — hardware/driver/version specifics make
+generic advice unreliable.
+
+- **r/LocalLLaMA** — search: `Strix Halo`, `Ryzen AI Max 395`, `gfx1151`, `Radeon 8060S`,
+  `ROCm vs Vulkan llama.cpp`, `unified memory GTT`. Good for real-world flag combos + gotchas.
+- **llama.cpp GitHub** — issues/PRs/discussions for `ROCm`/`HIP`, `Vulkan`, `gfx1151`,
+  `flash attention`, `KV cache quant`. PRs often reveal which backend just got faster and the
+  exact flag that unlocks it.
+- **kyuz0/amd-strix-halo-toolboxes** — issues + its `benchmark/` results; this is the same
+  image lineage we run, so its findings transfer best.
+- **ROCm release notes / AMD community** — for gfx1151 enablement and `HSA_OVERRIDE` quirks.
+
+Use your web tools (or the deep-research skill). For each promising claim, write down the
+**hypothesis + source**, then the **measured delta** on our model. Discard claims that don't
+reproduce here.
+
+## Quality floor (don't trade quality blindly)
+
+Speed flags can hurt output — especially aggressive KV quant. Before recommending a config
+that touches `-ctk/-ctv` (or anything beyond ub/b), validate quality, e.g. the existing
+`/mnt/lab/qwen3coder-bench/` capability/eval runs on the tuned settings. Report speed **and**
+quality; if quality drops, the config is not a win.
+
+## Applying a winning config to a slot
+
+Slot configs live in `/etc/hal0/slots/<slot>.toml` (`hal0:hal0` — agent-editable). To persist
+tuned flags:
+
+1. **Back up** the toml. Change **one** thing (the validated winner).
+2. Reload via the hal0 CLI (`hal0 slot ...` — check `hal0 slot --help`; it regenerates the
+   unit through the `hal0-slotctl` seam). Do **not** hand-edit `/etc/systemd/system/hal0-slot@*`
+   (regenerated).
+3. **Verify health** (`hal0 slot status`, the slot's `/health`) and confirm live tok/s improved.
+4. Keep the rollback ready. This changes **production serving** — treat as Tier-2: only when
+   safe, verify after, revert on regression.
+
+## Output
+
+A short tuning report: target metric, baseline vs best (pp/tg per backend), the winning flags
+with the measured delta and the rationale/source for each, any quality check, and the exact
+`hal0 slot` change to apply it. Raw evidence is in `/var/lib/hal0/benchmarks/` (`index.json`).

--- a/installer/bench/README.md
+++ b/installer/bench/README.md
@@ -1,0 +1,63 @@
+# Strix Halo Benchmark Harness (hal0)
+
+GPU inference benchmarking for hal0 / Strix Halo, sweeping **both runtimes — ROCm and
+Vulkan** — with the official `llama-bench`, emitting structured JSON for Hal0 tracking.
+
+Ported from
+[`kyuz0/amd-strix-halo-toolboxes/benchmark`](https://github.com/kyuz0/amd-strix-halo-toolboxes/tree/main/benchmark),
+adapted to drive the container images already in root's podman via `podman` (not `toolbox`).
+
+## Layout & privilege model (D hardened-perms)
+
+This harness is **root-owned and root-executed**. The unprivileged `hal0` agent never runs
+it directly — it goes through the `hal0-benchctl` sudo seam, exactly like `hal0-slotctl`.
+
+| Path | Owner | Purpose |
+|------|-------|---------|
+| `/usr/lib/hal0/bench/` | `root:root` | this harness (not agent-writable, off NFS) |
+| `/usr/lib/hal0/bin/hal0-benchctl` | `root:root 0755` | the seam (validates args, execs harness) |
+| `/etc/sudoers.d/hal0-benchctl` | `root:root 0440` | the grant |
+| `/var/lib/hal0/benchmarks/` | `hal0:hal0` | results (`runs/`, `logs/`, `index.json`, `SUMMARY.md`) |
+
+## Usage
+
+Agents/operators use the seam:
+
+```bash
+S="sudo -n /usr/lib/hal0/bin/hal0-benchctl"
+$S run --exclusive                 # full curated sweep, clean GPU
+$S run-model <rel.gguf>            # one model, both backends
+$S sweep <rel.gguf> <backend> -ub 512,1024,2048   # tuning (whitelisted flags)
+$S aggregate                       # rebuild index.json + SUMMARY.md
+$S list
+```
+
+Direct (root shell, e.g. operator on hal0) — the engine under the seam:
+
+```bash
+/usr/lib/hal0/bench/run_benchmarks.sh --help
+/usr/lib/hal0/bench/run_benchmarks.sh --all-models --contexts all --exclusive
+/usr/lib/hal0/bench/generate_results_json.py /var/lib/hal0/benchmarks
+```
+
+`run_benchmarks.sh` also accepts `--force` (run on a busy GPU; contended numbers) and
+`--dry-run`; the seam deliberately does **not** expose `--force`.
+
+## ⚠️ GPU contention
+
+One iGPU, shared with the live inference slots. The harness refuses to run while a GPU slot
+is active; `--exclusive` stops/restarts them for clean numbers (briefly offlines production).
+`hal0-slot@npu` is GPU-free and ignored.
+
+## Tuning / extending (operator, edits config.sh)
+
+- Add a backend: entry in `BACKENDS` (`image|bench_bin|ubatch|env`) + `BACKEND_ORDER`.
+- Add a context: entry in `CTX_CONFIGS` (`args|reps`, `%UB%` = per-backend ubatch).
+- Curated default model set: `DEFAULT_MODELS`. Common flags: `COMMON_BENCH_ARGS`.
+
+## Scope & roadmap
+
+Now: the kyuz0 **toolbox sweep** (raw `llama-bench` across backends) + a tuning `sweep` verb.
+Deferred: MTP/draft-speculative bench (server-level; see `/root/bench_mtp.py`), RPC bench
+(needs ≥2 nodes), pi-bench (coding-agent eval). Upstream end-state: a `hal0 bench` CLI +
+`/api/benchmarks` route reading `index.json`, landed in the hal0 git repo.

--- a/installer/bench/config.sh
+++ b/installer/bench/config.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Strix Halo benchmark harness — central configuration (hal0 / CT105).
+#
+# Sourced by run_benchmarks.sh. This is the single place that encodes the
+# hal0-specific facts: which container images provide each backend, where the
+# llama-bench binary lives inside them, the podman device/security flags, and
+# the model/context sweep matrix. Edit HERE to add a backend, model, or context.
+#
+# Ownership model (D hardened-perms): this harness is installed root-owned and
+# is invoked as root only via the /usr/lib/hal0/bin/hal0-benchctl seam. Results
+# go to a hal0-owned dir so the agent + UI can read them.
+
+# --- Host / paths -----------------------------------------------------------
+MODEL_DIR="${MODEL_DIR:-/mnt/ai-models}"
+HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESULT_DIR="${RESULT_DIR:-/var/lib/hal0/benchmarks}"   # hal0:hal0, agent-readable
+RUNS_DIR="$RESULT_DIR/runs"      # one llama-bench JSON (+ .meta.json) per cell
+LOG_DIR="$RESULT_DIR/logs"       # stderr / errors per cell
+HOST_LABEL="${HOST_LABEL:-hal0}"
+GPU_LABEL="${GPU_LABEL:-Radeon 8060S (gfx1151)}"
+
+# --- Container runtime ------------------------------------------------------
+# podman, NOT docker: `docker run` is AppArmor-blocked on hal0. Containers run
+# rootful (the container is the sandbox boundary, per hal0's hardened model).
+RUNTIME="${RUNTIME:-podman}"
+
+# Device + security flags, lifted verbatim from the working production unit
+# /etc/systemd/system/hal0-slot@agent.service (render gid 993, video gid 44).
+COMMON_RUN_FLAGS=(
+  --rm
+  --device=/dev/kfd
+  --device=/dev/dri/amdgpu
+  --device=/dev/dri/renderD128
+  --group-add=993                       # render
+  --group-add=44                        # video
+  --security-opt apparmor=unconfined
+  --security-opt seccomp=unconfined
+  --volume="${MODEL_DIR}:${MODEL_DIR}:ro,z"
+)
+
+# --- Backends ---------------------------------------------------------------
+# key -> "image | bench_bin | ubatch | extra_env (space-separated KEY=VAL)"
+# Images already present in root's podman (no pull/build needed); both ship llama-bench.
+declare -A BACKENDS=(
+  [rocm]="ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server|/usr/local/bin/llama-bench|2048|HSA_OVERRIDE_GFX_VERSION=11.5.1 GGML_HIP_ENABLE_UNIFIED_MEMORY=1"
+  [vulkan_radv]="ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server|/usr/bin/llama-bench|512|"
+)
+# Order backends are swept in.
+BACKEND_ORDER=(rocm vulkan_radv)
+
+# --- Context configurations -------------------------------------------------
+# key -> "extra llama-bench args (%UB% = per-backend ubatch) | repetitions"
+# default = stock pp512/tg128; long contexts mirror kyuz0's 32K/65K sweeps.
+declare -A CTX_CONFIGS=(
+  [default]="|5"
+  [ctx32k]="-p 2048 -n 32 -d 32768 -ub %UB%|3"
+  [ctx65k]="-p 2048 -n 32 -d 65536 -ub %UB%|3"
+)
+CTX_ORDER=(default ctx32k ctx65k)
+
+# --- Common llama-bench args (applied to every cell) ------------------------
+#  -ngl 99  : offload all layers to GPU
+#  -fa 1    : flash attention on
+#  -mmp 0   : no mmap (matches production serving + kyuz0 harness)
+COMMON_BENCH_ARGS=(-ngl 99 -fa 1 -mmp 0)
+
+# --- Default curated model set (paths relative to MODEL_DIR) ----------------
+# Deliberately small (one per size class) so a default run is quick. Use
+# --all-models to sweep every GGUF, or --models a,b,c to pick specific ones.
+DEFAULT_MODELS=(
+  "qwen3.5-0.8b/Qwen3.5-0.8B-UD-Q4_K_XL.gguf"
+  "qwopus3.5-4b-coder-mtp/Qwopus3.5-4B-Coder-MTP-Q6_K.gguf"
+  "gemma-4-12B-agentic-fable5/gemma4-v2-Q4_K_M.gguf"
+  "qwen3.6-27b/Qwen3.6-27B-UD-Q5_K_XL.gguf"
+)

--- a/installer/bench/generate_results_json.py
+++ b/installer/bench/generate_results_json.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Aggregate per-run llama-bench JSON into a single Hal0-ready index.json and a
+human SUMMARY.md (ROCm vs Vulkan comparison).
+
+Each file in <results>/runs/<name>.json is the raw JSON array emitted by
+`llama-bench -o json` (one row per pp/tg test). The sibling <name>.meta.json
+(written by run_benchmarks.sh) carries our labels: backend, image, context,
+tag, host, gpu, timestamp. We flatten every row into a normalized record, write
+<results>/index.json, and render <results>/SUMMARY.md.
+
+Schema kept compatible with the llama-bench fields already used in the platform's
+benchmark history so the datasets can later merge.
+
+Results dir resolution: argv[1] > $HAL0_BENCH_RESULTS > /var/lib/hal0/benchmarks
+"""
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+
+if len(sys.argv) > 1:
+    RESULT_DIR = sys.argv[1]
+else:
+    RESULT_DIR = os.environ.get("HAL0_BENCH_RESULTS", "/var/lib/hal0/benchmarks")
+RUNS_DIR = os.path.join(RESULT_DIR, "runs")
+
+
+def test_kind(row):
+    """pp (prompt processing) vs tg (token generation) for a llama-bench row."""
+    if int(row.get("n_gen", 0) or 0) > 0 and int(row.get("n_prompt", 0) or 0) == 0:
+        return "tg"
+    if int(row.get("n_prompt", 0) or 0) > 0 and int(row.get("n_gen", 0) or 0) == 0:
+        return "pp"
+    return "mixed"
+
+
+def load_meta(json_path):
+    meta_path = json_path[: -len(".json")] + ".meta.json"
+    if os.path.exists(meta_path):
+        try:
+            with open(meta_path) as fh:
+                return json.load(fh)
+        except (OSError, ValueError):
+            pass
+    return {}
+
+
+def normalize(row, meta, mtime_iso):
+    return {
+        "timestamp": meta.get("timestamp") or mtime_iso,
+        "host": meta.get("host"),
+        "gpu": meta.get("gpu") or row.get("gpu_info"),
+        "gpu_info": row.get("gpu_info"),
+        "cpu_info": row.get("cpu_info"),
+        "backend": meta.get("backend"),
+        "backends_reported": row.get("backends"),
+        "runtime_image": meta.get("image"),
+        "context": meta.get("context", "default"),
+        "tag": meta.get("tag", ""),
+        "llamacpp_build": {
+            "commit": row.get("build_commit"),
+            "number": row.get("build_number"),
+        },
+        "model": {
+            "name": meta.get("model_rel") or row.get("model_filename"),
+            "path": row.get("model_filename") or meta.get("model_path"),
+            "type": row.get("model_type"),
+            "size": row.get("model_size"),
+            "n_params": row.get("model_n_params"),
+        },
+        "config": {
+            "n_prompt": row.get("n_prompt"),
+            "n_gen": row.get("n_gen"),
+            "n_depth": row.get("n_depth", 0),
+            "n_batch": row.get("n_batch"),
+            "n_ubatch": row.get("n_ubatch"),
+            "n_threads": row.get("n_threads"),
+            "n_gpu_layers": row.get("n_gpu_layers"),
+            "flash_attn": row.get("flash_attn"),
+            "type_k": row.get("type_k"),
+            "type_v": row.get("type_v"),
+            "reps": meta.get("reps"),
+        },
+        "test": test_kind(row),
+        "metric": {
+            "avg_ts": row.get("avg_ts"),
+            "stddev_ts": row.get("stddev_ts"),
+            "avg_ns": row.get("avg_ns"),
+            "stddev_ns": row.get("stddev_ns"),
+        },
+    }
+
+
+def collect():
+    records = []
+    if not os.path.isdir(RUNS_DIR):
+        return records
+    for fname in sorted(os.listdir(RUNS_DIR)):
+        if not fname.endswith(".json") or fname.endswith(".meta.json"):
+            continue
+        path = os.path.join(RUNS_DIR, fname)
+        mtime_iso = datetime.fromtimestamp(
+            os.path.getmtime(path), tz=timezone.utc
+        ).isoformat()
+        try:
+            with open(path) as fh:
+                rows = json.load(fh)
+        except (OSError, ValueError) as exc:
+            print(f"  [warn] skipping unreadable {fname}: {exc}", file=sys.stderr)
+            continue
+        if not isinstance(rows, list):
+            rows = [rows]
+        meta = load_meta(path)
+        for row in rows:
+            records.append(normalize(row, meta, mtime_iso))
+    return records
+
+
+def fmt_ts(rec):
+    m = rec["metric"]
+    if m.get("avg_ts") is None:
+        return "-"
+    sd = m.get("stddev_ts") or 0
+    return f"{m['avg_ts']:.1f}±{sd:.1f}"
+
+
+def write_summary(records):
+    """Markdown table: rows = model x context x tag, columns = backend (pp / tg t/s)."""
+    backends = sorted({r["backend"] for r in records if r.get("backend")})
+    grid = defaultdict(lambda: defaultdict(dict))
+    for r in records:
+        mname = r["model"]["name"] or "?"
+        ctx = r.get("context", "default")
+        tag = r.get("tag") or ""
+        grid[(mname, ctx, tag)][r.get("backend")][r["test"]] = fmt_ts(r)
+
+    lines = []
+    lines.append("# Strix Halo Benchmark Summary")
+    lines.append("")
+    lines.append(
+        f"Generated {datetime.now(tz=timezone.utc).isoformat()} · "
+        f"{len(records)} measurements · backends: {', '.join(backends) or 'none'}"
+    )
+    lines.append("")
+    lines.append("Throughput in tokens/sec (avg±stddev). "
+                 "**pp** = prompt processing, **tg** = token generation.")
+    lines.append("")
+
+    header = ["model", "context", "tag"]
+    for b in backends:
+        header += [f"{b} pp", f"{b} tg"]
+    lines.append("| " + " | ".join(header) + " |")
+    lines.append("|" + "|".join(["---"] * len(header)) + "|")
+
+    for key in sorted(grid):
+        mname, ctx, tag = key
+        cells = grid[key]
+        row = [mname, ctx, tag or "-"]
+        for b in backends:
+            row.append(cells.get(b, {}).get("pp", "-"))
+            row.append(cells.get(b, {}).get("tg", "-"))
+        lines.append("| " + " | ".join(row) + " |")
+
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    records = collect()
+    os.makedirs(RESULT_DIR, exist_ok=True)
+
+    index_path = os.path.join(RESULT_DIR, "index.json")
+    out = {
+        "generated": datetime.now(tz=timezone.utc).isoformat(),
+        "count": len(records),
+        "records": records,
+    }
+    with open(index_path, "w") as fh:
+        json.dump(out, fh, indent=2)
+
+    summary_path = os.path.join(RESULT_DIR, "SUMMARY.md")
+    with open(summary_path, "w") as fh:
+        fh.write(write_summary(records))
+
+    print(f"Wrote {index_path} ({len(records)} measurements)")
+    print(f"Wrote {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/installer/bench/run_benchmarks.sh
+++ b/installer/bench/run_benchmarks.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Strix Halo benchmark sweep — runs llama-bench across backends (ROCm / Vulkan),
+# models, and context configs via podman, writing one JSON result per cell.
+#
+# Ported from kyuz0/amd-strix-halo-toolboxes/benchmark/run_benchmarks.sh, with
+# `toolbox run -c <name> -- <bin>` replaced by `podman run --entrypoint <bin>`
+# against the images already present on hal0. Resumable: existing results are
+# skipped. See config.sh for the backend/model/context matrix.
+#
+# Tuning: --extra "<verbatim llama-bench args>" + --tag <name> appends arbitrary
+# flags (incl. comma-separated value sweeps, e.g. -ub 512,1024,2048) and labels
+# the output, so the hal0-tune skill can drive sweeps through this same script.
+set -uo pipefail
+
+HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=config.sh
+source "$HARNESS_DIR/config.sh"
+
+# --- defaults ---------------------------------------------------------------
+SEL_BACKENDS=("${BACKEND_ORDER[@]}")
+SEL_CONTEXTS=(default)
+EXCLUSIVE=0
+FORCE=0
+DRYRUN=0
+ALL_MODELS=0
+REPS_OVERRIDE=""
+MODELS_ARG=""
+EXTRA=""
+TAG=""
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+  --models a,b,c     Comma-separated model paths relative to MODEL_DIR
+                     (default: curated DEFAULT_MODELS in config.sh)
+  --all-models       Sweep every *.gguf under MODEL_DIR (first shard only)
+  --backends a,b     Backends to run (default: ${BACKEND_ORDER[*]})
+  --contexts a,b     Context configs, or 'all' (default: default)
+                     available: ${CTX_ORDER[*]}
+  --reps N           Override repetitions for every cell
+  --extra "ARGS"     Extra verbatim llama-bench args, appended to every cell.
+                     Supports llama-bench value sweeps, e.g. --extra "-ub 512,1024,2048"
+  --tag NAME         Label appended to result filenames (use with --extra to keep
+                     tuning runs separate from baseline results)
+  --exclusive        Stop active GPU inference slots for the run, then restart
+                     them on exit (Tier-2: only use when no one is serving)
+  --force            Run even if GPU slots are active (numbers WILL be skewed)
+  --dry-run          Print the podman commands without running them
+  -h, --help         This help
+
+Results: \$RESULT_DIR/runs/<model>__<backend>[__ctx][__tag].json (+ .meta.json)
+Then aggregate with: ./generate_results_json.py
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --models)      MODELS_ARG="$2"; shift 2;;
+    --all-models)  ALL_MODELS=1; shift;;
+    --backends)    IFS=',' read -ra SEL_BACKENDS <<<"$2"; shift 2;;
+    --contexts)
+      if [[ "$2" == "all" ]]; then SEL_CONTEXTS=("${CTX_ORDER[@]}");
+      else IFS=',' read -ra SEL_CONTEXTS <<<"$2"; fi; shift 2;;
+    --reps)        REPS_OVERRIDE="$2"; shift 2;;
+    --extra)       EXTRA="$2"; shift 2;;
+    --tag)         TAG="$2"; shift 2;;
+    --exclusive)   EXCLUSIVE=1; shift;;
+    --force)       FORCE=1; shift;;
+    --dry-run)     DRYRUN=1; shift;;
+    -h|--help)     usage; exit 0;;
+    *) echo "unknown arg: $1" >&2; usage; exit 2;;
+  esac
+done
+
+mkdir -p "$RUNS_DIR" "$LOG_DIR"
+tagsuffix=""; [[ -n "$TAG" ]] && tagsuffix="__$(printf '%s' "$TAG" | tr -c 'A-Za-z0-9._-' '_')"
+
+# --- GPU-idle preflight -----------------------------------------------------
+# The production hal0-slot@agent inference slot shares this iGPU. Running
+# llama-bench against a busy GPU produces meaningless (contended) numbers, so
+# by default we refuse. --exclusive stops/restarts the GPU slots; --force runs
+# anyway. The NPU slot (hal0-slot@npu) does not touch the GPU and is ignored.
+gpu_slots_active() {
+  systemctl list-units 'hal0-slot@*' --no-legend --state=active 2>/dev/null \
+    | awk '{print $1}' | grep -v '^hal0-slot@npu' || true
+}
+
+STOPPED_SLOTS=()
+restore_slots() {
+  local s
+  for s in "${STOPPED_SLOTS[@]:-}"; do
+    [[ -n "$s" ]] || continue
+    echo "[exclusive] restarting $s" >&2
+    systemctl start "$s" || echo "[exclusive] WARN: failed to restart $s" >&2
+  done
+}
+
+active="$(gpu_slots_active)"
+if [[ -n "$active" ]]; then
+  if [[ $EXCLUSIVE -eq 1 ]]; then
+    trap restore_slots EXIT INT TERM
+    while read -r s; do
+      [[ -n "$s" ]] || continue
+      echo "[exclusive] stopping GPU slot: $s"
+      systemctl stop "$s" || { echo "could not stop $s, aborting" >&2; exit 1; }
+      STOPPED_SLOTS+=("$s")
+    done <<<"$active"
+    sleep 3
+  elif [[ $FORCE -eq 1 ]]; then
+    echo "[warn] GPU slots active; --force set — results will be contended:" >&2
+    echo "$active" >&2
+  else
+    echo "[abort] GPU inference slots are active; results would be skewed:" >&2
+    echo "$active" | sed 's/^/    /' >&2
+    echo "Re-run with --exclusive (stop+restart them) or --force (accept contention)." >&2
+    exit 1
+  fi
+fi
+
+# --- resolve model list -----------------------------------------------------
+declare -a MODELS=()
+if [[ -n "$MODELS_ARG" ]]; then
+  IFS=',' read -ra MODELS <<<"$MODELS_ARG"
+elif [[ $ALL_MODELS -eq 1 ]]; then
+  while IFS= read -r f; do MODELS+=("${f#"$MODEL_DIR"/}"); done < <(
+    find "$MODEL_DIR" -type f -name '*.gguf' \
+      \( -name '*-00001-of-*.gguf' -o -not -name '*-0*-of-*.gguf' \) | sort)
+else
+  MODELS=("${DEFAULT_MODELS[@]}")
+fi
+[[ ${#MODELS[@]} -gt 0 ]] || { echo "no models to benchmark" >&2; exit 1; }
+
+echo "Backends : ${SEL_BACKENDS[*]}"
+echo "Contexts : ${SEL_CONTEXTS[*]}"
+echo "Models   : ${#MODELS[@]}"
+[[ -n "$EXTRA" ]] && echo "Extra    : $EXTRA${TAG:+  (tag=$TAG)}"
+echo "Results  : $RESULT_DIR"
+echo
+
+# --- sweep ------------------------------------------------------------------
+fail_count=0 run_count=0 skip_count=0
+for backend in "${SEL_BACKENDS[@]}"; do
+  spec="${BACKENDS[$backend]:-}"
+  [[ -n "$spec" ]] || { echo "[skip] unknown backend: $backend" >&2; continue; }
+  IFS='|' read -r image bench_bin ubatch envstr <<<"$spec"
+  env_flags=()
+  for kv in $envstr; do env_flags+=(-e "$kv"); done
+
+  for rel in "${MODELS[@]}"; do
+    model_path="$MODEL_DIR/$rel"
+    if [[ ! -f "$model_path" ]]; then
+      echo "[skip] missing model: $model_path" >&2; continue
+    fi
+    mstem="$(basename "$rel" .gguf)"
+    msan="$(printf '%s' "$mstem" | tr -c 'A-Za-z0-9._-' '_')"
+
+    for ctx in "${SEL_CONTEXTS[@]}"; do
+      cspec="${CTX_CONFIGS[$ctx]:-}"
+      [[ -n "$cspec" ]] || { echo "[skip] unknown ctx: $ctx" >&2; continue; }
+      IFS='|' read -r ctxargs reps <<<"$cspec"
+      [[ -n "$REPS_OVERRIDE" ]] && reps="$REPS_OVERRIDE"
+      ctxargs="${ctxargs//%UB%/$ubatch}"
+      ctxsuffix=""; [[ "$ctx" != "default" ]] && ctxsuffix="__$ctx"
+      base="${msan}__${backend}${ctxsuffix}${tagsuffix}"
+      out="$RUNS_DIR/${base}.json"
+      meta="$RUNS_DIR/${base}.meta.json"
+      log="$LOG_DIR/${base}.log"
+
+      if [[ -s "$out" ]]; then
+        echo "[skip exists] $(basename "$out")"; ((skip_count++)); continue
+      fi
+
+      # shellcheck disable=SC2206  # intentional word-split of ctxargs / EXTRA
+      cmd=("$RUNTIME" run "${COMMON_RUN_FLAGS[@]}" "${env_flags[@]}"
+           --entrypoint "$bench_bin" "$image"
+           -m "$model_path" "${COMMON_BENCH_ARGS[@]}" $ctxargs $EXTRA -r "$reps" -o json)
+
+      echo "[run] $backend / $mstem / $ctx${TAG:+ / $TAG} (reps=$reps)"
+      if [[ $DRYRUN -eq 1 ]]; then printf '   '; printf '%q ' "${cmd[@]}"; echo; continue; fi
+
+      ts="$(date -Iseconds)"
+      if "${cmd[@]}" >"$out" 2>"$log"; then
+        extra_json="$(printf '%s' "$EXTRA" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+        cat >"$meta" <<META
+{"backend":"$backend","image":"$image","context":"$ctx","tag":"$TAG","extra":"$extra_json","reps":$reps,"ubatch":$ubatch,"model_rel":"$rel","model_path":"$model_path","host":"$HOST_LABEL","gpu":"$GPU_LABEL","timestamp":"$ts"}
+META
+        echo "   -> $(basename "$out")"; ((run_count++))
+      else
+        echo "   [FAIL] see $(basename "$log")" >&2
+        mv "$out" "${out}.failed" 2>/dev/null || true
+        ((fail_count++))
+      fi
+    done
+  done
+done
+
+echo
+echo "Done. ran=$run_count skipped=$skip_count failed=$fail_count"
+echo "Aggregate: $HARNESS_DIR/generate_results_json.py"
+[[ $fail_count -eq 0 ]]

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -725,6 +725,58 @@ if [[ -f "${AGENT_UNIT_SRC}" ]]; then
             warn "${AGENTENV_SUDOERS_SRC} not found — agent-env sudoers grant not installed"
         fi
     fi
+
+    # Privileged seam #3 (D hardened-perms): hal0-benchctl runs the GPU benchmark
+    # harness. Benchmarking is a rootful container op (needs /dev/kfd + the images
+    # in root's podman store), but the agent runs unprivileged, so it delegates the
+    # run/aggregate ops here. The seam validates every argument (model path under
+    # the model dir, backend + llama-bench flag whitelist) and is the entire
+    # privileged surface — no shell, no arbitrary args. Lands at the absolute
+    # /usr/lib/hal0/bin path the seam's callers hardcode.
+    BENCHCTL_SRC="${REPO_ROOT}/installer/wrappers/hal0-benchctl"
+    if [[ -f "${BENCHCTL_SRC}" ]]; then
+        install -d "${LIB_DIR}/bin"
+        install -m 0755 "${BENCHCTL_SRC}" "${LIB_DIR}/bin/hal0-benchctl"
+        info "wrote ${LIB_DIR}/bin/hal0-benchctl"
+    else
+        warn "${BENCHCTL_SRC} not found — benchmark seam helper not installed"
+    fi
+
+    # GPU benchmark harness driven by the seam. Root-owned and off any shared
+    # mount so the unprivileged agent cannot tamper with a script that runs as
+    # root. Results live under VAR_DIR (agent-readable); the seam chowns them back
+    # to hal0 after each run.
+    BENCH_SRC="${REPO_ROOT}/installer/bench"
+    if [[ -d "${BENCH_SRC}" ]]; then
+        install -d "${LIB_DIR}/bench"
+        install -m 0644 "${BENCH_SRC}/config.sh"                "${LIB_DIR}/bench/config.sh"
+        install -m 0755 "${BENCH_SRC}/run_benchmarks.sh"        "${LIB_DIR}/bench/run_benchmarks.sh"
+        install -m 0755 "${BENCH_SRC}/generate_results_json.py" "${LIB_DIR}/bench/generate_results_json.py"
+        install -m 0644 "${BENCH_SRC}/README.md"                "${LIB_DIR}/bench/README.md"
+        install -d "${VAR_DIR}/benchmarks" "${VAR_DIR}/benchmarks/runs" "${VAR_DIR}/benchmarks/logs"
+        chown -R hal0:hal0 "${VAR_DIR}/benchmarks" 2>/dev/null || true
+        chmod 2775 "${VAR_DIR}/benchmarks" "${VAR_DIR}/benchmarks/runs" "${VAR_DIR}/benchmarks/logs" 2>/dev/null || true
+        info "wrote ${LIB_DIR}/bench + ${VAR_DIR}/benchmarks"
+    else
+        warn "${BENCH_SRC} not found — benchmark harness not installed"
+    fi
+
+    # sudoers grant for the benchmark seam. Real installs only; visudo-validate
+    # before activating so a malformed drop-in can never wedge sudo for the box.
+    if [[ "${DEV_MODE}" -eq 0 ]]; then
+        BENCHCTL_SUDOERS_SRC="${REPO_ROOT}/packaging/sudoers/hal0-benchctl"
+        BENCHCTL_SUDOERS_DST="/etc/sudoers.d/hal0-benchctl"
+        if [[ -f "${BENCHCTL_SUDOERS_SRC}" ]]; then
+            if visudo -cf "${BENCHCTL_SUDOERS_SRC}" >/dev/null 2>&1; then
+                install -m 0440 "${BENCHCTL_SUDOERS_SRC}" "${BENCHCTL_SUDOERS_DST}"
+                info "wrote ${BENCHCTL_SUDOERS_DST}"
+            else
+                warn "${BENCHCTL_SUDOERS_SRC} failed visudo check — benchmark sudoers grant not installed"
+            fi
+        else
+            warn "${BENCHCTL_SUDOERS_SRC} not found — benchmark sudoers grant not installed"
+        fi
+    fi
 else
     warn "${AGENT_UNIT_SRC} not found — hal0-agent@ template not installed"
 fi

--- a/installer/uninstall.sh
+++ b/installer/uninstall.sh
@@ -354,6 +354,14 @@ else
     info "${LIB_DIR} not present"
 fi
 
+# Benchmark seam sudoers grant (install.sh seam #3). Lives in /etc/sudoers.d,
+# outside the /etc/hal0 config sweep, so remove it explicitly (system mode only).
+# The seam helper + harness themselves live under LIB_DIR (removed above); the
+# results under ${VAR_DIR}/benchmarks are data, kept unless --purge.
+if [[ "${DEV_MODE}" -eq 0 ]]; then
+    rm_path "/etc/sudoers.d/hal0-benchctl"
+fi
+
 # The install PREFIX (default /opt/hal0). install.sh rsyncs the source
 # tree + builds the venv here; before #508 the uninstaller only removed
 # LIB_DIR and left this behind. In --dev mode PREFIX is handled by the

--- a/installer/wrappers/hal0-benchctl
+++ b/installer/wrappers/hal0-benchctl
@@ -1,0 +1,106 @@
+#!/bin/bash
+# hal0-benchctl — privileged seam for GPU benchmarking (D hardened-perms).
+#
+# Background: hal0-api / the Hermes agent run as the unprivileged `hal0` system
+# user, but benchmark containers are ROOTFUL (the container is the sandbox
+# boundary) and need /dev/kfd + the images in root's podman store. The only
+# root operations benchmarking needs are "run the harness" and "aggregate the
+# results", so the agent delegates exactly those here, just like hal0-slotctl
+# delegates slot-unit + systemctl ops and hal0-agentenv delegates env writes.
+#
+# This script is the ENTIRE privileged surface. It validates every argument
+# (model path must resolve under /mnt/ai-models, backend whitelist, llama-bench
+# flag whitelist), builds the harness invocation itself, and never evaluates a
+# shell — so the grant in /etc/sudoers.d/hal0-benchctl can never be widened into
+# arbitrary command execution. The harness it execs is root-owned and not
+# writable by the hal0 user.
+set -euo pipefail
+
+HARNESS=/usr/lib/hal0/bench
+MODEL_ROOT=/mnt/ai-models
+RESULTS=/var/lib/hal0/benchmarks
+RESULTS_OWNER=hal0:hal0
+
+die() { echo "hal0-benchctl: $1" >&2; exit 2; }
+
+validate_model() {   # arg: path relative to MODEL_ROOT
+  local rel="$1"
+  [[ -n "$rel" ]]                              || die "missing model path"
+  [[ "$rel" != *..* ]]                         || die "path traversal in model path"
+  [[ "$rel" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*\.gguf$ ]] || die "bad model path: $rel"
+  [[ -f "$MODEL_ROOT/$rel" ]]                  || die "model not found under $MODEL_ROOT: $rel"
+}
+
+validate_backend() {
+  [[ "$1" =~ ^(rocm|vulkan_radv)$ ]] || die "bad backend: $1"
+}
+
+# Only whitelisted llama-bench tuning flags + safe (numeric / comma-list / quant)
+# values are allowed in a sweep. -m/-o and anything else are rejected.
+validate_extra() {
+  local tok expect_val=0
+  for tok in "$@"; do
+    if [[ $expect_val -eq 1 ]]; then
+      [[ "$tok" =~ ^[A-Za-z0-9_,.:+-]+$ ]] || die "bad flag value: $tok"
+      expect_val=0; continue
+    fi
+    case "$tok" in
+      -b|-ub|-ngl|-fa|-ctk|-ctv|-p|-n|-d|-r|-t|-mmp|-pg) expect_val=1 ;;
+      *) die "flag not allowed in sweep: $tok" ;;
+    esac
+  done
+  [[ $expect_val -eq 0 ]] || die "dangling flag without value"
+}
+
+# Hand results back to the agent user after any write.
+post() { chown -R "$RESULTS_OWNER" "$RESULTS" 2>/dev/null || true; }
+
+# Optional leading --exclusive (stop/restart GPU slots for clean numbers).
+take_exclusive() { if [[ "${1:-}" == "--exclusive" ]]; then echo "--exclusive"; fi; }
+
+cmd="${1:-help}"; shift || true
+
+case "$cmd" in
+  run)                       # full curated sweep, all contexts
+    excl="$(take_exclusive "${1:-}")"
+    rc=0; "$HARNESS/run_benchmarks.sh" --contexts all $excl || rc=$?
+    post; exit $rc ;;
+
+  run-model)                 # one model, both backends, all contexts
+    rel="${1:-}"; shift || true
+    validate_model "$rel"
+    excl="$(take_exclusive "${1:-}")"
+    rc=0; "$HARNESS/run_benchmarks.sh" --models "$rel" --contexts all $excl || rc=$?
+    post; exit $rc ;;
+
+  sweep)                     # tuning: one model+backend, whitelisted extra flags
+    rel="${1:-}"; backend="${2:-}"; shift 2 2>/dev/null || die "usage: sweep <model.gguf> <backend> [--exclusive] <flags...>"
+    validate_model "$rel"
+    validate_backend "$backend"
+    excl=""; if [[ "${1:-}" == "--exclusive" ]]; then excl="--exclusive"; shift; fi
+    validate_extra "$@"
+    rc=0; "$HARNESS/run_benchmarks.sh" --models "$rel" --backends "$backend" \
+            --tag sweep --extra "$*" $excl || rc=$?
+    post; exit $rc ;;
+
+  aggregate)                 # rebuild index.json + SUMMARY.md
+    rc=0; "$HARNESS/generate_results_json.py" "$RESULTS" || rc=$?
+    post; exit $rc ;;
+
+  list)
+    ls -1 "$RESULTS/runs" 2>/dev/null || true ;;
+
+  help|"")
+    cat <<EOF
+usage: hal0-benchctl <command>
+  run [--exclusive]                              full curated sweep (all contexts)
+  run-model <rel.gguf> [--exclusive]            one model, both backends
+  sweep <rel.gguf> <backend> [--exclusive] FLAGS  tuning sweep (whitelisted flags)
+  aggregate                                      rebuild index.json + SUMMARY.md
+  list                                           list result files
+backends: rocm | vulkan_radv ; results: $RESULTS
+EOF
+    ;;
+
+  *) die "bad cmd: $cmd" ;;
+esac

--- a/packaging/sudoers/hal0-benchctl
+++ b/packaging/sudoers/hal0-benchctl
@@ -1,0 +1,18 @@
+# hal0 — privileged seam grant for GPU benchmarking (D hardened-perms).
+#
+# The hal0 agent user runs unprivileged, but benchmark containers are rootful
+# and need /dev/kfd + the images in root's podman store. It delegates exactly
+# the benchmark run/aggregate ops to /usr/lib/hal0/bin/hal0-benchctl, which is
+# the entire privileged surface: the helper validates the model path (must
+# resolve under /mnt/ai-models), the backend (rocm|vulkan_radv), and the
+# llama-bench flag whitelist — no wildcards, no shell, no arbitrary args.
+#
+# Install (as root):
+#   install -m 0755 -o root -g root hal0-benchctl /usr/lib/hal0/bin/hal0-benchctl
+#   install -m 0440 -o root -g root hal0-benchctl.sudoers /etc/sudoers.d/hal0-benchctl
+#   visudo -cf /etc/sudoers.d/hal0-benchctl
+#
+# Keep this grant pinned to the helper binary; a broader grant would let the
+# agent run arbitrary root commands. Revoke with: rm /etc/sudoers.d/hal0-benchctl
+
+hal0 ALL=(root) NOPASSWD: /usr/lib/hal0/bin/hal0-benchctl


### PR DESCRIPTION
## What

Adds a first-class **GPU benchmarking** capability for Strix Halo / llama.cpp, exercising **both runtimes (ROCm + Vulkan)** and wired into the **D hardened-perms** model.

### Components
- **`installer/bench/`** — the harness (`run_benchmarks.sh`, `config.sh`, `generate_results_json.py`, `README.md`). Sweeps *model × backend × context* via `podman --entrypoint llama-bench -o json`; emits per-run JSON + aggregated `index.json` + `SUMMARY.md`. Installed **root-owned** to `/usr/lib/hal0/bench`; results to `/var/lib/hal0/benchmarks` (`hal0`-owned, agent-readable). Resumable; GPU-idle guard with `--exclusive`.
- **`installer/wrappers/hal0-benchctl`** + **`packaging/sudoers/hal0-benchctl`** — privileged seam mirroring `hal0-agentenv`. Verbs: `run / run-model / sweep / aggregate / list`. Validates the model path (under the model dir), backend (`rocm|vulkan_radv`), and a llama-bench **flag whitelist** for tuning sweeps. The entire privileged surface — no shell, no arbitrary args — so the unprivileged `hal0` agent can run rootful GPU benchmarks safely.
- **`installer/agent-skills/hal0-bench`** + **`hal0-tune`** — bundled agent skills: run benchmarks, and benchmark-driven flag/value tuning (external research + measure-before-applying).
- **`install.sh` / `uninstall.sh`** — install seam #3 + harness + results dir; remove the sudoers grant on uninstall (helper + harness ride the `LIB_DIR` sweep; results are data, kept unless `--purge`).

## Why
Benchmarking is a rootful container op (needs `/dev/kfd` + root's podman images), but the agent runs unprivileged. Rather than a broad wrapper, this follows the platform's existing seam pattern so the agent gets a narrow, validated, auditable path.

## Backends
Uses the images already shipped/run on Strix Halo hosts:
`ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server` and `:vulkan-radv-server` (both ship `llama-bench`).

## Verification
Validated end-to-end on a live Strix Halo host (Radeon 8060S / gfx1151): seam auth via `sudo -n`, path-traversal + non-whitelisted-flag rejection, GPU-idle guard, real ROCm + Vulkan runs, `aggregate` → `index.json`/`SUMMARY.md` chowned back to `hal0`. `bash -n`, `py_compile`, and `visudo -cf` all pass.

## Notes
- `config.sh:DEFAULT_MODELS` is the per-host curated set (operators edit it; missing models are skipped; `--all-models` discovers everything).
- Follow-up (separate PR): `hal0 bench` CLI subcommand + `/api/benchmarks` route reading `index.json` for the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)