### PR TITLE
feat(dash): iGPU usage gauge + prefill TTFT readout

### DIFF
--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -504,6 +504,10 @@ async def _local_live_stats(request: Request) -> dict[str, Any]:
         "gpu_util": snap.get("gpu_util"),
         "gpu_vram_used_mb": snap.get("gpu_vram_used_mb"),
         "gpu_vram_total_mb": snap.get("gpu_vram_total_mb"),
+        # Live iGPU clock (MHz) + temperature (°C) for the dashboard's
+        # GPU usage gauge; None when the host exposes no such counter.
+        "gpu_clock_mhz": snap.get("gpu_clock_mhz"),
+        "gpu_temp_c": snap.get("gpu_temp_c"),
         # gpu_util stays RAW; this flag tells the dashboard the counter is
         # pinned by a forced performance level (gpu-compute.service) and
         # should be captioned, not trusted as load.

--- a/src/hal0/hardware/stats.py
+++ b/src/hal0/hardware/stats.py
@@ -133,6 +133,61 @@ class HardwareStats:
         """Return total GPU VRAM in MiB (or GTT pool on UMA)."""
         return self.gpu_sample().total_mb
 
+    def gpu_clock_mhz(self) -> int | None:
+        """Return the active GPU shader clock in MHz, or None.
+
+        AMD: parses ``pp_dpm_sclk`` and returns the MHz of the active
+        ('*') DPM level (e.g. ``2: 2900Mhz *`` → 2900) — no subprocess.
+        NVIDIA: nvidia-smi ``clocks.sm``. Best-effort; any read/parse
+        failure yields None so the dashboard simply omits the clock.
+        """
+        vendor = self._vendor()
+        if vendor == "amd" and self._amd_drm is not None:
+            txt = self._read_text(self._amd_drm / "pp_dpm_sclk")
+            if txt:
+                for line in txt.splitlines():
+                    if line.rstrip().endswith("*"):
+                        for tok in line.replace("Mhz", " ").replace("MHz", " ").split():
+                            if tok.isdigit():
+                                return int(tok)
+            return None
+        if vendor == "nvidia":
+            rc, out, _ = _run(
+                ["nvidia-smi", "--query-gpu=clocks.sm", "--format=csv,noheader,nounits"]
+            )
+            if rc == 0 and out.strip():
+                with contextlib.suppress(IndexError, ValueError):
+                    return int(float(out.strip().splitlines()[0]))
+        return None
+
+    def gpu_temp_c(self) -> float | None:
+        """Return the GPU temperature in °C, or None.
+
+        AMD: reads the first hwmon ``temp1_input`` (edge sensor, in
+        millidegrees) under the DRM device — no subprocess. NVIDIA:
+        nvidia-smi ``temperature.gpu``. Best-effort; None on any failure.
+        """
+        vendor = self._vendor()
+        if vendor == "amd" and self._amd_drm is not None:
+            try:
+                hwmons = sorted((self._amd_drm / "hwmon").glob("hwmon*"))
+            except OSError:
+                hwmons = []
+            for h in hwmons:
+                raw = self._read_text(h / "temp1_input")
+                if raw:
+                    with contextlib.suppress(ValueError):
+                        return round(int(raw.strip()) / 1000.0, 1)
+            return None
+        if vendor == "nvidia":
+            rc, out, _ = _run(
+                ["nvidia-smi", "--query-gpu=temperature.gpu", "--format=csv,noheader,nounits"]
+            )
+            if rc == 0 and out.strip():
+                with contextlib.suppress(IndexError, ValueError):
+                    return round(float(out.strip().splitlines()[0]), 1)
+        return None
+
     def ram_used_gb(self) -> float:
         """Return current system RAM used in GiB (MemTotal - MemAvailable)."""
         total = 0
@@ -216,6 +271,12 @@ class HardwareStats:
             "gtt_used_mb": smp.gtt_used_mb,
             "vram_used_mb": smp.vram_used_mb,
             "util_is_forced_high": smp.util_is_forced_high,
+            # Live GPU clock + temperature for the dashboard's iGPU gauge.
+            # Read off the same memoised vendor/DRM device the sample used,
+            # so AMD stays subprocess-free. None when the host exposes no
+            # such counter (the UI renders an em-dash).
+            "gpu_clock_mhz": self.gpu_clock_mhz(),
+            "gpu_temp_c": self.gpu_temp_c(),
         }
         if include_slot_ports:
             out["slot_ports_occupied"] = self.occupied_slot_ports()

--- a/ui/src/api/hooks/useStatsHardware.ts
+++ b/ui/src/api/hooks/useStatsHardware.ts
@@ -34,6 +34,9 @@ export interface StatsHardware {
   gpu_util?: number | null
   gpu_vram_used_mb?: number | null
   gpu_vram_total_mb?: number | null
+  // Live iGPU clock + temperature — drive the Inference hero GPU gauge
+  gpu_clock_mhz?: number | null
+  gpu_temp_c?: number | null
   // §2b new fields — backend adds cpu_util; npu_util only if NPU-telemetry spike lands
   cpu_util?: number | null
   npu_util?: number | null

--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -530,18 +530,126 @@
   background: var(--bg-1);
 }
 
-/* hero band — iGPU GTT memory map (2fr) + combined-throughput tile (1fr),
-   pinned at the top of BOTH states (P2). */
+/* hero band — iGPU GTT memory map (1/2) + iGPU usage gauge (1/4) +
+   combined-throughput tile (1/4), pinned at the top of BOTH states (P2).
+   The memory map was 2fr/1fr (≈3/4); halving it frees a 1/4 column for the
+   live GPU gauge. */
 .infer-pane .hero-band {
   display: grid;
-  grid-template-columns: 2fr 1fr;
+  grid-template-columns: 2fr 1fr 1fr;
   gap: 20px;
   align-items: start;
+}
+@media (max-width: 1100px) {
+  .infer-pane .hero-band {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 @media (max-width: 880px) {
   .infer-pane .hero-band {
     grid-template-columns: 1fr;
   }
+}
+
+/* ─── iGPU usage gauge (270° radial — mirrors the NPU/Comfy gauge, in the
+   iGPU device hue --dev-rocm) ─────────────────────────────────────────── */
+.infer-pane .gpu-gauge-tile {
+  border: 1px solid var(--line);
+  border-radius: var(--rad);
+  background: var(--bg);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+.infer-pane .gpu-gauge-tile .blk-h {
+  align-self: stretch;
+}
+.infer-pane .gauge {
+  position: relative;
+}
+.infer-pane .gauge svg {
+  display: block;
+}
+.infer-pane .gauge .gtrack {
+  fill: none;
+  stroke: var(--bg-3);
+}
+.infer-pane .gauge .gfill {
+  fill: none;
+  stroke: var(--yellow);
+  stroke-linecap: round;
+  filter: drop-shadow(0 0 6px rgba(229, 184, 79, 0.5));
+  transition: stroke-dasharray 0.6s var(--ease, cubic-bezier(0.22, 1, 0.36, 1));
+}
+.infer-pane .gauge .gc {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+.infer-pane .gauge .gc .pct {
+  font-family: var(--jbm);
+  font-size: 30px;
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  color: var(--fg);
+  line-height: 1;
+}
+.infer-pane .gauge .gc .pct .s {
+  font-size: 14px;
+  color: var(--fg-3);
+}
+.infer-pane .gauge .gc .lbl {
+  font-family: var(--jbm);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--dev-rocm);
+  margin-top: 7px;
+}
+.infer-pane .gauge .gc .sub {
+  font-family: var(--jbm);
+  font-size: 10px;
+  color: var(--fg-4);
+  margin-top: 3px;
+  white-space: nowrap;
+}
+/* clock + temperature readout below the gauge (two stat columns, mirrors
+   the NPU pane's .aie-stat readouts) */
+.infer-pane .gpu-readout {
+  display: flex;
+  gap: 24px;
+  align-self: stretch;
+  justify-content: center;
+}
+.infer-pane .gpu-readout .st {
+  text-align: center;
+}
+.infer-pane .gpu-readout .sv {
+  font-family: var(--jbm);
+  font-size: 17px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--fg);
+  line-height: 1;
+}
+.infer-pane .gpu-readout .sv .u {
+  font-size: 10px;
+  color: var(--fg-4);
+  margin-left: 3px;
+  letter-spacing: 0;
+}
+.infer-pane .gpu-readout .sl {
+  font-family: var(--jbm);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-4);
+  margin-top: 5px;
 }
 
 /* ─── Memory map ────────────────────────────────────────────────────── */
@@ -724,6 +832,35 @@
 }
 .infer-pane .tp-aside .pk {
   color: var(--fg-3);
+}
+/* prefill (TTFT) readout — pinned to the tile bottom (margin-top:auto) so it
+   fills the space under the spark and lines up with the gauge/mem tiles. */
+.infer-pane .tp-prefill {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-top: auto;
+  padding-top: 8px;
+  border-top: 1px solid var(--line);
+}
+.infer-pane .tp-prefill .pf-lbl {
+  font-family: var(--jbm);
+  font-size: 10px;
+  color: var(--fg-4);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+.infer-pane .tp-prefill .pf-val {
+  font-family: var(--jbm);
+  font-size: 16px;
+  color: var(--fg-2);
+}
+.infer-pane .tp-prefill .pf-val .u {
+  font-size: 9px;
+  color: var(--fg-4);
+  margin-left: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
 }
 
 /* ─── Slot cards (P2) ───────────────────────────────────────────────── */

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -36,6 +36,7 @@ import {
   useSlotSwap,
 } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
+import { useStatsHardware } from '@/api/hooks/useStatsHardware'
 import { useMemoryMapModel } from './memory-map'
 import { slotIndicatorFromPhase, isSlotLive } from './slot-status.js'
 
@@ -263,7 +264,7 @@ function SparkBars({ data = [], hotN = 4 }) {
   )
 }
 
-function TpTile({ value, ticks, peak, servingN }) {
+function TpTile({ value, ticks, peak, servingN, prefillMs }) {
   return (
     <div className="tp-tile" data-testid="infer-tp">
       <div className="blk-h" style={{ margin: 0 }}>
@@ -285,6 +286,103 @@ function TpTile({ value, ticks, peak, servingN }) {
         </div>
       </div>
       <SparkBars data={ticks} />
+      <div className="tp-prefill" data-testid="infer-prefill">
+        <span className="pf-lbl">prefill</span>
+        <span className="pf-val">
+          {prefillMs == null ? '—' : prefillMs}
+          {prefillMs != null && <span className="u">ms ttft</span>}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ── iGPU usage gauge (270° radial) ──────────────────────────────────────
+// Same SVG semicircle as the NPU (purple) and ComfyUI (blue) panes; here it
+// carries the iGPU device hue (--dev-rocm) and reads live GPU usage off
+// /api/stats/hardware. `pct` null → renders an em-dash (never a fake 0).
+function Gauge({ pct, label, sub, size = 132 }) {
+  const sw = Math.round(size * 0.065)
+  const r = size / 2 - sw - 4
+  const cx = size / 2
+  const cy = size / 2
+  const C = 2 * Math.PI * r
+  const arc = C * 0.75 // 270° sweep
+  const p = Math.max(0, Math.min(1, (pct || 0) / 100))
+  const fill = p * arc
+  return (
+    <div className="gauge" style={{ width: size, height: size }}>
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        <circle
+          className="gtrack"
+          cx={cx}
+          cy={cy}
+          r={r}
+          strokeWidth={sw}
+          strokeDasharray={`${arc} ${C}`}
+          strokeLinecap="round"
+          transform={`rotate(135 ${cx} ${cy})`}
+        />
+        <circle
+          className="gfill"
+          cx={cx}
+          cy={cy}
+          r={r}
+          strokeWidth={sw}
+          strokeDasharray={`${fill} ${C}`}
+          transform={`rotate(135 ${cx} ${cy})`}
+        />
+      </svg>
+      <div className="gc">
+        <div className="pct">
+          {pct == null ? '—' : Math.round(pct)}
+          {pct != null && <span className="s">%</span>}
+        </div>
+        <div className="lbl">{label}</div>
+        {sub ? <div className="sub">{sub}</div> : null}
+      </div>
+    </div>
+  )
+}
+
+// iGPU usage tile for the hero band — gauge of GPU compute %, captioned with
+// the live shader clock (MHz) and edge temperature (°C). Forced-high perf
+// pinning (gpu-compute.service) makes the % unreliable; we tag it "pinned"
+// so the reading is captioned, not silently trusted (mirrors the backend
+// util_is_forced_high contract).
+function GpuGauge() {
+  const hw = useStatsHardware()
+  const d = hw.data || {}
+  const util = typeof d.gpu_util === 'number' ? d.gpu_util : null
+  const pct = util == null ? null : util * 100
+  const mhz = typeof d.gpu_clock_mhz === 'number' && d.gpu_clock_mhz > 0 ? d.gpu_clock_mhz : null
+  const temp = typeof d.gpu_temp_c === 'number' ? d.gpu_temp_c : null
+  const forced = !!d.util_is_forced_high
+  return (
+    <div className="gpu-gauge-tile" data-testid="infer-gpu-gauge">
+      <div className="blk-h" style={{ margin: 0 }}>
+        <span className="ic">
+          <Ic name="mem" size={13} />
+        </span>{' '}
+        igpu usage{forced ? ' · pinned' : ''}
+      </div>
+      <Gauge pct={pct} label="igpu" />
+      <div className="gpu-readout">
+        <div className="st">
+          <div className="sv">
+            {mhz == null ? '—' : mhz}
+            {mhz != null && <span className="u">MHz</span>}
+          </div>
+          <div className="sl">clock</div>
+        </div>
+        <div className="st">
+          <div className="sv">
+            {temp == null ? '—' : Math.round(temp)}
+            {temp != null && <span className="u">°C</span>}
+          </div>
+          <div className="sl">temp</div>
+        </div>
+      </div>
     </div>
   )
 }
@@ -598,12 +696,23 @@ export function InferenceHeroBand() {
   const ticks = historyRef.current
   const peak = ticks.length ? Math.max(...ticks) : null
 
+  // Combined prefill — avg TTFT (ms) across this pane's serving slots. The
+  // backend deliberately doesn't scrape a prompt-eval rate, so TTFT is the
+  // available prefill signal (slot.metrics.ttft). null → em-dash, never 0.
+  const ttftVals = slots
+    .map((s) => s?.metrics?.ttft)
+    .filter((t) => typeof t === 'number' && t > 0)
+  const prefillMs = ttftVals.length
+    ? Math.round(ttftVals.reduce((a, b) => a + b, 0) / ttftVals.length)
+    : null
+
   return (
     <div className="infer-pane infer-hero-top" data-testid="infer-hero-band">
       <div className="proto">
         <div className="hero-band">
           <MemGtt mm={mm} full />
-          <TpTile value={value} ticks={ticks} peak={peak} servingN={servingN} />
+          <GpuGauge />
+          <TpTile value={value} ticks={ticks} peak={peak} servingN={servingN} prefillMs={prefillMs} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What
Adds an **iGPU usage gauge** and a **prefill (TTFT) readout** to the inference hero band.

- **iGPU gauge** — 270° radial in the hero band, live `gpu_util / clock / temp` off `/api/stats/hardware`, with a `pinned` caption when forced-high perf makes util unreliable. Ring colored `var(--yellow)`.
- **Prefill readout** — avg `metrics.ttft` (ms) across serving slots, pinned to the bottom of the combined-throughput tile (fills the previously-empty space). TTFT is the available prefill signal — the backend deliberately doesn't scrape a prompt-eval rate.
- **Backend** — surface `gpu_util / gpu_clock_mhz / gpu_temp_c / util_is_forced_high` in the live hardware stats.

## Verify
Built clean (`vite build`, 217 modules) and deployed/verified on CT105: served bundle contains the gauge + prefill, ring renders yellow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)