### PR TITLE
fix(deploy): land UI builds reliably (no-cache index + install to served dist)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -145,6 +145,36 @@ elif [[ "$DO_BUILD" -eq 0 ]]; then
     warn "skipping UI build (--no-build)"
 fi
 
+# ── 2a. Install the built bundle where the RUNNING server serves it ───────────
+# We just built THIS checkout's ui/dist, but on an FHS install the api resolves
+# the dashboard via HAL0_UI_DIST (api.env) or /usr/lib/hal0/ui/dist — a DIFFERENT
+# tree. Without this sync the build never reaches the served bundle and the UI
+# stays stale (the step-5 health check would still pass against the old one).
+# Idempotent; no-op when the served path already IS this checkout (editable host).
+if [[ "$DO_BUILD" -eq 1 ]]; then
+    served_dist=""
+    api_env="${HAL0_API_ENV:-/etc/hal0/api.env}"
+    if [[ -r "$api_env" ]]; then
+        served_dist="$(sed -n 's/^[[:space:]]*HAL0_UI_DIST=//p' "$api_env" | tail -1 | tr -d '"')"
+    fi
+    [[ -z "$served_dist" && -d /usr/lib/hal0/ui/dist ]] && served_dist=/usr/lib/hal0/ui/dist
+    built_dist="${REPO_ROOT}/ui/dist"
+    if [[ -n "$served_dist" ]]; then
+        served_real="$(readlink -f "$served_dist" 2>/dev/null || echo "$served_dist")"
+        built_real="$(readlink -f "$built_dist" 2>/dev/null || echo "$built_dist")"
+        if [[ "$served_real" == "$built_real" ]]; then
+            info "served path is this checkout — no install step needed"
+        elif command -v rsync >/dev/null 2>&1 \
+            && install -d "$served_dist" 2>/dev/null \
+            && rsync -a --delete "$built_dist"/ "$served_dist"/ 2>/dev/null; then
+            chmod -R a+rX "$served_dist" 2>/dev/null || true
+            info "installed bundle → ${served_dist} (served path)"
+        else
+            warn "could not install bundle to ${served_dist} (need root / rsync?) — UI may serve stale"
+        fi
+    fi
+fi
+
 # ── 2b. Sync runtime-mounted ComfyUI custom nodes ─────────────────────────────
 # ComfyUI imports custom nodes from the persistent model share, not the source
 # checkout. Keep shipped hal0 nodes in sync during runtime deploys; the ComfyUI

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1504,7 +1504,11 @@ def _mount_dashboard(app: FastAPI) -> None:
         # Don't shadow API routes — those return 404 normally if missing.
         if full_path.startswith("api/") or full_path.startswith("v1/"):
             return Response(status_code=404)
-        return FileResponse(index)
+        # no-cache so browsers always revalidate index.html and pick up a new
+        # build's hashed assets immediately (hashed /assets stay cacheable).
+        # Without this the dashboard serves stale after a deploy until a hard
+        # reload — the "can't see my change on 105" trap.
+        return FileResponse(index, headers={"Cache-Control": "no-cache"})
 
 
 app = create_app()


### PR DESCRIPTION
Two fixes for the "deployed but the change isn't visible on the runtime host" trap (hit while shipping the iGPU gauge to CT105).

## 1. `no-cache` on dashboard `index.html`
`_spa` served `index.html` via `FileResponse` with **no `Cache-Control`**, so browsers heuristically cache it and keep referencing the previous build's hashed assets after a deploy. Now sends `Cache-Control: no-cache` → always revalidate. Hashed `/assets/*` are immutable and stay cacheable. (Note: there is **no** service worker — the SPA catch-all just returns `index.html` for unmatched paths, which made `/sw.js` look like one.)

## 2. `deploy.sh` installs to the **served** dist
`deploy.sh` builds `<checkout>/ui/dist`, but on an FHS install the api resolves the dashboard via `HAL0_UI_DIST` (from `api.env`) or `/usr/lib/hal0/ui/dist` — a different tree. So the build never reached the served bundle, yet the step-5 health check passed against the stale one (false green). Now, after building, it rsyncs the bundle to the resolved served path. Idempotent; no-op when the served path already is the checkout (editable runtime).

## Verify
`bash -n scripts/deploy.sh` and `py_compile` pass. On a real host, `deploy.sh` now logs `installed bundle → <served path>` and a browser shows the new UI without a hard refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)