### PR TITLE
feat(memory): revive hindsight recall-types + stable agent document_id (CT105 WIP)

### DIFF
--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -96,7 +96,7 @@ def _http_status(exc: Exception) -> int | None:
 # which silently hides the consolidated observation layer — the highest-value
 # tier (deduplicated, evidence-grounded beliefs). hal0's default includes it;
 # callers can still narrow with an explicit ``types``.
-_DEFAULT_RECALL_TYPES = ("world", "experience", "observation")
+_DEFAULT_RECALL_TYPES = ("world", "observation")
 
 
 class HindsightProvider(MemoryProvider):
@@ -165,15 +165,17 @@ class HindsightProvider(MemoryProvider):
         # The join key. Caller-supplied → Hindsight upserts the same
         # logical document across adds (conversation evolution); absent →
         # fresh document per call.
-        document_id = document_id or str(uuid.uuid4())
+        if not document_id:
+            document_id = f"hal0-agent-{source or 'anonymous'}"
         meta = dict(metadata or {})
         if source:
             meta["source"] = source
+        context = f"hal0 agent memory from {source or 'unknown'}: {', '.join(tags or [])}" if tags else f"hal0 agent memory from {source or 'unknown'}"
         resp = await self._client.retain(
             bank_id=bank,
             content=text,
             document_id=document_id,
-            context=meta.get("source"),
+            context=context,
             metadata={k: str(v) for k, v in meta.items()},
             tags=list(tags or []),
             timestamp=None,


### PR DESCRIPTION
Revives orphaned WIP preserved on `preserved/hindsight-recall-types-ct105-20260615` (your commit `3e35b5d`, 2026-06-15), re-applied cleanly on current `main` (post ADR-0023 — `extraction_slot` work is untouched, 8 refs intact, `py_compile` passes).

## Three independent changes to `HindsightProvider`
| Change | Risk | |
|---|---|---|
| Drop `"experience"` from `_DEFAULT_RECALL_TYPES` → `("world", "observation")` | Medium | No documented rationale found — confirm tier intent |
| `document_id` → `hal0-agent-{source}` (was random `uuid4()`) | **High** | Agent memories from one source now **upsert into one logical doc** vs fresh-per-call |
| `context` → descriptive string (was bare `source`) | Low | Strictly better metadata |

## Review notes
- **The `document_id` change is the consequential one** — it changes memory granularity semantics. Confirm it's intended before merge; it can be dropped independently of the other two.
- Draft until you've decided per-change. Backup also exists on CT105 (`stash@{0}` + `/root/hindsight_provider.preserved-pre-deploy.patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)