### PR TITLE
feat(providers): GPU Qwen3-TTS as a hal0-native slot (Qwen3TTSProvider)

### DIFF
--- a/installer/etc-hal0/profiles.toml
+++ b/installer/etc-hal0/profiles.toml
@@ -78,6 +78,21 @@ device_class = "cpu"
 intent       = "TTS · Kokoro"
 quant        = ""
 
+[profile.tts-qwen3]
+# GPU TTS slot (Qwen3-TTS CustomVoice, multilingual). ROCm on native gfx1151
+# (~2.1x realtime). The GPU sibling of the cpu `tts`/kokoro profile — runtime
+# family qwen3tts routes it to Qwen3TTSProvider (GPU passthrough + /cache).
+# Flags bake --model_path + default voice/language; the model store is mounted
+# read-only so there is no download on start. Do NOT add HSA_OVERRIDE here —
+# native gfx1151 is ~4.5x faster than the gfx1100 override.
+image        = "ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1"
+flags        = "--model_path /mnt/ai-models/local/qwen3-tts/Qwen3-TTS-12Hz-1.7B-CustomVoice --default_voice Ryan --default_language Auto"
+mtp          = false
+device_class = "gpu"
+backend      = "rocm"
+intent       = "TTS · Qwen3 (multilingual GPU)"
+quant        = "BF16"
+
 [profile.comfyui]
 # Image-gen slot (ComfyUI on ROCm, kyuz0 Strix Halo build). Exclusive-GPU:
 # the GpuArbiter stops LLM GPU slots while img runs (Phase D, #599).

--- a/installer/etc-hal0/slots/qwen3tts.toml
+++ b/installer/etc-hal0/slots/qwen3tts.toml
@@ -1,0 +1,15 @@
+# Qwen3-TTS slot — multilingual GPU TTS in a podman container
+# (hal0-slot@qwen3tts). The GPU sibling of the cpu `tts`/kokoro slot; both
+# implement the OpenAI /v1/audio/speech contract. Disabled by default so a
+# fresh install boots with the lighter CPU Kokoro slot; enable this to make
+# the GPU multilingual engine available.
+name = "qwen3tts"
+type = "tts"
+device = "gpu-rocm"
+runtime = "container"
+profile = "tts-qwen3"
+enabled = false
+port = 8095
+
+[model]
+default = "qwen3-tts"

--- a/packaging/toolbox/qwen3tts.Dockerfile
+++ b/packaging/toolbox/qwen3tts.Dockerfile
@@ -1,0 +1,60 @@
+# hal0-toolbox-qwen3tts — Qwen3-TTS (CustomVoice) GPU TTS backend, ROCm.
+#
+# A multilingual (10-language) voice engine that runs alongside the Kokoro
+# TTS slot. Implements the same OpenAI /v1/audio/speech contract
+# (packaging/toolbox/qwen3tts/qwen3tts_server.py) so it is a drop-in
+# alternative voice for Hermes / Open WebUI.
+#
+# Base: rocm/pytorch matching the host ROCm the agent slot already uses
+# (ROCm 7.2.4 on the Strix Halo gfx1151 iGPU) with PyTorch 2.10 prebuilt.
+# We deliberately DO NOT install flash-attn (no clean ROCm build); the
+# server omits attn_implementation so transformers falls back to sdpa/eager.
+#
+# Build (podman, so the image lands in the store the slot units use):
+#   podman build -t ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1 \
+#       -f packaging/toolbox/qwen3tts.Dockerfile packaging/toolbox/qwen3tts
+#
+# Run (GPU passthrough mirrors the agent slot):
+#   podman run --rm --device=/dev/kfd --device=/dev/dri/renderD128 \
+#       --device=/dev/dri/amdgpu --group-add=993 --group-add=44 \
+#       --security-opt=apparmor=unconfined --security-opt=seccomp=unconfined \
+#       -v /mnt/ai-models:/mnt/ai-models:ro,z -v /var/lib/hal0/qwen3tts-cache:/cache:z \
+#       --publish=127.0.0.1:8087:8087 ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1 \
+#       --model_path /mnt/ai-models/local/qwen3-tts/Qwen3-TTS-12Hz-1.7B-CustomVoice \
+#       --host 0.0.0.0 --port 8087
+
+FROM docker.io/rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ffmpeg for mp3/opus encode + atempo (speed); libsndfile for soundfile.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ffmpeg \
+        libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the TTS stack. torch (ROCm 2.10) is already in the base image and
+# satisfies qwen-tts's `torch>=` requirement, so pip leaves it untouched and
+# does NOT pull a CPU/CUDA wheel over it. Pin nothing else to a CUDA build.
+RUN python3 -m pip install --no-cache-dir \
+        qwen-tts \
+        "fastapi>=0.110" \
+        "uvicorn[standard]>=0.29" \
+        soundfile \
+    && python3 -c "import torch; print('torch', torch.__version__, 'hip', getattr(torch.version,'hip',None))"
+
+# HF cache on a mountable, writable path so the codec/tokenizer (resolved by
+# id at load time) is fetched once and reused across restarts.
+ENV HF_HOME=/cache \
+    HF_HUB_ENABLE_HF_TRANSFER=0 \
+    PYTHONUNBUFFERED=1
+
+COPY qwen3tts_server.py /opt/qwen3tts/qwen3tts_server.py
+
+RUN mkdir -p /cache && chmod 0777 /cache
+
+EXPOSE 8087
+
+# ENTRYPOINT runs the server; ContainerSpec/systemd command[] carries flags only.
+ENTRYPOINT ["python3", "/opt/qwen3tts/qwen3tts_server.py"]
+CMD ["--help"]

--- a/packaging/toolbox/qwen3tts/qwen3tts_server.py
+++ b/packaging/toolbox/qwen3tts/qwen3tts_server.py
@@ -1,0 +1,289 @@
+"""qwen3tts-server — FastAPI wrapper around the qwen-tts package.
+
+Implements the same OpenAI-compatible contract the hal0 TTS path expects
+(mirrors packaging/toolbox/kokoro/kokoro_server.py), so this slot is a
+drop-in alternative voice engine alongside Kokoro:
+
+  GET  /health                  -> {status, model_loaded, ...}
+  GET  /v1/models               -> {data: [{id: "qwen3-tts"}]}
+  POST /v1/audio/speech         -> OpenAI-compat TTS, returns raw audio bytes
+  GET  /v1/audio/voices         -> {voices: [...]}  (compatibility extension)
+
+Unlike Kokoro this engine is GPU (ROCm) and multilingual (10 languages) with
+description-style timbre control. It loads Qwen3-TTS-12Hz-1.7B-CustomVoice.
+
+CLI flags (mirror the kokoro server so the systemd unit / provider stays
+uniform):
+  --model_path       Local model dir (e.g. .../Qwen3-TTS-12Hz-1.7B-CustomVoice)
+  --default_voice    Default speaker/timbre id (default: Ryan)
+  --default_language Default synthesis language (default: Auto)
+  --port             Bind port (default 8087)
+  --host             Bind host (default 0.0.0.0)
+
+Body shape for /v1/audio/speech (OpenAI compatible + extensions):
+    {
+      "model":           "qwen3-tts",
+      "input":           "Hello, world.",
+      "voice":           "Ryan",          # speaker/timbre name
+      "response_format": "mp3" | "wav" | "opus" | "flac" | "pcm",
+      "speed":           1.0,
+      "language":        "Auto" | "English" | "German" | ...,   # extension
+      "instruct":        "Speak warmly."                         # extension
+    }
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import Response
+from pydantic import BaseModel
+
+log = logging.getLogger("qwen3tts-server")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+# CustomVoice built-in timbres (Qwen3-TTS-12Hz-1.7B-CustomVoice).
+KNOWN_SPEAKERS = [
+    "Vivian", "Serena", "Uncle_Fu", "Dylan", "Eric",  # Chinese / dialects
+    "Ryan", "Aiden",                                    # English
+    "Ono_Anna",                                         # Japanese
+    "Sohee",                                            # Korean
+]
+# Qwen3-TTS covers 10 languages; "Auto" lets the model detect from the text,
+# which is what we want for translated output.
+KNOWN_LANGUAGES = [
+    "Auto", "Chinese", "English", "Japanese", "Korean", "German",
+    "French", "Russian", "Portuguese", "Spanish", "Italian",
+]
+
+_state: dict[str, object] = {
+    "model": None,
+    "default_voice": "Ryan",
+    "default_language": "Auto",
+    "sample_rate": 24_000,
+    "loaded": False,
+}
+
+
+# ── Model load ────────────────────────────────────────────────────────────────
+def _resolve_model_dir(model_path: str | None) -> str | None:
+    """Return a usable local model dir, or None to fall back to the HF id.
+
+    Accepts either the model dir itself (containing config.json) or a parent
+    dir holding a single Qwen3-TTS-*CustomVoice* checkout.
+    """
+    if not model_path:
+        return None
+    root = Path(model_path)
+    if not root.is_dir():
+        return None
+    if (root / "config.json").is_file():
+        return str(root)
+    # Parent dir: find the CustomVoice checkout under it.
+    for child in sorted(root.glob("*CustomVoice*")):
+        if (child / "config.json").is_file():
+            return str(child)
+    return None
+
+
+def _load_model(model_path: str | None, default_voice: str, default_language: str) -> None:
+    """Load Qwen3-TTS CustomVoice onto the GPU and stash on _state.
+
+    ROCm note: torch maps ``cuda:0`` to the HIP device, so ``device_map="cuda:0"``
+    is correct on this box. We deliberately omit ``attn_implementation`` so
+    transformers picks a backend that exists without flash-attn (sdpa/eager),
+    which does not build cleanly on ROCm.
+    """
+    try:
+        import torch
+        from qwen_tts import Qwen3TTSModel  # type: ignore
+    except ImportError as exc:  # pragma: no cover — image install is the contract
+        raise RuntimeError("qwen-tts / torch not installed; this image is broken") from exc
+
+    src = _resolve_model_dir(model_path) or "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+    log.info("loading qwen3-tts CustomVoice from %s (device=cuda:0, dtype=bf16)", src)
+
+    model = Qwen3TTSModel.from_pretrained(
+        src,
+        device_map="cuda:0",
+        dtype=torch.bfloat16,
+    )
+
+    _state["model"] = model
+    _state["default_voice"] = default_voice if default_voice in KNOWN_SPEAKERS else "Ryan"
+    _state["default_language"] = default_language if default_language in KNOWN_LANGUAGES else "Auto"
+    _state["loaded"] = True
+    log.info(
+        "qwen3-tts loaded: default_voice=%s default_language=%s",
+        _state["default_voice"], _state["default_language"],
+    )
+
+    # Warm the kernels so the first real request isn't paying JIT/allocation cost.
+    try:
+        wavs, sr = model.generate_custom_voice(
+            text="Ready.", language="English", speaker=str(_state["default_voice"]),
+        )
+        _state["sample_rate"] = int(sr)
+        log.info("qwen3-tts warmup ok: sr=%d", int(sr))
+    except Exception:  # noqa: BLE001
+        log.exception("warmup synth failed (continuing; /health stays loaded)")
+
+
+# ── Audio helpers (shared shape with kokoro_server.py) ──────────────────────────
+_FORMAT_MIME = {
+    "wav": "audio/wav",
+    "mp3": "audio/mpeg",
+    "opus": "audio/ogg",
+    "flac": "audio/flac",
+    "pcm": "audio/L16",
+}
+
+
+def _encode_audio(samples: np.ndarray, sample_rate: int, response_format: str, speed: float) -> tuple[bytes, str]:
+    """Encode float32 mono samples to the requested format, applying ``speed``.
+
+    Speed is applied via ffmpeg's atempo filter for compressed/wav outputs.
+    Qwen3-TTS has no native speed knob, so we post-process; pcm/raw paths
+    skip tempo change to stay dependency-free.
+    """
+    fmt = response_format.lower()
+    speed = max(0.5, min(2.0, float(speed or 1.0)))
+
+    if fmt == "pcm":
+        pcm = np.clip(samples * 32767.0, -32768, 32767).astype(np.int16)
+        return pcm.tobytes(), _FORMAT_MIME["pcm"]
+
+    # For everything else we go through ffmpeg when speed != 1.0 (atempo),
+    # otherwise encode directly with libsndfile for wav/flac.
+    if fmt in ("wav", "flac") and abs(speed - 1.0) < 1e-3:
+        buf = io.BytesIO()
+        subtype = "PCM_16" if fmt == "wav" else None
+        sf.write(buf, samples, sample_rate, format=fmt.upper(), subtype=subtype)
+        return buf.getvalue(), _FORMAT_MIME[fmt]
+
+    if fmt in ("wav", "flac", "mp3", "opus"):
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as wav_f:
+            sf.write(wav_f.name, samples, sample_rate, format="WAV", subtype="PCM_16")
+            wav_path = wav_f.name
+        out_path = wav_path + "." + fmt
+        try:
+            af = [] if abs(speed - 1.0) < 1e-3 else ["-filter:a", f"atempo={speed:.3f}"]
+            codec = {"mp3": "libmp3lame", "opus": "libopus", "wav": "pcm_s16le", "flac": "flac"}[fmt]
+            subprocess.run(
+                ["ffmpeg", "-y", "-loglevel", "error", "-i", wav_path, *af, "-c:a", codec, out_path],
+                check=True,
+            )
+            with open(out_path, "rb") as f:
+                return f.read(), _FORMAT_MIME[fmt]
+        finally:
+            for p in (wav_path, out_path):
+                try:
+                    os.unlink(p)
+                except OSError:
+                    pass
+
+    raise HTTPException(status_code=400, detail=f"unsupported response_format={fmt!r}")
+
+
+# ── App ───────────────────────────────────────────────────────────────────────
+app = FastAPI(title="hal0-qwen3tts", version="1.0.0")
+
+
+class SpeechRequest(BaseModel):
+    model: str = "qwen3-tts"
+    input: str
+    voice: str | None = None
+    response_format: str = "mp3"
+    speed: float = 1.0
+    language: str | None = None
+    instruct: str | None = None
+
+
+@app.get("/health")
+async def health() -> dict[str, object]:
+    return {
+        "status": "ok" if _state["loaded"] else "loading",
+        "model_loaded": bool(_state["loaded"]),
+        "default_voice": _state.get("default_voice"),
+        "default_language": _state.get("default_language"),
+    }
+
+
+@app.get("/v1/models")
+async def models() -> dict[str, object]:
+    if not _state["loaded"]:
+        return {"data": []}
+    return {"data": [{"id": "qwen3-tts", "object": "model", "owned_by": "qwen"}]}
+
+
+@app.get("/v1/audio/voices")
+async def voices() -> dict[str, object]:
+    return {"voices": list(KNOWN_SPEAKERS), "languages": list(KNOWN_LANGUAGES)}
+
+
+@app.post("/v1/audio/speech")
+def speech(req: SpeechRequest) -> Response:
+    # Sync def on purpose: model.generate_custom_voice is blocking/GPU-bound,
+    # so Starlette runs it in a threadpool and the event loop stays responsive.
+    if not _state["loaded"]:
+        raise HTTPException(status_code=503, detail="model not loaded")
+    if not req.input.strip():
+        raise HTTPException(status_code=400, detail="empty input")
+
+    speaker = req.voice or str(_state["default_voice"])
+    if speaker not in KNOWN_SPEAKERS:
+        speaker = str(_state["default_voice"])
+    language = req.language or str(_state["default_language"])
+    if language not in KNOWN_LANGUAGES:
+        language = str(_state["default_language"])
+
+    model = _state["model"]
+    try:
+        kwargs: dict[str, object] = {"text": req.input, "language": language, "speaker": speaker}
+        if req.instruct:
+            kwargs["instruct"] = req.instruct
+        wavs, sr = model.generate_custom_voice(**kwargs)  # type: ignore[union-attr]
+    except Exception as exc:  # noqa: BLE001
+        log.exception("synthesis failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    samples = np.asarray(wavs[0], dtype=np.float32)
+    sample_rate = int(sr)
+    _state["sample_rate"] = sample_rate
+
+    audio_bytes, mime = _encode_audio(samples, sample_rate, req.response_format, req.speed)
+    return Response(content=audio_bytes, media_type=mime)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+def main() -> int:
+    p = argparse.ArgumentParser(description="hal0 qwen3-tts server")
+    p.add_argument("--model_path", default="", help="local model dir (optional)")
+    p.add_argument("--default_voice", default="Ryan")
+    p.add_argument("--default_language", default="Auto")
+    p.add_argument("--port", type=int, default=8087)
+    p.add_argument("--host", default="0.0.0.0")
+    args = p.parse_args()
+
+    try:
+        _load_model(args.model_path or None, args.default_voice, args.default_language)
+    except Exception:
+        log.exception("model load failed at startup; /health will report loading=false")
+
+    import uvicorn
+
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -86,7 +86,7 @@ BACKEND_TO_DEVICE: dict[str, str] = {
 # label compatibility. ``"comfyui"`` is the exception: it is the active
 # container image-gen provider (img.toml, ADR image slots), not a
 # deprecated legacy value.
-_VALID_PROVIDERS = frozenset({"llama-server", "flm", "moonshine", "kokoro", "comfyui"})
+_VALID_PROVIDERS = frozenset({"llama-server", "flm", "moonshine", "kokoro", "qwen3tts", "comfyui"})
 
 # Slot port range.  8080 is the hal0 API; slots get 8081-8099; 8188 =
 # ComfyUI's stock port for the img slot — kept well-known so operator
@@ -781,6 +781,18 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "intent": "TTS · Kokoro",
         "quant": "",
     },
+    "tts-qwen3": {
+        "image": "ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1",
+        "flags": (
+            "--model_path /mnt/ai-models/local/qwen3-tts/Qwen3-TTS-12Hz-1.7B-CustomVoice "
+            "--default_voice Ryan --default_language Auto"
+        ),
+        "mtp": False,
+        "device_class": "gpu",
+        "backend": "rocm",
+        "intent": "TTS · Qwen3 (multilingual GPU)",
+        "quant": "BF16",
+    },
     "comfyui": {
         "image": "docker.io/kyuz0/amd-strix-halo-comfyui@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2",
         "flags": "--disable-mmap --bf16-vae --cache-none",
@@ -802,6 +814,8 @@ PROFILE_BENCH: dict[str, dict[str, float]] = {
     "vulkan": {"tps": 41.0},
     "flm": {"tps": 38.6},
     "tts": {"rtf": 0.18},
+    # Native gfx1151 ~2.1x realtime -> rtf ~= 1/2.1 (memory qwen3tts-voice-ct105).
+    "tts-qwen3": {"rtf": 0.48},
 }
 
 #: Preselect map for the create-modal device picker and legacy-slot

--- a/src/hal0/profiles/__init__.py
+++ b/src/hal0/profiles/__init__.py
@@ -39,7 +39,7 @@ from hal0.errors import Conflict, NotFound
 
 log = logging.getLogger(__name__)
 
-RuntimeFamily = Literal["llama-server", "flm", "kokoro", "comfyui"]
+RuntimeFamily = Literal["llama-server", "flm", "kokoro", "qwen3tts", "comfyui"]
 SlotType = Literal["llm", "embedding", "reranking", "transcription", "tts", "image"]
 
 _PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
@@ -109,6 +109,12 @@ def _runtime_family(name: str, profile: ProfileConfig) -> RuntimeFamily:
     image = profile.image.lower()
     if name == "flm" or profile.device_class == "npu" or "flm" in image:
         return "flm"
+    # Qwen3-TTS (GPU) is checked before Kokoro and the llama-server fallback:
+    # it is a TTS engine on a GPU device_class, so neither the kokoro nor the
+    # llama discriminators would catch it. Match by image/name (robust to a
+    # slug rename, same belt-and-suspenders style as the others).
+    if name == "tts-qwen3" or "qwen3tts" in image or "qwen3-tts" in image:
+        return "qwen3tts"
     if name == "tts" or "kokoro" in image:
         return "kokoro"
     if name == "comfyui" or profile.device_class == "img" or "comfyui" in image:
@@ -119,7 +125,7 @@ def _runtime_family(name: str, profile: ProfileConfig) -> RuntimeFamily:
 def _supported_slot_types(runtime_family: RuntimeFamily) -> tuple[SlotType, ...]:
     if runtime_family == "flm":
         return ("llm", "embedding", "transcription")
-    if runtime_family == "kokoro":
+    if runtime_family in ("kokoro", "qwen3tts"):
         return ("tts",)
     if runtime_family == "comfyui":
         return ("image",)

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -424,6 +424,14 @@ def _spec_provider_for(slot_cfg: dict[str, Any]) -> Any | None:
         from hal0.providers.flm import FLMProvider
 
         return FLMProvider()
+    # Qwen3-TTS (GPU) must be matched by its runtime family BEFORE the generic
+    # ``slot_type == "tts"`` → Kokoro fallback, so the two TTS engines coexist:
+    # a slot whose profile resolves to the qwen3tts family gets the GPU
+    # provider; a profile-less ``type=tts`` slot still falls through to Kokoro.
+    if family == "qwen3tts":
+        from hal0.providers.qwen3tts import Qwen3TTSProvider
+
+        return Qwen3TTSProvider()
     if family == "kokoro" or slot_type == "tts":
         from hal0.providers.kokoro import KokoroProvider
 

--- a/src/hal0/providers/qwen3tts.py
+++ b/src/hal0/providers/qwen3tts.py
@@ -1,0 +1,257 @@
+"""Qwen3TTSProvider — GPU (ROCm) multilingual TTS inference backend.
+
+The GPU sibling of :class:`~hal0.providers.kokoro.KokoroProvider`.  Both
+implement the same OpenAI ``/v1/audio/speech`` contract so a ``type=tts``
+slot can be served by either engine; this one runs the multilingual
+Qwen3-TTS CustomVoice model on the Strix Halo iGPU instead of Kokoro's
+CPU ONNX path.
+
+Image API surface (packaging/toolbox/qwen3tts.Dockerfile):
+  ENTRYPOINT: python3 /opt/qwen3tts/qwen3tts_server.py
+  CMD:        --help
+
+  The server is the ENTRYPOINT, so ``container_spec.command`` carries
+  flags only — no binary path or subcommand prefix.  Flags come from the
+  resolved ``tts-qwen3`` profile (profiles.toml), which bakes
+  ``--model_path`` plus the default voice/language.
+
+GPU passthrough (mirrors the llama-server / agent slot path):
+  Unlike Kokoro, Qwen3-TTS runs on ROCm, so the spec emits the GPU device
+  nodes (/dev/kfd + /dev/dri/*) and the numeric render/video GIDs via the
+  shared :mod:`hal0.providers._gpu` helpers — the same passthrough the
+  GPU llama slots use.
+
+  PERF GOTCHA: run on NATIVE gfx1151.  We deliberately do NOT set
+  ``HSA_OVERRIDE_GFX_VERSION`` — overriding to gfx1100 forces slow MIOpen
+  GEMM fallbacks (~9.5x realtime vs ~2.1x realtime native).
+
+Writable cache mount:
+  MIOpen's user kernel DB and the HuggingFace codec/tokenizer cache must be
+  writable and survive restarts, so a host cache dir is bind-mounted at
+  ``/cache`` (read-write) and the MIOpen env points at it.  The model store
+  itself stays read-only (identical-path, same as every other slot).
+
+Self-managed weights:
+  Qwen3-TTS weights are operator-staged under /mnt/ai-models (not
+  hal0-registry-managed), so the provider name is in the slot subsystem's
+  ``SELF_MANAGED_PROVIDERS`` set.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+from typing import Any
+
+import httpx
+
+from hal0.config.paths import model_store_root
+from hal0.errors import Hal0Error
+from hal0.providers._gpu import resolve_gpu_device_paths, resolve_gpu_group_ids
+from hal0.providers.base import ContainerSpec, Mount, Provider
+
+# Default image tag (overridable via HAL0_TOOLBOX_IMAGE_QWEN3TTS for dev/test).
+_DEFAULT_QWEN3TTS_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1"
+
+# Default profile name if the slot TOML omits one.
+_DEFAULT_PROFILE = "tts-qwen3"
+
+# Default slot port (slot TOML normally pins this; mirrors the live
+# standalone deployment's 8095 so a profile-less default lands where the
+# Hermes bridge already expects it).
+_DEFAULT_PORT = 8095
+
+# Host directory bind-mounted read-write at /cache inside the container for
+# the MIOpen user kernel DB + HuggingFace cache. Overridable for dev/test.
+_DEFAULT_CACHE_DIR = "/var/lib/hal0/qwen3tts-cache"
+
+# Health/infer timeouts (GPU synth is slow — give the read leg headroom).
+_HEALTH_TIMEOUT = httpx.Timeout(5.0)
+_INFER_TIMEOUT = httpx.Timeout(connect=5.0, read=120.0, write=5.0, pool=5.0)
+
+
+class Qwen3TTSHealthError(Hal0Error):
+    """Qwen3-TTS health probe failed."""
+
+    code = "slot.not_ready"
+    status = 503
+
+
+class Qwen3TTSInferError(Hal0Error):
+    """Qwen3-TTS inference call failed."""
+
+    code = "dispatch.upstream_failed"
+    status = 502
+
+
+def _cache_dir() -> str:
+    """Resolve the host cache dir bind-mounted at /cache (env-overridable)."""
+    return os.environ.get("HAL0_QWEN3TTS_CACHE", _DEFAULT_CACHE_DIR)
+
+
+class Qwen3TTSProvider(Provider):
+    """Provider for the GPU (ROCm) Qwen3-TTS CustomVoice backend.
+
+    GPU passthrough + writable /cache mount, otherwise the same shape as
+    :class:`~hal0.providers.kokoro.KokoroProvider`.  The container image
+    wraps ``qwen3tts_server.py`` which implements OpenAI-compat
+    ``POST /v1/audio/speech``, ``GET /v1/models``, and ``GET /health``.
+
+    Primary deployment path is ``container_spec`` → ``_render_unit_from_plan``
+    (same pattern as KokoroProvider / FLMProvider).  ``build_env`` /
+    ``start_cmd`` are informational stubs kept for ABC compliance.
+    """
+
+    name = "qwen3tts"
+
+    # ── Provider ABC stubs ─────────────────────────────────────────────────────
+
+    def build_env(
+        self,
+        slot_cfg: dict[str, Any],
+        model_info: dict[str, Any],
+    ) -> dict[str, str]:
+        """Informational env block (container is self-contained)."""
+        return {
+            "HAL0_SLOT": str(slot_cfg.get("name", "")),
+            "HAL0_RUNTIME": "container",
+            "HAL0_PROFILE": str(slot_cfg.get("profile") or _DEFAULT_PROFILE),
+        }
+
+    def start_cmd(self, env: dict[str, str]) -> list[str]:
+        """Not applicable — systemd starts the container."""
+        raise NotImplementedError("Qwen3TTSProvider uses systemd; start_cmd() is unused")
+
+    # ── Image / container spec ─────────────────────────────────────────────────
+
+    def image_ref(self, slot_cfg: dict[str, Any]) -> str:
+        """Return the Qwen3-TTS toolbox image reference."""
+        return os.environ.get("HAL0_TOOLBOX_IMAGE_QWEN3TTS", _DEFAULT_QWEN3TTS_IMAGE)
+
+    def container_spec(
+        self,
+        slot_cfg: dict[str, Any],
+        model_info: dict[str, Any],
+    ) -> ContainerSpec:
+        """Build a ContainerSpec for the GPU Qwen3-TTS slot.
+
+        The toolbox image ENTRYPOINT is ``python3 qwen3tts_server.py``, so
+        ``command`` carries only flags (no binary path / subcommand).
+
+        Flags come from the resolved profile (``tts-qwen3`` by default),
+        which bakes ``--model_path`` + ``--default_voice`` + ``--default_language``.
+        ``--host`` and ``--port`` are always appended so the operator cannot
+        accidentally omit them (argparse last-wins, so the slot's --port beats
+        any --port baked into profile flags).
+
+        Unlike Kokoro this emits GPU device nodes + render/video GIDs (the
+        same passthrough the llama GPU slots use), bakes the MIOpen cache env,
+        and bind-mounts a writable /cache dir.  ``HSA_OVERRIDE_GFX_VERSION``
+        is intentionally NOT set (native gfx1151 — see module docstring).
+
+        Security opts (apparmor/seccomp=unconfined) are required for
+        Proxmox LXC deployments (same rationale as the other providers).
+        """
+        from hal0.profiles import ProfileCatalog
+
+        port = int(slot_cfg.get("port") or _DEFAULT_PORT)
+        profile_name: str = str(slot_cfg.get("profile") or _DEFAULT_PROFILE)
+        profile = ProfileCatalog().resolve(profile_name)
+        # ``resolved_flags`` includes --model_path + voice/language defaults.
+        flag_tokens = shlex.split(profile.resolved_flags) if profile.resolved_flags.strip() else []
+
+        # command = profile flags + mandatory server binding args.
+        command: list[str] = [
+            *flag_tokens,
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(port),
+        ]
+
+        # Effective model-store root ([models].store / HAL0_MODEL_STORE,
+        # default /mnt/ai-models), mounted identical-path read-only so the
+        # profile-baked --model_path resolves inside the container.
+        store_root = model_store_root()
+        cache_dir = _cache_dir()
+
+        return ContainerSpec(
+            image=profile.image,
+            command=command,
+            # MIOpen user DB + custom kernel cache on the writable /cache mount;
+            # FAST find-mode avoids the multi-minute exhaustive GEMM search.
+            env={
+                "MIOPEN_USER_DB_PATH": "/cache/miopen",
+                "MIOPEN_CUSTOM_CACHE_DIR": "/cache/miopen",
+                "MIOPEN_FIND_MODE": "FAST",
+            },
+            mounts=[
+                # Model store: read-only, SELinux relabel for enforcing hosts.
+                Mount(store_root, store_root, read_only=True, selinux="z"),
+                # Writable cache: MIOpen DB + HF codec/tokenizer cache.
+                Mount(cache_dir, "/cache", read_only=False, selinux="z"),
+            ],
+            # GPU passthrough mirrors the llama-server / agent slot path.
+            devices=list(resolve_gpu_device_paths()),
+            cap_add=[],
+            # Required for Proxmox LXC container deployments.
+            security_opt=["apparmor=unconfined", "seccomp=unconfined"],
+            # Numeric render/video GIDs (toolbox images lack the group names).
+            group_add=[str(g) for g in resolve_gpu_group_ids()],
+            port=port,
+            # Port-mapped (not host networking) so it can coexist with the
+            # Kokoro TTS slot. _render_unit_from_plan derives
+            # --publish=127.0.0.1:<port>:<port> from spec.port.
+            network_mode="",
+            extra_args=[],
+        )
+
+    # ── Health / infer ─────────────────────────────────────────────────────────
+
+    async def health(self, port: int) -> dict[str, Any]:
+        """Probe GET /health on the qwen3tts-server port.
+
+        NOTE: dead code in the container deployment path — slot health checks
+        go through :meth:`ContainerProvider.health` (which implements the same
+        ``model_loaded`` gating).  Kept because ``health`` is abstract on the
+        Provider ABC: removing it would make Qwen3TTSProvider abstract and
+        break the ``_spec_provider_for`` instantiation in container.py.
+
+        qwen3tts_server.py returns {status: "ok", model_loaded: true} when
+        ready.  Returns {"ok": bool, "status": str}.
+        """
+        url = f"http://127.0.0.1:{port}/health"
+        try:
+            async with httpx.AsyncClient(timeout=_HEALTH_TIMEOUT) as client:
+                resp = await client.get(url)
+                if resp.status_code == 200:
+                    body = resp.json()
+                    loaded = bool(body.get("model_loaded"))
+                    return {
+                        "ok": loaded,
+                        "status": "ready" if loaded else "loading",
+                    }
+                return {"ok": False, "status": f"http_{resp.status_code}"}
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+            return {"ok": False, "status": str(exc)}
+        except Exception as exc:
+            return {"ok": False, "status": "exception", "detail": str(exc)}
+
+    async def infer(self, port: int, body: dict[str, Any]) -> dict[str, Any]:
+        """Passthrough /v1/audio/speech to qwen3tts-server."""
+        url = f"http://127.0.0.1:{port}/v1/audio/speech"
+        try:
+            async with httpx.AsyncClient(timeout=_INFER_TIMEOUT) as client:
+                resp = await client.post(url, json=body)
+                resp.raise_for_status()
+                return resp.json()  # type: ignore[no-any-return]
+        except httpx.HTTPStatusError as exc:
+            raise Qwen3TTSInferError(
+                f"Qwen3-TTS returned HTTP {exc.response.status_code}",
+                details={"port": port, "status_code": exc.response.status_code},
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise Qwen3TTSInferError(
+                f"Qwen3-TTS transport error: {exc}",
+                details={"port": port},
+            ) from exc

--- a/src/hal0/slots/state.py
+++ b/src/hal0/slots/state.py
@@ -121,7 +121,7 @@ def is_transition_legal(from_state: SlotState, to_state: SlotState) -> bool:
 
 #: Providers that serve a baked-in model and don't require an explicit model_id.
 #: Must stay in sync with ui/src/composables/useSlotStats.js SELF_MANAGED_PROVIDERS.
-SELF_MANAGED_PROVIDERS: frozenset[str] = frozenset({"kokoro", "moonshine", "vibevoice"})
+SELF_MANAGED_PROVIDERS: frozenset[str] = frozenset({"kokoro", "qwen3tts", "moonshine", "vibevoice"})
 
 
 def provider_requires_model(provider: str | None) -> bool:

--- a/tests/api/test_profiles_route.py
+++ b/tests/api/test_profiles_route.py
@@ -42,10 +42,11 @@ class TestListProfiles:
         assert isinstance(data, list)
 
     def test_returns_seed_profiles(self, client: TestClient) -> None:
-        """One entry per seed profile (7: rocm-moe + rocm-dnse split, Phase D comfyui)."""
+        """One entry per seed profile (8: rocm-moe + rocm-dnse split, Phase D
+        comfyui, plus the GPU tts-qwen3 profile)."""
         data = client.get("/api/profiles").json()
         assert len(data) == len(SEED_PROFILES)
-        assert len(data) == 7
+        assert len(data) == 8
 
     def test_flm_npu_seed_present(self, client: TestClient) -> None:
         """Phase A added the flm container profile to the seeds."""

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -180,7 +180,8 @@ class TestLoadProfilesConfig:
 
     def test_seed_count(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
-        assert len(cfg.profile) == 7  # rocm, rocm-dnse, rocm-moe, vulkan, flm, tts, comfyui
+        # rocm, rocm-dnse, rocm-moe, vulkan, flm, tts, tts-qwen3, comfyui
+        assert len(cfg.profile) == 8
 
     def test_seed_profiles_have_correct_names(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")

--- a/tests/profiles/test_catalog.py
+++ b/tests/profiles/test_catalog.py
@@ -17,6 +17,18 @@ def test_resolve_seed_profile_includes_runtime_facts(tmp_hal0_home: str) -> None
     assert profile.supported_slot_types == ("llm", "embedding", "transcription")
 
 
+def test_resolve_qwen3tts_seed_is_gpu_tts_family(tmp_hal0_home: str) -> None:
+    profile = ProfileCatalog().resolve("tts-qwen3")
+
+    assert profile.seed is True
+    assert profile.runtime_family == "qwen3tts"
+    # GPU TTS engine: a TTS-only slot type on a ROCm GPU device.
+    assert profile.supported_slot_types == ("tts",)
+    assert profile.device_class == "gpu"
+    assert profile.backend == "rocm"
+    assert profile.rtf == 0.48
+
+
 def test_resolve_exposes_backend(tmp_hal0_home: str) -> None:
     catalog = ProfileCatalog()
     assert catalog.resolve("rocm").backend == "rocm"

--- a/tests/providers/test_qwen3tts_container_spec.py
+++ b/tests/providers/test_qwen3tts_container_spec.py
@@ -1,0 +1,161 @@
+"""Qwen3-TTS (GPU) container spec + dispatch routing.
+
+The GPU sibling of test_kokoro_container_spec.py: same OpenAI TTS contract,
+but the spec must emit GPU device nodes + render/video GIDs, a writable
+/cache mount, and the MIOpen env — and must NOT set HSA_OVERRIDE.
+"""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from hal0.providers.container import _render_unit_from_spec, _spec_provider_for
+from hal0.providers.qwen3tts import Qwen3TTSProvider
+
+_FAKE_DEVICES = ["/dev/kfd", "/dev/dri/renderD128", "/dev/dri/amdgpu"]
+_FAKE_GIDS = [993, 44]
+
+
+def _slot_cfg(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "qwen3tts",
+        "port": 8095,
+        "device": "gpu-rocm",
+        "type": "tts",
+        "runtime": "container",
+        "profile": "tts-qwen3",
+        "model": {"default": "qwen3-tts"},
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture(autouse=True)
+def _stub_gpu(tmp_hal0_home: str) -> Any:
+    """Deterministic GPU passthrough regardless of the host (CI or real iGPU).
+
+    Depends on ``tmp_hal0_home`` so the ``tts-qwen3`` profile resolves from
+    SEED_PROFILES (isolated HAL0_HOME) rather than the host's real
+    /etc/hal0/profiles.toml, which may not carry it yet (pre-deploy).
+    """
+    with (
+        patch(
+            "hal0.providers.qwen3tts.resolve_gpu_device_paths",
+            return_value=list(_FAKE_DEVICES),
+        ),
+        patch(
+            "hal0.providers.qwen3tts.resolve_gpu_group_ids",
+            return_value=list(_FAKE_GIDS),
+        ),
+    ):
+        yield
+
+
+# ── Spec-level assertions ──────────────────────────────────────────────────────
+
+
+def test_spec_emits_gpu_devices_and_groups() -> None:
+    spec = Qwen3TTSProvider().container_spec(_slot_cfg(), {})
+    assert spec.devices == _FAKE_DEVICES
+    assert spec.group_add == ["993", "44"]
+
+
+def test_spec_command_carries_port_host_model_path_and_voice() -> None:
+    spec = Qwen3TTSProvider().container_spec(_slot_cfg(), {})
+    c = spec.command
+    assert c[c.index("--port") + 1] == "8095"
+    assert c[c.index("--host") + 1] == "0.0.0.0"
+    assert (
+        c[c.index("--model_path") + 1]
+        == "/mnt/ai-models/local/qwen3-tts/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+    )
+    assert c[c.index("--default_voice") + 1] == "Ryan"
+    assert c[c.index("--default_language") + 1] == "Auto"
+
+
+def test_spec_miopen_env_set_no_hsa_override() -> None:
+    spec = Qwen3TTSProvider().container_spec(_slot_cfg(), {})
+    assert spec.env.get("MIOPEN_USER_DB_PATH") == "/cache/miopen"
+    assert spec.env.get("MIOPEN_CUSTOM_CACHE_DIR") == "/cache/miopen"
+    assert spec.env.get("MIOPEN_FIND_MODE") == "FAST"
+    # Native gfx1151 perf gotcha: the override must never be baked in.
+    assert "HSA_OVERRIDE_GFX_VERSION" not in spec.env
+
+
+def test_spec_mounts_ro_model_store_and_rw_cache() -> None:
+    spec = Qwen3TTSProvider().container_spec(_slot_cfg(), {})
+    store = next(m for m in spec.mounts if m.source == "/mnt/ai-models")
+    assert store.read_only is True
+    assert store.target == "/mnt/ai-models"
+    cache = next(m for m in spec.mounts if m.target == "/cache")
+    assert cache.read_only is False
+    assert cache.source == "/var/lib/hal0/qwen3tts-cache"
+    assert cache.selinux == "z"
+
+
+def test_spec_security_opts_and_loopback_publish() -> None:
+    spec = Qwen3TTSProvider().container_spec(_slot_cfg(), {})
+    assert "apparmor=unconfined" in spec.security_opt
+    assert "seccomp=unconfined" in spec.security_opt
+    assert spec.port == 8095
+    assert spec.network_mode == ""
+
+
+def test_cache_dir_env_override() -> None:
+    with patch.dict("os.environ", {"HAL0_QWEN3TTS_CACHE": "/tmp/q3cache"}):
+        spec = Qwen3TTSProvider().container_spec(_slot_cfg(), {})
+    cache = next(m for m in spec.mounts if m.target == "/cache")
+    assert cache.source == "/tmp/q3cache"
+
+
+def test_no_registry_model_path_required() -> None:
+    """qwen3-tts is not a GGUF; model_info with NO 'path' must not raise."""
+    spec = Qwen3TTSProvider().container_spec(_slot_cfg(), {})  # {} = no 'path'
+    assert spec.image == "ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1"
+
+
+# ── Renderer integration ───────────────────────────────────────────────────────
+
+
+def test_renderer_emits_gpu_args_cache_volume_and_miopen_env() -> None:
+    spec = Qwen3TTSProvider().container_spec(_slot_cfg(), {})
+    unit = _render_unit_from_spec("qwen3tts", spec, runtime_bin="/usr/bin/podman")
+    exec_line = next(line for line in unit.splitlines() if line.startswith("ExecStart="))
+
+    assert "--device=/dev/kfd" in exec_line
+    assert "--device=/dev/dri/renderD128" in exec_line
+    assert "--group-add=993" in exec_line
+    assert "--group-add=44" in exec_line
+    assert "--publish=127.0.0.1:8095:8095" in exec_line
+    assert "--volume=/mnt/ai-models:/mnt/ai-models:ro,z" in exec_line
+    assert "--volume=/var/lib/hal0/qwen3tts-cache:/cache:z" in exec_line
+    assert "--env=MIOPEN_FIND_MODE=FAST" in exec_line
+    assert "HSA_OVERRIDE_GFX_VERSION" not in exec_line
+
+
+def test_slot_port_override_wins() -> None:
+    spec = Qwen3TTSProvider().container_spec(_slot_cfg(port=8096), {})
+    c = spec.command
+    assert c[c.index("--port") + 1] == "8096"
+    assert spec.port == 8096
+
+
+# ── Dispatch routing ───────────────────────────────────────────────────────────
+
+
+def test_spec_provider_qwen3tts_profile_returns_qwen3tts() -> None:
+    """A type=tts slot whose profile resolves to the qwen3tts family gets the
+    GPU provider, NOT the Kokoro fallback."""
+    result = _spec_provider_for(_slot_cfg())
+    assert isinstance(result, Qwen3TTSProvider)
+
+
+def test_qwen3tts_family_wins_over_generic_tts_fallback() -> None:
+    """Family discrimination beats the bare ``type == "tts"`` → Kokoro rule."""
+    from hal0.providers.kokoro import KokoroProvider
+
+    qwen = _spec_provider_for({"type": "tts", "profile": "tts-qwen3"})
+    kok = _spec_provider_for({"type": "tts", "profile": "tts"})
+    assert isinstance(qwen, Qwen3TTSProvider)
+    assert isinstance(kok, KokoroProvider)

--- a/tests/slots/test_state_self_managed_providers.py
+++ b/tests/slots/test_state_self_managed_providers.py
@@ -1,8 +1,8 @@
 """Tests for the SELF_MANAGED_PROVIDERS gate.
 
-Some providers (kokoro, moonshine, vibevoice) serve a baked-in model and
-don't need an explicit ``model_id``.  Every other provider does.  This
-gate keeps adoption + transition guards from labelling a modelless
+Some providers (kokoro, qwen3tts, moonshine, vibevoice) serve operator-staged
+weights and don't need an explicit ``model_id``.  Every other provider does.
+This gate keeps adoption + transition guards from labelling a modelless
 llama-server / FLM slot as READY.
 """
 
@@ -13,7 +13,11 @@ from hal0.slots.state import SELF_MANAGED_PROVIDERS, provider_requires_model
 
 def test_self_managed_providers_set_matches_ui() -> None:
     """The Python set must stay in sync with the UI's SELF_MANAGED_PROVIDERS."""
-    assert frozenset({"kokoro", "moonshine", "vibevoice"}) == SELF_MANAGED_PROVIDERS
+    assert frozenset({"kokoro", "qwen3tts", "moonshine", "vibevoice"}) == SELF_MANAGED_PROVIDERS
+
+
+def test_qwen3tts_does_not_require_model() -> None:
+    assert provider_requires_model("qwen3tts") is False
 
 
 def test_kokoro_does_not_require_model() -> None:


### PR DESCRIPTION
## What

Promotes the multilingual **GPU Qwen3-TTS** engine from a standalone podman service into a first-class hal0-managed slot — the GPU sibling of the CPU Kokoro TTS slot. Both speak the OpenAI `/v1/audio/speech` contract.

### The problem
`_spec_provider_for` routed **every** `type=tts` slot to `KokoroProvider`, which is hardcoded CPU-only (`devices=[]`, `group_add=[]`). So a GPU TTS engine could not be a managed slot.

### Changes
- **`Qwen3TTSProvider`** (`src/hal0/providers/qwen3tts.py`) — mirrors `KokoroProvider` but emits GPU passthrough (`/dev/kfd` + `/dev/dri/*`, numeric render/video GIDs via `_gpu.py`), a writable `/cache` mount, and the MIOpen env. **No `HSA_OVERRIDE_GFX_VERSION`** — native gfx1151 is ~2.1× realtime vs ~9.5× with the gfx1100 override (slow MIOpen GEMM fallback).
- New **`qwen3tts` `RuntimeFamily`**, classified before kokoro/llama-server; `supported_slot_types → ("tts",)`.
- **Routing**: `_spec_provider_for` matches `family == "qwen3tts"` **before** the generic `type=="tts"` → Kokoro fallback, so both engines coexist. A profile-less `type=tts` slot still falls through to Kokoro.
- **`tts-qwen3` seed profile** (gpu/rocm) + `profiles.toml` mirror; `qwen3tts` added to `_VALID_PROVIDERS` and `SELF_MANAGED_PROVIDERS`.
- **`qwen3tts.toml` slot** — **disabled by default** (fresh installs keep the lighter CPU Kokoro slot; enable to use the GPU multilingual engine).
- Toolbox source (Dockerfile + `qwen3tts_server.py`) for the image.

## Tests
- New `tests/providers/test_qwen3tts_container_spec.py` (spec, GPU args, cache mount, MIOpen env, no-HSA-override, renderer integration, dispatch routing).
- Lockstep tests updated for the +1 seed profile / self-managed entry.
- `ruff` + `mypy` clean on the provider.

## Deferred follow-ups (not in this PR)
- Capability-switch wiring (`voice.tts` selection picks cpu/kokoro vs gpu/qwen3 + front-door honoring it).
- CI image build + digest pin (`scripts/update-toolbox-digests.sh`).
- Live migration: retire `hal0-qwen3tts.service` + repoint the Hermes bridge.

> Deploy is gated on a release (live hal0-api runs from `/usr/lib/hal0/current`); test on a fresh box (CT133/CT200) before CT105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)