### PR TITLE
fix(dispatcher): inject upstream auth headers for remote providers

### DIFF
--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -1201,8 +1201,11 @@ class Dispatcher:
             if lk in _HOP_BY_HOP or lk == "authorization":
                 continue
             out[k] = v
-        # Future hook: out.update(auth_headers(upstream)) when Agent J ships it.
-        _ = upstream  # silence unused
+        # Inject upstream auth (bearer/anthropic/header) for remote providers
+        # that declare an auth_value_env. Local slot upstreams use auth_style
+        # "none" so this is a no-op for them. (Lights the previously-stubbed
+        # Agent J hook so authed cloud upstreams like MiniMax don't 401.)
+        out.update(self._upstreams.auth_headers(upstream))
         return out
 
     async def _cold_prefetch(self, cold_remotes: list[Upstream]) -> None:  # TIER2 + TIER3


### PR DESCRIPTION
## What

Lights the previously-stubbed *Agent J* hook in `Dispatcher._forward_headers`: it now calls `self._upstreams.auth_headers(upstream)` so remote providers that declare an `auth_value_env` get their bearer/anthropic/header auth injected on forwarded requests.

```diff
-        # Future hook: out.update(auth_headers(upstream)) when Agent J ships it.
-        _ = upstream  # silence unused
+        out.update(self._upstreams.auth_headers(upstream))
```

## Why

Without this, authed cloud upstreams (e.g. MiniMax) **401** because the dispatcher forwarded requests with no `Authorization`. Local slot upstreams use `auth_style "none"`, so `auth_headers()` returns `{}` for them — this is a no-op for the local inference path.

## Tests
`UpstreamRegistry.auth_headers` (registry.py:290) already exists and is covered. Dispatcher header/auth/forward tests pass (35 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)