### PR TITLE
chore: qwen3tts standalone → hal0-slot migration prep (runbook + guarded script)

### DIFF
--- a/handoffs/qwen3tts-standalone-to-slot-migration-2026-06-28.md
+++ b/handoffs/qwen3tts-standalone-to-slot-migration-2026-06-28.md
@@ -1,0 +1,251 @@
+# Handoff: qwen3tts standalone → hal0-slot migration
+
+**Status:** PREP ONLY — do not execute until all preconditions are verified.
+**Author context:** Written from live inspection of CT105 on 2026-06-28. Read
+all of §2 (preconditions) before touching anything.
+
+---
+
+## 1. Background
+
+CT105 runs two TTS services that share the same underlying model
+(`Qwen3-TTS-12Hz-1.7B-CustomVoice`) and the same OpenAI `/v1/audio/speech`
+contract:
+
+| Service | How started | Port | GPU | Managed by |
+|---|---|---|---|---|
+| `hal0-qwen3tts.service` | standalone systemd + podman | `127.0.0.1:8095` | yes (ROCm, gfx1151 native) | manual |
+| `hal0-slot@qwen3tts` | hal0 `ContainerProvider` | `127.0.0.1:8095` (TOML default) | yes (ROCm, tts-qwen3 profile) | hal0-api |
+
+The standalone service pre-dates the hal0 container-runtime slot model (PR
+#972 + follow-ups) and exists because hal0's `type=tts` slot path was
+previously CPU-only. Now that the hal0-native qwen3tts slot TOML
+(`installer/etc-hal0/slots/qwen3tts.toml`) ships and is deployed after a
+release reinstall, the standalone service can be retired — but only once the
+slot is verified healthy.
+
+The Hermes TTS bridge (`/var/lib/hal0/.hermes/scripts/hal0-voice-tts.py`)
+currently reaches qwen3tts at `http://127.0.0.1:8095/v1/audio/speech` (the
+standalone service). The migration repoints it to the hal0 front door
+(`http://127.0.0.1:8080/v1/audio/speech`) so hal0-api dispatches TTS calls
+through the managed slot, keeping the `hal0-voice {qwen3|kokoro}` switch
+working.
+
+---
+
+## 2. Port collision — critical
+
+**Both the standalone service and the slot TOML default to port 8095.**
+They cannot both bind `127.0.0.1:8095` simultaneously. The cutover sequence
+must respect this:
+
+**Recommended approach:** Stop and disable the standalone service first, then
+enable and start the hal0 slot. This creates a brief (~30–90 s) window where
+no qwen3tts backend is available, during which the Hermes fallback engine
+(kokoro on :8084) handles any TTS requests.
+
+**Alternative (zero-downtime):** Change the slot TOML to a different port (e.g.
+`8096`) before enabling it, let hal0 start the slot there, verify it, then stop
+the standalone. Requires editing `/etc/hal0/slots/qwen3tts.toml` and updating
+`QWEN3TTS_URL` accordingly. This is more complex and not recommended unless
+voice continuity during the cutover is critical (Hermes already has a kokoro
+fallback, so the brief window is acceptable).
+
+The migration script (`scripts/migrate-qwen3tts-to-slot.sh`) implements the
+stop-first approach. If you need zero-downtime, see the `--alt-port` notes in
+that script's comments.
+
+---
+
+## 3. Preconditions (all must be true before running the script)
+
+1. **hal0 ≥ the release that ships PR #972 is deployed on CT105.**
+   Verify: `hal0 version` shows a release that includes the qwen3tts slot
+   TOML in `installer/etc-hal0/slots/`. A fresh `hal0 update` or reinstall is
+   required to drop `/etc/hal0/slots/qwen3tts.toml` onto the host.
+
+2. **`/etc/hal0/slots/qwen3tts.toml` exists and `enabled = true`.**
+   Verify: `cat /etc/hal0/slots/qwen3tts.toml | grep enabled`
+   The TOML ships with `enabled = false`. Edit it (as root) to `enabled = true`
+   before loading the slot. Alternatively: `hal0 slot enable qwen3tts` if that
+   CLI is available.
+
+3. **`hal0-slot@qwen3tts.service` is loaded and READY.**
+   Verify: `curl -s http://127.0.0.1:8080/api/slots/qwen3tts | python3 -m json.tool`
+   The state field must be `"ready"`.
+
+4. **`/v1/audio/speech` is served through the hal0 front door for qwen3tts.**
+   The migration script probes this directly (see §5 below). A `200 OK` with
+   non-empty body is required.
+
+5. **The `tts` slot (kokoro) is ready on `:8084`.**
+   Hermes's fallback leg uses kokoro. The migration script checks this too.
+
+---
+
+## 4. Hermes bridge repoint (the one file that changes)
+
+**File:** `/var/lib/hal0/.hermes/scripts/hal0-voice-tts.py`
+
+**Env var:** `QWEN3TTS_URL` (read at the top of the script)
+
+**Current default (hardcoded in script):**
+```python
+QWEN3_URL = os.environ.get("QWEN3TTS_URL", "http://127.0.0.1:8095/v1/audio/speech")
+```
+
+**New default after migration:**
+```python
+QWEN3_URL = os.environ.get("QWEN3TTS_URL", "http://127.0.0.1:8080/v1/audio/speech")
+```
+
+The script's env-var override path (`QWEN3TTS_URL`) is preserved so the URL
+can still be overridden without editing the file. The migration script edits
+the fallback default in the script (the `http://127.0.0.1:8095` string) to
+`http://127.0.0.1:8080`.
+
+**Ownership constraint:** `/var/lib/hal0/.hermes/` is `hal0:hal0` owned. Editing
+as root flips ownership and takes the Hermes gateway offline (see the `hal0
+operational gotchas` memory). The migration script runs the file edit as the
+`hal0` user via `sudo -u hal0`. Never edit this file as root.
+
+**`hal0-voice` status script:** `/usr/local/bin/hal0-voice status` also probes
+`:8095` directly for the qwen3 health check line. After migration, `:8095` will
+be gone (the slot may run there, but via hal0 management). The `hal0-voice`
+script can optionally be updated to probe via the hal0 API instead, but this is
+cosmetic — the TTS bridge itself will be correctly routed.
+
+---
+
+## 5. Step-by-step cutover
+
+All steps are automated by `scripts/migrate-qwen3tts-to-slot.sh --apply`.
+This section documents the manual equivalent for reference and verification.
+
+### Phase A — Verify slot readiness (guard)
+
+```bash
+# 1. Slot exists and is READY
+curl -sf http://127.0.0.1:8080/api/slots/qwen3tts \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); assert d.get('state')=='ready', f\"slot state={d.get('state')}\""
+
+# 2. /v1/audio/speech returns audio via the front door
+tmp=$(mktemp /tmp/tts-probe.XXXXXX.wav)
+curl -sf http://127.0.0.1:8080/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"model":"qwen3-tts","input":"hal0 migration probe","voice":"Ryan","response_format":"wav"}' \
+  -o "$tmp" && [ -s "$tmp" ] && echo "audio OK: $(wc -c < "$tmp") bytes"
+rm -f "$tmp"
+
+# 3. Kokoro fallback is also up
+curl -sf http://127.0.0.1:8084/health | python3 -c "import json,sys; d=json.load(sys.stdin); assert d.get('status')=='ok', d"
+```
+
+### Phase B — Stop standalone service
+
+```bash
+systemctl stop hal0-qwen3tts.service
+systemctl disable hal0-qwen3tts.service
+# Verify port 8095 is free or now owned by the hal0 slot container
+ss -tlnp | grep 8095
+```
+
+### Phase C — Repoint Hermes bridge
+
+```bash
+# Edit as hal0 user (NEVER as root)
+sudo -u hal0 sed -i \
+  's|http://127\.0\.0\.1:8095/v1/audio/speech|http://127.0.0.1:8080/v1/audio/speech|g' \
+  /var/lib/hal0/.hermes/scripts/hal0-voice-tts.py
+
+# Verify the change
+grep 'QWEN3_URL\|8095\|8080' /var/lib/hal0/.hermes/scripts/hal0-voice-tts.py
+```
+
+### Phase D — Verify end-to-end
+
+```bash
+# 1. Bridge script reads new URL
+grep 'QWEN3_URL' /var/lib/hal0/.hermes/scripts/hal0-voice-tts.py
+
+# 2. Test a live TTS call through the bridge
+tmp_in=$(mktemp /tmp/tts-in.XXXXXX.txt)
+tmp_out=$(mktemp /tmp/tts-out.XXXXXX.wav)
+echo "Migration complete. Qwen3 TTS is now running as a hal0 slot." > "$tmp_in"
+sudo -u hal0 python3 /var/lib/hal0/.hermes/scripts/hal0-voice-tts.py "$tmp_in" "$tmp_out"
+echo "output wav: $(wc -c < "$tmp_out") bytes"
+rm -f "$tmp_in" "$tmp_out"
+
+# 3. hal0-voice status (cosmetic — :8095 probe changes meaning after migration)
+hal0-voice status
+```
+
+---
+
+## 6. Rollback
+
+If anything fails after Phase C, revert in reverse order:
+
+```bash
+# 1. Revert Hermes bridge
+sudo -u hal0 sed -i \
+  's|http://127\.0\.0\.1:8080/v1/audio/speech|http://127.0.0.1:8095/v1/audio/speech|g' \
+  /var/lib/hal0/.hermes/scripts/hal0-voice-tts.py
+
+# 2. Re-enable and start the standalone service
+systemctl enable hal0-qwen3tts.service
+systemctl start hal0-qwen3tts.service
+
+# 3. Verify standalone is healthy again
+curl -s http://127.0.0.1:8095/health
+```
+
+The migration script (`scripts/migrate-qwen3tts-to-slot.sh --rollback`)
+automates this.
+
+---
+
+## 7. Post-migration cleanup (optional, after verification)
+
+Once the slot has been running stably for several days:
+
+- Remove `/etc/systemd/system/hal0-qwen3tts.service` (keep a backup first).
+- Run `systemctl daemon-reload`.
+- The `/var/lib/hal0/qwen3tts-cache/` MIOpen cache directory can be reused by
+  the slot container (mount it in the slot profile if needed) or removed.
+- Update `hal0-voice status` to probe the hal0 API (`/api/slots/qwen3tts`)
+  instead of `:8095` directly.
+
+---
+
+## 8. Notes on the hal0 slot TOML
+
+`installer/etc-hal0/slots/qwen3tts.toml` ships with:
+- `port = 8095` — same port as standalone; no conflict once standalone stops.
+- `enabled = false` — intentional; must be set to `true` before enabling.
+- `profile = "tts-qwen3"` — expects the `tts-qwen3` profile in
+  `profiles.toml` defining the ROCm container image, GPU passthrough args,
+  MIOpen env, and model path binding.
+- `device = "gpu-rocm"` — run on native gfx1151; do NOT override to gfx1100
+  (MIOpen GEMM fallbacks are ~9.5× slower; native is ~2.1× realtime).
+
+Verify the `tts-qwen3` profile exists: `grep -A5 'tts-qwen3' /etc/hal0/profiles.toml`
+
+---
+
+## 9. What was inspected (read-only; live state unchanged)
+
+- `cat /etc/systemd/system/hal0-qwen3tts.service`
+- `systemctl status hal0-qwen3tts.service --no-pager`
+- `cat /var/lib/hal0/.hermes/scripts/hal0-voice-tts.py`
+- `cat /var/lib/hal0/.hermes/tts_voice.conf`
+- `cat /var/lib/hal0/.hermes/gateway_voice_mode.json`
+- `grep "tts:" /var/lib/hal0/.hermes/config.yaml`
+- `grep -r "hal0-voice-tts\|QWEN3TTS_URL" /var/lib/hal0/.hermes/` (read-only grep)
+- `cat /usr/local/bin/hal0-voice`
+- `curl -s http://127.0.0.1:8080/api/slots` (read-only)
+- `curl -s http://127.0.0.1:8080/api/slots/qwen3tts` (read-only)
+- `curl -s http://127.0.0.1:8080/api/health` (read-only)
+- `curl -s http://127.0.0.1:8095/health` (read-only)
+- `curl -s http://127.0.0.1:8080/v1/audio/speech ... -o /dev/null -w %{http_code}` (read-only probe)
+- `cat /etc/hal0/slots/qwen3tts.toml` (NOT FOUND — slot not yet deployed)

--- a/scripts/migrate-qwen3tts-to-slot.sh
+++ b/scripts/migrate-qwen3tts-to-slot.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# migrate-qwen3tts-to-slot.sh
+#
+# Retire the standalone hal0-qwen3tts.service and repoint the Hermes TTS
+# bridge to use the hal0-managed qwen3tts slot instead.
+#
+# SAFETY:
+#   - Default mode is --dry-run. Nothing is changed unless you pass --apply.
+#   - All guards must pass before any state-changing step runs.
+#   - Edits to /var/lib/hal0/.hermes/ are done as the `hal0` user (never root)
+#     to preserve ownership and keep the Hermes gateway online.
+#
+# USAGE:
+#   bash scripts/migrate-qwen3tts-to-slot.sh [--dry-run] [--apply] [--rollback]
+#
+# FLAGS:
+#   --dry-run   Print what would be done; make no changes. (DEFAULT)
+#   --apply     Run the full migration after all guards pass.
+#   --rollback  Revert a previously applied migration.
+#
+# PRECONDITIONS (enforced by guards before --apply acts):
+#   1. hal0 qwen3tts slot exists and state == "ready"
+#   2. /v1/audio/speech via hal0 front door returns audio (non-empty WAV)
+#   3. Kokoro fallback slot is healthy on :8084
+#   4. /var/lib/hal0/.hermes/scripts/hal0-voice-tts.py contains the old URL
+#      (idempotency: skip bridge edit if already pointing to :8080)
+#
+# ROLLBACK:
+#   Reverts the bridge URL edit, re-enables and starts hal0-qwen3tts.service.
+#
+# PORT COLLISION CONTEXT:
+#   Both the standalone service and the slot TOML default to port 8095.
+#   This script stops the standalone first, then the hal0 slot manager may
+#   start the slot on 8095. If the slot is already running (enabled before
+#   this script), the standalone will have failed to bind on its last restart
+#   -- check `systemctl status hal0-qwen3tts` before running.
+#
+# OWNERSHIP GOTCHA:
+#   /var/lib/hal0/.hermes/ must stay owned by hal0:hal0. Root edits flip
+#   ownership and take the Hermes gateway offline. This script uses
+#   `sudo -u hal0` for all edits inside that directory.
+
+set -euo pipefail
+
+# --- Configuration -----------------------------------------------------------
+
+HAL0_API="http://127.0.0.1:8080"
+KOKORO_HEALTH="http://127.0.0.1:8084/health"
+STANDALONE_UNIT="hal0-qwen3tts.service"
+BRIDGE_SCRIPT="/var/lib/hal0/.hermes/scripts/hal0-voice-tts.py"
+OLD_TTS_URL="http://127.0.0.1:8095/v1/audio/speech"
+NEW_TTS_URL="http://127.0.0.1:8080/v1/audio/speech"
+
+# --- Argument parsing ---------------------------------------------------------
+
+MODE="dry-run"
+for arg in "$@"; do
+    case "$arg" in
+        --apply)    MODE="apply" ;;
+        --dry-run)  MODE="dry-run" ;;
+        --rollback) MODE="rollback" ;;
+        -h|--help)
+            sed -n '/^# USAGE:/,/^# [A-Z]/p' "$0" | head -n -1
+            exit 0
+            ;;
+        *)
+            echo "error: unknown flag: $arg" >&2
+            echo "usage: $0 [--dry-run] [--apply] [--rollback]" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# --- Helpers ------------------------------------------------------------------
+
+log()   { echo "[$(date -Iseconds)] $*"; }
+ok()    { echo "[$(date -Iseconds)] OK  $*"; }
+fail()  { echo "[$(date -Iseconds)] ERR $*" >&2; }
+step()  { echo; echo "==> $*"; }
+
+dry_or_run() {
+    # In dry-run mode: print the command, do not run it.
+    # In apply/rollback mode: run it.
+    if [ "$MODE" = "dry-run" ]; then
+        echo "  [dry-run] would run: $*"
+    else
+        "$@"
+    fi
+}
+
+# --- Guards -------------------------------------------------------------------
+
+guard_slot_ready() {
+    step "Guard 1: qwen3tts slot exists and is READY"
+    local resp
+    resp=$(curl -sf "${HAL0_API}/api/slots/qwen3tts" 2>/dev/null) || {
+        fail "Could not reach hal0 API at ${HAL0_API}/api/slots/qwen3tts"
+        fail "Is hal0-api running? Is the qwen3tts slot deployed via a release update?"
+        return 1
+    }
+    local state
+    state=$(echo "$resp" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('state','?'))" 2>/dev/null) || {
+        fail "Could not parse slot state from API response: $resp"
+        return 1
+    }
+    if [ "$state" != "ready" ]; then
+        fail "qwen3tts slot state is '${state}', expected 'ready'"
+        fail "Check: hal0 slot load qwen3tts; then re-run this script"
+        return 1
+    fi
+    ok "qwen3tts slot state = ready"
+}
+
+guard_audio_speech() {
+    step "Guard 2: /v1/audio/speech via hal0 front door returns audio"
+    local tmp
+    tmp=$(mktemp /tmp/tts-migration-probe.XXXXXX.wav)
+    local http_code size
+    http_code=$(curl -s -o "$tmp" -w "%{http_code}" \
+        -X POST "${HAL0_API}/v1/audio/speech" \
+        -H "Content-Type: application/json" \
+        -d '{"model":"qwen3-tts","input":"migration probe","voice":"Ryan","response_format":"wav"}' \
+        --max-time 90 2>/dev/null) || http_code=000
+    size=0
+    [ -f "$tmp" ] && size=$(wc -c < "$tmp" 2>/dev/null || echo 0)
+    rm -f "$tmp"
+
+    if [ "$http_code" != "200" ]; then
+        fail "/v1/audio/speech returned HTTP ${http_code} (expected 200)"
+        fail "The qwen3tts slot must be READY and serving before migration"
+        return 1
+    fi
+    if [ "$size" -lt 100 ]; then
+        fail "/v1/audio/speech returned ${size} bytes (expected non-empty WAV)"
+        return 1
+    fi
+    ok "/v1/audio/speech -> HTTP 200, ${size} bytes"
+}
+
+guard_kokoro_healthy() {
+    step "Guard 3: kokoro fallback is healthy on :8084"
+    local http_code
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 8 "$KOKORO_HEALTH" 2>/dev/null) || http_code=000
+    if [ "$http_code" != "200" ]; then
+        fail "kokoro health at ${KOKORO_HEALTH} returned HTTP ${http_code}"
+        fail "Hermes fallback engine must be up before cutting over"
+        return 1
+    fi
+    ok "kokoro :8084 health = 200"
+}
+
+guard_bridge_script_exists() {
+    step "Guard 4: bridge script exists"
+    if [ ! -f "$BRIDGE_SCRIPT" ]; then
+        fail "Bridge script not found: ${BRIDGE_SCRIPT}"
+        return 1
+    fi
+    ok "bridge script exists: ${BRIDGE_SCRIPT}"
+}
+
+run_guards() {
+    local failed=0
+    guard_slot_ready  || failed=1
+    guard_audio_speech || failed=1
+    guard_kokoro_healthy || failed=1
+    guard_bridge_script_exists || failed=1
+    if [ "$failed" -ne 0 ]; then
+        echo
+        fail "One or more guards failed. Fix the issues above before re-running."
+        exit 1
+    fi
+    echo
+    ok "All guards passed."
+}
+
+# --- Migration steps ----------------------------------------------------------
+
+step_stop_standalone() {
+    step "Stop and disable standalone hal0-qwen3tts.service"
+    if ! systemctl is-active --quiet "$STANDALONE_UNIT" 2>/dev/null; then
+        log "  ${STANDALONE_UNIT} is already stopped — skipping stop"
+    else
+        dry_or_run systemctl stop "$STANDALONE_UNIT"
+    fi
+    if ! systemctl is-enabled --quiet "$STANDALONE_UNIT" 2>/dev/null; then
+        log "  ${STANDALONE_UNIT} is already disabled — skipping disable"
+    else
+        dry_or_run systemctl disable "$STANDALONE_UNIT"
+    fi
+    ok "standalone service stopped and disabled"
+}
+
+step_repoint_bridge() {
+    step "Repoint Hermes TTS bridge: 8095 -> 8080"
+
+    if ! grep -qF "$OLD_TTS_URL" "$BRIDGE_SCRIPT" 2>/dev/null; then
+        log "  Bridge already points to ${NEW_TTS_URL} or URL not found — skipping (idempotent)"
+        ok "bridge already updated (no-op)"
+        return
+    fi
+
+    # CRITICAL: edit as hal0 user, not root.
+    # Root edits flip ownership on /var/lib/hal0/.hermes/ and take the
+    # Hermes gateway offline. Always use `sudo -u hal0`.
+    if [ "$MODE" = "dry-run" ]; then
+        echo "  [dry-run] would run as hal0 user:"
+        echo "    sed -i 's|${OLD_TTS_URL}|${NEW_TTS_URL}|g' ${BRIDGE_SCRIPT}"
+    else
+        # Verify we can sudo to hal0 before attempting
+        if ! sudo -n -u hal0 true 2>/dev/null; then
+            fail "Cannot sudo -u hal0 (passwordless sudo not configured for this user)"
+            fail "Add: $(whoami) ALL=(hal0) NOPASSWD: /usr/bin/sed to sudoers"
+            exit 1
+        fi
+        sudo -u hal0 sed -i \
+            "s|${OLD_TTS_URL}|${NEW_TTS_URL}|g" \
+            "$BRIDGE_SCRIPT"
+    fi
+    ok "bridge script updated: ${OLD_TTS_URL} -> ${NEW_TTS_URL}"
+}
+
+step_verify_bridge() {
+    step "Verify bridge edit"
+    if grep -qF "$NEW_TTS_URL" "$BRIDGE_SCRIPT" 2>/dev/null; then
+        ok "bridge now contains: ${NEW_TTS_URL}"
+    elif [ "$MODE" = "dry-run" ]; then
+        log "  [dry-run] would verify bridge contains: ${NEW_TTS_URL}"
+    else
+        fail "Bridge does NOT contain expected URL after edit!"
+        fail "Check ${BRIDGE_SCRIPT} manually."
+        exit 1
+    fi
+    if grep -qF "$OLD_TTS_URL" "$BRIDGE_SCRIPT" 2>/dev/null; then
+        fail "Bridge STILL contains old URL: ${OLD_TTS_URL}"
+        fail "Sed replacement may have partially failed."
+        exit 1
+    fi
+}
+
+step_verify_e2e() {
+    step "End-to-end verification: TTS bridge call via hal0 slot"
+    if [ "$MODE" = "dry-run" ]; then
+        echo "  [dry-run] would run bridge script as hal0 user and verify WAV output"
+        return
+    fi
+    local tmp_in tmp_out
+    tmp_in=$(mktemp /tmp/tts-migrate-in.XXXXXX.txt)
+    tmp_out=$(mktemp /tmp/tts-migrate-out.XXXXXX.wav)
+    echo "Migration complete. Qwen3 TTS is now running as a hal0 slot." > "$tmp_in"
+    if sudo -u hal0 python3 "$BRIDGE_SCRIPT" "$tmp_in" "$tmp_out" 2>&1; then
+        local size
+        size=$(wc -c < "$tmp_out" 2>/dev/null || echo 0)
+        ok "bridge call succeeded: ${size} bytes written to ${tmp_out}"
+    else
+        fail "bridge call failed — check stderr above"
+        rm -f "$tmp_in" "$tmp_out"
+        exit 1
+    fi
+    rm -f "$tmp_in" "$tmp_out"
+}
+
+# --- Rollback steps -----------------------------------------------------------
+
+step_rollback_bridge() {
+    step "Rollback: revert bridge URL 8080 -> 8095"
+    if ! grep -qF "$NEW_TTS_URL" "$BRIDGE_SCRIPT" 2>/dev/null; then
+        log "  Bridge already contains ${OLD_TTS_URL} or neither URL found — skipping"
+        ok "bridge rollback: no-op"
+        return
+    fi
+    if [ "$MODE" = "dry-run" ]; then
+        echo "  [dry-run] would run as hal0 user:"
+        echo "    sed -i 's|${NEW_TTS_URL}|${OLD_TTS_URL}|g' ${BRIDGE_SCRIPT}"
+    else
+        if ! sudo -n -u hal0 true 2>/dev/null; then
+            fail "Cannot sudo -u hal0"
+            exit 1
+        fi
+        sudo -u hal0 sed -i \
+            "s|${NEW_TTS_URL}|${OLD_TTS_URL}|g" \
+            "$BRIDGE_SCRIPT"
+    fi
+    ok "bridge reverted: ${NEW_TTS_URL} -> ${OLD_TTS_URL}"
+}
+
+step_rollback_standalone() {
+    step "Rollback: re-enable and start standalone hal0-qwen3tts.service"
+    dry_or_run systemctl enable "$STANDALONE_UNIT"
+    dry_or_run systemctl start "$STANDALONE_UNIT"
+    if [ "$MODE" != "dry-run" ]; then
+        local tries=0
+        while [ "$tries" -lt 12 ]; do
+            local code
+            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
+                http://127.0.0.1:8095/health 2>/dev/null) || code=000
+            [ "$code" = "200" ] && { ok "standalone back online: :8095/health = 200"; return; }
+            tries=$((tries + 1))
+            sleep 5
+        done
+        fail "standalone did not come back online within 60s — check journalctl -u ${STANDALONE_UNIT}"
+        exit 1
+    fi
+    ok "standalone re-enabled and started (dry-run)"
+}
+
+# --- Main entry points --------------------------------------------------------
+
+do_apply() {
+    log "Mode: APPLY (live changes will be made)"
+    echo
+
+    run_guards
+    step_stop_standalone
+    step_repoint_bridge
+    step_verify_bridge
+    step_verify_e2e
+
+    echo
+    ok "Migration complete."
+    log "  Standalone hal0-qwen3tts.service is stopped and disabled."
+    log "  Hermes bridge now routes qwen3 TTS through hal0 slot via :8080."
+    log "  The 'hal0-voice' switch continues to work (reads tts_voice.conf)."
+    log "  Run 'hal0-voice status' to confirm :8095 is now served by the slot."
+    log "  See handoffs/qwen3tts-standalone-to-slot-migration-2026-06-28.md §7 for post-migration cleanup."
+}
+
+do_dry_run() {
+    log "Mode: DRY-RUN (no changes will be made)"
+    echo
+
+    # Guards still run to report precondition status.
+    run_guards
+    step_stop_standalone
+    step_repoint_bridge
+    step_verify_bridge
+    step_verify_e2e
+
+    echo
+    log "Dry-run complete. Re-run with --apply to make changes."
+}
+
+do_rollback() {
+    log "Mode: ROLLBACK"
+    echo
+
+    step_rollback_bridge
+    step_rollback_standalone
+
+    echo
+    ok "Rollback complete."
+    log "  Standalone hal0-qwen3tts.service re-enabled and started."
+    log "  Hermes bridge reverted to ${OLD_TTS_URL}."
+    log "  Check: curl -s http://127.0.0.1:8095/health"
+}
+
+# --- Dispatch -----------------------------------------------------------------
+
+case "$MODE" in
+    apply)    do_apply ;;
+    dry-run)  do_dry_run ;;
+    rollback) do_rollback ;;
+esac


### PR DESCRIPTION
## Summary

This PR is **prep-only**. It does not change any running code, does not touch
the live `hal0-qwen3tts.service`, and makes zero live state changes. It
delivers the documentation and tooling needed to safely retire the standalone
TTS service once the hal0-native qwen3tts slot (from PR #972 + follow-ups) is
deployed and verified on CT105.

- `handoffs/qwen3tts-standalone-to-slot-migration-2026-06-28.md` — migration
  runbook: preconditions, port-collision analysis, Hermes bridge repoint
  details, step-by-step cutover, and rollback.
- `scripts/migrate-qwen3tts-to-slot.sh` — idempotent, guarded migration
  script (`bash -n` validated, NOT executed).

## Guard / dry-run design

The script defaults to `--dry-run` and refuses to act without an explicit
`--apply` flag. Before any state change, three guards must pass:

1. `hal0-slot@qwen3tts` state == `"ready"` (via `/api/slots/qwen3tts`)
2. `/v1/audio/speech` via the hal0 front door returns a non-empty WAV
3. Kokoro fallback slot is healthy on `:8084`

All edits to `/var/lib/hal0/.hermes/` are done as the `hal0` user (never
root) to avoid flipping ownership and taking the Hermes gateway offline.

## Port-collision decision

Both the standalone service and the slot TOML default to port `8095`. They
cannot coexist on that port. The script stops the standalone **first**, then
the hal0 slot manager takes over `8095`. The brief window (~30–90 s) during
which no qwen3tts backend is available is covered by the Hermes kokoro
fallback leg already present in `hal0-voice-tts.py`.

## Hermes bridge repoint

**File:** `/var/lib/hal0/.hermes/scripts/hal0-voice-tts.py`

**Old default:** `QWEN3_URL = os.environ.get("QWEN3TTS_URL", "http://127.0.0.1:8095/v1/audio/speech")`

**New default:** `QWEN3_URL = os.environ.get("QWEN3TTS_URL", "http://127.0.0.1:8080/v1/audio/speech")`

The `QWEN3TTS_URL` env-var override path is preserved for out-of-band
configuration. The `hal0-voice {qwen3|kokoro}` switch continues to work
unchanged (it reads `tts_voice.conf`, which is independent of the URL).

## Live state verification

Zero live changes were made. Read-only commands run against CT105:
- `cat /etc/systemd/system/hal0-qwen3tts.service`
- `systemctl status hal0-qwen3tts.service --no-pager`
- `cat /var/lib/hal0/.hermes/scripts/hal0-voice-tts.py`
- `cat /var/lib/hal0/.hermes/tts_voice.conf`
- `grep "tts:" /var/lib/hal0/.hermes/config.yaml`
- `cat /usr/local/bin/hal0-voice`
- `curl -s http://127.0.0.1:8080/api/slots` (read-only)
- `curl -s http://127.0.0.1:8080/api/slots/qwen3tts` (read-only)
- `curl -s http://127.0.0.1:8095/health` (read-only)
- `curl -s http://127.0.0.1:8080/v1/audio/speech ... -o /dev/null` (read-only probe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)