### PR TITLE
ci(toolbox): wire hal0-toolbox-qwen3tts build+push to ghcr.io

### DIFF
--- a/.github/workflows/toolbox.yml
+++ b/.github/workflows/toolbox.yml
@@ -1,0 +1,170 @@
+name: Toolbox image build
+
+# Build and push hal0 toolbox container images to ghcr.io/hal0ai/.
+#
+# Current images managed here:
+#   - hal0-toolbox-qwen3tts  (Qwen3-TTS ROCm GPU TTS backend)
+#
+# Previous toolbox images (vulkan, rocm, flm, moonshine, kokoro, comfyui) were
+# built and pushed in ad-hoc CI runs and are not yet wired to this workflow.
+# This workflow is the "never-built .github/workflows/toolbox.yml" referenced
+# in scripts/update-toolbox-digests.sh; qwen3tts is the first image to have a
+# durable build-on-push workflow.
+#
+# Digest pinning: after a successful push, the published digest lands on
+# ghcr.io.  Run `scripts/update-toolbox-digests.sh` on main to query the
+# registry and patch manifest.json with the new digest before cutting a
+# release.  `release.yml` refuses to publish while any toolbox_images digest
+# is null.
+#
+# Runner: ubuntu-latest (x86_64, standard GitHub-hosted).  Building a
+# ROCm/PyTorch-based image only requires pulling the base layers and running
+# pip install — no GPU hardware or ROCm runtime is needed at build time.
+# The resulting image is linux/amd64 and requires an AMD GPU at run time.
+#
+# Trigger:
+#   - push/PR that touches the qwen3tts Dockerfile or its context directory
+#   - workflow_dispatch for manual (re)builds — e.g. after base-image updates
+#
+# See: packaging/toolbox/qwen3tts.Dockerfile
+#      packaging/toolbox/qwen3tts/qwen3tts_server.py
+#      scripts/update-toolbox-digests.sh
+#      docs: PLAN.md §12 (toolbox images)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packaging/toolbox/qwen3tts.Dockerfile"
+      - "packaging/toolbox/qwen3tts/**"
+  pull_request:
+    paths:
+      - "packaging/toolbox/qwen3tts.Dockerfile"
+      - "packaging/toolbox/qwen3tts/**"
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Push to ghcr.io (true) or build-only dry-run (false)"
+        type: boolean
+        default: true
+
+# Cancel superseded PR runs; never cancel a push to main.
+concurrency:
+  group: toolbox-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  packages: write   # required to push to ghcr.io/hal0ai/
+
+jobs:
+  # ── qwen3tts ────────────────────────────────────────────────────────────────
+  qwen3tts:
+    name: hal0-toolbox-qwen3tts
+    runs-on: ubuntu-latest
+    # Build time is dominated by pulling the ~4 GB rocm/pytorch base image and
+    # running pip install; 60 min is generous but safe for a cold cache.
+    timeout-minutes: 60
+
+    env:
+      IMAGE: ghcr.io/hal0ai/hal0-toolbox-qwen3tts
+      TAG: v1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # Log in to ghcr.io so the push step (and the base-image pull, which is
+      # public but benefits from auth to avoid rate limits) is authenticated.
+      # On PRs `packages: write` is not granted for fork PRs, so we skip login
+      # and push there — the build still runs for validation.
+      - name: Log in to ghcr.io
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Set up Docker Buildx so we get BuildKit features (layer caching,
+      # --cache-from, multi-stage optimisation).
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Derive image tags from the Git context:
+      #   main push  → ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1  (the stable tag)
+      #              → ghcr.io/hal0ai/hal0-toolbox-qwen3tts:main (mutable branch ref)
+      #   PR         → ghcr.io/hal0ai/hal0-toolbox-qwen3tts:pr-<N>  (build-only, no push)
+      #   tag push   → ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1  (same stable tag)
+      #   manual     → ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1
+      - name: Compute image tags + labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=${{ env.TAG }},enable=${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
+            type=ref,event=branch
+            type=ref,event=pr
+          labels: |
+            org.opencontainers.image.title=hal0-toolbox-qwen3tts
+            org.opencontainers.image.description=Qwen3-TTS multilingual GPU TTS backend (ROCm) for hal0
+            org.opencontainers.image.source=https://github.com/Hal0ai/hal0
+            org.opencontainers.image.documentation=https://github.com/Hal0ai/hal0/blob/main/packaging/toolbox/qwen3tts.Dockerfile
+
+      # Build (and push on non-PR runs unless workflow_dispatch chose dry-run).
+      # Context: packaging/toolbox/qwen3tts/ — this is the directory that
+      # qwen3tts.Dockerfile's COPY instruction targets (qwen3tts_server.py).
+      # The Dockerfile path is relative to the repo root.
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: packaging/toolbox/qwen3tts
+          file: packaging/toolbox/qwen3tts.Dockerfile
+          push: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.push == true) }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Layer cache: read from and write back to the GitHub Actions cache.
+          # The rocm/pytorch base is ~4 GB — caching the layers dramatically
+          # reduces rebuild time when only qwen3tts_server.py or pip deps change.
+          cache-from: type=gha,scope=toolbox-qwen3tts
+          cache-to: type=gha,mode=max,scope=toolbox-qwen3tts
+          platforms: linux/amd64
+          provenance: false
+
+      # Emit the published digest so it's easy to copy into manifest.json
+      # (or pipe into scripts/update-toolbox-digests.sh --patch).
+      - name: Report published digest
+        if: steps.build.outputs.digest != ''
+        run: |
+          echo "Published: ${{ env.IMAGE }}:${{ env.TAG }}"
+          echo "Digest:    ${{ steps.build.outputs.digest }}"
+          echo ""
+          echo "To pin this digest in manifest.json, run on main:"
+          echo "  scripts/update-toolbox-digests.sh"
+          echo ""
+          echo "Or patch manually:"
+          echo "  jq '.toolbox_images.qwen3tts.digest = \"${{ steps.build.outputs.digest }}\"' manifest.json > tmp && mv tmp manifest.json"
+        shell: bash
+
+      - name: Summary
+        run: |
+          {
+            echo "## hal0-toolbox-qwen3tts build"
+            echo ""
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              echo "**PR build — image was NOT pushed** (push is skipped on PRs to avoid"
+              echo "publishing unreviewed images)."
+            else
+              echo "**Pushed:** \`${{ env.IMAGE }}:${{ env.TAG }}\`"
+              if [[ -n "${{ steps.build.outputs.digest }}" ]]; then
+                echo ""
+                echo "**Digest:** \`${{ steps.build.outputs.digest }}\`"
+                echo ""
+                echo "Run \`scripts/update-toolbox-digests.sh\` on main to pin this digest"
+                echo "in \`manifest.json\` before the next release."
+              fi
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+        shell: bash

--- a/manifest.json
+++ b/manifest.json
@@ -35,6 +35,11 @@
       "digest": "sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2",
       "_notes": "live-validated on CT105 2026-06-11 (Wan2.2/Qwen-Image/Flux/SDXL on gfx1151); repinned from unpublished hal0-toolbox-comfyui (Phase D)",
       "_upstream_reference": "https://github.com/comfyanonymous/ComfyUI"
+    },
+    "qwen3tts": {
+      "tag": "ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1",
+      "digest": null,
+      "_notes": "Qwen3-TTS-12Hz-1.7B-CustomVoice multilingual GPU TTS (ROCm); OpenAI-compat /v1/audio/speech. Digest is null until the first successful CI push via .github/workflows/toolbox.yml — run scripts/update-toolbox-digests.sh on main after the first build to pin it."
     }
   },
   "_legacy_toolboxes": {


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/toolbox.yml` — the first durable CI workflow to build and push a hal0 toolbox container image. This is what `scripts/update-toolbox-digests.sh` has long called the "never-built `.github/workflows/toolbox.yml`"; qwen3tts (added in #972) is the first image to have an automated build.
- Adds `manifest.json` `toolbox_images.qwen3tts` with `"digest": null` — the live digest populates on first successful push, after which `scripts/update-toolbox-digests.sh` on main pins it (same pattern as all other toolbox entries). `release.yml` already gates on non-null digests.

## Pattern used

There is **no pre-existing toolbox build workflow** in the repo. Prior images (vulkan, rocm, flm, moonshine, kokoro, comfyui) were built locally or in ad-hoc CI runs and pushed manually; their digests were then pinned in `manifest.json` by running `scripts/update-toolbox-digests.sh`. This PR creates `toolbox.yml` as the canonical build workflow.

The workflow mirrors the conventions established by `ci.yml` and `release.yml`:
- `ubuntu-latest` runner (x86_64, standard GitHub-hosted — same as all other workflows)
- `actions/checkout@v6`, `docker/login-action@v3`, `docker/setup-buildx-action@v3`, `docker/build-push-action@v6`, `docker/metadata-action@v5`
- `concurrency` group with PR cancellation, no-cancel on main pushes
- Least-privilege permissions (`contents: read` + `packages: write` for ghcr.io push)

The qwen3tts image is based on `rocm/pytorch` (AMD/x86_64, ~4 GB base). **No GPU is required at build time** — the Dockerfile only runs `apt-get` and `pip install`; ROCm hardware is required at run time only.

## Digest pinning

The digest cannot exist until CI runs a successful build. The flow after merge:

1. Push to main triggers `toolbox.yml` → builds and pushes `ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1`
2. Run `scripts/update-toolbox-digests.sh` on main — it queries ghcr.io for the content digest and patches `manifest.json.toolbox_images.qwen3tts.digest` in place
3. Commit the patched manifest before the next release
4. `release.yml` will then include the pinned qwen3tts digest in the release manifest

Until step 2 is done, `release.yml` will refuse to publish (it already gates on non-null digests for all `toolbox_images` entries — see the Python block in step "Generate release manifest").

## Validation

- All 8 workflow YAML files parse cleanly (`python3 -c "import yaml; yaml.safe_load(open(f))"`)
- `bash -n scripts/update-toolbox-digests.sh` passes — the digest script requires no changes (it iterates `toolbox_images` dynamically from manifest.json, so qwen3tts is automatically included)
- `tests/config` (296 tests) pass with the manifest change — `pytest tests/config -q`
- `manifest.json` JSON is valid and contains all 7 `toolbox_images` keys

## Runner / arch caveat

The `rocm/pytorch` base image is linux/amd64 only, so the build targets `platforms: linux/amd64`. The GH-hosted `ubuntu-latest` runner is x86_64 — this matches. Build time is dominated by pulling the ~4 GB base image; GHA layer cache (`cache-from/to: type=gha`) will cut subsequent builds to minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)