### PR TITLE
feat(capabilities): wire voice.tts engine switch (Kokoro CPU / Qwen3-TTS GPU)

### DIFF
--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -89,6 +89,54 @@ _CAPABILITY_TO_SLOT_TYPE: dict[str, str] = {
 }
 
 
+# ── voice.tts engine switch (deferred follow-up to #972) ──────────────────────
+#
+# TTS is engine-selected WITHIN the single ``tts`` slot: the operator picks a
+# device in the voice.tts card and the slot swaps which provider it runs.
+#   - cpu      → Kokoro (provider ``kokoro``, profile ``tts``)
+#   - gpu-rocm → Qwen3-TTS (provider ``qwen3tts``, profile ``tts-qwen3``)
+# Each entry feeds both the catalog enumeration below and ``_profile_for_fit``
+# so the picker and the apply path agree on which profile/provider a device
+# implies.
+_TTS_ENGINES: tuple[dict[str, str], ...] = (
+    {
+        "id": "kokoro-v1",
+        "device": "cpu",
+        "provider": "kokoro",
+        "profile": "tts",
+    },
+    {
+        "id": "qwen3-tts",
+        "device": "gpu-rocm",
+        "provider": "qwen3tts",
+        "profile": "tts-qwen3",
+    },
+)
+
+#: device → tts profile name (the engine switch). Used by ``_profile_for_fit``
+#: in BOTH this module and the orchestrator so picker fit and apply-time
+#: reconciliation resolve the same profile.
+TTS_DEVICE_TO_PROFILE: dict[str, str] = {e["device"]: e["profile"] for e in _TTS_ENGINES}
+
+#: GPU TTS resolves to Qwen3 regardless of which GPU backend the card offers
+#: (only ROCm is wired today, but a future Vulkan TTS engine would slot here).
+_TTS_GPU_PROFILE = "tts-qwen3"
+
+
+def tts_profile_for_device(device: str) -> str:
+    """Return the TTS slot profile a device selection implies.
+
+    The engine switch: ``cpu`` → Kokoro's ``tts`` profile, any GPU backend
+    → Qwen3's ``tts-qwen3`` profile. Unknown/empty devices fall back to the
+    CPU Kokoro profile (the safe default — it needs no GPU passthrough).
+    """
+    if device in TTS_DEVICE_TO_PROFILE:
+        return TTS_DEVICE_TO_PROFILE[device]
+    if device in {"gpu-rocm", "gpu-vulkan"}:
+        return _TTS_GPU_PROFILE
+    return "tts"
+
+
 # ── Backends ──────────────────────────────────────────────────────────────────
 
 
@@ -573,7 +621,85 @@ def _flat_rows_for_capability(
         seen.add(key)
         rows.append(npu_row)
 
+    for tts_row in _tts_rows_for_capability(capability, registry=registry):
+        key = (tts_row["id"], tts_row["backend"])
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(tts_row)
+
     return rows
+
+
+def _tts_rows_for_capability(
+    capability: str,
+    *,
+    registry: ModelRegistry | None = None,
+) -> list[dict[str, Any]]:
+    """Enumerate the two TTS engines for the voice.tts picker.
+
+    The deferred follow-up to #972 makes the voice.tts card a real engine
+    switch. Neither engine surfaces through the curated/registry fan-out
+    above: ``kokoro-v1`` is ``bundle_only`` (hidden from dropdowns) and the
+    operator-staged ``qwen3-tts`` weights aren't a curated entry at all. So
+    this enumerates both directly, mirroring how :func:`_flm_rows_for_capability`
+    injects the NPU rows.
+
+    Each engine emits one row on its legal device with the provider/profile
+    the apply path will write into the single ``tts`` slot
+    (:func:`tts_profile_for_device`). ``downloaded``/``pullable`` come from
+    the registry lookup so the picker shows an honest ⬇ chip.
+    """
+    if capability != "tts":
+        return []
+
+    from hal0.registry.curated import CURATED_BY_ID
+
+    out: list[dict[str, Any]] = []
+    for engine in _TTS_ENGINES:
+        curated = CURATED_BY_ID.get(engine["id"])
+        out.append(
+            {
+                "id": engine["id"],
+                "backend": engine["device"],
+                "provider": engine["provider"],
+                "size_gb": _size_gb(curated) if curated is not None else 0.0,
+                "capabilities": ["tts"],
+                # Kokoro is HF-pullable (curated coords); Qwen3-TTS weights are
+                # operator-staged self-managed (no pull route) — fall back to
+                # the registry for both so an installed engine reads as ready.
+                "downloaded": _is_downloaded(curated, registry=registry)
+                if curated is not None
+                else _registry_downloaded(engine["id"], registry=registry),
+                "pullable": _is_pullable(curated, registry=registry)
+                if curated is not None
+                else False,
+            }
+        )
+    return out
+
+
+def _registry_downloaded(model_id: str, *, registry: ModelRegistry | None) -> bool:
+    """True iff ``model_id`` resolves to an on-disk path in the registry.
+
+    Used for self-managed TTS weights (qwen3-tts) that have no curated entry:
+    the registry is the only signal that the operator staged them.
+    """
+    if registry is None:
+        return False
+    try:
+        if not registry.has(model_id):
+            return False
+        reg_entry = registry.get(model_id)
+    except Exception:
+        return False
+    reg_path = getattr(reg_entry, "path", None)
+    if not isinstance(reg_path, str) or not reg_path:
+        return False
+    try:
+        return Path(reg_path).exists()
+    except OSError:
+        return False
 
 
 def _profile_for_fit(capability: str, device: str) -> ResolvedProfile | None:
@@ -584,12 +710,15 @@ def _profile_for_fit(capability: str, device: str) -> ResolvedProfile | None:
     selection schema carries an explicit profile.
     """
     profile_name: str | None = None
-    if device == "npu":
+    if capability == "tts":
+        # Engine switch within the tts slot — GPU resolves Qwen3, CPU Kokoro.
+        # Must precede the generic gpu→llama branch (a TTS slot never runs the
+        # rocm/vulkan llama profile). See ``tts_profile_for_device``.
+        profile_name = tts_profile_for_device(device)
+    elif device == "npu":
         profile_name = DEVICE_DEFAULT_PROFILES.get("npu")
     elif device in {"gpu-rocm", "gpu-vulkan"}:
         profile_name = DEVICE_DEFAULT_PROFILES.get(device)
-    elif capability == "tts":
-        profile_name = "tts"
     elif capability == "image":
         profile_name = "comfyui"
     if not profile_name:

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -37,7 +37,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from hal0.capabilities.catalog import models_for_capability
+from hal0.capabilities.catalog import models_for_capability, tts_profile_for_device
 from hal0.capabilities.config import (
     CapabilityConfig,
     CapabilitySelection,
@@ -635,12 +635,18 @@ class CapabilityOrchestrator:
         avoid treating generic CPU as kokoro except for TTS.
         """
         profile_name: str | None = None
-        if device == "npu":
+        if capability == "tts":
+            # TTS is engine-selected within the single ``tts`` slot: GPU →
+            # Qwen3-TTS (``tts-qwen3`` → Qwen3TTSProvider), CPU → Kokoro
+            # (``tts``). This must precede the generic gpu→llama branch below,
+            # which would otherwise hand a TTS slot the rocm/vulkan llama
+            # profile (wrong runtime family — the slot would never start the
+            # TTS image).
+            profile_name = tts_profile_for_device(device)
+        elif device == "npu":
             profile_name = DEVICE_DEFAULT_PROFILES.get("npu")
         elif device in {"gpu-rocm", "gpu-vulkan"}:
             profile_name = DEVICE_DEFAULT_PROFILES.get(device)
-        elif capability == "tts":
-            profile_name = "tts"
         elif capability == "image":
             profile_name = "comfyui"
         if not profile_name:
@@ -691,6 +697,14 @@ class CapabilityOrchestrator:
         slot_type = _CHILD_TO_SLOT_TYPE.get(child) if child else None
         if slot_type:
             cfg_dict["type"] = slot_type
+        # voice.tts engine switch (follow-up to #972): a (re)created tts slot
+        # must carry the engine's runtime profile + type so the spawn routes to
+        # the right provider (cpu→Kokoro, gpu→Qwen3). The builtin tts.toml
+        # normally exists so this path is the deleted-slot fallback.
+        if child == "tts":
+            cfg_dict["type"] = "tts"
+            cfg_dict["runtime"] = "container"
+            cfg_dict["profile"] = tts_profile_for_device(selection.device)
         try:
             await self._slot_manager.create(slot_name, cfg_dict)
         except Exception as exc:

--- a/src/hal0/slot_config/__init__.py
+++ b/src/hal0/slot_config/__init__.py
@@ -182,7 +182,7 @@ class SlotConfigStore:
 
         slot_path = self._slot_path(selection.slot_name)
         slot_before = _read_toml_or_none(slot_path)
-        slot_after = self._reconciled_slot(slot_before, selection.selection)
+        slot_after = self._reconciled_slot(slot_before, selection)
 
         return ChangeSet(
             before=(
@@ -244,7 +244,7 @@ class SlotConfigStore:
         return capabilities_toml_payload(cfg)
 
     def _reconciled_slot(
-        self, raw_before: dict[str, Any] | None, selection: CapabilitySelection
+        self, raw_before: dict[str, Any] | None, slot_selection: SlotSelection
     ) -> dict[str, Any] | None:
         """Project an enabled selection onto the existing slot TOML dict.
 
@@ -259,7 +259,16 @@ class SlotConfigStore:
             legacy alias) written, translated via :mod:`hal0.model_meta`,
           - the ``ctx_size`` → ``context_size`` alias folded (#585) so
             the two keys can't diverge on disk.
+
+        voice.tts engine switch (follow-up to #972): the two TTS engines
+        (Kokoro CPU / Qwen3-TTS GPU) live in the SAME ``tts`` slot, selected
+        by device. The device alone is not enough to start the right engine —
+        the slot's ``profile`` is what ``container._spec_provider_for`` resolves
+        to a runtime family. So for the ``tts`` child we also derive and write
+        the engine's ``profile`` (cpu → ``tts``, gpu → ``tts-qwen3``); without
+        this the slot would keep Kokoro's profile and never spawn Qwen3.
         """
+        selection = slot_selection.selection
         if raw_before is None or not selection.enabled:
             return raw_before
 
@@ -275,6 +284,13 @@ class SlotConfigStore:
             updates["provider"] = selection.provider
         if selection.model:
             updates["model"] = {"default": selection.model}
+
+        # TTS engine switch: derive the slot profile from the picked device so
+        # the GPU/CPU choice actually swaps the provider inside the one tts slot.
+        tts_profile = self._tts_profile_for(slot_selection)
+        if tts_profile is not None:
+            updates["profile"] = tts_profile
+
         if not updates:
             return raw_before
 
@@ -294,6 +310,23 @@ class SlotConfigStore:
             model["context_size"] = model.pop("ctx_size")
             after["model"] = model
         return after
+
+    @staticmethod
+    def _tts_profile_for(slot_selection: SlotSelection) -> str | None:
+        """Engine profile a voice.tts selection implies, or ``None``.
+
+        Only the ``tts`` child carries an engine switch — every other
+        capability leaves the slot's profile untouched (most have none). The
+        canonical (device → profile) mapping lives in
+        :func:`hal0.capabilities.catalog.tts_profile_for_device`; imported
+        lazily here to keep this module import-light (the cycle the module
+        docstring guards against).
+        """
+        if slot_selection.child != "tts":
+            return None
+        from hal0.capabilities.catalog import tts_profile_for_device
+
+        return tts_profile_for_device(slot_selection.selection.device)
 
 
 # ── file-state IO ────────────────────────────────────────────────────────────

--- a/tests/capabilities/test_tts_capability_switch.py
+++ b/tests/capabilities/test_tts_capability_switch.py
@@ -1,0 +1,274 @@
+"""voice.tts capability switch — Kokoro (CPU) vs Qwen3-TTS (GPU/ROCm).
+
+The deferred follow-up to #972 (which landed the Qwen3TTSProvider
+foundation): wire the picker so an operator can select between the two
+TTS engines *within the single ``tts`` slot*. Three surfaces are exercised
+here:
+
+  - the catalog enumerates BOTH engines for voice.tts with their legal
+    device/backends (``kokoro-v1`` on cpu, ``qwen3-tts`` on gpu-rocm),
+  - ``_profile_for_fit`` resolves the right runtime profile per device:
+    tts+gpu → ``tts-qwen3`` (Qwen3TTSProvider), tts+cpu → ``tts``
+    (KokoroProvider) — NOT the generic llama rocm/vulkan profile,
+  - the apply path (SlotConfigStore) rewrites the single ``tts`` slot's
+    ``profile`` to match the picked engine, so the selection actually
+    swaps which provider the one slot spawns.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from hal0.capabilities import catalog as catalog_mod
+from hal0.capabilities.catalog import models_for_capability
+from hal0.capabilities.orchestrator import CapabilityOrchestrator
+
+# ── catalog enumeration ──────────────────────────────────────────────────────
+#
+# The catalog backends carry resolved profile/runtime_family, which come from
+# ProfileCatalog reading the on-disk profiles.toml. ``tmp_hal0_home`` (no file
+# → built-in SEED_PROFILES, which carry ``tts-qwen3``) isolates these from the
+# host's live profiles.toml.
+
+
+def test_voice_tts_catalog_enumerates_both_engines(tmp_hal0_home: str) -> None:
+    rows = models_for_capability("tts", registry=None)
+    ids = {row["id"] for row in rows}
+    assert "kokoro-v1" in ids, "Kokoro CPU engine missing from voice.tts catalog"
+    assert "qwen3-tts" in ids, "Qwen3-TTS GPU engine missing from voice.tts catalog"
+
+
+def test_kokoro_row_offers_cpu_backend(tmp_hal0_home: str) -> None:
+    rows = models_for_capability("tts", registry=None)
+    kokoro = next((r for r in rows if r["id"] == "kokoro-v1"), None)
+    assert kokoro is not None
+    backends = {b["id"]: b for b in kokoro["backends"]}
+    assert "cpu" in backends
+    assert backends["cpu"]["provider"] == "kokoro"
+    # The CPU engine resolves the Kokoro profile, not a llama profile.
+    assert backends["cpu"]["runtime_family"] == "kokoro"
+    assert backends["cpu"]["profile"] == "tts"
+
+
+def test_qwen3_row_offers_gpu_rocm_backend(tmp_hal0_home: str) -> None:
+    rows = models_for_capability("tts", registry=None)
+    qwen = next((r for r in rows if r["id"] == "qwen3-tts"), None)
+    assert qwen is not None
+    backends = {b["id"]: b for b in qwen["backends"]}
+    assert "gpu-rocm" in backends
+    assert backends["gpu-rocm"]["provider"] == "qwen3tts"
+    # The GPU engine resolves the Qwen3 TTS profile (→ Qwen3TTSProvider),
+    # NOT the generic rocm llama profile.
+    assert backends["gpu-rocm"]["runtime_family"] == "qwen3tts"
+    assert backends["gpu-rocm"]["profile"] == "tts-qwen3"
+
+
+# ── _profile_for_fit (catalog + orchestrator must agree) ─────────────────────
+#
+# These resolve a ResolvedProfile through ProfileCatalog (reads profiles.toml),
+# so they take ``tmp_hal0_home`` for the same SEED_PROFILES isolation.
+
+
+def test_catalog_profile_for_fit_tts_gpu_is_qwen3(tmp_hal0_home: str) -> None:
+    profile = catalog_mod._profile_for_fit("tts", "gpu-rocm")
+    assert profile is not None
+    assert profile.name == "tts-qwen3"
+    assert profile.runtime_family == "qwen3tts"
+
+
+def test_catalog_profile_for_fit_tts_cpu_is_kokoro(tmp_hal0_home: str) -> None:
+    profile = catalog_mod._profile_for_fit("tts", "cpu")
+    assert profile is not None
+    assert profile.name == "tts"
+    assert profile.runtime_family == "kokoro"
+
+
+def test_orchestrator_profile_for_fit_tts_gpu_is_qwen3(tmp_hal0_home: str) -> None:
+    orch = CapabilityOrchestrator.__new__(CapabilityOrchestrator)
+    profile = orch._profile_for_fit("tts", "gpu-rocm")
+    assert profile is not None
+    assert profile.name == "tts-qwen3"
+    assert profile.runtime_family == "qwen3tts"
+
+
+def test_orchestrator_profile_for_fit_tts_cpu_is_kokoro(tmp_hal0_home: str) -> None:
+    orch = CapabilityOrchestrator.__new__(CapabilityOrchestrator)
+    profile = orch._profile_for_fit("tts", "cpu")
+    assert profile is not None
+    assert profile.name == "tts"
+    assert profile.runtime_family == "kokoro"
+
+
+def test_orchestrator_profile_for_fit_non_tts_gpu_unchanged(tmp_hal0_home: str) -> None:
+    # Regression guard: non-TTS gpu selections still resolve the llama
+    # rocm/vulkan profile — the tts special-case must not leak.
+    orch = CapabilityOrchestrator.__new__(CapabilityOrchestrator)
+    profile = orch._profile_for_fit("embed", "gpu-rocm")
+    assert profile is not None
+    assert profile.name == "rocm"
+
+
+# ── tts_profile_for_device (the shared device→profile mapping) ────────────────
+
+
+def test_tts_profile_for_device_mapping() -> None:
+    from hal0.capabilities.catalog import tts_profile_for_device
+
+    assert tts_profile_for_device("cpu") == "tts"
+    assert tts_profile_for_device("gpu-rocm") == "tts-qwen3"
+    # Any GPU backend resolves the Qwen3 engine; unknown/empty → safe CPU default.
+    assert tts_profile_for_device("gpu-vulkan") == "tts-qwen3"
+    assert tts_profile_for_device("") == "tts"
+
+
+# ── apply path: the engine swap lands in the single ``tts`` slot ──────────────
+
+
+def _read_tts_slot(home: str) -> dict[str, Any]:
+    with open(Path(home) / "etc" / "hal0" / "slots" / "tts.toml", "rb") as f:
+        return tomllib.load(f)
+
+
+def _write_tts_slot(home: str, *, device: str, profile: str) -> None:
+    """Write the canonical single ``tts`` slot in a known engine state."""
+    slots_dir = Path(home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "tts.toml").write_text(
+        "\n".join(
+            [
+                'name = "tts"',
+                'type = "tts"',
+                f'device = "{device}"',
+                'runtime = "container"',
+                f'profile = "{profile}"',
+                "enabled = true",
+                "port = 8084",
+                "[model]",
+                'default = "kokoro-v1"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_apply_selecting_qwen3_gpu_swaps_tts_slot_to_qwen3_profile(
+    tmp_hal0_home: str,
+) -> None:
+    """Picking qwen3 / gpu-rocm rewrites the ``tts`` slot's profile to tts-qwen3.
+
+    The slot starts on Kokoro (profile=tts, device=cpu). After the apply the
+    SAME slot TOML must carry profile=tts-qwen3, device=gpu-rocm, and
+    provider=qwen3tts — so the next spawn routes through Qwen3TTSProvider.
+    This is the selection-within-the-single-tts-slot contract.
+    """
+    from hal0.capabilities.config import CapabilitySelection
+    from hal0.slot_config import SlotConfigStore, SlotSelection
+
+    _write_tts_slot(tmp_hal0_home, device="cpu", profile="tts")
+    store = SlotConfigStore()
+    selection = CapabilitySelection.model_validate(
+        {
+            "device": "gpu-rocm",
+            "provider": "qwen3tts",
+            "model": "qwen3-tts",
+            "enabled": True,
+        }
+    )
+    cs = store.apply(SlotSelection(slot="voice", child="tts", slot_name="tts", selection=selection))
+    store.commit(cs)
+
+    on_disk = _read_tts_slot(tmp_hal0_home)
+    assert on_disk["profile"] == "tts-qwen3", f"engine not swapped to qwen3: {on_disk!r}"
+    assert on_disk["device"] == "gpu-rocm", on_disk
+    assert on_disk["provider"] == "qwen3tts", on_disk
+    assert on_disk["model"]["default"] == "qwen3-tts", on_disk
+
+
+def test_apply_selecting_kokoro_cpu_swaps_tts_slot_back_to_kokoro_profile(
+    tmp_hal0_home: str,
+) -> None:
+    """Picking kokoro / cpu reverts the ``tts`` slot to the Kokoro profile.
+
+    Starting from the GPU engine state, selecting CPU Kokoro must rewrite the
+    same slot to profile=tts, device=cpu, provider=kokoro.
+    """
+    from hal0.capabilities.config import CapabilitySelection
+    from hal0.slot_config import SlotConfigStore, SlotSelection
+
+    _write_tts_slot(tmp_hal0_home, device="gpu-rocm", profile="tts-qwen3")
+    store = SlotConfigStore()
+    selection = CapabilitySelection.model_validate(
+        {"device": "cpu", "provider": "kokoro", "model": "kokoro-v1", "enabled": True}
+    )
+    cs = store.apply(SlotSelection(slot="voice", child="tts", slot_name="tts", selection=selection))
+    store.commit(cs)
+
+    on_disk = _read_tts_slot(tmp_hal0_home)
+    assert on_disk["profile"] == "tts", f"engine not reverted to kokoro: {on_disk!r}"
+    assert on_disk["device"] == "cpu", on_disk
+    assert on_disk["provider"] == "kokoro", on_disk
+
+
+def test_apply_disabled_tts_selection_does_not_rewrite_profile(tmp_hal0_home: str) -> None:
+    """A disabled selection never rewrites the slot (parity with #697)."""
+    from hal0.capabilities.config import CapabilitySelection
+    from hal0.slot_config import SlotConfigStore, SlotSelection
+
+    _write_tts_slot(tmp_hal0_home, device="cpu", profile="tts")
+    before = _read_tts_slot(tmp_hal0_home)
+    store = SlotConfigStore()
+    selection = CapabilitySelection.model_validate(
+        {"device": "gpu-rocm", "provider": "qwen3tts", "model": "qwen3-tts", "enabled": False}
+    )
+    cs = store.apply(SlotSelection(slot="voice", child="tts", slot_name="tts", selection=selection))
+    store.commit(cs)
+    assert _read_tts_slot(tmp_hal0_home) == before, "disabled selection must not rewrite slot"
+
+
+def test_apply_non_tts_child_does_not_write_profile(tmp_hal0_home: str) -> None:
+    """Regression: a non-tts child's slot reconciliation never injects a profile.
+
+    The profile derivation is gated on the tts child only — an embed apply
+    must leave the slot TOML's profile untouched (it has none), so the engine
+    switch can't leak into other capabilities.
+    """
+    from hal0.capabilities.config import CapabilitySelection
+    from hal0.slot_config import SlotConfigStore, SlotSelection
+
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "embed.toml").write_text(
+        "\n".join(
+            [
+                'name = "embed"',
+                "port = 8082",
+                'device = "gpu-vulkan"',
+                'provider = "llama-server"',
+                "enabled = true",
+                "[model]",
+                'default = "nomic-embed-text-v1.5-q8_0"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    store = SlotConfigStore()
+    selection = CapabilitySelection.model_validate(
+        {
+            "device": "gpu-rocm",
+            "provider": "llama-server",
+            "model": "nomic-embed-text-v1.5-q8_0",
+            "enabled": True,
+        }
+    )
+    cs = store.apply(
+        SlotSelection(slot="embed", child="embed", slot_name="embed", selection=selection)
+    )
+    store.commit(cs)
+
+    with open(slots_dir / "embed.toml", "rb") as f:
+        on_disk = tomllib.load(f)
+    assert "profile" not in on_disk, f"embed slot must not gain a profile: {on_disk!r}"


### PR DESCRIPTION
## What

Deferred follow-up to #972 (which merged the `Qwen3TTSProvider` foundation). Makes the **voice.tts** capability card a real engine switch so an operator can choose between **Kokoro (CPU)** and **Qwen3-TTS (GPU/ROCm)** for `/v1/audio/speech`.

## Design — selection within the single `tts` slot

This uses the **"selection within the single `tts` slot"** model, **not** two coexisting slots routed by the dispatcher. The dispatcher already pins `/audio/speech` → the `tts` slot, so the front door needs no change. Picking an engine swaps *which provider that one slot spawns* by rewriting the slot's runtime `profile` (`container._spec_provider_for` resolves the provider from the profile's `runtime_family`):

- `kokoro / cpu`  → `tts` profile → `KokoroProvider`
- `qwen3tts / gpu-rocm` → `tts-qwen3` profile → `Qwen3TTSProvider`

## Three gaps closed

1. **Catalog enumeration** (`capabilities/catalog.py`): `voice.tts` was effectively empty — `kokoro-v1` is `bundle_only` (filtered from dropdowns) and `qwen3-tts` has no curated entry at all, so the switch had nothing to pick. New `_tts_rows_for_capability` enumerates **both** engines directly (mirroring `_flm_rows_for_capability`): `kokoro-v1` on `cpu`/`kokoro`, `qwen3-tts` on `gpu-rocm`/`qwen3tts`, with honest `downloaded`/`pullable` chips.

2. **`_profile_for_fit`** (both `orchestrator.py` and `catalog.py`): for `capability=="tts"` it hardcoded the Kokoro `tts` profile, and the generic `gpu-rocm/gpu-vulkan` branch returned the **llama** `rocm`/`vulkan` profile for a TTS slot (wrong runtime family). Now resolves the engine profile **per device first** (tts+gpu → `tts-qwen3`, tts+cpu → `tts`), via the new shared `catalog.tts_profile_for_device()` so picker fit and apply-time reconciliation agree.

3. **Apply path** (`slot_config/SlotConfigStore._reconciled_slot`): the selection's `device`/`provider`/`model` were reconciled into the `tts` slot TOML, but **not `profile`** — so picking the GPU engine left Kokoro's profile and the slot never spawned Qwen3. Now derives and writes `profile` for the `tts` child only (gated — non-tts children are untouched, so the switch can't leak). `_ensure_slot_exists` also stamps `profile` + `type=tts` for the deleted-slot fallback (the builtin `tts.toml` normally exists, so the swap path covers the common case).

## Tested

`tests/capabilities/test_tts_capability_switch.py` (13 tests):
- catalog enumerates both engines with the right device/provider/profile/runtime_family rows;
- `_profile_for_fit` returns `tts-qwen3` for tts+gpu and `tts` for tts+cpu in **both** modules, plus a regression guard that non-tts gpu still resolves the llama profile;
- `tts_profile_for_device` device→profile map (incl. gpu-vulkan → qwen3, empty → cpu default);
- apply-path profile swap: gpu→qwen3, cpu→kokoro, disabled no-op, non-tts no-leak.

## Quality gates

- `pytest tests/capabilities tests/providers tests/profiles tests/config tests/slots tests/dispatcher -q` → **1074 passed, 5 skipped** (skips unrelated). Capability/catalog `tests/api` subset also green (26 passed).
- `ruff check` + `ruff format --check` clean on changed files.
- `mypy` clean on changed src files. (Two pre-existing `list?[dict]` attr-defined errors in untouched `orchestrator.py` `_npu_anchor_status`/`_set_flm_modality` are present on `origin/main` and not introduced here.)

## Remaining edges for the orchestrator

- The CI image build/digest pin for `hal0-toolbox-qwen3tts` and the live migration off the standalone `hal0-qwen3tts.service` remain separate follow-ups (out of scope here — code only, no live service touched).
- The GPU TTS path currently only wires `gpu-rocm` (matching the `tts-qwen3` seed profile, `device_class=gpu`/`backend=rocm`). `tts_profile_for_device` already maps any GPU backend → `tts-qwen3`, so a future Vulkan TTS engine would need its own profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)