### PR TITLE
chore(manifest): pin hal0-toolbox-qwen3tts image digest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -38,7 +38,7 @@
     },
     "qwen3tts": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1",
-      "digest": null,
+      "digest": "sha256:c3a4606de1488ef594c3552057985186bc01f4af7e79a23bbd2c9cf275e70838",
       "_notes": "Qwen3-TTS-12Hz-1.7B-CustomVoice multilingual GPU TTS (ROCm); OpenAI-compat /v1/audio/speech. Digest is null until the first successful CI push via .github/workflows/toolbox.yml — run scripts/update-toolbox-digests.sh on main after the first build to pin it."
     }
   },


### PR DESCRIPTION
Pins the published content digest for `ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1` in `manifest.json`, satisfying `release.yml`'s null-digest gate for this image.

## How
- `toolbox.yml` (from #975) built + pushed the image on `main` — run [28345384705](https://github.com/Hal0ai/hal0/actions/runs/28345384705), success.
- Digest `sha256:c3a4606de1488ef594c3552057985186bc01f4af7e79a23bbd2c9cf275e70838` resolved via `scripts/update-toolbox-digests.sh` (ghcr v2 manifest API).

## Scope
Single-line change — only the `qwen3tts` digest. The update script *also* tried to null `comfyui`'s `docker.io@sha256` pin (its curl path only resolves `ghcr.io` refs and nulls everything else); that regression was **intentionally not applied**. Worth a follow-up fix to the script so it preserves `@sha256`-pinned non-ghcr tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)