### PR TITLE
chore(release): bump version to 0.8.2b3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.8.2b2"
+version = "0.8.2b3"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Release-bump for **v0.8.2b3**, cutting the qwen3tts work landed since 0.8.2b2:
- #972 `Qwen3TTSProvider` foundation
- #973 dispatcher upstream-auth fix
- #976 voice.tts capability switch (Kokoro CPU / Qwen3 GPU)
- #975 toolbox image CI build/push
- #974 standalone→slot migration prep
- #977 pinned qwen3tts image digest

All `toolbox_images` digests are non-null (release.yml null-digest gate ✓). After merge, tag `v0.8.2b3` triggers `release.yml` → publishes to `releases.hal0.dev/stable.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)