### PR TITLE
chore(release): docs + installer hygiene; prep v0.8.2b4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,32 @@
 # AGENTS.md
 
 Agent-facing entry point: what kind of work happens here, what shape it
-takes in v0.3, and where to find the contracts a teammate AGENT needs.
+takes, and where to find the contracts a teammate AGENT needs.
 
 ## hal0 in one paragraph
 
 hal0 is an open-source home AI inference platform: a single FastAPI
-service (`hal0-api`) that orchestrates Lemonade-served chat / embed /
-voice / image models, plus a v0.3 bundled-agent surface where a
-third-party agent runtime (Hermes-Agent today, pi-coder in v0.4) runs
+service (`hal0-api`) that orchestrates chat / embed / voice / image
+models, each served by its own per-slot container runtime
+(`src/hal0/providers/container.py` — one podman container per slot),
+plus a bundled-agent surface where a third-party agent runtime runs
 as a sibling systemd unit with hal0 wired in as its local AI provider.
 
-## v0.3 agent surface (current)
+## Agent surface (current)
 
-A v0.3 bundled agent is:
+A bundled agent is:
 
 * A systemd unit `hal0-agent@<id>.service` (template, parameterised by
-  agent id). v0.3 ships `hermes` only — see ADR-0004 single-pick.
-* Provisioned by `hal0 agent provision hermes` → the 12-phase
+  agent id). Two agents ship as first-class bundled agents —
+  `BUNDLED_AGENTS = ("pi-coder", "hermes")` in
+  `src/hal0/agents/manager.py`; `hermes` is the default integration.
+* Provisioned by `hal0 agent provision hermes` → the 15-phase
   `src/hal0/agents/hermes_provision.py` orchestrator
-  (preflight → install → env_probe → home_init → config_write →
-  mcp_wire → context_link → namespace_register → model_automap →
-  voice_wire → smoke_tests → self_report). Idempotent + checkpointed
-  via `/var/lib/hal0/state/agents/hermes/provision.json`.
+  (preflight → install → env_probe → home_init → install_artifacts →
+  persona_seed → config_write → mcp_wire → context_link →
+  namespace_register → model_automap → voice_wire →
+  gateway_secrets_wire → smoke_tests → self_report). Idempotent +
+  checkpointed via `/var/lib/hal0/state/agents/hermes/provision.json`.
 * Reachable through hal0-api's chat surface — `/api/agents/{id}/{events,
   submit,session/*}` (PR-9 WS proxy + REST shim) — never directly
   exposed to the browser. Hermes itself binds 127.0.0.1:9119 inside the
@@ -35,7 +39,7 @@ A v0.3 bundled agent is:
 ### Install + lifecycle
 
 ```
-sudo hal0 agent provision hermes        # one-shot 12-phase bootstrap
+sudo hal0 agent provision hermes        # one-shot 15-phase bootstrap
 sudo systemctl status hal0-agent@hermes  # unit health
 hal0 agent personas                      # list personas (TOML store)
 hal0 agent personas activate coder       # swap active persona
@@ -52,7 +56,7 @@ A persona is a TOML file under `/var/lib/hal0/agents/hermes/personas/`
 declaring (`id`, `display_name`, `summary`, `system_prompt`,
 `tools_allowed`, `memory_namespace`, `preferred_upstream`,
 `preferred_model`, `approval.{default_policy, auto_approve,
-require_approval}`). v0.3 seeds two: `hermes` (general) and `coder`.
+require_approval}`). The provisioner seeds two: `hermes` (general) and `coder`.
 The active persona is the contents of `active.txt`; switching personas
 swaps the system-prompt scope on the next turn without restarting the
 agent process. Configured per-agent via `GET/POST
@@ -63,11 +67,12 @@ agent process. Configured per-agent via `GET/POST
 `hermes_provision` registers `hal0-memory` and `hal0-admin` as MCP
 servers in hermes's config.toml. The plugin slot for memory is
 implemented by the hal0-bundled hermes plugin at
-`src/hal0/agents/hermes/plugins/memory_cognee/` — a `MemoryProvider`
-subclass that turns memory into part of the system prompt
+`src/hal0/agents/hermes/plugins/memory_hindsight/` — a `MemoryProvider`
+subclass (memory is Hindsight-backed; see ADR-0023) that turns memory
+into part of the system prompt
 (`system_prompt_block`) rather than a tool the agent has to remember
 to call. Plugin host (PR-7) lets the dashboard mount upstream Hermes
-plugin bundles (the v0.3 kanban plugin today) inside an iframe with a
+plugin bundles (the kanban plugin today) inside an iframe with a
 shadow-DOM-isolated SDK shim.
 
 ### Approvals + audit
@@ -84,35 +89,44 @@ back for the dashboard Activity tab.
 
 ### Issue tracker
 
-GitHub Issues on `Hal0ai/hal0` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+GitHub Issues on `Hal0ai/hal0` via the `gh` CLI.
 
 ### Triage labels
 
-Default vocabulary — `needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`. See `docs/agents/triage-labels.md`.
+Default vocabulary — `needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`.
 
 ### Domain docs
 
-Single-context. `CONTEXT.md` at root; ADRs at `docs/internal/adr/`. See `docs/agents/domain.md`.
+Single-context. `CONTEXT.md` at root. Published docs live under `docs/`
+(Starlight `.mdx`); ADRs are operator-only notes kept out of the tree
+(`docs/internal/` is gitignored), so they are referenced by number in
+prose below, not by file link.
 
-## v0.3 agent contracts (for deeper dives)
+## Agent contracts (for deeper dives)
 
-* [`docs/agents/hermes/CONFIG.md`](docs/agents/hermes/CONFIG.md) —
-  persona TOML, overrides.yaml, allowlist.toml, runtime.json,
-  hermes.env, plugin manifests, hot-reload-vs-restart semantics.
-* [`docs/agents/hermes/SERVICE.md`](docs/agents/hermes/SERVICE.md) —
-  hal0-agent@.service unit shape, sandboxing, restart endpoint
-  reference.
-* [`docs/internal/adr/0004-agents.md`](docs/internal/adr/0004-agents.md)
-  — bundling decision + single-pick.
-* [`docs/internal/adr/0011-agent-identity-cards.md`](docs/internal/adr/0011-agent-identity-cards.md)
-  — agent identity card schema.
-* [`docs/internal/adr/0013-mcp-client-allow-list.md`](docs/internal/adr/0013-mcp-client-allow-list.md)
-  — server-axis + tool-axis default-deny.
-* [`docs/internal/adr/0018-upstream-hermes-pin-and-upgrade.md`](docs/internal/adr/0018-upstream-hermes-pin-and-upgrade.md)
-  — upstream pin + weekly drift detection.
-* [`docs/internal/adr/0019-v0_3-hermes-integration.md`](docs/internal/adr/0019-v0_3-hermes-integration.md)
-  — v0.3 integration roll-up (composer over xterm, plugin host,
-  persona TOML, composite upstream).
+Published agent docs:
+
+* [`docs/concepts/agents.mdx`](docs/concepts/agents.mdx) — the bundled-agent
+  model: sandboxed service, personas (tool gating), approval queue,
+  per-persona spending budgets.
+* [`docs/guides/run-agents.mdx`](docs/guides/run-agents.mdx) — the
+  `hal0 agent` CLI: provisioning, personas, approvals, budgets.
+* [`docs/concepts/memory.mdx`](docs/concepts/memory.mdx) — the
+  Hindsight-backed memory subsystem operators and agents share.
+
+Standing decisions (ADRs are operator-only and untracked; stated inline):
+
+* **Agent bundling** — hal0 does not build its own agent runtime; it
+  bundles third-party runtimes (`pi-coder`, `hermes`) and runs them
+  safely as sandboxed sibling units.
+* **MCP allow-list** — the MCP client is default-deny on two axes
+  (server-axis + tool-axis); a persona's `tools_allowed` opens the gate.
+* **Upstream pin** — the bundled Hermes runtime is pinned with periodic
+  drift detection rather than tracking upstream `main`.
+* **ADR-0023 (current canonical ADR)** — LLM roles are `agent`
+  (default anchor) + `utility`; the older `chat` / `primary` roles are
+  retired. Memory is Hindsight-only (Cognee removed). hal0-api runs as
+  root (the earlier hardened-perms mode was removed).
 
 ## Shipping: deploy + PR workflow (how teammate agents land work here)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # hal0 architecture
 
 This document covers hal0's internal architecture. For the user-facing
-shape (install, ports, filesystem layout), see [`docs/install.md`](./docs/install.md).
+shape (install, ports, filesystem layout), see [`docs/getting-started/install.mdx`](./docs/getting-started/install.mdx).
 For scope and roadmap, see [`PLAN.md`](./PLAN.md).
 
 ## Process model
@@ -46,9 +46,9 @@ src/hal0/
 │   ├── mcp_mount.py # mounts hal0-admin + hal0-memory MCP servers
 │   └── middleware/  # error envelope, request id, log scrub
 ├── agents/          # bundled-agent provisioner + driver
-│   ├── hermes_provision.py    # 12-phase Hermes bootstrap
+│   ├── hermes_provision.py    # 15-phase Hermes bootstrap
 │   ├── hermes/                # hal0-bundled Hermes plugins
-│   │   └── plugins/memory_cognee/  # hal0-cognee MemoryProvider
+│   │   └── plugins/memory_hindsight/  # hal0-hindsight MemoryProvider
 │   ├── personas.py            # persona TOML store + hot-reload nudge
 │   ├── manager.py             # single-pick install / uninstall
 │   └── mcp_client.py          # MCP client allow-list (ADR-0013)
@@ -232,7 +232,7 @@ model advertised and will 4xx on inference attempts (issue #31).
 ## v0.3 agents subsystem
 
 A bundled agent in v0.3 is a third-party agent runtime (Hermes-Agent
-today, pi-coder in v0.4) running as a sibling systemd unit with hal0
+and pi-coder, single-pick at install) running as a sibling systemd unit with hal0
 wired in as its local AI provider. The boundary is intentionally
 narrow: hal0 owns provisioning, identity, MCP wiring, and the chat-
 surface proxy. Runtime is whatever the bundled upstream does natively.
@@ -250,13 +250,13 @@ surface proxy. Runtime is whatever the bundled upstream does natively.
                   ▼                                ▼
         ┌────────────────────┐         ┌──────────────────────┐
         │  hal0-memory       │ ◀────── │  composite "hal0"    │
-        │  hal0-admin        │  Cognee │  upstream → /v1/*    │
+        │  hal0-admin        │ Hindsight│  upstream → /v1/*    │
         └────────────────────┘         └──────────────────────┘
 ```
 
 ### Surfaces
 
-* **Provision** — `hal0 agent provision hermes` → 12-phase orchestrator
+* **Provision** — `hal0 agent provision hermes` → 15-phase orchestrator
   in `src/hal0/agents/hermes_provision.py`. Idempotent + checkpointed
   via `/var/lib/hal0/state/agents/hermes/provision.json`.
 * **Service** — `hal0-agent@<id>.service` (template; v0.3 instances:
@@ -276,13 +276,16 @@ surface proxy. Runtime is whatever the bundled upstream does natively.
 * **Personas** — `src/hal0/agents/personas.py` owns the TOML store;
   `src/hal0/api/agents/personas.py` is the REST shim. Hot-reload nudges
   hermes via JSON-RPC; system-prompt scope swaps on the next turn.
-* **Memory** — `hal0-memory` MCP wraps `src/hal0/memory/cognee_wrapper.py`.
-  Per-agent private namespace = `private:<agent_id>` per ADR-0005 §3.
+* **Memory** — `hal0-memory` MCP wraps the engine-neutral
+  `MemoryProvider` (`src/hal0/memory/provider.py`), whose default engine
+  is Hindsight (`src/hal0/memory/hindsight_provider.py`); the cognee
+  wrapper was removed in ADR-0023. Per-agent private namespace =
+  `private:<agent_id>` per ADR-0005 §3.
 * **Skills catalog** — `GET /api/agents/skills` returns the static
   catalog (`HERMES_TOOL_CATALOG` + `HAL0_MCP_TOOL_CATALOG`) the
   dashboard sidebar renders. Bumps ride ADR-0018's weekly drift PRs.
 * **Identity** — agent identity card published once into the `agents`
-  Cognee dataset per ADR-0011. `X-hal0-Agent` is the header the proxy
+  memory namespace per ADR-0011. `X-hal0-Agent` is the header the proxy
   injects on every outbound hop.
 
 ### Module map
@@ -290,10 +293,10 @@ surface proxy. Runtime is whatever the bundled upstream does natively.
 | Module                                         | Owns                                         |
 |------------------------------------------------|----------------------------------------------|
 | `src/hal0/agents/manager.py`                   | single-pick install / uninstall              |
-| `src/hal0/agents/hermes_provision.py`          | 12-phase Hermes bootstrap orchestrator       |
+| `src/hal0/agents/hermes_provision.py`          | 15-phase Hermes bootstrap orchestrator       |
 | `src/hal0/agents/personas.py`                  | persona TOML store + hot-reload helper       |
 | `src/hal0/agents/mcp_client.py`                | MCP server-axis + tool-axis classifier       |
-| `src/hal0/agents/hermes/plugins/memory_cognee/`| hal0-cognee MemoryProvider plugin            |
+| `src/hal0/agents/hermes/plugins/memory_hindsight/`| hal0-hindsight MemoryProvider plugin       |
 | `src/hal0/api/agents/personas.py`              | `/api/agents/{id}/personas[/{pid}/activate]` |
 | `src/hal0/api/agents/chat_proxy.py`            | WS proxy + session REST shim                 |
 | `src/hal0/api/agents/restart.py`               | `POST /api/agents/{id}/restart`              |
@@ -318,6 +321,6 @@ HEAD. Bump process: review issue, edit shim adapters if needed, run
 ## See also
 
 - [`PLAN.md`](./PLAN.md) — v1 scope, modules ported from haloai, milestones
-- [`docs/slots.md`](./docs/slots.md) — slot lifecycle state machine *(TODO)*
-- [`docs/dispatcher.md`](./docs/dispatcher.md) — routing algorithm *(TODO)*
-- [`docs/install.md`](./docs/install.md) — install flow + filesystem layout *(TODO)*
+- [`docs/reference/slot-lifecycle.mdx`](./docs/reference/slot-lifecycle.mdx) — slot lifecycle state machine
+- [`docs/concepts/architecture.mdx`](./docs/concepts/architecture.mdx) — control plane + dispatcher routing
+- [`docs/getting-started/install.mdx`](./docs/getting-started/install.mdx) — install flow + filesystem layout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,70 @@ v0.2) may carry breaking changes; patch releases inside a minor line
 
 Tags older than v0.2.0 ship release notes inside the GitHub release
 page; this CHANGELOG starts at v0.2.0 (the Lemonade migration cut).
-For ADR-level architecture context see `docs/internal/adr/`.
+ADR-level architecture decisions are kept internal (the `docs/internal/`
+tree is gitignored, #638) and referenced by number throughout the code.
+
+## [v0.8.2b4] — 2026-06-30
+
+Documentation and installer hygiene — no runtime behaviour change. This
+release re-baselines the engineering docs to the current v0.8.x reality
+(container runtime, Hindsight memory, agent/utility roles) and fixes a
+handful of installer drift bugs surfaced by a codebase assessment sweep.
+Safe upgrade from v0.8.2b3.
+
+### Changed
+- **Docs re-baselined to v0.8.x.** Swept the Lemonade→container-runtime and
+  Cognee→Hindsight terminology out of `AGENTS.md`, `ARCHITECTURE.md`,
+  `CONTEXT.md`, `PLAN.md`, and `README.md`; corrected the Hermes provisioner
+  to its real 15-phase pipeline; refreshed version/status lines; and rewrote the
+  (largely fictional) `hal0-service-management` codebase-map reference against
+  the current `src/hal0/` tree. Marked the shipped Stacks and voice-stack
+  superpowers plans as completed.
+- **Dead ADR links fixed.** Tracked docs no longer link into the gitignored
+  `docs/internal/adr/` tree (#638); surviving decisions are inlined and ADRs are
+  referenced by number. (In-code citation sweep tracked in #984.)
+
+### Fixed
+- **qwen3tts migration script aligned with the `tts`-slot model.** The
+  standalone-to-slot migration script's Guard 1 checked a non-existent
+  `qwen3tts` slot (always 404) and Guard 3 checked a removed kokoro `:8084`
+  fallback; both are corrected to the deployed design where Qwen3-TTS serves
+  from the canonical `tts` slot via `voice.tts`. (#979)
+- **`uninstall.sh` now removes all three sudoers grants.** It only removed
+  `hal0-benchctl`, leaking `hal0-agentenv` and `hal0-comfyui` behind on uninstall.
+- **Hermes private memory bank seeded under its canonical name.** `install.sh`
+  seeded `private__hermes-agent`, which the server (which derives the bank from the
+  agent-id via `PRIVATE_PREFIX="private:"`) never matches — corrected to
+  `private:hermes` so the pre-seeded retain-mission/dispositions actually apply.
+- **Dropped the obsolete Lemonade boot-contention comment** from
+  `installer/comfyui/scripts/comfy-up.sh`.
+
+## [v0.8.2b3] — 2026-06-29
+
+GPU text-to-speech lands: Qwen3-TTS now runs as a hal0-native slot with a
+one-switch swap between the Kokoro (CPU) and Qwen3-TTS (GPU) engines, plus a
+GPU benchmark harness and dashboard polish. Safe upgrade from v0.8.2b2.
+
+### Added
+- **GPU Qwen3-TTS as a hal0-native slot.** New `Qwen3TTSProvider` serves
+  Qwen3-TTS from the `tts` slot, with a `voice.tts` capability switch that swaps
+  the engine between Kokoro (CPU) and Qwen3-TTS (GPU) without reconfiguring the
+  slot. (#972, #976) The toolbox image builds + pushes to ghcr.io and its digest
+  is pinned in `manifest.json`. (#975, #977) Ships a standalone-to-slot migration
+  runbook + guarded script. (#974)
+- **GPU benchmark harness.** A GPU benchmarking toolbox with the `hal0-benchctl`
+  seam and accompanying agent skills. (#967) Dashboard gains an iGPU usage gauge
+  and a prefill TTFT readout. (#968) Topbar adds Kanban / Agent-Chat launchers, a
+  global agent chat, and an Archived lane. (#966)
+
+### Fixed
+- **Dispatcher injects upstream auth headers for remote providers**, so requests
+  routed to authenticated remote upstreams carry their credentials. (#973)
+- **UI builds land reliably on deploy** (no-cache index + install to the served
+  `dist`). (#969)
+
+### Docs
+- Benchmarking toolbox UI/feature handoff. (#971)
 
 ## [v0.8.2b2] — 2026-06-24
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # hal0 — Glossary
 
-Project terminology. Update inline as new terms get resolved during design sessions or PR reviews. NOT a spec — this is just the canonical names + short disambiguators. For decision rationale, see `docs/internal/adr/`.
+Project terminology. Update inline as new terms get resolved during design sessions or PR reviews. NOT a spec — this is just the canonical names + short disambiguators. For decision rationale, see the ADRs (ADR-0023 fixes the canonical LLM roles; most ADR files are gitignored, so decisions that still matter are inlined here).
 
 ---
 
@@ -9,48 +9,48 @@ Project terminology. Update inline as new terms get resolved during design sessi
 Two distinct senses in this repo. Disambiguate by context.
 
 1. **internal dev sense** — a Claude teammate (the multi-agent fan-out pattern used in `docs/models-slots-impl-plan.md` and `CONTRIBUTING.md:93`). Never user-facing. About *how we build hal0*, not what hal0 is.
-2. **product sense** — a Phase 8 bundled agent app (`pi-coder` or `Hermes-Agent`). User-facing. About *what users do with hal0*. See ADR-0004.
+2. **product sense** — a bundled agent app (`pi-coder` or `Hermes-Agent`). User-facing. About *what users do with hal0*.
 
 When in doubt, ask which sense applies before writing the word.
 
 ## Agents subsystem
 
-**Stripped.** Previously a haloai-style first-party agent runtime (PLAN.md §1 Strip listed it as gone). The Phase 8 product-sense agents (above) are NOT a revival — they're third-party bundled apps with a fundamentally different architecture. Do not reintroduce the first-party runtime.
+**Stripped.** Previously a haloai-style first-party agent runtime (PLAN.md §1 Strip listed it as gone). The product-sense bundled agents (above) are NOT a revival — they're third-party bundled apps with a fundamentally different architecture. Do not reintroduce the first-party runtime.
 
 ## bundled agent
 
-Phase 8 product feature. A third-party agent application installed alongside hal0, prewired to use hal0 as its local AI provider and to consume hal0's MCP servers. v0.2 supports `pi-coder` (CLI shape) and `Hermes-Agent` (service shape). Single-pick at install. See ADR-0004.
+A third-party agent application installed alongside hal0, prewired to use hal0 as its local AI provider and to consume hal0's MCP servers. Supports `pi-coder` (CLI shape) and `Hermes-Agent` (service shape). Single-pick at install.
 
-## Cognee
+## Hindsight
 
-The embedded memory engine adopted from v0.2 (Apache 2.0). Defaults: SQLite + LanceDB + Kuzu — all embedded, no external services. Powers `/mcp/memory`. See ADR-0005.
+The memory engine (ADR-0023; client at `src/hal0/memory/hindsight_client.py`, provider at `hindsight_provider.py`). Replaced the earlier Cognee engine — the Cognee wrapper was removed in c4c77a80. Powers `/mcp/memory` and the `/api/memory/*` REST surface. (Cognee is dead vocabulary in this repo; do not reintroduce it.)
 
-## dataset (Cognee)
+## namespace (memory)
 
-Cognee's namespace primitive. hal0's namespace rule (v0.2): default `shared` for all clients; per-client `--private` toggle promotes that client's writes to `private:<client_id>`. Multi-user revisits the rule in Phase 9 (future ADR pending — ADR-0006 was reassigned to Lemonade migration). See ADR-0005 §3.
+Hindsight's per-client scope primitive. hal0's namespace rule: default `shared` for all clients; per-client `--private` toggle promotes that client's writes to `private:<client_id>`. Private-mode reads expand to `[shared, private:<client_id>]` so a caller sees their own scoped items alongside the shared bucket. Resolution lives in `src/hal0/memory/namespace.py`, shared by the MCP + REST surfaces. Multi-user hardening of the rule is a future concern.
 
 ## MCP server (hal0-exposed)
 
-hal0 exposes two MCP servers (Phase 8, v0.2):
-- `/mcp/admin` — wraps existing `/api/*` routes (slot/model/hardware/log admin). Tool catalog rule: ships iff it maps to an existing route. See ADR-0004 §4.
-- `/mcp/memory` — wraps Cognee's Python API. See ADR-0005 §2.
+hal0 exposes two MCP servers:
+- `/mcp/admin` — wraps existing `/api/*` routes (slot/model/hardware/log admin). Tool catalog rule: ships iff it maps to an existing route.
+- `/mcp/memory` — wraps the Hindsight memory surface.
 
-Both reachable by any MCP-speaking client: bundled agents, Claude Code, future RAG services. Auth via existing Bearer token (ADR-0001).
+Both reachable by any MCP-speaking client: bundled agents, Claude Code, future RAG services. Auth via the API's existing Bearer token.
 
 ## memory
 
 Two distinct memory surfaces coexist on a hal0 box. They serve different scopes — don't displace one with the other.
 
 - **pi-memory-md** — project-scoped markdown files in the repo. Pi-coder's native extension, kept in place by the hal0 pi-coder shim. NOT touched by hal0's memory MCP.
-- **hal0 memory MCP** — cross-session, cross-agent, cross-app. Backed by Cognee. Default namespace `shared`. See ADR-0005.
+- **hal0 memory MCP** — cross-session, cross-agent, cross-app. Backed by Hindsight. Default namespace `shared`.
 
 ## pi-coder
 
-Bundled agent option (CLI shape). Upstream: `badlogic/pi-mono`. Minimal-by-design (4 tools: read/write/edit/bash; no native MCP, no native memory). hal0's pi shim adds `pi-mcp-adapter` (MCP routing) + leaves `pi-memory-md` in place. Track-latest upstream (NOT pinned). See ADR-0004 §3, §6.
+Bundled agent option (CLI shape). Upstream: `badlogic/pi-mono`. Minimal-by-design (4 tools: read/write/edit/bash; no native MCP, no native memory). hal0's pi shim adds `pi-mcp-adapter` (MCP routing) + leaves `pi-memory-md` in place. Track-latest upstream (NOT pinned).
 
 ## Hermes-Agent
 
-Bundled agent option (service shape). User-owned upstream — grows native hal0-awareness on the Hermes side rather than via a hal0-owned shim. Runs as `hal0-agent-hermes.service`. Sidebar link-out OWUI-style in dashboard. See ADR-0004 §3, §6.
+Bundled agent option (service shape). User-owned upstream — grows native hal0-awareness on the Hermes side rather than via a hal0-owned shim. Runs as `hal0-agent-hermes.service`. Sidebar link-out OWUI-style in dashboard.
 
 ## skills
 
@@ -58,36 +58,36 @@ Overloaded THREE ways. Default to sense (3) in hal0 product context.
 
 1. **Claude Code skills** — the markdown + YAML-frontmatter format Claude Code itself uses (e.g. `~/.claude/skills/`). Internal tooling for dev sessions; not a hal0 product feature.
 2. **stripped haloai skills subsystem** — historical, gone (PLAN.md §1 Strip section). Do not reintroduce.
-3. **hal0 platform skills** = MCP tools exposed by the admin MCP server (Phase 8). An agent calling `/mcp/admin` sees `slot_list`, `model_swap`, etc. as its "skills." This is the sense used in hal0 product copy and ADR-0004.
+3. **hal0 platform skills** = MCP tools exposed by the admin MCP server. An agent calling `/mcp/admin` sees `slot_list`, `model_swap`, etc. as its "skills." This is the sense used in hal0 product copy.
 
-(Possible Phase 9+ stretch: agent-side skills in the `cognee-integrations/openclaw-skills` style — `SKILL.md` + YAML frontmatter + self-improving loop. If we ever ship that, it's a separate noun and gets its own gloss entry.)
+(Possible future stretch: agent-side skills in the `openclaw-skills` style — `SKILL.md` + YAML frontmatter + self-improving loop. If we ever ship that, it's a separate noun and gets its own gloss entry.)
 
 ## device
 
-Per-slot hardware preference. Field on `SlotConfig` replacing v0.1.x's overloaded `backend` field (which mixed providers and backends). Enum: `gpu-rocm` | `gpu-vulkan` | `cpu` | `npu`. Default for new installs: `gpu-rocm`. `model_meta.device_to_backend(device)` maps it to a `(recipe, llamacpp)` pair, and the device selects the container profile (`config/schema.DEVICE_DEFAULT_PROFILES`): `gpu-rocm` → `rocm` (ROCm-FP4 llama-server toolbox), `gpu-vulkan` → `vulkan`, `cpu` → `tts`, `npu` → `flm` (the FLM NPU toolbox).
+Per-slot hardware preference. Field on `SlotConfig` replacing v0.1.x's overloaded `backend` field (which mixed providers and backends). Enum: `gpu-rocm` | `gpu-vulkan` | `cpu` | `npu`. Default for new installs: `gpu-rocm`. `model_meta.device_to_backend(device)` maps it to a `(recipe, llamacpp)` pair, and the device selects the container profile (`config/schema.DEVICE_DEFAULT_PROFILES`): `gpu-rocm` → `rocm` (ROCm-FP4 llama-server image), `gpu-vulkan` → `vulkan`, `cpu` → `tts`, `npu` → `flm` (the FLM NPU image).
 
 Note: spike data showed `gpu-vulkan` is much slower than `gpu-rocm` for Strix Halo — the user-facing UI should advise `gpu-rocm` as the recommended default and label `gpu-vulkan` as fallback.
 
 ## slot
 
-A named, configured serving target — e.g. `primary`, `embed`, `stt`, `tts`, `img`, plus optional chat slots (`agent`, future others). NOT a memory or RAG primitive — slots serve inference, memory lives in `/mcp/memory`.
+A named, configured serving target — e.g. `agent`, `embed`, `stt`, `tts`, `img`, plus the `utility` helper slot and any user-defined ones. NOT a memory or RAG primitive — slots serve inference, memory lives in `/mcp/memory`.
 
-**Current runtime (container-per-slot, #652/#687).** A slot is one `hal0-slot@<name>.service` systemd unit whose `ExecStart` is a single `podman run` of the slot's container (llama-server, FLM, Kokoro, or ComfyUI). `SlotManager` dispatches lifecycle (load/unload/swap/status) through `ContainerProvider`; the profile (`/etc/hal0/profiles.toml`) supplies the image + bench-tuned flags, the slot TOML supplies model/port/`context_size`. Slot state (`ready`/`idle`/`serving`) comes from the state machine in `hal0.slots.state`, reconciled against `systemctl is-active` + a `/health` probe on the slot's loopback port. Slot identity persists in `capabilities.toml`; the runtime layer is the per-slot container.
+**Current runtime (container-per-slot, #652/#687).** A slot is one `hal0-slot@<name>.service` systemd unit whose `ExecStart` is a single `podman run` of the slot's container (llama-server, FLM, Kokoro, or ComfyUI). `SlotManager` dispatches lifecycle (load/unload/swap/status) through `ContainerProvider` (`src/hal0/providers/container.py`); the profile (`/etc/hal0/profiles.toml`) supplies the image + bench-tuned flags, the slot TOML supplies model/port/`context_size`. Slot state (`ready`/`idle`/`serving`) comes from the state machine in `hal0.slots.state`, reconciled against `systemctl is-active` + a `/health` probe on the slot's loopback port. Slot identity persists in `capabilities.toml`; the runtime layer is the per-slot container.
 
-(Historical: in v0.2, slots were a logical mapping onto a single shared `lemond` process with no per-slot systemd unit. The lemonade runtime was removed in the container-switchover epic, #687; the per-slot template unit returned, this time wrapping a podman container.)
+(Historical: slots once mapped logically onto a single shared `lemond` (Lemonade) process with no per-slot systemd unit. The Lemonade runtime was removed in the container-switchover epic, #687; the per-slot template unit returned, this time wrapping a podman container.)
 
 ### slot inventory
 
-A slot has exactly ONE `type` and ONE loaded model. **Slot identity is a bare name** (e.g., `chat`, `embed`, `rerank`, `agent`) — unique across the whole `capabilities.toml`. The `group` is a field on the slot's selection, used purely for dashboard rollup. `embed` and `rerank` are two separate slots filed under the `embed` group; same for `stt`/`tts` under `voice`. (The seeded `chat` slot was named `primary` in v0.1.x; `primary` is now a back-compat alias for `chat` in `SlotManager.SLOT_ALIASES`.)
+A slot has exactly ONE `type` and ONE loaded model. **Slot identity is a bare name** (e.g., `agent`, `utility`, `embed`, `rerank`) — unique across the whole `capabilities.toml`. The `group` is a field on the slot's selection, used purely for dashboard rollup. `embed` and `rerank` are two separate slots filed under the `embed` group; same for `stt`/`tts` under `voice`. The canonical chat roles are `agent` (default anchor) and `utility` (seeded helper) per ADR-0023; the pre-ADR `chat`/`primary` names are retired (a lingering operator-custom `chat` slot is reachable by its own name via generalized `hal0/<slot>` resolution, not an alias). The only surviving back-compat alias in `SlotManager.SLOT_ALIASES` is `agent-hermes` → `agent`.
 
 Migration note: the v0.1.x `capabilities.toml` shape `selections.<group>.<slot>` carries the group implicitly in the TOML path. The same TOML path is kept for back-compat but the canonical identity in code is the bare slot name.
 
-The seeded set is `SlotManager.SEEDED_SLOTS = (chat, embed, rerank, stt, tts, img, vision, agent)`; the NPU shadow slots `(stt-npu, embed-npu)` (`NPU_SEEDED_SLOTS`) seed only when the FastFlowLM `.deb` is installed.
+The seeded set is `SlotManager.SEEDED_SLOTS = (utility, embed, rerank, stt, tts, img, vision, agent)`; the NPU shadow slots `(stt-npu, embed-npu)` (`NPU_SEEDED_SLOTS`) seed only when the FastFlowLM `.deb` is installed.
 
 | Slot | type | UI group | Default at install |
 |---|---|---|---|
-| `chat` | `llm` | chat | seeded, empty model |
-| `agent` | `llm` | chat | seeded, empty (GPU MoE chat-role sibling of `chat`) |
+| `agent` | `llm` | chat | seeded, empty (default chat anchor — GPU MoE) |
+| `utility` | `llm` | chat | seeded, empty (seeded helper role) |
 | `embed` | `embedding` | embed | seeded, empty |
 | `rerank` | `reranking` | embed | seeded, empty |
 | `stt` | `transcription` | voice | seeded, empty |
@@ -99,7 +99,7 @@ The seeded slots are a **catalog**, not a stack — every selection is empty (`e
 
 ### group
 
-Pure UI rollup in `capabilities.toml` (`selections.<group>.<slot>`). Groups bundle related slots into one dashboard panel. v0.2 groups: `chat` (primary, agent, …), `embed` (embed, rerank), `voice` (stt, tts), `img` (img). Groups do NOT carry types or per-group state — slots do. Users adding custom slots pick which group to file under.
+Pure UI rollup in `capabilities.toml` (`selections.<group>.<slot>`). Groups bundle related slots into one dashboard panel. Groups: `chat` (agent, utility, vision, …), `embed` (embed, rerank), `voice` (stt, tts), `img` (img). Groups do NOT carry types or per-group state — slots do. Users adding custom slots pick which group to file under.
 
 ### user-defined slots
 
@@ -146,9 +146,9 @@ Type vocabulary: `llm`, `embedding`, `reranking`, `transcription`, `tts`, `image
 
 ## OmniRouter
 
-Client-side OpenAI tool-calling loop, owned by hal0 (it lives in hal0-api, not the inference container). The LLM in a `chat`-type slot is given a JSON tool catalog; it emits `tool_calls`; hal0 dispatches each to the appropriate `/api/v1/*` endpoint and folds the result back into the conversation.
+Client-side OpenAI tool-calling loop, owned by hal0 (it lives in hal0-api, not the inference container). The LLM in an `llm`-type slot is given a JSON tool catalog; it emits `tool_calls`; hal0 dispatches each to the appropriate `/api/v1/*` endpoint and folds the result back into the conversation.
 
-The tool set is per-bundle (a `collection.omni` manifest names which tools the LLM sees). v0.2 ships these 7 tools:
+The tool set is per-bundle (a `collection.omni` manifest names which tools the LLM sees). It ships these 7 tools:
 
 | Tool | Source | Endpoint | Target slot type | Required model labels |
 |---|---|---|---|---|
@@ -160,17 +160,17 @@ The tool set is per-bundle (a `collection.omni` manifest names which tools the L
 | `embed_text` | **hal0 custom** | `/v1/embeddings` | `embedding` | `embeddings` |
 | `rerank_documents` | **hal0 custom** | `/v1/rerank` | `reranking` | `reranking` |
 
-Deferred to v0.3: `route_to_chat` (LLM-driven persona swap; needs semantics ADR), `recall_memory` (depends on Cognee MCP maturity in Phase 8).
+Deferred: `route_to_chat` (LLM-driven persona swap; needs semantics decision), `recall_memory` (depends on the Hindsight memory MCP).
 
 Upstream tools are kept in sync via a checksum-pinned copy of `src/app/src/renderer/utils/toolDefinitions.json` at `src/hal0/omni_router/tool_definitions.json`. hal0 custom tools live next to them in the same JSON.
 
 **Dynamic tool filtering (per chat request).** hal0's OmniRouter client computes the active tool set at chat-start based on (a) which slots are `enabled = true` with a loadable model, AND (b) for label-gated tools like `analyze_image`, whether any enabled slot of the required type has a model with the required label. Only the active subset goes into the LLM prompt. LLMs without the `tool-calling` label receive no tools at all. Filtering re-runs at next dispatch when slot configuration changes mid-conversation.
 
-Bundle-level tool whitelists/blacklists are NOT supported in v0.2 (YAGNI until requested). The set is always derived from slot enablement.
+Bundle-level tool whitelists/blacklists are NOT supported (YAGNI until requested). The set is always derived from slot enablement.
 
 ## model namespace
 
-`registry.toml` (under `/var/lib/hal0/registry/`) is the **sole** model catalog — there is no second loader process to keep in sync (the lemonade `server_models.json` / `user_models.json` / `extra.*` split was removed with the runtime, #687). Every slot's `--model` path is a registry-backed file under the model store `/mnt/ai-models`.
+`registry.toml` (under `/var/lib/hal0/registry/`) is the **sole** model catalog — there is no second loader process to keep in sync (the Lemonade `server_models.json` / `user_models.json` / `extra.*` split was removed with the runtime, #687). Every slot's `--model` path is a registry-backed file under the model store `/mnt/ai-models`.
 
 The registry tags each row with a namespace bucket (`ns`) the dashboard renders as a badge:
 
@@ -196,7 +196,7 @@ Resolution rules:
 
 ## chat persona (DO NOT use "chat-duo")
 
-A user-facing label for "which chat slot is currently serving the dashboard chat surface". Implementation = each persona is just a chat slot (`primary`, `agent`, etc.). The UI offers a persona dropdown; the OmniRouter `route_to_chat` tool lets the LLM switch personas mid-conversation. "Chat-duo" was an early term that implied pairs — retired before it landed.
+A user-facing label for "which chat slot is currently serving the dashboard chat surface". Implementation = each persona is just an `llm`-type slot (`agent`, `utility`, etc.). The UI offers a persona dropdown; the OmniRouter `route_to_chat` tool lets the LLM switch personas mid-conversation. "Chat-duo" was an early term that implied pairs — retired before it landed.
 
 ## v0.1.x → v0.2 upgrade
 
@@ -222,11 +222,11 @@ Driver: v0.1.x audience is single-digit alpha users; migration script ROI is bad
 
 ## fresh install
 
-v0.2 installs ship **no pre-selected model stack**. capabilities.toml lands with empty selections (`enabled = false` for every group). First-run dashboard shows a **bundle picker** — 4 hardware-anchored tiers plus the vendor-blessed LMX bundle — with a "Skip — configure manually" path to a blank dashboard.
+Installs ship **no pre-selected model stack**. capabilities.toml lands with empty selections (`enabled = false` for every group). First-run dashboard shows a **bundle picker** — 4 hardware-anchored tiers plus the vendor-blessed LMX bundle — with a "Skip — configure manually" path to a blank dashboard.
 
 The bundle PICKER is the user's first action; the installer never silently chooses. Driver: hal0 is a platform, not a curated bundle; opinionation is a per-tier concept, not a default-install concept.
 
-## bundle tiers (v0.2 first-run picker)
+## bundle tiers (first-run picker)
 
 | Tier | Min unified RAM | `chat.primary` | `chat.coder` | Aux | NPU trio |
 |---|---|---|---|---|---|
@@ -245,7 +245,7 @@ Notes:
 
 ## two-tier scope
 
-Access-control pattern for the admin MCP per ADR-0004. Routine ops (slot status, `model_swap`, `hardware_probe`, `memory_add`, etc.) = autonomous. Capital-D destructives (`model_pull`, `slot_delete`, `config_write`, `memory_delete` >1 record, etc.) = gated via the dashboard approval inbox. No per-agent trust toggle (destructives must always be approved).
+Access-control pattern for the admin MCP. Routine ops (slot status, `model_swap`, `hardware_probe`, `memory_add`, etc.) = autonomous. Capital-D destructives (`model_pull`, `slot_delete`, `config_write`, `memory_delete` >1 record, etc.) = gated via the dashboard approval inbox. No per-agent trust toggle (destructives must always be approved).
 
 ---
 
@@ -253,15 +253,15 @@ Access-control pattern for the admin MCP per ADR-0004. Routine ops (slot status,
 
 ## agent identity card
 
-A memory item published by a bundled agent during its first-run bootstrap, recording who-it-is and how-to-reach-it. Lives in the dedicated `agents` Cognee dataset (NOT `shared`, NOT `private:*`), tagged `agent-identity`. Immutable — written once, cleaned on uninstall. Schema v1 pins required fields in `metadata`: `agent_id`, `display_name`, `namespace`, `hal0_state.{registered_at, bootstrap_version, hal0_version, hermes_version}`. The `text` field is a human-readable summary. See [ADR-0011](docs/internal/adr/0011-agent-identity-cards.md).
+A memory item published by a bundled agent during its first-run bootstrap, recording who-it-is and how-to-reach-it. Lives in the dedicated `agents` memory namespace (NOT `shared`, NOT `private:*`), tagged `agent-identity`. Immutable — written once, cleaned on uninstall. Schema v1 pins required fields in `metadata`: `agent_id`, `display_name`, `namespace`, `hal0_state.{registered_at, bootstrap_version, hal0_version, hermes_version}`. The `text` field is a human-readable summary.
 
-## agents dataset
+## agents namespace
 
-Cognee dataset reserved for agent identity cards. Separate from `shared` (episodic memory) and `private:*` (per-agent working memory). Small forever (5-10 cards). Discoverable via `memory_search({dataset: "agents", tags: ["agent-identity"]})`. Foundation for multi-agent discovery in v0.3+.
+Hindsight memory namespace reserved for agent identity cards. Separate from `shared` (episodic memory) and `private:*` (per-agent working memory). Small forever (5-10 cards). Discoverable via `memory_search({namespace: "agents", tags: ["agent-identity"]})`. Foundation for multi-agent discovery.
 
 ## Hal0Profile
 
-**Removed (R4 H4).** This was a hal0-owned Hermes model-provider plugin at `$HERMES_HOME/plugins/model-providers/hal0/`. It was deleted because it hardcoded a stale base URL; `hermes_provision` now actively removes the legacy plugin and points Hermes's config at hal0-api directly (`base_url = {HAL0_API_URL}/v1`, derived from the primary chat slot). Inference request shaping happens server-side in hal0-api's `/v1` surface, not in a Hermes-side profile.
+**Removed (R4 H4).** This was a hal0-owned Hermes model-provider plugin at `$HERMES_HOME/plugins/model-providers/hal0/`. It was deleted because it hardcoded a stale base URL; `hermes_provision` now actively removes the legacy plugin and points Hermes's config at hal0-api directly (`base_url = {HAL0_API_URL}/v1`, derived from the default chat slot — the `agent` anchor). Inference request shaping happens server-side in hal0-api's `/v1` surface, not in a Hermes-side profile.
 
 ## Hal0MemoryProvider
 
@@ -269,7 +269,7 @@ A hal0-owned Hermes plugin extending `agent.memory_provider.MemoryProvider`. Liv
 
 ## hermes_provision
 
-The hal0 module at `src/hal0/agents/hermes_provision.py` that orchestrates the 12-phase Hermes bootstrap (preflight → install → env_probe → home_init → config_write → mcp_wire → context_link → namespace_register → model_automap → voice_wire → smoke_tests → self_report). Idempotent + checkpointed via `/var/lib/hal0/state/agents/hermes/provision.json`. CLI verb is `hal0 agent bootstrap hermes`. Renamed from `hermes_bootstrap.py` to avoid soft collision with upstream's Windows-UTF8 module of the same filename.
+The hal0 module at `src/hal0/agents/hermes_provision.py` that orchestrates the 15-phase Hermes bootstrap (preflight → install → env_probe → home_init → install_artifacts → persona_seed → config_write → mcp_wire → context_link → namespace_register → model_automap → voice_wire → gateway_secrets_wire → smoke_tests → self_report). Idempotent + checkpointed via `/var/lib/hal0/state/agents/hermes/provision.json`. CLI verb is `hal0 agent bootstrap hermes`. Renamed from `hermes_bootstrap.py` to avoid soft collision with upstream's Windows-UTF8 module of the same filename.
 
 ## HERMES_HOME (v0.3)
 
@@ -277,13 +277,13 @@ Pinned to `/var/lib/hal0/agents/hermes/` for hal0-bundled installs (not `~/.herm
 
 ## v0.3
 
-The milestone opened 2026-05-23. Five interlocking streams: (1) Hermes-Agent first-run bootstrap, (2) React dashboard v3 wired to live data, (3) inference-runtime polish (preload+idle, GPU TTS, KV%, `/v1/*` proxy) — at the time this rode on the lemonade runtime, since replaced by the per-slot container runtime (#687), (4) Admin/auth simplification (ADR-0001 close-out: FastAPI owns auth, Caddy collapsed to TLS-only or removed), (5) Advanced memory + MCP client side (memory graph + Memify + federation + per-agent external MCP allow-list). See PLAN.md §1 v0.3 + §15 Phase 10.
+The milestone opened 2026-05-23. Five interlocking streams: (1) Hermes-Agent first-run bootstrap, (2) React dashboard v3 wired to live data, (3) inference-runtime polish (preload+idle, GPU TTS, KV%, `/v1/*` proxy) — at the time this rode on the Lemonade runtime, since replaced by the per-slot container runtime (#687), (4) Admin/auth simplification (ADR-0001 close-out: FastAPI owns auth, Caddy collapsed to TLS-only or removed), (5) Advanced memory + MCP client side (memory graph + Memify + federation + per-agent external MCP allow-list). See PLAN.md §1 v0.3 + §15 Phase 10.
 
 ---
 
 # v0.3 integration vocabulary (added 2026-05-28)
 
-The terms below land with the v0.3 Hermes integration sweep (PRs #393–#404 + #PR-11). Pinned by [ADR-0019](docs/internal/adr/0019-v0_3-hermes-integration.md).
+The terms below land with the Hermes integration sweep (PRs #393–#404 + #PR-11).
 
 ## composer
 
@@ -295,31 +295,31 @@ The rolling chat history rendered above the composer. Built by zustand store `us
 
 ## plugin host
 
-The hal0-api surface (`/api/dashboard/plugins/*` + `/dashboard-plugins/{name}/*`) that proxies upstream Hermes plugin manifests + static assets so the v3 dashboard can mount plugin bundles (the kanban plugin in v0.3) inside an `<AgentView>` tab. Each plugin renders inside a shadow-DOM iframe with the `__HERMES_PLUGIN_SDK__` global shimmed from `src/hal0/api/plugins/sdk-shim.js`. v0.3 vendors the SDK shape; ADR-0018's drift detection alerts on upstream registry.ts changes that would break the shim. See PR-7.
+The hal0-api surface (`/api/dashboard/plugins/*` + `/dashboard-plugins/{name}/*`) that proxies upstream Hermes plugin manifests + static assets so the v3 dashboard can mount plugin bundles (the kanban plugin in v0.3) inside an `<AgentView>` tab. Each plugin renders inside a shadow-DOM iframe with the `__HERMES_PLUGIN_SDK__` global shimmed from `src/hal0/api/plugins/sdk-shim.js`. hal0 vendors the SDK shape; the upstream-Hermes pin is human-gated and a drift-detection job (see `hermes-sdk-diff`) alerts on upstream registry.ts changes that would break the shim. See PR-7.
 
 ## sidecar agent block
 
-The compact agent panel rendered in the v3 dashboard sidebar — service-status chip, persona picker, memory chip, skills list, approvals bell, [Open chat] button. Lives at `ui/src/dash/agents/SidebarAgentBlock.jsx`. Parameterised by `agent_id` so v0.4 pi-coder lights up by adding a row. The service chip wires `POST /api/agents/{id}/restart` (PR-11); the memory chip reads `GET /api/agents/{id}/memory/stats` (PR-11); the skills list reads `GET /api/agents/skills` (PR-11).
+The compact agent panel rendered in the v3 dashboard sidebar — service-status chip, persona picker, memory chip, skills list, approvals bell, [Open chat] button. Lives at `ui/src/dash/agents/SidebarAgentBlock.jsx`. Parameterised by `agent_id` so pi-coder lights up by adding a row. The service chip wires `POST /api/agents/{id}/restart` (PR-11); the memory chip reads `GET /api/agents/{id}/memory/stats` (PR-11); the skills list reads `GET /api/agents/skills` (PR-11).
 
 ## persona TOML
 
-A file under `/var/lib/hal0/agents/hermes/personas/{id}.toml` declaring `[persona]` (`id`, `display_name`, `summary`, `system_prompt`, `tools_allowed`, `memory_namespace`, `preferred_upstream`, `preferred_model`) and `[persona.approval]` (`default_policy`, `auto_approve`, `require_approval`). The filename stem MUST match `[persona].id` — `load_persona` raises `PersonaError` on a mismatch to prevent silent renames. Seeded by `hermes_provision` Phase 8 with two personas (`hermes`, `coder`); operator-edited via `hal0 agent personas` or the dashboard persona editor. The active persona is the contents of `active.txt` next to the personas dir; switching swaps the system-prompt scope on the next turn without restart.
+A file under `/var/lib/hal0/agents/hermes/personas/{id}.toml` declaring `[persona]` (`id`, `display_name`, `summary`, `system_prompt`, `tools_allowed`, `memory_namespace`, `preferred_upstream`, `preferred_model`) and `[persona.approval]` (`default_policy`, `auto_approve`, `require_approval`). The filename stem MUST match `[persona].id` — `load_persona` raises `PersonaError` on a mismatch to prevent silent renames. Seeded by `hermes_provision` with two personas (`hermes`, `coder`); operator-edited via `hal0 agent personas` or the dashboard persona editor. The active persona is the contents of `active.txt` next to the personas dir; switching swaps the system-prompt scope on the next turn without restart.
 
-## hal0-cognee
+## hal0-memory (Hermes plugin)
 
-The hal0-owned `MemoryProvider` plugin at `src/hal0/agents/hermes/plugins/memory_cognee/`, mounted into `$HERMES_HOME/plugins/memory/hal0-memory/` by the provisioner. Wraps hal0-memory's REST surface (`/api/memory/{add,search,list,delete}`) so memory injection happens inside Hermes's prompt pipeline (`system_prompt_block`) rather than as an explicit tool call. Per-persona namespace via persona TOML `memory_namespace`; omitted dataset on writes resolves to `private:<agent_id>` server-side per ADR-0005 §3 (#317 fix once it lands). v0.3 supersedes Hal0MemoryProvider above as the canonical name.
+The hal0-owned `MemoryProvider` plugin at `src/hal0/agents/hermes/plugins/memory_hindsight/` (renamed from `hal0-cognee`), mounted into `$HERMES_HOME/plugins/memory/hal0-memory/` by the provisioner. Wraps hal0-memory's REST surface (`/api/memory/{add,search,list,delete}`) so memory injection happens inside Hermes's prompt pipeline (`system_prompt_block`) rather than as an explicit tool call. Per-persona namespace via persona TOML `memory_namespace`; an omitted namespace on writes resolves to `private:<agent_id>` server-side. Supersedes Hal0MemoryProvider above as the canonical name.
 
 ## hermes-sdk-diff
 
-The weekly GitHub Action + local script (`scripts/hermes-sdk-diff.sh`) that diffs hal0's pinned Hermes upstream commit (`pyproject.toml [tool.hal0.upstream-hermes]`) against upstream HEAD for the tracked files (`web/src/plugins/registry.ts`, `web/src/plugins/slots.ts`, `hermes_cli/web_server.py`, `agent/memory_provider.py`, `tools/registry.py`, `agent/events.py`). When any tracked file changes, the workflow opens an issue with the upstream commit range so the bump is human-gated. Bump process documented in [ADR-0018](docs/internal/adr/0018-upstream-hermes-pin-and-upgrade.md) §4.
+The weekly GitHub Action + local script (`scripts/hermes-sdk-diff.sh`) that diffs hal0's pinned Hermes upstream commit (`pyproject.toml [tool.hal0.upstream-hermes]`) against upstream HEAD for the tracked files (`web/src/plugins/registry.ts`, `web/src/plugins/slots.ts`, `hermes_cli/web_server.py`, `agent/memory_provider.py`, `tools/registry.py`, `agent/events.py`). When any tracked file changes, the workflow opens an issue with the upstream commit range so the bump is human-gated. (Decision: the upstream-Hermes pin is bumped only through this human-gated path — never auto-merged.)
 
 ## HMAC session cookie
 
-The browser-facing authn seam on hal0-api's chat-proxy surface (`/api/agents/{id}/{events,submit,session/*}`). Minted on first GET `/api/agents/{id}/session/handshake`, payload `{session_id, expires_at}`, signature `HMAC-SHA256(<secret>, base64url(payload))`. Secret lives at `/var/lib/hal0/agents/secret.bin` (chmod 0600, generated on first use). `HttpOnly` + `SameSite=Lax` + 8h TTL. Belongs to the chat-proxy specifically — ADR-0012 removed Bearer-token auth from the rest of the API. See `src/hal0/api/agents/_auth.py`.
+The browser-facing authn seam on hal0-api's chat-proxy surface (`/api/agents/{id}/{events,submit,session/*}`). Minted on first GET `/api/agents/{id}/session/handshake`, payload `{session_id, expires_at}`, signature `HMAC-SHA256(<secret>, base64url(payload))`. Secret lives at `/var/lib/hal0/agents/secret.bin` (chmod 0600, generated on first use). `HttpOnly` + `SameSite=Lax` + 8h TTL. Belongs to the chat-proxy specifically (Bearer-token auth was removed from the rest of the API; identity on hal0-api is carried by the `X-hal0-Agent` header, below). See `src/hal0/api/agents/_auth.py`.
 
 ## X-hal0-Agent
 
-The HTTP header hal0-api sets on outbound hops to hermes (and that bundled agents set on inbound hops to hal0-api). Carries the agent's stable id (e.g. `hermes`, `pi-coder`). Per ADR-0012 it's the identity claim on hal0-api (NOT Bearer); per MASTER-PLAN §1 security-baseline the chat-proxy injects it, the browser never sees or sets it. The hal0-memory MCP resolver derives the per-agent private namespace from this header.
+The HTTP header hal0-api sets on outbound hops to hermes (and that bundled agents set on inbound hops to hal0-api). Carries the agent's stable id (e.g. `hermes`, `pi-coder`). It is the identity claim on hal0-api (NOT Bearer); per the security-baseline the chat-proxy injects it, the browser never sees or sets it. The hal0-memory MCP resolver derives the per-agent private namespace from this header.
 
 ## composite hal0 upstream
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to hal0
 
-hal0 is licensed [Apache 2.0](./LICENSE). hal0 is at **v0.5.0-alpha.1** — the
-Lemonade Server adoption release. The contribution model is still
+hal0 is licensed [Apache 2.0](./LICENSE). hal0 is at **v0.8.2b3** — the
+container-runtime line (one podman container per slot). The contribution model is still
 being decided (see [`PLAN.md`](./PLAN.md) §16).
 <!-- TODO(human): flip the next line to open the external-PR merge window
      when ready (audit Q6.3 / #630). Timing is the maintainer's call. -->

--- a/PLAN.md
+++ b/PLAN.md
@@ -7,47 +7,46 @@ one-line install) and re-architected around the things that make hal0
 different from "a wrapper around llama-server": hardware-aware slots,
 clean lifecycle, and a real reliability bar.
 
-**Status (2026-06-14):** **v0.5.0-alpha.1** — container-runtime era.
+**Status (2026-06-30):** **v0.8.2b3** — container-runtime era.
 Every slot runs as a dedicated podman container under
 `hal0-slot@<name>.service` (ContainerProvider + `profiles.toml`).
 The v0.2 Lemonade daemon epoch is over — see Phase 9 (historical
 record below) and the container-runtime epic (#652) / full extraction
-(#687, PRs #688–#726). **Active work streams:**
+(#687, PRs #688–#726). **Work streams (most now shipped):**
 
-1. **Hermes-Agent bootstrap** — bundled agent becomes hal0-aware on
-   first run: env probe, model auto-wiring, MCP memory connection,
-   identity-card publishing to a dedicated `agents` dataset. Plan:
-   [`docs/internal/hermes-bootstrap-plan-2026-05-23.md`](docs/internal/hermes-bootstrap-plan-2026-05-23.md).
-   ADR: [ADR-0011 (agent identity cards)](docs/internal/adr/0011-agent-identity-cards.md).
+1. **Hermes-Agent bootstrap** — ✅ shipped. Bundled agent becomes
+   hal0-aware on first run: env probe, model auto-wiring, MCP memory
+   connection (Hindsight-backed), identity-card publishing to a
+   dedicated `agents` dataset. ADR: ADR-0011 (agent identity cards).
    Tracker: issues #237 / #238 / #240–#247 (10 tracer-bullet slices).
-2. **React dashboard v3 — fully functional** — v3 scaffold landed on
-   `main` (#235); wires every panel against live container-runtime /
-   admin-MCP / memory-MCP / agent surfaces. Replaces v2 (v0.2.1 cutover
-   shipped #199). Tracker: `dashboard-v3` label + `feat/dash-v3-*`
-   branches.
-3. **Container-runtime polish** — GPU-accelerated TTS (closes the
-   `[CPU]` chip on the voice card), KV% for GPU slots (hal0-built
-   llama-server or upstream), per-slot Prometheus metrics surface.
-4. **Admin / auth simplification (ADR-0001 close-out)** — collapse Caddy
-   to TLS-only or drop entirely; FastAPI owns auth (password + session
-   cookies + Bearer middleware), `/v1/*` served directly. In flight
-   across `feat/adr-0001-*` + `fix/issue-28-caddy-public-paths` +
-   `docs/adr-0001-close-out-2026-05-21`.
-5. **Advanced memory + MCP client side (Phase 10 → v0.3)** — Cognee
-   graph extraction + Memify pipeline + per-agent allow-listed external
-   MCP clients + memory federation across local + remote sources. Was
-   "post-v0.2 unscheduled"; reclassified as v0.3 scope.
+2. **React dashboard v3 — fully functional** — ✅ shipped. v3 wires
+   every panel against live container-runtime / admin-MCP / memory-MCP /
+   agent surfaces. Replaces v2 (v0.2.1 cutover shipped #199). Tracker:
+   `dashboard-v3` label + `feat/dash-v3-*` branches.
+3. **Container-runtime polish** — ✅ largely shipped. GPU-accelerated
+   TTS (voice stack live; Qwen3-TTS + kokoro slots), KV% for GPU slots
+   (hal0-built llama-server or upstream), per-slot Prometheus metrics
+   surface.
+4. **Admin / auth simplification** — ✅ shipped. ADR-0012 superseded
+   the ADR-0001 close-out: auth and Caddy were removed entirely (no
+   built-in auth or bundled TLS; upstream reverse proxy recommended for
+   non-LAN). `/v1/*` served directly from FastAPI.
+5. **Advanced memory + MCP client side** — Hindsight graph extraction
+   (Cognee removed per ADR-0023; `extraction_slot`-wired) + per-agent
+   allow-listed external MCP clients + memory federation across local +
+   remote sources.
 
-Architecture decisions in force:
-[ADR-0009 (FLM trio NPU packing)](docs/internal/adr/0009-flm-trio-npu-packing.md),
-[ADR-0010 (bundle picker — no default stack)](docs/internal/adr/0010-bundle-picker-no-default-stack.md).
-ADR-0008 (Lemonade adoption) is superseded by the container-runtime
-epic (#652); ADR-0006 / ADR-0007 were already superseded. v0.3 adds:
-- [ADR-0011 (agent identity cards)](docs/internal/adr/0011-agent-identity-cards.md) — Hermes bootstrap publishes per-agent cards into a dedicated `agents` Cognee dataset.
-- [ADR-0012 (remove auth and Caddy entirely)](docs/internal/adr/0012-remove-auth-and-caddy.md) — supersedes ADR-0001; hal0 v0.3 ships with no built-in auth or TLS, recommends upstream reverse proxy (Traefik / nginx / Cloudflare Tunnel) for non-LAN deployments. ~6,000 lines removed across backend, frontend, tests, installer, packaging.
-- [ADR-0013 (MCP-client allow-list for bundled agents)](docs/internal/adr/0013-mcp-client-allow-list.md) — resolves stream #5 ships-when "at least one MCP-client external source connectable from a bundled agent" with default-deny on server + tool axis + ADR-0004 approval-queue integration.
-- [ADR-0014 (Cognee graph extraction model gate)](docs/internal/adr/0014-cognee-graph-extraction-model-gate.md) — supersedes ADR-0005 §6 graph bullet; resolves stream #5 ships-when "configurable model" requirement (default-off + typed route enum: `upstream` / `primary` / `agent`).
-- [ADR-0023 (canonical LLM roles agent+utility)](docs/internal/adr/0023-canonical-llm-roles-agent-utility.md) — supersedes ADR-0014 §2; retires the `chat`/`primary` role names for `agent` (default/anchor) + `utility` (cheap helper, now seeded), generalizes `hal0/<slot>` addressing, removes Cognee, and replaces `[memory.graph].route`/`upstream` with a wired `extraction_slot`.
+Architecture decisions in force (ADRs are kept internal / not in-repo —
+referenced by number):
+ADR-0009 (FLM trio NPU packing), ADR-0010 (bundle picker — no default
+stack). ADR-0008 (Lemonade adoption) is superseded by the
+container-runtime epic (#652); ADR-0006 / ADR-0007 were already
+superseded. v0.3 adds:
+- ADR-0011 (agent identity cards) — Hermes bootstrap publishes per-agent cards into a dedicated `agents` dataset.
+- ADR-0012 (remove auth and Caddy entirely) — supersedes ADR-0001; hal0 ships with no built-in auth or TLS, recommends upstream reverse proxy (Traefik / nginx / Cloudflare Tunnel) for non-LAN deployments. ~6,000 lines removed across backend, frontend, tests, installer, packaging.
+- ADR-0013 (MCP-client allow-list for bundled agents) — resolves stream #5 ships-when "at least one MCP-client external source connectable from a bundled agent" with default-deny on server + tool axis + ADR-0004 approval-queue integration.
+- ADR-0014 (graph extraction model gate) — superseded by ADR-0023 §2; resolved stream #5 ships-when "configurable model" requirement (default-off + typed route enum).
+- ADR-0023 (canonical LLM roles agent+utility) — supersedes ADR-0014 §2; retires the `chat`/`primary` role names for `agent` (default/anchor) + `utility` (cheap helper, now seeded), generalizes `hal0/<slot>` addressing, removes Cognee (memory engine is now Hindsight), and replaces `[memory.graph].route`/`upstream` with a wired `extraction_slot`.
 
 ADR-0006 / ADR-0007 are superseded.
 
@@ -72,10 +71,9 @@ fully-wired dashboard, simpler admin, polished container runtime. See §1
 > extraction (#687, PRs #688–#726) supersede it. See §2 (Architecture)
 > and Phase 9 / Phase 11 below for the complete before/after.
 
-The Lemonade Server adoption was end-to-end at this cut. See
-[`docs/internal/lemonade-adoption-plan-2026-05-22.md`](docs/internal/lemonade-adoption-plan-2026-05-22.md)
-for the locked v0.2 implementation contract; the high-level
-deliverables were:
+The Lemonade Server adoption was end-to-end at this cut (locked v0.2
+implementation contract tracked in the internal Lemonade-adoption
+planning doc, not in-repo); the high-level deliverables were:
 
 - **Lemonade Server as the unified inference runtime** — one `lemond`
   process per host on `127.0.0.1:13305`, supervised by
@@ -133,7 +131,7 @@ See §15 Phase 9 below for the per-PR map.
     catalog (`b90a569`) groups models first, narrows the backend
     dropdown to backends a model can actually serve, and ships
     `hal0 capabilities migrate` for stale persisted selections.
-- **Auth + reverse proxy** (per [ADR-0001](docs/internal/adr/0001-collapse-edge-auth-into-fastapi.md),
+- **Auth + reverse proxy** (per ADR-0001,
   collapsed to a single FastAPI layer in PRs #58 + #59; original dual-layer
   shipped ahead of schedule via Team J, 2026-05-15 — `ba79427`, `f62902c`)
   - All auth lives in FastAPI: Bearer tokens for programmatic clients,
@@ -247,10 +245,9 @@ Two hal0-owned Hermes plugins (`Hal0Profile` for the provider,
 `Hal0MemoryProvider` for native memory injection via the upstream
 `MemoryProvider` ABC). Idempotent + repairable.
 
-- Bootstrap plan: [`docs/internal/hermes-bootstrap-plan-2026-05-23.md`](docs/internal/hermes-bootstrap-plan-2026-05-23.md)
-- Upstream surface: [`docs/internal/hermes-upstream-map-2026-05-23.md`](docs/internal/hermes-upstream-map-2026-05-23.md)
-- Env probes: [`docs/internal/hermes-env-probe-recipes-2026-05-23.md`](docs/internal/hermes-env-probe-recipes-2026-05-23.md)
-- ADR: [ADR-0011 (agent identity cards)](docs/internal/adr/0011-agent-identity-cards.md)
+- Bootstrap plan, upstream surface, and env-probe recipes: tracked in
+  the internal Hermes-bootstrap planning docs (not in-repo).
+- ADR: ADR-0011 (agent identity cards)
 - Tracker: 10 issues #237–#247 (4 admin MCP probe tools → scaffold → install → provider+config → memory plugin → identity cards → context → model_automap → robustness → dashboard panel)
 
 #### 2. React dashboard v3 — wired-up and functional
@@ -265,7 +262,7 @@ every panel against the live data planes:
 - **MCP** — list installed MCP servers (hal0-admin, hal0-memory,
   user-added); per-server tool surface introspection; identity-card
   reader for the `agents` dataset.
-- **Memory** — Cognee dataset explorer (shared / private / `agents`);
+- **Memory** — Hindsight dataset explorer (shared / private / `agents`);
   search + delete; per-agent namespace surfaced.
 - **Agents** — render identity cards from the `agents` dataset
   (per ADR-0011); reachability ping; bootstrap/repair/uninstall
@@ -306,27 +303,24 @@ Tracker: `dashboard-v3` label, `feat/dash-v3-*` branches, issue #200.
 
 Promoted to v0.3 scope. Locked deliverables:
 
-- **Cognee graph extraction (Kuzu)** — gated behind a configurable
-  model per [ADR-0014](docs/internal/adr/0014-cognee-graph-extraction-model-gate.md).
-  Default OFF; opt-in via dashboard toggle; route enum `upstream`
-  (default suggestion — OpenRouter / Anthropic / OpenAI) /
-  `primary` / `agent`. Eval suite deferred to v0.4 (audit gap G2).
+- **Hindsight graph extraction** — gated behind a configurable
+  model per ADR-0014 (superseded by ADR-0023, which wires a
+  dedicated `extraction_slot`). Default OFF; opt-in via dashboard
+  toggle. Eval suite deferred to v0.4 (audit gap G2).
 - **Memify pipeline** for memory hygiene.
 - **MCP client side of hal0** — bundled agents reach external MCP
-  servers with a per-agent allow-list per
-  [ADR-0013](docs/internal/adr/0013-mcp-client-allow-list.md).
+  servers with a per-agent allow-list per ADR-0013.
   Config at `/etc/hal0/agents/<name>.toml`; default-deny on both
   server + tool axis; three-tier classification (`allow` / `gated`
   / `blocked`); filesystem sandbox at
   `/var/lib/hal0/agents/<name>/workspace`; approval-queue reuse
   from ADR-0004.
 - **Memory federation** — pluggable Provider pattern; multiple
-  memory sources (local Cognee + remote MCPs) federated under one
+  memory sources (local Hindsight + remote MCPs) federated under one
   query path. Deferable to v0.4 per owner call mid-cycle (PLAN
   §15 Phase 10 "Deferred from v0.3 → v0.4" list).
-- **RBAC + audit log surface** — Cognee's built-in RBAC +
-  dataset-scoped permissions; rotating audit log visible in
-  dashboard.
+- **RBAC + audit log surface** — Hindsight dataset-scoped
+  permissions; rotating audit log visible in dashboard.
 
 #### Stretch / nice-to-have
 
@@ -1011,11 +1005,11 @@ Working assumption: 1 person full-time + Claude as pair. Adjust if not.
 - Migrate haloai LXC → hal0 (cutover) — script ready (PR #22, `scripts/migrate-haloai.py` + 14-model curated allow-list); cutover script tested with synthetic fixtures, not yet against live haloai data
 - Public launch — pending §16 decisions (launch story, contribution model)
 
-**Phase 8 — Agents v0.2 (initially v0.2; shipped 2026-05-22 ahead of the Lemonade migration)** — ✅ done 2026-05-22 — combined Agents + MCP + basic memory release; design settled via grilling 2026-05-22, deliverables in `docs/adr/0004-agents.md` + `docs/adr/0005-memory-engine-cognee.md`. Public API docs: [`docs/api/mcp.md`](./docs/api/mcp.md), [`docs/api/agents.md`](./docs/api/agents.md).
+**Phase 8 — Agents v0.2 (initially v0.2; shipped 2026-05-22 ahead of the Lemonade migration)** — ✅ done 2026-05-22 — combined Agents + MCP + basic memory release; design settled via grilling 2026-05-22, deliverables in ADR-0004 (agents) + ADR-0005 (memory engine — originally Cognee, since replaced by Hindsight per ADR-0023). Public API docs: [docs/reference/mcp-tools.mdx](./docs/reference/mcp-tools.mdx), [docs/concepts/agents.mdx](./docs/concepts/agents.mdx).
 
 - **Bundled agent app, single-pick at install.** Supported choices: `pi-coder` (CLI, installed from `Hal0ai/pi-mono` fork via `@earendil-works/pi-coding-agent` on npm) and `Hermes-Agent` (service, installed via the hal0-owned `hal0-hermes` wrapper around upstream `hermes`). User picks one via the first-run wizard or `hal0 agent {install,uninstall,list} <name>`; single-pick enforced; `--switch` flag for atomic swap. install.sh stays non-interactive (no `--agent` flag).
 - **hal0 admin MCP server at `/mcp/admin`.** Tools wrap existing `/api/*` routes only (rule: a tool ships iff it maps to an existing `/api/*` route — no new privileged surface). Bearer-token auth reused from ADR-0001. Two-tier scope: routine ops (slot status / list / `model_swap` / hardware probe / logs) autonomous; capital-D destructives (`model_pull`, `slot_restart/create/delete`, `capability_set`, `config_write`) gated.
-- **hal0 memory MCP server at `/mcp/memory`.** Wraps **Cognee** (Apache 2.0, embedded SQLite + LanceDB + Kuzu defaults — same stack we'd otherwise build). v0.2 surfaces only `memory_add` / `memory_search` / `memory_list` / `memory_delete`; Cognee's graph pipeline and Memify stay disabled until v0.3 (Phase 10 stream 5).
+- **hal0 memory MCP server at `/mcp/memory`.** Originally wrapped **Cognee** (Apache 2.0, embedded SQLite + LanceDB + Kuzu defaults); the v0.2 surface was `memory_add` / `memory_search` / `memory_list` / `memory_delete`. _Cognee was later removed per ADR-0023 — the memory engine is now **Hindsight**; the same four MCP tools carry forward._
 - **Approvals UX.** Bell+inbox in dashboard header (badge count, modal); inline pending indicators on Models / Slots / Capabilities pages where relevant; pending-forever (no auto-expire); no per-agent "trust mode" toggle (destructives must always be approved); full CLI parity via `hal0 agent approvals {list,approve,deny}` for headless workflows.
 - **Per-agent surface, asymmetric by upstream shape.** Service-shape (Hermes-Agent) gets a sidebar link-out OWUI-style; CLI-shape (pi-coder) gets no dashboard surface in v0.2. Both agents `track latest` upstream — no version pin — backed by a nightly CI smoke test that re-runs `installer/agents/pi-coder.sh` end-to-end against current upstream + asserts an MCP round-trip.
 - **Asymmetric ownership of integration shims.** hal0 maintains `installer/agents/pi-coder.sh` (installs pi-mono + `pi-mcp-adapter` for MCP routing + leaves `pi-memory-md` in place for project-scoped markdown memory). Hermes grows native hal0-awareness upstream (you own it); hal0's Hermes shim is a one-liner calling Hermes's own install command.
@@ -1024,7 +1018,7 @@ Working assumption: 1 person full-time + Claude as pair. Adjust if not.
   - `topoteretes/cognee-integrations/integrations/claude-code` — Claude Code plugin using six lifecycle hooks + `node_set` tagging (user-context / project-docs / agent-actions). Gives Claude Code users a second path into the same Cognee store, complementary to MCP.
   - `topoteretes/cognee-integrations/integrations/openclaw-skills` — `SKILL.md` + YAML-frontmatter format + Ingest → Execute → Observe → Amendify loop. Reference shape if hal0 ever grows agent-side skills (distinct from the platform "skills" = MCP tools settled here).
 
-**Phase 9 — Lemonade migration (v0.2)** — ✅ done 2026-05-23 — _Historical record. Superseded by the container runtime (epic #652) and full extraction (#687, PRs #688–#726); see Phase 11 below._ Lemonade Server was adopted as the unified inference runtime; six per-modality toolbox containers + the `hal0-slot@.service` template were retired in favour of one `hal0-lemonade.service`. Locked plan: [`docs/internal/lemonade-adoption-plan-2026-05-22.md`](docs/internal/lemonade-adoption-plan-2026-05-22.md). Architecture decisions: [ADR-0008](docs/internal/adr/0008-lemonade-adoption.md) (adoption — now superseded by #652), [ADR-0009](docs/internal/adr/0009-flm-trio-npu-packing.md) (FLM trio — still in force), [ADR-0010](docs/internal/adr/0010-bundle-picker-no-default-stack.md) (bundle picker — still in force). ADR-0006 / ADR-0007 superseded.
+**Phase 9 — Lemonade migration (v0.2)** — ✅ done 2026-05-23 — _Historical record. Superseded by the container runtime (epic #652) and full extraction (#687, PRs #688–#726); see Phase 11 below._ Lemonade Server was adopted as the unified inference runtime; six per-modality toolbox containers + the `hal0-slot@.service` template were retired in favour of one `hal0-lemonade.service`. Architecture decisions: ADR-0008 (adoption — now superseded by #652), ADR-0009 (FLM trio — still in force), ADR-0010 (bundle picker — still in force). ADR-0006 / ADR-0007 superseded.
 
 22 PRs across 6 sub-phases:
 
@@ -1049,7 +1043,7 @@ Cross-cutting:
 
 | Stream | Owner artifacts | Tracker |
 |---|---|---|
-| Hermes-Agent bootstrap | `docs/internal/hermes-bootstrap-plan-2026-05-23.md` + ADR-0011 | issues #237–#247 (10 tracer-bullet slices) |
+| Hermes-Agent bootstrap | internal Hermes-bootstrap plan (not in-repo) + ADR-0011 | issues #237–#247 (10 tracer-bullet slices) |
 | React dashboard v3 wired functional | `feat/dash-v3-*` branches; v3 scaffold landed (#235) | `dashboard-v3` label, issue #200 |
 | Container-runtime polish (GPU TTS, KV%, `/v1/*` proxy, Prometheus) | PR #248 + follow-ups | per-PR |
 | Admin/auth simplification (ADR-0001 close-out) | `feat/adr-0001-{a,b}-*`, `docs/adr-0001-{c-housekeeping,close-out-*}` | ADR-0001 children |
@@ -1070,7 +1064,7 @@ Cross-cutting:
 - Wiring `hermes-agent-self-evolution` (DSPy + GEPA prompt evolution; opens upstream PRs)
 - Memory federation: deferred only if it can't ship with the rest of stream #5 — owner's call mid-cycle
 
-**Phase 11 — Container runtime + Lemonade extraction (v0.3)** — ✅ done 2026-06-12 — Full removal of the `lemond` daemon; every slot is now a podman container supervised by `hal0-slot@<name>.service`. `ContainerProvider` + `profiles.toml` are the new inference layer. Operator reference: [docs/operate/container-runtime.md](docs/operate/container-runtime.md).
+**Phase 11 — Container runtime + Lemonade extraction (v0.3)** — ✅ done 2026-06-12 — Full removal of the `lemond` daemon; every slot is now a podman container supervised by `hal0-slot@<name>.service`. `ContainerProvider` + `profiles.toml` are the new inference layer. Operator reference: [docs/concepts/architecture.mdx](./docs/concepts/architecture.mdx).
 
 | Sub-epic | Issues | Scope |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ shared inference daemon; no extra process to babysit.
 curl -fsSL https://hal0.dev/install.sh | bash
 ```
 
-> **Status:** **v0.8.0-beta.2** — container-runtime era, declarative
+> **Status:** **v0.8.2b3** — container-runtime era, declarative
 > config. Each slot (`chat`, `embed`, `rerank`, `stt`, `tts`, `img`, NPU
 > trio) runs as a dedicated podman container (`hal0-slot@<name>.service`).
 > Slot definitions live in `/etc/hal0/slots/<name>.toml`; backend profiles
@@ -74,8 +74,7 @@ Whisper-V3-Turbo + Embedding-Gemma all coresident. hal0 exposes this
 as three slots (`agent`, `stt-npu`, `embed-npu`); the `npu.toml`
 `[npu]` table toggles ASR and embed. The host-side FLM `.deb` is
 installed for device-sanity probes only — inference runs in the
-container. See [ADR-0009](./docs/internal/adr/0009-flm-trio-npu-packing.md)
-for why.
+container. See ADR-0009 (FLM trio NPU packing) for why.
 
 **Dispatcher with single-flight + OmniRouter tool-calling.** Registry-aware
 routing across local slots *and* external upstreams (OpenRouter,
@@ -112,7 +111,7 @@ be evicted out from under a streaming request.
   under `hal0-slot@<name>.service`. `hal0-api` on `:8080` is the
   control plane; slot containers bind loopback ports (8081–8099 + fixed
   seeds). No shared inference daemon. See
-  [docs/operate/container-runtime.md](./docs/operate/container-runtime.md).
+  [docs/concepts/architecture.mdx](./docs/concepts/architecture.mdx).
 - **`hal0 setup` TUI** — after install (or anytime), `hal0 setup`
   walks you through storage, Extensions (Apps / Agents), Main and
   Agent model selection, and NPU opt-in, then downloads models with
@@ -177,7 +176,7 @@ be evicted out from under a streaming request.
 
 hal0 ships **two MCP servers** and **one bundled agent app**. The MCP
 servers (`/mcp/admin` for slot / model / capability / config / hardware
-/ log admin and `/mcp/memory` for Cognee-backed long-term memory) are
+/ log admin and `/mcp/memory` for Hindsight-backed long-term memory) are
 reachable by any MCP-speaking client — Claude Code, future RAG
 services, external scripts. The bundled agent is single-pick at install:
 `pi-coder` (CLI shape, installed from `Hal0ai/pi-mono` fork via
@@ -189,8 +188,9 @@ install <name>`; swap atomically with `--switch`. Capital-D destructive MCP call
 (`model_pull`, `slot_delete`, `config_write`, etc.) gate through a
 header bell + inbox modal in the dashboard, with CLI parity via
 `hal0 agent approvals {list,approve,deny}`. See
-[docs/mcp/overview.md](./docs/mcp/overview.md) and
-[docs/agents/overview.md](./docs/agents/overview.md).
+[docs/concepts/agents.mdx](./docs/concepts/agents.mdx),
+[docs/reference/mcp-tools.mdx](./docs/reference/mcp-tools.mdx), and
+[docs/guides/run-agents.mdx](./docs/guides/run-agents.mdx).
 
 ## Backends
 
@@ -213,7 +213,8 @@ inside the `hal0-toolbox-flm` container image. With FLM present,
 
 For the container-runtime operator reference — service layout, slot
 TOML fields, profiles, GPU arbiter, and day-2 commands — see
-[docs/operate/container-runtime.md](./docs/operate/container-runtime.md).
+[docs/concepts/architecture.mdx](./docs/concepts/architecture.mdx) and
+[docs/guides/manage-slots.mdx](./docs/guides/manage-slots.mdx).
 
 ## Hardware
 
@@ -293,7 +294,7 @@ systemctl restart hal0-slot@chat
 
 ### Auth posture
 
-Per [ADR-0012](./docs/internal/adr/0012-remove-auth-and-caddy.md) (supersedes
+Per ADR-0012 (remove auth and Caddy entirely, supersedes
 ADR-0001), hal0 ships with **no built-in auth and no bundled TLS**.
 `hal0-api` binds `0.0.0.0:8080` and treats every request as
 authenticated by virtue of network reachability — the right posture
@@ -302,7 +303,7 @@ for a homelab appliance on a trusted LAN.
 If hal0 is reachable from anything you don't physically control,
 front it with an upstream reverse proxy that owns auth + TLS — Traefik,
 nginx, Cloudflare Tunnel, or your own preferred edge. See
-[`docs/operate/auth.mdx`](./docs/operate/auth.mdx) for example configs
+[`docs/concepts/security.mdx`](./docs/concepts/security.mdx) for example configs
 of each.
 
 ### Proxmox integration (optional)
@@ -351,13 +352,13 @@ running on your box. Full version at [hal0.dev/roadmap](https://hal0.dev/roadmap
   probe, capability slots + orchestrator, dispatcher with
   single-flight + cold-cache prefetch, bundled OpenWebUI on `:3001`,
   cosign-keyless self-update with rollback, bundled agents
-  (pi-coder / Hermes-Agent) + MCP admin + Cognee memory MCP
+  (pi-coder / Hermes-Agent) + MCP admin + Hindsight memory MCP
 
 ### Soon
 
 - **GPU-accelerated TTS** — kokoro-vulkan or successor; closes the
   `[CPU]` chip on the voice slot card
-- **Advanced memory** — Cognee graph + Memify pipeline enabled, MCP
+- **Advanced memory** — Hindsight graph extraction enabled, MCP
   client side of hal0 (agents reach external MCP servers), federated
   memory across local + remote sources
 - **Benchmarks & presets UI** — in-dashboard tok/s + latency runs,

--- a/docs/superpowers/plans/2026-06-19-stacks-pr1-schema-catalog.md
+++ b/docs/superpowers/plans/2026-06-19-stacks-pr1-schema-catalog.md
@@ -1,5 +1,7 @@
 # Stacks — PR-1: Schema + Catalog — Implementation Plan
 
+> **Status: Implemented / Shipped (v0.8.x).** `StackConfig`/catalog landed in `src/hal0/config/schema.py` + `src/hal0/stacks/` (with seed stacks saber/forge/pi). (#921, #964) Plan retained for historical context.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add the `StackConfig` data model and a `StacksCatalog` that reads/writes a single atomic `stacks.toml`, giving hal0 a validated, persisted, CRUD-able catalog of Stacks — the foundation all later PRs bind to.

--- a/docs/superpowers/plans/2026-06-20-stacks-pr2a-config-apply-drift.md
+++ b/docs/superpowers/plans/2026-06-20-stacks-pr2a-config-apply-drift.md
@@ -1,5 +1,7 @@
 # Stacks — PR-2a: Config Apply + Dry-Run + Drift — Implementation Plan
 
+> **Status: Implemented / Shipped (v0.8.x).** `StackApplyEngine` (apply_config + dry-run + drift_status) landed in `src/hal0/stacks/apply.py` + `state.py`. (#923) Plan retained for historical context.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Translate a `StackConfig` into one atomic, reversible config change over the stack's slot TOMLs — with a compute-only dry-run preview, commit via the existing `SlotConfigStore` rollback machinery, and an active-stack pointer + content-hash drift status (`clean`/`modified`/`none`).

--- a/docs/superpowers/plans/2026-06-20-stacks-pr2b-lifecycle.md
+++ b/docs/superpowers/plans/2026-06-20-stacks-pr2b-lifecycle.md
@@ -1,5 +1,7 @@
 # Stacks — PR-2b: Lifecycle Convergence — Implementation Plan
 
+> **Status: Implemented / Shipped (v0.8.x).** `StackApplyEngine.converge()` (SlotManager load/swap/unload + capability-child routing) landed in `src/hal0/stacks/apply.py`. (#925) Plan retained for historical context.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add async `StackApplyEngine.converge(stack)` — drive the existing `SlotManager` to load/swap the stack's primary slots to their assigned models, route the stack's capability-child rows through the existing `CapabilityOrchestrator.apply`, and unload running slots NOT in the stack (declarative replace). Returns a per-slot `ConvergeReport`; individual failures are recorded, never unwound.

--- a/docs/superpowers/plans/2026-06-20-stacks-pr3-export-import.md
+++ b/docs/superpowers/plans/2026-06-20-stacks-pr3-export-import.md
@@ -1,5 +1,7 @@
 # Stacks — PR-3: Export / Import / Snapshot — Implementation Plan
 
+> **Status: Implemented / Shipped (v0.8.x).** Export/import/snapshot (`.hal0stack.json` envelope + model resolve pass) landed in `src/hal0/stacks/portable.py`; `stack_import`/`stack_apply` exposed via MCP + REST. (#926, #964) Plan retained for historical context.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Make a stack portable. **Export** a `StackConfig` to a self-contained `.hal0stack.json` envelope that embeds referenced profiles + model *metadata* (never weights/paths) with a content checksum. **Import** an envelope: validate, run a resolve pass classifying each model ref as present / pullable / unresolvable, reconcile embedded profiles, and create the stack. **Snapshot** the live config (slots + capabilities) into a new `StackConfig`.

--- a/docs/superpowers/plans/2026-06-20-voice-stack-bringup.md
+++ b/docs/superpowers/plans/2026-06-20-voice-stack-bringup.md
@@ -1,5 +1,7 @@
 # hal0 Voice Stack Bring-up Implementation Plan
 
+> **Status: Implemented / Shipped (v0.8.x).** Voice stack brought up and verified end-to-end (TTS + STT, `voice_wire` fix, Open WebUI Call mode); later extended with the Qwen3-TTS GPU slot and `voice.tts` engine switch. (#924, #928, #972, #976) Plan retained for historical context.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Take hal0 voice from "wired, never lit" to running and verifiably tested on hermes (CT105) — TTS (Kokoro), STT (Whisper, CPU then NPU), agent voice tools, and hands-free voice via Open WebUI Call mode.

--- a/docs/superpowers/specs/2026-06-19-stacks-design.md
+++ b/docs/superpowers/specs/2026-06-19-stacks-design.md
@@ -1,6 +1,6 @@
 # Stacks — Design Spec
 
-- **Status:** Approved design, pre-implementation
+- **Status:** Implemented / Shipped (v0.8.x) — Stacks subsystem (`src/hal0/stacks/`: schema/catalog, `StackApplyEngine` apply+drift+converge, `portable.py` export/import/snapshot), seed stacks (saber/forge/pi), and `stack_*` MCP/REST tools all landed. (#921, #923, #925, #926, #964) This spec is retained for historical/design context.
 - **Date:** 2026-06-19
 - **Author:** Alexander (via Claude)
 - **Target repo:** `hal0` (runtime + `ui/` dashboard). Docs page lands in `hal0-web`.

--- a/docs/superpowers/specs/2026-06-19-voice-stack-bringup-design.md
+++ b/docs/superpowers/specs/2026-06-19-voice-stack-bringup-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-19
 **Branch:** `feat/voice-stack` (worktree `/home/halo/dev/wt/voice-stack`, base `origin/main`)
-**Status:** Design — awaiting user review before plan
+**Status:** Implemented / Shipped (v0.8.x) — voice stack brought up and verified end-to-end (TTS + STT, `voice_wire` fix, Open WebUI Call mode); later extended with the Qwen3-TTS GPU slot and the `voice.tts` engine switch. (#924, #928, #972, #976) This design doc is retained for historical context.
 
 ## Problem
 

--- a/installer/agent-skills/hal0-service-management/references/hal0-codebase-map.md
+++ b/installer/agent-skills/hal0-service-management/references/hal0-codebase-map.md
@@ -1,67 +1,141 @@
 # hal0 codebase map
 
-Where things live in the hal0 source tree at `/opt/hal0/`.
+Where things live in the hal0 source tree. On an installed host the package
+lives under `/usr/lib/hal0/current/src/hal0/`; in a dev checkout it is
+`src/hal0/`. Paths below are relative to `src/hal0/`.
 
-## Source tree (`/opt/hal0/src/hal0/`)
+hal0 is a Python/FastAPI control plane. There is **no Go gateway**, **no
+Lemonade / lemond daemon**, and **no `:13305` upstream** — those were retired.
+Every local model runs as a **podman container, one per slot**. `hal0-api`
+runs **as root** (the hardened/non-root mode was removed, ADR-0023).
 
-### API layer
-- `api/routes/v1.py` — OpenAI-compatible `/v1/` endpoints. Chat handler at L550-584: `chat_completions()` reads body, rewrites slot aliases (`_rewrite_chat_slot_alias`, L233-281), optionally runs OmniRouter loop, then dispatches via `_dispatch_and_forward`. Also: `/v1/models` listing, embeddings, STT, TTS, image generation, rerankings.
-- `api/routes/lemonade_proxy.py` — NoRouteFound fall-through proxy to lemond `:13305` (L138).
-- `api/` — `hal0_chat_slot_alias_map()` builds alias→model_id dict from slot configs.
+## Top-level subpackages (`src/hal0/`)
 
-### Dispatcher
-- `dispatcher/router.py` — `dispatch()` routes requests to upstreams. Composite `hal0` upstream (L99-119) redirects to lemond `:13305/v1/` (L138). Remote upstreams forward to their own URLs.
-- `dispatcher/forward.py` — httpx-based forwarding with retry, error recovery.
+| Package | Role |
+|---------|------|
+| `api/` | FastAPI app factory (`api/__init__.py` → `create_app`, module-level `app` for `uvicorn hal0.api:app`) + all HTTP routes. |
+| `dispatcher/` | Registry-aware request router. Decides which upstream serves each OpenAI-compatible request; does **not** start/stop slots. |
+| `slots/` | Slot lifecycle: `SlotManager` (load/unload/swap/restart/create/delete) + the `SlotState` state machine. |
+| `providers/` | Inference backends. `ContainerProvider` is the sole slot-lifecycle backend (podman). |
+| `capabilities/` | Operator-facing overlay grouping slots into capability children (embed/voice/img). |
+| `slot_config/` | `SlotConfigStore` — reconciles `capabilities.toml` ↔ per-slot `slots/<name>.toml` atomically (compute `ChangeSet`, then `commit`). |
+| `profiles/` | `ProfileCatalog` — runtime profile (image + flags + runtime family) lookup and mutation over `profiles.toml`. |
+| `config/` | FHS path resolver (`paths.py`), config loader (`loader.py`), schema (`schema.py`), env (`env.py`), `migrations/`. |
+| `registry/` | Atomic TOML model catalog ("what models exist on this host"); `ModelRegistry` is the entry point. |
+| `upstreams/` | `UpstreamRegistry` of routing targets: `kind="slot"` (local container) or `kind="remote"` (OpenRouter/Anthropic/etc). |
+| `memory/` | Memory subsystem. `MemoryProvider` ABC + `HindsightProvider`/`PgVectorProvider` (Hindsight-backed; cognee removed, ADR-0023). |
+| `normalize/` | Virtual model-name resolution (`hal0/agent`, `hal0/utility`, `hal0/<slot>`) + thinking-flag normalization. |
+| `omni_router/` | Optional server-side tool-calling loop (`OmniRouter.run_loop`) invoked when a chat request opts in. |
+| `agents/` | Bundled agents (hermes + pi-coder), agent manager, MCP client, personas. |
+| `mcp/` | MCP servers exposed by hal0: `admin.py` (hal0-admin) and `memory.py` (hal0-memory). |
+| `cli/` | `hal0` CLI (`cli/main.py`) — slot/model/config/agent/setup/update subcommands. |
+| `capabilities/`, `comfyui/`, `hardware/`, `install/`, `stacks/`, `bundles/`, `release/`, `updater/`, `journal/`, `events/`, `activity/`, `board/`, `dashboard/`, `openwebui/`, `model_meta/`, `templates/` | Supporting subsystems (image-gen, hardware probe, installer orchestration, stacks, release channel, self-updater, audit/events, kanban board, dashboard layout, chat templates). |
 
-### Agent provisioning (Hermes integration)
-- `agents/hermes_templates/config.yaml.j2` — Jinja2 template for Hermes `config.yaml`. Sections: `model` (L45-57), `providers.custom` (L59-66), `model_aliases` (L70-76), `custom_providers` (L87-96, per-model context_length), `delegation` (L98-110), `memory` (L112-123), `mcp_servers` (L130-141), `skills` (L143-147), `terminal` (L149-151), `agent` (L153-164), `auxiliary` (L183-191), `stt/tts` (L193-210).
-- `agents/hermes_provision.py` — Bootstrap state assembly, template rendering, config write. `_apply_overrides()` at L818-833 deep-merges `/etc/hal0/agents/hermes/overrides.yaml` on top of rendered YAML.
-- `agents/hermes_provision.py:480` — legacy `Hal0Profile` model-provider plugin removal (dead `:8000` base_url).
+## API layer (`api/`)
 
-### Bifrost (to be retired, per spec)
-- `gateway/normalize/resolve.go` — live `/health` LLM-slot resolver + `isNPUorFLM` discriminator (ported to Python in spec).
-- `gateway/normalize/normalize.go:35` — `chat_template_kwargs.enable_thinking=false` (wrong layer for current lemond).
+- `api/__init__.py` — FastAPI app factory; mounts every router and constructs the `MemoryProvider`.
+- `api/routes/v1.py` — the OpenAI-compatible `/v1/` surface (the file the old map called `routes/v1.py`). Key functions:
+  - `chat_completions()` (L642) — `/v1/chat/completions` entry point.
+  - `_rewrite_chat_slot_alias()` (L188) — rewrites `hal0/<alias>` → concrete model/slot.
+  - `_ensure_backend_for_model()` (L379) — warms the backing slot via `SlotManager`.
+  - `_dispatch_and_forward()` (L438) — hands off to the `Dispatcher` and forwards the upstream response.
+  - `_dispatch_via_npu_trio()` (L755) — NPU FLM-trio dispatch path.
+  - `list_models()` (L479) — `/v1/models`. Plus embeddings, rerank, STT, TTS, image-gen handlers.
+- `api/routes/` — one router per concern: `slots.py`, `models.py`, `capabilities.py`, `profiles.py`, `providers.py`, `config.py`, `backends.py`, `stacks.py`, `memory.py`/`memory_admin.py`, `health.py`/`services_health.py`, `hardware.py`, `npu.py`, `updater.py`, `agents.py`, `installer.py`, `logs.py`, `journal.py`, `power.py`, `secrets.py`, `settings.py`, `events.py`, etc.
+- `api/agents/` — agent-facing endpoints (chat proxy, budget, personas, restart, memory stats).
+- `api/middleware/` — request-id, log scrubbing, error-code mapping.
+- `api/mcp_mount.py` — mounts the MCP servers under the API.
+
+There is **no** `api/routes/lemonade_proxy.py`.
+
+## Dispatcher (`dispatcher/`)
+
+- `dispatcher/router.py` — the heart. `Dispatcher.dispatch()` resolves a request through: (1) registry-exact binding → (2) warm-cache passthrough → (3) cold-cache prefetch (single-flight coalesced) → (4) capability/path routing (`resolve_by_capability`). The legacy `proxy.py` shim was **absorbed into `router.py`** — its slot heuristics now live in `resolve_by_capability`. There is **no** `dispatcher/forward.py` (only a `tests/dispatcher/test_forward.py` test remains).
+- `dispatcher/single_flight.py` — `SingleFlightGroup` for coalescing duplicate prefetches.
+- `dispatcher/npu_trio.py`, `_npu_common.py`, `npu_swap_status.py` — NPU FLM-trio routing helpers.
+- `dispatcher/memory_dispatcher.py` — routing for memory requests.
+- Decision logging: every routing decision emits one structured journald line with `SYSLOG_IDENTIFIER=hal0-dispatch`.
+
+## Slots (`slots/`)
+
+- `slots/manager.py` — `SlotManager`: every state-changing call (`load`/`unload`/`swap`/`status`/`restart`/`create`/`delete`/`update_config`) dispatches through `ContainerProvider`. Returns `Slot` snapshots, never dicts. Does **not** import from `dispatcher`.
+- `slots/state.py` — `SlotState` enum + state machine: `offline → pulling → starting → warming → ready ⇄ idle ⇄ serving → unloading → offline` (+ `error`). Persisted atomically to `/var/lib/hal0/slots/<name>/state.json`, streamable via SSE.
+- `slots/arbiter.py`, `capacity.py`, `argv.py`, `flag_merge.py`, `metrics.py`, `ttft_samples.py` — admission/capacity arbitration, argv assembly, flag merging, metrics.
+
+## Providers (`providers/`)
+
+- `providers/container.py` — `ContainerProvider`, the **sole** slot-lifecycle backend. Each slot → systemd template unit `hal0-slot@<name>.service` running `podman run … <image> --model <path> --port <n> <flags>`. Port is loopback-published; dispatcher reaches it via a `kind="remote"` upstream entry. Mounts `/mnt/ai-models` at the identical path (registry GGUFs are symlinks to absolute `/mnt/ai-models/...` targets).
+- `providers/base.py` — `Provider` ABC (stateless) + `ContainerSpec` (frozen).
+- `providers/llama_server.py` — llama.cpp argv/env derivation (Vulkan default, ROCm opt-in) consumed by container profiles.
+- `providers/flm.py` — AMD NPU via host FLM (Strix Halo only).
+- `providers/comfyui.py`, `kokoro.py`, `qwen3tts.py` — image-gen / TTS helpers (driven by `api/routes/v1.py`, not self-managed slots).
+- `providers/_gpu.py` — render/video GID resolution for container `/dev/dri` access.
+
+## Capabilities & slot config
+
+- `capabilities/orchestrator.py` — `CapabilityOrchestrator` bridges capability children (embed.embed, embed.rerank, voice.stt, voice.tts, img.img) 1:1 to real slots; `apply()` flips slots load/swap/unload. NPU-trio modalities drive the FLM anchor instead of spawning standalone processes.
+- `slot_config/__init__.py` — `SlotConfigStore`: `apply()` is compute-only (returns a `ChangeSet`), `commit()` writes atomically. Prevents `capabilities.toml` ↔ `slots/<name>.toml` drift.
+
+## Agents (`agents/`)
+
+- `agents/hermes_provision.py` — Hermes bootstrap state machine (15 deterministic phases, checkpointed to `/var/lib/hal0/state/agents/hermes/provision.json`). This is the provisioner.
+- `agents/hermes_refresh.py` — re-render/refresh of an already-provisioned Hermes.
+- `agents/hermes_templates/` — Jinja2 templates rendered into the Hermes home: `HERMES.md.j2`, `AGENTS.md.j2`, `SOUL.md.j2`, `STATE.md.j2`, `MCP-CLIENTS.md.j2`. (There is **no** `config.yaml.j2` — Hermes owns its own `config.yaml`; hal0 applies it via `hermes config set`.)
+- `agents/hermes/` — the bundled Hermes driver + `plugins/memory_hindsight/` (hal0-memory plugin).
+- `agents/pi_coder.py`, `agents/manager.py`, `agents/persona.py`, `agents/personas.py`, `agents/mcp_client.py` — pi-coder agent, agent manager, persona definitions, MCP client.
+
+## Memory (`memory/`)
+
+- `memory/provider.py` — `MemoryProvider` ABC + record types.
+- `memory/hindsight_provider.py` + `hindsight_client.py` — Hindsight backend (the default).
+- `memory/pgvector_provider.py` — pgvector backend.
+- `memory/namespace.py`, `migrate.py`, `extraction_env.py` — namespacing, migration, extraction-slot env. (cognee removed per ADR-0023.)
+- Surface: `/mcp/memory` (MCP) + `/api/memory/*` (REST), wired in `api/routes/memory.py`.
 
 ## Runtime paths
 
 | Path | Role |
 |------|------|
-| `/opt/hal0/` | Source repo root |
-| `/var/lib/hal0/` | hal0 data directory (runtime state, models, venvs, secrets) |
-| `/var/lib/hal0/.hermes/config.yaml` | Active Hermes config (rendered by provisioner) |
-| `/var/lib/hal0/secrets/agents/hermes.env` | Platform tokens, allowlists (provisioner-owned) |
-| `/var/lib/hal0/agents/hermes/logs/gateway.log` | Gateway application log (not journald) |
-| `/root/.config/systemd/user/hermes-gateway.service` | Gateway systemd unit |
-| `/etc/hal0/agents/hermes/overrides.yaml` | Config overrides (survives re-render) |
-| `/etc/hal0/capabilities.toml` | Slot/capability config (edit via hal0_admin, not directly) |
+| `/usr/lib/hal0/current/` | Installed code (symlink to versioned dir). Dev checkout uses the repo root instead. |
+| `HAL0_HOME` | Env override for all roots (dev installs / tests). When set, roots become `$HAL0_HOME/{usr-lib,etc,var-lib,var-log}`. |
+| `/etc/hal0/` | User-editable config (preserved on update). |
+| `/etc/hal0/capabilities.toml` | Operator capability selections (edit via hal0-admin / dashboard, not by hand). |
+| `/etc/hal0/slots/<name>.toml` | Per-slot config. |
+| `/etc/hal0/profiles.toml` | Runtime profiles (image + flags). |
+| `/etc/hal0/upstreams.toml` | Remote/slot upstream targets. |
+| `/var/lib/hal0/` | Mutable runtime state (preserved on update). |
+| `/var/lib/hal0/slots/<name>/state.json` | Persisted slot state. |
+| `/var/lib/hal0/registry/` | Atomic TOML model catalog. |
+| `/var/lib/hal0/state/agents/hermes/provision.json` | Hermes provisioning checkpoints. |
+| `/var/log/hal0/` | Optional file logs (journald is primary). |
+| `/mnt/ai-models/` | GGUF model store, mounted read-only into every slot container at the identical path. |
 
-## Design specs
+## Services / systemd units
 
-At `/opt/hal0/docs/superpowers/specs/`. Dated filenames, e.g. `2026-06-04-hal0-api-lemond-normalization-design.md`.
+- `hal0-api.service` — the FastAPI control plane on `:8080` (runs as **root**).
+- `hal0-slot@<name>.service` — one podman container per slot (`ExecStart = podman run …`, `ExecStop = podman stop`).
+- MCP servers (`hal0-admin`, `hal0-memory`) are mounted under the API, not separate daemons.
 
-## hal0-api request flow (chat)
+## hal0-api chat request flow
 
 ```
 POST /v1/chat/completions (:8080)
-  → _read_json_body (v1.py:569)
-  → _rewrite_chat_slot_alias (v1.py:233-281) — alias → model_id
-  → [OmniRouter loop if omni:true]
-  → _ensure_backend_for_model (v1.py:359) — SlotManager.load()
-  → Dispatcher.dispatch → forward
-      → composite "hal0" → http://127.0.0.1:13305/v1/chat/completions
-      → NoRouteFound → lemonade_proxy._proxy → :13305
+  → chat_completions()            api/routes/v1.py:642
+  → _rewrite_chat_slot_alias()    v1.py:188   (hal0/<alias> → model/slot)
+  → [OmniRouter.run_loop if the request opts into server-side tools]
+  → _ensure_backend_for_model()   v1.py:379   (SlotManager warms the slot)
+  → _dispatch_and_forward()       v1.py:438
+      → Dispatcher.dispatch()     dispatcher/router.py
+          → registry-exact | warm passthrough | cold prefetch | resolve_by_capability
+      → forward to the slot's loopback container upstream (kind="remote")
+  → [_dispatch_via_npu_trio() v1.py:755 for NPU FLM-trio requests]
 ```
 
-## Hermes → hal0 integration
+## Verifying this map
 
-- Provider: `custom` (built-in Hermes provider for OpenAI-compat LAN endpoints)
-- Base URL: `http://127.0.0.1:8080/v1`
-- Model discovery: Hermes queries `GET /v1/models` on startup (reads `data[].id` only — models.py:3168)
-- Model picker (`/model`): populated EXCLUSIVELY from server-side `/v1/models` response. Client-side `model_aliases` in config.yaml feed `DIRECT_ALIASES` for request-time resolution only — they do NOT populate the picker UI.
-- Context length: resolved via multi-step chain (model_metadata.py:1452-1738). Priority order: `model.context_length` global → `custom_providers` per-model → persistent cache → live `/v1/models` probe → provider-specific APIs → models.dev → hardcoded defaults → 256K fallback. `custom_providers` wins over `/v1/models` when both exist.
-- Context-length fields read from `/v1/models`: `context_length` > `context_window` > `context_size` > `max_model_len` > ... (11 keys, first valid int wins).
-- Thinking suppression: Hermes does NOT set `enable_thinking`/`chat_template_kwargs`/`no_think` on any outbound request. Safe for server-side defaults.
-- JSON tolerance: Hermes ignores unknown fields in `/v1/models` rows. Adding a `_hal0` metadata block is safe.
-- Subagents: `delegation.model` resolved once at delegate_task time, not re-read per turn.
-- Auxiliary tasks: `auxiliary.<task>.{provider,model,base_url}` for compaction/title/search/vision
-- Full internals: see `homelab-ops/hal0-hermes-integration` skill and its `references/hermes-provider-internals.md`.
+This doc is hand-maintained. When in doubt, re-derive it from the tree:
+
+```
+git ls-files src/hal0/            # current subpackages and modules
+sed -n '1,30p' src/hal0/<mod>.py  # each module's docstring states its role
+```

--- a/installer/comfyui/scripts/comfy-up.sh
+++ b/installer/comfyui/scripts/comfy-up.sh
@@ -2,8 +2,9 @@
 # Launch (or resume) the ComfyUI container on hal0 iGPU (gfx1151).
 # - Image is DIGEST-PINNED for reproducibility (a re-pull can't silently change the build).
 #   To update: pull a new tag, then replace the @sha256 below with its RepoDigest.
-# - --restart no: does NOT auto-start on boot, so it never contends with Lemonade at boot.
-#   (After a CT reboot, run this script to bring ComfyUI back up.)
+# - --restart no: does NOT auto-start on boot. (After a CT reboot, run this script to
+#   bring ComfyUI back up.) NOTE: the managed `img` slot owns ComfyUI on the iGPU via
+#   podman; this standalone docker script is for manual/debug use — see issue #985.
 # - On a FRESH create it self-heals node deps (which live in the ephemeral container venv).
 set -euo pipefail
 IMG=docker.io/kyuz0/amd-strix-halo-comfyui@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1343,8 +1343,10 @@ else
             if [[ "${hs_up}" -eq 1 ]]; then
                 info "hindsight-api is running (memory engine on 127.0.0.1:9177)"
                 # Seed banks through hal0-api (idempotent import, config-by-field):
-                # `shared` = the global cross-agent brain; `private__hermes-agent`
-                # = hermes' private store. Other private/project banks lazy-create.
+                # `shared` = the global cross-agent brain; `private:hermes`
+                # = hermes' private store (the server derives it from the agent-id
+                # via PRIVATE_PREFIX="private:", so the seed name must match exactly).
+                # Other private/project banks lazy-create.
                 _seed_bank() {
                     curl -fsS -m 20 -X POST \
                         "http://127.0.0.1:${HAL0_PORT}/api/memory/banks/$1/import" \
@@ -1352,8 +1354,8 @@ else
                         -d "$2" >/dev/null 2>&1
                 }
                 if _seed_bank shared '{"version":"1","bank":{"retain_mission":"Extract technical decisions and rationale, gotchas and fixes, PRs and status changes, conventions, commands, endpoints, flags, incidents and resolutions, and cross-session coordination facts. Ignore routine edits, transient state, secrets, and anything already in git.","enable_observations":true,"disposition_skepticism":4,"disposition_literalism":4,"disposition_empathy":1}}' \
-                    && _seed_bank private__hermes-agent '{"version":"1","bank":{"retain_mission":"This agent private working notes, scratch decisions, and per-task state. Never store shared facts here.","disposition_skepticism":4,"disposition_literalism":4,"disposition_empathy":2}}'; then
-                    info "seeded memory banks: shared (global) + private__hermes-agent"
+                    && _seed_bank private:hermes '{"version":"1","bank":{"retain_mission":"This agent private working notes, scratch decisions, and per-task state. Never store shared facts here.","disposition_skepticism":4,"disposition_literalism":4,"disposition_empathy":2}}'; then
+                    info "seeded memory banks: shared (global) + private:hermes"
                 else
                     warn "memory bank seeding incomplete — banks also lazy-create on first write"
                 fi

--- a/installer/uninstall.sh
+++ b/installer/uninstall.sh
@@ -354,12 +354,14 @@ else
     info "${LIB_DIR} not present"
 fi
 
-# Benchmark seam sudoers grant (install.sh seam #3). Lives in /etc/sudoers.d,
-# outside the /etc/hal0 config sweep, so remove it explicitly (system mode only).
-# The seam helper + harness themselves live under LIB_DIR (removed above); the
-# results under ${VAR_DIR}/benchmarks are data, kept unless --purge.
+# Sudoers grants (install.sh seams). Live in /etc/sudoers.d, outside the
+# /etc/hal0 config sweep, so remove them explicitly (system mode only). The
+# seam helpers + harness live under LIB_DIR (removed above); benchmark results
+# under ${VAR_DIR}/benchmarks are data, kept unless --purge.
 if [[ "${DEV_MODE}" -eq 0 ]]; then
+    rm_path "/etc/sudoers.d/hal0-agentenv"
     rm_path "/etc/sudoers.d/hal0-benchctl"
+    rm_path "/etc/sudoers.d/hal0-comfyui"
 fi
 
 # The install PREFIX (default /opt/hal0). install.sh rsyncs the source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.8.2b3"
+version = "0.8.2b4"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Documentation + installer hygiene surfaced by a codebase assessment sweep. **No runtime behaviour change** — docs, installer shell scripts, CHANGELOG, and the version bump only (zero `.py` runtime edits).

## Docs
- Re-baselined `AGENTS.md`, `ARCHITECTURE.md`, `CONTEXT.md`, `PLAN.md`, `README.md`, `CONTRIBUTING.md` to the v0.8.x reality: swept **Lemonade → container-runtime** and **Cognee → Hindsight**, corrected the Hermes provisioner to its real **15-phase** pipeline, refreshed version/status lines.
- Rewrote the (largely fictional) `hal0-service-management` codebase-map reference against the current `src/hal0/` tree.
- Marked the shipped Stacks / voice-stack superpowers plans as completed.
- Fixed dangling `docs/internal/adr/*` links — the ADR tree is gitignored (#638), so links are now by-number. In-code citation sweep tracked in #984.

## Installer
- `uninstall.sh` now removes **all three** sudoers grants (added `hal0-agentenv`, `hal0-comfyui` alongside `hal0-benchctl`).
- Seed the Hermes private memory bank as `private:hermes` (was the never-matched `private__hermes-agent` the server can't resolve via `PRIVATE_PREFIX="private:"`).
- Dropped the obsolete Lemonade boot-contention comment from `comfy-up.sh`.

## Release
- Added the **missing CHANGELOG `v0.8.2b3`** section + a new **`v0.8.2b4`** section.
- Bumped `pyproject` `0.8.2b3 → 0.8.2b4`.

## Validation
- `scripts/release-check.sh` gates 2 (ui build), 3 (ruff), 4 (manifest pins), 6 (clean tree), 7 (version↔tag) pass.
- Backend suite green except the 4 pre-existing env-only failures (test_comfyui_proxy, test_config_urls, test_models_preview, test_settings_models_store).
- CHANGELOG sections extract cleanly via `extract_changelog_section` for both v0.8.2b3 and v0.8.2b4.
- Remaining gate before tag: tier-γ `make release-test` report.

Companion issue hygiene (already applied on the tracker): closed 15 stale/obsolete issues; filed #980–#987 from the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)