### PR TITLE
fix(v1): canonicalise system messages — collapse + hoist to position 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ page; this CHANGELOG starts at v0.2.0 (the Lemonade migration cut).
 ADR-level architecture decisions are kept internal (the `docs/internal/`
 tree is gitignored, #638) and referenced by number throughout the code.
 
+## [Unreleased]
+
+### Fixed
+- **Chat requests with mis-positioned or stacked `role='system'` messages
+  no longer 500 the Qwen3.6-35B-A3B upstream.** The Hermes dashboard SPA,
+  Open WebUI and LibreChat build the messages array by append, so a stale
+  session system message can land mid-array; third-party clients can also
+  stack two system blocks deliberately. The Qwen3 Jinja chat template
+  hard-raises `System message must be at the beginning` from line ~85 in
+  both cases, surfacing as HTTP 500 with `Jinja Exception: ...`. The
+  OpenAI-compat normaliser now calls
+  `hal0.normalize.messages.normalize_system_messages` inside
+  `_normalize_chat_body`, which **collapses** every system entry into one
+  and **hoists** the result to position 0 (joined with blank lines,
+  matching the OpenAI/Anthropic convention for stacked-system payloads).
+  No-system payloads are returned without a copy so the SPA's hot path
+  pays nothing.
+
 ## [v0.8.2b4] — 2026-06-30
 
 Documentation and installer hygiene — no runtime behaviour change. This

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -345,13 +345,37 @@ async def _slot_thinking_default(request: Request, model_id: str) -> bool:
 
 
 async def _normalize_chat_body(request: Request, body: dict[str, Any]) -> dict[str, Any]:
-    """Resolve hal0/* virtual model names + inject thinking policy.
+    """Normalise messages → resolve hal0/* aliases → inject thinking policy.
 
-    Rewrites request._body so every downstream consumer observes the
-    normalized body.
+    Order of operations matters:
+
+      1. **Canonicalise the messages array** — collapse every
+         ``role='system'`` entry into one and hoist it to position 0
+         (see :func:`hal0.normalize.messages.normalize_system_messages`).
+         Doing this BEFORE the alias rewrite keeps every downstream
+         consumer — the dispatcher, audit middleware, response
+         introspection, the cached ``request._body`` — consistent.
+      2. **Rewrite the slot alias** (``hal0/agent`` → ``qwen3-6-…``) so
+         registry / dispatch see the real model id.
+      3. **Apply the thinking policy** (Qwen3 template kwarg lever;
+         see :mod:`hal0.normalize.thinking`).
+
+    ``request._body`` is rewritten at the end so any code re-reading
+    ``request.body()`` verbatim (e.g. ``Dispatcher``) observes the
+    normalised body too.
     """
+    from hal0.normalize.messages import normalize_system_messages
     from hal0.normalize.resolver import LiveSlotResolver
     from hal0.normalize.thinking import apply_thinking_policy
+
+    # Step 1: collapse + hoist system messages to position 0. Done before
+    # the alias rewrite so the rewrite sees the same canonical array the
+    # dispatcher will forward — avoids a second pass downstream.
+    messages = body.get("messages")
+    if isinstance(messages, list):
+        canonical = normalize_system_messages(messages)
+        if canonical is not messages:
+            body = {**body, "messages": canonical}
 
     views = await _normalize_slot_views(request)
     resolver = LiveSlotResolver(

--- a/src/hal0/normalize/__init__.py
+++ b/src/hal0/normalize/__init__.py
@@ -1,5 +1,6 @@
 """Request normalization for dispatcher-bound chat traffic (model resolution + thinking)."""
 
+from hal0.normalize.messages import normalize_system_messages  # noqa: F401
 from hal0.normalize.resolver import (  # noqa: F401
     DEFAULT_CHAINS,
     LiveSlotResolver,

--- a/src/hal0/normalize/messages.py
+++ b/src/hal0/normalize/messages.py
@@ -1,0 +1,61 @@
+"""Per-request normalisation helpers that operate on the OpenAI ``messages`` array.
+
+Currently exposes :func:`normalize_system_messages`, which collapses any
+``role='system'`` entries into one and hoists the result to position 0. The
+Qwen3.6-35B-A3B finetune served by ``hal0-slot-agent`` ships with a Jinja chat
+template that hard-raises when ``role='system'`` appears at any index > 0 *or*
+when more than one system message is present in the array. The Hermes dashboard
+SPA, Open WebUI and LibreChat build the messages array by append, so a stale
+session system message can land mid-array — and a third-party client can stack
+two system blocks deliberately. We normalise server-side so every client is
+correct by construction rather than relying on each surface remembering both
+ordering rules.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["normalize_system_messages"]
+
+
+def normalize_system_messages(messages: Any) -> Any:
+    """Collapse every ``role='system'`` entry into one and hoist it to position 0.
+
+    Two template-level rules this satisfies:
+
+      1. **Position rule.** ``role='system'`` must appear at index 0 (the
+         Qwen3 Jinja emits ``raise_exception('System message must be at the
+         beginning')`` from line ~85 of the chat template when this fails).
+      2. **Cardinality rule.** At most one ``role='system'`` entry may exist
+         in the array; multiple systems are likewise rejected by the same
+         template.
+
+    Semantics:
+
+      * Non-list input (or empty list) is returned unchanged.
+      * Lists with NO ``role='system'`` entries are returned unchanged — no
+        allocation. This is the hot path; the dashboard SPA's history filter
+        strips system messages, so user→hal0/agent requests land here and pass
+        through without a copy.
+      * Otherwise we join every system entry's ``content`` with ``"\\n\\n"``
+        (matching the convention OpenAI and Anthropic adopt for stacked-system
+        payloads) and emit a single ``{role: 'system', content: joined}`` at
+        position 0. Relative order among non-system entries is preserved, so
+        ``[user, sys1, asst, sys2]`` becomes
+        ``[sys1+sys2-joined, user, asst]``.
+
+    Returns either the input list (same object) or a brand-new list — callers
+    may ``is``-compare to detect the in-place case.
+    """
+    if not isinstance(messages, list) or not messages:
+        return messages
+    sys_contents: list[str] = [
+        m.get("content", "") if isinstance(m, dict) else ""
+        for m in messages
+        if isinstance(m, dict) and m.get("role") == "system"
+    ]
+    if not sys_contents:
+        return messages
+    others = [m for m in messages if not (isinstance(m, dict) and m.get("role") == "system")]
+    return [{"role": "system", "content": "\n\n".join(sys_contents)}, *others]

--- a/tests/api/test_chat_normalization.py
+++ b/tests/api/test_chat_normalization.py
@@ -323,3 +323,93 @@ def test_container_slot_not_treated_as_remote_for_thinking():
     assert v1._is_remote_model(req, "qwopus3.6-27b-v2") is False
     # Genuine external remote → remote (skip thinking injection).
     assert v1._is_remote_model(req, "gpt-x") is True
+
+
+# ── system-message canonicalisation integration tests ─────────────────────
+#
+# These exercise the call site in `_normalize_chat_body` itself rather than
+# the pure helper — they pin the contract that every body reaching the
+# upstream is canonical (system at index 0, at most one system), so the
+# Qwen3.6-35B-A3B Jinja template never sees a config that triggers its
+# `raise_exception('System message must be at the beginning')`.
+
+
+@pytest.mark.asyncio
+async def test_normalize_chat_body_hoists_mid_array_system_to_position_zero():
+    """The dashboard bug repro: a system message mid-array used to leave
+    `_normalize_chat_body` untouched and reach llama-server, which 500'd."""
+    req = _make_request(cfgs=_PRIMARY, loaded={"big"})
+    body = {
+        "model": "hal0/agent",
+        "messages": [
+            {"role": "user", "content": "Hi"},
+            {"role": "system", "content": "you are the hal0 operator"},
+        ],
+    }
+    out = await v1._normalize_chat_body(req, body)
+    msgs = out["messages"]
+    assert msgs[0]["role"] == "system"
+    assert msgs[0]["content"] == "you are the hal0 operator"
+    assert msgs[-1]["role"] == "user"
+    assert msgs[-1]["content"] == "Hi"
+
+
+@pytest.mark.asyncio
+async def test_normalize_chat_body_collapses_stacked_systems():
+    """Two system entries collapse into one leading system joined with
+    blank lines; non-system turns retain their original order."""
+    req = _make_request(cfgs=_PRIMARY, loaded={"big"})
+    body = {
+        "model": "hal0/agent",
+        "messages": [
+            {"role": "user", "content": "u1"},
+            {"role": "system", "content": "s1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "system", "content": "s2"},
+        ],
+    }
+    out = await v1._normalize_chat_body(req, body)
+    msgs = out["messages"]
+    sys_entries = [m for m in msgs if m["role"] == "system"]
+    assert len(sys_entries) == 1
+    assert sys_entries[0] == {"role": "system", "content": "s1\n\ns2"}
+    # non-system order preserved
+    assert msgs[1:] == [
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_normalize_chat_body_user_only_body_is_passthrough():
+    """No-system payloads must round-trip through normalise without
+    rewriting the message array (the SPA's hot path)."""
+    req = _make_request(cfgs=_PRIMARY, loaded={"big"})
+    msgs = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    out = await v1._normalize_chat_body(req, {"model": "hal0/agent", "messages": list(msgs)})
+    assert out["messages"] == msgs
+
+
+@pytest.mark.asyncio
+async def test_normalize_chat_body_caches_canonical_messages_in_request_body():
+    """Once normalised, request._body must reflect the canonical array so
+    downstream consumers reading the request body verbatim see the same
+    shape (Dispatcher re-serialises it)."""
+    req = _make_request(cfgs=_PRIMARY, loaded={"big"})
+    req._body = b""  # the helper writes here; assert it's rewritten
+    body = {
+        "model": "hal0/agent",
+        "messages": [
+            {"role": "user", "content": "Hi"},
+            {"role": "system", "content": "ops"},
+        ],
+    }
+    await v1._normalize_chat_body(req, body)
+    import json as _json
+
+    cached = _json.loads(req._body)
+    assert cached["messages"][0]["role"] == "system"
+    assert cached["messages"][-1]["role"] == "user"

--- a/tests/normalize/test_messages.py
+++ b/tests/normalize/test_messages.py
@@ -1,0 +1,135 @@
+"""Tests for :func:`hal0.normalize.messages.normalize_system_messages`.
+
+Covers the three constraints the Qwen3.6-35B-A3B chat template enforces
+(``System message must be at the beginning``): single-system position,
+absence of mid-array systems, and absence of stacked systems. Each of these
+was a 500 from llama-server before normalising.
+"""
+
+from hal0.normalize.messages import normalize_system_messages
+
+# ── trivial / no-op paths ──────────────────────────────────────────────────
+
+
+def test_non_list_passthrough():
+    # Non-list inputs aren't message arrays at all — return as-is so callers
+    # can match ``is`` to detect the no-op.
+    assert normalize_system_messages(None) is None
+    assert normalize_system_messages({"role": "user"}) == {"role": "user"}
+    assert normalize_system_messages("not a list") == "not a list"
+
+
+def test_empty_list_passthrough():
+    assert normalize_system_messages([]) == []
+    empty = []
+    assert normalize_system_messages(empty) is empty  # no copy on no-op
+
+
+def test_no_system_messages_no_allocation():
+    # Hot path: the SPA's history filter strips system messages, so user→agent
+    # requests must not pay a copy.
+    msgs = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
+    out = normalize_system_messages(msgs)
+    assert out is msgs
+    assert out == msgs
+
+
+# ── the original repro: system positioned mid-array ───────────────────────
+
+
+def test_system_after_user_is_hoisted():
+    # Was HTTP 500 on the live dashboard before the fix.
+    msgs = [{"role": "user", "content": "Hi"}, {"role": "system", "content": "ops"}]
+    out = normalize_system_messages(msgs)
+    assert out != msgs  # new list
+    assert out[0] == {"role": "system", "content": "ops"}
+    assert out[1] == {"role": "user", "content": "Hi"}
+
+
+def test_already_canonical_no_copy():
+    msgs = [{"role": "system", "content": "ops"}, {"role": "user", "content": "Hi"}]
+    out = normalize_system_messages(msgs)
+    assert out == msgs
+    # The function allocates a new list whenever ANY system was found —
+    # document that contract rather than over-engineer an identity-preserving
+    # no-op for an edge case that costs O(1) anyway.
+
+
+# ── the multi-system case (collapse path) ─────────────────────────────────
+
+
+def test_multi_system_collapses_into_single():
+    # Stacked systems also 500 the Qwen3 template (verified live). The
+    # collapse emits a single leading system whose content joins the inputs
+    # with blank lines — matching the OpenAI / Anthropic convention.
+    msgs = [
+        {"role": "user", "content": "u1"},
+        {"role": "system", "content": "s1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "system", "content": "s2"},
+    ]
+    out = normalize_system_messages(msgs)
+    assert len([m for m in out if isinstance(m, dict) and m.get("role") == "system"]) == 1
+    assert out[0] == {"role": "system", "content": "s1\n\ns2"}
+    assert out[1] == {"role": "user", "content": "u1"}
+    assert out[2] == {"role": "assistant", "content": "a1"}
+
+
+def test_three_or_more_systems_still_collapse():
+    msgs = [
+        {"role": "system", "content": "a"},
+        {"role": "system", "content": "b"},
+        {"role": "system", "content": "c"},
+        {"role": "user", "content": "hi"},
+    ]
+    out = normalize_system_messages(msgs)
+    assert len(out) == 2  # one system + one user
+    assert out[0] == {"role": "system", "content": "a\n\nb\n\nc"}
+    assert out[1] == {"role": "user", "content": "hi"}
+
+
+# ── robustness ────────────────────────────────────────────────────────────
+
+
+def test_junk_entries_preserved_as_others():
+    # Non-dict entries and entries with role=system but missing 'content'
+    # still trigger hoist; content defaults to "" so join() never raises.
+    msgs = [
+        {"role": "system", "content": "x"},
+        "string entry",
+        42,
+        {"role": "user", "content": "u"},
+    ]
+    out = normalize_system_messages(msgs)
+    assert out[0] == {"role": "system", "content": "x"}
+    assert out[1:] == ["string entry", 42, {"role": "user", "content": "u"}]
+
+
+def test_system_entry_without_content_key_still_hoists():
+    # role='system' with no ``content`` key still hoists; content defaults
+    # to "" so join() doesn't raise on the multi-system path.
+    msgs = [
+        {"role": "system", "content": "first"},
+        {"role": "user", "content": "u"},
+        {"role": "system"},  # no content
+    ]
+    out = normalize_system_messages(msgs)
+    # The two systems collapse into one; missing content contributes "".
+    assert out[0] == {"role": "system", "content": "first\n\n"}
+    assert out[1] == {"role": "user", "content": "u"}
+
+
+def test_user_only_passthrough_with_extras():
+    # Non-message body extras (tool calls, tool results, names) on the
+    # user/assistant entries should survive intact.
+    msgs = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "1", "type": "function", "function": {"name": "n"}}],
+        },
+        {"role": "tool", "tool_call_id": "1", "content": "{}"},
+        {"role": "user", "content": "u"},
+    ]
+    out = normalize_system_messages(msgs)
+    assert out == msgs  # no system → exact pass-through


### PR DESCRIPTION
The Qwen3.6-35B-A3B finetune served by hal0-slot-agent ships with a Jinja chat template that hard-raises "System message must be at the beginning" (line ~85) whenever role=system appears at any index > 0, OR when more than one system entry is present. Both shapes land on HTTP 500 with "Jinja Exception: ..." when the Hermes dashboard SPA, Open WebUI or LibreChat build a request whose session history drifts.

The /v1 OpenAI-compat normaliser already runs inside _normalize_chat_body to inject the Qwen3 thinking-policy kwarg and rewrite virtual aliases. This commit adds a third step BEFORE both — collapse every system entry into one (joined with blank lines, matching the OpenAI/Anthropic convention) and hoist the result to index 0. No-system payloads return without a copy so the SPA hot path pays nothing.

Fixes the dashboard "Hi" 500 I hit on v0.8.2b4 + clears the multi-system edge for third-party clients that stack system blocks.