### PR TITLE
fix(installer): recognise agent.toml as canonical default slot in _has_default_slot() (#981)

### DIFF
--- a/src/hal0/api/routes/installer.py
+++ b/src/hal0/api/routes/installer.py
@@ -59,7 +59,7 @@ class CuratedModelNotFound(PickDefaultError):
     status = 404
 
 
-_DEFAULT_SLOT = "chat"
+_DEFAULT_SLOT = "agent"
 
 
 def _first_run_sentinel() -> Path:
@@ -85,9 +85,18 @@ def _models_dir_populated() -> bool:
 
 
 def _has_default_slot() -> bool:
-    """True if the chat slot TOML exists (chat.toml or legacy primary.toml)."""
+    """True if the canonical agent slot TOML exists, or a legacy fallback.
+
+    Per ADR-0023 the default anchor slot is ``agent`` (SEED_STACKS bind
+    ``slot=agent``); ``chat`` and ``primary`` are retained as legacy
+    fallbacks for boxes that pre-date the rename.
+    """
     slots_dir = paths.slots_config_dir()
-    return (slots_dir / "chat.toml").exists() or (slots_dir / "primary.toml").exists()
+    return (
+        (slots_dir / "agent.toml").exists()
+        or (slots_dir / "chat.toml").exists()
+        or (slots_dir / "primary.toml").exists()
+    )
 
 
 async def _openwebui_running() -> bool:

--- a/tests/api/test_installer_routes.py
+++ b/tests/api/test_installer_routes.py
@@ -81,6 +81,21 @@ def test_install_state_has_default_slot_when_primary_toml_exists(
     assert r.json()["has_default_slot"] is True
 
 
+def test_install_state_has_default_slot_when_agent_toml_exists(
+    isolated_client: TestClient, tmp_hal0_home: str
+) -> None:
+    """An agent.toml on disk flips has_default_slot to True (canonical per ADR-0023)."""
+    slots = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots.mkdir(parents=True, exist_ok=True)
+    (slots / "agent.toml").write_text(
+        'name = "agent"\nport = 8081\nbackend = "vulkan"\nprovider = "llama-server"\n',
+        encoding="utf-8",
+    )
+    r = isolated_client.get("/api/install/state")
+    assert r.status_code == 200
+    assert r.json()["has_default_slot"] is True
+
+
 def test_install_state_has_no_bundle_field(isolated_client: TestClient, tmp_hal0_home: str) -> None:
     """The v1 ``bundle`` field is absent from /state (removed in Task 6.2)."""
     r = isolated_client.get("/api/install/state")


### PR DESCRIPTION
Fixes #981

## Summary

- `_has_default_slot()` in `src/hal0/api/routes/installer.py` only checked for `chat.toml` or `primary.toml`. Per ADR-0023, the canonical default anchor slot is now `agent` (SEED_STACKS bind `slot=agent`), so any box seeded post-rename permanently reported `has_default_slot: false`, mis-gating the first-run wizard.
- Added `agent.toml` as the primary check; `chat.toml` and `primary.toml` are retained as legacy fallbacks for pre-rename boxes.
- Updated `_DEFAULT_SLOT` constant from `"chat"` to `"agent"` and updated the `_has_default_slot()` docstring to reflect the canonical slot name.
- The `curated-models` filter (`recommended_slot in ('chat', 'primary')`) was audited and left unchanged — `recommended_slot` is a model-type classification field, not a runtime slot name, and no curated entry uses `"agent"` as its value.

## Tests added

- `test_install_state_has_default_slot_when_agent_toml_exists` — writes `agent.toml` into the tmp slots dir and asserts `has_default_slot` is `True`. This test **fails on `main`** (before this fix) since the old check ignores `agent.toml`.
- Existing `test_install_state_has_default_slot_when_primary_toml_exists` kept as-is to confirm legacy `primary.toml` compat is preserved.

**Local result:** `9 passed` in `tests/api/test_installer_routes.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)