### PR TITLE
fix(updater): re-pip prior tree into venv on rollback (#980)

### DIFF
--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1147,9 +1147,18 @@ class Updater:
         — forward-only migrations are acceptable for v1 (PLAN §9 + Team D
         brief). The route layer can surface the warning in the job result.
 
+        Step 8b (non-editable installs only): after the symlink swap, re-pips
+        the prior tree into the running venv so that the next ``hal0-api``
+        restart actually serves the rolled-back version. This mirrors the
+        same step in ``apply()`` (#495 / #980). On pip failure the symlink is
+        swapped *forward* again (back to ``current_target``) so the symlink
+        and the venv-installed code stay consistent — same failure-recovery
+        pattern as ``apply()``.
+
         Raises:
             UpdateRollbackUnavailable: No previous record on disk.
             UpdateSwapError: The symlink swap itself failed.
+            UpdateError: Re-pip of the prior tree failed (non-editable only).
         """
         record = _previous_record()
         if not record.exists():
@@ -1186,6 +1195,23 @@ class Updater:
                 f"rollback symlink swap failed: {exc}",
                 details={"link": str(link), "target": str(prior_path), "error": str(exc)},
             ) from exc
+
+        # Step 8b: re-install the prior tree into the running venv so the
+        # next hal0-api restart serves the rolled-back version. Editable/dev
+        # installs are exempt (no FHS venv to refresh; mirrors apply()).
+        if not _is_editable_install():
+            try:
+                await asyncio.to_thread(_reinstall_into_venv, prior_path, job_id=self.job_id)
+            except UpdateError:
+                # Re-pip failed: swap the symlink forward again so `current`
+                # and the venv's installed code stay consistent — both remain
+                # pointing at current_target (the version we just rolled away
+                # from), rather than leaving the symlink at prior_path while
+                # site-packages still has the newer code.
+                if current_target is not None:
+                    with contextlib.suppress(OSError):
+                        _atomic_symlink_swap(current_target, link)
+                raise
 
         # Re-record what we just swapped away from so a double-rollback
         # bounces between the two installs (matches haloai semantics).

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -715,6 +715,109 @@ def test_rollback_swaps_symlink_back(
     assert "hal0-0.0.2" in _previous_record().read_text(encoding="utf-8")
 
 
+# ── rollback re-pip into venv (#980) ──────────────────────────────────────────
+
+
+def test_rollback_repips_prior_tree_when_not_editable(
+    synthetic_release: dict[str, Any],
+    cosign_skip: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prod (non-editable) rollback re-pips the prior tree into the venv (#980).
+
+    After apply() v1 → apply() v2 → rollback(), _reinstall_into_venv must be
+    called with the v1 (prior) install directory so the next hal0-api restart
+    actually runs v1, not the v2 code still in site-packages.
+    """
+    # Land v0.0.1.
+    asyncio.run(Updater().apply())
+    v1_dir = _versioned_install_dir("0.0.1")
+
+    # Build and apply v0.0.2.
+    artifacts = tmp_path / "v2"
+    artifacts.mkdir()
+    tarball2 = _build_release_tarball(tmp=artifacts, version="0.0.2")
+    sig2 = artifacts / "hal0-0.0.2.tar.gz.sig"
+    sig2.write_bytes(b"sig")
+    cert2 = artifacts / "hal0-0.0.2.tar.gz.crt"
+    cert2.write_bytes(b"cert")
+    _write_release_manifest(
+        manifest_path=Path(os.environ["HAL0_RELEASES_URL"]),
+        tarball=tarball2,
+        sig=sig2,
+        cert=cert2,
+        version="0.0.2",
+    )
+    asyncio.run(Updater().apply())
+    assert Path(os.readlink(_current_symlink())).name == "hal0-0.0.2"
+
+    # Capture _reinstall_into_venv calls during rollback.
+    calls: list[Path] = []
+
+    def _capture(install_dir: Path, *, job_id: str | None = None) -> None:
+        calls.append(install_dir)
+
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
+    monkeypatch.setattr("hal0.updater.updater._reinstall_into_venv", _capture)
+
+    res = asyncio.run(Updater().rollback())
+
+    # rollback returned the prior (v0.0.1) path.
+    assert "hal0-0.0.1" in res["rolled_back_to"]
+    # _reinstall_into_venv was called exactly once with the v0.0.1 dir.
+    assert calls == [v1_dir]
+    # Symlink points at v0.0.1.
+    assert Path(os.readlink(_current_symlink())).name == "hal0-0.0.1"
+
+
+def test_rollback_repip_failure_re_swaps_symlink_forward(
+    synthetic_release: dict[str, Any],
+    cosign_skip: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing re-pip during rollback swaps `current` forward again (#980).
+
+    If _reinstall_into_venv raises during rollback, the symlink must be
+    restored to the version we just rolled *away from* (current_target) so
+    that the symlink and the venv's installed code remain consistent.
+    """
+    # Land v0.0.1.
+    asyncio.run(Updater().apply())
+
+    # Build and apply v0.0.2.
+    artifacts = tmp_path / "v2"
+    artifacts.mkdir()
+    tarball2 = _build_release_tarball(tmp=artifacts, version="0.0.2")
+    sig2 = artifacts / "hal0-0.0.2.tar.gz.sig"
+    sig2.write_bytes(b"sig")
+    cert2 = artifacts / "hal0-0.0.2.tar.gz.crt"
+    cert2.write_bytes(b"cert")
+    _write_release_manifest(
+        manifest_path=Path(os.environ["HAL0_RELEASES_URL"]),
+        tarball=tarball2,
+        sig=sig2,
+        cert=cert2,
+        version="0.0.2",
+    )
+    asyncio.run(Updater().apply())
+    assert Path(os.readlink(_current_symlink())).name == "hal0-0.0.2"
+
+    # Force the re-pip to fail.
+    def _boom(install_dir: Path, *, job_id: str | None = None) -> None:
+        raise UpdateError("pip reinstall failed during rollback", details={})
+
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
+    monkeypatch.setattr("hal0.updater.updater._reinstall_into_venv", _boom)
+
+    with pytest.raises(UpdateError):
+        asyncio.run(Updater().rollback())
+
+    # Symlink should be restored to v0.0.2 (the version we tried to leave).
+    assert Path(os.readlink(_current_symlink())).name == "hal0-0.0.2"
+
+
 # ── channel switching ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Fixes #980

## Summary

- `rollback()` atomic-swapped the `current` symlink but never called `_reinstall_into_venv()`, so after `apply()` installed version N into site-packages, a rollback flipped the symlink to N-1 while `import hal0` still resolved to N — making `hal0 update --rollback` silently a no-op on prod.
- Add `_reinstall_into_venv(prior_path, job_id=self.job_id)` inside `rollback()` after the successful atomic symlink swap, guarded by `if not _is_editable_install():`, mirroring the `apply()` pattern introduced in #495.
- On re-pip failure during rollback, swap the symlink forward again (back to `current_target`) to keep the symlink and venv-installed code consistent — same failure-recovery pattern `apply()` uses.
- Update the `rollback()` docstring to document the step-8b re-pip.

## Tests added

Two new tests in `tests/updater/test_updater.py`:

- `test_rollback_repips_prior_tree_when_not_editable` — asserts `_reinstall_into_venv` is called exactly once with the prior path when rolling back a non-editable install. This test **fails on the unpatched code** (calls list remains empty).
- `test_rollback_repip_failure_re_swaps_symlink_forward` — asserts that if the re-pip raises during rollback, the symlink is swapped forward again (consistency). This test **fails on the unpatched code** (symlink stays at the prior path instead of being restored to current).

Local result: **50/50 passed** (`PYTHONPATH=/tmp/hal0-wt-980/src pytest tests/updater/ -q`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)