### PR TITLE
fix(dispatcher): container slots now enter SERVING and bump last_used_at (#746)

### DIFF
--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -369,8 +369,10 @@ class UpstreamCall:
     503 instead of a raw 502 ConnectError.
 
     Deliberately separate from ``slot_name`` — container remotes must NOT
-    enter the ``_ensure_slot_loaded_backend_aware`` / ``_forward_with_serving``
-    path (no auto-load, no SERVING state wrap).
+    enter the ``_ensure_slot_loaded_backend_aware`` path (no auto-load).
+    They DO enter ``_forward_with_serving`` so the slot transitions
+    READY → SERVING → READY around each request and ``last_used_at`` is
+    bumped correctly (#746).
     """
 
     latency_ms: float = 0.0
@@ -779,6 +781,10 @@ class Dispatcher:
             # gets a structured slot.loading 503 with Retry-After instead of
             # a raw 502 ConnectError when the container is down or starting.
             await self._check_container_slot_ready(call)
+            # Mirror the slot_name branch: wrap the forward in the serving
+            # context so the slot transitions READY → SERVING → READY and
+            # last_used_at is bumped around every request (#746).
+            return await self._forward_with_serving(call)
         return await self._forward_plain(call)
 
     def _guard_gpu_image_mode(self, call: UpstreamCall) -> None:
@@ -966,7 +972,10 @@ class Dispatcher:
         finishes consuming the stream (or the response is GC'd).
         """
         assert self._slot_manager is not None  # narrowed by forward()
-        ctx = self._slot_manager.serving(call.slot_name)
+        # Use the effective slot name: slot_name for kind=slot upstreams,
+        # container_slot_name for container-backed kind=remote upstreams (#746).
+        effective_slot = call.slot_name or call.container_slot_name
+        ctx = self._slot_manager.serving(effective_slot)
         await ctx.__aenter__()
         released = False
 
@@ -980,7 +989,7 @@ class Dispatcher:
             except Exception as exc:  # never bury the request's outcome
                 log.warning(
                     "dispatch.serving_release_failed",
-                    slot=call.slot_name,
+                    slot=effective_slot,
                     error=str(exc),
                 )
 

--- a/tests/dispatcher/test_serving_integration.py
+++ b/tests/dispatcher/test_serving_integration.py
@@ -423,3 +423,131 @@ async def test_forward_remote_protocol_error_raises_upstream_unavailable() -> No
         assert calls["n"] == 1
     finally:
         await dispatcher.aclose()
+
+
+# ── container-slot serving (#746) ────────────────────────────────────────────
+#
+# Post-container-migration (#723) every slot is container-backed.  The old
+# code routed container_slot_name calls through _forward_plain (no serving
+# context, no last_used_at bump).  These tests verify the fix: the container
+# branch now enters _forward_with_serving so the slot state machine fires.
+
+
+class _RecordingContainerSlotManager(_RecordingSlotManager):
+    """Extends _RecordingSlotManager with a container_readiness_check stub.
+
+    Returning (True, "ready") by default so the gate passes through and
+    _forward_with_serving is reached.
+    """
+
+    def __init__(self, state: SlotState = SlotState.READY) -> None:
+        super().__init__(state=state)
+
+    async def container_readiness_check(self, slot_name: str) -> tuple[bool, str]:
+        return (True, "ready")
+
+
+def _container_slot_call(streaming: bool = False) -> UpstreamCall:
+    """UpstreamCall with container_slot_name set and slot_name empty."""
+    return UpstreamCall(
+        upstream_name="agent",
+        target_url="http://127.0.0.1:8090/v1/chat/completions",
+        headers={"content-type": "application/json"},
+        body=b"{}",
+        streaming=streaming,
+        method="POST",
+        slot_name="",  # container remotes carry no slot_name
+        container_slot_name="agent",
+    )
+
+
+@pytest.mark.asyncio
+async def test_container_slot_call_enters_and_exits_serving() -> None:
+    """A container-slot call (slot_name='', container_slot_name set) must
+    enter serving() and exit it — verifying READY→SERVING→READY and that
+    last_used_at is bumped (#746).
+    """
+    sm = _RecordingContainerSlotManager()
+    dispatcher = _make_dispatcher(
+        httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True})),
+        sm=sm,
+    )
+    try:
+        resp = await dispatcher.forward(_container_slot_call())
+        assert resp.status_code == 200
+        assert sm.events == [("enter", "agent"), ("exit", "agent")]
+        assert sm.in_flight_count("agent") == 0
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_container_slot_call_uses_container_slot_name_not_slot_name() -> None:
+    """serving() receives container_slot_name (not slot_name) as the key.
+
+    Defends against a regression where the effective-slot logic falls back
+    to slot_name (empty string) and serving("") is called instead.
+    """
+    sm = _RecordingContainerSlotManager()
+    dispatcher = _make_dispatcher(
+        httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True})),
+        sm=sm,
+    )
+    try:
+        await dispatcher.forward(_container_slot_call())
+        # The slot key must be the container name, never the empty string.
+        entered_slots = [slot for op, slot in sm.events if op == "enter"]
+        assert entered_slots == ["agent"], f"unexpected serving key(s): {entered_slots}"
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_container_slot_streaming_holds_serving_until_drain() -> None:
+    """Streaming container-slot call keeps SERVING open until the body drains."""
+    sm = _RecordingContainerSlotManager()
+    chunks = [b"data: a\n\n", b"data: [DONE]\n\n"]
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            stream=httpx.ByteStream(b"".join(chunks)),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm=sm)
+    try:
+        resp = await dispatcher.forward(_container_slot_call(streaming=True))
+        # forward() returns but the stream hasn't drained — SERVING held open.
+        assert sm.events == [("enter", "agent")]
+        assert sm.in_flight_count("agent") == 1
+
+        collected = b""
+        async for c in resp.body_iterator:
+            collected += c if isinstance(c, bytes) else c.encode()
+
+        # After drain, exit fires.
+        assert collected == b"".join(chunks)
+        assert sm.events == [("enter", "agent"), ("exit", "agent")]
+        assert sm.in_flight_count("agent") == 0
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_container_slot_network_error_releases_serving() -> None:
+    """A ConnectError on a container-slot call must still release serving()."""
+    sm = _RecordingContainerSlotManager()
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=req)
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm=sm)
+    try:
+        with pytest.raises(UpstreamUnavailable):
+            await dispatcher.forward(_container_slot_call())
+        assert sm.in_flight_count("agent") == 0
+        ops = [op for op, _ in sm.events]
+        assert ops == ["enter", "exit"]
+    finally:
+        await dispatcher.aclose()


### PR DESCRIPTION
Fixes #746

## Summary

- Container-slot calls (`container_slot_name` set, `slot_name` empty) were being routed through `_forward_plain` after the `_check_container_slot_ready` gate, bypassing `SlotManager.serving()` entirely. Post-#723 (every slot is container-backed), this made SERVING state and `last_used_at` dead for the whole platform — dashboard slot dots were stuck "ready" and the idle clock never advanced.
- `_forward_with_serving` hardcoded `call.slot_name` as the key passed to `SlotManager.serving()`, which would have been empty for container calls even if routed there.

## Changes

**`src/hal0/dispatcher/router.py`**

1. `forward()`: after `_check_container_slot_ready`, call `_forward_with_serving` instead of `_forward_plain` — mirrors the `slot_name` branch exactly.
2. `_forward_with_serving`: compute `effective_slot = call.slot_name or call.container_slot_name` and use it for `serving()` and the warning log, so both slot-kind and container-kind upstreams get the right key.
3. `UpstreamCall.container_slot_name` docstring: update the design note — container remotes now DO enter the serving path; only the auto-load path (`_ensure_slot_loaded_backend_aware`) remains excluded.

## Tests

Added 4 new tests in `tests/dispatcher/test_serving_integration.py` (all would fail against the old code):

| Test | Asserts |
|------|---------|
| `test_container_slot_call_enters_and_exits_serving` | Non-streaming container call produces `(enter, agent)` + `(exit, agent)` events |
| `test_container_slot_call_uses_container_slot_name_not_slot_name` | `serving()` receives `"agent"` not `""` |
| `test_container_slot_streaming_holds_serving_until_drain` | Streaming call holds SERVING open until body iterator drains, then releases |
| `test_container_slot_network_error_releases_serving` | `ConnectError` still releases the serving counter |

Local result: **150/150 passed** (`PYTHONPATH=/tmp/hal0-wt-746/src /mnt/repos/hal0-mono/hal0/.venv/bin/python -m pytest tests/dispatcher/ -q`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)