### PR TITLE
fix(images): move ensure_img() before dispatch() to fix cold-slot 404 (#725)

### DIFF
--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -1014,44 +1014,17 @@ async def images_generations(request: Request, dispatcher: DispatcherDep) -> Res
     if not body.get("prompt"):
         raise _ImagePromptRequired("body.prompt is required")
 
-    # 1. Resolve the slot the request should land on. We dispatch to get
-    #    the port + slot name; the dispatcher's heuristics already route
-    #    /v1/images/* to the `img` slot via the legacy fallback rule.
-    call = await dispatcher.dispatch(request, body=body)
-
-    # 2. Find the curated metadata for the requested model id so we know
-    #    which workflow template + checkpoint filename to pin into the
-    #    workflow.
-    requested = (body.get("model") or "").strip() or "sdxl-turbo"
-    curated = get_curated(requested)
-    if curated is None or curated.capability != "image":
-        raise _ImageModelNotCurated(
-            f"model {requested!r} is not in the curated image-gen catalogue; "
-            "current built-ins: sdxl-turbo, sd-1.5-pruned-emaonly",
-            details={"model": requested},
-        )
-
-    # 3. Discover the local slot's port from the resolved upstream.
-    upstream = request.app.state.upstreams.get(call.upstream_name)
-    if upstream is None:
-        raise NoRouteFound(
-            f"image-gen dispatch landed on upstream {call.upstream_name!r} which is not registered",
-            details={"upstream": call.upstream_name},
-        )
-    port = _extract_port_from_upstream_url(upstream.url)
-    if port is None:
-        raise UpstreamUnavailable(
-            f"image-gen upstream {call.upstream_name!r} has no parseable port "
-            f"in url={upstream.url!r}",
-            details={"upstream": call.upstream_name, "url": upstream.url},
-        )
-
-    # 4. GPU arbitration (Phase D, spec §7). Flip the GPU to exclusive
-    #    image mode BEFORE dispatching to the img upstream (unloads llm
-    #    GPU slots, loads the img slot), and stamp img activity at request
-    #    START and again at COMPLETION so long Wan video jobs keep the
-    #    idle-restore window open. Also seed #599 request defaults from
-    #    the img slot's [image] section (default_size / default_steps).
+    # 1. GPU arbitration (Phase D, spec §7) — BEFORE dispatch so the img
+    #    upstream is registered before resolve_by_capability runs.  When the
+    #    img slot is cold (the normal idle state after arbiter restore_llm),
+    #    ensure_img() cold-starts the container which calls
+    #    _register_container_upstream; without this, dispatch's Rule-4 path
+    #    selects slot "img" but no upstream exists yet and raises
+    #    LegacyResolutionFailed → 404.  Fix for issue #725.
+    #
+    #    Also seed #599 request defaults from the img slot's [image] section
+    #    (default_size / default_steps) here — before dispatch — so the body
+    #    the dispatcher sees already has the resolved defaults.
     manager = getattr(request.app.state, "slot_manager", None)
     arbiter = manager.arbiter if manager is not None else None
     if manager is not None:
@@ -1085,6 +1058,38 @@ async def images_generations(request: Request, dispatcher: DispatcherDep) -> Res
             if exc.code != "gpu.img_slot_missing":
                 raise
         arbiter.touch_img_activity()
+
+    # 2. Resolve the slot the request should land on.  ensure_img() above
+    #    guarantees the img upstream is registered, so resolve_by_capability
+    #    Rule 4 (/images/ path) succeeds even on a cold slot.
+    call = await dispatcher.dispatch(request, body=body)
+
+    # 3. Find the curated metadata for the requested model id so we know
+    #    which workflow template + checkpoint filename to pin into the
+    #    workflow.
+    requested = (body.get("model") or "").strip() or "sdxl-turbo"
+    curated = get_curated(requested)
+    if curated is None or curated.capability != "image":
+        raise _ImageModelNotCurated(
+            f"model {requested!r} is not in the curated image-gen catalogue; "
+            "current built-ins: sdxl-turbo, sd-1.5-pruned-emaonly",
+            details={"model": requested},
+        )
+
+    # 4. Discover the local slot's port from the resolved upstream.
+    upstream = request.app.state.upstreams.get(call.upstream_name)
+    if upstream is None:
+        raise NoRouteFound(
+            f"image-gen dispatch landed on upstream {call.upstream_name!r} which is not registered",
+            details={"upstream": call.upstream_name},
+        )
+    port = _extract_port_from_upstream_url(upstream.url)
+    if port is None:
+        raise UpstreamUnavailable(
+            f"image-gen upstream {call.upstream_name!r} has no parseable port "
+            f"in url={upstream.url!r}",
+            details={"upstream": call.upstream_name, "url": upstream.url},
+        )
 
     # 5. Drive the ComfyUI provider directly. Inject the curated metadata
     #    into the body so the provider's translator knows what to render

--- a/tests/api/test_v1_images.py
+++ b/tests/api/test_v1_images.py
@@ -17,7 +17,7 @@ this exercises:
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/api/test_v1_images.py
+++ b/tests/api/test_v1_images.py
@@ -10,12 +10,14 @@ this exercises:
   * b64_json response_format → inline base64 PNG.
   * GET /api/images/cache/{name}.png serves the cached bytes.
   * Cache-miss + path-traversal attempt 404 cleanly.
+  * Cold-slot path (issue #725): ensure_img() runs before dispatch so the
+    img upstream is registered before resolve_by_capability runs.
 """
 
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -194,6 +196,95 @@ def test_v1_images_provider_error_surfaces(
     )
     assert r.status_code == 502
     assert r.json()["error"]["code"] == "dispatch.upstream_failed"
+
+
+# ─── cold-slot dispatch path (issue #725) ────────────────────────────────────
+
+
+def test_v1_images_cold_slot_ensure_img_before_dispatch(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_hal0_home: str,
+) -> None:
+    """Regression test for #725: ensure_img() must run BEFORE dispatcher.dispatch().
+
+    Repro path (before fix):
+      - img upstream NOT registered (cold/idle slot)
+      - dispatcher.dispatch() → resolve_by_capability selects "img" (Rule 4)
+      - no "img" upstream in registry → LegacyResolutionFailed → 404
+
+    After fix, ensure_img() runs first and registers the upstream, so dispatch
+    succeeds.  We simulate this by installing a fake slot_manager/arbiter whose
+    ensure_img() side-effect registers the img upstream in app.state.upstreams,
+    exactly as the real arbiter does via _register_container_upstream.
+    """
+    fake_png = b"\x89PNG\r\n\x1a\n" + b"c" * 64
+
+    mock_infer = AsyncMock(
+        return_value={
+            "images": [
+                {
+                    "png": fake_png,
+                    "filename": "cold-slot-test.png",
+                    "subfolder": "",
+                    "type": "output",
+                }
+            ],
+            "meta": {"template": "sdxl_turbo_simple", "seed": 42, "width": 512, "height": 512},
+            "prompt_id": "cold725",
+        }
+    )
+    from hal0.providers import get_provider
+
+    monkeypatch.setattr(get_provider("comfyui"), "infer", mock_infer)
+
+    # Build a fake arbiter whose ensure_img() registers the upstream,
+    # simulating what the real arbiter does when it cold-starts the container.
+    upstreams = client.app.state.upstreams
+    _PORT = 8186
+
+    class _FakeArbiter:
+        async def ensure_img(self) -> None:
+            # Simulate _register_container_upstream: wire the img upstream
+            # so that resolve_by_capability Rule 4 can find it.
+            upstreams.upsert(
+                Upstream(
+                    name="img",
+                    kind="slot",
+                    url=f"http://127.0.0.1:{_PORT}/v1",
+                    slot_name="img",
+                    auth_style="none",
+                )
+            )
+
+        def touch_img_activity(self) -> None:
+            pass
+
+    class _FakeSlotManager:
+        arbiter = _FakeArbiter()
+
+        async def iter_configs(self) -> list[dict[str, Any]]:
+            # Return a config that gpu_exclusive_group() classifies as "img":
+            # provider=="comfyui" on a container slot (runtime=="container",
+            # device defaults to gpu-rocm).
+            return [{"name": "img", "provider": "comfyui", "enabled": True}]
+
+    # Verify that WITHOUT our fix the upstream is NOT pre-registered.
+    assert upstreams.get("img") is None, "upstream must be absent at test start"
+
+    client.app.state.slot_manager = _FakeSlotManager()
+
+    r = client.post(
+        "/v1/images/generations",
+        json={"model": "sdxl-turbo", "prompt": "cold slot test"},
+    )
+    # Must succeed — not 404 dispatch.no_route / dispatch.legacy_failed.
+    assert r.status_code == 200, (
+        f"cold-slot dispatch failed with {r.status_code}: {r.text}\n"
+        "This is the #725 regression: ensure_img() must run before dispatch()."
+    )
+    body = r.json()
+    assert body["data"], "expected at least one image in the response"
 
 
 # ─── image cache route ────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #725

## Problem

`POST /v1/images/generations` returns a 404 `dispatch.no_route` whenever the img (ComfyUI) slot is cold — the normal idle state after the arbiter's `restore_llm` unloads the container.

The handler called `dispatcher.dispatch()` **before** `arbiter.ensure_img()`. The dispatcher's `resolve_by_capability` Rule 4 selects slot `"img"` based on the `/images/` path, but with no container upstream registered yet it raises `LegacyResolutionFailed` → 404. Generation only worked when the img slot was already active (e.g. after `POST /api/comfyui/switchover`), which is why the Phase D/E e2es passed.

## Fix

Move the GPU arbitration block — `ensure_img()` plus the `[image]` config-defaults seeding — to run **before** `dispatcher.dispatch()`. The arbiter cold-starts the container (which calls `_register_container_upstream`), so the `"img"` upstream is present when dispatch's Rule 4 runs.

The `NotFound(code='gpu.img_slot_missing')` guard is preserved and still short-circuits cleanly when no img-group slot is configured (manually-registered upstreams, existing tests).

## Changes

- `src/hal0/api/routes/v1.py`: reorder `images_generations` handler — GPU arbitration (step 1) moves before dispatch (step 2); renumber comments to match new order; no logic changes beyond ordering.
- `tests/api/test_v1_images.py`: add `test_v1_images_cold_slot_ensure_img_before_dispatch` — installs a fake slot_manager/arbiter whose `ensure_img()` registers the img upstream (simulating `_register_container_upstream`); asserts 200 not 404; fails without the ordering fix.

## Test results

```
tests/api/test_v1_images.py::test_v1_images_cold_slot_ensure_img_before_dispatch PASSED
9/9 tests in test_v1_images.py passed
1091/1095 tests/api/ passed (4 pre-existing failures unrelated to this change)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)