### PR TITLE
fix(dispatcher): bound httpx pool and reduce direct read timeout (#415)

### DIFF
--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -156,6 +156,19 @@ _TTS_DEFAULT = "tts"
 # Phase D: model-less /v1/images/* requests default to the img slot (ComfyUI).
 _IMAGE_DEFAULT = "img"
 
+# Dispatcher HTTP client connection limits — mirrors the bounded pattern in
+# src/hal0/upstreams/registry.py.  Keeps the dispatcher pool from starving
+# new requests when many slow upstream calls are in-flight (#415).
+_DISPATCHER_MAX_CONNECTIONS: int = 64
+_DISPATCHER_MAX_KEEPALIVE: int = 16
+
+# Non-streaming (direct) read timeout.  300 s was too generous: a stuck
+# upstream could hold a connection slot for 5 min, rapidly exhausting the
+# pool under even modest sustained load.  60 s is still well above the
+# longest expected non-streaming completion time (and streaming paths are
+# unaffected — the read timeout is not applied once the stream is open).
+_DIRECT_READ_TIMEOUT_S: float = 60.0
+
 # Outgoing upstream path rewrites applied before forwarding.
 # Key: incoming /v1/* path (as-is from the client).
 # Value: replacement path to use in the upstream URL.
@@ -470,10 +483,22 @@ class Dispatcher:
 
     def _get_http_client(self) -> httpx.AsyncClient:
         if self._http_client is None:
-            # Long read timeout for slow generation; short connect/write/pool.
-            # Streaming responses ignore the read timeout once the stream starts.
+            # Short connect/write/pool; non-streaming read capped at
+            # _DIRECT_READ_TIMEOUT_S (streaming paths ignore the read timeout
+            # once the first byte arrives — see httpx docs on stream=True).
+            # Connection limits match registry.py to prevent pool starvation
+            # under sustained slow-upstream load (#415).
             self._http_client = httpx.AsyncClient(
-                timeout=httpx.Timeout(connect=5.0, read=300.0, write=10.0, pool=5.0),
+                timeout=httpx.Timeout(
+                    connect=5.0,
+                    read=_DIRECT_READ_TIMEOUT_S,
+                    write=10.0,
+                    pool=5.0,
+                ),
+                limits=httpx.Limits(
+                    max_connections=_DISPATCHER_MAX_CONNECTIONS,
+                    max_keepalive_connections=_DISPATCHER_MAX_KEEPALIVE,
+                ),
                 follow_redirects=False,
             )
         return self._http_client

--- a/tests/dispatcher/test_pool_bounds.py
+++ b/tests/dispatcher/test_pool_bounds.py
@@ -15,20 +15,17 @@ a bounded error rather than hanging indefinitely.
 
 from __future__ import annotations
 
-import asyncio
-
 import httpx
 import pytest
 
 from hal0.dispatcher.router import (
-    Dispatcher,
-    UpstreamCall,
-    UpstreamUnavailable,
     _DIRECT_READ_TIMEOUT_S,
     _DISPATCHER_MAX_CONNECTIONS,
     _DISPATCHER_MAX_KEEPALIVE,
+    Dispatcher,
+    UpstreamCall,
+    UpstreamUnavailable,
 )
-
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -54,9 +51,7 @@ def _call(
 def test_dispatcher_pool_constants_are_bounded() -> None:
     """The module constants must reflect the bounded values from the fix."""
     # Before the fix these didn't exist; importing them would NameError.
-    assert _DISPATCHER_MAX_CONNECTIONS == 64, (
-        "max_connections should be 64, matching registry.py"
-    )
+    assert _DISPATCHER_MAX_CONNECTIONS == 64, "max_connections should be 64, matching registry.py"
     assert _DISPATCHER_MAX_KEEPALIVE == 16, (
         "max_keepalive_connections should be 16, matching registry.py"
     )
@@ -93,8 +88,7 @@ def test_lazy_http_client_read_timeout() -> None:
     d = Dispatcher()
     client = d._get_http_client()
     assert client.timeout.read == _DIRECT_READ_TIMEOUT_S, (
-        f"Client read timeout is {client.timeout.read} s, "
-        f"expected {_DIRECT_READ_TIMEOUT_S} s"
+        f"Client read timeout is {client.timeout.read} s, expected {_DIRECT_READ_TIMEOUT_S} s"
     )
 
 

--- a/tests/dispatcher/test_pool_bounds.py
+++ b/tests/dispatcher/test_pool_bounds.py
@@ -1,0 +1,147 @@
+"""Regression tests for dispatcher HTTP client pool bounds (#415).
+
+Without the fix:
+  - The dispatcher's shared httpx.AsyncClient had no connection limits
+    (httpx default = 100 max_connections) and a 300 s read timeout,
+    allowing slow upstreams to exhaust the pool and starve new requests.
+
+With the fix:
+  - max_connections=64, max_keepalive_connections=16  (matches registry.py)
+  - non-streaming read timeout = 60 s  (was 300 s)
+
+These tests verify those bounds are in place and that the pool surfaces
+a bounded error rather than hanging indefinitely.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from hal0.dispatcher.router import (
+    Dispatcher,
+    UpstreamCall,
+    UpstreamUnavailable,
+    _DIRECT_READ_TIMEOUT_S,
+    _DISPATCHER_MAX_CONNECTIONS,
+    _DISPATCHER_MAX_KEEPALIVE,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _call(
+    *,
+    streaming: bool = False,
+    target: str = "http://upstream.test/v1/chat/completions",
+) -> UpstreamCall:
+    return UpstreamCall(
+        upstream_name="test-upstream",
+        target_url=target,
+        headers={"content-type": "application/json"},
+        body=b'{"model":"agent"}',
+        streaming=streaming,
+        method="POST",
+    )
+
+
+# ── constant assertions (fail without the fix) ────────────────────────────────
+
+
+def test_dispatcher_pool_constants_are_bounded() -> None:
+    """The module constants must reflect the bounded values from the fix."""
+    # Before the fix these didn't exist; importing them would NameError.
+    assert _DISPATCHER_MAX_CONNECTIONS == 64, (
+        "max_connections should be 64, matching registry.py"
+    )
+    assert _DISPATCHER_MAX_KEEPALIVE == 16, (
+        "max_keepalive_connections should be 16, matching registry.py"
+    )
+
+
+def test_direct_read_timeout_reduced() -> None:
+    """Non-streaming read timeout must be <= 60 s (was 300 s before the fix)."""
+    assert _DIRECT_READ_TIMEOUT_S <= 60.0, (
+        f"Non-streaming read timeout is {_DIRECT_READ_TIMEOUT_S} s — "
+        "must be <= 60 s to prevent pool starvation (#415)"
+    )
+
+
+# ── lazy-client construction (fail without limits= kwarg) ─────────────────────
+
+
+def test_lazy_http_client_has_bounded_pool() -> None:
+    """The lazily-constructed client must carry the connection limits."""
+    d = Dispatcher()
+    client = d._get_http_client()
+    pool = client._transport._pool  # httpcore.AsyncConnectionPool
+    assert pool._max_connections == _DISPATCHER_MAX_CONNECTIONS, (
+        f"Expected max_connections={_DISPATCHER_MAX_CONNECTIONS}, "
+        f"got {pool._max_connections} — limits= not passed to AsyncClient"
+    )
+    assert pool._max_keepalive_connections == _DISPATCHER_MAX_KEEPALIVE, (
+        f"Expected max_keepalive_connections={_DISPATCHER_MAX_KEEPALIVE}, "
+        f"got {pool._max_keepalive_connections}"
+    )
+
+
+def test_lazy_http_client_read_timeout() -> None:
+    """The lazily-constructed client's read timeout must use the constant."""
+    d = Dispatcher()
+    client = d._get_http_client()
+    assert client.timeout.read == _DIRECT_READ_TIMEOUT_S, (
+        f"Client read timeout is {client.timeout.read} s, "
+        f"expected {_DIRECT_READ_TIMEOUT_S} s"
+    )
+
+
+# ── pool-exhaustion / timeout surfaces as error not hang ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pool_timeout_raises_upstream_unavailable() -> None:
+    """A PoolTimeout from a saturated pool surfaces as UpstreamUnavailable.
+
+    We inject an httpx.PoolTimeout via a transport that raises it directly,
+    simulating what happens when all connections in a bounded pool are
+    occupied.  Before #415 the dispatcher had no limits= so PoolTimeout
+    would never fire; after the fix, _forward_direct catches the broader
+    httpx.HTTPError (which PoolTimeout extends) and wraps it.
+    """
+
+    def pool_timeout_handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.PoolTimeout("connection pool is full", request=req)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(pool_timeout_handler))
+    dispatcher = Dispatcher(http_client=client)
+
+    try:
+        with pytest.raises(UpstreamUnavailable) as exc_info:
+            await dispatcher.forward(_call(streaming=False))
+        # Ensure the error is correctly attributed and carries the upstream name.
+        assert "test-upstream" in exc_info.value.message
+        assert exc_info.value.status == 502
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pool_timeout_streaming_raises_upstream_unavailable() -> None:
+    """A PoolTimeout on stream-open also surfaces as UpstreamUnavailable."""
+
+    def pool_timeout_handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.PoolTimeout("connection pool is full", request=req)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(pool_timeout_handler))
+    dispatcher = Dispatcher(http_client=client)
+
+    try:
+        with pytest.raises(UpstreamUnavailable) as exc_info:
+            await dispatcher.forward(_call(streaming=True))
+        assert "test-upstream" in exc_info.value.message
+        assert exc_info.value.status == 502
+    finally:
+        await dispatcher.aclose()


### PR DESCRIPTION
Fixes #415

## Summary

- **Add `limits=httpx.Limits(max_connections=64, max_keepalive_connections=16)`** to the dispatcher's shared `httpx.AsyncClient` in `src/hal0/dispatcher/router.py`. Before this change the client used httpx's default of 100 unbounded connections; a slow upstream could hold each slot open for up to 5 min, rapidly exhausting the pool and starving new requests. The values match the bounded pattern already in `src/hal0/upstreams/registry.py`.
- **Reduce non-streaming read timeout from 300 s → 60 s** via a new module constant `_DIRECT_READ_TIMEOUT_S`. Streaming paths are unaffected: httpx does not apply the read timeout once the first byte of a stream arrives, so SSE/chunk responses have the same behaviour as before.
- **Add module constants** `_DISPATCHER_MAX_CONNECTIONS`, `_DISPATCHER_MAX_KEEPALIVE`, and `_DIRECT_READ_TIMEOUT_S` so the values are easy to find and tune without hunting inside `_get_http_client`.

## Tests added — `tests/dispatcher/test_pool_bounds.py`

| Test | What it covers |
|------|---------------|
| `test_dispatcher_pool_constants_are_bounded` | Imports the new module constants and asserts expected values — would `NameError` or `AssertionError` without the fix |
| `test_direct_read_timeout_reduced` | Asserts `_DIRECT_READ_TIMEOUT_S <= 60.0` — fails against the old 300 s default |
| `test_lazy_http_client_has_bounded_pool` | Instantiates a bare `Dispatcher()`, calls `_get_http_client()`, and inspects `httpcore.AsyncConnectionPool._max_connections` — fails if `limits=` is absent |
| `test_lazy_http_client_read_timeout` | Verifies the lazily-constructed client's `timeout.read` matches the constant |
| `test_pool_timeout_raises_upstream_unavailable` | Injects `httpx.PoolTimeout` via `MockTransport`; asserts it is caught and wrapped into `UpstreamUnavailable` (non-streaming path) |
| `test_pool_timeout_streaming_raises_upstream_unavailable` | Same for the streaming `_forward_streaming` path |

Local result: **156/156 passed** (all `tests/dispatcher/` tests, including pre-existing suite)

```
cd /tmp/hal0-wt-415 && PYTHONPATH=/tmp/hal0-wt-415/src /mnt/repos/hal0-mono/hal0/.venv/bin/python -m pytest tests/dispatcher/ -q
156 passed, 1 warning in 1.45s
```

## Follow-up (not in this PR)

Exposing pool `in_use` / `max_connections` gauges on `/api/health` or `/api/services_health` would give operators early warning of saturation before it manifests as 502s. Scope was intentionally left out here to keep the diff minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)