### PR TITLE
fix(dispatcher): raise SlotLoadFailed (non-retryable 502) for ERROR slots (#987)

### DIFF
--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -49,6 +49,7 @@ from fastapi.responses import Response, StreamingResponse
 from hal0.dispatcher.single_flight import SingleFlightGroup
 from hal0.errors import Hal0Error
 from hal0.slots.manager import SLOT_ALIASES
+from hal0.slots.state import SlotState
 from hal0.upstreams.registry import Upstream, UpstreamRegistry
 
 if TYPE_CHECKING:
@@ -286,6 +287,24 @@ class SlotLoading(DispatchError):
 
     code = "slot.loading"
     status = 503
+
+
+class SlotLoadFailed(DispatchError):
+    """The target slot encountered a hard load failure (``SlotState.ERROR``).
+
+    Raised by ``Dispatcher._check_slot_ready_for_dispatch`` when the slot
+    is in the terminal ``ERROR`` state rather than a transient loading
+    state.  Unlike :class:`SlotLoading`, this error is **non-retryable**:
+    the slot will not recover on its own, so clients must not retry.
+
+    Deliberately carries no ``retry_after_s`` in ``details`` so the error
+    middleware never emits a ``Retry-After`` header.  Status 502 (Bad
+    Gateway) signals a hard backend failure distinct from the 503 +
+    Retry-After that a loading slot emits.
+    """
+
+    code = "slot.load_failed"
+    status = 502
 
 
 class LegacyResolutionFailed(Hal0Error):
@@ -849,6 +868,20 @@ class Dispatcher:
                 error=str(exc),
                 error_type=type(exc).__name__,
             )
+            # Fix #987: if the slot is now in ERROR (hard load failure),
+            # raise SlotLoadFailed immediately rather than deferring to the
+            # ready-check — which cannot distinguish "still loading" from
+            # "permanently failed" and would return a retryable 503 instead.
+            if self._slot_manager.state(slot_name) == SlotState.ERROR:
+                raise SlotLoadFailed(
+                    f"slot {slot_name!r} failed to load — manual recovery required",
+                    details={
+                        "slot": slot_name,
+                        "state": SlotState.ERROR.value,
+                        "upstream": call.upstream_name,
+                        "load_error": str(exc),
+                    },
+                ) from exc
 
     async def _check_container_slot_ready(self, call: UpstreamCall) -> None:
         """Raise :class:`SlotLoading` if a container-backed slot isn't ready.
@@ -884,21 +917,36 @@ class Dispatcher:
             )
 
     def _check_slot_ready_for_dispatch(self, call: UpstreamCall) -> None:
-        """Raise :class:`SlotLoading` if the target slot isn't ready to serve.
+        """Raise a typed error if the target slot isn't ready to serve.
 
         Ready set: ``READY``, ``SERVING``, ``IDLE`` (per #696 — single source
         in :meth:`SlotManager.is_ready_for_dispatch`).  Any other state means
         the slot is mid-lifecycle (``OFFLINE``, ``PULLING``, ``STARTING``,
         ``WARMING``, ``UNLOADING``, ``ERROR``) and forwarding would either
         ConnectError or get a raw 503 from llama-server's "still loading"
-        gate.  We raise a typed error here so the middleware can emit a
-        structured envelope plus a ``Retry-After`` header.
+        gate.
+
+        ``ERROR`` is treated specially (fix #987): it is a **terminal** state
+        — the slot will not recover without operator intervention.  We raise
+        :class:`SlotLoadFailed` (502, no ``Retry-After``) so clients get a
+        non-retryable signal instead of hammering the API forever.  Every
+        other non-ready state gets the retryable :class:`SlotLoading` 503.
         """
         assert self._slot_manager is not None  # narrowed by caller
         if self._slot_manager.is_ready_for_dispatch(call.slot_name):
             return
 
         current = self._slot_manager.state(call.slot_name)
+        if current == SlotState.ERROR:
+            # Terminal failure — surface as non-retryable 502 (no Retry-After).
+            raise SlotLoadFailed(
+                f"slot {call.slot_name!r} failed to load — manual recovery required",
+                details={
+                    "slot": call.slot_name,
+                    "state": current.value,
+                    "upstream": call.upstream_name,
+                },
+            )
         raise SlotLoading(
             f"slot {call.slot_name!r} is {current.value} — not ready to serve",
             details=self._build_loading_response(call, current),
@@ -1507,6 +1555,8 @@ __all__ = [
     "LegacyResolutionFailed",
     "NoRouteFound",
     "RegistryLoadFailed",
+    "SlotLoadFailed",
+    "SlotLoading",
     "UnknownUpstream",
     "UpstreamCall",
     "UpstreamUnavailable",

--- a/tests/dispatcher/test_serving_integration.py
+++ b/tests/dispatcher/test_serving_integration.py
@@ -21,7 +21,7 @@ from typing import Any
 import httpx
 import pytest
 
-from hal0.dispatcher.router import Dispatcher, SlotLoading, UpstreamCall, UpstreamUnavailable
+from hal0.dispatcher.router import Dispatcher, SlotLoadFailed, SlotLoading, UpstreamCall, UpstreamUnavailable
 from hal0.slots.state import SlotState
 
 # ── tiny SlotManager stand-in ────────────────────────────────────────────────
@@ -243,17 +243,20 @@ async def test_single_flight_prefetch_does_not_enter_serving() -> None:
         SlotState.STARTING,
         SlotState.WARMING,
         SlotState.UNLOADING,
-        SlotState.ERROR,
     ],
 )
 @pytest.mark.asyncio
 async def test_forward_gates_slot_in_loading_state(state: SlotState) -> None:
-    """Every non-ready slot state must raise SlotLoading before the HTTP forward.
+    """Transient non-ready states raise SlotLoading (retryable 503) before the HTTP forward.
 
     Without the gate, requests in the swap window hit a dead port (502)
     or a still-loading llama-server (raw 503).  The gate raises a
     structured envelope with retry_after_s instead, which the error
     middleware promotes to a Retry-After header.
+
+    Note: SlotState.ERROR is intentionally excluded — it raises SlotLoadFailed
+    (non-retryable 502) rather than SlotLoading.  See
+    test_forward_error_state_raises_slot_load_failed below.
     """
     sm = _RecordingSlotManager(state=state)
 
@@ -274,6 +277,113 @@ async def test_forward_gates_slot_in_loading_state(state: SlotState) -> None:
         assert progress["phase"] == state.value
         assert progress["upstream"] == "primary"
         # No serving counter movement — the gate fires before _forward_with_serving.
+        assert sm.events == []
+        assert sm.in_flight_count("primary") == 0
+    finally:
+        await dispatcher.aclose()
+
+
+# ── ERROR state → SlotLoadFailed (fix #987) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_forward_error_state_raises_slot_load_failed() -> None:
+    """SlotState.ERROR must raise SlotLoadFailed (non-retryable 502), NOT SlotLoading.
+
+    A slot in ERROR has permanently failed — bad profile, OOM, missing
+    model file.  Returning a retryable 503 + Retry-After would cause the
+    client/SDK to hammer an endpoint that will never recover without
+    operator intervention.  SlotLoadFailed (502, no Retry-After) signals
+    a terminal failure so the client can surface a meaningful error.
+    """
+    sm = _RecordingSlotManager(state=SlotState.ERROR)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise AssertionError("forward must not reach upstream when slot is in ERROR")
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm=sm)
+    try:
+        with pytest.raises(SlotLoadFailed) as ei:
+            await dispatcher.forward(_slot_call())
+        exc = ei.value
+        assert exc.code == "slot.load_failed"
+        assert exc.status == 502
+        assert exc.details["slot"] == "primary"
+        assert exc.details["state"] == SlotState.ERROR.value
+        # Must NOT carry retry_after_s — the middleware must not emit Retry-After.
+        assert "retry_after_s" not in exc.details
+        # No serving counter movement — gate fires before _forward_with_serving.
+        assert sm.events == []
+        assert sm.in_flight_count("primary") == 0
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_forward_error_state_is_not_slot_loading() -> None:
+    """Regression guard: SlotState.ERROR must NOT surface as SlotLoading.
+
+    This test is designed to FAIL without the fix in _check_slot_ready_for_dispatch.
+    It complements test_forward_error_state_raises_slot_load_failed by
+    asserting the negative: the wrong error type is never raised.
+    """
+    sm = _RecordingSlotManager(state=SlotState.ERROR)
+    dispatcher = _make_dispatcher(
+        httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True})),
+        sm=sm,
+    )
+    try:
+        with pytest.raises(Exception) as ei:
+            await dispatcher.forward(_slot_call())
+        assert not isinstance(ei.value, SlotLoading), (
+            "SlotState.ERROR must not raise SlotLoading — "
+            "that would give the client a retryable Retry-After hint for a terminal failure"
+        )
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_backend_aware_load_failure_raises_slot_load_failed_immediately() -> None:
+    """When SlotManager.load() raises and leaves the slot in ERROR, raise SlotLoadFailed
+    immediately from _ensure_slot_loaded_backend_aware rather than deferring to the
+    ready-check (which would still mis-classify as loading before the fix).
+
+    The SlotManager stub here transitions to ERROR when load() raises,
+    mimicking a real load failure (bad profile, OOM, missing model).
+    """
+
+    class _ErrorOnLoadSlotManager(_RecordingSlotManager):
+        """Transitions slot to ERROR when load() raises."""
+
+        def __init__(self) -> None:
+            super().__init__(state=SlotState.OFFLINE)
+
+        def is_ready_for_dispatch(self, _slot_name: str) -> bool:
+            return self._state in _DISPATCHABLE_STATES
+
+        async def load(self, slot_name: str) -> None:
+            # Simulate a hard load failure: slot transitions to ERROR.
+            self._state = SlotState.ERROR
+            raise RuntimeError("model file not found: /models/missing.gguf")
+
+    sm = _ErrorOnLoadSlotManager()
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise AssertionError("forward must not reach upstream after load failure")
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm=sm)
+    try:
+        with pytest.raises(SlotLoadFailed) as ei:
+            await dispatcher.forward(_slot_call())
+        exc = ei.value
+        assert exc.code == "slot.load_failed"
+        assert exc.status == 502
+        assert exc.details["slot"] == "primary"
+        assert "retry_after_s" not in exc.details
+        # load_error carries the underlying exception message.
+        assert "missing.gguf" in exc.details.get("load_error", "")
+        # No serving counter movement.
         assert sm.events == []
         assert sm.in_flight_count("primary") == 0
     finally:

--- a/tests/dispatcher/test_serving_integration.py
+++ b/tests/dispatcher/test_serving_integration.py
@@ -21,7 +21,13 @@ from typing import Any
 import httpx
 import pytest
 
-from hal0.dispatcher.router import Dispatcher, SlotLoadFailed, SlotLoading, UpstreamCall, UpstreamUnavailable
+from hal0.dispatcher.router import (
+    Dispatcher,
+    SlotLoadFailed,
+    SlotLoading,
+    UpstreamCall,
+    UpstreamUnavailable,
+)
 from hal0.slots.state import SlotState
 
 # ── tiny SlotManager stand-in ────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #987

## Summary

- A slot in `SlotState.ERROR` is a **terminal** hard failure (bad profile, OOM, missing model file). Previously `_check_slot_ready_for_dispatch` raised `SlotLoading` (503 + `Retry-After: 15`) for **all** non-ready states including `ERROR`, so clients hammered an endpoint that would never recover.
- Adds `SlotLoadFailed` (`DispatchError`, code `slot.load_failed`, HTTP 502): carries no `retry_after_s`, so the error middleware never emits a `Retry-After` header — the client sees a non-retryable terminal signal immediately.
- Branches `_check_slot_ready_for_dispatch` on `SlotState.ERROR` to raise `SlotLoadFailed` instead of `SlotLoading`. All other transient non-ready states (`OFFLINE`, `PULLING`, `STARTING`, `WARMING`, `UNLOADING`) continue to raise the retryable `SlotLoading`.
- Also surfaces the failure early from `_ensure_slot_loaded_backend_aware`: if `SlotManager.load()` raises and leaves the slot in `ERROR`, `SlotLoadFailed` is raised immediately rather than deferring to the ready-check (which mis-classified it as a transient loading state).
- Adds `SlotState` as a direct import in `router.py` (no import cycle — `slots.state` does not import from `dispatcher`).

## Tests added

Four new tests in `tests/dispatcher/test_serving_integration.py`:

| Test | What it verifies |
|------|-----------------|
| `test_forward_error_state_raises_slot_load_failed` | `SlotState.ERROR` raises `SlotLoadFailed` (502, `slot.load_failed`, no `retry_after_s`) |
| `test_forward_error_state_is_not_slot_loading` | Regression guard — `ERROR` state must NOT raise `SlotLoading` (designed to fail without the fix) |
| `test_backend_aware_load_failure_raises_slot_load_failed_immediately` | `load()` raising + slot in ERROR surfaces `SlotLoadFailed` immediately with `load_error` in details |
| Updated `test_forward_gates_slot_in_loading_state` | `SlotState.ERROR` removed from the retryable parametrize list |

Local result: **152 passed, 0 failed** (`PYTHONPATH=/tmp/hal0-wt-987/src /mnt/repos/hal0-mono/hal0/.venv/bin/python -m pytest tests/dispatcher/ -q`).

## Diff scope

Stays within `_check_slot_ready_for_dispatch`, `_ensure_slot_loaded_backend_aware`, and the typed-error block — no overlap with #415's `AsyncClient`/timeouts region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)