### PR TITLE
fix(dispatcher): extend _guard_dead_port_image_mode to container slots (#997)

### DIFF
--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -994,14 +994,17 @@ class Dispatcher:
         Raises:
           GpuImageMode: llm-group slot during exclusive image mode.
         """
-        if not (call.slot_name and self._slot_manager is not None):
+        effective_slot = call.slot_name or call.container_slot_name
+        if not (effective_slot and self._slot_manager is not None):
             return
         arbiter = getattr(self._slot_manager, "arbiter", None)
         if arbiter is not None:
             # Raises GpuImageMode for llm-group slots while mode == img;
             # no-op otherwise. Covers the race where the arbiter flipped
             # to img (and force-killed the container) mid-request.
-            arbiter.guard_dispatch(call.slot_name)
+            # Uses effective_slot so container-backed slots (#723) also fire
+            # the guard — consistent with _forward_with_serving (#746).
+            arbiter.guard_dispatch(effective_slot)
 
     def _build_loading_response(
         self,

--- a/tests/dispatcher/test_arbiter_dispatch.py
+++ b/tests/dispatcher/test_arbiter_dispatch.py
@@ -140,6 +140,36 @@ def _slot_call(slot_name: str = "primary") -> UpstreamCall:
     )
 
 
+def _container_slot_call(slot_name: str = "primary") -> UpstreamCall:
+    """UpstreamCall with container_slot_name set and slot_name empty.
+
+    Mirrors the shape produced by ``_container_slot_name_of`` post-#723:
+    container-backed slots register as kind="remote" so ``slot_name`` is
+    empty and ``container_slot_name`` carries the effective slot key.
+    """
+    return UpstreamCall(
+        upstream_name=slot_name,
+        target_url="http://slot/chat/completions",
+        headers={"content-type": "application/json"},
+        body=b"{}",
+        streaming=False,
+        method="POST",
+        slot_name="",  # container remotes carry no slot_name
+        container_slot_name=slot_name,
+    )
+
+
+class _ArbiterContainerSlotManager(_ArbiterSlotManager):
+    """Extends _ArbiterSlotManager with a container_readiness_check stub.
+
+    Returns (True, "ready") by default so the gate passes and
+    _forward_with_serving (and then _forward_direct) is reached.
+    """
+
+    async def container_readiness_check(self, slot_name: str) -> tuple[bool, str]:
+        return (True, "ready")
+
+
 # ── app-level harness (mirrors tests/api/test_v1_images.py) ─────────────────
 
 
@@ -436,6 +466,71 @@ async def test_dead_port_in_llm_mode_raises_upstream_unavailable(tmp_path: Path)
     try:
         with pytest.raises(UpstreamUnavailable):
             await dispatcher.forward(_slot_call("primary"))
+        assert calls["n"] == 1, "dead port must not be retried"
+        assert sm.load_calls == []
+    finally:
+        await dispatcher.aclose()
+
+
+# ── NON-NEGOTIABLE 1b: dead-port guard fires for container slots (#997) ──────
+
+
+@pytest.mark.asyncio
+async def test_container_dead_port_in_img_mode_raises_gpu_image_mode(
+    tmp_path: Path,
+) -> None:
+    """ConnectError on a container-slot while mode==img → 503 gpu.image_mode.
+
+    Regression test for #997: ``_guard_dead_port_image_mode`` was checking
+    ``call.slot_name`` only, which is always empty for container-backed slots
+    (post-#723 they carry ``container_slot_name``, not ``slot_name``).  The
+    guard was therefore silently dead for every real inference slot.
+
+    This test MUST FAIL on the unfixed code (guard returns early at the
+    ``if not (call.slot_name …)`` check) and PASS after the fix
+    (``call.slot_name or call.container_slot_name``).
+    """
+    sm = _ArbiterContainerSlotManager(tmp_path)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        # Arbiter flips to img between the guard and the upstream connect.
+        st = sm.arbiter._load_state()
+        st["mode"] = "img"
+        st["saved_llm_slots"] = ["primary"]
+        raise httpx.ConnectError("container force-killed", request=req)
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm)
+    try:
+        with pytest.raises(GpuImageMode) as ei:
+            await dispatcher.forward(_container_slot_call("primary"))
+        assert ei.value.code == "gpu.image_mode"
+        assert ei.value.status == 503
+        assert sm.load_calls == [], "no slot load may fight the arbiter"
+        assert sm.in_flight_count("primary") == 0
+    finally:
+        await dispatcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_container_dead_port_in_llm_mode_raises_upstream_unavailable(
+    tmp_path: Path,
+) -> None:
+    """Outside image mode a dead container-slot port → plain UpstreamUnavailable.
+
+    Guard must NOT raise GpuImageMode when the arbiter is in LLM mode;
+    the caller sees a regular UpstreamUnavailable with no retry.
+    """
+    sm = _ArbiterContainerSlotManager(tmp_path)
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        raise httpx.ConnectError("connection refused", request=req)
+
+    dispatcher = _make_dispatcher(httpx.MockTransport(handler), sm)
+    try:
+        with pytest.raises(UpstreamUnavailable):
+            await dispatcher.forward(_container_slot_call("primary"))
         assert calls["n"] == 1, "dead port must not be retried"
         assert sm.load_calls == []
     finally:


### PR DESCRIPTION
Fixes #997

## Summary

- `_guard_dead_port_image_mode` in `router.py` checked `call.slot_name` only, which is **always empty** for container-backed slots. Post-#723, every real inference slot is container-backed (`container_slot_name` set, `slot_name` empty), so the NON-NEGOTIABLE GPU image-mode dead-port guard was silently dead for all real slots.
- Fix: use `call.slot_name or call.container_slot_name` (the effective-slot idiom already used by `_forward_with_serving` in #746 and `_guard_gpu_image_mode`) so the guard fires for container slots too. Pure remote upstreams (neither field set) are unchanged — the early-return still skips them correctly.
- Diff is 4 lines in `router.py` (introduce `effective_slot`, replace two usages of `call.slot_name`).

## Tests added (`tests/dispatcher/test_arbiter_dispatch.py`)

- `test_container_dead_port_in_img_mode_raises_gpu_image_mode` — asserts `GpuImageMode` (503, code `gpu.image_mode`) is raised when a container-slot `ConnectError` occurs while the arbiter is in img mode. **This test fails on the unfixed code** (the guard returns early because `call.slot_name` is empty) and passes after the fix.
- `test_container_dead_port_in_llm_mode_raises_upstream_unavailable` — asserts the guard does NOT raise `GpuImageMode` outside img mode; plain `UpstreamUnavailable` is raised exactly once (no retry).
- Helper `_container_slot_call()` and `_ArbiterContainerSlotManager` added to the file's dispatcher-level harness.

**Local result:** `tests/dispatcher/ — 160 passed` (previously 158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)