### PR TITLE
fix(slots): add host-memory-pressure LRU eviction (#903)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -831,7 +831,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # host RAM (#902).  The global default evict TTL comes from
     # slots.idle_timeout_s; per-slot TOML idle_timeout_s overrides it and
     # idle_timeout_s = 0 pins a slot.  Defaults to 300s for tests.
-    await slot_manager.start_idle_monitor(evict_after_s=hal0_cfg.slots.idle_timeout_s)
+    await slot_manager.start_idle_monitor(
+        evict_after_s=hal0_cfg.slots.idle_timeout_s,
+        evict_pressure_mb=hal0_cfg.slots.evict_pressure_mb,
+    )
 
     # Auto-register one composite ``hal0`` upstream so the dispatcher can
     # route ``model: <slot_name>`` requests without requiring the user to

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1542,6 +1542,16 @@ class SlotsConfig(BaseModel):
             "slot's TOML overrides this value."
         ),
     )
+    evict_pressure_mb: int = Field(
+        default=8192,
+        ge=0,
+        description=(
+            "Host free-RAM floor (MiB) for pressure-driven LRU eviction (#903). "
+            "When host MemAvailable drops below this value, idle lru-eligible "
+            "slots are evicted in least-recently-used order until free RAM is "
+            "back above the floor. 0 disables pressure eviction."
+        ),
+    )
 
     @model_validator(mode="after")
     def port_range_sane(self) -> SlotsConfig:

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -292,6 +292,7 @@ class SlotManager:
         model_cache_check: ModelCacheCheck | None = None,
         idle_after_s: float = _IDLE_AFTER_S,
         evict_after_s: float = _EVICT_AFTER_S,
+        evict_pressure_mb: float = 8192.0,
         idle_monitor_interval_s: float = _IDLE_MONITOR_INTERVAL_S,
         event_bus: Any | None = None,
         upstreams_registry: Any | None = None,
@@ -342,6 +343,10 @@ class SlotManager:
         # idle_timeout_s is unloaded, not just relabeled.  Per-slot TOML
         # idle_timeout_s overrides this global default.
         self._evict_after_s: float = evict_after_s
+        # Pressure-eviction floor (#903): when host MemAvailable drops below
+        # this value (MiB), idle lru-eligible slots are evicted in LRU order
+        # until free RAM recovers.  0 disables pressure eviction.
+        self._evict_pressure_mb: float = float(evict_pressure_mb)
         self._idle_monitor_interval_s: float = idle_monitor_interval_s
         self._idle_monitor_task: asyncio.Task[None] | None = None
         # GpuArbiter (Phase D, spec §7) — constructed lazily on first
@@ -2359,6 +2364,7 @@ class SlotManager:
         *,
         idle_after_s: float | None = None,
         evict_after_s: float | None = None,
+        evict_pressure_mb: float | None = None,
         interval_s: float | None = None,
     ) -> None:
         """Start the background sweeper that demotes READY → IDLE and evicts.
@@ -2372,6 +2378,8 @@ class SlotManager:
             self._idle_after_s = idle_after_s
         if evict_after_s is not None:
             self._evict_after_s = evict_after_s
+        if evict_pressure_mb is not None:
+            self._evict_pressure_mb = float(evict_pressure_mb)
         if interval_s is not None:
             self._idle_monitor_interval_s = interval_s
         existing = self._idle_monitor_task
@@ -2398,7 +2406,7 @@ class SlotManager:
             await task
 
     async def _idle_monitor_loop(self) -> None:
-        """Periodically sweep READY slots for idle-timeout."""
+        """Periodically sweep READY slots for idle-timeout and pressure."""
         try:
             while True:
                 await asyncio.sleep(self._idle_monitor_interval_s)
@@ -2406,6 +2414,10 @@ class SlotManager:
                     await self._sweep_idle_once()
                 except Exception as exc:  # never let the monitor die quietly
                     log.warning("slot.idle_sweep_failed", extra={"error": str(exc)})
+                try:
+                    await self._pressure_evict_once()
+                except Exception as exc:
+                    log.warning("slot.pressure_sweep_failed", extra={"error": str(exc)})
         except asyncio.CancelledError:
             raise
 
@@ -2494,6 +2506,101 @@ class SlotManager:
                 except IllegalSlotTransition:
                     # Raced with an unload — fine; next sweep will skip it.
                     continue
+
+    def _probe_host_free_mb(self) -> float:
+        """Return host MemAvailable in MiB by reading /proc/meminfo (#903).
+
+        Reuses :func:`hal0.slots.capacity._read_meminfo` — the single
+        authoritative reader for /proc/meminfo in the slots subtree.
+        Returns 0.0 on any probe failure so the pressure guard never
+        fires erroneously (a probe error is logged, not raised).
+        """
+        try:
+            from hal0.slots.capacity import _read_meminfo
+
+            _total_mib, avail_mib = _read_meminfo()
+            return avail_mib
+        except Exception as exc:
+            log.warning("slot.pressure_probe_failed", extra={"error": str(exc)})
+            return 0.0
+
+    async def _pressure_evict_once(self) -> None:
+        """One pressure-eviction pass (#903).
+
+        Probes host free RAM. When MemAvailable < ``_evict_pressure_mb``,
+        evicts idle, ``lru``-eligible slots one at a time in
+        least-recently-used order (oldest ``last_used`` first) until free
+        RAM is back above the floor or no more eligible slots remain.
+
+        Guards:
+          - ``_evict_pressure_mb == 0`` → pressure eviction is disabled.
+          - A slot serving a request (``serving_count > 0``) is never evicted.
+          - The canonical ``agent`` slot (and other _PINNED_BY_DEFAULT names)
+            is never evicted by pressure.
+          - Only slots with ``lru = true`` in their TOML are eligible.
+        """
+        if self._evict_pressure_mb <= 0:
+            return
+        free_mb = self._probe_host_free_mb()
+        if free_mb >= self._evict_pressure_mb:
+            return
+
+        # Build the LRU-ordered candidate list.  Only slots with a
+        # last_used timestamp are candidates (unloaded/offline slots are
+        # never in _last_used) so this is naturally bounded.
+        candidates: list[tuple[float, str]] = []
+        for slot_name, ts in list(self._last_used.items()):
+            if self._serving_count.get(slot_name, 0) > 0:
+                continue
+            canonical = self._resolve_alias(slot_name)
+            if canonical in _PINNED_BY_DEFAULT:
+                continue
+            state = self._current_state(slot_name)
+            if state not in (SlotState.READY, SlotState.IDLE):
+                continue
+            # Read lru flag from slot TOML.
+            try:
+                cfg = await self._load_slot_config(slot_name)
+            except (SlotConfigError, SlotNotFound):
+                continue
+            if not cfg.get("lru", False):
+                continue
+            candidates.append((ts, slot_name))
+
+        # Evict oldest-first until pressure is relieved or list is exhausted.
+        candidates.sort(key=lambda pair: pair[0])
+        for _ts, slot_name in candidates:
+            # Re-check serving guard and state — may have changed since
+            # the list was built (another coroutine may have started a
+            # request or the TTL sweep may have evicted it already).
+            if self._serving_count.get(slot_name, 0) > 0:
+                continue
+            state = self._current_state(slot_name)
+            if state not in (SlotState.READY, SlotState.IDLE):
+                continue
+            try:
+                await self.unload(slot_name)
+                log.info(
+                    "slot.pressure_evicted",
+                    extra={
+                        "slot": slot_name,
+                        "free_mb": round(free_mb),
+                        "floor_mb": round(self._evict_pressure_mb),
+                    },
+                )
+            except IllegalSlotTransition:
+                # Raced with another transition — skip, next sweep retries.
+                pass
+            except Exception as exc:
+                log.warning(
+                    "slot.pressure_evict_failed",
+                    extra={"slot": slot_name, "error": str(exc)},
+                )
+                continue
+            # Re-probe free RAM after each eviction to avoid over-shedding.
+            free_mb = self._probe_host_free_mb()
+            if free_mb >= self._evict_pressure_mb:
+                break
 
     async def get_config(self, slot_name: str) -> dict[str, Any]:
         """Return the slot's TOML config as a plain dict (read-only view).

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -2512,8 +2512,10 @@ class SlotManager:
 
         Reuses :func:`hal0.slots.capacity._read_meminfo` — the single
         authoritative reader for /proc/meminfo in the slots subtree.
-        Returns 0.0 on any probe failure so the pressure guard never
-        fires erroneously (a probe error is logged, not raised).
+        Returns ``inf`` on any probe failure so the pressure guard is
+        fail-SAFE: an unreadable probe reports "plenty of free RAM", so the
+        ``free_mb >= floor`` early-return skips eviction rather than evicting
+        blindly on a bad reading (the error is logged, not raised).
         """
         try:
             from hal0.slots.capacity import _read_meminfo
@@ -2522,7 +2524,7 @@ class SlotManager:
             return avail_mib
         except Exception as exc:
             log.warning("slot.pressure_probe_failed", extra={"error": str(exc)})
-            return 0.0
+            return float("inf")
 
     async def _pressure_evict_once(self) -> None:
         """One pressure-eviction pass (#903).

--- a/tests/slots/test_pressure_eviction.py
+++ b/tests/slots/test_pressure_eviction.py
@@ -1,0 +1,281 @@
+"""Tests for host-memory-pressure LRU eviction (#903).
+
+Covers _pressure_evict_once() and its integration with the idle monitor:
+
+  - Under-floor free RAM triggers LRU-ordered eviction until RAM ≥ floor.
+  - Non-lru slots are skipped (allow-list gate).
+  - The canonical ``agent`` slot is never evicted even under pressure.
+  - A slot serving a request is never evicted even under pressure.
+  - Above-floor free RAM is a no-op (no eviction).
+  - evict_pressure_mb = 0 disables pressure eviction entirely.
+  - The LRU ordering evicts oldest last_used first.
+
+The host-free-RAM probe (_probe_host_free_mb) is monkeypatched in every
+test — no real /proc/meminfo reads occur.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.slots.manager import SlotManager
+from hal0.slots.state import SlotState
+from tests.slots.conftest import FakeContainerProvider
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _write_slot(
+    root: Path,
+    name: str,
+    *,
+    port: int,
+    lru: bool = False,
+) -> None:
+    """Write a minimal slot TOML, optionally marking it lru-eligible."""
+    lines = [
+        f'name = "{name}"',
+        f"port = {port}",
+        'backend = "vulkan"',
+        'provider = "llama-server"',
+        "enabled = true",
+    ]
+    if lru:
+        lines.append("lru = true")
+    lines += ["[model]", 'default = "qwen3-4b-q4_k_m"', ""]
+    (root / f"{name}.toml").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _patch_free_mb(monkeypatch: pytest.MonkeyPatch, sm: SlotManager, value: float) -> None:
+    """Monkeypatch _probe_host_free_mb to return a fixed value."""
+    monkeypatch.setattr(sm, "_probe_host_free_mb", lambda: value)
+
+
+# ── above-floor: no-op ────────────────────────────────────────────────────────
+
+
+async def test_pressure_evict_noop_when_above_floor(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When free RAM ≥ evict_pressure_mb, pressure eviction does nothing."""
+    _write_slot(slot_root, "rerank", port=8090, lru=True)
+    sm = SlotManager(evict_pressure_mb=4096.0)
+    await sm.load("rerank")
+    sm._last_used["rerank"] = 0.0  # ancient — would be evicted if pressure fired
+
+    # Free RAM is above the floor → no eviction.
+    _patch_free_mb(monkeypatch, sm, 8192.0)
+    await sm._pressure_evict_once()
+
+    assert (await sm.status("rerank")).state == SlotState.READY
+    assert not container_stub.unload_calls
+
+
+# ── disabled: evict_pressure_mb = 0 ──────────────────────────────────────────
+
+
+async def test_pressure_evict_disabled_when_floor_is_zero(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """evict_pressure_mb = 0 disables pressure eviction entirely."""
+    _write_slot(slot_root, "rerank", port=8090, lru=True)
+    sm = SlotManager(evict_pressure_mb=0.0)
+    await sm.load("rerank")
+    sm._last_used["rerank"] = 0.0
+
+    # Even with zero free RAM, pressure eviction is disabled.
+    _patch_free_mb(monkeypatch, sm, 0.0)
+    await sm._pressure_evict_once()
+
+    assert (await sm.status("rerank")).state == SlotState.READY
+    assert not container_stub.unload_calls
+
+
+# ── allow-list: non-lru slots skipped ────────────────────────────────────────
+
+
+async def test_pressure_evict_skips_non_lru_slot(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slot without lru=true in its TOML is never evicted under pressure."""
+    _write_slot(slot_root, "rerank", port=8090, lru=False)  # NOT lru-eligible
+    sm = SlotManager(evict_pressure_mb=8192.0)
+    await sm.load("rerank")
+    sm._last_used["rerank"] = 0.0
+
+    # Free RAM well below floor → pressure fires, but rerank lacks lru=true.
+    _patch_free_mb(monkeypatch, sm, 512.0)
+    await sm._pressure_evict_once()
+
+    assert (await sm.status("rerank")).state in (SlotState.READY, SlotState.IDLE)
+    assert not container_stub.unload_calls
+
+
+# ── agent never evicted ───────────────────────────────────────────────────────
+
+
+async def test_pressure_evict_never_evicts_agent(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The canonical ``agent`` slot is never evicted under pressure (#903)."""
+    # Write agent with lru=true — the guard must reject it anyway.
+    _write_slot(slot_root, "agent", port=8095, lru=True)
+    sm = SlotManager(evict_pressure_mb=8192.0)
+    await sm.load("agent")
+    sm._last_used["agent"] = 0.0  # ancient
+
+    _patch_free_mb(monkeypatch, sm, 512.0)  # well below floor
+    await sm._pressure_evict_once()
+
+    # agent must remain loaded.
+    assert (await sm.status("agent")).state in (SlotState.READY, SlotState.IDLE)
+    assert not container_stub.unload_calls
+
+
+# ── serving slot never evicted ────────────────────────────────────────────────
+
+
+async def test_pressure_evict_skips_serving_slot(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slot mid-request is never evicted even when free RAM is critically low."""
+    _write_slot(slot_root, "rerank", port=8090, lru=True)
+    sm = SlotManager(evict_pressure_mb=8192.0)
+    await sm.load("rerank")
+
+    _patch_free_mb(monkeypatch, sm, 256.0)  # far below floor
+
+    async with sm.serving("rerank"):
+        sm._last_used["rerank"] = 0.0  # ancient — but serving_count > 0
+        await sm._pressure_evict_once()
+        assert (await sm.status("rerank")).state == SlotState.SERVING
+
+    assert not container_stub.unload_calls
+
+
+# ── under-floor: lru-eligible slot evicted ────────────────────────────────────
+
+
+async def test_pressure_evict_unloads_lru_slot_under_floor(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When free RAM < floor, an idle lru-eligible slot is unloaded."""
+    _write_slot(slot_root, "rerank", port=8090, lru=True)
+    sm = SlotManager(evict_pressure_mb=8192.0)
+    await sm.load("rerank")
+    sm._last_used["rerank"] = 0.0
+
+    _patch_free_mb(monkeypatch, sm, 1024.0)  # below floor
+    await sm._pressure_evict_once()
+
+    assert (await sm.status("rerank")).state == SlotState.OFFLINE
+    assert any(c.get("name") == "rerank" for c in container_stub.unload_calls)
+
+
+# ── LRU ordering ─────────────────────────────────────────────────────────────
+
+
+async def test_pressure_evict_lru_order(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When multiple lru-eligible slots exist, oldest last_used is evicted first.
+
+    The probe returns above-floor after the FIRST eviction so only one slot
+    is evicted, letting us verify the order.
+    """
+    _write_slot(slot_root, "rerank", port=8090, lru=True)
+    _write_slot(slot_root, "embed", port=8091, lru=True)
+    sm = SlotManager(evict_pressure_mb=4096.0)
+    await sm.load("rerank")
+    await sm.load("embed")
+
+    # embed is older (LRU) → must be evicted first.
+    sm._last_used["rerank"] = 1000.0  # newer
+    sm._last_used["embed"] = 100.0    # older → evicted first
+
+    evicted: list[str] = []
+
+    # Probe returns below-floor the first time, above-floor after first eviction.
+    call_count = 0
+
+    def _probe() -> float:
+        nonlocal call_count
+        call_count += 1
+        # First call: under pressure; subsequent calls: relieved.
+        return 512.0 if call_count == 1 else 8192.0
+
+    original_unload = sm.unload
+
+    async def _tracking_unload(name: str) -> object:
+        evicted.append(name)
+        return await original_unload(name)
+
+    monkeypatch.setattr(sm, "_probe_host_free_mb", _probe)
+    monkeypatch.setattr(sm, "unload", _tracking_unload)
+
+    await sm._pressure_evict_once()
+
+    assert evicted == ["embed"], (
+        f"oldest slot (embed) must be evicted first; got {evicted}"
+    )
+
+
+# ── stops evicting once floor is met ─────────────────────────────────────────
+
+
+async def test_pressure_evict_stops_when_floor_met(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Eviction stops as soon as free RAM recovers above the floor.
+
+    Three lru-eligible slots; the probe returns above-floor after the
+    first eviction, so exactly one eviction occurs.
+    """
+    for name, port in [("rerank", 8090), ("embed", 8091), ("stt", 8092)]:
+        _write_slot(slot_root, name, port=port, lru=True)
+
+    sm = SlotManager(evict_pressure_mb=4096.0)
+    for name in ("rerank", "embed", "stt"):
+        await sm.load(name)
+
+    sm._last_used["stt"] = 50.0    # oldest
+    sm._last_used["embed"] = 200.0
+    sm._last_used["rerank"] = 500.0  # newest
+
+    call_count = 0
+
+    def _probe() -> float:
+        nonlocal call_count
+        call_count += 1
+        return 512.0 if call_count <= 1 else 9999.0
+
+    monkeypatch.setattr(sm, "_probe_host_free_mb", _probe)
+    await sm._pressure_evict_once()
+
+    # Only the oldest slot (stt) should have been evicted.
+    states = {
+        n: (await sm.status(n)).state
+        for n in ("rerank", "embed", "stt")
+    }
+    assert states["stt"] == SlotState.OFFLINE
+    assert states["embed"] in (SlotState.READY, SlotState.IDLE)
+    assert states["rerank"] in (SlotState.READY, SlotState.IDLE)

--- a/tests/slots/test_pressure_eviction.py
+++ b/tests/slots/test_pressure_eviction.py
@@ -24,7 +24,6 @@ from hal0.slots.manager import SlotManager
 from hal0.slots.state import SlotState
 from tests.slots.conftest import FakeContainerProvider
 
-
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 
@@ -187,6 +186,33 @@ async def test_pressure_evict_unloads_lru_slot_under_floor(
     assert any(c.get("name") == "rerank" for c in container_stub.unload_calls)
 
 
+async def test_pressure_evict_noop_when_probe_fails(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed host-RAM probe is fail-SAFE: it reports ``inf`` free RAM so the
+    floor check short-circuits and nothing is evicted — rather than evicting
+    blindly on a bad reading (regression guard for the 0.0 fail-open bug)."""
+    _write_slot(slot_root, "rerank", port=8090, lru=True)
+    sm = SlotManager(evict_pressure_mb=8192.0)
+    await sm.load("rerank")
+    sm._last_used["rerank"] = 0.0
+
+    def _boom() -> tuple[float, float]:
+        raise OSError("cannot read /proc/meminfo")
+
+    # Local import inside _probe_host_free_mb resolves this name at call time.
+    monkeypatch.setattr("hal0.slots.capacity._read_meminfo", _boom)
+    assert sm._probe_host_free_mb() == float("inf")
+
+    await sm._pressure_evict_once()
+
+    # Slot survives — a probe failure must never trigger eviction.
+    assert (await sm.status("rerank")).state != SlotState.OFFLINE
+    assert not any(c.get("name") == "rerank" for c in container_stub.unload_calls)
+
+
 # ── LRU ordering ─────────────────────────────────────────────────────────────
 
 
@@ -208,7 +234,7 @@ async def test_pressure_evict_lru_order(
 
     # embed is older (LRU) → must be evicted first.
     sm._last_used["rerank"] = 1000.0  # newer
-    sm._last_used["embed"] = 100.0    # older → evicted first
+    sm._last_used["embed"] = 100.0  # older → evicted first
 
     evicted: list[str] = []
 
@@ -232,9 +258,7 @@ async def test_pressure_evict_lru_order(
 
     await sm._pressure_evict_once()
 
-    assert evicted == ["embed"], (
-        f"oldest slot (embed) must be evicted first; got {evicted}"
-    )
+    assert evicted == ["embed"], f"oldest slot (embed) must be evicted first; got {evicted}"
 
 
 # ── stops evicting once floor is met ─────────────────────────────────────────
@@ -257,7 +281,7 @@ async def test_pressure_evict_stops_when_floor_met(
     for name in ("rerank", "embed", "stt"):
         await sm.load(name)
 
-    sm._last_used["stt"] = 50.0    # oldest
+    sm._last_used["stt"] = 50.0  # oldest
     sm._last_used["embed"] = 200.0
     sm._last_used["rerank"] = 500.0  # newest
 
@@ -272,10 +296,7 @@ async def test_pressure_evict_stops_when_floor_met(
     await sm._pressure_evict_once()
 
     # Only the oldest slot (stt) should have been evicted.
-    states = {
-        n: (await sm.status(n)).state
-        for n in ("rerank", "embed", "stt")
-    }
+    states = {n: (await sm.status(n)).state for n in ("rerank", "embed", "stt")}
     assert states["stt"] == SlotState.OFFLINE
     assert states["embed"] in (SlotState.READY, SlotState.IDLE)
     assert states["rerank"] in (SlotState.READY, SlotState.IDLE)


### PR DESCRIPTION
Fixes #903

## Summary

- Adds `slots.evict_pressure_mb` (default 8192 MiB) to `SlotsConfig` — exposed automatically via the settings API's `model_dump` path, no separate route change needed
- Wires the dormant `lru` bundle flag as the per-slot eviction allow-list by reading `lru = true/false` from slot TOML config (the natural slot-config location, consistent with `idle_timeout_s`)
- Adds `SlotManager._probe_host_free_mb()` reusing `slots.capacity._read_meminfo` — no new /proc/meminfo reader
- Adds `SlotManager._pressure_evict_once()`: probes free RAM; when below the floor, sorts idle `lru`-eligible slots by `last_used` ASC (oldest first = LRU), skips serving slots and `_PINNED_BY_DEFAULT` names (`agent`/`utility`/`npu`), calls `unload()` until free RAM ≥ floor or candidates exhausted; re-probes after each eviction to avoid over-shedding
- Integrates into `_idle_monitor_loop()` — runs each sweep cycle after the existing TTL pass (#902)

## Tests added

`tests/slots/test_pressure_eviction.py` — 8 tests:

| Test | What it asserts |
|------|----------------|
| `test_pressure_evict_noop_when_above_floor` | No eviction when free RAM ≥ floor |
| `test_pressure_evict_disabled_when_floor_is_zero` | `evict_pressure_mb = 0` disables the feature |
| `test_pressure_evict_skips_non_lru_slot` | Non-`lru` slots are never candidates |
| `test_pressure_evict_never_evicts_agent` | `agent` (pinned) never evicted even with `lru=true` |
| `test_pressure_evict_skips_serving_slot` | In-flight request guards eviction |
| `test_pressure_evict_unloads_lru_slot_under_floor` | Under-floor triggers eviction of eligible slot |
| `test_pressure_evict_lru_order` | Oldest `last_used` evicted first |
| `test_pressure_evict_stops_when_floor_met` | Stops evicting once RAM recovers |

All 8 new tests pass locally. Full slots suite: 274/274 passed.

```
cd /tmp/hal0-wt-903 && PYTHONPATH=/tmp/hal0-wt-903/src /mnt/repos/hal0-mono/hal0/.venv/bin/python -m pytest tests/slots/ -q
274 passed, 2 warnings in 6.41s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)