### PR TITLE
fix(comfyui): add --disable-async-offload to stop idle CPU spin (#719)

### DIFF
--- a/installer/etc-hal0/profiles.toml
+++ b/installer/etc-hal0/profiles.toml
@@ -96,8 +96,10 @@ quant        = "BF16"
 [profile.comfyui]
 # Image-gen slot (ComfyUI on ROCm, kyuz0 Strix Halo build). Exclusive-GPU:
 # the GpuArbiter stops LLM GPU slots while img runs (Phase D, #599).
+# --disable-async-offload (#719): eliminates idle 100-165% CPU spin from
+# the HIP async-offload streams (NUM_STREAMS=2 on AMD by default in 0.22.0).
 image        = "docker.io/kyuz0/amd-strix-halo-comfyui@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2"
-flags        = "--disable-mmap --bf16-vae --cache-none"
+flags        = "--disable-mmap --bf16-vae --cache-none --disable-async-offload"
 mtp          = false
 device_class = "img"
 intent       = "Image generation"

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -795,7 +795,11 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
     },
     "comfyui": {
         "image": "docker.io/kyuz0/amd-strix-halo-comfyui@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2",
-        "flags": "--disable-mmap --bf16-vae --cache-none",
+        # --disable-async-offload (#719): stops the HIP async-offload streams
+        # (NUM_STREAMS=2) that spin one asyncio ThreadPoolExecutor thread at
+        # 100-165% CPU while the queue is idle. Safe on Strix Halo iGPU
+        # (NORMAL_VRAM — no VRAM pressure that async offload is designed for).
+        "flags": "--disable-mmap --bf16-vae --cache-none --disable-async-offload",
         "mtp": False,
         "device_class": "img",
         "intent": "Image generation",

--- a/src/hal0/providers/comfyui.py
+++ b/src/hal0/providers/comfyui.py
@@ -67,7 +67,18 @@ _COMFYUI_DATA_SUBDIR = "comfyui"
 
 # Live-validated flag bundle (matches the "comfyui" seed profile). Used
 # when the slot has no resolvable profile.
-_DEFAULT_PROFILE_FLAGS = "--disable-mmap --bf16-vae --cache-none"
+#
+# --disable-async-offload (#719): ComfyUI 0.22.0 enables async weight
+# offloading (NUM_STREAMS=2) by default on AMD. The two HIP streams spawn
+# asyncio ThreadPoolExecutor workers that spin at 100-165% CPU while the
+# queue is empty (strace shows zero syscalls → pure userspace busy-loop).
+# Disabling the streams eliminates the spin. The Strix Halo iGPU uses
+# NORMAL_VRAM mode (96 GB HBM shared); async offload is a VRAM-saving
+# optimisation aimed at NVIDIA cards with limited VRAM, so disabling it
+# here carries no inference-quality cost. Confirmed safe in ComfyUI 0.22.0
+# cli_args.py (sets NUM_STREAMS=0 and skips stream allocation entirely).
+# ⚠ REQUIRES live CT105 py-spy verification before merge (#719).
+_DEFAULT_PROFILE_FLAGS = "--disable-mmap --bf16-vae --cache-none --disable-async-offload"
 
 # Default port — ComfyUI's stock listen port.
 _DEFAULT_PORT = 8188

--- a/tests/config/test_schema_seeds_d1.py
+++ b/tests/config/test_schema_seeds_d1.py
@@ -21,6 +21,20 @@ def test_comfyui_seed_profile() -> None:
     assert "kyuz0/amd-strix-halo-comfyui" in p["image"]
 
 
+def test_comfyui_seed_profile_has_disable_async_offload() -> None:
+    """#719: seed profile flags must include --disable-async-offload.
+
+    ComfyUI 0.22.0 enables async weight offloading (NUM_STREAMS=2) on AMD by
+    default.  The resulting asyncio ThreadPoolExecutor streams busy-loop at
+    100-165% CPU while idle.  The seed profile (schema.py + profiles.toml)
+    must carry the flag so existing deployments pick it up on next restart.
+
+    ⚠ REQUIRES live CT105 py-spy verification before merge (#719).
+    """
+    p = SEED_PROFILES["comfyui"]
+    assert "--disable-async-offload" in p["flags"]
+
+
 def test_seed_img_toml_validates() -> None:
     raw = tomllib.loads((_SEEDED_SLOTS_DIR / "img.toml").read_text(encoding="utf-8"))
     cfg = SlotConfig.model_validate(raw)

--- a/tests/providers/test_comfyui_container_spec.py
+++ b/tests/providers/test_comfyui_container_spec.py
@@ -73,8 +73,11 @@ def test_comfyui_spec_matches_live_deployment() -> None:
     }
     assert spec.network_mode == "host"
     assert spec.port == 8188
-    # Profile flags flow into the bash -lc payload.
-    assert spec.command[-1].endswith("--cache-none")
+    # Profile flags flow into the bash -lc payload (always-present baseline flags).
+    payload = spec.command[-1]
+    assert "--disable-mmap" in payload
+    assert "--bf16-vae" in payload
+    assert "--cache-none" in payload
 
 
 def test_comfyui_argv_uses_opt_comfyui_workdir() -> None:
@@ -116,13 +119,61 @@ def test_comfyui_profile_flags_fallback_without_profile() -> None:
     cfg = _img_cfg()
     del cfg["profile"]
     spec = ComfyUIProvider().container_spec(cfg, {})
-    assert spec.command[2].endswith("--disable-mmap --bf16-vae --cache-none")
+    assert spec.command[2].endswith("--disable-mmap --bf16-vae --cache-none --disable-async-offload")
 
 
 def test_comfyui_slot_port_override_flows_into_argv() -> None:
     spec = ComfyUIProvider().container_spec(_img_cfg(port=8189), {})
     assert spec.port == 8189
     assert "--port 8189" in spec.command[2]
+
+
+def test_comfyui_disable_async_offload_flag_present() -> None:
+    """#719: --disable-async-offload must be in the default flag bundle and in the
+    container payload for both the profile path and the no-profile fallback path.
+
+    ComfyUI 0.22.0 enables async weight offloading (NUM_STREAMS=2) by default
+    on AMD, spawning asyncio ThreadPoolExecutor workers that busy-loop at
+    100-165% CPU while the queue is idle (strace: zero syscalls → pure
+    userspace spin).  Disabling the streams via this flag stops the spin.
+    The flag must be present here so it reaches the bash -lc argv that podman
+    executes.
+
+    ⚠ REQUIRES live CT105 py-spy verification before merge (#719).
+    """
+    from hal0.providers.comfyui import _DEFAULT_PROFILE_FLAGS
+
+    # 1. The constant itself must carry the flag.
+    assert "--disable-async-offload" in _DEFAULT_PROFILE_FLAGS
+
+    # 2. No-profile fallback: the flag reaches the container argv payload.
+    cfg_no_profile = _img_cfg()
+    del cfg_no_profile["profile"]
+    spec_no_profile = ComfyUIProvider().container_spec(cfg_no_profile, {})
+    assert "--disable-async-offload" in spec_no_profile.command[2]
+
+    # 3. Profile path (monkeypatching ProfileCatalog to return the real seed
+    #    flags so this test is self-contained without the full profiles.toml).
+    class _FakeResolved:
+        resolved_flags = _DEFAULT_PROFILE_FLAGS
+
+    class _FakeCatalog:
+        def resolve(self, _name: str) -> "_FakeResolved":
+            return _FakeResolved()
+
+    import hal0.providers.comfyui as _mod
+
+    orig = None
+    try:
+        import hal0.profiles as _profiles
+
+        orig = _profiles.ProfileCatalog
+        _profiles.ProfileCatalog = _FakeCatalog  # type: ignore[assignment]
+        spec_profile = ComfyUIProvider().container_spec(_img_cfg(), {})
+        assert "--disable-async-offload" in spec_profile.command[2]
+    finally:
+        if orig is not None:
+            _profiles.ProfileCatalog = orig
 
 
 def test_comfyui_fallback_image_is_kyuz0() -> None:

--- a/tests/providers/test_comfyui_container_spec.py
+++ b/tests/providers/test_comfyui_container_spec.py
@@ -119,7 +119,9 @@ def test_comfyui_profile_flags_fallback_without_profile() -> None:
     cfg = _img_cfg()
     del cfg["profile"]
     spec = ComfyUIProvider().container_spec(cfg, {})
-    assert spec.command[2].endswith("--disable-mmap --bf16-vae --cache-none --disable-async-offload")
+    assert spec.command[2].endswith(
+        "--disable-mmap --bf16-vae --cache-none --disable-async-offload"
+    )
 
 
 def test_comfyui_slot_port_override_flows_into_argv() -> None:
@@ -158,10 +160,8 @@ def test_comfyui_disable_async_offload_flag_present() -> None:
         resolved_flags = _DEFAULT_PROFILE_FLAGS
 
     class _FakeCatalog:
-        def resolve(self, _name: str) -> "_FakeResolved":
+        def resolve(self, _name: str) -> _FakeResolved:
             return _FakeResolved()
-
-    import hal0.providers.comfyui as _mod
 
     orig = None
     try:


### PR DESCRIPTION
Fixes #719

## Summary

- **Root cause**: ComfyUI 0.22.0 enables async weight offloading (`NUM_STREAMS=2`) by default on AMD. The two HIP streams spawn `asyncio` `ThreadPoolExecutor` workers that busy-loop at 100–165% CPU while the inference queue is empty (`strace` confirms zero syscalls — pure userspace spin matching the single thread at 99.9% CPU observed on CT105, kyuz0 digest `0066678a`).

- **Change**: Add `--disable-async-offload` to the ComfyUI seed profile flags in three co-owned locations that must stay in sync:
  - `src/hal0/config/schema.py` — `SEED_PROFILES["comfyui"]["flags"]`
  - `installer/etc-hal0/profiles.toml` — `[profile.comfyui] flags`
  - `src/hal0/providers/comfyui.py` — `_DEFAULT_PROFILE_FLAGS` (fallback when no profile resolves)

- **Safety**: The Strix Halo iGPU uses `NORMAL_VRAM` mode (96 GB HBM shared). Async offload is a VRAM-saving optimisation designed for NVIDIA cards under VRAM pressure. Disabling it on this hardware carries no inference-quality cost. The flag is documented in ComfyUI 0.22.0 `cli_args.py` and sets `NUM_STREAMS=0`, skipping stream allocation entirely on startup.

## Upstream research

- `Comfy-Org/ComfyUI#12133` is a different issue (Chrome browser UI CPU on the client side) — no overlap.
- `comfy-aimdo` has advanced from 0.4.1 → 0.4.10 since the kyuz0 image was built, with fixes labelled "Cold marking of pins" (0.4.5/0.4.6, v0.23.0) and "Fix interoperation with external source of pinned memory pressure" (0.4.9, v0.25.0). These _may_ reduce the spin in a newer image. However, no newer kyuz0 digest is published on Docker Hub as of 2026-07-01 — a digest bump cannot be done now. Tracked separately: once kyuz0 publishes a new build (with ComfyUI ≥ 0.23.0 / comfy-aimdo ≥ 0.4.5), the digest pin should be bumped and this flag re-evaluated.

## Tests

Two new tests added, covering the no-profile fallback path and the seed profile:

| Test | File | What it asserts |
|------|------|-----------------|
| `test_comfyui_disable_async_offload_flag_present` | `tests/providers/test_comfyui_container_spec.py` | `--disable-async-offload` is in `_DEFAULT_PROFILE_FLAGS` and flows into the `bash -lc` payload via both the fallback and profile-resolved paths |
| `test_comfyui_seed_profile_has_disable_async_offload` | `tests/config/test_schema_seeds_d1.py` | `SEED_PROFILES["comfyui"]["flags"]` contains the flag |

Local run result (37 targeted tests):
```
37 passed, 0 failed
```
Full suite: 4109 passed, 10 pre-existing failures (PVE detection, Hermes shim path — none related to this change).

Tests command: `PYTHONPATH=/tmp/hal0-wt-719/src /mnt/repos/hal0-mono/hal0/.venv/bin/python -m pytest tests/providers/test_comfyui_container_spec.py tests/providers/test_comfyui.py tests/config/test_schema_seeds_d1.py -v`

## ⚠ REQUIRES live CT105 py-spy verification before merge

Do **not** merge until the CT105 img slot has been restarted with the new flags and py-spy confirms the spinning thread is gone:

```bash
# On CT105 — restart the img slot to pick up the new flags
hal0 slot restart img

# Wait for ComfyUI to initialise, then check CPU
top -p $(pgrep -f "python main.py") -n 1

# If still suspicious, py-spy dump against the ComfyUI PID
py-spy dump --pid <comfyui-pid>
# Expected: no asyncio_N threads showing "active" / spinning
# Expected: "Using async weight offloading" log line absent from container logs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)