### PR TITLE
fix(installer): add cpu-llm seed profile and fix cpu→vulkan derive incoherence (#834)

### DIFF
--- a/installer/etc-hal0/profiles.toml
+++ b/installer/etc-hal0/profiles.toml
@@ -102,3 +102,15 @@ mtp          = false
 device_class = "img"
 intent       = "Image generation"
 quant        = ""
+
+[profile.cpu-llm]
+# CPU-only LLM template (#834). The Vulkan toolbox image runs llama-server in
+# CPU mode when no GPU devices are passed to the container (GGML_CPU auto-
+# selected). No backend → passes the #807 device/profile coherence check on a
+# CPU-only host. Seeded so first-run on a GPU-less box gets a coherent Main slot.
+image        = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server"
+flags        = "--threads 4 --threads-batch 8 -b 256 -ub 256 --parallel 1 --no-mmap"
+mtp          = false
+device_class = "cpu"
+intent       = "CPU-only LLM · llama-server"
+quant        = "Q4_K_M"

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -793,6 +793,19 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "intent": "TTS · Qwen3 (multilingual GPU)",
         "quant": "BF16",
     },
+    "cpu-llm": {
+        # The Vulkan toolbox image runs in CPU-only mode when no GPU devices
+        # are passed to the container (llama-server auto-selects GGML_CPU).
+        # CPU-optimal flags: no flash-attn (not available without GPU), smaller
+        # batch to limit peak RAM, and a thread count sensible for a typical
+        # multi-core host.  backend=None keeps the #807 coherence check happy.
+        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server",
+        "flags": "--threads 4 --threads-batch 8 -b 256 -ub 256 --parallel 1 --no-mmap",
+        "mtp": False,
+        "device_class": "cpu",
+        "intent": "CPU-only LLM · llama-server",
+        "quant": "Q4_K_M",
+    },
     "comfyui": {
         "image": "docker.io/kyuz0/amd-strix-halo-comfyui@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2",
         "flags": "--disable-mmap --bf16-vae --cache-none",

--- a/src/hal0/install/profile_derive.py
+++ b/src/hal0/install/profile_derive.py
@@ -98,5 +98,9 @@ def derive_profile(capability: str, device: str) -> str:
     if device == "gpu-vulkan":
         return "vulkan"
     if device == "cpu":
-        return "tts" if capability == "tts" else "vulkan"
-    return "vulkan"
+        # ``tts`` stays on the kokoro/CPU profile; everything else (chat,
+        # coder, embed, utility, …) goes to the CPU-coherent llama-server
+        # profile.  Returning "vulkan" here caused #807 to reject the slot
+        # on GPU-less boxes (device=cpu + profile=vulkan incoherent, #834).
+        return "tts" if capability == "tts" else "cpu-llm"
+    return "cpu-llm"

--- a/tests/api/test_profiles_route.py
+++ b/tests/api/test_profiles_route.py
@@ -42,11 +42,11 @@ class TestListProfiles:
         assert isinstance(data, list)
 
     def test_returns_seed_profiles(self, client: TestClient) -> None:
-        """One entry per seed profile (8: rocm-moe + rocm-dnse split, Phase D
-        comfyui, plus the GPU tts-qwen3 profile)."""
+        """One entry per seed profile (9: rocm-moe + rocm-dnse split, Phase D
+        comfyui, the GPU tts-qwen3 profile, plus the cpu-llm CPU profile #834)."""
         data = client.get("/api/profiles").json()
         assert len(data) == len(SEED_PROFILES)
-        assert len(data) == 8
+        assert len(data) == 9
 
     def test_flm_npu_seed_present(self, client: TestClient) -> None:
         """Phase A added the flm container profile to the seeds."""

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -180,8 +180,8 @@ class TestLoadProfilesConfig:
 
     def test_seed_count(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
-        # rocm, rocm-dnse, rocm-moe, vulkan, flm, tts, tts-qwen3, comfyui
-        assert len(cfg.profile) == 8
+        # rocm, rocm-dnse, rocm-moe, vulkan, flm, tts, tts-qwen3, comfyui, cpu-llm
+        assert len(cfg.profile) == len(SEED_PROFILES)
 
     def test_seed_profiles_have_correct_names(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")

--- a/tests/install/test_profile_derive.py
+++ b/tests/install/test_profile_derive.py
@@ -106,3 +106,62 @@ def test_strix_platform_forces_rocm_even_if_compute_flag_missing():
     # platform=strix-halo is the canonical FP4 signal.
     hw = _hw(platform="strix-halo", compute=False, vulkan=True)
     assert derive_device("chat", hw, npu_opt_in=False) == "gpu-rocm"
+
+
+# ── CPU-only host fixes (#834) ─────────────────────────────────────────────────
+
+
+def _cpu_hw():
+    """Hardware fixture for a GPU-less host (bare-metal-cpu-only)."""
+    return HardwareInfo(
+        cpu_model="Intel Xeon E5-2670",
+        cpu_cores=8,
+        cpu_threads=16,
+        ram_mb=32768,
+        unified_memory_mb=32768,
+        platform="bare-metal-cpu-only",
+        gpus=[],
+        npu=NPUInfo(present=False, vendor="", name="", driver=""),
+    )
+
+
+def test_cpu_host_chat_derives_cpu_device():
+    """On a GPU-less host, chat capability must derive to 'cpu', not a GPU device."""
+    hw = _cpu_hw()
+    assert derive_device("chat", hw, npu_opt_in=False) == "cpu"
+
+
+def test_cpu_host_chat_derives_cpu_llm_profile():
+    """derive_profile(chat, cpu) must return 'cpu-llm', not 'vulkan' (#834).
+
+    This test fails on the old code where cpu→non-tts returned 'vulkan',
+    causing the #807 coherence check to reject device=cpu + profile=vulkan.
+    """
+    assert derive_profile("chat", "cpu") == "cpu-llm"
+
+
+def test_cpu_host_coder_derives_cpu_llm_profile():
+    """coder capability on a CPU host must also derive to 'cpu-llm'."""
+    assert derive_profile("coder", "cpu") == "cpu-llm"
+
+
+def test_cpu_host_embed_derives_cpu_llm_profile():
+    """embed capability on a CPU host must derive to 'cpu-llm', not 'vulkan'."""
+    assert derive_profile("embed", "cpu") == "cpu-llm"
+
+
+def test_cpu_host_tts_still_derives_tts_profile():
+    """tts capability on a CPU host must still derive to 'tts' (kokoro), unchanged."""
+    assert derive_profile("tts", "cpu") == "tts"
+
+
+def test_cpu_llm_profile_exists_in_seed_profiles():
+    """The 'cpu-llm' seed profile must exist and have backend=None (cpu-coherent)."""
+    from hal0.config.schema import SEED_PROFILES
+
+    assert "cpu-llm" in SEED_PROFILES
+    profile = SEED_PROFILES["cpu-llm"]
+    assert profile.get("backend") is None, (
+        "cpu-llm profile must have backend=None so the #807 coherence check passes"
+    )
+    assert profile.get("device_class") == "cpu"


### PR DESCRIPTION
Fixes #834

## Summary

On GPU-less hosts `hal0 setup --auto` derived `device=cpu` then called `derive_profile("chat", "cpu")` which returned `"vulkan"`. The `#807` coherence check in `SlotManager.create()` rejects `device=cpu + profile=vulkan` as incoherent (a Vulkan GPU profile on a CPU device makes no sense), so no Main slot was ever seeded and `apply_setup` silently swallowed the error.

Changes:

- **`src/hal0/config/schema.py`**: Added `cpu-llm` entry to `SEED_PROFILES` — uses the Vulkan toolbox image (which runs llama-server in CPU-only mode when no GPU devices are passed to the container), CPU-appropriate flags (`--threads 4 --threads-batch 8 -b 256 -ub 256 --parallel 1 --no-mmap`), `device_class="cpu"`, and `backend=None` so the `#807` coherence check passes.

- **`src/hal0/install/profile_derive.py`**: Fixed `derive_profile()` `cpu` branch — non-tts capabilities now return `"cpu-llm"` instead of `"vulkan"`. TTS (`→"tts"`) behavior is unchanged. The unreachable fallback `return "vulkan"` also updated to `"cpu-llm"` for consistency.

## Tests added

`tests/install/test_profile_derive.py` — 6 new tests:

| Test | Result |
|------|--------|
| `test_cpu_host_chat_derives_cpu_device` | pass |
| `test_cpu_host_chat_derives_cpu_llm_profile` | pass (fails on old code) |
| `test_cpu_host_coder_derives_cpu_llm_profile` | pass (fails on old code) |
| `test_cpu_host_embed_derives_cpu_llm_profile` | pass (fails on old code) |
| `test_cpu_host_tts_still_derives_tts_profile` | pass |
| `test_cpu_llm_profile_exists_in_seed_profiles` | pass |

Full `tests/install/` suite: **59 passed** locally.

Command: `cd /tmp/hal0-wt-834 && PYTHONPATH=/tmp/hal0-wt-834/src /mnt/repos/hal0-mono/hal0/.venv/bin/python -m pytest tests/install/ -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)