### PR TITLE
fix(config): additively merge new SEED_PROFILES into existing profiles.toml (#838)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -617,7 +617,7 @@ Delete entirely (source + folder):
 2. Download `hal0-vX.Y.Z-linux-x86_64.tar.gz` + `.sig` from `hal0.dev/releases/latest.json` (channel = stable | nightly)
 3. Verify signature (cosign keyless against the release OIDC identity)
 4. Lay down `/usr/lib/hal0-X.Y.Z/`, atomic-swap `/usr/lib/hal0/current` symlink
-5. If first install: write `/etc/hal0/` defaults (slot TOMLs + `profiles.toml`); if upgrade: skip
+5. If first install: write `/etc/hal0/` defaults (slot TOMLs; `profiles.toml` is served in-memory from SEED_PROFILES until the operator saves a custom profile); if upgrade: additively merge any new SEED_PROFILES entries into an existing profiles.toml without clobbering operator edits (#838)
 6. Hardware probe → `/etc/hal0/hardware.json` + recommended `slots/chat.toml` derived from detected NPU/GPU
 7. Install + enable systemd units (`hal0-api`, `hal0-openwebui`, `hal0-agent@` template); per-slot units are written by `ContainerProvider` on first load, not pre-seeded
 8. Seed container image pulls in background (open-webui + toolbox images referenced by seed profiles)

--- a/installer/etc-hal0/profiles.toml
+++ b/installer/etc-hal0/profiles.toml
@@ -6,8 +6,10 @@
 # See the container-runtime design doc (§1) for the layering rationale.
 #
 # NOTE: this file is OPTIONAL.  hal0-api returns these seed profiles as built-in
-# defaults when the file is absent (SEED_PROFILES in schema.py).
-# Keep this file identical to SEED_PROFILES to avoid silent drift.
+# defaults when the file is absent (SEED_PROFILES in schema.py).  When the file
+# IS present, load_profiles_config additively merges any SEED_PROFILES entries
+# missing from the file without clobbering operator-customised profiles (#838).
+# Keep this file in sync with SEED_PROFILES to avoid silent drift.
 
 [profile.rocm]
 # Standard ROCm GPU template (ace-saber A3B MoE etc). ~52.8 tok/s gen, 131k ctx.

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1084,6 +1084,30 @@ for seed_slot in npu tts rerank utility img; do
     fi
 done
 
+# ── profiles.toml additive seed merge (A10b, #838) ────────────────────────────
+# If /etc/hal0/profiles.toml already exists (created by a prior install or a
+# dashboard profile edit), inject any SEED_PROFILES entries that are MISSING
+# from it — without clobbering operator-customised profiles (additive only).
+# On a fresh install the file does not yet exist; load_profiles_config returns
+# the seeds in-memory on every call and no write is needed until the operator
+# saves a custom profile via the dashboard.
+PROFILES_TOML="${ETC_DIR}/profiles.toml"
+if [[ "${DEV_MODE}" -eq 1 ]]; then
+    info "dev mode — skipping profiles.toml seed merge (no system writes)"
+elif [[ -f "${PROFILES_TOML}" ]]; then
+    info "profiles.toml exists — merging any missing seed profiles (additive, #838)"
+    "${VENV_DIR}/bin/python" - <<'PYEOF'
+from hal0.updater.updater import ensure_seed_profiles
+n = ensure_seed_profiles()
+if n:
+    print(f"  seeded {n} new profile(s) into /etc/hal0/profiles.toml")
+else:
+    print("  profiles.toml already contains all seed profiles")
+PYEOF
+else
+    info "profiles.toml absent — seeds served in-memory on first request"
+fi
+
 # ── ComfyUI model share ───────────────────────────────────────────────────────
 # The docker comfy-up/down/logs/postinstall.sh scripts have been retired; the
 # podman img slot (hal0-slot@img.service) is the sole lifecycle owner of :8188

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -391,10 +391,12 @@ def save_upstreams_config(cfg: UpstreamsConfig, path: Path | None = None) -> Non
 def load_profiles_config(path: Path | None = None) -> ProfilesConfig:
     """Load and validate /etc/hal0/profiles.toml.
 
-    Returns a :class:`ProfilesConfig` seeded with the three built-in bench
+    Returns a :class:`ProfilesConfig` seeded with the built-in bench
     profiles when the file is absent so ``GET /api/profiles`` is always
-    populated on a fresh install.  When the file *is* present, only its
-    contents are returned — the seeds are NOT merged in.
+    populated on a fresh install.  When the file *is* present, any
+    SEED_PROFILES entries whose keys are **missing** from the on-disk
+    catalog are injected additively — existing operator-customised profiles
+    are never overwritten (additive-merge semantics, #838).
 
     Args:
         path: Override path.  If None, uses
@@ -412,12 +414,19 @@ def load_profiles_config(path: Path | None = None) -> ProfilesConfig:
         return ProfilesConfig.model_validate({"profile": SEED_PROFILES})
     raw = _read_toml(Path(target))
     try:
-        return ProfilesConfig.model_validate(raw)
+        cfg = ProfilesConfig.model_validate(raw)
     except Exception as exc:
         raise ConfigParseError(
             f"failed to validate profiles.toml at {target}: {exc}",
             details={"path": str(target), "reason": str(exc)},
         ) from exc
+    # Additive merge: inject any seed profiles that are absent from the
+    # on-disk catalog so upgrades pick up newly-added seed profiles without
+    # clobbering operator edits.  Keys already present are left untouched.
+    for key, seed_raw in SEED_PROFILES.items():
+        if key not in cfg.profile:
+            cfg.profile[key] = ProfileConfig.model_validate(seed_raw)
+    return cfg
 
 
 def save_profiles_config(cfg: ProfilesConfig, path: Path | None = None) -> None:
@@ -427,12 +436,12 @@ def save_profiles_config(cfg: ProfilesConfig, path: Path | None = None) -> None:
     seed profiles that should survive — to ``paths.profiles_toml()`` (or
     *path* if given) via :func:`write_toml_atomic`.
 
-    The written file is the single source of truth; on next load,
-    :func:`load_profiles_config` will read it instead of returning the
-    in-memory seeds (load REPLACES, it does not merge).  Callers are
-    therefore responsible for ensuring the catalog passed to this function
-    is complete (e.g. start from ``load_profiles_config()`` and add/modify
-    entries) so the seed profiles survive the round trip.
+    The written file is the single source of truth for operator-authored
+    profiles; on next load :func:`load_profiles_config` additively fills in
+    any seed profiles missing from the file, so callers do not need to
+    include seed profiles in *cfg* to keep them available.  That said,
+    starting from ``load_profiles_config()`` and modifying entries is still
+    the recommended pattern so the full catalog is explicit on disk.
 
     Note: :func:`write_toml_atomic` emits pure TOML — no header comment is
     written (tomli_w has no comment support and the atomic writer takes no

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -58,7 +58,6 @@ from hal0.config import paths
 from hal0.config.loader import (
     ConfigParseError,
     load_hal0_config,
-    load_profiles_config,
     save_profiles_config,
     write_toml_atomic,
 )
@@ -887,8 +886,8 @@ def ensure_seed_profiles(*, job_id: str | None = None) -> int:
     Returns:
         Number of seed profiles injected (0 means already up-to-date).
     """
-    from hal0.config.schema import SEED_PROFILES, ProfileConfig, ProfilesConfig
     from hal0.config.loader import _read_toml
+    from hal0.config.schema import SEED_PROFILES, ProfileConfig, ProfilesConfig
 
     target = paths.profiles_toml()
     if not target.exists():

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -55,7 +55,13 @@ from pydantic import BaseModel, Field, field_validator
 
 import hal0
 from hal0.config import paths
-from hal0.config.loader import load_hal0_config, write_toml_atomic
+from hal0.config.loader import (
+    ConfigParseError,
+    load_hal0_config,
+    load_profiles_config,
+    save_profiles_config,
+    write_toml_atomic,
+)
 from hal0.config.migrations import latest_version, run_migrations
 from hal0.errors import Hal0Error
 
@@ -857,6 +863,71 @@ def _cache_dir(version: str) -> Path:
     return paths.var_lib() / "cache" / version
 
 
+# ── Seed-profile merge helpers ─────────────────────────────────────────────────
+
+
+def ensure_seed_profiles(*, job_id: str | None = None) -> int:
+    """Additively merge missing SEED_PROFILES into /etc/hal0/profiles.toml.
+
+    Loads the on-disk profile catalog (or the in-memory seeds when the
+    file is absent), injects any seed keys that are missing, and
+    atomically writes the result back to disk only when the file already
+    exists and new seeds were actually added.  If the file is absent,
+    nothing is written — :func:`load_profiles_config` returns the seeds
+    in-memory and the file is only created by explicit operator action or
+    :func:`save_profiles_config`.
+
+    Operator-customised profiles are never overwritten: the merge is
+    strictly additive — only keys absent from the on-disk catalog are
+    touched (#838).
+
+    Args:
+        job_id: Optional breadcrumb for structured-log tracing.
+
+    Returns:
+        Number of seed profiles injected (0 means already up-to-date).
+    """
+    from hal0.config.schema import SEED_PROFILES, ProfileConfig, ProfilesConfig
+    from hal0.config.loader import _read_toml
+
+    target = paths.profiles_toml()
+    if not target.exists():
+        # Fresh install — no on-disk file yet; load_profiles_config already
+        # returns the seeds in-memory on every call. No write needed.
+        log.info("updater.seed_profiles_noop", job_id=job_id, reason="profiles.toml absent")
+        return 0
+
+    # Load the raw on-disk catalog directly so we can detect exactly which
+    # seed keys are missing before deciding whether to write anything.
+    raw = _read_toml(target)
+    try:
+        cfg = ProfilesConfig.model_validate(raw)
+    except Exception as exc:
+        raise ConfigParseError(
+            f"failed to validate profiles.toml during seed merge at {target}: {exc}",
+            details={"path": str(target), "reason": str(exc)},
+        ) from exc
+
+    added: list[str] = []
+    for key, seed_raw in SEED_PROFILES.items():
+        if key not in cfg.profile:
+            cfg.profile[key] = ProfileConfig.model_validate(seed_raw)
+            added.append(key)
+
+    if not added:
+        log.info("updater.seed_profiles_noop", job_id=job_id, reason="all seeds present")
+        return 0
+
+    save_profiles_config(cfg, path=target)
+    log.info(
+        "updater.seed_profiles_merged",
+        job_id=job_id,
+        added=added,
+        count=len(added),
+    )
+    return len(added)
+
+
 # ── Updater class ──────────────────────────────────────────────────────────────
 
 
@@ -1084,6 +1155,19 @@ class Updater:
                 details={**exc.details, "version": target_version},
             ) from exc
 
+        # Step 7b: additive seed-profile merge — inject any new SEED_PROFILES
+        # entries into /etc/hal0/profiles.toml without clobbering operator edits.
+        # Runs after migrations so the schema is stable before touching profiles.
+        try:
+            await asyncio.to_thread(ensure_seed_profiles, job_id=self.job_id)
+        except Exception as exc:
+            log.warning(
+                "updater.seed_profiles_merge_failed",
+                job_id=self.job_id,
+                error=str(exc),
+            )
+            # Non-fatal: a missing seed profile is cosmetic; don't abort the update.
+
         # Step 8 + 9: atomic symlink swap + record previous.
         link = _current_symlink()
         try:
@@ -1264,6 +1348,7 @@ __all__ = [
     "UpdateSwapError",
     "UpdateVerifyError",
     "Updater",
+    "ensure_seed_profiles",
     "fetch_release_manifest",
     "releases_url",
 ]

--- a/tests/api/test_profiles_route.py
+++ b/tests/api/test_profiles_route.py
@@ -141,7 +141,9 @@ class TestListProfiles:
                 assert item["resolved_flags"] == item["flags"].strip()
 
     def test_custom_profiles_file_used_when_present(self, tmp_hal0_home: str) -> None:
-        """When profiles.toml is present, its contents are used (not seeds)."""
+        """A custom profiles.toml is preserved AND missing seed profiles are
+        additively merged in (#838): operator customisations coexist with the
+        canonical seeds so upgrades pick up newly-added seed profiles."""
         profiles_path = Path(tmp_hal0_home) / "etc" / "hal0" / "profiles.toml"
         profiles_path.parent.mkdir(parents=True, exist_ok=True)
         profiles_path.write_text(
@@ -155,7 +157,10 @@ class TestListProfiles:
         with TestClient(app) as c:
             data = c.get("/api/profiles").json()
         names = {item["name"] for item in data}
-        assert names == {"custom-only"}
+        # Operator's custom profile is preserved...
+        assert "custom-only" in names
+        # ...and the missing seed profiles were additively merged in (#838).
+        assert set(SEED_PROFILES.keys()) <= names
         custom = next(item for item in data if item["name"] == "custom-only")
         assert custom["seed"] is False
 

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -246,6 +246,89 @@ class TestLoadProfilesConfig:
         with pytest.raises(ConfigParseError):
             load_profiles_config(path=p)
 
+    # ── additive seed merge (#838) ────────────────────────────────────────────
+
+    def test_partial_file_gets_missing_seeds_merged_in(self, tmp_path: Path) -> None:
+        """A profiles.toml with only one profile gets the missing seeds injected."""
+        # Write a file with just the 'rocm' seed — everything else is missing.
+        toml_content = (
+            "[profile.rocm]\n"
+            'image = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server"\n'
+            'flags = "-fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap"\n'
+            "mtp = false\n"
+            'device_class = "gpu"\n'
+            'backend = "rocm"\n'
+            'intent = "MoE agents"\n'
+            'quant = "FP4"\n'
+        )
+        p = tmp_path / "profiles.toml"
+        p.write_bytes(toml_content.encode())
+
+        cfg = load_profiles_config(path=p)
+
+        # All SEED_PROFILES keys must now be present.
+        assert set(SEED_PROFILES.keys()) <= set(cfg.profile.keys()), (
+            f"missing seeds after merge: {set(SEED_PROFILES.keys()) - set(cfg.profile.keys())}"
+        )
+
+    def test_operator_customised_profile_not_overwritten(self, tmp_path: Path) -> None:
+        """An operator-edited seed profile is left untouched by the additive merge."""
+        # Write a 'rocm' entry with a custom image — the merge must not reset it
+        # to the SEED_PROFILES value.
+        custom_image = "ghcr.io/my-org/custom-rocm-toolbox:operator-build"
+        toml_content = (
+            "[profile.rocm]\n"
+            f'image = "{custom_image}"\n'
+            'flags = "-fa on"\n'
+            "mtp = false\n"
+            'device_class = "gpu"\n'
+            'backend = "rocm"\n'
+        )
+        p = tmp_path / "profiles.toml"
+        p.write_bytes(toml_content.encode())
+
+        cfg = load_profiles_config(path=p)
+
+        # The operator's custom image must be preserved — NOT replaced by the seed.
+        assert cfg.profile["rocm"].image == custom_image, (
+            "additive merge overwrote an operator-customised profile (key 'rocm')"
+        )
+
+    def test_partial_file_custom_profile_preserved(self, tmp_path: Path) -> None:
+        """A non-seed (operator-created) profile survives the additive merge."""
+        toml_content = (
+            "[profile.my-special]\n"
+            'image = "ghcr.io/my-org/special:v42"\n'
+            'flags = "--special-flag"\n'
+            "mtp = false\n"
+            'device_class = "gpu"\n'
+        )
+        p = tmp_path / "profiles.toml"
+        p.write_bytes(toml_content.encode())
+
+        cfg = load_profiles_config(path=p)
+
+        # Operator's custom profile survives.
+        assert "my-special" in cfg.profile
+        assert cfg.profile["my-special"].image == "ghcr.io/my-org/special:v42"
+        # Seeds are also present.
+        assert set(SEED_PROFILES.keys()) <= set(cfg.profile.keys())
+
+    def test_complete_seed_file_no_extras_added(self, tmp_path: Path) -> None:
+        """A file that already contains all seeds gets no duplicates."""
+        import tomli_w
+
+        # Write a file with all seeds present.
+        raw = {"profile": {k: dict(v) for k, v in SEED_PROFILES.items()}}
+        p = tmp_path / "profiles.toml"
+        with open(p, "wb") as f:
+            tomli_w.dump(raw, f)
+
+        cfg = load_profiles_config(path=p)
+
+        # Exactly the seed keys — no extras injected.
+        assert set(cfg.profile.keys()) == set(SEED_PROFILES.keys())
+
 
 # ── seed file parity check ────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #838

## Summary

When `/etc/hal0/profiles.toml` exists (created by a dashboard edit or hand-placed), upgrades previously received no new seed profiles — the file shadowed `SEED_PROFILES` entirely. Users without the file already got updated profiles on every restart because `load_profiles_config` falls back to the in-memory seeds.

This PR implements additive-merge semantics so all three upgrade surfaces (runtime load, `hal0 update`, and `install.sh`) pick up newly-added seed profiles without ever clobbering operator-customised ones.

## Changes

- **`src/hal0/config/loader.py` — `load_profiles_config`**: after loading the on-disk file, inject any `SEED_PROFILES` entries whose keys are absent from the loaded catalog. Operator-customised profiles (including customised seed-keyed profiles) are never overwritten.

- **`src/hal0/updater/updater.py`**: add `ensure_seed_profiles()` module-level helper that reads the on-disk file directly, detects missing seeds, and atomically writes them back only when something was actually added. Called from `Updater.apply()` after config migrations (step 7b). Failure is non-fatal — a missing seed profile is cosmetic and should not abort an update.

- **`installer/install.sh`**: add an idempotent additive-merge step (A10b, near the slot-seed loop) that invokes `ensure_seed_profiles()` via a Python heredoc. Runs only when `profiles.toml` already exists; fresh installs are served seeds in-memory with no write.

- **`installer/etc-hal0/profiles.toml`**: update comment to reflect additive-merge semantics.

- **`PLAN.md`**: update step 5 note from the stale "if upgrade: skip" description to the correct additive-merge description.

## Tests added (`tests/config/test_profiles.py`)

Four new tests, all in `TestLoadProfilesConfig`:

| Test | What it verifies |
|------|-----------------|
| `test_partial_file_gets_missing_seeds_merged_in` | A file with only the `rocm` profile gets all other seeds injected |
| `test_operator_customised_profile_not_overwritten` | An operator-edited `rocm` entry (custom image) survives the merge untouched |
| `test_partial_file_custom_profile_preserved` | A non-seed operator profile co-exists after merge |
| `test_complete_seed_file_no_extras_added` | A file already containing all seeds gets no duplicates |

Local run: `PYTHONPATH=/tmp/hal0-wt-838/src /mnt/repos/hal0-mono/hal0/.venv/bin/python -m pytest tests/config/test_profiles.py -q` → **43 passed** (39 pre-existing + 4 new). Full config suite: **300 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)