### PR TITLE
fix(memory): warn on in-memory PgVectorProvider writes and surface degraded status (#613)

### DIFF
--- a/src/hal0/api/routes/health.py
+++ b/src/hal0/api/routes/health.py
@@ -52,6 +52,19 @@ def _disk_free_mb(path: Path) -> int:
         return 0
 
 
+def _memory_degraded(request: Request) -> bool | None:
+    """Return the memory degraded state for /api/status.
+
+    True  → memory enabled, running on the volatile in-memory fallback.
+    False → memory enabled, using a real durable provider.
+    None  → memory is disabled (no provider wired).
+    """
+    provider = getattr(request.app.state, "memory_provider", None)
+    if provider is None:
+        return None
+    return bool(getattr(provider, "degraded", False))
+
+
 @router.get("/status")
 async def get_status(request: Request) -> dict[str, Any]:
     """Overall liveness + dashboard summary.
@@ -118,6 +131,11 @@ async def get_status(request: Request) -> dict[str, Any]:
         # backend can never disagree. Reflects the real wrapper, so an init
         # failure also reads as off.
         "memory_enabled": getattr(request.app.state, "memory_provider", None) is not None,
+        # True  → memory is enabled but running on the volatile in-memory
+        #         PgVectorProvider fallback (writes will be lost on restart).
+        # False → memory is enabled and using a real durable provider.
+        # None  → memory is disabled (HAL0_MEMORY_ENABLED not set / init failed).
+        "memory_degraded": _memory_degraded(request),
     }
 
 

--- a/src/hal0/memory/__init__.py
+++ b/src/hal0/memory/__init__.py
@@ -65,6 +65,11 @@ def provider_from_config(cfg: Any) -> MemoryProvider:
     to Hindsight, with a boot-time degrade to the in-memory PgVectorProvider when
     the Hindsight daemon is unreachable. ``cfg`` is the object returned by
     ``hal0.config.loader.load_hal0_config``.
+
+    Callers can check ``getattr(provider, "degraded", False)`` to detect when the
+    returned provider is the in-memory PgVectorProvider fallback rather than a real
+    durable engine. ``PgVectorProvider.degraded`` is always ``True``; all other
+    providers default to ``False`` (absent attribute → ``getattr`` fallback).
     """
     engine = str(getattr(cfg.memory, "engine", "hindsight") or "hindsight").lower()
     embed = cfg.memory.embedding

--- a/src/hal0/memory/pgvector_provider.py
+++ b/src/hal0/memory/pgvector_provider.py
@@ -5,6 +5,11 @@ as the engines. Stands in when Hindsight is unavailable at boot so the
 tools return empties + the dashboard shows "no engine" instead of crashing.
 A real pgvector backing is deferred; the contract + degrade path are what P0
 needs.
+
+SAFETY: this provider is IN-MEMORY ONLY — all writes are LOST on restart.
+Callers can detect this via the ``degraded`` attribute (always ``True`` here).
+``add()`` emits a structlog WARNING on the first write per instance to alert
+operators before data loss occurs.
 """
 
 from __future__ import annotations
@@ -13,7 +18,11 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
+import structlog
+
 from hal0.memory.provider import MemoryProvider
+
+log = structlog.get_logger(__name__)
 
 _SHARED = "shared"
 _PRIVATE = "private:"
@@ -24,12 +33,31 @@ def _now() -> str:
 
 
 class PgVectorProvider(MemoryProvider):
+    #: Always True — signals that this provider is the in-memory degrade
+    #: fallback; writes are NOT persisted and are LOST on restart.
+    degraded: bool = True
+
     def __init__(self, *, client_id: str = "anonymous") -> None:
         self._client_id = client_id
         self._rows: list[dict[str, Any]] = []
         self._graph_enabled = False
         self._extraction_slot = "utility"
         self._rerank_enabled = False
+        # Emit the degrade warning exactly once per provider instance so log
+        # consumers see it on construction rather than being spammed on each
+        # write.  A second warning fires on the first add() call so the
+        # WARNING is visible in the write path even when the provider was
+        # constructed outside of our factory (e.g. in tests).
+        self._add_warned = False
+        log.warning(
+            "hal0.memory.degraded_provider_active",
+            detail=(
+                "Memory is running on the in-memory PgVectorProvider fallback. "
+                "All writes are VOLATILE and will be LOST on restart. "
+                "Ensure Hindsight is reachable and HAL0_MEMORY_ENABLED=1 "
+                "to enable durable storage."
+            ),
+        )
 
     def _allowed(self, requested: str | list[str], client_id: str | None) -> list[str]:
         cid = client_id or self._client_id
@@ -57,6 +85,20 @@ class PgVectorProvider(MemoryProvider):
         client_id=None,
         document_id=None,
     ):
+        # Emit a per-call warning (throttled to once per instance) so the
+        # write-path is loud even when the construction-time warning was
+        # swallowed by a log filter or the provider was built outside our
+        # factory.
+        if not self._add_warned:
+            self._add_warned = True
+            log.warning(
+                "hal0.memory.degraded_write",
+                detail=(
+                    "Memory write accepted by in-memory PgVectorProvider. "
+                    "This data is VOLATILE and will be LOST on restart."
+                ),
+                dataset=dataset,
+            )
         # No document semantics on this engine — a caller-supplied
         # document_id just becomes the item id so delete round-trips.
         item_id = document_id or str(uuid.uuid4())

--- a/tests/api/test_memory_degraded_status.py
+++ b/tests/api/test_memory_degraded_status.py
@@ -41,7 +41,7 @@ def test_status_memory_degraded_none_when_disabled(
     tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """memory_degraded=None when no memory provider is wired."""
-    app, client = _build(monkeypatch, None)
+    _app, client = _build(monkeypatch, None)
     with client:
         body = client.get("/api/status").json()
     assert body["memory_enabled"] is False

--- a/tests/api/test_memory_degraded_status.py
+++ b/tests/api/test_memory_degraded_status.py
@@ -1,0 +1,89 @@
+"""#613 — /api/status must expose memory_degraded for operator visibility.
+
+Verifies:
+  1. memory_degraded=None when memory is disabled.
+  2. memory_degraded=True when memory is enabled + provider is the in-memory
+     PgVectorProvider fallback (degraded=True).
+  3. memory_degraded=False when memory is enabled + provider is a real durable
+     engine (degraded absent / False).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+
+
+def _build(monkeypatch: pytest.MonkeyPatch, value: str | None):
+    if value is None:
+        monkeypatch.delenv("HAL0_MEMORY_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("HAL0_MEMORY_ENABLED", value)
+    app = create_app()
+    return app, TestClient(app)
+
+
+# ── memory_degraded field present ─────────────────────────────────────────────
+
+
+def test_status_exposes_memory_degraded_field(client: TestClient) -> None:
+    """/api/status always carries a memory_degraded field."""
+    body = client.get("/api/status").json()
+    assert "memory_degraded" in body, f"memory_degraded missing from /api/status: {body}"
+
+
+# ── memory disabled → None ────────────────────────────────────────────────────
+
+
+def test_status_memory_degraded_none_when_disabled(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """memory_degraded=None when no memory provider is wired."""
+    app, client = _build(monkeypatch, None)
+    with client:
+        body = client.get("/api/status").json()
+    assert body["memory_enabled"] is False
+    assert body["memory_degraded"] is None
+
+
+# ── in-memory fallback → True ─────────────────────────────────────────────────
+
+
+def test_status_memory_degraded_true_for_pgvector_fallback(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """memory_degraded=True when PgVectorProvider (in-memory fallback) is wired."""
+    from hal0.memory.pgvector_provider import PgVectorProvider
+
+    app, client = _build(monkeypatch, "1")
+    # Replace whatever provider was built with the explicit in-memory fallback.
+    app.state.memory_provider = PgVectorProvider()
+
+    with client:
+        body = client.get("/api/status").json()
+
+    assert body["memory_enabled"] is True
+    assert body["memory_degraded"] is True
+
+
+# ── real provider → False ─────────────────────────────────────────────────────
+
+
+def test_status_memory_degraded_false_for_real_provider(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """memory_degraded=False when a durable provider (no degraded attr) is wired."""
+    from unittest.mock import MagicMock
+
+    app, client = _build(monkeypatch, "1")
+    # Simulate a real provider: no 'degraded' attribute (getattr fallback → False).
+    fake_real_provider = MagicMock(spec=[])  # no attributes
+    app.state.memory_provider = fake_real_provider
+
+    with client:
+        body = client.get("/api/status").json()
+
+    assert body["memory_enabled"] is True
+    assert body["memory_degraded"] is False

--- a/tests/memory/test_pgvector_degrade_safety.py
+++ b/tests/memory/test_pgvector_degrade_safety.py
@@ -14,10 +14,10 @@ Verifies:
 
 from __future__ import annotations
 
-import pytest
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -73,9 +73,9 @@ def test_pgvector_construction_emits_warning():
         PgVectorProvider()
 
     warning_events = [e["event"] for e in logs if e.get("log_level") == "warning"]
-    assert any(
-        "hal0.memory.degraded_provider_active" in ev for ev in warning_events
-    ), f"No degrade-provider-active warning found in: {warning_events}"
+    assert any("hal0.memory.degraded_provider_active" in ev for ev in warning_events), (
+        f"No degrade-provider-active warning found in: {warning_events}"
+    )
 
 
 # ── add() write warning ───────────────────────────────────────────────────────
@@ -94,9 +94,9 @@ async def test_pgvector_add_emits_warning_on_first_call():
         await p.add("hello", dataset="shared")
 
     warning_events = [e["event"] for e in logs if e.get("log_level") == "warning"]
-    assert any(
-        "hal0.memory.degraded_write" in ev for ev in warning_events
-    ), f"No degraded_write warning found in: {warning_events}"
+    assert any("hal0.memory.degraded_write" in ev for ev in warning_events), (
+        f"No degraded_write warning found in: {warning_events}"
+    )
 
 
 @pytest.mark.asyncio
@@ -116,12 +116,11 @@ async def test_pgvector_add_warns_only_once_per_instance():
 
     # After the first-write warning is consumed, subsequent adds must be silent.
     write_warnings = [
-        e for e in logs
+        e
+        for e in logs
         if e.get("log_level") == "warning" and "degraded_write" in e.get("event", "")
     ]
-    assert write_warnings == [], (
-        f"Unexpected repeated write warnings: {write_warnings}"
-    )
+    assert write_warnings == [], f"Unexpected repeated write warnings: {write_warnings}"
 
 
 @pytest.mark.asyncio
@@ -152,7 +151,6 @@ def test_factory_degrade_provider_has_degraded_true():
 def test_factory_real_provider_degraded_is_falsy():
     """When Hindsight is reachable, provider_from_config returns degraded=False/absent."""
     from hal0.memory import provider_from_config
-    from hal0.memory.hindsight_provider import HindsightProvider
 
     with (
         patch("hal0.memory._build_hindsight_client", return_value=object()),

--- a/tests/memory/test_pgvector_degrade_safety.py
+++ b/tests/memory/test_pgvector_degrade_safety.py
@@ -1,0 +1,165 @@
+"""#613 — PgVectorProvider degrade-safety: warn on writes, expose degraded flag.
+
+Verifies:
+  1. PgVectorProvider.degraded is True (callers can detect the fallback).
+  2. HindsightProvider.degraded is absent / falsy (not the fallback).
+  3. A structlog WARNING is emitted on construction of PgVectorProvider.
+  4. A structlog WARNING is emitted on the first add() call.
+  5. The WARNING is NOT repeated on subsequent add() calls (log-once).
+  6. provider_from_config() returns a provider with degraded=True when
+     Hindsight is unreachable (degrade ladder fires).
+  7. provider_from_config() returns a provider with degraded=False/absent
+     when Hindsight is reachable.
+"""
+
+from __future__ import annotations
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _cfg(engine="hindsight"):
+    return SimpleNamespace(
+        memory=SimpleNamespace(
+            engine=engine,
+            embedding=SimpleNamespace(
+                model="BAAI/bge-small-en-v1.5",
+                rerank_enabled=False,
+                rerank_url="http://127.0.0.1:8086",
+                rerank_gateway_url="http://127.0.0.1:8080",
+                rerank_over_fetch_factor=5,
+                rerank_max_candidates=500,
+                rerank_connect_timeout_s=1.0,
+                rerank_read_timeout_s=8.0,
+            ),
+            graph=SimpleNamespace(enabled=False, extraction_slot="utility"),
+        )
+    )
+
+
+# ── degraded attribute ────────────────────────────────────────────────────────
+
+
+def test_pgvector_provider_degraded_is_true():
+    """PgVectorProvider.degraded must be True so callers detect the fallback."""
+    from hal0.memory.pgvector_provider import PgVectorProvider
+
+    p = PgVectorProvider()
+    assert p.degraded is True
+
+
+def test_hindsight_provider_degraded_is_falsy():
+    """HindsightProvider must NOT carry degraded=True (it is the real engine)."""
+    from hal0.memory.hindsight_provider import HindsightProvider
+
+    p = HindsightProvider(client=object())
+    assert not getattr(p, "degraded", False)
+
+
+# ── construction-time warning ─────────────────────────────────────────────────
+
+
+def test_pgvector_construction_emits_warning():
+    """PgVectorProvider.__init__ must emit a WARNING about volatile storage."""
+    from structlog.testing import capture_logs
+
+    from hal0.memory.pgvector_provider import PgVectorProvider
+
+    with capture_logs() as logs:
+        PgVectorProvider()
+
+    warning_events = [e["event"] for e in logs if e.get("log_level") == "warning"]
+    assert any(
+        "hal0.memory.degraded_provider_active" in ev for ev in warning_events
+    ), f"No degrade-provider-active warning found in: {warning_events}"
+
+
+# ── add() write warning ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pgvector_add_emits_warning_on_first_call():
+    """add() must emit a WARNING on the first write."""
+    from structlog.testing import capture_logs
+
+    from hal0.memory.pgvector_provider import PgVectorProvider
+
+    p = PgVectorProvider()
+
+    with capture_logs() as logs:
+        await p.add("hello", dataset="shared")
+
+    warning_events = [e["event"] for e in logs if e.get("log_level") == "warning"]
+    assert any(
+        "hal0.memory.degraded_write" in ev for ev in warning_events
+    ), f"No degraded_write warning found in: {warning_events}"
+
+
+@pytest.mark.asyncio
+async def test_pgvector_add_warns_only_once_per_instance():
+    """Subsequent add() calls must NOT repeat the write warning (log-once throttle)."""
+    from structlog.testing import capture_logs
+
+    from hal0.memory.pgvector_provider import PgVectorProvider
+
+    p = PgVectorProvider()
+    # Prime the first-write warning (so _add_warned=True).
+    await p.add("first", dataset="shared")
+
+    with capture_logs() as logs:
+        await p.add("second", dataset="shared")
+        await p.add("third", dataset="shared")
+
+    # After the first-write warning is consumed, subsequent adds must be silent.
+    write_warnings = [
+        e for e in logs
+        if e.get("log_level") == "warning" and "degraded_write" in e.get("event", "")
+    ]
+    assert write_warnings == [], (
+        f"Unexpected repeated write warnings: {write_warnings}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pgvector_add_still_stores_data_despite_warning():
+    """The warning must not prevent the write — data IS stored in memory."""
+    from hal0.memory.pgvector_provider import PgVectorProvider
+
+    p = PgVectorProvider()
+    result = await p.add("keep me", dataset="shared")
+    assert "id" in result and "timestamp" in result
+    items = await p.list_items(dataset="shared")
+    assert any(r["text"] == "keep me" for r in items["items"])
+
+
+# ── factory degrade detection ─────────────────────────────────────────────────
+
+
+def test_factory_degrade_provider_has_degraded_true():
+    """When Hindsight is unreachable, provider_from_config returns degraded=True."""
+    from hal0.memory import provider_from_config
+
+    with patch("hal0.memory._build_hindsight_client", side_effect=RuntimeError("no daemon")):
+        provider = provider_from_config(_cfg("hindsight"))
+
+    assert getattr(provider, "degraded", False) is True
+
+
+def test_factory_real_provider_degraded_is_falsy():
+    """When Hindsight is reachable, provider_from_config returns degraded=False/absent."""
+    from hal0.memory import provider_from_config
+    from hal0.memory.hindsight_provider import HindsightProvider
+
+    with (
+        patch("hal0.memory._build_hindsight_client", return_value=object()),
+        patch("hal0.memory.HindsightProvider", autospec=True) as mock_cls,
+    ):
+        mock_instance = mock_cls.return_value
+        # HindsightProvider must NOT expose degraded=True
+        del mock_instance.degraded  # ensure getattr fallback to False
+        provider_from_config(_cfg("hindsight"))
+        assert not getattr(mock_cls.return_value, "degraded", False)


### PR DESCRIPTION
Fixes #613

## Summary

The in-memory `PgVectorProvider` degrade fallback silently accepted writes
that were lost on restart, with no operator warning and no API signal. A user
who enabled memory via `HAL0_MEMORY_ENABLED=1` but had Hindsight unavailable
would land on this path and lose all memory writes silently.

- **`pgvector_provider.py`**: Adds `degraded: bool = True` class attribute (detection sentinel) and emits a structlog `WARNING` on `__init__` (degrade path activated) plus a log-once `WARNING` on the first `add()` call per instance (write-path alert without spam).
- **`memory/__init__.py`**: Documents the `getattr(provider, "degraded", False)` detection pattern in `provider_from_config()` docstring.
- **`api/routes/health.py`**: Adds `memory_degraded` field to `GET /api/status`:
  - `True` — memory enabled but on the volatile in-memory fallback (writes lost on restart)
  - `False` — memory enabled with a real durable provider
  - `None` — memory disabled (no provider wired)

## Tests added

**`tests/memory/test_pgvector_degrade_safety.py`** (8 tests):
- `test_pgvector_provider_degraded_is_true` — degraded attribute is True
- `test_hindsight_provider_degraded_is_falsy` — real provider is not degraded
- `test_pgvector_construction_emits_warning` — construction emits structlog WARNING
- `test_pgvector_add_emits_warning_on_first_call` — first write emits WARNING
- `test_pgvector_add_warns_only_once_per_instance` — no repeated write warnings
- `test_pgvector_add_still_stores_data_despite_warning` — write still succeeds
- `test_factory_degrade_provider_has_degraded_true` — factory degrade path → degraded=True
- `test_factory_real_provider_degraded_is_falsy` — healthy path → degraded=False

**`tests/api/test_memory_degraded_status.py`** (4 tests):
- `test_status_exposes_memory_degraded_field` — field present in /api/status
- `test_status_memory_degraded_none_when_disabled` — None when no provider
- `test_status_memory_degraded_true_for_pgvector_fallback` — True for in-memory fallback
- `test_status_memory_degraded_false_for_real_provider` — False for real engine

All 12 new tests pass locally. 4 pre-existing unrelated test failures unchanged (verified on clean branch before changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)