### PR TITLE
fix(platform-review): Wave 1 — 4 born-broken bugs (SC-1, SC-2, PS-1, DR-1)

### DIFF
--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -459,6 +459,87 @@ async def _ensure_backend_for_model(request: Request, body: dict[str, Any]) -> N
         )
 
 
+# DR-1: path → capability-slot pins, mirroring resolve_by_capability rules
+# 1-4 in dispatcher/router.py (_EMBED_PATHS / _RERANK_PATHS / _TTS_PATHS /
+# _IMAGE_PATHS). Kept in lock-step with those fragments.
+_CAPABILITY_PATH_PINS: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("/embeddings",), "embed"),
+    (("/rerankings", "/rerank"), "rerank"),
+    (("/audio/speech",), "tts"),
+    (("/images/generations", "/images/edits", "/images/variations"), "img"),
+)
+
+
+def _capability_slot_for_path(path: str) -> str | None:
+    """Resolve a path-pinned capability slot name (embed/rerank/tts/img).
+
+    Mirrors the dispatcher's ``resolve_by_capability`` rules 1-4
+    (:mod:`hal0.dispatcher.router`): route purely by request path, first
+    fragment wins. Returns ``None`` for a non-capability path (e.g. chat).
+    """
+    for fragments, slot in _CAPABILITY_PATH_PINS:
+        if any(frag in path for frag in fragments):
+            return slot
+    return None
+
+
+async def _wake_capability_slot(request: Request) -> None:
+    """DR-1: wake an idle-EVICTED path-pinned capability slot before dispatch.
+
+    The idle sweeper unloads embed/rerank/tts/img slots to OFFLINE and
+    DEREGISTERS their container upstream
+    (``SlotManager._deregister_container_upstream``). A follow-up request
+    then 404s inside ``resolve_by_capability`` (surfaced as ``NoRouteFound``)
+    long before it can reach the dispatcher's container readiness gate — so
+    the gate can never reload it. This is the capability-layer twin of the
+    chat branch's :func:`_ensure_backend_for_model`: resolve the slot from
+    the request PATH (not the model id) and, when it is a known managed slot
+    sitting OFFLINE, drive ``SlotManager.load(slot)``, which re-registers the
+    upstream (``SlotManager._register_container_upstream``) so the subsequent
+    dispatch resolves it instead of 404ing.
+
+    Best-effort, same contract as the chat branch: the arbiter image-mode
+    guard fires FIRST (NOT swallowed — it is the outcome), then the load runs
+    in a try/except that logs + swallows so routing still proceeds.
+    """
+    slot_name = _capability_slot_for_path(request.url.path)
+    if slot_name is None:
+        return
+    slot_manager = getattr(request.app.state, "slot_manager", None)
+    if slot_manager is None:
+        return
+    # Only wake a KNOWN managed slot; an unconfigured capability path must
+    # dispatch as-is (and 404 as before) rather than trip a spurious load.
+    try:
+        cfgs = await slot_manager.iter_configs()
+    except Exception:
+        return
+    if slot_name not in {c.get("name") for c in cfgs}:
+        return
+    # Nothing to do unless the slot was actually evicted to OFFLINE — a
+    # READY/IDLE/SERVING slot is already routable, and a still-loading slot
+    # is handled by the dispatcher's readiness gate.
+    from hal0.slots.state import SlotState
+
+    if slot_manager.state(slot_name) is not SlotState.OFFLINE:
+        return
+    # Mirror the chat branch: NEVER lazy-load onto the GPU against the
+    # arbiter's exclusive mode. The guard is the outcome — not swallowed.
+    arbiter = getattr(slot_manager, "arbiter", None)
+    if arbiter is not None:
+        arbiter.guard_dispatch(slot_name)
+    try:
+        await slot_manager.load(slot_name)
+    except Exception as exc:
+        log.warning(
+            "v1.capability_wake_failed",
+            slot=slot_name,
+            path=request.url.path,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+
+
 async def _dispatch_and_forward(
     request: Request,
     dispatcher: DispatcherDep,
@@ -474,6 +555,10 @@ async def _dispatch_and_forward(
     # then takes. A model no upstream serves surfaces as the dispatcher's
     # NoRouteFound envelope (404) — there is no catch-all fall-through.
     await _ensure_backend_for_model(request, body)
+    # DR-1: capability twin of the backend-aware load — wake an idle-EVICTED
+    # embed/rerank/tts/img slot (resolved from the request PATH) so its
+    # upstream is re-registered before dispatch, instead of 404ing.
+    await _wake_capability_slot(request)
     call = await dispatcher.dispatch(request, body=body)
     # Remember the most recent model we sent to this upstream so the
     # dashboard's synthetic slot reflects what's actually being used,

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -508,13 +508,18 @@ async def _wake_capability_slot(request: Request) -> None:
     slot_manager = getattr(request.app.state, "slot_manager", None)
     if slot_manager is None:
         return
-    # Only wake a KNOWN managed slot; an unconfigured capability path must
-    # dispatch as-is (and 404 as before) rather than trip a spurious load.
+    # Only wake a KNOWN managed slot that is ENABLED; an unconfigured
+    # capability path must dispatch as-is (and 404 as before) rather than trip
+    # a spurious load. Critically, a DISABLED slot must stay dark: the routing
+    # layer drops ``enabled is False`` slots (``_loaded_slot_from_config``), so
+    # waking one here would revive a capability an operator explicitly disabled
+    # (and undo the SC-1 disable semantics). Mirror that rule.
     try:
         cfgs = await slot_manager.iter_configs()
     except Exception:
         return
-    if slot_name not in {c.get("name") for c in cfgs}:
+    eligible = {c.get("name") for c in cfgs if c.get("enabled") is not False}
+    if slot_name not in eligible:
         return
     # Nothing to do unless the slot was actually evicted to OFFLINE — a
     # READY/IDLE/SERVING slot is already routable, and a still-loading slot

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -165,35 +165,73 @@ _FLM_BROKEN_TAGS: dict[str, str] = {
 }
 
 
+# Cached result of the FLM-image-present probe (None = not yet probed).
+# The probe shells a container runtime, which the module contract
+# (``GET /api/capabilities`` must not spawn subprocesses on every load)
+# forbids doing per-GET — so we run it once and reuse it.
+# :func:`reset_flm_image_present_cache` drops it after an FLM pull.
+_flm_image_present_cache: bool | None = None
+
+
+def reset_flm_image_present_cache() -> None:
+    """Drop the cached FLM-image-present probe so the next call re-probes.
+
+    Invalidated alongside the FLM catalog cache after a successful FLM
+    pull (see :func:`hal0.registry.pull.run_flm_pull`) so a freshly-pulled
+    toolbox image flips the NPU backend on without a process restart.
+    Also exposed for tests.
+    """
+    global _flm_image_present_cache
+    _flm_image_present_cache = None
+
+
 def _flm_image_present() -> bool:
     """True iff the FLM toolbox image is already pulled locally.
 
-    Picking ``backend=npu`` rewrites the slot TOML and asks docker to
-    spawn the FLM container. The image is gated on ghcr.io credentials
-    that aren't part of the public install, so an unauthenticated host
-    spirals into a ``docker pull → unauthorized → systemd restart``
-    loop with no way for the user to recover from the dashboard.
-    Advertising NPU as a backend only after we know docker can spawn
+    Picking ``backend=npu`` rewrites the slot TOML and asks the container
+    runtime to spawn the FLM container. The image is gated on ghcr.io
+    credentials that aren't part of the public install, so an
+    unauthenticated host spirals into a ``pull → unauthorized → systemd
+    restart`` loop with no way for the user to recover from the dashboard.
+    Advertising NPU as a backend only after we know the runtime can spawn
     the container avoids that whole class of failure.
 
-    Checked via ``docker image inspect`` which returns 0 iff the image
-    id resolves locally. We cache nothing — the toolchain install
-    pulls the image once and the function is called only on the
-    /api/capabilities GET which is already cheap.
+    Checked via ``<runtime> image inspect`` which returns 0 iff the image
+    id resolves locally. The runtime binary is resolved through the shared
+    :func:`hal0.providers.container._container_runtime` path (podman →
+    docker → RuntimeError) so a podman-only host probes podman rather than
+    a missing ``docker``. The result is cached at module scope (see
+    :data:`_flm_image_present_cache`) so the /api/capabilities GET doesn't
+    re-spawn the probe on every load.
     """
+    global _flm_image_present_cache
+    if _flm_image_present_cache is not None:
+        return _flm_image_present_cache
+
     import subprocess
+
+    from hal0.providers.container import _container_runtime
+
+    try:
+        runtime = _container_runtime()
+    except RuntimeError:
+        # No container runtime installed — the NPU backend can't spawn.
+        _flm_image_present_cache = False
+        return False
 
     try:
         proc = subprocess.run(
-            ["docker", "image", "inspect", _FLM_TOOLBOX_IMAGE],
+            [runtime, "image", "inspect", _FLM_TOOLBOX_IMAGE],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             timeout=2.0,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        # Transient probe failure — don't cache, so a later GET can retry.
         return False
-    return proc.returncode == 0
+    _flm_image_present_cache = proc.returncode == 0
+    return _flm_image_present_cache
 
 
 def available_backends() -> list[dict[str, Any]]:

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -838,7 +838,7 @@ PROFILE_BENCH: dict[str, dict[str, float]] = {
 DEVICE_DEFAULT_PROFILES: dict[str, str] = {
     "gpu-rocm": "rocm",
     "gpu-vulkan": "vulkan",
-    "cpu": "tts",
+    "cpu": "cpu-llm",
     "npu": "flm",
 }
 

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -635,8 +635,14 @@ async def run_flm_pull(
             )
 
         # Refresh the catalog so subsequent /api/capabilities picks up
-        # the new installed=true flag without a process restart.
+        # the new installed=true flag without a process restart. Also drop
+        # the cached NPU image-present probe so a first FLM pull (which may
+        # have brought the toolbox image online) can flip the NPU backend on
+        # the next capabilities GET without a restart.
         reset_flm_catalog_cache()
+        from hal0.capabilities.catalog import reset_flm_image_present_cache
+
+        reset_flm_image_present_cache()
 
         # Best-effort path bookkeeping. FLM stores each tag's weights at
         # ``<host_models_dir>/<HF-repo-name>/`` — we resolve the dir from

--- a/src/hal0/slot_config/__init__.py
+++ b/src/hal0/slot_config/__init__.py
@@ -171,10 +171,13 @@ class SlotConfigStore:
              ``selection.selection``, serialised through the canonical
              :func:`capabilities_toml_payload` shape.
           2. ``slots/<slot_name>.toml`` — reconciled against the
-             selection **iff** the selection is enabled AND the file
-             already exists (slot creation carries state.json + port
-             allocation side effects and stays with
-             ``SlotManager.create``). Otherwise ``after == before``.
+             selection **iff** the file already exists (slot creation
+             carries state.json + port allocation side effects and stays
+             with ``SlotManager.create``, so a missing file yields
+             ``after == before``). The ``enabled`` flag is always written
+             on both enable and disable; the backend/device/provider/
+             model/profile fields are reconciled only when the selection
+             is enabled.
         """
         caps_path = self._caps_path()
         caps_before = _read_toml_or_none(caps_path)
@@ -246,13 +249,17 @@ class SlotConfigStore:
     def _reconciled_slot(
         self, raw_before: dict[str, Any] | None, slot_selection: SlotSelection
     ) -> dict[str, Any] | None:
-        """Project an enabled selection onto the existing slot TOML dict.
+        """Project a selection onto the existing slot TOML dict.
 
-        Mirrors the semantics of the pre-#697 rewrite-through-
-        ``SlotManager.update_config`` path exactly:
+        The store is the single owner of the slot's ``enabled`` flag (SC-1):
 
-          - reconcile only when the selection is enabled (pure disable
-            never rewrote the slot file) and the file exists,
+          - ``enabled`` is written UNCONDITIONALLY when the file exists — a
+            disable flips ``enabled = false`` (so the request router stops
+            resolving the slot) and an enable clears any stale
+            ``enabled = false``,
+          - the backend/device/provider/model/profile fields are reconciled
+            ONLY when the selection is enabled (a pure disable never rewrites
+            the model/device siblings),
           - one-level deep merge for the nested ``[model]`` table so
             sibling keys (``context_size`` etc.) survive,
           - both ``device`` (v0.2 canonical) and ``backend`` (one-release
@@ -269,30 +276,36 @@ class SlotConfigStore:
         this the slot would keep Kokoro's profile and never spawn Qwen3.
         """
         selection = slot_selection.selection
-        if raw_before is None or not selection.enabled:
+        if raw_before is None:
             return raw_before
 
-        updates: dict[str, Any] = {}
-        slot_backend = device_to_legacy_backend(selection.device)
-        slot_device = canonical_device(selection.device)
-        if slot_backend:
-            # Deprecated field, kept for one release — see ADR-0006 §7.
-            updates["backend"] = slot_backend
-        if slot_device:
-            updates["device"] = slot_device
-        if selection.provider:
-            updates["provider"] = selection.provider
-        if selection.model:
-            updates["model"] = {"default": selection.model}
+        # ``enabled`` is written UNCONDITIONALLY — this is the single owner of
+        # the slot's enablement (SC-1). A disable must flip ``enabled = false``
+        # so the request router (``_loaded_slot_from_config``) stops resolving
+        # the slot; an enable clears any stale ``enabled = false``.
+        updates: dict[str, Any] = {"enabled": selection.enabled}
+        if selection.enabled:
+            # The backend/device/provider/model/profile reconciliation only
+            # applies when the slot is going to run — a pure disable never
+            # rewrites the model/device siblings.
+            slot_backend = device_to_legacy_backend(selection.device)
+            slot_device = canonical_device(selection.device)
+            if slot_backend:
+                # Deprecated field, kept for one release — see ADR-0006 §7.
+                updates["backend"] = slot_backend
+            if slot_device:
+                updates["device"] = slot_device
+            if selection.provider:
+                updates["provider"] = selection.provider
+            if selection.model:
+                updates["model"] = {"default": selection.model}
 
-        # TTS engine switch: derive the slot profile from the picked device so
-        # the GPU/CPU choice actually swaps the provider inside the one tts slot.
-        tts_profile = self._tts_profile_for(slot_selection)
-        if tts_profile is not None:
-            updates["profile"] = tts_profile
-
-        if not updates:
-            return raw_before
+            # TTS engine switch: derive the slot profile from the picked device
+            # so the GPU/CPU choice actually swaps the provider inside the one
+            # tts slot.
+            tts_profile = self._tts_profile_for(slot_selection)
+            if tts_profile is not None:
+                updates["profile"] = tts_profile
 
         after = dict(raw_before)
         for key, value in updates.items():

--- a/tests/capabilities/test_catalog_backends.py
+++ b/tests/capabilities/test_catalog_backends.py
@@ -26,7 +26,7 @@ from hal0.capabilities import catalog
 
 
 def _npu_only_hw() -> Any:
-    \"\"\"A HardwareInfo-shaped stub: NPU present, no GPUs.\"\"\"
+    """A HardwareInfo-shaped stub: NPU present, no GPUs."""
     return types.SimpleNamespace(
         npu=types.SimpleNamespace(present=True),
         gpus=[],
@@ -35,14 +35,14 @@ def _npu_only_hw() -> Any:
 
 @pytest.fixture(autouse=True)
 def _reset_probe_cache() -> Any:
-    \"\"\"Ensure each test starts and ends with a clean image-present cache.\"\"\"
+    """Ensure each test starts and ends with a clean image-present cache."""
     catalog.reset_flm_image_present_cache()
     yield
     catalog.reset_flm_image_present_cache()
 
 
 def test_npu_advertised_under_podman_only(monkeypatch: pytest.MonkeyPatch) -> None:
-    \"\"\"NPU is advertised when podman (not docker) reports the image present.\"\"\"
+    """NPU is advertised when podman (not docker) reports the image present."""
     monkeypatch.setenv("HAL0_CONTAINER_RUNTIME", "podman")
     monkeypatch.setattr(catalog, "load_hardware_info", _npu_only_hw)
 
@@ -63,7 +63,7 @@ def test_npu_advertised_under_podman_only(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_npu_hidden_when_image_absent(monkeypatch: pytest.MonkeyPatch) -> None:
-    \"\"\"Runtime resolves but the image inspect fails → no NPU backend.\"\"\"
+    """Runtime resolves but the image inspect fails → no NPU backend."""
     monkeypatch.setenv("HAL0_CONTAINER_RUNTIME", "podman")
     monkeypatch.setattr(catalog, "load_hardware_info", _npu_only_hw)
 
@@ -78,8 +78,8 @@ def test_npu_hidden_when_image_absent(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_flm_probe_not_hardcoded_docker(monkeypatch: pytest.MonkeyPatch) -> None:
-    \"\"\"The resolved argv never equals literal ``docker`` under podman, and the
-    probe is cached across repeated ``available_backends`` calls.\"\"\"
+    """The resolved argv never equals literal ``docker`` under podman, and the
+    probe is cached across repeated ``available_backends`` calls."""
     monkeypatch.setenv("HAL0_CONTAINER_RUNTIME", "podman")
     monkeypatch.setattr(catalog, "load_hardware_info", _npu_only_hw)
 

--- a/tests/capabilities/test_catalog_backends.py
+++ b/tests/capabilities/test_catalog_backends.py
@@ -1,0 +1,99 @@
+"""SC-2 — the NPU picker probe must honour a podman-only runtime.
+
+``available_backends`` gates the NPU/FLM backend on
+:func:`hal0.capabilities.catalog._flm_image_present`, which checks whether
+the FLM toolbox image is already pulled locally. It used to shell a
+hard-coded ``docker image inspect``; on a podman-only host (the default
+install) that ``docker`` binary is absent, so the probe always returned
+False and the NPU backend was silently dropped even when the image was
+present under podman.
+
+These tests pin that the probe resolves the runtime through the shared
+``hal0.providers.container._container_runtime`` path (podman → docker →
+raise) rather than a literal ``docker`` argv, and that the result is
+cached so repeated ``/api/capabilities`` GETs don't re-spawn the probe.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import types
+from typing import Any
+
+import pytest
+
+from hal0.capabilities import catalog
+
+
+def _npu_only_hw() -> Any:
+    \"\"\"A HardwareInfo-shaped stub: NPU present, no GPUs.\"\"\"
+    return types.SimpleNamespace(
+        npu=types.SimpleNamespace(present=True),
+        gpus=[],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_probe_cache() -> Any:
+    \"\"\"Ensure each test starts and ends with a clean image-present cache.\"\"\"
+    catalog.reset_flm_image_present_cache()
+    yield
+    catalog.reset_flm_image_present_cache()
+
+
+def test_npu_advertised_under_podman_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    \"\"\"NPU is advertised when podman (not docker) reports the image present.\"\"\"
+    monkeypatch.setenv("HAL0_CONTAINER_RUNTIME", "podman")
+    monkeypatch.setattr(catalog, "load_hardware_info", _npu_only_hw)
+
+    calls: list[list[str]] = []
+
+    def fake_run(argv: list[str], **kwargs: Any) -> Any:
+        calls.append(list(argv))
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    backends = catalog.available_backends()
+
+    assert backends[0]["id"] == "npu", f"NPU not advertised on podman-only host: {backends!r}"
+    assert calls, "the image-present probe never ran"
+    assert calls[0][0] == "podman", f"probe argv[0] must be the podman binary: {calls[0]!r}"
+    assert calls[0][0] != "docker"
+
+
+def test_npu_hidden_when_image_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    \"\"\"Runtime resolves but the image inspect fails → no NPU backend.\"\"\"
+    monkeypatch.setenv("HAL0_CONTAINER_RUNTIME", "podman")
+    monkeypatch.setattr(catalog, "load_hardware_info", _npu_only_hw)
+
+    def fake_run(argv: list[str], **kwargs: Any) -> Any:
+        return types.SimpleNamespace(returncode=1)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    backends = catalog.available_backends()
+    ids = [b["id"] for b in backends]
+    assert "npu" not in ids, f"NPU advertised despite missing image: {backends!r}"
+
+
+def test_flm_probe_not_hardcoded_docker(monkeypatch: pytest.MonkeyPatch) -> None:
+    \"\"\"The resolved argv never equals literal ``docker`` under podman, and the
+    probe is cached across repeated ``available_backends`` calls.\"\"\"
+    monkeypatch.setenv("HAL0_CONTAINER_RUNTIME", "podman")
+    monkeypatch.setattr(catalog, "load_hardware_info", _npu_only_hw)
+
+    calls: list[list[str]] = []
+
+    def fake_run(argv: list[str], **kwargs: Any) -> Any:
+        calls.append(list(argv))
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    catalog.available_backends()
+    catalog.available_backends()
+
+    assert calls, "the image-present probe never ran"
+    assert all(argv[0] != "docker" for argv in calls), f"probe hard-coded docker: {calls!r}"
+    assert len(calls) == 1, f"probe re-ran instead of using the cache: {calls!r}"

--- a/tests/capabilities/test_orchestrator_reconciliation.py
+++ b/tests/capabilities/test_orchestrator_reconciliation.py
@@ -264,7 +264,14 @@ async def test_apply_no_rewrite_on_pure_disable(
     orchestrator: tuple[CapabilityOrchestrator, FakeSlotManager],
     drifted_state: Path,
 ) -> None:
-    """Disabling the slot does not require rewriting the TOML."""
+    """A pure disable flips only ``enabled`` on the slot TOML, via the store.
+
+    The STANDARD-lifecycle disable never calls ``update_config`` (persistence
+    flows through the store commit, not the SlotManager). Post-SC-1 the store
+    now writes ``enabled = false`` so routing stops resolving the slot — but
+    the model/backend siblings must survive verbatim (a pure disable does not
+    reconcile them).
+    """
     orch, fake = orchestrator
     # Pin the persisted selection to a non-NPU backend first: this test is
     # about the STANDARD lifecycle's pure-disable transition, and a
@@ -290,7 +297,12 @@ async def test_apply_no_rewrite_on_pure_disable(
 
     update_calls = [c for c in fake.calls if c[0] == "update_config"]
     assert update_calls == [], f"unexpected update_config on disable transition: {update_calls}"
-    assert _read_slot_toml(drifted_state) == before, "slot TOML changed on pure disable"
+    after = _read_slot_toml(drifted_state)
+    assert after["enabled"] is False, "pure disable must flip enabled=false on the slot TOML"
+    # Only ``enabled`` may differ — the model/backend siblings are untouched.
+    assert {k: v for k, v in after.items() if k != "enabled"} == {
+        k: v for k, v in before.items() if k != "enabled"
+    }, "pure disable rewrote a non-enabled field"
 
 
 async def test_apply_commit_failure_leaves_both_files_at_before(
@@ -338,6 +350,65 @@ async def test_apply_commit_failure_leaves_both_files_at_before(
     monkeypatch.setattr(slot_config_mod, "write_toml_atomic", real_write)
     assert _read_slot_toml(home) == slot_before
     assert caps_path.read_bytes() == caps_before
+
+
+async def test_disable_hides_slot_from_routing(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SC-1 end-to-end: disabling an embed capability flips the slot TOML's
+    ``enabled`` flag so the real SlotManager's request router stops resolving
+    it. Routing reads the reconciled slot TOML (``_loaded_slot_from_config``
+    drops ``enabled is False``), so before the fix the disabled slot stayed
+    routable because the store never wrote ``enabled = false``.
+    """
+    from hal0.slots.manager import SlotManager
+
+    monkeypatch.setattr(
+        CapabilityOrchestrator,
+        "_validate_model_in_catalog",
+        lambda self, slot, child, model_id, backend_id: None,
+    )
+    home = Path(tmp_hal0_home)
+    slots_dir = home / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "embed.toml").write_text(
+        "\n".join(
+            [
+                'name = "embed"',
+                "port = 8082",
+                'type = "embedding"',
+                'backend = "vulkan"',
+                'device = "gpu-vulkan"',
+                'provider = "llama-server"',
+                "enabled = true",
+                "[model]",
+                'default = "nomic-embed-text-v1.5-q8_0"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    _write_caps(
+        home,
+        slot="embed",
+        child="embed",
+        fields={
+            "backend": "gpu-vulkan",
+            "provider": "llama-server",
+            "model": "nomic-embed-text-v1.5-q8_0",
+            "enabled": True,
+        },
+    )
+
+    manager = SlotManager()
+    # Sanity: routing resolves the enabled slot before the disable.
+    assert await manager.resolve_for_request("embedding") is not None
+
+    orch = CapabilityOrchestrator(slot_manager=manager)
+    await orch.apply("embed", "embed", {"enabled": False})
+
+    # After the disable the router must no longer see the slot.
+    assert await manager.resolve_for_request("embedding") is None
 
 
 async def test_apply_lifecycle_failure_still_persists_intent(

--- a/tests/capabilities/test_tts_capability_switch.py
+++ b/tests/capabilities/test_tts_capability_switch.py
@@ -213,7 +213,12 @@ def test_apply_selecting_kokoro_cpu_swaps_tts_slot_back_to_kokoro_profile(
 
 
 def test_apply_disabled_tts_selection_does_not_rewrite_profile(tmp_hal0_home: str) -> None:
-    """A disabled selection never rewrites the slot (parity with #697)."""
+    """A disabled selection flips ``enabled`` but never rewrites the engine.
+
+    Post-SC-1 the store owns ``enabled`` on both transitions, so a disable
+    writes ``enabled = false`` — but the profile/device/provider engine fields
+    (which only reconcile on an ENABLE) must survive untouched.
+    """
     from hal0.capabilities.config import CapabilitySelection
     from hal0.slot_config import SlotConfigStore, SlotSelection
 
@@ -225,7 +230,12 @@ def test_apply_disabled_tts_selection_does_not_rewrite_profile(tmp_hal0_home: st
     )
     cs = store.apply(SlotSelection(slot="voice", child="tts", slot_name="tts", selection=selection))
     store.commit(cs)
-    assert _read_tts_slot(tmp_hal0_home) == before, "disabled selection must not rewrite slot"
+    after = _read_tts_slot(tmp_hal0_home)
+    assert after["enabled"] is False, "disable must flip enabled=false"
+    # The engine fields never move on a disable — only ``enabled`` may differ.
+    assert {k: v for k, v in after.items() if k != "enabled"} == {
+        k: v for k, v in before.items() if k != "enabled"
+    }, "disabled selection rewrote an engine field"
 
 
 def test_apply_non_tts_child_does_not_write_profile(tmp_hal0_home: str) -> None:

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -406,6 +406,19 @@ def test_device_default_profiles_map() -> None:
     assert DEVICE_DEFAULT_PROFILES == {
         "gpu-rocm": "rocm",
         "gpu-vulkan": "vulkan",
-        "cpu": "tts",
+        # PS-1: a GPU-less host must default to a chat-capable CPU profile,
+        # not the Kokoro TTS engine.
+        "cpu": "cpu-llm",
         "npu": "flm",
     }
+
+
+def test_cpu_default_profile_supports_llm(tmp_path: Path) -> None:
+    """PS-1: DEVICE_DEFAULT_PROFILES["cpu"] must name a chat-capable profile."""
+    from hal0.config.schema import DEVICE_DEFAULT_PROFILES
+    from hal0.profiles import ProfileCatalog
+
+    resolved = ProfileCatalog(path=tmp_path / "nonexistent.toml").resolve(
+        DEVICE_DEFAULT_PROFILES["cpu"]
+    )
+    assert "llm" in resolved.supported_slot_types

--- a/tests/dispatcher/test_capability_wake_on_evict.py
+++ b/tests/dispatcher/test_capability_wake_on_evict.py
@@ -34,7 +34,7 @@ from hal0.upstreams.registry import UpstreamRegistry
 from tests.slots.conftest import FakeContainerProvider
 
 
-def _write_min_slot(root: Path, name: str, *, port: int) -> None:
+def _write_min_slot(root: Path, name: str, *, port: int, enabled: bool = True) -> None:
     """Write a minimal llama-server slot TOML (mirrors the slots suite helper)."""
     root.mkdir(parents=True, exist_ok=True)
     (root / f"{name}.toml").write_text(
@@ -44,7 +44,7 @@ def _write_min_slot(root: Path, name: str, *, port: int) -> None:
                 f"port = {port}",
                 'backend = "vulkan"',
                 'provider = "llama-server"',
-                "enabled = true",
+                f"enabled = {'true' if enabled else 'false'}",
                 "[model]",
                 'default = "qwen3-4b-q4_k_m"',
                 "",
@@ -185,3 +185,51 @@ async def test_capability_slot_wakes_on_request_after_eviction(
     assert _rerank_load_count(fake) == 2, "wake must drive a second container load"
     assert resp.status_code == 200
     assert captured["call"].upstream_name == "rerank"
+
+
+async def test_disabled_capability_slot_is_not_woken(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DR-1 ↔ SC-1 interaction: the wake path must NOT revive a DISABLED slot.
+
+    When an operator disables a capability, SC-1 writes ``enabled = false`` and
+    the reconciler unloads it to OFFLINE / deregisters its upstream. A follow-up
+    capability request must still 404 — waking a disabled slot would start its
+    container and re-register the upstream, silently undoing the disable. The
+    wake gate mirrors the routing layer's ``enabled is False`` drop rule.
+    """
+    fake = FakeContainerProvider()
+    monkeypatch.setattr("hal0.providers.container.container_provider", lambda: fake)
+
+    root = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    _write_min_slot(root, "rerank", port=8090, enabled=False)
+
+    registry = UpstreamRegistry()
+    sm = SlotManager(
+        idle_after_s=0.0,
+        evict_after_s=0.01,
+        idle_monitor_interval_s=10.0,
+        upstreams_registry=registry,
+    )
+    dispatcher = Dispatcher(
+        upstream_registry=registry,
+        model_registry=None,
+        cached_models=lambda _name: [],
+        slot_manager=sm,
+    )
+
+    # Disabled slot starts OFFLINE with no upstream — the exact post-disable state.
+    assert (await sm.status("rerank")).state == SlotState.OFFLINE
+    assert registry.get("rerank") is None
+
+    req = _make_request("/v1/rerankings", sm)
+    with pytest.raises(NoRouteFound) as exc:
+        await _dispatch_and_forward(
+            req,
+            dispatcher,
+            body={"model": "bge-reranker-v2-m3", "query": "q", "documents": ["d"]},
+        )
+    assert exc.value.code == "dispatch.no_route"
+    # The wake gate skipped it: no container load, no re-registered upstream.
+    assert _rerank_load_count(fake) == 0, "a disabled slot must never be woken"
+    assert registry.get("rerank") is None

--- a/tests/dispatcher/test_capability_wake_on_evict.py
+++ b/tests/dispatcher/test_capability_wake_on_evict.py
@@ -1,0 +1,187 @@
+"""DR-1 regression: idle-EVICTED capability slots must wake on request.
+
+The idle sweeper unloads embed/rerank/tts/img slots to OFFLINE and
+DEREGISTERS their container upstream. A follow-up capability request then
+404s inside ``resolve_by_capability`` (surfaced as ``NoRouteFound``) long
+before it can reach the dispatcher's container readiness gate — so that gate
+can never reload the slot (the finding's first proposed fix is insufficient).
+
+The fix is the route-level capability twin of the chat branch's
+``_ensure_backend_for_model``: ``_wake_capability_slot`` resolves the slot
+from the request PATH and, when it is a known managed slot sitting OFFLINE,
+drives ``SlotManager.load(slot)`` — which re-registers the upstream — BEFORE
+``dispatcher.dispatch`` runs.
+
+Complements the eviction-only coverage at
+``tests/slots/test_pulling_serving_idle.py::test_idle_sweep_unloads_slot_past_ttl``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import Response
+
+from hal0.api.routes.v1 import _dispatch_and_forward
+from hal0.dispatcher.router import Dispatcher, NoRouteFound
+from hal0.slots.manager import SlotManager
+from hal0.slots.state import SlotState
+from hal0.upstreams.registry import UpstreamRegistry
+from tests.slots.conftest import FakeContainerProvider
+
+
+def _write_min_slot(root: Path, name: str, *, port: int) -> None:
+    """Write a minimal llama-server slot TOML (mirrors the slots suite helper)."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / f"{name}.toml").write_text(
+        "\n".join(
+            [
+                f'name = "{name}"',
+                f"port = {port}",
+                'backend = "vulkan"',
+                'provider = "llama-server"',
+                "enabled = true",
+                "[model]",
+                'default = "qwen3-4b-q4_k_m"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _make_request(path: str, slot_manager: SlotManager) -> Request:
+    """A Starlette Request whose ``app.state.slot_manager`` is wired.
+
+    ``app.state`` is a permissive namespace so the route helpers'
+    ``getattr(request.app.state, ..., None)`` probes degrade cleanly for the
+    fields this focused test does not populate (upstreams cache, etc.).
+    """
+    app = SimpleNamespace(state=SimpleNamespace(slot_manager=slot_manager))
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"authorization", b"Bearer test-token"),
+        ],
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 12345),
+        "http_version": "1.1",
+        "root_path": "",
+        "app": app,
+    }
+    return Request(scope)
+
+
+def _rerank_load_count(fake: FakeContainerProvider) -> int:
+    return sum(1 for cfg, _mi in fake.load_calls if cfg.get("name") == "rerank")
+
+
+async def _evict(sm: SlotManager) -> None:
+    sm._last_used["rerank"] = 0.0  # ancient — well past the 0.01s TTL
+    await sm._sweep_idle_once()
+
+
+@pytest.fixture
+def wired(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> tuple[SlotManager, Dispatcher, UpstreamRegistry, FakeContainerProvider]:
+    """A SlotManager + Dispatcher sharing ONE upstream registry.
+
+    Mirrors the real ``create_app`` wiring (api/__init__.py:811-818) where the
+    manager and dispatcher share the registry — so eviction's deregister and
+    ``load``'s re-register are visible to the dispatcher.
+    """
+    fake = FakeContainerProvider()
+    monkeypatch.setattr("hal0.providers.container.container_provider", lambda: fake)
+
+    root = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    _write_min_slot(root, "rerank", port=8090)
+
+    registry = UpstreamRegistry()
+    sm = SlotManager(
+        idle_after_s=0.0,
+        evict_after_s=0.01,
+        idle_monitor_interval_s=10.0,
+        upstreams_registry=registry,
+    )
+    dispatcher = Dispatcher(
+        upstream_registry=registry,
+        model_registry=None,
+        cached_models=lambda _name: [],
+        slot_manager=sm,
+    )
+    return sm, dispatcher, registry, fake
+
+
+async def test_evicted_capability_slot_404s_without_wake(
+    wired: tuple[SlotManager, Dispatcher, UpstreamRegistry, FakeContainerProvider],
+) -> None:
+    """Negative control: after eviction the upstream is deregistered, so a raw
+    dispatch (no wake) 404s with ``dispatch.no_route`` — locking the
+    born-broken behaviour the fix changes."""
+    sm, dispatcher, registry, _fake = wired
+
+    await sm.load("rerank")
+    assert (await sm.status("rerank")).state == SlotState.READY
+    assert registry.get("rerank") is not None
+
+    await _evict(sm)
+    assert (await sm.status("rerank")).state == SlotState.OFFLINE
+    assert registry.get("rerank") is None, "eviction must deregister the upstream"
+
+    req = _make_request("/v1/rerankings", sm)
+    with pytest.raises(NoRouteFound) as exc:
+        await dispatcher.dispatch(
+            req, body={"model": "bge-reranker-v2-m3", "query": "q", "documents": ["d"]}
+        )
+    assert exc.value.code == "dispatch.no_route"
+
+
+async def test_capability_slot_wakes_on_request_after_eviction(
+    wired: tuple[SlotManager, Dispatcher, UpstreamRegistry, FakeContainerProvider],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DR-1: a /v1/rerankings request through the route reloads an evicted
+    rerank slot (second container load) and resolves instead of 404ing."""
+    sm, dispatcher, registry, fake = wired
+
+    await sm.load("rerank")
+    assert _rerank_load_count(fake) == 1
+
+    await _evict(sm)
+    assert (await sm.status("rerank")).state == SlotState.OFFLINE
+    assert registry.get("rerank") is None
+
+    # Stub forward() so the resolved call is captured without real networking.
+    captured: dict[str, Any] = {}
+
+    async def _fake_forward(call: Any) -> Response:
+        captured["call"] = call
+        return Response(content=b"{}", media_type="application/json")
+
+    monkeypatch.setattr(dispatcher, "forward", _fake_forward)
+
+    req = _make_request("/v1/rerankings", sm)
+    resp = await _dispatch_and_forward(
+        req,
+        dispatcher,
+        body={"model": "bge-reranker-v2-m3", "query": "q", "documents": ["d"]},
+    )
+
+    # Wake fired: the slot was reloaded (a SECOND container load) and its
+    # upstream is re-registered — so dispatch resolved to rerank, not 404.
+    assert (await sm.status("rerank")).state == SlotState.READY
+    assert registry.get("rerank") is not None
+    assert _rerank_load_count(fake) == 2, "wake must drive a second container load"
+    assert resp.status_code == 200
+    assert captured["call"].upstream_name == "rerank"

--- a/tests/hardware/test_recommend.py
+++ b/tests/hardware/test_recommend.py
@@ -128,6 +128,42 @@ def test_cpu_host_gets_small_conservative_model() -> None:
     assert rec["backend"] == "cpu"
 
 
+# ── PS-1: GPU-less installs must seed a chat-capable profile, not TTS ─────────
+# Regression: DEVICE_DEFAULT_PROFILES["cpu"] used to be "tts", so a GPU-less
+# host got a chat slot pointing at the Kokoro TTS engine. That profile's
+# supported_slot_types is ("tts",), so evaluate_model_fit for the seeded chat
+# model was rejected with reason "profile.unsupported_slot_type" — the primary
+# slot was born broken on every CPU-only install.
+
+
+def test_cpu_only_host_seeds_chat_capable_profile(tmp_path) -> None:
+    from pathlib import Path
+
+    from hal0.model_fit import evaluate_model_fit
+    from hal0.profiles import ProfileCatalog
+
+    rec = recommend_primary_slot(_cpu_only_host(64))
+    # No GPU → device is plain "cpu"; its default profile must be chat-capable.
+    assert rec["device"] == "cpu"
+    assert rec["profile"] == "cpu-llm"
+
+    # Resolve the seeded profile (empty tmp path → seed defaults) and confirm
+    # it advertises "llm" support, i.e. it is a real chat runtime family.
+    catalog = ProfileCatalog(path=Path(tmp_path) / "nonexistent.toml")
+    resolved = catalog.resolve(rec["profile"])
+    assert "llm" in resolved.supported_slot_types
+
+    # Stronger: the seeded chat model must not be blocked on this profile with
+    # the old "profile.unsupported_slot_type" reason.
+    fit = evaluate_model_fit(
+        model_id=rec["model"]["default"],
+        slot_type="llm",
+        device=rec["device"],
+        profile=resolved,
+    )
+    assert "profile.unsupported_slot_type" not in fit.reasons
+
+
 # ── seeded chat slot must resolve a profile (container-runtime era) ──────────
 # Regression: recommend_primary_slot used to emit no ``profile``/``runtime``,
 # so the seeded chat.toml loaded with profile=None and the resolver rejected

--- a/tests/slot_config/test_store.py
+++ b/tests/slot_config/test_store.py
@@ -193,9 +193,11 @@ def test_apply_updates_capabilities_selection(tmp_hal0_home: str) -> None:
     assert after["schema_version"] == 2
 
 
-def test_apply_skips_slot_toml_when_disabled(tmp_hal0_home: str) -> None:
-    """A disable-only change must not reconcile the slot TOML (parity with
-    the pre-store orchestrator: pure disable never rewrote the slot)."""
+def test_apply_writes_enabled_false_on_disable(tmp_hal0_home: str) -> None:
+    """SC-1 regression: a disable change writes ``enabled = false`` into the
+    slot TOML while leaving the model/backend siblings intact (disabling a
+    capability must actually flip the slot's enablement so routing stops
+    resolving it)."""
     slot_path = _write_embed_slot(tmp_hal0_home)
     _write_caps(tmp_hal0_home)
 
@@ -203,7 +205,62 @@ def test_apply_skips_slot_toml_when_disabled(tmp_hal0_home: str) -> None:
 
     before = {fs.path: fs.data for fs in cs.before}[slot_path]
     after = {fs.path: fs.data for fs in cs.after}[slot_path]
-    assert after == before
+    assert after is not None
+    assert after["enabled"] is False
+    # A pure disable must not rewrite the reconciled fields — the model and
+    # backend siblings survive verbatim from the fixture.
+    assert after["model"]["default"] == before["model"]["default"] == "old-model"
+    assert after["backend"] == before["backend"] == "vulkan"
+    assert after["port"] == 8082
+
+
+def test_apply_writes_enabled_true_on_enable(tmp_hal0_home: str) -> None:
+    """SC-1 symmetric case: an enable change writes ``enabled = true`` and
+    clears a pre-existing stale ``enabled = false`` on the slot TOML, while
+    reconciling the device/model fields."""
+    slots_dir = _etc(tmp_hal0_home) / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    slot_path = slots_dir / "embed.toml"
+    slot_path.write_text(
+        "\n".join(
+            [
+                'name = "embed"',
+                "port = 8082",
+                'backend = "vulkan"',
+                'provider = "llama-server"',
+                "enabled = false",
+                "[model]",
+                'default = "old-model"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    _write_caps(tmp_hal0_home)
+
+    cs = SlotConfigStore().apply(_selection(enabled=True))
+
+    after = {fs.path: fs.data for fs in cs.after}[slot_path]
+    assert after is not None
+    assert after["enabled"] is True
+    assert after["device"] == "npu"
+    assert after["model"]["default"] == "nomic-embed-text-v1.5-q8_0"
+
+
+def test_commit_writes_enabled_false_to_disk_on_disable(tmp_hal0_home: str) -> None:
+    """SC-1 end-state: after ``commit`` the slot TOML on disk carries
+    ``enabled = false`` for a disable change (proving the store — not the
+    orchestrator lifecycle — is what persists disablement)."""
+    slot_path = _write_embed_slot(tmp_hal0_home)
+    _write_caps(tmp_hal0_home)
+
+    store = SlotConfigStore()
+    cs = store.apply(_selection(enabled=False))
+    store.commit(cs)
+
+    on_disk = _read_toml(slot_path)
+    assert on_disk["enabled"] is False
+    assert on_disk["model"]["default"] == "old-model"
 
 
 def test_apply_skips_slot_toml_when_missing(tmp_hal0_home: str) -> None:


### PR DESCRIPTION
## Wave 1 of the platform-review remediation program

Fixes the four critical born-broken / silent-failure bugs from the 2026-07-03 platform review (`handoffs/platform-review-2026-07-03.md`). Each finding was adversarially re-verified against current source, then fixed TDD-style (failing regression test → minimal fix → green).

| ID | Fix |
|----|-----|
| **SC-1** | `_reconciled_slot` now owns the slot TOML `enabled` flag and writes it unconditionally on enable **and** disable, so a disabled capability slot is no longer resolved/woken by the request router. |
| **SC-2** | NPU FLM-image probe goes through the container runtime (podman) instead of a hardcoded `docker` subprocess, and caches the result — the NPU trio is now advertised on the reference platform. |
| **PS-1** | `DEVICE_DEFAULT_PROFILES['cpu'] = 'cpu-llm'` (was `'tts'`), so GPU-less installs get a chat-capable primary slot instead of one bound to the Kokoro TTS engine. |
| **DR-1** | Idle-evicted non-chat capability slots (embed/rerank/tts) now wake on request instead of 404'ing forever. |

### Verification
- Adversarial verify pass: all four **confirmed** against current source.
- New/updated regression tests, each red-before → green-after.
- Local combined run of touched subsystems: **1140 passed**.

> Note: `tests/hardware/test_pve.py::TestDetectProxmoxHost` has 2 pre-existing failures that reproduce on unmodified `origin/main` — they read an unmocked `/proc/1/environ` and only fail on an LXC-on-Proxmox host. Unrelated to this PR; clean CI runners pass them.

Scope kept surgical — the broader consolidations (DR-7 lazy-load unification, PS-4 `profile_for()`, SC-11 shared projection) are deferred to later waves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)